### PR TITLE
Modify issue2299: xcatprobe xcatmn do not clear the /etc/hosts if no usefull cn node to check dhcp in the environment

### DIFF
--- a/xCAT-probe/subcmds/xcatmn
+++ b/xCAT-probe/subcmds/xcatmn
@@ -156,6 +156,7 @@ sub do_main_job {
         $rc |= $rst;
     }
 
+    cleanup();
     return $rc;
 }
 


### PR DESCRIPTION
Modify issue #2299: xcatprobe xcatmn do not clear the /etc/hosts if no usefull cn node to check dhcp in the environment