### PR TITLE
fix issue performing yum update xCAT* overwrote our log rotate settings. #2795

### DIFF
--- a/xCAT/xCAT.spec
+++ b/xCAT/xCAT.spec
@@ -251,7 +251,7 @@ exit 0
 /install/postscripts
 /install/prescripts
 %ifos linux
-/etc/logrotate.d/xcat
+%config /etc/logrotate.d/xcat
 /etc/rsyslog.d/xcat-cluster.conf
 /etc/rsyslog.d/xcat-compute.conf
 /etc/rsyslog.d/xcat-debug.conf


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/2795:

take /etc/logrotate.d/xcat as a config file. it follows the rules of processing config files during rpm upgrade in http://rpm5.org/docs/max-rpm.html#s2-rpm-upgrade-config-file-magic:


with this fix, the scenario in issue https://github.com/xcat2/xcat-core/issues/2795 will follow the 
````
**Original file = X, Current file = Y, New file = X**

Here we have a file that was changed at some point. However, the new file is identical to the existing file prior to the local modifications.

In this case, RPM takes the viewpoint that since the original file and the new file are identical, the modifications made to the original version must still be valid for the new version. It leaves the existing, modified file in place. 

````

if the /etc/logrotate.d/xcat shipped by xCAT changed in the future, it follows the  rule:

````
 **Original file = X, Current file = Y, New file = Z**

Here the original file was modified at some point. The new file is different from both the original and the modified versions of the original file.

RPM is not able to analyze the contents of the files, and determine what is going on. In this instance, it takes the best possible approach. The new file is known to work properly with the rest of the software in the new package — at least the people building the new package should have insured that it does. The modified original file is an unknown: it might work with the new package, it might not. So RPM installs the new file.

BUT… The existing file was definitely modified. Someone made an effort to change the file, for some reason. Perhaps the information contained in the file is still of use. Therefore, RPM saves the modified file, naming it <file>.rpmsave, and prints a warning, so the user knows what happened:


warning: /etc/skel/.bashrc saved as /etc/skel/.bashrc.rpmsave

            
````

