### PR TITLE
Fix defect of the rflash option to check

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -7625,10 +7625,6 @@ sub process_request {
                     return;
                 }
                 $args_hash{hpm} = $opt;
-            } else {
-                $callback->({error=>"Error command: Option $opt is not supported.",
-                             errorcode=>1});
-                return;
             }
         }
         if (exists($args_hash{hpm})){


### PR DESCRIPTION
rflash for ipmi also supports the fpc machines,
delete the check constraints for unknown options.