### PR TITLE
Update xcattest and complete install xCAT case

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/xcattest.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/xcattest.1.rst
@@ -58,7 +58,7 @@ OPTIONS
 
 \ **-b**\  \ *case bundle list*\ 
  
- Comma separated list of test cases bundle files, each test cases bundle can contain multiple lines and each line for one test case name.
+ Comma separated list of test cases bundle files, each test cases bundle can contain multiple lines and each line for one test case name.The bundle files should be listed in: /opt/xcat/share/xcat/tools/autotest/bundle.
  
 
 
@@ -136,7 +136,7 @@ EXAMPLES
  
  .. code-block:: perl
  
-    xcattest -c /tmp/config -c rpower
+    xcattest -f /tmp/config -c rpower
  
  
 
@@ -148,7 +148,7 @@ EXAMPLES
  
  .. code-block:: perl
  
-    xcattest -l  > /tmp/custom.bundle
+    xcattest -l  > /opt/xcat/share/xcat/tools/autotest/bundle/custom.bundle
     Modify custom.bundle
     xcattest -b custom.bundle
  

--- a/perl-xCAT/xCAT/SSH.pm
+++ b/perl-xCAT/xCAT/SSH.pm
@@ -75,7 +75,6 @@ sub remote_shell_command {
     if ($ssh_version eq 'OpenSSH') {
         push @command, '-o';
         push @command, 'BatchMode=yes';
-        push @command, '-tt';
 
         ($$config{'options'} !~ /-X/) && push @command, '-x';
     }

--- a/xCAT-genesis-scripts/bin/doxcat
+++ b/xCAT-genesis-scripts/bin/doxcat
@@ -217,15 +217,16 @@ else
 	                fi
                 fi
                 done
-                sleep 2
+                sleep 3
                 tries=$(($tries+1))
-                if [ $tries -ge 10 ]; then
+                # Wait for 60 seconds to make sure the STP is done for at least one port
+                if [ $tries -ge 20 ]; then
                     break
                 fi
 	    done
             if [ -z "$bootnic" ]; then
+                logger -s -t $log_label -p local4.info "still can not get bootnic, go into /bin/bash"
                 /bin/bash
-                logger -s -t $log_label -p local4.info "still can not get $bootnic, go into /bin/bash"
             fi
         else
 	    dhclient -cf /etc/dhclient.conf -pf /var/run/dhclient.$bootnic.pid $bootnic &

--- a/xCAT-probe/subcmds/detect_dhcpd
+++ b/xCAT-probe/subcmds/detect_dhcpd
@@ -30,7 +30,6 @@ Options:
     -m macaddress: The mac that will be used to detect dhcp server. Recommend to use the real mac of the node that will be netboot. If no specified, the mac of interface which specified by -i will be used.
     -d duration:   The time to wait to detect the dhcp messages. The default value is 10s.
     -V verbose:    To print additional debug information. 
-    -T         :   To verify if $program_name can work, reserve option for probe framework.
 ";
 
 #---------------------------

--- a/xCAT-probe/subcmds/discovery
+++ b/xCAT-probe/subcmds/discovery
@@ -32,17 +32,16 @@ my %monitor_nodes;
 
 $::USAGE = "Usage:
     $program_name -h
-    $program_name -T
     $program_name [-V] [-m <discovery_type> -n <node_range>] [--noprecheck] 
 
 Description:
     Do probe for discovery process, including pre-check for required configuration and realtime monitor of discovery process. 
     If all pre-check items pass, $program_name will go to monitor directly, otherwise $program_name exit for error.  
     In order to do realtime monitor, $program_name probe program must be run along with the node discovery procedure. Plese trigger this command before trigger node discovery procedure.
+    Currently, this command does not support hierarchy.
 
 Options:
     -h : Get usage information of $program_name.
-    -T : To verify if $program_name can work, reserve option for probe framework.
     -V : Output more information for debug.
     -m : The method of discovery, the valid values are $valid_discovery_type_str.
     -n : The range of predefined node, must used with option -m.
@@ -1137,7 +1136,7 @@ if ($help) {
 }
 
 if ($test) {
-    probe_utils->send_msg("$output", "o", "Do probe for discovery process, including pre-check for required configuration and realtime monitor of discovery process.Before using this command, please install nslookup command ahead.");
+    probe_utils->send_msg("$output", "o", "Do probe for discovery process, including pre-check for required configuration and realtime monitor of discovery process.Before using this command, please install nslookup command ahead. Currently, this command does not support hierarchy.");
     exit 0;
 }
 

--- a/xCAT-probe/subcmds/image
+++ b/xCAT-probe/subcmds/image
@@ -22,7 +22,6 @@ my $rst     = 0;
 
 $::USAGE = "Usage:
     $program_name -h
-    $program_name -T
     $program_name {-c|-d} [-n noderange] [-V]
 
 Description:
@@ -31,7 +30,6 @@ Description:
 
 Options:
     -h : Get usage information of $program_name
-    -T : To verify if $program_name can work, reserve option for probe framework
     -n : Range of nodes to check
     -d : To verify diskless, pingable compute nodes have the same images installed as defines in xCAT DB. 
     -c : To verify all diskless, pingable compute nodes have the identical images installed.

--- a/xCAT-probe/subcmds/switch-macmap
+++ b/xCAT-probe/subcmds/switch-macmap
@@ -16,14 +16,13 @@ my $output  = "stdout";
 
 $::USAGE = "Usage:
     $proname -h
-    $proname -T
     $proname  <noderange> [-c] [-V]
 
 Description:
     To retrieve MAC address mapping for the specified switch, or all the switches defined in switches table in xCAT db.
+    Currently, this command does not support hierarchy.
 
 Options:
-    -T: Check whether this script is OK to run.
     -c: To check whether the switch is OK to retrieve MAC address mapping.
     -V: Output verbose information when accessing switch
 ";
@@ -67,7 +66,7 @@ if ($test) {
         probe_utils->send_msg("$output", "f", "No switchprobe tool is available at $currdir/bin/");
         exit 1;
     } else {
-        probe_utils->send_msg("$output", "o", "To retrieve MAC address mapping for the specified switch, or all the switches defined in switches table in xCAT db.");
+        probe_utils->send_msg("$output", "o", "To retrieve MAC address mapping for the specified switch, or all the switches defined in switches table in xCAT db. Currently, this command does not support hierarchy.");
         exit 0;
     }
 }

--- a/xCAT-server/lib/perl/xCAT/SvrUtils.pm
+++ b/xCAT-server/lib/perl/xCAT/SvrUtils.pm
@@ -460,20 +460,20 @@ sub get_file_name {
     if (-r "$searchpath/$profile.$os.$arch.$extension") {
         return "$searchpath/$profile.$os.$arch.$extension";
     }
-    elsif (-r "$searchpath/$profile.$osbase.$arch.$extension") {
-        return "$searchpath/$profile.$osbase.$arch.$extension";
-    }
-    elsif (-r "$searchpath/$profile.$genos.$arch.$extension") {
-        return "$searchpath/$profile.$genos.$arch.$extension";
-    }
     elsif (-r "$searchpath/$profile.$os.$extension") {
         return "$searchpath/$profile.$os.$extension";
     }
+    elsif (($genos) && (-r "$searchpath/$profile.$genos.$arch.$extension")) {
+        return "$searchpath/$profile.$genos.$arch.$extension";
+    }
+    elsif (($genos) && (-r "$searchpath/$profile.$genos.$extension")) {
+        return "$searchpath/$profile.$genos.$extension";
+    }
+    elsif (-r "$searchpath/$profile.$osbase.$arch.$extension") {
+        return "$searchpath/$profile.$osbase.$arch.$extension";
+    }
     elsif (-r "$searchpath/$profile.$osbase.$extension") {
         return "$searchpath/$profile.$osbase.$extension";
-    }
-    elsif (-r "$searchpath/$profile.$genos.$extension") {
-        return "$searchpath/$profile.$genos.$extension";
     }
     elsif (-r "$searchpath/$profile.$arch.$extension") {
         return "$searchpath/$profile.$arch.$extension";

--- a/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
+++ b/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
@@ -55,6 +55,8 @@ $Getopt::Long::ignorecase = 0;
 #@::objfilelist;     # list of object names from the "-f" option
 #@::allobjnames;     # combined list
 
+my $doreq;
+
 #@::noderange;       # list of nodes derived from command line
 
 #------------------------------------------------------------------------------
@@ -137,6 +139,7 @@ sub process_request
 
     $::request  = shift;
     $::callback = shift;
+    $doreq = shift;
 
     my $ret;
     my $msg;
@@ -4237,6 +4240,26 @@ sub defrm
                 }
             }
         }
+    }
+
+    # Call nodeset offline on each node to cleanup its boot configuration files from /tftpboot directory
+    if ($doreq) {
+        # Go through each object and make sure it is a node type
+        my @allnodes;
+        foreach my $single_object (keys %objhash) {
+            if ($objhash{$single_object} eq "node") {
+                # build a list of nodes to offline
+                push @allnodes, $single_object;
+            }
+        }
+        # Run nodeset offline and capture output.
+        # But the output can be ignored since we do not want to prevent user from doing rmdef if
+        # nodeset returns some error.
+        my @output = xCAT::Utils->runxcmd({
+            command => ['nodeset'],
+            node => [@allnodes],
+            arg  => ['offline'],
+        }, $doreq, 0 ,1);
     }
 
     # remove the objects

--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -2239,17 +2239,27 @@ sub copycd
         }
     }
 
-
     unless ($distname)
     {
+        print "INFO - Could not find ID=$did in the discinfo database for OS=$desc ARCH=$darch NUM=$dno, attempt to auto-detect...\n";
         if ($desc =~ /IBM_PowerKVM/)
         {
             # check for PowerKVM support
             my @pkvm_version = split / /, $desc;
             $distname = "pkvm" . $pkvm_version[1];
         }
+        elsif ($desc =~ /Red Hat Enterprise Linux/)
+        {
+            #
+            # Attempt to auto-detect for RHEL OS.
+            # RHEL 7.3 description is: Red Hat Enterprise Linux 7.3
+            #
+            my @rhel_version = split / /, $desc;
+            $distname = "rhels" . $rhel_version[4];
+        }
         else
         {
+            print "INFO - Could not auto-detect operating system.\n";
             return;    #Do nothing, not ours..
         }
     }

--- a/xCAT-server/lib/xcat/plugins/switchdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/switchdiscover.pm
@@ -1418,7 +1418,7 @@ sub switchsetup {
         if ( $stype =~ /BNT/ ) {
             $ret = config_BNT($dswitch, $node, $static_ip, $request, $sub_req);
             if ($ret == 1) {
-                next;
+                xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'otherinterfaces=config failed, dhcp ip=$ip'] }, $sub_req, 0, 1);
             }
         } 
         # Mellanox switches
@@ -1427,15 +1427,13 @@ sub switchsetup {
             #NOTE:  this expect routine will timeout after set up address
             $ret = config_Mellanox($dswitch, $node, $static_ip, $request, $sub_req);
             if ($ret == 1) {
-                next;
+                xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'otherinterfaces=config failed, dhcp ip=$ip'] }, $sub_req, 0, 1);
             }
 
         } 
         else {
             send_msg($request, 0, "the switch $dswitch type $stype is not support\n");
-            $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$dswitch,"ip=$ip",'otherinterfaces=switch type is not supported'] }, $sub_req, 0, 1);
-            $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip","switchtype=$stype",'otherinterfaces=switch type is not supported'] }, $sub_req, 0, 1);
-            next;
+            $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip","switchtype=$stype",'otherinterfaces=switch type is not supported yet, dhcp ip=$ip'] }, $sub_req, 0, 1);
         }
 
         # save for update mac address and remove node definition
@@ -1458,8 +1456,6 @@ sub switchsetup {
     if ($mactab) {
         $mactab->setNodesAttribs($discovered_switch);
     }
-
-
     return;
 }
 
@@ -1496,7 +1492,7 @@ sub config_BNT {
     #send_msg($request, 0, Dumper($output));
     
     #add default attribute for BNT switch
-    my $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'username=root','password=admin','protocol=telnet','switchtype=BNT'] }, $sub_req, 0, 1);
+    my $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'username=root','password=admin','protocol=telnet','switchtype=BNT','otherinterfaces='] }, $sub_req, 0, 1);
     #send_msg($request, 0, Dumper($ret));
 
     #set up hostname
@@ -1507,7 +1503,6 @@ sub config_BNT {
     if ($::RUNCMD_RC != 0)
     {
         send_msg($request, 0, "Failed to change hostname on $node");
-        $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'otherinterfaces=Failed to change hostname'] }, $sub_req, 0, 1);
         return 1;
     }
    
@@ -1603,7 +1598,7 @@ sub config_Mellanox {
     $myexp->soft_close();
 
     #add default attribute for Mellanox switch
-    $output = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'username=admin','switchtype=Mellanox'] }, $sub_req, 0, 1);
+    $output = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'username=admin','switchtype=Mellanox','otherinterfaces='] }, $sub_req, 0, 1);
     #send_msg($request, 0, Dumper($output));
 
 
