### PR TITLE
failed to check postgresql package and ids

### DIFF
--- a/xCAT-client/bin/pgsqlsetup
+++ b/xCAT-client/bin/pgsqlsetup
@@ -164,7 +164,7 @@ if ($::RUNCMD_RC != 0)
 #
 # check to see if postgresql is installed
 #
-my $cmd = "rpm -qa | grep postgresql";
+my $cmd = "rpm -q postgresql";
 if ($debianflag){
     $cmd = "dpkg -l | grep postgresql | awk '{print \$2}'";
 }
@@ -179,6 +179,20 @@ if ($::RUNCMD_RC != 0)
     xCAT::MsgUtils->message("E", " $cmd failed. $message");
     exit(1);
 }
+
+#
+#check to see if postgres user is created
+#
+my $cmd = "id postgres";
+my @output=xCAT::Utils->runcmd($cmd, 0);
+if ($::RUNCMD_RC != 0)
+{
+    my $message = "\nPostgreSQL user is not created, please make sure postgresql-server packages are installed.";
+
+    xCAT::MsgUtils->message("E", " $cmd failed. $message");
+    exit(1);
+}
+
 # check if 9.X release not built by us is installed,  setup different
 # SLES used default dir
 if  ( (grep(/postgresql9/, @output)) && ($::linuxos !~ /sles/) ){  # postgresql 9.x

--- a/xCAT-client/bin/pgsqlsetup
+++ b/xCAT-client/bin/pgsqlsetup
@@ -164,7 +164,7 @@ if ($::RUNCMD_RC != 0)
 #
 # check to see if postgresql is installed
 #
-my $cmd = "rpm -q postgresql";
+my $cmd = "rpm -q postgresql-server";
 if ($debianflag){
     $cmd = "dpkg -l | grep postgresql | awk '{print \$2}'";
 }
@@ -180,18 +180,6 @@ if ($::RUNCMD_RC != 0)
     exit(1);
 }
 
-#
-#check to see if postgres user is created
-#
-my $cmd = "id postgres";
-my @output=xCAT::Utils->runcmd($cmd, 0);
-if ($::RUNCMD_RC != 0)
-{
-    my $message = "\nPostgreSQL user is not created, please make sure postgresql-server packages are installed.";
-
-    xCAT::MsgUtils->message("E", " $cmd failed. $message");
-    exit(1);
-}
 
 # check if 9.X release not built by us is installed,  setup different
 # SLES used default dir


### PR DESCRIPTION
Noticed on some of test system, the postgresql-libs was installed which cause pgsqlsetup scripts bypass the checking of "rpm -qa | grep postgresql" ,  "rpm -q postgresql"  works better for this case.  

"yum install postgresql"  will only installed postgresql-9.2...... and postgresql-libs....,   the postgres id will not created unless the postgresql-server is installed.   Add a checking for postgres id in the pgsqlsetup scripts to make sure all required dependency are set.