### PR TITLE
(#2586) xcatd supports systemd

### DIFF
--- a/perl-xCAT/debian/postrm
+++ b/perl-xCAT/debian/postrm
@@ -21,9 +21,8 @@ set -e
 
 case "$1" in
     upgrade)
-	if [ -x /etc/init.d/xcatd ] && [ -f "/proc/cmdline" ]; then
-	    . /etc/profile.d/xcat.sh
-	    /etc/init.d/xcatd reload
+	if [ -x /usr/sbin/xcatctl ] && [ -f "/proc/cmdline" ]; then
+	    /usr/sbin/xcatctl reload
 	fi
     ;;
     purge|remove|failed-upgrade|abort-install|abort-upgrade|disappear)

--- a/perl-xCAT/perl-xCAT.spec
+++ b/perl-xCAT/perl-xCAT.spec
@@ -136,14 +136,6 @@ fi
 %endif
 
 %post
-%ifos linux
-if [ "$1" -gt 1 ]; then #Ugrade only, restart daemon and migrate settings
-   if [ -x /etc/init.d/xcatd ] && [ -f "/proc/cmdline" ]; then
-      . /etc/profile.d/xcat.sh
-   fi
-fi
-%endif
-exit 0
 
 %changelog
 * Wed May 2 2007 - Norm Nott nott@us.ibm.com

--- a/xCAT-OpenStack/debian/postinst
+++ b/xCAT-OpenStack/debian/postinst
@@ -21,9 +21,7 @@ set -e
 case "$1" in
     configure)
         if [ -f "/proc/cmdline" ];then
-            if [ -f "/opt/xcat/sbin/xcatd" ];then
-                /etc/init.d/xcatd reload
-            fi
+            [ -f "/usr/sbin/xcatctl" ] && /usr/sbin/xcatctl reload
         fi
     ;;
 

--- a/xCAT-OpenStack/xCAT-OpenStack.spec
+++ b/xCAT-OpenStack/xCAT-OpenStack.spec
@@ -87,9 +87,7 @@ rm -rf $RPM_BUILD_ROOT
 %post
 %ifos linux
   if [ -f "/proc/cmdline" ]; then   # prevent running it during install into chroot image
-    if [ -f $RPM_INSTALL_PREFIX0/sbin/xcatd  ]; then
-      /etc/init.d/xcatd restart
-    fi
+    [ -f $RPM_INSTALL_PREFIX0/sbin/xcatctl ] && $RPM_INSTALL_PREFIX0/sbin/xcatctl restart
   fi
 %endif
 exit 0

--- a/xCAT-UI/xCAT-UI.spec
+++ b/xCAT-UI/xCAT-UI.spec
@@ -184,7 +184,7 @@ ln -sf ../bin/xcatclientnnr $RPM_BUILD_ROOT%{prefix}/bin/webportal
     if [ "$1" = 1 ] || [ "$1" = 2 ]             # Install or upgrade
     then
         # Restart xCAT
-        /etc/init.d/xcatd restart
+        /usr/sbin/xcatctl restart
 
         # Copy php.ini file into /opt/xcat/ui and turn off output_buffering
         if [ -e "/etc/redhat-release" ]; then

--- a/xCAT-rmc/debian/postinst
+++ b/xCAT-rmc/debian/postinst
@@ -58,9 +58,7 @@ case "$1" in
 
       if [[ `uname -s` = "Linux" ]] ; then
          if [ -f "/proc/cmdline" ]; then   # prevent running it during install into chroot image
-           if [ -f /opt/xcat/sbin/xcatd  ]; then
-              /etc/init.d/xcatd reload
-           fi
+            [ -f "/usr/sbin/xcatctl" ] && /usr/sbin/xcatctl reload
          fi
       else
       #restart the xcatd on if xCAT or xCATsn is installed already

--- a/xCAT-rmc/xCAT-rmc.spec
+++ b/xCAT-rmc/xCAT-rmc.spec
@@ -102,9 +102,7 @@ fi
 
 %ifos linux
   if [ -f "/proc/cmdline" ]; then   # prevent running it during install into chroot image
