### PR TITLE
Use arp command to get switch mac address

### DIFF
--- a/perl-xCAT/xCAT/Utils.pm
+++ b/perl-xCAT/xCAT/Utils.pm
@@ -4711,5 +4711,37 @@ sub get_nmapversion {
     return $nmap_version;
 }
 
+#--------------------------------------------------------------------------------
+=head3  get_macbyarp
+    Get Mac address by arp -n
+    Returns:
+       mac:  Mac address
+=cut
+#--------------------------------------------------------------------------------
+
+sub get_macbyarp {
+    my $arptable;
+    my $mac;
+    my $ip = shift;
+    if ($ip =~ /xCAT::Utils/)
+    {
+        $ip = shift;
+    }
+    if ( -x "/usr/sbin/arp") {
+        $arptable = `/usr/sbin/arp -n`;
+    }
+    else{
+        $arptable = `/sbin/arp -n`;
+    }
+    my @arpents = split /\n/,$arptable;
+    foreach  (@arpents) {
+        if (m/^($ip)\s+\S+\s+(\S+)\s/) {
+            $mac=$2;
+            last;
+        }
+    }
+
+    return $mac;
+}
 
 1;

--- a/perl-xCAT/xCAT/Utils.pm
+++ b/perl-xCAT/xCAT/Utils.pm
@@ -4711,37 +4711,4 @@ sub get_nmapversion {
     return $nmap_version;
 }
 
-#--------------------------------------------------------------------------------
-=head3  get_macbyarp
-    Get Mac address by arp -n
-    Returns:
-       mac:  Mac address
-=cut
-#--------------------------------------------------------------------------------
-
-sub get_macbyarp {
-    my $arptable;
-    my $mac;
-    my $ip = shift;
-    if ($ip =~ /xCAT::Utils/)
-    {
-        $ip = shift;
-    }
-    if ( -x "/usr/sbin/arp") {
-        $arptable = `/usr/sbin/arp -n`;
-    }
-    else{
-        $arptable = `/sbin/arp -n`;
-    }
-    my @arpents = split /\n/,$arptable;
-    foreach  (@arpents) {
-        if (m/^($ip)\s+\S+\s+(\S+)\s/) {
-            $mac=$2;
-            last;
-        }
-    }
-
-    return $mac;
-}
-
 1;

--- a/xCAT-server/lib/xcat/plugins/switchdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/switchdiscover.pm
@@ -867,7 +867,7 @@ sub snmp_scan {
 
         my $vendor = get_snmpvendorinfo($request, $ip);
         if ($vendor) {
-            my $mac = get_snmpmac($request, $ip);
+            my $mac = xCAT::Utils->get_macbyarp($ip);
             if (!$mac) {
                 $mac="nomac_nmap_$counter";
                 $counter++;

--- a/xCAT-server/lib/xcat/plugins/switchdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/switchdiscover.pm
@@ -832,6 +832,8 @@ sub snmp_scan {
     # Nmap scan report for switch-10-5-22-1 (10.5.22.1) 161/udp open  snmp
     # Nmap scan report for 10.5.23.1 161/udp open  snmp
     # Nmap scan report for 10.5.24.1 161/udp closed snmp  
+    # Host 10.5.23.1 appears to be up ... good. 161/udp open|filtered snmp
+    # Host 10.5.24.1 appears to be up ... good. 161/udp closed snmp
     ##########################################################
     my $nmap_version = xCAT::Utils->get_nmapversion();
     if (xCAT::Utils->version_cmp($nmap_version,"5.10") < 0) {
@@ -878,14 +880,7 @@ sub snmp_scan {
             my $display = "";
             my $nopping = "nopping";
             my $output = xCAT::SvrUtils->get_mac_by_arp([$ip], $display, $nopping);
-            my $mac;
-            foreach my $node (keys %{$output}) {
-              if ($node eq $ip) {
-                  my ($desc,$mac_arp) = split /: /, $output->{$node};
-                  $mac = $mac_arp;
-                  last;
-              }
-            }
+            my ($desc,$mac) = split /: /, $output->{$ip};
             if (exists($globalopt{verbose}))    {
                 send_msg($request, 0, "node: $ip, mac: $mac");
             }


### PR DESCRIPTION
The switchdiscover command couldn't find Mellox switch's Mac address via snmpwalk,  we are change it to use arp -n .  this is for issue #1036