### PR TITLE
Fix 998[FVT] Ubuntu14.04.4 is dash now, so automation test cases should be updated

### DIFF
--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -882,7 +882,7 @@ sub runcmd
     my $rc = 0;
     $::RUNCMD_RC = 0;
     my $outref = [];
-    @$outref = `$cmd 2>&1`;
+    @$outref = `/bin/bash -lic '$cmd 2>&1'`;
     if ($?)
     {
         $rc = $? ;


### PR DESCRIPTION
Fix bug #998, Ubuntu14.04.4 is dash now, so automation test cases should be updated