### PR TITLE
Do not undef nodelist reference in DB process

### DIFF
--- a/perl-xCAT/xCAT/Table.pm
+++ b/perl-xCAT/xCAT/Table.pm
@@ -3501,10 +3501,12 @@ sub close
     my $self = shift;
     #if ($self->{dbh}) { $self->{dbh}->disconnect(); }
     #undef $self->{dbh};
-    if ($self->{tabname} eq 'nodelist') {
-       undef $self->{nodelist};
-    } else {
-       $self->{nodelist}->close();
+    if ($0 ne "xcatd: DB Access") {
+        if ($self->{tabname} eq 'nodelist') {
+            undef $self->{nodelist};
+        } else {
+            $self->{nodelist}->close();
+        }
     }
 }
 

--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -1293,6 +1293,8 @@ my @pendingconnections;
 my $tconn;
 my $sslfudgefactor = 0;
 my $udpalive = 1;
+# Make sure DB process is ready.
+wait_db_process();
 until ($quit) {
     $SIG{CHLD} = \&ssl_reaper; # set here to ensure that signal handler is not corrupted during loop
     while ($udpalive and $udpwatcher->can_read(0)) {  # take an intermission to broker some state requests from udp traffic control
@@ -2352,6 +2354,33 @@ sub becomeuser {
     # If here, unable to validate given credential
     return undef;
 }
+
+# Wait for the db process
+sub wait_db_process {
+    my $retry = 100;
+    my $ready = 0;
+    # Make sure DB process is ready, so that no direct access
+    while($retry) {
+        if (!xCAT::Utils::is_process_exists($dbmaster)) {
+            sleep 0.1;
+        } else {
+            $ready = 1;
+            last;
+        }
+        $retry --;
+    }
+    if (!$ready) {
+        xCAT::MsgUtils->message("S","Error: xcat db process has not been started in 10 seconds.");
+        return -1;
+    }
+    # use create 1 to make sure nodelist and site object cached.
+    my $tmptab = xCAT::Table->new('site',-create=>1);
+    if(!$tmptab) {
+        return -1;
+    }
+    return 0;
+}
+
 sub populate_site_hash {
     %::XCATSITEVALS=();
     my $sitetab = xCAT::Table->new('site',-create=>0);


### PR DESCRIPTION
This patch add check method to wait for the DB process in xcatd.
Enhance the close method in Table.pm to disable the undef operation
for nodelist in DB process as the reference has already been cached
as a weak reference.

close-issue: #1011