### PR TITLE
fix issue  [DEV] "makehosts" generates the /etc/hosts entries with wrong domain name for node with "otherinterfaces" attribute #1575

### DIFF
--- a/xCAT-server/lib/xcat/plugins/hosts.pm
+++ b/xCAT-server/lib/xcat/plugins/hosts.pm
@@ -203,6 +203,13 @@ sub addotherinterfaces
             {
                 $itf = $node . $itf;
             }
+            
+            #lookup the domain for the ip address
+            #if failed, use the domain passed in
+            my ($mydomain,$mynet)=getIPdomain($ip);
+            if($mydomain){
+               $domain=$mydomain;
+            }
             addnode $callback, $itf, $ip, '', $domain;
         }
     }


### PR DESCRIPTION
fix https://github.com/xcat2/xcat-core/issues/1575