### PR TITLE
man page fixes for man8 section

### DIFF
--- a/create_man_pages.py
+++ b/create_man_pages.py
@@ -80,7 +80,22 @@ def cleanup_db_man_pages_dir():
     shutil.rmtree("perl-xCAT/pods")
     shutil.rmtree("perl-xCAT/share")
 
-   
+def fix_vertical_bar(rst_file):
+    print "Removing | from file %s, version %s" %(rst_file, man_ver)
+    # Verical bar can not appear with spaces around it, otherwise
+    # it gets displayed as a link in .html
+    sed_cmd = "sed 's/\*\*\\\ |\\\ \*\*/ | /g' %s > %s.sed1" %(rst_file, rst_file)
+    os.system(sed_cmd)
+
+def fix_double_dash(rst_file):
+    print "Fixing -- in file %s, version %s" %(rst_file, man_ver)
+    # -- gets displayed in .html as a sinle long dash, need to insert
+    # a non bold space between 2 dashes
+    sed_cmd = "sed 's/--/-\*\*\\\ \*\*-/g' %s.sed1 > %s" %(rst_file, rst_file)
+    os.system(sed_cmd)
+    #remove intermediate .sed1 file
+    rm_sed1file_cmd = "rm %s.sed1" %(rst_file)
+    os.system(rm_sed1file_cmd)   
 
 build_db_man_pages()
 
@@ -119,6 +134,9 @@ for component in COMPONENTS:
                 cmd += " --infile=%s --outfile=%s --title=%s.%s" %(pod_input, rst_output, title, man_ver)
                 print cmd 
                 os.system(cmd)
+		if man_ver == '8':
+                    fix_vertical_bar(rst_output)
+                    fix_double_dash(rst_output)
 
 cleanup_db_man_pages_dir()
 

--- a/docs/source/guides/admin-guides/references/man8/chtab.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/chtab.8.rst
@@ -19,15 +19,15 @@ SYNOPSIS
 ********
 
 
-\ *chtab [-h| --help]*\ 
+\ **chtab**\  [\ **-h**\  | \ **-**\ **-help**\ ]
 
-\ *chtab [-v| --version]*\ 
+\ **chtab**\  [\ **-v**\  | \ **-**\ **-version**\ ]
 
-\ *chtab [keycolname=keyvalue] [tablename.colname=newvalue] *\ 
+\ **chtab**\  [\ *keycolname=keyvalue*\ ] [\ *tablename.colname=newvalue*\ ]
 
-\ *chtab [keycolname=keyvalue] [tablename.colname+=newvalue] *\ 
+\ **chtab**\  [\ *keycolname=keyvalue*\ ] [\ *tablename.colname+=newvalue*\ ]
 
-\ *chtab -d [keycolname=keyvalue] [tablename.colname=newvalue] *\ 
+\ **chtab -d**\  [\ *keycolname=keyvalue*\ ] [\ *tablename.colname=newvalue*\ ]
 
 
 ***********
@@ -55,9 +55,14 @@ RETURN VALUE
 ************
 
 
-0 The command completed successfully.
 
-1 An error has occurred.
+0.  The command completed successfully.
+
+
+
+1.  An error has occurred.
+
+
 
 
 ********
@@ -65,29 +70,66 @@ EXAMPLES
 ********
 
 
-1. To add a node=node1 to the nodelist table with groups=all:
 
-\ *chtab  node=node1 nodelist.groups=all *\ 
+1.  To add a node=node1 to the nodelist table with groups=all:
+ 
+ 
+ .. code-block:: perl
+ 
+   chtab  node=node1 nodelist.groups=all
+ 
+ 
+
 
 2. To add a keyword (tftpdir) and value (/tftpboot) to the site table:
+ 
+ 
+ .. code-block:: perl
+ 
+   chtab  key=tftpdir site.value=/tftpboot
+ 
+ 
 
-\ *chtab  key=tftpdir site.value=/tftpboot *\ 
 
-3. To add node1 to the  nodetype table with os=rhel5:
+3.  To add node1 to the  nodetype table with os=rhel5:
+ 
+ 
+ .. code-block:: perl
+ 
+   chtab  node=node1 nodetype.os=rhel5
+ 
+ 
 
-\ *chtab  node=node1 nodetype.os=rhel5*\ 
 
-4. To change node1 in nodetype table setting os=sles:
+4.  To change node1 in nodetype table setting os=sles:
+ 
+ 
+ .. code-block:: perl
+ 
+   chtab  node=node1 nodetype.os=sles
+ 
+ 
 
-\ *chtab  node=node1 nodetype.os=sles*\ 
 
 5. To change node1 by appending otherpkgs to the postbootscripts field in the postscripts table:
+ 
+ 
+ .. code-block:: perl
+ 
+   chtab node=node1 postscripts.postbootscripts+=otherpkgs
+ 
+ 
 
-\ *chtab node=node1 postscripts.postbootscripts+=otherpkgs*\ 
 
 6. To delete node1 from nodetype table:
+ 
+ 
+ .. code-block:: perl
+ 
+   chtab -d node=node1 nodetype
+ 
+ 
 
-\ *chtab -d node=node1 nodetype*\ 
 
 
 *****

--- a/docs/source/guides/admin-guides/references/man8/copycds.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/copycds.8.rst
@@ -19,11 +19,11 @@ SYNOPSIS
 ********
 
 
-\ **copycds**\  [{\ **-n|--name|--osver**\ }=\ *distroname*\ ] [{\ **-a|--arch**\ }=\ *architecture*\ ] [{\ **-p|--path**\ }=\ *ospkgpath*\ ] [\ **-o**\ |\ **--noosimage**\ ] [\ **-w**\ |\ **--nonoverwrite**\ ] {\ *iso*\ |\ *device-path*\ } ...
+\ **copycds**\  [{\ **-n|-**\ **-name|-**\ **-osver**\ }=\ *distroname*\ ] [{\ **-a|-**\ **-arch**\ }=\ *architecture*\ ] [{\ **-p|-**\ **-path**\ }=\ *ospkgpath*\ ] [\ **-o | -**\ **-noosimage**\ ] [\ **-w | -**\ **-nonoverwrite**\ ] {\ *iso | device-path*\ } ...
 
-\ **copycds**\  [\ **-i**\ |\ **--inspection**\ ] {\ *iso*\ |\ *device-path*\ }
+\ **copycds**\  [\ **-i | -**\ **-inspection**\ ] {\ *iso | device-path*\ }
 
-\ **copycds**\  [\ **-h**\ |\ **--help**\ ]
+\ **copycds**\  [\ **-h | -**\ **-help**\ ]
 
 
 ***********
@@ -33,7 +33,7 @@ DESCRIPTION
 
 The \ **copycds**\  command copies all contents of Distribution DVDs/ISOs or Service Pack DVDs/ISOs to a destination directory. The destination directory can be specified by the -p option. If no path is specified, the default destination directory will be formed from the \ **installdir**\  site attribute and the distro name and architecture, for example: /install/rhels6.3/x86_64. The \ **copycds**\  command can copy from one or more ISO files, or the CD/DVD device path.
 
-You can specify -i or --inspection option to check whether the DVDs/ISOs can be recognized by xCAT. If recognized, the distribution name, architecture and the disc no (the disc sequence number of DVDs/ISOs in multi-disk distribution) of the DVD/ISO is displayed. If xCAT doesn't recognize the DVD/ISO, you must manually specify the distro name and architecture using the -n and -a options. This is sometimes the case for distros that have very recently been released, and the xCAT code hasn't been updated for it yet.
+You can specify \ **-i**\  or \ **-**\ **-inspection**\  option to check whether the DVDs/ISOs can be recognized by xCAT. If recognized, the distribution name, architecture and the disc no (the disc sequence number of DVDs/ISOs in multi-disk distribution) of the DVD/ISO is displayed. If xCAT doesn't recognize the DVD/ISO, you must manually specify the distro name and architecture using the -n and -a options. This is sometimes the case for distros that have very recently been released, and the xCAT code hasn't been updated for it yet.
 
 You can get xCAT to recognize new DVDs/ISOs by adding them to /opt/xcat/lib/perl/xCAT/data/discinfo.pm and reloading xcatd (service xcatd reload).
 
@@ -44,37 +44,37 @@ OPTIONS
 
 
 
-{\ **-n|--name|--osver**\ }=\ *distroname*\ 
+\ **-n|-**\ **-name|-**\ **-osver**\ =\ *distroname*\ 
  
  The linux distro name and version that the ISO/DVD contains.  Examples:  rhels6.3, sles11.2, fedora9.  Note the 's' in rhels6.3 which denotes the Server version of RHEL, which is typically used.
  
 
 
-{\ **-a|--arch**\ }=\ *architecture*\ 
+\ **-a|-**\ **-arch**\ =\ *architecture*\ 
  
  The architecture of the linux distro on the ISO/DVD.  Examples:  x86, x86_64, ppc64, s390x.
  
 
 
-{\ **-p|--path**\ }=\ *ospkgpath*\ 
+\ **-p|-**\ **-path**\ =\ *ospkgpath*\ 
  
  The destination directory to which the contents of ISO/DVD will be copied. When this option is not specified, the default destination directory will be formed from the \ **installdir**\  site attribute and the distro name and architecture, for example: /install/rhel6.3/x86_64. This option is only supported distributions of sles,redhat and windows.
  
 
 
-{\ **-i|--inspection**\ }
+\ **-i|-**\ **-inspection**\ 
  
  Check whether xCAT can recognize the DVDs/ISOs in the argument list, but do not copy the disc. Displays the os distribution name, architecture and disc no of each recognized DVD/ISO. This option only supported for distributions of sles,redhat and windows.
  
 
 
-{\ **-o|--noosimage**\ }
+\ **-o|-**\ **-noosimage**\ 
  
  Do not create the default osimages based on the osdistro copied in. By default, copycds will create a set of osimages based on the osdistro.
  
 
 
-{\ **-w|--nonoverwrite**\ }
+\ **-w|-**\ **-nonoverwrite**\ 
  
  Complain and exit if the os disc has already been copied in. By default, copycds will overwrite the os disc already copied in.
  
@@ -86,9 +86,9 @@ RETURN VALUE
 ************
 
 
-0: The command completed successfully. For the --inspection option, the ISO/DVD have been recognized successfully
+0: The command completed successfully. For the \ **-**\ **-inspection**\  option, the ISO/DVD have been recognized successfully
 
-Nonzero: An Error has occurred. For the --inspection option, the ISO/DVD cannot be recognized
+Nonzero: An Error has occurred. For the \ **-**\ **-inspection**\  option, the ISO/DVD cannot be recognized
 
 
 ********
@@ -97,9 +97,7 @@ EXAMPLES
 
 
 
-\*
- 
- To copy the RPMs from a set of ISOs that represent the DVDs of a distro:
+1. To copy the RPMs from a set of ISOs that represent the DVDs of a distro:
  
  
  .. code-block:: perl
@@ -109,9 +107,7 @@ EXAMPLES
  
 
 
-\*
- 
- To copy the RPMs from a physical DVD to /depot/kits/3 directory:
+2. To copy the RPMs from a physical DVD to /depot/kits/3 directory:
  
  
  .. code-block:: perl
@@ -121,9 +117,7 @@ EXAMPLES
  
 
 
-\*
- 
- To copy the RPMs from a DVD ISO of a very recently released distro:
+3. To copy the RPMs from a DVD ISO of a very recently released distro:
  
  
  .. code-block:: perl
@@ -133,9 +127,7 @@ EXAMPLES
  
 
 
-\*
- 
- To check whether a DVD ISO can be recognized by xCAT and display the recognized disc info:
+4. To check whether a DVD ISO can be recognized by xCAT and display the recognized disc info:
  
  
  .. code-block:: perl
@@ -158,9 +150,7 @@ EXAMPLES
  
 
 
-\*
- 
- To copy the packages from a supplemental DVD ISO file:
+5. To copy the packages from a supplemental DVD ISO file:
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man8/makeconservercf.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/makeconservercf.8.rst
@@ -19,15 +19,15 @@ SYNOPSIS
 ********
 
 
-\ **makeconservercf**\  [\ **-V|--verbose**\ ] [\ **-d|--delete**\ ] \ *noderange*\ 
+\ **makeconservercf**\  [\ **-V|-**\ **-verbose**\ ] [\ **-d|-**\ **-delete**\ ] \ *noderange*\ 
 
-\ **makeconservercf**\  [\ **-V|--verbose**\ ] [\ **-l|--local**\ ] [\ *noderange*\ ]
+\ **makeconservercf**\  [\ **-V|-**\ **-verbose**\ ] [\ **-l|-**\ **-local**\ ] [\ *noderange*\ ]
 
-\ **makeconservercf**\  [\ **-V|--verbose**\ ] [\ **-c|--conserver**\ ] [\ *noderange*\ ]
+\ **makeconservercf**\  [\ **-V|-**\ **-verbose**\ ] [\ **-c|-**\ **-conserver**\ ] [\ *noderange*\ ]
 
-\ **makeconservercf**\  [\ **-V|--verbose**\ ] \ *noderange*\  [\ **-t|--trust**\ ] \ *hosts*\ 
+\ **makeconservercf**\  [\ **-V|-**\ **-verbose**\ ] \ *noderange*\  [\ **-t|-**\ **-trust**\ ] \ *hosts*\ 
 
-\ **makeconservercf**\  [\ **-h|--help|-v|--version**\ ]
+\ **makeconservercf**\  [\ **-h|-**\ **-help|-v|-**\ **-version**\ ]
 
 
 ***********
@@ -52,46 +52,46 @@ OPTIONS
 
 
 
-\ **-d|--delete**\ 
+\ **-d|-**\ **-delete**\ 
  
  Delete rather than add or refresh the nodes specified as a noderange.
  
 
 
-\ **-c|--conserver**\ 
+\ **-c|-**\ **-conserver**\ 
  
  Only set up the conserver on the conserver host. If no conserver host
  is set for nodes, the conserver gets set up only on the management node.
  
 
 
-\ **-l|--local**\ 
+\ **-l|-**\ **-local**\ 
  
  Only run \ **makeconservercf**\  locally and create the local /etc/conserver.cf.  The default is to also
  run it on all service nodes, if there are any.
  
 
 
-\ **-t|--trust**\  \ *hosts*\ 
+\ **-t|-**\ **-trust**\  \ *hosts*\ 
  
  Add additional trusted hosts into /etc/conserver.cf. The \ *hosts*\  are comma separated list of
  ip addresses or host names.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Display version.
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Verbose mode.
  
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  
@@ -103,9 +103,14 @@ RETURN VALUE
 ************
 
 
-0 The command completed successfully.
 
-1 An error has occurred.
+0.  The command completed successfully.
+
+
+
+1.  An error has occurred.
+
+
 
 
 ********
@@ -114,9 +119,7 @@ EXAMPLES
 
 
 
-1.
- 
- To create conserver configuration for all the nodes.
+1. To create conserver configuration for all the nodes.
  
  
  .. code-block:: perl
@@ -126,9 +129,7 @@ EXAMPLES
  
 
 
-2.
- 
- To create conserver configuration for nodes node01-node10.
+2. To create conserver configuration for nodes node01-node10.
  
  
  .. code-block:: perl
@@ -138,9 +139,7 @@ EXAMPLES
  
 
 
-3.
- 
- To remove conserver configuration for node01.
+3. To remove conserver configuration for node01.
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man8/makedhcp.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/makedhcp.8.rst
@@ -19,19 +19,19 @@ SYNOPSIS
 ********
 
 
-\ **makedhcp**\  \ **-n**\  [\ **-l**\ |\ **--localonly**\ ]
+\ **makedhcp**\  \ **-n**\  [\ **-l | -**\ **-localonly**\ ]
 
-\ **makedhcp**\  \ **-a**\  [\ **-l**\ |\ **--localonly**\ ]
+\ **makedhcp**\  \ **-a**\  [\ **-l | -**\ **-localonly**\ ]
 
-\ **makedhcp**\  \ **-a -d**\  [\ **-l**\ |\ **--localonly**\ ]
+\ **makedhcp**\  \ **-a -d**\  [\ **-l | -**\ **-localonly**\ ]
 
-\ **makedhcp**\  \ **-d**\  \ *noderange*\  [\ **-l**\ |\ **--localonly**\ ]
+\ **makedhcp**\  \ **-d**\  \ *noderange*\  [\ **-l | -**\ **-localonly**\ ]
 
-\ **makedhcp**\  \ *noderange*\  [\ **-s**\  \ *statements*\ ] [\ **-l**\ |\ **--localonly**\ ]
+\ **makedhcp**\  \ *noderange*\  [\ **-s**\  \ *statements*\ ] [\ **-l | -**\ **-localonly**\ ]
 
 \ **makedhcp**\  \ **-q**\  \ *noderange*\ 
 
-\ **makedhcp**\  [\ *-h|--help*\ ]
+\ **makedhcp**\  \ **[-h|-**\ **-help]**\ 
 
 
 ***********
@@ -123,7 +123,7 @@ OPTIONS
  
 
 
-\ **-l**\ |\ **--localonly**\ 
+\ **-l | -**\ **-localonly**\ 
  
  Configure dhcpd on the local machine only.  Without this option, makedhcp will also send this
  operation to any service nodes that service the nodes in the noderange.
@@ -136,7 +136,7 @@ OPTIONS
  
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  
@@ -148,9 +148,14 @@ RETURN VALUE
 ************
 
 
-0 The command completed successfully.
 
-1 An error has occurred.
+0. The command completed successfully.
+
+
+
+1.  An error has occurred.
+
+
 
 
 ********
@@ -159,9 +164,7 @@ EXAMPLES
 
 
 
-1.
- 
- Create a new DHCP configuration file and add the network definitions:
+1. Create a new DHCP configuration file and add the network definitions:
  
  
  .. code-block:: perl
@@ -171,9 +174,7 @@ EXAMPLES
  
 
 
-2.
- 
- Define all nodes to the dhcp server:
+2. Define all nodes to the dhcp server:
  
  
  .. code-block:: perl
@@ -185,9 +186,7 @@ EXAMPLES
  
 
 
