### PR TITLE
save the content of the partition file to xcat.log to inspect the partition scheme after installation

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/pre.rh
+++ b/xCAT-server/share/xcat/install/scripts/pre.rh
@@ -223,6 +223,11 @@ echo "part / --size 1 --grow --ondisk $instdisk --fstype $FSTYPE" >> /tmp/partit
 	
 #XCA_PARTITION_SCRIPT#
 
+#save the content of /tmp/partitionfile in /var/log/xcat/xcat.log
+#so that we can inspect the partition scheme after installation
+echo "=================The Partition Scheme================"
+cat /tmp/partitionfile
+echo "====================================================="
 
 # The following code is to generate the repository for the installation
 cat /proc/cmdline

--- a/xCAT-server/share/xcat/install/scripts/pre.rh.rhels7
+++ b/xCAT-server/share/xcat/install/scripts/pre.rh.rhels7
@@ -210,7 +210,11 @@ if [ -n "#ENV:PERSKCMDLINE#" ];then
     grep bootloader /tmp/partitionfile >/dev/null 2>&1|| echo -e "bootloader --append=\"#ENV:PERSKCMDLINE#\"" >>/tmp/partitionfile
 fi
 
-
+#save the content of /tmp/partitionfile in /var/log/xcat/xcat.log
+#so that we can inspect the partition scheme after installation
+echo "=================The Partition Scheme================"
+cat /tmp/partitionfile
+echo "====================================================="
 
 # The following code is to generate the repository for the installation
 cat /proc/cmdline


### PR DESCRIPTION
Sometimes, we need to inspect the partition scheme in the installed system
The partition scheme can be found in /var/log/xcat/xcat.log in the installed system