### PR TITLE
Clean up some instructions for diskless install of cuda

### DIFF
--- a/docs/source/advanced/gpu/nvidia/osimage/rhels.rst
+++ b/docs/source/advanced/gpu/nvidia/osimage/rhels.rst
@@ -1,7 +1,7 @@
 RHEL 7.2 LE
 ===========
 
-xCAT provides a sample package list files for CUDA. You can find them: 
+xCAT provides a sample package list (pkglist) files for CUDA. You can find them: 
 
     * Diskful: ``/opt/xcat/share/xcat/install/rh/cuda*``
     * Diskless: ``/opt/xcat/share/xcat/install/rh/cuda*``
@@ -79,34 +79,46 @@ cudafull
 
        ln -s /install/cuda-7.5 /install/post/otherpkgs/rhels7.2/ppc64le/cuda-7.5
 
-#. Generate a custom ``pkglist`` file to install the CUDA dependency packages: ::
+#. Change the ``rootimgdir`` for the cudafull osimage: ::
 
-    # copy a pkglist file from /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist
-    mkdir -p /install/custom/netboot/rh/
-    cp /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist \
-      /install/custom/netboot/rh/cudafull.rhels7.ppc64le.pkglist
-
-    # append the dependency packages for cuda
-    vi /install/custom/netboot/rh/cudafull.rhels7.ppc64le.pkglist
-      ...
-      kernel-devel
-      gcc
-      pciutils
-
-    # set the pkglist file to pkglist attribute
     chdef -t osimage -o rhels7.2-ppc64le-netboot-cudafull \
-      pkglist=/install/custom/netboot/rh/cudafull.rhels7.ppc64le.pkglist
+       rootimgdir=/install/netboot/rhels7.2/ppc64le/cudafull
 
-#. Generate ``cudafull`` ``otherpkglist.pkglist`` file to install the CUDA packages: ::
+#. Create a custom pkglist file to install additional operating system packages for your CUDA node. 
 
-    # generate the otherpkgs.pkglist for cudafull osimage
-    vi /install/custom/netboot/rh/cudafull.rhels7.ppc64le.otherpkgs.pkglist
-      cuda-7.5/ppc64le/cuda-deps/dkms
-      cuda-7.5/ppc64le/cuda-core/cuda
+    #. Copy the default compute pkglist file as a starting point: ::
 
-    # set the pkglist file to otherpkglist attribute
-    chdef -t osimage -o rhels7.2-ppc64le-netboot-cudafull \
-      otherpkglist=/install/custom/netboot/rh/cudafull.rhels7.ppc64le.otherpkgs.pkglist
+        mkdir -p /install/custom/netboot/rh/
+
+        cp /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist \
+          /install/custom/netboot/rh/cudafull.rhels7.ppc64le.pkglist
+
+    #. Edit the pkglist file and append any packages you desire to be installed.  For example: ::
+
+        vi /install/custom/netboot/rh/cudafull.rhels7.ppc64le.pkglist
+        ...
+        # Additional packages for CUDA
+        pciutils
+
+    #. Set the new file as the ``pkglist`` attribute for the cudafull osimage: ::
+
+        chdef -t osimage -o rhels7.2-ppc64le-netboot-cudafull \
+          pkglist=/install/custom/netboot/rh/cudafull.rhels7.ppc64le.pkglist
+
+
+#. Create the ``otherpkg.pkglist`` file to do the install of the CUDA full packages:
+
+    #. Create the otherpkg.pkglist file for cudafull: ::
+
+        vi /install/custom/netboot/rh/cudafull.rhels7.ppc64le.otherpkgs.pkglist
+        # add the following packages 
+        cuda-7.5/ppc64le/cuda-deps/dkms
+        cuda-7.5/ppc64le/cuda-core/cuda
+
+    #. Set the ``otherpkg.pkglist`` attribute for the cudafull osimage: ::
+
+        chdef -t osimage -o rhels7.2-ppc64le-netboot-cudafull \
+          otherpkglist=/install/custom/netboot/rh/cudafull.rhels7.ppc64le.otherpkgs.pkglist
 
 #. Generate the image: ::
 
