### PR TITLE
Set value to '' if value within composite primary keys not defined

### DIFF
--- a/perl-xCAT/xCAT/Table.pm
+++ b/perl-xCAT/xCAT/Table.pm
@@ -1722,6 +1722,16 @@ sub setAttribs
         @bind   = ();
         $cols   = "";
         my %newpairs;
+        # NOTE(chenglch): Just work around, set the default value to '' due to
+        # null value can not be allowed in composite primary keys in standard
+        # SQL rules.
+        my $descr = $xCAT::Schema::tabspec{ $self->{tabname} };
+        my @pkeys = @{$descr->{keys}};
+        for my $p (@pkeys) {
+            if(!defined($elems->{$p}) && !defined($pKeypairs->{$p})) {
+                $elems->{$p}= '';
+            }
+        }
 
         #first, merge the two structures to a single hash
         foreach (keys %keypairs)


### PR DESCRIPTION
As history reasons, null value is always set within the composite primary
keys, this patch is just a work aroud for the issue encountered on postgres.
Correct fix is to report error to the client side, but too much error handler
is missing in xcat code

close-issue: #2037
close-issue: #2007
