### PR TITLE
fix issue#1159@github,add support for udp/tcp syslog reception for rsyslog shipped in ubuntu16.04

### DIFF
--- a/xCAT/postscripts/syslog
+++ b/xCAT/postscripts/syslog
@@ -195,6 +195,16 @@ config_rsyslog_V8()
                        s/#\$ModLoad imtcp.so/\$ModLoad imtcp.so/; 
                        s/#\$InputTCPServerRun <port>/\$InputTCPServerRun 514/' $remoteconf
     fi
+
+    #ubuntu16.04 ships rsyslog 8.16.0,which does not ship remote.conf
+    #the configuration for UDP and TCP syslog reception is in rsyslog.conf
+    if [ -f "$conf_file" ]; then
+        sed -i 's/#module(load="imudp")/module(load="imudp")/;
+                s/#input(type="imudp" port="514")/input(type="imudp" port="514")/;
+                s/#module(load="imtcp")/module(load="imtcp")/;
+                s/#input(type="imtcp" port="514")/input(type="imtcp" port="514")/' $conf_file
+    fi
+
   else
     # not logging local, forward logging
     # backup the existing remote.conf file from the install


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/1159

The rsyslogd 8.16.0 will not install /etc/rsyslog.d/remote.conf on package installation and the configuration for UDP/TCP reception is commented out in rsyslog.conf. However, the syslog postscript suppose configuration for UDP/TCP reception is included in/etc/rsyslog.d/remote.conf ,which is shipped by rsyslog package.