### PR TITLE
Remove -t option for bmcdiscover and used by default

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/discovery/mtms/discovery_using_defined.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/discovery/mtms/discovery_using_defined.rst
@@ -27,7 +27,7 @@ The BMC IP address is obtained by the open range dhcp server and the plan in thi
 
 #. Detect the BMCs and add the node definitions into xCAT.
 
-   Use the ``bmcdiscover`` command to discover the BMCs responding over an IP range and automatically write the output into the xCAT database.  You **must** use the ``-t`` option to indicate node type is bmc and the ``-w`` option to automatically write the output into the xCAT database. 
+   Use the ``bmcdiscover`` command to discover the BMCs responding over an IP range and automatically write the output into the xCAT database.  You **must** use the ``-w`` option to automatically write the output into the xCAT database. 
 
    To discover the BMC with an IP address of 172.30.0.1, use the command: ::
 

--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/discovery/mtms/discovery_using_defined.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/discovery/mtms/discovery_using_defined.rst
@@ -31,7 +31,7 @@ The BMC IP address is obtained by the open range dhcp server and the plan in thi
 
    To discover the BMC with an IP address of 172.30.0.1, use the command: ::
 
-      bmcdiscover --range 172.30.0.1 -t -z -w 
+      bmcdiscover --range 172.30.0.1 -z -w 
 
    The discovered nodes will be written to xCAT database: ::
 

--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/discovery/mtms/discovery_using_defined.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/discovery/mtms/discovery_using_defined.rst
@@ -47,6 +47,7 @@ The BMC IP address is obtained by the open range dhcp server and the plan in thi
           postbootscripts=otherpkgs
           postscripts=syslog,remoteshell,syncfiles
           serial=10112CA
+          nodetype=mp
 
 
 #. **Pre-define** the compute nodes:
@@ -68,6 +69,8 @@ The BMC IP address is obtained by the open range dhcp server and the plan in thi
         mgt=ipmi
         mtm=8247-22L
         serial=10112CA
+        nodetype=mp
+        hwtype=bmc
 
 
 #. Edit the ``predefined.stanzas`` file and change the discovered nodes to the intended ``hostname`` and ``IP address``. 
@@ -83,6 +86,8 @@ The BMC IP address is obtained by the open range dhcp server and the plan in thi
     #. Add a ``ip`` attribute and give it the compute node IP address: ::
 
           ip=10.1.2.1
+
+    #. Remove ``nodetype`` and ``hwtype`` from ``predefined.stanza`` file based on the MTMS mapping.
 
     #. Repeat for additional nodes in the ``predefined.stanza`` file based on the MTMS mapping.
 

--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/discovery/pbmc_discovery_with_bmcdiscover.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/discovery/pbmc_discovery_with_bmcdiscover.rst
@@ -5,7 +5,7 @@ After environment is ready, and the server is powered, we can start server disco
 
 The following command can be used to discovery BMC within an IP range and write the discovered node definition into xCAT database::
 
-    bmcdiscover -s nmap --range 50.0.100.1-100 -t -z -w
+    bmcdiscover -s nmap --range 50.0.100.1-100 -z -w
 
 The discovered BMC node will be like this::
 
@@ -27,7 +27,7 @@ The discovered BMC node will be like this::
     
     2. bmcdiscover will use username/password pair set in ``passwd`` table with **key** equal **ipmi**. If you'd like to use other username/password pair, you can use ::
 
-        bmcdiscover -s nmap --range 50.0.100.1-100 -t -z -w -u <username> -p <password>
+        bmcdiscover -s nmap --range 50.0.100.1-100 -z -w -u <username> -p <password>
 
 Start discovery process
 -----------------------

--- a/docs/source/guides/admin-guides/references/man1/bmcdiscover.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/bmcdiscover.1.rst
@@ -23,7 +23,7 @@ SYNOPSIS
 
 \ **bmcdiscover**\  [\ **-v | -**\ **-version**\ ]
 
-\ **bmcdiscover**\  [\ **-s**\  \ *scan_method*\ ] [\ **-u**\  \ *bmc_user*\ ] [\ **-p**\  \ *bmc_passwd*\ ] [\ **-z**\ ] [\ **-w**\ ] [\ **-t**\ ] \ **-**\ **-range**\  \ *ip_ranges*\ 
+\ **bmcdiscover**\  [\ **-s**\  \ *scan_method*\ ] [\ **-u**\  \ *bmc_user*\ ] [\ **-p**\  \ *bmc_passwd*\ ] [\ **-z**\ ] [\ **-w**\ ] \ **-**\ **-range**\  \ *ip_ranges*\ 
 
 \ **bmcdiscover**\  \ **-u**\  \ *bmc_user*\  \ **-p**\  \ *bmc_passwd*\  \ **-i**\  \ *bmc_ip*\  \ **-**\ **-check**\ 
 
@@ -71,12 +71,6 @@ OPTIONS
 \ **-w**\ 
  
  Write to the xCAT database.
