### PR TITLE
Fix xcat-genesis-base-x86-64 build issue on CentOS6.6

### DIFF
--- a/xCAT-genesis-builder/buildrpm
+++ b/xCAT-genesis-builder/buildrpm
@@ -58,6 +58,7 @@ cp $DIR/* $DRACUTMODDIR
 # Remove the ipr(IBM Power RAID) stuff when building on x86_64
 if [ $BUILDARCH = "x86_64" ]; then
     sed -i 's/dracut_install \/lib64\/libform.so.5//' $DRACUTMODDIR/install
+    sed -i 's/\/lib\/libtinfo.so.5.7/\/lib64\/libtinfo.so.5.7/' $DRACUTMODDIR/install
     sed -i 's/\/lib64\/libpanel.so.5//' $DRACUTMODDIR/install
     sed -i 's/\/lib64\/libmenu.so.5//' $DRACUTMODDIR/install
     sed -i 's/\/lib64\/libsysfs.so.2//' $DRACUTMODDIR/install


### PR DESCRIPTION
Fix the issue like below:

[root@ct6mn xcat]# ./share/xcat/netboot/genesis/builder/buildrpm
cp: omitting directory `/opt/xcat/share/xcat/netboot/genesis/builder/debian'
Creating the initramfs in /tmp/xcatgenesis.985.rfs using dracut ...

E: Failed to install /lib/libtinfo.so.5.7   <=====================
Expanding the initramfs into /tmp/xcatgenesis.985/opt/xcat/share/xcat/netboot/genesis/x86_64/fs ...
gzip: /tmp/xcatgenesis.985.rfs.gz: No such file or directory
cpio: premature end of archive
Adding kernel /boot/vmlinuz-x86_64 ...
/opt/xcat
...
....