### PR TITLE
Modify syntax error of two cases "query_9125-F2C_ffoVmin" and  "xcatsnap_v"

### DIFF
--- a/xCAT-test/autotest/testcase/renergy/case_9125-F2C
+++ b/xCAT-test/autotest/testcase/renergy/case_9125-F2C
@@ -218,7 +218,7 @@ check:output!~ffoNorm
 check:output!~ffovalue
 end
 
-tart:query_9125-F2C_ffoVmin
+start:query_9125-F2C_ffoVmin
 description:
 type:9125-F2C
 cmd:renergy $$CN ffoVmin

--- a/xCAT-test/autotest/testcase/xcatsnap/cases0
+++ b/xCAT-test/autotest/testcase/xcatsnap/cases0
@@ -25,7 +25,7 @@ check:output=~Usage
 end
 
 
-start;xcatsnap_v
+start:xcatsnap_v
 description:xcatsnap -v and --version
 cmd:xcatsnap -v
 check:output=~version|Version


### PR DESCRIPTION
Modify syntax error of two cases ``query_9125-F2C_ffoVmin`` and  ``xcatsnap_v``.