### PR TITLE
add powering-on status for PPC-HMC

### DIFF
--- a/perl-xCAT/xCAT/PPCboot.pm
+++ b/perl-xCAT/xCAT/PPCboot.pm
@@ -596,6 +596,10 @@ sub rnetboot {
     #
     #####################################
     if ( $data =~ /Finished/) {
+        my $newstat = $::STATUS_POWERING_ON;
+        my %newnodestatus=();
+        $newnodestatus{$newstat}=[$node];
+        xCAT_monitoring::monitorctrl::setNodeStatusAttributes(\%newnodestatus, 1);
         return( [[$node,"Success",$Rc]] );
     }
     #####################################

--- a/xCAT-server/lib/perl/xCAT/PPC.pm
+++ b/xCAT-server/lib/perl/xCAT/PPC.pm
@@ -250,32 +250,6 @@ sub process_command {
                 }
             }
             #print "oldstatus:" . Dumper(\%oldnodestatus);
-
-            #set the new status to the nodelist.status
-            my %newnodestatus=(); 
-            my $newstat;
-            if (($subcommand eq 'off') || ($subcommand eq 'softoff')) { 
-                my $newstat=$::STATUS_POWERING_OFF; 
-                $newnodestatus{$newstat}=\@allnodes;
-            } else {
-                #get the current nodeset stat
-                if (@allnodes>0) {
-                    my $nsh={};
-                    my ($ret, $msg)=xCAT::SvrUtils->getNodesetStates(\@allnodes, $nsh);
-                    if (!$ret) { 
-                        foreach (keys %$nsh) {
-                            my $newstat=xCAT_monitoring::monitorctrl->getNodeStatusFromNodesetState($_, $command);
-                            $newnodestatus{$newstat}=$nsh->{$_};
-                        }
-                    } else {
-                        trace( $request, $msg );
-                    }
-                }
-            }
-            #donot update node provision status (installing or netbooting) here
-            xCAT::Utils->filter_nostatusupdate(\%newnodestatus);
-            #print "newstatus" . Dumper(\%newnodestatus);
-            xCAT_monitoring::monitorctrl::setNodeStatusAttributes(\%newnodestatus, 1);
         }
     }
 

--- a/xCAT-server/lib/xcat/plugins/kvm.pm
+++ b/xCAT-server/lib/xcat/plugins/kvm.pm
@@ -3074,7 +3074,6 @@ sub power {
     }
 
     $newnodestatus{$newstat}=[$node];
-    xCAT::Utils->filter_nostatusupdate(\%newnodestatus);
     xCAT_monitoring::monitorctrl::setNodeStatusAttributes(\%newnodestatus, 1);
 
     unless ($retstring =~ /reset/) {


### PR DESCRIPTION
Normal: 
1. rpower node on ---> powering-on
2. rpower node off ---> powering-off
3. rpower node reset (current status is on) ---> powering-on
4. rpower node boot ---> powering-on
OS provision:
rnetboot node (after return SUCCESS) ---> powering-on --> installing --> booting --> booted