### PR TITLE
Cleanup boot configuration files when processing rmdef

### DIFF
--- a/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
+++ b/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
@@ -55,6 +55,8 @@ $Getopt::Long::ignorecase = 0;
 #@::objfilelist;     # list of object names from the "-f" option
 #@::allobjnames;     # combined list
 
+my $doreq;
+
 #@::noderange;       # list of nodes derived from command line
 
 #------------------------------------------------------------------------------
@@ -137,6 +139,7 @@ sub process_request
 
     $::request  = shift;
     $::callback = shift;
+    $doreq = shift;
 
     my $ret;
     my $msg;
@@ -4237,6 +4240,26 @@ sub defrm
                 }
             }
         }
+    }
+
+    # Call nodeset offline on each node to cleanup its boot configuration files from /tftpboot directory
+    if ($doreq) {
+        # Go through each object and make sure it is a node type
+        my @allnodes;
+        foreach my $single_object (keys %objhash) {
+            if ($objhash{$single_object} eq "node") {
+                # build a list of nodes to offline
+                push @allnodes, $single_object;
+            }
+        }
+        # Run nodeset offline and capture output.
+        # But the output can be ignored since we do not want to prevent user from doing rmdef if
+        # nodeset returns some error.
+        my @output = xCAT::Utils->runxcmd({
+            command => ['nodeset'],
+            node => [@allnodes],
+            arg  => ['offline'],
+        }, $doreq, 0 ,1);
     }
 
     # remove the objects


### PR DESCRIPTION
This pull request fixes #1524 
During `rmdef` processing of the node, `nodeset offline` is called to remove boot configuration files from /tftpboot directory.