### PR TITLE
fix issue postscript fails and status=booted. #2665

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/post.xcat
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat
@@ -180,6 +180,7 @@ echo "
 
 # global value to store the running status of the postbootscripts,the value is non-zero if one postbootscript failed
 return_value=0
+
 # subroutine used to run postscripts
 # \$1 argument is the script type
 # rest argument is the script name and arguments
@@ -226,6 +227,7 @@ run_ps () {
         msgutil_r \"\$MASTER_IP\" \"info\" "\"\`date\` \$scriptype \$1 does NOT exist.\"" \"\$logfile\"
         return_value=-1
     fi
+
 
     return 0
 }
@@ -389,6 +391,19 @@ fi
 #create the preboot script and run here
 TMP=`sed "/^#\s*postbootscripts-start-here/,/^#\s*postbootscripts-end-here/ d" /xcatpost/mypostscript`
 echo "$TMP" > /xcatpost/mypostscript
+
+echo "
+#save bad return code to /opt/xcat/xcatinfo
+if [ \"\$return_value\" -ne \"0\" ]; then
+    grep 'POSTSCRIPTS_RC' /opt/xcat/xcatinfo > /dev/null 2>&1
+    if [ \$? -eq 0 ]; then
+        sed -i \"s/POSTSCRIPTS_RC=.*/POSTSCRIPTS_RC=1/\" /opt/xcat/xcatinfo
+    else
+        echo \"POSTSCRIPTS_RC=1\" >> /opt/xcat/xcatinfo
+    fi
+fi
+" >> /xcatpost/mypostscript
+
 chmod 755 /xcatpost/mypostscript
 
 export ARCH=#TABLE:nodetype:THISNODE:arch#

--- a/xCAT/postscripts/xcatinstallpost
+++ b/xCAT/postscripts/xcatinstallpost
@@ -84,6 +84,9 @@ if [ -z "$CNS" ] || [[ "$CNS" =~ ^(1|yes|y)$ ]]; then
 
 echo "
 
+[ -f /opt/xcat/xcatinfo ] && grep 'POSTSCRIPTS_RC=1' /opt/xcat/xcatinfo >/dev/null 2>&1 && return_value=1
+
+
 if [ \"\$return_value\" -eq \"0\" ]; then
     if [ \"\$XCATDEBUGMODE\" = \"1\" ] || [ \"\$XCATDEBUGMODE\" = \"2\" ]; then
         msgutil_r \"\$MASTER_IP\" \"info\" \"node booted, reporting status...\" \"/var/log/xcat/xcat.log\"
@@ -98,6 +101,7 @@ else
 fi
 " >> /xcatpost/mypostscript.post
 fi
+
 
 chmod +x /xcatpost/mypostscript.post
 if [ -x /xcatpost/mypostscript.post ];then


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/2665:

1. if some PS fail during diskfull installation, save the ``POSTSCRIPTS_RC=1`` into ``/opt/xcat/xcatinfo`` in the installed root filesystem; 
2. during running of PBS on 1st reboot after installation,  determine the final node provision status based on the result of PS and PBS, only if all the PBS and PS are run successfully, the ``nodelist.status`` can be "booted", otherwise, the  ``nodelist.status`` will be "failed"
3. this feature should not affect the behavior of "updatenode" and reboot on "site.runbootscripts"