### PR TITLE
Update the ipmitool-xcat requires 

### DIFF
--- a/xCAT/xCAT.spec
+++ b/xCAT/xCAT.spec
@@ -61,13 +61,13 @@ Requires: conserver-xcat
 
 %ifarch i386 i586 i686 x86 x86_64
 Requires: syslinux xCAT-genesis-scripts-x86_64 elilo-xcat
-Requires: ipmitool-xcat >= 1.8.9
+Requires: ipmitool-xcat >= 1.8.11
 Requires: xnba-undi
 %endif
 %ifos linux
 %ifarch ppc ppc64 ppc64le
 Requires: xCAT-genesis-scripts-ppc64
-Requires: ipmitool-xcat >= 1.8.9
+Requires: ipmitool-xcat >= 1.8.15
 %endif
 %endif
 

--- a/xCATsn/xCATsn.spec
+++ b/xCATsn/xCATsn.spec
@@ -56,13 +56,13 @@ Requires: conserver-xcat
 
 %ifarch i386 i586 i686 x86 x86_64
 Requires: syslinux xCAT-genesis-scripts-x86_64 elilo-xcat
-Requires: ipmitool-xcat >= 1.8.9
+Requires: ipmitool-xcat >= 1.8.11
 Requires: xnba-undi
 %endif
 %ifos linux
 %ifarch ppc ppc64 ppc64le
 Requires: xCAT-genesis-scripts-ppc64
-Requires: ipmitool-xcat >= 1.8.9
+Requires: ipmitool-xcat >= 1.8.15
 %endif
 %endif
 


### PR DESCRIPTION
For OpenPower machines 1.8.15 is required.  
For x86_64, update to 1.8.11 because we have not built 1.8.15 on all platform, only the following:

```
 find ./ -name "ipmitool-xcat*" -print  | grep 1.8.15
./rh7/ppc64le/ipmitool-xcat-1.8.15-1.ppc64le.rpm
./rh7/x86_64/ipmitool-xcat-1.8.15-1.x86_64.rpm
./rh7/ppc64/ipmitool-xcat-1.8.15-1.ppc64.rpm
./sles12/ppc64le/ipmitool-xcat-1.8.15-1.ppc64le.rpm
```

This needs to be cherry picked to master branch after review and merged