### PR TITLE
Make running nodeset offline optional for rmdef

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rmdef.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rmdef.1.rst
@@ -22,7 +22,7 @@ SYNOPSIS
 \ **rmdef**\  [\ **-h | -**\ **-help**\ ] [\ **-t**\  \ *object-types*\ ]
 
 \ **rmdef**\  [\ **-V | -**\ **-verbose**\ ] [\ **-a | -**\ **-all**\ ] [\ **-t**\  \ *object-types*\ ] [\ **-o**\  \ *object-names*\ ]
-[\ **-f | -**\ **-force**\ ] [\ *noderange*\ ]
+[\ **-f | -**\ **-force**\ ] [\ **-C | -**\ **-cleanup**\ ] [\ *noderange*\ ]
 
 
 ***********
@@ -41,17 +41,13 @@ OPTIONS
 
 \ **-a|-**\ **-all**\ 
  
- Clear the whole xCAT database. A backup of the xCAT definitions should be saved before using this option.  Once all the data is removed the xCAT daemon will no longer work. Most xCAT commands will fail. 
- In order to use xCAT commands again, you have two options.  You can restore your database from your backup by switching to bypass mode, and running the restorexCATdb command. 
- You switch to bypass mode by setting the XCATBYPASS environmant variable.  (ex. "export XCATBYPASS=yes") 
- A second option is to run xcatconfig -d.  This will restore the initial setup of the database as when xCAT was initially installed. 
- You can then restart xcatd and run xCAT commands.
+ Clear the whole xCAT database. A backup of the xCAT definitions should be saved before using this option. Once all the data is removed the xCAT daemon will no longer work. Most xCAT commands will fail. In order to use xCAT commands again, you have two options. You can restore your database from your backup by switching to bypass mode, and running the \ **restorexCATdb**\  command. You can switch to bypass mode by setting the XCATBYPASS environmant variable.  (ex. "export XCATBYPASS=yes") A second option is to run \ **xcatconfig -d**\ .  This will restore the initial setup of the database as when xCAT was initially installed. You can then restart xcatd and run xCAT commands.
  
 
 
 \ **-f|-**\ **-force**\ 
  
- Use this with the all option as an extra indicator that ALL definitions are to be removed.
+ Use this with the \ **-**\ **-all**\  option as an extra indicator that ALL definitions are to be removed.
  
 
 
@@ -76,6 +72,12 @@ OPTIONS
 \ **-t**\  \ *object-types*\ 
  
  A set of comma delimited object types.
+ 
+
+
+\ **-C|-**\ **-cleanup**\ 
+ 
+ Perform additional cleanup by running \ **nodeset offline**\  on the objects specified in the \ *noderange*\ .
  
 
 

--- a/docs/source/guides/admin-guides/references/man1/rmdef.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rmdef.1.rst
@@ -41,49 +41,62 @@ OPTIONS
 
 \ **-a|-**\ **-all**\ 
  
- Clear the whole xCAT database. A backup of the xCAT definitions should be saved before using this option. Once all the data is removed the xCAT daemon will no longer work. Most xCAT commands will fail. In order to use xCAT commands again, you have two options. You can restore your database from your backup by switching to bypass mode, and running the \ **restorexCATdb**\  command. You can switch to bypass mode by setting the XCATBYPASS environmant variable.  (ex. "export XCATBYPASS=yes") A second option is to run \ **xcatconfig -d**\ .  This will restore the initial setup of the database as when xCAT was initially installed. You can then restart xcatd and run xCAT commands.
+ Clear the whole xCAT database. A backup of the xCAT definitions should be saved before using this option as the xCAT daemons will no longer work once cleared.
  
-
-
-\ **-f|-**\ **-force**\ 
+ To restore:
  
- Use this with the \ **-**\ **-all**\  option as an extra indicator that ALL definitions are to be removed.
  
-
-
-\ **-h|-**\ **-help**\ 
+ 1. \ **export XCATBYPASS=1**\  and run the \ **restorexCATdb**\  command.
+  
+  or
+  
  
- Display a usage message.
  
-
-
-\ *noderange*\ 
+ 2. Run \ **xcatconfig -d**\  which initializes the database the same as when xCAT was installed.
  
- A set of comma delimited node names and/or group names. See the "noderange" man page for details on supported formats.
  
-
-
-\ **-o**\  \ *object-names*\ 
  
- A set of comma delimited object names.
+ \ **-f|-**\ **-force**\ 
+  
+  Use this with the \ **-**\ **-all**\  option as an extra indicator that ALL definitions are to be removed.
+  
  
-
-
-\ **-t**\  \ *object-types*\ 
  
