### PR TITLE
Remove xcat-genesis-scripts-* from xcatsn depended packages, the work…

### DIFF
--- a/xCATsn/debian/control
+++ b/xCATsn/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.7.2
 
 Package: xcatsn
 Architecture: all
-Depends: ${perl:Depends}, xcat-server, perl-xcat, xcat-client, libdbd-sqlite3-perl, libxml-parser-perl, tftpd-hpa, tftp-hpa, conserver-xcat, libnet-telnet-perl, dhcp3-server, apache2, expect, nfs-kernel-server, nmap, bind9, ipmitool-xcat (>=1.8.15-2), syslinux-xcat, xnba-undi, xcat-genesis-scripts-ppc64, xcat-genesis-scripts-amd64, elilo-xcat,libsys-virt-perl
+Depends: ${perl:Depends}, xcat-server, perl-xcat, xcat-client, libdbd-sqlite3-perl, libxml-parser-perl, tftpd-hpa, tftp-hpa, conserver-xcat, libnet-telnet-perl, dhcp3-server, apache2, expect, nfs-kernel-server, nmap, bind9, ipmitool-xcat (>=1.8.15-2), syslinux-xcat, xnba-undi, elilo-xcat,libsys-virt-perl
 Recommends: yaboot-xcat
 Description: Metapackage for a common, default xCAT service node setup
  xCATsn is a service node management package intended for at-scale management, including hardware management and software management.

--- a/xCATsn/xCATsn.spec
+++ b/xCATsn/xCATsn.spec
@@ -17,7 +17,7 @@ Source3: xCATSN
 Source5: templates.tar.gz
 Source6: xcat.conf.apach24
 Provides: xCATsn = %{version}
-Requires: xCAT-server xCAT-client perl-DBD-SQLite xCAT-genesis-scripts-x86_64 xCAT-genesis-scripts-ppc64 
+Requires: xCAT-server xCAT-client perl-DBD-SQLite
 
 Conflicts: xCAT
 


### PR DESCRIPTION
…ing directory /tftpboot/ on SN was mounted from MN

The xcat-genesis-base/scripts-* will install files under /opt/xcat/share/xcat/netboot/genesis/$arch/.
But the kernel and initrd will be put under /tftpboot/ when running mknb. 
For xCAT sn, the /tftpboot/ can be either mount from MN or rsync from MN. Don't need to install them separately. 