### PR TITLE
Display errors for rmvm and mkvm

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/mkvm.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/mkvm.1.rst
@@ -81,13 +81,13 @@ For PPC (with HMC) specific:
 ============================
 
 
-The first form of mkvm command creates new partition(s) with the same profile/resources as the partition specified by \ *singlenode*\ . The -i and \ *noderange*\  specify the starting numeric partition number and the \ *noderange*\  for the newly created partitions, respectively. The LHEA port numbers and the HCA index numbers will be automatically increased if they are defined in the source partition.
+The first form of \ **mkvm**\  command creates new partition(s) with the same profile/resources as the partition specified by \ *singlenode*\ . The -i and \ *noderange*\  specify the starting numeric partition number and the \ *noderange*\  for the newly created partitions, respectively. The LHEA port numbers and the HCA index numbers will be automatically increased if they are defined in the source partition.
 
 The second form of this command duplicates all the partitions from the source specified by \ *profile*\  to the destination specified by \ *destcec*\ . The source and destination CECs can be managed by different HMCs.
 
 Please make sure the nodes in the \ *noderange*\  is defined in the \ *nodelist*\  table and the \ *mgt*\  is set to 'hmc' in the \ *nodehm*\  table before running this command.
 
-Please note that the mkvm command currently only supports creating standard LPARs, not virtual LPARs working with VIOS server.
+Please note that the \ **mkvm**\  command currently only supports creating standard LPARs, not virtual LPARs working with VIOS server.
 
 
 For PPC (using Direct FSP Management) specific:
@@ -103,16 +103,14 @@ For KVM and Vmware:
 ===================
 
 
-The mkvm command creates new virtual machine(s) with the \ *disksize*\  size of hard disk, \ *memsize*\  size of memory and \ *cpucount*\  number of cpu.
-
-For KVM: If \ **-f | -**\ **-force**\  is specified, the storage will be destroyed first if it existed.
+The \ **mkvm**\  command creates new virtual machine(s) with the \ *disksize*\  size of hard disk, \ *memsize*\  size of memory and \ *cpucount*\  number of cpu.
 
 
 For zVM:
 ========
 
 
-The first form of mkvm creates a new virtual machine based on a directory entry.
+The first form of \ **mkvm**\  creates a new virtual machine based on a directory entry.
 
 The second form of this creates a new virtual machine with the same profile/resources as the specified node (cloning).
 
@@ -158,7 +156,7 @@ OPTIONS
 
 \ **-f|-**\ **-force**\ 
  
- If \ **-f|-**\ **-force**\  is specified, the storage will be destroyed first if it existed.
+ If the storage already exists, remove it before creating a new virtual machine.
  
 
 

--- a/docs/source/guides/admin-guides/references/man1/mkvm.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/mkvm.1.rst
@@ -55,7 +55,7 @@ For KVM:
 \ **mkvm**\  \ *noderange*\  [\ **-s|-**\ **-size**\  \ *disksize*\ ] [\ **-**\ **-mem**\  \ *memsize*\ ] [\ **-**\ **-cpus**\  \ *cpucount*\ ] [\ **-f|-**\ **-force**\ ]
 
 
-For Vmware:
+For VMware:
 ===========
 
 
@@ -99,7 +99,7 @@ With option \ *full*\ , a partition using all the resources on a normal power ma
 If no option is specified, a partition using the parameters specified with attributes such as 'vmcpus', 'vmmory', 'vmphyslots', 'vmothersetting', 'vmnics', 'vmstorage' will be created. Those attributes can either be specified with '\*def' commands running before or be specified with this command.
 
 
-For KVM and Vmware:
+For KVM and VMware:
 ===================
 
 

--- a/xCAT-client/pods/man1/mkvm.1.pod
+++ b/xCAT-client/pods/man1/mkvm.1.pod
@@ -42,13 +42,13 @@ B<mkvm> I<noderange> [I<source_virtual_machine>] [B<pool=> I<disk_pool>]
 
 =head2 For PPC (with HMC) specific:
 
-The first form of mkvm command creates new partition(s) with the same profile/resources as the partition specified by I<singlenode>. The -i and I<noderange> specify the starting numeric partition number and the I<noderange> for the newly created partitions, respectively. The LHEA port numbers and the HCA index numbers will be automatically increased if they are defined in the source partition. 
+The first form of B<mkvm> command creates new partition(s) with the same profile/resources as the partition specified by I<singlenode>. The -i and I<noderange> specify the starting numeric partition number and the I<noderange> for the newly created partitions, respectively. The LHEA port numbers and the HCA index numbers will be automatically increased if they are defined in the source partition. 
 
 The second form of this command duplicates all the partitions from the source specified by I<profile> to the destination specified by I<destcec>. The source and destination CECs can be managed by different HMCs.
 
 Please make sure the nodes in the I<noderange> is defined in the I<nodelist> table and the I<mgt> is set to 'hmc' in the I<nodehm> table before running this command.
 
-Please note that the mkvm command currently only supports creating standard LPARs, not virtual LPARs working with VIOS server.
+Please note that the B<mkvm> command currently only supports creating standard LPARs, not virtual LPARs working with VIOS server.
 
 =head2 For PPC (using Direct FSP Management) specific:
 
@@ -58,13 +58,11 @@ If no option is specified, a partition using the parameters specified with attri
 
 =head2 For KVM and Vmware:
 
-The mkvm command creates new virtual machine(s) with the I<disksize> size of hard disk, I<memsize> size of memory and I<cpucount> number of cpu. 
+The B<mkvm> command creates new virtual machine(s) with the I<disksize> size of hard disk, I<memsize> size of memory and I<cpucount> number of cpu. 
 
