### PR TITLE
Change the summary message for go-xcat to just say xCAT is installed

### DIFF
--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -1502,18 +1502,11 @@ case "${GO_XCAT_ACTION}" in
 
 	while read -r ; do echo "${REPLY}" ; done <<-EOF
 
+	xCAT has been installed!  
+	========================
 
-	Congratulations
-	===============
-
-	The fact that you got this far is a strong indication that xCAT bas been
-	installed correctly.
-
-	Please notice if this is the first time you install xCAT. You need to do one
-	of the following.
-
-	1. Log out and then log in again, or
-	2. run the following command to set the environment variables.
+	If this is the very first time xCAT has been installed, run the following
+	commands to set environment variables into your PATH:
 
 	    for sh,
 	        \`source /etc/profile.d/xcat.sh\`

--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -1500,19 +1500,29 @@ case "${GO_XCAT_ACTION}" in
 		exit "${RET}"
 	fi
 
-	while read -r ; do echo "${REPLY}" ; done <<-EOF
+	if [ ${GO_XCAT_ACTION} == 'install' ]; then
+		# only print out this message on install
+		while read -r ; do echo "${REPLY}" ; done <<-EOF
 
-	xCAT has been installed!  
-	========================
+		xCAT has been installed!  
+		========================
 
-	If this is the very first time xCAT has been installed, run the following
-	commands to set environment variables into your PATH:
+		If this is the very first time xCAT has been installed, run the following
+		commands to set environment variables into your PATH:
 
-	    for sh,
-	        \`source /etc/profile.d/xcat.sh\`
-	    or csh,
-	        \`source /etc/profile.d/xcat.csh\`
-	EOF
+		    for sh,
+		        \`source /etc/profile.d/xcat.sh\`
+		    or csh,
+		        \`source /etc/profile.d/xcat.csh\`
+		EOF
+	else
+		while read -r ; do echo "${REPLY}" ; done <<-EOF
+
+		xCAT has been updated!
+		======================
+
+		EOF
+	fi
 	;;
 *)
 	list_xcat_packages


### PR DESCRIPTION
Suggest changing the summary message for go-xcat to not have any message that says "strong indication that xCAT has been installed correctly" but just say xCAT is installed. The purpose of `go-xcat` is to install correctly to help the new user.  :) 

The 2nd commit in this pull request fixes Issue #1642 