### PR TITLE
ADD support for power reset of PDU outlet

### DIFF
--- a/docs/source/advanced/pdu/pdu.rst
+++ b/docs/source/advanced/pdu/pdu.rst
@@ -63,6 +63,12 @@ The following commands are supported against a compute node:
          cn01: f5pdu3 outlet 6 is on
          cn01: f5pdu3 outlet 7 is on
 
+   * Power cycling the PDU outlets on a compute node: :: 
+   
+       # rpower cn01 pdureset
+         cn01: f5pdu3 outlet 6 is on
+         cn01: f5pdu3 outlet 7 is on
+
 The following commands are supported against a PDU: 
 
    * Check the status of the full PDU: ::
@@ -98,8 +104,24 @@ The following commands are supported against a PDU:
          f5pdu3: outlet 12 is off
 
    * Power on the full PDU: ::
-   
+
        # rpower f5pdu3 on
+         f5pdu3: outlet 1 is on
+         f5pdu3: outlet 2 is on
+         f5pdu3: outlet 3 is on
+         f5pdu3: outlet 4 is on
+         f5pdu3: outlet 5 is on
+         f5pdu3: outlet 6 is on
+         f5pdu3: outlet 7 is on
+         f5pdu3: outlet 8 is on
+         f5pdu3: outlet 9 is on
+         f5pdu3: outlet 10 is on
+         f5pdu3: outlet 11 is on
+         f5pdu3: outlet 12 is on
+
+   * Power reset the full PDU: ::
+   
+       # rpower f5pdu3 reset
          f5pdu3: outlet 1 is on
          f5pdu3: outlet 2 is on
          f5pdu3: outlet 3 is on

--- a/docs/source/advanced/pdu/pdu.rst
+++ b/docs/source/advanced/pdu/pdu.rst
@@ -66,8 +66,8 @@ The following commands are supported against a compute node:
    * Power cycling the PDU outlets on a compute node: :: 
    
        # rpower cn01 pdureset
-         cn01: f5pdu3 outlet 6 is on
-         cn01: f5pdu3 outlet 7 is on
+         cn01: f5pdu3 outlet 6 is reset 
+         cn01: f5pdu3 outlet 7 is reset
 
 The following commands are supported against a PDU: 
 
@@ -122,18 +122,18 @@ The following commands are supported against a PDU:
    * Power reset the full PDU: ::
    
        # rpower f5pdu3 reset
-         f5pdu3: outlet 1 is on
-         f5pdu3: outlet 2 is on
-         f5pdu3: outlet 3 is on
-         f5pdu3: outlet 4 is on
-         f5pdu3: outlet 5 is on
-         f5pdu3: outlet 6 is on
-         f5pdu3: outlet 7 is on
-         f5pdu3: outlet 8 is on
-         f5pdu3: outlet 9 is on
-         f5pdu3: outlet 10 is on
-         f5pdu3: outlet 11 is on
-         f5pdu3: outlet 12 is on
+         f5pdu3: outlet 1 is reset
+         f5pdu3: outlet 2 is reset
+         f5pdu3: outlet 3 is reset
+         f5pdu3: outlet 4 is reset
+         f5pdu3: outlet 5 is reset
+         f5pdu3: outlet 6 is reset
+         f5pdu3: outlet 7 is reset
+         f5pdu3: outlet 8 is reset
+         f5pdu3: outlet 9 is reset
+         f5pdu3: outlet 10 is reset
+         f5pdu3: outlet 11 is reset
+         f5pdu3: outlet 12 is reset
    
    
 **Note:** For BMC based compute nodes, turning the PDU outlet power on does not automatically power on the compute side.  Users will need to issue ``rpower <node> on`` to power on the compute node after the BMC boots. 

--- a/docs/source/guides/admin-guides/references/man1/rpower.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rpower.1.rst
@@ -29,7 +29,7 @@ BMC (using IPMI) specific:
 
 \ **rpower**\  \ *noderange*\  [\ **on | off | softoff | reset | boot | stat | state | status | wake | suspend**\  [\ **-w**\  \ *timeout*\ ] [\ **-o**\ ] [\ **-r**\ ]]
 
-\ **rpower**\  \ *noderange*\  [\ **pduon | pduoff | pdustat**\ ]
+\ **rpower**\  \ *noderange*\  [\ **pduon | pduoff | pdustat | pdureset**\ ]
 
 
 OpenBMC specific:
@@ -115,7 +115,7 @@ pdu specific:
 =============
 
 
