### PR TITLE
update xcat control file

### DIFF
--- a/xCAT/debian/control
+++ b/xCAT/debian/control
@@ -7,6 +7,6 @@ Standards-Version: 3.7.2
 
 Package: xcat
 Architecture: amd64 ppc64el
-Depends: ${perl:Depends}, xcat-server, xcat-client, libdbd-sqlite3-perl, isc-dhcp-server, apache2, nfs-kernel-server, nmap, bind9, libxml-parser-perl, xinetd, tftpd-hpa, tftp-hpa, libnet-telnet-perl, ipmitool-xcat (>=1.8.9), libsys-virt-perl, xnba-undi, xcat-genesis-scripts, elilo-xcat, xcat-buildkit
+Depends: ${perl:Depends}, xcat-server, xcat-client, libdbd-sqlite3-perl, isc-dhcp-server, apache2, nfs-kernel-server, nmap, bind9, libxml-parser-perl, xinetd, tftpd-hpa, tftp-hpa, libnet-telnet-perl, ipmitool-xcat (>=1.8.9), libsys-virt-perl, xnba-undi, xcat-genesis-scripts-ppc64, xcat-genesis-scripts-amd64, elilo-xcat, xcat-buildkit
 Description: Server and configuration utilities of the xCAT management project
  xcat-server provides the core server and configuration management components of xCAT.  This package should be installed on your management server


### PR DESCRIPTION
The require deb package(xcat-genesis-scripts) will make xcat failed to install on ubuntu16.04. The reason is the deb package name is already changed.