### PR TITLE
Fix bug #977 support running script in xcat test case and bug #982 update xcattest log recording time

### DIFF
--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -592,7 +592,7 @@ sub loadcase
             }elsif($line =~ /^stop\s*:\s*(\w[\w\,]+)/){
                 next if $skip;
                 $cases[$i]->{stop}=$1;
-            }elsif($line =~ /^cmd\s*:\s*([\$\w].+)/){
+            }elsif($line =~ /^cmd\s*:\s*([\/\$\w].+)/){
                 next if $skip;
                 $j = $j + 1;
                 $z = 0;
@@ -740,7 +740,7 @@ sub runcase
         $j = 0;
         $total = $total + 1;
         my $now1=timelocal(localtime());
-        my $time1=gmtime $now1;
+        my $time1=scalar(localtime());
         log_this("------START:$$case{name}::Time:$time1------");
         push @record, "------START:$$case{name}::Time:$time1------";
         push @record, "FILENAME:$$case{filename}";
@@ -855,7 +855,7 @@ sub runcase
             $j = $j + 1;
         }
         my $now2=timelocal(localtime());
-        my $time2=gmtime $now2;
+        my $time2 = scalar(localtime());
         my $diff=$now2-$now1;
         if($failed){
             log_this("------END::$$case{name}::Failed::Time:$time2 ::Duration::$diff sec------");


### PR DESCRIPTION
This pull request covers 2 things:
1, Fix bug #977 support running script in xcat test case 
2. Fix bug #982  update xcattest log recording time. We used system time to calculate ``xcattest`` itself running time, but used Greenwich time to calculate each test case running time, so it will cause problem in ``xcattest`` result report file.