### PR TITLE
Update release info

### DIFF
--- a/docs/source/overview/xcat2_release.rst
+++ b/docs/source/overview/xcat2_release.rst
@@ -7,6 +7,27 @@ The New OS and New Hardware which are listed in the table have been fully tested
 
 For a complete list of new functions, bug fixes, restrictions, and known problems, refer to the individual release notes.
 
+xCAT 2.11.x
+-----------
++---------------------------------+---------------+-------------+----------------------------------+
+|xCAT                             |New OS         |New          |New Feature                       |
+|Version                          |               |Hardware     |                                  |
++=================================+===============+=============+==================================+
+|| xCAT 2.11                      |- RHEL 7.2 LE  |- S822LC(GCA)|- NVIDIA GPU for OpenPOWER        |
+|| 2015/12/11                     |- UBT 14.4.3 LE|- S822LC(GTA)|- Infiniband for OpenPOWER        |
+||                                |- UBT 15.10 LE |- S812LC     |- KIT support for OpenPOWER       |
+| `2.11 Release Notes <https://   |- PowerKVM 3.1 |- NeuCloud OP|- renergy command for OpenPOWER   |
+| github.com/xcat2/xcat-core/     |               |- ZoomNet RP |- rlash command for OpenPOWER     |
+| wiki/XCAT_2.11_Release_Notes>`_ |               |             |- Add xCAT Troubleshooting Log    |
+|                                 |               |             |- xCAT Log Classification         |
+|                                 |               |             |- RAID Configuration              |
+|                                 |               |             |- Accelerate the genimage process |
+|                                 |               |             |- Add bmcdiscover Command         |
+|                                 |               |             |- Enhance the xcatdebugmode       |
+|                                 |               |             |- new xCAT doc in RTD             |
++---------------------------------+---------------+-------------+----------------------------------+
+
+
 xCAT 2.10.x
 -----------
 
@@ -37,6 +58,13 @@ xCAT 2.9.x
 |xCAT                             |New OS         |New          |New Feature                       |
 |Version                          |               |Hardware     |                                  |
 +=================================+===============+=============+==================================+
+|| xCAT 2.9.2 for AIX             |- AIX 6.1.8.6  |- Power 8    |- ssl version control in xcatd    |
+|| 2015/11/11                     |- AIX 6.1.9.5  |  for AIX    |                                  |
+||                                |- AIX 7.1.3.5  |             |                                  |
+| `2.9.2 Release Notes <https://  |               |             |                                  |
+| github.com/xcat2/xcat-core/     |               |             |                                  |
+| wiki/XCAT_2.9.2_Release_Notes>`_|               |             |                                  |
++---------------------------------+---------------+-------------+----------------------------------+
 || xCAT 2.9.1                     |- RHEL 7.1     |             |- Nvidia GPU                      |
 || 2015/03/20                     |- UBT 14.4.2   |             |- Ubuntu Local Mirror             |
 ||                                |               |             |- Sles12 diskless                 |

--- a/xCAT-server/sbin/xcatconfig
+++ b/xCAT-server/sbin/xcatconfig
@@ -1426,16 +1426,17 @@ sub initDB
             }
         }
 
-        # add default value to site.xcatsslversion
-        $cmds = "$::XCATROOT/sbin/chtab key=xcatsslversion site.value=TLSv1;";
-        $outref = xCAT::Utils->runcmd("$cmds", 0);
-        if ($::RUNCMD_RC != 0)
-        {
-            xCAT::MsgUtils->message('E',"Could not add default value for site.xcatsslversion.");
+        # Set default value for site.xcatsslversion when update xcat
+        $cmds = "XCATBYPASS=Y $::XCATROOT/sbin/tabdump site 2>/dev/null |grep xcatsslversion";
+        xCAT::Utils->runcmd("$cmds", -1);
+        if ($::RUNCMD_RC != 0) {
+            # if site.xcatsslversion was not set, then set the default value TLSv1
+            $cmds = "$::XCATROOT/sbin/chtab key=xcatsslversion site.value=TLSv1;";
+            xCAT::Utils->runcmd("$cmds", 0);
+            if ($::RUNCMD_RC != 0) {
+                xCAT::MsgUtils->message('E',"Could not add default value for site.xcatsslversion.");
+            }
         }
-
-
-
    } 
    # remove xcatserver,xcatclient
    # from the postscripts. They are now called by servicenode


### PR DESCRIPTION
Update xCAT release information page for 2.9.2 AIX and 2.11 releases.

Refer to the page in my local web server: http://10.4.14.20/release_info/overview/xcat2_release.html