### PR TITLE
AIX -  fix ssl_version issue for aix which openssl less 1.0

### DIFF
--- a/xCAT-client/xCAT-client.spec
+++ b/xCAT-client/xCAT-client.spec
@@ -340,6 +340,24 @@ MANPATH=\$XCATROOT/share/man:\$MANPATH
 export XCATROOT PATH MANPATH
 " >>/etc/profile
 fi
+
+# add environment variable XCATSSLVER=TLSv1 for AIX MN which AIX version < 6.1.9.0 or < 7.1.3.0
+aixver=`lslpp -lc|grep 'bos.rte:'|head -1|cut -d: -f3`
+if [[ $aixver < '6.1.9.0' ]]; then
+    newssl=0
+elif [[ $aixver < '7' ]]; then
+    newssl=1
+elif [[ $aixver < '7.1.3.0' ]]; then
+    newssl=0
+else
+    newssl=1
+fi
+
+if [ $newssl == 0 ]; then
+  echo 'XCATSSLVER=TLSv1' >> /etc/environment
+  echo 'XCATSSLVER=TLSv1' >> /etc/profile
+fi
+
 %endif
 exit 0
 

--- a/xCAT-server/share/xcat/installp_bundles/xCATaixCN61.bnd
+++ b/xCAT-server/share/xcat/installp_bundles/xCATaixCN61.bnd
@@ -14,6 +14,9 @@ R:rsync*
 R:bash*
 
 # built using Perl 5.8.8
-R:perl-Net_SSLeay.pm-1.30-2*
+# used for AIX 6.1.8 and older
+#R:perl-Net_SSLeay.pm-1.30-2*
+# used for AIX 6.1.9 and above
+R:perl-Net_SSLeay.pm-1.55-3*
 R:perl-IO-Socket-SSL*
 

--- a/xCAT-server/share/xcat/installp_bundles/xCATaixSN61.bnd
+++ b/xCAT-server/share/xcat/installp_bundles/xCATaixSN61.bnd
@@ -50,9 +50,11 @@ R:perl-IO-Tty*
 R:perl-Net-DNS*
 R:perl-Net-IP*
 R:perl-Net-Telnet*
-R:perl-Net_SSLeay.pm*
 R:perl-version-0.82-1*
-R:perl-Net_SSLeay.pm-1.30-2*
+# used for AIX 6.1.8 and older
+#R:perl-Net_SSLeay.pm-1.30-2*
+# used for AIX 6.1.9 and above
+R:perl-Net_SSLeay.pm-1.55-3*
 R:perl-IO-Socket-SSL*
 R:unixODBC*
 

--- a/xCAT/postscripts/aixremoteshell
+++ b/xCAT/postscripts/aixremoteshell
@@ -270,11 +270,29 @@ sub getresponse
 	# open listener connection to wait for check from management node
 	my $lpid = &openlistener();
 
+	# force to use XCATSSLVER=TLSv1 for AIX MN which AIX version < 6.1.9.0 or < 7.1.3.0
+	my $aixver=`lslpp -lc|grep 'bos.rte:'|head -1|cut -d: -f3`;
+	chomp($aixver);
+	my $newssl;
+	if ($aixver le '6.1.9.0') {
+		$newssl=0;
+	} elsif ($aixver le '7') {
+		$newssl=1;
+	} elsif ($aixver le '7.1.3.0') {
+		$newssl=0;
+	} else {
+		$newssl=1;
+	}
+	my %sslargs;
+	unless ($newssl) {
+		$sslargs{SSL_version} = "TLSv1";
+	}
 	# open a socket to request credentials
 	my $sock = IO::Socket::SSL->new(
 		PeerAddr => $::servnode,
 		PeerPort  => $port,
 		Proto    => 'tcp',
+		%sslargs,
 	);
 
 	unless ($sock) {

--- a/xCAT/postscripts/startsyncfiles.aix
+++ b/xCAT/postscripts/startsyncfiles.aix
@@ -16,8 +16,26 @@ if ($useSocketSSL) {
         require IO::Socket::SSL;
 }
 
+# force to use XCATSSLVER=TLSv1 for AIX MN which AIX version < 6.1.9.0 or < 7.1.3.0
+my $aixver=`lslpp -lc|grep 'bos.rte:'|head -1|cut -d: -f3`;
+chomp($aixver);
+my $newssl;
+if ($aixver le '6.1.9.0') {
+  $newssl=0;
+} elsif ($aixver le '7') {
+  $newssl=1;
+} elsif ($aixver le '7.1.3.0') {
+  $newssl=0;
+} else {
+  $newssl=1;
+}
+my %sslargs;
+unless ($newssl) {
+  $sslargs{SSL_version} = "TLSv1";
+}
+
 my $port = "3001";
-my $remote = IO::Socket::SSL->new( Proto => "tcp", PeerAddr => $ENV{MASTER}, PeerPort  => $port, );
+my $remote = IO::Socket::SSL->new( Proto => "tcp", PeerAddr => $ENV{MASTER}, PeerPort  => $port, %sslargs,);
 unless ($remote) {
   `logger -t xCAT -p local4.err "startsyncfiles: Cannot connect to host $ENV{MASTER}"`;
   exit 0;

--- a/xCAT/postscripts/xcataixpost
+++ b/xCAT/postscripts/xcataixpost
@@ -503,10 +503,29 @@ sub getmypost {
   if(!( -f $scriptname)) {
       my $port = "3001";
 	   # open a socket to request credentials
+      # force to use XCATSSLVER=TLSv1 for AIX MN which AIX version < 6.1.9.0 or < 7.1.3.0
+      my $aixver=`lslpp -lc|grep 'bos.rte:'|head -1|cut -d: -f3`;
+      chomp($aixver);
+      my $newssl;
+      if ($aixver le '6.1.9.0') {
+          $newssl=0;
+      } elsif ($aixver le '7') {
+          $newssl=1;
+      } elsif ($aixver le '7.1.3.0') {
+          $newssl=0;
+      } else {
+          $newssl=1;
+      }
+      my %sslargs;
+      unless ($newssl) {
+          $sslargs{SSL_version} = "TLSv1";
+      }
+
       my $remote = IO::Socket::SSL->new(
         PeerAddr => $servnode,
         PeerPort  => $port,
         Proto    => 'tcp',
+        %sslargs,
       );
       # get ready to create the file
 	  if (!open(POSTSCRIPT, ">$scriptname") ) {


### PR DESCRIPTION
*  export XCATSSLVER=TLSv1 when install xCAT-client
*  Explicitly using XCATSSLVER=TLSv1 in postscripts: xcataixpost,startsyncfiles.aix and aixremoteshell
*  change xCATaixCN61.bnd, make high version of perl-Net_SSLeay.pm to be default