### PR TITLE
Scaffold in framework for openbmc functionality

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-## IBM(c) 2007 EPL license http://www.eclipse.org/legal/epl-v10.html
+## IBM(c) 2017 EPL license http://www.eclipse.org/legal/epl-v10.html
 
 package xCAT_plugin::openbmc;
 
@@ -58,12 +58,10 @@ sub handled_commands {
         rspreset       => 'nodehm:mgt',
         rbeacon        => 'nodehm:mgt',
         renergy        => 'nodehm:mgt',
-        rscan          => 'nodehm:mgt',
-        ripmi          => 'ipmi',
-        getrvidparms   => 'nodehm:mgt',
     };
 }
 
+my $http_protocol="https";
 my $openbmc_url = "/org/openbmc";
 my $openbmc_project_url = "/xyz/openbmc_project";
 #-------------------------------------------------------
@@ -245,7 +243,7 @@ sub process_request {
 
     foreach my $node (keys %node_info) {
         $bmcip = $node_info{$node}{bmc};
-        $login_url = "https://$bmcip/login";
+        $login_url = "$http_protocol://$bmcip/login";
         $content = '{"data": [ "' . $node_info{$node}{username} .'", "' . $node_info{$node}{password} . '" ] }';
         $handle_id = xCAT::OPENBMC->new($async, $login_url, $content); 
         $handle_id_node{$handle_id} = $node;
@@ -464,7 +462,7 @@ sub gen_send_request {
     } else {
         $request_url = $status_info{ $node_info{$node}{cur_status} }{init_url};
     }
-    $request_url = "https://" . $node_info{$node}{bmc} . $request_url;
+    $request_url = "$http_protocol://" . $node_info{$node}{bmc} . $request_url;
 
     my $handle_id = xCAT::OPENBMC->send_request($async, $method, $request_url, $content);
     $handle_id_node{$handle_id} = $node;

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -273,11 +273,7 @@ sub process_request {
 sub parse_args {
     my $command  = shift;
     my $extrargs = shift;
-
-    my $check = unsupported($callback);
-    if (ref($check) eq "ARRAY") {
-        return $check;
-    }
+    my $check = undef;
 
     if (scalar(@ARGV) > 1) {
         return ([ 1, "Only one option is supported at the same time" ]);
@@ -285,6 +281,12 @@ sub parse_args {
 
     my $subcommand = $ARGV[0];
     if ($command eq "rpower") {
+        #
+        # disable function until fully tested 
+        #
+        $check = unsupported($callback);
+        if (ref($check) eq "ARRAY") { return $check; }
+
         if (!defined($extrargs)) {
             return ([ 1, "No option specified for rpower" ]);
         }
@@ -294,6 +296,13 @@ sub parse_args {
     }
 
     if ($command eq "rinv") {
+        #
+        # disable function until fully tested 
+        #
+        $check = unsupported($callback);
+        if (ref($check) eq "ARRAY") { return $check; }
+
+
         unless ($subcommand =~ /^cpu$|^dimm$|^bios$|^all$/) {
             return ([ 1, "Only 'cpu','dimm', 'bios','all' are supported currently" ]);
         }

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -24,6 +24,18 @@ use JSON;
 
 $::OPENBMC_DEVEL = $ENV{'OPENBMC_DEVEL'};
 
+
+sub unsupported {
+    my $callback = shift;
+    if (defined($::OPENBMC_DEVEL) && ($::OPENBMC_DEVEL eq "YES")) {
+        xCAT::SvrUtils::sendmsg("Warning: Currently running development code, use at your own risk.  Unset OPENBMC_DEVEL and `restartxcatd` to disable.\n",  $callback);
+        return;
+    } else {
+        return ([ 1, "This openbmc related function is unsupported and disabled. To bypass, run the following: \n\texport OPENBMC_DEVEL=YES\n\trestartxcatd" ]);
+    }
+}
+
+
 #-------------------------------------------------------
 
 =head3  handled_commands
@@ -289,17 +301,6 @@ sub parse_args {
     }
 
     return;
-}
-
-
-sub unsupported {
-    my $callback = shift;
-    if ($::OPENBMC_DEVEL ne "YES") {
-        return ([ 1, "This function is currently not supported\nTo enable development code, run the following commands:\n\nexport OPENBMC_DEVEL=YES\nrestartxcatd" ]);
-    } else {
-        xCAT::SvrUtils::sendmsg("Warning: Currently running development code, use at your own risk\n",  $callback);
-        return;
-    }
 }
 
 #-------------------------------------------------------

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -28,7 +28,7 @@ $::OPENBMC_DEVEL = $ENV{'OPENBMC_DEVEL'};
 sub unsupported {
     my $callback = shift;
     if (defined($::OPENBMC_DEVEL) && ($::OPENBMC_DEVEL eq "YES")) {
-        xCAT::SvrUtils::sendmsg("Warning: Currently running development code, use at your own risk.  Unset OPENBMC_DEVEL and `restartxcatd` to disable.\n",  $callback);
+        xCAT::SvrUtils::sendmsg("Warning: Currently running development code, use at your own risk.  Unset OPENBMC_DEVEL and `restartxcatd` to disable.",  $callback);
         return;
     } else {
         return ([ 1, "This openbmc related function is unsupported and disabled. To bypass, run the following: \n\texport OPENBMC_DEVEL=YES\n\trestartxcatd" ]);
@@ -64,7 +64,8 @@ sub handled_commands {
     };
 }
 
-my $pre_url = "/org/openbmc";
+my $openbmc_url = "/org/openbmc";
+my $openbmc_project_url = "/xyz/openbmc_project";
 #-------------------------------------------------------
 
 # The hash table to store method and url for request, 
@@ -82,7 +83,7 @@ my %status_info = (
 
     RPOWER_ON_REQUEST  => {
         method         => "PUT",
-        init_url       => "/xyz/openbmc_project/state/host0/attr/RequestedHostTransition",
+        init_url       => "$openbmc_project_url/state/host0/attr/RequestedHostTransition",
         data           => "xyz.openbmc_project.State.Host.Transition.On",
     },
     RPOWER_ON_RESPONSE => {
@@ -90,7 +91,7 @@ my %status_info = (
     },
     RPOWER_OFF_REQUEST  => {
         method         => "PUT",
-        init_url       => "/xyz/openbmc_project/state/host0/attr/RequestedHostTransition",
+        init_url       => "$openbmc_project_url/state/host0/attr/RequestedHostTransition",
         data           => "xyz.openbmc_project.State.Host.Transition.Off",
     },
     RPOWER_OFF_RESPONSE => {
@@ -98,7 +99,7 @@ my %status_info = (
     },
     RPOWER_RESET_REQUEST  => {
         method         => "PUT",
-        init_url       => "/xyz/openbmc_project/state/host0/attr/RequestedHostTransition",
+        init_url       => "$openbmc_project_url/state/host0/attr/RequestedHostTransition",
         data           => "xyz.openbmc_project.State.Host.Transition.Reboot",
     },
     RPOWER_RESET_RESPONSE => {
@@ -106,7 +107,7 @@ my %status_info = (
     },
     RPOWER_STATUS_REQUEST  => {
         method         => "GET",
-        init_url       => "/xyz/openbmc_project/state/host0",
+        init_url       => "$openbmc_project_url/state/host0",
     },
     RPOWER_STATUS_RESPONSE => {
         process        => \&rpower_response,
@@ -114,7 +115,7 @@ my %status_info = (
 
     RINV_REQUEST => {
         method         => "GET",
-        init_url       => "$pre_url/inventory/enumerate",
+        init_url       => "$openbmc_url/inventory/enumerate",
     },
     RINV_RESPONSE => {
         process        => \&rinv_response,

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -50,6 +50,17 @@ sub handled_commands {
         rpower => 'nodehm:mgt',
         rinv   => 'nodehm:mgt',
         getopenbmccons => 'nodehm:cons',
+        rsetboot       => 'nodehm:mgt',
+        rspconfig      => 'nodehm:mgt',
+        rvitals        => 'nodehm:mgt',
+        rflash         => 'nodehm:mgt',
+        reventlog      => 'nodehm:mgt',
+        rspreset       => 'nodehm:mgt',
+        rbeacon        => 'nodehm:mgt',
+        renergy        => 'nodehm:mgt',
+        rscan          => 'nodehm:mgt',
+        ripmi          => 'ipmi',
+        getrvidparms   => 'nodehm:mgt',
     };
 }
 
@@ -284,8 +295,7 @@ sub parse_args {
         #
         # disable function until fully tested 
         #
-        $check = unsupported($callback);
-        if (ref($check) eq "ARRAY") { return $check; }
+        $check = unsupported($callback); if (ref($check) eq "ARRAY") { return $check; }
 
         if (!defined($extrargs)) {
             return ([ 1, "No option specified for rpower" ]);
@@ -293,19 +303,18 @@ sub parse_args {
         unless ($subcommand =~ /^on$|^off$|^reset$|^boot$|^status$|^stat$|^state$/) {
             return ([ 1, "$subcommand is not supported for rpower" ]);
         }
-    }
-
-    if ($command eq "rinv") {
+    } elsif ($command eq "rinv") {
         #
         # disable function until fully tested 
         #
-        $check = unsupported($callback);
-        if (ref($check) eq "ARRAY") { return $check; }
+        $check = unsupported($callback); if (ref($check) eq "ARRAY") { return $check; }
 
 
         unless ($subcommand =~ /^cpu$|^dimm$|^bios$|^all$/) {
             return ([ 1, "Only 'cpu','dimm', 'bios','all' are supported currently" ]);
         }
+    } else {
+        return ([ 1, "Command is not supported." ]);
     }
 
     return;

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -279,16 +279,15 @@ sub parse_args {
         return $check;
     }
 
-    if (!defined($extrargs)) {
-        return ([ 1, "No option specified for rpower" ]);
-    }
-
     if (scalar(@ARGV) > 1) {
         return ([ 1, "Only one option is supported at the same time" ]);
     }
 
     my $subcommand = $ARGV[0];
     if ($command eq "rpower") {
+        if (!defined($extrargs)) {
+            return ([ 1, "No option specified for rpower" ]);
+        }
         unless ($subcommand =~ /^on$|^off$|^reset$|^boot$|^status$|^stat$|^state$/) {
             return ([ 1, "$subcommand is not supported for rpower" ]);
         }


### PR DESCRIPTION
This pull request partially addresses #2663 and attempts to start adding in some scaffold in the framework for the various commands that should be supported with the new openbmc management protocol.  The functions will be disabled and controlled mostly by the OPENBMC_DEVEL environment variable, even when set to YES, will still disable certain calls if it's not implemented yet. 


* b045fe79f0813cfd9b208ba91eda6903d3eb6096 - by moving unsupported calls, we enable rcons without OPENBMC_DEVEL=YES.  We want to allow users to call this function. 

* b831595b70f02b52946fefeecf12327a0d2a04e7 Identifies some function we should support based on ipmi.pm and returns unsupported
   ```
   [root@fs2vm105 opt]# rvitals openbmc1
   Error: Command is not supported.
   [root@fs2vm105 opt]# rbeacon openbmc1 on 
   Error: Command is not supported.
   ```