### PR TITLE
add compute.ubuntu14.04.3.x86_64.pkglist file and compute.ubuntu14.04.3.ppc64el.pkglist to support ubuntu14.04.3 on x86_64 and ppc64le architecture

### DIFF
--- a/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu14.04.3.ppc64el.pkglist
+++ b/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu14.04.3.ppc64el.pkglist
@@ -1,0 +1,15 @@
+bash
+nfs-common
+openssl
+isc-dhcp-client
+libc-bin
+linux-image-generic-lts-vivid
+openssh-server
+openssh-client
+wget
+vim
+ntp
+rsync
+busybox-static
+gawk
+dnsutils

--- a/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu14.04.3.ppc64le.pkglist
+++ b/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu14.04.3.ppc64le.pkglist
@@ -1,0 +1,1 @@
+compute.ubuntu14.04.3.ppc64el.pkglist

--- a/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu14.04.3.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu14.04.3.x86_64.pkglist
@@ -1,0 +1,15 @@
+bash
+nfs-common
+openssl
+isc-dhcp-client
+libc-bin
+linux-image-generic-lts-vivid
+openssh-server
+openssh-client
+wget
+vim
+ntp
+rsync
+busybox-static
+gawk
+dnsutils


### PR DESCRIPTION
add xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu14.04.3.x86_64.pkglist
file to support ubuntu14.04.3 on x86_64.