### PR TITLE
fix  [FVT]:ubuntu build script build-ubunturepo does not support minor release #1604

### DIFF
--- a/build-ubunturepo
+++ b/build-ubunturepo
@@ -203,7 +203,7 @@ then
         pkg_type="snap"
         build_string="Snap_Build"
         cur_date=`date +%Y%m%d%H%M`
-        pkg_version="${short_ver}-${pkg_type}${cur_date}"
+        pkg_version="${ver}-${pkg_type}${cur_date}"
     
         if [ ! -d ../../$package_dir_name ];then
             mkdir -p "../../$package_dir_name"


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/1604


````
./build-ubunturepo -c UP=0 BUILDALL=1
...
#################################
# Creating xcat-core repository #
#################################
../debsdevel/perl-xcat_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-buildkit_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-client_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-confluent_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-genesis-scripts-ppc64_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-genesis-scripts-x86-64_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-probe_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-server_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-test_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-vlan_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat_2.12.2-snap201608090726_amd64.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcatsn_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/perl-xcat_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-buildkit_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-client_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-confluent_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-genesis-scripts-ppc64_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-genesis-scripts-x86-64_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-probe_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-server_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-test_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-vlan_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat_2.12.2-snap201608090726_amd64.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat_2.12.2-snap201608090726_ppc64el.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcatsn_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/perl-xcat_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-buildkit_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-client_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-confluent_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-genesis-scripts-ppc64_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-genesis-scripts-x86-64_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-probe_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-server_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-test_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-vlan_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat_2.12.2-snap201608090726_amd64.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat_2.12.2-snap201608090726_ppc64el.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcatsn_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/perl-xcat_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-buildkit_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-client_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-confluent_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-genesis-scripts-ppc64_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-genesis-scripts-x86-64_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-probe_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-server_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-test_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat-vlan_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat_2.12.2-snap201608090726_amd64.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcat_2.12.2-snap201608090726_ppc64el.deb: component guessed as 'main'
Exporting indices...
../debsdevel/xcatsn_2.12.2-snap201608090726_all.deb: component guessed as 'main'
Exporting indices...
xcat:x:1000:

````