### PR TITLE
Switch-based switch discovery for BNT and Mellanox

### DIFF
--- a/xCAT-server/lib/xcat/plugins/switchdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/switchdiscover.pm
@@ -1418,7 +1418,7 @@ sub switchsetup {
         if ( $stype =~ /BNT/ ) {
             $ret = config_BNT($dswitch, $node, $static_ip, $request, $sub_req);
             if ($ret == 1) {
-                next;
+                xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'otherinterfaces=config failed, dhcp ip=$ip'] }, $sub_req, 0, 1);
             }
         } 
         # Mellanox switches
@@ -1427,15 +1427,13 @@ sub switchsetup {
             #NOTE:  this expect routine will timeout after set up address
             $ret = config_Mellanox($dswitch, $node, $static_ip, $request, $sub_req);
             if ($ret == 1) {
-                next;
+                xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'otherinterfaces=config failed, dhcp ip=$ip'] }, $sub_req, 0, 1);
             }
 
         } 
         else {
             send_msg($request, 0, "the switch $dswitch type $stype is not support\n");
-            $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$dswitch,"ip=$ip",'otherinterfaces=switch type is not supported'] }, $sub_req, 0, 1);
-            $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip","switchtype=$stype",'otherinterfaces=switch type is not supported'] }, $sub_req, 0, 1);
-            next;
+            $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip","switchtype=$stype",'otherinterfaces=switch type is not supported yet, dhcp ip=$ip'] }, $sub_req, 0, 1);
         }
 
         # save for update mac address and remove node definition
@@ -1458,8 +1456,6 @@ sub switchsetup {
     if ($mactab) {
         $mactab->setNodesAttribs($discovered_switch);
     }
-
-
     return;
 }
 
@@ -1496,7 +1492,7 @@ sub config_BNT {
     #send_msg($request, 0, Dumper($output));
     
     #add default attribute for BNT switch
-    my $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'username=root','password=admin','protocol=telnet','switchtype=BNT'] }, $sub_req, 0, 1);
+    my $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'username=root','password=admin','protocol=telnet','switchtype=BNT','otherinterfaces='] }, $sub_req, 0, 1);
     #send_msg($request, 0, Dumper($ret));
 
     #set up hostname
@@ -1507,7 +1503,6 @@ sub config_BNT {
     if ($::RUNCMD_RC != 0)
     {
         send_msg($request, 0, "Failed to change hostname on $node");
-        $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'otherinterfaces=Failed to change hostname'] }, $sub_req, 0, 1);
         return 1;
     }
    
@@ -1603,7 +1598,7 @@ sub config_Mellanox {
     $myexp->soft_close();
 
     #add default attribute for Mellanox switch
-    $output = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'username=admin','switchtype=Mellanox'] }, $sub_req, 0, 1);
+    $output = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'username=admin','switchtype=Mellanox','otherinterfaces='] }, $sub_req, 0, 1);
     #send_msg($request, 0, Dumper($output));
 
 
@@ -1615,7 +1610,6 @@ sub config_Mellanox {
     if ($::RUNCMD_RC != 0)
     {
         send_msg($request, 0, "Failed to change hostname on $node");
-        $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'otherinterfaces=Failed to change hostname'] }, $sub_req, 0, 1);
         return 1;
     }
 

--- a/xCAT-server/lib/xcat/plugins/switchdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/switchdiscover.pm
@@ -459,7 +459,7 @@ sub process_request {
             if ($key !~ /nomac/) {
                 $mac = $key;
             }
-            my $msg = sprintf $format, $ip, $name, $vendor, $key;
+            my $msg = sprintf $format, $ip, $name, $vendor, $mac;
             send_msg(\%request, 0, $msg);
         }
     }
@@ -1363,11 +1363,7 @@ sub switchsetup {
     my $outhash = shift;
     my $request = shift;
     my $sub_req = shift;
-    my $ret;
     my @switchnode = ();
-    my $switchInfo;
-    my $output;
-    my $dshcmd;
     my $static_ip;
     my $discover_switch;
     my $nodes_to_config;

--- a/xCAT-server/lib/xcat/plugins/switchdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/switchdiscover.pm
@@ -1399,7 +1399,7 @@ sub switchsetup {
         my $node = $macmap->find_mac($mac,0);
         if (!$node) {
             send_msg($request, 0, "NO predefined switch matched this switch $dswitch with mac address $mac");
-            $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$dswitch,"ip=$ip",'otherinterfaces=no predefined switch'] }, $sub_req, 0, 1);
+            $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$dswitch,"ip=$ip",'status=no predefined switch'] }, $sub_req, 0, 1);
             next;
         }
 
@@ -1418,7 +1418,7 @@ sub switchsetup {
         if ( $stype =~ /BNT/ ) {
             $ret = config_BNT($dswitch, $node, $static_ip, $request, $sub_req);
             if ($ret == 1) {
-                xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'otherinterfaces=config failed, dhcp ip=$ip'] }, $sub_req, 0, 1);
+                xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip","otherinterfaces=dhcp:$ip",'status=config failed'] }, $sub_req, 0, 1);
             }
         } 
         # Mellanox switches
@@ -1427,13 +1427,13 @@ sub switchsetup {
             #NOTE:  this expect routine will timeout after set up address
             $ret = config_Mellanox($dswitch, $node, $static_ip, $request, $sub_req);
             if ($ret == 1) {
-                xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'otherinterfaces=config failed, dhcp ip=$ip'] }, $sub_req, 0, 1);
+                xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip","otherinterfaces=dhcp:$ip",'status=config failed'] }, $sub_req, 0, 1);
             }
 
         } 
         else {
             send_msg($request, 0, "the switch $dswitch type $stype is not support\n");
-            $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip","switchtype=$stype",'otherinterfaces=switch type is not supported yet, dhcp ip=$ip'] }, $sub_req, 0, 1);
+            $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip","switchtype=$stype","otherinterfaces=dhcp:$ip",'status=switch type is not supported yet'] }, $sub_req, 0, 1);
         }
 
         # save for update mac address and remove node definition
@@ -1492,7 +1492,7 @@ sub config_BNT {
     #send_msg($request, 0, Dumper($output));
     
     #add default attribute for BNT switch
-    my $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'username=root','password=admin','protocol=telnet','switchtype=BNT','otherinterfaces='] }, $sub_req, 0, 1);
+    my $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'username=root','password=admin','protocol=telnet','switchtype=BNT','otherinterfaces=','status='] }, $sub_req, 0, 1);
     #send_msg($request, 0, Dumper($ret));
 
     #set up hostname
@@ -1598,7 +1598,7 @@ sub config_Mellanox {
     $myexp->soft_close();
 
     #add default attribute for Mellanox switch
-    $output = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'username=admin','switchtype=Mellanox','otherinterfaces='] }, $sub_req, 0, 1);
+    $output = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'username=admin','switchtype=Mellanox','otherinterfaces=','status='] }, $sub_req, 0, 1);
     #send_msg($request, 0, Dumper($output));
 
 

--- a/xCAT-server/share/xcat/tools/configBNT
+++ b/xCAT-server/share/xcat/tools/configBNT
@@ -54,9 +54,6 @@ if ($::SWITCH)
 
 my $cmd;
 
-#default root/password and protcol for BNT switch
-my $cmd = `chdef $switch protocol=telnet username=root password=admin`; 
-
 my $vlan;
 my $port;
 if ($::VLAN)

--- a/xCAT-server/share/xcat/tools/configBNT
+++ b/xCAT-server/share/xcat/tools/configBNT
@@ -327,9 +327,7 @@ sub config_snmp {
     if (@config_switches) {
         #update switch status
         my $csw = join(",",@config_switches);
-        $cmd = "chdef $csw status=switch_configed" ;
-        $rc= xCAT::Utils->runcmd($cmd, 0);
-        $cmd = "chtab switch=$csw switches.snmpversion=3 switches.auth=sha switches.username=$snmp_user switches.password=$snmp_passwd" ;
+        $cmd = "chdef $csw status=switch_configed snmpversion=3 snmpauth=sha snmpusername=$snmp_user snmppassword=$snmp_passwd";
         $rc= xCAT::Utils->runcmd($cmd, 0);
     }
 }

