### PR TITLE
Add Service Node install steps and fix formatting and man wording

### DIFF
--- a/docs/source/advanced/hierarchy/define_service_nodes.rst
+++ b/docs/source/advanced/hierarchy/define_service_nodes.rst
@@ -53,7 +53,7 @@ The following table illustrates the cluster being used in this example:
                                   setupconserver=1
 
    **Tips/Hint**
-      * Even if you do not want xCAT to configure any services, you must define the service nodes in the ``servicenode`` table with at least one attribute, set to 0, otherwise xCAT will not recognize the node as a service node**
+      * Even if you do not want xCAT to configure any services, you must define the service nodes in the ``servicenode`` table with at least one attribute, set to 0, otherwise xCAT will not recognize the node as a service node
       * See the ``setup*`` attributes in the node definition man page for the list of available services:  ``man node``
       * For clusters with subnetted management networks, you might want to set ``setupupforward=1``
 
@@ -82,4 +82,20 @@ The following table illustrates the cluster being used in this example:
         chdef -t group -o rack1 conserver=r1n01 monserver=r1n01
         chdef -t group -o rack2 conserver=r2n01 monserver=r2n01
 
+#. Choose location of ``/install`` and ``/tftpboot`` directories (optional).
 
+   The ``site`` table attributes ``installloc`` and ``sharedtftp`` control mounting of ``/install`` and ``/tftpboot`` directories from Management Node to Service node.
+
+   To mount ``/install`` and ``/tftpboot`` directories from Management node to each Service Node: ::
+
+         chdef -t site clustersite sharedtftp=1
+         chdef -t site clustersite installloc="/install"
+
+   To make ``/install`` and ``/tftpboot`` directories local on each Service Node, set ``site`` table attributes and "sync" ``/install`` and ``/tftpoot`` directory contents from Management Node to Service Nodes: ::
+
+         chdef -t site clustersite sharedtftp=0
+         chdef -t site clustersite installloc=
+         rsync -auv --exclude 'autoinst' /install r1n01:/ 
+         rsync -auv --exclude 'autoinst' /install r2n01:/ 
+         rsync -auv --exclude 'autoinst' /tftpboot r1n01:/ 
+         rsync -auv --exclude 'autoinst' /tftpboot r2n01:/ 

--- a/docs/source/guides/admin-guides/references/man1/prsync.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/prsync.1.rst
@@ -21,7 +21,7 @@ prsync - parallel rsync
 
 \ **prsync**\  \ *filename*\  [\ *filename*\  \ *...*\ ] \ *noderange:destinationdirectory*\ 
 
-\ **prsync**\   [\ **-o**\  \ *rsync options*\ ] [\ **-f**\  \ *fanout*\ ] [\ *filename*\  \ *filename*\  \ *...*\ ] [\ *directory*\  \ *directory*\  \ *...*\ ]
+\ **prsync**\   [\ **-o**\  \ *rsyncopts*\ ] [\ **-f**\  \ *fanout*\ ] [\ *filename*\  \ *filename*\  \ *...*\ ] [\ *directory*\  \ *directory*\  \ *...*\ ]
 \ *noderange:destinationdirectory*\ 
 
 \ **prsync**\  {\ **-h | -**\ **-help | -v | -**\ **-version**\ }
@@ -32,11 +32,9 @@ prsync - parallel rsync
 *******************
 
 
-\ **prsync**\  is a front-end to rsync for a single or range  of  nodes  and/or
-groups in parallel.
+\ **prsync**\  is a front-end to rsync for a single or range of nodes and/or groups in parallel.
 
-Note:  this command does not support the xcatd client/server communication and therefore must be run on the management node. It does not support hierarchy, use xdcp -F to run rsync from the
-management node to the compute node via a service node
+Note:  this command does not support the xcatd client/server communication and therefore must be run on the management node. It does not support hierarchy, use \ **xdcp -F**\  to run rsync from the management node to the compute node via a service node
 
 \ **prsync**\  is NOT multicast, but is parallel unicasts.
 
@@ -47,7 +45,7 @@ management node to the compute node via a service node
 
 
 
-\ *rsyncopts*\ 
+\ **-o**\  \ *rsyncopts*\ 
  
  rsync options.  See \ **rsync(1)**\ .
  
@@ -55,8 +53,7 @@ management node to the compute node via a service node
 
 \ **-f**\  \ *fanout*\ 
  
- Specifies a fanout value for the maximum number of  concur-
- rently  executing  remote shell processes.
+ Specifies a fanout value for the maximum number of concurrently executing remote shell processes.
  
 
 

--- a/docs/source/guides/admin-guides/references/man8/makeknownhosts.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/makeknownhosts.8.rst
@@ -29,7 +29,7 @@ DESCRIPTION
 ***********
 
 
