### PR TITLE
[FVT]Automation Case: Add analyze xCAT log file case to track known error even the OS is installed successfully 

### DIFF
--- a/xCAT-test/autotest/testcase/analyze_log/case0
+++ b/xCAT-test/autotest/testcase/analyze_log/case0
@@ -1,0 +1,10 @@
+start:check_mn_cluster_log_file
+os:linux,only support redhat and sles
+description:check known error message in /var/log/xcat/cluster.log file
+cmd:cat /var/log/xcat/cluster.log | grep "xcatd: Error happened when receiving data from DB access"
+check:output!~xcatd: Error happened when receiving data from DB access
+cmd:cat /var/log/xcat/cluster.log | grep "Undefined subroutine &main"
+check:output!~ "Undefined subroutine &main"
+cmd:cat /var/log/xcat/cluster.log | grep "xcatd: possible BUG encountered by xCAT UDP service"
+check:output!~"xcatd: possible BUG encountered by xCAT UDP service"
+end

--- a/xCAT-test/autotest/testcase/analyze_log/case0
+++ b/xCAT-test/autotest/testcase/analyze_log/case0
@@ -1,6 +1,6 @@
 start:check_mn_cluster_log_file
-os:linux,only support redhat and sles
-description:check known error message in /var/log/xcat/cluster.log file
+os:Linux
+description:check known error message in /var/log/xcat/cluster.log file. Only for redhat and sles.
 cmd:cat /var/log/xcat/cluster.log | grep "xcatd: Error happened when receiving data from DB access"
 check:output!~xcatd: Error happened when receiving data from DB access
 cmd:cat /var/log/xcat/cluster.log | grep "Undefined subroutine &main"


### PR DESCRIPTION
@tingtli 

Here is the case used to track the known error message even the OS is installed successfully.
Would you please review it.
