### PR TITLE
correct mknb will run twice during install xcat

### DIFF
--- a/xCAT-server/sbin/xcatconfig
+++ b/xCAT-server/sbin/xcatconfig
@@ -1856,21 +1856,20 @@ sub mknb
         $::arch = "ppc64";
     }
     if ((($::arch eq "x86_64") ||($::arch =~ /ppc/)) && (-f '/etc/xcat/genesis-scripts-updated') ) {
-      unlink '/etc/xcat/genesis-scripts-updated';
-      # Do not print messages or run command twice
-      if (-f '/etc/xcat/genesis-base-updated') {
-          unlink '/etc/xcat/genesis-base-updated';
-      }
-      $cmd = "$::XCATROOT/sbin/mknb $::arch";
-      xCAT::MsgUtils->message('I', "Running '$cmd', triggered by the installation/update of xCAT-genesis-scripts-$::arch ...");
+        unlink '/etc/xcat/genesis-scripts-updated';
+        # Do not print messages or run command twice
+        if (-f '/etc/xcat/genesis-base-updated') {
+            unlink '/etc/xcat/genesis-base-updated';
+        }
+        $cmd = "$::XCATROOT/sbin/mknb $::arch";
+        xCAT::MsgUtils->message('I', "Running '$cmd', triggered by the installation/update of xCAT-genesis-scripts-$::arch ...");
     }
-
     if ((($::arch eq "x86_64") ||($::arch =~ /ppc/)) && (-f '/etc/xcat/genesis-base-updated')) {
         unlink '/etc/xcat/genesis-base-updated';
         $cmd = "$::XCATROOT/sbin/mknb $::arch";
         xCAT::MsgUtils->message('I', "Running '$cmd', triggered by the installation/update of xCAT-genesis-base-$::arch ...");
     }
-    my $outref = xCAT::Utils->runcmd("$cmd", 0);
+    # my $outref = xCAT::Utils->runcmd("$cmd", 0);
     if ($cmd) {
         system($cmd);
         if ($? != 0) {
@@ -1878,7 +1877,7 @@ sub mknb
             xCAT::MsgUtils->message('E', "The 'mknb $::arch' command returned error code: $rc.");
         }
         else {
-          xCAT::MsgUtils->message('I', "The 'mknb $::arch' command completed successfully.");
+            xCAT::MsgUtils->message('I', "The 'mknb $::arch' command completed successfully.");
         }
     }
 }


### PR DESCRIPTION
```
How to reproduce:
1.down load the latest build
2.yum install xCAT
3.tail -f /var/log/xcat/commands.log

[Date] 2015-9-13 6:0:53
[ClientType] cli
[Request] mknb ppc64
[Response]
Creating genesis.fs.ppc64.gz in /tftpboot/xcat

[Date] 2015-9-13 6:1:20
[ClientType] cli
[Request] mknb ppc64
[Response]
Creating genesis.fs.ppc64.gz in /tftpboot/xcat
---------------------------------->mknb will run two time
```
