### PR TITLE
Become process group leader when updating firmware

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -1924,6 +1924,11 @@ sub do_rflash_process {
 
     # child
     elsif ($pid == 0) {
+        unless (setpgrp()) {
+            xCAT::SvrUtils::sendmsg([ 1, "Faild to run setgprp for $$ process" ],
+                $callback, $node);
+            exit(1);
+        }
         my $extra = $_[8];
         my @exargs = @$extra;
         my $programe = \$0;


### PR DESCRIPTION
As exec is invoked, child process can not ignore the signal sent
to the process group, use setpgrp to set the pgid to itself.

close-issue: #1849