### PR TITLE
Fix xCAT probe rpm install failed problem

### DIFF
--- a/xCAT-probe/lib/perl/LogParse.pm
+++ b/xCAT-probe/lib/perl/LogParse.pm
@@ -462,7 +462,7 @@ sub obtain_valid_log_start_point {
         %log_content
         $log_content{time}   : the timestamp of log, the format is epoch_seconds
         $log_content{sender} : the sender of log
-        $log_content{label}  : the label of log, such as $::LOGLABEL_DHCPD, $::LOGLABEL_TFTP.... refer to "probe_golbal_constant" for all kinds vaild labels 
+        $log_content{label}  : the label of log, such as $::LOGLABEL_DHCPD, $::LOGLABEL_TFTP.... refer to "probe_global_constant" for all kinds vaild labels 
         $log_content{msg}    : the main message of log
 =cut
 

--- a/xCAT-probe/lib/perl/probe_global_constant.pm
+++ b/xCAT-probe/lib/perl/probe_global_constant.pm
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # IBM(c) 2007 EPL license http://www.eclipse.org/legal/epl-v10.html
-package probe_golbal_constant;
+package probe_global_constant;
 
 #The type of log
 $::LOGTYPE_RSYSLOG = 0;    #rsyslog


### PR DESCRIPTION
Fix xCAT probe rpm install failed problem

    --> Finished Dependency Resolution
    Error: Package: 4:xCAT-probe-2.12.3-snap201609230616.noarch (xcat-2-core)
           Requires: perl(probe_global_constant)
    You could try using --skip-broken to work around the problem
    You could try running: rpm -Va --nofiles --nodigest