### PR TITLE
Ignore groups inheritance for ppcdirect table as the special desgin

### DIFF
--- a/perl-xCAT/xCAT/DBobjUtils.pm
+++ b/perl-xCAT/xCAT/DBobjUtils.pm
@@ -490,7 +490,7 @@ sub getobjdefs
                         # The %tabhash is for performance considerations
                         my $tabspec = $xCAT::Schema::tabspec{$lookup_table};
                         my $nodecol = $tabspec->{'nodecol'} if defined($tabspec->{'nodecol'});
-                        if (($lookup_attr eq 'node' && $objtype eq 'node') || (defined($nodecol) && $objtype eq 'node')) {
+                        if (($lookup_attr eq 'node' && $objtype eq 'node') || (defined($nodecol) && $objtype eq 'node' && $lookup_table ne 'ppcdirect')) {
                             if (defined($tabhash{$lookup_table}{$objname}{$tabattr})) {
                                 if ($verbose == 1) {
                                     $objhash{$objname}{$attr} = "$tabhash{$lookup_table}{$objname}{$tabattr}\t(Table:$lookup_table - Key:$lookup_attr - Column:$tabattr)";


### PR DESCRIPTION
This patch aims to fix the error from automation testcase
`chdef_multiple_keys` due to the changes to support groups inheritance
for switches table.
As the strange design about access_tabentry, ppcdirect works like site
table and must not support groups.

Close-issue: #2450