### PR TITLE
makehosts: prevent redundant names in /etc/hosts when aliases are defined

### DIFF
--- a/xCAT-server/lib/xcat/plugins/hosts.pm
+++ b/xCAT-server/lib/xcat/plugins/hosts.pm
@@ -87,13 +87,10 @@ sub addnode
 
                     # we're processing the nics table and we found an
                     #   existing entry for this ip so just add this
-                    # ode name as an alias for the existing entry
+                    # node name as an alias for the existing entry
                     chomp($hosts[$idx]);
                     my ($hip, $hnode, $hdom, $hother) = split(/ /, $hosts[$idx]);
 
-                    # at this point "othernames", if any is just a space
-                    # elimited list - so just add the node name to the list
-                    $othernames .= " $node";
                     $hosts[$idx] = build_line($callback, $ip, $hnode, $domain, $othernames);
                 } else {
 


### PR DESCRIPTION
I believe that when an alias is defined for an interface, [this line](https://github.com/xcat2/xcat-core/blob/master/xCAT-server/lib/xcat/plugins/hosts.pm#L96) generates duplicate names in a hosts' line in `/etc/hosts`, when the node's line already exists.

For instance, considering the following node:
```
Object name: testnode
    groups=server
    ip=10.10.0.51
    nicaliases.bmc=foo
    nicips.bmc=10.11.0.11
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
```
When invoked for the first time, `makehosts` generates the expected line:
```
# makehosts testnode
# grep testnode /etc/hosts
10.10.0.51 testnode.int testnode
10.11.0.11 testnode-bmc.ipmi testnode-bmc foo
```

But when `makehosts` is called a second time (ie. when `/etc/hosts` already contains a line for `testnode`), the node name is added a 2nd time at the end of the line:
```
# makehosts testnode
# grep testnode /etc/hosts
10.10.0.51 testnode.int testnode
10.11.0.11 testnode-bmc.ipmi testnode-bmc foo testnode-bmc
```

I'm not too sure why `$nodename` was happened to the list of other names in the first place, but removing that line seems to produce a more consistent result when `makehosts` is called several times.


I can post the `bmc` and `int` network definitions if required, but I don't believe they're relevant.