### PR TITLE
issue 1158: fix the syncfile issue for ubuntu 16.04

### DIFF
--- a/perl-xCAT/xCAT/RSYNC.pm
+++ b/perl-xCAT/xCAT/RSYNC.pm
@@ -129,7 +129,7 @@ sub remote_copy_command
         # if only syncing the service node or
         # (no postscripts and no append lines)  then do not
         # get update file notification
-        if (($::SYNCSN  == 1) || ((!(defined @::postscripts)) && (!(defined @::appendlines)) && (!(defined @::mergelines)))) { 
+        if (($::SYNCSN  == 1) || ((!(@::postscripts)) && (!(@::appendlines)) && (!(@::mergelines)))) { 
           $sync_opt .= '-Lprogtz ';
         } else {
            $sync_opt .= '-Liprogtz --out-format=%f%L '; # add notify of update

--- a/xCAT/postscripts/syncfiles
+++ b/xCAT/postscripts/syncfiles
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # IBM(c) 2009 EPL license http://www.eclipse.org/legal/epl-v10.html
 #####################################################
 #


### PR DESCRIPTION
  1. change the shebang for syncfiles postscripts to be /bin/bash from /bin/sh
  2. fix the syntax error in the xCAT/RSYNC.pm