@@ -125,46 +137,37 @@ cudaruntime
       | sed 's/netboot-compute:/netboot-cudaruntime:/' \
       | mkdef -z
 
-#. Verify that the CUDA repo created in the previous step is available in the directory specified by the ``otherpkgdir`` attribute.  
+#. Verify that the CUDA repo created previously is available in the directory specified by the ``otherpkgdir`` attribute.  
 
-   The ``otherpkgdir`` directory can be obtained by running lsdef on the osimage: ::
+    #. Obtain the ``otherpkgdir`` directory using the ``lsdef`` command: ::
 
-       # lsdef -t osimage rhels7.2-ppc64le-netboot-cudaruntime -i otherpkgdir
-       Object name: rhels7.2-ppc64le-netboot-cudaruntime
-           otherpkgdir=/install/post/otherpkgs/rhels7.2/ppc64le
+        # lsdef -t osimage rhels7.2-ppc64le-netboot-cudaruntime -i otherpkgdir
+          Object name: rhels7.2-ppc64le-netboot-cudaruntime
+             otherpkgdir=/install/post/otherpkgs/rhels7.2/ppc64le
 
-   Create a symbolic link of the CUDA repository in the directory specified by ``otherpkgdir`` ::
+    #. Create a symbolic link to the CUDA repository in the directory specified by ``otherpkgdir`` ::
 
-       ln -s /install/cuda-7.5 /install/post/otherpkgs/rhels7.2/ppc64le/cuda-7.5
+        ln -s /install/cuda-7.5 /install/post/otherpkgs/rhels7.2/ppc64le/cuda-7.5
 
-#. Generate a custom ``pkglist`` file to install the CUDA dependency packages: ::
+#. Change the ``rootimgdir`` for the cudaruntime osimage: ::
 
-    # copy a pkglist file from /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist
-    mkdir -p /install/custom/netboot/rh/
-    cp /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist \
-      /install/custom/netboot/rh/cudaruntime.rhels7.ppc64le.pkglist
-
-    # append the dependency packages for cuda
-    vi /install/custom/netboot/rh/cudaruntime.rhels7.ppc64le.pkglist
-      ...
-      kernel-devel
-      gcc
-      pciutils
-
-    # set the pkglist file to pkglist attribute
     chdef -t osimage -o rhels7.2-ppc64le-netboot-cudaruntime \
-      pkglist=/install/custom/netboot/rh/cudaruntime.rhels7.ppc64le.pkglist
+       rootimgdir=/install/netboot/rhels7.2/ppc64le/cudaruntime
 
-#. Generate ``cudaruntime`` ``otherpkglist.pkglist`` file to install the CUDA packages: ::
+#. Create the ``otherpkg.pkglist`` file to do the install of the CUDA runtime packages:
 
-    # generate the otherpkgs.pkglist for cudaruntime osimage
-    vi /install/custom/netboot/rh/cudaruntime.rhels7.ppc64le.otherpkgs.pkglist
-      cuda-7.5/ppc64le/cuda-deps/dkms
-      cuda-7.5/ppc64le/cuda-core/cuda-runtime-7-5
+    #. Create the otherpkg.pkglist file for cudaruntime: ::
 
-    # set the pkglist file to otherpkglist attribute
-    chdef -t osimage -o rhels7.2-ppc64le-netboot-cudaruntime \
-      otherpkglist=/install/custom/netboot/rh/cudaruntime.rhels7.ppc64le.otherpkgs.pkglist
+        vi /install/custom/netboot/rh/cudaruntime.rhels7.ppc64le.otherpkgs.pkglist
+
+        # Add the following packages:
+        cuda-7.5/ppc64le/cuda-deps/dkms
+        cuda-7.5/ppc64le/cuda-core/cuda-runtime-7-5
+
+    #. Set the ``otherpkg.pkglist`` attribute for the cudaruntime osimage: ::
+
+        chdef -t osimage -o rhels7.2-ppc64le-netboot-cudaruntime \
+          otherpkglist=/install/custom/netboot/rh/cudaruntime.rhels7.ppc64le.otherpkgs.pkglist
 
 #. Generate the image: ::
 


