### PR TITLE
Added packages to pkglist and otherpkglist for xCAT-csm rpm node types

### DIFF
--- a/xCAT-csm/csm.compute.rhels7.ppc64le.pkglist
+++ b/xCAT-csm/csm.compute.rhels7.ppc64le.pkglist
@@ -1,1 +1,26 @@
 #csm compute
+bash
+nfs-utils
+openssl
+dhclient
+kernel
+openssh-server
+openssh-clients
+wget
+rsyslog
+vim-minimal
+ntp
+rsyslog
+rpm
+rsync
+ppc64-utils
+iputils
+dracut
+dracut-network
+e2fsprogs
+bc
+lsvpd
+irqbalance
+procps-ng
+parted
+net-tools

--- a/xCAT-csm/csm.launch.rhels7.ppc64le.pkglist
+++ b/xCAT-csm/csm.launch.rhels7.ppc64le.pkglist
@@ -1,1 +1,26 @@
 #csm launch
+bash
+nfs-utils
+openssl
+dhclient
+kernel
+openssh-server
+openssh-clients
+wget
+rsyslog
+vim-minimal
+ntp
+rsyslog
+rpm
+rsync
+ppc64-utils
+iputils
+dracut
+dracut-network
+e2fsprogs
+bc
+lsvpd
+irqbalance
+procps-ng
+parted
+net-tools

--- a/xCAT-csm/csm.login.rhels7.ppc64le.pkglist
+++ b/xCAT-csm/csm.login.rhels7.ppc64le.pkglist
@@ -1,1 +1,26 @@
 #csm login
+bash
+nfs-utils
+openssl
+dhclient
+kernel
+openssh-server
+openssh-clients
+wget
+rsyslog
+vim-minimal
+ntp
+rsyslog
+rpm
+rsync
+ppc64-utils
+iputils
+dracut
+dracut-network
+e2fsprogs
+bc
+lsvpd
+irqbalance
+procps-ng
+parted
+net-tools

--- a/xCAT-csm/csm.service.rhels7.ppc64le.pkglist
+++ b/xCAT-csm/csm.service.rhels7.ppc64le.pkglist
@@ -1,1 +1,26 @@
 #csm service
+bash
+nfs-utils
+openssl
+dhclient
+kernel
+openssh-server
+openssh-clients
+wget
+rsyslog
+vim-minimal
+ntp
+rsyslog
+rpm
+rsync
+ppc64-utils
+iputils
+dracut
+dracut-network
+e2fsprogs
+bc
+lsvpd
+irqbalance
+procps-ng
+parted
+net-tools

--- a/xCAT-csm/csm.workloadmanager.rhels7.ppc64le.pkglist
+++ b/xCAT-csm/csm.workloadmanager.rhels7.ppc64le.pkglist
@@ -1,1 +1,26 @@
 #csm workload manager
+bash
+nfs-utils
+openssl
+dhclient
+kernel
+openssh-server
+openssh-clients
+wget
+rsyslog
+vim-minimal
+ntp
+rsyslog
+rpm
+rsync
+ppc64-utils
+iputils
+dracut
+dracut-network
+e2fsprogs
+bc
+lsvpd
+irqbalance
+procps-ng
+parted
+net-tools

--- a/xCAT-csm/install/post/otherpkgs/csm/csm.compute.otherpkglist
+++ b/xCAT-csm/install/post/otherpkgs/csm/csm.compute.otherpkglist
@@ -1,0 +1,69 @@
+#In distro.
+pciutils
+lsof
+tcl
+gcc-gfortran
+tcsh
+tk
+expect
+ksh
+numactl
+git
+cmake
+emacs
+python.ppc64le
+python-devel
+perl-XML-LibXML.ppc64le
+perl-XML-Simple-2.20-5.el7.noarch
+bzip2-devel
+gcc
+gcc-c++
+postgresql-libs
+postgresql-devel
+gdb
+openssl-devel
+c-ares-devel
+doxygen
+ctags
+libuuid-devel
+perl-Date-Calc.noarch
+perl-Date-Manip.noarch
+perl-DateTime.ppc64le
+perl-DateTime-Format-DateParse.noarch
+perl-DateTime-Locale.noarch
+perl-DateTime-TimeZone.noarch
+valgrind.ppc64le
+rpm-build
+
+# Needed for build.
+librdmacm
+librdmacm-devel
+librdmacm-utils
+
+# John Cohn request.
+libxlc
+libxlsmp
+
+# epel
+epel/mosquitto-devel
+
+
+# Boost-1.60.0
+boost/boost-1.60.0-4.el7.ppc64le
+boost/boost-devel-1.60.0-4.el7.ppc64le
+
+# libcgroup
+libcgroup-pam
+
+# Python Dependencies
+python-dateutil.noarch
+numpy
+
+libibverbs-utils
+ibutils
+perftest
+
+cuda-repo-rhel7-8-0-local
+
+#csm rpms
+ibm-csm-core

