### PR TITLE
refine the performance of makedhcp

### DIFF
--- a/perl-xCAT/xCAT/NetworkUtils.pm
+++ b/perl-xCAT/xCAT/NetworkUtils.pm
@@ -19,6 +19,7 @@ use File::Path;
 use Math::BigInt;
 use Socket;
 use xCAT::GlobalDef;
+use Sys::Hostname;
 
 #use Data::Dumper;
 use strict;
@@ -270,6 +271,10 @@ sub getipaddr
     #    #pass in an ip and only want an ip??
     #    return $iporhost;
     #}
+    my $isip=0;
+    if ($iporhost and ($iporhost =~ /\d+\.\d+\.\d+\.\d+/) || ($iporhost =~ /:/)){
+        $isip=1;
+    }
 
     #cache, do not lookup DNS each time
     if ($::hostiphash and defined($::hostiphash{$iporhost}) && $::hostiphash{$iporhost})
@@ -287,7 +292,12 @@ sub getipaddr
             } elsif ($extraarguments{OnlyV4}) {
                 $reqfamily = AF_INET;
             }
-            my @addrinfo = Socket6::getaddrinfo($iporhost, 0, $reqfamily, SOCK_STREAM, 6);
+            my @addrinfo;
+            if($isip) {
+                @addrinfo=Socket6::getaddrinfo($iporhost, 0, $reqfamily, SOCK_STREAM, 6,Socket6::AI_NUMERICHOST());
+            }else{
+                @addrinfo=Socket6::getaddrinfo($iporhost, 0, $reqfamily, SOCK_STREAM, 6);
+            }  
             my ($family, $socket, $protocol, $ip, $name) = splice(@addrinfo, 0, 5);
             while ($ip)
             {
@@ -417,7 +427,7 @@ sub linklocaladdr {
 =cut
 
 #-------------------------------------------------------------------------------
-sub ishostinsubnet {
+sub ishostinsubnet{
     my ($class, $ip, $mask, $subnet) = @_;
 
     #safe guard
@@ -425,6 +435,41 @@ sub ishostinsubnet {
     {
         return 0;
     }
+
+    my $maskType=0;
+    if ($mask) {
+        if ($mask =~ /\//) {
+            $mask =~ s/^\///;
+            $maskType=1;
+        } elsif($mask =~ /^0x/i ) {
+            $maskType=2;
+        }
+    } 
+
+    #CIDR notation supported
+    if ($subnet && ($subnet =~ /\//)) {
+        ($subnet, $mask) = split /\//, $subnet, 2;
+        $subnet =~ s/\/.*$//;
+        $maskType=1;
+    }
+
+    my $ret=xCAT::NetworkUtils::isInSameSubnet( $ip, $subnet, $mask, $maskType);
+    if(defined $ret and $ret==1){
+        return 1;
+    }else{
+        return 0;
+    }
+}
+
+sub ishostinsubnet_orig {
+    my ($class, $ip, $mask, $subnet) = @_;
+
+    #safe guard
+    if (!defined($ip) || !defined($mask) || !defined($subnet))
+    {
+        return 0;
+    }
+
     my $numbits = 32;
     if ($ip =~ /:/) {    #ipv6
         $numbits = 128;
@@ -1314,7 +1359,7 @@ sub formatNetmask
         
     Returns:  
         1: they are in same subnet
-        2: not in same subnet
+        undef: not in same subnet
         
     Globals:
         none
@@ -1853,16 +1898,13 @@ sub get_subnet_aix
 sub determinehostname
 {
     my $hostname;
-    my $hostnamecmd = "/bin/hostname";
-    my @thostname = xCAT::Utils->runcmd($hostnamecmd, 0);
-    if ($::RUNCMD_RC != 0)
-    {    # could not get hostname
-        xCAT::MsgUtils->message("S",
-            "Error $::RUNCMD_RC from $hostnamecmd command\n");
-        exit $::RUNCMD_RC;
+    eval {
+        $hostname = hostname;
+    };
+    if($@){
+        xCAT::MsgUtils->message("S","Fail to get hostname: $@\n");
+        exit -1;
     }
-    $hostname = $thostname[0];
-
     #get all potentially valid abbreviations, and pick the one that is ok
     #by 'noderange'
     my @hostnamecandidates;

--- a/perl-xCAT/xCAT/NetworkUtils.pm
+++ b/perl-xCAT/xCAT/NetworkUtils.pm
@@ -20,7 +20,6 @@ use Math::BigInt;
 use Socket;
 use xCAT::GlobalDef;
 use Sys::Hostname;
-use Data::Dumper;
 use strict;
 use warnings "all";
 my $socket6support = eval { require Socket6 };
@@ -477,7 +476,13 @@ sub ishostinsubnet{
     }
 
     my $maskType=0;
-    if ($mask) {
+
+    #CIDR notation supported
+    if ($subnet && ($subnet =~ /\//)) {
+        ($subnet, $mask) = split /\//, $subnet, 2;
+        $subnet =~ s/\/.*$//;
+        $maskType=1;
+    }elsif ($mask) {
         if ($mask =~ /\//) {
             $mask =~ s/^\///;
             $maskType=1;
@@ -485,13 +490,6 @@ sub ishostinsubnet{
             $maskType=2;
         }
     } 
-
-    #CIDR notation supported
-    if ($subnet && ($subnet =~ /\//)) {
-        ($subnet, $mask) = split /\//, $subnet, 2;
-        $subnet =~ s/\/.*$//;
-        $maskType=1;
-    }
 
     my $ret=xCAT::NetworkUtils::isInSameSubnet( $ip, $subnet, $mask, $maskType);
     if(defined $ret and $ret==1){

--- a/perl-xCAT/xCAT/ServiceNodeUtils.pm
+++ b/perl-xCAT/xCAT/ServiceNodeUtils.pm
@@ -378,7 +378,7 @@ sub getSNList
             push @whereclause,"$service = '1'";
         }
         push @whereclause,"groups !~ '__mgmtnode'";
-        @servicenodes = $servicenodetab->getAllAttribsWhere(@servicenodes,'node');
+        @servicenodes = $servicenodetab->getAllAttribsWhere(@whereclause,'node');
     } 
 
     return @servicenodes;

--- a/perl-xCAT/xCAT/ServiceNodeUtils.pm
+++ b/perl-xCAT/xCAT/ServiceNodeUtils.pm
@@ -370,18 +370,18 @@ sub getSNList
         if($service){
             @servicenodes = $servicenodetab->getAllAttribsWhere("$service = '1'",'node');
         }else{
-            @servicenodes = $servicenodetab->getAllAttribs(['node']);
+            @servicenodes = $servicenodetab->getAllAttribs(('node'));
         }
     }else{
         my @whereclause;
         if($service){
-            push @whereclause,"$service = '1'";
+            push @whereclause,"$service==1";
         }
-        push @whereclause,"groups !~ '__mgmtnode'";
-        @servicenodes = $servicenodetab->getAllAttribsWhere(@whereclause,'node');
+        push @whereclause,"groups!~__mgmtnode";
+        @servicenodes = $servicenodetab->getAllAttribsWhere(\@whereclause,'node');
     } 
 
-    return @servicenodes;
+    return map {$_->{node}} @servicenodes;
 }
 
 sub getSNList_orig
@@ -424,7 +424,7 @@ sub getSNList_orig
     # if did not input "ALL" and there is a MN, remove it
     my @newservicenodes;
     if ((!defined($options)) || ($options ne "ALL")) {
-        my $mname = xCAT::Utils->noderangecontainsMn(@servicenodes);
+        my $mname = xCAT::Utils->noderangecontainsMn_orig(@servicenodes);
         if ($mname) {    # if there is a MN
             foreach my $nodes (@servicenodes) {
                 if ($mname ne ($nodes)) {

--- a/perl-xCAT/xCAT/ServiceNodeUtils.pm
+++ b/perl-xCAT/xCAT/ServiceNodeUtils.pm
@@ -365,13 +365,22 @@ sub getSNList
         return @servicenodes;
 
     }
-    
-    if($service){
-        @servicenodes = $servicenodetab->getAllAttribsWhere("$service = '1'",'node');
+   
+    if($options eq "ALL"){
+        if($service){
+            @servicenodes = $servicenodetab->getAllAttribsWhere("$service = '1'",'node');
+        }else{
+            @servicenodes = $servicenodetab->getAllAttribs(['node']);
+        }
     }else{
-        @servicenodes = $servicenodetab->getAllAttribs(['node']);
-    }
-  
+        my @whereclause;
+        if($service){
+            push @whereclause,"$service = '1'";
+        }
+        push @whereclause,"groups !~ '__mgmtnode'";
+        @servicenodes = $servicenodetab->getAllAttribsWhere(@servicenodes,'node');
+    } 
+
     return @servicenodes;
 }
 

--- a/perl-xCAT/xCAT/ServiceNodeUtils.pm
+++ b/perl-xCAT/xCAT/ServiceNodeUtils.pm
@@ -356,6 +356,29 @@ sub getSNList
 {
     require xCAT::Table;
     my ($class, $service, $options) = @_;
+    my @servicenodes;
+    my $servicenodetab = xCAT::Table->new('servicenode');
+    unless ($servicenodetab)    # no  servicenode table
+    {
+        xCAT::MsgUtils->message('I', "Unable to open servicenode table.\n");
+        $servicenodetab->close;
+        return @servicenodes;
+
+    }
+    
+    if($service){
+        @servicenodes = $servicenodetab->getAllAttribsWhere("$service = '1'",'node');
+    }else{
+        @servicenodes = $servicenodetab->getAllAttribs(['node']);
+    }
+  
+    return @servicenodes;
+}
+
+sub getSNList_orig
+{
+    require xCAT::Table;
+    my ($class, $service, $options) = @_;
 
     # reads all nodes from the service node table
     my @servicenodes;

--- a/perl-xCAT/xCAT/ServiceNodeUtils.pm
+++ b/perl-xCAT/xCAT/ServiceNodeUtils.pm
@@ -14,7 +14,6 @@ if ($^O =~ /^aix/i) {
 }
 use lib "$::XCATROOT/lib/perl";
 use strict;
-use Data::Dumper;
 #-----------------------------------------------------------------------------
 
 =head3 readSNInfo
@@ -424,7 +423,7 @@ sub getSNList_orig
     # if did not input "ALL" and there is a MN, remove it
     my @newservicenodes;
     if ((!defined($options)) || ($options ne "ALL")) {
-        my $mname = xCAT::Utils->noderangecontainsMn_orig(@servicenodes);
+        my $mname = xCAT::Utils->noderangecontainsMn(@servicenodes);
         if ($mname) {    # if there is a MN
             foreach my $nodes (@servicenodes) {
                 if ($mname ne ($nodes)) {

--- a/perl-xCAT/xCAT/Utils.pm
+++ b/perl-xCAT/xCAT/Utils.pm
@@ -3306,7 +3306,22 @@ sub isSELINUX
 =cut
 
 #-------------------------------------------------------------------------------
+
+
 sub noderangecontainsMn
+{
+    my ($class, @noderange) = @_;
+
+    # check if any node in the noderange is the Management Node return the
+    # name
+    my @mnames;   # management node names in the database, members of __mgmtnode
+    my $tab = xCAT::Table->new('nodelist');
+    
+    my @nodelist = $tab->getAllAttribsWhere("node in ("."\'".join("\',\'", @noderange)."\'".") and groups like '__mgmtnode'",'node');
+    return @nodelist;            # if no MN in the noderange, return nothing
+}
+
+sub noderangecontainsMn_orig
 {
     my ($class, @noderange) = @_;
 

--- a/perl-xCAT/xCAT/Utils.pm
+++ b/perl-xCAT/xCAT/Utils.pm
@@ -3317,8 +3317,8 @@ sub noderangecontainsMn
     my @mnames;   # management node names in the database, members of __mgmtnode
     my $tab = xCAT::Table->new('nodelist');
     
-    my @nodelist = $tab->getAllAttribsWhere("node in ("."\'".join("\',\'", @noderange)."\'".") and groups like '__mgmtnode'",'node');
-    return @nodelist;            # if no MN in the noderange, return nothing
+    my @nodelist = $tab->getAllAttribsWhere("node in ("."\'".join("\',\'", @noderange)."\'".") and groups like '%__mgmtnode%'",'node');
+    return map {$_->{node}} @nodelist;            # if no MN in the noderange, return nothing
 }
 
 sub noderangecontainsMn_orig


### PR DESCRIPTION
perf data of ``makedhcp <node>``:
http://10.2.8.15/install/perlf/nytprof/opt-xcat-lib-perl-xCAT_plugin-dhcp-pm-140-line.html#1057
````
export NYTPROF=start=begin
 perl -d:NYTProf /opt/xcat/sbin/makedhcp node0001
 nytprofhtml  ./nytprof.out
````

draft code for for task https://github.com/xcat2/xcat-core/pull/2676

improve performance of ``makedhcp``
1. refine the code logic of ``getSNList``
2. refine the code logic of ``getipaddr``, ``getipaddr``
3. add the cache for dns lookup result in getipaddr

some compare between the optimized code and origin code:

1. with xCAT-2.13.2-snap201702222242:
against 100 nodes:
````
c910f02c08p15:/ # time makedhcp node0001-node0100

real	0m13.013s
user	0m0.124s
sys	0m0.017s
````


against 5000 nodes:
````
c910f02c08p15:/ # time makedhcp node0001-node5000

real	3m49.514s
user	0m0.165s
sys	0m0.020s
````

2. with the optimized code:
against 100 nodes:
````
c910f02c08p15:/ # time makedhcp node0001-node0100

real	0m6.587s
user	0m0.124s
sys	0m0.017s
````
against 5000 nodes:
````
c910f02c08p15:/opt # time makedhcp node0001-node5000

real	3m39.259s
user	0m0.168s
sys	0m0.021s
````

