### PR TITLE
mysqlsetup failed becuase /usr/bin/mysql_install_db is not available

### DIFF
--- a/xCAT-client/bin/mysqlsetup
+++ b/xCAT-client/bin/mysqlsetup
@@ -916,12 +916,13 @@ sub initmysqldb
     }
     else
     {
-        if (!(-e ("/usr/bin/mysql_install_db"))) {
-            xCAT::MsgUtils->message("E", "/usr/bin/mysql_install_db is not available, please install required packages");
+        my $sqlcmd = "/usr/bin/mysql_install_db";
+        if (!(-e ($sqlcmd))) {
+            xCAT::MsgUtils->message("E", "$sqlcmd is not available, please install required mysql/mariadb packages");
             exit(1);
         }
 
-        $cmd = "/usr/bin/mysql_install_db --user=mysql";
+        $cmd = "$sqlcmd --user=mysql";
     }
     xCAT::Utils->runcmd($cmd, 0);
     if ($::RUNCMD_RC != 0)

--- a/xCAT-client/bin/mysqlsetup
+++ b/xCAT-client/bin/mysqlsetup
@@ -917,7 +917,7 @@ sub initmysqldb
     else
     {
         my $sqlcmd = "/usr/bin/mysql_install_db";
-        if (!(-e ($sqlcmd))) {
+        if (!(-x ($sqlcmd))) {
             xCAT::MsgUtils->message("E", "$sqlcmd is not available, please install required mysql/mariadb packages");
             exit(1);
         }

--- a/xCAT-client/bin/mysqlsetup
+++ b/xCAT-client/bin/mysqlsetup
@@ -916,6 +916,11 @@ sub initmysqldb
     }
     else
     {
+        if (!(-e ("/usr/bin/mysql_install_db"))) {
+            xCAT::MsgUtils->message("E", "/usr/bin/mysql_install_db is not available, please install required packages");
+            exit(1);
+        }
+
         $cmd = "/usr/bin/mysql_install_db --user=mysql";
     }
     xCAT::Utils->runcmd($cmd, 0);


### PR DESCRIPTION
for issue #898 ,  the mysqlsetup -i failed because /usr/bin/mysql_install_db is not available.
Add the error message if /usr/bin/mysql_install_db is not exists.
`````
# mysqlsetup -i
Input the alpha-numberic  password for xcatadmin in the MySQL database:
Input the password for root in the MySQL database:
 /usr/bin/mysql_install_db is not available, please install required packages
``````