### PR TITLE
fix : updatestatus is not correct when -F run with -P and -S

### DIFF
--- a/xCAT-server/lib/xcat/plugins/updatenode.pm
+++ b/xCAT-server/lib/xcat/plugins/updatenode.pm
@@ -1358,30 +1358,30 @@ sub updatenode
     # if immediate return of status not requested (PCM), then update the DB here
     # in one transaction, otherwise it is updated in getdata callback and buildnodestatus
     if (!(defined($request->{status})) || ($request->{status} ne "yes")) {
-      # update the node status, this is done when -F -S -P are run
-      # make sure the nodes only appear in one array good or bad 
-      &cleanstatusarrays;  
+         # update the node status, this is done when -F -S -P are run
+         # make sure the nodes only appear in one array good or bad 
+           &cleanstatusarrays;  
 	   if(@::SUCCESSFULLNODES)
 	   {
-	     
-            my $stat="synced";
-            xCAT::TableUtils->setUpdateStatus(\@::SUCCESSFULLNODES, $stat);
+                my $stat="synced";
+                xCAT::TableUtils->setUpdateStatus(\@::SUCCESSFULLNODES, $stat);
                       
 	   }
 	   if(@::FAILEDNODES)
 	   {
-	     
-            my $stat="failed";
-            xCAT::TableUtils->setUpdateStatus(\@::FAILEDNODES, $stat);
+                my $stat="failed";
+                xCAT::TableUtils->setUpdateStatus(\@::FAILEDNODES, $stat);
                       
 	   }
+           # -P -S are not run
+           # -F is run, but there is no syncfiles
            if(!(@::SUCCESSFULLNODES || @::FAILEDNODES) && $::NOSYNCFILE)
            {
-            my $stat="synced";
-            xCAT::TableUtils->setUpdateStatus(\@$nodes,$stat);
+                my $stat="synced";
+                xCAT::TableUtils->setUpdateStatus(\@$nodes,$stat);
            }
+    }
 
-	 }
     #  if site.precreatemypostscripts = not 1 or yes or undefined,
     # remove all the
     # node files in the noderange in  /tftpboot/mypostscripts
@@ -1613,6 +1613,9 @@ sub updatenodesyncfiles
     my $localhostname      = hostname();
     my %syncfile_node      = ();
     my %syncfile_rootimage = ();
+    
+    # $::NOSYNCFILE default value is 0
+    # if there is no syncfiles, set $::NOSYNCFILE=1
     $::NOSYNCFILE=0;
     # if running -P or -S do not report  or no status requested
     if ((defined($request->{status})) && ($request->{status} eq "yes")) { # status requested 
@@ -1729,13 +1732,11 @@ sub updatenodesyncfiles
        }
     }
     else
-    {    # no syncfiles defined
+    {   # no syncfiles defined
         my $rsp = {};
         $rsp->{data}->[0] =
           "There were no syncfiles defined to process. File synchronization has completed.";
         $callback->($rsp);
-        #my $stat="synced";
-        #xCAT::TableUtils->setUpdateStatus(\@$nodes, $stat);
         $::NOSYNCFILE=1;
 
     }

--- a/xCAT-server/lib/xcat/plugins/updatenode.pm
+++ b/xCAT-server/lib/xcat/plugins/updatenode.pm
@@ -1375,6 +1375,12 @@ sub updatenode
             xCAT::TableUtils->setUpdateStatus(\@::FAILEDNODES, $stat);
                       
 	   }
+           if(!(@::SUCCESSFULLNODES || @::FAILEDNODES) && $::NOSYNCFILE)
+           {
+            my $stat="synced";
+            xCAT::TableUtils->setUpdateStatus(\@$nodes,$stat);
+           }
+
 	 }
     #  if site.precreatemypostscripts = not 1 or yes or undefined,
     # remove all the
@@ -1607,6 +1613,7 @@ sub updatenodesyncfiles
     my $localhostname      = hostname();
     my %syncfile_node      = ();
     my %syncfile_rootimage = ();
+    $::NOSYNCFILE=0;
     # if running -P or -S do not report  or no status requested
     if ((defined($request->{status})) && ($request->{status} eq "yes")) { # status requested 
       if (($request->{rerunps} && $request->{rerunps}->[0] eq "yes") ||  
@@ -1727,8 +1734,9 @@ sub updatenodesyncfiles
         $rsp->{data}->[0] =
           "There were no syncfiles defined to process. File synchronization has completed.";
         $callback->($rsp);
-        my $stat="synced";
-        xCAT::TableUtils->setUpdateStatus(\@$nodes, $stat);
+        #my $stat="synced";
+        #xCAT::TableUtils->setUpdateStatus(\@$nodes, $stat);
+        $::NOSYNCFILE=1;
 
     }
     # report final status PCM


### PR DESCRIPTION
The issue:
Updatastatus is not correct happens when there is no syncfiles.
When "updatenode CN -F" and there is no syncfile, updatestatus is set to "synced" in code directly. 
When "updatenode CN" or updatenode using -P,-F,-S at the same time, -F is first ran, its hard code change updatastatus as "synced", then, the initial state for -P or -S becomes "synced" but not "syncing",  all -P or -S procedure keeping synced updatestatus until it get the final updatestatus.
 
My fix:
1, Do not use hard code state "synced", when -F and there is no syncfile, set $::NOSYNCFILE=1;
2, When there is no -P -S and no syncfile ($::NOSYNCFILE=1), final state for updatestatus is synced.
3, If there is -P -S -F, run as before, updatestatus get final state as before;