### PR TITLE
The postscripts in EXECUTE for synclist do not run

### DIFF
--- a/perl-xCAT/xCAT/DSHCLI.pm
+++ b/perl-xCAT/xCAT/DSHCLI.pm
@@ -5685,10 +5685,6 @@ sub run_rsync_postscripts
         # return from rsync is tmp/file1  not /tmp/file1
         substr($tmppostfile,0,1)=""; 
 
-        # now remove .post from the postscript file for the compare
-        # with the returned file name
-        my($tp,$post) = split(/\.post/,$tmppostfile);
-        $tmppostfile = $tp;
         foreach my $line (@rsync_output) {
             my($hostname,$ps) = split(/: /, $line);
             chomp $ps;

--- a/perl-xCAT/xCAT/DSHCLI.pm
+++ b/perl-xCAT/xCAT/DSHCLI.pm
@@ -5674,39 +5674,39 @@ sub run_rsync_postscripts
     my $dshparms; 
     my $firstpass=1;
     foreach my $postsfile (@::postscripts) {
-       my $tmppostfile = $postsfile ;
- 
-       # if service node need to add the SNsyncfiledir to the path
-       if (xCAT::Utils->isServiceNode()) {
-         my $tmpp=$syncdir . $tmppostfile;
-         $tmppostfile = $tmpp;
-       }
-       # remove  first character for the compare, we have to do this because the
-       # return from rsync is tmp/file1  not /tmp/file1
-       substr($tmppostfile,0,1)=""; 
+        my $tmppostfile = $postsfile ;
 
-       # now remove .post from the postscript file for the compare
-       # with the returned file name
-       my($tp,$post) = split(/\.post/,$tmppostfile);
-       $tmppostfile = $tp;
-       foreach my $line (@rsync_output) {
-         my($hostname,$ps) = split(/: /, $line);
-         chomp $ps;
-         chomp $hostname;
-         if ($ps eq "rsync") {  # this is a line that is not an update 
-             # save output , if firstpass through output
-             if ($firstpass == 1) {
-               push @newoutput, $line;
-               $firstpass = 0;
-             }
-             next;
-         }
-         if ($tmppostfile eq $ps) { 
-           # build xdsh queue 
-           # build host and all scripts to execute
-           push (@{$dshparms->{'postscripts'} {$postsfile}}, $hostname);
-         }
-       }
+        # if service node need to add the SNsyncfiledir to the path
+        if (xCAT::Utils->isServiceNode()) {
+            my $tmpp=$syncdir . $tmppostfile;
+            $tmppostfile = $tmpp;
+        }
+        # remove  first character for the compare, we have to do this because the
+        # return from rsync is tmp/file1  not /tmp/file1
+        substr($tmppostfile,0,1)=""; 
+
+        # now remove .post from the postscript file for the compare
+        # with the returned file name
+        my($tp,$post) = split(/\.post/,$tmppostfile);
+        $tmppostfile = $tp;
+        foreach my $line (@rsync_output) {
+            my($hostname,$ps) = split(/: /, $line);
+            chomp $ps;
+            chomp $hostname;
+            if ($ps eq "rsync") {  # this is a line that is not an update 
+                # save output , if firstpass through output
+                if ($firstpass == 1) {
+                    push @newoutput, $line;
+                    $firstpass = 0;
+                }
+                next;
+            }
+            if ($tmppostfile eq $ps) { 
+                # build xdsh queue 
+                # build host and all scripts to execute
+                push (@{$dshparms->{'postscripts'} {$postsfile}}, $hostname);
+            }
+        }
     }
     # now if we have postscripts to run, run xdsh
     my $out;
@@ -5718,25 +5718,24 @@ sub run_rsync_postscripts
         push (@nodes, @{$$dshparms{'postscripts'}{$ps}}); 
         my @args=();
         if ($$options{'nodestatus'}) {
-          push @args,"--nodestatus" ;
+            push @args,"--nodestatus" ;
         }
         push @args,"-e";
-        # if on the service node need to add the $syncdir directory 
-        # to the path
+        #
+        # if on the service node need to add the $syncdir directory to the path
+        #
         if (xCAT::Utils->isServiceNode()) {
-         my $tmpp=$syncdir . $ps;
-         $ps=$tmpp;
+            my $tmpp=$syncdir . $ps;
+            $ps=$tmpp;
         }
         push @args,$ps;
         $out=xCAT::Utils->runxcmd( { command => ['xdsh'],
-                                    node    => \@nodes,
-                                    arg     => \@args, 
-                             }, $::SUBREQ, 0,1);
-        foreach my $r (@$out){
-                push(@newoutput, $r);
-
+                                     node    => \@nodes,
+                                     arg     => \@args, 
+                                   }, $::SUBREQ, 0,1);
+        foreach my $r (@$out) {
+            push(@newoutput, $r);
         }
