### PR TITLE
to fix Issue 302, modified my_ip_facing and related functions

### DIFF
--- a/perl-xCAT/xCAT/InstUtils.pm
+++ b/perl-xCAT/xCAT/InstUtils.pm
@@ -758,7 +758,8 @@ sub get_server_nodes
         else
         {
             #  get ip facing node
-			$serv = xCAT::NetworkUtils->my_ip_facing($node);
+            my @servd= xCAT::NetworkUtils->my_ip_facing($node);
+            unless (@servd[0]) { $serv = $servd[1];}
         }
 		chomp $serv;
 

--- a/perl-xCAT/xCAT/NetworkUtils.pm
+++ b/perl-xCAT/xCAT/NetworkUtils.pm
@@ -1088,17 +1088,23 @@ sub my_if_netmap
 #-------------------------------------------------------------------------------
 
 =head3   my_ip_facing
-         Returns my ip address  
+         Returns my ip address in the same network with the specified node
          Linux only
     Arguments:
         nodename 
     Returns:
+	result and error message or my ip address
+	1. If node can not be resolved, the return info will be like this:
+	[1, "The $node can not be resolved"].
+	2. If no IP found that matching the giving node, the return info will be:
+	[2, "No found matching IP for $node"].
+	3. If IP found:
+	[0,ip1,ip2,...] 
     Globals:
         none
     Error:
         none
     Example:
-        my $ip = xCAT::NetworkUtils->my_ip_facing($peerip)
         my @ip = xCAT::NetworkUtils->my_ip_facing($peerip)  # return multiple
     Comments:
         none
@@ -1112,10 +1118,15 @@ sub my_ip_facing
     {
         $peer = shift;
     }
+    
     return my_ip_facing_aix( $peer) if ( $^O eq 'aix');
+    my @rst;
     my $peernumber = inet_aton($peer); #TODO: IPv6 support
-    unless ($peernumber) { return undef; }
-    my $noden = unpack("N", inet_aton($peer));
+    unless ($peernumber) { 
+        $rst[0] = 1;
+        $rst[1] = "The $peer can not be resolved";
+        return @rst; }
+    my $noden = unpack("N", $peernumber);
     my @nets = split /\n/, `/sbin/ip addr`;
 
     my @ips;
@@ -1126,7 +1137,7 @@ sub my_ip_facing
         {
             next;
         }
-        (my $curnet, my $maskbits) = split /\//, $elems[2];
+        (my $curnet, my $maskbits) = split /\//, $elems[2];  
         my $curmask = 2**$maskbits - 1 << (32 - $maskbits);
         my $curn = unpack("N", inet_aton($curnet));
         if (($noden & $curmask) == ($curn & $curmask))
@@ -1136,14 +1147,13 @@ sub my_ip_facing
     }
 
     if (@ips) {
-        if (wantarray) {
-            return @ips;
-        } else {
-            return $ips[0];
-        }
+        $rst[0] = 0;
+        push @rst, @ips;
     } else {
-        return undef;
+        $rst[0] = 2;
+        $rst[1] = "No found matching IP for $peer";
     }
+    return @rst;
 }
 
 #-------------------------------------------------------------------------------
@@ -1169,6 +1179,8 @@ sub my_ip_facing_aix
     my $peer = shift;
     my @nets = `ifconfig -a`;
     chomp @nets;
+    my @ips;
+    my @rst;
     foreach my $net (@nets)
     {
         my ($curnet,$netmask);
@@ -1186,10 +1198,20 @@ sub my_ip_facing_aix
         }
         if (isInSameSubnet($peer, $curnet, $netmask, 2))
         {
-            return $curnet;
+            push @ips, $curnet;
         }
     }
-    return undef;
+    if (@ips)
+    {
+        $rst[0] = 0;
+        push @rst, @ips;
+    }
+    else 
+    {
+        $rst[0] = 2;
+        $rst[1] = "No found matching IP for $peer";
+    }
+    return @rst;
 }
 
 #-------------------------------------------------------------------------------

