### PR TITLE
support mkdef --template;support lsdef --template

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/lsdef.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/lsdef.1.rst
@@ -26,6 +26,9 @@ SYNOPSIS
 [\ **-c | -**\ **-compress**\ ] [\ **-**\ **-osimage**\ ] [\ **-**\ **-nics**\ ] [[\ **-w**\  \ *attr*\ ==\ *val*\ ]
 [\ **-w**\  \ *attr*\ =~\ *val*\ ] ...] [\ *noderange*\ ]
 
+\ **lsdef**\  [\ **-l | -**\ **-long**\ ] [\ **-a | -**\ **-all**\ ] [\ **-t**\  \ *object-types*\ ] [\ **-z | -**\ **-stanza**\ ] 
+[\ **-i**\  \ *attr-list*\ ] [\ **-**\ **-template**\  [\ *template-object-name*\ ]]
+
 
 ***********
 DESCRIPTION
@@ -33,7 +36,7 @@ DESCRIPTION
 
 
 This command is used to display xCAT object definitions which are stored
-in the xCAT database.
+in the xCAT database and xCAT object definition templates shipped in xCAT.
 
 
 *******
@@ -98,6 +101,12 @@ OPTIONS
 \ **-o**\  \ *object-names*\ 
  
  A set of comma delimited object names.
+ 
+
+
+\ **-**\ **-template**\  [\ *template-object-name*\ ]
+ 
+ Show the object definition templates \ *template-object-name*\   shipped in xCAT. If no \ *template-object-name*\  is specified, all the object definition templates of the specified type \ **-t**\  \ *object-types*\  will be listed. Use \ **-a|-**\ **-all**\  option to list all the object definition templates.
  
 
 
@@ -372,6 +381,42 @@ EXAMPLES
  .. code-block:: perl
  
    lsdef cn1 --nics
+ 
+ 
+
+
+18.
+ 
+ To list all the object definition templates shipped in xCAT.
+ 
+ 
+ .. code-block:: perl
+ 
+   lsdef --template -a
+ 
+ 
+
+
+19.
+ 
+ To display the details of "node" object definition template "powerLEnv" shipped in xCAT.
+ 
+ 
+ .. code-block:: perl
+ 
+   lsdef -t node --template powerLEnv
+ 
+ 
+
+
+20.
+ 
+ To list all the "node" object definition templates shipped in xCAT.
+ 
+ 
+ .. code-block:: perl
+ 
+   lsdef -t node --template
  
  
 

--- a/docs/source/guides/admin-guides/references/man1/mkdef.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/mkdef.1.rst
@@ -21,7 +21,7 @@ SYNOPSIS
 
 \ **mkdef**\  [\ **-h | -**\ **-help**\ ] [\ **-t**\  \ *object-types*\ ]
 
-\ **mkdef**\  [\ **-V | -**\ **-verbose**\ ] [\ **-t**\  \ *object-types*\ ] [\ **-o**\  \ *object-names*\ ] [\ **-z | -**\ **-stanza**\ ] [\ **-d | -**\ **-dynamic**\ ] [\ **-f | -**\ **-force**\ ] [[\ **-w**\  \ *attr*\ ==\ *val*\ ] [\ **-w**\  \ *attr*\ =~\ *val*\ ] ...] [\ *noderange*\ ] [\ *attr*\ =\ *val*\  [\ *attr*\ =\ *val...*\ ]] [\ **-u**\  \ **provmethod**\ ={\ **install**\  | \ **netboot**\  | \ **statelite**\ } \ **profile=**\  \ *xxx*\  [\ **osvers=**\  \ *value*\ ] [\ **osarch=**\  \ *value*\ ]]
+\ **mkdef**\  [\ **-V | -**\ **-verbose**\ ] [\ **-t**\  \ *object-types*\ ] [\ **-**\ **-template**\  \ *template-object-name*\ ] [\ **-o**\  \ *object-names*\ ] [\ **-z | -**\ **-stanza**\ ] [\ **-d | -**\ **-dynamic**\ ] [\ **-f | -**\ **-force**\ ] [[\ **-w**\  \ *attr*\ ==\ *val*\ ] [\ **-w**\  \ *attr*\ =~\ *val*\ ] ...] [\ *noderange*\ ] [\ *attr*\ =\ *val*\  [\ *attr*\ =\ *val...*\ ]] [\ **-u**\  \ **provmethod**\ ={\ **install**\  | \ **netboot**\  | \ **statelite**\ } \ **profile=**\  \ *xxx*\  [\ **osvers=**\  \ *value*\ ] [\ **osarch=**\  \ *value*\ ]]
 
 
 ***********
