### PR TITLE
[CUSTOMER] Use ntpdate in genesis kernel instead of starting the ntp daemon to reduce discovery time

### DIFF
--- a/xCAT-genesis-builder/install
+++ b/xCAT-genesis-builder/install
@@ -9,7 +9,7 @@ dracut_install efibootmgr
 #dracut_install libvirtd /usr/share/libvirt/cpu_map.xml /usr/bin/qemu-img /usr/libexec/qemu-kvm
 dracut_install mkswap df brctl vconfig ifenslave ssh-keygen scp clear dhclient lldpad
 dracut_install lldptool /lib64/libnss_dns-2.12.so /lib64/libnss_dns.so.2
-dracut_install poweroff ntpq ntpd hwclock date /usr/share/terminfo/x/xterm /usr/share/terminfo/s/screen /etc/nsswitch.conf /etc/services
+dracut_install poweroff ntpq ntpd ntpdate hwclock date /usr/share/terminfo/x/xterm /usr/share/terminfo/s/screen /etc/nsswitch.conf /etc/services
 dracut_install /sbin/rsyslogd /etc/protocols umount /bin/rpm /usr/lib/rpm/rpmrc
 dracut_install chmod /lib/libc.so.6 /lib/ld-linux.so.2 /lib/libdl.so.2 /lib/libm.so.6 /sbin/route /sbin/ifconfig /usr/bin/whoami /usr/bin/head /usr/bin/tail basename /etc/redhat-release ping tr lsusb /usr/share/hwdata/usb.ids #ibm fw wrapper requirements
 dracut_install dmidecode /usr/lib64/libstdc++.so.6 #uxspi prereqs, but will use dmidecode to improve decision on loading ipmi_si

--- a/xCAT-genesis-scripts/bin/doxcat
+++ b/xCAT-genesis-scripts/bin/doxcat
@@ -260,24 +260,16 @@ fi
 openssl genrsa -out /etc/xcat/certkey.pem 4096 > /dev/null 2>&1 &
 
 logger -s -t $log_label -p local4.info "Acquired IPv4 address on $bootnic"
-
 ip addr show dev $bootnic|grep -v 'scope link'|grep -v 'dynamic'|grep -v  inet6|grep inet|awk '{print $2}'
 
-logger -s -t $log_label -p local4.info "Starting ntpd..." 
-ntpd -g -x
+logger -s -t $log_label -p local4.info "Attempting to sync the date with $XCATMASTER..."
+ntpdate $XCATMASTER
 
 if [ -e "/dev/rtc" ]; then
     logger -s -t $log_label -p local4.info "Attempting to sync hardware clock..."
     ( sleep 8 ; hwclock --systohc ) </dev/null >/dev/null 2>&1 &
     disown
 fi
-
-# rv 0 state does not work with the new ntp versions
-logger -s -t $log_label -p local4.info "Checking ntpq for the offset values..."
-while [ "`ntpq -c 'rv 0 offset' | awk -F '=' '/offset=/ { print $2 }' | awk -F '.' '{ print $1 }' | sed s/-//`" -ge 1000 ]; do 
-    sleep 1
-done
-logger -s -t $log_label -p local4.info "Checking ntpq for the offset values... Done"
 
 logger -s -t $log_label -p local4.info "Restarting syslog..."
 read -r RSYSLOG_PID </var/run/syslogd.pid 2>/dev/null

--- a/xCAT-genesis-scripts/bin/doxcat
+++ b/xCAT-genesis-scripts/bin/doxcat
@@ -263,7 +263,7 @@ logger -s -t $log_label -p local4.info "Acquired IPv4 address on $bootnic"
 ip addr show dev $bootnic|grep -v 'scope link'|grep -v 'dynamic'|grep -v  inet6|grep inet|awk '{print $2}'
 
 logger -s -t $log_label -p local4.info "Attempting to sync the date with $XCATMASTER..."
