### PR TITLE
rflash check_bmc_status_with_ipmitool raw command

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/management.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/management.rst
@@ -108,16 +108,8 @@ Check firmware version of the node and the HPM file:  ::
 
 Update node firmware to the version of the HPM file
 
-**ATTENTION**
-
-* Currently rflash is not stable enough to select accurate time before
-  upgrading. A ``rflash_delay`` attribute can be set in site table to adjust the
-  wait time before upgrading. We suggest setting this value to 70 which means
-  wait 70 secondes after BMC reset cold.
-
 ::
 
-    chdef -t site clustersite rflash_delay=70
     rflash cn1 /firmware/8335_810.1543.20151021b_update.hpm
 
 Configures Nodes' Service Processors

--- a/docs/source/guides/admin-guides/references/man5/site.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/site.5.rst
@@ -235,10 +235,6 @@ site Attributes:
    snmpc:  The snmp community string that xcat should use when communicating with the
            switches.
   
-   rflash_delay:  Only for rflash command to upgrade firmware on OpenPOWER servers.
-                  This attribute is delay time to wait for the firmware initialization
-                  after cold reset. Default value is 120 in seconds. If set to 0, no delay.
-  
    ---------------------------
   INSTALL/DEPLOYMENT ATTRIBUTES
    ---------------------------

--- a/perl-xCAT/xCAT/Schema.pm
+++ b/perl-xCAT/xCAT/Schema.pm
@@ -1070,9 +1070,6 @@ site => {
    "              through HMC. Default is 0.\n\n".
    " snmpc:  The snmp community string that xcat should use when communicating with the\n".
    "         switches.\n\n".
-   " rflash_delay:  Only for rflash command to upgrade firmware on OpenPOWER servers.\n".
-   "                This attribute is delay time to wait for the firmware initialization\n".
-   "                after cold reset. Default value is 120 in seconds. If set to 0, no delay.\n\n".
    " ---------------------------\n".
    "INSTALL/DEPLOYMENT ATTRIBUTES\n".
    " ---------------------------\n".

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -1605,6 +1605,8 @@ sub check_bmc_status_with_ipmitool {
     my $count = 0;
     my $bmc_response = 0;
     my $cmd = $pre_cmd." raw 0x3a 0x0a";
+    # BMC response of " c0" means BMC still running IPL
+    # BMC response of " 00" means ready to flash 
     while ($count < $retry) {
         $bmc_response = xCAT::Utils->runcmd($cmd, -1);
         if ($bmc_response =~ /00/) {
@@ -1675,7 +1677,7 @@ sub do_firmware_update {
             return -1;
     }
     #check reset status
-    unless (check_bmc_status_with_ipmitool($pre_cmd, 5, 12)) {
+    unless (check_bmc_status_with_ipmitool($pre_cmd, 5, 24)) {
         xCAT::SvrUtils::sendmsg ([1,"Timeout to check the bmc status"],
             $callback,$sessdata->{node},%allerrornodes);
             return -1;
@@ -1689,9 +1691,6 @@ sub do_firmware_update {
             return -1;
     }
     # step 4 upgrade firmware
-    # NOTE(chenglch) some firmware may not stable enough, it can handle the ipmi session
-    # request, but failed to upgrade, add sleep function as a work around here to avoid of
-    # error.
     $cmd = $pre_cmd." -z 30000 hpm upgrade $hpm_file force";
     $output = xCAT::Utils->runcmd($cmd, -1);
 

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -1603,14 +1603,15 @@ sub check_bmc_status_with_ipmitool {
     my $interval = shift;
     my $retry = shift;
     my $count = 0;
-    my $cmd = $pre_cmd." power status";
+    my $bmc_response = 0;
+    my $cmd = $pre_cmd." raw 0x3a 0x0a";
     while ($count < $retry) {
-        xCAT::Utils->runcmd($cmd, -1);
-        if ($::RUNCMD_RC != 0) {
-            sleep($interval);
+        $bmc_response = xCAT::Utils->runcmd($cmd, -1);
+        if ($bmc_response =~ /00/) {
+            return 1;
         }
         else {
-            return 1;
+            sleep($interval);
         }
         $count++;
     }
@@ -1674,7 +1675,6 @@ sub do_firmware_update {
             return -1;
     }
     #check reset status
-    sleep(10);
     unless (check_bmc_status_with_ipmitool($pre_cmd, 5, 12)) {
         xCAT::SvrUtils::sendmsg ([1,"Timeout to check the bmc status"],
             $callback,$sessdata->{node},%allerrornodes);
@@ -1692,10 +1692,6 @@ sub do_firmware_update {
     # NOTE(chenglch) some firmware may not stable enough, it can handle the ipmi session
     # request, but failed to upgrade, add sleep function as a work around here to avoid of
     # error.
-    my $rflash_delay = 120;
-    my $delay_config = xCAT::TableUtils->get_site_attribute("rflash_delay");
-    $rflash_delay = $delay_config if defined($delay_config) and $delay_config =~ /^\d+$/;
-    sleep($rflash_delay) if $rflash_delay != 0;
     $cmd = $pre_cmd." -z 30000 hpm upgrade $hpm_file force";
     $output = xCAT::Utils->runcmd($cmd, -1);
 


### PR DESCRIPTION
As per Uma Yadlapati's suggestion, rflash will now poll BMC with a  "raw 0x3a 0x0a" command. A " 00" response indicates that BMC is finished with IPL (Initial Program Load) after reset, and therefore ready for firmware update command to be issued