@@ -79,6 +79,12 @@ OPTIONS
 \ **-t**\  \ *object-types*\ 
  
  A set of comma delimited object types.  Use the help option to get a list of valid object types.
+ 
+
+
+\ **-**\ **-template**\  \ *template-object-name*\ 
+ 
+ Name of the xCAT shipped object definition template or an existing object, from which the new object definition will be created from. The newly created object will inherit the attributes of the template definition unless the attribute is specified in the arguments of \ **mkdef**\  command. For the details of xCAT shipped object definition templates, please refer to the manpage of \ **-**\ **-template**\  option in lsdef(1)|lsdef.1.
  
 
 
@@ -276,6 +282,30 @@ EXAMPLES
  .. code-block:: perl
  
    mkdef redhat6img -u profile=compute provmethod=statelite
+ 
+ 
+
+
+13
+ 
+ To create a PowerLE kvm node definition with the xCAT shipped template "powerLEkvm".
+ 
+ 
+ .. code-block:: perl
+ 
+   mkdef -t node cn1 --template powerLEkvm ip=1.1.1.1 mac=42:3d:0a:05:27:0b vmhost=1.1.0.1 vmnics=br0
+ 
+ 
+
+
+14
+ 
+ To create a node definition from an existing node definition "cn1"
+ 
+ 
+ .. code-block:: perl
+ 
+   mkdef -t node cn2 --template cn1 ip=1.1.1.2 mac=42:3d:0a:05:27:0c
  
  
 

