### PR TITLE
If TFTPDIR does not begin with /, correct it

### DIFF
--- a/xCAT-server/share/xcat/install/centos/compute.centos7.tmpl
+++ b/xCAT-server/share/xcat/install/centos/compute.centos7.tmpl
@@ -147,7 +147,7 @@ reboot
 #INCLUDE_DEFAULT_PKGLIST#
 %end
 %pre
-#INCLUDE:#ENV:XCATROOT#/share/xcat/install/scripts/pre.rh.rhel7#
+#INCLUDE:#ENV:XCATROOT#/share/xcat/install/scripts/pre.rh.rhels7#
 %end
 %post
 #INCLUDE:#ENV:XCATROOT#/share/xcat/install/scripts/post.xcat#

--- a/xCAT-server/share/xcat/install/scripts/post.xcat
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat
@@ -19,6 +19,9 @@ if [ -z "$TFTPDIR" ]; then
 
     TFTPDIR="/tftpboot"
 fi
+if [[ $TFTPDIR != /* ]]; then
+    TFTPDIR="/"$TFTPDIR
+fi
 
 cd /tmp
 RAND=$(perl -e 'print int(rand(50)). "\n"')


### PR DESCRIPTION
TFTPDIR could be set without a leading /.  Support
this syntax by putting a slash in front and hoping
for the best