### PR TITLE
Fix for #78 - nodediscoverls: Reduce UUID width to 37 and increase serial width to 13

### DIFF
--- a/xCAT-server/lib/xcat/plugins/seqdiscovery.pm
+++ b/xCAT-server/lib/xcat/plugins/seqdiscovery.pm
@@ -888,7 +888,7 @@ Usage:
         } else {
             $ent->{'node'} = 'undef' unless ($ent->{'node'});
             $ent->{'method'} = 'undef' unless ($ent->{'method'});
-            push @discoverednodes, sprintf("  %-40s%-20s%-15s%-10s%-10s", $ent->{'uuid'}, $ent->{'node'}, $ent->{'method'}, $ent->{'mtm'}, substr($ent->{'serial'},0,8));
+            push @discoverednodes, sprintf("  %-37s%-20s%-15s%-10s%-13s", $ent->{'uuid'}, $ent->{'node'}, $ent->{'method'}, $ent->{'mtm'}, substr($ent->{'serial'},0,12));
         }
     }
 
@@ -898,7 +898,7 @@ Usage:
     }
     if (@discoverednodes) {
         unless ($long) {
-            push @{$rsp->{data}}, sprintf("  %-40s%-20s%-15s%-10s%-10s", 'UUID', 'NODE', ,'METHOD', 'MTM', 'SERIAL');
+            push @{$rsp->{data}}, sprintf("  %-37s%-20s%-15s%-10s%-13s", 'UUID', 'NODE', ,'METHOD', 'MTM', 'SERIAL');
         }
         foreach (@discoverednodes) {
              push @{$rsp->{data}}, "$_"; 

--- a/xCAT-server/lib/xcat/plugins/seqdiscovery.pm
+++ b/xCAT-server/lib/xcat/plugins/seqdiscovery.pm
@@ -888,7 +888,7 @@ Usage:
         } else {
             $ent->{'node'} = 'undef' unless ($ent->{'node'});
             $ent->{'method'} = 'undef' unless ($ent->{'method'});
-            push @discoverednodes, sprintf("  %-37s%-20s%-15s%-10s%-13s", $ent->{'uuid'}, $ent->{'node'}, $ent->{'method'}, $ent->{'mtm'}, substr($ent->{'serial'},0,12));
+            push @discoverednodes, sprintf("  %-40s%-20s%-15s%-10s%-13s", $ent->{'uuid'}, $ent->{'node'}, $ent->{'method'}, $ent->{'mtm'}, substr($ent->{'serial'},0,12));
         }
     }
 
@@ -898,7 +898,7 @@ Usage:
     }
     if (@discoverednodes) {
         unless ($long) {
-            push @{$rsp->{data}}, sprintf("  %-37s%-20s%-15s%-10s%-13s", 'UUID', 'NODE', ,'METHOD', 'MTM', 'SERIAL');
+            push @{$rsp->{data}}, sprintf("  %-40s%-20s%-15s%-10s%-13s", 'UUID', 'NODE', ,'METHOD', 'MTM', 'SERIAL');
         }
         foreach (@discoverednodes) {
              push @{$rsp->{data}}, "$_"; 


### PR DESCRIPTION
Fix for #78 - nodediscoverls: Reduce UUID width to 37 and increase serial width to 13

UUIDs [by definition](https://en.wikipedia.org/wiki/UUID) are 36 characters wide in their printable form:
```
[root@xcatmn01 ~]# awk '{printf $1}' < /proc/sys/kernel/random/uuid |wc -c
36
```
Thus for printing them, a width of 36 + 1 separator is enough, which is what I did, moving the extra 3 characters gained from it's reduction into the serial field.