### PR TITLE
Add switch matching string from vendor to switchtype

### DIFF
--- a/xCAT-server/lib/xcat/plugins/switchdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/switchdiscover.pm
@@ -40,6 +40,7 @@ my %global_switch_type = (
     BNT => "BNT",
     Blade => "BNT",
     G8052 => "BNT",
+    RackSwitch => "BNT",
     Mellanox => "Mellanox",
     mellanox => "Mellanox",
     MLNX => "Mellanox",


### PR DESCRIPTION
fix issue #1906
Different BNT switch model has different vendor information output.
Add "RackSwitch" to identify BNT switch for the model G8264-T and G8124