### PR TITLE
Fix doc version in `README.rst`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,10 +23,10 @@ Developers and prospective contributors are encouraged to read the `Developers G
 In particular the `GitHub <http://xcat-docs.readthedocs.io/en/latest/developers/github/>`_ related subsection.
 
 
-.. |docs_212| image:: https://readthedocs.org/projects/xcat-docs/badge/?version=2.12
-    :alt: 2.12 documentation status
+.. |docs_212| image:: https://readthedocs.org/projects/xcat-docs/badge/?version=2.12.0
+    :alt: 2.12.0 documentation status
     :scale: 100%
-    :target: http://xcat-docs.readthedocs.io/en/2.12/
+    :target: http://xcat-docs.readthedocs.io/en/2.12.0/
     
 .. |docs_211| image:: https://readthedocs.org/projects/xcat-docs/badge/?version=2.11
     :alt: 2.11 documentation status


### PR DESCRIPTION
Due to the changes in the release version tag of the documentation from `2.12` to `2.12.0`, the links listed in the README.rst are broken. This MR fixes it. Reference: #1786