### PR TITLE
Do not update bootparams table when running nodeset

### DIFF
--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -172,6 +172,7 @@ sub mknetboot
     if ($req->{command}->[0] =~ 'mkstatelite') {
         $statelite = "true";
     }
+    my $bootparams = ${$req->{bootparams}};
     my $globaltftpdir   = "/tftpboot";
     my $nodes           = @{ $req->{node} };
     my @args            = @{ $req->{arg} } if (exists($req->{arg}));
@@ -232,7 +233,6 @@ sub mknetboot
     my %donetftp = ();
     my %oents = %{ $ostab->getNodesAttribs(\@nodes, [qw(os arch profile provmethod)]) };
     my $restab = xCAT::Table->new('noderes');
-    my $bptab  = xCAT::Table->new('bootparams', -create => 1);
     my $hmtab  = xCAT::Table->new('nodehm');
     my $mactab = xCAT::Table->new('mac');
 
@@ -249,8 +249,6 @@ sub mknetboot
         $stateHash = $statetab->getNodesAttribs(\@nodes, ['statemnt']);
     }
 
-    #my $addkcmdhash =
-    #    $bptab->getNodesAttribs(\@nodes, ['addkcmdline']);
 
     # Warning message for nodeset <noderange> install/netboot/statelite
     foreach my $knode (keys %oents)
@@ -950,15 +948,9 @@ sub mknetboot
                 $kcmdline .= " MNTOPTS=$mntoptions";
             }
         }
-
-        $bptab->setNodeAttribs(
-            $node,
-            {
-                kernel   => $kernstr,
-                initrd   => $initrdstr,
-                kcmdline => $kcmdline
-            }
-        );
+        $bootparams->{$node}->[0]->{kernel} = $kernstr;
+        $bootparams->{$node}->[0]->{initrd} = $initrdstr;
+        $bootparams->{$node}->[0]->{kcmdline} = $kcmdline;
     }
 
 }
@@ -971,6 +963,7 @@ sub mkinstall
     my @nodes           = @{ $request->{node} };
     my $noupdateinitrd  = $request->{'noupdateinitrd'};
     my $ignorekernelchk = $request->{'ignorekernelchk'};
+    my $bootparams = ${$request->{bootparams}};
 
     #my $sitetab  = xCAT::Table->new('site');
     my $linuximagetab;
@@ -1023,7 +1016,6 @@ sub mkinstall
     my $ostab = xCAT::Table->new('nodetype');
     my %donetftp;
     my $restab = xCAT::Table->new('noderes');
-    my $bptab  = xCAT::Table->new('bootparams', -create => 1);
     my $hmtab  = xCAT::Table->new('nodehm');
     my $mactab = xCAT::Table->new('mac');
     my %osents = %{ $ostab->getNodesAttribs(\@nodes, [ 'profile', 'os', 'arch', 'provmethod' ]) };
@@ -1033,8 +1025,6 @@ sub mkinstall
             [ 'serialport', 'serialspeed', 'serialflow' ]) };
     my %macents = %{ $mactab->getNodesAttribs(\@nodes, ['mac']) };
 
-    #my $addkcmdhash =
-    #    $bptab->getNodesAttribs(\@nodes, ['addkcmdline']);
     require xCAT::Template;
 
     # Warning message for nodeset <noderange> install/netboot/statelite
@@ -1668,14 +1658,9 @@ sub mkinstall
 
             xCAT::MsgUtils->trace($verbose_on_off, "d", "anaconda->mkinstall: kcmdline=$kcmdline kernal=$k initrd=$i");
 
