### PR TITLE
buildkit returns Global symbol "$rmpdir" requires explicit package name

### DIFF
--- a/xCAT-buildkit/bin/buildkit
+++ b/xCAT-buildkit/bin/buildkit
@@ -3432,7 +3432,6 @@ sub kit_addpkgs
     $kittarfile = abs_path($kittarfile);
 
     foreach my $rpmdir (@pkgdirlist) {
-        print "rpmdir = $rmpdir\n";
         if (!(-d $rpmdir)) {
             print "The package directory $rpmdir could not be read. \n";
             return 1;


### PR DESCRIPTION
fix issue #2227 

ran the fixes on c910f03c17k22
`````
root@c910f03c17k22:~# perl -c /opt/xcat/bin/buildkit
/opt/xcat/bin/buildkit syntax OK
root@c910f03c17k22:~# perl -c /opt/xcat/bin/buildkit.orig
Global symbol "$rmpdir" requires explicit package name at /opt/xcat/bin/buildkit.orig line 3435.
/opt/xcat/bin/buildkit.orig had compilation errors.
root@c910f03c17k22:~# cd /root
root@c910f03c17k22:~# buildkit create mykit
Kit template for mykit created in /root/mykit directory
root@c910f03c17k22:~# diff /opt/xcat/bin/buildkit /opt/xcat/bin/buildkit.orig
3434a3435
>         print "rpmdir = $rmpdir\n";
````````