### PR TITLE
Testcase for `updatenodes -S`

### DIFF
--- a/xCAT-test/autotest/testcase/updatenode/cases2
+++ b/xCAT-test/autotest/testcase/updatenode/cases2
@@ -15,6 +15,7 @@ check:rc==0
 cmd:grep 'Running of Software Maintenance has completed' /tmp/updatenode.S.out
 check:rc==0
 cmd:mv `cat /tmp/pkglist.filename`.save `cat /tmp/pkglist.filename`
+cmd:rm -f /tmp/pkglist.filename
 cmd:xdsh $$CN '(rpm -qa || dpkg -l) | grep gcc' | grep gcc
 check:rc==0
 end

--- a/xCAT-test/autotest/testcase/updatenode/cases2
+++ b/xCAT-test/autotest/testcase/updatenode/cases2
@@ -1,6 +1,18 @@
 start:updatenode_S
-check:rc==0
 cmd:updatenode $$CN -S >/tmp/updatenode.S.out
 cmd:grep 'Running of Software Maintenance has completed' /tmp/updatenode.S.out
 check:rc==0
 end 
+
+start:updatenode_S_gcc
+cmd:lsdef $$CN -i provmethod | tail -n 1 | cut -d= -f2 | xargs lsdef -t osimage -i pkglist | tail -n 1 | cut -d= -f2 >/tmp/pkglist.filename
+cmd:mv `cat /tmp/pkglist.filename` `cat /tmp/pkglist.filename`.save
+cmd:cp `cat /tmp/pkglist.filename`.save `cat /tmp/pkglist.filename`
+cmd:echo gcc >>`cat /tmp/pkglist.filename`
+cmd:updatenode $$CN -S >/tmp/updatenode.S.out
+cmd:grep 'postscript: ospkgs exited with code 0' /tmp/updatenode.S.out
+check:rc==0
+cmd:grep 'Running of Software Maintenance has completed' /tmp/updatenode.S.out
+check:rc==0
+cmd:mv `cat /tmp/pkglist.filename`.save `cat /tmp/pkglist.filename`
+end

--- a/xCAT-test/autotest/testcase/updatenode/cases2
+++ b/xCAT-test/autotest/testcase/updatenode/cases2
@@ -15,4 +15,6 @@ check:rc==0
 cmd:grep 'Running of Software Maintenance has completed' /tmp/updatenode.S.out
 check:rc==0
 cmd:mv `cat /tmp/pkglist.filename`.save `cat /tmp/pkglist.filename`
+cmd:xdsh $$CN '(rpm -qa || dpkg -l) | grep gcc' | grep gcc
+check:rc==0
 end

--- a/xCAT-test/autotest/testcase/updatenode/cases2
+++ b/xCAT-test/autotest/testcase/updatenode/cases2
@@ -1,0 +1,6 @@
+start:updatenode_S
+check:rc==0
+cmd:updatenode $$CN -S >/tmp/updatenode.S.out
+cmd:grep 'Running of Software Maintenance has completed' /tmp/updatenode.S.out
+check:rc==0
+end 


### PR DESCRIPTION
These are test cases for `updatenode -S`. The command line argument `-S` for `updatenode` is use for update the software packages on the compute node to latest version, if there is any update in the `pkglist` or `otherpkglist` or the software repository itself.