-\ **rpower**\  \ *noderange*\  [\ **stat | off | on**\ ]
+\ **rpower**\  \ *noderange*\  [\ **stat | off | on | reset**\ ]
 
 
 

--- a/docs/source/guides/admin-guides/references/man5/nodehm.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/nodehm.5.rst
@@ -50,7 +50,7 @@ nodehm Attributes:
 
 \ **mgt**\ 
  
- The method to use to do general hardware management of the node.  This attribute is used as the default if power or getmac is not set.  Valid values: ipmi, blade, hmc, ivm, fsp, bpa, kvm, esx, rhevm.  See the power attribute for more details.
+ The method to use to do general hardware management of the node.  This attribute is used as the default if power or getmac is not set.  Valid values: openbmc, ipmi, blade, hmc, ivm, fsp, bpa, kvm, esx, rhevm.  See the power attribute for more details.
  
 
 

--- a/docs/source/guides/admin-guides/references/man5/openbmc.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/openbmc.5.rst
@@ -1,0 +1,82 @@
+
+#########
+openbmc.5
+#########
+
+.. highlight:: perl
+
+
+****
+NAME
+****
+
+
+\ **openbmc**\  - a table in the xCAT database.
+
+
+********
+SYNOPSIS
+********
+
+
+\ **openbmc Attributes:**\   \ *node*\ , \ *bmc*\ , \ *username*\ , \ *password*\ , \ *comments*\ , \ *disable*\ 
+
+
+***********
+DESCRIPTION
+***********
+
+
+Setting for nodes that are controlled by an on-board OpenBmc.
+
+
+*******************
+openbmc Attributes:
+*******************
+
+
+
+\ **node**\ 
+ 
+ The node name or group name.
+ 
+
+
+\ **bmc**\ 
+ 
+ The hostname of the BMC adapter.
+ 
+
+
+\ **username**\ 
+ 
+ The BMC userid.
+ 
+
+
+\ **password**\ 
+ 
+ The BMC password.
+ 
+
+
+\ **comments**\ 
+ 
+ Any user-written notes.
+ 
+
+
+\ **disable**\ 
+ 
+ Set to 'yes' or '1' to comment out this row.
+ 
+
+
+
+********
+SEE ALSO
+********
+
+
+\ **nodels(1)**\ , \ **chtab(8)**\ , \ **tabdump(8)**\ , \ **tabedit(8)**\ 
+

--- a/docs/source/guides/admin-guides/references/man5/passwd.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/passwd.5.rst
@@ -50,13 +50,13 @@ passwd Attributes:
 
 \ **password**\ 
  
- The default password for this type of component
+ The default password for this type of component. On Linux, a crypted form could be provided. Hashes starting with $1$, $5$ and $6$ (md5, sha256 and sha512 respectively) are supported.
  
 
 
 \ **cryptmethod**\ 
  
- Indicates the method that was used to encrypt the password attribute.  On AIX systems, if a value is provided for this attribute it indicates that the password attribute is encrypted.  If the cryptmethod value is not set it indicates the password is a simple string value. On Linux systems, the cryptmethod can be set to md5, sha256 or sha512. If not set, sha256 will be used as default.
+ Indicates the method to use to encrypt the password attribute.  On AIX systems, if a value is provided for this attribute it indicates that the password attribute is encrypted.  If the cryptmethod value is not set it indicates the password is a simple string value. On Linux systems, the cryptmethod can be set to md5, sha256 or sha512. If not set, sha256 will be used as default to encrypt plain-text passwords.
  
 
 

--- a/docs/source/guides/admin-guides/references/man5/xcatdb.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/xcatdb.5.rst
@@ -565,6 +565,12 @@ notification(5)|notification.5
  
 
 
+openbmc(5)|openbmc.5
+ 
+ Setting for nodes that are controlled by an on-board OpenBmc.
+ 
+
+
 osdistro(5)|osdistro.5
  
  Information about all the OS distros in the xCAT cluster

--- a/docs/source/guides/admin-guides/references/man7/group.7.rst
+++ b/docs/source/guides/admin-guides/references/man7/group.7.rst
@@ -57,15 +57,23 @@ group Attributes:
  
 
 
-\ **bmc**\  (ipmi.bmc)
+\ **bmc**\  (ipmi.bmc, openbmc.bmc)
+ 
+ The hostname of the BMC adapter.
+ 
+ or
  
  The hostname of the BMC adapter.
  
 
 
