### PR TITLE
fix statelite persistent dir use short name

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/xcat-prepivot.sh
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/xcat-prepivot.sh
@@ -41,7 +41,7 @@ fi
 
 mount -t tmpfs rw $NEWROOT/$RWDIR
 mkdir -p $NEWROOT/$RWDIR/tmpfs
-ME=`hostname`
+ME=`hostname -s`
 if [ ! -z $NODE ]; then
     ME=$NODE
 fi

--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
@@ -160,7 +160,7 @@ elif [ -r /rootimg-statelite.gz ]; then
 
   mount -t tmpfs rw $NEWROOT/$RWDIR
   mkdir -p $NEWROOT/$RWDIR/tmpfs
-  ME=`hostname`
+  ME=`hostname -s`
   if [ ! -z $NODE ]; then
       ME=$NODE
   fi


### PR DESCRIPTION
After fixed, will use short name as following:

[root@bybc0607 ~]# df
Filesystem                       1K-blocks     Used Available Use% Mounted on
rootfs                             2477816   600496   1877320  25% /
tmpfs                              2477816    16672   2461144   1% /run
rw                                 2477816    56792   2421024   3% /tmp
bybc0602:/nodedata/bybc0607       27769856 14007296  13762560  51% /.statelite/persistent
rw                                 2477816        4   2477812   1% /.sllocal/log
