### PR TITLE
Support Predefine switch has same hostname as discovery

### DIFF
--- a/docs/source/advanced/networks/switchdiscover/switch_based_switch_discovery.rst
+++ b/docs/source/advanced/networks/switchdiscover/switch_based_switch_discovery.rst
@@ -48,7 +48,13 @@ In order to do switch-based switch discovery, the admin
       switchtype=BNT
 
 
-3.  Setup Dynamic IP range in network table for discovered switches to use. ::
+3.  Add switches to /etc/hosts for hostname lookup and xdsh command.  ::
+
+    makehosts switch-192-168-5-23
+    makehosts switch-192-168-5-22
+
+
+4.  Setup Dynamic IP range in network table for discovered switches to use. ::
 
      # tabdump networks
       #netname,net,mask,mgtifname,gateway,dhcpserver,tftpserver,nameservers,ntpservers,logservers,dynamicrange,staticrange,staticrangeincrement,nodehostname,ddnsdomain,vlanid,domain,comments,disable

--- a/xCAT-server/share/xcat/scripts/configBNT
+++ b/xCAT-server/share/xcat/scripts/configBNT
@@ -16,6 +16,7 @@ use strict;
 use Socket;
 use Getopt::Long;
 use Expect;
+use Net::Ping;
 use xCAT::Usage;
 use xCAT::NodeRange;
 use xCAT::NetworkUtils;
@@ -121,10 +122,33 @@ sub config_ip {
     foreach my $switch (@nodes) {
         print "change $switch to static ip address\n";
         my $dip= $nodehash->{$switch}->[0]->{otherinterfaces};
+        if (!$dip) {
+            print "Add otherinterfaces attribute for discover ip: chdef $switch otherinterfaces=x.x.x.x\n";
+            next;
+        }
+
+        #Validate if this IP is reachable
+        my $p = Net::Ping->new();
+        if (!$p->ping($dip)) {
+            print "$dip is not reachable\n";
+            next;
+        }
+
         my $static_ip= $nodehash->{$switch}->[0]->{ip};
+
+        # don't need to set if ip addresses are same
+        if ($dip eq $static_ip) {
+            print "static ip $static_ip and discovery ip $dip is same, will not process command for $switch\n";
+            next;
+        }
 
         #get hostname
         my $dswitch = xCAT::NetworkUtils->gethostname($dip);
+
+        # if hostnames are same, created different one for discovery name
+        if ($dswitch eq $switch) {
+            $dswitch="";
+        }
 
         #if not defined, need to create one for xdsh to use
         if (!$dswitch) {

--- a/xCAT-server/share/xcat/scripts/configMellanox
+++ b/xCAT-server/share/xcat/scripts/configMellanox
@@ -15,6 +15,7 @@ use lib "$::XCATROOT/lib/perl";
 use strict;
 use Getopt::Long;
 use Expect;
+use Net::Ping;
 use xCAT::Usage;
 use xCAT::NodeRange;
 use xCAT::NetworkUtils;
@@ -70,7 +71,7 @@ if ($::SWITCH)
         if (($switches_hash->{$fsw}->[0]->{switchtype}) =~ /Mellanox/) {
             push @nodes, $fsw;
         } else {
-            xCAT::MsgUtils->message("E","The $fsw is not BNT switch, will not config");
+            xCAT::MsgUtils->message("E","The $fsw is not Mellanox switch, will not config");
         }
     }
     unless (@nodes) {
@@ -118,11 +119,33 @@ sub config_ip {
     foreach my $switch (@nodes) {
         print "change $switch to static ip address\n";
         my $dip= $nodehash->{$switch}->[0]->{otherinterfaces};
+        if (!$dip) {
+            print "Add otherinterfaces attribute for discover ip: chdef $switch otherinterfaces=x.x.x.x\n";
+            next;
+        }
+
+        #Validate if this IP is reachable 
+        my $p = Net::Ping->new();
+        if (!$p->ping($dip)) {
+            print "$dip is not reachable\n";
+            next;
+        }
+ 
         my $static_ip= $nodehash->{$switch}->[0]->{ip};
+
+        # don't need to set if ip addresses are same
+        if ($dip eq $static_ip) {
+            print "static ip $static_ip and discovery ip $dip is same, will not process command for $switch\n";
+            next;
+        }
 
         #get hostname
         my $dswitch = xCAT::NetworkUtils->gethostname($dip);
-        print "dip=$dip, static=$static_ip, dsw=$dswitch\n";
+
+        # if hostnames are same, created different one for discovery name
+        if ($dswitch eq $switch) {
+            $dswitch="";
+        }
 
         #if not defined, need to create one for xdsh to use
         if (!$dswitch) {
@@ -247,11 +270,11 @@ sub run_rspconfig {
 sub usage
 {
     print "Usage:
-    configMellonax [-?│-h│--help] 
-    configMellonax [--switches switchnames] [--all]
-    configMellonax [--switches switchnames] [--ip]
-    configMellonax [--switches switchnames] [--name]
-    configMellonax [--switches switchnames] [--config]  
+    configMellanox [-?│-h│--help] 
+    configMellanox [--switches switchnames] [--all]
+    configMellanox [--switches switchnames] [--ip]
+    configMellanox [--switches switchnames] [--name]
+    configMellanox [--switches switchnames] [--config]  
     \n";
 }
 


### PR DESCRIPTION
#for issue 1878

If discovery switch hostname has same name with predefine switch name, the switchdiscovery --setup command will be failed and some of predefine switch's attributes will be removed.