### PR TITLE
makentp -a returns NTP maynot be synchronized on servicenode

### DIFF
--- a/xCAT-server/lib/xcat/plugins/makentp.pm
+++ b/xCAT-server/lib/xcat/plugins/makentp.pm
@@ -366,6 +366,7 @@ sub process_request {
         }
         if ($::RUNCMD_RC != 0) {
             send_msg(\%request, 1, "Error from command $cmd\n    $result.");
+            send_msg(\%request, 1, "Please check $ntp_master, make sure time is synced (can be validated by 'ntpq -p'), then rerun makentp command again ");
             return 1;
         }
     }

--- a/xCAT/postscripts/setupntp
+++ b/xCAT/postscripts/setupntp
@@ -126,9 +126,9 @@ if [ $OS_TYPE = Linux ]; then
         output=`eval $cmd 2>&1`
         rc=$?
         if [ "$rc" != "0" ] || (pmatch "$output" "*Time could not*");then
-            echo "$cmd failed, NTP maynot be synchronized, please wait for NTP synchronized then run updatenode nodename -P setupntp"
+            echo "$cmd failed, NTP may not be synchronized on server node"
+            echo "please wait for NTP synchronized, may take at least 15 mins"
             logger -t xcat "$cmd failed"
-            exit 1
         fi
     else
         logger -t xcat "ntpdate -t5 $master "

--- a/xCAT/postscripts/setupntp
+++ b/xCAT/postscripts/setupntp
@@ -126,8 +126,11 @@ if [ $OS_TYPE = Linux ]; then
         output=`eval $cmd 2>&1`
         rc=$?
         if [ "$rc" != "0" ] || (pmatch "$output" "*Time could not*");then
-            echo "$cmd failed, NTP may not be synchronized on server node"
-            echo "please wait for NTP synchronized, may take at least 15 mins"
+            echo "WARNING: "
+            echo "    $cmd failed, NTP may not be synchronized on NTP server "
+            echo "    please wait for NTP synchronized, may take at least 15 mins"
+            echo "    use 'ntpq -p' command (output has "*" or "+" sign)  to validate the NTP server"
+            echo "    run 'updatenode nodename -P setupntp' if NTP is synced on NTP server but nodename is not synced"
             logger -t xcat "$cmd failed"
         fi
     else
@@ -144,7 +147,7 @@ if [ $OS_TYPE = Linux ]; then
 
     #setup the RTC is UTC format, which will be used by os
     if ( pmatch $OSVER "sles*" ) || ( pmatch $OSVER "suse*" ) || [ -f /etc/SuSE-release ];then
-        grep -i "HWCLOCK" /etc/sysconfig/clock
+        grep -i -q "HWCLOCK" /etc/sysconfig/clock
         if [ $? -eq 0 ];then
             sed -i 's/.*HWCLOCK.*/HWCLOCK=\"-u\"/' /etc/sysconfig/clock
         else
@@ -154,7 +157,7 @@ if [ $OS_TYPE = Linux ]; then
         sed -i 's/.*UTC.*/UTC=\"yes\"/' /etc/default/rcS
     else
         if [ -f "/etc/sysconfig/clock" ];then
-           grep -i "utc" /etc/sysconfig/clock
+           grep -i -q "utc" /etc/sysconfig/clock
            if [ $? -eq 0 ];then
               sed -i 's/.*UTC.*/UTC=\"yes\"/' /etc/sysconfig/clock
            else
@@ -167,18 +170,18 @@ if [ $OS_TYPE = Linux ]; then
 
     #update the hardware clock automaticly
     if [ -f "/etc/sysconfig/ntpd" ];then
-        grep -i "SYNC_HWCLOCK" /etc/sysconfig/ntpd
+        grep -i -q "SYNC_HWCLOCK" /etc/sysconfig/ntpd
         if [ $? -eq 0 ];then
             sed -i 's/.*SYNC_HWCLOCK.*/SYNC_HWCLOCK=\"yes\"/' /etc/sysconfig/ntpd
         else
             echo "SYNC_HWCLOCK=\"yes\"" >> /etc/sysconfig/ntpd
         fi
     elif [ -f /etc/sysconfig/ntp ];then
