### PR TITLE
lib/perl/xCAT/Template.pm: fix for multiple files in pkglist (RHEL 7.2)

### DIFF
--- a/xCAT-server/lib/perl/xCAT/Template.pm
+++ b/xCAT-server/lib/perl/xCAT/Template.pm
@@ -115,6 +115,12 @@ sub subvars {
   $inc =~ s/#ENV:([^#]+)#/envvar($1)/eg;
   my $res;
   if ($pkglistfile) {
+
+      # ugly hack to work with multiple comma-separated files in pkglist
+      # (combined with the next regex replace below) to avoid this in kickstart:
+      # #INCLUDEBAD:cannot open file1,file2,file3#
+      $pkglistfile =~ s/,/#\n#INCLUDE:/g;
+
       #substitute the tag #INCLUDE_DEFAULT_PKGLIST# with package file name (for full install of  rh, centos,SL, esx fedora)
       $inc =~ s/#INCLUDE_DEFAULT_PKGLIST#/#INCLUDE:$pkglistfile#/g;
             


### PR DESCRIPTION
This patch fixes this error in the kickstart file, when there are multiple files in the pkglist attribute of an osimage.
(which is triggered/done w/ the CUDA 7.5 example in the documentation, for example)

This error in the kickstart file of p8r1n3 node:

	# cat /install/autoinst/p8r1n3
	<...>
	%packages
	#INCLUDEBAD:cannot open /opt/xcat/share/xcat/install/rh/compute.rhels7.pkglist,/opt/xcat/share/xcat/install/rh/cudafull.rhels7.ppc64le.pkglist,/install/post/pkgs/pe-rte.pkglist#
	%end
	<...>

Steps to reproduce the problem: 
(add more than one file in the pkglist attribute, generate the kickstart for a node)

	# chdef -t osimage <image> --plus pkglist=<another pkglist>
	# nodeset <node> osimage=<image>

	# grep INCLUDEBAD /install/autoinst/<node>

The patch is far from optimal (sorry, I'm not fluent in Perl), 
and still leaves the contents of the first file duplicated (less problematic than the original problem :-)
but with it applied, the problem is resolved, and the 3 pkglist files in the example are included in the kickstart of that node:

Please, feel free to re-work into a better/proper fix.

	# cat /install/autoinst/p8r1n3
	<...>
	%packages
	#Please make sure there is a space between @ and group name
	wget
	ntp
	nfs-utils
	net-snmp
	rsync
	yp-tools
	openssh-server
	util-linux
	net-tools
	#Please make sure there is a space between @ and group name
	wget
	ntp
	nfs-utils
	net-snmp
	rsync
	yp-tools
	openssh-server
	util-linux
	net-tools

	#For Cuda 7.5
	kernel-devel
	gcc
	pciutils
	dkms
	cuda

	# For PE RTE's IVP
	ksh
	<...>