### PR TITLE
issue426 bmcdiscover return message need modified on ubuntu

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -905,9 +905,7 @@ sub bmcdiscovery_ipmi {
             xCAT::MsgUtils->message("I", {data=>["Warning: bmc username is incorrect for $node"]}, $::CALLBACK);
         } elsif ($output =~ /RAKP \S* \S* is invalid/) {
             xCAT::MsgUtils->message("I", {data=>["Warning: bmc password is incorrect for $node"]}, $::CALLBACK);
-        } else {
-            xCAT::MsgUtils->message("I", {data=>["Warning: other error for $node"]}, $::CALLBACK);
-        }
+        } 
        if ( defined($opz) || defined($opw) )
        {
           format_stanza($node, $ip);


### PR DESCRIPTION
Details refer to #426 .

bmcdiscover just checks if username or password is correct for bmc, and return bmcip or node definition. So there is a confused and useless warning message "Warning: other error for $node".
