### PR TITLE
Fix docs and usage for clonevm, rflash, and img* commands

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/clonevm.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/clonevm.1.rst
@@ -19,7 +19,7 @@ SYNOPSIS
 ********
 
 
-\ **clonevm**\  \ *noderange*\  [ \ **-t**\  \ *mastertobemade*\  | \ **-b**\  \ *master to base vms upon*\  ]  \ **-d|-**\ **-detached -f|-**\ **-force**\ 
+\ **clonevm**\  \ *noderange*\  [ \ **-t**\  \ *master_to_be_made*\  | \ **-b**\  \ *master_to_base_vms_upon*\  ]  [ \ **-d|-**\ **-detached**\ ]  [\ **-f|-**\ **-force**\ ]
 
 
 ***********
@@ -31,15 +31,15 @@ Command to promote a VM's current configuration and storage to a master as well 
 performing the converse operation of creating VMs based on a master.
 
 By default, attempting to create a master from a running VM will produce an error. 
-The force argument will request that a master be made of the VM anyway.
+The \ **-**\ **-force**\  argument will request that a master be made of the VM anyway.
 
 Also, by default a VM that is used to create a master will be rebased as a thin 
-clone of that master. If the force argument is used to create a master of a powered
-on vm, this will not be done.  Additionally, the detached option can be used to 
+clone of that master. If the \ **-**\ **-force**\  argument is used to create a master of a powered
+on vm, this will not be done.  Additionally, the \ **-**\ **-detached**\  option can be used to 
 explicitly request that a clone not be tethered to a master image, allowing the 
 clones to not be tied to the health of a master, at the cost of additional storage.
 
-When promoting a VM's current state to master, all rleated virtual disks will be 
+When promoting a VM's current state to master, all related virtual disks will be 
 copied and merged with any prerequisite images.  A master will not be tethered to
 other masters.
 
@@ -49,19 +49,48 @@ OPTIONS
 *******
 
 
-\ **-h|-**\ **-help**\        Display usage message.
 
-\ **-b**\               The master to base the clones upon
+\ **-h|-**\ **-help**\ 
+ 
+ Display usage message.
+ 
 
-\ **-t**\               The target master to copy a single VM's state to
 
-\ **-d**\               Explicitly request that the noderange be untethered from any masters.
+\ **-b**\  \ *master_to_base_vms_upon*\ 
+ 
+ The master to base the clones upon
+ 
 
-\ **-f**\               Force cloning of a powered on VM.  Implies -d if the VM is on.
 
-\ **-v|-**\ **-version**\     Command Version.
+\ **-t**\  \ *master_to_be_made*\ 
+ 
+ The target master to copy a single VM's state to
+ 
 
-\ **-V|-**\ **-verbose**\     Verbose output.
+
+\ **-d|-**\ **-detached**\ 
+ 
+ Explicitly request that the noderange be untethered from any masters.
+ 
+
+
+\ **-f|-**\ **-force**\ 
+ 
+ Force cloning of a powered on VM.  Implies \ **-d**\  if the VM is on.
+ 
+
+
+\ **-v|-**\ **-version**\ 
+ 
+ Command Version.
+ 
+
+
+\ **-V|-**\ **-verbose**\ 
+ 
+ Verbose output.
+ 
+
 
 
 ************
@@ -80,7 +109,7 @@ EXAMPLES
 
 
 
-1. Creating a master named appserver from a node called vm1:
+1. Creating a master named \ *appserver*\  from a node called \ *vm1*\ :
  
  
  .. code-block:: perl
@@ -90,7 +119,7 @@ EXAMPLES
  
 
 
-2. Cleating 30 VMs from a master named appserver:
+2. Cleating 30 VMs from a master named \ *appserver*\ :
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man1/imgcapture.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/imgcapture.1.rst
@@ -19,7 +19,7 @@ SYNOPSIS
 ********
 
 
