### PR TITLE
fix issue 2348, check error msg when run bmcdiscover

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -896,6 +896,11 @@ sub bmcdiscovery_ipmi {
     my $output = xCAT::Utils->runcmd("$icmd", -1);
     if ($output =~ $bmcstr) {
 
+        if ($output =~ /RAKP 2 message indicates an error : (.+)\nError: (.+)/) {
+            xCAT::MsgUtils->message("E", { data => ["$2: $1 for $ip"] }, $::CALLBACK);
+            return 1;
+        }
+
         # The output contains System Power indicated the username/password is correct, then try to get MTMS
         if ($output =~ /System Power\s*:\s*\S*/) {
             my $mtm    = '';


### PR DESCRIPTION
#2348 
Before modified: 
When run ``bmcdiscover`` to discover tuleta, the result will like below:
```
# bmcdiscover --range 50.3.19.2 -z -w
node-32031302:
	objtype=node
	groups=all
	bmc=50.3.19.2
	cons=ipmi
	mgt=imp
```

There is no ``mtm`` and ``serial``.

When print more msg, will see ``RAKP 2 message indicates an error : illegal parameter ``.
So add error check.

Check if there is ``RAKP 2 message indicates an error : `` in return msg when run bmcdiscover.
If there is, print error msg and return.

After modified:

```
Error: Unable to establish IPMI v2 / RMCP+ session: illegal parameter for 50.3.19.2
```