### PR TITLE
issue 1493, we made a change that include the updateflag from /instal…

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/chroot.sles
+++ b/xCAT-server/share/xcat/install/scripts/chroot.sles
@@ -22,19 +22,21 @@ fi
 
 AWK=`find / -name awk | head -1`
 #old awk /mounts/instsys/bin/awk -f
-
+if [ ! -e /usr/bin/awk ]; then
+    ln -s $AWK /usr/bin/awk
+fi
 
 XCATDPORT=#TABLE:site:key=xcatiport:value#
 XCATDHOST="#XCATVAR:XCATMASTER#"
 
-(cat >/tmp/updateflag.awk << 'EOF'
+(cat >/tmp/updateflag << 'EOF'
 #INCLUDE:#TABLE:site:key=installdir:value#/postscripts/updateflag.awk#
 EOF
-) >/tmp/updateflag.awk 
+) >/tmp/updateflag 
 
-chmod 755 /tmp/updateflag.awk
+chmod 755 /tmp/updateflag
 
-/tmp/updateflag.awk $XCATDHOST $XCATDPORT
+/tmp/updateflag $XCATDHOST $XCATDPORT
 
 export PRINIC=#TABLEBLANKOKAY:noderes:THISNODE:primarynic#
 if [ "$PRINIC" == "mac" ]

--- a/xCAT-server/share/xcat/install/scripts/pre.sles
+++ b/xCAT-server/share/xcat/install/scripts/pre.sles
@@ -18,7 +18,9 @@ fi
 
 AWK=`find / -name awk | tail -1`
 #old awk /mounts/instsys/bin/awk -f
-
+if [ ! -e /usr/bin/awk ]; then
+    ln -s $AWK /usr/bin/awk
+fi
 
 XCATDPORT=#TABLE:site:key=xcatiport:value#
 XCATDHOST="#XCATVAR:XCATMASTER#"


### PR DESCRIPTION
…l/postscripts/updateflag.awk. But the shebang in /install/postscripts/updateflag.awk points to the /usr/bin/awk which does not exist in sles11.x installer. This fix is to make a link to the installer shipped awk.