### PR TITLE
Add documentation for the noboot option

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/configure/networks.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/configure/networks.rst
@@ -12,7 +12,7 @@ Set attributes in the ``networks`` table
 
 #. To define additional networks, use one of the following options:
 
-   *  (**Recommended**) Use ``mkdef`` to create/update an entry into ``networks`` table.
+   *  [**Recommended**] Use ``mkdef`` to create/update an entry into ``networks`` table.
 
       To create a network entry for 192.168.X.X/16 with a gateway of 192.168.1.254: ::
 
@@ -35,26 +35,33 @@ Set attributes in the ``networks`` table
 Initialize DHCP services
 ------------------------
 
-#. Configure DHCP to listen on different network interfaces (**Optional**)
+Configure DHCP to listen on different network interfaces [**Optional**]
 
-   The ``dhcpinterfaces`` keyword allows users to specify or limit the DHCP to listen over certain network interfaces.
+   The default behavior of xCAT is to configure DHCP to listen on all interfaces defined in the ``networks`` table.  
 
-   If the management node has 4 interfaces, (eth0, eth1, eth2, and eth3), and you want DHCP to listen only on "eth1" and "eth3", set ``dhcpinterfaces`` with: ::
+   The ``dhcpinterfaces`` keyword in the ``site`` table allows administrators to limit the interfaces that DHCP will listen over.  If the management node has 4 interfaces, (eth0, eth1, eth2, and eth3), and you want DHCP to listen only on "eth1" and "eth3", set ``dhcpinterfaces`` using: ::
 
       chdef -t site dhcpinterfaces="eth1,eth3"
 
-   To set "eth1" and "eth3" on the management node, and "bond0" on all the nodes in the "service" nodegroup, set ``dhcpinterfaces`` with: ::
+   To set "eth1" and "eth3" on the management node and "bond0" on all nodes in the nodegroup="service", set ``dhcpinterfaces`` using: ::
 
       chdef -t site dhcpinterfaces="xcatmn|eth1,eth3;service|bond0"
 
-   [**noboot**]: For the IBM OpenPower S822LC for HPC ("Minsky") nodes, the BMC and "eth0" on the compute side shares the same physical ethernet port.  However, it is recommended to allow the BMC to be dedicated and to use "eth1" for the compute node.   When an open range is configured on the two networks, the xCAT Genesis Kernel will be sent to the BMC interface and will cause problems with discovery.  In this scenario, if "eth1" is the BMC network and "eth3" is the compute network, disabled genesis by setting ``:noboot`` in ``dhcpinterfaces`` with: ::
+**noboot**
+``````````
+   For the *IBM OpenPOWER S822LC for HPC ("Minsky")* nodes, the BMC and compute "eth0" share the left-size integrated ethernet port and compute "eth1" is the right-side integrated ethernet port.  For these servers, it is recommended to use two physical cables allowing the BMC port to be dedicated and "eth1" used by the OS.  When an open range is configured on the two networks, the xCAT Genesis kernel will be sent to the BMC interface and causes problems during hardware discovery.  To support this scenario, on the xCAT management node, if "eth1" is connected to the BMC network and "eth3" is connected to the compute network, disable genesis boot for the BMC network by setting ``:noboot`` in ``dhcpinterfaces`` using: ::
      
       chdef -t site dhcpinterfaces="eth1:noboot,eth3" 
 
-   
-   For more information, see ``dhcpinterfaces`` keyword in the :doc:`site </guides/admin-guides/references/man5/site.5>` table.
+      # run the mknb command to remove the genesis 
+      # configuration file for the specified network
+      mknb ppc64
 
-#. Create a new DHCP configuration file with the networks defined using the ``makedhcp`` command. ::
+   
+For more information, see ``dhcpinterfaces`` keyword in the :doc:`site </guides/admin-guides/references/man5/site.5>` table.
+
+
+After making any DHCP changes, create a new DHCP configuration file with the networks defined using the ``makedhcp`` command. ::
 
        makedhcp -n
 

--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/configure/networks.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/configure/networks.rst
@@ -12,15 +12,19 @@ Set attributes in the ``networks`` table
 
 #. To define additional networks, use one of the following options:
 
-   *  Use ``mkdef`` to create/update an entry into ``networks`` table. (**Recommended**)
+   *  (**Recommended**) Use ``mkdef`` to create/update an entry into ``networks`` table.
 
       To create a network entry for 192.168.X.X/16 with a gateway of 192.168.1.254: ::
 
           mkdef -t network -o net1 net=192.168.0.0 mask=255.255.0.0 gateway=192.168.1.254
 
-   *  Use the ``tabedit`` command to modify the networks table directly in an editor: ``tabedit networks`` 
+   *  Use the ``tabedit`` command to modify the networks table directly in an editor: ::
 
-   *  Use the ``makenetworks`` command to automatically generate a entry in the ``networks`` table
+          tabedit networks
+
+   *  Use the ``makenetworks`` command to automatically generate a entry in the ``networks`` table:  ::
+
+          makenetworks
 
 #. Verify the network statements 
 
@@ -33,12 +37,22 @@ Initialize DHCP services
 
 #. Configure DHCP to listen on different network interfaces (**Optional**)
 
-   xCAT allows specifying different network intercaces thateDHCP can listen on for different nodes or node groups.  If this is not needed, go to the next step.  To set dhcpinterfaces :: 
+   The ``dhcpinterfaces`` keyword allows users to specify or limit the DHCP to listen over certain network interfaces.
 
-       chdef -t site dhcpinterfaces='xcatmn|eth1,eth2;service|bond0'
+   If the management node has 4 interfaces, (eth0, eth1, eth2, and eth3), and you want DHCP to listen only on "eth1" and "eth3", set ``dhcpinterfaces`` with: ::
 
