### PR TITLE
Add timestamp to every cmd for xcattest failedcases log

### DIFF
--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -909,7 +909,7 @@ sub runcase
             my $runstart = timelocal(localtime());
             my $runstartstr = scalar(localtime());
             log_this("\nRUN:$cmd  [$runstartstr]");
-            push(@record, "\nRUN:$cmd");
+            push(@record, "\nRUN:$cmd [$runstartstr]");
             @output = &runcmd($cmd);
             $rc     = $::RUNCMD_RC;
 


### PR DESCRIPTION
This pull request is a supplement of pull request #2860 .
Add timestamp to every running command of xcattest failedcases log. 