### PR TITLE
Fix some wording in the log messages generated during HW discovery

### DIFF
--- a/xCAT-server/lib/xcat/plugins/aaadiscovery.pm
+++ b/xCAT-server/lib/xcat/plugins/aaadiscovery.pm
@@ -42,7 +42,7 @@ sub process_request {
 	    }
 	}
 
-        xCAT::MsgUtils->message("S", "xcat.discovery.aaadiscovery: ($mac) Get a discover request");
+        xCAT::MsgUtils->message("S", "xcat.discovery.aaadiscovery: ($mac) Got a discovery request, attempting to discover the node...");
         $req->{discoverymethod}->[0] = 'undef';
         $req->{_xcat_clientmac}->[0] = $mac;
         xCAT::DiscoveryUtils->update_discovery_data($req);

--- a/xCAT-server/lib/xcat/plugins/blade.pm
+++ b/xCAT-server/lib/xcat/plugins/blade.pm
@@ -4375,7 +4375,6 @@ sub process_request {
         return;
     }
 
-    xCAT::MsgUtils->message("S", "xcat.discovery.blade: ($request->{_xcat_clientmac}->[0]) Processing discovery request");
     my $mptab = xCAT::Table->new("mp");
     unless ($mptab) { return 2; }
     my @bladents = $mptab->getAllNodeAttribs([qw(node)]);
@@ -4454,7 +4453,7 @@ sub process_request {
        }
     }
     unless ($node) {
-      xCAT::MsgUtils->message("S", "xcat.discovery.blade: ($request->{_xcat_clientmac}->[0]) Error: Could not find any node");
+      xCAT::MsgUtils->message("S", "xcat.discovery.blade: ($request->{_xcat_clientmac}->[0]) Warning: Could not find any nodes using blade-based discovery");
       return 1; #failure
     }
     if ($request->{mtm} and $request->{mtm} =~ /^(\w{4})/) {
@@ -4470,7 +4469,7 @@ sub process_request {
        undef $mactab;
     }
 
-    xCAT::MsgUtils->message("S", "xcat.discovery.blade: ($request->{_xcat_clientmac}->[0]) Find node $node for the discovery request");
+    xCAT::MsgUtils->message("S", "xcat.discovery.blade: ($request->{_xcat_clientmac}->[0]) Found node: $node");
     #my %request = (
     #  command => ['makedhcp'],
     #  node => [$macmap{$mac}]

--- a/xCAT-server/lib/xcat/plugins/hpblade.pm
+++ b/xCAT-server/lib/xcat/plugins/hpblade.pm
@@ -689,7 +689,6 @@ sub process_request {
                     # The findme request had been processed by other module, just return
                     return;
                 }
-                xCAT::MsgUtils->message("S", "xcat.discovery.hpblade: ($request->{_xcat_clientmac}->[0]) Processing discovery request");
 		my $mptab = xCAT::Table->new("mp");
 		unless ($mptab) { return 2; }
 		my @bladents = $mptab->getAllNodeAttribs([qw(node)]);
@@ -733,7 +732,7 @@ sub process_request {
 			}
 		}
 		unless ($macmap{$mac}) { 
-                        xCAT::MsgUtils->message("S", "xcat.discovery.hpblade: ($request->{_xcat_clientmac}->[0]) Error: Could not find any node");
+                        xCAT::MsgUtils->message("S", "xcat.discovery.hpblade: ($request->{_xcat_clientmac}->[0]) Warning: Could not find any nodes using hpblade-based discovery");
 			return 1; #failure
 		}
                 # The discovered command will update mac table, no need to update here