--- a/xCAT-server/share/xcat/tools/configBNT
+++ b/xCAT-server/share/xcat/tools/configBNT
@@ -23,10 +23,6 @@ use xCAT::Utils;
 use xCAT::Table;
 use xCAT::MsgUtils;
 
-
-my $args = join ' ', @ARGV;
-$::command = "$0 $args";
-
 Getopt::Long::Configure("bundling");
 $Getopt::Long::ignorecase = 0;
 
@@ -41,17 +37,17 @@ my @filternodes;
 # parse the options
 if (
     !GetOptions(
-                'h|help'       => \$::HELP,
-                'range=s'    => \$::SWITCH,  
+                'h|help'     => \$::HELP,
+                'switches=s' => \$::SWITCH,  
                 'port=s'     => \$::PORT,  
                 'vlan=s'     => \$::VLAN,
                 'user=s'     => \$::USER,
                 'password=s' => \$::PASSWORD,
                 'group=s'    => \$::GROUP,
-                'snmp'         => \$::SNMP,
-		'ip'           => \$::IP,
-                'name'         => \$::NAME,
-                'all'          => \$::ALL,
+                'snmp'       => \$::SNMP,
+		'ip'         => \$::IP,
+                'name'       => \$::NAME,
+                'all'        => \$::ALL,
     )
   )
 {
@@ -72,15 +68,22 @@ if ($::SWITCH) {
         my $nodenotdefined = join(',', nodesmissed);
         xCAT::MsgUtils->message("I","The following nodes are not defined in xCAT DB: $nodenotdefined");
     }
-    foreach (@filternodes)  {
-        push @nodes, $_;
+    # check switch type
+    my $switchestab =  xCAT::Table->new('switches');
+    my $switches_hash = $switchestab->getNodesAttribs(\@filternodes,['switchtype']);
+    foreach my $fsw (@filternodes)  {
+        if (($switches_hash->{$fsw}->[0]->{switchtype}) =~ /BNT/) {
+            push @nodes, $fsw;
+        } else {
+            xCAT::MsgUtils->message("E","The $fsw is not BNT switch, will not config");
+        }
     }
     unless (@nodes) {
         xCAT::MsgUtils->message("E","No Valid Switch to process");
         exit(1);
     }
 } else {
-    xCAT::MsgUtils->message("E","Invalid flag, please provide switches with --range");
+    xCAT::MsgUtils->message("E","Invalid flag, please provide switches with --switches");
     &usage;
     exit(1);
 }
@@ -90,25 +93,18 @@ my $cmd;
 my $vlan;
 my $port;
 my $sub_req;
-my $switch;
 my $rc;
 
-if ($::ALL) {
-    config_ip();
-    config_hostname();
-    config_snmp();
-}
-
-if ($::IP)
+if (($::IP) || ($::ALL))
 {
     config_ip();
 }
 
-if ($::NAME)
+if (($::NAME) || ($::ALL))
 {
     config_hostname();
 }
-if ($::SNMP)
+if (($::SNMP) || ($::ALL))
 {
     config_snmp();
 }
@@ -118,12 +114,14 @@ if ($::VLAN)
 }
 
 sub config_ip {
-
+    my @config_switches;
+    my @discover_switches;
     my $nodetab = xCAT::Table->new('hosts');
-    my $nodehash = $nodetab->getNodesAttribs(\@nodes,['otherinterfaces']);
+    my $nodehash = $nodetab->getNodesAttribs(\@nodes,['ip','otherinterfaces']);
     foreach my $switch (@nodes) {
         print "change $switch to static ip address\n";
         my $dip= $nodehash->{$switch}->[0]->{otherinterfaces};
+        my $static_ip= $nodehash->{$switch}->[0]->{ip};
 
         #get hostname
         my $dswitch = xCAT::NetworkUtils->gethostname($dip);
@@ -133,20 +131,12 @@ sub config_ip {
             my $ip_str = $dip;
             $ip_str =~ s/\./\-/g;
             $dswitch = "switch-$ip_str";
-            #is there other way we can check if this node is defined in the xCATdb
-            $cmd = "lsdef $dswitch";
-            $rc= xCAT::Utils->runcmd($cmd, 0);
-            if ($::RUNCMD_RC != 0) {
-                $cmd = "mkdef -t node -o $dswitch groups=switch ip=$dip switchtype=BNT username=root password=admin protocol=telnet nodetype=switch";
-                $rc= xCAT::Utils->runcmd($cmd, 0);
-            }
         }
-        #check if it is in the /etc/hosts
-        my $output = `grep $dswitch /etc/hosts`;
-        if ( !$output ) {
-            $cmd = "makehosts $dswitch";
-            $rc= xCAT::Utils->runcmd($cmd, 0);
-        }
+        $cmd = "chdef -t node -o $dswitch groups=switch ip=$dip switchtype=BNT username=root password=admin protocol=telnet nodetype=switch";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+        $cmd = "makehosts $dswitch";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+
         # verify if xdsh works
         $cmd = "xdsh $dswitch --devicetype EthSwitch::BNT 'enable;configure terminal;exit' ";
         $rc= xCAT::Utils->runcmd($cmd, 0);
@@ -154,29 +144,30 @@ sub config_ip {
             xCAT::MsgUtils->message("E","Couldn't communicate with $dswitch, $dip");
             next;
         }
-        #change to static ip address
-        my $static_ip = xCAT::NetworkUtils->getipaddr($switch);
-        if (!$static_ip){
-            xCAT::MsgUtils->message("E","static ip is not defined for $switch");
-            next;
-        }
         $cmd="xdsh $dswitch -t 10 --devicetype EthSwitch::BNT 'enable;configure terminal;show interface ip;interface ip 1;ip address $static_ip;exit;exit' ";
         $rc= xCAT::Utils->runcmd($cmd, 0);
         print "finish setup static ip address for $switch\n";
-
+        push (@discover_switches, $dswitch);
+        push (@config_switches, $switch);
+    }
+    if (@config_switches) {
         #update switch status
-        $cmd = "chdef $switch status=ip_configed otherinterface=";
+        my $csw = join(",",@config_switches);
+        $cmd = "chdef $csw status=ip_configed otherinterfaces=";
         $rc= xCAT::Utils->runcmd($cmd, 0);
-
+    }
+    if (@discover_switches) {
+        my $dsw = join(",",@discover_switches);
         #remove discover switch from xCATdb and /etc/hosts
-        $cmd = "makehosts -d $dswitch";
+        $cmd = "makehosts -d $dsw";
         $rc= xCAT::Utils->runcmd($cmd, 0);
-        $cmd = "rmdef $dswitch";
+        $cmd = "rmdef $dsw";
         $rc= xCAT::Utils->runcmd($cmd, 0);
     }
 }
 
 sub config_hostname {
+    my @config_switches;
     my $switchtab = xCAT::Table->new('switches');
     my $switchhash = $switchtab->getNodesAttribs(\@nodes,['sshusername','sshpassword']);
     foreach my $switch (@nodes) {
@@ -193,8 +184,12 @@ sub config_hostname {
             xCAT::MsgUtils->message("E","Failed to setup hostname for $switch");
             next;
         }
+        push (@config_switches, $switch);
+    }
+    if (@config_switches) {
         #update switch status
-        $cmd = "chdef $switch status=hostname_configed" ;
+        my $csw = join(",",@config_switches);
+        $cmd = "chdef $csw status=hostname_configed" ;
         $rc= xCAT::Utils->runcmd($cmd, 0);
     }
 }
@@ -205,6 +200,7 @@ sub config_snmp {
     my $snmp_user;
     my $snmp_passwd;
     my $snmp_group;
+    my @config_switches;
 
     if ($::USER) {
         $snmp_user = $::USER;
@@ -326,9 +322,14 @@ sub config_snmp {
             exit(1);
         }
         $mysw->soft_close();
-
+        push (@config_switches, $switch);
+    }
+    if (@config_switches) {
         #update switch status
-        $cmd = "chdef $switch status=switch_configed" ;
+        my $csw = join(",",@config_switches);
+        $cmd = "chdef $csw status=switch_configed" ;
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+        $cmd = "chtab switch=$csw switches.snmpversion=3 switches.auth=sha switches.username=$snmp_user switches.password=$snmp_passwd" ;
         $rc= xCAT::Utils->runcmd($cmd, 0);
     }
 }
