### PR TITLE
Add attention message in doc for rflash

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/management.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/management.rst
@@ -100,15 +100,24 @@ As an example, get only the temperature information of a particular machine. ::
 Firmware Updating
 `````````````````
 
-For OpenPower machine, the firmware updating feature is implement in ``rflash``
-command.
+For OpenPOWER machines, use the ``rflash`` command to update firmware.
 
-Collect firmware version of the node and the HPM file:  ::
+Check firmware version of the node and the HPM file:  ::
 
     rflash cn1 -c /firmware/8335_810.1543.20151021b_update.hpm
 
-Update node firmware to the version of the HPM file:  ::
+Update node firmware to the version of the HPM file
 
+**ATTENTION**
+
+* Currently rflash is not stable enough to select accurate time before
+  upgrading. A ``rflash_delay`` attribute can be set in site table to adjust the
+  wait time before upgrading. We suggest setting this value to 70 which means
+  wait 70 secondes after BMC reset cold.
+
+::
+
+    chdef -t site clustersite rflash_delay=70
     rflash cn1 /firmware/8335_810.1543.20151021b_update.hpm
 
 Configures Nodes' Service Processors


### PR DESCRIPTION
The rflash command has problems working well, so adding information text to the user for adding delays before issuing the command. 