### PR TITLE
The bmcdiscover command does not support -c option, removing from documentation

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/bmcdiscover.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/bmcdiscover.1.rst
@@ -98,7 +98,7 @@ OPTIONS
  
 
 
-\ **-c|-**\ **-check**\ 
+\ **-**\ **-check**\ 
  
  Check BMC administrator User/Password.
  

--- a/xCAT-client/pods/man1/bmcdiscover.1.pod
+++ b/xCAT-client/pods/man1/bmcdiscover.1.pod
@@ -61,7 +61,7 @@ BMC user name.
 
 BMC user password.
 
-=item B<-c|--check>    
+=item B<--check>    
 
 Check BMC administrator User/Password.
 


### PR DESCRIPTION
Fix issue #834.  

After @daniceexi reviewed the pull request #1051, he mentioned that -c option is not supported in the code.  That is right, -c is not supported.  Removing it completely from the doc
