### PR TITLE
Preserve the user ownership of the file for xdcp command

### DIFF
--- a/docs/source/advanced/security/security.rst
+++ b/docs/source/advanced/security/security.rst
@@ -14,29 +14,30 @@ Commands Access Control
 
 Except SSL channel, xCAT only authorize root on the management node to run **xCAT** commands by default. But xCAT can be configured to allow both **non-root users** and **remote users** to run limited xCAT commands. For remote users, we mean the users who triggers the xCAT commands from other nodes and not have to login to the management node. xCAT uses the **policy** table to control who has authority to run specific xCAT commands. For a full explanation of the **policy** table, refer to :doc:`policy </guides/admin-guides/references/man5/policy.5>` man page. 
 
+.. _granting_xcat_privileges:
 
 Granting Users xCAT Privileges
 ``````````````````````````````
 
-To give a non-root user all xCAT commands privileges, run ``tabedit policy`` and add a line: ::
+To give a non-root user all xCAT command privileges, run ``tabedit policy`` and add a line: ::
 
     "6","<username>",,,,,,"allow",,
 
-Where <username> is the name of the user that you are granting privileges to. In the above case, this user can now perform all xCAT commands, including changing the ``policy`` table to grant right to other users, so this should be used with caution.
+Where <username> is the name of the user that you are granting privileges to. This user can now perform all xCAT commands, including changing the ``policy`` table to grant rights to other users, so this should be used with caution.
 
-You may only want to grant users limited access. One example is that one user may only be allowed to run ``nodels``. This can be done as follows: ::
+To grant a user ability to run ``nodels`` command: ::
 
     "6","<username>",,"nodels",,,,"allow",,
 
-If you want to grant all users the ability to run nodels, add this line:  ::
+To grant all users the ability to run ``nodels``:  ::
 
     "6.1","*",,"nodels",,,,"allow",,
 
-You also can do this by running: ::
+CLI can also be used: ::
 
     chdef -t policy -o 6.1 name=* commands=nodels rule=allow
 
-**Note** Make sure the directories that contain the xCAT commands are in the user's ``$PATH``. If not, add them to ``$PATH`` as appropriate way in your system. ::
+**Note** Make sure the directories that contain the xCAT commands are in the user's ``$PATH``. If not, add them to ``$PATH`` as appropriate in your system. ::
 
     echo $PATH | grep xcat
     /opt/xcat/bin:/opt/xcat/sbin: ....... 
@@ -44,18 +45,18 @@ You also can do this by running: ::
 Extra Setup for Remote Commands
 ```````````````````````````````
 
-To give a user the ability to run remote commands (xdsh, xdcp, psh, pcp) in some node, except above steps, also need to run below steps:  ::
+To give a user the ability to run remote commands (``xdsh``, ``xdcp``, ``psh``, ``pcp``) in some node, in addition to above steps, also need to run below steps:  ::
   
     su - <username>
     xdsh <noderange> -K
 
-This will setup the user and root ssh keys for the user under the ``$HOME/.ssh`` directory of the user on the nodes. The root ssh keys are needed for the user to run the xCAT commands under the xcatd daemon, where the user will be running as root. **Note**: the uid for the user should match the uid on the management node and a password for the user must have been set on the nodes. 
+This will setup the user and root ssh keys for the user under the ``$HOME/.ssh`` directory of the user on the nodes. The root ssh keys are needed for the user to run the xCAT commands under the xcatd daemon, where the user will be running as root. **Note**: the uid and the password for the user on the management node, should match the uid and password on the managed nodes. 
 
 
 Set Up Login Node (Remote Client)
 `````````````````````````````````
 
-In some cases, you don't want your **non-root** user login to management node but still can run some xCAT commands. This time, you need setup a login node(i.e. remote client) for these users.
+In some cases, you don't want your **non-root** user login to management node but still can run some xCAT commands. This time, you need setup a login node (i.e. remote client) for these users.
 
 Below are the steps of how to set up a login node.
 
