### PR TITLE
fix issue 496 lsf_startup use incorrect shell profile file on RHEL 7.2

### DIFF
--- a/xCAT/postscripts/lsf_startup
+++ b/xCAT/postscripts/lsf_startup
@@ -59,7 +59,14 @@ for lsfnode in $ALL_LSF_NODES
 do
     if [[ x${lsfnode} == x$NODE ]]
     then
-        echo ". $LSF_TOP/conf/profile.lsf" >> /root/.profile
+
+        if grep -q -i "release 7.2" /etc/redhat-release ; then 
+
+            echo ". $LSF_TOP/conf/profile.lsf" >> /root/.profile
+        else
+            #special case for redhat7.2
+            echo ". $LSF_TOP/conf/profile.lsf" >> ~/.bash_profile
+        fi
     fi
 done
 

--- a/xCAT/postscripts/lsf_startup
+++ b/xCAT/postscripts/lsf_startup
@@ -59,13 +59,18 @@ for lsfnode in $ALL_LSF_NODES
 do
     if [[ x${lsfnode} == x$NODE ]]
     then
-
         if [[ -f /root/.bash_profile ]] 
-        then 
-
-            echo ". $LSF_TOP/conf/profile.lsf" >> /root/.bash_profile
+        then
+            if ! grep -q -i "#Added by lsf_startup" /root/.bash_profile ; then 
+                echo "#Added by lsf_startup."
+                echo ". $LSF_TOP/conf/profile.lsf" >> /root/.bash_profile
+            fi
         else
-            echo ". $LSF_TOP/conf/profile.lsf" >> /root/.profile
+            if ! grep -q -i "#Added by lsf_startup" /root/.profile ; then
+                echo "#Added by lsf_startup."
+                echo ". $LSF_TOP/conf/profile.lsf" >> /root/.profile
+            fi
+            
         fi
     fi
 done

--- a/xCAT/postscripts/lsf_startup
+++ b/xCAT/postscripts/lsf_startup
@@ -60,12 +60,12 @@ do
     if [[ x${lsfnode} == x$NODE ]]
     then
 
-        if grep -q -i "release 7.2" /etc/redhat-release ; then 
+        if [[ -f /root/.bash_profile ]] 
+        then 
 
-            echo ". $LSF_TOP/conf/profile.lsf" >> /root/.profile
+            echo ". $LSF_TOP/conf/profile.lsf" >> /root/.bash_profile
         else
-            #special case for redhat7.2
-            echo ". $LSF_TOP/conf/profile.lsf" >> ~/.bash_profile
+            echo ". $LSF_TOP/conf/profile.lsf" >> /root/.profile
         fi
     fi
 done

--- a/xCAT/postscripts/lsf_startup
+++ b/xCAT/postscripts/lsf_startup
@@ -62,12 +62,12 @@ do
         if [[ -f /root/.bash_profile ]] 
         then
             if ! grep -q -i "#Added by lsf_startup" /root/.bash_profile ; then 
-                echo "#Added by lsf_startup."
+                echo "#Added by lsf_startup." >> /root/.bash_profile
                 echo ". $LSF_TOP/conf/profile.lsf" >> /root/.bash_profile
             fi
         else
             if ! grep -q -i "#Added by lsf_startup" /root/.profile ; then
-                echo "#Added by lsf_startup."
+                echo "#Added by lsf_startup." >> /root/.profile
                 echo ". $LSF_TOP/conf/profile.lsf" >> /root/.profile
             fi
             


### PR DESCRIPTION
fix issue #496 
lsf_startup use incorrect shell profile file on RHEL 7.2 #496