### PR TITLE
Removed keygen of SSH1 RSA Key

### DIFF
--- a/perl-xCAT/xCAT/TableUtils.pm
+++ b/perl-xCAT/xCAT/TableUtils.pm
@@ -1606,7 +1606,7 @@ sub checkCredFiles
     $dir = "/etc/xcat/hostkeys";
     if (-d $dir)
     {
-        my $file = "$dir/ssh_host_key.pub";
+        my $file = "$dir/ssh_host_rsa_key.pub";
         if (-e $file)
         {
             my $file2  = "$dir/*.pub";                     # all public keys

--- a/xCAT-server/lib/xcat/plugins/mknb.pm
+++ b/xCAT-server/lib/xcat/plugins/mknb.pm
@@ -120,14 +120,12 @@ sub process_request {
    chmod(0700,$tempdir."$sshdir");
    copy("/root/.ssh/id_rsa.pub","$tempdir$sshdir/authorized_keys");
    chmod(0600,"$tempdir$sshdir/authorized_keys");
-   if (not $invisibletouch and -r "/etc/xcat/hostkeys/ssh_host_key") {
-    copy("/etc/xcat/hostkeys/ssh_host_key","$tempdir/etc/ssh_host_key");
+   if (not $invisibletouch and -r "/etc/xcat/hostkeys/ssh_host_rsa_key") {
     copy("/etc/xcat/hostkeys/ssh_host_rsa_key","$tempdir/etc/ssh_host_rsa_key");
     copy("/etc/xcat/hostkeys/ssh_host_dsa_key","$tempdir/etc/ssh_host_dsa_key");
       chmod(0600,<$tempdir/etc/ssh_*>);
    }
-   unless ($invisibletouch or -r "$tempdir/etc/ssh_host_key") {
-      system("ssh-keygen -t rsa1 -f $tempdir/etc/ssh_host_key -C '' -N ''");
+   unless ($invisibletouch or -r "$tempdir/etc/ssh_host_rsa_key") {
       system("ssh-keygen -t rsa -f $tempdir/etc/ssh_host_rsa_key -C '' -N ''");
       system("ssh-keygen -t dsa -f $tempdir/etc/ssh_host_dsa_key -C '' -N ''");
    }

--- a/xCAT-server/sbin/xcatconfig
+++ b/xCAT-server/sbin/xcatconfig
@@ -949,15 +949,6 @@ sub genSSHNodeHostKey
     # generate new hostkeys
     #
     xCAT::MsgUtils->message('I', "Generating new node hostkeys...");
-    xCAT::MsgUtils->message('I', "Generating SSH1 RSA Key...");
-    my $cmd =
-          "/usr/bin/ssh-keygen -t rsa1 -f /etc/xcat/hostkeys/ssh_host_key -C '' -N ''";
-    my $outref = xCAT::Utils->runcmd("$cmd", 0);
-    if ($::RUNCMD_RC != 0)
-    {
-            xCAT::MsgUtils->message('E', "Could not generate SSH1 RSA key.");
-    }
-
     xCAT::MsgUtils->message('I', "Generating SSH2 RSA Key...");
     $cmd =
           "/usr/bin/ssh-keygen -t rsa -f /etc/xcat/hostkeys/ssh_host_rsa_key -C '' -N ''";

--- a/xCAT-server/share/xcat/netboot/mic/genimage
+++ b/xCAT-server/share/xcat/netboot/mic/genimage
@@ -251,10 +251,8 @@ my @sysfilelist = (
   "/etc/nsswitch.conf",
   "/etc/ssh/ssh_host_rsa_key",
   "/etc/ssh/ssh_config",
-  "/etc/ssh/ssh_host_key",
   "/etc/ssh/sshd_config",
   "/etc/ssh/ssh_host_dsa_key",
-  "/etc/ssh/ssh_host_key.pub",
   "/root/.ssh/id_rsa",
   "/root/.ssh/id_rsa.pub",
   "/root/.ssh/authorized_keys",);

--- a/xCAT-test/autotest/testcase/xcatconfig/case0
+++ b/xCAT-test/autotest/testcase/xcatconfig/case0
@@ -46,7 +46,7 @@ check:rc==0
 cmd:xcatconfig -s
 check:rc==0
 check:output=~(Generating new node hostkeys)
-cmd:diff /etc/xcat/hostkeys/ssh_host_key.pub /etc/xcat/hostkeysbak/ssh_host_key.pub
+cmd:diff /etc/xcat/hostkeys/ssh_host_rsa_key.pub /etc/xcat/hostkeysbak/ssh_host_rsa_key.pub
 check:rc!=0
 cmd:rm -rf /etc/xcat/hostkeysbak
 end
@@ -63,9 +63,7 @@ check:output=~Created xCAT certificate
 check:output=~Signature ok
 check:output=~OK
 check:output!~Fail
-cmd:diff /etc/xcat/hostkeys/ssh_host_key.pub /etc/xcat/hostkeysbak/ssh_host_key.pub
-check:rc!=0
-cmd:diff /etc/xcat/hostkeys/ssh_host_key.pub /etc/xcat/hostkeysbak/ssh_host_key.pub
+cmd:diff /etc/xcat/hostkeys/ssh_host_rsa_key.pub /etc/xcat/hostkeysbak/ssh_host_rsa_key.pub
 check:rc!=0
 cmd:rm -rf /etc/xcat/hostkeysbak
 cmd:rm -rf /root/.xcatbak


### PR DESCRIPTION
As per discussion in #883 

Additionally, removed instances of ssh_host_key.pub (rsa1 encryption, no longer supported) and replaced with ssh_host_rsa_key.pub (rsa encryption) when necessary