### PR TITLE
fix  "xcat-server can not be upgraded #1295"

### DIFF
--- a/docs/source/guides/install-guides/apt/update_xcat.rst
+++ b/docs/source/guides/install-guides/apt/update_xcat.rst
@@ -3,6 +3,6 @@ Updating xCAT
 If at a later date you want to update xCAT, first, update the software repositories and then run: ::
 
     apt-get update
-    apt-get upgrade xcat
+    apt-get --only-upgrade install xcat*
 
 


### PR DESCRIPTION
fix https://github.com/xcat2/xcat-core/issues/1295

the command,
````
apt-get upgrade xcat
````
the argument "xcat" is meaningless, in fact all the packages with upgrading candidates will be upgraded, this might not be what user want to do.

it need to be replaced with ``apt-get --only-upgrade install xcat*``