### PR TITLE
Modify switchdiscover usage, man page and update readdoc

### DIFF
--- a/docs/source/advanced/networks/index.rst
+++ b/docs/source/advanced/networks/index.rst
@@ -4,7 +4,7 @@ Networks
 .. toctree::
    :maxdepth: 2
 
-   switchdiscover/index.rst
    ethernet_switches/index.rst
+   switchdiscover/index.rst
    infiniband/index.rst
    ipv6/index.rst

--- a/docs/source/advanced/networks/switchdiscover/index.rst
+++ b/docs/source/advanced/networks/switchdiscover/index.rst
@@ -5,3 +5,4 @@ Switch Discover
    :maxdepth: 2
 
    switches_discovery.rst 
+   switch_based_switch_discovery.rst

--- a/docs/source/advanced/networks/switchdiscover/switch_based_switch_discovery.rst
+++ b/docs/source/advanced/networks/switchdiscover/switch_based_switch_discovery.rst
@@ -1,0 +1,131 @@
+Switch-based Switch Discovery
+=============================
+
+Currently, xCAT supports switch based hardware discovery, the servers are identified through the switches and switch ports they are directly connected to.  Use same method, xcat introduced how to discovery switches use switch-based discovery within the user defined dynamic IP range.
+
+Pre-requirement
+~~~~~~~~~~~~~~~
+
+In order to do switch-based switch discovery, the admin 
+
+1.  Needs to manually setup and configure core-switch, SNMP v3 needs to be enabled in order for xCAT access to it. Example of core-switch definition:   
+
+::
+
+    lsdef switch-10-5-23-1
+      Object name: switch-10-5-23-1
+      groups=switch
+      ip=10.5.23.1
+      mac=ab:cd:ef:gh:dc
+      mgt=switch
+      nodetype=switch
+      password=admin
+      postbootscripts=otherpkgs
+      postscripts=syslog,remoteshell,syncfiles
+      protocol=telnet
+      snmpauth=sha
+      snmppassword=userpassword
+      snmpusername=snmpadmin
+      snmpversion=3
+      switchtype=BNT
+      usercomment=IBM
+      username=root
+
+
+
+2.  Then pre-define all the top-rack switches which connect to core-switch. 
+
+::
+
+    lsdef switch-192-168-5-22
+      objtype=node
+      groups=switch
+      ip=192.168.5.22
+      mgt=switch
+      nodetype=switch
+      switch=switch-10-5-23-1
+      switchport=45
+      switchtype=BNT
+
+
+3.  Setup Dynamic ip range to network table for discovery switches to use.
+
+
+Discover Switches
+~~~~~~~~~~~~~~~~~
+
+xCAT supports **switchdiscover** command to discover the switches that are attached to the subnets on xCAT management node.  Please refer http://xcat-docs.readthedocs.io/en/latest/advanced/networks/switchdiscover/switches_discovery.html for more info.  
+
+For the switch-based switch discovery, we add ``–setup`` flag:  ::
+
+
+    switchdiscover [noderange|--range ip_ranges][-s scan_methods] [--setup]
+
+
+if ``–setup`` flag is specified, it will process following steps:
+
+1.  Use snmp or nmap scan method to find all the switches in the dynamic ip ranges which specified by ``--range``, the available switches will be store to switch hash table with hostname, switchtype, vendor info and mac address.  
+
+
+2.  Based on mac address for each switch defined in the hash table, call **find_mac** subroutine.   The **find_mac** subroutine will go thought the switch and switch port and find matched mac address.    
+
+* If discovered switch didn't match to pre-define, it will log the message to indicate ``NO predefined switch matched``.
+* If discovered switch matched with one of pre-defined switch, it will update the pre-defined switch with ::
+
+    otherinterface=x.x.x.x (discovered ip)
+    state=matched
+    switchtype=type of switch
+    usercomment=vendor information
+
+
+3.  after switches matched, will call config files to set up static ip address, hostname and enable the snmpv3.  currently, BNT and Mellanox switches are supported.  The two config files are located in the ** /opt/xcat/share/xcat/scripts/config.BNT** and **/opt/xcat/share/xcat/scripts/config.Mellanox**.  the log message ``the switch type is not support for config`` if switchtype other than BNT and Mellanox.
+
+
+Configure switches
+~~~~~~~~~~~~~~~~~~
+
+The **switchdiscover** command with ``–setup`` options will set up switches with static ip address, change the hostname from predefine switches and enable snmpv3 configuration.  For other switches configuration, please refer http://xcat-docs.readthedocs.io/en/latest/advanced/networks/ethernet_switches/ethernet_switches.html and http://xcat-docs.readthedocs.io/en/latest/advanced/networks/infiniband/switch_configuration.html
+
+These two config files are located in the **/opt/xcat/share/xcat/scripts**.  The **switchdiscover** process will call the config files with ``--all`` option.  User can call this scripts to setup one of options manually. 
+
+1.  **configBNT** is for configure BNT switches. 
+
+::
+
+     ./configBNT --help
+     Usage:
+       configBNT [-?│-h│--help]
+       configBNT [--switches switchnames] [--all]
+       configBNT [--switches switchnames] [--ip]
+       configBNT [--switches switchnames] [--name ]
+       configBNT [--switches switchnames] [--snmp] [--user snmp_user] [--password snmp_password] [--group snmp_group]
+       configBNT [--switches switchnames] [--port port] [--vlan vlan]
+
+2.   **configMellanox** is for configure Mellanox switch.   The script will configure ntp service on the switch with xCAT MN  and use rspconfig command to
+    * enable ssh
+    * enable snmp function on the switch
+    * enable the snmp trap
+    * set logging destination to xCAT MN
+
+::
+
+    ./configMellanox --help
+    Usage:
+        configMellonax [-?│-h│--help]
+        configMellonax [--switches switchnames] [--all]
+        configMellonax [--switches switchnames] [--ip]
+        configMellonax [--switches switchnames] [--name]
+        configMellonax [--switches switchnames] [--config]
+
+
+switch status
+~~~~~~~~~~~~~
+
+**Matched** --- Discover switch is matched to pre-define switch, otherinterfaces attribute is updated to dhcp ip address, and mac address, switch type and usercomment also updated with vendor information for the predefined switch.
+
+**ip_configed** --- switches are set up to static ip address based on pre-define switch ip address
+
+**hostname_configed** -- switches host name changed based on pre-define switch hostname.
+
+**switch_configed** -- snmpv3 is setup for the switches.  this should be finial status after run ``switchdiscover --setup`` command.
+

