### PR TITLE
Missed checkin of rinstall.rst file

### DIFF
--- a/docs/source/guides/admin-guides/references/man8/rinstall.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/rinstall.8.rst
@@ -71,7 +71,7 @@ If -c is specified, it will then run rcons on the node. This is allowed only if 
 
 
 
-1. Provison nodes 1 through 20, using their current configuration.
+1. Provision nodes 1 through 20, using their current configuration.
  
  
  .. code-block:: perl
@@ -91,7 +91,7 @@ If -c is specified, it will then run rcons on the node. This is allowed only if 
  
 
 
-3. Provisoon node1 and start a console to monitor the process.
+3. Provision node1 and start a console to monitor the process.
  
  
  .. code-block:: perl


### PR DESCRIPTION
Somehow previous man page fixes checkins missed this .rst file which just fixes spelling.