### PR TITLE
Fix defect #698 Default permissions on commands.log are 644, should change to 600

### DIFF
--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -1057,7 +1057,7 @@ unless ($cmdlog_svrpid){
 
     $SIG{USR2} = sub {
         while($writing){sleep(0.01);}
-        if($cmdlogfile){close($cmdlogfile);umask($cmdlog_logfile_umask);}
+        if($cmdlogfile){close($cmdlogfile);}
         if($clientsock){close($clientsock);}
         if( -e $cmdlogservicefile){ unlink("$cmdlogservicefile");}
         if($cmdlogsvrlistener){close($cmdlogsvrlistener);}
@@ -1067,7 +1067,7 @@ unless ($cmdlog_svrpid){
 
     $SIG{TERM} = $SIG{INT} = sub {
         while($writing){sleep(0.01);}
-        if($cmdlogfile){close($cmdlogfile);umask($cmdlog_logfile_umask);}
+        if($cmdlogfile){close($cmdlogfile);}
         if($clientsock){close($clientsock);}
         if( -e $cmdlogservicefile){ unlink("$cmdlogservicefile");}
         if($cmdlogsvrlistener){close($cmdlogsvrlistener);}
@@ -1096,7 +1096,6 @@ unless ($cmdlog_svrpid){
         }
         if(!$trytime){
             xCAT::MsgUtils->message("S","INFO xcatd: 'Command log writer' process $$ get HUP signal, reopen commands.log file failed, send TERM signal to kill itself");
-            umask($cmdlog_logfile_umask);
             kill 'INT', $$;
         }else{
             xCAT::MsgUtils->message("S","INFO xcatd: 'Command log writer' process $$ get HUP signal, reopen commands.log file");
@@ -1141,10 +1140,12 @@ unless ($cmdlog_svrpid){
 
     $cmdlog_logfile_umask = umask(0077);
     unless (open ($cmdlogfile, ">>$cmdlog_logfile")) {
+        umask($cmdlog_logfile_umask);
         xCAT::MsgUtils->trace(0,"E","xcatd: Can't open xcat command log file $cmdlog_logfile,command log process $$ stop.");
         if($cmdlogsvrlistener){close($cmdlogsvrlistener);}
         exit(0);
     }
+    umask($cmdlog_logfile_umask);
     select($cmdlogfile);
     $|=1;
     $cmdlogfileswitch=1;
@@ -1167,7 +1168,7 @@ unless ($cmdlog_svrpid){
         $writing=0;
     }
 
-    if($cmdlogfile){close($cmdlogfile);umask($cmdlog_logfile_umask);}
+    if($cmdlogfile){close($cmdlogfile);}
     if($cmdlogsvrlistener){close($cmdlogsvrlistener);}
     xCAT::MsgUtils->message("S","INFO xcatd: 'Command log writer' process $$ stop");
 }

--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -1112,7 +1112,7 @@ unless ($cmdlog_svrpid){
         xCAT::MsgUtils->message("S","INFO xcatd: 'Command log writer' process $$ is trying to get port $cmdlog_port");
         my $pid = <$cmdlogpidfile>;
         if ($pid) {
-            kill 'USR2',  $pid;
+            kill 'USR2', $pid;
         }
         close($cmdlogpidfile);
     }
@@ -1140,10 +1140,8 @@ unless ($cmdlog_svrpid){
 
     $cmdlog_logfile_umask = umask(0077);
     unless (open ($cmdlogfile, ">>$cmdlog_logfile")) {
-        umask($cmdlog_logfile_umask);
         xCAT::MsgUtils->trace(0,"E","xcatd: Can't open xcat command log file $cmdlog_logfile,command log process $$ stop.");
-        if($cmdlogsvrlistener){close($cmdlogsvrlistener);}
-        exit(0);
+        exit(1);
     }
     umask($cmdlog_logfile_umask);
     select($cmdlogfile);

--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -1053,10 +1053,11 @@ unless ($cmdlog_svrpid){
     my $writing=0;
     my $cmdlogfileswitch=0;
     my $cmdlogservicefile="/var/run/xcat/cmdlogservice.pid";
+    my $cmdlog_logfile_umask;
 
     $SIG{USR2} = sub {
         while($writing){sleep(0.01);}
-        if($cmdlogfile){close($cmdlogfile);}
+        if($cmdlogfile){close($cmdlogfile);umask($cmdlog_logfile_umask);}
         if($clientsock){close($clientsock);}
         if( -e $cmdlogservicefile){ unlink("$cmdlogservicefile");}
         if($cmdlogsvrlistener){close($cmdlogsvrlistener);}
@@ -1066,7 +1067,7 @@ unless ($cmdlog_svrpid){
 
     $SIG{TERM} = $SIG{INT} = sub {
         while($writing){sleep(0.01);}
-        if($cmdlogfile){close($cmdlogfile);}
+        if($cmdlogfile){close($cmdlogfile);umask($cmdlog_logfile_umask);}
         if($clientsock){close($clientsock);}
         if( -e $cmdlogservicefile){ unlink("$cmdlogservicefile");}
         if($cmdlogsvrlistener){close($cmdlogsvrlistener);}
@@ -1095,7 +1096,8 @@ unless ($cmdlog_svrpid){
         }
         if(!$trytime){
             xCAT::MsgUtils->message("S","INFO xcatd: 'Command log writer' process $$ get HUP signal, reopen commands.log file failed, send TERM signal to kill itself");
-            kill 2, $$;
+            umask($cmdlog_logfile_umask);
+            kill 'INT', $$;
         }else{
             xCAT::MsgUtils->message("S","INFO xcatd: 'Command log writer' process $$ get HUP signal, reopen commands.log file");
         }
@@ -1111,7 +1113,7 @@ unless ($cmdlog_svrpid){
         xCAT::MsgUtils->message("S","INFO xcatd: 'Command log writer' process $$ is trying to get port $cmdlog_port");
         my $pid = <$cmdlogpidfile>;
         if ($pid) {
-            kill 12, $pid;
+            kill 'USR2',  $pid;
         }
         close($cmdlogpidfile);
     }
@@ -1129,9 +1131,15 @@ unless ($cmdlog_svrpid){
         exit(0);
     }
 
+    open($cmdlogpidfile,">$cmdlogservicefile");
+    print $cmdlogpidfile $$;
+    close($cmdlogpidfile);
+    xCAT::MsgUtils->trace(0,"I","xcatd: command log process $$ start");
+
     my $cmdlog_logfile_path=dirname($cmdlog_logfile);
     mkpath("$cmdlog_logfile_path") unless(-d "$cmdlog_logfile_path");
 
+    $cmdlog_logfile_umask = umask(0077);
     unless (open ($cmdlogfile, ">>$cmdlog_logfile")) {
         xCAT::MsgUtils->trace(0,"E","xcatd: Can't open xcat command log file $cmdlog_logfile,command log process $$ stop.");
         if($cmdlogsvrlistener){close($cmdlogsvrlistener);}
@@ -1140,11 +1148,6 @@ unless ($cmdlog_svrpid){
     select($cmdlogfile);
     $|=1;
     $cmdlogfileswitch=1;
-
-    open($cmdlogpidfile,">$cmdlogservicefile");
-    print $cmdlogpidfile $$;
-    close($cmdlogpidfile);
-    xCAT::MsgUtils->trace(0,"I","xcatd: command log process $$ start");
 
     while (1)
     {
@@ -1164,7 +1167,7 @@ unless ($cmdlog_svrpid){
         $writing=0;
     }
 
-    if($cmdlogfile){close($cmdlogfile);}
+    if($cmdlogfile){close($cmdlogfile);umask($cmdlog_logfile_umask);}
     if($cmdlogsvrlistener){close($cmdlogsvrlistener);}
     xCAT::MsgUtils->message("S","INFO xcatd: 'Command log writer' process $$ stop");
 }


### PR DESCRIPTION
Depending on defect #698,  I changed the permissions of /var/log/xcat/commands.log to 600