### PR TITLE
Refine IB doc

### DIFF
--- a/docs/source/advanced/networks/infiniband/mlnxofed_ib_install_v2_diskful.rst
+++ b/docs/source/advanced/networks/infiniband/mlnxofed_ib_install_v2_diskful.rst
@@ -54,3 +54,34 @@ Configuration for Diskful Installation
 	nodeset <node> osimage=<osver>-<arch>-install-compute
 	rsetboot <node> net
 	rpower <node> reset
+
+  After installation, you can login target ndoe and issue ``ibstat`` command to verify if your IB driver works well. if everything is fine, you can get the IB apater information ::
+	
+    [root@server ~]# ibstat
+    CA 'mlx4_0'
+        CA type: MT4099
+        Number of ports: 2
+        Firmware version: 2.11.500
+        Hardware version: 0
+        Node GUID: 0x5cf3fc000004ec02
+        System image GUID: 0x5cf3fc000004ec05
+        Port 1:
+                State: Initializing
+                Physical state: LinkUp
+                Rate: 40 (FDR10)
+                Base lid: 0
+                LMC: 0
+                SM lid: 0
+                Capability mask: 0x02594868
+                Port GUID: 0x5cf3fc000004ec03
+                Link layer: InfiniBand
+        Port 2:
+                State: Down
+                Physical state: Disabled
+                Rate: 10
+                Base lid: 0
+                LMC: 0
+                SM lid: 0
+                Capability mask: 0x02594868
+                Port GUID: 0x5cf3fc000004ec04
+                Link layer: InfiniBand

--- a/docs/source/advanced/networks/infiniband/mlnxofed_ib_install_v2_diskless.rst
+++ b/docs/source/advanced/networks/infiniband/mlnxofed_ib_install_v2_diskless.rst
@@ -48,10 +48,32 @@ Configuration for Diskless Installation
 		
   b) Edit ``/install/custom/netboot/<ostype>/<profile>.postinstall`` and add below line in the end ::
 
-	/install/postscripts/mlnxofed_ib_install \
-	   -p /install/<path>/<MLNX_OFED_LINUX.iso> -i $1 -n genimage
+        /install/postscripts/mlnxofed_ib_install \
+        -p /install/<path>/<MLNX_OFED_LINUX.iso> -i $1 -n genimage
 
-	
+
+    **[Note]** If you want ot customized kernel version (i.e the kernel version of the diskless image you want to generate is different with the kernel version of you management node), you need to pass ``--add-kernel-support`` attribute to Mellanox. the line added into ``<profile>.postinstall`` should like below ::
+  
+        /install/postscripts/mlnxofed_ib_install \
+        -p /install/<path>/<MLNX_OFED_LINUX.iso> -m --add-kernel-support -end- -i $1 -n genimage
+  
+    Below steps maybe helpful for you to do judgment if you belong to this situation.
+  
+    Get the kernel version of your management node ::
+  
+        uname -r
+  
+    Get the kernel version of target image. take generating a diskless image of rhels7.0 on x86_64 for example ::
+  
+        [root@server]# lsdef -t osimage rhels7.0-x86_64-install-compute  -i pkgdir
+        Object name: rhels7.0-x86_64-install-compute
+        pkgdir=/install/rhels7.0/x86_64
+
+        [root@server]#  ls -l /install/rhels7.0/x86_64/Packages/ |grep kernel*
+        .......
+        -r--r--r-- 1 root root 30264588 May  5  2014 kernel-3.10.0-123.el7.x86_64.rpm
+        .......
+		
 3. Set the related osimage using the customized pkglist and compute.postinsall
 
 * [RHEL/SLES] ::
@@ -75,3 +97,34 @@ Configuration for Diskless Installation
 	nodeset <nodename> osimage=<osver>-<arch>-netboot-compute 
 	rsetboot <nodename> net
 	rpower <nodename> reset
+
+  After installation, you can login target ndoe and issue ``ibstat`` command to verify if your IB driver works well. if everything is fine, you can get the IB apater information ::
+	
+    [root@server ~]# ibstat
+    CA 'mlx4_0'
+        CA type: MT4099
+        Number of ports: 2
+        Firmware version: 2.11.500
+        Hardware version: 0
+        Node GUID: 0x5cf3fc000004ec02
+        System image GUID: 0x5cf3fc000004ec05
+        Port 1:
+                State: Initializing
+                Physical state: LinkUp
+                Rate: 40 (FDR10)
+                Base lid: 0
+                LMC: 0
+                SM lid: 0
+                Capability mask: 0x02594868
+                Port GUID: 0x5cf3fc000004ec03
+                Link layer: InfiniBand
+        Port 2:
+                State: Down
+                Physical state: Disabled
+                Rate: 10
+                Base lid: 0
+                LMC: 0
+                SM lid: 0
+                Capability mask: 0x02594868
+                Port GUID: 0x5cf3fc000004ec04
+                Link layer: InfiniBand

--- a/docs/source/advanced/networks/infiniband/mlnxofed_ib_install_v2_preparation.rst
+++ b/docs/source/advanced/networks/infiniband/mlnxofed_ib_install_v2_preparation.rst
@@ -19,16 +19,15 @@ Copy **mlnxofed_ib_install.v2** into ``/install/postscripts`` and change name to
 Below are the details of these options:
 
 * **-p**: [required]--the directory where the OFED iso file is located
-* **-m**: [optional]--the mlnxofed_ib_install invokes a script ``mlnxofedinstall`` shipped by Mellanox OFED iso. Use this option to pass arguments to the ``mlnxofedinstall``. You must include ``-end-`` at the completion of the options to distinguish the option list. if you don't pass any argument to ``mlnxofedinstall``, defualt value ``--without-32bit --without-fw-update --force`` will be passed to ``mlnxofedinstall`` by xCAT. 
+* **-m**: [optional]--the mlnxofed_ib_install invokes a script ``mlnxofedinstall`` shipped by Mellanox OFED iso. Use this option to pass arguments to the ``mlnxofedinstall``. You must include ``-end-`` at the completion of the options to distinguish the option list. if you don't pass any argument to ``mlnxofedinstall``, **defualt value** ``--without-32bit --without-fw-update --force`` will be passed to ``mlnxofedinstall`` by xCAT. 
 * **-i**: [required for diskless]--the image root path
-* **-n**: [required for diskless]--nodeset status, the value is 'genimage'. 
+* **-n**: [required for diskless]--nodeset status, the value is 'genimage'
 
 In general you can use ``mlnxofed_ib_install`` like below ::
 
     mlnxofed_ib_install -p /install/<path>/<MLNX_OFED_LINUX.iso>
 	
-If need to pass ``--without-32bit --without-fw-update --add-kernel-support --force`` to ``mlnxofedinstall`` in diskless scenario, refer to below command ::
+If need to pass ``--without-32bit --without-fw-update --add-kernel-support --force`` to ``mlnxofedinstall``, refer to below command ::
 
     mlnxofed_ib_install -p /install/<path>/<MLNX_OFED_LINUX.iso> \
-	-m --without-32bit --without-fw-update --add-kernel-support --force -end- \
-	-i /<imagepath> -n genimage
+	-m --without-32bit --without-fw-update --add-kernel-support --force -end- 


### PR DESCRIPTION
what are refined 
1. add how to verify the IB driver works well
2. modify some example
3. add notice, when the kernel version is different between  generate diskless image and management node, add ``--add-kernel-support`` attribute


