### PR TITLE
man5 and man7 section formatting changes

### DIFF
--- a/create_man_pages.py
+++ b/create_man_pages.py
@@ -130,7 +130,7 @@ for component in COMPONENTS:
                     cmd = "perl -I %s/share/perl5 %s/bin/%s " %(prefix_path, prefix_path, POD2RST)
 
                 cmd += " --infile=%s --outfile=%s --title=%s.%s" %(pod_input, rst_output, title, man_ver)
-                print cmd 
+                # print cmd 
                 os.system(cmd)
 		if man_ver == '1' or man_ver == '8':
                     fix_vertical_bar(rst_output)

--- a/docs/source/advanced/index.rst
+++ b/docs/source/advanced/index.rst
@@ -22,5 +22,4 @@ Advanced Topics
    softlayer/index.rst
    switches/index.rst
    sysclone/index.rst
-   webservices/index.rst
    zones/index.rst

--- a/docs/source/guides/admin-guides/references/man5/auditlog.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/auditlog.5.rst
@@ -27,11 +27,7 @@ DESCRIPTION
 ***********
 
 
-
-.. code-block:: perl
-
-  Audit Data log.
-
+Audit Data log.
 
 
 ********************

--- a/docs/source/guides/admin-guides/references/man5/eventlog.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/eventlog.5.rst
@@ -104,11 +104,7 @@ eventlog Attributes:
 
 \ **rawdata**\ 
  
- 
- .. code-block:: perl
- 
-   The data that associated with the event.
- 
+ The data that associated with the event.
  
 
 

--- a/docs/source/guides/admin-guides/references/man5/ipmi.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/ipmi.5.rst
@@ -50,14 +50,11 @@ ipmi Attributes:
 
 \ **bmcport**\ 
  
+ In systems with selectable shared/dedicated ethernet ports, this parameter can be used to specify the preferred port. 0 means use the shared port, 1 means dedicated, blank is to not assign.
+ 
  
  .. code-block:: perl
  
-   In systems with selectable shared/dedicated ethernet ports,
-             this parameter can be used to specify the preferred port.  0
-             means use the shared port, 1 means dedicated, blank is to not
-             assign.
-  
              The following special cases exist for IBM System x servers:
   
              For x3755 M3 systems, 0 means use the dedicated port, 1 means

--- a/docs/source/guides/admin-guides/references/man5/mpa.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/mpa.5.rst
@@ -63,9 +63,14 @@ mpa Attributes:
 \ **slots**\ 
  
  The number of available slots in the chassis. For PCM, this attribute is used to store the number of slots in the following format:  <slot rows>,<slot columns>,<slot orientation>  Where:
-                  <slot rows>  = number of rows of slots in chassis
-                  <slot columns> = number of columns of slots in chassis
-                  <slot orientation> = set to 0 if slots are vertical, and set to 1 if slots of horizontal
+ 
+ 
+ .. code-block:: perl
+ 
+                   <slot rows>  = number of rows of slots in chassis
+                   <slot columns> = number of columns of slots in chassis
+                   <slot orientation> = set to 0 if slots are vertical, and set to 1 if slots of horizontal
+ 
  
 
 

--- a/docs/source/guides/admin-guides/references/man5/nics.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/nics.5.rst
@@ -44,7 +44,8 @@ nics Attributes:
 
 \ **nicips**\ 
  
- Comma-separated list of IP addresses per NIC. To specify one ip address per NIC:
+ Comma-separated list of IP addresses per NIC. 
+                 To specify one ip address per NIC:
                      <nic1>!<ip1>,<nic2>!<ip2>,..., for example, eth0!10.0.0.100,ib0!11.0.0.100
                  To specify multiple ip addresses per NIC:
                      <nic1>!<ip1>|<ip2>,<nic2>!<ip1>|<ip2>,..., for example, eth0!10.0.0.100|fd55::214:5eff:fe15:849b,ib0!11.0.0.100|2001::214:5eff:fe15:849a. The xCAT object definition commands support to use nicips.<nicname> as the sub attributes.
@@ -102,9 +103,9 @@ nics Attributes:
 \ **nicaliases**\ 
  
  Comma-separated list of hostname aliases for each NIC.
-             Format: eth0!<alias list>,eth1!<alias1 list>|<alias2 list>
- 			For multiple aliases per nic use a space-separated list.
-             For example: eth0!moe larry curly,eth1!tom|jerry
+                 Format: eth0!<alias list>,eth1!<alias1 list>|<alias2 list>
+                     For multiple aliases per nic use a space-separated list. 
+                 For example: eth0!moe larry curly,eth1!tom|jerry
  
 
 
@@ -121,7 +122,7 @@ nics Attributes:
 
 \ **nicdevices**\ 
  
- Comma-separated list of NIC device per NIC, multiple ethernet devices can be bonded as bond device, these ethernet devices are separated by |. <nic1>!<dev1>|<dev3>,<nic2>!<dev2>, e.g. bond0!eth0|eth2,br0!bond0. The xCAT object definition commands support to use nicdevices.<nicname> as the sub attributes.
+ Comma-separated list of NIC device per NIC, multiple ethernet devices can be bonded as bond device, these ethernet devices are separated by | . <nic1>!<dev1>|<dev3>,<nic2>!<dev2>, e.g. bond0!eth0|eth2,br0!bond0. The xCAT object definition commands support to use nicdevices.<nicname> as the sub attributes.
  
 
 

--- a/docs/source/guides/admin-guides/references/man5/noderes.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/noderes.5.rst
@@ -51,12 +51,17 @@ noderes Attributes:
 \ **netboot**\ 
  
  The type of network booting to use for this node.  Valid values:
-                        Arch                  OS                           valid netboot options 
-                        x86, x86_64           ALL                          pxe, xnba 
-                        ppc64                 <=rhel6, <=sles11.3          yaboot
-                        ppc64                 >=rhels7, >=sles11.4         grub2,grub2-http,grub2-tftp
-                  ppc64le NonVirtualize       ALL                          petitboot
-                  ppc64le PowerKVM Guest      ALL                          grub2,grub2-http,grub2-tftp
+ 
+ 
+ .. code-block:: perl
+ 
+                         Arch                    OS                           valid netboot options 
+                         x86, x86_64             ALL                          pxe, xnba 
+                         ppc64                   <=rhel6, <=sles11.3          yaboot
+                         ppc64                   >=rhels7, >=sles11.4         grub2,grub2-http,grub2-tftp
+                         ppc64le NonVirtualize   ALL                          petitboot
+                         ppc64le PowerKVM Guest  ALL                          grub2,grub2-http,grub2-tftp
+ 
  
 
 

--- a/docs/source/guides/admin-guides/references/man5/prescripts.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/prescripts.5.rst
@@ -44,10 +44,9 @@ prescripts Attributes:
 
 \ **begin**\ 
  
- The scripts to be run at the beginning of the nodeset(Linux),
-  nimnodeset(AIX) or mkdsklsnode(AIX) command.
+ The scripts to be run at the beginning of the nodeset(Linux), nimnodeset(AIX) or mkdsklsnode(AIX) command.
   The format is:
-    [action1:]s1,s2...[|action2:s3,s4,s5...]
+    [action1:]s1,s2...[| action2:s3,s4,s5...]
   where:
    - action1 and action2 for Linux are the nodeset actions specified in the command. 
      For AIX, action1 and action1 can be 'diskless' for mkdsklsnode command'
@@ -59,28 +58,20 @@ prescripts Attributes:
     myscript1,myscript2  (all actions)
     diskless:myscript1,myscript2   (AIX)
     install:myscript1,myscript2|netboot:myscript3   (Linux)
- 
- 
- .. code-block:: perl
- 
-   All the scripts should be copied to /install/prescripts directory.
-   The following two environment variables will be passed to each script: 
-     NODES a coma separated list of node names that need to run the script for
-     ACTION current nodeset action.
-  
-   If '#xCAT setting:MAX_INSTANCE=number' is specified in the script, the script
-   will get invoked for each node in parallel, but no more than number of instances
-   will be invoked at at a time. If it is not specified, the script will be invoked
-   once for all the nodes.
- 
+  All the scripts should be copied to /install/prescripts directory.
+  The following two environment variables will be passed to each script: 
+    NODES a coma separated list of node names that need to run the script for
+    ACTION current nodeset action.
+  If '#xCAT setting:MAX_INSTANCE=number' is specified in the script, the script
+  will get invoked for each node in parallel, but no more than number of instances
+  will be invoked at at a time. If it is not specified, the script will be invoked
+  once for all the nodes.
  
 
 
 \ **end**\ 
  
- The scripts to be run at the end of the nodeset(Linux),
-  nimnodeset(AIX),or mkdsklsnode(AIX) command. 
-  The format is the same as the 'begin' column.
+ The scripts to be run at the end of the nodeset(Linux), nimnodeset(AIX),or mkdsklsnode(AIX) command. The format is the same as the 'begin' column.
  
 
 

--- a/docs/source/guides/admin-guides/references/man5/storage.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/storage.5.rst
@@ -43,9 +43,14 @@ storage Attributes:
 \ **osvolume**\ 
  
  Specification of what storage to place the node OS image onto.  Examples include:
-                 localdisk (Install to first non-FC attached disk)
-                 usbdisk (Install to first USB mass storage device seen)
-                 wwn=0x50000393c813840c (Install to storage device with given WWN)
+ 
+ 
+ .. code-block:: perl
+ 
+                  localdisk (Install to first non-FC attached disk)
+                  usbdisk (Install to first USB mass storage device seen)
+                  wwn=0x50000393c813840c (Install to storage device with given WWN)
+ 
  
 
 
@@ -93,9 +98,9 @@ storage Attributes:
 
 \ **controller**\ 
  
- The management address to attach/detach new volumes.
-                        In the scenario involving multiple controllers, this data must be
-                        passed as argument rather than by table value
+ The management address to attach/detach new volumes. 
+ In the scenario involving multiple controllers, this data must be
+ passed as argument rather than by table value
  
 
 

--- a/docs/source/guides/admin-guides/references/man5/vm.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/vm.5.rst
@@ -128,7 +128,8 @@ vm Attributes:
 
 \ **virtflags**\ 
  
- General flags used by the virtualization method.  For example, in Xen it could, among other things, specify paravirtualized setup, or direct kernel boot.  For a hypervisor/dom0 entry, it is the virtualization method (i.e. "xen").  For KVM, the following flag=value pairs are recognized:
+ General flags used by the virtualization method.  
+           For example, in Xen it could, among other things, specify paravirtualized setup, or direct kernel boot.  For a hypervisor/dom0 entry, it is the virtualization method (i.e. "xen").  For KVM, the following flag=value pairs are recognized:
              imageformat=[raw|fullraw|qcow2]
                  raw is a generic sparse file that allocates storage on demand
                  fullraw is a generic, non-sparse file that preallocates all space

