### PR TITLE
Change the kernel package name to linux-image-generic for Ubuntu 16.04

### DIFF
--- a/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu16.04.ppc64el.pkglist
+++ b/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu16.04.ppc64el.pkglist
@@ -3,7 +3,7 @@ nfs-common
 openssl
 isc-dhcp-client
 libc-bin
-linux-image-generic-lts-xenial
+linux-image-generic
 openssh-server
 openssh-client
 wget

--- a/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu16.04.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu16.04.x86_64.pkglist
@@ -3,7 +3,7 @@ nfs-common
 openssl
 isc-dhcp-client
 libc-bin
-linux-image-generic-lts-xenial
+linux-image-generic
 openssh-server
 openssh-client
 wget


### PR DESCRIPTION
... Based on the actual shape of the Ubuntu GA ISO image.