### PR TITLE
Provide a walk around to issue #424 by using rmimage

### DIFF
--- a/xCAT-server/lib/xcat/plugins/rmimage.pm
+++ b/xCAT-server/lib/xcat/plugins/rmimage.pm
@@ -190,7 +190,7 @@ sub process_request {
    # umount the rootimg/dev
    my $devmount = `cat /proc/mounts |grep  "$imagedir/rootimg/dev"`; 
    if($devmount){
-       xCAT::Utils->runcmd("umount $imagedir/rootimg/dev");
+       xCAT::Utils->runcmd("umount -l  $imagedir/rootimg/dev");
        if($?){
            $callback->({error=>["$imagedir/rootimg/dev mount on /dev, and can't umount. remove $imagename will lead to unpredictable result, please umount manualy before try again"], errorcode=>[1]}); 
            return;

--- a/xCAT-server/lib/xcat/plugins/rmimage.pm
+++ b/xCAT-server/lib/xcat/plugins/rmimage.pm
@@ -186,6 +186,16 @@ sub process_request {
    `umount -l $imagedir/rootimg/proc 2>&1 1>/dev/null`;
    # also umount the rootimg/sys
    `umount -l $imagedir/rootimg/sys 2>&1 1>/dev/null`;
+   
+   # umount the rootimg/dev
+   my $devmount = `cat /proc/mounts |grep  "$imagedir/rootimg/dev"`; 
+   if($devmount){
+       xCAT::Utils->runcmd("umount $imagedir/rootimg/dev");
+       if($?){
+           $callback->({error=>["$imagedir/rootimg/dev mount on /dev, and can't umount. remove $imagename will lead to unpredictable result, please umount manualy before try again"], errorcode=>[1]}); 
+           return;
+       }
+    }
 
    #Start removing the rootimg directory and files
    if (-d "$imagedir/rootimg") {


### PR DESCRIPTION
Due to we can't resolve the root cause #448 of issue #424 in xcat2.11, but this issue affects IST's work, so provide this walk around, let IST to avoid systemd crash again.