### PR TITLE
Node boot status=failed if postscripts failed

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/post.xcat
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat
@@ -180,6 +180,7 @@ echo "
 
 # global value to store the running status of the postbootscripts,the value is non-zero if one postbootscript failed
 return_value=0
+
 # subroutine used to run postscripts
 # \$1 argument is the script type
 # rest argument is the script name and arguments
@@ -227,9 +228,27 @@ run_ps () {
         return_value=-1
     fi
 
+    #save bad return code to /opt/xcat/xcatinfo
+    if [ \"\$return_value\" -ne \"0\" ]; then
+        grep 'POSTSCRIPTS_RC' /opt/xcat/xcatinfo > /dev/null 2>&1
+        if [ \$? -eq 0 ]; then
+            sed -i \"s/POSTSCRIPTS_RC=.*/POSTSCRIPTS_RC=1/\" /opt/xcat/xcatinfo
+        else
+            echo \"POSTSCRIPTS_RC=1\" >> /opt/xcat/xcatinfo
+        fi
+    fi
+
     return 0
 }
 # subroutine end
+
+#retrieve bad return code from /opt/xcat/xcatinfo if any
+if [ -f /opt/xcat/xcatinfo ]; then
+    grep 'POSTSCRIPTS_RC' /opt/xcat/xcatinfo
+    if [ \$? -eq 0 ]; then
+        return_value=1;
+    fi
+fi
 
 " >> /xcatpost/mypostscript
 echo "$TMP" >> /xcatpost/mypostscript


### PR DESCRIPTION
this for issue #2665 .  If one of postscripts failed, it will echo ````POSTSCRIPTS_RC=1```` to the ````/opt/xcat/xcatinfo```` file,  after postbootscripts completed, will check this file, if  ````POSTSCRIPTS_RC```` defined, will report bad return code and change node boot status=failed 

define a postscript and postbootscripts as issue#2665
```
# cat /install/postscripts/custom/rh73_post_test/compute.postscript
#/bin/bash
set -x; export PS4='+(`basename ${BASH_SOURCE}`:${LINENO}):';
echo "failing postscript"
exit 1

# cat /install/postscripts/custom/rh73_post_test/compute.postbootscript
#/bin/bash
set -x; export PS4='+(`basename ${BASH_SOURCE}`:${LINENO}):';
exit 0
`````
Add two postscripts to the diskfull images
```
# lsdef -t osimage sles12.2-ppc64le-install-computeObject name: sles12.2-ppc64le-install-compute
    imagetype=linux
    osarch=ppc64le
    osdistroname=sles12.2-ppc64le
    osname=Linux
    osvers=sles12.2
    otherpkgdir=/install/post/otherpkgs/sles12.2/ppc64le
    pkgdir=/install/sles12.2/ppc64le
    pkglist=/opt/xcat/share/xcat/install/sles/compute.sles12.pkglist
    postbootscripts=custom/rh73_post_test/compute.postbootscript
    postscripts=custom/rh73_post_test/compute.postscript
    profile=compute
    provmethod=install
    template=/opt/xcat/share/xcat/install/sles/compute.sles12.ppc64le.tmpl
`````
After provison the node, the status will showed as failed
````
# lsdef fs2vm111 -i status
Object name: fs2vm111
    status=failed
````

the bad return code will be stored at /opt/xcat/xcat/info
````
fs2vm111:~ # cat /opt/xcat/xcatinfo
XCATSERVER=10.3.31.101
INSTALLDIR=/install
POSTSCRIPTS_RC=1
REBOOT=TRUE
NODE=fs2vm111
USEFLOWCONTROL=NO
````




