### PR TITLE
pasu/psh/pscp Connection failure in sles11.4,error info in rh7.1 

### DIFF
--- a/xCAT-client/bin/pasu
+++ b/xCAT-client/bin/pasu
@@ -231,13 +231,19 @@ sub expandnoderange {
   my @nodes;
   my @user = getpwuid($>);
   my $homedir=$user[7];
+  my %sslargs;
+  if (defined($ENV{'XCATSSLVER'})) {
+      $sslargs{SSL_version} = $ENV{'XCATSSLVER'};
+  }
+
   my $client = IO::Socket::SSL->new(
                 PeerAddr=>$xcathost,
                 SSL_key_file=>$homedir."/.xcat/client-cred.pem",
                 SSL_cert_file=>$homedir."/.xcat/client-cred.pem",
                 SSL_ca_file => $homedir."/.xcat/ca.pem",
                 SSL_use_cert => 1,
-                #SSL_verify_mode => 1,
+                SSL_verify_mode => 1,
+                %sslargs,
              );
   die "Connection failure: $!\n" unless ($client);
   #todo: get the bmc attr for each node, not the node name itself
@@ -280,13 +286,19 @@ sub getipmiattrs {
   my $nodeattrs = {};        # this will be a reference to a hash
   my @user = getpwuid($>);
   my $homedir=$user[7];
+  my %sslargs;
+  if (defined($ENV{'XCATSSLVER'})) {
+      $sslargs{SSL_version} = $ENV{'XCATSSLVER'};
+  }
+
   my $client = IO::Socket::SSL->new(
                 PeerAddr=>$xcathost,
                 SSL_key_file=>$homedir."/.xcat/client-cred.pem",
                 SSL_cert_file=>$homedir."/.xcat/client-cred.pem",
                 SSL_ca_file => $homedir."/.xcat/ca.pem",
                 SSL_use_cert => 1,
-                #SSL_verify_mode => 1,
+                SSL_verify_mode => 1,
+                %sslargs,
              );
   die "Connection failure: $!\n" unless ($client);
   my %cmdref = (command => 'getipmicons', noderange => $noderange);

--- a/xCAT-client/bin/pscp
+++ b/xCAT-client/bin/pscp
@@ -56,6 +56,10 @@ else { usage("No node range specified\n\n"); }
 
 my  @user = getpwuid($>);
 my $homedir=$user[7];
+my %sslargs;
+if (defined($ENV{'XCATSSLVER'})) {
+    $sslargs{SSL_version} = $ENV{'XCATSSLVER'};
+}
 
 my $client = IO::Socket::SSL->new(
                 PeerAddr=>$xcathost,
@@ -63,7 +67,8 @@ my $client = IO::Socket::SSL->new(
                 SSL_cert_file=>$homedir."/.xcat/client-cred.pem",
                 SSL_ca_file => $homedir."/.xcat/ca.pem",
                 SSL_use_cert => 1,
-                #SSL_verify_mode => 1,
+                SSL_verify_mode => 1,
+                %sslargs,
              );
 die "Connection failure: $!\n" unless ($client);
 my %cmdref = (command => 'noderange', noderange => $noderange);

--- a/xCAT-client/bin/psh
+++ b/xCAT-client/bin/psh
@@ -55,13 +55,19 @@ if ($::NONODECHECK) {
 else {
   my @user = getpwuid($>);
   my $homedir=$user[7];
+  my %sslargs;
+  if (defined($ENV{'XCATSSLVER'})) {
+      $sslargs{SSL_version} = $ENV{'XCATSSLVER'};
+  }
+
   my $client = IO::Socket::SSL->new(
                 PeerAddr=>$xcathost,
                 SSL_key_file=>$homedir."/.xcat/client-cred.pem",
                 SSL_cert_file=>$homedir."/.xcat/client-cred.pem",
                 SSL_ca_file => $homedir."/.xcat/ca.pem",
                 SSL_use_cert => 1,
-                SSL_verify_mode => SSL_VERIFY_MODE,
+                SSL_verify_mode => 1,
+                %sslargs,
              );
   die "Connection failure: $!\n" unless ($client);
   my %cmdref = (command => 'noderange', noderange => $noderange);


### PR DESCRIPTION
details refer to :  #474 #479 
pasu return SSL_verify_mode error at /opt/xcat/bin/pasu line 283 in RH7.1
pasu Connection failure: Connection reset by peer on sles11

psh and pscp have the same problem.