### PR TITLE
Add the URL for the 16.04.1 mini.iso

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/common/deployment/create_img.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/deployment/create_img.rst
@@ -53,6 +53,8 @@ For ubuntu ppc64le, the initrd.gz shipped with the ISO does not support network 
   
   [ubuntu 16.04]: http://xcat.org/files/netboot/ubuntu16.04/ppc64el/mini.iso
 
+  [ubuntu 16.04.1]: http://xcat.org/files/netboot/ubuntu16.04.1/ppc64el/mini.iso
+
 * Mount mini.iso ::
 
     mkdir /tmp/iso


### PR DESCRIPTION
I added the mini.iso for 16.04.1 into our xcat.org download page and also updated the documentation. 