### PR TITLE
fix issue  [FVT] updatenode CN without return value for more than hours #1621

### DIFF
--- a/xCAT/postscripts/remoteshell
+++ b/xCAT/postscripts/remoteshell
@@ -225,6 +225,9 @@ fi
 rm /tmp/ssh_rsa_hostkey
 
 # if node supports ecdsa host key then download the replacement from the MN/SN
+# remove the /tmp/ecdsa_key first, otherwise the "ssh-keygen" below might hang
+# at waiting for user confirmation to overwritten the existing file
+rm -rf /tmp/ecdsa_key >/dev/null 2>&1
 if ssh-keygen -t ecdsa -f /tmp/ecdsa_key -P "" &>/dev/null ; then
   # download the host ecdsa key
   if [ $useflowcontrol = "1" ]; then


### PR DESCRIPTION
fix https://github.com/xcat2/xcat-core/issues/1621
The following code slice in remoteshell 
````
    225 
    226 # if node supports ecdsa host key then download the replacement from the         MN/SN
    227 if ssh-keygen -t ecdsa -f /tmp/ecdsa_key -P "" 1>/dev/null ; then
  ````
hang at
````

[root@c910f02c02p27 xcatpost]# ssh-keygen -t ecdsa -f /tmp/ecdsa_key -P ''
Generating public/private ecdsa key pair.
/tmp/ecdsa_key already exists.
Overwrite (y/n)? ^C
````
the fix is to remove the  /tmp/ecdsa_key to avoid the command hang on waiting for input