### PR TITLE
Set the hostname using the hostnamectl command in the hardeths postscripts 

### DIFF
--- a/xCAT/postscripts/hardeths
+++ b/xCAT/postscripts/hardeths
@@ -72,6 +72,17 @@ else
         echo "GATEWAY=$defgw" >> /etc/sysconfig/network
     fi
 fi
+
+HOSTNAMECTL=`which hostnamectl 2>&1 | grep -v "/usr/bin/which: no"`
+if [ ! -z $HOSTNAMECTL ] && [ ! -z $NODE ]; then
+    SET_HOSTNAME=$NODE
+    if [ ! -z $DOMAIN ]; then 
+        SET_HOSTNAME=$NODE.$DOMAIN
+    fi
+    echo "Setting hostname to: $SET_HOSTNAME"
+    hostnamectl set-hostname $SET_HOSTNAME
+fi
+
 for nic in `ip link |grep "BROADCAST" |awk '{print $2}'   | sed s/://`; do
     IPADDRMASK=`ip addr show dev $nic | grep inet | grep -v inet6 | awk '{print $2}' | head -n 1`
     IPADDR=`echo $IPADDRMASK | awk -F'/' '{print $1}'`


### PR DESCRIPTION
Addresses Issue #2446 

Currently when we are using `hardeths`, the hostname is not set on Operating systems with systemd using the `hostnamectl` command.  The pull requests changes this to test for the `hostnamectl` command and if it's found, set the hostname using the NODE and DOMAIN environment variables. 


Before code changes, the behavior is the following

## for diskless 
```
[root@fs1 ~]# NODE=frame45cn05
[root@fs1 ~]# lsdef $NODE -i provmethod,postscripts
Object name: frame45cn05
    postscripts=syslog,remoteshell,syncfiles,hardeths
    provmethod=rhels7.3-GA-ppc64le-netboot-compute
[root@fs1 ~]# xdsh $NODE  hostnamectl | grep hostname
frame45cn05:    Static hostname: localhost.localdomain
frame45cn05: Transient hostname: frame45cn05
[root@fs1 ~]#  xdsh $NODE cat /etc/hostname
frame45cn05: localhost.localdomain
```

## for diskful...
```
[root@fs1 ~]# NODE=frame45cn12
[root@fs1 ~]# lsdef $NODE -i provmethod,postscripts
Object name: frame45cn12
    postscripts=syslog,remoteshell,syncfiles,hardeths
    provmethod=rhels7.3-GA-ppc64le-install-compute
[root@fs1 ~]# xdsh $NODE  hostnamectl | grep hostname
frame45cn12:    Static hostname: frame45cn12
[root@fs1 ~]# xdsh $NODE cat /etc/hostname
frame45cn12: frame45cn12
```

After the changes, the behavior is the following:

## for diskless

```
[root@fs4 vhu]# NODE=frame23cn22
[root@fs4 vhu]# lsdef $NODE -i provmethod,postscripts
Object name: frame23cn22
    postscripts=syslog,remoteshell,syncfiles,hardeths
    provmethod=rhels7.3-GA-ppc64le-netboot-compute
[root@fs4 vhu]# xdsh $NODE  hostnamectl | grep hostname
frame23cn22:    Static hostname: frame23cn22.pok.stglabs.ibm.com
[root@fs4 vhu]# xdsh $NODE cat /etc/hostname
frame23cn22: frame23cn22.pok.stglabs.ibm.com
```

## for diskfull
```
[root@fs4 vhu]# NODE=frame23cn24
[root@fs4 vhu]# lsdef $NODE -i provmethod,postscripts
Object name: frame23cn24
    postscripts=syslog,remoteshell,syncfiles,hardeths
    provmethod=rhels7.3-GA-ppc64le-install-compute
[root@fs4 vhu]# xdsh $NODE  hostnamectl | grep hostname
frame23cn24:    Static hostname: frame23cn24
[root@fs4 vhu]# xdsh $NODE cat /etc/hostname
frame23cn24: frame23cn24
```
