### PR TITLE
[DON'T MERGE]To have petitboot and onie based node be able to get configuration from SN

### DIFF
--- a/xCAT-server/lib/xcat/plugins/dhcp.pm
+++ b/xCAT-server/lib/xcat/plugins/dhcp.pm
@@ -1964,7 +1964,7 @@ sub process_request
         } else {
             $chainents = undef;
         }
-        $nrhash = $nrtab->getNodesAttribs($req->{node}, [ 'tftpserver', 'netboot', 'proxydhcp' ]);
+        $nrhash = $nrtab->getNodesAttribs($req->{node}, [ 'tftpserver', 'netboot', 'proxydhcp', 'xcatmaster', 'servicenode']);
         my $nodetypetab;
         $nodetypetab = xCAT::Table->new('nodetype', -create => 0);
         if ($nodetypetab) {


### PR DESCRIPTION
For petitboot and onie, they will get next server from servicenode and/or xcatmaster attribute in noderes table. But the problem is, original code doesn't read those 2 attributes from noderes table.