### PR TITLE
Fix for  #177 (`chdef ` clobbers existing objects with `-n` option)

### DIFF
--- a/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
+++ b/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
@@ -1842,6 +1842,14 @@ sub defch
             return 1;
         }
 
+        # Ensure that the target object doesn't exist
+        if (grep /^$::opt_n$/, @validnode) {
+            my $rsp;
+            push @{$rsp->{data}}, "Object $::opt_n already exists.";
+            xCAT::MsgUtils->message("E", $rsp, $::callback);
+            return 1;
+        }
+
         # Use the getobjdefs function to get a hash which including
         # all the records in the table that should be changed
         my %chnamehash = ();


### PR DESCRIPTION
Added check to ensure that new name isn't already used on an existing object.