### PR TITLE
Small fixes to ib pkglist and mlnxofed_ib_install script

### DIFF
--- a/xCAT-server/share/xcat/ib/netboot/rh/ib.rhels7.ppc64le.pkglist
+++ b/xCAT-server/share/xcat/ib/netboot/rh/ib.rhels7.ppc64le.pkglist
@@ -16,5 +16,4 @@ atk
 cairo
 gcc
 createrepo
-libnl
 ethtool

--- a/xCAT-server/share/xcat/ib/scripts/Mellanox/mlnxofed_ib_install.v2
+++ b/xCAT-server/share/xcat/ib/scripts/Mellanox/mlnxofed_ib_install.v2
@@ -169,7 +169,7 @@ function hack_uname()
     chmod 0755 "$1/bin/uname"
     AFTER_UNAME_R="$($1/bin/uname -r)"
     AFTER_UNAME_M="$($1/bin/uname -m)"
-    echo "After  hack_uname(), -r='${AFTER_UNAME_R}', -m='${AFTER_UNAME_M}'"
+    echo "After  hack_uname(), -r=>'${AFTER_UNAME_R}', -m=>'${AFTER_UNAME_M}'"
 }
 
 function cleanup()


### PR DESCRIPTION
Two very small fixes to IB:
1. Remove duplicate entry for `libnl` from ib pkglist
2. Add missing character to the output of `mlnxofed_ib_install` script so that "Before" and "After" lines line up.