### PR TITLE
Revert "[CUSTOMER] Use ntpdate in genesis kernel instead of starting the ntp daemon to reduce discovery time"

### DIFF
--- a/xCAT-genesis-builder/install
+++ b/xCAT-genesis-builder/install
@@ -9,7 +9,7 @@ dracut_install efibootmgr
 #dracut_install libvirtd /usr/share/libvirt/cpu_map.xml /usr/bin/qemu-img /usr/libexec/qemu-kvm
 dracut_install mkswap df brctl vconfig ifenslave ssh-keygen scp clear dhclient lldpad
 dracut_install lldptool /lib64/libnss_dns-2.12.so /lib64/libnss_dns.so.2
-dracut_install poweroff ntpq ntpd ntpdate hwclock date /usr/share/terminfo/x/xterm /usr/share/terminfo/s/screen /etc/nsswitch.conf /etc/services
+dracut_install poweroff ntpq ntpd hwclock date /usr/share/terminfo/x/xterm /usr/share/terminfo/s/screen /etc/nsswitch.conf /etc/services
 dracut_install /sbin/rsyslogd /etc/protocols umount /bin/rpm /usr/lib/rpm/rpmrc
 dracut_install chmod /lib/libc.so.6 /lib/ld-linux.so.2 /lib/libdl.so.2 /lib/libm.so.6 /sbin/route /sbin/ifconfig /usr/bin/whoami /usr/bin/head /usr/bin/tail basename /etc/redhat-release ping tr lsusb /usr/share/hwdata/usb.ids #ibm fw wrapper requirements
 dracut_install dmidecode /usr/lib64/libstdc++.so.6 #uxspi prereqs, but will use dmidecode to improve decision on loading ipmi_si

--- a/xCAT-genesis-scripts/bin/doxcat
+++ b/xCAT-genesis-scripts/bin/doxcat
@@ -260,16 +260,24 @@ fi
 openssl genrsa -out /etc/xcat/certkey.pem 4096 > /dev/null 2>&1 &
 
 logger -s -t $log_label -p local4.info "Acquired IPv4 address on $bootnic"
+
 ip addr show dev $bootnic|grep -v 'scope link'|grep -v 'dynamic'|grep -v  inet6|grep inet|awk '{print $2}'
 
-logger -s -t $log_label -p local4.info "Attempting to sync the date with $XCATMASTER..."
-ntpdate -b $XCATMASTER
+logger -s -t $log_label -p local4.info "Starting ntpd..." 
+ntpd -g -x
 
 if [ -e "/dev/rtc" ]; then
     logger -s -t $log_label -p local4.info "Attempting to sync hardware clock..."
     ( sleep 8 ; hwclock --systohc ) </dev/null >/dev/null 2>&1 &
     disown
 fi
+
+# rv 0 state does not work with the new ntp versions
+logger -s -t $log_label -p local4.info "Checking ntpq for the offset values..."
+while [ "`ntpq -c 'rv 0 offset' | awk -F '=' '/offset=/ { print $2 }' | awk -F '.' '{ print $1 }' | sed s/-//`" -ge 1000 ]; do 
+    sleep 1
+done
+logger -s -t $log_label -p local4.info "Checking ntpq for the offset values... Done"
 
 logger -s -t $log_label -p local4.info "Restarting syslog..."
 read -r RSYSLOG_PID </var/run/syslogd.pid 2>/dev/null


### PR DESCRIPTION
Reverts xcat2/xcat-core#2307