### PR TITLE
Move the copy/cleanup code for xCAT-probe to their own functions in makerpm

### DIFF
--- a/makerpm
+++ b/makerpm
@@ -16,7 +16,7 @@ function xcat_probe_copy {
     #     3. symbolic link can't work during packaging
     RPMNAME=${1}
     if [ $RPMNAME = "xCAT-probe" ]; then
-        mkdir -p xCAT-probe/lib/perl/xCAT/
+        mkdir -p ${RPMNAME}/lib/perl/xCAT/
         files=("NetworkUtils.pm" "GlobalDef.pm" "ServiceNodeUtils.pm")
         for f in "${files[@]}"; do
             cp perl-xCAT/xCAT/$f ${RPMNAME}/lib/perl/xCAT/
@@ -27,7 +27,7 @@ function xcat_probe_copy {
 function xcat_probe_cleanup { 
    RPMNAME=${1}
    if [ $RPMNAME = "xCAT-probe" ]; then
-       rm -rf xCAT-probe/lib/perl/xCAT/
+       rm -rf ${RPMNAME}/lib/perl/xCAT/
    fi
 }
 

--- a/makerpm
+++ b/makerpm
@@ -9,7 +9,29 @@
 
 # set -x
 
-# Make one of the following rpms: perl-xCAT, xCAT-server, xCAT-client, xCAT-IBMhpc, xCAT-rmc, xCAT-UI, xCAT-test
+function xcat_probe_copy {
+    # xCAT-probe uses some functions shipped with xCAT,  copying for the following reasons:
+    #     1. make xCAT-probe code be self-contained
+    #     2. do not maintain two files for each script
+    #     3. symbolic link can't work during packaging
+    RPMNAME=${1}
+    if [ $RPMNAME = "xCAT-probe" ]; then
+        mkdir -p xCAT-probe/lib/perl/xCAT/
+        files=("NetworkUtils.pm" "GlobalDef.pm" "ServiceNodeUtils.pm")
+        for f in "${files[@]}"; do
+            cp perl-xCAT/xCAT/$f ${RPMNAME}/lib/perl/xCAT/
+        done
+   fi
+}
+
+function xcat_probe_cleanup { 
+   RPMNAME=${1}
+   if [ $RPMNAME = "xCAT-probe" ]; then
+       rm -rf xCAT-probe/lib/perl/xCAT/
+   fi
+}
+
+# Make the noarch rpms
 function makenoarch {
 	RPMNAME=$1
 	if [ "$OSNAME" = "AIX" ]; then
@@ -41,17 +63,7 @@ function makenoarch {
 			fi 
 		fi
 
-                #xcat probe use some functions shipped by xCAT, for below reasons we need to copy files to xCAT-probe directory
-                #1 make xcat probe code to be self-contained
-                #2 don't maintain two files for each script
-                #3 symbolic link can't work during package
-                if [ $RPMNAME = "xCAT-probe" ]; then
-                    CURDIR=$(pwd)
-                    mkdir -p ${CURDIR}/xCAT-probe/lib/perl/xCAT/
-                    cp -f ${CURDIR}/perl-xCAT/xCAT/NetworkUtils.pm ${CURDIR}/xCAT-probe/lib/perl/xCAT/
-                    cp -f ${CURDIR}/perl-xCAT/xCAT/GlobalDef.pm ${CURDIR}/xCAT-probe/lib/perl/xCAT/
-                    cp -f ${CURDIR}/perl-xCAT/xCAT/ServiceNodeUtils.pm ${CURDIR}/xCAT-probe/lib/perl/xCAT/
-                fi
+                xcat_probe_copy ${RPMNAME}
 
 		tar --exclude .svn -czf $RPMROOT/SOURCES/$RPMNAME-$VER.tar.gz $RPMNAME
 		rm -f $RPMROOT/SRPMS/$RPMNAME-$VER*rpm $RPMROOT/RPMS/noarch/$RPMNAME-$VER*rpm
@@ -62,6 +74,9 @@ function makenoarch {
 			# undo the modifications above to leave the sandbox prestine on the build machine
 			git checkout xCAT-UI/xCAT-UI.spec
 		fi
+
+                xcat_probe_cleanup ${RPMNAME}
+
 	fi
 }
 


### PR DESCRIPTION
In reviewing PR #2347, and seeing some files left around from the xCAT-probe build, decided to move this code to functions to copy/cleanup the xCAT-probe files so the git repo left undisturbed after a build. 

Here's the problem, create a new branch , start clean.... 

```
[vhu@victorvm7 xcat-core]$ git checkout -b xcat_probe
Switched to a new branch 'xcat_probe'
[vhu@victorvm7 xcat-core]$ git status
# On branch xcat_probe
nothing to commit, working directory clean
```

Run a build of xCAT

```
[vhu@victorvm7 xcat-core]$ ./buildcore.sh 
Building /home/vhu/rpmbuild/RPMS/noarch/perl-xCAT-2.13.1-snap*.noarch.rpm ...
Building /home/vhu/rpmbuild/RPMS/noarch/xCAT-client-2.13.1-snap*.noarch.rpm ...
...
...
```

At the end we are left with untracked file that are copied for ``xCAT-probe`` in the `makerpm` code.  

```
[vhu@victorvm7 xcat-core]$ git status
# On branch xcat_probe
# Untracked files:
#   (use "git add <file>..." to include in what will be committed)
#
#	xCAT-probe/lib/perl/xCAT/
nothing added to commit but untracked files present (use "git add" to track)
```

Changes will copy the files, then clean up the directory. 