### PR TITLE
fix issue enimage deleted /dev/* on the management node... #1767

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -70,7 +70,7 @@ my $noupdate;
 
 sub xdie {
     system("rm -rf /tmp/xcatinitrd.$$");
-    umount_chroot($rootimage_dir);
+    umount_chroot($rootimg_dir);
     die @_;
 }
 


### PR DESCRIPTION
correct a typo in rh/genimage
fix issue https://github.com/xcat2/xcat-core/issues/1767