### PR TITLE
Modify usage, some probe commands do not support hierarchy

### DIFF
--- a/xCAT-probe/subcmds/detect_dhcpd
+++ b/xCAT-probe/subcmds/detect_dhcpd
@@ -30,7 +30,6 @@ Options:
     -m macaddress: The mac that will be used to detect dhcp server. Recommend to use the real mac of the node that will be netboot. If no specified, the mac of interface which specified by -i will be used.
     -d duration:   The time to wait to detect the dhcp messages. The default value is 10s.
     -V verbose:    To print additional debug information. 
-    -T         :   To verify if $program_name can work, reserve option for probe framework.
 ";
 
 #---------------------------

--- a/xCAT-probe/subcmds/discovery
+++ b/xCAT-probe/subcmds/discovery
@@ -32,17 +32,16 @@ my %monitor_nodes;
 
 $::USAGE = "Usage:
     $program_name -h
-    $program_name -T
     $program_name [-V] [-m <discovery_type> -n <node_range>] [--noprecheck] 
 
 Description:
     Do probe for discovery process, including pre-check for required configuration and realtime monitor of discovery process. 
     If all pre-check items pass, $program_name will go to monitor directly, otherwise $program_name exit for error.  
     In order to do realtime monitor, $program_name probe program must be run along with the node discovery procedure. Plese trigger this command before trigger node discovery procedure.
+    Currently, this command does not support hierarchy.
 
 Options:
     -h : Get usage information of $program_name.
-    -T : To verify if $program_name can work, reserve option for probe framework.
     -V : Output more information for debug.
     -m : The method of discovery, the valid values are $valid_discovery_type_str.
     -n : The range of predefined node, must used with option -m.
@@ -1137,7 +1136,7 @@ if ($help) {
 }
 
 if ($test) {
-    probe_utils->send_msg("$output", "o", "Do probe for discovery process, including pre-check for required configuration and realtime monitor of discovery process.Before using this command, please install nslookup command ahead.");
+    probe_utils->send_msg("$output", "o", "Do probe for discovery process, including pre-check for required configuration and realtime monitor of discovery process.Before using this command, please install nslookup command ahead. Currently, this command does not support hierarchy.");
     exit 0;
 }
 

--- a/xCAT-probe/subcmds/image
+++ b/xCAT-probe/subcmds/image
@@ -22,7 +22,6 @@ my $rst     = 0;
 
 $::USAGE = "Usage:
     $program_name -h
-    $program_name -T
     $program_name {-c|-d} [-n noderange] [-V]
 
 Description:
@@ -31,7 +30,6 @@ Description:
 
 Options:
     -h : Get usage information of $program_name
-    -T : To verify if $program_name can work, reserve option for probe framework
     -n : Range of nodes to check
     -d : To verify diskless, pingable compute nodes have the same images installed as defines in xCAT DB. 
     -c : To verify all diskless, pingable compute nodes have the identical images installed.

--- a/xCAT-probe/subcmds/switch-macmap
+++ b/xCAT-probe/subcmds/switch-macmap
@@ -16,14 +16,13 @@ my $output  = "stdout";
 
 $::USAGE = "Usage:
     $proname -h
-    $proname -T
     $proname  <noderange> [-c] [-V]
 
 Description:
     To retrieve MAC address mapping for the specified switch, or all the switches defined in switches table in xCAT db.
+    Currently, this command does not support hierarchy.
 
 Options:
-    -T: Check whether this script is OK to run.
     -c: To check whether the switch is OK to retrieve MAC address mapping.
     -V: Output verbose information when accessing switch
 ";
@@ -67,7 +66,7 @@ if ($test) {
         probe_utils->send_msg("$output", "f", "No switchprobe tool is available at $currdir/bin/");
         exit 1;
     } else {
-        probe_utils->send_msg("$output", "o", "To retrieve MAC address mapping for the specified switch, or all the switches defined in switches table in xCAT db.");
+        probe_utils->send_msg("$output", "o", "To retrieve MAC address mapping for the specified switch, or all the switches defined in switches table in xCAT db. Currently, this command does not support hierarchy.");
         exit 0;
     }
 }


### PR DESCRIPTION
Modified discovery, image and switch-macmap.
Currently, these commands do not support hierarchy.