### PR TITLE
[Dev] Support rcons command for openbmc

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -294,7 +294,6 @@ sub parse_args {
 
 sub unsupported {
     my $callback = shift;
-    xCAT::SvrUtils::sendmsg("ENV: OPENBMC_DEVEL=$ENV{OPENBMC_DEVEL},$ENV{'OPENBMC_DEVEL'}\n",  $callback);
     if ($::OPENBMC_DEVEL ne "YES") {
         return ([ 1, "This function is currently not supported" ]);
     } else {

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -283,7 +283,7 @@ sub process_request {
 
     if ($request->{command}->[0] eq "getopenbmccons") {
         foreach (@donargs) {
-            configssh($_, $callback);
+            #configssh($_, $callback);
             getopenbmccons($_, $callback);
         }
         return;

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -262,17 +262,16 @@ sub process_request {
 
     foreach (@$noderange) {
         my $node     = $_;
-        my $nodeip = $node;
+        my $bmcip;
         my $nodeuser = $authdata->{$node}->{username};
         my $nodepass = $authdata->{$node}->{password};
-        my $nodeip   = $node;
         my $ent;
         if (defined($ipmitab)) {
             $ent = $ipmihash->{$node}->[0];
-            if (ref($ent) and defined $ent->{bmc}) { $nodeip = $ent->{bmc}; }
+            if (ref($ent) and defined $ent->{bmc}) { $bmcip = $ent->{bmc}; }
         }
-        push @donargs, [ $node,$nodeip,$nodeuser, $nodepass];
-        my $output = "openbmc, get $username and $password from ipmi table for $nodeip";
+        push @donargs, [ $node,$bmcip,$nodeuser, $nodepass];
+        my $output = "openbmc, get $username and $password from ipmi table for $bmcip";
         xCAT::SvrUtils::sendmsg($output, $callback, $node, %allerrornodes);
     }
 
@@ -678,7 +677,7 @@ sub rinv_response {
 sub getopenbmccons {
     my $argr = shift;
 
-    #$argr is [$node,$nodeuser,$nodepass];
+    #$argr is [$node,$bmcip,$nodeuser,$nodepass];
     my $callback = shift;
 
     my $rsp;
@@ -687,7 +686,7 @@ sub getopenbmccons {
     xCAT::SvrUtils::sendmsg($output, $callback, $argr->[0], %allerrornodes);
    
     $rsp = { node => [ { name => [ $argr->[0] ] } ] };
-    $rsp->{node}->[0]->{nodeip}->[0]    = $argr->[1];
+    $rsp->{node}->[0]->{bmcip}->[0]    = $argr->[1];
     $rsp->{node}->[0]->{username}->[0]    = $argr->[2];
     $rsp->{node}->[0]->{passwd}->[0]  = $argr->[3];
     $callback->($rsp);

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -41,6 +41,7 @@ use XML::Simple;
 use Storable qw(dclone);
 use SNMP;
 use xCAT::PasswordUtils;
+use Expect;
 
 $::OPENBMC_DEVEL = $ENV{'OPENBMC_DEVEL'};
 
@@ -282,6 +283,7 @@ sub process_request {
 
     if ($request->{command}->[0] eq "getopenbmccons") {
         foreach (@donargs) {
+            configssh($_, $callback);
             getopenbmccons($_, $callback);
         }
         return;
@@ -688,7 +690,7 @@ sub getopenbmccons {
     my $node=$argr->[0];
     my $output = "openbmc, getopenbmccoms";
     xCAT::SvrUtils::sendmsg($output, $callback, $argr->[0], %allerrornodes);
-
+   
     $rsp = { node => [ { name => [ $argr->[0] ] } ] };
     $rsp->{node}->[0]->{nodeip}->[0]    = $argr->[1];
     $rsp->{node}->[0]->{username}->[0]    = $argr->[2];
@@ -696,5 +698,104 @@ sub getopenbmccons {
     $callback->($rsp);
     return $rsp;
 }
+
+#-------------------------------------------------------
+
+=head3  configssh 
+
+    config passwordless for openbmc  
+
+=cut
+
+#-------------------------------------------------------
+sub configssh {
+    my $argr = shift;
+    my $callback = shift;
+
+    my $rsp;
+    my $node=$argr->[0];
+    my $bmcip = $argr->[1];
+    my $bmcuser = $argr->[2];
+    my $bmcpass = $argr->[3];
+    my $timeout = 10;
+
+    my $output = "openbmc, configssh ";
+    xCAT::SvrUtils::sendmsg($output, $callback, $argr->[0], %allerrornodes);
+
+    my $rootkey = `cat /root/.ssh/id_rsa.pub`;
+
+    # remove old host key from /root/.ssh/known_hosts
+    my $cmd = `ssh-keygen -R $bmcip`;
+
+    my ($exp, $errstr) = openbmc_connect($bmcip, $bmcuser, $bmcpass, $timeout);
+    if (!defined $exp) {
+        print ("connect failed $errstr\n");
+        next;
+    }
+
+    my $ret;
+    my $err;
+
+    ($ret, $err) = openbmc_exec($exp, "mkdir -p /home/root/.ssh");
+    ($ret, $err) = openbmc_exec($exp, "chmod 700 /home/root/.ssh");
+    ($ret, $err) = openbmc_exec($exp, "echo \"$rootkey\" >/home/root/.ssh/authorized_keys");
+    ($ret, $err) = openbmc_exec($exp, "chmod 644 /home/root/.ssh/authorized_keys");
+
+    $exp->hard_close();
+}
+
+sub openbmc_connect {
+     my $server   = shift;
+     my $userid   = shift;
+     my $password = shift;
+     my $timeout  = shift;
+
+     my $ssh      = Expect->new;
+     my $command     = 'ssh';
+     my @parameters  = ($userid . "@" . $server);
+
+     $ssh->debug(0);
+     $ssh->log_stdout(0);    # suppress stdout output..
+     $ssh->slave->stty(qw(sane -echo));
+
+     unless ($ssh->spawn($command, @parameters))
+     {
+         my $err = $!;
+         $ssh->soft_close();
+         my $rsp;
+         return(undef, "unable to run command $command $err\n");
+     }
+
+     $ssh->expect($timeout,
+                   [ "-re", qr/WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED/, sub {die "WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!\n"; } ],
+                   [ "-re", qr/\(yes\/no\)\?\s*$/, sub { $ssh->send("yes\n");  exp_continue; } ],
+                   [ "-re", qr/ password:/,        sub { $ssh->send("$password\n"); exp_continue; } ],
+                   [ "-re", qr/:~\#/,              sub { $ssh->clear_accum(); } ],
+                   [ timeout => sub { die "No login.\n"; } ]
+                  );
+     $ssh->clear_accum();
+     return ($ssh);
+}
+
+sub openbmc_exec {
+     my $exp = shift;
+     my $cmd = shift;
+     my $timeout    = shift;
+     my $prompt =  shift;
+
+     $timeout = 10 unless defined $timeout;
+     $prompt = qr/:~\#/ unless defined $prompt;
+
+     $exp->clear_accum();
+     $exp->send("$cmd\n");
+     my ($mpos, $merr, $mstr, $mbmatch, $mamatch) = $exp->expect(6,  "-re", $prompt);
+
+     if (defined $merr) {
+         return(undef,$merr);
+     }
+     return($mbmatch);
+}
+
+
 
 1;

--- a/xCAT-server/share/xcat/cons/openbmc
+++ b/xCAT-server/share/xcat/cons/openbmc
@@ -91,10 +91,5 @@ if ($ENV{SSHCONSOLEPORT}) {
     $sshport= $ENV{SSHCONSOLEPORT};
 }
 
-#sshpass command needs to install before can run that
-if (-x '/usr/bin/sshpass') {
-    exec "/usr/bin/sshpass -p $password ssh -p $sshport -l $username $nodeip";
-} else {
-    print "Please install sshpass first. \n";
-}
+exec "ssh -p $sshport -l $username $nodeip";
 

--- a/xCAT-server/share/xcat/cons/openbmc
+++ b/xCAT-server/share/xcat/cons/openbmc
@@ -1,0 +1,100 @@
+#!/usr/bin/env perl
+# IBM(c) 2007 EPL license http://www.eclipse.org/legal/epl-v10.html
+use Fcntl qw(:DEFAULT :flock);
+use Time::HiRes qw(sleep);
+use File::Path;
+BEGIN {
+    $::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : -d '/opt/xcat' ? '/opt/xcat' : '/usr';
+}
+my $sleepint = int(rand(10)); #Stagger start to avoid overwhelming conserver/xCATd
+my ($lockfd, $nodeip);
+my $username = 'UESRID';
+my $password = 'PASSWD';
+my $node     = $ARGV[0];
+
+use constant CONSOLE_LOCK_FILE => "/tmp/xcat/consolelock";
+use constant CONSOLE_LOCK_DIR => "/tmp/xcat";
+
+sub acquire_lock {
+    umask 0077;
+    mkpath(CONSOLE_LOCK_DIR);
+    print "Acquiring startup lock...";
+    unless (sysopen($lockfd, CONSOLE_LOCK_FILE, O_WRONLY | O_CREAT)) {
+        print "Unable to open file ".CONSOLE_LOCK_FILE."\n";
+        sleep(15);
+        exit 1;
+    }
+    unless (flock($lockfd, LOCK_EX)) {
+        print "Unable to lock file ".CONSOLE_LOCK_FILE."\n";
+        close($lockfd);
+        sleep(15);
+        exit 1;
+    }
+    print "done\n";
+    unless (syswrite($lockfd, $$, length($$))) {
+        print "Unable to write file ".CONSOLE_LOCK_FILE."\n";
+        close($lockfd);
+        sleep(15);
+        exit 1;
+    }
+}
+
+sub release_lock {
+    flock($lockfd, LOCK_UN);
+    close($lockfd);
+}
+
+
+use lib "$::XCATROOT/lib/perl";
+require xCAT::Client;
+
+sub getans {
+    my $rsp = shift;
+    if ($rsp->{node}) {
+        $nodeip = $rsp->{node}->[0]->{nodeip}->[0];
+        $username = $rsp->{node}->[0]->{username}->[0];
+        $password = $rsp->{node}->[0]->{passwd}->[0];
+        if (exists $rsp->{node}->[0]->{error}) {
+            my $error = $rsp->{node}->[0]->{error}->[0];
+            print "$error\n";
+        }
+    }
+}
+my $cmdref = {
+    command   => ["getopenbmccons"],
+    arg       => ["text"],
+    noderange => [ $ARGV[0] ]
+};
+acquire_lock();
+# avoid of congestion
+sleep(0.1);
+release_lock();
+xCAT::Client::submit_request($cmdref, \&getans);
+
+until (($username or $password) and $nodeip ) {
+    #Let other clients have a go
+    $sleepint = 10 + int(rand(20));
+    print "Console not ready, retrying in $sleepint seconds (Ctrl-e,c,o to skip delay) \n";
+    sleep ($sleepint);
+    acquire_lock();
+    sleep(0.1);
+    release_lock();
+    xCAT::Client::submit_request($cmdref, \&getans);
+}
+
+my $isintel = 0;
+my $sleepint;
+my $rc;
+ 
+my $sshport = 2200;
+if ($ENV{SSHCONSOLEPORT}) {
+    $sshport= $ENV{SSHCONSOLEPORT};
+}
+
+#sshpass command needs to install before can run that
+if (-x '/usr/bin/sshpass') {
+    exec "/usr/bin/sshpass -p $password ssh -p $sshport -l $username $nodeip";
+} else {
+    print "Please install sshpass first. \n";
+}
+

--- a/xCAT-server/share/xcat/cons/openbmc
+++ b/xCAT-server/share/xcat/cons/openbmc
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# IBM(c) 2007 EPL license http://www.eclipse.org/legal/epl-v10.html
+# IBM(c) 2017 EPL license http://www.eclipse.org/legal/epl-v10.html
 use Fcntl qw(:DEFAULT :flock);
 use Time::HiRes qw(sleep);
 use File::Path;
@@ -8,8 +8,8 @@ BEGIN {
 }
 my $sleepint = int(rand(10)); #Stagger start to avoid overwhelming conserver/xCATd
 my ($lockfd, $nodeip);
-my $username = 'UESRID';
-my $password = 'PASSWD';
+my $username = 'root';
+my $password = '0penBmc';
 my $node     = $ARGV[0];
 
 use constant CONSOLE_LOCK_FILE => "/tmp/xcat/consolelock";

--- a/xCAT-server/share/xcat/cons/openbmc
+++ b/xCAT-server/share/xcat/cons/openbmc
@@ -7,7 +7,7 @@ BEGIN {
     $::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : -d '/opt/xcat' ? '/opt/xcat' : '/usr';
 }
 my $sleepint = int(rand(10)); #Stagger start to avoid overwhelming conserver/xCATd
-my ($lockfd, $nodeip);
+my ($lockfd, $bmcip);
 my $username = 'root';
 my $password = '0penBmc';
 my $node     = $ARGV[0];
@@ -51,13 +51,14 @@ require xCAT::Client;
 sub getans {
     my $rsp = shift;
     if ($rsp->{node}) {
-        $nodeip = $rsp->{node}->[0]->{nodeip}->[0];
+        $bmcip = $rsp->{node}->[0]->{bmcip}->[0];
         $username = $rsp->{node}->[0]->{username}->[0];
         $password = $rsp->{node}->[0]->{passwd}->[0];
         if (exists $rsp->{node}->[0]->{error}) {
             my $error = $rsp->{node}->[0]->{error}->[0];
             print "$error\n";
         }
+        print "$bmcip, $username, $password\n";
     }
 }
 my $cmdref = {
@@ -71,7 +72,7 @@ sleep(0.1);
 release_lock();
 xCAT::Client::submit_request($cmdref, \&getans);
 
-until (($username or $password) and $nodeip ) {
+until (($username or $password) and $bmcip ) {
     #Let other clients have a go
     $sleepint = 10 + int(rand(20));
     print "Console not ready, retrying in $sleepint seconds (Ctrl-e,c,o to skip delay) \n";
@@ -91,5 +92,7 @@ if ($ENV{SSHCONSOLEPORT}) {
     $sshport= $ENV{SSHCONSOLEPORT};
 }
 
-exec "ssh -p $sshport -l $username $nodeip";
+print "If the console cannot connect, please verify whether ssh keys has been configured on the bmc for $username user\n";
+
+exec "ssh -p $sshport -l $username $bmcip";
 


### PR DESCRIPTION
for issue #2499 .

Create a new plugin and able to make conserver for openbmc node
1) Created openbmc node object
```
# lsdef openbmc1
Object name: openbmc1
    cons=openbmc
    groups=all,openbmc
    ip=9.3.x.x
    mgt=openbmc
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
````
2) run makeconservercf command
````
makeconservercf openbmc1
````
3) rcons to openbmc1 node
````
# rcons openbmc1
[Enter `^Ec?' for help]
Ubuntu Zesty Zapus (development branch) w33l ttyS0

w33l login:
Ubuntu Zesty Zapus (development branch) w33l ttyS0

````

**NOTE**  Passwordless ssh needs to be configured.  Need to open another issue for that.