### PR TITLE
bmcsetup requires some changes to work around some issues with OpenPower BMC

### DIFF
--- a/xCAT-genesis-scripts/bin/bmcsetup
+++ b/xCAT-genesis-scripts/bin/bmcsetup
@@ -27,7 +27,7 @@ TIMEOUT=15
 #
 function cold_reset_bmc() { 
     if [ -z $XPROD ]; then 
-        echo "FATAL ERROR - XPROD must be set before calling cold_reset_bmc()"
+        logger -s -t $log_label -p local4.crit "FATAL ERROR - XPROD must be set before calling ${FUNCNAME[0]}"
         exit 1
     fi
 
@@ -40,7 +40,6 @@ function cold_reset_bmc() {
             sleep 30
         fi
         logger -s -t $log_label -p local4.info "Resetting BMC ..."
-        echo "Resetting BMC ..."
         ipmitool mc reset cold
 
         logger -s -t $log_label -p local4.info "Waiting for the BMC to appear ..."
@@ -59,7 +58,7 @@ function cold_reset_bmc() {
                 tries=$(($tries+1))
             done
             TOTAL_SEC=$((${SLEEP_INTERVAL} * ${MAX_ITERATION}))
-            echo "ERROR, After waiting ${TOTAL_SEC} seconds, the BMC is not in a ready state."
+            logger -s -t $log_label -p local4.error "ERROR, After waiting ${TOTAL_SEC} seconds, the BMC is not in a ready state."
         else
             # for Non OpenPower servers, just sleep for some set time.
             sleep 15 
@@ -83,7 +82,7 @@ function cold_reset_bmc() {
 #
 function snooze() { 
     if [ -z $XPROD ]; then 
-        echo "FATAL ERROR - XPROD must be set before calling snooze()"
+        logger -s -t $log_label -p local4.crit "FATAL ERROR - XPROD must be set before calling ${FUNCNAME[0]}"
         exit 1
     fi
 
@@ -124,23 +123,28 @@ while [ -z "$BMCIP" -a $IPCFGMETHOD="static" ]; do
 done
 kill $CREDPID
 NUMBMCS=`grep bmcip /tmp/ipmicfg.xml |awk -F\> '{print $2}'|awk -F\< '{print $1}'|wc -l`
-logger -t $log_label -p local4.info "NUMBMCS=$NUMBMCS"
+logger -s -t $log_label -p local4.debug "BMC IP=$BMCIP, NETMASK=$BMCNM, GATEWAY=$BMCGW, VLAN=$BMCVLAN, USER=$BMCUS, PASSWORD=$BMCPW" 
+logger -s -t $log_label -p local4.info "NUMBMCS=$NUMBMCS"
 #
 # Get the BMC Version and Manufacturer ID
 #
 IPMIVER=`ipmitool mc info|grep ^IPMI|awk  '{print $4}'`
 IPMIMFG=`ipmitool mc info|grep "^Manufacturer ID"|awk  '{print $4}'`
-logger -t $log_label -p local4.info "IPMIVER=$IPMIVER"
-logger -t $log_label -p local4.info "IPMIMFG=$IPMIMFG"
+logger -s -t $log_label -p local4.info "IPMIVER=$IPMIVER, IPMIMFG=$IPMIMFG"
+
 # Get the BMC Product ID
 XPROD=`ipmitool mc info|grep "^Product ID"|awk '{print $4}'`
-logger -t $log_label -p local4.info "XPROD=$XPROD"
+logger -s -t $log_label -p local4.info "XPROD=$XPROD"
 
+#
+# IPMIMFG=2 = IBM
+# IPMIMFG=0 = OpenPower 
+#
 if [ "$IPMIMFG" == 2 ]; then #IBM
     if [ "$XPROD" == "220" ]; then
         LOCKEDUSERS=1
         BMCPORT=`grep bmcport /tmp/ipmicfg.xml |awk -F\> '{print $2}'|awk -F\< '{print $1}'`
-        logger -t $log_label -p local4.info "BMCPORT is $BMCPORT"
+        logger -s -t $log_label -p local4.info "BMCPORT is $BMCPORT"
         if [ ! -z "$BMCPORT" ]; then
             let idev=0
             IFS=','
@@ -150,7 +154,7 @@ if [ "$IPMIMFG" == 2 ]; then #IBM
                 # Set the PEF Configuration Parameters (Platform Event Filtering)
                 ipmitool -d $idev raw 0x04 0x12 0x09 0x01 0x18 0x${p}1 0x00 > /dev/null
                 CURBMCPORT=`ipmitool -d $idev raw 0xc 2 1 0xc0 0 0 | awk '{print $2}'`
-                logger -t $log_label -p local4.info "CURBMCPORT is $CURBMCPORT"
+                logger -s -t $log_label -p local4.info "CURBMCPORT is $CURBMCPORT"
                 while [ "$CURBMCPORT" -ne "$BMCPORT" ]; do
                     sleep 1
                     # Get the LAN Configuration Parameters (OEM)
@@ -165,7 +169,7 @@ if [ "$IPMIMFG" == 2 ]; then #IBM
     else
         # Get a ID for the server
         IBMFAM=`ipmitool raw 0x3a 0x50 |head -n 1| awk '{print $1 $2 $3 $4}'`
-        logger -t $log_label -p local4.info "IBMFAM is $IBMFAM"
+        logger -s -t $log_label -p local4.info "IBMFAM is $IBMFAM"
         if [ "$IBMFAM" == "59554f4f" ]; then
             BMCPORT=`grep bmcport /tmp/ipmicfg.xml |awk -F\> '{print $2}'|awk -F\< '{print $1}'`
             if [ ! -z "$BMCPORT" ]; then
@@ -174,7 +178,7 @@ if [ "$IPMIMFG" == 2 ]; then #IBM
                 for p in $BMCPORT; do
                     ipmitool -d $idev raw 0xc 1 1 0xc0 $p > /dev/null
                     CURBMCPORT=`ipmitool -d $idev raw 0xc 2 1 0xc0 0 0 | awk '{print $2}'`
-                    logger -t $log_label -p local4.info "CURBMCPORT is $CURBMCPORT"
+                    logger -s -t $log_label -p local4.info "CURBMCPORT is $CURBMCPORT"
                     while [ "$CURBMCPORT" -ne "$BMCPORT" ]; do
                         sleep 1
                         CURBMCPORT=`ipmitool -d $idev raw 0xc 2 1 0xc0 0 0 | awk '{print $2}'`
@@ -187,13 +191,13 @@ if [ "$IPMIMFG" == 2 ]; then #IBM
     fi
 elif [ "$IPMIMFG" == 20301 -o "$IPMIMFG" == 19046 ] ; then
     IBMVPDV=`ipmitool raw 0x3a 0xb 2 0 16 1`
-    logger -t $log_label -p local4.info "XPROD is $XPROD, IBMVPDV is $IBMVPDV"
+    logger -s -t $log_label -p local4.info "XPROD is $XPROD, IBMVPDV is $IBMVPDV"
     if [ $IBMVPDV -eq 2 ]; then
         ISITE=1;
     fi
         LOCKEDUSERS=1
         BMCPORT=`grep bmcport /tmp/ipmicfg.xml |awk -F\> '{print $2}'|awk -F\< '{print $1}'`
-        logger -t $log_label -p local4.info "BMCPORT is $BMCPORT"
+        logger -s -t $log_label -p local4.info "BMCPORT is $BMCPORT"
         if [ ! -z "$BMCPORT" ]; then
             let idev=0
             IFS=','
@@ -208,7 +212,7 @@ elif [ "$IPMIMFG" == 20301 -o "$IPMIMFG" == 19046 ] ; then
                 # reverts to dhcp then static, which setting a static ip for is
                 # considered invalid
                 CURBMCPORT=`ipmitool -d $idev raw 0xc 2 1 0xc0 0 0 | awk '{print $2}'`
-                logger -t $log_label -p local4.info "CURBMCPORT is $CURBMCPORT"
+                logger -s -t $log_label -p local4.info "CURBMCPORT is $CURBMCPORT"
                 while [ -z "$CURBMCPORT" -o 0"$CURBMCPORT" -ne "$BMCPORT" ]; do
                     sleep 1
                     CURBMCPORT=`ipmitool -d $idev raw 0xc 2 1 0xc0 0 0 | awk '{print $2}'`
@@ -352,7 +356,7 @@ for user in $BMCUS; do
     # Get the specified user
     CURRENTUSER=`ipmitool -d $idev user list $LANCHAN|grep ^$USERSLOT|awk '{print $2}'`
     DISABLEUSERS=`echo 1 2 3 4|sed -e s/$USERSLOT//`
-    logger -t $log_label -p local4.info "CURRENTUSER=$CURRENTUSER, DISABLEUSERS=$DISABLEUSERS"
+    logger -s -t $log_label -p local4.info "CURRENTUSER=$CURRENTUSER, DISABLEUSERS=$DISABLEUSERS"
     for user in $DISABLEUSERS; do
         TRIES=0
         # Disable the non-specified user 
@@ -378,7 +382,7 @@ for user in $BMCUS; do
     # Get privilege for the specified user
     #
     CURRPRIV=`ipmitool -d $idev user list $LANCHAN|grep ^$USERSLOT|awk '{print $6}'`
-    logger -t $log_label -p local4.info "CURRPRIV=$CURRPRIV"
+    logger -s -t $log_label -p local4.info "CURRPRIV=$CURRPRIV"
     if [ "$CURRPRIV" != "ADMINISTRATOR" ]; then 
         # Set the ADMIN privilege for the specified user
         while ! ipmitool -d $idev user priv $USERSLOT 4 $LANCHAN; do
@@ -493,7 +497,7 @@ while [ $idev -gt 0 ]; do
         TWOIDX=$(ipmitool lan print $LANCHAN|grep ^RMCP+|cut -d: -f 2|sed -e 's/ //' -e 's/,/\n/g'|grep -n '^2$'|sed -e 's/:.*//')
         THREEIDX=$(ipmitool lan print $LANCHAN|grep ^RMCP+|cut -d: -f 2|sed -e 's/ //' -e 's/,/\n/g'|grep -n '^3$'|sed -e 's/:.*//')
         ACCESS=$(ipmitool lan print $LANCHAN|grep 'Cipher Suite Priv Max'|cut -d: -f 2|sed -e 's/ //g' -e 's/\(.\)/\1\n/g'|grep -v '^$')
-        logger -t $log_label -p local4.info "ZEROIDX is $ZEROIDX, ONEIDX is $ONEIDX, TWOIDX is $TWOIDX, THREEIDX is $THREEIDX, ACCESS is $ACCESS"
+        logger -s -t $log_label -p local4.info "ZEROIDX is $ZEROIDX, ONEIDX is $ONEIDX, TWOIDX is $TWOIDX, THREEIDX is $THREEIDX, ACCESS is $ACCESS"
         NEWACCESS=""
         i=1
         for elem in $ACCESS; do

--- a/xCAT-genesis-scripts/bin/bmcsetup
+++ b/xCAT-genesis-scripts/bin/bmcsetup
@@ -44,11 +44,15 @@ while [ -z "$BMCIP" -a $IPCFGMETHOD="static" ]; do
 done
 kill $CREDPID
 NUMBMCS=`grep bmcip /tmp/ipmicfg.xml |awk -F\> '{print $2}'|awk -F\< '{print $1}'|wc -l`
+#
+# Get the BMC Version and Manufacturer ID
+#
 IPMIVER=`ipmitool mc info|grep ^IPMI|awk  '{print $4}'`
 IPMIMFG=`ipmitool mc info|grep "^Manufacturer ID"|awk  '{print $4}'`
 logger -t $log_label -p local4.info "NUMBMCS is $NUMBMCS, IPMIVER is $IPMIVER, IPMIMFG is $IPMIMFG"
 
 if [ "$IPMIMFG" == 2 ]; then #IBM
+    # Get the BMC Product ID
     XPROD=`ipmitool mc info|grep "^Product ID"|awk '{print $4}'`
     logger -t $log_label -p local4.info "XPROD is $XPROD"
     if [ "$XPROD" == "220" ]; then
@@ -59,12 +63,15 @@ if [ "$IPMIMFG" == 2 ]; then #IBM
             let idev=0
             IFS=','
             for p in $BMCPORT; do
+                # Set the LAN Configuration Parameters (OEM)
                 ipmitool -d $idev raw 0xc 1 1 0xc0 $p > /dev/null
+                # Set the PEF Configuration Parameters (Platform Event Filtering)
                 ipmitool -d $idev raw 0x04 0x12 0x09 0x01 0x18 0x${p}1 0x00 > /dev/null
                 CURBMCPORT=`ipmitool -d $idev raw 0xc 2 1 0xc0 0 0 | awk '{print $2}'`
                 logger -t $log_label -p local4.info "CURBMCPORT is $CURBMCPORT"
                 while [ "$CURBMCPORT" -ne "$BMCPORT" ]; do
                     sleep 1
+                    # Get the LAN Configuration Parameters (OEM)
                     CURBMCPORT=`ipmitool -d $idev raw 0xc 2 1 0xc0 0 0 | awk '{print $2}'`
                 done
                 let idev=idev+1
@@ -74,6 +81,7 @@ if [ "$IPMIMFG" == 2 ]; then #IBM
     elif [ "$XPROD" == "291" ]; then
         LOCKEDUSERS=1
     else
+        # Get a ID for the server
         IBMFAM=`ipmitool raw 0x3a 0x50 |head -n 1| awk '{print $1 $2 $3 $4}'`
         logger -t $log_label -p local4.info "IBMFAM is $IBMFAM"
         if [ "$IBMFAM" == "59554f4f" ]; then
@@ -134,7 +142,8 @@ fi
 
 logger -s -t $log_label -p local4.info "Auto detecting LAN channel..."
 while [ -z "$LANCHAN" ]; do 
-    for TLANCHAN in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do 
+    for TLANCHAN in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
+        # Try to get the channel information; then get the MAC which is used for the channel
         if ipmitool channel info $TLANCHAN 2> /dev/null | grep 802.3 > /dev/null 2>&1 && ipmitool raw 0xc 2 $TLANCHAN 5 0 0 > /dev/null 2>&1; 
         then 
             LANCHAN=$TLANCHAN
@@ -154,6 +163,7 @@ if [ $IPCFGMETHOD="static" ]; then
     while [ $idev -gt 0 ]; do
         let idev=idev-1
         TRIES=0
+        # Set the channel to use STATIC IP address 
         while ! ipmitool -d $idev lan set $LANCHAN ipsrc static; do
             sleep 1
             let TRIES=TRIES+1
@@ -165,6 +175,7 @@ if [ $IPCFGMETHOD="static" ]; then
     let idev=0
     for b in $BMCIP; do
         TRIES=0
+        # Set the IP for the current channel
         while ! ipmitool -d $idev lan set $LANCHAN ipaddr $b; do
             sleep 1
             let TRIES=TRIES+1
@@ -177,6 +188,7 @@ if [ $IPCFGMETHOD="static" ]; then
     let idev=0
     for m in $BMCNM; do
         TRIES=0
+        # Set the NETMASK for the current channel 
         while ! ipmitool -d $idev lan set $LANCHAN netmask $m; do
             sleep 1
             let TRIES=TRIES+1
@@ -191,6 +203,7 @@ if [ $IPCFGMETHOD="static" ]; then
         let idev=0
         for g in $BMCGW; do
             TRIES=0
+            # Set the GATEWAY for the current channel 
             while ! ipmitool -d $idev lan set $LANCHAN defgw ipaddr $g; do
                 sleep 1
                 let TRIES=TRIES+1
@@ -207,6 +220,7 @@ else
     while [ $idev -gt 0 ]; do
         let idev=idev-1
         TRIES=0
+        # Set the method to get IP for the current channel, if required.
         while ! ipmitool -d $idev lan set $LANCHAN ipsrc $IPCFGMETHOD; do
             sleep 1
             let TRIES=TRIES+1
@@ -220,6 +234,7 @@ fi
 let idev=0
 for b in $BMCVLAN; do
     TRIES=0
+    # Set VLAN for the current channel 
     while ! ipmitool -d $idev lan set $LANCHAN vlan id $b; do
         sleep 1
         let TRIES=TRIES+1
@@ -235,6 +250,7 @@ for bmcu in $BMCUS; do
     if [ "$bmcu" = "" ]; then continue; fi
 DISABLEUSERS="1 2 3 4"
 if [ ! -z "$LOCKEDUSERS" ]; then
+    # Get the User Slots
     USERSLOT=`ipmitool -d $idev user list $LANCHAN |grep -v ^ID|awk '{print $1 " " $2}'|grep -w "$BMCUS"|awk '{print $1}'`
     if [ -z "$USERSLOT" ]; then
         USERSLOT=4
@@ -251,10 +267,13 @@ if [ "$ISITE" = 1 ]; then
     done
     kill $CREDPID
 fi
+
+# Get the specified user
 CURRENTUSER=`ipmitool -d $idev user list $LANCHAN|grep ^$USERSLOT|awk '{print $2}'`
 DISABLEUSERS=`echo 1 2 3 4|sed -e s/$USERSLOT//`
 logger -t $log_label -p local4.info "CURRENTUSER is $CURRENTUSER, DISABLEUSERS is $DISABLEUSERS"
 for user in $DISABLEUSERS; do
+    # Disable the non-specified user 
     while ! ipmitool -d $idev user disable $user; do
         sleep 1
         let TRIES=TRIES+1
@@ -263,6 +282,7 @@ for user in $DISABLEUSERS; do
     TRIES=0
 done
 TRIES=0
+# Enable the specified user
 while ! ipmitool -d $idev user enable $USERSLOT; do
     sleep 1
     let TRIES=TRIES+1
@@ -271,9 +291,13 @@ done
 TRIES=0
 # Last param in ipmitool user priv is the channel to set it on.
 # Penguin boxes are all channel 2
+#
+# Get privilege for the specified user
+#
 CURRPRIV=`ipmitool -d $idev user list $LANCHAN|grep ^$USERSLOT|awk '{print $6}'`
 logger -t $log_label -p local4.info "CURRPRIV is $CURRPRIV"
 if [ "$CURRPRIV" != "ADMINISTRATOR" ]; then 
+    # Set the ADMIN privilege for the specified user
     while ! ipmitool -d $idev user priv $USERSLOT 4 $LANCHAN; do
         sleep 1
         let TRIES=TRIES+1
@@ -282,6 +306,7 @@ if [ "$CURRPRIV" != "ADMINISTRATOR" ]; then
     TRIES=0
 fi
 TRIES=0
+# Enable the channel link for the specified user
 while ! ipmitool -d $idev channel setaccess $LANCHAN $USERSLOT link=on; do
     sleep 1
     let TRIES=TRIES+1
@@ -289,6 +314,7 @@ while ! ipmitool -d $idev channel setaccess $LANCHAN $USERSLOT link=on; do
 done
 TRIES=0
 if [ "$CURRENTUSER" != "$bmcu" ]; then
+    # Change the user name, if necessary
     while ! ipmitool -d $idev user set name $USERSLOT $bmcu; do
         sleep 1
         let TRIES=TRIES+1
@@ -301,6 +327,7 @@ let idev=NUMBMCS-1
 for bmcp in $BMCPW; do
     if [ "$bmcp" = "" ]; then continue; fi
 TRIES=0
+# Set the password for the specified user 
 while ! ipmitool -d $idev user set password $USERSLOT $bmcp; do
     sleep 1
     let TRIES=TRIES+1
@@ -308,6 +335,7 @@ while ! ipmitool -d $idev user set password $USERSLOT $bmcp; do
 done
 TRIES=0
 logger -s -t $log_label -p local4.info "Set up following user table: "
+# Display the user list 
 ipmitool -d $idev user list $LANCHAN
 let idev=idev-1
 done
@@ -317,12 +345,14 @@ while [ $idev -gt 0 ]; do
 let idev=idev-1
 
 logger -s -t $log_label -p local4.info "Enabling Channel $LANCHAN: "
+# Set the non-volatile channel access: enable and privilege
 while ! ipmitool -d $idev raw 0x6 0x40 $LANCHAN 0x42 0x44 > /dev/null; do
     sleep 1
     let TRIES=TRIES+1
     if [ $TRIES -gt $TIMEOUT ]; then break; fi
 done
 TRIES=0
+# Set the volatile channel access: enable and privilege
 while ! ipmitool -d $idev raw 0x6 0x40 $LANCHAN 0x82 0x84 > /dev/null; do
     sleep 1
     let TRIES=TRIES+1
@@ -332,6 +362,7 @@ if [ $TRIES -gt $TIMEOUT ]; then logger -s -t $log_label -p local4.err "ERROR"; 
 TRIES=0
 
 logger -s -t $log_label -p local4.info "Enabling ARP responses: "
+# enable the ARP response on the channel
 while ! ipmitool -d $idev lan set $LANCHAN arp respond on > /dev/null; do
     sleep 1
     let TRIES=TRIES+1
@@ -342,6 +373,7 @@ if [ $TRIES -gt $TIMEOUT ]; then logger -s -t $log_label -p local4.err "ERROR"; 
 TRIES=0
 
 logger -s -t $log_label -p local4.info "Enabling IPMI v 1.5 MD5 LAN access:"
+# Set the auth level to md5 for the channel
 while ! ipmitool -d $idev lan set $LANCHAN auth admin md5 > /dev/null; do
     sleep 1
     let TRIES=TRIES+1
@@ -357,6 +389,9 @@ if [ ! "$IPMIVER" == "1.5"  ]; then
     #enable cipher suite 2 (scenarios without perl Rijndael)
     #enable cipher suite 3
     #ignore the rest
+    #
+    # Read the LAN info
+    #
     ZEROIDX=$(ipmitool lan print $LANCHAN|grep ^RMCP+|cut -d: -f 2|sed -e 's/ //' -e 's/,/\n/g'|grep -n '%0$'|sed -e 's/:.*//')
     ONEIDX=$(ipmitool lan print $LANCHAN|grep ^RMCP+|cut -d: -f 2|sed -e 's/ //' -e 's/,/\n/g'|grep -n '^1$'|sed -e 's/:.*//')
     TWOIDX=$(ipmitool lan print $LANCHAN|grep ^RMCP+|cut -d: -f 2|sed -e 's/ //' -e 's/,/\n/g'|grep -n '^2$'|sed -e 's/:.*//')
@@ -376,6 +411,7 @@ if [ ! "$IPMIVER" == "1.5"  ]; then
         fi
         i=$((i+1))
     done
+    # Set the cipher_privileges for the channel
     if ipmitool lan set $LANCHAN cipher_privs $NEWACCESS > /dev/null; then
         logger -s -t $log_label -p local4.info "OK"
     else
@@ -384,6 +420,7 @@ if [ ! "$IPMIVER" == "1.5"  ]; then
 
     TRIES=0
     logger -s -t $log_label -p local4.info "Enabling SOL for channel $LANCHAN:"
+    # Enable the SOL for the channel 
     while ! ipmitool -d $idev raw 0xc 0x21 $LANCHAN 0x1 0x1 > /dev/null; do
         sleep 1
         let TRIES=TRIES+1
@@ -393,25 +430,18 @@ if [ ! "$IPMIVER" == "1.5"  ]; then
     TRIES=0
     
     logger -s -t $log_label -p local4.info  "Enabling SOL for $BMCUS:"
+    # Enable the SOL for the USER and set the payload 1
     while ! ipmitool -d $idev raw 6 0x4c $LANCHAN $USERSLOT 2 0 0 0 > /dev/null; do
         sleep 1
         let TRIES=TRIES+1
         if [ $TRIES -gt $TIMEOUT ]; then break; fi
     done
-    if [ $TRIES -gt $TIMEOUT ]; then logger -s -t $log_label -p local4.err "ERROR"; else logger -s -t $log_label -p local4.info "OK"; fi
-    
-    # 0xc 0x21 with data 7 is used to set payload channel, it is readonly in the ipmiv2.0 doc, so comment this section out.
-    #echo -n "Putting SOL on channel $LANCHAN:"
-    #while ! OUTPUT=`ipmitool -d $idev raw 0xc 0x21 $LANCHAN 7 $LANCHAN 2>&1 > /dev/null`; do
-    #	if echo $OUTPUT|grep "Unknown (0x80)" > /dev/null; then
-    #		echo "Not Needed"
-    #		break
-    #    fi
-    #    sleep 1
-    #    let TRIES=TRIES+1
-    #    if [ $TRIES -gt $TIMEOUT ]; then break; fi
-    #done
-    #if [ $TRIES -gt $TIMEOUT ]; then echo "ERROR"; else echo "OK"; fi
+
+    if [ $TRIES -gt $TIMEOUT ]; then 
+        logger -s -t $log_label -p local4.err "ERROR Tried $TIMEOUT times, could not enable SOL for $BMCUS"
+    else
+        logger -s -t $log_label -p local4.info "Enabling SOL for $BMCUS: OK"
+    fi
 fi
 
 #
@@ -454,6 +484,7 @@ fi
 
 logger -s -t $log_label -p local4.info "Lighting Identify Light"
 while :
+    # Identify the server by turning on the LED light
     do ipmitool -d $idev raw 0 4 10 > /dev/null
     sleep 7
 done &

--- a/xCAT-genesis-scripts/bin/bmcsetup
+++ b/xCAT-genesis-scripts/bin/bmcsetup
@@ -27,7 +27,7 @@ TIMEOUT=15
 #
 function cold_reset_bmc() { 
     if [ -z $XPROD ]; then 
-        logger -s -t $log_label -p local4.crit "FATAL ERROR - XPROD must be set before calling ${FUNCNAME[0]}"
+        logger -s -t $log_label -p local4.crit "CRITICAL ERROR - XPROD must be set before calling ${FUNCNAME[0]}"
         exit 1
     fi
 
@@ -82,14 +82,16 @@ function cold_reset_bmc() {
 #
 function snooze() { 
     if [ -z $XPROD ]; then 
-        logger -s -t $log_label -p local4.crit "FATAL ERROR - XPROD must be set before calling ${FUNCNAME[0]}"
+        logger -s -t $log_label -p local4.crit "CRITICAL ERROR - XPROD must be set before calling ${FUNCNAME[0]}"
         exit 1
     fi
 
     if [ "$XPROD" = "43707" ]; then
         # For OpenPower Machines 
+        logger -s -t $log_label -p local4.debug "OpenPower, snooze for 30 seconds..."
         sleep 30
     else
+        logger -s -t $log_label -p local4.debug "snooze for 1 second..."
         sleep 1
     fi
 }
@@ -327,6 +329,9 @@ for b in $BMCVLAN; do
     done
     let idev=idev+1
 done
+
+# After network commands are issued, pause to allow the BMC to apply (OpenPower)
+snooze 
 
 let idev=NUMBMCS-1
 for user in $BMCUS; do

--- a/xCAT-genesis-scripts/bin/bmcsetup
+++ b/xCAT-genesis-scripts/bin/bmcsetup
@@ -431,7 +431,8 @@ let idev=NUMBMCS
 while [ $idev -gt 0 ]; do
     let idev=idev-1
 
-    logger -s -t $log_label -p local4.info "Enabling Channel $LANCHAN: "
+    MSG="Enabling the non-volatile channel access ($LANCHAN)"
+    logger -s -t $log_label -p local4.info "$MSG"
     TRIES=0
     # Set the non-volatile channel access: enable and privilege
     while ! ipmitool -d $idev raw 0x6 0x40 $LANCHAN 0x42 0x44 > /dev/null; do
@@ -439,7 +440,10 @@ while [ $idev -gt 0 ]; do
         let TRIES=TRIES+1
         if [ $TRIES -gt $TIMEOUT ]; then break; fi
     done
+    if [ $TRIES -gt $TIMEOUT ]; then logger -s -t $log_label -p local4.err "$MSG: ERROR"; else logger -s -t $log_label -p local4.info "$MSG: OK"; fi
 
+    MSG="Enabling the volatile channel access ($LANCHAN)"
+    logger -s -t $log_label -p local4.info "$MSG"
     TRIES=0
     # Set the volatile channel access: enable and privilege
     while ! ipmitool -d $idev raw 0x6 0x40 $LANCHAN 0x82 0x84 > /dev/null; do
@@ -447,13 +451,10 @@ while [ $idev -gt 0 ]; do
         let TRIES=TRIES+1
         if [ $TRIES -gt $TIMEOUT ]; then break; fi
     done
-    if [ $TRIES -gt $TIMEOUT ]; then 
-        logger -s -t $log_label -p local4.err "ERROR - Setting the volatile channel access."
-    else 
-        logger -s -t $log_label -p local4.info "OK"
-    fi
+    if [ $TRIES -gt $TIMEOUT ]; then logger -s -t $log_label -p local4.err "$MSG: ERROR"; else logger -s -t $log_label -p local4.info "$MSG: OK"; fi
 
-    logger -s -t $log_label -p local4.info "Enabling ARP responses: "
+    MSG="Enabling ARP responses"
+    logger -s -t $log_label -p local4.info "$MSG"
     TRIES=0
     # enable the ARP response on the channel
     while ! ipmitool -d $idev lan set $LANCHAN arp respond on > /dev/null; do
@@ -462,13 +463,10 @@ while [ $idev -gt 0 ]; do
         echo -n .
         if [ $TRIES -gt $TIMEOUT ]; then break; fi
     done
-    if [ $TRIES -gt $TIMEOUT ]; then 
-        logger -s -t $log_label -p local4.err "ERROR - Enabling ARP Responses."
-    else 
-        logger -s -t $log_label -p local4.info  "OK"
-    fi
+    if [ $TRIES -gt $TIMEOUT ]; then logger -s -t $log_label -p local4.err "$MSG: ERROR"; else logger -s -t $log_label -p local4.info "$MSG: OK"; fi
     
-    logger -s -t $log_label -p local4.info "Enabling IPMI v 1.5 MD5 LAN access:"
+    MSG="Enabling IPMI v 1.5 MD5 LAN access"
+    logger -s -t $log_label -p local4.info "$MSG"
     TRIES=0
     # Set the auth level to md5 for the channel
     while ! ipmitool -d $idev lan set $LANCHAN auth admin md5 > /dev/null; do
@@ -476,14 +474,11 @@ while [ $idev -gt 0 ]; do
         let TRIES=TRIES+1
         if [ $TRIES -gt $TIMEOUT ]; then break; fi
     done
-    if [ $TRIES -gt $TIMEOUT ]; then 
-        logger -s -t $log_label -p local4.err "ERROR - Enabling MD5 for the channel."
-    else
-        logger -s -t $log_label -p local4.info "OK"
-    fi
+    if [ $TRIES -gt $TIMEOUT ]; then logger -s -t $log_label -p local4.err "$MSG: ERROR"; else logger -s -t $log_label -p local4.info "$MSG: OK"; fi
 
     if [ ! "$IPMIVER" == "1.5"  ]; then 
-        logger -s -t $log_label -p local4.info "Enabling IPMI v 2.0 LAN access: "
+        MSG="Enabling IPMI v 2.0 LAN access"
+        logger -s -t $log_label -p local4.info "$MSG"
         # the following goals:
         #   - disable cipher suite 0 (if present, avoid password bypass)
         #   - disable cipher suite 1 (if present, to avoid weaking Kg if used)
@@ -512,14 +507,18 @@ while [ $idev -gt 0 ]; do
             fi
             i=$((i+1))
         done
+
+        MSG="Set the cipher_privileges for the channel"
+        logger -s -t $log_label -p local4.info "$MSG"
         # Set the cipher_privileges for the channel
         if ipmitool lan set $LANCHAN cipher_privs $NEWACCESS > /dev/null; then
-            logger -s -t $log_label -p local4.info "OK"
+            logger -s -t $log_label -p local4.info "$MSG: OK"
         else
-            logger -s -t $log_label -p local4.info "ERROR - Setting cipher privileges for the channel."
+            logger -s -t $log_label -p local4.info "$MSG: ERROR"
         fi
 
-        logger -s -t $log_label -p local4.info "Enabling SOL for channel $LANCHAN:"
+        MSG="Enabling SOL for channel $LANCHAN"
+        logger -s -t $log_label -p local4.info "$MSG"
         TRIES=0
         # Enable the SOL for the channel 
         while ! ipmitool -d $idev raw 0xc 0x21 $LANCHAN 0x1 0x1 > /dev/null; do
@@ -527,25 +526,18 @@ while [ $idev -gt 0 ]; do
             let TRIES=TRIES+1
             if [ $TRIES -gt $TIMEOUT ]; then break; fi
         done
-        if [ $TRIES -gt $TIMEOUT ]; then 
-            logger -s -t $log_label -p local4.info "ERROR - Enabling SOL for the channel: $LANCHAN"
-        else 
-            logger -s -t $log_label -p local4.info "OK"
-        fi
+        if [ $TRIES -gt $TIMEOUT ]; then logger -s -t $log_label -p local4.err "$MSG: ERROR"; else logger -s -t $log_label -p local4.info "$MSG: OK"; fi
 
-        logger -s -t $log_label -p local4.info "Enabling SOL for $BMCUS:"
+        MSG="Enabling SOL for $BMCUS"
+        logger -s -t $log_label -p local4.info "$MSG"
         TRIES=0
-        # Enabl the SOL for the USER and set the payload 1
+        # Enable the SOL for the USER and set the payload 1
         while ! ipmitool -d $idev raw 6 0x4c $LANCHAN $USERSLOT 2 0 0 0 > /dev/null; do
             sleep 1
             let TRIES=TRIES+1
             if [ $TRIES -gt $TIMEOUT ]; then break; fi
         done
-        if [ $TRIES -gt $TIMEOUT ]; then 
-            logger -s -t $log_label -p local4.info "ERROR - Enabling SOL for BMC User: $BMCUS"
-        else
-            echo "OK"
-        fi
+        if [ $TRIES -gt $TIMEOUT ]; then logger -s -t $log_label -p local4.err "$MSG: ERROR"; else logger -s -t $log_label -p local4.info "$MSG: OK"; fi
     fi
 
     # Cold reset the BMC

--- a/xCAT-genesis-scripts/bin/bmcsetup
+++ b/xCAT-genesis-scripts/bin/bmcsetup
@@ -300,222 +300,241 @@ done
 
 let idev=NUMBMCS-1
 for bmcu in $BMCUS; do
-    if [ "$bmcu" = "" ]; then continue; fi
-DISABLEUSERS="1 2 3 4"
-if [ ! -z "$LOCKEDUSERS" ]; then
-    # Get the User Slots
-    USERSLOT=`ipmitool -d $idev user list $LANCHAN |grep -v ^ID|awk '{print $1 " " $2}'|grep -w "$BMCUS"|awk '{print $1}'`
-    if [ -z "$USERSLOT" ]; then
-        USERSLOT=4
+    if [ "$bmcu" = "" ]; then 
+        continue
     fi
-else
-    USERSLOT=2
-fi
-if [ "$ISITE" = 1 ]; then
-    allowcred.awk &
-    CREDPID=$!
-    while ! remoteimmsetup
-    do
-        logger -s -t $log_label -p local4.info "Waiting for xCAT remote configuration of service processor via CMM.."
-    done
-    kill $CREDPID
-fi
+    DISABLEUSERS="1 2 3 4"
+    if [ ! -z "$LOCKEDUSERS" ]; then
+        # Get the User Slots
+        USERSLOT=`ipmitool -d $idev user list $LANCHAN |grep -v ^ID|awk '{print $1 " " $2}'|grep -w "$BMCUS"|awk '{print $1}'`
+        if [ -z "$USERSLOT" ]; then
+            USERSLOT=4
+        fi
+    else
+        USERSLOT=2
+    fi
+    if [ "$ISITE" = 1 ]; then
+        allowcred.awk &
+        CREDPID=$!
+        while ! remoteimmsetup
+        do
+            logger -s -t $log_label -p local4.info "Waiting for xCAT remote configuration of service processor via CMM.."
+        done
+        kill $CREDPID
+    fi
 
-# Get the specified user
-CURRENTUSER=`ipmitool -d $idev user list $LANCHAN|grep ^$USERSLOT|awk '{print $2}'`
-DISABLEUSERS=`echo 1 2 3 4|sed -e s/$USERSLOT//`
-logger -t $log_label -p local4.info "CURRENTUSER is $CURRENTUSER, DISABLEUSERS is $DISABLEUSERS"
-for user in $DISABLEUSERS; do
-    # Disable the non-specified user 
-    while ! ipmitool -d $idev user disable $user; do
+    # Get the specified user
+    CURRENTUSER=`ipmitool -d $idev user list $LANCHAN|grep ^$USERSLOT|awk '{print $2}'`
+    DISABLEUSERS=`echo 1 2 3 4|sed -e s/$USERSLOT//`
+    logger -t $log_label -p local4.info "CURRENTUSER=$CURRENTUSER, DISABLEUSERS=$DISABLEUSERS"
+    for user in $DISABLEUSERS; do
+        # Disable the non-specified user 
+        while ! ipmitool -d $idev user disable $user; do
+            sleep 1
+            let TRIES=TRIES+1
+            if [ $TRIES -gt $TIMEOUT ]; then break; fi
+        done
+        TRIES=0
+    done
+    TRIES=0
+    # Enable the specified user
+    while ! ipmitool -d $idev user enable $USERSLOT; do
         sleep 1
         let TRIES=TRIES+1
         if [ $TRIES -gt $TIMEOUT ]; then break; fi
     done
     TRIES=0
-done
-TRIES=0
-# Enable the specified user
-while ! ipmitool -d $idev user enable $USERSLOT; do
-    sleep 1
-    let TRIES=TRIES+1
-    if [ $TRIES -gt $TIMEOUT ]; then break; fi
-done
-TRIES=0
-# Last param in ipmitool user priv is the channel to set it on.
-# Penguin boxes are all channel 2
-#
-# Get privilege for the specified user
-#
-CURRPRIV=`ipmitool -d $idev user list $LANCHAN|grep ^$USERSLOT|awk '{print $6}'`
-logger -t $log_label -p local4.info "CURRPRIV is $CURRPRIV"
-if [ "$CURRPRIV" != "ADMINISTRATOR" ]; then 
-    # Set the ADMIN privilege for the specified user
-    while ! ipmitool -d $idev user priv $USERSLOT 4 $LANCHAN; do
-        sleep 1
-        let TRIES=TRIES+1
-    if [ $TRIES -gt $TIMEOUT ]; then break; fi
-    done
+    # Last param in ipmitool user priv is the channel to set it on.
+    # Penguin boxes are all channel 2
+    #
+    # Get privilege for the specified user
+    #
+    CURRPRIV=`ipmitool -d $idev user list $LANCHAN|grep ^$USERSLOT|awk '{print $6}'`
+    logger -t $log_label -p local4.info "CURRPRIV=$CURRPRIV"
+    if [ "$CURRPRIV" != "ADMINISTRATOR" ]; then 
+        # Set the ADMIN privilege for the specified user
+        while ! ipmitool -d $idev user priv $USERSLOT 4 $LANCHAN; do
+            sleep 1
+            let TRIES=TRIES+1
+            if [ $TRIES -gt $TIMEOUT ]; then break; fi
+        done
+    fi
     TRIES=0
-fi
-TRIES=0
-# Enable the channel link for the specified user
-while ! ipmitool -d $idev channel setaccess $LANCHAN $USERSLOT link=on; do
-    sleep 1
-    let TRIES=TRIES+1
-    if [ $TRIES -gt $TIMEOUT ]; then break; fi
-done
-TRIES=0
-if [ "$CURRENTUSER" != "$bmcu" ]; then
-    # Change the user name, if necessary
-    while ! ipmitool -d $idev user set name $USERSLOT $bmcu; do
+    # Enable the channel link for the specified user
+    while ! ipmitool -d $idev channel setaccess $LANCHAN $USERSLOT link=on; do
         sleep 1
         let TRIES=TRIES+1
         if [ $TRIES -gt $TIMEOUT ]; then break; fi
     done
-fi
-let idev=idev-1
+    TRIES=0
+    if [ "$CURRENTUSER" != "$bmcu" ]; then
+        # Change the user name, if necessary
+        while ! ipmitool -d $idev user set name $USERSLOT $bmcu; do
+            sleep 1
+            let TRIES=TRIES+1
+            if [ $TRIES -gt $TIMEOUT ]; then break; fi
+        done
+    fi
+    let idev=idev-1
 done
+
 let idev=NUMBMCS-1
 for bmcp in $BMCPW; do
     if [ "$bmcp" = "" ]; then continue; fi
-TRIES=0
-# Set the password for the specified user 
-while ! ipmitool -d $idev user set password $USERSLOT $bmcp; do
-    sleep 1
-    let TRIES=TRIES+1
-    if [ $TRIES -gt $TIMEOUT ]; then break; fi
-done
-TRIES=0
-logger -s -t $log_label -p local4.info "Set up following user table: "
-# Display the user list 
-ipmitool -d $idev user list $LANCHAN
-let idev=idev-1
+    TRIES=0
+    # Set the password for the specified user 
+    while ! ipmitool -d $idev user set password $USERSLOT $bmcp; do
+        sleep 1
+        let TRIES=TRIES+1
+        if [ $TRIES -gt $TIMEOUT ]; then break; fi
+    done
+    TRIES=0
+    logger -s -t $log_label -p local4.info "Set up following user table: "
+    # Display the user list 
+    ipmitool -d $idev user list $LANCHAN
+    let idev=idev-1
 done
 
 let idev=NUMBMCS
 while [ $idev -gt 0 ]; do
-let idev=idev-1
+    let idev=idev-1
 
-logger -s -t $log_label -p local4.info "Enabling Channel $LANCHAN: "
-# Set the non-volatile channel access: enable and privilege
-while ! ipmitool -d $idev raw 0x6 0x40 $LANCHAN 0x42 0x44 > /dev/null; do
-    sleep 1
-    let TRIES=TRIES+1
-    if [ $TRIES -gt $TIMEOUT ]; then break; fi
-done
-TRIES=0
-# Set the volatile channel access: enable and privilege
-while ! ipmitool -d $idev raw 0x6 0x40 $LANCHAN 0x82 0x84 > /dev/null; do
-    sleep 1
-    let TRIES=TRIES+1
-    if [ $TRIES -gt $TIMEOUT ]; then break; fi
-done
-if [ $TRIES -gt $TIMEOUT ]; then logger -s -t $log_label -p local4.err "ERROR"; else logger -s -t $log_label -p local4.info "OK"; fi
-TRIES=0
-
-logger -s -t $log_label -p local4.info "Enabling ARP responses: "
-# enable the ARP response on the channel
-while ! ipmitool -d $idev lan set $LANCHAN arp respond on > /dev/null; do
-    sleep 1
-    let TRIES=TRIES+1
-    echo -n "."
-    if [ $TRIES -gt $TIMEOUT ]; then break; fi
-done
-if [ $TRIES -gt $TIMEOUT ]; then logger -s -t $log_label -p local4.err "ERROR"; else logger -s -t $log_label -p local4.info "OK"; fi
-TRIES=0
-
-logger -s -t $log_label -p local4.info "Enabling IPMI v 1.5 MD5 LAN access:"
-# Set the auth level to md5 for the channel
-while ! ipmitool -d $idev lan set $LANCHAN auth admin md5 > /dev/null; do
-    sleep 1
-    let TRIES=TRIES+1
-    if [ $TRIES -gt $TIMEOUT ]; then break; fi
-done
-if [ $TRIES -gt $TIMEOUT ]; then logger -s -t $log_label -p local4.err "ERROR"; else logger -s -t $log_label -p local4.info "OK"; fi
-TRIES=0
-if [ ! "$IPMIVER" == "1.5"  ]; then 
-    logger -s -t $log_label -p local4.info "Enabling IPMI v 2.0 LAN access: "
-    #the following goals:
-    #disable cipher suite 0 (if present, avoid password bypass)
-    #disable cipher suite 1 (if present, to avoid weaking Kg if used)
-    #enable cipher suite 2 (scenarios without perl Rijndael)
-    #enable cipher suite 3
-    #ignore the rest
-    #
-    # Read the LAN info
-    #
-    ZEROIDX=$(ipmitool lan print $LANCHAN|grep ^RMCP+|cut -d: -f 2|sed -e 's/ //' -e 's/,/\n/g'|grep -n '%0$'|sed -e 's/:.*//')
-    ONEIDX=$(ipmitool lan print $LANCHAN|grep ^RMCP+|cut -d: -f 2|sed -e 's/ //' -e 's/,/\n/g'|grep -n '^1$'|sed -e 's/:.*//')
-    TWOIDX=$(ipmitool lan print $LANCHAN|grep ^RMCP+|cut -d: -f 2|sed -e 's/ //' -e 's/,/\n/g'|grep -n '^2$'|sed -e 's/:.*//')
-    THREEIDX=$(ipmitool lan print $LANCHAN|grep ^RMCP+|cut -d: -f 2|sed -e 's/ //' -e 's/,/\n/g'|grep -n '^3$'|sed -e 's/:.*//')
-    ACCESS=$(ipmitool lan print $LANCHAN|grep 'Cipher Suite Priv Max'|cut -d: -f 2|sed -e 's/ //g' -e 's/\(.\)/\1\n/g'|grep -v '^$')
-    NEWACCESS=""
-    logger -t $log_label -p local4.info "ZEROIDX is $ZEROIDX, ONEIDX is $ONEIDX, TWOIDX is $TWOIDX, THREEIDX is $THREEIDX, ACCESS is $ACCESS"
-    i=1
-    for elem in $ACCESS; do
-        if [ $i = "$ZEROIDX" -o $i = "$ONEIDX" ]; then
-            NEWACCESS="$NEWACCESS"X
-        elif [ $i = "$TWOIDX" -o $i = "$THREEIDX" ]; then
-            #do not *downgrade* from OEM priv
-            if [ "$elem" != "O" ]; then NEWACCESS="$NEWACCESS"a; else NEWACCESS="$NEWACCESS"$elem; fi
-        else
-            NEWACCESS="$NEWACCESS"$elem
-        fi
-        i=$((i+1))
-    done
-    # Set the cipher_privileges for the channel
-    if ipmitool lan set $LANCHAN cipher_privs $NEWACCESS > /dev/null; then
-        logger -s -t $log_label -p local4.info "OK"
-    else
-        logger -s -t $log_label -p local4.err "ERROR"
-    fi
-
+    logger -s -t $log_label -p local4.info "Enabling Channel $LANCHAN: "
     TRIES=0
-    logger -s -t $log_label -p local4.info "Enabling SOL for channel $LANCHAN:"
-    # Enable the SOL for the channel 
-    while ! ipmitool -d $idev raw 0xc 0x21 $LANCHAN 0x1 0x1 > /dev/null; do
-        sleep 1
-        let TRIES=TRIES+1
-        if [ $TRIES -gt $TIMEOUT ]; then break; fi
-    done
-    if [ $TRIES -gt $TIMEOUT ]; then logger -s -t $log_label -p local4.err "ERROR"; else logger -s -t $log_label -p local4.info  "OK"; fi
-    TRIES=0
-    
-    logger -s -t $log_label -p local4.info  "Enabling SOL for $BMCUS:"
-    # Enable the SOL for the USER and set the payload 1
-    while ! ipmitool -d $idev raw 6 0x4c $LANCHAN $USERSLOT 2 0 0 0 > /dev/null; do
+    # Set the non-volatile channel access: enable and privilege
+    while ! ipmitool -d $idev raw 0x6 0x40 $LANCHAN 0x42 0x44 > /dev/null; do
         sleep 1
         let TRIES=TRIES+1
         if [ $TRIES -gt $TIMEOUT ]; then break; fi
     done
 
+    TRIES=0
+    # Set the volatile channel access: enable and privilege
+    while ! ipmitool -d $idev raw 0x6 0x40 $LANCHAN 0x82 0x84 > /dev/null; do
+        sleep 1
+        let TRIES=TRIES+1
+        if [ $TRIES -gt $TIMEOUT ]; then break; fi
+    done
     if [ $TRIES -gt $TIMEOUT ]; then 
-        logger -s -t $log_label -p local4.err "ERROR Tried $TIMEOUT times, could not enable SOL for $BMCUS"
+        logger -s -t $log_label -p local4.err "ERROR - Setting the volatile channel access."
+    else 
+        logger -s -t $log_label -p local4.info "OK"
+    fi
+
+    logger -s -t $log_label -p local4.info "Enabling ARP responses: "
+    TRIES=0
+    # enable the ARP response on the channel
+    while ! ipmitool -d $idev lan set $LANCHAN arp respond on > /dev/null; do
+        sleep 1
+        let TRIES=TRIES+1
+        echo -n .
+        if [ $TRIES -gt $TIMEOUT ]; then break; fi
+    done
+    if [ $TRIES -gt $TIMEOUT ]; then 
+        logger -s -t $log_label -p local4.err "ERROR - Enabling ARP Responses."
+    else 
+        logger -s -t $log_label -p local4.info  "OK"
+    fi
+    
+    logger -s -t $log_label -p local4.info "Enabling IPMI v 1.5 MD5 LAN access:"
+    TRIES=0
+    # Set the auth level to md5 for the channel
+    while ! ipmitool -d $idev lan set $LANCHAN auth admin md5 > /dev/null; do
+        sleep 1
+        let TRIES=TRIES+1
+        if [ $TRIES -gt $TIMEOUT ]; then break; fi
+    done
+    if [ $TRIES -gt $TIMEOUT ]; then 
+        logger -s -t $log_label -p local4.err "ERROR - Enabling MD5 for the channel."
     else
-        logger -s -t $log_label -p local4.info "Enabling SOL for $BMCUS: OK"
+        logger -s -t $log_label -p local4.info "OK"
     fi
-fi
 
-# Cold reset the BMC
-cold_reset_bmc ${XPROD}
+    if [ ! "$IPMIVER" == "1.5"  ]; then 
+        logger -s -t $log_label -p local4.info "Enabling IPMI v 2.0 LAN access: "
+        # the following goals:
+        #   - disable cipher suite 0 (if present, avoid password bypass)
+        #   - disable cipher suite 1 (if present, to avoid weaking Kg if used)
+        #   - enable cipher suite 2 (scenarios without perl Rijndael)
+        #   - enable cipher suite 3
+        #   - ignore the rest
+        #
+        # Read the LAN info
+        #
+        ZEROIDX=$(ipmitool lan print $LANCHAN|grep ^RMCP+|cut -d: -f 2|sed -e 's/ //' -e 's/,/\n/g'|grep -n '%0$'|sed -e 's/:.*//')
+        ONEIDX=$(ipmitool lan print $LANCHAN|grep ^RMCP+|cut -d: -f 2|sed -e 's/ //' -e 's/,/\n/g'|grep -n '^1$'|sed -e 's/:.*//')
+        TWOIDX=$(ipmitool lan print $LANCHAN|grep ^RMCP+|cut -d: -f 2|sed -e 's/ //' -e 's/,/\n/g'|grep -n '^2$'|sed -e 's/:.*//')
+        THREEIDX=$(ipmitool lan print $LANCHAN|grep ^RMCP+|cut -d: -f 2|sed -e 's/ //' -e 's/,/\n/g'|grep -n '^3$'|sed -e 's/:.*//')
+        ACCESS=$(ipmitool lan print $LANCHAN|grep 'Cipher Suite Priv Max'|cut -d: -f 2|sed -e 's/ //g' -e 's/\(.\)/\1\n/g'|grep -v '^$')
+        logger -t $log_label -p local4.info "ZEROIDX is $ZEROIDX, ONEIDX is $ONEIDX, TWOIDX is $TWOIDX, THREEIDX is $THREEIDX, ACCESS is $ACCESS"
+        NEWACCESS=""
+        i=1
+        for elem in $ACCESS; do
+            if [ $i = "$ZEROIDX" -o $i = "$ONEIDX" ]; then
+                NEWACCESS="$NEWACCESS"X
+            elif [ $i = "$TWOIDX" -o $i = "$THREEIDX" ]; then
+                #do not *downgrade* from OEM priv
+                if [ "$elem" != "O" ]; then NEWACCESS="$NEWACCESS"a; else NEWACCESS="$NEWACCESS"$elem; fi
+            else
+                NEWACCESS="$NEWACCESS"$elem
+            fi
+            i=$((i+1))
+        done
+        # Set the cipher_privileges for the channel
+        if ipmitool lan set $LANCHAN cipher_privs $NEWACCESS > /dev/null; then
+            logger -s -t $log_label -p local4.info "OK"
+        else
+            logger -s -t $log_label -p local4.info "ERROR - Setting cipher privileges for the channel."
+        fi
 
-# update the node status to 'bmcready'
-for parm in `cat /proc/cmdline`; do
-    key=`echo $parm|awk -F= '{print $1}'`
-    if [ "$key" = "xcatd" ]; then
-        XCATMASTER=`echo $parm|awk -F= '{print $2}'|awk -F: '{print $1}'`
+        logger -s -t $log_label -p local4.info "Enabling SOL for channel $LANCHAN:"
+        TRIES=0
+        # Enable the SOL for the channel 
+        while ! ipmitool -d $idev raw 0xc 0x21 $LANCHAN 0x1 0x1 > /dev/null; do
+            sleep 1
+            let TRIES=TRIES+1
+            if [ $TRIES -gt $TIMEOUT ]; then break; fi
+        done
+        if [ $TRIES -gt $TIMEOUT ]; then 
+            logger -s -t $log_label -p local4.info "ERROR - Enabling SOL for the channel: $LANCHAN"
+        else 
+            logger -s -t $log_label -p local4.info "OK"
+        fi
+
+        TRIES=0
+        logger -s -t $log_label -p local4.info "Enabling SOL for $BMCUS:"
+        # Enable the SOL for the USER and set the payload 1
+        while ! ipmitool -d $idev raw 6 0x4c $LANCHAN $USERSLOT 2 0 0 0 > /dev/null; do
+            sleep 1
+            let TRIES=TRIES+1
+            if [ $TRIES -gt $TIMEOUT ]; then break; fi
+        done
+        if [ $TRIES -gt $TIMEOUT ]; then 
+            logger -s -t $log_label -p local4.info "ERROR - Enabling SOL for BMC User: $BMCUS"
+        else
+            echo "OK"
+        fi
     fi
-done
-if [ ! -z "$XCATMASTER" ]; then
-    updateflag.awk $XCATMASTER 3002 "installstatus bmcready"
-fi
 
-logger -s -t $log_label -p local4.info "Lighting Identify Light"
-while :
-    # Identify the server by turning on the LED light
-    do ipmitool -d $idev raw 0 4 10 > /dev/null
-    sleep 7
-done &
+    # Cold reset the BMC
+    cold_reset_bmc ${XPROD}
+
+    # update the node status to 'bmcready'
+    for parm in `cat /proc/cmdline`; do
+        key=`echo $parm|awk -F= '{print $1}'`
+        if [ "$key" = "xcatd" ]; then
+            XCATMASTER=`echo $parm|awk -F= '{print $2}'|awk -F: '{print $1}'`
+        fi
+    done
+    if [ ! -z "$XCATMASTER" ]; then
+        updateflag.awk $XCATMASTER 3002 "installstatus bmcready"
+    fi
+
+    logger -s -t $log_label -p local4.info "Lighting Identify Light"
+    while :
+        # Identify the server by turning on the LED light
+        do ipmitool -d $idev raw 0 4 10 > /dev/null
+        sleep 7
+    done &
 done
 

--- a/xCAT-genesis-scripts/bin/bmcsetup
+++ b/xCAT-genesis-scripts/bin/bmcsetup
@@ -531,10 +531,16 @@ while [ $idev -gt 0 ]; do
     fi
 
     logger -s -t $log_label -p local4.info "Lighting Identify Light"
-    while :
-        # Identify the server by turning on the LED light
-        do ipmitool -d $idev raw 0 4 10 > /dev/null
-        sleep 7
-    done &
+    if [ "$XPROD" = "43707" ]; then
+        # OpenPower BMC specific, turn on the LED beacon for 5 minutes 
+        ipmitool chassis identify 300
+    else
+        # All other BMCs
+        while :
+            # Identify the server by turning on the LED light
+            do ipmitool -d $idev raw 0 4 10 > /dev/null
+            sleep 7
+        done &
+    fi
 done
 

--- a/xCAT-genesis-scripts/bin/bmcsetup
+++ b/xCAT-genesis-scripts/bin/bmcsetup
@@ -63,15 +63,15 @@ function cold_reset_bmc() {
         else
             # for Non OpenPower servers, just sleep for some set time.
             sleep 15 
-        fi 
 
-        TRIES=0
-        # Get the LAN information
-        while ! ipmitool lan print $LANCHAN > /dev/null; do
-            sleep 3
-            let TRIES=TRIES+1
-            if [ $TRIES -gt $TIMEOUT ]; then break; fi
-        done
+            TRIES=0
+            # Get the LAN information
+            while ! ipmitool lan print $LANCHAN > /dev/null; do
+                sleep 3
+                let TRIES=TRIES+1
+                if [ $TRIES -gt $TIMEOUT ]; then break; fi
+            done
+        fi 
     fi
 }
 

--- a/xCAT-genesis-scripts/bin/bmcsetup
+++ b/xCAT-genesis-scripts/bin/bmcsetup
@@ -14,6 +14,58 @@
 #
 log_label="xcat.genesis.bmcsetup"
 
+# Cold reset the BMC for certain servers
+#    Product ID: 309   - x3755 M4 (8722)
+#    Product ID: 43707 - IBM Power S822LC and S812LC
+#
+# Otherwise the BMC will not respond to ping after running the ipmitool commands in this script
+#
+function cold_reset_bmc() { 
+    PROD=$1
+    if [ "$PROD" = "309" -o "$PROD" = "43707" ] ; then
+        if [ "$PROD" = "43707" ]; then
+            # OpenPower SPECIFIC, the OpenPower machines with AMI BMC should NOT need a 
+            # reset after applying ipmitool commands.  However, it seems there is a problem with 
+            # the BMC where after 15 seconds, it stops responding.  To work around, sleep 30
+            # seconds before issuing the reset of the BMC.
+            sleep 30
+        fi
+        logger -s -t $log_label -p local4.info "Resetting BMC ..."
+        echo "Resetting BMC ..."
+        ipmitool mc reset cold
+
+        logger -s -t $log_label -p local4.info "Waiting for the BMC to appear ..."
+        if [ "$PROD" = "43707" ]; then
+            # OpenPower SPECIFIC, check the BMC with the following raw command to
+            # make sure that the bmc is really in a "ready" state before continuing 
+            SLEEP_INTERVAL=3
+            MAX_ITERATION=100
+            tries=0
+            while [ $tries -lt ${MAX_ITERATION} ] ; do
+                sleep ${SLEEP_INTERVAL}
+                ret=`ipmitool raw 0x3a 0x0a 2> /dev/null`
+                if [ "$ret" == " 00" ]; then
+                    return
+                fi
+                tries=$(($tries+1))
+            done
+            TOTAL_SEC=$((${SLEEP_INTERVAL} * ${MAX_ITERATION}))
+            echo "ERROR, After waiting ${TOTAL_SEC} seconds, the BMC is not in a ready state."
+        else
+            # for Non OpenPower servers, just sleep for some set time.
+            sleep 15 
+        fi 
+
+        TRIES=0
+        # Get the LAN information
+        while ! ipmitool lan print $LANCHAN > /dev/null; do
+            sleep 3
+            let TRIES=TRIES+1
+            if [ $TRIES -gt $TIMEOUT ]; then break; fi
+        done
+    fi
+}
+
 allowcred.awk &
 CREDPID=$!
 sleep 5
@@ -44,17 +96,19 @@ while [ -z "$BMCIP" -a $IPCFGMETHOD="static" ]; do
 done
 kill $CREDPID
 NUMBMCS=`grep bmcip /tmp/ipmicfg.xml |awk -F\> '{print $2}'|awk -F\< '{print $1}'|wc -l`
+logger -t $log_label -p local4.info "NUMBMCS=$NUMBMCS"
 #
 # Get the BMC Version and Manufacturer ID
 #
 IPMIVER=`ipmitool mc info|grep ^IPMI|awk  '{print $4}'`
 IPMIMFG=`ipmitool mc info|grep "^Manufacturer ID"|awk  '{print $4}'`
-logger -t $log_label -p local4.info "NUMBMCS is $NUMBMCS, IPMIVER is $IPMIVER, IPMIMFG is $IPMIMFG"
+logger -t $log_label -p local4.info "IPMIVER=$IPMIVER"
+logger -t $log_label -p local4.info "IPMIMFG=$IPMIMFG"
+# Get the BMC Product ID
+XPROD=`ipmitool mc info|grep "^Product ID"|awk '{print $4}'`
+logger -t $log_label -p local4.info "XPROD=$XPROD"
 
 if [ "$IPMIMFG" == 2 ]; then #IBM
-    # Get the BMC Product ID
-    XPROD=`ipmitool mc info|grep "^Product ID"|awk '{print $4}'`
-    logger -t $log_label -p local4.info "XPROD is $XPROD"
     if [ "$XPROD" == "220" ]; then
         LOCKEDUSERS=1
         BMCPORT=`grep bmcport /tmp/ipmicfg.xml |awk -F\> '{print $2}'|awk -F\< '{print $1}'`
@@ -104,7 +158,6 @@ if [ "$IPMIMFG" == 2 ]; then #IBM
         fi
     fi
 elif [ "$IPMIMFG" == 20301 -o "$IPMIMFG" == 19046 ] ; then
-    XPROD=`ipmitool mc info|grep "^Product ID"|awk '{print $4}'`
     IBMVPDV=`ipmitool raw 0x3a 0xb 2 0 16 1`
     logger -t $log_label -p local4.info "XPROD is $XPROD, IBMVPDV is $IBMVPDV"
     if [ $IBMVPDV -eq 2 ]; then
@@ -444,32 +497,8 @@ if [ ! "$IPMIVER" == "1.5"  ]; then
     fi
 fi
 
-#
-# Cold Reset the BMC for: 
-#    Product ID: 309   - x3755 M4 (8722)
-#    Product ID: 43707 - IBM Power S822LC and S812LC
-# Otherwise the BMC will not respond to ping after running bmcsetup 
-#
-XPROD=`ipmitool mc info|grep "^Product ID"|awk '{print $4}'`
-if [ "$XPROD" = "309" -o "$XPROD" = "43707" ] ; then
-    if [ "$XPROD" = "43707" ]; then
-        # The IBM Power S822LC and S812LC should NOT need a reset to apply changes
-        # to the BMC.  However, it seems there's a problem with the BMC where after
-        # 15 seconds, it stops responding.  To work around until the firmware is fixed,
-        # have a sleep here for 30 seconds, then issue the reset of the BMC 
-        sleep 30
-    fi
-    logger -s -t $log_label -p local4.info "Resetting BMC ..."
-    ipmitool mc reset cold
-    logger -s -t $log_label -p local4.info "Waiting for the BMC to appear ..."
-    sleep 15
-    TRIES=0
-    while ! ipmitool lan print $LANCHAN > /dev/null; do
-        sleep 3
-        let TRIES=TRIES+1
-        if [ $TRIES -gt $TIMEOUT ]; then break; fi
-    done
-fi
+# Cold reset the BMC
+cold_reset_bmc ${XPROD}
 
 # update the node status to 'bmcready'
 for parm in `cat /proc/cmdline`; do

--- a/xCAT-genesis-scripts/bin/bmcsetup
+++ b/xCAT-genesis-scripts/bin/bmcsetup
@@ -14,6 +14,11 @@
 #
 log_label="xcat.genesis.bmcsetup"
 
+TIMEOUT=15
+
+#
+# Function: cold_reset_bmc
+#
 # Cold reset the BMC for certain servers
 #    Product ID: 309   - x3755 M4 (8722)
 #    Product ID: 43707 - IBM Power S822LC and S812LC
@@ -21,9 +26,13 @@ log_label="xcat.genesis.bmcsetup"
 # Otherwise the BMC will not respond to ping after running the ipmitool commands in this script
 #
 function cold_reset_bmc() { 
-    PROD=$1
-    if [ "$PROD" = "309" -o "$PROD" = "43707" ] ; then
-        if [ "$PROD" = "43707" ]; then
+    if [ -z $XPROD ]; then 
+        echo "FATAL ERROR - XPROD must be set before calling cold_reset_bmc()"
+        exit 1
+    fi
+
+    if [ "$XPROD" = "309" -o "$XPROD" = "43707" ] ; then
+        if [ "$XPROD" = "43707" ]; then
             # OpenPower SPECIFIC, the OpenPower machines with AMI BMC should NOT need a 
             # reset after applying ipmitool commands.  However, it seems there is a problem with 
             # the BMC where after 15 seconds, it stops responding.  To work around, sleep 30
@@ -35,7 +44,7 @@ function cold_reset_bmc() {
         ipmitool mc reset cold
 
         logger -s -t $log_label -p local4.info "Waiting for the BMC to appear ..."
-        if [ "$PROD" = "43707" ]; then
+        if [ "$XPROD" = "43707" ]; then
             # OpenPower SPECIFIC, check the BMC with the following raw command to
             # make sure that the bmc is really in a "ready" state before continuing 
             SLEEP_INTERVAL=3
@@ -66,6 +75,26 @@ function cold_reset_bmc() {
     fi
 }
 
+#
+# Function snooze()
+#
+# The purpose of this is to work around the issue with OpenPower BMCs after 
+# making a change to network configuration, sleep 30 to be sure the changes apply.
+#
+function snooze() { 
+    if [ -z $XPROD ]; then 
+        echo "FATAL ERROR - XPROD must be set before calling snooze()"
+        exit 1
+    fi
+
+    if [ "$XPROD" = "43707" ]; then
+        # For OpenPower Machines 
+        sleep 30
+    else
+        sleep 1
+    fi
+}
+
 allowcred.awk &
 CREDPID=$!
 sleep 5
@@ -75,7 +104,6 @@ while [ -z "$BMCIP" -a $IPCFGMETHOD="static" ]; do
     do
         logger -s -t $log_label -p local4.info "Retrying retrieval of IPMI settings from server"
     done
-    TIMEOUT=15
     BMCIP=`grep bmcip /tmp/ipmicfg.xml |awk -F\> '{print $2}'|awk -F\< '{print $1}'`
     BMCVLAN=`grep taggedvlan /tmp/ipmicfg.xml |awk -F\> '{print $2}'|awk -F\< '{print $1}'`
     if [ -z "$BMCVLAN" ]; then 
@@ -193,12 +221,11 @@ elif [ "$IPMIMFG" == "47488" ]; then
     LOCKEDUSERS=1
 fi
 
-logger -s -t $log_label -p local4.info "Auto detecting LAN channel..."
 while [ -z "$LANCHAN" ]; do 
-    for TLANCHAN in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
+    logger -s -t $log_label -p local4.info "Auto detecting LAN channel..."
+    for TLANCHAN in {1..16}; do
         # Try to get the channel information; then get the MAC which is used for the channel
-        if ipmitool channel info $TLANCHAN 2> /dev/null | grep 802.3 > /dev/null 2>&1 && ipmitool raw 0xc 2 $TLANCHAN 5 0 0 > /dev/null 2>&1; 
-        then 
+        if ipmitool channel info $TLANCHAN 2> /dev/null | grep 802.3 > /dev/null 2>&1 && ipmitool raw 0xc 2 $TLANCHAN 5 0 0 > /dev/null 2>&1; then
             LANCHAN=$TLANCHAN
             break; 
         fi; 
@@ -218,7 +245,7 @@ if [ $IPCFGMETHOD="static" ]; then
         TRIES=0
         # Set the channel to use STATIC IP address 
         while ! ipmitool -d $idev lan set $LANCHAN ipsrc static; do
-            sleep 1
+            snooze
             let TRIES=TRIES+1
             if [ $TRIES -gt $TIMEOUT ]; then
                 break;
@@ -230,7 +257,7 @@ if [ $IPCFGMETHOD="static" ]; then
         TRIES=0
         # Set the IP for the current channel
         while ! ipmitool -d $idev lan set $LANCHAN ipaddr $b; do
-            sleep 1
+            snooze
             let TRIES=TRIES+1
             if [ $TRIES -gt $TIMEOUT ]; then
                 break;
@@ -243,7 +270,7 @@ if [ $IPCFGMETHOD="static" ]; then
         TRIES=0
         # Set the NETMASK for the current channel 
         while ! ipmitool -d $idev lan set $LANCHAN netmask $m; do
-            sleep 1
+            snooze
             let TRIES=TRIES+1
             if [ $TRIES -gt $TIMEOUT ]; then
                 break;
@@ -251,14 +278,14 @@ if [ $IPCFGMETHOD="static" ]; then
         done
         let idev=idev+1
     done
-    TRIES=0
+
     if [ ! -z "$BMCGW" ]; then
         let idev=0
         for g in $BMCGW; do
             TRIES=0
             # Set the GATEWAY for the current channel 
             while ! ipmitool -d $idev lan set $LANCHAN defgw ipaddr $g; do
-                sleep 1
+                snooze
                 let TRIES=TRIES+1
                 if [ $TRIES -gt $TIMEOUT ]; then
                     break;
@@ -266,7 +293,6 @@ if [ $IPCFGMETHOD="static" ]; then
             done
             let idev=idev+1
         done
-        TRIES=0
     fi
 else
     let idev=NUMBMCS
@@ -275,7 +301,7 @@ else
         TRIES=0
         # Set the method to get IP for the current channel, if required.
         while ! ipmitool -d $idev lan set $LANCHAN ipsrc $IPCFGMETHOD; do
-            sleep 1
+            snooze
             let TRIES=TRIES+1
             if [ $TRIES -gt $TIMEOUT ]; then 
                 break;
@@ -289,7 +315,7 @@ for b in $BMCVLAN; do
     TRIES=0
     # Set VLAN for the current channel 
     while ! ipmitool -d $idev lan set $LANCHAN vlan id $b; do
-        sleep 1
+        snooze
         let TRIES=TRIES+1
         if [ $TRIES -gt $TIMEOUT ]; then 
             break;
@@ -299,8 +325,8 @@ for b in $BMCVLAN; do
 done
 
 let idev=NUMBMCS-1
-for bmcu in $BMCUS; do
-    if [ "$bmcu" = "" ]; then 
+for user in $BMCUS; do
+    if [ "$user" = "" ]; then 
         continue
     fi
     DISABLEUSERS="1 2 3 4"
@@ -328,14 +354,15 @@ for bmcu in $BMCUS; do
     DISABLEUSERS=`echo 1 2 3 4|sed -e s/$USERSLOT//`
     logger -t $log_label -p local4.info "CURRENTUSER=$CURRENTUSER, DISABLEUSERS=$DISABLEUSERS"
     for user in $DISABLEUSERS; do
+        TRIES=0
         # Disable the non-specified user 
         while ! ipmitool -d $idev user disable $user; do
             sleep 1
             let TRIES=TRIES+1
             if [ $TRIES -gt $TIMEOUT ]; then break; fi
         done
-        TRIES=0
     done
+
     TRIES=0
     # Enable the specified user
     while ! ipmitool -d $idev user enable $USERSLOT; do
@@ -343,6 +370,7 @@ for bmcu in $BMCUS; do
         let TRIES=TRIES+1
         if [ $TRIES -gt $TIMEOUT ]; then break; fi
     done
+
     TRIES=0
     # Last param in ipmitool user priv is the channel to set it on.
     # Penguin boxes are all channel 2
@@ -359,6 +387,7 @@ for bmcu in $BMCUS; do
             if [ $TRIES -gt $TIMEOUT ]; then break; fi
         done
     fi
+
     TRIES=0
     # Enable the channel link for the specified user
     while ! ipmitool -d $idev channel setaccess $LANCHAN $USERSLOT link=on; do
@@ -366,10 +395,11 @@ for bmcu in $BMCUS; do
         let TRIES=TRIES+1
         if [ $TRIES -gt $TIMEOUT ]; then break; fi
     done
+
     TRIES=0
-    if [ "$CURRENTUSER" != "$bmcu" ]; then
+    if [ "$CURRENTUSER" != "$user" ]; then
         # Change the user name, if necessary
-        while ! ipmitool -d $idev user set name $USERSLOT $bmcu; do
+        while ! ipmitool -d $idev user set name $USERSLOT $user; do
             sleep 1
             let TRIES=TRIES+1
             if [ $TRIES -gt $TIMEOUT ]; then break; fi
@@ -381,6 +411,7 @@ done
 let idev=NUMBMCS-1
 for bmcp in $BMCPW; do
     if [ "$bmcp" = "" ]; then continue; fi
+
     TRIES=0
     # Set the password for the specified user 
     while ! ipmitool -d $idev user set password $USERSLOT $bmcp; do
@@ -388,8 +419,9 @@ for bmcp in $BMCPW; do
         let TRIES=TRIES+1
         if [ $TRIES -gt $TIMEOUT ]; then break; fi
     done
-    TRIES=0
+
     logger -s -t $log_label -p local4.info "Set up following user table: "
+    TRIES=0
     # Display the user list 
     ipmitool -d $idev user list $LANCHAN
     let idev=idev-1
@@ -501,9 +533,9 @@ while [ $idev -gt 0 ]; do
             logger -s -t $log_label -p local4.info "OK"
         fi
 
-        TRIES=0
         logger -s -t $log_label -p local4.info "Enabling SOL for $BMCUS:"
-        # Enable the SOL for the USER and set the payload 1
+        TRIES=0
+        # Enabl the SOL for the USER and set the payload 1
         while ! ipmitool -d $idev raw 6 0x4c $LANCHAN $USERSLOT 2 0 0 0 > /dev/null; do
             sleep 1
             let TRIES=TRIES+1
@@ -517,7 +549,7 @@ while [ $idev -gt 0 ]; do
     fi
 
     # Cold reset the BMC
-    cold_reset_bmc ${XPROD}
+    cold_reset_bmc
 
     # update the node status to 'bmcready'
     for parm in `cat /proc/cmdline`; do


### PR DESCRIPTION
After review of the bmcsetup file that is executed in the genesis kernel during hardware discovery, a few things need to be changed in the bmcsetup file to work around some of the behavioral differences in the OpenPower BMC implementation.  

- Cleaned up the spacing of the code/formatting
- Added comments on the ipmitool raw commands to help understand the actions being performed
- Instead of blinking the light at the end of bmcsetup, use a different ipmitool command to light the LED for 5 minutes. 
- The mc reset cold for OpenPower BMC needs to query the status to ensure that the bmc is really in a ready state before continuing on 
- After making changes to networking commands, sleep 30 for OpenPower BMC (workaround)

Creating this pull request to start review and discussion with the team