### PR TITLE
fix issue#1139@github, run <dpkg-reconfigure locales> noninteractive

### DIFF
--- a/xCAT-server/share/xcat/netboot/ubuntu/compute.postinstall
+++ b/xCAT-server/share/xcat/netboot/ubuntu/compute.postinstall
@@ -49,5 +49,5 @@ chroot $installroot \
  locale-gen en_US.UTF-8 en_US
 chroot $installroot \
  update-locale
-chroot $installroot \
+DEBIAN_FRONTEND=noninteractive chroot $installroot \
  dpkg-reconfigure locales


### PR DESCRIPTION
the "ubuntu/compute.postinstall" includes 
````
dpkg-reconfigure locales
````
which raise a interactive dialog box to select locales, we have no chance to interact with it during genimage, the command should be run with "DEBIAN_FRONTEND=noninteractive" 