--- a/docs/source/guides/admin-guides/references/man5/xcatdb.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/xcatdb.5.rst
@@ -329,11 +329,7 @@ The tables are:
 
 auditlog(5)|auditlog.5
  
- 
- .. code-block:: perl
- 
-   Audit Data log.
- 
+ Audit Data log.
  
 
 

--- a/docs/source/guides/admin-guides/references/man7/eventlog.7.rst
+++ b/docs/source/guides/admin-guides/references/man7/eventlog.7.rst
@@ -107,11 +107,7 @@ eventlog Attributes:
 
 \ **rawdata**\  (eventlog.rawdata)
  
- 
- .. code-block:: perl
- 
-   The data that associated with the event.
- 
+ The data that associated with the event.
  
 
 

--- a/docs/source/guides/admin-guides/references/man7/group.7.rst
+++ b/docs/source/guides/admin-guides/references/man7/group.7.rst
@@ -286,7 +286,9 @@ group Attributes:
 \ **hcp**\  (ppc.hcp, zvm.hcp)
  
  The hardware control point for this node (HMC, IVM, Frame or CEC).  Do not need to set for BPAs and FSPs.
+ 
  or
+ 
  The hardware control point for this node.
  
 
@@ -330,11 +332,17 @@ group Attributes:
 \ **hwtype**\  (ppc.nodetype, zvm.nodetype, mp.nodetype, mic.nodetype)
  
  The hardware type of the node. Only can be one of fsp, bpa, cec, frame, ivm, hmc and lpar
+ 
  or
+ 
  The node type. Valid values: cec (Central Electronic Complex), lpar (logical partition), zvm (z/VM host operating system), and vm (virtual machine).
+ 
  or
+ 
  The hardware type for mp node. Valid values: mm,cmm, blade.
+ 
  or
+ 
  The hardware type of the mic node. Generally, it is mic.
  
 
@@ -342,7 +350,9 @@ group Attributes:
 \ **id**\  (ppc.id, mp.id)
  
  For LPARs: the LPAR numeric id; for CECs: the cage number; for Frames: the frame number.
+ 
  or
+ 
  The slot number of this blade in the BladeCenter chassis.
  
 
@@ -718,11 +728,17 @@ group Attributes:
 \ **password**\  (ppchcp.password, mpa.password, websrv.password, switches.sshpassword)
  
  Password of the HMC or IVM.  If not filled in, xCAT will look in the passwd table for key=hmc or key=ivm.  If not in the passwd table, the default used is abc123 for HMCs and padmin for IVMs.
+ 
  or
+ 
  Password to use to access the management module.  If not specified, the key=blade row in the passwd table is used as the default.
+ 
  or
+ 
  Password to use to access the web service.
+ 
  or
+ 
  The remote login password. It can be for ssh or telnet. If it is for telnet, please set protocol to "telnet". If the sshusername is blank, the username, password and protocol will be retrieved from the passwd table with "switch" as the key.
  
 
@@ -1115,11 +1131,17 @@ group Attributes:
 \ **username**\  (ppchcp.username, mpa.username, websrv.username, switches.sshusername)
  
  Userid of the HMC or IVM.  If not filled in, xCAT will look in the passwd table for key=hmc or key=ivm.  If not in the passwd table, the default used is hscroot for HMCs and padmin for IVMs.
+ 
  or
+ 
  Userid to use to access the management module.
+ 
  or
+ 
  Userid to use to access the web service.
+ 
  or
+ 
  The remote login user name. It can be for ssh or telnet. If it is for telnet, please set protocol to "telnet". If the sshusername is blank, the username, password and protocol will be retrieved from the passwd table with "switch" as the key.
  
 

--- a/docs/source/guides/admin-guides/references/man7/group.7.rst
+++ b/docs/source/guides/admin-guides/references/man7/group.7.rst
@@ -71,86 +71,44 @@ group Attributes:
 
 \ **bmcport**\  (ipmi.bmcport)
  
+ In systems with selectable shared/dedicated ethernet ports, this parameter can be used to specify the preferred port. 0 means use the shared port, 1 means dedicated, blank is to not assign.
+ 
  
  .. code-block:: perl
  
-   In systems with selectable shared/dedicated ethernet ports,
-  
-             this parameter can be used to specify the preferred port.  0
-  
-             means use the shared port, 1 means dedicated, blank is to not
-  
-             assign.
-  
-  
-  
              The following special cases exist for IBM System x servers:
   
-  
-  
              For x3755 M3 systems, 0 means use the dedicated port, 1 means
-  
              shared, blank is to not assign.
   
-  
-  
          For certain systems which have a mezzaine or ML2 adapter, there is a second
-  
          value to include:
-  
-  
-  
   
   
              For x3750 M4 (Model 8722):
   
   
-  
-  
-  
              0 2   1st 1Gbps interface for LOM
-  
-  
   
              0 0   1st 10Gbps interface for LOM
   
-  
-  
              0 3   2nd 1Gbps interface for LOM
   
-  
-  
              0 1   2nd 10Gbps interface for LOM
-  
-  
-  
   
   
              For  x3750 M4 (Model 8752), x3850/3950 X6, dx360 M4, x3550 M4, and x3650 M4:
   
   
-  
-  
-  
              0     Shared (1st onboard interface)
-  
-  
   
              1     Dedicated
   
-  
-  
              2 0   First interface on ML2 or mezzanine adapter
-  
-  
   
              2 1   Second interface on ML2 or mezzanine adapter
   
-  
-  
              2 2   Third interface on ML2 or mezzanine adapter
-  
-  
   
              2 3   Fourth interface on ML2 or mezzanine adapter
  
@@ -328,9 +286,7 @@ group Attributes:
 \ **hcp**\  (ppc.hcp, zvm.hcp)
  
  The hardware control point for this node (HMC, IVM, Frame or CEC).  Do not need to set for BPAs and FSPs.
- 
  or
- 
  The hardware control point for this node.
  
 
@@ -374,17 +330,11 @@ group Attributes:
 \ **hwtype**\  (ppc.nodetype, zvm.nodetype, mp.nodetype, mic.nodetype)
  
  The hardware type of the node. Only can be one of fsp, bpa, cec, frame, ivm, hmc and lpar
- 
  or
- 
  The node type. Valid values: cec (Central Electronic Complex), lpar (logical partition), zvm (z/VM host operating system), and vm (virtual machine).
- 
  or
- 
  The hardware type for mp node. Valid values: mm,cmm, blade.
- 
  or
- 
  The hardware type of the mic node. Generally, it is mic.
  
 
@@ -392,9 +342,7 @@ group Attributes:
 \ **id**\  (ppc.id, mp.id)
  
  For LPARs: the LPAR numeric id; for CECs: the cage number; for Frames: the frame number.
- 
  or
- 
  The slot number of this blade in the BladeCenter chassis.
  
 
@@ -568,17 +516,12 @@ group Attributes:
  
  .. code-block:: perl
  
-                         Arch                  OS                           valid netboot options 
-  
-                         x86, x86_64           ALL                          pxe, xnba 
-  
-                         ppc64                 <=rhel6, <=sles11.3          yaboot
-  
-                         ppc64                 >=rhels7, >=sles11.4         grub2,grub2-http,grub2-tftp
-  
-                   ppc64le NonVirtualize       ALL                          petitboot
-  
-                   ppc64le PowerKVM Guest      ALL                          grub2,grub2-http,grub2-tftp
+                         Arch                    OS                           valid netboot options 
+                         x86, x86_64             ALL                          pxe, xnba 
+                         ppc64                   <=rhel6, <=sles11.3          yaboot
+                         ppc64                   >=rhels7, >=sles11.4         grub2,grub2-http,grub2-tftp
+                         ppc64le NonVirtualize   ALL                          petitboot
+                         ppc64le PowerKVM Guest  ALL                          grub2,grub2-http,grub2-tftp
  
  
 
@@ -598,142 +541,85 @@ group Attributes:
 \ **nicaliases**\  (nics.nicaliases)
  
  Comma-separated list of hostname aliases for each NIC.
- 
- 
- .. code-block:: perl
- 
-              Format: eth0!<alias list>,eth1!<alias1 list>|<alias2 list>
-  
-  			For multiple aliases per nic use a space-separated list.
-  
-              For example: eth0!moe larry curly,eth1!tom|jerry
- 
+                 Format: eth0!<alias list>,eth1!<alias1 list>|<alias2 list>
+                     For multiple aliases per nic use a space-separated list. 
+                 For example: eth0!moe larry curly,eth1!tom|jerry
  
 
 
 \ **niccustomscripts**\  (nics.niccustomscripts)
  
  Comma-separated list of custom scripts per NIC.  <nic1>!<script1>,<nic2>!<script2>, e.g. eth0!configeth eth0, ib0!configib ib0. The xCAT object definition commands support to use niccustomscripts.<nicname> as the sub attribute
- 
  .
  
 
 
 \ **nicdevices**\  (nics.nicdevices)
  
- Comma-separated list of NIC device per NIC, multiple ethernet devices can be bonded as bond device, these ethernet devices are separated by |. <nic1>!<dev1>|<dev3>,<nic2>!<dev2>, e.g. bond0!eth0|eth2,br0!bond0. The xCAT object definition commands support to use nicdevices.<nicname> as the sub attributes.
+ Comma-separated list of NIC device per NIC, multiple ethernet devices can be bonded as bond device, these ethernet devices are separated by | . <nic1>!<dev1>|<dev3>,<nic2>!<dev2>, e.g. bond0!eth0|eth2,br0!bond0. The xCAT object definition commands support to use nicdevices.<nicname> as the sub attributes.
  
 
 
 \ **nicextraparams**\  (nics.nicextraparams)
  
  Comma-separated list of extra parameters that will be used for each NIC configuration.
- 
- 
- .. code-block:: perl
- 
-                  If only one ip address is associated with each NIC:
-  
-                      <nic1>!<param1=value1 param2=value2>,<nic2>!<param3=value3>, for example, eth0!MTU=1500,ib0!MTU=65520 CONNECTED_MODE=yes.
-  
-                  If multiple ip addresses are associated with each NIC:
-  
-                      <nic1>!<param1=value1 param2=value2>|<param3=value3>,<nic2>!<param4=value4 param5=value5>|<param6=value6>, for example, eth0!MTU=1500|MTU=1460,ib0!MTU=65520 CONNECTED_MODE=yes.
-  
-              The xCAT object definition commands support to use nicextraparams.<nicname> as the sub attributes.
- 
+                 If only one ip address is associated with each NIC:
+                     <nic1>!<param1=value1 param2=value2>,<nic2>!<param3=value3>, for example, eth0!MTU=1500,ib0!MTU=65520 CONNECTED_MODE=yes.
+                 If multiple ip addresses are associated with each NIC:
+                     <nic1>!<param1=value1 param2=value2>|<param3=value3>,<nic2>!<param4=value4 param5=value5>|<param6=value6>, for example, eth0!MTU=1500|MTU=1460,ib0!MTU=65520 CONNECTED_MODE=yes.
+             The xCAT object definition commands support to use nicextraparams.<nicname> as the sub attributes.
  
 
 
 \ **nichostnameprefixes**\  (nics.nichostnameprefixes)
  
