### PR TITLE
Change the ref type of errorcode in xcmdoutput to array

### DIFF
--- a/xCAT-server/lib/xcat/plugins/kvm.pm
+++ b/xCAT-server/lib/xcat/plugins/kvm.pm
@@ -3987,7 +3987,7 @@ sub dohyp {
             }
             $text =~ s/^\s+//;
             $text =~ s/\s+$//;
-            $output{node}->[0]->{errorcode} = $rc;
+            $output{node}->[0]->{errorcode} = [$rc];
             $output{node}->[0]->{name}->[0] = $node;
             if ($rc == 0) {
                 $output{node}->[0]->{data}->[0]->{contents}->[0] = $text;


### PR DESCRIPTION
Currently runxcmd can not work with kvm when running rpower command as
`runxcmd_output` subroutine just apply array type for `node->{errorcode}`.

close-issue: #1298