### PR TITLE
Fix issue 755: Disable the module which is using HTML::Form (only for 2.9 branch)

### DIFF
--- a/perl-xCAT/xCAT/PPCfsp.pm
+++ b/perl-xCAT/xCAT/PPCfsp.pm
@@ -5,7 +5,6 @@ use strict;
 use Getopt::Long;
 use LWP;
 use HTTP::Cookies;
-use HTML::Form;
 use xCAT::PPCcli qw(SUCCESS EXPECT_ERROR RC_ERROR NR_ERROR);
 use xCAT::Usage;
 use Socket;
@@ -53,6 +52,11 @@ sub handler {
     my $request = shift;
     my $exp     = shift;
     my $flag    = shift;
+
+    eval { require HTML::Form };
+    if ( $@ ) {
+       return("FSP direct access has been deprecated.");
+    }
 
     #####################################
     # Convert command to correct format


### PR DESCRIPTION
Since the perl module HTML::Form has been removed from default perl install and xCAT has deprecated the features which is using HTML::Form to runn direct fsp access, the fix is to require the HTML::Form module when using it. If the require operation fails, just display a message.

This fix is for #755.