### PR TITLE
Move the security advisories over to RTD from GitHub Wiki

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,4 +35,5 @@ Table of Contents
    troubleshooting/index.rst
    developers/index.rst
    help.rst
+   security/index.rst
 

--- a/docs/source/security/2016/20160115_openssl.rst
+++ b/docs/source/security/2016/20160115_openssl.rst
@@ -1,0 +1,28 @@
+2016-01-15 - OpenSSL Vulnerabilities (SLOTH)
+============================================
+
+A detailed description of this issue can be seen in the following blog posting: http://www.mitls.org/pages/attacks/SLOTH
+
+Advisory CVEs
+-------------
+
+`CVE-2015-7575 <https://access.redhat.com/security/cve/CVE-2015-7575>`_ - TLS 1.2 Transcipt Collision attacks against MD5 in key exchange protocol (SLOTH)
+
+Action
+------
+
+xCAT uses OpenSSL for client-server communication but **does not** ship it.  
+
+It is highly recommended to keep your OpenSSL levels up-to-date with the indicated versions in the security bulletins to prevent any potential security threats. Obtain the updated software packages from your Operating system distribution channels. 
+
+
+
+Disable MD5 authentication in the cipher list using the site table keyword ``xcatsslciphers``.
+
+1. Check if MD5 is already disabled: ``tabdump site | grep xcatssl``
+
+2. If nothing is set, add ``ALL:!MD5`` to the cipher list:  ``chtab key=xcatsslciphers site.value='ALL:!MD5'``
+
+3. Restart xcat:  ``service xcatd restart``
+
+

--- a/docs/source/security/2016/20160128_openssl.rst
+++ b/docs/source/security/2016/20160128_openssl.rst
@@ -1,0 +1,28 @@
+2016-01-28 - OpenSSL Vulnerabilities
+====================================
+
+*Jan 28, 2016* OpenSSL announced the following security advisories:  https://mta.openssl.org/pipermail/openssl-announce/2016-January/000061.html
+
+Advisory CVEs
+-------------
+
+* CVE-2016-0701 - **DH small subgroups**  (Severity:High)
+
+  This issue affects OpenSSL version 1.0.2.  
+  OpenSSL 1.0.2 users should upgrade to 1.0.2f
+
+* CVE-2015-3197 - **SSLv2 doesn't block disabled ciphers**   (Severity:Low)
+
+  This issue affects OpenSSL versions 1.0.2 and 1.0.1.  
+
+  OpenSSL 1.0.2 users should upgrade to 1.0.2f  
+  OpenSSL 1.0.1 users should upgrade to 1.0.1r
+
+
+Action
+------
+
+xCAT uses OpenSSL for client-server communication but **does not** ship it.
+
+It is recommended to keep your OpenSSL levels up-to-date with the indicated versions in the security bulletins to prevent any potential security threats. 
+

--- a/docs/source/security/2016/20160301_openssl.rst
+++ b/docs/source/security/2016/20160301_openssl.rst
@@ -1,0 +1,68 @@
+2016-03-01 - OpenSSL Vulnerabilities (DROWN)
+============================================
+
+*March 1, 2016* OpenSSL announced the following security advisories:  https://www.openssl.org/news/secadv/20160301.txt
+
+Advisory CVEs
+-------------
+
+* CVE-2016-0800 - **Cross-protocol attack on TLS using SSLv2 (DROWN)**  (Severity:High)
+
+  This issue affects OpenSSL versions 1.0.1 and 1.0.2.  
+  
+  OpenSSL 1.0.2 users should upgrade to 1.0.2g  
+  OpenSSL 1.0.1 users should upgrade to 1.0.1s
+
+* CVE-2016-0705 - **Double-free in DSA code** (Severity:Low)
+
+  This issue affects OpenSSL versions 1.0.2 and 1.0.1.
+
+  OpenSSL 1.0.2 users should upgrade to 1.0.2g  
+  OpenSSL 1.0.1 users should upgrade to 1.0.1s
+
+* CVE-2016-0798  - **Memory leak in SRP database lookups** (Severity:Low)
+ 
+  This issue affects OpenSSL versions 1.0.2 and 1.0.1.
+
+  OpenSSL 1.0.2 users should upgrade to 1.0.2g  
+  OpenSSL 1.0.1 users should upgrade to 1.0.1s
+
+* CVE-2016-0797  - **BN_hex2bn/BN_dec2bn NULL pointer deref/heap corruption** (Severity:Low)
+ 
+  This issue affects OpenSSL versions 1.0.2 and 1.0.1.
+
+  OpenSSL 1.0.2 users should upgrade to 1.0.2g  
+  OpenSSL 1.0.1 users should upgrade to 1.0.1s
+
+
+* CVE-2016-0797  - **Fix memory issues in BIO_*printf functions** (Severity:Low)
+ 
+  This issue affects OpenSSL versions 1.0.2 and 1.0.1.
+
+  OpenSSL 1.0.2 users should upgrade to 1.0.2g  
+  OpenSSL 1.0.1 users should upgrade to 1.0.1s
+
+
+* CVE-2016-0702  - **Side channel attack on modular exponentiation** (Severity:Low)
+ 
+  This issue affects OpenSSL versions 1.0.2 and 1.0.1.
+
+  OpenSSL 1.0.2 users should upgrade to 1.0.2g  
+  OpenSSL 1.0.1 users should upgrade to 1.0.1s
+
+* CVE-2016-0703  - **Divide-and-conquer session key recovery in SSLv2** (Severity:High)
+ 
+  This issue affected OpenSSL versions 1.0.2, 1.0.1l, 1.0.0q, 0.9.8ze and all earlier versions.  It was fixed in OpenSSL 1.0.2a, 1.0.1m, 1.0.0r and 0.9.8zf
+
+* CVE-2016-0704  - **Bleichenbacher oracle in SSLv2** (Severity:Moderate)
+ 
+  This issue affected OpenSSL versions 1.0.2, 1.0.1l, 1.0.0q, 0.9.8ze and all earlier versions.  It was fixed in OpenSSL 1.0.2a, 1.0.1m, 1.0.0r and 0.9.8zf
+
+
+Action
+------
+
+xCAT uses OpenSSL for client-server communication but **does not** ship it.  Regarding CVE-2016-0800, xCAT also does not use SSLv2 layer but uses the newer TLS transport layer security.  
+
+It is recommended to keep your OpenSSL levels up-to-date with the indicated versions in the security bulletins to prevent any potential security threats. 
+

