### PR TITLE
change the URL for go-xcat to github

### DIFF
--- a/docs/source/guides/install-guides/common_sections.rst
+++ b/docs/source/guides/install-guides/common_sections.rst
@@ -64,7 +64,7 @@ The following sections describe the different methods for installing xCAT.
 
 #. Download the ``go-xcat`` tool using ``wget``: ::
 
-        wget http://xcat.org/files/go-xcat -O - >/tmp/go-xcat
+        wget https://raw.githubusercontent.com/xcat2/xcat-core/master/xCAT-server/share/xcat/tools/go-xcat -O - >/tmp/go-xcat
         chmod +x /tmp/go-xcat
 
 #. Run the ``go-xcat`` tool: ::


### PR DESCRIPTION
With the changes made in https://github.com/xcat2/xcat.org/pull/42 , sync up the documentation to the same URL