### PR TITLE
fix issue  [Customer] bootloader is not grabbing the addkcmdline from osimage #1185

### DIFF
--- a/xCAT-server/share/xcat/install/centos/compute.centos6.tmpl
+++ b/xCAT-server/share/xcat/install/centos/compute.centos6.tmpl
@@ -33,7 +33,7 @@ clearpart --all --initlabel
 #No RAID
 #/boot really significant for this sort of setup nowadays?
 #part /boot --size 50 --fstype ext3
-%include /tmp/partitioning
+%include /tmp/partitionfile
 #XCAT_PARTITION_END#
 
 #RAID 0 /scr for performance

--- a/xCAT-server/share/xcat/install/centos/compute.centos7.tmpl
+++ b/xCAT-server/share/xcat/install/centos/compute.centos7.tmpl
@@ -35,7 +35,7 @@ clearpart --all --initlabel
 #No RAID
 #/boot really significant for this sort of setup nowadays?
 #part /boot --size 50 --fstype ext3
-%include /tmp/partitioning
+%include /tmp/partitionfile
 #part swap --size 1024 
 #part / --size 1 --grow --fstype ext4
 #XCAT_PARTITION_END#
@@ -79,7 +79,7 @@ clearpart --all --initlabel
 #The bootloader config here is commented out
 #For user customized partition file or partition script,
 #the bootloader configuration should be specified in the user customized partition file/script
-#For the xCAT default partition scheme, the bootloader configuration is in /tmp/partitioning
+#For the xCAT default partition scheme, the bootloader configuration is in /tmp/partitionfile
 #which is generated in %pre section
 ##KICKSTARTBOOTLOADER#
 

--- a/xCAT-server/share/xcat/install/centos/kvm.centos6.tmpl
+++ b/xCAT-server/share/xcat/install/centos/kvm.centos6.tmpl
@@ -31,7 +31,7 @@ clearpart --all --initlabel
 #No RAID
 #/boot really significant for this sort of setup nowadays?
 #part /boot --size 50 --fstype ext3
-%include /tmp/partitioning
+%include /tmp/partitionfile
 #XCAT_PARTITION_END#
 
 #RAID 0 /scr for performance

--- a/xCAT-server/share/xcat/install/fedora/compute.fedora19.tmpl
+++ b/xCAT-server/share/xcat/install/fedora/compute.fedora19.tmpl
@@ -35,7 +35,7 @@ clearpart --all --initlabel
 #No RAID
 #/boot really significant for this sort of setup nowadays?
 #part /boot --size 50 --fstype ext3
-%include /tmp/partitioning
+%include /tmp/partitionfile
 #XCAT_PARTITION_END#
 
 #RAID 0 /scr for performance

--- a/xCAT-server/share/xcat/install/fedora/compute.fedora20.tmpl
+++ b/xCAT-server/share/xcat/install/fedora/compute.fedora20.tmpl
@@ -35,7 +35,7 @@ clearpart --all --initlabel
 #No RAID
 #/boot really significant for this sort of setup nowadays?
 #part /boot --size 50 --fstype ext3
-%include /tmp/partitioning
+%include /tmp/partitionfile
 #XCAT_PARTITION_END#
 
 #RAID 0 /scr for performance

--- a/xCAT-server/share/xcat/install/fedora/compute.fedora21.tmpl
+++ b/xCAT-server/share/xcat/install/fedora/compute.fedora21.tmpl
@@ -35,7 +35,7 @@ clearpart --all --initlabel
 #No RAID
 #/boot really significant for this sort of setup nowadays?
 #part /boot --size 50 --fstype ext3
-%include /tmp/partitioning
+%include /tmp/partitionfile
 #XCAT_PARTITION_END#
 
 #RAID 0 /scr for performance

--- a/xCAT-server/share/xcat/install/pkvm/compute.pkvm3.ppc64le.tmpl
+++ b/xCAT-server/share/xcat/install/pkvm/compute.pkvm3.ppc64le.tmpl
@@ -31,7 +31,7 @@ rootpw --iscrypted #CRYPT:passwd:key=system,username=root:password#
 
 
 #XCAT_PARTITION_START#
-%include /tmp/partitioning
+%include /tmp/partitionfile
 #XCAT_PARTITION_END#
 
 %pre

--- a/xCAT-server/share/xcat/install/rh/compute.rhelhpc6.tmpl
+++ b/xCAT-server/share/xcat/install/rh/compute.rhelhpc6.tmpl
@@ -33,7 +33,7 @@ key --skip
 #No RAID
 #/boot really significant for this sort of setup nowadays?
 #part /boot --size 50 --fstype ext3
