### PR TITLE
fix issue linux orderly shutdown not noticed by xcat. #1939

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/post.xcat
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat
@@ -34,6 +34,8 @@ fi
 EOF
 ) >/tmp/updateflag
 
+chmod 0755 /tmp/updateflag
+
 cd /tmp
 RAND=$(perl -e 'print int(rand(50)). "\n"')
 if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
@@ -266,49 +268,68 @@ else
 fi
 
 
-#create the post init
-cat >/etc/init.d/xcatpostinit1 << 'EOF'
-#INCLUDE:#TABLE:site:key=installdir:value#/postscripts/xcatpostinit1#
-EOF
-chmod 755 /etc/init.d/xcatpostinit1
-
-if [ ! -x /etc/init.d/xcatpostinit1 ]; then
-    if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-        msgutil_r "$MASTER_IP" "debug" "failed to generate /etc/init.d/xcatpostinit1" "/var/log/xcat/xcat.log"
-    fi
-else
-    if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-        msgutil_r "$MASTER_IP" "debug" "/etc/init.d/xcatpostinit1 generated" "/var/log/xcat/xcat.log"
-    fi
-fi
-
 export OSVER=#TABLE:nodetype:THISNODE:os#
-
-if [[ $OSVER == ubuntu* ]]; then
-    ln -s /etc/init.d/xcatpostinit1 /etc/rc2.d/S84xcatpostinit1
-else
-    ln -s /etc/init.d/xcatpostinit1 /etc/rc.d/rc3.d/S84xcatpostinit1
-    ln -s /etc/init.d/xcatpostinit1 /etc/rc.d/rc4.d/S84xcatpostinit1
-    ln -s /etc/init.d/xcatpostinit1 /etc/rc.d/rc5.d/S84xcatpostinit1
+#create the post init service as a hook to run PS and PBS, as well as status updating
+hassystemd=0
+systemctl --version 2>/dev/null
+if [ $? -eq 0 ]; then
+    hassystemd=1
 fi
 
-if [[ $OSVER == ubuntu* ]]; then
-    update-rc.d xcatpostinit1 defaults
+if [ $hassystemd -eq 1 ] ; then
+    cat >/etc/systemd/system/xcatpostinit1.service <<'EOF'
+#INCLUDE:/install/postscripts/xcatpostinit1.service#
+EOF
+    msgutil_r "$MASTER_IP" "debug" "/etc/systemd/system/xcatpostinit1.service generated" "/var/log/xcat/xcat.log"
+
+    ln -s /etc/systemd/system/xcatpostinit1.service /etc/systemd/system/multi-user.target.wants/xcatpostinit1.service    
+    msgutil_r "$MASTER_IP" "debug" "xcatpostinit1.service enabled" "/var/log/xcat/xcat.log"
+
+    cat >/opt/xcat/xcatpostinit1 << 'EOF'
+#INCLUDE:/install/postscripts/xcatpostinit1.install#
+EOF
+    chmod 755 /opt/xcat/xcatpostinit1
 else
-    if [[ $OSVER == sles* ]]; then
-        if [[ $OSVER == sles10* ]]; then
-            /sbin/insserv xcatpostinit1
-        else
-            /sbin/insserv -p /etc/init.d xcatpostinit1
+    cat >/etc/init.d/xcatpostinit1 << 'EOF'
+#INCLUDE:#TABLE:site:key=installdir:value#/postscripts/xcatpostinit1.install#
+EOF
+    chmod 755 /etc/init.d/xcatpostinit1
+
+    if [ ! -x /etc/init.d/xcatpostinit1 ]; then
+        if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
+            msgutil_r "$MASTER_IP" "debug" "failed to generate /etc/init.d/xcatpostinit1" "/var/log/xcat/xcat.log"
+        fi
+    else
+        if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
+            msgutil_r "$MASTER_IP" "debug" "/etc/init.d/xcatpostinit1 generated" "/var/log/xcat/xcat.log"
         fi
     fi
