### PR TITLE
fix issue [DEV] nodes provisioned with redhat osimages created by xCAT 2.12.3 or earlier missed yum repo to MN in xCAT 2.12.4 or later #2856: process the multiple dirs in pkgdir

### DIFF
--- a/perl-xCAT/xCAT/Yum.pm
+++ b/perl-xCAT/xCAT/Yum.pm
@@ -54,8 +54,9 @@ sub generate_repo
     my $dirlocation = shift;
     my @dircomps    = File::Spec->splitdir($dirlocation);
     pop(@dircomps);
+    my $reponame = join("-",@dircomps);
     my $yumurl = File::Spec->catdir(@dircomps);
-    my $reponame = $dircomps[$#dircomps];
+
     print $yumrepofile "[local-$distname-$arch-$reponame]\n";
     print $yumrepofile "name=xCAT configured yum repository for $yumurl\n";
     print $yumrepofile "baseurl=$yumurl\n";

--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -16,6 +16,7 @@ use xCAT::TableUtils;
 use xCAT::NetworkUtils;
 use xCAT::MsgUtils;
 use xCAT::SvrUtils;
+use xCAT::Yum;
 
 #use Data::Dumper;
 use Getopt::Long;
@@ -1260,13 +1261,15 @@ sub mkinstall
             }
         }
 
-        unless(-f "/install/postscripts/repos/$pkgdir/local-repository.tmpl"){
-            #fix issue #2856@github
-            #for the osimages created by <=xCAT 2.12.3
-            #there is no local-repository.tmpl under pkgdir created on copycds
-            #generate local-repository.tmpl here if it does not exist
-            require xCAT::Yum;
-            xCAT::Yum->localize_yumrepo($pkgdir, $os, $arch);
+        my @pkgdirs=split(/,/,$pkgdir);
+        foreach my $mypkgdir (@pkgdirs){
+            unless(-f "/install/postscripts/repos/$mypkgdir/local-repository.tmpl"){
+                #fix issue #2856@github
+                #for the osimages created by <=xCAT 2.12.3
+                #there is no local-repository.tmpl under pkgdir created on copycds
+                #generate local-repository.tmpl here if it does not exist
+                xCAT::Yum->localize_yumrepo($mypkgdir, $os, $arch);
+            }
         }
 
         my @missingparms;
@@ -2471,8 +2474,6 @@ sub copycd
         }
     }
 
-
-    require xCAT::Yum;
     xCAT::Yum->localize_yumrepo($path, $distname, $arch);
 
     if ($rc != 0)


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/2856#issuecomment-293757872:

process the multiple directories in osimage.pkgdir on nodeset