### PR TITLE
Find switch vendor using snmpwalk command

### DIFF
--- a/docs/source/advanced/networks/switchdiscover/switches_discovery.rst
+++ b/docs/source/advanced/networks/switchdiscover/switches_discovery.rst
@@ -5,7 +5,7 @@ Use switchdiscover command to discover the switches that are attached to the nei
 
     switchdiscover [noderange|--range ip_ranges][-s scan_methods][-r|-x|-z][-w]
 
-where the scan_methods can be **nmap** . The default is **nmap**. (**nmap** comes from most os distribution.)
+where the scan_methods can be **nmap**, **snmp", or **lldp** . The default is **nmap**. (**nmap** comes from most os distribution.)
 
 To discover switches over the IP range 10.4.25.0/24 and 192.168.0.0/24, use the following command: ::
 

--- a/docs/source/guides/admin-guides/references/man1/switchdiscover.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/switchdiscover.1.rst
@@ -29,6 +29,8 @@ To view all the switches defined in the xCAT databasee use \ **lsdef -w "nodetyp
 
 For lldp method, please make sure that lldpd package is installed and lldpd is running on the xCAT management node. lldpd comes from xcat-dep packge or you can get it from http://vincentbernat.github.io/lldpd/installation.html.
 
+For snmp method, please make sure that snmpwalk command is installed and snmp is enabled for switches. To install snmpwalk, "yum install net-snmp-utils" for redhat and sles,  "apt-get install snmp" for Ubuntu.
+
 
 *******
 OPTIONS
@@ -60,6 +62,8 @@ OPTIONS
  Specify one or more IP ranges. Each can be an ip address (10.1.2.3) or an ip range (10.1.2.0/24). If the range is huge, for example, 192.168.1.1/8, the switch discover may take a very long time to scan. So the range should be exactly specified.
  
  For nmap scan method, it accepts multiple formats. For example, 192.168.1.1/24, 40-41.1-2.3-4.1-100.
+
+For snmp scan method, it accepts multiple formats.  For example: 192.168.1.1/24, 1.2-3.4.5, 1.2.3-4.5, 1.2.3.4-5
  
  If the range is not specified, the command scans all the subnets that the active network interfaces (eth0, eth1) are on where this command is issued.
  
@@ -74,7 +78,7 @@ OPTIONS
 \ **-s**\ 
  
  It is a comma separated list of methods for switch discovery. 
- The possible switch scan methods are: lldp and nmap. The default is nmap.
+ The possible switch scan methods are: lldp, nmap or snmp. The default is nmap.
  
 
 

--- a/docs/source/guides/admin-guides/references/man1/switchdiscover.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/switchdiscover.1.rst
@@ -61,9 +61,8 @@ OPTIONS
  
  Specify one or more IP ranges. Each can be an ip address (10.1.2.3) or an ip range (10.1.2.0/24). If the range is huge, for example, 192.168.1.1/8, the switch discover may take a very long time to scan. So the range should be exactly specified.
  
- For nmap scan method, it accepts multiple formats. For example, 192.168.1.1/24, 40-41.1-2.3-4.1-100.
+ For nmap and snmp scan method, it accepts multiple formats. For example, 192.168.1.1/24, 40-41.1-2.3-4.1-100.
 
-For snmp scan method, it accepts multiple formats.  For example: 192.168.1.1/24, 1.2-3.4.5, 1.2.3-4.5, 1.2.3.4-5
  
  If the range is not specified, the command scans all the subnets that the active network interfaces (eth0, eth1) are on where this command is issued.
  

--- a/docs/source/guides/admin-guides/references/man1/switchdiscover.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/switchdiscover.1.rst
@@ -23,7 +23,7 @@ DESCRIPTION
 ***********
 
 
-The switchdiscover command scans the subnets and discovers all the swithches on the subnets. The command takes a list of subnets as input. The default subnets are the ones that the xCAT management node is on. It uses nmap command to discover the switches. However, you can specify other discovery methods such as lldp with \ **-s**\  flag. You can write the discovered switches into xCAT database with \ **-w**\  flag. This command supports may output formats such as xml(\ **-x**\ ), raw(\ **-r**\ ) and stanza(\ **-z**\ ) in addition to the default format.
+The switchdiscover command scans the subnets and discovers all the swithches on the subnets. The command takes a list of subnets as input. The default subnets are the ones that the xCAT management node is on. It uses nmap command as default to discover the switches. However, you can specify other discovery methods such as lldp or snmp with \ **-s**\  flag. You can write the discovered switches into xCAT database with \ **-w**\  flag. This command supports may output formats such as xml(\ **-x**\ ), raw(\ **-r**\ ) and stanza(\ **-z**\ ) in addition to the default format.
 
 To view all the switches defined in the xCAT databasee use \ **lsdef -w "nodetype=switch"**\  command.
 
