### PR TITLE
fix salve/slave typo

### DIFF
--- a/xCAT/postscripts/configbond
+++ b/xCAT/postscripts/configbond
@@ -242,7 +242,7 @@ fi
 # add bonding driver alias for <bondname>
 echo "alias $str_bond_name bonding" > /etc/modprobe.d/$str_bond_name.conf
 
-# Bring down the salve devices first
+# Bring down the slave devices first
 for slave in ${str_bond_name} ${array_bond_slaves[*]}; do
     $(ifdown $slave &>/dev/null)
 done

--- a/xCAT/postscripts/confignics
+++ b/xCAT/postscripts/confignics
@@ -236,9 +236,9 @@ fi
 #do not configure the loopback nic
 if [ $bool_remove -eq 1 ];then
     if [ "$str_os_type" = "aix" ];then
-        str_temp=`ifconfig -a | grep flags | grep -vi loopback | grep -v SALVE | grep -v MASTER | awk -F: {'print $1'}`
+        str_temp=`ifconfig -a | grep flags | grep -vi loopback | grep -v SLAVE | grep -v MASTER | awk -F: {'print $1'}`
     else
-        str_temp=`ip link show | grep -v link | grep -vi loopback | grep -v SALVE | grep -v MASTER | awk {'print $2'} | sed s/://`
+        str_temp=`ip link show | grep -v link | grep -vi loopback | grep -v SLAVE | grep -v MASTER | awk {'print $2'} | sed s/://`
     fi
     old_ifs=$IFS
     IFS=$'\n'


### PR DESCRIPTION
Fix salve/slave typo in `confignics` and `configbond` (comment) postscripts