### PR TITLE
move rsyslogd restart code from dhclient-script to doxcat

### DIFF
--- a/xCAT-genesis-builder/dhclient-script
+++ b/xCAT-genesis-builder/dhclient-script
@@ -36,26 +36,6 @@ elif [ $reason = "BOUND" ]; then
 	for gw in $new_routers; do
 		ip route add default via $gw
 	done
-	# Up to this point we were logging to the local /var/log/xcat.genesis
-	# file. But now we know the xCAT MN, so replace logging to the local
-	# file with logging to the xCAT MN
-	if [ ! -z "$new_log_servers" ]; then
-		head -n -1 /etc/rsyslog.conf > /etc/rsyslog.conf.new
-		cp /etc/rsyslog.conf.new /etc/rsyslog.conf
-	fi
-        for ls in $new_log_servers; do
-		echo "*.* @$ls" >> /etc/rsyslog.conf
-	done
-	kill `cat /var/run/syslogd.pid`
-	sleep 3
-	RSYSLOGD_VERSION=`rsyslogd -v | grep "rsyslogd" | cut -d" " -f2 | cut -d"." -f1`
-	if [ $RSYSLOGD_VERSION -ge 8 ]; then
-        	# Newer versions of rsyslogd do not support -c flag anymore
-		/sbin/rsyslogd
-	else
-		/sbin/rsyslogd -c4
-	fi
-
 
 	if [ ! -z "$new_tcode" -a -r "/usr/share/zoneinfo/posix/$new_tcode" ]; then
 		cp "/usr/share/zoneinfo/posix/$new_tcode" /etc/localtime

--- a/xCAT-genesis-scripts/bin/doxcat
+++ b/xCAT-genesis-scripts/bin/doxcat
@@ -335,8 +335,8 @@ while :; do
 		/bin/getcert $XCATMASTER:$XCATPORT
 		destiny=''
 		dest=''
-		DISCOVERYDONE=1
-		export DISCOVERYDONE
+		XCAT_DISCOVERY_WAS_DONE=1
+		export XCAT_DISCOVERY_WAS_DONE
 	elif [ "$dest" = shell ]; then
 		logger -s -t $log_label -p local4.info "Dropping to debug shell(exit to run next destiny)..."
 		destiny=''
@@ -400,7 +400,7 @@ while :; do
 		delay=$((30+$RANDOM%270))
 		while [ $delay -gt 0 ]; do
 			if [ $((delay%10)) == 0 ]; then 
-				if [ $DISCOVERYDONE == 1 ]; then
+				if [ "$XCAT_DISCOVERY_WAS_DONE" == 1 ]; then
 					logger -s -t $log_label -p local4.info "Received request=$dest, will call xCAT back in $delay seconds. Discovery is complete, run nodeset on this node to provision an Operating System"
 				else
 					logger -s -t $log_label -p local4.info "Received request to retry in a bit, will call xCAT back in $delay seconds"
@@ -409,8 +409,8 @@ while :; do
 			delay=$((delay-1))
 			sleep 1
 		done
-                destiny=''
-                dest=''
+		destiny=''
+		dest=''
 		echo "Retrying                                                                                   ";
 	elif [ "$dest" = shutdown ]; then
 		logger -s -t $log_label -p local4.info "Poweroff..."

--- a/xCAT-genesis-scripts/bin/doxcat
+++ b/xCAT-genesis-scripts/bin/doxcat
@@ -169,6 +169,10 @@ export XCATMASTER
 
 logger -s -t $log_label -p local4.info "XCATMASTER is $XCATMASTER, XCATPORT is $XCATPORT"
 
+head -n -1 /etc/rsyslog.conf > /etc/rsyslog.conf.new
+cp /etc/rsyslog.conf.new /etc/rsyslog.conf
+echo "*.* @$XCATMASTER" >> /etc/rsyslog.conf
+
 if [[ -n $hostip && -n $netmask && -n $gateway && -n $bootnic ]]; then
 	# doing static ip
 	# the device was determined above from the bootif mac, and put in bootnic
@@ -253,21 +257,6 @@ else
         fi
 fi
 
-count_f=0
-while [ $count_f -le 8 ]; do
-    rsyslogd_ps=`ps -ef | grep 'rsyslogd' | grep -v 'grep'`
-    if [ "$rsyslogd_ps" ]; then
-        break
-    else
-        ((count_f++))
-        sleep 0.5
-    fi
-done
-
-if [ $count_f -gt 8 ]; then
-    echo "rsyslogd maybe off"
-fi
-
 openssl genrsa -out /etc/xcat/certkey.pem 4096 > /dev/null 2>&1 &
 
 logger -s -t $log_label -p local4.info "Acquired IPv4 address on $bootnic"
@@ -282,8 +271,18 @@ fi
 
 # rv 0 state does not work with the new ntp versions
 while [ "`ntpq -c 'rv 0 offset' | awk -F '=' '/offset=/ { print $2 }' | awk -F '.' '{ print $1 }' | sed s/-//`" -ge 1000 ]; do 
