### PR TITLE
Remove white space at the end of line for spawn strings.

### DIFF
--- a/perl-xCAT/xCAT/RemoteShellExp.pm
+++ b/perl-xCAT/xCAT/RemoteShellExp.pm
@@ -614,11 +614,11 @@ sub sendnodeskeys
       my $spawncopyfiles;
       if ($ENV{'DSH_ENABLE_SSH'}) { # we will enable node to node ssh 
          $spawncopyfiles=
-        "$remotecopy $home/.ssh/id_rsa $home/.ssh/id_rsa.pub $home/.ssh/copy.sh $home/.ssh/tmp/authorized_keys $to_userid\@$node:/tmp/$to_userid/.ssh "; 
+        "$remotecopy $home/.ssh/id_rsa $home/.ssh/id_rsa.pub $home/.ssh/copy.sh $home/.ssh/tmp/authorized_keys $to_userid\@$node:/tmp/$to_userid/.ssh"; 
           
       } else {    # no node to node ssh ( don't send private key)
          $spawncopyfiles=
-        "$remotecopy $home/.ssh/id_rsa.pub $home/.ssh/copy.sh $home/.ssh/tmp/authorized_keys $to_userid\@$node:/tmp/$to_userid/.ssh "; 
+        "$remotecopy $home/.ssh/id_rsa.pub $home/.ssh/copy.sh $home/.ssh/tmp/authorized_keys $to_userid\@$node:/tmp/$to_userid/.ssh"; 
       }
       # send copy command 
       unless ($sendkeys->spawn($spawncopyfiles))
@@ -839,7 +839,7 @@ sub senddeviceskeys
       # command to send key to the device
       # sshKey add "key" 
       my $spawnaddkey=
-      "$remoteshell $node -l $to_userid $setupcmd ";  
+      "$remoteshell $node -l $to_userid $setupcmd";  
     
       # send mkdir command 
       unless ($sendkeys->spawn($spawnaddkey))


### PR DESCRIPTION
IBM Cloud Analytics team report a "xdsh -K" issue on their Softlayer system.  The compute node was provisioned by different Manager Node.  The nodes are in the different datacenter and hooked up via tunnels. 
````
# xdsh uklon02hyp00014ianra -K
Enter the password for the userid: root on the node where the ssh keys 
will be updated:

Error: copykeys:uklon02hyp00014ianra has error,1:TIMEOUT
Error: copy.sh:uklon02hyp00014ianra has error,3:Child PID 14494 exited with status 32512
Error: remoteshellexp failed sending keys to enablenodes.
Error: SSH setup failed for the following nodes: uklon02hyp00014ianra.
return code = 1
 
but 
# ssh uklon02hyp00014ianra
root@uklon02hyp00014ianra's password: 
````