--- a/xCAT-client/pods/man1/lsdef.1.pod
+++ b/xCAT-client/pods/man1/lsdef.1.pod
@@ -11,11 +11,13 @@ B<lsdef> [B<-V>|B<--verbose>] [B<-l>|B<--long>] [B<-s>|B<--short>] [B<-a>|B<--al
 [B<-c>|B<--compress>] [B<--osimage>] [B<--nics>] [[B<-w> I<attr>==I<val>]
 [B<-w> I<attr>=~I<val>] ...] [I<noderange>]
 
+B<lsdef> [B<-l>|B<--long>] [B<-a>|B<--all>] [B<-t> I<object-types>] [B<-z>|B<--stanza>] 
+[B<-i> I<attr-list>] [B<--template> [I<template-object-name>]]
 
 =head1 DESCRIPTION
 
 This command is used to display xCAT object definitions which are stored
-in the xCAT database.
+in the xCAT database and xCAT object definition templates shipped in xCAT.
 
 
 =head1 OPTIONS
@@ -62,6 +64,10 @@ See the "noderange" man page for details on supported formats.
 =item B<-o> I<object-names>
 
 A set of comma delimited object names.
+
+=item B<--template> [I<template-object-name>]
+
+Show the object definition templates I<template-object-name>  shipped in xCAT. If no I<template-object-name> is specified, all the object definition templates of the specified type B<-t> I<object-types> will be listed. Use B<-a|--all> option to list all the object definition templates.
 
 =item B<--osimage>
 
@@ -221,6 +227,24 @@ when defining an xCAT node.
 To display the nics configuration information for node cn1.
 
  lsdef cn1 --nics
+
+=item 18.
+
+To list all the object definition templates shipped in xCAT.
+
+ lsdef --template -a
+
+=item 19.
+
+To display the details of "node" object definition template "powerLEnv" shipped in xCAT.
+  
+ lsdef -t node --template powerLEnv
+
+=item 20.
+
+To list all the "node" object definition templates shipped in xCAT.
+
+ lsdef -t node --template
 
 =back
 

--- a/xCAT-client/pods/man1/mkdef.1.pod
+++ b/xCAT-client/pods/man1/mkdef.1.pod
@@ -6,12 +6,12 @@ B<mkdef> - Use this command to create xCAT data object definitions.
 
 B<mkdef> [B<-h>|B<--help>] [B<-t> I<object-types>]
 
-B<mkdef> [B<-V>|B<--verbose>] [B<-t> I<object-types>] [B<-o> I<object-names>] [B<-z>|B<--stanza>] [B<-d>|B<--dynamic>] [B<-f>|B<--force>] [[B<-w> I<attr>==I<val>] [B<-w> I<attr>=~I<val>] ...] [I<noderange>] [I<attr>=I<val> [I<attr>=I<val...>]] [B<-u> B<provmethod>={B<install> | B<netboot> | B<statelite>} B<profile=> I<xxx> [B<osvers=> I<value>] [B<osarch=> I<value>]]
+B<mkdef> [B<-V>|B<--verbose>] [B<-t> I<object-types>] [B<--template> I<template-object-name>] [B<-o> I<object-names>] [B<-z>|B<--stanza>] [B<-d>|B<--dynamic>] [B<-f>|B<--force>] [[B<-w> I<attr>==I<val>] [B<-w> I<attr>=~I<val>] ...] [I<noderange>] [I<attr>=I<val> [I<attr>=I<val...>]] [B<-u> B<provmethod>={B<install> | B<netboot> | B<statelite>} B<profile=> I<xxx> [B<osvers=> I<value>] [B<osarch=> I<value>]]
 
 
 =head1 DESCRIPTION
 
-This command is used to create xCAT object definitions which are stored in the xCAT database. If the definition already exists it will return an error message. The force option may be used to re-create a definition.  In this case the old definition will be remove and the new definition will be created.
+This command is used to create xCAT object definitions which are stored in the xCAT database. If the definition already exists it will return an error message. The force option may be used to re-create a definition.  In this case the old definition will be remove and the new definition will be created. 
 
 
 =head1 OPTIONS
@@ -47,6 +47,10 @@ A set of comma delimited object names.
 =item B<-t> I<object-types>
 
 A set of comma delimited object types.  Use the help option to get a list of valid object types.
+
+=item B<--template> I<template-object-name>
+
+Name of the xCAT shipped object definition template or an existing object, from which the new object definition will be created from. The newly created object will inherit the attributes of the template definition unless the attribute is specified in the arguments of B<mkdef> command. For the details of xCAT shipped object definition templates, please refer to the manpage of B<--template> option in L<lsdef(1)|lsdef.1>.
 
 =item B<-V|--verbose>
 
@@ -162,6 +166,18 @@ To create a node definition with nic attributes
 To create an osimage definition and fill in attributes automatically.
 
  mkdef redhat6img -u profile=compute provmethod=statelite
+
+=item 13
+
+To create a PowerLE kvm node definition with the xCAT shipped template "powerLEkvm".
+
+ mkdef -t node cn1 --template powerLEkvm ip=1.1.1.1 mac=42:3d:0a:05:27:0b vmhost=1.1.0.1 vmnics=br0
+
+=item 14
+
+To create a node definition from an existing node definition "cn1"
+
+ mkdef -t node cn2 --template cn1 ip=1.1.1.2 mac=42:3d:0a:05:27:0c
 
 =back
 

--- a/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
+++ b/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
@@ -20,6 +20,7 @@ use Getopt::Long;
 use xCAT::MsgUtils;
 use xCAT::Utils;
 use xCAT::SvrUtils;
+use File::Find;
 use strict;
 
 # options can be bundled up like -vV
@@ -456,7 +457,7 @@ sub processArgs
     undef $::opt_osimg;
     undef $::opt_nics;
     undef $::opt_setattr;
-
+    undef $::opt_template;
 
     # parse the options - include any option from all 4 cmds
     Getopt::Long::Configure("no_pass_through");
@@ -485,6 +486,7 @@ sub processArgs
                     'osimage'  => \$::opt_osimg,
                     'nics'  => \$::opt_nics,
                     'u'     => \$::opt_setattr,
+                    'template:s' => \$::opt_template,
         )
       )
     {
@@ -600,6 +602,55 @@ sub processArgs
         $rsp->{data}->[0] = "The new object name \'$::opt_n\' is not valid.";
         xCAT::MsgUtils->message("E", $rsp, $::callback);
         return 2;
+    }
+
+   
+    if($::opt_template){
+        if($::opt_template =~ /,/ and $::command eq "mkdef"){
+            my $rsp;
+            $rsp->{data}->[0] = "mkdef: multiple templates specified!";
+            xCAT::MsgUtils->message("E", $rsp, $::callback);
+            return 2;
+        }
+    }
+
+
+    if (defined $::opt_template and ($::command eq "mkdef" or $::command eq "lsdef")){
+        my $objtmpldir="$::XCATROOT/share/xcat/templates/objects/";
+         
+        my @tmpldirlist;
+        if($::command eq "lsdef"){
+            if (!$::opt_a){
+                if($::opt_t){
+                    my @tmpltypelist=split(",",$::opt_t);
+                    foreach my $objtype (@tmpltypelist){
+                        push(@tmpldirlist,$objtmpldir.$objtype);
+                    }
+                }
+            }else{
+                push(@tmpldirlist,$objtmpldir);
+            }
+        }elsif($::command eq "mkdef"){
+            if($::opt_t){
+                push(@tmpldirlist,$objtmpldir.$::opt_t);
+            }else{
+                push(@tmpldirlist,$objtmpldir."node");
+            }
+        }
+        my $objfiledata;
+        find(\&wanted,@tmpldirlist);
+        sub wanted{
+            if (-f $_){
+                my $line;
+                open(FH,$_);
+                while($line=<FH>){
+                    $objfiledata.=$line;
+                }
+                close(FH)
+            }
+        }
+
+        $::filedata=$objfiledata;
     }
 
     # can get object names in many ways - easier to keep track
