### PR TITLE
fix issue 2336, get correct mac address

### DIFF
--- a/xCAT-probe/subcmds/osdeploy
+++ b/xCAT-probe/subcmds/osdeploy
@@ -293,6 +293,17 @@ sub check_noderange {
                     $mac =~ s/\!\*NOIP\*//g;
                     $macmap{$mac}{"ip"}   = "NOIP";
                     $macmap{$mac}{"node"} = $node;
+                } elsif ($mac =~ /(\w{2}:\w{2}:\w{2}:\w{2}:\w{2}:\w{2})\!(.+)/) {
+                    $mac = $1;
+                    my $tmp_node = $2;
+                    $macmap{$mac}{"node"} = $node;
+                    my $tmp_ip = xCAT::NetworkUtils->getipaddr($tmp_node);
+                    if ($tmp_ip) {
+                        $macmap{$mac}{"ip"}  = $tmp_ip;
+                        $ipnodemap{ $nodecheckrst{$node}{"ip"} } = $node;
+                    } else {
+                        $macmap{$mac}{"ip"} = "NOIP";
+                    }
                 } else {
                     $macmap{$mac}{"node"} = $node;
                     $macmap{$mac}{"ip"}   = $nodecheckrst{$node}{"ip"};


### PR DESCRIPTION
#2336 

If mac is defined as below:
```
mac=42:08:0a:03:05:07!c910f03c05k07-pri|42:08:0a:03:05:11!c910f03c05k07-pub
```

get correct info.