### PR TITLE
enhance packimage -m txc

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/packimage.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/packimage.1.rst
@@ -62,7 +62,7 @@ OPTIONS
 
 \ **-a**\           Architecture (ppc64,x86_64,etc)
 
-\ **-m**\           Method (cpio,txc,squashfs, default is cpio)
+\ **-m**\           Archive Method (cpio,tar,squashfs, default is cpio)
 
 
 ************

--- a/xCAT-client/pods/man1/packimage.1.pod
+++ b/xCAT-client/pods/man1/packimage.1.pod
@@ -36,7 +36,7 @@ B<-p>          Profile (compute,service)
 
 B<-a>          Architecture (ppc64,x86_64,etc)
 
-B<-m>          Method (cpio,txc,squashfs, default is cpio)
+B<-m>          Archive Method (cpio,tar,squashfs, default is cpio)
 
 
 =head1 RETURN VALUE

--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -464,7 +464,7 @@ sub mknetboot
         $platform = xCAT_plugin::anaconda::getplatform($osver);
         my $suffix = 'gz';
         $suffix = 'sfs' if (-r "$rootimgdir/rootimg.sfs");
-        $suffix = 'txz' if (-r "$rootimgdir/rootimg.txz");
+        $suffix = 'tgz' if (-r "$rootimgdir/rootimg.tgz");
 
         # statelite images are not packed.
         if ($statelite) {
@@ -513,7 +513,7 @@ sub mknetboot
                     copy("$rootimgdir/initrd.gz", "$rootimgdir/initrd-stateless.gz");
                 }
             }
