### PR TITLE
addkitcomp -n man page need to be updated for its extra fun…

### DIFF
--- a/xCAT-client/pods/man1/addkitcomp.1.pod
+++ b/xCAT-client/pods/man1/addkitcomp.1.pod
@@ -44,7 +44,9 @@ The osimage name that the kit component is assigning to.
 
 =item B<-n|--noupgrade>
 
-Allow multiple versions of kitcomponent to be installed into the osimage, instead of kitcomponent upgrade
+1. Allow multiple versions of kitcomponent to be installed into the osimage, instead of kitcomponent upgrade.
+
+2. Kit components added by addkitcomp -n will be installed separately behind all other ones which have been added.
 
 =item B<--noscripts>
 


### PR DESCRIPTION
Old man page only explain --noupgrage function, details : #418

Add another function explanation in man page for "-n | --noupgrage" as:
1.  Allow multiple versions of kitcomponent to be installed into the osimage, instead of kitcomponent upgrade
2. Allow these batch of kitcomponents to be installed separately, these kitcomponents will be installed behind those kitcomponents using addkitcomp without -n option
 