### PR TITLE
IBM Power S822LC machine support bmcsetup, build genesis based on Fedora 22 ppc64

### DIFF
--- a/xCAT-genesis-builder/buildrpm
+++ b/xCAT-genesis-builder/buildrpm
@@ -4,6 +4,20 @@
 # Option 2:  untar the root file system of the distro you want to use and then chroot into it and copy
 #            this whole dir into it somewhere (like /tmp).
 # Then run this script.  The optional 1st arg should be mcp if you are building against mcp.
+
+# Currently, *Fedora 22* is the only OS supported to build genesis-base for ppc64, and Centos 6.5 for x86_64
+
+
+# For building genesis-base based on Fedora 22 ppc64, the following steps are also needed before running this script
+#
+# 1. The Fedora 22 ppc64 can be installed either on pkvm VM or IBM Power S822LC machine.
+# 2. Install ipmitool with yum install ipmitool. It will install the default ipmitool-1.8.13.
+# 3. Download ipmitool-1.8.15 tar ball from https://sourceforge.net/projects/ipmitool/files/latest/download.
+# 4. Install gcc
+# 5. untar ipmitool-1.8.15 tar ball, cd into the top directory, then ./configure, make.
+#    The ipmitool-1.8.15 binary will be under ./src/.
+# 6, replace /usr/bin/ipmitool with ./src/ipmitool
+
 HOSTOS="$1"
 DIR=`dirname $0`
 #DIR=`realpath $DIR`
@@ -96,17 +110,23 @@ elif [ $BUILDARCH = "ppc64" ]; then
         sed -i 's/\/lib\/libgcc_s.so.1/\/lib64\/libgcc_s.so.1/' $DRACUTMODDIR/install
         sed -i 's/\/lib\/libtinfo.so.5.7/\/lib64\/libtinfo.so.5.7/' $DRACUTMODDIR/install
         # following changes are required on Fedora 20 ppc64
-        sed -i 's/\/lib64\/libnss_dns-2.12.so/\/lib64\/libnss_dns-2.18.so/' $DRACUTMODDIR/install
+        # sed -i 's/\/lib64\/libnss_dns-2.12.so/\/lib64\/libnss_dns-2.18.so/' $DRACUTMODDIR/install
+        # following changes are required on Fedora 22 ppc64
+        sed -i 's/\/lib64\/libnss_dns-2.12.so/\/lib64\/libnss_dns-2.21.so/' $DRACUTMODDIR/install
         sed -i 's/\/lib\/libc.so.6/\/lib64\/libc.so.6/' $DRACUTMODDIR/install
-        sed -i 's/\/lib\/ld-linux.so.2/\/lib64\/ld-2.18.so/' $DRACUTMODDIR/install
+        # following changes are required on Fedora 22 ppc64
+        #sed -i 's/\/lib\/ld-linux.so.2/\/lib64\/ld-2.18.so/' $DRACUTMODDIR/install
+        sed -i 's/\/lib\/ld-linux.so.2/\/lib64\/ld-2.21.so/' $DRACUTMODDIR/install
         sed -i 's/\/lib\/libdl.so.2/\/lib64\/libdl.so.2/' $DRACUTMODDIR/install
         sed -i 's/\/lib\/libm.so.6/\/lib64\/libm.so.6/' $DRACUTMODDIR/install
         sed -i 's/\/lib\/libpthread.so.0/\/lib64\/libpthread.so.0/' $DRACUTMODDIR/install
         sed -i 's/\/lib64\/libncurses.so.5.7/\/lib64\/libncurses.so.5.9/' $DRACUTMODDIR/install
