### PR TITLE
[FVT]Automation Case: Check site.xcatsslversion value after update xcat version to 2.11 or higher.

### DIFF
--- a/xCAT-test/autotest/testcase/xcatconfig/case0
+++ b/xCAT-test/autotest/testcase/xcatconfig/case0
@@ -88,20 +88,34 @@ cmd:xcatconfig --version
 check:output=~version|Version
 end
 
-start:xcatconfig_f_check_xcatsslversion
-description:after xcatconfig -f the site.xcatsslversion will not be changed
+start:xcatconfig_u_check_xcatsslversion_rhels_sles
+description:after xcatconfig -u the site.xcatsslversion will not be changed
 cmd:tabdump site | grep xcatsslversion
 check:output=~TLSv1
-cmd:if cat /etc/*-release | grep SUSE >/dev/null; then chtab key=xcatsslversion site.value=TLSv12;elif  cat /etc/*release |grep "Red Hat" >/dev/null;then chtab key=xcatsslversion site.value=TLSv12;elif  cat /etc/*release |grep "Ubuntu"  >/dev/null;then chtab key=xcatsslversion site.value=TLSv1_2;fi
+cmd:chtab key=xcatsslversion site.value=TLSv12
 check:rc==0
 cmd:tabdump site | grep "xcatsslversion"
-check:output=~TLSv12|TLSv1_2
+check:output=~TLSv12
 cmd:xcatconfig -u
 check:rc==0
 cmd:tabdump site | grep "xcatsslversion"
 check:output=~TLSv12
 cmd:chtab key=xcatsslversion site.value=TLSv1
 check:rc==0
-cmd:tabdump site | grep "xcatsslversion"
+end
+
+start:xcatconfig_u_check_xcatsslversion_ubuntu
+description:after xcatconfig -u the site.xcatsslversion will not be changed
+cmd:tabdump site | grep xcatsslversion
 check:output=~TLSv1
+cmd:chtab key=xcatsslversion site.value=TLSv1_2
+check:rc==0
+cmd:tabdump site | grep "xcatsslversion"
+check:output=~TLSv1_2
+cmd:xcatconfig -u
+check:rc==0
+cmd:tabdump site | grep "xcatsslversion"
+check:output=~TLSv1_2
+cmd:chtab key=xcatsslversion site.value=TLSv1
+check:rc==0
 end

--- a/xCAT-test/autotest/testcase/xcatconfig/case0
+++ b/xCAT-test/autotest/testcase/xcatconfig/case0
@@ -90,32 +90,32 @@ end
 
 start:xcatconfig_u_check_xcatsslversion_rhels_sles
 description:after xcatconfig -u the site.xcatsslversion will not be changed
-cmd:tabdump site | grep xcatsslversion
-check:output=~TLSv1
+cmd:default_value=`tabdump site | grep xcatsslversion | awk -F '"' '{print $4}'`; if [ "$default_value" = "TLSv1" ]; then echo "xcatsslversion default value is TLSv1"; else echo "xcatsslversion is $default_value"; fi
+check:output=~xcatsslversion default value is TLSv1
 cmd:chtab key=xcatsslversion site.value=TLSv12
 check:rc==0
-cmd:tabdump site | grep "xcatsslversion"
-check:output=~TLSv12
+cmd:value=`tabdump site | grep xcatsslversion | awk -F '"' '{print $4}'`; if [ "$value" = "TLSv12" ]; then echo "xcatsslversion is changed to be TLSv12"; else echo "xcatsslversion is $value"; fi
+check:output=~xcatsslversion is changed to be TLSv12
 cmd:xcatconfig -u
 check:rc==0
-cmd:tabdump site | grep "xcatsslversion"
-check:output=~TLSv12
+cmd:value=`tabdump site | grep xcatsslversion | awk -F '"' '{print $4}'`; if [ "$value" = "TLSv12" ]; then echo "xcatsslversion is still TLSv12"; else echo "xcatsslversion is $value"; fi
+check:output=~xcatsslversion is still TLSv12
 cmd:chtab key=xcatsslversion site.value=TLSv1
 check:rc==0
 end
 
 start:xcatconfig_u_check_xcatsslversion_ubuntu
 description:after xcatconfig -u the site.xcatsslversion will not be changed
-cmd:tabdump site | grep xcatsslversion
-check:output=~TLSv1
+cmd:default_value=`tabdump site | grep xcatsslversion | awk -F '"' '{print $4}'`; if [ "$default_value" = "TLSv1" ]; then echo "xcatsslversion default value is TLSv1"; else echo "xcatsslversion is $default_value"; fi
+check:output=~xcatsslversion default value is TLSv1
 cmd:chtab key=xcatsslversion site.value=TLSv1_2
 check:rc==0
-cmd:tabdump site | grep "xcatsslversion"
-check:output=~TLSv1_2
+cmd:value=`tabdump site | grep xcatsslversion | awk -F '"' '{print $4}'`; if [ "$value" = "TLSv1_2" ]; then echo "xcatsslversion is changed to be TLSv1_2"; else echo "xcatsslversion is $value"; fi
+check:output=~xcatsslversion is changed to be TLSv1_2
 cmd:xcatconfig -u
 check:rc==0
-cmd:tabdump site | grep "xcatsslversion"
-check:output=~TLSv1_2
+cmd:value=`tabdump site | grep xcatsslversion | awk -F '"' '{print $4}'`; if [ "$value" = "TLSv1_2" ]; then echo "xcatsslversion is still TLSv1_2"; else echo "xcatsslversion is $value"; fi
+check:output=~xcatsslversion is still TLSv1_2
 cmd:chtab key=xcatsslversion site.value=TLSv1
 check:rc==0
 end

--- a/xCAT-test/autotest/testcase/xcatconfig/case0
+++ b/xCAT-test/autotest/testcase/xcatconfig/case0
@@ -87,3 +87,21 @@ check:output=~version|Version
 cmd:xcatconfig --version
 check:output=~version|Version
 end
+
+start:xcatconfig_f_check_xcatsslversion
+description:after xcatconfig -f the site.xcatsslversion will not be changed
+cmd:tabdump site | grep xcatsslversion
+check:output=~TLSv1
+cmd:if cat /etc/*-release | grep SUSE >/dev/null; then chtab key=xcatsslversion site.value=TLSv12;elif  cat /etc/*release |grep "Red Hat" >/dev/null;then chtab key=xcatsslversion site.value=TLSv12;elif  cat /etc/*release |grep "Ubuntu"  >/dev/null;then chtab key=xcatsslversion site.value=TLSv1_2;fi
+check:rc==0
+cmd:tabdump site | grep "xcatsslversion"
+check:output=~TLSv12|TLSv1_2
+cmd:xcatconfig -u
+check:rc==0
+cmd:tabdump site | grep "xcatsslversion"
+check:output=~TLSv12
+cmd:chtab key=xcatsslversion site.value=TLSv1
+check:rc==0
+cmd:tabdump site | grep "xcatsslversion"
+check:output=~TLSv1
+end

--- a/xCAT-test/autotest/testcase/xcatconfig/case0
+++ b/xCAT-test/autotest/testcase/xcatconfig/case0
@@ -90,32 +90,33 @@ end
 
 start:xcatconfig_u_check_xcatsslversion_rhels_sles
 description:after xcatconfig -u the site.xcatsslversion will not be changed
-cmd:default_value=`tabdump site | grep xcatsslversion | awk -F '"' '{print $4}'`; if [ "$default_value" = "TLSv1" ]; then echo "xcatsslversion default value is TLSv1"; else echo "xcatsslversion is $default_value"; fi
-check:output=~xcatsslversion default value is TLSv1
+cmd:lsdef -t site -i xcatsslversion -c | grep '=TLSv1$'
+check:rc==0
 cmd:chtab key=xcatsslversion site.value=TLSv12
 check:rc==0
-cmd:value=`tabdump site | grep xcatsslversion | awk -F '"' '{print $4}'`; if [ "$value" = "TLSv12" ]; then echo "xcatsslversion is changed to be TLSv12"; else echo "xcatsslversion is $value"; fi
-check:output=~xcatsslversion is changed to be TLSv12
+cmd:lsdef -t site -i xcatsslversion -c | grep '=TLSv12$'
+check:rc==0
 cmd:xcatconfig -u
 check:rc==0
-cmd:value=`tabdump site | grep xcatsslversion | awk -F '"' '{print $4}'`; if [ "$value" = "TLSv12" ]; then echo "xcatsslversion is still TLSv12"; else echo "xcatsslversion is $value"; fi
-check:output=~xcatsslversion is still TLSv12
+cmd:lsdef -t site -i xcatsslversion -c | grep '=TLSv12$'
+check:rc==0
 cmd:chtab key=xcatsslversion site.value=TLSv1
 check:rc==0
 end
 
+
 start:xcatconfig_u_check_xcatsslversion_ubuntu
 description:after xcatconfig -u the site.xcatsslversion will not be changed
-cmd:default_value=`tabdump site | grep xcatsslversion | awk -F '"' '{print $4}'`; if [ "$default_value" = "TLSv1" ]; then echo "xcatsslversion default value is TLSv1"; else echo "xcatsslversion is $default_value"; fi
-check:output=~xcatsslversion default value is TLSv1
+cmd:lsdef -t site -i xcatsslversion -c | grep '=TLSv1$'
+check:rc==0
 cmd:chtab key=xcatsslversion site.value=TLSv1_2
 check:rc==0
-cmd:value=`tabdump site | grep xcatsslversion | awk -F '"' '{print $4}'`; if [ "$value" = "TLSv1_2" ]; then echo "xcatsslversion is changed to be TLSv1_2"; else echo "xcatsslversion is $value"; fi
-check:output=~xcatsslversion is changed to be TLSv1_2
+cmd:lsdef -t site -i xcatsslversion -c | grep '=TLSv1_2$'
+check:rc==0
 cmd:xcatconfig -u
 check:rc==0
-cmd:value=`tabdump site | grep xcatsslversion | awk -F '"' '{print $4}'`; if [ "$value" = "TLSv1_2" ]; then echo "xcatsslversion is still TLSv1_2"; else echo "xcatsslversion is $value"; fi
-check:output=~xcatsslversion is still TLSv1_2
+cmd:lsdef -t site -i xcatsslversion -c | grep '=TLSv1_2$'
+check:rc==0
 cmd:chtab key=xcatsslversion site.value=TLSv1
 check:rc==0
 end


### PR DESCRIPTION
@tingtli 
After update to xcat 2.11, the site.xcatsslversion  will be changed to default value, according to : https://github.com/xcat2/xcat-core/issues/569, in this case, using the xcatconfig -u to simulate the update process, then check the value.
rhels run log:
```
******************************
Start to run test cases
******************************
------START:xcatconfig_u_check_xcatsslversion_rhels_sles::Time:Tue Oct 25 01:05:35 2016------

RUN:lsdef -t site -i xcatsslversion -c | grep '=TLSv1$'

[lsdef -t site -i xcatsslversion -c | grep '=TLSv1$'] Running Time:0 sec
RETURN: rc = 0
OUTPUT:
clustersite: xcatsslversion=TLSv1
CHECK:rc == 0   [Pass]

RUN:chtab key=xcatsslversion site.value=TLSv12

[chtab key=xcatsslversion site.value=TLSv12] Running Time:0 sec
RETURN: rc = 0
OUTPUT:
CHECK:rc == 0   [Pass]

RUN:lsdef -t site -i xcatsslversion -c | grep '=TLSv12$'

[lsdef -t site -i xcatsslversion -c | grep '=TLSv12$'] Running Time:1 sec
RETURN: rc = 0
OUTPUT:
clustersite: xcatsslversion=TLSv12
CHECK:rc == 0   [Pass]

RUN:xcatconfig -u

[xcatconfig -u] Running Time:11 sec
RETURN: rc = 0
OUTPUT:
Restarting xcatd (via systemctl):  [  OK  ]
CHECK:rc == 0   [Pass]

RUN:lsdef -t site -i xcatsslversion -c | grep '=TLSv12$'

[lsdef -t site -i xcatsslversion -c | grep '=TLSv12$'] Running Time:1 sec
RETURN: rc = 0
OUTPUT:
clustersite: xcatsslversion=TLSv12
CHECK:rc == 0   [Pass]

RUN:chtab key=xcatsslversion site.value=TLSv1

[chtab key=xcatsslversion site.value=TLSv1] Running Time:0 sec
RETURN: rc = 0
OUTPUT:
CHECK:rc == 0   [Pass]
------END::a_xcatconfig_u_check_xcatsslversion_rhels_sles::Passed::Time:Tue Oct 25 01:05:48 2016 ::Duration::13 sec------
------Total: 1 , Failed: 0------
```

Ubuntu:
```
To run:
xcatconfig_u_check_xcatsslversion_ubuntu
******************************
Start to run test cases
******************************
------START:xcatconfig_u_check_xcatsslversion_ubuntu::Time:Tue Oct 25 01:02:24 2016------

RUN:lsdef -t site -i xcatsslversion -c | grep '=TLSv1$'

[lsdef -t site -i xcatsslversion -c | grep '=TLSv1$'] Running Time:0 sec
RETURN: rc = 0
OUTPUT:
clustersite: xcatsslversion=TLSv1
CHECK:rc == 0   [Pass]

RUN:chtab key=xcatsslversion site.value=TLSv1_2

[chtab key=xcatsslversion site.value=TLSv1_2] Running Time:0 sec
RETURN: rc = 0
OUTPUT:
CHECK:rc == 0   [Pass]

RUN:lsdef -t site -i xcatsslversion -c | grep '=TLSv1_2$'

[lsdef -t site -i xcatsslversion -c | grep '=TLSv1_2$'] Running Time:1 sec
RETURN: rc = 0
OUTPUT:
clustersite: xcatsslversion=TLSv1_2
CHECK:rc == 0   [Pass]

RUN:xcatconfig -u

[xcatconfig -u] Running Time:13 sec
RETURN: rc = 0
OUTPUT:
Command failed: type systemctl >/dev/null 2>&1 && systemctl daemon-reload 2>&1. Error message: .

Restarting xcatd                                           [  OK  ]
CHECK:rc == 0   [Pass]

RUN:lsdef -t site -i xcatsslversion -c | grep '=TLSv1_2$'

[lsdef -t site -i xcatsslversion -c | grep '=TLSv1_2$'] Running Time:1 sec
RETURN: rc = 0
OUTPUT:
clustersite: xcatsslversion=TLSv1_2
CHECK:rc == 0   [Pass]

RUN:chtab key=xcatsslversion site.value=TLSv1

[chtab key=xcatsslversion site.value=TLSv1] Running Time:0 sec
RETURN: rc = 0
OUTPUT:
CHECK:rc == 0   [Pass]
------END::xcatconfig_u_check_xcatsslversion_ubuntu::Passed::Time:Tue Oct 25 01:02:39 2016 ::Duration::15 sec------
```
