### PR TITLE
Enhance mtm discovery for non-IBM hardware

### DIFF
--- a/xCAT-genesis-scripts/bin/dodiscovery
+++ b/xCAT-genesis-scripts/bin/dodiscovery
@@ -73,14 +73,11 @@ if [ -r /sys/devices/virtual/dmi/id/product_name ]; then  #x86
 	else 
 		MTM=`cat /sys/devices/virtual/dmi/id/product_name|awk -F'[' '{print $2}'|awk -F']' '{print $1}'`
 		if [ -z "$MTM" ]; then
-			SYS=`cat /sys/devices/virtual/dmi/id/sys_vendor`
-            PRD=`cat /sys/devices/virtual/dmi/id/product_name`
-			if [ ! -z "$SYS" ]; then
-				MTM=${SYS^^}":"${PRD^^}
-			else
-				MTM=${PRD^^}
-			fi
-		fi
+            FRU=`ipmitool fru print 0`
+            if [ $? -eq 0 ]; then
+                MTM=`echo "$FRU" | awk -F': ' '/Product Manufacturer/ {m=$2} /Product Name/ {n=$2} END {print m":"n}'`
+            fi
+		fi 
 		SERIAL=`cat /sys/devices/virtual/dmi/id/product_serial`
 	fi
         CPUCOUNT=`cat /proc/cpuinfo |grep "model name"|wc -l`

--- a/xCAT-genesis-scripts/bin/dodiscovery
+++ b/xCAT-genesis-scripts/bin/dodiscovery
@@ -72,6 +72,15 @@ if [ -r /sys/devices/virtual/dmi/id/product_name ]; then  #x86
 		MTM=VMware
 	else 
 		MTM=`cat /sys/devices/virtual/dmi/id/product_name|awk -F'[' '{print $2}'|awk -F']' '{print $1}'`
+		if [ -z "$MTM" ]; then
+			SYS=`cat /sys/devices/virtual/dmi/id/sys_vendor`
+            PRD=`cat /sys/devices/virtual/dmi/id/product_name`
+			if [ ! -z "$SYS" ]; then
+				MTM=${SYS^^}":"${PRD^^}
+			else
+				MTM=${PRD^^}
+			fi
+		fi
 		SERIAL=`cat /sys/devices/virtual/dmi/id/product_serial`
 	fi
         CPUCOUNT=`cat /proc/cpuinfo |grep "model name"|wc -l`

--- a/xCAT-genesis-scripts/bin/dodiscovery
+++ b/xCAT-genesis-scripts/bin/dodiscovery
@@ -73,10 +73,10 @@ if [ -r /sys/devices/virtual/dmi/id/product_name ]; then  #x86
 	else 
 		MTM=`cat /sys/devices/virtual/dmi/id/product_name|awk -F'[' '{print $2}'|awk -F']' '{print $1}'`
 		if [ -z "$MTM" ]; then
-            FRU=`ipmitool fru print 0`
-            if [ $? -eq 0 ]; then
-                MTM=`echo "$FRU" | awk -F': ' '/Product Manufacturer/ {m=$2} /Product Name/ {n=$2} END {print m":"n}'`
-            fi
+			FRU=`ipmitool fru print 0`
+			if [ $? -eq 0 ]; then
+				MTM=`echo "$FRU" | awk -F': ' '/Product Manufacturer/ {m=$2} /Product Name/ {n=$2} END {print m":"n}'`
+			fi
 		fi 
 		SERIAL=`cat /sys/devices/virtual/dmi/id/product_serial`
 	fi

--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -921,6 +921,13 @@ sub bmcdiscovery_ipmi {
                         $serial = $2;
                         last;
                     }
+
+                    if (($fru_output =~ /Product Manufacturer\s+:\s+(.*?)\s+P.*?roduct Name\s+:\s+(.*?)\s+P.*?roduct Serial\s+:\s+(\S+)/)) {
+                        $mtm    = $1.":".$2;
+                        $serial = $3;
+                        last;
+                    }
+
                 }
             }
 

--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -946,6 +946,7 @@ sub bmcdiscovery_ipmi {
             if ($mtm and $serial) {
                 $node = "node-$mtm-$serial";
                 $node =~ s/(.*)/\L$1/g;
+                $node =~ s/[\s:\._]/-/g;
             }
         } elsif ($output =~ /error : unauthorized name/) {
             xCAT::MsgUtils->message("E", { data => ["BMC username is incorrect for $ip"] }, $::CALLBACK);


### PR DESCRIPTION
Currently, the population of the `mtm` field in the `vpd` table only works for IBM/Lenovo machines. This adds a fallback for cases where the MTM can't be correctly detected in `dodiscovery` and `bmcdiscover`.

Generates a `mtm` field of the form `VENDOR::MODEL`, using:
 * `Product Manufacturer` and `Product Name` from the IPMI FRU pages
 * `sys_vendor` and `product_name` from DMI

### Example results
Via `dodiscovery`
```
# lsdef sh-101-01 -i mtm
Object name: sh-101-01
    mtm=DELL INC.:POWEREDGE C6320
```

Via `bmcdiscover`
```
# bmcdiscover -s nmap --range sh-101-01.ipmi  -z
node-dell-poweredge-c6320-62d4fd2:
        objtype=node
        groups=all
        bmc=sh-101-01.ipmi
        cons=ipmi
        mgt=ipmi
        mtm=DELL:PowerEdge C6320
        serial=62D4FD2
```

The separator (`:`) between vendor and model can obviously be changed if problematic, as well as spaces in vendor and model names.