@@ -361,11 +362,11 @@ sub usage
 {
     print "Usage:
     configBNT [-?│-h│--help] 
-    configBNT [--range switchnames] [--all] 
-    configBNT [--range switchnames] [--ip] 
-    configBNT [--range switchnames] [--name ] 
-    configBNT [--range switchnames] [--snmp] [--user snmp_user] [--password snmp_password] [--group snmp_group]
-    configBNT [--range switchnames] [--port port] [--vlan vlan]
+    configBNT [--switches switchnames] [--all] 
+    configBNT [--switches switchnames] [--ip] 
+    configBNT [--switches switchnames] [--name ] 
+    configBNT [--switches switchnames] [--snmp] [--user snmp_user] [--password snmp_password] [--group snmp_group]
+    configBNT [--switches switchnames] [--port port] [--vlan vlan]
     \n";
 }
 

--- a/xCAT-server/share/xcat/tools/configBNT
+++ b/xCAT-server/share/xcat/tools/configBNT
@@ -4,15 +4,35 @@
 # Configure Ethnet BNT switches
 #---------------------------------------------------------
 
+BEGIN
+{
+  $::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : '/opt/xcat';
+  $::XCATDIR  = $ENV{'XCATDIR'}  ? $ENV{'XCATDIR'}  : '/etc/xcat';
+}
+use lib "$::XCATROOT/lib/perl";
+
+
 use strict;
+use Socket;
 use Getopt::Long;
 use Expect;
+use xCAT::Usage;
+use xCAT::NodeRange;
+use xCAT::NetworkUtils;
+use xCAT::Utils;
+use xCAT::Table;
+use xCAT::MsgUtils;
+
 
 my $args = join ' ', @ARGV;
 $::command = "$0 $args";
 
 Getopt::Long::Configure("bundling");
 $Getopt::Long::ignorecase = 0;
+
+#global variables
+my @nodes;
+my @filternodes;
 
 
 #---------------------------------------------------------
@@ -22,13 +42,16 @@ $Getopt::Long::ignorecase = 0;
 if (
     !GetOptions(
                 'h|help'       => \$::HELP,
-                'r|range=s'    => \$::SWITCH,  
-                'p|port=s'     => \$::PORT,  
-                'v|vlan=s'     => \$::VLAN,
-                'u|user=s'     => \$::USER,
-                'w|password=s' => \$::PASSWORD,
-                'g|group=s'    => \$::GROUP,
+                'range=s'    => \$::SWITCH,  
+                'port=s'     => \$::PORT,  
+                'vlan=s'     => \$::VLAN,
+                'user=s'     => \$::USER,
+                'password=s' => \$::PASSWORD,
+                'group=s'    => \$::GROUP,
                 'snmp'         => \$::SNMP,
+		'ip'           => \$::IP,
+                'name'         => \$::NAME,
+                'all'          => \$::ALL,
     )
   )
 {
@@ -43,54 +66,146 @@ if ($::HELP)
     exit(0);
 }
 
