### PR TITLE
fix 2090 delete underlying files for ro statelite mounts

### DIFF
--- a/xCAT-server/share/xcat/netboot/add-on/statelite/rc.statelite
+++ b/xCAT-server/share/xcat/netboot/add-on/statelite/rc.statelite
@@ -460,15 +460,11 @@ ProcessType () {
             CHAREND=`echo ${STRPATH} | /usr/bin/cut -c${STRLEN}`            
 
             if [ "${CHAREND}" = "/" ]; then # it is one directory
-                if [ ! -d ${STRPATH} ]; then
                     /bin/rm -rf ${STRPATH}
                     /bin/mkdir ${STRPATH}
-                fi
             else
-                if [ ! -f ${STRPATH} ]; then
                     /bin/rm -rf ${STRPATH}
                     /bin/touch ${STRPATH}
-                fi
             fi
 
             echo "mout --bind -o ro ${1} ${MNTDIR}${2}" >>$LOG 2>&1


### PR DESCRIPTION
fix #2090 

After statelite compute node is up, STRPATH will be overwriten by mount bind.  If the old STRPATH contains files, it occupies the RAMm, deleting these 2 dir can free RAM.