### PR TITLE
fix issue when using copycds -p, stateful install has yum point to the wrong repository. #1852

### DIFF
--- a/perl-xCAT/xCAT/Yum.pm
+++ b/perl-xCAT/xCAT/Yum.pm
@@ -11,29 +11,23 @@ my $installpfx;
 
 sub localize_yumrepo {
     my $self        = shift;
-    my $installroot = shift;
-    $distname = shift;
-    $arch     = shift;
-
-    $installpfx = "$installroot/$distname/$arch";
-    mkpath("$installroot/postscripts/repos/$distname/$arch/");
-    open($yumrepofile, ">", "$installroot/postscripts/repos/$distname/$arch/local-repository.tmpl");
+    my $pkgdir = shift;
+    $distname=shift;
+    $arch=shift;
+    open($yumrepofile, ">", "$pkgdir/local-repository.tmpl");
     my %options = (
         wanted      => \&check_tofix,
         follow_fast => 1
     );
-    find(\%options, $installpfx);
+    find(\%options, $pkgdir);
     close($yumrepofile);
 }
 
 
 sub remove_yumrepo {
     my $self        = shift;
-    my $installroot = shift;
-    $distname = shift;
-    $arch     = shift;
-
-    rmtree("$installroot/postscripts/repos/$distname/$arch/");
+    my $pkgdir = shift;
+    rmtree("$pkgdir/local-repository.tmpl");
 }
 
 sub check_tofix {
@@ -57,14 +51,13 @@ sub generate_repo
     my @dircomps    = File::Spec->splitdir($dirlocation);
     pop(@dircomps);
     my $yumurl = File::Spec->catdir(@dircomps);
-    $yumurl =~ s!$installpfx!http://#INSTSERVER#/install/$distname/$arch/!;
     my $reponame = $dircomps[$#dircomps];
     print $yumrepofile "[local-$distname-$arch-$reponame]\n";
-    print $yumrepofile "name=xCAT configured yum repository for $distname/$arch/$reponame\n";
+    print $yumrepofile "name=xCAT configured yum repository for $yumurl\n";
     print $yumrepofile "baseurl=$yumurl\n";
     print $yumrepofile "enabled=1\n";
     print $yumrepofile "gpgcheck=0\n\n";
-}
+}	
 
 sub fix_directory {
 

--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -2464,30 +2464,8 @@ sub copycd
     }
 
 
-    unless ($path =~ /^($defaultpath)/)
-    {
-        mkpath($defaultpath);
-        if (-d $defaultpath)
-        {
-            rmtree($defaultpath);
-        }
-        else
-        {
-            unlink($defaultpath);
-        }
-
-        my $hassymlink = eval { symlink("", ""); 1 };
-        if ($hassymlink) {
-            symlink($path, $defaultpath);
-        } else
-        {
-            link($path, $defaultpath);
-        }
-
-    }
-
     require xCAT::Yum;
-    xCAT::Yum->localize_yumrepo($installroot, $distname, $arch);
+    xCAT::Yum->localize_yumrepo($path, $distname, $arch);
 
     if ($rc != 0)
     {

--- a/xCAT-server/lib/xcat/plugins/copycds.pm
+++ b/xCAT-server/lib/xcat/plugins/copycds.pm
@@ -145,6 +145,10 @@ sub process_request {
 
             if ($path)
             {
+                $path=Cwd::realpath($path);
+                unless(substr($path,0,length("/install")) eq "/install"){
+                    $callback->({ warning => "copycds: the specified path \"$path\" is not a subdirectory under /install. Make sure this path is configured for httpd/apache, otherwise, the provisioning with this iso will fail!" }); 
+                }
                 push @{ $newreq->{arg} }, ("-p", $path);
             }
             if ($specific)

--- a/xCAT-server/share/xcat/install/scripts/post.xcat
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat
@@ -396,9 +396,10 @@ chmod 755 /xcatpost/mypostscript
 export ARCH=#TABLE:nodetype:THISNODE:arch#
 export CONSOLEPORT=#TABLEBLANKOKAY:nodehm:THISNODE:serialport#
 
-if [[ $OSVER != ubuntu* ]]; then
-    addsiteyum
-fi
+#for redhat:
+##place-holder for the code to save the repo info on compute node,pointing to the "pkgdir" of the osimage
+##so that the provisioned node
+##WRITEREPO#
 
 if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
    msgutil_r "$MASTER_IP" "info" "running mypostscript" "/var/log/xcat/xcat.log"


### PR DESCRIPTION
fix https://github.com/xcat2/xcat-core/issues/1852:
1. move the repo info of the specified osimage "pkgdir", local-repository.tmpl from "/install/<osver>/<arch>" to "pkgdir", to avoid the overwritten of the repo info during successive"copycds"
2. simplify the mechanism to save the osimage "pkgdir" repo info to provisioned node

@gurevichmark  created a PR on this https://github.com/xcat2/xcat-core/pull/2009,  during the UT and review process, we discussed a lot on the potential problems on the current method to save the repo info available on "pkgdir" of mn on the provisioned node. I created this PR as a fix to all the potential issues we found.

@gurevichmark , would you please review this? if this PR is ok for you, please close the https://github.com/xcat2/xcat-core/pull/2009, thanks
