### PR TITLE
Remove the chmod calls in the xCAT-probe spec file

### DIFF
--- a/xCAT-probe/xCAT-probe.spec
+++ b/xCAT-probe/xCAT-probe.spec
@@ -37,14 +37,8 @@ mkdir -p $RPM_BUILD_ROOT/%{prefix}/bin
 mkdir -p $RPM_BUILD_ROOT/%{prefix}/probe/
 
 cp xcatprobe $RPM_BUILD_ROOT/%{prefix}/bin
-chmod 755 $RPM_BUILD_ROOT/%{prefix}/bin/*
-
 cp -r subcmds  $RPM_BUILD_ROOT/%{prefix}/probe/
-chmod 755 $RPM_BUILD_ROOT/%{prefix}/probe/subcmds/*
-
 cp -r lib $RPM_BUILD_ROOT/%{prefix}/probe/
-chmod -R 644 $RPM_BUILD_ROOT/%{prefix}/probe/lib/perl/
-chmod -R 644 $RPM_BUILD_ROOT/%{prefix}/probe/lib/perl/xCAT/
 
 %clean
 # This step does not happen until *after* the %files packaging below


### PR DESCRIPTION
Fix Issue #1549 


Removing the chmod commands in the xCAT-probe.spec file.   These are causing some unwanted behavior: 

1) Cannot build in local forked copy 

```
[vhu@victorvm7 xcat-core]$ ./makerpm  xCAT-probe 
Building /home/vhu/rpmbuild/RPMS/noarch/xCAT-probe-2.12.2-snap*.noarch.rpm ...
rm: cannot remove '/home/vhu/rpmbuild/BUILDROOT/xCAT-probe-2.12.2-snap201607211542.x86_64/opt/xcat/probe/lib/perl/xCAT': Permission denied
rm: cannot remove '/home/vhu/rpmbuild/BUILDROOT/xCAT-probe-2.12.2-snap201607211542.x86_64/opt/xcat/probe/lib/perl/probe_utils.pm': Permission denied
error: Bad exit status from /var/tmp/rpm-tmp.urk1s5 (%install)
    Bad exit status from /var/tmp/rpm-tmp.urk1s5 (%install)
```

2)  Cannot clean up the BUILDROOT 
```
[vhu@victorvm7 BUILDROOT]$ rm -rf *
rm: cannot remove ‘xCAT-probe-2.12.2-snap201607180938.x86_64/opt/xcat/probe/lib/perl/xCAT’: Permission denied
rm: cannot remove ‘xCAT-probe-2.12.2-snap201607180938.x86_64/opt/xcat/probe/lib/perl/probe_utils.pm’: Permission denied
```

Since we do not want to explicitely define all the files being shipped in the RPM, we should rely on the developers to create the file permissions correctly to avoid this unwanted behavior. 