-ntpdate $XCATMASTER
+ntpdate -b $XCATMASTER
 
 if [ -e "/dev/rtc" ]; then
     logger -s -t $log_label -p local4.info "Attempting to sync hardware clock..."


### PR DESCRIPTION
This pull request fixes a customer reported issue for CORAL where certain nodes take 15+ minutes to do hardware discovery.  

The following log message points us to the 15 minute time difference inside the Genesis Kernel.

```
[Tue Nov 29 11:02:05 2016]cp: cannot stat '/usr/share/zoneinfo/posix/America/Los_Angeles': No such file or directory
[Tue Nov 29 11:02:07 2016]<166>Nov 29 11:02:06 xcat.genesis.doxcat: Acquired IPv4 address on enP5p7s0f1
[Tue Nov 29 11:02:07 2016]192.168.64.174/24
[Tue Nov 29 11:18:03 2016]ppc64   <-- 15 minutes later
```

At initial investigation, the `ntpq -c rv offset` seems to be the most likely place that causes a long loop.  However, we were unable to easily re-create it.   After further investigation, it turns out that most of the time, we start `ntpd` and immediately call the `ntpq` command that returns an offset of 0.   My guess is the ntp daemon is not quite ready yet and so we skip over the while loop.  

If we inject a `sleep 15` after starting the `ntpd` then the offset becomes very large, and ntp does not sync again for 15 minutes, thus, causing the 15 minute delay that we have seen.  

Since genesis is not intended to be a long running, I don't think it's necessary to start ntpd, but rather just use ntpdate to force the sync of the clock, if the server is configured on the xCAT MN 

## Testing results: 
* If no server is configured on xCAT mn, genesis will not be able to sync the clocks

```
[xCAT Genesis running on frame23cn18 /]# time ntpdate 192.168.3.25
13 Dec 10:39:37 ntpdate[1789]: no server suitable for synchronization found
 
real	0m8.102s
user	0m0.001s
sys	0m0.001s
```

* If an external ntp server is configured.... 

```
[root@fs4 ~]# chdef -t site extntpservers="10.0.0.101" 
1 object definitions have been created or modified.
[root@fs4 ~]# makentp
configuring management node: fs4.
[root@fs4 ~]# ps -ef | grep ntp
ntp       44966      1  0 10:35 ?        00:00:00 /usr/sbin/ntpd -u ntp:ntp -g
root      44992  44823  0 10:35 pts/7    00:00:00 grep --color=auto ntp
```

```
[xCAT Genesis running on frame23cn18 /]# time ntpdate 192.168.3.25
13 Dec 10:35:54 ntpdate[1796]: step time server 192.168.3.25 offset -359.118775 sec

real	0m0.000s
user	0m0.001s
sys	0m0.002s
```
 
* If ntp is configured on the mn node...  

```
# tabdump site | grep ntp
"ntpservers","<xcatmaster>",,

[root@fs4 ~]# date
Tue Dec 13 10:37:05 PST 2016
```

force change the date 
```
[root@fs4 ~]# date 12121000
Mon Dec 12 10:00:00 PST 2016
```

Sync in genesis: 
```
[xCAT Genesis running on frame23cn18 /]# time ntpdate -b 192.168.3.25
12 Dec 10:01:52 ntpdate[1809]: step time server 192.168.3.25 offset -88661.293557 sec

real	0m0.000s
user	0m0.001s
sys	0m0.002s
```



## Discovery Testing output 

After re-running a small provisioning test case, with ntp running on the MN node, we see the following messages: 
```
[root@fs4 consoles]# grep ntpdate node-8335-g*
node-8335-gtb-100470a:[Tue Dec 13 10:55:44 2016]13 Dec 10:55:44 ntpdate[1425]: step time server 192.168.3.25 offset 0.841350 sec
node-8335-gtb-2109e4a:[Tue Dec 13 10:56:12 2016]13 Dec 10:56:12 ntpdate[1691]: step time server 192.168.3.25 offset -357.007997 sec
```
