### PR TITLE
Update xcattest for default file deleted

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/xcattest.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/xcattest.1.rst
@@ -21,11 +21,21 @@ SYNOPSIS
 
 \ **xcattest**\  [\ **-?|-h**\ ]
 
-\ **xcattest**\  [\ **-f**\  \ *configure file*\ ] [\ **-b**\  \ *case bundle list*\ ] [\ **-l**\ ]
+\ **xcattest**\  [\ **-f**\  \ *configure file*\ ] [\ **-b**\  \ *case bundle list*\ ]
 
 \ **xcattest**\  [\ **-f**\  \ *configure file*\ ] [\ **-t**\  \ *case list*\ ]
 
-\ **xcattest**\  [\ **-f**\  \ *configure file*\ ] [\ **-c**\  \ *cmd list*\ ] [\ **-l**\ ]
+\ **xcattest**\  [\ **-f**\  \ *configure file*\ ] [\ **-c**\  \ *cmd list*\ ]
+
+\ **xcattest**\  [\ **-b**\  \ *case bundle list*\ ] [\ **-l**\ ]
+
+\ **xcattest**\  [\ **-t**\  \ *case list*\ ] [\ **-l**\ ]
+
+\ **xcattest**\  [\ **-c**\  \ *cmd list*\ ] [\ **-l**\ ]
+
+\ **xcattest**\  [\ **-s**\  \ *command*\ ]
+
+\ **xcattest**\  [\ **-s**\  \ *bundle*\ ]
 
 
 ***********
@@ -52,7 +62,7 @@ OPTIONS
 
 \ **-f**\  \ *configure file*\ 
  
- Specifies the configuration file, if not specified, the default configure file is /opt/xcat/share/xcat/tools/autotest/default.conf.
+Specifies the configuration file with full-path. xCAT supports an example config file: /opt/xcat/share/xcat/tools/autotest/linux.conf.template
  
 
 
@@ -79,7 +89,9 @@ OPTIONS
  Display the test cases names specified by the flag -b, -t or -c.
  
 
+\ **-s**\
 
+ Display the bundle files and command with value: bundle or command.
 
 ************
 RETURN VALUE
@@ -136,33 +148,33 @@ EXAMPLES
  
  .. code-block:: perl
  
-    xcattest -c /tmp/config -c rpower
+    xcattest -f /tmp/config -c rpower
  
  
 
 
 2.
  
- To run customized bundle:
+ To run customized bundle with /tmp/config file:
  
  
  .. code-block:: perl
  
-    xcattest -l  > /tmp/custom.bundle
+    xcattest -l  > /opt/xcat/share/xcat/tools/autotest/bundle/custom.bundle
     Modify custom.bundle
-    xcattest -b custom.bundle
+    xcattest -f /tmp/config -b custom.bundle
  
  
 
 
 3.
  
- To run specified test cases.
+ To run specified test cases with /tmp/config:
  
  
  .. code-block:: perl
  
-    xcattest -t lsdef_t_o_l_z
+    xcattest -f /tmp/config -t lsdef_t_o_l_z
  
  
 

--- a/xCAT-test/pods/man1/xcattest.1.pod
+++ b/xCAT-test/pods/man1/xcattest.1.pod
@@ -6,11 +6,21 @@ B<xcattest> - Run automated xCAT test cases.
 
 B<xcattest> [B<-?|-h>] 
 
-B<xcattest> [B<-f> I<configure file>] [B<-b> I<case bundle list>] [B<-l>]
+B<xcattest> [B<-f> I<configure file>] [B<-b> I<case bundle list>] 
 
 B<xcattest> [B<-f> I<configure file>] [B<-t> I<case list>]
 
-B<xcattest> [B<-f> I<configure file>] [B<-c> I<cmd list>] [B<-l>]
+B<xcattest> [B<-f> I<configure file>] [B<-c> I<cmd list>]
+
+B<xcattest> [B<-b> I<case bundle list>] [B<-l>]
+
+B<xcattest> [B<-t> I<case list>] [B<-l>]
+
+B<xcattest> [B<-c> I<cmd list>] [B<-l>]
+
+B<xcattest> [B<-s> B<command>]
+
+B<xcattest> [B<-s> B<bundle>]
 
 =head1 DESCRIPTION
 
@@ -28,11 +38,11 @@ Display usage message.
 
 =item B<-f> I<configure file>
 
