### PR TITLE
fix 2579 syncfile is in default node definition, but statelite does not support syncfiles

### DIFF
--- a/xCAT/postscripts/syncfiles
+++ b/xCAT/postscripts/syncfiles
@@ -7,6 +7,13 @@
 #
 #####################################################
 
+#statelite does not support syncfiles
+if [ -d /.statelite ]; then
+   echo "Statelite does not support syncfiles, nothing to do..."
+   logger -t xcat -p local4.info "Statelite does not support syncfiles, nothing to do..."
+   exit 0
+fi
+
 if cat /etc/os-release |grep -i -e "^NAME=[ \"']*Cumulus Linux[ \"']*$" >/dev/null 2>&1 ; then
    #TODO
    echo "Cumulus OS is not supported yet, nothing to do..."


### PR DESCRIPTION
fix #2579 syncfile is in default node definition, but statelite does not support syncfiles