### PR TITLE
Crypt passwd

### DIFF
--- a/docs/source/guides/admin-guides/references/man5/passwd.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/passwd.5.rst
@@ -50,13 +50,13 @@ passwd Attributes:
 
 \ **password**\ 
  
- The default password for this type of component
+ The default password for this type of component. On Linux, a crypted form could be provided. Hashes starting with $1$, $5$ and $6$ (md5, sha256 and sha512 respectively) are supported.
  
 
 
 \ **cryptmethod**\ 
  
- Indicates the method that was used to encrypt the password attribute.  On AIX systems, if a value is provided for this attribute it indicates that the password attribute is encrypted.  If the cryptmethod value is not set it indicates the password is a simple string value. On Linux systems, the cryptmethod can be set to md5, sha256 or sha512. If not set, sha256 will be used as default.
+ Indicates the method to use to encrypt the password attribute.  On AIX systems, if a value is provided for this attribute it indicates that the password attribute is encrypted.  If the cryptmethod value is not set it indicates the password is a simple string value. On Linux systems, the cryptmethod can be set to md5, sha256 or sha512. If not set, sha256 will be used as default to encrypt plain-text passwords.
  
 
 

--- a/xCAT-server/lib/perl/xCAT/PasswordUtils.pm
+++ b/xCAT-server/lib/perl/xCAT/PasswordUtils.pm
@@ -149,16 +149,21 @@ sub crypt_system_password {
             "ERROR: Unable to get password from database table $table, key=$key");
         return undef;
     }
-    $cryptmethod = $data->{'cryptmethod'};
-    if (!$cryptmethod) {
-        # Use sha256 crypt method by default
-        $result = crypt($password, $CRYPT_METHOD{'sha256'} . xCAT::Utils::genpassword(8));
-    } elsif( defined($CRYPT_METHOD{$cryptmethod})) {
-        $result = crypt($password,
-            $CRYPT_METHOD{$cryptmethod} . xCAT::Utils::genpassword(8));
+    if (($password =~ /^\$1\$/) || ($password =~ /^\$5\$/) || ($password =~ /^\$6\$/)) {
+        # $password is already hashed
+        $result = $password;
     } else {
-        xCAT::MsgUtils->message("S", "Unsupported crypt method $cryptmethod");
-        return undef;
+        $cryptmethod = $data->{'cryptmethod'};
+        if (!$cryptmethod) {
+            # Use sha256 crypt method by default
+            $result = crypt($password, $CRYPT_METHOD{'sha256'} . xCAT::Utils::genpassword(8));
+        } elsif( defined($CRYPT_METHOD{$cryptmethod})) {
+            $result = crypt($password,
+                $CRYPT_METHOD{$cryptmethod} . xCAT::Utils::genpassword(8));
+        } else {
+            xCAT::MsgUtils->message("S", "Unsupported crypt method $cryptmethod");
+            return undef;
+        }
     }
     return $result;
 }


### PR DESCRIPTION
Tentative fix for #2558 

Restore behavior from before #2168, clarified the purpose of the "cryptmethod" field, and avoid to re-crypt already crypted passwords. 