### PR TITLE
Fix issue1095 xcattest script doesn't support global variable with "http://"

### DIFF
--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -223,7 +223,7 @@ sub getConfig
             }
         } elsif ($type eq "Varible") {
             ##NODE_BLOCK##
-            if($line =~ /(\w+)\s*=\s*([\w\.\-\+\/]+)/) {
+            if($line =~ /(\w+)\s*=\s*([\w\.\-\+\/:]+)/) {
                 $config{var}{$1} = $2;
             }
         }


### PR DESCRIPTION
 ``xcattest`` only support limited character for the value of ``System->Varible`` previously, but now we need pass a wed address to test case, such like ``http://xxxx/xxx``, so now we need to support ``:``. 
This pull request add ``:`` to supported list of xcattest