### PR TITLE
Have snmpmon set the community string

### DIFF
--- a/buildcore.sh
+++ b/buildcore.sh
@@ -173,8 +173,8 @@ fi
 
 function setversionvars {
     if [ ! -z "$USEGITVER" ]; then
-        VER=`git describe`
-        VER=${VER/-/.post}
+        VER=`git describe --tags`
+        VER=${VER/-/.Post}
         VER=${VER/-/.}
     else
         VER=`cat Version`

--- a/makegenesisbuilderrpm
+++ b/makegenesisbuilderrpm
@@ -1,6 +1,6 @@
 #!/bin/sh
-VER=`git describe`
-VER=${VER/-/.post}
+VER=`git describe --tags`
+VER=${VER/-/.Post}
 VER=${VER/-/.}
 rpmbuild --version > /dev/null
 if [ $? -gt 0 ]

--- a/makerpm
+++ b/makerpm
@@ -55,7 +55,7 @@ function makenoarch {
 
 		tar --exclude .svn -czf $RPMROOT/SOURCES/$RPMNAME-$VER.tar.gz $RPMNAME
 		rm -f $RPMROOT/SRPMS/$RPMNAME-$VER*rpm $RPMROOT/RPMS/noarch/$RPMNAME-$VER*rpm
-		rpmbuild $QUIET -ta $RPMROOT/SOURCES/$RPMNAME-$VER.tar.gz --define "version $VER"
+		rpmbuild $QUIET -ta $RPMROOT/SOURCES/$RPMNAME-$VER.tar.gz --define "version $VER" $REL "$EASE"
 		RC=$?
 
 		if [ $RPMNAME = "xCAT-UI" ]; then
@@ -137,7 +137,7 @@ function makexcat {
 
 		rm -f $RPMROOT/SRPMS/$RPMNAME-$VER*rpm $RPMROOT/RPMS/$ARCH/$RPMNAME-$VER*rpm
 		echo "Building $RPMROOT/RPMS/$ARCH/$RPMNAME-$VER-snap*.$ARCH.rpm $EMBEDTXT..."
-		rpmbuild $QUIET -ba $RPMNAME/$RPMNAME.spec $TARGET --define "version $VER"
+		rpmbuild $QUIET -ba $RPMNAME/$RPMNAME.spec $TARGET --define "version $VER" $REL "$EASE"
 		RC=$?
 	fi
 }
@@ -170,7 +170,7 @@ function makegenesis {
 	cd - >/dev/null
 	rm -f $RPMROOT/SRPMS/$RPMNAME-$VER*rpm $RPMROOT/RPMS/noarch/$RPMNAME-$VER*rpm
 	echo "Building $RPMROOT/RPMS/noarch/$RPMNAME-$VER-snap*.noarch.rpm $EMBEDTXT..."
-	rpmbuild $QUIET -ba $DIR/$RPMNAME.spec --define "version $VER" 
+	rpmbuild $QUIET -ba $DIR/$RPMNAME.spec --define "version $VER" $REL "$EASE"
 }
 
 function makegenesisscripts {
@@ -190,7 +190,7 @@ function makegenesisscripts {
 	cd - >/dev/null
 	rm -f $RPMROOT/SRPMS/$RPMNAME-$ARCH-$VER*rpm $RPMROOT/RPMS/noarch/$RPMNAME-$ARCH-$VER*rpm
 	echo "Building $RPMROOT/RPMS/noarch/$RPMNAME-$ARCH-$VER-snap*.noarch.rpm $EMBEDTXT..."
-	rpmbuild $QUIET -ba $DIR/$RPMNAME.spec $TARGET --define "version $VER" 
+	rpmbuild $QUIET -ba $DIR/$RPMNAME.spec $TARGET --define "version $VER" $REL "$EASE"
 }
 
 

--- a/xCAT-server/lib/xcat/monitoring/snmpmon.pm
+++ b/xCAT-server/lib/xcat/monitoring/snmpmon.pm
@@ -514,8 +514,8 @@ sub configBMC {
             $ret_text .= "Changeing SNMP PEF policy for IPMI nodes $noderange:\n  $result\n";
         }
     } elsif ($action == 1) {
-        print "XCATBYPASS=Y rspconfig $noderange alert=en\n";
-        my $result = `XCATBYPASS=Y rspconfig $noderange alert=en 2>&1`;
+        print "XCATBYPASS=Y rspconfig $noderange alert=en community=public\n";
+        my $result = `XCATBYPASS=Y rspconfig $noderange alert=en community=public 2>&1`;
         if ($?) {
             $ret_val = 1;
             xCAT::MsgUtils->message('S', "[mon]: Changeing SNMP PEF policy for IPMI nodes $noderange:\n  $result\n");


### PR DESCRIPTION
Some BMCs do not default to 'public' for alerts.
Change this to do public for now, since other parts
of the code are still hard baked.