### PR TITLE
fix issue 1115: Don't run rspconfig after hardware discovery finished…

### DIFF
--- a/xCAT-genesis-scripts/bin/dodiscovery
+++ b/xCAT-genesis-scripts/bin/dodiscovery
@@ -141,6 +141,11 @@ if [ "$IsStatic" ]; then
     fi
 fi
 
+# Check whether the hardware support in-band BMC configuration with the IPMI device
+if [ -r /dev/ipmi0 -o -r /dev/ipmi/0 -o -r /dev/ipmidev/0 ]; then
+    echo "<bmcinband>1</bmcinband>" >> /tmp/discopacket
+fi
+
 #so we have some cases where DMI table explictly records every function number, and some where only first function is enumerated
 #so for each onboard device, we record it.  If it is also the first function, we'll seek out other function numbers and append
 #if that other function number does not show up in its own dmi type 41 record

--- a/xCAT-server/lib/xcat/plugins/nodediscover.pm
+++ b/xCAT-server/lib/xcat/plugins/nodediscover.pm
@@ -371,8 +371,16 @@ sub process_request {
         $callback->({error=> ["The node [$node] should have a correct IP address which belongs to the management network."], errorcode=>["1"]});
         return;
     }
-    if ($request->{arch}->[0] =~ /ppc/ and $request->{platform}->[0] =~ /PowerNV/) {
-        # This is a slow thing to do, and frequently breaks things thoroughly
+    if (defined($request->{bmcinband})) {
+        syslog("local4|info", "The attribute bmcinband is specified, just remove the temp BMC node if there is");
+        if (defined($request->{pbmc_node}) and defined($request->{pbmc_node}->[0]))  {
+            my $bmc_node = $request->{pbmc_node}->[0];
+            syslog("local4|info", "Find BMC $bmc_node, so remove it");
+            $doreq->({ command => ['rmdef'], arg => [$bmc_node]});
+        }
+    } else {
+        # Only BMC that doesn't support in-band configuration need to run rspconfig out-of-band, such as S822L running in OPAL model
+        syslog("local4|info", "No bmcinband specified, need to configure BMC out-of-band");
         xCAT::Utils->cleanup_for_powerLE_hardware_discovery($request, $doreq);
     }
 


### PR DESCRIPTION
… for servers Other than S822L(TLT)

For issue #1115 
The modifications are:
1. in findme request, add bmcinband attribute if the BMC can be accessed in-band
2. within hardware discovery process, the bmcinband is set, just run "rmdef" against the temp BMC node.