### PR TITLE
Add test case for issue 2521 : `makedhcp` fails for nodes on remote networks

### DIFF
--- a/xCAT-test/autotest/testcase/makedhcp/cases0
+++ b/xCAT-test/autotest/testcase/makedhcp/cases0
@@ -176,8 +176,8 @@ check:output!~$$CN
 cmd:makedhcp -a
 end
 
-start:makedhcp_remote_network_bug2521
-descriptiion:This case is to verify bug 2521 to test when there is mgtifname='!remote!<nicname>', makedhcp could work correctly and create entrys in dhcp lease file.
+start:makedhcp_remote_network
+descriptiion:This case is to test when there is mgtifname='!remote!<nicname>', makedhcp could work correctly and create entrys in dhcp lease file.
 cmd:mkdef -t network -o testnetwork net=100.100.100.0 mask=255.255.255.0 mgtifname='!remote!eth0' gateway=100.100.100.1
 check:rc==0
 cmd:lsdef -t network

--- a/xCAT-test/autotest/testcase/makedhcp/cases0
+++ b/xCAT-test/autotest/testcase/makedhcp/cases0
@@ -176,3 +176,31 @@ check:output!~$$CN
 cmd:makedhcp -a
 end
 
+start:makedhcp_remote_network_bug2521
+descriptiion:This case is to verify bug 2521 to test when there is mgtifname='!remote!<nicname>', makedhcp could work correctly and create entrys in dhcp lease file.
+cmd:mkdef -t network -o testnetwork net=100.100.100.0 mask=255.255.255.0 mgtifname='!remote!eth0' gateway=100.100.100.1
+check:rc==0
+cmd:lsdef -t network
+check:rc==0
+check:output=~testnetwork
+check:rc==0
+cmd:mkdef -t node -o testnode ip=100.100.100.2 groups=all mac=42:3d:0a:05:27:0b 
+check:rc==0
+cmd: cp -f /etc/hosts /etc/hosts.bak
+cmd:echo "100.100.100.2 testnode" >> /etc/hosts
+check:rc==0
+cmd:makedhcp testnode
+check:rc==0
+cmd:makdhcp -q testnode
+check:rc==0
+check:output=~testnode: ip-address = 100.100.100.2 
+cmd:makdhcp -d testnode
+check:rc==0
+cmd:makedhcp -n
+check:rc==0
+cmd:noderm testnode
+check:rc==0
+cmd:chtab -d netname=testnetwork networks
+check:rc==0
+cmd:cp -f /etc/hosts.bak /etc/hosts
+end

--- a/xCAT-test/autotest/testcase/makedhcp/cases0
+++ b/xCAT-test/autotest/testcase/makedhcp/cases0
@@ -189,6 +189,7 @@ check:rc==0
 cmd: cp -f /etc/hosts /etc/hosts.bak
 cmd:echo "100.100.100.2 testnode" >> /etc/hosts
 check:rc==0
+cmd:makdhcp -d testnode
 cmd:makedhcp testnode
 check:rc==0
 cmd:makdhcp -q testnode


### PR DESCRIPTION
Add 1 case in this pull request.
This case is added for issue#2521

[Case 1]
Case Name: makedhcp_remote_network
Description: This case is to verify bug 2521 to test when there is mgtifname='!remote!<nicname>', makedhcp could work correctly and create entrys in dhcp lease file.
Attribute:  N/A