-    #chkconfig --add xcatpostinit1
-    chkconfig xcatpostinit1 on
-    if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-        msgutil_r "$MASTER_IP" "debug" "service xcatpostinit1 enabled" "/var/log/xcat/xcat.log"
+    
+    if [[ $OSVER == ubuntu* ]]; then
+        ln -s /etc/init.d/xcatpostinit1 /etc/rc2.d/S84xcatpostinit1
+    else
+        ln -s /etc/init.d/xcatpostinit1 /etc/rc.d/rc3.d/S84xcatpostinit1
+        ln -s /etc/init.d/xcatpostinit1 /etc/rc.d/rc4.d/S84xcatpostinit1
+        ln -s /etc/init.d/xcatpostinit1 /etc/rc.d/rc5.d/S84xcatpostinit1
+    fi
+    
+    if [[ $OSVER == ubuntu* ]]; then
+        update-rc.d xcatpostinit1 defaults
+    else
+        if [[ $OSVER == sles* ]]; then
+            if [[ $OSVER == sles10* ]]; then
+                /sbin/insserv xcatpostinit1
+            else
+                /sbin/insserv -p /etc/init.d xcatpostinit1
+            fi
+        fi
+        #chkconfig --add xcatpostinit1
+        chkconfig xcatpostinit1 on
+        if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
+            msgutil_r "$MASTER_IP" "debug" "service xcatpostinit1 enabled" "/var/log/xcat/xcat.log"
+        fi
     fi
 fi
-
 
 #create the xcatinstallpost
 mkdir -p /opt/xcat
@@ -327,12 +348,13 @@ if [[ $OSVER == ubuntu* ]]; then
         msgutil_r "$MASTER_IP" "debug" "update-rc.d -f xcatpostinit1 remove" "/var/log/xcat/xcat.log"
     fi
 else
-    if [ "$RUNBOOTSCRIPTS" != "'yes'" ]; then
+    if [ "$RUNBOOTSCRIPTS" != "'yes'" ] && [ "$NODESTATUS" = "'n'" ]; then
         chkconfig xcatpostinit1 off
+        if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
+            msgutil_r "$MASTER_IP" "debug" "service xcatpostinit1 disabled" "/var/log/xcat/xcat.log"
+        fi
     fi
-    if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-        msgutil_r "$MASTER_IP" "debug" "service xcatpostinit1 disabled" "/var/log/xcat/xcat.log"
-    fi
+
 fi
 
 EOF
@@ -373,6 +395,7 @@ chmod 755 /xcatpost/mypostscript
 
 export ARCH=#TABLE:nodetype:THISNODE:arch#
 export CONSOLEPORT=#TABLEBLANKOKAY:nodehm:THISNODE:serialport#
+
 if [[ $OSVER != ubuntu* ]]; then
     addsiteyum
 fi

--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -1988,9 +1988,21 @@ sub generic_post { #This function is meant to leave the image in a state approxi
             system("cd $rootimg_dir/etc/rc3.d; ln -sf ../init.d/gettyset S60gettyset");
         }
 
-        copy("$installroot/postscripts/xcatpostinit", "$rootimg_dir/etc/init.d/xcatpostinit");
-        chmod(0755, "$rootimg_dir/etc/init.d/xcatpostinit");
-        system("cd $rootimg_dir/etc/rc3.d; ln -sf ../init.d/xcatpostinit S61xcatpostinit");
+        if(-e "$rootimg_dir/usr/lib/systemd/"){
+            #if systemd is the service management framework for the diskless image
+            #enable the xcatpostinit1.service
+            copy("/install/postscripts/xcatpostinit1.netboot","$rootimg_dir/opt/xcat/xcatpostinit1");
+            chmod(0755,"$rootimg_dir/opt/xcat/xcatpostinit1");
+            copy("/install/postscripts/xcatpostinit1.service","$rootimg_dir/etc/systemd/system/xcatpostinit1.service");
+            symlink("$rootimg_dir/etc/systemd/system/xcatpostinit1.service","$rootimg_dir/etc/systemd/system/multi-user.targ
+et.wants/xcatpostinit1.service") ;
+       }else{
+            #for traditional sysvinit
+            copy("$installroot/postscripts/xcatpostinit1.netboot", "$rootimg_dir/etc/init.d/xcatpostinit");
+            chmod(0755, "$rootimg_dir/etc/init.d/xcatpostinit");
+            system("cd $rootimg_dir/etc/rc3.d; ln -sf ../init.d/xcatpostinit S61xcatpostinit");
+       }
+
     }
 }
 

--- a/xCAT/postscripts/xcatpostinit1
+++ b/xCAT/postscripts/xcatpostinit1
@@ -1,5 +1,6 @@
 #!/bin/sh
 # IBM(c) 2007 EPL license http://www.eclipse.org/legal/epl-v10.html
+# This script is deprecated, please use xcatpostinit1.install instead 
 # chkconfig: 345 84 59
 # description: service node postboot script hack
 # processname: xcatpostinit

