### PR TITLE
Fix some bugs and change -t to -T

### DIFF
--- a/xCAT-probe/lib/perl/probe_utils.pm
+++ b/xCAT-probe/lib/perl/probe_utils.pm
@@ -223,23 +223,22 @@ sub is_selinux_enable {
 
 #------------------------------------------
 sub is_firewall_open {
-    my $os = get_os();
     my $output;
     my $rst = 0;
 
-    if ($os =~ /redhat/) {
-        $output = `service iptables status 2>&1`;
-        $rst = 1 if ($output =~ /running/i);
-    } elsif ($os =~ /sles/) {
-        $output = `service SuSEfirewall2_setup status`;
-        $rst = 1 if ($output =~ /running/i);
-    } elsif ($os =~ /ubuntu/) {
-        $output = `ufw status`;
-        $rst = 1 if ($output =~ /Status: active/i);
-    }
+    my $output =`iptables -nvL -t filter 2>&1`;
+
+    `echo "$output" |grep "Chain INPUT (policy ACCEPT" > /dev/null  2>&1`;
+    $rst=1 if($?);
+
+    `echo "$output" |grep "Chain FORWARD (policy ACCEPT" > /dev/null  2>&1`;
+    $rst=1 if($?);
+
+    `echo "$output" |grep "Chain OUTPUT (policy ACCEPT" > /dev/null  2>&1`;
+    $rst=1 if($?);
+
     return $rst;
 }
-
 #------------------------------------------
 
 =head3

--- a/xCAT-probe/subcmds/detect_dhcpd
+++ b/xCAT-probe/subcmds/detect_dhcpd
@@ -29,7 +29,8 @@ Options:
     -i interface:  Required. The interface which facing the target network.
     -m macaddress: The mac that will be used to detect dhcp server. Recommend to use the real mac of the node that will be netboot. If no specified, the mac of interface which specified by -i will be used.
     -d duration:   The time to wait to detect the dhcp messages. The default value is 10s.
-    -t         :   To verify if $program_name can work, reserve option for probe framework.
+    -V verbose:    To print additional debug information. 
+    -T         :   To verify if $program_name can work, reserve option for probe framework.
 ";
 
 #---------------------------
@@ -40,7 +41,7 @@ if (!GetOptions(
         'i=s'       => \$::IF,
         'm=s'       => \$::MACADD,
         'd=s'       => \$::DURATION,
-        't'         => \$::TEST,
+        'T'         => \$::TEST,
         'V|verbose' => \$::VERBOSE,
         'h|help'    => \$::HELP,))
 {

--- a/xCAT-probe/subcmds/discovery
+++ b/xCAT-probe/subcmds/discovery
@@ -978,7 +978,7 @@ sub do_monitor {
                         chomp($line = <VARLOGMSGFILE>);
                         ++$varlogmsgcnt;
                         last if ($varlogmsgcnt <= $oldlines);
-                        my @tmp = split(/ /, $line);
+                        my @tmp = split(/\s+/, $line);
                         if ($tmp[4] =~ /dhcpd:/i && $line =~ /$nics/) {
                             handle_dhcp_msg("$line");
                         } elsif ($tmp[4] =~ /in.tftpd/i) {
@@ -1065,7 +1065,7 @@ if (defined($noderange) && !defined($discovery_type)) {
 }
 
 if (defined($discovery_type)) {
-    unless (@valid_discovery_type ~~ /^$discovery_type$/) {
+    unless (grep(/^$discovery_type$/,  @valid_discovery_type)){
         probe_utils->send_msg("$output", "f", "Invalid discovery type. the vaild types are $valid_discovery_type_str");
         probe_utils->send_msg("$output", "d", "$::USAGE");
         exit 1;

--- a/xCAT-probe/subcmds/image
+++ b/xCAT-probe/subcmds/image
@@ -21,7 +21,7 @@ my $rst     = 0;
 
 $::USAGE = "Usage:
     $program_name -h
-    $program_name -t
+    $program_name -T
     $program_name {-c|-d} [-V]
 
 Description:
@@ -30,7 +30,7 @@ Description:
 
 Options:
     -h : Get usage information of $program_name
-    -t : To verify if $program_name can work, reserve option for probe framework
+    -T : To verify if $program_name can work, reserve option for probe framework
     -d : To verify diskless, pingable compute nodes have the same images installed as defines in xCAT DB. 
     -c : To verify all diskless, pingable compute nodes have the identical images installed.
     -V : To print additional debug information.
@@ -41,7 +41,7 @@ Options:
 #-------------------------------------
 if (
     !GetOptions("--help|h" => \$help,
-        "t" => \$test,
+        "T" => \$test,
         "V" => \$VERBOSE,
         "c" => \$CONSISTENCY_CHECK,
         "d" => \$DEFINITION_CHECK))

--- a/xCAT-probe/subcmds/switch-macmap
+++ b/xCAT-probe/subcmds/switch-macmap
@@ -16,14 +16,14 @@ my $output  = "stdout";
 
 $::USAGE = "Usage:
     $proname -h
-    $proname -t
+    $proname -T
     $proname  <noderange> [-c] [-V]
 
 Description:
     To retrieve MAC address mapping for the specified switch, or all the switches defined in switches table in xCAT db.
 
 Options:
-    -t: Check whether this script is OK to run.
+    -T: Check whether this script is OK to run.
     -c: To check whether the switch is OK to retrieve MAC address mapping.
     -V: Output verbose information when accessing switch
 ";
@@ -34,7 +34,7 @@ my $check;
 my @nodes = ();
 my $verbose = '';
 if (!GetOptions("help|h" => \$help, 
-                "t" => \$test,
+                "T" => \$test,
                 "c" => \$check,
                 "V" => \$verbose)) {
     probe_utils->send_msg("$output", "f", "Option not support");

--- a/xCAT-probe/subcmds/xcatmn
+++ b/xCAT-probe/subcmds/xcatmn
@@ -18,15 +18,15 @@ my $rst     = 0;
 
 $::USAGE = "Usage:
     $proname -h
-    $proname -t
-    $proname [-n] <install_nic> [-V]
+    $proname -T
+    $proname [-n <install_nic>] [-V]
 
 Description:
     After xcat installation, use this command to check if xcat has been installed correctly and is ready for use. 
 
 Options:
     -h : Get usage information of $proname
-    -t : To verify if $proname can work, reserve option for probe framework
+    -T : To verify if $proname can work, reserve option for probe framework
     -n : Required. Specify the network interface name of provision network
     -V : Output more information for debug
 ";
@@ -46,7 +46,7 @@ sub returncmdoutput {
 #-------------------------------------
 if (
     !GetOptions("--help|h" => \$help,
-        "t"   => \$test,
+        "T"   => \$test,
         "V"   => \$verbose,
         "n=s" => \$installnic))
 {
@@ -354,8 +354,7 @@ if (probe_utils->is_selinux_enable()) {
 
 $msg = "Firewall is closed on current server";
 if (probe_utils->is_firewall_open()) {
-    probe_utils->send_msg("$output", "f", "$msg");
-    $rst = 1;
+    probe_utils->send_msg("$output", "w", "Firewall is configured on current server");
 } else {
     probe_utils->send_msg("$output", "o", "$msg");
 }

--- a/xCAT-probe/xcatprobe
+++ b/xCAT-probe/xcatprobe
@@ -61,7 +61,7 @@ sub loadsubcmds {
             next;
         } else {
             my $desc = $2;
-            unless ($1 ~~ /^ok$/) {
+            unless ($1 =~ /^ok$/) { 
                 print "skip $_ for doing '$_ -T' failed, invalid flag\n" if ($verbose);
                 next;
             }
@@ -233,7 +233,7 @@ my $pluginname;
 my $optnum = 0;
 foreach my $attr (@tmpargv) {
     if ($attr =~ /^-/) {
-        unless (@supportopt ~~ /^$attr$/) {
+        unless (grep(/^$attr$/,  @supportopt)){
             print "Unsupported attribute: $attr\n";
             print $::USAGE;
             exit 1;


### PR DESCRIPTION
This pull request include below changing:
1 change all sub-command option ``t`` to ``T``.
2 fix below bugs:
#1458 [DEV]Error when discovery filter dhcpd message
#1378[fvt]2.12.1 SuSEfirewall2 check wrong on suse and ubuntu using "xcatprobe xcatmn"
#1377[fvt]2.12.1 "Smartmatch is experimental" warning in perl5.8.2 while using xcatprobe