### PR TITLE
Changes to support installing xCAT on Ubuntu 16.04 to unblock #790

### DIFF
--- a/build-ubunturepo
+++ b/build-ubunturepo
@@ -63,7 +63,7 @@ for i in $*; do
 done
 
 # Supported distributions
-dists="saucy trusty utopic"
+dists="saucy trusty utopic xenial"
 
 c_flag=            # xcat-core (trunk-delvel) path
 d_flag=            # xcat-dep (trunk) path
@@ -287,12 +287,13 @@ then
     mkdir conf
 
     for dist in $dists; do
-       if [ "$dist" = "trusty" ] || [ "$dist" = "utopic" ]; then
-           tmp_out_arch="amd64 ppc64el"
-       else
-           tmp_out_arch="amd64"
-       fi
-       cat << __EOF__ >> conf/distributions
+        # for all releases moving forward, support amd64 and ppc64el
+        tmp_out_arch="amd64 ppc64el"
+        if [ "$dist" = "saucy" ]; then
+            # for older releases of Ubuntu that does not support ppc64el
+            tmp_out_arch="amd64"
+        fi
+        cat << __EOF__ >> conf/distributions
 Origin: xCAT internal repository
 Label: xcat-core bazaar repository
 Codename: $dist
@@ -314,14 +315,14 @@ __EOF__
     amd_files=`ls ../$package_dir_name/*.deb | grep -v "ppc64el"`
     all_files=`ls ../$package_dir_name/*.deb`
     for dist in $dists; do
-      if [ "$dist" = "trusty" ] || [ "$dist" = "utopic" ]; then
-          deb_files=$all_files
-      else
-          deb_files=$amd_files
-      fi
-      for file in $deb_files; do
-	reprepro -b ./ includedeb $dist $file;
-      done
+        deb_files=$all_files
+        if [ "$dist" = "saucy" ]; then
+            # for older releases of Ubuntu that does not support ppc64el
+            deb_files=$amd_files
+        fi
+        for file in $deb_files; do
+            reprepro -b ./ includedeb $dist $file;
+        done
     done
     #create the mklocalrepo script
     cat << '__EOF__' > mklocalrepo.sh
@@ -416,11 +417,11 @@ then
 
     #create the conf/distributions file
     for dist in $dists; do
-       if [ "$dist" = "trusty" ] || [ "$dist" = "utopic" ]; then
-           tmp_out_arch="amd64 ppc64el"
-       else 
-           tmp_out_arch="amd64"
-       fi
+        tmp_out_arch="amd64 ppc64el"
+        if [ "$dist" = "saucy" ]; then
+            # for older releases of Ubuntu that does not support ppc64el
+            tmp_out_arch="amd64"
+        fi
         cat << __EOF__ >> conf/distributions
 Origin: xCAT internal repository
 Label: xcat-dep bazaar repository
@@ -443,14 +444,14 @@ __EOF__
     amd_files=`ls ../debs/*.deb | grep -v "ppc64el"`
     all_files=`ls ../debs/*.deb`
     for dist in $dists; do
-      if [ "$dist" = "trusty" ] || [ "$dist" = "utopic" ]; then
-          deb_files=$all_files
-      else
-          deb_files=$amd_files
-      fi
-      for file in $deb_files; do
-	reprepro -b ./ includedeb $dist $file;
-      done
+        deb_files=$all_files
+        if [ "$dist" = "saucy" ]; then
+            # for older releases of Ubuntu that does not support ppc64el
+            deb_files=$amd_files
+        fi
+        for file in $deb_files; do
+            reprepro -b ./ includedeb $dist $file;
+        done
     done
 
     cat << '__EOF__' > mklocalrepo.sh

--- a/build-ubunturepo
+++ b/build-ubunturepo
@@ -45,11 +45,16 @@ if [[ ! -f /etc/lsb-release ]]; then
 fi 
 . /etc/lsb-release
 
