### PR TITLE
fix issue 694: refine chtab's man page

### DIFF
--- a/xCAT-client/pods/man8/chtab.8.pod
+++ b/xCAT-client/pods/man8/chtab.8.pod
@@ -18,6 +18,7 @@ B<chtab -d> [I<keycolname=keyvalue>] [I<tablename.colname=newvalue>]
 
 The chtab command adds, deletes or updates the attribute value in the specified table.column for the specified keyvalue.  Normally, the given value will completely replace the current attribute value.  But if "+=" is used instead of "=", the specified value will be appended to the coma separated list of the attribute, if it is not already there.
 
+The chtab is designed to work without passing xcatd, so it's out of control of policy mechanism. 
 
 =head1 OPTIONS
 


### PR DESCRIPTION
Fix issue #694, Disable root permission in policy table, the chtab command still work well.

It don't need to change code, chtab command is designed to work without ``xcatd``, so it's out of control of ``policy`` mechanism.  

I refine the ``chtab`` man page to specify  it.