-        sed -i 's/\/usr\/lib64\/libstdc++.so.6.0.13/\/usr\/lib64\/libstdc++.so.6.0.19/' $DRACUTMODDIR/install
+        # following changes are required on Fedora 22 ppc64
+        #sed -i 's/\/usr\/lib64\/libstdc++.so.6.0.13/\/usr\/lib64\/libstdc++.so.6.0.19/' $DRACUTMODDIR/install
+        sed -i 's/\/usr\/lib64\/libstdc++.so.6.0.13/\/usr\/lib64\/libstdc++.so.6.0.21/' $DRACUTMODDIR/install
         sed -i 's/\/lib64\/libtinfo.so.5.7/\/lib64\/libtinfo.so.5.9/' $DRACUTMODDIR/install
         sed -i 's/\/usr\/lib64\/libsasl2.so.2/\/usr\/lib64\/libsasl2.so.3/' $DRACUTMODDIR/install
-        sed -i 's/\/lib64\/libnss_dns-2.12.so/\/lib64\/libnss_dns-2.18.so/' $DRACUTMODDIR/install
+        #sed -i 's/\/lib64\/libnss_dns-2.12.so/\/lib64\/libnss_dns-2.18.so/' $DRACUTMODDIR/install
         sed -i 's/\/lib\/terminfo\/l\/linux/\/usr\/share\/terminfo\/l\/linux/g' $DRACUTMODDIR/install
         sed -i 's/\/lib\/terminfo\/v\/vt100/\/usr\/share\/terminfo\/v\/vt100/g' $DRACUTMODDIR/install
 fi

--- a/xCAT-genesis-builder/installkernel
+++ b/xCAT-genesis-builder/installkernel
@@ -1,6 +1,6 @@
 #!/bin/bash
 instmods nfs sunrpc
-instmods e1000 e1000e virtio_net virtio_pci igb ines sfc mlx4_en cxgb3 cxgb4 tg3 bnx2 bnx2x bna ixgb ixgbe qlge mptsas mpt2sas mpt3sas ata_piix megaraid_sas virtio_blk ahci ibmaem xhci-hcd sd_mod pmcraid be2net vfat ext3 ext4 btrfs reiserfs usb_storage scsi_wait_scan kvm kvm-intel kvm-amd ipmi_si ipmi_devintf qlcnic xfs
+instmods e1000 e1000e virtio_net virtio_pci igb ines sfc mlx4_en cxgb3 cxgb4 tg3 bnx2 bnx2x bna ixgb ixgbe qlge mptsas mpt2sas mpt3sas ata_piix megaraid_sas virtio_blk ahci ibmaem xhci-hcd sd_mod pmcraid be2net vfat ext3 ext4 btrfs reiserfs usb_storage scsi_wait_scan kvm kvm-intel kvm-amd ipmi_powernv ipmi_si ipmi_devintf qlcnic xfs
 instmods macvlan macvtap 8021q bridge bonding vmxnet3 cpufreq_ondemand acpi-cpufreq powernow-k8 cdc_ether
 instmods mptctl #LSI firmware management requires this
 instmods mlx4_ib ib_umad #make the mellanox ib available enough to examine /sys

--- a/xCAT-genesis-scripts/bin/bmcsetup
+++ b/xCAT-genesis-scripts/bin/bmcsetup
@@ -15,8 +15,6 @@
 allowcred.awk &
 CREDPID=$!
 sleep 5
-modprobe ipmi_si
-modprobe ipmi_devintf
 IPCFGMETHOD=static
 while [ -z "$BMCIP" -a $IPCFGMETHOD="static" ]; do
     while ! getipmi
@@ -374,22 +372,25 @@ if [ ! "$IPMIVER" == "1.5"  ]; then
         if [ $TRIES -gt $TIMEOUT ]; then break; fi
     done
     if [ $TRIES -gt $TIMEOUT ]; then echo "ERROR"; else echo "OK"; fi