+      chdef -t site dhcpinterfaces="eth1,eth3"
+
+   To set "eth1" and "eth3" on the management node, and "bond0" on all the nodes in the "service" nodegroup, set ``dhcpinterfaces`` with: ::
+
+      chdef -t site dhcpinterfaces="xcatmn|eth1,eth3;service|bond0"
+
+   [**noboot**]: For the IBM OpenPower S822LC for HPC ("Minsky") nodes, the BMC and "eth0" on the compute side shares the same physical ethernet port.  However, it is recommended to allow the BMC to be dedicated and to use "eth1" for the compute node.   When an open range is configured on the two networks, the xCAT Genesis Kernel will be sent to the BMC interface and will cause problems with discovery.  In this scenario, if "eth1" is the BMC network and "eth3" is the compute network, disabled genesis by setting ``:noboot`` in ``dhcpinterfaces`` with: ::
+     
+      chdef -t site dhcpinterfaces="eth1:noboot,eth3" 
+
+   
    For more information, see ``dhcpinterfaces`` keyword in the :doc:`site </guides/admin-guides/references/man5/site.5>` table.
-
 
 #. Create a new DHCP configuration file with the networks defined using the ``makedhcp`` command. ::
 

--- a/docs/source/guides/admin-guides/references/man1/packimage.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/packimage.1.rst
@@ -33,7 +33,7 @@ DESCRIPTION
 
 Packs the stateless image from the chroot file system into a file to be sent to the node for a diskless boot.
 
-Note: For an osimage that is deployed on a cluster, running packimage will overwrite the existing rootimage file and be unavailable to the compute nodes while the command executes.
+Note: For an osimage that is deployed on a cluster, running packimage will overwrite the existing rootimage file and be unavailable to the compute nodes while packimage is running.
 
 
 **********

--- a/docs/source/guides/admin-guides/references/man5/site.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/site.5.rst
@@ -82,22 +82,28 @@ site Attributes:
                   details on supported formats.
   
    nodestatus:  If set to 'n', the nodelist.status column will not be updated during
-                the node deployment, node discovery and power operations. The default is to update.
+                the node deployment, node discovery and power operations. The default
+                is to update.
   
    skiptables:  Comma separated list of tables to be skipped by dumpxCATdb
   
-   skipvalidatelog:  If set to 1, then getcredentials and getpostscripts calls will not be logged in syslog.
+   skipvalidatelog:  If set to 1, then getcredentials and getpostscripts calls will not 
+                     be logged in syslog.
   
    -------------
   DHCP ATTRIBUTES
    -------------
-   dhcpinterfaces:  The network interfaces DHCP should listen on.  If it is the same
-                    for all nodes, use a simple comma-separated list of NICs.  To
-                    specify different NICs for different nodes:
-                         xcatmn|eth1,eth2;service|bond0.
-                    In this example xcatmn is the name of the xCAT MN, and DHCP there
-                    should listen on eth1 and eth2.  On all of the nodes in group
-                    'service' DHCP should listen on the bond0 nic.
+   dhcpinterfaces:  The network interfaces DHCP should listen on.  If it is the same for all
+                    nodes, use a comma-separated list of the NICs.  To specify different NICs
+                    for different nodes, use the format: "xcatmn|eth1,eth2;service|bond0", 
+                    where xcatmn is the name of the management node, DHCP should listen on 
+                    the eth1 and eth2 interfaces.  All the nodes in group 'service' should 
+                    listen on the 'bond0' interface.
+  
+                    To disable the genesis kernel from being sent to specific interfaces, a
+                    ':noboot' option can be appended to the interface name.  For example,
+                    if the management node has two interfaces, eth1 and eth2, disable
+                    genesis from being sent to eth1 using: "eth1:noboot,eth2".
   
    dhcpsetup:  If set to 'n', it will skip the dhcp setup process in the nodeset cmd.
   
@@ -120,18 +126,19 @@ site Attributes:
   DNS ATTRIBUTES
    ------------
    dnshandler:  Name of plugin that handles DNS setup for makedns.
+  
    domain:  The DNS domain name used for the cluster.
   
-   forwarders:  The DNS servers at your site that can provide names outside of the
-                cluster. The makedns command will configure the DNS on the management
-                node to forward requests it does not know to these servers.
-                Note that the DNS servers on the service nodes will ignore this value
-                and always be configured to forward requests to the management node.
+   forwarders:  The DNS servers at your site that can provide names outside of the cluster.
+                The makedns command will configure the DNS on the management node to foward
+                requests it does not know to these servers. Note that the DNS servers on the
+                service nodes will ignore this value and always be configured to forward 
+                to the management node.
   
    master:  The hostname of the xCAT management node, as known by the nodes.
   
-   nameservers:  A comma delimited list of DNS servers that each node in the cluster
-                 should use. This value will end up in the nameserver settings of the
+   nameservers:  A comma delimited list of DNS servers that each node in the cluster should
+                 use. This value will end up in the nameserver settings of the
                  /etc/resolv.conf on each node. It is common (but not required) to set
                  this attribute value to the IP addr of the xCAT management node, if
                  you have set up the DNS on the management node by running makedns.
@@ -148,16 +155,16 @@ site Attributes:
                  section. This is an interface for user to add configuration entries to
                  the zone sections in named.conf.
   
-   dnsinterfaces:  The network interfaces DNS server should listen on.  If it is the same
-                    for all nodes, use a simple comma-separated list of NICs.  To
-                    specify different NICs for different nodes:
-                         xcatmn|eth1,eth2;service|bond0.
-                    In this example xcatmn is the name of the xCAT MN, and DNS there
-                    should listen on eth1 and eth2.  On all of the nodes in group
-                    'service' DNS should listen on the bond0 nic.
-                    NOTE: if using this attribute to block certain interfaces, make sure
-                    the ip maps to your hostname of xCAT MN is not blocked since xCAT needs to
-                    use this ip to communicate with the local NDS server on MN.
+   dnsinterfaces:  The network interfaces DNS should listen on.  If it is the same for all
+                   nodes, use a simple comma-separated list of NICs.  To specify different 
+                   NICs for different nodes, use the format: "xcatmn|eth1,eth2;service|bond0", 
+                   where xcatmn is the name of the management node, and DNS should listen on
+                   the eth1 and eth2 interfaces.  All the nods in group 'service' should 
+                   listen on the 'bond0' interface.
+  
+                   NOTE: If using this attribute to block certain interfaces, make sure
+                   the IP maps to your hostname of xCAT MN is not blocked since xCAT needs
+                   to use this IP to communicate with the local NDS server on MN.
   
    -------------------------
   HARDWARE CONTROL ATTRIBUTES