-3.
- 
- Will cause dhcp on the next request to set root-path appropriately for only node5.  Note some characters (e.g. ") must be doubly escaped (once for the shell, and once for the OMAPI layer).
+3. Will cause dhcp on the next request to set root-path appropriately for only node5.  Note some characters (e.g. ") must be doubly escaped (once for the shell, and once for the OMAPI layer).
  
  
  .. code-block:: perl
@@ -197,9 +196,7 @@ EXAMPLES
  
 
 
-4.
- 
- Query a node from the DHCP server.
+4. Query a node from the DHCP server.
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man8/makedns.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/makedns.8.rst
@@ -19,11 +19,11 @@ SYNOPSIS
 ********
 
 
-\ **makedns**\  [\ *-h*\ |\ *--help*\ ]
+\ **makedns**\  [\ **-h | -**\ **-help**\ ]
 
-\ **makedns**\  [-V|--verbose] [-e|--external] [\ *-n*\ |\ *--new*\ ] [\ *noderange*\ ]
+\ **makedns**\  [\ **-V | -**\ **-verbose**\ ] [\ **-e | -**\ **-external**\ ] [\ **-n | -**\ **-new**\ ] [\ *noderange*\ ]
 
-\ **makedns**\  [-V|--verbose] [-e|--external] [\ *-d*\ |\ *--delete*\  \ *noderange*\ ]
+\ **makedns**\  [\ **-V | -**\ **-verbose**\ ] [\ **-e | -**\ **-external**\ ] [\ **-d | -**\ **-delete**\  \ *noderange*\ ]
 
 
 ***********
@@ -59,25 +59,25 @@ OPTIONS
 
 
 
-\ **-V**\ |\ **--verbose**\ 
+\ **-V | -**\ **-verbose**\ 
  
  Verbose mode.
  
 
 
-\ **-n**\ |\ **--new**\ 
+\ **-n | -**\ **-new**\ 
  
  Use this flag to create new named configuration and db files.
  
 
 
-\ **-d**\ |\ **--delete**\ 
+\ **-d | -**\ **-delete**\ 
  
  Remove the DNS records.
  
 
 
-\ **-e**\ |\ **--external**\ 
+\ **-e | -**\ **-external**\ 
  
  Update DNS records to the external DNS server listed in /etc/resolv.conf.
  
@@ -98,35 +98,43 @@ Examples
 
 
 
-1
+1. To set up DNS for all the hosts in /etc/hosts file.
  
- To set up DNS for all the hosts in /etc/hosts file.
  
- \ **makedns**\ 
+ .. code-block:: perl
  
-
-
-2
+   makedns
  
- To set up DNS for \ *node1*\ .
- 
- \ **makedns**\  \ *node1*\ 
  
 
 
-3
+2. To set up DNS for \ *node1*\ .
  
- To create a new named configuration and db files for all hosts in /etc/hosts.
  
- \ **makedns**\  \ **-n**\ 
+ .. code-block:: perl
+ 
+   makedns node1
+ 
  
 
 
-4
+3. To create a new named configuration and db files for all hosts in /etc/hosts.
  
- To delete the DNS records for \ *node1*\ .
  
- \ **makedns**\  \ **-d**\  \ *node1*\ 
+ .. code-block:: perl
+ 
+   makedns -n
+ 
+ 
+
+
+4. To delete the DNS records for \ *node1*\ .
+ 
+ 
+ .. code-block:: perl
+ 
+   makedns -d node1
+ 
  
 
 

--- a/docs/source/guides/admin-guides/references/man8/makehosts.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/makehosts.8.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **makehosts**\  [\ **-n**\ ] [\ *noderange*\ ] [\ **-l**\ |\ **--longnamefirst**\ ] [\ **-d**\ ] [\ **-m**\ |\ **--mactolinklocal**\ ]
+\ **makehosts**\  [\ **-n**\ ] [\ *noderange*\ ] [\ **-l | -**\ **-longnamefirst**\ ] [\ **-d**\ ] [\ **-m | -**\ **-mactolinklocal**\ ]
 
-\ **makehosts**\  {\ **-h**\ |\ **--help**\ }
+\ **makehosts**\  {\ **-h | -**\ **-help**\ }
 
 
 ***********
@@ -56,7 +56,7 @@ OPTIONS
  
 
 
-\ **-l**\ |\ **--longnamefirst**\ 
+\ **-l | -**\ **-longnamefirst**\ 
  
  The FQDN (Fully Qualified Domain Name) of the host will appear before the PQDN (Partially Qualified Domain Name) for each host in the /etc/hosts file.
  The default is PQDN first.
@@ -64,7 +64,7 @@ OPTIONS
  
 
 
-\ **-m**\ |\ **--mactolinklocal**\ 
+\ **-m | -**\ **-mactolinklocal**\ 
  
  Updates /etc/hosts file with IPv6 link local addresses, the link local address is generated 
  from the mac address stored in mac table.
@@ -84,9 +84,7 @@ EXAMPLES
 
 
 
-\*
- 
- Add entries to /etc/hosts for all nodes included in the xCAT node group called "compute".
+1. Add entries to /etc/hosts for all nodes included in the xCAT node group called "compute".
  
  
  .. code-block:: perl
@@ -96,9 +94,7 @@ EXAMPLES
  
 
 
-\*
- 
- If the xCAT hosts table contains:
+2. If the xCAT hosts table contains:
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man8/makeknownhosts.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/makeknownhosts.8.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **makeknownhosts**\  \ *noderange*\  [\ **-r**\ |\ **--remove**\ ] [\ **-V**\ |\ **--verbose**\ ]
+\ **makeknownhosts**\  \ *noderange*\  [\ **-r | -**\ **-remove**\ ] [\ **-V | -**\ **-verbose**\ ]
 
-\ **makeknownhosts**\  {\ **-h**\ |\ **--help**\ }
+\ **makeknownhosts**\  [\ **-h | -**\ **-help**\ ]
 
 
 ***********
@@ -53,13 +53,13 @@ OPTIONS
  
 
 
-\ **-r|--remove**\ 
+\ **-r|-**\ **-remove**\ 
  
  Only removes the entries for the nodes from the known_hosts file.
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Verbose mode.
  
@@ -72,21 +72,33 @@ EXAMPLES
 
 
 
-\*
+1. To build the known_hosts entry for the nodes in the compute group
  
- makeknownhosts compute
  
-
-
-\*
+ .. code-block:: perl
  
- makeknownhosts lpars,service
+   makeknownhosts compute
+ 
  
 
 
-\*
+2. To build the known_hosts entry for the nodes in the lpars and service groups
  
- makeknownhosts node02 -r
+ 
+ .. code-block:: perl
+ 
+   makeknownhosts lpars,service
+ 
+ 
+
+
+3. To remove the known_hosts entry for node02
+ 
+ 
+ .. code-block:: perl
+ 
+   makeknownhosts node02 -r
+ 
  
 
 

--- a/docs/source/guides/admin-guides/references/man8/makenetworks.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/makenetworks.8.rst
@@ -19,11 +19,11 @@ SYNOPSIS
 ********
 
 
-\ *makenetworks [-h|--help ]*\ 
+\ **makenetworks**\  [\ **-h**\  | \ **-**\ **-help**\  ]
 
-\ *makenetworks [-v| --version]*\ 
+\ **makenetworks**\  [\ **-v**\  | \ **-**\ **-version**\ ]
 
-\ *makenetworks [-V|--verbose] [-d|--display]*\ 
+\ **makenetworks**\  [\ **-V**\  | \ **-**\ **-verbose**\ ] [\ **-d | -**\ **-display**\ ]
 
 
 ***********
@@ -73,13 +73,13 @@ OPTIONS
 *******
 
 
-\ **-d|--display**\        Display the network definitions but do not write to the definitions to the xCAT database. The output will be in stanza file format and can be redirected to a stanza file that can be used with \ **mkdef**\  or \ **chdef**\  commands to create or modify the network definitions.
+\ **-d|-**\ **-display**\        Display the network definitions but do not write to the definitions to the xCAT database. The output will be in stanza file format and can be redirected to a stanza file that can be used with \ **mkdef**\  or \ **chdef**\  commands to create or modify the network definitions.
 
-\ **-h | --help**\          Display usage message.
+\ **-h | -**\ **-help**\          Display usage message.
 
-\ **-v | --version**\       Command Version.
+\ **-v | -**\ **-version**\       Command Version.
 
-\ **-V |--verbose**\        Verbose mode.
+\ **-V |-**\ **-verbose**\        Verbose mode.
 
 
 ************
@@ -87,9 +87,14 @@ RETURN VALUE
 ************
 
 
-0 The command completed successfully.
 
-1 An error has occurred.
+0.  The command completed successfully.
+
+
+
+1.  An error has occurred.
+
+
 
 
 ********
@@ -97,29 +102,34 @@ EXAMPLES
 ********
 
 
-1.  Gather cluster network information and create xCAT network definitions.
+
+1. Gather cluster network information and create xCAT network definitions.
+ 
+ 
+ .. code-block:: perl
+ 
+  	makenetworks
+ 
+ 
 
 
-.. code-block:: perl
+2. Display cluster network information but do not write the network definitions to the xCAT database.
+ 
+ 
+ .. code-block:: perl
+ 
+  	makenetworks -d
+ 
+ 
+ The output would be one or more stanzas of information similar to the following. The line that ends with a colon is the value of the "netname" attribute and is the name of the network object to use with the lsdef, mkdef, chdef and rmdef commands.
+ 
+ 9_114_37_0-255_255_255_0:
+     objtype=network
+     gateway=9.114.37.254
+     mask=255.255.255.0
+     net=9.114.37.0
+ 
 
- 	makenetworks
-
-
-2.  Display cluster network information but do not write the network definitions to the xCAT database.
-
-
-.. code-block:: perl
-
- 	makenetworks -d
-
-
-The output would be one or more stanzas of information similar to the following. The line that ends with a colon is the value of the "netname" attribute and is the name of the network object to use with the lsdef, mkdef, chdef and rmdef commands.
-
-9_114_37_0-255_255_255_0:
-    objtype=network
-    gateway=9.114.37.254
-    mask=255.255.255.0
-    net=9.114.37.0
 
 
 *****

--- a/docs/source/guides/admin-guides/references/man8/makeroutes.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/makeroutes.8.rst
@@ -19,15 +19,15 @@ SYNOPSIS
 ********
 
 
-\ **makeroutes**\  [\ **-r**\ |\ **--routename**\  \ *r1*\ [\ *,r2...*\ ]]
+\ **makeroutes**\  [\ **-r | -**\ **-routename**\  \ *r1*\ [\ *,r2...*\ ]]
 
-\ **makeroutes**\  \ **-d**\ |\ **--delete**\  [\ **-r**\ |\ **--routenames**\  \ *r1*\ [\ *,r2...*\ ]]
+\ **makeroutes**\  [\ **-d | -**\ **-delete**\ ] [\ **-r | -**\ **-routenames**\  \ *r1*\ [\ *,r2...*\ ]]
 
-\ **makeroutes**\  \ *noderange*\  [\ **-r**\ |\ **--routename**\  \ *r1*\ [\ *,r2...*\ ]]
+\ **makeroutes**\  \ *noderange*\  [\ **-r | -**\ **-routename**\  \ *r1*\ [\ *,r2...*\ ]]
 
-\ **makeroutes**\  \ *noderange*\  \ **-d**\ |\ **--delete**\  [\ **-r**\ |\ **--routenames**\  \ *r1*\ [\ *,r2...*\ ]]
+\ **makeroutes**\  \ *noderange*\  [\ **-d | -**\ **-delete**\ ] [\ **-r | -**\ **-routenames**\  \ *r1*\ [\ *,r2...*\ ]]
 
-\ **makeroutes**\  [\ **-h**\  \ **--help**\ |\ **-v**\ |\ **--version**\ ]
+\ **makeroutes**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
 
 ***********
@@ -54,25 +54,25 @@ OPTIONS
 
 
 
-\ **-d|--delete**\ 
+\ **-d|-**\ **-delete**\ 
  
  Specifies to delete the given routes. If not specified, the action is to add routes.
  
 
 
-\ **-r|--routename**\ 
+\ **-r|-**\ **-routename**\ 
  
  Specifies a list of comma separated route names defined in the \ **routes**\  table. If omitted, all routes defined in \ **noderes.routenames**\  for nodes or \ **site.mnroutenames**\  for the management node will be used.
  
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command Version.
  
@@ -85,9 +85,7 @@ EXAMPLES
 
 
 
-1.
- 
- To add all routes from the \ **site.mnroutenames**\  to the os route table for the management node.
+1. To add all routes from the \ **site.mnroutenames**\  to the os route table for the management node.
  
  
  .. code-block:: perl
@@ -97,9 +95,7 @@ EXAMPLES
  
 
 
-2.
- 
- To add all the routes from \ **noderes.routenames**\  to the os route table for node1.
+2. To add all the routes from \ **noderes.routenames**\  to the os route table for node1.
  
  
  .. code-block:: perl
@@ -109,9 +105,7 @@ EXAMPLES
  
 
 
-3.
- 
- To add route rr1 and rr2 to the os route table for the management node.
+3. To add route rr1 and rr2 to the os route table for the management node.
  
  
  .. code-block:: perl
@@ -121,9 +115,7 @@ EXAMPLES
  
 
 
-4.
- 
- To delete route rr1 and rr2 from the os route table on node1 and node1.
+4. To delete route rr1 and rr2 from the os route table on node1 and node1.
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man8/mknb.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/mknb.8.rst
@@ -55,9 +55,14 @@ RETURN VALUE
 ************
 
 
-0 The command completed successfully.
 
-1 An error has occurred.
+0.  The command completed successfully.
+
+
+
+1.  An error has occurred.
+
+
 
 
 ********

--- a/docs/source/guides/admin-guides/references/man8/nodeadd.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/nodeadd.8.rst
@@ -21,9 +21,9 @@ SYNOPSIS
 
 \ **nodeadd**\  \ *noderange*\  \ **groups**\ =\ *groupnames*\  [\ *table.column=value*\ ] [\ *...*\ ]
 
-\ **nodeadd**\  {\ **-v**\  | \ **--version**\ }
+\ **nodeadd**\  [\ **-v**\  | \ **-**\ **-version**\ ]
 
-\ **nodeadd**\  [\ **-?**\  | \ **-h**\  | \ **--help**\ ]
+\ **nodeadd**\  [\ **-?**\  | \ **-h**\  | \ **-**\ **-help**\ ]
 
 
 ***********
@@ -47,13 +47,13 @@ OPTIONS
 
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command Version.
  
 
 
-\ **-?|-h|--help**\ 
+\ **-?|-h|-**\ **-help**\ 
  
  Display usage message.
  
@@ -66,16 +66,12 @@ RETURN VALUE
 
 
 
-0
- 
- The command completed successfully.
- 
+0.  The command completed successfully.
 
 
-1
- 
- An error has occurred.
- 
+
+1.  An error has occurred.
+
 
 
 
@@ -85,19 +81,23 @@ EXAMPLES
 
 
 
-\*
+1. To add nodes in noderange  node1-node4 with group all:
  
- To add nodes in noderange  node1-node4 with group all:
  
- \ **nodeadd**\  \ *node1-node4 groups=all*\ 
+ .. code-block:: perl
+ 
+   nodeadd node1-node4 groups=all
+ 
  
 
 
-\*
+2. To add nodes in noderange  node1-node4 to the nodetype table with os=rhel5:
  
- To add nodes in noderange  node1-node4 to the nodetype table with os=rhel5:
  
- \ **nodeadd**\  \ *node1-node4 groups=all,rhel5 nodetype.os=rhel5*\ 
+ .. code-block:: perl
+ 
+   nodeadd node1-node4 groups=all,rhel5 nodetype.os=rhel5
+ 
  
 
 

--- a/docs/source/guides/admin-guides/references/man8/nodeset.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/nodeset.8.rst
@@ -19,11 +19,13 @@ Name
 ****************
 
 
-\ **nodeset**\  [\ *noderange*\ ] [\ *boot*\ |\ *stat*\ |\ *iscsiboot*\ |\ *offline*\ |\ *runcmd=bmcsetup*\ |\ *osimage[=<imagename*\ >]|\ *shell*\ |\ *shutdown*\ ]
+\ **nodeset**\  [\ *noderange*\ ] [\ **boot**\  | \ **stat**\  | \ **iscsiboot**\  | \ **offline**\  | \ **runcmd=bmcsetup**\  | \ **osimage**\ = \ *imagename*\  | \ **shell**\  | \ **shutdown**\ ]
 
-\ **nodeset**\  \ *noderange*\  \ *osimage=<imagename*\ > [\ *--noupdateinitrd*\ ] [\ *--ignorekernelchk*\ ]
+\ **nodeset**\  \ *noderange*\  \ **osimage=**\  \ *imagename*\  [\ **-**\ **-noupdateinitrd**\ ] [\ **-**\ **-ignorekernelchk**\ ]
 
-\ **nodeset**\  [\ *-h*\ |\ *--help*\ |\ *-v*\ |\ *--version*\ ]
+\ **nodeset**\  \ *noderange*\  \ **runimage=**\  \ *task*\ 
+
+\ **nodeset**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
 
 *******************
@@ -72,26 +74,26 @@ A user can supply their own scripts to be run on the mn or on the service node (
  
 
 
-\ **osimage**\ |\ **osimage=<imagename**\ >
+\ **osimage | osimage=<imagename**\ >
  
  Prepare server for installing a node using the specified os image. The os image is defined in the \ *osimage*\  table and \ *linuximage*\  table. If the <imagename> is omitted, the os image name will be obtained from \ *nodetype.provmethod*\  for the node.
  
 
 
-\ **--noupdateinitrd**\ 
+\ **-**\ **-noupdateinitrd**\ 
  
  Skip the rebuilding of initrd when the 'netdrivers', 'drvierupdatesrc' or 'osupdatename' were set for injecting new drviers to initrd. But, the geninitrd command
  should be run to rebuild the initrd for new drivers injecting. This is used to improve the performance of nodeset command.
  
 
 
-\ **--ignorekernelchk**\ 
+\ **-**\ **-ignorekernelchk**\ 
  
  Skip the kernel version checking when injecting drivers from osimage.driverupdatesrc. That means all drivers from osimage.driverupdatesrc will be injected to initrd for the specific target kernel.
  
 
 
-\ **runimage**\ =<task>>
+\ **runimage**\ =\ *task*\ 
  
  If you would like to run a task after deployment, you can define that task with this attribute.
  
@@ -123,13 +125,13 @@ A user can supply their own scripts to be run on the mn or on the service node (
  
 
 
-\ **-h**\ |\ **--help**\ 
+\ **-h | -**\ **-help**\ 
  
  Print help.
  
 
 
-\ **-v**\ |\ **--version**\ 
+\ **-v | -**\ **-version**\ 
  
  Print version.
  
@@ -163,19 +165,23 @@ root directory and the TFTP xCAT  subdirectory.   /tftpboot  and
 
 
 
-\*
+1. To setup to install mycomputeimage on the compute node group.
  
- To setup to install mycomputeimage on the compute node group.
  
- nodeset compute osimage=mycomputeimage
+ .. code-block:: perl
+ 
+   nodeset compute osimage=mycomputeimage
+ 
  
 
 
-\*
+2. To run http://$master/image.tgz  after deployment:
  
- To run http://$master/image.tgz  after deployment:
  
- nodeset $node runimage=http://$MASTER/image.tgznodeset
+ .. code-block:: perl
+ 
+   nodeset $node runimage=http://$MASTER/image.tgz
+ 
  
 
 

--- a/docs/source/guides/admin-guides/references/man8/rescanplugins.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/rescanplugins.8.rst
@@ -21,11 +21,11 @@ SYNOPSIS
 
 \ **rescanplugins**\ 
 
-\ **rescanplugins**\  {\ **-h**\ |\ **--help**\ }
+\ **rescanplugins**\  [\ **-h | -**\ **-help**\ ]
 
-\ **rescanplugins**\  {\ **-v**\ |\ **--version**\ }
+\ **rescanplugins**\  [\ **-v | -**\ **-version**\ ]
 
-\ **rescanplugins**\  [\ **-s**\ |\ **--servicenodes**\ ]
+\ **rescanplugins**\  [\ **-s | -**\ **-servicenodes**\ ]
 
 
 ***********
@@ -44,19 +44,19 @@ OPTIONS
 
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Displays the usage message.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Displays the release version of the code.
  
 
 
-\ **-s|--servicenodes**\ 
+\ **-s|-**\ **-servicenodes**\ 
  
  Process the rescanplugins on the management node and on all service nodes.  The rescanplugins command will be sent to the xcatd daemon on all nodes defined in the servicenode table.  The default is to only run on the management node.
  
@@ -69,19 +69,23 @@ EXAMPLES
 
 
 
-\*
+1. To rescan the plugins only on the xCAT Management Node:
  
- To rescan the plugins only on the xCAT Management Node:
  
- \ **rescanplugins**\ 
+ .. code-block:: perl
+ 
+   rescanplugins
+ 
  
 
 
-\*
+2. To rescan the plugins on the xCAT Management Node and on all service nodes:
  
- To rescan the plugins on the xCAT Management Node and on all service nodes:
  
- \ **rescanplugins -s**\ 
+ .. code-block:: perl
+ 
+   rescanplugins -s
+ 
  
 
 

--- a/docs/source/guides/admin-guides/references/man8/rinstall.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/rinstall.8.rst
@@ -19,7 +19,7 @@ Name
 ****************
 
 
-\ **rinstall**\  [\ *-O*\ |\ *--osimage*\ ] [\ *-c*\ |\ *--console*\ ] [\ *noderange*\ ]
+\ **rinstall**\  [\ **-O | -**\ **-osimage**\ ] [\ **-c | -**\ **-console**\ ] [\ **noderange**\ ]
 
 
 *******************
@@ -29,7 +29,7 @@ Name
 
 \ **rinstall**\  is a convenience command that will change tables as requested for operating system version, profile, and architecture, call \ **nodeset**\  to modify the network boot configuration, call \ **rsetboot**\  net to set the next boot over network (only support nodes with "nodetype.mgt=ipmi", for other nodes, make sure the correct boot order has been set before \ **rinstall**\ ), and \ **rpower**\  to begin a boot cycle.
 
-If [\ *-O*\ |\ *--osimage*\ ] is specified or nodetype.provmethod=\ *osimage*\  is set, provision the noderange with the osimage specified/configured, ignore the table change options if specified.
+If [\ **-O | -**\ **-osimage**\ ] is specified or nodetype.provmethod=\ **osimage**\  is set, provision the noderange with the osimage specified/configured, ignore the table change options if specified.
 
 If -c is specified, it will then run rcons on the node. This is allowed only if one node in the noderange.   If need consoles on multiple nodes , see winstall(8)|winstall.8.
 
@@ -40,25 +40,25 @@ If -c is specified, it will then run rcons on the node. This is allowed only if 
 
 
 
-\ **-h**\ |\ **--help**\ 
+\ **-h | -**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-v**\ |\ **--version**\ 
+\ **-v | -**\ **-version**\ 
  
  Display version.
  
 
 
-\ **-O**\ |\ **--osimage**\ 
+\ **-O | -**\ **-osimage**\ 
  
  Specifies the osimage to provision.
  
 
 
-\ **-c**\ |\ **--console**\ 
+\ **-c | -**\ **-console**\ 
  
  Requests that rinstall runs rcons once the provision starts.  This will only work if there is only one node in the noderange. See winstall(8)|winstall.8 for starting nsoles on multiple nodes.
  
@@ -70,17 +70,36 @@ If -c is specified, it will then run rcons on the node. This is allowed only if 
 ****************
 
 
-\ **rinstall**\  \ *node1-node20*\ 
 
-Provison nodes 1 through 20, using their current configuration.
+1. Provison nodes 1 through 20, using their current configuration.
+ 
+ 
+ .. code-block:: perl
+ 
+   rinstall node1-node20
+ 
+ 
 
-\ **rinstall**\  \ *node1-node20*\  -O rhels6.4-ppc64-netboot-compute
 
-Provision nodes 1 through 20 with the osimage rhels6.4-ppc64-netboot-compute.
+2. Provision nodes 1 through 20 with the osimage rhels6.4-ppc64-netboot-compute.
+ 
+ 
+ .. code-block:: perl
+ 
+   rinstall node1-node20 -O rhels6.4-ppc64-netboot-compute
+ 
+ 
 
-\ **rinstall**\   \ *node1*\  -c
 
-Provisoon node1 and start a console to monitor the process.
+3. Provisoon node1 and start a console to monitor the process.
+ 
+ 
+ .. code-block:: perl
+ 
+   rinstall node1 -c
+ 
+ 
+
 
 
 ************************

--- a/docs/source/guides/admin-guides/references/man8/rmosdistro.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/rmosdistro.8.rst
@@ -11,9 +11,9 @@ SYNOPSIS
 ********
 
 
-\ **rmosdistro**\  [\ **-a**\ |\ **--all**\ ] [\ **-f|--force**\ ] \ **osdistroname**\   [\ **osdistroname2 ...**\ ]
+\ **rmosdistro**\  [\ **-a | -**\ **-all**\ ] [\ **-f | -**\ **-force**\ ] \ *osdistroname*\  [\ *osdistroname2 ...*\ ]
 
-\ **rmosdistro**\  [\ **-h**\ |\ **--help**\ ]
+\ **rmosdistro**\  [\ **-h | -**\ **-help**\ ]
 
 
 ***********
@@ -21,7 +21,7 @@ DESCRIPTION
 ***********
 
 
-The \ **rmosdistro**\  command removes the specified OS Distro that was created by \ **copycds**\ . To delete all OS Distro entries, please specify \ **[-a|--all]**\ . If the specified OS Distro is referenced by some osimage, \ **[-f|force]**\  can be used to remove it.
+The \ **rmosdistro**\  command removes the specified OS Distro that was created by \ **copycds**\ . To delete all OS Distro entries, please specify \ **[-a|-**\ **-all]**\ . If the specified OS Distro is referenced by some osimage, \ **[-f|force]**\  can be used to remove it.
 
 
 *********
@@ -38,19 +38,19 @@ OPTIONS
 
 
 
-{\ **-a|--all**\ }
+\ **-a | -**\ **-all**\ 
  
  If specified, try to delete all the OS Distros.
  
 
 
-{\ **-f|--force**\ }
+\ **-f | -**\ **-force**\ 
  
  Remove referenced OS Distros, never prompt.
  
 
 
-{\ **-h|--help**\ }
+\ **-h | -**\ **-help**\ 
  
  Show info of rmosdistro usage.
  
@@ -75,27 +75,33 @@ EXAMPLES
 
 
 
-\*
+1. To remove OS Distro "rhels6.2-ppc64" and "sles11.2-ppc64":
  
- To remove OS Distro "rhels6.2-ppc64" and "sles11.2-ppc64":
  
- \ **rmosdistro rhels6.2-ppc64 sles11.2-ppc64**\ 
+ .. code-block:: perl
  
-
-
-\*
+   rmosdistro rhels6.2-ppc64 sles11.2-ppc64
  
- To remove OS Distro "rhels6.2-ppc64", regardless of whether is referenced by any osimage:
- 
- \ **rmosdistro -f rhels6.2-ppc64**\ 
  
 
 
-\*
+2. To remove OS Distro "rhels6.2-ppc64", regardless of whether is referenced by any osimage:
  
- To remove all OS Distros:
  
- \ **rmosdistro -a**\ 
+ .. code-block:: perl
+ 
+   rmosdistro -f rhels6.2-ppc64
+ 
+ 
+
+
+3. To remove all OS Distros:
+ 
+ 
+ .. code-block:: perl
+ 
+   rmosdistro -a
+ 
  
 
 

--- a/docs/source/guides/admin-guides/references/man8/runsqlcmd.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/runsqlcmd.8.rst
@@ -21,15 +21,15 @@ SYNOPSIS
 
 \ **runsqlcmd**\ 
 
-\ **runsqlcmd**\  {\ **-h**\ |\ **--help**\ }
+\ **runsqlcmd**\  [\ **-h | -**\ **-help**\ ]
 
-\ **runsqlcmd**\  {\ **-v**\ |\ **--version**\ }
+\ **runsqlcmd**\  [\ **-v | -**\ **-version**\ ]
 
-\ **runsqlcmd**\  {\ **-d**\ |\ **--dir**\  \ *directory_path*\ } {\ **-V**\ |\ **--verbose**\ }
+\ **runsqlcmd**\  [\ **-d | -**\ **-dir**\  \ *directory_path*\ ] [\ **-V | -**\ **-verbose**\ ]
 
-\ **runsqlcmd**\  {\ **-f**\ |\ **--files**\  \ *list of files*\ } {\ **-V**\ |\ **--verbose**\ }
+\ **runsqlcmd**\  [\ **-f | -**\ **-files**\  \ *list of files*\ ] [\ **-V | -**\ **-verbose**\ ]
 
-\ **runsqlcmd**\  {\ **-V**\ |\ **--verbose**\ } {\ **sql statement**\ }
+\ **runsqlcmd**\  [\ **-V | -**\ **-verbose**\ ] [\ *sql statement*\ ]
 
 
 ***********
@@ -49,31 +49,31 @@ OPTIONS
 
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Displays the usage message.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Displays current code version.
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Displays extra debug information.
  
 
 
-\ **-d|--dir**\ 
+\ **-d|-**\ **-dir**\ 
  
  To use a directory other than the default directory,  enter the directory path here.
  
 
 
-\ **-f|--files**\ 
+\ **-f|-**\ **-files**\ 
  
  Comma separated list of files (full path), wildcard (\*) can be used.
  
@@ -87,7 +87,7 @@ OPTIONS
  
 
 
-\ **sql statement**\ 
+\ *sql statement*\ 
  
  Quoted sql statement syntax appropriate for the current database.
  
@@ -100,43 +100,53 @@ EXAMPLES
 
 
 
-\*
+1. To run the database appropriate \*.sql files in /opt/xcat/lib/perl/xCAT_schema :
  
- To run the database appropriate \*.sql files in /opt/xcat/lib/perl/xCAT_schema :
  
- \ **runsqlcmd**\ 
+ .. code-block:: perl
  
-
-
-\*
+   runsqlcmd
  
- To run the database appropriate \*.sql files in /tmp/mysql:
- 
- \ **runsqlcmd**\  \ *-d*\  \ */tmp/mysql*\ 
  
 
 
-\*
+2. To run the database appropriate \*.sql files in /tmp/mysql:
  
- To run the database appropriate \*.sql files in the input list:
  
- \ **runsqlcmd**\  \ *-f*\  \ *"/tmp/mysql/test\\*,/tmp/mysql/test1\\*"*\ 
+ .. code-block:: perl
  
-
-
-\*
+   runsqlcmd -d /tmp/mysql
  
- To checkout one DB2 sql file:
- 
- \ **runsqlcmd**\  \ *-f*\  \ */tmp/db2/test_db2.sql*\ 
  
 
 
-\*
+3. To run the database appropriate \*.sql files in the input list:
  
- To run the following command to the database:
  
- \ **runsqlcmd**\  \ *"Select \\* from site;"*\ 
+ .. code-block:: perl
+ 
+   runsqlcmd -f "/tmp/mysql/test*,/tmp/mysql/test1*"
+ 
+ 
+
+
+4. To checkout one DB2 sql file:
+ 
+ 
+ .. code-block:: perl
+ 
+   runsqlcmd -f /tmp/db2/test_db2.sql
+ 
+ 
+
+
+5. To run the following command to the database:
+ 
+ 
+ .. code-block:: perl
+ 
+   runsqlcmd "Select * from site;"
+ 
  
 
 

--- a/docs/source/guides/admin-guides/references/man8/setupiscsidev.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/setupiscsidev.8.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **setupiscsidev**\  [\ **-s|--size**\ ] \ *noderange*\ 
+\ **setupiscsidev**\  [\ **-s|-**\ **-size**\ ] \ *noderange*\ 
 
-\ **setupiscsidev**\  [\ **-h|--help|-v|--version**\ ]
+\ **setupiscsidev**\  [\ **-h|-**\ **-help|-v|-**\ **-version**\ ]
 
 
 ***********
@@ -40,19 +40,19 @@ OPTIONS
 
 
 
-\ **-s|--size**\ 
+\ **-s|-**\ **-size**\ 
  
  The size of the LUN that should be created.  Default is 4096.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Display version.
  
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  
@@ -64,9 +64,14 @@ RETURN VALUE
 ************
 
 
-0 The command completed successfully.
 
-1 An error has occurred.
+0.  The command completed successfully.
+
+
+
+1.  An error has occurred.
+
+
 
 
 ********

--- a/docs/source/guides/admin-guides/references/man8/tabch.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/tabch.8.rst
@@ -19,15 +19,15 @@ SYNOPSIS
 ********
 
 
-\ *tabch [-h| --help]*\ 
+\ **tabch**\  [\ **-h**\  | \ **-**\ **-help**\ ]
 
-\ *tabch [-v| --version]*\ 
+\ **tabch**\  [\ **-v**\  | \ **-**\ **-version**\ ]
 
-\ *tabch [keycolname=keyvalue] [tablename.colname=newvalue] *\ 
+\ **tabch**\  [\ *keycolname=keyvalue*\ ] [\ *tablename.colname=newvalue*\ ]
 
-\ *tabch [keycolname=keyvalue] [tablename.colname+=newvalue] *\ 
+\ **tabch**\  [\ *keycolname=keyvalue*\ ] [\ *tablename.colname+=newvalue*\ ]
 
-\ *tabch -d [keycolname=keyvalue] [tablename.colname=newvalue] *\ 
+\ **tabch -d**\  [\ *keycolname=keyvalue*\ ] [\ *tablename.colname=newvalue*\ ]
 
 
 ***********
@@ -43,9 +43,9 @@ OPTIONS
 *******
 
 
-\ **-h**\           Display usage message.
+\ **-h|-**\ **-help**\           Display usage message.
 
-\ **-v**\           Command Version.
+\ **-v|-**\ **-version**\           Command Version.
 
 \ **-d**\           Delete option.
 
@@ -55,9 +55,14 @@ RETURN VALUE
 ************
 
 
-0 The command completed successfully.
 
-1 An error has occurred.
+0.  The command completed successfully.
+
+
+
+1.  An error has occurred.
+
+
 
 
 ********
@@ -65,29 +70,66 @@ EXAMPLES
 ********
 
 
-1. To add a node=node1 to the nodelist table with groups=all:
 
-\ *tabch  node=node1 nodelist.groups=all *\ 
+1.  To add a node=node1 to the nodelist table with groups=all:
+ 
+ 
+ .. code-block:: perl
+ 
+   tabch  node=node1 nodelist.groups=all
+ 
+ 
 
-2. To add a keyword (tftpdir) and value (/tftpboot) to the site table:
 
-\ *tabch  key=tftpdir site.value=/tftpboot *\ 
+2.  To add a keyword (tftpdir) and value (/tftpboot) to the site table:
+ 
+ 
+ .. code-block:: perl
+ 
+   tabch  key=tftpdir site.value=/tftpboot
+ 
+ 
 
-3. To add node1 to the  nodetype table with os=rhel5:
 
-\ *tabch  node=node1 nodetype.os=rhel5*\ 
+3.  To add node1 to the  nodetype table with os=rhel5:
+ 
+ 
+ .. code-block:: perl
+ 
+   tabch  node=node1 nodetype.os=rhel5
+ 
+ 
 
-4. To change node1 in nodetype table setting os=sles:
 
-\ *tabch  node=node1 nodetype.os=sles*\ 
+4.  To change node1 in nodetype table setting os=sles:
+ 
+ 
+ .. code-block:: perl
+ 
+   tabch  node=node1 nodetype.os=sles
+ 
+ 
 
-5. To change node1 by appending otherpkgs to the postbootscripts field in the postscripts table:
 
-\ *tabch node=node1 postscripts.postbootscripts+=otherpkgs*\ 
+5.  To change node1 by appending otherpkgs to the postbootscripts field in the postscripts table:
+ 
+ 
+ .. code-block:: perl
+ 
+   tabch node=node1 postscripts.postbootscripts+=otherpkgs
+ 
+ 
 
-6. To delete node1 from nodetype table:
 
-\ *tabch -d node=node1 nodetype*\ 
+6.  To delete node1 from nodetype table:
+ 
+ 
+ .. code-block:: perl
+ 
+   tabch -d node=node1 nodetype
+ 
+ 
+
 
 
 *****

--- a/docs/source/guides/admin-guides/references/man8/tabdump.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/tabdump.8.rst
@@ -19,23 +19,23 @@ SYNOPSIS
 ********
 
 
-\ **tabdump**\  [\ *-d*\ ] [\ *table*\ ]
+\ **tabdump**\ 
+
+\ **tabdump**\  [\ **-d**\ ] [\ *table*\ ]
 
 \ **tabdump**\  [\ *table*\ ]
 
-\ **tabdump**\  [\ *-f*\  \ *filename*\ ] [\ *table*\ ]
+\ **tabdump**\  [\ **-f**\  \ *filename*\ ] [\ *table*\ ]
 
-\ **tabdump**\  [\ *-n*\  \ *# of records*\ ] [\ *auditlog | eventlog*\ ]
+\ **tabdump**\  [\ **-n**\  \ *# of records*\ ] [\ **auditlog**\  | \ **eventlog**\ ]
 
-\ **tabdump**\  [\ *-w*\  \ *attr*\ ==\ *val*\ ] [\ **-w**\  \ *attr*\ =~\ *val*\ ] ...] [\ *table*\ ]
+\ **tabdump**\  [\ **-w**\  \ *attr*\ ==\ *val*\ ] [\ **-w**\  \ *attr*\ =~\ *val*\ ] ...] [\ *table*\ ]
 
-\ **tabdump**\  [\ *-w*\  \ *attr*\ ==\ *val*\ ] [\ **-w**\  \ *attr*\ =~\ *val*\ ] ...] [\ *-f*\  \ *filename*\ ] [\ *table*\ ]
+\ **tabdump**\  [\ **-w**\  \ *attr*\ ==\ *val*\ ] [\ **-w**\  \ *attr*\ =~\ *val*\ ] ...] [\ **-f**\  \ *filename*\ ] [\ *table*\ ]
 
-\ **tabdump**\  [\ *-v*\  | \ *--version*\ ]
+\ **tabdump**\  [\ **-v**\  | \ **-**\ **-version**\ ]
 
-\ **tabdump**\  [\ *-?*\  | \ *-h*\  | \ *--help*\ ]
-
-\ **tabdump**\ 
+\ **tabdump**\  [\ **-?**\  | \ **-h**\  | \ **-**\ **-help**\ ]
 
 
 ***********
@@ -54,7 +54,7 @@ OPTIONS
 
 
 
-\ **-?|-h|--help**\ 
+\ **-?|-h|-**\ **-help**\ 
  
  Display usage message.
  
@@ -107,16 +107,12 @@ RETURN VALUE
 
 
 
-0
- 
- The command completed successfully.
- 
+0.  The command completed successfully.
 
 
-1
- 
- An error has occurred.
- 
+
+1.  An error has occurred.
+
 
 
 
@@ -126,85 +122,105 @@ EXAMPLES
 
 
 
-\*
+1. To display the contents of the site table:
  
- To display the contents of the site table:
  
- \ **tabdump**\  \ **site**\ 
+ .. code-block:: perl
  
-
-
-\*
+   tabdump site
  
- To display the contents of the nodelist table where the groups attribute is compute :
- 
- \ **tabdump**\   \ **-w 'groups==compute'**\  \ **nodelist**\ 
  
 
 
-\*
+2. To display the contents of the nodelist table where the groups attribute is compute :
  
- To display the contents of the nodelist table where the groups attribute is comput% where % is a wildcard and can represent any string  and the status attribute is booted :
  
- \ **tabdump**\   \ **-w 'groups=~comput%'**\  \ **-w 'status==booted'**\  \ **nodelist**\ 
+ .. code-block:: perl
  
-
-
-\*
+   tabdump -w 'groups==compute' nodelist
  
- To display the records of the auditlog on date  2011-04-18 11:30:00 :
- 
- \ **tabdump**\    \ **-w 'audittime==2011-04-18 11:30:00'**\  \ **auditlog**\ 
  
 
 
-\*
+3. To display the contents of the nodelist table where the groups attribute is comput% where % is a wildcard and can represent any string  and the status attribute is booted :
  
- To display the records of the auditlog starting on 2011-04-18:
  
- tabdump -w 'audittime>2011-04-18 11:30:00' auditlog
+ .. code-block:: perl
  
-
-
-\*
+   tabdump -w 'groups=~comput%' -w 'status==booted' nodelist
  
- To display the 10 most recent entries in the auditlog:
- 
- tabdump -n 10 auditlog
  
 
 
-\*
+4. To display the records of the auditlog on date  2011-04-18 11:30:00 :
  
- To see what tables exist in the xCAT database:
  
- \ **tabdump**\ 
+ .. code-block:: perl
+ 
+   tabdump -w 'audittime==2011-04-18 11:30:00' auditlog
+ 
  
 
 
-\*
+5. To display the records of the auditlog starting on 2011-04-18:
  
- To back up all the xCAT database tables, instead of running \ **tabdump**\  multiple times, you can use the \ **dumpxCATdb**\  command as follows:
  
- \ **dumpxCATdb -p /tmp/xcatbak **\ 
+ .. code-block:: perl
+ 
+   tabdump -w 'audittime>2011-04-18 11:30:00' auditlog
+ 
+ 
+
+
+6. To display the 10 most recent entries in the auditlog:
+ 
+ 
+ .. code-block:: perl
+ 
+   tabdump -n 10 auditlog
+ 
+ 
+
+
+7. To see what tables exist in the xCAT database:
+ 
+ 
+ .. code-block:: perl
+ 
+   tabdump
+ 
+ 
+
+
+8. To back up all the xCAT database tables, instead of running \ **tabdump**\  multiple times, you can use the \ **dumpxCATdb**\  command as follows:
+ 
+ 
+ .. code-block:: perl
+ 
+   dumpxCATdb -p /tmp/xcatbak
+ 
  
  See the \ **dumpxCATdb**\  man page for details.
  
 
 
-\*
+9. To display a summary description of each table:
  
- To display a summary description of each table:
  
- \ **tabdump**\  \ **-d**\ 
+ .. code-block:: perl
+ 
+   tabdump -d
+ 
  
 
 
-\*
+10. To display a description of each column in the nodehm table:
  
- To display a description of each column in the nodehm table:
  
- \ **tabdump**\  \ **-d nodehm**\ 
+ .. code-block:: perl
+ 
+   tabdump -d nodehm
+ 
  
 
 

--- a/docs/source/guides/admin-guides/references/man8/tabedit.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/tabedit.8.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **tabedit**\  [\ *table*\ ]
+\ **tabedit**\  \ *table*\ 
 
-\ **tabedit**\  [\ *-?*\  | \ *-h*\  | \ *--help*\ ]
+\ **tabedit**\  [\ **-?**\  | \ **-h**\  | \ **-**\ **-help**\ ]
 
 
 ***********
@@ -43,7 +43,7 @@ OPTIONS
 
 
 
-\ **-?|-h|--help**\ 
+\ **-?|-h|-**\ **-help**\ 
  
  Display usage message.
  
@@ -71,16 +71,12 @@ RETURN VALUE
 
 
 
-0
- 
- The command completed successfully.
- 
+0.  The command completed successfully.
 
 
-1
- 
- An error has occurred.
- 
+
+1.  An error has occurred.
+
 
 
 
@@ -90,14 +86,12 @@ EXAMPLES
 
 
 
-\*
- 
- To edit the site table:
+1. To edit the site table:
  
  
  .. code-block:: perl
  
-    B<tabedit> I<site>
+   tabedit site
  
  
 

--- a/docs/source/guides/admin-guides/references/man8/tabprune.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/tabprune.8.rst
@@ -19,11 +19,11 @@ SYNOPSIS
 ********
 
 
-\ **tabprune**\  \ **eventlog | auditlog**\   [\ **-V**\ ] \ **-i**\  \ *recid*\  |\ **-n**\  \ *number of records*\  | \ **-p**\  \ *percentage*\  |  \ **-d**\  \ *number of days*\  | \ **-a**\ 
+\ **tabprune**\  [\ **eventlog | auditlog**\ ]  [\ **-V**\ ] [\ **-i**\  \ *recid*\  |\ **-n**\  \ *number of records*\  | \ **-p**\  \ *percentage*\  | \ **-d**\  \ *number of days*\  | \ **-a**\ ]
 
-\ **tabprune**\  \ **tablename**\  \ **-a**\ 
+\ **tabprune**\  \ *tablename*\  \ **-a**\ 
 
-\ **tabprune**\  [\ **-h**\ |\ **--help**\ ] [\ **-v**\ |\ **--version**\ ]
+\ **tabprune**\  [\ **-h | -**\ **-help**\ ] [\ **-v | -**\ **-version**\ ]
 
 
 ***********
@@ -31,7 +31,7 @@ DESCRIPTION
 ***********
 
 
-The tabprune command is used to delete records from the auditlog,eventlog,isnm_perf,isnm_perf_sum tables. As an option, the table header and all the rows pruned from the specified table will be displayed in CSV (comma separated values) format. The all records options (-a) can be used on any xCAT table.
+The tabprune command is used to delete records from the auditlog, eventlog, isnm_perf, isnm_perf_sum tables. As an option, the table header and all the rows pruned from the specified table will be displayed in CSV (comma separated values) format. The all records options (-a) can be used on any xCAT table.
 
 
 *******
@@ -40,7 +40,7 @@ OPTIONS
 
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  
@@ -90,16 +90,12 @@ RETURN VALUE
 
 
 
-0
- 
- The command completed successfully.
- 
+0. The command completed successfully.
 
 
-1
- 
- An error has occurred.
- 
+
+1. An error has occurred.
+
 
 
 
@@ -109,51 +105,63 @@ EXAMPLES
 
 
 
-\*
+1. To remove all the records in the eventlog table:
  
- To remove all the records in the eventlog table:
  
- \ **tabprune**\  \ *eventlog*\  -a
+ .. code-block:: perl
  
-
-
-\*
+   tabprune eventlog -a
  
- To remove all the records in the eventlog table saving the deleted records in eventlog.csv:
- 
- \ **tabprune**\  \ *eventlog*\  -V -a > eventlog.csv
  
 
 
-\*
+2. To remove all the records in the eventlog table saving the deleted records in eventlog.csv:
  
- To remove all the records before recid=200 in the auditlog table:
  
- \ **tabprune**\  \ *auditlog*\  -i 200
+ .. code-block:: perl
  
-
-
-\*
+   tabprune eventlog -V -a > eventlog.csv
  
- To remove 400 records from the auditlog table and display the remove records:
- 
- \ **tabprune**\  \ *auditlog*\  -V -n 400
  
 
 
-\*
+3. To remove all the records before recid=200 in the auditlog table:
  
- To remove 50% of the  eventlog table:
  
- \ **tabprune**\  \ *eventlog*\   -p 50
+ .. code-block:: perl
+ 
+   tabprune auditlog -i 200
+ 
  
 
 
-\*
+4. To remove 400 records from the auditlog table and display the remove records:
  
- To remove all records that occurred >= 5 days ago in the eventlog:
  
- \ **tabprune**\  \ *eventlog*\   -d 5
+ .. code-block:: perl
+ 
+   tabprune auditlog -V -n 400
+ 
+ 
+
+
+5. To remove 50% of the  eventlog table:
+ 
+ 
+ .. code-block:: perl
+ 
+   tabprune eventlog -p 50
+ 
+ 
+
+
+6. To remove all records that occurred >= 5 days ago in the eventlog:
+ 
+ 
+ .. code-block:: perl
+ 
+   tabprune eventlog -d 5
+ 
  
 
 

--- a/docs/source/guides/admin-guides/references/man8/tabrestore.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/tabrestore.8.rst
@@ -19,11 +19,11 @@ SYNOPSIS
 ********
 
 
-\ **tabrestore**\  [-a] \ *table.csv*\ 
+\ **tabrestore**\  [\ **-a**\ ] \ *table.csv*\ 
 
-\ **tabrestore**\  [\ *-?*\  | \ *-h*\  | \ *--help*\ ]
+\ **tabrestore**\  [\ **-?**\  | \ **-h**\  | \ **-**\ **-help**\ ]
 
-\ **tabrestore**\  [\ *v*\   | \ *--version*\ ]
+\ **tabrestore**\  [\ **-v**\   | \ **-**\ **-version**\ ]
 
 
 ***********
@@ -47,19 +47,19 @@ OPTIONS
 
 
 
-\ **-?|-h|--help**\ 
+\ **-?|-h|-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Display version.
  
 
 
-\ **-a|--addrows**\ 
+\ **-a|-**\ **-addrows**\ 
  
  Add rows from the CSV file to the table instead of replacing the table with the CSV file.
  
@@ -72,16 +72,12 @@ RETURN VALUE
 
 
 
-0
- 
- The command completed successfully.
- 
+0. The command completed successfully.
 
 
-1
- 
- An error has occurred.
- 
+
+1. An error has occurred.
+
 
 
 
@@ -91,11 +87,13 @@ EXAMPLES
 
 
 
-\*
+1. To replace the rows in the mp table with the rows in the mp.csv file:
  
- To replace the rows in the mp table with the rows in the mp.csv file:
  
- \ ** tabrestore**\  \ *mp.csv*\ 
+ .. code-block:: perl
+ 
+   tabrestore mp.csv
+ 
  
  The file mp.csv could contain something like:
  
@@ -108,19 +106,23 @@ EXAMPLES
  
 
 
-\*
+2. To add the rows in the mp.csv file to the rows in the mp table:
  
- To add the rows in the mp.csv file to the  rows in the mp table:
  
- \ ** tabrestore**\  -a \ *mp.csv*\ 
+ .. code-block:: perl
+ 
+   tabrestore -a mp.csv
+ 
  
 
 
-\*
+3. To restore database tables from restore_directory that we dumped with dumpxCATdb:
  
- To restore database tables that we dumped with dumpxCATdb:
  
- restorexCATdb -p <restore directory>
+ .. code-block:: perl
+ 
+   restorexCATdb -p restore_directory
+ 
  
 
 

--- a/docs/source/guides/admin-guides/references/man8/winstall.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/winstall.8.rst
@@ -19,9 +19,9 @@ Name
 ****************
 
 
-\ **winstall**\  [\ *-o*\ |\ *--osver*\ ] [\ *-p*\ |\ *--profile*\ ] [\ *-a*\ |\ *--arch*\ ] [\ *noderange*\ ]
+\ **winstall**\  [\ **-o | -**\ **-osver**\ ] [\ **-p | -**\ **-profile**\ ] [\ **-a | -**\ **-arch**\ ] [\ *noderange*\ ]
 
-\ **winstall**\  [\ *-O*\ |\ *--osimage*\ ] [\ *noderange*\ ]
+\ **winstall**\  [\ **-O | -**\ **-osimage**\ ] [\ *noderange*\ ]
 
 
 *******************
@@ -32,7 +32,7 @@ Name
 \ **winstall**\  is a convenience tool that will change attributes as requested for operating system version, profile, and architecture, call \ **nodeset**\  to modify the network boot configuration, call \ **rsetboot**\  net to set the next boot over network (only support nodes
 with "nodetype.mgt=ipmi", for other nodes, make sure the correct boot order has been set before \ **winstall**\ ), and \ **rpower**\  to begin a boot cycle.
 
-If [\ *-O*\ |\ *--osimage*\ ] is specified or nodetype.provmethod=\ *osimage*\  is set, provision the noderange with the osimage specified/configured, ignore the table change options if specified.
+If [\ *-O*\ |\ *-**\ **-osimage*\ ] is specified or nodetype.provmethod=\ *osimage*\  is set, provision the noderange with the osimage specified/configured, ignore the table change options if specified.
 
 It  will then run wcons on the nodes.
 
@@ -43,37 +43,37 @@ It  will then run wcons on the nodes.
 
 
 
-\ **-h**\ |\ **--help**\ 
+\ **-h | -**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-v**\ |\ **--version**\ 
+\ **-v | -**\ **-version**\ 
  
  Display version.
  
 
 
-\ **-o**\ |\ **--osver**\ 
+\ **-o | -**\ **-osver**\ 
  
- Specifies which os version to provision.  If unspecified, the current node os setting is used. Will be ignored if [\ *-O*\ |\ *--osimage*\ ] is specified or nodetype.provmethod=\ *osimage*\ .
- 
-
-
-\ **-p**\ |\ **--profile**\ 
- 
- Specifies what profile should be used of the operating system.  If not specified the current node profile setting is used. Will be ignored if [\ *-O*\ |\ *--osimage*\ ] is specified or nodetype.provmethod=\ *osimage*\ .
+ Specifies which os version to provision.  If unspecified, the current node os setting is used. Will be ignored if [\ *-O*\ |\ *-**\ **-osimage*\ ] is specified or nodetype.provmethod=\ *osimage*\ .
  
 
 
-\ **-a**\ |\ **--arch**\ 
+\ **-p | -**\ **-profile**\ 
  
- Specifies what architecture of the OS to provision.  Typically this is unneeded, but if provisioning between x86_64 and x86 frequently, this may be a useful flag. Will be ignored if [\ *-O*\ |\ *--osimage*\ ] is specified or nodetype.provmethod=\ *osimage*\ .
+ Specifies what profile should be used of the operating system.  If not specified the current node profile setting is used. Will be ignored if [\ *-O*\ |\ *-**\ **-osimage*\ ] is specified or nodetype.provmethod=\ *osimage*\ .
  
 
 
-\ **-O**\ |\ **--osimage**\ 
+\ **-a | -**\ **-arch**\ 
+ 
+ Specifies what architecture of the OS to provision.  Typically this is unneeded, but if provisioning between x86_64 and x86 frequently, this may be a useful flag. Will be ignored if [\ *-O*\ |\ *-**\ **-osimage*\ ] is specified or nodetype.provmethod=\ *osimage*\ .
+ 
+
+
+\ **-O | -**\ **-osimage**\ 
  
  Specifies the osimage to provision.
  
@@ -85,17 +85,36 @@ It  will then run wcons on the nodes.
 ****************
 
 
-\ **winstall**\  \ *node1-node20*\ 
 
-Provison nodes 1 through 20, using their current configuration.
+1. Provison nodes 1 through 20, using their current configuration.
+ 
+ 
+ .. code-block:: perl
+ 
+   winstall node1-node20
+ 
+ 
 
-\ **winstall**\  \ *node1-node20*\  -o rhels5.1 -p compute
 
-Provision nodes 1 through 20, forcing rhels5.1 and compute profile.
+2. Provision nodes 1 through 20, forcing rhels5.1 and compute profile.
+ 
+ 
+ .. code-block:: perl
+ 
+   winstall node1-node20 -o rhels5.1 -p compute
+ 
+ 
 
-\ **winstall**\  \ *node1-node20*\  -O rhels6.4-ppc64-netboot-compute
 
-Provision nodes 1 through 20 with the osimage rhels6.4-ppc64-netboot-compute.
+3. Provision nodes 1 through 20 with the osimage rhels6.4-ppc64-netboot-compute.
+ 
+ 
+ .. code-block:: perl
+ 
+   winstall node1-node20 -O rhels6.4-ppc64-netboot-compute
+ 
+ 
+
 
 
 ************************

--- a/docs/source/guides/admin-guides/references/man8/xcatconfig.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/xcatconfig.8.rst
@@ -19,17 +19,17 @@ SYNOPSIS
 ********
 
 
-\ **xcatconfig**\  {\ **-h**\ |\ **--help**\ }
+\ **xcatconfig**\  [\ **-h | -**\ **-help**\ ]
 
-\ **xcatconfig**\  {\ **-v**\ |\ **--version**\ }
+\ **xcatconfig**\  [\ **-v | -**\ **-version**\ ]
 
-\ **xcatconfig**\  {\ **-i**\ |\ **--initinstall**\ }  [\ **-V**\ |\ **--verbose**\ ]
+\ **xcatconfig**\  [\ **-i | -**\ **-initinstall**\ ] [\ **-V | -**\ **-verbose**\ ]
 
-\ **xcatconfig**\  {\ **-u**\ |\ **--updateinstall**\ }  [\ **-V**\ |\ **--verbose**\ ]
+\ **xcatconfig**\  [\ **-u | -**\ **-updateinstall**\ ] [\ **-V | -**\ **-verbose**\ ]
 
-\ **xcatconfig**\  [\ **-k**\ |\ **--sshkeys**\ ] [\ **-s**\ |\ **--sshnodehostkeys**\ ] [\ **-c**\ |\ **--credentials**\ ] [\ **-d**\ |\ **--database**\ ] [\ **-m**\ |\ **--mgtnode**\ ] [\ **-t**\ |\ **--tunables**\ ] [\ **-V**\ |\ **--verbose**\ ]
+\ **xcatconfig**\  [\ **-k | -**\ **-sshkeys**\ ] [\ **-s | -**\ **-sshnodehostkeys**\ ] [\ **-c | -**\ **-credentials**\ ] [\ **-d | -**\ **-database**\ ] [\ **-m | -**\ **-mgtnode**\ ] [\ **-t | -**\ **-tunables**\ ] [\ **-V | -**\ **-verbose**\ ]
 
-\ **xcatconfig**\  {\ **-f**\ |\ **--force**\ } [\ **-V**\ |\ **--verbose**\ ]
+\ **xcatconfig**\  [\ **-f | -**\ **-force**\ ] [\ **-V | -**\ **-verbose**\ ]
 
 
 ***********
@@ -46,62 +46,62 @@ OPTIONS
 
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Displays the usage message.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Displays the release version of the code.
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Displays verbose messages.
  
 
 
-\ **-i|--initialinstall**\ 
+\ **-i|-**\ **-initialinstall**\ 
  
  The install option is normally run as a post operation from the rpm xCAT.spec file during the initial install of xCAT on the Management Node. It will setup the root ssh keys, ssh node keys, xCAT credentials, initialize the datebase, export directories, start syslog and other daemons as needed after the initial install of xCAT.
  
 
 
-\ **-u|--updateinstall**\ 
+\ **-u|-**\ **-updateinstall**\ 
  
  The update install option is normally run as a post operation from the rpm xCAT.spec file during an update install of xCAT on the Management Node. It will check the setup the root ssh keys, ssh node keys, xCAT credentials, datebase, exported directories, syslog and the state of daemons needed by xCAT, after the updateinstall of xCAT. If setup is required, it will perform the operation.  It will restart the necessary daemons.
  
 
 
-\ **-k|--sshkeys**\ 
+\ **-k|-**\ **-sshkeys**\ 
  
  This option will remove and regenerate the root id_rsa keys.  It should only be used, if the keys are  deleted or corrupted. The keys must then be distribute to the nodes by installing, running updatenode -k, or using xdsh -K option, for root to be able to ssh to the nodes without being prompted for a password. 
  rspconfig will need to be run to distribute the key to the MM and HMCs. Any device, we need to ssh from the MN to the device will also have to be updated with the new ssh keys.
  
 
 
-\ **-s|--sshnodehostkeys**\ 
+\ **-s|-**\ **-sshnodehostkeys**\ 
  
  This option will remove and regenerate the node host ssh keys.  It should only be used, if the keys are deleted or are corrupted. The keys must then be redistribute to the nodes by installing, running updatenode -k  or using xdcp or pcp to copy the keys from /etc/xcat/hostkeys directory to the /etc/ssh directory on the nodes.
  
 
 
-\ **-c|--credentials**\ 
+\ **-c|-**\ **-credentials**\ 
  
  This option will remove all xcat credentials for root and any userids where credentials have been created. It will regenerate roots credentials,  but the admin will have to add back all the userid credentials needed with the /opt/xcat/share/xcat/scripts/setup-local-client.sh <username> command.  It should only be used, if they are deleted or become corrupted. The root credentials must be redistribed to the service nodes by installing the service node or using updatenode -k.  makeconservercf must be rerun to pick up the new credentials,  and conserver must be stop and started.
  
 
 
-\ **-d|--database**\ 
+\ **-d|-**\ **-database**\ 
  
  This option will reinitialize the basic xCAT database table setup.  It will not remove any new database entries that have been added, but it is strongly suggested that you backup you database (dumpxCATdb) before using it.
  
 
 
-\ **-f|--force**\ 
+\ **-f|-**\ **-force**\ 
  
  The force option may  be used after the install to reinitialize the Management Node. This option will  regenerate keys, credential and reinititialize the site table. This option should be used, if keys or credentials become corrupt or lost. 
  Additional action must be taken after using the force options.  ssh keys must be redistributed to the nodes, site table attributes might need to be restored, makeconservercf needs to be rerun to pick up the new credentials and conserver stoped and started, rspconfig needs to be rerun to distribute the new keys to the MM and the HMCs. 
@@ -110,13 +110,13 @@ OPTIONS
  
 
 
-\ **-m|--mgtnode**\ 
+\ **-m|-**\ **-mgtnode**\ 
  
  This option will add the Management Node to the database with the correct attributes set to be recognized by xCAT.  This should be run after the hostname of the Management Node is set to the name that  will resolve to the cluster-facing NIC.
  
 
 
-\ **-t|--tunables**\ 
+\ **-t|-**\ **-tunables**\ 
  
  This option will set tunable parameters on the Management and Service nodes recommended for your Linux cluster.  It will only set them during initial install, if you run xcatconfig -f or xcatconfig -t.
  
@@ -129,9 +129,7 @@ EXAMPLES
 
 
 
-1.
- 
- To force regeneration of keys and credentials and reinitialize the site table:
+1. To force regeneration of keys and credentials and reinitialize the site table:
  
  
  .. code-block:: perl
@@ -141,9 +139,7 @@ EXAMPLES
  
 
 
-2.
- 
- To regenerate root's ssh keys:
+2. To regenerate root's ssh keys:
  
  
  .. code-block:: perl
@@ -153,9 +149,7 @@ EXAMPLES
  
 
 
-3.
- 
- To regenerate node host ssh keys:
+3. To regenerate node host ssh keys:
  
  
  .. code-block:: perl
@@ -165,9 +159,7 @@ EXAMPLES
  
 
 
-4.
- 
- To regenerate node host ssh keys and credentials:
+4. To regenerate node host ssh keys and credentials:
  
  
  .. code-block:: perl
@@ -177,9 +169,7 @@ EXAMPLES
  
 
 
-5.
- 
- To add the Management Node to the DB:
+5. To add the Management Node to the DB:
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man8/xcatd.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/xcatd.8.rst
@@ -40,9 +40,7 @@ EXAMPLES
 
 
 
-1.
- 
- To start/stop/restart  xcatd on Linux, enter:
+1. To start/stop/restart  xcatd on Linux, enter:
  
  
  .. code-block:: perl
@@ -56,9 +54,7 @@ EXAMPLES
  
 
 
-2.
- 
- To start/stop/restart  xcatd on AIX, enter:
+2. To start/stop/restart  xcatd on AIX, enter:
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man8/xcatdebug.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/xcatdebug.8.rst
@@ -13,7 +13,12 @@ NAME
 
 \ **xcatdebug**\  - Enable or disable the trace facilities for xCAT. (Only supports Linux Operating System)
 
-\ **xcatdebug**\  { [\ **-f enable|disable**\  [\ **-c configuration file | subroutine list**\ ]] | [ \ **-d enable |disable**\ ]}
+
+****************************************************************************************************************************************************************************
+SYNOPSIS
+\ **xcatdebug**\  { [\ **-f enable**\  | \ **disable**\  [\ **-c**\  {\ *configuration file*\  | \ *subroutine list*\ }]] | [ \ **-d enable**\  | \ **disable**\ ]}
+****************************************************************************************************************************************************************************
+
 
 
 ***********
@@ -24,71 +29,55 @@ DESCRIPTION
 xCAT offers two trace facilities to debug the xCAT:
 
 
-\*
- 
- \ **Subroutine calling trace**\ 
- 
- Display the calling trace for subroutine when it is called.
- 
- The trace message includes: The name of the called subroutine; The arguments which passed to the called subroutine; The calling stack of the subroutine. By default, the trace will be enabled to all the subroutines in the xcatd and plugin modules. The target subroutine can be configured by configuration file or through xcatdebug command line.
- 
- The flag \ **-c**\  is used to specify the subroutine list for \ **subroutine calling trace**\ , it can only work with \ **-f**\ . The value of \ **-c**\  can be a configuration file or a subroutine list.
-   \ **configuration file**\ : a file contains multiple lines of \ **SUBROUTINE_DEFINITION**\ 
-   \ **subroutine list**\ :    \ **SUBROUTINE_DEFINITION**\ |\ **SUBROUTINE_DEFINITION**\ |...
- 
- \ **SUBROUTINE_DEFINITION**\ : is the element for the \ **-c**\  to specify the subroutine list.
- 
- The format of \ **SUBROUTINE_DEFINITION**\ : [plugin](subroutine1,subroutine2,...)
- 
- If ignoring the [plugin], the subroutines in the () should be defined in the xcatd.
-     e.g. (daemonize,do_installm_service,do_udp_service)
- 
- Otherwise, the package name of the plugin should be specified.
-     e.g. xCAT::Utils(isMN,Version)
-     e.g. xCAT_plugin::DBobjectdefs(defls,process_request)
- 
- The trace log will be written to /var/log/xcat/subcallingtrace. The log file subcallingtrace will be backed up for each running of the \ **xcatdebug -f enable**\ .
- 
+\ **Subroutine calling trace**\ 
+
+Display the calling trace for subroutine when it is called.
+
+The trace message includes: The name of the called subroutine; The arguments which passed to the called subroutine; The calling stack of the subroutine. By default, the trace will be enabled to all the subroutines in the xcatd and plugin modules. The target subroutine can be configured by configuration file or through xcatdebug command line.
+
+The flag \ **-c**\  is used to specify the subroutine list for \ **subroutine calling trace**\ , it can only work with \ **-f**\ . The value of \ **-c**\  can be a configuration file or a subroutine list.
+  \ **configuration file**\ : a file contains multiple lines of \ **SUBROUTINE_DEFINITION**\ 
+  \ **subroutine list**\ :    \ **SUBROUTINE_DEFINITION | SUBROUTINE_DEFINITION**\ |...
+
+\ **SUBROUTINE_DEFINITION**\ : is the element for the \ **-c**\  to specify the subroutine list.
+
+The format of \ **SUBROUTINE_DEFINITION**\ : [plugin](subroutine1,subroutine2,...)
+
+If ignoring the [plugin], the subroutines in the () should be defined in the xcatd.
+    e.g. (daemonize,do_installm_service,do_udp_service)
+
+Otherwise, the package name of the plugin should be specified.
+    e.g. xCAT::Utils(isMN,Version)
+    e.g. xCAT_plugin::DBobjectdefs(defls,process_request)
+
+The trace log will be written to /var/log/xcat/subcallingtrace. The log file subcallingtrace will be backed up for each running of the \ **xcatdebug -f enable**\ .
+
+\ **Commented trace log**\ 
+
+The trace log code is presented as comments in the code of xCAT. In general mode, it will be kept as comments. But in debug mode, it will be commented back as common code to display the trace log.
+
+NOTE: This facility can be enabled by pass the \ **ENABLE_TRACE_CODE=1**\  global variable when running the xcatd. e.g. ENABLE_TRACE_CODE=1 xcatd -f
+
+This facility offers two formats for the trace log code:
 
 
-\*
- 
- \ **Commented trace log**\ 
- 
- The trace log code is presented as comments in the code of xCAT. In general mode, it will be kept as comments. But in debug mode, it will be commented back as common code to display the trace log.
- 
- NOTE: This facility can be enabled by pass the \ **ENABLE_TRACE_CODE=1**\  global variable when running the xcatd. e.g. ENABLE_TRACE_CODE=1 xcatd -f
- 
- This facility offers two formats for the trace log code:
- 
- 
- \*
-  
-  Trace section
-      ## TRACE_BEGIN
-      # print "In the debug\n";
-      ## TRACE_END
-  
- 
- 
- \*
-  
-  Trace in a single line
-      ## TRACE_LINE print "In the trace line\n";
-  
- 
- 
- The \ **commented trace log**\  can be added in xcatd and plugin modules. But following section has been added into the BEGIN {} section of the target plugin module to enable the facility.
- 
- 
- .. code-block:: perl
- 
-     if (defined $ENV{ENABLE_TRACE_CODE}) {
-       use xCAT::Enabletrace qw(loadtrace filter);
-       loadtrace();
-     }
- 
- 
+Trace section
+    ## TRACE_BEGIN
+    # print "In the debug\n";
+    ## TRACE_END
+
+Trace in a single line
+    ## TRACE_LINE print "In the trace line\n";
+
+The \ **commented trace log**\  can be added in xcatd and plugin modules. But following section has been added into the BEGIN {} section of the target plugin module to enable the facility.
+
+
+.. code-block:: perl
+
+    if (defined $ENV{ENABLE_TRACE_CODE}) {
+      use xCAT::Enabletrace qw(loadtrace filter);
+      loadtrace();
+    }
 
 
 
@@ -113,21 +102,15 @@ OPTIONS
  Specify the configuration file or subroutine list.
  
  
- \*
-  
-  \ **configuration file**\ : a file contains multiple lines of \ **SUBROUTINE_DEFINITION**\ 
-    e.g.
-      (plugin_command)
-      xCAT_plugin::DBobjectdefs(defls,process_request)
-      xCAT::DBobjUtils(getobjdefs)
-  
+ \ **configuration file**\ : a file contains multiple lines of \ **SUBROUTINE_DEFINITION**\ 
+   e.g.
+     (plugin_command)
+     xCAT_plugin::DBobjectdefs(defls,process_request)
+     xCAT::DBobjUtils(getobjdefs)
  
- 
- \*   \ **subroutine list**\ : a string like  \ **SUBROUTINE_DEFINITION**\ |\ **SUBROUTINE_DEFINITION**\ |...
+ \ **subroutine list**\ : a string like  \ **SUBROUTINE_DEFINITION | SUBROUTINE_DEFINITION**\ |...
    e.g.
      "(plugin_command)|xCAT_plugin::DBobjectdefs(defls,process_request)|xCAT::DBobjUtils(getobjdefs)"
- 
- 
  
 
 
@@ -135,7 +118,7 @@ OPTIONS
  
  Enable or disable the \ **commented trace log**\ .
  
- Note: The xcatd will be restarted for the performing of \ **-d**\ .
+ Note: The xcatd will be restarted for the performing of \ **-d**\ 
  
 
 
@@ -146,45 +129,33 @@ EXAMPLES
 
 
 
-1
- 
- Enable the \ **subroutine calling trace**\  for all the subroutines in the xcatd and plugin modules.
-   \ **xcatdebug**\  -f enable
- 
+1. Enable the \ **subroutine calling trace**\  for all the subroutines in the xcatd and plugin modules.
+ xcatdebug -f enable
 
 
-2
- 
- Enable the \ **subroutine calling trace**\  for the subroutines configured in the /opt/xcat/share/xcat/samples/tracelevel0
-   \ **xcatdebug**\  -f enable -c /opt/xcat/share/xcat/samples/tracelevel0
- 
+
+2. Enable the \ **subroutine calling trace**\  for the subroutines configured in the /opt/xcat/share/xcat/samples/tracelevel0
+ xcatdebug -f enable -c /opt/xcat/share/xcat/samples/tracelevel0
 
 
-3
- 
- Enable the \ **subroutine calling trace**\  for the plugin_command in xcatd and defls,process_request in the xCAT_plugin::DBobjectdefs module.
-   \ **xcatdebug**\  -f enable -c "xCAT_plugin::DBobjectdefs(defls,process_request)|(plugin_command)"
- 
+
+3. Enable the \ **subroutine calling trace**\  for the plugin_command in xcatd and defls,process_request in the xCAT_plugin::DBobjectdefs module.
+ xcatdebug -f enable -c "xCAT_plugin::DBobjectdefs(defls,process_request)|(plugin_command)"
 
 
-4
- 
- Disable the \ **subroutine calling trace**\  for all the subroutines which have been enabled by \ **xcatdebug -f enable**\ .
-   \ **xcatdebug**\  -f disable
- 
+
+4. Disable the \ **subroutine calling trace**\  for all the subroutines which have been enabled by \ **xcatdebug -f enable**\ .
+ xcatdebug -f disable
 
 
-5
- 
- Enable the \ **commented trace log**\ 
-   \ **xcatdebug**\  -d enable
- 
+
+5. Enable the \ **commented trace log**\ 
+ xcatdebug -d enable
 
 
-6
- 
- Enable both the \ **subroutine calling trace**\  and \ **commented trace log**\ 
-   \ **xcatdebug**\  -f enable -c /opt/xcat/share/xcat/samples/tracelevel0 -d enable
- 
+
+6. Enable both the \ **subroutine calling trace**\  and \ **commented trace log**\ 
+  xcatdebug -f enable -c /opt/xcat/share/xcat/samples/tracelevel0 -d enable
+
 
 

--- a/docs/source/guides/admin-guides/references/man8/xcatsetup.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/xcatsetup.8.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **xcatsetup**\  [\ **-s|--stanzas**\  \ *stanza-list*\ ] [\ **--yesreallydeletenodes**\ ] \ *cluster-config-file*\ 
+\ **xcatsetup**\  [\ **-s|-**\ **-stanzas**\  \ *stanza-list*\ ] [\ **-**\ **-yesreallydeletenodes**\ ] \ *cluster-config-file*\ 
 
-\ **xcatsetup**\  [\ **-?**\  | \ **-h**\  | \ **--help**\  | \ **-v**\  | \ **--version**\ ]
+\ **xcatsetup**\  [\ **-?**\  | \ **-h**\  | \ **-**\ **-help**\  | \ **-v**\  | \ **-**\ **-version**\ ]
 
 
 ***********
@@ -35,49 +35,49 @@ representing this cluster configuration.  The \ **xcatsetup**\  command prepares
 the hardware that is connected to the service and cluster networks.  The typical steps of setting up a system p cluster are:
 
 
-\*
+1.
  
  Install the xCAT software on the management node
  
 
 
-\*
+2.
  
  Create the cluster config file and run xcatsetup
  
 
 
-\*
+3.
  
  Put hardware control passwords in the ppchcp or ppcdirect database table
  
 
 
-\*
+4.
  
  Run makenetworks and makedhcp
  
 
 
-\*
+5.
  
  Run the discovery commands (lsslp, mkhwconn, rspconfig) as described in the System P Hardware Management cookbook.
  
 
 
-\*
+6.
  
  Configure and start services using makehosts, makedns, mkconserver.cf, etc.
  
 
 
-\*
+7.
  
  Create the images that should be installed or booted on the nodes
  
 
 
-\*
+8.
  
  Run nodeset and rpower/rnetboot to boot up the nodes.
  
@@ -107,17 +107,15 @@ use individual rows for every node, you can do the following:
 Many of the sections and attributes in the configuration file can be omitted, if you have a simple cluster, or if you want
 to create just 1 or 2 of the object types at this time.  See the section \ **A Simpler Configuration File**\  for an example of this.
 
-If you want to delete all of the nodes that xcatsetup created, and start over, use the \ **--yesreallydeletenodes**\  option.
+If you want to delete all of the nodes that xcatsetup created, and start over, use the \ **-**\ **-yesreallydeletenodes**\  option.
 
 Restrictions
 ============
 
 
 
-\*
- 
- The \ **xcatsetup**\  command has only been implemented and tested for system p servers so far.
- 
+1. The \ **xcatsetup**\  command has only been implemented and tested for system p servers so far.
+
 
 
 
@@ -495,7 +493,7 @@ OPTIONS
 
 
 
-\ **-s|--stanzas**\  \ *stanza-list*\ 
+\ **-s|-**\ **-stanzas**\  \ *stanza-list*\ 
  
  A comma-separated list of stanza names that \ **xcatsetup**\  should process in the configuration file.  If not specified, it will process
  all the stanzas that start with 'xcat' and some other stanzas that give xCAT hints about how to set up the HPC products.
@@ -505,19 +503,19 @@ OPTIONS
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command Version.
  
 
 
-\ **-?|-h|--help**\ 
+\ **-?|-h|-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **--yesreallydeletenodes**\ 
+\ **-**\ **-yesreallydeletenodes**\ 
  
  Delete the nodes represented in the cluster config file, instead of creating them.  This is useful if your first attempt with the cluster
  config file wasn't quite right and you want to start over.  But use this option with extreme caution, because it will potentially delete
@@ -533,9 +531,14 @@ RETURN VALUE
 ************
 
 
-0  The command completed successfully.
 
-1  An error has occurred.
+0.   The command completed successfully.
+
+
+
+1.   An error has occurred.
+
+
 
 
 ********
@@ -544,10 +547,8 @@ EXAMPLES
 
 
 
-1.
- 
- Use the sample config.txt file at the beginning of this man page to create all the objects/nodes for a
- 2 building block cluster.
+1. Use the sample config.txt file at the beginning of this man page to create all the objects/nodes for a
+2 building block cluster.
  
  
  .. code-block:: perl
@@ -570,9 +571,7 @@ EXAMPLES
  
 
 
-2.
- 
- Use the simpler config file shown earlier in this man page to create just the frame and cec objects:
+2. Use the simpler config file shown earlier in this man page to create just the frame and cec objects:
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man8/xcatsnap.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/xcatsnap.8.rst
@@ -13,13 +13,21 @@ NAME
 
 \ **xcatsnap**\  - Gathers information for service about the current running xCAT environment.
 
-\ **xcatsnap**\  {\ **-h**\ |\ **--help**\ }
 
-\ **xcatsnap**\  {\ **-v**\ |\ **--version**\ }
+********
+SYNOPSIS
+********
 
-\ **xcatsnap**\  {\ **-B**\ |\ **--BYPASS**\ }
 
-\ **xcatsnap**\  {\ **-d**\ |\ **--dir**\ }
+\ **xcatsnap**\ 
+
+\ **xcatsnap**\  [\ **-h | -**\ **-help**\ ]
+
+\ **xcatsnap**\  [\ **-v | -**\ **-version**\ ]
+
+\ **xcatsnap**\  [\ **-B | -**\ **-bypass**\ ]
+
+\ **xcatsnap**\  [\ **-d | -**\ **-dir**\ ]
 
 
 ***********
@@ -38,25 +46,25 @@ OPTIONS
 
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Displays the usage message.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Displays the release version of the code.
  
 
 
-\ **-B|--bypass**\ 
+\ **-B|-**\ **-bypass**\ 
  
  Runs in bypass mode, use if the xcatd daemon is hung.
  
 
 
-\ **-d|--dir**\ 
+\ **-d|-**\ **-dir**\ 
  
  The directory to put the snap information.  Default is /tmp/xcatsnap.
  
@@ -75,19 +83,23 @@ EXAMPLES
 
 
 
-\*
+1. Run the xcatsnap routine in bypass mode and put info in /tmp/mydir :
  
- Run the xcatsnap routine in bypass mode and put info in /tmp/mydir :
  
- \ **xcatsnap**\  \ *-B*\  \ *-d*\  /tmp/mydir
+ .. code-block:: perl
+ 
+   xcatsnap -B -d /tmp/mydir
+ 
  
 
 
-\*
+2.  To run the xcatsnap routine and use default directory /tmp/xcatsnap :
  
- To run the xcatsnap routine and use default directory /tmp/xcatsnap :
  
- \ **xcatsnap**\ 
+ .. code-block:: perl
+ 
+   xcatsnap
+ 
  
 
 

--- a/xCAT-client/pods/man8/chtab.8.pod
+++ b/xCAT-client/pods/man8/chtab.8.pod
@@ -4,15 +4,15 @@ B<chtab> - Add, delete or update rows in the database tables.
 
 =head1 SYNOPSIS
 
-I<chtab [-h| --help]>
+B<chtab> [B<-h> | B<--help>]
 
-I<chtab [-v| --version]>
+B<chtab> [B<-v> | B<--version>]
 
-I<chtab [keycolname=keyvalue] [tablename.colname=newvalue] >
+B<chtab> [I<keycolname=keyvalue>] [I<tablename.colname=newvalue>]
 
-I<chtab [keycolname=keyvalue] [tablename.colname+=newvalue] >
+B<chtab> [I<keycolname=keyvalue>] [I<tablename.colname+=newvalue>]
 
-I<chtab -d [keycolname=keyvalue] [tablename.colname=newvalue] >
+B<chtab -d> [I<keycolname=keyvalue>] [I<tablename.colname=newvalue>]
 
 =head1 DESCRIPTION
 
@@ -32,38 +32,53 @@ B<-d>          Delete option.
 
 =head1 RETURN VALUE
 
-0 The command completed successfully.
+=over 2
 
-1 An error has occurred.
+=item 0. 
+The command completed successfully.
+
+=item 1. 
+An error has occurred.
+
+=back
 
 =head1 EXAMPLES
 
-1. To add a node=node1 to the nodelist table with groups=all:
+=over 2
 
-I<chtab  node=node1 nodelist.groups=all >
+=item 1. 
+To add a node=node1 to the nodelist table with groups=all:
 
-2. To add a keyword (tftpdir) and value (/tftpboot) to the site table:
+ chtab  node=node1 nodelist.groups=all
 
-I<chtab  key=tftpdir site.value=/tftpboot >
+=item 2.
+To add a keyword (tftpdir) and value (/tftpboot) to the site table:
 
-
-3. To add node1 to the  nodetype table with os=rhel5:
-
-I<chtab  node=node1 nodetype.os=rhel5>
+ chtab  key=tftpdir site.value=/tftpboot
 
 
-4. To change node1 in nodetype table setting os=sles:
+=item 3. 
+To add node1 to the  nodetype table with os=rhel5:
 
-I<chtab  node=node1 nodetype.os=sles>
+ chtab  node=node1 nodetype.os=rhel5
 
-5. To change node1 by appending otherpkgs to the postbootscripts field in the postscripts table:
 
-I<chtab node=node1 postscripts.postbootscripts+=otherpkgs>
+=item 4. 
+To change node1 in nodetype table setting os=sles:
 
-6. To delete node1 from nodetype table:
+ chtab  node=node1 nodetype.os=sles
 
-I<chtab -d node=node1 nodetype>
+=item 5.
+To change node1 by appending otherpkgs to the postbootscripts field in the postscripts table:
 
+ chtab node=node1 postscripts.postbootscripts+=otherpkgs
+
+=item 6.
+To delete node1 from nodetype table:
+
+ chtab -d node=node1 nodetype
+
+=back
 
 =head1 FILES
 

--- a/xCAT-client/pods/man8/copycds.8.pod
+++ b/xCAT-client/pods/man8/copycds.8.pod
@@ -4,9 +4,9 @@ B<copycds> - Copies Linux distributions and service levels from DVDs/ISOs to the
 
 =head1 SYNOPSIS
 
-B<copycds> [{B<-n|--name|--osver>}=I<distroname>] [{B<-a|--arch>}=I<architecture>] [{B<-p|--path>}=I<ospkgpath>] [B<-o>|B<--noosimage>] [B<-w>|B<--nonoverwrite>] {I<iso>|I<device-path>} ...
+B<copycds> [{B<-n|--name|--osver>}=I<distroname>] [{B<-a|--arch>}=I<architecture>] [{B<-p|--path>}=I<ospkgpath>] [B<-o>|B<--noosimage>] [B<-w>|B<--nonoverwrite>] {I<iso | device-path>} ...
 
-B<copycds> [B<-i>|B<--inspection>] {I<iso>|I<device-path>}
+B<copycds> [B<-i>|B<--inspection>] {I<iso | device-path>}
 
 B<copycds> [B<-h>|B<--help>]
 
@@ -14,7 +14,7 @@ B<copycds> [B<-h>|B<--help>]
 
 The B<copycds> command copies all contents of Distribution DVDs/ISOs or Service Pack DVDs/ISOs to a destination directory. The destination directory can be specified by the -p option. If no path is specified, the default destination directory will be formed from the B<installdir> site attribute and the distro name and architecture, for example: /install/rhels6.3/x86_64. The B<copycds> command can copy from one or more ISO files, or the CD/DVD device path.
 
-You can specify -i or --inspection option to check whether the DVDs/ISOs can be recognized by xCAT. If recognized, the distribution name, architecture and the disc no (the disc sequence number of DVDs/ISOs in multi-disk distribution) of the DVD/ISO is displayed. If xCAT doesn't recognize the DVD/ISO, you must manually specify the distro name and architecture using the -n and -a options. This is sometimes the case for distros that have very recently been released, and the xCAT code hasn't been updated for it yet.
+You can specify B<-i> or B<--inspection> option to check whether the DVDs/ISOs can be recognized by xCAT. If recognized, the distribution name, architecture and the disc no (the disc sequence number of DVDs/ISOs in multi-disk distribution) of the DVD/ISO is displayed. If xCAT doesn't recognize the DVD/ISO, you must manually specify the distro name and architecture using the -n and -a options. This is sometimes the case for distros that have very recently been released, and the xCAT code hasn't been updated for it yet.
 
 You can get xCAT to recognize new DVDs/ISOs by adding them to /opt/xcat/lib/perl/xCAT/data/discinfo.pm and reloading xcatd (service xcatd reload).
 
@@ -22,27 +22,27 @@ You can get xCAT to recognize new DVDs/ISOs by adding them to /opt/xcat/lib/perl
 
 =over 6
 
-=item {B<-n|--name|--osver>}=I<distroname>
+=item B<-n|--name|--osver>=I<distroname>
 
 The linux distro name and version that the ISO/DVD contains.  Examples:  rhels6.3, sles11.2, fedora9.  Note the 's' in rhels6.3 which denotes the Server version of RHEL, which is typically used.
 
-=item {B<-a|--arch>}=I<architecture>
+=item B<-a|--arch>=I<architecture>
 
 The architecture of the linux distro on the ISO/DVD.  Examples:  x86, x86_64, ppc64, s390x.
 
-=item {B<-p|--path>}=I<ospkgpath>
+=item B<-p|--path>=I<ospkgpath>
 
 The destination directory to which the contents of ISO/DVD will be copied. When this option is not specified, the default destination directory will be formed from the B<installdir> site attribute and the distro name and architecture, for example: /install/rhel6.3/x86_64. This option is only supported distributions of sles,redhat and windows.
 
-=item {B<-i|--inspection>}
+=item B<-i|--inspection>
 
 Check whether xCAT can recognize the DVDs/ISOs in the argument list, but do not copy the disc. Displays the os distribution name, architecture and disc no of each recognized DVD/ISO. This option only supported for distributions of sles,redhat and windows.
 
-=item {B<-o|--noosimage>}
+=item B<-o|--noosimage>
 
 Do not create the default osimages based on the osdistro copied in. By default, copycds will create a set of osimages based on the osdistro.
 
-=item {B<-w|--nonoverwrite>}
+=item B<-w|--nonoverwrite>
 
 Complain and exit if the os disc has already been copied in. By default, copycds will overwrite the os disc already copied in.
 
@@ -50,34 +50,30 @@ Complain and exit if the os disc has already been copied in. By default, copycds
 
 =head1 RETURN VALUE
 
-0: The command completed successfully. For the --inspection option, the ISO/DVD have been recognized successfully
+0: The command completed successfully. For the B<--inspection> option, the ISO/DVD have been recognized successfully
 
-Nonzero: An Error has occurred. For the --inspection option, the ISO/DVD cannot be recognized
+Nonzero: An Error has occurred. For the B<--inspection> option, the ISO/DVD cannot be recognized
 
 =head1 EXAMPLES
 
 =over 2
 
-=item *
-
+=item 1.
 To copy the RPMs from a set of ISOs that represent the DVDs of a distro:
 
  copycds dvd1.iso dvd2.iso
 
-=item *
-
+=item 2.
 To copy the RPMs from a physical DVD to /depot/kits/3 directory:
 
  copycds -p /depot/kits/3 /dev/dvd
 
-=item *
-
+=item 3.
 To copy the RPMs from a DVD ISO of a very recently released distro:
 
  copycds -n rhels6.4 -a x86_64 dvd.iso
 
-=item *
-
+=item 4.
 To check whether a DVD ISO can be recognized by xCAT and display the recognized disc info:
 
  copycds -i /media/RHEL/6.2/RHEL6.2-20111117.0-Server-ppc64-DVD1.iso
@@ -91,8 +87,7 @@ Output will be similar to:
 
 For the attributes that are not recognized, the value will be blank.
 
-=item *
-
+=item 5.
 To copy the packages from a supplemental DVD ISO file:
 
  copycds -n /isodir/RHEL6.5/RHEL6.5-Supplementary-20131114.2-Server-ppc64-DVD1.iso -n rhels6.5-supp

--- a/xCAT-client/pods/man8/makeconservercf.8.pod
+++ b/xCAT-client/pods/man8/makeconservercf.8.pod
@@ -68,28 +68,31 @@ Display usage message.
 
 =head1 RETURN VALUE
 
-0 The command completed successfully.
+=over 2
 
-1 An error has occurred.
+=item 0. 
+The command completed successfully.
+
+=item 1. 
+An error has occurred.
+
+=back
 
 =head1 EXAMPLES
 
-=over 3
+=over 2
 
 =item 1.
-
 To create conserver configuration for all the nodes.
 
  makeconservercf
 
 =item 2.
-
 To create conserver configuration for nodes node01-node10.
 
  makeconservercf node01-node10
 
 =item 3.
-
 To remove conserver configuration for node01.
 
  makeconservercf -d node01

--- a/xCAT-client/pods/man8/makedhcp.8.pod
+++ b/xCAT-client/pods/man8/makedhcp.8.pod
@@ -16,7 +16,7 @@ B<makedhcp> I<noderange> [B<-s> I<statements>] [B<-l>|B<--localonly>]
 
 B<makedhcp> B<-q> I<noderange>
 
-B<makedhcp> [I<-h|--help>]
+B<makedhcp> B<[-h|--help]>
 
 =head1 DESCRIPTION
 
@@ -101,22 +101,26 @@ Display usage message.
 
 =head1 RETURN VALUE
 
-0 The command completed successfully.
+=over 2
 
-1 An error has occurred.
+=item 0.
+The command completed successfully.
+
+=item 1. 
+An error has occurred.
+
+=back
 
 =head1 EXAMPLES
 
-=over 3
+=over 2
 
 =item 1.
-
 Create a new DHCP configuration file and add the network definitions:
 
  makedhcp -n
 
 =item 2.
-
 Define all nodes to the dhcp server:
 
  makedhcp -a
@@ -124,13 +128,11 @@ Define all nodes to the dhcp server:
 Note:  This does not add nodes that will be installed with AIX/NIM.
 
 =item 3.
-
 Will cause dhcp on the next request to set root-path appropriately for only node5.  Note some characters (e.g. ") must be doubly escaped (once for the shell, and once for the OMAPI layer).
 
  makedhcp node5 -s 'option root-path  \"172.16.0.1:/install/freebsd6.2/x86_64\";'
 
 =item 4.
-
 Query a node from the DHCP server. 
 
  # makedhcp -q node01 

--- a/xCAT-client/pods/man8/makedns.8.pod
+++ b/xCAT-client/pods/man8/makedns.8.pod
@@ -4,11 +4,11 @@ B<makedns> - sets up domain name services (DNS).
 
 =head1 SYNOPSIS
 
-B<makedns> [I<-h>|I<--help>]
+B<makedns> [B<-h>|B<--help>]
 
-B<makedns> [-V|--verbose] [-e|--external] [I<-n>|I<--new>] [I<noderange>]
+B<makedns> [B<-V>|B<--verbose>] [B<-e>|B<--external>] [B<-n>|B<--new>] [I<noderange>]
 
-B<makedns> [-V|--verbose] [-e|--external] [I<-d>|I<--delete> I<noderange>]
+B<makedns> [B<-V>|B<--verbose>] [B<-e>|B<--external>] [B<-d>|B<--delete> I<noderange>]
 
 =head1 DESCRIPTION
 
@@ -63,31 +63,27 @@ A set of comma delimited node names and/or group names. See the "noderange" man 
 
 =head1 Examples
 
-=over 6
+=over 2
 
-=item 1
-
+=item 1.
 To set up DNS for all the hosts in /etc/hosts file.
 
-B<makedns>
+ makedns
 
-=item 2
-
+=item 2.
 To set up DNS for I<node1>.
 
-B<makedns> I<node1>
+ makedns node1
 
-=item 3
-
+=item 3.
 To create a new named configuration and db files for all hosts in /etc/hosts.
 
-B<makedns> B<-n>
+ makedns -n
 
-=item 4
-
+=item 4.
 To delete the DNS records for I<node1>.
 
-B<makedns> B<-d> I<node1>
+ makedns -d node1
 
 =back
 

--- a/xCAT-client/pods/man8/makehosts.8.pod
+++ b/xCAT-client/pods/man8/makehosts.8.pod
@@ -53,14 +53,12 @@ Delete rather than create records. This will also delete any additional network 
 
 =over 2
 
-=item *
-
+=item 1.
 Add entries to /etc/hosts for all nodes included in the xCAT node group called "compute".
 
   makehosts compute
 
-=item *
-
+=item 2.
 If the xCAT hosts table contains:
 
   "compute","|node(\d+)|1.2.3.($1+0)|","|(.*)|($1).cluster.net|",,

--- a/xCAT-client/pods/man8/makeknownhosts.8.pod
+++ b/xCAT-client/pods/man8/makeknownhosts.8.pod
@@ -6,7 +6,7 @@ B<makeknownhosts> - Make a known_hosts file under $ROOTHOME/.ssh for input noder
 
 B<makeknownhosts> I<noderange> [B<-r>|B<--remove>] [B<-V>|B<--verbose>]
 
-B<makeknownhosts> {B<-h>|B<--help>}
+B<makeknownhosts> [B<-h>|B<--help>]
 
 =head1 DESCRIPTION
 
@@ -43,17 +43,20 @@ Verbose mode.
 
 =over 2
 
-=item *
+=item 1.
+To build the known_hosts entry for the nodes in the compute group
 
-makeknownhosts compute
+ makeknownhosts compute
 
-=item *
+=item 2.
+To build the known_hosts entry for the nodes in the lpars and service groups
 
-makeknownhosts lpars,service 
+ makeknownhosts lpars,service 
 
-=item *
+=item 3.
+To remove the known_hosts entry for node02
 
-makeknownhosts node02 -r
+ makeknownhosts node02 -r
 
 =back
 

--- a/xCAT-client/pods/man8/makenetworks.8.pod
+++ b/xCAT-client/pods/man8/makenetworks.8.pod
@@ -4,11 +4,11 @@ B<makenetworks> - Gather cluster network information and add it to the xCAT data
 
 =head1 SYNOPSIS
 
-I<makenetworks [-h|--help ]>
+B<makenetworks> [B<-h> | B<--help> ]
 
-I<makenetworks [-v| --version]>
+B<makenetworks> [B<-v> | B<--version>]
 
-I<makenetworks [-V|--verbose] [-d|--display]>
+B<makenetworks> [B<-V> | B<--verbose>] [B<-d>|B<--display>]
 
 =head1 DESCRIPTION
 
@@ -53,17 +53,27 @@ B<-V |--verbose>       Verbose mode.
 
 =head1 RETURN VALUE
 
-0 The command completed successfully.
+=over 2
 
-1 An error has occurred.
+=item 0. 
+The command completed successfully.
+
+=item 1. 
+An error has occurred.
+
+=back
 
 =head1 EXAMPLES
 
-1.  Gather cluster network information and create xCAT network definitions.
+=over 2
+
+=item 1.
+Gather cluster network information and create xCAT network definitions.
 
 	makenetworks
 
-2.  Display cluster network information but do not write the network definitions to the xCAT database.
+=item 2.
+Display cluster network information but do not write the network definitions to the xCAT database.
 
 	makenetworks -d
 
@@ -74,6 +84,8 @@ The output would be one or more stanzas of information similar to the following.
     gateway=9.114.37.254
     mask=255.255.255.0
     net=9.114.37.0
+
+=back
 
 =head1 FILES
 

--- a/xCAT-client/pods/man8/makeroutes.8.pod
+++ b/xCAT-client/pods/man8/makeroutes.8.pod
@@ -6,13 +6,13 @@ B<makeroutes> - add or delete routes to/from the os route table on nodes.
 
 B<makeroutes> [B<-r>|B<--routename> I<r1>[I<,r2...>]] 
 
-B<makeroutes> B<-d>|B<--delete> [B<-r>|B<--routenames> I<r1>[I<,r2...>]]
+B<makeroutes> [B<-d>|B<--delete>] [B<-r>|B<--routenames> I<r1>[I<,r2...>]]
 
 B<makeroutes> I<noderange> [B<-r>|B<--routename> I<r1>[I<,r2...>]] 
 
-B<makeroutes> I<noderange> B<-d>|B<--delete> [B<-r>|B<--routenames> I<r1>[I<,r2...>]]
+B<makeroutes> I<noderange> [B<-d>|B<--delete>] [B<-r>|B<--routenames> I<r1>[I<,r2...>]]
 
-B<makeroutes> [B<-h> B<--help>|B<-v>|B<--version>]
+B<makeroutes> [B<-h>|B<--help>|B<-v>|B<--version>]
 
 =head1 DESCRIPTION
 
@@ -51,32 +51,27 @@ Command Version.
 
 =head1 EXAMPLES
 
-=over 3
+=over 2
 
 =item 1.
-
 To add all routes from the B<site.mnroutenames> to the os route table for the management node.
 
  makeroutes
 
 =item 2.
-
 To add all the routes from B<noderes.routenames> to the os route table for node1.
 
  makeroutes node1
 
 =item 3.
-
 To add route rr1 and rr2 to the os route table for the management node.
 
  makeroutes -r rr1,rr2
 
 =item 4.
-
 To delete route rr1 and rr2 from the os route table on node1 and node1.
 
  makeroutes node1,node2 -d -r rr1,rr2
-
 
 =back
 

--- a/xCAT-client/pods/man8/mknb.8.pod
+++ b/xCAT-client/pods/man8/mknb.8.pod
@@ -31,9 +31,15 @@ The hardware architecture for which to build the boot image: x86_64
 
 =head1 RETURN VALUE
 
-0 The command completed successfully.
+=over 2
 
-1 An error has occurred.
+=item 0. 
+The command completed successfully.
+
+=item 1. 
+An error has occurred.
+
+=back
 
 
 =head1 SEE ALSO

--- a/xCAT-client/pods/man8/nodeadd.8.pod
+++ b/xCAT-client/pods/man8/nodeadd.8.pod
@@ -7,7 +7,7 @@ B<nodeadd> - Adds nodes to the xCAT cluster database.
 
 B<nodeadd> I<noderange> B<groups>=I<groupnames> [I<table.column=value>] [I<...>]
 
-B<nodeadd> {B<-v> | B<--version>}
+B<nodeadd> [B<-v> | B<--version>]
 
 B<nodeadd> [B<-?> | B<-h> | B<--help>]
 
@@ -43,12 +43,10 @@ Display usage message.
 
 =over 3
 
-=item 0
-
+=item 0. 
 The command completed successfully.
 
-=item 1
-
+=item 1. 
 An error has occurred.
 
 =back
@@ -58,17 +56,15 @@ An error has occurred.
 
 =over 2
 
-=item *
-
+=item 1.
 To add nodes in noderange  node1-node4 with group all:
 
-B<nodeadd> I<node1-node4 groups=all>
+ nodeadd node1-node4 groups=all
 
-=item *
-
+=item 2.
 To add nodes in noderange  node1-node4 to the nodetype table with os=rhel5:
 
-B<nodeadd> I<node1-node4 groups=all,rhel5 nodetype.os=rhel5>
+ nodeadd node1-node4 groups=all,rhel5 nodetype.os=rhel5
 
 =back
 

--- a/xCAT-client/pods/man8/nodeset.8.pod
+++ b/xCAT-client/pods/man8/nodeset.8.pod
@@ -4,11 +4,13 @@ B<nodeset> - set the boot state for a noderange
 
 =head1 B<Synopsis>
 
-B<nodeset> [I<noderange>] [I<boot>|I<stat>|I<iscsiboot>|I<offline>|I<runcmd=bmcsetup>|I<osimage[=<imagename>>]|I<shell>|I<shutdown>]
+B<nodeset> [I<noderange>] [B<boot> | B<stat> | B<iscsiboot> | B<offline> | B<runcmd=bmcsetup> | B<osimage>= I<imagename> | B<shell> | B<shutdown>]
 
-B<nodeset> I<noderange> I<osimage=<imagename>> [I<--noupdateinitrd>] [I<--ignorekernelchk>]
+B<nodeset> I<noderange> B<osimage=> I<imagename> [B<--noupdateinitrd>] [B<--ignorekernelchk>]
 
-B<nodeset> [I<-h>|I<--help>|I<-v>|I<--version>]
+B<nodeset> I<noderange> B<runimage=> I<task>
+
+B<nodeset> [B<-h>|B<--help>|B<-v>|B<--version>]
 
 =head1 B<Description>
 
@@ -60,7 +62,7 @@ should be run to rebuild the initrd for new drivers injecting. This is used to i
 
 Skip the kernel version checking when injecting drivers from osimage.driverupdatesrc. That means all drivers from osimage.driverupdatesrc will be injected to initrd for the specific target kernel.
 
-=item B<runimage>=<task>>
+=item B<runimage>=I<task>
 
 If you would like to run a task after deployment, you can define that task with this attribute.    
 
@@ -112,19 +114,17 @@ root directory and the TFTP xCAT  subdirectory.   /tftpboot  and
 
 =head1 B<Examples>
 
-=over 3
+=over 2
 
-=item *
-
+=item 1.
 To setup to install mycomputeimage on the compute node group.
 
-nodeset compute osimage=mycomputeimage
+ nodeset compute osimage=mycomputeimage
 
-=item *
-
+=item 2.
 To run http://$master/image.tgz  after deployment:
 
-nodeset $node runimage=http://$MASTER/image.tgznodeset
+ nodeset $node runimage=http://$MASTER/image.tgz
 
 =back
 

--- a/xCAT-client/pods/man8/rescanplugins.8.pod
+++ b/xCAT-client/pods/man8/rescanplugins.8.pod
@@ -6,9 +6,9 @@ B<rescanplugins> - Notifies xcatd to rescan the plugin directory
 
 B<rescanplugins> 
 
-B<rescanplugins> {B<-h>|B<--help>}
+B<rescanplugins> [B<-h>|B<--help>]
 
-B<rescanplugins> {B<-v>|B<--version>}
+B<rescanplugins> [B<-v>|B<--version>]
 
 B<rescanplugins> [B<-s>|B<--servicenodes>]
 
@@ -41,16 +41,14 @@ Process the rescanplugins on the management node and on all service nodes.  The 
 
 =over 2
 
-=item *
-
+=item 1.
 To rescan the plugins only on the xCAT Management Node:
 
-B<rescanplugins> 
+ rescanplugins 
 
-=item *
-
+=item 2.
 To rescan the plugins on the xCAT Management Node and on all service nodes:
 
-B<rescanplugins -s> 
+ rescanplugins -s 
 
 =back

--- a/xCAT-client/pods/man8/rinstall.8.pod
+++ b/xCAT-client/pods/man8/rinstall.8.pod
@@ -4,13 +4,13 @@ B<rinstall> - Begin OS provision on a noderange
 
 =head1 B<Synopsis>
 
-B<rinstall> [I<-O>|I<--osimage>] [I<-c>|I<--console>] [I<noderange>]
+B<rinstall> [B<-O>|B<--osimage>] [B<-c>|B<--console>] [B<noderange>]
 
 =head1 B<Description>
 
 B<rinstall> is a convenience command that will change tables as requested for operating system version, profile, and architecture, call B<nodeset> to modify the network boot configuration, call B<rsetboot> net to set the next boot over network (only support nodes with "nodetype.mgt=ipmi", for other nodes, make sure the correct boot order has been set before B<rinstall>), and B<rpower> to begin a boot cycle.
 
-If [I<-O>|I<--osimage>] is specified or nodetype.provmethod=I<osimage> is set, provision the noderange with the osimage specified/configured, ignore the table change options if specified.
+If [B<-O>|B<--osimage>] is specified or nodetype.provmethod=B<osimage> is set, provision the noderange with the osimage specified/configured, ignore the table change options if specified.
 
 If -c is specified, it will then run rcons on the node. This is allowed only if one node in the noderange.   If need consoles on multiple nodes , see L<winstall(8)|winstall.8>.
 
@@ -39,18 +39,22 @@ Requests that rinstall runs rcons once the provision starts.  This will only wor
 
 =head1 B<Examples>
 
-B<rinstall> I<node1-node20>
+=over 2
 
+=item 1.
 Provison nodes 1 through 20, using their current configuration.
 
-B<rinstall> I<node1-node20> -O rhels6.4-ppc64-netboot-compute
+ rinstall node1-node20
 
+=item 2.
 Provision nodes 1 through 20 with the osimage rhels6.4-ppc64-netboot-compute.
 
-B<rinstall>  I<node1> -c
+ rinstall node1-node20 -O rhels6.4-ppc64-netboot-compute
 
+=item 3.
 Provisoon node1 and start a console to monitor the process.
 
+ rinstall node1 -c
 
 =head1 B<See> B<Also>
 

--- a/xCAT-client/pods/man8/rmosdistro.8.pod
+++ b/xCAT-client/pods/man8/rmosdistro.8.pod
@@ -5,7 +5,7 @@ B<rmosdistro> - remove OS Distro
 
 =head1 SYNOPSIS
 
-B<rmosdistro> [B<-a>|B<--all>] [B<-f|--force>] B<osdistroname>  [B<osdistroname2 ...>]
+B<rmosdistro> [B<-a>|B<--all>] [B<-f>|B<--force>] I<osdistroname> [I<osdistroname2 ...>]
 
 
 B<rmosdistro> [B<-h>|B<--help>]
@@ -25,15 +25,15 @@ The OS Distro names to delete, delimited by blank space.
 
 =over 6
 
-=item {B<-a|--all>}
+=item B<-a>|B<--all>
 
 If specified, try to delete all the OS Distros.
 
-=item {B<-f|--force>}
+=item B<-f>|B<--force>
 
 Remove referenced OS Distros, never prompt. 
 
-=item {B<-h|--help>}
+=item B<-h>|B<--help>
 
 Show info of rmosdistro usage.
 
@@ -52,23 +52,20 @@ Nonzero:
 
 =over 2
 
-=item *
-
+=item 1.
 To remove OS Distro "rhels6.2-ppc64" and "sles11.2-ppc64":
 
-B<rmosdistro rhels6.2-ppc64 sles11.2-ppc64>
+ rmosdistro rhels6.2-ppc64 sles11.2-ppc64
 
-=item *
-
+=item 2.
 To remove OS Distro "rhels6.2-ppc64", regardless of whether is referenced by any osimage:
 
-B<rmosdistro -f rhels6.2-ppc64>
+ rmosdistro -f rhels6.2-ppc64
 
-=item *
-
+=item 3.
 To remove all OS Distros:
 
-B<rmosdistro -a>
+ rmosdistro -a
 
 
 =back

--- a/xCAT-client/pods/man8/runsqlcmd.8.pod
+++ b/xCAT-client/pods/man8/runsqlcmd.8.pod
@@ -7,15 +7,15 @@ B<runsqlcmd> -Runs sql command files against the current xCAT database.
 
 B<runsqlcmd> 
 
-B<runsqlcmd> {B<-h>|B<--help>}
+B<runsqlcmd> [B<-h>|B<--help>]
 
-B<runsqlcmd> {B<-v>|B<--version>}
+B<runsqlcmd> [B<-v>|B<--version>]
 
-B<runsqlcmd> {B<-d>|B<--dir> I<directory_path>} {B<-V>|B<--verbose>} 
+B<runsqlcmd> [B<-d>|B<--dir> I<directory_path>] [B<-V>|B<--verbose>] 
 
-B<runsqlcmd> {B<-f>|B<--files> I<list of files>} {B<-V>|B<--verbose>} 
+B<runsqlcmd> [B<-f>|B<--files> I<list of files>] [B<-V>|B<--verbose>] 
 
-B<runsqlcmd> {B<-V>|B<--verbose>} {B<sql statement>} 
+B<runsqlcmd> [B<-V>|B<--verbose>] [I<sql statement>] 
 
 
 =head1 DESCRIPTION
@@ -55,7 +55,7 @@ The files must be of the form <name>.sql or <name>_<database>.sql  where
 
 <database>  is mysql,pgsql, or db2. Files must have permission 0755.  
 
-=item B<sql statement>
+=item I<sql statement>
 
 Quoted sql statement syntax appropriate for the current database.
 
@@ -65,35 +65,29 @@ Quoted sql statement syntax appropriate for the current database.
 
 =over 2
 
-=item *
-
+=item 1.
 To run the database appropriate *.sql files in /opt/xcat/lib/perl/xCAT_schema :
 
-B<runsqlcmd> 
+ runsqlcmd 
 
-=item *
-
+=item 2.
 To run the database appropriate *.sql files in /tmp/mysql:
 
-B<runsqlcmd> I<-d> I</tmp/mysql>
+ runsqlcmd -d /tmp/mysql
 
-
-=item *
-
+=item 3.
 To run the database appropriate *.sql files in the input list:
 
-B<runsqlcmd> I<-f> I<"/tmp/mysql/test*,/tmp/mysql/test1*">
+ runsqlcmd -f "/tmp/mysql/test*,/tmp/mysql/test1*"
 
-=item *
-
+=item 4.
 To checkout one DB2 sql file: 
 
-B<runsqlcmd> I<-f> I</tmp/db2/test_db2.sql>
+ runsqlcmd -f /tmp/db2/test_db2.sql
 
-=item *
-
+=item 5.
 To run the following command to the database: 
 
-B<runsqlcmd> I<"Select * from site;">
+ runsqlcmd "Select * from site;"
 
 =back

--- a/xCAT-client/pods/man8/setupiscsidev.8.pod
+++ b/xCAT-client/pods/man8/setupiscsidev.8.pod
@@ -37,10 +37,15 @@ Display usage message.
 
 =head1 RETURN VALUE
 
-0 The command completed successfully.
+=over 2
 
-1 An error has occurred.
+=item 0. 
+The command completed successfully.
 
+=item 1. 
+An error has occurred.
+
+=back
 
 =head1 SEE ALSO
 

--- a/xCAT-client/pods/man8/tabch.8.pod
+++ b/xCAT-client/pods/man8/tabch.8.pod
@@ -4,15 +4,15 @@ B<tabch> - Add, delete or update rows in the database tables.
 
 =head1 SYNOPSIS
 
-I<tabch [-h| --help]>
+B<tabch> [B<-h> | B<--help>]
 
-I<tabch [-v| --version]>
+B<tabch> [B<-v> | B<--version>]
 
-I<tabch [keycolname=keyvalue] [tablename.colname=newvalue] >
+B<tabch> [I<keycolname=keyvalue>] [I<tablename.colname=newvalue>]
 
-I<tabch [keycolname=keyvalue] [tablename.colname+=newvalue] >
+B<tabch> [I<keycolname=keyvalue>] [I<tablename.colname+=newvalue>]
 
-I<tabch -d [keycolname=keyvalue] [tablename.colname=newvalue] >
+B<tabch -d> [I<keycolname=keyvalue>] [I<tablename.colname=newvalue>]
 
 =head1 DESCRIPTION
 
@@ -22,9 +22,9 @@ The tabch command adds, deletes or updates the attribute value in the specified 
 =head1 OPTIONS
 
 
-B<-h>          Display usage message.
+B<-h|--help>          Display usage message.
 
-B<-v>          Command Version.
+B<-v|--version>          Command Version.
 
 B<-d>          Delete option.
 
@@ -32,38 +32,53 @@ B<-d>          Delete option.
 
 =head1 RETURN VALUE
 
-0 The command completed successfully.
+=over 2
 
-1 An error has occurred.
+=item 0. 
+The command completed successfully.
+
+=item 1. 
+An error has occurred.
+
+=back
 
 =head1 EXAMPLES
 
-1. To add a node=node1 to the nodelist table with groups=all:
+=over 2
 
-I<tabch  node=node1 nodelist.groups=all >
+=item 1. 
+To add a node=node1 to the nodelist table with groups=all:
 
-2. To add a keyword (tftpdir) and value (/tftpboot) to the site table:
+ tabch  node=node1 nodelist.groups=all
 
-I<tabch  key=tftpdir site.value=/tftpboot >
+=item 2. 
+To add a keyword (tftpdir) and value (/tftpboot) to the site table:
 
-
-3. To add node1 to the  nodetype table with os=rhel5:
-
-I<tabch  node=node1 nodetype.os=rhel5>
+ tabch  key=tftpdir site.value=/tftpboot
 
 
-4. To change node1 in nodetype table setting os=sles:
+=item 3. 
+To add node1 to the  nodetype table with os=rhel5:
 
-I<tabch  node=node1 nodetype.os=sles>
+ tabch  node=node1 nodetype.os=rhel5
 
-5. To change node1 by appending otherpkgs to the postbootscripts field in the postscripts table:
 
-I<tabch node=node1 postscripts.postbootscripts+=otherpkgs>
+=item 4. 
+To change node1 in nodetype table setting os=sles:
 
-6. To delete node1 from nodetype table:
+ tabch  node=node1 nodetype.os=sles
 
-I<tabch -d node=node1 nodetype>
+=item 5. 
+To change node1 by appending otherpkgs to the postbootscripts field in the postscripts table:
 
+ tabch node=node1 postscripts.postbootscripts+=otherpkgs
+
+=item 6. 
+To delete node1 from nodetype table:
+
+ tabch -d node=node1 nodetype
+
+=back
 
 =head1 FILES
 

--- a/xCAT-client/pods/man8/tabdump.8.pod
+++ b/xCAT-client/pods/man8/tabdump.8.pod
@@ -4,23 +4,23 @@ B<tabdump> - display an xCAT database table in CSV format.
 
 =head1 SYNOPSIS
 
-B<tabdump> [I<-d>] [I<table>]
+B<tabdump> 
+
+B<tabdump> [B<-d>] [I<table>]
 
 B<tabdump> [I<table>]
 
-B<tabdump> [I<-f> I<filename>] [I<table>]
+B<tabdump> [B<-f> I<filename>] [I<table>]
 
-B<tabdump> [I<-n> I<# of records>] [I<auditlog | eventlog>]
+B<tabdump> [B<-n> I<# of records>] [B<auditlog> | B<eventlog>]
 
-B<tabdump> [I<-w> I<attr>==I<val>] [B<-w> I<attr>=~I<val>] ...] [I<table>]
+B<tabdump> [B<-w> I<attr>==I<val>] [B<-w> I<attr>=~I<val>] ...] [I<table>]
 
-B<tabdump> [I<-w> I<attr>==I<val>] [B<-w> I<attr>=~I<val>] ...] [I<-f> I<filename>] [I<table>]
+B<tabdump> [B<-w> I<attr>==I<val>] [B<-w> I<attr>=~I<val>] ...] [B<-f> I<filename>] [I<table>]
 
-B<tabdump> [I<-v> | I<--version>]
+B<tabdump> [B<-v> | B<--version>]
 
-B<tabdump> [I<-?> | I<-h> | I<--help>]
-
-B<tabdump> 
+B<tabdump> [B<-?> | B<-h> | B<--help>]
 
 =head1 DESCRIPTION
 
@@ -71,12 +71,10 @@ Operator descriptions:
 
 =over 3
 
-=item 0
-
+=item 0. 
 The command completed successfully.
 
-=item 1
-
+=item 1. 
 An error has occurred.
 
 =back
@@ -85,67 +83,57 @@ An error has occurred.
 
 =over 2
 
-=item *
-
+=item 1.
 To display the contents of the site table:
 
-B<tabdump> B<site>
+ tabdump site
 
-=item *
-
+=item 2.
 To display the contents of the nodelist table where the groups attribute is compute :
 
-B<tabdump>  B<-w 'groups==compute'> B<nodelist>
+ tabdump -w 'groups==compute' nodelist
 
-=item *
-
+=item 3.
 To display the contents of the nodelist table where the groups attribute is comput% where % is a wildcard and can represent any string  and the status attribute is booted :
 
-B<tabdump>  B<-w 'groups=~comput%'> B<-w 'status==booted'> B<nodelist>
+ tabdump -w 'groups=~comput%' -w 'status==booted' nodelist
 
-=item *
-
+=item 4.
 To display the records of the auditlog on date  2011-04-18 11:30:00 :
 
-B<tabdump>   B<-w 'audittime==2011-04-18 11:30:00'> B<auditlog>
+ tabdump -w 'audittime==2011-04-18 11:30:00' auditlog
 
-=item *
-
+=item 5.
 To display the records of the auditlog starting on 2011-04-18:
 
-tabdump -w 'audittime>2011-04-18 11:30:00' auditlog
+ tabdump -w 'audittime>2011-04-18 11:30:00' auditlog
 
-=item *
-
+=item 6.
 To display the 10 most recent entries in the auditlog:
 
-tabdump -n 10 auditlog
+ tabdump -n 10 auditlog
 
-=item *
-
+=item 7.
 To see what tables exist in the xCAT database:
 
-B<tabdump>
+ tabdump
 
-=item *
-
+=item 8.
 To back up all the xCAT database tables, instead of running B<tabdump> multiple times, you can use the B<dumpxCATdb> command as follows:
 
-B<dumpxCATdb -p /tmp/xcatbak >
+ dumpxCATdb -p /tmp/xcatbak
 
 See the B<dumpxCATdb> man page for details.
 
-=item *
-
+=item 9.
 To display a summary description of each table:
 
-B<tabdump> B<-d>
+ tabdump -d
 
-=item *
-
+=item 10.
 To display a description of each column in the nodehm table:
 
-B<tabdump> B<-d nodehm>
+ tabdump -d nodehm
 
 =back
 

--- a/xCAT-client/pods/man8/tabedit.8.pod
+++ b/xCAT-client/pods/man8/tabedit.8.pod
@@ -4,9 +4,9 @@ B<tabedit> - view an xCAT database table in an editor and make changes.
 
 =head1 SYNOPSIS
 
-B<tabedit> [I<table>]
+B<tabedit> I<table>
 
-B<tabedit> [I<-?> | I<-h> | I<--help>]
+B<tabedit> [B<-?> | B<-h> | B<--help>]
 
 =head1 DESCRIPTION
 
@@ -43,12 +43,10 @@ default to vi.
 
 =over 3
 
-=item 0
-
+=item 0. 
 The command completed successfully.
 
-=item 1
-
+=item 1. 
 An error has occurred.
 
 =back
@@ -57,11 +55,10 @@ An error has occurred.
 
 =over 2
 
-=item *
-
+=item 1.
 To edit the site table:
 
-  B<tabedit> I<site>
+ tabedit site
 
 =back
 

--- a/xCAT-client/pods/man8/tabprune.8.pod
+++ b/xCAT-client/pods/man8/tabprune.8.pod
@@ -4,15 +4,15 @@ B<tabprune> - Deletes records from the eventlog,auditlog,isnm_perf,isnm_perf_sum
 
 =head1 SYNOPSIS
 
-B<tabprune> B<eventlog | auditlog>  [B<-V>] B<-i> I<recid> |B<-n> I<number of records> | B<-p> I<percentage> |  B<-d> I<number of days> | B<-a>  
+B<tabprune> [B<eventlog | auditlog>]  [B<-V>] [B<-i> I<recid> |B<-n> I<number of records> | B<-p> I<percentage> | B<-d> I<number of days> | B<-a>] 
 
-B<tabprune> B<tablename> B<-a>  
+B<tabprune> I<tablename> B<-a>  
 
 B<tabprune> [B<-h>|B<--help>] [B<-v>|B<--version>] 
 
 =head1 DESCRIPTION
 
-The tabprune command is used to delete records from the auditlog,eventlog,isnm_perf,isnm_perf_sum tables. As an option, the table header and all the rows pruned from the specified table will be displayed in CSV (comma separated values) format. The all records options (-a) can be used on any xCAT table. 
+The tabprune command is used to delete records from the auditlog, eventlog, isnm_perf, isnm_perf_sum tables. As an option, the table header and all the rows pruned from the specified table will be displayed in CSV (comma separated values) format. The all records options (-a) can be used on any xCAT table. 
 
 =head1 OPTIONS
 
@@ -53,12 +53,10 @@ Remove all records that occurred >= than number of days ago.
 
 =over 3
 
-=item 0
-
+=item 0.
 The command completed successfully.
 
-=item 1
-
+=item 1.
 An error has occurred.
 
 =back
@@ -67,43 +65,35 @@ An error has occurred.
 
 =over 2
 
-=item *
-
+=item 1.
 To remove all the records in the eventlog table:
 
-B<tabprune> I<eventlog> -a
+ tabprune eventlog -a
 
-=item *
-
+=item 2.
 To remove all the records in the eventlog table saving the deleted records in eventlog.csv:
 
-B<tabprune> I<eventlog> -V -a > eventlog.csv
+ tabprune eventlog -V -a > eventlog.csv
 
-=item *
-
+=item 3.
 To remove all the records before recid=200 in the auditlog table:
 
-B<tabprune> I<auditlog> -i 200
+ tabprune auditlog -i 200
 
-=item *
-
+=item 4.
 To remove 400 records from the auditlog table and display the remove records: 
 
-B<tabprune> I<auditlog> -V -n 400
+ tabprune auditlog -V -n 400
 
-=item *
-
+=item 5.
 To remove 50% of the  eventlog table: 
 
-B<tabprune> I<eventlog>  -p 50 
+ tabprune eventlog -p 50 
 
-=item *
-
+=item 6.
 To remove all records that occurred >= 5 days ago in the eventlog: 
 
-B<tabprune> I<eventlog>  -d 5 
-
-
+ tabprune eventlog -d 5 
 
 =back
 

--- a/xCAT-client/pods/man8/tabrestore.8.pod
+++ b/xCAT-client/pods/man8/tabrestore.8.pod
@@ -4,11 +4,11 @@ B<tabrestore> - replaces with or adds to a xCAT database table the contents in a
 
 =head1 SYNOPSIS
 
-B<tabrestore> [-a] I<table.csv>
+B<tabrestore> [B<-a>] I<table.csv>
 
-B<tabrestore> [I<-?> | I<-h> | I<--help>]
+B<tabrestore> [B<-?> | B<-h> | B<--help>]
 
-B<tabrestore> [I<v>  | I<--version>]
+B<tabrestore> [B<-v>  | B<--version>]
 
 =head1 DESCRIPTION
 
@@ -43,12 +43,10 @@ Add rows from the CSV file to the table instead of replacing the table with the 
 
 =over 3
 
-=item 0
-
+=item 0.
 The command completed successfully.
 
-=item 1
-
+=item 1.
 An error has occurred.
 
 =back
@@ -57,28 +55,25 @@ An error has occurred.
 
 =over 2
 
-=item *
-
+=item 1.
 To replace the rows in the mp table with the rows in the mp.csv file:
 
-B< tabrestore> I<mp.csv>
+ tabrestore mp.csv
 
 The file mp.csv could contain something like:
 
   #node,mpa,id,comments,disable
   "blade","|\D+(\d+)|amm(($1-1)/14+1)|","|\D+(\d+)|(($1-1)%14+1)|",,
 
-=item *
+=item 2.
+To add the rows in the mp.csv file to the rows in the mp table:
 
-To add the rows in the mp.csv file to the  rows in the mp table:
+ tabrestore -a mp.csv
 
-B< tabrestore> -a I<mp.csv>
+=item 3.
+To restore database tables from restore_directory that we dumped with dumpxCATdb:
 
-=item *
-
-To restore database tables that we dumped with dumpxCATdb:
-
-restorexCATdb -p <restore directory>
+ restorexCATdb -p restore_directory
 
 =back
 

--- a/xCAT-client/pods/man8/winstall.8.pod
+++ b/xCAT-client/pods/man8/winstall.8.pod
@@ -4,9 +4,9 @@ B<winstall> - Begin OS provision on a noderange
 
 =head1 B<Synopsis>
 
-B<winstall> [I<-o>|I<--osver>] [I<-p>|I<--profile>] [I<-a>|I<--arch>] [I<noderange>]
+B<winstall> [B<-o>|B<--osver>] [B<-p>|B<--profile>] [B<-a>|B<--arch>] [I<noderange>]
 
-B<winstall> [I<-O>|I<--osimage>] [I<noderange>]
+B<winstall> [B<-O>|B<--osimage>] [I<noderange>]
 
 =head1 B<Description>
 
@@ -50,17 +50,24 @@ Specifies the osimage to provision.
 
 =head1 B<Examples>
 
-B<winstall> I<node1-node20>
+=over 2
 
+=item 1.
 Provison nodes 1 through 20, using their current configuration.
 
-B<winstall> I<node1-node20> -o rhels5.1 -p compute
+ winstall node1-node20
 
+=item 2.
 Provision nodes 1 through 20, forcing rhels5.1 and compute profile.
 
-B<winstall> I<node1-node20> -O rhels6.4-ppc64-netboot-compute
+ winstall node1-node20 -o rhels5.1 -p compute
 
+=item 3.
 Provision nodes 1 through 20 with the osimage rhels6.4-ppc64-netboot-compute.
+
+ winstall node1-node20 -O rhels6.4-ppc64-netboot-compute
+
+=back
 
 =head1 B<See> B<Also>
 

--- a/xCAT-client/pods/man8/xcatconfig.8.pod
+++ b/xCAT-client/pods/man8/xcatconfig.8.pod
@@ -4,17 +4,17 @@ B<xcatconfig> - Sets up the  Management Node during the xCAT install.
 
 =head1 SYNOPSIS
 
-B<xcatconfig> {B<-h>|B<--help>}
+B<xcatconfig> [B<-h>|B<--help>]
 
-B<xcatconfig> {B<-v>|B<--version>}
+B<xcatconfig> [B<-v>|B<--version>]
 
-B<xcatconfig> {B<-i>|B<--initinstall>}  [B<-V>|B<--verbose>]
+B<xcatconfig> [B<-i>|B<--initinstall>] [B<-V>|B<--verbose>]
 
-B<xcatconfig> {B<-u>|B<--updateinstall>}  [B<-V>|B<--verbose>]
+B<xcatconfig> [B<-u>|B<--updateinstall>] [B<-V>|B<--verbose>]
 
 B<xcatconfig> [B<-k>|B<--sshkeys>] [B<-s>|B<--sshnodehostkeys>] [B<-c>|B<--credentials>] [B<-d>|B<--database>] [B<-m>|B<--mgtnode>] [B<-t>|B<--tunables>] [B<-V>|B<--verbose>]
 
-B<xcatconfig> {B<-f>|B<--force>} [B<-V>|B<--verbose>]
+B<xcatconfig> [B<-f>|B<--force>] [B<-V>|B<--verbose>]
 
 =head1 DESCRIPTION
 
@@ -83,33 +83,29 @@ This option will set tunable parameters on the Management and Service nodes reco
 =over 2
 
 =item 1.
-
 To force regeneration of keys and credentials and reinitialize the site table:
 
  xcatconfig -f
 
 =item 2.
-
 To regenerate root's ssh keys:
 
  xcatconfig -k
 
 =item 3.
-
 To regenerate node host ssh keys:
 
  xcatconfig -s
 
 =item 4.
-
 To regenerate node host ssh keys and credentials:
 
  xcatconfig -s -c
 
 =item 5.
-
 To add the Management Node to the DB:
 
  xcatconfig -m 
+
 
 =back

--- a/xCAT-client/pods/man8/xcatd.8.pod
+++ b/xCAT-client/pods/man8/xcatd.8.pod
@@ -16,10 +16,9 @@ See http://xcat-docs.readthedocs.org/en/latest/overview/index.html#xcat-architec
 
 =head1 EXAMPLES
 
-=over 3
+=over 2
 
 =item 1.
-
 To start/stop/restart  xcatd on Linux, enter:
 
  service xcatd start 
@@ -29,7 +28,6 @@ To start/stop/restart  xcatd on Linux, enter:
  service xcatd restart 
 
 =item 2.
-
 To start/stop/restart  xcatd on AIX, enter:
 
  restartxcatd

--- a/xCAT-client/pods/man8/xcatdebug.8.pod
+++ b/xCAT-client/pods/man8/xcatdebug.8.pod
@@ -2,15 +2,14 @@
 
 B<xcatdebug> - Enable or disable the trace facilities for xCAT. (Only supports Linux Operating System)
 
-B<xcatdebug> { [B<-f enable|disable> [B<-c configuration file | subroutine list>]] | [ B<-d enable |disable>]}
+=head1 SYNOPSIS
+B<xcatdebug> { [B<-f enable> | B<disable> [B<-c> {I<configuration file> | I<subroutine list>}]] | [ B<-d enable> | B<disable>]}
 
 =head1 DESCRIPTION
 
 xCAT offers two trace facilities to debug the xCAT:
 
 =over 3
-
-=item *
 
 B<Subroutine calling trace>
 
@@ -36,8 +35,6 @@ Otherwise, the package name of the plugin should be specified.
 The trace log will be written to /var/log/xcat/subcallingtrace. The log file subcallingtrace will be backed up for each running of the B<xcatdebug -f enable>.
 
 
-=item *
-
 B<Commented trace log>
 
 The trace log code is presented as comments in the code of xCAT. In general mode, it will be kept as comments. But in debug mode, it will be commented back as common code to display the trace log.
@@ -48,14 +45,10 @@ This facility offers two formats for the trace log code:
 
 =over 2
 
-=item *
-
 Trace section
     ## TRACE_BEGIN
     # print "In the debug\n";
     ## TRACE_END
-
-=item *
 
 Trace in a single line
     ## TRACE_LINE print "In the trace line\n";
@@ -90,15 +83,12 @@ Specify the configuration file or subroutine list.
 
 =over 2
 
-=item *
-
 B<configuration file>: a file contains multiple lines of B<SUBROUTINE_DEFINITION>
   e.g.
     (plugin_command)
     xCAT_plugin::DBobjectdefs(defls,process_request)
     xCAT::DBobjUtils(getobjdefs)
 
-=item *  
 B<subroutine list>: a string like  B<SUBROUTINE_DEFINITION>|B<SUBROUTINE_DEFINITION>|...
   e.g.
     "(plugin_command)|xCAT_plugin::DBobjectdefs(defls,process_request)|xCAT::DBobjUtils(getobjdefs)"
@@ -109,44 +99,37 @@ B<subroutine list>: a string like  B<SUBROUTINE_DEFINITION>|B<SUBROUTINE_DEFINIT
 
 Enable or disable the B<commented trace log>.
 
-Note: The xcatd will be restarted for the performing of B<-d>. 
+Note: The xcatd will be restarted for the performing of B<-d> 
 
 =back
 
 
 =head1 EXAMPLES
 
-=over 4
+=over 2
 
-=item 1
-
+=item 1.
 Enable the B<subroutine calling trace> for all the subroutines in the xcatd and plugin modules.
-  B<xcatdebug> -f enable
+ xcatdebug -f enable
 
-=item 2
-
+=item 2.
 Enable the B<subroutine calling trace> for the subroutines configured in the /opt/xcat/share/xcat/samples/tracelevel0
-  B<xcatdebug> -f enable -c /opt/xcat/share/xcat/samples/tracelevel0
+ xcatdebug -f enable -c /opt/xcat/share/xcat/samples/tracelevel0
 
-=item 3
-
+=item 3.
 Enable the B<subroutine calling trace> for the plugin_command in xcatd and defls,process_request in the xCAT_plugin::DBobjectdefs module.
-  B<xcatdebug> -f enable -c "xCAT_plugin::DBobjectdefs(defls,process_request)|(plugin_command)"
+ xcatdebug -f enable -c "xCAT_plugin::DBobjectdefs(defls,process_request)|(plugin_command)"
 
-=item 4
-
+=item 4.
 Disable the B<subroutine calling trace> for all the subroutines which have been enabled by B<xcatdebug -f enable>.
-  B<xcatdebug> -f disable
+ xcatdebug -f disable
 
-=item 5
-
+=item 5.
 Enable the B<commented trace log>
-  B<xcatdebug> -d enable
+ xcatdebug -d enable
 
-=item 6
-
+=item 6.
 Enable both the B<subroutine calling trace> and B<commented trace log>
-  B<xcatdebug> -f enable -c /opt/xcat/share/xcat/samples/tracelevel0 -d enable
-
+  xcatdebug -f enable -c /opt/xcat/share/xcat/samples/tracelevel0 -d enable
 
 =back

--- a/xCAT-client/pods/man8/xcatsetup.8.pod
+++ b/xCAT-client/pods/man8/xcatsetup.8.pod
@@ -17,35 +17,35 @@ the hardware that is connected to the service and cluster networks.  The typical
 
 =over 3
 
-=item *
+=item 1.
 
 Install the xCAT software on the management node
 
-=item *
+=item 2. 
 
 Create the cluster config file and run xcatsetup
 
-=item *
+=item 3.
 
 Put hardware control passwords in the ppchcp or ppcdirect database table
 
-=item *
+=item 4.
 
 Run makenetworks and makedhcp
 
-=item *
+=item 5.
 
 Run the discovery commands (lsslp, mkhwconn, rspconfig) as described in the System P Hardware Management cookbook.
 
-=item *
+=item 6.
 
 Configure and start services using makehosts, makedns, mkconserver.cf, etc.
 
-=item *
+=item 7.
 
 Create the images that should be installed or booted on the nodes
 
-=item *
+=item 8.
 
 Run nodeset and rpower/rnetboot to boot up the nodes.
 
@@ -77,8 +77,7 @@ If you want to delete all of the nodes that xcatsetup created, and start over, u
 
 =over 3
 
-=item *
-
+=item 1.
 The B<xcatsetup> command has only been implemented and tested for system p servers so far.
 
 =back
@@ -435,16 +434,21 @@ using this option.
 
 =head1 RETURN VALUE
 
-0  The command completed successfully.
+=over 2
 
-1  An error has occurred.
+=item 0.  
+The command completed successfully.
+
+=item 1.  
+An error has occurred.
+
+=back
 
 =head1 EXAMPLES
 
-=over 3
+=over 2
 
 =item 1.
-
 Use the sample config.txt file at the beginning of this man page to create all the objects/nodes for a
 2 building block cluster.
 
@@ -460,7 +464,6 @@ The output:
  Defining LPAR nodes...
 
 =item 2.
-
 Use the simpler config file shown earlier in this man page to create just the frame and cec objects:
 
  xcatsetup config-simple.txt

--- a/xCAT-client/pods/man8/xcatsnap.8.pod
+++ b/xCAT-client/pods/man8/xcatsnap.8.pod
@@ -2,13 +2,17 @@
 
 B<xcatsnap> - Gathers information for service about the current running xCAT environment.  
 
-B<xcatsnap> {B<-h>|B<--help>}
+=head1 SYNOPSIS
 
-B<xcatsnap> {B<-v>|B<--version>}
+B<xcatsnap>
 
-B<xcatsnap> {B<-B>|B<--BYPASS>}
+B<xcatsnap> [B<-h>|B<--help>]
 
-B<xcatsnap> {B<-d>|B<--dir>} 
+B<xcatsnap> [B<-v>|B<--version>]
+
+B<xcatsnap> [B<-B>|B<--bypass>]
+
+B<xcatsnap> [B<-d>|B<--dir>] 
 
 =head1 DESCRIPTION
 
@@ -44,17 +48,14 @@ The directory to put the snap information.  Default is /tmp/xcatsnap.
 
 =over 2
 
-=item *
-
+=item 1.
 Run the xcatsnap routine in bypass mode and put info in /tmp/mydir :
 
-B<xcatsnap> I<-B> I<-d> /tmp/mydir
+ xcatsnap -B -d /tmp/mydir
 
-=item * 
-
+=item 2. 
 To run the xcatsnap routine and use default directory /tmp/xcatsnap :
 
-B<xcatsnap>
-
+ xcatsnap
 
 =back


### PR DESCRIPTION
Fixes for man pages in man8 section:
1. POD files modified:
    a. Consistent use of italics and bold fonts - bold for fixed options or parameters, italics for user substitutions
    b. Consistent EXAMPLES section - examples are numbered, example commands are shows as command text
    c. Consistent use of [ ] and { } - bracket for options, braces for choices
    d. Consistent RETURN VALUE section - return values and explanation on a single line with dot separation
    e. Misc wording fixed - some EXAMPLE section descriptions added
2. create_man_pages.py modified to fix generated .rst files
   a. Vertical bar fix to not appear as a link in some instances
   b. "- -" option fix to not appear as a single long dash. 