### PR TITLE
Add support for parsing pkvm version from .discinfo when doing copycds

### DIFF
--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -2180,7 +2180,16 @@ sub copycd
 
     unless ($distname)
     {
-        return;    #Do nothing, not ours..
+        if ($desc =~ /IBM_PowerKVM/)
+        {
+            # check for PowerKVM support
+            my @pkvm_version = split / /, $desc;
+            $distname = "pkvm" . $pkvm_version[1];
+        }
+        else
+        {
+            return;    #Do nothing, not ours..
+        }
     }
     if ($darch)
     {


### PR DESCRIPTION
Fix Issue #752 

Add code to automatically check the .discinfo file for IBM_PowerKVM and use the version that is after that tag. 

Example content:
```
1447791280.952507
IBM_PowerKVM 3.1.0
ppc64le
1
```