@@ -65,9 +66,9 @@ Below are the steps of how to set up a login node.
 
   * :doc:`Configure xCAT Software Repository in RHEL</guides/install-guides/yum/configure_xcat>`
 
-  * `Configure the Base OS Repository in SUSE <http://xcat-docs.readthedocs.org/en/latest/guides/install-guides/zypper/prepare_mgmt_node.html#configure-the-base-os-repository>`_
+  * :ref:`Configure the Base OS Repository in SUSE <zypper_configure_the_base_os_repository>`
  
-  * `Configure the Base OS Repository in Ubuntu <http://xcat-docs.readthedocs.org/en/latest/guides/install-guides/apt/prepare_mgmt_node.html#configure-the-base-os-repository>`_
+  * :ref:`Configure the Base OS Repository in Ubuntu <apt_configure_the_base_os_repository>`
 
 
   Then install ``xCAT-client``.

--- a/docs/source/guides/admin-guides/manage_clusters/common/parallel_cmd.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/parallel_cmd.rst
@@ -25,11 +25,11 @@ Examples for xdsh
 
     xdsh node1 -K
 
-- To run the ps -ef command on node targets node1 and node2, enter: ::
+- To run the ``ps -ef`` command on node targets node1 and node2, enter: ::
 
     xdsh node1,node2 "ps -ef"
 
-- To run the ps command on node targets node1 and run the remote command with the -v and -t flag, enter: ::
+- To run the ``ps`` command on node targets node1 and run the remote command with the ``-v`` and ``-t`` flag, enter: ::
 
     xdsh node1,node2 -o"-v -t" ps =item *
 
@@ -37,15 +37,15 @@ Examples for xdsh
 
     xdsh node1,node2 -f 1 -e myfile
 
