### PR TITLE
Provide 'txc' mode for packimage

### DIFF
--- a/xCAT-server/lib/xcat/plugins/packimage.pm
+++ b/xCAT-server/lib/xcat/plugins/packimage.pm
@@ -388,6 +388,18 @@ sub process_request {
             $excludestr = "cat $xcat_packimg_tmpfile|cpio -H newc -o | $compress -c - > ../rootimg.gz";
         }
         $oldmask = umask 0077;
+    } elsif ($method =~ /txc/) {
+        if ( ! $exlistloc ) {
+            $excludestr = "find . -xdev | tar --selinux --xattr-include='*' -T - -Jcvf ../rootimg.txz";
+        }else {
+            chdir("$rootimg_dir");
+            system("$excludestr >> $xcat_packimg_tmpfile"); 
+            if ($includestr) {
+            	system("$includestr >> $xcat_packimg_tmpfile"); 
+            }
+            $excludestr = "cat $xcat_packimg_tmpfile| tar --selinux --xattr-include='*' -T -Jcvf ../rootimg.txz";
+        }
+        $oldmask = umask 0077;
     } elsif ($method =~ /squashfs/) {
       $temppath = mkdtemp("/tmp/packimage.$$.XXXXXXXX");
       chmod 0755,$temppath;

--- a/xCAT-server/share/xcat/netboot/rh/dracut/install.netboot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut/install.netboot
@@ -1,6 +1,6 @@
 #!/bin/sh
 echo $drivers
-dracut_install wget cpio gzip dash  modprobe touch echo cut wc 
+dracut_install wget tar xz cpio gzip dash  modprobe touch echo cut wc 
 dracut_install -o ctorrent
 dracut_install grep ifconfig hostname awk egrep grep dirname expr
 dracut_install mount.nfs

--- a/xCAT-server/share/xcat/netboot/rh/dracut/install.statelite
+++ b/xCAT-server/share/xcat/netboot/rh/dracut/install.statelite
@@ -1,6 +1,6 @@
 #!/bin/sh
 echo $drivers
-dracut_install wget cpio gzip dash  modprobe wc touch echo cut
+dracut_install wget tar xz cpio gzip dash  modprobe wc touch echo cut
 dracut_install -o ctorrent
 dracut_install grep ifconfig hostname awk egrep grep dirname expr
 dracut_install parted mke2fs bc mkswap swapon chmod

--- a/xCAT-server/share/xcat/netboot/rh/dracut/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut/xcatroot
@@ -77,6 +77,19 @@ elif [ -r /rootimg.gz ]; then
   fi
   $NEWROOT/etc/init.d/localdisk
   echo Done
+elif [ -r /rootimg.txz ]; then
+  echo Setting up RAM-root tmpfs.
+  if [ -z $rootlimit ];then
+    mount -t tmpfs -o mode=755 rootfs $NEWROOT
+  else
+    mount -t tmpfs -o mode=755,size=$rootlimit rootfs $NEWROOT
+  fi
+
+  cd $NEWROOT
+  echo -n "Extracting root filesystem:"
+  tar -Jxvf /rootimg.txz
+  $NEWROOT/etc/init.d/localdisk
+  echo Done
 elif [ -r /rootimg-statelite.gz ]; then
   echo Setting up RAM-root tmpfs for statelite mode.
  

--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
@@ -89,6 +89,19 @@ elif [ -r /rootimg.gz ]; then
   $NEWROOT/etc/init.d/localdisk
   [  "$xcatdebugmode" = "1" ] &&  logger -t xcat -p debug "Done...."
   echo Done
+elif [ -r /rootimg.txz ]; then
+  echo Setting up RAM-root tmpfs.
+  if [ -z $rootlimit ];then
+    mount -t tmpfs -o mode=755 rootfs $NEWROOT
+  else
+    mount -t tmpfs -o mode=755,size=$rootlimit rootfs $NEWROOT
+  fi
+
+  cd $NEWROOT
+  echo -n "Extracting root filesystem:"
+  tar -Jxvf /rootimg.txz
+  $NEWROOT/etc/init.d/localdisk
+  echo Done
 elif [ -r /rootimg-statelite.gz ]; then
   echo Setting up RAM-root tmpfs for statelite mode.
  


### PR DESCRIPTION
tar.xz files will preserve an increasing number of things cpio will
not.  For now, implement for EL7 type oses to explore before making
it more widespread.