-\ **imgcapture**\  \ *node*\  \ **-t | -**\ **-type**\  {\ **diskless | sysclone**\ } \ **-o | -**\ **-osimage**\  \ *osimage*\  [\ **-V | -**\ **-verbose**\ ]
+\ **imgcapture**\  \ *node*\  \ **-t | -**\ **-type**\  {\ **diskless | sysclone**\ } \ **-o | -**\ **-osimage**\  \ *osimage*\  [\ **-i**\  \ *nodebootif*\ ] [\ **-n**\  \ *nodenetdrivers*\ ] [\ **-V | -**\ **-verbose**\ ]
 
 \ **imgcapture**\  [\ **-h**\  | \ **-**\ **-help**\ ] | [\ **-v**\  | \ **-**\ **-version**\ ]
 
@@ -31,9 +31,9 @@ DESCRIPTION
 
 The \ **imgcapture**\  command will capture an image from one running diskful Linux node and create a diskless or diskful image for later use.
 
-The \ **node**\  should be one diskful Linux node, managed by the xCAT MN, and the remote shell between MN and the \ **node**\  should have been configured. AIX is not supported.
+The \ **node**\  should be one diskful Linux node, managed by the xCAT MN, and the remote shell between MN and the \ **node**\  should have been configured. AIX is not supported. VMs are not supported.
 
-The \ **imgcapture**\  command supports two image types: \ **diskless**\  and \ **sysclone**\ . For the \ **diskless**\  type, it will capture an image from one running diskful Linux node, prepares the rootimg directory, kernel and initial rmadisks for the \ **liteimg**\ /\ **packimage**\  command to generate the statelite/stateless rootimg. For the \ **sysclone**\  type, it will capture an image from one running diskful Linux node, create an osimage which can be used to clone other diskful Linux nodes.
+The \ **imgcapture**\  command supports two image types: \ **diskless**\  and \ **sysclone**\ . For the \ **diskless**\  type, it will capture an image from one running diskful Linux node, prepares the rootimg directory, kernel and initial ramdisks for the \ **liteimg**\ /\ **packimage**\  command to generate the statelite/stateless rootimg. For the \ **sysclone**\  type, it will capture an image from one running diskful Linux node, create an osimage which can be used to clone other diskful Linux nodes.
 
 The \ **diskless**\  type:
 
@@ -80,15 +80,13 @@ OPTIONS
  
  The network interface the diskless node will boot over (e.g. eth0), which is used by the \ **genimage**\  command to generate initial ramdisks.
  
- This is optional.
- 
 
 
 \ **-n**\  \ *nodenetdrivers*\ 
  
  The driver modules needed for the network interface, which is used by the \ **genimage**\  command to generate initial ramdisks.
  
- This is optional. By default, the \ **genimage**\  command can provide drivers for the following network interfaces:
+ By default, the \ **genimage**\  command can provide drivers for the following network interfaces:
  
  For x86 or x86_64 platform:
  

--- a/docs/source/guides/admin-guides/references/man1/imgexport.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/imgexport.1.rst
@@ -29,7 +29,7 @@ DESCRIPTION
 ***********
 
 
-The imgexport command will export an image that is being used by xCAT.  To export images, you must have the images defined in the \ *osimage*\  table. All the columns in the \ *osimage*\  and \ *linuximage*\  tables will be exported. If kits are used in stateful or stateless images, \ *kit*\ , \ *kitcomponent*\  and \ *kitrepo*\  tables will be exported. In addition, the following files will also be exported.
+The \ **imgexport**\  command will export an image that is being used by xCAT.  To export images, you must have the images defined in the \ *osimage*\  table. All the columns in the \ *osimage*\  and \ *linuximage*\  tables will be exported. If kits are used in stateful or stateless images, \ *kit*\ , \ *kitcomponent*\  and \ *kitrepo*\  tables will be exported. In addition, the following files will also be exported.
 
 For stateful:
   x.pkglist
@@ -61,7 +61,7 @@ For statelite:
 
 where x is the name of the profile.
 
-Any files specified by the -e flag will also be exported. If -p flag is specified, the names of the postscripts and the postbootscripts for the given node will be exported. The postscripts themsleves need to be manualy exported using -e flag.
+Any files specified by the \ **-e**\  flag will also be exported. If \ **-p**\  flag is specified, the names of the postscripts and the postbootscripts for the given node will be exported. The postscripts themsleves need to be manualy exported using \ **-e**\  flag.
 
 For statelite, the litefile table settings for the image will also be exported. The litetree and statelite tables are not exported.
 
@@ -71,17 +71,42 @@ OPTIONS
 *******
 
 
