### PR TITLE
shebang of xcatinstallpost generated by post.xcat not in the beginning

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/post.xcat
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat
@@ -286,7 +286,6 @@ fi
 #create the xcatinstallpost
 mkdir -p /opt/xcat
 cat >/opt/xcat/xcatinstallpost << 'EOF'
-
 #INCLUDE:#TABLE:site:key=installdir:value#/postscripts/xcatinstallpost#
 
 if [ -f /xcatpost/mypostscript.post ]; then


### PR DESCRIPTION
fix https://github.com/xcat2/xcat-core/issues/810

In the installed ubuntu node, the shebang of "xcatpostinit1" is ``#!/bin/sh``, ``/bin/sh``is a symbol link to "/bin/dash", the shebang  of "xcatinstallpost"  "#!/bin/bash" is in the 2nd line, which will be parsed as a comment line, so the "xcatinstallpost" is run with ``dash`` in “xcatpostinit1”. The "xcatinstallpost" includes "xcatlib.sh", which involves some bash specific features, it fail to pass the syntax check and won't be run