### PR TITLE
Fix-issue 471: Add a user interface to set the delay time for rflash

### DIFF
--- a/docs/source/guides/admin-guides/references/man5/site.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/site.5.rst
@@ -235,6 +235,10 @@ site Attributes:
    snmpc:  The snmp community string that xcat should use when communicating with the
            switches.
   
+   rflash_delay:  Only for rflash command to upgrade firmware on OpenPOWER servers.
+                  This attribute is delay time to wait for the firmware initialization
+                  after cold reset. Default value is 120 in seconds. If set to 0, no delay.
+  
    ---------------------------
   INSTALL/DEPLOYMENT ATTRIBUTES
    ---------------------------

--- a/perl-xCAT/xCAT/Schema.pm
+++ b/perl-xCAT/xCAT/Schema.pm
@@ -1070,6 +1070,9 @@ site => {
    "              through HMC. Default is 0.\n\n".
    " snmpc:  The snmp community string that xcat should use when communicating with the\n".
    "         switches.\n\n".
+   " rflash_delay:  Only for rflash command to upgrade firmware on OpenPOWER servers.\n".
+   "                This attribute is delay time to wait for the firmware initialization\n".
+   "                after cold reset. Default value is 120 in seconds. If set to 0, no delay.\n\n".
    " ---------------------------\n".
    "INSTALL/DEPLOYMENT ATTRIBUTES\n".
    " ---------------------------\n".

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -1692,7 +1692,10 @@ sub do_firmware_update {
     # NOTE(chenglch) some firmware may not stable enough, it can handle the ipmi session
     # request, but failed to upgrade, add sleep function as a work around here to avoid of
     # error.
-    sleep(60);
+    my $rflash_delay = 120;
+    my $delay_config = xCAT::TableUtils->get_site_attribute("rflash_delay");
+    $rflash_delay = $delay_config if defined($delay_config) and $delay_config =~ /^\d+$/;
+    sleep($rflash_delay) if $rflash_delay != 0;
     $cmd = $pre_cmd." -z 30000 hpm upgrade $hpm_file force";
     $output = xCAT::Utils->runcmd($cmd, -1);
 


### PR DESCRIPTION
Currently abort failure(0x81) occur during the initiate stage as
the firmware state is not stable enough after cold reset. As the
delay time is not a constant value, this change add a interface in
site table for user to set this value.

Close-issue: #471