### PR TITLE
fix issue 433: 2.11 build failed with renergy.1.pod

### DIFF
--- a/xCAT-client/pods/man1/renergy.1.pod
+++ b/xCAT-client/pods/man1/renergy.1.pod
@@ -847,8 +847,6 @@ The output will be like this:
 
 =back
 
-=back
-
 =head1 B<REFERENCES>
 
 =over 3


### PR DESCRIPTION
The syntax error for renergy pod file.