@@ -61,8 +61,7 @@ OPTIONS
  
  Specify one or more IP ranges. Each can be an ip address (10.1.2.3) or an ip range (10.1.2.0/24). If the range is huge, for example, 192.168.1.1/8, the switch discover may take a very long time to scan. So the range should be exactly specified.
  
- For nmap and snmp scan method, it accepts multiple formats. For example, 192.168.1.1/24, 40-41.1-2.3-4.1-100.
-
+ For nmap and snmp scan method, it accepts multiple formats. For example: 192.168.1.1/24, 40-41.1-2.3-4.1-100.
  
  If the range is not specified, the command scans all the subnets that the active network interfaces (eth0, eth1) are on where this command is issued.
  

--- a/xCAT-client/pods/man1/switchdiscover.1.pod
+++ b/xCAT-client/pods/man1/switchdiscover.1.pod
@@ -48,9 +48,7 @@ Display usage message.
 
 Specify one or more IP ranges. Each can be an ip address (10.1.2.3) or an ip range (10.1.2.0/24). If the range is huge, for example, 192.168.1.1/8, the switch discover may take a very long time to scan. So the range should be exactly specified.
 
-For nmap scan method, it accepts multiple formats. For example: 192.168.1.1/24, 40-41.1-2.3-4.1-100.
-
-For snmp scan method, it accepts multiple formats.  For example: 192.168.1.1/24, 1.2-3.4.5, 1.2.3-4.5, 1.2.3.4-5
+For nmap and snmp scan method, it accepts multiple formats. For example: 192.168.1.1/24, 40-41.1-2.3-4.1-100.
 
 If the range is not specified, the command scans all the subnets that the active network interfaces (eth0, eth1) are on where this command is issued. 
 

--- a/xCAT-client/pods/man1/switchdiscover.1.pod
+++ b/xCAT-client/pods/man1/switchdiscover.1.pod
@@ -16,11 +16,13 @@ B<switchdiscover> [I<noderange> | B<--range> I<ip_ranges>] B<[-V] [-w][-r|-x|-z]
 
 =head1 DESCRIPTION
 
-The switchdiscover command scans the subnets and discovers all the swithches on the subnets. The command takes a list of subnets as input. The default subnets are the ones that the xCAT management node is on. It uses nmap command to discover the switches. However, you can specify other discovery methods such as lldp with B<-s> flag. You can write the discovered switches into xCAT database with B<-w> flag. This command supports may output formats such as xml(B<-x>), raw(B<-r>) and stanza(B<-z>) in addition to the default format.    
+The switchdiscover command scans the subnets and discovers all the swithches on the subnets. The command takes a list of subnets as input. The default subnets are the ones that the xCAT management node is on. It uses nmap command as default to discover the switches. However, you can specify other discovery methods such as lldp or snmp with B<-s> flag. You can write the discovered switches into xCAT database with B<-w> flag. This command supports may output formats such as xml(B<-x>), raw(B<-r>) and stanza(B<-z>) in addition to the default format.    
 
 To view all the switches defined in the xCAT databasee use B<lsdef -w "nodetype=switch"> command.
 
 For lldp method, please make sure that lldpd package is installed and lldpd is running on the xCAT management node. lldpd comes from xcat-dep packge or you can get it from http://vincentbernat.github.io/lldpd/installation.html. 
+
+For snmp method, please make sure that snmpwalk command is installed and snmp is enabled for switches. To install snmpwalk, "yum install net-snmp-utils" for redhat and sles,  "apt-get install snmp" for Ubuntu. 
 
 
 =head1 OPTIONS
@@ -46,7 +48,9 @@ Display usage message.
 
 Specify one or more IP ranges. Each can be an ip address (10.1.2.3) or an ip range (10.1.2.0/24). If the range is huge, for example, 192.168.1.1/8, the switch discover may take a very long time to scan. So the range should be exactly specified.
 