-\ **bmcpassword**\  (ipmi.password)
+\ **bmcpassword**\  (ipmi.password, openbmc.password)
  
  The BMC password.  If not specified, the key=ipmi row in the passwd table is used as the default.
+ 
+ or
+ 
+ The BMC password.
  
 
 
@@ -115,9 +123,13 @@ group Attributes:
  
 
 
-\ **bmcusername**\  (ipmi.username)
+\ **bmcusername**\  (ipmi.username, openbmc.username)
  
  The BMC userid.  If not specified, the key=ipmi row in the passwd table is used as the default.
+ 
+ or
+ 
+ The BMC userid.
  
 
 
@@ -461,7 +473,7 @@ group Attributes:
 
 \ **mgt**\  (nodehm.mgt)
  
- The method to use to do general hardware management of the node.  This attribute is used as the default if power or getmac is not set.  Valid values: ipmi, blade, hmc, ivm, fsp, bpa, kvm, esx, rhevm.  See the power attribute for more details.
+ The method to use to do general hardware management of the node.  This attribute is used as the default if power or getmac is not set.  Valid values: openbmc, ipmi, blade, hmc, ivm, fsp, bpa, kvm, esx, rhevm.  See the power attribute for more details.
  
 
 

--- a/docs/source/guides/admin-guides/references/man7/node.7.rst
+++ b/docs/source/guides/admin-guides/references/man7/node.7.rst
@@ -69,15 +69,23 @@ node Attributes:
  
 
 
-\ **bmc**\  (ipmi.bmc)
+\ **bmc**\  (ipmi.bmc, openbmc.bmc)
+ 
+ The hostname of the BMC adapter.
+ 
+ or
  
  The hostname of the BMC adapter.
  
 
 
-\ **bmcpassword**\  (ipmi.password)
+\ **bmcpassword**\  (ipmi.password, openbmc.password)
  
  The BMC password.  If not specified, the key=ipmi row in the passwd table is used as the default.
+ 
+ or
+ 
+ The BMC password.
  
 
 
@@ -127,9 +135,13 @@ node Attributes:
  
 
 
-\ **bmcusername**\  (ipmi.username)
+\ **bmcusername**\  (ipmi.username, openbmc.username)
  
  The BMC userid.  If not specified, the key=ipmi row in the passwd table is used as the default.
+ 
+ or
+ 
+ The BMC userid.
  
 
 
@@ -461,7 +473,7 @@ node Attributes:
 
 \ **mgt**\  (nodehm.mgt)
  
