### PR TITLE
Modify the buildinfo file to write out the long commit ID 

### DIFF
--- a/build-ubunturepo
+++ b/build-ubunturepo
@@ -177,7 +177,7 @@ then
         short_short_ver=`cat Version|cut -d. -f 1`
         build_time=`date`
         build_machine=`hostname`
-        commit_id=`git rev-parse --short HEAD`
+        commit_id=`git rev-parse HEAD`
 
         package_dir_name=debs$REL
         #TODO: define the core path and tarball name
@@ -362,14 +362,14 @@ __EOF__
     chmod 775 mklocalrepo.sh
 
     #
-    # Add a buildinfo file under xcat-core to track information about the build
+    # Add a buildinfo file into the tar.bz2 file to track information about the build 
     #
-    buildinfo=$local_core_repo_path/buildinfo
-    echo "VERSION=$ver" > $buildinfo
-    echo "RELEASE=$xcat_release" >> $buildinfo
-    echo "BUILD_TIME=$build_time" >> $buildinfo
-    echo "BUILD_MACHINE=$build_machine" >> $buildinfo
-    echo "COMMIT_ID=$commit_id" >> $buildinfo
+    BUILDINFO=$local_core_repo_path/buildinfo
+    echo "VERSION=$ver" > $BUILDINFO
+    echo "RELEASE=$xcat_release" >> $BUILDINFO
+    echo "BUILD_TIME=$build_time" >> $BUILDINFO
+    echo "BUILD_MACHINE=$build_machine" >> $BUILDINFO
+    echo "COMMIT_ID=$commit_id" >> $BUILDINFO
 
     #create the xcat-core.list file
 

--- a/build-ubunturepo
+++ b/build-ubunturepo
@@ -177,7 +177,8 @@ then
         short_short_ver=`cat Version|cut -d. -f 1`
         build_time=`date`
         build_machine=`hostname`
-        commit_id=`git rev-parse HEAD`
+        commit_id=`git rev-parse --short HEAD`
+        commit_id_long=`git rev-parse HEAD`
 
         package_dir_name=debs$REL
         #TODO: define the core path and tarball name
@@ -370,6 +371,7 @@ __EOF__
     echo "BUILD_TIME=$build_time" >> $BUILDINFO
     echo "BUILD_MACHINE=$build_machine" >> $BUILDINFO
     echo "COMMIT_ID=$commit_id" >> $BUILDINFO
+    echo "COMMIT_ID_LONG=$commit_id_long" >> $BUILDINFO
 
     #create the xcat-core.list file
 

--- a/buildcore.sh
+++ b/buildcore.sh
@@ -188,7 +188,7 @@ function setversionvars {
     SHORTSHORTVER=`echo $VER|cut -d. -f 1`
     BUILD_TIME=`date`
     BUILD_MACHINE=`hostname`
-    COMMIT_ID=`git rev-parse --short HEAD`
+    COMMIT_ID=`git rev-parse HEAD`
     XCAT_RELEASE="snap$(date '+%Y%m%d%H%M')"
     echo "$XCAT_RELEASE" >Release
 }
@@ -541,7 +541,7 @@ else
 fi
 
 #
-# Add a VERSION file into the tar.bz2 file to track information about the build
+# Add a buildinfo file into the tar.bz2 file to track information about the build
 #
 BUILDINFO=$XCATCORE/buildinfo
 echo "VERSION=$VER" > $BUILDINFO

--- a/buildcore.sh
+++ b/buildcore.sh
@@ -188,7 +188,8 @@ function setversionvars {
     SHORTSHORTVER=`echo $VER|cut -d. -f 1`
     BUILD_TIME=`date`
     BUILD_MACHINE=`hostname`
-    COMMIT_ID=`git rev-parse HEAD`
+    COMMIT_ID=`git rev-parse --short HEAD`
+    COMMIT_ID_LONG=`git rev-parse HEAD`
     XCAT_RELEASE="snap$(date '+%Y%m%d%H%M')"
     echo "$XCAT_RELEASE" >Release
 }
@@ -549,6 +550,7 @@ echo "RELEASE=$XCAT_RELEASE" >> $BUILDINFO
 echo "BUILD_TIME=$BUILD_TIME" >> $BUILDINFO
 echo "BUILD_MACHINE=$BUILD_MACHINE" >> $BUILDINFO
 echo "COMMIT_ID=$COMMIT_ID" >> $BUILDINFO
+echo "COMMIT_ID_LONG=$COMMIT_ID_LONG" >> $BUILDINFO
 
 echo "Creating $(dirname $DESTDIR)/$TARNAME ..."
 if [[ -e $TARNAME ]]; then


### PR DESCRIPTION
Change the commit ID to be a long commit ID to help FVT calculate more information based on the commit ID.  Sync'ed up the code between LINUX and UBUNTU builds so when we search "buildinfo" we will get less results.  

I didn't build ubuntu but I tested in Linux... hopefully I didn't make a silly TYPO error. 

```
...
Creating /home/vhu/xcatbuild/long_commit_id/core-rpms-snap.tar.bz2 ...
[vhu@victorvm7 xcat-core]$
[vhu@victorvm7 xcat-core]$ cd /home/vhu/xcatbuild/long_commit_id
[vhu@victorvm7 long_commit_id]$ tar -jxvf core-rpms-snap.tar.bz2 >> /dev/null
[vhu@victorvm7 long_commit_id]$ ls xcat-core/buildinfo 
xcat-core/buildinfo
[vhu@victorvm7 long_commit_id]$ cat xcat-core/buildinfo 
VERSION=2.13.3
RELEASE=snap201704130859
BUILD_TIME=Thu Apr 13 08:59:06 EDT 2017
BUILD_MACHINE=victorvm7.pok.ibm.com
COMMIT_ID=e64d8d8567c0f800241d0223f9c3a075cbb95abc
```

@hu-weihua  Do you think we should leave COMMIT_ID short and create another COMMIT_ID_LONG incase we have existing scripts that are expecting short ID? 

