### PR TITLE
Add back in the code to upload the ubuntu deps package to xcat.org

### DIFF
--- a/build-ubunturepo
+++ b/build-ubunturepo
@@ -96,6 +96,13 @@ if [ -z "$c_flag" -a -z "$d_flag" ];then
     exit 2
 fi
 
+USER="xcat"
+SERVER="xcat.org"
+FILES_PATH="files"
+FRS="/var/www/${SERVER}/${FILES_PATH}"
+APT_DIR="${FRS}/xcat"
+APT_REPO_DIR="${APT_DIR}/repos/apt"
+
 if [ "$c_flag" -a "$d_flag" ];then
     printusage
     exit 2
@@ -473,6 +480,32 @@ __EOF__
     tar -hjcf $dep_tar_name xcat-dep
     chgrp root $dep_tar_name
     chmod g+w $dep_tar_name
+
+    # Decide whether to upload or not (default NOT to upload)
+    if [ "$UP" != "1" ]; then 
+        echo "Upload not specified, Done! (rerun with UP=1, to upload)"
+        cd $old_pwd
+        exit 0
+    fi
+
+    #upload the dep packages
+    i=0
+    echo "Uploading debs from xcat-dep to ${APT_REPO_DIR}/xcat-dep/ ..."
+    while [ $((i+=1)) -le 5 ] && ! rsync -urLv --delete xcat-dep $USER@${SERVER}:${APT_REPO_DIR}/
+    do : ; done
+
+    #upload the tarball
+    i=0
+    echo "Uploading $dep_tar_name to ${APT_DIR}/xcat-dep/2.x_Ubuntu/ ..."
+    while [ $((i+=1)) -le 5 ] && ! rsync -v --force $dep_tar_name $USER@${SERVER}:${APT_DIR}/xcat-dep/2.x_Ubuntu/
+    do : ; done
+
+    #upload the README file
+    cd debs
+    i=0
+    echo "Uploading README to ${APT_DIR}/xcat-dep/2.x_Ubuntu/ ..."
+    while [ $((i+=1)) -le 5 ] && ! rsync -v --force README $USER@${SERVER}:${APT_DIR}/xcat-dep/2.x_Ubuntu/
+    do : ; done
 
     cd $old_pwd
     exit 0


### PR DESCRIPTION
In issue #1586, I removed too much of the build-ubunturepo script and removed the section for the xcat-deps build uploading to xcat.org. That portion is not moved out to the build script as it's built "on-demand" 

Adding it back in.  I tested this code change on the xcat-deps build today. 

It uploaded to:
* http://xcat.org/files/xcat/xcat-dep/2.x_Ubuntu/
* http://xcat.org/files/xcat/repos/apt/xcat-dep/