### PR TITLE
fix issue#1122@github;create /dev under chroot env based on /dev on host;use lazy mount for sysfs and procfs to make sure they are umounted no matter whether busy

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -91,15 +91,18 @@ sub mount_chroot {
     my $rootimage_dir = shift;
 
     #postinstall script of some packages might access the /proc, /sys and /dev filesystem
-    #For Redhat7 or above, mount these directories readonly from host to avoid error messages
+    #For Redhat7 or above, mount /proc,/sys from host to avoid error messages
+    #For Redhat7 or above, create /dev according to /dev on the host to avoid error messages
     #For Redhat6 or below, mount these directories might introduce error messages
     if(majversion($osver) > 6){
        system("mkdir -p $rootimage_dir/proc");
-       system("mount proc $rootimage_dir/proc -t proc -o ro");
+       system("mount proc $rootimage_dir/proc -t proc");
        system("mkdir -p $rootimage_dir/sys");
-       system("mount sysfs $rootimage_dir/sys -t sysfs -o ro");
+       system("mount sysfs $rootimage_dir/sys -t sysfs");
        system("mkdir -p $rootimage_dir/dev");
-       system("mount devtmpfs $rootimage_dir/dev -t devtmpfs -o ro");
+       #system("mount devtmpfs $rootimage_dir/dev -t devtmpfs");
+       system("cd /dev;find .|cpio -H newc -o >$rootimage_dir/dev/dev.archive;cd -");
+       system("cd $rootimage_dir/dev;cpio -idum<./dev.archive;rm -f ./dev.archive;cd -");
     }
 }
 
@@ -109,9 +112,10 @@ sub umount_chroot {
     my $rootimage_dir = shift;
 
     if(majversion($osver) >6){
-        system("umount $rootimage_dir/proc");
-        system("umount $rootimage_dir/sys");
-        system("umount $rootimage_dir/dev");
+        system("umount -l $rootimage_dir/proc");
+        system("umount -l $rootimage_dir/sys");
+        #system("umount -l $rootimage_dir/dev");
+        system("rm -rf $rootimage_dir/dev/*");
     }
 }
 

--- a/xCAT-server/share/xcat/netboot/ubuntu/genimage
+++ b/xCAT-server/share/xcat/netboot/ubuntu/genimage
@@ -1970,13 +1970,17 @@ sub mount_chroot {
 
    #postinstall script of package installation
    #might access the /proc, /sys and /dev filesystem
-   #mount them from host read-only
+   #mount /proc, /sys from host 
+   #create /dev based on /dev/ on host
    system("mkdir -p $rootimage_dir/proc");
-   system("mount proc $rootimage_dir/proc -t proc -o ro");
+   system("mount proc $rootimage_dir/proc -t proc");
    system("mkdir -p $rootimage_dir/sys");
-   system("mount sysfs $rootimage_dir/sys -t sysfs -o ro");
+   system("mount sysfs $rootimage_dir/sys -t sysfs");
    system("mkdir -p $rootimage_dir/dev");
-   system("mount devfs $rootimage_dir/dev -t devfs -o ro");
+   #system("mount devtmpfs $rootimage_dir/dev -t devtmpfs");
+   system("cd /dev;find .|cpio -H newc -o >$rootimage_dir/dev/dev.archive;cd -");
+   system("cd $rootimage_dir/dev;cpio -idum<./dev.archive;rm -f ./dev.archive;cd -");
+
 
    if ($pkgdir) {
        if (-d $pkgdir) {
@@ -2009,21 +2013,22 @@ sub mount_chroot {
 sub umount_chroot {
    my $rootimage_dir = shift;
 
-   system("umount $rootimage_dir/proc");
-   system("umount $rootimage_dir/sys");
-   system("umount $rootimage_dir/dev");
+   system("umount -l $rootimage_dir/proc");
+   system("umount -l $rootimage_dir/sys");
+   #system("umount -l $rootimage_dir/dev");
+   system("rm -rf $rootimage_dir/dev/*");
 
-   system("umount $rootimage_dir/mnt/pkgdir");
+   system("umount -l $rootimage_dir/mnt/pkgdir");
    rmdir("$rootimage_dir/mnt/pkgdir");
 
    my @data = `grep /mnt/otherpkgdir /proc/mounts | cut -f2 -d' ' | sort -r`;
    foreach (@data) {
-       `umount $_`;
+       `umount -l $_`;
    }
    rmdir("$rootimage_dir/mnt/otherpkgdir");
 
    if (-d "$rootimage_dir/mnt/kerneldir") {
-       system("umount $rootimage_dir/mnt/kerneldir");
+       system("umount -l $rootimage_dir/mnt/kerneldir");
        rmdir("$rootimage_dir/mnt/kerneldir");
    }
 }


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/1122
for /proc and /sys, they are safe to be mounted on chrooted env., since they are readonly themselves.
for /dev under chrooted rootimg, we cannot use readonly mount, because it will make /dev/ on the management node readonly; 
we cannot use RW mount either, because when the "genimage" is terminated with either CTRL+C or session disconnect, the genimage will be terminated for user,  but genimage might not call the interrupt handler on SIGINT or SIGTERM correctly, the mounted /dev failed to be umounted, if user run "rm -rf /install/netboot/<osver>/<arch>/compute/rooimg", the /dev/ on management node will be cleaned up and the management node will be broken.
The fix for /dev in this PR is a safe way. 

