### PR TITLE
Ignore 'File exists' error from storage pool build

### DIFF
--- a/xCAT-server/lib/xcat/plugins/kvm.pm
+++ b/xCAT-server/lib/xcat/plugins/kvm.pm
@@ -234,7 +234,10 @@ sub get_storage_pool_by_url {
     eval { $poolobj->build(); };
     if ($@) {
         my $error = $@;
-        unless ($error =~ /vgcreate.*exit status 3/ or $error =~ /pvcreate.*exit status 5/) {
+	# Some errors from building storage pool object are safe to ignore.
+	# For example, "File exists" is returned when a directory location for storage pool is already there. 
+	# The storage pool still gets built, and the next statement to create storage pool will work.
+        unless ($error =~ /vgcreate.*exit status 3/ or $error =~ /pvcreate.*exit status 5/ or $error =~ /File exists/) {
             die $@;
         }
     }


### PR DESCRIPTION
It is safe to ignore "File exists" error from `$poolobj->build()`
This error is returned when directory, even an empty one, exists when trying to setup a new storage pool.
The storage pool gets built even if this error is returned, so it is safe to continue and create a storage pool at that location. 
The files in the storage pool directory get preserved, if they existed there prior to storage pool creation.