### PR TITLE
[packimage -m -c]:  supress the verbose info of rootimg decompression; add tar "--no-recursion" option in packimage; correct the path of gnu tar to be "/bin/tar" in genimage

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/packimage.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/packimage.1.rst
@@ -23,7 +23,7 @@ SYNOPSIS
 
 \ **packimage  [-v| -**\ **-version]**\ 
 
-\ **packimage**\  \ *imagename*\ 
+\ **packimage**\  [\ **-m | -**\ **-method**\  \ *cpio|tar*\ ] [\ **-c | -**\ **-compress**\  \ *gzip|pigz|xz*\ ]  \ *imagename*\ 
 
 
 ***********
@@ -62,9 +62,9 @@ OPTIONS
 
 \ **-a**\           Architecture (ppc64,x86_64,etc)
 
-\ **-m**\           Archive Method (cpio,tar,squashfs, default is cpio)
+\ **-m| -**\ **-method**\           Archive Method (cpio,tar,squashfs, default is cpio)
 
-\ **-c**\           Compress Method (pigz,gzip,xz, default is pigz)
+\ **-c| -**\ **-compress**\           Compress Method (pigz,gzip,xz, default is pigz/gzip)
 
 
 ************
@@ -88,6 +88,14 @@ EXAMPLES
 .. code-block:: perl
 
   packimage rhels7.1-x86_64-netboot-compute
+
+
+2. To pack the osimage rhels7.1-x86_64-netboot-compute with "tar" to archive and "pigz" to compress:
+
+
+.. code-block:: perl
+
+  packimage -m tar -c pigz rhels7.1-x86_64-netboot-compute
 
 
 

--- a/xCAT-client/pods/man1/packimage.1.pod
+++ b/xCAT-client/pods/man1/packimage.1.pod
@@ -8,7 +8,7 @@ B<packimage [-h| --help]>
 
 B<packimage  [-v| --version]>
 
-B<packimage> I<imagename>
+B<packimage> [B<-m>|B<--method> I<cpio|tar>] [B<-c>|B<--compress> I<gzip|pigz|xz>]  I<imagename>
 
 =head1 DESCRIPTION
 
@@ -36,9 +36,9 @@ B<-p>          Profile (compute,service)
 
 B<-a>          Architecture (ppc64,x86_64,etc)
 
-B<-m>          Archive Method (cpio,tar,squashfs, default is cpio)
+B<-m| --method>          Archive Method (cpio,tar,squashfs, default is cpio)
 
-B<-c>          Compress Method (pigz,gzip,xz, default is pigz)
+B<-c| --compress>          Compress Method (pigz,gzip,xz, default is pigz/gzip)
 
 
 =head1 RETURN VALUE
@@ -53,6 +53,9 @@ B<-c>          Compress Method (pigz,gzip,xz, default is pigz)
 
  packimage rhels7.1-x86_64-netboot-compute
 
+2. To pack the osimage rhels7.1-x86_64-netboot-compute with "tar" to archive and "pigz" to compress:
+
+ packimage -m tar -c pigz rhels7.1-x86_64-netboot-compute
 
 =head1 FILES
 

--- a/xCAT-server/lib/xcat/plugins/packimage.pm
+++ b/xCAT-server/lib/xcat/plugins/packimage.pm
@@ -79,7 +79,7 @@ sub process_request {
         @ARGV = @{$args};
     }
     if (scalar(@ARGV) == 0) {
-        $callback->({ info => ["Usage:\n   packimage <imagename>\n   packimage [-h| --help]\n   packimage [-v| --version]"] });
+        $callback->({ info => ["Usage:\n   packimage [-m| --method=cpio|tar] [-c| --compress=gzip|pigz|xz] <imagename>\n   packimage [-h| --help]\n   packimage [-v| --version]"] });
         return 0;
     }
 
@@ -114,7 +114,7 @@ sub process_request {
         return 0;
     }
     if ($help) {
-        $callback->({ info => ["Usage:\n   packimage <imagename>\n   packimage [-h| --help]\n   packimage [-v| --version]"] });
+        $callback->({ info => ["Usage:\n   packimage [-m| --method=cpio|tar] [-c| --compress=gzip|pigz|xz] <imagename>\n   packimage [-h| --help]\n   packimage [-v| --version]"] });
         return 0;
     }
 
@@ -468,8 +468,12 @@ sub process_request {
     }
 
     $suffix = $method.".".$suffix;
-    unlink("$destdir/rootimg.$suffix");
     unlink("$destdir/rootimg.sfs");
