### PR TITLE
fix issue copycds issues when using -p path option #2630

### DIFF
--- a/xCAT-server/lib/xcat/plugins/copycds.pm
+++ b/xCAT-server/lib/xcat/plugins/copycds.pm
@@ -145,8 +145,11 @@ sub process_request {
 
             if ($path)
             {
-                $path=Cwd::realpath($path);
-                unless(substr($path,0,length("/install")) eq "/install"){
+                
+                if(-e $path) {
+                    $path=Cwd::realpath($path);
+                }
+                unless((substr($path,0,length("/install/")) eq "/install/") or ($path eq "/install")){
                     $callback->({ warning => "copycds: the specified path \"$path\" is not a subdirectory under /install. Make sure this path is configured for httpd/apache, otherwise, the provisioning with this iso will fail!" }); 
                 }
                 push @{ $newreq->{arg} }, ("-p", $path);


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/2630:
1. when $path specified with "-p" does not exist, copycds will complain 
````
Warning: copycds: the specified path "" is not a subdirectory under /install. Make sure this path is configured for httpd/apache, otherwise, the provisioning with this iso will fail!
Copying media to /install/rhels7.3/ppc64le

```` 
and copy /iso contents into default path without "-p"

2.  for ``copycds -p /installm`` , copycds should complain 
````
Warning: copycds: the specified path "" is not a subdirectory under /install. Make sure this path is configured for httpd/apache, otherwise, the provisioning with this iso will fail!
````

