### PR TITLE
Look for Packages or Packages.gz in the otherpkgdir

### DIFF
--- a/xCAT-server/share/xcat/netboot/ubuntu/genimage
+++ b/xCAT-server/share/xcat/netboot/ubuntu/genimage
@@ -494,10 +494,8 @@ unless ($onlyinitrd) {
                 #if there is no Packages file in otherpkgsdir local, it will not be added into source list
                 if ($otherpkgsdir_local) 
                 {
-                      my $tmppkg=$otherpkgsdir_local."/".$_."/Packages";
                       my $tmpdir=$otherpkgsdir_local."/".$_;
-                      `ls $tmppkg 2>&1`;
-                      if(!$?)
+                      if (-f $tmpdir . '/Packages' || -f $tmpdir . '/Packages.gz')
                       {
                           print $aptconfig "deb file:///mnt/otherpkgdir/$_ ./\n"
                       }


### PR DESCRIPTION
Allow the otherpkgdir to use a compressed Packages file so it can also be served over http