### PR TITLE
Remove hostname from known_hosts file after nodes reset

### DIFF
--- a/xCAT-server/lib/xcat/plugins/credentials.pm
+++ b/xCAT-server/lib/xcat/plugins/credentials.pm
@@ -320,9 +320,6 @@ sub process_request
            @filecontent=();
        }
     }
-     `logger -t xcat -p local4.info "credentials: remove $client from known_hosts"` ;
-    system("ssh-keygen -R $client -f /root/.ssh/known_hosts");
-
     if (defined $rsp->{data}->[0]) {
 	#if we got the data from the file, send the data message to the client
         xCAT::MsgUtils->message("D", $rsp, $callback, 0);

--- a/xCAT-server/lib/xcat/plugins/credentials.pm
+++ b/xCAT-server/lib/xcat/plugins/credentials.pm
@@ -320,6 +320,9 @@ sub process_request
            @filecontent=();
        }
     }
+     `logger -t xcat -p local4.info "credentials: remove $client from known_hosts"` ;
+    system("ssh-keygen -R $client -f /root/.ssh/known_hosts");
+
     if (defined $rsp->{data}->[0]) {
 	#if we got the data from the file, send the data message to the client
         xCAT::MsgUtils->message("D", $rsp, $callback, 0);

--- a/xCAT/postscripts/remoteshell
+++ b/xCAT/postscripts/remoteshell
@@ -224,8 +224,8 @@ else
 fi
 rm /tmp/ssh_rsa_hostkey
 
-# if there is a ecdsa host key on the node then download the replacement from the MN/SN
-if [ -f /etc/ssh/ssh_host_ecdsa_key ]; then
+# if node supports ecdsa host key then download the replacement from the MN/SN
+if ssh-keygen -t ecdsa -f /tmp/ecdsa_key -P "" &>/dev/null ; then
   # download the host ecdsa key
   if [ $useflowcontrol = "1" ]; then
     #first contact daemon  xcatflowrequest <server> 3001


### PR DESCRIPTION
Issue #516 , this fix will remove hostname from known_hosts file on the MN to avoid "man-in-the-middle attack" message after nodes reset.