### PR TITLE
Add security notices from 2015 over to RTD

### DIFF
--- a/docs/source/security/2015/20150312_openssl.rst
+++ b/docs/source/security/2015/20150312_openssl.rst
@@ -1,0 +1,20 @@
+2015-03-12 - OpenSSL Vulnerabilities  (FREAK)
+=============================================
+
+OpenSSL announced security fixes on 01/08/15 in the following bulletin: https://www-origin.openssl.org/news/secadv/20150108.txt  
+
+Advisory CVEs
+-------------
+
+* CVE-2015-0204 **RSA silently downgrades to EXPORT_RSA [Client]** (Severity: Low)
+
+FREAK vulnerability CVE-2015-0204 is involved when 'RSA_EXPORT' ssl cipher suit is used in ssl server/client. 
+
+Action
+------
+
+xCAT does not use RSA_EXPORT ciphers for ssl communication by default. However, xCAT does allow user to choose the ciphers from the site.xcatsslciphers attribute. 
+
+Please make sure you do not put RSA_EXPORT related ciphers in this attribute.
+
+It is recommended that you upgrade openssl to 1.0.1L and upper version for the fix of this problem. Please go to the os distribution to get the latest openssl package.

--- a/docs/source/security/2015/20150324_openssl.rst
+++ b/docs/source/security/2015/20150324_openssl.rst
@@ -1,0 +1,12 @@
+2015-03-24 - OpenSSL Vulnerabilities 
+====================================
+
+OpenSSL 1.0.2 introduced the "multiblock" performance improvement. This feature only applies on 64 bit x86 architecture platforms that support AES NI instructions. A defect in the implementation of "multiblock" can cause a segmentation fault within OpenSSL, thus enabling a potential DoS attack. 
+
+This issue affects OpenSSL version: 1.0.2
+
+
+Action
+------
+
+xCAT uses OpenSSL for client-server communication but **does not** ship it.  Please upgrade OpenSSL to 1.0.2a or higher. 

--- a/docs/source/security/2015/20150403_openssl.rst
+++ b/docs/source/security/2015/20150403_openssl.rst
@@ -1,0 +1,14 @@
+2015-04-03 - OpenSSL Vulnerabilities (BAR MITZVAH)
+==================================================
+
+The RC4 Bar mitzvah attack is an attack on the SSL/TLS protocols when both the client and server have RC4 enabled. 
+
+* http://www.darkreading.com/attacks-breaches/ssl-tls-suffers-bar-mitzvah-attack-/d/d-id/1319633 
+* http://www.imperva.com/docs/HII_Attacking_SSL_when_using_RC4.pdf.
+
+Action
+------
+
+xCAT uses OpenSSL shipped with OS distribution for client-server communication. It does not use RC4 ciphers explicitly. However, it allows user to specify xcatsslciphers on the site table for ssl communication. It is recommended that the user not specify RC4 ciphers to avoid the Bar mitzvah attack. 
+
+It is also recommended that the user go to the OS distribution to get latest OpenSSL package for the fix of this problem. 

