### PR TITLE
fix issue [CentOS6.8 and RHEL6.8] User will see ERROR message during running updatenode and in xcat.log on compute node. #2104

### DIFF
--- a/xCAT-server/sbin/xcatconfig
+++ b/xCAT-server/sbin/xcatconfig
@@ -989,7 +989,8 @@ sub genSSHNodeHostKey
     }
 
     # see if this system supports the ecdsa
-    if (-e "/etc/ssh/ssh_host_ecdsa_key") {
+    xCAT::Utils->runcmd('rm -rf /tmp/ecdsa_key >/dev/null 2>&1 ; /usr/bin/ssh-keygen -t ecdsa -f /tmp/ecdsa_key  -P "" &>/dev/null', 0);
+    if ($::RUNCMD_RC == 0) {
         xCAT::MsgUtils->message('I', "Generating SSH2 ECDSA Key...");
         $cmd =
 "/usr/bin/ssh-keygen -t ecdsa -f /etc/xcat/hostkeys/ssh_host_ecdsa_key -C '' -N ''";


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/2104
on centos6.8, the opens-server support "ecdsa", but there is no "/etc/ssh/ssh_host_ecdsa_key" created on ssh server start by default. correct the logic to determine the ecdsa support in xcatconfig with the same logic in "remoteshell"