### PR TITLE
add /tmp into the exlist of rhels7 diskless osimage

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels7.ppc64.exlist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels7.ppc64.exlist
@@ -32,4 +32,4 @@
 ./usr/share/zoneinfo*
 ./var/cache/man*
 ./var/lib/yum*
-
+./tmp*

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels7.x86_64.exlist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels7.x86_64.exlist
@@ -32,4 +32,4 @@
 ./usr/share/zoneinfo*
 ./var/cache/man*
 ./var/lib/yum*
-
+./tmp*


### PR DESCRIPTION
the /tmp directory under diskless osimage might cause the compressed rootimg too large, add it into exlist