### PR TITLE
Use sleep subroutine instead of exec(sleep)

### DIFF
--- a/xCAT-server/share/xcat/cons/ipmi
+++ b/xCAT-server/share/xcat/cons/ipmi
@@ -1,50 +1,52 @@
 #!/usr/bin/env perl
 # IBM(c) 2007 EPL license http://www.eclipse.org/legal/epl-v10.html
 use Fcntl qw(:DEFAULT :flock);
-
-sub get_lock {
-    unless (flock(LOCKHANDLE, LOCK_EX | LOCK_NB)) {
-        $| = 1;
-        print "Acquiring startup lock...";
-        flock(LOCKHANDLE, LOCK_EX) or die "Fatal Error securing startup lock";
-        print "done\n";
-    }
-    truncate(LOCKHANDLE, 0);
-    print LOCKHANDLE $$ . "\n";
-}
-
-sub release_lock {
-    truncate(LOCKHANDLE, 0);
-    flock(LOCKHANDLE, LOCK_UN);
-}
-
-BEGIN
-{
-    use Time::HiRes qw(sleep);
-    use File::Path;
-    use Fcntl qw(:DEFAULT :flock);
-    $::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : '/opt/xcat';
-    umask 0077;
-    mkpath("/tmp/xcat/");
-    unless (sysopen(LOCKHANDLE, "/tmp/xcat/consolelock", O_WRONLY | O_CREAT)) {
-        print "Unable to open lock file";
-        exec("sleep 15");
-        exit 0;
-    }
-    get_lock();
-
-    #my $sleepint=int(rand(10));
-    #print "Opening console in ".(2+(0.5*$sleepint))." seconds...\n";
-    #sleep $sleepint;
+use Time::HiRes qw(sleep);
+use File::Path;
+BEGIN {
+    $::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : -d '/opt/xcat' ? '/opt/xcat' : '/usr';
 }
 my $sleepint = int(rand(10)); #Stagger start to avoid overwhelming conserver/xCATd
-$::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : '/opt/xcat';
-use lib "$::XCATROOT/lib/perl";
-require xCAT::Client;
+my ($lockfd, $bmc);
 my $username = 'USERID';
 my $password = 'PASSW0RD';
 my $node     = $ARGV[0];
-my $bmc;
+
+use constant CONSOLE_LOCK_FILE => "/tmp/xcat/consolelock";
+use constant CONSOLE_LOCK_DIR => "/tmp/xcat";
+
+sub acquire_lock {
+    umask 0077;
+    mkpath(CONSOLE_LOCK_DIR);
+    print "Acquiring startup lock...";
+    unless (sysopen($lockfd, CONSOLE_LOCK_FILE, O_WRONLY | O_CREAT)) {
+        print "Unable to open file ".CONSOLE_LOCK_FILE."\n";
+        sleep(15);
+        exit 1;
+    }
+    unless (flock($lockfd, LOCK_EX)) {
+        print "Unable to lock file ".CONSOLE_LOCK_FILE."\n";
+        close($lockfd);
+        sleep(15);
+        exit 1;
+    }
+    print "done\n";
+    unless (syswrite($lockfd, $$, length($$))) {
+        print "Unable to write file ".CONSOLE_LOCK_FILE."\n";
+        close($lockfd);
+        sleep(15);
+        exit 1;
+    }
+}
+
+sub release_lock {
+    flock($lockfd, LOCK_UN);
+    close($lockfd);
+}
+
+
+use lib "$::XCATROOT/lib/perl";
+require xCAT::Client;
 
 sub getans {
     my $rsp = shift;
@@ -63,16 +65,22 @@ my $cmdref = {
     arg       => ["text"],
     noderange => [ $ARGV[0] ]
 };
+acquire_lock();
+# avoid of congestion
+sleep(0.1);
+release_lock();
 xCAT::Client::submit_request($cmdref, \&getans);
+
 until (($username or $password) and $bmc) {
-    release_lock();    #Let other clients have a go
+    #Let other clients have a go
     $sleepint = 10 + int(rand(20));
     print "Console not ready, retrying in $sleepint seconds (Ctrl-e,c,o to skip delay) \n";
-    exec("sleep $sleepint");
-    get_lock();
+    sleep ($sleepint);
+    acquire_lock();
+    sleep(0.1);
+    release_lock();
     xCAT::Client::submit_request($cmdref, \&getans);
 }
-release_lock();
 
 my ($user, $pass);
 if ($username) {
@@ -124,9 +132,7 @@ if ($rc) { #some shoddy vendors ignore the IPMI 2.0 requirement to support IPMI 
 while ($rc != 0) {
     $sleepint = 10 + int(rand(20));
     print "Failure to reach IPMI device, retrying in $sleepint seconds (Hit Ctrl-E,c,o to skip)\n";
-    exec("sleep $sleepint");
-
-    #sleep $sleepint;
+    sleep ($sleepint);
     @mcinfo = `$ipmitool -I lanplus $user $pass -H $bmc mc info`; #| grep 'Manufacturer ID           : 343' > /dev/null 2>&1";
     $rc     = $?;
     if ($rc) {    #repeat workaround for shoddy vendors


### PR DESCRIPTION
exec function call will take over all the process, lead to no chance to
continue the work within the script, this patch use sleep function call from
perl library instead.

Close-issue: #1801