--- a/xCAT/postscripts/xcatpostinit1.install
+++ b/xCAT/postscripts/xcatpostinit1.install
@@ -1,0 +1,38 @@
+#!/bin/sh
+# IBM(c) 2007 EPL license http://www.eclipse.org/legal/epl-v10.html
+# chkconfig: 345 84 59
+# description: the hook for systemd service unit to run PB and report node status on diskful node 
+# processname: xcatpostinit1
+
+# Source function library.
+if [ -x /etc/rc.d/init.d/functions ]; then
+  . /etc/rc.d/init.d/functions
+fi
+
+[ -f /opt/xcat/xcatinfo ] && XCATSERVER=`grep 'XCATSERVER' /opt/xcat/xcatinfo |cut -d= -f2 2>/dev/null`
+[ -f /xcatpost/mypostscript ] && NODESTATUS=`grep 'NODESTATUS=' /xcatpost/mypostscript |awk -F = '{print $2}' 2>/dev/null`
+[ -f /xcatpost/mypostscript ] && RUNBOOTSCRIPT=`grep 'RUNBOOTSCRIPT=' /xcatpost/mypostscript |awk -F = '{print $2}' 2>/dev/null`
+
+case $1 in
+stop)
+  [ "$NODESTATUS" != "n" ] &&  /xcatpost/updateflag.awk $XCATSERVER 3002 "installstatus powering-off"  
+  ;;
+start)
+  # check for the REBOOT specified in xcatinfo to run post boot scripts on reboot 
+  if [ -f /opt/xcat/xcatinfo ]; then
+    REBOOT=`grep 'REBOOT' /opt/xcat/xcatinfo |cut -d= -f2`
+  fi
+  # if the xcatdsklspost file exists and this is a reboot - run xcatdsklspost with a mode of 6
+  if [ "$REBOOT" = "TRUE" -a -r /opt/xcat/xcatdsklspost -a "$RUNBOOTSCRIPT" = "1"]; then
+      /opt/xcat/xcatdsklspost 6
+  elif [ "$REBOOT" = "TRUE" -a "NODESTATUS" != "n" ]; then
+      /xcatpost/updateflag.awk $XCATSERVER 3002 "installstatus booted"  
+  else
+    # run /opt/xcat/xcatinstallpost
+    if [ -r /opt/xcat/xcatinstallpost ]; then
+      /opt/xcat/xcatinstallpost
+    fi
+  fi
+
+  ;;
+esac

--- a/xCAT/postscripts/xcatpostinit1.netboot
+++ b/xCAT/postscripts/xcatpostinit1.netboot
@@ -1,9 +1,8 @@
 #!/bin/sh
 # IBM(c) 2007 EPL license http://www.eclipse.org/legal/epl-v10.html
-# this script is deprecated,please use xcatpostinit1.netboot instead
 # chkconfig: 345 84 59
-# description: service node postboot script hack
-# processname: xcatpostinit
+# description: the hook in systemd service unit to run PB or report node status on  diskless & statelite node
+# processname: xcatpostinit1
 
 ### BEGIN INIT INFO
 # Provides: xcatpostinit
@@ -20,6 +19,8 @@ if [ -x /etc/rc.d/init.d/functions ]; then
   . /etc/rc.d/init.d/functions
 fi
 
+XCATSERVER=$(grep --only-matching "\<XCAT=[^ ]*\>" /proc/cmdline |cut -d= -f2 |cut -d: -f1 2>/dev/null)
+
 logger -t xcat -p local4.info "$0: action is $1"
 case $1 in
 restart)
@@ -33,6 +34,7 @@ status)
 stop)
   echo -n "nothing to stop "
   logger -t xcat -p local4.info "nothing to stop"
+  grep nonodestatus /proc/cmdline 2>/dev/null || [ -n "$XCATSERVER" ] &&  /xcatpost/updateflag.awk $XCATSERVER 3002 "installstatus powering-off" 
   ;;
 start)
         # Node is stateless by default

--- a/xCAT/postscripts/xcatpostinit1.service
+++ b/xCAT/postscripts/xcatpostinit1.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=xcat service on compute node, the framework to run postbootscript and update node status 
+After=network.target rsyslog.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/xcat/xcatpostinit1 start
+ExecStop=/opt/xcat/xcatpostinit1 stop
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/1939:
1. replace xcatpostinit1 sysvinit service with xcatpostinit1.service systemd service unit as the hook to run PS&PBS and report node status for redhat;
2. report node status on system <reboot/shutdown> command

with this PR, the node status will be changed to "powering-off" on system "reboot" or "shutdown"