### PR TITLE
call get_info() for rmvm -f -p

### DIFF
--- a/xCAT-server/lib/xcat/plugins/kvm.pm
+++ b/xCAT-server/lib/xcat/plugins/kvm.pm
@@ -1764,7 +1764,11 @@ sub rmvm {
                     last;
                 }
                 if ($vol) {
-                    eval { $vol->delete(); };
+                    eval { 
+                        # Need to call get_info() before deleting a volume, without that, delete() will sometimes fail. Issue #455
+                        $vol->get_info(); 
+                        $vol->delete(); 
+                    };
                     if ($@) {
                         xCAT::MsgUtils->trace(0, "e", "kvm: $@");
                     }


### PR DESCRIPTION
Adding back get_info() before the volume delete.

```
Hi Mark,
 
Thanks for the digging.
 
From the RH bugzilla, someone mentioned your workaround that dump the volume definition before the deleting 
operating might help. So with the current retry logic, we can take back the '$vol->get_info();' before the delete 
operation.

Wang Xiaopeng 
```