### PR TITLE
Dirty hack, fix the permission of direcotry /var/log/xcat

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/post.ubuntu
+++ b/xCAT-server/share/xcat/install/scripts/post.ubuntu
@@ -153,6 +153,14 @@ return_value=0
 run_ps () {
  local ret_local=0
  mkdir -p "\"/var/log/xcat\""
+ # On Ubuntu, the rsyslogd daemon write log files with syslog:adm
+ # permissison. And in some case, the directory /var/log/xcat was
+ # created by xCAT, and had root:root ownership. In this way, rsyslogd
+ # did not have enough permission to write to log files under this
+ # directory.
+ # As a dirty hack, change the ownership of directory /var/log/xcat
+ # to the same ownership of directory /var/log.
+ chown `ls -ld /var/log | awk '{ print \$3\":\"\$4 }'` "\"/var/log/xcat\""
  local logfile=\"/var/log/xcat/xcat.log\"
 
  if [ -f \$1 ]; then 
@@ -300,4 +308,3 @@ cd /
 #rm -Rf /xcatpost
 #rm -f /tmp/mypostscript
 exit 0
-

--- a/xCAT-server/share/xcat/install/scripts/post.xcat
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat
@@ -138,6 +138,13 @@ return_value=0
 run_ps () {
  local ret_local=0
  mkdir -p "\"/var/log/xcat\""
+ # On some Linux distro, the rsyslogd daemon write log files with permision
+ # other than root:root. And in some case, the directory /var/log/xcat was
+ # created by xCAT, and had root:root ownership. In this way, rsyslogd
+ # did not have enough permission to write to log files under this directory.
+ # As a dirty hack, change the ownership of directory /var/log/xcat to the
+ # same ownership of directory /var/log.
+ chown `ls -ld /var/log | awk '{ print \$3\":\"\$4 }'` "\"/var/log/xcat\"" 
  local logfile=\"/var/log/xcat/xcat.log\"
 
  if [ -f \$1 ]; then 
@@ -274,5 +281,3 @@ updateflag.awk $MASTER 3002
 cd /
 #rm -Rf /xcatpost
 #rm -f /xcatpost/mypostscript
-
-

--- a/xCAT/debian/postinst
+++ b/xCAT/debian/postinst
@@ -20,12 +20,12 @@ set -e
 
 case "$1" in
     configure)
-         #make dir for the current pid
-         mkdir -p /var/run/xcat
-	 cp -f /opt/xcat/share/xcat/scripts/xHRM /install/postscripts/
-	. /etc/profile.d/xcat.sh
-	if [ -f /tmp/xCAT_upgrade.tmp ]
-	then
+        # Make dir for the current pid
+        mkdir -p /var/run/xcat
+        cp -f /opt/xcat/share/xcat/scripts/xHRM /install/postscripts/
+        . /etc/profile.d/xcat.sh
+        if [ -f /tmp/xCAT_upgrade.tmp ]
+        then
             if [ -r "/tmp/xcat/installservice.pid" ]; then
                 mv /tmp/xcat/installservice.pid /var/run/xcat/installservice.pid
             fi
@@ -35,16 +35,15 @@ case "$1" in
             if [ -r "/tmp/xcat/mainservice.pid" ]; then
                 mv /tmp/xcat/mainservice.pid /var/run/xcat/mainservice.pid
             fi
-	    xcatconfig -u
-	    rm /tmp/xCAT_upgrade.tmp
-	else
-	    xcatconfig -i -d -s
-	fi
+            xcatconfig -u
+            rm /tmp/xCAT_upgrade.tmp
+        else
+            xcatconfig -i -d -s
+        fi
 
-#        [ -e /etc/apache2/conf-enabled/xcat.conf ] && rm /etc/apache2/conf-enabled/xcat.conf
-         ln -s -f /etc/apache2/conf-available/xcat.conf.apach24 /etc/apache2/conf-enabled/xcat.conf
+        ln -s -f /etc/apache2/conf-available/xcat.conf.apach24 /etc/apache2/conf-enabled/xcat.conf
 
-	/etc/init.d/apache2 restart
+        /etc/init.d/apache2 restart
 
         # Let rsyslogd perform close of any open files
         if [ -e /var/run/rsyslogd.pid ]; then

--- a/xCAT/postscripts/syslog
+++ b/xCAT/postscripts/syslog
@@ -348,7 +348,8 @@ else
     #making sure all the messages goes to /var/log/messages
     touch  /var/log/messages 
     if ( pmatch $OSVER "ubuntu*" ) || ( is_lsb_ubuntu ) || ( pmatch $OSVER "debian*" ); then
-      chown syslog:adm /var/log/messages
+      chown --reference=/var/log /var/log/messages
+      chown --reference=/var/log /var/log/xcat
     fi
     if [ $ng -eq 0 ]; then
       if [ ! -f $conf_file.XCATORIG ]; then


### PR DESCRIPTION
On Ubuntu, the ``rsyslogd`` daemon write log files with ``syslog:adm`` permissison. And in some case, the directory ``/var/log/xcat`` was created by xCAT, and had ``root:root`` ownership. In this way, ``rsyslogd`` did not have enough permission to write to log files under this directory.

As a dirty hack, change the ownership of directory ``/var/log/xcat`` to the same ownership of directory ``/var/log``.