-\ **makeknownhosts**\  Replaces or removes in the known_hosts file in the $ROOTHOME/.ssh directory, the enties for the nodes from the noderange input to the command.
+\ **makeknownhosts**\  Replaces or removes entries for the nodes in the known_hosts file in the $ROOTHOME/.ssh directory.
 The known_hosts file entry is built from the shared ssh host key that xCAT distributes to the installed nodes.
 
 HMCs, AMM, switches, etc., where xCAT does not distribute the shared ssh host key, should not be put in the noderange.
@@ -37,7 +37,7 @@ HMCs, AMM, switches, etc., where xCAT does not distribute the shared ssh host ke
 To build the known_hosts entry for a node, you are only required to have the node in the database, and name resolution working for the node. You do not have to be able to access the node.
 
 Having this file with correct entries, will avoid the ssh warning when nodes are automatically added to the known_hosts file.
-The file should be distributed using xdcp to all the nodes, if you want node to node communication not to display the warning.
+The file should be distributed using \ **xdcp**\  to all the nodes, if you want node to node communication not to display the warning.
 
 
 *******
@@ -49,7 +49,7 @@ OPTIONS
 \ *noderange*\ 
  
  A set of comma delimited node names and/or group names.
- See the "noderange" man page for details on supported formats.
+ See the \ *noderange*\  man page for details on supported formats.
  
 
 

--- a/xCAT-client/pods/man1/prsync.1.pod
+++ b/xCAT-client/pods/man1/prsync.1.pod
@@ -6,18 +6,16 @@ prsync - parallel rsync
 
 B<prsync> I<filename> [I<filename> I<...>] I<noderange:destinationdirectory>
 
-B<prsync>  [B<-o> I<rsync options>] [B<-f> I<fanout>] [I<filename> I<filename> I<...>] [I<directory> I<directory> I<...>]
+B<prsync>  [B<-o> I<rsyncopts>] [B<-f> I<fanout>] [I<filename> I<filename> I<...>] [I<directory> I<directory> I<...>]
 I<noderange:destinationdirectory>
 
 B<prsync> {B<-h>|B<--help>|B<-v>|B<--version>}
 
 =head1 B<Description>
 
-B<prsync> is a front-end to rsync for a single or range  of  nodes  and/or
-groups in parallel.
+B<prsync> is a front-end to rsync for a single or range of nodes and/or groups in parallel.
 
-Note:  this command does not support the xcatd client/server communication and therefore must be run on the management node. It does not support hierarchy, use xdcp -F to run rsync from the
-management node to the compute node via a service node
+Note:  this command does not support the xcatd client/server communication and therefore must be run on the management node. It does not support hierarchy, use B<xdcp -F> to run rsync from the management node to the compute node via a service node
 
 B<prsync> is NOT multicast, but is parallel unicasts.
 
@@ -25,14 +23,13 @@ B<prsync> is NOT multicast, but is parallel unicasts.
 
 =over 7
 
-=item I<rsyncopts>
+=item B<-o> I<rsyncopts>
 
 rsync options.  See B<rsync(1)>.
 
 =item B<-f> I<fanout>
 
-Specifies a fanout value for the maximum number of  concur-
-rently  executing  remote shell processes.
+Specifies a fanout value for the maximum number of concurrently executing remote shell processes.
 
 =item I<filename>
 

--- a/xCAT-client/pods/man8/makeknownhosts.8.pod
+++ b/xCAT-client/pods/man8/makeknownhosts.8.pod
@@ -10,7 +10,7 @@ B<makeknownhosts> [B<-h>|B<--help>]
 
 =head1 DESCRIPTION
 
-B<makeknownhosts> Replaces or removes in the known_hosts file in the $ROOTHOME/.ssh directory, the enties for the nodes from the noderange input to the command.
+B<makeknownhosts> Replaces or removes entries for the nodes in the known_hosts file in the $ROOTHOME/.ssh directory.
 The known_hosts file entry is built from the shared ssh host key that xCAT distributes to the installed nodes.
 
 HMCs, AMM, switches, etc., where xCAT does not distribute the shared ssh host key, should not be put in the noderange.
@@ -18,7 +18,7 @@ HMCs, AMM, switches, etc., where xCAT does not distribute the shared ssh host ke
 To build the known_hosts entry for a node, you are only required to have the node in the database, and name resolution working for the node. You do not have to be able to access the node. 
 
 Having this file with correct entries, will avoid the ssh warning when nodes are automatically added to the known_hosts file.
-The file should be distributed using xdcp to all the nodes, if you want node to node communication not to display the warning. 
+The file should be distributed using B<xdcp> to all the nodes, if you want node to node communication not to display the warning. 
 
 =head1 OPTIONS
 
@@ -27,7 +27,7 @@ The file should be distributed using xdcp to all the nodes, if you want node to 
 =item I<noderange>
 
 A set of comma delimited node names and/or group names.
-See the "noderange" man page for details on supported formats.
+See the I<noderange> man page for details on supported formats.
 
 =item B<-r|--remove>
 


### PR DESCRIPTION
1. Add Service Node instructions for controlling mounting `/install` and `/tftpboot` directories
2. Fix some wording and formatting in a few man pages