### PR TITLE
Make tables which contain nodecol column inheritable

### DIFF
--- a/perl-xCAT/xCAT/DBobjUtils.pm
+++ b/perl-xCAT/xCAT/DBobjUtils.pm
@@ -488,7 +488,9 @@ sub getobjdefs
                     foreach my $lookup_attr (keys %{ $tabentry{'lookup_attrs'} }) {
                         # Check whether the attribute is already in %tabhash
                         # The %tabhash is for performance considerations
-                        if (($lookup_attr eq 'node') && ($objtype eq 'node')) {
+                        my $tabspec = $xCAT::Schema::tabspec{$lookup_table};
+                        my $nodecol = $tabspec->{'nodecol'} if defined($tabspec->{'nodecol'});
+                        if (($lookup_attr eq 'node' && $objtype eq 'node') || (defined($nodecol) && $objtype eq 'node')) {
                             if (defined($tabhash{$lookup_table}{$objname}{$tabattr})) {
                                 if ($verbose == 1) {
                                     $objhash{$objname}{$attr} = "$tabhash{$lookup_table}{$objname}{$tabattr}\t(Table:$lookup_table - Key:$lookup_attr - Column:$tabattr)";


### PR DESCRIPTION
Actually, the subroutine getNodeAttribs already fetch the attributes
related to the groups, but the defobj ignore these attributes as it is
not node although nodecol is used. This patch treat nodecol as node to
make the attributes inheritable.

fix-issue: #2450