### PR TITLE
[xCAT-client]Improvements to `bin/xdshbak`

### DIFF
--- a/xCAT-client/bin/xdshbak
+++ b/xCAT-client/bin/xdshbak
@@ -10,6 +10,9 @@ use xCAT::MsgUtils;
 use xCAT::DSHCLI;
 use locale;
 use Getopt::Std;
+
+eval "use Sort::Versions qw/versioncmp/; 1;" or  *versioncmp = sub ($$) { ($a,$b)= @_ ; return $a cmp $b };
+
 #####################################################################
 #                                                                   #
 # Module: xdshbak                                                   #
@@ -231,7 +234,7 @@ sub print_list
 
     local (@lines, $numhosts, $hn_string, $l_string);
 
-    foreach $hostname (sort @hs)
+    foreach $hostname (sort { versioncmp($a, $b) } @hs)
     {
         if (!$::opt_x) { ($num_hosts >= 1) && print "\n"; }
         $num_hosts++;
@@ -295,7 +298,7 @@ sub print_tree
         ($num_hosts >= 1) && print "\n";
         $num_hosts++;
         @wc = split(/:/, $hdr{$index});
-        @wc = sort(@wc);
+        @wc = sort { versioncmp($a, $b) } @wc;
 
         #system "$SPMSG DSH $MSGCAT  INFO511 'HOSTS '";
         xCAT::MsgUtils->message("I",

--- a/xCAT-client/bin/xdshbak
+++ b/xCAT-client/bin/xdshbak
@@ -236,9 +236,9 @@ sub print_list
         if (!$::opt_x) { ($num_hosts >= 1) && print "\n"; }
         $num_hosts++;
 
-        if ($::opt_x) { print "$hostname: $ls{$hostname}"; }
-        else
-        {
+        if ($::opt_x) {
+            map { print "$hostname: $_\n" } split(/\n/, $ls{$hostname});
+        } else {
 
             #$hn_string = `$SPMSG DSH $MSGCAT  INFO510 'HOST: %1\$s\n' $hostname`;
             xCAT::MsgUtils->message("I", "HOST:$hostname\n");

--- a/xCAT-client/bin/xdshbak
+++ b/xCAT-client/bin/xdshbak
@@ -241,7 +241,7 @@ sub print_list
         } else {
 
             #$hn_string = `$SPMSG DSH $MSGCAT  INFO510 'HOST: %1\$s\n' $hostname`;
-            xCAT::MsgUtils->message("I", "HOST:$hostname\n");
+            xCAT::MsgUtils->message("I", "HOST:$hostname");
 
             printf '%.' . (6 + length($hostname)) . "s\n",
               '---------------------------------------------------------------';
@@ -298,10 +298,9 @@ sub print_tree
         @wc = sort(@wc);
 
         #system "$SPMSG DSH $MSGCAT  INFO511 'HOSTS '";
-        xCAT::MsgUtils->message("I", "HOSTS:");
-
-        print
-          "-------------------------------------------------------------------------\n";
+        xCAT::MsgUtils->message("I",
+          "HOSTS -------------------------------------------------------------------------"
+        );
         &display_wc;
         print
           "-------------------------------------------------------------------------------\n";

--- a/xCAT-client/bin/xdshbak
+++ b/xCAT-client/bin/xdshbak
@@ -24,6 +24,7 @@ eval "use Sort::Versions qw/versioncmp/; 1;" or  *versioncmp = sub ($$) { ($a,$b
 #              output from multiple nodes preceded by the hostname  #
 #                                                                   #
 # Inputs:                                                           #
+#  -b : bare output, don't prepend hostname per line. only with -x  #
 #  -c : list distinct output only once                              #
 #  -h : usage                                                       #
 #  -x : omit extra header output for each node.                     #
@@ -53,7 +54,7 @@ $::dsh_command = 'xdshbak';
 #
 # Process the command line...
 #
-if (!getopts('cxhq'))
+if (!getopts('bcxhq'))
 {    # Gather options; if errors
     &d_syntax;
     exit(-1);
@@ -70,6 +71,11 @@ if ($::opt_c && $::opt_x)
     &d_syntax;
     exit(-1);
 }    # these 2 options are mutually exclusive
+
+if ($::opt_b && !($::opt_x)) {
+    &d_syntax;
+    exit(-1);
+}    # -b only makes sense with -x
 
 if ($::opt_c)
 {
@@ -201,14 +207,15 @@ else
 
 sub d_syntax
 {
-    my $usage1 = "Usage: xdshbak   [-c | -x | -h | -q] \n";
-    my $usage2 =
-      "-c : compresses the output by listing unique output only once.\n";
-    my $usage3 = "-h : help  \n";
-    my $usage4 =
-      "-x : omit extra header output for each node.  Can not be used with -c. \n";
-    my $usage5 = "-q : quiet mode.\n";
-    my $usage = $usage1 .= $usage2 .= $usage3 .= $usage4 .= $usage5;
+    # Duplicates POD - pod2usage ?
+    my @usage;
+    push @usage, "Usage: xdshbak   [-c | -x [-b] | -h | -q]";
+    push @usage, "    -b : bare output, don't prepend hostname per line. only with -x";
+    push @usage, "    -c : compresses the output by listing unique output only once.";
+    push @usage, "    -h : help";
+    push @usage, "    -x : omit extra header output for each node.  Can not be used with -c.";
+    push @usage, "    -q : quiet mode.";
+    my $usage = join "\n", @usage;
     xCAT::MsgUtils->message("I", $usage);
 
 }
@@ -240,7 +247,13 @@ sub print_list
         $num_hosts++;
 
         if ($::opt_x) {
-            map { print "$hostname: $_\n" } split(/\n/, $ls{$hostname});
+            if ($::opt_b) {
+                # Bare output
+                print $ls{$hostname};
+            } else {
+                # No header. hostname prepended on every line
+                map { print "$hostname: $_\n" } split(/\n/, $ls{$hostname});
+            }
         } else {
 
             #$hn_string = `$SPMSG DSH $MSGCAT  INFO510 'HOST: %1\$s\n' $hostname`;

--- a/xCAT-client/bin/xdshbak
+++ b/xCAT-client/bin/xdshbak
@@ -169,7 +169,7 @@ while (<STDIN>)
 # The hostnames are sorted alphabetically
 #
 
-$num_lines > 999 && print STDOUT "\n";
+!($quiet) && $num_lines > 999 && print STDOUT "\n";
 if ($compress)
 {
     if ($long_ln eq $prev_ln)

--- a/xCAT-client/bin/xdshbak
+++ b/xCAT-client/bin/xdshbak
@@ -110,8 +110,7 @@ while (<STDIN>)
     #
     $num_lines++;
     if (!($quiet)) {
-      if ($::opt_x) { $num_lines % 100 == 0 && print STDOUT "."; }
-      else { $num_lines % 1000 == 0 && print STDOUT "."; }
+        $num_lines % 1000 == 0 && print STDOUT ".";
     }
     if (/: /)
     {

--- a/xCAT-client/debian/control
+++ b/xCAT-client/debian/control
@@ -7,6 +7,6 @@ Standards-Version: 3.7.2
 
 Package: xcat-client
 Architecture: all
-Depends: ${perl:Depends}, nmap, perl-xCAT
+Depends: ${perl:Depends}, nmap, perl-xCAT, libsort-versions-perl
 Description: Core executables and data of the xCAT management project
  xCAT-client provides the fundamental xCAT commands (chtab, chnode, rpower, etc) helpful in administrating systems at scale, with particular attention paid to large HPC clusters.

--- a/xCAT-client/pods/man1/xdshbak.1.pod
+++ b/xCAT-client/pods/man1/xdshbak.1.pod
@@ -4,7 +4,7 @@ B<xdshbak> - Formats the output of the B<xdsh> command.
 
 =head1 B<SYNOPSIS>
 
-B<xdshbak> [B<-c> | B<-x> | B<-h> | B<-q>]
+B<xdshbak> [B<-c> | B<-x> [ B<-b> ] | B<-h> | B<-q>]
 
 =head1 DESCRIPTION
 
@@ -62,6 +62,9 @@ the output by hostname for easier viewing:
  .
  .
 
+If the B<-b> flag is specified in addition to B<-x>, the hostname at the beginning
+of each line is stripped.
+
 =head2 Standard Error
 
 When the B<xdshbak> filter is used and standard error messages are generated,
@@ -71,6 +74,11 @@ output messages. This is true with and without the B<-c> flag.
 =head1 OPTIONS
 
 =over 6
+
+=item B<-b>
+
+Strip the host prefix from the beginning of the lines. This only
+works with the B<-x> option.
 
 =item B<-c>
 

--- a/xCAT-client/xCAT-client.spec
+++ b/xCAT-client/xCAT-client.spec
@@ -27,7 +27,7 @@ Requires: perl-xCAT >= %{epoch}:%(cat Version)
 
 # fping or nmap is needed by pping (in case xCAT-client is installed by itself on a remote client)
 %ifos linux
-Requires: nmap perl-XML-Simple perl-XML-Parser
+Requires: nmap perl-XML-Simple perl-XML-Parser perl-Sort-Versions
 %else
 Requires: expat 
 %endif


### PR DESCRIPTION
*    Make xdshbak output match manpage description.
  * Current output:
     ```
[root@xcatmn1 ~]# for op in '-x' '-x -q' '-c' '-c -q' '' '-q'; do 
>     echo "==== xdshbak $op ===" 
>     (  /bin/yes |head -n 1001 |sed 's#^#node1: #'; \
>        /bin/yes |head -n 1001 |sed 's#^#node2: #'  ) | xdshbak $op | head -n 5
> done
==== xdshbak -x ===
....................
node1: y
y
y
y
==== xdshbak -x -q ===

node1: y
y
y
y
==== xdshbak -c ===
..
HOSTS:
-------------------------------------------------------------------------
node1, node2
-------------------------------------------------------------------------------
==== xdshbak -c -q ===

HOSTS:
-------------------------------------------------------------------------
node1, node2
-------------------------------------------------------------------------------
==== xdshbak  ===
..
HOST:node1

-----------
y
==== xdshbak -q ===

HOST:node1

-----------
y
```
  * Manpage described output:

     ```
[root@xcatmn1 ~]# for op in '-x' '-x -q' '-c' '-c -q' '' '-q'; do 
>     echo "==== xdshbak $op ===" 
>     (  /bin/yes |head -n 1001 |sed 's#^#node1: #'; \
>        /bin/yes |head -n 1001 |sed 's#^#node2: #'  ) | xdshbak $op | head -n 5
> done
==== xdshbak -x ===
..
node1: y
node1: y
node1: y
node1: y
==== xdshbak -x -q ===
node1: y
node1: y
node1: y
node1: y
node1: y
==== xdshbak -c ===
..
HOSTS -------------------------------------------------------------------------
node1, node2
-------------------------------------------------------------------------------
y
==== xdshbak -c -q ===
HOSTS -------------------------------------------------------------------------
node1, node2
-------------------------------------------------------------------------------
y
y
==== xdshbak  ===
..
HOST:node1
-----------
y
y
==== xdshbak -q ===
HOST:node1
-----------
y
y
y
```
* Add `-b` option to strip leading hostnames in conjunction with `-x` option (the utility is that I generate a script snippet on each node and combine the generated snippets into a single script on the management node):
```
[root@xcatmn1 ~]# echo spare{1..5}| sed "s# #\\n#g"| sed "s#\$#: executable_line#" \
>     | xdshbak -x
spare1: executable_line
spare2: executable_line
spare3: executable_line
spare4: executable_line
spare5: executable_line
[root@xcatmn1 ~]# echo spare{1..5}| sed "s# #\\n#g"| sed "s#\$#: executable_line#" \
>     | xdshbak -x -b
executable_line
executable_line
executable_line
executable_line
executable_line
```
*   Sort the hostnames using `version` sort instead of string value sort:
  * String value sort:

     ```
[root@inframgtlivexcatmn1.hkdc ~]# echo spare{1..5} spare{10..50..10} \
>     | sed "s# #\\n#g"| sed "s#\$#: $(date)#" |xdshbak -x 
spare1: Thu Nov  5 11:47:31 UTC 2015
spare10: Thu Nov  5 11:47:31 UTC 2015
spare2: Thu Nov  5 11:47:31 UTC 2015
spare20: Thu Nov  5 11:47:31 UTC 2015
spare3: Thu Nov  5 11:47:31 UTC 2015
spare30: Thu Nov  5 11:47:31 UTC 2015
spare4: Thu Nov  5 11:47:31 UTC 2015
spare40: Thu Nov  5 11:47:31 UTC 2015
spare5: Thu Nov  5 11:47:31 UTC 2015
spare50: Thu Nov  5 11:47:31 UTC 2015
```
  * `version` sort:

     ```
[root@xcatmn1 ~]# echo spare{1..5} spare{10..50..10}| sed "s# #\\n#g" \
>     | sed "s#\$#: $(date)#" |xdshbak -x
spare1: Thu Nov  5 06:43:32 EST 2015
spare2: Thu Nov  5 06:43:32 EST 2015
spare3: Thu Nov  5 06:43:32 EST 2015
spare4: Thu Nov  5 06:43:32 EST 2015
spare5: Thu Nov  5 06:43:32 EST 2015
spare10: Thu Nov  5 06:43:32 EST 2015
spare20: Thu Nov  5 06:43:32 EST 2015
spare30: Thu Nov  5 06:43:32 EST 2015
spare40: Thu Nov  5 06:43:32 EST 2015
spare50: Thu Nov  5 06:43:32 EST 2015
```
  * The `version` sort uses the perl package `perl-Sort-Versions` from `[epel]` on RH/Centos {5,6} systems and from `[base]` in RH/Centos 7.
  * The same package is provided by the package `libsort-versions-perl` on Debian/Ubuntu as part of `optional`/`universe` groups.