- Comma-separated list of hostname prefixes per NIC.
- 
- 
- .. code-block:: perl
- 
-                          If only one ip address is associated with each NIC:
-  
-                              <nic1>!<ext1>,<nic2>!<ext2>,..., for example, eth0!eth0-,ib0!ib-
-  
-                          If multiple ip addresses are associcated with each NIC:
-  
-                              <nic1>!<ext1>|<ext2>,<nic2>!<ext1>|<ext2>,..., for example,  eth0!eth0-|eth0-ipv6i-,ib0!ib-|ib-ipv6-. 
-  
-                          The xCAT object definition commands support to use nichostnameprefixes.<nicname> as the sub attributes. 
-  
-                          Note:  According to DNS rules a hostname must be a text string up to 24 characters drawn from the alphabet (A-Z), digits (0-9), minus sign (-),and period (.). When you are specifying "nichostnameprefixes" or "nicaliases" make sure the resulting hostnames will conform to this naming convention
- 
+ Comma-separated list of hostname prefixes per NIC. 
+                         If only one ip address is associated with each NIC:
+                             <nic1>!<ext1>,<nic2>!<ext2>,..., for example, eth0!eth0-,ib0!ib-
+                         If multiple ip addresses are associcated with each NIC:
+                             <nic1>!<ext1>|<ext2>,<nic2>!<ext1>|<ext2>,..., for example,  eth0!eth0-|eth0-ipv6i-,ib0!ib-|ib-ipv6-. 
+                         The xCAT object definition commands support to use nichostnameprefixes.<nicname> as the sub attributes. 
+                         Note:  According to DNS rules a hostname must be a text string up to 24 characters drawn from the alphabet (A-Z), digits (0-9), minus sign (-),and period (.). When you are specifying "nichostnameprefixes" or "nicaliases" make sure the resulting hostnames will conform to this naming convention
  
 
 
 \ **nichostnamesuffixes**\  (nics.nichostnamesuffixes)
  
- Comma-separated list of hostname suffixes per NIC.
- 
- 
- .. code-block:: perl
- 
-                          If only one ip address is associated with each NIC:
-  
-                              <nic1>!<ext1>,<nic2>!<ext2>,..., for example, eth0!-eth0,ib0!-ib0
-  
-                          If multiple ip addresses are associcated with each NIC:
-  
-                              <nic1>!<ext1>|<ext2>,<nic2>!<ext1>|<ext2>,..., for example,  eth0!-eth0|-eth0-ipv6,ib0!-ib0|-ib0-ipv6. 
-  
-                          The xCAT object definition commands support to use nichostnamesuffixes.<nicname> as the sub attributes. 
-  
-                          Note:  According to DNS rules a hostname must be a text string up to 24 characters drawn from the alphabet (A-Z), digits (0-9), minus sign (-),and period (.). When you are specifying "nichostnamesuffixes" or "nicaliases" make sure the resulting hostnames will conform to this naming convention
- 
+ Comma-separated list of hostname suffixes per NIC. 
+                         If only one ip address is associated with each NIC:
+                             <nic1>!<ext1>,<nic2>!<ext2>,..., for example, eth0!-eth0,ib0!-ib0
+                         If multiple ip addresses are associcated with each NIC:
+                             <nic1>!<ext1>|<ext2>,<nic2>!<ext1>|<ext2>,..., for example,  eth0!-eth0|-eth0-ipv6,ib0!-ib0|-ib0-ipv6. 
+                         The xCAT object definition commands support to use nichostnamesuffixes.<nicname> as the sub attributes. 
+                         Note:  According to DNS rules a hostname must be a text string up to 24 characters drawn from the alphabet (A-Z), digits (0-9), minus sign (-),and period (.). When you are specifying "nichostnamesuffixes" or "nicaliases" make sure the resulting hostnames will conform to this naming convention
  
 
 
 \ **nicips**\  (nics.nicips)
  
- Comma-separated list of IP addresses per NIC. To specify one ip address per NIC:
- 
- 
- .. code-block:: perl
- 
-                      <nic1>!<ip1>,<nic2>!<ip2>,..., for example, eth0!10.0.0.100,ib0!11.0.0.100
-  
-                  To specify multiple ip addresses per NIC:
-  
-                      <nic1>!<ip1>|<ip2>,<nic2>!<ip1>|<ip2>,..., for example, eth0!10.0.0.100|fd55::214:5eff:fe15:849b,ib0!11.0.0.100|2001::214:5eff:fe15:849a. The xCAT object definition commands support to use nicips.<nicname> as the sub attributes.
-  
-                  Note: The primary IP address must also be stored in the hosts.ip attribute. The nichostnamesuffixes should specify one hostname suffix for each ip address.
- 
+ Comma-separated list of IP addresses per NIC. 
+                 To specify one ip address per NIC:
+                     <nic1>!<ip1>,<nic2>!<ip2>,..., for example, eth0!10.0.0.100,ib0!11.0.0.100
+                 To specify multiple ip addresses per NIC:
+                     <nic1>!<ip1>|<ip2>,<nic2>!<ip1>|<ip2>,..., for example, eth0!10.0.0.100|fd55::214:5eff:fe15:849b,ib0!11.0.0.100|2001::214:5eff:fe15:849a. The xCAT object definition commands support to use nicips.<nicname> as the sub attributes.
+                 Note: The primary IP address must also be stored in the hosts.ip attribute. The nichostnamesuffixes should specify one hostname suffix for each ip address.
  
 
 
 \ **nicnetworks**\  (nics.nicnetworks)
  
  Comma-separated list of networks connected to each NIC.
- 
- 
- .. code-block:: perl
- 
-                  If only one ip address is associated with each NIC:
-  
-                      <nic1>!<network1>,<nic2>!<network2>, for example, eth0!10_0_0_0-255_255_0_0, ib0!11_0_0_0-255_255_0_0
-  
-                  If multiple ip addresses are associated with each NIC:
-  
-                      <nic1>!<network1>|<network2>,<nic2>!<network1>|<network2>, for example, eth0!10_0_0_0-255_255_0_0|fd55:faaf:e1ab:336::/64,ib0!11_0_0_0-255_255_0_0|2001:db8:1:0::/64. The xCAT object definition commands support to use nicnetworks.<nicname> as the sub attributes.
- 
+                 If only one ip address is associated with each NIC:
+                     <nic1>!<network1>,<nic2>!<network2>, for example, eth0!10_0_0_0-255_255_0_0, ib0!11_0_0_0-255_255_0_0
+                 If multiple ip addresses are associated with each NIC:
+                     <nic1>!<network1>|<network2>,<nic2>!<network1>|<network2>, for example, eth0!10_0_0_0-255_255_0_0|fd55:faaf:e1ab:336::/64,ib0!11_0_0_0-255_255_0_0|2001:db8:1:0::/64. The xCAT object definition commands support to use nicnetworks.<nicname> as the sub attributes.
  
 
 
 \ **nicsadapter**\  (nics.nicsadapter)
  
  Comma-separated list of extra parameters that will be used for each NIC configuration.
- 
- 
- .. code-block:: perl
- 
-                      <nic1>!<param1=value1 param2=value2>|<param3=value3>,<nic2>!<param4=value4 param5=value5>|<param6=value6>, for example, eth0!MTU=1500|MTU=1460,ib0!MTU=65520 CONNECTED_MODE=yes.
- 
+                     <nic1>!<param1=value1 param2=value2>|<param3=value3>,<nic2>!<param4=value4 param5=value5>|<param6=value6>, for example, eth0!MTU=1500|MTU=1460,ib0!MTU=65520 CONNECTED_MODE=yes.
  
 
 
@@ -775,9 +661,7 @@ group Attributes:
  .. code-block:: perl
  
                   localdisk (Install to first non-FC attached disk)
-  
                   usbdisk (Install to first USB mass storage device seen)
-  
                   wwn=0x50000393c813840c (Install to storage device with given WWN)
  
  
@@ -834,17 +718,11 @@ group Attributes:
 \ **password**\  (ppchcp.password, mpa.password, websrv.password, switches.sshpassword)
  
  Password of the HMC or IVM.  If not filled in, xCAT will look in the passwd table for key=hmc or key=ivm.  If not in the passwd table, the default used is abc123 for HMCs and padmin for IVMs.
- 
  or
- 
  Password to use to access the management module.  If not specified, the key=blade row in the passwd table is used as the default.
- 
  or
- 
  Password to use to access the web service.
- 
  or
- 
  The remote login password. It can be for ssh or telnet. If it is for telnet, please set protocol to "telnet". If the sshusername is blank, the username, password and protocol will be retrieved from the passwd table with "switch" as the key.
  
 
@@ -875,73 +753,34 @@ group Attributes:
 
 \ **prescripts-begin**\  (prescripts.begin)
  
- The scripts to be run at the beginning of the nodeset(Linux),
- 
- 
- .. code-block:: perl
- 
-   nimnodeset(AIX) or mkdsklsnode(AIX) command.
-  
-   The format is:
-  
-     [action1:]s1,s2...[|action2:s3,s4,s5...]
-  
-   where:
-  
-    - action1 and action2 for Linux are the nodeset actions specified in the command. 
-  
-      For AIX, action1 and action1 can be 'diskless' for mkdsklsnode command'
-  
-      and 'standalone for nimnodeset command. 
-  
-    - s1 and s2 are the scripts to run for action1 in order.
-  
-    - s3, s4, and s5 are the scripts to run for actions2.
-  
-   If actions are omitted, the scripts apply to all actions.
-  
-   Examples:
-  
-     myscript1,myscript2  (all actions)
-  
-     diskless:myscript1,myscript2   (AIX)
-  
-     install:myscript1,myscript2|netboot:myscript3   (Linux)
-  
-  
-  
-   All the scripts should be copied to /install/prescripts directory.
-  
-   The following two environment variables will be passed to each script: 
-  
-     NODES a coma separated list of node names that need to run the script for
-  
-     ACTION current nodeset action.
-  
-  
-  
-   If '#xCAT setting:MAX_INSTANCE=number' is specified in the script, the script
-  
-   will get invoked for each node in parallel, but no more than number of instances
-  
-   will be invoked at at a time. If it is not specified, the script will be invoked
-  
-   once for all the nodes.
- 
+ The scripts to be run at the beginning of the nodeset(Linux), nimnodeset(AIX) or mkdsklsnode(AIX) command.
+  The format is:
+    [action1:]s1,s2...[| action2:s3,s4,s5...]
+  where:
+   - action1 and action2 for Linux are the nodeset actions specified in the command. 
+     For AIX, action1 and action1 can be 'diskless' for mkdsklsnode command'
+     and 'standalone for nimnodeset command. 
+   - s1 and s2 are the scripts to run for action1 in order.
+   - s3, s4, and s5 are the scripts to run for actions2.
+  If actions are omitted, the scripts apply to all actions.
+  Examples:
+    myscript1,myscript2  (all actions)
+    diskless:myscript1,myscript2   (AIX)
+    install:myscript1,myscript2|netboot:myscript3   (Linux)
+  All the scripts should be copied to /install/prescripts directory.
+  The following two environment variables will be passed to each script: 
+    NODES a coma separated list of node names that need to run the script for
+    ACTION current nodeset action.
+  If '#xCAT setting:MAX_INSTANCE=number' is specified in the script, the script
+  will get invoked for each node in parallel, but no more than number of instances
+  will be invoked at at a time. If it is not specified, the script will be invoked
+  once for all the nodes.
  
 
 
 \ **prescripts-end**\  (prescripts.end)
  
