### PR TITLE
fix issue [DEV] "remoteshell" postscript complains "chown: invalid group: root:ssh_keys" and "Permissions 0640 for /etc/ssh/ssh_host_dsa_key are too open" on sles11.4

### DIFF
--- a/xCAT/postscripts/remoteshell
+++ b/xCAT/postscripts/remoteshell
@@ -11,6 +11,7 @@
 #      id.rsa
 #
 # if on the Management Node, exit
+umask 0077
 if [ -f /etc/os-release ] && cat /etc/os-release |grep -i -e "^NAME=[ \"']*Cumulus Linux[ \"']*$" >/dev/null 2>&1 ; then
    #TODO
    echo "Cumulus OS is not supported yet, nothing to do..."
@@ -314,7 +315,7 @@ if [[ $NTYPE = service ]]; then
    cp /etc/ssh/ssh* /etc/xcat/hostkeys/.
 fi
 
-umask 0077 
+
 # This is where we start getting root ssh keys
 # This tells credentials.pm where to get the root .ssh keys.  If no zone then old path of ~.ssh
 #rootsshpvtkey=ssh_root_key:$zonename


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/2757:

set the umask to be "0077", so that all the newly created is created with 600
