### PR TITLE
xCAT-genesis-builder for Openpower

### DIFF
--- a/perl-xCAT/xCAT/ProfiledNodeUtils.pm
+++ b/perl-xCAT/xCAT/ProfiledNodeUtils.pm
@@ -1347,12 +1347,23 @@ sub gen_chain_for_profiles{
     }
     #run bmcsetups.
     #PowerNV nodes can't use 'runcmd=bmcsetup' to set BMC.
-    if ((exists $netprofileattr->{"bmc"}) and $hw_reconfig and $netboot ne 'petitboot'){ 
-        if (index($final_chain, "runcmd=bmcsetup") == -1){
-            $final_chain = 'runcmd=bmcsetup,'.$final_chain.':reboot4deploy';
-        }
-        else{
-            $final_chain = $final_chain.':reboot4deploy';
+    #But OpenPower need to support bmcsetup
+    my $nodehmtab = xCAT::Table->new('nodehm');
+    my $comments = "";
+    my $nodehmtab_entry = $nodehmtab->getNodeAttribs($hwprofile, ['comments']);
+    if (defined $nodehmtab_entry->{'comments'}) {
+       $comments = $nodehmtab_entry->{'comments'};
+    }
+
+    if ((exists $netprofileattr->{"bmc"}) and $hw_reconfig){
+        if ((($netboot eq 'petitboot') and ($comments eq 'openpower')) or ($netboot ne 'petiboot'))
+        {
+            if (index($final_chain, "runcmd=bmcsetup") == -1){
+               $final_chain = 'runcmd=bmcsetup,'.$final_chain.':reboot4deploy';
+            }
+            else{
+                $final_chain = $final_chain.':reboot4deploy';
+            }
         }
     }
     return (0, $final_chain);

--- a/xCAT-genesis-builder/buildrpm
+++ b/xCAT-genesis-builder/buildrpm
@@ -10,6 +10,11 @@ DIR=`dirname $0`
 DIR=`readlink -f $DIR`
 BUILDARCH=`uname -m`
 
+#For Openpower
+if [ $BUILDARCH = "ppc64le" ]; then
+    BUILDARCH="ppc64"
+fi
+
 # get the input files for dracut in the right place
 # Fedora 20 ppc64 uses /usr/lib/dracut/modules.d
 # CentOS 7 probably uses /usr/lib/dracut/modules.d also
@@ -39,6 +44,8 @@ if [ "$HOSTOS" = "mcp" ]; then
             sed -i 's/dracut_install dmidecode \/usr\/lib64\/libstdc++.so.5//' $DRACUTMODDIR/install
             sed -i 's/dmidecode//' $DRACUTMODDIR/install
             sed -i 's/\/lib\/ld-linux.so.2/\/usr\/lib64\/ld-2.17.so/' $DRACUTMODDIR/install
+            sed -i 's/\/lib64\/libsysfs.so.2//' $DRACUTMODDIR/install
+            sed -i 's/\/usr\/sbin\/iprconfig//' $DRACUTMODDIR/install
         else
             sed -i 's/\/lib\/ld-linux.so.2/\/usr\/lib64\/ld-linux-x86-64.so.2/' $DRACUTMODDIR/install
         fi

--- a/xCAT-genesis-builder/xCAT-genesis-base.spec
+++ b/xCAT-genesis-builder/xCAT-genesis-base.spec
@@ -5,7 +5,7 @@
 %ifarch x86_64
 %define tarch x86_64
 %endif
-%ifarch ppc ppc64
+%ifarch ppc ppc64 ppc64le
 %define tarch ppc64
 %endif
 BuildArch: noarch

--- a/xCAT-genesis-builder/xcat-cmdline.sh
+++ b/xCAT-genesis-builder/xcat-cmdline.sh
@@ -45,6 +45,11 @@ while :; do screen -ln < /dev/tty2 > /dev/tty2 2>&1; done &
 # Need to wait for NIC initialization
 sleep 20
 ARCH=`uname -m`
+#For Openpower
+if [ $ARCH = "ppc64le" ]; then
+    ARCH="ppc64"
+fi
+
 if [ $ARCH == 'ppc64' ]; then
 
     ALL_NICS=`ip link show | grep -v "^ " | awk '{print $2}' | sed -e 's/:$//' | grep -v lo`


### PR DESCRIPTION
For ticket https://github.com/xcat2/xcat-core/issues/281
Update xCAT-genesis-builder for building MCP 8.1, make it suitable for openpower