### PR TITLE
Add timestamp for every cmd running in xcatteat log to convenient debug in the future

### DIFF
--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -907,7 +907,8 @@ sub runcase
 
             #by
             my $runstart = timelocal(localtime());
-            log_this("\nRUN:$cmd");
+            my $runstartstr = scalar(localtime());
+            log_this("\nRUN:$cmd  [$runstartstr]");
             push(@record, "\nRUN:$cmd");
             @output = &runcmd($cmd);
             $rc     = $::RUNCMD_RC;


### PR DESCRIPTION
 This pull request modify xcattest to add timestamp for every cmd running in xcatteat log to convenient debug in the future