### PR TITLE
fix issue  [DEV] Diskless boot failed for rhel7.3 because selinux disabled. #1666 ; disable selinux in the rootimg

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels7.ppc64.postinstall
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels7.ppc64.postinstall
@@ -32,6 +32,10 @@ END
 #cons:12345:respawn:/sbin/smart_agetty -L 38400 console
 echo "co:2345:respawn:/sbin/agetty -L 38400 console" >> $installroot/etc/inittab
 
+#-- Disable SELinux in the rootimg
+#-- Redhat 7.3 will install selinux-policy and selinux is enabled by default
+#-- Need to disable selinux, otherwise, the booting  will hang on "Loading selinux policy"
+sed -i 's/SELINUX=enforcing\|permissive/SELINUX=disabled/' $installroot/etc/selinux/config
 
 #-- Example of booted image versioning
 #-- We want to know, with what configuration (version of the image) each node was booted.

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels7.x86_64.postinstall
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels7.x86_64.postinstall
@@ -32,6 +32,12 @@ END
 #echo "co:2345:respawn:/sbin/agetty -L 38400 console" >> $installroot/etc/inittab
 
 
+#-- Disable SELinux in the rootimg
+#-- Redhat 7.3 will install selinux-policy and selinux is enabled by default
+#-- Need to disable selinux, otherwise, the booting  will hang on "Loading selinux policy"
+sed -i 's/SELINUX=enforcing\|permissive/SELINUX=disabled/' $installroot/etc/selinux/config
+
+
 #-- Example of booted image versioning
 #-- We want to know, with what configuration (version of the image) each node was booted.
 #-- Hence, we keep image definition files and postscripts in CVS. During image generation we create file /etc/IMGVERSION and fill it with CVS "$Id$" of files with image definition (.pkglist, .exlist, .repolist, .postinstall). Then, during boot, each  "CVS enabled" postscript (see /install/postscripts/cvs_template.sh and /install/postscripts/cvs_template.pl) adds one line to /etc/IMGVERSION. Then you can determine in any time what image you are running and what postscipts in which versions were run.

--- a/xCAT-server/share/xcat/netboot/rh/service.postinstall
+++ b/xCAT-server/share/xcat/netboot/rh/service.postinstall
@@ -35,6 +35,12 @@ workdir=$5
 echo "co:2345:respawn:/sbin/agetty -L 38400 console" >> $installroot/etc/inittab
 
 
+
+#-- Disable SELinux in the rootimg
+#-- Redhat 7.3 will install selinux-policy and selinux is enabled by default
+#-- Need to disable selinux, otherwise, the booting  will hang on "Loading selinux policy"
+sed -i 's/SELINUX=enforcing\|permissive/SELINUX=disabled/' $installroot/etc/selinux/config
+
 #-- Example of booted image versioning
 #-- We want to know, with what configuration (version of the image) each node was booted.
 #-- Hence, we keep image definition files and postscripts in CVS. During image generation we create file /etc/IMGVERSION and fill it with CVS "$Id$" of files with image definition (.pkglist, .exlist, .repolist, .postinstall). Then, during boot, each  "CVS enabled" postscript (see /install/postscripts/cvs_template.sh and /install/postscripts/cvs_template.pl) adds one line to /etc/IMGVERSION. Then you can determine in any time what image you are running and what postscipts in which versions were run.


### PR DESCRIPTION
fix https://github.com/xcat2/xcat-core/issues/1666

Redhat 7.3 will install selinux-policy package by default, in the /etc/selinux/config, selinux will be enabled by default, can be disabled on genimage 