### PR TITLE
Redirect progress message to rflash log files when updating firmware

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rflash.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rflash.1.rst
@@ -50,7 +50,7 @@ OpenPOWER BMC specific:
 =======================
 
 
-\ **rflash**\  \ *noderange*\  \ *hpm file path*\  [\ **-c | -**\ **-check**\ ]
+\ **rflash**\  \ *noderange*\  \ *hpm file path*\  [\ **-c | -**\ **-check**\ ] [\ **-V**\ ]
 
 
 
@@ -249,6 +249,14 @@ The command will update firmware for OpenPOWER BMC when given an OpenPOWER node 
  .. code-block:: perl
  
    rflash fs3 /firmware/8335_810.1543.20151021b_update.hpm
+ 
+ 
+ Print verbose message to rflash log file per node when updading firmware:
+ 
+ 
+ .. code-block:: perl
+ 
+   rflash fs3 /firmware/8335_810.1543.20151021b_update.hpm -V
  
  
 

--- a/xCAT-client/pods/man1/rflash.1.pod
+++ b/xCAT-client/pods/man1/rflash.1.pod
@@ -24,7 +24,7 @@ B<rflash> I<noderange> I<http directory>
 
 =head2 OpenPOWER BMC specific:
 
-B<rflash> I<noderange> I<hpm file path> [B<-c>|B<--check>]
+B<rflash> I<noderange> I<hpm file path> [B<-c>|B<--check>] [B<-V>]
 
 =head1 B<Description>
 
@@ -158,6 +158,10 @@ To update the firmware on a NeXtScale FPC specify the FPC node name and the HTTP
 To update the firmware on OpenPOWER machine specify the node name and the file path of the HPM firmware file as follows:
 
  rflash fs3 /firmware/8335_810.1543.20151021b_update.hpm
+
+Print verbose message to rflash log file per node when updading firmware:
+
+ rflash fs3 /firmware/8335_810.1543.20151021b_update.hpm -V
 
 =back
 


### PR DESCRIPTION
Previously rflash process will be terminated when the tty session is closed
which is a very dangerous operation  may bricked the BMC. This patch will
ignore the `int`, `term` and `hup` signal when rflash is running and redirect
the output of ipmitool command to `/var/log/xcat/rflash/<node.log>` which make
the progress trackable. In addition,  -V option is provided to print more
verbose message of ipmitool when `hpm upgrade` command is running.

This patch also update the node status in the `nodelist` table to record
the rflash status.

fix-issue: #1849