@@ -200,12 +207,12 @@ site Attributes:
             It takes effects on other PPC hardware control command
             getmacs/rnetboot/rbootseq and so on. Default is 8.
   
-   syspowerinterval:  For system p CECs, this is the number of seconds the rpower
-                   command will wait between performing the action for each CEC.
-                   For system x IPMI servers, this is the number of seconds the
-                   rpower command will wait between powering on <syspowermaxnodes>
-                   nodes at a time.  This value is used to control the power on speed
-                   in large clusters. Default is 0.
+   syspowerinterval:  For SystemP CECs, this is the number of seconds the rpower command
+                      will wait between performing the action for each CEC.  For SystemX
+                      IPMI servers, this is the number of seconds the rpower command will
+                      wait between powering on <syspowermaxnodes> nodes at a time.  This
+                      value is used to control the power on speed in large clusters. 
+                      Default is 0.
   
    syspowermaxnodes:  The number of servers to power on at one time before waiting
                       'syspowerinterval' seconds to continue on to the next set of
@@ -291,12 +298,13 @@ site Attributes:
                 If value is set to a hostname, the directory in tftpdir
                 will be mounted from that hostname on the SN
   
-   sharedinstall: Indicates if a shared file system will be used for installation
-                 resources. Possible values are: 'no', 'sns', or 'all'.  'no' 
-                 means a shared file system is not being used.  'sns' means a
-                 shared filesystem is being used across all service nodes.
-                 'all' means that the management as well as the service nodes
-                 are all using a common shared filesystem. The default is 'no'.
+   sharedinstall:  Indicates if a shared file system will be used for installation
+                   resources. Possible values are: 'no', 'sns', or 'all'.  'no' 
+                   means a shared file system is not being used.  'sns' means a
+                   shared filesystem is being used across all service nodes.
+                   'all' means that the management as well as the service nodes
+                   are all using a common shared filesystem. The default is 'no'.
+  
    xcatconfdir:  Where xCAT config data is (default /etc/xcat).
   
    xcatdebugmode:  the xCAT debug level. xCAT provides a batch of techniques
@@ -315,23 +323,24 @@ site Attributes:
   REMOTESHELL ATTRIBUTES
    --------------------
    nodesyncfiledir:  The directory on the node, where xdcp will rsync the files
+  
    SNsyncfiledir:  The directory on the Service Node, where xdcp will rsync the files
                    from the MN that will eventually be rsync'd to the compute nodes.
   
-   sshbetweennodes:  Comma separated list of groups of compute nodes to enable passwordless root 
-                     ssh during install, or xdsh -K. Default is ALLGROUPS.
-                     Set to NOGROUPS,if you do not wish to enabled any group of compute nodes.
-                     Service Nodes are not affected by this attribute
-                     they are always setup with
-                     passwordless root access to nodes and other SN.
+   sshbetweennodes:  Comma separated list of groups of compute nodes to enable passwordless
+                     root ssh to the nodes during install or running 'xdsh -K'. The default
+                     is ALLGROUPS.  Set to NOGROUPS to disable.
+  
+                     Service Nodes are not affected by this attribute as they are always
+                     configured with passwordless root access.
                      If using the zone table, this attribute in not used.
   
    -----------------
   SERVICES ATTRIBUTES
    -----------------
    consoleondemand:  When set to 'yes', conserver connects and creates the console
-                     output only when the user opens the console. Default is no on
-                     Linux, yes on AIX.
+                     output only when the user opens the console. Default is 'no' on
+                     Linux, 'yes' on AIX.
   
    httpport:    The port number that the booting/installing nodes should contact the
                 http server on the MN/SN on. It is your responsibility to configure
@@ -355,12 +364,12 @@ site Attributes:
                    will use the management node's own hardware clock to calculate
                    the system date and time
   
-   svloglocal:  if set to 1, syslog on the service node will not get forwarded to the
-                mgmt node.
+   svloglocal:  If set to 1, syslog on the service node will not get forwarded to the
+                management node.
   
    timezone:  (e.g. America/New_York)
   
-   tftpdir:  tftp directory path. Default is /tftpboot
+   tftpdir:  The tftp directory path. Default is /tftpboot
   
    tftpflags:  The flags that used to start tftpd. Default is '-v -l -s /tftpboot 
                  -m /etc/tftpmapfile4xcat.conf' if tftplfags is not set
@@ -369,29 +378,24 @@ site Attributes:
                    using nmap (if available) from the management node instead of the
                    service node. This will improve the performance in a flat network.
   
