### PR TITLE
Discard grep output and display error message

### DIFF
--- a/xCAT/postscripts/remoteshell
+++ b/xCAT/postscripts/remoteshell
@@ -108,7 +108,7 @@ fi
 getcredentials.awk ssh_dsa_hostkey | grep -E -v '</{0,1}xcatresponse>|</{0,1}serverdone>' | sed -e 's/&lt;/</' -e 's/&gt;/>/' -e 's/&amp;/&/' -e 's/&quot/"/' -e "s/&apos;/'/" > /tmp/ssh_dsa_hostkey
 
 #check the message is an error or not
-grep -E '<error>' /tmp/ssh_dsa_hostkey
+grep -E '<error>' /tmp/ssh_dsa_hostkey > /dev/null 2>&1
 if [ $? -ne 0 ]; then
 	#the message received is the data
 	cat /tmp/ssh_dsa_hostkey | grep -E -v '</{0,1}errorcode>|/{0,1}data>|</{0,1}content>|</{0,1}desc>' >/etc/ssh/ssh_host_dsa_key
@@ -154,7 +154,7 @@ if [ $? -ne 0 ]; then
 else 
 	#the message received is an error, so parse it
 	ERR_MSG=`sed -n 's%.*<error>\(.*\)</error>.*%\1%p' /tmp/ssh_dsa_hostkey`
-	logger -t xcat -p local4.err Error: $ERR_MSG
+	logger -s -t xcat -p local4.err Error: $ERR_MSG
 fi
 rm /tmp/ssh_dsa_hostkey
 
@@ -174,7 +174,7 @@ fi
 getcredentials.awk ssh_rsa_hostkey | grep -E -v '</{0,1}xcatresponse>|</{0,1}serverdone>' | sed -e 's/&lt;/</' -e 's/&gt;/>/' -e 's/&amp;/&/' -e 's/&quot/"/' -e "s/&apos;/'/" > /tmp/ssh_rsa_hostkey
 
 #check whether the message is an error or not
-grep -E '<error>' /tmp/ssh_rsa_hostkey
+grep -E '<error>' /tmp/ssh_rsa_hostkey > /dev/null 2>&1
 if [ $? -ne 0 ]; then
 	#the message received is the data we request
 	cat /tmp/ssh_rsa_hostkey | grep -E -v '</{0,1}errorcode>|/{0,1}data>|</{0,1}content>|</{0,1}desc>' >/etc/ssh/ssh_host_rsa_key
@@ -220,7 +220,7 @@ if [ $? -ne 0 ]; then
 else
 	#This is an error message
 	ERR_MSG=`sed -n 's%.*<error>\(.*\)</error>.*%\1%p' /tmp/ssh_rsa_hostkey`
-	logger -t xcat -p local4.err Error: $ERR_MSG
+	logger -s -t xcat -p local4.err Error: $ERR_MSG
 fi
 rm /tmp/ssh_rsa_hostkey
 
@@ -242,7 +242,7 @@ if ssh-keygen -t ecdsa -f /tmp/ecdsa_key -P "" &>/dev/null ; then
   getcredentials.awk ssh_ecdsa_hostkey | grep -E -v '</{0,1}xcatresponse>|</{0,1}serverdone>' | sed -e 's/&lt;/</' -e 's/&gt;/>/' -e 's/&amp;/&/' -e 's/&quot/"/' -e "s/&apos;/'/" > /tmp/ssh_ecdsa_hostkey
 
   #check whether the message is an error or not
-  grep -E '<error>' /tmp/ssh_ecdsa_hostkey
+  grep -E '<error>' /tmp/ssh_ecdsa_hostkey > /dev/null 2>&1
   if [ $? -ne 0 ]; then
 	#the message received is the data we request
 	cat /tmp/ssh_ecdsa_hostkey | grep -E -v '</{0,1}errorcode>|/{0,1}data>|</{0,1}content>|</{0,1}desc>' >/etc/ssh/ssh_host_ecdsa_key
@@ -296,7 +296,7 @@ if ssh-keygen -t ecdsa -f /tmp/ecdsa_key -P "" &>/dev/null ; then
   else
 	#This is an error message
 	ERR_MSG=`sed -n 's%.*<error>\(.*\)</error>.*%\1%p' /tmp/ssh_ecdsa_hostkey`
-	logger -t xcat -p local4.err Error: $ERR_MSG
+	logger -s -t xcat -p local4.err Error: $ERR_MSG
   fi
   rm /tmp/ssh_ecdsa_hostkey
 fi


### PR DESCRIPTION
Fix for issue #1168 
- Discard output of `grep` command when checking for error from `getcredentials.awk`.
- Use `-s` option of existing `logger` statement to display the text of the error on console.