### PR TITLE
xCAT-server: Fix exclude list for RH7 - Vim >= 7.4

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels7.ppc64.exlist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels7.ppc64.exlist
@@ -28,7 +28,7 @@
 ./usr/share/man*
 ./usr/share/omf*
 ./usr/share/vim/site/doc*
-./usr/share/vim/vim72/doc*
+./usr/share/vim/vim74/doc*
 ./usr/share/zoneinfo*
 ./var/cache/man*
 ./var/lib/yum*

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels7.x86_64.exlist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels7.x86_64.exlist
@@ -28,7 +28,7 @@
 ./usr/share/man*
 ./usr/share/omf*
 ./usr/share/vim/site/doc*
-./usr/share/vim/vim72/doc*
+./usr/share/vim/vim74/doc*
 ./usr/share/zoneinfo*
 ./var/cache/man*
 ./var/lib/yum*


### PR DESCRIPTION
Exclude lists are outdated. RH7 has Vim-minimal-7.4-*, not Vim-minimal-7.2-*