-            $bptab->setNodeAttribs(
-                $node,
-                {
-                    kernel   => $k,
-                    initrd   => $i,
-                    kcmdline => $kcmdline
-                }
-            );
+            $bootparams->{$node}->[0]->{kernel} = $k;
+            $bootparams->{$node}->[0]->{initrd} = $i;
+            $bootparams->{$node}->[0]->{kcmdline} = $kcmdline;
         }
         else
         {
@@ -1701,6 +1686,7 @@ sub mksysclone
     my $callback = shift;
     my $doreq    = shift;
     my @nodes    = @{ $request->{node} };
+    my $bootparams = ${$request->{bootparams}};
     my $linuximagetab;
     my $osimagetab;
     my %img_hash = ();
@@ -1727,7 +1713,6 @@ sub mksysclone
     my $ostab = xCAT::Table->new('nodetype');
     my %donetftp;
     my $restab = xCAT::Table->new('noderes');
-    my $bptab  = xCAT::Table->new('bootparams', -create => 1);
     my $hmtab  = xCAT::Table->new('nodehm');
     my $mactab = xCAT::Table->new('mac');
 
@@ -2064,15 +2049,9 @@ sub mksysclone
 
             $k = "xcat/$kernpath";
             $i = "xcat/$initrdpath";
-
-            $bptab->setNodeAttribs(
-                $node,
-                {
-                    kernel   => $k,
-                    initrd   => $i,
-                    kcmdline => $kcmdline
-                }
-            );
+            $bootparams->{$node}->[0]->{kernel} = $k;
+            $bootparams->{$node}->[0]->{initrd} = $i;
+            $bootparams->{$node}->[0]->{kcmdline} = $kcmdline;
         }
         else
         {

--- a/xCAT-server/lib/xcat/plugins/pxe.pm
+++ b/xCAT-server/lib/xcat/plugins/pxe.pm
@@ -497,6 +497,7 @@ sub process_request {
 
 
     $errored = 0;
+    my %bphash;
     my $inittime = 0;
     if (exists($::PXE_request->{inittime})) { $inittime = $::PXE_request->{inittime}->[0]; }
     if (!$inittime) { $inittime = 0; }
@@ -505,19 +506,19 @@ sub process_request {
         $sub_req->({ command => ['setdestiny'],
                 node     => \@nodes,
                 inittime => [$inittime],
-                arg      => \@args }, \&pass_along);
+                arg      => \@args,
+                bootparams => \%bphash
+                }, \&pass_along);
     }
     if ($errored) { return; }
 
     #Time to actually configure the nodes, first extract database data with the scalable calls
-    my $bptab = xCAT::Table->new('bootparams', -create => 1);
     my $chaintab = xCAT::Table->new('chain');
     my $mactab  = xCAT::Table->new('mac');        #to get all the hostnames
     my $typetab = xCAT::Table->new('nodetype');
     my $restab  = xCAT::Table->new('noderes');
     my $linuximgtab = xCAT::Table->new('linuximage', -create => 1);
     my %nrhash = %{ $restab->getNodesAttribs(\@nodes, [qw(tftpdir)]) };
-    my %bphash = %{ $bptab->getNodesAttribs(\@nodes, [qw(kernel initrd kcmdline addkcmdline)]) };
     my %chainhash = %{ $chaintab->getNodesAttribs(\@nodes, [qw(currstate)]) };
     my %machash = %{ $mactab->getNodesAttribs(\@nodes, [qw(mac)]) };
     my %nthash = %{ $typetab->getNodesAttribs(\@nodes, [qw(os provmethod)]) };

--- a/xCAT-server/lib/xcat/plugins/sles.pm
+++ b/xCAT-server/lib/xcat/plugins/sles.pm
@@ -54,6 +54,7 @@ sub mknetboot
     if ($req->{command}->[0] =~ 'mkstatelite') {
         $statelite = "true";
     }
+    my $bootparams = ${$req->{bootparams}};
 
     my $globaltftpdir   = "/tftpboot";
     my $nodes           = @{ $req->{node} };
@@ -445,7 +446,6 @@ sub mknetboot
         }
 
         # TODO: move the table operations out of the foreach loop
-        my $bptab = xCAT::Table->new('bootparams', -create => 1);
         my $hmtab = xCAT::Table->new('nodehm');
         my $sent =
           $hmtab->getNodeAttribs($node,
@@ -720,13 +720,9 @@ sub mknetboot
                 $kcmdline .= "MNTOPTS=\'$mntoptions\'";
             }
         }
-        $bptab->setNodeAttribs(
-            $node,
-            {
-                kernel   => "$rtftppath/kernel",
-                initrd   => $initrdstr,
-                kcmdline => $kcmdline
-            });
+        $bootparams->{$node}->[0]->{kernel} = "$rtftppath/kernel";
+        $bootparams->{$node}->[0]->{initrd} = $initrdstr;
+        $bootparams->{$node}->[0]->{kcmdline} = $kcmdline;
     }
 }
 
@@ -770,6 +766,7 @@ sub mkinstall
 
     my $noupdateinitrd  = $request->{'noupdateinitrd'};
     my $ignorekernelchk = $request->{'ignorekernelchk'};
