### PR TITLE
Fix the issue with bmcdiscover on older FSP and Tuletta machines where bmcuser is not needed 

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -204,24 +204,19 @@ sub bmcdiscovery_processargs {
         return 1;
     }
 
-    #
-    # Get the default bmc account from passwd table
-    #
-    ($bmc_user, $bmc_pass) = bmcaccount_from_passwd();
-
-    # overwrite the default user/pass with what is passed in
-    if ($::opt_U) {
-        $bmc_user = $::opt_U;
-    }
-    if ($::opt_P) {
-        $bmc_pass = $::opt_P;
-    }
-
     #########################################
     # Option -s -r should be together
     ######################################
     if (defined($::opt_R))
     {
+        # Option -c should not be used with -r 
+        if (defined($::opt_C)) {
+            my $msg = "The 'check' and 'range' option cannot be used together.";
+            my $rsp = {};
+            push @{ $rsp->{data} }, "$msg";
+            xCAT::MsgUtils->message("E", $rsp, $::CALLBACK);
+            return 2;
+        }
         ######################################
         # check if there is nmap or not
         ######################################
@@ -240,6 +235,24 @@ sub bmcdiscovery_processargs {
             xCAT::MsgUtils->message("E", $rsp, $::CALLBACK);
             return 1;
         }
+
+        #
+        # Get the default bmc account from passwd table, this is only done for the 
+        # discovery process
+        #
+        ($bmc_user, $bmc_pass) = bmcaccount_from_passwd();
+        # overwrite the default password if one is provided
+        if ($::opt_U) {
+            $bmc_user = $::opt_U;
+        } else {
+            # If password is provided, but no user, set the user to blank
+            # Support older FSP and Tuletta machines
+            $bmc_user = '';
+        }
+        if ($::opt_P) {
+            $bmc_pass = $::opt_P;
+        }
+
         scan_process($::opt_M, $::opt_R, $::opt_Z, $::opt_W, $request_command);
         return 0;
     }


### PR DESCRIPTION
Seems like for discovery of FSP and TUL servers, there is no bmcuser name so adding the code from commit 3f54b456d2f2479489386b9291fa1867dd22c32d and d82e14b56656482279d58e38295a9900e82ba056 to set the default user breaks that function.  

Reverting back to the old ways

Discussion by @zet809  in Pull Request #1066 

For OpenPower machines, the behavior now looks like this: 
```
[root@c910f02c05p03 ~]# bmcdiscover --range 50.5.33.10 -p passw0rd
Error: BMC username is incorrect for 50.5.33.10
[root@c910f02c05p03 ~]# bmcdiscover --range 50.5.33.10 -p passw0rd -u ADMIN
50.5.33.10,8335-GTA,1210532,ADMIN,passw0rd
```

Also blocked the use of `-i` and `--range`
```
[root@c910f02c05p03 ~]#  bmcdiscover --range 50.5.33.10 -u ADMIN -p passw0rd --check
Error: The 'check' and 'range' option cannot be used together.
```