### PR TITLE
Revert "Adding two new files to xCAT-genesis-scripts spec file to resolve build error"

### DIFF
--- a/xCAT-genesis-scripts/xCAT-genesis-scripts.spec
+++ b/xCAT-genesis-scripts/xCAT-genesis-scripts.spec
@@ -112,6 +112,4 @@ touch /etc/xcat/genesis-scripts-updated
 %{rpminstallroot}/debian/rules
 %{rpminstallroot}/etc/init.d/functions
 %{rpminstallroot}/etc/udev/rules.d/99-imm.rules
-%{rpminstallroot}/etc/udev/rules.d/98-mlx.rules
 %{rpminstallroot}/sbin/setupimmnic
-%{rpminstallroot}/sbin/loadmlxeth 


### PR DESCRIPTION
Reverts xcat2/xcat-core#1019
This change caused the issue #1025. We revert it first and try to find a more reasonable fix.