-\ **-e|-**\ **-extra**\  \ *srcfile:destdir*\     Pack up extra files. If \ *destdir*\  is omitted, the destination directory will be the same as the source directory.
 
-\ **-h|-**\ **-help**\                          Display usage message.
+\ **-e|-**\ **-extra**\  \ *srcfile:destdir*\ 
+ 
+ Pack up extra files. If \ *destdir*\  is omitted, the destination directory will be the same as the source directory.
+ 
 
-\ **-p|-**\ **-postscripts**\  \ *node_name*\   Get the names of the postscripts and postbootscripts for the given node and pack them into the image.
 
-\ **-v|-**\ **-verbose**\                       Verbose output.
+\ **-h|-**\ **-help**\ 
+ 
+ Display usage message.
+ 
 
-\ *image_name*\                         The name of the image. Use \ *lsdef -t*\  osimage to find out all the image names.
 
-\ *destination*\                        The output bundle file name.
+\ **-p|-**\ **-postscripts**\  \ *node_name*\ 
+ 
+ Get the names of the postscripts and postbootscripts for the given node and pack them into the image.
+ 
+
+
+\ **-v|-**\ **-verbose**\ 
+ 
+ Verbose output.
+ 
+
+
+\ *image_name*\ 
+ 
+ The name of the image. Use \ **lsdef -t osimage**\  to find out all the image names.
+ 
+
+
+\ *destination*\ 
+ 
+ The output bundle file name.
+ 
+
 
 
 ************

--- a/docs/source/guides/admin-guides/references/man1/imgimport.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/imgimport.1.rst
@@ -29,7 +29,7 @@ DESCRIPTION
 ***********
 
 
-The imgimport command will import an image that has been exported by \ *imgexport*\  from xCAT.  This is the easiest way to transfer/backup/, change or share images created by xCAT whether they be stateless or stateful. The bundle file will be unpacked in the current working directory. The xCAT configuration such as \ *osimage*\  and \ *linuximage*\  tables will then be updated.
+The \ **imgimport**\  command will import an image that has been exported by \ **imgexport**\  from xCAT.  This is the easiest way to transfer, backup, change or share images created by xCAT whether they be stateless or stateful. The bundle file will be unpacked in the current working directory. The xCAT configuration such as \ *osimage*\  and \ *linuximage*\  tables will then be updated.
 
 For stateful, the following files will be copied to the appropriate directories.
   x.pkglist
@@ -61,15 +61,15 @@ For statelite, the following files will be copied to the appropriate directories
 
 where x is the profile name.
 
-Any extra files, included by --extra flag in the imgexport command, will also be copied to the appropriate directories.
+Any extra files, included by \ **-**\ **-extra**\  flag in the \ **imgexport**\  command, will also be copied to the appropriate directories.
 
 For statelite, the litefile table will be updated for the image. The litetree and statelite tables are not imported.
 
-If -p flag is specified, the \ *postscripts*\  table will be updated with the postscripts and the postbootscripts names from the image for the nodes given by this flag.
+If \ **-p**\  flag is specified, the \ *postscripts*\  table will be updated with the postscripts and the postbootscripts names from the image for the nodes given by this flag.
 
-If -f flag is not specified, all the files will be copied to the same directories as the source. If it is specified, the old profile name x will be changed to the new and the files will be copied to the appropriate directores for the new profiles. For example, \ */opt/xcat/share/xcat/netboot/sles/x.pkglist*\  will be copied to \ */install/custom/netboot/sles/compute_new.pkglist*\  and \ */install/netboot/sles11/ppc64/x/kernel*\  will be copied to \ */install/netboot/sles11/ppc64/compute_new/kernel*\ . This flag is commonly used when you want to copy the image on the same xCAT mn so you can make modification on the new one.
+If \ **-f**\  flag is not specified, all the files will be copied to the same directories as the source. If it is specified, the old profile name x will be changed to the new and the files will be copied to the appropriate directores for the new profiles. For example, \ */opt/xcat/share/xcat/netboot/sles/x.pkglist*\  will be copied to \ */install/custom/netboot/sles/compute_new.pkglist*\  and \ */install/netboot/sles11/ppc64/x/kernel*\  will be copied to \ */install/netboot/sles11/ppc64/compute_new/kernel*\ . This flag is commonly used when you want to copy the image on the same xCAT mn so you can make modification on the new one.
 
