### PR TITLE
Modify hardeths postscripts to support onie switch

### DIFF
--- a/xCAT/postscripts/hardeths
+++ b/xCAT/postscripts/hardeths
@@ -46,8 +46,12 @@ network_ipv4calc ()
     echo $NETWORK
 }
 
+if (cat /etc/os-release |grep -i  '^NAME=[ "]*Cumulus Linux[ "]*$' >/dev/null 2>&1); then
+    osver="cumulus"
+fi
+
 defgw=`ip route | grep default | awk '{print $3}'`
-if ( pmatch $OSVER "ubuntu*" )
+if ( pmatch $OSVER "ubuntu*" ) || (pmatch $osver "cumulus")
 then
     echo `hostname` >/etc/hostname
     mv /etc/network/interfaces /etc/network/interfaces.old # this file will be filled up next
@@ -76,7 +80,7 @@ fi
 HOSTNAMECTL=`which hostnamectl 2>&1 | grep -v "/usr/bin/which: no"`
 if [ ! -z $HOSTNAMECTL ] && [ ! -z $NODE ]; then
     SET_HOSTNAME=$NODE
-    if [ ! -z $DOMAIN ]; then 
+    if [ ! -z $DOMAIN ]; then
         SET_HOSTNAME=$NODE.$DOMAIN
     fi
     echo "Setting hostname to: $SET_HOSTNAME"
@@ -90,7 +94,7 @@ for nic in `ip link |grep "BROADCAST" |awk '{print $2}'   | sed s/://`; do
     PREFIXMASK=`echo $IPADDRMASK | awk -F'/' '{print $2}'`
     # converts to x.x.x.x mask value
     maskfromprefix $PREFIXMASK
-    if ( pmatch $OSVER "ubuntu*" )
+    if ( pmatch $OSVER "ubuntu*" ) || (pmatch $osver "cumulus")
     then
         NETWORK=`network_ipv4calc $IPADDR $NETMASK`
         #BROADCAST=`ifconfig $nic | grep Bcast | awk '{print $3}' | awk -F: '{print $2}'`
@@ -149,7 +153,7 @@ EOF
     fi
 done
 
-if ( pmatch $OSVER "ubuntu*")
+if ( pmatch $OSVER "ubuntu*") || (pmatch $osver "cumulus")
 then
     cat >>/etc/network/interfaces <<EOF
 auto lo


### PR DESCRIPTION
For issue #2485 
Here are the output when I tested hardeths postscripts

````
# updatenode frame1sw1 -P hardeths
frame1sw1: xcatdsklspost: downloaded postscripts successfully
frame1sw1: Thu Feb 16 20:27:36 UTC 2017 Running postscript: hardeths
frame1sw1: 255.255.0.0
frame1sw1: postscript: hardeths exited with code 0
frame1sw1: Running of postscripts has completed.
```````
the interface file on the cumulus switch
````
root@frame1sw1:~# cat /etc/network/interfaces
auto eth0
iface eth0 inet static
    address 192.168.3.200
    network 192.168.0.0
    netmask 255.255.0.0
    broadcast 192.168.255.255
    gateway 192.168.27.1


auto lo
iface lo inet loopback
``````
