### PR TITLE
from sles11.3, suseboot/linux64 and suseboot/initrd64 should be used in diskful installation instead of suseboot/inst64

### DIFF
--- a/xCAT-server/lib/xcat/plugins/sles.pm
+++ b/xCAT-server/lib/xcat/plugins/sles.pm
@@ -1070,6 +1070,11 @@ sub mkinstall
              and -r "$pkgdir/1/boot/ppc64le/linux"
              and -r "$pkgdir/1/boot/ppc64le/initrd"
             )
+            or (
+             $arch eq "ppc64"
+             and -r "$pkgdir/1/suseboot/linux64"
+             and -r "$pkgdir/1/suseboot/initrd64"
+            )
             or ($arch =~ /ppc/ and -r "$pkgdir/1/suseboot/inst64")
           )
         {
@@ -1118,6 +1123,16 @@ sub mkinstall
                         copy("$pkgdir/1/boot/$arch/initrd", "$tftppath");
                         @dd_drivers = &insert_dd($callback, $os, $arch, "$tftppath/initrd", "$tftppath/linux", $driverupdatesrc, $netdrivers, $osupdir, $ignorekernelchk);
                         xCAT::MsgUtils->trace($verbose_on_off,"d","sles->mkinstall: copy initrd.img and linux to $tftppath");
+                    }
+                }
+                elsif($arch eq "ppc64"  
+                      and -r "$pkgdir/1/suseboot/linux64"
+                      and -r "$pkgdir/1/suseboot/initrd64"){
+                    unless ($noupdateinitrd) {
+                        copy("$pkgdir/1/suseboot/linux64", "$tftppath");
+                        copy("$pkgdir/1/suseboot/initrd64", "$tftppath");
+                        @dd_drivers = &insert_dd($callback, $os, $arch,"$tftppath/initrd64" ,"$tftppath/linux64", undef, $driverupdatesrc, $netdrivers, $osupdir, $ignorekernelchk);
+                        xCAT::MsgUtils->trace($verbose_on_off,"d","sles->mkinstall: copy initrd64 and linux64 to $tftppath");
                     }
                 }
                 elsif ($arch =~ /ppc/)
@@ -1309,6 +1324,22 @@ sub mkinstall
             {
                 $kernelpath = "$rtftppath/linux";
                 $initrdpath = "$rtftppath/initrd";
+                xCAT::MsgUtils->trace($verbose_on_off,"d","sles->mkinstall: kcmdline=$kcmdline kernal=$kernelpath initrd=$initrdpath");
+                $bptab->setNodeAttribs(
+                                        $node,
+                                        {
+                                         kernel   => $kernelpath,
+                                         initrd   => $initrdpath,
+                                         kcmdline => $kcmdline
+                                        }
+                                        );
+            } 
+            elsif ($arch eq "ppc64" 
+                   and -r "$tftppath/linux64"
+                   and -r "$tftppath/initrd64")
+            {
+                $kernelpath = "$rtftppath/linux64";
+                $initrdpath = "$rtftppath/initrd64";
                 xCAT::MsgUtils->trace($verbose_on_off,"d","sles->mkinstall: kcmdline=$kcmdline kernal=$kernelpath initrd=$initrdpath");
                 $bptab->setNodeAttribs(
                                         $node,

--- a/xCAT-server/lib/xcat/plugins/sles.pm
+++ b/xCAT-server/lib/xcat/plugins/sles.pm
@@ -1125,22 +1125,25 @@ sub mkinstall
                         xCAT::MsgUtils->trace($verbose_on_off,"d","sles->mkinstall: copy initrd.img and linux to $tftppath");
                     }
                 }
-                elsif($arch eq "ppc64"  
-                      and -r "$pkgdir/1/suseboot/linux64"
-                      and -r "$pkgdir/1/suseboot/initrd64"){
+                elsif($arch eq "ppc64"){
                     unless ($noupdateinitrd) {
-                        copy("$pkgdir/1/suseboot/linux64", "$tftppath");
-                        copy("$pkgdir/1/suseboot/initrd64", "$tftppath");
-                        @dd_drivers = &insert_dd($callback, $os, $arch,"$tftppath/initrd64" ,"$tftppath/linux64", undef, $driverupdatesrc, $netdrivers, $osupdir, $ignorekernelchk);
-                        xCAT::MsgUtils->trace($verbose_on_off,"d","sles->mkinstall: copy initrd64 and linux64 to $tftppath");
-                    }
-                }
-                elsif ($arch =~ /ppc/)
-                {
-                    unless ($noupdateinitrd) {
-                        copy("$pkgdir/1/suseboot/inst64", "$tftppath");
-                        @dd_drivers = &insert_dd($callback, $os, $arch, "$tftppath/inst64", undef, $driverupdatesrc, $netdrivers, $osupdir, $ignorekernelchk);
-                        xCAT::MsgUtils->trace($verbose_on_off,"d","sles->mkinstall: copy inst64 to $tftppath");
+                        if(-r "$pkgdir/1/suseboot/linux64" and -r "$pkgdir/1/suseboot/initrd64"){
+                            #from sles11.3, suseboot/linux64 and suseboot/initrd64 are used for diskful 
+                            #network installation
+                            #the previous suseboot/inst64 can not be run on Power8 BE
+                            copy("$pkgdir/1/suseboot/linux64", "$tftppath");
+                            copy("$pkgdir/1/suseboot/initrd64", "$tftppath");
+                            #TODO: need to verify whether initrd64 and linux64 can be inserted into initrd
+                            #@dd_drivers = &insert_dd($callback, $os, $arch,"$tftppath/initrd64" ,"$tftppath/linux64", undef, $driverupdatesrc, $netdrivers, $osupdir, $ignorekernelchk);
+                            xCAT::MsgUtils->trace($verbose_on_off,"d","sles->mkinstall: copy initrd64 and linux64 to $tftppath");
+                        }
+                        elsif(-r "$pkgdir/1/suseboot/inst64"){
+                            #suseboot/inst64 is used for network installation before sles11.3
+                            #suseboot/inst64 can not be run on Power8 BE
+                            copy("$pkgdir/1/suseboot/inst64", "$tftppath");
+                            @dd_drivers = &insert_dd($callback, $os, $arch, "$tftppath/inst64", undef, $driverupdatesrc, $netdrivers, $osupdir, $ignorekernelchk);
+                            xCAT::MsgUtils->trace($verbose_on_off,"d","sles->mkinstall: copy inst64 to $tftppath");
+                        }
                     }
                 }
             }
