### PR TITLE
dodiscovery: add a fallback for getting MTM from DMI

### DIFF
--- a/xCAT-genesis-scripts/bin/dodiscovery
+++ b/xCAT-genesis-scripts/bin/dodiscovery
@@ -76,6 +76,11 @@ if [ -r /sys/devices/virtual/dmi/id/product_name ]; then  #x86
 			FRU=`ipmitool fru print 0`
 			if [ $? -eq 0 ]; then
 				MTM=`echo "$FRU" | awk -F': ' '/Product Manufacturer/ {m=$2} /Product Name/ {n=$2} END {print m":"n}'`
+			else
+				logger -s -t $log_label -p local4.warning "Couldn't find MTM information in FRU, falling back to DMI (MTMS-based discovery may fail)"
+				m=`cat /sys/devices/virtual/dmi/id/sys_vendor`
+				n=`cat /sys/devices/virtual/dmi/id/product_name`
+				MTM="$m:$n"
 			fi
 		fi 
 		SERIAL=`cat /sys/devices/virtual/dmi/id/product_serial`


### PR DESCRIPTION
In some cases, FRU pages are not available, or don't contain relevant
readable or relevant information. In those cases, we could still fall
back to DMI to get the MTM information, and log a warning that
MTMS-based discovery may not work as expected.