### PR TITLE
fix issue #901:add xz to rh6 netboot pkglist; do not mount /proc,/sys and /dev during genimage for rh6; do not add syslog module for dracut to generate initrd on rh6

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels6.ppc64.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels6.ppc64.pkglist
@@ -24,3 +24,4 @@ lsvpd
 irqbalance
 procps
 parted
+xz

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels6.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels6.x86_64.pkglist
@@ -20,3 +20,4 @@ rsync
 rsyslog
 e2fsprogs
 parted
+xz

--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -73,18 +73,35 @@ sub xdie {
    die @_;
 }
 
+
+#helper subroutine to get the major release number 
+#of a osver
+sub majversion {
+    my $version=shift;
+    my $majorrel;
+
+    if($osver =~ /$\D*(\d*)[.\d]*$/){
+        $majorrel=$1;
+    }
+
+    return $majorrel;    
+}
+
 sub mount_chroot {
     my $rootimage_dir = shift;
 
-    #postinstall script of package installation
-    #might access the /proc, /sys and /dev filesystem
-    #mount them from host read-only
-    system("mkdir -p $rootimage_dir/proc");
-    system("mount proc $rootimage_dir/proc -t proc -o ro");
-    system("mkdir -p $rootimage_dir/sys");
-    system("mount sysfs $rootimage_dir/sys -t sysfs -o ro");
-    system("mkdir -p $rootimage_dir/dev");
-    system("mount devtmpfs $rootimage_dir/dev -t devtmpfs -o ro");
+    if(majversion($osver) > 6){
+       #postinstall script of package installation
+       #might access the /proc, /sys and /dev filesystem
+       #mount them from host read-only
+       #only available for rh7 or above
+       system("mkdir -p $rootimage_dir/proc");
+       system("mount proc $rootimage_dir/proc -t proc -o ro");
+       system("mkdir -p $rootimage_dir/sys");
+       system("mount sysfs $rootimage_dir/sys -t sysfs -o ro");
+       system("mkdir -p $rootimage_dir/dev");
+       system("mount devtmpfs $rootimage_dir/dev -t devtmpfs -o ro");
+    }
 }
 
 
@@ -92,9 +109,11 @@ sub mount_chroot {
 sub umount_chroot {
     my $rootimage_dir = shift;
 
-    system("umount $rootimage_dir/proc");
-    system("umount $rootimage_dir/sys");
-    system("umount $rootimage_dir/dev");
+    if(majversion($osver) >6){
+        system("umount $rootimage_dir/proc");
+        system("umount $rootimage_dir/sys");
+        system("umount $rootimage_dir/dev");
+    }
 }
 
 #check whether a dir is NFS mounted
@@ -969,14 +988,19 @@ sub mkinitrd_dracut {
         $perm = (stat("$fullpath/$dracutdir/installkernel"))[2];
         chmod($perm&07777, "$dracutmpath/installkernel");
 
+        my $dracutmodulelist=" xcat nfs base network kernel-modules ";
+        if (-d glob($dracutmoduledir."[0-9]*fadump")){
+            $dracutmodulelist .=" fadump ";
+
+        }
+
+        if ($dracutver >= "033") {
+            $dracutmodulelist .= " syslog ";
+        }
+
         # update etc/dracut.conf
         open($DRACUTCONF, '>', "$rootimg_dir/etc/dracut.conf");
-        if (-d glob($dracutmoduledir."[0-9]*fadump")){
-            print $DRACUTCONF qq{dracutmodules+="xcat nfs base network kernel-modules fadump syslog"\n};
-        }
-        else{
-            print $DRACUTCONF qq{dracutmodules+="xcat nfs base network kernel-modules syslog"\n};
-        }
+        print $DRACUTCONF qq{dracutmodules+="$$dracutmodulelist"\n};
         print $DRACUTCONF qq{add_drivers+="$add_drivers"\n};
         close $DRACUTCONF;
     } else {

--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -77,11 +77,11 @@ sub xdie {
 #helper subroutine to get the major release number 
 #of a osver
 sub majversion {
-    my $version=shift;
+    my $version = shift;
     my $majorrel;
 
-    if($osver =~ /$\D*(\d*)[.\d]*$/){
-        $majorrel=$1;
+    if($osver =~ /^\D*(\d*)[.\d]*$/){
+        $majorrel = $1;
     }
 
     return $majorrel;    
@@ -90,11 +90,10 @@ sub majversion {
 sub mount_chroot {
     my $rootimage_dir = shift;
 
+    #postinstall script of some packages might access the /proc, /sys and /dev filesystem
+    #For Redhat7 or above, mount these directories readonly from host to avoid error messages
+    #For Redhat6 or below, mount these directories might introduce error messages
     if(majversion($osver) > 6){
-       #postinstall script of package installation
-       #might access the /proc, /sys and /dev filesystem
-       #mount them from host read-only
-       #only available for rh7 or above
        system("mkdir -p $rootimage_dir/proc");
        system("mount proc $rootimage_dir/proc -t proc -o ro");
        system("mkdir -p $rootimage_dir/sys");


### PR DESCRIPTION
fix issue #https://github.com/xcat2/xcat-core/issues/901
add xz to rh6 netboot pkglist;
do not mount /proc,/sys and /dev during genimage for rh6;
do not add syslog module for dracut to generate initrd on rh6