### PR TITLE
fix issue 2657 makehosts erroneously deletes entries from /etc/hosts

### DIFF
--- a/xCAT-server/lib/xcat/plugins/hosts.pm
+++ b/xCAT-server/lib/xcat/plugins/hosts.pm
@@ -74,7 +74,7 @@ sub addnode
     {
 
         if ($hosts[$idx] =~ /^${ip}\s/
-            or $hosts[$idx] =~ /^\d+\.\d+\.\d+\.\d+\s+${node}[\s\.r]/)
+            or $hosts[$idx] =~ /^\d+\.\d+\.\d+\.\d+\s+${node}[\s\.\r]/)
         {
             if ($foundone)
             {


### PR DESCRIPTION
fix #2657 makehosts erroneously deletes entries from /etc/hosts

typo error.
