### PR TITLE
man page changes to remove xcatconfig without any flags and fix EXAMPL

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/chdef.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/chdef.1.rst
@@ -72,7 +72,7 @@ OPTIONS
 \ **-n**\  \ *new-name*\ 
  
  Change the current object name to the new-name which is specified by the -n option.
- Objects of type site and monitoring cannot be renamed with the -n option.
+ Objects of type site, group and monitoring cannot be renamed with the -n option.
  Note: For the \ **-n**\  option, only one node can be specified. For some special nodes such as fsp, bpa, frame, cec etc., their name is referenced in their own hcp attribute, or the hcp attribute of other nodes. If you use \ **-n**\  option, you must manually change all hcp attributes that refer to this name.
  
 

--- a/docs/source/guides/admin-guides/references/man8/xcatconfig.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/xcatconfig.8.rst
@@ -19,8 +19,6 @@ SYNOPSIS
 ********
 
 
-\ **xcatconfig**\ 
-
 \ **xcatconfig**\  {\ **-h**\ |\ **--help**\ }
 
 \ **xcatconfig**\  {\ **-v**\ |\ **--version**\ }
@@ -131,43 +129,63 @@ EXAMPLES
 
 
 
-\*
+1.
  
  To force regeneration of keys and credentials and reinitialize the site table:
  
- \ **xcatconfig**\  \ *-f*\ 
+ 
+ .. code-block:: perl
+ 
+   xcatconfig -f
+ 
  
 
 
-\*
+2.
  
  To regenerate root's ssh keys:
  
- \ **xcatconfig**\  \ *-k*\ 
+ 
+ .. code-block:: perl
+ 
+   xcatconfig -k
+ 
  
 
 
-\*
+3.
  
  To regenerate node host ssh keys:
  
- \ **xcatconfig**\  \ *-s*\ 
+ 
+ .. code-block:: perl
+ 
+   xcatconfig -s
+ 
  
 
 
-\*
+4.
  
  To regenerate node host ssh keys and credentials:
  
- \ **xcatconfig**\  \ *-s*\  \ *-c*\ 
+ 
+ .. code-block:: perl
+ 
+   xcatconfig -s -c
+ 
  
 
 
-\*
+5.
  
  To add the Management Node to the DB:
  
- \ **xcatconfig**\  \ *-m*\ 
+ 
+ .. code-block:: perl
+ 
+   xcatconfig -m
+ 
  
 
 

--- a/xCAT-client/pods/man8/xcatconfig.8.pod
+++ b/xCAT-client/pods/man8/xcatconfig.8.pod
@@ -4,8 +4,6 @@ B<xcatconfig> - Sets up the  Management Node during the xCAT install.
 
 =head1 SYNOPSIS
 
-B<xcatconfig> 
-
 B<xcatconfig> {B<-h>|B<--help>}
 
 B<xcatconfig> {B<-v>|B<--version>}
@@ -84,34 +82,34 @@ This option will set tunable parameters on the Management and Service nodes reco
 
 =over 2
 
-=item *
+=item 1.
 
 To force regeneration of keys and credentials and reinitialize the site table:
 
-B<xcatconfig> I<-f>
+ xcatconfig -f
 
-=item *
+=item 2.
 
 To regenerate root's ssh keys:
 
-B<xcatconfig> I<-k>
+ xcatconfig -k
 
-=item *
+=item 3.
 
 To regenerate node host ssh keys:
 
-B<xcatconfig> I<-s>
+ xcatconfig -s
 
-=item *
+=item 4.
 
 To regenerate node host ssh keys and credentials:
 
-B<xcatconfig> I<-s> I<-c>
+ xcatconfig -s -c
 
-=item *
+=item 5.
 
 To add the Management Node to the DB:
 
-B<xcatconfig> I<-m> 
+ xcatconfig -m 
 
 =back


### PR DESCRIPTION
Fixes related to #676 
1. Removed xcatconfig without flags from xcatconfig man page
2. Sync of xcatfonfig.rst with man page
3. Sync of chdef.rst with man page