--- a/docs/source/advanced/networks/switchdiscover/switch_based_switch_discovery.rst
+++ b/docs/source/advanced/networks/switchdiscover/switch_based_switch_discovery.rst
@@ -1,14 +1,14 @@
 Switch-based Switch Discovery
 =============================
 
-Currently, xCAT supports switch based hardware discovery, the servers are identified through the switches and switch ports they are directly connected to.  Use same method, xcat introduced how to discovery switches use switch-based discovery within the user defined dynamic IP range.
+Currently, xCAT supports switch based hardware discovery, the servers are identified through the switches and switch ports they are directly connected to.  A similar method can be used to discover switches using switch-based discovery within the user defined dynamic IP range. 
 
 Pre-requirement
 ~~~~~~~~~~~~~~~
 
 In order to do switch-based switch discovery, the admin 
 
-1.  Needs to manually setup and configure core-switch, SNMP v3 needs to be enabled in order for xCAT access to it. username and userpassword attribute are for the remote login. It can be for ssh or telnet. If it is for telnet, please set protocol to “telnet”. If the sshusername is blank, the username, password and protocol will be retrieved from the passwd table with “switch” as the key. SNMP attributes will used for SNMPv3 communication.  nodetype has to be set to **switch** to differentiate between switch-based node discovery or switch-based switch discovery. Please refer switches table attributes.  Example of core-switch definition:   
+1.  Needs to manually setup and configure core-switch, SNMP v3 needs to be enabled in order for xCAT access to it. **username** and **userpassword** attributes are for the remote login. It can be for **ssh** or **telnet**. If it is for **telnet**, please set protocol to “telnet”. If the **username** is blank, the **username** and **password** will be retrieved from the passwd table with “switch” as the key. SNMP attributes will used for SNMPv3 communication.  **nodetype** has to be set to "switch" to differentiate between switch-based node discovery or switch-based switch discovery. Refer to switches table attributes.  Example of core-switch definition:   
 
 ::
 
@@ -33,7 +33,7 @@ In order to do switch-based switch discovery, the admin
 
 
 
-2.  Then pre-define all the top-rack switches which connect to core-switch.  The attribute **ip** is static ip address for the switch.  If ``switchdiscover --setup`` specified, this ip address will replace dhcp ip address on the switch. ``nodetype=switch`` needs to be set to differentiate between switch-based node discovery or switch-based switch discovery during discover process.  the ``switch`` is hostname of core-switch and ``switchport`` is the port number in the core-switch that top-rack switch is connected to.    
+2. Predefine all top-rack switches which connect to core-switch.  The attribute **ip** is static ip address for the switch.  When ``switchdiscover --setup`` command is issued, this ip address will replace dhcp IP address on the switch. **nodetype=switch** needs to be set to differentiate between switch-based node discovery or switch-based switch discovery during discovery process.  the attribute **switch** is hostname of core-switch and **switchport** is the port number in the core-switch that top-rack switch is connected to.    
 
 ::
 
@@ -48,36 +48,36 @@ In order to do switch-based switch discovery, the admin
       switchtype=BNT
 
 
