### PR TITLE
Improve the content in the xCAT kit related command man page, better formatting on RTD 

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/addkit.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/addkit.1.rst
@@ -33,7 +33,7 @@ DESCRIPTION
 
 The \ **addkit**\  command install a kit on the xCAT management node from a kit tarfile or directory, creating xCAT database definitions for kit, kitrepo, kitcomponent.
 
-Note: The xCAT support for Kits is only available for Linux operating systems.
+\ **Note:**\  xCAT Kit support is ONLY available for Linux operating systems.
 
 
 *******
@@ -68,13 +68,13 @@ OPTIONS
 
 \ **-p|--path <path**\ >
  
- The destination directory to which the contents of the kit tarfiles and/or kit deploy dirs will be copied.  When this option is not specified, the default destination directory will be formed from the installdir site attribute with ./kits subdirectory.
+ The destination directory to which the contents of the kit tarfiles and/or kit deploy directories will be copied.  When this option is not specified, the default destination directory will be formed from the installdir site attribute with ./kits subdirectory.
  
 
 
 \ **kitlist**\ 
  
- a comma delimited list of kit_tarball_files and kit_deploy_dirs that are to be added to the xCAT cluster.  Each entry can be an absolute or relative path.  For kit_tarball_files, these must be valid kits tarfiles added.  For kit_deploy_dirs, these must be fully populated directory structures that are identical to the contents of an expanded kit_tarball_file.
+ A comma delimited list of kit_tarball_files and kit_deploy_dirs that are to be added to the xCAT cluster.  Each entry can be an absolute or relative path.  For kit_tarball_files, these must be valid kits tarfiles added.  For kit_deploy_dirs, these must be fully populated directory structures that are identical to the contents of an expanded kit_tarball_file.
  
 
 
@@ -96,38 +96,35 @@ EXAMPLES
 
 1. To add two kits from tarball files.
 
-addkit kit-test1.tar.bz2,kit-test2.tar.bz2
 
-Output is similar to:
+.. code-block:: perl
 
-Kit /kit/kit-test1.tar.bz2,/kit/kit-test2.tar.bz2 was successfully added.
+  addkit kit-test1.tar.bz2,kit-test2.tar.bz2
+
 
 2. To add two kits from directories.
 
-addkit kit-test1,kit-test2
 
-Output is similar to:
+.. code-block:: perl
 
-Kit /kit/kit-test1,/kit/kit-test2 was successfully added.
+  addkit kit-test1,kit-test2
+
 
 3. To add a kit from tarball file to /install/test directory.
 
-addkit -p /install/test kit-test1.tar.bz2
 
-Output is similar to:
+.. code-block:: perl
 
-Kit /kit/kit-test1.tar.bz2 was successfully added.
+  addkit -p /install/test kit-test1.tar.bz2
 
-4. To read the general infomration of the kit, without adding the kits to xCAT DB
 
-addkit -i kit-test1.tar.bz2
+4. To read the general information of the kit, without adding the kits to xCAT DB
 
-Output is similar to:
 
-kitname=xlc-12.1.0.0-Linux
-description=XLC12 for Linux
-version=12.1.0.0
-ostype=Linux
+.. code-block:: perl
+
+  addkit -i kit-test1.tar.bz2
+
 
 
 ********

--- a/docs/source/guides/admin-guides/references/man1/addkitcomp.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/addkitcomp.1.rst
@@ -31,7 +31,7 @@ DESCRIPTION
 
 The \ **addkitcomp**\  command will assign kit components to an xCAT osimage. The kit component meta rpm, package rpm and deploy parameters will be added to osimage's otherpkg.pkglist and postbootscripts will be added to osimages's postbootscripts attribute.
 
-Note: The xCAT support for Kits is only available for Linux operating systems.
+\ **Note:**\  xCAT Kit support is ONLY available for Linux operating systems.
 
 
 *******
@@ -112,48 +112,37 @@ EXAMPLES
 ********
 
 
-1. To assign a kit component to osimage
+1. To add a single kit component to osimage "rhels6.2-ppc64-netboot-compute":
 
-addkitcomp -i rhels6.2-ppc64-netboot-compute comp-test1-1.0-1-rhels-6.2-ppc64
 
-Output is similar to:
+.. code-block:: perl
 