@@ -1334,36 +1337,39 @@ sub mkinstall
                                         }
                                         );
             } 
-            elsif ($arch eq "ppc64" 
-                   and -r "$tftppath/linux64"
-                   and -r "$tftppath/initrd64")
+            elsif ($arch eq "ppc64") 
             {
-                $kernelpath = "$rtftppath/linux64";
-                $initrdpath = "$rtftppath/initrd64";
-                xCAT::MsgUtils->trace($verbose_on_off,"d","sles->mkinstall: kcmdline=$kcmdline kernal=$kernelpath initrd=$initrdpath");
-                $bptab->setNodeAttribs(
-                                        $node,
-                                        {
-                                         kernel   => $kernelpath,
-                                         initrd   => $initrdpath,
-                                         kcmdline => $kcmdline
-                                        }
-                                        );
+                if(-r "$tftppath/linux64" and -r "$tftppath/initrd64"){
+                    #from sles11.3, suseboot/linux64 and suseboot/initrd64 are used for diskful 
+                    #network installation
+                    #the previous suseboot/inst64 can not be run on Power8 BE
+                    $kernelpath = "$rtftppath/linux64";
+                    $initrdpath = "$rtftppath/initrd64";
+                    xCAT::MsgUtils->trace($verbose_on_off,"d","sles->mkinstall: kcmdline=$kcmdline kernal=$kernelpath initrd=$initrdpath");
+                    $bptab->setNodeAttribs(
+                                            $node,
+                                            {
+                                             kernel   => $kernelpath,
+                                             initrd   => $initrdpath,
+                                             kcmdline => $kcmdline
+                                            }
+                                            );
+                }
+                elsif(-r "$tftppath/inst64"){
+                    #suseboot/inst64 is used for network installation before sles11.3
+                    #suseboot/inst64 can not be run on Power8 BE
+                    $kernelpath = "$rtftppath/inst64";
+                    xCAT::MsgUtils->trace($verbose_on_off,"d","sles->mkinstall: kcmdline=$kcmdline kernal=$kernelpath initrd=");
+                    $bptab->setNodeAttribs(
+                                            $node,
+                                            {
+                                             kernel   => $kernelpath,
+                                             initrd   => "",
+                                             kcmdline => $kcmdline
+                                            }
+                                            );
+                }
             }
-            elsif ($arch =~ /ppc/)
-            {
-                $kernelpath = "$rtftppath/inst64";
-                xCAT::MsgUtils->trace($verbose_on_off,"d","sles->mkinstall: kcmdline=$kcmdline kernal=$kernelpath initrd=");
-                $bptab->setNodeAttribs(
-                                        $node,
-                                        {
-                                         kernel   => $kernelpath,
-                                         initrd   => "",
-                                         kcmdline => $kcmdline
-                                        }
-                                        );
-            }
-
         }
         else
         {


### PR DESCRIPTION
fix issue:https://sourceforge.net/p/xcat/bugs/4420/, https://github.com/xcat2/xcat-core/issues/1060

This is recommended in yaboot.cnf file inside sles11.4 iso
````
linux-z38a:~ # cat /install/sles11.4/ppc64/1/suseboot/yaboot.cnf
message=yaboot.txt

image[64bit]=linux64
  label=install
  append="quiet sysrq=1 insmod=sym53c8xx insmod=ipr            "
  initrd=initrd64
image[64bit]=linux64
  label=slp
  append="quiet sysrq=1 install=slp           "
  initrd=initrd64
image[64bit]=linux64
  label=rescue
  append="quiet sysrq=1 rescue=1              "
  initrd=initrd64
````

the previous suseboot/inst64 can not be loaded on P8BE 