### PR TITLE
Remove test case get_xcat_install_loginfo

### DIFF
--- a/xCAT-test/autotest/bundle/p_rhels_cmd.bundle
+++ b/xCAT-test/autotest/bundle/p_rhels_cmd.bundle
@@ -271,7 +271,6 @@ makentp_a
 nodeset_check_warninginfo
 runcmdinstaller
 runcmdinstaller_command
-get_xcat_install_loginfo
 get_xcat_postscripts_loginfo
 updatenode_postscripts_loginfo
 bmcdiscover_h

--- a/xCAT-test/autotest/testcase/runcmdinstaller/cases0
+++ b/xCAT-test/autotest/testcase/runcmdinstaller/cases0
@@ -20,19 +20,6 @@ check:rc==0
 check:output=~yum
 cmd:chtab key=xcatdebugmode site.value="0"
 end
-start:get_xcat_install_loginfo
-description:xcatdebugloginfo for install
-cmd:chtab key=xcatdebugmode site.value="1"
-check:rc==0
-cmd:nodeset $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
-check:rc==0
-cmd:if [[ "__GETNODEATTR($$CN,arch)__" =~ "ppc64" ]]; then rnetboot $$CN;elif [[ "__GETNODEATTR($$CN,arch)__" =~ "x86_64" ]];then rpower $$CN boot; fi
-check:rc==0
-cmd:sleep 300
-cmd:cat /var/log/messages /var/log/xcat/computes.log 2>/dev/null | grep "packaging: Installing"
-check:rc==0
-cmd:chtab key=xcatdebugmode site.value="0"
-end
 start:get_xcat_postscripts_loginfo
 description:get xcat post scripts loginfo
 cmd:chtab key=xcatdebugmode site.value="1"


### PR DESCRIPTION
Remove test case get_xcat_install_loginfo. This test case only run on RHEL ppc64 env. And this test case always failed, since the RHEL installer did not produce the old style log output any more.