--- a/xCAT-csm/install/post/otherpkgs/csm/csm.launch.otherpkglist
+++ b/xCAT-csm/install/post/otherpkgs/csm/csm.launch.otherpkglist
@@ -1,0 +1,70 @@
+#In distro.
+pciutils
+lsof
+tcl
+gcc-gfortran
+tcsh
+tk
+expect
+ksh
+numactl
+git
+cmake
+emacs
+python.ppc64le
+python-devel
+perl-XML-LibXML.ppc64le
+perl-XML-Simple-2.20-5.el7.noarch
+bzip2-devel
+gcc
+gcc-c++
+postgresql-libs
+postgresql-devel
+gdb
+openssl-devel
+c-ares-devel
+doxygen
+ctags
+libuuid-devel
+perl-Date-Calc.noarch
+perl-Date-Manip.noarch
+perl-DateTime.ppc64le
+perl-DateTime-Format-DateParse.noarch
+perl-DateTime-Locale.noarch
+perl-DateTime-TimeZone.noarch
+valgrind.ppc64le
+rpm-build
+
+# Needed for build.
+librdmacm
+librdmacm-devel
+librdmacm-utils
+
+# John Cohn request.
+libxlc
+libxlsmp
+
+# epel
+epel/mosquitto-devel
+
+
+# Boost-1.60.0
+boost/boost-1.60.0-4.el7.ppc64le
+boost/boost-devel-1.60.0-4.el7.ppc64le
+
+# libcgroup
+libcgroup-pam
+
+# Python Dependencies
+python-dateutil.noarch
+numpy
+
+libibverbs-utils
+ibutils
+perftest
+
+cuda-repo-rhel7-8-0-local
+
+#csm rpms
+ibm-csm-core
+ibm-csm-api

--- a/xCAT-csm/install/post/otherpkgs/csm/csm.login.otherpkglist
+++ b/xCAT-csm/install/post/otherpkgs/csm/csm.login.otherpkglist
@@ -1,0 +1,70 @@
+#In distro.
+pciutils
+lsof
+tcl
+gcc-gfortran
+tcsh
+tk
+expect
+ksh
+numactl
+git
+cmake
+emacs
+python.ppc64le
+python-devel
+perl-XML-LibXML.ppc64le
+perl-XML-Simple-2.20-5.el7.noarch
+bzip2-devel
+gcc
+gcc-c++
+postgresql-libs
+postgresql-devel
+gdb
+openssl-devel
+c-ares-devel
+doxygen
+ctags
+libuuid-devel
+perl-Date-Calc.noarch
+perl-Date-Manip.noarch
+perl-DateTime.ppc64le
+perl-DateTime-Format-DateParse.noarch
+perl-DateTime-Locale.noarch
+perl-DateTime-TimeZone.noarch
+valgrind.ppc64le
+rpm-build
+
+# Needed for build.
+librdmacm
+librdmacm-devel
+librdmacm-utils
+
+# John Cohn request.
+libxlc
+libxlsmp
+
+# epel
+epel/mosquitto-devel
+
+
+# Boost-1.60.0
+boost/boost-1.60.0-4.el7.ppc64le
+boost/boost-devel-1.60.0-4.el7.ppc64le
+
+# libcgroup
+libcgroup-pam
+
+# Python Dependencies
+python-dateutil.noarch
+numpy
+
+libibverbs-utils
+ibutils
+perftest
+
+cuda-repo-rhel7-8-0-local
+
+#csm rpms
+ibm-csm-core
+ibm-csm-api