-Assigning kit component comp-test1-1.0-1-rhels-6.2-ppc64 to osimage rhels6.2-ppc64-netboot-compute
-Kit components comp-test1-1.0-1-rhels-6.2-ppc64 were added to osimage rhels6.2-ppc64-netboot-compute successfully
+  addkitcomp -i rhels6.2-ppc64-netboot-compute comp-test1-1.0-1-rhels-6.2-ppc64
 
-2. To assign a kit component to osimage with its dependency.
 
-addkitcomp -a -i rhels6.2-ppc64-netboot-compute comp-test2-1.0-1-rhels-6.2-ppc64
+2. To add a kit component to osimage with dependencies, use the -a (addeps) option:
 
-Output is similar to:
 
-Assigning kit component comp-test1-1.0-1-rhels-6.0-ppc64 to osimage rhels6.2-ppc64-netboot-compute
-Assigning kit component comp-test2-1.0-1-rhels-6.2-ppc64 to osimage rhels6.2-ppc64-netboot-compute
-Kit components comp-test1-1.0-1-rhels-6.0-ppc64,comp-test2-1.0-1-rhels-6.2-ppc64 were added to osimage rhels6.2-ppc64-netboot-compute successfully
+.. code-block:: perl
 
-3. To assign a kit component to osimage with incompatable osarch, osversion or ostype.
+  addkitcomp -a -i rhels6.2-ppc64-netboot-compute comp-test2-1.0-1-rhels-6.2-ppc64
 
-addkitcomp -f -i rhels6.2-ppc64-netboot-compute comp-test1-1.0-1-rhels-6.2-ppc64
 
-Output is similar to:
+3. To add a kit component to osimage with incompatable osarch, osversion or ostype, use the -f (force) option:
 
-Assigning kit component comp-test1-1.0-1-rhels-6.2-ppc64 to osimage rhels6.2-ppc64-netboot-compute
-Kit components comp-test1-1.0-1-rhels-6.2-ppc64 were added to osimage rhels6.2-ppc64-netboot-compute successfully
 
-4. To assign a new version of kit component to osimage without upgrade.
+.. code-block:: perl
 
-addkitcomp -n -i rhels6.2-ppc64-netboot-compute comp-test2-1.0-1-rhels-6.2-ppc64
+  addkitcomp -f -i rhels6.2-ppc64-netboot-compute comp-test1-1.0-1-rhels-6.2-ppc64
 
-Output is similar to:
 
-Assigning kit component comp-test1-1.0-1-rhels-6.0-ppc64 to osimage rhels6.2-ppc64-netboot-compute
-Assigning kit component comp-test2-1.0-1-rhels-6.2-ppc64 to osimage rhels6.2-ppc64-netboot-compute
-Kit components comp-test2-1.0-1-rhels-6.2-ppc64 were added to osimage rhels6.2-ppc64-netboot-compute successfully
+4. To add a new version of kit component to osimage without upgrade, use the -n (noupgrade) option:
 
-The result will be:
-lsdef -t osimage rhels6.2-ppc64-netboot-compute -i kitcomponents
-Object name: rhels6.2-ppc64-netboot-compute
-kitcomponents=comp-test2-1.0-0-rhels-6.2-ppc64,comp-test2-1.0-1-rhels-6.2-ppc64
+
+.. code-block:: perl
+
+  addkitcomp -n -i rhels6.2-ppc64-netboot-compute comp-test2-1.0-1-rhels-6.2-ppc64
+
 
 
 ********

--- a/docs/source/guides/admin-guides/references/man1/bmcdiscover.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/bmcdiscover.1.rst
@@ -11,7 +11,7 @@ NAME
 ****
 
 
-\ **bmcdiscover**\  - Discover bmc using scan method, now scan_method can be nmap.
+\ **bmcdiscover**\  - Discover Baseboard Management Controllers (BMCs) using a scan method
 
 
 ********
@@ -33,13 +33,13 @@ DESCRIPTION
 ***********
 
 
-The \ **bmcdiscover**\  command will discover bmc using scan method.
+The \ **bmcdiscover**\  command will discover Baseboard Management Controllers (BMCs) using a scan mathod.
 
-This command will use nmap scan active nodes, ip range format should be the same format with that is used by nmap.
+The command uses \ **nmap**\  to scan active nodes over a specified IP range.  The IP range format should be a format that is acceptable by \ **nmap**\ .
 
-Note: scan method can only be nmap now, default scan method is nmap.
+The \ **bmcdiscover**\  command can also obtain some information about the BMC. (Check username/password, IP address source, DHCP/static configuration)
 
