### PR TITLE
Update tabprune auditlog related case

### DIFF
--- a/xCAT-test/autotest/testcase/tabprune/cases0
+++ b/xCAT-test/autotest/testcase/tabprune/cases0
@@ -41,6 +41,10 @@ start:tabprune_i_auditlog
 description:remove the records whose recid is less than the input recid number
 cmd:chtab key=auditskipcmds site.value=
 check:rc=0
+cmd:lsdef -t site
+cmd:lsdef -t site
+cmd:lsdef -t site
+cmd:sleep 3
 cmd:n1=`lsdef -t auditlog|sed -n 2p|awk '{print $1}'`;tabprune auditlog -i $n1;n1=$(($n1-1));lsdef -t auditlog -l $n1
 check:rc=0
 check:output=~tabprune of auditlog complete

--- a/xCAT-test/autotest/testcase/tabprune/cases0
+++ b/xCAT-test/autotest/testcase/tabprune/cases0
@@ -49,7 +49,7 @@ cmd:n1=`lsdef -t auditlog|sed -n 2p|awk '{print $1}'`;tabprune auditlog -i $n1;n
 check:rc=0
 check:output=~tabprune of auditlog complete
 check:output=~Could not get xCAT object definitions
-cmd:cmd:chtab key=auditskipcmds site.value=ALL
+cmd:chtab key=auditskipcmds site.value=ALL
 check:rc=0
 end
 


### PR DESCRIPTION
Hi @tingtli 
Please help to review code change for tabprune auditlog related case.

```
To run:
tabprune_i_auditlog_1
Not to run:
******************************
Start to run test cases
******************************
------START:tabprune_i_auditlog_1::Time:Thu May  5 05:49:49 2016------

RUN:chtab key=auditskipcmds site.value=

[chtab key=auditskipcmds site.value=] Running Time:1 sec
RETURN: rc = 0
OUTPUT:
CHECK:rc = 0    [Pass]

RUN:lsdef -t site

[lsdef -t site] Running Time:1 sec
RETURN: rc = 0
OUTPUT:
clustersite  (site)

RUN:lsdef -t site

[lsdef -t site] Running Time:0 sec
RETURN: rc = 0
OUTPUT:
clustersite  (site)

RUN:lsdef -t site

[lsdef -t site] Running Time:1 sec
RETURN: rc = 0
OUTPUT:
clustersite  (site)

RUN:sleep 3
[sleep 3] Running Time:3 sec
RETURN: rc = 0
OUTPUT:

RUN:n1=`lsdef -t auditlog|sed -n 2p|awk '{print $1}'`;tabprune auditlog -i $n1;n1=$(($n1-1));lsdef -t auditlog -l $n1

[n1=`lsdef -t auditlog|sed -n 2p|awk '{print $1}'`;tabprune auditlog -i $n1;n1=$(($n1-1));lsdef -t auditlog -l $n1] Running Time:2 sec
RETURN: rc = 1
OUTPUT:
tabprune of auditlog complete.
Error: Could not get xCAT object definitions.
CHECK:rc = 0    [Pass]
CHECK:output =~ tabprune of auditlog complete   [Pass]
CHECK:output =~ Could not get xCAT object definitions   [Pass]

RUN:cmd:chtab key=auditskipcmds site.value=ALL

[cmd:chtab key=auditskipcmds site.value=ALL] Running Time:0 sec
RETURN: rc = 72057594037927935
OUTPUT:
CHECK:rc = 0    [Pass]
------END::tabprune_i_auditlog_1::Passed::Time:Thu May  5 05:49:57 2016 ::Duration::8 sec------
```

