### PR TITLE
Sync changed cases from 2.12

### DIFF
--- a/xCAT-server/share/xcat/tools/xCATreg
+++ b/xCAT-server/share/xcat/tools/xCATreg
@@ -667,7 +667,8 @@ sub do_test {
 	my $sn_installation_hierarchy_testcase="";
 	my $diskfull_installation_hierarchy_testcase="";
 	my $diskless_installation_hierarchy_testcase="";
-	my $statelite_installation_hierarchy_testcase="";
+        my $statelite_installation_hierarchy_by_ramdisk_testcase="";
+        my $statelite_installation_hierarchy_by_nfs_testcase="";
 	my $batbundle="";
 	if($mn =~ /sles/ || $mn =~ /rh/){
         $diskfull_installation_flat_testcase="reg_linux_diskfull_installation_flat";
@@ -676,7 +677,8 @@ sub do_test {
         $sn_installation_hierarchy_testcase="reg_linux_SN_installation_hierarchy";
         $diskfull_installation_hierarchy_testcase="reg_linux_diskfull_installation_hierarchy";
         $diskless_installation_hierarchy_testcase="reg_linux_diskless_installation_hierarchy";
-        $statelite_installation_hierarchy_testcase="reg_linux_statelite_installation_hierarchy";
+        $statelite_installation_hierarchy_by_ramdisk_testcase="reg_linux_statelite_installation_hierarchy_by_ramdisk";
+        $statelite_installation_hierarchy_by_nfs_testcase="reg_linux_statelite_installation_hierarchy_by_nfs";
 		$batbundle="p_rhels_cmd.bundle" if($mn =~ /rhp/);
 		$batbundle="x_rhels_cmd.bundle" if($mn =~ /rhx/);
 		$batbundle="p_sles_cmd.bundle" if($mn =~ /slesp/);
@@ -778,11 +780,14 @@ sub do_test {
 		system("xdsh $confkeys{$mn} \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -t $diskless_installation_hierarchy_testcase\" >/dev/null 2>&1");
 		send_msg(2, "[$mn->$confkeys{$mn}][do_test] do diskless installation test in hierarchy mode in $mn.....[done]");
 
-		#statelite installation in hierarchy mode test
-		send_msg(2, "[$mn->$confkeys{$mn}][do_test] doing statelite installation test in hierarchy mode in $mn.....");
-		system("xdsh $confkeys{$mn} \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -t $statelite_installation_hierarchy_testcase\" >/dev/null 2>&1");
-		send_msg(2, "[$mn->$confkeys{$mn}][do_test] do statelite installation test in hierarchy mode in $mn.....[done]");	
-		
+        	#statelite installation by ramdisk in hierarchy mode test
+		send_msg(2, "[$mn->$confkeys{$mn}][do_test] doing statelite installation by ramdisk test in hierarchy mode in $mn.....");
+		system("xdsh $confkeys{$mn} \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -t $statelite_installation_hierarchy_by_ramdisk_testcase\" >/dev/null 2>&1");
+		send_msg(2, "[$mn->$confkeys{$mn}][do_test] do statelite installation by ramdisk test in hierarchy mode in $mn.....[done]");	
+                #statelite installation by nfs in hierarchy mode test
+                send_msg(2, "[$mn->$confkeys{$mn}][do_test] doing statelite installation by nfs test in hierarchy mode in $mn.....");
+                system("xdsh $confkeys{$mn} \"xcattest -f /opt/xcat/share/xcat/tools/autotest/default.conf  -t $statelite_installation_hierarchy_by_nfs_testcase\" >/dev/null 2>&1");
+                send_msg(2, "[$mn->$confkeys{$mn}][do_test] do statelite installation by nfs test in hierarchy mode in $mn.....[done]"); 
     }else{
 		#diskfull installation in flat mode test
 		send_msg(2, "[$mn->$confkeys{$mn}][do_test] doing diskfull installation test in flat mode in $mn.....");
@@ -857,7 +862,7 @@ sub creat_report{
                 $batbundle="$xcatcoredir/xCAT-test/autotest/bundle/p_sles_cmd.bundle" if($k =~ /slesp/);
                 $batbundle="$xcatcoredir/xCAT-test/autotest/bundle/x_sles_cmd.bundle" if($k =~ /slesx/);
                 $totalcase=`cat $batbundle|wc -l`;
-                $totalcase+=7;
+                $totalcase+=8;
                 }elsif($k =~ /ubuntux/){
                 $batbundle="/$xcatcoredir/xCAT-test/autotest/bundle/x_ubuntu_cmd.bundle";
                 $totalcase=`cat $batbundle|wc -l`;

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_nfs
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_nfs
@@ -1,0 +1,99 @@
+start:reg_linux_statelite_installation_hierarchy_by_nfs
+os:Linux
+
+cmd:chdef -t node -o $$CN servicenode=$$SN monserver=$$SN nfsserver=$$SN tftpserver=$$SN  xcatmaster=$$SN
+check:rc==0
+cmd:chdef -t node $$SN groups=service,all
+check:rc==0
+
+cmd:makedns -n
+check:rc==0
+cmd:makeconservercf
+check:rc==0
+cmd:sleep 20
+cmd:if [[ "__GETNODEATTR($$CN,arch)__" =~ "ppc64" ]]; then getmacs -D $$CN; fi
+check:rc==0
+cmd:makedhcp -n
+check:rc==0
+cmd:makedhcp -a
+check:rc==0
+
+cmd:copycds $$ISO
+check:rc==0
+
+cmd:xdsh $$SN df|grep /install;if [ $? -eq 0 ] ;then xdsh $$SN umount /install;fi
+check:rc==0
+cmd:xdsh $$SN 'cat /etc/exports|grep install; if [ "$?" -ne "0" ]; then echo "/install *(rw,no_root_squash,sync,no_subtree_check)" >> /etc/exports; fi'
+check:rc==0
+
+cmd:xdsh $$SN "mkdir -p /nodedata"
+check:rc==0
+cmd:xdsh $$SN "chmod 755 /etc/exports"
+check:rc==0
+cmd:xdsh $$SN 'cat /etc/exports|grep nodedata; if [ "$?" -ne "0" ]; then echo "/nodedata *(rw,no_root_squash,sync,no_subtree_check)" >> /etc/exports; fi'
+check:rc==0
+cmd:xdsh $$SN 'cd /etc; export exports;cd -'
+check:rc==0
+cmd:if cat /etc/*release |grep SUSE >/dev/null;then xdsh $$SN 'service nfsserver restart'; elif cat /etc/*release |grep "Red Hat" >/dev/null;then xdsh $$SN 'service nfs restart'; fi
+check:rc==0
+
+cmd:chtab node=$$CN statelite.statemnt="$$SN:/nodedata"
+check:rc==0
+
+cmd:if cat /etc/*release |grep SUSE >/dev/null; then cp /opt/xcat/share/xcat/tools/autotest/testcase/installation/litefile_sles.csv /tmp/litefile.csv; tabrestore /tmp/litefile.csv; elif cat /etc/*release |grep "Red Hat" >/dev/null; then  tabrestore /opt/xcat/share/xcat/tools/autotest/testcase/installation/litefile.csv; fi
+check:rc==0
+cmd:tabdump litefile
+check:rc==0
+
+cmd:chtab priority=4.7 policy.commands=litefile policy.rule=allow
+check:rc==0
+cmd:chtab priority=4.8 policy.commands=litetree policy.rule=allow
+check:rc==0
+
+cmd:rootimgdir=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir ]; then mv $rootimgdir $rootimgdir.regbak;fi
+check:rc==0
+
+cmd:if cat /etc/*release |grep SUSE >/dev/null;then if [ ! -d /install/custom/netboot/sles ]; then mkdir -p /install/custom/netboot/sles; fi; elif cat /etc/*release |grep "Red Hat" >/dev/null;then if [ ! -d /install/custom/netboot/rh ]; then mkdir -p /install/custom/netboot/rh; fi;fi
+check:rc==0
+cmd:if cat /etc/*release |grep SUSE >/dev/null;then if [ ! -e /install/custom/netboot/sles/compute.synclist ]; then echo "/etc/resolv.conf -> /etc/resolv.conf" > /install/custom/netboot/sles/compute.synclist; fi; elif cat /etc/*release |grep "Red Hat" >/dev/null;then if [ ! -e /install/custom/netboot/rh/compute.synclist ]; then echo "/etc/resolv.conf -> /etc/resolv.conf" > /install/custom/netboot/rh/compute.synclist; fi;fi
+check:rc==0
+cmd:if cat /etc/*release |grep SUSE >/dev/null;then chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute synclists=/install/custom/netboot/sles/compute.synclist rootfstype=; elif cat /etc/*release |grep "Red Hat" >/dev/null;then chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute synclists=/install/custom/netboot/rh/compute.synclist rootfstype=; fi
+check:rc==0
+
+cmd:genimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
+check:rc==0
+cmd:liteimg __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
+check:rc==0
+cmd:prsync /install $$SN:/
+check:rc==0
+
+cmd:nodeset $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
+check:rc==0
+cmd:lsdef $$CN |grep provmethod
+check:rc==0
+check:output=~statelite
+cmd:if [[ "__GETNODEATTR($$CN,arch)__" =~ "ppc64" ]]; then rnetboot $$CN;elif [[ "__GETNODEATTR($$CN,arch)__" =~ "x86_64" ]];then rpower $$CN boot; fi
+check:rc==0
+
+cmd:sleep 900
+cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 10;((a++));if [ $a -gt 60 ];then break;fi done
+
+cmd:ping $$CN -c 3
+check:rc==0
+check:output=~64 bytes from $$CN
+cmd:lsdef -l $$CN | grep status
+check:rc==0
+check:output=~booted
+cmd:xdsh $$CN date
+check:rc==0
+check:output=~\d\d:\d\d:\d\d
+cmd:xdsh $$CN mount
+check:rc==0
+check:output=~/nodedata/$$CN on /.statelite/persistent
+check:output=~compute/rootimg on / type nfs
+cmd:MNIP=`cat /etc/hosts|grep $$MN|awk '{print $1}'`; result=`xdsh $$CN "cat /etc/resolv.conf|grep $MNIP"`; if [ "$result" = "$$CN: nameserver $MNIP" ]; then echo "sync file works well"; fi;
+check:output=~sync file works well
+
+cmd:rootimgdir=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir ]; then rm -rf $rootimgdir;fi
+check:rc==0
+end

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_ramdisk
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_ramdisk
@@ -1,0 +1,101 @@
+start:reg_linux_statelite_installation_hierarchy_by_ramdisk
+os:Linux
+
+cmd:chdef -t node -o $$CN servicenode=$$SN monserver=$$SN nfsserver=$$SN tftpserver=$$SN  xcatmaster=$$SN
+check:rc==0
+cmd:chdef -t node $$SN groups=service,all
+check:rc==0
+
+cmd:makedns -n
+check:rc==0
+cmd:makeconservercf
+check:rc==0
+cmd:sleep 20
+cmd:if [[ "__GETNODEATTR($$CN,arch)__" =~ "ppc64" ]]; then getmacs -D $$CN; fi
+check:rc==0
+cmd:makedhcp -n
+check:rc==0
+cmd:makedhcp -a
+check:rc==0
+
+cmd:copycds $$ISO
+check:rc==0
+
+cmd:xdsh $$SN df|grep /install;if [ $? -eq 0 ] ;then xdsh $$SN umount /install;fi
+check:rc==0
+cmd:xdsh $$SN 'cat /etc/exports|grep install; if [ "$?" -ne "0" ]; then echo "/install *(rw,no_root_squash,sync,no_subtree_check)" >> /etc/exports; fi'
+check:rc==0
+
+cmd:xdsh $$SN "mkdir -p /nodedata"
+check:rc==0
+cmd:xdsh $$SN "chmod 755 /etc/exports"
+check:rc==0
+cmd:xdsh $$SN 'cat /etc/exports|grep nodedata; if [ "$?" -ne "0" ]; then echo "/nodedata *(rw,no_root_squash,sync,no_subtree_check)" >> /etc/exports; fi'
+check:rc==0
+cmd:xdsh $$SN 'cd /etc; export exports;cd -'
+check:rc==0
+cmd:if cat /etc/*release |grep SUSE >/dev/null;then xdsh $$SN 'service nfsserver restart'; elif cat /etc/*release |grep "Red Hat" >/dev/null;then xdsh $$SN 'service nfs restart'; fi
+check:rc==0
+
+cmd:chtab node=$$CN statelite.statemnt="$$SN:/nodedata"
+check:rc==0
+
+cmd:if cat /etc/*release |grep SUSE >/dev/null; then cp /opt/xcat/share/xcat/tools/autotest/testcase/installation/litefile_sles.csv /tmp/litefile.csv; tabrestore /tmp/litefile.csv; elif cat /etc/*release |grep "Red Hat" >/dev/null; then  tabrestore /opt/xcat/share/xcat/tools/autotest/testcase/installation/litefile.csv; fi
+check:rc==0
+cmd:tabdump litefile
+check:rc==0
+
+cmd:chtab priority=4.7 policy.commands=litefile policy.rule=allow
+check:rc==0
+cmd:chtab priority=4.8 policy.commands=litetree policy.rule=allow
+check:rc==0
+
+cmd:rootimgdir=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir ]; then mv $rootimgdir $rootimgdir.regbak;fi
+check:rc==0
+
+cmd:if cat /etc/*release |grep SUSE >/dev/null;then if [ ! -d /install/custom/netboot/sles ]; then mkdir -p /install/custom/netboot/sles; fi; elif cat /etc/*release |grep "Red Hat" >/dev/null;then if [ ! -d /install/custom/netboot/rh ]; then mkdir -p /install/custom/netboot/rh; fi;fi
+check:rc==0
+cmd:if cat /etc/*release |grep SUSE >/dev/null;then if [ ! -e /install/custom/netboot/sles/compute.synclist ]; then echo "/etc/resolv.conf -> /etc/resolv.conf" > /install/custom/netboot/sles/compute.synclist; fi; elif cat /etc/*release |grep "Red Hat" >/dev/null;then if [ ! -e /install/custom/netboot/rh/compute.synclist ]; then echo "/etc/resolv.conf -> /etc/resolv.conf" > /install/custom/netboot/rh/compute.synclist; fi;fi
+check:rc==0
+cmd:if cat /etc/*release |grep SUSE >/dev/null;then chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute synclists=/install/custom/netboot/sles/compute.synclist rootfstype=; elif cat /etc/*release |grep "Red Hat" >/dev/null;then chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute synclists=/install/custom/netboot/rh/compute.synclist rootfstype=; fi
+check:rc==0
+
+cmd:chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute rootfstype=ramdisk
+check:rc==0
+cmd:genimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
+check:rc==0
+cmd:liteimg __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
+check:rc==0
+cmd:prsync /install $$SN:/
+check:rc==0
+
+cmd:nodeset $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
+check:rc==0
+cmd:lsdef $$CN |grep provmethod
+check:rc==0
+check:output=~__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
+cmd:if [[ "__GETNODEATTR($$CN,arch)__" =~ "ppc64" ]]; then rnetboot $$CN;elif [[ "__GETNODEATTR($$CN,arch)__" =~ "x86_64" ]];then rpower $$CN boot; fi
+check:rc==0
+
+cmd:sleep 900
+cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 10;((a++));if [ $a -gt 60 ];then break;fi done
+
+cmd:ping $$CN -c 3
+check:rc==0
+check:output=~64 bytes from $$CN
+cmd:lsdef -l $$CN | grep status
+check:rc==0
+check:output=~booted
+cmd:xdsh $$CN date
+check:rc==0
+check:output=~\d\d:\d\d:\d\d
+cmd:xdsh $$CN mount
+check:rc==0
+check:output=~/nodedata/$$CN on /.statelite/persistent
+check:output=~rootfs on / type
+cmd:MNIP=`cat /etc/hosts|grep $$MN|awk '{print $1}'`; result=`xdsh $$CN "cat /etc/resolv.conf|grep $MNIP"`; if [ "$result" = "$$CN: nameserver $MNIP" ]; then echo "sync file works well"; fi;
+check:output=~sync file works well
+
+cmd:rootimgdir=`lsdef -t osimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir.regbak ]; then rm -rf $rootimgdir; mv $rootimgdir.regbak $rootimgdir; fi
+check:rc==0
+end

--- a/xCAT-test/autotest/testcase/runcmdinstaller/cases0
+++ b/xCAT-test/autotest/testcase/runcmdinstaller/cases0
@@ -14,7 +14,7 @@ cmd:if [[ "__GETNODEATTR($$CN,arch)__" =~ "ppc64" ]]; then rnetboot $$CN;elif [[
 check:rc==0
 cmd:sleep 300
 cmd:xdsh $$CN date
-check:output=~2015
+check:output=~$$DATE
 cmd:runcmdinstaller $$CN "ls -al /tmp"
 check:rc==0
 check:output=~yum


### PR DESCRIPTION
@tingtli , please help review code:
What is synced:
1. Divide reg_linux_statelite_installation_hierarchy case into two ones, and also changed the xCATreg.pl.
2. Update runcmdinstaller cases for the year is 2016 not 2015 using $$DATE 

Can't synced:
1. xcatd new cases, developer doesn't sync code.
2. updatenode new cases, doesn't run in 2.11 till now, so make a mark here, if necessary will sync later.

Thanks.
