### PR TITLE
Add test cases for check exit code when abnormal commands were performed

### DIFF
--- a/xCAT-test/autotest/testcase/nodestat/cases1
+++ b/xCAT-test/autotest/testcase/nodestat/cases1
@@ -1,0 +1,4 @@
+start:nodestat_usage
+cmd:nodestat
+check:rc!=0
+end

--- a/xCAT-test/autotest/testcase/nodestat/cases1
+++ b/xCAT-test/autotest/testcase/nodestat/cases1
@@ -1,4 +1,5 @@
 start:nodestat_usage
+description: Test the exit code when no command line argument is passed to nodestat
 cmd:nodestat
 check:rc!=0
 end

--- a/xCAT-test/autotest/testcase/xdsh/cases1
+++ b/xCAT-test/autotest/testcase/xdsh/cases1
@@ -1,4 +1,5 @@
 start:xdsh_permission_denied
+description: Test the exit code when command xdsh failed
 cmd:xdsh $$CN date
 check:rc==0
 cmd:mv /root/.ssh/id_rsa /root/.ssh/id_rsa.backup

--- a/xCAT-test/autotest/testcase/xdsh/cases1
+++ b/xCAT-test/autotest/testcase/xdsh/cases1
@@ -1,0 +1,10 @@
+start:xdsh_permission_denied
+cmd:xdsh $$CN date
+check:rc==0
+cmd:mv /root/.ssh/id_rsa /root/.ssh/id_rsa.backup
+check:rc==0
+cmd:xdsh $$CN date
+check:rc!=0
+cmd:mv /root/.ssh/id_rsa.backup /root/.ssh/id_rsa
+check:rc==0
+end


### PR DESCRIPTION
Add 2 cases in this pull request
These 2 cases are for issue #2636 
This pull request is for task #2702

[case 1]
Case Name: nodestat_usage
description: Test the exit code when no command line argument is passed to nodestat

[case 2]
Case Name: xdsh_permission_denied
description: Test the exit code when command xdsh failed