-my $switch;
-if ($::SWITCH)
-{
-    $switch = $::SWITCH;
+if ($::SWITCH) {
+    my @filternodes = xCAT::NodeRange::noderange( $::SWITCH );
+    if (nodesmissed) {
+        my $nodenotdefined = join(',', nodesmissed);
+        xCAT::MsgUtils->message("I","The following nodes are not defined in xCAT DB: $nodenotdefined");
+    }
+    foreach (@filternodes)  {
+        push @nodes, $_;
+    }
+    unless (@nodes) {
+        xCAT::MsgUtils->message("E","No Valid Switch to process");
+        exit(1);
+    }
 } else {
+    xCAT::MsgUtils->message("E","Invalid flag, please provide switches with --range");
     &usage;
     exit(1);
 }
 
+my $switches = join(",",@nodes);
 my $cmd;
-
 my $vlan;
 my $port;
-if ($::VLAN)
-{
-    if ($::PORT) {
-        $port = $::PORT;
-    } else {
-        print "Need port number to set up VLAN\n";
-        &usage;
-        exit(1);
-    }
-    $vlan = $::VLAN;
-    print "Tagging VLAN=$vlan for $switch port $port\n";
-    #create vlan
-    #tagged vlan
-    $cmd = `xdsh $switch --devicetype EthSwitch::BNT "enable;configure terminal;vlan $vlan;exit;interface port $port;switchport mode trunk;switchport trunk allowed vlan $vlan;write memory;exit;exit"`;
+my $sub_req;
+my $switch;
+my $rc;
+
+if ($::ALL) {
+    config_ip();
+    config_hostname();
+    config_snmp();
 }
 
+if ($::IP)
+{
+    config_ip();
+}
+
+if ($::NAME)
+{
+    config_hostname();
+}
+if ($::SNMP)
+{
+    config_snmp();
+}
+if ($::VLAN)
+{
+    config_vlan();
+}
+
+sub config_ip {
+
+    my $nodetab = xCAT::Table->new('hosts');
+    my $nodehash = $nodetab->getNodesAttribs(\@nodes,['otherinterfaces']);
+    foreach my $switch (@nodes) {
+        print "change $switch to static ip address\n";
+        my $dip= $nodehash->{$switch}->[0]->{otherinterfaces};
+
+        #get hostname
+        my $dswitch = xCAT::NetworkUtils->gethostname($dip);
+
+        #if not defined, need to create one for xdsh to use
+        if (!$dswitch) {
+            my $ip_str = $dip;
+            $ip_str =~ s/\./\-/g;
+            $dswitch = "switch-$ip_str";
+            #is there other way we can check if this node is defined in the xCATdb
+            $cmd = "lsdef $dswitch";
+            $rc= xCAT::Utils->runcmd($cmd, 0);
+            if ($::RUNCMD_RC != 0) {
+                $cmd = "mkdef -t node -o $dswitch groups=switch ip=$dip switchtype=BNT username=root password=admin protocol=telnet nodetype=switch";
+                $rc= xCAT::Utils->runcmd($cmd, 0);
+            }
+        }
+        #check if it is in the /etc/hosts
+        my $output = `grep $dswitch /etc/hosts`;
+        if ( !$output ) {
+            $cmd = "makehosts $dswitch";
+            $rc= xCAT::Utils->runcmd($cmd, 0);
+        }
+        # verify if xdsh works
+        $cmd = "xdsh $dswitch --devicetype EthSwitch::BNT 'enable;configure terminal;exit' ";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+        if ($::RUNCMD_RC != 0) {
+            xCAT::MsgUtils->message("E","Couldn't communicate with $dswitch, $dip");
+            next;
+        }
+        #change to static ip address
+        my $static_ip = xCAT::NetworkUtils->getipaddr($switch);
+        if (!$static_ip){
+            xCAT::MsgUtils->message("E","static ip is not defined for $switch");
+            next;
+        }
+        $cmd="xdsh $dswitch -t 10 --devicetype EthSwitch::BNT 'enable;configure terminal;show interface ip;interface ip 1;ip address $static_ip;exit;exit' ";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+        print "finish setup static ip address for $switch\n";
+
+        #update switch status
+        $cmd = "chdef $switch status=ip_configed otherinterface=";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+
+        #remove discover switch from xCATdb and /etc/hosts
+        $cmd = "makehosts -d $dswitch";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+        $cmd = "rmdef $dswitch";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+    }
+}
+
+sub config_hostname {
+    my $switchtab = xCAT::Table->new('switches');
+    my $switchhash = $switchtab->getNodesAttribs(\@nodes,['sshusername','sshpassword']);
+    foreach my $switch (@nodes) {
+        my $user= $switchhash->{$switch}->[0]->{sshusername};
+        my $pwd= $switchhash->{$switch}->[0]->{sshpassword};
+        if ((!$user)||(!$pwd)) {
+            print "switch ssh username or password is not define, add default one\n";
+            $cmd = "chdef $switch username=root password=admin";
+            $rc= xCAT::Utils->runcmd($cmd, 0);
+        }
+        $cmd="xdsh $switch --devicetype EthSwitch::BNT 'enable;configure terminal;hostname $switch;write memory' ";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+        if ($::RUNCMD_RC != 0) {
+            xCAT::MsgUtils->message("E","Failed to setup hostname for $switch");
+            next;
+        }
+        #update switch status
+        $cmd = "chdef $switch status=hostname_configed" ;
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+    }
+}
+
+
 #setup secure SNMP v3 
-if ($::SNMP){
-    my $mysw;
-    my $enable_cmd="enable\r";
-    my $config_cmd="configure terminal\r";
-    my $exit_cmd="exit\r";
-
-    my $pwd_prompt   = "password: ";
-    my $sw_prompt = "$switch>";
-    my $enable_prompt="$switch#";
-    my $config_prompt="^.*\\\(config\\\)\#";
-
-    $mysw = new Expect;
-    my $timeout = 20;
-    my $login_cmd = "telnet $switch\r";
-    my $passwd = "admin\r";
+sub config_snmp {
     my $snmp_user;
     my $snmp_passwd;
     my $snmp_group;
+
     if ($::USER) {
         $snmp_user = $::USER;
     } else {
@@ -107,98 +222,131 @@ if ($::SNMP){
     } else {
         $snmp_group = "xcatgroup\r";
     }
-    print "Setup SNMP server for user=$snmp_user, password=$snmp_passwd, group=$snmp_group\n";
-    #create a SNMP user
-    my $cfg_user1="snmp-server user 5 name $snmp_user\r";
-    my $cfg_user2="snmp-server user 5 authentication-protocol sha authentication-password\r";
-    #create a SNMP group
-    my $cfg_group1="snmp-server group 5 group-name $snmp_group\r";
-    my $cfg_group2="snmp-server group 5 user-name $snmp_user\r";
-    my $cfg_group3="snmp-server group 5 security usm\r";
-    #Add access permission
-    my $cfg_access1="snmp-server access 5 name $snmp_group\r";
-    my $cfg_access2="snmp-server access 5 level authNoPriv\r";
-    my $cfg_access3="snmp-server access 5 security usm\r";
-    my $cfg_access4="snmp-server access 5 read-view iso\r";
 
-    $mysw->slave->stty(qw(sane -echo));
+    foreach my $switch (@nodes) {
+        my $mysw;
+        my $enable_cmd="enable\r";
+        my $config_cmd="configure terminal\r";
+        my $exit_cmd="exit\r";
 
-    unless ($mysw->spawn($login_cmd))
-    {
+        my $pwd_prompt   = "password: ";
+        my $sw_prompt = "$switch>";
+        my $enable_prompt="$switch#";
+        my $config_prompt="^.*\\\(config\\\)\#";
+
+        $mysw = new Expect;
+        my $timeout = 20;
+        my $login_cmd = "telnet $switch\r";
+        my $passwd = "admin\r";
+
+        print "Setup SNMP server for $switch\n";
+        #create a SNMP user
+        my $cfg_user1="snmp-server user 5 name $snmp_user\r";
+        my $cfg_user2="snmp-server user 5 authentication-protocol sha authentication-password\r";
+        #create a SNMP group
+        my $cfg_group1="snmp-server group 5 group-name $snmp_group\r";
+        my $cfg_group2="snmp-server group 5 user-name $snmp_user\r";
+        my $cfg_group3="snmp-server group 5 security usm\r";
+        #Add access permission
+        my $cfg_access1="snmp-server access 5 name $snmp_group\r";
+        my $cfg_access2="snmp-server access 5 level authNoPriv\r";
+        my $cfg_access3="snmp-server access 5 security usm\r";
+        my $cfg_access4="snmp-server access 5 read-view iso\r";
+
+        $mysw->slave->stty(qw(sane -echo));
+
+        unless ($mysw->spawn($login_cmd))
+        {
+            $mysw->soft_close();
+            print "Unable to run $login_cmd\n";
+            next;
+        }
+        my @result = $mysw->expect(
+            $timeout,
+            [
+                $pwd_prompt,
+                sub {
+                    $mysw->clear_accum();
+                    $mysw->send("$passwd\r");
+                    $mysw->clear_accum();
+                    $mysw->exp_continue();
+                }
+            ],
+            [
+                "-re", $sw_prompt,
+                sub {
+                    $mysw->clear_accum();
+                    $mysw->send($enable_cmd);
+                    $mysw->exp_continue();
+                }
+            ],
+            [
+                "-re", $enable_prompt,
+                sub {
+                    $mysw->clear_accum();
+                    $mysw->send($config_cmd);
+                    $mysw->exp_continue();
+                }
+            ],
+            [
+                "-re", $config_prompt,
+                sub {
+                    $mysw->clear_accum();
+                    $mysw->send($cfg_user1);
+                    $mysw->send($cfg_user2);
+                    $mysw->send($passwd);
+                    $mysw->send($snmp_passwd);
+                    $mysw->send($snmp_passwd);
+                    sleep 1;
+                    $mysw->clear_accum();
+                    # create snmp group
+                    $mysw->send($cfg_group1);
+                    $mysw->send($cfg_group2);
+                    $mysw->send($cfg_group3);
+                    $mysw->clear_accum();
+                    $mysw->send($cfg_access1);
+                    $mysw->send($cfg_access2);
+                    $mysw->send($cfg_access3);
+                    $mysw->send($cfg_access4);
+                    $mysw->clear_accum();
+                    $mysw->send("write memory\r");
+                    $mysw->send($exit_cmd);
+                    $mysw->send($exit_cmd);
+                }
+            ],
+        );
+        ##########################################
+        # Expect error - report and quit
+        ##########################################
+        if (defined($result[1]))
+        {
+            my $errmsg = $result[1];
+            $mysw->soft_close();
+            print "Failed expect command $errmsg\n";
+            exit(1);
+        }
         $mysw->soft_close();
-        print "Unable to run $login_cmd\n";
-        next;
+
+        #update switch status
+        $cmd = "chdef $switch status=switch_configed" ;
+        $rc= xCAT::Utils->runcmd($cmd, 0);
     }
-    my @result = $mysw->expect(
-        $timeout,
-        [
-            $pwd_prompt,
-            sub {
-                $mysw->clear_accum();
-                $mysw->send("$passwd\r");
-                $mysw->clear_accum();
-                $mysw->exp_continue();
-            }
-        ],
-        [
-            "-re", $sw_prompt,
-            sub {
-                #print "$switch: sending enable command: $enable_cmd\n";
-                $mysw->clear_accum();
-                $mysw->send($enable_cmd);
-                $mysw->exp_continue();
-            }
-        ],
-        [
-            "-re", $enable_prompt,
-            sub {
-                #print "$switch: sending config command: $config_cmd\n";
-                $mysw->clear_accum();
-                $mysw->send($config_cmd);
-                $mysw->exp_continue();
-            }
-        ],
-        [
-            "-re", $config_prompt,
-            sub {
-                $mysw->clear_accum();
-                $mysw->send($cfg_user1);
-                $mysw->send($cfg_user2);
-                $mysw->send($passwd);
-                $mysw->send($snmp_passwd);
-                $mysw->send($snmp_passwd);
-                sleep 1;
-                $mysw->clear_accum();
-                # create snmp group
-                $mysw->send($cfg_group1);
-                $mysw->send($cfg_group2);
-                $mysw->send($cfg_group3);
-                $mysw->clear_accum();
-                $mysw->send($cfg_access1);
-                $mysw->send($cfg_access2);
-                $mysw->send($cfg_access3);
-                $mysw->send($cfg_access4);
-                $mysw->clear_accum();
-                $mysw->send("write memory\r");
-                $mysw->send($exit_cmd);
-                $mysw->send($exit_cmd);
-            }
-        ],
-    );
-    ##########################################
-    # Expect error - report and quit
-    ##########################################
-    if (defined($result[1]))
-    {
-        my $errmsg = $result[1];
-        $mysw->soft_close();
-        print "Failed expect command $errmsg\n";
+}
+
+sub config_vlan {
+    if ($::PORT) {
+        $port = $::PORT;
+    } else {
+        &usage;
         exit(1);
     }
-    $mysw->soft_close();
+    $vlan = $::VLAN;
+    print "Tagging VLAN=$vlan for $switches port $port\n";
+    #create vlan, tagged vlan
+    $cmd = `xdsh $switches --devicetype EthSwitch::BNT "enable;configure terminal;vlan $vlan;exit;interface port $port;switchport mode trunk;switchport trunk allowed vlan $vlan;write memory;exit;exit"`;
 
-             
 }
+
 
 #---------------------------------------------------------
 
@@ -213,8 +361,11 @@ sub usage
 {
     print "Usage:
     configBNT [-?│-h│--help] 
-    configBNT [--range switchnames] [-p|--port port] [-v|--vlan vlan]
-    configBNT [--range switchnames] [--snmp] [-u|--user snmp_user] [-w|--password snmp_password] [-g|--group snmp_group]
+    configBNT [--range switchnames] [--all] 
+    configBNT [--range switchnames] [--ip] 
+    configBNT [--range switchnames] [--name ] 
+    configBNT [--range switchnames] [--snmp] [--user snmp_user] [--password snmp_password] [--group snmp_group]
+    configBNT [--range switchnames] [--port port] [--vlan vlan]
     \n";
 }
 

--- a/xCAT-server/share/xcat/tools/configBNT
+++ b/xCAT-server/share/xcat/tools/configBNT
@@ -1,0 +1,224 @@
+#!/usr/bin/env perl
+
+#---------------------------------------------------------
+# Configure Ethnet BNT switches
+#---------------------------------------------------------
+
+use strict;
+use Getopt::Long;
+use Expect;
+
+my $args = join ' ', @ARGV;
+$::command = "$0 $args";
+
+Getopt::Long::Configure("bundling");
+$Getopt::Long::ignorecase = 0;
+
+
+#---------------------------------------------------------
+#Main
+
+# parse the options
+if (
+    !GetOptions(
+                'h|help'       => \$::HELP,
+                'r|range=s'    => \$::SWITCH,  
+                'p|port=s'     => \$::PORT,  
+                'v|vlan=s'     => \$::VLAN,
+                'u|user=s'     => \$::USER,
+                'w|password=s' => \$::PASSWORD,
+                'g|group=s'    => \$::GROUP,
+                'snmp'         => \$::SNMP,
+    )
+  )
+{
+    &usage;
+    exit(1);
+}
+
+# display the usage if -h or --help is specified
+if ($::HELP)
+{
+    &usage;
+    exit(0);
+}
+
+my $switch;
+if ($::SWITCH)
+{
+    $switch = $::SWITCH;
+} else {
+    &usage;
+    exit(1);
+}
+
+my $cmd;
+
+#default root/password and protcol for BNT switch
+my $cmd = `chdef $switch protocol=telnet username=root password=admin`; 
+
+my $vlan;
+my $port;
+if ($::VLAN)
+{
+    if ($::PORT) {
+        $port = $::PORT;
+    } else {
+        print "Need port number to set up VLAN\n";
+        &usage;
+        exit(1);
+    }
+    $vlan = $::VLAN;
+    print "Tagging VLAN=$vlan for $switch port $port\n";
+    #create vlan
+    #tagged vlan
+    $cmd = `xdsh $switch --devicetype EthSwitch::BNT "enable;configure terminal;vlan $vlan;exit;interface port $port;switchport mode trunk;switchport trunk allowed vlan $vlan;write memory;exit;exit"`;
+}
+
+#setup secure SNMP v3 
+if ($::SNMP){
+    my $mysw;
+    my $enable_cmd="enable\r";
+    my $config_cmd="configure terminal\r";
+    my $exit_cmd="exit\r";
+
+    my $pwd_prompt   = "password: ";
+    my $sw_prompt = "$switch>";
+    my $enable_prompt="$switch#";
+    my $config_prompt="^.*\\\(config\\\)\#";
+
+    $mysw = new Expect;
+    my $timeout = 20;
+    my $login_cmd = "telnet $switch\r";
+    my $passwd = "admin\r";
+    my $snmp_user;
+    my $snmp_passwd;
+    my $snmp_group;
+    if ($::USER) {
+        $snmp_user = $::USER;
+    } else {
+        $snmp_user = "xcatadmin\r";
+    }
+    if ($::PASSWORD) {
+        $snmp_passwd = $::PASSWORD;
+    } else {
+        # Need a special character
+        $snmp_passwd = "xcatadminpassw0rd\@snmp\r";
+    }
+    if ($::GROUP) {
+        $snmp_group = $::GROUP;
+    } else {
+        $snmp_group = "xcatgroup\r";
+    }
+    print "Setup SNMP server for user=$snmp_user, password=$snmp_passwd, group=$snmp_group\n";
+    #create a SNMP user
+    my $cfg_user1="snmp-server user 5 name $snmp_user\r";
+    my $cfg_user2="snmp-server user 5 authentication-protocol sha authentication-password\r";
+    #create a SNMP group
+    my $cfg_group1="snmp-server group 5 group-name $snmp_group\r";
+    my $cfg_group2="snmp-server group 5 user-name $snmp_user\r";
+    my $cfg_group3="snmp-server group 5 security usm\r";
+    #Add access permission
+    my $cfg_access1="snmp-server access 5 name $snmp_group\r";
+    my $cfg_access2="snmp-server access 5 level authNoPriv\r";
+    my $cfg_access3="snmp-server access 5 security usm\r";
+    my $cfg_access4="snmp-server access 5 read-view iso\r";
+
+    $mysw->slave->stty(qw(sane -echo));
+
+    unless ($mysw->spawn($login_cmd))
+    {
+        $mysw->soft_close();
+        print "Unable to run $login_cmd\n";
+        next;
+    }
+    my @result = $mysw->expect(
+        $timeout,
+        [
+            $pwd_prompt,
+            sub {
+                $mysw->clear_accum();
+                $mysw->send("$passwd\r");
+                $mysw->clear_accum();
+                $mysw->exp_continue();
+            }
+        ],
+        [
+            "-re", $sw_prompt,
+            sub {
+                #print "$switch: sending enable command: $enable_cmd\n";
+                $mysw->clear_accum();
+                $mysw->send($enable_cmd);
+                $mysw->exp_continue();
+            }
+        ],
+        [
+            "-re", $enable_prompt,
+            sub {
+                #print "$switch: sending config command: $config_cmd\n";
+                $mysw->clear_accum();
+                $mysw->send($config_cmd);
+                $mysw->exp_continue();
+            }
+        ],
+        [
+            "-re", $config_prompt,
+            sub {
+                $mysw->clear_accum();
+                $mysw->send($cfg_user1);
+                $mysw->send($cfg_user2);
+                $mysw->send($passwd);
+                $mysw->send($snmp_passwd);
+                $mysw->send($snmp_passwd);
+                sleep 1;
+                $mysw->clear_accum();
+                # create snmp group
+                $mysw->send($cfg_group1);
+                $mysw->send($cfg_group2);
+                $mysw->send($cfg_group3);
+                $mysw->clear_accum();
+                $mysw->send($cfg_access1);
+                $mysw->send($cfg_access2);
+                $mysw->send($cfg_access3);
+                $mysw->send($cfg_access4);
+                $mysw->clear_accum();
+                $mysw->send("write memory\r");
+                $mysw->send($exit_cmd);
+                $mysw->send($exit_cmd);
+            }
+        ],
+    );
+    ##########################################
+    # Expect error - report and quit
+    ##########################################
+    if (defined($result[1]))
+    {
+        my $errmsg = $result[1];
+        $mysw->soft_close();
+        print "Failed expect command $errmsg\n";
+        exit(1);
+    }
+    $mysw->soft_close();
+
+             
+}
+
+#---------------------------------------------------------
+
+=head3    usage
+
+        Displays message for -h option
+
+=cut
+
+#---------------------------------------------------------
+sub usage
+{
+    print "Usage:
+    configBNT [-?│-h│--help] 
+    configBNT [--range switchnames] [-p|--port port] [-v|--vlan vlan]
+    configBNT [--range switchnames] [--snmp] [-u|--user snmp_user] [-w|--password snmp_password] [-g|--group snmp_group]
+    \n";
+}
+
+

--- a/xCAT-server/share/xcat/tools/configMellanox
+++ b/xCAT-server/share/xcat/tools/configMellanox
@@ -76,19 +76,19 @@ print $cmd;
 
 #call rspconfig command to setup switch
 #enable ssh
-$cmd=`rscpconfig $switch sshcfg=enable`;
+$cmd=`rspconfig $switch sshcfg=enable`;
 print $cmd;
 
 #enable snmp function on the switch
-$cmd=`rscpconfig $switch snmpcfg=enable`;
+$cmd=`rspconfig $switch snmpcfg=enable`;
 print $cmd;
 
 #enable the snmp trap
-$cmd=`rscpconfig $switch alert=enable`;
+$cmd=`rspconfig $switch alert=enable`;
 print $cmd;
 
 #Logging destination:
-$cmd=`rscpconfig $switch logdest=$ip`;
+$cmd=`rspconfig $switch logdest=$ip`;
 print $cmd;
 
 #config ntp

--- a/xCAT-server/share/xcat/tools/configMellanox
+++ b/xCAT-server/share/xcat/tools/configMellanox
@@ -78,7 +78,7 @@ if ($::SWITCH)
         exit(1);
     }
 } else {
-    xCAT::MsgUtils->message("E","Invalid flag, please provide switches with --range");
+    xCAT::MsgUtils->message("E","Invalid flag, please provide switches with --switches");
     &usage;
     exit(1);
 }
@@ -248,10 +248,10 @@ sub usage
 {
     print "Usage:
     configMellonax [-?│-h│--help] 
-    configMellonax [--range switchnames] [--all]
-    configMellonax [--range switchnames] [--ip]
-    configMellonax [--range switchnames] [--name]
-    configMellonax [--range switchnames] [--config]  
+    configMellonax [--switches switchnames] [--all]
+    configMellonax [--switches switchnames] [--ip]
+    configMellonax [--switches switchnames] [--name]
+    configMellonax [--switches switchnames] [--config]  
     \n";
 }
 

--- a/xCAT-server/share/xcat/tools/configMellanox
+++ b/xCAT-server/share/xcat/tools/configMellanox
@@ -1,0 +1,115 @@
+#!/usr/bin/env perl
+
+#---------------------------------------------------------
+# Configure Ethnet Mellonax switches
+#---------------------------------------------------------
+
+use strict;
+use Getopt::Long;
+use Expect;
+
+my $args = join ' ', @ARGV;
+$::command = "$0 $args";
+
+Getopt::Long::Configure("bundling");
+$Getopt::Long::ignorecase = 0;
+
+
+#---------------------------------------------------------
+#Main
+
+# parse the options
+if (
+    !GetOptions(
+                'h|help'       => \$::HELP,
+                'r|range=s'    => \$::SWITCH,  
+                'u|user=s'     => \$::USER,
+                'i|ip=s'     => \$::IP,
+    )
+  )
+{
+    &usage;
+    exit(1);
+}
+
+# display the usage if -h or --help is specified
+if ($::HELP)
+{
+    &usage;
+    exit(0);
+}
+
+my $switch;
+if ($::SWITCH)
+{
+    $switch = $::SWITCH;
+} else {
+    &usage;
+    exit(1);
+}
+
+my $user;
+
+if ($::USER)
+{
+    $user = $::USER;
+} else {
+    &usage;
+    exit(1);
+}
+
+my $ip;
+if ($::IP)
+{
+    $ip = $::IP;
+} else {
+    &usage;
+    exit(1);
+}
+
+
+my $cmd;
+
+#default root/password and protcol for Mellonax switch
+$cmd = `chtab switch=$switch switches.sshusername=$user`; 
+print $cmd;
+
+#call rspconfig command to setup switch
+#enable ssh
+$cmd=`rscpconfig $switch sshcfg=enable`;
+print $cmd;
+
+#enable snmp function on the switch
+$cmd=`rscpconfig $switch snmpcfg=enable`;
+print $cmd;
+
+#enable the snmp trap
+$cmd=`rscpconfig $switch alert=enable`;
+print $cmd;
+
+#Logging destination:
+$cmd=`rscpconfig $switch logdest=$ip`;
+print $cmd;
+
+#config ntp
+$cmd = `xdsh $switch -l $user --devicetype IBSwitch::Mellanox "enable;configure terminal;ntp enable;ntpdate $ip; ntp server $ip;configuration write;show ntp" `;
+print $cmd;
+
+#---------------------------------------------------------
+
+=head3    usage
+
+        Displays message for -h option
+
+=cut
+
+#---------------------------------------------------------
+sub usage
+{
+    print "Usage:
+    configMellonax [-?│-h│--help] 
+    configMellonax [--range switchnames] [-u|--user sshusername] [-i|--ip xcatMN_ip_address] 
+    \n";
+}
+
+

--- a/xCAT-server/share/xcat/tools/configMellanox
+++ b/xCAT-server/share/xcat/tools/configMellanox
@@ -22,10 +22,6 @@ use xCAT::Utils;
 use xCAT::Table;
 use xCAT::MsgUtils;
 
-
-my $args = join ' ', @ARGV;
-$::command = "$0 $args";
-
 Getopt::Long::Configure("bundling");
 $Getopt::Long::ignorecase = 0;
 
@@ -41,7 +37,7 @@ my @filternodes;
 if (
     !GetOptions(
                 'h|help'     => \$::HELP,
-                'range=s'    => \$::SWITCH,  
+                'switches=s' => \$::SWITCH,  
                 'config'     => \$::CONFIG,
                 'ip'         => \$::IP,
                 'name'       => \$::NAME,
@@ -67,8 +63,15 @@ if ($::SWITCH)
         my $nodenotdefined = join(',', nodesmissed);
         xCAT::MsgUtils->message("I","The following nodes are not defined in xCAT DB: $nodenotdefined");
     }
-    foreach (@filternodes)  {
-        push @nodes, $_;
+    # check switch type
+    my $switchestab =  xCAT::Table->new('switches');
+    my $switches_hash = $switchestab->getNodesAttribs(\@filternodes,['switchtype']);
+    foreach my $fsw (@filternodes)  {
+        if (($switches_hash->{$fsw}->[0]->{switchtype}) =~ /Mellanox/) {
+            push @nodes, $fsw;
+        } else {
+            xCAT::MsgUtils->message("E","The $fsw is not BNT switch, will not config");
+        }
     }
     unless (@nodes) {
         xCAT::MsgUtils->message("E","No Valid Switch to process");
@@ -83,34 +86,29 @@ if ($::SWITCH)
 my $switches = join(",",@nodes);
 my $user;
 my $cmd;
-my $switch;
 my $rc;
 my $master;
 
-if ($::ALL) {
-    config_ip();
-    config_hostname();
-    run_rspconfig();
-}
-if ($::IP) {
+if (($::IP) || ($::ALL)) {
     config_ip();
 }
 
-if ($::NAME) {
+if (($::NAME) || ($::ALL)) {
     config_hostname();
 }
 
 
-if ($::CONFIG)
-{
+if (($::CONFIG) || ($::ALL)) {
     run_rspconfig();
 }
 
 
 sub config_ip {
+    my @config_switches;
+    my @discover_switches;
     # get host table for otherinterfaces
     my $nodetab = xCAT::Table->new('hosts');
-    my $nodehash = $nodetab->getNodesAttribs(\@nodes,['otherinterfaces']);
+    my $nodehash = $nodetab->getNodesAttribs(\@nodes,['ip','otherinterfaces']);
     # get netmask from network table
     my $nettab = xCAT::Table->new("networks");
     my @nets;
@@ -120,40 +118,28 @@ sub config_ip {
     foreach my $switch (@nodes) {
         print "change $switch to static ip address\n";
         my $dip= $nodehash->{$switch}->[0]->{otherinterfaces};
+        my $static_ip= $nodehash->{$switch}->[0]->{ip};
 
         #get hostname
         my $dswitch = xCAT::NetworkUtils->gethostname($dip);
+        print "dip=$dip, static=$static_ip, dsw=$dswitch\n";
 
         #if not defined, need to create one for xdsh to use
         if (!$dswitch) {
             my $ip_str = $dip;
             $ip_str =~ s/\./\-/g;
             $dswitch = "switch-$ip_str";
-            #is there other way we can check if this node is defined in the xCATdb
-            $cmd = "lsdef $dswitch";
-            $rc= xCAT::Utils->runcmd($cmd, 0);
-            if ($::RUNCMD_RC != 0) {
-                $cmd = "mkdef -t node -o $dswitch groups=switch ip=$dip switchtype=Mellanox username=admin nodetype=switch";
-                $rc= xCAT::Utils->runcmd($cmd, 0);
-            }
         }
-        #check if it is in the /etc/hosts
-        my $output = `grep $dswitch /etc/hosts`;
-        if ( !$output ) {
-            $cmd = "makehosts $dswitch";
-            $rc= xCAT::Utils->runcmd($cmd, 0);
-        }
+        $cmd = "chdef -t node -o $dswitch groups=switch ip=$dip switchtype=Mellanox username=admin nodetype=switch";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+        $cmd = "makehosts $dswitch";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+
         # verify if xdsh works
         $cmd = "xdsh $dswitch -l admin --devicetype IBSwitch::Mellanox 'enable;configure terminal;exit' ";
         $rc= xCAT::Utils->runcmd($cmd, 0);
         if ($::RUNCMD_RC != 0) {
             xCAT::MsgUtils->message("E","Couldn't communicate with $dswitch, $dip");
-            next;
-        }
-        #change to static ip address
-        my $static_ip = xCAT::NetworkUtils->getipaddr($switch);
-        if (!$static_ip){
-            xCAT::MsgUtils->message("E","static ip is not defined for $switch");
             next;
         }
         #get netmask
@@ -166,20 +152,29 @@ sub config_ip {
 
         $cmd="xdsh $dswitch -t 10 -l admin --devicetype IBSwitch::Mellanox 'enable;configure terminal;no interface mgmt0 dhcp;interface mgmt0 ip address $static_ip $mask;configuration write;exit;exit' ";
         $rc= xCAT::Utils->runcmd($cmd, 0);
+        push (@discover_switches, $dswitch);
+        push (@config_switches, $switch);
+    }
 
+    if (@config_switches) {
         #update switch status
-        $cmd = "chdef $switch status=ip_configed otherinterface=";
+        my $csw = join(",",@config_switches);
+        $cmd = "chdef $csw status=ip_configed otherinterfaces=";
         $rc= xCAT::Utils->runcmd($cmd, 0);
-  
+    }
+ 
+     if (@discover_switches) {
+        my $dsw = join(",",@discover_switches);
         #remove discover switch from xCATdb and /etc/hosts
-        $cmd = "makehosts -d $dswitch";
+        $cmd = "makehosts -d $dsw";
         $rc= xCAT::Utils->runcmd($cmd, 0);
-        $cmd = "rmdef $dswitch";
+        $cmd = "rmdef $dsw";
         $rc= xCAT::Utils->runcmd($cmd, 0);
     }
 }
 
 sub config_hostname {
+    my @config_switches;
     my $switchtab = xCAT::Table->new('switches');
     my $switchhash = $switchtab->getNodesAttribs(\@nodes,['sshusername']);
     foreach my $switch (@nodes) {
@@ -196,13 +191,18 @@ sub config_hostname {
             xCAT::MsgUtils->message("E","Failed to setup hostname for $switch");
             next;
         }
+         push (@config_switches, $switch);
+    }
+    if (@config_switches) {
         #update switch status
-        $cmd = "chdef $switch status=hostname_configed" ;
+        my $csw = join(",",@config_switches);
+        $cmd = "chdef $csw status=hostname_configed" ;
         $rc= xCAT::Utils->runcmd($cmd, 0);
     }
 }
 
 sub run_rspconfig {
+    my @config_switches;
     my $switchtab = xCAT::Table->new('switches');
     my $switchhash = $switchtab->getNodesAttribs(\@nodes,['sshusername']);
     $master = `hostname -i`;
@@ -224,9 +224,12 @@ sub run_rspconfig {
 
         #config ntp
         $cmd = `xdsh $switch -l $user --devicetype IBSwitch::Mellanox "enable;configure terminal;ntp enable;ntpdate $master; ntp server $master;configuration write;show ntp" `;
-
+        push (@config_switches, $switch);
+    }
+    if (@config_switches) {
         #update switch status
-        $cmd = "chdef $switch status=switch_configed" ;
+        my $csw = join(",",@config_switches);
+        $cmd = "chdef $csw status=switch_configed" ;
         $rc= xCAT::Utils->runcmd($cmd, 0);
     }
 

--- a/xCAT-server/share/xcat/tools/configMellanox
+++ b/xCAT-server/share/xcat/tools/configMellanox
@@ -4,15 +4,34 @@
 # Configure Ethnet Mellonax switches
 #---------------------------------------------------------
 
+BEGIN
+{
+  $::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : '/opt/xcat';
+  $::XCATDIR  = $ENV{'XCATDIR'}  ? $ENV{'XCATDIR'}  : '/etc/xcat';
+}
+use lib "$::XCATROOT/lib/perl";
+
+
 use strict;
 use Getopt::Long;
 use Expect;
+use xCAT::Usage;
+use xCAT::NodeRange;
+use xCAT::NetworkUtils;
+use xCAT::Utils;
+use xCAT::Table;
+use xCAT::MsgUtils;
+
 
 my $args = join ' ', @ARGV;
 $::command = "$0 $args";
 
 Getopt::Long::Configure("bundling");
 $Getopt::Long::ignorecase = 0;
+
+#global variables
+my @nodes;
+my @filternodes;
 
 
 #---------------------------------------------------------
@@ -21,10 +40,12 @@ $Getopt::Long::ignorecase = 0;
 # parse the options
 if (
     !GetOptions(
-                'h|help'       => \$::HELP,
-                'r|range=s'    => \$::SWITCH,  
-                'u|user=s'     => \$::USER,
-                'i|ip=s'     => \$::IP,
+                'h|help'     => \$::HELP,
+                'range=s'    => \$::SWITCH,  
+                'config'     => \$::CONFIG,
+                'ip'         => \$::IP,
+                'name'       => \$::NAME,
+                'all'        => \$::ALL,
     )
   )
 {
@@ -39,61 +60,177 @@ if ($::HELP)
     exit(0);
 }
 
-my $switch;
 if ($::SWITCH)
 {
-    $switch = $::SWITCH;
+    my @filternodes = xCAT::NodeRange::noderange( $::SWITCH );
+    if (nodesmissed) {
+        my $nodenotdefined = join(',', nodesmissed);
+        xCAT::MsgUtils->message("I","The following nodes are not defined in xCAT DB: $nodenotdefined");
+    }
+    foreach (@filternodes)  {
+        push @nodes, $_;
+    }
+    unless (@nodes) {
+        xCAT::MsgUtils->message("E","No Valid Switch to process");
+        exit(1);
+    }
 } else {
+    xCAT::MsgUtils->message("E","Invalid flag, please provide switches with --range");
     &usage;
     exit(1);
 }
 
+my $switches = join(",",@nodes);
 my $user;
-
-if ($::USER)
-{
-    $user = $::USER;
-} else {
-    &usage;
-    exit(1);
-}
-
-my $ip;
-if ($::IP)
-{
-    $ip = $::IP;
-} else {
-    &usage;
-    exit(1);
-}
-
-
 my $cmd;
+my $switch;
+my $rc;
+my $master;
 
-#default root/password and protcol for Mellonax switch
-$cmd = `chtab switch=$switch switches.sshusername=$user`; 
-print $cmd;
+if ($::ALL) {
+    config_ip();
+    config_hostname();
+    run_rspconfig();
+}
+if ($::IP) {
+    config_ip();
+}
 
-#call rspconfig command to setup switch
-#enable ssh
-$cmd=`rspconfig $switch sshcfg=enable`;
-print $cmd;
+if ($::NAME) {
+    config_hostname();
+}
 
-#enable snmp function on the switch
-$cmd=`rspconfig $switch snmpcfg=enable`;
-print $cmd;
 
-#enable the snmp trap
-$cmd=`rspconfig $switch alert=enable`;
-print $cmd;
+if ($::CONFIG)
+{
+    run_rspconfig();
+}
 
-#Logging destination:
-$cmd=`rspconfig $switch logdest=$ip`;
-print $cmd;
 
-#config ntp
-$cmd = `xdsh $switch -l $user --devicetype IBSwitch::Mellanox "enable;configure terminal;ntp enable;ntpdate $ip; ntp server $ip;configuration write;show ntp" `;
-print $cmd;
+sub config_ip {
+    # get host table for otherinterfaces
+    my $nodetab = xCAT::Table->new('hosts');
+    my $nodehash = $nodetab->getNodesAttribs(\@nodes,['otherinterfaces']);
+    # get netmask from network table
+    my $nettab = xCAT::Table->new("networks");
+    my @nets;
+    if ($nettab) {
+        @nets = $nettab->getAllAttribs('net','mask');
+    }
+    foreach my $switch (@nodes) {
+        print "change $switch to static ip address\n";
+        my $dip= $nodehash->{$switch}->[0]->{otherinterfaces};
+
+        #get hostname
+        my $dswitch = xCAT::NetworkUtils->gethostname($dip);
+
+        #if not defined, need to create one for xdsh to use
+        if (!$dswitch) {
+            my $ip_str = $dip;
+            $ip_str =~ s/\./\-/g;
+            $dswitch = "switch-$ip_str";
+            #is there other way we can check if this node is defined in the xCATdb
+            $cmd = "lsdef $dswitch";
+            $rc= xCAT::Utils->runcmd($cmd, 0);
+            if ($::RUNCMD_RC != 0) {
+                $cmd = "mkdef -t node -o $dswitch groups=switch ip=$dip switchtype=Mellanox username=admin nodetype=switch";
+                $rc= xCAT::Utils->runcmd($cmd, 0);
+            }
+        }
+        #check if it is in the /etc/hosts
+        my $output = `grep $dswitch /etc/hosts`;
+        if ( !$output ) {
+            $cmd = "makehosts $dswitch";
+            $rc= xCAT::Utils->runcmd($cmd, 0);
+        }
+        # verify if xdsh works
+        $cmd = "xdsh $dswitch -l admin --devicetype IBSwitch::Mellanox 'enable;configure terminal;exit' ";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+        if ($::RUNCMD_RC != 0) {
+            xCAT::MsgUtils->message("E","Couldn't communicate with $dswitch, $dip");
+            next;
+        }
+        #change to static ip address
+        my $static_ip = xCAT::NetworkUtils->getipaddr($switch);
+        if (!$static_ip){
+            xCAT::MsgUtils->message("E","static ip is not defined for $switch");
+            next;
+        }
+        #get netmask
+        my $mask;
+        foreach my $net (@nets) {
+            if (xCAT::NetworkUtils::isInSameSubnet( $net->{'net'}, $static_ip, $net->{'mask'}, 0)) {
+                $mask=$net->{'mask'};
+            }
+        }
+
+        $cmd="xdsh $dswitch -t 10 -l admin --devicetype IBSwitch::Mellanox 'enable;configure terminal;no interface mgmt0 dhcp;interface mgmt0 ip address $static_ip $mask;configuration write;exit;exit' ";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+
+        #update switch status
+        $cmd = "chdef $switch status=ip_configed otherinterface=";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+  
+        #remove discover switch from xCATdb and /etc/hosts
+        $cmd = "makehosts -d $dswitch";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+        $cmd = "rmdef $dswitch";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+    }
+}
+
+sub config_hostname {
+    my $switchtab = xCAT::Table->new('switches');
+    my $switchhash = $switchtab->getNodesAttribs(\@nodes,['sshusername']);
+    foreach my $switch (@nodes) {
+        my $user= $switchhash->{$switch}->[0]->{sshusername};
+        if (!$user) {
+            print "switch ssh username is not defined, add default one\n";
+            $cmd = "chdef $switch username=admin";
+            $rc= xCAT::Utils->runcmd($cmd, 0);
+            $user="admin";
+        }
+        $cmd="xdsh $switch -l $user --devicetype IBSwitch::Mellanox 'enable;configure terminal;hostname $switch;configuration write' ";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+        if ($::RUNCMD_RC != 0) {
+            xCAT::MsgUtils->message("E","Failed to setup hostname for $switch");
+            next;
+        }
+        #update switch status
+        $cmd = "chdef $switch status=hostname_configed" ;
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+    }
+}
+
+sub run_rspconfig {
+    my $switchtab = xCAT::Table->new('switches');
+    my $switchhash = $switchtab->getNodesAttribs(\@nodes,['sshusername']);
+    $master = `hostname -i`;
+    print "master=$master\n";
+    foreach my $switch (@nodes) {
+        my $user= $switchhash->{$switch}->[0]->{sshusername};
+        #call rspconfig command to setup switch
+        #enable ssh
+        $cmd=`rspconfig $switch sshcfg=enable`;
+
+        #enable snmp function on the switch
+        $cmd=`rspconfig $switch snmpcfg=enable`;
+
+        #enable the snmp trap
+        $cmd=`rspconfig $switch alert=enable`;
+
+        #Logging destination:
+        $cmd=`rspconfig $switch logdest=$master`;
+
+        #config ntp
+        $cmd = `xdsh $switch -l $user --devicetype IBSwitch::Mellanox "enable;configure terminal;ntp enable;ntpdate $master; ntp server $master;configuration write;show ntp" `;
+
+        #update switch status
+        $cmd = "chdef $switch status=switch_configed" ;
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+    }
+
+}
 
 #---------------------------------------------------------
 
@@ -108,7 +245,10 @@ sub usage
 {
     print "Usage:
     configMellonax [-?│-h│--help] 
-    configMellonax [--range switchnames] [-u|--user sshusername] [-i|--ip xcatMN_ip_address] 
+    configMellonax [--range switchnames] [--all]
+    configMellonax [--range switchnames] [--ip]
+    configMellonax [--range switchnames] [--name]
+    configMellonax [--range switchnames] [--config]  
     \n";
 }
 


### PR DESCRIPTION
Add Switch-based switch discovery for hardware discovery
1) need to manually define and configure core-switch on xCAT MN 
2) need to predefine switch with core-switch ,port number and static ip address
`````
# cat switch-192-168-5-22.stanza
switch-192-168-5-22:
    objtype=node
    groups=switch
    ip=192.168.5.22
    mgt=switch
    nodetype=switch
    switch=switch-10-5-23-1
    switchport=45
    switchtype=BNT
``````
3) To discovery switch via dynamic dhcp ip address:
``````
switchdiscovery --range dynamic_ip -s snmp --setup
``````
this command 
---will discover switch with dynamic ip address, 
---use mac address to match pre-defined switch 
---set static ip address to discovered switch
---set host name via predefine switch 
---remove discovered switch definition from xCAT DB
--- set mac address to predefine switch
4) config switch
BNT:
````
# ./configBNT
Usage:
    configBNT [-?│-h│--help]
    configBNT [--range switchnames] [-p|--port port] [-v|--vlan vlan]
    configBNT [--range switchnames] [--snmp] [-u|--user snmp_user] [-w|--password snmp_password] [-g|--group snmp_group]
``````
Mellanox:
````
# ./configMellanox
Usage:
    configMellonax [-?│-h│--help]
    configMellonax [--range switchnames] [-u|--user sshusername] [-i|--ip xcatMN_ip_address]
``````

