### PR TITLE
fix #1093, powerkvm, diskfull, enable the pre-script log can be saved to the CN

### DIFF
--- a/xCAT-server/share/xcat/install/pkvm/compute.pkvm3.ppc64le.tmpl
+++ b/xCAT-server/share/xcat/install/pkvm/compute.pkvm3.ppc64le.tmpl
@@ -36,22 +36,21 @@ rootpw --iscrypted #CRYPT:passwd:key=system,username=root:password#
 
 %pre
 {
-set -x
-touch "/startpre"
+echo "Running Automated Network Pre-Installation script..."
 #add the code to determine the disk to partition here
 #default is /dev/sda
 #INCLUDE:#ENV:XCATROOT#/share/xcat/install/scripts/pre.pkvm3#
-} >>/tmp/prelog 2>&1
+} >>/tmp/pre-install.log 2>&1
 %end
 
 %post
-touch "/startpost"
-
+mkdir -p /var/log/xcat/
+{
+cat >> /var/log/xcat/xcat.log << "EOF"
+%include /tmp/pre-install.log
+EOF
+echo "Running Automated Network Post-Installation script..."
 #INCLUDE:#ENV:XCATROOT#/share/xcat/install/scripts/post.xcat#
-touch "/inpost"
-
-#sleep 1000000
-
-
+} >>/var/log/xcat/xcat.log 2>&1
 %end
 

--- a/xCAT-server/share/xcat/install/scripts/pre.pkvm3
+++ b/xCAT-server/share/xcat/install/scripts/pre.pkvm3
@@ -1,3 +1,8 @@
+export XCATDEBUGMODE="#TABLEBLANKOKAY:site:key=xcatdebugmode:value#"
+if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
+    set -x
+fi
+
 #find first available block device (sda or vda likely)
 #TODO: pick a likely non-SAN target if possible
 
@@ -18,4 +23,6 @@ fi
 echo "part PV.01 --ondisk=$instdisk" >> /tmp/partitioning
 echo "volgroup ibmpkvm_rootvg PV.01" >> /tmp/partitioning	
 
-
+if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
+    set +x
+fi

--- a/xCAT-server/share/xcat/install/scripts/pre.pkvm3
+++ b/xCAT-server/share/xcat/install/scripts/pre.pkvm3
@@ -3,6 +3,10 @@ if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
     set -x
 fi
 
+if [ "$XCATDEBUGMODE" = "2" ]; then
+    echo 'root:cluster' | chpasswd
+fi
+
 #find first available block device (sda or vda likely)
 #TODO: pick a likely non-SAN target if possible
 


### PR DESCRIPTION
fix #1093
For PowerKVM diskfull installation, enable the pre-script log can be saved to the CN
fix #1300 
For PowerKVM diskfull installation, enable access the installer via ssh when xcatdebugmode=2