### PR TITLE
File /etc/sysconfig/ntpd doesn't exists in the SLES

### DIFF
--- a/xCAT-server/lib/xcat/plugins/makentp.pm
+++ b/xCAT-server/lib/xcat/plugins/makentp.pm
@@ -318,7 +318,7 @@ sub process_request {
         print CFGFILE "disable auth\n";
         print CFGFILE "broadcastclient\n";
     } elsif ($os =~ /sles/) {
-        print CFGFILE "driftfile /etc/ntp.drift\n";
+        print CFGFILE "driftfile /var/lib/ntp/drift/ntp.drift\n";
         print CFGFILE "disable auth\n";
     } else {
         print CFGFILE "driftfile /var/lib/ntp/drift\n";

--- a/xCAT-server/lib/xcat/plugins/makentp.pm
+++ b/xCAT-server/lib/xcat/plugins/makentp.pm
@@ -309,6 +309,8 @@ sub process_request {
         }
     }
 
+    my $os          = xCAT::Utils->osver("all");
+
     #for sles, /var/lib/ntp/drift is a dir
     if (xCAT::Utils->isAIX()) {
         print CFGFILE "driftfile /etc/ntp.drift\n";
@@ -329,7 +331,6 @@ sub process_request {
 
     close CFGFILE;
 
-    my $os          = xCAT::Utils->osver("all");
     my $ntp_service = "ntpserver";
 
     #stop ntpd
@@ -396,15 +397,15 @@ sub process_request {
             `echo HWCLOCK=\"-u\" >> /etc/sysconfig/clock`;
         }
     } elsif (-f "/etc/debian_version") {
-        `sed -i "s/.*UTC.*/UTC=yes/" /etc/default/rcS`;
+        `sed -i 's/.*UTC.*/UTC=\"yes\"/' /etc/default/rcS`;
     } else {
         if (-f "/etc/sysconfig/clock") {
             $grep_cmd = "grep -i utc /etc/sysconfig/clock";
             $rc = xCAT::Utils->runcmd($grep_cmd, 0);
             if ($::RUNCMD_RC == 0) {
-                `sed -i 's/.*UTC.*/UTC=yes/' /etc/sysconfig/clock`;
+                `sed -i 's/.*UTC.*/UTC=\"yes\"/' /etc/sysconfig/clock`;
             } else {
-                `echo "UTC=yes" >> /etc/sysconfig/clock`;
+                `echo UTC=\"yes\" >> /etc/sysconfig/clock`;
             }
         } else {
             `type -P timedatectl >/dev/null 2>&1`;
@@ -422,9 +423,9 @@ sub process_request {
             `echo SYNC_HWCLOCK=\"yes\" >> /etc/sysconfig/ntpd`;
         }
     } elsif (-f "/etc/sysconfig/ntp") {
-        `sed -i "s/.*SYNC_HWCLOCK.*/NTPD_FORCE_SYNC_HWCLOCK_ON_STARTUP=yes/" /etc/sysconfig/ntp`;
-        `sed -i "s/^NTPD_FORCE_SYNC_ON.*/NTPD_FORCE_SYNC_ON_STARTUP=yes/" /etc/sysconfig/ntp`;
-        `sed -i "s/.*RUN_CHROOTED.*/NTPD_RUN_CHROOTED=yes/" /etc/sysconfig/ntp`;
+        `sed -i 's/.*SYNC_HWCLOCK.*/NTPD_FORCE_SYNC_HWCLOCK_ON_STARTUP=\"yes\"/' /etc/sysconfig/ntp`;
+        `sed -i 's/^NTPD_FORCE_SYNC_ON.*/NTPD_FORCE_SYNC_ON_STARTUP=\"yes\"/' /etc/sysconfig/ntp`;
+        `sed -i 's/.*RUN_CHROOTED.*/NTPD_RUN_CHROOTED=\"yes\"/' /etc/sysconfig/ntp`;
     } else {
         my $cron_file = "/etc/cron.daily/xcatsethwclock";
         if (!-f "$cron_file") {

--- a/xCAT/postscripts/setupntp
+++ b/xCAT/postscripts/setupntp
@@ -100,7 +100,7 @@ if [ $OS_TYPE = Linux ]; then
     mkdir -p /var/lib/ntp
     chown ntp /var/lib/ntp
     if ( pmatch $OSVER "sles*" ) || ( pmatch $OSVER "suse*" ) || [ -f /etc/SuSE-release ];then
-        echo "driftfile /etc/ntp.drift" >>$conf_file
+        echo "driftfile /var/lib/ntp/drift/ntp.drift" >>$conf_file
     else 
         echo "driftfile /var/lib/ntp/drift" >>$conf_file
     fi 

--- a/xCAT/postscripts/setupntp
+++ b/xCAT/postscripts/setupntp
@@ -99,9 +99,13 @@ OS_TYPE=`uname`
 if [ $OS_TYPE = Linux ]; then
     mkdir -p /var/lib/ntp
     chown ntp /var/lib/ntp
-    echo "driftfile /var/lib/ntp/drift
-disable auth
-restrict 127.0.0.1" >>$conf_file
+    if ( pmatch $OSVER "sles*" ) || ( pmatch $OSVER "suse*" ) || [ -f /etc/SuSE-release ];then
+        echo "driftfile /etc/ntp.drift" >>$conf_file
+    else 
+        echo "driftfile /var/lib/ntp/drift" >>$conf_file
+    fi 
+    echo "disable auth" >>$conf_file
+    echo "restrict 127.0.0.1" >>$conf_file
 
     #ntpdate/sntp conflict with ntpd, stop the service first
     checkservicestatus ntpserver
@@ -140,7 +144,12 @@ restrict 127.0.0.1" >>$conf_file
 
     #setup the RTC is UTC format, which will be used by os
     if ( pmatch $OSVER "sles*" ) || ( pmatch $OSVER "suse*" ) || [ -f /etc/SuSE-release ];then
-        sed -i 's/.*HWCLOCK.*/HWCLOCK="-u"/' /etc/sysconfig/clock
+        grep -i "HWCLOCK" /etc/sysconfig/clock
+        if [ $? -eq 0 ];then
+            sed -i 's/.*HWCLOCK.*/HWCLOCK=\"-u\"/' /etc/sysconfig/clock
+        else
+            echo "HWCLOCK=\"-u\"" >> /etc/sysconfig/clock
+        fi
     elif [ -f "/etc/debian_version" ];then
         sed -i 's/.*UTC.*/UTC=yes/' /etc/default/rcS
     else
@@ -160,9 +169,9 @@ restrict 127.0.0.1" >>$conf_file
     if [ -f "/etc/sysconfig/ntpd" ];then
         grep -i "SYNC_HWCLOCK" /etc/sysconfig/ntpd
         if [ $? -eq 0 ];then
-            sed -i 's/.*SYNC_HWCLOCK.*/SYNC_HWCLOCK=yes/' /etc/sysconfig/ntpd
+            sed -i 's/.*SYNC_HWCLOCK.*/SYNC_HWCLOCK=\"yes\"/' /etc/sysconfig/ntpd
         else
-            echo "SYNC_HWCLOCK=yes" >> /etc/sysconfig/ntpd
+            echo "SYNC_HWCLOCK=\"yes\"" >> /etc/sysconfig/ntpd
         fi
     elif [ -f /etc/sysconfig/ntp ];then
         grep -i "NTPD_FORCE_SYNC_ON_STARTUP" /etc/sysconfig/ntp

--- a/xCAT/postscripts/setupntp
+++ b/xCAT/postscripts/setupntp
@@ -148,17 +148,17 @@ if [ $OS_TYPE = Linux ]; then
         if [ $? -eq 0 ];then
             sed -i 's/.*HWCLOCK.*/HWCLOCK=\"-u\"/' /etc/sysconfig/clock
         else
-            echo "HWCLOCK=\"-u\"" >> /etc/sysconfig/clock
+            echo HWCLOCK=\"-u\" >> /etc/sysconfig/clock
         fi
     elif [ -f "/etc/debian_version" ];then
-        sed -i 's/.*UTC.*/UTC=yes/' /etc/default/rcS
+        sed -i 's/.*UTC.*/UTC=\"yes\"/' /etc/default/rcS
     else
         if [ -f "/etc/sysconfig/clock" ];then
            grep -i "utc" /etc/sysconfig/clock
            if [ $? -eq 0 ];then
-              sed -i 's/.*UTC.*/UTC=yes/' /etc/sysconfig/clock
+              sed -i 's/.*UTC.*/UTC=\"yes\"/' /etc/sysconfig/clock
            else
-              echo "UTC=yes" >> /etc/sysconfig/clock
+              echo UTC=\"yes\" >> /etc/sysconfig/clock
            fi
         elif type -P timedatectl >/dev/null 2>&1 ;then
            timedatectl set-local-rtc 0
@@ -176,11 +176,11 @@ if [ $OS_TYPE = Linux ]; then
     elif [ -f /etc/sysconfig/ntp ];then
         grep -i "NTPD_FORCE_SYNC_ON_STARTUP" /etc/sysconfig/ntp
         if [ $? -eq 0 ];then
-	    sed -i 's/NTPD_FORCE_SYNC_ON_STARTUP="no"/NTPD_FORCE_SYNC_ON_STARTUP="yes"/' /etc/sysconfig/ntp
+	    sed -i 's/NTPD_FORCE_SYNC_ON_STARTUP=\"no\"/NTPD_FORCE_SYNC_ON_STARTUP=\"yes\"/' /etc/sysconfig/ntp
         fi
         grep -i "NTPD_FORCE_SYNC_HWCLOCK_ON_STARTUP" /etc/sysconfig/ntp
         if [ $? -eq 0 ];then
-	    sed -i 's/NTPD_FORCE_SYNC_HWCLOCK_ON_STARTUP="no"/NTPD_FORCE_SYNC_HWCLOCK_ON_STARTUP="yes"/' /etc/sysconfig/ntp
+	    sed -i 's/NTPD_FORCE_SYNC_HWCLOCK_ON_STARTUP=\"no\"/NTPD_FORCE_SYNC_HWCLOCK_ON_STARTUP=\"yes\"/' /etc/sysconfig/ntp
         fi
     else
         cron_file="/etc/cron.daily/xcatsethwclock"


### PR DESCRIPTION
fix few issues in the makentp and setupntp scripts
1) modify /etc/sysconfig/ntp instead of /etc/sysconfig/ntpd for SLES
2) /var/lib/ntp/drift is a directory for SLES, change to /etc/ntp.drift
3) modify /etc/sysconfig/clock
4) add SYNC_HWCLOCK="yes" to /etc/sysconfig/ntpd, the old code didn't work for that checking