- 
-
-
-\ **-t**\ 
- 
- Generate a BMC type node object
  
 
 

--- a/xCAT-client/pods/man1/bmcdiscover.1.pod
+++ b/xCAT-client/pods/man1/bmcdiscover.1.pod
@@ -8,7 +8,7 @@ B<bmcdiscover> [B<-?>|B<-h>|B<--help>]
 
 B<bmcdiscover> [B<-v>|B<--version>]
 
-B<bmcdiscover> [B<-s> I<scan_method>] [B<-u> I<bmc_user>] [B<-p> I<bmc_passwd>] [B<-z>] [B<-w>] [B<-t>] B<--range> I<ip_ranges>
+B<bmcdiscover> [B<-s> I<scan_method>] [B<-u> I<bmc_user>] [B<-p> I<bmc_passwd>] [B<-z>] [B<-w>] B<--range> I<ip_ranges>
 
 B<bmcdiscover> B<-u> I<bmc_user> B<-p> I<bmc_passwd> B<-i> I<bmc_ip> B<--check>
 
@@ -44,10 +44,6 @@ List the data returned in xCAT stanza format
 =item B<-w>            
 
 Write to the xCAT database.
-
-=item B<-t>
-
-Generate a BMC type node object
 
 =item B<-i|--bmcip>    
 

--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -115,7 +115,7 @@ sub bmcdiscovery_usage {
     push @{ $rsp->{data} }, "Usage:";
     push @{ $rsp->{data} }, "\tbmcdiscover [-?|-h|--help]";
     push @{ $rsp->{data} }, "\tbmcdiscover [-v|--version]";
-    push @{ $rsp->{data} }, "\tbmcdiscover [-s scan_method] [-u bmc_user] [-p bmc_passwd] [-z] [-w] [-t] --range ip_range\n";
+    push @{ $rsp->{data} }, "\tbmcdiscover [-s scan_method] [-u bmc_user] [-p bmc_passwd] [-z] [-w] --range ip_range\n";
 
     push @{ $rsp->{data} }, "\tCheck BMC administrator User/Password:\n";
     push @{ $rsp->{data} }, "\t\tbmcdiscover -u bmc_user -p bmc_password -i bmc_ip --check\n";
@@ -168,7 +168,6 @@ sub bmcdiscovery_processargs {
         'bmcpasswd|p=s' => \$::opt_P,
         'ipsource'      => \$::opt_S,
         'version|v'     => \$::opt_v,
-        't'             => \$::opt_T,
     );
 
     if (!$getopt_success) {
@@ -935,9 +934,7 @@ sub bmcdiscovery_ipmi {
             } else {
                 $ip .= ",,";
             }
-            if ($::opt_T) {
-                $ip .= ",mp,bmc";
-            }
+            $ip .= ",mp,bmc";
             if ($mtm and $serial) {
                 $node = "node-$mtm-$serial";
                 $node =~ s/(.*)/\L$1/g;

--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -256,10 +256,10 @@ sub bmcdiscovery_processargs {
         }
 
         if ($::opt_T) {
-            my $msg = "WARN: The -t option is deprecated and will be ignored";
+            my $msg = "The -t option is deprecated and will be ignored";
             my $rsp = {};
             push @{ $rsp->{data} }, "$msg";
-            xCAT::MsgUtils->message("I", $rsp, $::CALLBACK);
+            xCAT::MsgUtils->message("W", $rsp, $::CALLBACK);
         }
 
         scan_process($::opt_M, $::opt_R, $::opt_Z, $::opt_W, $request_command);

--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -168,6 +168,7 @@ sub bmcdiscovery_processargs {
         'bmcpasswd|p=s' => \$::opt_P,
         'ipsource'      => \$::opt_S,
         'version|v'     => \$::opt_v,
+        't'             => \$::opt_T,
     );
 
     if (!$getopt_success) {
@@ -252,6 +253,13 @@ sub bmcdiscovery_processargs {
             push @{ $rsp->{data} }, "\tThere is no nmap in /usr/bin/ or /usr/local/bin/. \n ";
             xCAT::MsgUtils->message("E", $rsp, $::CALLBACK);
             return 1;
+        }
+
+        if ($::opt_T) {
+            my $msg = "WARN: The -t option is deprecated and will be ignored";
+            my $rsp = {};
+            push @{ $rsp->{data} }, "$msg";
+            xCAT::MsgUtils->message("I", $rsp, $::CALLBACK);
         }
 
         scan_process($::opt_M, $::opt_R, $::opt_Z, $::opt_W, $request_command);


### PR DESCRIPTION
For issue #1853 .

change "-t " option to default for bmcdiscover command
`````
# bmcdiscover --range 50.0.0.1-5 -z
node-8335-gtb-100470a:
        objtype=node
        groups=all
        bmc=50.0.0.5
        cons=ipmi
        mgt=ipmi
        mtm=8335-GTB
        serial=100470A
        nodetype=mp
        hwtype=bmc
```````