### PR TITLE
fix issue rh7.3 and rh7.2 diskless image installation failed. #1855

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
@@ -1,13 +1,13 @@
 #!/bin/sh
 
-
 NEWROOT=$3
 RWDIR=.statelite
-XCATMASTER=$XCAT
 
 . /lib/dracut-lib.sh
-rootlimit="$(getarg rootlimit=)"
+XCAT="$(getarg XCAT=)"
+XCATMASTER=$XCAT
 
+rootlimit="$(getarg rootlimit=)"
 
 getarg nonodestatus
 NODESTATUS=$?
@@ -15,22 +15,21 @@ NODESTATUS=$?
 MASTER=`echo $XCATMASTER |awk -F: '{print $1}'`
 XCATIPORT="$(getarg XCATIPORT=)"
 if [ $? -ne 0 ]; then
-XCATIPORT="3002"
+    XCATIPORT="3002"
 fi
 
-
 xcatdebugmode="$(getarg xcatdebugmode=)"
-
 
 [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "running xcatroot...."
 [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "MASTER=$MASTER XCATIPORT=$XCATIPORT"
 
-
 if [ "$NODESTATUS" != "0" ]; then
 [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "nodestatus: netbooting,reporting..."
-/tmp/updateflag $MASTER $XCATIPORT "installstatus netbooting"
+    /tmp/updateflag $MASTER $XCATIPORT "installstatus netbooting"
 fi
 
+
+imgurl="$(getarg imgurl=)";
 if [ ! -z "$imgurl" ]; then
 	if [ xhttp = x${imgurl%%:*} ]; then
 		NFS=0
@@ -269,7 +268,7 @@ else
   e.g.:  -n tg3,aufs,loop,sunrpc,lockd,nfs_acl,nfs
 
 "
-  /bin/dash
+  /bin/sh
   exit
 fi
 cd /


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/1855:

1. since "systemd" dracut module has been included in the rh diskless initrd, we need to parse the "XCAT" and "imgurl" from /proc/cmdline inside initrd
2. when "xcatroot" failed to download rooting.gz and drop into emergency shell, "/bin/sh" should be used instead of "/bin/dash" 