### PR TITLE
write MAC when creating docker container, remove connect network and/…

### DIFF
--- a/xCAT-server/lib/xcat/plugins/docker.pm
+++ b/xCAT-server/lib/xcat/plugins/docker.pm
@@ -172,15 +172,9 @@ my %command_states = (
 #              ^                   /         |
 #              |       404 and    /          |
 #           20x|  'No such image'/           |
-#              |                v         20x|                error
+#              |                v            |                error
 #  CREATE_TO_WAIT_FOR_IMAGE_PULL_DONE ------------------------------> error_msg
 #                                            |
-#                                            v                error
-#                          CREATE_TO_WAIT_FOR_RM_DEFCONN_DONE-------> error_msg
-#                                            |
-#                                         20x|
-#                                            v                error
-#                          CREATE_TO_WAIT_FOR_CONNECT_NET_DONE------> error_msg
 #                                            |
 #                                         20x|
 #                                            v
@@ -200,28 +194,10 @@ my %command_states = (
             init_url => "/images/create?fromImage=#DOCKER_IMAGE#",
             init_state => "CREATE_TO_WAIT_FOR_IMAGE_PULL_DONE",
         },
-        connectnet => {
-            genreq_ptr => \&genreq_for_net_connect,
-            state_machine_engine => \&default_state_engine,
-            init_method => "POST",
-            init_url => "/networks/#NETNAME#/connect",
-            init_state => "CREATE_TO_WAIT_FOR_CONNECT_NET_DONE",
-        },
-        rmdefconn => {
-            genreq_ptr => \&genreq_for_net_disconnect,
-            state_machine_engine => \&default_state_engine,
-            init_method => "POST",
-            init_url => "/networks/bridge/disconnect",
-            init_state => "CREATE_TO_WAIT_FOR_RM_DEFCONN_DONE",
-        }
     },
 
-# The state changing for rmdocker
-#
-#    INIT_TO_WAIT_FOR_DISCONNECT_NET_DONE 
-#        If success or force to remove, to remove docker
-#        Else return error
-#    In remove docker round, return error_msg if failed or success if done
+# For rmdocker
+#    return error_msg if failed or success if done
     rmdocker => {
         force => {
             state_machine_engine => \&default_state_engine,
@@ -232,13 +208,6 @@ my %command_states = (
             state_machine_engine => \&default_state_engine,
             init_method => "DELETE",
             init_url => "/containers/#NODE#",
-        },
-        disconnect => {
-            genreq_ptr => \&genreq_for_net_disconnect,
-            state_machine_engine => \&default_state_engine,
-            init_method => "POST",
-            init_url => "/networks/#NETNAME#/disconnect",
-            init_state => "INIT_TO_WAIT_FOR_DISCONNECT_NET_DONE",
         },
     },
 
@@ -484,17 +453,6 @@ sub default_state_engine {
             $global_callback->({node=>[{name=>[$node],"$info_flag"=>["Pull image $node_hash->{image} start"]}]});
             change_node_state($node, $command_states{mkdocker}{pullimage});
             return;
-        } elsif ($data->is_success) {
-            $global_callback->({node=>[{name=>[$node],"$info_flag"=>["Remove default network connection"]}]});
-            change_node_state($node, $command_states{mkdocker}{rmdefconn});
-            return;
-        }
-    }
-    elsif ($curr_state eq 'CREATE_TO_WAIT_FOR_RM_DEFCONN_DONE') {
-        if ($data->is_success) {
-            $global_callback->({node=>[{name=>[$node],"$info_flag"=>["Connecting customzied network '$node_hash->{nics}'"]}]});
-            change_node_state($node, $command_states{mkdocker}{connectnet});
-            return;
         }
     }
     elsif ($curr_state eq 'CREATE_TO_WAIT_FOR_IMAGE_PULL_DONE') {
@@ -502,13 +460,6 @@ sub default_state_engine {
             $global_callback->({node=>[{name=>[$node],"$info_flag"=>["Pull image $node_hash->{image} done"]}]});
             $node_hash->{have_pulled_image} = 1;
             change_node_state($node, $command_states{mkdocker}{default});
-            return;
-        }
-    }
-    elsif ($curr_state eq 'INIT_TO_WAIT_FOR_DISCONNECT_NET_DONE') {
-        if ($data->is_success or $node_hash_variable{$node}->{opt} eq 'force') {
-            $global_callback->({node=>[{name=>[$node],"$info_flag"=>["Disconnect customzied network '$node_hash->{nics}' done"]}]});
-            change_node_state($node, $command_states{rmdocker}{$node_hash->{opt}});
             return;
         }
     }
@@ -736,7 +687,7 @@ sub parse_args {
                 return ( [1, "Option $op is not supported for $cmd"]);
             }
         }
