### PR TITLE
fix issue [CUSTOMER] the old diskless image built by xCAT can not be used after xcat 2.12.2 #2130

### DIFF
--- a/xCAT-server/lib/perl/xCAT/SvrUtils.pm
+++ b/xCAT-server/lib/perl/xCAT/SvrUtils.pm
@@ -2099,4 +2099,41 @@ sub getplatform {
 
     return $platform;
 }
+
+#--------------------------------------------------------------------------------------------------------
+#searchcompressedrootimg:
+#description: search the compressed rootimage for diskless or statelite osimage under specified directory
+#argument:
+#        $rootimgdir: the directory in which the compressed rootimage exist
+#return:
+#        on success: the basename of the compressed rootimage
+#        on fail:    undef
+#--------------------------------------------------------------------------------------------------------
+sub searchcompressedrootimg{
+    my $rootimgdir = shift;   
+    if (($rootimgdir) && ($rootimgdir =~ /xCAT::SvrUtils/)) {
+        $rootimgdir = shift;
+    }
+
+    my $cpsdrootimg=undef;
+    if (-f -r "$rootimgdir/rootimg.sfs"){
+        $cpsdrootimg="rootimg.sfs";
+    }elsif(-f -r "$rootimgdir/rootimg.gz"){
+        $cpsdrootimg="rootimg.gz";
+    }
+
+    if(-f -r "$rootimgdir/rootimg.cpio.gz"){
+        $cpsdrootimg = 'rootimg.cpio.gz';
+    }elsif(-f -r "$rootimgdir/rootimg.cpio.xz"){
+        $cpsdrootimg = 'rootimg.cpio.xz';
+    }elsif(-f -r "$rootimgdir/rootimg.tar.gz"){
+        $cpsdrootimg = 'rootimg.tar.gz';
+    }elsif(-f -r "$rootimgdir/rootimg.tar.xz"){
+        $cpsdrootimg = 'rootimg.tar.xz';
+    }
+
+    return $cpsdrootimg;
+}
+
+
 1;

--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -462,13 +462,9 @@ sub mknetboot
         }
 
         $platform = xCAT_plugin::anaconda::getplatform($osver);
-        my $suffix = 'cpio.gz';
-        $suffix = 'sfs' if (-r "$rootimgdir/rootimg.sfs");
-        $suffix = 'gz' if (-r "$rootimgdir/rootimg.gz");
-        $suffix = 'cpio.xz' if (-r "$rootimgdir/rootimg.cpio.xz");
-        $suffix = 'tar.gz' if (-r "$rootimgdir/rootimg.tar.gz");
-        $suffix = 'tar.xz' if (-r "$rootimgdir/rootimg.tar.xz");
-
+        my $compressedrootimg=xCAT::SvrUtils->searchcompressedrootimg("$rootimgdir");
+        
+      
         # statelite images are not packed.
         if ($statelite) {
             unless (-r "$rootimgdir/kernel") {
@@ -516,7 +512,7 @@ sub mknetboot
                     copy("$rootimgdir/initrd.gz", "$rootimgdir/initrd-stateless.gz");
                 }
             }
