### PR TITLE
replace the digest algorithm of xCAT ssl certificate from sha1 to sha256

### DIFF
--- a/xCAT-server/share/xcat/ca/openssl.cnf.tmpl
+++ b/xCAT-server/share/xcat/ca/openssl.cnf.tmpl
@@ -67,7 +67,7 @@ cert_opt 	= ca_default		# Certificate field options
 
 default_days	= 7300			# how long to certify for
 default_crl_days= 30			# how long before next CRL
-default_md	= sha1			# which md to use.
+default_md	= sha256		# which md to use.
 preserve	= no			# keep passed DN ordering
 
 # A few difference way of specifying how similar the request should look


### PR DESCRIPTION
"xCAT-server/share/xcat/ca/openssl.cnf.tmpl" is used as a template for the openssl.conf, which was the configuration file xCAT use to sign certificates for ssl communication between xcat client and xcatd, the message digest algorithm should be changed to "sha256" instead of "sha1" due to security reasons.

````
default_md      = sha256                # which md to use.
````