### PR TITLE
remove install_initd and remove_initd in spec

### DIFF
--- a/xCAT-server/xCAT-server.spec
+++ b/xCAT-server/xCAT-server.spec
@@ -413,9 +413,7 @@ fi
 ln -sf $RPM_INSTALL_PREFIX0/sbin/xcatd /usr/sbin/xcatd
 
 if [ "$1" = "1" ]; then #Only if installing for the first time..
- if [ -x /usr/lib/lsb/install_initd ]; then
-   /usr/lib/lsb/install_initd /etc/init.d/xcatd
- elif [ -x /sbin/chkconfig ]; then
+ if [ -x /sbin/chkconfig ]; then
    /sbin/chkconfig --add xcatd
  else
    echo "Unable to register init scripts on this system"
@@ -463,9 +461,7 @@ if [ $1 == 0 ]; then  #This means only on -e
 	if [ -f "/proc/cmdline" ]; then   # prevent running it during install into chroot image
   		/etc/init.d/xcatd stop
   	fi
-  if [ -x /usr/lib/lsb/remove_initd ]; then
-      /usr/lib/lsb/remove_initd /etc/init.d/xcatd
-  elif [ -x /sbin/chkconfig ]; then
+  if [ -x /sbin/chkconfig ]; then
     /sbin/chkconfig --del xcatd
   fi
   rm -f /usr/sbin/xcatd  #remove the symbolic


### PR DESCRIPTION
fix https://github.com/xcat2/xcat-core/issues/492

 install_initd has become a link to chkconfig, `` /usr/lib/lsb/install_initd /etc/init.d/xcatd`` does nothing