### PR TITLE
fix issue [fvt]2.11 rcons will stay in anaconda interface in rh7.2 ppc64le

### DIFF
--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -798,7 +798,7 @@ sub mknetboot
             $kcmdline .= "rdloaddriver=hf_if ";
         }
 
-        
+
         if (defined $sent->{serialport})
         {
 
@@ -816,6 +816,7 @@ sub mknetboot
                 next;
             }
             if ( $arch =~ /ppc64/i ) {
+
                 # For IBM Power machines, either ppc64 or ppc64le (ppc64el),
                 # both the physical serial port or virtual serial port appeared
                 # in PowerVM LPAR or PowerKVM guest use device /dev/hvc0 or
@@ -1421,7 +1422,6 @@ sub mkinstall
             my $kversion=$os;
             $kversion =~ s/^\D*([\.0-9]+)/$1/;
             $kversion =~ s/\.$//;
-            print "xxx $kversion\n";
             if ($pkvm) {
                    $kcmdline = "ksdevice=bootif kssendmac text selinux=0 rd.dm=0 rd.md=0 repo=$httpmethod://$instserver:$httpport$httpprefix/packages/ kvmp.inst.auto=$httpmethod://$instserver:$httpport/install/autoinst/$node root=live:$httpmethod://$instserver:$httpport$httpprefix/LiveOS/squashfs.img";
             } else {
@@ -1572,10 +1572,17 @@ sub mkinstall
                    $kcmdline .=" inst.cmdline ";
                 }
 
-                $kcmdline .=
-                    " console=tty0 console=ttyS"
-                  . $sent->{serialport} . ","
-                  . $sent->{serialspeed};
+                if ( $arch =~ /ppc64/i ) {
+
+                     # For IBM Power machines, either ppc64 or ppc64le (ppc64el),
+                     # both the physical serial port or virtual serial port appeared
+                     # in PowerVM LPAR or PowerKVM guest use device /dev/hvc0 or
+                     # /dev/hvc1 instead of /dev/ttyS0 or /dev/ttyS1
+                     $kcmdline .= " console=tty0 console=hvc" . $sent->{serialport} . "," . $sent->{serialspeed};
+                } else {
+                     $kcmdline .= " console=tty0 console=ttyS" . $sent->{serialport} . "," . $sent->{serialspeed};
+                }
+
                 if ($sent->{serialflow} =~ /(hard|cts|ctsrts)/)
                 {
                     $kcmdline .= "n8r";


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/317