-3.  Setup Dynamic ip range to network table for discovery switches to use. ::
+3.  Setup Dynamic IP range in network table for discovered switches to use. ::
 
      # tabdump networks
       #netname,net,mask,mgtifname,gateway,dhcpserver,tftpserver,nameservers,ntpservers,logservers,dynamicrange,staticrange,staticrangeincrement,nodehostname,ddnsdomain,vlanid,domain,comments,disable
       "192_168_0_0-255_255_0_0","192.168.0.0","255.255.0.0","enP4p1s0f2","<xcatmaster>",,"192.168.3.29",,,,"192.168.5.150-192.168.5.170",,,,,,,,
 
 
-dhcp should restarted after set up dynamic ip address.
+dhcp should be restarted after seting up dynamic IP range.
 
 
 Discover Switches
 ~~~~~~~~~~~~~~~~~
 
-xCAT supports **switchdiscover** command to discover the switches that are attached to the subnets on xCAT management node.  Please refer http://xcat-docs.readthedocs.io/en/latest/advanced/networks/switchdiscover/switches_discovery.html for more info.  
+xCAT supports **switchdiscover** command to discover the switches that are attached to the subnets on xCAT management node.  Refer to http://xcat-docs.readthedocs.io/en/latest/advanced/networks/switchdiscover/switches_discovery.html for more info.  
 
-For the switch-based switch discovery, we add ``–setup`` flag:  ::
+For the switch-based switch discovery, we add **–setup** flag:  ::
 
 
     switchdiscover [noderange|--range ip_ranges][-s scan_methods] [--setup]
 
 
-if ``–setup`` flag is specified, it will process following steps:
+if **--setup** flag is specified, the command will perform following steps:
 
-1.  Use snmp or nmap scan method to find all the switches in the dynamic ip ranges which specified by ``--range``, the available switches will be store to switch hash table with hostname, switchtype, vendor info and mac address.  
+1.  Use snmp or nmap scan methods to find all switches in the dynamic IP ranges specified by --range, the available switches will be stored in switch hash table with hostname, switchtype, vendor info and mac address.  
 
 
-2.  Based on mac address for each switch defined in the hash table, call **find_mac** subroutine.   The **find_mac** subroutine will go thought the switch and switch port and find matched mac address.    
+2.  Based on mac address for each switch defined in the hash table, call **find_mac** subroutine.   The **find_mac** subroutine will go thought the switch and switch ports and find matched mac address.    
 
-* If discovered switch didn't match to pre-define, it will log the message to indicate ``NO predefined switch matched``.
-* If discovered switch matched with one of pre-defined switch, it will update the pre-defined switch with ::
+* If discovered switch didn't find any predefined switch matches, it will log the message ``NO predefined switch matched``.
+* If discovered switch matched with one of pre-defined switch, it will update the predefined switch with ::
 
     otherinterface=x.x.x.x (discovered ip)
     state=matched
@@ -85,9 +85,9 @@ if ``–setup`` flag is specified, it will process following steps:
     usercomment=vendor information
 
 
-3.  after switches matched, will call config files to set up static ip address, hostname and enable the snmpv3.  currently, BNT and Mellanox switches are supported.  The two config files are located in the ** /opt/xcat/share/xcat/scripts/config.BNT** and **/opt/xcat/share/xcat/scripts/config.Mellanox**.  the log message ``the switch type is not support for config`` if switchtype other than BNT and Mellanox.
+3.  After switches are matched, the command will call config files to set up static IP address, hostname and enable the snmpv3.  Currently, BNT and Mellanox switches are supported.  The two config files are located in the **/opt/xcat/share/xcat/scripts/config.BNT** and **/opt/xcat/share/xcat/scripts/config.Mellanox**.  the log message ``the switch type is not support for config`` is displayed if switchtype is something other than BNT or Mellanox.
 
-4.  After discover process, the pre-defined node attribute in the xCATdb should be updated. 
+4.  After discovery process, the predefined node attribute in the xCATdb should be updated. 
 
 ::
 
@@ -119,9 +119,9 @@ if ``–setup`` flag is specified, it will process following steps:
 Configure switches
 ~~~~~~~~~~~~~~~~~~
 
-The **switchdiscover** command with ``–setup`` options will set up switches with static ip address, change the hostname from predefine switches and enable snmpv3 configuration.  For other switches configuration, please refer http://xcat-docs.readthedocs.io/en/latest/advanced/networks/ethernet_switches/ethernet_switches.html and http://xcat-docs.readthedocs.io/en/latest/advanced/networks/infiniband/switch_configuration.html
+The **switchdiscover** command with ``--setup`` flag will set up switches with static ip address, change the hostname from predefine switches and enable snmpv3 configuration.  For other switches configuration, Refer to http://xcat-docs.readthedocs.io/en/latest/advanced/networks/ethernet_switches/ethernet_switches.html and http://xcat-docs.readthedocs.io/en/latest/advanced/networks/infiniband/switch_configuration.html
 
-These two config files are located in the **/opt/xcat/share/xcat/scripts**.  The **switchdiscover** process will call the config files with ``--all`` option.  User can call this scripts to setup one of options manually. 
+These two config files are located in the **/opt/xcat/share/xcat/scripts**.  The **switchdiscover** process will call the config files with ``--all`` option.  User can call these scripts to setup one of options manually. 
 
 1.  **configBNT** is for configure BNT switches. 
 
