### PR TITLE
fix 2025 Re-enable the creation of statelite when copycds on RHEL 7

### DIFF
--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -2491,7 +2491,7 @@ sub copycd
             #if ($ret[0] != 0) {
             #$callback->({data => "Error when updating the osimage tables for stateless: " . $ret[1]});
             #}
-
+            my @ret=xCAT::SvrUtils->update_tables_with_diskless_image($distname, $arch, undef, "statelite",$path,$osdistroname);
         }
     }
 }


### PR DESCRIPTION
After copycds, osimage definition rhels*-*-statelite-compute is created.