### PR TITLE
Add test case to check the update syslog when xcatdebugmode opens.

### DIFF
--- a/xCAT-test/autotest/testcase/updatenode/cases0
+++ b/xCAT-test/autotest/testcase/updatenode/cases0
@@ -454,3 +454,23 @@ check:output=~postscripts has completed
 check:output=~Software Maintenance has completed
 end
 
+start:updatenode_P_syslog_V_xcatdebugmode_is_one
+description:xcatdebugmode value is one, there should be execution outputs.
+cmd:chtab key=xcatdebugmode site.value=1
+check:rc==0
+cmd:updatenode $$CN -P syslog -V
+check:output=~$$CN: ++
+cmd:chtab key=xcatdebugmode site.value=0
+check:rc==0
+end
+
+start:updatenode_P_syslog_V_xcatdebugmode_is_two
+description:xcatdebugmode value is two, there should be execution outputs.
+cmd:chtab key=xcatdebugmode site.value=2
+check:rc==0
+cmd:updatenode $$CN -P syslog -V
+check:output=~$$CN: ++
+cmd:chtab key=xcatdebugmode site.value=0
+check:rc==0
+end
+


### PR DESCRIPTION
@tingtli 
add test case to check if the execution logs are output, when xcatdebugmode value is one or two: 
https://github.com/xcat2/xcat-core/issues/1922
Test in rhels7.2 ppc64 and ubuntu16.04.1 ppc64le, works well.
please help to review.
