### PR TITLE
Only try to kill ssl listener process at first

### DIFF
--- a/xCAT-server/etc/init.d/xcatd
+++ b/xCAT-server/etc/init.d/xcatd
@@ -101,7 +101,7 @@ stop)
     echo
     exit 0
   fi
-  kill -TERM -`cat /var/run/xcatd.pid`
+  kill -TERM `cat /var/run/xcatd.pid`
   i=0;
   while $STATUS > /dev/null 2>&1 && [ $i -lt 30 ]; do
     sleep .1


### PR DESCRIPTION
Previously service xcatd stop or systemctl stop xcatd.service
will send TERM signal to all the processes of xcatd on some
platform which support this feature.

Close-issue: #1008 #537