@@ -136,7 +136,7 @@ These two config files are located in the **/opt/xcat/share/xcat/scripts**.  The
        configBNT [--switches switchnames] [--snmp] [--user snmp_user] [--password snmp_password] [--group snmp_group]
        configBNT [--switches switchnames] [--port port] [--vlan vlan]
 
-2.   **configMellanox** is for configure Mellanox switch.   The script will configure ntp service on the switch with xCAT MN  and use rspconfig command to
+2.   **configMellanox** is for configuring Mellanox switch.   The script will configure ntp service on the switch with xCAT MN  and will use rspconfig command to
     * enable ssh
     * enable snmp function on the switch
     * enable the snmp trap
@@ -153,16 +153,16 @@ These two config files are located in the **/opt/xcat/share/xcat/scripts**.  The
         configMellonax [--switches switchnames] [--config]
 
 
-switch status
+Switch Status
 ~~~~~~~~~~~~~
 
-During the switch-based switch discovery process, there are four status introduced.  User may only see **switch_configed** status on node definition if discovery process succefully finished.  
+During the switch-based switch discovery process, there are four states displayed.  User may only see **switch_configed** status on node definition if discovery process succefully finished.  
 
-**Matched** --- Discover switch is matched to pre-define switch, otherinterfaces attribute is updated to dhcp ip address, and mac address, switch type and usercomment also updated with vendor information for the predefined switch.
+**Matched** --- Discovered switch is matched to predefine switch, **otherinterfaces** attribute is updated to dhcp IP address, and mac address, **switch type** and **usercomment** also updated with vendor information for the predefined switch.
 
-**ip_configed** --- switches are set up to static ip address based on pre-define switch ip address.  If failed to set up ip address, the status will keep as **Matched**.
+**ip_configed** --- switch is set up to static ip address based on predefine switch IP address.  If failure to set up IP address, the status will stay as **Matched**.
 
-**hostname_configed** -- switches host name changed based on pre-define switch hostname. If failed to change hostname on the switch, the status will keep as **ip_configed**.
+**hostname_configed** -- switch host name is changed based on predefine switch hostname. If failure to change hostname on the switch, the status will stay as **ip_configed**.
 
-**switch_configed** -- snmpv3 is setup for the switches.  this should be finial status after run ``switchdiscover --setup`` command. If failed to setup snmpv3,  the status will keep as **hostname_configed**.
+**switch_configed** -- snmpv3 is setup for the switches.  This should be finial status after running ``switchdiscover --setup`` command. If failure to setup snmpv3,  the status will stay as **hostname_configed**.
 

--- a/docs/source/advanced/networks/switchdiscover/switch_based_switch_discovery.rst
+++ b/docs/source/advanced/networks/switchdiscover/switch_based_switch_discovery.rst
@@ -87,7 +87,7 @@ if **--setup** flag is specified, the command will perform following steps:
 
 3.  After switches are matched, the command will call config files to set up static IP address, hostname and enable the snmpv3.  Currently, BNT and Mellanox switches are supported.  The two config files are located in the **/opt/xcat/share/xcat/scripts/config.BNT** and **/opt/xcat/share/xcat/scripts/config.Mellanox**.  the log message ``the switch type is not support for config`` is displayed if switchtype is something other than BNT or Mellanox.
 
-4.  After discovery process, the predefined node attribute in the xCATdb should be updated. 
+4.  After discovery process, the predefined node attribute in the xCATdb will be updated. 
 
 ::
 

--- a/docs/source/advanced/networks/switchdiscover/switch_based_switch_discovery.rst
+++ b/docs/source/advanced/networks/switchdiscover/switch_based_switch_discovery.rst
@@ -8,7 +8,7 @@ Pre-requirement
 
 In order to do switch-based switch discovery, the admin 
 
-1.  Needs to manually setup and configure core-switch, SNMP v3 needs to be enabled in order for xCAT access to it. Example of core-switch definition:   
+1.  Needs to manually setup and configure core-switch, SNMP v3 needs to be enabled in order for xCAT access to it. username and userpassword attribute are for the remote login. It can be for ssh or telnet. If it is for telnet, please set protocol to “telnet”. If the sshusername is blank, the username, password and protocol will be retrieved from the passwd table with “switch” as the key. SNMP attributes will used for SNMPv3 communication.  nodetype has to be set to **switch** to differentiate between switch-based node discovery or switch-based switch discovery. Please refer switches table attributes.  Example of core-switch definition:   
 
 ::
 
@@ -33,7 +33,7 @@ In order to do switch-based switch discovery, the admin
 
 
 