@@ -768,10 +819,39 @@ sub processArgs
             return 1;
         }
 
-        #   - %::FILEATTRS{fileobjname}{attr}=val
-        # set @::fileobjtypes, @::fileobjnames, %::FILEATTRS
+        if($::opt_template){
+            my %tmpfileattr;
+            my @tmpfileobjtypes;
+            my @tmpfileobjnames;
+            my @tmplobjlist=split(",",$::opt_template);
+            foreach my $key (@tmplobjlist){
+                if(exists $::FILEATTRS{$key}){
+                    $tmpfileattr{$key}=\%{$::FILEATTRS{$key}};
+                    push(@tmpfileobjnames,$key);
+                    push(@tmpfileobjtypes,$tmpfileattr{$key}{objtype});
+                }else{
+                    delete $::FILEATTRS{$key};
+                    my $rsp;
+                    $rsp->{data}->[0] = "Could not find $key in xCAT templates, checking whether it is an existing object definition... ";
+                    xCAT::MsgUtils->message("I", $rsp, $::callback);
+                }
+            }
+            
+            if(@tmpfileobjnames){
+                %::FILEATTRS=%tmpfileattr;
+                @::fileobjtypes=@tmpfileobjtypes;
+                @::fileobjnames=@tmpfileobjnames;
+                $::objectsfrom_file = 1;
+            }else{
+                @::fileobjtypes=();
+                @::fileobjnames=(); 
+            }    
+        }else{
+            #   - %::FILEATTRS{fileobjname}{attr}=val
+            # set @::fileobjtypes, @::fileobjnames, %::FILEATTRS
 
-        $::objectsfrom_file = 1;
+            $::objectsfrom_file = 1;
+        }
     }
 
     #
@@ -830,11 +910,11 @@ sub processArgs
 
 
     # must have object type(s) - default if not provided
