### PR TITLE
Make the --check example consistent with the usage in bmcdiscover man page

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/bmcdiscover.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/bmcdiscover.1.rst
@@ -169,7 +169,7 @@ Note: Input for IP range can be in the form: scanme.nmap.org, microsoft.com/24, 
 
 .. code-block:: perl
 
-     bmcdiscover -i 10.4.23.254 -u USERID -p PASSW0RD -c
+     bmcdiscover -i 10.4.23.254 -u USERID -p PASSW0RD --check
 
 
 5. Get BMC IP Address source, DHCP Address or static Address

--- a/xCAT-client/pods/man1/bmcdiscover.1.pod
+++ b/xCAT-client/pods/man1/bmcdiscover.1.pod
@@ -104,7 +104,7 @@ Note: Input for IP range can be in the form: scanme.nmap.org, microsoft.com/24, 
 
 4. To check if the username or password is correct against the BMC:
 
-    bmcdiscover -i 10.4.23.254 -u USERID -p PASSW0RD -c
+    bmcdiscover -i 10.4.23.254 -u USERID -p PASSW0RD --check
 
 5. Get BMC IP Address source, DHCP Address or static Address
 


### PR DESCRIPTION
Fix Issue #834 

The --check is used in the usage but the example below is using the -c option.
Both the --check and -c option will work, but sync up the example to match the usage. 