### PR TITLE
Print before and after results of hack_uname() function

### DIFF
--- a/xCAT-server/share/xcat/ib/scripts/Mellanox/mlnxofed_ib_install.v2
+++ b/xCAT-server/share/xcat/ib/scripts/Mellanox/mlnxofed_ib_install.v2
@@ -137,7 +137,9 @@ echo "NODESETSTATE is $NODESETSTATE"
 
 function hack_uname()
 {
-    BEFORE_UNAME_HACK="$($1/bin/uname -r)"
+    BEFORE_UNAME_R="$($1/bin/uname -r)"
+    BEFORE_UNAME_M="$($1/bin/uname -m)"
+    echo "Before hack_uname(), -r=>'${BEFORE_UNAME_R}' -m=>'${BEFORE_UNAME_M}'"
     mv "$1/bin/uname" "$1/bin/uname.save"
     cat <<-EOF >"$1/bin/uname"
 		#!/bin/sh
@@ -165,8 +167,9 @@ function hack_uname()
 		EOF
 
     chmod 0755 "$1/bin/uname"
-    AFTER_UNAME_HACK="$($1/bin/uname -r)"
-    echo "Before hack-uname() to replace 'uname' command, 'uname -r'='${BEFORE_UNAME_HACK}'. After, 'uname -r'='${AFTER_UNAME_HACK}'"
+    AFTER_UNAME_R="$($1/bin/uname -r)"
+    AFTER_UNAME_M="$($1/bin/uname -m)"
+    echo "After  hack_uname(), -r='${AFTER_UNAME_R}', -m='${AFTER_UNAME_M}'"
 }
 
 function cleanup()

--- a/xCAT-server/share/xcat/ib/scripts/Mellanox/mlnxofed_ib_install.v2
+++ b/xCAT-server/share/xcat/ib/scripts/Mellanox/mlnxofed_ib_install.v2
@@ -137,6 +137,7 @@ echo "NODESETSTATE is $NODESETSTATE"
 
 function hack_uname()
 {
+    BEFORE_UNAME_HACK="$($1/bin/uname -r)"
     mv "$1/bin/uname" "$1/bin/uname.save"
     cat <<-EOF >"$1/bin/uname"
 		#!/bin/sh
@@ -164,6 +165,8 @@ function hack_uname()
 		EOF
 
     chmod 0755 "$1/bin/uname"
+    AFTER_UNAME_HACK="$($1/bin/uname -r)"
+    echo "Before hack-uname() to replace 'uname' command, 'uname -r'='${BEFORE_UNAME_HACK}'. After, 'uname -r'='${AFTER_UNAME_HACK}'"
 }
 
 function cleanup()


### PR DESCRIPTION
This pull request fixes one of the problems reported by issue #1816 
Print debug information for `uname -r` command before and after `hack_uname()`.

Output is:
`Before uname-hack() to change 'uname' command, 'uname -r'='3.10.0-327.el7.ppc64le'. After 'uname -r'='3.10.0-123.openpower5.el7.x86_64'`