-This command can check if bmc username or password is correct or not. It can get BMC IP Address source, DHCP Address or static Address.
+Note: The scan method currently support is \ **nmap**\ .
 
 
 *******
@@ -50,37 +50,37 @@ OPTIONS
 
 \ **--range**\ 
  
- Specify one or more IP ranges. Ip ranges should be a string, can pass hostnames, IP addresses, networks, etc. Each can be an ip address (10.1.2.3) or an ip range (10.1.2.0/24). If the range is huge, for example, 192.168.1.1/8, the bmcdiscover may take a very long time to scan. So the range should be exactly specified. For nmap scan method, it accepts multiple formats. For example, 192.168.1.1/24, 40-41.1-2.3-4.1-100, scanme.nmap.org, microsoft.com/24.
+ Specify one or more IP ranges acceptable to nmap.  IP rance can be hostnames, IP addresses, networks, etc.  A single IP address (10.1.2.3) or an IP range (10.1.2.0/24) can be specified.  If the range is very large, the \ **bmcdiscover**\  command may take a long time to return.
  
 
 
 \ **-s**\ 
  
- Scan method, now it is nmap.
+ Scan method  (The only supported scan method at this time is 'nmap')
  
 
 
 \ **-z**\ 
  
- List the stanza formate data.
+ List the data returned in xCAT stanza format
  
 
 
 \ **-w**\ 
  
- Write to the database.
+ Write to the xCAT database
  
 
 
 \ **-t**\ 
  
- Genereate a BMC type node object.
+ Generate a BMC type node object
  
 
 
 \ **-i|--bmcip**\ 
  
- BMC ip.
+ BMC IP
  
 
 
@@ -98,25 +98,25 @@ OPTIONS
 
 \ **-c|--check**\ 
  
- Check.
+ Check
  
 
 
 \ **--ipsource**\ 
  
- BMC IP source.
+ BMC IP source
  
 
 
 \ **-h|--help**\ 
  
- Display usage message.
+ Display usage message
  
 
 
 \ **-v|--version**\ 
  
- Command version.
+ Display version information
  
 
 
@@ -136,16 +136,24 @@ EXAMPLES
 ********
 
 
-1. To get all bmc from ip range
+1. To get all bmc from IP range
 
-bmcdiscover -s nmap --range "10.4.23.100-254 50.3.15.1-2"
+
+.. code-block:: perl
+
+  bmcdiscover -s nmap --range "10.4.23.100-254 50.3.15.1-2"
+
 
 Output is similar to:
 
-10.4.23.254
-50.3.15.1
 
-Note: input for ip range can also be like scanme.nmap.org, microsoft.com/24, 192.168.0.1; 10.0.0-255.1-254.
+.. code-block:: perl
+
+  10.4.23.254
+  50.3.15.1
+
+
+Note: input for IP range can also be like scanme.nmap.org, microsoft.com/24, 192.168.0.1; 10.0.0-255.1-254.
 
 2. After discover bmc, list the stanza format data
 
@@ -153,73 +161,113 @@ bmcdiscover -s nmap --range "10.4.22-23.100-254" -z
 
 Output is similar to:
 
-node10422254:
-        objtype=node
-        groups=all
-        bmc=10.4.22.254
-        cons=ipmi
-        mgt=ipmi
 
-node10423254:
-        objtype=node
-        groups=all
-        bmc=10.4.23.254
-        cons=ipmi
-        mgt=ipmi
+.. code-block:: perl
+
+  node10422254:
+         objtype=node
+         groups=all
+         bmc=10.4.22.254
+         cons=ipmi
+         mgt=ipmi
+ 
+  node10423254:
+         objtype=node
+         groups=all
+         bmc=10.4.23.254
+         cons=ipmi
+         mgt=ipmi
+
 
 3. After discover bmc, write host node definition into the database, and the same time, give out stanza format data
 
-bmcdiscover -s nmap --range "10.4.22-23.100-254" -w
+
+.. code-block:: perl
+
+  bmcdiscover -s nmap --range "10.4.22-23.100-254" -w
+
 
 Output is similar to:
 
-node10422254:
-        objtype=node
-        groups=all
-        bmc=10.4.22.254
-        cons=ipmi
-        mgt=ipmi
 
