### PR TITLE
Make the error message on bmcdiscovery make more sense using IP instead of generated node name

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -888,10 +888,10 @@ sub bmcdiscovery_ipmi {
                 $node =~ s/(.*)/\L$1/g;
             }
         } elsif ($output =~ /error : unauthorized name/){
-            xCAT::MsgUtils->message("E", {data=>["BMC username is incorrect for $node"]}, $::CALLBACK);
+            xCAT::MsgUtils->message("E", {data=>["BMC username is incorrect for $ip"]}, $::CALLBACK);
             return 1;
         } elsif ($output =~ /RAKP \S* \S* is invalid/) {
-            xCAT::MsgUtils->message("E", {data=>["BMC password is incorrect for $node"]}, $::CALLBACK);
+            xCAT::MsgUtils->message("E", {data=>["BMC password is incorrect for $ip"]}, $::CALLBACK);
             return 1;
         } 
         if ( defined($opz) || defined($opw) )


### PR DESCRIPTION
Implement a comment from @daniceexi  in issue #1065 to print the IP address for the BMC instead of the generated node name because the generated node name is not complete and does not make sense

Before change:
```
[root@fs1 ~]# bmcdiscover  --range 50.5.29-31.1  -z -p abc123
Error: BMC password is incorrect for node-32051d01
Error: BMC password is incorrect for node-32051f01
```

After change: 
```
[root@fs1 xCAT_plugin]# bmcdiscover  --range 50.5.29-31.1  -z -p abc123
Error: BMC password is incorrect for 50.5.31.1
Error: BMC password is incorrect for 50.5.29.1
```