### PR TITLE
Fix bug 2667 test case nodeset_check_warninginfo need to refine

### DIFF
--- a/xCAT-test/autotest/testcase/nodeset/cases0
+++ b/xCAT-test/autotest/testcase/nodeset/cases0
@@ -169,7 +169,7 @@ cmd:mkdef -t node -o testnode1 arch=ppc64el cons=ipmi groups=pbmc mgt=ipmi ip=10
 check:rc==0
 cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
-check:output=~Warning: testnode1: petitboot might be invalid
+check:output=~Warning: testnode1: petitboot might be invalid|testnode1 could not be resolved
 cmd:noderm testnode1
 end
 


### PR DESCRIPTION
The output of  ``nodeset_check_warninginfo`` on rhels7.3+ppc64le are 

     [nodeset testnode1 osimage=rhels7.3-ppc64le-install-compute] Running Time:1 sec
     RETURN rc = 0
     OUTPUT:
     Warning: The hostname testnode1 of node testnode1 could not be resolved.
     testnode1: install rhels7.3-ppc64le-compute
     CHECK:rc == 0   [Pass]
     CHECK:output =~ Warning: testnode1: petitboot might be invalid  [Failed]

So fix bug #2667 to refine this case