-        grep -i "NTPD_FORCE_SYNC_ON_STARTUP" /etc/sysconfig/ntp
+        grep -i -q "NTPD_FORCE_SYNC_ON_STARTUP" /etc/sysconfig/ntp
         if [ $? -eq 0 ];then
 	    sed -i 's/NTPD_FORCE_SYNC_ON_STARTUP=\"no\"/NTPD_FORCE_SYNC_ON_STARTUP=\"yes\"/' /etc/sysconfig/ntp
         fi
-        grep -i "NTPD_FORCE_SYNC_HWCLOCK_ON_STARTUP" /etc/sysconfig/ntp
+        grep -i -q "NTPD_FORCE_SYNC_HWCLOCK_ON_STARTUP" /etc/sysconfig/ntp
         if [ $? -eq 0 ];then
 	    sed -i 's/NTPD_FORCE_SYNC_HWCLOCK_ON_STARTUP=\"no\"/NTPD_FORCE_SYNC_HWCLOCK_ON_STARTUP=\"yes\"/' /etc/sysconfig/ntp
         fi


### PR DESCRIPTION
For issue #2398 
Do not **exit** after  /usr/sbin/rcntpd ntptimeset failed, let code flow continues to configure ntp server on service node and start up ntpd server.  NTP server will be synchronized within 15 to 20 mins after issue **makentp -a** command.  below is test results:

NTP server node (xcatmaster) is synced
`````
# ntpq -p
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
*LOCAL(0)        .LOCL.          10 l   21   64  377    0.000    0.000   0.000
````````
issue **makentp -a** command to setup NTP servers for both MN and SN
`````
# makentp -a
configuring management node: c910f03c04k12.
configuring service nodes: c910f03c04k11
c910f03c04k11: xcatdsklspost: updating VPD database
c910f03c04k11: xcatdsklspost: downloaded postscripts successfully
c910f03c04k11: Tue Jan 17 13:46:17 EST 2017 Running postscript: setupntp
c910f03c04k11: inactive
c910f03c04k11: /usr/sbin/rcntpd ntptimeset
c910f03c04k11: /usr/sbin/rcntpd ntptimeset failed, NTP may not be synchronized on server node
c910f03c04k11: please wait for NTP synchronized, may take at least 15 mins
c910f03c04k11: HWCLOCK="-u"
c910f03c04k11: NTPD_FORCE_SYNC_ON_STARTUP="yes"
c910f03c04k11: # This works only if NTPD_FORCE_SYNC_ON_STARTUP is set
c910f03c04k11: NTPD_FORCE_SYNC_HWCLOCK_ON_STARTUP="yes"
c910f03c04k11: postscript: setupntp exited with code 0
c910f03c04k11: Running of postscripts has completed.
`````````
NTP server is not synced on MN:
``````
# ntpq -p
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
 LOCAL(0)        .LOCL.          10 l   21   64    1    0.000    0.000   0.000
`````````
On the service node, ntp.conf is updated, ntpd is running, but NTP server is not synced
``````
# service ntpd status
ntpd.service - NTP Server Daemon
   Loaded: loaded (/usr/lib/systemd/system/ntpd.service; enabled)
   Active: active (running) since Tue 2017-01-17 13:46:18 EST; 52s ago
     Docs: man:ntpd(1)

# ntpq -p
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
 c910f03c04k12.p .INIT.          16 u    1   64    0    0.000    0.000   0.000
```````

After approximately 6 mins,  NTP synced on the server node
```````
# ntpq -p
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
*LOCAL(0)        .LOCL.          10 l    6   64   77    0.000    0.000   0.000
```````
on service node, refid changed from INIT to LOCAL:
`````` 
# ntpq -p
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
 c910f03c04k12.p LOCAL(0)        11 u   61   64    1    0.481    0.001   0.000
```````
approximately another 5 mins, NTP synced on the service node.
```````
# ntpq -p
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
*c910f03c04k12.p LOCAL(0)        11 u    1   64   17    0.336    0.023   0.027
````````

