### PR TITLE
Fix bug 995 [FVT]xcattest does not support vmstorage=dir:///var/lib/libvirt/images/ in default.conf

### DIFF
--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -197,7 +197,7 @@ sub getConfig
             }
         }elsif ($type eq "Object") {
             ##OBJECT BLOCK##
-               if($line =~ /(\w+)\s*=\s*([:\w\.\-]+)/) {
+               if($line =~ /(\w+)\s*=\s*([:\w\.\-\/]+)/) {
                $attr = $1;
                $value = $2;
                if($attr eq "Name"){


### PR DESCRIPTION
Fix bug #995 xcattest does not support vmstorage=dir:///var/lib/libvirt/images/ in default.conf