### PR TITLE
apt-get update displays errors when pointing at the xCAT management node

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/post.ubuntu.common
+++ b/xCAT-server/share/xcat/install/scripts/post.ubuntu.common
@@ -45,3 +45,5 @@ for i in $(echo #TABLE:site:key=nameservers:value# | tr ',' ' ')
 do
 	echo "nameserver $i"
 done >>/etc/resolv.conf
+
+grep "install/ubuntu" /etc/apt/sources.list && sed -i '/install\/ubuntu/d' /etc/apt/sources.list


### PR DESCRIPTION
Issue #841 

deleting all the lines including /install/ubuntu from sources.list.
Tested in ubuntu14.04.4 x86_64.