- The method to use to do general hardware management of the node.  This attribute is used as the default if power or getmac is not set.  Valid values: ipmi, blade, hmc, ivm, fsp, bpa, kvm, esx, rhevm.  See the power attribute for more details.
+ The method to use to do general hardware management of the node.  This attribute is used as the default if power or getmac is not set.  Valid values: openbmc, ipmi, blade, hmc, ivm, fsp, bpa, kvm, esx, rhevm.  See the power attribute for more details.
  
 
 

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -53,8 +53,8 @@ my %usage = (
      docker specific:
        rpower noderange [start|stop|restart|pause|unpause|state]
      pdu specific:
-       rpower noderange [off|on|stat]
-       rpower noderange [pduoff|pduon|pdustat]
+       rpower noderange [off|on|stat|status|reset]
+       rpower noderange [pduoff|pduon|pdustat|pdustatus|pdureset]
 ",
     "rbeacon" =>
       "Usage: rbeacon <noderange> [on|off|stat] [-V|--verbose]

--- a/xCAT-client/pods/man1/rpower.1.pod
+++ b/xCAT-client/pods/man1/rpower.1.pod
@@ -12,7 +12,7 @@ B<rpower> [B<-h>|B<--help>|B<-v>|B<--version>]
 
 B<rpower> I<noderange> [B<on>|B<off>|B<softoff>|B<reset>|B<boot>|B<stat>|B<state>|B<status>|B<wake>|B<suspend> [B<-w> I<timeout>] [B<-o>] [B<-r>]] 
 
-B<rpower> I<noderange> [B<pduon>|B<pduoff>|B<pdustat>]
+B<rpower> I<noderange> [B<pduon>|B<pduoff>|B<pdustat>|B<pdureset>]
 
 =head2 OpenBMC specific:
 
@@ -62,7 +62,7 @@ B<rpower> I<noderange> [B<start>|B<stop>|B<restart>|B<pause>|B<unpause>|B<state>
 
 =head2 pdu specific:
 
-B<rpower> I<noderange> [B<stat>|B<off>|B<on>]
+B<rpower> I<noderange> [B<stat>|B<off>|B<on>|B<reset>]
 
 =head1 DESCRIPTION
 

--- a/xCAT-server/lib/perl/xCAT/PPC.pm
+++ b/xCAT-server/lib/perl/xCAT/PPC.pm
@@ -235,7 +235,7 @@ sub process_command {
         if ($command eq 'rpower') { $subcommand = $request->{op}; }
 
         #pdu commands will be handled in the pdu plugin
-        if(($subcommand eq 'pduoff') || ($subcommand eq 'pduon') || ($subcommand eq 'pdustat')){
+        if(($subcommand eq 'pduoff') || ($subcommand eq 'pduon') || ($subcommand eq 'pdustat') || ($subcommand eq 'pdureset')){
              return 0;
         }
 

--- a/xCAT-server/lib/xcat/plugins/blade.pm
+++ b/xCAT-server/lib/xcat/plugins/blade.pm
@@ -4401,7 +4401,7 @@ sub process_request {
     else { $moreinfo = build_more_info($noderange, $callback); }
 
     #pdu commands will be handled in the pdu plugin
-    if ($command eq "rpower" and grep(/^pduon|pduoff|pdustat$/, @exargs)) {
+    if ($command eq "rpower" and grep(/^pduon|pduoff|pdureset|pdustat$/, @exargs)) {
         return;
     }
 

--- a/xCAT-server/lib/xcat/plugins/esx.pm
+++ b/xCAT-server/lib/xcat/plugins/esx.pm
@@ -407,7 +407,7 @@ sub process_request {
     }
 
     #pdu commands will be handled in the pdu plugin
-    if ($command eq "rpower" and grep(/^pduon|pduoff|pdustat$/, @exargs)) {
+    if ($command eq "rpower" and grep(/^pduon|pduoff|pdureset|pdustat$/, @exargs)) {
         return;
     }
     #my $sitetab = xCAT::Table->new('site');

--- a/xCAT-server/lib/xcat/plugins/hpblade.pm
+++ b/xCAT-server/lib/xcat/plugins/hpblade.pm
@@ -647,7 +647,7 @@ sub process_request {
     else { $moreinfo = build_more_info($noderange, $callback); }
 
     #pdu commands will be handled in the pdu plugin
-    if ($command eq "rpower" and grep(/^pduon|pduoff|pdustat$/, @exargs)) {
+    if ($command eq "rpower" and grep(/^pduon|pduoff|pdureset|pdustat$/, @exargs)) {
         return;
     }
 

--- a/xCAT-server/lib/xcat/plugins/hpilo.pm
+++ b/xCAT-server/lib/xcat/plugins/hpilo.pm
@@ -362,7 +362,7 @@ sub process_request {
     }
 
     #pdu commands will be handled in the pdu plugin
-    if (($extrargs->[0] eq 'pdustat') || ($extrargs->[0] eq 'pduon') || ($extrargs->[0] eq 'pduoff')) {
+    if (($extrargs->[0] eq 'pdustat') || ($extrargs->[0] eq 'pdureset') || ($extrargs->[0] eq 'pduon') || ($extrargs->[0] eq 'pduoff')) {
         return;
     }
 

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -7682,7 +7682,7 @@ sub preprocess_request {
         }
 
         #pdu commands will be handled in the pdu plugin
-        if(($subcmd eq 'pduoff') || ($subcmd eq 'pduon') || ($subcmd eq 'pdustat')){
+        if(($subcmd eq 'pduoff') || ($subcmd eq 'pduon') || ($subcmd eq 'pdustat') || ($subcmd eq 'pdureset')){
              return 0;
         }
 

--- a/xCAT-server/lib/xcat/plugins/kvm.pm
+++ b/xCAT-server/lib/xcat/plugins/kvm.pm
@@ -3675,7 +3675,7 @@ sub process_request {
     }
 
     #pdu commands will be handled in the pdu plugin
-    if ($command eq "rpower" and grep(/^pduon|pduoff|pdustat$/, @exargs)) {
+    if ($command eq "rpower" and grep(/^pduon|pduoff|pdureset|pdustat$/, @exargs)) {
         return;
     }
 

--- a/xCAT-server/lib/xcat/plugins/pdu.pm
+++ b/xCAT-server/lib/xcat/plugins/pdu.pm
@@ -140,7 +140,7 @@ sub process_request
         return powerstat($noderange, $callback);
     }elsif ($command eq "rpower") {
         my $subcmd = $exargs[0];
-        if (($subcmd eq 'pduoff') || ($subcmd eq 'pduon') || ($subcmd eq 'pdustat')){
+        if (($subcmd eq 'pduoff') || ($subcmd eq 'pduon') || ($subcmd eq 'pdustat')|| ($subcmd eq 'pdureset') ){
             #if one day, pdu node have pdu attribute, handle in this section too
             return powerpduoutlet($noderange, $subcmd, $callback);
         } else {
@@ -160,7 +160,7 @@ sub process_request
                 }
             }
             if(@allpdunodes) {
-                if(($subcmd eq 'on') || ($subcmd eq 'off') || ($subcmd eq 'stat') || ($subcmd eq 'state')){
+                if(($subcmd eq 'on') || ($subcmd eq 'off') || ($subcmd eq 'stat') || ($subcmd eq 'state') || ($subcmd eq 'reset') ){
                     return powerpdu(\@allpdunodes, $subcmd, $callback);
                 } else {
                     my $pdunode = join (",", @allpdunodes);
@@ -232,9 +232,12 @@ sub powerpdu {
         if ($subcmd eq "off") {
             $value = 0;
             $statstr = "off";
-        } else {
+        } elsif ( $subcmd eq "on") {
             $value = 1;
             $statstr = "on";
+        } else  {
+            $value = 2;
+            $statstr = "reset";
         }
 
         for (my $outlet =1; $outlet <= $count; $outlet++)
@@ -303,6 +306,10 @@ sub powerpduoutlet {
             } elsif ($subcmd eq "pduon") {
                 $value = 1;
                 $statstr = "on";
+                outletpower($session, $outlet, $value);
+            } elsif ($subcmd eq "pdureset") {
+                $value = 2;
+                $statstr = "reset";
                 outletpower($session, $outlet, $value);
             } else {
                 $callback->({ error => "$subcmd is not support"});

--- a/xCAT-server/lib/xcat/plugins/rhevm.pm
+++ b/xCAT-server/lib/xcat/plugins/rhevm.pm
@@ -127,7 +127,7 @@ sub preprocess_request {
     }
 
     #pdu commands will be handled in the pdu plugin
-    if (($extraargs->[0] eq 'pdustat') || ($extraargs->[0] eq 'pduon') || ($extraargs->[0] eq 'pduoff')) {
+    if (($extraargs->[0] eq 'pdustat') || ($extraargs->[0] eq 'pdureset') || ($extraargs->[0] eq 'pduon') || ($extraargs->[0] eq 'pduoff')) {
         return;
     }
 

--- a/xCAT-server/lib/xcat/plugins/xen.pm
+++ b/xCAT-server/lib/xcat/plugins/xen.pm
@@ -706,7 +706,7 @@ sub process_request {
     }
 
      #pdu commands will be handled in the pdu plugin
-     if ($command eq "rpower" and grep(/^pduon|pduoff|pdustat$/, @exargs)) {
+     if ($command eq "rpower" and grep(/^pduon|pduoff|pdureset|pdustat$/, @exargs)) {
          return;
      }
      

--- a/xCAT-server/lib/xcat/plugins/zvm.pm
+++ b/xCAT-server/lib/xcat/plugins/zvm.pm
@@ -2319,7 +2319,7 @@ sub powerVM {
     my $out;
     
     ##pdu commands will be handled in the pdu plugin
-    if ($args->[0] eq 'pduon' || $args->[0] eq 'pduoff' || $args->[0] eq 'pdustat') {
+    if ($args->[0] eq 'pduon' || $args->[0] eq 'pdureset' || $args->[0] eq 'pduoff' || $args->[0] eq 'pdustat') {
         return;
     }
 


### PR DESCRIPTION
Add new commands for reset PDU/outlet

```
# rpower f5pdu3 reset
f5pdu3: outlet 1 is reset
f5pdu3: outlet 2 is reset
f5pdu3: outlet 3 is reset
f5pdu3: outlet 4 is reset
f5pdu3: outlet 5 is reset
f5pdu3: outlet 6 is reset
f5pdu3: outlet 7 is reset
f5pdu3: outlet 8 is reset
f5pdu3: outlet 9 is reset
f5pdu3: outlet 10 is reset
f5pdu3: outlet 11 is reset
f5pdu3: outlet 12 is reset

# rpower frame45cn02 pdureset
frame45cn02: f5pdu3 outlet 6 is reset
frame45cn02: f5pdu3 outlet 7 is reset

````

