### PR TITLE
bmcdiscover command does not allow -u without -p specified in command

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -206,11 +206,11 @@ sub bmcdiscovery_processargs {
     #
     ($bmc_user, $bmc_pass) = bmcaccount_from_passwd();
     # overwrite the default user/pass with what is passed in
+    if ($::opt_U) {
+        $bmc_user = $::opt_U;
+    }
     if ($::opt_P) {
         $bmc_pass = $::opt_P;
-        if ($::opt_U) {
-            $bmc_user = $::opt_U;
-        }
     }
 
     #########################################


### PR DESCRIPTION
Specifying the -u option to bmcdiscover command only took effect if the -p option was alos used. 

Moving the check so that either option can be specified to override the default in the site.passwd table