### PR TITLE
fix issue #2856: [DEV] nodes provisioned with redhat osimages created by xCAT 2.12.3 or earlier missed yum repo to MN in xCAT 2.12.4 or later 

### DIFF
--- a/perl-xCAT/xCAT/Yum.pm
+++ b/perl-xCAT/xCAT/Yum.pm
@@ -9,12 +9,16 @@ my $distname;
 my $arch;
 my $installpfx;
 
+my $distrepopfx="/install/postscripts/repos";
+
 sub localize_yumrepo {
     my $self        = shift;
     my $pkgdir = shift;
     $distname=shift;
     $arch=shift;
-    open($yumrepofile, ">", "$pkgdir/local-repository.tmpl");
+    
+    mkpath("$distrepopfx/$pkgdir");
+    open($yumrepofile, ">", "$distrepopfx/$pkgdir/local-repository.tmpl");
     my %options = (
         wanted      => \&check_tofix,
         follow_fast => 1
@@ -27,7 +31,7 @@ sub localize_yumrepo {
 sub remove_yumrepo {
     my $self        = shift;
     my $pkgdir = shift;
-    rmtree("$pkgdir/local-repository.tmpl");
+    rmtree("$distrepopfx/$pkgdir/local-repository.tmpl");
 }
 
 sub check_tofix {

--- a/xCAT-server/lib/perl/xCAT/Template.pm
+++ b/xCAT-server/lib/perl/xCAT/Template.pm
@@ -303,11 +303,12 @@ sub subvars {
                         $source_in_pre .= "\necho 'repo --name=pkg$c --baseurl=http://'\$nextserver'/$pkgdir' >> /tmp/repos";
                         $source .= "repo --name=pkg$c --baseurl=http://#TABLE:noderes:\$NODE:nfsserver#/$pkgdir\n"; #for rhels5.9
                     }
-                    if( -f "$pkgdir/local-repository.tmpl"){
+                    my $distrepofile="/install/postscripts/repos/$pkgdir/local-repository.tmpl";
+                    if( -f "$distrepofile"){
                         my $repofd;
                         my $repo_in_post;
                         local $/=undef;
-                        open($repofd,"<","$pkgdir/local-repository.tmpl");
+                        open($repofd,"<","$distrepofile");
                         $repo_in_post = <$repofd>;
                         close($repofd);
                         $repo_in_post =~ s#baseurl=#baseurl=http://$master/#g;

--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -1260,8 +1260,14 @@ sub mkinstall
             }
         }
 
-       require xCAT::Yum;
-       xCAT::Yum->localize_yumrepo($pkgdir, $os, $arch);
+        unless(-f "/install/postscripts/repos/$pkgdir/local-repository.tmpl"){
+            #fix issue #2856@github
+            #for the osimages created by <=xCAT 2.12.3
+            #there is no local-repository.tmpl under pkgdir created on copycds
+            #generate local-repository.tmpl here if it does not exist
+            require xCAT::Yum;
+            xCAT::Yum->localize_yumrepo($pkgdir, $os, $arch);
+        }
 
         my @missingparms;
         unless ($os) {

--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -1260,6 +1260,9 @@ sub mkinstall
             }
         }
 
+       require xCAT::Yum;
+       xCAT::Yum->localize_yumrepo($pkgdir, $os, $arch);
+
         my @missingparms;
         unless ($os) {
             if   ($imagename) { push @missingparms, "osimage.osvers"; }

--- a/xCAT-server/share/xcat/install/scripts/post.xcat
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat
@@ -411,7 +411,7 @@ export CONSOLEPORT=#TABLEBLANKOKAY:nodehm:THISNODE:serialport#
 
 #for redhat:
 #place-holder for the code to save the repo info on compute node,pointing to the "pkgdir" of the osimage
-#so that the provisioned node
+#so that the provisioned node has the repo pointed to the distro path on MN
 #WRITEREPO#
 
 if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then

--- a/xCAT-server/share/xcat/install/scripts/post.xcat
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat
@@ -410,9 +410,9 @@ export ARCH=#TABLE:nodetype:THISNODE:arch#
 export CONSOLEPORT=#TABLEBLANKOKAY:nodehm:THISNODE:serialport#
 
 #for redhat:
-##place-holder for the code to save the repo info on compute node,pointing to the "pkgdir" of the osimage
-##so that the provisioned node
-##WRITEREPO#
+#place-holder for the code to save the repo info on compute node,pointing to the "pkgdir" of the osimage
+#so that the provisioned node
+#WRITEREPO#
 
 if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
    msgutil_r "$MASTER_IP" "info" "running mypostscript" "/var/log/xcat/xcat.log"


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/2856

1. for the osimages created by <=xCAT 2.12.3, there is no local-repository.tmpl under pkgdir created on copycds, generate local-repository.tmpl on ``nodeset`` if it does not exist

2. remove some redundant leading "#"s in post.xcat


Unit Test:

````
c910f02c08p15:/opt/rpms/xcat-core # lsxcatd -v
Version 2.12.2 (git commit e4a7359d31008d81c4c57e0857d5f09009a3269c, built Thu Aug 18 06:43:29 EDT 2016)

c910f02c08p15:/opt/rpms/xcat-core # copycds /iso2/iso/redhat/6.9/rc2/ppc64/RHEL-6.9-20170309.0-Server-ppc64-dvd1.iso
Copying media to /install/rhels6.9/ppc64
Media copy operation successful

c910f02c08p15:/opt/rpms/xcat-core # lsdef -t osimage -o rhels6.9-ppc64-install-compute
Object name: rhels6.9-ppc64-install-compute
    imagetype=linux
    osarch=ppc64
    osdistroname=rhels6.9-ppc64
    osname=Linux
    osvers=rhels6.9
    otherpkgdir=/install/post/otherpkgs/rhels6.9/ppc64
    pkgdir=/install/rhels6.9/ppc64
    pkglist=/opt/xcat/share/xcat/install/rh/compute.rhels6.ppc64.pkglist
    profile=compute
    provmethod=install
    template=/opt/xcat/share/xcat/install/rh/compute.rhels6.ppc64.tmpl

c910f02c08p15:/opt/rpms/xcat-core # ls /install/rhels6.9/ppc64/ -l
total 456
-r--r--r-- 1 root root     55 Mar  8 21:17 .discinfo
dr-xr-xr-x 2 root root   4096 Apr 12 14:58 etc
-r--r--r-- 1 root root   8724 Nov  7  2012 EULA
-r--r--r-- 1 root root  10726 Nov  7  2012 EULA_de
-r--r--r-- 1 root root   8724 Nov  7  2012 EULA_en
-r--r--r-- 1 root root  10846 Nov  7  2012 EULA_es
-r--r--r-- 1 root root  10682 Nov  7  2012 EULA_fr
-r--r--r-- 1 root root  10497 Nov  7  2012 EULA_it
-r--r--r-- 1 root root  13173 Nov  7  2012 EULA_ja
-r--r--r-- 1 root root   9841 Nov  7  2012 EULA_ko
-r--r--r-- 1 root root  10033 Nov  7  2012 EULA_pt
-r--r--r-- 1 root root   7306 Nov  7  2012 EULA_zh
-rw-r--r-- 1 root root     33 Apr 12 14:59 .fingerprint
-r--r--r-- 1 root root  18092 Jun 29  2010 GPL
dr-xr-xr-x 3 root root   4096 Apr 12 14:59 images
-r--r--r-- 1 root root    114 Mar  8 21:16 media.repo
dr-xr-xr-x 2 root root 249856 Apr 12 14:58 Packages
dr-xr-xr-x 4 root root   4096 Apr 12 14:59 ppc
-r--r--r-- 1 root root  16435 Sep  2  2010 README
dr-xr-xr-x 2 root root   4096 Apr 12 14:59 repodata
-r--r--r-- 1 root root   3375 Feb 26 11:06 RPM-GPG-KEY-redhat-beta
-r--r--r-- 1 root root   3211 Feb 26 11:06 RPM-GPG-KEY-redhat-release
dr-xr-xr-x 3 root root   4096 Apr 12 14:58 Server
-r--r--r-- 1 root root   3757 Mar  8 21:26 TRANS.TBL
-r--r--r-- 1 root root   1528 Mar  8 21:17 .treeinfo

````

If upgraded to xCAT 2.13.2:

````
c910f02c08p15:/opt/rpms/2.13.2/xcat-core # lsxcatd -v
Version 2.12.2 (git commit e4a7359d31008d81c4c57e0857d5f09009a3269c, built Thu Aug 18 06:43:29 EDT 2016)

c910f02c08p15:/opt/rpms # ls /install/rhels6.9/ppc64/ -l
total 456
-r--r--r-- 1 root root     55 Mar  8 21:17 .discinfo
dr-xr-xr-x 2 root root   4096 Apr 12 14:58 etc
-r--r--r-- 1 root root   8724 Nov  7  2012 EULA
-r--r--r-- 1 root root  10726 Nov  7  2012 EULA_de
-r--r--r-- 1 root root   8724 Nov  7  2012 EULA_en
-r--r--r-- 1 root root  10846 Nov  7  2012 EULA_es
-r--r--r-- 1 root root  10682 Nov  7  2012 EULA_fr
-r--r--r-- 1 root root  10497 Nov  7  2012 EULA_it
-r--r--r-- 1 root root  13173 Nov  7  2012 EULA_ja
-r--r--r-- 1 root root   9841 Nov  7  2012 EULA_ko
-r--r--r-- 1 root root  10033 Nov  7  2012 EULA_pt
-r--r--r-- 1 root root   7306 Nov  7  2012 EULA_zh
-rw-r--r-- 1 root root     33 Apr 12 14:59 .fingerprint
-r--r--r-- 1 root root  18092 Jun 29  2010 GPL
dr-xr-xr-x 3 root root   4096 Apr 12 14:59 images
-r--r--r-- 1 root root    114 Mar  8 21:16 media.repo
dr-xr-xr-x 2 root root 249856 Apr 12 14:58 Packages
dr-xr-xr-x 4 root root   4096 Apr 12 14:59 ppc
-r--r--r-- 1 root root  16435 Sep  2  2010 README
dr-xr-xr-x 2 root root   4096 Apr 12 14:59 repodata
-r--r--r-- 1 root root   3375 Feb 26 11:06 RPM-GPG-KEY-redhat-beta
-r--r--r-- 1 root root   3211 Feb 26 11:06 RPM-GPG-KEY-redhat-release
dr-xr-xr-x 3 root root   4096 Apr 12 14:58 Server
-r--r--r-- 1 root root   3757 Mar  8 21:26 TRANS.TBL
-r--r--r-- 1 root root   1528 Mar  8 21:17 .treeinfo

c910f02c08p15:/opt/rpms/2.13.2/xcat-core # rnetboot c910f02c08p16
c910f02c08p16: Success

[root@c910f02c08p16 ~]# ll /etc/yum.repos.d/
total 8
-rw-r--r--. 1 root root 358 Apr 12 10:56 redhat.repo
-rw-r--r--. 1 root root 529 Feb 26 11:06 rhel-source.repo

[root@c910f02c08p16 ~]# cat /etc/yum.repos.d/*
#
# Certificate-Based Repositories
# Managed by (rhsm) subscription-manager
#
# *** This file is auto-generated.  Changes made here will be over-written. ***
# *** Use "subscription-manager repo-override --help" if you wish to make changes. ***
#
# If this file is empty and this system is subscribed consider
# a "yum repolist" to refresh available repos
#[rhel-source]
name=Red Hat Enterprise Linux $releasever - $basearch - Source
baseurl=ftp://ftp.redhat.com/pub/redhat/linux/enterprise/$releasever/en/os/SRPMS/
enabled=0
gpgcheck=1
gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release

[rhel-source-beta]
name=Red Hat Enterprise Linux $releasever Beta - $basearch - Source
baseurl=ftp://ftp.redhat.com/pub/redhat/linux/beta/$releasever/en/os/SRPMS/
enabled=0
gpgcheck=1
gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
[root@c910f02c08p16 ~]#
````

After upgrade to xCAT snapshot build included this PR from xCAT 2.12.2 :
````
c910f02c08p15:/opt/rpms/xcat-core # lsxcatd -v
Version 2.13.3 (git commit 3433f9551aea9e27491cae6eae8a8059210539e1, built Wed Apr 12 10:31:39 EDT 2017)

c910f02c08p15:/opt/rpms # ls /install/rhels6.9/ppc64/ -l
total 456
-r--r--r-- 1 root root     55 Mar  8 21:17 .discinfo
dr-xr-xr-x 2 root root   4096 Apr 12 14:58 etc
-r--r--r-- 1 root root   8724 Nov  7  2012 EULA
-r--r--r-- 1 root root  10726 Nov  7  2012 EULA_de
-r--r--r-- 1 root root   8724 Nov  7  2012 EULA_en
-r--r--r-- 1 root root  10846 Nov  7  2012 EULA_es
-r--r--r-- 1 root root  10682 Nov  7  2012 EULA_fr
-r--r--r-- 1 root root  10497 Nov  7  2012 EULA_it
-r--r--r-- 1 root root  13173 Nov  7  2012 EULA_ja
-r--r--r-- 1 root root   9841 Nov  7  2012 EULA_ko
-r--r--r-- 1 root root  10033 Nov  7  2012 EULA_pt
-r--r--r-- 1 root root   7306 Nov  7  2012 EULA_zh
-rw-r--r-- 1 root root     33 Apr 12 14:59 .fingerprint
-r--r--r-- 1 root root  18092 Jun 29  2010 GPL
dr-xr-xr-x 3 root root   4096 Apr 12 14:59 images
-r--r--r-- 1 root root    114 Mar  8 21:16 media.repo
dr-xr-xr-x 2 root root 249856 Apr 12 14:58 Packages
dr-xr-xr-x 4 root root   4096 Apr 12 14:59 ppc
-r--r--r-- 1 root root  16435 Sep  2  2010 README
dr-xr-xr-x 2 root root   4096 Apr 12 14:59 repodata
-r--r--r-- 1 root root   3375 Feb 26 11:06 RPM-GPG-KEY-redhat-beta
-r--r--r-- 1 root root   3211 Feb 26 11:06 RPM-GPG-KEY-redhat-release
dr-xr-xr-x 3 root root   4096 Apr 12 14:58 Server
-r--r--r-- 1 root root   3757 Mar  8 21:26 TRANS.TBL
-r--r--r-- 1 root root   1528 Mar  8 21:17 .treeinfo

c910f02c08p15:/opt/rpms/xcat-core # nodeset c910f02c08p16 osimage=rhels6.9-ppc64-install-compute
Warning: c910f02c08p16: grub2 might be invalid when provisioning rhels6.9-ppc64-install-compute,valid options: "yaboot".
For more details see the 'netboot' description in the output of "tabdump -d noderes".
c910f02c08p16: install rhels6.9-ppc64-compute

c910f02c08p15:/opt/rpms/xcat-core # ll /install/rhels6.9/ppc64/
total 460
-r--r--r-- 1 root root     55 Mar  8 21:17 .discinfo
dr-xr-xr-x 2 root root   4096 Apr 12 14:58 etc
-r--r--r-- 1 root root   8724 Nov  7  2012 EULA
-r--r--r-- 1 root root  10726 Nov  7  2012 EULA_de
-r--r--r-- 1 root root   8724 Nov  7  2012 EULA_en
-r--r--r-- 1 root root  10846 Nov  7  2012 EULA_es
-r--r--r-- 1 root root  10682 Nov  7  2012 EULA_fr
-r--r--r-- 1 root root  10497 Nov  7  2012 EULA_it
-r--r--r-- 1 root root  13173 Nov  7  2012 EULA_ja
-r--r--r-- 1 root root   9841 Nov  7  2012 EULA_ko
-r--r--r-- 1 root root  10033 Nov  7  2012 EULA_pt
-r--r--r-- 1 root root   7306 Nov  7  2012 EULA_zh
-rw-r--r-- 1 root root     33 Apr 12 14:59 .fingerprint
-r--r--r-- 1 root root  18092 Jun 29  2010 GPL
dr-xr-xr-x 3 root root   4096 Apr 12 14:59 images
-rw-r--r-- 1 root root    309 Apr 12 16:05 local-repository.tmpl
-r--r--r-- 1 root root    114 Mar  8 21:16 media.repo
dr-xr-xr-x 2 root root 249856 Apr 12 14:58 Packages
dr-xr-xr-x 4 root root   4096 Apr 12 14:59 ppc
-r--r--r-- 1 root root  16435 Sep  2  2010 README
dr-xr-xr-x 2 root root   4096 Apr 12 14:59 repodata
-r--r--r-- 1 root root   3375 Feb 26 11:06 RPM-GPG-KEY-redhat-beta
-r--r--r-- 1 root root   3211 Feb 26 11:06 RPM-GPG-KEY-redhat-release
dr-xr-xr-x 3 root root   4096 Apr 12 14:58 Server
-r--r--r-- 1 root root   3757 Mar  8 21:26 TRANS.TBL
-r--r--r-- 1 root root   1528 Mar  8 21:17 .treeinfo

c910f02c08p15:/opt/rpms/xcat-core # cat /install/rhels6.9/ppc64/local-repository.tmpl
[local-rhels6.9-ppc64-ppc64]
name=xCAT configured yum repository for /install/rhels6.9/ppc64
baseurl=/install/rhels6.9/ppc64
enabled=1
gpgcheck=0

[local-rhels6.9-ppc64-Server]
name=xCAT configured yum repository for /install/rhels6.9/ppc64/Server
baseurl=/install/rhels6.9/ppc64/Server
enabled=1
gpgcheck=0

c910f02c08p15:/opt/rpms/xcat-core # rnetboot c910f02c08p16
c910f02c08p16: Success

[root@c910f02c08p16 ~]# ll /etc/yum.repos.d/
total 12
-rw-r--r--. 1 root root 344 Apr 12 11:13 local-repository-0.repo
-rw-r--r--. 1 root root 358 Apr 12 11:12 redhat.repo
-rw-r--r--. 1 root root 529 Feb 26 11:06 rhel-source.repo
[root@c910f02c08p16 ~]# cat /etc/yum.repos.d/local-repository-0.repo
[local-rhels6.9-ppc64-ppc64]
name=xCAT configured yum repository for /install/rhels6.9/ppc64
baseurl=http://10.2.8.15//install/rhels6.9/ppc64
enabled=1
gpgcheck=0

[local-rhels6.9-ppc64-Server]
name=xCAT configured yum repository for /install/rhels6.9/ppc64/Server
baseurl=http://10.2.8.15//install/rhels6.9/ppc64/Server
enabled=1
gpgcheck=0


[root@c910f02c08p16 ~]#yum install gdb
Loaded plugins: product-id, search-disabled-repos, security, subscription-
              : manager
This system is not registered with an entitlement server. You can use subscriptii
on-manager to register.
Setting up Install Process
Resolving Dependencies
--> Running transaction check
---> Package gdb.ppc64 0:7.2-92.el6 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package   Arch        Version          Repository                         Size
================================================================================
Installing:
 gdb       ppc64       7.2-92.el6       local-rhels6.9-ppc64-Server       2.3 M

Dependencies Resolved

================================================================================
 Package   Arch        Version          Repository                         Size
================================================================================
Installing:
 gdb       ppc64       7.2-92.el6       local-rhels6.9-ppc64-Server       2.3 M

Transaction Summary
================================================================================
Install       1 Package(s)

Total download size: 2.3 M
Installed size: 6.0 M
````