### PR TITLE
Missing version when building xcat-genesis-base

### DIFF
--- a/xCAT-genesis-builder/buildrpm
+++ b/xCAT-genesis-builder/buildrpm
@@ -32,7 +32,7 @@ if [ $BUILDARCH = 'ppc64' -a $HOSTOS != 'mcp' -a $HOSTOS != '-y' ]; then
     echo "2. Download Mellanox EN Driver for Linux from http://www.mellanox.com/downloads/Drivers/mlnx-en-3.2-1.0.1.1.tgz"
     echo "3. Extract it and run ./install.sh from the extracted directory"
     echo "    tar -xvf mlnx-en-3.2-1.0.1.1.tgz"
-    echo "    ./mlnx-en-3.2-1.0.1/install.sh"
+    echo "    ./mlnx-en-3.2-1.0.1.1/install.sh"
     echo "4. Check whether the mlx4 driver is updated"
     echo "    modprobe mlx4-en"
     echo "    modinfo mlx4-en | grep version"

--- a/xCAT-genesis-builder/xCAT-genesis-base.spec
+++ b/xCAT-genesis-builder/xCAT-genesis-base.spec
@@ -1,3 +1,4 @@
+%define version        2.12
 Version: %{?version:%{version}}%{!?version:%(cat Version)}
 Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
 %ifarch i386 i586 i686 x86


### PR DESCRIPTION
1. Add param version in xCAT-genesis-base.spec
2. Modify an spell error in buildrpm script when building mlx driver.