-2.  Then pre-define all the top-rack switches which connect to core-switch. 
+2.  Then pre-define all the top-rack switches which connect to core-switch.  The attribute **ip** is static ip address for the switch.  If ``switchdiscover --setup`` specified, this ip address will replace dhcp ip address on the switch. ``nodetype=switch`` needs to be set to differentiate between switch-based node discovery or switch-based switch discovery during discover process.  the ``switch`` is hostname of core-switch and ``switchport`` is the port number in the core-switch that top-rack switch is connected to.    
 
 ::
 
@@ -48,7 +48,14 @@ In order to do switch-based switch discovery, the admin
       switchtype=BNT
 
 
-3.  Setup Dynamic ip range to network table for discovery switches to use.
+3.  Setup Dynamic ip range to network table for discovery switches to use. ::
+
+     # tabdump networks
+      #netname,net,mask,mgtifname,gateway,dhcpserver,tftpserver,nameservers,ntpservers,logservers,dynamicrange,staticrange,staticrangeincrement,nodehostname,ddnsdomain,vlanid,domain,comments,disable
+      "192_168_0_0-255_255_0_0","192.168.0.0","255.255.0.0","enP4p1s0f2","<xcatmaster>",,"192.168.3.29",,,,"192.168.5.150-192.168.5.170",,,,,,,,
+
+
+dhcp should restarted after set up dynamic ip address.
 
 
 Discover Switches
@@ -79,6 +86,34 @@ if ``–setup`` flag is specified, it will process following steps:
 
 
 3.  after switches matched, will call config files to set up static ip address, hostname and enable the snmpv3.  currently, BNT and Mellanox switches are supported.  The two config files are located in the ** /opt/xcat/share/xcat/scripts/config.BNT** and **/opt/xcat/share/xcat/scripts/config.Mellanox**.  the log message ``the switch type is not support for config`` if switchtype other than BNT and Mellanox.
+
+4.  After discover process, the pre-defined node attribute in the xCATdb should be updated. 
+
+::
+
+    lsdef switch-192-168-5-22
+       groups=switch
+       ip=192.168.5.22
+       mac=a8:97:dc:02:92:00
+       mgt=switch
+       nodetype=switch
+       password=admin
+       postbootscripts=otherpkgs
+       postscripts=syslog,remoteshell,syncfiles
+       protocol=telnet
+       snmpauth=sha
+       snmppassword=xcatadminpassw0rd@snmp
+       snmpusername=xcatadmin
+       snmpversion=3
+       status=hostname_configed
+       statustime=08-31-2016 15:35:49
+       supportedarchs=ppc64
+       switch=switch-10-5-23-1
+       switchport=45
+       switchtype=BNT
+       usercomment=IBM Networking Operating System RackSwitch G8052
+       username=root
+
 
 
 Configure switches
@@ -121,11 +156,13 @@ These two config files are located in the **/opt/xcat/share/xcat/scripts**.  The
 switch status
 ~~~~~~~~~~~~~
 
+During the switch-based switch discovery process, there are four status introduced.  User may only see **switch_configed** status on node definition if discovery process succefully finished.  
+
 **Matched** --- Discover switch is matched to pre-define switch, otherinterfaces attribute is updated to dhcp ip address, and mac address, switch type and usercomment also updated with vendor information for the predefined switch.
 
-**ip_configed** --- switches are set up to static ip address based on pre-define switch ip address
+**ip_configed** --- switches are set up to static ip address based on pre-define switch ip address.  If failed to set up ip address, the status will keep as **Matched**.
 
-**hostname_configed** -- switches host name changed based on pre-define switch hostname.
+**hostname_configed** -- switches host name changed based on pre-define switch hostname. If failed to change hostname on the switch, the status will keep as **ip_configed**.
 
-**switch_configed** -- snmpv3 is setup for the switches.  this should be finial status after run ``switchdiscover --setup`` command.
+**switch_configed** -- snmpv3 is setup for the switches.  this should be finial status after run ``switchdiscover --setup`` command. If failed to setup snmpv3,  the status will keep as **hostname_configed**.
 

--- a/docs/source/guides/admin-guides/references/man1/switchdiscover.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/switchdiscover.1.rst
@@ -25,7 +25,7 @@ DESCRIPTION
 
 The switchdiscover command scans the subnets and discovers all the swithches on the subnets. The command takes a list of subnets as input. The default subnets are the ones that the xCAT management node is on. It uses nmap command as default to discover the switches. However, you can specify other discovery methods such as lldp or snmp with \ **-s**\  flag. You can write the discovered switches into xCAT database with \ **-w**\  flag. This command supports may output formats such as xml(\ **-x**\ ), raw(\ **-r**\ ) and stanza(\ **-z**\ ) in addition to the default format.
 
