### PR TITLE
Make auto test environment stop when one key test case failed, keep environment for debug

### DIFF
--- a/xCAT-server/share/xcat/tools/xCATreg
+++ b/xCAT-server/share/xcat/tools/xCATreg
@@ -39,7 +39,7 @@ BEGIN
 use lib "$::XCATROOT/lib/perl";
 
 my $date;
-my $regrootdir="/autotest/xCATreg/";
+my $regrootdir="/home/autotest_code";
 my $mailtitle="PPC64LE Cluster";
 #my $regrootdir="/xCATreg";
 #my $mailtitle="X Cluster";

--- a/xCAT-server/share/xcat/tools/xCATreg
+++ b/xCAT-server/share/xcat/tools/xCATreg
@@ -736,7 +736,7 @@ sub do_test {
                 $batbundle="le_ubuntu_cmd.bundle" if($mn =~ /ubuntuEL/);
         }	
         if(($mn !~ /ubuntu/) && ($mn !~ /E/)){
-            for(my $loop=0; $loop<1; $loop++){
+            {
                 my $rc;
 
 		#diskfull installation in flat mode test
@@ -845,7 +845,7 @@ sub do_test {
                 $casestop=0;
         }		
     }else{
-         for(my $loop=0; $loop<1; $loop++){
+        {
                 my $rc=0;
 
 		#diskless installation in flat mode test		

--- a/xCAT-server/share/xcat/tools/xCATreg
+++ b/xCAT-server/share/xcat/tools/xCATreg
@@ -39,7 +39,7 @@ BEGIN
 use lib "$::XCATROOT/lib/perl";
 
 my $date;
-my $regrootdir="/home/autotest_code";
+my $regrootdir="/autotest/xCATreg/";
 my $mailtitle="PPC64LE Cluster";
 #my $regrootdir="/xCATreg";
 #my $mailtitle="X Cluster";
@@ -690,6 +690,8 @@ sub install_xcat {
 sub do_test {
     my $mn = shift;
     my $os = $confkeys{$mn."os"};
+    my $casestop=1;
+
     send_msg(2, "[$mn->$confkeys{$mn}][do_test] starting to run regression test in $confkeys{$mn}");  
 	
 	my $regconf=$mn.".conf";
@@ -734,25 +736,32 @@ sub do_test {
                 $batbundle="le_ubuntu_cmd.bundle" if($mn =~ /ubuntuEL/);
         }	
         if(($mn !~ /ubuntu/) && ($mn !~ /E/)){
+            for(my $loop=0; $loop<1; $loop++){
+                my $rc;
+
 		#diskfull installation in flat mode test
 		send_msg(2, "[$mn->$confkeys{$mn}][do_test] doing diskfull installation test in flat mode in $mn.....");
-		system("xdsh $confkeys{$mn} \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -t $diskfull_installation_flat_testcase\" >/dev/null 2>&1");
+		$rc=system("xdsh $confkeys{$mn} \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -t $diskfull_installation_flat_testcase\" >/dev/null 2>&1");
 		send_msg(2, "[$mn->$confkeys{$mn}][do_test] do diskfull installation test in flat mode in $mn.....[done]");
+                last if($rc != 0);
 
 		#commands bundle in flat mode test
 		send_msg(2, "[$mn->$confkeys{$mn}][do_test] doing all commands test in flat mode in $mn.....");
-		system("xdsh $confkeys{$mn} \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -b $batbundle\" >/dev/null 2>&1");
+                $rc=system("xdsh $confkeys{$mn} \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -b $batbundle\" >/dev/null 2>&1");
 		send_msg(2, "[$mn->$confkeys{$mn}][do_test] do all commands test in flat mode in $mn.....[done]");
+                last if($rc != 0);
 
 		#diskless installation in flat mode test		
 		send_msg(2, "[$mn->$confkeys{$mn}][do_test] doing diskless installation test in flat mode in $mn.....");
-		system("xdsh $confkeys{$mn} \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -t $diskless_installation_flat_testcase\" >/dev/null 2>&1");
+		$rc=system("xdsh $confkeys{$mn} \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -t $diskless_installation_flat_testcase\" >/dev/null 2>&1");
 		send_msg(2, "[$mn->$confkeys{$mn}][do_test] do diskless installation test in flat mode in $mn.....[done]");	
+                last if($rc != 0);
 	
 		#statelite installation in flat mode test
 		send_msg(2, "[$mn->$confkeys{$mn}][do_test] doing statelite installation test in flat mode in $mn.....");
-		system("xdsh $confkeys{$mn} \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -t $statelite_installation_flat_testcase\" >/dev/null 2>&1");
+		$rc=system("xdsh $confkeys{$mn} \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -t $statelite_installation_flat_testcase\" >/dev/null 2>&1");
 		send_msg(2, "[$mn->$confkeys{$mn}][do_test] do statelite installation test in flat mode in $mn.....[done]");
+                last if($rc != 0);
 
 		#deploy SN
 		send_msg(2, "[$mn->$confkeys{$mn}][do_test] setting up mysql for installing SN in $mn.....");
@@ -813,40 +822,57 @@ sub do_test {
 		}
 		
 		send_msg(2, "[$mn->$confkeys{$mn}][do_test] installing SN.....");
-		system("xdsh $confkeys{$mn} \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -t $sn_installation_hierarchy_testcase\" >/dev/null 2>&1");
+		$rc=system("xdsh $confkeys{$mn} \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -t $sn_installation_hierarchy_testcase\" >/dev/null 2>&1");
 		send_msg(2, "[$mn->$confkeys{$mn}][do_test] install SN.....[done]");
+                last if($rc != 0);
 		
 		#diskfull installation in hierarchy mode test
 		send_msg(2, "[$mn->$confkeys{$mn}][do_test] doing diskfull installation test in hierarchy mode in $mn.....");
-		system("xdsh $confkeys{$mn} \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -t $diskfull_installation_hierarchy_testcase\" >/dev/null 2>&1");
+		$rc=system("xdsh $confkeys{$mn} \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -t $diskfull_installation_hierarchy_testcase\" >/dev/null 2>&1");
 		send_msg(2, "[$mn->$confkeys{$mn}][do_test] do diskfull installation test in hierarchy mode in $mn.....[done]");
-		
+                last if($rc != 0);
+
 		#diskless installation in hierarchy mode test
 		send_msg(2, "[$mn->$confkeys{$mn}][do_test] doing diskless installation test in hierarchy mode in $mn.....");
-		system("xdsh $confkeys{$mn} \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -t $diskless_installation_hierarchy_testcase\" >/dev/null 2>&1");
+		$rc=system("xdsh $confkeys{$mn} \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -t $diskless_installation_hierarchy_testcase\" >/dev/null 2>&1");
 		send_msg(2, "[$mn->$confkeys{$mn}][do_test] do diskless installation test in hierarchy mode in $mn.....[done]");
+                last if($rc != 0);
 
 		#statelite installation in hierarchy mode test
 		send_msg(2, "[$mn->$confkeys{$mn}][do_test] doing statelite installation test in hierarchy mode in $mn.....");
 		system("xdsh $confkeys{$mn} \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -t $statelite_installation_hierarchy_testcase\" >/dev/null 2>&1");
 		send_msg(2, "[$mn->$confkeys{$mn}][do_test] do statelite installation test in hierarchy mode in $mn.....[done]");	
-		
+                $casestop=0;
+        }		
     }else{
+         for(my $loop=0; $loop<1; $loop++){
+                my $rc=0;
+
 		#diskless installation in flat mode test		
 		send_msg(2, "[$mn->$confkeys{$mn}][do_test] doing diskless installation test in flat mode in $mn.....");
-		system("ssh -t $confkeys{$mn} 'exec bash -l -i -c \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -t $diskless_installation_flat_testcase\"' >/dev/null 2>&1");
+		$rc=system("ssh -t $confkeys{$mn} 'exec bash -l -i -c \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -t $diskless_installation_flat_testcase\"' >/dev/null 2>&1");
 		send_msg(2, "[$mn->$confkeys{$mn}][do_test] do diskless installation test in flat mode in $mn.....[done]");
+                last if($rc != 0);
 
                 #diskfull installation in flat mode test
                 send_msg(2, "[$mn->$confkeys{$mn}][do_test] doing diskfull installation test in flat mode in $mn.....");
-                system("ssh -t $confkeys{$mn} 'exec bash -l -i -c \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -t $diskfull_installation_flat_testcase\"' >/dev/null 2>&1");
+                $rc=system("ssh -t $confkeys{$mn} 'exec bash -l -i -c \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -t $diskfull_installation_flat_testcase\"' >/dev/null 2>&1");
                 send_msg(2, "[$mn->$confkeys{$mn}][do_test] do diskfull installation test in flat mode in $mn.....[done]");
+                last if($rc != 0);
 
                 #commands bundle in flat mode test
                 send_msg(2, "[$mn->$confkeys{$mn}][do_test] doing all commands test in flat mode in $mn.....");
-                system("ssh -t $confkeys{$mn} 'exec bash -l -i -c \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -b $batbundle\"' >/dev/null 2>&1");
+                $rc=system("ssh -t $confkeys{$mn} 'exec bash -l -i -c \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -b $batbundle\"' >/dev/null 2>&1");
                 send_msg(2, "[$mn->$confkeys{$mn}][do_test] do all commands test in flat mode in $mn.....[done]");
+                $casestop=0;
 	}
+    }
+
+    if($casestop){
+        send_msg(2, "[$mn->$confkeys{$mn}][do_test] the regression job in $mn was broken by one case.");
+    }else{
+        send_msg(2, "[$mn->$confkeys{$mn}][do_test] run the whole regression test in $mn finished");
+    }
 	
     send_msg(2, "[$mn->$confkeys{$mn}][install_xcat] run regression test in $mn finished");
 	
@@ -962,8 +988,14 @@ sub creat_report{
 
 			closedir(DIR);
 
+                        my $lastfile = `ls -lrt $todayregresultdir/$k|grep "xcattest.log"|tail -1|awk '{print \$9}'`;
+                        chomp($lastfile);
+                        my $lastline=`cat $todayregresultdir/$k/$lastfile |grep -- "------END::"|tail -1`;
+                        chomp($lastline);
+                        my $lastcase;
+                        $lastcase=$1 if($lastline =~ /------END::([a-zA-Z0-9_-]+)::([a-zA-Z0-9_-]+)::Time.+/);
 
-			$mailreport .= "\tTotalCase $totalcase TotalRun $totalcnt Failed $failcnt\n\tFailed cases: $faillist\n";
+                        $mailreport .= "\tTotalCase $totalcase TotalRun $totalcnt Failed $failcnt\n\tFailed cases: $faillist\n\tFinal environment stop at $lastcase\n";
 		}else{ # regression test out of time
 			$mailreport .= "\tTime consumption: Out of 9 hours!!!!!!\n";
 		}

--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -59,6 +59,7 @@ if($needshow){
 }
 
 my $resultdir = "$rootdir/result";
+my $stop_to_keep_env = 0;
 #Create result directory
 mkdir $resultdir unless -d $resultdir;
 
@@ -106,7 +107,11 @@ close(LOG_ERR);
 my $reportfile="$resultdir/performance.report.$timestamp";
 my $tmpreport="$resultdir/xcattest.log.$timestamp";
 &getreport($tmpreport,$reportfile);
-exit 0;
+if($stop_to_keep_env){
+    exit 1;
+}else{
+    exit 0;
+}
 
 # end main
 
@@ -584,6 +589,9 @@ sub loadcase
                     pop(@rightcase);
                     $skip = 1;
                 }
+            }elsif($line =~ /^stop\s*:\s*(\w[\w\,]+)/){
+                next if $skip;
+                $cases[$i]->{stop}=$1;
             }elsif($line =~ /^cmd\s*:\s*([\$\w].+)/){
                 next if $skip;
                 $j = $j + 1;
@@ -859,6 +867,10 @@ sub runcase
         if($failed){
             $failnum = $failnum + 1;
             log_error(@record);
+            if($$case{stop} =~ /^yes$/){
+                $stop_to_keep_env=1;
+                last;
+            }
         }
     }
     log_this("\n\n");


### PR DESCRIPTION
This pull request add a feature for current auto test environment,  when one key test case failed, the whole auto test stop for keeping environment to debug.

Usage:
If you think one test case is very important,  you can add a label ``stop=yes`` in this test case. Take test case ``lsdef_t_o_l``  for example, you can edit it like below:

    start:lsdef_t_o_l
    description: lsdef -o -l
    stop:yes
    cmd:mkdef -t node -o testnode groups=all
    check:rc==0
    cmd:mkdef -t network -o testnetwork net=1.2.3.0 mask=255.255.255.0
    .....
    end

when  ``lsdef_t_o_l`` failed.  you will get report in mail like below:

    [rhels6.5+PPC64]
	    Time consumption: 0 hours 0 minutes 19 seconds
	    TotalCase 7 TotalRun 3 Failed 2
	    Failed cases: lsdef_null, lsdef_t_o_l,
	    Final environment stop at lsdef_t_o_l

``Final environment stop at`` label will indicate the whole auto test environment stop at which case.

Some important things:
1. If the all test cases complete without breaking, the ``Final environment stop at`` label will indicate the last one case we plan to run
2. If there are some unimportant test case (without ``stop=yes`` label)  failed before the key test case. these case's name still appear in ``Failed cases:`` list and be counted into failed case in report mail. ``TotalRun`` will indicate how many cases we have run before breaking.