### PR TITLE
fix issue 2362: If packimage is not run, osimage in the chain table w…

### DIFF
--- a/xCAT-genesis-scripts/bin/doxcat
+++ b/xCAT-genesis-scripts/bin/doxcat
@@ -422,7 +422,11 @@ while :; do
 		logger -s -t $log_label -p local4.info "Poweroff..."
 		poweroff -f
 	else 
-		logger -s -t $log_label -p local4.err "Unrecognized directive (dest=$dest)"
+                if [ "$dest" = error ]; then
+                    logger -s -t $log_label -p local4.info "$destparameter"
+                else
+		    logger -s -t $log_label -p local4.err "Unrecognized directive (dest=$dest)"
+                fi
 		destiny=''
 		dest=''
 		delay=$((30+$RANDOM%270))

--- a/xCAT-genesis-scripts/bin/nextdestiny
+++ b/xCAT-genesis-scripts/bin/nextdestiny
@@ -7,23 +7,30 @@ echo "<xcatrequest>
 <callback_port>300</callback_port>
 </xcatrequest>" > /tmp/destreq.xml
 if [ -f /tmp/destiny.xml ]; then rm /tmp/destiny.xml; fi
-while [ ! -f /tmp/destiny.xml ] || grep error /tmp/destiny.xml; do
-	if [ -f /tmp/destiny.xml ]; then
-		timer=60
-		while [ $timer -gt 0 ]; do
-			echo -en  "Retrying in $timer seconds  \r" >&2
-			sleep 1
-			timer=$(($timer-1));
-		done
-	fi
+timer=0
+while [ ! -f /tmp/destiny.xml ]; do
+	while [ $timer -gt 0 ]; do
+		echo -en  "No destiny command received, retrying in $timer seconds  \r" >&2
+		sleep 1
+		timer=$(($timer-1));
+	done
 	echo "                                                         " >&2;
 	if [ -f /etc/xcat/cert.pem -a -f /etc/xcat/certkey.pem ]; then #use client cert if available
 		cat /tmp/destreq.xml | openssl s_client -key /etc/xcat/certkey.pem -cert /etc/xcat/cert.pem -connect $XCATDEST -quiet 2> /dev/null > /tmp/destiny.xml
 	else
 		cat /tmp/destreq.xml | openssl s_client -connect $XCATDEST -quiet 2> /dev/null > /tmp/destiny.xml
 	fi
+	timer=60
 done
 rm /tmp/destreq.xml
 DESTINY=`grep '<destiny>' /tmp/destiny.xml | awk -F'>' '{print $2}'|awk -F'<' '{print $1}'`
+if [ -z "$DESTINY" ]; then
+    ERROR=`grep '<error>' /tmp/destiny.xml | awk -F'>' '{print $2}'|awk -F'<' '{print $1}'`
+    if [ ! -z "$ERROR" ]; then
+        DESTINY="error=$ERROR"
+    else
+        DESTINY="error=No destiny command received"
+    fi
+fi
 rm /tmp/destiny.xml
 echo $DESTINY

--- a/xCAT-server/lib/xcat/plugins/destiny.pm
+++ b/xCAT-server/lib/xcat/plugins/destiny.pm
@@ -389,10 +389,7 @@ sub setdestiny {
                     ignorekernelchk => $ignorekernelchk,
                     bootparams => \$bphash}, \&relay_response);
             if ($errored) {
-                my @myself = xCAT::NetworkUtils->determinehostname();
-                my $myname = $myself[ (scalar @myself) - 1 ];
-                # The callback function point to xcatd::build_response, it use dclone to clone data, but it can only accept a reference. The error msg here is a simple string, and will cause dclone failed. Seems to be string array can be used by dclone.
-                $callback->({ errorcode => [1], error => ["Some nodes failed to set up $state resources on server $myname, aborting"] });
+                # The error messeage for mkinstall/mknetboot/mkstatelite had been output within relay_response function above, don't need to output more
                 return;
             }
 


### PR DESCRIPTION
…ill fail on netboot images
Fix issue #2362 

The modification include:

   1.  To have the xcatd return one 1 error message when checking destiny.
   2. In genesis nextdestiny script, it can return error message rather than hung to get a valid value.
   3. In doxcat, if the nextdestiny script get an error destiny, it can do it current work first, then output the error mesage or unknow destiny and output it.

The output will looks like this:
```
<166>Mar  3 04:05:13 xcat.genesis.doxcat: The destiny=runcmd, destiny parameters=date
<166>Mar  3 04:05:13 xcat.genesis.doxcat: Running nextdestiny 10.3.29.2:3001...

Fri Mar  3 04:05:15 EST 2017
<166>Mar  3 04:05:15 xcat.genesis.doxcat: nextdestiny - Complete.
<166>Mar  3 04:05:15 xcat.genesis.doxcat: The destiny=error, destiny parameters=No packed image for platform rhels7.3-GA, architecture ppc64le, and profile compute found at /install/netboot/rhels7.3-GA/ppc64le/compute/rootimg.gz or /install/netboot/rhels7.3-GA/ppc64le/compute/rootimg.sfs on fs1.pok.stglabs.ibm.com, please run packimage (e.g. packimage -o rhels7.3-GA -p compute -a ppc64le
<166>Mar  3 04:05:15 xcat.genesis.doxcat: No packed image for platform rhels7.3-GA, architecture ppc64le, and profile compute found at /install/netboot/rhels7.3-GA/ppc64le/compute/rootimg.gz or /install/netboot/rhels7.3-GA/ppc64le/compute/rootimg.sfs on fs1.pok.stglabs.ibm.com, please run packimage (e.g. packimage -o rhels7.3-GA -p compute -a ppc64le
<166>Mar  3 04:05:24 xcat.genesis.doxcat: ... Will retry xCAT in 220 seconds
```