### PR TITLE
Add DSH_VERIFY environment variable to xdsh command

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/xdsh.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/xdsh.1.rst
@@ -264,7 +264,7 @@ running commands, are terminated (SIGTERM).
  xdsh will chroot (xcatchroot for AIX) to this path and run the xdsh command against the
  install image.  No other xdsh flags, environment variables apply with 
  this input.  A noderange is not accepted. Only runs on the local host, 
- normally the Management Node. The command you run must not prompt for input, the prompt will not be returned to you, and it will appear that xdsh hangs.
+ normally the Management Node. The command you run must not prompt for input, the prompt will not be returned to you, and it will appear that \ **xdsh**\  hangs.
  
 
 
@@ -381,8 +381,8 @@ running commands, are terminated (SIGTERM).
  displays an error and terminates execution for the remote
  targets  that  failed to respond. If \ *timeout*\  is not specified,
  \ **xdsh**\  waits indefinitely to continue processing output  from
- all  remote  targets. The exception is the -K flag which defaults 
- to  10 seconds.
+ all  remote  targets. The exception is the \ **-K**\  flag which defaults 
+ to 10 seconds.
  
 
 
@@ -512,22 +512,28 @@ running commands, are terminated (SIGTERM).
  
  If \ **DSH_REMOTE_PASSWORD**\  is set to the password of the
  userid (usually root) that will ssh to the node, then when
- you use the -K flag, you will  not be prompted for a password.
+ you use the \ **-K**\  flag, you will not be prompted for a password.
  
 
 
 \ **DSH_SYNTAX**\ 
  
  Specifies the shell syntax to use on remote targets; \ **ksh**\  or
- \ **csh**\ . If not specified, the  \ **ksh**\   syntax  is  assumed.  This
+ \ **csh**\ . If not specified, the  \ **ksh**\   syntax is assumed.  This
  variable is overridden by the \ **-S**\  flag.
  
 
 
 \ **DSH_TIMEOUT**\ 
  
- Specifies  the  time,  in  seconds, to wait for output from
- each remote target. This variable is overridden by  the  \ **-t**\  flag.
+ Specifies the time, in seconds, to wait for output from
+ each remote target. This variable is overridden by the \ **-t**\  flag.
+ 
+
+
+\ **DSH_VERIFY**\ 
+ 
+ Verifies each target before executing any remote commands on the target. If a target is not responding, execution of remote commands for the target is canceled. This variable is overridden by the \ **-v**\  flag.
  
 
 
@@ -537,10 +543,10 @@ running commands, are terminated (SIGTERM).
 **********************************
 
 
-To provide backward compatibility for scripts written using dsh in
+To provide backward compatibility for scripts written using \ **dsh**\  in
 AIX and CSM, a tool has been provided \ **groupfiles4dsh**\ ,
 which will build node group files from the
-xCAT database that can be used by dsh. See \ **man groupfiles4dsh**\ .
+xCAT database that can be used by \ **dsh**\ . See \ **man groupfiles4dsh**\ .
 
 
 ****************
@@ -566,7 +572,7 @@ userdefined.
 *******************
 
 
-The dsh command exit code is 0 if the command executed without errors and all remote shell commands finished with exit codes of 0. If internal dsh errors occur or the remote shell commands do not complete successfully, the dsh command exit value is greater than 0. The exit value is increased by 1 for each successive instance of an unsuccessful remote command execution.  If the remotely issued command is run in the background, the exit code of the remotely issued command is 0.
+The \ **xdsh**\  command exit code is 0 if the command executed without errors and all remote shell commands finished with exit codes of 0. If internal dsh errors occur or the remote shell commands do not complete successfully, the dsh command exit value is greater than 0. The exit value is increased by 1 for each successive instance of an unsuccessful remote command execution.  If the remotely issued command is run in the background, the exit code of the remotely issued command is 0.
 
 
 ****************
@@ -662,7 +668,7 @@ on the service node fedora9 diskless image, enter:
  
  To define the QLogic IB switch as a node and to set up the SSH keys for IB switch 
  \ **qswitch**\  with device configuration file
- \ **/var/opt/xcat/IBSwitch/Qlogic/config**\  and user name \ **username**\ , Enter
+ \ **/var/opt/xcat/IBSwitch/Qlogic/config**\  and user name \ **username**\ , enter
  
  
  .. code-block:: perl
@@ -674,7 +680,7 @@ on the service node fedora9 diskless image, enter:
  
 
 
-10. To define the Management Node  in the database so you can use xdsh, Enter
+10. To define the Management Node  in the database so you can use \ **xdsh**\ , enter
  
  
  .. code-block:: perl
