### PR TITLE
fix issue 2572 makedns fails with a noderange error

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ddns.pm
+++ b/xCAT-server/lib/xcat/plugins/ddns.pm
@@ -622,7 +622,7 @@ sub process_request {
                 } else {
 
                     # this host string might be a xcat group, try to test each node in the group
-                    foreach my $host (noderange($hosts)) {
+                    foreach my $host (xCAT::NodeRange->noderange($hosts)) {
                         unless (xCAT::NetworkUtils->thishostisnot($host)) {
                             $listenonifs = $dnsif;
                             last;


### PR DESCRIPTION
fix #2572 makedns fails with a noderange error - 'Undefined subroutine &xCAT_plugin::ddns::noderange' 