--- a/docs/source/security/2016/20160503_openssl.rst
+++ b/docs/source/security/2016/20160503_openssl.rst
@@ -1,0 +1,52 @@
+2016-05-03 - OpenSSL Vulnerabilities (ANS.1 encoder)
+====================================================
+
+*May 3, 2016* OpenSSL announced the following security advisories:  https://www.openssl.org/news/secadv/20160503.txt
+
+Advisory CVEs
+-------------
+
+* CVE-2016-2108 - **Memory corruption in the ASN.1 encoder** (Severity:High)
+
+  This issue affects all OpenSSL version prior to April 2015
+  
+  OpenSSL 1.0.2 users should upgrade to 1.0.2c
+  OpenSSL 1.0.1 users should upgrade to 1.0.1o
+
+* CVE-2016-2107 - **Padding oracle in AES-NI CBC MAC check** (Severity: High)
+
+  This issue was introduced as part of the fix for Lucky 13 padding attack (CVE-2013-0169)
+
+  OpenSSL 1.0.2 users should upgrade to 1.0.2h
+  OpenSSL 1.0.1 users should upgrade to 1.0.1t
+
+* CVE-2016-2105 - **EVP_EncodeUpdate overflow** (Severity:Low)
+ 
+  OpenSSL 1.0.2 users should upgrade to 1.0.2h
+  OpenSSL 1.0.1 users should upgrade to 1.0.1t
+
+* CVE-2016-2106 - **EVP_EncryptUpdate overflow** (Severity:Low)
+ 
+  OpenSSL 1.0.2 users should upgrade to 1.0.2h
+  OpenSSL 1.0.1 users should upgrade to 1.0.1t
+
+
+* CVE-2016-2109 - **ASN.1 BIO excessive memory allocation** (Severity:Low)
+
+  OpenSSL 1.0.2 users should upgrade to 1.0.2h
+  OpenSSL 1.0.1 users should upgrade to 1.0.1t
+
+
+* CVE-2016-2176 - **EBCDIC overread** (Severity:Low)
+ 
+  OpenSSL 1.0.2 users should upgrade to 1.0.2h
+  OpenSSL 1.0.1 users should upgrade to 1.0.1t
+
+
+Action
+------
+
+xCAT uses OpenSSL for client-server communication but **does not** ship it.  
+
+It is recommended to keep your OpenSSL levels up-to-date with the indicated versions in the security bulletins to prevent any potential security threats. 
+

--- a/docs/source/security/2016/index.rst
+++ b/docs/source/security/2016/index.rst
@@ -1,0 +1,10 @@
+2016 Notices 
+============
+
+.. toctree::
+   :maxdepth: 1
+
+   20160503_openssl.rst
+   20160301_openssl.rst
+   20160128_openssl.rst
+   20160115_openssl.rst

--- a/docs/source/security/index.rst
+++ b/docs/source/security/index.rst
@@ -1,0 +1,8 @@
+Security Notices
+================
+
+.. toctree::
+   :maxdepth: 2
+
+   2016/index.rst
+   2015/index.rst


### PR DESCRIPTION
In an attempt to better organize the github wiki page (https://github.com/xcat2/xcat-core/wiki) and reduce the number of pages, I propose that we should move the security notices over to the RTD.  

In this pull request I'm only moving over the Security Notices from 2016.  It seems that we are getting more and more openSSL advisories.  

We can better organize the notices over on RTD by having sub directories.  Once we feel that they are no longer needed, we can delete the year and it will still be kept around in the older branches. 

Thoughts?