### PR TITLE
Add test case for issue 2614 : nodeset does not support addkcmdline when netboot=xnba

### DIFF
--- a/xCAT-test/autotest/testcase/nodeset/cases0
+++ b/xCAT-test/autotest/testcase/nodeset/cases0
@@ -178,7 +178,7 @@ description: This case is to verify bug 2614. To support addkcmdline when netboo
 cmd:mkdef -t node -o testnode1 arch=x86_64 cons=kvm groups=kvm ip=10.1.1.200 mac=e6:d4:d2:3a:ad:06 mgt=kvm monserver=10.1.1.1 nameservers=10.1.1.1 profile=compute tftpserver=10.1.1.1 xcatmaster=10.1.1.1
 os=__GETNODEATTR($$CN,os)__ 
 check:rc==0
-cmd:cp -f /etc/hosts /etc/hosts.bak
+cmd:cp -f /etc/hosts /etc/hosts.xcattestbak
 cmd:echo "10.1.1.200 testnode1" >> /etc/hosts
 cmd:makedns -n
 check:rc==0
@@ -194,6 +194,6 @@ cmd:grep "rd.break=pre-pivot" /tftpboot/xcat/xnba/nodes/testnode1.elilo
 check:rc==0
 cmd:noderm testnode1
 cmd:rmdef -t osimage -o "__GETNODEATTR($$CN,os)__-x86_64-install-compute"
-cmd:cp -f /etc/hosts.bak /etc/hosts
+cmd:cp -f /etc/hosts.xcattestbak /etc/hosts
 end
 

--- a/xCAT-test/autotest/testcase/nodeset/cases0
+++ b/xCAT-test/autotest/testcase/nodeset/cases0
@@ -173,3 +173,27 @@ check:output=~Warning: testnode1: petitboot might be invalid|testnode1 could not
 cmd:noderm testnode1
 end
 
+start:nodeset_addkcmdline_bug2614
+description: This case is to verify bug 2614. To support addkcmdline when netboot=xnba.
+cmd:mkdef -t node -o testnode1 arch=x86_64 cons=kvm groups=kvm ip=10.1.1.200 mac=e6:d4:d2:3a:ad:06 mgt=kvm monserver=10.1.1.1 nameservers=10.1.1.1 profile=compute tftpserver=10.1.1.1 xcatmaster=10.1.1.1
+os=__GETNODEATTR($$CN,os)__ 
+check:rc==0
+cmd:cp -f /etc/hosts /etc/hosts.bak
+cmd:echo "10.1.1.200 testnode1" >> /etc/hosts
+cmd:makedns -n
+check:rc==0
+cmd:chdef testnode1 netboot=xnba addkcmdline=rd.break=pre-pivot
+check:rc==0
+cmd: mkdef "__GETNODEATTR($$CN,os)__-x86_64-install-compute" -u profile=compute provmethod=install osvers=__GETNODEATTR($$CN,os)__
+check:rc==0
+cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-x86_64-install-compute
+check:rc==0
+cmd:grep "rd.break=pre-pivot" /tftpboot/xcat/xnba/nodes/testnode1
+check:rc==0
+cmd:grep "rd.break=pre-pivot" /tftpboot/xcat/xnba/nodes/testnode1.elilo
+check:rc==0
+cmd:noderm testnode1
+cmd:rmdef -t osimage -o "__GETNODEATTR($$CN,os)__-x86_64-install-compute"
+cmd:cp -f /etc/hosts.bak /etc/hosts
+end
+

--- a/xCAT-test/autotest/testcase/nodeset/cases0
+++ b/xCAT-test/autotest/testcase/nodeset/cases0
@@ -173,8 +173,8 @@ check:output=~Warning: testnode1: petitboot might be invalid|testnode1 could not
 cmd:noderm testnode1
 end
 
-start:nodeset_addkcmdline_bug2614
-description: This case is to verify bug 2614. To support addkcmdline when netboot=xnba.
+start:nodeset_addkcmdline
+description: This case is to verify when netboot=xnba, addkcmdline is correctly supported. 
 cmd:mkdef -t node -o testnode1 arch=x86_64 cons=kvm groups=kvm ip=10.1.1.200 mac=e6:d4:d2:3a:ad:06 mgt=kvm monserver=10.1.1.1 nameservers=10.1.1.1 profile=compute tftpserver=10.1.1.1 xcatmaster=10.1.1.1
 os=__GETNODEATTR($$CN,os)__ 
 check:rc==0
@@ -188,9 +188,7 @@ cmd: mkdef "__GETNODEATTR($$CN,os)__-x86_64-install-compute" -u profile=compute 
 check:rc==0
 cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-x86_64-install-compute
 check:rc==0
-cmd:grep "rd.break=pre-pivot" /tftpboot/xcat/xnba/nodes/testnode1
-check:rc==0
-cmd:grep "rd.break=pre-pivot" /tftpboot/xcat/xnba/nodes/testnode1.elilo
+cmd:find -L /tftpboot -name '*testnode1*' -exec cat {} + | grep "rd.break=pre-pivot" 
 check:rc==0
 cmd:noderm testnode1
 cmd:rmdef -t osimage -o "__GETNODEATTR($$CN,os)__-x86_64-install-compute"

--- a/xCAT-test/autotest/testcase/nodeset/cases0
+++ b/xCAT-test/autotest/testcase/nodeset/cases0
@@ -188,7 +188,9 @@ cmd: mkdef "__GETNODEATTR($$CN,os)__-x86_64-install-compute" -u profile=compute 
 check:rc==0
 cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-x86_64-install-compute
 check:rc==0
-cmd:find -L /tftpboot -name '*testnode1*' -exec cat {} + | grep "rd.break=pre-pivot" 
+cmd:grep "rd.break=pre-pivot" /tftpboot/xcat/xnba/nodes/testnode1
+check:rc==0
+cmd:grep "rd.break=pre-pivot" /tftpboot/xcat/xnba/nodes/testnode1.elilo
 check:rc==0
 cmd:noderm testnode1
 cmd:rmdef -t osimage -o "__GETNODEATTR($$CN,os)__-x86_64-install-compute"

--- a/xCAT-test/autotest/testcase/nodeset/cases1
+++ b/xCAT-test/autotest/testcase/nodeset/cases1
@@ -1,9 +1,0 @@
-start:nodeset_addkcmdline
-cmd:chdef $$CN addkcmdline=debug
-check:rc==0
-cmd:nodeset $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
-check:rc==0
-cmd:find -L /tftpboot -name '*$$CN*' -exec cat {} + | grep debug
-check:rc==0
-cmd:chdef $$CN addkcmdline=
-end


### PR DESCRIPTION
Add 1 case in this pull request.
This case is added for issue #2614

[Case 1]
Case Name: nodeset_addkcmdline
Description: This case is to verify bug 2614 to test nodeset does  support addkcmdline when netboot=xnba
Attribute: N/A