### PR TITLE
Set the FQDN in the xcatd certificate, use subjectAltNames

### DIFF
--- a/xCAT-server/share/xcat/ca/openssl.cnf.tmpl
+++ b/xCAT-server/share/xcat/ca/openssl.cnf.tmpl
@@ -225,6 +225,9 @@ authorityKeyIdentifier=keyid,issuer
 basicConstraints = CA:FALSE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 
+[ san_env ]
+subjectAltaName = ${ENV::SAN}
+
 [ v3_ca ]
 
 

--- a/xCAT-server/share/xcat/scripts/setup-server-cert.sh
+++ b/xCAT-server/share/xcat/scripts/setup-server-cert.sh
@@ -23,6 +23,7 @@ fi
 mkdir -p $XCATDIR/cert
 cd $XCATDIR/cert
 openssl genrsa -out server-key.pem 2048
+export SAN=DNS:`hostname --long`,DNS:`hostname --short`
 openssl req -config $XCATCADIR/openssl.cnf -new -key server-key.pem -out server-req.pem -extensions server -subj "/CN=$CNA"
 cp server-req.pem  $XCATDIR/ca/`hostname`.csr
 cd -
@@ -33,7 +34,7 @@ cd $XCATDIR/ca
 #   - call cmds directly instead - seems safe
 # make sign
 
-openssl ca -startdate 600101010101Z -config openssl.cnf -in `hostname`.csr -out `hostname`.cert -extensions server
+openssl ca -startdate 600101010101Z -config openssl.cnf -in `hostname`.csr -out `hostname`.cert -extensions server -extensions san_env
 if [ -f `hostname`.cert ]; then
     rm `hostname`.csr
 fi


### PR DESCRIPTION
Add subjectAltName in openssl.cnf, set subjectAltName as FQDN and PQDN.
The subject 'SAN' (subjectAltName) used in the certificate can indicate the identity of the server, including FQDN and PQDN.