### PR TITLE
Handle blank spaces in the addkit directory path name

### DIFF
--- a/xCAT-server/lib/xcat/plugins/kit.pm
+++ b/xCAT-server/lib/xcat/plugins/kit.pm
@@ -1268,7 +1268,7 @@ sub addkit
                 xCAT::MsgUtils->message("I", \%rsp, $callback);
             }
 
-            #avoid white space in the dir name
+            #support white space in the dir name
             $kit =~ s/(\s)/\\$1/g;
 
             $rc = system("tar jxvf $kit -C /tmp/tmpkit/");

--- a/xCAT-server/lib/xcat/plugins/kit.pm
+++ b/xCAT-server/lib/xcat/plugins/kit.pm
@@ -1268,7 +1268,7 @@ sub addkit
                 xCAT::MsgUtils->message("I", \%rsp, $callback);
             }
 
-            #avoid while space in the dir name
+            #avoid white space in the dir name
             $kit =~ s/(\s)/\\$1/g;
 
             $rc = system("tar jxvf $kit -C /tmp/tmpkit/");

--- a/xCAT-server/lib/xcat/plugins/kit.pm
+++ b/xCAT-server/lib/xcat/plugins/kit.pm
@@ -1267,6 +1267,10 @@ sub addkit
                 push @{ $rsp{data} }, "Extract Kit $kit to /tmp/tmpkit";
                 xCAT::MsgUtils->message("I", \%rsp, $callback);
             }
+
+            #avoid while space in the dir name
+            $kit =~ s/(\s)/\\$1/g;
+
             $rc = system("tar jxvf $kit -C /tmp/tmpkit/");
 
             opendir($dir, "/tmp/tmpkit/");


### PR DESCRIPTION
If kit located in the path and directory name has blank space , the addkit command will failed.
From issue#1815


