### PR TITLE
Fix for xcat-core/issues/177 master branch, predictable nic names

### DIFF
--- a/xCAT/postscripts/confignics
+++ b/xCAT/postscripts/confignics
@@ -315,7 +315,7 @@ do
                 continue
             fi
         fi
-        if [ `echo $key | grep -E 'e(n|th|m)[0-9a-z]+'` ];then
+        if [ `echo $key | grep -E 'e(n|th|m)[0-9a-zA-Z]+'` ];then
             str_nic_type="ethernet"
         elif [ `echo $key | grep -E 'ib[0-9]+'` ];then
             str_nic_type="infiniband"


### PR DESCRIPTION
Add to regular expression for ethernet devices to handle the
predictable nic naming conventions that are starting to be used
in the later OS releases

 xcat2/xcat-core/issues/172