- The scripts to be run at the end of the nodeset(Linux),
- 
- 
- .. code-block:: perl
- 
-   nimnodeset(AIX),or mkdsklsnode(AIX) command. 
-  
-   The format is the same as the 'begin' column.
- 
+ The scripts to be run at the end of the nodeset(Linux), nimnodeset(AIX),or mkdsklsnode(AIX) command. The format is the same as the 'begin' column.
  
 
 
@@ -1121,9 +960,7 @@ group Attributes:
  .. code-block:: perl
  
                    <slot rows>  = number of rows of slots in chassis
-  
                    <slot columns> = number of columns of slots in chassis
-  
                    <slot orientation> = set to 0 if slots are vertical, and set to 1 if slots of horizontal
  
  
@@ -1161,15 +998,9 @@ group Attributes:
 
 \ **storagcontroller**\  (storage.controller)
  
- The management address to attach/detach new volumes.
- 
- 
- .. code-block:: perl
- 
-                         In the scenario involving multiple controllers, this data must be
-  
-                         passed as argument rather than by table value
- 
+ The management address to attach/detach new volumes. 
+ In the scenario involving multiple controllers, this data must be
+ passed as argument rather than by table value
  
 
 
@@ -1284,17 +1115,11 @@ group Attributes:
 \ **username**\  (ppchcp.username, mpa.username, websrv.username, switches.sshusername)
  
  Userid of the HMC or IVM.  If not filled in, xCAT will look in the passwd table for key=hmc or key=ivm.  If not in the passwd table, the default used is hscroot for HMCs and padmin for IVMs.
- 
  or
- 
  Userid to use to access the management module.
- 
  or
- 
  Userid to use to access the web service.
- 
  or
- 
  The remote login user name. It can be for ssh or telnet. If it is for telnet, please set protocol to "telnet". If the sshusername is blank, the username, password and protocol will be retrieved from the passwd table with "switch" as the key.
  
 
@@ -1409,27 +1234,16 @@ group Attributes:
 
 \ **vmvirtflags**\  (vm.virtflags)
  
- General flags used by the virtualization method.  For example, in Xen it could, among other things, specify paravirtualized setup, or direct kernel boot.  For a hypervisor/dom0 entry, it is the virtualization method (i.e. "xen").  For KVM, the following flag=value pairs are recognized:
- 
- 
- .. code-block:: perl
- 
-              imageformat=[raw|fullraw|qcow2]
-  
-                  raw is a generic sparse file that allocates storage on demand
-  
-                  fullraw is a generic, non-sparse file that preallocates all space
-  
-                  qcow2 is a sparse, copy-on-write capable format implemented at the virtualization layer rather than the filesystem level
-  
-              clonemethod=[qemu-img|reflink]
-  
-                  qemu-img allows use of qcow2 to generate virtualization layer copy-on-write
-  
-                  reflink uses a generic filesystem facility to clone the files on your behalf, but requires filesystem support such as btrfs 
-  
-              placement_affinity=[migratable|user_migratable|pinned]
- 
+ General flags used by the virtualization method.  
+           For example, in Xen it could, among other things, specify paravirtualized setup, or direct kernel boot.  For a hypervisor/dom0 entry, it is the virtualization method (i.e. "xen").  For KVM, the following flag=value pairs are recognized:
+             imageformat=[raw|fullraw|qcow2]
+                 raw is a generic sparse file that allocates storage on demand
+                 fullraw is a generic, non-sparse file that preallocates all space
+                 qcow2 is a sparse, copy-on-write capable format implemented at the virtualization layer rather than the filesystem level
+             clonemethod=[qemu-img|reflink]
+                 qemu-img allows use of qcow2 to generate virtualization layer copy-on-write
+                 reflink uses a generic filesystem facility to clone the files on your behalf, but requires filesystem support such as btrfs 
+             placement_affinity=[migratable|user_migratable|pinned]
  
 
 

--- a/docs/source/guides/admin-guides/references/man7/node.7.rst
+++ b/docs/source/guides/admin-guides/references/man7/node.7.rst
@@ -83,86 +83,44 @@ node Attributes:
 
 \ **bmcport**\  (ipmi.bmcport)
  
+ In systems with selectable shared/dedicated ethernet ports, this parameter can be used to specify the preferred port. 0 means use the shared port, 1 means dedicated, blank is to not assign.
+ 
  
  .. code-block:: perl
  
-   In systems with selectable shared/dedicated ethernet ports,
-  
-             this parameter can be used to specify the preferred port.  0
-  
-             means use the shared port, 1 means dedicated, blank is to not
-  
-             assign.
-  
-  
-  
              The following special cases exist for IBM System x servers:
   
-  
-  
              For x3755 M3 systems, 0 means use the dedicated port, 1 means
-  
              shared, blank is to not assign.
   
-  
-  
          For certain systems which have a mezzaine or ML2 adapter, there is a second
-  
          value to include:
-  
-  
-  
   
   
              For x3750 M4 (Model 8722):
   
   
-  
-  
-  
              0 2   1st 1Gbps interface for LOM
-  
-  
   
              0 0   1st 10Gbps interface for LOM
   
-  
-  
              0 3   2nd 1Gbps interface for LOM
   
-  
-  
              0 1   2nd 10Gbps interface for LOM
-  
-  
-  
   
   
              For  x3750 M4 (Model 8752), x3850/3950 X6, dx360 M4, x3550 M4, and x3650 M4:
   
   
-  
-  
-  
              0     Shared (1st onboard interface)
-  
-  
   
              1     Dedicated
   
-  
-  
              2 0   First interface on ML2 or mezzanine adapter
-  
-  
   
              2 1   Second interface on ML2 or mezzanine adapter
   
-  
-  
              2 2   Third interface on ML2 or mezzanine adapter
-  
-  
   
              2 3   Fourth interface on ML2 or mezzanine adapter
  
@@ -334,9 +292,7 @@ node Attributes:
 \ **hcp**\  (ppc.hcp, zvm.hcp)
  
  The hardware control point for this node (HMC, IVM, Frame or CEC).  Do not need to set for BPAs and FSPs.
- 
  or
- 
  The hardware control point for this node.
  
 
@@ -386,17 +342,11 @@ node Attributes:
 \ **hwtype**\  (ppc.nodetype, zvm.nodetype, mp.nodetype, mic.nodetype)
  
  The hardware type of the node. Only can be one of fsp, bpa, cec, frame, ivm, hmc and lpar
- 
  or
- 
  The node type. Valid values: cec (Central Electronic Complex), lpar (logical partition), zvm (z/VM host operating system), and vm (virtual machine).
- 
  or
- 
  The hardware type for mp node. Valid values: mm,cmm, blade.
- 
  or
- 
  The hardware type of the mic node. Generally, it is mic.
  
 
@@ -404,9 +354,7 @@ node Attributes:
 \ **id**\  (ppc.id, mp.id)
  
  For LPARs: the LPAR numeric id; for CECs: the cage number; for Frames: the frame number.
- 
  or
- 
  The slot number of this blade in the BladeCenter chassis.
  
 
@@ -568,17 +516,12 @@ node Attributes:
  
  .. code-block:: perl
  
-                         Arch                  OS                           valid netboot options 
-  
-                         x86, x86_64           ALL                          pxe, xnba 
-  
-                         ppc64                 <=rhel6, <=sles11.3          yaboot
-  
-                         ppc64                 >=rhels7, >=sles11.4         grub2,grub2-http,grub2-tftp
-  
-                   ppc64le NonVirtualize       ALL                          petitboot
-  
-                   ppc64le PowerKVM Guest      ALL                          grub2,grub2-http,grub2-tftp
+                         Arch                    OS                           valid netboot options 
+                         x86, x86_64             ALL                          pxe, xnba 
+                         ppc64                   <=rhel6, <=sles11.3          yaboot
+                         ppc64                   >=rhels7, >=sles11.4         grub2,grub2-http,grub2-tftp
+                         ppc64le NonVirtualize   ALL                          petitboot
+                         ppc64le PowerKVM Guest  ALL                          grub2,grub2-http,grub2-tftp
  
  
 
@@ -598,142 +541,85 @@ node Attributes:
 \ **nicaliases**\  (nics.nicaliases)
  
  Comma-separated list of hostname aliases for each NIC.
- 
- 
- .. code-block:: perl
- 
-              Format: eth0!<alias list>,eth1!<alias1 list>|<alias2 list>
-  
-  			For multiple aliases per nic use a space-separated list.
-  
-              For example: eth0!moe larry curly,eth1!tom|jerry
- 
+                 Format: eth0!<alias list>,eth1!<alias1 list>|<alias2 list>
+                     For multiple aliases per nic use a space-separated list. 
+                 For example: eth0!moe larry curly,eth1!tom|jerry
  
 
 
 \ **niccustomscripts**\  (nics.niccustomscripts)
  
  Comma-separated list of custom scripts per NIC.  <nic1>!<script1>,<nic2>!<script2>, e.g. eth0!configeth eth0, ib0!configib ib0. The xCAT object definition commands support to use niccustomscripts.<nicname> as the sub attribute
- 
  .
  
 
 
 \ **nicdevices**\  (nics.nicdevices)
  
- Comma-separated list of NIC device per NIC, multiple ethernet devices can be bonded as bond device, these ethernet devices are separated by |. <nic1>!<dev1>|<dev3>,<nic2>!<dev2>, e.g. bond0!eth0|eth2,br0!bond0. The xCAT object definition commands support to use nicdevices.<nicname> as the sub attributes.
+ Comma-separated list of NIC device per NIC, multiple ethernet devices can be bonded as bond device, these ethernet devices are separated by | . <nic1>!<dev1>|<dev3>,<nic2>!<dev2>, e.g. bond0!eth0|eth2,br0!bond0. The xCAT object definition commands support to use nicdevices.<nicname> as the sub attributes.
  
 
 
 \ **nicextraparams**\  (nics.nicextraparams)
  
  Comma-separated list of extra parameters that will be used for each NIC configuration.
