### PR TITLE
fix hostname linux in statelite sles12.2

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/statelite/config_statelite.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/statelite/config_statelite.rst
@@ -76,6 +76,7 @@ This is the minimal list of files needed, you can add additional files to the li
     "ALL","/etc/ntp.conf","tmpfs",,
     "ALL","/etc/ntp.conf.org","tmpfs",,
     "ALL","/etc/resolv.conf","tmpfs",,
+    "ALL","/etc/hostname","tmpfs",,
     "ALL","/etc/ssh/","tmpfs",,
     "ALL","/etc/sysconfig/","tmpfs",,
     "ALL","/etc/syslog-ng/","tmpfs",,

--- a/xCAT-server/share/xcat/netboot/sles/dracut_033/xcat-prepivot.sh
+++ b/xCAT-server/share/xcat/netboot/sles/dracut_033/xcat-prepivot.sh
@@ -140,8 +140,8 @@ for lf in /tmp/dhclient.*.lease; do
     cp $lf  "$NEWROOT/var/lib/dhclient/dhclient-$netif.leases"
 done
 
-if [ -f $NEWROOT/etc/HOSTNAME ]; then 
-    echo `hostname -s` > $NEWROOT/etc/HOSTNAME
+if [ -f $NEWROOT/etc/hostname ]; then 
+    echo `hostname -s` > $NEWROOT/etc/hostname
 fi
 
 if [ ! -z "$ifname" ]; then

--- a/xCAT-server/share/xcat/netboot/sles/dracut_033/xcat-prepivot.sh
+++ b/xCAT-server/share/xcat/netboot/sles/dracut_033/xcat-prepivot.sh
@@ -134,7 +134,15 @@ function getdevfrommac() {
     done
 }
 
-echo `hostname -s` > $NEWROOT/etc/HOSTNAME
+for lf in /tmp/dhclient.*.lease; do
+    netif=${lf#*.}
+    netif=${netif%.*}
+    cp $lf  "$NEWROOT/var/lib/dhclient/dhclient-$netif.leases"
+done
+
+if [ -f $NEWROOT/etc/HOSTNAME ]; then 
+    echo `hostname -s` > $NEWROOT/etc/HOSTNAME
+fi
 
 if [ ! -z "$ifname" ]; then
     MACX=${ifname#*:}

--- a/xCAT-server/share/xcat/netboot/sles/dracut_033/xcat-prepivot.sh
+++ b/xCAT-server/share/xcat/netboot/sles/dracut_033/xcat-prepivot.sh
@@ -134,12 +134,7 @@ function getdevfrommac() {
     done
 }
 
-
-for lf in /tmp/dhclient.*.lease; do
-    netif=${lf#*.}
-    netif=${netif%.*}
-    cp $lf  "$NEWROOT/var/lib/dhclient/dhclient-$netif.leases"
-done
+echo `hostname -s` > $NEWROOT/etc/HOSTNAME
 
 if [ ! -z "$ifname" ]; then
     MACX=${ifname#*:}


### PR DESCRIPTION
In diskless we use `hostname -s` to change hostname in sles;
So add the same way to change hostname in statelite sles;

Fix issue #2616 