### PR TITLE
postscripts: add --showduplicates to yum list

### DIFF
--- a/xCAT/postscripts/otherpkgs
+++ b/xCAT/postscripts/otherpkgs
@@ -715,7 +715,7 @@ while [ $op_index -le $OTHERPKGS_INDEX ]; do
 	    fi
 	        if [ $hasyum -eq 1 ]; then 
 	            #use yum
-		    result=`yum list $fn 2>&1`
+		    result=`yum --showduplicates list $fn 2>&1`
 		    if [ $? -eq 0 ]; then  
 		        rc=0
 		        array_set_element repo_path $index $path


### PR DESCRIPTION
"yum list" alone does NOT check the older packages available in the
yum repo. If we want to install a specific package version, the
--showduplicates option is required. As an example, with this patch,
we can now add a specific kernel package to otherpkgs.pkglist that is
older that the one available in the distro.