### PR TITLE
Require the ipmitool-xcat to be at 1.8.17-1 when installing xCAT 2.12.4

### DIFF
--- a/xCAT/xCAT.spec
+++ b/xCAT/xCAT.spec
@@ -64,12 +64,12 @@ Requires: elilo-xcat xnba-undi
 
 %ifarch i386 i586 i686 x86 x86_64
 Requires: syslinux
-Requires: ipmitool-xcat >= 1.8.17
+Requires: ipmitool-xcat >= 1.8.17-1
 %endif
 
 %ifos linux
 %ifarch ppc ppc64 ppc64le
-Requires: ipmitool-xcat >= 1.8.17
+Requires: ipmitool-xcat >= 1.8.17-1
 %endif
 %endif
 

--- a/xCATsn/xCATsn.spec
+++ b/xCATsn/xCATsn.spec
@@ -59,11 +59,11 @@ Requires: elilo-xcat xnba-undi
 
 %ifarch i386 i586 i686 x86 x86_64
 Requires: syslinux
-Requires: ipmitool-xcat >= 1.8.17
+Requires: ipmitool-xcat >= 1.8.17-1
 %endif
 %ifos linux
 %ifarch ppc ppc64 ppc64le
-Requires: ipmitool-xcat >= 1.8.17
+Requires: ipmitool-xcat >= 1.8.17-:
 %endif
 %endif
 


### PR DESCRIPTION
The ipmitool-xcat 1.8.17-1 build will help resolve some of console connnection dropping issue that is experienced on the OpenPower machines 

DO NOT merge this Pull Request UNTIL the ipmitool-xcat 1.8.17-1 is built and shipped in the xcat-deps, or it will cause installation failures. 

Unit Testing out the changes against the current xcat-deps results in: 
```
Error: Package: xCAT-2.12.4-snap201611071521.ppc64le (xcat-2-core)
           Requires: ipmitool-xcat >= 1.8.17-1
           Available: ipmitool-xcat-1.8.17-0.ppc64le (xcat-dep)
               ipmitool-xcat = 1.8.17-0
 You could try using --skip-broken to work around the problem
 You could try running: rpm -Va --nofiles --nodigest
```