-node10423254:
-        objtype=node
-        groups=all
-        bmc=10.4.23.254
-        cons=ipmi
-        mgt=ipmi
+.. code-block:: perl
+
+  node10422254:
+         objtype=node
+         groups=all
+         bmc=10.4.22.254
+         cons=ipmi
+         mgt=ipmi
+ 
+  node10423254:
+         objtype=node
+         groups=all
+         bmc=10.4.23.254
+         cons=ipmi
+         mgt=ipmi
+
 
 4. To check if user name or password is correct or not for bmc
 
-bmcdiscover -i 10.4.23.254 -u USERID -p PASSW0RD -c
+
+.. code-block:: perl
+
+  bmcdiscover -i 10.4.23.254 -u USERID -p PASSW0RD -c
+
 
 Output is similar to:
 
-Correct ADMINISTRATOR
 
-bmcdiscover -i 10.4.23.254 -u USERID -p PASSW0RD1 -c
+.. code-block:: perl
 
-Output is similar to:
+  Correct ADMINISTRATOR
+ 
+  bmcdiscover -i 10.4.23.254 -u USERID -p PASSW0RD1 -c
 
-Error: Wrong bmc password
-
-bmcdiscover -i 10.4.23.254 -u USERID1 -p PASSW0RD1 -c
 
 Output is similar to:
 
-Error: Wrong bmc user
 
-bmcdiscover -i 10.4.23.2541234 -u USERID -p PASSW0RD -c
+.. code-block:: perl
+
+  Error: Wrong bmc password
+ 
+  bmcdiscover -i 10.4.23.254 -u USERID1 -p PASSW0RD1 -c
+
 
 Output is similar to:
 
-Error: Not bmc
+
+.. code-block:: perl
+
+  Error: Wrong bmc user
+ 
+  bmcdiscover -i 10.4.23.2541234 -u USERID -p PASSW0RD -c
+
+
+Output is similar to:
+
+
+.. code-block:: perl
+
+  Error: Not bmc
+
 
 5. Get BMC IP Address source, DHCP Address or static Address
 
-bmcdiscover -i 10.4.23.254 -u USERID -p PASSW0RD --ipsource
+
+.. code-block:: perl
+
+  bmcdiscover -i 10.4.23.254 -u USERID -p PASSW0RD --ipsource
+
 
 Output is similar to:
 
-Static Address
+
+.. code-block:: perl
+
+  Static Address
+
 
 
 ********

--- a/docs/source/guides/admin-guides/references/man1/chkkitcomp.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/chkkitcomp.1.rst
@@ -31,9 +31,9 @@ DESCRIPTION
 
 The \ **chkkitcomp**\  command will check if the kit components are compatible with the xCAT osimage.
 
-This command will ignore the current osimage.kitcomponents setting, and just to check if the kitcompname list in the cmdline are compatible with the osimage by osversion/ostype/osarch/ and kit component dependencies.
+This command will ignore the current osimage.kitcomponents setting and check if the kitcompname_list is compatible with the osimage and kit component dependencies.
 
-Note: The xCAT support for Kits is only available for Linux operating systems.
+\ **Note:**\  xCAT Kit support is ONLY available for Linux operating systems.
 
 
 *******
@@ -62,13 +62,13 @@ OPTIONS
 
 \ **-i**\  \ *osimage*\ 
  
- The name of the osimage is used for check.
+ The name of the osimage to check against.
  
 
 
 \ **kitcompname_list**\ 
  
- A comma-delimited list of valid full kit component names or kit component basenames that are to be checking to the osimage.
+ A comma-delimited list of valid full kit component names or kit component basenames that are to be checked against the osimage.
  
 
 
@@ -88,13 +88,13 @@ EXAMPLES
 ********
 
 
-1. To check if a kit component is fitting to an osimage
+1. To check if a kit component , \ *comp-test1-1.0-1-rhels-6.2-ppc64*\  can be added to osimage \ *rhels6.2-ppc64-netboot-compute*\ :
 
-chkkitcomp -i rhels6.2-ppc64-netboot-compute comp-test1-1.0-1-rhels-6.2-ppc64
 
-Output is similar to:
+.. code-block:: perl
 
-Kit components comp-test1-1.0-1-rhels-6.2-ppc64 fit to osimage rhels6.2-ppc64-netboot-compute
+    chkkitcomp -i rhels6.2-ppc64-netboot-compute comp-test1-1.0-1-rhels-6.2-ppc64
+
 
 
 ********

