### PR TITLE
fix issue [CUSTOMER] Stale rootimg.gz file left in the rootimg dir caused node boot failed. #2225

### DIFF
--- a/xCAT-server/lib/xcat/plugins/packimage.pm
+++ b/xCAT-server/lib/xcat/plugins/packimage.pm
@@ -481,13 +481,8 @@ sub process_request {
     }
 
     $suffix = $method.".".$suffix;
-    unlink("$destdir/rootimg.sfs");
-    unlink("$destdir/rootimg.gz");
-    unlink("$destdir/rootimg.cpio.xz");
-    unlink("$destdir/rootimg.cpio.gz");
-    unlink("$destdir/rootimg.tar.xz");
-    unlink("$destdir/rootimg.tar.gz");
-    
+    unlink glob("$destdir/rootimg.*");   
+ 
     if ($method =~ /cpio/) {
         if (!$exlistloc) {
             $excludestr = "find . -xdev -print0 | cpio -H newc -o -0 | $compress -c - > ../rootimg.$suffix";

--- a/xCAT-server/lib/xcat/plugins/rmimage.pm
+++ b/xCAT-server/lib/xcat/plugins/rmimage.pm
@@ -197,7 +197,7 @@ sub process_request {
     }
 
     my @filestoremove = ("$imagedir/kernel", "$imagedir/initrd-stateless.gz", "$imagedir/initrd-statelite.gz");
-    my @rootimgtars=glob "$imagedir/rootimg.{tar,cpio}.{xz,gz}"; 
+    my @rootimgtars=glob "$imagedir/rootimg.*"; 
     push @filestoremove,@rootimgtars;
     #unmount all the mount points under rootimg directory 
     #to avoid removing the directory/files on management node by mistake  


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/2225