### PR TITLE
xCAT provision Sles11.2 will hang-on when excuting remoteshell script

### DIFF
--- a/xCAT-server/share/xcat/install/ubuntu/compute.tmpl
+++ b/xCAT-server/share/xcat/install/ubuntu/compute.tmpl
@@ -63,6 +63,11 @@ d-i partman/early_command string \
         mount $d /tmp/mymount || rc=$?; \
         if [[ $rc -eq 0 ]]; then \
             [[ -d /tmp/mymount/boot ]] && echo $d >>/tmp/devs-with-boot; \
+            for i in /tmp/mymount/vmlinuz* ; do \
+                if [ -e $i ]; then \
+                    echo $d >>/tmp/devs-with-boot; break; \
+                fi; \
+            done; \
             umount /tmp/mymount; \
         fi \
     done; \

--- a/xCAT/postscripts/remoteshell
+++ b/xCAT/postscripts/remoteshell
@@ -281,8 +281,7 @@ if [ -f /etc/ssh/ssh_host_ecdsa_key ]; then
 	if ! grep "PRIVATE KEY" /etc/ssh/ssh_host_ecdsa_key > /dev/null 2>&1 ; then
    		rm /etc/ssh/ssh_host_ecdsa_key
 	else
-		ssh-keygen -t ecdsa -y -f /etc/ssh/ssh_host_ecdsa_key -P ""
-		if [ "x$?" = "x0" ]; then
+		if ssh-keygen -t ecdsa -y -f /etc/ssh/ssh_host_ecdsa_key -P "" &>/dev/null ; then
 			ssh-keygen -y -f /etc/ssh/ssh_host_ecdsa_key > /etc/ssh/ssh_host_ecdsa_key.pub
 			chmod 644 /etc/ssh/ssh_host_ecdsa_key.pub
 			chown root /etc/ssh/ssh_host_ecdsa_key.pub

--- a/xCAT/postscripts/remoteshell
+++ b/xCAT/postscripts/remoteshell
@@ -281,6 +281,10 @@ if [ -f /etc/ssh/ssh_host_ecdsa_key ]; then
 	if ! grep "PRIVATE KEY" /etc/ssh/ssh_host_ecdsa_key > /dev/null 2>&1 ; then
    		rm /etc/ssh/ssh_host_ecdsa_key
 	else
+		# Because of openssh version differs, provisioning errors may happen when MN support ecdsa while CN don't ecdsa.
+		# Judge CN support ecdsa or not. "-t ecdsa" indicate the key type, "-P "" " avoid hang-on and wait for input passphrase when CN don't support ecdsa.
+		# If ture, means support ecdsa, then generate corresponding key.pub. 
+		# If false, remove ssh_host_ecdsa_key useless file, to avoid future errors.
 		if ssh-keygen -t ecdsa -y -f /etc/ssh/ssh_host_ecdsa_key -P "" &>/dev/null ; then
 			ssh-keygen -y -f /etc/ssh/ssh_host_ecdsa_key > /etc/ssh/ssh_host_ecdsa_key.pub
 			chmod 644 /etc/ssh/ssh_host_ecdsa_key.pub


### PR DESCRIPTION


xCAT provision Sles11.2 will hang-on and wait for input passphrase when executing "ssh-keygen -y -f /etc/ssh/ssh_host_ecdsa_key > /etc/ssh/ssh_host_ecdsa_key.pub" command in remoteshell script.

Root Cause: Sles11.2 install openssh-5.1p1-41.57.1 build-in package, and this version openssh don't support ecdsa key type.
So there needs a openssh support check before ecdsa key generation. In remoteshell script, line 283, we will add "ssh-keygen -t ecdsa -y -f /etc/ssh/ssh_host_ecdsa_key -P "" " command and check the result to judge support or not.
