### PR TITLE
enable ipmi raw data if xcatdebugmodel set

### DIFF
--- a/xCAT-server/lib/perl/xCAT/IPMI.pm
+++ b/xCAT-server/lib/perl/xCAT/IPMI.pm
@@ -80,6 +80,63 @@ sub hexdump {
     print "\n";
 }
 
+my %command_info = (
+    6 => {
+        56 => "Get Channel Authentication Capabilities",
+        59 => "Set session privilege level",
+        60 => "Close Session",
+        58 => "activate session",
+        57 => "Get Session Challenge",
+        1 => "Get Device ID",
+        2 => "Cold Reset",
+        55 => "Get System GUID",
+        64  => "Set Channel Access", 
+        76 => "Set User Payload Access",
+        10 => "Get Command Support",
+    },	 
+    4 => {
+        18 => "Set PEF Configuration Parameters",
+        19 => "Get PEF Configuration Parameters",
+        45 => "Get Sensor Reading",
+    },
+    0 => {
+        8 => "Set System Boot Options",
+        9 => "Get System Boot Options",
+        4 => "Chassis Identify(beacon)",
+        2 => "Chassis Control",
+        1 => "Get Chassis Status",
+    },
+    12 => {
+        1 => "Set LAN Configuration Parameters",
+        2 => "Get LAN Configuration Parameters",
+        33 => "Set SOL Configuration Parameters",
+        34 => "Get SOL Configuration Parameters",         
+    },
+    10 => {
+        35 => "Get SDR",
+        34 => "Reserve SDR Repository",
+        71 => "Clear SEL",
+        67 => "Get SEL Entry",
+        66 => "Reserve SEL",
+        72 => "Get SEL Time",
+        64 => "Get SEL Info",
+        17 => "Read FRU Data",
+        16 => "Get FRU Inventory Area Info",
+        32 => "Get SDR Repository Info",
+    },
+);
+
+my %netfn_types = (
+    0 => "Chassis",
+    2 => "Bridge",
+    4 => "Sensor/Event",
+    6 => "App",
+    8 => "Firmware",
+    10 => "Storage",
+    12 => "Transport",
+    # do we need to define anymore then these?
+);
+
 my %payload_types = ( #help readability in certain areas of code by specifying payload by name rather than number
     'ipmi'                 => 0,
     'sol'                  => 1,
@@ -417,7 +474,9 @@ sub subcmd {
     $self->{expectedcmd}   = $args{command};
     $self->{expectednetfn} = $args{netfn} + 1;
     if ($self->{onlogon_args}->{xcatdebugmode}) {
-        my $msg = sprintf ("The command running: $self->{onlogon_args}->{command}:$self->{onlogon_args}->{subcommand}(@{$self->{onlogon_args}->{extraargs}}), the raw data: netfn(0x%02x), cmd(0x%02x)", $args{netfn}, $args{command});
+        my $command_string = $command_info{$args{netfn}}->{$args{command}};
+        my $data_values = join ", ", @{$args{data}};
+        my $msg = sprintf ("[ipmi_debug] $self->{onlogon_args}->{command}:$self->{onlogon_args}->{subcommand}(@{$self->{onlogon_args}->{extraargs}}), raw_cmd: netfn(0x%02x=>%s), cmd(0x%02x=>%s), data=[%s]", $args{netfn}, $netfn_types{$args{netfn}}, $args{command}, $command_string, $data_values);
         xCAT::SvrUtils::sendmsg([0, $msg], $self->{onlogon_args}->{outfunc});
     }
     my $seqincrement = 7;

--- a/xCAT-server/lib/perl/xCAT/IPMI.pm
+++ b/xCAT-server/lib/perl/xCAT/IPMI.pm
@@ -15,6 +15,7 @@ use lib "$::XCATROOT/lib/perl";
 use strict;
 use warnings "all";
 use Time::HiRes qw/time/;
+use xCAT::SvrUtils;
 
 use IO::Socket::INET qw/!AF_INET6 !PF_INET6/;
 my $initialtimeout = 0.5;
@@ -415,6 +416,10 @@ sub subcmd {
     my %args = @_;
     $self->{expectedcmd}   = $args{command};
     $self->{expectednetfn} = $args{netfn} + 1;
+    if ($self->{onlogon_args}->{xcatdebugmodel}) {
+        my $msg = sprintf ("The command running: $self->{onlogon_args}->{command}:$self->{onlogon_args}->{subcommand}(@{$self->{onlogon_args}->{extraargs}}), the raw data: netfn(0x%02x), cmd(0x%02x)", $args{netfn}, $args{command});
+        xCAT::SvrUtils::sendmsg([0, $msg], $self->{onlogon_args}->{outfunc});
+    }
     my $seqincrement = 7;
     while ($tabooseq{ $self->{expectednetfn} }->{ $self->{expectedcmd} }->{ $self->{seqlun} } and $seqincrement) { #avoid using a seqlun formerly marked 'taboo', but don't advance by more than 7, just in case
         $tabooseq{ $self->{expectednetfn} }->{ $self->{expectedcmd} }->{ $self->{seqlun} }--; #forgive a taboo lun over time...

--- a/xCAT-server/lib/perl/xCAT/IPMI.pm
+++ b/xCAT-server/lib/perl/xCAT/IPMI.pm
@@ -416,7 +416,7 @@ sub subcmd {
     my %args = @_;
     $self->{expectedcmd}   = $args{command};
     $self->{expectednetfn} = $args{netfn} + 1;
-    if ($self->{onlogon_args}->{xcatdebugmodel}) {
+    if ($self->{onlogon_args}->{xcatdebugmode}) {
         my $msg = sprintf ("The command running: $self->{onlogon_args}->{command}:$self->{onlogon_args}->{subcommand}(@{$self->{onlogon_args}->{extraargs}}), the raw data: netfn(0x%02x), cmd(0x%02x)", $args{netfn}, $args{command});
         xCAT::SvrUtils::sendmsg([0, $msg], $self->{onlogon_args}->{outfunc});
     }

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -8163,7 +8163,7 @@ sub process_request {
     if ($::XCATSITEVALS{ipmitimeout}) { $ipmitimeout = $::XCATSITEVALS{ipmitimeout} }
     if ($::XCATSITEVALS{ipmiretries}) { $ipmitrys = $::XCATSITEVALS{ipmitretries} }
     if ($::XCATSITEVALS{ipmisdrcache}) { $enable_cache = $::XCATSITEVALS{ipmisdrcache} }
-    if ($::XCATSITEVALS{xcatdebugmode}) { $xcatdebugmodel = $::XCATSITEVALS{xcatdebugmode} }
+    if ($::XCATSITEVALS{xcatdebugmode}) { $xcatdebugmode = $::XCATSITEVALS{xcatdebugmode} }
 
     #my @threads;
     my @donargs = ();

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -43,6 +43,7 @@ my %allerrornodes = ();
 my %newnodestatus = ();
 my $global_sessdata;
 my %child_pids;
+my $xcatdebugmodel = 0;
 
 my $IPMIXCAT  = "/opt/xcat/bin/ipmitool-xcat";
 my $NON_BLOCK = 1;
@@ -8162,6 +8163,7 @@ sub process_request {
     if ($::XCATSITEVALS{ipmitimeout}) { $ipmitimeout = $::XCATSITEVALS{ipmitimeout} }
     if ($::XCATSITEVALS{ipmiretries}) { $ipmitrys = $::XCATSITEVALS{ipmitretries} }
     if ($::XCATSITEVALS{ipmisdrcache}) { $enable_cache = $::XCATSITEVALS{ipmisdrcache} }
+    if ($::XCATSITEVALS{xcatdebugmodel}) { $xcatdebugmodel = $::XCATSITEVALS{xcatdebugmodel} }
 
     #my @threads;
     my @donargs = ();
@@ -8375,6 +8377,8 @@ sub donode {
         command    => $command,
         extraargs  => \@exargs,
         subcommand => $exargs[0],
+        xcatdebugmodel => $xcatdebugmodel,
+        outfunc => $callback,
     };
     if ($sessiondata{$node}->{ipmisession}->{error}) {
         xCAT::SvrUtils::sendmsg([ 1, $sessiondata{$node}->{ipmisession}->{error} ], $callback, $node, %allerrornodes);

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -43,7 +43,7 @@ my %allerrornodes = ();
 my %newnodestatus = ();
 my $global_sessdata;
 my %child_pids;
-my $xcatdebugmodel = 0;
+my $xcatdebugmode = 0;
 
 my $IPMIXCAT  = "/opt/xcat/bin/ipmitool-xcat";
 my $NON_BLOCK = 1;
@@ -8163,7 +8163,7 @@ sub process_request {
     if ($::XCATSITEVALS{ipmitimeout}) { $ipmitimeout = $::XCATSITEVALS{ipmitimeout} }
     if ($::XCATSITEVALS{ipmiretries}) { $ipmitrys = $::XCATSITEVALS{ipmitretries} }
     if ($::XCATSITEVALS{ipmisdrcache}) { $enable_cache = $::XCATSITEVALS{ipmisdrcache} }
-    if ($::XCATSITEVALS{xcatdebugmodel}) { $xcatdebugmodel = $::XCATSITEVALS{xcatdebugmodel} }
+    if ($::XCATSITEVALS{xcatdebugmode}) { $xcatdebugmodel = $::XCATSITEVALS{xcatdebugmode} }
 
     #my @threads;
     my @donargs = ();
@@ -8377,7 +8377,7 @@ sub donode {
         command    => $command,
         extraargs  => \@exargs,
         subcommand => $exargs[0],
-        xcatdebugmodel => $xcatdebugmodel,
+        xcatdebugmode => $xcatdebugmode,
         outfunc => $callback,
     };
     if ($sessiondata{$node}->{ipmisession}->{error}) {


### PR DESCRIPTION
For feature #2735 

Sample output: 
```
[root@fs1 openbmc_test]# rpower frame45cn02 state
frame45cn02: on

[root@fs1 openbmc_test]# chdef -t site xcatdebugmode=1
1 object definitions have been created or modified.

[root@fs1 openbmc_test]# rpower frame45cn02 state
[ipmi_debug] rpower: state(state), raw_cmd: netfn(0x06=>App), cmd(0x38=>Get Channel Authentication Capabilities), data=[142, 4]
[ipmi_debug] rpower: state(state), raw_cmd: netfn(0x06=>App), cmd(0x3b=>Set session privilege level), data=[4]
[ipmi_debug] rpower: state(state), raw_cmd: netfn(0x06=>App), cmd(0x01=>Get Device ID), data=[]
[ipmi_debug] rpower: state(state), raw_cmd: netfn(0x00=>Chassis), cmd(0x01=>Get Chassis Status), data=[]
frame45cn02: on
[ipmi_debug] rpower: state(state), raw_cmd: netfn(0x06=>App), cmd(0x3c=>Close Session), data=[63, 91, 139, 192]
[root@fs1 openbmc_test]# chdef -t site xcatdebugmode=0
1 object definitions have been created or modified.

[root@fs1 openbmc_test]# rpower frame45cn02 state
frame45cn02: on
```