### PR TITLE
[CUSTOMER] Attempt to force sync time with ntpd instead of starting the ntp daemon to reduce discovery time

### DIFF
--- a/xCAT-genesis-scripts/bin/doxcat
+++ b/xCAT-genesis-scripts/bin/doxcat
@@ -263,21 +263,15 @@ logger -s -t $log_label -p local4.info "Acquired IPv4 address on $bootnic"
 
 ip addr show dev $bootnic|grep -v 'scope link'|grep -v 'dynamic'|grep -v  inet6|grep inet|awk '{print $2}'
 
-logger -s -t $log_label -p local4.info "Starting ntpd..." 
-ntpd -g -x
+logger -s -t $log_label -p local4.info "Attempting to sync time with using ntpd..."
+# ntpd command replacement for ntpdate, no need to start the daemon
+ntpd -g -x -q
 
 if [ -e "/dev/rtc" ]; then
-    logger -s -t $log_label -p local4.info "Attempting to sync hardware clock..."
+    logger -s -t $log_label -p local4.info "Attempting to sync hardware clock from system time..."
     ( sleep 8 ; hwclock --systohc ) </dev/null >/dev/null 2>&1 &
     disown
 fi
-
-# rv 0 state does not work with the new ntp versions
-logger -s -t $log_label -p local4.info "Checking ntpq for the offset values..."
-while [ "`ntpq -c 'rv 0 offset' | awk -F '=' '/offset=/ { print $2 }' | awk -F '.' '{ print $1 }' | sed s/-//`" -ge 1000 ]; do 
-    sleep 1
-done
-logger -s -t $log_label -p local4.info "Checking ntpq for the offset values... Done"
 
 logger -s -t $log_label -p local4.info "Restarting syslog..."
 read -r RSYSLOG_PID </var/run/syslogd.pid 2>/dev/null


### PR DESCRIPTION
Attempt to resolve #2327

See #2307 for details about this pull request.  It was reverted because `ntpdate` is deprecated, using ntpd command instead, but do not start the daemon, simply call ntpd and exit.   The customer would need to have ntp running to force sync the clocks, then force the hardware clock to sync with the system time. 

Output from the code changes
```
node-8335-gtb-100470a:[Wed Dec 14 10:56:46 2016]<166>Dec 12 14:40:24 xcat.genesis.doxcat: Attempting to sync time with using ntpd...
node-8335-gtb-100470a:[Wed Dec 14 10:56:47 2016]ntpd: time set +159381.409771s
node-8335-gtb-2109e4a:[Wed Dec 14 10:57:11 2016]<166>Dec 12 14:40:49 xcat.genesis.doxcat: Attempting to sync time with using ntpd...
node-8335-gtb-2109e4a:[Wed Dec 14 10:57:12 2016]ntpd: time set +159381.830421s
```