### PR TITLE
Support Mariadb on ubuntu 16.04

### DIFF
--- a/docs/source/advanced/hierarchy/databases/mysql_configure.rst
+++ b/docs/source/advanced/hierarchy/databases/mysql_configure.rst
@@ -29,7 +29,7 @@ Granting/Revoking access to the database for Service Node Clients
 
 * Log into the MySQL interactive program.  ::
 
-    /usr/bin/mysql -r root -p
+    /usr/bin/mysql -u root -p
 
 * Granting access to the xCAT database.  Service Nodes are required for xCAT hierarchical support.  Compute nodes may also need access that depends on which application is going to run. (xcat201 is xcatadmin's password for following examples) ::
 

--- a/docs/source/advanced/hierarchy/databases/mysql_install.rst
+++ b/docs/source/advanced/hierarchy/databases/mysql_install.rst
@@ -77,7 +77,7 @@ Debian/Ubuntu
         mysql-server-5*
         mysql-server-core-5*
 
-* MariaDB - Using ``apt-get``, ensure that the following packages are installed on the management node: ::
+* MariaDB - Using ``apt-get``, ensure that the following packages are installed on the management node. ``apt-get install mariadb-server`` will pull in all required packages. For Ubuntu 16.04, it no longer required ``libmariadbclient18``. ::
 
         libmariadbclient18
         mariadb-client

--- a/xCAT-client/bin/mysqlsetup
+++ b/xCAT-client/bin/mysqlsetup
@@ -874,12 +874,20 @@ sub initmysqldb
     }    # end AIX only
 
     #on debian/ubuntu should comment the bind-adress line in my.cnf
+    #on Ubuntu16.04, the bind-address line is in the mariadb.conf.d/50-server.cnf
     if ( $::debianflag ){
-        $cmd = "sed 's/\\(^\\s*bind.*\\)/#\\1/' /etc/mysql/my.cnf > /tmp/my.cnf; mv -f /tmp/my.cnf /etc/mysql/my.cnf;chmod 644 /etc/mysql/my.cnf";
+        my $bind_file;
+        if (-e "/etc/mysql/mariadb.conf.d/50-server.cnf")
+        {
+            $bind_file = "/etc/mysql/mariadb.conf.d/50-server.cnf";
+        } else {
+            $bind_file = "/etc/mysql/my.cnf";
+        }
+        $cmd = "sed 's/\\(^\\s*bind.*\\)/#\\1/' $bind_file > /tmp/my.cnf; mv -f /tmp/my.cnf $bind_file;chmod 644 $bind_file";
         xCAT::Utils->runcmd($cmd, 0);
         if ($::RUNCMD_RC != 0)
         {
-            xCAT::MsgUtils->message("E", " comment the bind-address line in /etc/mysql/my.cfg failed: $cmd.");
+            xCAT::MsgUtils->message("E", " comment the bind-address line in $bind_file failed: $cmd.");
             exit(1);
         }
     }


### PR DESCRIPTION
For issue #908 
1) update Mariadb documentation to indicate no longer required libmariadbclient18 for ubuntu16.04
2) for ubuntu16.04,  the line for bind_address is in the /etc/mysql/mariadb.conf.d/50-server.cnf, not in the /etc/mysql/my.cnf any more.