### PR TITLE
the shebang of bash scripts should be the 1st line of script file

### DIFF
--- a/buildcore.sh
+++ b/buildcore.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# The shell is commented out so that it will run in bash on linux and ksh on aix
 # Build and upload the xcat-core code, on either linux or aix.
 
 # Getting Started:

--- a/buildcore.sh
+++ b/buildcore.sh
@@ -1,6 +1,6 @@
-# The shell is commented out so that it will run in bash on linux and ksh on aix
-#  !/bin/bash
+#!/bin/bash
 
+# The shell is commented out so that it will run in bash on linux and ksh on aix
 # Build and upload the xcat-core code, on either linux or aix.
 
 # Getting Started:

--- a/builddep.sh
+++ b/builddep.sh
@@ -1,5 +1,6 @@
+#!/bin/sh
 # The shell is commented out so that it will run in bash on linux and ksh on aix
-# !/bin/sh
+
 #
 # Package up all the xCAT open source dependencies
 # - creating the yum repos

--- a/builddep.sh
+++ b/builddep.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-# The shell is commented out so that it will run in bash on linux and ksh on aix
 
 #
 # Package up all the xCAT open source dependencies

--- a/buildlocal.sh
+++ b/buildlocal.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 #######################################################################
 #build script for local usage
 #used for Linux/AIX/Ubuntu

--- a/makerpm
+++ b/makerpm
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# The shell is commented out so that it will run in bash on linux and ksh on aix
 # IBM(c) 2007 EPL license http://www.eclipse.org/legal/epl-v10.html
 
 # Common script to make any one the xcat rpms.  To build locally, run in the top dir of local svn repository, for example:

--- a/makerpm
+++ b/makerpm
@@ -1,6 +1,6 @@
-# The shell is commented out so that it will run in bash on linux and ksh on aix
-#  !/bin/bash
+#!/bin/bash
 
+# The shell is commented out so that it will run in bash on linux and ksh on aix
 # IBM(c) 2007 EPL license http://www.eclipse.org/legal/epl-v10.html
 
 # Common script to make any one the xcat rpms.  To build locally, run in the top dir of local svn repository, for example:


### PR DESCRIPTION
fix https://github.com/xcat2/xcat-core/issues/916 

The shebang of our build srcipts are not in the 1st line of the script files. The 1st line in these files are some description comments, the shebang below will be ignored as comment lines, which introduced problems