### PR TITLE
fix issue 1803: node discovery won't keep nodeset parameters if genes…

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/discovery/mtms/discovery_using_defined.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/discovery/mtms/discovery_using_defined.rst
@@ -101,9 +101,9 @@ The BMC IP address is obtained by the open range dhcp server and the plan in thi
           ip=10.1.2.1 
 
 
-#. Set the chain table to run the ``bmcsetup`` script, this will set the BMC IP to static. ::
+#. Set the chain table to run the ``bmcsetup`` script and append ``standby``, this will set the BMC IP to static and then standby to wait for the next task. ::
 
-       chdef cn01 chain="runcmd=bmcsetup"
+       chdef cn01 chain="runcmd=bmcsetup,standby"
 
 
 #. Change the BMC IP address 

--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/discovery/mtms/discovery_using_dhcp.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/discovery/mtms/discovery_using_dhcp.rst
@@ -78,9 +78,9 @@ The BMC IP address is obtained by the open range dhcp server and the plan is to 
           ip=10.1.2.1 
 
 
-#. Set the chain table to run the ``bmcsetup`` script, this will set the BMC IP to static. ::
+#. Set the chain table to run the ``bmcsetup`` script and append ``standby``, this will set the BMC IP to static and then standby to wait for the next task. ::
 
-       chdef cn01 chain="runcmd=bmcsetup"
+       chdef cn01 chain="runcmd=bmcsetup,standby"
 
 #. Define the compute nodes into xCAT: ::
 

--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/discovery/seq_discovery.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/discovery/seq_discovery.rst
@@ -18,9 +18,9 @@ Predefine a group of nodes with desired IP address for host and IP address for F
     nodeadd cn1 groups=powerLE,all
     chdef cn1 mgt=ipmi cons=ipmi ip=10.0.101.1 bmc=50.0.101.1 netboot=petitboot installnic=mac primarynic=mac
 
-In order to do BMC configuration during the discovery process, set ``runcmd=bmcsetup``. For more info about chain, please refer to :doc:`Chain <../../../../../advanced/chain/index>`   ::
+In order to do BMC configuration during the discovery process, set ``runcmd=bmcsetup``. And append ``standby`` for chain to have the genesis standby to wait for the next task after finished BMC configuration. For more info about chain, please refer to :doc:`Chain <../../../../../advanced/chain/index>`   ::
 
-    chdef cn1 chain="runcmd=bmcsetup"
+    chdef cn1 chain="runcmd=bmcsetup,standby"
 
 Initialize the discovery process
 ````````````````````````````````

--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/discovery/switch_discovery.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/discovery/switch_discovery.rst
@@ -54,9 +54,9 @@ After switches are defined, the server node can be predefined with the following
     chdef cn1 mgt=ipmi cons=ipmi ip=10.0.101.1 bmc=50.0.101.1 netboot=petitboot installnic=mac primarynic=mac
     chdef cn1 switch=switch1 switchport=0
 
-In order to do BMC configuration during the discovery process, set ``runcmd=bmcsetup``. For more info about chain, please refer to :doc:`Chain <../../../../../advanced/chain/index>`   ::
+In order to do BMC configuration during the discovery process, set ``runcmd=bmcsetup``. And append ``standby`` for chain to have the genesis standby to wait for the next task after finished BMC configuration. For more info about chain, please refer to :doc:`Chain <../../../../../advanced/chain/index>`   ::
 
-    chdef cn1 chain="runcmd=bmcsetup"
+    chdef cn1 chain="runcmd=bmcsetup,standby"
 
 Add cn1 into DNS::
 


### PR DESCRIPTION
…is is still running

1. Fix issue #1803 and #1422 
2. Updated the document to append 'standby' to 'runcmd=bmcsetup' for chain table. 
