### PR TITLE
Add mysql user to localhost account

### DIFF
--- a/xCAT-client/bin/mysqlsetup
+++ b/xCAT-client/bin/mysqlsetup
@@ -914,6 +914,7 @@ sub initmysqldb
 
         exit(1);
     }
+
 }
 
 #-----------------------------------------------------------------------------
@@ -1213,6 +1214,14 @@ sub setupxcatdb
     $grantall .= "\'";
     $grantall .= " IDENTIFIED BY \'$::adminpassword\';\r";
 
+    #GRAND user xcatadmin to localhost account
+    my $grantall_localhost= "";
+    $grantall_localhost = "GRANT ALL on xcatdb.* TO xcatadmin@";
+    $grantall_localhost .= "\'";
+    $grantall_localhost .= "localhost";
+    $grantall_localhost .= "\'";
+    $grantall_localhost .= " IDENTIFIED BY \'$::adminpassword\';\r";
+
     #
     # -re $pwd_prompt
     #     Enter the password for root
@@ -1278,6 +1287,8 @@ sub setupxcatdb
              $mysql->send("$createuser");
              $mysql->clear_accum();
              $mysql->send("$grantall");
+             $mysql->clear_accum();
+             $mysql->send("$grantall_localhost");
              $mysql->clear_accum();
              $mysql->send("exit;\r");
 


### PR DESCRIPTION
for issue #1413 , allow xcatadmin user access to localhost

the output after fixes:
````
# mysql -u xcatadmin -p
Enter password:
Welcome to the MariaDB monitor.  Commands end with ; or \g.
Your MariaDB connection id is 299
Server version: 10.0.11-MariaDB openSUSE package

Copyright (c) 2000, 2014, Oracle, SkySQL Ab and others.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

MariaDB [(none)]>
```````