-    if (!@::clobjtypes && !@::fileobjtypes && !$::opt_a && !$::opt_t)
+    if (!@::clobjtypes && (!@::fileobjtypes || (@::fileobjtypes && defined $::opt_template)) && !$::opt_a && !$::opt_t)
     {
-
         # make the default type = 'node' if not specified
         push(@::clobjtypes, 'node');
+
         my $rsp;
         if ( !$::opt_z && !$::opt_x) {
             # don't want this msg in stanza or xml output
@@ -1074,7 +1154,7 @@ sub processArgs
 
     # can't have -a with other obj sources
     if ($::opt_a
-        && ($::opt_o || $::filedata || @::noderange))
+        && ($::opt_o || ($::filedata && ! defined $::opt_template ) || @::noderange))
     {
 
         my $rsp;
@@ -1087,30 +1167,37 @@ sub processArgs
     if ($::opt_a)
     {
 
-        my @tmplist;
-
-        # for every type of data object get the list of defined objects
-        foreach my $t (keys %{xCAT::Schema::defspec})
-        {
-            # exclude the auditlog and eventlog,
-            # the auditlog and eventlog tables might be very big
-            # use lsdef -t auditlog or lsdef -t eventlog instead
-            if (($t eq 'auditlog') || ($t eq 'eventlog')) { next; }
-
-            $::objectsfrom_opta = 1;
-
+        if(!defined $::opt_template){
             my @tmplist;
-            @tmplist = xCAT::DBobjUtils->getObjectsOfType($t);
 
-            # add objname and type to hash and global list
-            if (scalar(@tmplist) > 0)
+            # for every type of data object get the list of defined objects
+            foreach my $t (keys %{xCAT::Schema::defspec})
             {
-                foreach my $o (@tmplist)
+                # exclude the auditlog and eventlog,
+                # the auditlog and eventlog tables might be very big
+                # use lsdef -t auditlog or lsdef -t eventlog instead
+                if (($t eq 'auditlog') || ($t eq 'eventlog')) { next; }
+
+                $::objectsfrom_opta = 1;
+
+                my @tmplist;
+                @tmplist = xCAT::DBobjUtils->getObjectsOfType($t);
+
+                # add objname and type to hash and global list
+                if (scalar(@tmplist) > 0)
                 {
-                    push(@::clobjnames, $o);
-                    $::AllObjTypeHash{$o} = $t;
+                    foreach my $o (@tmplist)
+                    {
+                        push(@::clobjnames, $o);
+                        $::AllObjTypeHash{$o} = $t;
+                    }
                 }
             }
+        }
+        else{
+            foreach my $fileobj (@::fileobjnames){
+                $::AllObjTypeHash{$fileobj}=$::FILEATTRS{$fileobj}{objtype};
+            } 
         }
     }
 
@@ -1125,7 +1212,7 @@ sub processArgs
 
     # combine object name all object names provided
     @::allobjnames = @::clobjnames;
-    if (scalar(@::fileobjnames) > 0)
+    if (scalar(@::fileobjnames) > 0 && !defined($::opt_template))
     {
         # add list from stanza or xml file
         push @::allobjnames, @::fileobjnames;
@@ -1167,6 +1254,53 @@ sub processArgs
                     return 1;
                 }
             }
+        }
+    }
+
+    if ($::opt_template && ($::command eq 'mkdef') )
+    {
+        unless($::objectsfrom_file){
+            my @myobjlist = xCAT::DBobjUtils->getObjectsOfType($::clobjtypes[0]);
+            unless (@myobjlist)
+            {
+                my $rsp;
+                $rsp->{data}->[0] = "Could not get objects of type \'$::clobjtypes[0]\'.";
+                xCAT::MsgUtils->message("E", $rsp, $::callback);
+                return 3;
+            }
+
+            unless(grep(/^$::opt_template$/,@myobjlist)){
+                my $rsp;
+                $rsp->{data}->[0] = "Could not find the template object named \'$::opt_template\' of type \'$::clobjtypes[0]\'.";
+                xCAT::MsgUtils->message("E", $rsp, $::callback);
+                return 3;
+            }
+
+            if(grep(/^$::opt_template$/,@::allobjnames)){
+                my $rsp;
+                $rsp->{data}->[0] = "The template node cannot be the same as the node to create.";
+                xCAT::MsgUtils->message("E", $rsp, $::callback);
+                return 1;
+            }
+     
+            my %objtypehash;
+            $objtypehash{$::opt_template} = $::clobjtypes[0];
+            $::ATTRLIST="all";
+            my %objattrhash = xCAT::DBobjUtils->getobjdefs(\%objtypehash);
+            foreach my $key(keys %{$objattrhash{$::opt_template}}){
+                if($key ne "objtype" and not $::ATTRS{$key}){
+                    $::ATTRS{$key}=$objattrhash{$::opt_template}{$key};
+                }
+            }
+        }else{
+            foreach my $key(keys %{$::FILEATTRS{$::opt_template}}){
+                if($key ne "objtype" and not $::ATTRS{$key}){
+                    $::ATTRS{$key}=$::FILEATTRS{$::opt_template}{$key};
+                }
+            }
+            delete $::FILEATTRS{$::opt_template};
+            @::fileobjtypes=();
+            @::fileobjnames=(); 
         }
     }
 
@@ -2789,7 +2923,6 @@ sub defls
 
     # process the command line
     my $rc = &processArgs;
-
     if ($rc != 0)
     {
 
@@ -2810,7 +2943,7 @@ sub defls
 
 
     # do we want just the object names or all the attr=val
-    if ($::opt_l || @::noderange || $::opt_o || $::opt_i)
+    if ($::opt_l || @::noderange || $::opt_o || $::opt_i || $::opt_template)
     {
 
         # assume we want the the details - not just the names
@@ -2861,6 +2994,26 @@ sub defls
             @neededattrs = (@neededattrs, @whereattrs);
         }
     }
+  
+    if (defined $::opt_template){
+
+        unless ($::opt_template){
+            %myhash=%::FILEATTRS;    
+        }else{
+            my @templatelist=split(",",$::opt_template);
+            foreach my $mytemplate (@templatelist){
+                if(exists $::FILEATTRS{$mytemplate}){
+                    $myhash{$mytemplate}= \%{$::FILEATTRS{$mytemplate}};            
+                }else{
+                    my $rsp;
+                    $rsp->{data}->[0] = "Could not find the specified $::opt_t template $mytemplate.";
+                    xCAT::MsgUtils->message("I", $rsp, $::callback);
+                    return 1;
+                } 
+            }
+        }
+    }
+
 
     if ($::objectsfrom_opto || $::objectsfrom_nr || $::objectsfrom_args)
     {
@@ -2883,11 +3036,11 @@ sub defls
             return 1;
 
         }