@@ -1615,7 +1610,6 @@ sub config_Mellanox {
     if ($::RUNCMD_RC != 0)
     {
         send_msg($request, 0, "Failed to change hostname on $node");
-        $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'otherinterfaces=Failed to change hostname'] }, $sub_req, 0, 1);
         return 1;
     }
 

--- a/xCAT-server/lib/xcat/plugins/switchdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/switchdiscover.pm
@@ -459,7 +459,7 @@ sub process_request {
             if ($key !~ /nomac/) {
                 $mac = $key;
             }
-            my $msg = sprintf $format, $ip, $name, $vendor, $key;
+            my $msg = sprintf $format, $ip, $name, $vendor, $mac;
             send_msg(\%request, 0, $msg);
         }
     }
@@ -1363,11 +1363,7 @@ sub switchsetup {
     my $outhash = shift;
     my $request = shift;
     my $sub_req = shift;
-    my $ret;
     my @switchnode = ();
-    my $switchInfo;
-    my $output;
-    my $dshcmd;
     my $static_ip;
     my $discover_switch;
     my $nodes_to_config;

--- a/xCAT-server/lib/xcat/plugins/switchdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/switchdiscover.pm
@@ -1399,7 +1399,7 @@ sub switchsetup {
         my $node = $macmap->find_mac($mac,0);
         if (!$node) {
             send_msg($request, 0, "NO predefined switch matched this switch $dswitch with mac address $mac");
-            $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$dswitch,"ip=$ip",'otherinterfaces=no predefined switch'] }, $sub_req, 0, 1);
+            $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$dswitch,"ip=$ip",'status=no predefined switch'] }, $sub_req, 0, 1);
             next;
         }
 
@@ -1418,7 +1418,7 @@ sub switchsetup {
         if ( $stype =~ /BNT/ ) {
             $ret = config_BNT($dswitch, $node, $static_ip, $request, $sub_req);
             if ($ret == 1) {
-                xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'otherinterfaces=config failed, dhcp ip=$ip'] }, $sub_req, 0, 1);
+                xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip","otherinterfaces=dhcp:$ip",'status=config failed'] }, $sub_req, 0, 1);
             }
         } 
         # Mellanox switches
@@ -1427,13 +1427,13 @@ sub switchsetup {
             #NOTE:  this expect routine will timeout after set up address
             $ret = config_Mellanox($dswitch, $node, $static_ip, $request, $sub_req);
             if ($ret == 1) {
-                xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'otherinterfaces=config failed, dhcp ip=$ip'] }, $sub_req, 0, 1);
+                xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip","otherinterfaces=dhcp:$ip",'status=config failed'] }, $sub_req, 0, 1);
             }
 
         } 
         else {
             send_msg($request, 0, "the switch $dswitch type $stype is not support\n");
-            $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip","switchtype=$stype",'otherinterfaces=switch type is not supported yet, dhcp ip=$ip'] }, $sub_req, 0, 1);
+            $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip","switchtype=$stype","otherinterfaces=dhcp:$ip",'status=switch type is not supported yet'] }, $sub_req, 0, 1);
         }
 
         # save for update mac address and remove node definition
@@ -1492,7 +1492,7 @@ sub config_BNT {
     #send_msg($request, 0, Dumper($output));
     
     #add default attribute for BNT switch
-    my $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'username=root','password=admin','protocol=telnet','switchtype=BNT','otherinterfaces='] }, $sub_req, 0, 1);
+    my $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'username=root','password=admin','protocol=telnet','switchtype=BNT','otherinterfaces=','status='] }, $sub_req, 0, 1);
     #send_msg($request, 0, Dumper($ret));
 
     #set up hostname
@@ -1598,7 +1598,7 @@ sub config_Mellanox {
     $myexp->soft_close();
 
     #add default attribute for Mellanox switch
-    $output = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'username=admin','switchtype=Mellanox','otherinterfaces='] }, $sub_req, 0, 1);
+    $output = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"ip=$static_ip",'username=admin','switchtype=Mellanox','otherinterfaces=','status='] }, $sub_req, 0, 1);
     #send_msg($request, 0, Dumper($output));
 
 

--- a/xCAT-server/share/xcat/netboot/rh/dracut/install.statelite
+++ b/xCAT-server/share/xcat/netboot/rh/dracut/install.statelite
@@ -1,6 +1,6 @@
 #!/bin/sh
 echo $drivers
-dracut_install wget tar xz cpio gzip dash  modprobe wc touch echo cut
+dracut_install wget tar cpio gzip dash modprobe wc touch echo cut
 dracut_install -o ctorrent
 dracut_install grep ifconfig hostname awk egrep grep dirname expr
 dracut_install parted mke2fs bc mkswap swapon chmod

--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -265,12 +265,17 @@ unless ($onlyinitrd) {
     @yumdirs = ();
 
     my @pkgdirs = split(",", $srcdir);
+    my @pkgdir_internet; #Put all of the http mirrors in this array
     my $dir;
     foreach $dir (@pkgdirs) {
+      if ($dir =~ /^http.*/) {
+        push @pkgdir_internet, $dir;
+      } else {
         find(\&isyumdir, <$dir/>);
         if (!grep /$dir/, @yumdirs) {
             print "The repository for $dir should be created before running the genimge. Try to run [createrepo $dir].\n";
         }
+      }
     }
 
     # Add the dir for kernel rpm to be installed
@@ -280,8 +285,8 @@ unless ($onlyinitrd) {
             print "The repository for $kerneldir should be created before running the genimge. Try to run [createrepo $kerneldir].\n";
         }
     }
