### PR TITLE
fix bug 1224 xcattest returns Use of uninitialized value if the case fails and there is not stop label defined

### DIFF
--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -868,7 +868,7 @@ sub runcase
         if($failed){
             $failnum = $failnum + 1;
             log_error(@record);
-            if($$case{stop} =~ /^yes$/){
+            if(defined ($$case{stop}) && ($$case{stop} =~ /^yes$/)){
                 $stop_to_keep_env=1;
                 last;
             }


### PR DESCRIPTION
Fix issue #1224 , xcattest returns Use of uninitialized value if the case fails and there is not stop label defined