### PR TITLE
fix issue [fvt]2.13 mypostscript syntax error in subroutine run_ps on sles11.4 #2183

### DIFF
--- a/xCAT/postscripts/xcatdsklspost
+++ b/xCAT/postscripts/xcatdsklspost
@@ -827,7 +827,7 @@ if [ $NODE_DEPLOYMENT -eq 1 ] || [ "$MODE" = "4" ] || [ "$MODE" = "6" ]; then
 else
     TMP=`sed "/# postscripts-start-here/,/# postscripts-end-here/ s/\(.*\)/run_ps postscript \1/;s/run_ps postscript\s*#/#/;s/run_ps postscript\s*$//" /$xcatpost/mypostscript`
 fi
-echo "
+echo "#!/bin/bash
 . /xcatpost/xcatlib.sh
 
 # global value to store the running status of the postbootscripts,the value is non-zero if one postbootscript failed


### PR DESCRIPTION
fix https://github.com/xcat2/xcat-core/issues/2183
add she-bang to mypostscript, so that it will be invoked with ``bash``, otherwise it will be invoked with "sh", and some bash specific features will not be supported.
````
~man bash
...
       If  bash is invoked with the name sh, it tries to mimic the startup behavior of historical versions of sh as closely as
       possible, while conforming to the POSIX standard as well.  When invoked as an interactive login shell, or a  non-inter‐
       active  shell with the --login option, it first attempts to read and execute commands from /etc/profile and ~/.profile,
       in that order.  The --noprofile option may be used to inhibit this behavior.  When invoked as an interactive shell with
       the  name  sh,  bash looks for the variable ENV, expands its value if it is defined, and uses the expanded value as the
       name of a file to read and execute.  Since a shell invoked as sh does not attempt to read and execute commands from any
       other  startup  files,  the  --rcfile  option has no effect.  A non-interactive shell invoked with the name sh does not
       attempt to read any other startup files.  When invoked as sh, bash enters posix mode after the startup files are read.

       When bash is started in posix mode, as with the --posix command line option, it follows the POSIX standard for  startup
       files.  In this mode, interactive shells expand the ENV variable and commands are read and executed from the file whose
       name is the expanded value.  No other startup files are read.
,,,
````
