### PR TITLE
Nodeset offline for ppc64

### DIFF
--- a/docs/source/guides/admin-guides/references/man8/nodeset.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/nodeset.8.rst
@@ -19,7 +19,7 @@ Name
 ****************
 
 
-\ **nodeset**\  \ *noderange*\  [\ **boot**\  | \ **stat**\  | \ **iscsiboot**\  | \ **offline**\  | \ **runcmd=bmcsetup**\  | \ **osimage**\ [=\ *imagename*\ ] | \ **shell**\  | \ **shutdown**\ ]
+\ **nodeset**\  \ *noderange*\  [\ **boot**\  | \ **stat**\  | \ **offline**\  | \ **runcmd=bmcsetup**\  | \ **osimage**\ [=\ *imagename*\ ] | \ **shell**\  | \ **shutdown**\ ]
 
 \ **nodeset**\  \ *noderange*\  \ **osimage**\ [=\ *imagename*\ ] [\ **-**\ **-noupdateinitrd**\ ] [\ **-**\ **-ignorekernelchk**\ ]
 
@@ -50,7 +50,7 @@ Assume that /tftpboot is the root for tftpd (set in site(5)|site.5).
 
 \ **nodeset**\  only sets the next boot state, but does not reboot.
 
-\ **nodeset**\   is  called  by rinstall and winstall and is also called by the
+\ **nodeset**\   is  called  by \ **rinstall**\  and \ **winstall**\  and is also called by the
 installation process remotely to set the boot state back to "boot".
 
 A user can supply their own scripts to be run on the mn or on the service node (if a hierarchical cluster) for a node when the nodeset command is run. Such scripts are called \ **prescripts**\ . They should be copied to /install/prescripts dirctory. A table called \ *prescripts*\  is used to specify the scripts and their associated actions. The scripts to be run at the beginning of the nodeset command are stored in the 'begin' column of \ *prescripts*\  table. The scripts to be run at the end of the nodeset command are stored in the 'end' column of \ *prescripts*\  table. You can run 'tabdump -d prescripts' command for details. The following two environment variables will be passed to each script: NODES contains all the names of the nodes that need to run the script for and ACTION contains the current nodeset action. If \ *#xCAT setting:MAX_INSTANCE=number*\  is specified in the script, the script will get invoked for each node in parallel, but no more than \ *number*\  of instances will be invoked at at a time. If it is not specified, the script will be invoked once for all the nodes.
@@ -82,8 +82,8 @@ A user can supply their own scripts to be run on the mn or on the service node (
 
 \ **-**\ **-noupdateinitrd**\ 
  
- Skip the rebuilding of initrd when the 'netdrivers', 'drvierupdatesrc' or 'osupdatename' were set for injecting new drviers to initrd. But, the geninitrd command
- should be run to rebuild the initrd for new drivers injecting. This is used to improve the performance of nodeset command.
+ Skip the rebuilding of initrd when the 'netdrivers', 'drvierupdatesrc' or 'osupdatename' were set for injecting new drivers to initrd. But, the \ **geninitrd**\  command
+ should be run to rebuild the initrd for new drivers injecting. This is used to improve the performance of \ **nodeset**\  command.
  
 
 

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -461,7 +461,7 @@ Options:
 "Usage:
    Common:
       nodeset [-h|--help|-v|--version]
-      nodeset <noderange> [shell|boot|runcmd=bmcsetup|iscsiboot|osimage[=<imagename>]|offline|shutdown|stat]",
+      nodeset <noderange> [shell|boot|runcmd=bmcsetup|osimage[=<imagename>]|offline|shutdown|stat]",
   "rmflexnode" =>
 "Usage:
     rmflexnode [-h|--help|-v|--version]

--- a/xCAT-client/pods/man8/nodeset.8.pod
+++ b/xCAT-client/pods/man8/nodeset.8.pod
@@ -4,7 +4,7 @@ B<nodeset> - set the boot state for a noderange
 
 =head1 B<Synopsis>
 
-B<nodeset> I<noderange> [B<boot> | B<stat> | B<iscsiboot> | B<offline> | B<runcmd=bmcsetup> | B<osimage>[=I<imagename>] | B<shell> | B<shutdown>]
+B<nodeset> I<noderange> [B<boot> | B<stat> | B<offline> | B<runcmd=bmcsetup> | B<osimage>[=I<imagename>] | B<shell> | B<shutdown>]
 
 B<nodeset> I<noderange> B<osimage>[=I<imagename>] [B<--noupdateinitrd>] [B<--ignorekernelchk>]
 
@@ -31,7 +31,7 @@ B<nodeset> for yaboot makes changes to /tftpboot/etc/{node hex ip}
 
 B<nodeset> only sets the next boot state, but does not reboot.
 
-B<nodeset>  is  called  by rinstall and winstall and is also called by the
+B<nodeset>  is  called  by B<rinstall> and B<winstall> and is also called by the
 installation process remotely to set the boot state back to "boot".
 
 A user can supply their own scripts to be run on the mn or on the service node (if a hierarchical cluster) for a node when the nodeset command is run. Such scripts are called B<prescripts>. They should be copied to /install/prescripts dirctory. A table called I<prescripts> is used to specify the scripts and their associated actions. The scripts to be run at the beginning of the nodeset command are stored in the 'begin' column of I<prescripts> table. The scripts to be run at the end of the nodeset command are stored in the 'end' column of I<prescripts> table. You can run 'tabdump -d prescripts' command for details. The following two environment variables will be passed to each script: NODES contains all the names of the nodes that need to run the script for and ACTION contains the current nodeset action. If I<#xCAT setting:MAX_INSTANCE=number> is specified in the script, the script will get invoked for each node in parallel, but no more than I<number> of instances will be invoked at at a time. If it is not specified, the script will be invoked once for all the nodes.
@@ -55,8 +55,8 @@ Prepare server for installing a node using the specified os image. The os image 
 
 =item B<--noupdateinitrd>
 
-Skip the rebuilding of initrd when the 'netdrivers', 'drvierupdatesrc' or 'osupdatename' were set for injecting new drviers to initrd. But, the geninitrd command
-should be run to rebuild the initrd for new drivers injecting. This is used to improve the performance of nodeset command.
+Skip the rebuilding of initrd when the 'netdrivers', 'drvierupdatesrc' or 'osupdatename' were set for injecting new drivers to initrd. But, the B<geninitrd> command
+should be run to rebuild the initrd for new drivers injecting. This is used to improve the performance of B<nodeset> command.
 
 =item B<--ignorekernelchk>
 

--- a/xCAT-server/lib/xcat/plugins/grub2.pm
+++ b/xCAT-server/lib/xcat/plugins/grub2.pm
@@ -724,16 +724,16 @@ sub process_request {
         }
     }
 
