### PR TITLE
Move over the tools page off of SF to RTD

### DIFF
--- a/docs/source/guides/admin-guides/references/index.rst
+++ b/docs/source/guides/admin-guides/references/index.rst
@@ -4,10 +4,15 @@ References
 xCAT Commands
 -------------
 
+xCAT Database
+-------------
+
 xCAT Man Pages
 --------------
 
-*These man pages are auto generated from pod files to rst.  Please do not modify the content from GitHub directly*
+*These man pages are auto generated from pod files to rst.  *
+
+*DO NOT modify directly from GitHub*
 
 .. toctree::
    :maxdepth: 1
@@ -19,6 +24,25 @@ xCAT Man Pages
    man8/index.rst
         
 
-xCAT Database Tables
---------------------
+xCAT Tools
+----------
+
+**Use at your own risk** 
+
+This is a list of additional tools that are shipped with xCAT.  The tools are located in the ``/opt/xcat/share/xcat/tools/``  directory and it's recommended to add to your PATH.  Many of these tools have been contributed by xCAT users that are not part of the core xCAT development team.  
+
+If you encounter any problems with the tools, post a message to the xCAT mailing list for help.
+
+.. toctree::
+   :maxdepth:1
+
+   tools/detect_dhcpd.rst
+   tools/mac2linklocal.rst
+   tools/mktoolscenter.rst
+   tools/nodesw.rst
+   tools/reorgtbls.rst
+   tools/rmblade.rst
+   tools/rmnodecfg.rst
+   tools/test_hca_state.rst
+
 

--- a/docs/source/guides/admin-guides/references/tools/detect_dhcpd.rst
+++ b/docs/source/guides/admin-guides/references/tools/detect_dhcpd.rst
@@ -1,0 +1,15 @@
+detect_dhcpd
+============
+
+::
+
+    Usage: detect_dhcpd -i interface [-m macaddress] [-t timeout] [-V]
+
+    This command can be used to detect the dhcp server in a network for a specific mac address.
+    
+    Options:
+        -i interface:  The interface which facing the target network.
+        -m macaddress: The mac that will be used to detect dhcp server. Recommend to use the real mac of the node that will be netboot. If no specified, the mac of interface which specified by -i will be used.
+        -t timeout:    The time to wait to detect the dhcp messages. The default value is 10s.
+    
+Author:  Wang, Xiao Peng

--- a/docs/source/guides/admin-guides/references/tools/mac2linklocal.rst
+++ b/docs/source/guides/admin-guides/references/tools/mac2linklocal.rst
@@ -1,0 +1,10 @@
+mac2linklocal
+=============
+
+:: 
+
+    Usage:  mac2linklocal -m 
+
+    Determines the IPv6 link local address that is appropriate for a NIC, based on its MAC.
+
+Author:  Li, Guang Cheng

--- a/docs/source/guides/admin-guides/references/tools/mktoolscenter.rst
+++ b/docs/source/guides/admin-guides/references/tools/mktoolscenter.rst
@@ -1,0 +1,20 @@
+mktoolscenter
+=============
+
+::
+
+    Usage: mktoolscenter
+      --ph 
+      --pp 
+      --puser 
+      --ppw 
+      -l 
+      -s
+      --nfsserver 
+      --nfspath 
+      --profilename 
+      --help
+    
+    Updates IBM system x server hardware using IBM Bootable Media Creator.
+    
+Author:  Jim Turner

--- a/docs/source/guides/admin-guides/references/tools/nodesw.rst
+++ b/docs/source/guides/admin-guides/references/tools/nodesw.rst
@@ -1,0 +1,12 @@
+nodesw
+======
+
+::
+
+    nodesw changes the vlan of a node to a specified vlan
+    requires xCAT 2.0, Switch configured with SNMP sets, and only tested on SMC8648T
+    nodesw -h|--help
+    nodesw [-v]  vlan 
+    nodesw [-v]  show
+
+Author:  Vallard Benincosa

--- a/docs/source/guides/admin-guides/references/tools/reorgtbls.rst
+++ b/docs/source/guides/admin-guides/references/tools/reorgtbls.rst
@@ -1,0 +1,14 @@
+reorgtbls
+=========
+
+::
+
+    DB2 Table Reorganization utility.
+    This script can be set as a cron job or run on the command line to reorg the xcatdb DB2 database tables. It automatically added as a cron job, if you use the db2sqlsetup command to create your DB2 database setup for xCAT. 
+    Usage:
+            --V - Verbose mode
+            --h - usage
+            --t -comma delimitated list of tables.
+                 Without this flag it reorgs all tables in the xcatdb database .
+    
+Author:  Lissa Valletta