--- a/xCAT-server/lib/perl/xCAT/Postage.pm
+++ b/xCAT-server/lib/perl/xCAT/Postage.pm
@@ -1429,12 +1429,10 @@ sub  collect_all_attribs_for_tables_in_template
                                      ( ! exists($::GLOBAL_TAB_HASH{noderes}{$node}{xcatmaster}) ||
                                        $::GLOBAL_TAB_HASH{noderes}{$node}{xcatmaster} eq ""        ) )
                                   {
-                                      my $value;
-                                      $value = xCAT::NetworkUtils->my_ip_facing($node);
-                                      if ($value eq "0")
-                                      {
-                                         undef($value);
-                                      }
+                                      my $value = undef;
+                                      my @valued = xCAT::NetworkUtils->my_ip_facing($node);
+                                      unless ($valued[0]) { $value = $valued[1];}
+
                                       $::GLOBAL_TAB_HASH{$tabname}{$node}{$attrib} = $value;
                                   }
 

--- a/xCAT-server/lib/perl/xCAT/Template.pm
+++ b/xCAT-server/lib/perl/xCAT/Template.pm
@@ -83,7 +83,9 @@ sub subvars {
   if ( defined($tmp) ) {
       $master = $tmp;
   }
-  my $ipfn = xCAT::NetworkUtils->my_ip_facing($node);
+  my $ipfn; 
+  my @ipfnd = xCAT::NetworkUtils->my_ip_facing($node);
+  unless ($ipfnd[0]) { $ipfn = $ipfnd[1];}
   if ($ipfn) {
       $master = $ipfn;
   }
@@ -604,7 +606,8 @@ sub windows_net_cfg {
                             }
                             if ($gw) { $gateway = $gw; }
                             if ($gateway eq '<xcatmaster>') {
-                                $gateway = xCAT::NetworkUtils->my_ip_facing($ip);
+                                my @gatewayd = xCAT::NetworkUtils->my_ip_facing($ip);
+                                unless ($gatewayd[0]) { $gateway = $gatewayd[1];}
                             }
                             $interface_cfg .= '<IpAddress wcm:action="add" wcm:keyValue="'.$num++.'">'.$ip."/$netmask".'</IpAddress>';
                         }
