### PR TITLE
issue633 confignetwork failed to create tagged VLAN interface when a …

### DIFF
--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -261,7 +261,7 @@ function sort_nics_device_order {
             done
         else
             temp_base_nic_dev=$base_nic_dev
-            temp_base_nic_type=`find_nic_type "temp_base_nic_dev"`
+            temp_base_nic_type=`find_nic_type "$temp_base_nic_dev"`
         fi
 
         base_nic_type=$temp_base_nic_type


### PR DESCRIPTION
issue #633  confignetwork failed to create tagged VLAN interface when a customized interface name is used