### PR TITLE
Small grammar and formatting fixes for mkdef command

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/mkdef.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/mkdef.1.rst
@@ -84,7 +84,7 @@ OPTIONS
 
 \ **-**\ **-template**\  \ *template-object-name*\ 
  
- Name of the xCAT shipped object definition template or an existing object, from which the new object definition will be created from. The newly created object will inherit the attributes of the template definition unless the attribute is specified in the arguments of \ **mkdef**\  command. If there are an existing object and a template with the same name \ *template-object-name*\ , the existing object takes precedence over the object definition template. For the details of xCAT shipped object definition templates, please refer to the manpage of \ **-**\ **-template**\  option in lsdef(1)|lsdef.1.
+ Name of the xCAT shipped object definition template or an existing object, from which the new object definition will be created. The newly created object will inherit the attributes of the template definition unless the attribute is specified in the arguments of \ **mkdef**\  command. If there are an existing object and a template with the same name \ *template-object-name*\ , the existing object takes precedence over the object definition template. For the details of xCAT shipped object definition templates, refer to the manpage of \ **-**\ **-template**\  option in lsdef(1)|lsdef.1.
  
 
 
@@ -286,7 +286,7 @@ EXAMPLES
  
 
 
-13
+13.
  
  To create a PowerLE kvm node definition with the xCAT shipped template "ppc64lekvmguest-template".
  
@@ -298,7 +298,7 @@ EXAMPLES
  
 
 
-14
+14.
  
  To create a node definition from an existing node definition "cn1"
  

--- a/xCAT-client/pods/man1/mkdef.1.pod
+++ b/xCAT-client/pods/man1/mkdef.1.pod
@@ -50,7 +50,7 @@ A set of comma delimited object types.  Use the help option to get a list of val
 
 =item B<--template> I<template-object-name>
 
-Name of the xCAT shipped object definition template or an existing object, from which the new object definition will be created from. The newly created object will inherit the attributes of the template definition unless the attribute is specified in the arguments of B<mkdef> command. If there are an existing object and a template with the same name I<template-object-name>, the existing object takes precedence over the object definition template. For the details of xCAT shipped object definition templates, please refer to the manpage of B<--template> option in L<lsdef(1)|lsdef.1>.
+Name of the xCAT shipped object definition template or an existing object, from which the new object definition will be created. The newly created object will inherit the attributes of the template definition unless the attribute is specified in the arguments of B<mkdef> command. If there are an existing object and a template with the same name I<template-object-name>, the existing object takes precedence over the object definition template. For the details of xCAT shipped object definition templates, refer to the manpage of B<--template> option in L<lsdef(1)|lsdef.1>.
 
 =item B<-V|--verbose>
 
@@ -167,13 +167,13 @@ To create an osimage definition and fill in attributes automatically.
 
  mkdef redhat6img -u profile=compute provmethod=statelite
 
-=item 13
+=item 13.
 
 To create a PowerLE kvm node definition with the xCAT shipped template "ppc64lekvmguest-template".
 
  mkdef -t node cn1 --template ppc64lekvmguest-template ip=1.1.1.1 mac=42:3d:0a:05:27:0b vmhost=1.1.0.1 vmnics=br0
 
-=item 14
+=item 14.
 
 To create a node definition from an existing node definition "cn1"
 


### PR DESCRIPTION
1. Fix wording for the `--template` description
2. Fix formatting of `--template` examples