-%include /tmp/partitioning
+%include /tmp/partitionfile
 #part swap --size 1024 
 #part / --size 1 --grow --fstype ext4
 #XCAT_PARTITION_END#

--- a/xCAT-server/share/xcat/install/rh/compute.rhels6.tmpl
+++ b/xCAT-server/share/xcat/install/rh/compute.rhels6.tmpl
@@ -34,7 +34,7 @@ key --skip
 #No RAID
 #/boot really significant for this sort of setup nowadays?
 #part /boot --size 50 --fstype ext3
-%include /tmp/partitioning
+%include /tmp/partitionfile
 #part swap --size 1024 
 #part / --size 1 --grow --fstype ext4
 #XCAT_PARTITION_END#

--- a/xCAT-server/share/xcat/install/rh/compute.rhels6.x86_64.tmpl
+++ b/xCAT-server/share/xcat/install/rh/compute.rhels6.x86_64.tmpl
@@ -37,7 +37,7 @@ key --skip
 #No RAID
 #/boot really significant for this sort of setup nowadays?
 #part /boot --size 50 --fstype ext3
-%include /tmp/partitioning
+%include /tmp/partitionfile
 #XCAT_PARTITION_END#
 
 #RAID 0 /scr for performance

--- a/xCAT-server/share/xcat/install/rh/compute.rhels7.tmpl
+++ b/xCAT-server/share/xcat/install/rh/compute.rhels7.tmpl
@@ -34,7 +34,7 @@ clearpart --all --initlabel
 #No RAID
 #/boot really significant for this sort of setup nowadays?
 #part /boot --size 50 --fstype ext3
-%include /tmp/partitioning
+%include /tmp/partitionfile
 #part swap --size 1024 
 #part / --size 1 --grow --fstype ext4
 #XCAT_PARTITION_END#
@@ -78,7 +78,7 @@ clearpart --all --initlabel
 #The bootloader config here is commented out
 #For user customized partition file or partition script, 
 #the bootloader configuration should be specified in the user customized partition file/script
-#For the xCAT default partition scheme, the bootloader configuration is in /tmp/partitioning
+#For the xCAT default partition scheme, the bootloader configuration is in /tmp/partitionfile
 #which is generated in %pre section
 ##KICKSTARTBOOTLOADER#
 

--- a/xCAT-server/share/xcat/install/rh/compute_ad.rhels6.tmpl
+++ b/xCAT-server/share/xcat/install/rh/compute_ad.rhels6.tmpl
@@ -33,7 +33,7 @@ key --skip
 #No RAID
 #/boot really significant for this sort of setup nowadays?
 #part /boot --size 50 --fstype ext3
-%include /tmp/partitioning
+%include /tmp/partitionfile
 #part swap --size 1024 
 #part / --size 1 --grow --fstype ext4
 #XCAT_PARTITION_END#

--- a/xCAT-server/share/xcat/install/rh/hpc.rhels6.tmpl
+++ b/xCAT-server/share/xcat/install/rh/hpc.rhels6.tmpl
@@ -33,7 +33,7 @@ key --skip
 #No RAID
 #/boot really significant for this sort of setup nowadays?
 #part /boot --size 50 --fstype ext3
-%include /tmp/partitioning
+%include /tmp/partitionfile
 #part swap --size 1024 
 #part / --size 1 --grow --fstype ext4
 #XCAT_PARTITION_END#

--- a/xCAT-server/share/xcat/install/rh/kvm.rhels6.tmpl
+++ b/xCAT-server/share/xcat/install/rh/kvm.rhels6.tmpl
@@ -35,7 +35,7 @@ key --skip
 #No RAID
 #/boot really significant for this sort of setup nowadays?
 #part /boot --size 50 --fstype ext3
-%include /tmp/partitioning
+%include /tmp/partitionfile
 #part swap --size 1024 
 #part / --size 1 --grow --fstype ext4
 #XCAT_PARTITION_END#

--- a/xCAT-server/share/xcat/install/rh/kvm.rhels7.tmpl
+++ b/xCAT-server/share/xcat/install/rh/kvm.rhels7.tmpl
@@ -34,7 +34,7 @@ clearpart --all --initlabel
 #No RAID
 #/boot really significant for this sort of setup nowadays?
 #part /boot --size 50 --fstype ext3
-%include /tmp/partitioning
+%include /tmp/partitionfile
 #part swap --size 1024 
 #part / --size 1 --grow --fstype ext4
 #XCAT_PARTITION_END#

