### PR TITLE
genimage failed for rhels7.2 because /etc/selinux/config file is not exists

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels7.ppc64.postinstall
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels7.ppc64.postinstall
@@ -37,7 +37,7 @@ echo "co:2345:respawn:/sbin/agetty -L 38400 console" >> $installroot/etc/inittab
 #-- Need to disable selinux, otherwise, the booting  will hang on "Loading selinux policy"
 if [ -f "$installroot/etc/selinux/config" ]
 then
-sed -i 's/SELINUX=enforcing\|permissive/SELINUX=disabled/' $installroot/etc/selinux/config
+    sed -i 's/SELINUX=enforcing\|permissive/SELINUX=disabled/' $installroot/etc/selinux/config
 fi
 
 #-- Example of booted image versioning

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels7.ppc64.postinstall
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels7.ppc64.postinstall
@@ -35,7 +35,10 @@ echo "co:2345:respawn:/sbin/agetty -L 38400 console" >> $installroot/etc/inittab
 #-- Disable SELinux in the rootimg
 #-- Redhat 7.3 will install selinux-policy and selinux is enabled by default
 #-- Need to disable selinux, otherwise, the booting  will hang on "Loading selinux policy"
+if [ -f "$installroot/etc/selinux/config" ]
+then
 sed -i 's/SELINUX=enforcing\|permissive/SELINUX=disabled/' $installroot/etc/selinux/config
+fi
 
 #-- Example of booted image versioning
 #-- We want to know, with what configuration (version of the image) each node was booted.

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels7.x86_64.postinstall
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels7.x86_64.postinstall
@@ -35,8 +35,10 @@ END
 #-- Disable SELinux in the rootimg
 #-- Redhat 7.3 will install selinux-policy and selinux is enabled by default
 #-- Need to disable selinux, otherwise, the booting  will hang on "Loading selinux policy"
+if [ -f "$installroot/etc/selinux/config" ]
+then
 sed -i 's/SELINUX=enforcing\|permissive/SELINUX=disabled/' $installroot/etc/selinux/config
-
+fi
 
 #-- Example of booted image versioning
 #-- We want to know, with what configuration (version of the image) each node was booted.

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels7.x86_64.postinstall
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels7.x86_64.postinstall
@@ -37,7 +37,7 @@ END
 #-- Need to disable selinux, otherwise, the booting  will hang on "Loading selinux policy"
 if [ -f "$installroot/etc/selinux/config" ]
 then
-sed -i 's/SELINUX=enforcing\|permissive/SELINUX=disabled/' $installroot/etc/selinux/config
+    sed -i 's/SELINUX=enforcing\|permissive/SELINUX=disabled/' $installroot/etc/selinux/config
 fi
 
 #-- Example of booted image versioning

--- a/xCAT-server/share/xcat/netboot/rh/service.postinstall
+++ b/xCAT-server/share/xcat/netboot/rh/service.postinstall
@@ -39,7 +39,10 @@ echo "co:2345:respawn:/sbin/agetty -L 38400 console" >> $installroot/etc/inittab
 #-- Disable SELinux in the rootimg
 #-- Redhat 7.3 will install selinux-policy and selinux is enabled by default
 #-- Need to disable selinux, otherwise, the booting  will hang on "Loading selinux policy"
+if [ -f "$installroot/etc/selinux/config" ]
+then
 sed -i 's/SELINUX=enforcing\|permissive/SELINUX=disabled/' $installroot/etc/selinux/config
+fi
 
 #-- Example of booted image versioning
 #-- We want to know, with what configuration (version of the image) each node was booted.

--- a/xCAT-server/share/xcat/netboot/rh/service.postinstall
+++ b/xCAT-server/share/xcat/netboot/rh/service.postinstall
@@ -41,7 +41,7 @@ echo "co:2345:respawn:/sbin/agetty -L 38400 console" >> $installroot/etc/inittab
 #-- Need to disable selinux, otherwise, the booting  will hang on "Loading selinux policy"
 if [ -f "$installroot/etc/selinux/config" ]
 then
-sed -i 's/SELINUX=enforcing\|permissive/SELINUX=disabled/' $installroot/etc/selinux/config
+    sed -i 's/SELINUX=enforcing\|permissive/SELINUX=disabled/' $installroot/etc/selinux/config
 fi
 
 #-- Example of booted image versioning


### PR DESCRIPTION
the changes in the pull request #1676 cause genimage failed on rhels7.2
````
Enter the dracut mode. Dracut version: 033. Dracut directory: dracut_033.
sed: can't read /install/netboot/rhels7.2/ppc64le/compute/rootimg/etc/selinux/config: No such file or directory
postinstall script /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.postinstall failed.
`````

need to check if file /etc/selinux/config exists before modify this file