### PR TITLE
fix issue 2727, add Async path to @INC when want to use it

### DIFF
--- a/xCAT-server/lib/xcat/plugins/docker.pm
+++ b/xCAT-server/lib/xcat/plugins/docker.pm
@@ -12,6 +12,10 @@ package xCAT_plugin::docker;
 BEGIN
 {
     $::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : '/opt/xcat';
+    my $async_path = "/usr/local/share/perl5/";
+    unless (grep { $_ eq $async_path } @INC) {
+        push @INC, $async_path;
+    }
 }
 use lib "$::XCATROOT/lib/perl";
 

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -6,6 +6,10 @@ package xCAT_plugin::openbmc;
 BEGIN
 {
     $::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : '/opt/xcat';
+    my $async_path = "/usr/local/share/perl5/";
+    unless (grep { $_ eq $async_path } @INC) {
+        push @INC, $async_path;
+    }
 }
 use lib "$::XCATROOT/lib/perl";
 use strict;


### PR DESCRIPTION
#2727 

In docker.pm & openbmc.pm, if there is no Async.pm's path: ``/usr/local/share/perl5/``, push it to ``@INC``.