### PR TITLE
support timestamps per line for console output

### DIFF
--- a/xCAT-server/lib/xcat/plugins/conserver.pm
+++ b/xCAT-server/lib/xcat/plugins/conserver.pm
@@ -264,7 +264,7 @@ sub docfheaders {
 
   push @newheaders,"default * {\n";
   push @newheaders,"  logfile /var/log/consoles/&;\n";
-  push @newheaders,"  timestamp 1hab;\n";
+  push @newheaders,"  timestamp 1lab;\n";
   push @newheaders,"  rw *;\n";
   push @newheaders,"  master localhost;\n";
 


### PR DESCRIPTION
Request from Ralph:
https://sourceforge.net/p/xcat/bugs/4581/

Verified and works for replaycons also
sample of output:
`````
[Thu Mar 24 05:15:43 2016][   14.557616] usb 1-3: USB disconnect, device number 4^M
[Thu Mar 24 05:15:43 2016][   14.557805] usb 1-3.1: USB disconnect, device number 5^M
[Thu Mar 24 05:15:43 2016][   14.681827] IPv6: ADDRCONF(NETDEV_UP): eth0: link is not ready^M
[Thu Mar 24 05:15:43 2016][   14.686803] IPv6: ADDRCONF(NETDEV_UP): eth1: link is not ready^M
[Thu Mar 24 05:15:43 2016][   15.009284] usb 1-3: new full-speed USB device number 7 using ohci-pci^M
[Thu Mar 24 05:15:44 2016][   15.234761] usb 1-3: New USB device found, idVendor=0409, idProduct=55aa^M
[Thu Mar 24 05:15:44 2016][   15.235109] usb 1-3: New USB device strings: Mfr=1, Product=2, SerialNumber=3^M
[Thu Mar 24 05:15:44 2016][   15.235499] usb 1-3: Product: QEMU USB Hub^M
[Thu Mar 24 05:15:44 2016][   15.235753] usb 1-3: Manufacturer: QEMU^M
[Thu Mar 24 05:15:44 2016][   15.236126] usb 1-3: SerialNumber: 314159-pci@800000020000000:03.0-3^M
[Thu Mar 24 05:15:44 2016][   15.238114] hub 1-3:1.0: USB hub found^M
``````