-
     }
 
+
     #  if just provided type list then find all objects of these types
-    if ($::objectsfrom_optt)
+    if ( ! defined $::opt_template && $::objectsfrom_optt)
     {
         %objhash = %::ObjTypeHash;
 
@@ -2901,64 +3054,69 @@ sub defls
         }
     }
 
+
     # if specify all
     if ($::opt_a)
     {
-
-        # could be modified by type
-        if ($::opt_t)
-        {
-
-            # get all objects matching type list
-            # Get all object in this type list
-            foreach my $t (@::clobjtypes)
+        if(! defined $::opt_template){
+            # could be modified by type
+            if ($::opt_t)
             {
-                my @tmplist = xCAT::DBobjUtils->getObjectsOfType($t);
 
-                if (scalar(@tmplist) > 1)
+                # get all objects matching type list
+                # Get all object in this type list
+                foreach my $t (@::clobjtypes)
                 {
-                    foreach my $obj (@tmplist)
-                    {
+                    my @tmplist = xCAT::DBobjUtils->getObjectsOfType($t);
 
-                        $objhash{$obj} = $t;
+                    if (scalar(@tmplist) > 1)
+                    {
+                        foreach my $obj (@tmplist)
+                        {
+
+                            $objhash{$obj} = $t;
+                        }
+                    }
+                    else
+                    {
+                        my $rsp;
+                        $rsp->{data}->[0] = "Could not get objects of type \'$t\'.";
+                        xCAT::MsgUtils->message("I", $rsp, $::callback);
                     }
                 }
-                else
+
+                %myhash = xCAT::DBobjUtils->getobjdefs(\%objhash);
+                if (!(%myhash))
                 {
                     my $rsp;
-                    $rsp->{data}->[0] = "Could not get objects of type \'$t\'.";
-                    xCAT::MsgUtils->message("I", $rsp, $::callback);
+                    $rsp->{data}->[0] = "Could not get xCAT object definitions.";
+                    xCAT::MsgUtils->message("E", $rsp, $::callback);
+                    return 1;
                 }
-            }
 
-            %myhash = xCAT::DBobjUtils->getobjdefs(\%objhash);
-            if (!(%myhash))
+            }
+            else
             {
-                my $rsp;
-                $rsp->{data}->[0] = "Could not get xCAT object definitions.";
-                xCAT::MsgUtils->message("E", $rsp, $::callback);
-                return 1;
+
+                %myhash = xCAT::DBobjUtils->getobjdefs(\%::AllObjTypeHash, $::VERBOSE);
+                if (!(%myhash))
+                {
+                    my $rsp;
+                    $rsp->{data}->[0] = "Could not get xCAT object definitions.";
+                    xCAT::MsgUtils->message("E", $rsp, $::callback);
+                    return 1;
+                }
+
             }
-
-        }
-        else
-        {
-
-            %myhash = xCAT::DBobjUtils->getobjdefs(\%::AllObjTypeHash, $::VERBOSE);
-            if (!(%myhash))
+            foreach my $t (keys %{xCAT::Schema::defspec})
             {
-                my $rsp;
-                $rsp->{data}->[0] = "Could not get xCAT object definitions.";
-                xCAT::MsgUtils->message("E", $rsp, $::callback);
-                return 1;
+                push(@::clobjtypes, $t);
             }
-
-        }
-        foreach my $t (keys %{xCAT::Schema::defspec})
-        {
-            push(@::clobjtypes, $t);
+        }elsif( defined $::opt_template){
+            push @::clobjtypes, keys { map { $_ => 1 } @::fileobjtypes }; 
         }
     } # end - if specify all
+
 
     if (!(%myhash))
     {
@@ -2967,7 +3125,6 @@ sub defls
         xCAT::MsgUtils->message("I", $rsp, $::callback);
         return 0;
     }
-
 
     # need a special case for the node postscripts attribute,
     # The 'xcatdefaults' postscript should be added to the postscripts and postbootscripts attribute
@@ -2982,6 +3139,8 @@ sub defls
             }
         }
     }
+
+
     my %nodeosimagehash = ();
     if ($getnodes)
     {
@@ -3172,6 +3331,8 @@ sub defls
                 }
             }
 