+    unlink("$destdir/rootimg.cpio.xz");
+    unlink("$destdir/rootimg.cpio.gz");
+    unlink("$destdir/rootimg.tar.xz");
+    unlink("$destdir/rootimg.tar.gz");
+    
     if ($method =~ /cpio/) {
         if (!$exlistloc) {
             $excludestr = "find . -xdev -print0 | cpio -H newc -o -0 | $compress -c - > ../rootimg.$suffix";
@@ -507,6 +511,7 @@ sub process_request {
         $callback->({ error => ["Invalid archive method '$method' requested"], errorcode => [1] });
         return 1;
     }
+
     chdir("$rootimg_dir");
     my $outputmsg = `$excludestr 2>&1`;
     unless($?){
@@ -517,6 +522,7 @@ sub process_request {
         system("rm -rf $xcat_packimg_tmpfile");
         return 1;
     }
+
     if ($method =~ /cpio/) {
         chmod 0644, "$destdir/rootimg.$suffix";
         if ($dotorrent) {

--- a/xCAT-server/share/xcat/netboot/rh/dracut/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut/xcatroot
@@ -106,9 +106,9 @@ elif [ -r /rootimg.tar.gz ] || [ -r /rootimg.tar.xz ]; then
   cd $NEWROOT
   echo -n "Extracting root filesystem:"
   if [ -r /rootimg.tar.gz ]; then
-    tar --selinux --xattrs-include='*' -zxvf /rootimg.tar.gz
+    tar --selinux --xattrs-include='*' -zxf /rootimg.tar.gz
   elif [ -r /rootimg.tar.xz ]; then
-    tar --selinux --xattrs-include='*' -Jxvf /rootimg.tar.xz
+    tar --selinux --xattrs-include='*' -Jxf /rootimg.tar.xz
   fi
   $NEWROOT/etc/init.d/localdisk
   echo Done

--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
@@ -110,9 +110,9 @@ elif [ -r /rootimg.tar.gz ] || [ -r /rootimg.tar.xz ]; then
   [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "Extracting root filesystem:"
   echo -n "Extracting root filesystem:"
   if [ -r /rootimg.tar.gz ]; then
-    tar --selinux --xattrs-include='*' -zxvf /rootimg.tar.gz
+    tar --selinux --xattrs-include='*' -zxf /rootimg.tar.gz
   elif [ -r /rootimg.tar.xz ]; then
-    tar --selinux --xattrs-include='*' -Jxvf /rootimg.tar.xz
+    tar --selinux --xattrs-include='*' -Jxf /rootimg.tar.xz
   fi
   $NEWROOT/etc/init.d/localdisk
   [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "Done...."

--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -1640,9 +1640,9 @@ EOMS
     print $inifile "    cd \$NEWROOT\n";
     print $inifile "    echo -n \"Extracting root filesystem:\"\n";
     print $inifile "    if [ -r /rootimg.tar.gz ]; then\n";
-    print $inifile "        tar --selinux --xattrs-include='*' -zxvf /rootimg.tar.gz\n";
+    print $inifile "        tar --selinux --xattrs-include='*' -zxf /rootimg.tar.gz\n";
     print $inifile "    elif [ -r /rootimg.tar.xz ]; then\n";
-    print $inifile "        tar --selinux --xattrs-include='*' -Jxvf /rootimg.tar.xz\n";
+    print $inifile "        tar --selinux --xattrs-include='*' -Jxf /rootimg.tar.xz\n";
     print $inifile "    fi\n";
     print $inifile "    echo Done\n";
     print $inifile "else\n";

--- a/xCAT-server/share/xcat/netboot/sles/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/sles/dracut_033/xcatroot
@@ -108,9 +108,9 @@ elif [ -r /rootimg.tar.gz ] || [ -r /rootimg.tar.xz ]; then
   [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "Extracting root filesystem:"
   echo -n "Extracting root filesystem:"
   if [ -r /rootimg.tar.gz ]; then
-    tar --selinux --xattrs-include='*' -zxvf /rootimg.tar.gz
+    tar --selinux --xattrs-include='*' -zxf /rootimg.tar.gz
   elif [ -r /rootimg.tar.xz ]; then
-    tar --selinux --xattrs-include='*' -Jxvf /rootimg.tar.xz
+    tar --selinux --xattrs-include='*' -Jxf /rootimg.tar.xz
   fi
   $NEWROOT/etc/init.d/localdisk
   [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "Done...."

--- a/xCAT-server/share/xcat/netboot/sles/genimage
+++ b/xCAT-server/share/xcat/netboot/sles/genimage
@@ -1658,9 +1658,9 @@ EOMS
     print $inifile "    cd \$NEWROOT\n";
     print $inifile "    echo -n \"Extracting root filesystem:\"\n";
     print $inifile "    if [ -r /rootimg.tar.gz ]; then\n";
-    print $inifile "        tar --selinux --xattrs-include='*' -zxvf /rootimg.tar.gz\n";
+    print $inifile "        tar --selinux --xattrs-include='*' -zxf /rootimg.tar.gz\n";
     print $inifile "    elif [ -r /rootimg.tar.xz ]; then\n";
-    print $inifile "        tar --selinux --xattrs-include='*' -Jxvf /rootimg.tar.xz\n";
+    print $inifile "        tar --selinux --xattrs-include='*' -Jxf /rootimg.tar.xz\n";
     print $inifile "    fi\n";
     print $inifile "    echo Done\n";
     print $inifile "else\n";

--- a/xCAT-server/share/xcat/netboot/ubuntu/dracut/xcatroot
+++ b/xCAT-server/share/xcat/netboot/ubuntu/dracut/xcatroot
@@ -64,9 +64,9 @@ elif [ -r /rootimg.tar.gz ] || [ -r /rootimg.tar.xz ]; then
   cd $NEWROOT
   echo -n "Extracting root filesystem:"
   if [ -r /rootimg.tar.gz ]; then
-    tar --selinux --xattrs-include='*' -zxvf /rootimg.tar.gz
+    tar --selinux --xattrs-include='*' -zxf /rootimg.tar.gz
   elif [ -r /rootimg.tar.xz ]; then
-    tar --selinux --xattrs-include='*' -Jxvf /rootimg.tar.xz
+    tar --selinux --xattrs-include='*' -Jxf /rootimg.tar.xz
   fi
   echo Done
 elif [ -r /rootimg-statelite.gz ]; then

--- a/xCAT-server/share/xcat/netboot/ubuntu/genimage
+++ b/xCAT-server/share/xcat/netboot/ubuntu/genimage
@@ -1480,9 +1480,9 @@ EOMS
     print $inifile "    ([ \"\$xcatdebugmode\" = \"1\" ] || [ \"\$xcatdebugmode\" = \"2\" ]) && logger -t xcat -p debug \"Extracting root filesystem:\"\n";
     print $inifile "    echo -n \"Extracting root filesystem:\"\n";
     print $inifile "    if [ -r /rootimg.tar.gz ]; then\n";
-    print $inifile "        tar --selinux --xattrs-include='*' -zxvf /rootimg.tar.gz\n";
+    print $inifile "        /bin/tar --selinux --xattrs-include='*' -zxf /rootimg.tar.gz\n";
     print $inifile "    elif [ -r /rootimg.tar.xz ]; then\n";
-    print $inifile "        tar --selinux --xattrs-include='*' -Jxvf /rootimg.tar.xz\n";
+    print $inifile "        /bin/tar --selinux --xattrs-include='*' -Jxf /rootimg.tar.xz\n";
     print $inifile "    fi\n";
     print $inifile "    ([ \"\$xcatdebugmode\" = \"1\" ] || [ \"\$xcatdebugmode\" = \"2\" ]) && logger -t xcat -p debug \"Done...\"\n";
     print $inifile "    echo Done\n";
@@ -1624,7 +1624,7 @@ EOMS
     }
 
     # add rsync for statelite
-    foreach ("usr/bin/dig", "bin/busybox", "bin/bash", "sbin/mount.nfs", "usr/bin/rsync", "sbin/insmod", "sbin/udevd", "sbin/udevadm", "sbin/modprobe", "sbin/blkid", "sbin/depmod", "usr/bin/wget", "usr/bin/xz", "usr/bin/gzip", "usr/bin/tar") {
+    foreach ("usr/bin/dig", "bin/busybox", "bin/bash", "sbin/mount.nfs", "usr/bin/rsync", "sbin/insmod", "sbin/udevd", "sbin/udevadm", "sbin/modprobe", "sbin/blkid", "sbin/depmod", "usr/bin/wget", "usr/bin/xz", "bin/gzip", "bin/tar") {
         getlibs($_);
         push @filestoadd, $_;
     }


### PR DESCRIPTION
supress the verbose info of rootimg decompression during diskless boot to reduce the time of rootimg decompress; 
fix https://github.com/xcat2/xcat-core/issues/1688: 
1. add tar "--no-recursion" option in packimage, to prevent the duplicate compress of directory and the files under the directory.
2. the gnu tar in rootimg is located in "/bin/tar" instead of "/usr/bin/tar"
3. in the initrd, the full path to the gnu tar "/bin/tar" should be used, otherwise, tar in busybox will be used

fix https://github.com/xcat2/xcat-core/issues/1689:
1. the return value of the rootimg archive/compress should be checked and prompt user about the error if any
2. use "--use-compress-program" instead of piped "find ,...| tar ...|gzip/pigz/xz ..." to capture the error message during archive if any 

fix https://github.com/xcat2/xcat-core/issues/1695:
when run "packimage", remove all the existed compressed rootimg to make sure the  newly generated one will be used on "nodeset"

add "-m" and "-c" to "packimage" usage info of "-h|--help" and manpage
The updated doc: http://10.3.5.21/xcat-doc/html/guides/admin-guides/references/man1/packimage.1.html