### PR TITLE
ipmitool-xcat-1.8.17 now required by xCAT.spec, xCATsn.spec

### DIFF
--- a/xCAT/xCAT.spec
+++ b/xCAT/xCAT.spec
@@ -64,12 +64,12 @@ Requires: elilo-xcat xnba-undi
 
 %ifarch i386 i586 i686 x86 x86_64
 Requires: syslinux
-Requires: ipmitool-xcat >= 1.8.15-2
+Requires: ipmitool-xcat >= 1.8.17
 %endif
 
 %ifos linux
 %ifarch ppc ppc64 ppc64le
-Requires: ipmitool-xcat >= 1.8.15-2
+Requires: ipmitool-xcat >= 1.8.17
 %endif
 %endif
 

--- a/xCATsn/xCATsn.spec
+++ b/xCATsn/xCATsn.spec
@@ -59,11 +59,11 @@ Requires: elilo-xcat xnba-undi
 
 %ifarch i386 i586 i686 x86 x86_64
 Requires: syslinux
-Requires: ipmitool-xcat >= 1.8.15-2
+Requires: ipmitool-xcat >= 1.8.17
 %endif
 %ifos linux
 %ifarch ppc ppc64 ppc64le
-Requires: ipmitool-xcat >= 1.8.15-2
+Requires: ipmitool-xcat >= 1.8.17
 %endif
 %endif
 


### PR DESCRIPTION
Issue #1957 

These changes will allow for `yum update "*xCAT*"` to also pull in ipmitool-xcat-1.8.17 for xCAT 2.12.4 release