### PR TITLE
Clean up logger messages for xcatroot in diskless boot

### DIFF
--- a/perl-xCAT/xCAT/FSPvm.pm
+++ b/perl-xCAT/xCAT/FSPvm.pm
@@ -2037,7 +2037,7 @@ sub query_cec_info {
             if (scalar(@$rethash)) {
                 push @result, @$rethash;
             } else {
-                push @result, [ $name, "No information got", -1 ];
+                push @result, [ $name, "No information obtained.", -1 ];
                 last;
             }
             $lpar_hash{$name} = \%tmp_hash;
@@ -2048,7 +2048,7 @@ sub query_cec_info {
             if (scalar(@$rethash)) {
                 push @result, @$rethash;
             } else {
-                push @result, [ @td[3], "No information got", -1 ];
+                push @result, [ @td[3], "No information obtained.", -1 ];
                 last;
             }
 

--- a/perl-xCAT/xCAT/MacMap.pm
+++ b/perl-xCAT/xCAT/MacMap.pm
@@ -329,14 +329,14 @@ sub dump_mac_info {
     foreach my $switch (keys %{ $self->{switchparmhash} }) {
         if ($dump_all_switches or defined($switches_to_dump{$switch})) {
             if ($self->{show_verbose_info}) {
-                xCAT::MsgUtils->message("I", { data => ["<INFO>$switch: Start to get information"] }, $self->{callback});
+                xCAT::MsgUtils->message("I", { data => ["<INFO>$switch: Attempting to refresh switch information..."] }, $self->{callback});
             }
             $self->refresh_switch(undef, $community, $switch);
             if ($self->{show_verbose_info}) {
-                xCAT::MsgUtils->message("I", { data => ["<INFO>$switch: Finish to get information"] }, $self->{callback});
+                xCAT::MsgUtils->message("I", { data => ["<INFO>$switch: Finished refreshing switch information."] }, $self->{callback});
             }
             if (!defined($self->{macinfo}->{$switch})) {
-                $ret{$switch}->{ErrorStr} = "No information get";
+                $ret{$switch}->{ErrorStr} = "No switch information obtained.";
                 foreach my $defportname (keys %{ $self->{switches}->{$switch} }) {
                     $ret{$switch}->{$defportname}->{Node} = $self->{switches}->{$switch}->{$defportname};
                 }

--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
@@ -24,241 +24,240 @@ xcatdebugmode="$(getarg xcatdebugmode=)"
 [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "MASTER=$MASTER XCATIPORT=$XCATIPORT"
 
 if [ "$NODESTATUS" != "0" ]; then
-[ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "nodestatus: netbooting,reporting..."
+    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "nodestatus: netbooting,reporting..."
     /tmp/updateflag $MASTER $XCATIPORT "installstatus netbooting"
 fi
 
 
 imgurl="$(getarg imgurl=)";
 if [ ! -z "$imgurl" ]; then
-	if [ xhttp = x${imgurl%%:*} ]; then
-		NFS=0
-		FILENAME=${imgurl##*/}
-		while [ ! -r "$FILENAME" ]; do
+    if [ xhttp = x${imgurl%%:*} ]; then
+        NFS=0
+        FILENAME=${imgurl##*/}
+        while [ ! -r "$FILENAME" ]; do
             [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "downloading $imgurl...."
-			echo Getting $imgurl...
-			if ! wget -nv $imgurl; then
+            echo Getting $imgurl...
+            if ! wget -nv $imgurl; then
                 [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "downloading $imgurl failed,retrying...."
-				rm -f $FILENAME
-				sleep 27
-			fi
-		done
-	elif [ xnfs = x${imgurl%%:*} ]; then
-		NFS=1
-		SERVER=${imgurl#nfs:}
-		SERVER=${SERVER#/}
-		SERVER=${SERVER#/}
-		ROOTDIR=$SERVER
-		SERVER=${SERVER%%/*}
-		SERVER=${SERVER%:}
-		ROOTDIR=/${ROOTDIR#*/} 
-	fi
+                rm -f $FILENAME
+                sleep 27
+            fi
+        done
+    elif [ xnfs = x${imgurl%%:*} ]; then
+        NFS=1
+        SERVER=${imgurl#nfs:}
+        SERVER=${SERVER#/}
+        SERVER=${SERVER#/}
+        ROOTDIR=$SERVER
+        SERVER=${SERVER%%/*}
+        SERVER=${SERVER%:}
+        ROOTDIR=/${ROOTDIR#*/} 
+    fi
 fi
-#echo 0 > /proc/sys/vm/zone_reclaim_mode #Avoid kernel bug
 
 if [ -r /rootimg.sfs ]; then
-  echo Setting up squashfs with ram overlay.
-  mknod /dev/loop0 b 7 0
-  mkdir -p /ro
-  mkdir -p /rw
-  mount -t squashfs /rootimg.sfs /ro
-  mount -t tmpfs rw /rw
-  mount -t aufs -o dirs=/rw:/ro mergedroot $NEWROOT
-  mkdir -p $NEWROOT/ro
-  mkdir -p $NEWROOT/rw
-  mount --move /ro $NEWROOT/ro
-  mount --move /rw $NEWROOT/rw
+    echo Setting up squashfs with ram overlay.
+    mknod /dev/loop0 b 7 0
+    mkdir -p /ro
+    mkdir -p /rw
+    mount -t squashfs /rootimg.sfs /ro
+    mount -t tmpfs rw /rw
+    mount -t aufs -o dirs=/rw:/ro mergedroot $NEWROOT
+    mkdir -p $NEWROOT/ro
+    mkdir -p $NEWROOT/rw
+    mount --move /ro $NEWROOT/ro
+    mount --move /rw $NEWROOT/rw
 elif [ -r /rootimg.cpio.gz ] || [ -r /rootimg.cpio.xz ]; then
-  [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "rootimg downloaded,setting up RAM-root tmpfs...."
-  echo Setting up RAM-root tmpfs.
-  if [ -z $rootlimit ];then
-    mount -t tmpfs -o mode=755 rootfs $NEWROOT
-  else
-    mount -t tmpfs -o mode=755,size=$rootlimit rootfs $NEWROOT
-  fi
+    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "rootimg downloaded,setting up RAM-root tmpfs...."
+    echo Setting up RAM-root tmpfs.
+    if [ -z $rootlimit ];then
+        mount -t tmpfs -o mode=755 rootfs $NEWROOT
+    else
+        mount -t tmpfs -o mode=755,size=$rootlimit rootfs $NEWROOT
+    fi
 
-  cd $NEWROOT
-  [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "Extracting root filesystem:"
-  echo -n "Extracting root filesystem:"
-  if [ -r /rootimg.cpio.gz ]; then
-    if [ -x /bin/cpio ]; then
-      gzip -cd /rootimg.cpio.gz |/bin/cpio -idum
-    else
-      gzip -cd /rootimg.cpio.gz |cpio -idum
+    cd $NEWROOT
+    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "Extracting root filesystem:"
+    echo -n "Extracting root filesystem:"
+    if [ -r /rootimg.cpio.gz ]; then
+        if [ -x /bin/cpio ]; then
+            gzip -cd /rootimg.cpio.gz |/bin/cpio -idum
+        else
+            gzip -cd /rootimg.cpio.gz |cpio -idum
+        fi
+    elif [ -r /rootimg.cpio.xz ]; then
+        if [ -x /bin/cpio ]; then
+            xz -cd /rootimg.cpio.xz |/bin/cpio -idum
+        else
+            xz -cd /rootimg.cpio.xz |cpio -idum
+        fi
     fi
-  elif [ -r /rootimg.cpio.xz ]; then
-    if [ -x /bin/cpio ]; then
-      xz -cd /rootimg.cpio.xz |/bin/cpio -idum
-    else
-      xz -cd /rootimg.cpio.xz |cpio -idum
-    fi
-  fi
-  $NEWROOT/etc/init.d/localdisk
-  [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "Done...."
-  echo Done
+    $NEWROOT/etc/init.d/localdisk
+    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "Done...."
+    echo Done
 elif [ -r /rootimg.tar.gz ] || [ -r /rootimg.tar.xz ]; then
-  [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "rootimg downloaded,setting up RAM-root tmpfs...."
-  echo Setting up RAM-root tmpfs.
-  if [ -z $rootlimit ];then
-    mount -t tmpfs -o mode=755 rootfs $NEWROOT
-  else
-    mount -t tmpfs -o mode=755,size=$rootlimit rootfs $NEWROOT
-  fi
+    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "rootimg downloaded,setting up RAM-root tmpfs...."
+    echo Setting up RAM-root tmpfs.
+    if [ -z $rootlimit ];then
+        mount -t tmpfs -o mode=755 rootfs $NEWROOT
+    else
+        mount -t tmpfs -o mode=755,size=$rootlimit rootfs $NEWROOT
+    fi
 
-  cd $NEWROOT
-  [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "Extracting root filesystem:"
-  echo -n "Extracting root filesystem:"
-  if [ -r /rootimg.tar.gz ]; then
-    tar --selinux --xattrs-include='*' -zxf /rootimg.tar.gz
-    if [ $? -ne 0 ]; then
-        tar --selinux -zxf /rootimg.tar.gz
+    cd $NEWROOT
+    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "Extracting root filesystem:"
+    echo -n "Extracting root filesystem:"
+    if [ -r /rootimg.tar.gz ]; then
+        tar --selinux --xattrs-include='*' -zxf /rootimg.tar.gz
+        if [ $? -ne 0 ]; then
+            tar --selinux -zxf /rootimg.tar.gz
+        fi
+    elif [ -r /rootimg.tar.xz ]; then
+        tar --selinux --xattrs-include='*' -Jxf /rootimg.tar.xz
+        if [ $? -ne 0 ]; then
+            tar --selinux -Jxf /rootimg.tar.xz
+        fi
     fi
-  elif [ -r /rootimg.tar.xz ]; then
-    tar --selinux --xattrs-include='*' -Jxf /rootimg.tar.xz
-    if [ $? -ne 0 ]; then
-        tar --selinux -Jxf /rootimg.tar.xz
-    fi
-  fi
-  $NEWROOT/etc/init.d/localdisk
-  [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "Done...."
-  echo Done
+    $NEWROOT/etc/init.d/localdisk
+    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "Done...."
+    echo Done
 elif [ -r /rootimg-statelite.gz ]; then
-  echo Setting up RAM-root tmpfs for statelite mode.
+    echo Setting up RAM-root tmpfs for statelite mode.
  
-  if [ -z $rootlimit];then
-    mount -t tmpfs -o mode=755 rootfs $NEWROOT
-  else
-    mount -t tmpfs -o mode=755,size=$rootlimit rootfs $NEWROOT
-  fi
-
-  cd $NEWROOT
-  echo -n "Extracting root filesystem:"
-  if [ -x /bin/cpio ]; then
-    gzip -cd /rootimg-statelite.gz |/bin/cpio -idum
-  else
-    gzip -cd /rootimg-statelite.gz |cpio -idum
-  fi
-  echo Done
-  # then, the statelite staffs will be processed
-  echo Setting up Statelite 
-  modprobe nfs
-  MAXTRIES=7
-  ITER=0
-  if [ ! -e "$NEWROOT/$RWDIR" ]; then
-    echo ""
-    echo "The /$RWDIR directory doesn't exist in the rootimg... "
-    echo ""
-    /bin/sh
-  fi
-
-  if [ ! -e "$NEWROOT/etc/init.d/statelite" ]; then
-    echo ""
-    echo "$NEWROOT/etc/init.d/statelite doesn't exist... "
-    echo ""
-    /bin/sh
-  fi
-
-  mount -t tmpfs rw $NEWROOT/$RWDIR
-  mkdir -p $NEWROOT/$RWDIR/tmpfs
-  ME=`hostname`
-  if [ ! -z $NODE ]; then
-      ME=$NODE
-  fi
-
-
-  # mount the SNAPSHOT directory here for persistent use.
-  if [ ! -z $STATEMNT ]; then
-    SNAPSHOTSERVER=${STATEMNT%:*}
-    SNAPSHOTROOT=${STATEMNT#*/}
-    if [ -z $SNAPSHOTROOT ]; then
-        SNAPSHOTROOT=$SNAPSHOTSERVER
-        SNAPSHOTSERVER=
+    if [ -z $rootlimit];then
+        mount -t tmpfs -o mode=755 rootfs $NEWROOT
+    else
+        mount -t tmpfs -o mode=755,size=$rootlimit rootfs $NEWROOT
     fi
-  fi
 
-  if [ ! -z $SNAPSHOTSERVER ]; then
-    mkdir -p $NEWROOT/$RWDIR/persistent
-    MAXTRIES=5
+    cd $NEWROOT
+    echo -n "Extracting root filesystem:"
+    if [ -x /bin/cpio ]; then
+        gzip -cd /rootimg-statelite.gz |/bin/cpio -idum
+    else
+        gzip -cd /rootimg-statelite.gz |cpio -idum
+    fi
+    echo Done
+    # then, the statelite staffs will be processed
+    echo Setting up Statelite 
+    modprobe nfs
+    MAXTRIES=7
     ITER=0
-	if [ -z $MNTOPTS ]; then
-		MNT_OPTIONS="nolock,rsize=32768,tcp,nfsvers=3,timeo=14"
-	else
-		MNT_OPTIONS=$MNTOPTS
-	fi
-    while ! mount $SNAPSHOTSERVER:/$SNAPSHOTROOT $NEWROOT/$RWDIR/persistent -o $MNT_OPTIONS; do
-        ITER=$(( ITER + 1 ))
-        if [ "$ITER" == "$MAXTRIES" ]; then
-            echo "You are dead, rpower $ME boot to play again."
-            echo "Possible problems:
+    if [ ! -e "$NEWROOT/$RWDIR" ]; then
+        echo ""
+        echo "The /$RWDIR directory doesn't exist in the rootimg... "
+        echo ""
+        /bin/sh
+    fi
+
+    if [ ! -e "$NEWROOT/etc/init.d/statelite" ]; then
+        echo ""
+        echo "$NEWROOT/etc/init.d/statelite doesn't exist... "
+        echo ""
+        /bin/sh
+    fi
+
+    mount -t tmpfs rw $NEWROOT/$RWDIR
+    mkdir -p $NEWROOT/$RWDIR/tmpfs
+    ME=`hostname`
+    if [ ! -z $NODE ]; then
+        ME=$NODE
+    fi
+
+
+    # mount the SNAPSHOT directory here for persistent use.
+    if [ ! -z $STATEMNT ]; then
+        SNAPSHOTSERVER=${STATEMNT%:*}
+        SNAPSHOTROOT=${STATEMNT#*/}
+        if [ -z $SNAPSHOTROOT ]; then
+            SNAPSHOTROOT=$SNAPSHOTSERVER
+            SNAPSHOTSERVER=
+        fi
+    fi
+
+    if [ ! -z $SNAPSHOTSERVER ]; then
+        mkdir -p $NEWROOT/$RWDIR/persistent
+        MAXTRIES=5
+        ITER=0
+        if [ -z $MNTOPTS ]; then
+            MNT_OPTIONS="nolock,rsize=32768,tcp,nfsvers=3,timeo=14"
+        else
+            MNT_OPTIONS=$MNTOPTS
+        fi
+        while ! mount $SNAPSHOTSERVER:/$SNAPSHOTROOT $NEWROOT/$RWDIR/persistent -o $MNT_OPTIONS; do
+            ITER=$(( ITER + 1 ))
+            if [ "$ITER" == "$MAXTRIES" ]; then
+                echo "You are dead, rpower $ME boot to play again."
+                echo "Possible problems:
 1.  $SNAPSHOTSERVER is not exporting $SNAPSHOTROOT ?
 2.  Is DNS set up? Maybe that's why I can't mount $SNAPSHOTSERVER."
-            /bin/sh
-            exit
-        fi
-        RS=$(( $RANDOM % 20 ))
-        echo "Trying again in $RS seconds ..."
-        sleep $RS
-    done
+                /bin/sh
+                exit
+            fi
+            RS=$(( $RANDOM % 20 ))
+            echo "Trying again in $RS seconds ..."
+            sleep $RS
+        done
 
-    # create directory which is named after my node name
-    mkdir -p $NEWROOT/$RWDIR/persistent/$ME
-    ITER=0
-    # umount current persistent mount
-    while ! umount -l $NEWROOT/$RWDIR/persistent; do
-        ITER=$(( ITER + 1 ))
-        if [ "$ITER" == "$MAXTRIES" ]; then
-            echo "Your are dead, rpower $ME boot to play again."
-            echo "Cannot umount $NEWROOT/$RWDIR/persistent."
-            /bin/sh
-            exit
-        fi
-        RS= $(( $RANDOM % 20 ))
-        echo "Trying again in $RS seconds..."
-        sleep $RS
-    done
+        # create directory which is named after my node name
+        mkdir -p $NEWROOT/$RWDIR/persistent/$ME
+        ITER=0
+        # umount current persistent mount
+        while ! umount -l $NEWROOT/$RWDIR/persistent; do
+            ITER=$(( ITER + 1 ))
+            if [ "$ITER" == "$MAXTRIES" ]; then
+                echo "Your are dead, rpower $ME boot to play again."
+                echo "Cannot umount $NEWROOT/$RWDIR/persistent."
+                /bin/sh
+                exit
+            fi
+            RS= $(( $RANDOM % 20 ))
+            echo "Trying again in $RS seconds..."
+            sleep $RS
+        done
 
-    # mount persistent to server:/rootpath/nodename
-    ITER=0
-    while ! mount $SNAPSHOTSERVER:/$SNAPSHOTROOT/$ME  $NEWROOT/$RWDIR/persistent -o $MNT_OPTIONS; do
-        ITER=$(( ITER + 1 ))
-        if [ "$ITER" == "$MAXTRIES" ]; then
-            echo "Your are dead, rpower $ME boot to play again."
-            echo "Possible problems: cannot mount to $SNAPSHOTSERVER:/$SNAPSHOTROOT/$ME."
-            /bin/sh
-            exit
-        fi
-        RS= $(( $RANDOM % 20 ))
-        echo "Trying again in $RS seconds..."
-        sleep $RS
-    done
-  fi
+        # mount persistent to server:/rootpath/nodename
+        ITER=0
+        while ! mount $SNAPSHOTSERVER:/$SNAPSHOTROOT/$ME  $NEWROOT/$RWDIR/persistent -o $MNT_OPTIONS; do
+            ITER=$(( ITER + 1 ))
+            if [ "$ITER" == "$MAXTRIES" ]; then
+                echo "Your are dead, rpower $ME boot to play again."
+                echo "Possible problems: cannot mount to $SNAPSHOTSERVER:/$SNAPSHOTROOT/$ME."
+                /bin/sh
+                exit
+            fi
+            RS= $(( $RANDOM % 20 ))
+            echo "Trying again in $RS seconds..."
+            sleep $RS
+        done
+    fi
 
-  $NEWROOT/etc/init.d/localdisk
-  $NEWROOT/etc/init.d/statelite
-  fastboot=yes
-  export fastboot
-  keep_old_ip=yes
-  export keep_old_ip
+    $NEWROOT/etc/init.d/localdisk
+    $NEWROOT/etc/init.d/statelite
+    fastboot=yes
+    export fastboot
+    keep_old_ip=yes
+    export keep_old_ip
 
-  mount -n --bind /dev $NEWROOT/dev
-  mount -n --bind /proc $NEWROOT/proc
-  mount -n --bind /sys $NEWROOT/sys
+    mount -n --bind /dev $NEWROOT/dev
+    mount -n --bind /proc $NEWROOT/proc
+    mount -n --bind /sys $NEWROOT/sys
 
 else
-  [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "Failed to download image, panicing in 5..."
-  echo -n Failed to download image, panicing in 5...
-  for i in 4 3 2 1 0; do
-    /bin/sleep 1
-    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "$i..."
-    echo -n $i...
-  done 
-  [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "You're dead.  rpower nodename reset to play again." 
-  [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "* Did you packimage with -m cpio, -m squashfs, or -m nfs?"
-  [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "* If using -m squashfs did you include aufs.ko with geninitrd? e.g.:  -n tg3,squashfs,aufs,loop"
-  [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "If using -m nfs did you export NFS and sync rootimg?  And did you include the aufs and nfs modules in the proper order: e.g.:  -n tg3,aufs,loop,sunrpc,lockd,nfs_acl,nfs"
+    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "Failed to download image, panicing in 5..."
+    echo -n Failed to download image, panicing in 5...
+    for i in 4 3 2 1 0; do
+        /bin/sleep 1
+        [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "$i..."
+        echo -n $i...
+    done 
+    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "You're dead.  rpower nodename reset to play again." 
+    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "* Did you packimage with -m cpio, -m squashfs, or -m nfs?"
+    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "* If using -m squashfs did you include aufs.ko with geninitrd? e.g.:  -n tg3,squashfs,aufs,loop"
+    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "If using -m nfs did you export NFS and sync rootimg?  And did you include the aufs and nfs modules in the proper order: e.g.:  -n tg3,aufs,loop,sunrpc,lockd,nfs_acl,nfs"
  
-  echo
-  echo "You're dead.  rpower nodename reset to play again.
+    echo
+    echo "You're dead.  rpower nodename reset to play again.
 
 * Did you packimage with -m cpio, -m squashfs, or -m nfs?
 * If using -m squashfs did you include aufs.ko with geninitrd?
@@ -268,8 +267,8 @@ else
   e.g.:  -n tg3,aufs,loop,sunrpc,lockd,nfs_acl,nfs
 
 "
-  /bin/sh
-  exit
+    /bin/sh
+    exit
 fi
 cd /
 
@@ -293,41 +292,41 @@ function getdevfrommac() {
 
 
 if [ -z $STATEMNT ]; then
-  for lf in /tmp/dhclient.*.lease; do
-    netif=${lf#*.}
-    netif=${netif%.*}
-    cp $lf  "$NEWROOT/var/lib/dhclient/dhclient-$netif.leases"
-    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "saving $NEWROOT/var/lib/dhclient/dhclient-$netif.leases"
-  done
+    for lf in /tmp/dhclient.*.lease; do
+        netif=${lf#*.}
+        netif=${netif%.*}
+        cp $lf  "$NEWROOT/var/lib/dhclient/dhclient-$netif.leases"
+        [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "saving $NEWROOT/var/lib/dhclient/dhclient-$netif.leases"
+    done
 
-  ifname="$(getarg ifname=)"
-  netdev="$(getarg netdev=)"
-  BOOTIF="$(getarg BOOTIF=)"
-  if [ ! -z "$ifname" ]; then
-    MACX=${ifname#*:}
-    ETHX=${ifname%:$MACX*}
-  elif [ ! -z "$netdev" ]; then
-    ETHX=$netdev
-    MACX=`ip link show $netdev | grep ether | awk '{print $2}'`
-  elif [ ! -z "$BOOTIF" ]; then
-    MACX=$BOOTIF
-    MACX=${MACX#01-}
-    MACX=${MACX//-/:}
-    ETHX=$(getdevfrommac $MACX)
-  fi
-
-
-  if [ ! -z "$MACX" ] && [ ! -z "$ETHX" ]; then
-    if [ ! -e $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX ]; then
-        [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "creating $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX"
-        touch $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX
+    ifname="$(getarg ifname=)"
+    netdev="$(getarg netdev=)"
+    BOOTIF="$(getarg BOOTIF=)"
+    if [ ! -z "$ifname" ]; then
+        MACX=${ifname#*:}
+        ETHX=${ifname%:$MACX*}
+    elif [ ! -z "$netdev" ]; then
+        ETHX=$netdev
+        MACX=`ip link show $netdev | grep ether | awk '{print $2}'`
+    elif [ ! -z "$BOOTIF" ]; then
+        MACX=$BOOTIF
+        MACX=${MACX#01-}
+        MACX=${MACX//-/:}
+        ETHX=$(getdevfrommac $MACX)
     fi
-    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "writing $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX: DEVICE=$ETHX;BOOTPROTO=dhcp;HWADDR=$MACX;ONBOOT=yes"
-    echo "DEVICE=$ETHX" > $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX
-    echo "BOOTPROTO=dhcp" >> $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX
-    echo "HWADDR=$MACX" >> $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX
-    echo "ONBOOT=yes" >> $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX
-  fi
+
+
+    if [ ! -z "$MACX" ] && [ ! -z "$ETHX" ]; then
+        if [ ! -e $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX ]; then
+            [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "creating $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX"
+            touch $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX
+        fi
+        [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "writing $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX: DEVICE=$ETHX;BOOTPROTO=dhcp;HWADDR=$MACX;ONBOOT=yes"
+        echo "DEVICE=$ETHX" > $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX
+        echo "BOOTPROTO=dhcp" >> $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX
+        echo "HWADDR=$MACX" >> $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX
+        echo "ONBOOT=yes" >> $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX
+    fi
 fi
 
 [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "saving $NEWROOT/etc/resolv.conf"
@@ -335,7 +334,7 @@ cp /etc/resolv.conf "$NEWROOT/etc/"
 
 if [ -d "$NEWROOT/etc/sysconfig" -a ! -e "$NEWROOT/etc/sysconfig/selinux" ]; then
     [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "disable selinux ..."
-	echo "SELINUX=disabled" >> "$NEWROOT/etc/sysconfig/selinux"
+    echo "SELINUX=disabled" >> "$NEWROOT/etc/sysconfig/selinux"
 fi
 
 [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "exiting xcatroot..."

--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
@@ -10,6 +10,9 @@ XCAT="$(getarg XCAT=)"
 XCATMASTER=$XCAT
 
 rootlimit="$(getarg rootlimit=)"
+xcatdebugmode="$(getarg xcatdebugmode=)"
+
+[ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "in dracut, executing xcatroot..."
 
 getarg nonodestatus
 NODESTATUS=$?
@@ -20,13 +23,10 @@ if [ $? -ne 0 ]; then
     XCATIPORT="3002"
 fi
 
-xcatdebugmode="$(getarg xcatdebugmode=)"
-
-[ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "running xcatroot...."
-[ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "MASTER=$MASTER XCATIPORT=$XCATIPORT"
+[ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "MASTER=$MASTER XCATIPORT=$XCATIPORT NODESTATUS=$NODESTATUS"
 
 if [ "$NODESTATUS" != "0" ]; then
-    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "nodestatus: netbooting,reporting..."
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Reporting status=netbooting..."
     /tmp/updateflag $MASTER $XCATIPORT "installstatus netbooting"
 fi
 
@@ -37,10 +37,10 @@ if [ ! -z "$imgurl" ]; then
         NFS=0
         FILENAME=${imgurl##*/}
         while [ ! -r "$FILENAME" ]; do
-            [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "downloading $imgurl...."
+            [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Downloading $imgurl...."
             echo Getting $imgurl...
             if ! wget -nv $imgurl; then
-                [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "downloading $imgurl failed,retrying...."
+                [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Downloading $imgurl FAILED, retrying..."
                 rm -f $FILENAME
                 sleep 27
             fi
@@ -55,6 +55,7 @@ if [ ! -z "$imgurl" ]; then
         SERVER=${SERVER%:}
         ROOTDIR=/${ROOTDIR#*/} 
     fi
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Download complete."
 fi
 
 if [ -r /rootimg.sfs ]; then
@@ -70,7 +71,7 @@ if [ -r /rootimg.sfs ]; then
     mount --move /ro $NEWROOT/ro
     mount --move /rw $NEWROOT/rw
 elif [ -r /rootimg.cpio.gz ] || [ -r /rootimg.cpio.xz ]; then
-    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "rootimg downloaded,setting up RAM-root tmpfs...."
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "[rootimg.cpio.[gz/xz]...Setting up RAM-root tmpfs."
     echo Setting up RAM-root tmpfs.
     if [ -z $rootlimit ];then
         mount -t tmpfs -o mode=755 rootfs $NEWROOT
@@ -79,8 +80,8 @@ elif [ -r /rootimg.cpio.gz ] || [ -r /rootimg.cpio.xz ]; then
     fi
 
     cd $NEWROOT
-    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Extracting root filesystem:"
-    echo -n "Extracting root filesystem:"
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Extracting the root filesystem..."
+    echo -n "Extracting the root filesystem..."
     if [ -r /rootimg.cpio.gz ]; then
         if [ -x /bin/cpio ]; then
             gzip -cd /rootimg.cpio.gz |/bin/cpio -idum
@@ -95,10 +96,10 @@ elif [ -r /rootimg.cpio.gz ] || [ -r /rootimg.cpio.xz ]; then
         fi
     fi
     $NEWROOT/etc/init.d/localdisk
-    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Done...."
-    echo Done
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Done extracting the root filesystem..."
+    echo "Done extracting the root filesystem..."
 elif [ -r /rootimg.tar.gz ] || [ -r /rootimg.tar.xz ]; then
-    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "rootimg downloaded,setting up RAM-root tmpfs...."
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "[rootimg.tar.[gz/xz]...Setting up RAM-root tmpfs."
     echo Setting up RAM-root tmpfs.
     if [ -z $rootlimit ];then
         mount -t tmpfs -o mode=755 rootfs $NEWROOT
@@ -107,8 +108,8 @@ elif [ -r /rootimg.tar.gz ] || [ -r /rootimg.tar.xz ]; then
     fi
 
     cd $NEWROOT
-    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Extracting root filesystem:"
-    echo -n "Extracting root filesystem:"
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Extracting the root filesystem..."
+    echo -n "Extracting the root filesystem..."
     if [ -r /rootimg.tar.gz ]; then
         tar --selinux --xattrs-include='*' -zxf /rootimg.tar.gz
         if [ $? -ne 0 ]; then
@@ -121,9 +122,10 @@ elif [ -r /rootimg.tar.gz ] || [ -r /rootimg.tar.xz ]; then
         fi
     fi
     $NEWROOT/etc/init.d/localdisk
-    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Done...."
-    echo Done
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Done extracting the root filesystem..."
+    echo "Done extracting the root filesystem..."
 elif [ -r /rootimg-statelite.gz ]; then
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Setting up RAM-root tmpfs for statelite mode."
     echo Setting up RAM-root tmpfs for statelite mode.
  
     if [ -z $rootlimit];then
@@ -133,14 +135,17 @@ elif [ -r /rootimg-statelite.gz ]; then
     fi
 
     cd $NEWROOT
-    echo -n "Extracting root filesystem:"
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Extracting the root filesystem..."
+    echo -n "Extracting root filesystem..."
     if [ -x /bin/cpio ]; then
         gzip -cd /rootimg-statelite.gz |/bin/cpio -idum
     else
         gzip -cd /rootimg-statelite.gz |cpio -idum
     fi
-    echo Done
-    # then, the statelite staffs will be processed
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Done extracting the root filesystem..."
+    echo "Done extracting the root filesystem..."
+
+    # then, the statelite stuff will be processed
     echo Setting up Statelite 
     modprobe nfs
     MAXTRIES=7
@@ -246,8 +251,8 @@ elif [ -r /rootimg-statelite.gz ]; then
     mount -n --bind /sys $NEWROOT/sys
 
 else
-    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Failed to download image, panicing in 5..."
-    echo -n Failed to download image, panicing in 5...
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Failed to download image, panic in 5..."
+    echo -n Failed to download image, panic in 5...
     for i in 4 3 2 1 0; do
         /bin/sleep 1
         [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "$i..."
@@ -298,7 +303,7 @@ if [ -z $STATEMNT ]; then
         netif=${lf#*.}
         netif=${netif%.*}
         cp $lf  "$NEWROOT/var/lib/dhclient/dhclient-$netif.leases"
-        [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "saving $NEWROOT/var/lib/dhclient/dhclient-$netif.leases"
+        [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Saving $NEWROOT/var/lib/dhclient/dhclient-$netif.leases"
     done
 
     ifname="$(getarg ifname=)"
@@ -320,10 +325,10 @@ if [ -z $STATEMNT ]; then
 
     if [ ! -z "$MACX" ] && [ ! -z "$ETHX" ]; then
         if [ ! -e $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX ]; then
-            [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "creating $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX"
+            [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Creating $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX"
             touch $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX
         fi
-        [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "writing $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX: DEVICE=$ETHX;BOOTPROTO=dhcp;HWADDR=$MACX;ONBOOT=yes"
+        [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Writing $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX: DEVICE=$ETHX;BOOTPROTO=dhcp;HWADDR=$MACX;ONBOOT=yes"
         echo "DEVICE=$ETHX" > $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX
         echo "BOOTPROTO=dhcp" >> $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX
         echo "HWADDR=$MACX" >> $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX
@@ -331,7 +336,7 @@ if [ -z $STATEMNT ]; then
     fi
 fi
 
-[ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "saving $NEWROOT/etc/resolv.conf"
+[ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Saving $NEWROOT/etc/resolv.conf"
 cp /etc/resolv.conf "$NEWROOT/etc/"
 
 if [ -d "$NEWROOT/etc/sysconfig" -a ! -e "$NEWROOT/etc/sysconfig/selinux" ]; then

--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+log_label="xcat.dracut_033"
+
 NEWROOT=$3
 RWDIR=.statelite
 
@@ -20,11 +22,11 @@ fi
 
 xcatdebugmode="$(getarg xcatdebugmode=)"
 
-[ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "running xcatroot...."
-[ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "MASTER=$MASTER XCATIPORT=$XCATIPORT"
+[ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "running xcatroot...."
+[ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "MASTER=$MASTER XCATIPORT=$XCATIPORT"
 
 if [ "$NODESTATUS" != "0" ]; then
-    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "nodestatus: netbooting,reporting..."
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "nodestatus: netbooting,reporting..."
     /tmp/updateflag $MASTER $XCATIPORT "installstatus netbooting"
 fi
 
@@ -35,10 +37,10 @@ if [ ! -z "$imgurl" ]; then
         NFS=0
         FILENAME=${imgurl##*/}
         while [ ! -r "$FILENAME" ]; do
-            [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "downloading $imgurl...."
+            [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "downloading $imgurl...."
             echo Getting $imgurl...
             if ! wget -nv $imgurl; then
-                [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "downloading $imgurl failed,retrying...."
+                [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "downloading $imgurl failed,retrying...."
                 rm -f $FILENAME
                 sleep 27
             fi
@@ -68,7 +70,7 @@ if [ -r /rootimg.sfs ]; then
     mount --move /ro $NEWROOT/ro
     mount --move /rw $NEWROOT/rw
 elif [ -r /rootimg.cpio.gz ] || [ -r /rootimg.cpio.xz ]; then
-    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "rootimg downloaded,setting up RAM-root tmpfs...."
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "rootimg downloaded,setting up RAM-root tmpfs...."
     echo Setting up RAM-root tmpfs.
     if [ -z $rootlimit ];then
         mount -t tmpfs -o mode=755 rootfs $NEWROOT
@@ -77,7 +79,7 @@ elif [ -r /rootimg.cpio.gz ] || [ -r /rootimg.cpio.xz ]; then
     fi
 
     cd $NEWROOT
-    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "Extracting root filesystem:"
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Extracting root filesystem:"
     echo -n "Extracting root filesystem:"
     if [ -r /rootimg.cpio.gz ]; then
         if [ -x /bin/cpio ]; then
@@ -93,10 +95,10 @@ elif [ -r /rootimg.cpio.gz ] || [ -r /rootimg.cpio.xz ]; then
         fi
     fi
     $NEWROOT/etc/init.d/localdisk
-    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "Done...."
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Done...."
     echo Done
 elif [ -r /rootimg.tar.gz ] || [ -r /rootimg.tar.xz ]; then
-    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "rootimg downloaded,setting up RAM-root tmpfs...."
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "rootimg downloaded,setting up RAM-root tmpfs...."
     echo Setting up RAM-root tmpfs.
     if [ -z $rootlimit ];then
         mount -t tmpfs -o mode=755 rootfs $NEWROOT
@@ -105,7 +107,7 @@ elif [ -r /rootimg.tar.gz ] || [ -r /rootimg.tar.xz ]; then
     fi
 
     cd $NEWROOT
-    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "Extracting root filesystem:"
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Extracting root filesystem:"
     echo -n "Extracting root filesystem:"
     if [ -r /rootimg.tar.gz ]; then
         tar --selinux --xattrs-include='*' -zxf /rootimg.tar.gz
@@ -119,7 +121,7 @@ elif [ -r /rootimg.tar.gz ] || [ -r /rootimg.tar.xz ]; then
         fi
     fi
     $NEWROOT/etc/init.d/localdisk
-    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "Done...."
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Done...."
     echo Done
 elif [ -r /rootimg-statelite.gz ]; then
     echo Setting up RAM-root tmpfs for statelite mode.
@@ -244,17 +246,17 @@ elif [ -r /rootimg-statelite.gz ]; then
     mount -n --bind /sys $NEWROOT/sys
 
 else
-    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "Failed to download image, panicing in 5..."
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Failed to download image, panicing in 5..."
     echo -n Failed to download image, panicing in 5...
     for i in 4 3 2 1 0; do
         /bin/sleep 1
-        [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "$i..."
+        [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "$i..."
         echo -n $i...
     done 
-    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "You're dead.  rpower nodename reset to play again." 
-    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "* Did you packimage with -m cpio, -m squashfs, or -m nfs?"
-    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "* If using -m squashfs did you include aufs.ko with geninitrd? e.g.:  -n tg3,squashfs,aufs,loop"
-    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "If using -m nfs did you export NFS and sync rootimg?  And did you include the aufs and nfs modules in the proper order: e.g.:  -n tg3,aufs,loop,sunrpc,lockd,nfs_acl,nfs"
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "You're dead.  rpower nodename reset to play again." 
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "* Did you packimage with -m cpio, -m squashfs, or -m nfs?"
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "* If using -m squashfs did you include aufs.ko with geninitrd? e.g.:  -n tg3,squashfs,aufs,loop"
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "If using -m nfs did you export NFS and sync rootimg?  And did you include the aufs and nfs modules in the proper order: e.g.:  -n tg3,aufs,loop,sunrpc,lockd,nfs_acl,nfs"
  
     echo
     echo "You're dead.  rpower nodename reset to play again.
@@ -296,7 +298,7 @@ if [ -z $STATEMNT ]; then
         netif=${lf#*.}
         netif=${netif%.*}
         cp $lf  "$NEWROOT/var/lib/dhclient/dhclient-$netif.leases"
-        [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "saving $NEWROOT/var/lib/dhclient/dhclient-$netif.leases"
+        [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "saving $NEWROOT/var/lib/dhclient/dhclient-$netif.leases"
     done
 
     ifname="$(getarg ifname=)"
@@ -318,10 +320,10 @@ if [ -z $STATEMNT ]; then
 
     if [ ! -z "$MACX" ] && [ ! -z "$ETHX" ]; then
         if [ ! -e $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX ]; then
-            [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "creating $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX"
+            [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "creating $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX"
             touch $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX
         fi
-        [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "writing $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX: DEVICE=$ETHX;BOOTPROTO=dhcp;HWADDR=$MACX;ONBOOT=yes"
+        [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "writing $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX: DEVICE=$ETHX;BOOTPROTO=dhcp;HWADDR=$MACX;ONBOOT=yes"
         echo "DEVICE=$ETHX" > $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX
         echo "BOOTPROTO=dhcp" >> $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX
         echo "HWADDR=$MACX" >> $NEWROOT/etc/sysconfig/network-scripts/ifcfg-$ETHX
@@ -329,15 +331,15 @@ if [ -z $STATEMNT ]; then
     fi
 fi
 
-[ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "saving $NEWROOT/etc/resolv.conf"
+[ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "saving $NEWROOT/etc/resolv.conf"
 cp /etc/resolv.conf "$NEWROOT/etc/"
 
 if [ -d "$NEWROOT/etc/sysconfig" -a ! -e "$NEWROOT/etc/sysconfig/selinux" ]; then
-    [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "disable selinux ..."
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "disable selinux ..."
     echo "SELINUX=disabled" >> "$NEWROOT/etc/sysconfig/selinux"
 fi
 
-[ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "exiting xcatroot..."
+[ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "exiting xcatroot..."
 # inject new exit_if_exists
 echo 'settle_exit_if_exists="--exit-if-exists=/dev/root"; rm "$job"' > $hookdir/initqueue/xcat.sh
 # force udevsettle to break


### PR DESCRIPTION
Initial changes to clean up some of the log messages that are being generated during diskless provisioning to attempt to have some log messages to time the process. 