- 
- 
- .. code-block:: perl
- 
-                  If only one ip address is associated with each NIC:
-  
-                      <nic1>!<param1=value1 param2=value2>,<nic2>!<param3=value3>, for example, eth0!MTU=1500,ib0!MTU=65520 CONNECTED_MODE=yes.
-  
-                  If multiple ip addresses are associated with each NIC:
-  
-                      <nic1>!<param1=value1 param2=value2>|<param3=value3>,<nic2>!<param4=value4 param5=value5>|<param6=value6>, for example, eth0!MTU=1500|MTU=1460,ib0!MTU=65520 CONNECTED_MODE=yes.
-  
-              The xCAT object definition commands support to use nicextraparams.<nicname> as the sub attributes.
- 
+                 If only one ip address is associated with each NIC:
+                     <nic1>!<param1=value1 param2=value2>,<nic2>!<param3=value3>, for example, eth0!MTU=1500,ib0!MTU=65520 CONNECTED_MODE=yes.
+                 If multiple ip addresses are associated with each NIC:
+                     <nic1>!<param1=value1 param2=value2>|<param3=value3>,<nic2>!<param4=value4 param5=value5>|<param6=value6>, for example, eth0!MTU=1500|MTU=1460,ib0!MTU=65520 CONNECTED_MODE=yes.
+             The xCAT object definition commands support to use nicextraparams.<nicname> as the sub attributes.
  
 
 
 \ **nichostnameprefixes**\  (nics.nichostnameprefixes)
  
- Comma-separated list of hostname prefixes per NIC.
- 
- 
- .. code-block:: perl
- 
-                          If only one ip address is associated with each NIC:
-  
-                              <nic1>!<ext1>,<nic2>!<ext2>,..., for example, eth0!eth0-,ib0!ib-
-  
-                          If multiple ip addresses are associcated with each NIC:
-  
-                              <nic1>!<ext1>|<ext2>,<nic2>!<ext1>|<ext2>,..., for example,  eth0!eth0-|eth0-ipv6i-,ib0!ib-|ib-ipv6-. 
-  
-                          The xCAT object definition commands support to use nichostnameprefixes.<nicname> as the sub attributes. 
-  
-                          Note:  According to DNS rules a hostname must be a text string up to 24 characters drawn from the alphabet (A-Z), digits (0-9), minus sign (-),and period (.). When you are specifying "nichostnameprefixes" or "nicaliases" make sure the resulting hostnames will conform to this naming convention
- 
+ Comma-separated list of hostname prefixes per NIC. 
+                         If only one ip address is associated with each NIC:
+                             <nic1>!<ext1>,<nic2>!<ext2>,..., for example, eth0!eth0-,ib0!ib-
+                         If multiple ip addresses are associcated with each NIC:
+                             <nic1>!<ext1>|<ext2>,<nic2>!<ext1>|<ext2>,..., for example,  eth0!eth0-|eth0-ipv6i-,ib0!ib-|ib-ipv6-. 
+                         The xCAT object definition commands support to use nichostnameprefixes.<nicname> as the sub attributes. 
+                         Note:  According to DNS rules a hostname must be a text string up to 24 characters drawn from the alphabet (A-Z), digits (0-9), minus sign (-),and period (.). When you are specifying "nichostnameprefixes" or "nicaliases" make sure the resulting hostnames will conform to this naming convention
  
 
 
 \ **nichostnamesuffixes**\  (nics.nichostnamesuffixes)
  
- Comma-separated list of hostname suffixes per NIC.
- 
- 
- .. code-block:: perl
- 
-                          If only one ip address is associated with each NIC:
-  
-                              <nic1>!<ext1>,<nic2>!<ext2>,..., for example, eth0!-eth0,ib0!-ib0
-  
-                          If multiple ip addresses are associcated with each NIC:
-  
-                              <nic1>!<ext1>|<ext2>,<nic2>!<ext1>|<ext2>,..., for example,  eth0!-eth0|-eth0-ipv6,ib0!-ib0|-ib0-ipv6. 
-  
-                          The xCAT object definition commands support to use nichostnamesuffixes.<nicname> as the sub attributes. 
-  
-                          Note:  According to DNS rules a hostname must be a text string up to 24 characters drawn from the alphabet (A-Z), digits (0-9), minus sign (-),and period (.). When you are specifying "nichostnamesuffixes" or "nicaliases" make sure the resulting hostnames will conform to this naming convention
- 
+ Comma-separated list of hostname suffixes per NIC. 
+                         If only one ip address is associated with each NIC:
+                             <nic1>!<ext1>,<nic2>!<ext2>,..., for example, eth0!-eth0,ib0!-ib0
+                         If multiple ip addresses are associcated with each NIC:
+                             <nic1>!<ext1>|<ext2>,<nic2>!<ext1>|<ext2>,..., for example,  eth0!-eth0|-eth0-ipv6,ib0!-ib0|-ib0-ipv6. 
+                         The xCAT object definition commands support to use nichostnamesuffixes.<nicname> as the sub attributes. 
+                         Note:  According to DNS rules a hostname must be a text string up to 24 characters drawn from the alphabet (A-Z), digits (0-9), minus sign (-),and period (.). When you are specifying "nichostnamesuffixes" or "nicaliases" make sure the resulting hostnames will conform to this naming convention
  
 
 
 \ **nicips**\  (nics.nicips)
  
- Comma-separated list of IP addresses per NIC. To specify one ip address per NIC:
- 
- 
- .. code-block:: perl
- 
-                      <nic1>!<ip1>,<nic2>!<ip2>,..., for example, eth0!10.0.0.100,ib0!11.0.0.100
-  
-                  To specify multiple ip addresses per NIC:
-  
-                      <nic1>!<ip1>|<ip2>,<nic2>!<ip1>|<ip2>,..., for example, eth0!10.0.0.100|fd55::214:5eff:fe15:849b,ib0!11.0.0.100|2001::214:5eff:fe15:849a. The xCAT object definition commands support to use nicips.<nicname> as the sub attributes.
-  
-                  Note: The primary IP address must also be stored in the hosts.ip attribute. The nichostnamesuffixes should specify one hostname suffix for each ip address.
- 
+ Comma-separated list of IP addresses per NIC. 
+                 To specify one ip address per NIC:
+                     <nic1>!<ip1>,<nic2>!<ip2>,..., for example, eth0!10.0.0.100,ib0!11.0.0.100
+                 To specify multiple ip addresses per NIC:
+                     <nic1>!<ip1>|<ip2>,<nic2>!<ip1>|<ip2>,..., for example, eth0!10.0.0.100|fd55::214:5eff:fe15:849b,ib0!11.0.0.100|2001::214:5eff:fe15:849a. The xCAT object definition commands support to use nicips.<nicname> as the sub attributes.
+                 Note: The primary IP address must also be stored in the hosts.ip attribute. The nichostnamesuffixes should specify one hostname suffix for each ip address.
  
 
 
 \ **nicnetworks**\  (nics.nicnetworks)
  
  Comma-separated list of networks connected to each NIC.
- 
- 
- .. code-block:: perl
- 
-                  If only one ip address is associated with each NIC:
-  
-                      <nic1>!<network1>,<nic2>!<network2>, for example, eth0!10_0_0_0-255_255_0_0, ib0!11_0_0_0-255_255_0_0
-  
-                  If multiple ip addresses are associated with each NIC:
-  
-                      <nic1>!<network1>|<network2>,<nic2>!<network1>|<network2>, for example, eth0!10_0_0_0-255_255_0_0|fd55:faaf:e1ab:336::/64,ib0!11_0_0_0-255_255_0_0|2001:db8:1:0::/64. The xCAT object definition commands support to use nicnetworks.<nicname> as the sub attributes.
- 
+                 If only one ip address is associated with each NIC:
+                     <nic1>!<network1>,<nic2>!<network2>, for example, eth0!10_0_0_0-255_255_0_0, ib0!11_0_0_0-255_255_0_0
+                 If multiple ip addresses are associated with each NIC:
+                     <nic1>!<network1>|<network2>,<nic2>!<network1>|<network2>, for example, eth0!10_0_0_0-255_255_0_0|fd55:faaf:e1ab:336::/64,ib0!11_0_0_0-255_255_0_0|2001:db8:1:0::/64. The xCAT object definition commands support to use nicnetworks.<nicname> as the sub attributes.
  
 
 
 \ **nicsadapter**\  (nics.nicsadapter)
  
  Comma-separated list of extra parameters that will be used for each NIC configuration.
- 
- 
- .. code-block:: perl
- 
-                      <nic1>!<param1=value1 param2=value2>|<param3=value3>,<nic2>!<param4=value4 param5=value5>|<param6=value6>, for example, eth0!MTU=1500|MTU=1460,ib0!MTU=65520 CONNECTED_MODE=yes.
- 
+                     <nic1>!<param1=value1 param2=value2>|<param3=value3>,<nic2>!<param4=value4 param5=value5>|<param6=value6>, for example, eth0!MTU=1500|MTU=1460,ib0!MTU=65520 CONNECTED_MODE=yes.
  
 
 
@@ -781,9 +667,7 @@ node Attributes:
  .. code-block:: perl
  
                   localdisk (Install to first non-FC attached disk)
-  
                   usbdisk (Install to first USB mass storage device seen)
-  
                   wwn=0x50000393c813840c (Install to storage device with given WWN)
  
  
@@ -840,17 +724,11 @@ node Attributes:
 \ **password**\  (ppchcp.password, mpa.password, websrv.password, switches.sshpassword)
  
  Password of the HMC or IVM.  If not filled in, xCAT will look in the passwd table for key=hmc or key=ivm.  If not in the passwd table, the default used is abc123 for HMCs and padmin for IVMs.
- 
  or
- 
  Password to use to access the management module.  If not specified, the key=blade row in the passwd table is used as the default.
- 
  or
- 
  Password to use to access the web service.
- 
  or
- 
  The remote login password. It can be for ssh or telnet. If it is for telnet, please set protocol to "telnet". If the sshusername is blank, the username, password and protocol will be retrieved from the passwd table with "switch" as the key.
  
 
@@ -881,73 +759,34 @@ node Attributes:
 
 \ **prescripts-begin**\  (prescripts.begin)
  
