### PR TITLE
Protect umount_chroot from running with rootimage_dir undefined

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -70,7 +70,7 @@ my $noupdate;
 
 sub xdie {
     system("rm -rf /tmp/xcatinitrd.$$");
-    umount_chroot($rootimage_dir);
+    umount_chroot($rootimg_dir);
     die @_;
 }
 
@@ -112,6 +112,10 @@ sub mount_chroot {
 
 sub umount_chroot {
     my $rootimage_dir = shift;
+    if ($rootimage_dir eq "") {
+        print "\n\n\n\nWARNING: /proc and /sys may still be mounted in the rootimgdir\n\n\n\n";
+        return 1;
+    }
 
     if (majversion($osver) > 6) {
         system("umount -l $rootimage_dir/proc");

--- a/xCAT-server/share/xcat/netboot/ubuntu/genimage
+++ b/xCAT-server/share/xcat/netboot/ubuntu/genimage
@@ -2094,6 +2094,11 @@ sub mount_chroot {
 
 sub umount_chroot {
     my $rootimage_dir = shift;
+    if ($rootimage_dir eq "") {
+        print "\n\n\n\nWARNING: /proc and /sys may still be mounted in the rootimgdir\n\n\n\n";
+        return 1;
+    }
+
 
     system("umount -l $rootimage_dir/proc");
     system("umount -l $rootimage_dir/sys");


### PR DESCRIPTION
We had an issue with our kernel version, so xCAT called xdie.  There's a typo in the RHEL 7.2 xdie, so it called umount_chroot with a blank rootimage_dir, which tried to unmount the xCAT server's /proc, /sys, and delete its device files.  Fix the typo and add some logic to umount_chroot to prevent this in the future