+    my $bootparams = ${$request->{bootparams}};
     my @nodes           = @{ $request->{node} };
     my $node;
     my $ostab = xCAT::Table->new('nodetype');
@@ -799,7 +796,6 @@ sub mkinstall
     my $installroot;
     $installroot = "/install";
     my $restab = xCAT::Table->new('noderes');
-    my $bptab  = xCAT::Table->new('bootparams', -create => 1);
     my $hmtab  = xCAT::Table->new('nodehm');
     my $resents =
       $restab->getNodesAttribs(
@@ -1365,14 +1361,9 @@ sub mkinstall
                 $kernelpath = "$rtftppath/linux";
                 $initrdpath = "$rtftppath/initrd";
                 xCAT::MsgUtils->trace($verbose_on_off, "d", "sles->mkinstall: kcmdline=$kcmdline kernal=$kernelpath initrd=$initrdpath");
-                $bptab->setNodeAttribs(
-                    $node,
-                    {
-                        kernel   => $kernelpath,
-                        initrd   => $initrdpath,
-                        kcmdline => $kcmdline
-                    }
-                );
+                $bootparams->{$node}->[0]->{kernel} = $kernelpath;
+                $bootparams->{$node}->[0]->{initrd} = $initrdpath;
+                $bootparams->{$node}->[0]->{kcmdline} = $kcmdline;
             }
             elsif ($arch eq "ppc64")
             {
@@ -1384,14 +1375,9 @@ sub mkinstall
                     $kernelpath = "$rtftppath/linux64";
                     $initrdpath = "$rtftppath/initrd64";
                     xCAT::MsgUtils->trace($verbose_on_off, "d", "sles->mkinstall: kcmdline=$kcmdline kernal=$kernelpath initrd=$initrdpath");
-                    $bptab->setNodeAttribs(
-                        $node,
-                        {
-                            kernel   => $kernelpath,
-                            initrd   => $initrdpath,
-                            kcmdline => $kcmdline
-                        }
-                    );
+                    $bootparams->{$node}->[0]->{kernel} = $kernelpath;
+                    $bootparams->{$node}->[0]->{initrd} = $initrdpath;
+                    $bootparams->{$node}->[0]->{kcmdline} = $kcmdline;
                 }
                 elsif (-r "$tftppath/inst64") {
 
@@ -1399,14 +1385,9 @@ sub mkinstall
                     #suseboot/inst64 can not be run on Power8 BE
                     $kernelpath = "$rtftppath/inst64";
                     xCAT::MsgUtils->trace($verbose_on_off, "d", "sles->mkinstall: kcmdline=$kcmdline kernal=$kernelpath initrd=");
-                    $bptab->setNodeAttribs(
-                        $node,
-                        {
-                            kernel   => $kernelpath,
-                            initrd   => "",
-                            kcmdline => $kcmdline
-                        }
-                    );
+                    $bootparams->{$node}->[0]->{kernel} = $kernelpath;
+                    $bootparams->{$node}->[0]->{initrd} = "";
+                    $bootparams->{$node}->[0]->{kcmdline} = $kcmdline;
                 }
             }
         }
@@ -1436,6 +1417,7 @@ sub mksysclone
     my $callback = shift;
     my $doreq    = shift;
     my @nodes    = @{ $request->{node} };
+    my $bootparams = ${$request->{bootparams}};
     my $osimagetab;
     my %img_hash = ();
 
@@ -1460,7 +1442,6 @@ sub mksysclone
     my $node;
     my $ostab  = xCAT::Table->new('nodetype');
     my $restab = xCAT::Table->new('noderes');
-    my $bptab  = xCAT::Table->new('bootparams', -create => 1);
     my $hmtab  = xCAT::Table->new('nodehm');
     my %osents = %{ $ostab->getNodesAttribs(\@nodes, [ 'os', 'arch', 'provmethod' ]) };
     my %rents =
@@ -1645,14 +1626,9 @@ sub mksysclone
             if (-r "$tftpdir/xcat/genesis.fs.$arch.lzma") {
                 $i = "xcat/genesis.fs.$arch.lzma";
             }
