### PR TITLE
Return error if no /usr/bin/fping is available

### DIFF
--- a/xCAT-client/bin/pping
+++ b/xCAT-client/bin/pping
@@ -162,6 +162,11 @@ sub fping_pping {
     }
     else
     {
+        if (!-x '/usr/bin/fping')
+        {
+            print "fping is not available, please install missing package fping.\n";
+            exit 1;
+        }
         open(FPING, "fping " . join(' ', @$nodes) . " 2>&1 |") or die("Cannot open fping pipe: $!");
     }
     while (<FPING>) {


### PR DESCRIPTION
Fix issue #2501 
Add checking that whether fping command is available, return error if not.