-        #     $ranaps=1;
     }
     return @newoutput;
 }

--- a/perl-xCAT/xCAT/DSHCLI.pm
+++ b/perl-xCAT/xCAT/DSHCLI.pm
@@ -211,11 +211,6 @@ sub execute_dcp
                     $::DCP_API_MESSAGE .=
                         join("", @{$output_buffers{$user_target}})
                       . join("", @{$error_buffers{$user_target}});
-                    if ($$options{'display_output'})
-                    {
-                        print STDOUT @{$output_buffers{$user_target}};
-                        print STDERR @{$error_buffers{$user_target}};
-                    }
                 }
                 else
                 {
@@ -580,21 +575,6 @@ sub _execute_dsh
                         $::DSH_API_MESSAGE
                       . join("", @{$output_buffers{$user_target}})
                       . join("", @{$error_buffers{$user_target}});
-                    if ($$options{'display_output'})
-                    {
-
-                        # print STDOUT @{$output_buffers{$user_target}};
-                        # print STDERR @{$error_buffers{$user_target}};
-                        chomp(@{$output_buffers{$user_target}});
-                        chomp(@{$error_buffers{$user_target}});
-                        my $rsp = {};
-                        push @{$rsp->{data}}, @{$output_buffers{$user_target}};
-                        xCAT::MsgUtils->message("D", $rsp, $::CALLBACK);
-                        $rsp = {};
-                        push @{$rsp->{error}}, @{$error_buffers{$user_target}};
-                        $rsp->{NoErrorPrefix} = 1;
-                        xCAT::MsgUtils->message("E", $rsp, $::CALLBACK,0);
-                    }
                 }
                 else
                 {


### PR DESCRIPTION
Fix for EXECUTE not running the scripts, addressing Issue  #257 

Unit test: 
```
[root@c910f02c05p03 xCAT]# lsdef -t osimage -o rhels6.6-ppc64-install-compute | grep synclist
    synclists=/install/custom/install/rhels7/compute.rhels.synclist
[root@c910f02c05p03 xCAT]# cat /install/custom/install/rhels7/compute.rhels.synclist
/tmp/file.post -> /tmp/file.post
/tmp/file2.post -> /tmp/file2.post
EXECUTE:
/tmp/file.post
/tmp/file2.post
```

Content of the .post files

```
[root@c910f02c05p03 xCAT]# cat /tmp/file.post
echo hello > /tmp/test
[root@c910f02c05p03 xCAT]# cat /tmp/file2.post
echo hello > /tmp/test2
```

Clean out the /tmp directory for the target node

```
[root@c910f02c05p03 xCAT]# xdsh c910f02c05p04 "rm -f /tmp/*"
[root@c910f02c05p03 xCAT]# xdsh c910f02c05p04 "ls -ltr /tmp"
c910f02c05p04: total 0
```

Run Update node
```
[root@c910f02c05p03 xCAT]# updatenode c910f02c05p04 -F    
File synchronization has completed for nodes.
```

Check the files
```
[root@c910f02c05p03 xCAT]# xdsh c910f02c05p04 "ls -ltr /tmp"
c910f02c05p04: total 16
c910f02c05p04: -rwxr-xr-x 1 root root 23 Oct 19 16:06 file.post
c910f02c05p04: -rw-r--r-- 1 root root  6 Oct 20 17:11 test2
c910f02c05p04: -rw-r--r-- 1 root root  6 Oct 20 17:11 test
c910f02c05p04: -rwxr-xr-x 1 root root 24 Oct 20  2015 file2.post

[root@c910f02c05p03 xCAT]# xdsh c910f02c05p04 cat /tmp/test
c910f02c05p04: hello
[root@c910f02c05p03 xCAT]# xdsh c910f02c05p04 cat /tmp/test2
c910f02c05p04: hello
```