### PR TITLE
Disable ac97 for ppc64le platforms for KVM

### DIFF
--- a/xCAT-server/lib/xcat/plugins/kvm.pm
+++ b/xCAT-server/lib/xcat/plugins/kvm.pm
@@ -897,6 +897,9 @@ sub build_xmldesc {
     }
     if (defined($hypcpumodel) and $hypcpumodel eq 'ppc64') {
         $xtree{devices}->{emulator}->{content} = "/usr/bin/qemu-system-ppc64";
+    } elsif (defined($hypcpumodel) and $hypcpumodel eq 'ppc64le') {
+        # do nothing for ppc64le, do not support sound at this time
+        ;
     } else {
         $xtree{devices}->{sound}->{model} = 'ac97';
     }


### PR DESCRIPTION
Problems seem to happen when we power on RHEV KVMs when we request the ac97 driver. 
This just disables the support for ppc64le for now... 