### PR TITLE
Add rest api helper interface to access non-xcat resource

### DIFF
--- a/xCAT-server/lib/xcat/plugins/localrest.pm
+++ b/xCAT-server/lib/xcat/plugins/localrest.pm
@@ -1,0 +1,211 @@
+# IBM(c) 2007 EPL license http://www.eclipse.org/legal/epl-v10.html
+#-------------------------------------------------------
+
+=head1
+  xCAT plugin package to non xcat resource
+
+=cut
+
+#-------------------------------------------------------
+package xCAT_plugin::localrest;
+
+BEGIN {
+    $::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : -d '/opt/xcat' ? '/opt/xcat' : '/usr';
+}
+use lib "$::XCATROOT/lib/perl";
+
+use xCAT::Utils;
+use xCAT::MsgUtils;
+use File::Basename;
+use strict;
+
+#-------------------------------------------------------
+
+=head3  handled_commands
+
+Return list of commands handled by this plugin
+
+=cut
+
+#-------------------------------------------------------
+
+sub handled_commands
+{
+    return {
+        localrest => "localrest",
+    };
+}
+
+#-------------------------------------------------------
+
+=head3  process_request
+
+  Process the command.
+
+=cut
+
+#-------------------------------------------------------
+sub process_request
+{
+    my $request = shift;
+    $::callback = shift;
+    my $subreq  = shift;
+    my $command = $request->{command}->[0];
+
+    if ($command eq "localrest") {
+        return handle_rest_request($request, $subreq);
+    }
+}
+
+#-------------------------------------------------------
+
+=head3  handle_rest_request
+
+  This function check the command option, then call the
+  related function to complete the request.
+
+  Usage example:
+        This function is called from process_request,
+        do not call it directly.
+=cut
+
+#-------------------------------------------------------
+
+sub handle_rest_request {
+    my ($request, $subreq) = @_;
+    my ($method, $resource, @params, $subroutine, $rsp, $rc);
+    require JSON;
+    my $JSON = JSON->new();
+
+    my @args = @{ $request->{arg} };
+    if (scalar(@args) < 2) {
+        $rsp->{data}->[0] = "Local rest api take at least two parameter.";
+        xCAT::MsgUtils->message("E", $rsp, $::callback);
+        return 1;
+    }
+    $method     = shift @args;
+    $resource   = shift @args;
+    $subroutine = $method . '_' . $resource;
+    @params     = @args;
+
+    # if related subroutine found, call it
+    # subroutine for rest handler must return a ref to HASH or ARRAY
+    # comtaining the data that should be return to the CGI
+    if (__PACKAGE__->can({$subroutine})) {
+        $rsp->{data}->[0] = "Unsupported request: $subroutine.";
+        xCAT::MsgUtils->message("E", $rsp, $::callback);
+        return 1;
+    }
+    no strict 'refs';
+    my $result = $subroutine->(@params);
+
+    # handle the result from the rest subroutine
+    if (ref($result) eq 'HASH') {
+        if (defined($result->{'type'}) && $result->{'type'} eq 'stream'
+            && defined($result->{'filename'})) {
+            $rsp->{data}->[0] = "stream";
+            $rsp->{data}->[1] = $result->{'filename'};
+            $rsp->{data}->[2] = $result->{'data'};
+        } else {
+            my $json = $JSON->encode($result);
+            $rsp->{data}->[0] = "json";
+            $rsp->{data}->[1] = $json;
+        }
+        xCAT::MsgUtils->message("I", $rsp, $::callback);
+        $rc = 0;
+    } elsif (ref($result) eq 'ARRAY') {
+        my $json = $JSON->encode($result);
+        $rsp->{data}->[0] = "json";
+        $rsp->{data}->[1] = $json;
+        xCAT::MsgUtils->message("I", $rsp, $::callback);
+        $rc = 0;
+    } elsif ($result == 1 || $result == 0) {
+        $rc = $result;
+    } else {
+        $rc = 1;
+        $rsp->{data}->[0] = "Internal error, result value is unacceptable";
+        xCAT::MsgUtils->message("E", $rsp, $::callback);
+    }
+    return $rc;
+}
+
+#-------------------------------------------------------
+
+=head3  handler to list network adapters
+
+  Subroutine to handle rest request
+  GET /localres/adapter/
+
+  Usage example:
+        This function is called from handle_rest_request,
+        do not call it directly.
+=cut
+
+#-------------------------------------------------------
+sub list_adapter {
+    my ($rsp, $result, $i);
+    if (!opendir DIR, "/sys/class/net") {
+        $rsp->{data}->[0] = "Unable open /sys/class/net dir.";
+        xCAT::MsgUtils->message("E", $rsp, $::callback);
+        return 1;
+    }
+    my @dir = readdir(DIR);
+    closedir(DIR);
+    $i = 0;
+    foreach my $item (@dir) {
+        if ($item eq '.' || $item eq '..') {
+            next;
+        }
+        $result->[ $i++ ] = $item;
+    }
+    return $result;
+}
+
+#-------------------------------------------------------
+
+=head3  handler to download credential files
+
+  Subroutine to handle rest request
+  GET /localres/credential/conserver/file
+  GET /localres/credential/ca/file
+
+  Usage example:
+        This function is called from handle_rest_request,
+        do not call it directly.
+=cut
+
+#-------------------------------------------------------
+sub download_credential {
+    my @params = @_;
+    my ($rsp, $buf, $fpath, $fd, $data, $result, $n);
+    if (!@params) {
+        $rsp->{data}->[0] = "Argmument error.";
+        xCAT::MsgUtils->message("E", $rsp, $::callback);
+        return 1;
+    }
+    my %filemap = (
+        'conserver' => "/home/conserver/.xcat/client-cred.pem",
+        'ca'        => "/home/conserver/.xcat/ca.pem",
+    );
+    $fpath = $filemap{ $params[0] };
+    if (!$fpath || !-e $fpath) {
+        $rsp->{data}->[0] = "File resource for " . $params[0] . " unavailable.";
+        xCAT::MsgUtils->message("E", $rsp, $::callback);
+        return 1;
+    }
+
+    if (!($n = open($fd, '<', $fpath))) {
+        $rsp->{data}->[0] = "Coundn't open file $fpath.";
+        xCAT::MsgUtils->message("E", $rsp, $::callback);
+        return 1;
+    }
+    while ($n = read($fd, $buf, 8192)) {
+        $data .= $buf;
+    }
+    close($fd);
+    $result->{'type'}     = 'stream';
+    $result->{'filename'} = basename($fpath);
+    $result->{'data'}     = $data;
+    return $result;
+}
+1;

