### PR TITLE
fix issue  Ubuntu Xenial: xcat-server needs to depend on openssh-server #1419 ; remove sshd from xcatd sysvinit file

### DIFF
--- a/xCAT-server/etc/init.d/xcatd
+++ b/xCAT-server/etc/init.d/xcatd
@@ -6,7 +6,7 @@
 
 ### BEGIN INIT INFO
 # Provides: xcatd
-# Required-Start: $network $syslog sshd
+# Required-Start: $network $syslog 
 # Required-Stop: 
 # Should-Start: mysql
 # Default-Start: 3 4 5


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/1419