### PR TITLE
Fix issue667: command log writer process failed to start in xcat docker container 

### DIFF
--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -1128,6 +1128,11 @@ unless ($cmdlog_svrpid){
         exit(0);
     }
 
+    my @tmp =  split "/",$cmdlog_logfile;
+    splice (@tmp, -1);
+    my $cmdlog_logfile_path=join("/", @tmp);
+    mkdir("$cmdlog_logfile_path") unless(-d "$cmdlog_logfile_path");
+
     unless (open ($cmdlogfile, ">>$cmdlog_logfile")) {
         xCAT::MsgUtils->trace(0,"E","xcatd: Can't open xcat command log file $cmdlog_logfile,command log process $$ stop.");
         if($cmdlogsvrlistener){close($cmdlogsvrlistener);}

--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -1131,7 +1131,7 @@ unless ($cmdlog_svrpid){
     my @tmp =  split "/",$cmdlog_logfile;
     splice (@tmp, -1);
     my $cmdlog_logfile_path=join("/", @tmp);
-    mkdir("$cmdlog_logfile_path") unless(-d "$cmdlog_logfile_path");
+    mkpath("$cmdlog_logfile_path") unless(-d "$cmdlog_logfile_path");
 
     unless (open ($cmdlogfile, ">>$cmdlog_logfile")) {
         xCAT::MsgUtils->trace(0,"E","xcatd: Can't open xcat command log file $cmdlog_logfile,command log process $$ stop.");

--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -51,6 +51,7 @@ my $arch = `uname -p`;
 unless (($^O =~ /^aix/i) || ($os =~ /^sle[sc]10/) || (($os =~ /^rh.*5$/) && ($arch =~ /ppc64/))){
     eval {require IO::Uncompress::Gunzip;}
 }
+use File::Basename;
 use File::Path;
 use Time::HiRes qw(sleep);
 use Thread qw(yield);
@@ -1128,9 +1129,7 @@ unless ($cmdlog_svrpid){
         exit(0);
     }
 
-    my @tmp =  split "/",$cmdlog_logfile;
-    splice (@tmp, -1);
-    my $cmdlog_logfile_path=join("/", @tmp);
+    my $cmdlog_logfile_path=dirname($cmdlog_logfile);
     mkpath("$cmdlog_logfile_path") unless(-d "$cmdlog_logfile_path");
 
     unless (open ($cmdlogfile, ">>$cmdlog_logfile")) {


### PR DESCRIPTION
Due to command log operates ``/var/log/xcat/commands.log``, but when directory ``/var/log/xcat/`` didn't exist before command log process starting,  command log process will exit.  

Add code to create ``/var/log/xcat/`` if ``/var/log/xcat/`` didn't exist before. 