### PR TITLE
fix issue 1462: bmcsetup hang after commencing transmit of discovery …

### DIFF
--- a/xCAT-server/lib/xcat/plugins/blade.pm
+++ b/xCAT-server/lib/xcat/plugins/blade.pm
@@ -4370,7 +4370,7 @@ sub process_request {
     }
   }
   if ($request->{command}->[0] eq "findme") {
-    if (defined($request->{discoverymethod}) and defined($request->{discoverymethod}->[0]))  {
+    if (defined($request->{discoverymethod}) and defined($request->{discoverymethod}->[0]) and ($request->{discoverymethod}->[0] ne 'undef'))  {
         # The findme request had been processed by other module, just return
         return;
     }

--- a/xCAT-server/lib/xcat/plugins/hpblade.pm
+++ b/xCAT-server/lib/xcat/plugins/hpblade.pm
@@ -685,7 +685,7 @@ sub process_request {
 		}
 	}
 	if ($request->{command}->[0] eq "findme") {
-                if (defined($request->{discoverymethod}) and defined($request->{discoverymethod}->[0]))  {
+                if (defined($request->{discoverymethod}) and defined($request->{discoverymethod}->[0]) and ($request->{discoverymethod}->[0] ne 'undef'))  {
                     # The findme request had been processed by other module, just return
                     return;
                 }

--- a/xCAT-server/lib/xcat/plugins/profilednodes.pm
+++ b/xCAT-server/lib/xcat/plugins/profilednodes.pm
@@ -1816,7 +1816,7 @@ Usage:
 
 #-------------------------------------------------------
 sub findme{
-    if (defined($request->{discoverymethod}) and defined($request->{discoverymethod}->[0]))  {
+    if (defined($request->{discoverymethod}) and defined($request->{discoverymethod}->[0]) and ($request->{discoverymethod}->[0] ne 'undef'))  {
         # The findme request had been processed by other module, just return
         return;
     }

--- a/xCAT-server/lib/xcat/plugins/seqdiscovery.pm
+++ b/xCAT-server/lib/xcat/plugins/seqdiscovery.pm
@@ -54,7 +54,7 @@ sub findme {
     my @SEQdiscover = xCAT::TableUtils->get_site_attribute("__SEQDiscover");
     my @PCMdiscover = xCAT::TableUtils->get_site_attribute("__PCMDiscover");
     
-    if (defined($request->{discoverymethod}) and defined($request->{discoverymethod}->[0]))  {
+    if (defined($request->{discoverymethod}) and defined($request->{discoverymethod}->[0]) and ($request->{discoverymethod}->[0] ne 'undef'))  {
         # The findme request had been processed by other module, just return
         return;
     }

--- a/xCAT-server/lib/xcat/plugins/switch.pm
+++ b/xCAT-server/lib/xcat/plugins/switch.pm
@@ -268,7 +268,7 @@ sub process_request {
         }
         return;
     } elsif ($req->{command}->[0] eq 'findme') {
-        if (defined($req->{discoverymethod}) and defined($req->{discoverymethod}->[0]))  {
+        if (defined($req->{discoverymethod}) and defined($req->{discoverymethod}->[0]) and ($req->{discoverymethod}->[0] ne 'undef'))  {
             # The findme request had been processed by other module, just return
             return;
         }

--- a/xCAT-server/lib/xcat/plugins/typemtms.pm
+++ b/xCAT-server/lib/xcat/plugins/typemtms.pm
@@ -57,7 +57,7 @@ sub process_request {
     my $cb = shift;
     my $doreq = shift;
     if ($req->{command}->[0] eq 'findme') {
-        if (defined($req->{discoverymethod}) and defined($req->{discoverymethod}->[0]))  {
+        if (defined($req->{discoverymethod}) and defined($req->{discoverymethod}->[0]) and ($req->{discoverymethod}->[0] ne 'undef'))  {
             # The findme request had been processed by other module, just return
             return;
         }

--- a/xCAT-server/lib/xcat/plugins/zzzdiscovery.pm
+++ b/xCAT-server/lib/xcat/plugins/zzzdiscovery.pm
@@ -18,7 +18,7 @@ sub process_request {
     my $doreq = shift;
     if ($req->{command}->[0] eq 'findme') {
         xCAT::MsgUtils->message("S", "xcat.discovery.zzzdiscovery: ($req->{mtm}->[0]*$req->{serial}->[0]) Finish to process the discovery request");
-        if (!defined($req->{discoverymethod}) or !defined($req->{discoverymethod}->[0]))  {
+        if (!defined($req->{discoverymethod}) or !defined($req->{discoverymethod}->[0]) or ($req->{discoverymethod}->[0] eq 'undef'))  {
             my $rsp = {};
             $rsp->{error}->[0] = "The discovery request can not be processed";
             $cb->($rsp);


### PR DESCRIPTION
…packets
For issue #1462 
The root reason is the hardware discovery doesn't completed, then the next task bmcsetup won't run.
The pull request is to fix the issue that hardware discovery process doesn't finished. 