-   vsftp:       Default is 'n'. If set to 'y', the xcatd on the mn will automatically
-                bring up vsftpd.  (You must manually install vsftpd before this.
-                This setting does not apply to the service node. For sn
-                you need to set servicenode.ftpserver=1 if you want xcatd to
-                bring up vsftpd.
- 
- 
- FQDNfirst: Fully Qualified Domain Name first. If set to 1/yes/enable, the /etc/hosts 
-            entries generated by 'makehosts' will put the FQDN before the PQDN(Partially 
-            Qualified Domain Name). Otherwise, the original behavior will be performed.
- 
- hierarchicalattrs: Table attributes(e.g. postscripts, postbootscripts) that will be
-                    included hierarchically. Attribute values for all the node's groups
-                    will be applied to the node in the groups' order except the repeat one.
- 
- 
- .. code-block:: perl
- 
+   vsftp:  Default is 'n'. If set to 'y', xcatd on the management node will automatically
+           start vsftpd.  (vsftpd must be installed by the admin).  This setting does not
+           apply to service nodes.  For service nodes, set servicenode.ftpserver=1.
+  
+   FQDNfirst:  Fully Qualified Domain Name first. If set to 1/yes/enable, the /etc/hosts 
+               entries generated by 'makehosts' will put the FQDN before the PQDN(Partially 
+               Qualified Domain Name). Otherwise, the original behavior will be performed.
+  
+   hierarchicalattrs:  Table attributes(e.g. postscripts, postbootscripts) that will be
+                       included hierarchically. Attribute values for all the node's groups
+                       will be applied to the node in the groups' order except the repeat one.
+  
    -----------------------
   VIRTUALIZATION ATTRIBUTES
    -----------------------
-   usexhrm:  Have xCAT run its xHRM script when booting up KVM guests to set the
-             virtual network bridge up correctly.
+   usexhrm:  Have xCAT execute the xHRM script when booting up KVM guests to configure
+             the virtual network bridge.
+  
    vcenterautojoin:  When set to no, the VMWare plugin will not attempt to auto remove
                      and add hypervisors while trying to perform operations.  If users
                      or tasks outside of xCAT perform the joining this assures xCAT

--- a/perl-xCAT/xCAT/Schema.pm
+++ b/perl-xCAT/xCAT/Schema.pm
@@ -937,18 +937,18 @@ passed as argument rather than by table value',
 
             # Do not put description text past column 88, so it displays well in a 100 char wide window.
             # ----------------------------------------------------------------------------------|----------
-            key => "Attribute Name:  Description\n\n" .
-              " ------------\n" .
-              "AIX ATTRIBUTES\n" .
-              " ------------\n" .
-" nimprime :   The name of NIM server, if not set default is the AIX MN.
-              If Linux MN, then must be set for support of mixed cluster (TBD).\n\n" .
+        key => "Attribute Name:  Description\n\n" .
+" ------------\n" .
+"AIX ATTRIBUTES\n" .
+" ------------\n" .
+" nimprime :   The name of NIM server, if not set default is the AIX MN.\n" .
+"              If Linux MN, then must be set for support of mixed cluster (TBD).\n\n" .
 " useSSHonAIX:  (yes/1 or no/0). Default is yes.  The support for rsh/rcp is deprecated.\n" .
 " useNFSv4onAIX:  (yes/1 or no/0). If yes, NFSv4 will be used with NIM. If no,\n" .
-              "               NFSv3 will be used with NIM. Default is no.\n\n" .
-              " -----------------\n" .
-              "DATABASE ATTRIBUTES\n" .
-              " -----------------\n" .
+"               NFSv3 will be used with NIM. Default is no.\n\n" .
+" -----------------\n" .
+"DATABASE ATTRIBUTES\n" .
+" -----------------\n" .
 " auditnosyslog: If set to 1, then commands will only be written to the auditlog table.\n" .
 "                This attribute set to 1 and auditskipcmds=ALL means no logging of commands.\n" .
 "                Default is to write to both the auditlog table and syslog.\n" .
@@ -967,21 +967,26 @@ passed as argument rather than by table value',
 " excludenodes:  A set of comma separated nodes and/or groups that would automatically\n" .
 "                be subtracted from any noderange, it can be used for excluding some\n" .
 "                failed nodes for any xCAT commands. See the 'noderange' manpage for\n" .
-              "                details on supported formats.\n\n" .
+"                details on supported formats.\n\n" .
 " nodestatus:  If set to 'n', the nodelist.status column will not be updated during\n" .
-"              the node deployment, node discovery and power operations. The default is to update.\n\n" .
+"              the node deployment, node discovery and power operations. The default\n" .
+"              is to update.\n\n" .
 " skiptables:  Comma separated list of tables to be skipped by dumpxCATdb\n\n" .
-" skipvalidatelog:  If set to 1, then getcredentials and getpostscripts calls will not be logged in syslog.\n\n" .
-              " -------------\n" .
-              "DHCP ATTRIBUTES\n" .
-              " -------------\n" .
-" dhcpinterfaces:  The network interfaces DHCP should listen on.  If it is the same\n" .
-"                  for all nodes, use a simple comma-separated list of NICs.  To\n" .
-"                  specify different NICs for different nodes:\n" .
-              "                       xcatmn|eth1,eth2;service|bond0.\n" .
-"                  In this example xcatmn is the name of the xCAT MN, and DHCP there\n" .
-"                  should listen on eth1 and eth2.  On all of the nodes in group\n" .
-"                  'service' DHCP should listen on the bond0 nic.\n\n" .
+" skipvalidatelog:  If set to 1, then getcredentials and getpostscripts calls will not \n" .
+"                   be logged in syslog.\n\n" .
+" -------------\n" .
+"DHCP ATTRIBUTES\n" .
+" -------------\n" .
+" dhcpinterfaces:  The network interfaces DHCP should listen on.  If it is the same for all\n" .
+"                  nodes, use a comma-separated list of the NICs.  To specify different NICs\n" .
+"                  for different nodes, use the format: \"xcatmn|eth1,eth2;service|bond0\", \n" .
+"                  where xcatmn is the name of the management node, DHCP should listen on \n" .
+"                  the eth1 and eth2 interfaces.  All the nodes in group 'service' should \n" .
+"                  listen on the 'bond0' interface.\n\n" .
+"                  To disable the genesis kernel from being sent to specific interfaces, a\n" .
+"                  ':noboot' option can be appended to the interface name.  For example,\n" .
+"                  if the management node has two interfaces, eth1 and eth2, disable\n" .
+"                  genesis from being sent to eth1 using: \"eth1:noboot,eth2\".\n\n" .
 " dhcpsetup:  If set to 'n', it will skip the dhcp setup process in the nodeset cmd.\n\n" .
 " dhcplease:  The lease time for the dhcp client. The default value is 43200.\n\n" .
 " disjointdhcps:  If set to '1', the .leases file on a service node only contains\n" .
@@ -993,78 +998,77 @@ passed as argument rather than by table value',
 "                     If set to 'static', the network configuration will be configured \n" .
 "                     in static mode based on the node and network definition on MN.\n" .
 "                     If set to 'dhcp', the network will be configured with dhcp protocol.\n" .
-              "                     The default is 'dhcp'.\n\n" .
-              " ------------\n" .
-              "DNS ATTRIBUTES\n" .
-              " ------------\n" .
-" dnshandler:  Name of plugin that handles DNS setup for makedns.\n" .
-              " domain:  The DNS domain name used for the cluster.\n\n" .
-" forwarders:  The DNS servers at your site that can provide names outside of the\n" .
-"              cluster. The makedns command will configure the DNS on the management\n" .
-"              node to forward requests it does not know to these servers.\n" .
-"              Note that the DNS servers on the service nodes will ignore this value\n" .
-"              and always be configured to forward requests to the management node.\n\n" .
+"                     The default is 'dhcp'.\n\n" .
+" ------------\n" .
+"DNS ATTRIBUTES\n" .
+" ------------\n" .
+" dnshandler:  Name of plugin that handles DNS setup for makedns.\n\n" .
+" domain:  The DNS domain name used for the cluster.\n\n" .
+" forwarders:  The DNS servers at your site that can provide names outside of the cluster.\n" .
+"              The makedns command will configure the DNS on the management node to foward\n" .
+"              requests it does not know to these servers. Note that the DNS servers on the\n" .
+"              service nodes will ignore this value and always be configured to forward \n" .
+"              to the management node.\n\n" .
 " master:  The hostname of the xCAT management node, as known by the nodes.\n\n" .
-" nameservers:  A comma delimited list of DNS servers that each node in the cluster\n" .
-"               should use. This value will end up in the nameserver settings of the\n" .
+" nameservers:  A comma delimited list of DNS servers that each node in the cluster should\n" .
+"               use. This value will end up in the nameserver settings of the\n" .
 "               /etc/resolv.conf on each node. It is common (but not required) to set\n" .
 "               this attribute value to the IP addr of the xCAT management node, if\n" .
 "               you have set up the DNS on the management node by running makedns.\n" .
 "               In a hierarchical cluster, you can also set this attribute to\n" .
 "               \"<xcatmaster>\" to mean the DNS server for each node should be the\n" .
 "               node that is managing it (either its service node or the management\n" .
-              "               node).\n\n" .
+"               node).\n\n" .
 " externaldns:  To specify that external dns is used. If externaldns is set to any value\n" .
 "               then, makedns command will not start the local nameserver on xCAT MN. \n" .
-              "               Default is to start the local nameserver.\n\n" .
+"               Default is to start the local nameserver.\n\n" .
 " dnsupdaters:  The value are \',\' separated string which will be added to the zone config\n" .
 "               section. This is an interface for user to add configuration entries to\n" .
-              "               the zone sections in named.conf.\n\n" .
-" dnsinterfaces:  The network interfaces DNS server should listen on.  If it is the same\n" .
-"                  for all nodes, use a simple comma-separated list of NICs.  To\n" .
-"                  specify different NICs for different nodes:\n" .
-              "                       xcatmn|eth1,eth2;service|bond0.\n" .
-"                  In this example xcatmn is the name of the xCAT MN, and DNS there\n" .
-"                  should listen on eth1 and eth2.  On all of the nodes in group\n" .
-"                  'service' DNS should listen on the bond0 nic.\n" .
-"                  NOTE: if using this attribute to block certain interfaces, make sure\n" .
-"                  the ip maps to your hostname of xCAT MN is not blocked since xCAT needs to\n" .
-"                  use this ip to communicate with the local NDS server on MN.\n\n" .
-              " -------------------------\n" .
-              "HARDWARE CONTROL ATTRIBUTES\n" .
-              " -------------------------\n" .
+"               the zone sections in named.conf.\n\n" .
+" dnsinterfaces:  The network interfaces DNS should listen on.  If it is the same for all\n" .
+"                 nodes, use a simple comma-separated list of NICs.  To specify different \n" .
+"                 NICs for different nodes, use the format: \"xcatmn|eth1,eth2;service|bond0\", \n" .
+"                 where xcatmn is the name of the management node, and DNS should listen on\n" .
+"                 the eth1 and eth2 interfaces.  All the nods in group 'service' should \n" . 
+"                 listen on the 'bond0' interface.\n\n" .
+"                 NOTE: If using this attribute to block certain interfaces, make sure\n" .
+"                 the IP maps to your hostname of xCAT MN is not blocked since xCAT needs\n" .
+"                 to use this IP to communicate with the local NDS server on MN.\n\n" .
+" -------------------------\n" .
+"HARDWARE CONTROL ATTRIBUTES\n" .
+" -------------------------\n" .
 " blademaxp:  The maximum number of concurrent processes for blade hardware control.\n\n" .
 " ea_primary_hmc:  The hostname of the HMC that the Integrated Switch Network\n" .
 "                  Management Event Analysis should send hardware serviceable\n" .
 "                  events to for processing and potentially sending to IBM.\n\n" .
 " ea_backup_hmc:  The hostname of the HMC that the Integrated Switch Network\n" .
 "                  Management Event Analysis should send hardware serviceable\n" .
-              "                  events to if the primary HMC is down.\n\n" .
+"                  events to if the primary HMC is down.\n\n" .
 " enableASMI:  (yes/1 or no/0). If yes, ASMI method will be used after fsp-api. If no,\n" .
 "               when fsp-api is used, ASMI method will not be used. Default is no.\n\n" .
 " fsptimeout:  The timeout, in milliseconds, to use when communicating with FSPs.\n\n" .
 " hwctrldispatch:  Whether or not to send hw control operations to the service\n" .
 "                  node of the target nodes. Default is 'y'.(At present, this attribute\n" .
-              "                  is only used for IBM Flex System)\n\n" .
+"                  is only used for IBM Flex System)\n\n" .
 " ipmidispatch:  Whether or not to send ipmi hw control operations to the service\n" .
 "                node of the target compute nodes. Default is 'y'.\n\n" .
 " ipmimaxp:  The max # of processes for ipmi hw ctrl. The default is 64. Currently,\n" .
-              "            this is only used for HP hw control.\n\n" .
+"            this is only used for HP hw control.\n\n" .
 " ipmiretries:  The # of retries to use when communicating with BMCs. Default is 3.\n\n" .
 " ipmisdrcache:  If set to 'no', then the xCAT IPMI support will not cache locally\n" .
 "                the target node's SDR cache to improve performance.\n\n" .
 " ipmitimeout:  The timeout to use when communicating with BMCs. Default is 2.\n" .
-              "               This attribute is currently not used.\n\n" .
+"               This attribute is currently not used.\n\n" .
 " maxssh:  The max # of SSH connections at any one time to the hw ctrl point for PPC\n" .
 "          This parameter doesn't take effect on the rpower command.\n" .
 "          It takes effects on other PPC hardware control command\n" .
 "          getmacs/rnetboot/rbootseq and so on. Default is 8.\n\n" .
-" syspowerinterval:  For system p CECs, this is the number of seconds the rpower\n" .
-"                 command will wait between performing the action for each CEC.\n" .
-"                 For system x IPMI servers, this is the number of seconds the\n" .
-"                 rpower command will wait between powering on <syspowermaxnodes>\n" .
-"                 nodes at a time.  This value is used to control the power on speed\n" .
-              "                 in large clusters. Default is 0.\n\n" .
+" syspowerinterval:  For SystemP CECs, this is the number of seconds the rpower command\n" .
+"                    will wait between performing the action for each CEC.  For SystemX\n" .
+"                    IPMI servers, this is the number of seconds the rpower command will\n" .
+"                    wait between powering on <syspowermaxnodes> nodes at a time.  This\n" .
+"                    value is used to control the power on speed in large clusters. \n" .
+"                    Default is 0.\n\n" .
 " syspowermaxnodes:  The number of servers to power on at one time before waiting\n" .
 "                    'syspowerinterval' seconds to continue on to the next set of\n" .
 "                    nodes.  If the noderange given to rpower includes nodes served\n" .
@@ -1081,18 +1085,18 @@ passed as argument rather than by table value',
 "           processes for PPC hardware control commands. Default is 64.\n\n" .
 " ppcretry:  The max # of PPC hw connection attempts to HMC before failing.\n" .
 "           It only takes effect on the hardware control commands through HMC. \n" .
-              "           Default is 3.\n\n" .
+"           Default is 3.\n\n" .
 " ppctimeout:  The timeout, in milliseconds, to use when communicating with PPC hw\n" .
 "              through HMC. It only takes effect on the hardware control commands\n" .
-              "              through HMC. Default is 0.\n\n" .
+"              through HMC. Default is 0.\n\n" .
 " snmpc:  The snmp community string that xcat should use when communicating with the\n" .
-              "         switches.\n\n" .
-              " ---------------------------\n" .
-              "INSTALL/DEPLOYMENT ATTRIBUTES\n" .
-              " ---------------------------\n" .
+"         switches.\n\n" .
+" ---------------------------\n" .
+"INSTALL/DEPLOYMENT ATTRIBUTES\n" .
+" ---------------------------\n" .
 " cleanupxcatpost:  (yes/1 or no/0). Set to 'yes' or '1' to clean up the /xcatpost\n" .
 "                   directory on the stateless and statelite nodes after the\n" .
-              "                   postscripts are run. Default is no.\n\n" .
+"                   postscripts are run. Default is no.\n\n" .
 " db2installloc:  The location which the service nodes should mount for\n" .
 "                 the db2 code to install. Format is hostname:/path.  If hostname is\n" .
 "                 omitted, it defaults to the management node. Default is /mntdb2.\n\n" .
@@ -1100,18 +1104,18 @@ passed as argument rather than by table value',
 " defserialport:  The default serial port - currently only used by mknb.\n\n" .
 " defserialspeed:  The default serial speed - currently only used by mknb.\n\n" .
 " genmacprefix:  When generating mac addresses automatically, use this manufacturing\n" .
-              "                prefix (e.g. 00:11:aa)\n\n" .
+"                prefix (e.g. 00:11:aa)\n\n" .
 " genpasswords:  Automatically generate random passwords for BMCs when configuring\n" .
-              "                them.\n\n" .
+"                them.\n\n" .
 " installdir:  The local directory name used to hold the node deployment packages.\n\n" .
 " installloc:  The location from which the service nodes should mount the \n" .
 "              deployment packages in the format hostname:/path.  If hostname is\n" .
 "              omitted, it defaults to the management node. The path must\n" .
-              "              match the path in the installdir attribute.\n\n" .
+"              match the path in the installdir attribute.\n\n" .
 " iscsidir:  The path to put the iscsi disks in on the mgmt node.\n\n" .
 " mnroutenames:  The name of the routes to be setup on the management node.\n" .
 "                It is a comma separated list of route names that are defined in the\n" .
-              "                routes table.\n\n" .
+"                routes table.\n\n" .
 " runbootscripts:  If set to 'yes' the scripts listed in the postbootscripts\n" .
 "                  attribute in the osimage and postscripts tables will be run during\n" .
 "                  each reboot of stateful (diskful) nodes. This attribute has no\n" .
@@ -1127,44 +1131,43 @@ passed as argument rather than by table value',
 " sharedtftp:  Set to 0 or no, xCAT should not assume the directory\n" .
 "              in tftpdir is mounted on all on Service Nodes. Default is 1/yes.\n" .
 "              If value is set to a hostname, the directory in tftpdir\n" .
-              "              will be mounted from that hostname on the SN\n\n" .
-" sharedinstall: Indicates if a shared file system will be used for installation\n" .
-"               resources. Possible values are: 'no', 'sns', or 'all'.  'no' \n" .
-"               means a shared file system is not being used.  'sns' means a\n" .
-"               shared filesystem is being used across all service nodes.\n" .
-"               'all' means that the management as well as the service nodes\n" .
-"               are all using a common shared filesystem. The default is 'no'.\n" .
+"              will be mounted from that hostname on the SN\n\n" .
+" sharedinstall:  Indicates if a shared file system will be used for installation\n" .
+"                 resources. Possible values are: 'no', 'sns', or 'all'.  'no' \n" .
+"                 means a shared file system is not being used.  'sns' means a\n" .
+"                 shared filesystem is being used across all service nodes.\n" .
+"                 'all' means that the management as well as the service nodes\n" .
+"                 are all using a common shared filesystem. The default is 'no'.\n\n" .
 " xcatconfdir:  Where xCAT config data is (default /etc/xcat).\n\n" .
 " xcatdebugmode:  the xCAT debug level. xCAT provides a batch of techniques\n" .
 "                 to help user debug problems while using xCAT, especially on OS provision,\n" .
 "                 such as collecting logs of the whole installation process and accessing\n" .
 "                 the installing system via ssh, etc. These techniques will be enabled\n" .
 "                 according to different xCAT debug levels specified by 'xcatdebugmode',\n" .
-              "                 currently supported values:\n" .
-              "                   '0':  disable debug mode\n" .
-              "                   '1':  enable basic debug mode\n" .
-              "                   '2':  enable expert debug mode\n" .
+"                 currently supported values:\n" .
+"                   '0':  disable debug mode\n" .
+"                   '1':  enable basic debug mode\n" .
+"                   '2':  enable expert debug mode\n" .
 "                 For the details on 'basic debug mode' and 'expert debug mode',\n" .
-              "                 refer to xCAT documentation.\n\n" .
-              " --------------------\n" .
-              "REMOTESHELL ATTRIBUTES\n" .
-              " --------------------\n" .
-" nodesyncfiledir:  The directory on the node, where xdcp will rsync the files\n" .
+"                 refer to xCAT documentation.\n\n" .
+" --------------------\n" .
+"REMOTESHELL ATTRIBUTES\n" .
+" --------------------\n" .
+" nodesyncfiledir:  The directory on the node, where xdcp will rsync the files\n\n" .
 " SNsyncfiledir:  The directory on the Service Node, where xdcp will rsync the files\n" .
 "                 from the MN that will eventually be rsync'd to the compute nodes.\n\n" .
-" sshbetweennodes:  Comma separated list of groups of compute nodes to enable passwordless root \n" .
-"                   ssh during install, or xdsh -K. Default is ALLGROUPS.\n" .
-"                   Set to NOGROUPS,if you do not wish to enabled any group of compute nodes.\n" .
-"                   Service Nodes are not affected by this attribute\n" .
-              "                   they are always setup with\n" .
-"                   passwordless root access to nodes and other SN.\n" .
+" sshbetweennodes:  Comma separated list of groups of compute nodes to enable passwordless\n" .
+"                   root ssh to the nodes during install or running 'xdsh -K'. The default\n" .
+"                   is ALLGROUPS.  Set to NOGROUPS to disable.\n\n" .
+"                   Service Nodes are not affected by this attribute as they are always\n" .
+"                   configured with passwordless root access.\n" .
 "                   If using the zone table, this attribute in not used.\n\n" .
-              " -----------------\n" .
-              "SERVICES ATTRIBUTES\n" .
-              " -----------------\n" .
+" -----------------\n" .
+"SERVICES ATTRIBUTES\n" .
+" -----------------\n" .
 " consoleondemand:  When set to 'yes', conserver connects and creates the console\n" .
-"                   output only when the user opens the console. Default is no on\n" .
-              "                   Linux, yes on AIX.\n\n" .
+"                   output only when the user opens the console. Default is 'no' on\n" .
+"                   Linux, 'yes' on AIX.\n\n" .
 " httpport:    The port number that the booting/installing nodes should contact the\n" .
 "              http server on the MN/SN on. It is your responsibility to configure\n" .
 "              the http server to listen on that port - xCAT will not do that.\n\n" .
@@ -1174,7 +1177,7 @@ passed as argument rather than by table value',
 "              For example, if the network response time is too slow, nmap may not\n" .
 "              give stable output. You can increase the timeout value by specifying \n" .
 "              '--min-rtt-timeout 1s'. xCAT will append the options defined here to \n" .
-              "              the nmap command.\n\n" .
+"              the nmap command.\n\n" .
 " ntpservers:  A comma delimited list of NTP servers for the service node and\n" .
 "              the compute node to sync with. The keyword <xcatmaster> means that\n" .
 "              the node's NTP server is the node that is managing it\n" .
@@ -1182,45 +1185,43 @@ passed as argument rather than by table value',
 " extntpservers:  A comma delimited list of external NTP servers for the xCAT\n" .
 "                 management node to sync with. If it is empty, the NTP server\n" .
 "                 will use the management node's own hardware clock to calculate\n" .
-              "                 the system date and time\n\n" .
-" svloglocal:  if set to 1, syslog on the service node will not get forwarded to the\n" .
-              "              mgmt node.\n\n" .
-              " timezone:  (e.g. America/New_York)\n\n" .
-              " tftpdir:  tftp directory path. Default is /tftpboot\n\n" .
+"                 the system date and time\n\n" .
+" svloglocal:  If set to 1, syslog on the service node will not get forwarded to the\n" .
+"              management node.\n\n" .
+" timezone:  (e.g. America/New_York)\n\n" .
+" tftpdir:  The tftp directory path. Default is /tftpboot\n\n" .
 " tftpflags:  The flags that used to start tftpd. Default is \'-v -l -s /tftpboot \n" .
 "               -m /etc/tftpmapfile4xcat.conf\' if tftplfags is not set\n\n" .
 " useNmapfromMN:  When set to yes, nodestat command should obtain the node status\n" .
 "                 using nmap (if available) from the management node instead of the\n" .
 "                 service node. This will improve the performance in a flat network.\n\n" .
-" vsftp:       Default is 'n'. If set to 'y', the xcatd on the mn will automatically\n" .
-"              bring up vsftpd.  (You must manually install vsftpd before this.\n" .
-"              This setting does not apply to the service node. For sn\n" .
-"              you need to set servicenode.ftpserver=1 if you want xcatd to\n" .
-              "              bring up vsftpd.\n\n" .
-"FQDNfirst: Fully Qualified Domain Name first. If set to 1/yes/enable, the /etc/hosts \n" .
-"           entries generated by 'makehosts' will put the FQDN before the PQDN(Partially \n" .
-"           Qualified Domain Name). Otherwise, the original behavior will be performed.\n\n" .
-"hierarchicalattrs: Table attributes(e.g. postscripts, postbootscripts) that will be\n" .
-"                   included hierarchically. Attribute values for all the node's groups\n" .
-"                   will be applied to the node in the groups' order except the repeat one.\n\n" .
-              " -----------------------\n" .
-              "VIRTUALIZATION ATTRIBUTES\n" .
-              " -----------------------\n" .
-" usexhrm:  Have xCAT run its xHRM script when booting up KVM guests to set the\n" .
-              "           virtual network bridge up correctly.\n" .
+" vsftp:  Default is 'n'. If set to 'y', xcatd on the management node will automatically\n" .
+"         start vsftpd.  (vsftpd must be installed by the admin).  This setting does not\n" .
+"         apply to service nodes.  For service nodes, set servicenode.ftpserver=1.\n\n" .
+" FQDNfirst:  Fully Qualified Domain Name first. If set to 1/yes/enable, the /etc/hosts \n" .
+"             entries generated by 'makehosts' will put the FQDN before the PQDN(Partially \n" .
+"             Qualified Domain Name). Otherwise, the original behavior will be performed.\n\n" .
+" hierarchicalattrs:  Table attributes(e.g. postscripts, postbootscripts) that will be\n" .
+"                     included hierarchically. Attribute values for all the node's groups\n" .
+"                     will be applied to the node in the groups' order except the repeat one.\n\n" .
+" -----------------------\n" .
+"VIRTUALIZATION ATTRIBUTES\n" .
+" -----------------------\n" .
+" usexhrm:  Have xCAT execute the xHRM script when booting up KVM guests to configure\n" .
+"           the virtual network bridge.\n\n" .
 " vcenterautojoin:  When set to no, the VMWare plugin will not attempt to auto remove\n" .
 "                   and add hypervisors while trying to perform operations.  If users\n" .
 "                   or tasks outside of xCAT perform the joining this assures xCAT\n" .
-              "                   will not interfere.\n\n" .
+"                   will not interfere.\n\n" .
 " vmwarereconfigonpower:  When set to no, the VMWare plugin will make no effort to\n" .
 "                         push vm.cpus/vm.memory updates from xCAT to VMWare.\n\n" .
 " persistkvmguests:  Keep the kvm definition on the kvm hypervisor when you power off\n" .
 "                    the kvm guest node. This is useful for you to manually change the \n" .
 "                    kvm xml definition file in virsh for debugging. Set anything means\n" .
-              "                    enable.\n\n" .
-              " --------------------\n" .
-              "XCAT DAEMON ATTRIBUTES\n" .
-              " --------------------\n" .
+"                    enable.\n\n" .
+" --------------------\n" .
+"XCAT DAEMON ATTRIBUTES\n" .
+" --------------------\n" .
 " useflowcontrol:  (yes/1 or no/0). If yes, the postscript processing on each node\n" .
 "               contacts xcatd on the MN/SN using a lightweight UDP packet to wait\n" .
 "               until xcatd is ready to handle the requests associated with\n" .
@@ -1228,9 +1229,9 @@ passed as argument rather than by table value',
 "               locking out admin interactive use. This value works with the\n" .
 "               xcatmaxconnections and xcatmaxbatch attributes. Is not supported on AIX.\n" .
 "               If the value is no, nodes sleep for a random time before contacting\n" .
-              "               xcatd, and retry. The default is no.\n" .
-              "               See the following document for details:\n" .
-              "               Hints_and_Tips_for_Large_Scale_Clusters\n\n" .
+"               xcatd, and retry. The default is no.\n" .
+"               See the following document for details:\n" .
+"               Hints_and_Tips_for_Large_Scale_Clusters\n\n" .
 " xcatmaxconnections:  Number of concurrent xCAT protocol requests before requests\n" .
 "                      begin queueing. This applies to both client command requests\n" .
 "                      and node requests, e.g. to get postscripts. Default is 64.\n\n" .
@@ -1240,7 +1241,7 @@ passed as argument rather than by table value',
 " xcatiport:  The port used by xcatd to receive install status updates from nodes.\n\n" .
 " xcatlport:  The port used by xcatd command log writer process to collect command output.\n\n" .
 " xcatsslversion:  The ssl version by xcatd. Default is SSLv3.\n\n" .
-              " xcatsslciphers:  The ssl cipher by xcatd. Default is 3DES.\n\n",
+" xcatsslciphers:  The ssl cipher by xcatd. Default is 3DES.\n\n",
             value => 'The value of the attribute specified in the "key" column.',
             comments => 'Any user-written notes.',
             disable  => "Set to 'yes' or '1' to comment out this row.",


### PR DESCRIPTION
In reference to the changes for #1881 

Add documentation describing the noboot attribute for Minsky Servers
In the process, cleaned up some of the text for the site table man page