### PR TITLE
Support kitcomponent can be add to higher version of OS

### DIFF
--- a/docs/source/advanced/kit/custom/build/createkit.rst
+++ b/docs/source/advanced/kit/custom/build/createkit.rst
@@ -56,7 +56,7 @@ The ``buildkit.conf`` file is a sample file that contains a description of all t
       kitlicense=ILAN           <== the default kit license string is "EPL"
       kitdeployparams=pe.env    <== pe.env has to define in the other_files dir.
 
-**kitrepo** --- This stanza defines a Kit Package Repository. There must be at least one kitrepo stanza in a kit build file.  If this kit need to support multiple OSes, user should create a separate repository for each OS.  Also, no two repositories can be defined with the same OS name, major/minor version, and arch.  ::
+**kitrepo** --- This stanza defines a Kit Package Repository. There must be at least one kitrepo stanza in a kit build file.  If this kit need to support multiple OSes, user should create a separate repository for each OS.  Also, no two repositories can be defined with the same OS name, major version, and arch.  ::
 
   kitrepo:
       kitrepoid=rhels6_x86_64
@@ -69,6 +69,14 @@ The ``buildkit.conf`` file is a sample file that contains a description of all t
       osbasename=sles
       osmajorversion=11
       osarch=x86_64
+
+minor version can be support following format: ::
+    
+    osminorversion=2  <<-- minor version has to be exactly matched to 2
+    osminorversion=>=2  <<-- minor version can be 2 or greater than 2
+    osminorversion=<=2  <<-- minor version can be 2 or less than 2 
+    osminorversion=>2  <<-- minor version has to be greater than 2
+    osminorversion=<2  <<-- minor version has to be less than 2 
 
 **kitcomponent** --- This stanza defines one Kit Component. A kitcomponent definition is a way of specifying a subset of the product Kit that may be installed into an xCAT osimage.  A kitcomponent may or may not be dependent on other kitcomponents.If user want to build a component which supports multiple OSes, need to create one kitcomponent stanza for each OS.  ::
 

