### PR TITLE
Add extra nics to link-up detection search list

### DIFF
--- a/xCAT/postscripts/xcatinstallpost
+++ b/xCAT/postscripts/xcatinstallpost
@@ -20,10 +20,21 @@ fi
 SLI=$(awk 'BEGIN{srand(); printf("%d\n",rand()*10)}')
 sleep $SLI
 
-
+# Get the name of the installnic
 MACADDR=`grep MACADDRESS= /xcatpost/mypostscript.post |awk -F = '{print $2}'|sed s/\'//g`
 INSTALLNIC=`ip -o link|grep -i $MACADDR|awk  '{print $2}'|sed s/://`
 
+# Also get the any interface names set in NICIPS (nics table)
+NICIPS=$(grep NICIPS= /xcatpost/mypostscript.post |awk -F = '{print $2}'|sed s/\'//g)
+NICS=""
+OIFS=$IFS
+IFS=$','
+for n in $NICIPS; do
+  NAME=$(echo $n | awk -F \! '{print $1}')
+  NICS="$NICS $NAME"
+done
+IFS=$OIFS
+INSTALLNIC="$INSTALLNIC $NICS"
 
 #the nics have not been configured when running the PBS sometimes, need to make sure... 
 RETRY=0


### PR DESCRIPTION
When a bonded NIC configuration is to be used as the primary interface
for a node, often that interface cannot be used to PXE boot the node.
In this case, an different NIC is used as the "installnic".
It's possible that after the node reboots, that the "installnic"
is not configured with an address. The IP address can be moved to the
bonded connection after provisioning.
The additional interfaces used by the node are listed in "NICIPS"
from the "nics" table. This code change parses "NICIPS" for adapter
names and adds them to the INSTALLNIC variable so that all defined
interfaces for this node are checked in the link-up check.
This should still fix "defect 4616"
https://sourceforge.net/p/xcat/bugs/4616/
The original code change was intended to delay the execution of the
xcatinstallpost script until a real network interface came up (i.e. not usb0)