### PR TITLE
Fix issue 836 Uniform xcatd service naming, using lowercase

### DIFF
--- a/xCAT-server/etc/init.d/xcatd
+++ b/xCAT-server/etc/init.d/xcatd
@@ -11,7 +11,7 @@
 # Should-Start: mysql
 # Default-Start: 3 4 5
 # Default-stop: 0 1 2 6
-# Short-Description: xCATd
+# Short-Description: xcatd
 # Description: xCAT management service
 ### END INIT INFO
 
@@ -39,16 +39,16 @@ MStatus()
 {
   PID=`cat /var/run/xcatd.pid`
   if [ -z "$PID" ]; then
-    echo "xCAT service is not running"
+    echo "xcatd service is not running"
     return 3
   fi
   ps $PID|grep xcatd: > /dev/null 2>&1
   if [ "$?" = "0" ]; then
     RVAL=0
-    echo "xCAT service is running"
+    echo "xcatd service is running"
   else
     RVAL=3
-    echo "xCAT service is not running"
+    echo "xcatd service is not running"
   fi
   return $RVAL
 }
@@ -75,14 +75,14 @@ fi
 
 case $1 in
 restart)
-  echo -n "Restarting xCATd "
+  echo -n "Restarting xcatd "
   if [ -r /etc/profile.d/xcat.sh ]; then
        . /etc/profile.d/xcat.sh
   fi
    xcatd -p /var/run/xcatd.pid && $LOG_SUCCESS || $LOG_FAILURE
   ;;
 reload)
-  echo -n "Reloading xCATd "
+  echo -n "Reloading xcatd "
   if [ -r /etc/profile.d/xcat.sh ]; then
        . /etc/profile.d/xcat.sh
   fi
@@ -93,10 +93,10 @@ status)
   $STATUS
   ;;
 stop)
-  echo -n "Stopping xCATd "
+  echo -n "Stopping xcatd "
   $STATUS > /dev/null 2>&1
   if [ "$?" != "0" ]; then
-    echo -n "xCATd not running, not stopping "
+    echo -n "xcatd not running, not stopping "
     $LOG_WARNING
     echo
     exit 0
@@ -123,12 +123,12 @@ stop)
 start)
   $STATUS > /dev/null 2>&1
   if [ "$?" = "0" ]; then
-    echo -n "xCATd already running "
+    echo -n "xcatd already running "
     $LOG_WARNING
     echo
     exit
   fi
-  echo -n "Starting xCATd "
+  echo -n "Starting xcatd "
   #/var/run/ is a symlink on /run and that's just a tmpfs mount created on boot on ubuntu. 
   #if there is not this directory, create first 
   if [ ! -d /var/run/xcat ];then

--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -261,13 +261,13 @@ sub daemonize {
             print PFILE $pid;
             close (PFILE);
         } else {
-            xCAT::MsgUtils->message("S","xCATd starting as PID $pid");
+            xCAT::MsgUtils->message("S","xcatd starting as PID $pid");
         }
         my $result=<$startupchild>;
         chomp($result);
         unless ($result) { exit (1); }
         if ($result ne "SUCCESS") {
-            xCAT::MsgUtils->message("S","xCATd failed to start: $result");
+            xCAT::MsgUtils->message("S","xcatd failed to start: $result");
             exit(1);
         }
         exit;
@@ -874,7 +874,7 @@ if (defined $pid_init) {
 
 unless (xCAT::Utils->isLinux()) {	# messes up the output of the service cmd on linux
     eval {
-        xCAT::MsgUtils->message("S","xCATd: service starting");
+        xCAT::MsgUtils->message("S","xcatd: service starting");
     };
 }
 if ($@) {
@@ -1369,7 +1369,7 @@ until ($quit) {
     }
 
     unless (defined $child) {
-        xCAT::MsgUtils->message("S","xCATd cannot fork");
+        xCAT::MsgUtils->message("S","xcatd cannot fork");
         die;
     }
 
@@ -1454,7 +1454,7 @@ until ($quit) {
         my $debugmsg = "xcatd: connection from ".($peername ? $peername . "@" . $peerhost : $peerhost)."\n";
         xCAT::MsgUtils->trace(0,"D","$debugmsg");
 
-        $$progname="xCATd SSL: Instance for ".($peername ? $peername ."@".$peerhost : $peerhost) if $peerhost;
+        $$progname="xcatd SSL: Instance for ".($peername ? $peername ."@".$peerhost : $peerhost) if $peerhost;
         service_connection($connection,$peername,$peerhost,$peerfqdn,$peerhostorg);
 
         $debugmsg = "xcatd: close connection with ".($peername ? $peername . "@" . $peerhost : $peerhost)."\n";
@@ -2609,7 +2609,7 @@ sub service_connection {
                     $req->{'_xcat_clienthost'} = [$peerhost];
                     $req->{'_xcat_clientfqdn'} = [$peerfqdn];
                     $req->{'_xcat_clientport'}= [$peerport];
-                    $$progname="xCATd SSL: ".$req->{command}->[0];
+                    $$progname="xcatd SSL: ".$req->{command}->[0];
                     if ($req->{noderange} && defined($req->{noderange}->[0])) {
                         $$progname .= " to ".$req->{noderange}->[0];
                     }


### PR DESCRIPTION
Fix issue #836, Uniform xcatd service naming, using lowercase ``xcatd``.