### PR TITLE
Don't use "which" to check whether ipmitool is installed in genesis

### DIFF
--- a/xCAT-genesis-scripts/bin/bmcsetup
+++ b/xCAT-genesis-scripts/bin/bmcsetup
@@ -104,7 +104,7 @@ function snooze() {
     fi
 } 
 
-if which ipmitool 2>&1 | grep no; then 
+if ! ipmitool -V 2>/dev/null| grep "version"; then
     echo "No ipmitool find, please install it first"; 
     exit 1;
 fi


### PR DESCRIPTION
Fix issue #2422 
The command 'which' wasn't included in xcat-genesis-base, use other method to check whether ipmitool is installed.