### PR TITLE
The test for "/usr/sbin/lsvpd | grep -i -E 'cpu|processor'" always

### DIFF
--- a/xCAT/postscripts/xcatdsklspost
+++ b/xCAT/postscripts/xcatdsklspost
@@ -97,10 +97,10 @@ update_VPD()
 
 # Run updatevpd only when necessary
 if [ -f /usr/sbin/lsvpd ]; then
-    /usr/sbin/lsvpd | grep -i -E 'cpu|processor' 2>&1 1>/dev/null
-    if [ "$?" = "1" ]; then
-      update_VPD
-    fi
+    BOOTTIME=$(date -R --date="$(who -b | sed 's/system boot//')")
+    BOOTTMP=$(mktemp /tmp/boottmp.XXXXXXXXXX || exit 1)
+    touch --date="$BOOTTIME" $BOOTTMP
+    test /var/lib/lsvpd/vpd.db -nt $BOOTTMP || update_VPD
 fi
 
 download_postscripts()


### PR DESCRIPTION
failed, causing all my post scripts to run vpdupdate, which
can take quite some time..

Change this test to rather check if the vpd.db has been changed
since last boot, and only rebuild it if not.