-\ **-**\ **-setup**\  flag is for switch-based switch discovery.  It will find all the discovery switches in the subnets, then matched with pre-defined switches in the xCATDB. It then set discovery switches with static ip address and hostname based on the pre-defined switch.  It also enables snmpv3 configuration. The detail of process is defined in the http://xcat-docs.readthedocs.io/en/latest/advanced/networks/switchdiscover/switches_discovery.html.
+\ **-**\ **-setup**\  flag is for switch-based switch discovery.  It will find all the discovered switches on the subnets, then match them with predefined switches in the xCATDB. Next, it will set discovered switches with static ip address and hostname based on the predefined switch.  It will also enable snmpv3 configuration. The details of the process are defined in the http://xcat-docs.readthedocs.io/en/latest/advanced/networks/switchdiscover/switches_discovery.html.
 
 To view all the switches defined in the xCAT databasee use \ **lsdef -w "nodetype=switch"**\  command.
 
@@ -114,7 +114,7 @@ OPTIONS
 
 \ **-**\ **-setup**\ 
  
- Process switch-based switch discovery. Update discovered switch's ip address, hostname and enable snmpv3 configuration based on the pre-defined switch.
+ Process switch-based switch discovery. Update discovered switch's ip address, hostname and enable snmpv3 configuration based on the predefined switch.
  
 
 
@@ -167,7 +167,7 @@ EXAMPLES
  
 
 
-4. To process switch-based switch discovery, the core switch has to configure already and top-of-rack (edge) switch has to pre-define into xCAT databse with attribute \ **switch**\  and \ **switchport**\  to core switch:
+4. To process switch-based switch discovery, the core switch has to be configured and top-of-rack (edge) switch has to be predefine into xCAT databse with attribute \ **switch**\  and \ **switchport**\  to core switch:
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man1/switchdiscover.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/switchdiscover.1.rst
@@ -23,7 +23,8 @@ DESCRIPTION
 ***********
 
 
-The switchdiscover command scans the subnets and discovers all the swithches on the subnets. The command takes a list of subnets as input. The default subnets are the ones that the xCAT management node is on. It uses nmap command as default to discover the switches. However, you can specify other discovery methods such as lldp or snmp with \ **-s**\  flag. You can write the discovered switches into xCAT database with \ **-w**\  flag. This command supports may output formats such as xml(\ **-x**\ ), raw(\ **-r**\ ) and stanza(\ **-z**\ ) in addition to the default format.    
+The switchdiscover command scans the subnets and discovers all the swithches on the subnets. The command takes a list of subnets as input. The default subnets are the ones that the xCAT management node is on. It uses nmap command as default to discover the switches. However, you can specify other discovery methods such as lldp or snmp with \ **-s**\  flag. You can write the discovered switches into xCAT database with \ **-w**\  flag. This command supports may output formats such as xml(\ **-x**\ ), raw(\ **-r**\ ) and stanza(\ **-z**\ ) in addition to the default format.
+
 \ **-**\ **-setup**\  flag is for switch-based switch discovery.  It will find all the discovery switches in the subnets, then matched with pre-defined switches in the xCATDB. It then set discovery switches with static ip address and hostname based on the pre-defined switch.  It also enables snmpv3 configuration. The detail of process is defined in the http://xcat-docs.readthedocs.io/en/latest/advanced/networks/switchdiscover/switches_discovery.html.
 
 To view all the switches defined in the xCAT databasee use \ **lsdef -w "nodetype=switch"**\  command.
@@ -166,9 +167,14 @@ EXAMPLES
  
 
 
-4. To process switch-based switch discovery, the core switch has to configure already and top-of-rack (edge) switch has to pre-define into xCAT databse with attribute switch and switchport to core switch:
- switchdiscover --range 192.168.5.150-170 -s snmp --setup
-
+4. To process switch-based switch discovery, the core switch has to configure already and top-of-rack (edge) switch has to pre-define into xCAT databse with attribute \ **switch**\  and \ **switchport**\  to core switch:
+ 
+ 
+ .. code-block:: perl
+ 
+   switchdiscover --range 192.168.5.150-170 -s snmp --setup
+ 
+ 
 
 
 

--- a/docs/source/guides/admin-guides/references/man1/switchdiscover.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/switchdiscover.1.rst
@@ -15,7 +15,7 @@ SYNOPSIS
 
 \ **switchdiscover [-v| -**\ **-version]**\ 
 
-\ **switchdiscover**\  [\ *noderange*\  | \ **-**\ **-range**\  \ *ip_ranges*\ ] \ **[-V] [-w][-r|-x|-z][-s**\  \ *scan_methods*\ ]
+\ **switchdiscover**\  [\ *noderange*\  | \ **-**\ **-range**\  \ *ip_ranges*\ ] \ **[-V] [-w][-r|-x|-z][-s**\  \ *scan_methods*\  \ **-**\ **-setup**\ ]
 
 
 ***********
@@ -23,7 +23,8 @@ DESCRIPTION
 ***********
 
 
