### PR TITLE
Remove the reference to hwtype=bmc from the documentation

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/discovery/mtms/discovery_using_defined.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/discovery/mtms/discovery_using_defined.rst
@@ -27,27 +27,17 @@ The BMC IP address is obtained by the open range dhcp server and the plan in thi
 
 #. Detect the BMCs and add the node definitions into xCAT.
 
-   Use the ``bmcdiscover`` command to discover the BMCs responding over an IP range and automatically write the output into the xCAT database.  You **must** use the ``-w`` option to automatically write the output into the xCAT database. 
+   Use the :doc:`bmcdiscover </guides/admin-guides/references/man1/bmcdiscover.1>` command to discover the BMCs responding over an IP range and write the output into the xCAT database.  This discovered BMC node is used to control the physical server during hardware discovery and will be deleted after the correct server node object is matched to a pre-defined node.  You **must** use the ``-w`` option to write the output into the xCAT database. 
 
-   To discover the BMC with an IP address of 172.30.0.1, use the command: ::
+   To discover the BMC with an IP address range of 50.0.100.1-100: ::
 
-      bmcdiscover --range 172.30.0.1 -z -w 
+      bmcdiscover --range 50.0.100.1-100 -z -w
 
-   The discovered nodes will be written to xCAT database: ::
+   The discovered nodes will be written to xCAT database.  The discovered BMC nodes are in the form **node-model_type-serial**.   To view the discovered nodes: ::
 
-      # lsdef node-8247-22l-10112ca
-      Object name: node-8247-22l-10112ca
-          bmc=172.30.0.1
-          cons=ipmi
-          groups=all
-          hwtype=bmc
-          mgt=ipmi
-          mtm=8247-22L
-          nodetype=mp
-          postbootscripts=otherpkgs
-          postscripts=syslog,remoteshell,syncfiles
-          serial=10112CA
-          nodetype=mp
+      lsdef /node-.*
+
+   **Note:** The ``bmcdiscover`` command will use the username/password from the ``passwd`` table corresponding to ``key=ipmi``.  To overwrite with a different username/password use the ``-u`` and ``-p`` option to ``bmcdiscover``.
 
 
 #. **Pre-define** the compute nodes:

--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/discovery/pbmc_discovery_with_bmcdiscover.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/discovery/pbmc_discovery_with_bmcdiscover.rst
@@ -3,31 +3,18 @@ Discover server and define
 
 After environment is ready, and the server is powered, we can start server discovery process. The first thing to do is discovering the FSP/BMC of the server. It is automatically powered on when the physical server is powered.
 
-The following command can be used to discovery BMC within an IP range and write the discovered node definition into xCAT database::
+Use the :doc:`bmcdiscover </guides/admin-guides/references/man1/bmcdiscover.1>` command to discover the BMCs responding over an IP range and write the output into the xCAT database.  This discovered BMC node is used to control the physical server during hardware discovery and will be deleted after the correct server node object is matched to a pre-defined node.  You **must** use the ``-w`` option to write the output into the xCAT database.  
 
-    bmcdiscover -s nmap --range 50.0.100.1-100 -z -w
+To discover the BMC with an IP address range of 50.0.100.1-100: ::
 
-The discovered BMC node will be like this::
+   bmcdiscover --range 50.0.100.1-100 -z -w
 
-    # lsdef node-8247-42l-10112ca
-    Object name: node-8247-42l-10112ca
-    bmc=50.0.100.1
-    cons=ipmi
-    groups=all
-    hwtype=bmc
-    mgt=ipmi
-    mtm=8247-42L
-    nodetype=mp
-    postbootscripts=otherpkgs
-    postscripts=syslog,remoteshell,syncfiles
-    serial=10112CA
+The discovered nodes will be written to xCAT database.  The discovered BMC nodes are in the form **node-model_type-serial**.   To view the discovered nodes: ::
 
-**Note**:
-    1. The BMC node is just used to control the physical during hardware discovery process, it will be deleted after the correct server node object is found.
-    
-    2. bmcdiscover will use username/password pair set in ``passwd`` table with **key** equal **ipmi**. If you'd like to use other username/password pair, you can use ::
+   lsdef /node-.*
 
-        bmcdiscover -s nmap --range 50.0.100.1-100 -z -w -u <username> -p <password>
+**Note:** The ``bmcdiscover`` command will use the username/password from the ``passwd`` table corresponding to ``key=ipmi``.  To overwrite with a different username/password use the ``-u`` and ``-p`` option to ``bmcdiscover``.
+
 
 Start discovery process
 -----------------------


### PR DESCRIPTION
Remove the references to hwtype=bmc from the documentation . This was only used internally to detect the temporary bmc node, and the display in the example output is causing confusion.  Replace the command to list out the discovered definition with a wildcard  ``lsdef /node-.*`` and this will help reduce the need to maintain the documentation when the output of the command changes. 

current output of ``bmcdiscover``

```
[root@fs1 common]# bmcdiscover --range 50.45.2.1 -z 
node-8335-gtb-100499a:
	objtype=node
	groups=all
	bmc=50.45.2.1
	cons=ipmi
	mgt=ipmi
	mtm=8335-GTB
	serial=100499A
```
