### PR TITLE
Add test case for verify the github issue #2637: Preserve the user ownership of the file for xdcp command

### DIFF
--- a/xCAT-test/autotest/testcase/xdcp/cases1
+++ b/xCAT-test/autotest/testcase/xdcp/cases1
@@ -1,4 +1,4 @@
-start:xdcp_github_issue2637
+start:xdcp_nonroot_user
 cmd:useradd -m xyzzy
 check:rc==0
 cmd:( cd ~ && tar cf - .xcat .ssh ) | ( cd ~xyzzy && tar xf - )

--- a/xCAT-test/autotest/testcase/xdcp/cases1
+++ b/xCAT-test/autotest/testcase/xdcp/cases1
@@ -1,0 +1,22 @@
+start:xdcp_github_issue2637
+cmd:useradd -m xyzzy
+check:rc==0
+cmd:( cd ~ && tar cf - .xcat .ssh ) | ( cd ~xyzzy && tar xf - )
+check:rc==0
+cmd:chown -R xyzzy ~xyzzy/.xcat ~xyzzy/.ssh
+check:rc==0
+cmd:xdsh $$CN "useradd -m xyzzy"
+check:rc==0
+cmd:xdsh $$CN "( cd ~ && tar cf - .ssh ) | ( cd ~xyzzy && tar xf - )"
+check:rc==0
+cmd:xdsh $$CN "chown -R xyzzy ~xyzzy/.ssh"
+check:rc==0
+cmd:su -c "xdcp $$CN /etc/sysctl.conf /tmp/sysctl.conf" - xyzzy
+check:rc==0 
+cmd:xdsh $$CN "stat -c '%U' /tmp/sysctl.conf"
+check:output=~xyzzy
+cmd:xdsh $$CN "userdel xyzzy"
+check:rc==0
+cmd:userdel xyzzy
+check:rc==0
+end


### PR DESCRIPTION
Add one cases in this pull request.
This case is added for issue #2637

[Case index]
Case Name: xdcp_nonroot_user
description: The test case add a ordinary system user on the manage node and compute node, and then use this non-root system user to perform `xdcp`, and check the owner of the copied file after that. 