### PR TITLE
Fix issue 1468, modified to check the value of array element

### DIFF
--- a/xCAT-server/lib/xcat/plugins/kvm.pm
+++ b/xCAT-server/lib/xcat/plugins/kvm.pm
@@ -3899,7 +3899,7 @@ sub forward_data {
 
                 #save the nodes that has errors and the ones that has no-op for use by the node status monitoring
                 my $no_op = 0;
-                if ($_->{node}->[0]->{errorcode}) { $no_op = 1; }
+                if ($_->{node}->[0]->{errorcode}->[0]) { $no_op = 1; }
                 else {
                     my $text = $_->{node}->[0]->{data}->[0]->{contents}->[0];
 


### PR DESCRIPTION
#1468 
Now the hash of response array element is just like this. So modified to check the errorcode value of array element.
```
$VAR1 = {
          'node' => [
                      {
                        'errorcode' => [
                                                    0
                                            ],
                        'name' => [
                                    'c910f03c17k17'
                                  ],
                        'data' => [
                                    {
                                      'contents' => [
                                                      'off'
                                                    ]
                                    }
                                  ]
                      }
                    ]
        };
```