### PR TITLE
Adding two new files to xCAT-genesis-scripts spec file to resolve build error

### DIFF
--- a/xCAT-genesis-scripts/xCAT-genesis-scripts.spec
+++ b/xCAT-genesis-scripts/xCAT-genesis-scripts.spec
@@ -112,4 +112,6 @@ touch /etc/xcat/genesis-scripts-updated
 %{rpminstallroot}/debian/rules
 %{rpminstallroot}/etc/init.d/functions
 %{rpminstallroot}/etc/udev/rules.d/99-imm.rules
+%{rpminstallroot}/etc/udev/rules.d/98-mlx.rules
 %{rpminstallroot}/sbin/setupimmnic
+%{rpminstallroot}/sbin/loadmlxeth 


### PR DESCRIPTION
Added the missing files to the .spec file that were missed in commit 4fea80d7 which caused the following build failure.  fyi @jjohnson42 

```
Building /home/vhu/rpmbuild/RPMS/noarch/xCAT-genesis-scripts-x86_64-2.12-snap*.noarch.rpm ...
Building target platforms: x86_64
Building for target x86_64
error: Installed (but unpackaged) file(s) found:
   /opt/xcat/share/xcat/netboot/genesis/x86_64/fs/etc/udev/rules.d/98-mlx.rules
   /opt/xcat/share/xcat/netboot/genesis/x86_64/fs/sbin/loadmlxeth
    Installed (but unpackaged) file(s) found:
   /opt/xcat/share/xcat/netboot/genesis/x86_64/fs/etc/udev/rules.d/98-mlx.rules
   /opt/xcat/share/xcat/netboot/genesis/x86_64/fs/sbin/loadmlxeth
```