### PR TITLE
Add a better label to display in the boot loader to identify genesis boot

### DIFF
--- a/xCAT-server/lib/xcat/plugins/mknb.pm
+++ b/xCAT-server/lib/xcat/plugins/mknb.pm
@@ -252,8 +252,9 @@ CREAT_CONF_FILE:
          close($cfg);
 	if ($invisibletouch and $arch =~ /x86_64/) { #UEFI time
          open($cfg,">","$tftpdir/xcat/xnba/nets/$net.elilo");
-         print $cfg "default=\"xCAT Genesis\"\ndelay=5\n\n";
-         print $cfg 'image=/tftpboot/xcat/genesis.kernel.'."$arch\n";
+         print $cfg "default=\"xCAT Genesis (".$normnets->{$_}.")\"\n";
+         print $cfg "   delay=5\n";
+         print $cfg '   image=/tftpboot/xcat/genesis.kernel.'."$arch\n";
 	 print $cfg "   label=\"xCAT Genesis (".$normnets->{$_}.")\"\n";
 	if ($lzma_exit_value) {
 	 print $cfg "   initrd=/tftpboot/xcat/genesis.fs.$arch.gz\n";
@@ -270,8 +271,9 @@ CREAT_CONF_FILE:
 	
       } elsif ($arch =~ /ppc/) {
          open($cfgfile,">", "$tftpdir/pxelinux.cfg/p/$net");
-         print $cfgfile "default xCAT\n";
-         print $cfgfile "   label xCAT Genesis (".$normnets->{$_}.")\n";
+         print $cfgfile "default \"xCAT Genesis (".$normnets->{$_}.")\"\n";
+         print $cfgfile "   delay=10\n";
+         print $cfgfile "   label \"xCAT Genesis (".$normnets->{$_}.")\"\n";
          print $cfgfile "   kernel http://".$normnets->{$_}.":80/$tftpdir/xcat/genesis.kernel.$arch\n";
          print $cfgfile "   initrd http://".$normnets->{$_}.":80/$initrd_file\n";
          print $cfgfile '   append "quiet xcatd='.$normnets->{$_}.":$xcatdport $consolecmdline\"\n";
@@ -307,8 +309,9 @@ CREAT_CONF_FILE:
          close($cfgfile);
       } elsif ($arch =~ /ppc/) {
          open($cfgfile,">","$tftpdir/etc/".lc($_));
-         print $cfgfile "default xCAT\n";
-         print $cfgfile "   label xCAT Genesis (".$normnets->{$_}.")\n";
+         print $cfgfile "default \"xCAT Genesis (".$normnets->{$_}.")\"\n"; 
+         print $cfgfile "   delay=10\n";
+         print $cfgfile "   label \"xCAT Genesis (".$normnets->{$_}.")\"\n";
          print $cfgfile "   kernel http://".$hexnets->{$_}.":80/$tftpdir/xcat/genesis.kernel.$arch\n";
          print $cfgfile "   initrd http://".$hexnets->{$_}.":80/$initrd_file\n";
          print $cfgfile '   append "quiet xcatd='.$hexnets->{$_}.":$xcatdport $consolecmdline\"\n";

--- a/xCAT-server/lib/xcat/plugins/mknb.pm
+++ b/xCAT-server/lib/xcat/plugins/mknb.pm
@@ -15,39 +15,34 @@ sub handled_commands {
 sub process_request {
    my $request = shift;
    my $callback = shift;
-   #my $sitetab = xCAT::Table->new('site');
    my $serialport;
    my $serialspeed;
    my $serialflow;
    my $initrd_file = undef;
    my $xcatdport = 3001;
-   #if ($sitetab) {
-      #my $portent = $sitetab->getAttribs({key=>'defserialport'},'value');
-      my @entries =  xCAT::TableUtils->get_site_attribute("defserialport");
-      my $t_entry = $entries[0];
-      if ( defined($t_entry) ) {
-         $serialport=$t_entry;
-      }
-      #$portent = $sitetab->getAttribs({key=>'defserialspeed'},'value');
-      @entries =  xCAT::TableUtils->get_site_attribute("defserialspeed");
-      $t_entry = $entries[0];
-      if ( defined($t_entry) ) {
-         $serialspeed=$t_entry;
-      }
-      #$portent = $sitetab->getAttribs({key=>'defserialflow'},'value');
-      @entries =  xCAT::TableUtils->get_site_attribute("defserialflow");
-      $t_entry = $entries[0];
-      if ( defined($t_entry) ) {
-         $serialflow=$t_entry;
-      }
-      #$portent = $sitetab->getAttribs({key=>'xcatdport'},'value');
-      @entries =  xCAT::TableUtils->get_site_attribute("xcatdport");
-      $t_entry = $entries[0];
-      if ( defined($t_entry) ) {
-         $xcatdport=$t_entry;
-      }
-      #$sitetab->close;
-   #}
+   my @entries =  xCAT::TableUtils->get_site_attribute("defserialport");
+   my $t_entry = $entries[0];
+   if ( defined($t_entry) ) {
+      $serialport=$t_entry;
+   }
+
+   @entries =  xCAT::TableUtils->get_site_attribute("defserialspeed");
+   $t_entry = $entries[0];
+   if ( defined($t_entry) ) {
+      $serialspeed=$t_entry;
+   }
+
+   @entries =  xCAT::TableUtils->get_site_attribute("defserialflow");
+   $t_entry = $entries[0];
+   if ( defined($t_entry) ) {
+      $serialflow=$t_entry;
+   }
+
+   @entries =  xCAT::TableUtils->get_site_attribute("xcatdport");
+   $t_entry = $entries[0];
+   if ( defined($t_entry) ) {
+      $xcatdport=$t_entry;
+   }
 
    my $tftpdir = xCAT::TableUtils->getTftpDir();
    my $arch = $request->{arg}->[0];
@@ -55,8 +50,8 @@ sub process_request {
       $callback->({error=>"Need to specify architecture (x86, x86_64 or ppc64)"},{errorcode=>[1]});
       return;
    } elsif ( $arch eq "ppc64le" or $arch eq "ppc64el" ) {
-       $callback->({data=>"The arch:$arch is not supported at present, pls use \"ppc64\" instead"});
-       return;
+      $callback->({data=>"The arch:$arch is not supported at present, pls use \"ppc64\" instead"});
+      return;
    }
    unless (-d "$::XCATROOT/share/xcat/netboot/$arch" or -d "$::XCATROOT/share/xcat/netboot/genesis/$arch") {
       $callback->({error=>"Unable to find directory $::XCATROOT/share/xcat/netboot/$arch or $::XCATROOT/share/xcat/netboot/genesis/$arch",errorcode=>[1]});
@@ -121,8 +116,8 @@ sub process_request {
    copy("/root/.ssh/id_rsa.pub","$tempdir$sshdir/authorized_keys");
    chmod(0600,"$tempdir$sshdir/authorized_keys");
    if (not $invisibletouch and -r "/etc/xcat/hostkeys/ssh_host_rsa_key") {
-    copy("/etc/xcat/hostkeys/ssh_host_rsa_key","$tempdir/etc/ssh_host_rsa_key");
-    copy("/etc/xcat/hostkeys/ssh_host_dsa_key","$tempdir/etc/ssh_host_dsa_key");
+      copy("/etc/xcat/hostkeys/ssh_host_rsa_key","$tempdir/etc/ssh_host_rsa_key");
+      copy("/etc/xcat/hostkeys/ssh_host_dsa_key","$tempdir/etc/ssh_host_dsa_key");
       chmod(0600,<$tempdir/etc/ssh_*>);
    }
    unless ($invisibletouch or -r "$tempdir/etc/ssh_host_rsa_key") {
@@ -131,34 +126,34 @@ sub process_request {
    }
    my $lzma_exit_value=1;
    if ($invisibletouch) {
-       my $done=0;
-       if (-x "/usr/bin/lzma") { #let's reclaim some of that size...
-       $callback->({data=>["Creating genesis.fs.$arch.lzma in $tftpdir/xcat"]});
-       system("cd $tempdir; find . | cpio -o -H newc | lzma -C crc32 -9 > $tftpdir/xcat/genesis.fs.$arch.lzma");
-	$lzma_exit_value=$? >> 8;
-	if ($lzma_exit_value) {
-		$callback->({data=>["Creating genesis.fs.$arch.lzma in $tftpdir/xcat failed, falling back to gzip"]});
-		unlink ("$tftpdir/xcat/genesis.fs.$arch.lzma");
-	} else {
-		$done = 1;
-                $initrd_file = "$tftpdir/xcat/genesis.fs.$arch.lzma";
-	}
-	}
-		
-       if (not $done) {
-       $callback->({data=>["Creating genesis.fs.$arch.gz in $tftpdir/xcat"]});
-       system("cd $tempdir; find . | cpio -o -H newc | gzip -9 > $tftpdir/xcat/genesis.fs.$arch.gz");
-       $initrd_file = "$tftpdir/xcat/genesis.fs.$arch.gz";
-	}
+      my $done=0;
+      if (-x "/usr/bin/lzma") { #let's reclaim some of that size...
+         $callback->({data=>["Creating genesis.fs.$arch.lzma in $tftpdir/xcat"]});
+         system("cd $tempdir; find . | cpio -o -H newc | lzma -C crc32 -9 > $tftpdir/xcat/genesis.fs.$arch.lzma");
+         $lzma_exit_value=$? >> 8;
+         if ($lzma_exit_value) {
+            $callback->({data=>["Creating genesis.fs.$arch.lzma in $tftpdir/xcat failed, falling back to gzip"]});
+            unlink ("$tftpdir/xcat/genesis.fs.$arch.lzma");
+         } else {
+            $done = 1;
+            $initrd_file = "$tftpdir/xcat/genesis.fs.$arch.lzma";
+         }
+      }
+
+      if (not $done) {
+         $callback->({data=>["Creating genesis.fs.$arch.gz in $tftpdir/xcat"]});
+         system("cd $tempdir; find . | cpio -o -H newc | gzip -9 > $tftpdir/xcat/genesis.fs.$arch.gz");
+         $initrd_file = "$tftpdir/xcat/genesis.fs.$arch.gz";
+      }
    } else {
-   	$callback->({data=>["Creating nbfs.$arch.gz in $tftpdir/xcat"]});
-       system("cd $tempdir; find . | cpio -o -H newc | gzip -9 > $tftpdir/xcat/nbfs.$arch.gz");
-       $initrd_file = "$tftpdir/xcat/nbfs.$arch.gz";
+      $callback->({data=>["Creating nbfs.$arch.gz in $tftpdir/xcat"]});
+      system("cd $tempdir; find . | cpio -o -H newc | gzip -9 > $tftpdir/xcat/nbfs.$arch.gz");
+      $initrd_file = "$tftpdir/xcat/nbfs.$arch.gz";
    }
    system ("rm -rf $tempdir");
    unless ($initrd_file) {
-       $callback->({data=>["Creating filesystem file in $tftpdir/xcat failed"]});
-       return;
+      $callback->({data=>["Creating filesystem file in $tftpdir/xcat failed"]});
+      return;
    }
 
 CREAT_CONF_FILE:
@@ -182,11 +177,11 @@ CREAT_CONF_FILE:
    my $normnets = xCAT::NetworkUtils->my_nets();
    my $consolecmdline;
    if (defined($serialport) and $serialspeed) {
-       if ($arch =~ /ppc/) {
-           $consolecmdline = "console=tty0 console=hvc$serialport,$serialspeed";
-       } else {
-           $consolecmdline = "console=tty0 console=ttyS$serialport,$serialspeed";
-       }
+      if ($arch =~ /ppc/) {
+         $consolecmdline = "console=tty0 console=hvc$serialport,$serialspeed";
+      } else {
+         $consolecmdline = "console=tty0 console=ttyS$serialport,$serialspeed";
+      }
       if ($serialflow =~ /cts/ or $serialflow =~ /hard/) {
          $consolecmdline .= "n8r";
       } 
@@ -199,12 +194,12 @@ CREAT_CONF_FILE:
       mkpath("$tftpdir/pxelinux.cfg");
       chmod(0755,"$tftpdir/pxelinux.cfg");
       if (-r "/usr/lib/syslinux/pxelinux.0") {
-          copy("/usr/lib/syslinux/pxelinux.0","$tftpdir/pxelinux.0");
+         copy("/usr/lib/syslinux/pxelinux.0","$tftpdir/pxelinux.0");
       } elsif (-r "/usr/share/syslinux/pxelinux.0") {
-          copy("/usr/share/syslinux/pxelinux.0","$tftpdir/pxelinux.0");
+         copy("/usr/share/syslinux/pxelinux.0","$tftpdir/pxelinux.0");
       }
       if (-r "$tftpdir/pxelinux.0") {
-          chmod(0644,"$tftpdir/pxelinux.0");
+         chmod(0644,"$tftpdir/pxelinux.0");
       }
    } elsif ($arch =~ /ppc/) {
       mkpath("$tftpdir/pxelinux.cfg/p/");
@@ -215,60 +210,59 @@ CREAT_CONF_FILE:
       $net =~s/\//_/;
       $dopxe=0;
       if ($arch =~ /x86/) { #only do pxe if just x86 or x86_64 and no x86
-          if ($arch =~ /x86_64/ and not $invisibletouch) {
-              if (-r "$tftpdir/xcat/xnba/nets/$net") {
-                  my $cfg;
-                  my @contents;
-                  open($cfg,"<","$tftpdir/xcat/xnba/nets/$net");
-                  @contents = <$cfg>;
-                  close($cfg);
-                   if (grep (/x86_64/,@contents)) {
-                      $dopxe=1;
-                   }
-             } else {
-                 $dopxe = 1;
-             }
-          } else {
-             $dopxe = 1;
-          }
+         if ($arch =~ /x86_64/ and not $invisibletouch) {
+            if (-r "$tftpdir/xcat/xnba/nets/$net") {
+               my $cfg;
+               my @contents;
+               open($cfg,"<","$tftpdir/xcat/xnba/nets/$net");
+               @contents = <$cfg>;
+               close($cfg);
+               if (grep (/x86_64/,@contents)) {
+                  $dopxe=1;
+               }
+            } else {
+               $dopxe = 1;
+            }
+         } else {
+            $dopxe = 1;
+         }
       }
       if ($dopxe) {
-          my $cfg;
+         my $cfg;
          open($cfg,">","$tftpdir/xcat/xnba/nets/$net");
          print $cfg "#!gpxe\n";
-	 if ($invisibletouch) {
-         print $cfg 'imgfetch -n kernel http://${next-server}/tftpboot/xcat/genesis.kernel.'."$arch quiet xcatd=".$normnets->{$_}.":$xcatdport $consolecmdline BOOTIF=01-".'${netX/machyp}'."\n";
-	if ($lzma_exit_value) {
-         print $cfg 'imgfetch -n nbfs http://${next-server}/tftpboot/xcat/genesis.fs.'."$arch.gz\n";
-	} else {
-         print $cfg 'imgfetch -n nbfs http://${next-server}/tftpboot/xcat/genesis.fs.'."$arch.lzma\n";
-	}
+         if ($invisibletouch) {
+            print $cfg 'imgfetch -n kernel http://${next-server}/tftpboot/xcat/genesis.kernel.'."$arch quiet xcatd=".$normnets->{$_}.":$xcatdport $consolecmdline BOOTIF=01-".'${netX/machyp}'."\n";
+            if ($lzma_exit_value) {
+               print $cfg 'imgfetch -n nbfs http://${next-server}/tftpboot/xcat/genesis.fs.'."$arch.gz\n";
+            } else {
+               print $cfg 'imgfetch -n nbfs http://${next-server}/tftpboot/xcat/genesis.fs.'."$arch.lzma\n";
+            }
          } else {
-         print $cfg 'imgfetch -n kernel http://${next-server}/tftpboot/xcat/nbk.'."$arch quiet xcatd=".$normnets->{$_}.":$xcatdport $consolecmdline\n";
-         print $cfg 'imgfetch -n nbfs http://${next-server}/tftpboot/xcat/nbfs.'."$arch.gz\n";
-	 }
+            print $cfg 'imgfetch -n kernel http://${next-server}/tftpboot/xcat/nbk.'."$arch quiet xcatd=".$normnets->{$_}.":$xcatdport $consolecmdline\n";
+            print $cfg 'imgfetch -n nbfs http://${next-server}/tftpboot/xcat/nbfs.'."$arch.gz\n";
+         }
          print $cfg "imgload kernel\n";
          print $cfg "imgexec kernel\n";
          close($cfg);
-	if ($invisibletouch and $arch =~ /x86_64/) { #UEFI time
-         open($cfg,">","$tftpdir/xcat/xnba/nets/$net.elilo");
-         print $cfg "default=\"xCAT Genesis (".$normnets->{$_}.")\"\n";
-         print $cfg "   delay=5\n";
-         print $cfg '   image=/tftpboot/xcat/genesis.kernel.'."$arch\n";
-	 print $cfg "   label=\"xCAT Genesis (".$normnets->{$_}.")\"\n";
-	if ($lzma_exit_value) {
-	 print $cfg "   initrd=/tftpboot/xcat/genesis.fs.$arch.gz\n";
-	} else {
-	 print $cfg "   initrd=/tftpboot/xcat/genesis.fs.$arch.lzma\n";
-	}
-	 print $cfg "   append=\"quiet xcatd=".$normnets->{$_}.":$xcatdport destiny=discover $consolecmdline BOOTIF=%B\"\n";
-	 close($cfg);
-         open($cfg,">","$tftpdir/xcat/xnba/nets/$net.uefi");
-         print $cfg "#!gpxe\n";
-	 print $cfg 'chain http://${next-server}/tftpboot/xcat/elilo-x64.efi -C /tftpboot/xcat/xnba/nets/'."$net.elilo\n";
-	 close($cfg);
-	}
-	
+         if ($invisibletouch and $arch =~ /x86_64/) { #UEFI time
+            open($cfg,">","$tftpdir/xcat/xnba/nets/$net.elilo");
+            print $cfg "default=\"xCAT Genesis (".$normnets->{$_}.")\"\n";
+            print $cfg "   delay=5\n";
+            print $cfg '   image=/tftpboot/xcat/genesis.kernel.'."$arch\n";
+            print $cfg "   label=\"xCAT Genesis (".$normnets->{$_}.")\"\n";
+            if ($lzma_exit_value) {
+                print $cfg "   initrd=/tftpboot/xcat/genesis.fs.$arch.gz\n";
+            } else {
+                print $cfg "   initrd=/tftpboot/xcat/genesis.fs.$arch.lzma\n";
+            }
+            print $cfg "   append=\"quiet xcatd=".$normnets->{$_}.":$xcatdport destiny=discover $consolecmdline BOOTIF=%B\"\n";
+            close($cfg);
+            open($cfg,">","$tftpdir/xcat/xnba/nets/$net.uefi");
+            print $cfg "#!gpxe\n";
+            print $cfg 'chain http://${next-server}/tftpboot/xcat/elilo-x64.efi -C /tftpboot/xcat/xnba/nets/'."$net.elilo\n";
+            close($cfg);
+         }
       } elsif ($arch =~ /ppc/) {
          open($cfgfile,">", "$tftpdir/pxelinux.cfg/p/$net");
          print $cfgfile "default \"xCAT Genesis (".$normnets->{$_}.")\"\n";

--- a/xCAT-server/lib/xcat/plugins/mknb.pm
+++ b/xCAT-server/lib/xcat/plugins/mknb.pm
@@ -254,7 +254,7 @@ CREAT_CONF_FILE:
          open($cfg,">","$tftpdir/xcat/xnba/nets/$net.elilo");
          print $cfg "default=\"xCAT Genesis\"\ndelay=5\n\n";
          print $cfg 'image=/tftpboot/xcat/genesis.kernel.'."$arch\n";
-	 print $cfg "   label=\"xCAT Genesis\"\n";
+	 print $cfg "   label=\"xCAT Genesis (".$normnets->{$_}.")\"\n";
 	if ($lzma_exit_value) {
 	 print $cfg "   initrd=/tftpboot/xcat/genesis.fs.$arch.gz\n";
 	} else {
@@ -271,7 +271,7 @@ CREAT_CONF_FILE:
       } elsif ($arch =~ /ppc/) {
          open($cfgfile,">", "$tftpdir/pxelinux.cfg/p/$net");
          print $cfgfile "default xCAT\n";
-         print $cfgfile "   label xCAT\n";
+         print $cfgfile "   label xCAT Genesis (".$normnets->{$_}.")\n";
          print $cfgfile "   kernel http://".$normnets->{$_}.":80/$tftpdir/xcat/genesis.kernel.$arch\n";
          print $cfgfile "   initrd http://".$normnets->{$_}.":80/$initrd_file\n";
          print $cfgfile '   append "quiet xcatd='.$normnets->{$_}.":$xcatdport $consolecmdline\"\n";
@@ -308,7 +308,7 @@ CREAT_CONF_FILE:
       } elsif ($arch =~ /ppc/) {
          open($cfgfile,">","$tftpdir/etc/".lc($_));
          print $cfgfile "default xCAT\n";
-         print $cfgfile "   label xCAT\n";
+         print $cfgfile "   label xCAT Genesis (".$normnets->{$_}.")\n";
          print $cfgfile "   kernel http://".$hexnets->{$_}.":80/$tftpdir/xcat/genesis.kernel.$arch\n";
          print $cfgfile "   initrd http://".$hexnets->{$_}.":80/$initrd_file\n";
          print $cfgfile '   append "quiet xcatd='.$hexnets->{$_}.":$xcatdport $consolecmdline\"\n";


### PR DESCRIPTION
"xCAT" label is used whenever doing network boot.  It's hard to differentiate whether we are doing OS provisioning or booting to Genesis to do hardware discovery.   Added more info to the label to differentiate when the network boot is doing Genesis. 

Before:
```
[root@fs1 p]# cat *
default xCAT
   label xCAT
   kernel http://10.3.29.2:80//tftpboot/xcat/genesis.kernel.ppc64
   initrd http://10.3.29.2:80//tftpboot/xcat/genesis.fs.ppc64.gz
   append "quiet xcatd=10.3.29.2:3001 "
default xCAT
   label xCAT
   kernel http://127.0.0.1:80//tftpboot/xcat/genesis.kernel.ppc64
   initrd http://127.0.0.1:80//tftpboot/xcat/genesis.fs.ppc64.gz
   append "quiet xcatd=127.0.0.1:3001 "
default xCAT
   label xCAT
   kernel http://192.168.3.29:80//tftpboot/xcat/genesis.kernel.ppc64
   initrd http://192.168.3.29:80//tftpboot/xcat/genesis.fs.ppc64.gz
   append "quiet xcatd=192.168.3.29:3001 "
default xCAT
   label xCAT
   kernel http://50.3.29.1:80//tftpboot/xcat/genesis.kernel.ppc64
   initrd http://50.3.29.1:80//tftpboot/xcat/genesis.fs.ppc64.gz
   append "quiet xcatd=50.3.29.1:3001 "
```
After 
```
[root@fs1 p]# mknb ppc64
Creating genesis.fs.ppc64.gz in /tftpboot/xcat
[root@fs1 p]# cat *
default xCAT
   label xCAT Genesis (10.3.29.2)
   kernel http://10.3.29.2:80//tftpboot/xcat/genesis.kernel.ppc64
   initrd http://10.3.29.2:80//tftpboot/xcat/genesis.fs.ppc64.gz
   append "quiet xcatd=10.3.29.2:3001 "
default xCAT
   label xCAT Genesis (127.0.0.1)
   kernel http://127.0.0.1:80//tftpboot/xcat/genesis.kernel.ppc64
   initrd http://127.0.0.1:80//tftpboot/xcat/genesis.fs.ppc64.gz
   append "quiet xcatd=127.0.0.1:3001 "
default xCAT
   label xCAT Genesis (192.168.3.29)
   kernel http://192.168.3.29:80//tftpboot/xcat/genesis.kernel.ppc64
   initrd http://192.168.3.29:80//tftpboot/xcat/genesis.fs.ppc64.gz
   append "quiet xcatd=192.168.3.29:3001 "
default xCAT
   label xCAT Genesis (50.3.29.1)
   kernel http://50.3.29.1:80//tftpboot/xcat/genesis.kernel.ppc64
   initrd http://50.3.29.1:80//tftpboot/xcat/genesis.fs.ppc64.gz
   append "quiet xcatd=50.3.29.1:3001 "
```

Here's an example in petitboot:

![image](https://cloud.githubusercontent.com/assets/10049070/15588316/47c9e8ea-235b-11e6-82c4-4a638188d255.png)