-            $bptab->setNodeAttribs(
-                $node,
-                {
-                    kernel   => "xcat/genesis.kernel.$arch",
-                    initrd   => $i,
-                    kcmdline => $kcmdline
-                }
-            );
+            $bootparams->{$node}->[0]->{kernel} = "xcat/genesis.kernel.$arch";
+            $bootparams->{$node}->[0]->{initrd} = $i;
+            $bootparams->{$node}->[0]->{kcmdline} = $kcmdline;
         }
         else
         {

--- a/xCAT-server/lib/xcat/plugins/vsmppxe.pm
+++ b/xCAT-server/lib/xcat/plugins/vsmppxe.pm
@@ -402,6 +402,7 @@ sub process_request {
 
 
     $errored = 0;
+    my %bphash;
     my $inittime = 0;
     if (exists($::VSMPPXE_request->{inittime})) { $inittime = $::VSMPPXE_request->{inittime}->[0]; }
     if (!$inittime) { $inittime = 0; }
@@ -409,15 +410,15 @@ sub process_request {
         $sub_req->({ command => ['setdestiny'],
                 node     => \@nodes,
                 inittime => [$inittime],
-                arg      => [ $args[0] ] }, \&pass_along);
+                arg      => [ $args[0] ],
+                bootparams => \%bphash
+                }, \&pass_along);
     }
     if ($errored) { return; }
 
     #Time to actually configure the nodes, first extract database data with the scalable calls
-    my $bptab = xCAT::Table->new('bootparams', -create => 1);
     my $chaintab = xCAT::Table->new('chain');
     my $mactab = xCAT::Table->new('mac');    #to get all the hostnames
-    my %bphash = %{ $bptab->getNodesAttribs(\@nodes, [qw(kernel initrd kcmdline addkcmdline)]) };
     my %chainhash = %{ $chaintab->getNodesAttribs(\@nodes, [qw(currstate)]) };
     my %machash = %{ $mactab->getNodesAttribs(\@nodes, [qw(mac)]) };
     foreach (@nodes) {

--- a/xCAT-server/lib/xcat/plugins/xnba.pm
+++ b/xCAT-server/lib/xcat/plugins/xnba.pm
@@ -108,7 +108,7 @@ sub setstate {
     my $linuximghashref = shift;
     if (ref $linuximghashref) { %linuximghash = %{$linuximghashref}; }
     my $imgaddkcmdline = ($linuximghash{'boottarget'}) ? undef : $linuximghash{'addkcmdline'};
-    my $kern = $bphash{$node}->[0]; #$bptab->getNodeAttribs($node,['kernel','initrd','kcmdline']);
+    my $kern = $bphash{$node}->[0];
 
     unless ($::XNBA_addkcmdlinehandled->{$node}) { #Tag to let us know the plugin had a special syntax implemented for addkcmdline
         if ($kern->{addkcmdline} or ($imgaddkcmdline)) {
@@ -520,22 +520,24 @@ sub process_request {
     if (exists($::XNBA_request->{inittime})) { $inittime = $::XNBA_request->{inittime}->[0]; }
     if (!$inittime) { $inittime = 0; }
     $errored = 0;
+    my %bphash;
     unless ($args[0] eq 'stat') {    # or $args[0] eq 'enact') {
         xCAT::MsgUtils->trace($verbose_on_off, "d", "xnba: issue setdestiny request");
         $sub_req->({ command => ['setdestiny'],
                 node     => \@nodes,
                 inittime => [$inittime],
-                arg      => \@args }, \&pass_along);
+                arg      => \@args ,
+                bootparams => \%bphash},
+                \&pass_along);
     }
+
     if ($errored) { return; }
 
     #Time to actually configure the nodes, first extract database data with the scalable calls
-    my $bptab = xCAT::Table->new('bootparams', -create => 1);
     my $chaintab = xCAT::Table->new('chain');
     my $noderestab = xCAT::Table->new('noderes'); #in order to detect per-node tftp directories
     my $mactab     = xCAT::Table->new('mac');     #to get all the hostnames
     my %nrhash = %{ $noderestab->getNodesAttribs(\@nodes, [qw(tftpdir)]) };
-    my %bphash = %{ $bptab->getNodesAttribs(\@nodes, [qw(kernel initrd kcmdline addkcmdline)]) };
     my %chainhash = %{ $chaintab->getNodesAttribs(\@nodes, [qw(currstate)]) };
     my %iscsihash;
     my $iscsitab = xCAT::Table->new('iscsi');


### PR DESCRIPTION
With the nytprof tool, the buttleneck is the time to update the bootparams
table.To optimize the performance on large scale nodes, this patch tranfer
the bootparams hash through variable reference.

posible impact: getdestiny can not get the information about bootparams.

partial-issue: #2024