### PR TITLE
Create a buildinfo file under xcat-core that provides some information about xCAT build on Ubuntu

### DIFF
--- a/build-ubunturepo
+++ b/build-ubunturepo
@@ -22,7 +22,6 @@
 #                           When you are ready to release this build, use PROMOTE=1 without PREGA
 #               BUILDALL=1 - build all rpms, whether they changed or not.  Should be used for snap builds that are in
 #                            prep for a release.
-#               UP=0 or UP=1 - override the default upload behavior
 #               LOG=<filename> - provide an LOG file option to redirect some output into log file
 #
 # For the dependency packages 1. All the xcat dependency deb packages should be uploaded to
@@ -96,13 +95,6 @@ if [ -z "$c_flag" -a -z "$d_flag" ];then
     exit 2
 fi
 
-USER="xcat"
-SERVER="xcat.org"
-FILES_PATH="files"
-FRS="/var/www/${SERVER}/${FILES_PATH}"
-APT_DIR="${FRS}/xcat"
-APT_REPO_DIR="${APT_DIR}/repos/apt"
-
 if [ "$c_flag" -a "$d_flag" ];then
     printusage
     exit 2
@@ -118,7 +110,7 @@ curdir=`pwd`
 local_core_repo_path="$curdir/../../xcat-core"
 local_dep_repo_path="$curdir/../../xcat-dep/xcat-dep"
 
-#use flock to only one person build at the same time
+# Use flock to only one person build at the same time
 # Get a lock, so can not do 2 builds at once
 exec 8>/var/lock/xcatbld.lock
 if ! flock -n 8; then
@@ -201,7 +193,7 @@ then
         echo "###############################"
 
         #the package type:  local | snap | alpha
-        #the build introduce stirng
+        #the build introduce string
         build_string="Snap_Build"
         xcat_release="snap$(date '+%Y%m%d%H%M')"
         pkg_version="${ver}-${xcat_release}"
@@ -223,8 +215,6 @@ then
             do
                 if grep -q $file $update_log || [ "$BUILDALL" == 1 -o "$file" = "perl-xCAT" ]; then
                     rm -f ../../$package_dir_name/${file_low}_*.$target_arch.deb
-                    #genesis scripts package, don't remove genesis amd64 files
-                    #rm -f ../../$package_dir_name/${file_low}-amd64_*.deb
                     cd $file
                     CURDIR=$(pwd)
                     dch -v $pkg_version -b -c debian/changelog $build_string
@@ -505,33 +495,5 @@ __EOF__
     chgrp root $dep_tar_name
     chmod g+w $dep_tar_name
 
-    # Decide whether to upload or not (default NOT to upload)
-    if [ "$UP" != "1" ]; then
-        echo "Upload not specified, Done! (rerun with UP=1, to upload)"
-        cd $old_pwd
-        exit 0
-    fi
-
-    #upload the dep packages
-    i=0
-    echo "Uploading debs from xcat-dep to ${APT_REPO_DIR}/xcat-dep/ ..."
-    while [ $((i+=1)) -le 5 ] && ! rsync -urLv --delete xcat-dep $USER@${SERVER}:${APT_REPO_DIR}/
-    do : ; done
-
-    #upload the tarball
-    i=0
-    echo "Uploading $dep_tar_name to ${APT_DIR}/xcat-dep/2.x_Ubuntu/ ..."
-    while [ $((i+=1)) -le 5 ] && ! rsync -v --force $dep_tar_name $USER@${SERVER}:${APT_DIR}/xcat-dep/2.x_Ubuntu/
-    do : ; done
-
-    #upload the README file
-    cd debs
-    i=0
-    echo "Uploading README to ${APT_DIR}/xcat-dep/2.x_Ubuntu/ ..."
-    while [ $((i+=1)) -le 5 ] && ! rsync -v --force README $USER@${SERVER}:${APT_DIR}/xcat-dep/2.x_Ubuntu/
-    do : ; done
-
-    cd $old_pwd
-    exit 0
 fi
 exit 0

--- a/build-ubunturepo
+++ b/build-ubunturepo
@@ -6,10 +6,10 @@
 #
 #
 # Getting Started:
-#  - Clone the xcat-core git repository int a directory called <rel>/src/xcat-core, where <rel>
-#    is the same name as the release dir it is uploaded to xcat.org (e.g devel, 2.9, 2.10)
+#  - Clone the xcat-core git repository under a directory named "xcat-core/src"
 #  - make sure reprepro is installed on the build machine
-#  - Run this script from the local git repository you just created.  It will create the other directories that are needed.
+#  - Run this script from the local git repository you just created.  
+#       ./build-ubunturepo -c BUILDALL=1
 
 # Usage:  attr=value attr=value ... ./build-ubunturepo { -c | -d }
 #               PROMOTE=1 - if the attribute "PROMOTE" is specified, means an official dot release.  This does not
@@ -146,47 +146,39 @@ done
 
 if [ "$c_flag" ]
 then