+
+
             # Get osimage definition info in one invocation
             if(scalar(keys %imglist) > 0)
             {
@@ -3208,6 +3369,7 @@ sub defls
                 }
             }
         }
+
         my $xcatdefaultsps;
         my $xcatdefaultspbs;
         my @TableRowArray = xCAT::DBobjUtils->getDBtable('postscripts');
@@ -3223,6 +3385,7 @@ sub defls
                 }
             }
         }
+
         foreach my $obj (keys %myhash)
         {
             if ($myhash{$obj}{objtype} eq 'node')
@@ -3260,6 +3423,7 @@ sub defls
         }
     }
 
+
     # the list of objects may be limited by the "-w" option
     # see which objects have attr/val that match the where values
     #        - if provided
@@ -3284,9 +3448,11 @@ sub defls
         push (@{$rsp_info->{data}}, "# <xCAT data object stanza file>");
     }
 
+
     # group the objects by type to make the output easier to read
     my $numobjects = 0;    # keep track of how many object we want to display
     # for each type
+
     foreach my $type (@::clobjtypes)
     {
         # Check if -i specifies valid attributes
@@ -3301,6 +3467,7 @@ sub defls
                 $validattrslist{$a} = 1;
             }
         }
+
 
         my %defhash;
 
@@ -3337,12 +3504,6 @@ sub defls
             }
 
             if (!defined($::opt_S) ) {
-                #my $tmp1=$listtab->getAllEntries("all");
-                #if (defined($tmp1) && (@$tmp1 > 0)) {
-                #    foreach(@$tmp1) {
-                #        $newhash{$_->{node}} = 1;
-                #    }
-                #}
                 my @def_nodes = keys %defhash;
                 my $hidden_nodes = $listtab->getNodesAttribs(\@def_nodes, ['hidden']);
                 foreach my $n (keys %{$hidden_nodes}) {
@@ -3645,31 +3806,6 @@ sub defls
         } # end - for each object
     } # end - for each type
 