--- a/xCAT-client/pods/man1/addkit.1.pod
+++ b/xCAT-client/pods/man1/addkit.1.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-B<addkit> - Install a kit on the xCAT management node
+B<addkit> - Adds product software Kits to an xCAT cluster environmnet.
 
 =head1 SYNOPSIS
 
@@ -12,9 +12,10 @@ B<addkit> [B<-V>|B<--verbose>] [B<-p>|B<--path> I<path>] I<kitlist>
 
 =head1 DESCRIPTION
 
-The B<addkit> command install a kit on the xCAT management node from a kit tarfile or directory, creating xCAT database definitions for kit, kitrepo, kitcomponent.
+The B<addkit> command installs a kit on the xCAT management node from a kit tarfile or directory.
+It creates xCAT database definitions for the kit, kitrepo, and kitcomponent.
 
-Note: The xCAT support for Kits is only available for Linux operating systems.
+B<Note:> xCAT Kit support is ONLY available for Linux operating systems.
 
 =head1 OPTIONS
 
@@ -36,13 +37,13 @@ Command version.
 
 Show the summary of the given kits
 
-=item B<-p|--path <path>>
+=item B<-p|--path <path>
 
-The destination directory to which the contents of the kit tarfiles and/or kit deploy dirs will be copied.  When this option is not specified, the default destination directory will be formed from the installdir site attribute with ./kits subdirectory.
+The destination directory to which the contents of the kit tarfiles and/or kit deploy directories will be copied.  When this option is not specified, the default destination directory will be formed from the installdir site attribute with ./kits subdirectory.
 
 =item B<kitlist>
 
-a comma delimited list of kit_tarball_files and kit_deploy_dirs that are to be added to the xCAT cluster.  Each entry can be an absolute or relative path.  For kit_tarball_files, these must be valid kits tarfiles added.  For kit_deploy_dirs, these must be fully populated directory structures that are identical to the contents of an expanded kit_tarball_file.
+A comma delimited list of kit_tarball_files or kit_deploy_directories to be added to the xCAT environment. Each entry can be an absolute or relative path.  See xCAT documentation for more information on building kits.
 
 =back
 
@@ -54,40 +55,22 @@ a comma delimited list of kit_tarball_files and kit_deploy_dirs that are to be a
 
 =head1 EXAMPLES
 
-1. To add two kits from tarball files.
+1. To add kits from tarball files:
 
-addkit kit-test1.tar.bz2,kit-test2.tar.bz2
+ addkit kit-test1.tar.bz2,kit-test2.tar.bz2
 
-Output is similar to:
+2. To add kits from directories:
 
-Kit /kit/kit-test1.tar.bz2,/kit/kit-test2.tar.bz2 was successfully added.
+ addkit kit-test1,kit-test2
 
-2. To add two kits from directories.
+3. To add kits from tarball 'kit-test1.tar.bz2' to target path '/install/test':
 
-addkit kit-test1,kit-test2
+ addkit -p /install/test kit-test1.tar.bz2
 
-Output is similar to:
+4. To see general information about kit 'kit-test1.tar.bz2' without adding the kit to xCAT:
 
-Kit /kit/kit-test1,/kit/kit-test2 was successfully added.
+ addkit -i kit-test1.tar.bz2
 
-3. To add a kit from tarball file to /install/test directory.
-
-addkit -p /install/test kit-test1.tar.bz2
-
-Output is similar to:
-
-Kit /kit/kit-test1.tar.bz2 was successfully added.
-
-4. To read the general infomration of the kit, without adding the kits to xCAT DB
-
-addkit -i kit-test1.tar.bz2
-
-Output is similar to:
-
-kitname=xlc-12.1.0.0-Linux
-description=XLC12 for Linux
-version=12.1.0.0
-ostype=Linux
 
 =head1 SEE ALSO
 

