### PR TITLE
lsf_startup: fix LSF_VERSION expression

### DIFF
--- a/xCAT/postscripts/lsf_startup
+++ b/xCAT/postscripts/lsf_startup
@@ -31,7 +31,7 @@ then
 fi
 
 #get lsf main version,
-LSF_VERSION=`find /$LSF_TOP -name hostsetup|head -1|awk '{print $5}'`
+LSF_VERSION="$(find /$LSF_TOP -path "*/install/hostsetup" | grep -o "/[^/]\+/install/hostsetup" | cut -d/ -f2)"
 
 if [[ x${LSF_ADD_SERVERS} != x ]]; then
      ALL_LSF_NODES=${LSF_MASTER_LIST}' '${LSF_ADD_SERVERS}


### PR DESCRIPTION
When running lsf_startup

	[root@xcat-mn lsf]# updatenode $lsf_master --scripts lsf_startup
	<...>
	p8r1n1: Mon Nov 30 21:30:58 EST 2015 Running postscript: lsf_startup
	p8r1n1: INFO: Run hostsetup on each node.
	p8r1n1: ./lsf_startup: line 48: /usr/share/lsf//install/hostsetup: No such file or directory
	<...>

It is because this expression is broken; no mention to / as field separator.

	# grep '^LSF_VERSION' /install/postscripts/lsf_startup LSF_VERSION=`find /$LSF_TOP -name hostsetup|head -1|awk '{print $5}'`

See:

	[root@p8r1n1 ~]# LSF_TOP="/usr/share/lsf"

	[root@p8r1n1 ~]# find /$LSF_TOP -name hostsetup | head -1
	//usr/share/lsf/9.1/install/hostsetup

	[root@p8r1n1 ~]# find /$LSF_TOP -name hostsetup|head -1|awk '{print $5}'
	[root@p8r1n1 ~]# 

Additionally, it would fail if the version was not exactly the 5th field, which may occur if the user doesn't use /usr/share/lsf for LSF_TOP. And there's even a leading / before $LSF_TOP (ie, /$LSF_TOP).. and what if the user sets LSF_TOP with a trailing / ?

So, lets make this independent of leading slashes and trailing slashes.

	LSF_VERSION="$(find /$LSF_TOP -path "*/install/hostsetup" | grep -o "/[^/]\+/install/hostsetup" | cut -d/ -f2)"

It works on the usual and non-usual cases:

	[root@p8r1n1 ~]# LSF_TOP=/usr/share/lsf
	[root@p8r1n1 ~]# find /$LSF_TOP -path '*/install/hostsetup' | grep -o '/[^/]\+/install/hostsetup' | cut -d/ -f2
	9.1

	[root@p8r1n1 ~]# LSF_TOP=/test/some/other/dir/for/lsf
	[root@p8r1n1 ~]# mkdir -p $LSF_TOP/9.1/install
	[root@p8r1n1 ~]# touch $LSF_TOP/9.1/install/hostsetup
	[root@p8r1n1 ~]# find /$LSF_TOP -path "*/install/hostsetup" | grep -o '/[^/]\+/install/hostsetup' | cut -d/ -f2
	9.1