- The scripts to be run at the beginning of the nodeset(Linux),
- 
- 
- .. code-block:: perl
- 
-   nimnodeset(AIX) or mkdsklsnode(AIX) command.
-  
-   The format is:
-  
-     [action1:]s1,s2...[|action2:s3,s4,s5...]
-  
-   where:
-  
-    - action1 and action2 for Linux are the nodeset actions specified in the command. 
-  
-      For AIX, action1 and action1 can be 'diskless' for mkdsklsnode command'
-  
-      and 'standalone for nimnodeset command. 
-  
-    - s1 and s2 are the scripts to run for action1 in order.
-  
-    - s3, s4, and s5 are the scripts to run for actions2.
-  
-   If actions are omitted, the scripts apply to all actions.
-  
-   Examples:
-  
-     myscript1,myscript2  (all actions)
-  
-     diskless:myscript1,myscript2   (AIX)
-  
-     install:myscript1,myscript2|netboot:myscript3   (Linux)
-  
-  
-  
-   All the scripts should be copied to /install/prescripts directory.
-  
-   The following two environment variables will be passed to each script: 
-  
-     NODES a coma separated list of node names that need to run the script for
-  
-     ACTION current nodeset action.
-  
-  
-  
-   If '#xCAT setting:MAX_INSTANCE=number' is specified in the script, the script
-  
-   will get invoked for each node in parallel, but no more than number of instances
-  
-   will be invoked at at a time. If it is not specified, the script will be invoked
-  
-   once for all the nodes.
- 
+ The scripts to be run at the beginning of the nodeset(Linux), nimnodeset(AIX) or mkdsklsnode(AIX) command.
+  The format is:
+    [action1:]s1,s2...[| action2:s3,s4,s5...]
+  where:
+   - action1 and action2 for Linux are the nodeset actions specified in the command. 
+     For AIX, action1 and action1 can be 'diskless' for mkdsklsnode command'
+     and 'standalone for nimnodeset command. 
+   - s1 and s2 are the scripts to run for action1 in order.
+   - s3, s4, and s5 are the scripts to run for actions2.
+  If actions are omitted, the scripts apply to all actions.
+  Examples:
+    myscript1,myscript2  (all actions)
+    diskless:myscript1,myscript2   (AIX)
+    install:myscript1,myscript2|netboot:myscript3   (Linux)
+  All the scripts should be copied to /install/prescripts directory.
+  The following two environment variables will be passed to each script: 
+    NODES a coma separated list of node names that need to run the script for
+    ACTION current nodeset action.
+  If '#xCAT setting:MAX_INSTANCE=number' is specified in the script, the script
+  will get invoked for each node in parallel, but no more than number of instances
+  will be invoked at at a time. If it is not specified, the script will be invoked
+  once for all the nodes.
  
 
 
 \ **prescripts-end**\  (prescripts.end)
  
- The scripts to be run at the end of the nodeset(Linux),
- 
- 
- .. code-block:: perl
- 
-   nimnodeset(AIX),or mkdsklsnode(AIX) command. 
-  
-   The format is the same as the 'begin' column.
- 
+ The scripts to be run at the end of the nodeset(Linux), nimnodeset(AIX),or mkdsklsnode(AIX) command. The format is the same as the 'begin' column.
  
 
 
@@ -1133,9 +972,7 @@ node Attributes:
  .. code-block:: perl
  
                    <slot rows>  = number of rows of slots in chassis
-  
                    <slot columns> = number of columns of slots in chassis
-  
                    <slot orientation> = set to 0 if slots are vertical, and set to 1 if slots of horizontal
  
  
@@ -1185,15 +1022,9 @@ node Attributes:
 
 \ **storagcontroller**\  (storage.controller)
  
- The management address to attach/detach new volumes.
- 
- 
- .. code-block:: perl
- 
-                         In the scenario involving multiple controllers, this data must be
-  
-                         passed as argument rather than by table value
- 
+ The management address to attach/detach new volumes. 
+ In the scenario involving multiple controllers, this data must be
+ passed as argument rather than by table value
  
 
 
@@ -1320,17 +1151,11 @@ node Attributes:
 \ **username**\  (ppchcp.username, mpa.username, websrv.username, switches.sshusername)
  
  Userid of the HMC or IVM.  If not filled in, xCAT will look in the passwd table for key=hmc or key=ivm.  If not in the passwd table, the default used is hscroot for HMCs and padmin for IVMs.
- 
  or
- 
  Userid to use to access the management module.
- 
  or
- 
  Userid to use to access the web service.
- 
  or
- 
  The remote login user name. It can be for ssh or telnet. If it is for telnet, please set protocol to "telnet". If the sshusername is blank, the username, password and protocol will be retrieved from the passwd table with "switch" as the key.
  
 
@@ -1445,27 +1270,16 @@ node Attributes:
 
 \ **vmvirtflags**\  (vm.virtflags)
  
- General flags used by the virtualization method.  For example, in Xen it could, among other things, specify paravirtualized setup, or direct kernel boot.  For a hypervisor/dom0 entry, it is the virtualization method (i.e. "xen").  For KVM, the following flag=value pairs are recognized:
- 
- 
- .. code-block:: perl
- 
-              imageformat=[raw|fullraw|qcow2]
-  
-                  raw is a generic sparse file that allocates storage on demand
-  
-                  fullraw is a generic, non-sparse file that preallocates all space
-  
-                  qcow2 is a sparse, copy-on-write capable format implemented at the virtualization layer rather than the filesystem level
-  
-              clonemethod=[qemu-img|reflink]
-  
-                  qemu-img allows use of qcow2 to generate virtualization layer copy-on-write
-  
-                  reflink uses a generic filesystem facility to clone the files on your behalf, but requires filesystem support such as btrfs 
-  
-              placement_affinity=[migratable|user_migratable|pinned]
- 
+ General flags used by the virtualization method.  
+           For example, in Xen it could, among other things, specify paravirtualized setup, or direct kernel boot.  For a hypervisor/dom0 entry, it is the virtualization method (i.e. "xen").  For KVM, the following flag=value pairs are recognized:
+             imageformat=[raw|fullraw|qcow2]
+                 raw is a generic sparse file that allocates storage on demand
+                 fullraw is a generic, non-sparse file that preallocates all space
+                 qcow2 is a sparse, copy-on-write capable format implemented at the virtualization layer rather than the filesystem level
+             clonemethod=[qemu-img|reflink]
+                 qemu-img allows use of qcow2 to generate virtualization layer copy-on-write
+                 reflink uses a generic filesystem facility to clone the files on your behalf, but requires filesystem support such as btrfs 
+             placement_affinity=[migratable|user_migratable|pinned]
  
 
 

--- a/docs/source/guides/admin-guides/references/man7/node.7.rst
+++ b/docs/source/guides/admin-guides/references/man7/node.7.rst
@@ -292,7 +292,9 @@ node Attributes:
 \ **hcp**\  (ppc.hcp, zvm.hcp)
  
  The hardware control point for this node (HMC, IVM, Frame or CEC).  Do not need to set for BPAs and FSPs.
+ 
  or
+ 
  The hardware control point for this node.
  
 
@@ -342,11 +344,17 @@ node Attributes:
 \ **hwtype**\  (ppc.nodetype, zvm.nodetype, mp.nodetype, mic.nodetype)
  
  The hardware type of the node. Only can be one of fsp, bpa, cec, frame, ivm, hmc and lpar
+ 
  or
+ 
  The node type. Valid values: cec (Central Electronic Complex), lpar (logical partition), zvm (z/VM host operating system), and vm (virtual machine).
+ 
  or
+ 
  The hardware type for mp node. Valid values: mm,cmm, blade.
+ 
  or
+ 
  The hardware type of the mic node. Generally, it is mic.
  
 
@@ -354,7 +362,9 @@ node Attributes:
 \ **id**\  (ppc.id, mp.id)
  
  For LPARs: the LPAR numeric id; for CECs: the cage number; for Frames: the frame number.
+ 
  or
+ 
  The slot number of this blade in the BladeCenter chassis.
  
 
@@ -724,11 +734,17 @@ node Attributes:
 \ **password**\  (ppchcp.password, mpa.password, websrv.password, switches.sshpassword)
  
  Password of the HMC or IVM.  If not filled in, xCAT will look in the passwd table for key=hmc or key=ivm.  If not in the passwd table, the default used is abc123 for HMCs and padmin for IVMs.
+ 
  or
+ 
  Password to use to access the management module.  If not specified, the key=blade row in the passwd table is used as the default.
+ 
  or
+ 
  Password to use to access the web service.
+ 
  or
+ 
  The remote login password. It can be for ssh or telnet. If it is for telnet, please set protocol to "telnet". If the sshusername is blank, the username, password and protocol will be retrieved from the passwd table with "switch" as the key.
  
 
@@ -1151,11 +1167,17 @@ node Attributes:
 \ **username**\  (ppchcp.username, mpa.username, websrv.username, switches.sshusername)
  
  Userid of the HMC or IVM.  If not filled in, xCAT will look in the passwd table for key=hmc or key=ivm.  If not in the passwd table, the default used is hscroot for HMCs and padmin for IVMs.
+ 
  or
+ 
  Userid to use to access the management module.
+ 
  or
+ 
  Userid to use to access the web service.
+ 
  or
+ 
  The remote login user name. It can be for ssh or telnet. If it is for telnet, please set protocol to "telnet". If the sshusername is blank, the username, password and protocol will be retrieved from the passwd table with "switch" as the key.
  
 

--- a/docs/source/guides/admin-guides/references/man7/osimage.7.rst
+++ b/docs/source/guides/admin-guides/references/man7/osimage.7.rst
@@ -90,9 +90,7 @@ osimage Attributes:
 \ **dump**\  (linuximage.dump, nimimage.dump)
  
  The NFS directory to hold the Linux kernel dump file (vmcore) when the node with this image crashes, its format is "nfs://<nfs_server_ip>/<kdump_path>". If you want to use the node's "xcatmaster" (its SN or MN), <nfs_server_ip> can be left blank. For example, "nfs:///<kdump_path>" means the NFS directory to hold the kernel dump file is on the node's SN, or MN if there's no SN.
- 
  or
- 
  The name of the NIM dump resource.
  
 
@@ -279,10 +277,8 @@ osimage Attributes:
 
 \ **partitionfile**\  (linuximage.partitionfile, winimage.partitionfile)
  
