### PR TITLE
delete docker cases which could not be automated on ubuntu16.04 now

### DIFF
--- a/xCAT-test/autotest/bundle/ubuntu16.04_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu16.04_x86_64.bundle
@@ -249,17 +249,3 @@ run_command_with_XCATBYPASS_systemd
 disable_root_permission_in_policy_table_systemd
 assign_certain_command_permission_systemd
 nodeset_check_warninginfo
-Full_installation_flat_docker
-rpower_stop
-rpower_start
-rpower_state
-rpower_restart
-rpower_pause
-rpower_unpause
-mkdocker_h
-mkdocker_command
-rmdocker_h
-rmdocker_command
-rmdocker_f_command
-lsdocker_h_command
-lsdocker_l_command


### PR DESCRIPTION
@tingtli  delete docker cases on ubuntu 16.04