### PR TITLE
Revert the naming of xCAT-genesis-base back to using snap<date> and use Epoch instead 

### DIFF
--- a/makerpm
+++ b/makerpm
@@ -165,9 +165,7 @@ function makegenesis {
 	SPEC_FILE="xCAT-genesis-base.spec"
 	RPMNAME="$1"
 	cd `dirname $0`/$DIR
-	GEN_BASE_REL=0
 	sed -i s/%%REPLACE_CURRENT_VERSION%%/${VER}/g ${SPEC_FILE}
-	sed -i s/%%REPLACE_RELEASE%%/${GEN_BASE_REL}/g ${SPEC_FILE}
 	tar --exclude .svn -cjf $RPMROOT/SOURCES/$RPMNAME.tar.bz2 .
 	# undo the changes from the SED command above so it's not tracked by Git
         git checkout ${SPEC_FILE}

--- a/xCAT-genesis-builder/xCAT-genesis-base.spec
+++ b/xCAT-genesis-builder/xCAT-genesis-base.spec
@@ -1,5 +1,4 @@
 %define version     %%REPLACE_CURRENT_VERSION%%
-%define release     %%REPLACE_RELEASE%%
 Version: %{?version:%{version}}%{!?version:%(cat Version)}
 Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
 %ifarch i386 i586 i686 x86
@@ -18,6 +17,7 @@ BuildArch: noarch
 %define __prelink_undo_cmd %{nil}
 # To fix the issue error: Arch dependent binaries in noarch package, the following line is needed on Fedora 23 ppc64
 %define _binaries_in_noarch_packages_terminate_build   0
+Epoch: 2
 AutoReq: false
 Prefix: /opt/xcat
 AutoProv: false

--- a/xCAT-genesis-scripts/xCAT-genesis-scripts.spec
+++ b/xCAT-genesis-scripts/xCAT-genesis-scripts.spec
@@ -31,7 +31,7 @@ Vendor: IBM Corp
 Summary: xCAT Genesis netboot image - Core content
 URL:	 http://xcat.org
 Source1: xCAT-genesis-scripts.tar.bz2
-Requires: xCAT-genesis-base-%{tarch} >= 2.13.0
+Requires: xCAT-genesis-base-%{tarch}
 
 Buildroot: %{_localstatedir}/tmp/xCAT-genesis
 Packager: IBM Corp.


### PR DESCRIPTION
The changes in #2250 attempted to change the versioning of xCAT-genesis-base to something more standard, removing the `snap<date>` naming from the RPM.  This was so that xCAT-genesis-scripts could require a certain version of the xCAT-genesis-base so that it ensures that the end user has configured the correct xcat-dep repository if we made changes that need xcat-core and xcat-dep to be in sync.  

What I was unaware of is the high use of `Epoch` in the xCAT rpms.  My guess is that the irregular naming convention for the xCAT rpms caused for this `Epoch` keyword to control which package is "higher priority" 

```
$ git grep "Epoch"  | grep ".spec" | wc  -l
18
```

So in testing the changes from #2250, the behvior is not as I wanted it to be.  I knew that `yum update "*xCAT*"` would not pull in a new xCAT-genesis-base version because of the `Epoch` already set in the older RPM.   However, I thought that doing `yum update xCAT-genesis-base` would force the update, but it turns out that it does not.

So rather than fight this Epoch, I'm going to just bump it up `Epoch: 2` and go back to the snap naming convention.  

Then the expected behavior happens. 
```
[root@fs4 ppc64le]# yum update xCAT-genesis-base*
Loaded plugins: product-id, search-disabled-repos, subscription-manager
This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.
Examining xCAT-genesis-base-ppc64-2.13.0-snap201612051402.noarch.rpm: 2:xCAT-genesis-base-ppc64-2.13.0-snap201612051402.noarch
Marking xCAT-genesis-base-ppc64-2.13.0-snap201612051402.noarch.rpm as an update to 1:xCAT-genesis-base-ppc64-2.12-snap201610250931.noarch
Examining xCAT-genesis-base-x86_64-2.13.0-snap201612051408.noarch.rpm: 2:xCAT-genesis-base-x86_64-2.13.0-snap201612051408.noarch
Marking xCAT-genesis-base-x86_64-2.13.0-snap201612051408.noarch.rpm as an update to 1:xCAT-genesis-base-x86_64-2.12-snap201607221057.noarch
Resolving Dependencies
--> Running transaction check
---> Package xCAT-genesis-base-ppc64.noarch 1:2.12-snap201610250931 will be updated
---> Package xCAT-genesis-base-ppc64.noarch 2:2.13.0-snap201612051402 will be an update
---> Package xCAT-genesis-base-x86_64.noarch 1:2.12-snap201607221057 will be updated
---> Package xCAT-genesis-base-x86_64.noarch 2:2.13.0-snap201612051408 will be an update
--> Finished Dependency Resolution

Dependencies Resolved

====================================================================================================================================================
 Package                        Arch         Version                           Repository                                                      Size
====================================================================================================================================================
Updating:
 xCAT-genesis-base-ppc64        noarch       2:2.13.0-snap201612051402         /xCAT-genesis-base-ppc64-2.13.0-snap201612051402.noarch        165 M
 xCAT-genesis-base-x86_64       noarch       2:2.13.0-snap201612051408         /xCAT-genesis-base-x86_64-2.13.0-snap201612051408.noarch        71 M

Transaction Summary
====================================================================================================================================================```

Still keeping the 2.13.0 "three number" naming for the xCAT-genesis-base so that we can match up the minor release that a new version was created for. 