### PR TITLE
Add back in the changes for mellanox workaround 

### DIFF
--- a/xCAT-genesis-scripts/etc/udev/rules.d/98-mlx.rules
+++ b/xCAT-genesis-scripts/etc/udev/rules.d/98-mlx.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="pci", ATTRS{subsystem_vendor}=="15b3", ATTRS{subsystem_device}=="4010", RUN+="/sbin/loadmlxeth"

--- a/xCAT-genesis-scripts/sbin/loadmlxeth
+++ b/xCAT-genesis-scripts/sbin/loadmlxeth
@@ -1,0 +1,2 @@
+#!/bin/sh
+/sbin/modprobe mlx4_en

--- a/xCAT-genesis-scripts/xCAT-genesis-scripts.spec
+++ b/xCAT-genesis-scripts/xCAT-genesis-scripts.spec
@@ -112,4 +112,6 @@ touch /etc/xcat/genesis-scripts-updated
 %{rpminstallroot}/debian/rules
 %{rpminstallroot}/etc/init.d/functions
 %{rpminstallroot}/etc/udev/rules.d/99-imm.rules
+%{rpminstallroot}/etc/udev/rules.d/98-mlx.rules
 %{rpminstallroot}/sbin/setupimmnic
+%{rpminstallroot}/sbin/loadmlxeth 


### PR DESCRIPTION
After @daniceexi removed the following files from the genesis-base in #1025, adding back the changes to genesis-scripts that @jjohnson42  made 