### PR TITLE
using dist-upgrade to upgrade the most important packages

### DIFF
--- a/xCAT-server/share/xcat/netboot/ubuntu/genimage
+++ b/xCAT-server/share/xcat/netboot/ubuntu/genimage
@@ -354,8 +354,8 @@ unless ($onlyinitrd) {
 
    close($aptconfig);
 
-   # run apt-get upgrade to update any installed debs
-   my $aptgetcmd_update = $aptgetcmd . "&&". $aptgetcmdby . " upgrade  ";
+   # run apt-get dist-upgrade to update any installed debs
+   my $aptgetcmd_update = $aptgetcmd . "&&". $aptgetcmdby . " dist-upgrade  ";
    $rc = system("$aptgetcmd_update");
         
    # Start to install pkgs in pkglist
@@ -575,10 +575,10 @@ unless ($onlyinitrd) {
    }
 
    if (!$noupdate) {
-       # run apt-get upgrade to update any installed debs
+       # run apt-get dist-upgrade to update any installed debs
        # needed when running genimage again after updating software in repositories
        #my $aptgetcmd_update = $yumcmd_base . " upgrade  ";
-       my $aptgetcmd_update = $aptgetcmd . "&&". $aptgetcmdby . " upgrade  ";
+       my $aptgetcmd_update = $aptgetcmd . "&&". $aptgetcmdby . " dist-upgrade  ";
        $rc = system("$aptgetcmd_update");
 #       if ($kernelimage) {
 #           if ($kernelver) {


### PR DESCRIPTION
dist-upgrade will attempt to upgrade the most important packages at the expense of less important ones if necessary. The dist-upgrade command may therefore remove some packages. Thus an obsolete util-linux package will not installed for Ubuntu 14.04.3 on ppc64el diskless node.