--- a/xCAT-server/share/xcat/install/rh/service.rhels6.x86_64.tmpl
+++ b/xCAT-server/share/xcat/install/rh/service.rhels6.x86_64.tmpl
@@ -35,7 +35,7 @@ key --skip
 #No RAID
 #/boot really significant for this sort of setup nowadays?
 #part /boot --size 50 --fstype ext3
-%include /tmp/partitioning
+%include /tmp/partitionfile
 #XCAT_PARTITION_END#
 
 #RAID 0 /scr for performance

--- a/xCAT-server/share/xcat/install/rh/service.rhels7.tmpl
+++ b/xCAT-server/share/xcat/install/rh/service.rhels7.tmpl
@@ -34,7 +34,7 @@ clearpart --all --initlabel
 #No RAID
 #/boot really significant for this sort of setup nowadays?
 #part /boot --size 50 --fstype ext3
-%include /tmp/partitioning
+%include /tmp/partitionfile
 #part swap --size 1024 
 #part / --size 1 --grow --fstype ext4
 #XCAT_PARTITION_END#
@@ -78,7 +78,7 @@ clearpart --all --initlabel
 #The bootloader config here is commented out
 #For user customized partition file or partition script, 
 #the bootloader configuration should be specified in the user customized partition file/script
-#For the xCAT default partition scheme, the bootloader configuration is in /tmp/partitioning
+#For the xCAT default partition scheme, the bootloader configuration is in /tmp/partitionfile
 #which is generated in %pre section
 ##KICKSTARTBOOTLOADER#
 

--- a/xCAT-server/share/xcat/install/scripts/pre.pkvm3
+++ b/xCAT-server/share/xcat/install/scripts/pre.pkvm3
@@ -21,8 +21,8 @@ if [ -e "/tmp/xcat.install_disk" ]; then
     instdisk=`cat /tmp/xcat.install_disk`
 fi
 
-echo "part PV.01 --ondisk=$instdisk" >> /tmp/partitioning
-echo "volgroup ibmpkvm_rootvg PV.01" >> /tmp/partitioning	
+echo "part PV.01 --ondisk=$instdisk" >> /tmp/partitionfile
+echo "volgroup ibmpkvm_rootvg PV.01" >> /tmp/partitionfile	
 
 if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
     set +x

--- a/xCAT-server/share/xcat/install/scripts/pre.rh
+++ b/xCAT-server/share/xcat/install/scripts/pre.rh
@@ -207,19 +207,19 @@ BOOTFSTYPE=ext3
 EFIFSTYPE=vfat
 
 if [ `uname -m` = "ppc64" ]; then
-	echo 'part None --fstype "PPC PReP Boot" --ondisk '$instdisk' --size 8' >> /tmp/partitioning 
+	echo 'part None --fstype "PPC PReP Boot" --ondisk '$instdisk' --size 8' >> /tmp/partitionfile 
 fi
 if [ -d /sys/firmware/efi ]; then 
-    echo 'bootloader --driveorder='$instdisk >> /tmp/partitioning
-	echo 'part /boot/efi --size 50 --ondisk '$instdisk' --fstype '$EFIFSTYPE >> /tmp/partitioning
+    echo 'bootloader --driveorder='$instdisk >> /tmp/partitionfile
+	echo 'part /boot/efi --size 50 --ondisk '$instdisk' --fstype '$EFIFSTYPE >> /tmp/partitionfile
 else
-    echo 'bootloader' >> /tmp/partitioning
+    echo 'bootloader' >> /tmp/partitionfile
 fi
 
 #TODO: ondisk detection, /dev/disk/by-id/edd-int13_dev80 for legacy maybe, and no idea about efi.  at least maybe blacklist SAN if mptsas/mpt2sas/megaraid_sas seen...
-echo "part /boot --size 256 --fstype $BOOTFSTYPE --ondisk $instdisk" >> /tmp/partitioning
-echo "part swap --recommended --ondisk $instdisk" >> /tmp/partitioning
-echo "part / --size 1 --grow --ondisk $instdisk --fstype $FSTYPE" >> /tmp/partitioning
+echo "part /boot --size 256 --fstype $BOOTFSTYPE --ondisk $instdisk" >> /tmp/partitionfile
+echo "part swap --recommended --ondisk $instdisk" >> /tmp/partitionfile
+echo "part / --size 1 --grow --ondisk $instdisk --fstype $FSTYPE" >> /tmp/partitionfile
 	
 #XCA_PARTITION_SCRIPT#
 