--- a/xCAT-csm/install/post/otherpkgs/csm/csm.service.otherpkglist
+++ b/xCAT-csm/install/post/otherpkgs/csm/csm.service.otherpkglist
@@ -1,0 +1,72 @@
+#In distro.
+pciutils
+lsof
+tcl
+gcc-gfortran
+tcsh
+tk
+expect
+ksh
+numactl
+git
+cmake
+emacs
+python.ppc64le
+python-devel
+perl-XML-LibXML.ppc64le
+perl-XML-Simple-2.20-5.el7.noarch
+bzip2-devel
+gcc
+gcc-c++
+postgresql-libs
+postgresql-devel
+gdb
+openssl-devel
+c-ares-devel
+doxygen
+ctags
+libuuid-devel
+perl-Date-Calc.noarch
+perl-Date-Manip.noarch
+perl-DateTime.ppc64le
+perl-DateTime-Format-DateParse.noarch
+perl-DateTime-Locale.noarch
+perl-DateTime-TimeZone.noarch
+valgrind.ppc64le
+rpm-build
+
+# Needed for build.
+librdmacm
+librdmacm-devel
+librdmacm-utils
+
+# John Cohn request.
+libxlc
+libxlsmp
+
+# epel
+epel/mosquitto-devel
+
+
+# Boost-1.60.0
+boost/boost-1.60.0-4.el7.ppc64le
+boost/boost-devel-1.60.0-4.el7.ppc64le
+
+# libcgroup
+libcgroup-pam
+
+# Python Dependencies
+python-dateutil.noarch
+numpy
+
+libibverbs-utils
+ibutils
+perftest
+
+cuda-repo-rhel7-8-0-local
+
+#csm rpms
+ibm-csm-core
+ibm-csm-api
+ibm-csm-hcdiag
+ibm-csm-db

--- a/xCAT-csm/install/post/otherpkgs/csm/csm.workloadmanager.otherpkglist
+++ b/xCAT-csm/install/post/otherpkgs/csm/csm.workloadmanager.otherpkglist
@@ -1,0 +1,70 @@
+#In distro.
+pciutils
+lsof
+tcl
+gcc-gfortran
+tcsh
+tk
+expect
+ksh
+numactl
+git
+cmake
+emacs
+python.ppc64le
+python-devel
+perl-XML-LibXML.ppc64le
+perl-XML-Simple-2.20-5.el7.noarch
+bzip2-devel
+gcc
+gcc-c++
+postgresql-libs
+postgresql-devel
+gdb
+openssl-devel
+c-ares-devel
+doxygen
+ctags
+libuuid-devel
+perl-Date-Calc.noarch
+perl-Date-Manip.noarch
+perl-DateTime.ppc64le
+perl-DateTime-Format-DateParse.noarch
+perl-DateTime-Locale.noarch
+perl-DateTime-TimeZone.noarch
+valgrind.ppc64le
+rpm-build
+
+# Needed for build.
+librdmacm
+librdmacm-devel
+librdmacm-utils
+
+# John Cohn request.
+libxlc
+libxlsmp
+
+# epel
+epel/mosquitto-devel
+
+
+# Boost-1.60.0
+boost/boost-1.60.0-4.el7.ppc64le
+boost/boost-devel-1.60.0-4.el7.ppc64le
+
+# libcgroup
+libcgroup-pam
+
+# Python Dependencies
+python-dateutil.noarch
+numpy
+
+libibverbs-utils
+ibutils
+perftest
+
+cuda-repo-rhel7-8-0-local
+
+#csm rpms
+ibm-csm-core
+ibm-csm-api

--- a/xCAT-csm/xCAT-csm.spec
+++ b/xCAT-csm/xCAT-csm.spec
@@ -34,9 +34,11 @@ rm -rf %{buildroot}
 
 mkdir -p $RPM_BUILD_ROOT/%{prefix}/share/xcat/install/rh/
 mkdir -p $RPM_BUILD_ROOT/install/postscripts/csm/
+mkdir -p $RPM_BUILD_ROOT/install/post/otherpkgs/csm/
 
 cp csm* $RPM_BUILD_ROOT/%{prefix}/share/xcat/install/rh/
 cp install/postscripts/* $RPM_BUILD_ROOT/install/postscripts/csm/
+cp install/post/otherpkgs/csm/* $RPM_BUILD_ROOT/install/post/otherpkgs/csm/
 
 %clean
 # This step does not happen until *after* the %files packaging below
@@ -46,6 +48,7 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-,root,root,-)
 %{prefix}
 /install/postscripts
+/install/post
 %doc
 
 


### PR DESCRIPTION
Issue #2028 

As it stands, pkglist for all node types are the same, provided by John Dunham.

otherpkglists use the same base for all node types (also provided by John Dunham).  Additionally, each otherpkglist contains specific csm rpms provided by Nate Besaw.  Actual rpm files are not included yet as CSM team is still using development builds.  

Perhaps leave this PR open until CSM releases rpm builds?