### PR TITLE
update switch definition only if -w or --setup option is specified for switchdiscover command

### DIFF
--- a/xCAT-server/lib/xcat/plugins/switchdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/switchdiscover.pm
@@ -1423,7 +1423,10 @@ sub matchPredefineSwitch {
 
         send_msg($request, 0, "Switch discovered and matched: $dswitch to $node" );
 
-        xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"otherinterfaces=$ip",'status=Matched',"mac=$mac","switchtype=$stype","usercomment=$vendor"] }, $sub_req, 0, 1);
+        # only write to xcatdb if -w or --setup option specified
+        if ( (exists($globalopt{w})) || (exists($globalopt{setup})) ) {
+            xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"otherinterfaces=$ip",'status=Matched',"mac=$mac","switchtype=$stype","usercomment=$vendor"] }, $sub_req, 0, 1);
+        }
 
         push (@{$configswitch->{$stype}}, $node);
     }


### PR DESCRIPTION
Lab service team report this issue while  they are exercising switch-based-switch discovery.  switchdiscover command updated switch definition even without -w or --setup options.   
```
# lsdef c910f05ibsw1mgt4
Object name: c910f05ibsw1mgt4
    groups=switch
    ip=192.168.5.49
    mac=7c:fe:90:2c:b8:f8
    mgt=switch
    nodetype=switch
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
    snmpauth=sha
    snmppassword=passw0rd
    snmpusername=xcatadmin1
    snmpversion=3
    status=switch_configed
    switch=switch-10-5-23-1
    switchport=46
    switchtype=Mellanox
    usercomment=Mellanox MSB7700,MLNX-OS,SWv3.4.3050
    username=admin
# switchdiscover --range 192.168.5.49 -s snmp

# lsdef c910f05ibsw1mgt4
Object name: c910f05ibsw1mgt4
    groups=switch
    ip=192.168.5.49
    mac=7c:fe:90:2c:b8:f8
    mgt=switch
    nodetype=switch
    otherinterfaces=192.168.5.49    <----------------------ADDED
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
    snmpauth=sha
    snmppassword=passw0rd
    snmpusername=xcatadmin1
    snmpversion=3
    status=Matched <-----------------------CHANGED
    switch=switch-10-5-23-1
    switchport=46
    switchtype=Mellanox
    usercomment=Mellanox MSB7700,MLNX-OS,SWv3.4.3050
    username=admin
````
otherinterfaces added and status changed in the xcatdb

