### PR TITLE
Checking credential files will now check for rsa key, rather than rsa1 key

### DIFF
--- a/perl-xCAT/xCAT/TableUtils.pm
+++ b/perl-xCAT/xCAT/TableUtils.pm
@@ -1575,7 +1575,7 @@ sub checkCredFiles
     $dir = "$installdir/postscripts/hostkeys";
     if (-d $dir)
     {
-        my $file = "$dir/ssh_host_key.pub";
+        my $file = "$dir/ssh_host_rsa_key.pub";
         if (-e $file)
         {
             my $file2  = "$dir/*.pub";                     # all public keys


### PR DESCRIPTION
Solution discussed in Issue #861 