- A set of comma delimited object types.
+ \ **-h|-**\ **-help**\ 
+  
+  Display a usage message.
+  
  
-
-
-\ **-C|-**\ **-cleanup**\ 
  
- Perform additional cleanup by running \ **nodeset offline**\  on the objects specified in the \ *noderange*\ .
+ \ *noderange*\ 
+  
+  A set of comma delimited node names and/or group names. See the "noderange" man page for details on supported formats.
+  
  
-
-
-\ **-V|-**\ **-verbose**\ 
  
- Verbose mode.
+ \ **-o**\  \ *object-names*\ 
+  
+  A set of comma delimited object names.
+  
+ 
+ 
+ \ **-t**\  \ *object-types*\ 
+  
+  A set of comma delimited object types.
+  
+ 
+ 
+ \ **-C|-**\ **-cleanup**\ 
+  
+  Perform additional cleanup by running \ **nodeset offline**\  on the objects specified in the \ *noderange*\ .
+  
+ 
+ 
+ \ **-V|-**\ **-verbose**\ 
+  
+  Verbose mode.
+  
+ 
  
 
 

--- a/xCAT-client/pods/man1/rmdef.1.pod
+++ b/xCAT-client/pods/man1/rmdef.1.pod
@@ -22,7 +22,17 @@ This command is used to remove xCAT object definitions that are stored in the xC
 
 =item B<-a|--all>
 
-Clear the whole xCAT database. A backup of the xCAT definitions should be saved before using this option. Once all the data is removed the xCAT daemon will no longer work. Most xCAT commands will fail. In order to use xCAT commands again, you have two options. You can restore your database from your backup by switching to bypass mode, and running the B<restorexCATdb> command. You can switch to bypass mode by setting the XCATBYPASS environmant variable.  (ex. "export XCATBYPASS=yes") A second option is to run B<xcatconfig -d>.  This will restore the initial setup of the database as when xCAT was initially installed. You can then restart xcatd and run xCAT commands.  
+Clear the whole xCAT database. A backup of the xCAT definitions should be saved before using this option as the xCAT daemons will no longer work once cleared.
+
+To restore: 
+
+=over 5
+
+=item 1. B<export XCATBYPASS=1> and run the B<restorexCATdb> command.  
+
+or 
+
+=item 2. Run B<xcatconfig -d> which initializes the database the same as when xCAT was installed. 
 
 =item B<-f|--force>
 

--- a/xCAT-client/pods/man1/rmdef.1.pod
+++ b/xCAT-client/pods/man1/rmdef.1.pod
@@ -8,7 +8,7 @@ B<rmdef> - Use this command to remove xCAT data object definitions.
 B<rmdef> [B<-h>|B<--help>] [B<-t> I<object-types>]
 
 B<rmdef> [B<-V>|B<--verbose>] [B<-a>|B<--all>] [B<-t> I<object-types>] [B<-o> I<object-names>]
-[B<-f>|B<--force>] [I<noderange>]
+[B<-f>|B<--force>] [B<-C>|B<--cleanup>] [I<noderange>]
 
 
 =head1 DESCRIPTION
@@ -22,15 +22,11 @@ This command is used to remove xCAT object definitions that are stored in the xC
 
 =item B<-a|--all>
 
-Clear the whole xCAT database. A backup of the xCAT definitions should be saved before using this option.  Once all the data is removed the xCAT daemon will no longer work. Most xCAT commands will fail. 
-In order to use xCAT commands again, you have two options.  You can restore your database from your backup by switching to bypass mode, and running the restorexCATdb command. 
-You switch to bypass mode by setting the XCATBYPASS environmant variable.  (ex. "export XCATBYPASS=yes") 
-A second option is to run xcatconfig -d.  This will restore the initial setup of the database as when xCAT was initially installed. 
-You can then restart xcatd and run xCAT commands.  
+Clear the whole xCAT database. A backup of the xCAT definitions should be saved before using this option. Once all the data is removed the xCAT daemon will no longer work. Most xCAT commands will fail. In order to use xCAT commands again, you have two options. You can restore your database from your backup by switching to bypass mode, and running the B<restorexCATdb> command. You can switch to bypass mode by setting the XCATBYPASS environmant variable.  (ex. "export XCATBYPASS=yes") A second option is to run B<xcatconfig -d>.  This will restore the initial setup of the database as when xCAT was initially installed. You can then restart xcatd and run xCAT commands.  
 
 =item B<-f|--force>
 
-Use this with the all option as an extra indicator that ALL definitions are to be removed.
+Use this with the B<--all> option as an extra indicator that ALL definitions are to be removed.
 
 =item B<-h|--help>
 
@@ -47,6 +43,10 @@ A set of comma delimited object names.
 =item B<-t> I<object-types>
 
 A set of comma delimited object types.
