### PR TITLE
Add uuid into /opt/xcat/xcatinfo

### DIFF
--- a/xCAT-server/lib/xcat/plugins/packimage.pm
+++ b/xCAT-server/lib/xcat/plugins/packimage.pm
@@ -181,8 +181,12 @@ sub process_request {
     system("mkdir -p $rootimg_dir/xcatpost");
     system("cp -r $installroot/postscripts/* $rootimg_dir/xcatpost/");
 
-    #put the image name and timestamp into diskless image when it is packed.
+    #put the image name, uuid and timestamp into diskless image when it is packed.
     `echo IMAGENAME="'$imagename'" > $rootimg_dir/opt/xcat/xcatinfo`;
+
+    my $uuid = `uuidgen`;
+    chomp $uuid;
+    `echo IMAGEUUID="'$uuid'" >> $rootimg_dir/opt/xcat/xcatinfo`;
     
     my $timestamp = `date`;
     chomp $timestamp;

--- a/xCAT-server/share/xcat/install/scripts/post.debian
+++ b/xCAT-server/share/xcat/install/scripts/post.debian
@@ -89,7 +89,12 @@ do
                 mkdir -p /opt/xcat
                 touch /opt/xcat/xcatinfo
             fi
-            echo "XCATSERVER=$i" > /opt/xcat/xcatinfo
+            grep 'XCATSERVER' /opt/xcat/xcatinfo 2>&1 > /dev/null
+            if [ $? -eq 0 ]; then
+                sed -i "s/XCATSERVER=.*/XCATSERVER=$i/" /opt/xcat/xcatinfo
+            else
+                echo "XCATSERVER=$i" >> /opt/xcat/xcatinfo
+            fi
 	    break
 	fi
 	RAND=$(perl -e 'print int(rand(5)). "\n"')

--- a/xCAT-server/share/xcat/install/scripts/post.xcat
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat
@@ -47,8 +47,21 @@ if [ ! -f /opt/xcat/xcatinfo ]; then
     mkdir -p /opt/xcat
     touch /opt/xcat/xcatinfo
 fi
-echo "XCATSERVER=$MASTER_IP" > /opt/xcat/xcatinfo
-echo "INSTALLDIR=$INSTALLDIR" >> /opt/xcat/xcatinfo
+
+grep 'XCATSERVER' /opt/xcat/xcatinfo 2>&1 > /dev/null
+if [ $? -eq 0 ]; then
+    sed -i "s/XCATSERVER=.*/XCATSERVER=$MASTER_IP/" /opt/xcat/xcatinfo
+else
+    echo "XCATSERVER=$MASTER_IP" >> /opt/xcat/xcatinfo
+fi
+
+grep 'INSTALLDIR' /opt/xcat/xcatinfo 2>&1 > /dev/null
+if [ $? -eq 0 ]; then
+    sed -i "s/INSTALLDIR=.*/INSTALLDIR=$INSTALLDIR/" /opt/xcat/xcatinfo
+else
+    echo "INSTALLDIR=$INSTALLDIR" >> /opt/xcat/xcatinfo
+fi
+
 if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
     msgutil_r "$MASTER_IP" "debug" "/opt/xcat/xcatinfo generated" "/var/log/xcat/xcat.log"
 fi

--- a/xCAT/postscripts/xcatdsklspost
+++ b/xCAT/postscripts/xcatdsklspost
@@ -322,7 +322,12 @@ if [ "$MODE" = "4" ]; then # for statelite mode
         if [ "$KEY" =  "XCAT" ]; then
             TMP=`echo $i | awk -F= '{print $2}'`
             XCATSERVER=`echo $TMP | cut -d: -f1`
-            echo "XCATSERVER=$XCATSERVER" > /opt/xcat/xcatinfo
+            grep 'XCATSERVER' /opt/xcat/xcatinfo 2>&1 > /dev/null
+            if [ $? -eq 0 ]; then
+                sed -i "s/XCATSERVER=.*/XCATSERVER=$XCATSERVER/" /opt/xcat/xcatinfo
+            else
+                echo "XCATSERVER=$XCATSERVER" >> /opt/xcat/xcatinfo
+            fi
             break
         fi
     done
@@ -627,7 +632,7 @@ fi
 #save the MASTER into the xcatinfo file for node deployment case, 
 #for updatenode case, only save it when -M is specified
 if [ $NODE_DEPLOYMENT -eq 1 ] || [ "$MODE" = "4" ]; then
-    new_ms=`grep '^MASTER' /$xcatpost/mypostscript |cut -d= -f2`
+    new_ms=`grep '^MASTER' /$xcatpost/mypostscript |head -n 1 |cut -d= -f2`
 fi
 if [ -n "$new_ms" ]; then
     if [ ! -f /opt/xcat/xcatinfo ]; then

--- a/xCAT/postscripts/xcatinstallpost
+++ b/xCAT/postscripts/xcatinstallpost
@@ -75,7 +75,13 @@ DHCP_TMP=`sed 's/\(DHCPINTERFACES=\)\(.*\)$/\1"\2"/' /xcatpost/mypostscript.post
 echo "$DHCP_TMP" > /xcatpost/mypostscript.post
 
 #mark that the first reboot after installation is finished
-echo "REBOOT=TRUE" >> /opt/xcat/xcatinfo
+grep 'REBOOT' /opt/xcat/xcatinfo 2>&1 > /dev/null
+if [ $? -eq 0 ]; then
+    sed -i "s/REBOOT=.*/REBOOT=TRUE/" /opt/xcat/xcatinfo
+else
+    echo "REBOOT=TRUE" >> /opt/xcat/xcatinfo
+fi
+
 
 CNS=`grep NODESTATUS= /xcatpost/mypostscript.post |awk -F = '{print $2}'`
 if [ -z "$CNS" ] || [ "$CNS" != "'0'" -a   "$CNS" != "'N'"  -a  "$CNS" != "'n'" ]; then


### PR DESCRIPTION
Add uuid to /opt/xcat/xcatinfo into the rootimg dir during packimage, so customer can check uuid in the compute node to verify if osimage matches with the one on the MN. 