### PR TITLE
Fix typo in bmcsetup script 

### DIFF
--- a/xCAT-genesis-scripts/bin/bmcsetup
+++ b/xCAT-genesis-scripts/bin/bmcsetup
@@ -253,7 +253,7 @@ elif [ "$IPMIMFG" == "674" ]; then # DELL
     logger -s -t $log_label -p local4.info "BMCPORT is $BMCPORT"
     if [ "$BMCPORT" == "0" ]; then # dedicated
         ipmitool delloem lan set dedicated &>/dev/null
-    elif [ "$BMCPORT" == "1" -o "$BMCPORT" == "2" -o "$BMCPORT" == "3" -o "$BMCPORT" == "4"]; then # shared
+    elif [ "$BMCPORT" == "1" -o "$BMCPORT" == "2" -o "$BMCPORT" == "3" -o "$BMCPORT" == "4" ]; then # shared
         ipmitool delloem lan set shared &>/dev/null
         ipmitool delloem lan set shared with lom$BMCPORT &>/dev/null
         ipmitool delloem lan set shared with failover all loms &>dev/null


### PR DESCRIPTION
Space required in the if test, pointed out by Issue #2451 