### PR TITLE
Do not send warning message as the output is complete

### DIFF
--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -1901,20 +1901,12 @@ sub plugin_command {
             $xcatresponses{xcatresponse}=[];
         }
     }
+    if ($check_fds->count > 0) {
+        relay_fds($check_fds,$xcatresponses{xcatresponse});
+    }
     if (scalar(@{$xcatresponses{xcatresponse}})) {
         send_response(\%xcatresponses,$sock);
         $xcatresponses{xcatresponse}=[];
-    }
-    if ($check_fds->count > 0) {
-        my %resp_timeout = ('errorcode'=>[1],
-                            'data'=>["Warning: Process terminated due to IO timeout, the following output may not complete.\n"]);
-        push @{$xcatresponses{xcatresponse}},\%resp_timeout;
-        my $count = scalar(@{$xcatresponses{xcatresponse}});
-        relay_fds($check_fds,$xcatresponses{xcatresponse});
-        if (scalar(@{$xcatresponses{xcatresponse}}) != $count) {
-            send_response(\%xcatresponses,$sock);
-            $xcatresponses{xcatresponse}=[];
-        }
     }
     #while (relay_fds($check_fds,$sock)) {}
 


### PR DESCRIPTION
Although handshake between parent and child process fails
due to the heavy IO loading, the message received by parent
process  is complete as the block operation is used.