### PR TITLE
allow multiple valid access tokens to exist at the same time for a user

### DIFF
--- a/xCAT-server/lib/perl/xCAT/xcatd.pm
+++ b/xCAT-server/lib/perl/xCAT/xcatd.pm
@@ -309,21 +309,15 @@ sub gettoken {
         return undef;
     }
     my $tokens = $tokentb->getAllEntries;
-    my $expiretime = time() + $tokentimeout;
     foreach my $token (@{$tokens}) {
-        if ($token->{username} eq $user) {
-            #delete old token
-            $tokentb->delEntries({'tokenid'=>$token->{tokenid}});
-        } else {
             #clean the expired token
-            if ($token->{expire} > $expiretime) {
+            if ($token->{'expire'} < time()) {
                 $tokentb->delEntries({'tokenid'=>$token->{tokenid}});
             }
-        }
     }
-    
     # create a new token for this request
     my $uuid = xCAT::Utils->genUUID();
+    my $expiretime = time() + $tokentimeout;
     $tokentb->setAttribs({tokenid=>$uuid, username => $user}, {expire => $expiretime});
     $tokentb->close();
    


### PR DESCRIPTION
Currently, xcat do not keep several tokens for the same user in token table.If the user is the same, when you get a new token, the old one is deleted from token table.
After code is changed, it allows multiple valid access tokens to exist at the same time for a user, at the same time it removes all expire token.