### PR TITLE
Remove the Juniper directory if exists, cause symlink creation to fail

### DIFF
--- a/xCAT-server/xCAT-server.spec
+++ b/xCAT-server/xCAT-server.spec
@@ -402,6 +402,12 @@ if [ -x /usr/sbin/emgr ]; then          # Check for emgr cmd
 fi
 %endif
 
+# The Juniper directory is switched to Jun and a sylink is created
+if [ -d $RPM_INSTALL_PREFIX0/share/xcat/devicetype/EthSwitch/Juniper ]; then 
+    # need to remove the old directory otherwise the symlink won't get creatd correctly
+    rm -rf $RPM_INSTALL_PREFIX0/share/xcat/devicetype/EthSwitch/Juniper
+fi
+
 %post
 %ifos linux
 ln -sf $RPM_INSTALL_PREFIX0/sbin/xcatd /usr/sbin/xcatd


### PR DESCRIPTION
Check if the  /opt/xcat/share/xcat/devicetype/EthSwitch/Junipe exists because we changed this to "Jun" and create a symlink . The symlink creation will fail if the directory is there.   Worse yet, the rpm update does not successfully run... 
```
# ls -ltr /opt/xcat/share/xcat/devicetype/EthSwitch/
total 24
-rw-r--r-- 1 root root  439 Jun 23 22:20 config
drwxr-xr-x 2 root root 4096 Jun 24 15:24 Mellanox
drwxr-xr-x 2 root root 4096 Jun 24 23:02 Juniper
lrwxrwxrwx 1 root root    3 Oct 20 08:50 Juniper;5626389c -> Jun
lrwxrwxrwx 1 root root    3 Oct 20 08:54 Juniper;5626397f -> Jun
drwxr-xr-x 2 root root 4096 Oct 20 08:54 Jun
drwxr-xr-x 2 root root 4096 Oct 20 08:54 Cisco
drwxr-xr-x 2 root root 4096 Oct 20 08:54 BNT
```
Fix Issue #287 