-    if [ -f $RPM_INSTALL_PREFIX0/sbin/xcatd  ]; then
-      /etc/init.d/xcatd restart
-    fi
+      [ -f $RPM_INSTALL_PREFIX0/sbin/xcatctl ] && $RPM_INSTALL_PREFIX0/sbin/xcatctl restart
   fi
 %else
   #restart the xcatd on if xCAT or xCATsn is installed already

--- a/xCAT-server/debian/install
+++ b/xCAT-server/debian/install
@@ -27,7 +27,8 @@ lib/xcat/dsh/Context/* opt/xcat/xdsh/Context
 lib/xcat/Confluent/* opt/xcat/lib/perl/Confluent/
 
 lib/xcat/shfunctions opt/xcat/lib
-etc/init.d/xcatd etc/init.d
+etc/init.d/xcatd opt/xcat/etc/init.d/
+etc/systemd/xcatd.service opt/xcat/etc/systemd/
 xCAT-wsapi/* opt/xcat/ws/
 
 LICENSE.html opt/xcat/share/doc/packages/xCAT-server

--- a/xCAT-server/debian/postinst
+++ b/xCAT-server/debian/postinst
@@ -20,15 +20,31 @@ set -e
 
 case "$1" in
     configure)
-	. /etc/profile.d/xcat.sh
+    . /etc/profile.d/xcat.sh
+    ln -sf /opt/xcat/sbin/xcatd /usr/sbin/xcatd
+    ln -sf /opt/xcat/sbin/xcatctl /usr/sbin/xcatctl
+  
+    if [ -d "/usr/lib/systemd/system" ]; then   # Systemd
+        UNIT_PATH=/usr/lib/systemd/system
+    elif [ -d "/lib/systemd/system" ]; then
+        UNIT_PATH=/lib/systemd/system
+    fi
+
+    if [ -z "$UNIT_PATH" ]; then   # SysV init
+        ln -sf /opt/xcat/etc/init.d/xcatd /etc/init.d/xcatd
         update-rc.d xcatd defaults
-	if [ -f /tmp/xCAT-server_upgrade.tmp ]; then
-	    if [ -f "/proc/cmdline" ]; then   # prevent running it during install into chroot image
-		/etc/init.d/xcatd reload
-	    fi
-            rm /tmp/xCAT-server_upgrade.tmp
-	fi
-	ln -sf /opt/xcat/sbin/xcatd /usr/sbin/xcatd
+    else  # Systemd
+        ln -sf /opt/xcat/etc/systemd/xcatd.service $UNIT_PATH/xcatd.service
+        systemctl daemon-reload >/dev/null 2>&1
+        systemctl enable xcat.service >/dev/null 2>&1
+    fi
+        
+    if [ -f /tmp/xCAT-server_upgrade.tmp ]; then
+        if [ -f "/proc/cmdline" ]; then   # prevent running it during install into chroot image
+            [ -f /usr/sbin/xcatctl ] && /usr/sbin/xcatctl reload
+        fi
+        rm /tmp/xCAT-server_upgrade.tmp
+    fi
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/xCAT-server/debian/postrm
+++ b/xCAT-server/debian/postrm
@@ -25,10 +25,28 @@ case "$1" in
     
     remove)
        if [ -f "/proc/cmdline" ]; then   # prevent running it during install into chroot image
-             /etc/init.d/xcatd stop
+          [ -f /usr/sbin/xcatctl ] && /usr/sbin/xcatctl stop
        fi
-       update-rc.d xcatd disable
-       rm -f /usr/sbin/xcatd  #remove the symbolic
+       
+      
+       if [ -d "/usr/lib/systemd/system" ]; then   # Systemd
+          UNIT_PATH=/usr/lib/systemd/system
+       elif [ -d "/lib/systemd/system" ]; then
+          UNIT_PATH=/lib/systemd/system
+       fi
+
+       if [ -z "$UNIT_PATH" ]; then   # SysV init
+          update-rc.d xcatd disable
+          rm -f /etc/init.d/xcatd
+       else  # Systemd
+          systemctl --no-reload disable xcat.service >/dev/null 2>&1
+          rm -f $UNIT_PATH/xcatd.service
+          systemctl daemon-reload >/dev/null 2>&1
+        fi
+
+       #remove the symbolic links
+       rm -f /usr/sbin/xcatd  
+       rm -f /usr/sbin/xcatctl
 
        rm -f /etc/apache2/conf-enabled/xcat-ws.conf
     ;;

--- a/xCAT-server/etc/init.d/xcatd
+++ b/xCAT-server/etc/init.d/xcatd
@@ -15,15 +15,6 @@
 # Description: xCAT management service
 ### END INIT INFO
 
-# This avoids the perl locale warnings
-if [ -z $LC_ALL ]; then
-  export LC_ALL=C
-fi
-
-if [ -r /etc/sysconfig/xcat ]; then
-	. /etc/sysconfig/xcat
-fi
-
 RHSuccess()
 {
     success
@@ -35,36 +26,17 @@ RHFailure()
     failure
     echo
 }
-MStatus()
-{
-  PID=`cat /var/run/xcatd.pid`
-  if [ -z "$PID" ]; then
-    echo "xcatd service is not running"
-    return 3
-  fi
-  ps $PID|grep xcatd: > /dev/null 2>&1
-  if [ "$?" = "0" ]; then
-    RVAL=0
-    echo "xcatd service is running"
-  else
-    RVAL=3
-    echo "xcatd service is not running"
-  fi
-  return $RVAL
-}
 
 if [ -f /etc/init.d/functions ]; then
   #echo RH
   . /etc/init.d/functions
   START_DAEMON=daemon
-  STATUS=MStatus
   LOG_SUCCESS=RHSuccess
   LOG_FAILURE=RHFailure
   LOG_WARNING=passed
 elif [ -f /lib/lsb/init-functions ]; then
   . /lib/lsb/init-functions
   START_DAEMON=start_daemon
-  STATUS=MStatus
   LOG_SUCCESS=log_success_msg
   LOG_FAILURE=log_failure_msg
   LOG_WARNING=log_warning_msg
@@ -73,61 +45,27 @@ else
   exit 1
 fi
 
+if [ -r /etc/profile.d/xcat.sh ]; then
+       . /etc/profile.d/xcat.sh
+fi
 case $1 in
 restart)
   echo -n "Restarting xcatd "
-  if [ -r /etc/profile.d/xcat.sh ]; then
-       . /etc/profile.d/xcat.sh
-  fi
-   xcatd -p /var/run/xcatd.pid && $LOG_SUCCESS || $LOG_FAILURE
+  xcatctl restart > /dev/null && $LOG_SUCCESS || $LOG_FAILURE
   ;;
 reload)
   echo -n "Reloading xcatd "
-  if [ -r /etc/profile.d/xcat.sh ]; then
-       . /etc/profile.d/xcat.sh
-  fi
-  export XCATRELOAD=yes 
-  xcatd -p /var/run/xcatd.pid && $LOG_SUCCESS || $LOG_FAILURE
+  xcatctl reload > /dev/null && $LOG_SUCCESS || $LOG_FAILURE
   ;;
 status)
-  $STATUS
+  xcatctl status
   ;;
 stop)
   echo -n "Stopping xcatd "
-  $STATUS > /dev/null 2>&1
-  if [ "$?" != "0" ]; then
-    echo -n "xcatd not running, not stopping "
-    $LOG_WARNING
-    echo
-    exit 0
-  fi
-  kill -TERM `cat /var/run/xcatd.pid`
-  i=0;
-  while $STATUS > /dev/null 2>&1 && [ $i -lt 30 ]; do
-    sleep .1
-    i=$((i+1))
-  done
-  $STATUS > /dev/null 2>&1
-
-  if [ "$?" = "0" ]; then
-    kill -KILL -`cat /var/run/xcatd.pid`
-    i=0
-    while $STATUS > /dev/null 2>&1 && [ $i -lt 30 ]; do
-      sleep .1
-      i=$((i+1))
-    done
-  fi
-
-  $STATUS > /dev/null 2>&1
-  if [ "$?" = "0" ]; then
-    $LOG_FAILURE
-    exit 0
-  fi
-  rm /var/run/xcatd.pid
-  $LOG_SUCCESS
+  xcatctl stop > /dev/null && $LOG_SUCCESS || $LOG_FAILURE
   ;;
 start)
-  $STATUS > /dev/null 2>&1
+  xcatctl status >/dev/null 2>&1
   if [ "$?" = "0" ]; then
     echo -n "xcatd already running "
     $LOG_WARNING
@@ -135,22 +73,6 @@ start)
     exit
   fi
   echo -n "Starting xcatd "
-  #/var/run/ is a symlink on /run and that's just a tmpfs mount created on boot on ubuntu. 
-  #if there is not this directory, create first 
-  if [ ! -d /var/run/xcat ];then
-    mkdir -p /var/run/xcat
-  fi
-  #xcatroot=`head -n1 /etc/profile.d/xcat.sh`
-  #export $xcatroot
-  # When this script is invoked via the service cmd on RH, it doesn't have PATH
-  # set either, so we run our profile entry to get everything set up properly.
-  if [ -r /etc/profile.d/xcat.sh ]; then
-	. /etc/profile.d/xcat.sh
-  fi
-  xcatd -p /var/run/xcatd.pid && $LOG_SUCCESS || $LOG_FAILURE
+  xcatctl start > /dev/null && $LOG_SUCCESS || $LOG_FAILURE
   ;;
 esac
-
-
-
-

--- a/xCAT-server/etc/systemd/xcatd.service
+++ b/xCAT-server/etc/systemd/xcatd.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=xCAT management service
+After=network.target syslog.service
+
+[Service]
+EnvironmentFile=-/etc/sysconfig/xcat
+Type=forking
+PIDFile=/var/run/xcatd.pid
+ExecStart=/usr/sbin/xcatctl start
+ExecStop=/usr/sbin/xcatctl stop
+ExecReload=/bin/sh -c "echo Not support reload action in systemd, run \'xcatctl reload\' instead.; exit -1"
+
+[Install]
+WantedBy=multi-user.target

--- a/xCAT-server/lib/xcat/plugins/imgport.pm
+++ b/xCAT-server/lib/xcat/plugins/imgport.pm
@@ -1973,7 +1973,7 @@ sub make_files {
     if ($hasplugin) {
 
         # Issue xcatd reload to load the new plugins
-        system("/etc/init.d/xcatd restart");
+        system("/usr/sbin/xcatctl restart");
         $hasplugin = 0;
     }
 

--- a/xCAT-server/sbin/xcatctl
+++ b/xCAT-server/sbin/xcatctl
@@ -1,0 +1,130 @@
+#!/bin/sh
+# IBM(c) 2007 EPL license http://www.eclipse.org/legal/epl-v10.html
+#(C)IBM Corp
+#
+###################################################################
+#
+# Description:
+#     This internal routine controls the xcatd daemon (Linux Only). 
+#
+# Syntax:
+#       xcatctl start|stop|restart|reload|status
+#
+###################################################################
+
+if [ -z "$1" ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  echo "$0 start|stop|restart|reload|status"
+  exit
+fi
+
+ACTION="$1"
+OS_TYPE=`uname -s | tr 'A-Z' 'a-z'`
+if [ "$OS_TYPE" != "linux" ];then
+  # TODO, to support AIX later
+  echo "Error: This command should only be run on Linux."
+  exit -1
+fi
+
+# This avoids the perl locale warnings
+if [ -z $LC_ALL ]; then
+  export LC_ALL=C
+fi
+
+if [ -r /etc/sysconfig/xcat ]; then
+  . /etc/sysconfig/xcat
+fi
+if [ -r /etc/profile.d/xcat.sh ]; then
+  . /etc/profile.d/xcat.sh
+fi
+
+if [ -z $XCATROOT ]; then
+  echo "Error: Environment variable XCATROOT is not set."
+  exit -1
+fi
+
+XCATdStatus()
+{
+  PID=`cat /var/run/xcatd.pid 2>/dev/null`
+  if [ ! -z "$PID" ]; then
+    kill -0 $PID 2>/dev/null && ps $PID | grep xcatd: > /dev/null 2>&1
+    if [ "$?" = "0" ]; then
+      return
+    fi
+  fi
+  return 3
+}
+
+# Main
+case $ACTION in
+status)
+  XCATdStatus
+  if [ "$?" != "0" ]; then
+    echo "xcatd service is not running "
+    exit -1
+  fi
+  echo "xcatd service is running "
+  ;;
+
+restart)
+  exec xcatd -p /var/run/xcatd.pid
+  ;;
+
+reload)
+  export XCATRELOAD=yes
+  exec xcatd -p /var/run/xcatd.pid
+  ;;
+
+stop)
+  XCATdStatus
+  if [ "$?" != "0" ]; then
+    echo "xcatd is not running, not stopping "
+    exit
+  fi
+
+  kill -TERM `cat /var/run/xcatd.pid` > /dev/null 2>&1
+  i=0;
+  while XCATdStatus && [ $i -lt 30 ]; do
+    sleep .1
+    i=$((i+1))
+  done
+
+  XCATdStatus
+  if [ "$?" = "0" ]; then
+    kill -KILL -`cat /var/run/xcatd.pid` > /dev/null 2>&1
+    i=0
+    while XCATdStatus && [ $i -lt 30 ]; do
+      sleep .1
+      i=$((i+1))
+    done
+  fi
+
+  XCATdStatus
+  if [ "$?" = "0" ]; then
+    # daemon is still running, return with error.
+    exit 99
+  fi
+
+  rm -f /var/run/xcatd.pid 2>/dev/null
+  ;;
+
+start)
+  XCATdStatus
+  if [ "$?" = "0" ]; then
+    echo "xcatd already running "
+    exit
+  fi
+  #/var/run/ is a symlink on /run and that's just a tmpfs mount created on boot on ubuntu.
+  #if there is not this directory, create first
+  if [ ! -d /var/run/xcat ];then
+    mkdir -p /var/run/xcat
+  fi
+
+  exec xcatd -p /var/run/xcatd.pid
+  ;;
+
+*)
+  echo "Not supported action "
+  exit -1
+  ;;
+
+esac

--- a/xCAT-vlan/xCAT-vlan.spec
+++ b/xCAT-vlan/xCAT-vlan.spec
@@ -78,9 +78,7 @@ rm -rf $RPM_BUILD_ROOT
 %post
 %ifos linux
   if [ -f "/proc/cmdline" ]; then   # prevent running it during install into chroot image
-    if [ -f $RPM_INSTALL_PREFIX0/sbin/xcatd  ]; then
-      /etc/init.d/xcatd reload
-    fi
+     [ -f $RPM_INSTALL_PREFIX0/sbin/xcatctl ] &&  $RPM_INSTALL_PREFIX0/sbin/xcatctl reload
   fi
 %else
   #restart the xcatd on if xCAT or xCATsn is installed already

--- a/xCATsn/debian/postinst
+++ b/xCATsn/debian/postinst
@@ -57,7 +57,7 @@ case "$1" in
       update-rc.d $apachedaemon enable
 
       if [ -f "/proc/cmdline" ]; then   # prevent running it during install into chroot image
-       	 XCATROOT=/opt/xcat /etc/init.d/xcatd start
+       	 XCATROOT=/opt/xcat $XCATROOT/sbin/xcatctl start
  	 /etc/init.d/$apachedaemon reload 
       fi
       echo "xCATsn is now installed"

--- a/xCATsn/xCATsn.spec
+++ b/xCATsn/xCATsn.spec
@@ -211,7 +211,7 @@ fi
 [ -e "/etc/init.d/$apachedaemon" ] && chkconfig $apachedaemon on
 [ -e "/usr/lib/systemd/system/$apacheserviceunit" ] && systemctl enable $apacheserviceunit
 if [ -f "/proc/cmdline" ]; then   # prevent running it during install into chroot image
-          XCATROOT=$RPM_INSTALL_PREFIX0 /etc/init.d/xcatd restart
+          XCATROOT=$RPM_INSTALL_PREFIX0 $RPM_INSTALL_PREFIX0/sbin/xcatctl restart
           [ -e "/etc/init.d/$apachedaemon" ] && /etc/init.d/$apachedaemon reload
           [ -e "/usr/lib/systemd/system/$apacheserviceunit" ] && systemctl reload $apacheserviceunit
 fi


### PR DESCRIPTION
Resolves issue #2586
1, Using xcatctl to control the xcatd daemon, and the unit file just
leverage this routine.
2, xcatd reload action will create a new Process, the behaviour is not
supported in systemd fork mode
3, Modify the related spec/debian files for above changes; and it should
cover the upgrade case from no systemd unit version