### PR TITLE
Add "attribute" label to xcattest

### DIFF
--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -651,8 +651,9 @@ sub loadcase
             #skip comment lines
             next if ($line =~ /^\s*#/);
 
-            #TODO: description line is treated as a comment line for now
+            #TODO: description and attribute line is treated as a comment line for now
             next if ($line =~ /^description\s*:/);
+            next if ($line =~ /^attribute\s*:/);
 
             if ($line =~ /^start\s*:\s*(.*)/) {
                 my $name =$1;


### PR DESCRIPTION
Modify code to support "attribute" label in ``xcattest``.

``attirbute`` will list all the attribute needed to be configured in xcattest config file. If there are more than one attributes, using semicolon to separate. There is a simple description for each attribute. For example: $$a-description;$$b-description;$$c-description

Now this label work like label ``description``. Will be used in future.