### PR TITLE
Fix #218,  Check file rsyslogd.pid before issuing kill on the pid

### DIFF
--- a/xCAT/debian/postinst
+++ b/xCAT/debian/postinst
@@ -46,7 +46,11 @@ case "$1" in
 
 	/etc/init.d/apache2 restart
 
-	kill -HUP $(</var/run/rsyslogd.pid) >/dev/null 2>&1 || :
+        if [ -e /var/run/rsyslogd.pid ]; then
+            kill -HUP $(</var/run/rsyslogd.pid) >/dev/null 2>&1 || :
+        elif [ -e /var/run/syslogd.pid ]; then
+            kill -HUP $(</var/run/syslogd.pid) >/dev/null 2>&1 || :
+        fi
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/xCAT/debian/postinst
+++ b/xCAT/debian/postinst
@@ -46,6 +46,7 @@ case "$1" in
 
 	/etc/init.d/apache2 restart
 
+        # Let rsyslogd perform close of any open files
         if [ -e /var/run/rsyslogd.pid ]; then
             kill -HUP $(</var/run/rsyslogd.pid) >/dev/null 2>&1 || :
         elif [ -e /var/run/syslogd.pid ]; then

--- a/xCAT/xCAT.spec
+++ b/xCAT/xCAT.spec
@@ -201,7 +201,7 @@ then
    cp /etc/xcat/conf.orig/xcat.conf.apach24 /etc/apache2/conf.d/xcat.conf
 fi
 
-# Lets rsyslogd perform close all open files
+# Let rsyslogd perform close of any open files
 if [ -e /var/run/rsyslogd.pid ]; then
     kill -HUP $(</var/run/rsyslogd.pid) >/dev/null 2>&1 || :
 elif [ -e /var/run/syslogd.pid ]; then

--- a/xCAT/xCAT.spec
+++ b/xCAT/xCAT.spec
@@ -202,7 +202,11 @@ then
 fi
 
 # Lets rsyslogd perform close all open files
-kill -HUP $(</var/run/rsyslogd.pid) >/dev/null 2>&1 || :
+if [ -e /var/run/rsyslogd.pid ]; then
+    kill -HUP $(</var/run/rsyslogd.pid) >/dev/null 2>&1 || :
+elif [ -e /var/run/syslogd.pid ]; then
+    kill -HUP $(</var/run/syslogd.pid) >/dev/null 2>&1 || :
+fi
 %endif
 
 # create dir for the current pid

--- a/xCATsn/xCATsn.spec
+++ b/xCATsn/xCATsn.spec
@@ -156,6 +156,13 @@ if [ -n "$version" ]; then
 fi
 
 
+# Let rsyslogd perform close of any open files
+if [ -e /var/run/rsyslogd.pid ]; then
+    kill -HUP $(</var/run/rsyslogd.pid) >/dev/null 2>&1 || :
+elif [ -e /var/run/syslogd.pid ]; then
+    kill -HUP $(</var/run/syslogd.pid) >/dev/null 2>&1 || :
+fi
+
 %endif
 
 # create dir for the current pid and move the original ones from /tmp/xcat to /var/run/xcat


### PR DESCRIPTION

Added a test for rsylogd.pid before just assuming that is the fileanme on the system.
The older systems is syslogd.pid.  Only of those files are there do we issue a kill -HUP on it. 

Fix Issues #218