### PR TITLE
fix issue #2898 on ububuntu 16.4.1-x86_64  diskless, failed to resolve hostname due to lack of libnss_dns.so.2

### DIFF
--- a/xCAT-server/share/xcat/netboot/ubuntu/genimage
+++ b/xCAT-server/share/xcat/netboot/ubuntu/genimage
@@ -1657,9 +1657,12 @@ EOMS
             push @filestoadd, $_;
         }
     }
+    
 
     if ($arch =~ /x86_64/) {
         push @filestoadd, "lib64/libnss_dns.so.2";
+        #the path of libnss_dns.so.2 for ubuntu 14.4+
+        push @filestoadd, "lib/x86_64-linux-gnu/libnss_dns.so.2";
         push @filestoadd, "lib64/libresolv.so.2";
     } elsif ($arch =~ /ppc64el/) {
         push @filestoadd, "lib/powerpc64le-linux-gnu/libnss_files.so.2";


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/2898 :

this issue is caused by the lack of " libnss_dns.so.2" inside the initrd, the fix is to push the " libnss_dns.so.2" file into "lib/x86_64-linux-gnu/libnss_dns.so.2" inside the initrd

the fix has been verified on ubuntu 16.4.1 x86 vm