### PR TITLE
fix issue 2710, print usage when run renergy node without option

### DIFF
--- a/xCAT-server/lib/xcat/plugins/energy.pm
+++ b/xCAT-server/lib/xcat/plugins/energy.pm
@@ -151,6 +151,8 @@ sub parse_args {
         if ($::VERBOSE) {
             $opt->{verbose} = 1;
         }
+    } else {
+        return (1, &usage());
     }
 
     # if the request has node range


### PR DESCRIPTION
#2710 

For node that ``mgt=ipmi``, it will enter energy.pm first.
In energy.pm, check the node's type. If there is no option, did not know its type. So it will be processed in wrong function(not for ipmi). 
Modified that if without option, return error message with renergy usage.

Before:
```
[root@fs1 ~]# renergy frame45cn05
Error: frame45cn05: Couldn't connect to server [50.45.5.1].
```

After:
```
# renergy frame45cn05
Error: Usage:
    renergy [-h | --help]
    renergy [-v | --version]

    Power 6 server specific :
      renergy noderange [-V] { all | { [savingstatus] [cappingstatus] [cappingmaxmin] [cappingvalue] [cappingsoftmin] [averageAC] [averageDC] [ambienttemp] [exhausttemp] [CPUspeed] } }
      renergy noderange [-V] { {savingstatus}={on | off} | {cappingstatus}={on | off} | {cappingwatt}=watt | {cappingperc}=percentage }

    Power 7 server specific :
      renergy noderange [-V] { all | { [savingstatus] [dsavingstatus] [cappingstatus] [cappingmaxmin] [cappingvalue] [cappingsoftmin] [averageAC] [averageDC] [ambienttemp] [exhausttemp] [CPUspeed] [syssbpower] [sysIPLtime] [fsavingstatus] [ffoMin] [ffoVmin] [ffoTurbo] [ffoNorm] [ffovalue] } }
      renergy noderange [-V] { {savingstatus}={on | off} | {dsavingstatus}={on-norm | on-maxp | off} | {fsavingstatus}={on | off} | {ffovalue}=MHZ | {cappingstatus}={on | off} | {cappingwatt}=watt | {cappingperc}=percentage }

    Power 8 server specific :
      renergy noderange [-V] { all | [savingstatus] [dsavingstatus] [averageAC] [averageAChistory] [averageDC] [averageDChistory] [ambienttemp] [ambienttemphistory] [exhausttemp] [exhausttemphistory] [fanspeed] [fanspeedhistory] [CPUspeed] [CPUspeedhistory] [syssbpower] [sysIPLtime] [fsavingstatus] [ffoMin] [ffoVmin] [ffoTurbo] [ffoNorm] [ffovalue]}
      renergy noderange [-V] { savingstatus={on | off} | dsavingstatus={on-norm | on-maxp | off} | fsavingstatus={on | off} | ffovalue=MHZ }

    BladeCenter specific :
      For Management Modules:
        renergy noderange [-V] { all | pd1all | pd2all | [pd1status] [pd2status] [pd1policy] [pd2policy] [pd1powermodule1] [pd1powermodule2] [pd2powermodule1] [pd2powermodule2] [pd1avaiablepower] [pd2avaiablepower] [pd1reservedpower] [pd2reservedpower] [pd1remainpower] [pd2remainpower] [pd1inusedpower] [pd2inusedpower] [availableDC] [averageAC] [thermaloutput] [ambienttemp] [mmtemp] }
      For a blade server nodes:
        renergy noderange [-V] { all | [averageDC] [capability] [cappingvalue] [CPUspeed] [maxCPUspeed] [savingstatus] [dsavingstatus] }
        renergy noderange [-V] { savingstatus={on | off} | dsavingstatus={on-norm | on-maxp | off} }

    Flex specific :
      For Flex Management Modules:
        renergy noderange [-V] { all | [powerstatus] [powerpolicy] [powermodule] [avaiablepower] [reservedpower] [remainpower] [inusedpower] [availableDC] [averageAC] [thermaloutput] [ambienttemp] [mmtemp] }

      For Flex node (power and x86):
        renergy noderange [-V] { all | [averageDC] [capability] [cappingvalue] [cappingmaxmin] [cappingmax] [cappingmin] [cappingGmin] [CPUspeed] [maxCPUspeed] [savingstatus] [dsavingstatus] }
        renergy noderange [-V] { cappingstatus={on | off} | cappingwatt=watt | cappingperc=percentage | savingstatus={on | off} | dsavingstatus={on-norm | on-maxp | off} }

    iDataPlex specific :
      renergy noderange [-V] [ { cappingmaxmin | cappingmax | cappingmin } ] [cappingstatus] [cappingvalue] [relhistogram]
      renergy noderange [-V] { cappingstatus={on | enable | off | disable} | {cappingwatt|cappingvalue}=watt }

    OpenPOWER server specific :
      renergy noderange [ powerusage | temperature]
```