### PR TITLE
Update the master branch to have new build versioning and revert the release format

### DIFF
--- a/buildcore.sh
+++ b/buildcore.sh
@@ -172,9 +172,17 @@ else
 fi
 
 function setversionvars {
-    VER=`cat Version`
-    SHORTVER=`cat Version|cut -d. -f 1,2`
-    SHORTSHORTVER=`cat Version|cut -d. -f 1`
+    if [ ! -z "$USEGITVER" ]; then
+        VER=`git describe`
+        VER=${GITVER/-/.post}
+        VER=${VER/-/.}
+    else
+        VER=`cat Version`
+    fi
+    XCATVER=$VER
+    export XCATVER
+    SHORTVER=`echo $VER|cut -d. -f 1,2`
+    SHORTSHORTVER=`echo $VER|cut -d. -f 1`
     BUILD_TIME=`date`
     BUILD_MACHINE=`hostname`
     COMMIT_ID=`git rev-parse --short HEAD`

--- a/buildcore.sh
+++ b/buildcore.sh
@@ -174,7 +174,7 @@ fi
 function setversionvars {
     if [ ! -z "$USEGITVER" ]; then
         VER=`git describe`
-        VER=${GITVER/-/.post}
+        VER=${VER/-/.post}
         VER=${VER/-/.}
     else
         VER=`cat Version`

--- a/makegenesisbuilderrpm
+++ b/makegenesisbuilderrpm
@@ -1,5 +1,7 @@
 #!/bin/sh
-VER=`cat Version`
+VER=`git describe`
+VER=${VER/-/.post}
+VER=${VER/-/.}
 rpmbuild --version > /dev/null
 if [ $? -gt 0 ]
 then
@@ -20,4 +22,4 @@ cp LICENSE.html $RPMROOT/BUILD
 cp xCAT-genesis-builder.spec $RPMROOT/SOURCES
 cd -
 rm -f $RPMROOT/SRPMS/xCAT-genesis-builder-$VER*rpm $RPMROOT/RPMS/*/xCAT-genesis-builder-$VER*rpm
-rpmbuild -ba xCAT-genesis-builder/xCAT-genesis-builder.spec
+rpmbuild -ba xCAT-genesis-builder/xCAT-genesis-builder.spec --define "version $VER" --define "release 1"

--- a/makerpm
+++ b/makerpm
@@ -55,7 +55,7 @@ function makenoarch {
 
 		tar --exclude .svn -czf $RPMROOT/SOURCES/$RPMNAME-$VER.tar.gz $RPMNAME
 		rm -f $RPMROOT/SRPMS/$RPMNAME-$VER*rpm $RPMROOT/RPMS/noarch/$RPMNAME-$VER*rpm
-		rpmbuild $QUIET -ta $RPMROOT/SOURCES/$RPMNAME-$VER.tar.gz
+		rpmbuild $QUIET -ta $RPMROOT/SOURCES/$RPMNAME-$VER.tar.gz --define "version $VER" $RELEASE
 		RC=$?
 
 		if [ $RPMNAME = "xCAT-UI" ]; then
@@ -137,7 +137,7 @@ function makexcat {
 
 		rm -f $RPMROOT/SRPMS/$RPMNAME-$VER*rpm $RPMROOT/RPMS/$ARCH/$RPMNAME-$VER*rpm
 		echo "Building $RPMROOT/RPMS/$ARCH/$RPMNAME-$VER-snap*.$ARCH.rpm $EMBEDTXT..."
-		rpmbuild $QUIET -ba $RPMNAME/$RPMNAME.spec $TARGET
+		rpmbuild $QUIET -ba $RPMNAME/$RPMNAME.spec $TARGET --define "version $VER" $RELEASE
 		RC=$?
 	fi
 }
@@ -170,7 +170,7 @@ function makegenesis {
 	cd - >/dev/null
 	rm -f $RPMROOT/SRPMS/$RPMNAME-$VER*rpm $RPMROOT/RPMS/noarch/$RPMNAME-$VER*rpm
 	echo "Building $RPMROOT/RPMS/noarch/$RPMNAME-$VER-snap*.noarch.rpm $EMBEDTXT..."
-	rpmbuild $QUIET -ba $DIR/$RPMNAME.spec
+	rpmbuild $QUIET -ba $DIR/$RPMNAME.spec --define "version $VER" $RELEASE
 }
 
 function makegenesisscripts {
@@ -190,7 +190,7 @@ function makegenesisscripts {
 	cd - >/dev/null
 	rm -f $RPMROOT/SRPMS/$RPMNAME-$ARCH-$VER*rpm $RPMROOT/RPMS/noarch/$RPMNAME-$ARCH-$VER*rpm
 	echo "Building $RPMROOT/RPMS/noarch/$RPMNAME-$ARCH-$VER-snap*.noarch.rpm $EMBEDTXT..."
-	rpmbuild $QUIET -ba $DIR/$RPMNAME.spec $TARGET
+	rpmbuild $QUIET -ba $DIR/$RPMNAME.spec $TARGET --define "version $VER" $RELEASE
 }
 
 
@@ -213,7 +213,12 @@ if [ -z "$1" ]; then
 fi
 
 OSNAME=$(uname)
-VER=`cat Version`
+if [ -z "$XCATVER"] ; then
+	VER=`cat Version`
+        RELEASE="--define 'release 1'"
+else
+	VER=$XCATVER
+fi
 if [ "$VERBOSE" = "1" -o "$VERBOSE" = "yes" ];then
 	QUIET=""
 else

--- a/makerpm
+++ b/makerpm
@@ -55,7 +55,7 @@ function makenoarch {
 
 		tar --exclude .svn -czf $RPMROOT/SOURCES/$RPMNAME-$VER.tar.gz $RPMNAME
 		rm -f $RPMROOT/SRPMS/$RPMNAME-$VER*rpm $RPMROOT/RPMS/noarch/$RPMNAME-$VER*rpm
-		rpmbuild $QUIET -ta $RPMROOT/SOURCES/$RPMNAME-$VER.tar.gz --define "version $VER" $RELEASE
+		rpmbuild $QUIET -ta $RPMROOT/SOURCES/$RPMNAME-$VER.tar.gz --define "version $VER" $REL "$EASE"
 		RC=$?
 
 		if [ $RPMNAME = "xCAT-UI" ]; then
@@ -137,7 +137,7 @@ function makexcat {
 
 		rm -f $RPMROOT/SRPMS/$RPMNAME-$VER*rpm $RPMROOT/RPMS/$ARCH/$RPMNAME-$VER*rpm
 		echo "Building $RPMROOT/RPMS/$ARCH/$RPMNAME-$VER-snap*.$ARCH.rpm $EMBEDTXT..."
-		rpmbuild $QUIET -ba $RPMNAME/$RPMNAME.spec $TARGET --define "version $VER" $RELEASE
+		rpmbuild $QUIET -ba $RPMNAME/$RPMNAME.spec $TARGET --define "version $VER" $REL "$EASE"
 		RC=$?
 	fi
 }
@@ -170,7 +170,7 @@ function makegenesis {
 	cd - >/dev/null
 	rm -f $RPMROOT/SRPMS/$RPMNAME-$VER*rpm $RPMROOT/RPMS/noarch/$RPMNAME-$VER*rpm
 	echo "Building $RPMROOT/RPMS/noarch/$RPMNAME-$VER-snap*.noarch.rpm $EMBEDTXT..."
-	rpmbuild $QUIET -ba $DIR/$RPMNAME.spec --define "version $VER" $RELEASE
+	rpmbuild $QUIET -ba $DIR/$RPMNAME.spec --define "version $VER" $REL "$EASE"
 }
 
 function makegenesisscripts {
@@ -190,7 +190,7 @@ function makegenesisscripts {
 	cd - >/dev/null
 	rm -f $RPMROOT/SRPMS/$RPMNAME-$ARCH-$VER*rpm $RPMROOT/RPMS/noarch/$RPMNAME-$ARCH-$VER*rpm
 	echo "Building $RPMROOT/RPMS/noarch/$RPMNAME-$ARCH-$VER-snap*.noarch.rpm $EMBEDTXT..."
-	rpmbuild $QUIET -ba $DIR/$RPMNAME.spec $TARGET --define "version $VER" $RELEASE
+	rpmbuild $QUIET -ba $DIR/$RPMNAME.spec $TARGET --define "version $VER" $REL "$EASE"
 }
 
 
@@ -213,11 +213,12 @@ if [ -z "$1" ]; then
 fi
 
 OSNAME=$(uname)
-if [ -z "$XCATVER"] ; then
+if [ -z "$XCATVER" ] ; then
 	VER=`cat Version`
-        RELEASE="--define 'release 1'"
 else
 	VER=$XCATVER
+        REL="--define"
+	EASE='release 1'
 fi
 if [ "$VERBOSE" = "1" -o "$VERBOSE" = "yes" ];then
 	QUIET=""

--- a/makerpm
+++ b/makerpm
@@ -55,7 +55,7 @@ function makenoarch {
 
 		tar --exclude .svn -czf $RPMROOT/SOURCES/$RPMNAME-$VER.tar.gz $RPMNAME
 		rm -f $RPMROOT/SRPMS/$RPMNAME-$VER*rpm $RPMROOT/RPMS/noarch/$RPMNAME-$VER*rpm
-		rpmbuild $QUIET -ta $RPMROOT/SOURCES/$RPMNAME-$VER.tar.gz --define "version $VER" $REL "$EASE"
+		rpmbuild $QUIET -ta $RPMROOT/SOURCES/$RPMNAME-$VER.tar.gz --define "version $VER"
 		RC=$?
 
 		if [ $RPMNAME = "xCAT-UI" ]; then
@@ -137,7 +137,7 @@ function makexcat {
 
 		rm -f $RPMROOT/SRPMS/$RPMNAME-$VER*rpm $RPMROOT/RPMS/$ARCH/$RPMNAME-$VER*rpm
 		echo "Building $RPMROOT/RPMS/$ARCH/$RPMNAME-$VER-snap*.$ARCH.rpm $EMBEDTXT..."
-		rpmbuild $QUIET -ba $RPMNAME/$RPMNAME.spec $TARGET --define "version $VER" $REL "$EASE"
+		rpmbuild $QUIET -ba $RPMNAME/$RPMNAME.spec $TARGET --define "version $VER"
 		RC=$?
 	fi
 }
@@ -170,7 +170,7 @@ function makegenesis {
 	cd - >/dev/null
 	rm -f $RPMROOT/SRPMS/$RPMNAME-$VER*rpm $RPMROOT/RPMS/noarch/$RPMNAME-$VER*rpm
 	echo "Building $RPMROOT/RPMS/noarch/$RPMNAME-$VER-snap*.noarch.rpm $EMBEDTXT..."
-	rpmbuild $QUIET -ba $DIR/$RPMNAME.spec --define "version $VER" $REL "$EASE"
+	rpmbuild $QUIET -ba $DIR/$RPMNAME.spec --define "version $VER" 
 }
 
 function makegenesisscripts {
@@ -190,7 +190,7 @@ function makegenesisscripts {
 	cd - >/dev/null
 	rm -f $RPMROOT/SRPMS/$RPMNAME-$ARCH-$VER*rpm $RPMROOT/RPMS/noarch/$RPMNAME-$ARCH-$VER*rpm
 	echo "Building $RPMROOT/RPMS/noarch/$RPMNAME-$ARCH-$VER-snap*.noarch.rpm $EMBEDTXT..."
-	rpmbuild $QUIET -ba $DIR/$RPMNAME.spec $TARGET --define "version $VER" $REL "$EASE"
+	rpmbuild $QUIET -ba $DIR/$RPMNAME.spec $TARGET --define "version $VER" 
 }
 
 

--- a/perl-xCAT/perl-xCAT.spec
+++ b/perl-xCAT/perl-xCAT.spec
@@ -1,11 +1,11 @@
 Summary: xCAT perl libraries
 Name: perl-xCAT
-Version: %(cat Version)
-Release: snap%(date +"%Y%m%d%H%M")
+Version: %{?version:%{version}}%{!?version:%(cat Version)}
+Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
 Epoch: 4
 License: EPL
 Group: System Environment/Libraries
-Source: perl-xCAT-%(cat Version).tar.gz
+Source: perl-xCAT-%{version}.tar.gz
 Packager: IBM Corp.
 Vendor: IBM Corp.
 Distribution: %{?_distribution:%{_distribution}}%{!?_distribution:%{_vendor}}

--- a/xCAT-IBMhpc/xCAT-IBMhpc.spec
+++ b/xCAT-IBMhpc/xCAT-IBMhpc.spec
@@ -1,11 +1,11 @@
 Summary: Install and configuration utilities for IBM HPC products in an xCAT cluster
 Name: xCAT-IBMhpc
-Version: %(cat Version)
-Release: snap%(date +"%Y%m%d%H%M")
+Version: %{?version:%{version}}%{!?version:%(cat Version)}
+Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
 Epoch: 4
 License: EPL
 Group: Applications/System
-Source: xCAT-IBMhpc-%(cat Version).tar.gz
+Source: xCAT-IBMhpc-%{version}.tar.gz
 Packager: IBM Corp.
 Vendor: IBM Corp.
 Distribution: %{?_distribution:%{_distribution}}%{!?_distribution:%{_vendor}}
@@ -23,8 +23,8 @@ BuildArch: noarch
 #Requires: 
 %endif
 
-Requires: perl-xCAT >= %{epoch}:%(cat Version)
-Requires: xCAT-client  >= %{epoch}:%(cat Version|cut -d. -f 1,2)
+Requires: perl-xCAT >= %{epoch}:%{version}
+Requires: xCAT-client  >= %{epoch}:%{version}
 
 Provides: xCAT-IBMhpc = %{epoch}:%{version}
 

--- a/xCAT-OpenStack-baremetal/xCAT-OpenStack-baremetal.spec
+++ b/xCAT-OpenStack-baremetal/xCAT-OpenStack-baremetal.spec
@@ -1,7 +1,7 @@
 Summary: Executables and data of the xCAT baremetal driver for OpenStack
 Name: xCAT-OpenStack-baremetal
-Version: %(cat Version)
-Release: snap%(date +"%Y%m%d%H%M")
+Version: %{?version:%{version}}%{!?version:%(cat Version)}
+Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
 Epoch: 4
 License: IBM
 Group: Applications/System

--- a/xCAT-OpenStack/xCAT-OpenStack.spec
+++ b/xCAT-OpenStack/xCAT-OpenStack.spec
@@ -1,7 +1,7 @@
 Summary: Meta-Metapackage for a common, default xCAT management node setup with OpenStack 
 Name: xCAT-OpenStack
-Version: %(cat Version)
-Release: snap%(date +"%Y%m%d%H%M")
+Version: %{?version:%{version}}%{!?version:%(cat Version)}
+Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
 License: EPL
 Group: Applications/System
 Vendor: IBM Corp.
@@ -10,7 +10,7 @@ Distribution: %{?_distribution:%{_distribution}}%{!?_distribution:%{_vendor}}
 Prefix: /opt/xcat
 BuildRoot: /var/tmp/%{name}-%{version}-%{release}-root
 #BuildArch: noarch
-Source:  xCAT-OpenStack-%(cat Version).tar.gz
+Source:  xCAT-OpenStack-%{version}.tar.gz
 
 Provides: xCAT-OpenStack = %{version}
 Requires: xCAT

--- a/xCAT-SoftLayer/xCAT-SoftLayer.spec
+++ b/xCAT-SoftLayer/xCAT-SoftLayer.spec
@@ -1,11 +1,11 @@
 Summary: Utilities to make xCAT work in a SoftLayer environment
 Name: xCAT-SoftLayer
-Version: %(cat Version)
-Release: snap%(date +"%Y%m%d%H%M")
+Version: %{?version:%{version}}%{!?version:%(cat Version)}
+Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
 Epoch: 4
 License: EPL
 Group: Applications/System
-Source: xCAT-SoftLayer-%(cat Version).tar.gz
+Source: xCAT-SoftLayer-%{version}.tar.gz
 Packager: IBM Corp.
 Vendor: IBM Corp.
 Distribution: %{?_distribution:%{_distribution}}%{!?_distribution:%{_vendor}}
@@ -15,7 +15,6 @@ BuildRoot: /var/tmp/%{name}-%{version}-%{release}-root
 BuildArch: noarch
 %endif
 Requires: xCAT-server
-#Requires: xCAT-server  >= %{epoch}:%(cat Version|cut -d. -f 1,2)
 
 # perl-ExtUtils-MakeMaker, perl-CPAN, perl-Test-Harness are only available in rhel.
 # When this rpm supports being installed in sles, need to add these to xcat-dep.

--- a/xCAT-UI/xCAT-UI.spec
+++ b/xCAT-UI/xCAT-UI.spec
@@ -1,14 +1,14 @@
 Summary: Web Client for xCAT 2
 Name: xCAT-UI
-Version: %(cat Version)
-Release: snap%(date +"%Y%m%d%H%M")
+Version: %{?version:%{version}}%{!?version:%(cat Version)}
+Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
 License: EPL
 Group: Applications/System
 URL: http://xcat.org
 Packager: IBM
 Vendor: IBM
 
-Source: xCAT-UI-%(cat Version).tar.gz
+Source: xCAT-UI-%{version}.tar.gz
 BuildRoot: /var/tmp/%{name}-%{version}-%{release}-root
 %ifos linux
 BuildArch: noarch

--- a/xCAT-buildkit/xCAT-buildkit.spec
+++ b/xCAT-buildkit/xCAT-buildkit.spec
@@ -1,11 +1,11 @@
 Summary: xCAT buildkit tools and sample kit
 Name: xCAT-buildkit
-Version: %(cat Version)
-Release: snap%(date +"%Y%m%d%H%M")
+Version: %{?version:%{version}}%{!?version:%(cat Version)}
+Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
 Epoch: 4
 License: EPL
 Group: Applications/System
-Source: xCAT-buildkit-%(cat Version).tar.gz
+Source: xCAT-buildkit-%{version}.tar.gz
 Packager: IBM Corp.
 Vendor: IBM Corp.
 Distribution: %{?_distribution:%{_distribution}}%{!?_distribution:%{_vendor}}

--- a/xCAT-client/xCAT-client.spec
+++ b/xCAT-client/xCAT-client.spec
@@ -1,11 +1,11 @@
 Summary: Core executables and data of the xCAT management project
 Name: xCAT-client
-Version: %(cat Version)
-Release: snap%(date +"%Y%m%d%H%M")
+Version: %{?version:%{version}}%{!?version:%(cat Version)}
+Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
 Epoch: 4
 License: EPL
 Group: Applications/System
-Source: xCAT-client-%(cat Version).tar.gz
+Source: xCAT-client-%{version}.tar.gz
 Packager: IBM Corp.
 Vendor: IBM Corp.
 Distribution: %{?_distribution:%{_distribution}}%{!?_distribution:%{_vendor}}
@@ -23,7 +23,7 @@ BuildArch: noarch
 
 Provides: xCAT-client = %{epoch}:%{version}
 
-Requires: perl-xCAT >= %{epoch}:%(cat Version)
+Requires: perl-xCAT >= %{epoch}:%{version}
 
 # fping or nmap is needed by pping (in case xCAT-client is installed by itself on a remote client)
 %ifos linux

--- a/xCAT-confluent/xCAT-confluent.spec
+++ b/xCAT-confluent/xCAT-confluent.spec
@@ -1,11 +1,11 @@
 Summary: xCAT integration with confluent systems management server
 Name: xCAT-confluent
-Version: %(cat Version)
-Release: snap%(date +"%Y%m%d%H%M")
+Version: %{?version:%{version}}%{!?version:%(cat Version)}
+Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
 Epoch: 4
 License: EPL
 Group: Applications/System
-Source: xCAT-confluent-%(cat Version).tar.gz
+Source: xCAT-confluent-%{version}.tar.gz
 Packager: IBM Corp.
 Vendor: IBM Corp.
 Distribution: %{?_distribution:%{_distribution}}%{!?_distribution:%{_vendor}}

--- a/xCAT-genesis-builder/xCAT-genesis-base.spec
+++ b/xCAT-genesis-builder/xCAT-genesis-base.spec
@@ -16,7 +16,6 @@ BuildArch: noarch
 %define __prelink_undo_cmd %{nil}
 # To fix the issue error: Arch dependent binaries in noarch package, the following line is needed on Fedora 23 ppc64
 %define _binaries_in_noarch_packages_terminate_build   0
-Release: snap%(date +"%Y%m%d%H%M")
 Epoch: 1
 AutoReq: false
 Prefix: /opt/xcat
@@ -25,7 +24,6 @@ AutoProv: false
 
 
 Name:	 %{name}
-Version: %{version}
 Group: System/Utilities
 License: Various (see individual packages for details)
 Vendor: IBM Corp.

--- a/xCAT-genesis-builder/xCAT-genesis-base.spec
+++ b/xCAT-genesis-builder/xCAT-genesis-base.spec
@@ -1,4 +1,5 @@
-%define version	2.12
+Version: %{?version:%{version}}%{!?version:%(cat Version)}
+Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
 %ifarch i386 i586 i686 x86
 %define tarch x86
 %endif

--- a/xCAT-genesis-builder/xCAT-genesis-builder.spec
+++ b/xCAT-genesis-builder/xCAT-genesis-builder.spec
@@ -1,7 +1,7 @@
-%define version	%(cat Version)
 BuildArch: noarch
 %define name	xCAT-genesis-builder
-Release: snap%(date +"%Y%m%d%H%M")
+Version: %{?version:%{version}}%{!?version:%(cat Version)}
+Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
 Epoch: 1
 AutoReq: false
 Requires: ipmitool screen btrfs-progs lldpad rpm-build compat-libstdc++-33 mstflint xfsprogs nc reiserfs-utils

--- a/xCAT-genesis-builder/xCAT-genesis-builder.spec
+++ b/xCAT-genesis-builder/xCAT-genesis-builder.spec
@@ -11,7 +11,6 @@ AutoProv: false
 
 
 Name:	 %{name}
-Version: %{version}
 Group: System/Utilities
 License: EPL
 Vendor: IBM Corp.

--- a/xCAT-genesis-scripts/xCAT-genesis-scripts.spec
+++ b/xCAT-genesis-scripts/xCAT-genesis-scripts.spec
@@ -13,7 +13,8 @@ BuildArch: noarch
 %define __spec_install_post :
 %define debug_package %{nil}
 %define __prelink_undo_cmd %{nil}
-Release: snap%(date +"%Y%m%d%H%M")
+Version: %{?version:%{version}}%{!?version:%{version}}
+Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
 Epoch: 1
 AutoReq: false
 Prefix: /opt/xcat
@@ -24,7 +25,6 @@ Provides: xCAT-genesis-%{tarch}
 
 
 Name:	 %{name}
-Version: %(cat Version)
 Group: System/Utilities
 License: EPL
 Vendor: IBM Corp

--- a/xCAT-probe/xCAT-probe.spec
+++ b/xCAT-probe/xCAT-probe.spec
@@ -1,11 +1,11 @@
 Summary: xCAT diagnostic tool 
 Name: xCAT-probe
-Version: %(cat Version)
-Release: snap%(date +"%Y%m%d%H%M")
+Version: %{?version:%{version}}%{!?version:%(cat Version)}
+Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
 Epoch: 4
 License: EPL
 Group: Applications/System
-Source: xCAT-probe-%(cat Version).tar.gz
+Source: xCAT-probe-%{version}.tar.gz
 Packager: IBM Corp.
 Vendor: IBM Corp.
 Distribution: %{?_distribution:%{_distribution}}%{!?_distribution:%{_vendor}}

--- a/xCAT-rmc/xCAT-rmc.spec
+++ b/xCAT-rmc/xCAT-rmc.spec
@@ -1,11 +1,11 @@
 Summary: RMC monitoring plug-in for xCAT
 Name: xCAT-rmc
-Version: %(cat Version)
-Release: snap%(date +"%Y%m%d%H%M")
+Version: %{?version:%{version}}%{!?version:%(cat Version)}
+Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
 Epoch: 4
 License: EPL
 Group: System Environment/Libraries
-Source: xCAT-rmc-%(cat Version).tar.gz
+Source: xCAT-rmc-%{version}.tar.gz
 Packager: IBM Corp.
 Vendor: IBM Corp.
 Distribution: %{?_distribution:%{_distribution}}%{!?_distribution:%{_vendor}}
@@ -15,8 +15,8 @@ BuildRoot: /var/tmp/%{name}-%{version}-%{release}-root
 BuildArch: noarch
 %endif
 
-Requires: perl-xCAT >= %{epoch}:%(cat Version)
-Requires: xCAT-server  >= %{epoch}:%(cat Version|cut -d. -f 1,2)
+Requires: perl-xCAT >= %{epoch}:%{version}
+Requires: xCAT-server  >= %{epoch}:%{version}
 
 Provides: xCAT-rmc = %{version}
 

--- a/xCAT-server/xCAT-server.spec
+++ b/xCAT-server/xCAT-server.spec
@@ -1,11 +1,11 @@
 Summary: Server and configuration utilities of the xCAT management project
 Name: xCAT-server
-Version: %(cat Version)
-Release: snap%(date +"%Y%m%d%H%M")
+Version: %{?version:%{version}}%{!?version:%(cat Version)}
+Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
 Epoch: 4
 License: EPL
 Group: Applications/System
-Source: xCAT-server-%(cat Version).tar.gz
+Source: xCAT-server-%{version}.tar.gz
 Packager: IBM Corp.
 Vendor: IBM Corp.
 Distribution: %{?_distribution:%{_distribution}}%{!?_distribution:%{_vendor}}
@@ -48,8 +48,8 @@ Requires: perl-IO-Tty perl-Crypt-SSLeay make
 %endif
 
 
-Requires: perl-xCAT >= %{epoch}:%(cat Version)
-Requires: xCAT-client  >= %{epoch}:%(cat Version|cut -d. -f 1,2)
+Requires: perl-xCAT >= %{epoch}:%{version}
+Requires: xCAT-client  >= %{epoch}:%{version}
 
 Provides: xCAT-server = %{epoch}:%{version}
 

--- a/xCAT-test/xCAT-test.spec
+++ b/xCAT-test/xCAT-test.spec
@@ -1,11 +1,11 @@
 Summary: xCAT automated test tool
 Name: xCAT-test
-Version: %(cat Version)
-Release: snap%(date +"%Y%m%d%H%M")
+Version: %{?version:%{version}}%{!?version:%(cat Version)}
+Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
 Epoch: 4
 License: EPL
 Group: Applications/System
-Source: xCAT-test-%(cat Version).tar.gz
+Source: xCAT-test-%{version}.tar.gz
 Packager: IBM Corp.
 Vendor: IBM Corp.
 Distribution: %{?_distribution:%{_distribution}}%{!?_distribution:%{_vendor}}

--- a/xCAT-vlan/xCAT-vlan.spec
+++ b/xCAT-vlan/xCAT-vlan.spec
@@ -1,7 +1,7 @@
 Summary: Executables and data of the xCAT vlan management project
 Name: xCAT-vlan
-Version: %(cat Version)
-Release: snap%(date +"%Y%m%d%H%M")
+Version: %{?version:%{version}}%{!?version:%(cat Version)}
+Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
 Epoch: 4
 License: IBM
 Group: Applications/System

--- a/xCAT/xCAT.spec
+++ b/xCAT/xCAT.spec
@@ -1,7 +1,7 @@
 Summary: Meta-package for a common, default xCAT setup
 Name: xCAT
-Version: %(cat Version)
-Release: snap%(date +"%Y%m%d%H%M")
+Version: %{?version:%{version}}%{!?version:%(cat Version)}
+Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
 License: EPL
 Group: Applications/System
 Vendor: IBM Corp.

--- a/xCATsn/xCATsn.spec
+++ b/xCATsn/xCATsn.spec
@@ -1,7 +1,7 @@
 Summary: Metapackage for a common, default xCAT service node setup
 Name: xCATsn
-Version: %(cat Version)
-Release: snap%(date +"%Y%m%d%H%M")
+Version: %{?version:%{version}}%{!?version:%(cat Version)}
+Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
 Epoch: 4
 License: EPL
 Group: Applications/System


### PR DESCRIPTION
Cherry picked the changes from @jjohnson42  from the 2.12 branch up to master branch.  
Disabled the release field in `makerpm` so that we revert back to the older rpm naming convention. 

After the changes: 

```
./xcat-core/xCAT-2.12.3-snap201609280855.s390x.rpm
./xcat-core/xCATsn-2.12.3-snap201609280855.x86_64.rpm
./xcat-core/xCATsn-2.12.3-snap201609280855.ppc64le.rpm
./xcat-core/xCATsn-2.12.3-snap201609280855.ppc64.rpm
./xcat-core/xCATsn-2.12.3-snap201609280855.s390x.rpm
./xcat-core/perl-xCAT-2.12.3-snap201609280855.noarch.rpm
./xcat-core/xCAT-client-2.12.3-snap201609280855.noarch.rpm
./xcat-core/xCAT-server-2.12.3-snap201609280855.noarch.rpm
./xcat-core/xCAT-test-2.12.3-snap201609280855.noarch.rpm
./xcat-core/xCAT-buildkit-2.12.3-snap201609280855.noarch.rpm
./xcat-core/xCAT-SoftLayer-2.12.3-snap201609280855.noarch.rpm
./xcat-core/xCAT-vlan-2.12.3-snap201609280855.noarch.rpm
./xcat-core/xCAT-confluent-2.12.3-snap201609280855.noarch.rpm
./xcat-core/xCAT-probe-2.12.3-snap201609280855.noarch.rpm
./xcat-core/xCAT-genesis-scripts-ppc64-2.12.3-snap201609280855.noarch.rpm
./xcat-core/xCAT-genesis-scripts-x86_64-2.12.3-snap201609280855.noarch.rpm
./xcat-core/xCAT-2.12.3-snap201609280855.ppc64le.rpm
./xcat-core/xCAT-2.12.3-snap201609280855.ppc64.rpm
./xcat-core/xCAT-2.12.3-snap201609280855.x86_64.rpm
```

Partly resolves #1905