### PR TITLE
Fix the issue with restoring the Release file at the end of buildcore.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # ignore the documentation build files
 docs/build
+# Ignore the temporary file for creating the Release version
+Release.save*

--- a/buildcore.sh
+++ b/buildcore.sh
@@ -35,6 +35,9 @@
 # The following environment variables can be modified if you need
 #
 
+SCRIPT=$(readlink -f $0)
+SCRIPTPATH=`dirname $SCRIPT`
+
 UPLOADUSER=litingt
 USER=xcat
 SERVER=xcat.org
@@ -190,7 +193,7 @@ function setversionvars {
     echo "$XCAT_RELEASE" >Release
 }
 
-RELEASE_FILE="Release"
+RELEASE_FILE="${SCRIPTPATH}/Release"
 RELEASE_FILE_SAVE="${RELEASE_FILE}.save.998"
 
 function internal_backup()
@@ -240,7 +243,6 @@ else
         echo "Error: Could not determine rpmbuild's root directory."
         exit 2
     fi
-    #echo "source=$source"
 fi
 
 #


### PR DESCRIPTION
Fixes a problem introduced in PR #2195.    FYI @neo954 

The initial problem was detected in our auto build scripts that checks the git repo for untracked file.  This is to ensure that we are building from CLEAN git repo that does not contain any changes... the Release file causes this problem: 
```
The following files are not tracked in git: Release.save.998,...
Not a clean build, aborting...
```

Investigating this, I realized that the Release.save.998 file was NOT being restored correctly. 

On a CLEAN master branch where I fetch all the upstream changes...
```
[vhu@victorvm7 xcat-core]$ git status
# On branch master
nothing to commit, working directory clean
[vhu@victorvm7 xcat-core]$ ./buildcore.sh 
Building /home/vhu/rpmbuild/RPMS/noarch/perl-xCAT-2.13.1-snap*.noarch.rpm ...
Building /home/vhu/rpmbuild/RPMS/noarch/xCAT-client-2.13.1-snap*.noarch.rpm ...
Building /home/vhu/rpmbuild/RPMS/noarch/xCAT-server-2.13.1-snap*.noarch.rpm ...
...
Creating /home/vhu/xcatbuild/devel/core-rpms-snap.tar.bz2 ...
```

After the build is run, the files are modified...

```
[vhu@victorvm7 xcat-core]$ git status
# On branch master
# Changes not staged for commit:
#   (use "git add <file>..." to update what will be committed)
#   (use "git checkout -- <file>..." to discard changes in working directory)
#
#	modified:   Release
#
# Untracked files:
#   (use "git add <file>..." to include in what will be committed)
#
#	Release.save.998
```

Adding some debug... 
```
[vhu@victorvm7 xcat-core]$ git diff buildcore.sh
diff --git a/buildcore.sh b/buildcore.sh
index 9ea0235..7dd446e 100755
--- a/buildcore.sh
+++ b/buildcore.sh
@@ -206,6 +206,7 @@ function internal_backup()
 function internal_cleanup()
 {
     # Restore file `Release'
+    echo "VKHU_DEBUG - In internal_cleanup, PWD: $PWD"
     if [ -f "${RELEASE_FILE_SAVE}" ]
     then
         mv "${RELEASE_FILE_SAVE}" "${RELEASE_FILE}"
```

The following message is printed: 

```
VKHU_DEBUG - In internal_cleanup, PWD: /home/vhu/xcatbuild/devel
```

So we are not in the xcat-core repo anymore at the end of the script. 


This pull request fixes the above and I hope the entry to `.gitignore` will allow the auto build scripts to pass without changing the checking set in place..  

Running the changes in this PR shows... 
```
[vhu@victorvm7 xcat-core]$ git checkout fix_release_file 
Switched to branch 'fix_release_file'

[vhu@victorvm7 xcat-core]$ git status
# On branch fix_release_file
nothing to commit, working directory clean

[vhu@victorvm7 xcat-core]$ ./buildcore.sh 
Building /home/vhu/rpmbuild/RPMS/noarch/perl-xCAT-2.13.1-snap*.noarch.rpm ...
Building /home/vhu/rpmbuild/RPMS/noarch/xCAT-client-2.13.1-snap*.noarch.rpm ...
...
...
Creating /home/vhu/xcatbuild/fix_release_file/core-rpms-snap.tar.bz2 ...
[vhu@victorvm7 xcat-core]$ git status
# On branch fix_release_file
# Untracked files:
#   (use "git add <file>..." to include in what will be committed)
#
#	xCAT-probe/lib/perl/xCAT/
nothing added to commit but untracked files present (use "git add" to track)
```

The xCAT-probe I am fixing in another PR so that can be ignored.  The resulting repo is left clean after the build. 