### PR TITLE
Eliminate some Genesis boot errors

### DIFF
--- a/xCAT-genesis-builder/dhclient-script
+++ b/xCAT-genesis-builder/dhclient-script
@@ -36,15 +36,26 @@ elif [ $reason = "BOUND" ]; then
 	for gw in $new_routers; do
 		ip route add default via $gw
 	done
-        if [ ! -z "$new_log_servers" ]; then
+	# Up to this point we were logging to the local /var/log/xcat.genesis
+	# file. But now we know the xCAT MN, so replace logging to the local
+	# file with logging to the xCAT MN
+	if [ ! -z "$new_log_servers" ]; then
 		head -n -1 /etc/rsyslog.conf > /etc/rsyslog.conf.new
 		cp /etc/rsyslog.conf.new /etc/rsyslog.conf
 	fi
         for ls in $new_log_servers; do
-		echo *.* @$ls >> /etc/rsyslog.conf
+		echo "*.* @$ls" >> /etc/rsyslog.conf
 	done
 	kill `cat /var/run/syslogd.pid`
-	( sleep 3;/sbin/rsyslogd -c4 ) &
+	sleep 3
+	RSYSLOGD_VERSION=`rsyslogd -v | grep "rsyslogd" | cut -d" " -f2 | cut -d"." -f1`
+	if [ $RSYSLOGD_VERSION -ge 8 ]; then
+        	# Newer versions of rsyslogd do not support -c flag anymore
+		/sbin/rsyslogd
+	else
+		/sbin/rsyslogd -c4
+	fi
+
 
 	if [ ! -z "$new_tcode" -a -r "/usr/share/zoneinfo/posix/$new_tcode" ]; then
 		cp "/usr/share/zoneinfo/posix/$new_tcode" /etc/localtime

--- a/xCAT-genesis-builder/rsyslog.conf
+++ b/xCAT-genesis-builder/rsyslog.conf
@@ -1,5 +1,4 @@
 $ModLoad imuxsock
 $ModLoad immark
 $MarkMessagePeriod 1200
-*.emerg                                                 *
-*.*                ~
+*.* /var/log/xcat.genesis

--- a/xCAT-genesis-scripts/bin/doxcat
+++ b/xCAT-genesis-scripts/bin/doxcat
@@ -40,10 +40,19 @@ if [ -r /sys/devices/virtual/dmi/id/product_uuid ]; then
 	duid=$duid'";'
 	echo $duid > /var/lib/dhclient/dhclient6.leases
 fi
+
 rpcbind
 rpc.statd
-ssh-keygen -q -t rsa -f /etc/ssh/ssh_host_rsa_key -C '' -N ''
-ssh-keygen -q -t dsa -f /etc/ssh/ssh_host_dsa_key -C '' -N ''
+
+# Try -A available on more current version of ssh-keygen to generate all keys
+ssh-keygen -A 2> /dev/null
+if [ $? -ne 0 ]; then
+	# -A option did not work, must be running on older version of
+	# ssh-keygen, try generating needed keys one at a time
+	ssh-keygen -q -t rsa -f /etc/ssh/ssh_host_rsa_key -C '' -N ''
+	ssh-keygen -q -t dsa -f /etc/ssh/ssh_host_dsa_key -C '' -N ''
+fi
+
 echo 'Protocol 2' >> /etc/ssh/sshd_config
 /usr/sbin/sshd
 mkdir -p /etc/xcat
@@ -58,7 +67,16 @@ echo "Done"
 PUBKEY=`openssl rsa -in /etc/xcat/privkey.pem -pubout 2> /dev/null|grep -v "PUBLIC KEY"`
 PUBKEY=`echo $PUBKEY|sed -e 's/ //g'`
 export PUBKEY
-/sbin/rsyslogd -4
+RSYSLOGD_VERSION=`rsyslogd -v | grep "rsyslogd" | cut -d" " -f2 | cut -d"." -f1`
+# Start rsyslogd and log into a local file specified in /etc/rsyslog.conf
+# Later, once xCAT MN is known, dhclient-script will change 
+# rsyslog.conf file to send log entries to xCAT MN
+if [ $RSYSLOGD_VERSION -ge 8 ]; then
+	# Newer vers of rsyslogd (8 and higher) do not support -c flag anymore
+	/sbin/rsyslogd
+else
+	/sbin/rsyslogd -c4
+fi
 mkdir -p /var/lib/lldpad
 echo 'lldp :' >> /var/lib/lldpad/lldpad.conf
 echo '{' >> /var/lib/lldpad/lldpad.conf
@@ -217,9 +235,13 @@ echo -n "Acquired IPv4 address on $bootnic: "
 ip addr show dev $bootnic|grep -v 'scope link'|grep -v 'dynamic'|grep -v  inet6|grep inet|awk '{print $2}'
 ntpd -g -x
 # rv 0 state does not work with the new ntp versions
-#(while ! ntpq -c "rv 0 state"|grep 'state=4' > /dev/null; do sleep 1; done; hwclock --systohc) &
-(while [ "`ntpq -c \"rv 0 offset\" | grep \"offset=\" | awk -F \"=\" '{print $2}' | awk -F \".\" '{print $1}' | sed s/-//`" -ge 1000 ]; do sleep 1; done; hwclock --systohc) &
+while [ "`ntpq -c \"rv 0 offset\" | grep \"offset=\" | awk -F \"=\" '{print $2}' | awk -F \".\" '{print $1}' | sed s/-//`" -ge 1000 ]; do 
+    sleep 1
+done
 
+if [ -e "/dev/rtc" ]; then
+    hwclock --systohc
+fi
 HOST_ARCH=`uname -m`
 if echo $HOST_ARCH | grep "ppc64"; then
     modprobe ipmi_powernv


### PR DESCRIPTION
This pull request fixes several Genesis boot errors in **doxcat** and **dhclinet-script** scripts.
This pull request is related to RTC task 93486.

1. When sshd starts on ppc64 it complains about some keys not being generated. 
     - Changed to call to **ssh-keygen** with **-A** option to generate all the keys.

2. When **hwclock** command is called on ppc64, it returns an error if **/dev/rtc** file is not there. 
     - Changed code to check for this file before calling **hwclock**.

3. Several errors from **rsyslogd** command. On ppc64 a later version of **rsyslogd** is used than on x86. 
    - Added code to check for **rsyslogd** version and use appropriate command invocation
    - Fixed **rsyslog.conf** file to initially log locally into **/var/log/xcat.genesis** file. Later when xCAT MN node is known, the **rsyslog.conf** file is changed to sent all log messages to xCAT MN
    - removed _*.emerg *_ from **rsyslog.conf** file which was intended to call **wall** if emergency message is received. But it does not work, probably because **wall** does not appears to be a valid command while running in Genesis shell.