### PR TITLE
fix [FVT]set xcatdebugmode=1 does not work after xcatdebugmode is set to 2 #2337

### DIFF
--- a/xCAT-server/lib/xcat/plugins/grub2.pm
+++ b/xCAT-server/lib/xcat/plugins/grub2.pm
@@ -185,8 +185,8 @@ sub setstate {
 
     my $cref = $chainhash{$node}->[0]; #$chaintab->getNodeAttribs($node,['currstate']);
 
-    # remove the old boot configuration file and create a new one, but only if not offline directive
-    unlink($tftpdir . "/boot/grub2/" . $node);
+    # remove the old boot configuration files and create a new one, but only if not offline directive
+    system("find . -inum \$(stat --printf \%i $tftpdir/boot/grub2/$node 2>/dev/null) -exec rm -f {} \\; 2>/dev/null");
     if ($cref and $cref->{currstate} ne "offline") {
         open($pcfg, '>', $tftpdir . "/boot/grub2/" . $node);
         print $pcfg "#" . $cref->{currstate} . "\n";
@@ -334,7 +334,6 @@ sub setstate {
     }
         
 
-     
     if (! $nodemac and $macstring) {
         $nodemac = xCAT::Utils->parseMacTabEntry($macstring, $node);
     }


### PR DESCRIPTION
fix https://github.com/xcat2/xcat-core/issues/2337

 remove all the existing grub.cfg-xxx files while running ``nodeset``