### PR TITLE
refine the code logic to stop network.service for sles12 and above

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/post.xcat
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat
@@ -430,8 +430,8 @@ cd /
 # To skip the conflict, the network service should be stoped in the yast first stage. Then base on the service
 # dependency, the service start order will be 'YaST2-Second-Stage.service'->'network'->'xcatpostinit1' in serial.
 # Then the Yast2 will be stopped before running the zypper in otherpkgs.
-if [[ $OSVER != sles11* ]]; then
-    service network stop
+if [[ "$OSVER" == sles* && ! "$OSVER" < "sles12" ]]; then
+        service network stop
 fi
 
 if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then


### PR DESCRIPTION
refine the PR https://github.com/xcat2/xcat-core/pull/1087 ,which is the fix for  issue https://github.com/xcat2/xcat-core/issues/929
only stop network service for sles12 or above

verified on sles12-ppc64le and sles11.4-x86_64
