### PR TITLE
osimagecheck probe enhancements

### DIFF
--- a/xCAT-probe/subcmds/osimagecheck
+++ b/xCAT-probe/subcmds/osimagecheck
@@ -9,7 +9,7 @@ use File::Basename;
 use Net::Ping;
 use Getopt::Long qw(:config no_ignore_case);
 
-#use Data::Dumper;
+use Data::Dumper;
 use warnings;
 
 my $program_name = basename("$0");
@@ -120,15 +120,15 @@ sub check_for_duplicate_rootimgdir {
             my @list_of_osimages = split ",", $rootimgdir_osimage_hash{$rootimgdirpath};
             if (scalar(@list_of_osimages) > 1) {
                 # More than one entry in the hash value, means we
-                # have more than on osimage point to the same rootimgdir
+                # have more than one osimage point to the same rootimgdir
                 my $print_list = join("\n  ",@list_of_osimages);
                 $rootimgdirpath=~s/^\s+//; #discard leading space
-                probe_utils->send_msg("$output", "w", "Same attribute value ($rootimgdirpath) used by : \n  $print_list");
+                probe_utils->send_msg("$output", "w", "Same attribute value ($rootimgdirpath) used by diskless osimages: \n  $print_list");
             }
         }
     }
     else {
-        probe_utils->send_msg("$output", "o", "No osimages with duplicate rootimgdir were found.");
+        probe_utils->send_msg("$output", "o", "No diskless osimages with duplicate rootimgdir were found.");
         $rc = 0;
     }
 
@@ -165,7 +165,7 @@ sub check_for_valid_osimage_attributes {
         }
         my ($junk, $template_file) = split "=", $template;
         if (($template_file =~ /compute.tmpl/) || ($template_file =~ /service.tmpl/)) {
-            probe_utils->send_msg("$output", "w", "$osimage_name contains depricted 'template' value \n  $template_file");
+            probe_utils->send_msg("$output", "w", "$osimage_name contains depricated 'template' value \n  $template_file");
         }
     }
 

--- a/xCAT-probe/subcmds/osimagecheck
+++ b/xCAT-probe/subcmds/osimagecheck
@@ -9,7 +9,7 @@ use File::Basename;
 use Net::Ping;
 use Getopt::Long qw(:config no_ignore_case);
 
-use Data::Dumper;
+#use Data::Dumper;
 use warnings;
 
 my $program_name = basename("$0");
@@ -99,9 +99,10 @@ sub check_for_duplicate_rootimgdir {
             probe_utils->send_msg("$output", "d", "No rootimgdir for osimage $osimage_name") if ($VERBOSE);
             next;
         }
