### PR TITLE
fix for Ubuntu MN to provision rhel CN failed

### DIFF
--- a/xCAT-server/lib/xcat/plugins/kit.pm
+++ b/xCAT-server/lib/xcat/plugins/kit.pm
@@ -616,7 +616,22 @@ sub assign_to_osimage
                 unless ( -d "$otherpkgdir" ) {
                     mkpath("$otherpkgdir");
                 }
-                if ( $debianflag )
+		# Consider the mixed environment 
+		my $imagerhelflag = 0;
+		if ( $osimage =~ /rhel/ ){
+		    $imagerhelflag = 1;
+		}
+
+		if ( $debianflag && $imagerhelflag)
+                {
+                    unless ( -d "$otherpkgdir/$kitcomptable->{kitreponame}" )
+                    {
+		        system("ln -sf $kitrepodir $otherpkgdir/$kitcomptable->{kitreponame} ");
+                    }
+                }
+
+
+                elsif ( $debianflag )
                 {
                     unless ( -d "$otherpkgdir/$kitcomptable->{kitreponame}" )
                     {

--- a/xCAT-server/lib/xcat/plugins/kit.pm
+++ b/xCAT-server/lib/xcat/plugins/kit.pm
@@ -397,7 +397,7 @@ sub assign_to_osimage
     my $tabs = shift;
 
     (my $kitcomptable) = $tabs->{kitcomponent}->getAttribs({kitcompname=> $kitcomp}, 'kitname', 'kitreponame', 'basename', 'kitcompdeps', 'kitpkgdeps', 'prerequisite', 'exlist', 'genimage_postinstall','postbootscripts', 'driverpacks');
-    (my $osimagetable) = $tabs->{osimage}->getAttribs({imagename=> $osimage}, 'provmethod', 'osarch', 'postbootscripts', 'kitcomponents');
+    (my $osimagetable) = $tabs->{osimage}->getAttribs({imagename=> $osimage}, 'provmethod', 'osarch', 'postbootscripts', 'kitcomponents', 'osvers');
     (my $linuximagetable) = $tabs->{linuximage}->getAttribs({imagename=> $osimage}, 'rootimgdir', 'exlist', 'postinstall', 'otherpkglist', 'otherpkgdir', 'driverupdatesrc');
 
     # Reading installdir.
@@ -618,9 +618,12 @@ sub assign_to_osimage
                 }
 		# Consider the mixed environment 
 		my $imagerhelflag = 0;
-		if ( $osimage =~ /rhel/ ){
-		    $imagerhelflag = 1;
-		}
+                if ( $osimagetable and $osimagetable->{osvers} ) {
+                    if ($osimagetable->{osvers} =~ /rhel/){
+                    $imagerhelflag = 1;
+                    }
+                }
+		
 
 		if ( $debianflag && $imagerhelflag)
                 {


### PR DESCRIPTION
The change is for Ubuntu MN provisioning rhel CN.
I have done some unit tests and the change doesn't affect its previous features.
When preparing for ubuntu MN to provision rhel CN, MN will make right soft link to add kit
instead of copy the wrong links so that the CN can install the kit packages.