-For KVM: If B<-f>|B<--force> is specified, the storage will be destroyed first if it existed.
- 
 =head2 For zVM:
 
-The first form of mkvm creates a new virtual machine based on a directory entry.
+The first form of B<mkvm> creates a new virtual machine based on a directory entry.
 
 The second form of this creates a new virtual machine with the same profile/resources as the specified node (cloning).
 
@@ -96,7 +94,7 @@ The option I<vios> is used to specify the partition that will be created is a VI
 
 =item B<-f|--force>
 
-If B<-f|--force> is specified, the storage will be destroyed first if it existed.
+If the storage already exists, remove it before creating a new virtual machine.
 
 =item B<-i>              
 

--- a/xCAT-client/pods/man1/mkvm.1.pod
+++ b/xCAT-client/pods/man1/mkvm.1.pod
@@ -28,7 +28,7 @@ B<mkvm> I<noderange> [B<vmcpus=> I<min/req/max>] [B<vmmemory=> I<min/req/max>] [
 
 B<mkvm> I<noderange> [B<-s|--size> I<disksize>] [B<--mem> I<memsize>] [B<--cpus> I<cpucount>] [B<-f|--force>]
 
-=head2 For Vmware:
+=head2 For VMware:
 
 B<mkvm> I<noderange> [B<-s>|B<--size> I<disksize>] [B<--mem> I<memsize>] [B<--cpus> I<cpucount>]
 
@@ -56,7 +56,7 @@ With option I<full>, a partition using all the resources on a normal power machi
 
 If no option is specified, a partition using the parameters specified with attributes such as 'vmcpus', 'vmmory', 'vmphyslots', 'vmothersetting', 'vmnics', 'vmstorage' will be created. Those attributes can either be specified with '*def' commands running before or be specified with this command.
 
-=head2 For KVM and Vmware:
+=head2 For KVM and VMware:
 
 The B<mkvm> command creates new virtual machine(s) with the I<disksize> size of hard disk, I<memsize> size of memory and I<cpucount> number of cpu. 
 

--- a/xCAT-server/lib/xcat/plugins/kvm.pm
+++ b/xCAT-server/lib/xcat/plugins/kvm.pm
@@ -1760,6 +1760,10 @@ sub rmvm {
         }
     } else {
         $currxml = $confdata->{kvmnodedata}->{$node}->[0]->{xml};
+        unless ($currxml) {
+            xCAT::SvrUtils::sendmsg([ 1, "Cannot remove guest, no such vm" ], $callback, $node);
+            return;
+        }
     }
     if ($purge and $currxml) {
         my $deadman    = $parser->parse_string($currxml);
@@ -3048,8 +3052,9 @@ sub mkvm {
                 @return = createstorage($diskname, $mastername, $disksize, $confdata->{vm}->{$node}->[0], $force);
             };
             if ($@) {
-                if ($@ =~ /ath already exists/) {
-                    return 1, "Storage creation request conflicts with existing file(s)";
+                if ($@ =~ /Path (\S+) already exists at /) {
+                    return 1, "Storage creation request conflicts with existing file(s) $1 (use mkvm with -f argument to remove)";
+
                 } else {
                     return 1, "Unknown issue $@";
                 }

--- a/xCAT-server/lib/xcat/plugins/kvm.pm
+++ b/xCAT-server/lib/xcat/plugins/kvm.pm
@@ -1761,7 +1761,7 @@ sub rmvm {
     } else {
         $currxml = $confdata->{kvmnodedata}->{$node}->[0]->{xml};
         unless ($currxml) {
-            xCAT::SvrUtils::sendmsg([ 1, "Cannot remove guest, no such vm" ], $callback, $node);
+            xCAT::SvrUtils::sendmsg([ 1, "Cannot remove guest vm, no such vm found" ], $callback, $node);
             return;
         }
     }
@@ -3053,7 +3053,7 @@ sub mkvm {
             };
             if ($@) {
                 if ($@ =~ /Path (\S+) already exists at /) {
-                    return 1, "Storage creation request conflicts with existing file(s) $1 (use mkvm with -f argument to remove)";
+                    return 1, "Storage creation request conflicts with existing file(s) $1. To force remove the existing storage file, rerun mkvm with the -f option.";
 
                 } else {
                     return 1, "Unknown issue $@";


### PR DESCRIPTION
This pull request:
* Fixes some formatting and wording issues for mkvm man page
* Displays an error and RC=1 when rmvm is issued for a non-existent vm.
```
[root@fs2vm100 gurevich]# rmvm RHEL72generatedvm1
[root@fs2vm100 gurevich]# echo $?
0
[root@fs2vm100 gurevich]# rmvm RHEL72generatedvm1
RHEL72generatedvm1: Error: Cannot remove guest, no such vm
[root@fs2vm100 gurevich]# echo $?
1

```
* Display a better message and RC=1 when mkvm is issued and there still a disk left over from previous vm by the same name.

Old message:
```
[root@fs2vm100 gurevich]# mkvm RHEL72generatedvm1 -s 5G
RHEL72generatedvm1: Error: Unknown issue Path RHEL72generatedvm1.sda.qcow2 already exists at /opt/xcat/lib/perl/xCAT_plugin/kvm.pm line 318.
```

New message:
```
[root@fs2vm100 gurevich]# mkvm RHEL72generatedvm1 -s 5G
RHEL72generatedvm1: Error: Storage creation request conflicts with existing file(s) RHEL72generatedvm1.sda.qcow2 (use mkvm with -f argument to remove)
[root@fs2vm100 gurevich]# echo $?
1

```