### PR TITLE
use pigz to improve the performance of genimage/packimage

### DIFF
--- a/xCAT-server/lib/xcat/plugins/packimage.pm
+++ b/xCAT-server/lib/xcat/plugins/packimage.pm
@@ -369,7 +369,7 @@ sub process_request {
 
     my $compress="gzip";
     #use "pigz" as the compress tool instead of gzip if "pigz" exist
-    my $ispigz=system("bash -c 'type -p pigz'");
+    my $ispigz=system("bash -c 'type -p pigz' >/dev/null 2>&1");
     if($ispigz == 0){
        $compress="pigz";
     }
@@ -385,7 +385,6 @@ sub process_request {
             if ($includestr) {
             	system("$includestr >> $xcat_packimg_tmpfile"); 
             }
-            #$excludestr =~ s!-a \z!|cpio -H newc -o | $compress -c - > ../rootimg.gz!;
             $excludestr = "cat $xcat_packimg_tmpfile|cpio -H newc -o | $compress -c - > ../rootimg.gz";
         }
         $oldmask = umask 0077;

--- a/xCAT-server/lib/xcat/plugins/statelite.pm
+++ b/xCAT-server/lib/xcat/plugins/statelite.pm
@@ -523,10 +523,9 @@ sub process_request {
         $callback->({data=>["$verb contents of $rootimg_dir"]});
         unlink("$destdir/rootimg-statelite.gz");
 
-
         my $compress="gzip";
         #use "pigz" as the compress tool instead of gzip if "pigz" exist
-        my $ispigz=system("bash -c 'type -p pigz'");
+        my $ispigz=system("bash -c 'type -p pigz' >/dev/null 2>&1");
         if($ispigz == 0){
            $compress="pigz";
         }

--- a/xCAT-server/lib/xcat/plugins/statelite.pm
+++ b/xCAT-server/lib/xcat/plugins/statelite.pm
@@ -522,15 +522,26 @@ sub process_request {
         my $oldmask;
         $callback->({data=>["$verb contents of $rootimg_dir"]});
         unlink("$destdir/rootimg-statelite.gz");
+
+
+        my $compress="gzip";
+        #use "pigz" as the compress tool instead of gzip if "pigz" exist
+        my $ispigz=system("bash -c 'type -p pigz'");
+        if($ispigz == 0){
+           $compress="pigz";
+        }
+
+        $callback->({info=>["compress method: $compress"]});  
+
         if ($exlistloc) {
             chdir("$rootimg_dir");
             system("$excludestr >> $xcat_packimg_tmpfile");
             if ( $includestr) {
                 system("$includestr >> $xcat_packimg_tmpfile");
             }
-            $excludestr = "cat $xcat_packimg_tmpfile |cpio -H newc -o | gzip -c - > ../rootimg-statelite.gz";
+            $excludestr = "cat $xcat_packimg_tmpfile |cpio -H newc -o | $compress -c - > ../rootimg-statelite.gz";
         } else {
-            $excludestr = "find . |cpio -H newc -o | gzip -c - > ../rootimg-statelite.gz";
+            $excludestr = "find . |cpio -H newc -o | $compress -c - > ../rootimg-statelite.gz";
         }
         $oldmask = umask 0077;
         chdir("$rootimg_dir");

--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -955,6 +955,16 @@ sub mkinitrd_dracut {
     if ($dracutver > "033") {
         $additional_options .= " -N";
     }
+
+
+    #if "pigz" is available in the rootimg, use "pigz" instead of "gzip"
+    my $compress=qx(chroot $rootimg_dir bash -c "type -p pigz"|tr -d "\n");
+    if ($compress){
+        #take the online cpu numerber as the pigz processes number
+        my $processnum=qx(lscpu -p=cpu --online|grep -v '#'|wc -l|tr -d "\n");
+        $additional_options .= " --compress \"$compress -p $processnum \"";
+    }
+     print "\nchroot $rootimg_dir dracut $additional_options -f /tmp/initrd.$$.gz $kernelver\n";
     !system("chroot $rootimg_dir dracut $additional_options -f /tmp/initrd.$$.gz $kernelver")
         or die("Error: failed to generate the initial ramdisk for $mode.\n");
     print "the initial ramdisk for $mode is generated successfully.\n";

--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -949,13 +949,10 @@ sub mkinitrd_dracut {
 	$additional_options= qq{--include /tmp/cmdline /etc/cmdline};
     }
 
-
-
     # force the dracut run in non-hostonly mode for dracut higher than version 033
     if ($dracutver > "033") {
         $additional_options .= " -N";
     }
-
 
     #if "pigz" is available in the rootimg, use "pigz" instead of "gzip"
     my $compress=qx(chroot $rootimg_dir bash -c "type -p pigz"|tr -d "\n");
@@ -964,7 +961,8 @@ sub mkinitrd_dracut {
         my $processnum=qx(lscpu -p=cpu --online|grep -v '#'|wc -l|tr -d "\n");
         $additional_options .= " --compress \"$compress -p $processnum \"";
     }
-     print "\nchroot $rootimg_dir dracut $additional_options -f /tmp/initrd.$$.gz $kernelver\n";
+
+    print "\nchroot $rootimg_dir dracut $additional_options -f /tmp/initrd.$$.gz $kernelver\n";
     !system("chroot $rootimg_dir dracut $additional_options -f /tmp/initrd.$$.gz $kernelver")
         or die("Error: failed to generate the initial ramdisk for $mode.\n");
     print "the initial ramdisk for $mode is generated successfully.\n";

--- a/xCAT-server/share/xcat/netboot/sles/genimage
+++ b/xCAT-server/share/xcat/netboot/sles/genimage
@@ -1088,6 +1088,16 @@ sub mkinitrd_dracut {
         $additional_options .= " -N";
     }
 
+
+    #if "pigz" is available in the rootimg, use "pigz" instead of "gzip"
+    my $compress=qx(chroot $rootimg_dir bash -c "type -p pigz"|tr -d "\n");
+    if ($compress){
+        #take the online cpu numerber as the pigz processes number
+        my $processnum=qx(lscpu -p=cpu --online|grep -v '#'|wc -l|tr -d "\n");
+        $additional_options .= " --compress \"$compress -p $processnum \"";
+    }
+     print "\nchroot $rootimg_dir dracut $additional_options -f /tmp/initrd.$$.gz $kernelver\n";
+
     !system("chroot $rootimg_dir dracut $additional_options -f /tmp/initrd.$$.gz $kernelver")
         or die("Error: failed to generate the initial ramdisk for $mode.\n");
     print "the initial ramdisk for $mode is generated successfully.\n";

--- a/xCAT-server/share/xcat/netboot/sles/genimage
+++ b/xCAT-server/share/xcat/netboot/sles/genimage
@@ -1088,7 +1088,6 @@ sub mkinitrd_dracut {
         $additional_options .= " -N";
     }
 
-
     #if "pigz" is available in the rootimg, use "pigz" instead of "gzip"
     my $compress=qx(chroot $rootimg_dir bash -c "type -p pigz"|tr -d "\n");
     if ($compress){
@@ -1096,8 +1095,8 @@ sub mkinitrd_dracut {
         my $processnum=qx(lscpu -p=cpu --online|grep -v '#'|wc -l|tr -d "\n");
         $additional_options .= " --compress \"$compress -p $processnum \"";
     }
-     print "\nchroot $rootimg_dir dracut $additional_options -f /tmp/initrd.$$.gz $kernelver\n";
 
+    print "\nchroot $rootimg_dir dracut $additional_options -f /tmp/initrd.$$.gz $kernelver\n";
     !system("chroot $rootimg_dir dracut $additional_options -f /tmp/initrd.$$.gz $kernelver")
         or die("Error: failed to generate the initial ramdisk for $mode.\n");
     print "the initial ramdisk for $mode is generated successfully.\n";

--- a/xCAT-server/share/xcat/netboot/ubuntu/genimage
+++ b/xCAT-server/share/xcat/netboot/ubuntu/genimage
@@ -1629,39 +1629,50 @@ EOMS
 #   }
 
     system("chroot /tmp/xcatinitrd.$$/ depmod $kernelver");
-	# Copy udev and network scripts into initrd for s390x, which also works for other platforms
-	# udev
-	system("mkdir -p /tmp/xcatinitrd.$$/etc/udev");
-	system("cp -r $rootimg_dir/etc/udev/* /tmp/xcatinitrd.$$/etc/udev");
-	system("mkdir -p /tmp/xcatinitrd.$$/lib/udev");
-	system("cp -r $rootimg_dir/lib/udev/* /tmp/xcatinitrd.$$/lib/udev");
-	system("mkdir -p /tmp/xcatinitrd.$$/proc/self");
-	system("cp -r /proc/self/oom_adj /tmp/xcatinitrd.$$/proc/self");
-	
-	# Network related scripts
-        #system("echo $kernelver\n");
-	#system("mkdir -p /tmp/xcatinitrd.$$/sbin");
-	#system("cp -r $rootimg_dir/sbin/* /tmp/xcatinitrd.$$/sbin");
-	#system("mkdir -p /tmp/xcatinitrd.$$/lib/modules/$kernelver");
-	#system("cp -r $rootimg_dir/lib/modules/$kernelver/modules.dep /tmp/xcatinitrd.$$/lib/modules/$kernelver/modules.dep");
-	#system("mkdir -p /tmp/xcatinitrd.$$/etc/init.d");
-	#system("cp -r $rootimg_dir/etc/init.d/* /tmp/xcatinitrd.$$/etc/init.d");
-	#system("mkdir -p /tmp/xcatinitrd.$$/lib64");
-	#system("cp -r $rootimg_dir/lib64/* /tmp/xcatinitrd.$$/lib64");
-	#system("mkdir -p /tmp/xcatinitrd.$$/var/run/netreport");
-        symlink("busybox","/tmp/xcatinitrd.$$/bin/pivot_root");
-        symlink("busybox", "/tmp/xcatinitrd.$$/bin/udhcpc");
-        symlink("busybox", "/tmp/xcatinitrd.$$/sbin/ifconfig");
-        symlink("busybox", "/tmp/xcatinitrd.$$/bin/hostname");
-        symlink("busybox", "/tmp/xcatinitrd.$$/bin/route");
-        symlink("busybox", "/tmp/xcatinitrd.$$/bin/nc");
-        symlink("bash", "/tmp/xcatinitrd.$$/bin/sh");
-        symlink("bash", "/tmp/xcatinitrd.$$/sbin/sh");
+    # Copy udev and network scripts into initrd for s390x, which also works for other platforms
+    # udev
+    system("mkdir -p /tmp/xcatinitrd.$$/etc/udev");
+    system("cp -r $rootimg_dir/etc/udev/* /tmp/xcatinitrd.$$/etc/udev");
+    system("mkdir -p /tmp/xcatinitrd.$$/lib/udev");
+    system("cp -r $rootimg_dir/lib/udev/* /tmp/xcatinitrd.$$/lib/udev");
+    system("mkdir -p /tmp/xcatinitrd.$$/proc/self");
+    system("cp -r /proc/self/oom_adj /tmp/xcatinitrd.$$/proc/self");
+    
+    # Network related scripts
+    #system("echo $kernelver\n");
+    #system("mkdir -p /tmp/xcatinitrd.$$/sbin");
+    #system("cp -r $rootimg_dir/sbin/* /tmp/xcatinitrd.$$/sbin");
+    #system("mkdir -p /tmp/xcatinitrd.$$/lib/modules/$kernelver");
+    #system("cp -r $rootimg_dir/lib/modules/$kernelver/modules.dep /tmp/xcatinitrd.$$/lib/modules/$kernelver/modules.dep");
+    #system("mkdir -p /tmp/xcatinitrd.$$/etc/init.d");
+    #system("cp -r $rootimg_dir/etc/init.d/* /tmp/xcatinitrd.$$/etc/init.d");
+    #system("mkdir -p /tmp/xcatinitrd.$$/lib64");
+    #system("cp -r $rootimg_dir/lib64/* /tmp/xcatinitrd.$$/lib64");
+    #system("mkdir -p /tmp/xcatinitrd.$$/var/run/netreport");
+    symlink("busybox","/tmp/xcatinitrd.$$/bin/pivot_root");
+    symlink("busybox", "/tmp/xcatinitrd.$$/bin/udhcpc");
+    symlink("busybox", "/tmp/xcatinitrd.$$/sbin/ifconfig");
+    symlink("busybox", "/tmp/xcatinitrd.$$/bin/hostname");
+    symlink("busybox", "/tmp/xcatinitrd.$$/bin/route");
+    symlink("busybox", "/tmp/xcatinitrd.$$/bin/nc");
+    symlink("bash", "/tmp/xcatinitrd.$$/bin/sh");
+    symlink("bash", "/tmp/xcatinitrd.$$/sbin/sh");
 
-	
-   #copy("$rootimg_dir/lib/modules/*d","/tmp/xcatinitrd.$$/$_");
-   system("cd /tmp/xcatinitrd.$$;find .|cpio -H newc -o|gzip -9 -c - > $destdir/initrd-$mode.gz");
-   system("rm -rf /tmp/xcatinitrd.$$");
+
+    my $compress="gzip";
+    #if pigz is available,use pigz instead of gzip
+    my $ispigz=system("bash -c 'type -p pigz' >/dev/null 2>&1");
+    if($ispigz == 0){
+       $compress="pigz";
+    }else{
+       $compress="gzip";
+    }
+
+
+    #copy("$rootimg_dir/lib/modules/*d","/tmp/xcatinitrd.$$/$_");
+    print "\ncd /tmp/xcatinitrd.$$;find .|cpio -H newc -o|$compress -9 -c - > $destdir/initrd-$mode.gz \n";
+    system("cd /tmp/xcatinitrd.$$;find .|cpio -H newc -o|$compress -9 -c - > $destdir/initrd-$mode.gz");
+    system("rm -rf /tmp/xcatinitrd.$$");
 
 }
 

--- a/xCAT-server/share/xcat/netboot/ubuntu/genimage
+++ b/xCAT-server/share/xcat/netboot/ubuntu/genimage
@@ -1645,16 +1645,12 @@ EOMS
     symlink("bash", "/tmp/xcatinitrd.$$/bin/sh");
     symlink("bash", "/tmp/xcatinitrd.$$/sbin/sh");
 
-
     my $compress="gzip";
     #if pigz is available,use pigz instead of gzip
     my $ispigz=system("bash -c 'type -p pigz' >/dev/null 2>&1");
     if($ispigz == 0){
        $compress="pigz";
-    }else{
-       $compress="gzip";
     }
-
 
     #copy("$rootimg_dir/lib/modules/*d","/tmp/xcatinitrd.$$/$_");
     print "\ncd /tmp/xcatinitrd.$$;find .|cpio -H newc -o|$compress -9 -c - > $destdir/initrd-$mode.gz \n";

--- a/xCAT-server/share/xcat/netboot/ubuntu/genimage
+++ b/xCAT-server/share/xcat/netboot/ubuntu/genimage
@@ -1624,9 +1624,6 @@ EOMS
     }
 
 
-#   if (-d "$rootimg_dir/lib/powerpc64le-linux-gnu/"){
-#      system("cp  -rf $rootimg_dir/lib/powerpc64le-linux-gnu/* /tmp/xcatinitrd.$$/lib/powerpc64le-linux-gnu/");
-#   }
 
     system("chroot /tmp/xcatinitrd.$$/ depmod $kernelver");
     # Copy udev and network scripts into initrd for s390x, which also works for other platforms
@@ -1639,16 +1636,6 @@ EOMS
     system("cp -r /proc/self/oom_adj /tmp/xcatinitrd.$$/proc/self");
     
     # Network related scripts
-    #system("echo $kernelver\n");
-    #system("mkdir -p /tmp/xcatinitrd.$$/sbin");
-    #system("cp -r $rootimg_dir/sbin/* /tmp/xcatinitrd.$$/sbin");
-    #system("mkdir -p /tmp/xcatinitrd.$$/lib/modules/$kernelver");
-    #system("cp -r $rootimg_dir/lib/modules/$kernelver/modules.dep /tmp/xcatinitrd.$$/lib/modules/$kernelver/modules.dep");
-    #system("mkdir -p /tmp/xcatinitrd.$$/etc/init.d");
-    #system("cp -r $rootimg_dir/etc/init.d/* /tmp/xcatinitrd.$$/etc/init.d");
-    #system("mkdir -p /tmp/xcatinitrd.$$/lib64");
-    #system("cp -r $rootimg_dir/lib64/* /tmp/xcatinitrd.$$/lib64");
-    #system("mkdir -p /tmp/xcatinitrd.$$/var/run/netreport");
     symlink("busybox","/tmp/xcatinitrd.$$/bin/pivot_root");
     symlink("busybox", "/tmp/xcatinitrd.$$/bin/udhcpc");
     symlink("busybox", "/tmp/xcatinitrd.$$/sbin/ifconfig");


### PR DESCRIPTION
1. correct some indent problem in ubuntu/genimage 
2. when "pigz" is available on the management node, "genimage"  on ubuntu and "packimage" will use "pigz" instead of "gzip" as the compress tool  
3. when "pigz" is available in the chrooted rootimg generated by "genimage", "genimage" will use "pigz" as the dracut compress tool. The process number of pigz will be the number of online cpus on the server which performs the "genimage" operation.
4. for “genimage” on redhat and sles, the "pigz" feature is only supported on the os releases which use dracut to generated the initrd, i.e, redhat 6 or above, sles12 or above
5. there will be a document on how to enable the "pigz" in genimage and packimage 