-For nmap scan method, it accepts multiple formats. For example, 192.168.1.1/24, 40-41.1-2.3-4.1-100.
+For nmap scan method, it accepts multiple formats. For example: 192.168.1.1/24, 40-41.1-2.3-4.1-100.
+
+For snmp scan method, it accepts multiple formats.  For example: 192.168.1.1/24, 1.2-3.4.5, 1.2.3-4.5, 1.2.3.4-5
 
 If the range is not specified, the command scans all the subnets that the active network interfaces (eth0, eth1) are on where this command is issued. 
 
@@ -57,7 +61,7 @@ Display Raw responses.
 =item B<-s>  
 
 It is a comma separated list of methods for switch discovery. 
-The possible switch scan methods are: lldp and nmap. The default is nmap.
+The possible switch scan methods are: lldp, nmap or snmp. The default is nmap.
 
 =item B<-v|--version>  
 

--- a/xCAT-server/lib/xcat/plugins/switchdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/switchdiscover.pm
@@ -43,9 +43,11 @@ my %global_OID_model_metrix = (
     "enterprises.26543.1.7.4" => "(BNT)IBM Networking Operating System RackSwitch G8124",
     "enterprises.26543.1.7.6" => "(BNT)IBM Networking Operating System RackSwitch G8264",
     "enterprises.26543.1.7.7" => "(BNT)IBM Networking Operating System RackSwitch G8052",
+    "enterprises.26543" => "BNT",
     "enterprises.33049.1.1.1.6036" => "IBM Mellanox Switch SX6036",
     "enterprises.33049.1.1.1.6512" => "IBM Mellanox Switch SX6512",
-    "enterprises.33049.2.1" => "IBM Mellanox Switch IB6131"
+    "enterprises.33049.2.1" => "IBM Mellanox Switch IB6131",
+    "enterprises.33049" => "IBM Mellanox Switch"
 );
 
 

--- a/xCAT-server/lib/xcat/plugins/switchdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/switchdiscover.pm
@@ -666,12 +666,8 @@ sub nmap_scan {
     #################################################
     #display the raw output
     #################################################
-    if (exists($globalopt{r})) {
+    if (defined($globalopt{r}) || defined($globalopt{verbose})) {
         send_msg($request, 0, "$result\n" );
-    } else {
-        if (exists($globalopt{verbose})) {
-            send_msg($request, 0, "$result\n" );
-        }
     }
 
     #################################################
@@ -839,18 +835,16 @@ sub snmp_scan {
     #################################################
     #display the raw output
     #################################################
-    if (exists($globalopt{r})) {
+    if (defined($globalopt{r}) || defined($globalopt{verbose})) {
         send_msg($request, 0, "$result\n" );
-    } else {
-        if (exists($globalopt{verbose})) {
-            send_msg($request, 0, "$result\n" );
-        }
     }
     my @lines = split /\n/, $result;
 
+    # each line like this: "Discovered open port 161/udp on 10.4.25.1"
     # only open port will be scan
     foreach my $line (@lines) {
-        my $ip = `echo "$line\n" |awk '{printf \$6}'`; 
+        my @array = split / /, $line;
+        my $ip = $array[5];
         if (exists($globalopt{verbose}))    {
             send_msg($request, 0, "Run snmpwalk command to get information for $ip");
         }


### PR DESCRIPTION
For the RTC Task #70903.

switchdiscover is based on the nmap command to find switch information, like Mac address, hostname and vendors, but in the some environment,  the nmap couldn't find the vendor info.  In this task, it will add snmpwalk command to enhance switchdiscover and use OID.enterprises to match vendor info and sysName to find it's hostname.

The metrix for some OID and switches we are supporting as following;
```
enterprises.20301.1.18.13    IBM Flex System Fabric EN4093/EN2092 Scalable Switch
enterprises.26543.1.7.1       IBM Networking Operating System RackSwitch G8000-RS
enterprises.26543.1.7.4       IBM Networking Operating System RackSwitch G8124
enterprises.26543.1.7.6       IBM Networking Operating System RackSwitch G8264
enterprises.26543.1.7.7       IBM Networking Operating System RackSwitch G8052
enterprises.33049.1.1.1.6036  IBM Mellanox switch SX6036
enterprises.33049.1.1.1.6512  IBM Mellanox switch SX6512
enterprises.33049.2.1            IBM Mellanox IB switch IB6131
```
