### PR TITLE
Removed require Net::SSL so that LWP.pm will default to use IO::Socket::SSL

### DIFF
--- a/perl-xCAT/xCAT/PPCcfg.pm
+++ b/perl-xCAT/xCAT/PPCcfg.pm
@@ -1352,8 +1352,8 @@ sub connect {
              return( "Unable to redirect STDERR: $!" );
         }
     }
-    $IO::Socket::SSL::VERSION = undef;
-    eval { require Net::SSL };
+#    $IO::Socket::SSL::VERSION = undef;
+#    eval { require Net::SSL };
 
     ##################################
     # Turn on tracing

--- a/perl-xCAT/xCAT/PPCfsp.pm
+++ b/perl-xCAT/xCAT/PPCfsp.pm
@@ -124,8 +124,8 @@ sub connect {
              return( "Unable to redirect STDERR: $!" );
         }
     }
-    $IO::Socket::SSL::VERSION = undef;
-    eval { require Net::SSL };
+#    $IO::Socket::SSL::VERSION = undef;
+#    eval { require Net::SSL };
 
     ##################################
     # Turn on tracing

--- a/xCAT-server/lib/xcat/plugins/bpa.pm
+++ b/xCAT-server/lib/xcat/plugins/bpa.pm
@@ -40,13 +40,13 @@ sub preprocess_request {
     # So we should invalidate  IO::Socket::SSL here and
     # load Net::SSL.
     #######################################################
-    $IO::Socket::SSL::VERSION = undef;
-    eval { require Net::SSL };
-    if ( $@ ) {
-        my $callback = $_[1];
-        $callback->( {errorcode=>1,data=>[$@]} );
-        return(1);
-    }
+    #$IO::Socket::SSL::VERSION = undef;
+    #eval { require Net::SSL };
+    #if ( $@ ) {
+    #    my $callback = $_[1];
+    #    $callback->( {errorcode=>1,data=>[$@]} );
+    #    return(1);
+    #}
     xCAT::PPC::preprocess_request(__PACKAGE__,@_);
 }
 

--- a/xCAT-server/lib/xcat/plugins/fsp.pm
+++ b/xCAT-server/lib/xcat/plugins/fsp.pm
@@ -54,13 +54,13 @@ sub preprocess_request {
     # So we should invalidate  IO::Socket::SSL here and
     # load Net::SSL.
     #######################################################
-    $IO::Socket::SSL::VERSION = undef;
-    eval { require Net::SSL };
-    if ( $@ ) {
-        my $callback = $_[1];
-        $callback->( {errorcode=>1,data=>[$@]} );
-        return(1);
-    }
+#    $IO::Socket::SSL::VERSION = undef;
+#    eval { require Net::SSL };
+#    if ( $@ ) {
+#        my $callback = $_[1];
+#        $callback->( {errorcode=>1,data=>[$@]} );
+#        return(1);
+#    }
     my ($arg1, $arg2, $arg3) = @_;
     if ($arg1->{command}->[0] eq "getfspcon") { #Can handle it here and now
         my $node = $arg1->{noderange}->[0];


### PR DESCRIPTION
This pull request is to fix issue #1217 where Net::SSL will fail to load SSLeay.so because libssl.a no longer supports SSLv2.  The fix is to not use Net::SSL and default to use IO::Socket::SSL which works.