-            unless (-r "$rootimgdir/rootimg.gz" or -r "$rootimgdir/rootimg.txz" or -r "$rootimgdir/rootimg.sfs") {
+            unless (-r "$rootimgdir/rootimg.gz" or -r "$rootimgdir/rootimg.tgz" or -r "$rootimgdir/rootimg.sfs") {
                 $callback->({
                         error => ["No packed image for platform $osver, architecture $arch, and profile $profile found at $rootimgdir/rootimg.gz or $rootimgdir/rootimg.sfs on $myname, please run packimage (e.g.  packimage -o $osver -p $profile -a $arch"],
                         errorcode => [1] });

--- a/xCAT-server/lib/xcat/plugins/debian.pm
+++ b/xCAT-server/lib/xcat/plugins/debian.pm
@@ -1172,7 +1172,7 @@ sub mknetboot
         $platform = xCAT_plugin::debian::getplatform($osver);
         my $suffix = 'gz';
         $suffix = 'sfs' if (-r "$rootimgdir/rootimg.sfs");
-        $suffix = 'txz' if (-r "$rootimgdir/rootimg.txz");
+        $suffix = 'tgz' if (-r "$rootimgdir/rootimg.tgz");
 
         # statelite images are not packed.
         if ($statelite) {
@@ -1222,7 +1222,7 @@ sub mknetboot
                     copy("$rootimgdir/initrd.gz", "$rootimgdir/initrd-stateless.gz");
                 }
             }
-            unless (-r "$rootimgdir/rootimg.gz" or -r "$rootimgdir/rootimg.txz" or -r "$rootimgdir/rootimg.sfs") {
+            unless (-r "$rootimgdir/rootimg.gz" or -r "$rootimgdir/rootimg.tgz" or -r "$rootimgdir/rootimg.sfs") {
                 $callback->({
                         error => ["No packed image for platform $osver, architecture $arch, and profile $profile, please run packimage (e.g.  packimage -o $osver -p $profile -a $arch"],
                         errorcode => [1] });

--- a/xCAT-server/lib/xcat/plugins/sles.pm
+++ b/xCAT-server/lib/xcat/plugins/sles.pm
@@ -329,7 +329,7 @@ sub mknetboot
 
         my $suffix = 'gz';
         $suffix = 'sfs' if (-r "$rootimgdir/rootimg.sfs");
-        $suffix = 'txz' if (-r "$rootimgdir/rootimg.txz");
+        $suffix = 'tgz' if (-r "$rootimgdir/rootimg.tgz");
 
         if ($statelite) {
             unless (-r "$rootimgdir/kernel") {
@@ -381,7 +381,7 @@ sub mknetboot
                 }
             }
 
-            unless (-r "$rootimgdir/rootimg.gz" or -r "$rootimgdir/rootimg.txz" or -r "$rootimgdir/rootimg.sfs") {
+            unless (-r "$rootimgdir/rootimg.gz" or -r "$rootimgdir/rootimg.tgz" or -r "$rootimgdir/rootimg.sfs") {
                 $callback->({
                         error => [qq{No packed image for platform $osver, architecture $arch, and profile $profile, please run packimage before nodeset}],
                         errorcode => [1]

--- a/xCAT-server/share/xcat/netboot/rh/compute.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.pkglist
@@ -12,3 +12,5 @@ ntp
 sysklogd
 rpm
 rsync
+tar
+gzip

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels6.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels6.pkglist
@@ -13,3 +13,5 @@ rpm
 rsync
 rsyslog
 e2fsprogs
+gzip
+tar

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels6.ppc64.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels6.ppc64.pkglist
@@ -24,4 +24,5 @@ lsvpd
 irqbalance
 procps
 parted
-xz
+gzip
+tar

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels6.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels6.x86_64.pkglist
@@ -20,4 +20,5 @@ rsync
 rsyslog
 e2fsprogs
 parted
-xz
+gzip
+tar

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels7.ppc64.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels7.ppc64.pkglist
@@ -24,4 +24,5 @@ irqbalance
 procps-ng
 parted
 net-tools
-xz
+gzip
+tar

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels7.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels7.x86_64.pkglist
@@ -19,4 +19,5 @@ rsyslog
 e2fsprogs
 parted
 net-tools
-xz
+gzip
+tar

--- a/xCAT-server/share/xcat/netboot/rh/dracut/install.netboot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut/install.netboot
@@ -1,6 +1,6 @@
 #!/bin/sh
 echo $drivers
-dracut_install wget tar xz cpio gzip dash modprobe touch echo cut wc xz
+dracut_install wget tar cpio gzip dash modprobe touch echo cut wc
 dracut_install -o ctorrent
 dracut_install grep ifconfig hostname awk egrep grep dirname expr
 dracut_install mount.nfs

--- a/xCAT-server/share/xcat/netboot/rh/dracut/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut/xcatroot
@@ -87,7 +87,7 @@ elif [ -r /rootimg.gz ]; then
   $NEWROOT/etc/init.d/localdisk
   [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "Done...."
   echo Done
-elif [ -r /rootimg.txz ]; then
+elif [ -r /rootimg.tgz ]; then
   echo Setting up RAM-root tmpfs.
   if [ -z $rootlimit ];then
     mount -t tmpfs -o mode=755 rootfs $NEWROOT
@@ -97,7 +97,7 @@ elif [ -r /rootimg.txz ]; then
 
   cd $NEWROOT
   echo -n "Extracting root filesystem:"
-  tar -Jxvf /rootimg.txz
+  tar --selinux --xattrs-include='*' -zxvf /rootimg.tgz
   $NEWROOT/etc/init.d/localdisk
   echo Done
 elif [ -r /rootimg-statelite.gz ]; then

--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/install.netboot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/install.netboot
@@ -1,6 +1,6 @@
 #!/bin/sh
 echo $drivers
-dracut_install wget cpio gzip modprobe touch echo cut wc xz
+dracut_install wget tar cpio gzip modprobe touch echo cut wc
 dracut_install grep ifconfig hostname awk egrep grep dirname expr
 dracut_install mount.nfs
 dracut_install parted mke2fs bc mkswap swapon chmod

--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
@@ -89,8 +89,8 @@ elif [ -r /rootimg.gz ]; then
   $NEWROOT/etc/init.d/localdisk
   [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "Done...."
   echo Done
-elif [ -r /rootimg.txz ]; then
-  [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "rootimg.txz downloaded,setting up RAM-root tmpfs...."
+elif [ -r /rootimg.tgz ]; then
+  [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "rootimg.tgz downloaded,setting up RAM-root tmpfs...."
   echo Setting up RAM-root tmpfs.
   if [ -z $rootlimit ];then
     mount -t tmpfs -o mode=755 rootfs $NEWROOT
@@ -101,7 +101,7 @@ elif [ -r /rootimg.txz ]; then
   cd $NEWROOT
   [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "Extracting root filesystem:"
   echo -n "Extracting root filesystem:"
-  tar -Jxvf /rootimg.txz
+  tar --selinux --xattrs-include='*' -zxvf /rootimg.tgz
   $NEWROOT/etc/init.d/localdisk
   [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "Done...."
   echo Done

--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -1612,7 +1612,7 @@ EOMS
     print $inifile "  zcat /rootimg.gz |cpio -idum\n";
     print $inifile "  fi\n";
     print $inifile "  echo Done\n";
-    print $inifile "elif [ -r /rootimg.txz ]; then\n";
+    print $inifile "elif [ -r /rootimg.tgz ]; then\n";
     print $inifile "    echo Setting up RAM-root tmpfs.\n";
 
     if ($rootlimit) {
@@ -1622,7 +1622,7 @@ EOMS
     }
     print $inifile "    cd \$NEWROOT\n";
     print $inifile "    echo -n \"Extracting root filesystem:\"\n";
-    print $inifile "    tar -Jxvf /rootimg.txz\n";
+    print $inifile "    tar --selinux --xattrs-include='*' -zxvf /rootimg.tgz\n";
     print $inifile "    echo Done\n";
     print $inifile "else\n";
     print $inifile "  echo -n Failed to download image, panicing in 5...\n";
@@ -1699,7 +1699,7 @@ EOMS
     }
 
     # add rsync for statelite
-    foreach ("bin/cpio", "sbin/nash", "sbin/busybox.anaconda", "sbin/rmmod", "bin/bash", "usr/sbin/chroot", "sbin/mount.nfs", "usr/bin/rsync", "usr/bin/wc", "usr/bin/xz") {
+    foreach ("bin/cpio", "sbin/nash", "sbin/busybox.anaconda", "sbin/rmmod", "bin/bash", "usr/sbin/chroot", "sbin/mount.nfs", "usr/bin/rsync", "usr/bin/wc", "usr/bin/gzip", "usr/bin/tar") {
         getlibs($_);
         push @filestoadd, $_;
     }

--- a/xCAT-server/share/xcat/netboot/sles/compute.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/compute.pkglist
@@ -11,3 +11,5 @@ wget
 rsync
 timezone
 ntp
+tar
+gzip

--- a/xCAT-server/share/xcat/netboot/sles/compute.sles11.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/compute.sles11.pkglist
@@ -17,3 +17,5 @@ rsync
 timezone
 bc
 ntp
+gzip
+tar

--- a/xCAT-server/share/xcat/netboot/sles/compute.sles11.ppc64.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/compute.sles11.ppc64.pkglist
@@ -19,3 +19,5 @@ lsvpd
 irqbalance
 procps
 ntp
+gzip
+tar

--- a/xCAT-server/share/xcat/netboot/sles/compute.sles12.ppc64le.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/compute.sles12.ppc64le.pkglist
@@ -41,4 +41,3 @@ udev
 kernel-default
 kernel-firmware
 adaptec-firmware
-xz

--- a/xCAT-server/share/xcat/netboot/sles/compute.sles12.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/compute.sles12.x86_64.pkglist
@@ -41,4 +41,3 @@ udev
 kernel-default
 kernel-firmware
 adaptec-firmware
-xz

--- a/xCAT-server/share/xcat/netboot/sles/dracut_033/install.netboot
+++ b/xCAT-server/share/xcat/netboot/sles/dracut_033/install.netboot
@@ -1,6 +1,6 @@
 #!/bin/sh
 echo $drivers
-dracut_install wget cpio gzip modprobe touch echo cut wc xz
+dracut_install wget tar cpio gzip modprobe touch echo cut wc
 dracut_install grep ifconfig hostname awk egrep grep dirname expr
 dracut_install mount.nfs
 dracut_install parted mke2fs bc mkswap swapon chmod

--- a/xCAT-server/share/xcat/netboot/sles/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/sles/dracut_033/xcatroot
@@ -87,8 +87,8 @@ elif [ -r /rootimg.gz ]; then
   $NEWROOT/etc/init.d/localdisk
   [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "Done...."
   echo Done
-elif [ -r /rootimg.txz ]; then
-  [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "rootimg.txz downloaded,setting up RAM-root tmpfs...."
+elif [ -r /rootimg.tgz ]; then
+  [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "rootimg.tgz downloaded,setting up RAM-root tmpfs...."
   echo Setting up RAM-root tmpfs.
   if [ -z $rootlimit ];then
     mount -t tmpfs -o mode=755 rootfs $NEWROOT
@@ -99,7 +99,7 @@ elif [ -r /rootimg.txz ]; then
   cd $NEWROOT
   [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "Extracting root filesystem:"
   echo -n "Extracting root filesystem:"
-  tar -Jxvf /rootimg.txz
+  tar --selinux --xattrs-include='*' -zxvf /rootimg.tgz
   $NEWROOT/etc/init.d/localdisk
   [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "Done...."
   echo Done

--- a/xCAT-server/share/xcat/netboot/sles/genimage
+++ b/xCAT-server/share/xcat/netboot/sles/genimage
@@ -1639,7 +1639,7 @@ EOMS
     print $inifile "  zcat /rootimg.gz |cpio -idum\n";
     print $inifile "  fi\n";
     print $inifile "  echo Done\n";
-    print $inifile "elif [ -r /rootimg.txz ]; then\n";
+    print $inifile "elif [ -r /rootimg.tgz ]; then\n";
     print $inifile "    echo Setting up RAM-root tmpfs.\n";
 
     if ($rootlimit) {
@@ -1649,7 +1649,7 @@ EOMS
     }
     print $inifile "    cd \$NEWROOT\n";
     print $inifile "    echo -n \"Extracting root filesystem:\"\n";
-    print $inifile "    tar -Jxvf /rootimg.txz\n";
+    print $inifile "    tar --selinux --xattrs-include='*' -zxvf /rootimg.tgz\n";
     print $inifile "    echo Done\n";
     print $inifile "else\n";
     print $inifile "  echo -n Failed to download image, panicing in 5...\n";
@@ -1758,7 +1758,7 @@ EOMS
         }
     }
     if ($mode eq "statelite") {
-        foreach ("sbin/ifconfig", "usr/bin/clear", "usr/bin/touch", "bin/hostname", "usr/bin/egrep", "bin/ln", "bin/ls", "usr/bin/dirname", "usr/bin/expr", "usr/bin/chroot", "usr/bin/grep", "bin/cpio", "bin/sleep", "bin/mount", "bin/umount", "sbin/dhcpcd", "bin/bash", "sbin/insmod", "bin/mkdir", "bin/mknod", "sbin/ip", "bin/cat", "usr/bin/awk", "usr/bin/wget", "bin/cp", "usr/bin/cpio", "usr/bin/zcat", "usr/bin/gzip", "lib/mkinitrd/bin/run-init", "usr/bin/uniq", "usr/bin/sed", "usr/bin/wc", "bin/sed", "sbin/udevd", "usr/bin/readlink", "usr/sbin/parted", "sbin/mke2fs", "sbin/mkswap", "sbin/swapon", "bin/chmod", "usr/bin/bc", "usr/bin/xz") {
+        foreach ("sbin/ifconfig", "usr/bin/clear", "usr/bin/touch", "bin/hostname", "usr/bin/egrep", "bin/ln", "bin/ls", "usr/bin/dirname", "usr/bin/expr", "usr/bin/chroot", "usr/bin/grep", "bin/cpio", "bin/sleep", "bin/mount", "bin/umount", "sbin/dhcpcd", "bin/bash", "sbin/insmod", "bin/mkdir", "bin/mknod", "sbin/ip", "bin/cat", "usr/bin/awk", "usr/bin/wget", "bin/cp", "usr/bin/cpio", "usr/bin/zcat", "usr/bin/gzip", "lib/mkinitrd/bin/run-init", "usr/bin/uniq", "usr/bin/sed", "usr/bin/wc", "bin/sed", "sbin/udevd", "usr/bin/readlink", "usr/sbin/parted", "sbin/mke2fs", "sbin/mkswap", "sbin/swapon", "bin/chmod", "usr/bin/bc", "usr/bin/gzip", "usr/bin/tar") {
             getlibs($_);
             push @filestoadd, $_;
         }
@@ -1770,7 +1770,7 @@ EOMS
         }
 
     } else {
-        foreach ("sbin/ifconfig", "usr/bin/clear", "usr/bin/touch", "usr/bin/grep", "usr/bin/egrep", "bin/cpio", "bin/sleep", "bin/mount", "sbin/dhcpcd", "bin/bash", "sbin/insmod", "bin/mkdir", "bin/mknod", "sbin/ip", "bin/cat", "usr/bin/awk", "usr/bin/wget", "bin/cp", "usr/bin/cpio", "usr/bin/zcat", "usr/bin/gzip", "lib/mkinitrd/bin/run-init", "usr/bin/uniq", "usr/bin/sed", "sbin/udevd", "usr/bin/readlink", "usr/bin/expr", "usr/sbin/parted", "sbin/mke2fs", "sbin/mkswap", "sbin/swapon", "bin/chmod", "usr/bin/bc", "usr/bin/xz") {
+        foreach ("sbin/ifconfig", "usr/bin/clear", "usr/bin/touch", "usr/bin/grep", "usr/bin/egrep", "bin/cpio", "bin/sleep", "bin/mount", "sbin/dhcpcd", "bin/bash", "sbin/insmod", "bin/mkdir", "bin/mknod", "sbin/ip", "bin/cat", "usr/bin/awk", "usr/bin/wget", "bin/cp", "usr/bin/cpio", "usr/bin/zcat", "usr/bin/gzip", "lib/mkinitrd/bin/run-init", "usr/bin/uniq", "usr/bin/sed", "sbin/udevd", "usr/bin/readlink", "usr/bin/expr", "usr/sbin/parted", "sbin/mke2fs", "sbin/mkswap", "sbin/swapon", "bin/chmod", "usr/bin/bc", "usr/bin/gzip", "usr/bin/tar") {
             getlibs($_);
             push @filestoadd, $_;
         }
@@ -2422,3 +2422,4 @@ sub usage {
     print " genimage -i eth0 -n tg3,bnx2 -o sles11 -p compute --permission 777\n";
     return 0;
 }
+

--- a/xCAT-server/share/xcat/netboot/ubuntu/compute.pkglist
+++ b/xCAT-server/share/xcat/netboot/ubuntu/compute.pkglist
@@ -12,3 +12,5 @@ rsyslog
 rsync
 busybox-static
 gawk
+tar
+gzip

--- a/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu14.04.4.ppc64el.pkglist
+++ b/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu14.04.4.ppc64el.pkglist
@@ -13,4 +13,5 @@ rsync
 busybox-static
 gawk
 dnsutils
-xz-utils
+tar
+gzip

--- a/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu14.04.4.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu14.04.4.x86_64.pkglist
@@ -13,4 +13,5 @@ rsync
 busybox-static
 gawk
 dnsutils
-xz-utils
+tar
+gzip

--- a/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu14.04.pkglist
+++ b/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu14.04.pkglist
@@ -12,3 +12,5 @@ rsyslog
 rsync
 busybox-static
 gawk
+tar
+gzip

--- a/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu16.04.pkglist
+++ b/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu16.04.pkglist
@@ -12,3 +12,5 @@ rsyslog
 rsync
 busybox-static
 gawk
+tar
+gzip

--- a/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu16.04.ppc64el.pkglist
+++ b/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu16.04.ppc64el.pkglist
@@ -14,4 +14,5 @@ rsync
 busybox-static
 gawk
 dnsutils
-xz-utils
+tar
+gzip

--- a/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu16.04.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu16.04.x86_64.pkglist
@@ -14,4 +14,5 @@ rsync
 busybox-static
 gawk
 dnsutils
-xz-utils
+tar
+gzip

--- a/xCAT-server/share/xcat/netboot/ubuntu/dracut/install.netboot
+++ b/xCAT-server/share/xcat/netboot/ubuntu/dracut/install.netboot
@@ -1,6 +1,6 @@
 #!/bin/sh
 echo $drivers
-dracut_install wget cpio gzip dash modprobe touch echo cut wc xz
+dracut_install wget tar cpio gzip dash modprobe touch echo cut wc
 dracut_install grep ifconfig hostname awk egrep grep dirname expr
 dracut_install mount.nfs
 inst "$moddir/xcatroot" "/sbin/xcatroot"

--- a/xCAT-server/share/xcat/netboot/ubuntu/dracut/xcatroot
+++ b/xCAT-server/share/xcat/netboot/ubuntu/dracut/xcatroot
@@ -50,12 +50,12 @@ elif [ -r /rootimg.gz ]; then
     gzip -cd /rootimg.gz |cpio -idum
   fi
   echo Done
-elif [ -r /rootimg.txz ]; then
+elif [ -r /rootimg.tgz ]; then
   echo Setting up RAM-root tmpfs.
   mount -t tmpfs -o mode=755 rootfs $NEWROOT
   cd $NEWROOT
   echo -n "Extracting root filesystem:"
-  tar -Jxvf /rootimg.txz
+  tar --selinux --xattrs-include='*' -zxvf /rootimg.tgz
   echo Done
 elif [ -r /rootimg-statelite.gz ]; then
   echo Setting up RAM-root tmpfs for statelite mode.

--- a/xCAT-server/share/xcat/netboot/ubuntu/genimage
+++ b/xCAT-server/share/xcat/netboot/ubuntu/genimage
@@ -1459,8 +1459,8 @@ EOMS
     print $inifile "    fi\n";
     print $inifile "    ([ \"\$xcatdebugmode\" = \"1\" ] || [ \"\$xcatdebugmode\" = \"2\" ]) && logger -t xcat -p debug \"Done...\"\n";
     print $inifile "    echo Done\n";
-    print $inifile "elif [ -r /rootimg.txz ]; then\n";
-    print $inifile "    ([ \"\$xcatdebugmode\" = \"1\" ] || [ \"\$xcatdebugmode\" = \"2\" ]) && logger -t xcat -p debug \"rootimg.txz downloaded,setting up RAM-root tmpfs...\"\n";
+    print $inifile "elif [ -r /rootimg.tgz ]; then\n";
+    print $inifile "    ([ \"\$xcatdebugmode\" = \"1\" ] || [ \"\$xcatdebugmode\" = \"2\" ]) && logger -t xcat -p debug \"rootimg.tgz downloaded,setting up RAM-root tmpfs...\"\n";
     print $inifile "    echo Setting up RAM-root tmpfs.\n";
 
     if ($rootlimit) {
@@ -1471,7 +1471,7 @@ EOMS
     print $inifile "    cd \$NEWROOT\n";
     print $inifile "    ([ \"\$xcatdebugmode\" = \"1\" ] || [ \"\$xcatdebugmode\" = \"2\" ]) && logger -t xcat -p debug \"Extracting root filesystem:\"\n";
     print $inifile "    echo -n \"Extracting root filesystem:\"\n";
-    print $inifile "    tar -Jxvf /rootimg.txz\n";
+    print $inifile "    tar --selinux --xattrs-include='*' -zxvf /rootimg.tgz\n";
     print $inifile "    ([ \"\$xcatdebugmode\" = \"1\" ] || [ \"\$xcatdebugmode\" = \"2\" ]) && logger -t xcat -p debug \"Done...\"\n";
     print $inifile "    echo Done\n";
     print $inifile "else\n";
@@ -1612,7 +1612,7 @@ EOMS
     }
 
     # add rsync for statelite
-    foreach ("usr/bin/dig", "bin/busybox", "bin/bash", "sbin/mount.nfs", "usr/bin/rsync", "sbin/insmod", "sbin/udevd", "sbin/udevadm", "sbin/modprobe", "sbin/blkid", "sbin/depmod", "usr/bin/wget", "usr/bin/xz") {
+    foreach ("usr/bin/dig", "bin/busybox", "bin/bash", "sbin/mount.nfs", "usr/bin/rsync", "sbin/insmod", "sbin/udevd", "sbin/udevadm", "sbin/modprobe", "sbin/blkid", "sbin/depmod", "usr/bin/wget", "usr/bin/gzip", "usr/bin/tar") {
         getlibs($_);
         push @filestoadd, $_;
     }


### PR DESCRIPTION
1 use gzip instead of xz to improve the compress speed.(will try to use pigz first, if pigz not available then use gzip)
```
[root@c910f03c17k14 compute]# echo `date`;packimage -m txc rhels7.2-ppc64le-netboot-compute;echo `date`
Thu Jul 28 04:50:52 EDT 2016
Packing contents of /install/netboot/rhels7.2/ppc64le/compute/rootimg
compress method:txc
Thu Jul 28 04:51:37 EDT 2016
```
```
[root@c910f03c17k14 compute]# ls -al rootimg.txz
-rw-r--r-- 1 root root 295053947 Jul 28 04:51 rootimg.txz
```
2 fix #922
3 change -m txc to -m tar