-REPREPRO=`which reprepro >> /dev/null 2>&1; echo $?`
-if [[ ${REPREPRO} != 0 ]]; then
-    echo "ERROR: Could not find reprepro, verify that reprepro is installed on this machine.  Cannot continue!"
-    exit 1
-fi
+# Check the necessary packages before starting the build
+declare -a packages=( "reprepro" "devscripts" "debhelper" "libsoap-lite-perl" "libdbi-perl" "quilt" )
+
+for package in ${packages[@]}; do
+    RC=`dpkg -l | grep $package >> /dev/null 2>&1; echo $?`
+    if [[ ${RC} != 0 ]]; then
+        echo "ERROR: Could not find $package, install using 'apt-get install $package' to continue"
+        exit 1
+    fi
+done
 
 # Process cmd line variable assignments, assigning each attr=val pair to a variable of same name
 for i in $*; do

--- a/build-ubunturepo
+++ b/build-ubunturepo
@@ -484,7 +484,7 @@ __EOF__
     chmod -R g+w xcat-dep
 
     #create the tar ball
-    dep_tar_name=xcat-dep-ubuntu-`date +%Y%m%d%H%M`.tar.bz
+    dep_tar_name=xcat-dep-ubuntu-`date +%Y%m%d%H%M`.tar.bz2
     tar -hjcf $dep_tar_name xcat-dep
     chgrp root $dep_tar_name
     chmod g+w $dep_tar_name

--- a/docs/source/guides/install-guides/apt/install_xcat.rst
+++ b/docs/source/guides/install-guides/apt/install_xcat.rst
@@ -22,10 +22,12 @@ Add the necessary apt-repositories to the management node ::
         add-apt-repository "deb http://ports.ubuntu.com/ubuntu-ports $(lsb_release -sc) universe"
         add-apt-repository "deb http://ports.ubuntu.com/ubuntu-ports $(lsb_release -sc)-updates universe"
 
-Install xCAT with the following command: ::
+Install xCAT [#]_ with the following command: ::
 
         apt-get clean all
         apt-get update
-        apt-get install xCAT
+        apt-get install xcat
+
+.. [#] Starting with Ubuntu 16.04, the package name 'xCAT' is required to be all lowercase
 
 

--- a/perl-xCAT/xCAT/Client.pm
+++ b/perl-xCAT/xCAT/Client.pm
@@ -14,6 +14,7 @@ if ($^O =~ /^aix/i) {
 }
 use IO::Handle;
 use MIME::Base64 qw(decode_base64);
+use IO::Socket::SSL;
 
 my $inet6support;
 if ($^O =~ /^aix/i) {  # disable AIX IPV6  TODO fix

--- a/xCAT-server/lib/xcat/plugins/docker.pm
+++ b/xCAT-server/lib/xcat/plugins/docker.pm
@@ -35,7 +35,6 @@ use xCAT::MsgUtils;
 use Cwd;
 use xCAT::Usage;
 use JSON;
-#use Data::Dumper;
 
 my $verbose;
 my $global_callback;
@@ -1003,7 +1002,7 @@ sub init_async {
     $async = HTTP::Async->new(
         slots => $args{slots},
         ssl_options => {
-            SSL_verify_mode => "SSL_VERIFY_PEER",
+            SSL_verify_mode => SSL_VERIFY_PEER,
             SSL_ca_file => $ssl_ca_file,
             SSL_cert_file => $ssl_cert_file,
             SSL_key_file => $key_file,


### PR DESCRIPTION
Fixes Issue #790 

- Change the SSL_VERIFY_PEER in commit ed02740 to be a number instead of a string.  
- Looks like ``apt-get install xcat`` needs to be in lowercase, most strict in this version of Ubuntu? 
- Documentation change for the instructions
- change the build script so that we only need to update the release name moving forward instead of looking for each release of Ubuntu

Followed the steps in http://xcat-docs.readthedocs.org/en/latest/guides/install-guides/apt/install_xcat.html  and xCAT installs OK with my sandbox build

```
root@fs1vm202:/tmp/xcat-dep# source /etc/profile.d/xcat.sh 
root@fs1vm202:/tmp/xcat-dep# lsxcatd -a
Version 2.12 (git commit ed02740d1e18595f24181be7865aa0f5bd07b0b4, built Tue Mar 15 14:06:50 EDT 2016)
This is a Management Node
dbengine=SQLite
```

Documentation change: 
![image](https://cloud.githubusercontent.com/assets/10049070/13789578/122af2a2-eabb-11e5-819d-884035ef7c15.png)