- The path of the configuration file which will be used to partition the disk for the node. For stateful osimages,two types of files are supported: "<partition file absolute path>" which contains a partitioning definition that will be inserted directly into the generated autoinst configuration file and must be formatted for the corresponding OS installer (e.g. kickstart for RedHat, autoyast for SLES, pressed for Ubuntu).  "s:<partitioning script absolute path>" which specifies a shell script that will be run from the OS installer configuration file %pre section;  the script must write the correct partitioning definition into the file /tmp/partitionfile on the node which will be included into the configuration file during the install process. For statelite osimages, partitionfile should specify "<partition file absolute path>";  see the xCAT Statelite documentation for the xCAT defined format of this configuration file.For Ubuntu, besides  "<partition file absolute path>" or "s:<partitioning script absolute path>", the disk name(s) to partition must be specified in traditional, non-devfs format, delimited with space,  it can be specified in 2 forms: "d:<the absolute path of the disk name file>" which contains the disk name(s) to partition and "s:d:<the absolute path of the disk script>" which runs in pressed/early_command and writes the disk names into the "/tmp/install_disk" . To support other specific partition methods such as RAID or LVM in Ubuntu, some additional preseed values should be specified, these values can be specified with "c:<the absolute path of the additional pressed config file>" which contains the additional pressed entries in "d-i ..." form and "s:c:<the absolute path of the additional pressed config script>" which runs in pressed/early_command and set the preseed values with "debconf-set". The multiple values should be delimited with comma ","
- 
+ The path of the configuration file which will be used to partition the disk for the node. For stateful osimages,two types of files are supported: "<partition file absolute path>" which contains a partitioning definition that will be inserted directly into the generated autoinst configuration file and must be formatted for the corresponding OS installer (e.g. kickstart for RedHat, autoyast for SLES, pressed for Ubuntu).  "s:<partitioning script absolute path>" which specifies a shell script that will be run from the OS installer configuration file %pre section;  the script must write the correct partitioning definition into the file /tmp/partitionfile on the node which will be included into the configuration file during the install process. For statelite osimages, partitionfile should specify "<partition file absolute path>";  see the xCAT Statelite documentation for the xCAT defined format of this configuration file.For Ubuntu, besides  "<partition file absolute path>" or "s:<partitioning script absolute path>", the disk name(s) to partition must be specified in traditional, non-devfs format, delimited with space,  it can be specified in 2 forms: "d:<the absolute path of the disk name file>" which contains the disk name(s) to partition and "s:d:<the absolute path of the disk script>" which runs in pressed/early_command and writes the disk names into the "/tmp/install_disk" . To support other specific partition methods such as RAID or LVM in Ubuntu, some additional preseed values should be specified, these values can be specified with "c:<the absolute path of the additional pressed config file>" which contains the additional pressed entries in "d-i ..." form and "s:c:<the absolute path of the additional pressed config script>" which runs in pressed/early_command and set the preseed values with "debconf-set". The multiple values should be delimited with comma "," 
  or
- 
  The path of partition configuration file. Since the partition configuration for bios boot mode and uefi boot mode are different, this configuration file can include both configurations if you need to support both bios and uefi mode. Either way, you must specify the boot mode in the configuration. Example of partition configuration file: [BIOS]xxxxxxx[UEFI]yyyyyyy. To simplify the setting, you also can set installto in partitionfile with section like [INSTALLTO]0:1
  
 
@@ -398,9 +394,7 @@ osimage Attributes:
 \ **template**\  (linuximage.template, winimage.template)
  
  The fully qualified name of the template file that will be used to create the OS installer configuration file for stateful installations (e.g.  kickstart for RedHat, autoyast for SLES).
- 
  or
- 
  The fully qualified name of the template file that is used to create the windows unattend.xml file for diskful installation.
  
 
@@ -414,9 +408,7 @@ osimage Attributes:
 \ **usercomment**\  (linuximage.comments, nimimage.comments)
  
  Any user-written notes.
- 
  or
- 
  Any user-provided notes.
  
 

--- a/docs/source/guides/admin-guides/references/man7/osimage.7.rst
+++ b/docs/source/guides/admin-guides/references/man7/osimage.7.rst
@@ -90,7 +90,9 @@ osimage Attributes:
 \ **dump**\  (linuximage.dump, nimimage.dump)
  
  The NFS directory to hold the Linux kernel dump file (vmcore) when the node with this image crashes, its format is "nfs://<nfs_server_ip>/<kdump_path>". If you want to use the node's "xcatmaster" (its SN or MN), <nfs_server_ip> can be left blank. For example, "nfs:///<kdump_path>" means the NFS directory to hold the kernel dump file is on the node's SN, or MN if there's no SN.
+ 
  or
+ 
  The name of the NIM dump resource.
  
 
@@ -277,8 +279,10 @@ osimage Attributes:
 
 \ **partitionfile**\  (linuximage.partitionfile, winimage.partitionfile)
  
- The path of the configuration file which will be used to partition the disk for the node. For stateful osimages,two types of files are supported: "<partition file absolute path>" which contains a partitioning definition that will be inserted directly into the generated autoinst configuration file and must be formatted for the corresponding OS installer (e.g. kickstart for RedHat, autoyast for SLES, pressed for Ubuntu).  "s:<partitioning script absolute path>" which specifies a shell script that will be run from the OS installer configuration file %pre section;  the script must write the correct partitioning definition into the file /tmp/partitionfile on the node which will be included into the configuration file during the install process. For statelite osimages, partitionfile should specify "<partition file absolute path>";  see the xCAT Statelite documentation for the xCAT defined format of this configuration file.For Ubuntu, besides  "<partition file absolute path>" or "s:<partitioning script absolute path>", the disk name(s) to partition must be specified in traditional, non-devfs format, delimited with space,  it can be specified in 2 forms: "d:<the absolute path of the disk name file>" which contains the disk name(s) to partition and "s:d:<the absolute path of the disk script>" which runs in pressed/early_command and writes the disk names into the "/tmp/install_disk" . To support other specific partition methods such as RAID or LVM in Ubuntu, some additional preseed values should be specified, these values can be specified with "c:<the absolute path of the additional pressed config file>" which contains the additional pressed entries in "d-i ..." form and "s:c:<the absolute path of the additional pressed config script>" which runs in pressed/early_command and set the preseed values with "debconf-set". The multiple values should be delimited with comma "," 
+ The path of the configuration file which will be used to partition the disk for the node. For stateful osimages,two types of files are supported: "<partition file absolute path>" which contains a partitioning definition that will be inserted directly into the generated autoinst configuration file and must be formatted for the corresponding OS installer (e.g. kickstart for RedHat, autoyast for SLES, pressed for Ubuntu).  "s:<partitioning script absolute path>" which specifies a shell script that will be run from the OS installer configuration file %pre section;  the script must write the correct partitioning definition into the file /tmp/partitionfile on the node which will be included into the configuration file during the install process. For statelite osimages, partitionfile should specify "<partition file absolute path>";  see the xCAT Statelite documentation for the xCAT defined format of this configuration file.For Ubuntu, besides  "<partition file absolute path>" or "s:<partitioning script absolute path>", the disk name(s) to partition must be specified in traditional, non-devfs format, delimited with space,  it can be specified in 2 forms: "d:<the absolute path of the disk name file>" which contains the disk name(s) to partition and "s:d:<the absolute path of the disk script>" which runs in pressed/early_command and writes the disk names into the "/tmp/install_disk" . To support other specific partition methods such as RAID or LVM in Ubuntu, some additional preseed values should be specified, these values can be specified with "c:<the absolute path of the additional pressed config file>" which contains the additional pressed entries in "d-i ..." form and "s:c:<the absolute path of the additional pressed config script>" which runs in pressed/early_command and set the preseed values with "debconf-set". The multiple values should be delimited with comma ","
+ 
  or
+ 
  The path of partition configuration file. Since the partition configuration for bios boot mode and uefi boot mode are different, this configuration file can include both configurations if you need to support both bios and uefi mode. Either way, you must specify the boot mode in the configuration. Example of partition configuration file: [BIOS]xxxxxxx[UEFI]yyyyyyy. To simplify the setting, you also can set installto in partitionfile with section like [INSTALLTO]0:1
  
 
@@ -394,7 +398,9 @@ osimage Attributes:
 \ **template**\  (linuximage.template, winimage.template)
  
  The fully qualified name of the template file that will be used to create the OS installer configuration file for stateful installations (e.g.  kickstart for RedHat, autoyast for SLES).
+ 
  or
+ 
  The fully qualified name of the template file that is used to create the windows unattend.xml file for diskful installation.
  
 
@@ -408,7 +414,9 @@ osimage Attributes:
 \ **usercomment**\  (linuximage.comments, nimimage.comments)
  
  Any user-written notes.
+ 
  or
+ 
  Any user-provided notes.
  
 