-            unless (-r "$rootimgdir/rootimg.cpio.gz" or -r "$rootimgdir/rootimg.cpio.xz" or -r "$rootimgdir/rootimg.tar.gz" or -r "$rootimgdir/rootimg.tar.xz" or -r "$rootimgdir/rootimg.sfs" or -r "$rootimgdir/rootimg.gz") {
+            unless ( -f -r "$rootimgdir/$compressedrootimg") {
                 $callback->({
                         error => ["No packed image for platform $osver, architecture $arch, and profile $profile found at $rootimgdir/rootimg.gz or $rootimgdir/rootimg.sfs on $myname, please run packimage (e.g.  packimage -o $osver -p $profile -a $arch"],
                         errorcode => [1] });
@@ -757,12 +753,12 @@ sub mknetboot
             $kcmdline .= "NODE=$node ";
         }
         else {
-            if (-r "$rootimgdir/rootimg.$suffix.metainfo") {
+            if (-r "$rootimgdir/$compressedrootimg.metainfo") {
                 $kcmdline =
-"imgurl=$httpmethod://$imgsrv:$httpport/$rootimgdir/rootimg.$suffix.metainfo ";
+"imgurl=$httpmethod://$imgsrv:$httpport/$rootimgdir/$compressedrootimg.metainfo ";
             } else {
                 $kcmdline =
-"imgurl=$httpmethod://$imgsrv:$httpport/$rootimgdir/rootimg.$suffix ";
+"imgurl=$httpmethod://$imgsrv:$httpport/$rootimgdir/$compressedrootimg ";
             }
             $kcmdline .= "XCAT=$xcatmaster:$xcatdport ";
             $kcmdline .= "NODE=$node ";

--- a/xCAT-server/lib/xcat/plugins/debian.pm
+++ b/xCAT-server/lib/xcat/plugins/debian.pm
@@ -1170,11 +1170,7 @@ sub mknetboot
         }
 
         $platform = xCAT_plugin::debian::getplatform($osver);
-        my $suffix = 'cpio.gz';
-        $suffix = 'gz' if (-r "$rootimgdir/rootimg.gz");
-        $suffix = 'cpio.xz' if (-r "$rootimgdir/rootimg.cpio.xz");
-        $suffix = 'tar.gz' if (-r "$rootimgdir/rootimg.tar.gz");
-        $suffix = 'tar.xz' if (-r "$rootimgdir/rootimg.tar.xz");
+        my $compressedrootimg=xCAT::SvrUtils->searchcompressedrootimg("$rootimgdir");
 
         # statelite images are not packed.
         if ($statelite) {
@@ -1224,7 +1220,7 @@ sub mknetboot
                     copy("$rootimgdir/initrd.gz", "$rootimgdir/initrd-stateless.gz");
                 }
             }
-            unless (-r "$rootimgdir/rootimg.cpio.gz" or -r "$rootimgdir/rootimg.cpio.xz" or -r "$rootimgdir/rootimg.tar.gz" or -r "$rootimgdir/rootimg.tar.xz" or -r "$rootimgdir/rootimg.sfs" or -r "$rootimgdir/rootimg.gz") {
+            unless (-f -r $compressedrootimg) {
                 $callback->({
                         error => ["No packed image for platform $osver, architecture $arch, and profile $profile, please run packimage (e.g.  packimage -o $osver -p $profile -a $arch"],
                         errorcode => [1] });
@@ -1452,7 +1448,7 @@ sub mknetboot
         else
         {
             $kcmdline =
-              "imgurl=http://$imgsrv/$rootimgdir/rootimg.$suffix ";
+              "imgurl=http://$imgsrv/$rootimgdir/$compressedrootimg ";
             $kcmdline .= "XCAT=$xcatmaster:$xcatdport ";
         }
 

--- a/xCAT-server/lib/xcat/plugins/imgport.pm
+++ b/xCAT-server/lib/xcat/plugins/imgport.pm
@@ -32,6 +32,7 @@ use File::Path qw/rmtree/;
 use File::Basename;
 use xCAT::NodeRange;
 use xCAT::Schema;
+use xCAT::SvrUtils;
 use Cwd;
 my $requestcommand;
 $::VERBOSE = 0;
@@ -607,17 +608,9 @@ sub get_files {
                     if (-f "$rootimgdir/kernel") {
                         $kernel = "$rootimgdir/kernel";
                     }
-                    if (-f "$rootimgdir/rootimg.cpio.xz") {
-                        $rootimg = "$rootimgdir/rootimg.cpio.xz";
-                    } elsif (-f "$rootimgdir/rootimg.cpio.gz") {
-                        $rootimg = "$rootimgdir/rootimg.cpio.gz";
-                    } elsif (-f "$rootimgdir/rootimg.tar.xz") {
-                        $rootimg = "$rootimgdir/rootimg.tar.xz";
-                    } elsif (-f "$rootimgdir/rootimg.tar.gz") {
-                        $rootimg = "$rootimgdir/rootimg.tar.gz";
-                    } elsif (-f "$rootimgdir/rootimg.gz") {
-                        $rootimg = "$rootimgdir/rootimg.gz";
-                    }
+                    
+                    my $compressedrootimg=xCAT::SvrUtils->searchcompressedrootimg("$rootimgdir");
+                    $rootimg = "$rootimgdir/$compressedrootimg";
 
                 } else {
                     $ramdisk = look_for_file('initrd-stateless.gz', $callback, $attrs, @arr);

--- a/xCAT-server/lib/xcat/plugins/packimage.pm
+++ b/xCAT-server/lib/xcat/plugins/packimage.pm
@@ -488,6 +488,7 @@ sub process_request {
 
     $suffix = $method.".".$suffix;
     unlink("$destdir/rootimg.sfs");
+    unlink("$destdir/rootimg.gz");
     unlink("$destdir/rootimg.cpio.xz");
     unlink("$destdir/rootimg.cpio.gz");
     unlink("$destdir/rootimg.tar.xz");

--- a/xCAT-server/lib/xcat/plugins/sles.pm
+++ b/xCAT-server/lib/xcat/plugins/sles.pm
@@ -327,12 +327,7 @@ sub mknetboot
             $platform = "sles";
         }
 
-        my $suffix = 'cpio.gz';
-        $suffix = 'sfs' if (-r "$rootimgdir/rootimg.sfs");
-        $suffix = 'gz' if (-r "$rootimgdir/rootimg.gz");
-        $suffix = 'cpio.xz' if (-r "$rootimgdir/rootimg.cpio.xz");
-        $suffix = 'tar.gz' if (-r "$rootimgdir/rootimg.tar.gz");
-        $suffix = 'tar.xz' if (-r "$rootimgdir/rootimg.tar.xz");
+        my $compressedrootimg=xCAT::SvrUtils->searchcompressedrootimg("$rootimgdir");
 
         if ($statelite) {
             unless (-r "$rootimgdir/kernel") {
@@ -384,7 +379,7 @@ sub mknetboot
                 }
             }
 
-            unless (-r "$rootimgdir/rootimg.cpio.gz" or -r "$rootimgdir/rootimg.cpio.xz" or -r "$rootimgdir/rootimg.tar.gz" or -r "$rootimgdir/rootimg.tar.xz" or -r "$rootimgdir/rootimg.sfs" or -r "$rootimgdir/rootimg.gz") {
+            unless (-r -f $compressedrootimg) {
                 $callback->({
                         error => [qq{No packed image for platform $osver, architecture $arch, and profile $profile, please run packimage before nodeset}],
                         errorcode => [1]
@@ -588,7 +583,7 @@ sub mknetboot
         else
         {
             $kcmdline =
-              "imgurl=$httpmethod://$imgsrv/$rootimgdir/rootimg.$suffix ";
+              "imgurl=$httpmethod://$imgsrv/$rootimgdir/$compressedrootimg ";
         }
         $kcmdline .= "XCAT=$xcatmaster:$xcatdport quiet ";
 


### PR DESCRIPTION
fix https://github.com/xcat2/xcat-core/issues/2130