### PR TITLE
Fix xcatprobe issue, discovery and osdeploy

### DIFF
--- a/xCAT-probe/subcmds/discovery
+++ b/xCAT-probe/subcmds/discovery
@@ -86,8 +86,8 @@ sub check_genesis_file {
         probe_utils->send_msg("$output", "d", "The OS is not supported.") if ($verbose);
         return 1;
     } elsif ($os =~ "ubuntu") {
-        $genesis_base = `dpkg -l | grep -i "xcat-genesis-base" | grep -i "$arch_tmp"`;
-        $genesis_scripts = `dpkg -l | grep -i "xcat-genesis-scripts" | grep -i "$arch_tmp"`;
+        $genesis_base = `dpkg -l | grep -iE "ii\\s+xcat-genesis-base" | grep -i "$arch_tmp"`;
+        $genesis_scripts = `dpkg -l | grep -iE "ii\\s+xcat-genesis-scripts" | grep -i "$arch_tmp"`;
     } else {
         $genesis_base = `rpm -qa | grep -i "xcat-genesis-base" | grep -i "$arch"`;
         $genesis_scripts = `rpm -qa | grep -i "xcat-genesis-scripts" | grep -i "$arch"`;
@@ -267,6 +267,55 @@ sub check_genesis_file {
     return $rst_f;
 }
 
+sub get_node_ip {
+    my $ip_net;
+    my @node_info = `lsdef $noderange -i ip -c 2>&1`;
+    my %nodeip;
+    my %nodecheckrst;
+
+    foreach (@node_info) {
+        chomp($_);
+        $_ =~ s/^\s+|\s+$//g;
+        if ($_ =~ /^Error: Could not find an object named '(\w+)' .+/i) {
+            $nodecheckrst{$1}{"error"} = "Could not find node definition";
+            $rst = 1;
+        } elsif ($_ =~ /^(\w+): ip=(.+)/i) {
+            $nodeip{$1} = $2;
+        }
+    }
+
+    foreach my $node (keys %nodeip) {
+        $ip_net = xCAT::NetworkUtils->getipaddr($node);
+        if ($nodeip{$node} and ($nodeip{$node} ne $ip_net)) {
+            probe_utils->send_msg("$output", "d", "IP $nodeip{$node} of definition for $node is not correct") if ($verbose);
+        }
+        $nodeip{$node} = $ip_net;
+    }
+
+    foreach my $node (keys %nodecheckrst) {
+        probe_utils->send_msg("$output", "d", "$node : $nodecheckrst{$node}{error}") if(exists($nodecheckrst{$node}{error}));
+    }
+
+    return %nodeip;
+}
+
+sub compare_ip_value {
+    my $ip1 = shift;
+    my $ip2 = shift;
+
+    my @ip_arr1 = split(/\./, $ip1);
+    my @ip_arr2 = split(/\./, $ip2);
+
+    my $ip_num1 = ($ip_arr1[0] << 24) | ($ip_arr1[1] << 16) | ($ip_arr1[2] << 8) | $ip_arr1[3];
+    my $ip_num2 = ($ip_arr2[0] << 24) | ($ip_arr2[1] << 16) | ($ip_arr2[2] << 8) | $ip_arr2[3];
+
+    if ($ip_num1 <= $ip_num2) {
+        return 1;
+    }
+
+    return 0;
+}
+
 #------------------------------------------
 
 =head3
@@ -291,6 +340,8 @@ sub dhcp_dynamic_range_check {
         $dhcpconfig = "/etc/dhcp/dhcpd.conf";
     } elsif (-e "/etc/dhcp3/dhcpd.conf") {
         $dhcpconfig = "/etc/dhcp3/dhcpd.conf";
+    } elsif (-e "/etc/dhcpd.conf") {
+        $dhcpconfig = "/etc/dhcpd.conf";
     }
 
     unless ($dhcpconfig) {
@@ -300,7 +351,7 @@ sub dhcp_dynamic_range_check {
 
     my $config_line;
     my $subnet;
-    my $dynamic_range;
+    my @dynamic_range;
     my %subnet_hash;
 
     unless (open(FILE, $dhcpconfig)) {
@@ -318,12 +369,17 @@ sub dhcp_dynamic_range_check {
             $subnet_hash{$subnet} = "unknown";
         }
         if ($config_line =~ /subnet_end/) {
-            $subnet_hash{$subnet} = $dynamic_range if ($dynamic_range);
+            $subnet_hash{$subnet} = [@dynamic_range] if (@dynamic_range);
             $subnet               = "";
-            $dynamic_range        = "";
+            @dynamic_range        = "";
         }
         if ($config_line =~ /^range dynamic-bootp (\d+.\d+.\d+.\d+) (\d+.\d+.\d+.\d+)/) {
-            $dynamic_range = "$1-$2";
+            if (compare_ip_value($1, $2)) {
+                push @dynamic_range, "$1-$2";
+            } else {
+                push @dynamic_range, "$2-$1";
+            }
+            
         }
     }
 
@@ -340,6 +396,11 @@ sub dhcp_dynamic_range_check {
         $tftpdir = "/tftpboot";
     }
 
+    my %node_ip;
+    if ($noderange) {
+        %node_ip = get_node_ip();
+    }
+
     foreach my $net (@$nets) {
 
         if (!exists($subnet_hash{$net})) {
@@ -349,7 +410,20 @@ sub dhcp_dynamic_range_check {
         }
 
         if ($subnet_hash{$net} ne "unknown") {
-            probe_utils->send_msg("$output", "d", "Dynamic range for net $net is $subnet_hash{$net}.") if ($verbose);
+            probe_utils->send_msg("$output", "d", "Dynamic range for net $net is @{$subnet_hash{$net}}.") if ($verbose);
+
+            if (%node_ip) {
+               foreach my $node (keys %node_ip) {
+                   foreach my $dr (@{$subnet_hash{$net}}) {
+                       my @dr_ip = split(/-/, $dr);
+
+                       if (compare_ip_value($dr_ip[0], $node_ip{$node}) and compare_ip_value($node_ip{$node}, $dr_ip[1])) {
+                           probe_utils->send_msg("$output", "d", "$node ip $node_ip{$node} is conflicting with dynamic range.") if ($verbose);
+                           $rst = 1;
+                       }
+                   }
+               }
+            }
         } else {
             probe_utils->send_msg("$output", "d", "Dynamic range for net $net did not be configured.") if ($verbose);
             $rst = 1;

--- a/xCAT-probe/subcmds/osdeploy
+++ b/xCAT-probe/subcmds/osdeploy
@@ -14,14 +14,14 @@ use Getopt::Long qw(:config no_ignore_case);
 my $program_name = basename("$0");
 my $help;
 my $test;
-my $output    = "stdout";
-my $verbose   = 0;
-my $rst       = 0;
+my $output  = "stdout";
+my $verbose = 0;
+my $rst     = 0;
 my $noderange;
 my %rawdata;
 my %ipnodemap;
 my %macmap;
-my $terminal  = 0;
+my $terminal = 0;
 my %monitor_nodes;
 
 $::USAGE = "Usage:
@@ -40,7 +40,19 @@ Options:
     -n : The range of monitored node.
 ";
 
-sub check_noderange{
+#------------------------------------------
+=head3
+    Description:
+        Check if all nodes are valid
+    Arguments:
+        node_range: node range
+    Returns:
+        0 : pass
+        1 : failed
+=cut
+
+#------------------------------------------
+sub check_noderange {
     my $node_range  = shift;
     my @cmdoutput   = `lsdef $node_range -i ip,mac 2>&1`;
     my $rst         = 0;
@@ -58,30 +70,34 @@ sub check_noderange{
             $nodecheckrst{$currentnode}{"error"} = "Could not find node definition";
             $rst = 1;
         } elsif ($_ =~ /^\s*Object name: (\w+)/i) {
-            $monitor_nodes{$1} = 0; 
-            $currentnode = $1;
-            $ip = "NOIP";
+            # 'rst' is used to check whether the node process finished, 1 is finished.
+            $monitor_nodes{$1}{"rst"} = 0;
+            $currentnode              = $1;
+            $ip                       = "NOIP";
         } elsif ($_ =~ /^ip=(.+)/i) {
-            $ip = $1;
+            if ($1) {
+                $ip = $1;
+            }
         } elsif ($_ =~ /^mac=(.+)/i) {
+            next unless ($1);
             $mac_line = $1;
             @macs = split(/\|/, $mac_line);
-            foreach my $mac(@macs) {
+            foreach my $mac (@macs) {
                 if ($mac =~ /\!\*NOIP\*/) {
                     $mac =~ s/\!\*NOIP\*//g;
-                    $macmap{$mac}{"ip"} = "NOIP";
+                    $macmap{$mac}{"ip"}   = "NOIP";
                     $macmap{$mac}{"node"} = $currentnode;
                 }
                 else {
-                    $macmap{$mac}{"ip"} = $ip;
+                    $macmap{$mac}{"ip"}   = $ip;
                     $macmap{$mac}{"node"} = $currentnode;
                 }
             }
         }
-    }   
+    }
 
     foreach my $node (keys %nodecheckrst) {
-        probe_utils->send_msg("$output", "d", "$node : $nodecheckrst{$node}{error}") if(exists($nodecheckrst{$node}{error}));
+        probe_utils->send_msg("$output", "d", "$node : $nodecheckrst{$node}{error}") if (exists($nodecheckrst{$node}{error}));
     }
 
     unless (%monitor_nodes) {
@@ -91,31 +107,45 @@ sub check_noderange{
     return $rst;
 }
 
+#------------------------------------------
+
+=head3
+    Description:
+       Handle one line log come from dhcp log file
+    Arguments:
+       msg: one line http log
+       nics: target network interfaces
+    Returns:
+        0 : pass
+        1 : failed
+=cut
+
+#------------------------------------------
 sub handle_dhcp_msg {
     my $msg = shift;
 
-    if ($msg =~ /.+DHCPDISCOVER\s+from\s+(.+)\s+via\s+([^:]+)(.*)/i) { 
-        my $mac    = $1;
-        my $nic    = $2;
+    if ($msg =~ /.+DHCPDISCOVER\s+from\s+(.+)\s+via\s+([^:]+)(.*)/i) {
+        my $mac = $1;
+        my $nic = $2;
 
         if (exists $macmap{$mac}) {
-            my $node = $macmap{$mac}{"node"};
+            my $node   = $macmap{$mac}{"node"};
             my $record = "Receive DHCPDISCOVER from [$node] $mac via $nic";
             probe_utils->send_msg("$output", "d", "$record");
             push(@{ $rawdata{$node}{"history"} }, $record);
         }
     } elsif ($msg =~ /.+DHCPOFFER\s+on\s+(.+)\s+to\s+(.+)\s+via\s+(.+)/i) {
-        my $ip     = $1;
-        my $mac    = $2;
-        my $nic    = $3;
+        my $ip  = $1;
+        my $mac = $2;
+        my $nic = $3;
 
         if (exists $macmap{$mac}) {
-            my $node = $macmap{$mac}{"node"};
+            my $node   = $macmap{$mac}{"node"};
             my $record = "Send DHCPOFFER on $ip back to [$node] $mac via $nic";
             probe_utils->send_msg("$output", "d", "$record");
             push(@{ $rawdata{$node}{"history"} }, $record);
         }
-        
+
     } elsif ($msg !~ /unknown lease/ && $msg !~ /ignored/ && $msg =~ /.+DHCPREQUEST\s+for\s+(.+)\s\((.+)\)\s+from\s+(.+)\s+via\s+(.+)/) {
         my $ip     = $1;
         my $server = $2;
@@ -125,7 +155,7 @@ sub handle_dhcp_msg {
         if (exists $macmap{$mac}) {
             my $node = $macmap{$mac}{"node"};
             my $record = "Receive DHCPREQUEST from [$node] $mac for $ip via $nic";
-            probe_utils->send_msg("$output", "d", "$record");           
+            probe_utils->send_msg("$output", "d", "$record");
             push(@{ $rawdata{$node}{"history"} }, $record);
 
             if ($macmap{$mac}{"ip"} != "NOIP" and $macmap{$mac}{"ip"} != $ip) {
@@ -135,9 +165,9 @@ sub handle_dhcp_msg {
             }
         }
     } elsif ($msg =~ /.+DHCPACK\s+on\s+(.+)\s+to\s+(.+)\s+via\s+(.+)/) {
-        my $ip     = $1;
-        my $mac    = $2;
-        my $nic    = $3;
+        my $ip  = $1;
+        my $mac = $2;
+        my $nic = $3;
 
         if (exists $macmap{$mac}) {
             my $node   = $macmap{$mac}{"node"};
@@ -157,12 +187,12 @@ sub handle_dhcp_msg {
             push(@{ $rawdata{$node}{"history"} }, $record);
         }
     } elsif ($msg =~ /.+BOOTREPLY\s+for\s+(.+)\s+to\s+.+(\w\w:\w\w:\w\w:\w\w:\w\w:\w\w).+via\s+(.+)/) {
-        my $ip     = $1;
-        my $mac    = $2;
-        my $nic    = $3;
+        my $ip  = $1;
+        my $mac = $2;
+        my $nic = $3;
 
         if (exists $macmap{$mac}) {
-            my $node = $macmap{$mac}{"node"};
+            my $node   = $macmap{$mac}{"node"};
             my $record = "Send BOOTREPLY on $ip back to [$node] $mac via $nic";
             probe_utils->send_msg("$output", "d", "$record");
             push(@{ $rawdata{$node}{"history"} }, $record);
@@ -179,13 +209,54 @@ sub handle_dhcp_msg {
     return 0;
 }
 
+#------------------------------------------
+
+=head3
+    Description:
+       Handle one line log come from tftp log file
+    Arguments:
+       msg: one line tftp log
+    Returns:
+        0 : pass
+        1 : failed
+=cut
+
+#------------------------------------------
+sub handle_tftp_msg {
+    my $msg = shift;
+
+    if ($msg =~ /RRQ\s+from\s+(.+)\s+filename\s+(.+)/i) {
+        my $ip     = $1;
+        my $file   = $2;
+        my $record = "[$ipnodemap{$ip}] Via TFTP $ip download $file";
+
+        if (exists($rawdata{"$ipnodemap{$ip}"})) {
+            probe_utils->send_msg("$output", "d", "$record");
+            push(@{ $rawdata{ $ipnodemap{$ip} }{"history"} }, $record);
+        }
+    }
+}
+
+#------------------------------------------
+
+=head3
+    Description:
+       Handle one line log come from http log file
+    Arguments:
+       msg: one line http log
+    Returns:
+        0 : pass
+        1 : failed
+=cut
+
+#------------------------------------------
 sub handle_http_msg {
     my $msg = shift;
     if ($msg =~ /(\d+\.\d+.\d+.\d+)\s.+GET\s+(.+)\s+HTTP.+/) {
         my $ip     = $1;
         my $file   = $2;
         my $record = "[$ipnodemap{$ip}] Via HTTP $ip GET $file";
-        
+
         if (exists($rawdata{"$ipnodemap{$ip}"})) {
             probe_utils->send_msg("$output", "d", "$record");
             push(@{ $rawdata{ $ipnodemap{$ip} }{"history"} }, $record);
@@ -194,50 +265,73 @@ sub handle_http_msg {
     return 0;
 }
 
+#------------------------------------------
+
+=head3
+    Description:
+       Handle one line log come from cluster.log
+    Arguments:
+       msg: one line log
+    Returns:
+        0 : pass
+        1 : failed
+=cut
+
+#------------------------------------------
 sub handle_cluster_msg {
-    my $line   = shift;
-    my $sender = "";
-    my $node     = "";
+    my $line = shift;
+    my $node = "";
     my $msg;
     my $status;
 
-    if ($line =~ /.+\d{2}:\d{2}:\d{2}\s+(.+)\s+(xcat.+)/i) {
-        $sender = $1;
-        $msg    = $2;
-
-        if (!xCAT::NetworkUtils->isIpaddr($sender)) {
-            $node = $sender;
-        } else {
-            $node = $ipnodemap{$sender};
-        }
-        if ($node ne "" && exists($rawdata{$node})) {
-            my $record = "Receive from $node : $msg";
-            probe_utils->send_msg("$output", "d", "$record");
-            push(@{ $rawdata{ $node }{"history"} }, $record);
-        }
-    }
-
     if ($line =~ /.+\s+xcat:\s+(.+)\s+status:\s+(.+)\s+statustime:\s(.+)/) {
-        $node = $1;
+        $node   = $1;
         $status = $2;
 
         if (exists($rawdata{$node})) {
             my $record = "Receive from $node : status is $status";
             probe_utils->send_msg("$output", "d", "$record");
-            push(@{ $rawdata{ $node }{"history"} }, $record);
+            push(@{ $rawdata{$node}{"history"} }, $record);
         }
-        
+
+        # When receive 'status is booted', check whether the $monitor_nodes{$node}{"status"} is installing.
+        # If so, the node has finished its os provision.
         if (exists($rawdata{$node}) and ($status eq "booted")) {
-            $monitor_nodes{$node} = 1 if (defined($monitor_nodes{$node}));
-            probe_utils->send_msg("$output", "o", "Node $node has finished it's os provision process");
+            if ($monitor_nodes{$node}{"status"} eq "installing") {
+                $record = "Node $node has finished it's os provision process";
+                probe_utils->send_msg("$output", "o", "$record");
+                push(@{ $rawdata{$node}{"history"} }, $record);
+            } else {
+                $record = "NO installing process detected for node $node";
+                probe_utils->send_msg("$output", "f", "$record");
+                push(@{ $rawdata{$node}{"history"} }, $record);
+            }
+            $monitor_nodes{$node}{"rst"} = 1 if (defined($monitor_nodes{$node}));
         } elsif (exists($rawdata{$node}) and ($status eq "failed")) {
-            $monitor_nodes{$node} = 1 if (defined($monitor_nodes{$node}));
+            $monitor_nodes{$node}{"rst"} = 1 if (defined($monitor_nodes{$node}));
             probe_utils->send_msg("$output", "f", "Node $node has finished it's os provision process");
+            push(@{ $rawdata{$node}{"history"} }, "Node $node os provision failed");
+        } elsif (exists($rawdata{$node}) and ($status eq "installing")) {
+            # record 'installing' status, to check when receive 'booted' status 
+            $monitor_nodes{$node}{"status"} = "installing";
         }
     }
     return 0;
 }
 
+#-----------------------------------------
+
+=head3
+    Description:
+       Handle one line log come from computes.log
+    Arguments:
+       msg: one line compute log
+    Returns:
+        0 : pass
+        1 : failed
+=cut
+
+#-----------------------------------------
 sub handle_compute_msg {
     my $line = shift;
     my $sender;
@@ -256,25 +350,50 @@ sub handle_compute_msg {
         if ($node ne "" && exists($rawdata{$node})) {
             my $record = "Receive from $node : $msg";
             probe_utils->send_msg("$output", "d", "$record");
-            push(@{ $rawdata{ $node }{"history"} }, $record);
+            push(@{ $rawdata{$node}{"history"} }, $record);
         }
     }
 
     return 0;
 }
 
+#------------------------------------------
+
+=head3
+    Description:
+       Test if all nodes have finished job
+    Arguments:
+       One golble attribute %monitor_nodes;
+    Returns:
+       1: all nodes finished
+       0: not all nodes finished
+=cut
+
+#------------------------------------------
 sub all_monitor_node_done {
     my $done = 1;
+
     foreach my $node (keys %monitor_nodes) {
-        if ($monitor_nodes{$node} == 0) {
+        if ($monitor_nodes{$node}{"rst"} == 0) {
             $done = 0;
             last;
         }
     }
-    
+
     return $done;
 }
 
+#------------------------------------------
+
+=head3
+    Description:
+       Dump monitor history,  categorised by mac address.
+    Arguments:
+       NULL
+    Returns:
+=cut
+
+#------------------------------------------
 sub dump_history {
 
     my $title = "
@@ -288,20 +407,21 @@ sub dump_history {
         my $line_num = 0;
         my $http_num = 0;
         my $length_http;
-        for (my $i = @{ $rawdata{$node}{"history"} }; $i >=0; $i--) {
+        for (my $i = @{ $rawdata{$node}{"history"} } ; $i >= 0 ; $i--) {
             if (${ $rawdata{$node}{"history"} }[$i] =~ /Via HTTP/) {
                 $length_http = $i;
                 last;
             }
         }
         foreach my $line (@{ $rawdata{$node}{"history"} }) {
+
             # Print http message less than 10 lines
             if ($line =~ /Via HTTP/)
             {
-                if (($http_num <= 4) or ($length_http - $line_num <= 4)){
+                if (($http_num <= 4) or ($length_http - $line_num <= 4)) {
                     probe_utils->send_msg("$output", "d", "\t$line");
                 } else {
-                    probe_utils->send_msg("$output", "d", "\t......") if ($http_num ==5);
+                    probe_utils->send_msg("$output", "d", "\t......") if ($http_num == 5);
                 }
                 $http_num++;
             } else {
@@ -312,13 +432,24 @@ sub dump_history {
     }
 }
 
-sub do_monitor{
+#------------------------------------------
+
+=head3
+    Description:
+       Monitor the process of os provision
+    Returns:
+        0: pass
+        1: failed
+=cut
+
+#------------------------------------------
+sub do_monitor {
     $SIG{TERM} = $SIG{INT} = sub {
         $terminal = 1;
     };
 
     my $msg = "All pre_defined nodes are valid";
-    my $rc = check_noderange($noderange);
+    my $rc  = check_noderange($noderange);
     if ($rc) {
         probe_utils->send_msg("$output", "f", $msg);
         $rst = 1;
@@ -341,17 +472,17 @@ sub do_monitor{
     }
 
     my $rst = 0;
-    my $startline = 
-"-------------------------------------------------------------
+    my $startline =
+      "-------------------------------------------------------------
 Start to capture every message during os provision process......
 -------------------------------------------------------------
 ";
 
     print("$startline\n");
 
-    my $varlogmsg = "/var/log/messages";
+    my $varlogmsg  = "/var/log/messages";
     my $clusterlog = "/var/log/xcat/cluster.log";
-    my $computelog = "/var/log/xcat/computes.log";   
+    my $computelog = "/var/log/xcat/computes.log";
 
     my $httplog;
     if (-e "/var/log/httpd/access_log") {
@@ -367,71 +498,105 @@ Start to capture every message during os provision process......
     my $httppid;
     my $computerpid;
 
-    if (!($varlogpid = open(VARLOGMSGFILE, "tail -f -n 0 $varlogmsg 2>&1 |"))) {
-        probe_utils->send_msg("$output", "f", "Can't open $varlogmsg to get logs");
-        $rst = 1;
-        last;
-    }
-    if (!($clusterpid = open(CLUSTERLOGFILE, "tail -f -n 0 $clusterlog 2>&1 |"))) {
-        probe_utils->send_msg("$output", "f", "Can't open $clusterlog to get logs");
-        $rst = 1;
-        last;
-    }
-    if (!($httppid = open(HTTPLOGFILE, "tail -f -n 0 $httplog 2>&1 |"))) {
-        probe_utils->send_msg("$output", "f", "Can't open $httplog to get logs");
-        $rst = 1;
-        last;
-    }
-    if (!($computerpid = open(COMPUTERFILE, "tail -f -n 0 $computelog 2>&1 |"))) {
-        probe_utils->send_msg("$output", "f", "Can't open $computelog to get logs");
-        $rst = 1;
-        last;
-    }
-
-    my $select = new IO::Select;
-    $select->add(\*VARLOGMSGFILE);
-    $select->add(\*CLUSTERLOGFILE);
-    $select->add(\*HTTPLOGFILE);
-    $select->add(\*COMPUTERFILE);
-    $| = 1;
-
-    my $line = "";
-    my @hdls;
-    my $hdl;
-
-    for (; ;){
-        if (@hdls = $select->can_read(0)) {
-            foreach $hdl (@hdls) {
-                if ($hdl == \*VARLOGMSGFILE) {
-                    chomp($line = <VARLOGMSGFILE>);
-                    my @tmp = split(/\s+/, $line);
-                    if ($tmp[4] =~ /dhcpd:/i && $line =~ /$nics/) {
-                        handle_dhcp_msg("$line");
-                    }
-                } elsif ($hdl == \*CLUSTERLOGFILE) {
-                    chomp($line = <CLUSTERLOGFILE>);
-                    handle_cluster_msg("$line");
-                } elsif ($hdl == \*HTTPLOGFILE) {
-                    chomp($line = <HTTPLOGFILE>);
-                    handle_http_msg("$line");
-                } elsif ($hdl == \*COMPUTERFILE) {
-                    chomp($line = <COMPUTERFILE>);
-                    handle_compute_msg("$line");
-                }
+    {
+        if (!-e $varlogmsg) {
+            probe_utils->send_msg("$output", "w", "$varlogmsg doesn't exist");
+        } else {
+            if (!($varlogpid = open(VARLOGMSGFILE, "tail -f -n 0 $varlogmsg 2>&1 |"))) {
+                probe_utils->send_msg("$output", "f", "Can't open $varlogmsg to get logs");
+                $rst = 1;
+                last;
             }
         }
 
-        if ($terminal || (%monitor_nodes && all_monitor_node_done())) {
-            if ($terminal) {
-                probe_utils->send_msg("$output", "d", "Get INT or TERM signal from STDIN");
-            } else {
-                probe_utils->send_msg("$output", "o", "All nodes need to monitor have finished os provision process");
+        if (!-e "$clusterlog") {
+            probe_utils->send_msg("$output", "w", "$clusterlog doesn't exist");
+        } else {
+            if (!($clusterpid = open(CLUSTERLOGFILE, "tail -f -n 0 $clusterlog 2>&1 |"))) {
+                probe_utils->send_msg("$output", "f", "Can't open $clusterlog to get logs");
+                $rst = 1;
+                last;
             }
-            last;
-        } sleep 0.01;
-    }
-    &dump_history;
+        }
+        if (!-e "$httplog") {
+            probe_utils->send_msg("$output", "w", "$httplog doesn't exist");
+        } else {
+            if (!($httppid = open(HTTPLOGFILE, "tail -f -n 0 $httplog 2>&1 |"))) {
+                probe_utils->send_msg("$output", "f", "Can't open $httplog to get logs");
+                $rst = 1;
+                last;
+            }
+        }
+        if (!-e "$computelog") {
+            probe_utils->send_msg("$output", "w", "$computelog doesn't exist");
+        } else {
+            if (!($computerpid = open(COMPUTERFILE, "tail -f -n 0 $computelog 2>&1 |"))) {
+                probe_utils->send_msg("$output", "f", "Can't open $computelog to get logs");
+                $rst = 1;
+                last;
+            }
+        }
 
+        my $select = new IO::Select;
+        $select->add(\*VARLOGMSGFILE);
+        $select->add(\*CLUSTERLOGFILE);
+        $select->add(\*HTTPLOGFILE);
+        $select->add(\*COMPUTERFILE);
+        $| = 1;
+
+        my $line = "";
+        my @hdls;
+        my $hdl;
+
+        my @candidate_svr_hostname_inlog;
+        my $svr_hostname_short = `hostname -s`;
+        chomp($svr_hostname_short);
+        my $svr_hostname_domain = `hostname -d`;
+        chomp($svr_hostname_domain);
+        push(@candidate_svr_hostname_inlog, $svr_hostname_short);
+        push(@candidate_svr_hostname_inlog, "$svr_hostname_short.$svr_hostname_domain");
+
+        for (; ;) {
+            if (@hdls = $select->can_read(0)) {
+                foreach $hdl (@hdls) {
+                    if ($hdl == \*VARLOGMSGFILE) {
+                        chomp($line = <VARLOGMSGFILE>);
+                        my @tmp = split(/\s+/, $line);
+                        if ($tmp[4] =~ /dhcpd:/i && $line =~ /$nics/) {
+                            handle_dhcp_msg("$line");
+                        } elsif ($tmp[4] =~ /in.tftpd/i) {
+                            handle_tftp_msg("$line");
+                        } elsif (($tmp[4] =~ /^xcat/i) || ($tmp[5] =~ /^xcat/i)) {
+                            if (grep(/^$tmp[3]$/, @candidate_svr_hostname_inlog)) {
+                                handle_cluster_msg("$line");
+                            } else {
+                                handle_compute_msg("$line");
+                            }
+                        }
+                    } elsif ($hdl == \*CLUSTERLOGFILE) {
+                        chomp($line = <CLUSTERLOGFILE>);
+                        handle_cluster_msg("$line");
+                    } elsif ($hdl == \*HTTPLOGFILE) {
+                        chomp($line = <HTTPLOGFILE>);
+                        handle_http_msg("$line");
+                    } elsif ($hdl == \*COMPUTERFILE) {
+                        chomp($line = <COMPUTERFILE>);
+                        handle_compute_msg("$line");
+                    }
+                }
+            }
+
+            if ($terminal || (%monitor_nodes && all_monitor_node_done())) {
+                if ($terminal) {
+                    probe_utils->send_msg("$output", "d", "Get INT or TERM signal from STDIN");
+                } else {
+                    probe_utils->send_msg("$output", "o", "All nodes need to monitor have finished os provision process");
+                }
+                last;
+            } sleep 0.01;
+        }
+        &dump_history;
+    }
     kill 'INT', $varlogpid   if ($varlogpid);
     kill 'INT', $clusterpid  if ($clusterpid);
     kill 'INT', $httppid     if ($httppid);
@@ -472,8 +637,8 @@ if ($test) {
     exit 0;
 }
 
-unless ( $noderange ) {
-    probe_utils->send_msg("$output", "f", "Option -n is required");    
+unless ($noderange) {
+    probe_utils->send_msg("$output", "f", "Option -n is required");
     probe_utils->send_msg("$output", "d", "$::USAGE");
     exit 1;
 }


### PR DESCRIPTION
1. issue #1508 , check if rc label when check genesis packages.
2. issue #1507 , modified dynamic range check.
3. issue #1487 , if log in /var/log/message has tag "xcat", using "handle_cluster_msg" subroutine.
4. issue #1479 , check whether the status was installing.
When receive the status is booted, check the status in hash whether installing. If so, it completes os provision. If not, it did not do os provision.