### PR TITLE
Remove nodetype and hwtype from bmcdiscover -z output

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/discovery/mtms/discovery_using_defined.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/discovery/mtms/discovery_using_defined.rst
@@ -69,8 +69,6 @@ The BMC IP address is obtained by the open range dhcp server and the plan in thi
         mgt=ipmi
         mtm=8247-22L
         serial=10112CA
-        nodetype=mp
-        hwtype=bmc
 
 
 #. Edit the ``predefined.stanzas`` file and change the discovered nodes to the intended ``hostname`` and ``IP address``. 
@@ -87,7 +85,7 @@ The BMC IP address is obtained by the open range dhcp server and the plan in thi
 
           ip=10.1.2.1
 
-    #. Remove ``nodetype`` and ``hwtype`` from ``predefined.stanza`` file based on the MTMS mapping.
+    #. Remove ``nodetype`` and ``hwtype`` if defined in the ``predefined.stanza``.
 
     #. Repeat for additional nodes in the ``predefined.stanza`` file based on the MTMS mapping.
 

--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -645,10 +645,6 @@ sub format_stanza {
         if ($bmcpass) {
             $result .= "\tbmcpassword=$bmcpass\n";
         }
-        if ($nodetype && $hwtype) {
-            $result .= "\tnodetype=$nodetype\n";
-            $result .= "\thwtype=$hwtype\n";
-        }
         my $rsp = {};
         push @{ $rsp->{data} }, "$result";
         xCAT::MsgUtils->message("I", $rsp, $::CALLBACK);


### PR DESCRIPTION
Issue #1853 Remove nodetype and hwtype from bmcdiscover -z output to avoid user mistaken to leave those two attributes in the predefined node stanza.   -w option will write them to xCATdb.  Example of output:
````
[root@fs4 xcat]# bmcdiscover --range 50.23.18.1 -t -z  -w
Warning: The -t option is deprecated and will be ignored
node-8335-gtb-2109e4a:
    objtype=node
    groups=all
    bmc=50.23.18.1
    cons=ipmi
    mgt=ipmi
    mtm=8335-GTB
    serial=2109E4A

[root@fs4 xcat]# lsdef node-8335-gtb-2109e4a
Object name: node-8335-gtb-2109e4a
    bmc=50.23.18.1
    cons=ipmi
    groups=all
    hwtype=bmc
    mgt=ipmi
    mtm=8335-GTB
    nodetype=mp
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
    serial=2109E4A
`````