-    my @makedhcp_nodes;
     if ($args[0] eq 'offline') {
+        my @rmdhcp_nodes;
         # If nodeset directive was offline we need to remove the architecture file link and remove dhcp entries
         foreach my $osimage (keys %osimagenodehash) {
             foreach my $tmp_node (@{ $osimagenodehash{$osimage} }) {
                 unlink( "$tftpdir/boot/grub2/grub2-$tmp_node");
-                push(@makedhcp_nodes, $tmp_node);
+                push(@rmdhcp_nodes, $tmp_node);
             }
         }
-        $sub_req->({ command => ['makedhcp'],arg=>['-d'], node => \@makedhcp_nodes }, $callback);
+        $sub_req->({ command => ['makedhcp'],arg=>['-d'], node => \@rmdhcp_nodes }, $callback);
     } 
 
     #now run the end part of the prescripts

--- a/xCAT-server/lib/xcat/plugins/grub2.pm
+++ b/xCAT-server/lib/xcat/plugins/grub2.pm
@@ -724,15 +724,16 @@ sub process_request {
         }
     }
 
+    my @makedhcp_nodes;
     if ($args[0] eq 'offline') {
         # If nodeset directive was offline we need to remove the architecture file link and remove dhcp entries
         foreach my $osimage (keys %osimagenodehash) {
             foreach my $tmp_node (@{ $osimagenodehash{$osimage} }) {
                 unlink( "$tftpdir/boot/grub2/grub2-$tmp_node");
-                $sub_req->({ command => ['makedhcp'],arg=>['-d'],
-                           node => \@{ $osimagenodehash{$osimage} } }, $callback);
+                push(@makedhcp_nodes, $tmp_node);
             }
         }
+        $sub_req->({ command => ['makedhcp'],arg=>['-d'], node => \@makedhcp_nodes }, $callback);
     } 
 
     #now run the end part of the prescripts

--- a/xCAT-server/lib/xcat/plugins/xnba.pm
+++ b/xCAT-server/lib/xcat/plugins/xnba.pm
@@ -532,7 +532,6 @@ sub process_request {
   my $linuximgtab=xCAT::Table->new('linuximage',-create=>1);
 
   my %machash = %{$mactab->getNodesAttribs(\@nodes,[qw(mac)])};
-  my @makedhcp_nodes;
   foreach (@nodes) {
     my $tftpdir;
     if ($nrhash{$_}->[0] and $nrhash{$_}->[0]->{tftpdir}) {
@@ -567,13 +566,12 @@ sub process_request {
         unlink($tftpdir."/xcat/xnba/nodes/".$_.".pxelinux");
         unlink($tftpdir."/xcat/xnba/nodes/".$_.".uefi");
         unlink($tftpdir."/xcat/xnba/nodes/".$_.".elilo");
-        push(@makedhcp_nodes, $_);
       }
     }
   }
   # for offline operation, remove the dhcp entries
   if ($args[0] eq 'offline') {
-      $sub_req->({ command => ['makedhcp'],arg=>['-d'],node => \@makedhcp_nodes }, $::XNBA_callback);
+      $sub_req->({ command => ['makedhcp'],arg=>['-d'],node => \@nodes }, $::XNBA_callback);
   }
 
 


### PR DESCRIPTION
This pull request fixes problem reported by issue #450.
The perl modules for handling nodeset offline for ppc64 did not remove boot configuration files in /tftpboot.
The perl modules for handling x86 were not changed. They appear to correctly remove the boot configuration files.

This pull request does the following:
1. Updates man page for **nodeset** command to remove the `iscsiboot` option
2. Removes duplicate `getstate` function definition from **petitboot.pm**
3. Removes appropriate boot configuration files from /tftpboot directory when **nodeset \<node\> offline** is issued for ppc64le virtual and ppc64le non-virtual
4. Removes dhcp entries from dhcp.leases file for nodes specified in **nodeset \<node\> offline**
5. Changes the status returned by **nodeset \<node\> stat** from `boot` to `offline` if no boot configuration file is found.

Unit test was performed against ppc64le VM and ppc64le non-VM systems. Single machine and multiples.