### PR TITLE
fix no persistent dir in statelite ramdisk

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
@@ -6,7 +6,7 @@ RWDIR=.statelite
 . /lib/dracut-lib.sh
 XCAT="$(getarg XCAT=)"
 XCATMASTER=$XCAT
-
+STATEMNT="$(getarg STATEMNT=)"
 rootlimit="$(getarg rootlimit=)"
 
 getarg nonodestatus


### PR DESCRIPTION
After code is changed, the statelite file system is as following, there is /.statelite/persistent dir in CN with SN:
[root@c910f03fsp03v04 persistent]# df -h
Filesystem                                                     Size  Used Avail Use% Mounted on
rootfs                                                         2.0G  1.4G  623M  70% /
tmpfs                                                          2.0G   21M  2.0G   2% /run
rw                                                             2.0G   98M  1.9G   5% /tmp
c910f03fsp03v03:/nodedata/c910f03fsp03v04.pok.stglabs.ibm.com   18G  9.7G  7.9G  56% /.statelite/persistent
rw                                                             2.0G   64K  2.0G   1% /.sllocal/log
devtmpfs                                                       2.0G     0  2.0G   0% /dev
tmpfs                                                          2.0G     0  2.0G   0% /dev/shm
tmpfs                                                          2.0G     0  2.0G   0% /sys/fs/cgroup
tmpfs                                                          408M     0  408M   0% /run/user/0
[root@c910f03fsp03v04 persistent]#
