### PR TITLE
confignics: fix regexp for Ethernet checks

### DIFF
--- a/xCAT/postscripts/confignics
+++ b/xCAT/postscripts/confignics
@@ -202,7 +202,7 @@ if [ "$str_temp" = "mac" ];then
     else
        str_inst_nic=`ip -o link | grep -i "$MACADDRESS" | awk '{print $2;}' | sed s/://` 
     fi
-elif [ `echo $str_temp | grep -E "e(n|th)[0-9a-z]+"` ];then
+elif [ `echo $str_temp | grep -E "e(n|th|m)[0-9a-zA-Z]+"` ];then
     str_inst_nic=$str_temp
 fi
 
@@ -247,7 +247,7 @@ if [ $bool_remove -eq 1 ];then
     for str_temp_nic in ${array_nics_temp[@]}
     do
         #the nic type should be ethernet
-        echo $str_temp_nic | grep -E "e(n|th)[0-9a-z]+"
+        echo $str_temp_nic | grep -E "e(n|th|m)[0-9a-zA-Z]+"
         if [ $? -ne 0 ];then
             continue
         fi


### PR DESCRIPTION
Fix regular expressions in `confignics` that checks for Ethernet interfaces.

They missed `em1`-type interfaces, and prevented `confignics -r` to remove unused `emX` interfaces.