### PR TITLE
Make xcat-porbe as xCAT's dependency to install xcat-porbe during xCAT installation

### DIFF
--- a/xCAT/debian/control
+++ b/xCAT/debian/control
@@ -7,6 +7,6 @@ Standards-Version: 3.7.2
 
 Package: xcat
 Architecture: amd64 ppc64el
-Depends: ${perl:Depends}, xcat-server, xcat-client, libdbd-sqlite3-perl, isc-dhcp-server, apache2, nfs-kernel-server, nmap, bind9, libxml-parser-perl, xinetd, tftpd-hpa, tftp-hpa, conserver-xcat, libnet-telnet-perl, ipmitool-xcat (>=1.8.9), syslinux[any-amd64], libsys-virt-perl, syslinux-xcat[any-amd64], xnba-undi, xcat-genesis-scripts, elilo-xcat, xcat-buildkit
+Depends: ${perl:Depends}, xcat-server, xcat-client, libdbd-sqlite3-perl, isc-dhcp-server, apache2, nfs-kernel-server, nmap, bind9, libxml-parser-perl, xinetd, tftpd-hpa, tftp-hpa, conserver-xcat, libnet-telnet-perl, ipmitool-xcat (>=1.8.9), syslinux[any-amd64], libsys-virt-perl, syslinux-xcat[any-amd64], xnba-undi, xcat-genesis-scripts, elilo-xcat, xcat-buildkit, xcat-probe (>=2.12)
 Description: Server and configuration utilities of the xCAT management project
  xcat-server provides the core server and configuration management components of xCAT.  This package should be installed on your management server

--- a/xCAT/xCAT.spec
+++ b/xCAT/xCAT.spec
@@ -25,7 +25,7 @@ Source7: xcat.conf.apach24
 
 Provides: xCAT = %{version}
 Conflicts: xCATsn
-Requires: xCAT-server xCAT-client perl-DBD-SQLite
+Requires: xCAT-server xCAT-client perl-DBD-SQLite xCAT-probe >= 2.12.1
 
 %define pcm %(if [ "$pcm" = "1" ];then echo 1; else echo 0; fi)
 %define notpcm %(if [ "$pcm" = "1" ];then echo 0; else echo 1; fi)


### PR DESCRIPTION
In order to install xcat-porbe during xCAT installation, now make xcat-probe as xCAT's dependency.