### PR TITLE
Add debug flag for getmacs in SN_setup_case case

### DIFF
--- a/xCAT-test/autotest/testcase/installation/SN_setup_case
+++ b/xCAT-test/autotest/testcase/installation/SN_setup_case
@@ -16,7 +16,7 @@ check:rc==0
 cmd:cat /etc/conserver.cf | grep $$SN
 check:output=~$$SN
 cmd:sleep 10
-cmd:if [[ "__GETNODEATTR($$SN,arch)__" =~ "ppc64" ]]; then getmacs -D $$SN; fi
+cmd:if [[ "__GETNODEATTR($$SN,arch)__" =~ "ppc64" ]]; then getmacs -D $$SN -V; fi
 check:rc==0
 cmd:makedhcp -n
 check:rc==0


### PR DESCRIPTION
In jenkins environment, ``SN_setup_case``  always failed in ``getmacs`` command in ppc64, we can't reproduce it by hand, we need more information to find problem, so open verbose flag of ``getmacs``.