### PR TITLE
Provide Security Notice for Vulnerability created on 2016-08-15

### DIFF
--- a/docs/source/security/2016/20160815_openssl.rst
+++ b/docs/source/security/2016/20160815_openssl.rst
@@ -1,0 +1,18 @@
+2016-08-16 - OpenSSL Vulnerabilities
+====================================
+
+This vulnerability has no fix available at this time (other then mentioned patches below)
+
+Issue: https://bugzilla.redhat.com/show_bug.cgi?id=1359615
+
+Patch: https://github.com/openssl/openssl/commit/0ed26acce328ec16a3aa635f1ca37365e8c7403a
+
+Advisory CVEs
+-------------
+
+`CVE-2016-2180 <https://exchange.xforce.ibmcloud.com/vulnerabilities/115829>`_ - OpenSSL is vulnerable to a denial of service, caused by an out-of-bounds read in the TS_OBJ_print_bio function. 
+
+Action
+------
+
+xCAT uses OpenSSL for client-server communication but **does not** ship it.  It is highly recommended to keep your OpenSSL levels up-to-date to prevent any potential security threats.  

--- a/docs/source/security/2016/index.rst
+++ b/docs/source/security/2016/index.rst
@@ -8,3 +8,4 @@
    20160301_openssl.rst
    20160128_openssl.rst
    20160115_openssl.rst
+   20160815_openssl.rst


### PR DESCRIPTION
OpenSSL is vulnerable to a denial of service, caused by an out-of-bounds read in the TS_OBJ_print_bio function. A remote attacker could exploit this vulnerability using a specially crafted time-stamp file to cause the application to crash.