-        # Check if hash already has the same key indicating another osimage definition has the same rootimgdir
+        # Check if hash already has the same key, indicating another osimage definition has the same rootimgdir
         if (exists($rootimgdir_osimage_hash{$rootimgdir})) {
-            probe_utils->send_msg("$output", "w", "Duplicate found for osimage with $rootimgdir : \n    $osimage_name and $rootimgdir_osimage_hash{$rootimgdir}");
+            # Build a list of osimages that have the same rootimgdir
+            $rootimgdir_osimage_hash{$rootimgdir} .= "," . $osimage_name;
             $any_dups = 1;
         }
         else {
@@ -110,10 +111,23 @@ sub check_for_duplicate_rootimgdir {
 
     }
 
-    print Dumper(\%rootimgdir_osimage_hash) if ($VERBOSE);
-
+    #print Dumper(\%rootimgdir_osimage_hash) if ($VERBOSE);
     my $rc = 1;
-    unless ($any_dups) {
+
+    if ($any_dups) {
+        # Loop through each entry in hash to print a list of osimgage objects that point to the same rootimgdir
+        foreach $rootimgdirpath (keys %rootimgdir_osimage_hash) {
+            my @list_of_osimages = split ",", $rootimgdir_osimage_hash{$rootimgdirpath};
+            if (scalar(@list_of_osimages) > 1) {
+                # More than one entry in the hash value, means we
+                # have more than on osimage point to the same rootimgdir
+                my $print_list = join("\n  ",@list_of_osimages);
+                $rootimgdirpath=~s/^\s+//; #discard leading space
+                probe_utils->send_msg("$output", "w", "Same attribute value ($rootimgdirpath) used by : \n  $print_list");
+            }
+        }
+    }
+    else {
         probe_utils->send_msg("$output", "o", "No osimages with duplicate rootimgdir were found.");
         $rc = 0;
     }
@@ -126,6 +140,34 @@ sub check_for_valid_osimage_attributes {
     my $na = "N/A";
 
     my $rc = 0;
+
+    my %rootimgdir_osimage_hash;
+    my $any_dups = 0;
+
+    # Check if any osimage object has "template" attribute set to service.tmpl or compute.tmpl
+    my $all_osimages_template = `lsdef -t osimage -i template -c 2> /dev/null`;
+    chomp($all_osimages_template);
+    my @all_osimages_template_lines = split("[\n\r]", $all_osimages_template);
+
+    if (scalar(@all_osimages_template_lines) <= 0) {
+
+        # There were no osimages found. Issue a warning and exit.
+        probe_utils->send_msg("$output", "w", "No osimages were found.");
+        return 1;
+    }
+    foreach (@all_osimages_template_lines) {
+        probe_utils->send_msg("$output", "d", "Processing $_.") if ($VERBOSE);
+        my ($osimage_name, $template) = split ":", $_;
+        if ($template eq " template=") {
+            # Exclude entries that do not have template set
+            probe_utils->send_msg("$output", "d", "No template for osimage $osimage_name") if ($VERBOSE);
+            next;
+        }
+        my ($junk, $template_file) = split "=", $template;
+        if (($template_file =~ /compute.tmpl/) || ($template_file =~ /service.tmpl/)) {
+            probe_utils->send_msg("$output", "w", "$osimage_name contains depricted 'template' value \n  $template_file");
+        }
+    }
 
     return $rc;
 }

--- a/xCAT-probe/subcmds/osimagecheck
+++ b/xCAT-probe/subcmds/osimagecheck
@@ -123,12 +123,12 @@ sub check_for_duplicate_rootimgdir {
                 # have more than one osimage point to the same rootimgdir
                 my $print_list = join("\n  ",@list_of_osimages);
                 $rootimgdirpath=~s/^\s+//; #discard leading space
-                probe_utils->send_msg("$output", "w", "Same attribute value ($rootimgdirpath) used by diskless osimages: \n  $print_list");
+                probe_utils->send_msg("$output", "w", "Identical root image directory ($rootimgdirpath) is configured for the diskless osimages: \n  $print_list");
             }
         }
     }
     else {
-        probe_utils->send_msg("$output", "o", "No diskless osimages with duplicate rootimgdir were found.");
+        probe_utils->send_msg("$output", "o", "No diskless osimages with identical root image directories were found.");
         $rc = 0;
     }
 
@@ -159,13 +159,16 @@ sub check_for_valid_osimage_attributes {
         probe_utils->send_msg("$output", "d", "Processing $_.") if ($VERBOSE);
         my ($osimage_name, $template) = split ":", $_;
         if ($template eq " template=") {
-            # Exclude entries that do not have template set
+            # Exclude entries that do not have template attribute set
             probe_utils->send_msg("$output", "d", "No template for osimage $osimage_name") if ($VERBOSE);
             next;
         }
         my ($junk, $template_file) = split "=", $template;
         if (($template_file =~ /compute.tmpl/) || ($template_file =~ /service.tmpl/)) {
-            probe_utils->send_msg("$output", "w", "$osimage_name contains depricated 'template' value \n  $template_file");
+            if ($template_file !~ /ubuntu/) {
+                # Skip Ubintu osimages, currently ok to have service.tmpl and compute.tmpl for them
+                probe_utils->send_msg("$output", "w", "$osimage_name contains depricated 'template' value \n  $template_file");
+            }
         }
     }
 


### PR DESCRIPTION
Enhancements to `osimagecheck` probe:
1. Display list of osimage names that point to the same rootimgdir, one per line
2. Display a warning if any osimage object has "template" value of "service.tmpl" or "compute.tmpl", templates that are deprecated and should not be used.