### PR TITLE
Modify xcat-genesis-script pkg name for ubuntu

### DIFF
--- a/xCAT-genesis-scripts/debian/control-amd64
+++ b/xCAT-genesis-scripts/debian/control-amd64
@@ -5,11 +5,11 @@ Maintainer: xCAT <xcat-user@lists.sourceforge.net>
 Build-Depends: debhelper (>= 8.0.0)
 Standards-Version: 3.9.2
 
-Package: xcat-genesis-scripts-x86-64
+Package: xcat-genesis-scripts-amd64
 Architecture: all 
-Depends: xcat-genesis-base-x86-64
-Conflicts: xcat-genesis-scripts,xcat-genesis-scripts-amd64
-Replaces: xcat-genesis-scripts,xcat-genesis-scripts-amd64
+Depends: xcat-genesis-base-amd64
+Conflicts: xcat-genesis-scripts,xcat-genesis-scripts-x86-64
+Replaces: xcat-genesis-scripts,xcat-genesis-scripts-x86-64
 Description: xCAT genesis 
 	(Genesis Enhanced Netboot Environment for System Information and Servicing) is a small, embedded-like environment for xCAT's use in discovery and management actions when interaction with an OS is infeasible. This package reperesents the EPL content that is more tightly bound to specific xcat-core versions
 

--- a/xCAT-genesis-scripts/xCAT-genesis-scripts.spec
+++ b/xCAT-genesis-scripts/xCAT-genesis-scripts.spec
@@ -99,21 +99,9 @@ touch /etc/xcat/genesis-scripts-updated
 %{rpminstallroot}/bin/update_flash
 %{rpminstallroot}/bin/update_flash_nv
 %{rpminstallroot}/bin/restart
-%{rpminstallroot}/debian/changelog
-%{rpminstallroot}/debian/compat
-%{rpminstallroot}/debian/control-amd64
-%{rpminstallroot}/debian/control-ppc64el
-%{rpminstallroot}/debian/copyright
-#%{rpminstallroot}/debian/dirs
-%{rpminstallroot}/debian/docs
-#%{rpminstallroot}/debian/install
-%{rpminstallroot}/debian/postinst
-%{rpminstallroot}/debian/postrm
-%{rpminstallroot}/debian/preinst
-%{rpminstallroot}/debian/prerm
-%{rpminstallroot}/debian/rules
 %{rpminstallroot}/etc/init.d/functions
 %{rpminstallroot}/etc/udev/rules.d/99-imm.rules
 %{rpminstallroot}/etc/udev/rules.d/98-mlx.rules
 %{rpminstallroot}/sbin/setupimmnic
 %{rpminstallroot}/sbin/loadmlxeth 
