### PR TITLE
Handle purging block or raw VM disks when removing a VM

### DIFF
--- a/xCAT-server/lib/xcat/plugins/kvm.pm
+++ b/xCAT-server/lib/xcat/plugins/kvm.pm
@@ -1777,6 +1777,7 @@ sub rmvm {
             if ($disktype eq "cdrom") { next; }
 
             my @driver = $disk->parentNode()->findnodes("driver");
+            unless ($driver[0]) { next; }
             my $drivertype = $driver[0]->getAttribute("type");
             if (($drivertype eq "raw") || ($disktype eq "block")) { 
                 #For raw or block devices, do not remove, even if purge was specified. Log info message.
@@ -1784,6 +1785,7 @@ sub rmvm {
                 next; 
             }
             my $file = $disk->getAttribute("file");
+            unless ($file) { next; }
 
             # try to check the existence first, if cannot find, do nothing.
             # we do retry because we found sometimes the delete might fail

--- a/xCAT-server/lib/xcat/plugins/kvm.pm
+++ b/xCAT-server/lib/xcat/plugins/kvm.pm
@@ -1775,6 +1775,14 @@ sub rmvm {
         foreach $disk (@purgedisks) {
             my $disktype = $disk->parentNode()->getAttribute("device");
             if ($disktype eq "cdrom") { next; }
+
+            my @driver = $disk->parentNode()->findnodes("driver");
+            my $drivertype = $driver[0]->getAttribute("type");
+            if (($drivertype eq "raw") || ($disktype eq "block")) { 
+                #For raw or block devices, do not remove, even if purge was specified. Log info message.
+                xCAT::MsgUtils->trace(0, "i", "Not purging raw or block storage device: $disk");
+                next; 
+            }
             my $file = $disk->getAttribute("file");
 
             # try to check the existence first, if cannot find, do nothing.

--- a/xCAT-server/lib/xcat/plugins/kvm.pm
+++ b/xCAT-server/lib/xcat/plugins/kvm.pm
@@ -1785,7 +1785,10 @@ sub rmvm {
                 next; 
             }
             my $file = $disk->getAttribute("file");
-            unless ($file) { next; }
+            unless ($file) { 
+                xCAT::MsgUtils->trace(0, "w", "Not able to find 'file' attribute value for: $disk");
+                next; 
+            }
 
             # try to check the existence first, if cannot find, do nothing.
             # we do retry because we found sometimes the delete might fail


### PR DESCRIPTION
When removing a VM with a "purge" option, we try to remove the disks that were created when a VM was being created.

Normally it is a `qcaw2` file and we can easily remove it  since it was created as part of the VM creation (`vmstorage=dir:/xxx`) . However, when VM is created with `vmstorage=phy:/dev/sdx` or `vmstorage=phy:/dev/mapper/<lv-name` or `vmstorage=/xxx/yyy.img`, it is not easy to remove these physical entities because they were not created during VM creation.
Such physical devices will have `raw` or `block` attribute values. In cases like that, do not attempt to remove the device, and just log an info message into `cluster.log` file.