### PR TITLE
[FVT]Automation Case: Add xcatd related cases.

### DIFF
--- a/xCAT-test/autotest/testcase/xcatd/case0
+++ b/xCAT-test/autotest/testcase/xcatd/case0
@@ -39,7 +39,7 @@ check:cat /tmp/xcatd_processes.txt | grep "xcatd: Discovery worke" -c
 check:output==1
 check:cat /tmp/xcatd_processes.txt | grep "xcatd: Command log writer" -c
 check:output==1
-cmd:rm -rf /tmp//tmp/xcatd_processes.txt
+cmd:rm -rf /tmp/xcatd_processes.txt
 end
 
 start:xcatd_restart

--- a/xCAT-test/autotest/testcase/xcatd/case0
+++ b/xCAT-test/autotest/testcase/xcatd/case0
@@ -14,19 +14,20 @@ check:output=~[  OK  ]
 cmd:service xcatd status
 check:rc==0
 check:output=~xCAT service is running
-cmd:ps -ef | grep "xcatd: SSL listener" | grep -v grep | wc -l
-check:output==1
-cmd:ps -ef | grep "xcatd: DB Access" | grep -v grep | wc -l
-check:output==1
-cmd:ps -ef | grep "xcatd: UDP listener" | grep -v grep | wc -l
-check:output==1
-cmd:ps -ef | grep "xcatd: install monitor" | grep -v grep | wc -l
-check:output==1
-cmd:ps -ef | grep "xcatd: Discovery worke" | grep -v grep | wc -l
-check:output==1
-cmd:ps -ef | grep "xcatd: Command log writer" | grep -v grep | wc -l
-check:output==1
+cmd:result=`ps -ef | grep "xcatd: SSL listener" | grep -v grep | wc -l`; if [ $result -eq 1 ]; then echo "only one process"; fi
+check:output=~only one process
+cmd:result=`ps -ef | grep "xcatd: DB Access" | grep -v grep | wc -l`; if [ $result -eq 1 ]; then echo "only one process"; fi
+check:output=~only one process
+cmd:result=`ps -ef | grep "xcatd: UDP listener" | grep -v grep | wc -l`; if [ $result -eq 1 ]; then echo "only one process"; fi
+check:output=~only one process
+cmd:result=`ps -ef | grep "xcatd: install monitor" | grep -v grep | wc -l`; if [ $result -eq 1 ]; then echo "only one process"; fi
+check:output=~only one process
+cmd:result=`ps -ef | grep "xcatd: Discovery worke" | grep -v grep | wc -l`; if [ $result -eq 1 ]; then echo "only one process"; fi
+check:output=~only one process
+cmd:result=`ps -ef | grep "xcatd: Command log writer" | grep -v grep | wc -l`; if [ $result -eq 1 ]; then echo "only one process"; fi
+check:output=~only one process
 end
+
 
 start:xcatd_stop
 description:stop xcatd daemon, then check all the 6 processes are stopped