--- a/xCAT-server/sbin/xcatconfig
+++ b/xCAT-server/sbin/xcatconfig
@@ -448,12 +448,6 @@ if ($::INITIALINSTALL || $::FORCE || $::UPDATEINSTALL || $::genCredentials)
     }
     else
     {
-        #since the xcatd service unit file is updated on xcat upgrade
-        #"systemctl daemon-reload" need to be run to update the service unit
-        if ($::UPDATEINSTALL){
-            $xcmd="type systemctl >/dev/null 2>&1 && systemctl daemon-reload";
-            xCAT::Utils->runcmd("$xcmd", 0);
-        }
         #$xcmd = "/etc/init.d/xcatd restart";
         xCAT::Utils->restartservice("xcatd");
     }
@@ -1507,8 +1501,30 @@ sub checkotherpkgs
 #-----------------------------------------------------------------------------
 
 sub genCredentials
-
 {
+    my $add_user_func = sub {
+        my $user = shift;
+        my ($cmd, $outref, $rc);
+        $rc = getgrnam($user);
+        if (!$rc) {
+            $cmd = "groupadd $user";
+            $outref = xCAT::Utils->runcmd("$cmd", 0);
+            if ($::RUNCMD_RC != 0) {
+                xCAT::MsgUtils->message('E',"$cmd failed");
+                return;
+            }
+        }
+        $rc = getpwnam($user);
+        if (!$rc) {
+            $cmd = "useradd -g $user -s /bin/bash -d /home/$user -m $user";
+            $outref = xCAT::Utils->runcmd("$cmd", 0);
+            if ($::RUNCMD_RC != 0) {
+               xCAT::MsgUtils->message('E',"$cmd failed");
+               return;
+            }
+        }
+    };
+
     my $hname = `hostname`;
     chomp $hname;
     if ((!-d "/etc/xcat/ca") || $::FORCE || $::genCredentials)
@@ -1609,6 +1625,24 @@ sub genCredentials
         {
             xCAT::MsgUtils->message('E',
                  "Could not create xCAT certificate in /.xcat/client-key.pem.");
+        }
+        else
+        {
+            xCAT::MsgUtils->message('I', "Created xCAT certificate.");
+        }
+    }
+
+    if ((!-r "/home/conserver/.xcat/client-key.pem") || $::FORCE || $::genCredentials)
+    {
+        $add_user_func->('conserver');
+        my $cmd =
+          "echo 'y\ny\ny\ny' |$::XCATROOT/share/xcat/scripts/setup-local-client.sh conserver";
+        verbose("Running $cmd");
+        my $rc = system($cmd);
+        if ($rc >> 8)
+        {
+            xCAT::MsgUtils->message('E',
+                 "Could not create xCAT certificate in /home/conserver/.xcat/client-key.pem.");
         }
         else
         {


### PR DESCRIPTION
Currently xcat rest service is running with apache user who do
not have the privilege to manage some local resource like credential
files needed by xcat web ui to get the conserver access.

This patch add scripts in xcatconfig to generate credential files
for conserver user. This patch also add a work around framework for
xcat restapi to provide the interface to get or set the system resource
so that restapi with apache privilege can retrieve the credential files.