### PR TITLE
Don't need to update otherpkgdir to default dir for genimage command

### DIFF
--- a/xCAT-server/share/xcat/netboot/debian/genimage
+++ b/xCAT-server/share/xcat/netboot/debian/genimage
@@ -119,7 +119,7 @@ $updates{'pkgdir'} = $srcdir if ($tempfile);
 if (!$srcdir_otherpkgs) {
     $srcdir_otherpkgs = "$installroot/post/otherpkgs/$osver/$arch";
 }
-$updates{'otherpkgdir'} = $srcdir_otherpkgs if ($tempfile);
+#$updates{'otherpkgdir'} = $srcdir_otherpkgs if ($tempfile);
 
 if (!$destdir)
 {

--- a/xCAT-server/share/xcat/netboot/fedora12/genimage
+++ b/xCAT-server/share/xcat/netboot/fedora12/genimage
@@ -122,7 +122,7 @@ $updates{'pkgdir'} = $srcdir if ($tempfile);
 if (!$srcdir_otherpkgs) {
     $srcdir_otherpkgs = "$installroot/post/otherpkgs/$osver/$arch";
 }
-$updates{'otherpkgdir'} = $srcdir_otherpkgs if ($tempfile);
+#$updates{'otherpkgdir'} = $srcdir_otherpkgs if ($tempfile);
 
 if (!$destdir)
 {

--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -189,7 +189,7 @@ $srcdir = "$installroot/$osver/$arch" unless ($srcdir);
 $updates{'pkgdir'} = $srcdir if ($tempfile);
 
 $srcdir_otherpkgs = "$installroot/post/otherpkgs/$osver/$arch" unless ($srcdir_otherpkgs);
-$updates{'otherpkgdir'} = $srcdir_otherpkgs if ($tempfile);
+#$updates{'otherpkgdir'} = $srcdir_otherpkgs if ($tempfile);
 
 $destdir = "$installroot/netboot/$osver/$arch/$profile" unless ($destdir);
 $updates{'rootimgdir'} = $destdir if ($tempfile);

--- a/xCAT-server/share/xcat/netboot/sles/genimage
+++ b/xCAT-server/share/xcat/netboot/sles/genimage
@@ -140,7 +140,7 @@ $updates{'pkgdir'} = $srcdir if ($tempfile);
 #$srcdir = $srcdir . "/1";
 
 $srcdir_otherpkgs = "$installroot/post/otherpkgs/$osver/$arch" unless ($srcdir_otherpkgs);
-$updates{'otherpkgdir'} = $srcdir_otherpkgs if ($tempfile);
+#$updates{'otherpkgdir'} = $srcdir_otherpkgs if ($tempfile);
 
 $destdir = "$installroot/netboot/$osver/$arch/$profile" unless ($destdir);
 $updates{'rootimgdir'} = $destdir if ($tempfile);


### PR DESCRIPTION
for issue #1948 .

genimage will not add otherpkgdir to default directory if there is no otherpkgdir specified in the osimage.