### PR TITLE
xCAT-server: fix S7200AP ipmi detection

### DIFF
--- a/xCAT-server/share/xcat/cons/ipmi
+++ b/xCAT-server/share/xcat/cons/ipmi
@@ -124,7 +124,7 @@ my $iface  = "lanplus";
 if (grep /IPMI Version              : 1.5/, @mcinfo) {
     $solcom = "isol";
     $iface  = "lan";
-} elsif (grep /Manufacturer ID           : 343/, @mcinfo) {
+} elsif (grep /Manufacturer ID           : 343/, @mcinfo && ! grep /Product ID                : 117/,@mcinfo) {
     $isintel = 1;
 }
 my $inteloption = "";


### PR DESCRIPTION
The Intel Xeon PHI S7200AP board uses a Manufacturer ID of 343, so xCAT attempts to use intelplus for the IPMI console.  However, this board does not use intelplus, so we should exclude it from the check (by also testing against the Product ID).