### PR TITLE
fix #1409, Can't find the expected ++ logs while xcatdebugmode=1/2 for RH7.2 on x86

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels7.ppc64.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels7.ppc64.pkglist
@@ -18,6 +18,7 @@ dracut
 dracut-network
 e2fsprogs
 bc
+file
 lsvpd
 irqbalance
 procps-ng


### PR DESCRIPTION
fix #1409
It's related to the file command on the OS.
no file command -> no bash -x -> no ++ logs.