### PR TITLE
[xCAT-server] Add changes missed in 0dba62260c995c824bb26bad9f8686ee7…

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/post.debian
+++ b/xCAT-server/share/xcat/install/scripts/post.debian
@@ -17,7 +17,7 @@ fi
 IP=$(ifconfig $PRINIC | grep inet | awk '{print $2}' | awk -F: '{print $2}')
 if [ -z $IP ]
 then
-	dhclient eth0
+	dhclient $PRINIC
 	IP=$(ifconfig $PRINIC | grep inet | awk '{print $2}' | awk -F: '{print $2}')
 fi
 echo "search #TABLE:site:key=domain:value#" >/etc/resolv.conf

--- a/xCAT-server/share/xcat/install/scripts/post.esx
+++ b/xCAT-server/share/xcat/install/scripts/post.esx
@@ -17,7 +17,7 @@ fi
 IP=$(ifconfig $PRINIC | grep inet | awk '{print $2}' | awk -F: '{print $2}')
 if [ -z $IP ]
 then
-	dhclient eth0
+	dhclient $PRINIC
 	IP=$(ifconfig $PRINIC | grep inet | awk '{print $2}' | awk -F: '{print $2}')
 fi
 echo "search #TABLE:site:key=domain:value#" >/etc/resolv.conf

--- a/xCAT-server/share/xcat/install/scripts/post.ubuntu
+++ b/xCAT-server/share/xcat/install/scripts/post.ubuntu
@@ -25,7 +25,7 @@ fi
 IP=$(ip addr show dev $PRINIC | grep inet | grep -v inet6  | awk  '{print $2}' | head -n 1 | awk -F '/' '{print $1}')
 if [ -z $IP ]
 then
-	dhclient eth0
+	dhclient $PRINIC
 	#IP=$(ifconfig $PRINIC | grep inet | awk '{print $2}' | awk -F: '{print $2}')
         IP=$(ip addr show dev $PRINIC | grep inet | grep -v inet6  | awk  '{print $2}' | head -n 1 | awk -F '/' '{print $1}')
 fi


### PR DESCRIPTION
The postscripts for debian, ubuntu and esx missed the fix for using the parameterizing interface name in the dhclient invocation (using a hardcoded eth0 instead of the introspected/passed parameter).

These correspond to the change made for the RH postscript in 0dba62260c995c824bb26bad9f8686ee711e963f