### PR TITLE
Based on Debian policy, all package names should not use upper-case letters

### DIFF
--- a/xCAT-OpenStack-baremetal/debian/control
+++ b/xCAT-OpenStack-baremetal/debian/control
@@ -10,5 +10,5 @@ Homepage: http://xcat.org
 
 Package: xcat-openstack-baremetal
 Architecture: all
-Depends: xCAT-client
+Depends: xcat-client
 Description:  Executables and data of the xCAT baremetal driver for OpenStack

--- a/xCAT-vlan/debian/control
+++ b/xCAT-vlan/debian/control
@@ -9,5 +9,5 @@ Standards-Version: 3.9.2
 
 Package: xcat-vlan
 Architecture: all
-Depends: xCAT-client
+Depends: xcat-client
 Description: xCAT-vlan provides the xCAT vlan confiuration.


### PR DESCRIPTION
Change depends xCAT-client -> xcat-client