### PR TITLE
Fix configefi script

### DIFF
--- a/xCAT/postscripts/configefi
+++ b/xCAT/postscripts/configefi
@@ -21,7 +21,7 @@ if [ "$arch" =  "x86_64" ]; then
                 elif [ -f "/boot/efi/EFI/redhat/grubx64.efi" ];then
                         efibootmgr -c -l \\EFI\\redhat\\grubx64.efi -L syscloneLinux
                         
-                        boot_root=`mount | grep -E ' on\s+/ type ' | awk '{print $1}'`
+                        boot_root=`df /boot | awk '{print $1}' | tail -n 1`
                         sed -i 's| root=\S*| root='$boot_root' net.ifnames=0|' /boot/efi/EFI/redhat/grub.cfg 
       
                         blkid -c /dev/null |grep UUID|while read str_line
@@ -52,10 +52,10 @@ if [ "$arch" =  "x86_64" ]; then
 		boot_device=''
 		if [ -f "/etc/systemconfig/systemconfig.conf" ];then
 			#boot_root=`cat /etc/systemconfig/systemconfig.conf | grep ROOTDEV | awk '{print $3}'`
-                        boot_root=`mount | grep -E ' on\s+/ type ' | awk '{print $1}'`
+                        boot_root=`df /boot | awk '{print $1}' | tail -n 1`
 			boot_device=`cat /etc/systemconfig/systemconfig.conf | grep BOOTDEV | awk '{print $3}'`
 		else
-			boot_root=`mount | grep -E ' on\s+/ type ' | awk '{print $1}'`
+			boot_root=`df /boot | awk '{print $1}' | tail -n 1`
 			boot_device=`echo $boot_root | sed -e 's/[0-9]*$//'`
 
 			#str_temp=`mount | awk '{print $1","$3}'`
@@ -85,8 +85,13 @@ if [ "$arch" =  "x86_64" ]; then
 			# note: the error about grub-set-default not existing is harmless, because we want the default to be 0 anyway
 		else
 			#for sles10, should run grub-install with parameters
-			echo "grub-install --no-floppy --recheck $boot_device"
-			grub-install --no-floppy --recheck $boot_device
+			if [ -x /usr/sbin/grub2-install ]; then
+				echo "grub2-install -s --recheck $boot_device"
+				grub2-install -s --recheck $boot_device
+			else
+				echo "grub-install --no-floppy --recheck $boot_device"
+				grub-install --no-floppy --recheck $boot_device
+			fi
 		fi
 
 		# change the entries in the grub conf file to use the correct boot root device


### PR DESCRIPTION
* use df instead of mount, and check for the disk that /boot is on, rather than /
* use grub2-install if that exists, as that is the default on el7

This is something I have been testing on a system at the moment, and these changes were able to resolve some of the issues