### PR TITLE
fix rinv should return correct warning message when the option is not valid

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -2460,6 +2460,7 @@ sub beacon_answer {
 
 sub inv {
     my $sessdata   = shift;
+    my $command = $sessdata->{command};
     my $subcommand = $sessdata->{subcommand};
 
     my $rc = 0;
@@ -2515,9 +2516,9 @@ sub inv {
         @types = qw(guid);
     }
     else {
-        @types = ($subcommand);
-
-        #return(1,"unsupported BMC inv argument $subcommand");
+        my $usage_string = xCAT::Usage->getUsage($command);
+        $callback->({ error => ["$usage_string"], errorcode => [1] });
+        return 1;
     }
     $sessdata->{invtypes} = \@types;
     initfru($sessdata);


### PR DESCRIPTION
I think return the usage info to user can be helpful.
fix #1987