### PR TITLE
check the postscripts before running it with 'bash -x'

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/post.ubuntu
+++ b/xCAT-server/share/xcat/install/scripts/post.ubuntu
@@ -159,8 +159,12 @@ run_ps () {
   echo \"\`date\` Running postscript: \$*\" 
   msgutil_r \"\$MASTER_IP\" \"info\" "\"\`date\` Running postscript: \$*\"" \"\$logfile\"
   if [ \"\$XCATDEBUGMODE\" = \"1\" ]; then
-     bash -x ./\$@ 2>&1 | tee -a \$logfile
-     ret_local=\${PIPESTATUS[0]}
+     local compt=\$(file \$1)
+     local reg=\"shell script\"
+     if [[ \"\$compt\" =~ \$reg ]]; then
+        bash -x ./\$@ 2>&1 | tee -a \$logfile
+        ret_local=\${PIPESTATUS[0]}
+     fi
   else
      ./\$@ 2>&1 | tee -a \$logfile
      ret_local=\${PIPESTATUS[0]}

--- a/xCAT-server/share/xcat/install/scripts/post.xcat
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat
@@ -144,8 +144,12 @@ run_ps () {
   echo \"\`date\` Running postscript: \$*\" 
   msgutil_r \"\$MASTER_IP\" \"info\" "\"\`date\` Running postscript: \$*\"" \"\$logfile\"
   if [ \"\$XCATDEBUGMODE\" = \"1\" ]; then
-     bash -x ./\$@ 2>&1 | tee -a \$logfile
-     ret_local=\${PIPESTATUS[0]}
+     local compt=\$(file \$1)
+     local reg=\"shell script\"
+     if [[ \"\$compt\" =~ \$reg ]]; then
+        bash -x ./\$@ 2>&1 | tee -a \$logfile
+        ret_local=\${PIPESTATUS[0]}
+     fi
   else
      ./\$@ 2>&1 | tee -a \$logfile
      ret_local=\${PIPESTATUS[0]}

--- a/xCAT/postscripts/xcatdsklspost
+++ b/xCAT/postscripts/xcatdsklspost
@@ -829,8 +829,12 @@ run_ps () {
   echo \"\`date\` Running postscript: \$*\" 
   msgutil_r \"\$MASTER_IP\" \"info\" "\"\`date\` Running postscript: \$*\"" \"\$logfile\"
   if [ \"\$XCATDEBUGMODE\" = \"1\" ]; then
-     bash -x ./\$@ 2>&1 | tee -a \$logfile
-     ret_local=\${PIPESTATUS[0]}
+     local compt=\$(file \$1)
+     local reg=\"shell script\"
+     if [[ \"\$compt\" =~ \$reg ]]; then
+        bash -x ./\$@ 2>&1 | tee -a \$logfile
+        ret_local=\${PIPESTATUS[0]}
+     fi
   else
      ./\$@ 2>&1 | tee -a \$logfile
      ret_local=\${PIPESTATUS[0]}


### PR DESCRIPTION
When enable the site.xcatdebugmode, the postscript will be run with 'bash -x' to output more debug messages. But not all of xCAT postscripts are shell script, so do the check before running it with 'bash -x'.