### PR TITLE
Add instructions for when compute nodes are services and replaced

### DIFF
--- a/docs/source/advanced/cluster_maintenance/compute_node/index.rst
+++ b/docs/source/advanced/cluster_maintenance/compute_node/index.rst
@@ -5,3 +5,4 @@ Compute Node
    :maxdepth: 2
 
    changing_hostname_ip.rst 
+   replace/index.rst

--- a/docs/source/advanced/cluster_maintenance/compute_node/replace/index.rst
+++ b/docs/source/advanced/cluster_maintenance/compute_node/replace/index.rst
@@ -1,0 +1,7 @@
+Replacing Nodes
+===============
+
+.. toctree::
+   :maxdepth: 2
+
+   openpower.rst

--- a/docs/source/advanced/cluster_maintenance/compute_node/replace/openpower.rst
+++ b/docs/source/advanced/cluster_maintenance/compute_node/replace/openpower.rst
@@ -1,0 +1,38 @@
+OpenPower Nodes
+===============
+
+
+When compute nodes are physically replaced in the frame, leverage xCAT to re-discover the compute nodes.  The following guide can be used for:
+
+  * IBM OpenPower S822LC for HPC 
+
+
+#. Identify the machine(s) to be replaced: ``frame10cn02``.
+
+#. [**Optional**] It's recommended to set the BMC IP address back to DHCP, if it was set to STATIC. ::
+
+    rspconfig frame10cn02 ip=dhcp
+
+#. Set the outgoing machine to ``offline`` and remove attributes of the machine: ::
+
+    nodeset frame10cn02 offline 
+    chdef frame10cn02 mac=""
+
+#. If using **MTMS**-based discovery, fill in the Model-Type and Serial Number for the machine: ::
+
+    chdef frame10cn02 mtm=8335-GTB serial=<NEW SERIAL NUMBER>
+
+#. If using **SWITCH**-based discovery, go on to the next step. The ``switch`` and ``switch-port`` should already be set in the compute node definition. 
+
+   Node attributes will be replaced during the discovery process (mtm, serial, mac, etc.)
+
+#. Search for the new BMC in the open range: ::
+
+    bmcdiscover --range <IP open range> -w -z 
+
+#. When the BMC is found, start the discovery with the following commands: ::
+
+    rsetboot /node-8335.* net
+    rpower /node-8335.* boot 
+
+


### PR DESCRIPTION
This is to address #2414 and is only a documentation change to help document a set process. 