--- a/docs/source/guides/admin-guides/references/tools/rmblade.rst
+++ b/docs/source/guides/admin-guides/references/tools/rmblade.rst
@@ -1,0 +1,17 @@
+rmblade
+=======
+
+::
+    Usage: rmblade [-h|--help]
+
+    Response to SNMP for monsetting to remove blade from xCAT when trap is recieved.
+    Pipe the MM IP address and blade slot number into this cmd.
+
+    Example: 
+     1.  user removes a blade from the chassis
+     2.  snmp trap setup to point here
+     3.  this script removes the blade configuration from xCAT
+     4.  so if blade is placed in new slot or back in then xCAT goes 
+         through rediscover process again.
+    
+Author:  Jarrod Johnson

--- a/docs/source/guides/admin-guides/references/tools/rmnodecfg.rst
+++ b/docs/source/guides/admin-guides/references/tools/rmnodecfg.rst
@@ -1,0 +1,12 @@
+rmnodecfg
+=========
+
+::
+    Usage: rmnodecfg [-h|--help] 
+
+    Removes the configuration of a node so that the next time you reboot 
+    it, it forces it to go through the discovery process.
+    This does not remove it completely from xCAT.  You may want to do this
+    command before running noderm to completely purge the system of the node
+
+Author:  Vallard Benincosa

--- a/docs/source/guides/admin-guides/references/tools/test_hca_state.rst
+++ b/docs/source/guides/admin-guides/references/tools/test_hca_state.rst
@@ -1,0 +1,97 @@
+test_hca_state
+==============
+
+::
+
+    test_hca_state (part of the BEF_Scripts for xCAT) v3.2.27
+
+    Usage: test_hca_state NODERANGE [FILTER] | xcoll
+
+        --help  Display this help output.
+
+        NODERANGE
+            An xCAT noderange on which to operate.
+
+        FILTER
+            A string to match in the output, filtering out everything else.  This
+            is passed to "egrep" and can be a simple string or a regular
+            expression.
+
+    Purpose:  
+    
+        This tool provides a quick and easily repeatable method of
+        validating key InfiniBand adapter (HCA) and node based InfiniBand
+        settings across an entire cluster.  
+        
+        Having consistent OFED settings, and even HCA firmware, can be very
+        important for a properly functioning InfiniBand fabric.  This tool
+        can help you confirm that your nodes are using the settings you
+        want, and if any nodes have settings descrepancies.
+
+
+    Example output:
+
+        #
+        # This example shows that all of rack 14 has the same settings.
+        #
+        root@mgt1:~ # test_hca_state rack14 | xcoll
+        ====================================
+        rack14
+        ====================================
+        OFED Version: MLNX_OFED_LINUX-2.0-3.0.0.3 (OFED-2.0-3.0.0):
+        mlx4_0
+          PCI: Gen3
+          Firmware installed: 2.30.3200
+          Firmware active:    2.30.3200
+          log_num_mtt:      20
+          log_mtts_per_seg: 3
+          Port 1: InfiniBand    phys_state: 5: LinkUp
+            state: 4: ACTIVE
+            rate: 40 Gb/sec (4X FDR10)
+            symbol_error: 0
+            port_rcv_errors: 0
+          Port 2: InfiniBand    phys_state: 3: Disabled
+            state: 1: DOWN
+            rate: 10 Gb/sec (4X)
+            symbol_error: 0
+            port_rcv_errors: 0
+        
+          IPoIB
+            recv_queue_size: 8192
+            send_queue_size: 8192
+            ib0:
+              Mode: datagram
+              MTU:  4092
+              Mode: up
+            ib1:
+              Mode: datagram
+              MTU:  4092
+              Mode: up
+    
+    
+        #
+        # This example uses a FILTER on the word 'firmware'.  In this case, we've
+        # upgraded the firmware across rack11 and rack12.  
+        #
+        #   - On rack11, we've also restarted the IB stack (/etc/init.d/openibd
+        #     restart) to activate the new firmware.  
+        #
+        #   - Rack 12 has also been updated, as we can see from the 'Firmware
+        #     installed' line, but it's nodes are still running with their prior
+        #     level of firmware and must reload the IB stack to have it take effect.
+        #
+        root@mgt1:~ # test_hca_state rack11,rack12 firmware | xcoll
+        ====================================
+        rack11
+        ====================================
+          Firmware installed: 2.30.3200
+          Firmware active:    2.30.3200
+        
+        ====================================
+        rack12
+        ====================================
+          Firmware installed: 2.30.3200
+          Firmware active:    2.11.1260
+    
+    
+Author:  Brian Finley


### PR DESCRIPTION
There's a tools README page on SF that I've moved over to the References page on RTD.  The original page is here: http://xcat.sourceforge.net/tools/README.html