### PR TITLE
Add tmp doc for how to use openbmc

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/index.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/index.rst
@@ -11,3 +11,4 @@ The sections are organized based on hardware architecture.
 
    ppc64le/index.rst
    x86_64/index.rst
+   openbmc/index.rst

--- a/docs/source/guides/admin-guides/manage_clusters/openbmc/configure.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/openbmc/configure.rst
@@ -1,0 +1,9 @@
+Configure passwords
+===================
+
+Configure the passwords for Management modules of the compute nodes.
+
+* For OpenBMC managed systems: ::
+
+    chtab key=openbmc passwd.username=root passwd.password=0penBMC
+

--- a/docs/source/guides/admin-guides/manage_clusters/openbmc/index.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/openbmc/index.rst
@@ -1,0 +1,12 @@
+OpenPOWER (OpenBMC managed)
+===========================
+
+The following sections documents the procedures in managing OpenPOWER servers in an xCAT cluster.  
+These are machines use the IBM Power Architecture and is **OpenBMC** managed.
+
+
+.. toctree::
+   :maxdepth: 2
+
+   configure.rst
+   openbmc.rst 

--- a/docs/source/guides/admin-guides/manage_clusters/openbmc/index.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/openbmc/index.rst
@@ -1,9 +1,8 @@
 OpenPOWER (OpenBMC managed)
 ===========================
 
-The following sections documents the procedures in managing OpenPOWER servers in an xCAT cluster.  
-These are machines use the IBM Power Architecture and is **OpenBMC** managed.
-
+The following sections document the procedures in managing OpenPOWER servers in an xCAT cluster.
+OpenPower servers are machines that use IBM Power Architecture and are **OpenBMC** managed.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/guides/admin-guides/manage_clusters/openbmc/openbmc.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/openbmc/openbmc.rst
@@ -1,9 +1,9 @@
 Manually Define Nodes
 =====================
 
-**Manually Define Node** means the admin knows the detailed information of the physical server and manually defines it into xCAT database with ``mkdef`` commands.
+**Manually Define Node** means if admin knows the detailed information of the physical server, ``mkdef`` command can be used to manually define it into xCAT database..
 
-In this document, the following configuration is used in the example
+In this document, the following configuration is used as an example
 
 Compute Node info::
 
@@ -12,16 +12,16 @@ Compute Node info::
     OpenBMC username: root
     OpenBMC Password: 0penBMC
 
-Execute ``mkdef`` command to define the node: ::
+Run ``mkdef`` command to define the node: ::
 
-    mkdef -t node cn1 groups=openbmc,all mgt=openbmc cons=openbmc bmc=50.0.101.1 bmcusername=root bmcpassword=OpenBMC
+    mkdef -t node cn1 groups=openbmc,all mgt=openbmc cons=openbmc bmc=50.0.101.1 bmcusername=root bmcpassword=0penBmc
 
-The manually defined node will be like this::
+The manually defined node will be ::
 
     # lsdef cn1
     Object name: cn1
         bmc=50.0.101.1
-        bmcpassword=OpenBMC
+        bmcpassword=0penBmc 
         bmcusername=root
         cons=openbmc
         groups=openbmc,all
@@ -35,14 +35,14 @@ Hardware Management
 Remote Power Control
 ````````````````````
 
-The next important thing is to control the power of a remote physical machine. For this purpose, ``rpower`` command is involved. ::
+``rpower`` command can be used to control the power of a remote physical machine. ::
 
     rpower cn1 on
     rpower cn1 off
     rpower cn1 boot
     rpower cn1 reset
 
-Get the current rpower state of a machine, refer to the example below. ::
+To get the current rpower state of a machine: ::
 
     # rpower cn1 state
     cn1: on
@@ -50,11 +50,11 @@ Get the current rpower state of a machine, refer to the example below. ::
 Remote Console
 ``````````````
 
-In order to get the command line console remotely. xCAT provides the ``rcons`` command.
+``rcons`` command can be used to get command line remote console.
 
-#. Make sure the ``conserver`` is configured by running ``makeconservercf``.
+#. Make sure the ``conserver`` is configured by running ``makeconservercf cn1``.
 
-#. After that, you can get the command line console for a specific machine with the ``rcons`` command ::
+#. Start command line remote console: ::
 
     rcons cn1
 

--- a/docs/source/guides/admin-guides/manage_clusters/openbmc/openbmc.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/openbmc/openbmc.rst
@@ -1,7 +1,7 @@
 Manually Define Nodes
 =====================
 
-**Manually Define Node** means if admin knows the detailed information of the physical server, ``mkdef`` command can be used to manually define it into xCAT database..
+If admin knows the detailed information of the physical server, ``mkdef`` command can be used to manually define it into xCAT database.
 
 In this document, the following configuration is used as an example
 

--- a/docs/source/guides/admin-guides/manage_clusters/openbmc/openbmc.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/openbmc/openbmc.rst
@@ -1,0 +1,60 @@
+Manually Define Nodes
+=====================
+
+**Manually Define Node** means the admin knows the detailed information of the physical server and manually defines it into xCAT database with ``mkdef`` commands.
+
+In this document, the following configuration is used in the example
+
+Compute Node info::
+
+    CN Hostname: cn1
+    BMC Address: 50.0.101.1
+    OpenBMC username: root
+    OpenBMC Password: 0penBMC
+
+Execute ``mkdef`` command to define the node: ::
+
+    mkdef -t node cn1 groups=openbmc,all mgt=openbmc cons=openbmc bmc=50.0.101.1 bmcusername=root bmcpassword=OpenBMC
+
+The manually defined node will be like this::
+
+    # lsdef cn1
+    Object name: cn1
+        bmc=50.0.101.1
+        bmcpassword=OpenBMC
+        bmcusername=root
+        cons=openbmc
+        groups=openbmc,all
+        mgt=openbmc
+        postbootscripts=otherpkgs
+        postscripts=syslog,remoteshell,syncfiles
+
+Hardware Management
+===================
+
+Remote Power Control
+````````````````````
+
+The next important thing is to control the power of a remote physical machine. For this purpose, ``rpower`` command is involved. ::
+
+    rpower cn1 on
+    rpower cn1 off
+    rpower cn1 boot
+    rpower cn1 reset
+
+Get the current rpower state of a machine, refer to the example below. ::
+
+    # rpower cn1 state
+    cn1: on
+
+Remote Console
+``````````````
+
+In order to get the command line console remotely. xCAT provides the ``rcons`` command.
+
+#. Make sure the ``conserver`` is configured by running ``makeconservercf``.
+
+#. After that, you can get the command line console for a specific machine with the ``rcons`` command ::
+
+    rcons cn1
+


### PR DESCRIPTION
#2692 

http://10.3.5.4/install/build/html/guides/admin-guides/manage_clusters/openbmc/index.html

Add temporary doc to support openbmc's use.
Include: how to define openbmc node, how to set and get openbmc node's power status, how to enter console of openbmc node.

If all commands are supported for openbmc, will change all information to OpenPower section. 