### PR TITLE
Add pdu to object type and modify attributes in the pdu table

### DIFF
--- a/perl-xCAT/xCAT/Schema.pm
+++ b/perl-xCAT/xCAT/Schema.pm
@@ -679,12 +679,12 @@ passed as argument rather than by table value',
         },
     },
     pdu => {
-        cols => [qw(pdu machinetype modelnum serialnum outletCount comments disable)],
-        keys         => [qw(pdu)],
-        nodecol      => "pdu",
+        cols => [qw(node machinetype modelnum serialnum outletCount comments disable)],
+        keys         => [qw(node)],
+        nodecol      => "node",
         table_desc   => 'Parameters to use when interrogating pdus',
         descriptions => {
-            pdu => 'The hostname/address of the pdu to which the settings apply',
+            node => 'The hostname/address of the pdu to which the settings apply',
             machinetype => 'The pdu machine type',
             modelnum    => 'The pdu model number',
             serialnum   => 'The pdu serial number',
@@ -1840,6 +1840,7 @@ foreach my $tabname (keys(%xCAT::ExtTab::ext_tabspec)) {
     zone           => { attrs => [], attrhash => {}, objkey => 'zonename' },
     firmware       => { attrs => [], attrhash => {}, objkey => 'cfgfile' },
     taskstate      => { attrs => [], attrhash => {}, objkey => 'node' },
+    pdu            => { attrs => [], attrhash => {}, objkey => 'node' },
 
 );
 
@@ -2855,22 +2856,22 @@ my @nodeattrs = (
     {   attr_name => 'machinetype',
         only_if         => 'nodetype=pdu',
         tabentry        => 'pdu.machinetype',
-        access_tabentry => 'pdu.pdu=attr:node',
+        access_tabentry => 'pdu.node=attr:node',
     },
     { attr_name => 'modelnum',
         only_if         => 'nodetype=pdu',
         tabentry        => 'pdu.modelnum',
-        access_tabentry => 'pdu.pdu=attr:node',
+        access_tabentry => 'pdu.node=attr:node',
     },
     { attr_name => 'serialnum',
         only_if         => 'nodetype=pdu',
         tabentry        => 'pdu.serialnum',
-        access_tabentry => 'pdu.pdu=attr:node',
+        access_tabentry => 'pdu.node=attr:node',
     },
     { attr_name => 'outletcount',
         only_if         => 'nodetype=pdu',
         tabentry        => 'pdu.outletcount',
-        access_tabentry => 'pdu.pdu=attr:node',
+        access_tabentry => 'pdu.node=attr:node',
     },
 
 #########################
@@ -4074,6 +4075,46 @@ push(@{ $defspec{group}->{'attrs'} }, @nodeattrs);
         access_tabentry => 'boottarget.bprofile=attr:bprofile',
     },
   );
+
+#############################
+#  pdu object #
+#############################
+#############################
+#    pdu table #
+#############################
+@{ $defspec{pdu}->{'attrs'} } =
+  (
+    { attr_name => 'node',
+        tabentry        => 'pdu.node',
+        access_tabentry => 'pdu.node=attr:node',
+    },
+    { attr_name => 'nodetype',
+        only_if         => 'nodetype=pdu',
+        tabentry        => 'pdu.nodetype',
+        access_tabentry => 'pdu.node=attr:node',
+    },
+    {   attr_name => 'machinetype',
+        only_if         => 'nodetype=pdu',
+        tabentry        => 'pdu.machinetype',
+        access_tabentry => 'pdu.node=attr:node',
+    },
+    { attr_name => 'modelnum',
+        only_if         => 'nodetype=pdu',
+        tabentry        => 'pdu.modelnum',
+        access_tabentry => 'pdu.node=attr:node',
+    },
+    { attr_name => 'serialnum',
+        only_if         => 'nodetype=pdu',
+        tabentry        => 'pdu.serialnum',
+        access_tabentry => 'pdu.node=attr:node',
+    },
+    { attr_name => 'outletcount',
+        only_if         => 'nodetype=pdu',
+        tabentry        => 'pdu.outletcount',
+        access_tabentry => 'pdu.node=attr:node',
+    },
+);
+
 
 
 ###################################################


### PR DESCRIPTION
For issue #2513 and #2506,  Here is testing results:
```
[root@fs1 xCAT]# mkdef pdu2 groups=pdu nodetype=pdu machinetype=1u
1 object definitions have been created or modified.
[root@fs1 xCAT]# lsdef pdu2
Object name: pdu2
    groups=pdu
    machinetype=1u
    nodetype=pdu
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
[root@fs1 xCAT]# lsdef -t pdu
pdu2  (pdu)
pdu3  (pdu)
[root@fs1 xCAT]# tabdump pdu
#node,machinetype,modelnum,serialnum,outletCount,comments,disable
"pdu3","1u",,,,,
"pdu2","1u",,,,,
[root@fs1 xCAT]# noderm pdu2
[root@fs1 xCAT]# tabdump pdu
#node,machinetype,modelnum,serialnum,outletCount,comments,disable
"pdu3","1u",,,,,
[root@fs1 xCAT]# lsdef pdu2
Error: Could not find an object named 'pdu2' of type 'node'.
````
