### PR TITLE
fix issue xcatd restart failed using latest build during loading dock…

### DIFF
--- a/xCAT-server/lib/xcat/plugins/docker.pm
+++ b/xCAT-server/lib/xcat/plugins/docker.pm
@@ -310,7 +310,7 @@ sub send_req {
                                       );
     if ($socket) {
         $connect = IO::Socket::SSL->start_SSL( $socket,
-                                                   SSL_verify_mode => SSL_VERIFY_PEER,
+                                                   SSL_verify_mode => "SSL_VERIFY_PEER",
                                                    SSL_ca_file => $ssl_ca_file,
                                                    SSL_cert_file =>$ssl_cert_file,
                                                    SSL_key_file => $key_file,


### PR DESCRIPTION
Before fix：
 xcat-core]# perl -c ./xCAT-server/lib/xcat/plugins/docker.pm
Bareword "SSL_VERIFY_PEER" not allowed while "strict subs" in use at ./xCAT-server/lib/xcat/plugins/docker.pm line 312.
./xCAT-server/lib/xcat/plugins/docker.pm had compilation errors.

After fix：
 xcat-core]# perl -c ./xCAT-server/lib/xcat/plugins/docker.pm
./xCAT-server/lib/xcat/plugins/docker.pm syntax OK

/perl/xCAT_plugin # service xcatd status
xcatd.service - LSB: xCATd
   Loaded: loaded (/etc/init.d/xcatd)
   Active: active (running) since Mon 2015-08-31 09:24:13 EDT; 6s ago
  Process: 16135 ExecStop=/etc/init.d/xcatd stop (code=exited, status=0/SUCCESS)
  Process: 16152 ExecStart=/etc/init.d/xcatd start (code=exited, status=0/SUCCESS)
   CGroup: /system.slice/xcatd.service
           `-16191 /usr/sbin/in.tftpd -v -l -s /tftpboot -m /etc/tftpmapfile4xcat.conf

Aug 31 09:24:14 c910f03c05k06 xcat[16194]: xcatd: possible BUG encountered by xCAT UDP service: Undefined subroutine &main::update_udpcontext_from_sslctl called at /opt/xcat/sbin/xcatd line 731.