-Specifies the configuration file, if not specified, the default configure file is /opt/xcat/share/xcat/tools/autotest/default.conf.
+Specifies the configuration file with full-path. xCAT supports an example config file: /opt/xcat/share/xcat/tools/autotest/linux.conf.template
 
 =item B<-b> I<case bundle list>
 
-Comma separated list of test cases bundle files, each test cases bundle can contain multiple lines and each line for one test case name. 
+Comma separated list of test cases bundle files, each test cases bundle can contain multiple lines and each line for one test case name. The bundle files should be listed in: /opt/xcat/share/xcat/tools/autotest/bundle.
 
 =item B<-t> I<cases list>
 
@@ -45,6 +55,10 @@ Comma separated list of commands which will be tested, i.e., all the test cases 
 =item B<-l>
 
 Display the test cases names specified by the flag -b, -t or -c.
+
+=item B<-s>
+
+Display the bundle files and command with value: bundle or command.
 
 =back
 
@@ -86,21 +100,21 @@ B<Note>: Each test case can have more than one I<cmd> sections and each I<cmd> s
 
 To run all  test cases related command rpower:
 
-  xcattest -c /tmp/config -c rpower
+  xcattest -f /tmp/config -c rpower
 
 =item 2.
 
-To run customized bundle:
+To run customized bundle with /tmp/config file:
 
-  xcattest -l  > /tmp/custom.bundle
+  xcattest -c lsdef -l  > /opt/xcat/share/xcat/tools/autotest/bundle/custom.bundle
   Modify custom.bundle
-  xcattest -b custom.bundle
+  xcattest -f /tmp/config -b custom.bundle
 
 =item 3.
 
-To run specified test cases.
+To run specified test cases with /tmp/config file:
 
-  xcattest -t lsdef_t_o_l_z 
+  xcattest -f /tmp/config -t lsdef_t_o_l_z 
 
 =item 4.
 

--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -17,7 +17,8 @@ use lib "$::XCATROOT/lib/perl";
 my $rootdir         = "$::XCATROOT/share/xcat/tools/autotest";
 my $needhelp        = 0;
 my $configinfo      = undef;
-my $configfile      = "$rootdir/default.conf";
+#my $configfile      = "$rootdir/default.conf";
+my $configfile      = undef;
 my $casedir         = "$rootdir/testcase";
 my $bundledir       = "$rootdir/bundle";
 my $resultdir       = "$rootdir/result";
@@ -768,7 +769,6 @@ sub loadcase
     
     if ($needshow) {
         if (@cases) {
-            log_this("Test cases:");            
             foreach my $case (@cases) {
                 log_this("$case->{name}");
             }
@@ -1063,9 +1063,10 @@ sub usage
     log_this("  xcattest [-f configure file] [-t cases list]");
     log_this("  xcattest [-f configure file] [-c cmds list]");
     log_this("Show xcat test cases, bundle files, commands lists:");
-    log_this("  xcattest [-f configure file] [-b case bundle files] [-l]");
-    log_this("  xcattest [-f configure file] [-t cases list] [-l]");
-    log_this("  xcattest [-f configure file] [-c cmds list] [-l]");
+    log_this("  xcattest [-b case bundle files] [-l]");
+    log_this("  xcattest [-t cases list] [-l]");
+    log_this("  xcattest [-c cmds list] [-l]");
+    log_this("Show all bundle files, all commands:");
     log_this("  xcattest [-s command|bundle]");
     log_this("");
     return;
@@ -1111,7 +1112,7 @@ sub listbundlefiles
          }
          close(FILE);
          if (!$skip){
-             $bundlefilesinfo{$bundlefile} = "No description, add \"description: details\" in this bundle file";
+             $bundlefilesinfo{$bundlefile} = "No description, add with \"description: details\" in bundle file";
          }
      }
      &listformatbundleinfo(%bundlefilesinfo);
@@ -1132,8 +1133,9 @@ sub listformatbundleinfo
     my $finallen = ($screenwidth > $desiredwidth ? $desiredwidth : $screenwidth);
 
     print "bundle files and descriptions:\n";
