### PR TITLE
Apply fix for bug #4669 to centos template

### DIFF
--- a/xCAT-server/share/xcat/install/centos/compute.centos7.tmpl
+++ b/xCAT-server/share/xcat/install/centos/compute.centos7.tmpl
@@ -147,7 +147,7 @@ reboot
 #INCLUDE_DEFAULT_PKGLIST#
 %end
 %pre
-#INCLUDE:#ENV:XCATROOT#/share/xcat/install/scripts/pre.rh.rhel7#
+#INCLUDE:#ENV:XCATROOT#/share/xcat/install/scripts/pre.rh.rhels7#
 %end
 %post
 #INCLUDE:#ENV:XCATROOT#/share/xcat/install/scripts/post.xcat#


### PR DESCRIPTION
The current centos7 template includes pre.rh.rhel7 which doesn't exist. Based on the fix for centos7 it looks like the name should be pre.rh.rhels7.