-The switchdiscover command scans the subnets and discovers all the swithches on the subnets. The command takes a list of subnets as input. The default subnets are the ones that the xCAT management node is on. It uses nmap command as default to discover the switches. However, you can specify other discovery methods such as lldp or snmp with \ **-s**\  flag. You can write the discovered switches into xCAT database with \ **-w**\  flag. This command supports may output formats such as xml(\ **-x**\ ), raw(\ **-r**\ ) and stanza(\ **-z**\ ) in addition to the default format.
+The switchdiscover command scans the subnets and discovers all the swithches on the subnets. The command takes a list of subnets as input. The default subnets are the ones that the xCAT management node is on. It uses nmap command as default to discover the switches. However, you can specify other discovery methods such as lldp or snmp with \ **-s**\  flag. You can write the discovered switches into xCAT database with \ **-w**\  flag. This command supports may output formats such as xml(\ **-x**\ ), raw(\ **-r**\ ) and stanza(\ **-z**\ ) in addition to the default format.    
+\ **-**\ **-setup**\  flag is for switch-based switch discovery.  It will find all the discovery switches in the subnets, then matched with pre-defined switches in the xCATDB. It then set discovery switches with static ip address and hostname based on the pre-defined switch.  It also enables snmpv3 configuration. The detail of process is defined in the http://xcat-docs.readthedocs.io/en/latest/advanced/networks/switchdiscover/switches_discovery.html.
 
 To view all the switches defined in the xCAT databasee use \ **lsdef -w "nodetype=switch"**\  command.
 
@@ -110,6 +111,12 @@ OPTIONS
  
 
 
+\ **-**\ **-setup**\ 
+ 
+ Process switch-based switch discovery. Update discovered switch's ip address, hostname and enable snmpv3 configuration based on the pre-defined switch.
+ 
+
+
 
 ************
 RETURN VALUE
@@ -149,9 +156,7 @@ EXAMPLES
  
 
 
-3.
- 
- To use lldp method to discover the switches:
+3. To use lldp method to discover the switches:
  
  
  .. code-block:: perl
@@ -159,6 +164,11 @@ EXAMPLES
    switchdiscover -s lldp
  
  
