### PR TITLE
Filter out global local ipv6 address for makedhcp command

### DIFF
--- a/xCAT-server/lib/xcat/plugins/dhcp.pm
+++ b/xCAT-server/lib/xcat/plugins/dhcp.pm
@@ -1591,7 +1591,8 @@ sub process_request
         foreach (@ip6routes) {
 
             #TODO: filter out multicast?  Don't know if multicast groups *can* appear in ip -6 route...
-            if (/^default/ or /^fe80::\/64/ or /^unreachable/ or /^[^ ]+ via/) { #ignore link-local, junk, and routed networks
+            #ignore link-local, global-local, junk, and routed networks
+            if (/^default/ or /^fe80::\/64/ or /^2002::\/64/ or /^unreachable/ or /^[^ ]+ via/) { 
                 next;
             }
             my @parts = split /\s+/;


### PR DESCRIPTION
This is for issue #2132 .  From ipv6 documentation:
``````
The following prefixes have been reserved for special use:

2002::/16
Indicates that a 6to4 routing prefix follows.

fe80::/10
Indicates that a link-local address follows.

ff00::/8
Indicates that a multicast address follows.
```````

So, I think it's safe for us to filter out prefix 2002 for ipv6 global local address, as we did for prefix fe80 for ipv6 link local address.