### PR TITLE
Suppress invalid mac data

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -3772,13 +3772,17 @@ sub parseboard {
 	#time to process the mac field...
 	my $macdata = $boardinf{extra}->[6]->{value};
         my $macstring = "1";
+	my $macprefix;
 	while ($macstring !~ /00:00:00:00:00:00/ and not ref $global_sessdata->{currmacs}) {
             my @currmac = splice @$macdata,0,6;
             unless ((scalar @currmac) == 6) {
                 last;
             }
             $macstring = sprintf("%02x:%02x:%02x:%02x:%02x:%02x",@currmac);
-            if ($macstring !~ /00:00:00:00:00:00/) { 
+	    unless ($macprefix) {
+	    	$macprefix = substr($macstring, 0, 8);
+	    }
+            if ($macstring !~ /00:00:00:00:00:00/ and $macstring =~/^$macprefix/) { 
                 push @{$boardinf{macaddrs}},$macstring;
             }
         }


### PR DESCRIPTION
Sometimes a FRU MAC address area may have
unitialized data for irrelevant portion.
Mask by filtering out scenarios where
mfg OUI changes for a single NIC, which
is never the case.