### PR TITLE
fix issue  Nodeset for Ubuntu OS displays warning, but we should be more specific and only print on conditions where it might fail #1097

### DIFF
--- a/xCAT-server/lib/xcat/plugins/debian.pm
+++ b/xCAT-server/lib/xcat/plugins/debian.pm
@@ -891,7 +891,7 @@ sub mkinstall {
                     $kcmdline .= "n8r";
                 }
             } else {
-                $callback->({ warning => ["rcons my not work since no serialport specified"], });
+                $callback->({ warning => ["rcons may not work since no serialport is specified for $node"], });
             }
 
             # need to add these in, otherwise aptitude will ask questions
@@ -1548,7 +1548,7 @@ sub mknetboot
         } else {
             $callback->(
                 {
-                    warning => ["rcons my not work since no serialport specified"],
+                    warning => ["rcons may not work since no serialport is specified for $node"],
                 }
             );
         }


### PR DESCRIPTION
fix https://github.com/xcat2/xcat-core/issues/1097

refine the warning message when node.serialport not specified