@@ -685,7 +691,7 @@ on the service node fedora9 diskless image, enter:
 
 
 11. To define the Mellanox switch as a node and run a command to show the ssh keys. 
-\ **mswitch**\  with and user name \ **username**\ , Enter
+\ **mswitch**\  with and user name \ **username**\ , enter
  
  
  .. code-block:: perl
@@ -723,7 +729,7 @@ on the service node fedora9 diskless image, enter:
 
 13.
  
- To run xdsh with the non-root userid "user1" that has been setup as an xCAT userid and with sudo on node1 and node2 to run as root, do the following, see xCAT doc on Granting_Users_xCAT_privileges:
+ To run \ **xdsh**\  with the non-root userid "user1" that has been setup as an xCAT userid and with sudo on node1 and node2 to run as root, do the following, see xCAT doc on Granting_Users_xCAT_privileges:
  
  
  .. code-block:: perl

--- a/perl-xCAT/xCAT/DSHCLI.pm
+++ b/perl-xCAT/xCAT/DSHCLI.pm
@@ -50,7 +50,7 @@ our @dsh_valid_env = (
     'DSH_REMOTE_PASSWORD', 'DSH_TO_USERID',
     'DSH_FROM_USERID',     'DEVICETYPE',
     'RSYNCSN',             'DSH_RSYNC_FILE',
-    'RSYNCSNONLY',
+    'RSYNCSNONLY',         'DSH_VERIFY',
 );
 select(STDERR);
 $| = 1;
@@ -2489,6 +2489,12 @@ sub config_dsh
     $$options{'timeout'} = $$options{'timeout'} || $ENV{'DSH_TIMEOUT'} || undef;
     my $rsp = {};
     $rsp->{data}->[0] = "TRACE: Timeout value is $$options{'timeout'} ";
+    $dsh_trace
+      && xCAT::MsgUtils->message("I", $rsp, $::CALLBACK);
+
+    $$options{'verify'} = $$options{'verify'} || $ENV{'DSH_VERIFY'} || undef;
+    my $rsp = {};
+    $rsp->{data}->[0] = "TRACE: Verify value is $$options{'verify'} ";
     $dsh_trace
       && xCAT::MsgUtils->message("I", $rsp, $::CALLBACK);
 

--- a/xCAT-client/bin/xdsh
+++ b/xCAT-client/bin/xdsh
@@ -190,6 +190,11 @@ if ($ENV{'DSH_ENVIRONMENT'})
     push(@{ $cmdref->{env} }, "DSH_ENVIRONMENT=$ENV{'DSH_ENVIRONMENT'}");
 }
 
+if ($ENV{'DSH_VERIFY'})
+{
+    push(@{ $cmdref->{env} }, "DSH_VERIFY=$ENV{'DSH_VERIFY'}");
+}
+
 xCAT::Client::submit_request($cmdref, \&xCAT::Client::handle_response);
 exit $xCAT::Client::EXITCODE;
 

--- a/xCAT-client/pods/man1/xdsh.1.pod
+++ b/xCAT-client/pods/man1/xdsh.1.pod
@@ -231,7 +231,7 @@ for valid names.
 xdsh will chroot (xcatchroot for AIX) to this path and run the xdsh command against the
 install image.  No other xdsh flags, environment variables apply with 
 this input.  A noderange is not accepted. Only runs on the local host, 
-normally the Management Node. The command you run must not prompt for input, the prompt will not be returned to you, and it will appear that xdsh hangs. 
+normally the Management Node. The command you run must not prompt for input, the prompt will not be returned to you, and it will appear that B<xdsh> hangs. 
 
 =item B<-K>|B<--ssh-setup>
 
@@ -324,8 +324,8 @@ available  from  any  target in the specified I<timeout>, B<xdsh>
 displays an error and terminates execution for the remote
 targets  that  failed to respond. If I<timeout> is not specified,
 B<xdsh> waits indefinitely to continue processing output  from
-all  remote  targets. The exception is the -K flag which defaults 
-to  10 seconds. 
+all  remote  targets. The exception is the B<-K> flag which defaults 
+to 10 seconds. 
 
 =item B<-T>|B<--trace>
 
@@ -430,28 +430,32 @@ remote I<user_ID> is used.
 
 If B<DSH_REMOTE_PASSWORD> is set to the password of the
 userid (usually root) that will ssh to the node, then when
-you use the -K flag, you will  not be prompted for a password.
+you use the B<-K> flag, you will not be prompted for a password.
 
 
 =item B<DSH_SYNTAX>
 
 Specifies the shell syntax to use on remote targets; B<ksh> or