@@ -939,7 +942,9 @@ sub kickstartnetwork {
                 unless($ipaddr) { die "cannot resolve the network configuration of $node"; }
             
                 if($gateway eq '<xcatmaster>'){
-                   $gateway = xCAT::NetworkUtils->my_ip_facing($ipaddr);
+		   
+                   my @gatewayd = xCAT::NetworkUtils->my_ip_facing($ipaddr);
+                   unless ($gatewayd[0]) { $gateway = $gatewayd[1];}
                 }
 
                 $line .="static  --device=$suffix --ip=$ipaddr --netmask=$netmask --gateway=$gateway --hostname=$hostname ";
@@ -951,7 +956,8 @@ sub kickstartnetwork {
                 {
                    my $ip;
                    if($_ eq '<xcatmaster>'){
-                      $ip = xCAT::NetworkUtils->my_ip_facing($gateway);
+                      my @ipd = xCAT::NetworkUtils->my_ip_facing($gateway);
+                      unless ($ipd[0]) { $ip = $ipd[1];}
                    }else{
                       (undef,$ip) = xCAT::NetworkUtils->gethostnameandip($_);
                    }
@@ -1051,7 +1057,8 @@ sub yast2network {
                 unless($ipaddr) { die "cannot resolve the network configuration of $node"; }
 
                 if($gateway eq '<xcatmaster>'){
-                   $gateway = xCAT::NetworkUtils->my_ip_facing($ipaddr);
+                   my @gatewayd = xCAT::NetworkUtils->my_ip_facing($ipaddr);
+                   unless ($gatewayd[0]) { $gateway = $gatewayd[1];}
                 }
 
                 my %nameservers=%{xCAT::NetworkUtils->getNodeNameservers([$node])};
@@ -1063,7 +1070,8 @@ sub yast2network {
                 {
                    my $ip;
                    if($_ eq '<xcatmaster>'){
-                      $ip = xCAT::NetworkUtils->my_ip_facing($gateway);
+                      my @ipd = xCAT::NetworkUtils->my_ip_facing($gateway);
+                      unless ($ipd[0]) {$ip = $ipd[1];}
                    }else{
                       (undef,$ip) = xCAT::NetworkUtils->gethostnameandip($_);
                    }
@@ -1560,7 +1568,9 @@ sub tabdb
     unless($ent and  defined($ent->{$field})) {
       unless ($blankok) {
          if ($field eq "xcatmaster") {
-           my $ipfn = xCAT::NetworkUtils->my_ip_facing($node);
+           my $ipfn;
+           my @ipfnd = xCAT::NetworkUtils->my_ip_facing($node);
+           unless ($ipfnd[0]) { $ipfn = $ipfnd[1];}
            if ($ipfn) {
              return $ipfn;
            }

--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -1478,7 +1478,8 @@ sub mkinstall
                }         
 
                if($gateway eq '<xcatmaster>'){
-                      $gateway = xCAT::NetworkUtils->my_ip_facing($ipaddr);
+                      my @gatewayd = xCAT::NetworkUtils->my_ip_facing($ipaddr);
+                      unless ($gatewayd[0]) { $gateway = $gatewayd[1];}
                }
                
                if(xCAT::Utils->version_cmp($kversion,"7.0")<0){
@@ -1503,7 +1504,8 @@ sub mkinstall
                 {
                    my $ip;
                    if($_ eq '<xcatmaster>'){
-                      $ip = xCAT::NetworkUtils->my_ip_facing($gateway);
+                      my @ipd = xCAT::NetworkUtils->my_ip_facing($gateway);
+                      unless ($ipd[0]) { $ip = $ipd[1];}
                    }else{
                       (undef,$ip) = xCAT::NetworkUtils->gethostnameandip($_);
                    }

--- a/xCAT-server/lib/xcat/plugins/bmcconfig.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcconfig.pm
@@ -50,7 +50,8 @@ sub net_parms {
     $net =~ /([0-9]+)\.([0-9]+)\.([0-9]+)\.([0-9]+)/ or next; #next if ipv6, TODO: IPv6 support
     my $netnum = ($1<<24)+($2<<16)+($3<<8)+$4;
     if ($gw eq '<xcatmaster>') {
-	$gw=xCAT::NetworkUtils->my_ip_facing($ip);
+	my @gwd=xCAT::NetworkUtils->my_ip_facing($ip);
+	unless ($gwd[0]) { $gw = $gwd[1];}
     }
     if (($ipnum & $masknum)==$netnum) {
       return ($ip,$mask,$gw);

--- a/xCAT-server/lib/xcat/plugins/configfpc.pm
+++ b/xCAT-server/lib/xcat/plugins/configfpc.pm
@@ -354,7 +354,8 @@ sub get_network_parms {
 		$net =~ /([0-9]+)\.([0-9]+)\.([0-9]+)\.([0-9]+)/ or next; #next if ipv6, TODO: IPv6 support
 		my $netnum = ($1<<24)+($2<<16)+($3<<8)+$4;
 		if ($gw eq '<xcatmaster>') {
-		$gw=xCAT::NetworkUtils->my_ip_facing($ip);
+                    my @gwd=xCAT::NetworkUtils->my_ip_facing($ip);
+                    unless ($gwd[0]) { $gw = $gwd[1];}
 		}
 		if (($ipnum & $masknum)==$netnum) {
 			$netmask = $mask;

--- a/xCAT-server/lib/xcat/plugins/ddns.pm
+++ b/xCAT-server/lib/xcat/plugins/ddns.pm
@@ -355,7 +355,10 @@ sub process_request {
         if ($net and $net->{nameservers})
         {
             my $valid = 0;
-            my @myips = xCAT::NetworkUtils->my_ip_facing($net->{net});
+            my @myips;
+            my @myipsd = xCAT::NetworkUtils->my_ip_facing($net->{net});
+            my $myipsd_l = @myipsd;
+            unless ($myipsd[0]) { @myips = @myipsd[1..($myipsd_l-1)];}
             foreach (split /,/, $net->{nameservers})
             {
                 chomp $_;

--- a/xCAT-server/lib/xcat/plugins/destiny.pm
+++ b/xCAT-server/lib/xcat/plugins/destiny.pm
@@ -776,7 +776,8 @@ sub getdestiny {
     } elsif (defined( $master_value )) {
         $response{imgserver}=$master_value;
     } else {
-       $response{imgserver} = xCAT::NetworkUtils->my_ip_facing($node);
+        my @resd = xCAT::NetworkUtils->my_ip_facing($node);
+        unless ($resd[0]) { $response{imgserver} = $resd[1];}
     }
     
     #collect node status for certain states

--- a/xCAT-server/lib/xcat/plugins/dhcp.pm
+++ b/xCAT-server/lib/xcat/plugins/dhcp.pm
@@ -509,21 +509,23 @@ sub addnode
                     $node_server = $nrent->{servicenode};
                 }
                 unless($node_server) {
-                    $nxtsrv = xCAT::NetworkUtils->my_ip_facing($node);
-                    unless($nxtsrv) {
-                        $callback->({ error => ["Unable to determine the tftpserver for node"], errorcode => [1]});
+                    my @nxtsrvd = xCAT::NetworkUtils->my_ip_facing($node);
+                    unless ($nxtsrvd[0]) { $nxtsrv = $nxtsrvd[1];}
+                    elsif ($nxtsrvd[0] eq 1) {$callback->({ error=> [$nxtsrvd[1]]});}
+                    else {
+                        $callback->({ error => ["Unable to determine the tftpserver for $node"], errorcode => [1]});
                         return;
                     }
                 } else {
                     my $tmp_server = inet_aton($node_server);
                     unless($tmp_server) {
-                        $callback->({ error => ["Unable to resolve the tftpserver for node"], errorcode => [1]});
+                        $callback->({ error => ["Unable to resolve the tftpserver for $node"], errorcode => [1]});
                         return;
                     }
                     $nxtsrv = inet_ntoa($tmp_server);
                 }
                 unless ($nxtsrv) {
-                    $callback->({ error => ["Unable to determine the tftpserver for node"], errorcode => [1]});
+                    $callback->({ error => ["Unable to determine the tftpserver for $node"], errorcode => [1]});
                     return;
                 }
                 $guess_next_server = 0;
@@ -771,8 +773,9 @@ sub addrangedetection {
     my $begin;
     my $end;
     my $myip;
-    $myip = xCAT::NetworkUtils->my_ip_facing($net->{net});
-    
+    my @myipd = xCAT::NetworkUtils->my_ip_facing($net->{net});
+    unless ($myipd[0]) { $myip = $myipd[1];}
+
     # convert <xcatmaster> to nameserver IP
     if ($net->{nameservers} eq '<xcatmaster>')
     {
@@ -2283,7 +2286,8 @@ sub addnet
         my $tftp;
         my $range;
         my $myip;
-        $myip = xCAT::NetworkUtils->my_ip_facing($net);
+        my @myipd = xCAT::NetworkUtils->my_ip_facing($net);
+        unless ($myipd[0]) {$myip = $myipd[1];}
         if ($nettab)
         {
             my $mask_formated = $mask;

--- a/xCAT-server/lib/xcat/plugins/grub2.pm
+++ b/xCAT-server/lib/xcat/plugins/grub2.pm
@@ -96,8 +96,18 @@ sub setstate {
     my $linuximghash = shift();
     my $kern = $bphash{$node}->[0]; #$bptab->getNodeAttribs($node,['kernel','initrd','kcmdline']);
     if ($kern->{kcmdline} =~ /!myipfn!/) {
-        my $ipfn = xCAT::NetworkUtils->my_ip_facing($node);
-        unless ($ipfn) {
+        my $ipfn;
+        my @ipfnd = xCAT::NetworkUtils->my_ip_facing($node);
+
+        if ($ipfnd[0] eq 1) {
+            $::callback->(
+            {
+                error => [$ipfnd[1]],
+                errorcode => [1]
+            });
+            return;
+        }
+        elsif ($ipfnd[0] eq 2) {
             my $servicenodes = $nrhash{$node}->[0];
             if ($servicenodes and $servicenodes->{servicenode}) {
                 my @sns = split /,/, $servicenodes->{servicenode};
@@ -129,6 +139,7 @@ sub setstate {
                 return;
             }
         } else {
+            $ipfn = $ipfnd[1];
             $kern->{kcmdline} =~ s/!myipfn!/$ipfn/g;
         }
     }

--- a/xCAT-server/lib/xcat/plugins/mic.pm
+++ b/xCAT-server/lib/xcat/plugins/mic.pm
@@ -623,7 +623,10 @@ sub rflash {
     # (otherwise, will need to move this call into loop above for each host
     #  and build separate miccfg calls for each unique returned value from
     #  my_ip_facing)
-    my $ipfn = xCAT::NetworkUtils->my_ip_facing(@hosts[0]);
+    
+    my $ipfn;
+    my @ipfnd = xCAT::NetworkUtils->my_ip_facing(@hosts[0]);
+    unless ($ipfnd[0]) { $ipfn = $ipfnd[1];}
     if ($ipfn) {
         $master = $ipfn;
     } else { 
@@ -945,7 +948,9 @@ sub nodeset {
     # (otherwise, will need to move this call into loop above for each host
     #  and build separate miccfg calls for each unique returned value from
     #  my_ip_facing)
-    my $ipfn = xCAT::NetworkUtils->my_ip_facing(@hosts[0]);
+    my $ipfn;
+    my @ipfnd = xCAT::NetworkUtils->my_ip_facing(@hosts[0]);
+    unless ($ipfnd[0]) { $ipfn = $ipfnd[1];}
     if ($ipfn) {
         $master = $ipfn;
     } else {

--- a/xCAT-server/lib/xcat/plugins/petitboot.pm
+++ b/xCAT-server/lib/xcat/plugins/petitboot.pm
@@ -99,8 +99,18 @@ sub setstate {
       $kern->{initrd} = "$httpmethod://$installsrv:$httpport$tftpdir/".$kern->{initrd};
   }
   if ($kern->{kcmdline} =~ /!myipfn!/ or $kern->{kernel} =~ /!myipfn!/) {
-      my $ipfn = xCAT::NetworkUtils->my_ip_facing($node);
-      unless ($ipfn) {
+      my $ipfn;
+      my @ipfnd = xCAT::NetworkUtils->my_ip_facing($node);
+
+      if ($ipfnd[0] eq 1) {
+          $::callback->(
+          {
+             error => [$ipfnd[1]],
+             errorcode => [1]
+          });
+          return;
+      }
+      elsif ($ipfnd[0] eq 2) {
           my $servicenodes = $nrhash{$node}->[0];
           if ($servicenodes and $servicenodes->{servicenode}) {
               my @sns = split /,/, $servicenodes->{servicenode};
@@ -132,6 +142,7 @@ sub setstate {
               return;
           }
       } else {
+          $ipfn = $ipfnd[1];
           $kern->{kernel} =~ s/!myipfn!/$ipfn/g;
           $kern->{initrd} =~ s/!myipfn!/$ipfn/g;
           $kern->{kcmdline} =~ s/!myipfn!/$ipfn/g;

--- a/xCAT-server/lib/xcat/plugins/pxe.pm
+++ b/xCAT-server/lib/xcat/plugins/pxe.pm
@@ -151,7 +151,9 @@ sub setstate {
 
   }
   if ($kern->{kcmdline} =~ /!myipfn!/) {
-      my $ipfn = xCAT::NetworkUtils->my_ip_facing($node);
+      my $ipfn;
+      my @ipfnd = xCAT::NetworkUtils->my_ip_facing($node);
+      unless ($ipfnd[0]) { $ipfn = $ipfnd[1];}
       unless ($ipfn) {
         my @myself = xCAT::NetworkUtils->determinehostname();
         my $myname = $myself[(scalar @myself)-1];

--- a/xCAT-server/lib/xcat/plugins/sles.pm
+++ b/xCAT-server/lib/xcat/plugins/sles.pm
@@ -1212,7 +1212,8 @@ sub mkinstall
                         );
                }
                if($gateway eq '<xcatmaster>'){
-                      $gateway = xCAT::NetworkUtils->my_ip_facing($ipaddr);
+                      my @gatewayd = xCAT::NetworkUtils->my_ip_facing($ipaddr);
+                      unless ($gatewayd[0]) { $gateway = $gatewayd[1];}
                }
                $kcmdline .=" hostip=$ipaddr netmask=$netmask gateway=$gateway  hostname=$hostname ";
 
@@ -1224,7 +1225,8 @@ sub mkinstall
                 {
                    my $ip;
                    if($_ eq '<xcatmaster>'){
-                      $ip = xCAT::NetworkUtils->my_ip_facing($gateway);
+                      my @ipd = xCAT::NetworkUtils->my_ip_facing($gateway);
+                      unless ($ipd[0]) { $ip = $ipd[1];}
                    }else{
                       (undef,$ip) = xCAT::NetworkUtils->gethostnameandip($_);
                    }

--- a/xCAT-server/lib/xcat/plugins/updatenode.pm
+++ b/xCAT-server/lib/xcat/plugins/updatenode.pm
@@ -3114,7 +3114,9 @@ sub updateOS
     my $installDIR = xCAT::TableUtils->getInstallDir();
 
     # Get HTTP server
-    my $http = xCAT::NetworkUtils->my_ip_facing($node);
+    my $http;
+    my @httpd = xCAT::NetworkUtils->my_ip_facing($node);
+    unless ($httpd[0]) { $http = $httpd[1];}
     if (!$http)
     {
         push @{$rsp->{data}}, "$node: (Error) Missing HTTP server";

--- a/xCAT-server/lib/xcat/plugins/vsmppxe.pm
+++ b/xCAT-server/lib/xcat/plugins/vsmppxe.pm
@@ -77,7 +77,9 @@ sub setstate {
         $kern->{kcmdline} .= " ".$kern->{addkcmdline};
   }
   if ($kern->{kcmdline} =~ /!myipfn!/) {
-      my $ipfn = xCAT::NetworkUtils->my_ip_facing($node);
+      my $ipfn; 
+      my @ipfnd = xCAT::NetworkUtils->my_ip_facing($node);
+      unless ($ipfnd[0]) {$ipfn = $ipfnd[1];}
       unless ($ipfn) {
         my @myself = xCAT::NetworkUtils->determinehostname();
         my $myname = $myself[(scalar @myself)-1];

--- a/xCAT-server/lib/xcat/plugins/xnba.pm
+++ b/xCAT-server/lib/xcat/plugins/xnba.pm
@@ -166,10 +166,12 @@ sub setstate {
       my $ipfn = '${next-server}';#xCAT::Utils->my_ip_facing($node);
       $kern->{kcmdline} =~ s/!myipfn!/$ipfn/g;
       $elilokcmdline =~ s/!myipfn!/%N/g;
-      $ipfn = xCAT::NetworkUtils->my_ip_facing($node);
+      my @ipfnd = xCAT::NetworkUtils->my_ip_facing($node);
+      unless ($ipfnd[0]) {$ipfn = $ipfnd[1];}
+      else { $ipfn = undef;}
       unless ($ipfn) { $ipfn = $::XCATSITEVALS{master}; }
       if ($ipfn) {
-      	$pxelinuxkcmdline =~ s/!myipfn!/$ipfn/g;
+        $pxelinuxkcmdline =~ s/!myipfn!/$ipfn/g;
       }
   }
   my $pcfg;

--- a/xCAT-server/lib/xcat/plugins/yaboot.pm
+++ b/xCAT-server/lib/xcat/plugins/yaboot.pm
@@ -91,8 +91,18 @@ sub setstate {
   my $linuximghash = shift();
   my $kern = $bphash{$node}->[0]; #$bptab->getNodeAttribs($node,['kernel','initrd','kcmdline']);
   if ($kern->{kcmdline} =~ /!myipfn!/) {
-      my $ipfn = xCAT::NetworkUtils->my_ip_facing($node);
-      unless ($ipfn) {
+      my $ipfn;
+      my @ipfnd = xCAT::NetworkUtils->my_ip_facing($node);
+      
+      if ($ipfnd[0] eq 1) { 
+          $::YABOOT_callback->(
+          {
+              error => [$ipfnd[1]],
+              errorcode => [1]
+          });
+	  return;
+      }
+      elsif ($ipfnd[0] eq 2) {
           my $servicenodes = $nrhash{$node}->[0];
           if ($servicenodes and $servicenodes->{servicenode}) {
               my @sns = split /,/, $servicenodes->{servicenode};
@@ -124,6 +134,7 @@ sub setstate {
               return;
           }
       } else {
+          $ipfn = $ipfnd[1];
           $kern->{kcmdline} =~ s/!myipfn!/$ipfn/g;
       }
   }


### PR DESCRIPTION
The return info for my_ip_facing is an array with the following information:
[<return_code>, <info0>,<info1>]
For example:  
1. If node can not be resolved, the return info will be like this:
[1, "The $node can not be resolved"].
2. If no IP found that matching the giving node, the return info will be:
[2, "No found matching IP for $node"].
3. If IP found:
[0, <ip1>, <ip2>...] 