### PR TITLE
bmcdiscover -i IP -u USERID -p PASSW0RD --ipsource failed

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -206,11 +206,10 @@ sub bmcdiscovery_processargs {
 
     ############################################
     # Option -U and -P for bmc user and password 
-    ############################################
     #
     # Get the default bmc account from passwd table, 
     # this is only done for the discovery process
-    #
+    ############################################
     ($bmc_user, $bmc_pass) = bmcaccount_from_passwd();
     # overwrite the default user and password if one is provided
     if ($::opt_U) {
@@ -348,7 +347,6 @@ sub get_bmc_ip_source {
     my $callback = $::CALLBACK;
     my $pcmd;
 
-
     if ($bmcuser eq "none") {
         $pcmd = "/opt/xcat/bin/ipmitool-xcat -vv -I lanplus -P $bmcpw -H $bmcip lan print ";
     }
@@ -359,7 +357,6 @@ sub get_bmc_ip_source {
     my $output = xCAT::Utils->runcmd("$pcmd", -1);
 
     if ($output =~ "IP Address Source") {
-
         # success case
         my $rsp      = {};
         my $ipsource = `echo "$output"|grep "IP Address Source"`;
@@ -371,11 +368,9 @@ sub get_bmc_ip_source {
     else {
         my $rsp = {};
         if ($output =~ $bmc_str1) {
-
             # Error: RAKP 2 message indicates an error : unauthorized name <== incorrect username
             push @{ $rsp->{data} }, "$bmc_resp1";
         } elsif ($output =~ $bmc_str2) {
-
             # Error: RAKP 2 HMAC is invalid <== incorrect password
             push @{ $rsp->{data} }, "$bmc_resp2";
         } else {
@@ -383,7 +378,6 @@ sub get_bmc_ip_source {
             if ($error_msg eq ""){
                 $error_msg = "Can not find IP address Source";
             }
-
             # all other errors
             push @{ $rsp->{data} }, "$error_msg";
         }

--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -207,8 +207,18 @@ sub bmcdiscovery_processargs {
     ############################################
     # Option -U and -P for bmc user and password 
     ############################################
+    #
+    # Get the default bmc account from passwd table, 
+    # this is only done for the discovery process
+    #
+    ($bmc_user, $bmc_pass) = bmcaccount_from_passwd();
+    # overwrite the default user and password if one is provided
     if ($::opt_U) {
         $bmc_user = $::opt_U;
+    } elsif ($::opt_P) {
+        # If password is provided, but no user, set the user to blank
+        # Support older FSP and Tuletta machines
+        $bmc_user = '';
     }
     if ($::opt_P) {
         $bmc_pass = $::opt_P;
@@ -244,23 +254,6 @@ sub bmcdiscovery_processargs {
             push @{ $rsp->{data} }, "\tThere is no nmap in /usr/bin/ or /usr/local/bin/. \n ";
             xCAT::MsgUtils->message("E", $rsp, $::CALLBACK);
             return 1;
-        }
-
-        #
-        # Get the default bmc account from passwd table, this is only done for the 
-        # discovery process
-        #
-        ($bmc_user, $bmc_pass) = bmcaccount_from_passwd();
-        # overwrite the default password if one is provided
-        if ($::opt_U) {
-            $bmc_user = $::opt_U;
-        } else {
-            # If password is provided, but no user, set the user to blank
-            # Support older FSP and Tuletta machines
-            $bmc_user = '';
-        }
-        if ($::opt_P) {
-            $bmc_pass = $::opt_P;
         }
 
         scan_process($::opt_M, $::opt_R, $::opt_Z, $::opt_W, $request_command);
@@ -303,7 +296,7 @@ sub bmcdiscovery_processargs {
     # --ipsource option, requires -i, -p to be specified
     ####################################################
     if (defined($::opt_S)) {
-        if (defined($bmc_user) && defined($bmc_pass) && defined($::opt_I)) {
+        if (defined($bmc_pass) && defined($::opt_I)) {
             my $res = get_bmc_ip_source($::opt_I, $bmc_user, $bmc_pass);
             return $res;
         }


### PR DESCRIPTION
for issue #1872,  the bmc_user and bmc_pass is uninitialized for --ipsource flag in the following code:
`````
if (defined($::opt_S)) {
        if (defined($bmc_user) && defined($bmc_pass) && defined($::opt_I)) {
            my $res = get_bmc_ip_source($::opt_I, $bmc_user, $bmc_pass);
            return $res;
        }
``````

The fixes are
1) initialized the bmc_user if $::opt_U is set
2) initialized the bmc_user if $::opt_P is set
3) command will return more meanfull error message