### PR TITLE
fix issue  [Customere]xcatd service can not be started automatically after reboot for RHEL7.2 #492 

### DIFF
--- a/xCAT-server/xCAT-server.spec
+++ b/xCAT-server/xCAT-server.spec
@@ -413,9 +413,7 @@ fi
 ln -sf $RPM_INSTALL_PREFIX0/sbin/xcatd /usr/sbin/xcatd
 
 if [ "$1" = "1" ]; then #Only if installing for the first time..
- if [ -x /usr/lib/lsb/install_initd ]; then
-   /usr/lib/lsb/install_initd /etc/init.d/xcatd
- elif [ -x /sbin/chkconfig ]; then
+ if [ -x /sbin/chkconfig ]; then
    /sbin/chkconfig --add xcatd
  else
    echo "Unable to register init scripts on this system"
@@ -463,9 +461,7 @@ if [ $1 == 0 ]; then  #This means only on -e
 	if [ -f "/proc/cmdline" ]; then   # prevent running it during install into chroot image
   		/etc/init.d/xcatd stop
   	fi
-  if [ -x /usr/lib/lsb/remove_initd ]; then
-      /usr/lib/lsb/remove_initd /etc/init.d/xcatd
-  elif [ -x /sbin/chkconfig ]; then
+  if [ -x /sbin/chkconfig ]; then
     /sbin/chkconfig --del xcatd
   fi
   rm -f /usr/sbin/xcatd  #remove the symbolic

--- a/xCAT-server/xCAT-server.spec
+++ b/xCAT-server/xCAT-server.spec
@@ -413,12 +413,15 @@ fi
 ln -sf $RPM_INSTALL_PREFIX0/sbin/xcatd /usr/sbin/xcatd
 
 if [ "$1" = "1" ]; then #Only if installing for the first time..
- if [ -x /sbin/chkconfig ]; then
-   /sbin/chkconfig --add xcatd
- else
-   echo "Unable to register init scripts on this system"
- fi
+   if [ -x /sbin/chkconfig ]; then
+       /sbin/chkconfig --add xcatd
+   elif [ -x /usr/lib/lsb/install_initd ]; then
+       /usr/lib/lsb/install_initd /etc/init.d/xcatd
+   else
+     echo "Unable to register init scripts on this system"
+   fi
 fi
+
 if [ "$1" -gt "1" ]; then #only on upgrade...
   #migration issue for monitoring
   XCATROOT=$RPM_INSTALL_PREFIX0 $RPM_INSTALL_PREFIX0/sbin/chtab filename=monitorctrl.pm notification -d
@@ -461,8 +464,11 @@ if [ $1 == 0 ]; then  #This means only on -e
 	if [ -f "/proc/cmdline" ]; then   # prevent running it during install into chroot image
   		/etc/init.d/xcatd stop
   	fi
+
   if [ -x /sbin/chkconfig ]; then
-    /sbin/chkconfig --del xcatd
+      /sbin/chkconfig --del xcatd
+  elif [ -x /usr/lib/lsb/remove_initd ]; then
+      /usr/lib/lsb/remove_initd /etc/init.d/xcatd
   fi
   rm -f /usr/sbin/xcatd  #remove the symbolic
 


### PR DESCRIPTION
/usr/lib/lsb/remove_initd and /usr/lib/lsb/install_initd shipped in redhat-lsb-core has been a link to chkconfig in redhat7.2, whis will cause problem while enabling xcatd service after xCAT-server installation when redhat-lsb-core is installed