### PR TITLE
fix issue Enable Kdump can not work on diskless image for rh7.3 snapshot1 #1805;add support for kdump on rh7.x

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/common/deployment/enable_kdump.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/deployment/enable_kdump.rst
@@ -163,11 +163,7 @@ Normally, kernel panic() will trigger booting into capture kernel. Once the kern
 
 #. For SLES10 the directory is <kdump_path>/<node hostname>
 	
-For RHELS6 testing purposes, you can simulate the trigger through /proc interface: ::
-	
-    echo c > /proc/sysrq-trigger
-	
-For SLES11.1 testing, you can use the following commands: ::
+For Redhat and SLES11.1 testing, you can use the following commands: ::
 
     echo 1 > /proc/sys/kernel/sysrq
     echo c > /proc/sysrq-trigger

--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -1000,12 +1000,17 @@ sub mkinitrd_dracut {
 
         #update etc/dracut.conf
         open($DRACUTCONF, '>', "$rootimg_dir/etc/dracut.conf");
+        my $dracutmodulelist = "xcat nfs base network kernel-modules syslog ";
+
+        if (-d glob($dracutmoduledir . "[0-9]*systemd")) {
+            $dracutmodulelist .= " systemd ";
+        }
+
         if (-d glob($dracutmoduledir . "[0-9]*fadump")) {
-            print $DRACUTCONF qq{dracutmodules+="xcat nfs base network kernel-modules syslog fadump"\n};
+            $dracutmodulelist .= " fadump ";
         }
-        else {
-            print $DRACUTCONF qq{dracutmodules+="xcat nfs base network kernel-modules syslog"\n};
-        }
+
+        print $DRACUTCONF qq{dracutmodules+="$dracutmodulelist"\n};
         print $DRACUTCONF qq{add_drivers+="$add_drivers"\n};
         print $DRACUTCONF qq{filesystems+="nfs"\n};
         close $DRACUTCONF;
@@ -1038,9 +1043,14 @@ sub mkinitrd_dracut {
         chmod($perm & 07777, "$dracutmpath/installkernel");
 
         my $dracutmodulelist = " xcat nfs base network kernel-modules syslog ";
+ 
+        
+        if (-d glob($dracutmoduledir . "[0-9]*systemd")) {
+            $dracutmodulelist .= " systemd ";
+        }
+
         if (-d glob($dracutmoduledir . "[0-9]*fadump")) {
             $dracutmodulelist .= " fadump ";
-
         }
 
         # update etc/dracut.conf

--- a/xCAT/postscripts/enablekdump
+++ b/xCAT/postscripts/enablekdump
@@ -32,7 +32,7 @@ for i in `/bin/cat /proc/cmdline`; do
         MACX=`/sbin/ip link show $ETHX | /bin/grep ether | /bin/awk '{print $2}'`
         break
     elif [ "$KEY" = "BOOTIF" ]; then
-        MACX=`/bin/echo $i | /bin/awk -F= '{print $2}'|sed -e s/^01-// -e s/-/:/g`
+        MACX=`/bin/echo $i | /bin/awk -F= '{print $2}'|sed -e 's/^01-//' -e 's/-/:/g'`
         #ETHX=`/sbin/ifconfig | /bin/grep -i $MACX | /bin/awk '{print $1}'`
         ETHX=`/sbin/ip -oneline link show |/bin/grep -i $MACX |/bin/awk -F ":" '{print $2}'|/bin/grep -o "[^ ]\+\( \+[^ ]\+\)*"`
         break
@@ -99,7 +99,7 @@ if [ ! -z "$DUMP" ]; then
     # workaround for RHEL6
     # the $KDIP:$KDPATH directory will be used to generate the initrd for kdump service
     MOUNTPATH=""
-    if ((pmatch $OSVER "*6\.*")); then
+    if (pmatch $OSVER "*6\.*"); then
 	MOUNTPATH="/tmp"
     elif (pmatch $OSVER "*7\.*"); then
         MOUNTPATH="/mnt"
@@ -219,9 +219,29 @@ EOF
                /bin/mount -o vers=3 $KDIP:$KDPATH $MOUNTPATH
                #/bin/mount -o nolock $KDIP:$KDPATH $MOUNTPATH
                [ -d $MOUNTPATH/var/crash ] || mkdir -p $MOUNTPATH/var/crash
+
+               #The initramfs used in kdump does not need "root", however, the initramfs refused to continue
+               #if no valid "root" provided in redhat7.1 kdump; As a workaround,we provide a fake "root=nfs:$KDIP:$KDPATH"
+               #with a dummy "proc" inside, which will fake "root=nfs:$KDIP:$KDPATH" as a valid root directory 
+               [ -e $MOUNTPATH/proc ] || echo "Dummy file: fake the /proc to pass the checking of 'root=' inside dracut-cmdline " > $MOUNTPATH/proc
+
                echo "nfs $KDIP:$KDPATH" > /etc/kdump.conf 
                echo "default shell" >> /etc/kdump.conf
-               sed -i 's/KDUMP_COMMANDLINE_APPEND="/KDUMP_COMMANDLINE_APPEND="nonodestatus /' /etc/sysconfig/kdump
+               #strip "xcat" out of the initramfs for kdump
+               echo "dracut_args --omit \"xcat\"" >> /etc/kdump.conf
+               #strip the unnecessary kernel options from /proc/cmdline
+               #the modified "cmdline" will be used as the kernel options
+               #for kdump initramfs; otherwise, the "service kdump restart" will fail
+               #with "command line overflow" since the kernel options are longer than 255 chars`
+               kdumpcmdline=
+               for i in $(cat /proc/cmdline)
+                   do 
+                       if [[ $i == console=* ]] || [[ $i == crashkernel=* ]]; then 
+                             kdumpcmdline="$kdumpcmdline $i "
+                       fi
+               done
+               sed -i "s#^[\t ]*KDUMP_COMMANDLINE=\"#KDUMP_COMMANDLINE=\"$kdumpcmdline#" /etc/sysconfig/kdump
+               sed -i "s#^[\t ]*KDUMP_COMMANDLINE_APPEND=\"#KDUMP_COMMANDLINE_APPEND=\"root=nfs:$KDIP:$KDPATH #" /etc/sysconfig/kdump
                [ -f /etc/dracut.conf ] && mv /etc/dracut.conf  /tmp/dracut.conf
                restartservice kdump
                [ -f /tmp/dracut.conf ] && mv /tmp/dracut.conf /etc/dracut.conf 


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/1805

add support for kdump on redhat 7.x

verified on rhels7.[1,2,3beta2] on ppc64le