### PR TITLE
Using bulk operation to invoke makedhcp to imporve nodeset perforamnce (#2024)

### DIFF
--- a/xCAT-server/lib/xcat/plugins/petitboot.pm
+++ b/xCAT-server/lib/xcat/plugins/petitboot.pm
@@ -545,21 +545,14 @@ sub process_request {
             if ($t_entry =~ /0|n|N/) { $do_dhcpsetup = 0; }
         }
         if ($do_dhcpsetup) {
-            foreach my $node (@normalnodeset) {
-                if ($request->{'_disparatetftp'}->[0]) { #reading hint from preprocess_command
-                    xCAT::MsgUtils->trace($verbose_on_off, "d", "petitboot: issue makedhcp request");
-                    $sub_req->({ command => ['makedhcp'],
-                            node => [$node],
-                            arg => ['-l'] }, $callback);
-
-                    #arg=>['-l','-s','option conf-file \"'.$fpath.'\";']},$callback);
-                } else {
-                    xCAT::MsgUtils->trace($verbose_on_off, "d", "petitboot: issue makedhcp request");
-                    $sub_req->({ command => ['makedhcp'],
-                            node => [$node] }, $callback);
-
-                    #arg=>['-s','option conf-file \"'.$fpath.'\";']},$callback);
-                }
+            if ($::request->{'_disparatetftp'}->[0]) { #reading hint from preprocess_command
+                xCAT::MsgUtils->trace($verbose_on_off, "d", "petitboot: issue makedhcp request");
+                $sub_req->({ command => ['makedhcp'], arg => ['-l'],
+                        node => \@normalnodeset }, $callback);
+            } else {
+                xCAT::MsgUtils->trace($verbose_on_off, "d", "petitboot: issue makedhcp request");
+                $sub_req->({ command => ['makedhcp'],
+                        node => \@normalnodeset }, $callback);
             }
         }
     }


### PR DESCRIPTION
This patch aims to fix the 'nodeset' command performance issue when using 'petitboot' netboot attribute for ppc64le nodes. It leverage bulk operation to invoke 'makedhcp', instead of run 'makedhcp' in a loop for each node one by one. (The same design as 'nodeset' in xnba plugin for x86_64 nodes)
In a cluster with thousandths nodes, it could reduce the time of running 'makedhcp' greatly.