### PR TITLE
Add old commit 693d3facfc34541c52440ad9cef973ffb74a46ff back to configib script

### DIFF
--- a/xCAT/postscripts/configib
+++ b/xCAT/postscripts/configib
@@ -156,7 +156,11 @@ then
 		
         #`rm -f $dir/ifcfg-$nic` 2>&1 1>/dev/null
         # nic aliases
-        `rm -f $dir/ifcfg-ib*` 2>&1 1>/dev/null
+        for nic in `echo "$NIC_IBNICS" | tr "," "\n"`
+        do
+            rm -f $dir/ifcfg-$nic 2>&1 1>/dev/null
+        done
+
         else  
             interfaces="/etc/network/interfaces"
 


### PR DESCRIPTION
A old fix which commit number is 693d3facfc34541c52440ad9cef973ffb74a46ff  was lost by me. So I am trying to add it back. 

