### PR TITLE
refine the doc on dhcp in large cluster; correcta typo

### DIFF
--- a/docs/source/advanced/hierarchy/configure_dhcp.rst
+++ b/docs/source/advanced/hierarchy/configure_dhcp.rst
@@ -6,7 +6,7 @@ Add the relevant networks into the DHCP configuration, refer to: :ref:`Setup-dhc
 Add the defined nodes into the DHCP configuration, refer to:
 `XCAT_pLinux_Clusters/#configure-dhcp <http://localhost/fake_todo>`_
 
-In the large cluster, the size of dhcp lease file "/var/lib/dhcpd/dhcpd.leases" on the DHCP server will grow over time, when it increases to around 100MB, the DHCP server will take a long time to respond the DHCP requests from the clients, which will cause the DHCP timeout in the client's side: ::
+In the large cluster, the size of dhcp lease file "/var/lib/dhcpd/dhcpd.leases" on the DHCP server will grow over time. At around 100MB in size, the DHCP server will take a long time to respond to DHCP requests from clients and cause DHCP timeouts: ::
  
    ...
    Mar  2 01:59:10 c656ems2 dhcpd: DHCPDISCOVER from 00:0a:f7:73:7d:d0 via eth0

--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/configure_xcat.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/configure_xcat.rst
@@ -10,7 +10,7 @@ Here is a summary of steps required for the xCAT management node .
   1.Check Site Table 
   2.Check Networks 
   3.Configure Password Table
-  3.Initialize DHCP 
+  4.Initialize DHCP 
 
 Check Site Table 
 ----------------


### PR DESCRIPTION
refine the doc on dhcp in large cluster; 
correct a typo 

see http://10.3.5.21/doc/advanced/hierarchy/configure_dhcp.html