@@ -745,7 +744,7 @@ sub process_request {
 		#  node => [$macmap{$mac}]
 		#  );
 		#$doreq->(\%request);
-                xCAT::MsgUtils->message("S", "xcat.discovery.hpblade: ($request->{_xcat_clientmac}->[0]) Find node:$macmap{$mac} for the discovery request");
+                xCAT::MsgUtils->message("S", "xcat.discovery.hpblade: ($request->{_xcat_clientmac}->[0]) Found node: $macmap{$mac}");
                 my $req={%$request};
 		$req->{command}=['discovered'];
 		$req->{noderange} = [$macmap{$mac}];

--- a/xCAT-server/lib/xcat/plugins/nodediscover.pm
+++ b/xCAT-server/lib/xcat/plugins/nodediscover.pm
@@ -375,7 +375,7 @@ sub process_request {
         syslog("local4|info", "The attribute bmcinband is specified, just remove the temp BMC node if there is");
         if (defined($request->{bmc_node}) and defined($request->{bmc_node}->[0]))  {
             my $bmc_node = $request->{bmc_node}->[0];
-            syslog("local4|info", "Find BMC $bmc_node, so remove it");
+            syslog("local4|info", "Found node corresponding to BMC=$bmc_node, removing it...");
             $doreq->({ command => ['rmdef'], arg => [$bmc_node]});
         }
     } else {

--- a/xCAT-server/lib/xcat/plugins/seqdiscovery.pm
+++ b/xCAT-server/lib/xcat/plugins/seqdiscovery.pm
@@ -62,9 +62,6 @@ sub findme {
         return;
     }
 
-    # do the sequential discovery
-    xCAT::MsgUtils->message("S", "xcat.discovery.seqdiscovery: ($request->{_xcat_clientmac}->[0]) Processing discovery request");
-
     # Get the parameters for the sequential discovery
     my %param;
     my @params = split (',', $SEQdiscover[0]);
@@ -373,7 +370,7 @@ sub findme {
 
         # call the discovered command to update the discovery request to a node
          
-        xCAT::MsgUtils->message("S", "xcat.discovery.seqdiscovery: ($request->{_xcat_clientmac}->[0]) Find node:$node for the discovery request");
+        xCAT::MsgUtils->message("S", "xcat.discovery.seqdiscovery: ($request->{_xcat_clientmac}->[0]) Found node: $node");
         $request->{discoverymethod} = ['sequential'];
         my $req = {%$request};
         $req->{command}=['discovered'];
@@ -386,7 +383,7 @@ sub findme {
         undef $mactab;
     } else {
         nodediscoverstop($callback, undef, "node names");
-        xCAT::MsgUtils->message("S", "xcat.discovery.seqdiscovery: ($request->{_xcat_clientmac}->[0]) Error: Could not find any node");
+        xCAT::MsgUtils->message("S", "xcat.discovery.seqdiscovery: ($request->{_xcat_clientmac}->[0]) Warning: Could not find any nodes using sequential-based discovery");
         return;
     }
 

--- a/xCAT-server/lib/xcat/plugins/switch.pm
+++ b/xCAT-server/lib/xcat/plugins/switch.pm
@@ -278,7 +278,6 @@ sub process_request {
             return;
         }
         $mac = $req->{_xcat_clientmac}->[0];
-        xCAT::MsgUtils->message("S", "xcat.discovery.switch: ($mac) Processing discovery request");
 	if (defined $req->{nodetype} and $req->{nodetype}->[0] eq 'virtual') {
 	    #Don't attempt switch discovery of a  VM Guest
 	    #TODO: in this case, we could/should find the host system 
@@ -313,7 +312,7 @@ sub process_request {
         }
 	 
 	if ($node) {
-            xCAT::MsgUtils->message("S", "xcat.discovery.switch: ($req->{_xcat_clientmac}->[0]) Find node:$node for the discovery request");
+            xCAT::MsgUtils->message("S", "xcat.discovery.switch: ($req->{_xcat_clientmac}->[0]) Found node: $node");
             # No need to write mac table here, 'discovered' command will write
 	    # my $mactab = xCAT::Table->new('mac',-create=>1);
 	    # $mactab->setNodeAttribs($node,{mac=>$mac});
@@ -332,7 +331,7 @@ sub process_request {
 	    %{$request}=();#Clear req structure, it's done..
 	    undef $mactab;
 	} else { 
-            xCAT::MsgUtils->message("S", "xcat.discovery.switch: ($req->{_xcat_clientmac}->[0]) Error: Could not find any node");
+            xCAT::MsgUtils->message("S", "xcat.discovery.switch: ($req->{_xcat_clientmac}->[0]) Warning: Could not find any nodes using switch-based discovery");
 	}
     }
 }

--- a/xCAT-server/lib/xcat/plugins/typemtms.pm
+++ b/xCAT-server/lib/xcat/plugins/typemtms.pm
@@ -22,7 +22,6 @@ sub findme {
     }
     my @attr_array = ();
     my $mtms = $request->{'mtm'}->[0]."*".$request->{'serial'}->[0]; 
-    xCAT::MsgUtils->message("S", "xcat.discovery.mtms: ($request->{_xcat_clientmac}->[0]) Processing discovery request");
     my $tmp_nodes = $::XCATVPDHASH{$mtms};
     my @nodes = ();
     my $bmc_node;
@@ -35,14 +34,14 @@ sub findme {
     }
     my $nodenum = $#nodes;
     if ($nodenum < 0) {
-        xCAT::MsgUtils->message("S", "xcat.discovery.mtms: ($request->{_xcat_clientmac}->[0]) Error: Could not find any node");
+        xCAT::MsgUtils->message("S", "xcat.discovery.mtms: ($request->{_xcat_clientmac}->[0]) Warning: Could not find any nodes using mtms-based discovery");
         return;
     } elsif ($nodenum > 0) {
         xCAT::MsgUtils->message("S", "xcat.discovery.mtms: ($request->{_xcat_clientmac}->[0]) Error: More than one node were found");
         return;
     }
     {
-        xCAT::MsgUtils->message("S", "xcat.discovery.mtms: ($request->{_xcat_clientmac}->[0]) Find node:$nodes[0] for the discovery request");
+        xCAT::MsgUtils->message("S", "xcat.discovery.mtms: ($request->{_xcat_clientmac}->[0]) Found node: $nodes[0]");
         $request->{discoverymethod}->[0] = 'mtms';
         my $req = {%$request};
         $req->{command} = ['discovered'];

--- a/xCAT-server/lib/xcat/plugins/zzzdiscovery.pm
+++ b/xCAT-server/lib/xcat/plugins/zzzdiscovery.pm
@@ -17,15 +17,14 @@ sub process_request {
     my $cb = shift;
     my $doreq = shift;
     if ($req->{command}->[0] eq 'findme') {
-        xCAT::MsgUtils->message("S", "xcat.discovery.zzzdiscovery: ($req->{_xcat_clientmac}->[0]) Finish to process the discovery request");
         if (!defined($req->{discoverymethod}) or !defined($req->{discoverymethod}->[0]) or ($req->{discoverymethod}->[0] eq 'undef'))  {
             my $rsp = {};
             $rsp->{error}->[0] = "The discovery request can not be processed";
             $cb->($rsp);
-            xCAT::MsgUtils->message("S", "xcat.discovery.zzzdiscovery: ($req->{_xcat_clientmac}->[0]) Failed to be processed");
+            xCAT::MsgUtils->message("S", "xcat.discovery.zzzdiscovery: ($req->{_xcat_clientmac}->[0]) Failed to discover the node.");
             return;
         }
-        xCAT::MsgUtils->message("S", "xcat.discovery.zzzdiscovery: ($req->{_xcat_clientmac}->[0]) Successfully processed by $req->{discoverymethod}->[0] method");
+        xCAT::MsgUtils->message("S", "xcat.discovery.zzzdiscovery: ($req->{_xcat_clientmac}->[0]) Successfully discovered the node using $req->{discoverymethod}->[0] discovery method.");
         return;
     }
 }


### PR DESCRIPTION
Fix some of the wording and simplify the number of messages that appear during discovery to shorten the amount of lines produced when doing HW discovery...   

Before... 
```
[root@fs1 xcat]# grep discovery /var/log/xcat/cluster.log 
Jul 18 16:01:47 fs1 xcat[54000]: xcatd: Processing discovery request from 192.168.5.161
Jul 18 16:01:47 fs1 xcat[54000]: xcat.discovery.aaadiscovery: (70:e2:84:14:09:f6) Get a discover request
Jul 18 16:01:47 fs1 xcat[54000]: xcat.discovery.blade: (70:e2:84:14:09:f6) Processing discovery request
Jul 18 16:01:47 fs1 xcat[54000]: xcat.discovery.blade: (70:e2:84:14:09:f6) Error: Could not find any node
Jul 18 16:01:47 fs1 xcat[54000]: xcat.discovery.switch: (70:e2:84:14:09:f6) Processing discovery request
Jul 18 16:01:50 fs1 xcat[54000]: xcat.discovery.switch: (70:e2:84:14:09:f6) Find node:c910f05c25 for the discovery request
Jul 18 16:01:53 fs1 xcat[54000]: xcat.discovery.zzzdiscovery: (70:e2:84:14:09:f6) Finish to process the discovery request
Jul 18 16:01:53 fs1 xcat[54000]: xcat.discovery.zzzdiscovery: (70:e2:84:14:09:f6) Successfully processed by switch method
Jul 18 16:03:16 fs1 xcat[54000]: xcatd: Processing discovery request from 192.168.5.162
Jul 18 16:03:16 fs1 xcat[54000]: xcat.discovery.aaadiscovery: (70:e2:84:14:0a:71) Get a discover request
Jul 18 16:03:16 fs1 xcat[54000]: xcat.discovery.blade: (70:e2:84:14:0a:71) Processing discovery request
Jul 18 16:03:16 fs1 xcat[54000]: xcat.discovery.blade: (70:e2:84:14:0a:71) Error: Could not find any node
Jul 18 16:03:16 fs1 xcat[54000]: xcat.discovery.switch: (70:e2:84:14:0a:71) Processing discovery request
Jul 18 16:03:18 fs1 xcat[54000]: xcat.discovery.switch: (70:e2:84:14:0a:71) Find node:c910f05c27 for the discovery request
Jul 18 16:03:21 fs1 xcat[54000]: xcat.discovery.zzzdiscovery: (70:e2:84:14:0a:71) Finish to process the discovery request
Jul 18 16:03:21 fs1 xcat[54000]: xcat.discovery.zzzdiscovery: (70:e2:84:14:0a:71) Successfully processed by switch method
```

After: 
```
Jul 18 16:14:12 fs1 xcat[57312]: xcatd: Processing discovery request from 192.168.5.163
Jul 18 16:14:12 fs1 xcat[57312]: xcat.discovery.aaadiscovery: (70:e2:84:14:09:f6) Got a discovery request, attempting to discover the node...
Jul 18 16:14:12 fs1 xcat[57312]: xcat.discovery.blade: (70:e2:84:14:09:f6) Warning: Could not find any nodes using blade-based discovery
Jul 18 16:14:14 fs1 xcat[57312]: xcat.discovery.switch: (70:e2:84:14:09:f6) Found node: c910f05c25
Jul 18 16:14:18 fs1 xcat[57312]: xcat.discovery.zzzdiscovery: (70:e2:84:14:09:f6) Successfully discovered the node using switch discovery method.
Jul 18 16:15:14 fs1 xcat[57312]: xcatd: Processing discovery request from 192.168.5.152
Jul 18 16:15:14 fs1 xcat[57312]: xcat.discovery.aaadiscovery: (70:e2:84:14:0a:71) Got a discovery request, attempting to discover the node...
Jul 18 16:15:14 fs1 xcat[57312]: xcat.discovery.blade: (70:e2:84:14:0a:71) Warning: Could not find any nodes using blade-based discovery
Jul 18 16:15:16 fs1 xcat[57312]: xcat.discovery.switch: (70:e2:84:14:0a:71) Found node: c910f05c27
Jul 18 16:15:20 fs1 xcat[57312]: xcat.discovery.zzzdiscovery: (70:e2:84:14:0a:71) Successfully discovered the node using switch discovery method.

```