### PR TITLE
For issue xCAT Object Name Format error when trying to name osimages …

### DIFF
--- a/xCAT-test/autotest/testcase/mkdef/cases0
+++ b/xCAT-test/autotest/testcase/mkdef/cases0
@@ -326,7 +326,7 @@ check:rc==0
 end
 start:mkdef_rhels73
 os:linux
-description:check rootimgdir warning message after make new osimage with mkdef --template
+description: mkdef --template could create rhels7.3 osiamge
 cmd:mkdef -t osimage -o rhels7.3-test-osimage --template  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 output=~1 object definitions have been created or modified

--- a/xCAT-test/autotest/testcase/mkdef/cases0
+++ b/xCAT-test/autotest/testcase/mkdef/cases0
@@ -340,7 +340,7 @@ cmd:cat /tmp/osiamge.stanza1|mkdef -z
 check:rc==0
 cmd:rm -rf /tmp/osiamge.stanza;rm -rf /tmp/osiamge.stanza1
 check:rc==0
-cmd:lsdef -t osimage -o rhels7.3-test |grep rhels7.3-test
+cmd:lsdef -t osimage -o rhels7.3-test |grep "Object name: rhels7.3-test"
 check:rc==0
 cmd:lsdef -t osimage -o rhels7.3-test |grep pkgdir=
 check:rc==0

--- a/xCAT-test/autotest/testcase/mkdef/cases0
+++ b/xCAT-test/autotest/testcase/mkdef/cases0
@@ -324,3 +324,12 @@ check:output=~__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-comput
 cmd:rmdef -t osimage -o test-osimage_with_template
 check:rc==0
 end
+start:mkdef_rhels73
+os:linux
+description:check rootimgdir warning message after make new osimage with mkdef --template
+cmd:mkdef -t osimage -o rhels7.3-test-osimage --template  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+check:rc==0
+output=~1 object definitions have been created or modified
+cmd:rmdef -t osimage -o rhels7.3-test-osimage
+check:rc==0
+end

--- a/xCAT-test/autotest/testcase/mkdef/cases0
+++ b/xCAT-test/autotest/testcase/mkdef/cases0
@@ -326,10 +326,20 @@ check:rc==0
 end
 start:mkdef_rhels73
 os:linux
-description: mkdef --template could create rhels7.3 osiamge
+description:create rhels7.3 osimage
 cmd:mkdef -t osimage -o rhels7.3-test-osimage --template  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 output=~1 object definitions have been created or modified
 cmd:rmdef -t osimage -o rhels7.3-test-osimage
+check:rc==0
+cmd:lsdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute -z > /tmp/osiamge.stanza
+check:rc==0
+cmd:cat /tmp/osiamge.stanza |sed 's/__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute:/rhels7.3-test:/g' >/tmp/osiamge.stanza1
+check:rc==0
+cmd:cat /tmp/osiamge.stanza1|mkdef -z
+check:rc==0
+cmd:rm -rf /tmp/osiamge.stanza;rm -rf /tmp/osiamge.stanza1
+check:rc==0
+cmd:rmdef -t osimage -o rhels7.3-test
 check:rc==0
 end

--- a/xCAT-test/autotest/testcase/mkdef/cases0
+++ b/xCAT-test/autotest/testcase/mkdef/cases0
@@ -340,6 +340,10 @@ cmd:cat /tmp/osiamge.stanza1|mkdef -z
 check:rc==0
 cmd:rm -rf /tmp/osiamge.stanza;rm -rf /tmp/osiamge.stanza1
 check:rc==0
+cmd:lsdef -t osimage -o rhels7.3-test |grep rhels7.3-test
+check:rc==0
+cmd:lsdef -t osimage -o rhels7.3-test |grep pkgdir=
+check:rc==0
 cmd:rmdef -t osimage -o rhels7.3-test
 check:rc==0
 end


### PR DESCRIPTION
…starting with rhels7.3 #2157
when rhels7.3 osimage could create the case will pass