### PR TITLE
fix issue 1553 makedns failed when input invalid hostname into /etc/h…

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ddns.pm
+++ b/xCAT-server/lib/xcat/plugins/ddns.pm
@@ -441,11 +441,11 @@ sub process_request {
                 xCAT::SvrUtils::sendmsg(":Ignoring line $_ in /etc/hosts, names  $names contain invalid characters (valid characters include a through z, numbers and the '-', but not '_'", $callback);
                 next;
             }
-
+            $invalid = "";
             @eachhost = split(/ /,$names);
             foreach my $hname (@eachhost) {
-                unless ($hname !~ /^\.[a-z0-9]+/i) {
-                    xCAT::SvrUtils::sendmsg(":Ignoring line $_ in /etc/hosts, names  $names start with . ", $callback);
+                if ($hname =~ /^\./) {
+                    xCAT::SvrUtils::sendmsg(":Ignoring line $_ in /etc/hosts, name $hname start with . ", $callback);
                     $invalid = $names;
                     last;
                 }

--- a/xCAT-server/lib/xcat/plugins/ddns.pm
+++ b/xCAT-server/lib/xcat/plugins/ddns.pm
@@ -423,6 +423,8 @@ sub process_request {
         my $names;
         my @hosts;
         my %nodehash;
+        my @eachhost;
+        my $invalid;
 
         foreach (@contents) {
             chomp;            #no newline
@@ -437,6 +439,18 @@ sub process_request {
             }
             unless ($names =~ /^[a-z0-9\. \t\n-]+$/i) {
                 xCAT::SvrUtils::sendmsg(":Ignoring line $_ in /etc/hosts, names  $names contain invalid characters (valid characters include a through z, numbers and the '-', but not '_'", $callback);
+                next;
+            }
+
+            @eachhost = split(/ /,$names);
+            foreach my $hname (@eachhost) {
+                unless ($hname !~ /^\.[a-z0-9]+/i) {
+                    xCAT::SvrUtils::sendmsg(":Ignoring line $_ in /etc/hosts, names  $names start with . ", $callback);
+                    $invalid = $names;
+                    last;
+                }
+            }
+            if ($invalid) {
                 next;
             }
 


### PR DESCRIPTION
#1553 https://github.com/xcat2/xcat-core/issues/1553

My examples:
[root@byrh04 ~]# makedns -n
Ignoring line 9.21.54.31 db04b11-eno1 .eng.platformlab.ibm.com  in /etc/hosts, names  db04b11-eno1 .eng.platformlab.ibm.com  start with .
Ignoring line 20.4.41.22 test1 .cluster.com in /etc/hosts, names  test1 .cluster.com start with .
Ignoring line 10.32.77.2 .test.com test1 in /etc/hosts, names  .test.com test1 start with .
Handling localhost in /etc/hosts.
Handling byrh04.cluster.com in /etc/hosts.
Handling byrh04.test.com in /etc/hosts.
Handling localhost in /etc/hosts.
Getting reverse zones, this may take several minutes for a large cluster.
Completed getting reverse zones.
Updating zones.
Completed updating zones.
Restarting named
Restarting named complete
Updating DNS records, this may take several minutes for a large cluster.
Completed updating DNS records.
