### PR TITLE
Reduce `grep` invocations by passing `-[46]` to `ip`

### DIFF
--- a/perl-xCAT/xCAT/Client.pm
+++ b/perl-xCAT/xCAT/Client.pm
@@ -33,7 +33,7 @@ if ($inet6support) {
 if ($^O =~ /^linux/i) {
 
     # Is IPv6 enabled on the MN or xcat client node at all?
-    my $ipv6enabled = `ip addr 2> /dev/null | grep inet6`;
+    my $ipv6enabled = `ip -6 -o addr 2> /dev/null`;
     if (!$ipv6enabled) {
         $inet6support = 0;
     }

--- a/xCAT-OpenStack/postscripts/configgw
+++ b/xCAT-OpenStack/postscripts/configgw
@@ -9,7 +9,7 @@ if [ -z "$1" ];then
 fi
 
 str_nic_name=$1
-str_ip_mask=`ip addr show dev $str_nic_name | grep inet | grep -v inet6 | awk '{print $2}' | head -n 1`
+str_ip_mask=`ip -4 -o addr show dev $str_nic_name | awk '{print $4}' | head -n 1`
 
 str_ip=`echo $str_ip_mask | awk -F'/' '{print $1}'`
 str_mask=`echo $str_ip_mask | awk -F'/' '{print $2}'`

--- a/xCAT-client/bin/rcons
+++ b/xCAT-client/bin/rcons
@@ -87,7 +87,7 @@ if [ $USE_CONFLUENT == "1" ] && ([ -x "/opt/confluent/bin/confetty" ] || [ -x "/
     fi
     if [ -z "$CONSERVER" ]; then
         CONSERVER=`nodels $1 nodehm.conserver 2>/dev/null | awk -F: '{print $2}' | tr -d ' '`
-        declare -a ipaddrs=`ip addr | grep 'inet' | awk {'print $2'} | cut -d/ -f1 | grep -v : | tr '\n' ' '`
+        declare -a ipaddrs=`ip -o a | awk {'print $4'} | cut -d/ -f1 | grep -v : | tr '\n' ' '`
         for IP in ${ipaddrs[*]}; do 
             if [[ "${CONSERVER}" == "${IP}" ]]; then 
                 # conserver is the same node, do not connect using -s

--- a/xCAT-genesis-builder/dhclient-script
+++ b/xCAT-genesis-builder/dhclient-script
@@ -14,7 +14,7 @@ elif [ $reason = "BOUND" ]; then
 	if [ ! -z "$old_ip_address" ]; then
 		ip addr del dev $interface $old_ip_address/$old_subnet_mask
 	fi
-        for oldip in `ip addr show dev $interface|grep 'inet '|awk '{print $2}'`; do
+        for oldip in `ip -o addr show dev $interface|awk '{print $4}'`; do
 		ip addr del dev $interface $oldip
 	done
 	if [ ! -z "$new_ip_address" -a ! -z "$new_subnet_mask" ]; then

--- a/xCAT-genesis-scripts/bin/dodiscovery
+++ b/xCAT-genesis-scripts/bin/dodiscovery
@@ -25,11 +25,11 @@ logger -s -t $log_label -p local4.info "Waiting for nics to get addresses"
 while [ ! -z "$NICSGETTINGADDR" -a $timewaiting != 700 ]; do
 	NEWNICSGETTINGADDR=""
 	for nic in $NICSGETTINGADDR; do
-		if ! ip addr show dev $nic |grep -v inet6|grep inet >/dev/null;  then
+		if ! ip -4 -o a show dev $nic |grep -q inet;  then
 			NEWNICSGETTINGADDR="$NEWNICSGETTINGADDR $nic"
 		else
 			echo -n "$nic|"
-			ip addr show dev $nic |grep -v inet6|grep inet|sed -e s/\\/.*//|awk '{print $2}'
+			ip -4 -o addr show dev $nic | awk '{print $4}' | sed -e sX/.*XX
 		fi
 	done
 	sleep 0.1
@@ -187,8 +187,8 @@ for dev in `ip link|grep -B1 ether|grep UP|awk '{print $2}'|sed -e s/://|grep -v
 	ONBOARDINDEX=""
 	DRIVER=`grep DRIVER /sys/class/net/$dev/device/uevent|awk -F= '{print $2}'`
 	PCI_SLOT=`grep PCI_SLOT_NAME /sys/class/net/$dev/device/uevent|awk -F= '{print $2}'`
-	ADDRESS=`ip address show dev $dev|grep "inet "|grep global|awk '{print $2}'`
-	MAC=`ip link show dev $dev|grep ether|awk '{print $2}'| tr /a-f/ /A-F/`
+	ADDRESS=`ip -4 -o a show dev $dev|awk '/global/{print $4}'`
+	MAC=`ip -o l show dev $dev|awk '/ether/{print $15}'| tr /a-f/ /A-F/`
         if [ "$MAC_OF_FIRST_UP_NIC" == "unknown" ]; then
             MAC_OF_FIRST_UP_NIC=`echo $MAC | sed -e s/://g`
         fi

--- a/xCAT-genesis-scripts/bin/doxcat
+++ b/xCAT-genesis-scripts/bin/doxcat
@@ -212,7 +212,7 @@ else
             tries=0
             while [ -z "$bootnic" ]; do
 	        for tmp1 in $ALLUP_NICS; do
-	            if ip addr show dev $tmp1|grep -v 'scope link'|grep -v 'dynamic'|grep -v  inet6|grep inet > /dev/null; then
+	            if ip -4 -o a show dev $tmp1|grep -v 'scope link'|grep -v 'dynamic'|grep -q inet ; then
                         result=`ping -c1 -I $tmp1 $XCATMASTER 2>&1`
 	                if [ $? -eq 0 ]; then
 	                    logger -s -t $log_label -p local4.info "the nic $tmp1 can ping $XCATMASTER"
@@ -247,7 +247,7 @@ else
 
             gripeiter=101
             logger -s -t $log_label -p local4.info "Acquiring network addresses.."
-            while ! ip addr show dev $bootnic|grep -v 'scope link'|grep -v 'dynamic'|grep -v  inet6|grep inet > /dev/null; do
+            while ! ip -4 -o a show dev $bootnic|grep -v 'scope link'|grep -v 'dynamic'|grep -q inet; do
                 sleep 0.1
                 if [ $gripeiter = 1 ]; then
                     logger -s -t $log_label -p local4.info "It seems to be taking a while to acquire an IPv4 address, you may want to check spanning tree..."
@@ -261,7 +261,7 @@ openssl genrsa -out /etc/xcat/certkey.pem 4096 > /dev/null 2>&1 &
 
 logger -s -t $log_label -p local4.info "Acquired IPv4 address on $bootnic"
 
-ip addr show dev $bootnic|grep -v 'scope link'|grep -v 'dynamic'|grep -v  inet6|grep inet|awk '{print $2}'
+ip -4 -o a show dev $bootnic|grep -v 'scope link'|grep -v 'dynamic'|awk '{print $4}'
 
 logger -s -t $log_label -p local4.info "Starting ntpd..." 
 ntpd -g -x

--- a/xCAT-probe/subcmds/xcatmn
+++ b/xCAT-probe/subcmds/xcatmn
@@ -387,7 +387,7 @@ sub check_network {
 
         # on SN, get ip address by compare 'master' attribute in 'site' table
         # choose the one in the same network with 'master'
-        my @ipoutput = `ip addr show 2>&1| grep inet | grep -v inet6`;
+        my @ipoutput = `ip -4 a show 2>&1| grep inet`;
         foreach (@ipoutput) {
             if ($_ =~ /inet\s+(.+)\/(.+)\s+brd\s+(.+)\s+scope global/i) {
                 if (xCAT::NetworkUtils::isInSameSubnet($sitetable_ref->{master}, $1, $2, 1)) {

--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -97,7 +97,7 @@ if ($inet6support) {
 if ($^O =~ /^linux/i) {
 
     # Is IPv6 enabled on the MN or SN at all?
-    my $ipv6enabled = `ip addr | grep inet6`;
+    my $ipv6enabled = `ip -6 -o a`;
     if (!$ipv6enabled) {
         $inet6support = 0;
     }

--- a/xCAT-server/share/xcat/install/scripts/post.rh.common
+++ b/xCAT-server/share/xcat/install/scripts/post.rh.common
@@ -39,12 +39,12 @@ elif [[ `echo "$PRINIC" | grep -sqE ^[A-Fa-f0-9]+:[A-Fa-f0-9]+:[A-Fa-f0-9]+:[A-F
 fi
 
 #IP=$(ifconfig $PRINIC | grep inet | awk '{print $2}' | awk -F: '{print $2}')
-IP=$(ip addr show dev $PRINIC | grep inet | grep -v inet6  | awk  '{print $2}' | head -n 1 | awk -F '/' '{print $1}')
-if [ -z $IP ]
+IP=$(ip -4 -o a sh dev $PRINIC | awk  '/inet/{print $4}' | head -n 1 | awk -F '/' '{print $1}')
+if [ -z "$IP" ]
 then
 	dhclient $PRINIC
 	#IP=$(ifconfig $PRINIC | grep inet | awk '{print $2}' | awk -F: '{print $2}')
-        IP=$(ip addr show dev $PRINIC | grep inet | grep -v inet6  | awk  '{print $2}' | head -n 1 | awk -F '/' '{print $1}')
+        IP=$(ip -4 -o a sh dev $PRINIC | awk  '/inet/{print $4}' | head -n 1 | awk -F '/' '{print $1}')
 fi
 
 export HOSTNAME=$(host $IP 2>/dev/null | awk '{print $5}' | awk -F. '{print $1}')

--- a/xCAT-server/share/xcat/install/scripts/post.ubuntu.common
+++ b/xCAT-server/share/xcat/install/scripts/post.ubuntu.common
@@ -22,12 +22,12 @@ elif [[ `echo "$PRINIC" | grep -sqE ^[A-Fa-f0-9]+:[A-Fa-f0-9]+:[A-Fa-f0-9]+:[A-F
     export PRINIC=`ip -o link|grep -i  "$PRINIC" |awk  '{print $2}'|sed s/://`
 fi
 #IP=$(ifconfig $PRINIC | grep inet | awk '{print $2}' | awk -F: '{print $2}')
-IP=$(ip addr show dev $PRINIC | grep inet | grep -v inet6  | awk  '{print $2}' | head -n 1 | awk -F '/' '{print $1}')
+IP=$(ip -4 -o a sh dev $PRINIC | awk  '/inet/{print $4}' | head -n 1 | awk -F '/' '{print $1}')
 if [ -z $IP ]
 then
 	dhclient $PRINIC
 	#IP=$(ifconfig $PRINIC | grep inet | awk '{print $2}' | awk -F: '{print $2}')
-        IP=$(ip addr show dev $PRINIC | grep inet | grep -v inet6  | awk  '{print $2}' | head -n 1 | awk -F '/' '{print $1}')
+        IP=$(ip -4 -o a sh dev $PRINIC | awk  '/inet/{print $4}' | head -n 1 | awk -F '/' '{print $1}')
 fi
 
 if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then

--- a/xCAT-server/share/xcat/tools/detect_dhcpd
+++ b/xCAT-server/share/xcat/tools/detect_dhcpd
@@ -46,7 +46,7 @@ $start =~ s/(\d.*)\.(\d.*)/$1/;
 if (!$nic) { print "specify a nic\n"; print $::USAGE; exit 1; }
 
 #my $IP = `ifconfig $nic | grep "inet addr" | awk '{print \$2}' | awk -F: '{print \$2}'`;
-my $IPADDRMASK = `ip addr show dev $nic | grep inet | grep -v inet6 | awk '{print \$2}' | head -n 1`;
+my $IPADDRMASK = `ip -4 -o a show dev $nic | awk '/inet/{print \$4}' | head -n 1`;
 my ($IP, $MASK) = split(/\//, $IPADDRMASK);
 my $MAC;
 my $tmpMAC;

--- a/xCAT/postscripts/hardeths
+++ b/xCAT/postscripts/hardeths
@@ -88,7 +88,7 @@ if [ ! -z $HOSTNAMECTL ] && [ ! -z $NODE ]; then
 fi
 
 for nic in `ip link |grep "BROADCAST" |awk '{print $2}'   | sed s/://`; do
-    IPADDRMASK=`ip addr show dev $nic | grep inet | grep -v inet6 | awk '{print $2}' | head -n 1`
+    IPADDRMASK=`ip -4 -o a sh dev $nic | awk '/inet/{print $4}' | head -n 1`
     IPADDR=`echo $IPADDRMASK | awk -F'/' '{print $1}'`
     [ -z $IPADDR ] && continue
     PREFIXMASK=`echo $IPADDRMASK | awk -F'/' '{print $2}'`


### PR DESCRIPTION
The xCAT code has a lot of invocations of `ip` without paramters which outputs `IP` (both `v4` and `v6`) and `link` information,  when just one of the 3 pieces of information is needed (using `-[46]` and `-o`. 

I've traced down all such redundent filters using the pattern `'grep\s\+ipv6|grep\s\+-v\s\+ipv6` invocations and removed them, adjusting the `ip` and `awk` invocations appropriately.