### PR TITLE
Make nics attribute inhertable

### DIFF
--- a/perl-xCAT/xCAT/DBobjUtils.pm
+++ b/perl-xCAT/xCAT/DBobjUtils.pm
@@ -424,7 +424,6 @@ sub getobjdefs
 
             # get the key to look for, for this object type
             my $objkey = $datatype->{'objkey'};
-
             # go through the list of valid attrs
             foreach my $this_attr (@{ $datatype->{'attrs'} }) {
                 my $ent;
@@ -487,7 +486,6 @@ sub getobjdefs
                     my $intabhash    = 0;
                     my $notsearched  = 0;
                     foreach my $lookup_attr (keys %{ $tabentry{'lookup_attrs'} }) {
-
                         # Check whether the attribute is already in %tabhash
                         # The %tabhash is for performance considerations
                         if (($lookup_attr eq 'node') && ($objtype eq 'node')) {
@@ -513,7 +511,6 @@ sub getobjdefs
                     # Not in tabhash,
                     # Need to lookup the table
                     if ($intabhash == 0 && $notsearched == 1) {
-
                         # look up attr values
                         my @rows = xCAT::DBobjUtils->getDBtable($lookup_table);
                         if (@rows) {
@@ -2502,6 +2499,7 @@ sub judge_node
 
     Arguments:
         nicsattr value, like niccsips=eth0!1.1.1.1|2.1.1.1,eth1!3.1.1.1|4.1.1.1
+        node name, like frame10node10
         nicnames: only return the value for specific nics, like "eth0,eth1"
     Returns:
         expanded format, like:
@@ -2524,8 +2522,8 @@ sub expandnicsattr()
     if (($nicstr) && ($nicstr =~ /xCAT::/)) {
         $nicstr = shift;
     }
+    my $node = shift;
     my $nicnames = shift;
-
     my $ret;
 
     $nicstr =~ /^(.*?)=(.*?)$/;
@@ -2547,7 +2545,6 @@ sub expandnicsattr()
         #$nicval Value: node(d+)|eth0!192.1.1.($1+10)
         if (($nicval) && ($nicval =~ /\|/)) {
             my ($str1, $str2) = split('\|', $nicval);
-
             #$nivval Value: eth0!192.1.1.($1+10)
             $nicval = $str2;
         }
@@ -2576,6 +2573,7 @@ sub expandnicsattr()
             }
         }
 
+        $nicv[1]= xCAT::Table::transRegexAttrs($node, $nicv[1]);
         # ignore the line that does not have nicname or value
         if ($nicv[0] && $nicv[1]) {
             $ret .= "    $nicattr.$nicv[0]=$nicv[1]\n";
@@ -2628,7 +2626,6 @@ sub collapsenicsattr()
         $nodeattrhash = shift;
     }
     my $objname = shift;
-
     my %nicattrs = ();
     foreach my $nodeattr (keys %{$nodeattrhash}) {
 

--- a/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
+++ b/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
@@ -2973,7 +2973,6 @@ sub setFINALattrs
                     }
                 }
             }
-
             # $tmphash{nicips} = "eth0!1.1.1.1|1.2.1.1,eth1!2.1.1.1|2.2.1.1"
             foreach my $nicattr (keys %tmphash)
             {
@@ -3188,7 +3187,6 @@ sub defls
 
         }
     }
-
 
     #  if just provided type list then find all objects of these types
     if (!defined $::opt_template && $::objectsfrom_optt)
@@ -3845,11 +3843,11 @@ sub defls
                                         my $nicsstr;
                                         if ($nicnames)
                                         {
-                                            $nicsstr = xCAT::DBobjUtils->expandnicsattr($nicval, $nicnames);
+                                            $nicsstr = xCAT::DBobjUtils->expandnicsattr($nicval, $obj, $nicnames);
                                         }
                                         else
                                         {
-                                            $nicsstr = xCAT::DBobjUtils->expandnicsattr($nicval);
+                                            $nicsstr = xCAT::DBobjUtils->expandnicsattr($nicval, $obj);
                                         }
 
                                         # Compress mode, format the output
@@ -3902,7 +3900,7 @@ sub defls
                                     if ($showattr =~ /^nic/)
                                     {
                                         my $nicval = "$showattr=$attrval";
-                                        my $nicsstr = xCAT::DBobjUtils->expandnicsattr($nicval);
+                                        my $nicsstr = xCAT::DBobjUtils->expandnicsattr($nicval, $obj);
                                         if ($nicsstr)
                                         {
                                             push(@{ $rsp_info->{data} }, "$nicsstr");


### PR DESCRIPTION
As the attribute value in the nics table can not match the regular
expresion format supported by the table library, this patch add the
logic in the def utils to handle the regular expresion.

close-issue: #2412