### PR TITLE
SLES12 SP1 - Modify pgsqlsetup to support detecting postgresql-server package

### DIFF
--- a/xCAT-client/bin/pgsqlsetup
+++ b/xCAT-client/bin/pgsqlsetup
@@ -164,7 +164,7 @@ if ($::RUNCMD_RC != 0)
 #
 # check to see if postgresql is installed
 #
-my $cmd = "rpm -q postgresql-server";
+my $cmd = "rpm -qa | grep postgresql | grep server";
 if ($debianflag){
     $cmd = "dpkg -l | grep postgresql | awk '{print \$2}'";
 }


### PR DESCRIPTION
For the sles12 SP1,  the postgres server has different name than other OS
````
 # rpm -qa | grep postgres
postgresql94-server-9.4.5-1.4.ppc64le
````
So checking "rpm -q postgresql-server" will not working for sles12 SP1.