+
+=item B<-C|--cleanup>
+
+Perform additional cleanup by running B<nodeset offline> on the objects specified in the I<noderange>.
 
 =item B<-V|--verbose>
 

--- a/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
+++ b/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
@@ -468,6 +468,7 @@ sub processArgs
     undef $::opt_nics;
     undef $::opt_setattr;
     undef $::opt_template;
+    undef $::opt_cleanup;
 
     # parse the options - include any option from all 4 cmds
     Getopt::Long::Configure("no_pass_through");
@@ -497,6 +498,7 @@ sub processArgs
             'nics'       => \$::opt_nics,
             'u'          => \$::opt_setattr,
             'template:s' => \$::opt_template,
+            'C|cleanup'  => \$::opt_cleanup,
         )
       )
     {
@@ -509,6 +511,13 @@ sub processArgs
     if (defined($::opt_setattr) && ($::command ne "chdef") && ($::command ne "mkdef")) {
         my $rsp;
         $rsp->{data}->[0] = "Option \'-u\' can not work with $::command.";
+        xCAT::MsgUtils->message("E", $rsp, $::callback);
+        return 2;
+    }
+
+    if (defined($::opt_cleanup) && ($::command ne "rmdef")) {
+        my $rsp;
+        $rsp->{data}->[0] = "Option \'-C\' can not be used with $::command.";
         xCAT::MsgUtils->message("E", $rsp, $::callback);
         return 2;
     }
@@ -4015,6 +4024,9 @@ sub defrm
     # process the command line
     my $rc = &processArgs;
 
+    # Issue info message if more than cleanup_msg_trigger nodes are being removed with --cleanup option
+    my $cleanup_msg_trigger = 100;
+
     if ($rc != 0)
     {
 
@@ -4258,24 +4270,33 @@ sub defrm
         }
     }
 
-    # Call nodeset offline on each node to cleanup its boot configuration files from /tftpboot directory
-    if ($doreq) {
-        # Go through each object and make sure it is a node type
-        my @allnodes;
-        foreach my $single_object (keys %objhash) {
-            if ($objhash{$single_object} eq "node") {
-                # build a list of nodes to offline
-                push @allnodes, $single_object;
+    if ($::opt_cleanup) {
+        # Call nodeset offline on each node to cleanup its boot configuration files from /tftpboot directory
+        if ($doreq) {
+            # Go through each object and make sure it is a node type
+            my @allnodes;
+            foreach my $single_object (keys %objhash) {
+                if ($objhash{$single_object} eq "node") {
+                    # build a list of nodes to offline
+                    push @allnodes, $single_object;
+                }
             }
+            # If cleaning up (issuing nodeset offline) for more than cleanup_msg_trigger node, 
+            # issue info message
+            if (@allnodes > $cleanup_msg_trigger) {
+               my $rsp;
+               $rsp->{data}->[0] = "Performing configuration cleanup. This might take a some time.";
+               xCAT::MsgUtils->message("I", $rsp, $::callback);
+            }
+            # Run nodeset offline and capture output.
+            # But the output can be ignored since we do not want to prevent user from doing rmdef if
+            # nodeset returns some error.
+            my @output = xCAT::Utils->runxcmd({
+                command => ['nodeset'],
+                node => [@allnodes],
+                arg  => ['offline'],
+            }, $doreq, 0 ,1);
         }
-        # Run nodeset offline and capture output.
-        # But the output can be ignored since we do not want to prevent user from doing rmdef if
-        # nodeset returns some error.
-        my @output = xCAT::Utils->runxcmd({
-            command => ['nodeset'],
-            node => [@allnodes],
-            arg  => ['offline'],
-        }, $doreq, 0 ,1);
     }
 
     # remove the objects
@@ -4488,7 +4509,7 @@ sub defrm_usage
     $rsp->{data}->[0] = "\nUsage: rmdef - Remove xCAT data object definitions.\n";
     $rsp->{data}->[1] = "  rmdef [-h | --help ] [-t object-types]\n";
     $rsp->{data}->[2] = "  rmdef [-V | --verbose] [-t object-types] [-a | --all] [-f | --force]";
-    $rsp->{data}->[3] = "    [-o object-names] [-w attr=val,[attr=val...] [noderange]\n";
+    $rsp->{data}->[3] = "    [-o object-names] [-C | --cleanup] [noderange]\n";
     $rsp->{data}->[4] = "\nThe following data object types are supported by xCAT.\n";
     my $n = 5;
 


### PR DESCRIPTION
* Use `-C|--cleanup` option to run `nodeset offline` when removing node objects with `rmdef` command.
* Update man page
