### PR TITLE
To have xcat 2.13 build use package name like snap...

### DIFF
--- a/buildcore.sh
+++ b/buildcore.sh
@@ -180,7 +180,7 @@ function setversionvars {
         VER=`cat Version`
     fi
     XCATVER=$VER
-    export XCATVER
+    #export XCATVER
     SHORTVER=`echo $VER|cut -d. -f 1,2`
     SHORTSHORTVER=`echo $VER|cut -d. -f 1`
     BUILD_TIME=`date`

--- a/makerpm
+++ b/makerpm
@@ -215,6 +215,8 @@ fi
 OSNAME=$(uname)
 if [ -z "$XCATVER" ] ; then
 	VER=`cat Version`
+        REL="--define"
+        EASE='usedate 1'
 else
 	VER=$XCATVER
         REL="--define"


### PR DESCRIPTION
To have xCAT 2.13 package using name like '2.13-snap20161202xxxx' rather than '2.13-1'.