### PR TITLE
call info() before deleting vm volume

### DIFF
--- a/xCAT-server/lib/xcat/plugins/kvm.pm
+++ b/xCAT-server/lib/xcat/plugins/kvm.pm
@@ -1735,7 +1735,7 @@ sub rmvm {
     if ($currstate eq 'on') {
         if ($force) {
             $currxml = $dom->get_xml_description();
-            $dom->destroy();
+            $dom->shutdown();
         } else {
             xCAT::SvrUtils::sendmsg([ 1, "Cannot rmvm active guest (use -f argument to force)" ], $callback, $node);
             return;
@@ -1753,6 +1753,8 @@ sub rmvm {
             my $file = $disk->getAttribute("file");
             my $vol  = $hypconn->get_storage_volume_by_path($file);
             if ($vol) {
+                # Need to call get_info() before deleting a volume, without that, delete() will fail. Issue #455
+                $vol->get_info();
                 $vol->delete();
             }
         }


### PR DESCRIPTION
This pull request fixes issue #455.

1. Changed destroy() to shutdown(). The libvir documentation describes destroy() as an equivalent of pulling a power cord and recommends using shutdown() instead.

2. get_info() needs to be called before deleting a volume. This seems to be the only thing that works. Adding sleeps between shutdown and delete volume did not solve the problem.