### PR TITLE
Fix bug#398 IB driver can not be installed via /opt/xcat/share/xcat/ib/scripts/Mellanox/mlnxofed_ib_install.v2 

### DIFF
--- a/xCAT-server/share/xcat/ib/scripts/Mellanox/mlnxofed_ib_install.v2
+++ b/xCAT-server/share/xcat/ib/scripts/Mellanox/mlnxofed_ib_install.v2
@@ -114,7 +114,7 @@ do
     shift
 done
 
-if [ ! -f "$OFED_PATH" ]; then
+if [ -z "$OFED_PATH" ]; then
     echo "[Error] Without Mellanox OFED file path, please assign correct path" >&2
     exit 1
 fi


### PR DESCRIPTION
When restructure code, made a mistake. fix it now