### PR TITLE
Fix bug #405 Miss 3 dependence package when install IB driver in rhel7.1+x86_64 environment 

### DIFF
--- a/xCAT-server/share/xcat/ib/netboot/rh/ib.rhels7.ppc64le.pkglist
+++ b/xCAT-server/share/xcat/ib/netboot/rh/ib.rhels7.ppc64le.pkglist
@@ -11,4 +11,7 @@ python-devel
 redhat-rpm-config
 rpm-build
 kernel-devel
+gtk2
+atk
+cairo
 


### PR DESCRIPTION
Add these **gtk2 atk cairo** 3 dependence package into ib.rhels7.ppc64le.pkglist