-After this command, you can run the \ *nodeset*\  command and then start deploying the nodes. You can also choose to modify the files and run the following commands before the node depolyment.
+After this command, you can run the \ **nodeset**\  command and then start deploying the nodes. You can also choose to modify the files and run the following commands before the node depolyment.
 
 For stateful:
   nodeset
@@ -90,13 +90,30 @@ OPTIONS
 *******
 
 
-\ **-f|-**\ **-profile**\  \ *new_prof*\       Import the image with a new profile name.
 
-\ **-h|-**\ **-help**\                      Display usage message.
+\ **-f|-**\ **-profile**\  \ *new_profile*\ 
+ 
+ Import the image with a new profile name.
+ 
 
-\ **-p|-**\ **-postscripts**\  \ *nodelist*\   Import the postscripts. The postscripts contained in the image will be set in the postscripts table for \ *nodelist*\ .
 
-\ **-v|-**\ **-verbose**\                   Verbose output.
+\ **-h|-**\ **-help**\ 
+ 
+ Display usage message.
+ 
+
+
+\ **-p|-**\ **-postscripts**\  \ *nodelist*\ 
+ 
+ Import the postscripts. The postscripts contained in the image will be set in the postscripts table for \ *nodelist*\ .
+ 
+
+
+\ **-v|-**\ **-verbose**\ 
+ 
+ Verbose output.
+ 
+
 
 
 ************

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -324,14 +324,14 @@ my %usage = (
       "Usage: 
     rflash [ -h|--help|-v|--version]
     PPC (with HMC) specific:
-	rflash <noderange> -p <rpm_directory> [--activate concurrent | disruptive][-V|--verbose] 
-	rflash <noderange> [--commit | --recover] [-V|--verbose]
+	rflash <noderange> -p <rpm_directory> [--activate {concurrent | disruptive}] [-V|--verbose] 
+	rflash <noderange> {--commit | --recover} [-V|--verbose]
     PPC (using Direct FSP Management) specific:
-	rflash <noderange> -p <rpm_directory> --activate <disruptive|deferred> [-d <data_directory>]
+	rflash <noderange> -p <rpm_directory> [--activate {disruptive|deferred}] [-d <data_directory>]
 	rflash <noderange> [--commit | --recover] [-V|--verbose]
         rflash <noderange> [--bpa_acdl]
     PPC64LE (using BMC Management) specific:
-        rflash <noderange> [-c | --check] <hpm_file>",
+        rflash <noderange> [-c | --check] [--retry=<count>] [-V] <hpm_file>",
     "mkhwconn" =>
       "Usage:
     mkhwconn [-h|--help]

--- a/xCAT-client/pods/man1/clonevm.1.pod
+++ b/xCAT-client/pods/man1/clonevm.1.pod
@@ -4,7 +4,7 @@ B<clonevm> - Create masters from virtual machines and virtual machines from mast
 
 =head1 SYNOPSIS
 
-B<clonevm> I<noderange> [ B<-t> I<mastertobemade> | B<-b> I<master to base vms upon> ]  B<-d|--detached -f|--force>
+B<clonevm> I<noderange> [ B<-t> I<master_to_be_made> | B<-b> I<master_to_base_vms_upon> ]  [ B<-d|--detached>]  [B<-f|--force>]
 
 =head1 DESCRIPTION
 
@@ -12,35 +12,51 @@ Command to promote a VM's current configuration and storage to a master as well 
 performing the converse operation of creating VMs based on a master.
 
 By default, attempting to create a master from a running VM will produce an error. 
-The force argument will request that a master be made of the VM anyway.
+The B<--force> argument will request that a master be made of the VM anyway.
 
 Also, by default a VM that is used to create a master will be rebased as a thin 
-clone of that master. If the force argument is used to create a master of a powered
-on vm, this will not be done.  Additionally, the detached option can be used to 
+clone of that master. If the B<--force> argument is used to create a master of a powered
+on vm, this will not be done.  Additionally, the B<--detached> option can be used to 
 explicitly request that a clone not be tethered to a master image, allowing the 
 clones to not be tied to the health of a master, at the cost of additional storage.
 
-When promoting a VM's current state to master, all rleated virtual disks will be 
+When promoting a VM's current state to master, all related virtual disks will be 
 copied and merged with any prerequisite images.  A master will not be tethered to
 other masters.
 
 =head1 OPTIONS
 
+=over 4
 
-B<-h|--help>       Display usage message.
+=item B<-h|--help>
 
-B<-b>              The master to base the clones upon
+Display usage message.
 
-B<-t>              The target master to copy a single VM's state to
+=item B<-b> I<master_to_base_vms_upon>
 
-B<-d>              Explicitly request that the noderange be untethered from any masters.
+The master to base the clones upon
 
-B<-f>              Force cloning of a powered on VM.  Implies -d if the VM is on.
+=item B<-t> I<master_to_be_made>
 
-B<-v|--version>    Command Version.
+The target master to copy a single VM's state to
 
-B<-V|--verbose>    Verbose output.
+=item B<-d|--detached>
 
+Explicitly request that the noderange be untethered from any masters.
+
+=item B<-f|--force>
+
+Force cloning of a powered on VM.  Implies B<-d> if the VM is on.
+
+=item B<-v|--version>
+
+Command Version.
+
+=item B<-V|--verbose>
+
+Verbose output.
+
+=back
 
 =head1 RETURN VALUE
 
@@ -53,12 +69,12 @@ Any other value: An error has occurred.
 =over 3
 
 =item 1.
-Creating a master named appserver from a node called vm1:
+Creating a master named I<appserver> from a node called I<vm1>:
 
  clonevm vm1 -t appserver
 
 =item 2.
-Cleating 30 VMs from a master named appserver:
+Cleating 30 VMs from a master named I<appserver>:
 
  clonevm vm1-vm30 -b appserver
 

--- a/xCAT-client/pods/man1/imgcapture.1.pod
+++ b/xCAT-client/pods/man1/imgcapture.1.pod
@@ -4,7 +4,7 @@ B<imgcapture> - Captures an image from a Linux diskful node and create a diskles
 
 =head1 SYNOPSIS
 
-B<imgcapture> I<node> B<-t>|B<--type> {B<diskless>|B<sysclone>} B<-o>|B<--osimage> I<osimage> [B<-V>|B<--verbose>]
+B<imgcapture> I<node> B<-t>|B<--type> {B<diskless>|B<sysclone>} B<-o>|B<--osimage> I<osimage> [B<-i> I<nodebootif>] [B<-n> I<nodenetdrivers>] [B<-V>|B<--verbose>]
 
 B<imgcapture> [B<-h> | B<--help>] | [B<-v> | B<--version>]
 
@@ -12,9 +12,9 @@ B<imgcapture> [B<-h> | B<--help>] | [B<-v> | B<--version>]
 
 The B<imgcapture> command will capture an image from one running diskful Linux node and create a diskless or diskful image for later use.
 
-The B<node> should be one diskful Linux node, managed by the xCAT MN, and the remote shell between MN and the B<node> should have been configured. AIX is not supported. 
+The B<node> should be one diskful Linux node, managed by the xCAT MN, and the remote shell between MN and the B<node> should have been configured. AIX is not supported. VMs are not supported.
 
-The B<imgcapture> command supports two image types: B<diskless> and B<sysclone>. For the B<diskless> type, it will capture an image from one running diskful Linux node, prepares the rootimg directory, kernel and initial rmadisks for the B<liteimg>/B<packimage> command to generate the statelite/stateless rootimg. For the B<sysclone> type, it will capture an image from one running diskful Linux node, create an osimage which can be used to clone other diskful Linux nodes.
+The B<imgcapture> command supports two image types: B<diskless> and B<sysclone>. For the B<diskless> type, it will capture an image from one running diskful Linux node, prepares the rootimg directory, kernel and initial ramdisks for the B<liteimg>/B<packimage> command to generate the statelite/stateless rootimg. For the B<sysclone> type, it will capture an image from one running diskful Linux node, create an osimage which can be used to clone other diskful Linux nodes.
 
 The B<diskless> type:
 
@@ -52,13 +52,11 @@ The osimage name.
 
 The network interface the diskless node will boot over (e.g. eth0), which is used by the B<genimage> command to generate initial ramdisks.
 
-This is optional.
-
 =item B<-n> I<nodenetdrivers>
 
 The driver modules needed for the network interface, which is used by the B<genimage> command to generate initial ramdisks.
 
-This is optional. By default, the B<genimage> command can provide drivers for the following network interfaces:
+By default, the B<genimage> command can provide drivers for the following network interfaces:
 
 For x86 or x86_64 platform:
 

--- a/xCAT-client/pods/man1/imgexport.1.pod
+++ b/xCAT-client/pods/man1/imgexport.1.pod
@@ -11,7 +11,7 @@ B<imgexport> I<image_name> [I<destination>] [[B<-e>|B<--extra> I<file:dir>] ... 
 
 =head1 DESCRIPTION
 
-The imgexport command will export an image that is being used by xCAT.  To export images, you must have the images defined in the I<osimage> table. All the columns in the I<osimage> and I<linuximage> tables will be exported. If kits are used in stateful or stateless images, I<kit>, I<kitcomponent> and I<kitrepo> tables will be exported. In addition, the following files will also be exported.
+The B<imgexport> command will export an image that is being used by xCAT.  To export images, you must have the images defined in the I<osimage> table. All the columns in the I<osimage> and I<linuximage> tables will be exported. If kits are used in stateful or stateless images, I<kit>, I<kitcomponent> and I<kitrepo> tables will be exported. In addition, the following files will also be exported.
 
 For stateful:
   x.pkglist
@@ -45,24 +45,39 @@ For statelite:
 where x is the name of the profile.
 
 
-Any files specified by the -e flag will also be exported. If -p flag is specified, the names of the postscripts and the postbootscripts for the given node will be exported. The postscripts themsleves need to be manualy exported using -e flag. 
+Any files specified by the B<-e> flag will also be exported. If B<-p> flag is specified, the names of the postscripts and the postbootscripts for the given node will be exported. The postscripts themsleves need to be manualy exported using B<-e> flag. 
 
 For statelite, the litefile table settings for the image will also be exported. The litetree and statelite tables are not exported.
 
 =head1 OPTIONS
 
+=over 4
 
-B<-e|--extra> I<srcfile:destdir>    Pack up extra files. If I<destdir> is omitted, the destination directory will be the same as the source directory. 
+=item B<-e|--extra> I<srcfile:destdir>
 
-B<-h|--help>                         Display usage message.
+Pack up extra files. If I<destdir> is omitted, the destination directory will be the same as the source directory. 
+
+=item B<-h|--help>
+
+Display usage message.
   
-B<-p|--postscripts> I<node_name>  Get the names of the postscripts and postbootscripts for the given node and pack them into the image. 
+=item B<-p|--postscripts> I<node_name>
 
-B<-v|--verbose>                      Verbose output.
+Get the names of the postscripts and postbootscripts for the given node and pack them into the image. 
 
-I<image_name>                        The name of the image. Use I<lsdef -t> osimage to find out all the image names. 
+=item B<-v|--verbose>
 
-I<destination>                       The output bundle file name. 
+Verbose output.
+
+=item I<image_name>
+
+The name of the image. Use B<lsdef -t osimage> to find out all the image names. 
+
+=item I<destination>
+
+The output bundle file name. 
+
+=back
 
 
 =head1 RETURN VALUE

--- a/xCAT-client/pods/man1/imgimport.1.pod
+++ b/xCAT-client/pods/man1/imgimport.1.pod
@@ -10,7 +10,7 @@ B<imgimport> I<bundle_file_name> [B<-p>|B<--postscripts> I<nodelist>] [B<-f>|B<-
 
 =head1 DESCRIPTION
 
-The imgimport command will import an image that has been exported by I<imgexport> from xCAT.  This is the easiest way to transfer/backup/, change or share images created by xCAT whether they be stateless or stateful. The bundle file will be unpacked in the current working directory. The xCAT configuration such as I<osimage> and I<linuximage> tables will then be updated.
+The B<imgimport> command will import an image that has been exported by B<imgexport> from xCAT.  This is the easiest way to transfer, backup, change or share images created by xCAT whether they be stateless or stateful. The bundle file will be unpacked in the current working directory. The xCAT configuration such as I<osimage> and I<linuximage> tables will then be updated.
 
 For stateful, the following files will be copied to the appropriate directories.
   x.pkglist
@@ -42,15 +42,15 @@ For statelite, the following files will be copied to the appropriate directories
 
 where x is the profile name. 
 
-Any extra files, included by --extra flag in the imgexport command, will also be copied to the appropriate directories. 
+Any extra files, included by B<--extra> flag in the B<imgexport> command, will also be copied to the appropriate directories. 
 
 For statelite, the litefile table will be updated for the image. The litetree and statelite tables are not imported.
 
-If -p flag is specified, the I<postscripts> table will be updated with the postscripts and the postbootscripts names from the image for the nodes given by this flag.
+If B<-p> flag is specified, the I<postscripts> table will be updated with the postscripts and the postbootscripts names from the image for the nodes given by this flag.
 
-If -f flag is not specified, all the files will be copied to the same directories as the source. If it is specified, the old profile name x will be changed to the new and the files will be copied to the appropriate directores for the new profiles. For example, I</opt/xcat/share/xcat/netboot/sles/x.pkglist> will be copied to I</install/custom/netboot/sles/compute_new.pkglist> and I</install/netboot/sles11/ppc64/x/kernel> will be copied to I</install/netboot/sles11/ppc64/compute_new/kernel>. This flag is commonly used when you want to copy the image on the same xCAT mn so you can make modification on the new one. 
+If B<-f> flag is not specified, all the files will be copied to the same directories as the source. If it is specified, the old profile name x will be changed to the new and the files will be copied to the appropriate directores for the new profiles. For example, I</opt/xcat/share/xcat/netboot/sles/x.pkglist> will be copied to I</install/custom/netboot/sles/compute_new.pkglist> and I</install/netboot/sles11/ppc64/x/kernel> will be copied to I</install/netboot/sles11/ppc64/compute_new/kernel>. This flag is commonly used when you want to copy the image on the same xCAT mn so you can make modification on the new one. 
 
-After this command, you can run the I<nodeset> command and then start deploying the nodes. You can also choose to modify the files and run the following commands before the node depolyment. 
+After this command, you can run the B<nodeset> command and then start deploying the nodes. You can also choose to modify the files and run the following commands before the node depolyment. 
 
 For stateful:
   nodeset
@@ -68,15 +68,25 @@ For statelite
 
 =head1 OPTIONS
 
+=over 4
 
-B<-f|--profile> I<new_prof>      Import the image with a new profile name. 
+=item B<-f|--profile> I<new_profile>
 
-B<-h|--help>                     Display usage message.
+Import the image with a new profile name. 
 
-B<-p|--postscripts> I<nodelist>  Import the postscripts. The postscripts contained in the image will be set in the postscripts table for I<nodelist>.
+=item B<-h|--help>
 
-B<-v|--verbose>                  Verbose output.
+Display usage message.
 
+=item B<-p|--postscripts> I<nodelist>
+
+Import the postscripts. The postscripts contained in the image will be set in the postscripts table for I<nodelist>.
+
+=item B<-v|--verbose>
+
+Verbose output.
+
+=back
 
 =head1 RETURN VALUE
 

--- a/xCAT-server/lib/xcat/plugins/imgcapture.pm
+++ b/xCAT-server/lib/xcat/plugins/imgcapture.pm
@@ -46,7 +46,7 @@ sub process_request {
     @ARGV = @{ $request->{arg} } if (defined $request->{arg});
     my $argc = scalar @ARGV;
 
-    my $usage = "Usage:\n imgcapture <node> -t|--type {diskless|sysclone} -o|--osimage <osimage> [-V | --verbose] \n imgcapture [-h|--help] \n imgcapture [-v|--version]";
+    my $usage = "Usage:\n imgcapture <node> -t|--type {diskless|sysclone} -o|--osimage <osimage> [-i <nodebootif>] [-n <nodebootif>] [-V | --verbose] \n imgcapture [-h|--help] \n imgcapture [-v|--version]";
 
     my $os;
     my $arch;


### PR DESCRIPTION
Fix usage, spelling, grammar and formatting for:
`rflash`
`clonevm`
`imgimport`
`imgexport`
`imgcapture`