### PR TITLE
fix several issues on redhat kernel cmdline  and grub2 config file generating

### DIFF
--- a/perl-xCAT/xCAT/NetworkUtils.pm
+++ b/perl-xCAT/xCAT/NetworkUtils.pm
@@ -2636,11 +2636,10 @@ sub gen_net_boot_params
         $net_params->{ip}        = "ip=$nicname:dhcp";
         $net_params->{netdev}    = "netdev=$nicname";
         $net_params->{netdevice} = "netdevice=$nicname";
-        $net_params->{ifname} = "ifname=$nicname:$mac"; # todo: may not use mac arbitrary
+        $net_params->{bootdev}   = "bootdev=$nicname";
     } elsif ($mac) {
         $net_params->{ksdevice}  = "ksdevice=$mac";
         $net_params->{BOOTIF}    = "BOOTIF=$mac";
-        $net_params->{bootdev}   = "bootdev=$mac";
         $net_params->{ip}        = "ip=dhcp";
         $net_params->{netdevice} = "netdevice=$mac";
     }

--- a/xCAT-server/lib/xcat/plugins/grub2.pm
+++ b/xCAT-server/lib/xcat/plugins/grub2.pm
@@ -302,7 +302,6 @@ sub setstate {
             $macstring = $ment->{mac};
             my @macs = split(/\|/, $ment->{mac});
             foreach (@macs) {
-                $nodemac = $_;
                 if (/!(.*)/) {
                     my $ipaddr = xCAT::NetworkUtils->getipaddr($1);
                     if ($ipaddr) {
@@ -317,7 +316,7 @@ sub setstate {
     #  my $hassymlink = eval { symlink("",""); 1 };
     foreach $ip (keys %ipaddrs) {
         my @ipa = split(/\./, $ip);
-        my $pname = "grub.cfg-" . sprintf("%02x%02x%02x%02x", @ipa);
+        my $pname = "grub.cfg-" . sprintf("%02X%02X%02X%02X", @ipa);
 
         # remove the old boot configuration file and copy (link) a new one, but only if not offline directive
         unlink($tftpdir . "/boot/grub2/" . $pname);
@@ -325,7 +324,18 @@ sub setstate {
             link($tftpdir . "/boot/grub2/" . $node, $tftpdir . "/boot/grub2/" . $pname);
         }
     }
-    if ($macstring) {
+    
+    my $nrent=$nrhash{$node}->[0];
+    if($nrent and $nrent->{installnic}){
+        my $myinstallnic=$nrent->{installnic};
+        if(xCAT::NetworkUtils->isValidMAC($myinstallnic)){
+            $nodemac=$myinstallnic;
+        }
+    }
+        
+
+     
+    if (! $nodemac and $macstring) {
         $nodemac = xCAT::Utils->parseMacTabEntry($macstring, $node);
     }
 
@@ -579,7 +589,7 @@ sub process_request {
     my $mactab = xCAT::Table->new('mac', -create => 1);
     my $machash = $mactab->getNodesAttribs(\@nodes, ['mac']);
     my $nrtab = xCAT::Table->new('noderes', -create => 1);
-    my $nrhash = $nrtab->getNodesAttribs(\@nodes, [ 'servicenode', 'tftpserver', 'xcatmaster', 'netboot' ]);
+    my $nrhash = $nrtab->getNodesAttribs(\@nodes, [ 'servicenode', 'tftpserver', 'xcatmaster', 'netboot' , 'installnic']);
     my $typetab = xCAT::Table->new('nodetype', -create => 1);
     my $typehash = $typetab->getNodesAttribs(\@nodes, [ 'os', 'provmethod', 'arch', 'profile' ]);
     my $linuximgtab = xCAT::Table->new('linuximage', -create => 1);


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/2174

fix issue https://github.com/xcat2/xcat-core/issues/1502:
according to dracut documentation https://www.kernel.org/pub/linux/utils/boot/dracut/dracut.html#_troubleshooting :
````
ifname=<interface>:<MAC>
Assign network device name <interface> (ie "bootnet") to the NIC with MAC <MAC>.

Warning
Do not use the default kernel naming scheme for the interface name, as it can conflict with the kernel names. So, don’t use "eth[0-9]+" for the interface name. Better name it "bootnet" or "bluesocket".

....

bootdev=<interface>
specify network interface to use routing and netroot information from. Required if multiple ip= lines are used.
````
"ifname" is used to assign the name for the nic with specified mac address, it should not be in kernel cmdline for provision.
"bootdev" should be the nic name instead of mac address 



