### PR TITLE
Delete signal to stop monitor process

### DIFF
--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -962,7 +962,6 @@ $SIG{TERM} = $SIG{INT} = sub {
         kill 'USR2', $pid_UDP;
     }
     if ($pid_MON) {
-        kill 'INT', $pid_MON;
         kill 'USR2', $pid_MON;
     }
     xCAT::Table::shut_dbworker;


### PR DESCRIPTION
Currently INT signal and USR2 signal are sent to stop the monitor
process at the same time, just keep USR2 as the stop signal in this
patch.

Close-issue: #972