+%exclude %{rpminstallroot}/debian/*

--- a/xCAT/debian/control
+++ b/xCAT/debian/control
@@ -7,6 +7,6 @@ Standards-Version: 3.7.2
 
 Package: xcat
 Architecture: amd64 ppc64el
-Depends: ${perl:Depends}, xcat-server, xcat-client, libdbd-sqlite3-perl, isc-dhcp-server, apache2, nfs-kernel-server, nmap, bind9, libxml-parser-perl, xinetd, tftpd-hpa, tftp-hpa, conserver-xcat, libnet-telnet-perl, ipmitool-xcat (>=1.8.15-2), syslinux[any-amd64], libsys-virt-perl, syslinux-xcat[any-amd64], xnba-undi, xcat-genesis-scripts-ppc64, xcat-genesis-scripts-x86-64, elilo-xcat, xcat-buildkit, xcat-probe (>=2.12)
+Depends: ${perl:Depends}, xcat-server, xcat-client, libdbd-sqlite3-perl, isc-dhcp-server, apache2, nfs-kernel-server, nmap, bind9, libxml-parser-perl, xinetd, tftpd-hpa, tftp-hpa, conserver-xcat, libnet-telnet-perl, ipmitool-xcat (>=1.8.15-2), syslinux[any-amd64], libsys-virt-perl, syslinux-xcat[any-amd64], xnba-undi, xcat-genesis-scripts-ppc64, xcat-genesis-scripts-amd64, elilo-xcat, xcat-buildkit, xcat-probe (>=2.12)
 Description: Server and configuration utilities of the xCAT management project
  xcat-server provides the core server and configuration management components of xCAT.  This package should be installed on your management server

--- a/xCAT/xCAT.spec
+++ b/xCAT/xCAT.spec
@@ -25,7 +25,7 @@ Source7: xcat.conf.apach24
 
 Provides: xCAT = %{version}
 Conflicts: xCATsn
-Requires: xCAT-server xCAT-client perl-DBD-SQLite xCAT-probe >= 2.12.1
+Requires: xCAT-server xCAT-client perl-DBD-SQLite xCAT-probe >= 2.12.1 xCAT-genesis-scripts-x86_64 xCAT-genesis-scripts-ppc64
 
 %define pcm %(if [ "$pcm" = "1" ];then echo 1; else echo 0; fi)
 %define notpcm %(if [ "$pcm" = "1" ];then echo 0; else echo 1; fi)
@@ -60,13 +60,12 @@ Requires: conserver-xcat
 %endif
 
 %ifarch i386 i586 i686 x86 x86_64
-Requires: syslinux xCAT-genesis-scripts-x86_64 elilo-xcat
+Requires: syslinux elilo-xcat
 Requires: ipmitool-xcat >= 1.8.15-2
 Requires: xnba-undi
 %endif
 %ifos linux
 %ifarch ppc ppc64 ppc64le
-Requires: xCAT-genesis-scripts-ppc64
 Requires: ipmitool-xcat >= 1.8.15-2
 %endif
 %endif

--- a/xCATsn/debian/control
+++ b/xCATsn/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.7.2
 
 Package: xcatsn
 Architecture: all
-Depends: ${perl:Depends}, xcat-server, perl-xcat, xcat-client, libdbd-sqlite3-perl, libxml-parser-perl, tftpd-hpa, tftp-hpa, conserver-xcat, libnet-telnet-perl, dhcp3-server, apache2, expect, nfs-kernel-server, nmap, bind9, ipmitool-xcat (>=1.8.15-2), syslinux-xcat, xnba-undi, xcat-genesis-scripts-ppc64, xcat-genesis-scripts-x86-64, elilo-xcat,libsys-virt-perl
+Depends: ${perl:Depends}, xcat-server, perl-xcat, xcat-client, libdbd-sqlite3-perl, libxml-parser-perl, tftpd-hpa, tftp-hpa, conserver-xcat, libnet-telnet-perl, dhcp3-server, apache2, expect, nfs-kernel-server, nmap, bind9, ipmitool-xcat (>=1.8.15-2), syslinux-xcat, xnba-undi, xcat-genesis-scripts-ppc64, xcat-genesis-scripts-amd64, elilo-xcat,libsys-virt-perl
 Recommends: yaboot-xcat
 Description: Metapackage for a common, default xCAT service node setup
  xCATsn is a service node management package intended for at-scale management, including hardware management and software management.

--- a/xCATsn/xCATsn.spec
+++ b/xCATsn/xCATsn.spec
@@ -17,7 +17,7 @@ Source3: xCATSN
 Source5: templates.tar.gz
 Source6: xcat.conf.apach24
 Provides: xCATsn = %{version}
-Requires: xCAT-server xCAT-client perl-DBD-SQLite 
+Requires: xCAT-server xCAT-client perl-DBD-SQLite xCAT-genesis-scripts-x86_64 xCAT-genesis-scripts-ppc64 
 
 Conflicts: xCAT
 
@@ -55,13 +55,12 @@ Requires: conserver-xcat
 %endif
 
 %ifarch i386 i586 i686 x86 x86_64
-Requires: syslinux xCAT-genesis-scripts-x86_64 elilo-xcat
+Requires: syslinux elilo-xcat
 Requires: ipmitool-xcat >= 1.8.15-2
 Requires: xnba-undi
 %endif
 %ifos linux
 %ifarch ppc ppc64 ppc64le
-Requires: xCAT-genesis-scripts-ppc64
 Requires: ipmitool-xcat >= 1.8.15-2
 %endif
 %endif


### PR DESCRIPTION
Modifications:
1. move xcat-genesis-scripts-x86-64 to be xcat-genesis-scripts-amd64 for ubuntu
2. remove files under xCAT-genesis-scripts/debian/ from xCAT-genesis-scripts.spec, there won't be debian directory under /opt/xcat/share/xcat/netboot/genesis/<ppc64|x86_64>/fs/
3. Modify xCAT depended on both xCAT-genesis-scripts-x86_64 and xCAT-genesis-scripts-ppc64