### PR TITLE
Update discinfo.pm for support Rhelhpc6.7(for 2.9.1-pcm branch)

### DIFF
--- a/perl-xCAT/xCAT/data/discinfo.pm
+++ b/perl-xCAT/xCAT/data/discinfo.pm
@@ -84,6 +84,7 @@ require Exporter;
 		 "1359576195.413831" => "rhelhpc6.4",#x86_64, RHEL ComputeNode
 		 "1384196516.465862" => "rhelhpc6.5",#x86_64, RHEL ComputeNode
 		 "1411733344.599861" => "rhelhpc6.6",#x86_64, RHEL ComputeNode
+		 "1435823078.264564" => "rhelhpc6.7",#x86_64, RHEL ComputeNode
 		 "1399449226.140088" => "rhelhpc7.0",#x86_64, RHEL ComputeNode
                  "1194015916.783841" => "fedora8",
                  "1194015385.299901" => "fedora8",


### PR DESCRIPTION
Update discinfo.pm for support Rhelhpc6.7(RHEL ComputeNode).
Branch:
2.9.1-pcm
support case:
cross-os:Rhel6.7->Rhelhpc6.7