### PR TITLE
update xcatdebugmode value from 1 to 2 as latest design

### DIFF
--- a/xCAT-test/autotest/testcase/runcmdinstaller/cases0
+++ b/xCAT-test/autotest/testcase/runcmdinstaller/cases0
@@ -6,7 +6,7 @@ check:output=~runcmdinstaller <node> "<command>"
 end
 start:runcmdinstaller_command
 descriptiop:runcmdinstaller
-cmd:chtab key=xcatdebugmode site.value="1"
+cmd:chtab key=xcatdebugmode site.value="2"
 check:rc==0
 cmd:nodeset $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0


### PR DESCRIPTION
@tingtli 
Please help review code.
As the xcatdebugmode logic is changed, only when value is 2 the ssh will be supported.
Already passed with latest build.