### PR TITLE
Temp BMC node definition hadn't been removed for switch-based discovery

### DIFF
--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -585,13 +585,13 @@ sub do_discovery_process {
     populate_vpd_hash();
     populate_mp_hash();
     while (not $quit) {
+        my $msg = fd_retrieve($broker);
         if ((time()-$vintage)> 15) {
             populate_site_hash();
             populate_vpd_hash();
             populate_mp_hash();
             $vintage = time();
         } # site table reread every 15 second
-        my $msg = fd_retrieve($broker);
         my $data;
         my $client;
         my $clientn;
@@ -616,7 +616,7 @@ sub do_discovery_process {
             # xcatrequest xml, so go ahead and decompress it
             my $bigdata;
             IO::Uncompress::Gunzip::gunzip(\$data,\$bigdata);
-            $data = $bigdata
+            $data = $bigdata;
         }
         my $req = eval { XMLin($data, SuppressEmpty=>undef,ForceArray=>1) };
         if ($req and $req->{command} and ($req->{command}->[0] eq "findme" and $sport < 1000)) { # only consider priveleged port requests to start with


### PR DESCRIPTION
for issue #1114 .

ErTao's note for this issue:
for the issue that temp BMC node can not be found, a possible reason seems as:
```
sub do_discovery_process {
    $SIG{TERM} = 'DEFAULT';
    $SIG{INT} = 'DEFAULT';
    my %args =@_;
    my $broker = $args{broker};
    my $quit=0;
    my $vintage = time();
    $dispatch_requests=0;
    populate_site_hash();
    populate_vpd_hash();
    populate_mp_hash();
    while (not $quit) {
        if ((time()-$vintage)> 15) {
            populate_site_hash();
            populate_vpd_hash();
            populate_mp_hash();
            $vintage = time();
        } # site table reread every 15 second
        my $msg = fd_retrieve($broker);

```
As you can see the sub-routine do_discovery_process, it will read vpd and mp table before going into the while loop, but if there is no findme request got, the loop will hung at "fd_retrieve", which mean if there is any modification for vpd and mp after xcatd start, they can not be read since it have no change to check whether it is time to refresh vpd and mp hash again.
 
Then, if there is a findme come in, it may won't be able to match any node from vpd and mp hash. 

