### PR TITLE
rinv command get error message on Habanero

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -3302,12 +3302,8 @@ sub initfru_zero {
 
         if ($sessdata->{skipotherfru} and isopenpower($sessdata)) {
             # For openpower Big Data servers, fru 2 has MTM/Serial and fru 43 has firmware information
-            if (isopenpower_bd($sessdata)) {
-                @{$sessdata->{frus_for_openpower}} = qw(2 43);
             # For openpower HPC servers, fru 3 has MTM/Serial and fru 47 has firmware information
-            } else {
-                @{$sessdata->{frus_for_openpower}} = qw(3 47);
-            }
+            @{$sessdata->{frus_for_openpower}} = qw(2 3 43 47);
             my %fruids_hash = map {$_ => 1} @{$sessdata->{frus_for_openpower}};
             foreach my $key (keys %{ $sessdata->{sdr_hash} }) {
                 my $sdr = $sessdata->{sdr_hash}->{$key};
@@ -3594,7 +3590,7 @@ sub add_fruhash {
             $fru->rec_type("hw");
         }
         $fru->value($sessdata->{currfrudata});
-        if (exists($sessdata->{currfrusdr})) {
+        if ($sessdata->{currfrusdr}) {
             $fru->desc($sessdata->{currfrusdr}->id_string);
         }
         $sessdata->{fru_hash}->{ $sessdata->{frudex} } = $fru;
@@ -8466,38 +8462,5 @@ sub genhwtree
     return \%hwtree;
 
 }
-
-##########################################################################
-# To check if this is openpower Big Data system
-# we identified it via Chassis Part number : 8348-21C
-##########################################################################
-sub isopenpower_bd
-{
-    my $sessdata = shift;
-
-    my $bmc_addr     = $sessdata->{ipmisession}->{bmc};
-    my $bmc_userid   = $sessdata->{ipmisession}->{userid};
-    my $bmc_password = undef;
-    if (defined($sessdata->{ipmisession}->{password})) {
-        $bmc_password = $sessdata->{ipmisession}->{password};
-    }
-
-    my $pre_cmd = "$IPMIXCAT -H $bmc_addr -I lanplus -U $bmc_userid";
-    if ($bmc_password) {
-        $pre_cmd = $pre_cmd . " -P $bmc_password";
-    }
-
-    my $cmd = $pre_cmd . " fru print 2";
-    my $output = xCAT::Utils->runcmd($cmd, -1);
-    if ($::RUNCMD_RC == 0) {
-        if ($output =~ /8348-21C/) {
-            return 1;
-        }
-    }
-
-    return 0;
-}
-
-
 
 1;

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -3288,7 +3288,7 @@ sub initfru_zero {
         if ($_->{encoding} == 3) {
             $fru->value($_->{value});
         } else {
-            next;
+            
 
             #print Dumper($_);
             #print $_->{encoding};
@@ -3301,9 +3301,10 @@ sub initfru_zero {
     if ($sessdata->{skipotherfru}) {    #skip non-primary fru devices
 
         if ($sessdata->{skipotherfru} and isopenpower($sessdata)) {
-            # For openpower servers, fru 3 is used to get MTM/Serial information, fru 47 is used to get firmware information
-            if (isHabanero($sessdata)) {
+            # For openpower Big Data servers, fru 2 has MTM/Serial and fru 43 has firmware information
+            if (isopenpower_bd($sessdata)) {
                 @{$sessdata->{frus_for_openpower}} = qw(2 43);
+            # For openpower HPC servers, fru 3 has MTM/Serial and fru 47 has firmware information
             } else {
                 @{$sessdata->{frus_for_openpower}} = qw(3 47);
             }
@@ -8467,10 +8468,10 @@ sub genhwtree
 }
 
 ##########################################################################
-# To check if this is Habanero system
-# we identified Hananero via Chassis Part number : 8348-21C
+# To check if this is openpower Big Data system
+# we identified it via Chassis Part number : 8348-21C
 ##########################################################################
-sub isHabanero
+sub isopenpower_bd
 {
     my $sessdata = shift;
 

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -3288,7 +3288,7 @@ sub initfru_zero {
         if ($_->{encoding} == 3) {
             $fru->value($_->{value});
         } else {
-            
+            next; 
 
             #print Dumper($_);
             #print $_->{encoding};


### PR DESCRIPTION
Resolves Issue #2335  

For Hananerro system,  it uses fru id 2 to get ```model``` subcommand  and  fru id 43 to get ``firm`` subcommand.

Test results:
````
# rinv c712f11n06 model
c712f11n06: Backplane Chassis Part Number: 8348-21C
# rinv c712f11n06 firm
c712f11n06: BMC Firmware: 2.08
c712f11n06: System Firmware Product Version: IBM-habanero-ibm-OP8_v1.6_0.37
c712f11n06: System Firmware Product Additional Info: hostboot-bc98d0b-3385c16
c712f11n06: System Firmware Product Additional Info: occ-0362706
c712f11n06: System Firmware Product Additional Info: skiboot-5.1.5-9f8b09a
c712f11n06: System Firmware Product Additional Info: hostboot-binaries-43d5a59
c712f11n06: System Firmware Product Additional Info: habanero-xml-a71550e-209a017
c712f11n06: System Firmware Product Additional Info: capp-ucode-105cb8f
````