-B<csh>. If not specified, the  B<ksh>  syntax  is  assumed.  This
+B<csh>. If not specified, the  B<ksh>  syntax is assumed.  This
 variable is overridden by the B<-S> flag.
 
 =item B<DSH_TIMEOUT>
 
-Specifies  the  time,  in  seconds, to wait for output from
-each remote target. This variable is overridden by  the  B<-t> flag.
+Specifies the time, in seconds, to wait for output from
+each remote target. This variable is overridden by the B<-t> flag.
+
+=item B<DSH_VERIFY>
+
+Verifies each target before executing any remote commands on the target. If a target is not responding, execution of remote commands for the target is canceled. This variable is overridden by the B<-v> flag.
 
 =back
 
 =head1 B<Compatibility with AIX dsh>
 
-To provide backward compatibility for scripts written using dsh in
+To provide backward compatibility for scripts written using B<dsh> in
 AIX and CSM, a tool has been provided B<groupfiles4dsh>,
 which will build node group files from the
-xCAT database that can be used by dsh. See B<man groupfiles4dsh>. 
+xCAT database that can be used by B<dsh>. See B<man groupfiles4dsh>. 
 
 =head1 B<SECURITY>
 
@@ -470,7 +474,7 @@ userdefined.
 
 =head1 B<EXIT STATUS>
 
-The dsh command exit code is 0 if the command executed without errors and all remote shell commands finished with exit codes of 0. If internal dsh errors occur or the remote shell commands do not complete successfully, the dsh command exit value is greater than 0. The exit value is increased by 1 for each successive instance of an unsuccessful remote command execution.  If the remotely issued command is run in the background, the exit code of the remotely issued command is 0.
+The B<xdsh> command exit code is 0 if the command executed without errors and all remote shell commands finished with exit codes of 0. If internal dsh errors occur or the remote shell commands do not complete successfully, the dsh command exit value is greater than 0. The exit value is increased by 1 for each successive instance of an unsuccessful remote command execution.  If the remotely issued command is run in the background, the exit code of the remotely issued command is 0.
 
 
 =head1 B<EXAMPLES>
@@ -524,20 +528,20 @@ To cleanup the servicenode directory that stages the copy of files to the nodes,
 
 To define the QLogic IB switch as a node and to set up the SSH keys for IB switch 
 B<qswitch> with device configuration file
-B</var/opt/xcat/IBSwitch/Qlogic/config> and user name B<username>, Enter
+B</var/opt/xcat/IBSwitch/Qlogic/config> and user name B<username>, enter
 
  chdef -t node -o qswitch groups=all nodetype=switch
 
  xdsh qswitch -K -l username --devicetype IBSwitch::Qlogic
 
 =item 10.
-To define the Management Node  in the database so you can use xdsh, Enter
+To define the Management Node  in the database so you can use B<xdsh>, enter
 
  xcatconfig -m
 
 =item 11.
 To define the Mellanox switch as a node and run a command to show the ssh keys. 
-B<mswitch> with and user name B<username>, Enter
+B<mswitch> with and user name B<username>, enter
 
  chdef -t node -o mswitch groups=all nodetype=switch
 
@@ -559,7 +563,7 @@ If it is for Telnet, add I<tn:> in front of the user name: I<tn:admin>.
 
 =item 13.
 
-To run xdsh with the non-root userid "user1" that has been setup as an xCAT userid and with sudo on node1 and node2 to run as root, do the following, see xCAT doc on Granting_Users_xCAT_privileges:
+To run B<xdsh> with the non-root userid "user1" that has been setup as an xCAT userid and with sudo on node1 and node2 to run as root, do the following, see xCAT doc on Granting_Users_xCAT_privileges:
 
  xdsh node1,node2 --sudo -l user1 "cat /etc/passwd"
 

--- a/xCAT-server/lib/xcat/dsh/Context/DSH.pm
+++ b/xCAT-server/lib/xcat/dsh/Context/DSH.pm
@@ -132,6 +132,7 @@ sub context_properties {
       || $ENV{'DSH_REPORTS_DIRECTORY'};
     $properties{'DSH_SYNTAX'}  = $ENV{'DSH_SYNTAX'};
     $properties{'DSH_TIMEOUT'} = $ENV{'DSH_TIMEOUT'};
+    $properties{'DSH_VERIFY'} = $ENV{'DSH_VERIFY'};
     $properties{'RSYNC_RSH'}   = $ENV{'RSYNC_RSH'};
 
     if ($ENV{'DSH_ON_HMC'}) {


### PR DESCRIPTION
Add DSH_VERIFY environment variable to allow same control as `-verify` command line flag of `xdsh` command.
Add DSH_VERIFY environment variable description to `man xdsh`