### PR TITLE
Additional small man page fixes

### DIFF
--- a/create_man_pages.py
+++ b/create_man_pages.py
@@ -81,14 +81,12 @@ def cleanup_db_man_pages_dir():
     shutil.rmtree("perl-xCAT/share")
 
 def fix_vertical_bar(rst_file):
-    print "Removing | from file %s, version %s" %(rst_file, man_ver)
     # Verical bar can not appear with spaces around it, otherwise
     # it gets displayed as a link in .html
     sed_cmd = "sed 's/\*\*\\\ |\\\ \*\*/ | /g' %s > %s.sed1" %(rst_file, rst_file)
     os.system(sed_cmd)
 
 def fix_double_dash(rst_file):
-    print "Fixing -- in file %s, version %s" %(rst_file, man_ver)
     # -- gets displayed in .html as a sinle long dash, need to insert
     # a non bold space between 2 dashes
     sed_cmd = "sed '/\*\*/s/--/-\*\*\\\ \*\*-/g' %s.sed1 > %s" %(rst_file, rst_file)

--- a/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
@@ -1103,13 +1103,9 @@ EXAMPLES
    rspconfig cec01 setup_failover=disable
   
    cec01: Success
- 
- 
- \ **rspconfig**\  \ *cec01 setup_failover*\ 
- 
- 
- .. code-block:: perl
- 
+  
+   rspconfig cec01 setup_failover
+  
    cec01: Failover status: Disabled
  
  

--- a/docs/source/guides/admin-guides/references/man1/switchdiscover.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/switchdiscover.1.rst
@@ -149,7 +149,7 @@ EXAMPLES
 
 3.
  
- To use lldp mathod to discover the switches:
+ To use lldp method to discover the switches:
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man1/updatenode.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/updatenode.1.rst
@@ -19,7 +19,7 @@ SYNOPSIS
 ********
 
 
-\ **updatenode**\  \ *noderange*\  [\ **-V | -**\ **-verbose**\ ] [\ **-F | -**\ **-sync**\ ] [\ **-f | -**\ **-snsync**\ ] [\ **-S | -**\ **-sw**\ ]  [\ **-l**\   \ *userID*\ ]  [\ **-P | -**\ **-scripts**\  [\ *script1,script2...*\ ]] [\ **-s | -**\ **-sn**\ ] [\ **-A | -**\ **-updateallsw**\ ] [\ **-c | -**\ **-cmdlineonly**\ ] [\ **-d**\  \ *alt_source_dir*\ ] [\ **-**\ **-fanout**\ ] [\ **-ti**\  \ *timeout*\ } [\ *attr=val*\  [\ *attr=val...*\ ]] [\ **-n | -**\ **-noverify**\ ]
+\ **updatenode**\  \ *noderange*\  [\ **-V | -**\ **-verbose**\ ] [\ **-F | -**\ **-sync**\ ] [\ **-f | -**\ **-snsync**\ ] [\ **-S | -**\ **-sw**\ ]  [\ **-l**\   \ *userID*\ ]  [\ **-P | -**\ **-scripts**\  [\ *script1,script2...*\ ]] [\ **-s | -**\ **-sn**\ ] [\ **-A | -**\ **-updateallsw**\ ] [\ **-c | -**\ **-cmdlineonly**\ ] [\ **-d**\  \ *alt_source_dir*\ ] [\ **-**\ **-fanout**\ =\ *fanout_value*\ ] [\ **-t**\  \ *timeout*\ } [\ *attr=val*\  [\ *attr=val...*\ ]] [\ **-n | -**\ **-noverify**\ ]
 
 \ **updatenode**\  \ **noderange**\  [\ **-k | -**\ **-security**\ ] [\ **-t**\  \ *timeout*\ ]
 
@@ -353,8 +353,7 @@ OPTIONS
  
  Specifies a fanout value for the maximum number of  concur-
  rently  executing  remote shell processes. Serial execution
- can be specified by indicating a fanout value of \ **1**\ .  If  \ **-**\ **-fanout**\ 
- is not specified, a default fanout value of \ **64**\  is used.
+ can be specified by indicating a fanout value of \ **1**\ .  If \ **-**\ **-fanout**\  is not specified, a default fanout value of \ **64**\  is used.
  
 
 

--- a/docs/source/guides/admin-guides/references/man8/rinstall.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/rinstall.8.rst
@@ -19,7 +19,7 @@ Name
 ****************
 
 
