### PR TITLE
man1 chages for commands a-n

### DIFF
--- a/create_man_pages.py
+++ b/create_man_pages.py
@@ -91,7 +91,7 @@ def fix_double_dash(rst_file):
     print "Fixing -- in file %s, version %s" %(rst_file, man_ver)
     # -- gets displayed in .html as a sinle long dash, need to insert
     # a non bold space between 2 dashes
-    sed_cmd = "sed 's/--/-\*\*\\\ \*\*-/g' %s.sed1 > %s" %(rst_file, rst_file)
+    sed_cmd = "sed '/\*\*/s/--/-\*\*\\\ \*\*-/g' %s.sed1 > %s" %(rst_file, rst_file)
     os.system(sed_cmd)
     #remove intermediate .sed1 file
     rm_sed1file_cmd = "rm %s.sed1" %(rst_file)
@@ -134,7 +134,7 @@ for component in COMPONENTS:
                 cmd += " --infile=%s --outfile=%s --title=%s.%s" %(pod_input, rst_output, title, man_ver)
                 print cmd 
                 os.system(cmd)
-		if man_ver == '8':
+		if man_ver == '1' or man_ver == '8':
                     fix_vertical_bar(rst_output)
                     fix_double_dash(rst_output)
 

--- a/docs/source/guides/admin-guides/references/man1/addkit.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/addkit.1.rst
@@ -11,7 +11,7 @@ NAME
 ****
 
 
-\ **addkit**\  - Install a kit on the xCAT management node
+\ **addkit**\  - Adds product software Kits to an xCAT cluster environmnet.
 
 
 ********
@@ -19,11 +19,11 @@ SYNOPSIS
 ********
 
 
-\ **addkit**\  [\ **-?**\ |\ **-h**\ |\ **--help**\ ] [\ **-v**\ |\ **--version**\ ]
+\ **addkit**\  [\ **-? | -h | -**\ **-help**\ ] [\ **-v | -**\ **-version**\ ]
 
-\ **addkit**\  [\ **-i**\ |\ **--inspection**\ ] \ *kitlist*\ 
+\ **addkit**\  [\ **-i | -**\ **-inspection**\ ] \ *kitlist*\ 
 
-\ **addkit**\  [\ **-V**\ |\ **--verbose**\ ] [\ **-p**\ |\ **--path**\  \ *path*\ ] \ *kitlist*\ 
+\ **addkit**\  [\ **-V | -**\ **-verbose**\ ] [\ **-p | -**\ **-path**\  \ *path*\ ] \ *kitlist*\ 
 
 
 ***********
@@ -31,7 +31,8 @@ DESCRIPTION
 ***********
 
 
-The \ **addkit**\  command install a kit on the xCAT management node from a kit tarfile or directory, creating xCAT database definitions for kit, kitrepo, kitcomponent.
+The \ **addkit**\  command installs a kit on the xCAT management node from a kit tarfile or directory.
+It creates xCAT database definitions for the kit, kitrepo, and kitcomponent.
 
 \ **Note:**\  xCAT Kit support is ONLY available for Linux operating systems.
 
@@ -42,39 +43,39 @@ OPTIONS
 
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Verbose mode.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command version.
  
 
 
-\ **-i|--inspection**\ 
+\ **-i|-**\ **-inspection**\ 
  
  Show the summary of the given kits
  
 
 
-\ **-p|--path <path**\ >
+\ **-p|-**\ **-path**\  \ *path*\ 
  
  The destination directory to which the contents of the kit tarfiles and/or kit deploy directories will be copied.  When this option is not specified, the default destination directory will be formed from the installdir site attribute with ./kits subdirectory.
  
 
 
-\ **kitlist**\ 
+\ *kitlist*\ 
  
- A comma delimited list of kit_tarball_files and kit_deploy_dirs that are to be added to the xCAT cluster.  Each entry can be an absolute or relative path.  For kit_tarball_files, these must be valid kits tarfiles added.  For kit_deploy_dirs, these must be fully populated directory structures that are identical to the contents of an expanded kit_tarball_file.
+ A comma delimited list of kit_tarball_files or kit_deploy_directories to be added to the xCAT environment. Each entry can be an absolute or relative path.  See xCAT documentation for more information on building kits.
  
 
 
@@ -94,7 +95,7 @@ EXAMPLES
 ********
 
 
-1. To add two kits from tarball files.
+1. To add kits from tarball files:
 
 
 .. code-block:: perl
@@ -102,7 +103,7 @@ EXAMPLES
   addkit kit-test1.tar.bz2,kit-test2.tar.bz2
 
 
-2. To add two kits from directories.
+2. To add kits from directories:
 
 
 .. code-block:: perl
@@ -110,7 +111,7 @@ EXAMPLES
   addkit kit-test1,kit-test2
 
 
-3. To add a kit from tarball file to /install/test directory.
+3. To add kits from tarball \ *kit-test1.tar.bz2*\  to target path \ */install/test*\ :
 
 
 .. code-block:: perl
@@ -118,7 +119,7 @@ EXAMPLES
   addkit -p /install/test kit-test1.tar.bz2
 
 
-4. To read the general information of the kit, without adding the kits to xCAT DB
+4. To see general information about kit \ *kit-test1.tar.bz2*\  without adding the kit to xCAT:
 
 
 .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man1/addkitcomp.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/addkitcomp.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **addkitcomp**\  [\ **-?**\ |\ **-h**\ |\ **--help**\ ] [\ **-v**\ |\ **--version**\ ]
+\ **addkitcomp**\  [\ **-? | -h | -**\ **-help**\ ] [\ **-v | -**\ **-version**\ ]
 
-\ **addkitcomp**\  [\ **-V**\ |\ **--verbose**\ ] [\ **-a**\ |\ **--adddeps**\ ] [\ **-f**\ |\ **--force**\ ] [\ **-n**\ |\ **--noupgrade**\ ] [\ **--noscripts**\ ] \ **-i**\  \ *osimage*\   \ *kitcompname_list*\ 
+\ **addkitcomp**\  [\ **-V | -**\ **-verbose**\ ] [\ **-a | -**\ **-adddeps**\ ] [\ **-f | -**\ **-force**\ ] [\ **-n | -**\ **-noupgrade**\ ] [\ **-**\ **-noscripts**\ ] \ **-i**\  \ *osimage*\   \ *kitcompname_list*\ 
 
 
 ***********
@@ -40,31 +40,31 @@ OPTIONS
 
 
 
-\ **-a|--adddeps**\ 
+\ **-a|-**\ **-adddeps**\ 
  
  Assign kitcomponent dependencies to the osimage.
  
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Verbose mode.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command version.
  
 
 
-\ **-f|--force**\ 
+\ **-f|-**\ **-force**\ 
  
  Add kit component to osimage even if there is a mismatch in OS, version, arch, serverrole, or kitcompdeps
  
@@ -76,7 +76,7 @@ OPTIONS
  
 
 
-\ **-n|--noupgrade**\ 
+\ **-n|-**\ **-noupgrade**\ 
  
  1. Allow multiple versions of kitcomponent to be installed into the osimage, instead of kitcomponent upgrade.
  
@@ -84,13 +84,13 @@ OPTIONS
  
 
 
-\ **--noscripts**\ 
+\ **-**\ **-noscripts**\ 
  
  Do not add kitcomponent's postbootscripts to osimage
  
 
 
-\ **kitcompname_list**\ 
+\ *kitcompname_list*\ 
  
  A comma-delimited list of valid full kit component names or kit component basenames that are to be added to the osimage.
  

--- a/docs/source/guides/admin-guides/references/man1/bmcdiscover.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/bmcdiscover.1.rst
@@ -19,13 +19,13 @@ SYNOPSIS
 ********
 
 
-\ **bmcdiscover**\  [\ **-h**\ |\ **--help**\ ] [\ **-v**\ |\ **--version**\ ]
+\ **bmcdiscover**\  [\ **-h | -**\ **-help**\ ] [\ **-v | -**\ **-version**\ ]
 
-\ **bmcdiscover**\  [\ **-s**\  \ *scan_method*\ ] \ **--range**\  \ *ip_ranges*\  [\ **-z**\ ] [\ **-w**\ ] [\ **-t**\ ]
+\ **bmcdiscover**\  [\ **-s**\  \ *scan_method*\ ] \ **-**\ **-range**\  \ *ip_ranges*\  [\ **-z**\ ] [\ **-w**\ ] [\ **-t**\ ]
 
-\ **bmcdiscover**\  \ **-i**\ |\ **--bmcip**\  \ *bmc_ip*\  [\ **-u**\ |\ **--bmcuser**\  \ *bmcusername*\ ] \ **-p**\ |\ **--bmcpwd**\  \ *bmcpassword*\  \ **-c**\ |\ **--check**\ 
+\ **bmcdiscover**\  \ **-i | -**\ **-bmcip**\  \ *bmc_ip*\  [\ **-u | -**\ **-bmcuser**\  \ *bmcusername*\ ] \ **-p | -**\ **-bmcpwd**\  \ *bmcpassword*\  \ **-c | -**\ **-check**\ 
 
-\ **bmcdiscover**\  \ **-i**\ |\ **--bmcip**\  \ *bmc_ip*\  [\ **-u**\ |\ **--bmcuser**\  \ *bmcusername*\ ] \ **-p**\ |\ **--bmcpwd**\  \ *bmcpassword*\  \ **--ipsource**\ 
+\ **bmcdiscover**\  \ **-i | -**\ **-bmcip**\  \ *bmc_ip*\  [\ **-u | -**\ **-bmcuser**\  \ *bmcusername*\ ] \ **-p | -**\ **-bmcpwd**\  \ *bmcpassword*\  \ **-**\ **-ipsource**\ 
 
 
 ***********
@@ -48,7 +48,7 @@ OPTIONS
 
 
 
-\ **--range**\ 
+\ **-**\ **-range**\ 
  
  Specify one or more IP ranges acceptable to nmap.  IP rance can be hostnames, IP addresses, networks, etc.  A single IP address (10.1.2.3) or an IP range (10.1.2.0/24) can be specified.  If the range is very large, the \ **bmcdiscover**\  command may take a long time to return.
  
@@ -78,43 +78,43 @@ OPTIONS
  
 
 
-\ **-i|--bmcip**\ 
+\ **-i|-**\ **-bmcip**\ 
  
  BMC IP
  
 
 
-\ **-u|--bmcuser**\ 
+\ **-u|-**\ **-bmcuser**\ 
  
  BMC user name.
  
 
 
-\ **-p|--bmcpwd**\ 
+\ **-p|-**\ **-bmcpwd**\ 
  
  BMC user password.
  
 
 
-\ **-c|--check**\ 
+\ **-c|-**\ **-check**\ 
  
  Check
  
 
 
-\ **--ipsource**\ 
+\ **-**\ **-ipsource**\ 
  
  BMC IP source
  
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Display version information
  

--- a/docs/source/guides/admin-guides/references/man1/cfgve.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/cfgve.1.rst
@@ -19,17 +19,15 @@ SYNOPSIS
 ********
 
 
-\ **cfgve**\  \ **-t**\  dc \ **-m**\  manager \ **-o**\  object [\ **-c**\  \ **-k**\  nfs|localfs | \ **-r**\ ]
+\ **cfgve**\  \ **-t dc -m**\  \ *manager*\  \ **-o**\  \ *object*\  [\ **-c**\  \ **-k nfs**\  | \ **localfs**\  | \ **-r**\ ]
 
-\ **cfgve**\  \ **-t**\  cl \ **-m**\  manager \ **-o**\  object [\ **-c**\  \ **-p**\  cpu type| \ **-r**\  \ **-f**\ ]
+\ **cfgve**\  \ **-t cl -m**\  \ *manager*\  \ **-o**\  \ *object*\  [\ **-c -p**\  \ *cpu type*\  | \ **-r -f**\ ]
 
-\ **cfgve**\  \ **-t**\  sd \ **-m**\  manager \ **-o**\  object [\ **-c**\  | \ **-g**\  | \ **-s**\  
-| \ **-a**\  | \ **-b**\  | \ **-r**\  \ **-f**\ ]
+\ **cfgve**\  \ **-t sd -m**\  \ *manager*\  \ **-o**\  \ *object*\  [\ **-c**\  | \ **-g**\  | \ **-s**\  | \ **-a**\  | \ **-b**\  | \ **-r**\  \ **-f**\ ]
 
-\ **cfgve**\  \ **-t**\  nw \ **-m**\  manager \ **-o**\  object [\ **-c**\  \ **-d**\  data center \ **-n**\  
-vlan ID | \ **-a**\  \ **-l**\  cluster | \ **-b**\  | \ **-r**\ ]
+\ **cfgve**\  \ **-t nw -m**\  \ *manager*\  \ **-o**\  \ *object*\  [\ **-c**\  \ **-d**\  \ *data center*\  \ **-n**\  \ *vlan ID*\  | \ **-a**\  \ **-l**\  \ *cluster*\  | \ **-b**\  | \ **-r**\ ]
 
-\ **cfgve**\  \ **-t**\  tpl \ **-m**\  manager \ **-o**\  object [\ **-r**\ ]
+\ **cfgve**\  \ **-t tpl -m**\  \ *manager*\  \ **-o**\  \ *object*\  [\ **-r**\ ]
 
 
 ***********
@@ -40,10 +38,10 @@ DESCRIPTION
 The \ **cfgve**\  command can be used to configure a virtual environment for 
 'Storage Domain', 'Network' and 'Template' objects.
 
-The mandatory parameter \ **-m manager**\  is used to specify the address of the 
+The mandatory parameter \ **-m**\  \ *manager*\  is used to specify the address of the 
 manager of virtual environment. xCAT needs it to access the RHEV manager.
 
-The mandatory parameter \ **-t type**\  is used to specify the type of the target 
+The mandatory parameter \ **-t**\  \ *type*\  is used to specify the type of the target 
 object.
 
 Basically, \ **cfgve**\  command supports five types of object: \ **dc**\ , \ **cl**\ , 
@@ -61,7 +59,7 @@ Basically, \ **cfgve**\  command supports five types of object: \ **dc**\ , \ **
 
 \ **tpl**\  - The \ **remove**\  operation is supported.
 
-The mandatory parameter \ **-o object**\  is used to specify which object to configure.
+The mandatory parameter \ **-o**\  \ *object*\  is used to specify which object to configure.
 
 
 *******

--- a/docs/source/guides/admin-guides/references/man1/cfm2xcat.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/cfm2xcat.1.rst
@@ -19,7 +19,7 @@ NAME
 ****************
 
 
-\ **cfm2xcat**\  [\ **-i**\  \ *path of the CFM distribution files generated *\ ] [\ **-o**\  \ *path of the xdcp rsync files generated from the CFM distribution files *\ ]
+\ **cfm2xcat**\  [\ **-i**\  \ *path of the CFM distribution files generated*\ ] [\ **-o**\  \ *path of the xdcp rsync files generated from the CFM distribution files*\ ]
 
 \ **cfm2xcat**\  [\ **-h**\ ]
 
@@ -29,8 +29,10 @@ NAME
 *******************
 
 
-Copy the cfm2xcat command to the CSM Management Server.  Run the command, indicating where you want your files saved with the -i and -o flags. They can be in the same directory.   
+Copy the cfm2xcat command to the CSM Management Server.  Run the command, indicating where you want your files saved with the -i and -o flags. They can be in the same directory.
+
 The cfm2xcat command will run cfmupdatenode -a, saving the generated CFM distribution files in the directory indicates with (-i). From those distribution files, it will generate xdcp rsync input files (-F option on xdcp) in the directory indicated by ( -o).
+
 Check the rsync files generated.  There will be a file generated (rsyncfiles)  from the input -o option on the command, and the same file with a (.nr) extension generated for each different noderange that will used to sync files based on your CFM setup in CSM. The rsyncfiles will contain the rsync file list.   The rsyncfiles.nr will contain the noderange. If multiple noderanges then the file name (rsyncfiles)  will be appended with a number.
 
 
@@ -63,13 +65,21 @@ EXAMPLES
 
 1. To build xCAT rsync files to use with xdcp -F , enter on the CSM Management Server, make sure the path exists:
 
-\ **cfm2xcat -i /tmp/cfm/cfmdistfiles -o /tmp/cfm/rsyncfiles**\ 
+
+.. code-block:: perl
+
+  cfm2xcat -i /tmp/cfm/cfmdistfiles -o /tmp/cfm/rsyncfiles
+
 
 2. To use the file on the xCAT Management Node copy to /tmp/cfm on the xCAT MN:
 
-\ **xdcp ^/tmp/cfm/rsyncfiles.nr -F /tmp/cfm/rsyncfiles**\ 
-\ **xdcp ^/tmp/cfm/rsyncfiles.nr1 -F /tmp/cfm/rsyncfiles1**\ 
-\ **xdcp ^/tmp/cfm/rsyncfiles.nr2 -F /tmp/cfm/rsyncfiles2**\ 
+
+.. code-block:: perl
+
+  xdcp ^/tmp/cfm/rsyncfiles.nr -F /tmp/cfm/rsyncfiles
+  xdcp ^/tmp/cfm/rsyncfiles.nr1 -F /tmp/cfm/rsyncfiles1
+  xdcp ^/tmp/cfm/rsyncfiles.nr2 -F /tmp/cfm/rsyncfiles2
+
 
 
 *****

--- a/docs/source/guides/admin-guides/references/man1/chdef.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/chdef.1.rst
@@ -19,14 +19,13 @@ SYNOPSIS
 ********
 
 
-\ **chdef**\  [\ **-h**\ |\ **--help**\ ] [\ **-t**\  \ *object-types*\ ]
+\ **chdef**\  [\ **-h | -**\ **-help**\ ] [\ **-t**\  \ *object-types*\ ]
 
 \ **chdef**\  [\ **-t**\  \ *object-types*\ ] [\ **-o**\  \ *object-names*\ ] [\ **-n**\  \ *new-name*\ ] [\ *node*\ ]
 
-\ **chdef**\  [\ **-V**\ |\ **--verbose**\ ] [\ **-t**\  \ *object-types*\ ] [\ **-o**\  \ *object-names*\ ]
-[\ **-d**\ |\ **--dynamic**\ ] [\ **-p**\ |\ **--plus**\ ] [\ **-m**\ |\ **--minus**\ ] [\ **-z**\ |\ **--stanza**\ ]
-[[\ **-w**\  \ *attr*\ ==\ *val*\ ] [\ **-w**\  \ *attr*\ =~\ *val*\ ] ...] [\ *noderange*\ ] [\ *attr*\ =\ *val*\  [\ *attr*\ =\ *val...*\ ]]
-      [\ **-u**\  [\ *provmethod*\ =<\ *install*\ |\ *netboot*\ |\ *statelite*\ >] [\ *profile*\ =<xxx>] [\ *osvers*\ =\ *value*\ ] [\ *osarch*\ =\ *value*\ ]]
+\ **chdef**\  [\ **-V | -**\ **-verbose**\ ] [\ **-t**\  \ *object-types*\ ] [\ **-o**\  \ *object-names*\ ]
+[\ **-d | -**\ **-dynamic**\ ] [\ **-p | -**\ **-plus**\ ] [\ **-m | -**\ **-minus**\ ] [\ **-z | -**\ **-stanza**\ ]
+[[\ **-w**\  \ *attr*\ ==\ *val*\ ] [\ **-w**\  \ *attr*\ =~\ *val*\ ] ...] [\ *noderange*\ ] [\ *attr=val*\  [\ *attr=val...*\ ]] [\ **-u**\  [\ **provmethod=**\  {\ **install**\  | \ **netboot**\  | \ **statelite**\ }] [\ **profile=**\ \ *xxx*\ ] [\ **osvers**\ =\ *value*\ ] [\ **osarch**\ =\ *value*\ ]]
 
 
 ***********
@@ -51,19 +50,19 @@ OPTIONS
  
 
 
-\ **-d|--dynamic**\ 
+\ **-d|-**\ **-dynamic**\ 
  
  Use the dynamic option to change dynamic node groups definition. This option must be used with -w option.
  
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-m|--minus**\ 
+\ **-m|-**\ **-minus**\ 
  
  If the value of the attribute is a list then this option may be used to remove one or more items from the list.
  
@@ -89,7 +88,7 @@ OPTIONS
  
 
 
-\ **-p|--plus**\ 
+\ **-p|-**\ **-plus**\ 
  
  This option will add the specified values to the existing value of the attribute.  It will create a comma-separated list of values.
  
@@ -101,7 +100,7 @@ OPTIONS
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Verbose mode.
  
@@ -121,7 +120,7 @@ OPTIONS
  
 
 
-\ **-z|--stanza**\ 
+\ **-z|-**\ **-stanza**\ 
  
  Indicates that the file being piped to the command is in stanza format. See the xcatstanzafile man page for details on using xCAT stanza files.
  

--- a/docs/source/guides/admin-guides/references/man1/chhypervisor.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/chhypervisor.1.rst
@@ -35,27 +35,27 @@ SYNOPSIS
 \ **zVM specific :**\ 
 
 
-\ **chhypervisor**\  \ *noderange*\  [\ **--adddisk2pool**\  \ *function*\  \ *region*\  \ *volume*\  \ *group*\ ]
+\ **chhypervisor**\  \ *noderange*\  [\ **-**\ **-adddisk2pool**\  \ *function*\  \ *region*\  \ *volume*\  \ *group*\ ]
 
-\ **chhypervisor**\  \ *noderange*\  [\ **--addscsi**\  \ *device_number*\  \ *device_path*\  \ *option*\  \ *persist*\ ]
+\ **chhypervisor**\  \ *noderange*\  [\ **-**\ **-addscsi**\  \ *device_number*\  \ *device_path*\  \ *option*\  \ *persist*\ ]
 
-\ **chhypervisor**\  \ *noderange*\  [\ **--addvlan**\  \ *name*\  \ *owner*\  \ *type*\  \ *transport*\ ]
+\ **chhypervisor**\  \ *noderange*\  [\ **-**\ **-addvlan**\  \ *name*\  \ *owner*\  \ *type*\  \ *transport*\ ]
 
-\ **chhypervisor**\  \ *noderange*\  [\ **--addvswitch**\  \ *name*\  \ *osa_dev_addr*\  \ *osa_exp_adapter*\  \ *controller*\  \ *connect (0, 1, or 2)*\  \ *memory_queue*\  \ *router*\  \ *transport*\  \ *vlan_id*\  \ *port_type*\  \ *update*\  \ *gvrp*\  \ *native_vlan*\ ]
+\ **chhypervisor**\  \ *noderange*\  [\ **-**\ **-addvswitch**\  \ *name*\  \ *osa_dev_addr*\  \ *osa_exp_adapter*\  \ *controller*\  \ *connect (0, 1, or 2)*\  \ *memory_queue*\  \ *router*\  \ *transport*\  \ *vlan_id*\  \ *port_type*\  \ *update*\  \ *gvrp*\  \ *native_vlan*\ ]
 
-\ **chhypervisor**\  \ *noderange*\  [\ **--addzfcp2pool**\  \ *pool*\  \ *status*\  \ *wwpn*\  \ *lun*\  \ *size*\  \ *owner*\ ]
+\ **chhypervisor**\  \ *noderange*\  [\ **-**\ **-addzfcp2pool**\  \ *pool*\  \ *status*\  \ *wwpn*\  \ *lun*\  \ *size*\  \ *owner*\ ]
 
-\ **chhypervisor**\  \ *noderange*\  [\ **--removediskfrompool**\  \ *function*\  \ *region*\  \ *group*\ ]
+\ **chhypervisor**\  \ *noderange*\  [\ **-**\ **-removediskfrompool**\  \ *function*\  \ *region*\  \ *group*\ ]
 
-\ **chhypervisor**\  \ *noderange*\  [\ **--removescsi**\  \ *device_number*\  \ *persist (YES or NO)*\ ]
+\ **chhypervisor**\  \ *noderange*\  [\ **-**\ **-removescsi**\  \ *device_number*\  \ *persist (YES or NO)*\ ]
 
-\ **chhypervisor**\  \ *noderange*\  [\ **--removevlan**\  \ *name*\  \ *owner*\ ]
+\ **chhypervisor**\  \ *noderange*\  [\ **-**\ **-removevlan**\  \ *name*\  \ *owner*\ ]
 
-\ **chhypervisor**\  \ *noderange*\  [\ **--removevswitch**\  \ *name*\ ]
+\ **chhypervisor**\  \ *noderange*\  [\ **-**\ **-removevswitch**\  \ *name*\ ]
 
-\ **chhypervisor**\  \ *noderange*\  [\ **--removezfcpfrompool**\  \ *pool*\  \ *lun*\  \ *wwpn*\ ]
+\ **chhypervisor**\  \ *noderange*\  [\ **-**\ **-removezfcpfrompool**\  \ *pool*\  \ *lun*\  \ *wwpn*\ ]
 
-\ **chhypervisor**\  \ *noderange*\  [\ **--smcli**\  \ *function*\  \ *arguments*\ ]
+\ **chhypervisor**\  \ *noderange*\  [\ **-**\ **-smcli**\  \ *function*\  \ *arguments*\ ]
 
 
 ***********
@@ -167,7 +167,7 @@ zVM specific :
 
 
 
-\ **--adddisk2pool**\  \ *function*\  \ *region*\  \ *volume*\  \ *group*\ 
+\ **-**\ **-adddisk2pool**\  \ *function*\  \ *region*\  \ *volume*\  \ *group*\ 
  
  Add a disk to a disk pool defined in the EXTENT CONTROL. Function type can be 
  either: (4) Define region as full volume and add to group OR (5) Add existing 
@@ -177,25 +177,25 @@ zVM specific :
  
 
 
-\ **--addscsi**\  \ *device_number*\  \ *device_path*\  \ *option*\  \ *persist*\ 
+\ **-**\ **-addscsi**\  \ *device_number*\  \ *device_path*\  \ *option*\  \ *persist*\ 
  
  Dynamically add a SCSI disk to a running z/VM system.
  
 
 
-\ **--addvlan**\  \ *name*\  \ *owner*\  \ *type*\  \ *transport*\ 
+\ **-**\ **-addvlan**\  \ *name*\  \ *owner*\  \ *type*\  \ *transport*\ 
  
  Create a virtual network LAN.
  
 
 
-\ **--addvswitch**\  \ *name*\  \ *osa_dev_addr*\  \ *osa_exp_adapter*\  \ *controller*\  \ *connect (0, 1, or 2)*\  \ *memory_queue*\  \ *router*\  \ *transport*\  \ *vlan_id*\  \ *port_type*\  \ *update*\  \ *gvrp*\  \ *native_vlan*\ 
+\ **-**\ **-addvswitch**\  \ *name*\  \ *osa_dev_addr*\  \ *osa_exp_adapter*\  \ *controller*\  \ *connect (0, 1, or 2)*\  \ *memory_queue*\  \ *router*\  \ *transport*\  \ *vlan_id*\  \ *port_type*\  \ *update*\  \ *gvrp*\  \ *native_vlan*\ 
  
  Create a virtual switch.
  
 
 
-\ **--addzfcp2pool**\  \ *pool*\  \ *status*\  \ *wwpn*\  \ *lun*\  \ *size*\  \ *owner*\ 
+\ **-**\ **-addzfcp2pool**\  \ *pool*\  \ *status*\  \ *wwpn*\  \ *lun*\  \ *size*\  \ *owner*\ 
  
  Add a zFCP device to a device pool defined in xCAT. The device must have been 
  carved up in the storage controller and configured with a WWPN/LUN before it 
@@ -204,7 +204,7 @@ zVM specific :
  
 
 
-\ **--removediskfrompool**\  \ *function*\  \ *region*\  \ *group*\ 
+\ **-**\ **-removediskfrompool**\  \ *function*\  \ *region*\  \ *group*\ 
  
  Remove a disk from a disk pool defined in the EXTENT CONTROL. Function type can 
  be either: (1) Remove region, (2) Remove region from group, (3) Remove region 
@@ -212,31 +212,31 @@ zVM specific :
  
 
 
-\ **--removescsi**\  \ *device_number*\  \ *persist (YES or NO)*\ 
+\ **-**\ **-removescsi**\  \ *device_number*\  \ *persist (YES or NO)*\ 
  
  Delete a real SCSI disk.
  
 
 
-\ **--removevlan**\  \ *name*\  \ *owner*\ 
+\ **-**\ **-removevlan**\  \ *name*\  \ *owner*\ 
  
  Delete a virtual network LAN.
  
 
 
-\ **--removevswitch**\  \ *name*\ 
+\ **-**\ **-removevswitch**\  \ *name*\ 
  
  Delete a virtual switch.
  
 
 
-\ **--removezfcpfrompool**\  \ *pool*\  \ *lun*\ 
+\ **-**\ **-removezfcpfrompool**\  \ *pool*\  \ *lun*\ 
  
  Remove a zFCP device from a device pool defined in xCAT.
  
 
 
-\ **--smcli**\  \ *function*\  \ *arguments*\ 
+\ **-**\ **-smcli**\  \ *function*\  \ *arguments*\ 
  
  Execute a SMAPI function. A list of APIs supported can be found by using the 
  help flag, e.g. chhypervisor pokdev61 --smcli -h. Specific arguments associated 

--- a/docs/source/guides/admin-guides/references/man1/chkkitcomp.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/chkkitcomp.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **chkkitcomp**\  [\ **-?**\ |\ **-h**\ |\ **--help**\ ] [\ **-v**\ |\ **--version**\ ]
+\ **chkkitcomp**\  [\ **-? | -h | -**\ **-help**\ ] [\ **-v | -**\ **-version**\ ]
 
-\ **chkkitcomp**\  [\ **-V**\ |\ **--verbose**\ ] \ **-i**\  \ *osimage*\   \ *kitcompname_list*\ 
+\ **chkkitcomp**\  [\ **-V | -**\ **-verbose**\ ] \ **-i**\  \ *osimage*\   \ *kitcompname_list*\ 
 
 
 ***********
@@ -42,19 +42,19 @@ OPTIONS
 
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Verbose mode.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command version.
  
@@ -66,7 +66,7 @@ OPTIONS
  
 
 
-\ **kitcompname_list**\ 
+\ *kitcompname_list*\ 
  
  A comma-delimited list of valid full kit component names or kit component basenames that are to be checked against the osimage.
  
@@ -88,7 +88,7 @@ EXAMPLES
 ********
 
 
-1. To check if a kit component , \ *comp-test1-1.0-1-rhels-6.2-ppc64*\  can be added to osimage \ *rhels6.2-ppc64-netboot-compute*\ :
+1. To check if a kit component, \ *comp-test1-1.0-1-rhels-6.2-ppc64*\  can be added to osimage \ *rhels6.2-ppc64-netboot-compute*\ :
 
 
 .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man1/chkosimage.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/chkosimage.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **chkosimage [-h | --help ]**\ 
+\ **chkosimage [-h | -**\ **-help ]**\ 
 
-\ **chkosimage [-V] [-c|--clean] osimage_name**\ 
+\ **chkosimage [-V] [-c|-**\ **-clean]**\  \ *osimage_name*\ 
 
 
 ***********
@@ -68,26 +68,26 @@ OPTIONS
 
 
 
-\ **-c |--clean**\ 
+\ **-c |-**\ **-clean**\ 
  
  Remove any older versions of the rpms.  Keep the version with the latest
  timestamp.
  
 
 
-\ **-h |--help**\ 
+\ **-h |-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **osimage_name**\ 
+\ *osimage_name*\ 
  
  The name of the xCAT for AIX osimage definition.
  
 
 
-\ **-V |--verbose**\ 
+\ **-V |-**\ **-verbose**\ 
  
  Verbose mode.
  
@@ -100,16 +100,12 @@ RETURN VALUE
 
 
 
-0
- 
- The command completed successfully.
- 
+0 The command completed successfully.
 
 
-1
- 
- An error has occurred.
- 
+
+1 An error has occurred.
+
 
 
 
@@ -119,22 +115,26 @@ EXAMPLES
 
 
 
-1
+1. Check the XCAT osimage called "61image" to verify that the lpp_source 
+directories contain all the software that is specified in the
+"installp_bundle" and "otherpkgs" attributes.
  
- Check the XCAT osimage called "61image" to verify that the lpp_source 
- directories contain all the software that is specified in the
- "installp_bundle" and "otherpkgs" attributes.
  
- \ **chkosimage -V 61image**\ 
+ .. code-block:: perl
+ 
+   chkosimage -V 61image
+ 
  
 
 
-2
+2. Clean up the lpp_source directory for the osimage named "61img" by removing
+any older rpms with the same names but different versions.
  
- Clean up the lpp_source directory for the osimage named "61img" by removing
- any older rpms with the same names but different versions.
  
- \ **chkosimage -c 61img**\ 
+ .. code-block:: perl
+ 
+   chkosimage -c 61img
+ 
  
 
 

--- a/docs/source/guides/admin-guides/references/man1/chvlan.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/chvlan.1.rst
@@ -19,13 +19,13 @@ SYNOPSIS
 ********
 
 
-\ **chvlan**\  \ *vlanid*\  \ **-n**\ |\ **--nodes**\  \ *noderange*\  [\ **-i**\ |\ **--interface**\  \ *nic*\ ]
+\ **chvlan**\  \ *vlanid*\  \ **-n | -**\ **-nodes**\  \ *noderange*\  [\ **-i | -**\ **-interface**\  \ *nic*\ ]
 
-\ **chvlan**\  \ *vlanid*\  \ **-n**\ |\ **--nodes**\  \ *noderange*\  \ **-d**\ |\ **--delete**\ 
+\ **chvlan**\  \ *vlanid*\  \ **-n | -**\ **-nodes**\  \ *noderange*\  \ **-d | -**\ **-delete**\ 
 
-\ **chvlan**\  [\ **-h**\ |\ **--help**\ ]
+\ **chvlan**\  [\ **-h | -**\ **-help**\ ]
 
-\ **chvlan**\  [\ **-v**\ |\ **--version**\ ]
+\ **chvlan**\  [\ **-v | -**\ **-version**\ ]
 
 
 ***********
@@ -52,19 +52,19 @@ OPTIONS
 
 
 
-\ **-n|--nodes**\     The nodes or groups to be added or removed. It can be stand alone nodes or KVM guests. It takes the noderange format. Please check the man page for noderange for details.
+\ **-n|-**\ **-nodes**\     The nodes or groups to be added or removed. It can be stand alone nodes or KVM guests. It takes the noderange format. Please check the man page for noderange for details.
 
 
 
-\ **-i|--interface**\  (For adding only). The interface name where the vlan will be tagged on. If omitted, the xCAT management network will be assumed. For KVM, it is the interface name on the host.
+\ **-i|-**\ **-interface**\  (For adding only). The interface name where the vlan will be tagged on. If omitted, the xCAT management network will be assumed. For KVM, it is the interface name on the host.
 
 
 
-\ **-h|--help**\      Display usage message.
+\ **-h|-**\ **-help**\      Display usage message.
 
 
 
-\ **-v|--version**\   The Command Version.
+\ **-v|-**\ **-version**\   The Command Version.
 
 
 

--- a/docs/source/guides/admin-guides/references/man1/chvlanports.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/chvlanports.1.rst
@@ -19,13 +19,13 @@ SYNOPSIS
 ********
 
 
-\ **chvlanports**\  \ *vlanid*\  \ **-n**\ |\ **--nodes**\  \ *noderange*\  \ **-i**\ |\ **--interface**\  \ *nic*\ 
+\ **chvlanports**\  \ *vlanid*\  \ **-n | -**\ **-nodes**\  \ *noderange*\  \ **-i | -**\ **-interface**\  \ *nic*\ 
 
-\ **chvlanports**\  \ *vlanid*\  \ **-n**\ |\ **--nodes**\  \ *noderange*\  \ **-i**\ |\ **--interface**\  \ *nic*\  \ **-d**\ |\ **--delete**\ 
+\ **chvlanports**\  \ *vlanid*\  \ **-n | -**\ **-nodes**\  \ *noderange*\  \ **-i | -**\ **-interface**\  \ *nic*\  \ **-d | -**\ **-delete**\ 
 
-\ **chvlanports**\  [\ **-h**\ |\ **--help**\ ]
+\ **chvlanports**\  [\ **-h | -**\ **-help**\ ]
 
-\ **chvlanports**\  [\ **-v**\ |\ **--version**\ ]
+\ **chvlanports**\  [\ **-v | -**\ **-version**\ ]
 
 
 ***********
@@ -47,19 +47,19 @@ OPTIONS
 
 
 
-\ **-n|--nodes**\     The nodes or groups to be added or removed. It takes the noderange format. Please check the man page for noderange for details.
+\ **-n|-**\ **-nodes**\     The nodes or groups to be added or removed. It takes the noderange format. Please check the man page for noderange for details.
 
 
 
-\ **-i|--interface**\  The interface name where the vlan will be tagged on.
+\ **-i|-**\ **-interface**\  The interface name where the vlan will be tagged on.
 
 
 
-\ **-h|--help**\      Display usage message.
+\ **-h|-**\ **-help**\      Display usage message.
 
 
 
-\ **-v|--version**\   The Command Version.
+\ **-v|-**\ **-version**\   The Command Version.
 
 
 

--- a/docs/source/guides/admin-guides/references/man1/chvm.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/chvm.1.rst
@@ -19,120 +19,115 @@ SYNOPSIS
 ********
 
 
-\ **chvm**\  [\ **-h**\ | \ **--help**\ ]
+\ **chvm**\  [\ **-h**\ | \ **-**\ **-help**\ ]
 
-\ **chvm**\  [\ **-v**\ | \ **--version**\ ]
+\ **chvm**\  [\ **-v**\ | \ **-**\ **-version**\ ]
 
 PPC (with HMC) specific:
 ========================
 
 
-\ **chvm**\  [\ **-V**\ | \ **--verbose**\ ] \ *noderange*\  [\ **-p**\  \ *profile*\ ]
+\ **chvm**\  [\ **-V**\ | \ **-**\ **-verbose**\ ] \ *noderange*\  [\ **-p**\  \ *profile*\ ]
 
-\ **chvm**\  [\ **-V**\ | \ **--verbose**\ ] \ *noderange*\  \ *attr*\ =\ *val*\  [\ *attr*\ =\ *val*\ ...]
+\ **chvm**\  [\ **-V**\ | \ **-**\ **-verbose**\ ] \ *noderange*\  \ *attr*\ =\ *val*\  [\ *attr*\ =\ *val*\ ...]
 
 
 PPC (using Direct FSP Management) specific:
 ===========================================
 
 
-\ **chvm**\  \ *noderange*\  \ *--p775*\  [\ **-p**\  \ *profile*\ ]
+\ **chvm**\  \ *noderange*\  \ **-**\ **-p775**\  [\ **-p**\  \ *profile*\ ]
 
-\ **chvm**\  \ *noderange*\  \ *--p775*\  \ **-i id**\  [\ **-m**\  \ *memory_interleaving*\ ] \ **-r**\  \ *partition_rule*\ 
+\ **chvm**\  \ *noderange*\  \ **-**\ **-p775**\  \ **-i id**\  [\ **-m**\  \ *memory_interleaving*\ ] \ **-r**\  \ *partition_rule*\ 
 
-\ **chvm**\  \ *noderange*\  [\ **lparname**\ ={\ **\\***\ |\ **name**\ }]
+\ **chvm**\  \ *noderange*\  [\ **lparname**\ ={ \* | \ *name*\ }]
 
-\ **chvm**\  \ *noderange*\  [\ **vmcpus=min/req/max**\ ] [\ **vmmemory=min/req/max**\ ]
-               [\ **vmothersetting=hugepage:N,bsr:N**\ ]
-               [\ **add_physlots=drc_index1,drc_index2...**\ ]
-               [\ **add_vmnics=vlan1[,vlan2..]]**\  [\ **add_vmstorage=<N|viosnode:slotid**\ >] [\ **--vios**\ ]
-               [\ **del_physlots=drc_index1,drc_index2...**\ ]
-               [\ **del_vadapter=slotid**\ ]
+\ **chvm**\  \ *noderange*\  [\ **vmcpus=**\  \ *min/req/max*\ ] [\ **vmmemory=**\  \ *min/req/max*\ ] [\ **vmothersetting=hugepage:N,bsr:N**\ ] [\ **add_physlots=**\  \ *drc_index1,drc_index2...*\ ] [\ **add_vmnics=**\  \ *vlan1[,vlan2..]]*\  [\ **add_vmstorage=<N|viosnode:slotid**\ >] [\ **-**\ **-vios**\ ] [\ **del_physlots=**\  \ *drc_index1,drc_index2...*\ ] [\ **del_vadapter=**\  \ *slotid*\ ]
 
 
 KVM specific:
 =============
 
 
-\ **chvm**\  \ *noderange*\  [\ **--cpupin**\  \ *hostcpuset*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-cpupin**\  \ *hostcpuset*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--membind**\  \ *numanodeset*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-membind**\  \ *numanodeset*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--devpassthru**\  \ *pcidevice*\ ...]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-devpassthru**\  \ *pcidevice*\ ...]
 
-\ **chvm**\  \ *noderange*\  [\ **--devdetach**\  \ *pcidevice*\ ...]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-devdetach**\  \ *pcidevice*\ ...]
 
 
 VMware/KVM specific:
 ====================
 
 
-\ **chvm**\  \ *noderange*\  [\ **-a**\  \ *size*\ ] [\ **-d**\  \ *disk*\ ] [\ **-p**\  \ *disk*\ ] [\ **--resize**\  \ **disk**\ =\ *size*\ ] [\ **--cpus**\  \ *count*\ ] [\ **--mem**\  \ *memory*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-a**\  \ *size*\ ] [\ **-d**\  \ *disk*\ ] [\ **-p**\  \ *disk*\ ] [\ **-**\ **-resize**\  \ **disk**\ =\ *size*\ ] [\ **-**\ **-cpus**\  \ *count*\ ] [\ **-**\ **-mem**\  \ *memory*\ ]
 
 
 zVM specific:
 =============
 
 
-\ **chvm**\  \ *noderange*\  [\ **--add3390**\  \ *disk_pool*\  \ *device_address*\  \ *size*\  \ *mode*\  \ *read_password*\  \ *write_password*\  \ *multi_password*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-add3390**\  \ *disk_pool*\  \ *device_address*\  \ *size*\  \ *mode*\  \ *read_password*\  \ *write_password*\  \ *multi_password*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--add3390active**\  \ *device_address*\  \ *mode*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-add3390active**\  \ *device_address*\  \ *mode*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--add9336**\  \ *disk_pool*\  \ *device_address*\  \ *size*\  \ *mode*\  \ *read_password*\  \ *write_password*\  \ *multi_password*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-add9336**\  \ *disk_pool*\  \ *device_address*\  \ *size*\  \ *mode*\  \ *read_password*\  \ *write_password*\  \ *multi_password*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--adddisk2pool**\  \ *function*\  \ *region*\  \ *volume*\  \ *group*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-adddisk2pool**\  \ *function*\  \ *region*\  \ *volume*\  \ *group*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--addnic**\  \ *device_address*\  \ *type*\  \ *device_count*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-addnic**\  \ *device_address*\  \ *type*\  \ *device_count*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--addpagespool**\  \ *volume_address*\  \ *volume_label*\  \ *volume_use*\  \ *system_config_name*\  \ *system_config_type*\  \ *parm_disk_owner*\  \ *parm_disk_number*\  \ *parm_disk_password*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-addpagespool**\  \ *volume_address*\  \ *volume_label*\  \ *volume_use*\  \ *system_config_name*\  \ *system_config_type*\  \ *parm_disk_owner*\  \ *parm_disk_number*\  \ *parm_disk_password*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--addprocessor**\  \ *device_address*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-addprocessor**\  \ *device_address*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--addprocessoractive**\  \ *device_address*\  \ *type*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-addprocessoractive**\  \ *device_address*\  \ *type*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--addvdisk**\  \ *device_address*\  \ *size*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-addvdisk**\  \ *device_address*\  \ *size*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--addzfcp**\  \ *pool*\  \ *device_address*\  \ *loaddev*\  \ *size*\  \ *tag*\  \ *wwpn*\  \ *lun*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-addzfcp**\  \ *pool*\  \ *device_address*\  \ *loaddev*\  \ *size*\  \ *tag*\  \ *wwpn*\  \ *lun*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--connectnic2guestlan**\  \ *device_address*\  \ *lan*\  \ *owner*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-connectnic2guestlan**\  \ *device_address*\  \ *lan*\  \ *owner*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--connectnic2vswitch**\  \ *device_address*\  \ *vswitch*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-connectnic2vswitch**\  \ *device_address*\  \ *vswitch*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--copydisk**\  \ *target_address*\  \ *source_node*\  \ *source_address*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-copydisk**\  \ *target_address*\  \ *source_node*\  \ *source_address*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--dedicatedevice**\  \ *virtual_device*\  \ *real_device*\  \ *mode*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-dedicatedevice**\  \ *virtual_device*\  \ *real_device*\  \ *mode*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--deleteipl**\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-deleteipl**\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--disconnectnic**\  \ *device_address*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-disconnectnic**\  \ *device_address*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--formatdisk**\  \ *device_address*\  \ *multi_password*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-formatdisk**\  \ *device_address*\  \ *multi_password*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--grantvswitch**\  \ *vswitch*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-grantvswitch**\  \ *vswitch*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--purgerdr**\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-purgerdr**\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--removedisk**\  \ *device_address*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-removedisk**\  \ *device_address*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--removenic**\  \ *device_address*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-removenic**\  \ *device_address*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--removeprocessor**\  \ *device_address*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-removeprocessor**\  \ *device_address*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--removeloaddev**\  \ *wwpn*\  \ *lun*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-removeloaddev**\  \ *wwpn*\  \ *lun*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--removezfcp**\  \ *device_address*\  \ *wwpn*\  \ *lun*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-removezfcp**\  \ *device_address*\  \ *wwpn*\  \ *lun*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--replacevs**\  \ *directory_entry*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-replacevs**\  \ *directory_entry*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--setipl**\  \ *ipl_target*\  \ *load_parms*\  \ *parms*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-setipl**\  \ *ipl_target*\  \ *load_parms*\  \ *parms*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--setpassword**\  \ *password*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-setpassword**\  \ *password*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--setloaddev**\  \ *wwpn*\  \ *lun*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-setloaddev**\  \ *wwpn*\  \ *lun*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--sharevolume**\  \ *volume_address*\  \ *share_enable*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-sharevolume**\  \ *volume_address*\  \ *share_enable*\ ]
 
-\ **chvm**\  \ *noderange*\  [\ **--undedicatedevice**\  \ *device_address*\ ]
+\ **chvm**\  \ *noderange*\  [\ **-**\ **-undedicatedevice**\  \ *device_address*\ ]
 
 
 
@@ -227,7 +222,7 @@ PPC (using Direct FSP Management) specific:
 
 
 
-\ **--p775**\ 
+\ **-**\ **-p775**\ 
  
  Specify the operation is for Power 775 machines.
  
@@ -235,19 +230,19 @@ PPC (using Direct FSP Management) specific:
 
 \ **-i**\ 
  
- Starting numeric id of the newly created partitions. For Power 775 using Direct FSP Management, the id value only could be \ **1**\ , \ **5**\ , \ **9**\ , \ **13**\ , \ **17**\ , \ **21**\ , \ **25**\  and \ **29**\ . Shall work with option \ **--p775**\ .
+ Starting numeric id of the newly created partitions. For Power 775 using Direct FSP Management, the id value only could be \ **1**\ , \ **5**\ , \ **9**\ , \ **13**\ , \ **17**\ , \ **21**\ , \ **25**\  and \ **29**\ . Shall work with option \ **-**\ **-p775**\ .
  
 
 
 \ **-m**\ 
  
- memory interleaving. The setting value only could be \ **1**\  or \ **2**\ . \ **2**\  means \ **non-interleaved**\  mode (also 2MC mode), the memory cannot be shared across the processors in an octant. \ **1**\  means \ **interleaved**\  mode (also 8MC mode) , the memory can be shared. The default value is \ **1**\ . Shall work with option \ **--p775**\ .
+ memory interleaving. The setting value only could be \ **1**\  or \ **2**\ . \ **2**\  means \ **non-interleaved**\  mode (also 2MC mode), the memory cannot be shared across the processors in an octant. \ **1**\  means \ **interleaved**\  mode (also 8MC mode) , the memory can be shared. The default value is \ **1**\ . Shall work with option \ **-**\ **-p775**\ .
  
 
 
 \ **-r**\ 
  
- partition rule. Shall work with option \ **--p775**\ .
+ partition rule. Shall work with option \ **-**\ **-p775**\ .
  
  If all the octants configuration value are same in one CEC,  it will be  " \ **-r**\   \ **0-7**\ :\ *value*\ " .
  
@@ -269,11 +264,11 @@ PPC (using Direct FSP Management) specific:
 
 \ **-p**\  \ *profile*\ 
  
- Name of I/O slots assignment profile. Shall work with option \ **--p775**\ .
+ Name of I/O slots assignment profile. Shall work with option \ **-**\ **-p775**\ .
  
 
 
-\ **lparname**\ ={\ **\\***\ |\ **name**\ }
+\ **lparname**\ ={\ **\\* | name**\ }
  
  Set LPAR name for the specified lpars. If '\*' specified, it means to get names from xCAT database and then set them for the specified lpars. If a string is specified, it only supports single node and the string will be set for the specified lpar. The user can use lsvm to check the lparnames for lpars.
  
@@ -285,7 +280,7 @@ PPC (using Direct FSP Management) specific:
  
 
 
-\ **add_vmnics=value**\  \ **add_vmstorage=value**\  [\ **--vios**\ ]
+\ **add_vmnics=value**\  \ **add_vmstorage=value**\  [\ **-**\ **-vios**\ ]
  
  To create new virtual adapter for the specified node.
  
@@ -315,7 +310,7 @@ VMware/KVM specific:
  
 
 
-\ **--cpus**\  \ *count*\ 
+\ **-**\ **-cpus**\  \ *count*\ 
  
  Set the number of CPUs.
  
@@ -327,7 +322,7 @@ VMware/KVM specific:
  
 
 
-\ **--mem**\  \ *memory*\ 
+\ **-**\ **-mem**\  \ *memory*\ 
  
  Set the memory, defaults to MB.
  
@@ -339,7 +334,7 @@ VMware/KVM specific:
  
 
 
-\ **--resize**\  \ **disk**\ =\ *size*\ 
+\ **-**\ **-resize**\  \ **disk**\ =\ *size*\ 
  
  Change the size of the Hard disk.  The disk can never be set to less than it's current size.  Multiple disks can be resized to \ *size*\  by using comma separated values on the left side of \ **=**\ .  The disks are specified by SCSI id.  Size defaults to GB.
  
@@ -351,7 +346,7 @@ KVM specific:
 
 
 
-\ **--cpupin hostcpuset**\ 
+\ **-**\ **-cpupin hostcpuset**\ 
  
  To pin guest domain virtual CPUs to physical host CPUs specified with \ *hostcpuset*\ .
  \ *hostcpuset*\  is a list of physical CPU numbers. Its syntax is a comma separated list and a special
@@ -363,7 +358,7 @@ KVM specific:
  
 
 
-\ **--membind numanodeset**\ 
+\ **-**\ **-membind numanodeset**\ 
  
  It is possible to restrict a guest to allocate memory from the specified set of NUMA nodes \ *numanodeset*\ . 
  If the guest vCPUs are also pinned to a set of cores located on that same set of NUMA nodes, memory
@@ -371,7 +366,7 @@ KVM specific:
  
 
 
-\ **--devpassthru pcidevice1,pcidevice2...**\ 
+\ **-**\ **-devpassthru pcidevice1,pcidevice2...**\ 
  
  The PCI passthrough gives a guest VM direct access to I/O devices \ *pcidevice1,pcidevice2...*\ . 
  The PCI devices are assigned to a virtual machine, and the virtual machine can use this I/O exclusively.
@@ -379,7 +374,7 @@ KVM specific:
  
 
 
-\ **--devdetach pcidevice1,pcidevice2...**\ 
+\ **-**\ **-devdetach pcidevice1,pcidevice2...**\ 
  
  To detaching the PCI devices which are attached to VM guest via PCI passthrough from the VM guest. The devices list are a list of comma separated PCI device names delimited with comma, the PCI device names can be obtained by running \ **virsh nodedev-list**\  on the host.
  
@@ -391,61 +386,61 @@ zVM specific:
 
 
 
-\ **--add3390**\  \ *disk_pool*\  \ *device_address*\  \ *size*\  \ *mode*\  \ *read_password*\  \ *write_password*\  \ *multi_password*\ 
+\ **-**\ **-add3390**\  \ *disk_pool*\  \ *device_address*\  \ *size*\  \ *mode*\  \ *read_password*\  \ *write_password*\  \ *multi_password*\ 
  
  Adds a 3390 (ECKD) disk to a virtual machine's directory entry. The device address can be automatically assigned by specifying 'auto'. The size of the disk can be specified in GB, MB, or the number of cylinders.
  
 
 
-\ **--add3390active**\  \ *device_address*\  \ *mode*\ 
+\ **-**\ **-add3390active**\  \ *device_address*\  \ *mode*\ 
  
  Adds a 3390 (ECKD) disk that is defined in a virtual machine's directory entry to that virtual server's active configuration.
  
 
 
-\ **--add9336**\  \ *disk_pool*\  \ *device_address*\  \ *size*\  \ *mode*\  \ *read_password*\  \ *write_password*\  \ *multi_password*\ 
+\ **-**\ **-add9336**\  \ *disk_pool*\  \ *device_address*\  \ *size*\  \ *mode*\  \ *read_password*\  \ *write_password*\  \ *multi_password*\ 
  
  Adds a 9336 (FBA) disk to a virtual machine's directory entry. The device address can be automatically assigned by specifying 'auto'. The size of the disk can be specified in GB, MB, or the number of blocks.
  
 
 
-\ **--adddisk2pool**\  \ *function*\  \ *region*\  \ *volume*\  \ *group*\ 
+\ **-**\ **-adddisk2pool**\  \ *function*\  \ *region*\  \ *volume*\  \ *group*\ 
  
  Add a disk to a disk pool defined in the EXTENT CONTROL. Function type can be either: (4) Define region as full volume and add to group OR (5) Add existing region to group.  The disk has to already be attached to SYSTEM.
  
 
 
-\ **--addnic**\  \ *device_address*\  \ *type*\  \ *device_count*\ 
+\ **-**\ **-addnic**\  \ *device_address*\  \ *type*\  \ *device_count*\ 
  
  Adds a network adapter to a virtual machine's directory entry (case sensitive).
  
 
 
-\ **--addpagespool**\  \ *volume_addr*\  \ *volume_label*\  \ *volume_use*\  \ *system_config_name*\  \ *system_config_type*\  \ *parm_disk_owner*\  \ *parm_disk_number*\  \ *parm_disk_password*\ 
+\ **-**\ **-addpagespool**\  \ *volume_addr*\  \ *volume_label*\  \ *volume_use*\  \ *system_config_name*\  \ *system_config_type*\  \ *parm_disk_owner*\  \ *parm_disk_number*\  \ *parm_disk_password*\ 
  
  Add a full volume page or spool disk to the virtual machine.
  
 
 
-\ **--addprocessor**\  \ *device_address*\ 
+\ **-**\ **-addprocessor**\  \ *device_address*\ 
  
  Adds a virtual processor to a virtual machine's directory entry.
  
 
 
-\ **--addprocessoractive**\  \ *device_address*\  \ *type*\ 
+\ **-**\ **-addprocessoractive**\  \ *device_address*\  \ *type*\ 
  
  Adds a virtual processor to a virtual machine's active configuration (case sensitive).
  
 
 
-\ **--addvdisk**\  \ *device_address*\  \ *size*\ 
+\ **-**\ **-addvdisk**\  \ *device_address*\  \ *size*\ 
  
  Adds a v-disk to a virtual machine's directory entry.
  
 
 
-\ **--addzfcp**\  \ *pool*\  \ *device_address*\  \ *loaddev*\  \ *size*\  \ *tag*\  \ *wwpn*\  \ *lun*\ 
+\ **-**\ **-addzfcp**\  \ *pool*\  \ *device_address*\  \ *loaddev*\  \ *size*\  \ *tag*\  \ *wwpn*\  \ *lun*\ 
  
  Add a zFCP device to a device pool defined in xCAT. The device must have been 
  carved up in the storage controller and configured with a WWPN/LUN before it can 
@@ -458,115 +453,115 @@ zVM specific:
  
 
 
-\ **--connectnic2guestlan**\  \ *device_address*\  \ *lan*\  \ *owner*\ 
+\ **-**\ **-connectnic2guestlan**\  \ *device_address*\  \ *lan*\  \ *owner*\ 
  
  Connects a given network adapter to a GuestLAN.
  
 
 
-\ **--connectnic2vswitch**\  \ *device_address*\  \ *vswitch*\ 
+\ **-**\ **-connectnic2vswitch**\  \ *device_address*\  \ *vswitch*\ 
  
  Connects a given network adapter to a VSwitch.
  
 
 
-\ **--copydisk**\  \ *target_address*\  \ *source_node*\  \ *source_address*\ 
+\ **-**\ **-copydisk**\  \ *target_address*\  \ *source_node*\  \ *source_address*\ 
  
  Copy a disk attached to a given virtual server.
  
 
 
-\ **--dedicatedevice**\  \ *virtual_device*\  \ *real_device*\  \ *mode*\ 
+\ **-**\ **-dedicatedevice**\  \ *virtual_device*\  \ *real_device*\  \ *mode*\ 
  
  Adds a dedicated device to a virtual machine's directory entry.
  
 
 
-\ **--deleteipl**\ 
+\ **-**\ **-deleteipl**\ 
  
  Deletes the IPL statement from the virtual machine's directory entry.
  
 
 
-\ **--disconnectnic**\  \ *device_address*\ 
+\ **-**\ **-disconnectnic**\  \ *device_address*\ 
  
  Disconnects a given network adapter.
  
 
 
-\ **--formatdisk**\  \ *disk_address*\  \ *multi_password*\ 
+\ **-**\ **-formatdisk**\  \ *disk_address*\  \ *multi_password*\ 
  
  Formats a disk attached to a given virtual server (only ECKD disks supported). The disk should not be linked to any other virtual server. This command is best used after add3390().
  
 
 
-\ **--grantvswitch**\  \ *vswitch*\ 
+\ **-**\ **-grantvswitch**\  \ *vswitch*\ 
  
  Grant vSwitch access for given virtual machine.
  
 
 
-\ **--purgerdr**\ 
+\ **-**\ **-purgerdr**\ 
  
  Purge the reader belonging to the virtual machine
  
 
 
-\ **--removedisk**\  \ *device_address*\ 
+\ **-**\ **-removedisk**\  \ *device_address*\ 
  
  Removes a minidisk from a virtual machine's directory entry.
  
 
 
-\ **--removenic**\  \ *device_address*\ 
+\ **-**\ **-removenic**\  \ *device_address*\ 
  
  Removes a network adapter from a virtual machine's directory entry.
  
 
 
-\ **--removeprocessor**\  \ *device_address*\ 
+\ **-**\ **-removeprocessor**\  \ *device_address*\ 
  
  Removes a processor from an active virtual machine's configuration.
  
 
 
-\ **--removeloaddev**\  \ *wwpn*\  \ *lun*\ 
+\ **-**\ **-removeloaddev**\  \ *wwpn*\  \ *lun*\ 
  
  Removes the LOADDEV statement from a virtual machines's directory entry.
  
 
 
-\ **--removezfcp**\  \ *device_address*\  \ *wwpn*\  \ *lun*\ 
+\ **-**\ **-removezfcp**\  \ *device_address*\  \ *wwpn*\  \ *lun*\ 
  
  Removes a given SCSI/FCP device belonging to the virtual machine.
  
 
 
-\ **--replacevs**\  \ *directory_entry*\ 
+\ **-**\ **-replacevs**\  \ *directory_entry*\ 
  
  Replaces a virtual machine's directory entry. The directory entry can be echoed into stdin or a text file.
  
 
 
-\ **--setipl**\  \ *ipl_target*\  \ *load_parms*\  \ *parms*\ 
+\ **-**\ **-setipl**\  \ *ipl_target*\  \ *load_parms*\  \ *parms*\ 
  
  Sets the IPL statement for a given virtual machine.
  
 
 
-\ **--setpassword**\  \ *password*\ 
+\ **-**\ **-setpassword**\  \ *password*\ 
  
  Sets the password for a given virtual machine.
  
 
 
-\ **--setloaddev**\  \ *wwpn*\  \ *lun*\ 
+\ **-**\ **-setloaddev**\  \ *wwpn*\  \ *lun*\ 
  
  Sets the LOADDEV statement in the virtual machine's directory entry.
  
 
 
-\ **--undedicatedevice**\  \ *device_address*\ 
+\ **-**\ **-undedicatedevice**\  \ *device_address*\ 
  
  Delete a dedicated device from a virtual machine's active configuration and directory entry.
  
@@ -781,7 +776,12 @@ Output is similar to:
 7. For Normal Power machine, to modify the resource assigned to a partition:
 
 Before modify, the resource assigned to node 'lpar1' can be shown with:
- lsvm lpar1
+
+
+.. code-block:: perl
+
+  lsvm lpar1
+
 
 The output is similar to:
 

--- a/docs/source/guides/admin-guides/references/man1/chzone.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/chzone.1.rst
@@ -19,7 +19,7 @@ chzone.1
 ****************
 
 
-\ **chzone**\  <zonename>  [\ **--defaultzone**\ ] [-K] [\ **-k**\  \ *full path to the ssh RSA private key*\ ] [\ **-a**\  \ *noderange*\  | \ **-r**\  \ *noderange*\ ] [\ **-g**\ ] [\ **-f**\ ] [\ **-s**\  \ *yes|no*\ ] [-V]
+\ **chzone**\  \ *zonename*\   [\ **-**\ **-defaultzone**\ ] \ **[-K]**\  [\ **-k**\  \ *full path to the ssh RSA private key*\ ] [\ **-a**\  \ *noderange*\  | \ **-r**\  \ *noderange*\ ] [\ **-g**\ ] [\ **-f**\ ] [\ **-s**\  \ **{yes|no}**\ ] [\ **-V**\ ]
 
 \ **chzone**\  [\ **-h**\  | \ **-v**\ ]
 
@@ -41,42 +41,42 @@ Note: if any zones in the zone table, there must be one and only one defaultzone
 
 
 
-\ **-h**\ |\ **--help**\ 
+\ **-h | -**\ **-help**\ 
  
  Displays usage information.
  
 
 
-\ **-v**\ |\ **--version**\ 
+\ **-v | -**\ **-version**\ 
  
  Displays command version and build date.
  
 
 
-\ **-k | --sshkeypath**\  \ *full path to the ssh RSA private key*\ 
+\ **-k | -**\ **-sshkeypath**\  \ *full path to the ssh RSA private key*\ 
  
  This is the path to the id_rsa key that will be used to build new root's ssh keys for the zone. If -k is used, it will generate the ssh public key from the input ssh RSA private key, and store both in /etc/xcat/sshkeys/<zonename>/.ssh directory.
  
 
 
-\ **-K | --genkeys**\ 
+\ **-K | -**\ **-genkeys**\ 
  
  Using this flag, will  generate new ssh RSA private and public keys for the zone into the /etc/xcat/sshkeys/<zonename>/.ssh directory.
  The nodes are not automatically updated with the new root ssh keys by chzone. You must run updatenode -k  or xdsh -K to the nodes to update the root ssh keys to the new generated zone keys. This will also sync any service nodes with the zone keys, if you have a hierarchical cluster.
  
 
 
-\ **--default**\ 
+\ **-**\ **-defaultzone**\ 
  
- if --defaultzone is input, then it will set the zone defaultzone attribute to yes.
- if --defaultzone is input and another zone is currently the default,
- then the -f flag must be used to force a change to the new defaultzone.
- If -f flag is not use an error will be returned and no change made. 
+ if \ **-**\ **-defaultzone**\  is input, then it will set the zone defaultzone attribute to yes.
+ if \ **-**\ **-defaultzone**\  is input and another zone is currently the default,
+ then the \ **-f**\  flag must be used to force a change to the new defaultzone.
+ If \ **-f**\  flag is not use an error will be returned and no change made. 
  Note: if any zones in the zone table, there must be one and only one defaultzone. Otherwise, errors will occur.
  
 
 
-\ **-a | --addnoderange**\  \ *noderange*\ 
+\ **-a | -**\ **-addnoderange**\  \ *noderange*\ 
  
  For each node in the noderange, it will set the zonename attribute for that node to the input zonename.
  If the -g flag is also on the command, then
@@ -84,7 +84,7 @@ Note: if any zones in the zone table, there must be one and only one defaultzone
  
 
 
-\ **-r | --rmnoderange**\  \ *noderange*\ 
+\ **-r | -**\ **-rmnoderange**\  \ *noderange*\ 
  
  For each node in the noderange, if the node is a member of the input zone, it will remove the zonename attribute for that node.
  If any of the nodes in the noderange is not a member of the zone, you will get an error and nothing will be changed.
@@ -93,25 +93,25 @@ Note: if any zones in the zone table, there must be one and only one defaultzone
  
 
 
-\ **-s| --sshbetweennodes**\  \ **yes|no**\ 
+\ **-s| -**\ **-sshbetweennodes**\  \ **yes|no**\ 
  
  If -s entered, the zone sshbetweennodes attribute will be set to yes or no based on the input. When this is set to yes, then ssh will be setup to allow passwordless root access between nodes.  If no, then root will be prompted for a password when running ssh between the nodes in the zone.
  
 
 
-\ **-f | --force**\ 
+\ **-f | -**\ **-force**\ 
  
- Used with the (--defaultzone) flag to override the current default zone.
- 
-
-
-\ **-g | --assigngroup**\ 
- 
- Used with the (-a or -r ) flag to add or remove the group zonename for all nodes in the input noderange.
+ Used with the \ **-**\ **-defaultzone**\  flag to override the current default zone.
  
 
 
-\ **-V**\ |\ **--Verbose**\ 
+\ **-g | -**\ **-assigngroup**\ 
+ 
+ Used with the \ **-a**\  or \ **-r**\  flag to add or remove the group zonename for all nodes in the input noderange.
+ 
+
+
+\ **-V | -**\ **-Verbose**\ 
  
  Verbose mode.
  
@@ -119,68 +119,86 @@ Note: if any zones in the zone table, there must be one and only one defaultzone
 
 
 ****************
-\ **Examples**\ 
+\ **EXAMPLES**\ 
 ****************
 
 
 
-\*
+1. To chzone zone1 to the default zone, enter:
  
- To chzone zone1 to the default zone, enter:
  
- \ **chzone**\  \ *zone1*\  --default -f
+ .. code-block:: perl
+ 
+   chzone> zone1 --default -f
+ 
  
 
 
-\*
+2. To generate new root ssh keys for zone2A using the ssh id_rsa private key in /root/.ssh:
  
- To generate new root ssh keys for zone2A using the ssh id_rsa private key in /root/.ssh:
  
- \ **chzone**\  \ *zone2A*\  -k /root/.ssh
+ .. code-block:: perl
+ 
+   chzone zone2A -k /root/.ssh
+ 
  
  Note: you must use xdsh -K or updatenode -k to update the nodes with the new keys
  
 
 
-\*
+3. To generate new root ssh keys for zone2A, enter :
  
- To generate new root ssh keys for zone2A, enter :
  
- \ **chzone**\  \ *zone2A*\  -K
+ .. code-block:: perl
+ 
+   chzone zone2A -K
+ 
  
  Note: you must use xdsh -K or updatenode -k to update the nodes with the new keys
  
 
 
-\*
+4. To add a new group of nodes (compute3) to zone3 and add zone3 group to the nodes,  enter:
  
- To add a new group of nodes (compute3) to zone3 and add zone3 group to the nodes,  enter:
  
- \ **chzone**\  \ *zone3*\   -a compute3 -g
+ .. code-block:: perl
+ 
+   chzone zone3 -a compute3 -g
+ 
  
 
 
-\*
+5.
  
  To remove a group of nodes (compute4) from zone4 and remove zone4 group from the nodes,  enter:
  
- \ **chzone**\  \ *zone4*\   -r compute4 -g
+ 
+ .. code-block:: perl
+ 
+   chzone> zone4 -r compute4 -g
+ 
  
 
 
-\*
+6. To change the sshbetweennodes setting on the zone to not allow passwordless ssh between nodes,  enter:
  
- To change the sshbetweennodes setting on the zone to not allow passwordless ssh between nodes,  enter:
  
- \ **chzone**\  \ *zone5*\  -s no
+ .. code-block:: perl
  
- Note: you must use xdsh -K or updatenode -k to update the nodes with this new setting.
+   chzone zone5 -s no
+ 
+ 
+ Note: you must use \ **xdsh -K**\  or \ **updatenode -k**\  to update the nodes with this new setting.
  
 
 
-\ **Files**\ 
 
-\ **/opt/xcat/bin/chzone/**\ 
+*************
+\ **FILES**\ 
+*************
+
+
+/opt/xcat/bin/chzone/
 
 Location of the chzone command.
 

--- a/docs/source/guides/admin-guides/references/man1/clonevm.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/clonevm.1.rst
@@ -19,7 +19,7 @@ SYNOPSIS
 ********
 
 
-\ *clonevm noderange [ -t <mastertobemade*\  | -b <master to base vms upon> ]  -d|--detached -f|--force>
+\ **clonevm**\  \ *noderange*\  [ \ **-t**\  \ *mastertobemade*\  | \ **-b**\  \ *master to base vms upon*\  ]  \ **-d|-**\ **-detached -f|-**\ **-force**\ 
 
 
 ***********
@@ -49,7 +49,7 @@ OPTIONS
 *******
 
 
-\ **-h|--help**\        Display usage message.
+\ **-h|-**\ **-help**\        Display usage message.
 
 \ **-b**\               The master to base the clones upon
 
@@ -59,9 +59,9 @@ OPTIONS
 
 \ **-f**\               Force cloning of a powered on VM.  Implies -d if the VM is on.
 
-\ **-v|--version**\     Command Version.
+\ **-v|-**\ **-version**\     Command Version.
 
-\ **-V|--verbose**\     Verbose output.
+\ **-V|-**\ **-verbose**\     Verbose output.
 
 
 ************
@@ -79,11 +79,26 @@ EXAMPLES
 ********
 
 
-Creating a master named appserver from a node called vm1:
-\ *clonevm vm1 -t appserver*\ 
 
-Cleating 30 VMs from a master named appserver:
-\ *clonevm vm1-vm30 -b appserver*\ 
+1. Creating a master named appserver from a node called vm1:
+ 
+ 
+ .. code-block:: perl
+ 
+   clonevm vm1 -t appserver
+ 
+ 
+
+
+2. Cleating 30 VMs from a master named appserver:
+ 
+ 
+ .. code-block:: perl
+ 
+   clonevm vm1-vm30 -b appserver
+ 
+ 
+
 
 
 *****

--- a/docs/source/guides/admin-guides/references/man1/configfpc.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/configfpc.1.rst
@@ -21,11 +21,11 @@ SYNOPSIS
 
 \ **configfpc**\  \ **-i**\  \ *interface*\ 
 
-\ **configfpc**\  \ **-i**\  \ *interface*\  \ **--ip**\  \ *default ip address*\ 
+\ **configfpc**\  \ **-i**\  \ *interface*\  \ **-**\ **-ip**\  \ *default ip address*\ 
 
-\ **configfpc**\  [\ **-V**\ |\ **--verbose**\ ]
+\ **configfpc**\  [\ **-V | -**\ **-verbose**\ ]
 
-\ **configfpc**\  [\ **-h**\ |\ **--help**\ |\ **-?**\ ]
+\ **configfpc**\  [\ **-h | -**\ **-help | -?**\ ]
 
 
 ***********
@@ -35,7 +35,7 @@ DESCRIPTION
 
 \ **configfpc**\  will discover and configure all FPCs that are set to the default IP address. If not supplied the default ip is 192.168.0.100.
 
-The \ **-i**\  \ **interface**\  is required to direct \ **configfpc**\  to the xCAT MN interface which is on the same VLAN as the FPCs.
+The \ **-i**\  \ *interface*\  is required to direct \ **configfpc**\  to the xCAT MN interface which is on the same VLAN as the FPCs.
 
 There are several bits of information that must be included in the xCAT database before running this command.
 
@@ -61,38 +61,42 @@ OPTIONS
  
 
 
-\ **--ip**\  \ *default ip address*\ 
+\ **-**\ **-ip**\  \ *default ip address*\ 
  
  Use this flag to override the default ip address of 192.168.0.100 with a new address.
  
 
 
-\ **-V**\ |\ **--verbose**\ 
+\ **-V | -**\ **-verbose**\ 
  
  Verbose mode
  
 
 
 
-*******
-Example
-*******
+********
+EXAMPLES
+********
 
 
 
-1
+1. To discover and configure all NeXtScale Fan Power Controllers (FPCs) connected on eth0 interface.
  
- To discover and configure all NeXtScale Fan Power Controllers (FPCs) connected on eth0 interface.
  
- \ **configfpc**\  \ **-i**\  \ *eth0*\ 
+ .. code-block:: perl
+ 
+   configfpc -i eth0
+ 
  
 
 
-2
+2. To override the default ip address and run in Verbose mode.
  
- To override the default ip address and run in Verbose mode.
  
- \ **configfpc**\  \ **-i**\  \ *eth0*\  \ **--ip**\  \ *196.68.0.100*\   \ **-V**\ 
+ .. code-block:: perl
+ 
+   configfpc -i eth0 --ip 196.68.0.100 -V
+ 
  
 
 

--- a/docs/source/guides/admin-guides/references/man1/csm2xcat.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/csm2xcat.1.rst
@@ -19,7 +19,7 @@ SYNOPSIS
 ********
 
 
-\ **csm2xcat**\  [\ **--dir**\  \ *path*\ ]
+\ **csm2xcat**\  [\ **-**\ **-dir**\  \ *path*\ ]
 
 \ **csm2xcat**\  [\ **-h**\ ]
 
@@ -31,7 +31,7 @@ DESCRIPTION
 
 The csm2xcat command must be run on the Management Server of the CSM system that you want to migrate to xCAT.  The commmand will build  two xCAT stanza files that can update the xCAT database with the chdef command.
 
-Copy the csm2xcat command to the CSM Management Server.  Run the command, indicating where you want your stanza files saved with the --dir parameter.  Check the stanza files to see if the information is what you want put in the xCAT database. Copy the two stanza files: node.stanza, device.stanza back to your xCAT Management node, and run the chdef command to input into the xCAT database.
+Copy the csm2xcat command to the CSM Management Server.  Run the command, indicating where you want your stanza files saved with the \ **-**\ **-dir**\  parameter.  Check the stanza files to see if the information is what you want put in the xCAT database. Copy the two stanza files: node.stanza, device.stanza back to your xCAT Management node, and run the chdef command to input into the xCAT database.
 
 
 *******
@@ -41,7 +41,7 @@ OPTIONS
 
 \ **-h**\           Display usage message.
 
-\ **--dir**\           Path to the directory containing the stanza files.
+\ **-**\ **-dir**\           Path to the directory containing the stanza files.
 
 
 ************
@@ -61,13 +61,21 @@ EXAMPLES
 
 1. To build xCAT stanza files, enter on the CSM Management Server:
 
-\ **csm2xcat --dir  /tmp/mydir**\ 
+
+.. code-block:: perl
+
+  csm2xcat --dir /tmp/mydir
+
 
 2. To put the data in the xCAT database on the xCAT Management Node:
 
-\ **cat node.stanza | chdef -z**\ 
 
-\ **cat device.stanza | chdef -z**\ 
+.. code-block:: perl
+
+  cat node.stanza | chdef -z
+ 
+  cat device.stanza | chdef -z
+
 
 
 *****

--- a/docs/source/guides/admin-guides/references/man1/db2sqlsetup.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/db2sqlsetup.1.rst
@@ -19,17 +19,17 @@ SYNOPSIS
 ********
 
 
-\ **db2sqlsetup**\  {\ **-h**\ |\ **--help**\ }
+\ **db2sqlsetup**\  [\ **-h | -**\ **-help**\ }
 
-\ **db2sqlsetup**\  {\ **-v**\ |\ **--version**\ }
+\ **db2sqlsetup**\  [\ **-v | -**\ **-version**\ }
 
-\ **db2sqlsetup**\  {\ **-i**\ |\ **--init**\ }{<-S> | <-C>} [-o|--setupODBC]  [\ **-V**\ |\ **--verbose**\ ]
+\ **db2sqlsetup**\  [\ **-i | -**\ **-init**\ ] {\ **-S**\  | \ **-C**\ } [\ **-o | -**\ **-setupODBC**\ ] [\ **-V | -**\ **-verbose**\ ]
 
-\ **db2sqlsetup**\  {\ **-i**\ |\ **--init**\ }{<-S>} [-N|--nostart]  [-o|--setupODBC]  [\ **-V**\ |\ **--verbose**\ ]
+\ **db2sqlsetup**\  [\ **-i | -**\ **-init**\ ] {\ **-S**\ } [\ **-N | -**\ **-nostart**\ ] [\ **-o | -**\ **-setupODBC**\ ] [\ **-V | -**\ **-verbose**\ ]
 
-\ **db2sqlsetup**\  {\ **-o**\ |\ **--setupODBC**\ } {<-S> | <-C>} [-V|--verbose]
+\ **db2sqlsetup**\  [\ **-o | -**\ **-setupODBC**\ ] {\ **-S**\  | \ **-C**\ } [\ **-V | -**\ **-verbose**\ ]
 
-\ **db2sqlsetup**\  {\ **-p**\ |\ **--passwd**\ } [<-S> | <-C>]
+\ **db2sqlsetup**\  [\ **-p | -**\ **-passwd**\ ] [\ **-S**\  | \ **-C**\ ]
 
 
 ***********
@@ -61,31 +61,31 @@ OPTIONS
 
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Displays the usage message.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Displays the release version of the code.
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Displays verbose messages.
  
 
 
-\ **-i|--init**\ 
+\ **-i|-**\ **-init**\ 
  
  The init option is used to setup an installed DB2 database on AIX or Linux (p-Series) so that xCAT can use the database. This must be combined with either the -S or -C flag to indicate whether we are setting up the Server or the Client. With the -S flag, it involves creating the xcatdb database, the xcatdb instance id, allowing access to the xcatdb database by the Management Node. It also backs up the current xCAT database and restores it into the newly setup xcatdb DB2 database.  It creates the /etc/xcat/cfgloc file to point the xcatd daemon to the DB2 database and restarts the xcatd daemon using the database.
  
 
 
-\ **-p|--passwd**\ 
+\ **-p|-**\ **-passwd**\ 
  
  The password change option is to change the database access password for the DB2 xcatdb database. If -S is input then it will only change the password on the DB2 Server (MN).  If -C is input it will only change on the DB2 clients (SN).  If neither -S or -C are input with this flag, then it will change both the DB2 Server and Clients. When changing the password the xcatd daemon will be stopped and restarted.  Any other tools accessing the database should also be stopped before changing and restarted after changing.
  
@@ -97,13 +97,13 @@ OPTIONS
  
 
 
-\ **-N|--nostart**\ 
+\ **-N|-**\ **-nostart**\ 
  
  This option with the -S flag will create the database, but will not backup and restore xCAT tables into the database. It will create the cfgloc file such that the next start of xcatd will try and contact the database.  This can be used to setup the xCAT DB2 database during or before install.
  
 
 
-\ **-o|--setupODBC**\ 
+\ **-o|-**\ **-setupODBC**\ 
  
  This option sets up the ODBC  /etc/../odbcinst.ini, /etc/../odbc.ini and the .odbc.ini file in roots home directory will be created and initialized to run off the xcatdb DB2 database.
  
@@ -116,22 +116,16 @@ ENVIRONMENT VARIABLES
 
 
 
-\*
- 
- XCATDB2INSPATH  overrides the default install path for DB2 which is /opt/ibm/db2/V9.7 for Linux and /opt/IBM/db2/V9.7 for AIX.
- 
+\* XCATDB2INSPATH  overrides the default install path for DB2 which is /opt/ibm/db2/V9.7 for Linux and /opt/IBM/db2/V9.7 for AIX.
 
 
-\*
- 
- DATABASELOC override the where to create the xcat DB2 database, which is /var/lib/db2 by default of taken from the site.databaseloc  attribute.
- 
+
+\* DATABASELOC override the where to create the xcat DB2 database, which is /var/lib/db2 by default of taken from the site.databaseloc  attribute.
 
 
-\*
- 
- XCATDB2PW can be set to the password for the xcatdb DB2 instance id so that there will be no prompting for a password when the script is run.
- 
+
+\* XCATDB2PW can be set to the password for the xcatdb DB2 instance id so that there will be no prompting for a password when the script is run.
+
 
 
 
@@ -141,51 +135,65 @@ EXAMPLES
 
 
 
-\*
+1. To setup DB2 Server for  xCAT to run on the DB2 xcatdb database, on the MN:
  
- To setup DB2 Server for  xCAT to run on the DB2 xcatdb database, on the MN:
  
- \ **db2sqlsetup**\  \ *-i*\  \ *-S*\ 
+ .. code-block:: perl
  
-
-
-\*
+   db2sqlsetup -i -S
  
- To setup DB2 Client for  xCAT to run on the DB2 xcatdb database, on the SN:
- 
- \ **db2sqlsetup**\  \ *-i*\  \ *-C*\ 
  
 
 
-\*
+2. To setup DB2 Client for  xCAT to run on the DB2 xcatdb database, on the SN:
  
- To setup the ODBC for  DB2 xcatdb database access, on the MN :
  
- \ **db2sqlsetup**\  \ *-o*\  \ *-S*\ 
+ .. code-block:: perl
  
-
-
-\*
+   db2sqlsetup -i -C
  
- To setup the ODBC for  DB2 xcatdb database access, on the SN :
- 
- \ **db2sqlsetup**\  \ *-o*\  \ *-C*\ 
  
 
 
-\*
+3. To setup the ODBC for  DB2 xcatdb database access, on the MN :
+ 
+ 
+ .. code-block:: perl
+ 
+   db2sqlsetup -o -S
+ 
+ 
+
+
+4. To setup the ODBC for  DB2 xcatdb database access, on the SN :
+ 
+ 
+ .. code-block:: perl
+ 
+   db2sqlsetup -o -C
+ 
+ 
+
+
+5.
  
  To setup the DB2 database but not start xcat running with it:
  
- \ **db2sqlsetup**\  \ *-i*\  \ *-S*\  \ *-N*\ 
+ 
+ .. code-block:: perl
+ 
+   db2sqlsetup -i -S -N
+ 
  
 
 
-\*
+6. To change the DB2 xcatdb password on both the Management and Service Nodes:
  
- To change the DB2 xcatdb password on both the Management and Service Nodes:
  
- \ **db2sqlsetup**\  \ *-p*\ 
+ .. code-block:: perl
+ 
+   db2sqlsetup -p
+ 
  
 
 

--- a/docs/source/guides/admin-guides/references/man1/dumpxCATdb.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/dumpxCATdb.1.rst
@@ -19,11 +19,11 @@ SYNOPSIS
 ********
 
 
-\ **dumpxCATdb**\  [\ **-a**\ ] [\ **-V**\ ] [{\ **-p**\ |\ **--path**\ } \ *path*\ ]
+\ **dumpxCATdb**\  [\ **-a**\ ] [\ **-V**\ ] [{\ **-p | -**\ **-path**\ } \ *path*\ ]
 
-\ **dumpxCATdb**\  [\ **-b**\ ] [\ **-V**\ ] [{\ **-p**\ |\ **--path**\ } \ *path*\ ]
+\ **dumpxCATdb**\  [\ **-b**\ ] [\ **-V**\ ] [{\ **-p | -**\ **-path**\ } \ *path*\ ]
 
-\ **dumpxCATdb**\  [\ **-h**\ |\ **--help**\ ] [\ **-v**\ |\ **--version**\ ]
+\ **dumpxCATdb**\  [\ **-h | -**\ **-help**\ ] [\ **-v | -**\ **-version**\ ]
 
 
 ***********
@@ -73,27 +73,47 @@ EXAMPLES
 
 1. To dump the xCAT database into the /tmp/db directory, enter:
 
-\ **dumpxCATdb -p /tmp/db**\ 
+
+.. code-block:: perl
+
+  dumpxCATdb -p /tmp/db
+
 
 2. To dump the xCAT database into the /tmp/db directory, including the auditlog and eventlog enter:
 
-\ **dumpxCATdb -a -p /tmp/db**\ 
+
+.. code-block:: perl
+
+  dumpxCATdb -a -p /tmp/db
+
 
 3. To have dumpxCATdb not backup the hosts or passwd table:
 
-\ **chtab key=skiptables site.value="hosts,passwd"**\ 
 
-\ **dumpxCATdb  -p /tmp/db**\ 
+.. code-block:: perl
+
+  chtab key=skiptables site.value="hosts,passwd"
+ 
+  dumpxCATdb  -p /tmp/db
+
 
 4. To have dumpxCATdb not backup the hosts or passwd table:
 
-\ **export XCAT_SKIPTABLES="hosts,passwd"**\ 
 
-\ **dumpxCATdb  -p /tmp/db**\ 
+.. code-block:: perl
+
+  export XCAT_SKIPTABLES="hosts,passwd"
+ 
+  dumpxCATdb  -p /tmp/db
+
 
 5. To have dumpxCATdb use DB2 utilities to backup the DB2 database:
 
-\ **dumpxCATdb -b -p /install/db2backup**\ 
+
+.. code-block:: perl
+
+  dumpxCATdb -b -p /install/db2backup
+
 
 
 *****

--- a/docs/source/guides/admin-guides/references/man1/genimage.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/genimage.1.rst
@@ -21,9 +21,9 @@ SYNOPSIS
 
 \ **genimage**\ 
 
-\ **genimage**\  [\ **-o**\  \ *osver*\ ] [\ **-a**\  \ *arch*\ ] [\ **-p**\  \ *profile*\ ] [\ **-i**\  \ *nodebootif*\ ] [\ **-n**\  \ *nodenetdrivers*\ ] [\ **--onlyinitrd**\ ] [\ **-r**\  \ *otherifaces*\ ] [\ **-k**\  \ *kernelver*\ ] [\ **-g**\  \ *krpmver*\ ] [\ **-m**\  \ *statelite*\ ] [\ **-l**\  \ *rootlimitsize*\ ] [\ **--permission**\  \ *permission*\ ] [\ **--interactive**\ ] [\ **--dryrun**\ ] [\ **--ignorekernelchk**\ ] [\ **--noupdate**\ ] \ *imagename*\ 
+\ **genimage**\  [\ **-o**\  \ *osver*\ ] [\ **-a**\  \ *arch*\ ] [\ **-p**\  \ *profile*\ ] [\ **-i**\  \ *nodebootif*\ ] [\ **-n**\  \ *nodenetdrivers*\ ] [\ **-**\ **-onlyinitrd**\ ] [\ **-r**\  \ *otherifaces*\ ] [\ **-k**\  \ *kernelver*\ ] [\ **-g**\  \ *krpmver*\ ] [\ **-m**\  \ *statelite*\ ] [\ **-l**\  \ *rootlimitsize*\ ] [\ **-**\ **-permission**\  \ *permission*\ ] [\ **-**\ **-interactive**\ ] [\ **-**\ **-dryrun**\ ] [\ **-**\ **-ignorekernelchk**\ ] [\ **-**\ **-noupdate**\ ] \ *imagename*\ 
 
-\ **genimage**\  [\ **-h**\  | \ **--help**\  | \ **-v**\  | \ **--version**\ ]
+\ **genimage**\  [\ **-h**\  | \ **-**\ **-help**\  | \ **-v**\  | \ **-**\ **-version**\ ]
 
 
 ***********
@@ -46,9 +46,9 @@ for stateless: \ **packimage**\
 
 for statelite: \ **liteimg**\ 
 
-Besides prompting for some paramter values, the \ **genimage**\  command takes default guesses for the parameters not specified or not defined in the \ *osimage*\  and \ *linuximage*\  tables. It also assumes default answers for questions from the yum/zypper command when installing rpms into the image. Please use --interactive flag if you want the yum/zypper command to prompt you for the answers.
+Besides prompting for some paramter values, the \ **genimage**\  command takes default guesses for the parameters not specified or not defined in the \ *osimage*\  and \ *linuximage*\  tables. It also assumes default answers for questions from the yum/zypper command when installing rpms into the image. Please use \ **-**\ **-interactive**\  flag if you want the yum/zypper command to prompt you for the answers.
 
-If \ **--onlyinitrd**\  is specified, genimage only regenerates the initrd for a stateless image to be used for a diskless install.
+If \ **-**\ **-onlyinitrd**\  is specified, genimage only regenerates the initrd for a stateless image to be used for a diskless install.
 
 The \ **genimage**\  command must be run on a system that is the same architecture and same distro with same major release version as the nodes it will be
 used on.  If the management node is not the same architecture or same distro level, copy the contents of
@@ -117,18 +117,18 @@ OPTIONS
  
 
 
-\ **--onlyinitrd**\ 
+\ **-**\ **-onlyinitrd**\ 
  
  Regenerates the initrd for a stateless image to be used for a diskless install.
  
  Regenerates the initrd that is part of a stateless/statelite image that is used to boot xCAT nodes in a stateless/stateli
  te mode.
  
- The \ **genimage --onlyinitrd**\  command will generate two initial ramdisks, one is \ **initrd-statelite.gz**\  for \ **statelite**\  mode, the other one is \ **initrd-stateless.gz**\  for \ **stateless**\  mode.
+ The \ **genimage -**\ **-onlyinitrd**\  command will generate two initial ramdisks, one is \ **initrd-statelite.gz**\  for \ **statelite**\  mode, the other one is \ **initrd-stateless.gz**\  for \ **stateless**\  mode.
  
 
 
-\ **--permission**\  \ *permission*\ 
+\ **-**\ **-permission**\  \ *permission*\ 
  
  The mount permission of \ **/.statelite**\  directory for \ **statelite**\  mode, which is only used for \ **statelite**\  mode, and the default permission is 755.
  
@@ -159,13 +159,13 @@ OPTIONS
  
 
 
-\ **--interactive**\ 
+\ **-**\ **-interactive**\ 
  
  This flag allows the user to answer questions from yum/zypper command when installing rpms into the image. If it is not specified, '-y' will be passed to the yum command and '--non-interactive --no-gpg-checks' will be passed to the zypper command as default answers.
  
 
 
-\ **--dryrun**\ 
+\ **-**\ **-dryrun**\ 
  
  This flag shows the underlying call to the os specific genimage function. The user can copy and the paste the output to run the command on another machine that does not have xCAT installed.
  
@@ -177,25 +177,25 @@ OPTIONS
  
 
 
-\ **--ignorekernelchk**\ 
+\ **-**\ **-ignorekernelchk**\ 
  
  Skip the kernel version checking when injecting drivers from osimage.driverupdatesrc. That means all drivers from osimage.driverupdatesrc will be injected to initrd for the specific target kernel.
  
 
 
-\ **--noupdate**\ 
+\ **-**\ **-noupdate**\ 
  
  This flag allows the user to bypass automatic package updating when installing other packages.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Display version.
  
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  

--- a/docs/source/guides/admin-guides/references/man1/geninitrd.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/geninitrd.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **geninitrd**\  \ *imagename*\  [\ **--ignorekernelchk**\ ]
+\ **geninitrd**\  \ *imagename*\  [\ **-**\ **-ignorekernelchk**\ ]
 
-\ **geninitrd**\  [\ **-h**\  | \ **--help**\ ]
+\ **geninitrd**\  [\ **-h**\  | \ **-**\ **-help**\ ]
 
 
 ***********
@@ -82,7 +82,7 @@ Parameters
 \ *imagename*\  specifies the name of an os image definition to be used. The specification for the image is storted in the \ *osimage*\  table and \ *linuximage*\  table.
 
 
-\ **--ignorekernelchk**\ 
+\ **-**\ **-ignorekernelchk**\ 
  
  Skip the kernel version checking when injecting drivers from osimage.driverupdatesrc. That means all drivers from osimage.driverupdatesrc will be injected to initrd for the specific target kernel.
  

--- a/docs/source/guides/admin-guides/references/man1/getadapter.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/getadapter.1.rst
@@ -21,7 +21,7 @@ SYNOPSIS
 
 \ **getadapter**\  \ *noderange*\  [\ **-f**\ ]
 
-\ **getadapter**\  [\ **-h**\ |\ **--help**\ |\ **-v**\ |\ **--version**\ |\ **-V**\ ]
+\ **getadapter**\  [\ **-h | -**\ **-help | -v | -**\ **-version | -V**\ ]
 
 
 ***********
@@ -89,14 +89,18 @@ EXAMPLES
 
 Output is similar to:
 
--->Starting scan for: node1,node2
-The whole scan result:
---------------------------------------
-[node1]: Adapter information exists, no need to scan.
---------------------------------------
-[node2] scan successfully, below are the latest data
-node2:[1]->eno1!mac=34:40:b5:be:6a:80|pci=/pci0000:00/0000:00:01.0/0000:0c:00.0|candidatename=eno1/enp12s0f0/enx3440b5be6a80
-node2:[2]->enp0s29u1u1u5!mac=36:40:b5:bf:44:33|pci=/pci0000:00/0000:00:1d.0/usb2/2-1/2-1.1/2-1.1.5/2-1.1.5:1.0|candidatename=enp0s29u1u1u5/enx3640b5bf4433
+
+.. code-block:: perl
+
+  -->Starting scan for: node1,node2
+  The whole scan result:
+  --------------------------------------
+  [node1]: Adapter information exists, no need to scan.
+  --------------------------------------
+  [node2] scan successfully, below are the latest data
+  node2:[1]->eno1!mac=34:40:b5:be:6a:80|pci=/pci0000:00/0000:00:01.0/0000:0c:00.0|candidatename=eno1/enp12s0f0/enx3440b5be6a80
+  node2:[2]->enp0s29u1u1u5!mac=36:40:b5:bf:44:33|pci=/pci0000:00/0000:00:1d.0/usb2/2-1/2-1.1/2-1.1.5/2-1.1.5:1.0|candidatename=enp0s29u1u1u5/enx3640b5bf4433
+
 
 Every node gets a separate section to display its all network adapters information, every network adapter owns single line which start as node name and followed by index and other information.
 

--- a/docs/source/guides/admin-guides/references/man1/getmacs.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/getmacs.1.rst
@@ -23,7 +23,7 @@ Common:
 =======
 
 
-\ **getmacs**\  [\ **-h**\ | \ **--help**\  | \ **-v**\ | \ **--version**\ ]
+\ **getmacs**\  [\ **-h**\ | \ **-**\ **-help**\  | \ **-v**\ | \ **-**\ **-version**\ ]
 
 
 PPC specific:
@@ -34,14 +34,14 @@ PPC specific:
 
 \ **getmacs**\  \ *noderange*\  [\ **-M**\ ]
 
-\ **getmacs**\  \ *noderange*\  [\ **-V**\ | \ **--verbose**\ ] [\ **-f**\ ] [\ **-d**\ ] [\ **--arp**\ ] | [\ **-D**\  {[\ **-S**\  \ *server*\ ] [\ **-G**\  \ *gateway*\ ] [\ **-C**\  \ *client*\ ] [\ **-o**\ ] | [\ **--noping**\ ]}]
+\ **getmacs**\  \ *noderange*\  [\ **-V**\ | \ **-**\ **-verbose**\ ] [\ **-f**\ ] [\ **-d**\ ] [\ **-**\ **-arp**\ ] | [\ **-D**\  {[\ **-S**\  \ *server*\ ] [\ **-G**\  \ *gateway*\ ] [\ **-C**\  \ *client*\ ] [\ **-o**\ ] | [\ **-**\ **-noping**\ ]}]
 
 
 blade specific:
 ===============
 
 
-\ **getmacs**\  \ *noderange*\  [\ **-V**\ | \ **--verbose**\ ] [\ **-d**\ ] [\ **--arp**\ ] [\ **-i**\  \ *ethN*\ |\ *enN*\ ]
+\ **getmacs**\  \ *noderange*\  [\ **-V**\ | \ **-**\ **-verbose**\ ] [\ **-d**\ ] [\ **-**\ **-arp**\ ] [\ **-i**\  \ *ethN*\ |\ *enN*\ ]
 
 
 
@@ -72,7 +72,7 @@ OPTIONS
 *******
 
 
-\ **--arp**\ 
+\ **-**\ **-arp**\ 
 
 Read MAC address with ARP protocal.
 
@@ -108,7 +108,7 @@ Display usage message.
 
 Return multiple MAC addresses for the same adapter or port, if available from the hardware.  For some network adapters (e.g. HFI) the MAC can change when there are some recoverable internal errors.  In this case, the hardware can return several MACs that the adapter can potentially have, so that xCAT can put all of them in DHCP.  This allows successful booting, even after a MAC change, but on Linux at this time, it can also cause duplicate IP addresses, so it is currently not recommended on Linux.  By default (without this flag), only a single MAC address is returned for each adapter.
 
-\ **--noping**\ 
+\ **-**\ **-noping**\ 
 
 Only can be used with '-D' to display all the available adapters with mac address but do NOT run ping test.
 
@@ -138,13 +138,9 @@ RETURN VALUE
 ************
 
 
+0 The command completed successfully.
 
-.. code-block:: perl
-
-   0 The command completed successfully.
- 
-   1 An error has occurred.
-
+1 An error has occurred.
 
 
 ********

--- a/docs/source/guides/admin-guides/references/man1/getslnodes.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/getslnodes.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **getslnodes**\  [\ **-v**\ |\ **--verbose**\ ] [\ *hostname-match*\ ]
+\ **getslnodes**\  [\ **-v | -**\ **-verbose**\ ] [\ *hostname-match*\ ]
 
-\ **getslnodes**\  [\ **-?**\  | \ **-h**\  | \ **--help**\ ]
+\ **getslnodes**\  [\ **-?**\  | \ **-h**\  | \ **-**\ **-help**\ ]
 
 
 ***********
@@ -65,13 +65,13 @@ OPTIONS
 
 
 
-\ **-?|-h|--help**\ 
+\ **-?|-h|-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command Version.
  

--- a/docs/source/guides/admin-guides/references/man1/gettab.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/gettab.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **gettab**\  [\ **-H**\  | \ **--with-fieldname**\ ] \ *key=value,...  table.attribute ...*\ 
+\ **gettab**\  [\ **-H**\  | \ **-**\ **-with-fieldname**\ ] \ *key=value,...  table.attribute ...*\ 
 
-\ **gettab**\  [\ **-?**\  | \ **-h**\  | \ **--help**\ ]
+\ **gettab**\  [\ **-?**\  | \ **-h**\  | \ **-**\ **-help**\ ]
 
 
 ***********
@@ -41,14 +41,14 @@ OPTIONS
 
 
 
-\ **-H|--with-fieldname**\ 
+\ **-H|-**\ **-with-fieldname**\ 
  
  Always display table.attribute name next to result.  By default, this is done only if more than
  one table.attribute is requested.
  
 
 
-\ **-?|-h|--help**\ 
+\ **-?|-h|-**\ **-help**\ 
  
  Display usage message.
  
@@ -61,16 +61,12 @@ RETURN VALUE
 
 
 
-0
- 
- The command completed successfully.
- 
+0 The command completed successfully.
 
 
-1
- 
- An error has occurred.
- 
+
+1 An error has occurred.
+
 
 
 
@@ -80,34 +76,38 @@ EXAMPLES
 
 
 
-\*
+1. To display setting for \ **master**\  (management node) in the site table:
  
- To display setting for \ **master**\  (management node) in the site table:
  
- \ **gettab -H**\  \ *key=master site.value*\ 
+ .. code-block:: perl
+ 
+   gettab -H key=master site.value
+ 
  
  The output would be similar to:
  
  
  .. code-block:: perl
  
-       site.value: mgmtnode.cluster.com
+   site.value: mgmtnode.cluster.com
  
  
 
 
-\*
+2. To display the first node or group name that has \ **mgt**\  set to \ **blade**\  in the nodehm table:
  
- To display the first node or group name that has \ **mgt**\  set to \ **blade**\  in the nodehm table:
  
- \ **gettab**\  \ *mgt=blade nodehm.node*\ 
+ .. code-block:: perl
+ 
+   gettab mgt=blade nodehm.node
+ 
  
  The output would be similar to:
  
  
  .. code-block:: perl
  
-       blades
+   blades
  
  
 

--- a/docs/source/guides/admin-guides/references/man1/groupfiles4dsh.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/groupfiles4dsh.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **groupfiles4dsh**\  [{\ **-p**\ |\ **--path**\ } \ *path*\ ]
+\ **groupfiles4dsh**\  [{\ **-p | -**\ **-path**\ } \ *path*\ ]
 
-\ **groupfiles4dsh**\  [\ **-h**\ |\ **--help**\ ] [\ **-v**\ |\ **--version**\ ]
+\ **groupfiles4dsh**\  [\ **-h | -**\ **-help**\ ] [\ **-v | -**\ **-version**\ ]
 
 
 ***********
@@ -68,7 +68,11 @@ EXAMPLES
 
 1. To create the nodegroup files in directory /tmp/nodegroupfiles, enter:
 
-\ **groupfiles4dsh -p /tmp/nodegroupfiles**\ 
+
+.. code-block:: perl
+
+  groupfiles4dsh -p /tmp/nodegroupfiles
+
 
 To use with dsh:
 

--- a/docs/source/guides/admin-guides/references/man1/imgcapture.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/imgcapture.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **imgcapture**\  node \ **-t**\ |\ **--type**\  {diskless|sysclone} \ **-o**\ |\ **--osimage**\  \ *osimage*\  [\ **-V**\ |\ **--verbose**\ ]
+\ **imgcapture**\  \ *node*\  \ **-t | -**\ **-type**\  {\ **diskless | sysclone**\ } \ **-o | -**\ **-osimage**\  \ *osimage*\  [\ **-V | -**\ **-verbose**\ ]
 
-\ **imgcapture**\  [\ **-h**\  | \ **--help**\ ] | [\ **-v**\  | \ **--version**\ ]
+\ **imgcapture**\  [\ **-h**\  | \ **-**\ **-help**\ ] | [\ **-v**\  | \ **-**\ **-version**\ ]
 
 
 ***********
@@ -37,7 +37,7 @@ The \ **imgcapture**\  command supports two image types: \ **diskless**\  and \ 
 
 The \ **diskless**\  type:
 
-The attributes of osimage will be used to capture and prepare the root image. The \ **osver**\ , \ **arch**\  and \ **profile**\  attributes for the stateless/statelite image to be created are duplicated from the \ **node**\ 's attribute. If the \ **-p|--profile**\  \ *profile*\  option is specified, the image will be created under "/<\ *installroot*\ >/netboot/<osver>/<arch>/<\ *profile*\ >/rootimg".
+The attributes of osimage will be used to capture and prepare the root image. The \ **osver**\ , \ **arch**\  and \ **profile**\  attributes for the stateless/statelite image to be created are duplicated from the \ **node**\ 's attribute. If the \ **-p|-**\ **-profile**\  \ *profile*\  option is specified, the image will be created under "/<\ *installroot*\ >/netboot/<osver>/<arch>/<\ *profile*\ >/rootimg".
 
 The default files/directories excluded in the image are specified by /opt/xcat/share/xcat/netboot/<os>/<\ *profile*\ >.<osver>.<arch>.imgcapture.exlist; also, you can put your customized file (<\ *profile*\ >.<osver>.<arch>.imgcapture.exlist) to /install/custom/netboot/<osplatform>. The directories in the default \ *.imgcapture.exlist*\  file are necessary to capture image from the diskful Linux node managed by xCAT, please don't remove it.
 
@@ -58,19 +58,19 @@ OPTIONS
 
 
 
-\ **-t**\ |\ **--type**\ 
+\ **-t | -**\ **-type**\ 
  
  Specify the osimage type you want to capture, two types are supported: diskless and sysclone.
  
 
 
-\ **-p|--profile**\  \ *profile*\ 
+\ **-p|-**\ **-profile**\  \ *profile*\ 
  
  Assign \ *profile*\  as the profile of the image to be created.
  
 
 
-\ **-o|--osimage**\  \ *osimage*\ 
+\ **-o|-**\ **-osimage**\  \ *osimage*\ 
  
  The osimage name.
  
@@ -118,19 +118,19 @@ OPTIONS
  
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display the usage message.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Display the version.
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Verbose output.
  
@@ -156,11 +156,19 @@ EXAMPLES
 
 1. There's one pre-defined \ *osimage*\ . In order to capture and prepare the diskless root image for \ *osimage*\ , run the command:
 
-imgcapture node1 -t diskless -o osimage
+
+.. code-block:: perl
+
+  imgcapture node1 -t diskless -o osimage
+
 
 2. In order to capture the diskful image from \ **node1**\  and create the \ *osimage*\  \ **img1**\ , run the command:
 
-imgcapture node1 -t sysclone -o img1
+
+.. code-block:: perl
+
+  imgcapture node1 -t sysclone -o img1
+
 
 
 *****

--- a/docs/source/guides/admin-guides/references/man1/imgexport.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/imgexport.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **imgexport [-h| --help]**\ 
+\ **imgexport [-h| -**\ **-help]**\ 
 
-\ **imgexport image_name [destination] [[-e|--extra file:dir] ... ] [-p|--postscripts node_name] [-v|--verbose]**\ 
+\ **imgexport**\  \ *image_name*\  [\ *destination*\ ] [[\ **-e | -**\ **-extra**\  \ *file:dir*\ ] ... ] [\ **-p | -**\ **-postscripts**\  \ *node_name*\ ] [\ **-v | -**\ **-verbose**\ ]
 
 
 ***********
@@ -71,13 +71,13 @@ OPTIONS
 *******
 
 
-\ **-e|--extra**\  \ *srcfile:destdir*\     Pack up extra files. If \ *destdir*\  is omitted, the destination directory will be the same as the source directory.
+\ **-e|-**\ **-extra**\  \ *srcfile:destdir*\     Pack up extra files. If \ *destdir*\  is omitted, the destination directory will be the same as the source directory.
 
-\ **-h|--help**\                          Display usage message.
+\ **-h|-**\ **-help**\                          Display usage message.
 
-\ **-p|--postscripts**\  \ *node_name*\   Get the names of the postscripts and postbootscripts for the given node and pack them into the image.
+\ **-p|-**\ **-postscripts**\  \ *node_name*\   Get the names of the postscripts and postbootscripts for the given node and pack them into the image.
 
-\ **-v|--verbose**\                       Verbose output.
+\ **-v|-**\ **-verbose**\                       Verbose output.
 
 \ *image_name*\                         The name of the image. Use \ *lsdef -t*\  osimage to find out all the image names.
 
@@ -101,19 +101,31 @@ EXAMPLES
 
 1. Simplest way to export an image.  If there is an image in the osimage table named 'foo', then run:
 
-\ **imgexport foo**\ 
+
+.. code-block:: perl
+
+  imgexport foo
+
 
 foo.tgz will be built in the current working directory.  Make sure that you have enough space in the directory that you are in to run imgexport if you have a big image to tar up.
 
 2. To include extra files with your image:
 
-\ **imgexport Default_Stateless_1265981465 foo.tgz -e /install/postscripts/myscript1  -e /tmp/mydir:/usr/mydir**\ 
+
+.. code-block:: perl
+
+  imgexport Default_Stateless_1265981465 foo.tgz -e /install/postscripts/myscript1 -e /tmp/mydir:/usr/mydir
+
 
 In addition to all the default files, this will export \ */install/postscripts/myscript1*\  and the whole directory \ */tmp/dir*\  into the file called foo.tgz.  And when imgimport is called  \ */install/postscripts/myscript1*\  will be copied into the same directory and \ */tmp/mydir*\  will be copied to \ */usr/mydir*\ .
 
 3. To include postscript with your image:
 
-\ **imgexport Default_Stateless_1265981465 foo.tgz -p node1 -e /install/postscripts/myscript1**\ 
+
+.. code-block:: perl
+
+  imgexport Default_Stateless_1265981465 foo.tgz -p node1 -e /install/postscripts/myscript1
+
 
 The \ *postscripts*\  and the \ *postbootscripts*\  names specified in the \ *postscripts*\  table for node1 will be exported into the image. The postscript \ *myscript1*\  will also be exported.
 

--- a/docs/source/guides/admin-guides/references/man1/imgimport.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/imgimport.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **imgimport [-h|--help]**\ 
+\ **imgimport [-h|-**\ **-help]**\ 
 
-\ **imgimport**\  bundle_file_name [-p|--postscripts nodelist] [-f|--profile new_profile] [-v|--verbose]>
+\ **imgimport**\  \ *bundle_file_name*\  [\ **-p | -**\ **-postscripts**\  \ *nodelist*\ ] [\ **-f | -**\ **-profile**\  \ *new_profile*\ ] [\ **-v | -**\ **-verbose**\ ]
 
 
 ***********
@@ -90,13 +90,13 @@ OPTIONS
 *******
 
 
-\ **-f|--profile**\  \ *new_prof*\       Import the image with a new profile name.
+\ **-f|-**\ **-profile**\  \ *new_prof*\       Import the image with a new profile name.
 
-\ **-h|--help**\                      Display usage message.
+\ **-h|-**\ **-help**\                      Display usage message.
 
-\ **-p|--postscripts**\  \ *nodelist*\   Import the postscripts. The postscripts contained in the image will be set in the postscripts table for \ *nodelist*\ .
+\ **-p|-**\ **-postscripts**\  \ *nodelist*\   Import the postscripts. The postscripts contained in the image will be set in the postscripts table for \ *nodelist*\ .
 
-\ **-v|--verbose**\                   Verbose output.
+\ **-v|-**\ **-verbose**\                   Verbose output.
 
 
 ************
@@ -114,19 +114,31 @@ EXAMPLES
 ********
 
 
-1. Simplest way to import an image.  If there is a bundle file named 'foo.gz', then run:
+1. Simplest way to import an image. If there is a bundle file named 'foo.gz', then run:
 
-\ *imgimport foo.gz*\ 
+
+.. code-block:: perl
+
+  imgimport foo.gz
+
 
 2. Import the image with postscript names.
 
-\ *imgimport foo.gz -p node1,node2*\ 
+
+.. code-block:: perl
+
+  imgimport foo.gz -p node1,node2
+
 
 The \ *postscripts*\  table will be updated with the name of the \ *postscripts*\  and the \ *postbootscripts*\  for node1 and node2.
 
 3. Import the image with a new profile name
 
-\ *imgimport foo.gz -f compute_test*\ 
+
+.. code-block:: perl
+
+  imgimport foo.gz -f compute_test
+
 
 
 *****

--- a/docs/source/guides/admin-guides/references/man1/liteimg.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/liteimg.1.rst
@@ -19,11 +19,11 @@ SYNOPSIS
 ********
 
 
-\ *liteimg [-h| --help]*\ 
+\ **liteimg [-h| -**\ **-help]**\ 
 
-\ *liteimg  [-v| --version]*\ 
+\ **liteimg  [-v| -**\ **-version]**\ 
 
-\ *liteimg imagename*\ 
+\ **liteimg**\  \ *imagename*\ 
 
 
 ***********
@@ -59,7 +59,7 @@ Note: If you make any changes to your litefile table after running liteimg then 
 
 
 **********
-Parameters
+PARAMETERS
 **********
 
 
@@ -71,9 +71,9 @@ OPTIONS
 *******
 
 
-\ **-h**\           Display usage message.
+\ **-h|-**\ **-help**\           Display usage message.
 
-\ **-v**\           Command Version.
+\ **-v|-**\ **-version**\           Command Version.
 
 
 ************
@@ -93,7 +93,11 @@ EXAMPLES
 
 1. To lite a RHEL 6.6 statelite image for a compute node architecture x86_64 enter:
 
-\ *liteimg rhels6.6-x86_64-statelite-compute*\ 
+
+.. code-block:: perl
+
+  liteimg rhels6.6-x86_64-statelite-compute
+
 
 
 *****
@@ -101,7 +105,7 @@ FILES
 *****
 
 
-/opt/xcat/bin/
+/opt/xcat/bin/liteimg
 
 
 *****

--- a/docs/source/guides/admin-guides/references/man1/lsdef.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/lsdef.1.rst
@@ -19,11 +19,11 @@ SYNOPSIS
 ********
 
 
-\ **lsdef**\  [\ **-h**\ |\ **--help**\ ] [\ **-t**\  \ *object-types*\ ] [\ **-i**\  \ *attr-list*\ ]
+\ **lsdef**\  [\ **-h | -**\ **-help**\ ] [\ **-t**\  \ *object-types*\ ] [\ **-i**\  \ *attr-list*\ ]
 
-\ **lsdef**\  [\ **-V**\ |\ **--verbose**\ ] [\ **-l**\ |\ **--long**\ ] [\ **-s**\ |\ **--short**\ ] [\ **-a**\ |\ **--all**\ ] [\ **-S**\ ] 
-[\ **-t**\  \ *object-types*\ ] [\ **-o**\  \ *object-names*\ ] [\ **-z**\ |\ **--stanza**\ ] [\ **-i**\  \ *attr-list*\ ]
-[\ **-c**\ |\ **--compress**\ ] [\ **--osimage**\ ] [\ **--nics**\ ] [[\ **-w**\  \ *attr*\ ==\ *val*\ ]
+\ **lsdef**\  [\ **-V | -**\ **-verbose**\ ] [\ **-l | -**\ **-long**\ ] [\ **-s | -**\ **-short**\ ] [\ **-a | -**\ **-all**\ ] [\ **-S**\ ] 
+[\ **-t**\  \ *object-types*\ ] [\ **-o**\  \ *object-names*\ ] [\ **-z | -**\ **-stanza**\ ] [\ **-i**\  \ *attr-list*\ ]
+[\ **-c | -**\ **-compress**\ ] [\ **-**\ **-osimage**\ ] [\ **-**\ **-nics**\ ] [[\ **-w**\  \ *attr*\ ==\ *val*\ ]
 [\ **-w**\  \ *attr*\ =~\ *val*\ ] ...] [\ *noderange*\ ]
 
 
@@ -42,7 +42,7 @@ OPTIONS
 
 
 
-\ **-a|--all**\ 
+\ **-a|-**\ **-all**\ 
  
  Display all definitions.
  For performance consideration, the auditlog and eventlog objects will not be listed.
@@ -50,7 +50,7 @@ OPTIONS
  
 
 
-\ **-c|--compress**\ 
+\ **-c|-**\ **-compress**\ 
  
  Display information in compressed mode, each output line has format "<object name>: <data>".
  The output can be passed to command xcoll or xdshbak for formatted output. 
@@ -58,7 +58,7 @@ OPTIONS
  
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  
@@ -70,13 +70,13 @@ OPTIONS
  
 
 
-\ **-l|--long**\ 
+\ **-l|-**\ **-long**\ 
  
  List the complete object definition.
  
 
 
-\ **-s|--short**\ 
+\ **-s|-**\ **-short**\ 
  
  Only list the object names.
  
@@ -101,13 +101,13 @@ OPTIONS
  
 
 
-\ **--osimage**\ 
+\ **-**\ **-osimage**\ 
  
  Show all the osimage information for the node.
  
 
 
-\ **--nics**\ 
+\ **-**\ **-nics**\ 
  
  Show the nics configuration information for the node.
  
@@ -119,7 +119,7 @@ OPTIONS
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Verbose mode.
  
@@ -139,7 +139,7 @@ OPTIONS
  
 
 
-\ **-z|--stanza**\ 
+\ **-z|-**\ **-stanza**\ 
  
  Display output in stanza format. See the xcatstanzafile man page for details on using xCAT stanza files.
  

--- a/docs/source/guides/admin-guides/references/man1/lsdocker.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/lsdocker.1.rst
@@ -19,13 +19,13 @@ SYNOPSIS
 ********
 
 
-\ **lsdocker**\  \ *noderange*\  [\ **-l**\ |\ **--logs**\ ]
+\ **lsdocker**\  \ *noderange*\  [\ **-l | -**\ **-logs**\ ]
 
 \ **lsdocker**\  \ *dockerhost*\ 
 
-\ **lsdocker**\  [\ **-h**\ |\ **--help**\ ]
+\ **lsdocker**\  [\ **-h | -**\ **-help**\ ]
 
-\ **lsdocker**\  {\ **-v**\ |\ **--version**\ }
+\ **lsdocker**\  {\ **-v | -**\ **-version**\ }
 
 
 ***********
@@ -42,7 +42,7 @@ OPTIONS
 
 
 
-\ **-l|--logs**\ 
+\ **-l|-**\ **-logs**\ 
 
 
 
@@ -55,27 +55,37 @@ EXAMPLES
 
 
 
-\*
- 
- To get info for docker instance "host01c01"
+1. To get info for docker instance "host01c01"
  
  
  .. code-block:: perl
  
    lsdocker host01c01
+ 
+ 
+ Output is similar to:
+ 
+ 
+ .. code-block:: perl
+ 
    host01c01: 50800dfd8b5f	ubuntu	/bin/bash	2016-01-13T06:32:59	running	/host01c01
  
  
 
 
-\*
- 
- To get info for running docker instance on dockerhost "host01"
+2. To get info for running docker instance on dockerhost "host01"
  
  
  .. code-block:: perl
  
    lsdocker host01
+ 
+ 
+ Output is similar to:
+ 
+ 
+ .. code-block:: perl
+ 
    host01: 50800dfd8b5f	ubuntu	/bin/bash	2016-1-13 - 1:32:59	Up 12 minutes	/host01c01
    host01: 875ce11d5987	ubuntu	/bin/bash	2016-1-21 - 1:12:37	Up 5 seconds	/host01c02
  

--- a/docs/source/guides/admin-guides/references/man1/lsflexnode.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/lsflexnode.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **lsflexnode**\  [-h | --help]
+\ **lsflexnode**\  [\ **-h**\  | \ **-**\ **-help**\ ]
 
-\ **lsflexnode**\  [-v | --version]
+\ **lsflexnode**\  [\ **-v**\  | \ **-**\ **-version**\ ]
 
 \ **lsflexnode**\  \ *noderange*\ 
 
@@ -55,13 +55,13 @@ OPTIONS
 
 
 
-\ **-h | --help**\ 
+\ **-h | -**\ **-help**\ 
  
  Display the usage message.
  
 
 
-\ **-v | --version**\ 
+\ **-v | -**\ **-version**\ 
  
  Display the version information.
  
@@ -181,9 +181,7 @@ EXAMPLES
 
 
 
-1
- 
- Display all the \ **Complex**\ , \ **Partition**\  and \ **Blade slot node**\  which managed by a AMM.
+1 Display all the \ **Complex**\ , \ **Partition**\  and \ **Blade slot node**\  which managed by a AMM.
  
  
  .. code-block:: perl
@@ -220,9 +218,7 @@ EXAMPLES
  
 
 
-2
- 
- Display a flexible node.
+2 Display a flexible node.
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man1/lshwconn.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/lshwconn.1.rst
@@ -19,15 +19,15 @@ SYNOPSIS
 ********
 
 
-\ **lshwconn**\  [\ **-h**\ | \ **--help**\ ]
+\ **lshwconn**\  [\ **-h**\ | \ **-**\ **-help**\ ]
 
-\ **lshwconn**\  [\ **-v**\ | \ **--version**\ ]
+\ **lshwconn**\  [\ **-v**\ | \ **-**\ **-version**\ ]
 
 PPC (with HMC) specific:
 ========================
 
 
-\ **lshwconn**\  [\ **-V**\ | \ **--verbose**\ ] \ *noderange*\ 
+\ **lshwconn**\  [\ **-V**\ | \ **-**\ **-verbose**\ ] \ *noderange*\ 
 
 
 PPC (without HMC, using FSPAPI) specific:
@@ -52,13 +52,13 @@ OPTIONS
 
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Verbose output.
  

--- a/docs/source/guides/admin-guides/references/man1/lskit.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/lskit.1.rst
@@ -19,17 +19,11 @@ SYNOPSIS
 ********
 
 
-\ **lskit**\  [\ **-V**\  | \ **--verbose**\ ] 
-      [\ **-F**\  | \ **--framework**\  \ *kitattr_names*\ ]
-      [\ **-x**\  | \ **--xml**\  | \ **--XML**\ ]
-      [\ **-K**\  | \ **--kitattr**\  \ *kitattr_names*\ ]
-      [\ **-R**\  | \ **--repoattr**\  \ *repoattr_names*\ ]
-      [\ **-C**\  | \ **--compattr**\  \ *compattr_names*\ ]
-      [kit_names]
+\ **lskit**\  [\ **-V**\  | \ **-**\ **-verbose**\ ] [\ **-F**\  | \ **-**\ **-framework**\  \ *kitattr_names*\ ] [\ **-x**\  | \ **-**\ **-xml**\  | \ **-**\ **-XML**\ ] [\ **-K**\  | \ **-**\ **-kitattr**\  \ *kitattr_names*\ ] [\ **-R**\  | \ **-**\ **-repoattr**\  \ *repoattr_names*\ ] [\ **-C**\  | \ **-**\ **-compattr**\  \ *compattr_names*\ ] [\ *kit_names*\ ]
 
-\ **lskit**\  [\ **-?**\  | \ **-h**\  | \ **--help**\  | \ **-v**\  | \ **--version**\ ]
+\ **lskit**\  [\ **-?**\  | \ **-h**\  | \ **-**\ **-help**\  | \ **-v**\  | \ **-**\ **-version**\ ]
 
-\ **lskit**\  [\ **-F**\  | \ **--framework**\  \ *kit_path_name*\ ]
+\ **lskit**\  [\ **-F**\  | \ **-**\ **-framework**\  \ *kit_path_name*\ ]
 
 
 ***********
@@ -52,25 +46,25 @@ OPTIONS
 
 
 
-\ **-F|--framework**\  \ *kit_path_name*\ 
+\ **-F|-**\ **-framework**\  \ *kit_path_name*\ 
  
  Use this option to display the framework values of the specified Kit tarfile.  This information is retreived directly from the tarfile and can be done before the Kit has been defined in the xCAT database.  This option cannot be combined with other options.
  
 
 
-\ **-K|--kitattr**\  \ *kitattr_names*\ 
+\ **-K|-**\ **-kitattr**\  \ *kitattr_names*\ 
  
  Where \ *kitattr_names*\  is a comma-delimited list of kit attribute names. The names correspond to attribute names in the \ **kit**\  table. The \ **lskit**\  command will only display the specified kit attributes.
  
 
 
-\ **-R|--repoattr**\  \ *repoattr_names*\ 
+\ **-R|-**\ **-repoattr**\  \ *repoattr_names*\ 
  
  Where \ *repoattr_names*\  is a comma-delimited list of kit repository attribute names. The names correspond to attribute names in the \ **kitrepo**\  table. The \ **lskit**\  command will only display the specified kit repository attributes.
  
 
 
-\ **-C|--compattr**\  \ *compattr_names*\ 
+\ **-C|-**\ **-compattr**\  \ *compattr_names*\ 
  
  where \ *compattr_names*\  is a comma-delimited list of kit component attribute names. The names correspond to attribute names in the \ **kitcomponent**\  table. The \ **lskit**\  command will only display the specified kit component attributes.
  
@@ -82,36 +76,47 @@ OPTIONS
  
 
 
-\ **-x|--xml|--XML**\ 
+\ **-x|-**\ **-xml|-**\ **-XML**\ 
  
  Need XCATXMLTRACE=1 env when using -x|--xml|--XML, for example: XCATXMLTRACE=1  lskit -x testkit-1.0.0
  Return the output with XML tags.  The data is returned as:
-   <data>
-     <kitinfo>
-        ...
-     </kitinfo>
-   </data>
-   ...
-   <data>
-     <kitinfo>
-        ...
-     </kitinfo>
-   </data>
- 
- Each <kitinfo> tag contains info for one kit.  The info inside <kitinfo> is structured as follows:
-   The <kit> sub-tag contains the kit's basic info.
-   The <kitrepo> sub-tags store info about the kit's repositories.
-   The <kitcomponent> sub-tags store info about the kit's components.
- 
- The data inside <kitinfo> is returned as:
-   <kitinfo>
-      <kit>
-        ...
-      </kit>
  
  
  .. code-block:: perl
  
+    <data>
+      <kitinfo>
+         ...
+      </kitinfo>
+    </data>
+    ...
+    <data>
+      <kitinfo>
+         ...
+      </kitinfo>
+    </data>
+ 
+ 
+ Each <kitinfo> tag contains info for one kit.  The info inside <kitinfo> is structured as follows:
+ 
+ 
+ .. code-block:: perl
+ 
+    The <kit> sub-tag contains the kit's basic info.
+    The <kitrepo> sub-tags store info about the kit's repositories.
+    The <kitcomponent> sub-tags store info about the kit's components.
+ 
+ 
+ The data inside <kitinfo> is returned as:
+ 
+ 
+ .. code-block:: perl
+ 
+    <kitinfo>
+       <kit>
+         ...
+       </kit>
+  
        <kitrepo>
          ...
        </kitrepo>
@@ -126,19 +131,19 @@ OPTIONS
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Display additional progress and error messages.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command Version.
  
 
 
-\ **-?|-h|--help**\ 
+\ **-?|-h|-**\ **-help**\ 
  
  Display usage message.
  
@@ -151,16 +156,12 @@ RETURN VALUE
 
 
 
-0
- 
- The command completed successfully.
- 
+0 The command completed successfully.
 
 
-1
- 
- An error has occurred.
- 
+
+1 An error has occurred.
+
 
 
 
@@ -170,9 +171,7 @@ EXAMPLES
 
 
 
-1.
- 
- To list all kits, enter:
+1. To list all kits, enter:
  
  
  .. code-block:: perl
@@ -182,9 +181,7 @@ EXAMPLES
  
 
 
-2.
- 
- To list the kit "kit-test1-1.0-Linux", enter:
+2. To list the kit "kit-test1-1.0-Linux", enter:
  
  
  .. code-block:: perl
@@ -194,9 +191,7 @@ EXAMPLES
  
 
 
-3.
- 
- To list the kit "kit-test1-1.0-Linux" for selected attributes, enter:
+3. To list the kit "kit-test1-1.0-Linux" for selected attributes, enter:
  
  
  .. code-block:: perl
@@ -206,15 +201,19 @@ EXAMPLES
  
 
 
-4.
- 
- To list the framework value of a Kit tarfile.
+4. To list the framework value of a Kit tarfile.
  
  
  .. code-block:: perl
  
     lskit -F /myhome/mykits/pperte-1.3.0.2-0-x86_64.tar.bz2
-  
+ 
+ 
+ Output is similar to:
+ 
+ 
+ .. code-block:: perl
+ 
     Extracting the kit.conf file from /myhome/mykits/pperte-1.3.0.2-0-x86_64.tar.bz2. Please wait.
     
           kitframework=2
@@ -223,9 +222,7 @@ EXAMPLES
  
 
 
-5.
- 
- To list kit "testkit-1.0-1" with XML tags, enter:
+5. To list kit "testkit-1.0-1" with XML tags, enter:
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man1/lskitcomp.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/lskitcomp.1.rst
@@ -19,14 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **lskitcomp**\  [\ **-V**\  | \ **--verbose**\ ] 
-      [\ **-x**\  | \ **--xml**\  | \ **--XML**\ ]
-      [\ **-C**\  | \ **--compattr**\  \ *compattr_names*\ ]
-      [\ **-O**\  | \ **--osdistro**\  \ *os_distro*\ ]
-      [\ **-S**\  | \ **--serverrole**\  \ *server_role*\ ]
-      [kitcomp_names]
+\ **lskitcomp**\  [\ **-V**\  | \ **-**\ **-verbose**\ ] [\ **-x**\  | \ **-**\ **-xml**\  | \ **-**\ **-XML**\ ] [\ **-C**\  | \ **-**\ **-compattr**\  \ *compattr_names*\ ] [\ **-O**\  | \ **-**\ **-osdistro**\  \ *os_distro*\ ] [\ **-S**\  | \ **-**\ **-serverrole**\  \ *server_role*\ ] [\ *kitcomp_names*\ ]
 
-\ **lskitcomp**\  [\ **-?**\  | \ **-h**\  | \ **--help**\  | \ **-v**\  | \ **--version**\ ]
+\ **lskitcomp**\  [\ **-?**\  | \ **-h**\  | \ **-**\ **-help**\  | \ **-v**\  | \ **-**\ **-version**\ ]
 
 
 ***********
@@ -49,19 +44,19 @@ OPTIONS
 
 
 
-\ **-C|--compattr**\  \ *compattr_names*\ 
+\ **-C|-**\ **-compattr**\  \ *compattr_names*\ 
  
  where \ *compattr_names*\  is a comma-delimited list of kit component attribute names. The names correspond to attribute names in the \ **kitcomponent**\  table.  The \ **lskitcomp**\  command will only display the specified kit component attributes.
  
 
 
-\ **-O|--osdistro**\  \ *os_distro*\ 
+\ **-O|-**\ **-osdistro**\  \ *os_distro*\ 
  
  where \ *os_distro*\  is the name of an osdistro in \ **osdistro**\  table. The \ **lskitcomp**\  command will only display the kit components matching the specified osdistro.
  
 
 
-\ **-S|--serverrole**\  \ *server_role*\ 
+\ **-S|-**\ **-serverrole**\  \ *server_role*\ 
  
  where \ *server_role*\  is the name of a server role. The typical server roles are: mgtnode, servicenode, computenode, loginnode, storagennode. The \ **lskitcomp**\  command will only display the kit components matching the specified server role.
  
@@ -73,35 +68,46 @@ OPTIONS
  
 
 
-\ **-x|--xml|--XML**\ 
+\ **-x|-**\ **-xml|-**\ **-XML**\ 
  
  Need XCATXMLTRACE=1 env when using -x|--xml|--XML.
  Return the output with XML tags.  The data is returned as:
-   <data>
-     <kitinfo>
-        ...
-     </kitinfo>
-   </data>
-   ...
-   <data>
-     <kitinfo>
-        ...
-     </kitinfo>
-   </data>
- 
- Each <kitinfo> tag contains info for a group of kit compoonents belonging to the same kit. The info inside <kitinfo> is structured as follows:
-   The <kit> sub-tag contains the kit's name.
-   The <kitcomponent> sub-tags store info about the kit's components.
- 
- The data inside <kitinfo> is returned as:
-   <kitinfo>
-      <kit>
-        ...
-      </kit>
  
  
  .. code-block:: perl
  
+    <data>
+      <kitinfo>
+         ...
+      </kitinfo>
+    </data>
+    ...
+    <data>
+      <kitinfo>
+         ...
+      </kitinfo>
+    </data>
+ 
+ 
+ Each <kitinfo> tag contains info for a group of kit compoonents belonging to the same kit. The info inside <kitinfo> is structured as follows:
+ 
+ 
+ .. code-block:: perl
+ 
+    The <kit> sub-tag contains the kit's name.
+    The <kitcomponent> sub-tags store info about the kit's components.
+ 
+ 
+ The data inside <kitinfo> is returned as:
+ 
+ 
+ .. code-block:: perl
+ 
+    <kitinfo>
+       <kit>
+         ...
+       </kit>
+  
        <kitcomponent>
          ...
        </kitcomponent>
@@ -111,19 +117,19 @@ OPTIONS
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Display additional progress and error messages.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command Version.
  
 
 
-\ **-?|-h|--help**\ 
+\ **-?|-h|-**\ **-help**\ 
  
  Display usage message.
  
@@ -136,16 +142,12 @@ RETURN VALUE
 
 
 
-0
- 
- The command completed successfully.
- 
+0 The command completed successfully.
 
 
-1
- 
- An error has occurred.
- 
+
+1 An error has occurred.
+
 
 
 

--- a/docs/source/guides/admin-guides/references/man1/lskitdeployparam.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/lskitdeployparam.1.rst
@@ -19,12 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **lskitdeployparam**\  [\ **-V**\  | \ **--verbose**\ ] 
-      [\ **-x**\  | \ **--xml**\  | \ **--XML**\ ]
-      [\ **-k**\  | \ **--kitname**\  \ *kit_names*\ ]
-      [\ **-c**\  | \ **--compname**\  \ *comp_names*\ ]
+\ **lskitdeployparam**\  [\ **-V**\  | \ **-**\ **-verbose**\ ] [\ **-x**\  | \ **-**\ **-xml**\  | \ **-**\ **-XML**\ ] [\ **-k**\  | \ **-**\ **-kitname**\  \ *kit_names*\ ] [\ **-c**\  | \ **-**\ **-compname**\  \ *comp_names*\ ]
 
-\ **lskitdeployparam**\  [\ **-?**\  | \ **-h**\  | \ **--help**\  | \ **-v**\  | \ **--version**\ ]
+\ **lskitdeployparam**\  [\ **-?**\  | \ **-h**\  | \ **-**\ **-help**\  | \ **-v**\  | \ **-**\ **-version**\ ]
 
 
 ***********
@@ -47,50 +44,55 @@ OPTIONS
 
 
 
-\ **-k|--kitname**\  \ *kit_names*\ 
+\ **-k|-**\ **-kitname**\  \ *kit_names*\ 
  
  Where \ *kit_names*\  is a comma-delimited list of kit names. The \ **lskitdeployparam**\  command will only display the deployment parameters for the kits with the matching names.
  
 
 
-\ **-c|--compname**\  \ *comp_names*\ 
+\ **-c|-**\ **-compname**\  \ *comp_names*\ 
  
  Where \ *comp_names*\  is a comma-delimited list of kit component names. The \ **lskitdeployparam**\  command will only display the deployment parameters for the kit components with the matching names.
  
 
 
-\ **-x|--xml|--XML**\ 
+\ **-x|-**\ **-xml|-**\ **-XML**\ 
  
  Return the output with XML tags.  The data is returned as:
-   <data>
-     <kitdeployparam>
-       <name>KIT_KIT1_PARAM1</name>
-       <value>value11</value>
-     </kitdeployparam>
-   </data>
-   <data>
-     <kitdeployparam>
-       <name>KIT_KIT1_PARAM2</name>
-       <value>value12</value>
-     </kitdeployparam>
-   </data>
-   ...
+ 
+ 
+ .. code-block:: perl
+ 
+    <data>
+      <kitdeployparam>
+        <name>KIT_KIT1_PARAM1</name>
+        <value>value11</value>
+      </kitdeployparam>
+    </data>
+    <data>
+      <kitdeployparam>
+        <name>KIT_KIT1_PARAM2</name>
+        <value>value12</value>
+      </kitdeployparam>
+    </data>
+    ...
+ 
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Display additional progress and error messages.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command Version.
  
 
 
-\ **-?|-h|--help**\ 
+\ **-?|-h|-**\ **-help**\ 
  
  Display usage message.
  
@@ -103,16 +105,12 @@ RETURN VALUE
 
 
 
-0
- 
- The command completed successfully.
- 
+0 The command completed successfully.
 
 
-1
- 
- An error has occurred.
- 
+
+1 An error has occurred.
+
 
 
 

--- a/docs/source/guides/admin-guides/references/man1/lskmodules.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/lskmodules.1.rst
@@ -19,14 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **lskmodules**\  [\ **-V**\  | \ **--verbose**\ ] 
-      [\ **-i**\  | \ **--osimage**\  \ *osimage_names*\ ]
-      [\ **-c**\  | \ **--kitcomponent**\  \ *kitcomp_names*\ ]
-      [\ **-o**\  | \ **--osdistro**\  \ *osdistro_names*\ ]
-      [\ **-u**\  | \ **--osdistropudate**\  \ *osdistroupdate_names*\ ]
-      [\ **-x**\  | \ **--xml**\  | \ **--XML**\ ]
+\ **lskmodules**\  [\ **-V**\  | \ **-**\ **-verbose**\ ] [\ **-i**\  | \ **-**\ **-osimage**\  \ *osimage_names*\ ] [\ **-c**\  | \ **-**\ **-kitcomponent**\  \ *kitcomp_names*\ ] [\ **-o**\  | \ **-**\ **-osdistro**\  \ *osdistro_names*\ ] [\ **-u**\  | \ **-**\ **-osdistropudate**\  \ *osdistroupdate_names*\ ] [\ **-x**\  | \ **-**\ **-xml**\  | \ **-**\ **-XML**\ ]
 
-\ **lskmodules**\  [\ **-?**\  | \ **-h**\  | \ **--help**\  | \ **-v**\  | \ **--version**\ ]
+\ **lskmodules**\  [\ **-?**\  | \ **-h**\  | \ **-**\ **-help**\  | \ **-v**\  | \ **-**\ **-version**\ ]
 
 
 ***********
@@ -45,54 +40,60 @@ OPTIONS
 
 
 
-\ **-i|--osimage**\  \ *osimage_names*\ 
+\ **-i|-**\ **-osimage**\  \ *osimage_names*\ 
  
  where \ *osimage_names*\  is a comma-delimited list of xCAT database osimage object names.  For each \ *osimage_name*\ , lskmodules will use the entries in osimage.driverupdatesrc for the rpms and driver disk image files to search.
  
 
 
-\ **-c|--kitcomponent**\  \ *kitcomponent_names*\ 
+\ **-c|-**\ **-kitcomponent**\  \ *kitcomponent_names*\ 
  
  where \ *kitcomponent_names*\  is a comma-delimited list of xCAT database kitcomponent object names.  For each \ *kitcomponent_name*\ , lskmodules will use the entries in kitcomponent.driverpacks for the rpm list and the repodir of the kitcomponent.kitreponame for the location of the rpm files to search.
  
 
 
-\ **-o|--osdistro**\  \ *osdistro_names*\ 
+\ **-o|-**\ **-osdistro**\  \ *osdistro_names*\ 
  
  where \ *osdistro_names*\  is a comma-delimited list of xCAT database osdistro object names.  For each \ *osdistro_name*\ , lskmodules will search each <osdistro.dirpaths>/Packages/kernel-<kernelversion>.rpm file.
  
 
 
-\ **-u|--osdistroupdate**\  \ *osdistroupdate_names*\ 
+\ **-u|-**\ **-osdistroupdate**\  \ *osdistroupdate_names*\ 
  
  where \ *osdistroupdate_names*\  is a comma-delimited list of xCAT database osdistroupdate table entries.  For each \ *osdistroupdate_name*\ , lskmodules will search the <osdistroupdate.dirpath>/kernel-<kernelversion>.rpm file.
  
 
 
-\ **-x|--xml|--XML**\ 
+\ **-x|-**\ **-xml|-**\ **-XML**\ 
  
  Return the output with XML tags.  The data is returned as:
-   <module>
-     <name> xxx.ko </name>
-     <description> this is module xxx </description>
-   </module>
+ 
+ 
+ .. code-block:: perl
+ 
+    <module>
+      <name> xxx.ko </name>
+      <description> this is module xxx </description>
+    </module>
+ 
+ 
  This option is intended for use by other programs.  The XML will not be displayed.  To view the returned XML, set the XCATSHOWXML=yes environment variable before running this command.
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Display additional progress and error messages.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command Version.
  
 
 
-\ **-?|-h|--help**\ 
+\ **-?|-h|-**\ **-help**\ 
  
  Display usage message.
  
@@ -105,16 +106,12 @@ RETURN VALUE
 
 
 
-0
- 
- The command completed successfully.
- 
+0 The command completed successfully.
 
 
-1
- 
- An error has occurred.
- 
+
+1 An error has occurred.
+
 
 
 
@@ -126,8 +123,7 @@ EXAMPLES
 
 1.
  
- To list the kernel modules included in the driverpacks shipped with kitcomponent kit1_comp1-x86_64,
- enter:
+ To list the kernel modules included in the driverpacks shipped with kitcomponent kit1_comp1-x86_64, enter:
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man1/lslite.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/lslite.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **lslite**\  [-h | --help]
+\ **lslite**\  [\ **-h**\  | \ **-**\ **-help**\ ]
 
-\ **lslite**\  [-V | --verbose] [-i imagename] | [noderange]
+\ **lslite**\  [\ **-V**\  | \ **-**\ **-verbose**\ ] [\ **-i**\  \ *imagename*\ ] | [\ *noderange*\ ]
 
 
 ***********
@@ -38,25 +38,25 @@ OPTIONS
 
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Verbose mode.
  
 
 
-\ **-i imagename**\ 
+\ **-i**\  \ *imagename*\ 
  
  The name of an existing xCAT osimage definition.
  
 
 
-\ **noderange**\ 
+\ *noderange*\ 
  
  A set of comma delimited node names and/or group names. See the "noderange" man page for details on additional supported formats.
  
@@ -83,26 +83,34 @@ EXAMPLES
  
  To list the statelite information for an xCAT node named "node01".
  
- \ **lslite node01**\ 
+ 
+ .. code-block:: perl
+ 
+   lslite node01
+ 
  
  Output is similar to:
  
- >>>Node: node01
  
- Osimage: 61img
+ .. code-block:: perl
  
- Persistent directory (statelite table):
-         xcatmn1:/statelite
+   >>>Node: node01
+  
+   Osimage: 61img
+  
+   Persistent directory (statelite table):
+          xcatmn1:/statelite
+  
+   Litefiles (litefile table):
+          tmpfs,rw      /etc/adjtime
+          tmpfs,rw      /etc/lvm/.cache
+          tmpfs,rw      /etc/mtab
+          ........
+  
+   Litetree path (litetree table):
+          1,MN:/etc
+          2,server1:/etc
  
- Litefiles (litefile table):
-         tmpfs,rw      /etc/adjtime
-         tmpfs,rw      /etc/lvm/.cache
-         tmpfs,rw      /etc/mtab
-         ........
- 
- Litetree path (litetree table):
-         1,MN:/etc
-         2,server1:/etc
  
 
 
@@ -110,7 +118,11 @@ EXAMPLES
  
  To list the statelite information for an xCAT osimage named "osimage01".
  
- \ **lslite -i osimage01**\ 
+ 
+ .. code-block:: perl
+ 
+   lslite -i osimage01
+ 
  
  Output is similar to:
  

--- a/docs/source/guides/admin-guides/references/man1/lsslp.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/lsslp.1.rst
@@ -19,11 +19,11 @@ SYNOPSIS
 ********
 
 
-\ *lsslp [-h| --help]*\ 
+\ **lsslp [-h| -**\ **-help]**\ 
 
-\ *lsslp [-v| --version]*\ 
+\ **lsslp [-v| -**\ **-version]**\ 
 
-\ *lsslp [noderange] [-V] [-i ip[,ip..]][-w][-r|-x|-z][-n][-s CEC|FRAME|MM|IVM|RSA|HMC|CMM|IMM2|FSP][-t tries][-I][-C counts][-T timeout][--vpdtable]*\ 
+\ **lsslp**\  [\ *noderange*\ ] [\ **-V**\ ] [\ **-i**\  \ *ip[,ip..]*\ ] \ **[-w] [-r|-x|-z] [-n] [-s CEC|FRAME|MM|IVM|RSA|HMC|CMM|IMM2|FSP]**\  [\ **-t**\  \ *tries*\ ] [\ **-I**\ ] [\ **-C**\  \ *counts*\ ] [\ **-T**\  \ *timeout*\ ] [\ **-**\ **-vpdtable**\ ]
 
 
 ***********
@@ -41,14 +41,7 @@ OPTIONS
 *******
 
 
-\ **noderange**\    The nodes which the user want to discover.
-            If the user specify the noderange, lsslp will just return the nodes in 
-            the node range. Which means it will help to add the new nodes to the xCAT
-            database without modifying the existed definitions. But the nodes' name 
-            specified in noderange should be defined in database in advance. The specified
-            nodes' type can be frame/cec/hmc/fsp/bpa. If the it is frame or cec, lsslp
-            will list the bpa or fsp nodes within the nodes(bap for frame, fsp for cec).
-            Please do not use noderange with the flag -s.
+\ **noderange**\    The nodes which the user want to discover.  If the user specify the noderange, lsslp will just return the nodes in the node range. Which means it will help to add the new nodes to the xCAT database without modifying the existed definitions. But the nodes' name specified in noderange should be defined in database in advance. The specified nodes' type can be frame/cec/hmc/fsp/bpa. If the it is frame or cec, lsslp will list the bpa or fsp nodes within the nodes(bap for frame, fsp for cec).  Please do not use noderange with the flag -s.
 
 \ **-i**\           IP(s) the command will send out (defaults to all available adapters).
 
@@ -56,20 +49,13 @@ OPTIONS
 
 \ **-n**\           Only display and write the newly discovered hardwares.
 
-\ **-u**\           Do unicast to a specified IP range. Must be used with -s and --range.
-            The -u flag is not supported on AIX.
+\ **-u**\           Do unicast to a specified IP range. Must be used with \ **-s**\  and \ **-**\ **-range**\ . The \ **-u**\  flag is not supported on AIX.
 
-\ **--range**\      Specify one or more IP ranges. Must be use in unicast mode. 
-            It accepts multiple formats. For example, 192.168.1.1/24, 40-41.1-2.3-4.1-100.
-            If the range is huge, for example, 192.168.1.1/8, lsslp may take a very long time for node scan.
-            So the range should be exactly specified.
+\ **-**\ **-range**\      Specify one or more IP ranges. Must be use in unicast mode. It accepts multiple formats. For example, 192.168.1.1/24, 40-41.1-2.3-4.1-100. If the range is huge, for example, 192.168.1.1/8, lsslp may take a very long time for node scan. So the range should be exactly specified.
 
 \ **-r**\           Display Raw SLP response.
 
-\ **-C**\           The number of the expected responses specified by the user. 
-            When using this flag, lsslp will not return until the it has found all the nodes or time out.
-            The default max time is 3 secondes. The user can use -T flag the specify the time they want to use.
-            A short time will limite the time costing, while a long time will help to find all the nodes.
+\ **-C**\           The number of the expected responses specified by the user.  When using this flag, lsslp will not return until the it has found all the nodes or time out.  The default max time is 3 secondes. The user can use -T flag the specify the time they want to use.  A short time will limite the time costing, while a long time will help to find all the nodes.
 
 \ **-T**\           The number in seconds to limite the time costing of lsslp.
 
@@ -77,7 +63,7 @@ OPTIONS
 
 \ **-t**\           Number or service-request attempts.
 
-\ **--vpdtable**\   Output the SLP response in vpdtable formatting. Easy for writting data to vpd table.
+\ **-**\ **-vpdtable**\   Output the SLP response in vpdtable formatting. Easy for writting data to vpd table.
 
 \ **-v**\           Command Version.
 
@@ -89,8 +75,7 @@ OPTIONS
 
 \ **-z**\           Stanza formated output.
 
-\ **-I**\           Give the warning message for the nodes in database which have no SLP responses.
-            Please note that this flag noly can be used after the database migration finished successfully.
+\ **-I**\           Give the warning message for the nodes in database which have no SLP responses. Please note that this flag noly can be used after the database migration finished successfully.
 
 
 ************
@@ -179,64 +164,68 @@ Output is similar to:
 
 Output is similar to:
 
-c76v1hmc02:
-        objtype=node
-        hcp=c76v1hmc02
-        nodetype=hmc
-        mtm=7315CR2
-        serial=10407DA
-        ip=192.168.200.125
-        groups=hmc,all
-        mgt=hmc
-        mac=00:1a:64:fb:7d:50        
-        hidden=0
-192.168.200.244:
-        objtype=node
-        hcp=192.168.200.244
-        nodetype=fsp
-        mtm=9125-F2A
-        serial=0262662
-        side=A-0
-        otherinterfaces=192.168.200.244
-        groups=fsp,all
-        mgt=fsp
-        id=4
-        parent=Server-9125-F2A-SN0262662
-        mac=00:1a:64:fa:01:fe
-        hidden=1
-Server-8205-E6B-SN1074CDP:
-        objtype=node
-        hcp=Server-8205-E6B-SN1074CDP
-        nodetype=cec
-        mtm=8205-E6B
-        serial=1074CDP
-        groups=cec,all
-        mgt=fsp
-        id=0
-        hidden=0
-192.168.200.33:
-        objtype=node
-        hcp=192.168.200.33
-        nodetype=bpa
-        mtm=9458-100
-        serial=99201WM
-        side=B-0
-        otherinterfaces=192.168.200.33
-        groups=bpa,all
-        mgt=bpa
-        id=0
-        mac=00:09:6b:ad:19:90
-        hidden=1
-Server-9125-F2A-SN0262652:
-        objtype=node
-        hcp=Server-9125-F2A-SN0262652
-        nodetype=frame
-        mtm=9125-F2A
-        serial=0262652
-        groups=frame,all
-        mgt=fsp
-        id=5
-        hidden=0
+
+.. code-block:: perl
+
+  c76v1hmc02:
+         objtype=node
+         hcp=c76v1hmc02
+         nodetype=hmc
+         mtm=7315CR2
+         serial=10407DA
+         ip=192.168.200.125
+         groups=hmc,all
+         mgt=hmc
+         mac=00:1a:64:fb:7d:50        
+         hidden=0
+  192.168.200.244:
+         objtype=node
+         hcp=192.168.200.244
+         nodetype=fsp
+         mtm=9125-F2A
+         serial=0262662
+         side=A-0
+         otherinterfaces=192.168.200.244
+         groups=fsp,all
+         mgt=fsp
+         id=4
+         parent=Server-9125-F2A-SN0262662
+         mac=00:1a:64:fa:01:fe
+         hidden=1
+  Server-8205-E6B-SN1074CDP:
+         objtype=node
+         hcp=Server-8205-E6B-SN1074CDP
+         nodetype=cec
+         mtm=8205-E6B
+         serial=1074CDP
+         groups=cec,all
+         mgt=fsp
+         id=0
+         hidden=0
+  192.168.200.33:
+         objtype=node
+         hcp=192.168.200.33
+         nodetype=bpa
+         mtm=9458-100
+         serial=99201WM
+         side=B-0
+         otherinterfaces=192.168.200.33
+         groups=bpa,all
+         mgt=bpa
+         id=0
+         mac=00:09:6b:ad:19:90
+         hidden=1
+  Server-9125-F2A-SN0262652:
+         objtype=node
+         hcp=Server-9125-F2A-SN0262652
+         nodetype=frame
+         mtm=9125-F2A
+         serial=0262652
+         groups=frame,all
+         mgt=fsp
+         id=5
+         hidden=0
+
 
 5. To list all discovered service types in stanza format and display the IP address, enter:
 
@@ -281,13 +270,13 @@ Output is similar to:
 
 .. code-block:: perl
 
-  lsslp -s CEC
+  lsslp -s CEC 
+  
+  device  type-model  serial-number  side  ip-addresses  hostname
+  FSP     9117-MMB    105EBEP        A-1   20.0.0.138    20.0.0.138
+  FSP     9117-MMB    105EBEP        B-1   20.0.0.139    20.0.0.139
+  CEC     9117-MMB    105EBEP                            Server-9117-MMB-SN105EBEP
 
-
-device  type-model  serial-number  side  ip-addresses  hostname
-FSP     9117-MMB    105EBEP        A-1   20.0.0.138    20.0.0.138
-FSP     9117-MMB    105EBEP        B-1   20.0.0.139    20.0.0.139
-CEC     9117-MMB    105EBEP                            Server-9117-MMB-SN105EBEP
 
 7. To list all the nodes defined in database which have no SLP response.
 
@@ -299,11 +288,15 @@ CEC     9117-MMB    105EBEP                            Server-9117-MMB-SN105EBEP
 
 Output is similar to:
 
-These nodes defined in database but can't be discovered: f17c00bpcb_b,f17c01bpcb_a,f17c01bpcb_b,f17c02bpcb_a,
 
-device  type-model  serial-number  side  ip-addresses  hostname
-bpa     9458-100    BPCF017        A-0   40.17.0.1     f17c00bpca_a
-bpa     9458-100    BPCF017        B-0   40.17.0.2     f17c00bpcb_a
+.. code-block:: perl
+
+  These nodes defined in database but can't be discovered: f17c00bpcb_b,f17c01bpcb_a,f17c01bpcb_b,f17c02bpcb_a,
+ 
+  device  type-model  serial-number  side  ip-addresses  hostname
+  bpa     9458-100    BPCF017        A-0   40.17.0.1     f17c00bpca_a
+  bpa     9458-100    BPCF017        B-0   40.17.0.2     f17c00bpcb_a
+
 
 8. To find the nodes within the user specified. Please make sure the noderange input have been defined in xCAT database.
 
@@ -334,20 +327,29 @@ bpa     9458-100    BPCF017        B-0   40.17.0.2     f17c00bpcb_a
 9. To list all discovered CMM in stanza format, enter:
    lsslp -s CMM -m -z
 
-e114ngmm1:
-        objtype=node
-        mpa=e114ngmm1
-        nodetype=cmm
-        mtm=98939AX
-        serial=102537A
-        groups=cmm,all
-        mgt=blade
-        hidden=0
-        otherinterfaces=70.0.0.30
-        hwtype=cmm
+
+.. code-block:: perl
+
+  e114ngmm1:
+         objtype=node
+         mpa=e114ngmm1
+         nodetype=cmm
+         mtm=98939AX
+         serial=102537A
+         groups=cmm,all
+         mgt=blade
+         hidden=0
+         otherinterfaces=70.0.0.30
+         hwtype=cmm
+
 
 10. To use lsslp unicast, enter:
-    lsslp -u -s CEC --range 40-41.1-2.1-2.1-2
+
+
+.. code-block:: perl
+
+     lsslp -u -s CEC --range 40-41.1-2.1-2.1-2
+
 
 
 *****

--- a/docs/source/guides/admin-guides/references/man1/lstree.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/lstree.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **lstree**\  [-h | --help]
+\ **lstree**\  [\ **-h**\  | \ **-**\ **-help**\ ]
 
-\ **lstree**\  [-s | --servicenode] [-H | --hardwaremgmt] [-v | --virtualmachine] [noderange]
+\ **lstree**\  [\ **-s**\  | \ **-**\ **-servicenode**\ ] [\ **-H**\  | \ **-**\ **-hardwaremgmt**\ ] [\ **-v**\  | \ **-**\ **-virtualmachine**\ ] [\ *noderange*\ ]
 
 
 ***********
@@ -38,31 +38,31 @@ OPTIONS
 
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-s|-- servicenode**\ 
+\ **-s|-**\ **- servicenode**\ 
  
  Show the tree of service node hierarchy.
  
 
 
-\ **-H|--hardwaremgmt**\ 
+\ **-H|-**\ **-hardwaremgmt**\ 
  
  Show the tree of hardware hierarchy.
  
 
 
-\ **--v|--virtualmachine**\ 
+\ **-**\ **-v|-**\ **-virtualmachine**\ 
  
  Show the tree of VM hierarchy.
  
 
 
-\ **noderange**\ 
+\ *noderange*\ 
  
  A set of comma delimited node names and/or group names. See the "noderange" man page for details on additional supported formats.
  
@@ -85,24 +85,30 @@ EXAMPLES
 
 
 
-1.
+1. To display the tree of service node hierarchy for all the nodes.
  
- To display the tree of service node hierarchy for all the nodes.
  
- \ **lstree -s**\ 
+ .. code-block:: perl
+ 
+   lstree -s
+ 
  
  Output is similar to:
  
- Service Node: mysn01
-  |__mycn01
-  |__mycn02
-  |__mycn03
  
- Service Node: mysn02
-  |__mycn11
-  |__mycn12
-  |__mycn13
-  ......
+ .. code-block:: perl
+ 
+   Service Node: mysn01
+   |__mycn01
+   |__mycn02
+   |__mycn03
+  
+   Service Node: mysn02
+   |__mycn11
+   |__mycn12
+   |__mycn13
+   ......
+ 
  
 
 
@@ -110,14 +116,22 @@ EXAMPLES
  
  To display the tree of service node hierarchy for service node "mysn01".
  
- \ **lstree -s mysn01**\ 
+ 
+ .. code-block:: perl
+ 
+   lstree -s mysn01
+ 
  
  Output is similar to:
  
- Service Node: mysn01
-  |__mycn01
-  |__mycn02
-  |__mycn03
+ 
+ .. code-block:: perl
+ 
+   Service Node: mysn01
+   |__mycn01
+   |__mycn02
+   |__mycn03
+ 
  
 
 
@@ -125,129 +139,161 @@ EXAMPLES
  
  To display the tree of hardware hierarchy for all the nodes.
  
- \ **lstree -H**\ 
+ 
+ .. code-block:: perl
+ 
+   lstree -H
+ 
  
  Output is similar to:
  
- HMC: myhmc01
-  |__Frame: myframe01
-     |__CEC: mycec01
-     |__CEC: mycec02
-     ......
  
- Service Focal Point: myhmc02
-  |__Frame: myframe01
-     |__CEC: mycec01
-     |__CEC: mycec02
-     |__CEC: mycec03
-     ......
+ .. code-block:: perl
  
- Management Module: mymm01
-  |__Blade 1: js22n01
-  |__Blade 2: js22n02
-  |__Blade 3: js22n03
-  ......
+   HMC: myhmc01
+   |__Frame: myframe01
+      |__CEC: mycec01
+      |__CEC: mycec02
+      ......
+  
+   Service Focal Point: myhmc02
+   |__Frame: myframe01
+      |__CEC: mycec01
+      |__CEC: mycec02
+      |__CEC: mycec03
+      ......
+  
+   Management Module: mymm01
+   |__Blade 1: js22n01
+   |__Blade 2: js22n02
+   |__Blade 3: js22n03
+   ......
+  
+   BMC: 192.168.0.1
+   |__Server: x3650n01
  
- BMC: 192.168.0.1
-  |__Server: x3650n01
  
 
 
-4.
+4. To display the tree of hardware hierarchy for HMC "myhmc01".
  
- To display the tree of hardware hierarchy for HMC "myhmc01".
  
- \ **lstree -H myhmc01**\ 
+ .. code-block:: perl
+ 
+   lstree -H myhmc01
+ 
  
  Output is similar to:
  
- HMC: myhmc01
-  |__Frame: myframe01
-     |__CEC: mycec01
-     |__CEC: mycec02
-     ......
+ 
+ .. code-block:: perl
+ 
+   HMC: myhmc01
+   |__Frame: myframe01
+      |__CEC: mycec01
+      |__CEC: mycec02
+      ......
+ 
  
 
 
-5.
+5. To display the tree of VM hierarchy for all the nodes.
  
- To display the tree of VM hierarchy for all the nodes.
  
- \ **lstree -v**\ 
+ .. code-block:: perl
+ 
+   lstree -v
+ 
  
  Output is similar to:
  
- Server: hs22n01
-  |__ hs22vm1
  
- Server: x3650n01
-  |__ x3650n01kvm1
-  |__ x3650n01kvm2
+ .. code-block:: perl
+ 
+   Server: hs22n01
+   |__ hs22vm1
+  
+   Server: x3650n01
+   |__ x3650n01kvm1
+   |__ x3650n01kvm2
+ 
  
 
 
-6.
+6. To display the tree of VM hierarchy for the node "x3650n01".
  
- To display the tree of VM hierarchy for the node "x3650n01".
  
- \ **lstree -v x3650n01**\ 
+ .. code-block:: perl
+ 
+   lstree -v x3650n01
+ 
  
  Output is similar to:
  
- Server: x3650n01
-  |__ x3650n01kvm1
-  |__ x3650n01kvm2
+ 
+ .. code-block:: perl
+ 
+   Server: x3650n01
+   |__ x3650n01kvm1
+   |__ x3650n01kvm2
+ 
  
 
 
-7.
+7. To display both the hardware tree and VM tree for all nodes.
  
- To display both the hardware tree and VM tree for all nodes.
  
- \ **lstree**\ 
+ .. code-block:: perl
+ 
+   lstree
+ 
  
  Output is similar to:
  
- HMC: myhmc01
-  |__Frame: myframe01
-     |__CEC: mycec01
-        |__LPAR 1: node01
-        |__LPAR 2: node02
-        |__LPAR 3: node03
-        ......
-     |__CEC: mycec02
-        |__LPAR 1: node11
-        |__LPAR 2: node12
-        |__LPAR 3: node13
-        ......
  
- Service Focal Point: myhmc02
-  |__Frame: myframe01
-     |__CEC: mycec01
-        |__LPAR 1: node01
-        |__LPAR 2: node02
-        |__LPAR 3: node03
-        ......
-  |__Frame: myframe02
-     |__CEC: mycec02
-        |__LPAR 1: node21
-        |__LPAR 2: node22
-        |__LPAR 3: node23
-        ......
+ .. code-block:: perl
  
- Management Module: mymm01
-  |__Blade 1: hs22n01
-     |__hs22n01vm1
-     |__hs22n01vm2
-  |__Blade 2: hs22n02
-     |__hs22n02vm1
-     |__hs22n02vm2
-  ......
+   HMC: myhmc01
+   |__Frame: myframe01
+      |__CEC: mycec01
+         |__LPAR 1: node01
+         |__LPAR 2: node02
+         |__LPAR 3: node03
+         ......
+      |__CEC: mycec02
+         |__LPAR 1: node11
+         |__LPAR 2: node12
+         |__LPAR 3: node13
+         ......
+  
+   Service Focal Point: myhmc02
+   |__Frame: myframe01
+      |__CEC: mycec01
+         |__LPAR 1: node01
+         |__LPAR 2: node02
+         |__LPAR 3: node03
+         ......
+   |__Frame: myframe02
+      |__CEC: mycec02
+         |__LPAR 1: node21
+         |__LPAR 2: node22
+         |__LPAR 3: node23
+         ......
+  
+   Management Module: mymm01
+   |__Blade 1: hs22n01
+      |__hs22n01vm1
+      |__hs22n01vm2
+   |__Blade 2: hs22n02
+      |__hs22n02vm1
+      |__hs22n02vm2
+   ......
+  
+   BMC: 192.168.0.1
+   |__Server: x3650n01
+      |__ x3650n01kvm1
+      |__ x3650n01kvm2
  
- BMC: 192.168.0.1
-  |__Server: x3650n01
-     |__ x3650n01kvm1
-     |__ x3650n01kvm2
  
 
 

--- a/docs/source/guides/admin-guides/references/man1/lsve.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/lsve.1.rst
@@ -19,7 +19,7 @@ SYNOPSIS
 ********
 
 
-\ **lsve**\  [\ **-t**\  type] [\ **-m**\  manager] [\ **-o**\  object]
+\ **lsve**\  [\ **-t**\  \ *type*\ ] [\ **-m**\  \ *manager*\ ] [\ **-o**\  \ *object*\ ]
 
 
 ***********
@@ -30,10 +30,10 @@ DESCRIPTION
 The \ **lsve**\  command can be used to list a virtual environment for 
 'Data Center', 'Cluster', 'Storage Domain', 'Network' and 'Template' objects.
 
-The mandatory parameter \ **-m manager**\  is used to specify the address of the 
+The mandatory parameter \ **-m**\  \ *manager*\  is used to specify the address of the 
 manager of virtual environment. xCAT needs it to access the RHEV manager.
 
-The mandatory parameter \ **-t type**\  is used to specify the type of the target 
+The mandatory parameter \ **-t**\  \ *type*\  is used to specify the type of the target 
 object.
 
 Basically, \ **lsve**\  command supports three types of object: \ **dc**\ , \ **cl**\ , \ **sd**\ , \ **nw**\  
@@ -98,7 +98,7 @@ EXAMPLES
  
  .. code-block:: perl
  
-   lsve -t B<dc> -m <FQDN of rhev manager> -o Default
+   lsve -t dc -m <FQDN of rhev manager> -o Default
  
  
  Output is similar to:
@@ -154,7 +154,7 @@ EXAMPLES
  
  .. code-block:: perl
  
-   lsve -t B<cl> -m <FQDN of rhev manager> -o Default
+   lsve -t cl -m <FQDN of rhev manager> -o Default
  
  
  Output is similar to:
@@ -175,21 +175,26 @@ EXAMPLES
  
  .. code-block:: perl
  
-   lsve -t B<sd> -m <FQDN of rhev manager> -o image
+   lsve -t sd -m <FQDN of rhev manager> -o image
  
  
  Output is similar to:
-   storagedomains: [image]
-     available: 55834574848
-     committed: 13958643712
-     ismaster: true
-     status:
-     storage_add: <Address of storage domain>
-     storage_format: v1
-     storage_path: /vfsimg
-     storage_type: nfs
-     type: data
-     used: 9663676416
+ 
+ 
+ .. code-block:: perl
+ 
+    storagedomains: [image]
+      available: 55834574848
+      committed: 13958643712
+      ismaster: true
+      status:
+      storage_add: <Address of storage domain>
+      storage_format: v1
+      storage_path: /vfsimg
+      storage_type: nfs
+      type: data
+      used: 9663676416
+ 
  
 
 
@@ -198,7 +203,7 @@ EXAMPLES
  
  .. code-block:: perl
  
-   lsve -t B<nw> -m <FQDN of rhev manager> -o rhevm
+   lsve -t nw -m <FQDN of rhev manager> -o rhevm
  
  
  Output is similar to:

--- a/docs/source/guides/admin-guides/references/man1/lsvlan.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/lsvlan.1.rst
@@ -23,9 +23,9 @@ SYNOPSIS
 
 \ **lsvlan**\  [\ *vlanid*\ ]
 
-\ **lsvlan**\  [\ **-h**\ |\ **--help**\ ]
+\ **lsvlan**\  [\ **-h | -**\ **-help**\ ]
 
-\ **lsvlan**\  [\ **-v**\ |\ **--version**\ ]
+\ **lsvlan**\  [\ **-v | -**\ **-version**\ ]
 
 
 ***********
@@ -37,7 +37,7 @@ The \ **lsvlan**\  command lists all the vlans for the cluster. If \ *vlanid*\  
 
 
 **********
-Parameters
+PARAMETERS
 **********
 
 
@@ -50,11 +50,11 @@ OPTIONS
 
 
 
-\ **-h|--help**\   Display usage message.
+\ **-h|-**\ **-help**\   Display usage message.
 
 
 
-\ **-v|--version**\   Command Version.
+\ **-v|-**\ **-version**\   Command Version.
 
 
 
@@ -75,9 +75,7 @@ EXAMPLES
 
 
 
-1.
- 
- To list all the vlans in the cluster
+1. To list all the vlans in the cluster
  
  
  .. code-block:: perl
@@ -86,13 +84,14 @@ EXAMPLES
  
  
  Output is similar to:
-   vlan 3:
-       subnet 10.3.0.0
-       netmask 255.255.0.0
  
  
  .. code-block:: perl
  
+    vlan 3:
+        subnet 10.3.0.0
+        netmask 255.255.0.0
+  
     vlan 4:
         subnet 10.4.0.0
         netmask 255.255.0.0
@@ -100,9 +99,7 @@ EXAMPLES
  
 
 
-2.
- 
- TO list the details for vlan3
+2. To list the details for vlan3
  
  
  .. code-block:: perl
@@ -111,13 +108,14 @@ EXAMPLES
  
  
  Output is similar to:
-   vlan 3
-       subnet 10.3.0.0
-       netmask 255.255.0.0
  
  
  .. code-block:: perl
  
+    vlan 3
+        subnet 10.3.0.0
+        netmask 255.255.0.0
+  
         hostname    ip address      node            vm host
         v3n1        10.3.0.1        c68m4hsp06
         v3n2        10.3.0.2        x3455n01

--- a/docs/source/guides/admin-guides/references/man1/lsvm.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/lsvm.1.rst
@@ -19,19 +19,19 @@ SYNOPSIS
 ********
 
 
-\ **lsvm**\  [\ **-h**\ | \ **--help]**\ 
+\ **lsvm**\  [\ **-h**\ | \ **-**\ **-help]**\ 
 
-\ **lsvm**\  [\ **-v**\ | \ **--version**\ ]
+\ **lsvm**\  [\ **-v**\ | \ **-**\ **-version**\ ]
 
-\ **lsvm**\  [\ **-V**\ | \ **--verbose**\ ] \ *noderange*\ 
+\ **lsvm**\  [\ **-V**\ | \ **-**\ **-verbose**\ ] \ *noderange*\ 
 
-\ **lsvm**\  [\ **-a**\ | \ **--all**\ ] \ *noderange*\ 
+\ **lsvm**\  [\ **-a**\ | \ **-**\ **-all**\ ] \ *noderange*\ 
 
 For PPC (using Direct FSP Management):
 ======================================
 
 
-\ **lsvm**\  [\ **-l**\ | \ **--long**\ ] \ **--p775**\  \ *noderange*\ 
+\ **lsvm**\  [\ **-l**\ | \ **-**\ **-long**\ ] \ **-**\ **-p775**\  \ *noderange*\ 
 
 \ **lsvm**\  \ *noderange*\ 
 
@@ -110,13 +110,13 @@ Verbose output.
 
 List all the profiles for one partition
 
-\ **--p775**\ 
+\ **-**\ **-p775**\ 
 
 Specify the operation is for Power 775 machines.
 
 \ **-l**\ 
 
-Show lparnames for lpars. It shall work with option \ **--p775**\ .
+Show lparnames for lpars. It shall work with option \ **-**\ **-p775**\ .
 
 
 ************
@@ -158,7 +158,7 @@ Output is similar to:
   lsvm cec01
 
 
-g Output is similar to:
+Output is similar to:
 
 
 .. code-block:: perl
@@ -186,7 +186,7 @@ Output is similar to:
   1: 512/U78A9.001.0123456-P1-C16/0x21010200/2/1
 
 
-To list the lparname of lpars, enter:
+4. To list the lparname of lpars, enter:
 
 
 .. code-block:: perl
@@ -195,11 +195,16 @@ To list the lparname of lpars, enter:
 
 
 Output is similar to:
- lpar1: 1: 514/U78A9.001.0123456-P1-C17/0x21010202/2/1
- lpar1: 1: 513/U78A9.001.0123456-P1-C15/0x21010201/2/1
- lpar1: 1: 512/U78A9.001.0123456-P1-C16/0x21010200/2/1
 
-4. For Power 775, to list the I/O slot information and octant configuration of cec1, enter:
+
+.. code-block:: perl
+
+  lpar1: 1: 514/U78A9.001.0123456-P1-C17/0x21010202/2/1
+  lpar1: 1: 513/U78A9.001.0123456-P1-C15/0x21010201/2/1
+  lpar1: 1: 512/U78A9.001.0123456-P1-C16/0x21010200/2/1
+
+
+5. For Power 775, to list the I/O slot information and octant configuration of cec1, enter:
 
 
 .. code-block:: perl
@@ -240,7 +245,7 @@ Output is similar to:
   OctantID=7,PendingOctCfg=1,CurrentOctCfg=1,PendingMemoryInterleaveMode=2,CurrentMemoryInterleaveMode=2;
 
 
-To list the lparname of lpars, enter:
+6.To list the lparname of lpars, enter:
 
 
 .. code-block:: perl
@@ -293,7 +298,7 @@ Output is similar to:
   Requested huge page memory(in pages):     15
 
 
-5. To list the virtual machine's directory entry:
+7. To list the virtual machine's directory entry:
 
 
 .. code-block:: perl
@@ -311,7 +316,7 @@ Output is similar to:
   gpok3: COMMAND SET VSWITCH VSW2 GRANT LNX3
 
 
-6. For DFM-managed normal power machine, list out the detailed resource information:
+8. For DFM-managed normal power machine, list out the detailed resource information:
 
 
 .. code-block:: perl
@@ -350,7 +355,7 @@ Output is similar to:
 
 Note: The lines list in "All Physical I/O info" section represent all the physical I/O resource information. The format is like "owner_lparid,slot_id,physical resource name,drc_index,slot_class_code(class discription)". The 'drc index' is short for Dynamic Resource Configuration Index, it uniquely indicate a physical I/O resource in normal power machine.
 
-For DFM-managed partition on normal power machine, list out the detailed information:
+9.For DFM-managed partition on normal power machine, list out the detailed information:
 
 
 .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man1/lsxcatd.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/lsxcatd.1.rst
@@ -19,7 +19,7 @@ SYNOPSIS
 ********
 
 
-\ **lsxcatd**\  [\ **-h**\  | \ **--help**\  | \ **-v**\  | \ **--version**\  | \ **-d**\  | \ **--database**\  |\ **-t**\  | \ **--nodetype**\  | \ **-a**\  | \ **--all**\  ]
+\ **lsxcatd**\  [\ **-h**\  | \ **-**\ **-help**\  | \ **-v**\  | \ **-**\ **-version**\  | \ **-d**\  | \ **-**\ **-database**\  | \ **-t**\  | \ **-**\ **-nodetype**\  | \ **-a**\  | \ **-**\ **-all**\  ]
 
 
 ***********
@@ -36,31 +36,31 @@ OPTIONS
 
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command Version.
  
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-d|--database**\ 
+\ **-d|-**\ **-database**\ 
  
  Displays information about the current database being used by xCAT.
  
 
 
-\ **-t|--nodetype**\ 
+\ **-t|-**\ **-nodetype**\ 
  
  Displays whether the node is a Management Node or a Service Node.
  
 
 
-\ **-a|--all**\ 
+\ **-a|-**\ **-all**\ 
  
  Displays all information about the daemon supported by the command.
  
@@ -119,13 +119,17 @@ EXAMPLES
  
  Output is similar to:
  
- Version 2.8.5 (git commit 0d4888af5a7a96ed521cb0e32e2c918a9d13d7cc, built Tue Jul 29 02:22:47 EDT 2014)
- This is a Management Node
- cfgloc=mysql:dbname=xcatdb;host=9.114.34.44|xcatadmin
- dbengine=mysql
- dbname=xcatdb
- dbhost=9.114.34.44
- dbadmin=xcatadmin
+ 
+ .. code-block:: perl
+ 
+   Version 2.8.5 (git commit 0d4888af5a7a96ed521cb0e32e2c918a9d13d7cc, built Tue Jul 29 02:22:47 EDT 2014)
+   This is a Management Node
+   cfgloc=mysql:dbname=xcatdb;host=9.114.34.44|xcatadmin
+   dbengine=mysql
+   dbname=xcatdb
+   dbhost=9.114.34.44
+   dbadmin=xcatadmin
+ 
  
 
 

--- a/docs/source/guides/admin-guides/references/man1/makentp.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/makentp.1.rst
@@ -11,11 +11,11 @@ SYNOPSIS
 ********
 
 
-\ *makentp [-h|--help]*\ 
+\ **makentp [-h|-**\ **-help]**\ 
 
-\ *makentp [-v|--version]*\ 
+\ **makentp [-v|-**\ **-version]**\ 
 
-\ *makentp [-a|--all] [-V|--verbose]*\ 
+\ **makentp [-a|-**\ **-all] [-V|-**\ **-verbose]**\ 
 
 
 ***********
@@ -23,7 +23,7 @@ DESCRIPTION
 ***********
 
 
-\ *makentp*\  command sets up the NTP server on the xCAT management node and the service node.
+\ **makentp**\  command sets up the NTP server on the xCAT management node and the service node.
 
 By default, it sets up the NTP server for xCAT management node. If -a flag is specified, the command will setup the ntp servers for management node as well as all the service nodes that have \ *servicenode.ntpserver*\  set. It honors the site table attributes \ *extntpservers*\  and \ *ntpservers*\  described below:
 
@@ -41,25 +41,25 @@ OPTIONS
 
 
 
-\ **-a|--all**\ 
+\ **-a|-**\ **-all**\ 
  
  Setup NTP servers for both management node and the service node.
  
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command Version.
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Verbose output.
  
@@ -82,19 +82,23 @@ EXAMPLES
 
 
 
-\*
+1. To setup NTP server on the management node:
  
- To setup NTP server on the management node:
  
- \ **makentp**\ 
+ .. code-block:: perl
+ 
+   makentp
+ 
  
 
 
-\*
+2. To setup NTP servers on both management node and the service node:
  
- To setup NTP servers on both management node and the service node:
  
- \ **setupntp**\  \ *-a*\ 
+ .. code-block:: perl
+ 
+   setupntp -a
+ 
  
 
 

--- a/docs/source/guides/admin-guides/references/man1/mkdef.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/mkdef.1.rst
@@ -19,12 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **mkdef**\  [\ **-h**\ |\ **--help**\ ] [\ **-t**\  \ *object-types*\ ]
+\ **mkdef**\  [\ **-h | -**\ **-help**\ ] [\ **-t**\  \ *object-types*\ ]
 
-\ **mkdef**\  [\ **-V**\ |\ **--verbose**\ ] [\ **-t**\  \ *object-types*\ ] [\ **-o**\  \ *object-names*\ ]
-[\ **-z**\ |\ **--stanza**\ ] [\ **-d**\ |\ **--dynamic**\ ] [\ **-f**\ |\ **--force**\ ]
-[[\ **-w**\  \ *attr*\ ==\ *val*\ ] [\ **-w**\  \ *attr*\ =~\ *val*\ ] ...] [\ *noderange*\ ] [\ *attr*\ =\ *val*\  [\ *attr*\ =\ *val...*\ ]]
-      [\ **-u**\  \ **provmethod**\ =<\ *install*\ |\ *netboot*\ |\ *statelite*\ > \ **profile**\ =<xxx> [\ *osvers*\ =\ *value*\ ] [\ *osarch*\ =\ *value*\ ]]
+\ **mkdef**\  [\ **-V | -**\ **-verbose**\ ] [\ **-t**\  \ *object-types*\ ] [\ **-o**\  \ *object-names*\ ] [\ **-z | -**\ **-stanza**\ ] [\ **-d | -**\ **-dynamic**\ ] [\ **-f | -**\ **-force**\ ] [[\ **-w**\  \ *attr*\ ==\ *val*\ ] [\ **-w**\  \ *attr*\ =~\ *val*\ ] ...] [\ *noderange*\ ] [\ *attr*\ =\ *val*\  [\ *attr*\ =\ *val...*\ ]] [\ **-u**\  \ **provmethod**\ ={\ **install**\  | \ **netboot**\  | \ **statelite**\ } \ **profile=**\  \ *xxx*\  [\ **osvers=**\  \ *value*\ ] [\ **osarch=**\  \ *value*\ ]]
 
 
 ***********
@@ -49,19 +46,19 @@ OPTIONS
  
 
 
-\ **-d|--dynamic**\ 
+\ **-d|-**\ **-dynamic**\ 
  
  Use the dynamic option to create dynamic node groups. This option must be used with -w option.
  
 
 
-\ **-f|--force**\ 
+\ **-f|-**\ **-force**\ 
  
  Use the force option to re-create object definitions. This option removes the old definition before creating the new one.
  
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  
@@ -85,7 +82,7 @@ OPTIONS
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Verbose mode.
  
@@ -105,7 +102,7 @@ OPTIONS
  
 
 
-\ **-z|--stanza**\ 
+\ **-z|-**\ **-stanza**\ 
  
  Indicates that the file being piped to the command is in stanza format.  See the xcatstanzafile man page for details on using xCAT stanza files.
  

--- a/docs/source/guides/admin-guides/references/man1/mkdocker.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/mkdocker.1.rst
@@ -19,11 +19,11 @@ SYNOPSIS
 ********
 
 
-\ **mkdocker**\  \ *noderange*\  [\ **image**\ =\ **image_name**\  [\ **command**\ =\ **command**\ ]] [\ **dockerflag**\ =\ **flags_to_create_instance**\ ]
+\ **mkdocker**\  \ *noderange*\  [\ **image**\ =\ *image_name*\  [\ **command**\ =\ *command*\ ]] [\ **dockerflag**\ =\ *flags_to_create_instance*\ ]
 
-\ **mkdocker**\  [\ **-h**\ |\ **--help**\ ]
+\ **mkdocker**\  [\ **-h | -**\ **-help**\ ]
 
-\ **mkdocker**\  {\ **-v**\ |\ **--version**\ }
+\ **mkdocker**\  {\ **-v | -**\ **-version**\ }
 
 
 ***********
@@ -31,7 +31,7 @@ DESCRIPTION
 ***********
 
 
-\ **rmdocker**\  To create docker instances with the specified image, command and/or dockerflags.
+\ **mkdocker**\  To create docker instances with the specified image, command and/or dockerflags.
 
 
 *******
@@ -59,31 +59,31 @@ OPTIONS
  Some useful flags are:
  
  
- \ **AttachStdin**\ =\ **true**\ |\ **false**\ 
+ \ **AttachStdin**\ =\ **true | false**\ 
   
   Whether attaches to stdin.
   
  
  
- \ **AttachStdout**\ =\ **true**\ |\ **false**\ 
+ \ **AttachStdout**\ =\ **true | false**\ 
   
   Whether attaches to stdout.
   
  
  
- \ **AttachStderr**\ =\ **true**\ |\ **false**\ 
+ \ **AttachStderr**\ =\ **true | false**\ 
   
   Whether attaches to stderr.
   
  
  
- \ **OpenStdin**\ =\ **true**\ |\ **false**\ 
+ \ **OpenStdin**\ =\ **true | false**\ 
   
   Whether opens stdin.
   
  
  
- \ **Tty**\ =\ **true**\ |\ **false**\ 
+ \ **Tty**\ =\ **true | false**\ 
   
   Attach standard streams to a tty, including stdin if it is not closed.
   
@@ -133,6 +133,13 @@ EXAMPLES
 .. code-block:: perl
 
      mkdocker host01c01 image=ubuntu command=/bin/bash dockerflag="{\"AttachStdin\":true,\"AttachStdout\":true,\"AttachStderr\":true,\"OpenStdin\":true}"
+
+
+Output is similar to:
+
+
+.. code-block:: perl
+
      host01c01: success
 
 
@@ -142,6 +149,13 @@ EXAMPLES
 .. code-block:: perl
 
      mkdocker host01c01 image=ubuntu command=/bin/bash dockerflag="{\"AttachStdin\":true,\"AttachStdout\":true,\"AttachStderr\":true,\"OpenStdin\":true,\"NetworkDisabled\":ture}"
+
+
+Output is similar to:
+
+
+.. code-block:: perl
+
      host01c01: success
 
 
@@ -151,6 +165,13 @@ EXAMPLES
 .. code-block:: perl
 
      mkdocker host01c01 image=ubuntu command=/bin/bash dockerflag="{\"AttachStdin\":true,\"AttachStdout\":true,\"AttachStderr\":true,\"OpenStdin\":true,\"Tty\":true,\"HostConfig\":{\"Binds\":[\"/srcdir:/destdir\"]}}"
+
+
+Output is similar to:
+
+
+.. code-block:: perl
+
      host01c01: success
 
 

--- a/docs/source/guides/admin-guides/references/man1/mkdsklsnode.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/mkdsklsnode.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **mkdsklsnode [-h|--help ]**\ 
+\ **mkdsklsnode [-h|-**\ **-help ]**\ 
 
-\ **mkdsklsnode [-V|--verbose] [-f|--force] [-n|--newname] [-i osimage_name] [-l location] [-u|--updateSN] [-k|--skipsync] [-p|--primarySN] [-b|--backupSN] [-S|--setuphanfs] noderange [attr=val [attr=val ...]]**\ 
+\ **mkdsklsnode [-V|-**\ **-verbose] [-f|-**\ **-force] [-n|-**\ **-newname] [-i**\  \ *osimage_name*\ ] [\ **-l**\  \ *location*\ ] [\ **-u | -**\ **-updateSN**\ ] [\ **-k | -**\ **-skipsync**\ ] [\ **-p | -**\ **-primarySN**\ ] [\ **-b | -**\ **-backupSN**\ ] [\ **-S | -**\ **-setuphanfs**\ ] \ *noderange*\  [\ *attr=val [attr=val ...]*\ ]
 
 
 ***********
@@ -70,7 +70,7 @@ OPTIONS
 
 
 
-\ **attr=val [attr=val ...]**\ 
+\ *attr=val [attr=val ...]*\ 
  
  Specifies one or more "attribute equals value" pairs, separated by spaces. Attr=
  val pairs must be specified last on the command line. These are used to specify additional values that can be passed to the underlying NIM commands.
@@ -123,73 +123,73 @@ OPTIONS
  
 
 
-\ **-b |--backupSN**\ 
+\ **-b |-**\ **-backupSN**\ 
  
  When using backup service nodes only update the backup.  The default is to update both the primary and backup service nodes.
  
 
 
-\ **-f |--force**\ 
+\ **-f |-**\ **-force**\ 
  
  Use the force option to reinitialize the NIM machines.
  
 
 
-\ **-h |--help**\ 
+\ **-h |-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-i image_name**\ 
+\ **-i**\  \ *image_name*\ 
  
  The name of an existing xCAT osimage definition. If this information is not provided on the command line the code checks the node definition for the value of the "provmethod" attribute. If the "-i" value is provided on the command line then that value will be used to set the "provmethod" attribute of the node definitions.
  
 
 
-\ **-k|--skipsync**\ 
+\ **-k|-**\ **-skipsync**\ 
  
  Use this option to have the mkdsklsnode command skip the NIM sync_roots operation.  This option should only be used if you are certain that the shared_root resource does not have to be updated from the SPOT.  Normally, when the SPOT is updated, you should do a sync_roots on the shared_root resource.
  
 
 
-\ **-l|--location**\ 
+\ **-l|-**\ **-location**\ 
  
  The directory location to use when creating new NIM resolv_conf resources. The default location is /install/nim.
  
 
 
-\ **-n|--newname**\ 
+\ **-n|-**\ **-newname**\ 
  
  Create a new NIM machine object name for the xCAT node. Use the naming convention "<xcat_node_name>_<image_name>" for the new NIM machine definition.
  
 
 
-\ **-p|--primarySN**\ 
+\ **-p|-**\ **-primarySN**\ 
  
  When using backup service nodes only update the primary.  The default is to update both the primary and backup service nodes.
  
 
 
-\ **-S|--setuphanfs**\ 
+\ **-S|-**\ **-setuphanfs**\ 
  
  Setup NFSv4 replication between the primary service nodes and backup service nodes to provide high availability NFS for the compute nodes. This option only exports the /install directory with NFSv4 replication settings, the data synchronization between the primary service nodes and backup service nodes needs to be taken care of through some mechanism.
  
 
 
-\ **-u|--updateSN**\ 
+\ **-u|-**\ **-updateSN**\ 
  
  Use this option if you wish to update the osimages but do not want to define or initialize the NIM client definitions. This option is only valid when the xCAT "site" definition attribute "sharedinstall" is set to either "sns" or "all".
  
 
 
-\ **noderange**\ 
+\ *noderange*\ 
  
  A set of comma delimited node names and/or group names. See the "noderange" man page for details on additional supported formats.
  
 
 
-\ **-V |--verbose**\ 
+\ **-V |-**\ **-verbose**\ 
  
  Verbose mode.
  
@@ -202,16 +202,12 @@ RETURN VALUE
 
 
 
-0
- 
- The command completed successfully.
- 
+0 The command completed successfully.
 
 
-1
- 
- An error has occurred.
- 
+
+1 An error has occurred.
+
 
 
 
@@ -221,35 +217,45 @@ EXAMPLES
 
 
 
-1
+1. Initialize an xCAT node named "node01" as an AIX diskless machine.  The xCAT osimage named "61spot" should be used to boot the node.
  
- Initialize an xCAT node named "node01" as an AIX diskless machine.  The xCAT osimage named "61spot" should be used to boot the node.
  
- \ **mkdsklsnode -i 61spot node01**\ 
+ .. code-block:: perl
  
-
-
-2
+   mkdsklsnode -i 61spot node01
  
- Initialize all AIX diskless nodes contained in the xCAT node group called "aixnodes" using the image definitions pointed to by the "provmethod" attribute of the xCAT node definitions.
- 
- \ **mkdsklsnode aixnodes**\ 
  
 
 
-3
+2. Initialize all AIX diskless nodes contained in the xCAT node group called "aixnodes" using the image definitions pointed to by the "provmethod" attribute of the xCAT node definitions.
  
- Initialize diskless node "clstrn29" using the xCAT osimage called "61dskls".  Also set the paging size to be 128M and specify the paging file be an AIX sparse file.
  
- \ **mkdsklsnode -i 61dskls clstrn29 psize=128 sparse_paging=yes**\ 
+ .. code-block:: perl
+ 
+   mkdsklsnode aixnodes
+ 
  
 
 
-4
+3. Initialize diskless node "clstrn29" using the xCAT osimage called "61dskls".  Also set the paging size to be 128M and specify the paging file be an AIX sparse file.
+ 
+ 
+ .. code-block:: perl
+ 
+   mkdsklsnode -i 61dskls clstrn29 psize=128 sparse_paging=yes
+ 
+ 
+
+
+4.
  
  Initialize an xCAT node called "node02" as an AIX diskless node.  Create a new NIM machine definition name with the osimage as an extension to the xCAT node name.
  
- \ **mkdsklsnode -n -i 61spot node02**\ 
+ 
+ .. code-block:: perl
+ 
+   mkdsklsnode -n -i 61spot node02
+ 
  
 
 

--- a/docs/source/guides/admin-guides/references/man1/mkflexnode.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/mkflexnode.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **mkflexnode**\  [-h | --help]
+\ **mkflexnode**\  [\ **-h**\  | \ **-**\ **-help**\ ]
 
-\ **mkflexnode**\  [-v | --version]
+\ **mkflexnode**\  [\ **-v**\  | \ **-**\ **-version**\ ]
 
 \ **mkflexnode**\  \ *noderange*\ 
 
@@ -48,13 +48,13 @@ OPTIONS
 
 
 
-\ **-h | --help**\ 
+\ **-h | -**\ **-help**\ 
  
  Display the usage message.
  
 
 
-\ **-v | --version**\ 
+\ **-v | -**\ **-version**\ 
  
  Display the version information.
  
@@ -67,9 +67,7 @@ EXAMPLES
 
 
 
-1
- 
- Create a flexible node base on the xCAT node blade1.
+1. Create a flexible node base on the xCAT node blade1.
  
  The blade1 should belong to a complex, the \ *id*\  attribute should be set correctly and all the slots should be in \ **power off**\  state.
  

--- a/docs/source/guides/admin-guides/references/man1/mkhwconn.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/mkhwconn.1.rst
@@ -19,26 +19,26 @@ SYNOPSIS
 ********
 
 
-\ **mkhwconn**\  [\ **-h**\ | \ **--help**\ ]
+\ **mkhwconn**\  [\ **-h**\ | \ **-**\ **-help**\ ]
 
-\ **mkhwconn**\  [\ **-v**\ | \ **--version**\ ]
+\ **mkhwconn**\  [\ **-v**\ | \ **-**\ **-version**\ ]
 
 PPC (with HMC) specific:
 ========================
 
 
-\ **mkhwconn**\  [\ **-V**\ | \ **--verbose**\ ] \ *noderange*\  \ **-t**\  [\ **--port**\  \ *port_value*\ ]
+\ **mkhwconn**\  [\ **-V**\ | \ **-**\ **-verbose**\ ] \ *noderange*\  \ **-t**\  [\ **-**\ **-port**\  \ *port_value*\ ]
 
-\ **mkhwconn**\  [\ **-V**\ | \ **--verbose**\ ] \ *noderange*\  \ **-s**\  [\ *hmcnode*\  \ **--port**\  \ *port_value*\ ]
+\ **mkhwconn**\  [\ **-V**\ | \ **-**\ **-verbose**\ ] \ *noderange*\  \ **-s**\  [\ *hmcnode*\  \ **-**\ **-port**\  \ *port_value*\ ]
 
-\ **mkhwconn**\  [\ **-V**\ | \ **--verbose**\ ] \ *noderange*\  \ **-p**\  \ *hmc*\  [\ **-P**\  \ *passwd*\ ] [\ **--port**\  \ *port_value*\ ]
+\ **mkhwconn**\  [\ **-V**\ | \ **-**\ **-verbose**\ ] \ *noderange*\  \ **-p**\  \ *hmc*\  [\ **-P**\  \ *passwd*\ ] [\ **-**\ **-port**\  \ *port_value*\ ]
 
 
 PPC (using Direct FSP Management) specific:
 ===========================================
 
 
-\ **mkhwconn**\  \ *noderange*\  \ **-t**\  [\ **-T tooltype**\ ] [\ **--port**\  \ *port_value*\ ]
+\ **mkhwconn**\  \ *noderange*\  \ **-t**\  [\ **-T tooltype**\ ] [\ **-**\ **-port**\  \ *port_value*\ ]
 
 
 
@@ -68,7 +68,7 @@ For PPC (using Direct FSP Management) specific:
 
 It is used to set up connections for CEC and Frame node to Hardware Server on management node (or service node ). It only could be done according to the node definition in xCAT DB. And this command will try to read the user/password from the ppcdirect table first. If fails, then read them from passwd table. Commonly , the username is \ **HMC**\ . If using the \ **ppcdirect**\  table,  each CEC/Frame and user/password should be  stored in \ **ppcdirect**\  table. If using the \ **passwd**\  table, the key should be "\ **cec**\ " or "\ **frame**\ ", and the related user/password are stored in \ **passwd**\  table.
 
-When \ **--port**\  is specified, this command will create the connections for CECs/Frames whose side in \ **vpd**\  table is equal to port value.
+When \ **-**\ **-port**\  is specified, this command will create the connections for CECs/Frames whose side in \ **vpd**\  table is equal to port value.
 
 
 *******
@@ -77,7 +77,7 @@ OPTIONS
 
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  
@@ -108,7 +108,7 @@ OPTIONS
  
 
 
-\ **--port**\ 
+\ **-**\ **-port**\ 
  
  The port value specifies which special side will be used to create the connection to the CEC/Frame. The value could only be specified as "\ **0**\ " or "\ **1**\ " and the default value is "\ **0,1**\ ". If the user wants to use all ports to create the connection, he should not specify this value. If the port value is specified as "\ **0**\ ", in the vpd table, the side column should be \ **A-0**\  and \ **B-0**\ ; If the port value is specified as "\ **1**\ ", the side column should be \ **A-1**\  and \ **B-1**\ . When making hardware connection between CEC/Frame and HMC, the value is used to specify the fsp/bpa port of the cec/frame and will be organized in order of "\ **A-0,A-1,B-0,B-1**\ ". If any side does not exist, the side would simply be ignored. Generally, only one port of a fsp/bap can be connected while another port be used as backup.
  
@@ -120,7 +120,7 @@ OPTIONS
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Verbose output.
  

--- a/docs/source/guides/admin-guides/references/man1/mknimimage.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/mknimimage.1.rst
@@ -19,11 +19,11 @@ SYNOPSIS
 ********
 
 
-\ **mknimimage [-h | --help ]**\ 
+\ **mknimimage [-h | -**\ **-help ]**\ 
 
-\ **mknimimage [-V] -u osimage_name [attr=val [attr=val ...]]**\ 
+\ **mknimimage [-V] -u**\  \ *osimage_name [attr=val [attr=val ...]*\ ]
 
-\ **mknimimage [-V] [-f|--force] [-r|--sharedroot] [-D|--mkdumpres] [-l location] [-c|--completeosimage] [-s image_source] [-i current_image] [-p|--cplpp] [-t nimtype] [-m nimmethod] [-n mksysbnode] [-b mksysbfile] osimage_name [attr=val [attr=val ...]]**\ 
+\ **mknimimage [-V] [-f|-**\ **-force] [-r|-**\ **-sharedroot] [-D|-**\ **-mkdumpres] [-l**\  \ *location*\ ] [\ **-c | -**\ **-completeosimage**\ ] [\ **-s**\  \ *image_source*\ ] [\ **-i**\  \ *current_image*\ ] [\ **-p | -**\ **-cplpp**\ ] [\ **-t**\  \ *nimtype*\ ] [\ **-m**\  \ *nimmethod*\ ] [\ **-n**\  \ *mksysbnode*\ ] [\ **-b**\  \ *mksysbfile*\ ] \ *osimage_name*\  [\ *attr=val [attr=val ...]*\ ]
 
 
 ***********
@@ -94,7 +94,7 @@ OPTIONS
 
 
 
-\ **attr=val [attr=val ...]**\ 
+\ *attr=val [attr=val ...]*\ 
  
  Specifies one or more "attribute equals value" pairs, separated by spaces. Attr=val pairs must be specified last on the command line.
  
@@ -259,79 +259,79 @@ OPTIONS
  
 
 
-\ **-b mksysbfile**\ 
+\ **-b**\  \ *mksysbfile*\ 
  
  Used to specify the path name of a mksysb file to use when defining a NIM mksysb resource.
  
 
 
-\ **-c|--completeosimage**\ 
+\ **-c|-**\ **-completeosimage**\ 
  
  Complete the creation of the osimage definition passed in on the command line. This option will use any additonal values passed in on the command line and/or it will attempt to create required resources in order to complete the definition of the xCAT osimage.  For example, if the osimage definition is missing a spot or shared_root resource the command will create those resources and add them to the osimage definition.
  
 
 
-\ **-f|--force**\ 
+\ **-f|-**\ **-force**\ 
  
  Use the force option to re-create xCAT osimage definition. This option removes the old definition before creating the new one. It does not remove any of the NIM resource definitions named in the osimage definition.  Use the \ **rmnimimage**\  command to remove the NIM resources associated with an xCAT osimage definition.
  
 
 
-\ **-h |--help**\ 
+\ **-h |-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **osimage_name**\ 
+\ *osimage_name*\ 
  
  The name of the xCAT osimage definition.  This will be used as the name of the xCAT osimage definition as well as the name of the NIM SPOT resource.
  
 
 
-\ **-D|--mkdumpres**\ 
+\ **-D|-**\ **-mkdumpres**\ 
  
  Create a diskless dump resource.
  
 
 
-\ **-i current_image**\ 
+\ **-i**\  \ *current_image*\ 
  
  The name of an existing xCAT osimage that should be copied to make a new xCAT osimage definition. Only valid when defining a "diskless" or "dataless" type image.
  
 
 
-\ **-l location**\ 
+\ **-l**\  \ *location*\ 
  
  The directory location to use when creating new NIM resources. The default location is /install/nim.
  
 
 
-\ **-m nimmethod**\ 
+\ **-m**\  \ *nimmethod*\ 
  
  Used to specify the NIM installation method to use. The possible values are "rte" and "mksysb". The default is "rte".
  
 
 
-\ **-n mksysbnode**\ 
+\ **-n**\  \ *mksysbnode*\ 
  
  The xCAT node to use to create a mksysb image.  The node must be a defined as a NIM client machine.
  
 
 
-\ **-p|--cplpp**\ 
+\ **-p|-**\ **-cplpp**\ 
  
  Use this option when copying existing diskless osimages to indicate that you also wish to have the lpp_resource copied.  This option is only valid when using the "-i" option.
  
 
 
-\ **-r|--sharedroot**\ 
+\ **-r|-**\ **-sharedroot**\ 
  
  Use this option to specify that a NIM "shared_root" resource be created for the AIX diskless nodes.  The default is to create a NIM "root" resource.  This feature is only available when using AIX version 6.1.4 or beyond. See the AIX/NIM documentation for a description of the "root" and "shared_root" resources.
  
 
 
-\ **-s image_source**\ 
+\ **-s**\  \ *image_source*\ 
  
  The source of software to use when creating the new NIM lpp_source resource. This could be a source directory or a previously defined NIM lpp_source resource name.
  
@@ -349,7 +349,7 @@ OPTIONS
  
 
 
-\ **-V |--verbose**\ 
+\ **-V |-**\ **-verbose**\ 
  
  Verbose mode.
  
@@ -362,16 +362,12 @@ RETURN VALUE
 
 
 
-0
- 
- The command completed successfully.
- 
+0. The command completed successfully.
 
 
-1
- 
- An error has occurred.
- 
+
+1. An error has occurred.
+
 
 
 
@@ -382,73 +378,129 @@ EXAMPLES
 
 1) Create an osimage definition and the basic NIM resources needed to do a NIM "standalone" "rte" installation of node "node01".  Assume the software contained on the AIX product media has been copied to the /AIX/instimages directory.
 
-\ **mknimimage -s /AIX/instimages  61image**\ 
+
+.. code-block:: perl
+
+  mknimimage -s /AIX/instimages  61image
+
 
 2) Create an osimage definition that includes some additional NIM resources.
 
-\ **mknimimage -s /AIX/instimages 61image installp_bundle=mybndlres,addswbnd**\ 
+
+.. code-block:: perl
+
+  mknimimage -s /AIX/instimages 61image installp_bundle=mybndlres,addswbnd
+
 
 This command will create lpp_source, spot, and bosinst_data resources using the source specified by the "-s" option.  The installp_bundle information will also be included in the osimage definition.  The mybndlres and addswbnd resources must be created before using this osimage definition to install a node.
 
 3) Create an osimage definition that includes a mksysb image and related resources.
 
-\ **mknimimage -m mksysb -n node27 newsysb spot=myspot bosinst_data=mybdata**\ 
+
+.. code-block:: perl
+
+  mknimimage -m mksysb -n node27 newsysb spot=myspot bosinst_data=mybdata
+
 
 This command will use node27 to create a mksysb backup image and use that to define a NIM mksysb resource. The osimage definition will contain the name of the mksysb resource as well as the spot and bosinst_data resource.
 
 4) Create an osimage definition using a mksysb image provided on the command line.
 
-\ **mknimimage -m mksysb -b /tmp/backups/mysysbimage newsysb spot=myspot bosinst_data=mybdata**\ 
+
+.. code-block:: perl
+
+  mknimimage -m mksysb -b /tmp/backups/mysysbimage newsysb spot=myspot bosinst_data=mybdata
+
 
 This command defines a NIM mksysb resource using mysysbimage.
 
 5) Create an osimage definition and create the required spot definition using the mksysb backup file provided on the command line.
 
-\ **mknimimage -m mksysb -b /tmp/backups/mysysbimage newsysb bosinst_data=mybdata**\ 
+
+.. code-block:: perl
+
+  mknimimage -m mksysb -b /tmp/backups/mysysbimage newsysb bosinst_data=mybdata
+
 
 This command defines a NIM mksysb resource and a spot definition using mysysbimage.
 
 6) Create a diskless image called 61dskls using the AIX source files provided in the /AIX/instimages directory.
 
-\ **mknimimage -t diskless -s /AIX/instimages 61dskls**\ 
+
+.. code-block:: perl
+
+  mknimimage -t diskless -s /AIX/instimages 61dskls
+
 
 7) Create a diskless image called "614dskls" that includes a NIM "shared_root" and a "dump" resource.  Use the existing NIM lpp_resource called "614_lpp_source". Also specify verbose output.
 
-\ **mknimimage -V -r -D -t diskless -s 614_lpp_source 614dskls snapcollect=yes**\ 
+
+.. code-block:: perl
+
+  mknimimage -V -r -D -t diskless -s 614_lpp_source 614dskls snapcollect=yes
+
 
 The "snapcollect" attribute specifies that AIX "snap" data should be include when a system dump is initiated.
 
 8) Create a new diskless image by copying an existing image.
 
-\ **mknimimage -t diskless -i 61cosi 61cosi_updt1**\ 
+
+.. code-block:: perl
+
+  mknimimage -t diskless -i 61cosi 61cosi_updt1
+
 
 Note:  If you also wish to have the original lpp_source copied and defined use the -p option.
 
-\ **mknimimage -t diskless -i 61cosi -p 61cosi_updt1**\ 
+
+.. code-block:: perl
+
+  mknimimage -t diskless -i 61cosi -p 61cosi_updt1
+
 
 9) Create a diskless image using an existing lpp_source resource named "61cosi_lpp_source" and include NIM tmp and home resources.  This assumes that the "mytmp" and "myhome" NIM resources have already been created by using NIM commands.
 
-\ **mknimimage -t diskless -s 61cosi_lpp_source 611cosi tmp=mytmp home=myhome**\ 
+
+.. code-block:: perl
+
+  mknimimage -t diskless -s 61cosi_lpp_source 611cosi tmp=mytmp home=myhome
+
 
 10) Create a diskless image and update it with additional software using rpm flags and configuration files.
 
-\ **mknimimage -t diskless -s 61cosi_lpp_source 61dskls otherpkgs=I:fset1,R:foo.rpm,E:IZ38930TL0.120304.epkg.Z synclists=/install/mysyncfile rpm_flags="-i --nodeps"**\ 
+
+.. code-block:: perl
+
+  mknimimage -t diskless -s 61cosi_lpp_source 61dskls otherpkgs=I:fset1,R:foo.rpm,E:IZ38930TL0.120304.epkg.Z synclists=/install/mysyncfile rpm_flags="-i --nodeps"
+
 
 The xCAT osimage definition created by this command will include the "otherpkgs" and "synclists" values.  The NIM SPOT resource associated with this osimage will be updated with the additional software using rpm flags "-i --nodeps" and configuration files.
 
 11) Update an existing diskless image (AIX/NIM SPOT) using the information saved in the xCAT "61dskls" osimage definition. Also specify verbose messages.
 
-\ **mknimimage -V -u 61dskls**\ 
+
+.. code-block:: perl
+
+  mknimimage -V -u 61dskls
+
 
 12) Update an existing diskless image called "61dskls".  Install the additional software specified in the NIM "bndres1" and "bndres2" installp_bundle resources using the installp flags "-agcQX".  (The NIM "bndres1" and "bndres2" definitions must be created before using them in this command.)
 
-\ **mknimimage -u 61dskls installp_bundle=bndres1,bndres2 installp_flags="-agcQX"**\ 
+
+.. code-block:: perl
+
+  mknimimage -u 61dskls installp_bundle=bndres1,bndres2 installp_flags="-agcQX"
+
 
 Note that when "installp_bundle", "otherpkgs", or "synclists" values are specified with the "-u" option then the xCAT osimage definiton is not used or updated.
 
 13) Update an existing image to support NFSv4. Also specify verbose messages.
 
-\ **mknimimage -V -u 61dskls nfs_vers=4**\ 
+
+.. code-block:: perl
+
+  mknimimage -V -u 61dskls nfs_vers=4
+
 
 
 *****

--- a/docs/source/guides/admin-guides/references/man1/mkvlan.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/mkvlan.1.rst
@@ -19,11 +19,11 @@ SYNOPSIS
 ********
 
 
-\ **mkvlan**\  [\ *vlanid*\ ] \ **-n**\ |\ **--nodes**\  \ *noderange*\  [\ **-t**\ |\ **--net**\  \ *subnet*\ ] [\ **-m**\ |\ **--mask**\  \ *netmask*\ ] [\ **-p**\ |\ **--prefix**\  \ *hostname_prefix*\ ] [\ **-i**\ |\ **--interface**\  \ *nic*\ ]
+\ **mkvlan**\  [\ *vlanid*\ ] \ **-n | -**\ **-nodes**\  \ *noderange*\  [\ **-t | -**\ **-net**\  \ *subnet*\ ] [\ **-m | -**\ **-mask**\  \ *netmask*\ ] [\ **-p | -**\ **-prefix**\  \ *hostname_prefix*\ ] [\ **-i | -**\ **-interface**\  \ *nic*\ ]
 
-\ **mkvlan**\  [\ **-h**\ |\ **--help**\ ]
+\ **mkvlan**\  [\ **-h | -**\ **-help**\ ]
 
-\ **mkvlan**\  [\ **-v**\ |\ **--version**\ ]
+\ **mkvlan**\  [\ **-v | -**\ **-version**\ ]
 
 
 ***********
@@ -70,7 +70,7 @@ For added security, the root guard and bpdu guard will be enabled for the ports 
 
 
 **********
-Parameters
+PARAMETERS
 **********
 
 
@@ -83,31 +83,31 @@ OPTIONS
 
 
 
-\ **-n|--nodes**\      The nodes or groups to be included in the vlan. It can be stand alone nodes or KVM guests. It takes the noderange format. Please check the man page for noderange for details.
+\ **-n|-**\ **-nodes**\      The nodes or groups to be included in the vlan. It can be stand alone nodes or KVM guests. It takes the noderange format. Please check the man page for noderange for details.
 
 
 
-\ **-t|--net**\        The subnet for the vlan.
+\ **-t|-**\ **-net**\        The subnet for the vlan.
 
 
 
-\ **-m|--mask**\       The netmask for the vlan
+\ **-m|-**\ **-mask**\       The netmask for the vlan
 
 
 
-\ **-p|--prefix**\     The prefix the the new hostnames for the nodes in the vlan.
+\ **-p|-**\ **-prefix**\     The prefix the the new hostnames for the nodes in the vlan.
 
 
 
-\ **-i|--interface**\  The interface name where the vlan will be tagged on. If omitted, the xCAT management network will be assumed. For FVM, this is the interface name on the host.
+\ **-i|-**\ **-interface**\  The interface name where the vlan will be tagged on. If omitted, the xCAT management network will be assumed. For FVM, this is the interface name on the host.
 
 
 
-\ **-h|--help**\       Display usage message.
+\ **-h|-**\ **-help**\       Display usage message.
 
 
 
-\ **-v|--version**\    The Command Version.
+\ **-v|-**\ **-version**\    The Command Version.
 
 
 
@@ -174,7 +174,7 @@ The following is an example of the switches table
 
 3.
  
- TO make a private vlan for node1, node2 with given subnet and netmask.
+ To make a private vlan for node1, node2 with given subnet and netmask.
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man1/mkvm.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/mkvm.1.rst
@@ -23,45 +23,43 @@ Common:
 =======
 
 
-\ **mkvm**\  [\ **-h**\ | \ **--help**\ ]
+\ **mkvm**\  [\ **-h**\ | \ **-**\ **-help**\ ]
 
-\ **mkvm**\  [\ **-v**\ | \ **--version**\ ]
+\ **mkvm**\  [\ **-v**\ | \ **-**\ **-version**\ ]
 
 
 For PPC (with HMC) specific:
 ============================
 
 
-\ **mkvm**\  [\ **-V**\ | \ **--verbose**\ ] \ *noderange*\  \ **-i**\  \ *id*\  \ **-l**\  \ *singlenode*\ 
+\ **mkvm**\  [\ **-V**\ | \ **-**\ **-verbose**\ ] \ *noderange*\  \ **-i**\  \ *id*\  \ **-l**\  \ *singlenode*\ 
 
-\ **mkvm**\  [\ **-V**\ | \ **--verbose**\ ] \ *noderange*\  \ **-c**\  \ *destcec*\  \ **-p**\  \ *profile*\ 
+\ **mkvm**\  [\ **-V**\ | \ **-**\ **-verbose**\ ] \ *noderange*\  \ **-c**\  \ *destcec*\  \ **-p**\  \ *profile*\ 
 
-\ **mkvm**\  [\ **-V**\ | \ **--verbose**\ ] \ *noderange*\  \ **--full**\ 
+\ **mkvm**\  [\ **-V**\ | \ **-**\ **-verbose**\ ] \ *noderange*\  \ **-**\ **-full**\ 
 
 
 For PPC (using Direct FSP Management) specific:
 ===============================================
 
 
-\ **mkvm**\  \ *noderange*\  [\ **--full**\ ]
+\ **mkvm**\  \ *noderange*\  [\ **-**\ **-full**\ ]
 
-\ **mkvm**\  \ *noderange*\  [\ **vmcpus=min/req/max**\ ] [\ **vmmemory=min/req/max**\ ]
-               [\ **vmphyslots=drc_index1,drc_index2...**\ ] [\ **vmothersetting=hugepage:N,bsr:N**\ ]
-               [\ **vmnics=vlan1[,vlan2..]]**\  [\ **vmstorage=<N|viosnode:slotid**\ >] [\ **--vios**\ ]
+\ **mkvm**\  \ *noderange*\  [\ **vmcpus=**\  \ *min/req/max*\ ] [\ **vmmemory=**\  \ *min/req/max*\ ] [\ **vmphyslots=**\  \ *drc_index1,drc_index2...*\ ] [\ **vmothersetting=**\  \ *hugepage:N,bsr:N*\ ] [\ **vmnics=**\  \ *vlan1[,vlan2..]*\ ] [\ **vmstorage=**\  \ *N|viosnode:slotid*\ ] [\ **-**\ **-vios**\ ]
 
 
 For KVM:
 ========
 
 
-\ **mkvm**\  \ *noderange*\  [\ **-m|--master**\  \ *mastername*\ ] [\ **-s|--size**\  \ *disksize*\ ] [\ **--mem**\  \ *memsize*\ ] [\ **--cpus**\  \ *cpucount*\ ] [\ **-f|--force**\ ]
+\ **mkvm**\  \ *noderange*\  [\ **-m|-**\ **-master**\  \ *mastername*\ ] [\ **-s|-**\ **-size**\  \ *disksize*\ ] [\ **-**\ **-mem**\  \ *memsize*\ ] [\ **-**\ **-cpus**\  \ *cpucount*\ ] [\ **-f|-**\ **-force**\ ]
 
 
 For Vmware:
 ===========
 
 
-\ **mkvm**\  \ *noderange*\  [\ **-s**\ |\ **--size**\  \ *disksize*\ ] [\ **--mem**\  \ *memsize*\ ] [\ **--cpus**\  \ *cpucount*\ ]
+\ **mkvm**\  \ *noderange*\  [\ **-s | -**\ **-size**\  \ *disksize*\ ] [\ **-**\ **-mem**\  \ *memsize*\ ] [\ **-**\ **-cpus**\  \ *cpucount*\ ]
 
 
 For zVM:
@@ -107,7 +105,7 @@ For KVM and Vmware:
 
 The mkvm command creates new virtual machine(s) with the \ *disksize*\  size of hard disk, \ *memsize*\  size of memory and \ *cpucount*\  number of cpu.
 
-For KVM: If \ **-f**\ |\ **--force**\  is specified, the storage will be destroyed first if it existed.
+For KVM: If \ **-f | -**\ **-force**\  is specified, the storage will be destroyed first if it existed.
 
 
 For zVM:
@@ -126,7 +124,7 @@ OPTIONS
 
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  
@@ -138,19 +136,19 @@ OPTIONS
  
 
 
-\ **--cpus**\ 
+\ **-**\ **-cpus**\ 
  
  The cpu count which will be created for the kvm/vmware virtual machine.
  
 
 
-\ **--full**\ 
+\ **-**\ **-full**\ 
  
  Request to create a new full system partition for each CEC.
  
 
 
-\ **vmcpus=value**\  \ **vmmemory=value**\  \ **vmphyslots=value**\  \ **vmothersetting=value**\  \ **vmnics=value**\  \ **vmstorage=value**\  [\ **--vios**\ ]
+\ **vmcpus=**\  \ *value*\  \ **vmmemory=**\  \ *value*\  \ **vmphyslots=**\  \ *value*\  \ **vmothersetting=**\  \ *value*\  \ **vmnics=**\  \ *value*\  \ **vmstorage=**\  \ *value*\  [\ **-**\ **-vios**\ ]
  
  To specify the parameters which are used to create a partition. The \ *vmcpus*\ , \ *vmmemory*\  are necessay, and the value specified with this command have a more high priority. If the value of any of the three options is not specified, the corresponding value specified for the node object will be used. If any of the three attributes is neither specified with this command nor specified with the node object, error information will be returned. To reference to lsvm(1)|lsvm.1 for more information about 'drc_index' for \ *vmphyslots*\ .
  
@@ -158,9 +156,9 @@ OPTIONS
  
 
 
-\ **-f|--force**\ 
+\ **-f|-**\ **-force**\ 
  
- If \ **-f|--force**\  is specified, the storage will be destroyed first if it existed.
+ If \ **-f|-**\ **-force**\  is specified, the storage will be destroyed first if it existed.
  
 
 
@@ -176,7 +174,7 @@ OPTIONS
  
 
 
-\ **--mem**\ 
+\ **-**\ **-mem**\ 
  
  The memory size which will be used for the new created kvm/vmware virtual machine. Unit is Megabyte.
  
@@ -188,19 +186,19 @@ OPTIONS
  
 
 
-\ **-s|--size**\ 
+\ **-s|-**\ **-size**\ 
  
  The size of storage which will be created for the kvm/vmware virtual machine.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command Version.
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Verbose output.
  

--- a/docs/source/guides/admin-guides/references/man1/mkzone.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/mkzone.1.rst
@@ -19,7 +19,7 @@ mkzone.1
 ****************
 
 
-\ **mkzone**\  <zonename>  [\ **--defaultzone**\ ] [\ **-k**\  \ *full path to the ssh RSA private key*\ ] [\ **-a**\  \ *noderange*\ ] [\ **-g**\ ] [\ **-f**\ ] [\ **-s**\  \ *yes|no*\ ] [-V]
+\ **mkzone**\  \ *zonename*\   [\ **-**\ **-defaultzone**\ ] [\ **-k**\  \ *full path to the ssh RSA private key*\ ] [\ **-a**\  \ *noderange*\ ] [\ **-g**\ ] [\ **-f**\ ] [\ **-s**\  \ *{yes|no}*\ ] [\ **-V**\ ]
 
 \ **mkzone**\  [\ **-h**\  | \ **-v**\ ]
 
@@ -41,26 +41,26 @@ Note: if any zones in the zone table, there must be one and only one defaultzone
 
 
 
-\ **-h**\ |\ **--help**\ 
+\ **-h | -**\ **-help**\ 
  
  Displays usage information.
  
 
 
-\ **-v**\ |\ **--version**\ 
+\ **-v | -**\ **-version**\ 
  
  Displays command version and build date.
  
 
 
-\ **-k | --sshkeypath**\  \ *full path to the ssh RSA private key*\ 
+\ **-k | -**\ **-sshkeypath**\  \ *full path to the ssh RSA private key*\ 
  
  This is the path to the id_rsa key that will be used to build root's ssh keys for the zone. If -k is used, it will generate the ssh public key from the input ssh RSA private key and store both in /etc/xcat/sshkeys/<zonename>/.ssh directory.
  If -f is not used,  then it will generate a set of root ssh keys for the zone and store them in /etc/xcat/sshkeys/<zonename>/.ssh.
  
 
 
-\ **--default**\ 
+\ **-**\ **-default**\ 
  
  if --defaultzone is input, then it will set the zone defaultzone attribute to yes; otherwise it will set to no.
  if --defaultzone is input and another zone is currently the default,
@@ -70,7 +70,7 @@ Note: if any zones in the zone table, there must be one and only one defaultzone
  
 
 
-\ **-a | --addnoderange**\  \ *noderange*\ 
+\ **-a | -**\ **-addnoderange**\  \ *noderange*\ 
  
  For each node in the noderange, it will set the zonename attribute for that node to the input zonename.
  If the -g flag is also on the command, then
@@ -78,26 +78,26 @@ Note: if any zones in the zone table, there must be one and only one defaultzone
  
 
 
-\ **-s| --sshbetweennodes**\  \ **yes|no**\ 
+\ **-s| -**\ **-sshbetweennodes**\  \ **yes|no**\ 
  
  If -s entered, the zone sshbetweennodes attribute will be set to yes or no. It defaults to yes. When this is set to yes, then ssh will be setup
  to allow passwordless root access between nodes.  If no, then root will be prompted for a password when running ssh between the nodes in the zone.
  
 
 
-\ **-f | --force**\ 
+\ **-f | -**\ **-force**\ 
  
  Used with the (--defaultzone) flag to override the current default zone.
  
 
 
-\ **-g | --assigngroup**\ 
+\ **-g | -**\ **-assigngroup**\ 
  
  Used with the (-a) flag to create the group zonename for all nodes in the input noderange.
  
 
 
-\ **-V**\ |\ **--Verbose**\ 
+\ **-V | -**\ **-Verbose**\ 
  
  Verbose mode.
  
@@ -105,65 +105,86 @@ Note: if any zones in the zone table, there must be one and only one defaultzone
 
 
 ****************
-\ **Examples**\ 
+\ **EXAMPLES**\ 
 ****************
 
 
 
-\*
+1. To make a new zone1 using defaults, enter:
  
- To make a new zone1 using defaults , enter:
  
- \ **mkzone**\  \ *zone1*\ 
+ .. code-block:: perl
  
- Note: with the first mkzone, you will automatically get the xcatdefault zone created as the default zone.  This zone uses ssh keys from
-       <roothome>/.ssh directory.
+   mkzone zone1
  
-
-
-\*
  
- To make a new zone2 using defaults and make it the default zone enter:
- 
- \ **mkzone**\  \ *zone2*\  --defaultzone -f
+ Note: with the first \ **mkzone**\ , you will automatically get the xcatdefault zone created as the default zone.  This zone uses ssh keys from <roothome>/.ssh directory.
  
 
 
-\*
+2. To make a new zone2 using defaults and make it the default zone enter:
+ 
+ 
+ .. code-block:: perl
+ 
+   mkzone> zone2 --defaultzone -f
+ 
+ 
+
+
+3.
  
  To make a new zone2A using the ssh id_rsa private key in /root/.ssh:
  
- \ **mkzone**\  \ *zone2A*\  -k /root/.ssh
+ 
+ .. code-block:: perl
+ 
+   mkzone zone2A -k /root/.ssh
+ 
  
 
 
-\*
+4.
  
  To make a new zone3 and assign the noderange compute3 to the zone  enter:
  
- \ **mkzone**\  \ *zone3*\   -a compute3
+ 
+ .. code-block:: perl
+ 
+   mkzone zone3 -a compute3
+ 
  
 
 
-\*
+5. To make a new zone4 and assign the noderange compute4 to the zone and add zone4 as a group to each node  enter:
  
- To make a new zone4 and assign the noderange compute4 to the zone and add zone4 as a group to each node  enter:
  
- \ **mkzone**\  \ *zone4*\   -a compute4  -g
+ .. code-block:: perl
+ 
+   mkzone zone4 -a compute4 -g
+ 
  
 
 
-\*
+6.
  
  To make a new zone5 and assign the noderange compute5 to the zone and add zone5 as a group to each node but not allow passwordless ssh between the nodes  enter:
  
- \ **mkzone**\  \ *zone5*\   -a compute5  -g -s no
+ 
+ .. code-block:: perl
+ 
+   mkzone zone5 -a compute5 -g -s no
+ 
  
 
 
-\ **Files**\ 
 
-\ **/opt/xcat/bin/mkzone/**\ 
+*************
+\ **Files**\ 
+*************
+
+
+/opt/xcat/bin/mkzone/
 
 Location of the mkzone command.
 

--- a/docs/source/guides/admin-guides/references/man1/monadd.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/monadd.1.rst
@@ -19,11 +19,11 @@ SYNOPSIS
 ********
 
 
-\ *monadd  [-h| --help]*\ 
+\ **monadd  [-h| -**\ **-help]**\ 
 
-\ *monadd  [-v| --version]*\ 
+\ **monadd  [-v| -**\ **-version]**\ 
 
-\ *monadd  name [-n|--nodestatmon] [-s|--settings settings]*\ 
+\ **monadd  name [-n|-**\ **-nodestatmon] [-s|-**\ **-settings**\  \ *settings]*\ 
 
 
 ***********
@@ -50,25 +50,25 @@ OPTIONS
 
 
 
-\ **-h | --help**\ 
+\ **-h | -**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-n | --nodestatmon**\ 
+\ **-n | -**\ **-nodestatmon**\ 
  
  Indicate that this monitoring plug-in will be used for feeding the node liveness status to the xCAT \ *nodelist*\  table.
  
 
 
-\ **-s | --settings**\ 
+\ **-s | -**\ **-settings**\ 
  
  Specifies the plug-in specific settings. These settings will be used by the plug-in to customize certain entities for the plug-in or the third party monitoring software. e.g. -s mon_interval=10 -s toggle=1.
  
 
 
-\ **-v | --version **\ 
+\ **-v | -**\ **-version**\ 
  
  Command Version.
  

--- a/docs/source/guides/admin-guides/references/man1/moncfg.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/moncfg.1.rst
@@ -19,11 +19,11 @@ SYNOPSIS
 ********
 
 
-\ *moncfg [-h| --help]*\ 
+\ **moncfg [-h| -**\ **-help]**\ 
 
-\ *moncfg [-v| --version]*\ 
+\ **moncfg [-v| -**\ **-version]**\ 
 
-\ *moncfg name [noderange] [-r|--remote]*\ 
+\ **moncfg**\  \ *name*\  \ *[noderange]*\  \ **[-r|-**\ **-remote]**\ 
 
 
 ***********
@@ -49,11 +49,11 @@ OPTIONS
 *******
 
 
-\ **-h | --help**\           Display usage message.
+\ **-h | -**\ **-help**\           Display usage message.
 
-\ **-r | --remote**\         Specifies that the operation will also be performed on the nodes.
+\ **-r | -**\ **-remote**\         Specifies that the operation will also be performed on the nodes.
 
-\ **-v | --version **\       Command Version.
+\ **-v | -**\ **-version**\        Command Version.
 
 
 ************
@@ -79,7 +79,7 @@ EXAMPLES
    moncfg gangliamon
 
 
-1. To configure the management node, nodes and their service nodes for ganglia monitoring, enter:
+2. To configure the management node, nodes and their service nodes for ganglia monitoring, enter:
 
 
 .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man1/mondecfg.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/mondecfg.1.rst
@@ -19,11 +19,11 @@ SYNOPSIS
 ********
 
 
-\ *moncfg [-h| --help]*\ 
+\ **mondecfg [-h| -**\ **-help]**\ 
 
-\ *moncfg [-v| --version]*\ 
+\ **mondecfg [-v| -**\ **-version]**\ 
 
-\ *moncfg name [noderange] [-r|--remote]*\ 
+\ **mondecfg**\  \ *name*\  \ *[noderange]*\  \ **[-r|-**\ **-remote]**\ 
 
 
 ***********
@@ -35,7 +35,7 @@ This command is used to deconfigure a 3rd party monitoring software from monitor
 
 
 **********
-Parameters
+PARAMETERS
 **********
 
 
@@ -49,11 +49,11 @@ OPTIONS
 *******
 
 
-\ **-h | --help**\           Display usage message.
+\ **-h | -**\ **-help**\           Display usage message.
 
-\ **-r | --remote**\         Specifies that the operation will also be performed on the nodes.
+\ **-r | -**\ **-remote**\         Specifies that the operation will also be performed on the nodes.
 
-\ **-v | --version **\       Command Version.
+\ **-v | -**\ **-version**\        Command Version.
 
 
 ************
@@ -79,7 +79,7 @@ EXAMPLES
    mondecfg gangliamon
 
 
-1. To deconfigure the management node, nodes and their service nodes from the ganglia monitoring, enter:
+2. To deconfigure the management node, nodes and their service nodes from the ganglia monitoring, enter:
 
 
 .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man1/monls.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/monls.1.rst
@@ -19,13 +19,13 @@ SYNOPSIS
 ********
 
 
-\ *monls [-h| --help]*\ 
+\ **monls [-h| -**\ **-help]**\ 
 
-\ *monls  [-v| --version]*\ 
+\ **monls  [-v| -**\ **-version]**\ 
 
-\ *monls \ \*name\*\  [-d|--description]*\ 
+\ **monls**\  \ *name*\  \ **[-d|-**\ **-description]**\ 
 
-\ *monls [-a|--all] [-d|--description]*\ 
+\ **monls [-a|-**\ **-all] [-d|-**\ **-description]**\ 
 
 
 ***********
@@ -49,13 +49,13 @@ OPTIONS
 *******
 
 
-\ **-a | --all**\           Searches the \ *XCATROOT/lib/perl/xCAT_monitoring*\  directory and reports all the monitoring plug-in modules. If nothing is specified, the list is read from the \ *monitoring*\  tabel.
+\ **-a | -**\ **-all**\           Searches the \ *XCATROOT/lib/perl/xCAT_monitoring*\  directory and reports all the monitoring plug-in modules. If nothing is specified, the list is read from the \ *monitoring*\  tabel.
 
-\ **-d | --description**\   Display the description of the plug-in modules. The description ususally contains the possible settings.
+\ **-d | -**\ **-description**\   Display the description of the plug-in modules. The description ususally contains the possible settings.
 
-\ **-h | --help**\          Display usage message.
+\ **-h | -**\ **-help**\          Display usage message.
 
-\ **-v | --version **\       Command Version.
+\ **-v | -**\ **-version**\       Command Version.
 
 
 ************

--- a/docs/source/guides/admin-guides/references/man1/monrm.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/monrm.1.rst
@@ -19,11 +19,11 @@ SYNOPSIS
 ********
 
 
-\ *monrm [-h| --help]*\ 
+\ **monrm [-h| -**\ **-help]**\ 
 
-\ *monrm [-v| --version]*\ 
+\ **monrm [-v| -**\ **-version]**\ 
 
-\ *monrm name*\ 
+\ **monrm**\  \ *name*\ 
 
 
 ***********
@@ -35,7 +35,7 @@ This command is used to unregister a monitoring plug-in module from the \ *monit
 
 
 **********
-Parameters
+PARAMETERS
 **********
 
 
@@ -47,9 +47,9 @@ OPTIONS
 *******
 
 
-\ **-h | --help**\           Display usage message.
+\ **-h | -**\ **-help**\           Display usage message.
 
-\ **-v | --version **\       Command Version.
+\ **-v | -**\ **-version**\        Command Version.
 
 
 ************
@@ -75,7 +75,7 @@ EXAMPLES
    monrm gangliamon
 
 
-Please note that gangliamon must have been registered in the xCAT \ *monitoring*\  table. For a list of registered plug-in modules, use command \ *monls*\ .
+Please note that gangliamon must have been registered in the xCAT \ *monitoring*\  table. For a list of registered plug-in modules, use command \ **monls**\ .
 
 
 *****

--- a/docs/source/guides/admin-guides/references/man1/monshow.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/monshow.1.rst
@@ -19,11 +19,11 @@ SYNOPSIS
 ********
 
 
-\ *monshow [-h| --help]*\ 
+\ **monshow [-h| -**\ **-help]**\ 
 
-\ *monshow [-v| --version]*\ 
+\ **monshow [-v| -**\ **-version]**\ 
 
-\ *monshow name [noderange] [-s] [-t time] [-a attributes] [-w attr<operator*\ val [-w attr<operator>val] ... ][-o {p|e}]>
+\ **monshow**\  \ *name*\  \ *[noderange]*\  [\ **-s**\ ] [\ **-t**\  \ *time*\ ] [\ **-a**\  \ *attributes*\ ] [\ **-w**\  \ *attr*\  < \ *operator*\  > \ *val*\  [\ **-w**\  \ *attr*\  < \ *operator*\  > \ *val*\ ] ... ][\ **-o {p|e}**\ ]
 
 
 ***********
@@ -35,7 +35,7 @@ This command displays the events that happened on the given nodes or the monitor
 
 
 **********
-Parameters
+PARAMETERS
 **********
 
 
@@ -49,9 +49,9 @@ OPTIONS
 *******
 
 
-\ **-h | --help**\           Display usage message.
+\ **-h | -**\ **-help**\           Display usage message.
 
-\ **-v | --version **\       Command Version.
+\ **-v | -**\ **-version**\       Command Version.
 
 \ **-s**\ 	shows the summary data.
 
@@ -61,16 +61,42 @@ OPTIONS
 
 \ **-w**\ 	specify one or multiple selection string that can be used to select events. The operators ==, !=, =,!,>,<,>=,<= are available.  Wildcards % and _ are supported in the pattern string. % allows you to match any string of any length(including zero length) and _ allows you to match on a single character. The valid attributes are eventtype, monitor, monnode, application, component, id, serverity, message, rawdata, comments. Valid severity are: Informational, Warning, Critical.
 
-Operator descriptions: 
-  ==        Select event where the attribute value is exactly this value.
-  !=        Select event where the attribute value is not this specific value.
-  =~        Select event where the attribute value matches this pattern string. Not work with severity.
-  !~        Select event where the attribute value does not match this pattern string. Not work with severity.
-  >         Select event where the severity is higher than this value. Only work with severity.
-  <         Select event where the severity is lower than this value. Only work with severity.
-  >=        Select event where the severity is higher than this value(include). Only work with severity.
-  <=        Select event where the severity is lower than this value(include). Only work with severity.
-            Note: if the "val" or "operator" fields includes spaces or any other characters that will be parsed by shell, the "attr<operator>val" needs to be quoted. If the operator is "!~", the "attr<operator>val" needs to be quoted using single quote.
+Operator descriptions:
+
+
+\ **==**\  Select event where the attribute value is exactly this value.
+
+
+
+\ **!=**\  Select event where the attribute value is not this specific value.
+
+
+
+\ **=~**\  Select event where the attribute value matches this pattern string. Not work with severity.
+
+
+
+\ **!~>**\  Select event where the attribute value does not match this pattern string. Not work with severity.
+
+
+
+\ **>**\  Select event where the severity is higher than this value. Only work with severity.
+
+
+
+\ **<**\  Select event where the severity is lower than this value. Only work with severity.
+
+
+
+\ **>=**\  Select event where the severity is higher than this value(include). Only work with severity.
+
+
+
+\ **<=**\  Select event where the severity is lower than this value(include). Only work with severity.
+
+
+
+Note: if the "val" or "operator" fields includes spaces or any other characters that will be parsed by shell, the "attr<operator>val" needs to be quoted. If the operator is "!~", the "attr<operator>val" needs to be quoted using single quote.
 
 \ **-o**\ 	specifies montype, it can be p or e. p means performance, e means events.
 

--- a/docs/source/guides/admin-guides/references/man1/monstart.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/monstart.1.rst
@@ -19,11 +19,11 @@ SYNOPSIS
 ********
 
 
-\ *monstart [-h| --help]*\ 
+\ **monstart [-h| -**\ **-help]**\ 
 
-\ *monstart [-v| --version]*\ 
+\ **monstart [-v| -**\ **-version]**\ 
 
-\ *monstart name [noderange] [-r|--remote]*\ 
+\ **monstart**\  \ *name*\  \ *[noderange]*\  [\ **-r|-**\ **-remote**\ ]
 
 
 ***********
@@ -31,15 +31,15 @@ DESCRIPTION
 ***********
 
 
-This command is used to start a 3rd party software, (for example start the daemons), to monitor the xCAT cluster. The operation is performed on the management node and the service nodes of the given nodes.  The operation will also be performed on the nodes if the \ *-r*\  option is specified.
+This command is used to start a 3rd party software, (for example start the daemons), to monitor the xCAT cluster. The operation is performed on the management node and the service nodes of the given nodes.  The operation will also be performed on the nodes if the \ **-r**\  option is specified.
 
 
 **********
-Parameters
+PARAMETERS
 **********
 
 
-\ *name*\  is the name of the monitoring plug-in module. For example, if the the \ *name*\  is called \ *xxx*\ , then the actual file name that the xcatd looks for is \ */opt/xcat/lib/perl/xCAT_monitoring/xxx.pm*\ . Use \ *monls -a*\  command to list all the monitoring plug-in modules that can be used.
+\ *name*\  is the name of the monitoring plug-in module. For example, if the the \ *name*\  is called \ *xxx*\ , then the actual file name that the xcatd looks for is \ */opt/xcat/lib/perl/xCAT_monitoring/xxx.pm*\ . Use \ **monls -a**\  command to list all the monitoring plug-in modules that can be used.
 
 \ *noderange*\  is the nodes to be monitored. If omitted, all nodes will be monitored.
 
@@ -49,11 +49,11 @@ OPTIONS
 *******
 
 
-\ **-h | --help**\           Display usage message.
+\ **-h | -**\ **-help**\           Display usage message.
 
-\ **-r | --remote**\         Specifies that the operation will also be performed on the nodes. For example, the3rd party monitoring software daemons on the nodes will also be started.
+\ **-r | -**\ **-remote**\         Specifies that the operation will also be performed on the nodes. For example, the3rd party monitoring software daemons on the nodes will also be started.
 
-\ **-v | --version **\       Command Version.
+\ **-v | -**\ **-version**\        Command Version.
 
 
 ************

--- a/docs/source/guides/admin-guides/references/man1/monstop.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/monstop.1.rst
@@ -19,11 +19,11 @@ SYNOPSIS
 ********
 
 
-\ *monstop [-h| --help]*\ 
+\ **monstop [-h| -**\ **-help]**\ 
 
-\ *monstop [-v| --version]*\ 
+\ **monstop [-v| -**\ **-version]**\ 
 
-\ *monstop name [noderange] [-r|--remote]*\ 
+\ **monstop**\  \ *name*\  [\ *noderange*\ ] [\ **-r|-**\ **-remote**\ ]
 
 
 ***********
@@ -31,15 +31,15 @@ DESCRIPTION
 ***********
 
 
-This command is used to stop a 3rd party software, (for example stop the daemons), from monitoring the xCAT cluster. The operation is performed on the management node and the service nodes of the given nodes.  The operation will also be performed on the nodes if the \ *-r*\  option is specified.
+This command is used to stop a 3rd party software, (for example stop the daemons), from monitoring the xCAT cluster. The operation is performed on the management node and the service nodes of the given nodes.  The operation will also be performed on the nodes if the \ **-r**\  option is specified.
 
 
 **********
-Parameters
+PARAMETERS
 **********
 
 
-\ *name*\  is the name of the monitoring plug-in module in the \ *monitoring*\  table. Use \ *monls*\  command to list all the monitoring plug-in modules that can be used.
+\ *name*\  is the name of the monitoring plug-in module in the \ *monitoring*\  table. Use \ **monls**\  command to list all the monitoring plug-in modules that can be used.
 
 \ *noderange*\  is the nodes to be stopped for monitoring. If omitted, all nodes will be stopped.
 
@@ -51,9 +51,9 @@ OPTIONS
 
 \ **-h | -help**\           Display usage message.
 
-\ **-r | --remote**\        Specifies that the operation will also be performed on the nodes. For example, the3rd party monitoring software daemons on the nodes will also be stopped.
+\ **-r | -**\ **-remote**\        Specifies that the operation will also be performed on the nodes. For example, the3rd party monitoring software daemons on the nodes will also be stopped.
 
-\ **-v | -version **\       Command Version.
+\ **-v | -version**\        Command Version.
 
 
 ************

--- a/docs/source/guides/admin-guides/references/man1/mysqlsetup.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/mysqlsetup.1.rst
@@ -19,17 +19,17 @@ SYNOPSIS
 ********
 
 
-\ **mysqlsetup**\  {\ **-h**\ |\ **--help**\ }
+\ **mysqlsetup**\  {\ **-h | -**\ **-help**\ }
 
-\ **mysqlsetup**\  {\ **-v**\ |\ **--version**\ }
+\ **mysqlsetup**\  {\ **-v | -**\ **-version**\ }
 
-\ **mysqlsetup**\  {\ **-i**\ |\ **--init**\ } [\ **-f**\ |\ **--hostfile**\ ] [-o|--odbc] [-L|--LL] [\ **-V**\ |\ **--verbose**\ ]
+\ **mysqlsetup**\  {\ **-i | -**\ **-init**\ } [\ **-f | -**\ **-hostfile**\ ] [\ **-o | -**\ **-odbc**\ ] [\ **-L | -**\ **-LL**\ ] [\ **-V | -**\ **-verbose**\ ]
 
-\ **mysqlsetup**\  {\ **-u**\ |\ **--update**\ } [\ **-f**\ |\ **--hostfile**\ ] [-o|--odbc] [-L|--LL]          [\ **-V**\ |\ **--verbose**\ ]
+\ **mysqlsetup**\  {\ **-u | -**\ **-update**\ } [\ **-f | -**\ **-hostfile**\ ] [\ **-o | -**\ **-odbc**\ ] [\ **-L | -**\ **-LL**\ ] [\ **-V | -**\ **-verbose**\ ]
 
-\ **mysqlsetup**\  {\ **-o**\ |\ **--odbc**\ } [-V|--verbose]
+\ **mysqlsetup**\  {\ **-o | -**\ **-odbc**\ } [\ **-V | -**\ **-verbose**\ ]
 
-\ **mysqlsetup**\  {\ **-L**\ |\ **--LL**\ } [-V|--verbose]
+\ **mysqlsetup**\  {\ **-L | -**\ **-LL**\ } [\ **-V | -**\ **-verbose**\ ]
 
 
 ***********
@@ -37,9 +37,12 @@ DESCRIPTION
 ***********
 
 
-\ **mysqlsetup**\  - Sets up the MySQL or MariaDB database (linux only for MariaDB) for xCAT to use. The mysqlsetup script is run on the Management Node as root after the MySQL code or MariaDB code has been installed. Before running the init option, the MySQL server should be stopped, if it is running.  The xCAT daemon, xcatd, must be running, do not stop it. No xCAT commands should be run during the init process, because we will be migrating the xCAT database to MySQL or MariaDB and restarting the xcatd daemon as well as the MySQL daemon. For full information on all the steps that will be done, read the "Configure MySQL and Migrate xCAT Data to MySQL" sections in 
-Setting_Up_MySQL_as_the_xCAT_DB
-Two passwords must be supplied for the setup,  a password for the xcatadmin id and a password for the root id in the MySQL database.  These will be prompted for interactively, unless the environment variables XCATMYSQLADMIN_PW and  XCATMYSQLROOT_PW are set to the passwords for the xcatadmin id and root id in the database,resp. 
+\ **mysqlsetup**\  - Sets up the MySQL or MariaDB database (linux only for MariaDB) for xCAT to use. The mysqlsetup script is run on the Management Node as root after the MySQL code or MariaDB code has been installed. Before running the init option, the MySQL server should be stopped, if it is running.  The xCAT daemon, xcatd, must be running, do not stop it. No xCAT commands should be run during the init process, because we will be migrating the xCAT database to MySQL or MariaDB and restarting the xcatd daemon as well as the MySQL daemon. For full information on all the steps that will be done, read the "Configure MySQL and Migrate xCAT Data to MySQL" sections in
+
+\ **Setting_Up_MySQL_as_the_xCAT_DB**\ 
+
+Two passwords must be supplied for the setup,  a password for the xcatadmin id and a password for the root id in the MySQL database.  These will be prompted for interactively, unless the environment variables XCATMYSQLADMIN_PW and  XCATMYSQLROOT_PW are set to the passwords for the xcatadmin id and root id in the database,resp.
+
 Note below we refer to MySQL but it works the same for MariaDB.
 
 
@@ -49,44 +52,44 @@ OPTIONS
 
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Displays the usage message.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Displays the release version of the code.
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Displays verbose messages.
  
 
 
-\ **-i|--init**\ 
+\ **-i|-**\ **-init**\ 
  
  The init option is used to setup a xCAT database on an installed MySQL or MariaDB server for xCAT to use. The mysqlsetup script will check for the installed MariaDB server rpm first and will use MariaDB if it is installed.   This involves creating the xcatdb database, the xcatadmin id, allowing access to the xcatdb database by the Management Node. It customizes the my.cnf configuration file for xcat and starts the MySQL server.  It also backs up the current xCAT database and restores it into the newly setup xcatdb MySQL database.  It creates the /etc/xcat/cfgloc file to point the xcatd daemon to the MySQL database and restarts the xcatd daemon using the database. 
  On AIX, it additionally setup the mysql id and group and corrects the permissions in the MySQL install directories. For AIX, you should be using the MySQL rpms available from the xCAT website. For Linux, you should use the MySQL or MariaDB rpms shipped with the OS. You can chose the -f and/or the -o option, to run after the init.
  
 
 
-\ **-u|--update**\ 
+\ **-u|-**\ **-update**\ 
  
  To run the update option,  you must first have run the -i option and have xcat successfully running on the MySQL database. You can chose the -f and/or the -o option, to update.
  
 
 
-\ **-f|--hostfile**\ 
+\ **-f|-**\ **-hostfile**\ 
  
  This option runs during update, it will take all the host from the input file (provide a full path) and give them database access to the xcatdb in  MySQL for the xcatadmin id. Wildcards and ipaddresses may be used. xCAT  must have been previously successfully setup to use MySQL. xcatadmin and MySQL root password are required.
  
 
 
-\ **-o|--odbc**\ 
+\ **-o|-**\ **-odbc**\ 
  
  This option sets up the ODBC  /etc/../odbcinst.ini, /etc/../odbc.ini and the .odbc.ini file in roots home directory will be created and initialized to run off the xcatdb MySQL database.
  See "Add ODBC Support" in
@@ -94,7 +97,7 @@ OPTIONS
  
 
 
-\ **-L|--LL**\ 
+\ **-L|-**\ **-LL**\ 
  
  Additional database configuration specifically for the LoadLeveler product. 
  See "Add ODBC Support" in
@@ -109,16 +112,12 @@ ENVIRONMENT VARIABLES
 
 
 
-\*
- 
- \ **XCATMYSQLADMIN_PW**\  - the password for the xcatadmin id that will be assigned in the MySQL database.
- 
+\* \ **XCATMYSQLADMIN_PW**\  - the password for the xcatadmin id that will be assigned in the MySQL database.
 
 
-\*
- 
- \ **XCATMYSQLROOT_PW**\  - the password for the root id that will be assigned to the MySQL root id, if the script creates it.  The password to use to run MySQL command to the database as the MySQL root id.  This password may be different than the unix root password on the Management Node.
- 
+
+\* \ **XCATMYSQLROOT_PW**\  - the password for the root id that will be assigned to the MySQL root id, if the script creates it.  The password to use to run MySQL command to the database as the MySQL root id.  This password may be different than the unix root password on the Management Node.
+
 
 
 
@@ -128,19 +127,27 @@ EXAMPLES
 
 
 
-\*
+1.
  
  To setup MySQL for xCAT to run on the MySQL xcatdb database :
  
- \ **mysqlsetup**\  \ *-i*\ 
+ 
+ .. code-block:: perl
+ 
+   mysqlsetup -i
+ 
  
 
 
-\*
+2.
  
  Add hosts from /tmp/xcat/hostlist that can access the xcatdb database in MySQL:
  
- \ **mysqlsetup**\  \ *-u*\  \ *-f /tmp/xcat/hostlist*\ 
+ 
+ .. code-block:: perl
+ 
+   mysqlsetup -u -f /tmp/xcat/hostlist
+ 
  
  Where the file contains a host per line, for example:
  
@@ -155,19 +162,27 @@ EXAMPLES
  
 
 
-\*
+3.
  
  To setup the ODBC for MySQL xcatdb database access :
  
- \ **mysqlsetup**\  \ *-o*\ 
+ 
+ .. code-block:: perl
+ 
+   mysqlsetup -o
+ 
  
 
 
-\*
+4.
  
  To setup MySQL for xCAT and add hosts from /tmp/xcat/hostlist and setup the ODBC in Verbose mode:
  
- \ **mysqlsetup**\  \ *-i*\  \ *-f /tmp/xcat/hostlist*\  \ *-o*\  \ *-V*\ 
+ 
+ .. code-block:: perl
+ 
+   mysqlsetup -i -f /tmp/xcat/hostlist -o -V
+ 
  
 
 

--- a/docs/source/guides/admin-guides/references/man1/nimnodecust.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/nimnodecust.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **nimnodecust [-h|--help ]**\ 
+\ **nimnodecust [-h|-**\ **-help ]**\ 
 
-\ **nimnodecust [-V] -s lpp_source_name [-p packages] [-b installp_bundles] noderange [attr=val [attr=val ...]]**\ 
+\ **nimnodecust [-V] -s**\  \ *lpp_source_name*\  [\ **-p**\  \ *packages*\ ] [\ **-b**\  \ *installp_bundles*\ ] \ *noderange [attr=val [attr=val ...]]*\ 
 
 
 ***********
@@ -52,7 +52,10 @@ A bundle file contains a list of package names.  The RPMs must have a prefix of 
 To create a NIM installp_bundle definition you can use the "nim -o define" operation.  For example, to create a definition called "mypackages" for a bundle file located at "/install/nim/mypkgs.bnd" you could issue the following command.
 
 
-"nim -o define -t installp_bundle -a server=master -a location=/install/nim/mypkgs.bnd mypackages".
+.. code-block:: perl
+
+  nim -o define -t installp_bundle -a server=master -a location=/install/nim/mypkgs.bnd mypackages
+
 
 See the AIX documantation for more information on using installp_bundle files.
 
@@ -65,42 +68,38 @@ OPTIONS
 
 
 
-\ **attr=val [attr=val ...]**\ 
+\ *attr=val [attr=val ...]*\ 
  
  Specifies one or more "attribute equals value" pairs, separated by spaces. Attr=val pairs must be specified last on the command line. These are used to specify
  additional values that can be passed to the underlying NIM commands, ("nim -o cust..."). See the NIM documentation for valid "nim" command line options.
  
 
 
-\ **-b installp_bundle_names**\ 
+\ **-b**\  \ *installp_bundle_names*\ 
  
- 
- .. code-block:: perl
- 
-  	A comma separated list of NIM installp_bundle names.
- 
+ A comma separated list of NIM installp_bundle names.
  
 
 
-\ **-h |--help**\ 
+\ **-h |-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-p package_names**\ 
+\ **-p**\  \ *package_names*\ 
  
  A comma-separated list of software packages to install.  Packages may be RPM or installp.
  
 
 
-\ **noderange**\ 
+\ *noderange*\ 
  
  A set of comma delimited node names and/or group names. See the "noderange" man page for details on additional supported formats.
  
 
 
-\ **-V |--verbose**\ 
+\ **-V |-**\ **-verbose**\ 
  
  Verbose mode.
  
@@ -113,16 +112,12 @@ RETURN VALUE
 
 
 
-0
- 
- The command completed successfully.
- 
+0 The command completed successfully.
 
 
-1
- 
- An error has occurred.
- 
+
+1 An error has occurred.
+
 
 
 
@@ -134,12 +129,18 @@ EXAMPLES
 1) Install the installp package "openssh.base.server" on an xCAT node named "node01".  Assume that the package has been copied to the NIM lpp_source resource called "61lppsource".
 
 
-\ **nimnodecust -s 61lppsource -p openssh.base.server node01**\ 
+.. code-block:: perl
+
+  nimnodecust -s 61lppsource -p openssh.base.server node01
+
+
 
 2) Install the product software contained in the two bundles called "llbnd" and "pebnd" on all AIX nodes contained in the xCAT node group called "aixnodes".  Assume that all the software packages have been copied to the NIM lpp_source resource called "61lppsource".
 
 
-\ **nimnodecust -s 61lppsource -b llbnd,pebnd  aixnodes**\ 
+.. code-block:: perl
+
+  nimnodecust -s 61lppsource -b llbnd,pebnd  aixnodes
 
 
 *****

--- a/docs/source/guides/admin-guides/references/man1/nimnodeset.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/nimnodeset.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **nimnodeset [-h|--help ]**\ 
+\ **nimnodeset [-h|-**\ **-help ]**\ 
 
-\ **nimnodeset [-V|--verbose] [-f|--force] [-i osimage_name] [-l location] [-p|--primarySN] [-b|--backupSN] noderange [attr=val [attr=val ...]]**\ 
+\ **nimnodeset [-V|-**\ **-verbose] [-f|-**\ **-force] [-i**\  \ *osimage_name*\ ] [\ **-l**\  \ *location*\ ] [\ **-p|-**\ **-primarySN**\ ] [\ **-b | -**\ **-backupSN**\ ] \ *noderange [attr=val [attr=val ...]]*\ 
 
 
 ***********
@@ -48,7 +48,10 @@ The "nameservers" value can either be set to a specific IP address or the "<xcat
 You can set the "domain" and "nameservers" attributes by using the \ **chdef**\  command.  For example:
 
 
-chdef -t network -o clstr_net domain=cluster.com nameservers=<xcatmaster>
+.. code-block:: perl
+
+  chdef -t network -o clstr_net domain=cluster.com nameservers=<xcatmaster>
+
 
 If the "domain" and "nameservers" attributes are not set in either the nodes "network" definition or the "site" definition then no new NIM resolv_conf resource
 will be created.
@@ -70,57 +73,57 @@ OPTIONS
 
 
 
-\ **attr=val [attr=val ...]**\ 
+\ *attr=val [attr=val ...]*\ 
  
  Specifies one or more "attribute equals value" pairs, separated by spaces. Attr=
  val pairs must be specified last on the command line. These are used to specify additional values that can be passed to the underlying NIM commands, ("nim -o bos_inst ...").  See the NIM documentation for valid "nim" command line options. Note that you may specify multiple "script" and "installp_bundle" values by using a comma seperated list. (ex. "script=ascript,bscript").
  
 
 
-\ **-b|--backupSN**\ 
+\ **-b|-**\ **-backupSN**\ 
  
  When using backup service nodes only update the backup.  The default is to update both the primary and backup service nodes
  
 
 
-\ **-f |--force**\ 
+\ **-f |-**\ **-force**\ 
  
  Use the force option to reinitialize the NIM machines.
  
 
 
-\ **-h |--help**\ 
+\ **-h |-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-i image_name**\ 
+\ **-i**\  \ *image_name*\ 
  
  The name of an existing xCAT osimage definition.
  
 
 
-\ **-l|--location**\ 
+\ **-l|-**\ **-location**\ 
  
  The directory location to use when creating new NIM resolv_conf resources. The d
  efault location is /install/nim.
  
 
 
-\ **-p|--primarySN**\ 
+\ **-p|-**\ **-primarySN**\ 
  
  When using backup service nodes only update the primary.  The default is to update both the primary and backup service nodes.
  
 
 
-\ **noderange**\ 
+\ *noderange*\ 
  
  A set of comma delimited node names and/or group names. See the "noderange" man page for details on additional supported formats.
  
 
 
-\ **-V |--verbose**\ 
+\ **-V |-**\ **-verbose**\ 
  
  Verbose mode.
  
@@ -133,16 +136,12 @@ RETURN VALUE
 
 
 
-0
- 
- The command completed successfully.
- 
+0 The command completed successfully.
 
 
-1
- 
- An error has occurred.
- 
+
+1 An error has occurred.
+
 
 
 
@@ -154,17 +153,26 @@ EXAMPLES
 1) Initialize an xCAT node named "node01".  Use the xCAT osimage named "61gold" to install the node.
 
 
-\ **nimnodeset -i 61gold node01**\ 
+.. code-block:: perl
+
+  nimnodeset -i 61gold node01
+
+
 
 2) Initialize all AIX nodes contained in the xCAT node group called "aixnodes" using the image definitions pointed to by the "provmethod" attribute of the xCAT node definitions.
 
 
-\ **nimnodeset aixnodes**\ 
+.. code-block:: perl
+
+  nimnodeset aixnodes
+
 
 3) Initialize an xCAT node called "node02".  Include installp_bundle resources that are not included in the osimage definition. This assumes the NIM installp_bundle resources have already been created.
 
 
-\ **nimnodeset -i 611image node02 installp_bundle=sshbundle,addswbundle**\ 
+.. code-block:: perl
+
+  nimnodeset -i 611image node02 installp_bundle=sshbundle,addswbundle
 
 
 *****

--- a/docs/source/guides/admin-guides/references/man1/nodeaddunmged.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/nodeaddunmged.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **nodeaddunmged**\  [-h| --help | -v | --version]
+\ **nodeaddunmged**\  [\ **-h**\ | \ **-**\ **-help**\  | \ **-v**\  | \ **-**\ **-version**\ ]
 
-\ **nodeaddunmged**\  hostname=<node-name> ip=<ip-address>
+\ **nodeaddunmged hostname=**\ \ *node-name*\  \ **ip=**\ \ *ip-address*\ 
 
 
 ***********
@@ -37,21 +37,21 @@ OPTIONS
 *******
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
 
 Display usage message.
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
 
 Command Version.
 
-\ **hostname=<node-name**\ >
+\ **hostname=**\ \ *node-name*\ 
 
 Sets the name of the new unmanaged node, where <node-name> is the name of the node.
 
-\ **ip=<ip-address**\ >
+\ **ip=**\ \ *ip-address*\ 
 
-Sets the IP address of the unmanaged node, where <ip-address> is the IP address of the new node in the form xxx.xxx.xxx.xxx
+Sets the IP address of the unmanaged node, where \ *ip-address*\  is the IP address of the new node in the form xxx.xxx.xxx.xxx
 
 
 ************
@@ -70,7 +70,12 @@ EXAMPLES
 
 
 To add an unmanaged node, use the following command:
-nodeaddunmged hostname=unmanaged01 ip=192.168.1.100
+
+
+.. code-block:: perl
+
+  nodeaddunmged hostname=unmanaged01 ip=192.168.1.100
+
 
 
 ********

--- a/docs/source/guides/admin-guides/references/man1/nodech.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/nodech.1.rst
@@ -21,11 +21,11 @@ SYNOPSIS
 
 \ **nodech**\  \ *noderange*\  \ *table.column=value*\  [\ *...*\ ]
 
-\ **nodech**\  {\ **-d**\  | \ **--delete**\ } \ *noderange*\  \ *table*\  [\ *...*\ ]
+\ **nodech**\  {\ **-d**\  | \ **-**\ **-delete**\ } \ *noderange*\  \ *table*\  [\ *...*\ ]
 
-\ **nodech**\  {\ **-v**\  | \ **--version**\ }
+\ **nodech**\  {\ **-v**\  | \ **-**\ **-version**\ }
 
-\ **nodech**\  [\ **-?**\  | \ **-h**\  | \ **--help**\ ]
+\ **nodech**\  [\ **-?**\  | \ **-h**\  | \ **-**\ **-help**\ ]
 
 
 ***********
@@ -58,19 +58,19 @@ OPTIONS
 
 
 
-\ **-d|--delete**\ 
+\ **-d|-**\ **-delete**\ 
  
  Delete the nodes' row in the specified tables.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command Version.
  
 
 
-\ **-?|-h|--help**\ 
+\ **-?|-h|-**\ **-help**\ 
  
  Display usage message.
  
@@ -83,16 +83,12 @@ RETURN VALUE
 
 
 
-0
- 
- The command completed successfully.
- 
+0 The command completed successfully.
 
 
-1
- 
- An error has occurred.
- 
+
+1 An error has occurred.
+
 
 
 
@@ -102,43 +98,53 @@ EXAMPLES
 
 
 
-\*
+1. To update nodes in noderange  node1-node4 to be in only group all:
  
- To update nodes in noderange  node1-node4 to be in only group all:
  
- \ **nodech**\  \ *node1-node4 groups=all*\ 
+ .. code-block:: perl
  
-
-
-\*
+   nodech node1-node4 groups=all
  
- To put all nodes with nodepos.rack value of 2 into a group called rack2:
- 
- \ **nodech**\  \ *all*\  nodepos.rack==2 groups,=rack2
  
 
 
-\*
+2. To put all nodes with nodepos.rack value of 2 into a group called rack2:
  
- To add nodes in noderange  node1-node4 to the nodetype table with os=rhel5:
  
- \ **nodech**\  \ *node1-node4 groups=all,rhel5 nodetype.os=rhel5*\ 
+ .. code-block:: perl
  
-
-
-\*
+   nodech all nodepos.rack==2 groups,=rack2
  
- To add node1-node4 to group1 in addition to the groups they are already in:
- 
- \ **nodech**\  \ *node1-node4 groups,=group1*\ 
  
 
 
-\*
+3. To add nodes in noderange  node1-node4 to the nodetype table with os=rhel5:
  
- To put node1-node4 in group2, instead of group1:
  
- \ **nodech**\  \ *node1-node4 groups^=group1 groups,=group2*\ 
+ .. code-block:: perl
+ 
+   nodech node1-node4 groups=all,rhel5 nodetype.os=rhel5
+ 
+ 
+
+
+4. To add node1-node4 to group1 in addition to the groups they are already in:
+ 
+ 
+ .. code-block:: perl
+ 
+   nodech node1-node4 groups,=group1
+ 
+ 
+
+
+5. To put node1-node4 in group2, instead of group1:
+ 
+ 
+ .. code-block:: perl
+ 
+   nodech node1-node4 groups^=group1 groups,=group2
+ 
  
 
 

--- a/docs/source/guides/admin-guides/references/man1/nodechmac.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/nodechmac.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **nodechmac**\  [-h| --help | -v | --version]
+\ **nodechmac**\  [\ **-h**\  | \ **-**\ **-help**\  | \ **-v**\  | \ **-**\ **-version**\ ]
 
-\ **nodechmac**\  <node-name> mac=<mac-address>
+\ **nodechmac**\  \ *node-name*\  \ **mac=**\ \ *mac-address*\ 
 
 
 ***********
@@ -39,19 +39,19 @@ OPTIONS
 *******
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
 
 Display usage message.
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
 
 Command Version.
 
-\ **node-name**\ 
+\ *node-name*\ 
 
 Specifies the name of the node you want to update, where <node-name> is the node that is updated.
 
-\ **mac=<mac-address**\ 
+\ **mac=**\ \ *mac-address*\ 
 
 Sets the new MAC address for the NIC used by the provisioning node, where <mac-address> is the NICs new MAC address.
 
@@ -72,7 +72,12 @@ EXAMPLES
 
 
 You can update the MAC address for a node, by using the following command:
-nodechmac compute-000 mac=2F:3C:88:98:7E:01
+
+
+.. code-block:: perl
+
+  nodechmac compute-000 mac=2F:3C:88:98:7E:01
+
 
 
 ********

--- a/docs/source/guides/admin-guides/references/man1/nodechprofile.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/nodechprofile.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **nodechprofile**\  [-h| --help | -v | --version]
+\ **nodechprofile**\  \ **[-h| -**\ **-help | -v | -**\ **-version]**\ 
 
-\ **nodechprofile**\  <noderange> [imageprofile=<image-profile>] [networkprofile=<network-profile>] [hardwareprofile=<hardware-profile>]
+\ **nodechprofile**\  \ *noderange*\  [\ **imageprofile=**\  \ *image-profile*\ ] [\ **networkprofile=**\  \ *network-profile*\ ] [\ **hardwareprofile=**\  \ *hardware-profile*\ ]
 
 
 ***********
@@ -47,27 +47,27 @@ OPTIONS
 *******
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
 
 Display usage message.
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
 
 Command Version.
 
-\ **noderange**\ 
+\ *noderange*\ 
 
 The nodes to be removed.
 
-\ **imageprofile=<image-profile**\ >
+\ **imageprofile=**\  \ *image-profile*\ 
 
 Sets the new image profile name used by the node, where <image-profile> is the new image profile.  An image profile defines the provisioning method, OS information, kit information, and provisioning parameters for a node. If the "__ImageProfile_imgprofile" group already exists in the nodehm table, then "imgprofile" is used as the image profile name.
 
-\ **networkprofile=<network-profile**\ >
+\ **networkprofile=**\  \ *network-profile*\ 
 
 Sets the new network profile name used by the node, where <network-profile> is the new network profile. A network profile defines the network, NIC, and routes for a node. If the "__NetworkProfile_netprofile" group already exists in the nodehm table, then "netprofile" is used as the network profile name.
 
-\ **hardwareprofile=<hardware-profile**\ >
+\ **hardwareprofile=**\  \ *hardware-profile*\ 
 
 Sets the new hardware profile name used by the node, where <hardware-profile> is the new hardware management profile used by the node. If a "__HardwareProfile_hwprofile" group exists, then "hwprofile" is the hardware profile name. A hardware profile defines hardware management related information for imported nodes, including: IPMI, HMC, CEC, CMM.
 
@@ -87,13 +87,17 @@ EXAMPLES
 ********
 
 
-To change the image profile to rhels6.3_packaged for compute nodes compute-000 and compute-001, use the following command:
 
-nodechprofile compute-000,compute-001 imageprofile=rhels6.3_packaged
 
-To change all of the profiles for compute node compute-000, enter the following command:
+.. code-block:: perl
 
-nodechprofile compute-000 imageprofile=rhels6.3_packaged networkprofile=default_cn hardwareprofile=default_ipmi
+  nodechprofile compute-000,compute-001 imageprofile=rhels6.3_packaged
+
+
+
+.. code-block:: perl
+
+  nodechprofile compute-000 imageprofile=rhels6.3_packaged networkprofile=default_cn hardwareprofile=default_ipmi
 
 
 ********

--- a/docs/source/guides/admin-guides/references/man1/nodediscoverdef.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/nodediscoverdef.1.rst
@@ -21,13 +21,13 @@ SYNOPSIS
 ********
 
 
-\ **nodediscoverdef**\  \ **-u uuid**\  \ **-n node**\ 
+\ **nodediscoverdef**\  \ **-u**\  \ *uuid*\  \ **-n**\  \ *node*\ 
 
-\ **nodediscoverdef**\  \ **-r**\  \ **-u uuid**\ 
+\ **nodediscoverdef**\  \ **-r**\  \ **-u**\  \ *uuid*\ 
 
-\ **nodediscoverdef**\  \ **-r**\  \ **-t**\  {\ **seq**\ |\ **profile**\ |\ **switch**\ |\ **blade**\ |\ **manual**\ |\ **undef**\ |\ **all**\ }
+\ **nodediscoverdef**\  \ **-r**\  \ **-t**\  {\ **seq | profile | switch | blade | manual | undef | all**\ }
 
-\ **nodediscoverdef**\  [\ **-h**\ |\ **--help**\ |\ **-v**\ |\ **--version**\ ]
+\ **nodediscoverdef**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
 
 ***********
@@ -61,51 +61,37 @@ OPTIONS
  Specify the nodes that have been discovered by the specified discovery method:
  
  
- \*
-  
-  \ **seq**\  - Sequential discovery (started via nodediscoverstart noderange=<noderange> ...).
-  
+ \* \ **seq**\  - Sequential discovery (started via nodediscoverstart noderange=<noderange> ...).
  
  
- \*
-  
-  \ **profile**\  - Profile discovery (started via nodediscoverstart networkprofile=<network-profile> ...).
-  
+ 
+ \* \ **profile**\  - Profile discovery (started via nodediscoverstart networkprofile=<network-profile> ...).
  
  
- \*
-  
-  \ **switch**\  - Switch-based discovery (used when the switch and switches tables are filled in).
-  
+ 
+ \* \ **switch**\  - Switch-based discovery (used when the switch and switches tables are filled in).
  
  
- \*
-  
-  \ **blade**\  - Blade discovery (used for IBM Flex blades).
-  
+ 
+ \* \ **blade**\  - Blade discovery (used for IBM Flex blades).
  
  
- \*
-  
-  \ **manual**\  - Manually discovery (used when defining node by nodediscoverdef command).
-  
+ 
+ \* \ **manual**\  - Manually discovery (used when defining node by nodediscoverdef command).
  
  
- \*
-  
-  \ **undef**\  - Display the nodes that were in the discovery pool, but for which xCAT has not yet received a discovery request.
-  
+ 
+ \* \ **undef**\  - Display the nodes that were in the discovery pool, but for which xCAT has not yet received a discovery request.
  
  
- \*
-  
-  \ **all**\  - All discovered nodes.
-  
+ 
+ \* \ **all**\  - All discovered nodes.
+ 
  
  
 
 
-\ **-n node**\ 
+\ **-n**\  \ *node*\ 
  
  The xCAT node that the discovery entry will be defined to.
  
@@ -117,19 +103,19 @@ OPTIONS
  
 
 
-\ **-u uuid**\ 
+\ **-u**\  \ *uuid*\ 
  
  The uuid of the discovered entry.
  
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command version.
  
@@ -152,11 +138,15 @@ EXAMPLES
 
 
 
-1
+1. Define the discovery entry which uuid is 51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB4 to node node1
  
- Define the discovery entry which uuid is 51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB4 to node node1
  
- \ **nodediscoverdef**\  -u 51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB4 -n node1
+ .. code-block:: perl
+ 
+   nodediscoverdef -u 51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB4 -n node1
+ 
+ 
+ Output is similar to:
  
  
  .. code-block:: perl
@@ -166,11 +156,15 @@ EXAMPLES
  
 
 
-2
+2. Remove the discovery entry which uuid is 51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB4 from the discoverydata table
  
- Remove the discovery entry which uuid is 51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB4 from the discoverydata table
  
- \ **nodediscoverdef**\  -r -u 51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB4
+ .. code-block:: perl
+ 
+   nodediscoverdef -r -u 51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB4
+ 
+ 
+ Output is similar to:
  
  
  .. code-block:: perl
@@ -180,11 +174,15 @@ EXAMPLES
  
 
 
-3
+3. Remove the discovery entries which discover type is \ **seq**\  from the discoverydata table
  
- Remove the discovery entries which discover type is \ **seq**\  from the discoverydata table
  
- \ **nodediscoverdef**\  -r -t seq
+ .. code-block:: perl
+ 
+   nodediscoverdef -r -t seq
+ 
+ 
+ Output is similar to:
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man1/nodediscoverls.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/nodediscoverls.1.rst
@@ -19,11 +19,11 @@ SYNOPSIS
 ********
 
 
-\ **nodediscoverls**\  [\ **-t seq**\ |\ **profile**\ |\ **switch**\ |\ **blade**\ |\ **manual**\ |\ **undef**\ |\ **all**\ ] [\ **-l**\ ]
+\ **nodediscoverls**\  [\ **-t seq | profile | switch | blade | manual | undef | all**\ ] [\ **-l**\ ]
 
-\ **nodediscoverls**\  [\ **-u uuid**\ ] [\ **-l**\ ]
+\ **nodediscoverls**\  [\ **-u**\  \ *uuid*\ ] [\ **-l**\ ]
 
-\ **nodediscoverls**\  [\ **-h**\ |\ **--help**\ |\ **-v**\ |\ **--version**\ ]
+\ **nodediscoverls**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
 
 ***********
@@ -52,46 +52,32 @@ OPTIONS
  Display the nodes that have been discovered by the specified discovery method:
  
  
- \*
-  
-  \ **seq**\  - Sequential discovery (started via nodediscoverstart noderange=<noderange> ...).
-  
+ \* \ **seq**\  - Sequential discovery (started via nodediscoverstart noderange=<noderange> ...).
  
  
- \*
-  
-  \ **profile**\  - Profile discovery (started via nodediscoverstart networkprofile=<network-profile> ...).
-  
+ 
+ \* \ **profile**\  - Profile discovery (started via nodediscoverstart networkprofile=<network-profile> ...).
  
  
- \*
-  
-  \ **switch**\  - Switch-based discovery (used when the switch and switches tables are filled in).
-  
+ 
+ \* \ **switch**\  - Switch-based discovery (used when the switch and switches tables are filled in).
  
  
- \*
-  
-  \ **blade**\  - Blade discovery (used for IBM Flex blades).
-  
+ 
+ \* \ **blade**\  - Blade discovery (used for IBM Flex blades).
  
  
- \*
-  
-  \ **manual**\  - Manually discovery (used when defining node by nodediscoverdef command).
-  
+ 
+ \* \ **manual**\  - Manually discovery (used when defining node by nodediscoverdef command).
  
  
- \*
-  
-  \ **undef**\  - Display the nodes that were in the discovery pool, but for which xCAT has not yet received a discovery request.
-  
+ 
+ \* \ **undef**\  - Display the nodes that were in the discovery pool, but for which xCAT has not yet received a discovery request.
  
  
- \*
-  
-  \ **all**\  - All discovered nodes.
-  
+ 
+ \* \ **all**\  - All discovered nodes.
+ 
  
  
 
@@ -102,19 +88,19 @@ OPTIONS
  
 
 
-\ **-u uuid**\ 
+\ **-u**\  \ *uuid*\ 
  
  Display the discovered node that has this uuid.
  
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command version.
  
@@ -137,11 +123,15 @@ EXAMPLES
 
 
 
-1
+1. Display the discovered nodes when sequential discovery is running:
  
- Display the discovered nodes when sequential discovery is running:
  
- \ **nodediscoverls**\ 
+ .. code-block:: perl
+ 
+   nodediscoverls
+ 
+ 
+ Output is similar to:
  
  
  .. code-block:: perl
@@ -153,11 +143,15 @@ EXAMPLES
  
 
 
-2
+2. Display the nodes that were in the discovery pool, but for which xCAT has not yet received a discovery request:
  
- Display the nodes that were in the discovery pool, but for which xCAT has not yet received a discovery request:
  
- \ **nodediscoverls**\  -t undef
+ .. code-block:: perl
+ 
+   nodediscoverls -t undef
+ 
+ 
+ Output is similar to:
  
  
  .. code-block:: perl
@@ -169,11 +163,15 @@ EXAMPLES
  
 
 
-3
+3. Display all the discovered nodes:
  
- Display all the discovered nodes:
  
- \ **nodediscoverls**\  -t all
+ .. code-block:: perl
+ 
+   nodediscoverls -t all
+ 
+ 
+ Output is similar to:
  
  
  .. code-block:: perl
@@ -187,11 +185,15 @@ EXAMPLES
  
 
 
-4
+4. Display the discovered node whose uuid is \ **51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB2**\ , with detailed information:
  
- Display the discovered node whose uuid is \ **51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB2**\ , with detailed information:
  
- \ **nodediscoverls**\  -u 51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB2 -l
+ .. code-block:: perl
+ 
+   nodediscoverls -u 51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB2 -l
+ 
+ 
+ Output is similar to:
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man1/nodediscoverstart.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/nodediscoverstart.1.rst
@@ -19,12 +19,12 @@ SYNOPSIS
 ********
 
 
-\ **nodediscoverstart**\  [\ **-h**\ |\ **--help**\ |\ **-v**\ |\ **--version**\ ]
+\ **nodediscoverstart**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
 \ **Sequential Discovery Specific:**\ 
 
 
-\ **nodediscoverstart**\  \ **noderange=**\ \ *noderange*\  [\ **hostiprange=**\ \ *imageprofile*\ ] [\ **bmciprange=**\ \ *bmciprange*\ ] [\ **groups=**\ \ *groups*\ ] [\ **rack=**\ \ *rack*\ ] [\ **chassis=**\ \ *chassis*\ ] [\ **height=**\ \ *height*\ ] [\ **unit=**\ \ *unit*\ ] [osimage=<osimagename>] [-n|--dns] [-s|--skipbmcsetup] [\ **-V|--verbose**\ ]
+\ **nodediscoverstart**\  \ **noderange=**\ \ *noderange*\  [\ **hostiprange=**\ \ *imageprofile*\ ] [\ **bmciprange=**\ \ *bmciprange*\ ] [\ **groups=**\ \ *groups*\ ] [\ **rack=**\ \ *rack*\ ] [\ **chassis=**\ \ *chassis*\ ] [\ **height=**\ \ *height*\ ] [\ **unit=**\ \ *unit*\ ] [\ **osimage=**\  \ *osimagename*\ >] [\ **-n | -**\ **-dns**\ ] [\ **-s | -**\ **-skipbmcsetup**\ ] [\ **-V|-**\ **-verbose**\ ]
 
 \ **Profile Discovery Specific:**\ 
 
@@ -157,32 +157,32 @@ OPTIONS
  
 
 
-\ **-n|--dns**\ 
+\ **-n|-**\ **-dns**\ 
  
  Specifies to run makedns <nodename> for any new discovered node. This is useful mainly for non-predefined configuration, before running the "nodediscoverstart -n", the user needs to run makedns -n to initialize the named setup on the management node.
  
 
 
-\ **-s|--skipbmcsetup**\ 
+\ **-s|-**\ **-skipbmcsetup**\ 
  
  Specifies to skip the bmcsetup during the sequential discovery process, if the bmciprange is specified with nodediscoverstart command, the BMC will be setup automatically during the discovery process, if the user does not want to run bmcsetup, could specify the "-s|--skipbmcsetup" with nodediscoverstart command to skip the bmcsetup.
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Enumerates the free node names and host/bmc ips that are being specified in the ranges given.  Use this option
  with Sequential Discovery to ensure that you are specifying the ranges you intend.
  
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command Version.
  
@@ -205,11 +205,15 @@ EXAMPLES
 
 
 
-1
+1. \ **Sequential Discovery**\ : To discover nodes with noderange and host/bmc ip range:
  
- \ **Sequential Discovery**\ : To discover nodes with noderange and host/bmc ip range:
  
- \ **nodediscoverstart noderange=n[1-10] hostiprange='172.20.101.1-172.20.101.10' bmciprange='172.20.102.1-172.20.102.10' -V**\ 
+ .. code-block:: perl
+ 
+   nodediscoverstart noderange=n[1-10] hostiprange='172.20.101.1-172.20.101.10' bmciprange='172.20.102.1-172.20.102.10' -V
+ 
+ 
+ Output is similar to:
  
  
  .. code-block:: perl
@@ -227,11 +231,13 @@ EXAMPLES
  
 
 
-2
+2. \ **Profile Discovery**\ : To discover nodes using the default_cn network profile and the rhels6.3_packaged image profile, use the following command:
  
- \ **Profile Discovery**\ : To discover nodes using the default_cn network profile and the rhels6.3_packaged image profile, use the following command:
  
- \ **nodediscoverstart networkprofile=default_cn imageprofile=rhels6.3_packaged hostnameformat=compute#NNN**\ 
+ .. code-block:: perl
+ 
+   nodediscoverstart networkprofile=default_cn imageprofile=rhels6.3_packaged hostnameformat=compute#NNN
+ 
  
 
 

--- a/docs/source/guides/admin-guides/references/man1/nodediscoverstatus.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/nodediscoverstatus.1.rst
@@ -19,7 +19,7 @@ SYNOPSIS
 ********
 
 
-\ **nodediscoverstatus**\  [\ **-h**\ |\ **--help**\ |\ **-v**\ |\ **--version**\ ]
+\ **nodediscoverstatus**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
 
 ***********
@@ -36,11 +36,11 @@ OPTIONS
 *******
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
 
 Display usage message.
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
 
 Command Version.
 
@@ -62,7 +62,11 @@ EXAMPLES
 
 To determine if there are some nodes discovered and the discovered nodes' status, enter the following command:
 
-nodediscoverstatus
+
+.. code-block:: perl
+
+  nodediscoverstatus
+
 
 
 ********

--- a/docs/source/guides/admin-guides/references/man1/nodediscoverstop.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/nodediscoverstop.1.rst
@@ -19,7 +19,7 @@ SYNOPSIS
 ********
 
 
-\ **nodediscoverstop**\  [\ **-h**\ |\ **--help**\ |\ **-v**\ |\ **--version**\ ]
+\ **nodediscoverstop**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
 
 ***********
@@ -37,11 +37,11 @@ OPTIONS
 *******
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
 
 Display usage message.
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
 
 Command Version.
 
@@ -61,7 +61,11 @@ EXAMPLES
 ********
 
 
-nodediscoverstop
+
+.. code-block:: perl
+
+  nodediscoverstop
+
 
 
 ********

--- a/docs/source/guides/admin-guides/references/man1/nodegrpch.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/nodegrpch.1.rst
@@ -21,9 +21,9 @@ SYNOPSIS
 
 \ **nodegrpch**\  \ *group1,group2,...*\  \ *table.column=value*\  [\ *...*\ ]
 
-\ **nodegrpch**\  {\ **-v**\  | \ **--version**\ }
+\ **nodegrpch**\  {\ **-v**\  | \ **-**\ **-version**\ }
 
-\ **nodegrpch**\  [\ **-?**\  | \ **-h**\  | \ **--help**\ ]
+\ **nodegrpch**\  [\ **-?**\  | \ **-h**\  | \ **-**\ **-help**\ ]
 
 
 ***********
@@ -55,13 +55,13 @@ OPTIONS
 
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command Version.
  
 
 
-\ **-?|-h|--help**\ 
+\ **-?|-h|-**\ **-help**\ 
  
  Display usage message.
  
@@ -74,16 +74,12 @@ RETURN VALUE
 
 
 
-0
- 
- The command completed successfully.
- 
+0 The command completed successfully.
 
 
-1
- 
- An error has occurred.
- 
+
+1 An error has occurred.
+
 
 
 
@@ -93,11 +89,15 @@ EXAMPLES
 
 
 
-\*
+1.
  
  To declare all members of ipmi group to have nodehm.mgt be ipmi
  
- \ **  nodegrpch**\  \ *ipmi nodehm.mgt=ipmi*\ 
+ 
+ .. code-block:: perl
+ 
+   nodegrpch ipmi nodehm.mgt=ipmi
+ 
  
 
 

--- a/docs/source/guides/admin-guides/references/man1/nodeimport.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/nodeimport.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **nodeimport**\  [-h| --help | -v | --version]
+\ **nodeimport**\  [\ **-h**\  | \ **-**\ **-help**\  | \ **-v**\  | \ **-**\ **-version**\ ]
 
-\ **nodeimport**\  file=<hostinfo-filename> networkprofile=<network-profile> imageprofile=<image-profile> hostnameformat=<node-name-format> [hardwareprofile=<hardware-profile>] [groups=<node-groups>]
+\ **nodeimport**\  \ **file=**\  \ *hostinfo-filename*\  \ **networkprofile=**\  \ *network-profile*\  \ **imageprofile=**\  \ *image-profile*\  \ **hostnameformat=**\  \ *node-name-format*\  [\ **hardwareprofile=**\  \ *hardware-profile*\ ] [\ **groups=**\  \ *node-groups*\ ]
 
 
 ***********
@@ -39,31 +39,31 @@ OPTIONS
 *******
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
 
 Display usage message.
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
 
 Command Version.
 
-\ **file=<nodeinfo-filename**\ >
+\ **file=**\  \ *nodeinfo-filename*\ 
 
 Specifies the node information file, where <nodeinfo-filename> is the full path and file name of the node information file.
 
-\ **imageprofile=<image-profile**\ >
+\ **imageprofile=**\  \ *image-profile*\ 
 
 Sets the new image profile name used by the node, where <image-profile> is the new image profile.  An image profile defines the provisioning method, OS information, kit information, and provisioning parameters for a node. If the "__ImageProfile_imgprofile" group already exists in the nodehm table, then "imgprofile" is used as the image profile name.
 
-\ **networkprofile=<network-profile**\ >
+\ **networkprofile=**\  \ *network-profile*\ 
 
 Sets the new network profile name used by the node, where <network-profile> is the new network profile. A network profile defines the network, NIC, and routes for a node. If the "__NetworkProfile_netprofile" group already exists in the nodehm table, then "netprofile" is used as the network profile name.
 
-\ **hardwareprofile=<hardware-profile**\ >
+\ **hardwareprofile=**\  \ *hardware-profile*\ 
 
 Sets the new hardware profile name used by the node, where <hardware-profile> is the new hardware management profile used by the node. If a "__HardwareProfile_hwprofile" group exists, then "hwprofile" is the hardware profile name. A hardware profile defines hardware management related information for imported nodes, including: IPMI, HMC, CEC, CMM.
 
-\ **hostnameformat=<host-name-format**\ >
+\ **hostnameformat=**\  \ *host-name-format*\ 
 
 Sets the node name format for all nodes discovered, where <node-name-format> is a supported format. The two types of formats supported are prefix#NNNappendix and prefix#RRand#NNappendix, where wildcard #NNN and #NN are replaced by a system generated number that is based on the provisioning order. Wildcard #RR represents the rack number and stays constant.
 
@@ -71,7 +71,7 @@ For example, if the node name format is compute-#NN, the node name is generated 
 
 For example, if the node name format is compute-#RR-#NN and the rack number is 2, the node name is generated as: compute-02-00, compute-02-01, ..., compute-02-99. If node name format is node-#NN-in-#RR and rack number is 1, the node name is generated as: node-00-in-01, node-01-in-01, ... , node-99-in-01
 
-\ **groups=<node-groups**\ >
+\ **groups=**\  \ *node-groups*\ 
 
 Sets the node groups that the imported node belongs to, where <node-group> is a comma-separated list of node groups.
 
@@ -238,7 +238,12 @@ Description: node location info, for rack server only. Specify the node's start 
 Description: Specifies the vmhost of a Power KVM Guest node, where <vmhost> is the host name of PowerKVM Hypervisior.
 
 3. Import the nodes, by using the following commands. Note: If we want to import PureFlex X/P nodes, hardware profile must be set to a PureFlex hardware type.
-  nodeimport file=/root/hostinfo.txt networkprofile=default_cn imageprofile=rhels6.3_packaged hostnameformat=compute-#NNN
+
+
+.. code-block:: perl
+
+   nodeimport file=/root/hostinfo.txt networkprofile=default_cn imageprofile=rhels6.3_packaged hostnameformat=compute-#NNN
+
 
 4. After importing the nodes, the nodes are created and all configuration files used by the nodes are updated, including: /etc/hosts, DNS, DHCP.
 

--- a/docs/source/guides/admin-guides/references/man1/nodels.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/nodels.1.rst
@@ -19,11 +19,11 @@ SYNOPSIS
 ********
 
 
-\ **nodels**\  [\ *noderange*\ ] [\ **-b**\  | \ **--blame**\ ] [\ **-H**\  | \ **--with-fieldname**\ ] [\ **-S**\ ] [\ *table.column*\  | \ *shortname*\ ] [\ *...*\ ]
+\ **nodels**\  [\ *noderange*\ ] [\ **-b**\  | \ **-**\ **-blame**\ ] [\ **-H**\  | \ **-**\ **-with-fieldname**\ ] [\ **-S**\ ] [\ *table.column*\  | \ *shortname*\ ] [\ *...*\ ]
 
-\ **nodels**\  [\ *noderange*\ ] [\ **-H**\  | \ **--with-fieldname**\ ] [\ *table*\ ]
+\ **nodels**\  [\ *noderange*\ ] [\ **-H**\  | \ **-**\ **-with-fieldname**\ ] [\ *table*\ ]
 
-\ **nodels**\  [\ **-?**\  | \ **-h**\  | \ **--help**\  | \ **-v**\  | \ **--version**\ ]
+\ **nodels**\  [\ **-?**\  | \ **-h**\  | \ **-**\ **-help**\  | \ **-v**\  | \ **-**\ **-version**\ ]
 
 
 ***********
@@ -95,19 +95,19 @@ OPTIONS
 
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command Version.
  
 
 
-\ **-H|--with-fieldname**\ 
+\ **-H|-**\ **-with-fieldname**\ 
  
  Force display of table name and column name context for each result
  
 
 
-\ **-b|--blame**\ 
+\ **-b|-**\ **-blame**\ 
  
  For values inherited from groups, display which groups provided the inheritence
  
@@ -119,7 +119,7 @@ OPTIONS
  
 
 
-\ **-?|-h|--help**\ 
+\ **-?|-h|-**\ **-help**\ 
  
  Display usage message.
  

--- a/docs/source/guides/admin-guides/references/man1/nodepurge.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/nodepurge.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **nodepurge**\  [-h| --help | -v | --version]
+\ **nodepurge [-h| -**\ **-help | -v | -**\ **-version]**\ 
 
-\ **nodepurge**\  <noderange>
+\ **nodepurge**\  \ *noderange*\ 
 
 
 ***********
@@ -39,15 +39,15 @@ OPTIONS
 *******
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
 
 Display usage message.
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
 
 Command Version
 
-\ **noderange**\ 
+\ *noderange*\ 
 
 The nodes to be removed.
 
@@ -69,7 +69,11 @@ EXAMPLES
 
 To remove nodes compute-000 and compute-001, use the following command:
 
-nodepurge compute-000,compute-001
+
+.. code-block:: perl
+
+  nodepurge compute-000,compute-001
+
 
 
 ********

--- a/docs/source/guides/admin-guides/references/man1/noderefresh.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/noderefresh.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **noderefresh**\  [-h| --help | -v | --version]
+\ **noderefresh [-h| -**\ **-help | -v | -**\ **-version]**\ 
 
-\ **noderefresh**\  <noderange>
+\ **noderefresh**\  \ *noderange*\ 
 
 
 ***********
@@ -37,15 +37,15 @@ OPTIONS
 *******
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
 
 Display usage message.
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
 
 Command Version.
 
-\ **noderange**\ 
+\ *noderange*\ 
 
 The nodes to be updated.
 
@@ -65,7 +65,11 @@ EXAMPLES
 ********
 
 
-noderefresh compute-000,compute-001
+
+.. code-block:: perl
+
+  noderefresh compute-000,compute-001
+
 
 
 ********

--- a/docs/source/guides/admin-guides/references/man1/noderm.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/noderm.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ *noderm [-h| --help]*\ 
+\ **noderm [-h| -**\ **-help]**\ 
 
-\ *noderm noderange*\ 
+\ **noderm noderange**\ 
 
 
 ***********
@@ -29,11 +29,7 @@ DESCRIPTION
 ***********
 
 
-
-.. code-block:: perl
-
-  The noderm command removes the nodes in the input node range.
-
+The noderm command removes the nodes in the input node range.
 
 
 *******
@@ -41,7 +37,7 @@ OPTIONS
 *******
 
 
-\ **-h**\           Display usage message.
+\ **-h|-**\ **-help**\           Display usage message.
 
 
 ************
@@ -61,7 +57,11 @@ EXAMPLES
 
 1. To remove the nodes in noderange node1-node4, enter:
 
-\ *noderm node1-node4*\ 
+
+.. code-block:: perl
+
+  noderm node1-node4
+
 
 
 *****

--- a/docs/source/guides/admin-guides/references/man1/nodestat.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/nodestat.1.rst
@@ -19,9 +19,9 @@ Name
 ****************
 
 
-\ **nodestat**\  [\ *noderange*\ ] [\ *-m*\ |\ *--usemon*\ ] [\ *-p*\ |\ *--powerstat*\ ] [\ *-f*\ ] [\ *-u*\ |\ *--updatedb*\ ]
+\ **nodestat**\  [\ *noderange*\ ] [\ **-m | -**\ **-usemon**\ ] [\ **-p | -**\ **-powerstat**\ ] [\ **-f**\ ] [\ **-u | -**\ **-updatedb**\ ]
 
-\ **nodestat**\  [\ *-h*\ |\ *--help*\ |\ *-v*\ |\ *--version*\ ]
+\ **nodestat**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
 
 *******************
@@ -92,31 +92,31 @@ For the command specified by 'dcmd', no input is needed, the output can be a str
  
 
 
-\ **-m**\ |\ **--usemon**\ 
+\ **-m | -**\ **-usemon**\ 
  
  Uses the settings from the \ **monsetting**\  talbe to determine a list of applications that need to get status for.
  
 
 
-\ **-p**\ |\ **--powerstat**\ 
+\ **-p | -**\ **-powerstat**\ 
  
  Gets the power status for the nodes that are 'noping'.
  
 
 
-\ **-u**\ |\ **--updatedb**\ 
+\ **-u | -**\ **-updatedb**\ 
  
  Updates the status and appstatus columns of the nodelist table with the returned running status from the given nodes.
  
 
 
-\ **-v**\ |\ **--version**\ 
+\ **-v | -**\ **-version**\ 
  
  Print version.
  
 
 
-\ **-h**\ |\ **--help**\ 
+\ **-h | -**\ **-help**\ 
  
  Print help.
  
@@ -128,42 +128,93 @@ For the command specified by 'dcmd', no input is needed, the output can be a str
 ****************
 
 
-1.  nodestat compute
+
+1.
+ 
+ 
+ .. code-block:: perl
+ 
+   nodestat compute
+ 
+ 
+ Output is similar to:
+ 
+ 
+ .. code-block:: perl
+ 
+   node1   sshd
+   node2   sshd
+   node3   ping
+   node4   pbs
+   node5   noping
+ 
+ 
 
 
-.. code-block:: perl
+2.
+ 
+ 
+ .. code-block:: perl
+ 
+   nodestat compute -p
+ 
+ 
+ Output is similar to:
+ 
+ 
+ .. code-block:: perl
+ 
+   node1   sshd
+   node2   sshd
+   node3   ping
+   node4   pbs
+   node5   noping(Shutting down)
+ 
+ 
 
-  node1   sshd
-  node2   sshd
-  node3   ping
-  node4   pbs
-  node5   noping
+
+3.
+ 
+ 
+ .. code-block:: perl
+ 
+   nodestat compute -u
+ 
+ 
+ Output is similar to:
+ 
+ 
+ .. code-block:: perl
+ 
+   node1   sshd
+   node2   sshd
+   node3   ping
+   node4   netboot
+   node5   noping
+ 
+ 
 
 
-2.  nodestat compute -p
+4.
+ 
+ 
+ .. code-block:: perl
+ 
+   nodestat compute -m
+ 
+ 
+ Output is similar to:
+ 
+ 
+ .. code-block:: perl
+ 
+   node1   ping,sshd,ll,gpfs=ok
+   node2   ping,sshd,ll,gpfs=not ok,someapp=something is wrong
+   node3   netboot
+   node4   noping
+ 
+ 
 
-
-.. code-block:: perl
-
-  node1   sshd
-  node2   sshd
-  node3   ping
-  node4   pbs
-  node5   noping(Shutting down)
-
-
-3. nodestat compute -u
- node1   sshd
- node2   sshd
- node3   ping
- node4   netboot
- node5   noping
-
-4. nodestat compute -m
- node1   ping,sshd,ll,gpfs=ok
- node2   ping,sshd,ll,gpfs=not ok,someapp=something is wrong
- node3   netboot
- node4   noping
 
 
 ************************

--- a/docs/source/guides/admin-guides/references/man1/pasu.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/pasu.1.rst
@@ -23,7 +23,7 @@ SYNOPSIS
 
 \ **pasu**\  [\ **-V**\ ] [\ **-d**\ ] [\ **-n**\ ] [\ **-l**\  \ *user*\ ] [\ **-p**\  \ *passwd*\ ] [\ **-f**\  \ *fanout*\ ] [\ **-i**\  \ *hostname-suffix*\ ] \ **-b**\  \ *batchfile*\  \ *noderange*\ 
 
-\ **pasu**\  [\ **-h**\  | \ **--help**\ ]
+\ **pasu**\  [\ **-h**\  | \ **-**\ **-help**\ ]
 
 
 ***********
@@ -47,41 +47,41 @@ OPTIONS
 
 
 
-\ **-n|--nonodecheck**\ 
+\ **-n|-**\ **-nonodecheck**\ 
  
  Do not send the noderange to xcatd to expand it into a list of nodes.  Use the noderange exactly as it is specified
  to pasu.  In this case, the noderange must be a simple list of comma-separated hostnames of the IMMs.
  
 
 
-\ **-l|--loginname**\  \ *username*\ 
+\ **-l|-**\ **-loginname**\  \ *username*\ 
  
  The username to use to connect to the IMMs.  If not specified, the row in the xCAT \ **passwd**\  table with key "ipmi"
  will be used to get the username.
  
 
 
-\ **-p|--passwd**\  \ *passwd*\ 
+\ **-p|-**\ **-passwd**\  \ *passwd*\ 
  
  The password to use to connect to the IMMs.  If not specified, the row in the xCAT passwd table with key "ipmi"
  will be used to get the password.
  
 
 
-\ **-f|--fanout**\ 
+\ **-f|-**\ **-fanout**\ 
  
  How many processes to run in parallel simultaneously.  The default is 64.  You can also set the XCATPSHFANOUT
  environment variable.
  
 
 
-\ **-b|--batch**\  -\ *batchfile*\ 
+\ **-b|-**\ **-batch**\  -\ *batchfile*\ 
  
  A simple text file that contains multiple ASU commands, each on its own line.
  
 
 
-\ **-d|--donotfilter**\ 
+\ **-d|-**\ **-donotfilter**\ 
  
  By default, pasu filters out (i.e. does not display) the standard initial output from ASU:
  
@@ -98,19 +98,19 @@ OPTIONS
  
 
 
-\ **-i|--interface**\  \ *hostname-suffix*\ 
+\ **-i|-**\ **-interface**\  \ *hostname-suffix*\ 
  
  The hostname suffix to be appended to the node names.
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Display verbose messages.
  
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  

--- a/docs/source/guides/admin-guides/references/man1/pcons.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/pcons.1.rst
@@ -14,10 +14,10 @@ SYNOPSIS
 \ **pcons**\  \ *noderange*\  \ *command*\ 
 
 \ **pcons**\ 
-[\ **-h**\ |\ **--help**\ ]
+[\ **-h | -**\ **-help**\ ]
 
 \ **pcons**\ 
-[\ **-v**\ |\ **--version**\ ]
+[\ **-v | -**\ **-version**\ ]
 
 
 ***********

--- a/docs/source/guides/admin-guides/references/man1/pgsqlsetup.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/pgsqlsetup.1.rst
@@ -19,13 +19,13 @@ SYNOPSIS
 ********
 
 
-\ **pgsqlsetup**\  {\ **-h**\ |\ **--help**\ }
+\ **pgsqlsetup**\  {\ **-h | -**\ **-help**\ }
 
-\ **pgsqlsetup**\  {\ **-v**\ |\ **--version**\ }
+\ **pgsqlsetup**\  {\ **-v | -**\ **-version**\ }
 
-\ **pgsqlsetup**\  {\ **-i**\ |\ **--init**\ } [-N|nostart] [-P|--PCM] [-o|--setupODBC] [\ **-V**\ |\ **--verbose**\ ]
+\ **pgsqlsetup**\  {\ **-i | -**\ **-init**\ } [-N|nostart] [-P|-**\ **-PCM] [-o|-**\ **-setupODBC] [\ **-V | -**\ **-verbose**\ ]
 
-\ **pgsqlsetup**\  {\ **-o**\ |\ **--setupODBC**\ } [-V|--verbose]
+\ **pgsqlsetup**\  {\ **-o | -**\ **-setupODBC**\ } [-V|-**\ **-verbose]
 
 
 ***********
@@ -43,25 +43,25 @@ OPTIONS
 
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Displays the usage message.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Displays the release version of the code.
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Displays verbose messages.
  
 
 
-\ **-i|--init**\ 
+\ **-i|-**\ **-init**\ 
  
  The init option is used to setup an installed PostgreSQL database so that xCAT can use the database.  This involves creating the xcat database, the xcat admin id, allowing access to the xcatdb database by the Management Node. It customizes the postgresql.conf configuration file, adds the management server to the pg_hba.conf and starts the PostgreSQL server.  It also backs up the current xCAT database and restores it into the newly setup xcatdb PostgreSQL database.  It creates the /etc/xcat/cfgloc file to point the xcatd daemon to the PostgreSQL database and restarts the xcatd daemon using the database. 
  On AIX, it additionally setup the xcatadm unix id and the postgres id and group. For AIX, you should be using the PostgreSQL rpms available from the xCAT website. For Linux, you should use the PostgreSQL rpms shipped with the OS. You can chose the -o option, to run after the init.
@@ -71,19 +71,19 @@ OPTIONS
  
 
 
-\ **-N|--nostart**\ 
+\ **-N|-**\ **-nostart**\ 
  
  This option with the -i flag will create the database, but will not backup and restore xCAT tables into the database. It will create the cfgloc file such that the next start of xcatd will try and contact the database.  This can be used to setup the xCAT PostgreSQL database during or before install.
  
 
 
-\ **-P|--PCM**\ 
+\ **-P|-**\ **-PCM**\ 
  
  This option sets up PostgreSQL database to be used with xCAT running with PCM.
  
 
 
-\ **-o|--odbc**\ 
+\ **-o|-**\ **-odbc**\ 
  
  This option sets up the ODBC  /etc/../odbcinst.ini, /etc/../odbc.ini and the .odbc.ini file in roots home directory will be created and initialized to run off the xcatdb PostgreSQL database.
  

--- a/docs/source/guides/admin-guides/references/man1/pping.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/pping.1.rst
@@ -11,11 +11,11 @@ SYNOPSIS
 ********
 
 
-\ **pping**\  [\ **-i**\ |\ **--interface**\  \ *interfaces*\ ] [\ **-f**\ |\ **--use_fping**\ ] \ *noderange*\ 
+\ **pping**\  [\ **-i | -**\ **-interface**\  \ *interfaces*\ ] [\ **-f | -**\ **-use_fping**\ ] \ *noderange*\ 
 
-\ **pping**\  [\ **-h**\ |\ **--help**\ ]
+\ **pping**\  [\ **-h | -**\ **-help**\ ]
 
-\ **pping**\  {\ **-v**\ |\ **--version**\ }
+\ **pping**\  {\ **-v | -**\ **-version**\ }
 
 
 ***********
@@ -36,7 +36,7 @@ OPTIONS
 
 
 
-\ **-i**\ |\ **--interface**\  \ *interfaces*\ 
+\ **-i | -**\ **-interface**\  \ *interfaces*\ 
  
  A comma separated list of network interface names that should be pinged instead of the interface represented by the nodename/hostname.
  The following name resolution convention is assumed:  an interface is reachable by the hostname <nodename>-<interface>.  For example,
@@ -46,19 +46,19 @@ OPTIONS
  
 
 
-\ **-f**\ |\ **--use_fping**\ 
+\ **-f | -**\ **-use_fping**\ 
  
  Use fping instead of nmap
  
 
 
-\ **-h**\ |\ **--help**\ 
+\ **-h | -**\ **-help**\ 
  
  Show usage information.
  
 
 
-\ **-v**\ |\ **--version**\ 
+\ **-v | -**\ **-version**\ 
  
  Display the installed version of xCAT.
  

--- a/docs/source/guides/admin-guides/references/man1/ppping.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/ppping.1.rst
@@ -11,11 +11,11 @@ SYNOPSIS
 ********
 
 
-\ **ppping**\  [\ **-i**\ |\ **--interface**\  \ *interfaces*\ ] [\ **-d**\ |\ **--debug**\ ] [\ **-V**\ |\ **--verbose**\ ] [\ **-q**\ |\ **--quiet**\ ] [\ **-s**\ |\ **--serial**\ ] \ *noderange*\ 
+\ **ppping**\  [\ **-i | -**\ **-interface**\  \ *interfaces*\ ] [\ **-d | -**\ **-debug**\ ] [\ **-V | -**\ **-verbose**\ ] [\ **-q | -**\ **-quiet**\ ] [\ **-s | -**\ **-serial**\ ] \ *noderange*\ 
 
-\ **ppping**\  [\ **-h**\ |\ **--help**\ ]
+\ **ppping**\  [\ **-h | -**\ **-help**\ ]
 
-\ **pping**\  {\ **-v**\ |\ **--version**\ }
+\ **pping**\  {\ **-v | -**\ **-version**\ }
 
 
 ***********
@@ -41,7 +41,7 @@ OPTIONS
  
 
 
-\ **-i**\ |\ **--interface**\  \ *interfaces*\ 
+\ **-i | -**\ **-interface**\  \ *interfaces*\ 
  
  A comma separated list of network interface names that should be pinged instead of the interface represented by the nodename/hostname.
  The following name resolution convention is assumed:  an interface is reachable by the hostname <nodename>-<interface>.  For example,
@@ -51,33 +51,33 @@ OPTIONS
  
 
 
-\ **-V**\ |\ **--verbose**\ 
+\ **-V | -**\ **-verbose**\ 
  
  Display verbose output.  The result of every ping attempt from every node will be displayed.  Without this option, just a summary
  of the successful pings are displayed, along with all of the unsuccessful pings.
  
 
 
-\ **-q**\ |\ **--quiet**\ 
+\ **-q | -**\ **-quiet**\ 
  
  Display minimum output:  just the unsuccessful pings.  This option has the effect that if all pings are successful, nothing is displayed.
  But it also has the performance benefit that each node does not have to send successful ping info back to the management node.
  
 
 
-\ **-d**\ |\ **--debug**\ 
+\ **-d | -**\ **-debug**\ 
  
  Print debug information.
  
 
 
-\ **-h**\ |\ **--help**\ 
+\ **-h | -**\ **-help**\ 
  
  Show usage information.
  
 
 
-\ **-v**\ |\ **--version**\ 
+\ **-v | -**\ **-version**\ 
  
  Display the installed version of xCAT.
  

--- a/docs/source/guides/admin-guides/references/man1/prsync.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/prsync.1.rst
@@ -24,7 +24,7 @@ prsync - parallel rsync
 \ **prsync**\   [\ *-o rsync options*\ ] [\ **-f**\  \ *fanout*\ ] [\ *filename*\  \ *filename*\  \ *...*\ ] [\ *directory*\  \ *directory*\  \ *...*\ ]
 \ *noderange:destinationdirectory*\ 
 
-\ **prsync**\  {\ **-h**\ |\ **--help**\ |\ **-v**\ |\ **--version**\ }
+\ **prsync**\  {\ **-h | -**\ **-help | -v | -**\ **-version**\ }
 
 
 *******************
@@ -78,13 +78,13 @@ management node to the compute node via a service node
  
 
 
-\ **-h**\ |\ **--help**\ 
+\ **-h | -**\ **-help**\ 
  
  Print help.
  
 
 
-\ **-v**\ |\ **--version**\ 
+\ **-v | -**\ **-version**\ 
  
  Print version.
  

--- a/docs/source/guides/admin-guides/references/man1/pscp.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/pscp.1.rst
@@ -21,7 +21,7 @@ Name
 
 \ **pscp**\  [-i \ *suffix*\ ] [\ *scp options*\  \ *...*\ ] [\ **-f**\  \ *fanout*\ ] \ *filename*\  [\ *filename*\  \ *...*\ ] \ *noderange:destinationdirectory*\ 
 
-\ **pscp**\  {\ **-h**\ |\ **--help**\ |\ **-v**\ |\ **--version**\ }
+\ **pscp**\  {\ **-h | -**\ **-help | -v | -**\ **-version**\ }
 
 
 *******************
@@ -77,13 +77,13 @@ management node to the compute node via a service node.
  
 
 
-\ **-h**\ |\ **--help**\ 
+\ **-h | -**\ **-help**\ 
  
  Print help.
  
 
 
-\ **-v**\ |\ **--version**\ 
+\ **-v | -**\ **-version**\ 
  
  Print version.
  

--- a/docs/source/guides/admin-guides/references/man1/psh.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/psh.1.rst
@@ -21,7 +21,7 @@ psh - parallel remote shell
 
 \ **psh**\  [\ **-i**\  \ *interface*\ ] [\ **-f**\  \ *fanout*\ ] [\ **-l**\  \ *user*\ ] \ *noderange*\  \ *command*\ 
 
-\ **psh**\  {\ **-h**\ |\ **--help**\ |\ **-v**\ |\ **--version**\ }
+\ **psh**\  {\ **-h | -**\ **-help | -v | -**\ **-version**\ }
 
 
 *******************
@@ -71,7 +71,7 @@ management node to the compute node via a service node.
  
 
 
-\ **-n|--nonodecheck**\ 
+\ **-n|-**\ **-nonodecheck**\ 
  
  Do not send the noderange to xcatd to expand it into a list of nodes.  Instead, use the noderange exactly as it is specified.
  In this case, the noderange must be a simple list of comma-separated hostnames of the nodes.
@@ -94,7 +94,7 @@ management node to the compute node via a service node.
  
 
 
-\ **-h**\ |\ **--help**\ 
+\ **-h | -**\ **-help**\ 
  
  Print help.
  

--- a/docs/source/guides/admin-guides/references/man1/pushinitrd.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/pushinitrd.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **pushinitrd**\  [\ **-v**\ |\ **--verbose**\ ]  [\ **-w**\  \ *waittime*\ ] [\ *noderange*\ ]
+\ **pushinitrd**\  [\ **-v | -**\ **-verbose**\ ]  [\ **-w**\  \ *waittime*\ ] [\ *noderange*\ ]
 
-\ **pushinitrd**\  [\ **-?**\  | \ **-h**\  | \ **--help**\ ]
+\ **pushinitrd**\  [\ **-?**\  | \ **-h**\  | \ **-**\ **-help**\ ]
 
 
 ***********
@@ -57,13 +57,13 @@ OPTIONS
  
 
 
-\ **-?|-h|--help**\ 
+\ **-?|-h|-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command Version.
  

--- a/docs/source/guides/admin-guides/references/man1/rbeacon.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rbeacon.1.rst
@@ -11,11 +11,11 @@ SYNOPSIS
 ********
 
 
-\ **rbeacon**\  \ *noderange*\  {\ **on**\ |\ **blink**\ |\ **off**\ |\ **stat**\ }
+\ **rbeacon**\  \ *noderange*\  {\ **on | blink | off | stat**\ }
 
-\ **rbeacon**\  [\ **-h**\ |\ **--help**\ ]
+\ **rbeacon**\  [\ **-h | -**\ **-help**\ ]
 
-\ **rbeacon**\  {\ **-v**\ |\ **--version**\ }
+\ **rbeacon**\  {\ **-v | -**\ **-version**\ }
 
 
 ***********

--- a/docs/source/guides/admin-guides/references/man1/rbootseq.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rbootseq.1.rst
@@ -11,20 +11,20 @@ SYNOPSIS
 ********
 
 
-\ **rbootseq**\  [\ **-h**\ |\ **--help**\ |\ **-v**\ |\ **--version**\ ]
+\ **rbootseq**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
 Blade specific:
 ===============
 
 
-\ **rbootseq**\  \ *noderange*\  {\ **hd0**\ |\ **hd1**\ |\ **hd2**\ |\ **hd3**\ |\ **net**\ |\ **iscsi**\ |\ **iscsicrit**\ |\ **cdrom**\ |\ **usbflash**\ |\ **floppy**\ |\ **none**\ |\ **list**\ |\ **stat**\ }\ **,**\ \ *...*\ 
+\ **rbootseq**\  \ *noderange*\  {\ **hd0 | hd1 | hd2 | hd3 | net | iscsi | iscsicrit | cdrom | usbflash | floppy | none | list | stat**\ }\ **,**\ \ *...*\ 
 
 
 HP Blade specific:
 ==================
 
 
-\ **rbootseq**\  \ *noderange*\  {\ **hd**\ |\ **net1**\ |\ **net2**\ |\ **net3**\ |\ **net4**\ |\ **cdrom**\ |\ **usbflash**\ |\ **floppy**\ |\ **none**\ }\ **,**\ \ *...*\ 
+\ **rbootseq**\  \ *noderange*\  {\ **hd | net1 | net2 | net3 | net4 | cdrom | usbflash | floppy | none**\ }\ **,**\ \ *...*\ 
 
 
 PPC (using Direct FSP Management) specific:
@@ -58,55 +58,55 @@ OPTIONS
 
 
 
-\ **hd0**\ |\ **harddisk0**\ |\ **hd**\ |\ **harddisk**\ 
+\ **hd0 | harddisk0 | hd | harddisk**\ 
  
  The first hard disk.
  
 
 
-\ **hd1**\ |\ **harddisk1**\ 
+\ **hd1 | harddisk1**\ 
  
  The second hard disk.
  
 
 
-\ **hd2**\ |\ **harddisk2**\ 
+\ **hd2 | harddisk2**\ 
  
  The third hard disk.
  
 
 
-\ **hd3**\ |\ **harddisk3**\ 
+\ **hd3 | harddisk3**\ 
  
  The fourth hard disk.
  
 
 
-\ **n**\ |\ **net**\ |\ **network**\ 
+\ **n | net | network**\ 
  
  Boot over the ethernet network, using a PXE or BOOTP broadcast.
  
 
 
-\ **n**\ |\ **net**\ |\ **network**\ |\ **net1**\ |\ **nic1**\  (HP Blade Only)
+\ **n | net | network | net1 | nic1**\  (HP Blade Only)
  
  Boot over the first ethernet network, using a PXE or BOOTP broadcast.
  
 
 
-\ **net2**\ |\ **nic2**\  (HP Blade Only)
+\ **net2 | nic2**\  (HP Blade Only)
  
  Boot over the second ethernet network, using a PXE or BOOTP broadcast.
  
 
 
-\ **net3**\ |\ **nic3**\  (HP Blade Only)
+\ **net3 | nic3**\  (HP Blade Only)
  
  Boot over the third ethernet network, using a PXE or BOOTP broadcast.
  
 
 
-\ **net3**\ |\ **nic3**\  (HP Blade Only)
+\ **net3 | nic3**\  (HP Blade Only)
  
  Boot over the fourth ethernet network, using a PXE or BOOTP broadcast.
  
@@ -130,13 +130,13 @@ OPTIONS
  
 
 
-\ **cd**\ |\ **cdrom**\ 
+\ **cd | cdrom**\ 
  
  The CD or DVD drive.
  
 
 
-\ **usbflash**\ |\ **usb**\ |\ **flash**\ 
+\ **usbflash | usb | flash**\ 
  
  A USB flash drive.
  
@@ -154,7 +154,7 @@ OPTIONS
  
 
 
-\ **list**\ |\ **stat**\ 
+\ **list | stat**\ 
  
  Display the current boot sequence.
  

--- a/docs/source/guides/admin-guides/references/man1/rcons.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rcons.1.rst
@@ -21,7 +21,7 @@ Name
 
 \ **rcons**\  \ *singlenode*\  [\ *conserver-host*\ ] [\ **-f**\ ] [\ **-s**\ ]
 
-\ **rcons**\  [\ **-h**\ |\ **--help**\ |\ **-v**\ |\ **--version**\ ]
+\ **rcons**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
 
 *******************
@@ -59,13 +59,13 @@ To exit the console session, enter:  <ctrl><shift>e c .
  
 
 
-\ **-h**\ |\ **--help**\ 
+\ **-h | -**\ **-help**\ 
  
  Print help.
  
 
 
-\ **-v**\ |\ **--version**\ 
+\ **-v | -**\ **-version**\ 
  
  Print version.
  

--- a/docs/source/guides/admin-guides/references/man1/renergy.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/renergy.1.rst
@@ -19,9 +19,9 @@ renergy.1
 ****************
 
 
-\ **renergy**\  [-h | --help]
+\ **renergy**\  [-h | -**\ **-help]
 
-\ **renergy**\  [-v | --version]
+\ **renergy**\  [-v | -**\ **-version]
 
 \ **Power 6 server specific :**\ 
 
@@ -258,13 +258,13 @@ so no additional plugins are needed for BladeCenter.)
 
 
 
-\ **-h | --help**\ 
+\ **-h | -**\ **-help**\ 
  
  Display the usage message.
  
 
 
-\ **-v | --version**\ 
+\ **-v | -**\ **-version**\ 
  
  Display the version information.
  

--- a/docs/source/guides/admin-guides/references/man1/replaycons.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/replaycons.1.rst
@@ -21,7 +21,7 @@ SYNOPSIS
 
 \ **replaycons**\  [\ *node*\ ] [\ *bps*\ ] [\ *tail_amount*\ ]
 
-\ **replaycons**\  [\ **-h**\  | \ **--help**\  | \ **-v**\  | \ **--version**\ ]
+\ **replaycons**\  [\ **-h**\  | \ **-**\ **-help**\  | \ **-v**\  | \ **-**\ **-version**\ ]
 
 
 ***********
@@ -55,13 +55,13 @@ OPTIONS
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command Version.
  
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  

--- a/docs/source/guides/admin-guides/references/man1/restartxcatd.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/restartxcatd.1.rst
@@ -19,7 +19,7 @@ SYNOPSIS
 ********
 
 
-\ **restartxcatd**\  [[\ **-h**\ |\ **--help**\ ] | [\ **-v**\ |\ **--version**\ ] | [\ **-r**\ |\ **--reload**\ ]] [\ **-V**\ |\ **--verbose**\ ]
+\ **restartxcatd**\  [[\ **-h | -**\ **-help**\ ] | [\ **-v | -**\ **-version**\ ] | [\ **-r | -**\ **-reload**\ ]] [\ **-V | -**\ **-verbose**\ ]
 
 
 ***********

--- a/docs/source/guides/admin-guides/references/man1/restorexCATdb.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/restorexCATdb.1.rst
@@ -19,11 +19,11 @@ SYNOPSIS
 ********
 
 
-\ **restorexCATdb**\  [\ **-a**\ ] [\ **-V**\ ] [{\ **-p**\ |\ **--path**\ } \ *path*\ ]
+\ **restorexCATdb**\  [\ **-a**\ ] [\ **-V**\ ] [{\ **-p | -**\ **-path**\ } \ *path*\ ]
 
-\ **restorexCATdb**\  [\ **-b**\ ] [\ **-V**\ ] [{\ **-t**\ |\ **--timestamp**\ } \ *timestamp*\ ] [{\ **-p**\ |\ **--path**\ } \ *path*\ ]
+\ **restorexCATdb**\  [\ **-b**\ ] [\ **-V**\ ] [{\ **-t | -**\ **-timestamp**\ } \ *timestamp*\ ] [{\ **-p | -**\ **-path**\ } \ *path*\ ]
 
-\ **restorexCATdb**\  [\ **-h**\ |\ **--help**\ ] [\ **-v**\ |\ **--version**\ ]
+\ **restorexCATdb**\  [\ **-h | -**\ **-help**\ ] [\ **-v | -**\ **-version**\ ]
 
 
 ***********

--- a/docs/source/guides/admin-guides/references/man1/reventlog.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/reventlog.1.rst
@@ -19,9 +19,9 @@ Name
 ****************
 
 
-\ **reventlog**\  \ *noderange*\  {\ *number-of-entries [-s]*\ |\ **all [-s]**\ |\ **clear**\ }
+\ **reventlog**\  \ *noderange*\  {\ *number-of-entries [-s]*\ |\ **all [-s] | clear**\ }
 
-\ **reventlog**\  [\ **-h**\ |\ **--help**\ |\ **-v**\ |\ **--version**\ ]
+\ **reventlog**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
 
 *******************
@@ -64,13 +64,13 @@ logs are stored on each servers service processor.
  
 
 
-\ **-h**\ |\ **--help**\ 
+\ **-h | -**\ **-help**\ 
  
  Print help.
  
 
 
-\ **-v**\ |\ **--version**\ 
+\ **-v | -**\ **-version**\ 
  
  Print version.
  

--- a/docs/source/guides/admin-guides/references/man1/rflash.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rflash.1.rst
@@ -19,24 +19,24 @@ Name
 ****************
 
 
-\ **rflash**\  [\ **-h**\ |\ **--help**\  | \ **-v**\ |\ **--version**\ ]
+\ **rflash**\  [\ **-h | -**\ **-help**\  | \ **-v | -**\ **-version**\ ]
 
 PPC (with HMC) specific:
 ========================
 
 
-\ **rflash**\  \ *noderange*\  \ **-p**\  \ *directory*\  {\ **--activate**\  \ **concurrent**\ |\ **disruptive**\ } [\ **-V**\ |\ **--verbose**\ ]
+\ **rflash**\  \ *noderange*\  \ **-p**\  \ *directory*\  {\ **-**\ **-activate**\  \ **concurrent | disruptive**\ } [\ **-V | -**\ **-verbose**\ ]
 
-\ **rflash**\  \ *noderange*\  {\ **--commit**\ |\ **--recover**\ } [\ **-V**\ |\ **--verbose**\ ]
+\ **rflash**\  \ *noderange*\  {\ **-**\ **-commit | -**\ **-recover**\ } [\ **-V | -**\ **-verbose**\ ]
 
 
 PPC (without HMC, using Direct FSP Management) specific:
 ========================================================
 
 
-\ **rflash**\  \ *noderange*\  \ **-p**\  \ *directory*\  \ **--activate**\  \ **disruptive**\ |\ **deferred**\  [\ **-d**\  \ *data_directory*\ ]
+\ **rflash**\  \ *noderange*\  \ **-p**\  \ *directory*\  \ **-**\ **-activate**\  \ **disruptive | deferred**\  [\ **-d**\  \ *data_directory*\ ]
 
-\ **rflash**\  \ *noderange*\  {\ **--commit**\ |\ **--recover**\ }
+\ **rflash**\  \ *noderange*\  {\ **-**\ **-commit | -**\ **-recover**\ }
 
 
 NeXtScale FPC specific:
@@ -50,7 +50,7 @@ OpenPOWER BMC specific:
 =======================
 
 
-\ **rflash**\  \ *noderange*\  \ *hpm file path*\  [\ **-c**\ |\ **--check**\ ]
+\ **rflash**\  \ *noderange*\  \ *hpm file path*\  [\ **-c | -**\ **-check**\ ]
 
 
 
@@ -77,13 +77,13 @@ The \ **rflash**\  command uses the \ **xdsh**\  command to connect to the HMC c
 
 \ **Warning!**\   This command may take considerable time to complete, depending on the number of systems being updated and the workload on the target HMC.  In particular, power subsystem updates may take an hour or more if there are many attached managed systems.
 
-Depending on the Licensed Internal Code update that is installed, the affected HMC-attached POWER5 and POWER6 systems may need to be recycled.  The \ **--activate**\  flag determines how the affected systems activate the new code.  The concurrent option activates code updates that do not require a system recycle (known as a "concurrent update").  If this option is given with an update that requires a system recycle (known as a "disruptive update"), a message will be returned, and no activation will be performed.  The disruptive option will cause any affected systems that are powered on to be powered down before installing and activating the update.  Once the update is complete, the command will attempt to power on any affected systems that it powered down.  Those systems that were powered down when the command was issued will remain powered down when the update is complete.
+Depending on the Licensed Internal Code update that is installed, the affected HMC-attached POWER5 and POWER6 systems may need to be recycled.  The \ **-**\ **-activate**\  flag determines how the affected systems activate the new code.  The concurrent option activates code updates that do not require a system recycle (known as a "concurrent update").  If this option is given with an update that requires a system recycle (known as a "disruptive update"), a message will be returned, and no activation will be performed.  The disruptive option will cause any affected systems that are powered on to be powered down before installing and activating the update.  Once the update is complete, the command will attempt to power on any affected systems that it powered down.  Those systems that were powered down when the command was issued will remain powered down when the update is complete.
 
 The flash chip of a POWER5 and POWER6 managed system or power subsystem stores firmware in two locations, referred to as the temporary side and the permanent side.  By default, most POWER5 and POWER6 systems boot from the temporary side of the flash.  When the \ **rflash**\  command updates code, the current contents of the temporary side are written to the permanent side, and the new code is written to the temporary side.  The new code is then activated.  Therefore, the two sides of the flash will contain different levels of code when the update has completed.
 
-The \ **--commit**\  flag is used to write the contents of the temporary side of the flash to the permanent side.  This flag should be used after updating code and verifying correct system operation.  The \ **--recover**\  flag is used to write the permanent side of the flash chip back to the temporary side.  This flag should be used to recover from a corrupt flash operation, so that the previously running code can be restored.
+The \ **-**\ **-commit**\  flag is used to write the contents of the temporary side of the flash to the permanent side.  This flag should be used after updating code and verifying correct system operation.  The \ **-**\ **-recover**\  flag is used to write the permanent side of the flash chip back to the temporary side.  This flag should be used to recover from a corrupt flash operation, so that the previously running code can be restored.
 
-\ **NOTE:**\ When the \ **--commit**\  or \ **--recover**\  two flags is used, the noderange \ **cannot**\  be BPA. It only \ **can**\  be CEC or LPAR ,and  will take effect for \ **both**\  managed systems and power subsystems.
+\ **NOTE:**\ When the \ **-**\ **-commit**\  or \ **-**\ **-recover**\  two flags is used, the noderange \ **cannot**\  be BPA. It only \ **can**\  be CEC or LPAR ,and  will take effect for \ **both**\  managed systems and power subsystems.
 
 xCAT recommends that you shutdown your Operating System images and power off your managed systems before applying disruptive updates to managed systems or power subsystems.
 
@@ -98,7 +98,7 @@ PPC (using Direct FSP Management) specific:
 ===========================================
 
 
-In currently Direct FSP/BPA Management, our \ **rflash**\  doesn't support \ **concurrent**\  value of \ **--activate**\  flag, and supports \ **disruptive**\  and \ **deferred**\ . The \ **disruptive**\  option will cause any affected systems that are powered on to be powered down before installing and activating the update. So we require that the systems should be powered off before do the firmware update.
+In currently Direct FSP/BPA Management, our \ **rflash**\  doesn't support \ **concurrent**\  value of \ **-**\ **-activate**\  flag, and supports \ **disruptive**\  and \ **deferred**\ . The \ **disruptive**\  option will cause any affected systems that are powered on to be powered down before installing and activating the update. So we require that the systems should be powered off before do the firmware update.
 
 The \ **deferred**\  option will load the new firmware into the T (temp) side, but will not activate it like the disruptive firmware. The customer will continue to run the Frames and CECs working with the P (perm) side and can wait for a maintenance window where they can activate and boot the Frame/CECs with new firmware levels. Refer to the doc to get more details:
   XCAT_Power_775_Hardware_Management
@@ -136,13 +136,13 @@ The command will update firmware for OpenPOWER BMC when given an OpenPOWER node 
 
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Writes the command's usage statement to standard output.
  
 
 
-\ **-c|--check**\ 
+\ **-c|-**\ **-check**\ 
  
  Chech the firmware version of BMC and HPM file.
  
@@ -160,31 +160,31 @@ The command will update firmware for OpenPOWER BMC when given an OpenPOWER node 
  
 
 
-\ **--activate**\  \ **concurrent**\  | \ **disruptive**\ 
+\ **-**\ **-activate**\  \ **concurrent**\  | \ **disruptive**\ 
  
  Must be specified to activate the new Licensed Internal Code.  The "disruptive" option will cause the target systems to be recycled.  Without this flag, LIC updates will be installed only, not activated.
  
 
 
-\ **--commit**\ 
+\ **-**\ **-commit**\ 
  
  Used to commit the flash image in the temporary side of the chip to the permanent side for both managed systems and power subsystems.
  
 
 
-\ **--recover**\ 
+\ **-**\ **-recover**\ 
  
  Used to recover the flash image in the permanent side of the chip to the temporary side for both managed systems and power subsystems.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Displays the command's version.
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Verbose output.
  

--- a/docs/source/guides/admin-guides/references/man1/rinv.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rinv.1.rst
@@ -19,20 +19,20 @@ Name
 ****************
 
 
-\ **rinv**\  [\ **-h**\ |\ **--help**\ |\ **-v**\ |\ **--version**\ ]
+\ **rinv**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
 BMC/MPA specific:
 =================
 
 
-\ **rinv**\  \ *noderange*\  {\ **pci**\ |\ **model**\ |\ **serial**\ |\ **asset**\ |\ **vpd**\ |\ **mprom**\ |\ **deviceid**\ |\ **guid**\ |\ **firm**\ |\ **diag**\ |\ **bios**\ |\ **mparom**\ |\ **mac**\ |\ **all**\ }
+\ **rinv**\  \ *noderange*\  {\ **pci | model | serial | asset | vpd | mprom | deviceid | guid | firm | diag | bios | mparom | mac | all**\ }
 
 
 PPC (with HMC) specific:
 ========================
 
 
-\ **rinv**\  \ *noderange*\  {\ **bus**\ |\ **config**\ |\ **serial**\ |\ **model**\ |\ **firm**\ |\ **all**\ }
+\ **rinv**\  \ *noderange*\  {\ **bus | config | serial | model | firm | all**\ }
 
 
 PPC (using Direct FSP Management) specific:
@@ -48,7 +48,7 @@ Blade specific:
 ===============
 
 
-\ **rinv**\  \ *noderange*\  {\ **mtm**\ |\ **serial**\ |\ **mac**\ |\ **bios**\ |\ **diag**\ |\ **mprom**\ |\ **mparom**\ |\ **firm**\ |\ **all**\ }
+\ **rinv**\  \ *noderange*\  {\ **mtm | serial | mac | bios | diag | mprom | mparom | firm | all**\ }
 
 
 VMware specific:
@@ -62,29 +62,29 @@ zVM specific:
 =============
 
 
-\ **rinv**\  \ *noderange*\  [\ **config**\ |\ **all**\ ]
+\ **rinv**\  \ *noderange*\  [\ **config | all**\ ]
 
-\ **rinv**\  \ *noderange*\  [\ **--diskpoolspace**\ ]
+\ **rinv**\  \ *noderange*\  [\ **-**\ **-diskpoolspace**\ ]
 
-\ **rinv**\  \ *noderange*\  [\ **--diskpool**\  \ *pool*\  \ *space*\ ]
+\ **rinv**\  \ *noderange*\  [\ **-**\ **-diskpool**\  \ *pool*\  \ *space*\ ]
 
-\ **rinv**\  \ *noderange*\  [\ **--fcpdevices**\  \ *state*\  \ *details*\ ]
+\ **rinv**\  \ *noderange*\  [\ **-**\ **-fcpdevices**\  \ *state*\  \ *details*\ ]
 
-\ **rinv**\  \ *noderange*\  [\ **--diskpoolnames**\ ]
+\ **rinv**\  \ *noderange*\  [\ **-**\ **-diskpoolnames**\ ]
 
-\ **rinv**\  \ *noderange*\  [\ **--networknames**\ ]
+\ **rinv**\  \ *noderange*\  [\ **-**\ **-networknames**\ ]
 
-\ **rinv**\  \ *noderange*\  [\ **--network**\  \ *name*\ ]
+\ **rinv**\  \ *noderange*\  [\ **-**\ **-network**\  \ *name*\ ]
 
-\ **rinv**\  \ *noderange*\  [\ **--ssi**\ ]
+\ **rinv**\  \ *noderange*\  [\ **-**\ **-ssi**\ ]
 
-\ **rinv**\  \ *noderange*\  [\ **--smapilevel**\ ]
+\ **rinv**\  \ *noderange*\  [\ **-**\ **-smapilevel**\ ]
 
-\ **rinv**\  \ *noderange*\  [\ **--wwpns**\  \ *fcp_channel*\ ]
+\ **rinv**\  \ *noderange*\  [\ **-**\ **-wwpns**\  \ *fcp_channel*\ ]
 
-\ **rinv**\  \ *noderange*\  [\ **--zfcppool**\  \ *pool*\  \ *space*\ ]
+\ **rinv**\  \ *noderange*\  [\ **-**\ **-zfcppool**\  \ *pool*\  \ *space*\ ]
 
-\ **rinv**\  \ *noderange*\  [\ **--zfcppoolnames**\ ]
+\ **rinv**\  \ *noderange*\  [\ **-**\ **-zfcppoolnames**\ ]
 
 
 
@@ -196,13 +196,13 @@ Calling \ **rinv**\  for VMware will display the UUID/GUID, nuumber of CPUs, amo
  
 
 
-\ **-h**\ |\ **--help**\ 
+\ **-h | -**\ **-help**\ 
  
  Print help.
  
 
 
-\ **-v**\ |\ **--version**\ 
+\ **-v | -**\ **-version**\ 
  
  Print version.
  
@@ -215,67 +215,67 @@ Calling \ **rinv**\  for VMware will display the UUID/GUID, nuumber of CPUs, amo
  \ **zVM specific :**\ 
  
  
- \ **--diskpoolspace**\ 
+ \ **-**\ **-diskpoolspace**\ 
   
   Calculates the total size of every known storage pool.
   
  
  
- \ **--diskpool**\  \ *pool*\  \ *space*\ 
+ \ **-**\ **-diskpool**\  \ *pool*\  \ *space*\ 
   
   Lists the storage devices (ECKD and FBA) contained in a disk pool. Space can be: all, free, or used.
   
  
  
- \ **--fcpdevices**\  \ *state*\  \ *details*\ 
+ \ **-**\ **-fcpdevices**\  \ *state*\  \ *details*\ 
   
   Lists the FCP device channels that are active, free, or offline. State can be: active, free, or offline.
   
  
  
- \ **--diskpoolnames**\ 
+ \ **-**\ **-diskpoolnames**\ 
   
   Lists the known disk pool names.
   
  
  
- \ **--networknames**\ 
+ \ **-**\ **-networknames**\ 
   
   Lists the known network names.
   
  
  
- \ **--network**\  \ *name*\ 
+ \ **-**\ **-network**\  \ *name*\ 
   
   Shows the configuration of a given network device.
   
  
  
- \ **--ssi**\ 
+ \ **-**\ **-ssi**\ 
   
   Obtain the SSI and system status.
   
  
  
- \ **--smapilevel**\ 
+ \ **-**\ **-smapilevel**\ 
   
   Obtain the SMAPI level installed on the z/VM system.
   
  
  
- \ **--wwpns**\  \ *fcp_channel*\ 
+ \ **-**\ **-wwpns**\  \ *fcp_channel*\ 
   
   Query a given FCP device channel on a z/VM system and return a list of WWPNs.
   
  
  
- \ **--zfcppool**\  \ *pool*\  \ *space*\ 
+ \ **-**\ **-zfcppool**\  \ *pool*\  \ *space*\ 
   
   List the SCSI/FCP devices contained in a zFCP pool. Space can be: free or used.
   
  
  
- \ **--zfcppoolnames**\ 
+ \ **-**\ **-zfcppoolnames**\ 
   
   List the known zFCP pool names.
   

--- a/docs/source/guides/admin-guides/references/man1/rmdef.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rmdef.1.rst
@@ -19,10 +19,10 @@ SYNOPSIS
 ********
 
 
-\ **rmdef**\  [\ **-h**\ |\ **--help**\ ] [\ **-t**\  \ *object-types*\ ]
+\ **rmdef**\  [\ **-h | -**\ **-help**\ ] [\ **-t**\  \ *object-types*\ ]
 
-\ **rmdef**\  [\ **-V**\ |\ **--verbose**\ ] [\ **-a**\ |\ **--all**\ ] [\ **-t**\  \ *object-types*\ ] [\ **-o**\  \ *object-names*\ ]
-[\ **-f**\ |\ **--force**\ ] [\ *noderange*\ ]
+\ **rmdef**\  [\ **-V | -**\ **-verbose**\ ] [\ **-a | -**\ **-all**\ ] [\ **-t**\  \ *object-types*\ ] [\ **-o**\  \ *object-names*\ ]
+[\ **-f | -**\ **-force**\ ] [\ *noderange*\ ]
 
 
 ***********
@@ -39,7 +39,7 @@ OPTIONS
 
 
 
-\ **-a|--all**\ 
+\ **-a|-**\ **-all**\ 
  
  Clear the whole xCAT database. A backup of the xCAT definitions should be saved before using this option.  Once all the data is removed the xCAT daemon will no longer work. Most xCAT commands will fail. 
  In order to use xCAT commands again, you have two options.  You can restore your database from your backup by switching to bypass mode, and running the restorexCATdb command. 
@@ -49,13 +49,13 @@ OPTIONS
  
 
 
-\ **-f|--force**\ 
+\ **-f|-**\ **-force**\ 
  
  Use this with the all option as an extra indicator that ALL definitions are to be removed.
  
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display a usage message.
  
@@ -79,7 +79,7 @@ OPTIONS
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Verbose mode.
  

--- a/docs/source/guides/admin-guides/references/man1/rmdocker.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rmdocker.1.rst
@@ -13,9 +13,9 @@ SYNOPSIS
 
 \ **rmdocker**\  \ *noderange*\ 
 
-\ **rmdocker**\  [\ **-h**\ |\ **--help**\ ]
+\ **rmdocker**\  [\ **-h | -**\ **-help**\ ]
 
-\ **rmdocker**\  {\ **-v**\ |\ **--version**\ }
+\ **rmdocker**\  {\ **-v | -**\ **-version**\ }
 
 
 ***********

--- a/docs/source/guides/admin-guides/references/man1/rmdsklsnode.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rmdsklsnode.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **rmdsklsnode [-h | --help ]**\ 
+\ **rmdsklsnode [-h | -**\ **-help ]**\ 
 
-\ **rmdsklsnode [-V|--verbose] [-f|--force] [-r|--remdef] [-i image_name] [-p|--primarySN] [-b|--backupSN] noderange**\ 
+\ **rmdsklsnode [-V|-**\ **-verbose] [-f|-**\ **-force] [-r|-**\ **-remdef] [-i image_name] [-p|-**\ **-primarySN] [-b|-**\ **-backupSN] noderange**\ 
 
 
 ***********
@@ -52,20 +52,20 @@ OPTIONS
 
 
 
-\ **-f |--force**\ 
+\ **-f |-**\ **-force**\ 
  
  Use the force option to stop and remove running nodes. This handles the situation where a NIM machine definition indicates that a node is still running even though it is not.
  
 
 
-\ **-b |--backupSN**\ 
+\ **-b |-**\ **-backupSN**\ 
  
  When using backup service nodes only update the backup.  The default is to updat
  e both the primary and backup service nodes.
  
 
 
-\ **-h |--help**\ 
+\ **-h |-**\ **-help**\ 
  
  Display usage message.
  
@@ -83,20 +83,20 @@ OPTIONS
  
 
 
-\ **-p|--primarySN**\ 
+\ **-p|-**\ **-primarySN**\ 
  
  When using backup service nodes only update the primary.  The default is to upda
  te both the primary and backup service nodes.
  
 
 
-\ **-r|--remdef**\ 
+\ **-r|-**\ **-remdef**\ 
  
  Use this option to reset, deallocate, and remove NIM client definitions.  This option will not attempt to shut down running nodes. This option should be used when remove alternate NIM client definitions that were created using \ **mkdsklsnode -n**\ .
  
 
 
-\ **-V |--verbose**\ 
+\ **-V |-**\ **-verbose**\ 
  
  Verbose mode.
  

--- a/docs/source/guides/admin-guides/references/man1/rmflexnode.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rmflexnode.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **rmflexnode**\  [-h | --help]
+\ **rmflexnode**\  [-h | -**\ **-help]
 
-\ **rmflexnode**\  [-v | --version]
+\ **rmflexnode**\  [-v | -**\ **-version]
 
 \ **rmflexnode**\  \ *noderange*\ 
 
@@ -48,13 +48,13 @@ OPTIONS
 
 
 
-\ **-h | --help**\ 
+\ **-h | -**\ **-help**\ 
  
  Display the usage message.
  
 
 
-\ **-v | --version**\ 
+\ **-v | -**\ **-version**\ 
  
  Display the version information.
  

--- a/docs/source/guides/admin-guides/references/man1/rmhwconn.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rmhwconn.1.rst
@@ -19,15 +19,15 @@ SYNOPSIS
 ********
 
 
-\ **rmhwconn**\  [\ **-h**\ | \ **--help**\ ]
+\ **rmhwconn**\  [\ **-h**\ | \ **-**\ **-help**\ ]
 
-\ **rmhwconn**\  [\ **-v**\ | \ **--version**\ ]
+\ **rmhwconn**\  [\ **-v**\ | \ **-**\ **-version**\ ]
 
 PPC (with HMC) specific:
 ========================
 
 
-\ **rmhwconn**\  [\ **-V**\ | \ **--verbose**\ ] \ *noderange*\ 
+\ **rmhwconn**\  [\ **-V**\ | \ **-**\ **-verbose**\ ] \ *noderange*\ 
 
 
 PPC (without HMC, using FSPAPI) specific:
@@ -71,13 +71,13 @@ OPTIONS
 
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Verbose output.
  

--- a/docs/source/guides/admin-guides/references/man1/rmimage.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rmimage.1.rst
@@ -59,11 +59,11 @@ OPTIONS
 *******
 
 
-\ **-h | --help**\      Display usage message.
+\ **-h | -**\ **-help**\      Display usage message.
 
-\ **-V | --verbose**\   Verbose mode.
+\ **-V | -**\ **-verbose**\   Verbose mode.
 
-\ **--xcatdef**\        Remove the xCAT osimage definition
+\ **-**\ **-xcatdef**\        Remove the xCAT osimage definition
 
 
 ************

--- a/docs/source/guides/admin-guides/references/man1/rmkit.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rmkit.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **rmkit**\  [\ **-?**\ |\ **-h**\ |\ **--help**\ ] [\ **-v**\ |\ **--version**\ ]
+\ **rmkit**\  [\ **-? | -h | -**\ **-help**\ ] [\ **-v | -**\ **-version**\ ]
 
-\ **rmkit**\  [\ **-V**\ |\ **--verbose**\ ] [\ **-f**\ |\ **--force**\ ] [\ **-t**\ |\ **--test**\ ] \ *kitlist*\ 
+\ **rmkit**\  [\ **-V | -**\ **-verbose**\ ] [\ **-f | -**\ **-force**\ ] [\ **-t | -**\ **-test**\ ] \ *kitlist*\ 
 
 
 ***********
@@ -40,31 +40,31 @@ OPTIONS
 
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Verbose mode.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command version.
  
 
 
-\ **-f|--force**\ 
+\ **-f|-**\ **-force**\ 
  
  Remove this kit even there is any component in this kit is listed by osimage.kitcomponents.  If this option is not specified, this kit will not be removed if any kit components listed in an osimage.kitcomponents
  
 
 
-\ **-t|--test**\ 
+\ **-t|-**\ **-test**\ 
  
  Test if kitcomponents in this kit are used by osimage
  

--- a/docs/source/guides/admin-guides/references/man1/rmkitcomp.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rmkitcomp.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **rmkitcomp**\  [\ **-?**\ |\ **-h**\ |\ **--help**\ ] [\ **-v**\ |\ **--version**\ ]
+\ **rmkitcomp**\  [\ **-? | -h | -**\ **-help**\ ] [\ **-v | -**\ **-version**\ ]
 
-\ **rmkitcomp**\  [\ **-V**\ |\ **--verbose**\ ] [\ **-u**\ |\ **--uninstall**\ ] [\ **-f**\ |\ **--force**\ ] [\ **--noscripts**\ ] \ **-i**\  \ *osimage*\   \ *kitcompname_list*\ 
+\ **rmkitcomp**\  [\ **-V | -**\ **-verbose**\ ] [\ **-u | -**\ **-uninstall**\ ] [\ **-f | -**\ **-force**\ ] [\ **-**\ **-noscripts**\ ] \ **-i**\  \ *osimage*\   \ *kitcompname_list*\ 
 
 
 ***********
@@ -29,7 +29,7 @@ DESCRIPTION
 ***********
 
 
-The \ **rmkitcomp**\  command removes kit components from an xCAT osimage.  All the kit component attribute values that are contained in the osimage will be removed, and the kit comoponent meta rpm and package rpm could be uninstalled by <-u|--uninstall> option.
+The \ **rmkitcomp**\  command removes kit components from an xCAT osimage.  All the kit component attribute values that are contained in the osimage will be removed, and the kit comoponent meta rpm and package rpm could be uninstalled by <-u|-**\ **-uninstall> option.
 
 Note: The xCAT support for Kits is only available for Linux operating systems.
 
@@ -40,37 +40,37 @@ OPTIONS
 
 
 
-\ **-u|--uninstall**\ 
+\ **-u|-**\ **-uninstall**\ 
  
  All the kit component meta rpms and package rpms in otherpkglist will be uninstalled during genimage for stateless image and updatenode for stateful nodes.
  
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Verbose mode.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command version.
  
 
 
-\ **-f|--force**\ 
+\ **-f|-**\ **-force**\ 
  
  Remove this kit component from osimage no matter it is a dependency of other kit components.
  
 
 
-\ **--noscripts**\ 
+\ **-**\ **-noscripts**\ 
  
  Do not remove kitcomponent's postbootscripts from osimage
  

--- a/docs/source/guides/admin-guides/references/man1/rmnimimage.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rmnimimage.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **rmnimimage [-h|--help]**\ 
+\ **rmnimimage [-h|-**\ **-help]**\ 
 
-\ **rmnimimage [-V|--verbose] [-f|--force] [-d|--delete] [-x|--xcatdef] [-M|--managementnode] [-s servicenoderange] osimage_name**\ 
+\ **rmnimimage [-V|-**\ **-verbose] [-f|-**\ **-force] [-d|-**\ **-delete] [-x|-**\ **-xcatdef] [-M|-**\ **-managementnode] [-s servicenoderange] osimage_name**\ 
 
 
 ***********
@@ -58,25 +58,25 @@ OPTIONS
 
 
 
-\ **-h |--help**\ 
+\ **-h |-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-d|--delete**\ 
+\ **-d|-**\ **-delete**\ 
  
  Delete any files or directories that were left after the "nim -o remove" command was run. This option will also remove the lpp_source resouce and all files contained in the lpp_source directories. When this command completes all definitions and files will be completely erased so use with caution!
  
 
 
-\ **-f|--force**\ 
+\ **-f|-**\ **-force**\ 
  
  Override the check for shared resources when removing an xCAT osimage.
  
 
 
-\ **-M|--managementnode**\ 
+\ **-M|-**\ **-managementnode**\ 
  
  Remove NIM resources from the xCAT management node only.
  
@@ -94,13 +94,13 @@ OPTIONS
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Verbose mode. This option will display the underlying NIM commands that are being called.
  
 
 
-\ **-x|--xcatdef**\ 
+\ **-x|-**\ **-xcatdef**\ 
  
  Remove the xCAT osimage definition.
  

--- a/docs/source/guides/admin-guides/references/man1/rmvlan.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rmvlan.1.rst
@@ -21,9 +21,9 @@ SYNOPSIS
 
 \ **rmvlan**\  \ *vlanid*\ 
 
-\ **rmvlan**\  [\ **-h**\ |\ **--help**\ ]
+\ **rmvlan**\  [\ **-h | -**\ **-help**\ ]
 
-\ **rmvlan**\  [\ **-v**\ |\ **--version**\ ]
+\ **rmvlan**\  [\ **-v | -**\ **-version**\ ]
 
 
 ***********
@@ -50,11 +50,11 @@ OPTIONS
 
 
 
-\ **-h|--help**\      Display usage message.
+\ **-h|-**\ **-help**\      Display usage message.
 
 
 
-\ **-v|--version**\   The Command Version.
+\ **-v|-**\ **-version**\   The Command Version.
 
 
 

--- a/docs/source/guides/admin-guides/references/man1/rmvm.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rmvm.1.rst
@@ -63,11 +63,11 @@ OPTIONS
 
 \ **-r**\           Retain the data object definitions of the nodes.
 
-\ **--service**\    Remove the service partitions of the specified CECs.
+\ **-**\ **-service**\    Remove the service partitions of the specified CECs.
 
 \ **-p**\           Purge the existence of the VM from persistant storage.  This will erase all storage related to the VM in addition to removing it from the active virtualization configuration.
 
-\ **-p|--part**\    Remove the specified partiton on normal power machine.
+\ **-p|-**\ **-part**\    Remove the specified partiton on normal power machine.
 
 \ **-f**\           Force remove the VM, even if the VM appears to be online.  This will bring down a live VM if requested.
 

--- a/docs/source/guides/admin-guides/references/man1/rmzone.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rmzone.1.rst
@@ -43,32 +43,32 @@ Note: if any zones in the zone table, there must be one and only one defaultzone
 
 
 
-\ **-h**\ |\ **--help**\ 
+\ **-h | -**\ **-help**\ 
  
  Displays usage information.
  
 
 
-\ **-v**\ |\ **--version**\ 
+\ **-v | -**\ **-version**\ 
  
  Displays command version and build date.
  
 
 
-\ **-f | --force**\ 
+\ **-f | -**\ **-force**\ 
  
  Used to remove a zone that is defined as current default zone.  This should only be done if you are removing all zones, or you will
  adding a new zone or changing an existing zone to be the default zone.
  
 
 
-\ **-g | --assigngroup**\ 
+\ **-g | -**\ **-assigngroup**\ 
  
  Remove the assigned group named \ **zonename**\  from all nodes assigned to the zone being removed.
  
 
 
-\ **-V**\ |\ **--Verbose**\ 
+\ **-V | -**\ **-Verbose**\ 
  
  Verbose mode.
  

--- a/docs/source/guides/admin-guides/references/man1/rnetboot.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rnetboot.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **rnetboot**\  [\ **-V**\ |\ **--verbose**\ ] [\ **-s**\  \ *boot_device_order*\ ] [\ **-F**\ ] [\ **-f**\ ] \ *noderange*\  [\ **-m**\  \ *table.column*\ ==\ *expectedstatus*\  [\ **-m**\  \ *table.col-umn*\ =~\ *expectedstatus*\ ]] [\ **-t**\  \ *timeout*\ ] [\ **-r**\  \ *retrycount*\ ]
+\ **rnetboot**\  [\ **-V | -**\ **-verbose**\ ] [\ **-s**\  \ *boot_device_order*\ ] [\ **-F**\ ] [\ **-f**\ ] \ *noderange*\  [\ **-m**\  \ *table.column*\ ==\ *expectedstatus*\  [\ **-m**\  \ *table.col-umn*\ =~\ *expectedstatus*\ ]] [\ **-t**\  \ *timeout*\ ] [\ **-r**\  \ *retrycount*\ ]
 
-\ **rnetboot**\  [\ **-h**\ |\ **--help**\ ] [\ **-v**\ |\ **--version**\ ]
+\ **rnetboot**\  [\ **-h | -**\ **-help**\ ] [\ **-v | -**\ **-version**\ ]
 
 zVM specific:
 =============

--- a/docs/source/guides/admin-guides/references/man1/rollupdate.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rollupdate.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **cat**\  \ *stanza-file*\  \ **|**\  \ **rollupdate**\  [\ **-V**\  | \ **--verbose**\ ] [\ **-t**\ | \ **--test**\ ]
+\ **cat**\  \ *stanza-file*\  \ **|**\  \ **rollupdate**\  [\ **-V**\  | \ **-**\ **-verbose**\ ] [\ **-t**\ | \ **-**\ **-test**\ ]
 
-\ **rollupdate**\  [\ **-?**\  | \ **-h**\  | \ **--help**\  | \ **-v**\  | \ **--version**\ ]
+\ **rollupdate**\  [\ **-?**\  | \ **-h**\  | \ **-**\ **-help**\  | \ **-v**\  | \ **-**\ **-version**\ ]
 
 
 ***********
@@ -48,25 +48,25 @@ OPTIONS
 
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command Version.
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Display additional progress and error messages.  Output is also logged in /var/log/xcat/rollupdate.log.
  
 
 
-\ **-t|--test**\ 
+\ **-t|-**\ **-test**\ 
  
  Run the rollupdate command in test mode only to verify the output files that are created.  No scheduler reservation requests will be submitted.
  
 
 
-\ **-?|-h|--help**\ 
+\ **-?|-h|-**\ **-help**\ 
  
  Display usage message.
  

--- a/docs/source/guides/admin-guides/references/man1/rpower.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rpower.1.rst
@@ -19,87 +19,87 @@ SYNOPSIS
 ********
 
 
-\ **rpower**\  \ *noderange*\  [\ **--nodeps**\ ] [\ **on**\ |\ **onstandby**\ |\ **off**\ |\ **suspend**\ |\ **stat**\ |\ **state**\ |\ **reset**\ |\ **boot**\ ] [\ **-m**\  \ *table.column*\ ==\ *expectedstatus*\  [\ **-m**\  \ *table.column*\ =~\ *expectedstatus*\ ]] [\ **-t**\  \ *timeout*\ ] [\ **-r**\  \ *retrycount*\ ]
+\ **rpower**\  \ *noderange*\  [\ **-**\ **-nodeps**\ ] [\ **on | onstandby | off | suspend | stat | state | reset | boot**\ ] [\ **-m**\  \ *table.column*\ ==\ *expectedstatus*\  [\ **-m**\  \ *table.column*\ =~\ *expectedstatus*\ ]] [\ **-t**\  \ *timeout*\ ] [\ **-r**\  \ *retrycount*\ ]
 
-\ **rpower**\  [\ **-h**\ |\ **--help**\ |\ **-v**\ |\ **--version**\ ]
+\ **rpower**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
 BMC (using IPMI) specific:
 ==========================
 
 
-\ **rpower**\  \ *noderange*\  [\ **on**\ |\ **off**\ |\ **softoff**\ |\ **reset**\ |\ **boot**\ |\ **stat**\ |\ **state**\ |\ **status**\ |\ **wake**\ |\ **suspend**\  [\ **-w**\  \ *timeout*\ ] [\ **-o**\ ] [\ **-r**\ ]]
+\ **rpower**\  \ *noderange*\  [\ **on | off | softoff | reset | boot | stat | state | status | wake | suspend**\  [\ **-w**\  \ *timeout*\ ] [\ **-o**\ ] [\ **-r**\ ]]
 
 
 PPC (with IVM or HMC) specific:
 ===============================
 
 
-\ **rpower**\  \ *noderange*\  [\ **--nodeps**\ ] {\ **of**\ }
+\ **rpower**\  \ *noderange*\  [\ **-**\ **-nodeps**\ ] {\ **of**\ }
 
 
 CEC (with HMC) specific:
 ========================
 
 
-\ **rpower**\  \ *noderange*\  [\ **on**\ |\ **off**\ |\ **reset**\ |\ **boot**\ |\ **onstandby**\ ]
+\ **rpower**\  \ *noderange*\  [\ **on | off | reset | boot | onstandby**\ ]
 
 
 LPAR (with HMC) specific:
 =========================
 
 
-\ **rpower**\  \ *noderange*\  [\ **on**\ |\ **off**\ |\ **stat**\ |\ **state**\ |\ **reset**\ |\ **boot**\ |\ **of**\ |\ **sms**\ |\ **softoff**\ ]
+\ **rpower**\  \ *noderange*\  [\ **on | off | stat | state | reset | boot | of | sms | softoff**\ ]
 
 
 CEC (using Direct FSP Management) specific:
 ===========================================
 
 
-\ **rpower**\  \ *noderange*\  [\ **onstandby**\ |\ **stat**\ |\ **state**\ ] [\ **-T tooltype**\ ]
+\ **rpower**\  \ *noderange*\  [\ **onstandby | stat | state**\ ] [\ **-T tooltype**\ ]
 
-\ **rpower**\  \ *noderange*\  [\ **on**\ |\ **off**\ |\ **resetsp**\ ]
+\ **rpower**\  \ *noderange*\  [\ **on | off | resetsp**\ ]
 
 
 Frame (using Direct FSP Management) specific:
 =============================================
 
 
-\ **rpower**\  \ *noderange*\  [\ **rackstandby**\ |\ **exit_rackstandby**\ |\ **stat**\ |\ **state**\ |\ **resetsp**\ ]
+\ **rpower**\  \ *noderange*\  [\ **rackstandby | exit_rackstandby | stat | state | resetsp**\ ]
 
 
 LPAR (using Direct FSP Management) specific:
 ============================================
 
 
-\ **rpower**\  \ *noderange*\  [\ **on**\ |\ **off**\ |\ **stat**\ |\ **state**\ |\ **reset**\ |\ **boot**\ |\ **of**\ |\ **sms**\ ]
+\ **rpower**\  \ *noderange*\  [\ **on | off | stat | state | reset | boot | of | sms**\ ]
 
 
 Blade (using Direct FSP Management) specific:
 =============================================
 
 
-\ **rpower**\  \ *noderange*\  [\ **on**\ |\ **onstandby**\ |\ **off**\ |\ **stat**\ |\ **state**\ |\ **sms**\ ]
+\ **rpower**\  \ *noderange*\  [\ **on | onstandby | off | stat | state | sms**\ ]
 
 
 Blade specific:
 ===============
 
 
-\ **rpower**\  \ *noderange*\  [\ **cycle**\ |\ **softoff**\ ]
+\ **rpower**\  \ *noderange*\  [\ **cycle | softoff**\ ]
 
 
 zVM specific:
 =============
 
 
-\ **rpower**\  \ *noderange*\  [\ **on**\ |\ **off**\ |\ **reset**\ |\ **stat**\ |\ **softoff**\ ]
+\ **rpower**\  \ *noderange*\  [\ **on | off | reset | stat | softoff**\ ]
 
 
 docker specific:
 ================
 
 
-\ **rpower**\  \ *noderange*\  [\ **start**\ |\ **stop**\ |\ **restart**\ |\ **pause**\ |\ **unpause**\ |\ **state**\ ]
+\ **rpower**\  \ *noderange*\  [\ **start | stop | restart | pause | unpause | state**\ ]
 
 
 
@@ -228,7 +228,7 @@ OPTIONS
  
 
 
-\ **stat**\ |\ **state**\ 
+\ **stat | state**\ 
  
  Print the current power state/status.
  
@@ -274,7 +274,7 @@ OPTIONS
  
 
 
-\ **--nodeps**\ 
+\ **-**\ **-nodeps**\ 
  
  Do not use dependency table (default is to use dependency table). Valid only with \ **on|off|boot|reset|cycle**\  for blade power method and \ **on|off|reset|softoff**\  for hmc/fsp power method.
  
@@ -348,13 +348,13 @@ OPTIONS
  
 
 
-\ **-h**\ |\ **--help**\ 
+\ **-h | -**\ **-help**\ 
  
  Prints out a brief usage message.
  
 
 
-\ **-v**\ |\ **--version**\ 
+\ **-v | -**\ **-version**\ 
  
  Display the version number.
  

--- a/docs/source/guides/admin-guides/references/man1/rsetboot.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rsetboot.1.rst
@@ -11,9 +11,9 @@ SYNOPSIS
 ********
 
 
-\ **rsetboot**\  \ *noderange*\  {\ **hd**\ |\ **net**\ |\ **cd**\ |\ **default**\ |\ **stat**\ }
+\ **rsetboot**\  \ *noderange*\  {\ **hd | net | cd | default | stat**\ }
 
-\ **rsetboot**\  [\ **-h**\ |\ **--help**\ |\ **-v**\ |\ **--version**\ ]
+\ **rsetboot**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
 
 ***********
@@ -50,7 +50,7 @@ OPTIONS
  
 
 
-\ **def**\ |\ **default**\ 
+\ **def | default**\ 
  
  Boot using the default set in BIOS.
  

--- a/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
@@ -19,15 +19,15 @@ SYNOPSIS
 ********
 
 
-\ **rspconfig**\  [\ **-h**\ |\ **--help**\ |\ **-v**\ |\ **--version**\ ]
+\ **rspconfig**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
 BMC/MPA specific:
 =================
 
 
-\ **rspconfig**\  \ *noderange*\  {\ **alert**\ |\ **snmpdest**\ |\ **community**\ }
+\ **rspconfig**\  \ *noderange*\  {\ **alert | snmpdest | community**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **alert**\ ={\ **on**\ |\ **enable**\ |\ **off**\ |\ **disable**\ }
+\ **rspconfig**\  \ *noderange*\  \ **alert**\ ={\ **on | enable | off | disable**\ }
 
 \ **rspconfig**\  \ *noderange*\  \ **snmpdest**\ =\ *snmpmanager-IP*\ 
 
@@ -38,7 +38,7 @@ BMC specific:
 =============
 
 
-\ **rspconfig**\  \ *noderange*\  {\ **ip**\ |\ **netmask**\ |\ **gateway**\ |\ **backupgateway**\ |\ **garp**\ }
+\ **rspconfig**\  \ *noderange*\  {\ **ip | netmask | gateway | backupgateway | garp**\ }
 
 \ **rspconfig**\  \ *noderange*\  \ **garp**\ ={\ *time*\ }
 
@@ -47,19 +47,19 @@ MPA specific:
 =============
 
 
-\ **rspconfig**\  \ *noderange*\  {\ **sshcfg**\ |\ **snmpcfg**\ |\ **pd1**\ |\ **pd2**\ |\ **network**\ |\ **swnet**\ |\ **ntp**\ |\ **textid**\ |\ **frame**\ }
+\ **rspconfig**\  \ *noderange*\  {\ **sshcfg | snmpcfg | pd1 | pd2 | network | swnet | ntp | textid | frame**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **USERID**\ ={\ **newpasswd**\ } \ **updateBMC**\ ={\ **y**\ |\ **n**\ }
+\ **rspconfig**\  \ *noderange*\  \ **USERID**\ ={\ **newpasswd**\ } \ **updateBMC**\ ={\ **y | n**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **sshcfg**\ ={\ **enable**\ |\ **disable**\ }
+\ **rspconfig**\  \ *noderange*\  \ **sshcfg**\ ={\ **enable | disable**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **snmpcfg**\ ={\ **enable**\ |\ **disable**\ }
+\ **rspconfig**\  \ *noderange*\  \ **snmpcfg**\ ={\ **enable | disable**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **solcfg**\ ={\ **enable**\ |\ **disable**\ }
+\ **rspconfig**\  \ *noderange*\  \ **solcfg**\ ={\ **enable | disable**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **pd1**\ ={\ **nonred**\ |\ **redwoperf**\ |\ **redwperf**\ }
+\ **rspconfig**\  \ *noderange*\  \ **pd1**\ ={\ **nonred | redwoperf | redwperf**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **pd2**\ ={\ **nonred**\ |\ **redwoperf**\ |\ **redwperf**\ }
+\ **rspconfig**\  \ *noderange*\  \ **pd2**\ ={\ **nonred | redwoperf | redwperf**\ }
 
 \ **rspconfig**\  \ *noderange*\  \ **network**\ ={[\ **ip**\ ],[\ **host**\ ],[\ **gateway**\ ],[\ **netmask**\ ]|\ **\\***\ }
 
@@ -80,15 +80,15 @@ FSP/CEC specific:
 =================
 
 
-\ **rspconfig**\  \ *noderange*\  {\ **autopower**\ |\ **iocap**\ |\ **dev**\ |\ **celogin1**\ |\ **decfg**\ |\ **memdecfg**\ |\ **procdecfg**\ |\ **time**\ |\ **date**\ |\ **spdump**\ |\ **sysdump**\ |\ **network**\ }
+\ **rspconfig**\  \ *noderange*\  {\ **autopower | iocap | dev | celogin1 | decfg | memdecfg | procdecfg | time | date | spdump | sysdump | network**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **autopower**\ ={\ **enable**\ |\ **disable**\ }
+\ **rspconfig**\  \ *noderange*\  \ **autopower**\ ={\ **enable | disable**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **iocap**\ ={\ **enable**\ |\ **disable**\ }
+\ **rspconfig**\  \ *noderange*\  \ **iocap**\ ={\ **enable | disable**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **dev**\ ={\ **enable**\ |\ **disable**\ }
+\ **rspconfig**\  \ *noderange*\  \ **dev**\ ={\ **enable | disable**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **celogin1**\ ={\ **enable**\ |\ **disable**\ }
+\ **rspconfig**\  \ *noderange*\  \ **celogin1**\ ={\ **enable | disable**\ }
 
 \ **rspconfig**\  \ *noderange*\  \ **time**\ ={\ **hh:mm:ss**\ }
 
@@ -118,31 +118,31 @@ FSP/CEC specific:
 
 \ **rspconfig**\  \ *noderange*\  \ **hostname**\ ={\ **\\*|name**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **--resetnet**\ 
+\ **rspconfig**\  \ *noderange*\  \ **-**\ **-resetnet**\ 
 
 
 Flex system Specific:
 =====================
 
 
-\ **rspconfig**\  \ *noderange*\  \ **sshcfg**\ ={\ **enable**\ |\ **disable**\ }
+\ **rspconfig**\  \ *noderange*\  \ **sshcfg**\ ={\ **enable | disable**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **snmpcfg**\ ={\ **enable**\ |\ **disable**\ }
+\ **rspconfig**\  \ *noderange*\  \ **snmpcfg**\ ={\ **enable | disable**\ }
 
 \ **rspconfig**\  \ *noderange*\  \ **network**\ ={[\ **ip**\ ],[\ **host**\ ],[\ **gateway**\ ],[\ **netmask**\ ]|\ **\\***\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **solcfg**\ ={\ **enable**\ |\ **disable**\ }
+\ **rspconfig**\  \ *noderange*\  \ **solcfg**\ ={\ **enable | disable**\ }
 
 \ **rspconfig**\  \ *noderange*\  \ **textid**\ ={\ **\\*|textid**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **cec_off_policy**\ ={\ **poweroff**\ |\ **stayon**\ }
+\ **rspconfig**\  \ *noderange*\  \ **cec_off_policy**\ ={\ **poweroff | stayon**\ }
 
 
 BPA/Frame Specific:
 ===================
 
 
-\ **rspconfig**\  \ *noderange*\  {\ **network**\ |\ **dev**\ |\ **celogin1**\ }
+\ **rspconfig**\  \ *noderange*\  {\ **network | dev | celogin1**\ }
 
 \ **rspconfig**\  \ *noderange*\  \ **network**\ ={\ **nic,\\***\ }
 
@@ -150,9 +150,9 @@ BPA/Frame Specific:
 
 \ **rspconfig**\  \ *noderange*\  \ **network**\ ={\ **nic,0.0.0.0**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **dev**\ ={\ **enable**\ |\ **disable**\ }
+\ **rspconfig**\  \ *noderange*\  \ **dev**\ ={\ **enable | disable**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **celogin1**\ ={\ **enable**\ |\ **disable**\ }
+\ **rspconfig**\  \ *noderange*\  \ **celogin1**\ ={\ **enable | disable**\ }
 
 \ **rspconfig**\  \ *noderange*\  \ **HMC_passwd**\ ={\ **currentpasswd,newpasswd**\ }
 
@@ -166,7 +166,7 @@ BPA/Frame Specific:
 
 \ **rspconfig**\  \ *noderange*\  \ **hostname**\ ={\ **\\*|name**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **--resetnet**\ 
+\ **rspconfig**\  \ *noderange*\  \ **-**\ **-resetnet**\ 
 
 
 FSP/CEC (using Direct FSP Management) Specific:
@@ -183,15 +183,15 @@ FSP/CEC (using Direct FSP Management) Specific:
 
 \ **rspconfig**\  \ *noderange*\  {\ **sysname**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **sysname**\ ={\ **\\***\ |\ **name**\ }
+\ **rspconfig**\  \ *noderange*\  \ **sysname**\ ={\ **\\* | name**\ }
 
 \ **rspconfig**\  \ *noderange*\  {\ **pending_power_on_side**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **pending_power_on_side**\ ={\ **temp**\ |\ **perm**\ }
+\ **rspconfig**\  \ *noderange*\  \ **pending_power_on_side**\ ={\ **temp | perm**\ }
 
 \ **rspconfig**\  \ *noderange*\  {\ **cec_off_policy**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **cec_off_policy**\ ={\ **poweroff**\ |\ **stayon**\ }
+\ **rspconfig**\  \ *noderange*\  \ **cec_off_policy**\ ={\ **poweroff | stayon**\ }
 
 \ **rspconfig**\  \ *noderange*\  {\ **BSR**\ }
 
@@ -201,11 +201,11 @@ FSP/CEC (using Direct FSP Management) Specific:
 
 \ **rspconfig**\  \ *noderange*\  {\ **setup_failover**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **setup_failover**\ ={\ **enable**\ |\ **disable**\ }
+\ **rspconfig**\  \ *noderange*\  \ **setup_failover**\ ={\ **enable | disable**\ }
 
 \ **rspconfig**\  \ *noderange*\  {\ **force_failover**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **--resetnet**\ 
+\ **rspconfig**\  \ *noderange*\  \ **-**\ **-resetnet**\ 
 
 
 BPA/Frame (using Direct FSP Management) Specific:
@@ -226,13 +226,13 @@ BPA/Frame (using Direct FSP Management) Specific:
 
 \ **rspconfig**\  \ *noderange*\  {\ **sysname**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **sysname**\ ={\ **\\***\ |\ **name**\ }
+\ **rspconfig**\  \ *noderange*\  \ **sysname**\ ={\ **\\* | name**\ }
 
 \ **rspconfig**\  \ *noderange*\  {\ **pending_power_on_side**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **pending_power_on_side**\ ={\ **temp**\ |\ **perm**\ }
+\ **rspconfig**\  \ *noderange*\  \ **pending_power_on_side**\ ={\ **temp | perm**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **--resetnet**\ 
+\ **rspconfig**\  \ *noderange*\  \ **-**\ **-resetnet**\ 
 
 
 HMC Specific:
@@ -241,9 +241,9 @@ HMC Specific:
 
 \ **rspconfig**\  \ *noderange*\  {\ **sshcfg**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **sshcfg**\ ={\ **enable**\ |\ **disable**\ }
+\ **rspconfig**\  \ *noderange*\  \ **sshcfg**\ ={\ **enable | disable**\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **--resetnet**\ 
+\ **rspconfig**\  \ *noderange*\  \ **-**\ **-resetnet**\ 
 
 
 
@@ -255,7 +255,7 @@ DESCRIPTION
 \ **rspconfig**\  configures various settings in the nodes' service processors.  If only a keyword is
 specified, without the \ **=**\ , it displays the current value.
 
-For options \ **autopower**\ |\ **iocap**\ |\ **dev**\ |\ **celogin1**\ |\ **decfg**\ |\ **memdecfg**\ |\ **procdecfg**\ |\ **time**\ |\ **date**\ |\ **spdump**\ |\ **sysdump**\ |\ **network**\ , user need to use \ *chdef -t site enableASMI=yes*\  to enable ASMI first. For options \ **dev**\ |\ **celogin1**\ , user also need to contact IBM service to get the dynamic password for 'celogin' and put it in passwd table. After completed the command, user should use \ *chdef -t site enableASMI=no*\  to disable ASMI.
+For options \ **autopower | iocap | dev | celogin1 | decfg | memdecfg | procdecfg | time | date | spdump | sysdump | network**\ , user need to use \ *chdef -t site enableASMI=yes*\  to enable ASMI first. For options \ **dev | celogin1**\ , user also need to contact IBM service to get the dynamic password for 'celogin' and put it in passwd table. After completed the command, user should use \ *chdef -t site enableASMI=no*\  to disable ASMI.
 
 
 *******
@@ -306,7 +306,7 @@ OPTIONS
  
 
 
-\ **cec_off_policy**\ ={\ **poweroff**\ |\ **stayon**\ }
+\ **cec_off_policy**\ ={\ **poweroff | stayon**\ }
  
  Set or get cec off policy after lpars are powered off.  If no cec_off_policy value specified, the cec_off_policy for the nodes will be displayed. the cec_off_policy has two values: \ **poweroff**\  and \ **stayon**\ . \ **poweroff**\  means Power off when last partition powers off. \ **stayon**\  means Stay running after last partition powers off. If cec_off_policy value is specified, the cec off policy will be set for that cec.
  
@@ -473,13 +473,13 @@ OPTIONS
  
 
 
-\ **pd1**\ ={\ **nonred**\ |\ **redwoperf**\ |\ **redwperf**\ }
+\ **pd1**\ ={\ **nonred | redwoperf | redwperf**\ }
  
  Power Domain 1 - determines how an MPA responds to a loss of redundant power.
  
 
 
-\ **pd2**\ ={\ **nonred**\ |\ **redwoperf**\ |\ **redwperf**\ }
+\ **pd2**\ ={\ **nonred | redwoperf | redwperf**\ }
  
  Power Domain 2 - determines how an MPA responds to a loss of redundant power.
  
@@ -577,7 +577,7 @@ OPTIONS
  
 
 
-\ **--resetnet**\ 
+\ **-**\ **-resetnet**\ 
  
  Reset the network interfaces of the specified nodes.
  
@@ -589,13 +589,13 @@ OPTIONS
  
 
 
-\ **-h**\ |\ **--help**\ 
+\ **-h | -**\ **-help**\ 
  
  Prints out a brief usage message.
  
 
 
-\ **-v**\ , \ **--version**\ 
+\ **-v**\ , \ **-**\ **-version**\ 
  
  Display the version number.
  
@@ -1107,7 +1107,7 @@ EXAMPLES
  
  To reset the network interface of the specified nodes:
  
- \ **rspconfig**\  \ *--resetnet*\ 
+ \ **rspconfig**\  \ *-**\ **-resetnet*\ 
  
  Output is similar to:
  

--- a/docs/source/guides/admin-guides/references/man1/rspreset.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rspreset.1.rst
@@ -21,7 +21,7 @@ Name
 
 \ **rspreset**\  \ *noderange*\ 
 
-\ **rspreset**\  [\ **-h**\ |\ **--help**\ |\ **-v**\ |\ **--version**\ ]
+\ **rspreset**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
 
 *******************
@@ -41,13 +41,13 @@ the blade's on board service processor will be reset.
 
 
 
-\ **-h**\ |\ **--help**\ 
+\ **-h | -**\ **-help**\ 
  
  Print help.
  
 
 
-\ **-v**\ |\ **--version**\ 
+\ **-v | -**\ **-version**\ 
  
  Print version.
  

--- a/docs/source/guides/admin-guides/references/man1/rvitals.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rvitals.1.rst
@@ -19,41 +19,41 @@ Name
 ****************
 
 
-\ **rvitals**\  [\ **-h**\ |\ **--help**\ |\ **-v**\ |\ **--version**\ ]
+\ **rvitals**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
 FSP/LPAR (with HMC) specific:
 =============================
 
 
-\ **rvitals**\  \ *noderange*\  {\ **temp**\ |\ **voltage**\ |\ **lcds**\ |\ **all**\ }
+\ **rvitals**\  \ *noderange*\  {\ **temp | voltage | lcds | all**\ }
 
 
 CEC/LPAR/Frame (using Direct FSP Management ) specific:
 =======================================================
 
 
-\ **rvitals**\  \ *noderange*\  {\ **rackenv**\ |\ **lcds**\ |\ **all**\ } [\ **-V**\ | \ **--verbose**\ ]
+\ **rvitals**\  \ *noderange*\  {\ **rackenv | lcds | all**\ } [\ **-V**\ | \ **-**\ **-verbose**\ ]
 
 
 MPA specific:
 =============
 
 
-\ **rvitals**\  \ *noderange*\  {\ **temp**\ |\ **voltage**\ |\ **wattage**\ |\ **fanspeed**\ |\ **power**\ |\ **leds**\ |\ **summary**\ |\ **all**\ }
+\ **rvitals**\  \ *noderange*\  {\ **temp | voltage | wattage | fanspeed | power | leds | summary | all**\ }
 
 
 Blade specific:
 ===============
 
 
-\ **rvitals**\  \ *noderange*\  {\ **temp**\ |\ **wattage**\ |\ **fanspeed**\ |\ **leds**\ |\ **summary**\ |\ **all**\ }
+\ **rvitals**\  \ *noderange*\  {\ **temp | wattage | fanspeed | leds | summary | all**\ }
 
 
 BMC specific:
 =============
 
 
-\ **rvitals**\  \ *noderange*\  {\ **temp**\ |\ **voltage**\ |\ **wattage**\ |\ **fanspeed**\ |\ **power**\ |\ **leds**\ |\ **all**\ }
+\ **rvitals**\  \ *noderange*\  {\ **temp | voltage | wattage | fanspeed | power | leds | all**\ }
 
 
 
@@ -158,13 +158,13 @@ Processor for a single or range of nodes and groups.
  
 
 
-\ **-h**\ |\ **--help**\ 
+\ **-h | -**\ **-help**\ 
  
  Print help.
  
 
 
-\ **-v**\ |\ **--version**\ 
+\ **-v | -**\ **-version**\ 
  
  Print version.
  

--- a/docs/source/guides/admin-guides/references/man1/sinv.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/sinv.1.rst
@@ -19,7 +19,7 @@ sinv.1
 ****************
 
 
-\ **sinv**\   [\ **-o**\  \ *output*\ ] [\ **-p**\  \ *template path*\ ] [\ **-t**\  \ *template count*\ ] [\ **-s**\  \ *seed node*\ ] [\ **-i**\ ] [\ **-e**\ ] [\ **-r**\ ] [\ **-V**\ ] [\ **--devicetype**\  \ *type_of_device*\ ]  [\ **-l**\   \ *userID*\ ] [[\ **-f**\  \ *command file*\ ] | [\ **-c**\  \ *command*\ ]]
+\ **sinv**\   [\ **-o**\  \ *output*\ ] [\ **-p**\  \ *template path*\ ] [\ **-t**\  \ *template count*\ ] [\ **-s**\  \ *seed node*\ ] [\ **-i**\ ] [\ **-e**\ ] [\ **-r**\ ] [\ **-V**\ ] [\ **-**\ **-devicetype**\  \ *type_of_device*\ ]  [\ **-l**\   \ *userID*\ ] [[\ **-f**\  \ *command file*\ ] | [\ **-c**\  \ *command*\ ]]
 
 \ **sinv**\  [\ **-h**\  | \ **-v**\ ]
 
@@ -73,14 +73,14 @@ Command Protocol can be used. See man \ **xdsh**\  for more details.
 
 
 
-\ **-o**\ |\ **--output**\  \ *report output file*\ 
+\ **-o | -**\ **-output**\  \ *report output file*\ 
  
  Optional output file. This is the location of the file that will contain the report of the nodes that match, and do not match, the input templates.
  If the flag is not used, the output will go to stdout.
  
 
 
-\ **-p**\ |\ **--tp**\  \ *template path*\ 
+\ **-p | -**\ **-tp**\  \ *template path*\ 
  
  This is the path to the template file. The template contains the output
  of xdsh command, that has been run against a "seed" node, a node 
@@ -104,7 +104,7 @@ Command Protocol can be used. See man \ **xdsh**\  for more details.
  
 
 
-\ **-t**\ |\ **--tc**\  \ *template count*\ 
+\ **-t | -**\ **-tc**\  \ *template count*\ 
  
  This count is the number of templates that the command will use
  to check for nodes matches.  If the template in the template path does not
@@ -122,7 +122,7 @@ Command Protocol can be used. See man \ **xdsh**\  for more details.
  
 
 
-\ **-s**\ |\ **--seed**\  \ *seed node*\ 
+\ **-s | -**\ **-seed**\  \ *seed node*\ 
  
  This is the node that will be used to build the first template
  that is stored in template path.  You can use this parameter instead of running
@@ -134,7 +134,7 @@ Command Protocol can be used. See man \ **xdsh**\  for more details.
  
 
 
-\ **-i**\ |\ **--ignorefirst**\ 
+\ **-i | -**\ **-ignorefirst**\ 
  
  This flag suppresses the reporting of the nodes matching the first
  template. In very large systems, you may not want to show the nodes that
@@ -144,7 +144,7 @@ Command Protocol can be used. See man \ **xdsh**\  for more details.
  
 
 
-\ **-e**\ |\ **--exactmatch**\ 
+\ **-e | -**\ **-exactmatch**\ 
  
  This requires the check of node output against template to be an exact match.
  If this flag is not set, \ **sinv**\  checks to see if the return from the 
@@ -160,7 +160,7 @@ Command Protocol can be used. See man \ **xdsh**\  for more details.
  
 
 
-\ **--devicetype**\  \ *type_of_device*\ 
+\ **-**\ **-devicetype**\  \ *type_of_device*\ 
  
  Specify a user-defined device type that references the location
  of relevant device configuration file. The devicetype value must
@@ -178,13 +178,13 @@ Command Protocol can be used. See man \ **xdsh**\  for more details.
  
 
 
-\ **-l**\ |\ **--user**\  \ *user_ID*\ 
+\ **-l | -**\ **-user**\  \ *user_ID*\ 
  
  Specifies a remote user name to use for remote command execution.
  
 
 
-\ **-c**\ |\ **--command**\ 
+\ **-c | -**\ **-command**\ 
  
  The xdsh or rinv command that will be run. The command should be enclosed in 
  double quotes to insure correct shell interpretation. This parameter must only contain, the node range or the image path (Linux) or spot name for AIX. It cannot be used to set additional input flags to xdsh or rinv (for example -s,-T,-e).  See examples below.
@@ -194,7 +194,7 @@ Command Protocol can be used. See man \ **xdsh**\  for more details.
  
 
 
-\ **-f**\ |\ **--file**\ 
+\ **-f | -**\ **-file**\ 
  
  The file containing the xdsh or rinv command that will be run. 
  This should be the fully qualified name of the file.
@@ -204,7 +204,7 @@ Command Protocol can be used. See man \ **xdsh**\  for more details.
  
 
 
-\ **-r**\ |\ **--remove**\ 
+\ **-r | -**\ **-remove**\ 
  
  This flag indicates that generated templates should be removed at the
  at the end of the \ **sinv**\  command execution.
@@ -218,19 +218,19 @@ Command Protocol can be used. See man \ **xdsh**\  for more details.
  
 
 
-\ **-h**\ |\ **--help**\ 
+\ **-h | -**\ **-help**\ 
  
  Displays usage information.
  
 
 
-\ **-v**\ |\ **--version**\ 
+\ **-v | -**\ **-version**\ 
  
  Displays xCAT release version.
  
 
 
-\ **-V**\ |\ **--Verbose**\ 
+\ **-V | -**\ **-Verbose**\ 
  
  Verbose mode.
  
@@ -337,7 +337,7 @@ Command Protocol can be used. See man \ **xdsh**\  for more details.
  
  To execute \ **sinv**\  on the device mswitch2 and compare to mswitch1
  
- \ **sinv**\  \ *-c "xdsh mswitch  enable;show version"  -s mswitch1 -p /tmp/sinv/template --devicetype IBSwitch::Mellanox -l admin -t 2*\ 
+ \ **sinv**\  \ *-c "xdsh mswitch  enable;show version"  -s mswitch1 -p /tmp/sinv/template -**\ **-devicetype IBSwitch::Mellanox -l admin -t 2*\ 
  
 
 

--- a/docs/source/guides/admin-guides/references/man1/snmove.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/snmove.1.rst
@@ -19,11 +19,11 @@ SYNOPSIS
 ********
 
 
-\ **snmove**\  \ *noderange*\  [\ **-V**\ ] [\ **-l**\ |\ **--liteonly**\ ] [\ **-d**\ |\ **--dest**\  \ *sn2*\ ] [\ **-D**\ |\ **--destn**\  \ *sn2n*\ ] [\ **-i**\ |\ **--ignorenodes**\ ] [\ **-P**\ |\ **--postscripts**\  \ *script1,script2...*\ |\ *all*\ ]
+\ **snmove**\  \ *noderange*\  [\ **-V**\ ] [\ **-l | -**\ **-liteonly**\ ] [\ **-d | -**\ **-dest**\  \ *sn2*\ ] [\ **-D | -**\ **-destn**\  \ *sn2n*\ ] [\ **-i | -**\ **-ignorenodes**\ ] [\ **-P | -**\ **-postscripts**\  \ *script1,script2...*\ |\ *all*\ ]
 
-\ **snmove**\  [\ **-V**\ ] [\ **-l**\ |\ **--liteonly**\ ] \ **-s**\ |\ **--source**\  \ *sn1*\  [\ **-S**\ |\ **--sourcen**\  \ *sn1n*\ ] [\ **-d**\ |\ **--dest**\  \ *sn2*\ ] [\ **-D**\ |\ **--destn**\  \ *sn2n*\ ] [\ **-i**\ |\ **--ignorenodes**\ ] [\ **-P**\ |\ **--postscripts**\  \ *script1,script2...*\ |\ *all*\ ]
+\ **snmove**\  [\ **-V**\ ] [\ **-l | -**\ **-liteonly**\ ] \ **-s | -**\ **-source**\  \ *sn1*\  [\ **-S | -**\ **-sourcen**\  \ *sn1n*\ ] [\ **-d | -**\ **-dest**\  \ *sn2*\ ] [\ **-D | -**\ **-destn**\  \ *sn2n*\ ] [\ **-i | -**\ **-ignorenodes**\ ] [\ **-P | -**\ **-postscripts**\  \ *script1,script2...*\ |\ *all*\ ]
 
-\ **snmove**\  [\ **-h**\ |\ **--help**\ |\ **-v**\ |\ **--version**\ ]
+\ **snmove**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
 
 ***********
@@ -88,63 +88,63 @@ OPTIONS
 
 
 
-\ **-d|--dest**\ 
+\ **-d|-**\ **-dest**\ 
  
  Specifies the hostname of the new destination service node as known by (facing) the management node.
  
 
 
-\ **-D|--destn**\ 
+\ **-D|-**\ **-destn**\ 
  
  Specifies the hostname of the destination service node as known by (facing) the nodes.
  
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-i|--ignorenodes**\ 
+\ **-i|-**\ **-ignorenodes**\ 
  
  No modifications will be made on the nodes. If not specified, several xCAT postscripts will be run on the nodes to complete the switch to the new service node.
  
 
 
-\ **-l|--liteonly**\ 
+\ **-l|-**\ **-liteonly**\ 
  
  Use this option to ONLY synchronize any AIX statelite files from the primary server to the backup server for the nodes. It will not do the actual moving of thre nodes the the backup servers.
  
 
 
-\ **-P|--postscripts**\ 
+\ **-P|-**\ **-postscripts**\ 
  
  Specifies a list of extra postscripts to be run on the nodes after the nodes are moved over to the new serive node. If 'all' is specified, all the postscripts defined in the postscripts table will be run for the nodes. The specified postscripts must be stored under /install/postscripts directory.
  
 
 
-\ **-s|--source**\ 
+\ **-s|-**\ **-source**\ 
  
  Specifies the hostname of the current (source) service node sa known by (facing)
   the management node.
  
 
 
-\ **-S|--sourcen**\ 
+\ **-S|-**\ **-sourcen**\ 
  
  Specifies the hostname of the current service node adapter as known by (facing)
  the nodes.
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Verbose mode.
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command Version.
  

--- a/docs/source/guides/admin-guides/references/man1/swapnodes.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/swapnodes.1.rst
@@ -19,7 +19,7 @@ SYNOPSIS
 ********
 
 
-\ **swapnodes**\  [\ **-h**\ | \ **--help**\ ]
+\ **swapnodes**\  [\ **-h**\ | \ **-**\ **-help**\ ]
 
 \ **swapnodes**\  \ **-c**\  \ *current_node*\  \ **-f**\  \ *fip_node*\  [\ **-o**\ ]
 
@@ -55,7 +55,7 @@ OPTIONS
 
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  

--- a/docs/source/guides/admin-guides/references/man1/switchblade.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/switchblade.1.rst
@@ -15,7 +15,7 @@ SYNOPSIS
 
 \ **switchblade**\  \ *node*\  {\ **media**\  | \ **mt**\  | \ **kvm**\  | \ **video**\  | \ **both**\ } [\ *slot_num*\ ]
 
-\ **switchblade**\  [\ **-h**\ |\ **--help**\ |\ **-v**\ |\ **--version**\ ]
+\ **switchblade**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
 
 ***********
@@ -35,19 +35,19 @@ OPTIONS
 
 
 
-\ **list**\ |\ **stat**\ 
+\ **list | stat**\ 
  
  Display which blade the media tray and KVM are currently assigned to.
  
 
 
-\ **media**\ |\ **mt**\ 
+\ **media | mt**\ 
  
  Assign the media tray to the specified blade.
  
 
 
-\ **kvm**\ |\ **video**\ 
+\ **kvm | video**\ 
  
  Assign the KVM (video display) to the specified blade.
  

--- a/docs/source/guides/admin-guides/references/man1/switchdiscover.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/switchdiscover.1.rst
@@ -55,7 +55,7 @@ OPTIONS
  
 
 
-\ **--range**\ 
+\ **-**\ **-range**\ 
  
  Specify one or more IP ranges. Each can be an ip address (10.1.2.3) or an ip range (10.1.2.0/24). If the range is huge, for example, 192.168.1.1/8, the switch discover may take a very long time to scan. So the range should be exactly specified.
  
@@ -129,7 +129,7 @@ EXAMPLES
  
  To discover the switches on some subnets:
  
- \ **switchdiscover**\  \ *--range 10.2.3.0/24,192.168.3.0/24,11.5.6.7*\ 
+ \ **switchdiscover**\  \ *-**\ **-range 10.2.3.0/24,192.168.3.0/24,11.5.6.7*\ 
  
 
 
@@ -137,7 +137,7 @@ EXAMPLES
  
  To do the switch discovery and save them to the xCAT database:
  
- \ **switchdiscover**\  \ *--range 10.2.3.4/24 -w*\ 
+ \ **switchdiscover**\  \ *-**\ **-range 10.2.3.4/24 -w*\ 
  
  It is recommended to run \ **makehosts**\  after the switches are saved in the DB.
  

--- a/docs/source/guides/admin-guides/references/man1/tabgrep.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/tabgrep.1.rst
@@ -21,7 +21,7 @@ SYNOPSIS
 
 \ **tabgrep**\  \ *nodename*\ 
 
-\ **tabgrep**\  [\ *-?*\  | \ *-h*\  | \ *--help*\ ]
+\ **tabgrep**\  [\ *-?*\  | \ *-h*\  | \ *-**\ **-help*\ ]
 
 
 ***********
@@ -40,7 +40,7 @@ OPTIONS
 
 
 
-\ **-?|-h|--help**\ 
+\ **-?|-h|-**\ **-help**\ 
  
  Display usage message.
  

--- a/docs/source/guides/admin-guides/references/man1/updateSNimage.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/updateSNimage.1.rst
@@ -39,13 +39,13 @@ OPTIONS
 *******
 
 
-\ **-h |--help**\             Display usage message.
+\ **-h |-**\ **-help**\             Display usage message.
 
-\ **-v |--version**\          Display xCAT version.
+\ **-v |-**\ **-version**\          Display xCAT version.
 
-\ **-n | --node**\            A remote host name or ip address that contains the install image to be updated.
+\ **-n | -**\ **-node**\            A remote host name or ip address that contains the install image to be updated.
 
-\ **-p |--path**\             Path to the install image.
+\ **-p |-**\ **-path**\             Path to the install image.
 
 
 ************

--- a/docs/source/guides/admin-guides/references/man1/updatenode.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/updatenode.1.rst
@@ -19,17 +19,17 @@ SYNOPSIS
 ********
 
 
-\ **updatenode**\  \ **noderange**\  [\ **-V**\ |\ **--verbose**\ ] [\ **-F**\ |\ **--sync**\ ] [\ **-f**\ |\ **--snsync**\ ] [\ **-S**\ |\ **--sw**\ ]  [\ **-l**\   \ *userID*\ ]  [\ **-P**\ |\ **--scripts**\  [\ **script1,script2...**\ ]] [\ **-s**\ |\ **--sn**\ ] [\ **-A**\ |\ **--updateallsw**\ ] [\ **-c**\ |\ **--cmdlineonly**\ ] [\ **-d alt_source_dir**\ ] [\ **--fanout**\ ] [\ **-t timeout**\ } [\ **attr=val**\  [\ **attr=val...**\ ]] [\ **-n**\ |\ **--noverify**\ ]
+\ **updatenode**\  \ **noderange**\  [\ **-V | -**\ **-verbose**\ ] [\ **-F | -**\ **-sync**\ ] [\ **-f | -**\ **-snsync**\ ] [\ **-S | -**\ **-sw**\ ]  [\ **-l**\   \ *userID*\ ]  [\ **-P | -**\ **-scripts**\  [\ **script1,script2...**\ ]] [\ **-s | -**\ **-sn**\ ] [\ **-A | -**\ **-updateallsw**\ ] [\ **-c | -**\ **-cmdlineonly**\ ] [\ **-d alt_source_dir**\ ] [\ **-**\ **-fanout**\ ] [\ **-t timeout**\ } [\ **attr=val**\  [\ **attr=val...**\ ]] [\ **-n | -**\ **-noverify**\ ]
 
-\ **updatenode**\  \ **noderange**\  [\ **-k**\ |\ **--security**\ ] [\ **-t timeout**\ ]
+\ **updatenode**\  \ **noderange**\  [\ **-k | -**\ **-security**\ ] [\ **-t timeout**\ ]
 
-\ **updatenode**\  \ **noderange**\  [\ **-g**\ |\ **--genmypost**\ ]
+\ **updatenode**\  \ **noderange**\  [\ **-g | -**\ **-genmypost**\ ]
 
-\ **updatenode**\  \ **noderange**\  [\ **-V**\ |\ **--verbose**\ ] [\ **-t timeout**\ ] [\ **script1,script2...**\ ]
+\ **updatenode**\  \ **noderange**\  [\ **-V | -**\ **-verbose**\ ] [\ **-t timeout**\ ] [\ **script1,script2...**\ ]
 
-\ **updatenode**\  \ **noderange**\  [\ **-V**\ |\ **--verbose**\ ] [\ **-f**\ |\ **--snsync**\ ]
+\ **updatenode**\  \ **noderange**\  [\ **-V | -**\ **-verbose**\ ] [\ **-f | -**\ **-snsync**\ ]
 
-\ **updatenode**\  [\ **-h**\ |\ **--help**\ ] [\ **-v**\ |\ **--version**\ ]
+\ **updatenode**\  [\ **-h | -**\ **-help**\ ] [\ **-v | -**\ **-version**\ ]
 
 
 ***********
@@ -365,16 +365,16 @@ OPTIONS
 
 
 
-\ **--fanout**\ =\ *fanout_value*\ 
+\ **-**\ **-fanout**\ =\ *fanout_value*\ 
  
  Specifies a fanout value for the maximum number of  concur-
  rently  executing  remote shell processes. Serial execution
- can be specified by indicating a fanout value of \ **1**\ .  If  \ **--fanout**\ 
+ can be specified by indicating a fanout value of \ **1**\ .  If  \ **-**\ **-fanout**\ 
  is not specified, a default fanout value of \ **64**\  is used.
  
 
 
-\ **-A|--updateallsw**\ 
+\ **-A|-**\ **-updateallsw**\ 
  
  Install or update all software contained in the source directory. (AIX only)
  
@@ -394,7 +394,7 @@ OPTIONS
  
 
 
-\ **-F|--sync**\ 
+\ **-F|-**\ **-sync**\ 
  
  Specifies that file synchronization should be
  performed on the nodes.  rsync and ssh must
@@ -406,7 +406,7 @@ OPTIONS
  
 
 
-\ **-f|--snsync**\ 
+\ **-f|-**\ **-snsync**\ 
  
  Specifies that file synchronization should be
  performed to the service nodes that service the
@@ -427,20 +427,20 @@ OPTIONS
  
 
 
-\ **-g|--genmypost**\ 
+\ **-g|-**\ **-genmypost**\ 
  
  Will generate a new mypostscript file for the
  nodes in the noderange, if site precreatemypostscripts is 1 or YES.
  
 
 
-\ **-h|--help**\ 
+\ **-h|-**\ **-help**\ 
  
  Display usage message.
  
 
 
-\ **-k|--security**\ 
+\ **-k|-**\ **-security**\ 
  
  Update the ssh keys and host keys for the service nodes and compute nodes;
  Update the ca and credentials to the service nodes.  Never run this command to the Management Node, it will take down xcatd.
@@ -448,7 +448,7 @@ OPTIONS
  
 
 
-\ **-l**\ |\ **--user**\  \ *user_ID*\ 
+\ **-l | -**\ **-user**\  \ *user_ID*\ 
  
  Specifies a non-root user name to use for remote command execution. This option is only available when running postscripts (-P) for 
  AIX and Linux and updating software (-S) for Linux only. 
@@ -459,7 +459,7 @@ OPTIONS
  
 
 
-\ **-P|--scripts**\ 
+\ **-P|-**\ **-scripts**\ 
  
  Specifies that postscripts and postbootscripts should be run on the nodes. 
  updatenode -P syncfiles is not supported.  The syncfiles postscript can only
@@ -467,19 +467,19 @@ OPTIONS
  
 
 
-\ **-S|--sw**\ 
+\ **-S|-**\ **-sw**\ 
  
  Specifies that node software should be updated.  In Sysclone environment, specifies pushing the delta changes to target nodes.
  
 
 
-\ **-n|--noverify**\ 
+\ **-n|-**\ **-noverify**\ 
  
  Specifies that node network availability verification will be skipped.
  
 
 
-\ **-s|--sn**\ 
+\ **-s|-**\ **-sn**\ 
  
  Set the server information stored on the nodes in /opt/xcat/xcatinfo on Linux.
  
@@ -492,13 +492,13 @@ OPTIONS
  
 
 
-\ **-v|--version**\ 
+\ **-v|-**\ **-version**\ 
  
  Command Version.
  
 
 
-\ **-V|--verbose**\ 
+\ **-V|-**\ **-verbose**\ 
  
  Verbose mode.
  
@@ -644,7 +644,7 @@ EXAMPLES
  To update the AIX nodes "xcatn11" and "xcatn12" with the "gpfs.base" fileset
  and the "rsync" rpm using the installp flags "-agQXY" and the rpm flags "-i --nodeps".
  
- \ **updatenode xcatn11,xcatn12 -V -S otherpkgs="I:gpfs.base,R:rsync-2.6.2-1.aix5.1.ppc.rpm" installp_flags="-agQXY" rpm_flags="-i --nodeps"**\ 
+ \ **updatenode xcatn11,xcatn12 -V -S otherpkgs="I:gpfs.base,R:rsync-2.6.2-1.aix5.1.ppc.rpm" installp_flags="-agQXY" rpm_flags="-i -**\ **-nodeps"**\ 
  
  Note: Using the "-V" flag with multiple nodes may result in a large amount of output.
  

--- a/docs/source/guides/admin-guides/references/man1/wcons.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/wcons.1.rst
@@ -19,9 +19,9 @@ wcons - windowed remote console
 ****************
 
 
-\ **wcons**\   [\ **-t**\ |\ **--tile**\ =\ *n*\ ] [\ *xterm-options*\ ] \ *noderange*\ 
+\ **wcons**\   [\ **-t | -**\ **-tile**\ =\ *n*\ ] [\ *xterm-options*\ ] \ *noderange*\ 
 
-\ **wcons**\  [\ **-h**\ |\ **--help**\ |\ **-v**\ |\ **--version**\ ]
+\ **wcons**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
 
 *******************
@@ -41,7 +41,7 @@ range or nodes or groups.
 
 
 
-\ **-t**\ |\ **--tile**\ =\ *n*\ 
+\ **-t | -**\ **-tile**\ =\ *n*\ 
  
  Tile \ **wcons**\  windows from top left to bottom right.  If \ *n*\  is spec-
  ified  then  tile  \ *n*\  across.  If \ *n*\  is not specified then tile to
@@ -50,13 +50,13 @@ range or nodes or groups.
  
 
 
-\ **-h**\ |\ **--help**\ 
+\ **-h | -**\ **-help**\ 
  
  Print help.
  
 
 
-\ **-v**\ |\ **--version**\ 
+\ **-v | -**\ **-version**\ 
  
  Print version.
  
@@ -90,7 +90,7 @@ method.
 
 \ **wcons**\  \ *node1-node5*\ 
 
-\ **wcons**\  \ **--tile**\  \ **--font**\ =\ *nil2*\  \ *all*\ 
+\ **wcons**\  \ **-**\ **-tile**\  \ **-**\ **-font**\ =\ *nil2*\  \ *all*\ 
 
 \ **wcons**\  \ **-t**\  \ *4*\  \ *node1-node16*\ 
 

--- a/docs/source/guides/admin-guides/references/man1/wkill.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/wkill.1.rst
@@ -21,7 +21,7 @@ Name
 
 \ **wkill**\  [\ *noderange*\ ]
 
-\ **wkill**\  [\ **-h**\ |\ **--help**\ |\ **-v**\ |\ **--version**\ ]
+\ **wkill**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
 
 *******************
@@ -45,13 +45,13 @@ wcons windows on your $DISPLAY will be killed.
 
 
 
-\ **-h**\ |\ **--help**\ 
+\ **-h | -**\ **-help**\ 
  
  Print help.
  
 
 
-\ **-v**\ |\ **--version**\ 
+\ **-v | -**\ **-version**\ 
  
  Print version.
  

--- a/docs/source/guides/admin-guides/references/man1/xcat2nim.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/xcat2nim.1.rst
@@ -63,31 +63,31 @@ OPTIONS
 *******
 
 
-\ **-a|--all**\              The list of objects will include all xCAT node, group and network objects.
+\ **-a|-**\ **-all**\              The list of objects will include all xCAT node, group and network objects.
 
 \ **attr=val [attr=val ...]**\   Specifies one or more "attribute equals value" pairs, separated by spaces. Attr=val pairs must be specified last on the command line.  The attribute names must correspond to the attributes supported by the relevant NIM commands.  When providing attr=val pairs on the command line you must not specify more than one object type.
 
-\ **-b|--backupSN**\        When using backup service nodes only update the backup.  The default is to update both the primary and backup service nodes.
+\ **-b|-**\ **-backupSN**\        When using backup service nodes only update the backup.  The default is to update both the primary and backup service nodes.
 
-\ **-f|--force**\    	 The force option will remove the existing NIM definition and create a new one.
+\ **-f|-**\ **-force**\    	 The force option will remove the existing NIM definition and create a new one.
 
-\ **-h|--help**\             Display the usage message.
+\ **-h|-**\ **-help**\             Display the usage message.
 
-\ **-l|--list**\ 		 List NIM definitions corresponding to xCAT definitions.
+\ **-l|-**\ **-list**\ 		 List NIM definitions corresponding to xCAT definitions.
 
 \ **-o object-names**\        A set of comma delimited xCAT object names. Objects must be of type node, group, or network.
 
-\ **-p|--primarySN**\         When using backup service nodes only update the primary.  The default is to update both the primary and backup service nodes.
+\ **-p|-**\ **-primarySN**\         When using backup service nodes only update the primary.  The default is to update both the primary and backup service nodes.
 
-\ **-r|--remove**\          Remove NIM definitions corresponding to xCAT definitions.
+\ **-r|-**\ **-remove**\          Remove NIM definitions corresponding to xCAT definitions.
 
 \ **-t object-types**\        A set of comma delimited xCAT object types. Supported types include: node, group, and network.
 
 Note: If the object type is "group", it means that the \ **xcat2nim**\  command will operate on a NIM machine group definition corresponding to the xCAT node group definition. Before creating a NIM machine group, all the NIM client nodes definition must have been created.
 
-\ **-u|--update**\         Update existing NIM definitions based on xCAT definitions.
+\ **-u|-**\ **-update**\         Update existing NIM definitions based on xCAT definitions.
 
-\ **-V|--verbose**\        Verbose mode.
+\ **-V|-**\ **-verbose**\        Verbose mode.
 
 
 ************

--- a/docs/source/guides/admin-guides/references/man1/xcatchroot.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/xcatchroot.1.rst
@@ -100,7 +100,7 @@ OPTIONS
  
 
 
-\ **-h |--help**\ 
+\ **-h |-**\ **-help**\ 
  
  Display usage message.
  
@@ -112,7 +112,7 @@ OPTIONS
  
 
 
-\ **-V |--verbose**\ 
+\ **-V |-**\ **-verbose**\ 
  
  Verbose mode.
  

--- a/docs/source/guides/admin-guides/references/man1/xdcp.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/xdcp.1.rst
@@ -117,7 +117,7 @@ standard output or standard error is displayed.
  
 
 
-\ **-f**\ |\ **--fanout**\  \ *fanout_value*\ 
+\ **-f | -**\ **-fanout**\  \ *fanout_value*\ 
  
  Specifies a fanout value for the maximum number of  concur-
  rently  executing  remote shell processes. Serial execution
@@ -126,7 +126,7 @@ standard output or standard error is displayed.
  
 
 
-\ **-F**\ |\ **--File**\  \ *rsync input file*\ 
+\ **-F | -**\ **-File**\  \ *rsync input file*\ 
  
  Specifies the path to the file that will be used to  
  build the rsync command.
@@ -249,19 +249,19 @@ standard output or standard error is displayed.
  
 
 
-\ **-h**\ |\ **--help**\ 
+\ **-h | -**\ **-help**\ 
  
  Displays usage information.
  
 
 
-\ **-i**\ |\ **--rootimg**\  \ *install image*\ 
+\ **-i | -**\ **-rootimg**\  \ *install image*\ 
  
  Specifies  the path to the install image on the local Linux node.
  
 
 
-\ **-o**\ |\ **--node-options**\  \ *node_options*\ 
+\ **-o | -**\ **-node-options**\  \ *node_options*\ 
  
  Specifies options to pass to the remote shell  command  for
  node  targets.  The options must be specified within double
@@ -269,14 +269,14 @@ standard output or standard error is displayed.
  
 
 
-\ **-p**\ |\ **--preserve**\ 
+\ **-p | -**\ **-preserve**\ 
  
  Preserves  the  source  file characteristics as implemented by
  the configured remote copy command.
  
 
 
-\ **-P**\ |\ **--pull**\ 
+\ **-P | -**\ **-pull**\ 
  
  Pulls (copies) the files from the targets and places  them  in
  the  target_path  directory on the local host. The target_path
@@ -291,7 +291,7 @@ standard output or standard error is displayed.
  
 
 
-\ **-q**\ |\ **--show-config**\ 
+\ **-q | -**\ **-show-config**\ 
  
  Displays the current environment settings for all DSH
  Utilities commands. This includes the values of all environment
@@ -301,14 +301,14 @@ standard output or standard error is displayed.
  
 
 
-\ **-r**\ |\ **--node-rcp**\  \ *node_remote_copy*\ 
+\ **-r | -**\ **-node-rcp**\  \ *node_remote_copy*\ 
  
  Specifies  the  full  path of the remote copy command used
  for remote command execution on node targets.
  
 
 
-\ **-R**\ |\ **--recursive**\  \ *recursive*\ 
+\ **-R | -**\ **-recursive**\  \ *recursive*\ 
  
  Recursively  copies files from a local directory to the remote
  targets, or when specified with the -P flag, recursively pulls
@@ -327,7 +327,7 @@ standard output or standard error is displayed.
  
 
 
-\ **-t**\ |\ **--timeout**\  \ *timeout*\ 
+\ **-t | -**\ **-timeout**\  \ *timeout*\ 
  
  Specifies the time, in seconds, to wait for output from any
  currently executing remote targets. If no output is
@@ -341,14 +341,14 @@ standard output or standard error is displayed.
  
 
 
-\ **-T**\ |\ **--trace**\ 
+\ **-T | -**\ **-trace**\ 
  
  Enables trace mode. The \ **xdcp**\  command prints diagnostic
  messages to standard output during execution to each target.
  
 
 
-\ **-v**\ |\ **--verify**\ 
+\ **-v | -**\ **-verify**\ 
  
  Verifies each target before executing any  remote  commands
  on  the target. If a target is not responding, execution of
@@ -356,7 +356,7 @@ standard output or standard error is displayed.
  
 
 
-\ **-V**\ |\ **--version**\ 
+\ **-V | -**\ **-version**\ 
  
  Displays the \ **xdcp**\  command version information.
  

--- a/docs/source/guides/admin-guides/references/man1/xdsh.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/xdsh.1.rst
@@ -19,14 +19,14 @@ xdsh.1
 ****************
 
 
-\ **xdsh**\  \ *noderange*\  [\ **-B**\  \ *bypass*\ ]  [\ **--devicetype**\  \ *type_of_device*\ ] [\ **-e**\ ] [\ **-E**\  \ *environment_file*\ ]  [\ **-f**\  \ *fanout*\ ]
+\ **xdsh**\  \ *noderange*\  [\ **-B**\  \ *bypass*\ ]  [\ **-**\ **-devicetype**\  \ *type_of_device*\ ] [\ **-e**\ ] [\ **-E**\  \ *environment_file*\ ]  [\ **-f**\  \ *fanout*\ ]
 [\ **-L**\ ]  [\ **-l**\   \ *userID*\ ]   [\ **-m**\ ]   [\ **-o**\ 
-\ *node_options*\ ] [\ **-Q**\ ] [\ **-r**\  \ *node_remote_shell*\ ] [\ **-s**\ ] [\ **-S**\  \ **csh**\ |\ **ksh**\ ] [\ **-t**\  \ *timeout*\ ]
-[\ **-T**\ ] [\ **-v**\ ] [\ **-X**\  \ *env_list*\ ] [\ **-z**\ ] [\ **--sudo**\ ] \ *command_list*\ 
+\ *node_options*\ ] [\ **-Q**\ ] [\ **-r**\  \ *node_remote_shell*\ ] [\ **-s**\ ] [\ **-S**\  \ **csh | ksh**\ ] [\ **-t**\  \ *timeout*\ ]
+[\ **-T**\ ] [\ **-v**\ ] [\ **-X**\  \ *env_list*\ ] [\ **-z**\ ] [\ **-**\ **-sudo**\ ] \ *command_list*\ 
 
 \ **xdsh**\  \ *noderange*\   [\ **-K**\ ]
 
-\ **xdsh**\  \ *noderange*\   [\ **-K**\ ] [\ **-l**\   \ *userID*\ ] \ **--devicetype**\  \ *type_of_device*\ 
+\ **xdsh**\  \ *noderange*\   [\ **-K**\ ] [\ **-l**\   \ *userID*\ ] \ **-**\ **-devicetype**\  \ *type_of_device*\ 
 
 \ **xdsh**\  [\ **-i**\  \ *image path | nim image name*\ ] \ *command_list*\ 
 
@@ -196,7 +196,7 @@ running commands, are terminated (SIGTERM).
 
 
 
-\ **-c**\ |\ **--cleanup**\ 
+\ **-c | -**\ **-cleanup**\ 
  
  This flag will have xdsh remove all files from the subdirectories of the
  the directory on the servicenodes, where xdcp stages the copy to the 
@@ -208,7 +208,7 @@ running commands, are terminated (SIGTERM).
  
 
 
-\ **-e**\ |\ **--execute**\ 
+\ **-e | -**\ **-execute**\ 
  
  Indicates  that \ *command_list*\  specifies a local script
  filename and arguments to be executed on  the  remote  targets.
@@ -219,7 +219,7 @@ running commands, are terminated (SIGTERM).
  
 
 
-\ **-E**\ |\ **--environment**\  \ *environment_file*\ 
+\ **-E | -**\ **-environment**\  \ *environment_file*\ 
  
  Specifies that the  \ *environment_file*\   contains  environment
  variable definitions to export to the target before
@@ -227,7 +227,7 @@ running commands, are terminated (SIGTERM).
  
 
 
-\ **--devicetype**\  \ *type_of_device*\ 
+\ **-**\ **-devicetype**\  \ *type_of_device*\ 
  
  Specify a user-defined device type that references the location
  of relevant device configuration file. The devicetype value must
@@ -245,7 +245,7 @@ running commands, are terminated (SIGTERM).
  
 
 
-\ **-f**\ |\ **--fanout**\  \ *fanout_value*\ 
+\ **-f | -**\ **-fanout**\  \ *fanout_value*\ 
  
  Specifies a fanout value for the maximum number of  concur-
  rently  executing  remote shell processes. Serial execution
@@ -254,13 +254,13 @@ running commands, are terminated (SIGTERM).
  
 
 
-\ **-h**\ |\ **--help**\ 
+\ **-h | -**\ **-help**\ 
  
  Displays usage information.
  
 
 
-\ **-i**\ |\ **--rootimg**\  \ *install image*\ 
+\ **-i | -**\ **-rootimg**\  \ *install image*\ 
  
  For Linux, Specifies the path to the install image on the local node.
  For AIX, specifies the name of the osimage on the local node. Run lsnim 
@@ -272,11 +272,11 @@ running commands, are terminated (SIGTERM).
  
 
 
-\ **-K**\ |\ **--ssh-setup**\ 
+\ **-K | -**\ **-ssh-setup**\ 
 
 
 
-\ **-K**\ |\ **--ssh-setup**\   \ **-l**\ |\ **--user**\  \ *user_ID*\  \ **--devicetype**\  \ *type_of_device*\ 
+\ **-K | -**\ **-ssh-setup**\   \ **-l | -**\ **-user**\  \ *user_ID*\  \ **-**\ **-devicetype**\  \ *type_of_device*\ 
  
  Set up the SSH keys for the user running the command to the specified node list.
  The userid must have the same uid, gid and password as the userid on the node
@@ -293,14 +293,14 @@ running commands, are terminated (SIGTERM).
  
 
 
-\ **-l**\ |\ **--user**\  \ *user_ID*\ 
+\ **-l | -**\ **-user**\  \ *user_ID*\ 
  
  Specifies a remote user name to use for remote command exe-
  cution.
  
 
 
-\ **-L**\ |\ **--no-locale**\ 
+\ **-L | -**\ **-no-locale**\ 
  
  Specifies to not export the locale definitions of the local
  host to the remote targets. Local host  locale  definitions
@@ -308,14 +308,14 @@ running commands, are terminated (SIGTERM).
  
 
 
-\ **-m**\ |\ **--monitor**\ 
+\ **-m | -**\ **-monitor**\ 
  
  Monitors  remote  shell execution by displaying status
  messages during execution on each target.
  
 
 
-\ **-o**\ |\ **--node-options**\  \ *node_options*\ 
+\ **-o | -**\ **-node-options**\  \ *node_options*\ 
  
  Specifies options to pass to the remote shell  command  for
  node  targets.  The options must be specified within double
@@ -323,7 +323,7 @@ running commands, are terminated (SIGTERM).
  
 
 
-\ **-q**\ |\ **--show-config**\ 
+\ **-q | -**\ **-show-config**\ 
  
  Displays the current environment settings for all DSH
  Utilities commands. This includes the values of all environment
@@ -333,7 +333,7 @@ running commands, are terminated (SIGTERM).
  
 
 
-\ **-Q**\ |\ **--silent**\ 
+\ **-Q | -**\ **-silent**\ 
  
  Specifies silent mode. No target output is written to stan-
  dard output or  standard  error.  Monitoring  messages  are
@@ -341,14 +341,14 @@ running commands, are terminated (SIGTERM).
  
 
 
-\ **-r**\ |\ **--node-rsh**\  \ *node_remote_shell*\ 
+\ **-r | -**\ **-node-rsh**\  \ *node_remote_shell*\ 
  
  Specifies the path of the remote shell command used
  for remote command execution on node targets.
  
 
 
-\ **-s**\ |\ **--stream**\ 
+\ **-s | -**\ **-stream**\ 
  
  Specifies that output is returned as it  becomes  available
  from  each  target, instead of waiting for the \ *command_list*\ 
@@ -356,14 +356,14 @@ running commands, are terminated (SIGTERM).
  
 
 
-\ **-S**\ |\ **--syntax**\  \ **csh**\ |\ **ksh**\ 
+\ **-S | -**\ **-syntax**\  \ **csh | ksh**\ 
  
  Specifies the shell syntax to be used on the remote target.
  If not specified, the \ **ksh**\  syntax is used.
  
 
 
-\ **--sudo**\ |\ **--sudo**\ 
+\ **-**\ **-sudo | -**\ **-sudo**\ 
  
  Adding the --sudo flag to the xdsh command will have xdsh run sudo before
  running the command.  This is particular useful when using the -e option.
@@ -379,7 +379,7 @@ running commands, are terminated (SIGTERM).
  
 
 
-\ **-t**\ |\ **--timeout**\  \ *timeout*\ 
+\ **-t | -**\ **-timeout**\  \ *timeout*\ 
  
  Specifies the time, in seconds, to wait for output from any
  currently executing remote targets. If no output is
@@ -392,14 +392,14 @@ running commands, are terminated (SIGTERM).
  
 
 
-\ **-T**\ |\ **--trace**\ 
+\ **-T | -**\ **-trace**\ 
  
  Enables trace mode. The \ **xdsh**\  command prints diagnostic
  messages to standard output during execution to each target.
  
 
 
-\ **-v**\ |\ **--verify**\ 
+\ **-v | -**\ **-verify**\ 
  
  Verifies each target before executing any  remote  commands
  on  the target. If a target is not responding, execution of
@@ -409,7 +409,7 @@ running commands, are terminated (SIGTERM).
  
 
 
-\ **-V**\ |\ **--version**\ 
+\ **-V | -**\ **-version**\ 
  
  Displays the \ **xdsh**\  command version information.
  
@@ -428,7 +428,7 @@ running commands, are terminated (SIGTERM).
  
 
 
-\ **-z**\ |\ **--exit-status**\ 
+\ **-z | -**\ **-exit-status**\ 
  
  Displays the exit status for  the  last  remotely  executed
  non-asynchronous  command  on  each  target. If the command
@@ -463,7 +463,7 @@ running commands, are terminated (SIGTERM).
 
 \ **DEVICETYPE**\ 
  
- Specify a user-defined device type.  See \ **--devicetype**\  flag.
+ Specify a user-defined device type.  See \ **-**\ **-devicetype**\  flag.
  
 
 
@@ -656,7 +656,7 @@ The dsh command exit code is 0 if the command executed without errors and all re
  
  \ **chdef**\  \ *-t node -o qswitch groups=all nodetype=switch*\ 
  
- \ **xdsh**\  \ *qswitch -K -l username --devicetype IBSwitch::Qlogic*\ 
+ \ **xdsh**\  \ *qswitch -K -l username -**\ **-devicetype IBSwitch::Qlogic*\ 
  
 
 
@@ -675,7 +675,7 @@ The dsh command exit code is 0 if the command executed without errors and all re
  
  \ **chdef**\  \ *-t node -o mswitch groups=all nodetype=switch*\ 
  
- \ **xdsh**\  \ *mswitch -l admin --devicetype IBSwitch::Mellanox  'enable;configure terminal;show ssh server host-keys'*\ 
+ \ **xdsh**\  \ *mswitch -l admin -**\ **-devicetype IBSwitch::Mellanox  'enable;configure terminal;show ssh server host-keys'*\ 
  
 
 
@@ -696,7 +696,7 @@ The dsh command exit code is 0 if the command executed without errors and all re
  
  To run xdsh with the non-root userid "user1" that has been setup as an xCAT userid and with sudo on node1 and node2 to run as root, do the following, see xCAT doc on Granting_Users_xCAT_privileges:
  
- \ **xdsh**\  \ *node1,node2 --sudo -l user1 "cat /etc/passwd"*\ 
+ \ **xdsh**\  \ *node1,node2 -**\ **-sudo -l user1 "cat /etc/passwd"*\ 
  
 
 

--- a/docs/source/guides/admin-guides/references/man1/xpbsnodes.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/xpbsnodes.1.rst
@@ -19,9 +19,9 @@ SYNOPSIS
 ********
 
 
-\ **xpbsnodes**\  [{\ **noderange**\ }] [{\ **offline**\ |\ **clear**\ |\ **stat**\ |\ **state**\ }]
+\ **xpbsnodes**\  [{\ **noderange**\ }] [{\ **offline | clear | stat | state**\ }]
 
-\ **xpbsnodes**\  [\ **-h**\ |\ **--help**\ ] [\ **-v**\ |\ **--version**\ ]
+\ **xpbsnodes**\  [\ **-h | -**\ **-help**\ ] [\ **-v | -**\ **-version**\ ]
 
 
 ***********

--- a/docs/source/guides/admin-guides/references/man8/winstall.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/winstall.8.rst
@@ -32,7 +32,7 @@ Name
 \ **winstall**\  is a convenience tool that will change attributes as requested for operating system version, profile, and architecture, call \ **nodeset**\  to modify the network boot configuration, call \ **rsetboot**\  net to set the next boot over network (only support nodes
 with "nodetype.mgt=ipmi", for other nodes, make sure the correct boot order has been set before \ **winstall**\ ), and \ **rpower**\  to begin a boot cycle.
 
-If [\ *-O*\ |\ *-**\ **-osimage*\ ] is specified or nodetype.provmethod=\ *osimage*\  is set, provision the noderange with the osimage specified/configured, ignore the table change options if specified.
+If [\ **-O | -**\ **-osimage**\ ] is specified or nodetype.provmethod=\ *osimage*\  is set, provision the noderange with the osimage specified/configured, ignore the table change options if specified.
 
 It  will then run wcons on the nodes.
 
@@ -57,19 +57,19 @@ It  will then run wcons on the nodes.
 
 \ **-o | -**\ **-osver**\ 
  
- Specifies which os version to provision.  If unspecified, the current node os setting is used. Will be ignored if [\ *-O*\ |\ *-**\ **-osimage*\ ] is specified or nodetype.provmethod=\ *osimage*\ .
+ Specifies which os version to provision.  If unspecified, the current node os setting is used. Will be ignored if [\ *-O*\ |\ *--osimage*\ ] is specified or nodetype.provmethod=\ *osimage*\ .
  
 
 
 \ **-p | -**\ **-profile**\ 
  
- Specifies what profile should be used of the operating system.  If not specified the current node profile setting is used. Will be ignored if [\ *-O*\ |\ *-**\ **-osimage*\ ] is specified or nodetype.provmethod=\ *osimage*\ .
+ Specifies what profile should be used of the operating system.  If not specified the current node profile setting is used. Will be ignored if [\ *-O*\ |\ *--osimage*\ ] is specified or nodetype.provmethod=\ *osimage*\ .
  
 
 
 \ **-a | -**\ **-arch**\ 
  
- Specifies what architecture of the OS to provision.  Typically this is unneeded, but if provisioning between x86_64 and x86 frequently, this may be a useful flag. Will be ignored if [\ *-O*\ |\ *-**\ **-osimage*\ ] is specified or nodetype.provmethod=\ *osimage*\ .
+ Specifies what architecture of the OS to provision.  Typically this is unneeded, but if provisioning between x86_64 and x86 frequently, this may be a useful flag. Will be ignored if [\ *-O*\ |\ *--osimage*\ ] is specified or nodetype.provmethod=\ *osimage*\ .
  
 
 

--- a/xCAT-client/pods/man1/addkit.1.pod
+++ b/xCAT-client/pods/man1/addkit.1.pod
@@ -37,11 +37,11 @@ Command version.
 
 Show the summary of the given kits
 
-=item B<-p|--path <path>
+=item B<-p|--path> I<path>
 
 The destination directory to which the contents of the kit tarfiles and/or kit deploy directories will be copied.  When this option is not specified, the default destination directory will be formed from the installdir site attribute with ./kits subdirectory.
 
-=item B<kitlist>
+=item I<kitlist>
 
 A comma delimited list of kit_tarball_files or kit_deploy_directories to be added to the xCAT environment. Each entry can be an absolute or relative path.  See xCAT documentation for more information on building kits.
 
@@ -63,11 +63,11 @@ A comma delimited list of kit_tarball_files or kit_deploy_directories to be adde
 
  addkit kit-test1,kit-test2
 
-3. To add kits from tarball 'kit-test1.tar.bz2' to target path '/install/test':
+3. To add kits from tarball I<kit-test1.tar.bz2> to target path I</install/test>:
 
  addkit -p /install/test kit-test1.tar.bz2
 
-4. To see general information about kit 'kit-test1.tar.bz2' without adding the kit to xCAT:
+4. To see general information about kit I<kit-test1.tar.bz2> without adding the kit to xCAT:
 
  addkit -i kit-test1.tar.bz2
 

--- a/xCAT-client/pods/man1/addkitcomp.1.pod
+++ b/xCAT-client/pods/man1/addkitcomp.1.pod
@@ -52,7 +52,7 @@ The osimage name that the kit component is assigning to.
 
 Do not add kitcomponent's postbootscripts to osimage
 
-=item B<kitcompname_list>
+=item I<kitcompname_list>
 
 A comma-delimited list of valid full kit component names or kit component basenames that are to be added to the osimage.
 

--- a/xCAT-client/pods/man1/cfgve.1.pod
+++ b/xCAT-client/pods/man1/cfgve.1.pod
@@ -4,17 +4,15 @@ B<cfgve> - Configure the elements for a virtual environment.
 
 =head1 SYNOPSIS
 
-B<cfgve> B<-t> dc B<-m> manager B<-o> object [B<-c> B<-k> nfs|localfs | B<-r>]
+B<cfgve> B<-t dc -m> I<manager> B<-o> I<object> [B<-c> B<-k nfs> | B<localfs> | B<-r>]
 
-B<cfgve> B<-t> cl B<-m> manager B<-o> object [B<-c> B<-p> cpu type| B<-r> B<-f>]
+B<cfgve> B<-t cl -m> I<manager> B<-o> I<object> [B<-c -p> I<cpu type> | B<-r -f>]
 
-B<cfgve> B<-t> sd B<-m> manager B<-o> object [B<-c> | B<-g> | B<-s> 
-| B<-a> | B<-b> | B<-r> B<-f>]
+B<cfgve> B<-t sd -m> I<manager> B<-o> I<object> [B<-c> | B<-g> | B<-s> | B<-a> | B<-b> | B<-r> B<-f>]
 
-B<cfgve> B<-t> nw B<-m> manager B<-o> object [B<-c> B<-d> data center B<-n> 
-vlan ID | B<-a> B<-l> cluster | B<-b> | B<-r>]
+B<cfgve> B<-t nw -m> I<manager> B<-o> I<object> [B<-c> B<-d> I<data center> B<-n> I<vlan ID> | B<-a> B<-l> I<cluster> | B<-b> | B<-r>]
 
-B<cfgve> B<-t> tpl B<-m> manager B<-o> object [B<-r>]
+B<cfgve> B<-t tpl -m> I<manager> B<-o> I<object> [B<-r>]
 
 
 =head1 DESCRIPTION
@@ -22,10 +20,10 @@ B<cfgve> B<-t> tpl B<-m> manager B<-o> object [B<-r>]
 The B<cfgve> command can be used to configure a virtual environment for 
 'Storage Domain', 'Network' and 'Template' objects.
 
-The mandatory parameter B<-m manager> is used to specify the address of the 
+The mandatory parameter B<-m> I<manager> is used to specify the address of the 
 manager of virtual environment. xCAT needs it to access the RHEV manager.
 
-The mandatory parameter B<-t type> is used to specify the type of the target 
+The mandatory parameter B<-t> I<type> is used to specify the type of the target 
 object.
 
 Basically, B<cfgve> command supports five types of object: B<dc>, B<cl>, 
@@ -46,7 +44,7 @@ B<tpl> - The B<remove> operation is supported.
 
 =back
 
-The mandatory parameter B<-o object> is used to specify which object to configure.
+The mandatory parameter B<-o> I<object> is used to specify which object to configure.
 
 
 =head1 OPTIONS

--- a/xCAT-client/pods/man1/cfm2xcat.1.pod
+++ b/xCAT-client/pods/man1/cfm2xcat.1.pod
@@ -4,7 +4,7 @@ B<cfm2xcat> - Migrates the CFM setup in CSM to the xdcp rsync setup in xCAT.
 
 =head1 B<SYNOPSIS>
 
-B<cfm2xcat> [B<-i> I<path of the CFM distribution files generated >] [B<-o> I<path of the xdcp rsync files generated from the CFM distribution files >]
+B<cfm2xcat> [B<-i> I<path of the CFM distribution files generated>] [B<-o> I<path of the xdcp rsync files generated from the CFM distribution files>]
 
 B<cfm2xcat> [B<-h>] 
 
@@ -12,7 +12,9 @@ B<cfm2xcat> [B<-h>]
 =head1 B<DESCRIPTION>
 
 Copy the cfm2xcat command to the CSM Management Server.  Run the command, indicating where you want your files saved with the -i and -o flags. They can be in the same directory.   
+
 The cfm2xcat command will run cfmupdatenode -a, saving the generated CFM distribution files in the directory indicates with (-i). From those distribution files, it will generate xdcp rsync input files (-F option on xdcp) in the directory indicated by ( -o).
+
 Check the rsync files generated.  There will be a file generated (rsyncfiles)  from the input -o option on the command, and the same file with a (.nr) extension generated for each different noderange that will used to sync files based on your CFM setup in CSM. The rsyncfiles will contain the rsync file list.   The rsyncfiles.nr will contain the noderange. If multiple noderanges then the file name (rsyncfiles)  will be appended with a number. 
 
 =head1 OPTIONS
@@ -34,14 +36,14 @@ B<-o>          Path of the xdcp rsync input file generated from the CFM distribu
 
 1. To build xCAT rsync files to use with xdcp -F , enter on the CSM Management Server, make sure the path exists:
 
-B<cfm2xcat -i /tmp/cfm/cfmdistfiles -o /tmp/cfm/rsyncfiles>
+ cfm2xcat -i /tmp/cfm/cfmdistfiles -o /tmp/cfm/rsyncfiles
 
 
 2. To use the file on the xCAT Management Node copy to /tmp/cfm on the xCAT MN:
 
-B<xdcp ^/tmp/cfm/rsyncfiles.nr -F /tmp/cfm/rsyncfiles>
-B<xdcp ^/tmp/cfm/rsyncfiles.nr1 -F /tmp/cfm/rsyncfiles1>
-B<xdcp ^/tmp/cfm/rsyncfiles.nr2 -F /tmp/cfm/rsyncfiles2>
+ xdcp ^/tmp/cfm/rsyncfiles.nr -F /tmp/cfm/rsyncfiles
+ xdcp ^/tmp/cfm/rsyncfiles.nr1 -F /tmp/cfm/rsyncfiles1
+ xdcp ^/tmp/cfm/rsyncfiles.nr2 -F /tmp/cfm/rsyncfiles2
 
 
 =head1 FILES

--- a/xCAT-client/pods/man1/chdef.1.pod
+++ b/xCAT-client/pods/man1/chdef.1.pod
@@ -10,8 +10,7 @@ B<chdef> [B<-t> I<object-types>] [B<-o> I<object-names>] [B<-n> I<new-name>] [I<
 
 B<chdef> [B<-V>|B<--verbose>] [B<-t> I<object-types>] [B<-o> I<object-names>]
 [B<-d>|B<--dynamic>] [B<-p>|B<--plus>] [B<-m>|B<--minus>] [B<-z>|B<--stanza>]
-[[B<-w> I<attr>==I<val>] [B<-w> I<attr>=~I<val>] ...] [I<noderange>] [I<attr>=I<val> [I<attr>=I<val...>]]
-      [B<-u> [I<provmethod>=<I<install>|I<netboot>|I<statelite>>] [I<profile>=<xxx>] [I<osvers>=I<value>] [I<osarch>=I<value>]]
+[[B<-w> I<attr>==I<val>] [B<-w> I<attr>=~I<val>] ...] [I<noderange>] [I<attr=val> [I<attr=val...>]] [B<-u> [B<provmethod=> {B<install> | B<netboot> | B<statelite>}] [B<profile=>I<xxx>] [B<osvers>=I<value>] [B<osarch>=I<value>]]
 
 =head1 DESCRIPTION
 

--- a/xCAT-client/pods/man1/chkkitcomp.1.pod
+++ b/xCAT-client/pods/man1/chkkitcomp.1.pod
@@ -36,7 +36,7 @@ Command version.
 
 The name of the osimage to check against.
 
-=item B<kitcompname_list>
+=item I<kitcompname_list>
 
 A comma-delimited list of valid full kit component names or kit component basenames that are to be checked against the osimage.
 
@@ -50,7 +50,7 @@ A comma-delimited list of valid full kit component names or kit component basena
 
 =head1 EXAMPLES
 
-1. To check if a kit component , I<comp-test1-1.0-1-rhels-6.2-ppc64> can be added to osimage I<rhels6.2-ppc64-netboot-compute>:
+1. To check if a kit component, I<comp-test1-1.0-1-rhels-6.2-ppc64> can be added to osimage I<rhels6.2-ppc64-netboot-compute>:
 
    chkkitcomp -i rhels6.2-ppc64-netboot-compute comp-test1-1.0-1-rhels-6.2-ppc64
 

--- a/xCAT-client/pods/man1/chkosimage.1.pod
+++ b/xCAT-client/pods/man1/chkosimage.1.pod
@@ -6,7 +6,7 @@ B<chkosimage> - Use this xCAT command to check an xCAT osimage.
 
 B<chkosimage [-h | --help ]>
 
-B<chkosimage [-V] [-c|--clean] osimage_name> 
+B<chkosimage [-V] [-c|--clean]> I<osimage_name> 
 
 =head1 DESCRIPTION
 
@@ -55,7 +55,7 @@ timestamp.
 
 Display usage message.
 
-=item B<osimage_name>
+=item I<osimage_name>
 
 The name of the xCAT for AIX osimage definition. 
 
@@ -70,11 +70,9 @@ Verbose mode.
 =over 3
 
 =item 0
-
 The command completed successfully.
 
 =item 1
-
 An error has occurred.
 
 =back
@@ -83,20 +81,18 @@ An error has occurred.
 
 =over 3
 
-=item 1
-
+=item 1.
 Check the XCAT osimage called "61image" to verify that the lpp_source 
 directories contain all the software that is specified in the
 "installp_bundle" and "otherpkgs" attributes.
 
-B<chkosimage -V 61image>
+ chkosimage -V 61image
 
-=item 2
-
+=item 2.
 Clean up the lpp_source directory for the osimage named "61img" by removing
 any older rpms with the same names but different versions.
 
-B<chkosimage -c 61img>
+ chkosimage -c 61img
 
 =back
 

--- a/xCAT-client/pods/man1/chvm.1.pod
+++ b/xCAT-client/pods/man1/chvm.1.pod
@@ -16,18 +16,13 @@ B<chvm> [B<-V>| B<--verbose>] I<noderange> I<attr>=I<val> [I<attr>=I<val>...]
 
 =head2 PPC (using Direct FSP Management) specific:
 
-B<chvm> I<noderange> I<--p775> [B<-p> I<profile>]
+B<chvm> I<noderange> B<--p775> [B<-p> I<profile>]
 
-B<chvm> I<noderange> I<--p775> B<-i id> [B<-m> I<memory_interleaving>] B<-r> I<partition_rule>
+B<chvm> I<noderange> B<--p775> B<-i id> [B<-m> I<memory_interleaving>] B<-r> I<partition_rule>
 
-B<chvm> I<noderange> [B<lparname>={B<*>|B<name>}]
+B<chvm> I<noderange> [B<lparname>={ * | I<name>}]
 
-B<chvm> I<noderange> [B<vmcpus=min/req/max>] [B<vmmemory=min/req/max>]
-               [B<vmothersetting=hugepage:N,bsr:N>]
-               [B<add_physlots=drc_index1,drc_index2...>]
-               [B<add_vmnics=vlan1[,vlan2..]]> [B<add_vmstorage=<N|viosnode:slotid>>] [B<--vios>]
-               [B<del_physlots=drc_index1,drc_index2...>]
-               [B<del_vadapter=slotid>]
+B<chvm> I<noderange> [B<vmcpus=> I<min/req/max>] [B<vmmemory=> I<min/req/max>] [B<vmothersetting=hugepage:N,bsr:N>] [B<add_physlots=> I<drc_index1,drc_index2...>] [B<add_vmnics=> I<vlan1[,vlan2..]]> [B<add_vmstorage=<N|viosnode:slotid>>] [B<--vios>] [B<del_physlots=> I<drc_index1,drc_index2...>] [B<del_vadapter=> I<slotid>]
 
 
 =head2 KVM specific:
@@ -535,6 +530,7 @@ Output is similar to:
 7. For Normal Power machine, to modify the resource assigned to a partition:
 
 Before modify, the resource assigned to node 'lpar1' can be shown with:
+
  lsvm lpar1
 
 The output is similar to:

--- a/xCAT-client/pods/man1/chzone.1.pod
+++ b/xCAT-client/pods/man1/chzone.1.pod
@@ -4,7 +4,7 @@ B<chzone> - Changes a zone defined  in the cluster.
 
 =head1 B<SYNOPSIS>
 
-B<chzone> <zonename>  [B<--defaultzone>] [-K] [B<-k> I<full path to the ssh RSA private key>] [B<-a> I<noderange> | B<-r> I<noderange>] [B<-g>] [B<-f>] [B<-s> I<yes|no>] [-V] 
+B<chzone> I<zonename>  [B<--defaultzone>] B<[-K]> [B<-k> I<full path to the ssh RSA private key>] [B<-a> I<noderange> | B<-r> I<noderange>] [B<-g>] [B<-f>] [B<-s> B<{yes|no}>] [B<-V>] 
 
 B<chzone> [B<-h> | B<-v>]
 
@@ -37,12 +37,12 @@ This is the path to the id_rsa key that will be used to build new root's ssh key
 Using this flag, will  generate new ssh RSA private and public keys for the zone into the /etc/xcat/sshkeys/<zonename>/.ssh directory.
 The nodes are not automatically updated with the new root ssh keys by chzone. You must run updatenode -k  or xdsh -K to the nodes to update the root ssh keys to the new generated zone keys. This will also sync any service nodes with the zone keys, if you have a hierarchical cluster.
 
-=item B<--default>
+=item B<--defaultzone>
 
-if --defaultzone is input, then it will set the zone defaultzone attribute to yes.
-if --defaultzone is input and another zone is currently the default,
-then the -f flag must be used to force a change to the new defaultzone.
-If -f flag is not use an error will be returned and no change made. 
+if B<--defaultzone> is input, then it will set the zone defaultzone attribute to yes.
+if B<--defaultzone> is input and another zone is currently the default,
+then the B<-f> flag must be used to force a change to the new defaultzone.
+If B<-f> flag is not use an error will be returned and no change made. 
 Note: if any zones in the zone table, there must be one and only one defaultzone. Otherwise, errors will occur.
 
 =item B<-a | --addnoderange> I<noderange>
@@ -65,11 +65,11 @@ If -s entered, the zone sshbetweennodes attribute will be set to yes or no based
 
 =item B<-f | --force> 
 
-Used with the (--defaultzone) flag to override the current default zone.
+Used with the B<--defaultzone> flag to override the current default zone.
 
 =item B<-g | --assigngroup> 
 
-Used with the (-a or -r ) flag to add or remove the group zonename for all nodes in the input noderange.
+Used with the B<-a> or B<-r> flag to add or remove the group zonename for all nodes in the input noderange.
 
 =item B<-V>|B<--Verbose>
 
@@ -79,57 +79,52 @@ Verbose mode.
 =back
 
 
-=head1 B<Examples>
+=head1 B<EXAMPLES>
 
 =over 3
 
-=item *
-
+=item 1.
 To chzone zone1 to the default zone, enter:
 
-B<chzone> I<zone1> --default -f
+ chzone> zone1 --default -f
 
-=item *
-
+=item 2.
 To generate new root ssh keys for zone2A using the ssh id_rsa private key in /root/.ssh:
 
-B<chzone> I<zone2A> -k /root/.ssh
+ chzone zone2A -k /root/.ssh
 
 Note: you must use xdsh -K or updatenode -k to update the nodes with the new keys 
 
-=item *
-
+=item 3.
 To generate new root ssh keys for zone2A, enter :
 
-B<chzone> I<zone2A> -K  
+ chzone zone2A -K  
 
 Note: you must use xdsh -K or updatenode -k to update the nodes with the new keys 
 
-=item *
-
+=item 4.
 To add a new group of nodes (compute3) to zone3 and add zone3 group to the nodes,  enter:
 
-B<chzone> I<zone3>  -a compute3 -g
+ chzone zone3 -a compute3 -g
 
-=item *
+=item 5.
 
 To remove a group of nodes (compute4) from zone4 and remove zone4 group from the nodes,  enter:
 
-B<chzone> I<zone4>  -r compute4 -g
+ chzone> zone4 -r compute4 -g
 
-=item *
-
+=item 6.
 To change the sshbetweennodes setting on the zone to not allow passwordless ssh between nodes,  enter:
 
-B<chzone> I<zone5> -s no 
+ chzone zone5 -s no 
 
-Note: you must use xdsh -K or updatenode -k to update the nodes with this new setting.
+Note: you must use B<xdsh -K> or B<updatenode -k> to update the nodes with this new setting.
 
 =back
 
-B<Files>
+=head1 B<FILES>
 
-B</opt/xcat/bin/chzone/>
+/opt/xcat/bin/chzone/
 
 Location of the chzone command.
 

--- a/xCAT-client/pods/man1/clonevm.1.pod
+++ b/xCAT-client/pods/man1/clonevm.1.pod
@@ -4,7 +4,7 @@ B<clonevm> - Create masters from virtual machines and virtual machines from mast
 
 =head1 SYNOPSIS
 
-I<clonevm noderange [ -t <mastertobemade> | -b <master to base vms upon> ]  -d|--detached -f|--force>
+B<clonevm> I<noderange> [ B<-t> I<mastertobemade> | B<-b> I<master to base vms upon> ]  B<-d|--detached -f|--force>
 
 =head1 DESCRIPTION
 
@@ -50,11 +50,19 @@ Any other value: An error has occurred.
 
 =head1 EXAMPLES
 
-Creating a master named appserver from a node called vm1:
-I<clonevm vm1 -t appserver>
+=over 3
 
+=item 1.
+Creating a master named appserver from a node called vm1:
+
+ clonevm vm1 -t appserver
+
+=item 2.
 Cleating 30 VMs from a master named appserver:
-I<clonevm vm1-vm30 -b appserver>
+
+ clonevm vm1-vm30 -b appserver
+
+=back
 
 =head1 FILES
 

--- a/xCAT-client/pods/man1/configfpc.1.pod
+++ b/xCAT-client/pods/man1/configfpc.1.pod
@@ -16,7 +16,7 @@ B<configfpc> [B<-h>|B<--help>|B<-?>]
 
 B<configfpc> will discover and configure all FPCs that are set to the default IP address. If not supplied the default ip is 192.168.0.100.
 
-The B<-i> B<interface> is required to direct B<configfpc> to the xCAT MN interface which is on the same VLAN as the FPCs.
+The B<-i> I<interface> is required to direct B<configfpc> to the xCAT MN interface which is on the same VLAN as the FPCs.
 
 There are several bits of information that must be included in the xCAT database before running this command.
 
@@ -47,21 +47,19 @@ Verbose mode
 
 =back
 
-=head1 Example
+=head1 EXAMPLES
 
 =over 6
 
-=item 1
-
+=item 1.
 To discover and configure all NeXtScale Fan Power Controllers (FPCs) connected on eth0 interface. 
 
-B<configfpc> B<-i> I<eth0>
+ configfpc -i eth0
 
-=item 2
-
+=item 2.
 To override the default ip address and run in Verbose mode. 
 
-B<configfpc> B<-i> I<eth0> B<--ip> I<196.68.0.100>  B<-V>
+ configfpc -i eth0 --ip 196.68.0.100 -V
 
 =back
 

--- a/xCAT-client/pods/man1/csm2xcat.1.pod
+++ b/xCAT-client/pods/man1/csm2xcat.1.pod
@@ -13,7 +13,7 @@ B<csm2xcat> [B<-h>]
 
 The csm2xcat command must be run on the Management Server of the CSM system that you want to migrate to xCAT.  The commmand will build  two xCAT stanza files that can update the xCAT database with the chdef command. 
 
-Copy the csm2xcat command to the CSM Management Server.  Run the command, indicating where you want your stanza files saved with the --dir parameter.  Check the stanza files to see if the information is what you want put in the xCAT database. Copy the two stanza files: node.stanza, device.stanza back to your xCAT Management node, and run the chdef command to input into the xCAT database.
+Copy the csm2xcat command to the CSM Management Server.  Run the command, indicating where you want your stanza files saved with the B<--dir> parameter.  Check the stanza files to see if the information is what you want put in the xCAT database. Copy the two stanza files: node.stanza, device.stanza back to your xCAT Management node, and run the chdef command to input into the xCAT database.
 
 =head1 OPTIONS
 
@@ -31,14 +31,14 @@ B<--dir>          Path to the directory containing the stanza files.
 
 1. To build xCAT stanza files, enter on the CSM Management Server:
 
-B<csm2xcat --dir  /tmp/mydir>
+ csm2xcat --dir /tmp/mydir
 
 
 2. To put the data in the xCAT database on the xCAT Management Node:
 
-B<cat node.stanza | chdef -z>
+ cat node.stanza | chdef -z
 
-B<cat device.stanza | chdef -z>
+ cat device.stanza | chdef -z
 
 
 =head1 FILES

--- a/xCAT-client/pods/man1/db2sqlsetup.1.pod
+++ b/xCAT-client/pods/man1/db2sqlsetup.1.pod
@@ -5,17 +5,17 @@ B<db2sqlsetup> - Sets up the IBM DB2 for xCAT to use.
 =head1 SYNOPSIS
 
 
-B<db2sqlsetup> {B<-h>|B<--help>}
+B<db2sqlsetup> [B<-h>|B<--help>}
 
-B<db2sqlsetup> {B<-v>|B<--version>}
+B<db2sqlsetup> [B<-v>|B<--version>}
 
-B<db2sqlsetup> {B<-i>|B<--init>}{<-S> | <-C>} [-o|--setupODBC]  [B<-V>|B<--verbose>]
+B<db2sqlsetup> [B<-i>|B<--init>] {B<-S> | B<-C>} [B<-o>|B<--setupODBC>] [B<-V>|B<--verbose>]
 
-B<db2sqlsetup> {B<-i>|B<--init>}{<-S>} [-N|--nostart]  [-o|--setupODBC]  [B<-V>|B<--verbose>]
+B<db2sqlsetup> [B<-i>|B<--init>] {B<-S>} [B<-N>|B<--nostart>] [B<-o>|B<--setupODBC>] [B<-V>|B<--verbose>]
 
-B<db2sqlsetup> {B<-o>|B<--setupODBC>} {<-S> | <-C>} [-V|--verbose] 
+B<db2sqlsetup> [B<-o>|B<--setupODBC>] {B<-S> | B<-C>} [B<-V>|B<--verbose>] 
 
-B<db2sqlsetup> {B<-p>|B<--passwd>} [<-S> | <-C>]
+B<db2sqlsetup> [B<-p>|B<--passwd>] [B<-S> | B<-C>]
 
 =head1 DESCRIPTION
 
@@ -81,15 +81,12 @@ This option sets up the ODBC  /etc/../odbcinst.ini, /etc/../odbc.ini and the .od
 =over 2
 
 =item *
-
 XCATDB2INSPATH  overrides the default install path for DB2 which is /opt/ibm/db2/V9.7 for Linux and /opt/IBM/db2/V9.7 for AIX.
 
 =item *
-
 DATABASELOC override the where to create the xcat DB2 database, which is /var/lib/db2 by default of taken from the site.databaseloc  attribute.
 
 =item *
-
 XCATDB2PW can be set to the password for the xcatdb DB2 instance id so that there will be no prompting for a password when the script is run.
 
 =back
@@ -98,40 +95,35 @@ XCATDB2PW can be set to the password for the xcatdb DB2 instance id so that ther
 
 =over 2
 
-=item *
-
+=item 1.
 To setup DB2 Server for  xCAT to run on the DB2 xcatdb database, on the MN:
 
-B<db2sqlsetup> I<-i> I<-S>
+ db2sqlsetup -i -S
 
-=item *
-
+=item 2.
 To setup DB2 Client for  xCAT to run on the DB2 xcatdb database, on the SN:
 
-B<db2sqlsetup> I<-i> I<-C>
+ db2sqlsetup -i -C
 
-=item *
-
+=item 3.
 To setup the ODBC for  DB2 xcatdb database access, on the MN :
 
-B<db2sqlsetup> I<-o> I<-S>
+ db2sqlsetup -o -S
 
-=item *
-
+=item 4.
 To setup the ODBC for  DB2 xcatdb database access, on the SN :
 
-B<db2sqlsetup> I<-o> I<-C>
+ db2sqlsetup -o -C
 
-=item *
+=item 5.
 
 To setup the DB2 database but not start xcat running with it:
 
-B<db2sqlsetup> I<-i> I<-S> I<-N>
+ db2sqlsetup -i -S -N
 
-=item *
-
+=item 6.
 To change the DB2 xcatdb password on both the Management and Service Nodes:
 
-B<db2sqlsetup> I<-p>
+ db2sqlsetup -p
 
 =back

--- a/xCAT-client/pods/man1/dumpxCATdb.1.pod
+++ b/xCAT-client/pods/man1/dumpxCATdb.1.pod
@@ -45,27 +45,27 @@ B<-p>          Path to the directory to dump the database. It will be created, i
 
 1. To dump the xCAT database into the /tmp/db directory, enter:
 
-B<dumpxCATdb -p /tmp/db>
+ dumpxCATdb -p /tmp/db
 
 2. To dump the xCAT database into the /tmp/db directory, including the auditlog and eventlog enter:
 
-B<dumpxCATdb -a -p /tmp/db>
+ dumpxCATdb -a -p /tmp/db
 
 3. To have dumpxCATdb not backup the hosts or passwd table:
 
-B<chtab key=skiptables site.value="hosts,passwd">
+ chtab key=skiptables site.value="hosts,passwd"
 
-B<dumpxCATdb  -p /tmp/db>
+ dumpxCATdb  -p /tmp/db
 
 4. To have dumpxCATdb not backup the hosts or passwd table:
 
-B<export XCAT_SKIPTABLES="hosts,passwd">
+ export XCAT_SKIPTABLES="hosts,passwd"
 
-B<dumpxCATdb  -p /tmp/db>
+ dumpxCATdb  -p /tmp/db
 
 5. To have dumpxCATdb use DB2 utilities to backup the DB2 database:
 
-B<dumpxCATdb -b -p /install/db2backup>
+ dumpxCATdb -b -p /install/db2backup
 
 
 =head1 FILES

--- a/xCAT-client/pods/man1/genimage.1.pod
+++ b/xCAT-client/pods/man1/genimage.1.pod
@@ -29,7 +29,7 @@ for stateless: B<packimage>
 
 for statelite: B<liteimg>
 
-Besides prompting for some paramter values, the B<genimage> command takes default guesses for the parameters not specified or not defined in the I<osimage> and I<linuximage> tables. It also assumes default answers for questions from the yum/zypper command when installing rpms into the image. Please use --interactive flag if you want the yum/zypper command to prompt you for the answers.  
+Besides prompting for some paramter values, the B<genimage> command takes default guesses for the parameters not specified or not defined in the I<osimage> and I<linuximage> tables. It also assumes default answers for questions from the yum/zypper command when installing rpms into the image. Please use B<--interactive> flag if you want the yum/zypper command to prompt you for the answers.  
 
 If B<--onlyinitrd> is specified, genimage only regenerates the initrd for a stateless image to be used for a diskless install.
 

--- a/xCAT-client/pods/man1/getadapter.1.pod
+++ b/xCAT-client/pods/man1/getadapter.1.pod
@@ -59,14 +59,14 @@ Force to trigger new round scan. ignore the data collected before.
 
 Output is similar to:
 
--->Starting scan for: node1,node2
-The whole scan result:
---------------------------------------
-[node1]: Adapter information exists, no need to scan.
---------------------------------------
-[node2] scan successfully, below are the latest data
-node2:[1]->eno1!mac=34:40:b5:be:6a:80|pci=/pci0000:00/0000:00:01.0/0000:0c:00.0|candidatename=eno1/enp12s0f0/enx3440b5be6a80
-node2:[2]->enp0s29u1u1u5!mac=36:40:b5:bf:44:33|pci=/pci0000:00/0000:00:1d.0/usb2/2-1/2-1.1/2-1.1.5/2-1.1.5:1.0|candidatename=enp0s29u1u1u5/enx3640b5bf4433
+ -->Starting scan for: node1,node2
+ The whole scan result:
+ --------------------------------------
+ [node1]: Adapter information exists, no need to scan.
+ --------------------------------------
+ [node2] scan successfully, below are the latest data
+ node2:[1]->eno1!mac=34:40:b5:be:6a:80|pci=/pci0000:00/0000:00:01.0/0000:0c:00.0|candidatename=eno1/enp12s0f0/enx3440b5be6a80
+ node2:[2]->enp0s29u1u1u5!mac=36:40:b5:bf:44:33|pci=/pci0000:00/0000:00:1d.0/usb2/2-1/2-1.1/2-1.1.5/2-1.1.5:1.0|candidatename=enp0s29u1u1u5/enx3640b5bf4433
 
 Every node gets a separate section to display its all network adapters information, every network adapter owns single line which start as node name and followed by index and other information.
 

--- a/xCAT-client/pods/man1/getmacs.1.pod
+++ b/xCAT-client/pods/man1/getmacs.1.pod
@@ -103,9 +103,9 @@ Specify the interface whose mac address will be collected and written into mac t
 
 =head1 RETURN VALUE
 
-  0 The command completed successfully.
+0 The command completed successfully.
 
-  1 An error has occurred.
+1 An error has occurred.
 
 
 =head1 EXAMPLES

--- a/xCAT-client/pods/man1/gettab.1.pod
+++ b/xCAT-client/pods/man1/gettab.1.pod
@@ -35,11 +35,9 @@ Display usage message.
 =over 3
 
 =item 0
-
 The command completed successfully.
 
 =item 1
-
 An error has occurred.
 
 =back
@@ -48,25 +46,23 @@ An error has occurred.
 
 =over 2
 
-=item *
-
+=item 1.
 To display setting for B<master> (management node) in the site table:
 
-B<gettab -H> I<key=master site.value>
+ gettab -H key=master site.value
 
 The output would be similar to:
 
-     site.value: mgmtnode.cluster.com
+ site.value: mgmtnode.cluster.com
 
-=item *
-
+=item 2.
 To display the first node or group name that has B<mgt> set to B<blade> in the nodehm table:
 
-B<gettab> I<mgt=blade nodehm.node>
+ gettab mgt=blade nodehm.node
 
 The output would be similar to:
 
-     blades
+ blades
 
 =back
 

--- a/xCAT-client/pods/man1/groupfiles4dsh.1.pod
+++ b/xCAT-client/pods/man1/groupfiles4dsh.1.pod
@@ -40,7 +40,7 @@ B<-p>          Path to the directory to create the nodegroup files (must exist).
 
 1. To create the nodegroup files in directory /tmp/nodegroupfiles, enter:
 
-B<groupfiles4dsh -p /tmp/nodegroupfiles>
+ groupfiles4dsh -p /tmp/nodegroupfiles
 
 To use with dsh:
 

--- a/xCAT-client/pods/man1/imgcapture.1.pod
+++ b/xCAT-client/pods/man1/imgcapture.1.pod
@@ -4,7 +4,7 @@ B<imgcapture> - Captures an image from a Linux diskful node and create a diskles
 
 =head1 SYNOPSIS
 
-B<imgcapture> node B<-t>|B<--type> {diskless|sysclone} B<-o>|B<--osimage> I<osimage> [B<-V>|B<--verbose>]
+B<imgcapture> I<node> B<-t>|B<--type> {B<diskless>|B<sysclone>} B<-o>|B<--osimage> I<osimage> [B<-V>|B<--verbose>]
 
 B<imgcapture> [B<-h> | B<--help>] | [B<-v> | B<--version>]
 
@@ -100,11 +100,11 @@ B<node1> is one diskful Linux node, which is managed by xCAT.
 
 1. There's one pre-defined I<osimage>. In order to capture and prepare the diskless root image for I<osimage>, run the command:
 
-imgcapture node1 -t diskless -o osimage
+ imgcapture node1 -t diskless -o osimage
 
 2. In order to capture the diskful image from B<node1> and create the I<osimage> B<img1>, run the command:
 
-imgcapture node1 -t sysclone -o img1
+ imgcapture node1 -t sysclone -o img1
 
 =head1 FILES
 

--- a/xCAT-client/pods/man1/imgexport.1.pod
+++ b/xCAT-client/pods/man1/imgexport.1.pod
@@ -6,7 +6,7 @@ B<imgexport> - Exports an xCAT image.
 
 B<imgexport [-h| --help]>
 
-B<imgexport image_name [destination] [[-e|--extra file:dir] ... ] [-p|--postscripts node_name] [-v|--verbose]>
+B<imgexport> I<image_name> [I<destination>] [[B<-e>|B<--extra> I<file:dir>] ... ] [B<-p>|B<--postscripts> I<node_name>] [B<-v>|B<--verbose>]
 
 
 =head1 DESCRIPTION
@@ -75,19 +75,19 @@ I<destination>                       The output bundle file name.
 
 1. Simplest way to export an image.  If there is an image in the osimage table named 'foo', then run:
 
-B<imgexport foo>
+ imgexport foo
 
 foo.tgz will be built in the current working directory.  Make sure that you have enough space in the directory that you are in to run imgexport if you have a big image to tar up.
 
 2. To include extra files with your image:
 
-B<imgexport Default_Stateless_1265981465 foo.tgz -e /install/postscripts/myscript1  -e /tmp/mydir:/usr/mydir>
+ imgexport Default_Stateless_1265981465 foo.tgz -e /install/postscripts/myscript1 -e /tmp/mydir:/usr/mydir
 
 In addition to all the default files, this will export I</install/postscripts/myscript1> and the whole directory I</tmp/dir> into the file called foo.tgz.  And when imgimport is called  I</install/postscripts/myscript1> will be copied into the same directory and I</tmp/mydir> will be copied to I</usr/mydir>. 
 
 3. To include postscript with your image:
 
-B<imgexport Default_Stateless_1265981465 foo.tgz -p node1 -e /install/postscripts/myscript1>
+ imgexport Default_Stateless_1265981465 foo.tgz -p node1 -e /install/postscripts/myscript1
 
 The I<postscripts> and the I<postbootscripts> names specified in the I<postscripts> table for node1 will be exported into the image. The postscript I<myscript1> will also be exported.
 

--- a/xCAT-client/pods/man1/imgimport.1.pod
+++ b/xCAT-client/pods/man1/imgimport.1.pod
@@ -6,7 +6,7 @@ B<imgimport> - Imports an xCAT image or configuration file into the xCAT tables 
 
 B<imgimport [-h|--help]>
 
-B<imgimport> bundle_file_name [-p|--postscripts nodelist] [-f|--profile new_profile] [-v|--verbose]>
+B<imgimport> I<bundle_file_name> [B<-p>|B<--postscripts> I<nodelist>] [B<-f>|B<--profile> I<new_profile>] [B<-v>|B<--verbose>]
 
 =head1 DESCRIPTION
 
@@ -86,21 +86,21 @@ B<-v|--verbose>                  Verbose output.
 
 =head1 EXAMPLES
 
-1. Simplest way to import an image.  If there is a bundle file named 'foo.gz', then run:
+1. Simplest way to import an image. If there is a bundle file named 'foo.gz', then run:
 
-I<imgimport foo.gz>
+ imgimport foo.gz
 
 
 2. Import the image with postscript names. 
 
-I<imgimport foo.gz -p node1,node2>
+ imgimport foo.gz -p node1,node2
 
 The I<postscripts> table will be updated with the name of the I<postscripts> and the I<postbootscripts> for node1 and node2.
 
 
 3. Import the image with a new profile name 
 
-I<imgimport foo.gz -f compute_test>
+ imgimport foo.gz -f compute_test
 
 
 =head1 FILES

--- a/xCAT-client/pods/man1/liteimg.1.pod
+++ b/xCAT-client/pods/man1/liteimg.1.pod
@@ -4,11 +4,11 @@ B<liteimg> - Modify statelite image by creating a series of links.
 
 =head1 SYNOPSIS
 
-I<liteimg [-h| --help]>
+B<liteimg [-h| --help]>
 
-I<liteimg  [-v| --version]>
+B<liteimg  [-v| --version]>
 
-I<liteimg imagename>
+B<liteimg> I<imagename>
 
 =head1 DESCRIPTION
 
@@ -39,7 +39,7 @@ I<$imgroot/.default/etc/ntp.conf>
 
 Note: If you make any changes to your litefile table after running liteimg then you will need to rerun liteimg again.
 
-=head1 Parameters
+=head1 PARAMETERS
 
 I<imagename> specifies the name of a os image definition to be used. The specification for the image is storted in the I<osimage> table and I<linuximage> table.
 
@@ -47,9 +47,9 @@ I<imagename> specifies the name of a os image definition to be used. The specifi
 =head1 OPTIONS
 
 
-B<-h>          Display usage message.
+B<-h|--help>          Display usage message.
 
-B<-v>          Command Version.
+B<-v|--version>          Command Version.
 
 =head1 RETURN VALUE
 
@@ -61,12 +61,12 @@ B<-v>          Command Version.
 
 1. To lite a RHEL 6.6 statelite image for a compute node architecture x86_64 enter:
 
-I<liteimg rhels6.6-x86_64-statelite-compute>
+ liteimg rhels6.6-x86_64-statelite-compute
 
 
 =head1 FILES
 
-/opt/xcat/bin/
+/opt/xcat/bin/liteimg
 
 
 =head1 NOTES

--- a/xCAT-client/pods/man1/lsdocker.1.pod
+++ b/xCAT-client/pods/man1/lsdocker.1.pod
@@ -31,18 +31,22 @@ To return the logs of docker instance. Only works for docker instance.
 
 =over 3
 
-=item *
-
+=item 1.
 To get info for docker instance "host01c01"
 
  lsdocker host01c01
+
+Output is similar to:
+
  host01c01: 50800dfd8b5f	ubuntu	/bin/bash	2016-01-13T06:32:59	running	/host01c01
 
-=item *
-
+=item 2.
 To get info for running docker instance on dockerhost "host01"
 
  lsdocker host01
+
+Output is similar to:
+
  host01: 50800dfd8b5f	ubuntu	/bin/bash	2016-1-13 - 1:32:59	Up 12 minutes	/host01c01
  host01: 875ce11d5987	ubuntu	/bin/bash	2016-1-21 - 1:12:37	Up 5 seconds	/host01c02
 

--- a/xCAT-client/pods/man1/lsflexnode.1.pod
+++ b/xCAT-client/pods/man1/lsflexnode.1.pod
@@ -5,9 +5,9 @@ B<lsflexnode> - Display the information of flexible node
 
 =head1 SYNOPSIS
 
-B<lsflexnode> [-h | --help]
+B<lsflexnode> [B<-h> | B<--help>]
 
-B<lsflexnode> [-v | --version]
+B<lsflexnode> [B<-v> | B<--version>]
 
 B<lsflexnode> I<noderange> 
 
@@ -130,7 +130,6 @@ The identifier of the partition this node belongs to.
 =over 3
 
 =item 1
-
 Display all the B<Complex>, B<Partition> and B<Blade slot node> which managed by a AMM.
 
  lsflexnode amm1
@@ -159,7 +158,6 @@ The output:
     amm1: ......Node role - unassigned
 
 =item 2
-
 Display a flexible node.
 
  lsflexnode blade1

--- a/xCAT-client/pods/man1/lskit.1.pod
+++ b/xCAT-client/pods/man1/lskit.1.pod
@@ -5,13 +5,7 @@ B<lskit> - Lists information for one or more Kits.
 
 =head1 SYNOPSIS
 
-B<lskit> [B<-V> | B<--verbose>] 
-      [B<-F> | B<--framework> I<kitattr_names>]
-      [B<-x> | B<--xml> | B<--XML>]
-      [B<-K> | B<--kitattr> I<kitattr_names>]
-      [B<-R> | B<--repoattr> I<repoattr_names>]
-      [B<-C> | B<--compattr> I<compattr_names>]
-      [kit_names]
+B<lskit> [B<-V> | B<--verbose>] [B<-F> | B<--framework> I<kitattr_names>] [B<-x> | B<--xml> | B<--XML>] [B<-K> | B<--kitattr> I<kitattr_names>] [B<-R> | B<--repoattr> I<repoattr_names>] [B<-C> | B<--compattr> I<compattr_names>] [I<kit_names>]
 
 B<lskit> [B<-?> | B<-h> | B<--help> | B<-v> | B<--version>]
 
@@ -60,6 +54,7 @@ is a comma-delimited list of kit names. The B<lskit> command will only display t
 
 Need XCATXMLTRACE=1 env when using -x|--xml|--XML, for example: XCATXMLTRACE=1  lskit -x testkit-1.0.0
 Return the output with XML tags.  The data is returned as:
+
   <data>
     <kitinfo>
        ...
@@ -73,11 +68,13 @@ Return the output with XML tags.  The data is returned as:
   </data>
 
 Each <kitinfo> tag contains info for one kit.  The info inside <kitinfo> is structured as follows:
+
   The <kit> sub-tag contains the kit's basic info.
   The <kitrepo> sub-tags store info about the kit's repositories.
   The <kitcomponent> sub-tags store info about the kit's components.
 
 The data inside <kitinfo> is returned as:
+
   <kitinfo>
      <kit>
        ...
@@ -114,11 +111,9 @@ Display usage message.
 =over 3
 
 =item 0
-
 The command completed successfully.
 
 =item 1
-
 An error has occurred.
 
 =back
@@ -129,28 +124,26 @@ An error has occurred.
 =over 3
 
 =item 1.
-
 To list all kits, enter:
 
   lskit
 
 =item 2.
-
 To list the kit "kit-test1-1.0-Linux", enter:
 
   lskit kit-test1-1.0-Linux
 
 =item 3.
-
 To list the kit "kit-test1-1.0-Linux" for selected attributes, enter:
 
   lskit -K basename,description -R kitreponame -C kitcompname kit-test1-1.0-Linux
 
 =item 4.
-
 To list the framework value of a Kit tarfile.
 
   lskit -F /myhome/mykits/pperte-1.3.0.2-0-x86_64.tar.bz2
+
+Output is similar to:
 
   Extracting the kit.conf file from /myhome/mykits/pperte-1.3.0.2-0-x86_64.tar.bz2. Please wait.
   
@@ -158,7 +151,6 @@ To list the framework value of a Kit tarfile.
         compatible_kitframeworks=0,1,2
 
 =item 5.
-
 To list kit "testkit-1.0-1" with XML tags, enter:
 
   XCATXMLTRACE=1 lskit -x testkit-1.0-1

--- a/xCAT-client/pods/man1/lskitcomp.1.pod
+++ b/xCAT-client/pods/man1/lskitcomp.1.pod
@@ -5,12 +5,7 @@ B<lskitcomp> - Used to list information for one or more kit components.
 
 =head1 SYNOPSIS
 
-B<lskitcomp> [B<-V> | B<--verbose>] 
-      [B<-x> | B<--xml> | B<--XML>]
-      [B<-C> | B<--compattr> I<compattr_names>]
-      [B<-O> | B<--osdistro> I<os_distro>]
-      [B<-S> | B<--serverrole> I<server_role>]
-      [kitcomp_names]
+B<lskitcomp> [B<-V> | B<--verbose>] [B<-x> | B<--xml> | B<--XML>] [B<-C> | B<--compattr> I<compattr_names>] [B<-O> | B<--osdistro> I<os_distro>] [B<-S> | B<--serverrole> I<server_role>] [I<kitcomp_names>]
 
 B<lskitcomp> [B<-?> | B<-h> | B<--help> | B<-v> | B<--version>]
 
@@ -49,6 +44,7 @@ is a comma-delimited list of kit component names. The B<lskitcomp> command will 
 
 Need XCATXMLTRACE=1 env when using -x|--xml|--XML.
 Return the output with XML tags.  The data is returned as:
+
   <data>
     <kitinfo>
        ...
@@ -62,10 +58,12 @@ Return the output with XML tags.  The data is returned as:
   </data>
 
 Each <kitinfo> tag contains info for a group of kit compoonents belonging to the same kit. The info inside <kitinfo> is structured as follows:
+
   The <kit> sub-tag contains the kit's name.
   The <kitcomponent> sub-tags store info about the kit's components.
 
 The data inside <kitinfo> is returned as:
+
   <kitinfo>
      <kit>
        ...
@@ -97,11 +95,9 @@ Display usage message.
 =over 3
 
 =item 0
-
 The command completed successfully.
 
 =item 1
-
 An error has occurred.
 
 =back

--- a/xCAT-client/pods/man1/lskitdeployparam.1.pod
+++ b/xCAT-client/pods/man1/lskitdeployparam.1.pod
@@ -5,10 +5,7 @@ B<lskitdeployparam> - Lists the deployment parameters for one or more Kits or Ki
 
 =head1 SYNOPSIS
 
-B<lskitdeployparam> [B<-V> | B<--verbose>] 
-      [B<-x> | B<--xml> | B<--XML>]
-      [B<-k> | B<--kitname> I<kit_names>]
-      [B<-c> | B<--compname> I<comp_names>]
+B<lskitdeployparam> [B<-V> | B<--verbose>] [B<-x> | B<--xml> | B<--XML>] [B<-k> | B<--kitname> I<kit_names>] [B<-c> | B<--compname> I<comp_names>]
 
 B<lskitdeployparam> [B<-?> | B<-h> | B<--help> | B<-v> | B<--version>]
 
@@ -38,6 +35,7 @@ Where I<comp_names> is a comma-delimited list of kit component names. The B<lski
 =item B<-x|--xml|--XML>
 
 Return the output with XML tags.  The data is returned as:
+
   <data>
     <kitdeployparam>
       <name>KIT_KIT1_PARAM1</name>
@@ -72,11 +70,9 @@ Display usage message.
 =over 3
 
 =item 0
-
 The command completed successfully.
 
 =item 1
-
 An error has occurred.
 
 =back

--- a/xCAT-client/pods/man1/lskmodules.1.pod
+++ b/xCAT-client/pods/man1/lskmodules.1.pod
@@ -5,12 +5,7 @@ B<lskmodules> - list kernel driver modules in rpms or driver disk image files
 
 =head1 SYNOPSIS
 
-B<lskmodules> [B<-V> | B<--verbose>] 
-      [B<-i> | B<--osimage> I<osimage_names>]
-      [B<-c> | B<--kitcomponent> I<kitcomp_names>]
-      [B<-o> | B<--osdistro> I<osdistro_names>]
-      [B<-u> | B<--osdistropudate> I<osdistroupdate_names>]
-      [B<-x> | B<--xml> | B<--XML>]
+B<lskmodules> [B<-V> | B<--verbose>] [B<-i> | B<--osimage> I<osimage_names>] [B<-c> | B<--kitcomponent> I<kitcomp_names>] [B<-o> | B<--osdistro> I<osdistro_names>] [B<-u> | B<--osdistropudate> I<osdistroupdate_names>] [B<-x> | B<--xml> | B<--XML>]
 
 B<lskmodules> [B<-?> | B<-h> | B<--help> | B<-v> | B<--version>]
 
@@ -49,10 +44,12 @@ where I<osdistroupdate_names> is a comma-delimited list of xCAT database osdistr
 =item B<-x|--xml|--XML>
 
 Return the output with XML tags.  The data is returned as:
+
   <module>
     <name> xxx.ko </name>
     <description> this is module xxx </description>
   </module>
+
 This option is intended for use by other programs.  The XML will not be displayed.  To view the returned XML, set the XCATSHOWXML=yes environment variable before running this command.
 
 =item B<-V|--verbose>
@@ -75,11 +72,9 @@ Display usage message.
 =over 3
 
 =item 0
-
 The command completed successfully.
 
 =item 1
-
 An error has occurred.
 
 =back
@@ -91,8 +86,7 @@ An error has occurred.
 
 =item 1.
 
-To list the kernel modules included in the driverpacks shipped with kitcomponent kit1_comp1-x86_64,
-enter:
+To list the kernel modules included in the driverpacks shipped with kitcomponent kit1_comp1-x86_64, enter:
 
   lskmodules -c kit1_comp1-x86_64
 

--- a/xCAT-client/pods/man1/lslite.1.pod
+++ b/xCAT-client/pods/man1/lslite.1.pod
@@ -4,9 +4,9 @@ B<lslite> - Display a summary of the statelite information.
 
 =head1 SYNOPSIS
 
-B<lslite> [-h | --help]
+B<lslite> [B<-h> | B<--help>]
 
-B<lslite> [-V | --verbose] [-i imagename] | [noderange]
+B<lslite> [B<-V> | B<--verbose>] [B<-i> I<imagename>] | [I<noderange>]
 
 =head1 DESCRIPTION
 
@@ -24,11 +24,11 @@ Display usage message.
 
 Verbose mode.
 
-=item B<-i imagename>
+=item B<-i> I<imagename>
 
 The name of an existing xCAT osimage definition.
 
-=item B<noderange>
+=item I<noderange>
 
 A set of comma delimited node names and/or group names. See the "noderange" man page for details on additional supported formats.
 
@@ -48,24 +48,24 @@ A set of comma delimited node names and/or group names. See the "noderange" man 
 
 To list the statelite information for an xCAT node named "node01".
 
-B<lslite node01>
+ lslite node01
 
 Output is similar to:
 
->>>Node: node01
+ >>>Node: node01
 
-Osimage: 61img
+ Osimage: 61img
 
-Persistent directory (statelite table):
+ Persistent directory (statelite table):
         xcatmn1:/statelite
 
-Litefiles (litefile table):
+ Litefiles (litefile table):
         tmpfs,rw      /etc/adjtime
         tmpfs,rw      /etc/lvm/.cache
         tmpfs,rw      /etc/mtab
         ........
 
-Litetree path (litetree table):
+ Litetree path (litetree table):
         1,MN:/etc
         2,server1:/etc
 
@@ -73,7 +73,7 @@ Litetree path (litetree table):
 
 To list the statelite information for an xCAT osimage named "osimage01".
 
-B<lslite -i osimage01>
+ lslite -i osimage01
 
 Output is similar to:
 

--- a/xCAT-client/pods/man1/lsslp.1.pod
+++ b/xCAT-client/pods/man1/lsslp.1.pod
@@ -4,12 +4,11 @@ B<lsslp> - Discovers selected networked services information within the same sub
 
 =head1 SYNOPSIS
 
-I<lsslp [-h| --help]>
+B<lsslp [-h| --help]>
 
-I<lsslp [-v| --version]>
+B<lsslp [-v| --version]>
 
-
-I<lsslp [noderange] [-V] [-i ip[,ip..]][-w][-r|-x|-z][-n][-s CEC|FRAME|MM|IVM|RSA|HMC|CMM|IMM2|FSP][-t tries][-I][-C counts][-T timeout][--vpdtable]>
+B<lsslp> [I<noderange>] [B<-V>] [B<-i> I<ip[,ip..]>] B<[-w] [-r|-x|-z] [-n] [-s CEC|FRAME|MM|IVM|RSA|HMC|CMM|IMM2|FSP]> [B<-t> I<tries>] [B<-I>] [B<-C> I<counts>] [B<-T> I<timeout>] [B<--vpdtable>]
 
 
 =head1 DESCRIPTION
@@ -20,15 +19,7 @@ NOTE: SLP broadcast requests will propagate only within the subnet of the networ
 
 =head1 OPTIONS
 
-B<noderange>   The nodes which the user want to discover.
-            If the user specify the noderange, lsslp will just return the nodes in 
-            the node range. Which means it will help to add the new nodes to the xCAT
-            database without modifying the existed definitions. But the nodes' name 
-            specified in noderange should be defined in database in advance. The specified
-            nodes' type can be frame/cec/hmc/fsp/bpa. If the it is frame or cec, lsslp
-            will list the bpa or fsp nodes within the nodes(bap for frame, fsp for cec).
-            Please do not use noderange with the flag -s.
-
+B<noderange>   The nodes which the user want to discover.  If the user specify the noderange, lsslp will just return the nodes in the node range. Which means it will help to add the new nodes to the xCAT database without modifying the existed definitions. But the nodes' name specified in noderange should be defined in database in advance. The specified nodes' type can be frame/cec/hmc/fsp/bpa. If the it is frame or cec, lsslp will list the bpa or fsp nodes within the nodes(bap for frame, fsp for cec).  Please do not use noderange with the flag -s.
 
 B<-i>          IP(s) the command will send out (defaults to all available adapters).
 
@@ -36,21 +27,14 @@ B<-h>          Display usage message.
 
 B<-n>          Only display and write the newly discovered hardwares.
 
-B<-u>          Do unicast to a specified IP range. Must be used with -s and --range.
-            The -u flag is not supported on AIX.
+B<-u>          Do unicast to a specified IP range. Must be used with B<-s> and B<--range>. The B<-u> flag is not supported on AIX.
 
-B<--range>     Specify one or more IP ranges. Must be use in unicast mode. 
-            It accepts multiple formats. For example, 192.168.1.1/24, 40-41.1-2.3-4.1-100.
-            If the range is huge, for example, 192.168.1.1/8, lsslp may take a very long time for node scan.
-            So the range should be exactly specified. 
+B<--range>     Specify one or more IP ranges. Must be use in unicast mode. It accepts multiple formats. For example, 192.168.1.1/24, 40-41.1-2.3-4.1-100. If the range is huge, for example, 192.168.1.1/8, lsslp may take a very long time for node scan. So the range should be exactly specified. 
 
 B<-r>          Display Raw SLP response.
 
-B<-C>          The number of the expected responses specified by the user. 
-            When using this flag, lsslp will not return until the it has found all the nodes or time out.
-            The default max time is 3 secondes. The user can use -T flag the specify the time they want to use.
-            A short time will limite the time costing, while a long time will help to find all the nodes.
-
+B<-C>          The number of the expected responses specified by the user.  When using this flag, lsslp will not return until the it has found all the nodes or time out.  The default max time is 3 secondes. The user can use -T flag the specify the time they want to use.  A short time will limite the time costing, while a long time will help to find all the nodes.
+  
 B<-T>          The number in seconds to limite the time costing of lsslp.             
 
 
@@ -70,8 +54,7 @@ B<-x>          XML format.
 
 B<-z>          Stanza formated output.
 
-B<-I>          Give the warning message for the nodes in database which have no SLP responses.
-            Please note that this flag noly can be used after the database migration finished successfully.
+B<-I>          Give the warning message for the nodes in database which have no SLP responses. Please note that this flag noly can be used after the database migration finished successfully.
 
 
 =head1 RETURN VALUE
@@ -129,7 +112,7 @@ Output is similar to:
 
 Output is similar to:
 
-c76v1hmc02:
+ c76v1hmc02:
         objtype=node
         hcp=c76v1hmc02
         nodetype=hmc
@@ -140,7 +123,7 @@ c76v1hmc02:
         mgt=hmc
         mac=00:1a:64:fb:7d:50        
         hidden=0
-192.168.200.244:
+ 192.168.200.244:
         objtype=node
         hcp=192.168.200.244
         nodetype=fsp
@@ -154,7 +137,7 @@ c76v1hmc02:
         parent=Server-9125-F2A-SN0262662
         mac=00:1a:64:fa:01:fe
         hidden=1
-Server-8205-E6B-SN1074CDP:
+ Server-8205-E6B-SN1074CDP:
         objtype=node
         hcp=Server-8205-E6B-SN1074CDP
         nodetype=cec
@@ -164,7 +147,7 @@ Server-8205-E6B-SN1074CDP:
         mgt=fsp
         id=0
         hidden=0
-192.168.200.33:
+ 192.168.200.33:
         objtype=node
         hcp=192.168.200.33
         nodetype=bpa
@@ -177,7 +160,7 @@ Server-8205-E6B-SN1074CDP:
         id=0
         mac=00:09:6b:ad:19:90
         hidden=1
-Server-9125-F2A-SN0262652:
+ Server-9125-F2A-SN0262652:
         objtype=node
         hcp=Server-9125-F2A-SN0262652
         nodetype=frame
@@ -225,10 +208,10 @@ Output is similar to:
 
  lsslp -s CEC 
  
-device  type-model  serial-number  side  ip-addresses  hostname
-FSP     9117-MMB    105EBEP        A-1   20.0.0.138    20.0.0.138
-FSP     9117-MMB    105EBEP        B-1   20.0.0.139    20.0.0.139
-CEC     9117-MMB    105EBEP                            Server-9117-MMB-SN105EBEP
+ device  type-model  serial-number  side  ip-addresses  hostname
+ FSP     9117-MMB    105EBEP        A-1   20.0.0.138    20.0.0.138
+ FSP     9117-MMB    105EBEP        B-1   20.0.0.139    20.0.0.139
+ CEC     9117-MMB    105EBEP                            Server-9117-MMB-SN105EBEP
 
  
 7. To list all the nodes defined in database which have no SLP response.
@@ -237,11 +220,11 @@ CEC     9117-MMB    105EBEP                            Server-9117-MMB-SN105EBEP
 
 Output is similar to:
 
-These nodes defined in database but can't be discovered: f17c00bpcb_b,f17c01bpcb_a,f17c01bpcb_b,f17c02bpcb_a,
+ These nodes defined in database but can't be discovered: f17c00bpcb_b,f17c01bpcb_a,f17c01bpcb_b,f17c02bpcb_a,
 
-device  type-model  serial-number  side  ip-addresses  hostname
-bpa     9458-100    BPCF017        A-0   40.17.0.1     f17c00bpca_a
-bpa     9458-100    BPCF017        B-0   40.17.0.2     f17c00bpcb_a
+ device  type-model  serial-number  side  ip-addresses  hostname
+ bpa     9458-100    BPCF017        A-0   40.17.0.1     f17c00bpca_a
+ bpa     9458-100    BPCF017        B-0   40.17.0.2     f17c00bpcb_a
 
 
 8. To find the nodes within the user specified. Please make sure the noderange input have been defined in xCAT database.
@@ -270,7 +253,7 @@ or lsslp CEC1,CEC2,CEC3
 9. To list all discovered CMM in stanza format, enter:
    lsslp -s CMM -m -z 
 
-e114ngmm1:
+ e114ngmm1:
         objtype=node
         mpa=e114ngmm1
         nodetype=cmm
@@ -283,6 +266,7 @@ e114ngmm1:
         hwtype=cmm
 
 10. To use lsslp unicast, enter:
+
     lsslp -u -s CEC --range 40-41.1-2.1-2.1-2
 
 =head1 FILES

--- a/xCAT-client/pods/man1/lstree.1.pod
+++ b/xCAT-client/pods/man1/lstree.1.pod
@@ -4,9 +4,9 @@ B<lstree> - Display the tree of service node hierarchy, hardware hierarchy, or V
 
 =head1 SYNOPSIS
 
-B<lstree> [-h | --help]
+B<lstree> [B<-h> | B<--help>]
 
-B<lstree> [-s | --servicenode] [-H | --hardwaremgmt] [-v | --virtualmachine] [noderange]
+B<lstree> [B<-s> | B<--servicenode>] [B<-H> | B<--hardwaremgmt>] [B<-v> | B<--virtualmachine>] [I<noderange>]
 
 =head1 DESCRIPTION
 
@@ -32,7 +32,7 @@ Show the tree of hardware hierarchy.
 
 Show the tree of VM hierarchy.
 
-=item B<noderange>
+=item I<noderange>
 
 A set of comma delimited node names and/or group names. See the "noderange" man page for details on additional supported formats.
 
@@ -49,19 +49,18 @@ A set of comma delimited node names and/or group names. See the "noderange" man 
 =over 3
 
 =item 1.
-
 To display the tree of service node hierarchy for all the nodes.
 
-B<lstree -s>
+ lstree -s
 
 Output is similar to:
 
-Service Node: mysn01
+ Service Node: mysn01
  |__mycn01
  |__mycn02
  |__mycn03
 
-Service Node: mysn02
+ Service Node: mysn02
  |__mycn11
  |__mycn12
  |__mycn13
@@ -71,11 +70,11 @@ Service Node: mysn02
 
 To display the tree of service node hierarchy for service node "mysn01".
 
-B<lstree -s mysn01>
+ lstree -s mysn01
 
 Output is similar to:
 
-Service Node: mysn01
+ Service Node: mysn01
  |__mycn01
  |__mycn02
  |__mycn03
@@ -84,82 +83,78 @@ Service Node: mysn01
 
 To display the tree of hardware hierarchy for all the nodes.
 
-B<lstree -H>
+ lstree -H
 
 Output is similar to:
 
-HMC: myhmc01
+ HMC: myhmc01
  |__Frame: myframe01
     |__CEC: mycec01
     |__CEC: mycec02
     ......
 
-Service Focal Point: myhmc02
+ Service Focal Point: myhmc02
  |__Frame: myframe01
     |__CEC: mycec01
     |__CEC: mycec02
     |__CEC: mycec03
     ......
 
-Management Module: mymm01
+ Management Module: mymm01
  |__Blade 1: js22n01
  |__Blade 2: js22n02
  |__Blade 3: js22n03
  ......
 
-BMC: 192.168.0.1
+ BMC: 192.168.0.1
  |__Server: x3650n01
 
 =item 4.
-
 To display the tree of hardware hierarchy for HMC "myhmc01".
 
-B<lstree -H myhmc01>
+ lstree -H myhmc01
 
 Output is similar to:
 
-HMC: myhmc01
+ HMC: myhmc01
  |__Frame: myframe01
     |__CEC: mycec01
     |__CEC: mycec02
     ......
 
 =item 5.
-
 To display the tree of VM hierarchy for all the nodes.
 
-B<lstree -v>
+ lstree -v
 
 Output is similar to:
 
-Server: hs22n01
+ Server: hs22n01
  |__ hs22vm1
 
-Server: x3650n01
+ Server: x3650n01
  |__ x3650n01kvm1
  |__ x3650n01kvm2
 
 =item 6.
-
 To display the tree of VM hierarchy for the node "x3650n01".
 
-B<lstree -v x3650n01>
+ lstree -v x3650n01
 
 Output is similar to:
 
-Server: x3650n01
+ Server: x3650n01
  |__ x3650n01kvm1
  |__ x3650n01kvm2
 
 =item 7.
-
 To display both the hardware tree and VM tree for all nodes.
 
-B<lstree>
+ lstree
 
 Output is similar to:
 
-HMC: myhmc01
+ HMC: myhmc01
  |__Frame: myframe01
     |__CEC: mycec01
        |__LPAR 1: node01
@@ -172,7 +167,7 @@ HMC: myhmc01
        |__LPAR 3: node13
        ......
 
-Service Focal Point: myhmc02
+ Service Focal Point: myhmc02
  |__Frame: myframe01
     |__CEC: mycec01
        |__LPAR 1: node01
@@ -186,7 +181,7 @@ Service Focal Point: myhmc02
        |__LPAR 3: node23
        ......
 
-Management Module: mymm01
+ Management Module: mymm01
  |__Blade 1: hs22n01
     |__hs22n01vm1
     |__hs22n01vm2
@@ -195,7 +190,7 @@ Management Module: mymm01
     |__hs22n02vm2
  ......
 
-BMC: 192.168.0.1
+ BMC: 192.168.0.1
  |__Server: x3650n01
     |__ x3650n01kvm1
     |__ x3650n01kvm2

--- a/xCAT-client/pods/man1/lsve.1.pod
+++ b/xCAT-client/pods/man1/lsve.1.pod
@@ -4,17 +4,17 @@ B<lsve> - Lists detail attributes for a virtual environment.
 
 =head1 SYNOPSIS
 
-B<lsve> [B<-t> type] [B<-m> manager] [B<-o> object]
+B<lsve> [B<-t> I<type>] [B<-m> I<manager>] [B<-o> I<object>]
 
 =head1 DESCRIPTION
 
 The B<lsve> command can be used to list a virtual environment for 
 'Data Center', 'Cluster', 'Storage Domain', 'Network' and 'Template' objects.
 
-The mandatory parameter B<-m manager> is used to specify the address of the 
+The mandatory parameter B<-m> I<manager> is used to specify the address of the 
 manager of virtual environment. xCAT needs it to access the RHEV manager.
 
-The mandatory parameter B<-t type> is used to specify the type of the target 
+The mandatory parameter B<-t> I<type> is used to specify the type of the target 
 object.
 
 Basically, B<lsve> command supports three types of object: B<dc>, B<cl>, B<sd>, B<nw> 
@@ -65,7 +65,7 @@ Supported types:
 =item 1.
 To list the data center 'Default', enter:
 
- lsve -t B<dc> -m <FQDN of rhev manager> -o Default
+ lsve -t dc -m <FQDN of rhev manager> -o Default
 
 Output is similar to:
 
@@ -113,7 +113,7 @@ Output is similar to:
 =item 2.
 To list the cluster 'Default', enter:
 
- lsve -t B<cl> -m <FQDN of rhev manager> -o Default
+ lsve -t cl -m <FQDN of rhev manager> -o Default
 
 Output is similar to:
 
@@ -126,9 +126,10 @@ Output is similar to:
 =item 3.
 To list the Storage Domain 'image', enter:
 
- lsve -t B<sd> -m <FQDN of rhev manager> -o image
+ lsve -t sd -m <FQDN of rhev manager> -o image
 
 Output is similar to:
+
   storagedomains: [image]
     available: 55834574848
     committed: 13958643712
@@ -144,7 +145,7 @@ Output is similar to:
 =item 4.
 To list the network 'rhevm', enter:
 
- lsve -t B<nw> -m <FQDN of rhev manager> -o rhevm
+ lsve -t nw -m <FQDN of rhev manager> -o rhevm
 
 Output is similar to:
 

--- a/xCAT-client/pods/man1/lsvm.1.pod
+++ b/xCAT-client/pods/man1/lsvm.1.pod
@@ -101,7 +101,7 @@ Output is similar to:
 
  lsvm cec01
 
-g Output is similar to:
+Output is similar to:
 
  cec01: name=10-B7D1G,lpar_name=10-B7D1G,lpar_id=1,os_type=vioserver,all_resources=0,min_mem=512, desired_mem=2048,max_mem=2048,proc_mode=shared,min_proc_units=0.10,desired_proc_units=0.40, max_proc_units=4.00,min_procs=1,desired_procs=4,max_procs=4,sharing_mode=uncap,uncap_weight=128, "io_slots=21010002/none/0,21010003/none/0,21010004/none/0,21020003/none/0,21020004/none/0,21030003/none/0,21030004/none/0,21040003/none/0,21040004/none/0",lpar_io_pool_ids=none,max_virtual_slots=48, "virtual_serial_adapters=0/server/1/any//any/1,1/server/1/any//any/1,10/client/0/2/lp2/0/0,12/client/0/3/lp3/0/0,14/client/0/4/lp4/0/0","virtual_scsi_adapters=11/server/2/lp2/2/0,13/server/3/lp3/2/0,15/server/4/lp4/2/0","virtual_eth_adapters=3/0/1//1/0,4/0/2//1/0,5/0/3//1/0,6/0/4//1/0",boot_mode=norm,conn_monitoring=0,auto_start=0,power_ctrl_lpar_ids=none
    name=lp2,lpar_name=lp2,lpar_id=2,os_type=aixlinux,all_resources=0,min_mem=128,desired_mem=1024,max_mem=1024,proc_mode=shared,min_proc_units=0.10,desired_proc_units=0.10,max_proc_units=4.00,min_procs=1,desired_procs=1,max_procs=4,sharing_mode=uncap,uncap_weight=128,io_slots=none,lpar_io_pool_ids=none,max_virtual_slots=6, "virtual_serial_adapters=0/server/1/any//any/1,1/server/1/any//any/1",virtual_scsi_adapters=2/client/1/10-7D1G/11/1,virtual_eth_adapters=4/0/1//0/0,boot_mode=norm,conn_monitoring=0,auto_start=0,power_ctrl_lpar_ids=none
@@ -117,16 +117,17 @@ Output is similar to:
  1: 513/U78A9.001.0123456-P1-C15/0x21010201/2/1
  1: 512/U78A9.001.0123456-P1-C16/0x21010200/2/1
 
-To list the lparname of lpars, enter:
+4. To list the lparname of lpars, enter:
 
  lsvm lpar1 -l --p775
 
 Output is similar to:
+
  lpar1: 1: 514/U78A9.001.0123456-P1-C17/0x21010202/2/1
  lpar1: 1: 513/U78A9.001.0123456-P1-C15/0x21010201/2/1
  lpar1: 1: 512/U78A9.001.0123456-P1-C16/0x21010200/2/1
 
-4. For Power 775, to list the I/O slot information and octant configuration of cec1, enter:
+5. For Power 775, to list the I/O slot information and octant configuration of cec1, enter:
 
  lsvm cec1 --p775
 
@@ -159,7 +160,7 @@ Output is similar to:
  OctantID=6,PendingOctCfg=1,CurrentOctCfg=1,PendingMemoryInterleaveMode=2,CurrentMemoryInterleaveMode=2;
  OctantID=7,PendingOctCfg=1,CurrentOctCfg=1,PendingMemoryInterleaveMode=2,CurrentMemoryInterleaveMode=2;
 
-To list the lparname of lpars, enter:
+6.To list the lparname of lpars, enter:
 
  lsvm cec1 -l --p775
  
@@ -204,7 +205,7 @@ Output is similar to:
  Maximum huge page memory(in pages):       24
  Requested huge page memory(in pages):     15
 
-5. To list the virtual machine's directory entry:
+7. To list the virtual machine's directory entry:
 
  lsvm gpok3
 
@@ -214,7 +215,7 @@ Output is similar to:
  gpok3: INCLUDE LNXDFLT
  gpok3: COMMAND SET VSWITCH VSW2 GRANT LNX3
 
-6. For DFM-managed normal power machine, list out the detailed resource information:
+8. For DFM-managed normal power machine, list out the detailed resource information:
 
  lsvm cec 
 
@@ -245,7 +246,7 @@ Output is similar to:
 
 Note: The lines list in "All Physical I/O info" section represent all the physical I/O resource information. The format is like "owner_lparid,slot_id,physical resource name,drc_index,slot_class_code(class discription)". The 'drc index' is short for Dynamic Resource Configuration Index, it uniquely indicate a physical I/O resource in normal power machine. 
 
-For DFM-managed partition on normal power machine, list out the detailed information:
+9.For DFM-managed partition on normal power machine, list out the detailed information:
 
   lsvm lpar1 
  

--- a/xCAT-client/pods/man1/lsxcatd.1.pod
+++ b/xCAT-client/pods/man1/lsxcatd.1.pod
@@ -4,7 +4,7 @@ B<lsxcatd> - lists xCAT daemon information.
 
 =head1 SYNOPSIS
 
-B<lsxcatd> [B<-h> | B<--help> | B<-v> | B<--version> | B<-d> | B<--database> |B<-t> | B<--nodetype> | B<-a> | B<--all> ]
+B<lsxcatd> [B<-h> | B<--help> | B<-v> | B<--version> | B<-d> | B<--database> | B<-t> | B<--nodetype> | B<-a> | B<--all> ]
 
 =head1 DESCRIPTION
 
@@ -68,13 +68,13 @@ To display all information:
 
 Output is similar to: 
 
-Version 2.8.5 (git commit 0d4888af5a7a96ed521cb0e32e2c918a9d13d7cc, built Tue Jul 29 02:22:47 EDT 2014)
-This is a Management Node
-cfgloc=mysql:dbname=xcatdb;host=9.114.34.44|xcatadmin
-dbengine=mysql
-dbname=xcatdb
-dbhost=9.114.34.44
-dbadmin=xcatadmin
+ Version 2.8.5 (git commit 0d4888af5a7a96ed521cb0e32e2c918a9d13d7cc, built Tue Jul 29 02:22:47 EDT 2014)
+ This is a Management Node
+ cfgloc=mysql:dbname=xcatdb;host=9.114.34.44|xcatadmin
+ dbengine=mysql
+ dbname=xcatdb
+ dbhost=9.114.34.44
+ dbadmin=xcatadmin
 
 
 =back

--- a/xCAT-client/pods/man1/makentp.1.pod
+++ b/xCAT-client/pods/man1/makentp.1.pod
@@ -6,18 +6,17 @@ B<makentp> - Setup NTP server on the management node and the service node.
 
 =head1 SYNOPSIS
 
-I<makentp [-h|--help]>
+B<makentp [-h|--help]>
 
-I<makentp [-v|--version]>
+B<makentp [-v|--version]>
 
-
-I<makentp [-a|--all] [-V|--verbose]>
+B<makentp [-a|--all] [-V|--verbose]>
 
 
 
 =head1 DESCRIPTION
 
-I<makentp> command sets up the NTP server on the xCAT management node and the service node.
+B<makentp> command sets up the NTP server on the xCAT management node and the service node.
 
 By default, it sets up the NTP server for xCAT management node. If -a flag is specified, the command will setup the ntp servers for management node as well as all the service nodes that have I<servicenode.ntpserver> set. It honors the site table attributes I<extntpservers> and I<ntpservers> described below:
 
@@ -67,17 +66,15 @@ Verbose output.
 
 =over 3
 
-=item *
-
+=item 1.
 To setup NTP server on the management node:
 
-B<makentp>
+ makentp
 
-=item *
-
+=item 2.
 To setup NTP servers on both management node and the service node:
 
-B<setupntp> I<-a>
+ setupntp -a
 
 
 =back

--- a/xCAT-client/pods/man1/mkdef.1.pod
+++ b/xCAT-client/pods/man1/mkdef.1.pod
@@ -6,10 +6,7 @@ B<mkdef> - Use this command to create xCAT data object definitions.
 
 B<mkdef> [B<-h>|B<--help>] [B<-t> I<object-types>]
 
-B<mkdef> [B<-V>|B<--verbose>] [B<-t> I<object-types>] [B<-o> I<object-names>]
-[B<-z>|B<--stanza>] [B<-d>|B<--dynamic>] [B<-f>|B<--force>]
-[[B<-w> I<attr>==I<val>] [B<-w> I<attr>=~I<val>] ...] [I<noderange>] [I<attr>=I<val> [I<attr>=I<val...>]]
-      [B<-u> B<provmethod>=<I<install>|I<netboot>|I<statelite>> B<profile>=<xxx> [I<osvers>=I<value>] [I<osarch>=I<value>]]
+B<mkdef> [B<-V>|B<--verbose>] [B<-t> I<object-types>] [B<-o> I<object-names>] [B<-z>|B<--stanza>] [B<-d>|B<--dynamic>] [B<-f>|B<--force>] [[B<-w> I<attr>==I<val>] [B<-w> I<attr>=~I<val>] ...] [I<noderange>] [I<attr>=I<val> [I<attr>=I<val...>]] [B<-u> B<provmethod>={B<install> | B<netboot> | B<statelite>} B<profile=> I<xxx> [B<osvers=> I<value>] [B<osarch=> I<value>]]
 
 
 =head1 DESCRIPTION

--- a/xCAT-client/pods/man1/mkdocker.1.pod
+++ b/xCAT-client/pods/man1/mkdocker.1.pod
@@ -4,7 +4,7 @@ B<mkdocker> - Create docker instance.
 
 =head1 SYNOPSIS
 
-B<mkdocker> I<noderange> [B<image>=B<image_name> [B<command>=B<command>]] [B<dockerflag>=B<flags_to_create_instance>]
+B<mkdocker> I<noderange> [B<image>=I<image_name> [B<command>=I<command>]] [B<dockerflag>=I<flags_to_create_instance>]
 
 B<mkdocker> [B<-h>|B<--help>]
 
@@ -13,7 +13,7 @@ B<mkdocker> {B<-v>|B<--version>}
 
 =head1 DESCRIPTION
 
-B<rmdocker> To create docker instances with the specified image, command and/or dockerflags.
+B<mkdocker> To create docker instances with the specified image, command and/or dockerflags.
 
 =head1 OPTIONS
 
@@ -80,16 +80,25 @@ A list of volume bindings for this docker instance, the form will be:
 1. To create a basic docker instance with stdin opened
 
     mkdocker host01c01 image=ubuntu command=/bin/bash dockerflag="{\"AttachStdin\":true,\"AttachStdout\":true,\"AttachStderr\":true,\"OpenStdin\":true}"
+
+Output is similar to:
+
     host01c01: success
 
 2. To create a docker instance with network disabled
 
     mkdocker host01c01 image=ubuntu command=/bin/bash dockerflag="{\"AttachStdin\":true,\"AttachStdout\":true,\"AttachStderr\":true,\"OpenStdin\":true,\"NetworkDisabled\":ture}"
+
+Output is similar to:
+
     host01c01: success
 
 3. To create a docker instance which have dir "destdir" in docker instance bind from "srcdir" on dockerhost, and have "Tty" opened with which the docker instance can be attached after started to check the files under "destdir".
 
     mkdocker host01c01 image=ubuntu command=/bin/bash dockerflag="{\"AttachStdin\":true,\"AttachStdout\":true,\"AttachStderr\":true,\"OpenStdin\":true,\"Tty\":true,\"HostConfig\":{\"Binds\":[\"/srcdir:/destdir\"]}}"
+
+Output is similar to:
+
     host01c01: success
 
 =head1 SEE ALSO

--- a/xCAT-client/pods/man1/mkdsklsnode.1.pod
+++ b/xCAT-client/pods/man1/mkdsklsnode.1.pod
@@ -6,7 +6,7 @@ B<mkdsklsnode> - Use this xCAT command to define and initialize AIX/NIM diskless
 
 B<mkdsklsnode [-h|--help ]>
 
-B<mkdsklsnode [-V|--verbose] [-f|--force] [-n|--newname] [-i osimage_name] [-l location] [-u|--updateSN] [-k|--skipsync] [-p|--primarySN] [-b|--backupSN] [-S|--setuphanfs] noderange [attr=val [attr=val ...]]>
+B<mkdsklsnode [-V|--verbose] [-f|--force] [-n|--newname] [-i> I<osimage_name>] [B<-l> I<location>] [B<-u>|B<--updateSN>] [B<-k>|B<--skipsync>] [B<-p>|B<--primarySN>] [B<-b>|B<--backupSN>] [B<-S>|B<--setuphanfs>] I<noderange> [I<attr=val [attr=val ...]>]
 
 =head1 DESCRIPTION
 
@@ -52,7 +52,7 @@ You can supply your own scripts to be run on the management node  or on the serv
 
 =over 10
 
-=item B<attr=val [attr=val ...]>
+=item I<attr=val [attr=val ...]>
 
 Specifies one or more "attribute equals value" pairs, separated by spaces. Attr=
 val pairs must be specified last on the command line. These are used to specify additional values that can be passed to the underlying NIM commands.
@@ -106,7 +106,7 @@ Use the force option to reinitialize the NIM machines.
 
 Display usage message.
 
-=item B<-i image_name>
+=item B<-i> I<image_name>
 
 The name of an existing xCAT osimage definition. If this information is not provided on the command line the code checks the node definition for the value of the "provmethod" attribute. If the "-i" value is provided on the command line then that value will be used to set the "provmethod" attribute of the node definitions.
 
@@ -134,7 +134,7 @@ Setup NFSv4 replication between the primary service nodes and backup service nod
 
 Use this option if you wish to update the osimages but do not want to define or initialize the NIM client definitions. This option is only valid when the xCAT "site" definition attribute "sharedinstall" is set to either "sns" or "all".
 
-=item B<noderange>
+=item I<noderange>
 
 A set of comma delimited node names and/or group names. See the "noderange" man page for details on additional supported formats.
 
@@ -149,11 +149,9 @@ Verbose mode.
 =over 3
 
 =item 0
-
 The command completed successfully.
 
 =item 1
-
 An error has occurred.
 
 =back
@@ -162,29 +160,26 @@ An error has occurred.
 
 =over 3
 
-=item 1
-
+=item 1.
 Initialize an xCAT node named "node01" as an AIX diskless machine.  The xCAT osimage named "61spot" should be used to boot the node.
 
-B<mkdsklsnode -i 61spot node01>
+ mkdsklsnode -i 61spot node01
 
-=item 2
-
+=item 2.
 Initialize all AIX diskless nodes contained in the xCAT node group called "aixnodes" using the image definitions pointed to by the "provmethod" attribute of the xCAT node definitions.
 
-B<mkdsklsnode aixnodes>
+ mkdsklsnode aixnodes
 
-=item 3
-
+=item 3.
 Initialize diskless node "clstrn29" using the xCAT osimage called "61dskls".  Also set the paging size to be 128M and specify the paging file be an AIX sparse file.
 
-B<mkdsklsnode -i 61dskls clstrn29 psize=128 sparse_paging=yes>
+ mkdsklsnode -i 61dskls clstrn29 psize=128 sparse_paging=yes
 
-=item 4
+=item 4.
 
 Initialize an xCAT node called "node02" as an AIX diskless node.  Create a new NIM machine definition name with the osimage as an extension to the xCAT node name.
 
-B<mkdsklsnode -n -i 61spot node02>
+ mkdsklsnode -n -i 61spot node02
 
 =back
 

--- a/xCAT-client/pods/man1/mkflexnode.1.pod
+++ b/xCAT-client/pods/man1/mkflexnode.1.pod
@@ -5,9 +5,9 @@ B<mkflexnode> - Create a flexible node.
 
 =head1 SYNOPSIS
 
-B<mkflexnode> [-h | --help]
+B<mkflexnode> [B<-h> | B<--help>]
 
-B<mkflexnode> [-v | --version]
+B<mkflexnode> [B<-v> | B<--version>]
 
 B<mkflexnode> I<noderange>
 
@@ -43,8 +43,7 @@ Display the version information.
 
 =over 3
 
-=item 1
-
+=item 1.
 Create a flexible node base on the xCAT node blade1.
 
 The blade1 should belong to a complex, the I<id> attribute should be set correctly and all the slots should be in B<power off> state.

--- a/xCAT-client/pods/man1/mknimimage.1.pod
+++ b/xCAT-client/pods/man1/mknimimage.1.pod
@@ -6,9 +6,9 @@ B<mknimimage> - Use this xCAT command to create xCAT osimage definitions and rel
 
 B<mknimimage [-h | --help ]>
 
-B<mknimimage [-V] -u osimage_name [attr=val [attr=val ...]]>
+B<mknimimage [-V] -u> I<osimage_name [attr=val [attr=val ...]>]
 
-B<mknimimage [-V] [-f|--force] [-r|--sharedroot] [-D|--mkdumpres] [-l location] [-c|--completeosimage] [-s image_source] [-i current_image] [-p|--cplpp] [-t nimtype] [-m nimmethod] [-n mksysbnode] [-b mksysbfile] osimage_name [attr=val [attr=val ...]]>
+B<mknimimage [-V] [-f|--force] [-r|--sharedroot] [-D|--mkdumpres] [-l> I<location>] [B<-c>|B<--completeosimage>] [B<-s> I<image_source>] [B<-i> I<current_image>] [B<-p>|B<--cplpp>] [B<-t> I<nimtype>] [B<-m> I<nimmethod>] [B<-n> I<mksysbnode>] [B<-b> I<mksysbfile>] I<osimage_name> [I<attr=val [attr=val ...]>]
 
 =head1 DESCRIPTION
 
@@ -73,7 +73,7 @@ To remove specific NIM resource definitons use the AIX B<nim> command. ("nim -o 
 
 =over 10
 
-=item B<attr=val [attr=val ...]>
+=item I<attr=val [attr=val ...]>
 
 Specifies one or more "attribute equals value" pairs, separated by spaces. Attr=val pairs must be specified last on the command line. 
 
@@ -189,7 +189,7 @@ Value Specifies the security method required for NFS access.
 
 Note that you may specify multiple "script", "otherpkgs", and "installp_bundle" resources by using a comma seperated list. (ex. "script=ascript,bscript"). RPM names may be included in the "otherpkgs" list by using a "R:" prefix(ex. "R:whatever.rpm"). epkg (AIX interim fix package) file names may be included in the "otherpkgs" using the 'E:' prefix. (ex. "otherpkgs=E:IZ38930TL0.120304.epkg.Z").
 
-=item B<-b mksysbfile>
+=item B<-b> I<mksysbfile>
 
 Used to specify the path name of a mksysb file to use when defining a NIM mksysb resource.
 
@@ -205,7 +205,7 @@ Use the force option to re-create xCAT osimage definition. This option removes t
 
 Display usage message.
 
-=item B<osimage_name>
+=item I<osimage_name>
 
 The name of the xCAT osimage definition.  This will be used as the name of the xCAT osimage definition as well as the name of the NIM SPOT resource.
 
@@ -213,19 +213,19 @@ The name of the xCAT osimage definition.  This will be used as the name of the x
 
 Create a diskless dump resource.
 
-=item B<-i current_image>
+=item B<-i> I<current_image>
 
 The name of an existing xCAT osimage that should be copied to make a new xCAT osimage definition. Only valid when defining a "diskless" or "dataless" type image.
 
-=item B<-l location>
+=item B<-l> I<location>
 
 The directory location to use when creating new NIM resources. The default location is /install/nim.
 
-=item B<-m nimmethod>
+=item B<-m> I<nimmethod>
 
 Used to specify the NIM installation method to use. The possible values are "rte" and "mksysb". The default is "rte".
 
-=item B<-n mksysbnode>
+=item B<-n> I<mksysbnode>
 
 The xCAT node to use to create a mksysb image.  The node must be a defined as a NIM client machine.
 
@@ -237,7 +237,7 @@ Use this option when copying existing diskless osimages to indicate that you als
 
 Use this option to specify that a NIM "shared_root" resource be created for the AIX diskless nodes.  The default is to create a NIM "root" resource.  This feature is only available when using AIX version 6.1.4 or beyond. See the AIX/NIM documentation for a description of the "root" and "shared_root" resources.
 
-=item B<-s image_source>
+=item B<-s> I<image_source>
 
 The source of software to use when creating the new NIM lpp_source resource. This could be a source directory or a previously defined NIM lpp_source resource name. 
 
@@ -259,12 +259,10 @@ Verbose mode.
 
 =over 3
 
-=item 0
-
+=item 0.
 The command completed successfully.
 
-=item 1
-
+=item 1.
 An error has occurred.
 
 =back
@@ -273,73 +271,73 @@ An error has occurred.
 
 1) Create an osimage definition and the basic NIM resources needed to do a NIM "standalone" "rte" installation of node "node01".  Assume the software contained on the AIX product media has been copied to the /AIX/instimages directory.
 
-B<mknimimage -s /AIX/instimages  61image>
+ mknimimage -s /AIX/instimages  61image
 
 2) Create an osimage definition that includes some additional NIM resources.
 
-B<mknimimage -s /AIX/instimages 61image installp_bundle=mybndlres,addswbnd>
+ mknimimage -s /AIX/instimages 61image installp_bundle=mybndlres,addswbnd
 
 This command will create lpp_source, spot, and bosinst_data resources using the source specified by the "-s" option.  The installp_bundle information will also be included in the osimage definition.  The mybndlres and addswbnd resources must be created before using this osimage definition to install a node.
 
 3) Create an osimage definition that includes a mksysb image and related resources.
 
-B<mknimimage -m mksysb -n node27 newsysb spot=myspot bosinst_data=mybdata>
+ mknimimage -m mksysb -n node27 newsysb spot=myspot bosinst_data=mybdata
 
 This command will use node27 to create a mksysb backup image and use that to define a NIM mksysb resource. The osimage definition will contain the name of the mksysb resource as well as the spot and bosinst_data resource.
 
 4) Create an osimage definition using a mksysb image provided on the command line.
 
-B<mknimimage -m mksysb -b /tmp/backups/mysysbimage newsysb spot=myspot bosinst_data=mybdata>
+ mknimimage -m mksysb -b /tmp/backups/mysysbimage newsysb spot=myspot bosinst_data=mybdata
 
 This command defines a NIM mksysb resource using mysysbimage.
 
 5) Create an osimage definition and create the required spot definition using the mksysb backup file provided on the command line.
 
-B<mknimimage -m mksysb -b /tmp/backups/mysysbimage newsysb bosinst_data=mybdata>
+ mknimimage -m mksysb -b /tmp/backups/mysysbimage newsysb bosinst_data=mybdata
 
 This command defines a NIM mksysb resource and a spot definition using mysysbimage.
 
 6) Create a diskless image called 61dskls using the AIX source files provided in the /AIX/instimages directory.
 
-B<mknimimage -t diskless -s /AIX/instimages 61dskls>
+ mknimimage -t diskless -s /AIX/instimages 61dskls
 
 7) Create a diskless image called "614dskls" that includes a NIM "shared_root" and a "dump" resource.  Use the existing NIM lpp_resource called "614_lpp_source". Also specify verbose output.
 
-B<mknimimage -V -r -D -t diskless -s 614_lpp_source 614dskls snapcollect=yes>
+ mknimimage -V -r -D -t diskless -s 614_lpp_source 614dskls snapcollect=yes
 
 The "snapcollect" attribute specifies that AIX "snap" data should be include when a system dump is initiated.
 
 8) Create a new diskless image by copying an existing image.
 
-B<mknimimage -t diskless -i 61cosi 61cosi_updt1>
+ mknimimage -t diskless -i 61cosi 61cosi_updt1
 
 Note:  If you also wish to have the original lpp_source copied and defined use the -p option.
 
-B<mknimimage -t diskless -i 61cosi -p 61cosi_updt1>
+ mknimimage -t diskless -i 61cosi -p 61cosi_updt1
 
 9) Create a diskless image using an existing lpp_source resource named "61cosi_lpp_source" and include NIM tmp and home resources.  This assumes that the "mytmp" and "myhome" NIM resources have already been created by using NIM commands.
 
-B<mknimimage -t diskless -s 61cosi_lpp_source 611cosi tmp=mytmp home=myhome>
+ mknimimage -t diskless -s 61cosi_lpp_source 611cosi tmp=mytmp home=myhome
 
 10) Create a diskless image and update it with additional software using rpm flags and configuration files. 
 
-B<mknimimage -t diskless -s 61cosi_lpp_source 61dskls otherpkgs=I:fset1,R:foo.rpm,E:IZ38930TL0.120304.epkg.Z synclists=/install/mysyncfile rpm_flags="-i --nodeps">
+ mknimimage -t diskless -s 61cosi_lpp_source 61dskls otherpkgs=I:fset1,R:foo.rpm,E:IZ38930TL0.120304.epkg.Z synclists=/install/mysyncfile rpm_flags="-i --nodeps"
 
 The xCAT osimage definition created by this command will include the "otherpkgs" and "synclists" values.  The NIM SPOT resource associated with this osimage will be updated with the additional software using rpm flags "-i --nodeps" and configuration files.
 
 11) Update an existing diskless image (AIX/NIM SPOT) using the information saved in the xCAT "61dskls" osimage definition. Also specify verbose messages.  
 
-B<mknimimage -V -u 61dskls>
+ mknimimage -V -u 61dskls
 
 12) Update an existing diskless image called "61dskls".  Install the additional software specified in the NIM "bndres1" and "bndres2" installp_bundle resources using the installp flags "-agcQX".  (The NIM "bndres1" and "bndres2" definitions must be created before using them in this command.)
 
-B<mknimimage -u 61dskls installp_bundle=bndres1,bndres2 installp_flags="-agcQX">
+ mknimimage -u 61dskls installp_bundle=bndres1,bndres2 installp_flags="-agcQX"
 
 Note that when "installp_bundle", "otherpkgs", or "synclists" values are specified with the "-u" option then the xCAT osimage definiton is not used or updated.
 
 13) Update an existing image to support NFSv4. Also specify verbose messages.  
 
-B<mknimimage -V -u 61dskls nfs_vers=4>
+ mknimimage -V -u 61dskls nfs_vers=4
 
 =head1 FILES
 

--- a/xCAT-client/pods/man1/mkvm.1.pod
+++ b/xCAT-client/pods/man1/mkvm.1.pod
@@ -22,9 +22,7 @@ B<mkvm> [B<-V>| B<--verbose>] I<noderange> B<--full>
 
 B<mkvm> I<noderange> [B<--full>]
 
-B<mkvm> I<noderange> [B<vmcpus=min/req/max>] [B<vmmemory=min/req/max>]
-               [B<vmphyslots=drc_index1,drc_index2...>] [B<vmothersetting=hugepage:N,bsr:N>]
-               [B<vmnics=vlan1[,vlan2..]]> [B<vmstorage=<N|viosnode:slotid>>] [B<--vios>]
+B<mkvm> I<noderange> [B<vmcpus=> I<min/req/max>] [B<vmmemory=> I<min/req/max>] [B<vmphyslots=> I<drc_index1,drc_index2...>] [B<vmothersetting=> I<hugepage:N,bsr:N>] [B<vmnics=> I<vlan1[,vlan2..]>] [B<vmstorage=> I<N|viosnode:slotid>] [B<--vios>]
 
 =head2 For KVM:
 
@@ -90,7 +88,7 @@ The cpu count which will be created for the kvm/vmware virtual machine.
 
 Request to create a new full system partition for each CEC.
 
-=item B<vmcpus=value> B<vmmemory=value> B<vmphyslots=value> B<vmothersetting=value> B<vmnics=value> B<vmstorage=value> [B<--vios>]
+=item B<vmcpus=> I<value> B<vmmemory=> I<value> B<vmphyslots=> I<value> B<vmothersetting=> I<value> B<vmnics=> I<value> B<vmstorage=> I<value> [B<--vios>]
 
 To specify the parameters which are used to create a partition. The I<vmcpus>, I<vmmemory> are necessay, and the value specified with this command have a more high priority. If the value of any of the three options is not specified, the corresponding value specified for the node object will be used. If any of the three attributes is neither specified with this command nor specified with the node object, error information will be returned. To reference to L<lsvm(1)|lsvm.1> for more information about 'drc_index' for I<vmphyslots>.  
 

--- a/xCAT-client/pods/man1/mkzone.1.pod
+++ b/xCAT-client/pods/man1/mkzone.1.pod
@@ -4,7 +4,7 @@ B<mkzone> - Defines a new zone in the cluster.
 
 =head1 B<SYNOPSIS>
 
-B<mkzone> <zonename>  [B<--defaultzone>] [B<-k> I<full path to the ssh RSA private key>] [B<-a> I<noderange>] [B<-g>] [B<-f>] [B<-s> I<yes|no>] [-V] 
+B<mkzone> I<zonename>  [B<--defaultzone>] [B<-k> I<full path to the ssh RSA private key>] [B<-a> I<noderange>] [B<-g>] [B<-f>] [B<-s> I<{yes|no}>] [B<-V>] 
 
 B<mkzone> [B<-h> | B<-v>]
 
@@ -65,54 +65,50 @@ Verbose mode.
 
 =back
 
-=head1 B<Examples>
+=head1 B<EXAMPLES>
 
 =over 3
 
-=item *
+=item 1.
+To make a new zone1 using defaults, enter:
 
-To make a new zone1 using defaults , enter:
+ mkzone zone1
 
-B<mkzone> I<zone1>
+Note: with the first B<mkzone>, you will automatically get the xcatdefault zone created as the default zone.  This zone uses ssh keys from <roothome>/.ssh directory.  
 
-Note: with the first mkzone, you will automatically get the xcatdefault zone created as the default zone.  This zone uses ssh keys from
-      <roothome>/.ssh directory.  
-
-=item *
-
+=item 2.
 To make a new zone2 using defaults and make it the default zone enter:
 
-B<mkzone> I<zone2> --defaultzone -f
+ mkzone> zone2 --defaultzone -f
 
-=item *
+=item 3.
 
 To make a new zone2A using the ssh id_rsa private key in /root/.ssh:
 
-B<mkzone> I<zone2A> -k /root/.ssh 
+ mkzone zone2A -k /root/.ssh 
 
-=item *
+=item 4.
 
 To make a new zone3 and assign the noderange compute3 to the zone  enter:
 
-B<mkzone> I<zone3>  -a compute3
+ mkzone zone3 -a compute3
 
-=item *
-
+=item 5.
 To make a new zone4 and assign the noderange compute4 to the zone and add zone4 as a group to each node  enter:
 
-B<mkzone> I<zone4>  -a compute4  -g
+ mkzone zone4 -a compute4 -g
 
-=item *
+=item 6.
 
 To make a new zone5 and assign the noderange compute5 to the zone and add zone5 as a group to each node but not allow passwordless ssh between the nodes  enter:
 
-B<mkzone> I<zone5>  -a compute5  -g -s no
+ mkzone zone5 -a compute5 -g -s no
 
 =back
 
-B<Files>
+=head1 B<Files>
 
-B</opt/xcat/bin/mkzone/>
+/opt/xcat/bin/mkzone/
 
 Location of the mkzone command.
 

--- a/xCAT-client/pods/man1/monadd.1.pod
+++ b/xCAT-client/pods/man1/monadd.1.pod
@@ -4,11 +4,11 @@ B<monadd> - Registers a monitoring plug-in to the xCAT cluster.
 
 =head1 SYNOPSIS
 
-I<monadd  [-h| --help]>
+B<monadd  [-h| --help]>
 
-I<monadd  [-v| --version]>
+B<monadd  [-v| --version]>
 
-I<monadd  name [-n|--nodestatmon] [-s|--settings settings]>
+B<monadd  name [-n|--nodestatmon] [-s|--settings> I<settings]>
 
 
 =head1 DESCRIPTION
@@ -38,7 +38,7 @@ Indicate that this monitoring plug-in will be used for feeding the node liveness
 
 Specifies the plug-in specific settings. These settings will be used by the plug-in to customize certain entities for the plug-in or the third party monitoring software. e.g. -s mon_interval=10 -s toggle=1.
 
-=item B<-v | --version >
+=item B<-v | --version>
 
 Command Version.
 

--- a/xCAT-client/pods/man1/moncfg.1.pod
+++ b/xCAT-client/pods/man1/moncfg.1.pod
@@ -6,11 +6,11 @@ B<moncfg> - Configures a 3rd party monitoring software to monitor the xCAT clust
 
 =head1 SYNOPSIS
 
-I<moncfg [-h| --help]>
+B<moncfg [-h| --help]>
 
-I<moncfg [-v| --version]>
+B<moncfg [-v| --version]>
 
-I<moncfg name [noderange] [-r|--remote]>
+B<moncfg> I<name> I<[noderange]> B<[-r|--remote]>
 
 
 =head1 DESCRIPTION
@@ -31,7 +31,7 @@ B<-h | --help>          Display usage message.
 
 B<-r | --remote>        Specifies that the operation will also be performed on the nodes.
 
-B<-v | --version >      Command Version.
+B<-v | --version>       Command Version.
 
 
 =head1 RETURN VALUE
@@ -47,7 +47,7 @@ B<-v | --version >      Command Version.
   moncfg gangliamon
 
 
-1. To configure the management node, nodes and their service nodes for ganglia monitoring, enter:
+2. To configure the management node, nodes and their service nodes for ganglia monitoring, enter:
 
   moncfg gangliamon -r
 

--- a/xCAT-client/pods/man1/mondecfg.1.pod
+++ b/xCAT-client/pods/man1/mondecfg.1.pod
@@ -6,11 +6,11 @@ B<mondecfg> - Deconfigures a 3rd party monitoring software from monitoring the x
 
 =head1 SYNOPSIS
 
-I<moncfg [-h| --help]>
+B<mondecfg [-h| --help]>
 
-I<moncfg [-v| --version]>
+B<mondecfg [-v| --version]>
 
-I<moncfg name [noderange] [-r|--remote]>
+B<mondecfg> I<name> I<[noderange]> B<[-r|--remote]>
 
 
 =head1 DESCRIPTION
@@ -18,7 +18,7 @@ I<moncfg name [noderange] [-r|--remote]>
 This command is used to deconfigure a 3rd party monitoring software from monitoring the xCAT cluster. The operation is performed on the management node and the service nodes of the given nodes. The operation will also be performed on the nodes if the I<-r> option is specified. The deconfigration operation will remove the nodes from the 3rd party software's monitoring domain. 
 
 
-=head1 Parameters
+=head1 PARAMETERS
 
 I<name> is the name of the monitoring plug-in module.  Use I<monls> command to list all the monitoring plug-in modules that can be used.
 
@@ -31,7 +31,7 @@ B<-h | --help>          Display usage message.
 
 B<-r | --remote>        Specifies that the operation will also be performed on the nodes.
 
-B<-v | --version >      Command Version.
+B<-v | --version>       Command Version.
 
 
 =head1 RETURN VALUE
@@ -47,7 +47,7 @@ B<-v | --version >      Command Version.
   mondecfg gangliamon
 
 
-1. To deconfigure the management node, nodes and their service nodes from the ganglia monitoring, enter:
+2. To deconfigure the management node, nodes and their service nodes from the ganglia monitoring, enter:
 
   mondecfg gangliamon -r
 

--- a/xCAT-client/pods/man1/monls.1.pod
+++ b/xCAT-client/pods/man1/monls.1.pod
@@ -2,17 +2,15 @@
 
 B<monls> - Lists monitoring plug-in modules that can be used to monitor the xCAT cluster.
 
-
-
 =head1 SYNOPSIS
 
-I<monls [-h| --help]>
+B<monls [-h| --help]>
 
-I<monls  [-v| --version]>
+B<monls  [-v| --version]>
 
-I<monls I<name> [-d|--description]>
+B<monls> I<name> B<[-d|--description]>
 
-I<monls [-a|--all] [-d|--description]>
+B<monls [-a|--all] [-d|--description]>
 
 
 =head1 DESCRIPTION
@@ -34,7 +32,7 @@ B<-d | --description>  Display the description of the plug-in modules. The descr
 
 B<-h | --help>         Display usage message.
 
-B<-v | --version >      Command Version.
+B<-v | --version>      Command Version.
 
 =head1 RETURN VALUE
 

--- a/xCAT-client/pods/man1/monrm.1.pod
+++ b/xCAT-client/pods/man1/monrm.1.pod
@@ -2,21 +2,20 @@
 
 B<monrm> -  Unregisters a monitoring plug-in module from the xCAT cluster.
 
-
 =head1 SYNOPSIS
 
-I<monrm [-h| --help]>
+B<monrm [-h| --help]>
 
-I<monrm [-v| --version]>
+B<monrm [-v| --version]>
 
-I<monrm name>
+B<monrm> I<name>
 
 
 =head1 DESCRIPTION
 
 This command is used to unregister a monitoring plug-in module from the I<monitoring> table. It also removes any configuration scripts associated with the monitoring plug-in from the I<postscripts> table.  A monitoring plug-in module acts as a bridge that connects a 3rd party monitoring software and the xCAT cluster. A configuration script is used to configure the 3rd party software. Once added to the I<postscripts> table, it will be invoked on the nodes during node deployment stage.
 
-=head1 Parameters
+=head1 PARAMETERS
 
 I<name> is the name of the monitoring plug-in module in the I<monitoring> table.  Use I<monls> command to list all the monitoring plug-in modules that can be used. 
 
@@ -25,7 +24,7 @@ I<name> is the name of the monitoring plug-in module in the I<monitoring> table.
 
 B<-h | --help>          Display usage message.
 
-B<-v | --version >      Command Version.
+B<-v | --version>       Command Version.
 
 
 =head1 RETURN VALUE
@@ -40,7 +39,7 @@ B<-v | --version >      Command Version.
 
   monrm gangliamon
 
-Please note that gangliamon must have been registered in the xCAT I<monitoring> table. For a list of registered plug-in modules, use command I<monls>.
+Please note that gangliamon must have been registered in the xCAT I<monitoring> table. For a list of registered plug-in modules, use command B<monls>.
 
 
 

--- a/xCAT-client/pods/man1/monshow.1.pod
+++ b/xCAT-client/pods/man1/monshow.1.pod
@@ -2,15 +2,13 @@
 
 B<monshow> - Shows event data for monitoring.
 
-
-
 =head1 SYNOPSIS
 
-I<monshow [-h| --help]>
+B<monshow [-h| --help]>
 
-I<monshow [-v| --version]>
+B<monshow [-v| --version]>
 
-I<monshow name [noderange] [-s] [-t time] [-a attributes] [-w attr<operator>val [-w attr<operator>val] ... ][-o {p|e}]>
+B<monshow> I<name> I<[noderange]> [B<-s>] [B<-t> I<time>] [B<-a> I<attributes>] [B<-w> I<attr> E<lt> I<operator> E<gt> I<val> [B<-w> I<attr> E<lt> I<operator> E<gt> I<val>] ... ][B<-o {p|e}>]
 
 
 
@@ -19,7 +17,7 @@ I<monshow name [noderange] [-s] [-t time] [-a attributes] [-w attr<operator>val 
 This command displays the events that happened on the given nodes or the monitoring data that is collected from the given nodes for a monitoring plugin.
 
 
-=head1 Parameters
+=head1 PARAMETERS
 
 I<name> is the name of the monitoring plug-in module to be invoked. 
 
@@ -30,7 +28,7 @@ I<noderange> is a list of nodes to be showed for. If omitted, the data for all t
 
 B<-h | --help>          Display usage message.
 
-B<-v | --version >      Command Version.
+B<-v | --version>      Command Version.
 
 B<-s>	shows the summary data. 
 
@@ -41,15 +39,36 @@ B<-a>	specifies a comma-separated list of attributes or metrics names. The defau
 B<-w>	specify one or multiple selection string that can be used to select events. The operators ==, !=, =,!,>,<,>=,<= are available.  Wildcards % and _ are supported in the pattern string. % allows you to match any string of any length(including zero length) and _ allows you to match on a single character. The valid attributes are eventtype, monitor, monnode, application, component, id, serverity, message, rawdata, comments. Valid severity are: Informational, Warning, Critical.
 
 Operator descriptions: 
-  ==        Select event where the attribute value is exactly this value.
-  !=        Select event where the attribute value is not this specific value.
-  =~        Select event where the attribute value matches this pattern string. Not work with severity.
-  !~        Select event where the attribute value does not match this pattern string. Not work with severity.
-  >         Select event where the severity is higher than this value. Only work with severity.
-  <         Select event where the severity is lower than this value. Only work with severity.
-  >=        Select event where the severity is higher than this value(include). Only work with severity.
-  <=        Select event where the severity is lower than this value(include). Only work with severity.
-            Note: if the "val" or "operator" fields includes spaces or any other characters that will be parsed by shell, the "attr<operator>val" needs to be quoted. If the operator is "!~", the "attr<operator>val" needs to be quoted using single quote.
+
+=over 10
+
+=item B<==>
+Select event where the attribute value is exactly this value.
+
+=item B<!=>
+Select event where the attribute value is not this specific value.
+
+=item B<=~>
+Select event where the attribute value matches this pattern string. Not work with severity.
+
+=item B<!~E<gt>>
+Select event where the attribute value does not match this pattern string. Not work with severity.
+
+=item B<E<gt>>
+Select event where the severity is higher than this value. Only work with severity.
+
+=item B<E<lt>>
+Select event where the severity is lower than this value. Only work with severity.
+
+=item B<E<gt>=>
+Select event where the severity is higher than this value(include). Only work with severity.
+
+=item B<E<lt>=>
+Select event where the severity is lower than this value(include). Only work with severity.
+
+=back
+
+Note: if the "val" or "operator" fields includes spaces or any other characters that will be parsed by shell, the "attr<operator>val" needs to be quoted. If the operator is "!~", the "attr<operator>val" needs to be quoted using single quote.
 
 B<-o>	specifies montype, it can be p or e. p means performance, e means events.
 

--- a/xCAT-client/pods/man1/monstart.1.pod
+++ b/xCAT-client/pods/man1/monstart.1.pod
@@ -2,25 +2,23 @@
 
 B<monstart> - Starts a plug-in module to monitor the xCAT cluster.
 
-
-
 =head1 SYNOPSIS
 
-I<monstart [-h| --help]>
+B<monstart [-h| --help]>
 
-I<monstart [-v| --version]>
+B<monstart [-v| --version]>
 
-I<monstart name [noderange] [-r|--remote]>
+B<monstart> I<name> I<[noderange]> [B<-r|--remote>]
 
 
 =head1 DESCRIPTION
 
-This command is used to start a 3rd party software, (for example start the daemons), to monitor the xCAT cluster. The operation is performed on the management node and the service nodes of the given nodes.  The operation will also be performed on the nodes if the I<-r> option is specified.
+This command is used to start a 3rd party software, (for example start the daemons), to monitor the xCAT cluster. The operation is performed on the management node and the service nodes of the given nodes.  The operation will also be performed on the nodes if the B<-r> option is specified.
 
 
-=head1 Parameters
+=head1 PARAMETERS
 
-I<name> is the name of the monitoring plug-in module. For example, if the the I<name> is called I<xxx>, then the actual file name that the xcatd looks for is I</opt/xcat/lib/perl/xCAT_monitoring/xxx.pm>. Use I<monls -a> command to list all the monitoring plug-in modules that can be used.
+I<name> is the name of the monitoring plug-in module. For example, if the the I<name> is called I<xxx>, then the actual file name that the xcatd looks for is I</opt/xcat/lib/perl/xCAT_monitoring/xxx.pm>. Use B<monls -a> command to list all the monitoring plug-in modules that can be used.
 
 I<noderange> is the nodes to be monitored. If omitted, all nodes will be monitored.
 
@@ -31,7 +29,7 @@ B<-h | --help>          Display usage message.
 
 B<-r | --remote>        Specifies that the operation will also be performed on the nodes. For example, the3rd party monitoring software daemons on the nodes will also be started.
 
-B<-v | --version >      Command Version.
+B<-v | --version>       Command Version.
 
 
 =head1 RETURN VALUE

--- a/xCAT-client/pods/man1/monstop.1.pod
+++ b/xCAT-client/pods/man1/monstop.1.pod
@@ -5,20 +5,20 @@ B<monstop> -  Stops a monitoring plug-in module to monitor the xCAT cluster.
 
 =head1 SYNOPSIS
 
-I<monstop [-h| --help]>
+B<monstop [-h| --help]>
 
-I<monstop [-v| --version]>
+B<monstop [-v| --version]>
 
-I<monstop name [noderange] [-r|--remote]>
+B<monstop> I<name> [I<noderange>] [B<-r|--remote>]
 
 
 =head1 DESCRIPTION
 
-This command is used to stop a 3rd party software, (for example stop the daemons), from monitoring the xCAT cluster. The operation is performed on the management node and the service nodes of the given nodes.  The operation will also be performed on the nodes if the I<-r> option is specified.
+This command is used to stop a 3rd party software, (for example stop the daemons), from monitoring the xCAT cluster. The operation is performed on the management node and the service nodes of the given nodes.  The operation will also be performed on the nodes if the B<-r> option is specified.
 
-=head1 Parameters
+=head1 PARAMETERS
 
-I<name> is the name of the monitoring plug-in module in the I<monitoring> table. Use I<monls> command to list all the monitoring plug-in modules that can be used.
+I<name> is the name of the monitoring plug-in module in the I<monitoring> table. Use B<monls> command to list all the monitoring plug-in modules that can be used.
 
 I<noderange> is the nodes to be stopped for monitoring. If omitted, all nodes will be stopped.
 
@@ -29,7 +29,7 @@ B<-h | -help>          Display usage message.
 
 B<-r | --remote>       Specifies that the operation will also be performed on the nodes. For example, the3rd party monitoring software daemons on the nodes will also be stopped.
 
-B<-v | -version >      Command Version.
+B<-v | -version>       Command Version.
 
 
 

--- a/xCAT-client/pods/man1/mysqlsetup.1.pod
+++ b/xCAT-client/pods/man1/mysqlsetup.1.pod
@@ -9,19 +9,22 @@ B<mysqlsetup> {B<-h>|B<--help>}
 
 B<mysqlsetup> {B<-v>|B<--version>}
 
-B<mysqlsetup> {B<-i>|B<--init>} [B<-f>|B<--hostfile>] [-o|--odbc] [-L|--LL] [B<-V>|B<--verbose>]
+B<mysqlsetup> {B<-i>|B<--init>} [B<-f>|B<--hostfile>] [B<-o>|B<--odbc>] [B<-L>|B<--LL>] [B<-V>|B<--verbose>]
 
-B<mysqlsetup> {B<-u>|B<--update>} [B<-f>|B<--hostfile>] [-o|--odbc] [-L|--LL]          [B<-V>|B<--verbose>]
+B<mysqlsetup> {B<-u>|B<--update>} [B<-f>|B<--hostfile>] [B<-o>|B<--odbc>] [B<-L>|B<--LL>] [B<-V>|B<--verbose>]
 
-B<mysqlsetup> {B<-o>|B<--odbc>} [-V|--verbose] 
+B<mysqlsetup> {B<-o>|B<--odbc>} [B<-V>|B<--verbose>] 
 
-B<mysqlsetup> {B<-L>|B<--LL>} [-V|--verbose] 
+B<mysqlsetup> {B<-L>|B<--LL>} [B<-V>|B<--verbose>] 
 
 =head1 DESCRIPTION
 
 B<mysqlsetup> - Sets up the MySQL or MariaDB database (linux only for MariaDB) for xCAT to use. The mysqlsetup script is run on the Management Node as root after the MySQL code or MariaDB code has been installed. Before running the init option, the MySQL server should be stopped, if it is running.  The xCAT daemon, xcatd, must be running, do not stop it. No xCAT commands should be run during the init process, because we will be migrating the xCAT database to MySQL or MariaDB and restarting the xcatd daemon as well as the MySQL daemon. For full information on all the steps that will be done, read the "Configure MySQL and Migrate xCAT Data to MySQL" sections in 
-Setting_Up_MySQL_as_the_xCAT_DB
+
+B<Setting_Up_MySQL_as_the_xCAT_DB>
+
 Two passwords must be supplied for the setup,  a password for the xcatadmin id and a password for the root id in the MySQL database.  These will be prompted for interactively, unless the environment variables XCATMYSQLADMIN_PW and  XCATMYSQLROOT_PW are set to the passwords for the xcatadmin id and root id in the database,resp. 
+
 Note below we refer to MySQL but it works the same for MariaDB.
 
 =head1 OPTIONS
@@ -72,11 +75,9 @@ Setting_Up_MySQL_as_the_xCAT_DB
 =over 2
 
 =item *
-
 B<XCATMYSQLADMIN_PW> - the password for the xcatadmin id that will be assigned in the MySQL database.
 
 =item *
-
 B<XCATMYSQLROOT_PW> - the password for the root id that will be assigned to the MySQL root id, if the script creates it.  The password to use to run MySQL command to the database as the MySQL root id.  This password may be different than the unix root password on the Management Node.  
 
 =back
@@ -85,17 +86,17 @@ B<XCATMYSQLROOT_PW> - the password for the root id that will be assigned to the 
 
 =over 2
 
-=item *
+=item 1.
 
 To setup MySQL for xCAT to run on the MySQL xcatdb database :
 
-B<mysqlsetup> I<-i>
+ mysqlsetup -i
 
-=item *
+=item 2.
 
 Add hosts from /tmp/xcat/hostlist that can access the xcatdb database in MySQL:
 
-B<mysqlsetup> I<-u> I<-f /tmp/xcat/hostlist>
+ mysqlsetup -u -f /tmp/xcat/hostlist
 
 Where the file contains a host per line, for example:
 
@@ -104,16 +105,16 @@ Where the file contains a host per line, for example:
          10.%.%.%
          nodex.cluster.net
 
-=item * 
+=item 3. 
 
 To setup the ODBC for MySQL xcatdb database access :
 
-B<mysqlsetup> I<-o>
+ mysqlsetup -o
 
-=item * 
+=item 4. 
 
 To setup MySQL for xCAT and add hosts from /tmp/xcat/hostlist and setup the ODBC in Verbose mode:
 
-B<mysqlsetup> I<-i> I<-f /tmp/xcat/hostlist> I<-o> I<-V>
+ mysqlsetup -i -f /tmp/xcat/hostlist -o -V
 
 =back

--- a/xCAT-client/pods/man1/nimnodecust.1.pod
+++ b/xCAT-client/pods/man1/nimnodecust.1.pod
@@ -6,7 +6,7 @@ B<nimnodecust> - Use this xCAT command to customize AIX/NIM standalone machines.
 
 B<nimnodecust [-h|--help ]>
 
-B<nimnodecust [-V] -s lpp_source_name [-p packages] [-b installp_bundles] noderange [attr=val [attr=val ...]]>
+B<nimnodecust [-V] -s> I<lpp_source_name> [B<-p> I<packages>] [B<-b> I<installp_bundles>] I<noderange [attr=val [attr=val ...]]>
 
 =head1 DESCRIPTION
 
@@ -28,11 +28,7 @@ A bundle file contains a list of package names.  The RPMs must have a prefix of 
 
 To create a NIM installp_bundle definition you can use the "nim -o define" operation.  For example, to create a definition called "mypackages" for a bundle file located at "/install/nim/mypkgs.bnd" you could issue the following command. 
 
-=over 5
-
-"nim -o define -t installp_bundle -a server=master -a location=/install/nim/mypkgs.bnd mypackages".
-
-=back
+ nim -o define -t installp_bundle -a server=master -a location=/install/nim/mypkgs.bnd mypackages
 
 See the AIX documantation for more information on using installp_bundle files.
 
@@ -42,24 +38,24 @@ The xCAT nimnodecust command will automatically handle the distribution of the p
 
 =over 10
 
-=item B<attr=val [attr=val ...]>
+=item I<attr=val [attr=val ...]>
 
 Specifies one or more "attribute equals value" pairs, separated by spaces. Attr=val pairs must be specified last on the command line. These are used to specify
 additional values that can be passed to the underlying NIM commands, ("nim -o cust..."). See the NIM documentation for valid "nim" command line options. 
 
-=item B<-b installp_bundle_names>
+=item B<-b> I<installp_bundle_names>
 
-	A comma separated list of NIM installp_bundle names.
+A comma separated list of NIM installp_bundle names.
 
 =item B<-h |--help>
 
 Display usage message.
 
-=item B<-p package_names>
+=item B<-p> I<package_names>
 
 A comma-separated list of software packages to install.  Packages may be RPM or installp.
 
-=item B<noderange>
+=item I<noderange>
 
 A set of comma delimited node names and/or group names. See the "noderange" man page for details on additional supported formats.
 
@@ -74,11 +70,9 @@ Verbose mode.
 =over 3
 
 =item 0
-
 The command completed successfully.
 
 =item 1
-
 An error has occurred.
 
 =back
@@ -87,17 +81,13 @@ An error has occurred.
 
 1) Install the installp package "openssh.base.server" on an xCAT node named "node01".  Assume that the package has been copied to the NIM lpp_source resource called "61lppsource".  
 
-=over 5
-
-B<nimnodecust -s 61lppsource -p openssh.base.server node01>
+ nimnodecust -s 61lppsource -p openssh.base.server node01
 
 =back
 
 2) Install the product software contained in the two bundles called "llbnd" and "pebnd" on all AIX nodes contained in the xCAT node group called "aixnodes".  Assume that all the software packages have been copied to the NIM lpp_source resource called "61lppsource".
 
-=over 5
-
-B<nimnodecust -s 61lppsource -b llbnd,pebnd  aixnodes>
+ nimnodecust -s 61lppsource -b llbnd,pebnd  aixnodes
 
 =back
 

--- a/xCAT-client/pods/man1/nimnodeset.1.pod
+++ b/xCAT-client/pods/man1/nimnodeset.1.pod
@@ -6,7 +6,7 @@ B<nimnodeset> - Use this xCAT command to initialize AIX/NIM standalone machines.
 
 B<nimnodeset [-h|--help ]>
 
-B<nimnodeset [-V|--verbose] [-f|--force] [-i osimage_name] [-l location] [-p|--primarySN] [-b|--backupSN] noderange [attr=val [attr=val ...]]>
+B<nimnodeset [-V|--verbose] [-f|--force] [-i> I<osimage_name>] [B<-l> I<location>] [B<-p|--primarySN>] [B<-b>|B<--backupSN>] I<noderange [attr=val [attr=val ...]]>
 
 =head1 DESCRIPTION
 
@@ -28,11 +28,7 @@ The "nameservers" value can either be set to a specific IP address or the "<xcat
 
 You can set the "domain" and "nameservers" attributes by using the B<chdef> command.  For example:
 
-=over 3
-
-chdef -t network -o clstr_net domain=cluster.com nameservers=<xcatmaster>
-
-=back
+ chdef -t network -o clstr_net domain=cluster.com nameservers=<xcatmaster>
 
 If the "domain" and "nameservers" attributes are not set in either the nodes "network" definition or the "site" definition then no new NIM resolv_conf resource
 will be created.
@@ -51,7 +47,7 @@ You can supply your own scripts to be run on the management node  or on the serv
 
 =over 10
 
-=item B<attr=val [attr=val ...]>
+=item I<attr=val [attr=val ...]>
 
 Specifies one or more "attribute equals value" pairs, separated by spaces. Attr=
 val pairs must be specified last on the command line. These are used to specify additional values that can be passed to the underlying NIM commands, ("nim -o bos_inst ...").  See the NIM documentation for valid "nim" command line options. Note that you may specify multiple "script" and "installp_bundle" values by using a comma seperated list. (ex. "script=ascript,bscript").
@@ -68,7 +64,7 @@ Use the force option to reinitialize the NIM machines.
 
 Display usage message.
 
-=item B<-i image_name>
+=item B<-i> I<image_name>
 
 The name of an existing xCAT osimage definition.
 
@@ -81,7 +77,7 @@ efault location is /install/nim.
 
 When using backup service nodes only update the primary.  The default is to update both the primary and backup service nodes.
 
-=item B<noderange>
+=item I<noderange>
 
 A set of comma delimited node names and/or group names. See the "noderange" man page for details on additional supported formats.
 
@@ -96,11 +92,9 @@ Verbose mode.
 =over 3
 
 =item 0
-
 The command completed successfully.
 
 =item 1
-
 An error has occurred.
 
 =back
@@ -109,26 +103,20 @@ An error has occurred.
 
 1) Initialize an xCAT node named "node01".  Use the xCAT osimage named "61gold" to install the node.
 
-=over 5
-
-B<nimnodeset -i 61gold node01>
+ nimnodeset -i 61gold node01
 
 =back
 
 2) Initialize all AIX nodes contained in the xCAT node group called "aixnodes" using the image definitions pointed to by the "provmethod" attribute of the xCAT node definitions.
 
-=over 5
-
-B<nimnodeset aixnodes>
+ nimnodeset aixnodes
 
 =back
 
 
 3) Initialize an xCAT node called "node02".  Include installp_bundle resources that are not included in the osimage definition. This assumes the NIM installp_bundle resources have already been created.
 
-=over 5
-
-B<nimnodeset -i 611image node02 installp_bundle=sshbundle,addswbundle>
+ nimnodeset -i 611image node02 installp_bundle=sshbundle,addswbundle
 
 =back
 

--- a/xCAT-client/pods/man1/nodeaddunmged.1.pod
+++ b/xCAT-client/pods/man1/nodeaddunmged.1.pod
@@ -4,9 +4,9 @@ B<nodeaddunmged> - Create a unmanaged node.
 
 =head1 SYNOPSIS
 
-B<nodeaddunmged> [-h| --help | -v | --version]
+B<nodeaddunmged> [B<-h>| B<--help> | B<-v> | B<--version>]
 
-B<nodeaddunmged> hostname=<node-name> ip=<ip-address>
+B<nodeaddunmged hostname=>I<node-name> B<ip=>I<ip-address>
 
 =head1 DESCRIPTION
 
@@ -22,13 +22,13 @@ B<-v|--version>
 
 Command Version.
 
-B<hostname=<node-name>>
+B<hostname=>I<node-name>
 
 Sets the name of the new unmanaged node, where <node-name> is the name of the node.
 
-B<ip=<ip-address>>
+B<ip=>I<ip-address>
 
-Sets the IP address of the unmanaged node, where <ip-address> is the IP address of the new node in the form xxx.xxx.xxx.xxx
+Sets the IP address of the unmanaged node, where I<ip-address> is the IP address of the new node in the form xxx.xxx.xxx.xxx
 
 =head1 RETURN VALUE
 
@@ -39,7 +39,8 @@ Sets the IP address of the unmanaged node, where <ip-address> is the IP address 
 =head1 EXAMPLES
 
 To add an unmanaged node, use the following command:
-nodeaddunmged hostname=unmanaged01 ip=192.168.1.100
+
+ nodeaddunmged hostname=unmanaged01 ip=192.168.1.100
 
 =head1 SEE ALSO
 

--- a/xCAT-client/pods/man1/nodech.1.pod
+++ b/xCAT-client/pods/man1/nodech.1.pod
@@ -59,11 +59,9 @@ Display usage message.
 =over 3
 
 =item 0
-
 The command completed successfully.
 
 =item 1
-
 An error has occurred.
 
 =back
@@ -73,35 +71,30 @@ An error has occurred.
 
 =over 2
 
-=item *
-
+=item 1.
 To update nodes in noderange  node1-node4 to be in only group all:
 
-B<nodech> I<node1-node4 groups=all>
+ nodech node1-node4 groups=all
 
-=item *
-
+=item 2.
 To put all nodes with nodepos.rack value of 2 into a group called rack2:
 
-B<nodech> I<all> nodepos.rack==2 groups,=rack2
+ nodech all nodepos.rack==2 groups,=rack2
 
-=item *
-
+=item 3.
 To add nodes in noderange  node1-node4 to the nodetype table with os=rhel5:
 
-B<nodech> I<node1-node4 groups=all,rhel5 nodetype.os=rhel5>
+ nodech node1-node4 groups=all,rhel5 nodetype.os=rhel5
 
-=item *
-
+=item 4.
 To add node1-node4 to group1 in addition to the groups they are already in:
 
-B<nodech> I<node1-node4 groups,=group1>
+ nodech node1-node4 groups,=group1
 
-=item *
-
+=item 5.
 To put node1-node4 in group2, instead of group1:
 
-B<nodech> I<node1-node4 groups^=group1 groups,=group2>
+ nodech node1-node4 groups^=group1 groups,=group2
 
 =back
 

--- a/xCAT-client/pods/man1/nodechmac.1.pod
+++ b/xCAT-client/pods/man1/nodechmac.1.pod
@@ -4,9 +4,9 @@ B<nodechmac> - Updates the MAC address for a node.
 
 =head1 SYNOPSIS
 
-B<nodechmac> [-h| --help | -v | --version]
+B<nodechmac> [B<-h> | B<--help> | B<-v> | B<--version>]
 
-B<nodechmac> <node-name> mac=<mac-address>
+B<nodechmac> I<node-name> B<mac=>I<mac-address>
 
 =head1 DESCRIPTION
 
@@ -24,11 +24,11 @@ B<-v|--version>
 
 Command Version.
 
-B<node-name>
+I<node-name>
 
 Specifies the name of the node you want to update, where <node-name> is the node that is updated.
 
-B<mac=<mac-address>
+B<mac=>I<mac-address>
 
 Sets the new MAC address for the NIC used by the provisioning node, where <mac-address> is the NICs new MAC address.
 
@@ -41,7 +41,8 @@ Sets the new MAC address for the NIC used by the provisioning node, where <mac-a
 =head1 EXAMPLES
 
 You can update the MAC address for a node, by using the following command:
-nodechmac compute-000 mac=2F:3C:88:98:7E:01
+
+ nodechmac compute-000 mac=2F:3C:88:98:7E:01
 
 =head1 SEE ALSO
 

--- a/xCAT-client/pods/man1/nodechprofile.1.pod
+++ b/xCAT-client/pods/man1/nodechprofile.1.pod
@@ -4,9 +4,9 @@ B<nodechprofile> - updates a profile used by a node
 
 =head1 SYNOPSIS
 
-B<nodechprofile> [-h| --help | -v | --version]
+B<nodechprofile> B<[-h| --help | -v | --version]>
 
-B<nodechprofile> <noderange> [imageprofile=<image-profile>] [networkprofile=<network-profile>] [hardwareprofile=<hardware-profile>]
+B<nodechprofile> I<noderange> [B<imageprofile=> I<image-profile>] [B<networkprofile=> I<network-profile>] [B<hardwareprofile=> I<hardware-profile>]
 
 =head1 DESCRIPTION
 
@@ -32,19 +32,19 @@ B<-v|--version>
 
 Command Version.
 
-B<noderange>
+I<noderange>
 
 The nodes to be removed.
 
-B<imageprofile=<image-profile>>
+B<imageprofile=> I<image-profile>
 
 Sets the new image profile name used by the node, where <image-profile> is the new image profile.  An image profile defines the provisioning method, OS information, kit information, and provisioning parameters for a node. If the "__ImageProfile_imgprofile" group already exists in the nodehm table, then "imgprofile" is used as the image profile name. 
 
-B<networkprofile=<network-profile>>
+B<networkprofile=> I<network-profile>
 
 Sets the new network profile name used by the node, where <network-profile> is the new network profile. A network profile defines the network, NIC, and routes for a node. If the "__NetworkProfile_netprofile" group already exists in the nodehm table, then "netprofile" is used as the network profile name. 
 
-B<hardwareprofile=<hardware-profile>>
+B<hardwareprofile=> I<hardware-profile>
 
 Sets the new hardware profile name used by the node, where <hardware-profile> is the new hardware management profile used by the node. If a "__HardwareProfile_hwprofile" group exists, then "hwprofile" is the hardware profile name. A hardware profile defines hardware management related information for imported nodes, including: IPMI, HMC, CEC, CMM.
 
@@ -56,13 +56,15 @@ Sets the new hardware profile name used by the node, where <hardware-profile> is
 
 =head1 EXAMPLES
 
+=item 1.
 To change the image profile to rhels6.3_packaged for compute nodes compute-000 and compute-001, use the following command:
 
-nodechprofile compute-000,compute-001 imageprofile=rhels6.3_packaged
+ nodechprofile compute-000,compute-001 imageprofile=rhels6.3_packaged
 
+=item 2.
 To change all of the profiles for compute node compute-000, enter the following command:
 
-nodechprofile compute-000 imageprofile=rhels6.3_packaged networkprofile=default_cn hardwareprofile=default_ipmi
+ nodechprofile compute-000 imageprofile=rhels6.3_packaged networkprofile=default_cn hardwareprofile=default_ipmi
 
 =head1 SEE ALSO
 

--- a/xCAT-client/pods/man1/nodediscoverdef.1.pod
+++ b/xCAT-client/pods/man1/nodediscoverdef.1.pod
@@ -6,9 +6,9 @@ or clean up the discovery entries from the discoverydata table
 
 =head1 SYNOPSIS
 
-B<nodediscoverdef> B<-u uuid> B<-n node>
+B<nodediscoverdef> B<-u> I<uuid> B<-n> I<node>
 
-B<nodediscoverdef> B<-r> B<-u uuid>
+B<nodediscoverdef> B<-r> B<-u> I<uuid>
 
 B<nodediscoverdef> B<-r> B<-t> {B<seq>|B<profile>|B<switch>|B<blade>|B<manual>|B<undef>|B<all>}
 
@@ -41,36 +41,29 @@ Specify the nodes that have been discovered by the specified discovery method:
 =over 3
 
 =item *
-
 B<seq> - Sequential discovery (started via nodediscoverstart noderange=<noderange> ...).
 
 =item *
-
 B<profile> - Profile discovery (started via nodediscoverstart networkprofile=<network-profile> ...).
 
 =item *
-
 B<switch> - Switch-based discovery (used when the switch and switches tables are filled in).
 
 =item *
-
 B<blade> - Blade discovery (used for IBM Flex blades).
 
 =item *
-
 B<manual> - Manually discovery (used when defining node by nodediscoverdef command).
 
 =item *
-
 B<undef> - Display the nodes that were in the discovery pool, but for which xCAT has not yet received a discovery request.
 
 =item *
-
 B<all> - All discovered nodes.
 
 =back
 
-=item B<-n node>
+=item B<-n> I<node>
 
 The xCAT node that the discovery entry will be defined to.
 
@@ -78,7 +71,7 @@ The xCAT node that the discovery entry will be defined to.
 
 Remove the discovery entries from discoverydata table.
 
-=item B<-u uuid>
+=item B<-u> I<uuid>
 
 The uuid of the discovered entry.
 
@@ -102,27 +95,30 @@ Command version.
 
 =over 3
 
-=item 1
-
+=item 1.
 Define the discovery entry which uuid is 51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB4 to node node1
 
-B<nodediscoverdef> -u 51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB4 -n node1
+ nodediscoverdef -u 51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB4 -n node1
+
+Output is similar to:
 
  Defined [51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB4] to node node1.
 
-=item 2
-
+=item 2.
 Remove the discovery entry which uuid is 51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB4 from the discoverydata table
 
-B<nodediscoverdef> -r -u 51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB4
+ nodediscoverdef -r -u 51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB4
+
+Output is similar to:
 
  Removing discovery entries finished.
 
-=item 3
-
+=item 3.
 Remove the discovery entries which discover type is B<seq> from the discoverydata table
 
-B<nodediscoverdef> -r -t seq
+ nodediscoverdef -r -t seq
+
+Output is similar to:
 
  Removing discovery entries finished.
 

--- a/xCAT-client/pods/man1/nodediscoverls.1.pod
+++ b/xCAT-client/pods/man1/nodediscoverls.1.pod
@@ -6,7 +6,7 @@ B<nodediscoverls> -  List the discovered nodes
 
 B<nodediscoverls> [B<-t seq>|B<profile>|B<switch>|B<blade>|B<manual>|B<undef>|B<all>] [B<-l>] 
 
-B<nodediscoverls> [B<-u uuid>] [B<-l>]
+B<nodediscoverls> [B<-u> I<uuid>] [B<-l>]
 
 B<nodediscoverls> [B<-h>|B<--help>|B<-v>|B<--version>]
 
@@ -32,31 +32,24 @@ Display the nodes that have been discovered by the specified discovery method:
 =over 3
 
 =item *
-
 B<seq> - Sequential discovery (started via nodediscoverstart noderange=<noderange> ...).
 
 =item *
-
 B<profile> - Profile discovery (started via nodediscoverstart networkprofile=<network-profile> ...).
 
 =item *
-
 B<switch> - Switch-based discovery (used when the switch and switches tables are filled in).
 
 =item *
-
 B<blade> - Blade discovery (used for IBM Flex blades).
 
 =item *
-
 B<manual> - Manually discovery (used when defining node by nodediscoverdef command).
 
 =item *
-
 B<undef> - Display the nodes that were in the discovery pool, but for which xCAT has not yet received a discovery request.
 
 =item *
-
 B<all> - All discovered nodes.
 
 =back
@@ -65,7 +58,7 @@ B<all> - All discovered nodes.
 
 Display more detailed information about the discovered nodes.
 
-=item B<-u uuid>
+=item B<-u> I<uuid>
 
 Display the discovered node that has this uuid.
 
@@ -89,31 +82,34 @@ Command version.
 
 =over 3
 
-=item 1
-
+=item 1.
 Display the discovered nodes when sequential discovery is running:
 
-B<nodediscoverls>
+ nodediscoverls
+
+Output is similar to:
 
  UUID                                    NODE                METHOD         MTM       SERIAL
  51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB2    distest1            sequential     786310X   1052EF2
  51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB3    distest2            sequential     786310X   1052EF3
 
-=item 2
-
+=item 2.
 Display the nodes that were in the discovery pool, but for which xCAT has not yet received a discovery request:
 
-B<nodediscoverls> -t undef
+ nodediscoverls -t undef
+
+Output is similar to:
 
  UUID                                    NODE                METHOD         MTM       SERIAL
  51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB0    undef               undef          786310X   1052EF0
  51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB1    undef               undef          786310X   1052EF1
 
-=item 3
-
+=item 3.
 Display all the discovered nodes:
 
-B<nodediscoverls> -t all
+ nodediscoverls -t all
+
+Output is similar to:
 
  UUID                                    NODE                METHOD         MTM       SERIAL
  51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB0    undef               undef          786310X   1052EF0
@@ -121,11 +117,12 @@ B<nodediscoverls> -t all
  51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB2    distest1            sequential     786310X   1052EF2
  51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB3    distest2            sequential     786310X   1052EF3
 
-=item 4
-
+=item 4.
 Display the discovered node whose uuid is B<51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB2>, with detailed information:
 
-B<nodediscoverls> -u 51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB2 -l
+ nodediscoverls -u 51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB2 -l
+
+Output is similar to:
 
  Object uuid: 51E5F2D7-0D59-11E2-A7BC-3440B5BEDBB2
     node=distest1

--- a/xCAT-client/pods/man1/nodediscoverstart.1.pod
+++ b/xCAT-client/pods/man1/nodediscoverstart.1.pod
@@ -10,7 +10,7 @@ B<Sequential Discovery Specific:>
 
 =over 2
 
-B<nodediscoverstart> B<noderange=>I<noderange> [B<hostiprange=>I<imageprofile>] [B<bmciprange=>I<bmciprange>] [B<groups=>I<groups>] [B<rack=>I<rack>] [B<chassis=>I<chassis>] [B<height=>I<height>] [B<unit=>I<unit>] [osimage=<osimagename>] [-n|--dns] [-s|--skipbmcsetup] [B<-V|--verbose>]
+B<nodediscoverstart> B<noderange=>I<noderange> [B<hostiprange=>I<imageprofile>] [B<bmciprange=>I<bmciprange>] [B<groups=>I<groups>] [B<rack=>I<rack>] [B<chassis=>I<chassis>] [B<height=>I<height>] [B<unit=>I<unit>] [B<osimage=> I<osimagename>>] [B<-n>|B<--dns>] [B<-s>|B<--skipbmcsetup>] [B<-V|--verbose>]
 
 =back
 
@@ -152,11 +152,12 @@ Command Version.
 
 =over 3
 
-=item 1
-
+=item 1.
 B<Sequential Discovery>: To discover nodes with noderange and host/bmc ip range:
 
-B<nodediscoverstart noderange=n[1-10] hostiprange='172.20.101.1-172.20.101.10' bmciprange='172.20.102.1-172.20.102.10' -V>
+ nodediscoverstart noderange=n[1-10] hostiprange='172.20.101.1-172.20.101.10' bmciprange='172.20.102.1-172.20.102.10' -V
+
+Output is similar to:
 
  Sequential Discovery: Started:
     Number of free node names: 10
@@ -168,11 +169,10 @@ B<nodediscoverstart noderange=n[1-10] hostiprange='172.20.101.1-172.20.101.10' b
  n02                 172.20.101.2        172.20.102.2
  ...                 ...                 ...
 
-=item 2
-
+=item 2.
 B<Profile Discovery>: To discover nodes using the default_cn network profile and the rhels6.3_packaged image profile, use the following command:
 
-B<nodediscoverstart networkprofile=default_cn imageprofile=rhels6.3_packaged hostnameformat=compute#NNN>
+ nodediscoverstart networkprofile=default_cn imageprofile=rhels6.3_packaged hostnameformat=compute#NNN
 
 =back
 

--- a/xCAT-client/pods/man1/nodediscoverstatus.1.pod
+++ b/xCAT-client/pods/man1/nodediscoverstatus.1.pod
@@ -31,7 +31,7 @@ Command Version.
 
 To determine if there are some nodes discovered and the discovered nodes' status, enter the following command:
 
-nodediscoverstatus 
+ nodediscoverstatus 
 
 =head1 SEE ALSO
 

--- a/xCAT-client/pods/man1/nodediscoverstop.1.pod
+++ b/xCAT-client/pods/man1/nodediscoverstop.1.pod
@@ -30,7 +30,7 @@ Command Version.
 
 =head1 EXAMPLES
 
-nodediscoverstop 
+ nodediscoverstop 
 
 =head1 SEE ALSO
 

--- a/xCAT-client/pods/man1/nodegrpch.1.pod
+++ b/xCAT-client/pods/man1/nodegrpch.1.pod
@@ -53,11 +53,9 @@ Display usage message.
 =over 3
 
 =item 0
-
 The command completed successfully.
 
 =item 1
-
 An error has occurred.
 
 =back
@@ -67,13 +65,11 @@ An error has occurred.
 
 =over 2
 
-
-
-=item *
+=item 1.
 
 To declare all members of ipmi group to have nodehm.mgt be ipmi
 
-B<  nodegrpch> I<ipmi nodehm.mgt=ipmi>
+ nodegrpch ipmi nodehm.mgt=ipmi
 
 =back
 

--- a/xCAT-client/pods/man1/nodeimport.1.pod
+++ b/xCAT-client/pods/man1/nodeimport.1.pod
@@ -4,9 +4,9 @@ B<nodeimport> - Create profiled nodes by importing hostinfo file.
 
 =head1 SYNOPSIS
 
-B<nodeimport> [-h| --help | -v | --version]
+B<nodeimport> [B<-h> | B<--help> | B<-v> | B<--version>]
 
-B<nodeimport> file=<hostinfo-filename> networkprofile=<network-profile> imageprofile=<image-profile> hostnameformat=<node-name-format> [hardwareprofile=<hardware-profile>] [groups=<node-groups>]
+B<nodeimport> B<file=> I<hostinfo-filename> B<networkprofile=> I<network-profile> B<imageprofile=> I<image-profile> B<hostnameformat=> I<node-name-format> [B<hardwareprofile=> I<hardware-profile>] [B<groups=> I<node-groups>]
 
 =head1 DESCRIPTION
 
@@ -24,23 +24,23 @@ B<-v|--version>
 
 Command Version.
 
-B<file=<nodeinfo-filename>>
+B<file=> I<nodeinfo-filename>
 
 Specifies the node information file, where <nodeinfo-filename> is the full path and file name of the node information file.
 
-B<imageprofile=<image-profile>>
+B<imageprofile=> I<image-profile>
 
 Sets the new image profile name used by the node, where <image-profile> is the new image profile.  An image profile defines the provisioning method, OS information, kit information, and provisioning parameters for a node. If the "__ImageProfile_imgprofile" group already exists in the nodehm table, then "imgprofile" is used as the image profile name.
 
-B<networkprofile=<network-profile>>
+B<networkprofile=> I<network-profile>
 
 Sets the new network profile name used by the node, where <network-profile> is the new network profile. A network profile defines the network, NIC, and routes for a node. If the "__NetworkProfile_netprofile" group already exists in the nodehm table, then "netprofile" is used as the network profile name.
 
-B<hardwareprofile=<hardware-profile>>
+B<hardwareprofile=> I<hardware-profile>
 
 Sets the new hardware profile name used by the node, where <hardware-profile> is the new hardware management profile used by the node. If a "__HardwareProfile_hwprofile" group exists, then "hwprofile" is the hardware profile name. A hardware profile defines hardware management related information for imported nodes, including: IPMI, HMC, CEC, CMM.
 
-B<hostnameformat=<host-name-format>>
+B<hostnameformat=> I<host-name-format>
 
 Sets the node name format for all nodes discovered, where <node-name-format> is a supported format. The two types of formats supported are prefix#NNNappendix and prefix#RRand#NNappendix, where wildcard #NNN and #NN are replaced by a system generated number that is based on the provisioning order. Wildcard #RR represents the rack number and stays constant.
 
@@ -48,7 +48,7 @@ For example, if the node name format is compute-#NN, the node name is generated 
 
 For example, if the node name format is compute-#RR-#NN and the rack number is 2, the node name is generated as: compute-02-00, compute-02-01, ..., compute-02-99. If node name format is node-#NN-in-#RR and rack number is 1, the node name is generated as: node-00-in-01, node-01-in-01, ... , node-99-in-01
 
-B<groups=<node-groups>>
+B<groups=> I<node-groups>
 
 Sets the node groups that the imported node belongs to, where <node-group> is a comma-separated list of node groups.
 
@@ -200,6 +200,7 @@ B<vmhost=<PowerKVM Hypervisior Host Name>>  This is a mandatory option for defin
 Description: Specifies the vmhost of a Power KVM Guest node, where <vmhost> is the host name of PowerKVM Hypervisior. 
 
 3. Import the nodes, by using the following commands. Note: If we want to import PureFlex X/P nodes, hardware profile must be set to a PureFlex hardware type.
+
   nodeimport file=/root/hostinfo.txt networkprofile=default_cn imageprofile=rhels6.3_packaged hostnameformat=compute-#NNN
 
 4. After importing the nodes, the nodes are created and all configuration files used by the nodes are updated, including: /etc/hosts, DNS, DHCP.

--- a/xCAT-client/pods/man1/nodepurge.1.pod
+++ b/xCAT-client/pods/man1/nodepurge.1.pod
@@ -4,9 +4,9 @@ B<nodepurge> - Removes nodes.
 
 =head1 SYNOPSIS
 
-B<nodepurge> [-h| --help | -v | --version]
+B<nodepurge [-h| --help | -v | --version]>
 
-B<nodepurge> <noderange>
+B<nodepurge> I<noderange>
 
 =head1 DESCRIPTION
 
@@ -24,7 +24,7 @@ B<-v|--version>
 
 Command Version
 
-B<noderange>
+I<noderange>
 
 The nodes to be removed.
 
@@ -38,7 +38,7 @@ The nodes to be removed.
 
 To remove nodes compute-000 and compute-001, use the following command:
 
-nodepurge compute-000,compute-001
+ nodepurge compute-000,compute-001
 
 =head1 SEE ALSO
 

--- a/xCAT-client/pods/man1/noderefresh.1.pod
+++ b/xCAT-client/pods/man1/noderefresh.1.pod
@@ -4,9 +4,9 @@ B<noderefresh> - Update nodes configurations by running associated kit plugins.
 
 =head1 SYNOPSIS
 
-B<noderefresh> [-h| --help | -v | --version]
+B<noderefresh [-h| --help | -v | --version]>
 
-B<noderefresh> <noderange>
+B<noderefresh> I<noderange>
 
 =head1 DESCRIPTION
 
@@ -22,7 +22,7 @@ B<-v|--version>
 
 Command Version.
 
-B<noderange>
+I<noderange>
 
 The nodes to be updated.
 
@@ -34,7 +34,7 @@ The nodes to be updated.
 
 =head1 EXAMPLES
 
-noderefresh compute-000,compute-001
+ noderefresh compute-000,compute-001
 
 =head1 SEE ALSO
 

--- a/xCAT-client/pods/man1/noderm.1.pod
+++ b/xCAT-client/pods/man1/noderm.1.pod
@@ -4,21 +4,19 @@ B<noderm> -Removes the nodes in the noderange from all database table.
 
 =head1 SYNOPSIS
 
-I<noderm [-h| --help]>
+B<noderm [-h| --help]>
 
-
-
-I<noderm noderange>
+B<noderm noderange>
 
 
 =head1 DESCRIPTION
 
- The noderm command removes the nodes in the input node range.
+The noderm command removes the nodes in the input node range.
 
 =head1 OPTIONS
 
 
-B<-h>          Display usage message.
+B<-h|--help>          Display usage message.
 
 
 
@@ -32,7 +30,7 @@ B<-h>          Display usage message.
 
 1. To remove the nodes in noderange node1-node4, enter:
 
-I<noderm node1-node4>
+ noderm node1-node4
 
 
 =head1 FILES

--- a/xCAT-client/pods/man1/nodestat.1.pod
+++ b/xCAT-client/pods/man1/nodestat.1.pod
@@ -4,9 +4,9 @@ B<nodestat> - display the running status of each node in a noderange
 
 =head1 B<Synopsis>
 
-B<nodestat> [I<noderange>] [I<-m>|I<--usemon>] [I<-p>|I<--powerstat>] [I<-f>] [I<-u>|I<--updatedb>]
+B<nodestat> [I<noderange>] [B<-m>|B<--usemon>] [B<-p>|B<--powerstat>] [B<-f>] [B<-u>|B<--updatedb>]
 
-B<nodestat> [I<-h>|I<--help>|I<-v>|I<--version>]
+B<nodestat> [B<-h>|B<--help>|B<-v>|B<--version>]
 
 =head1 B<Description>
 
@@ -86,7 +86,13 @@ Print help.
 
 =head1 B<Examples>
 
-1.  nodestat compute
+=over 2
+
+=item 1.  
+
+ nodestat compute
+
+Output is similar to:
 
  node1   sshd
  node2   sshd
@@ -94,7 +100,11 @@ Print help.
  node4   pbs
  node5   noping
 
-2.  nodestat compute -p
+=item 2.  
+
+ nodestat compute -p
+
+Output is similar to:
 
  node1   sshd
  node2   sshd
@@ -103,7 +113,12 @@ Print help.
  node5   noping(Shutting down)
 
 
-3. nodestat compute -u
+=item 3. 
+
+ nodestat compute -u
+
+Output is similar to:
+ 
  node1   sshd
  node2   sshd
  node3   ping
@@ -111,12 +126,18 @@ Print help.
  node5   noping
 
 
-4. nodestat compute -m
+=item 4. 
+
+ nodestat compute -m
+
+Output is similar to:
+
  node1   ping,sshd,ll,gpfs=ok
  node2   ping,sshd,ll,gpfs=not ok,someapp=something is wrong
  node3   netboot
  node4   noping
 
+=back
 
 =head1 B<See> B<Also>
 

--- a/xCAT-client/pods/man8/winstall.8.pod
+++ b/xCAT-client/pods/man8/winstall.8.pod
@@ -13,7 +13,7 @@ B<winstall> [B<-O>|B<--osimage>] [I<noderange>]
 B<winstall> is a convenience tool that will change attributes as requested for operating system version, profile, and architecture, call B<nodeset> to modify the network boot configuration, call B<rsetboot> net to set the next boot over network (only support nodes
 with "nodetype.mgt=ipmi", for other nodes, make sure the correct boot order has been set before B<winstall>), and B<rpower> to begin a boot cycle.
 
-If [I<-O>|I<--osimage>] is specified or nodetype.provmethod=I<osimage> is set, provision the noderange with the osimage specified/configured, ignore the table change options if specified.
+If [B<-O>|B<--osimage>] is specified or nodetype.provmethod=I<osimage> is set, provision the noderange with the osimage specified/configured, ignore the table change options if specified.
 
 It  will then run wcons on the nodes. 
 

--- a/xCAT-vlan/pods/man1/lsvlan.1.pod
+++ b/xCAT-vlan/pods/man1/lsvlan.1.pod
@@ -16,7 +16,7 @@ B<lsvlan> [B<-v>|B<--version>]
 
 The B<lsvlan> command lists all the vlans for the cluster. If I<vlanid> is specifined it will list more details about this vlan including the nodes in the vlan.  
 
-=head1 Parameters
+=head1 PARAMETERS
 
 I<vlanid> is a unique vlan number. If it is omitted, all vlans will be listed.
 
@@ -42,12 +42,12 @@ I<vlanid> is a unique vlan number. If it is omitted, all vlans will be listed.
 =over 3
 
 =item 1.
-
 To list all the vlans in the cluster
 
   lsvlan
 
 Output is similar to:
+
   vlan 3:
       subnet 10.3.0.0
       netmask 255.255.0.0
@@ -58,12 +58,12 @@ Output is similar to:
 
 
 =item 2.
-
-TO list the details for vlan3
+To list the details for vlan3
 
   lsvlan 3
 
 Output is similar to:
+
   vlan 3
       subnet 10.3.0.0
       netmask 255.255.0.0

--- a/xCAT-vlan/pods/man1/mkvlan.1.pod
+++ b/xCAT-vlan/pods/man1/mkvlan.1.pod
@@ -37,7 +37,7 @@ This command will automatically configure the cross-over ports if the given node
 
 For added security, the root guard and bpdu guard will be enabled for the ports in this vlan. However, the guards will not be disabled if the ports are removed from the vlan using chvlan or rmvlan commands. To disable them, you need to use the switch command line interface. Please refer to the switch command line interface manual to see how to disable the root guard and bpdu guard for a port. 
 
-=head1 Parameters
+=head1 PARAMETERS
 
 I<vlanid> is a unique vlan number. If it is omitted, xCAT will automatically generate the new vlan ID by querying all the switches involved and finding out the smallest common number that is not used by any existing vlans. Use B<lsvlan> to find out the existing vlan ids used by xCAT. 
 
@@ -109,7 +109,7 @@ To make a private vlan for node1, node2 and node3 on eth1,
 
 =item 3.
 
-TO make a private vlan for node1, node2 with given subnet and netmask.
+To make a private vlan for node1, node2 with given subnet and netmask.
 
   mkvlan -n node1,node2,node3 -t 10.3.2.0 -m 255.255.255.0
 


### PR DESCRIPTION
Fixes for man pages in man1 section (commands a-n):
1. POD files modified:
a. Consistent use of italics and bold fonts - bold for fixed options or parameters, italics for user substitutions
b. Consistent EXAMPLES section - examples are numbered, example commands are shows as command text
c. Consistent use of [ ] and { } - bracket for options, braces for choices
d. Various formatting fixes.
2. create_man_pages.py modified to fix generated .rst files
a. Vertical bar fix to not appear as a link in some instances
b. "- -" option fix to not appear as a single long dash. 