### PR TITLE
Use correct prefix for disks when vmstoragemodel=virtio

### DIFF
--- a/xCAT-server/lib/xcat/plugins/kvm.pm
+++ b/xCAT-server/lib/xcat/plugins/kvm.pm
@@ -588,11 +588,11 @@ sub build_diskstruct {
     }
     my $cdprefix = 'hd';
 
-    # device name vd* doesn't work for CDROM, so delete it.
-    #if ($storagemodel eq 'virtio') {
-    #    $cdprefix='vd';
-    #} els
-    if ($storagemodel eq 'scsi') {
+    # Normally for vmstoragemodel=virtio, we would set prefix of "vd", but device name vd*
+    # doesn't work for CDROM, so for now use the same prefix "sd" as for vmstoragemodel=scsi.
+    if ($storagemodel eq 'virtio') {
+        $cdprefix='sd';
+    } elsif ($storagemodel eq 'scsi') {
         $cdprefix = 'sd';
     }
     $suffidx += 1;
@@ -4045,7 +4045,8 @@ sub dohyp {
     my %newnodestatus;
 
     foreach $node (sort (keys %{ $hyphash{$hyp}->{nodes} })) {
-        if ($confdata->{$hyp}->{cpumodel} and $confdata->{$hyp}->{cpumodel} =~ /ppc64/i) {
+        unless ($confdata->{vm}->{$node}->[0]->{storagemodel}) {
+            # Storage model is not set, default to  scsi for all architectures
             $confdata->{vm}->{$node}->[0]->{storagemodel} = "scsi";
         }
         if ($confdata->{$hyp}->{cpu_thread}) {


### PR DESCRIPTION
This pull request fixes issue #2139.

If `vmstoragemodel` attribute of node definition is not specified, default to `scsi`.
If `vmstoragemodel=virtios` disk prefix should be `vd*`, CDROM prefix `sd*`