### PR TITLE
DO NOT MERGE Add "power on" to end of rflash

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -1851,6 +1851,19 @@ sub do_firmware_update {
             "rflashing ... See the detail progress :\"tail -f $rflash_log_file\"" ],
         $callback, $sessdata->{node});
     exec($cmd);
+
+    # step 5 power on
+    $cmd = $pre_cmd . " chassis power on";
+    $output = xCAT::Utils->runcmd($cmd, -1);
+    if ($::RUNCMD_RC != 0) {
+        xCAT::SvrUtils::sendmsg([ 1, "Running ipmitool command $cmd failed: $output" ],
+            $callback, $sessdata->{node}, %allerrornodes);
+        return -1;
+    }
+
+    xCAT::SvrUtils::sendmsg("rflash completed.", $callback, $sessdata->{node},
+        %allerrornodes);
+    return 0;
 }
 
 sub rflash {


### PR DESCRIPTION
In response to behavior observed by Lab Based Services team and on our own machines

After firmware update completes, the FRU information will remain blank.  This means that `rinv` command will return with errors, and `rflash` will be unable to run since it depends on FRU information to determine machine type.  Firmware team suggests power restart will force machine in to initial program load (IPL) which will populate FRU information

DO NOT MERGE: Lab network is down, unable to unit test at this time