### PR TITLE
fix todays development version of xcat has a dramatically longer netboot time. #1882

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
@@ -37,7 +37,7 @@ if [ ! -z "$imgurl" ]; then
 		while [ ! -r "$FILENAME" ]; do
             [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "downloading $imgurl...."
 			echo Getting $imgurl...
-			if ! wget $imgurl; then
+			if ! wget -nv $imgurl; then
                 [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "downloading $imgurl failed,retrying...."
 				rm -f $FILENAME
 				sleep 27

--- a/xCAT-server/share/xcat/netboot/sles/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/sles/dracut_033/xcatroot
@@ -36,7 +36,7 @@ if [ ! -z "$imgurl" ]; then
 		while [ ! -r "$FILENAME" ]; do
             [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "downloading $imgurl...."
 			echo Getting $imgurl...
-			if ! wget $imgurl; then
+			if ! wget -nv $imgurl; then
                 [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "downloading $imgurl failed,retrying...."
 				rm -f $FILENAME
 				sleep 27


### PR DESCRIPTION
fix https://github.com/xcat2/xcat-core/issues/1882:

add "-nv" option to suppress the verbose output of wget while downloading rootimg.gz inside the diskless initrd