### PR TITLE
Checking nodetype to distinguish between node/switch discovery

### DIFF
--- a/perl-xCAT/xCAT/MacMap.pm
+++ b/perl-xCAT/xCAT/MacMap.pm
@@ -439,6 +439,9 @@ sub refresh_table {
     my @switchentries = $self->{switchestab}->getAllNodeAttribs([qw(switch snmpversion username password privacy auth)]);
     my $community = "public";
 
+    #$self->{sitetab} = xCAT::Table->new('site');
+    #my $tmp = $self->{sitetab}->getAttribs({key=>'snmpc'},'value');
+    #if ($tmp and $tmp->{value}) { $community = $tmp->{value} }
     my @snmpcs = xCAT::TableUtils->get_site_attribute("snmpc");
     my $tmp    = $snmpcs[0];
     if (defined($tmp)) { $community = $tmp }
@@ -473,21 +476,17 @@ sub refresh_table {
     #Build hash of switch port names per switch
     $self->{switches} = {};
     
-    #get nodetype from nodetype table, build a temp nodetype hash
-    my %typehash;
-    my @typeentries;
+    #get nodetype from nodetype table, build a temp hash
+    my $typehash;
     my $ntable = xCAT::Table->new('nodetype');
     if ($ntable) {
-        @typeentries = $ntable->getAllNodeAttribs(['node', 'nodetype']);
-    }
-    for my $typeentry (@typeentries) {
-        $typehash{ $typeentry->{node} } = $typeentry->{nodetype};
+        $typehash = $ntable->getAllNodeAttribs(['node','nodetype'], 1);
     }
 
     foreach my $entry (@entries) {
         # if we are doing switch discovery and the node is not a switch, skip
         # if we are NOT doing switch discovery, and the node is a switch, skip
-        my $ntype = $typehash{$entry->{node}};
+        my $ntype = $typehash->{$entry->{node}}->[0]->{nodetype};
         if ( (($discover_switch) and ( $ntype ne "switch"))
             or ( !($discover_switch) and ( $ntype eq "switch")) ){
             xCAT::MsgUtils->message("S", "refresh_table: skip $entry->{node} and $entry->{switch}");

--- a/perl-xCAT/xCAT/MacMap.pm
+++ b/perl-xCAT/xCAT/MacMap.pm
@@ -288,6 +288,10 @@ sub dump_mac_info {
         $self->{callback}          = $callback;
     }
     my $community         = "public";
+    my @snmpcs = xCAT::TableUtils->get_site_attribute("snmpc");
+    my $tmp    = $snmpcs[0];
+    if (defined($tmp)) { $community = $tmp }
+
     my $dump_all_switches = 0;
     my %switches_to_dump  = ();
     if (!defined($noderange)) {
@@ -366,6 +370,7 @@ sub find_mac {
     my $self       = shift;
     my $mac        = shift;
     my $cachedonly = shift;
+    my $discover_switch=shift;
 
     # For now HARDCODE (TODO, configurable?) a cache as stale after five minutes
     # Also, if things are changed in the config, our cache could be wrong,
@@ -390,7 +395,7 @@ sub find_mac {
     #If requesting a cache only check or the cache is a mere 20 seconds old
     #don't bother querying switches
     if ($cachedonly or ($self->{timestamp} > (time() - 20))) { return undef; }
-    $self->refresh_table;    #not cached or stale cache, refresh
+    $self->refresh_table($discover_switch);    #not cached or stale cache, refresh
     if ($self->{mactable}->{ lc($mac) }) {
         return $self->{mactable}->{ lc($mac) };
     }
@@ -426,6 +431,7 @@ sub fill_switchparms {
 
 sub refresh_table {
     my $self = shift;
+    my $discover_switch = shift;
     my $curswitch;
     $self->{mactable}    = {};
     $self->{switchtab}   = xCAT::Table->new('switch', -create => 1);
@@ -469,7 +475,22 @@ sub refresh_table {
 
     #Build hash of switch port names per switch
     $self->{switches} = {};
+    
+    #get nodetype from nodetype
+    my $ntable = xCAT::Table->new('nodetype');
+    my @typeentries = $ntable->getAllNodeAttribs(['node', 'nodetype']);
+    foreach my $ntnode (@typeentries) {
+        if ($ntnode->{nodetype} eq "switch") {
+            $self->{switches}->{$ntnode->{node} }->{nodetype}  = $ntnode->{nodetype};
+            xCAT::MsgUtils->message("S", "refresh_table: $ntnode->{node} is $self->{switches}->{$ntnode->{node} }->{nodetype}");
+        }
+    }
     foreach my $entry (@entries) {
+        if ( (($discover_switch) and ($self->{switches}->{$entry->{node}}->{nodetype} ne "switch"))
+            or ( !($discover_switch) and ($self->{switches}->{$entry->{node}}->{nodetype} eq "switch")) ){
+            xCAT::MsgUtils->message("S", "refresh_table: skip $entry->{node} and $entry->{switch}");
+            next;
+        }
         if (defined($entry->{switch}) and $entry->{switch} ne "" and defined($entry->{port}) and $entry->{port} ne "") {
 
             if (!$self->{switches}->{ $entry->{switch} }->{ $entry->{port} })

--- a/xCAT-server/lib/xcat/plugins/switchdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/switchdiscover.pm
@@ -1383,7 +1383,7 @@ sub switchsetup {
         # issue makehosts so we can use xdsh
         my $dswitch = get_hostname($outhash->{$mac}->{name}, $ip);
 
-        my $node = $macmap->find_mac($mac,0);
+        my $node = $macmap->find_mac($mac,0,1);
         if (!$node) {
             send_msg($request, 0, "NO predefined switch matched this switch $dswitch with ip address $ip and mac address $mac");
             next;


### PR DESCRIPTION
finding this on fs1,  the top of rack switch frame45_sw1 is connect to core switch switch-10-5-23-1, and compute node c39 is connect to top of rack switch.  
`````
[root@fs1 xCAT]# switchprobe switch-10-5-23-1  | grep frame45_sw1
switch-10-5-23-1  Ethernet45  a8:97:dc:02:92:00  frame45_sw1
switch-10-5-23-1  Ethernet45  98:be:94:59:ee:a7  frame45_sw1
switch-10-5-23-1  Ethernet45  70:e2:84:14:02:34  frame45_sw1
switch-10-5-23-1  Ethernet45  a8:97:dc:02:92:2f  frame45_sw1
switch-10-5-23-1  Ethernet45  70:e2:84:14:02:5f  frame45_sw1
[root@fs1 xCAT]# switchprobe frame45_sw1 | grep c910f05c39
frame45_sw1  Ethernet3   98:be:94:59:ee:a7  c910f05c39
````````
when we ran switch-based node discovery for c39, find_mac subroutine will find frame45_sw1 as compute node based on mac address  98:be:94:59:ee:a7 on port 45 of switch-10-5-23-1.  that cause switch unreachable any more and c39 never discovered.   

to fix this:
for all the switch, the nodetype has to set as "switch",  find_mac subroutine will add a new flag to indicate if this is node discovery or switch discovery, then based on nodetype, we will collect (switch-port, node) mapping.

this PR also add code for issue #1798 