--- a/xCAT-client/pods/man1/addkitcomp.1.pod
+++ b/xCAT-client/pods/man1/addkitcomp.1.pod
@@ -12,7 +12,7 @@ B<addkitcomp> [B<-V>|B<--verbose>] [B<-a>|B<--adddeps>] [B<-f>|B<--force>] [B<-n
 
 The B<addkitcomp> command will assign kit components to an xCAT osimage. The kit component meta rpm, package rpm and deploy parameters will be added to osimage's otherpkg.pkglist and postbootscripts will be added to osimages's postbootscripts attribute.
 
-Note: The xCAT support for Kits is only available for Linux operating systems.
+B<Note:> xCAT Kit support is ONLY available for Linux operating systems.
 
 =head1 OPTIONS
 
@@ -66,48 +66,21 @@ A comma-delimited list of valid full kit component names or kit component basena
 
 =head1 EXAMPLES
 
-1. To assign a kit component to osimage
+1. To add a single kit component to osimage "rhels6.2-ppc64-netboot-compute":
 
-addkitcomp -i rhels6.2-ppc64-netboot-compute comp-test1-1.0-1-rhels-6.2-ppc64
+ addkitcomp -i rhels6.2-ppc64-netboot-compute comp-test1-1.0-1-rhels-6.2-ppc64
 
-Output is similar to:
+2. To add a kit component to osimage with dependencies, use the -a (addeps) option:
 
-Assigning kit component comp-test1-1.0-1-rhels-6.2-ppc64 to osimage rhels6.2-ppc64-netboot-compute
-Kit components comp-test1-1.0-1-rhels-6.2-ppc64 were added to osimage rhels6.2-ppc64-netboot-compute successfully
+ addkitcomp -a -i rhels6.2-ppc64-netboot-compute comp-test2-1.0-1-rhels-6.2-ppc64
 
-2. To assign a kit component to osimage with its dependency.
+3. To add a kit component to osimage with incompatable osarch, osversion or ostype, use the -f (force) option: 
 
-addkitcomp -a -i rhels6.2-ppc64-netboot-compute comp-test2-1.0-1-rhels-6.2-ppc64
+ addkitcomp -f -i rhels6.2-ppc64-netboot-compute comp-test1-1.0-1-rhels-6.2-ppc64
 
-Output is similar to:
+4. To add a new version of kit component to osimage without upgrade, use the -n (noupgrade) option:
 
-Assigning kit component comp-test1-1.0-1-rhels-6.0-ppc64 to osimage rhels6.2-ppc64-netboot-compute
-Assigning kit component comp-test2-1.0-1-rhels-6.2-ppc64 to osimage rhels6.2-ppc64-netboot-compute
-Kit components comp-test1-1.0-1-rhels-6.0-ppc64,comp-test2-1.0-1-rhels-6.2-ppc64 were added to osimage rhels6.2-ppc64-netboot-compute successfully
-
-3. To assign a kit component to osimage with incompatable osarch, osversion or ostype.
-
-addkitcomp -f -i rhels6.2-ppc64-netboot-compute comp-test1-1.0-1-rhels-6.2-ppc64
-
-Output is similar to:
-
-Assigning kit component comp-test1-1.0-1-rhels-6.2-ppc64 to osimage rhels6.2-ppc64-netboot-compute
-Kit components comp-test1-1.0-1-rhels-6.2-ppc64 were added to osimage rhels6.2-ppc64-netboot-compute successfully
-
-4. To assign a new version of kit component to osimage without upgrade.
-
-addkitcomp -n -i rhels6.2-ppc64-netboot-compute comp-test2-1.0-1-rhels-6.2-ppc64
-
-Output is similar to:
-
-Assigning kit component comp-test1-1.0-1-rhels-6.0-ppc64 to osimage rhels6.2-ppc64-netboot-compute
-Assigning kit component comp-test2-1.0-1-rhels-6.2-ppc64 to osimage rhels6.2-ppc64-netboot-compute
-Kit components comp-test2-1.0-1-rhels-6.2-ppc64 were added to osimage rhels6.2-ppc64-netboot-compute successfully
-
-The result will be:
-lsdef -t osimage rhels6.2-ppc64-netboot-compute -i kitcomponents
-Object name: rhels6.2-ppc64-netboot-compute
-kitcomponents=comp-test2-1.0-0-rhels-6.2-ppc64,comp-test2-1.0-1-rhels-6.2-ppc64
+ addkitcomp -n -i rhels6.2-ppc64-netboot-compute comp-test2-1.0-1-rhels-6.2-ppc64
 
 
 =head1 SEE ALSO

--- a/xCAT-client/pods/man1/bmcdiscover.1.pod
+++ b/xCAT-client/pods/man1/bmcdiscover.1.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-B<bmcdiscover> - Discover bmc using scan method, now scan_method can be nmap.
+B<bmcdiscover> - Discover Baseboard Management Controllers (BMCs) using a scan method
 
 =head1 SYNOPSIS
 
@@ -14,13 +14,13 @@ B<bmcdiscover> B<-i>|B<--bmcip> I<bmc_ip> [B<-u>|B<--bmcuser> I<bmcusername>] B<
 
 =head1 DESCRIPTION
 
-The B<bmcdiscover> command will discover bmc using scan method.
+The B<bmcdiscover> command will discover Baseboard Management Controllers (BMCs) using a scan mathod.  
 
-This command will use nmap scan active nodes, ip range format should be the same format with that is used by nmap.
+The command uses B<nmap> to scan active nodes over a specified IP range.  The IP range format should be a format that is acceptable by B<nmap>. 
 
-Note: scan method can only be nmap now, default scan method is nmap.
+The B<bmcdiscover> command can also obtain some information about the BMC. (Check username/password, IP address source, DHCP/static configuration)
 
-This command can check if bmc username or password is correct or not. It can get BMC IP Address source, DHCP Address or static Address.
+Note: The scan method currently support is B<nmap>. 
 
 =head1 OPTIONS
 
@@ -28,27 +28,27 @@ This command can check if bmc username or password is correct or not. It can get
 
 =item B<--range>       
 
-Specify one or more IP ranges. Ip ranges should be a string, can pass hostnames, IP addresses, networks, etc. Each can be an ip address (10.1.2.3) or an ip range (10.1.2.0/24). If the range is huge, for example, 192.168.1.1/8, the bmcdiscover may take a very long time to scan. So the range should be exactly specified. For nmap scan method, it accepts multiple formats. For example, 192.168.1.1/24, 40-41.1-2.3-4.1-100, scanme.nmap.org, microsoft.com/24.
+Specify one or more IP ranges acceptable to nmap.  IP rance can be hostnames, IP addresses, networks, etc.  A single IP address (10.1.2.3) or an IP range (10.1.2.0/24) can be specified.  If the range is very large, the B<bmcdiscover> command may take a long time to return. 
 
 =item B<-s>            
 
-Scan method, now it is nmap.
+Scan method  (The only supported scan method at this time is 'nmap')
 
 =item B<-z>            
 
-List the stanza formate data.
+List the data returned in xCAT stanza format
 
 =item B<-w>            
 
-Write to the database.
+Write to the xCAT database
 
 =item B<-t>
 
-Genereate a BMC type node object.
+Generate a BMC type node object
 
 =item B<-i|--bmcip>    
 
-BMC ip.
+BMC IP
 
 =item B<-u|--bmcuser>  
 
@@ -60,19 +60,19 @@ BMC user password.
 
 =item B<-c|--check>    
 
-Check.
+Check
 
 =item B<--ipsource>    
 
-BMC IP source.
+BMC IP source
 
 =item B<-h|--help>
 
-Display usage message.
+Display usage message
 
 =item B<-v|--version>
 
-Command version.
+Display version information
 
 =back
 
@@ -84,16 +84,16 @@ Command version.
 
 =head1 EXAMPLES
 
-1. To get all bmc from ip range
+1. To get all bmc from IP range
 
-bmcdiscover -s nmap --range "10.4.23.100-254 50.3.15.1-2"
+ bmcdiscover -s nmap --range "10.4.23.100-254 50.3.15.1-2"
 
 Output is similar to:
 
-10.4.23.254
-50.3.15.1
+ 10.4.23.254
+ 50.3.15.1
 
-Note: input for ip range can also be like scanme.nmap.org, microsoft.com/24, 192.168.0.1; 10.0.0-255.1-254.
+Note: input for IP range can also be like scanme.nmap.org, microsoft.com/24, 192.168.0.1; 10.0.0-255.1-254.
 
 2. After discover bmc, list the stanza format data
 
@@ -101,14 +101,14 @@ bmcdiscover -s nmap --range "10.4.22-23.100-254" -z
 
 Output is similar to:
 
-node10422254:
+ node10422254:
         objtype=node
         groups=all
         bmc=10.4.22.254
         cons=ipmi
         mgt=ipmi
 
-node10423254:
+ node10423254:
         objtype=node
         groups=all
         bmc=10.4.23.254
@@ -117,18 +117,18 @@ node10423254:
 
 3. After discover bmc, write host node definition into the database, and the same time, give out stanza format data
 
-bmcdiscover -s nmap --range "10.4.22-23.100-254" -w
+ bmcdiscover -s nmap --range "10.4.22-23.100-254" -w
 
 Output is similar to:
 
-node10422254:
+ node10422254:
         objtype=node
         groups=all
         bmc=10.4.22.254
         cons=ipmi
         mgt=ipmi
 
-node10423254:
+ node10423254:
         objtype=node
         groups=all
         bmc=10.4.23.254
@@ -137,37 +137,37 @@ node10423254:
 
 4. To check if user name or password is correct or not for bmc
 
-bmcdiscover -i 10.4.23.254 -u USERID -p PASSW0RD -c
+ bmcdiscover -i 10.4.23.254 -u USERID -p PASSW0RD -c
 
 Output is similar to:
 
-Correct ADMINISTRATOR
+ Correct ADMINISTRATOR
 
-bmcdiscover -i 10.4.23.254 -u USERID -p PASSW0RD1 -c
-
-Output is similar to:
-
-Error: Wrong bmc password
-
-bmcdiscover -i 10.4.23.254 -u USERID1 -p PASSW0RD1 -c
+ bmcdiscover -i 10.4.23.254 -u USERID -p PASSW0RD1 -c
 
 Output is similar to:
 
-Error: Wrong bmc user
+ Error: Wrong bmc password
 
-bmcdiscover -i 10.4.23.2541234 -u USERID -p PASSW0RD -c
+ bmcdiscover -i 10.4.23.254 -u USERID1 -p PASSW0RD1 -c
 
 Output is similar to:
 
-Error: Not bmc
+ Error: Wrong bmc user
+
+ bmcdiscover -i 10.4.23.2541234 -u USERID -p PASSW0RD -c
+
+Output is similar to:
+
+ Error: Not bmc
 
 5. Get BMC IP Address source, DHCP Address or static Address
 
-bmcdiscover -i 10.4.23.254 -u USERID -p PASSW0RD --ipsource
+ bmcdiscover -i 10.4.23.254 -u USERID -p PASSW0RD --ipsource
 
 Output is similar to:
 
-Static Address
+ Static Address
 
 =head1 SEE ALSO
 

--- a/xCAT-client/pods/man1/chkkitcomp.1.pod
+++ b/xCAT-client/pods/man1/chkkitcomp.1.pod
@@ -12,9 +12,9 @@ B<chkkitcomp> [B<-V>|B<--verbose>] B<-i> I<osimage>  I<kitcompname_list>
 
 The B<chkkitcomp> command will check if the kit components are compatible with the xCAT osimage.
 
-This command will ignore the current osimage.kitcomponents setting, and just to check if the kitcompname list in the cmdline are compatible with the osimage by osversion/ostype/osarch/ and kit component dependencies.
+This command will ignore the current osimage.kitcomponents setting and check if the kitcompname_list is compatible with the osimage and kit component dependencies.
 
-Note: The xCAT support for Kits is only available for Linux operating systems.
+B<Note:> xCAT Kit support is ONLY available for Linux operating systems.
 
 =head1 OPTIONS
 
@@ -34,11 +34,11 @@ Command version.
 
 =item B<-i> I<osimage>
 
-The name of the osimage is used for check.
+The name of the osimage to check against.
 
 =item B<kitcompname_list>
 
-A comma-delimited list of valid full kit component names or kit component basenames that are to be checking to the osimage.
+A comma-delimited list of valid full kit component names or kit component basenames that are to be checked against the osimage.
 
 =back
 
@@ -50,13 +50,10 @@ A comma-delimited list of valid full kit component names or kit component basena
 
 =head1 EXAMPLES
 
-1. To check if a kit component is fitting to an osimage
+1. To check if a kit component , I<comp-test1-1.0-1-rhels-6.2-ppc64> can be added to osimage I<rhels6.2-ppc64-netboot-compute>:
 
-chkkitcomp -i rhels6.2-ppc64-netboot-compute comp-test1-1.0-1-rhels-6.2-ppc64
+   chkkitcomp -i rhels6.2-ppc64-netboot-compute comp-test1-1.0-1-rhels-6.2-ppc64
 
-Output is similar to:
-
-Kit components comp-test1-1.0-1-rhels-6.2-ppc64 fit to osimage rhels6.2-ppc64-netboot-compute
 
 
 =head1 SEE ALSO


### PR DESCRIPTION
I'm working with some of the kit related commands so I spent some time to improve the format of the .pod files so they would render a little nicer on RTD. 

Also clean up some of the text wording