--- a/docs/source/security/2015/20150519_openssl.rst
+++ b/docs/source/security/2015/20150519_openssl.rst
@@ -1,0 +1,27 @@
+2015-05-19 - OpenSSL Vulnerabilities (VENOM)
+============================================
+
+Advisory CVEs
+-------------
+
+* CVE-2015-3456 - **(aka VENOM) is a security flaw in the QEMU's Floppy Disk Controller (FDC) emulation.** 
+
+VENOM vulnerability could expose virtual machines on unpatched host systems
+
+A new vulnerability known as VENOM has been discovered, which could allow an attacker to escape a guest virtual machine (VM) and access the host system along with other VMs running on this system. The VENOM bug could potentially allow an attacker to steal sensitive data on any of the virtual machines on this system and gain elevated access to the host''''s local network and its systems.
+
+The VENOM bug (CVE-2015-3456) exists in the virtual Floppy Disk Controller for the open-source hypervisor QEMU, which is installed by default in a number of virtualization infrastructures such as Xen hypervisors, the QEMU client, and Kernel-based Virtual Machine (KVM). VENOM does not affect VMware, Microsoft Hyper-V, and Bochs hypervisors.
+
+* QEMU: http://git.qemu.org/?p=qemu.git;a=commitdiff;h=e907746266721f305d67bc0718795fedee2e824c
+* Xen Project: http://xenbits.xen.org/xsa/advisory-133.html
+* Red Hat: https://access.redhat.com/articles/1444903
+* SUSE: https://www.suse.com/support/kb/doc.php?id=7016497
+* Ubuntu: http://www.ubuntu.com/usn/usn-2608-1/
+
+
+Action
+------
+
+xCAT does not ship any rpms that have QEMU component directly. However xCAT does make system calls to QEMU when doing KVM/Xen visualization. If you are using xCAT to manage KVM or Xen hosts and quests, please get the latest rpms that have QEMU component from the os distro and do a upgrade on both xCAT management node and the KVM/Xen hosts. 
+
+

--- a/docs/source/security/2015/20150520_openssl.rst
+++ b/docs/source/security/2015/20150520_openssl.rst
@@ -1,0 +1,20 @@
+2015-05-20 - OpenSSL Vulnerabilities (LOGJAM)
+=============================================
+
+A Logjam vulnerability attacks openssl and web services on weak (512-bit) Diffie-Hellman key groups. Please refer to the following documents for details.
+
+Main site: https://weakdh.org/
+
+Server test: https://weakdh.org/sysadmin.html
+
+Please refer to the following openssl link for more details regarding the fix: https://www.openssl.org/blog/blog/2015/05/20/logjam-freak-upcoming-changes/
+
+  OpenSSL 1.0.2 users should upgrade to 1.0.2b
+  OpenSSL 1.0.1 users should upgrade to 1.0.1n
+
+Action
+------
+
+xCAT uses OpenSSL for client-server communication but **does not** ship it.  It uses the default ciphers from openssl. It also allows the user to customize it through site.xcatsslversion and site.xcatsslciphers. Please make sure you do not enable DH or DHE ciphers. 
+
+Please get the latest openssl package from the os distros and upgrade it on all the xCAT management nodes, the service nodes and xCAT client nodes.

--- a/docs/source/security/2015/20151203_openssl.rst
+++ b/docs/source/security/2015/20151203_openssl.rst
@@ -1,0 +1,42 @@
+2015-12-03 - OpenSSL Vulnerabilities
+====================================
+
+OpenSSL announced security fixes on 12/03/15 in the following bulletin: http://openssl.org/news/secadv/20151203.txt
+
+Advisory CVEs
+-------------
+
+* CVE-2015-3193 - **BN_mod_exp may produce incorrect results on x86_64** (Severity:Moderate)
+
+    OpenSSL 1.0.2 users should upgrade to 1.0.2e
+
+* CVE-2015-3194 - **Certificate verify crash with missing PSS parameter** (Severity:Moderate)
+
+    OpenSSL 1.0.2 users should upgrade to 1.0.2e
+    OpenSSL 1.0.1 users should upgrade to 1.0.1q
+
+* CVE-2015-3195 - **X509_ATTRIBUTE memory leak** (Severity:Moderate)
+
+    OpenSSL 1.0.2 users should upgrade to 1.0.2e
+    OpenSSL 1.0.1 users should upgrade to 1.0.1q
+    OpenSSL 1.0.0 users should upgrade to 1.0.0t
+    OpenSSL 0.9.8 users should upgrade to 0.9.8zh
+
+* CVE-2015-3196 - **Race condition handling PSK identify hint** (Severity:Low)
+
+    OpenSSL 1.0.2 users should upgrade to 1.0.2d
+    OpenSSL 1.0.1 users should upgrade to 1.0.1p
+    OpenSSL 1.0.0 users should upgrade to 1.0.0t
+
+* CVE-2015-1794 - **Anon DH ServerKeyExchange with 0 p parameter** (Severity:Low)
+
+    OpenSSL 1.0.2 users should upgrade to 1.0.2e
+
+
+Action
+------
+
+xCAT uses OpenSSL for client-server communication but **does not** ship it.  
+
+It is recommended to keep your OpenSSL levels up-to-date with the indicated versions in the security bulletins to prevent any potential security threats. 
+

--- a/docs/source/security/2015/index.rst
+++ b/docs/source/security/2015/index.rst
@@ -1,0 +1,12 @@
+2015 Notices 
+============
+
+.. toctree::
+   :maxdepth: 1
+
+   20151203_openssl.rst
+   20150520_openssl.rst
+   20150519_openssl.rst
+   20150403_openssl.rst
+   20150324_openssl.rst
+   20150312_openssl.rst

--- a/docs/source/security/index.rst
+++ b/docs/source/security/index.rst
@@ -5,3 +5,4 @@ Security Notices
    :maxdepth: 2
 
    2016/index.rst
+   2015/index.rst


### PR DESCRIPTION
Created the security notices that were on SF for 2015 into the xCAT doc so that we can remove the broken links in the GitHub Wiki. 

After 2 years, I think we should start deleting the old ones from the master branch and only keep a running 2 years.  The 2.12 branch would have 2015, but maybe the 2.13 release should remove 2015 and only keep 2016,2017.. etc.. 