### PR TITLE
correct 'updatenode node -k -F' without prompting message directly

### DIFF
--- a/xCAT-client/bin/updatenode
+++ b/xCAT-client/bin/updatenode
@@ -79,71 +79,77 @@ if (!($tmp =~ / (--help|-h|-v|--version)/)) {
 
 push (@{$cmdref->{arg}}, @ARGV);
 # check the syntax
+my ($ALLSW,$CMDLINE,$ALTSRC,$HELP,$VERSION,$VERBOSE,$FILESYNC,$GENMYPOST,$USER,$SNFILESYNC,$SWMAINTENANCE,$SETSERVER,$RERUNPS,$SECURITY,$OS,$fanout,$timeout,$NOVERIFY);
 if (
     !GetOptions(
-                'A|updateallsw'    => \$::ALLSW,
-                'c|cmdlineonly'    => \$::CMDLINE,
-                'd=s'              => \$::ALTSRC,
-                'h|help'           => \$::HELP,
-                'v|version'        => \$::VERSION,
-                'V|verbose'        => \$::VERBOSE,
-                'F|sync'           => \$::FILESYNC,
-                'g|genmypost'      => \$::GENMYPOST,
-                'f|snsync'         => \$::SNFILESYNC,
-                'l|user:s'         => \$::USER,
-                'S|sw'             => \$::SWMAINTENANCE,
-                's|sn'             => \$::SETSERVER,
-                'P|scripts:s'      => \$::RERUNPS,
-                'k|security'       => \$::SECURITY,
-                'o|os:s'      	   => \$::OS,
-                'fanout=i'         => \$::fanout,
-                't|timetout=i'     => \$::timeout,
-                'n|noverify'       => \$::NOVERIFY,
+                'A|updateallsw'    => \$ALLSW,
+                'c|cmdlineonly'    => \$CMDLINE,
+                'd=s'              => \$ALTSRC,
+                'h|help'           => \$HELP,
+                'v|version'        => \$VERSION,
+                'V|verbose'        => \$VERBOSE,
+                'F|sync'           => \$FILESYNC,
+                'g|genmypost'      => \$GENMYPOST,
+                'f|snsync'         => \$SNFILESYNC,
+                'l|user=s'         => \$USER,
+                'S|sw'             => \$SWMAINTENANCE,
+                's|sn'             => \$SETSERVER,
+                'P|scripts:s'      => \$RERUNPS,
+                'k|security'       => \$SECURITY,
+                'o|os=s'      	   => \$OS,
+                'fanout=i'         => \$fanout,
+                't|timetout=i'     => \$timeout,
+                'n|noverify'       => \$NOVERIFY,
     )
   ) {
     &updatenode_usage();
     exit 1;
 }
 
-if ($::HELP)
+if ($HELP)
 {
-  &updatenode_usage();
-  exit 0;
+    &updatenode_usage();
+    exit 0;
 }
-if (($::USER) && ($::SECURITY))
+if (($USER) && ($SECURITY))
 {
-     my $msg = "-l option is not allowed with -k option.";
-     xCAT::MsgUtils->message("E", $msg);
-     exit 1;
+    my $msg = "-l option is not allowed with -k option.";
+    xCAT::MsgUtils->message("E", $msg);
+    exit 1;
 }
-if (($::USER) && ($::SNFILESYNC))
+if (($USER) && ($SNFILESYNC))
 {
-     my $msg = "-l option is not allowed with -f options.";
-     xCAT::MsgUtils->message("E", $msg);
-     exit 1;
+    my $msg = "-l option is not allowed with -f options.";
+    xCAT::MsgUtils->message("E", $msg);
+    exit 1;
 }
 
 # display the version statement if -v or --verison is specified
-if ($::VERSION)
+if ($VERSION)
 {
-  my $version = xCAT::Utils->Version();
-  print "$version\n";
-  exit 0;
+    my $version = xCAT::Utils->Version();
+    print "$version\n";
+    exit 0;
 }
-if (($::FILESYNC) && ($::SNFILESYNC)){  # only one
-     my $msg = "Choose either -f to sync the service nodes, or -F  to sync the nodes not both.";
-     xCAT::MsgUtils->message("E", $msg);
-     exit 1;
+if (($FILESYNC) && ($SNFILESYNC)){  # only one
+    my $msg = "Choose either -f to sync the service nodes, or -F  to sync the nodes not both.";
+    xCAT::MsgUtils->message("E", $msg);
+    exit 1;
 } 
+if (($SECURITY) && (($SWMAINTENANCE) || defined($RERUNPS) || ($FILESYNC) || ($SNFILESYNC))){
+    my $msg = "If you use the -k flag, you cannot specify the -S,-P,-f or -F flags.";
+    xCAT::MsgUtils->message("E", $msg);
+    exit 1;
+}
 
 # determine who is running the command on the client and who we will run as 
 # on the node
 my $current_userid = getpwuid($>);
 $ENV{DSH_FROM_USERID} = $current_userid;
 my $to_userid;
-if ($::USER)   # entered -l
+if ($USER)   # entered -l
 {
-    $to_userid = $::USER;
+    $to_userid = $USER;
 }
 else
 {
@@ -152,7 +158,7 @@ else
 $ENV{DSH_TO_USERID} = $to_userid;
 
 # if -k then we have to get the password
-if ($::SECURITY) {
+if ($SECURITY) {
     my $msg;
     if (!($ENV{'DSH_REMOTE_PASSWORD'}))
     {                         # if not already set

--- a/xCAT-server/lib/xcat/plugins/updatenode.pm
+++ b/xCAT-server/lib/xcat/plugins/updatenode.pm
@@ -222,13 +222,13 @@ sub preprocess_updatenode
                     'V|verbose'     => \$VERBOSE,
                     'F|sync'        => \$FILESYNC,
                     'g|genmypost'   => \$GENMYPOST,
-                    'l|user:s'      => \$USER,
+                    'l|user=s'      => \$USER,
                     'f|snsync'      => \$SNFILESYNC,
                     'S|sw'          => \$SWMAINTENANCE,
                     's|sn'          => \$SETSERVER,
                     'P|scripts:s'   => \$RERUNPS,
                     'k|security'    => \$SECURITY,
-                    'o|os:s'        => \$OS,
+                    'o|os=s'        => \$OS,
                     'fanout=i'      => \$fanout,
                     't|timetout=i'  => \$timeout,
                     'n|noverify'    => \$NOVERIFY, 
@@ -1102,13 +1102,13 @@ sub updatenode
                     'v|version'     => \$VERSION,
                     'V|verbose'     => \$VERBOSE,
                     'F|sync'        => \$FILESYNC,
-                    'l|user:s'      => \$USER,
+                    'l|user=s'      => \$USER,
                     'f|snsync'      => \$SNFILESYNC,
                     'S|sw'          => \$SWMAINTENANCE,
                     's|sn'          => \$SETSERVER,
                     'P|scripts:s'   => \$RERUNPS,
                     'k|security'    => \$SECURITY,
-                    'o|os:s'        => \$OS,
+                    'o|os=s'        => \$OS,
                     'fanout=i'      => \$fanout,
                     't|timetout=i'  => \$timeout,
                     'n|noverify'    => \$NOVERIFY,
@@ -3258,9 +3258,8 @@ sub updateOS
     {
 
         my $verifyOS = $os;
-        $verifyOS =~ s/[^0-9]*([0-9]+).*/$1/;
-        if ($verifyOS < '7')
-        {
+        $verifyOS =~ s/^\D+([\d.]+)$/$1/; 
+        if(xCAT::Utils->version_cmp($verifyOS,"7.0") < 0){
             $path = "http://$http$installDIR/$os/$arch/Server/";
             if (!(-e "$installDIR/$os/$arch/Server/"))
             {
@@ -3269,8 +3268,7 @@ sub updateOS
                 xCAT::MsgUtils->message("I", $rsp, $callback);
                 return;
             }
-        }
-		
+        }	
         else
         {
             $path = "http://$http$installDIR/$os/$arch/";


### PR DESCRIPTION
There should be message pops up directly to remainder: If you use the -k flag, you cannot specify the -S,-P,-f or -F flags. Don't need to input password. 