### PR TITLE
fix issue 2296, get correct mtms for B&S

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -910,19 +910,16 @@ sub bmcdiscovery_ipmi {
                 if (($::RUNCMD_RC eq 0) && @fru_output_array) {
                     my $fru_output = join(" ", @fru_output_array);
 
-                    if ($fru_cmd_num == 0) {
-                        if (($fru_output =~ /Product Part Number   :\s*(\S*).*Product Serial        :\s*(\S*)/)) {
-                            $mtm    = $1;
-                            $serial = $2;
-                            last;
-                        }
+                    if (($fru_output =~ /Chassis Part Number\s*:\s*(\S*).*Chassis Serial\s*:\s*(\S*)/)) {
+                        $mtm    = $1;
+                        $serial = $2;
+                        last;
                     }
-                    else {
-                        if (($fru_output =~ /Chassis Part Number\s*:\s*(\S*).*Chassis Serial\s*:\s*(\S*)/)) {
-                            $mtm    = $1;
-                            $serial = $2;
-                            last;
-                        }
+
+                    if (($fru_output =~ /Product Part Number   :\s*(\S*).*Product Serial        :\s*(\S*)/)) {
+                        $mtm    = $1;
+                        $serial = $2;
+                        last;
                     }
                 }
             }


### PR DESCRIPTION
#2296 

If use command ``ipmitool-xcat fru print 0``, check "chassis part number" & "chassis serial" first. If has, set mtm as "chassis part number" and serial as "chassis serial".
If no, check "product part number" and "product serial".