### PR TITLE
Update remoteshell to avoid provsioning hang-on when CN don't support ecdsa

### DIFF
--- a/xCAT/postscripts/remoteshell
+++ b/xCAT/postscripts/remoteshell
@@ -281,9 +281,17 @@ if [ -f /etc/ssh/ssh_host_ecdsa_key ]; then
 	if ! grep "PRIVATE KEY" /etc/ssh/ssh_host_ecdsa_key > /dev/null 2>&1 ; then
    		rm /etc/ssh/ssh_host_ecdsa_key
 	else
-		ssh-keygen -y -f /etc/ssh/ssh_host_ecdsa_key > /etc/ssh/ssh_host_ecdsa_key.pub
-		chmod 644 /etc/ssh/ssh_host_ecdsa_key.pub
-		chown root /etc/ssh/ssh_host_ecdsa_key.pub
+		# Because of openssh version differs, provisioning errors may happen when MN support ecdsa while CN don't ecdsa.
+		# Judge CN support ecdsa or not. "-t ecdsa" indicate the key type, "-P "" " avoid hang-on and wait for input passphrase when CN don't support ecdsa.
+		# If ture, means support ecdsa, then generate corresponding key.pub. 
+		# If false, remove ssh_host_ecdsa_key useless file, to avoid future errors.
+		if ssh-keygen -t ecdsa -y -f /etc/ssh/ssh_host_ecdsa_key -P "" &>/dev/null ; then
+			ssh-keygen -y -f /etc/ssh/ssh_host_ecdsa_key > /etc/ssh/ssh_host_ecdsa_key.pub
+			chmod 644 /etc/ssh/ssh_host_ecdsa_key.pub
+			chown root /etc/ssh/ssh_host_ecdsa_key.pub
+		else
+			rm -fr /etc/ssh/ssh_host_ecdsa_key
+		fi
 	fi
   else
 	#This is an error message


### PR DESCRIPTION

Update remoteshell to avoid provsioning hang-on when MN support ecdsa but CN don't support ecdsa. Already merge this code to matser branch, but we need to merge in 2.9.1-pcm branch for PCM team.