### PR TITLE
Remove --master from mkvm man page and usage

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/lsvm.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/lsvm.1.rst
@@ -83,7 +83,7 @@ For KVM and VMware
 ==================
 
 
-The virtual machines that defined in the hypervisor \ *noderange*\  will be displayed. \ *noderange*\  only can be hypervisor.
+The virtual machines that defined in the hypervisor \ *noderange*\  will be displayed. \ *noderange*\  can only be hypervisor.
 
 Note: Only the virtual machine which is in power on state can be listed by lsvm command.
 

--- a/docs/source/guides/admin-guides/references/man1/mkvm.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/mkvm.1.rst
@@ -52,7 +52,7 @@ For KVM:
 ========
 
 
-\ **mkvm**\  \ *noderange*\  [\ **-m|-**\ **-master**\  \ *mastername*\ ] [\ **-s|-**\ **-size**\  \ *disksize*\ ] [\ **-**\ **-mem**\  \ *memsize*\ ] [\ **-**\ **-cpus**\  \ *cpucount*\ ] [\ **-f|-**\ **-force**\ ]
+\ **mkvm**\  \ *noderange*\  [\ **-s|-**\ **-size**\  \ *disksize*\ ] [\ **-**\ **-mem**\  \ *memsize*\ ] [\ **-**\ **-cpus**\  \ *cpucount*\ ] [\ **-f|-**\ **-force**\ ]
 
 
 For Vmware:

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -215,7 +215,7 @@ my %usage = (
                       [vmphyslots=drc_index1,drc_index2...] [vmothersetting=hugepage:N,bsr:N]
                       [vmnics=vlan1,vlan2] [vmstorage=<N|viosnode:slotid>] [--vios]
     For KVM
-       mkvm noderange -m|--master mastername -s|--size disksize -f|--force
+       mkvm noderange [-s|--size disksize] [--mem memsize] [--cpus cpucount] [-f|--force]
     For zVM
        mkvm noderange directory_entry_file_path
        mkvm noderange source_virtual_machine pool=disk_pool pw=multi_password",

--- a/xCAT-client/pods/man1/mkvm.1.pod
+++ b/xCAT-client/pods/man1/mkvm.1.pod
@@ -26,7 +26,7 @@ B<mkvm> I<noderange> [B<vmcpus=> I<min/req/max>] [B<vmmemory=> I<min/req/max>] [
 
 =head2 For KVM:
 
-B<mkvm> I<noderange> [B<-m|--master> I<mastername>] [B<-s|--size> I<disksize>] [B<--mem> I<memsize>] [B<--cpus> I<cpucount>] [B<-f|--force>]
+B<mkvm> I<noderange> [B<-s|--size> I<disksize>] [B<--mem> I<memsize>] [B<--cpus> I<cpucount>] [B<-f|--force>]
 
 =head2 For Vmware:
 


### PR DESCRIPTION
Based on Xiaopeng's recommendation on May 13, 2016 removing `--master` flag from `mkvm` command usage and man page.