-        $request->{mapping_option} = "disconnect";
+        $request->{mapping_option} = "force";
     }
     elsif ($cmd eq 'lsdocker') {
         foreach my $op (@ARGV) {
@@ -825,11 +776,7 @@ sub process_request {
         $mapping_hash = $command_states{$command}{$req->{mapping_option}};
     }
     else {
-        if ($command eq 'rmdocker') {
-            $mapping_hash = $command_states{$command}{disconnect};
-        } else {
-            $mapping_hash = $command_states{$command}{default};
-        }
+        $mapping_hash = $command_states{$command}{default};
     }
     my $max_concur_session_allow = 20; # A variable can be set by caculated in the future
     if ($command eq 'lsdocker') {
@@ -1139,6 +1086,10 @@ sub genreq_for_mkdocker {
     $info_hash{Memory} = $dockerinfo->{mem};
     $info_hash{MacAddress} = $dockerinfo->{mac};
     $info_hash{CpusetCpus} = $dockerinfo->{cpus};
+    $info_hash{HostConfig}->{NetworkMode} = $dockerinfo->{nics};
+    $info_hash{NetworkDisabled} = JSON::false;
+    $info_hash{NetworkingConfig}->{EndpointsConfig}->{"$dockerinfo->{nics}"}->{IPAMConfig}->{IPv4Address} = $dockerinfo->{ip};
+    $info_hash{NetworkingConfig}->{EndpointsConfig}->{"$dockerinfo->{nics}"}->{MacAddress} = $dockerinfo->{mac};
     if (defined($dockerinfo->{flag})) {
         my $flag_hash = decode_json($dockerinfo->{flag});
         %info_hash = (%info_hash, %$flag_hash);  
@@ -1147,62 +1098,6 @@ sub genreq_for_mkdocker {
     return genreq($node, $dockerhost, $method, $api, $content);
 }
 
-#-------------------------------------------------------
-
-=head3  genreq_for_net_connect
-
-  Generate HTTP request for network operation for a docker
-
-  Input: $node: The docker container name
-         $dockerhost: hash, keys: name, port, user, pw, user, pw, user, pw
-         $method: the http method to generate the http request
-         $api: the url to generate the http request
-
-  return: The http request;
-  Usage example:
-          my $res = genreq_for_net_connect($node,\%dockerhost,'POST','/networks/$nic/connect');
-
-=cut
-
-#-------------------------------------------------------
-
-sub genreq_for_net_connect {
-    my ($node, $dockerhost, $method, $api) = @_; 
-    my $dockerinfo = $node_hash_variable{$node};
-    my %info_hash = ();
-    $info_hash{container} = $node;
-    $info_hash{EndpointConfig}->{IPAMConfig}->{IPv4Address} = $dockerinfo->{ip};
-    my $content = encode_json \%info_hash;
-    return genreq($node, $dockerhost, $method, $api, $content);
-}
-#-------------------------------------------------------
-
-=head3  genreq_for_net_disconnect
-
-  Generate HTTP request for network operation for a docker
-
-  Input: $node: The docker container name
-         $dockerhost: hash, keys: name, port, user, pw, user, pw, user, pw
-         $method: the http method to generate the http request
-         $api: the url to generate the http request
-
-  return: The http request;
-  Usage example:
-          my $res = genreq_for_net_disconnect($node,\%dockerhost,'POST','/networks/$nic/disconnect');
-
-=cut
-
-#-------------------------------------------------------
-
-sub genreq_for_net_disconnect {
-    my ($node, $dockerhost, $method, $api) = @_; 
-    my $dockerinfo = $node_hash_variable{$node};
-    my %info_hash = ();
-    $info_hash{Container} = $node;
-    $info_hash{Force} = JSON::false;
-    my $content = encode_json \%info_hash;
-    return genreq($node, $dockerhost, $method, $api, $content);
-}
 #-------------------------------------------------------
 
 =head3  sendreq


### PR DESCRIPTION
…or disconnect network

This pull request include 3 changes:
1. write Macaddress, IPaddress for creating container interface within mkdocker command. The IPaddress is assigned to container through connecting network interface before.
2. Remove the logic to disconnect default network and connect to customized network within mkdocker command, since we can specify the network directly through the creating container interface.
3. Remove the disconnect customized network logic for rmdocker command, since the connection will be removed automatically when destroy a container.

Interesting finding is: even through we assign MAC to the container when creating, once start it, the docker will use a MAC based on IPaddress to replace it. Maybe a docker defect? They must be not pay attention to MACaddress at all.
So, to avoid issue #863, we need to remove mac attribute for container definition in the doc until the defect fixed by docker.
 
After mkdocker, the Macaddress are looks like this:  
"Networks": {
                "mynet0": {
                    "IPAMConfig": {
                        "IPv4Address": "10.4.30.130"
                    },
                    "Links": null,
                    "Aliases": null,
                    "NetworkID": "",
                    "EndpointID": "",
                    "Gateway": "",
                    "IPAddress": "",
                    "IPPrefixLen": 0,
                    "IPv6Gateway": "",
                    "GlobalIPv6Address": "",
                    "GlobalIPv6PrefixLen": 0,
                    "MacAddress": "00:0a:e6:f3:54:41"
                }
            }
But once the container is started, the Macaddress will be changed:  
"Networks": {
                "mynet0": {
                    "IPAMConfig": {
                        "IPv4Address": "10.4.30.130"
                    },
                    "Links": null,
                    "Aliases": null,
                    "NetworkID": "e02bf7e58e4c9f9e53a4ab874b575251f6fdf1b53995e0962e5ee92951e972f9",
                    "EndpointID": "4a15751295b3981618874a839356236018cc8a55188e97e51aa6bf76f4611ada",
                    "Gateway": "10.4.30.13",
                    "IPAddress": "10.4.30.130",
                    "IPPrefixLen": 8,
                    "IPv6Gateway": "",
                    "GlobalIPv6Address": "",
                    "GlobalIPv6PrefixLen": 0,
                    "MacAddress": "02:42:0a:04:1e:82"
                }
            }