### PR TITLE
Fix issue with SGA when creating diskless VMs on PowerKVM

### DIFF
--- a/xCAT-server/lib/xcat/plugins/kvm.pm
+++ b/xCAT-server/lib/xcat/plugins/kvm.pm
@@ -3873,7 +3873,7 @@ sub dohyp {
             return 1, "General error establishing libvirt communication";
         }
     }
-    if (($command eq 'mkvm' or $command eq 'chvm') and $hypconn) {
+    if (($command eq 'mkvm' or $command eq 'chvm' or $command eq 'rpower') and $hypconn) {
         my $nodeinfo = $hypconn->get_node_info();
         if (exists($nodeinfo->{model})) {
             $confdata->{$hyp}->{cpumodel} = $nodeinfo->{model};


### PR DESCRIPTION
When creating a diskless VM, and doing rpower <vm> on, it comes back with ``Error: internal error: qemu does not support SGA``.  The entry useserial is causing this problem. 

This is on power kvm , so we have a check in the build_oshash() to NOT set useserial.  However, when I debugged this, the code is not setting anything in the $confdata.  So I added a condition to set this in dohyp() for the rpower command.  

Address Issue #510 

I think this should also be fixed in 2.11... 