--- a/xCAT-test/autotest/testcase/xcatd/case0
+++ b/xCAT-test/autotest/testcase/xcatd/case0
@@ -1,0 +1,160 @@
+start:xcatd_stop_then_start
+description:stop then start xcatd daemon, and check all the 6 processes status
+os:linux
+cmd:service xcatd status
+check:rc==0
+check:output=~xCAT service is running
+cmd:service xcatd stop
+check:rc==0
+check:output=~Stopping xcatd
+check:output=~[  OK  ]
+cmd:sleep 3
+cmd:service xcatd status
+check:output=~xCAT service is not running
+cmd:ps -ef | grep xcatd
+check:output!~SSL listener
+check:output!~DB Access
+check:output!~UDP listener
+check:output!~install monitor
+check:output!~Discovery worker
+check:output!~Command log writer
+cmd:service xcatd start
+check:rc==0
+check:output=~Starting xcatd
+check:output=~[  OK  ]
+cmd:service xcatd status
+check:rc==0
+check:output=~xCAT service is running
+cmd:ps -ef | grep "xcatd:" > /tmp/xcatd_processes.txt
+check:rc==0
+check:cat /tmp/xcatd_processes.txt | grep "xcatd: SSL listener" -c
+check:output==1
+check:cat /tmp/xcatd_processes.txt | grep "xcatd: DB Access" -c
+check:output==1
+check:cat /tmp/xcatd_processes.txt | grep "xcatd: UDP listener" -c
+check:output==1
+check:cat /tmp/xcatd_processes.txt | grep "xcatd: install monitor" -c
+check:output==1
+check:cat /tmp/xcatd_processes.txt | grep "xcatd: Discovery worke" -c
+check:output==1
+check:cat /tmp/xcatd_processes.txt | grep "xcatd: Command log writer" -c
+check:output==1
+cmd:rm -rf /tmp//tmp/xcatd_processes.txt
+end
+
+start:xcatd_restart
+description:restart xcatd daemon
+os:linux
+cmd:service xcatd status
+check:output=~xCAT service is running
+check:rc==0
+cmd:service xcatd restart
+check:rc==0
+check:output=~Restarting xcatd
+check:output=~[  OK  ]
+cmd:service xcatd restart
+check:rc==0
+check:output=~Restarting xcatd
+check:output=~[  OK  ]
+cmd:service xcatd restart
+check:rc==0
+check:output=~Restarting xcatd
+check:output=~[  OK  ]
+cmd:service xcatd restart
+check:rc==0
+check:output=~Restarting xcatd
+check:output=~[  OK  ]
+cmd:service xcatd restart
+check:rc==0
+check:output=~Restarting xcatd
+check:output=~[  OK  ]
+cmd:service xcatd restart
+check:rc==0
+check:output=~Restarting xcatd
+check:output=~[  OK  ]
+cmd:service xcatd restart
+check:rc==0
+check:output=~Restarting xcatd
+check:output=~[  OK  ]
+cmd:service xcatd restart
+check:rc==0
+check:output=~Restarting xcatd
+check:output=~[  OK  ]
+cmd:service xcatd restart
+check:rc==0
+check:output=~Restarting xcatd
+check:output=~[  OK  ]
+cmd:service xcatd restart
+check:rc==0
+check:output=~Restarting xcatd
+check:output=~[  OK  ]
+cmd:service xcatd status
+check:output=~xCAT service is running
+check:rc==0
+end
+
+start:run_command_with_XCATBYPASS
+description:with XCATBYPASS=YES, the command works either xcatd deamon running or not
+os:linux
+cmd:service xcatd status
+check:rc==0
+check:output=~xCAT service is running
+cmd:XCATBYPASS=YES tabdump site
+check:rc==0
+cmd:service xcatd stop
+check:rc==0
+check:output=~Stopping xcatd
+check:output=~[  OK  ]
+cmd:sleep 3
+cmd:service xcatd status
+check:output=~xCAT service is not running
+cmd:tabdump site
+check:rc!=0
+cmd:XCATBYPASS=YES tabdump site
+check:rc==0
+cmd:service xcatd start
+check:rc==0
+check:output=~Starting xcatd
+check:output=~[  OK  ]
+cmd:service xcatd status
+check:rc==0
+check:output=~xCAT service is running
+end
+
+start:disable_root_permission_in_policy_table
+description:disable root permission, only with XCATBYPASS=YES, the command works 
+os:linux
+cmd:service xcatd status
+check:rc==0
+check:output=~xCAT service is running
+cmd:chtab name=root policy.rule=disable
+check:rc==0
+cmd:lsdef
+check:output=~Error: Permission denied for request
+cmd:XCATBYPASS=YES lsdef
+check:rc==0
+cmd:XCATBYPASS=YES chtab name=root policy.rule=allow
+check:rc==0
+cmd:lsdef
+check:rc==0
+end
+
+start:assign_certain_command_permission
+description:assign root permission to certain command, only this command works 
+os:linux
+cmd:service xcatd status
+check:rc==0
+check:output=~xCAT service is running
+cmd:lsdef
+check:rc==0
+cmd:tabdump policy
+check:rc==0
+cmd:chtab name=root policy.commands=lsdef policy.rule=allow
+check:rc==0
+cmd:lsdef
+check:rc==0 
+cmd:tabdump policy
+check:output=~Error: Permission denied for request
+cmd:chtab name=root policy.commands= policy.rule=allow
+check:rc==0
+end

--- a/xCAT-test/autotest/testcase/xcatd/case0
+++ b/xCAT-test/autotest/testcase/xcatd/case0
@@ -1,5 +1,35 @@
-start:xcatd_stop_then_start
-description:stop then start xcatd daemon, and check all the 6 processes status
+start:xcatd_start
+description:stop then start xcatd daemon, and check all the 6 processes are running
+os:linux
+cmd:service xcatd status
+check:rc==0
+check:output=~xCAT service is running
+cmd:service xcatd stop
+check:rc==0
+cmd:sleep 3
+cmd:service xcatd start
+check:rc==0
+check:output=~Starting xcatd
+check:output=~[  OK  ]
+cmd:service xcatd status
+check:rc==0
+check:output=~xCAT service is running
+cmd:ps -ef | grep "xcatd: SSL listener" | grep -v grep | wc -l
+check:output==1
+cmd:ps -ef | grep "xcatd: DB Access" | grep -v grep | wc -l
+check:output==1
+cmd:ps -ef | grep "xcatd: UDP listener" | grep -v grep | wc -l
+check:output==1
+cmd:ps -ef | grep "xcatd: install monitor" | grep -v grep | wc -l
+check:output==1
+cmd:ps -ef | grep "xcatd: Discovery worke" | grep -v grep | wc -l
+check:output==1
+cmd:ps -ef | grep "xcatd: Command log writer" | grep -v grep | wc -l
+check:output==1
+end
+
+start:xcatd_stop
+description:stop xcatd daemon, then check all the 6 processes are stopped
 os:linux
 cmd:service xcatd status
 check:rc==0
