### PR TITLE
fix issue #1972: Stateless boot node looses network connection at dhcp lease expiration time;add NetworkManager in to rh7 diskless osimage pkglist

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels7.ppc64.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels7.ppc64.pkglist
@@ -30,3 +30,4 @@ xz
 grub2
 grub2-tools
 bzip2
+NetworkManager

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels7.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels7.x86_64.pkglist
@@ -22,3 +22,4 @@ net-tools
 gzip
 tar
 xz
+NetworkManager


### PR DESCRIPTION
fix issue:stateless boot node looses network connection at dhcp leaseexpiration time. #1972;
add NetworkManager in to rh7 diskless osimage pkglist