### PR TITLE
add link for bmcdiscover in xcat-client.links

### DIFF
--- a/xCAT-client/debian/xcat-client.links
+++ b/xCAT-client/debian/xcat-client.links
@@ -122,5 +122,6 @@ opt/xcat/bin/xcatclientnnr opt/xcat/bin/rmzone
 opt/xcat/bin/xcatclientnnr opt/xcat/bin/slpdiscover
 opt/xcat/bin/xcatclient    opt/xcat/bin/xCATWorld
 opt/xcat/bin/xcatclientnnr opt/xcat/bin/switchdiscover
+opt/xcat/bin/xcatclientnnr opt/xcat/bin/bmcdiscover
 opt/xcat/bin/xcatclientnnr opt/xcat/bin/makentp
 


### PR DESCRIPTION
add link for bmcdiscover in xcat-client.links to add bmcdiscover command for debian