### PR TITLE
Add dependency to support rhels7.2+IB

### DIFF
--- a/xCAT-server/share/xcat/ib/netboot/rh/ib.rhels7.ppc64le.pkglist
+++ b/xCAT-server/share/xcat/ib/netboot/rh/ib.rhels7.ppc64le.pkglist
@@ -17,3 +17,4 @@ cairo
 gcc
 createrepo
 libnl
+ethtool


### PR DESCRIPTION
Support rhels7.2+IB in ESP,  need one more dependency ``ethtool``. Add it into ``ib.rhels7.ppc64le.pkglist``