-    echo -n "Putting SOL on channel $LANCHAN:"
-    while ! OUTPUT=`ipmitool -d $idev raw 0xc 0x21 $LANCHAN 7 $LANCHAN 2>&1 > /dev/null`; do
-	if echo $OUTPUT|grep "Unknown (0x80)" > /dev/null; then
-		echo "Not Needed"
-		break
-        fi
-        sleep 1
-        let TRIES=TRIES+1
-        if [ $TRIES -gt $TIMEOUT ]; then break; fi
-    done
-    if [ $TRIES -gt $TIMEOUT ]; then echo "ERROR"; else echo "OK"; fi
+    
+    # 0xc 0x21 with data 7 is used to set payload channel, it is readonly in the ipmiv2.0 doc, so comment this section out.
+    #echo -n "Putting SOL on channel $LANCHAN:"
+    #while ! OUTPUT=`ipmitool -d $idev raw 0xc 0x21 $LANCHAN 7 $LANCHAN 2>&1 > /dev/null`; do
+    #	if echo $OUTPUT|grep "Unknown (0x80)" > /dev/null; then
+    #		echo "Not Needed"
+    #		break
+    #    fi
+    #    sleep 1
+    #    let TRIES=TRIES+1
+    #    if [ $TRIES -gt $TIMEOUT ]; then break; fi
+    #done
+    #if [ $TRIES -gt $TIMEOUT ]; then echo "ERROR"; else echo "OK"; fi
 fi
 
 # Reset the BMC for the x3755 M4 (8722), otherwise the BMC will not be pingable after running of bmcsetup
 XPROD=`ipmitool mc info|grep "^Product ID"|awk '{print $4}'`
-if [ "$XPROD" = "309" ] ; then
+# Product ID with 43707 is for IBM Power S822LC and S812LC machine
+if [ "$XPROD" = "309" -o "$XPROD" = "43707" ] ; then
     echo "Resetting BMC ..."
     ipmitool mc reset cold
     echo "Waiting for the BMC to appear ..."

--- a/xCAT-genesis-scripts/bin/doxcat
+++ b/xCAT-genesis-scripts/bin/doxcat
@@ -219,19 +219,21 @@ ntpd -g -x
 # rv 0 state does not work with the new ntp versions
 #(while ! ntpq -c "rv 0 state"|grep 'state=4' > /dev/null; do sleep 1; done; hwclock --systohc) &
 (while [ "`ntpq -c \"rv 0 offset\" | grep \"offset=\" | awk -F \"=\" '{print $2}' | awk -F \".\" '{print $1}' | sed s/-//`" -ge 1000 ]; do sleep 1; done; hwclock --systohc) &
-IPMI_ERROR=`ipmitool mc info`
-IPMI_RC=$?
+
+HOST_ARCH=`uname -m`
+if echo $HOST_ARCH | grep "ppc64"; then
+    modprobe ipmi_powernv
+else
+    modprobe ipmi_si
+fi
+modprobe ipmi_devintf
+
+IPMI_RC=`ipmitool mc info >/dev/null 2>&1; echo $?`
 IPMI_SUPPORT=1
 if [ $IPMI_RC -ne 0 ]; then
     IPMI_SUPPORT=0
 fi
 
-if [ -f "/usr/sbin/dmidecode" ]; then
-    if dmidecode|grep IPMI > /dev/null; then
-        modprobe ipmi_si
-        modprobe ipmi_devintf
-    fi
-fi
 DEVICE=$bootnic
 export DEVICE
 


### PR DESCRIPTION
For building genesis with Fedora 22 ppc64 that include the latest ipmitool, pls following the steps below before build genesis-base package.
1. The Fedora 22 ppc64 can be installed either on pkvm VM or IBM Power S822LC machine.
2. Install ipmitool with yum install ipmitool. It will install the default ipmitool-1.8.13.
3. Download ipmitool-1.8.15 tar ball from https://sourceforge.net/projects/ipmitool/files/latest/download.
4. Install gcc
5. untar ipmitool-1.8.15 tar ball, cd into the top directory, then ./configure, make.
    The ipmitool-1.8.15 binary will be under ./src/.
6, replace /usr/bin/ipmitool with ./src/ipmitool
7. Then build xcat-genesis-base pkg with normal steps.