### PR TITLE
Handle ',,' in nodelist

### DIFF
--- a/xCAT-server/lib/xcat/plugins/confluent.pm
+++ b/xCAT-server/lib/xcat/plugins/confluent.pm
@@ -362,7 +362,7 @@ sub donodeent {
   }
   my @cfgroups;
   foreach (keys %$groupdata) {
-      push @cfgroups, split /,/,$groupdata->{$_}->[0]->{groups};
+      push @cfgroups, grep {defined && length} split /,/,$groupdata->{$_}->[0]->{groups};
   }
   $confluent->read('/nodegroups/');
   my $currgroup = $confluent->next_result();
@@ -419,7 +419,7 @@ foreach my $node (sort keys %$cfgenthash) {
   } elsif ($::XCATSITEVALS{'consoleondemand'} and $::XCATSITEVALS{'consoleondemand'} !~ m/^n/) {
     $parameters{'console.logging'} = 'none';
   }
-  $parameters{'groups'} = [split /,/,$groupdata->{$node}->[0]->{'groups'}];
+  $parameters{'groups'} = [grep {defined && length} split /,/,$groupdata->{$node}->[0]->{'groups'}];
   if (exists $currnodes{$node}) {
     $confluent->update('/nodes/'.$node.'/attributes/current', parameters=>\%parameters);
     my $rsp = $confluent->next_result();


### PR DESCRIPTION
If ',,' is in nodelist, then confluent is
told to deal with empty groups.  Filter
that phenomenon out.