### PR TITLE
correct to generate stateful-mgmtnode osimage on rh7.0

### DIFF
--- a/xCAT-server/lib/perl/xCAT/SvrUtils.pm
+++ b/xCAT-server/lib/perl/xCAT/SvrUtils.pm
@@ -829,7 +829,7 @@ sub  update_tables_with_mgt_image
     #if the osver does not match the osver of MN, return
     my $myosver = xCAT::Utils->osver("all");
     $myosver =~ s/,//;
-    if ( $osver ne $myosver ) {
+    if(xCAT::Utils->version_cmp("$osver","$myosver")!=0){
         return 0;
     }
 


### PR DESCRIPTION
The return value for $myosver not equal $osver.