### PR TITLE
Altered statelite behavior w.r.t. /etc/mtab on RHEL7 distros

### DIFF
--- a/xCAT-server/lib/xcat/plugins/statelite.pm
+++ b/xCAT-server/lib/xcat/plugins/statelite.pm
@@ -797,6 +797,18 @@ sub liteItem {
         # the /etc/mtab should be handled every time even the parent /etc/ has been handled.
         # if adding /etc/ to litefile, only tmpfs should be used. 
         if ($entry[1] eq "/etc/mtab") {
+            #
+            # In RHEL7 /etc/mtab is a symlink to /proc/self/mounts and not a regular file.
+            # If that's the case, then we skip forcing /etc/mtab into the .statelite path
+            # and symlink'ing /etc/mtab to that file.  Otherwise, since the OS isn't updating
+            # /etc/mtab commands like "df" will not be happy.
+            #
+            my $ret=`readlink $rootimg_dir/etc/mtab`;
+            chomp($ret);
+            if ($? == 0 and ($ret eq '/proc/self/mounts') ) {
+                $verbose && $callback->({info=>["skipping /etc/mtab (symlink to /proc/self/mounts)"]});
+                next;
+            }
             $isChild = 0;
         }
 


### PR DESCRIPTION
In RHEL7/CentOS7, /etc/mtab has been changed to be a symlink to /proc/self/mount and the OS no longer updates /etc/mtab.  If /etc/mtab is replaced with a file under the /.statelite tmpfs, it remains blank and commands like "df" will fail.

Detecting when /etc/mtab is a symlink to /proc/self/mount and skipping that file's move to the tmpfs is the solution implemented here.