### PR TITLE
fix issue  [FVT]lsdef/mkdef commands <Error: Unsupported request error> on rh6.8 ppc64 #1369 @github

### DIFF
--- a/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
+++ b/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
@@ -669,8 +669,7 @@ sub processArgs
         #if "-a" is not specified, read the template files content 
         #under "/opt/xcat/share/xcat/templates/objects/<object type>"
         my $objfiledata;
-        find(\&wanted,@tmpldirlist);
-        sub wanted{
+        my $wanted= sub {
             if (-f $_){
                 my $line;
                 open(FH,$_);
@@ -679,7 +678,9 @@ sub processArgs
                 }
                 close(FH)
             }
-        }
+        };
+        find($wanted,@tmpldirlist);
+
          
         #save the template definitions in global variable $::filedata 
         #for the later parse 
@@ -3183,7 +3184,8 @@ sub defls
         }
         else{
             #push the unique object types from @::fileobjtypes to @::clobjtypes 
-            push @::clobjtypes, keys { map { $_ => 1 } @::fileobjtypes }; 
+            my %objtypehash=map { $_ => 1 } @::fileobjtypes;
+            push @::clobjtypes, keys(%objtypehash); 
         }
     } # end - if specify all
 


### PR DESCRIPTION
fix issue  [FVT]lsdef/mkdef commands "Error: Unsupported request" error on rh6.8 ppc64 #1369 
refine the code to apply to the syntax in perl 5.10.1:
1. ``map`` subroutine does not support anonymous hash 
2. use anonymous subroutine to get freshly bound to the lexical environment at runtime 