### PR TITLE
Add test case for issue 2225 : [CUSTOMER] Stale rootimg.gz file left in the rootimg dir caused node boot failed.

### DIFF
--- a/xCAT-test/autotest/testcase/rmimage/case0
+++ b/xCAT-test/autotest/testcase/rmimage/case0
@@ -1,0 +1,26 @@
+start:genimage_stateless
+descriptiion:This case is to verify bug 2225 to test rmimage could work correctly to remove all image files.
+cmd:ls /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/;if [ $? -eq 0 ];then mv -f /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute.bak;fi
+cmd:copycds $$ISO
+check:rc==0
+cmd:genimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+check:rc==0
+cmd:packimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+check:rc==0
+cmd:cp -f /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.cpio.gz /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.gz
+check:rc==0
+cmd:rmimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+check:rc==0
+check:output=~Removing directory /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg
+check:output=~Removing file /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/kernel
+check:output=~Removing file /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/initrd-stateless.gz
+check:output=~Removing file /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/initrd-statelite.gz
+check:output=~Removing file /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.cpio.gz
+check:output=~Removing file /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.gz
+check:output=~Removing directory /tftpboot/xcat/osimage/__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+check:output=~Image files have been removed successfully from this management node.
+cmd:nodeset $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+check:rc!=0
+check:output=~kernel cannot be found at /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/kernel
+cmd:ls /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute.bak/;if [ $? -eq 0 ];then mv -f /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute.bak /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute;fi
+end

--- a/xCAT-test/autotest/testcase/rmimage/case0
+++ b/xCAT-test/autotest/testcase/rmimage/case0
@@ -1,4 +1,4 @@
-start:genimage_stateless
+start:rmimage_diskless_bug2225
 descriptiion:This case is to verify bug 2225 to test rmimage could work correctly to remove all image files.
 cmd:ls /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/;if [ $? -eq 0 ];then mv -f /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute.bak;fi
 cmd:copycds $$ISO

--- a/xCAT-test/autotest/testcase/rmimage/case0
+++ b/xCAT-test/autotest/testcase/rmimage/case0
@@ -1,5 +1,5 @@
-start:rmimage_diskless_bug2225
-descriptiion:This case is to verify bug 2225 to test rmimage could work correctly to remove all image files.
+start:rmimage_diskless
+descriptiion:This case is to test rmimage could work correctly to remove all image files.
 cmd:ls /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/;if [ $? -eq 0 ];then mv -f /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute.bak;fi
 cmd:copycds $$ISO
 check:rc==0


### PR DESCRIPTION
Add 1 case in this pull request.
This case is added for issue#2225

[Case 1]
Case Name: rmimage_diskless
Description: This case isto test rmimage could work correctly to remove all image files.
Attribute: CN is the compute node and is defined in xcatconfig file

@cxhong  Please review. Thanks!