-\ **rinstall**\  [\ **-O | -**\ **-osimage**\ ] [\ **-c | -**\ **-console**\ ] [\ **noderange**\ ]
+\ **rinstall**\  [\ **-O | -**\ **-osimage**\ ] [\ **-c | -**\ **-console**\ ] [\ *noderange*\ ]
 
 
 *******************

--- a/xCAT-client/pods/man1/rspconfig.1.pod
+++ b/xCAT-client/pods/man1/rspconfig.1.pod
@@ -740,7 +740,7 @@ To disable service processor failover for cec01, in order to complete this comma
 
  cec01: Success
 
-B<rspconfig> I<cec01 setup_failover>
+ rspconfig cec01 setup_failover
 
  cec01: Failover status: Disabled
 

--- a/xCAT-client/pods/man1/switchdiscover.1.pod
+++ b/xCAT-client/pods/man1/switchdiscover.1.pod
@@ -105,7 +105,7 @@ It is recommended to run B<makehosts> after the switches are saved in the DB.
 
 =item 3.
 
-To use lldp mathod to discover the switches:
+To use lldp method to discover the switches:
 
  switchdiscover -s lldp
 

--- a/xCAT-client/pods/man1/updatenode.1.pod
+++ b/xCAT-client/pods/man1/updatenode.1.pod
@@ -4,7 +4,7 @@ B<updatenode> - Update nodes in an xCAT cluster environment.
 
 =head1 SYNOPSIS
 
-B<updatenode> I<noderange> [B<-V>|B<--verbose>] [B<-F>|B<--sync>] [B<-f>|B<--snsync>] [B<-S>|B<--sw>]  [B<-l>  I<userID>]  [B<-P>|B<--scripts> [I<script1,script2...>]] [B<-s>|B<--sn>] [B<-A>|B<--updateallsw>] [B<-c>|B<--cmdlineonly>] [B<-d> I<alt_source_dir>] [B<--fanout>] [B<-ti> I<timeout>} [I<attr=val> [I<attr=val...>]] [B<-n>|B<--noverify>]
+B<updatenode> I<noderange> [B<-V>|B<--verbose>] [B<-F>|B<--sync>] [B<-f>|B<--snsync>] [B<-S>|B<--sw>]  [B<-l>  I<userID>]  [B<-P>|B<--scripts> [I<script1,script2...>]] [B<-s>|B<--sn>] [B<-A>|B<--updateallsw>] [B<-c>|B<--cmdlineonly>] [B<-d> I<alt_source_dir>] [B<--fanout>=I<fanout_value>] [B<-t> I<timeout>} [I<attr=val> [I<attr=val...>]] [B<-n>|B<--noverify>]
 
 B<updatenode> B<noderange> [B<-k>|B<--security>] [B<-t> I<timeout>]
 
@@ -272,8 +272,7 @@ maintenance support.
 
 Specifies a fanout value for the maximum number of  concur-
 rently  executing  remote shell processes. Serial execution
-can be specified by indicating a fanout value of B<1>.  If  B<--fanout>
-is not specified, a default fanout value of B<64> is used.
+can be specified by indicating a fanout value of B<1>.  If B<--fanout> is not specified, a default fanout value of B<64> is used.
 
 =item B<-A|--updateallsw>
 

--- a/xCAT-client/pods/man8/rinstall.8.pod
+++ b/xCAT-client/pods/man8/rinstall.8.pod
@@ -4,7 +4,7 @@ B<rinstall> - Begin OS provision on a noderange
 
 =head1 B<Synopsis>
 
-B<rinstall> [B<-O>|B<--osimage>] [B<-c>|B<--console>] [B<noderange>]
+B<rinstall> [B<-O>|B<--osimage>] [B<-c>|B<--console>] [I<noderange>]
 
 =head1 B<Description>
 
@@ -42,7 +42,7 @@ Requests that rinstall runs rcons once the provision starts.  This will only wor
 =over 2
 
 =item 1.
-Provison nodes 1 through 20, using their current configuration.
+Provision nodes 1 through 20, using their current configuration.
 
  rinstall node1-node20
 
@@ -52,7 +52,7 @@ Provision nodes 1 through 20 with the osimage rhels6.4-ppc64-netboot-compute.
  rinstall node1-node20 -O rhels6.4-ppc64-netboot-compute
 
 =item 3.
-Provisoon node1 and start a console to monitor the process.
+Provision node1 and start a console to monitor the process.
 
  rinstall node1 -c
 


### PR DESCRIPTION
Remove "print" from create_man_pages script and fix small spelling and formatting errors.