--- a/xCAT-server/share/xcat/install/scripts/pre.rh.rhels7
+++ b/xCAT-server/share/xcat/install/scripts/pre.rh.rhels7
@@ -176,32 +176,40 @@ if uname -r|grep -q '^3.*el7'; then
 fi
 
 if [ `uname -m` = "ppc64" -o `uname -m` = "ppc64le" ]; then
-	echo 'part None --fstype "PPC PReP Boot" --ondisk '$instdisk' --size 8' >> /tmp/partitioning 
+	echo 'part None --fstype "PPC PReP Boot" --ondisk '$instdisk' --size 8' >> /tmp/partitionfile 
 fi
 if [ -d /sys/firmware/efi ]; then 
-	echo 'part /boot/efi --size 50 --ondisk '$instdisk' --fstype '$EFIFSTYPE >> /tmp/partitioning
+	echo 'part /boot/efi --size 50 --ondisk '$instdisk' --fstype '$EFIFSTYPE >> /tmp/partitionfile
 fi
 
 #TODO: ondisk detection, /dev/disk/by-id/edd-int13_dev80 for legacy maybe, and no idea about efi.  at least maybe blacklist SAN if mptsas/mpt2sas/megaraid_sas seen...
-echo "part /boot --size 256 --fstype $BOOTFSTYPE --ondisk $instdisk" >> /tmp/partitioning
-echo "part swap --recommended --ondisk $instdisk" >> /tmp/partitioning
-echo "part pv.01 --size 1 --grow --ondisk $instdisk" >> /tmp/partitioning
-echo "volgroup system pv.01" >> /tmp/partitioning
-echo "logvol / --vgname=system --name=root --size 1 --grow --fstype $FSTYPE" >> /tmp/partitioning
+echo "part /boot --size 256 --fstype $BOOTFSTYPE --ondisk $instdisk" >> /tmp/partitionfile
+echo "part swap --recommended --ondisk $instdisk" >> /tmp/partitionfile
+echo "part pv.01 --size 1 --grow --ondisk $instdisk" >> /tmp/partitionfile
+echo "volgroup system pv.01" >> /tmp/partitionfile
+echo "logvol / --vgname=system --name=root --size 1 --grow --fstype $FSTYPE" >> /tmp/partitionfile
 
-#specify "bootloader" configuration in "/tmp/partitioning" if there is no user customized partition file
+#specify "bootloader" configuration in "/tmp/partitionfile" if there is no user customized partition file
 BOOTLOADER="bootloader "
-
-#specify the kernel options which will be persistent after installation
-[ -n "#ENV:PERSKCMDLINE#" ] && BOOTLOADER=$BOOTLOADER" --append=#ENV:PERSKCMDLINE#"
 
 #Specifies which drive the boot loader should be written to
 #and therefore which drive the computer will boot from.
 [ -n "$instdisk" ] && BOOTLOADER=$BOOTLOADER" --boot-drive=$(basename $instdisk)"
 
-echo "$BOOTLOADER" >> /tmp/partitioning
+echo "$BOOTLOADER" >> /tmp/partitionfile
 	
 #XCA_PARTITION_SCRIPT#
+
+#specify the kernel options which will be persistent after installation
+if [ -n "#ENV:PERSKCMDLINE#" ];then
+    #append the persistent kernel options to the lines including "bootloader --append"
+    sed -i -e /bootloader/s#\'#\"#g -e '/bootloader/s/--append=\([^"]\S*[^"]\)/--append="\1"/g' -e '/bootloader/s/--append="\(.*\)"/--append="\1 #ENV:PERSKCMDLINE#"/g' /tmp/partitionfile
+    #append the persistent kernel options to the lines including "bootloader" without "--append"
+    sed -i -e '/bootloader/{/append=/!s/$/& --append="#ENV:PERSKCMDLINE#" /}' /tmp/partitionfile
+    #append the persistent kernel options to /tmp/partitionfile if it does not include "bootloader"
+    grep bootloader /tmp/partitionfile >/dev/null 2>&1|| echo -e "bootloader --append=\"#ENV:PERSKCMDLINE#\"" >>/tmp/partitionfile
+fi
+
 
 
 # The following code is to generate the repository for the installation


### PR DESCRIPTION
fix issue:https://github.com/xcat2/xcat-core/issues/1185

1. rename /tmp/partitioning to /tmp/partitionfile to keep consistent across automatically generated partition,user-specified partitionfile, user-specified partition script
2. support persistent kernel options addkcmdline="R::" in automatically generated partition,user-specified partitionfile, user-specified partition script
