### PR TITLE
makeconservercf -d to remove all xCAT nodes

### DIFF
--- a/docs/source/guides/admin-guides/references/man8/makeconservercf.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/makeconservercf.8.rst
@@ -19,7 +19,7 @@ SYNOPSIS
 ********
 
 
-\ **makeconservercf**\  [\ **-V|-**\ **-verbose**\ ] [\ **-d|-**\ **-delete**\ ] \ *noderange*\ 
+\ **makeconservercf**\  [\ **-V|-**\ **-verbose**\ ] [\ **-d|-**\ **-delete**\ ] [\ *noderange*\ ]
 
 \ **makeconservercf**\  [\ **-V|-**\ **-verbose**\ ] [\ **-l|-**\ **-local**\ ] [\ *noderange*\ ]
 
@@ -36,14 +36,16 @@ DESCRIPTION
 
 
 The \ **makeconservercf**\  command will write out the /etc/conserver.cf, using information from the nodehm table
-and related tables (e.g. mp, ipmi, ppc).  Normally, \ **makeconservercf**\  will write all nodes to the conserver.cf
-file.  If a noderange is specified, it will write on those nodes to the file.  In either case, if a node
+and related tables (e.g. mp, ipmi, ppc).  Normally, \ **makeconservercf**\  will write all nodes to the /etc/conserver.cf
+file.  If a \ *noderange*\  is specified, it will write only those nodes to the file.  In either case, if a node
 does not have nodehm.cons set, it will not be written to the file.
+
+If \ **-d**\  is specified, \ **makeconservercf**\  will remove specified nodes from /etc/conserver.cf file. If \ *noderange*\  is not specified, all xCAT nodes will be removed from /etc/conserver.cf file.
 
 In the case of a hierarchical cluster (i.e. one with service nodes) \ **makeconservercf**\  will determine
 which nodes will have their consoles accessed from the management node and which from a service node
 (based on the nodehm.conserver attribute).  The /etc/conserver.cf file will be created accordingly on
-all relevant management/service nodes.  If -l is specified, it will only create the local file.
+all relevant management/service nodes.  If \ **-l**\  is specified, it will only create the local file.
 
 
 *******

--- a/xCAT-client/pods/man8/makeconservercf.8.pod
+++ b/xCAT-client/pods/man8/makeconservercf.8.pod
@@ -4,7 +4,7 @@ B<makeconservercf> - creates the conserver configuration file from info in the x
 
 =head1 SYNOPSIS
 
-B<makeconservercf> [B<-V|--verbose>] [B<-d|--delete>] I<noderange>
+B<makeconservercf> [B<-V|--verbose>] [B<-d|--delete>] [I<noderange>]
 
 B<makeconservercf> [B<-V|--verbose>] [B<-l|--local>] [I<noderange>]
 
@@ -18,14 +18,16 @@ B<makeconservercf> [B<-h|--help|-v|--version>]
 =head1 DESCRIPTION
 
 The B<makeconservercf> command will write out the /etc/conserver.cf, using information from the nodehm table
-and related tables (e.g. mp, ipmi, ppc).  Normally, B<makeconservercf> will write all nodes to the conserver.cf
-file.  If a noderange is specified, it will write on those nodes to the file.  In either case, if a node
+and related tables (e.g. mp, ipmi, ppc).  Normally, B<makeconservercf> will write all nodes to the /etc/conserver.cf
+file.  If a I<noderange> is specified, it will write only those nodes to the file.  In either case, if a node
 does not have nodehm.cons set, it will not be written to the file.
+
+If B<-d> is specified, B<makeconservercf> will remove specified nodes from /etc/conserver.cf file. If I<noderange> is not specified, all xCAT nodes will be removed from /etc/conserver.cf file. 
 
 In the case of a hierarchical cluster (i.e. one with service nodes) B<makeconservercf> will determine
 which nodes will have their consoles accessed from the management node and which from a service node
 (based on the nodehm.conserver attribute).  The /etc/conserver.cf file will be created accordingly on
-all relevant management/service nodes.  If -l is specified, it will only create the local file.
+all relevant management/service nodes.  If B<-l> is specified, it will only create the local file.
 
 
 =head1 OPTIONS

--- a/xCAT-server/lib/xcat/plugins/conserver.pm
+++ b/xCAT-server/lib/xcat/plugins/conserver.pm
@@ -428,7 +428,7 @@ sub makeconservercf {
 
         # Now add into the file all the node entries that we kept
         my $node;
-        if ($node = donodeent(\%cfgenthash, \@filecontent)) {
+        if ($node = donodeent(\%cfgenthash, \@filecontent, $delmode)) {
 
             # donodeent will return the 1st node in error
             #$cb->({node=>[{name=>$node,error=>"Bad configuration, check attributes under the nodehm category",errorcode=>1}]});


### PR DESCRIPTION
This pull request fixes the problem reported by #2302 
1. Added `$delmode` flag when calling `donodeent()`. This call is done in 2 places, first when *noderange* is specified, second when *noderange* is not specified. First call to `donodeent()` was already passing `$delmode`, this pull request adds `$delmode` flag to the second call of  `donodeent()`.
2. Modified man page for `makeconservercf` to make it more clear what happens when *noderange* is not specified.