### PR TITLE
fix bug876: xCATreg can't stop when one specific case failed

### DIFF
--- a/xCAT-server/share/xcat/tools/xCATreg
+++ b/xCAT-server/share/xcat/tools/xCATreg
@@ -841,12 +841,15 @@ sub do_test {
 
 		#statelite installation by ramdisk in hierarchy mode test
 		send_msg(2, "[$mn->$confkeys{$mn}][do_test] doing statelite installation by ramdisk test in hierarchy mode in $mn.....");
-		system("xdsh $confkeys{$mn} \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -t $statelite_installation_hierarchy_by_ramdisk_testcase\" >/dev/null 2>&1");
+		$rc=system("xdsh $confkeys{$mn} \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -t $statelite_installation_hierarchy_by_ramdisk_testcase\" >/dev/null 2>&1");
 		send_msg(2, "[$mn->$confkeys{$mn}][do_test] do statelite installation by ramdisk test in hierarchy mode in $mn.....[done]");	
+                last if($rc != 0);
+
                 #statelite installation by nfs in hierarchy mode test
                 send_msg(2, "[$mn->$confkeys{$mn}][do_test] doing statelite installation by nfs test in hierarchy mode in $mn.....");
-                system("xdsh $confkeys{$mn} \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -t $statelite_installation_hierarchy_by_nfs_testcase\" >/dev/null 2>&1");
+                $rc=system("xdsh $confkeys{$mn} \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -t $statelite_installation_hierarchy_by_nfs_testcase\" >/dev/null 2>&1");
                 send_msg(2, "[$mn->$confkeys{$mn}][do_test] do statelite installation by nfs test in hierarchy mode in $mn.....[done]"); 
+                last if($rc != 0);
 
                 $casestop=0;
         }		


### PR DESCRIPTION
Fix issue #876 : After split of statelite installation test case in hierarchy, the test case stop after fail feature become incomplete

