### PR TITLE
support different outputs from nmap command

### DIFF
--- a/perl-xCAT/xCAT/SLP.pm
+++ b/perl-xCAT/xCAT/SLP.pm
@@ -124,6 +124,11 @@ sub dodiscover {
             foreach my $line (split(/\n\n/,$nmapres)) {
                 my $server;
                 foreach my $sline (split(/\n/, $line)) {
+                    #output of nmap command for version under 5.10
+                    if ($sline =~ /Interesting ports on (\d+\.\d+\.\d+\.\d+)/) {
+                       $server = $1;
+                    }
+                    #output of nmap command for version 5.10 and above
                     if ($sline =~ /Nmap scan report for (\d+\.\d+\.\d+\.\d+)/) {
                        $server = $1;
                     }

--- a/perl-xCAT/xCAT/Utils.pm
+++ b/perl-xCAT/xCAT/Utils.pm
@@ -4690,4 +4690,26 @@ sub is_process_exists{
     return 0;
 }
 
+#--------------------------------------------------------------------------------
+=head3  get_nmapversion
+      for nmap version 5.10 above, the sP option changed to sn.
+      the output of some commands also have differents.
+      example:  for snmp_scan option,
+        version 4.75 has output "Host 10.4.25.1 appears to be up ... good."  but
+        for version 6.40, it has output "Discovered open port 161/udp on 10.4.25.1"
+    Returns:
+      result: version of nmap on the system
+=cut
+#--------------------------------------------------------------------------------
+
+sub get_nmapversion {
+    my $nmap_version;
+    my $ccmd = "nmap -V | grep version";
+    my $result = xCAT::Utils->runcmd($ccmd, 0);
+    my @version_array = split / /, $result;
+    $nmap_version = $version_array[2];
+    return $nmap_version;
+}
+
+
 1;

--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -457,15 +457,12 @@ sub scan_process{
     ###########################################################
     if ( $method eq "nmap" ) {
         #check nmap version first
-        my $ccmd = "$nmap_path -V | grep version";
-        my $version_result = xCAT::Utils->runcmd($ccmd, 0);
-        my @version_array = split / /, $version_result;
-        my $nmap_version = $version_array[2];
+        my $nmap_version = xCAT::Utils->get_nmapversion();
         # the output of nmap is different for version under 5.10 
         if (xCAT::Utils->version_cmp($nmap_version,"5.10") < 0) {
             $bcmd = join(" ",$nmap_path," -sP -n $range | grep \"appears to be up\" |cut -d ' ' -f2 |tr -s '\n' ' ' ");
         } else {
-            $bcmd = join(" ",$nmap_path," -sn -n $range | grep \"Nmap scan report\" |cut -d ' ' -f5 |tr -s '\n' ' ' ");
+            $bcmd = join(" ",$nmap_path," -sn -n $range | grep -B1 up | grep \"Nmap scan report\" |cut -d ' ' -f5 |tr -s '\n' ' ' ");
         }
 
         $ip_list = xCAT::Utils->runcmd("$bcmd", -1);

--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -461,11 +461,11 @@ sub scan_process{
         my $version_result = xCAT::Utils->runcmd($ccmd, 0);
         my @version_array = split / /, $version_result;
         my $nmap_version = $version_array[2];
-        # the output of nmap is different for version under 4.75
-        if (xCAT::Utils->version_cmp($nmap_version,"4.75") <= 0) {
-            $bcmd = join(" ",$nmap_path," -sP -n $range | grep Host |cut -d ' ' -f2 |tr -s '\n' ' ' ");
+        # the output of nmap is different for version under 5.10 
+        if (xCAT::Utils->version_cmp($nmap_version,"5.10") < 0) {
+            $bcmd = join(" ",$nmap_path," -sP -n $range | grep \"appears to be up\" |cut -d ' ' -f2 |tr -s '\n' ' ' ");
         } else {
-            $bcmd = join(" ",$nmap_path," -sn -n $range | grep for |cut -d ' ' -f5 |tr -s '\n' ' ' ");
+            $bcmd = join(" ",$nmap_path," -sn -n $range | grep \"Nmap scan report\" |cut -d ' ' -f5 |tr -s '\n' ' ' ");
         }
 
         $ip_list = xCAT::Utils->runcmd("$bcmd", -1);

--- a/xCAT-server/lib/xcat/plugins/switchdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/switchdiscover.pm
@@ -651,7 +651,7 @@ sub nmap_scan {
         }
     };
 
-    my $nmap_version = get_nmapversion($request);
+    my $nmap_version = xCAT::Utils->get_nmapversion();
     if (xCAT::Utils->version_cmp($nmap_version,"5.10") < 0) {
         $ccmd = "/usr/bin/nmap -sP -oX - @$ranges";
     } else {
@@ -828,8 +828,8 @@ sub snmp_scan {
 
     #use nmap to find if snmp port is enabled  
     # only open port will be scan
-    my $nmap_version = get_nmapversion($request);
-    if (xCAT::Utils->version_cmp($nmap_version,"5.10") <= 0) {
+    my $nmap_version = xCAT::Utils->get_nmapversion();
+    if (xCAT::Utils->version_cmp($nmap_version,"5.10") < 0) {
         $ccmd = "/usr/bin/nmap -P0 -v -sU -p 161 -oA snmp_scan @$ranges | grep up | grep good ";    
     } else {
         $ccmd = "/usr/bin/nmap -P0 -v -sU -p 161 -oA snmp_scan @$ranges | grep 'open port 161' ";    
@@ -856,7 +856,7 @@ sub snmp_scan {
     foreach my $line (@lines) {
         my @array = split / /, $line;
         my $ip;
-        if (xCAT::Utils->version_cmp($nmap_version,"4.75") <= 0) {
+        if (xCAT::Utils->version_cmp($nmap_version,"5.10") < 0) {
             $ip = $array[1];
         } else {
             $ip = $array[5];
@@ -1250,31 +1250,6 @@ sub format_xml {
                      RootName => undef );
     }
     return ($xml);    
-}
-
-#--------------------------------------------------------------------------------
-=head3  get_nmapversion 
-      for nmap version 5.10 above, the sP option changed to sn.
-      the output of some commands also have differents.
-      example:  for snmp_scan option, 
-        version 4.75 has output "Host 10.4.25.1 appears to be up ... good."  but 
-        for version 6.40, it has output "Discovered open port 161/udp on 10.4.25.1"
-    Returns:
-      result: version of nmap on the system 
-=cut
-#--------------------------------------------------------------------------------
-
-sub get_nmapversion {
-    $request = shift;
-    my $nmap_version;
-    my $ccmd = "nmap -V | grep version";
-    my $result = xCAT::Utils->runcmd($ccmd, 0);
-    my @version_array = split / /, $result;
-    $nmap_version = $version_array[2];
-    if (exists($globalopt{verbose}))    {
-        send_msg($request, 0, "version of nmap: $nmap_version\n");
-    }
-    return $nmap_version;
 }
 
 1;

--- a/xCAT-server/lib/xcat/plugins/switchdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/switchdiscover.pm
@@ -651,8 +651,12 @@ sub nmap_scan {
         }
     };
 
-    
-    $ccmd = "/usr/bin/nmap -sP -oX - @$ranges";
+    my $nmap_version = get_nmapversion($request);
+    if (xCAT::Utils->version_cmp($nmap_version,"5.10") < 0) {
+        $ccmd = "/usr/bin/nmap -sP -oX - @$ranges";
+    } else {
+        $ccmd = "/usr/bin/nmap -sn -oX - @$ranges";
+    }
     if (exists($globalopt{verbose}))    {
         send_msg($request, 0, "Process command: $ccmd\n");
     }
@@ -805,7 +809,6 @@ sub snmp_scan {
     my $result;
     my $switches;
     my $counter = 0;
-    my $nmap_version;
 
     # snmpwalk command has to be available for snmp_scan
     if (-x "/usr/bin/snmpwalk" ){
@@ -822,21 +825,11 @@ sub snmp_scan {
     ##################################################
     my $ranges = get_ip_ranges($request);
 
-    $ccmd = "nmap -V | grep version";
-    $result = xCAT::Utils->runcmd($ccmd, 0);
-    my @version_array = split / /, $result;
-    $nmap_version = $version_array[2];
-    if (exists($globalopt{verbose}))    {
-        send_msg($request, 0, "version of nmap: $nmap_version\n");
-    }
 
     #use nmap to find if snmp port is enabled  
     # only open port will be scan
-    # currently, we know nmap version 4.75 has different output for snmp_scan
-    # command.
-    # for version 4.75, the line as :"Host 10.4.25.1 appears to be up ... good."
-    # other higher version has line like this: "Discovered open port 161/udp on 10.4.25.1"
-    if (xCAT::Utils->version_cmp($nmap_version,"4.75") <= 0) {
+    my $nmap_version = get_nmapversion($request);
+    if (xCAT::Utils->version_cmp($nmap_version,"5.10") <= 0) {
         $ccmd = "/usr/bin/nmap -P0 -v -sU -p 161 -oA snmp_scan @$ranges | grep up | grep good ";    
     } else {
         $ccmd = "/usr/bin/nmap -P0 -v -sU -p 161 -oA snmp_scan @$ranges | grep 'open port 161' ";    
@@ -1257,6 +1250,31 @@ sub format_xml {
                      RootName => undef );
     }
     return ($xml);    
+}
+
+#--------------------------------------------------------------------------------
+=head3  get_nmapversion 
+      for nmap version 5.10 above, the sP option changed to sn.
+      the output of some commands also have differents.
+      example:  for snmp_scan option, 
+        version 4.75 has output "Host 10.4.25.1 appears to be up ... good."  but 
+        for version 6.40, it has output "Discovered open port 161/udp on 10.4.25.1"
+    Returns:
+      result: version of nmap on the system 
+=cut
+#--------------------------------------------------------------------------------
+
+sub get_nmapversion {
+    $request = shift;
+    my $nmap_version;
+    my $ccmd = "nmap -V | grep version";
+    my $result = xCAT::Utils->runcmd($ccmd, 0);
+    my @version_array = split / /, $result;
+    $nmap_version = $version_array[2];
+    if (exists($globalopt{verbose}))    {
+        send_msg($request, 0, "version of nmap: $nmap_version\n");
+    }
+    return $nmap_version;
 }
 
 1;


### PR DESCRIPTION
This is enhancement for pull request #1134 and for issue #1120 

output strings are different for nmap command on version 5.10 above than lower version.  So, the grep string has to be modified.