### PR TITLE
fix issue [DEV] Install xcat on ubuntu14.4.4+ppc64le by go-xcat show "Restarting xcatd ERROR:". That is why Diskless_installation_flat_p8_le always fail and stay on powering_on

### DIFF
--- a/xCAT-server/lib/xcat/plugins/AAsn.pm
+++ b/xCAT-server/lib/xcat/plugins/AAsn.pm
@@ -1279,7 +1279,7 @@ sub setup_HTTP
 #-----------------------------------------------------------------------------
 sub stop_TFTP
 {
-    my $distro;
+    my $distro=xCAT::Utils->osver();
     # Check whether the tftp-hpa has been installed, the ubuntu tftpd-hpa configure file is under /etc/default
     unless (-x "/usr/sbin/in.tftpd" and (-e "/etc/xinetd.d/tftp" or -e "/etc/default/tftpd-hpa")) {
         xCAT::MsgUtils->message("S", "ERROR: The tftpd was not installed, enable the tftp failed.");


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/2668#issuecomment-287673025