-- To run the ps command on node1 and ignore all the dsh environment variable except the DSH_NODE_OPTS, enter: ::
+- To run the ``ps`` command on node1 and ignore all the dsh environment variable except the DSH_NODE_OPTS, enter: ::
 
     xdsh node1 -X `DSH_NODE_OPTS' ps
 
-- To run on Linux, the xdsh command "dpkg | grep vim" on the node ubuntu diskless image, enter: ::
+- To run on Linux, the ``xdsh`` command ``dpkg -l| grep vim`` on the node ubuntu diskless image, enter: ::
 
     xdsh -i /install/netboot/ubuntu14.04.2/ppc64el/compute/rootimg "dpkg -l|grep vim"
 
-- To run xdsh with the non-root userid "user1" that has been setup as an xCAT userid and with sudo on node1 and node2 to run as root, do the following, see xCAT doc on Granting_Users_xCAT_privileges: ::
+- To run ``xdsh`` with the non-root userid "user1" that has been setup as an xCAT userid and with sudo on node1 and node2 to run as root, do the following, see :ref:`Granting users xCAT privileges <granting_xcat_privileges>`: ::
 
     xdsh node1,node2 --sudo -l user1 "cat /etc/passwd"
 
@@ -70,7 +70,7 @@ Examples for xdcp
 
     xdcp all /etc/hosts /etc/hosts
 
-- To rsync the /etc/hosts file to your compute nodes:
+- To ``rsync`` the /etc/hosts file to your compute nodes:
 
   Create a rsync file /tmp/myrsync, with this line: ::
 
@@ -84,7 +84,7 @@ Examples for xdcp
 
    xdcp compute -F /tmp/myrsync
 
-- To rsync the /etc/file1 and file2 to your compute nodes and rename to filex and filey:
+- To ``rsync`` the /etc/file1 and file2 to your compute nodes and rename to filex and filey:
 
   Create a rsync file /tmp/myrsync, with these line: ::
 
@@ -96,7 +96,7 @@ Examples for xdcp
 
    xdcp compute -F /tmp/myrsync to update the Compute Nodes
 
-- To rsync files in the Linux image at /install/netboot/ubuntu14.04.2/ppc64el/compute/rootimg on the MN:
+- To ``rsync`` files in the Linux image at /install/netboot/ubuntu14.04.2/ppc64el/compute/rootimg on the MN:
 
   Create a rsync file /tmp/myrsync, with this line: ::
 

--- a/docs/source/guides/install-guides/apt/prepare_mgmt_node.rst
+++ b/docs/source/guides/install-guides/apt/prepare_mgmt_node.rst
@@ -10,6 +10,8 @@ Install an OS on the Management Node
   :start-after: BEGIN_install_os_mgmt_node
   :end-before: END_install_os_mgmt_node
 
+.. _apt_configure_the_base_os_repository:
+
 Configure the Base OS Repository
 --------------------------------
 

--- a/docs/source/guides/install-guides/zypper/prepare_mgmt_node.rst
+++ b/docs/source/guides/install-guides/zypper/prepare_mgmt_node.rst
@@ -10,6 +10,8 @@ Install an OS on the Management Node
    :start-after: BEGIN_install_os_mgmt_node
    :end-before: END_install_os_mgmt_node
 
+.. _zypper_configure_the_base_os_repository:
+
 Configure the Base OS Repository
 --------------------------------
 

--- a/perl-xCAT/xCAT/DSHCLI.pm
+++ b/perl-xCAT/xCAT/DSHCLI.pm
@@ -4434,6 +4434,17 @@ sub parse_and_run_dcp
         return 0;
     }
 
+    unless ($options{'user'})
+    {
+            # user was not specified with -l flag, check it user calling the command
+            # was saved in DSH_FROM_USERID environment variable
+            my $current_userid = $ENV{'DSH_FROM_USERID'};
+            if (defined($current_userid)) {
+                # Set userid from value in DSH_FROM_USERID environment variable
+                $options{'user'} = $current_userid;
+            }
+    }
+
     if (defined($options{'rootimg'}))
     {
         if (xCAT::Utils->isAIX())

--- a/xCAT-client/bin/xdsh
+++ b/xCAT-client/bin/xdsh
@@ -666,6 +666,24 @@ sub parse_args_xdcp
         $::NODE_RCP = 1;
     }
 
+    # find out who is the current user running xdcp
+    my $current_userid = getpwuid($>);
+
+    $ENV{DSH_FROM_USERID} = $current_userid;
+
+    my $to_userid;
+    if ($options{'user'})    # if -l option
+    {
+        $to_userid = $options{'user'};
+    }
+    else
+    {
+        $to_userid = $current_userid;
+    }
+    # Save userid running this command in ENV variable.
+    # It will be later extraced by DSHCLI.pm
+    $ENV{DSH_TO_USERID} = $to_userid;
+
     if ($options{'bypass'})
     {
         $ENV{XCATBYPASS} = "yes";    # bypass xcatd

--- a/xCAT-client/bin/xdsh
+++ b/xCAT-client/bin/xdsh
@@ -666,11 +666,6 @@ sub parse_args_xdcp
         $::NODE_RCP = 1;
     }
 
-    # find out who is the current user running xdcp
-    my $current_userid = getpwuid($>);
-
-    $ENV{DSH_FROM_USERID} = $current_userid;
-
     my $to_userid;
     if ($options{'user'})    # if -l option
     {
@@ -678,6 +673,11 @@ sub parse_args_xdcp
     }
     else
     {
+        # find out who is the current user running xdcp
+        my $current_userid = getpwuid($>);
+
+        $ENV{DSH_FROM_USERID} = $current_userid;
+
         $to_userid = $current_userid;
     }
     # Save userid running this command in ENV variable.


### PR DESCRIPTION
Resolves Issue #1001  Use the same logic for `xdcp` as `xdsh -K` uses to save the userid of the user running the command.
The userid is saved in `DSH_FROM_USERID` environment variable by `xCAT-client/bin/xdsh`. Later it is extracted by  `perl-xCAT/xCAT/DSHCLI.pm` from that environment variable. 
It is not possible to determine the userid using `getpwuid()` inside `perl-xCAT/xCAT/DSHCLI.pm` directly, because it runs under `root`.

Also fix links, formatting and grammar in related doc pages.