### PR TITLE
add ubuntu16.04.1 netboot pkglist;modify the precedence of SvrUtils:get_file_name

### DIFF
--- a/xCAT-server/lib/perl/xCAT/SvrUtils.pm
+++ b/xCAT-server/lib/perl/xCAT/SvrUtils.pm
@@ -460,20 +460,20 @@ sub get_file_name {
     if (-r "$searchpath/$profile.$os.$arch.$extension") {
         return "$searchpath/$profile.$os.$arch.$extension";
     }
-    elsif (-r "$searchpath/$profile.$osbase.$arch.$extension") {
-        return "$searchpath/$profile.$osbase.$arch.$extension";
-    }
-    elsif (-r "$searchpath/$profile.$genos.$arch.$extension") {
-        return "$searchpath/$profile.$genos.$arch.$extension";
-    }
     elsif (-r "$searchpath/$profile.$os.$extension") {
         return "$searchpath/$profile.$os.$extension";
     }
+    elsif (($genos) && (-r "$searchpath/$profile.$genos.$arch.$extension")) {
+        return "$searchpath/$profile.$genos.$arch.$extension";
+    }
+    elsif (($genos) && (-r "$searchpath/$profile.$genos.$extension")) {
+        return "$searchpath/$profile.$genos.$extension";
+    }
+    elsif (-r "$searchpath/$profile.$osbase.$arch.$extension") {
+        return "$searchpath/$profile.$osbase.$arch.$extension";
+    }
     elsif (-r "$searchpath/$profile.$osbase.$extension") {
         return "$searchpath/$profile.$osbase.$extension";
-    }
-    elsif (-r "$searchpath/$profile.$genos.$extension") {
-        return "$searchpath/$profile.$genos.$extension";
     }
     elsif (-r "$searchpath/$profile.$arch.$extension") {
         return "$searchpath/$profile.$arch.$extension";

--- a/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu16.04.1.pkglist
+++ b/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu16.04.1.pkglist
@@ -1,0 +1,17 @@
+bash
+nfs-common
+openssl
+isc-dhcp-client
+libc-bin
+linux-image-generic
+openssh-server
+openssh-client
+wget
+ntp
+ntpdate
+rsync
+busybox-static
+gawk
+dnsutils
+tar
+gzip


### PR DESCRIPTION
fix https://github.com/xcat2/xcat-core/issues/1611

1. add ubuntu16.04.1 diskless pkglist  file "compute.ubuntu16.04.1.pkglist", which is based on the one for ubuntu16.04,  "vim" is not included since its dependency in the ubuntu 16.04.1 iso is incomplete. 

2. modify the the logic of get_file_name subroutine in SvrUtils.pm, so that the pkglist with the name with full os release number takes precedence over the base os release number. after modification, the "compute.ubuntu16.04.1.pkglist" will be the better candidate than "compute.ubuntu16.04.ppc64le.pkglist" for ubuntu 16.04.1 ppc64le osimage