+
+
+4. To process switch-based switch discovery, the core switch has to configure already and top-of-rack (edge) switch has to pre-define into xCAT databse with attribute switch and switchport to core switch:
+ switchdiscover --range 192.168.5.150-170 -s snmp --setup
+
 
 
 

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -303,7 +303,7 @@ my %usage = (
              [-u] [--range IPranges][-t tries][--vpdtable][-C counts][-T timeout]",
     "switchdiscover" =>
       "Usage: switchdiscover [-h|--help|-v|--version]
-       switchdiscover [<noderange>|--range ipranges] [-s scan_methods] [-r|-x|-z] [-w] [-V|--verbose]",
+       switchdiscover [<noderange>|--range ipranges] [-s scan_methods] [-r|-x|-z] [-w] [-V|--verbose] [--setup]",
     "switchprobe" =>
       "Usage: switchprobe [<noderange>] [-V|--verbose | -c|--check]",
     "makentp" =>

--- a/xCAT-client/pods/man1/switchdiscover.1.pod
+++ b/xCAT-client/pods/man1/switchdiscover.1.pod
@@ -18,7 +18,7 @@ B<switchdiscover> [I<noderange> | B<--range> I<ip_ranges>] B<[-V] [-w][-r|-x|-z]
 
 The switchdiscover command scans the subnets and discovers all the swithches on the subnets. The command takes a list of subnets as input. The default subnets are the ones that the xCAT management node is on. It uses nmap command as default to discover the switches. However, you can specify other discovery methods such as lldp or snmp with B<-s> flag. You can write the discovered switches into xCAT database with B<-w> flag. This command supports may output formats such as xml(B<-x>), raw(B<-r>) and stanza(B<-z>) in addition to the default format.    
 
-B<--setup> flag is for switch-based switch discovery.  It will find all the discovery switches in the subnets, then matched with pre-defined switches in the xCATDB. It then set discovery switches with static ip address and hostname based on the pre-defined switch.  It also enables snmpv3 configuration. The detail of process is defined in the http://xcat-docs.readthedocs.io/en/latest/advanced/networks/switchdiscover/switches_discovery.html.
+B<--setup> flag is for switch-based switch discovery.  It will find all the discovered switches on the subnets, then match them with predefined switches in the xCATDB. Next, it will set discovered switches with static ip address and hostname based on the predefined switch.  It will also enable snmpv3 configuration. The details of the process are defined in the http://xcat-docs.readthedocs.io/en/latest/advanced/networks/switchdiscover/switches_discovery.html.
 
 To view all the switches defined in the xCAT databasee use B<lsdef -w "nodetype=switch"> command.
 
@@ -85,7 +85,7 @@ Stanza formated output.
 
 =item B<--setup>
 
-Process switch-based switch discovery. Update discovered switch's ip address, hostname and enable snmpv3 configuration based on the pre-defined switch. 
+Process switch-based switch discovery. Update discovered switch's ip address, hostname and enable snmpv3 configuration based on the predefined switch. 
 
 =back
 
@@ -117,7 +117,7 @@ To use lldp method to discover the switches:
  switchdiscover -s lldp
 
 =item 4.
-To process switch-based switch discovery, the core switch has to configure already and top-of-rack (edge) switch has to pre-define into xCAT databse with attribute B<switch> and B<switchport> to core switch:
+To process switch-based switch discovery, the core switch has to be configured and top-of-rack (edge) switch has to be predefine into xCAT databse with attribute B<switch> and B<switchport> to core switch:
 
  switchdiscover --range 192.168.5.150-170 -s snmp --setup
 

--- a/xCAT-client/pods/man1/switchdiscover.1.pod
+++ b/xCAT-client/pods/man1/switchdiscover.1.pod
@@ -10,13 +10,14 @@ B<switchdiscover [-h| --help]>
 
 B<switchdiscover [-v| --version]>
 
-B<switchdiscover> [I<noderange> | B<--range> I<ip_ranges>] B<[-V] [-w][-r|-x|-z][-s> I<scan_methods>]
+B<switchdiscover> [I<noderange> | B<--range> I<ip_ranges>] B<[-V] [-w][-r|-x|-z][-s> I<scan_methods> B<--setup>]
 
 
 
 =head1 DESCRIPTION
 
 The switchdiscover command scans the subnets and discovers all the swithches on the subnets. The command takes a list of subnets as input. The default subnets are the ones that the xCAT management node is on. It uses nmap command as default to discover the switches. However, you can specify other discovery methods such as lldp or snmp with B<-s> flag. You can write the discovered switches into xCAT database with B<-w> flag. This command supports may output formats such as xml(B<-x>), raw(B<-r>) and stanza(B<-z>) in addition to the default format.    
+B<--setup> flag is for switch-based switch discovery.  It will find all the discovery switches in the subnets, then matched with pre-defined switches in the xCATDB. It then set discovery switches with static ip address and hostname based on the pre-defined switch.  It also enables snmpv3 configuration. The detail of process is defined in the http://xcat-docs.readthedocs.io/en/latest/advanced/networks/switchdiscover/switches_discovery.html.
 
 To view all the switches defined in the xCAT databasee use B<lsdef -w "nodetype=switch"> command.
 
@@ -81,6 +82,10 @@ XML formated output.
 
 Stanza formated output.
 
+=item B<--setup>
+
+Process switch-based switch discovery. Update discovered switch's ip address, hostname and enable snmpv3 configuration based on the pre-defined switch. 
+
 =back
 
 =head1 RETURN VALUE
@@ -106,10 +111,13 @@ To do the switch discovery and save them to the xCAT database:
 It is recommended to run B<makehosts> after the switches are saved in the DB.
 
 =item 3.
-
 To use lldp method to discover the switches:
 
  switchdiscover -s lldp
+
+=item 4.
+To process switch-based switch discovery, the core switch has to configure already and top-of-rack (edge) switch has to pre-define into xCAT databse with attribute switch and switchport to core switch:
+ switchdiscover --range 192.168.5.150-170 -s snmp --setup
 
 
 =back

--- a/xCAT-client/pods/man1/switchdiscover.1.pod
+++ b/xCAT-client/pods/man1/switchdiscover.1.pod
@@ -17,6 +17,7 @@ B<switchdiscover> [I<noderange> | B<--range> I<ip_ranges>] B<[-V] [-w][-r|-x|-z]
 =head1 DESCRIPTION
 
 The switchdiscover command scans the subnets and discovers all the swithches on the subnets. The command takes a list of subnets as input. The default subnets are the ones that the xCAT management node is on. It uses nmap command as default to discover the switches. However, you can specify other discovery methods such as lldp or snmp with B<-s> flag. You can write the discovered switches into xCAT database with B<-w> flag. This command supports may output formats such as xml(B<-x>), raw(B<-r>) and stanza(B<-z>) in addition to the default format.    
+
 B<--setup> flag is for switch-based switch discovery.  It will find all the discovery switches in the subnets, then matched with pre-defined switches in the xCATDB. It then set discovery switches with static ip address and hostname based on the pre-defined switch.  It also enables snmpv3 configuration. The detail of process is defined in the http://xcat-docs.readthedocs.io/en/latest/advanced/networks/switchdiscover/switches_discovery.html.
 
 To view all the switches defined in the xCAT databasee use B<lsdef -w "nodetype=switch"> command.
@@ -116,7 +117,8 @@ To use lldp method to discover the switches:
  switchdiscover -s lldp
 
 =item 4.
-To process switch-based switch discovery, the core switch has to configure already and top-of-rack (edge) switch has to pre-define into xCAT databse with attribute switch and switchport to core switch:
+To process switch-based switch discovery, the core switch has to configure already and top-of-rack (edge) switch has to pre-define into xCAT databse with attribute B<switch> and B<switchport> to core switch:
+
  switchdiscover --range 192.168.5.150-170 -s snmp --setup
 
 


### PR DESCRIPTION
For issue #1732 , the usage and man page are updated with --setup options.
Add a section to document switch-based switch discovery.  