### PR TITLE
Support noboot on interfaces that are tagged vlan on the mangement node

### DIFF
--- a/xCAT-server/lib/xcat/plugins/mknb.pm
+++ b/xCAT-server/lib/xcat/plugins/mknb.pm
@@ -74,8 +74,27 @@ sub process_request {
         }
         my $nicips = xCAT::NetworkUtils->get_nic_ip();
         foreach (keys %nobootnics)  {
-            if (defined($nicips->{$_})) {
-                $nobootnicips{$nicips->{$_}} = 1;
+            # looping on each nics that has 'noboot' configured 
+            print "DEBUG ==> Interface $_ is set to 'noboot'\n";
+            if (defined($nicips)) {
+                foreach my $nicipkey (keys $nicips) {
+                   if ( $nicipkey =~ "@" ) {
+                       # If VLAN tagging is in use on this management node, the interface name is taken
+                       # from 'ip addr show' command and will contain the physical interface: 
+                       #    enP1p12s0f0.2@enP1p12s0f0 
+                       if ($nicipkey =~ m/$_\@/i ) { 
+                           print "DEBUG ---- FOUND ---- Interface name $_ is part of $nicipkey, IP=$nicips->{$nicipkey}!\n";
+                           if (defined($nicips->{$nicipkey})) {
+                               $nobootnicips{$nicips->{$nicipkey}} = 1;
+                           }
+                       }
+                   } else {
+                       # Non VLAN case
+                       if (defined($nicips->{$_})) {
+                           $nobootnicips{$nicips->{$_}} = 1;
+                       }
+                   }
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes Issue #2148 where the interface on the mgmt node is a tagged VLAN.
In this scenario , the `ip addr show` command which is used to get the `nicips` contains the physical device in the name.  

```
12: enP1p12s0f0.2@enP1p12s0f0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP
    link/ether 98:be:94:63:ab:6c brd ff:ff:ff:ff:ff:ff
    inet 10.2.0.1/16 brd 10.2.255.255 scope global enP1p12s0f0.2
       valid_lft forever preferred_lft forever
```
Because of this, the nicname `enP1p12s0f0.2` doesn't match and we are unable detect noboot is configured. 