### PR TITLE
fix issue #4673 There's no netbooting status when provision ubuntu stateless node

### DIFF
--- a/xCAT-server/share/xcat/netboot/ubuntu/genimage
+++ b/xCAT-server/share/xcat/netboot/ubuntu/genimage
@@ -1532,14 +1532,14 @@ else
    retrytimes=0
    cmd=""
    while [ "\$cmd" != "done" ]; do
-         retrytimes=`expr \$retrytimes + 1`
+         retrytimes=`busybox expr \$retrytimes + 1`
          if [ \$retrytimes -eq 60 ]; then
             break;
          fi
          read -t 60 cmd
          if [ "\$cmd" == "ready" ]; then
-             head -n 1 /tmp/ncarg
-             rm -rf /tmp/ncarg
+             busybox head -n 1 /tmp/ncarg
+             busybox rm -rf /tmp/ncarg
          fi
    done
 


### PR DESCRIPTION
some commands used in node status reporting code does not exist in the ubuntu diskless initrd, use commands in busybox instead