### PR TITLE
rcons command failed for openbmc

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -316,6 +316,8 @@ sub parse_args {
         unless ($subcommand =~ /^cpu$|^dimm$|^bios$|^all$/) {
             return ([ 1, "Unsupported command: $command $subcommand" ]);
         }
+    } elsif ($command eq "getopenbmccons") {
+        #command for openbmc rcons
     } else {
         return ([ 1, "Command is not supported." ]);
     }

--- a/xCAT-server/share/xcat/cons/openbmc
+++ b/xCAT-server/share/xcat/cons/openbmc
@@ -58,7 +58,6 @@ sub getans {
             my $error = $rsp->{node}->[0]->{error}->[0];
             print "$error\n";
         }
-        print "$bmcip, $username, $password\n";
     }
 }
 my $cmdref = {


### PR DESCRIPTION
rcons didn't work for the openbmc node on our test system
````
[root@stratton01 xCAT_plugin]# rcons p9euh01
[Enter `^Ec?' for help]
Acquiring startup lock...done
Console not ready, retrying in 15 seconds (Ctrl-e,c,o to skip delay)
Acquiring startup lock...done
Console not ready, retrying in 29 seconds (Ctrl-e,c,o to skip delay)
Acquiring startup lock...done
Console not ready, retrying in 20 seconds (Ctrl-e,c,o to skip delay)
``````