--- a/perl-xCAT/db2man
+++ b/perl-xCAT/db2man
@@ -416,7 +416,7 @@ parentheses, what tables each attribute is stored in.
 EOS2
 
 foreach my $a (sort keys %attrlist) {
-	my $d = join("\nor\n", @{$attrlist{$a}->{'descriptions'}});
+	my $d = join("\n\nor\n\n", @{$attrlist{$a}->{'descriptions'}});
 	#$d =~ s/\n/\n\n/sg;      # if there are newlines, double them so pod sees a blank line, otherwise pod will ignore them
 	my $t = '(' . join(', ',@{$attrlist{$a}->{'tables'}}) . ')';
 	#print FILE "\nB<$a> - $d\n";

--- a/perl-xCAT/db2man
+++ b/perl-xCAT/db2man
@@ -417,7 +417,7 @@ EOS2
 
 foreach my $a (sort keys %attrlist) {
 	my $d = join("\nor\n", @{$attrlist{$a}->{'descriptions'}});
-	$d =~ s/\n/\n\n/sg;      # if there are newlines, double them so pod sees a blank line, otherwise pod will ignore them
+	#$d =~ s/\n/\n\n/sg;      # if there are newlines, double them so pod sees a blank line, otherwise pod will ignore them
 	my $t = '(' . join(', ',@{$attrlist{$a}->{'tables'}}) . ')';
 	#print FILE "\nB<$a> - $d\n";
 	print FILE "\n=item B<$a> $t\n\n$d\n";

--- a/perl-xCAT/xCAT/Schema.pm
+++ b/perl-xCAT/xCAT/Schema.pm
@@ -213,7 +213,8 @@ use xCAT::ExtTab;
             'nicmodel' => 'Model of NICs that will be provided to VMs (i.e. e1000, rtl8139, virtio, etc)',
             'bootorder' => 'Boot sequence (i.e. net,hd)',
             'clockoffset' => 'Whether to have guest RTC synced to "localtime" or "utc"  If not populated, xCAT will guess based on the nodetype.os contents.',
-            'virtflags' => 'General flags used by the virtualization method.  For example, in Xen it could, among other things, specify paravirtualized setup, or direct kernel boot.  For a hypervisor/dom0 entry, it is the virtualization method (i.e. "xen").  For KVM, the following flag=value pairs are recognized:
+            'virtflags' => 'General flags used by the virtualization method.  
+          For example, in Xen it could, among other things, specify paravirtualized setup, or direct kernel boot.  For a hypervisor/dom0 entry, it is the virtualization method (i.e. "xen").  For KVM, the following flag=value pairs are recognized:
             imageformat=[raw|fullraw|qcow2]
                 raw is a generic sparse file that allocates storage on demand
                 fullraw is a generic, non-sparse file that preallocates all space
@@ -275,10 +276,11 @@ use xCAT::ExtTab;
         table_descr  => 'Node storage resources',
         descriptions => {
             node       => 'The node name',
-            controller => 'The management address to attach/detach new volumes.
-                       In the scenario involving multiple controllers, this data must be
-                       passed as argument rather than by table value',
+            controller => 'The management address to attach/detach new volumes. 
+In the scenario involving multiple controllers, this data must be
+passed as argument rather than by table value',
             osvolume => "Specification of what storage to place the node OS image onto.  Examples include:
+
                 localdisk (Install to first non-FC attached disk)
                 usbdisk (Install to first USB mass storage device seen)
                 wwn=0x50000393c813840c (Install to storage device with given WWN)",
@@ -396,10 +398,7 @@ use xCAT::ExtTab;
         descriptions => {
             node => 'The node name or group name.',
             bmc  => 'The hostname of the BMC adapater.',
-            bmcport => ' In systems with selectable shared/dedicated ethernet ports,
-           this parameter can be used to specify the preferred port.  0
-           means use the shared port, 1 means dedicated, blank is to not
-           assign.
+            bmcport => 'In systems with selectable shared/dedicated ethernet ports, this parameter can be used to specify the preferred port. 0 means use the shared port, 1 means dedicated, blank is to not assign.
 
            The following special cases exist for IBM System x servers:
 
@@ -527,6 +526,7 @@ use xCAT::ExtTab;
             password => 'Password to use to access the management module.  If not specified, the key=blade row in the passwd table is used as the default.',
             displayname => 'Alternative name for BladeCenter chassis. Only used by PCM.',
             slots => 'The number of available slots in the chassis. For PCM, this attribute is used to store the number of slots in the following format:  <slot rows>,<slot columns>,<slot orientation>  Where:
+
                  <slot rows>  = number of rows of slots in chassis
                  <slot columns> = number of columns of slots in chassis
                  <slot orientation> = set to 0 if slots are vertical, and set to 1 if slots of horizontal
@@ -647,12 +647,13 @@ use xCAT::ExtTab;
             node => 'The node name or group name.',
             servicenode => 'A comma separated list of node names (as known by the management node) that provides most services for this node. The first service node on the list that is accessible will be used.  The 2nd node on the list is generally considered to be the backup service node for this node when running commands like snmove.',
             netboot => 'The type of network booting to use for this node.  Valid values:
-                       Arch                  OS                           valid netboot options 
-                       x86, x86_64           ALL                          pxe, xnba 
-                       ppc64                 <=rhel6, <=sles11.3          yaboot
-                       ppc64                 >=rhels7, >=sles11.4         grub2,grub2-http,grub2-tftp
-                 ppc64le NonVirtualize       ALL                          petitboot
-                 ppc64le PowerKVM Guest      ALL                          grub2,grub2-http,grub2-tftp
+
+                       Arch                    OS                           valid netboot options 
+                       x86, x86_64             ALL                          pxe, xnba 
+                       ppc64                   <=rhel6, <=sles11.3          yaboot
+                       ppc64                   >=rhels7, >=sles11.4         grub2,grub2-http,grub2-tftp
+                       ppc64le NonVirtualize   ALL                          petitboot
+                       ppc64le PowerKVM Guest  ALL                          grub2,grub2-http,grub2-tftp
                        
 ',
             tftpserver => 'The TFTP server for this node (as known by this node). If not set, it defaults to networks.tftpserver.',
@@ -1341,7 +1342,7 @@ use xCAT::ExtTab;
             id => 'The location or the resource name where the event occurred.', #In RMC it's the resource name and attribute name
             severity => 'The severity of the event. Valid values are: informational, warning, critical.',
             message => 'The full description of the event.',
-            rawdata => ' The data that associated with the event. ', # in RMC, it's the attribute value, it takes the format of attname=attvalue[,atrrname=attvalue....]
+            rawdata => 'The data that associated with the event. ', # in RMC, it's the attribute value, it takes the format of attname=attvalue[,atrrname=attvalue....]
             comments => 'Any user-provided notes.',
             disable => "Do not use.  tabprune will not work if set to yes or 1",
         },
@@ -1355,7 +1356,7 @@ use xCAT::ExtTab;
         },
         compress     => 'YES',
         tablespace   => 'XCATTBS32K',
-        table_desc   => ' Audit Data log.',
+        table_desc   => 'Audit Data log.',
         descriptions => {
             recid      => 'The record id.',
             audittime  => 'The timestamp for the audit entry.',
@@ -1382,10 +1383,10 @@ use xCAT::ExtTab;
 # Do not put description text past column 88, so it displays well in a 100 char wide window.
 # ----------------------------------------------------------------------------------|
             begin =>
-"The scripts to be run at the beginning of the nodeset(Linux),\n" .
+"The scripts to be run at the beginning of the nodeset(Linux)," .
 " nimnodeset(AIX) or mkdsklsnode(AIX) command.\n" .
 " The format is:\n" .
-"   [action1:]s1,s2...[|action2:s3,s4,s5...]\n" .
+"   [action1:]s1,s2...[| action2:s3,s4,s5...]\n" .
 " where:\n" .
 "  - action1 and action2 for Linux are the nodeset actions specified in the command. \n" .
 "    For AIX, action1 and action1 can be 'diskless' for mkdsklsnode command'\n" .
@@ -1396,17 +1397,17 @@ use xCAT::ExtTab;
 " Examples:\n" .
 "   myscript1,myscript2  (all actions)\n" .
 "   diskless:myscript1,myscript2   (AIX)\n" .
-"   install:myscript1,myscript2|netboot:myscript3   (Linux)\n\n" .
+"   install:myscript1,myscript2|netboot:myscript3   (Linux)\n" .
 " All the scripts should be copied to /install/prescripts directory.\n" .
 " The following two environment variables will be passed to each script: \n" .
 "   NODES a coma separated list of node names that need to run the script for\n" .
-"   ACTION current nodeset action.\n\n" .
+"   ACTION current nodeset action.\n" .
 " If '#xCAT setting:MAX_INSTANCE=number' is specified in the script, the script\n" .
 " will get invoked for each node in parallel, but no more than number of instances\n" .
 " will be invoked at at a time. If it is not specified, the script will be invoked\n" .
 " once for all the nodes.\n",
-            end => "The scripts to be run at the end of the nodeset(Linux),\n" .
-                " nimnodeset(AIX),or mkdsklsnode(AIX) command. \n" .
+            end => "The scripts to be run at the end of the nodeset(Linux)," .
+                " nimnodeset(AIX),or mkdsklsnode(AIX) command." .
                 " The format is the same as the 'begin' column.",
             comments => 'Any user-written notes.',
             disable  => "Set to 'yes' or '1' to comment out this row.",
@@ -1463,7 +1464,8 @@ use xCAT::ExtTab;
         table_desc   => 'Stores NIC details.',
         descriptions => {
             node => 'The node or group name.',
-            nicips => 'Comma-separated list of IP addresses per NIC. To specify one ip address per NIC:
+            nicips => 'Comma-separated list of IP addresses per NIC. 
+                To specify one ip address per NIC:
                     <nic1>!<ip1>,<nic2>!<ip2>,..., for example, eth0!10.0.0.100,ib0!11.0.0.100
                 To specify multiple ip addresses per NIC:
                     <nic1>!<ip1>|<ip2>,<nic2>!<ip1>|<ip2>,..., for example, eth0!10.0.0.100|fd55::214:5eff:fe15:849b,ib0!11.0.0.100|2001::214:5eff:fe15:849a. The xCAT object definition commands support to use nicips.<nicname> as the sub attributes.
@@ -1491,16 +1493,16 @@ use xCAT::ExtTab;
                 If multiple ip addresses are associated with each NIC:
                     <nic1>!<network1>|<network2>,<nic2>!<network1>|<network2>, for example, eth0!10_0_0_0-255_255_0_0|fd55:faaf:e1ab:336::/64,ib0!11_0_0_0-255_255_0_0|2001:db8:1:0::/64. The xCAT object definition commands support to use nicnetworks.<nicname> as the sub attributes.',
             nicaliases => 'Comma-separated list of hostname aliases for each NIC.
-            Format: eth0!<alias list>,eth1!<alias1 list>|<alias2 list>
-			For multiple aliases per nic use a space-separated list.
-            For example: eth0!moe larry curly,eth1!tom|jerry',
+                Format: eth0!<alias list>,eth1!<alias1 list>|<alias2 list>
+                    For multiple aliases per nic use a space-separated list. 
+                For example: eth0!moe larry curly,eth1!tom|jerry',
             nicextraparams => 'Comma-separated list of extra parameters that will be used for each NIC configuration.
                 If only one ip address is associated with each NIC:
                     <nic1>!<param1=value1 param2=value2>,<nic2>!<param3=value3>, for example, eth0!MTU=1500,ib0!MTU=65520 CONNECTED_MODE=yes.
                 If multiple ip addresses are associated with each NIC:
                     <nic1>!<param1=value1 param2=value2>|<param3=value3>,<nic2>!<param4=value4 param5=value5>|<param6=value6>, for example, eth0!MTU=1500|MTU=1460,ib0!MTU=65520 CONNECTED_MODE=yes.
             The xCAT object definition commands support to use nicextraparams.<nicname> as the sub attributes.',
-            nicdevices => 'Comma-separated list of NIC device per NIC, multiple ethernet devices can be bonded as bond device, these ethernet devices are separated by |. <nic1>!<dev1>|<dev3>,<nic2>!<dev2>, e.g. bond0!eth0|eth2,br0!bond0. The xCAT object definition commands support to use nicdevices.<nicname> as the sub attributes.',
+            nicdevices => 'Comma-separated list of NIC device per NIC, multiple ethernet devices can be bonded as bond device, these ethernet devices are separated by | . <nic1>!<dev1>|<dev3>,<nic2>!<dev2>, e.g. bond0!eth0|eth2,br0!bond0. The xCAT object definition commands support to use nicdevices.<nicname> as the sub attributes.',
             nicsadapter => 'Comma-separated list of extra parameters that will be used for each NIC configuration.
                     <nic1>!<param1=value1 param2=value2>|<param3=value3>,<nic2>!<param4=value4 param5=value5>|<param6=value6>, for example, eth0!MTU=1500|MTU=1460,ib0!MTU=65520 CONNECTED_MODE=yes.',
             comments => 'Any user-written notes.',


### PR DESCRIPTION
This pull request eliminates some warning when building xCAT documentation and improves display formatting of the man5 and man7 sections for ReadTheDocs display.
Not all the warnings and display formatting can be eliminated because it affects the display of man pages with `man` command. It was decided the correct display of man page is more important than the display in RTD. 
Only the descriptions of attributes in Schema.pm file were changed in this pull request.