### PR TITLE
Add some error checking and dependency packages to xCAT-genesis-builder

### DIFF
--- a/xCAT-genesis-builder/buildrpm
+++ b/xCAT-genesis-builder/buildrpm
@@ -170,9 +170,20 @@ if [ $BUILDARCH = "ppc64" ]; then
 else
     dracut -m "xcat base" -f /tmp/xcatgenesis.$$.rfs $KERNELVERSION
 fi
+
+if [ $? -ne 0 ]; then
+    echo "ERROR - creating the initramfs, please correct the issues and try again"
+    exit 1
+fi
+
 echo Expanding the initramfs into /tmp/xcatgenesis.$$/opt/xcat/share/xcat/netboot/genesis/$BUILDARCH/fs ...
 cd /tmp/xcatgenesis.$$/opt/xcat/share/xcat/netboot/genesis/$BUILDARCH/fs 
 zcat /tmp/xcatgenesis.$$.rfs|cpio -dumi
+
+if [ $? -ne 0 ]; then
+    echo "ERROR - expanding the initramfs, please correct the issues and try again"
+    exit 1
+fi
 
 # add the kernel
 if [ "$HOSTOS" = "mcp" ]; then

--- a/xCAT-genesis-builder/xCAT-genesis-builder.spec
+++ b/xCAT-genesis-builder/xCAT-genesis-builder.spec
@@ -4,7 +4,7 @@ BuildArch: noarch
 Release: snap%(date +"%Y%m%d%H%M")
 Epoch: 1
 AutoReq: false
-Requires: ipmitool screen btrfs-progs lldpad rpm-build compat-libstdc++-33
+Requires: ipmitool screen btrfs-progs lldpad rpm-build compat-libstdc++-33 mstflint xfsprogs nc reiserfs-utils
 Prefix: /opt/xcat
 AutoProv: false
 


### PR DESCRIPTION
This is to help make it easier to create the genesis-base on newly installed machines when installing the xCAT-genesis-builder so most of the packages that are required to successfully build will be pulled in when doing `yum install xCAT-genesis-builder...` 