### PR TITLE
Fix xcatmn's bugs #2110  and  #1725

### DIFF
--- a/xCAT-probe/debian/control
+++ b/xCAT-probe/debian/control
@@ -8,4 +8,8 @@ Standards-Version: 3.7.2
 Package: xcat-probe
 Architecture: all
 Depends: ${perl:Depends}
+
+#Sub-command 'xcatmn' need tools tftp, nslookup, wget. 
+Suggests: wget, dnsutils, tftp-hpa
+
 Description: Provides a toolkits to help probe all the possible issues in xCAT 

--- a/xCAT-probe/subcmds/xcatmn
+++ b/xCAT-probe/subcmds/xcatmn
@@ -872,6 +872,12 @@ if ($test) {
     exit 0;
 }
 
+if (!$installnic){
+    probe_utils->send_msg("$output", "f", "Option '-i' is required");
+    probe_utils->send_msg("$output", "d", "$::USAGE");
+    exit 1;
+}
+
 #Handle the interrupt signal from STDIN
 $SIG{TERM} = $SIG{INT} = sub {
     $terminal = 1;

--- a/xCAT-probe/xCAT-probe.spec
+++ b/xCAT-probe/xCAT-probe.spec
@@ -16,6 +16,13 @@ BuildRoot: /var/tmp/%{name}-%{version}-%{release}-root
 BuildArch: noarch
 %endif
 
+%ifos linux
+#Below tools are required by sub-command 'xcatmn' 
+Requires: /usr/bin/nslookup
+Requires: /usr/bin/tftp
+Requires: /usr/bin/wget
+%endif
+
 Provides: xCAT-probe = %{version}
 
 %description


### PR DESCRIPTION
This pull request fix below 2 bugs:

1  If the  ``-i`` option is not specified for ``xcatmn``,  ``xcatmn`` should not run because option ``i`` is required for ``xcatmn``. Refer to issue #1725 

2 ``xcatmn`` need 3 tools (wget, tftp, nslookup) to do probe, so add these tools as xCAT-probe package's dependency. Refer to issue #2110 