### PR TITLE
Attempt to auto-detect RHEL operating systems without ID number

### DIFF
--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -2239,17 +2239,27 @@ sub copycd
         }
     }
 
-
     unless ($distname)
     {
+        print "INFO - Could not find ID=$did in the discinfo database for OS=$desc ARCH=$darch NUM=$dno, attempt to auto-detect...\n";
         if ($desc =~ /IBM_PowerKVM/)
         {
             # check for PowerKVM support
             my @pkvm_version = split / /, $desc;
             $distname = "pkvm" . $pkvm_version[1];
         }
+        elsif ($desc =~ /Red Hat Enterprise Linux/)
+        {
+            #
+            # Attempt to auto-detect for RHEL OS.
+            # RHEL 7.3 description is: Red Hat Enterprise Linux 7.3
+            #
+            my @rhel_version = split / /, $desc;
+            $distname = "rhels" . $rhel_version[4];
+        }
         else
         {
+            print "INFO - Could not auto-detect operating system.\n";
             return;    #Do nothing, not ours..
         }
     }


### PR DESCRIPTION
The `anaconda.pm` plugin looks at the discinfle to take the ID and map it to a hard coded name/arch.  This means that every time we get a new operating system, we first have to get an error message like 
```
Error: copycds could not identify the ISO supplied, you may wish to try -n <osver>
```
Then manually mount the DVD `.iso` and extract the disc ID number and add it into discinfo.pm before we are able to successfully copycds.  I think this is inefficient and we should allow for the ability to auto-detect the OS if we can.  


I added an INFO msg if `XCATBYPASS=1` is set that will print out the ID from the `.discinfo` file to make it slightly easier if we need to find the ID to add to `discinfo.pm`