--- a/xCAT-buildkit/bin/buildkit
+++ b/xCAT-buildkit/bin/buildkit
@@ -1390,12 +1390,13 @@ sub validate_bldkitconf
         $full_kitname .= '-' . $::bldkit_config->{kit}{entries}[0]->{osmajorversion};
     }
     if (defined($::bldkit_config->{kit}{entries}[0]->{osminorversion})) {
+        my $kitminor = split /<=|>=|==|<|>/, $::bldkit_config->{kit}{entries}[0]->{osminorversion};
         if ((!defined($::bldkit_config->{kit}{entries}[0]->{osbasename})) ||
             (!defined($::bldkit_config->{kit}{entries}[0]->{osmajorversion}))) {
             print "Error:  Kit osminorversion attribute was specified but either Kit osbasename or Kit osmajorversion were not set. \n";
             return 1;
         }
-        $full_kitname .= '-' . $::bldkit_config->{kit}{entries}[0]->{osminorversion};
+        $full_kitname .= '-' . $kitminor;
     }
     if (defined($::bldkit_config->{kit}{entries}[0]->{osarch})) {
         $full_kitname .= '-' . $::bldkit_config->{kit}{entries}[0]->{osarch};
@@ -1500,12 +1501,14 @@ sub validate_bldkitconf
         }
         $reponame .= '-' . $kr->{osmajorversion};
         if (defined($kr->{osminorversion})) {
+            my $krminor = split /<=|>=|==|<|>/, $kr->{osminorversion};
             if ((defined($::bldkit_config->{kit}{entries}[0]->{osminorversion})) &&
                 ($::bldkit_config->{kit}{entries}[0]->{osminorversion} ne
                     $kr->{osminorversion})) {
                 print "Warning:  Kit osminorversion is set to \"$::bldkit_config->{kit}{entries}[0]->{osminorversion}\", but this does not match kitrepo $kr->{kitrepoid} osminorversion \"$kr->{osminorversion}\".  Processing will continue, but verify that you do not have an error in your buildkit configuration file. \n";
             }
-            $reponame .= '.' . $kr->{osminorversion};
+            $reponame .= '.' . $krminor;
+            $::bldkit_config->{kit}{entries}[0]->{osminorversion} = $krminor;            
         }
         if ((defined($::bldkit_config->{kit}{entries}[0]->{osarch})) &&
             ($::bldkit_config->{kit}{entries}[0]->{osarch} ne
@@ -1549,7 +1552,8 @@ sub validate_bldkitconf
         $compname .= '-' . $repo{osbasename};
         $compname .= '-' . $repo{osmajorversion};
         if (defined($repo{osminorversion})) {
-            $compname .= '.' . $repo{osminorversion};
+            my $minorversion = split /<=|>=|==|<|>/, $repo{osminorversion};
+            $compname .= '.' . $minorversion;
         }
         $compname .= '-' . $repo{osarch};
         $kc->{kitcompname} = $compname;
@@ -1931,8 +1935,10 @@ sub validate_os
     }
     $osinfo =~ s/\,//;
     my $repo_osinfo = "$repo->{osbasename}$repo->{osmajorversion}";
+    my $minorversion;
     if (defined($repo->{osminorversion})) {
-        $repo_osinfo .= ".$repo->{osminorversion}";
+        $minorversion = split /<=|>=|==|<|>/, $repo->{osminorversion};
+        $repo_osinfo .= ".$minorversion";
     }
     $repo_osinfo .= "-$repo->{osarch} ";
     my $mismatch_msg = "The local host is running $osinfo-$osarch.  This does not match the Kit Repository \"$repo->{kitrepoid}\" data:  $repo_osinfo";
@@ -1968,7 +1974,7 @@ sub validate_os
         return 1;
     }
     if (defined($repo->{osminorversion})) {
-        if (($repo->{osminorversion} ne $osminorversion) &&
+        if (($minorversion ne $osminorversion) &&
             (!$compat_match)) {
             print "$mismatch_msg \n";
             if ($::VERBOSE) {
@@ -3411,6 +3417,7 @@ sub kit_addpkgs
     #  - could be list of pkgdir s
     my @pkgdirlist = split(",", $::PKGDIR);
 
+    print "$tmpdir_base\n";
     # Cleanup - should have been removed when last command ran
     #            - but just in case
     system("rm -Rf $tmpdir_base");
@@ -3425,6 +3432,7 @@ sub kit_addpkgs
     $kittarfile = abs_path($kittarfile);
 
     foreach my $rpmdir (@pkgdirlist) {
+        print "rpmdir = $rmpdir\n";
         if (!(-d $rpmdir)) {
             print "The package directory $rpmdir could not be read. \n";
             return 1;

--- a/xCAT-server/lib/xcat/plugins/kit.pm
+++ b/xCAT-server/lib/xcat/plugins/kit.pm
@@ -1844,7 +1844,7 @@ sub validate_os {
         return 1;
     }
 
-    if ($kitcomp->{osminorversion} and ($osimage->{minorversion} ne $kitcomp->{osminorversion})) {
+    if ($kitcomp->{osminorversion} and ($osimage->{minorversion} lt $kitcomp->{osminorversion})) {
 
         #        my %rsp;
         #        push@{ $rsp{data} }, "osimage $os is not compatible with kit component $kitcomp->{kitcompname} with attribute minorversion";
@@ -2149,7 +2149,7 @@ sub addkitcomp
                 return 1;
             }
 
-            if ($kitcomps{$kitcomp}{osminorversion} and ($os{$osimage}{minorversion} ne $kitcomps{$kitcomp}{osminorversion})) {
+            if ($kitcomps{$kitcomp}{osminorversion} and ($os{$osimage}{minorversion} lt $kitcomps{$kitcomp}{osminorversion})) {
                 my %rsp;
                 push @{ $rsp{data} }, "osimage $osimage is not compatible with kit component $kitcomp with attribute minorversion";
                 xCAT::MsgUtils->message("E", \%rsp, $callback);
@@ -3606,7 +3606,7 @@ sub chkkitcomp
             return 1;
         }
 
-        if ($kitcomps{$kitcomp}{osminorversion} and ($os{$osimage}{minorversion} ne $kitcomps{$kitcomp}{osminorversion})) {
+        if ($kitcomps{$kitcomp}{osminorversion} and ($os{$osimage}{minorversion} lt $kitcomps{$kitcomp}{osminorversion})) {
             my %rsp;
             push @{ $rsp{data} }, "kit component $kitcomp is not compatible with osimage $osimage with attribute minorversion";
             xCAT::MsgUtils->message("E", \%rsp, $callback);
@@ -5080,7 +5080,7 @@ sub get_compat_kitreponames {
         if (defined($kitrepo->{osmajorversion}) && $kitrepo->{osmajorversion} ne $osdistro->{majorversion}) {
             next;
         }
-        if (defined($kitrepo->{osminorversion}) && $kitrepo->{osminorversion} ne $osdistro->{minorversion}) {
+        if (defined($kitrepo->{osminorversion}) && $osdistro->{minorversion} lt $kitrepo->{osminorversion} ) {
             next;
         }
         if (defined($kitrepo->{osarch}) && $kitrepo->{osarch} ne $osdistro->{arch} && $kitrepo->{osarch} ne 'noarch') {

--- a/xCAT-server/lib/xcat/plugins/kit.pm
+++ b/xCAT-server/lib/xcat/plugins/kit.pm
@@ -1108,7 +1108,7 @@ sub read_kit_config
                 $key =~ s/\s+//g;
                 $value =~ s/\s+//g;
             } else {
-                ($key, $value) = split /=/, $line;
+                ($key, $value) = split(/=/, $line,2);
             }
         }
 
@@ -1803,6 +1803,24 @@ sub rmkit
 
 }
 
+sub check_minorversion
+{
+    my $kitminor = shift;
+    my $osminor = shift;
+
+    if ($kitminor eq $osminor) {
+        return 0;
+    }
+
+    if (($kitminor =~ />/) || ($kitminor =~ /</) || ($kitminor =~ /==/)) {
+        if (eval ($osminor. $kitminor)) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+
 #-------------------------------------------------------
 
 =head3 validate_os
@@ -1844,12 +1862,11 @@ sub validate_os {
         return 1;
     }
 
-    if ($kitcomp->{osminorversion} and ($osimage->{minorversion} lt $kitcomp->{osminorversion})) {
-
-        #        my %rsp;
-        #        push@{ $rsp{data} }, "osimage $os is not compatible with kit component $kitcomp->{kitcompname} with attribute minorversion";
-        #        xCAT::MsgUtils->message( "E", \%rsp, $::CALLBACK );
-        return 1;
+    if ($kitcomp->{osminorversion}) {
+        if (check_minorversion($kitcomp->{osminorversion}, $osimage->{minorversion}))
+        {
+            return 1;
+        }
     }
 
     if ($osimage->{arch} ne $kitcomp->{osarch} && $kitcomp->{osarch} ne 'noarch') {
@@ -2149,11 +2166,14 @@ sub addkitcomp
                 return 1;
             }
 
-            if ($kitcomps{$kitcomp}{osminorversion} and ($os{$osimage}{minorversion} lt $kitcomps{$kitcomp}{osminorversion})) {
-                my %rsp;
-                push @{ $rsp{data} }, "osimage $osimage is not compatible with kit component $kitcomp with attribute minorversion";
-                xCAT::MsgUtils->message("E", \%rsp, $callback);
-                return 1;
+            if ($kitcomps{$kitcomp}{osminorversion}) {
+                if (check_minorversion($kitcomps{$kitcomp}{osminorversion}, $os{$osimage}{minorversion}))
+                {
+                    my %rsp;
+                    push @{ $rsp{data} }, "osimage $osimage is not compatible with kit component $kitcomp with attribute minorversion";
+                    xCAT::MsgUtils->message("E", \%rsp, $callback);
+                    return 1;
+                }
             }
 
             if ($os{$osimage}{arch} ne $kitcomps{$kitcomp}{osarch} && $kitcomps{$kitcomp}{osarch} ne 'noarch') {
@@ -3606,11 +3626,14 @@ sub chkkitcomp
             return 1;
         }
 
-        if ($kitcomps{$kitcomp}{osminorversion} and ($os{$osimage}{minorversion} lt $kitcomps{$kitcomp}{osminorversion})) {
-            my %rsp;
-            push @{ $rsp{data} }, "kit component $kitcomp is not compatible with osimage $osimage with attribute minorversion";
-            xCAT::MsgUtils->message("E", \%rsp, $callback);
-            return 1;
+        if ($kitcomps{$kitcomp}{osminorversion} ) {
+            if (check_minorversion($kitcomps{$kitcomp}{osminorversion}, $os{$osimage}{minorversion}))
+            {
+                my %rsp;
+                push @{ $rsp{data} }, "kit component $kitcomp is not compatible with osimage $osimage with attribute minorversion";
+                xCAT::MsgUtils->message("E", \%rsp, $callback);
+                return 1;
+            }
         }
 
         if ($os{$osimage}{arch} ne $kitcomps{$kitcomp}{osarch} && $kitcomps{$kitcomp}{osarch} ne 'noarch') {
@@ -5080,8 +5103,11 @@ sub get_compat_kitreponames {
         if (defined($kitrepo->{osmajorversion}) && $kitrepo->{osmajorversion} ne $osdistro->{majorversion}) {
             next;
         }
-        if (defined($kitrepo->{osminorversion}) && $osdistro->{minorversion} lt $kitrepo->{osminorversion} ) {
-            next;
+        if (defined($kitrepo->{osminorversion})) {
+            if (check_minorversion($kitrepo->{osminorversion},$osdistro->{minorversion}))
+            {
+                next;
+            }
         }
         if (defined($kitrepo->{osarch}) && $kitrepo->{osarch} ne $osdistro->{arch} && $kitrepo->{osarch} ne 'noarch') {
             next;


### PR DESCRIPTION
Request from ESSL,,  If osminor version is set for the kits,  it can be add to higher version of OS minor number instead of minor version has to be matched.

Test results:

```
# addkitcomp -i rhels7.3-ppc64le-netboot-compute xlc.license-compute-13.1.4-0-rhels-7.2-ppc64le
Assigning kit component xlc.license-compute-13.1.4-0-rhels-7.2-ppc64le to osimage rhels7.3-ppc64le-netboot-compute
Kit components xlc.license-compute-13.1.4-0-rhels-7.2-ppc64le were added to osimage rhels7.3-ppc64le-netboot-compute successfully

# addkitcomp -i rhels7.1-ppc64le-netboot-compute xlc.license-compute-13.1.4-0-rhels-7.2-ppc64le
Error: osimage rhels7.1-ppc64le-netboot-compute is not compatible with kit component xlc.license-compute-13.1.4-0-rhels-7.2-ppc64le with attribute minorversion

I ran genimage , looks like xlc.license-compute is successfully installed.

# chroot /install/netboot/rhels7.3/ppc64le/compute/rootimg
# rpm -qa | grep xlc
xlc.license-compute-13.1.4-0.noarch
xlc-license.13.1.4-13.1.4.0-160519.ppc64le
```