-    unless (scalar(@yumdirs)) {
-        print "Need $installroot/$osver/$arch/ available from a system that has ran copycds on $osver $arch\n";
+    unless (scalar(@yumdirs) || scalar(@pkgdir_internet)) {
+       print "Need $installroot/$osver/$arch/ available from a system that has ran copycds on $osver $arch or correct web repo\n";
         exit 1;
     }
 
@@ -299,6 +304,10 @@ unless ($onlyinitrd) {
     foreach $srcdir (@yumdirs) {
         print $yumconfig "[$osver-$arch-$repnum]\nname=$osver-$arch-$repnum\nbaseurl=file://$srcdir\ngpgpcheck=0\n\n";
         $repnum += 1;
+    }
+    foreach $srcdir (@pkgdir_internet) {
+       print $yumconfig "[$osver-$arch-$repnum]\nname=$osver-$arch-$repnum\nbaseurl=$srcdir\ngpgpcheck=0\n\n";
+       $repnum += 1;
     }
     $repnum -= 1;
     close($yumconfig);

--- a/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu16.04.1.pkglist
+++ b/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu16.04.1.pkglist
@@ -1,0 +1,17 @@
+bash
+nfs-common
+openssl
+isc-dhcp-client
+libc-bin
+linux-image-generic
+openssh-server
+openssh-client
+wget
+ntp
+ntpdate
+rsync
+busybox-static
+gawk
+dnsutils
+tar
+gzip

--- a/xCAT-server/share/xcat/tools/configBNT
+++ b/xCAT-server/share/xcat/tools/configBNT
@@ -54,9 +54,6 @@ if ($::SWITCH)
 
 my $cmd;
 
-#default root/password and protcol for BNT switch
-my $cmd = `chdef $switch protocol=telnet username=root password=admin`; 
-
 my $vlan;
 my $port;
 if ($::VLAN)

--- a/xCAT-server/share/xcat/tools/configBNT
+++ b/xCAT-server/share/xcat/tools/configBNT
@@ -327,9 +327,7 @@ sub config_snmp {
     if (@config_switches) {
         #update switch status
         my $csw = join(",",@config_switches);
-        $cmd = "chdef $csw status=switch_configed" ;
-        $rc= xCAT::Utils->runcmd($cmd, 0);
-        $cmd = "chtab switch=$csw switches.snmpversion=3 switches.auth=sha switches.username=$snmp_user switches.password=$snmp_passwd" ;
+        $cmd = "chdef $csw status=switch_configed snmpversion=3 snmpauth=sha snmpusername=$snmp_user snmppassword=$snmp_passwd";
         $rc= xCAT::Utils->runcmd($cmd, 0);
     }
 }

--- a/xCAT-server/share/xcat/tools/configBNT
+++ b/xCAT-server/share/xcat/tools/configBNT
@@ -23,10 +23,6 @@ use xCAT::Utils;
 use xCAT::Table;
 use xCAT::MsgUtils;
 
-
-my $args = join ' ', @ARGV;
-$::command = "$0 $args";
-
 Getopt::Long::Configure("bundling");
 $Getopt::Long::ignorecase = 0;
 
@@ -41,17 +37,17 @@ my @filternodes;
 # parse the options
 if (
     !GetOptions(
-                'h|help'       => \$::HELP,
-                'range=s'    => \$::SWITCH,  
+                'h|help'     => \$::HELP,
+                'switches=s' => \$::SWITCH,  
                 'port=s'     => \$::PORT,  
                 'vlan=s'     => \$::VLAN,
                 'user=s'     => \$::USER,
                 'password=s' => \$::PASSWORD,
                 'group=s'    => \$::GROUP,
-                'snmp'         => \$::SNMP,
-		'ip'           => \$::IP,
-                'name'         => \$::NAME,
-                'all'          => \$::ALL,
+                'snmp'       => \$::SNMP,
+		'ip'         => \$::IP,
+                'name'       => \$::NAME,
+                'all'        => \$::ALL,
     )
   )
 {
@@ -72,15 +68,22 @@ if ($::SWITCH) {
         my $nodenotdefined = join(',', nodesmissed);
         xCAT::MsgUtils->message("I","The following nodes are not defined in xCAT DB: $nodenotdefined");
     }
-    foreach (@filternodes)  {
-        push @nodes, $_;
+    # check switch type
+    my $switchestab =  xCAT::Table->new('switches');
+    my $switches_hash = $switchestab->getNodesAttribs(\@filternodes,['switchtype']);
+    foreach my $fsw (@filternodes)  {
+        if (($switches_hash->{$fsw}->[0]->{switchtype}) =~ /BNT/) {
+            push @nodes, $fsw;
+        } else {
+            xCAT::MsgUtils->message("E","The $fsw is not BNT switch, will not config");
+        }
     }
     unless (@nodes) {
         xCAT::MsgUtils->message("E","No Valid Switch to process");
         exit(1);
     }
 } else {
-    xCAT::MsgUtils->message("E","Invalid flag, please provide switches with --range");
+    xCAT::MsgUtils->message("E","Invalid flag, please provide switches with --switches");
     &usage;
     exit(1);
 }
@@ -90,25 +93,18 @@ my $cmd;
 my $vlan;
 my $port;
 my $sub_req;
-my $switch;
 my $rc;
 
-if ($::ALL) {
-    config_ip();
-    config_hostname();
-    config_snmp();
-}
-
-if ($::IP)
+if (($::IP) || ($::ALL))
 {
     config_ip();
 }
 
-if ($::NAME)
+if (($::NAME) || ($::ALL))
 {
     config_hostname();
 }
-if ($::SNMP)
+if (($::SNMP) || ($::ALL))
 {
     config_snmp();
 }
@@ -118,12 +114,14 @@ if ($::VLAN)
 }
 
 sub config_ip {
-
+    my @config_switches;
+    my @discover_switches;
     my $nodetab = xCAT::Table->new('hosts');
-    my $nodehash = $nodetab->getNodesAttribs(\@nodes,['otherinterfaces']);
+    my $nodehash = $nodetab->getNodesAttribs(\@nodes,['ip','otherinterfaces']);
     foreach my $switch (@nodes) {
         print "change $switch to static ip address\n";
         my $dip= $nodehash->{$switch}->[0]->{otherinterfaces};
+        my $static_ip= $nodehash->{$switch}->[0]->{ip};
 
         #get hostname
         my $dswitch = xCAT::NetworkUtils->gethostname($dip);
@@ -133,20 +131,12 @@ sub config_ip {
             my $ip_str = $dip;
             $ip_str =~ s/\./\-/g;
             $dswitch = "switch-$ip_str";
-            #is there other way we can check if this node is defined in the xCATdb
-            $cmd = "lsdef $dswitch";
-            $rc= xCAT::Utils->runcmd($cmd, 0);
-            if ($::RUNCMD_RC != 0) {
-                $cmd = "mkdef -t node -o $dswitch groups=switch ip=$dip switchtype=BNT username=root password=admin protocol=telnet nodetype=switch";
-                $rc= xCAT::Utils->runcmd($cmd, 0);
-            }
         }
-        #check if it is in the /etc/hosts
-        my $output = `grep $dswitch /etc/hosts`;
-        if ( !$output ) {
-            $cmd = "makehosts $dswitch";
-            $rc= xCAT::Utils->runcmd($cmd, 0);
-        }
+        $cmd = "chdef -t node -o $dswitch groups=switch ip=$dip switchtype=BNT username=root password=admin protocol=telnet nodetype=switch";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+        $cmd = "makehosts $dswitch";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+
         # verify if xdsh works
         $cmd = "xdsh $dswitch --devicetype EthSwitch::BNT 'enable;configure terminal;exit' ";
         $rc= xCAT::Utils->runcmd($cmd, 0);
@@ -154,29 +144,30 @@ sub config_ip {
             xCAT::MsgUtils->message("E","Couldn't communicate with $dswitch, $dip");
             next;
         }
-        #change to static ip address
-        my $static_ip = xCAT::NetworkUtils->getipaddr($switch);
-        if (!$static_ip){
-            xCAT::MsgUtils->message("E","static ip is not defined for $switch");
-            next;
-        }
         $cmd="xdsh $dswitch -t 10 --devicetype EthSwitch::BNT 'enable;configure terminal;show interface ip;interface ip 1;ip address $static_ip;exit;exit' ";
         $rc= xCAT::Utils->runcmd($cmd, 0);
         print "finish setup static ip address for $switch\n";
-
+        push (@discover_switches, $dswitch);
+        push (@config_switches, $switch);
+    }
+    if (@config_switches) {
         #update switch status
-        $cmd = "chdef $switch status=ip_configed otherinterface=";
+        my $csw = join(",",@config_switches);
+        $cmd = "chdef $csw status=ip_configed otherinterfaces=";
         $rc= xCAT::Utils->runcmd($cmd, 0);
-
+    }
+    if (@discover_switches) {
+        my $dsw = join(",",@discover_switches);
         #remove discover switch from xCATdb and /etc/hosts
-        $cmd = "makehosts -d $dswitch";
+        $cmd = "makehosts -d $dsw";
         $rc= xCAT::Utils->runcmd($cmd, 0);
-        $cmd = "rmdef $dswitch";
+        $cmd = "rmdef $dsw";
         $rc= xCAT::Utils->runcmd($cmd, 0);
     }
 }
 
 sub config_hostname {
+    my @config_switches;
     my $switchtab = xCAT::Table->new('switches');
     my $switchhash = $switchtab->getNodesAttribs(\@nodes,['sshusername','sshpassword']);
     foreach my $switch (@nodes) {
@@ -193,8 +184,12 @@ sub config_hostname {
             xCAT::MsgUtils->message("E","Failed to setup hostname for $switch");
             next;
         }
+        push (@config_switches, $switch);
+    }
+    if (@config_switches) {
         #update switch status
-        $cmd = "chdef $switch status=hostname_configed" ;
+        my $csw = join(",",@config_switches);
+        $cmd = "chdef $csw status=hostname_configed" ;
         $rc= xCAT::Utils->runcmd($cmd, 0);
     }
 }
@@ -205,6 +200,7 @@ sub config_snmp {
     my $snmp_user;
     my $snmp_passwd;
     my $snmp_group;
+    my @config_switches;
 
     if ($::USER) {
         $snmp_user = $::USER;
@@ -326,9 +322,14 @@ sub config_snmp {
             exit(1);
         }
         $mysw->soft_close();
-
+        push (@config_switches, $switch);
+    }
+    if (@config_switches) {
         #update switch status
-        $cmd = "chdef $switch status=switch_configed" ;
+        my $csw = join(",",@config_switches);
+        $cmd = "chdef $csw status=switch_configed" ;
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+        $cmd = "chtab switch=$csw switches.snmpversion=3 switches.auth=sha switches.username=$snmp_user switches.password=$snmp_passwd" ;
         $rc= xCAT::Utils->runcmd($cmd, 0);
     }
 }
@@ -361,11 +362,11 @@ sub usage
 {
     print "Usage:
     configBNT [-?│-h│--help] 
-    configBNT [--range switchnames] [--all] 
-    configBNT [--range switchnames] [--ip] 
-    configBNT [--range switchnames] [--name ] 
-    configBNT [--range switchnames] [--snmp] [--user snmp_user] [--password snmp_password] [--group snmp_group]
-    configBNT [--range switchnames] [--port port] [--vlan vlan]
+    configBNT [--switches switchnames] [--all] 
+    configBNT [--switches switchnames] [--ip] 
+    configBNT [--switches switchnames] [--name ] 
+    configBNT [--switches switchnames] [--snmp] [--user snmp_user] [--password snmp_password] [--group snmp_group]
+    configBNT [--switches switchnames] [--port port] [--vlan vlan]
     \n";
 }
 

--- a/xCAT-server/share/xcat/tools/configBNT
+++ b/xCAT-server/share/xcat/tools/configBNT
@@ -4,15 +4,35 @@
 # Configure Ethnet BNT switches
 #---------------------------------------------------------
 
+BEGIN
+{
+  $::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : '/opt/xcat';
+  $::XCATDIR  = $ENV{'XCATDIR'}  ? $ENV{'XCATDIR'}  : '/etc/xcat';
+}
+use lib "$::XCATROOT/lib/perl";
+
+
 use strict;
+use Socket;
 use Getopt::Long;
 use Expect;
+use xCAT::Usage;
+use xCAT::NodeRange;
+use xCAT::NetworkUtils;
+use xCAT::Utils;
+use xCAT::Table;
+use xCAT::MsgUtils;
+
 
 my $args = join ' ', @ARGV;
 $::command = "$0 $args";
 
 Getopt::Long::Configure("bundling");
 $Getopt::Long::ignorecase = 0;
+
+#global variables
+my @nodes;
+my @filternodes;
 
 
 #---------------------------------------------------------
@@ -22,13 +42,16 @@ $Getopt::Long::ignorecase = 0;
 if (
     !GetOptions(
                 'h|help'       => \$::HELP,
-                'r|range=s'    => \$::SWITCH,  
-                'p|port=s'     => \$::PORT,  
-                'v|vlan=s'     => \$::VLAN,
-                'u|user=s'     => \$::USER,
-                'w|password=s' => \$::PASSWORD,
-                'g|group=s'    => \$::GROUP,
+                'range=s'    => \$::SWITCH,  
+                'port=s'     => \$::PORT,  
+                'vlan=s'     => \$::VLAN,
+                'user=s'     => \$::USER,
+                'password=s' => \$::PASSWORD,
+                'group=s'    => \$::GROUP,
                 'snmp'         => \$::SNMP,
+		'ip'           => \$::IP,
+                'name'         => \$::NAME,
+                'all'          => \$::ALL,
     )
   )
 {
@@ -43,54 +66,146 @@ if ($::HELP)
     exit(0);
 }
 
-my $switch;
-if ($::SWITCH)
-{
-    $switch = $::SWITCH;
+if ($::SWITCH) {
+    my @filternodes = xCAT::NodeRange::noderange( $::SWITCH );
+    if (nodesmissed) {
+        my $nodenotdefined = join(',', nodesmissed);
+        xCAT::MsgUtils->message("I","The following nodes are not defined in xCAT DB: $nodenotdefined");
+    }
+    foreach (@filternodes)  {
+        push @nodes, $_;
+    }
+    unless (@nodes) {
+        xCAT::MsgUtils->message("E","No Valid Switch to process");
+        exit(1);
+    }
 } else {
+    xCAT::MsgUtils->message("E","Invalid flag, please provide switches with --range");
     &usage;
     exit(1);
 }
 
+my $switches = join(",",@nodes);
 my $cmd;
-
 my $vlan;
 my $port;
-if ($::VLAN)
-{
-    if ($::PORT) {
-        $port = $::PORT;
-    } else {
-        print "Need port number to set up VLAN\n";
-        &usage;
-        exit(1);
-    }
-    $vlan = $::VLAN;
-    print "Tagging VLAN=$vlan for $switch port $port\n";
-    #create vlan
-    #tagged vlan
-    $cmd = `xdsh $switch --devicetype EthSwitch::BNT "enable;configure terminal;vlan $vlan;exit;interface port $port;switchport mode trunk;switchport trunk allowed vlan $vlan;write memory;exit;exit"`;
+my $sub_req;
+my $switch;
+my $rc;
+
+if ($::ALL) {
+    config_ip();
+    config_hostname();
+    config_snmp();
 }
 
+if ($::IP)
+{
+    config_ip();
+}
+
+if ($::NAME)
+{
+    config_hostname();
+}
+if ($::SNMP)
+{
+    config_snmp();
+}
+if ($::VLAN)
+{
+    config_vlan();
+}
+
+sub config_ip {
+
+    my $nodetab = xCAT::Table->new('hosts');
+    my $nodehash = $nodetab->getNodesAttribs(\@nodes,['otherinterfaces']);
+    foreach my $switch (@nodes) {
+        print "change $switch to static ip address\n";
+        my $dip= $nodehash->{$switch}->[0]->{otherinterfaces};
+
+        #get hostname
+        my $dswitch = xCAT::NetworkUtils->gethostname($dip);
+
+        #if not defined, need to create one for xdsh to use
+        if (!$dswitch) {
+            my $ip_str = $dip;
+            $ip_str =~ s/\./\-/g;
+            $dswitch = "switch-$ip_str";
+            #is there other way we can check if this node is defined in the xCATdb
+            $cmd = "lsdef $dswitch";
+            $rc= xCAT::Utils->runcmd($cmd, 0);
+            if ($::RUNCMD_RC != 0) {
+                $cmd = "mkdef -t node -o $dswitch groups=switch ip=$dip switchtype=BNT username=root password=admin protocol=telnet nodetype=switch";
+                $rc= xCAT::Utils->runcmd($cmd, 0);
+            }
+        }
+        #check if it is in the /etc/hosts
+        my $output = `grep $dswitch /etc/hosts`;
+        if ( !$output ) {
+            $cmd = "makehosts $dswitch";
+            $rc= xCAT::Utils->runcmd($cmd, 0);
+        }
+        # verify if xdsh works
+        $cmd = "xdsh $dswitch --devicetype EthSwitch::BNT 'enable;configure terminal;exit' ";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+        if ($::RUNCMD_RC != 0) {
+            xCAT::MsgUtils->message("E","Couldn't communicate with $dswitch, $dip");
+            next;
+        }
+        #change to static ip address
+        my $static_ip = xCAT::NetworkUtils->getipaddr($switch);
+        if (!$static_ip){
+            xCAT::MsgUtils->message("E","static ip is not defined for $switch");
+            next;
+        }
+        $cmd="xdsh $dswitch -t 10 --devicetype EthSwitch::BNT 'enable;configure terminal;show interface ip;interface ip 1;ip address $static_ip;exit;exit' ";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+        print "finish setup static ip address for $switch\n";
+
+        #update switch status
+        $cmd = "chdef $switch status=ip_configed otherinterface=";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+
+        #remove discover switch from xCATdb and /etc/hosts
+        $cmd = "makehosts -d $dswitch";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+        $cmd = "rmdef $dswitch";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+    }
+}
+
+sub config_hostname {
+    my $switchtab = xCAT::Table->new('switches');
+    my $switchhash = $switchtab->getNodesAttribs(\@nodes,['sshusername','sshpassword']);
+    foreach my $switch (@nodes) {
+        my $user= $switchhash->{$switch}->[0]->{sshusername};
+        my $pwd= $switchhash->{$switch}->[0]->{sshpassword};
+        if ((!$user)||(!$pwd)) {
+            print "switch ssh username or password is not define, add default one\n";
+            $cmd = "chdef $switch username=root password=admin";
+            $rc= xCAT::Utils->runcmd($cmd, 0);
+        }
+        $cmd="xdsh $switch --devicetype EthSwitch::BNT 'enable;configure terminal;hostname $switch;write memory' ";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+        if ($::RUNCMD_RC != 0) {
+            xCAT::MsgUtils->message("E","Failed to setup hostname for $switch");
+            next;
+        }
+        #update switch status
+        $cmd = "chdef $switch status=hostname_configed" ;
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+    }
+}
+
+
 #setup secure SNMP v3 
-if ($::SNMP){
-    my $mysw;
-    my $enable_cmd="enable\r";
-    my $config_cmd="configure terminal\r";
-    my $exit_cmd="exit\r";
-
-    my $pwd_prompt   = "password: ";
-    my $sw_prompt = "$switch>";
-    my $enable_prompt="$switch#";
-    my $config_prompt="^.*\\\(config\\\)\#";
-
-    $mysw = new Expect;
-    my $timeout = 20;
-    my $login_cmd = "telnet $switch\r";
-    my $passwd = "admin\r";
+sub config_snmp {
     my $snmp_user;
     my $snmp_passwd;
     my $snmp_group;
+
     if ($::USER) {
         $snmp_user = $::USER;
     } else {
@@ -107,98 +222,131 @@ if ($::SNMP){
     } else {
         $snmp_group = "xcatgroup\r";
     }
-    print "Setup SNMP server for user=$snmp_user, password=$snmp_passwd, group=$snmp_group\n";
-    #create a SNMP user
-    my $cfg_user1="snmp-server user 5 name $snmp_user\r";
-    my $cfg_user2="snmp-server user 5 authentication-protocol sha authentication-password\r";
-    #create a SNMP group
-    my $cfg_group1="snmp-server group 5 group-name $snmp_group\r";
-    my $cfg_group2="snmp-server group 5 user-name $snmp_user\r";
-    my $cfg_group3="snmp-server group 5 security usm\r";
-    #Add access permission
-    my $cfg_access1="snmp-server access 5 name $snmp_group\r";
-    my $cfg_access2="snmp-server access 5 level authNoPriv\r";
-    my $cfg_access3="snmp-server access 5 security usm\r";
-    my $cfg_access4="snmp-server access 5 read-view iso\r";
 
-    $mysw->slave->stty(qw(sane -echo));
+    foreach my $switch (@nodes) {
+        my $mysw;
+        my $enable_cmd="enable\r";
+        my $config_cmd="configure terminal\r";
+        my $exit_cmd="exit\r";
 
-    unless ($mysw->spawn($login_cmd))
-    {
+        my $pwd_prompt   = "password: ";
+        my $sw_prompt = "$switch>";
+        my $enable_prompt="$switch#";
+        my $config_prompt="^.*\\\(config\\\)\#";
+
+        $mysw = new Expect;
+        my $timeout = 20;
+        my $login_cmd = "telnet $switch\r";
+        my $passwd = "admin\r";
+
+        print "Setup SNMP server for $switch\n";
+        #create a SNMP user
+        my $cfg_user1="snmp-server user 5 name $snmp_user\r";
+        my $cfg_user2="snmp-server user 5 authentication-protocol sha authentication-password\r";
+        #create a SNMP group
+        my $cfg_group1="snmp-server group 5 group-name $snmp_group\r";
+        my $cfg_group2="snmp-server group 5 user-name $snmp_user\r";
+        my $cfg_group3="snmp-server group 5 security usm\r";
+        #Add access permission
+        my $cfg_access1="snmp-server access 5 name $snmp_group\r";
+        my $cfg_access2="snmp-server access 5 level authNoPriv\r";
+        my $cfg_access3="snmp-server access 5 security usm\r";
+        my $cfg_access4="snmp-server access 5 read-view iso\r";
+
+        $mysw->slave->stty(qw(sane -echo));
+
+        unless ($mysw->spawn($login_cmd))
+        {
+            $mysw->soft_close();
+            print "Unable to run $login_cmd\n";
+            next;
+        }
+        my @result = $mysw->expect(
+            $timeout,
+            [
+                $pwd_prompt,
+                sub {
+                    $mysw->clear_accum();
+                    $mysw->send("$passwd\r");
+                    $mysw->clear_accum();
+                    $mysw->exp_continue();
+                }
+            ],
+            [
+                "-re", $sw_prompt,
+                sub {
+                    $mysw->clear_accum();
+                    $mysw->send($enable_cmd);
+                    $mysw->exp_continue();
+                }
+            ],
+            [
+                "-re", $enable_prompt,
+                sub {
+                    $mysw->clear_accum();
+                    $mysw->send($config_cmd);
+                    $mysw->exp_continue();
+                }
+            ],
+            [
+                "-re", $config_prompt,
+                sub {
+                    $mysw->clear_accum();
+                    $mysw->send($cfg_user1);
+                    $mysw->send($cfg_user2);
+                    $mysw->send($passwd);
+                    $mysw->send($snmp_passwd);
+                    $mysw->send($snmp_passwd);
+                    sleep 1;
+                    $mysw->clear_accum();
+                    # create snmp group
+                    $mysw->send($cfg_group1);
+                    $mysw->send($cfg_group2);
+                    $mysw->send($cfg_group3);
+                    $mysw->clear_accum();
+                    $mysw->send($cfg_access1);
+                    $mysw->send($cfg_access2);
+                    $mysw->send($cfg_access3);
+                    $mysw->send($cfg_access4);
+                    $mysw->clear_accum();
+                    $mysw->send("write memory\r");
+                    $mysw->send($exit_cmd);
+                    $mysw->send($exit_cmd);
+                }
+            ],
+        );
+        ##########################################
+        # Expect error - report and quit
+        ##########################################
+        if (defined($result[1]))
+        {
+            my $errmsg = $result[1];
+            $mysw->soft_close();
+            print "Failed expect command $errmsg\n";
+            exit(1);
+        }
         $mysw->soft_close();
-        print "Unable to run $login_cmd\n";
-        next;
+
+        #update switch status
+        $cmd = "chdef $switch status=switch_configed" ;
+        $rc= xCAT::Utils->runcmd($cmd, 0);
     }
-    my @result = $mysw->expect(
-        $timeout,
-        [
-            $pwd_prompt,
-            sub {
-                $mysw->clear_accum();
-                $mysw->send("$passwd\r");
-                $mysw->clear_accum();
-                $mysw->exp_continue();
-            }
-        ],
-        [
-            "-re", $sw_prompt,
-            sub {
-                #print "$switch: sending enable command: $enable_cmd\n";
-                $mysw->clear_accum();
-                $mysw->send($enable_cmd);
-                $mysw->exp_continue();
-            }
-        ],
-        [
-            "-re", $enable_prompt,
-            sub {
-                #print "$switch: sending config command: $config_cmd\n";
-                $mysw->clear_accum();
-                $mysw->send($config_cmd);
-                $mysw->exp_continue();
-            }
-        ],
-        [
-            "-re", $config_prompt,
-            sub {
-                $mysw->clear_accum();
-                $mysw->send($cfg_user1);
-                $mysw->send($cfg_user2);
-                $mysw->send($passwd);
-                $mysw->send($snmp_passwd);
-                $mysw->send($snmp_passwd);
-                sleep 1;
-                $mysw->clear_accum();
-                # create snmp group
-                $mysw->send($cfg_group1);
-                $mysw->send($cfg_group2);
-                $mysw->send($cfg_group3);
-                $mysw->clear_accum();
-                $mysw->send($cfg_access1);
-                $mysw->send($cfg_access2);
-                $mysw->send($cfg_access3);
-                $mysw->send($cfg_access4);
-                $mysw->clear_accum();
-                $mysw->send("write memory\r");
-                $mysw->send($exit_cmd);
-                $mysw->send($exit_cmd);
-            }
-        ],
-    );
-    ##########################################
-    # Expect error - report and quit
-    ##########################################
-    if (defined($result[1]))
-    {
-        my $errmsg = $result[1];
-        $mysw->soft_close();
-        print "Failed expect command $errmsg\n";
+}
+
+sub config_vlan {
+    if ($::PORT) {
+        $port = $::PORT;
+    } else {
+        &usage;
         exit(1);
     }
-    $mysw->soft_close();
+    $vlan = $::VLAN;
+    print "Tagging VLAN=$vlan for $switches port $port\n";
+    #create vlan, tagged vlan
+    $cmd = `xdsh $switches --devicetype EthSwitch::BNT "enable;configure terminal;vlan $vlan;exit;interface port $port;switchport mode trunk;switchport trunk allowed vlan $vlan;write memory;exit;exit"`;
 
-             
 }
+
 
 #---------------------------------------------------------
 
@@ -213,8 +361,11 @@ sub usage
 {
     print "Usage:
     configBNT [-?│-h│--help] 
-    configBNT [--range switchnames] [-p|--port port] [-v|--vlan vlan]
-    configBNT [--range switchnames] [--snmp] [-u|--user snmp_user] [-w|--password snmp_password] [-g|--group snmp_group]
+    configBNT [--range switchnames] [--all] 
+    configBNT [--range switchnames] [--ip] 
+    configBNT [--range switchnames] [--name ] 
+    configBNT [--range switchnames] [--snmp] [--user snmp_user] [--password snmp_password] [--group snmp_group]
+    configBNT [--range switchnames] [--port port] [--vlan vlan]
     \n";
 }
 

--- a/xCAT-server/share/xcat/tools/configBNT
+++ b/xCAT-server/share/xcat/tools/configBNT
@@ -1,0 +1,224 @@
+#!/usr/bin/env perl
+
+#---------------------------------------------------------
+# Configure Ethnet BNT switches
+#---------------------------------------------------------
+
+use strict;
+use Getopt::Long;
+use Expect;
+
+my $args = join ' ', @ARGV;
+$::command = "$0 $args";
+
+Getopt::Long::Configure("bundling");
+$Getopt::Long::ignorecase = 0;
+
+
+#---------------------------------------------------------
+#Main
+
+# parse the options
+if (
+    !GetOptions(
+                'h|help'       => \$::HELP,
+                'r|range=s'    => \$::SWITCH,  
+                'p|port=s'     => \$::PORT,  
+                'v|vlan=s'     => \$::VLAN,
+                'u|user=s'     => \$::USER,
+                'w|password=s' => \$::PASSWORD,
+                'g|group=s'    => \$::GROUP,
+                'snmp'         => \$::SNMP,
+    )
+  )
+{
+    &usage;
+    exit(1);
+}
+
+# display the usage if -h or --help is specified
+if ($::HELP)
+{
+    &usage;
+    exit(0);
+}
+
+my $switch;
+if ($::SWITCH)
+{
+    $switch = $::SWITCH;
+} else {
+    &usage;
+    exit(1);
+}
+
+my $cmd;
+
+#default root/password and protcol for BNT switch
+my $cmd = `chdef $switch protocol=telnet username=root password=admin`; 
+
+my $vlan;
+my $port;
+if ($::VLAN)
+{
+    if ($::PORT) {
+        $port = $::PORT;
+    } else {
+        print "Need port number to set up VLAN\n";
+        &usage;
+        exit(1);
+    }
+    $vlan = $::VLAN;
+    print "Tagging VLAN=$vlan for $switch port $port\n";
+    #create vlan
+    #tagged vlan
+    $cmd = `xdsh $switch --devicetype EthSwitch::BNT "enable;configure terminal;vlan $vlan;exit;interface port $port;switchport mode trunk;switchport trunk allowed vlan $vlan;write memory;exit;exit"`;
+}
+
+#setup secure SNMP v3 
+if ($::SNMP){
+    my $mysw;
+    my $enable_cmd="enable\r";
+    my $config_cmd="configure terminal\r";
+    my $exit_cmd="exit\r";
+
+    my $pwd_prompt   = "password: ";
+    my $sw_prompt = "$switch>";
+    my $enable_prompt="$switch#";
+    my $config_prompt="^.*\\\(config\\\)\#";
+
+    $mysw = new Expect;
+    my $timeout = 20;
+    my $login_cmd = "telnet $switch\r";
+    my $passwd = "admin\r";
+    my $snmp_user;
+    my $snmp_passwd;
+    my $snmp_group;
+    if ($::USER) {
+        $snmp_user = $::USER;
+    } else {
+        $snmp_user = "xcatadmin\r";
+    }
+    if ($::PASSWORD) {
+        $snmp_passwd = $::PASSWORD;
+    } else {
+        # Need a special character
+        $snmp_passwd = "xcatadminpassw0rd\@snmp\r";
+    }
+    if ($::GROUP) {
+        $snmp_group = $::GROUP;
+    } else {
+        $snmp_group = "xcatgroup\r";
+    }
+    print "Setup SNMP server for user=$snmp_user, password=$snmp_passwd, group=$snmp_group\n";
+    #create a SNMP user
+    my $cfg_user1="snmp-server user 5 name $snmp_user\r";
+    my $cfg_user2="snmp-server user 5 authentication-protocol sha authentication-password\r";
+    #create a SNMP group
+    my $cfg_group1="snmp-server group 5 group-name $snmp_group\r";
+    my $cfg_group2="snmp-server group 5 user-name $snmp_user\r";
+    my $cfg_group3="snmp-server group 5 security usm\r";
+    #Add access permission
+    my $cfg_access1="snmp-server access 5 name $snmp_group\r";
+    my $cfg_access2="snmp-server access 5 level authNoPriv\r";
+    my $cfg_access3="snmp-server access 5 security usm\r";
+    my $cfg_access4="snmp-server access 5 read-view iso\r";
+
+    $mysw->slave->stty(qw(sane -echo));
+
+    unless ($mysw->spawn($login_cmd))
+    {
+        $mysw->soft_close();
+        print "Unable to run $login_cmd\n";
+        next;
+    }
+    my @result = $mysw->expect(
+        $timeout,
+        [
+            $pwd_prompt,
+            sub {
+                $mysw->clear_accum();
+                $mysw->send("$passwd\r");
+                $mysw->clear_accum();
+                $mysw->exp_continue();
+            }
+        ],
+        [
+            "-re", $sw_prompt,
+            sub {
+                #print "$switch: sending enable command: $enable_cmd\n";
+                $mysw->clear_accum();
+                $mysw->send($enable_cmd);
+                $mysw->exp_continue();
+            }
+        ],
+        [
+            "-re", $enable_prompt,
+            sub {
+                #print "$switch: sending config command: $config_cmd\n";
+                $mysw->clear_accum();
+                $mysw->send($config_cmd);
+                $mysw->exp_continue();
+            }
+        ],
+        [
+            "-re", $config_prompt,
+            sub {
+                $mysw->clear_accum();
+                $mysw->send($cfg_user1);
+                $mysw->send($cfg_user2);
+                $mysw->send($passwd);
+                $mysw->send($snmp_passwd);
+                $mysw->send($snmp_passwd);
+                sleep 1;
+                $mysw->clear_accum();
+                # create snmp group
+                $mysw->send($cfg_group1);
+                $mysw->send($cfg_group2);
+                $mysw->send($cfg_group3);
+                $mysw->clear_accum();
+                $mysw->send($cfg_access1);
+                $mysw->send($cfg_access2);
+                $mysw->send($cfg_access3);
+                $mysw->send($cfg_access4);
+                $mysw->clear_accum();
+                $mysw->send("write memory\r");
+                $mysw->send($exit_cmd);
+                $mysw->send($exit_cmd);
+            }
+        ],
+    );
+    ##########################################
+    # Expect error - report and quit
+    ##########################################
+    if (defined($result[1]))
+    {
+        my $errmsg = $result[1];
+        $mysw->soft_close();
+        print "Failed expect command $errmsg\n";
+        exit(1);
+    }
+    $mysw->soft_close();
+
+             
+}
+
+#---------------------------------------------------------
+
+=head3    usage
+
+        Displays message for -h option
+
+=cut
+
+#---------------------------------------------------------
+sub usage
+{
+    print "Usage:
+    configBNT [-?│-h│--help] 
+    configBNT [--range switchnames] [-p|--port port] [-v|--vlan vlan]
+    configBNT [--range switchnames] [--snmp] [-u|--user snmp_user] [-w|--password snmp_password] [-g|--group snmp_group]
+    \n";
+}
+
+

--- a/xCAT-server/share/xcat/tools/configMellanox
+++ b/xCAT-server/share/xcat/tools/configMellanox
@@ -76,19 +76,19 @@ print $cmd;
 
 #call rspconfig command to setup switch
 #enable ssh
-$cmd=`rscpconfig $switch sshcfg=enable`;
+$cmd=`rspconfig $switch sshcfg=enable`;
 print $cmd;
 
 #enable snmp function on the switch
-$cmd=`rscpconfig $switch snmpcfg=enable`;
+$cmd=`rspconfig $switch snmpcfg=enable`;
 print $cmd;
 
 #enable the snmp trap
-$cmd=`rscpconfig $switch alert=enable`;
+$cmd=`rspconfig $switch alert=enable`;
 print $cmd;
 
 #Logging destination:
-$cmd=`rscpconfig $switch logdest=$ip`;
+$cmd=`rspconfig $switch logdest=$ip`;
 print $cmd;
 
 #config ntp

--- a/xCAT-server/share/xcat/tools/configMellanox
+++ b/xCAT-server/share/xcat/tools/configMellanox
@@ -78,7 +78,7 @@ if ($::SWITCH)
         exit(1);
     }
 } else {
-    xCAT::MsgUtils->message("E","Invalid flag, please provide switches with --range");
+    xCAT::MsgUtils->message("E","Invalid flag, please provide switches with --switches");
     &usage;
     exit(1);
 }
@@ -248,10 +248,10 @@ sub usage
 {
     print "Usage:
     configMellonax [-?│-h│--help] 
-    configMellonax [--range switchnames] [--all]
-    configMellonax [--range switchnames] [--ip]
-    configMellonax [--range switchnames] [--name]
-    configMellonax [--range switchnames] [--config]  
+    configMellonax [--switches switchnames] [--all]
+    configMellonax [--switches switchnames] [--ip]
+    configMellonax [--switches switchnames] [--name]
+    configMellonax [--switches switchnames] [--config]  
     \n";
 }
 

--- a/xCAT-server/share/xcat/tools/configMellanox
+++ b/xCAT-server/share/xcat/tools/configMellanox
@@ -1,0 +1,115 @@
+#!/usr/bin/env perl
+
+#---------------------------------------------------------
+# Configure Ethnet Mellonax switches
+#---------------------------------------------------------
+
+use strict;
+use Getopt::Long;
+use Expect;
+
+my $args = join ' ', @ARGV;
+$::command = "$0 $args";
+
+Getopt::Long::Configure("bundling");
+$Getopt::Long::ignorecase = 0;
+
+
+#---------------------------------------------------------
+#Main
+
+# parse the options
+if (
+    !GetOptions(
+                'h|help'       => \$::HELP,
+                'r|range=s'    => \$::SWITCH,  
+                'u|user=s'     => \$::USER,
+                'i|ip=s'     => \$::IP,
+    )
+  )
+{
+    &usage;
+    exit(1);
+}
+
+# display the usage if -h or --help is specified
+if ($::HELP)
+{
+    &usage;
+    exit(0);
+}
+
+my $switch;
+if ($::SWITCH)
+{
+    $switch = $::SWITCH;
+} else {
+    &usage;
+    exit(1);
+}
+
+my $user;
+
+if ($::USER)
+{
+    $user = $::USER;
+} else {
+    &usage;
+    exit(1);
+}
+
+my $ip;
+if ($::IP)
+{
+    $ip = $::IP;
+} else {
+    &usage;
+    exit(1);
+}
+
+
+my $cmd;
+
+#default root/password and protcol for Mellonax switch
+$cmd = `chtab switch=$switch switches.sshusername=$user`; 
+print $cmd;
+
+#call rspconfig command to setup switch
+#enable ssh
+$cmd=`rscpconfig $switch sshcfg=enable`;
+print $cmd;
+
+#enable snmp function on the switch
+$cmd=`rscpconfig $switch snmpcfg=enable`;
+print $cmd;
+
+#enable the snmp trap
+$cmd=`rscpconfig $switch alert=enable`;
+print $cmd;
+
+#Logging destination:
+$cmd=`rscpconfig $switch logdest=$ip`;
+print $cmd;
+
+#config ntp
+$cmd = `xdsh $switch -l $user --devicetype IBSwitch::Mellanox "enable;configure terminal;ntp enable;ntpdate $ip; ntp server $ip;configuration write;show ntp" `;
+print $cmd;
+
+#---------------------------------------------------------
+
+=head3    usage
+
+        Displays message for -h option
+
+=cut
+
+#---------------------------------------------------------
+sub usage
+{
+    print "Usage:
+    configMellonax [-?│-h│--help] 
+    configMellonax [--range switchnames] [-u|--user sshusername] [-i|--ip xcatMN_ip_address] 
+    \n";
+}
+
+

--- a/xCAT-server/share/xcat/tools/configMellanox
+++ b/xCAT-server/share/xcat/tools/configMellanox
@@ -22,10 +22,6 @@ use xCAT::Utils;
 use xCAT::Table;
 use xCAT::MsgUtils;
 
-
-my $args = join ' ', @ARGV;
-$::command = "$0 $args";
-
 Getopt::Long::Configure("bundling");
 $Getopt::Long::ignorecase = 0;
 
@@ -41,7 +37,7 @@ my @filternodes;
 if (
     !GetOptions(
                 'h|help'     => \$::HELP,
-                'range=s'    => \$::SWITCH,  
+                'switches=s' => \$::SWITCH,  
                 'config'     => \$::CONFIG,
                 'ip'         => \$::IP,
                 'name'       => \$::NAME,
@@ -67,8 +63,15 @@ if ($::SWITCH)
         my $nodenotdefined = join(',', nodesmissed);
         xCAT::MsgUtils->message("I","The following nodes are not defined in xCAT DB: $nodenotdefined");
     }
-    foreach (@filternodes)  {
-        push @nodes, $_;
+    # check switch type
+    my $switchestab =  xCAT::Table->new('switches');
+    my $switches_hash = $switchestab->getNodesAttribs(\@filternodes,['switchtype']);
+    foreach my $fsw (@filternodes)  {
+        if (($switches_hash->{$fsw}->[0]->{switchtype}) =~ /Mellanox/) {
+            push @nodes, $fsw;
+        } else {
+            xCAT::MsgUtils->message("E","The $fsw is not BNT switch, will not config");
+        }
     }
     unless (@nodes) {
         xCAT::MsgUtils->message("E","No Valid Switch to process");
@@ -83,34 +86,29 @@ if ($::SWITCH)
 my $switches = join(",",@nodes);
 my $user;
 my $cmd;
-my $switch;
 my $rc;
 my $master;
 
-if ($::ALL) {
-    config_ip();
-    config_hostname();
-    run_rspconfig();
-}
-if ($::IP) {
+if (($::IP) || ($::ALL)) {
     config_ip();
 }
 
-if ($::NAME) {
+if (($::NAME) || ($::ALL)) {
     config_hostname();
 }
 
 
-if ($::CONFIG)
-{
+if (($::CONFIG) || ($::ALL)) {
     run_rspconfig();
 }
 
 
 sub config_ip {
+    my @config_switches;
+    my @discover_switches;
     # get host table for otherinterfaces
     my $nodetab = xCAT::Table->new('hosts');
-    my $nodehash = $nodetab->getNodesAttribs(\@nodes,['otherinterfaces']);
+    my $nodehash = $nodetab->getNodesAttribs(\@nodes,['ip','otherinterfaces']);
     # get netmask from network table
     my $nettab = xCAT::Table->new("networks");
     my @nets;
@@ -120,40 +118,28 @@ sub config_ip {
     foreach my $switch (@nodes) {
         print "change $switch to static ip address\n";
         my $dip= $nodehash->{$switch}->[0]->{otherinterfaces};
+        my $static_ip= $nodehash->{$switch}->[0]->{ip};
 
         #get hostname
         my $dswitch = xCAT::NetworkUtils->gethostname($dip);
+        print "dip=$dip, static=$static_ip, dsw=$dswitch\n";
 
         #if not defined, need to create one for xdsh to use
         if (!$dswitch) {
             my $ip_str = $dip;
             $ip_str =~ s/\./\-/g;
             $dswitch = "switch-$ip_str";
-            #is there other way we can check if this node is defined in the xCATdb
-            $cmd = "lsdef $dswitch";
-            $rc= xCAT::Utils->runcmd($cmd, 0);
-            if ($::RUNCMD_RC != 0) {
-                $cmd = "mkdef -t node -o $dswitch groups=switch ip=$dip switchtype=Mellanox username=admin nodetype=switch";
-                $rc= xCAT::Utils->runcmd($cmd, 0);
-            }
         }
-        #check if it is in the /etc/hosts
-        my $output = `grep $dswitch /etc/hosts`;
-        if ( !$output ) {
-            $cmd = "makehosts $dswitch";
-            $rc= xCAT::Utils->runcmd($cmd, 0);
-        }
+        $cmd = "chdef -t node -o $dswitch groups=switch ip=$dip switchtype=Mellanox username=admin nodetype=switch";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+        $cmd = "makehosts $dswitch";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+
         # verify if xdsh works
         $cmd = "xdsh $dswitch -l admin --devicetype IBSwitch::Mellanox 'enable;configure terminal;exit' ";
         $rc= xCAT::Utils->runcmd($cmd, 0);
         if ($::RUNCMD_RC != 0) {
             xCAT::MsgUtils->message("E","Couldn't communicate with $dswitch, $dip");
-            next;
-        }
-        #change to static ip address
-        my $static_ip = xCAT::NetworkUtils->getipaddr($switch);
-        if (!$static_ip){
-            xCAT::MsgUtils->message("E","static ip is not defined for $switch");
             next;
         }
         #get netmask
@@ -166,20 +152,29 @@ sub config_ip {
 
         $cmd="xdsh $dswitch -t 10 -l admin --devicetype IBSwitch::Mellanox 'enable;configure terminal;no interface mgmt0 dhcp;interface mgmt0 ip address $static_ip $mask;configuration write;exit;exit' ";
         $rc= xCAT::Utils->runcmd($cmd, 0);
+        push (@discover_switches, $dswitch);
+        push (@config_switches, $switch);
+    }
 
+    if (@config_switches) {
         #update switch status
-        $cmd = "chdef $switch status=ip_configed otherinterface=";
+        my $csw = join(",",@config_switches);
+        $cmd = "chdef $csw status=ip_configed otherinterfaces=";
         $rc= xCAT::Utils->runcmd($cmd, 0);
-  
+    }
+ 
+     if (@discover_switches) {
+        my $dsw = join(",",@discover_switches);
         #remove discover switch from xCATdb and /etc/hosts
-        $cmd = "makehosts -d $dswitch";
+        $cmd = "makehosts -d $dsw";
         $rc= xCAT::Utils->runcmd($cmd, 0);
-        $cmd = "rmdef $dswitch";
+        $cmd = "rmdef $dsw";
         $rc= xCAT::Utils->runcmd($cmd, 0);
     }
 }
 
 sub config_hostname {
+    my @config_switches;
     my $switchtab = xCAT::Table->new('switches');
     my $switchhash = $switchtab->getNodesAttribs(\@nodes,['sshusername']);
     foreach my $switch (@nodes) {
@@ -196,13 +191,18 @@ sub config_hostname {
             xCAT::MsgUtils->message("E","Failed to setup hostname for $switch");
             next;
         }
+         push (@config_switches, $switch);
+    }
+    if (@config_switches) {
         #update switch status
-        $cmd = "chdef $switch status=hostname_configed" ;
+        my $csw = join(",",@config_switches);
+        $cmd = "chdef $csw status=hostname_configed" ;
         $rc= xCAT::Utils->runcmd($cmd, 0);
     }
 }
 
 sub run_rspconfig {
+    my @config_switches;
     my $switchtab = xCAT::Table->new('switches');
     my $switchhash = $switchtab->getNodesAttribs(\@nodes,['sshusername']);
     $master = `hostname -i`;
@@ -224,9 +224,12 @@ sub run_rspconfig {
 
         #config ntp
         $cmd = `xdsh $switch -l $user --devicetype IBSwitch::Mellanox "enable;configure terminal;ntp enable;ntpdate $master; ntp server $master;configuration write;show ntp" `;
-
+        push (@config_switches, $switch);
+    }
+    if (@config_switches) {
         #update switch status
-        $cmd = "chdef $switch status=switch_configed" ;
+        my $csw = join(",",@config_switches);
+        $cmd = "chdef $csw status=switch_configed" ;
         $rc= xCAT::Utils->runcmd($cmd, 0);
     }
 

--- a/xCAT-server/share/xcat/tools/configMellanox
+++ b/xCAT-server/share/xcat/tools/configMellanox
@@ -4,15 +4,34 @@
 # Configure Ethnet Mellonax switches
 #---------------------------------------------------------
 
+BEGIN
+{
+  $::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : '/opt/xcat';
+  $::XCATDIR  = $ENV{'XCATDIR'}  ? $ENV{'XCATDIR'}  : '/etc/xcat';
+}
+use lib "$::XCATROOT/lib/perl";
+
+
 use strict;
 use Getopt::Long;
 use Expect;
+use xCAT::Usage;
+use xCAT::NodeRange;
+use xCAT::NetworkUtils;
+use xCAT::Utils;
+use xCAT::Table;
+use xCAT::MsgUtils;
+
 
 my $args = join ' ', @ARGV;
 $::command = "$0 $args";
 
 Getopt::Long::Configure("bundling");
 $Getopt::Long::ignorecase = 0;
+
+#global variables
+my @nodes;
+my @filternodes;
 
 
 #---------------------------------------------------------
@@ -21,10 +40,12 @@ $Getopt::Long::ignorecase = 0;
 # parse the options
 if (
     !GetOptions(
-                'h|help'       => \$::HELP,
-                'r|range=s'    => \$::SWITCH,  
-                'u|user=s'     => \$::USER,
-                'i|ip=s'     => \$::IP,
+                'h|help'     => \$::HELP,
+                'range=s'    => \$::SWITCH,  
+                'config'     => \$::CONFIG,
+                'ip'         => \$::IP,
+                'name'       => \$::NAME,
+                'all'        => \$::ALL,
     )
   )
 {
@@ -39,61 +60,177 @@ if ($::HELP)
     exit(0);
 }
 
-my $switch;
 if ($::SWITCH)
 {
-    $switch = $::SWITCH;
+    my @filternodes = xCAT::NodeRange::noderange( $::SWITCH );
+    if (nodesmissed) {
+        my $nodenotdefined = join(',', nodesmissed);
+        xCAT::MsgUtils->message("I","The following nodes are not defined in xCAT DB: $nodenotdefined");
+    }
+    foreach (@filternodes)  {
+        push @nodes, $_;
+    }
+    unless (@nodes) {
+        xCAT::MsgUtils->message("E","No Valid Switch to process");
+        exit(1);
+    }
 } else {
+    xCAT::MsgUtils->message("E","Invalid flag, please provide switches with --range");
     &usage;
     exit(1);
 }
 
+my $switches = join(",",@nodes);
 my $user;
-
-if ($::USER)
-{
-    $user = $::USER;
-} else {
-    &usage;
-    exit(1);
-}
-
-my $ip;
-if ($::IP)
-{
-    $ip = $::IP;
-} else {
-    &usage;
-    exit(1);
-}
-
-
 my $cmd;
+my $switch;
+my $rc;
+my $master;
 
-#default root/password and protcol for Mellonax switch
-$cmd = `chtab switch=$switch switches.sshusername=$user`; 
-print $cmd;
+if ($::ALL) {
+    config_ip();
+    config_hostname();
+    run_rspconfig();
+}
+if ($::IP) {
+    config_ip();
+}
 
-#call rspconfig command to setup switch
-#enable ssh
-$cmd=`rspconfig $switch sshcfg=enable`;
-print $cmd;
+if ($::NAME) {
+    config_hostname();
+}
 
-#enable snmp function on the switch
-$cmd=`rspconfig $switch snmpcfg=enable`;
-print $cmd;
 
-#enable the snmp trap
-$cmd=`rspconfig $switch alert=enable`;
-print $cmd;
+if ($::CONFIG)
+{
+    run_rspconfig();
+}
 
-#Logging destination:
-$cmd=`rspconfig $switch logdest=$ip`;
-print $cmd;
 
-#config ntp
-$cmd = `xdsh $switch -l $user --devicetype IBSwitch::Mellanox "enable;configure terminal;ntp enable;ntpdate $ip; ntp server $ip;configuration write;show ntp" `;
-print $cmd;
+sub config_ip {
+    # get host table for otherinterfaces
+    my $nodetab = xCAT::Table->new('hosts');
+    my $nodehash = $nodetab->getNodesAttribs(\@nodes,['otherinterfaces']);
+    # get netmask from network table
+    my $nettab = xCAT::Table->new("networks");
+    my @nets;
+    if ($nettab) {
+        @nets = $nettab->getAllAttribs('net','mask');
+    }
+    foreach my $switch (@nodes) {
+        print "change $switch to static ip address\n";
+        my $dip= $nodehash->{$switch}->[0]->{otherinterfaces};
+
+        #get hostname
+        my $dswitch = xCAT::NetworkUtils->gethostname($dip);
+
+        #if not defined, need to create one for xdsh to use
+        if (!$dswitch) {
+            my $ip_str = $dip;
+            $ip_str =~ s/\./\-/g;
+            $dswitch = "switch-$ip_str";
+            #is there other way we can check if this node is defined in the xCATdb
+            $cmd = "lsdef $dswitch";
+            $rc= xCAT::Utils->runcmd($cmd, 0);
+            if ($::RUNCMD_RC != 0) {
+                $cmd = "mkdef -t node -o $dswitch groups=switch ip=$dip switchtype=Mellanox username=admin nodetype=switch";
+                $rc= xCAT::Utils->runcmd($cmd, 0);
+            }
+        }
+        #check if it is in the /etc/hosts
+        my $output = `grep $dswitch /etc/hosts`;
+        if ( !$output ) {
+            $cmd = "makehosts $dswitch";
+            $rc= xCAT::Utils->runcmd($cmd, 0);
+        }
+        # verify if xdsh works
+        $cmd = "xdsh $dswitch -l admin --devicetype IBSwitch::Mellanox 'enable;configure terminal;exit' ";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+        if ($::RUNCMD_RC != 0) {
+            xCAT::MsgUtils->message("E","Couldn't communicate with $dswitch, $dip");
+            next;
+        }
+        #change to static ip address
+        my $static_ip = xCAT::NetworkUtils->getipaddr($switch);
+        if (!$static_ip){
+            xCAT::MsgUtils->message("E","static ip is not defined for $switch");
+            next;
+        }
+        #get netmask
+        my $mask;
+        foreach my $net (@nets) {
+            if (xCAT::NetworkUtils::isInSameSubnet( $net->{'net'}, $static_ip, $net->{'mask'}, 0)) {
+                $mask=$net->{'mask'};
+            }
+        }
+
+        $cmd="xdsh $dswitch -t 10 -l admin --devicetype IBSwitch::Mellanox 'enable;configure terminal;no interface mgmt0 dhcp;interface mgmt0 ip address $static_ip $mask;configuration write;exit;exit' ";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+
+        #update switch status
+        $cmd = "chdef $switch status=ip_configed otherinterface=";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+  
+        #remove discover switch from xCATdb and /etc/hosts
+        $cmd = "makehosts -d $dswitch";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+        $cmd = "rmdef $dswitch";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+    }
+}
+
+sub config_hostname {
+    my $switchtab = xCAT::Table->new('switches');
+    my $switchhash = $switchtab->getNodesAttribs(\@nodes,['sshusername']);
+    foreach my $switch (@nodes) {
+        my $user= $switchhash->{$switch}->[0]->{sshusername};
+        if (!$user) {
+            print "switch ssh username is not defined, add default one\n";
+            $cmd = "chdef $switch username=admin";
+            $rc= xCAT::Utils->runcmd($cmd, 0);
+            $user="admin";
+        }
+        $cmd="xdsh $switch -l $user --devicetype IBSwitch::Mellanox 'enable;configure terminal;hostname $switch;configuration write' ";
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+        if ($::RUNCMD_RC != 0) {
+            xCAT::MsgUtils->message("E","Failed to setup hostname for $switch");
+            next;
+        }
+        #update switch status
+        $cmd = "chdef $switch status=hostname_configed" ;
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+    }
+}
+
+sub run_rspconfig {
+    my $switchtab = xCAT::Table->new('switches');
+    my $switchhash = $switchtab->getNodesAttribs(\@nodes,['sshusername']);
+    $master = `hostname -i`;
+    print "master=$master\n";
+    foreach my $switch (@nodes) {
+        my $user= $switchhash->{$switch}->[0]->{sshusername};
+        #call rspconfig command to setup switch
+        #enable ssh
+        $cmd=`rspconfig $switch sshcfg=enable`;
+
+        #enable snmp function on the switch
+        $cmd=`rspconfig $switch snmpcfg=enable`;
+
+        #enable the snmp trap
+        $cmd=`rspconfig $switch alert=enable`;
+
+        #Logging destination:
+        $cmd=`rspconfig $switch logdest=$master`;
+
+        #config ntp
+        $cmd = `xdsh $switch -l $user --devicetype IBSwitch::Mellanox "enable;configure terminal;ntp enable;ntpdate $master; ntp server $master;configuration write;show ntp" `;
+
+        #update switch status
+        $cmd = "chdef $switch status=switch_configed" ;
+        $rc= xCAT::Utils->runcmd($cmd, 0);
+    }
+
+}
 
 #---------------------------------------------------------
 
@@ -108,7 +245,10 @@ sub usage
 {
     print "Usage:
     configMellonax [-?│-h│--help] 
-    configMellonax [--range switchnames] [-u|--user sshusername] [-i|--ip xcatMN_ip_address] 
+    configMellonax [--range switchnames] [--all]
+    configMellonax [--range switchnames] [--ip]
+    configMellonax [--range switchnames] [--name]
+    configMellonax [--range switchnames] [--config]  
     \n";
 }
 

--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -1502,18 +1502,11 @@ case "${GO_XCAT_ACTION}" in
 
 	while read -r ; do echo "${REPLY}" ; done <<-EOF
 
+	xCAT has been installed!  
+	========================
 
-	Congratulations
-	===============
-
-	The fact that you got this far is a strong indication that xCAT bas been
-	installed correctly.
-
-	Please notice if this is the first time you install xCAT. You need to do one
-	of the following.
-
-	1. Log out and then log in again, or
-	2. run the following command to set the environment variables.
+	If this is the very first time xCAT has been installed, run the following
+	commands to set environment variables into your PATH:
 
 	    for sh,
 	        \`source /etc/profile.d/xcat.sh\`

--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -49,26 +49,8 @@ function usage()
 	  ${script} --yes install
 	  ${script} -x 2.12 -y install
 	  ${script} --xcat-version=devel install
-	  ${script} --xcat-core=/path/to/xcat-core.repo install
-	  ${script} --xcat-core=/path/to/xcat-core install
-	  ${script} --xcat-core=/path/to/xcat-core.tar install
-	  ${script} --xcat-core=/path/to/xcat-core.tar.Z install
-	  ${script} --xcat-core=/path/to/xcat-core.tar.gz install
-	  ${script} --xcat-core=/path/to/xcat-core.tar.bz2 install
-	  ${script} --xcat-core=/path/to/xcat-core.tar.xz install
-	  ${script} --xcat-core=http://xcat.org/path/to/xcat-core.repo install
-	  ${script} --xcat-core=http://xcat.org/path/to/xcat-core install
-	  ${script} --xcat-core=http://xcat.org/path/to/xcat-core.tar.bz2 install
-	  ${script} --xcat-core=/path/to/xcat-core.repo \\
-	          --xcat-dep=/path/to/xcat-dep.repo install
-	  ${script} --xcat-core=/path/to/xcat-core \\
-	          --xcat-dep=/path/to/xcat-dep install
 	  ${script} --xcat-core=/path/to/xcat-core.tar.bz2 \\
 	          --xcat-dep=/path/to/xcat-dep.tar.bz2 install
-	  ${script} --xcat-core=http://xcat.org/path/to/xcat-core.repo \\
-	          --xcat-dep=http://xcat.org/path/to/xcat-dep.repo install
-	  ${script} --xcat-core=http://xcat.org/path/to/xcat-core \\
-	          --xcat-dep=http://xcat.org/path/to/xcat-dep install
 	  ${script} --xcat-core=http://xcat.org/path/to/xcat-core.tar.bz2 \\
 	          --xcat-dep=http://xcat.org/path/to/xcat-dep.tar.bz2 install
 

--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -1500,19 +1500,29 @@ case "${GO_XCAT_ACTION}" in
 		exit "${RET}"
 	fi
 
-	while read -r ; do echo "${REPLY}" ; done <<-EOF
+	if [ ${GO_XCAT_ACTION} == 'install' ]; then
+		# only print out this message on install
+		while read -r ; do echo "${REPLY}" ; done <<-EOF
 
-	xCAT has been installed!  
-	========================
+		xCAT has been installed!  
+		========================
 
-	If this is the very first time xCAT has been installed, run the following
-	commands to set environment variables into your PATH:
+		If this is the very first time xCAT has been installed, run the following
+		commands to set environment variables into your PATH:
 
-	    for sh,
-	        \`source /etc/profile.d/xcat.sh\`
-	    or csh,
-	        \`source /etc/profile.d/xcat.csh\`
-	EOF
+		    for sh,
+		        \`source /etc/profile.d/xcat.sh\`
+		    or csh,
+		        \`source /etc/profile.d/xcat.csh\`
+		EOF
+	else
+		while read -r ; do echo "${REPLY}" ; done <<-EOF
+
+		xCAT has been updated!
+		======================
+
+		EOF
+	fi
 	;;
 *)
 	list_xcat_packages

--- a/xCAT-test/autotest/bundle/sles12.1_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/sles12.1_x86_64.bundle
@@ -220,4 +220,3 @@ assign_certain_command_permission_systemd
 sles_migration1
 sles_migration2
 reg_linux_diskless_installation_flat
-reg_linux_statelite_installation_flat

--- a/xCAT-test/autotest/testcase/install_xCAT/case0
+++ b/xCAT-test/autotest/testcase/install_xCAT/case0
@@ -1,5 +1,5 @@
-start:install_xCAT_new
-description:install xCAT with go-xcat tool
+start:install_xCAT_on_rhels_sles
+description:install xCAT with go-xcat tool in a fresh environment for rhels and sles
 os:Linux
 cmd:if grep "Red Hat" /etc/*release >/dev/null; then yum install -y yum-utils bzip2; fi
 check:rc==0
@@ -19,3 +19,27 @@ check:rc==0
 check:output=~running
 cmd:rm -rf /xcat-core.tar.bz2 /xcat-dep.tar.bz2
 end
+
+start:install_xCAT_on_ubuntu
+description:install xCAT with go-xcat tool in a fresh environment for ubuntu
+os:Linux
+cmd:arc_all=`uname -a`; code=`lsb_release -sc`;if [[ $arc_all =~ "ppc64le" ]]; then arch="ppc64el";else arch="x86_64";fi; cp "/opt/xcat/share/xcat/tools/autotest/testcase/go-xcat/$code-$arch.sources.list" "/etc/apt/sources.list" 
+cmd:apt-get clean;apt-get update
+check:rc==0
+cmd:cp /core-*-snap.tar.bz2 /xcat-core.tar.bz2
+check:rc==0
+cmd:cp /xcat-dep*.tar.bz2 /xcat-dep.tar.bz2
+check:rc==0
+cmd:./go-xcat --xcat-core=/xcat-core.tar.bz2 --xcat-dep=/xcat-dep.tar.bz2  -y install;
+check:rc==0
+cmd:source "/etc/profile.d/xcat.sh"
+check:rc==0
+cmd:lsxcatd -v
+check:rc==0
+check:output=~Version
+cmd:service xcatd status
+check:rc==0
+check:output=~running
+cmd:rm -rf /xcat-core.tar.bz2 /xcat-dep.tar.bz2
+end
+

--- a/xCAT-test/autotest/testcase/install_xCAT/case0
+++ b/xCAT-test/autotest/testcase/install_xCAT/case0
@@ -1,0 +1,21 @@
+start:install_xCAT_new
+description:install xCAT with go-xcat tool
+os:Linux
+cmd:if grep "Red Hat" /etc/*release >/dev/null; then yum install -y yum-utils bzip2; fi
+check:rc==0
+cmd:cp /core-*-snap.tar.bz2 /xcat-core.tar.bz2
+check:rc==0
+cmd:cp /xcat-dep*.tar.bz2 /xcat-dep.tar.bz2
+check:rc==0
+cmd:cd /; ./go-xcat --xcat-core=/xcat-core.tar.bz2 --xcat-dep=/xcat-dep.tar.bz2  -y install;
+check:rc==0
+cmd:source "/etc/profile.d/xcat.sh"
+check:rc==0
+cmd:lsxcatd -v
+check:rc==0
+check:output=~Version
+cmd:service xcatd status
+check:rc==0
+check:output=~running
+cmd:rm -rf /xcat-core.tar.bz2 /xcat-dep.tar.bz2
+end

--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -14,7 +14,7 @@ BEGIN
 use lib "$::XCATROOT/lib/perl";
 my $rootdir     = "$::XCATROOT/share/xcat/tools/autotest";
 my $needhelp    = 0;
-my $configfile  = "$rootdir/default.conf";
+my $config_info  = "$rootdir/default.conf";
 my $bundle_list = undef;
 my $case_list   = undef;
 my $cmd_list    = undef;
@@ -24,7 +24,7 @@ my $ret         = 0;
 my $string1     = undef;
 if (
     !GetOptions("h|?" => \$needhelp,
-        "f=s"     => \$configfile,
+        "f=s"     => \$config_info,
         "b=s"     => \$bundle_list,
         "t=s"     => \$case_list,
         "c=s"     => \$cmd_list,
@@ -36,10 +36,46 @@ if (
     exit 1;
 }
 
+unless(defined($bundle_list) || defined($case_list) || defined($cmd_list) || defined($needshow)){
+    &usage;
+    exit 1;
+}
 if ($needhelp)
 {
     &usage;
     exit 0;
+}
+
+#check config file and system label
+my $configfile  = undef;
+my $inital_info = undef;
+if ($config_info){   
+    if ($config_info =~ /:/){
+        my @config_info = split /:/, $config_info;
+        $configfile = $config_info[0];
+        $inital_info = $config_info[1];
+        if ($inital_info ne "system"){
+            print "Failed: $inital_info in $config_info is not supported!\n";
+            exit 1;
+        }
+    }else{
+        $configfile = $config_info;
+    }
+}
+if (!open(FILE, "$configfile")) {
+    print "can't open config file: $configfile\n";
+    exit 1;
+}
+
+#check bundle files
+if ($bundle_list){
+     my @bundles = split /,/, $bundle_list;
+     foreach my $bundle (@bundles){
+        if (!open(FILE, "<$rootdir/bundle/$bundle")) {
+            print "can't open bundle file: $rootdir/bundle/$bundle\n";
+            exit 1;
+        }
+    }
 }
 
 #load case to $cases
@@ -51,7 +87,6 @@ if ($needhelp)
 #    hcp:hmc/mm/bmc/fsp         string
 #    cmd:                       array
 #    check:                     array
-
 my @cases = ();
 if ($needshow) {
     &loadcase;
@@ -150,10 +185,6 @@ sub getConfig
     log_this("******************************");
     log_this("Reading Configure");
     log_this("******************************");
-    if (!(-e $configfile)) {
-        log_this("Warning: The xCAT test Configure file doesn't exist!");
-        return 0;
-    }
 
     my $type     = undef;    #Script_Prev,Script_Post,Table,Object,System,Custom
     my $sub_type = undef;    # The string after $type_
@@ -175,7 +206,6 @@ sub getConfig
 
     my $mgt_name = undef;
 
-    open(FILE, "$configfile") or die "can't to open $configfile";
     while (my $line = <FILE>) {
         $line = &trim($line);
         next if (length($line) == 0);
@@ -444,7 +474,7 @@ sub Get_Files_Recursive
             }
             else
             { my $dirpath = $dir . '/' . $direntry . "\n";
-                print $dirpath;
+    #            print $dirpath;
 
                 #print $dir."\n";
                 push(@filespath, glob("$dirpath"));
@@ -501,10 +531,6 @@ sub loadcase
     if ($bundle_list) {
         my @bundles = split /,/, $bundle_list;
         foreach my $bundle (@bundles) {
-            if (!open(FILE, "<$rootdir/bundle/$bundle")) {
-                log_this("can't open $rootdir/bundle/$bundle");
-                return 1;
-            }
             while ($line = <FILE>) {
                 $line = trim($line);
                 next if (length($line) == 0);

--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -14,7 +14,8 @@ BEGIN
 use lib "$::XCATROOT/lib/perl";
 my $rootdir     = "$::XCATROOT/share/xcat/tools/autotest";
 my $needhelp    = 0;
-my $config_info  = "$rootdir/default.conf";
+my $config_info = "$rootdir/default.conf";
+my $bundle_dir  ="$rootdir/bundle";
 my $bundle_list = undef;
 my $case_list   = undef;
 my $cmd_list    = undef;
@@ -36,10 +37,12 @@ if (
     exit 1;
 }
 
-unless(defined($bundle_list) || defined($case_list) || defined($cmd_list) || defined($needshow)){
+#bundle, cases lists and command lists, one of them must be defined
+if (!defined($bundle_list) && !defined($case_list) && !defined($cmd_list)){
     &usage;
     exit 1;
 }
+
 if ($needhelp)
 {
     &usage;
@@ -47,6 +50,7 @@ if ($needhelp)
 }
 
 #check config file and system label
+#this system label means only the System variable will be loaded
 my $configfile  = undef;
 my $inital_info = undef;
 if ($config_info){   
@@ -55,7 +59,7 @@ if ($config_info){
         $configfile = $config_info[0];
         $inital_info = $config_info[1];
         if ($inital_info ne "system"){
-            print "Failed: $inital_info in $config_info is not supported!\n";
+            print " $inital_info in $config_info is not supported!\n";
             exit 1;
         }
     }else{
@@ -63,7 +67,7 @@ if ($config_info){
     }
 }
 if (!open(FILE, "$configfile")) {
-    print "can't open config file: $configfile\n";
+    print "Can't open config file: $configfile\n";
     exit 1;
 }
 
@@ -71,8 +75,9 @@ if (!open(FILE, "$configfile")) {
 if ($bundle_list){
      my @bundles = split /,/, $bundle_list;
      foreach my $bundle (@bundles){
-        if (!open(FILE, "<$rootdir/bundle/$bundle")) {
-            print "can't open bundle file: $rootdir/bundle/$bundle\n";
+        if (!open(FILE, "< $bundle_dir/$bundle")) {
+            print "Can't open bundle file: $bundle_dir/$bundle\n";
+            &show_bundle_files;
             exit 1;
         }
     }
@@ -119,9 +124,11 @@ if ($ret != 0) {
     goto EXIT;
 }
 
-$ret = &init;
-if ($ret != 0) {
-    goto EXIT;
+if ($inital_info ne "system"){
+    $ret = &init;
+    if ($ret != 0) {
+        goto EXIT;
+    }
 }
 my @filespath = ();
 
@@ -203,10 +210,28 @@ sub getConfig
     my $value = undef;
     my $c     = 0;
     my $cmd   = undef;
-
     my $mgt_name = undef;
+    
+    open(FILE, "$configfile") or die "Can't open $configfile";    
+    #Only load system information 
+    if (defined($inital_info) && ($inital_info eq "system")) {
+        while (my $line = <FILE>) {
+	    $line = &trim($line);
+            next if (length($line) == 0);
 
-    while (my $line = <FILE>) {
+            #Only read System variable
+            if ($line =~ /\[System\]/) {
+               $type = "Varible";
+            } 
+            if (defined($type) && ($type eq "Varible")) {
+                if ($line =~ /(\w+)\s*=\s*([\w\.\-\+\/:]+)/) {
+                    $config{var}{$1} = $2;
+                }
+            }  
+        }            
+    }else{
+    #Load all config files information    
+        while (my $line = <FILE>) {
         $line = &trim($line);
         next if (length($line) == 0);
 
@@ -262,6 +287,7 @@ sub getConfig
             }
         }
     }
+}
 
     if (exists $config{object}) {
         foreach my $type (keys %{ $config{object} }) {
@@ -385,7 +411,7 @@ sub init
     if (!exists $config{var}{ARCH}) {
         if (!exists $config{var}{CN}) {
             $config{var}{ARCH} = "Unknown";
-            log_this("No compute node defined,can't get ARCH of compute node");
+            log_this("No compute node defined, can't get ARCH of compute node");
         } else {
             $config{var}{ARCH} = getnodeattr($config{var}{CN}, "arch");
             if ($config{var}{ARCH} =~ /ppc/) {
@@ -399,7 +425,7 @@ sub init
     if (!exists $config{var}{HCP}) {
         if (!exists $config{var}{CN}) {
             $config{var}{HCP} = "Unknown";
-            log_this("No compute node defined,can't get HCP TYPE of compute node");
+            log_this("No compute node defined, can't get HCP TYPE of compute node");
         } else {
             $config{var}{HCP} = getnodeattr($config{var}{CN}, "mgt");
             log_this("Detecting: HCP = $config{var}{HCP}");
@@ -531,6 +557,7 @@ sub loadcase
     if ($bundle_list) {
         my @bundles = split /,/, $bundle_list;
         foreach my $bundle (@bundles) {
+            open(FILE, "<$bundle_dir/$bundle") or die "Can't open bundle file: $bundle";
             while ($line = <FILE>) {
                 $line = trim($line);
                 next if (length($line) == 0);
@@ -544,7 +571,7 @@ sub loadcase
     }
     foreach $file (@files) {
         if (!open(FILE, "<$file")) {
-            log_this("can't open $file");
+            log_this("Can't open $file");
             return 1;
         }
         while ($line = <FILE>) {
@@ -728,7 +755,7 @@ sub getvar
         if (exists($config{var}{$varname})) {
             $str =~ s/\$\$$varname/$config{var}{$varname}/g;
         } else {
-            log_this("Error:can't get varible $varname");
+            log_this("Error: can't get varible $varname");
             return '';
         }
     }
@@ -945,10 +972,19 @@ sub usage
 {
     print "Usage:xcattest - Run xcat test cases.\n";
     print "  xcattest [-?|-h]\n";
-    print "  xcattest [-f configure file] [-b case bundle list] [--restore]\n";
-    print "  xcattest [-f configure file] [-t case list] [--restore]\n";
-    print "  xcattest [-f configure file] [-c cmd list] [-l] [--restore]\n";
+    print "  xcattest [-f configure file] [-b case bundle list]\n";
+    print "  xcattest [-f configure file] [-t case list]\n";
+    print "  xcattest [-f configure file] [-c cmd list]\n";
+    print "  xcattest [-f configure file] [-b case bundle list] [-l]\n";
+    print "  xcattest [-f configure file] [-t case list] [-l]\n";
+    print "  xcattest [-f configure file] [-c cmd list] [-l]\n";    
     print "\n";
+}
+
+sub show_bundle_files
+{
+    print "Valid bundle files:\n\n";
+    system("ls $bundle_dir");    
     return;
 }
 
@@ -979,10 +1015,7 @@ sub reordercases {
     if ($bundle_list) {
         my @bundles = split /,/, $bundle_list;
         foreach my $bundle (@bundles) {
-            if (!open(FILE, "<$rootdir/bundle/$bundle")) {
-                log_this("can't open $rootdir/bundle/$bundle");
-                return 1;
-            }
+            open(FILE, "<$bundle_dir/$bundle") or die "Can't open bundle file: $bundle";
             while ($line = <FILE>) {
                 $line = trim($line);
                 next if (length($line) == 0);

--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -12,33 +12,33 @@ BEGIN
     $::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : -d '/opt/xcat' ? '/opt/xcat' : '/usr';
 }
 use lib "$::XCATROOT/lib/perl";
-my $rootdir     = "$::XCATROOT/share/xcat/tools/autotest";
-my $needhelp    = 0;
-my $config_info = "$rootdir/default.conf";
-my $bundle_dir  ="$rootdir/bundle";
-my $bundle_list = undef;
-my $case_list   = undef;
-my $cmd_list    = undef;
-my $needshow    = 0;
-my $restore     = 0;
-my $ret         = 0;
-my $string1     = undef;
+my $rootdir         = "$::XCATROOT/share/xcat/tools/autotest";
+my $needhelp        = 0;
+my $configinfo      = undef;
+my $configfile      = "$rootdir/default.conf";;
+my $initallabel     = 0;
+my $bundledir       = "$rootdir/bundle";
+my $bundlelist      = undef;
+my $caselist        = undef;
+my $cmdlist         = undef;
+my $needshow        = 0;
+my $showbundlefiles = 0;
+my $restore         = 0;
+my $ret             = 0;
+my $string1         = undef;
+my $loadsysteminfo  = "System";
+
 if (
     !GetOptions("h|?" => \$needhelp,
-        "f=s"     => \$config_info,
-        "b=s"     => \$bundle_list,
-        "t=s"     => \$case_list,
-        "c=s"     => \$cmd_list,
+        "f=s"     => \$configinfo,
+        "b=s"     => \$bundlelist,
+        "t=s"     => \$caselist,
+        "c=s"     => \$cmdlist,
         "l"       => \$needshow,
+        "bl"      => \$showbundlefiles,
         "restore" => \$restore)
   )
 {
-    &usage;
-    exit 1;
-}
-
-#bundle, cases lists and command lists, one of them must be defined
-if (!defined($bundle_list) && !defined($case_list) && !defined($cmd_list)){
     &usage;
     exit 1;
 }
@@ -49,40 +49,18 @@ if ($needhelp)
     exit 0;
 }
 
-#check config file and system label
-#this system label means only the System variable will be loaded
-my $configfile  = undef;
-my $inital_info = undef;
-if ($config_info){   
-    if ($config_info =~ /:/){
-        my @config_info = split /:/, $config_info;
-        $configfile = $config_info[0];
-        $inital_info = $config_info[1];
-        if ($inital_info ne "system"){
-            print " $inital_info in $config_info is not supported!\n";
-            exit 1;
-        }
-    }else{
-        $configfile = $config_info;
-    }
-}
-if (!open(FILE, "$configfile")) {
-    print "Can't open config file: $configfile\n";
-    exit 1;
+if (&checkoptions)
+{
+    &usage;
+    exit 1;      
 }
 
-#check bundle files
-if ($bundle_list){
-     my @bundles = split /,/, $bundle_list;
-     foreach my $bundle (@bundles){
-        if (!open(FILE, "< $bundle_dir/$bundle")) {
-            print "Can't open bundle file: $bundle_dir/$bundle\n";
-            &show_bundle_files;
-            exit 1;
-        }
-    }
-}
-
+if ($showbundlefiles)
+{
+    &listbundlefiles;
+    exit 0;
+}   
+ 
 #load case to $cases
 #    key                        type
 #$cases[x](x>0):                hash
@@ -124,7 +102,7 @@ if ($ret != 0) {
     goto EXIT;
 }
 
-if ($inital_info ne "system"){
+if ($initallabel){
     $ret = &init;
     if ($ret != 0) {
         goto EXIT;
@@ -139,7 +117,7 @@ if ($ret != 0) {
 }
 
 #run case
-&reordercases if (defined($bundle_list) || defined($case_list));
+&reordercases if (defined($bundlelist) || defined($caselist));
 &runcase;
 
 EXIT:
@@ -212,9 +190,14 @@ sub getConfig
     my $cmd   = undef;
     my $mgt_name = undef;
     
-    open(FILE, "$configfile") or die "Can't open $configfile";    
-    #Only load system information 
-    if (defined($inital_info) && ($inital_info eq "system")) {
+    if (!open(FILE, "$configfile")) {
+       log_this("Error: can't open xCAT config file: $configfile");
+       close(FILE);
+       return 1;
+    }  
+    
+    #Only load System information 
+    if (defined($initallabel) && ($initallabel eq $loadsysteminfo)) {
         while (my $line = <FILE>) {
 	    $line = &trim($line);
             next if (length($line) == 0);
@@ -411,7 +394,7 @@ sub init
     if (!exists $config{var}{ARCH}) {
         if (!exists $config{var}{CN}) {
             $config{var}{ARCH} = "Unknown";
-            log_this("No compute node defined, can't get ARCH of compute node");
+            log_this("Error: No compute node defined, can't get ARCH of compute node");
         } else {
             $config{var}{ARCH} = getnodeattr($config{var}{CN}, "arch");
             if ($config{var}{ARCH} =~ /ppc/) {
@@ -425,7 +408,7 @@ sub init
     if (!exists $config{var}{HCP}) {
         if (!exists $config{var}{CN}) {
             $config{var}{HCP} = "Unknown";
-            log_this("No compute node defined, can't get HCP TYPE of compute node");
+            log_this("Error: No compute node defined, can't get HCP TYPE of compute node");
         } else {
             $config{var}{HCP} = getnodeattr($config{var}{CN}, "mgt");
             log_this("Detecting: HCP = $config{var}{HCP}");
@@ -472,7 +455,7 @@ sub uninit
         log_this($cmd);
         runcmd($cmd);
         if ($::RUNCMD_RC != 0) {
-            log_this("Fail to run $cmd");
+            log_this("Error: Fail to run $cmd");
             return 1;
         }
     }
@@ -520,8 +503,8 @@ sub loadcase
     my $casedir = "/opt/xcat/share/xcat/tools/autotest/testcase";
     my @files   = ();
 
-    #if($cmd_list){
-    #    my @cmds = split /,/,$cmd_list;
+    #if($caselist){
+    #    my @cmds = split /,/,$caselist;
     #    for my $cmd (@cmds){
     #         push (@files, glob("$casedir/$cmd/*"));
     #    }
@@ -531,8 +514,8 @@ sub loadcase
     Get_Files_Recursive("$casedir");
     for (my $countfile = 0 ; $countfile < @filespath ; $countfile++)
     {
-        if ($cmd_list) {
-            my @cmds = split /,/, $cmd_list;
+        if ($caselist) {
+            my @cmds = split /,/, $caselist;
             for (my $countcmd = 0 ; $countcmd < @cmds ; $countcmd++) {
                 if ($filespath[$countfile] =~ m/\/$cmds[$countcmd]\/case/) {
                     push(@files, glob("$filespath[$countfile]"));
@@ -554,10 +537,14 @@ sub loadcase
     my @caserange    = ();
     my @rightcase    = ();
     my @notrightcase = ();
-    if ($bundle_list) {
-        my @bundles = split /,/, $bundle_list;
+    if ($bundlelist) {
+        my @bundles = split /,/, $bundlelist;
         foreach my $bundle (@bundles) {
-            open(FILE, "<$bundle_dir/$bundle") or die "Can't open bundle file: $bundle";
+            if (!open(FILE, "<$bundledir/$bundle")){
+                log_this("Error: Can't open bundle file: $bundle");
+                close(FILE);
+                return 1;
+            }
             while ($line = <FILE>) {
                 $line = trim($line);
                 next if (length($line) == 0);
@@ -566,12 +553,12 @@ sub loadcase
             close(FILE);
         }
     }
-    if ($case_list) {
-        @caserange = split /,/, $case_list;
+    if ($caselist) {
+        @caserange = split /,/, $caselist;
     }
     foreach $file (@files) {
         if (!open(FILE, "<$file")) {
-            log_this("Can't open $file");
+            log_this("Error: Can't open $file");
             return 1;
         }
         while ($line = <FILE>) {
@@ -709,7 +696,7 @@ sub getnodeattr
 
         #    return "Unknown";
         foreach $t (1 .. 40) {
-            log_this("could not get node attr $attr ");
+            log_this("Error: could not get node attr $attr ");
             @output = runcmd("lsdef -t node -o $node -i $attr");
             last if ($::RUNCMD_RC == 0);
         }
@@ -975,17 +962,20 @@ sub usage
     print "  xcattest [-f configure file] [-b case bundle list]\n";
     print "  xcattest [-f configure file] [-t case list]\n";
     print "  xcattest [-f configure file] [-c cmd list]\n";
+    print "  xcattest [-f configure file:System] [-t case] \n"; 
     print "  xcattest [-f configure file] [-b case bundle list] [-l]\n";
     print "  xcattest [-f configure file] [-t case list] [-l]\n";
-    print "  xcattest [-f configure file] [-c cmd list] [-l]\n";    
+    print "  xcattest [-f configure file] [-c cmd list] [-l]\n"; 
+    print "  xcattest [-bl]";  
     print "\n";
+    return;
 }
 
-sub show_bundle_files
+sub listbundlefiles
 {
-    print "Valid bundle files:\n\n";
-    system("ls $bundle_dir");    
-    return;
+    print "Bundle files listed in $bundledir/:\n";
+    system("ls $bundledir  ");    
+    return 0;
 }
 
 sub getreport
@@ -1012,10 +1002,13 @@ sub getreport
 sub reordercases {
     my @caserange = ();
     my $line;
-    if ($bundle_list) {
-        my @bundles = split /,/, $bundle_list;
+    if ($bundlelist) {
+        my @bundles = split /,/, $bundlelist;
         foreach my $bundle (@bundles) {
-            open(FILE, "<$bundle_dir/$bundle") or die "Can't open bundle file: $bundle";
+            if (!open(FILE, "<$bundledir/$bundle")){
+                log_this("Error: Can't open bundle file: $bundle");
+                return 1;
+            }
             while ($line = <FILE>) {
                 $line = trim($line);
                 next if (length($line) == 0);
@@ -1024,8 +1017,8 @@ sub reordercases {
             close(FILE);
         }
     }
-    if ($case_list) {
-        @caserange = split /,/, $case_list;
+    if ($caselist) {
+        @caserange = split /,/, $caselist;
     }
 
     my @tmpcases = ();
@@ -1044,4 +1037,50 @@ sub reordercases {
     }
     @cases = @tmpcases;
 }
+
+sub checkoptions{
+    #bundle, cases lists and command lists, one of them must be defined
+    if (!defined($bundlelist) && !defined($caselist) && !defined($caselist) && !defined($showbundlefiles)){
+        &usage;
+        exit 1;
+    }
+
+    #get and check config file and System label
+    #this System label means only the [System] variable will be loaded
+    if ($configinfo){   
+          if ($configinfo =~ /(\w+):(\w+)/){
+            $configfile =$1;
+            $initallabel = $2;
+            if ($initallabel ne $loadsysteminfo){
+                print "Error： $initallabel is not supported!\n";
+                log_this("Error: $initallabel is not supported!");
+                return 1;
+            }
+        }else{
+            $configfile = $configinfo;
+        }
+    }
+    if (!(-e $configfile)) {
+        print "Error： Can't open config file: $configfile\n";
+        log_this("Error： Can't open config file: $configfile");
+        return 1;
+    }
+
+    #check bundle files
+    if ($bundlelist){
+        my @bundles = split /,/, $bundlelist;
+        foreach my $bundle (@bundles){
+            if (!(-e "$bundledir/$bundle")) {
+                print "Error: Can't open bundle file: $bundledir/$bundle\n";
+                log_this("Error: Can't open bundle file: $bundledir/$bundle");
+                return 1;
+            }
+        }
+    }
+    
+    return 0;
+}
+
+
+
 


### PR DESCRIPTION
In order to divide the install xCAT from the xcatjktest auto-test framework, just change the xcattest file and complete the install xCAT case.
Meanwhile, improve the xcattest command:
1. optional define
2. optional input error messages: config/bundle file error and bundle file list show.
3. delete the case files output when unexpected.
 
@tingtli @hu-weihua 