@@ -12,34 +42,14 @@ cmd:sleep 3
 cmd:service xcatd status
 check:output=~xCAT service is not running
 cmd:ps -ef | grep xcatd
-check:output!~SSL listener
-check:output!~DB Access
-check:output!~UDP listener
-check:output!~install monitor
-check:output!~Discovery worker
-check:output!~Command log writer
+check:output!~"xcatd: SSL listener"
+check:output!~"xcatd: DB Access"
+check:output!~"xcatd: UDP listener"
+check:output!~"xcatd: install monitor"
+check:output!~"xcatd: Discovery worke"
+check:output!~"xcatd: Command log writer"
 cmd:service xcatd start
 check:rc==0
-check:output=~Starting xcatd
-check:output=~[  OK  ]
-cmd:service xcatd status
-check:rc==0
-check:output=~xCAT service is running
-cmd:ps -ef | grep "xcatd:" > /tmp/xcatd_processes.txt
-check:rc==0
-check:cat /tmp/xcatd_processes.txt | grep "xcatd: SSL listener" -c
-check:output==1
-check:cat /tmp/xcatd_processes.txt | grep "xcatd: DB Access" -c
-check:output==1
-check:cat /tmp/xcatd_processes.txt | grep "xcatd: UDP listener" -c
-check:output==1
-check:cat /tmp/xcatd_processes.txt | grep "xcatd: install monitor" -c
-check:output==1
-check:cat /tmp/xcatd_processes.txt | grep "xcatd: Discovery worke" -c
-check:output==1
-check:cat /tmp/xcatd_processes.txt | grep "xcatd: Command log writer" -c
-check:output==1
-cmd:rm -rf /tmp/xcatd_processes.txt
 end
 
 start:xcatd_restart
@@ -48,46 +58,8 @@ os:linux
 cmd:service xcatd status
 check:output=~xCAT service is running
 check:rc==0
-cmd:service xcatd restart
+cmd:times=10; while [ $times -gt 0 ]; do service xcatd restart; if [ "$?" -ne "0" ]; then break; fi; ((times--)); done; if [ $times -gt 0 ]; then $?=1; fi
 check:rc==0
-check:output=~Restarting xcatd
-check:output=~[  OK  ]
-cmd:service xcatd restart
-check:rc==0
-check:output=~Restarting xcatd
-check:output=~[  OK  ]
-cmd:service xcatd restart
-check:rc==0
-check:output=~Restarting xcatd
-check:output=~[  OK  ]
-cmd:service xcatd restart
-check:rc==0
-check:output=~Restarting xcatd
-check:output=~[  OK  ]
-cmd:service xcatd restart
-check:rc==0
-check:output=~Restarting xcatd
-check:output=~[  OK  ]
-cmd:service xcatd restart
-check:rc==0
-check:output=~Restarting xcatd
-check:output=~[  OK  ]
-cmd:service xcatd restart
-check:rc==0
-check:output=~Restarting xcatd
-check:output=~[  OK  ]
-cmd:service xcatd restart
-check:rc==0
-check:output=~Restarting xcatd
-check:output=~[  OK  ]
-cmd:service xcatd restart
-check:rc==0
-check:output=~Restarting xcatd
-check:output=~[  OK  ]
-cmd:service xcatd restart
-check:rc==0
-check:output=~Restarting xcatd
-check:output=~[  OK  ]
 cmd:service xcatd status
 check:output=~xCAT service is running
 check:rc==0


### PR DESCRIPTION
@tingtli @daniceexi 
Add 5 xcatd related test cases:
1. Run service xcatd stop; check all process of xcatd have been stopped; service xcatd start; chck all process are started;
2. Run service xcatd restart more than 10 times to make sure xcatd still works well;
3. Stop xcatd, then run xcat command with XCATBYPASS=YES with commands, it works well;
4. If remove the 'root' policy in the policy table, the xcat cmd will fail;
5. If only add permission for certain cmd, check that only this cmd is working but other cmd won't.