### PR DESCRIPTION
Clean up the documentation some more when running the instructons for diskless.

- we need to change the rootimgdir otherwise will overwrite the netboot-compute image

The ``kernel-devel`` and ``gcc`` packages that we specify in the pkglist are automatically pulled in by the cuda and cuda-runtime packages.  There's no need to specify it, which would simplify our instructions.  For the cudafull, I left creating the pkglist and adding pciutils which provides the ``lspci`` command to validate that you have GPU enabled cards.  

I took that step out for diskless cudaruntime to simplify the steps. 

Here's an example of the yum output when installing cuda-runtime
```
Dependencies Resolved
================================================================================
 Package                   Arch    Version             Repository          Size
================================================================================
Installing:
 cuda-runtime-7-5          ppc64le 7.5-18              otherpkgs1         5.8 k
 dkms                      noarch  2.2.0.3-30.git.7c3e7c5.el7
                                                       otherpkgs2          77 k
Installing for dependencies:
 cpp                       ppc64le 4.8.5-4.el7         rhels7.2-ppc64le-0 6.9 M
 cuda-cublas-7-5           ppc64le 7.5-18              otherpkgs1          16 M
 cuda-cudart-7-5           ppc64le 7.5-18              otherpkgs1         138 k
 cuda-cufft-7-5            ppc64le 7.5-18              otherpkgs1          82 M
 cuda-curand-7-5           ppc64le 7.5-18              otherpkgs1          39 M
 cuda-cusolver-7-5         ppc64le 7.5-18              otherpkgs1          19 M
 cuda-cusparse-7-5         ppc64le 7.5-18              otherpkgs1          23 M
 cuda-drivers              ppc64le 352.50-0            otherpkgs1         1.8 k
 cuda-license-7-5          ppc64le 7.5-18              otherpkgs1          32 k
 cuda-npp-7-5              ppc64le 7.5-18              otherpkgs1          42 M
 cuda-nvrtc-7-5            ppc64le 7.5-18              otherpkgs1          11 M
 file                      ppc64le 5.11-31.el7         rhels7.2-ppc64le-0  57 k
 file-libs                 ppc64le 5.11-31.el7         rhels7.2-ppc64le-0 340 k
 gcc                       ppc64le 4.8.5-4.el7         rhels7.2-ppc64le-0  15 M
 glibc-devel               ppc64le 2.17-105.el7        rhels7.2-ppc64le-0 1.1 M
 glibc-headers             ppc64le 2.17-105.el7        rhels7.2-ppc64le-0 650 k
 kernel-devel              ppc64le 3.10.0-316.el7      rhels7.2-ppc64le-0  11 M
 kernel-headers            ppc64le 3.10.0-316.el7      rhels7.2-ppc64le-0 3.1 M
 libatomic                 ppc64le 4.8.5-4.el7         rhels7.2-ppc64le-0  43 k
 libgomp                   ppc64le 4.8.5-4.el7         rhels7.2-ppc64le-0 135 k
 libmpc                    ppc64le 1.0.1-3.el7         rhels7.2-ppc64le-0  52 k
 mpfr                      ppc64le 3.1.1-4.el7         rhels7.2-ppc64le-0 210 k
 nvidia-kmod               ppc64le 1:352.50-2.el7      otherpkgs1         4.9 M
 nvidia-uvm-kmod           ppc64le 1:352.50-3.el7      otherpkgs1         123 k
 tar                       ppc64le 2:1.26-29.el7       rhels7.2-ppc64le-0 848 k
 xorg-x11-drv-nvidia       ppc64le 1:352.50-1.el7      otherpkgs1         789 k
 xorg-x11-drv-nvidia-devel ppc64le 1:352.50-1.el7      otherpkgs1          38 k
 xorg-x11-drv-nvidia-libs  ppc64le 1:352.50-1.el7      otherpkgs1          11 M
```
- cuda runtime does not require pciutils, could save some steps