-    # strip the /src/xcat-core from the end of the dir to get the next dir up and use as the release
+    # 
+    # The format of the directory for Ubuntu builds needs to be "xcat-core/src/xcat-core" so 
+    # that the output build files are created under "xcat-core". 
+    # TODO: This should be fixed in the future....
+    #
     if [ -z "$REL" ]; then
         t=${curdir%/src/xcat-core}
         REL=`basename $t`
     fi
+    if [ "$REL" != "xcat-core" ]; then
+        echo "ERROR: REL='$REL'needs to be 'xcat-core'.  Ensure the path is 'xcat-core/src/xcat-core'"
+        exit 1
+    fi
 
-    ver=`cat Version`
     if [ "$PROMOTE" != 1 ]; then
         code_change=0
         update_log=''
-        #get the version
-        if [ "$REL" = "xcat-core" ];then
-            git_flag=1
-            REL=`git rev-parse --abbrev-ref HEAD`
-            if [ "$REL" = "master" ]; then
-                REL="devel"
-            fi
-            if [ -z "$GITUP" ];then
-                update_log=../coregitup
-                echo "git pull > $update_log"
-                git pull > $update_log
-            else
-                update_log=$GITUP
-            fi
-
-            if ! grep -q  'Already up-to-date' $update_log; then
-                code_change=1
-            fi
+        # get the version
+        git_flag=1
+        REL=`git rev-parse --abbrev-ref HEAD`
+        if [ "$REL" = "master" ]; then
+            REL="devel"
+        fi
+        if [ -z "$GITUP" ];then
+            update_log=../coregitup
+            echo "git pull > $update_log"
+            git pull > $update_log
         else
-            git_flag=0
-            if [ -z "$SVNUP" ];	then
-                update_log=../coresvnup
-                echo "svn up > $update_log"
-                svn up > $update_log
-            else
-                update_log=$SVNUP
-            fi
+            update_log=$GITUP
+        fi
 
-            if ! grep -q 'At revision' $update_log;then
-                code_change=1
-            fi
+        if ! grep -q  'Already up-to-date' $update_log; then
+            code_change=1
         fi
         ver=`cat Version`
         short_ver=`cat Version|cut -d. -f 1,2`

--- a/build-ubunturepo
+++ b/build-ubunturepo
@@ -183,6 +183,9 @@ then
         ver=`cat Version`
         short_ver=`cat Version|cut -d. -f 1,2`
         short_short_ver=`cat Version|cut -d. -f 1`
+        build_time=`date`
+        build_machine=`hostname`
+        commit_id=`git rev-parse --short HEAD`
 
         package_dir_name=debs$REL
         #TODO: define the core path and tarball name
@@ -199,10 +202,9 @@ then
 
         #the package type:  local | snap | alpha
         #the build introduce stirng
-        pkg_type="snap"
         build_string="Snap_Build"
-        cur_date=`date +%Y%m%d%H%M`
-        pkg_version="${ver}-${pkg_type}${cur_date}"
+        xcat_release="snap$(date '+%Y%m%d%H%M')"
+        pkg_version="${ver}-${xcat_release}"
 
         if [ ! -d ../../$package_dir_name ];then
             mkdir -p "../../$package_dir_name"
@@ -368,6 +370,16 @@ echo deb [arch=$host_arch] file://"`pwd`" $DISTRIB_CODENAME main > /etc/apt/sour
 __EOF__
 
     chmod 775 mklocalrepo.sh
+
+    #
+    # Add a buildinfo file under xcat-core to track information about the build
+    #
+    buildinfo=$local_core_repo_path/buildinfo
+    echo "VERSION=$ver" > $buildinfo
+    echo "RELEASE=$xcat_release" >> $buildinfo
+    echo "BUILD_TIME=$build_time" >> $buildinfo
+    echo "BUILD_MACHINE=$build_machine" >> $buildinfo
+    echo "COMMIT_ID=$commit_id" >> $buildinfo
 
     #create the xcat-core.list file
 


### PR DESCRIPTION
This was implemented in the Linux build and there's a `xcat-core/buildinfo` file under the xcat-core directory in the xCAT tarball.  Adding this into the Ubuntu build side. 

Within this pull request, I've also cleaned up the code for uploading the packages since that is no longer done in this build script, but done in our daily build automated scripts.  

After the ubuntu build is complete, the following file is created: 

```
root@c910f02c07p03:~/vhu/xcat-core/src/xcat-core# ls -ltr ../../xcat-core/
total 24
drwxrwxr-x 2 root root 4096 Jan 24 14:18 conf
drwxrwxr-x 3 root root 4096 Jan 24 14:18 pool
drwxrwxr-x 6 root root 4096 Jan 24 14:18 dists
drwxrwxr-x 2 root root 4096 Jan 24 14:18 db
-rwxrwxr-x 1 root root  254 Jan 24 14:18 mklocalrepo.sh
-rw-rw-r-- 1 root root  126 Jan 24 14:18 buildinfo

root@c910f02c07p03:~/vhu/xcat-core/src/xcat-core# cat ../../xcat-core/buildinfo 
VERSION=2.13.2
RELEASE=snap201701241416
BUILD_TIME=Tue Jan 24 14:16:29 EST 2017
BUILD_MACHINE=c910f02c07p03
COMMIT_ID=9eb044f
```