+    echo `ntpq -c 'rv 0 offset`
     sleep 1
 done
+
+kill `cat /var/run/syslogd.pid`
+sleep 3
+RSYSLOGD_VERSION=`rsyslogd -v | grep "rsyslogd" | cut -d" " -f2 | cut -d"." -f1`
+if [ $RSYSLOGD_VERSION -ge 8 ]; then
+    /sbin/rsyslogd
+else
+    /sbin/rsyslogd -c4
+fi
 
 HOST_ARCH=`uname -m`
 if echo $HOST_ARCH | grep "ppc64"; then
@@ -331,6 +330,7 @@ while :; do
 		/bin/getcert $XCATMASTER:$XCATPORT
 		destiny=''
 		dest=''
+		touch /tmp/xcatgenesisdiscovery
 	elif [ "$dest" = shell ]; then
 		logger -s -t $log_label -p local4.info "Dropping to debug shell(exit to run next destiny)..."
 		destiny=''
@@ -391,16 +391,20 @@ while :; do
                 destiny=''
                 dest='' 
 	elif [ "$dest" = standby ]; then
-		destiny=''
-		dest=''
 		delay=$((30+$RANDOM%270))
 		while [ $delay -gt 0 ]; do
 			if [ $((delay%10)) == 0 ]; then 
-				logger -s -t $log_label -p local4.info "Received request to retry in a bit, will call xCAT back in $delay seconds"
+				if [ -e "/tmp/xcatgenesisdiscovery" ]; then
+					logger -s -t $log_label -p local4.info "Received request=$dest, will call xCAT back in $delay seconds. Discovery is complete, run nodeset on this node to provision an Operating System"
+				else
+					logger -s -t $log_label -p local4.info "Received request to retry in a bit, will call xCAT back in $delay seconds"
+				fi
 			fi
 			delay=$((delay-1))
 			sleep 1
 		done
+                destiny=''
+                dest=''
 		echo "Retrying                                                                                   ";
 	elif [ "$dest" = shutdown ]; then
 		logger -s -t $log_label -p local4.info "Poweroff..."

--- a/xCAT-genesis-scripts/bin/doxcat
+++ b/xCAT-genesis-scripts/bin/doxcat
@@ -271,14 +271,19 @@ fi
 
 # rv 0 state does not work with the new ntp versions
 while [ "`ntpq -c 'rv 0 offset' | awk -F '=' '/offset=/ { print $2 }' | awk -F '.' '{ print $1 }' | sed s/-//`" -ge 1000 ]; do 
-    echo `ntpq -c 'rv 0 offset`
     sleep 1
 done
 
-kill `cat /var/run/syslogd.pid`
-sleep 3
-RSYSLOGD_VERSION=`rsyslogd -v | grep "rsyslogd" | cut -d" " -f2 | cut -d"." -f1`
-if [ $RSYSLOGD_VERSION -ge 8 ]; then
+read -r RSYSLOG_PID </var/run/syslogd.pid 2>/dev/null
+kill "$RSYSLOG_PID" 2>/dev/null
+while kill -0 "$RSYSLOG_PID" 2>/dev/null
+do
+    sleep 0.5
+done
+unset RSYSLOG_PID
+
+RSYSLOGD_VERSION=`rsyslogd -v | awk '/rsyslogd/ { split($2, a, "."); print a[1]; }'`
+if [ "$RSYSLOGD_VERSION" -ge 8 ]; then
     /sbin/rsyslogd
 else
     /sbin/rsyslogd -c4
@@ -330,7 +335,8 @@ while :; do
 		/bin/getcert $XCATMASTER:$XCATPORT
 		destiny=''
 		dest=''
-		touch /tmp/xcatgenesisdiscovery
+		DISCOVERYDONE=1
+		export DISCOVERYDONE
 	elif [ "$dest" = shell ]; then
 		logger -s -t $log_label -p local4.info "Dropping to debug shell(exit to run next destiny)..."
 		destiny=''
@@ -394,7 +400,7 @@ while :; do
 		delay=$((30+$RANDOM%270))
 		while [ $delay -gt 0 ]; do
 			if [ $((delay%10)) == 0 ]; then 
-				if [ -e "/tmp/xcatgenesisdiscovery" ]; then
+				if [ $DISCOVERYDONE == 1 ]; then
 					logger -s -t $log_label -p local4.info "Received request=$dest, will call xCAT back in $delay seconds. Discovery is complete, run nodeset on this node to provision an Operating System"
 				else
 					logger -s -t $log_label -p local4.info "Received request to retry in a bit, will call xCAT back in $delay seconds"


### PR DESCRIPTION
To get log after time synchronization，move rsyslogd restart to doxcat.
The code after ntp start.

Fix issue #1788 , modified log to "Received request=$dest, will call xCAT back in $delay seconds. Discovery is complete, run nodeset on this node to provision an Operating System.