-
-    foreach my $filename (keys %bundlefilesinfo) {
+    
+    foreach my $filename (sort { $a cmp $b } keys %bundlefilesinfo ) { 
+   # foreach my $filename (keys %bundlefilesinfo) {
         my @desc       = split(" ", $bundlefilesinfo{$filename});
         my $str        = "";
         my @formatdesc = ();
@@ -1242,8 +1244,13 @@ sub checkoptions
     if (!defined($bundlelist) && !defined($caselist) && !defined($cmdlist) && !defined($showbundlesorcommands)) {
         log_this("Error: please define options correctly, see below usage information:");
         return 1;
+    }elsif ((defined($bundlelist) || defined($caselist) || defined($cmdlist)) && (! $needshow) && !defined($configinfo)) {
+        #config file must be defined if the using -c,-b,-t to run test cases
+        log_this("Error: To run test cases, please define the config file with -f option");
+        log_this("       To show test cases, please use the -l option");
+        return 1;
     }elsif (defined($showbundlesorcommands) && (defined($bundlelist) || defined($caselist) || defined($cmdlist))) {
-    # -s can't be used together with -c,-b,-t 
+        #-s can't be used together with -c,-b,-t 
         log_this("Error: -b,-c or -t can't be used together with -s");
         return 1;
     }elsif (defined($showbundlesorcommands) && $needshow) {
@@ -1251,7 +1258,7 @@ sub checkoptions
 	return 1;
     } 
     
-    #check the L option, it only should be bundle or command
+    #check the -s option, the value should be bundle or command
     if (defined($showbundlesorcommands)) {
        if (($showbundlesorcommands ne "bundle") && ($showbundlesorcommands ne "command")) {
            log_this("Error: please use \"bundle\" or \"command\" as the \-s value");
@@ -1262,10 +1269,11 @@ sub checkoptions
        }          
            $showcommandslist= 1;
     }
+
     #get and check config file and System label
     #this System label means only the [System] variable will be loaded
-    if ($configinfo) {   
-          if ($configinfo =~ /(.*):(.*)/) {
+    if (defined($configinfo)) {   
+        if ($configinfo =~ /(.*):(.*)/) {
             $configfile  = $1;
             $initallabel = $2;
             if ($initallabel ne $loadsysteminfo) {
@@ -1275,11 +1283,10 @@ sub checkoptions
         }else {
             $configfile = $configinfo;
         }
-    }
-    
-    if (!(-e $configfile)) {
-        log_this("Error: Can't open config file: $configfile");
-        return 1;
+        if (!(-e $configfile)) {
+            log_this("Error: Can't open config file: $configfile");
+            return 1;
+        }        
     }
     
     #check bundle files
@@ -1288,12 +1295,12 @@ sub checkoptions
         foreach my $bundle (@bundles){
             if ("$bundledir/$bundle" !~ /\.bundle$/) {
                 log_this("Error: please input the .bundle file");
-                log_this("Use 'xcattest -s bundle' to list out available bundles");
+                log_this("Use 'xcattest -s bundle' to list all bundle files");
                 return 1;
             }
             if (!(-e "$bundledir/$bundle")) {
                 log_this("Error: Can't open bundle file: $bundle");
-                log_this("Use 'xcattest -b bundle' to list out available bundles");
+                log_this("Use 'xcattest -s bundle' to list all bundle files");
                 return 1;
             }
         }

--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -17,7 +17,6 @@ use lib "$::XCATROOT/lib/perl";
 my $rootdir         = "$::XCATROOT/share/xcat/tools/autotest";
 my $needhelp        = 0;
 my $configinfo      = undef;
-#my $configfile      = "$rootdir/default.conf";
 my $configfile      = undef;
 my $casedir         = "$rootdir/testcase";
 my $bundledir       = "$rootdir/bundle";
@@ -1135,7 +1134,6 @@ sub listformatbundleinfo
     print "bundle files and descriptions:\n";
     
     foreach my $filename (sort { $a cmp $b } keys %bundlefilesinfo ) { 
-   # foreach my $filename (keys %bundlefilesinfo) {
         my @desc       = split(" ", $bundlefilesinfo{$filename});
         my $str        = "";
         my @formatdesc = ();


### PR DESCRIPTION
@tingtli 
To fix issue:　
https://github.com/xcat2/xcat-core/issues/2053:  default.conf is not existed in xCAT
https://github.com/xcat2/xcat-core/issues/1310:  update xcattest document and man page both
please help to review:
1. update code for default.conf is deleted from xCAT
2. update man page and document related