### PR TITLE
Add messages to trace the ntpd commands in genesis

### DIFF
--- a/xCAT-genesis-scripts/bin/doxcat
+++ b/xCAT-genesis-scripts/bin/doxcat
@@ -262,18 +262,24 @@ openssl genrsa -out /etc/xcat/certkey.pem 4096 > /dev/null 2>&1 &
 logger -s -t $log_label -p local4.info "Acquired IPv4 address on $bootnic"
 
 ip addr show dev $bootnic|grep -v 'scope link'|grep -v 'dynamic'|grep -v  inet6|grep inet|awk '{print $2}'
+
+logger -s -t $log_label -p local4.info "Starting ntpd..." 
 ntpd -g -x
 
 if [ -e "/dev/rtc" ]; then
+    logger -s -t $log_label -p local4.info "Attempting to sync hardware clock..."
     ( sleep 8 ; hwclock --systohc ) </dev/null >/dev/null 2>&1 &
     disown
 fi
 
 # rv 0 state does not work with the new ntp versions
+logger -s -t $log_label -p local4.info "Checking ntpq for the offset values..."
 while [ "`ntpq -c 'rv 0 offset' | awk -F '=' '/offset=/ { print $2 }' | awk -F '.' '{ print $1 }' | sed s/-//`" -ge 1000 ]; do 
     sleep 1
 done
+logger -s -t $log_label -p local4.info "Checking ntpq for the offset values... Done"
 
+logger -s -t $log_label -p local4.info "Restarting syslog..."
 read -r RSYSLOG_PID </var/run/syslogd.pid 2>/dev/null
 kill "$RSYSLOG_PID" 2>/dev/null
 while kill -0 "$RSYSLOG_PID" 2>/dev/null


### PR DESCRIPTION
We have seen some reports from customers that hardware discovery takes up to 15 minutes in some cases in the genesis kernel. It looks like it has something to do with NTP but the actual reason is not known.
```
[Tue Nov 29 11:02:05 2016]cp: cannot stat '/usr/share/zoneinfo/posix/America/Los_Angeles': No such file or directory
[Tue Nov 29 11:02:07 2016]<166>Nov 29 11:02:06 xcat.genesis.doxcat: Acquired IPv4 address on enP5p7s0f1
[Tue Nov 29 11:02:07 2016]192.168.64.174/24
[Tue Nov 29 11:18:03 2016]ppc64
```
Between the IP address and "ppc64" it's around 16 minutes.

To help us trace the time that it takes, adding some more detailed logger messages between the ntpd calls 