### PR TITLE
Sort the port by looking at the numeric number in the port string.

### DIFF
--- a/xCAT-server/lib/xcat/plugins/switch.pm
+++ b/xCAT-server/lib/xcat/plugins/switch.pm
@@ -251,7 +251,7 @@ sub process_request {
                     $cb->({ node => [ { name => $switch, data => ["PASS"] } ] });
                     next;
                 }
-                foreach my $port (sort keys %{ $macinfo->{$switch} }) {
+                foreach my $port (sort {($a =~ /(\d+)/)[0] <=> ($b =~ /(\d+)/)[0]} keys %{ $macinfo->{$switch} }) {
                     my $node = '';
                     if (defined($macinfo->{$switch}->{$port}->{Node})) {
                         $node = $macinfo->{$switch}->{$port}->{Node};


### PR DESCRIPTION
This fixes issue #1649 and sorts the Port column by the number in the "EthernetX" String. 

With the change, the output looks like the following: 
```
[root@fs1 xCAT_plugin]# xcatprobe switch-macmap frame45_sw1
Switch       Port        MAC address         Node                                                                 
------------------------------------------------------------------                                                
frame45_sw1  Ethernet1          N/A          frame45cn01                                                          
frame45_sw1  Ethernet2          N/A          frame45cn02                                                          
frame45_sw1  Ethernet3          N/A          frame45cn03                                                          
frame45_sw1  Ethernet4          N/A          frame45cn04                                                          
frame45_sw1  Ethernet5          N/A          frame45cn05                                                          
frame45_sw1  Ethernet6          N/A          frame45cn06                                                          
frame45_sw1  Ethernet7          N/A          frame45cn07                                                          
frame45_sw1  Ethernet8          N/A          frame45cn08                                                          
frame45_sw1  Ethernet9          N/A          frame45cn09                                                          
frame45_sw1  Ethernet10         N/A          frame45cn10                                                          
frame45_sw1  Ethernet11         N/A          frame45cn11                                                          
frame45_sw1  Ethernet12         N/A          frame45cn12                                                          
frame45_sw1  Ethernet13         N/A          frame45cn13                                                          
frame45_sw1  Ethernet14         N/A          frame45cn14                                                          
frame45_sw1  Ethernet15         N/A          frame45cn15                                                          
frame45_sw1  Ethernet16         N/A          frame45cn16                                                          
frame45_sw1  Ethernet17         N/A          frame45cn17                                                          
frame45_sw1  Ethernet18         N/A          frame45cn18                                                          
frame45_sw1  Ethernet19         N/A                                                                               
frame45_sw1  Ethernet20         N/A                                                                               
frame45_sw1  Ethernet21         N/A                                                                               
frame45_sw1  Ethernet22         N/A                                                                               
frame45_sw1  Ethernet23         N/A                            
....
```