-    #delete the fsp and bpa node from the hash
-    #my $newrsp;
-    #my $listtab  = xCAT::Table->new( 'nodelist' );
-    #if ($listtab and  (!defined($::opt_S))  ) {
-    #    foreach my $n (@{$rsp_info->{data}}) {
-    #        if ( $n =~ /\(node\)/ ) {
-    #            $_= $n;
-    #            s/ +\(node\)//;
-    #            my ($hidhash) = $listtab->getNodeAttribs($_ ,['hidden']);
-    #            if ( $hidhash->{hidden} ne 1)  {
-    #                push (@{$newrsp->{data}}, $n);
-    #            }
-    #        }else{
-    #        push (@{$newrsp->{data}}, $n);
-    #        }
-    #    }
-    #    if (defined($newrsp->{data}) && scalar(@{$newrsp->{data}}) > 0) {
-    #        xCAT::MsgUtils->message("I", $newrsp, $::callback);
-    #        return 0;
-    #    }
-    #}else {
-    #    my $rsp;
-    #    $rsp->{data}->[0] = "Could not open nodelist table.";
-    #    xCAT::MsgUtils->message("I", $rsp, $::callback);
-    #}
 
     # Display the definition of objects
     if (defined($rsp_info->{data}) && scalar(@{$rsp_info->{data}}) > 0) {

--- a/xCAT/templates/objects/node/cec.stanza
+++ b/xCAT/templates/objects/node/cec.stanza
@@ -1,0 +1,12 @@
+# <the cec definition template>
+
+cec:
+    objtype=node
+    groups=cec,all
+    hcp="MANDATORY:The hardware control point(HMC) for the node"
+    hwtype=cec
+    mgt=hmc
+    mtm="MANDATORY:The machine type and model number of the node"
+    nodetype=ppc
+    serial="MANDATORY:The serial number of the node"
+    usercomment="the cec definition template"

--- a/xCAT/templates/objects/node/hmc.stanza
+++ b/xCAT/templates/objects/node/hmc.stanza
@@ -1,0 +1,12 @@
+# <the template for hmc definition >
+
+hmc:
+    objtype=node
+    groups=hmc
+    hwtype=hmc
+    mgt=hmc
+    nodetype=hmc
+    ip="MANDATORY:the ip address of the hmc"
+    password="MANDATORY:the password of the hmc"
+    username="MANDATORY:the username on the hmc"
+    usercomment="the template for hmc definition" 

--- a/xCAT/templates/objects/node/ppc64le.stanza
+++ b/xCAT/templates/objects/node/ppc64le.stanza
@@ -1,0 +1,18 @@
+# <the template for PowerLE NV node definition>
+
+ppc64le:
+    objtype=node
+    arch=ppc64le
+    bmc="MANDATORY:The hostname or ip address of the BMC adapater"
+    bmcpassword="MANDATORY:the password of the BMC"
+    bmcusername="MANDATORY:the username of the BMC"
+    cons=ipmi
+    groups=all
+    ip=OPTIONAL:the ip address of the node
+    mac=OPTIONAL:the mac of the node
+    mgt=ipmi
+    netboot=petitboot
+    nodetype=mp
+    serialport=0
+    serialspeed=115200
+    usercomment="the template for PowerLE NV node definition"

--- a/xCAT/templates/objects/node/ppc64lekvmguest.stanza
+++ b/xCAT/templates/objects/node/ppc64lekvmguest.stanza
@@ -1,0 +1,17 @@
+# <the power LE kvm node definition template>
+
+ppc64lekvmguest:
+    objtype=node
+    arch=ppc64le
+    groups=all
+    ip="OPTIONAL:the ip address of the kvm guest"
+    mac="OPTIONAL:the mac of the kvm guest"
+    mgt=kvm
+    netboot=grub2
+    vmcpus=2
+    vmhost="MANDATORY:the hostname or ip address of the KVM hypervisor"
+    vmmemory=4096
+    vmnicnicmodel=virtio
+    vmnics="MANDATORY:the hypervisor nics used to create the kvm guest network"
+    vmstorage=dir:///var/lib/libvirt/images
+    usercomment="the power LE kvm node definition template"

--- a/xCAT/templates/objects/node/switch.stanza
+++ b/xCAT/templates/objects/node/switch.stanza
@@ -1,0 +1,11 @@
+# <the switch definition template>
+
+switch:
+    objtype=node
+    groups=switch
+    ip="OPTIONAL:the ip address of the switch"
+    mac="OPTIONAL:the MAC address of the switch"
+    mgt=switch
+    nodetype=switch
+    switchtype="OPTIONAL:The type of switch. It is used to identify the file name that implements the functions for this swithc. The valid values are: Mellanox, Cisco, BNT and Juniper."
+    usercomment="the switch definition template"

--- a/xCAT/templates/objects/node/x86_64.stanza
+++ b/xCAT/templates/objects/node/x86_64.stanza
@@ -1,0 +1,19 @@
+# <the system X node definition>
+
+x86_64:
+    objtype=node
+    arch=x86_64
+    bmc="MANDATORY:The hostname or ip address of the BMC adapater"
+    bmcpassword="MANDATORY:the password of the BMC"
+    bmcusername="MANDATORY:the username of the BMC"
+    cons=ipmi
+    getmac=ipmi
+    groups=all
+    hcp=
+    ip="OPTIONAL:the ip address of the node"
+    mac="OPTIONAL:the mac of the node"
+    mgt=ipmi
+    netboot=xnba
+    serialport=0
+    serialspeed=115200
+    usercomment="the system X node definition"

--- a/xCAT/templates/objects/node/x86_64kvmguest.stanza
+++ b/xCAT/templates/objects/node/x86_64kvmguest.stanza
@@ -1,0 +1,19 @@
+# <the system X kvm node definition>
+
+x86_64kvmguest:
+    objtype=node
+    arch=x86_64
+    groups=all
+    ip="OPTIONAL:the ip address of the kvm guest"
+    mac="OPTIONAL:the mac of the kvm guest"
+    mgt=kvm
+    netboot=xnba
+    serialport=0
+    serialspeed=115200
+    vmcpus=2
+    vmhost="MANDATORY:the hostname or ip address of the KVM hypervisor"
+    vmmemory=4096
+    vmnicnicmodel=virtio
+    vmnics="MANDATORY:the hypervisor nics used to create the kvm guest network"
+    vmstorage=dir:///var/lib/libvirt/images
+    usercomment="the system X kvm node definition"


### PR DESCRIPTION
support ``mkdef --template`` to create object definitions based on the existing object definitions or object definition template 
support ``lsdef --template`` to show the object definition template. ``lsdef -t <node/osimage> --template`` to show all the  templates of a specified object type;``lsdef --template -a`` to show all the templates present in xCAT; ``lsdef -t <node/osimage> --template <object name> `` to show the details of attributes of a specified template. 

updated manpage:
http://10.3.5.21/xcat-doc/html/guides/admin-guides/references/man1/lsdef.1.html
http://10.3.5.21/xcat-doc/html/guides/admin-guides/references/man1/mkdef.1.html