### PR TITLE
correct mknb will run two twice during install xcat

### DIFF
--- a/xCAT-server/sbin/xcatconfig
+++ b/xCAT-server/sbin/xcatconfig
@@ -1855,20 +1855,26 @@ sub mknb
     if ($::arch =~ /ppc/) {
         $::arch = "ppc64";
     }
-    if ((($::arch eq "x86_64") ||($::arch =~ /ppc/)) && (-f '/etc/xcat/genesis-scripts-updated') ) {
-      unlink '/etc/xcat/genesis-scripts-updated';
-      # Do not print messages or run command twice
-      if (-f '/etc/xcat/genesis-base-updated') {
-          unlink '/etc/xcat/genesis-base-updated';
+    if (($::arch eq "x86_64") ||($::arch =~ /ppc/)) {
+      if (-f '/etc/xcat/genesis-scripts-updated') {
+        unlink '/etc/xcat/genesis-scripts-updated';
+        # Do not print messages or run command twice
+        if (-f '/etc/xcat/genesis-base-updated') {
+            unlink '/etc/xcat/genesis-base-updated';
+        }
       }
-      $cmd = "$::XCATROOT/sbin/mknb $::arch";
-      xCAT::MsgUtils->message('I', "Running '$cmd', triggered by the installation/update of xCAT-genesis-scripts-$::arch ...");
-    }
-
-    if ((($::arch eq "x86_64") ||($::arch =~ /ppc/)) && (-f '/etc/xcat/genesis-base-updated')) {
+      if (-f '/etc/xcat/genesis-base-updated') {
         unlink '/etc/xcat/genesis-base-updated';
+      }
+      if ((-f '/etc/xcat/genesis-scripts-updated') ||(-f '/etc/xcat/genesis-base-updated')) {
         $cmd = "$::XCATROOT/sbin/mknb $::arch";
+      }
+      if (-f '/etc/xcat/genesis-scripts-updated') {
+        xCAT::MsgUtils->message('I', "Running '$cmd', triggered by the installation/update of xCAT-genesis-scripts-$::arch ...");
+      }
+      if (-f '/etc/xcat/genesis-base-updated') {
         xCAT::MsgUtils->message('I', "Running '$cmd', triggered by the installation/update of xCAT-genesis-base-$::arch ...");
+      }
     }
     my $outref = xCAT::Utils->runcmd("$cmd", 0);
     if ($cmd) {


### PR DESCRIPTION
How to reproduce:
1.down load the latest build
2.yum install xCAT
3.tail -f /var/log/xcat/commands.log

[Date] 2015-9-13 6:0:53
[ClientType] cli
[Request] mknb ppc64
[Response]
Creating genesis.fs.ppc64.gz in /tftpboot/xcat

[Date] 2015-9-13 6:1:20
[ClientType] cli
[Request] mknb ppc64
[Response]
Creating genesis.fs.ppc64.gz in /tftpboot/xcat
---------------------------------->mknb will run two time
