### PR TITLE
Propagate signal via ssh even though pipe broken can not be detected

### DIFF
--- a/perl-xCAT/xCAT/SSH.pm
+++ b/perl-xCAT/xCAT/SSH.pm
@@ -75,6 +75,7 @@ sub remote_shell_command {
     if ($ssh_version eq 'OpenSSH') {
         push @command, '-o';
         push @command, 'BatchMode=yes';
+        push @command, '-tt';
 
         ($$config{'options'} !~ /-X/) && push @command, '-x';
     }


### PR DESCRIPTION
Add `-tt` option to force tty allocation when running ssh command

close-issue: #1609