### PR TITLE
Wrong repository name if osminorversion doesn't have comparison operator

### DIFF
--- a/xCAT-buildkit/bin/buildkit
+++ b/xCAT-buildkit/bin/buildkit
@@ -1390,7 +1390,10 @@ sub validate_bldkitconf
         $full_kitname .= '-' . $::bldkit_config->{kit}{entries}[0]->{osmajorversion};
     }
     if (defined($::bldkit_config->{kit}{entries}[0]->{osminorversion})) {
-        my $kitminor = split /<=|>=|==|<|>/, $::bldkit_config->{kit}{entries}[0]->{osminorversion};
+        my $kitminor = $::bldkit_config->{kit}{entries}[0]->{osminorversion};
+        unless ($kitminor =~ /^\d/) {
+            $kitminor = split /<=|>=|==|<|>|=/, $::bldkit_config->{kit}{entries}[0]->{osminorversion};
+        }
         if ((!defined($::bldkit_config->{kit}{entries}[0]->{osbasename})) ||
             (!defined($::bldkit_config->{kit}{entries}[0]->{osmajorversion}))) {
             print "Error:  Kit osminorversion attribute was specified but either Kit osbasename or Kit osmajorversion were not set. \n";
@@ -1501,7 +1504,10 @@ sub validate_bldkitconf
         }
         $reponame .= '-' . $kr->{osmajorversion};
         if (defined($kr->{osminorversion})) {
-            my $krminor = split /<=|>=|==|<|>/, $kr->{osminorversion};
+            my $krminor = $kr->{osminorversion};
+            unless ($krminor =~ /^\d/) {
+                $krminor = split /<=|>=|==|<|>|=/, $kr->{osminorversion};
+            }
             if ((defined($::bldkit_config->{kit}{entries}[0]->{osminorversion})) &&
                 ($::bldkit_config->{kit}{entries}[0]->{osminorversion} ne
                     $kr->{osminorversion})) {
@@ -1552,7 +1558,10 @@ sub validate_bldkitconf
         $compname .= '-' . $repo{osbasename};
         $compname .= '-' . $repo{osmajorversion};
         if (defined($repo{osminorversion})) {
-            my $minorversion = split /<=|>=|==|<|>/, $repo{osminorversion};
+            my $minorversion = $repo{osminorversion};
+            unless ($minorversion =~ /^\d/) {
+                $minorversion = split /<=|>=|==|<|>|=/, $repo{osminorversion};
+            }
             $compname .= '.' . $minorversion;
         }
         $compname .= '-' . $repo{osarch};
@@ -1937,7 +1946,10 @@ sub validate_os
     my $repo_osinfo = "$repo->{osbasename}$repo->{osmajorversion}";
     my $minorversion;
     if (defined($repo->{osminorversion})) {
-        $minorversion = split /<=|>=|==|<|>/, $repo->{osminorversion};
+        $minorversion = $repo->{osminorversion};
+        unless ($minorversion =~ /^\d/) {
+            $minorversion = split /<=|>=|==|<|>|=/, $repo->{osminorversion};
+        }
         $repo_osinfo .= ".$minorversion";
     }
     $repo_osinfo .= "-$repo->{osarch} ";


### PR DESCRIPTION
if kitrepo define as:
````
kitrepo:
  kitrepoid=rhels7.3
  osbasename=rhels
  osmajorversion=7
  osminorversion=3
  osarch=ppc64le
`````
buildkit command will create repository name as rhels7.1-ppc64le

````
# buildkit buildrepo all
The local host is running rhels7.3-ppc64le.  This does not match the Kit Repository "rhels7.3" data:  rhels7.1-ppc64le
`````
It caused by split function didn't parse correct if doesn't have split symbol.
$osminorversion will be 3 in this case, but $minor will be 1 from following split function.
````
$minor = split /<=|>=|==|<|>|=/, $osminorversion;
`````

