### PR TITLE
fix issue #2636: xcat command returns 0 when cmd fails due authorization

### DIFF
--- a/perl-xCAT/xCAT/Client.pm
+++ b/perl-xCAT/xCAT/Client.pm
@@ -265,7 +265,11 @@ sub submit_request {
             %sslargs,
         );
     } else {
+        print "warning: the client certificates under $homedir/.xcat/ are not setup correctly, please run '/opt/xcat/share/xcat/scripts/setup-local-client.sh"." $ENV{'USER'}' as 'root' to generate the client certificates; otherwise, the SSL connection between xcat client and xcatd will be setup without certificate verification and open to Man-In-The-Middle attacks.\n";
+        #Using the default of SSL_verify_mode of SSL_VERIFY_NONE for client is deprecated!
+        #need to specify SSL_verify_mode => SSL_VERIFY_NONE explicitly 
         $client = IO::Socket::SSL->start_SSL($pclient,
+            SSL_verify_mode => SSL_VERIFY_NONE,
             Timeout => 0,
         );
     }


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/2636  
1. prompt meaningful message for user if client certificates not setup correctly; 
2. specify SSL_verify_mode => SSL_VERIFY_NONE explicitly for IO::Socket::SSL->start_SSL

before modification:

if user run xcat commands when the client certificates are not setup correctly:

````
*******************************************************************
 Using the default of SSL_verify_mode of SSL_VERIFY_NONE for client
 is deprecated! Please set SSL_verify_mode to SSL_VERIFY_PEER
 together with SSL_ca_file|SSL_ca_path for verification.
 If you really don't want to verify the certificate and keep the
 connection open to Man-In-The-Middle attacks please set
 SSL_verify_mode explicitly to SSL_VERIFY_NONE in your application.
*******************************************************************
  at /opt/xcat/lib/perl/xCAT/Client.pm line 268.
Error: Permission denied for request
````

with this PR, the original message thrown out by " IO::Socket::SSL->start_SSL" is replaced with the messages which make sense for user:
````
[root@c910f03c05k27 ~]# lsxcatd -v
warning: the client certificates under /root/.xcat/ are not setup correctly, please run '/opt/xcat/share/xcat/scripts/setup-local-client.sh/root' as 'root' to generate the client certificates; otherwise, the SSL connection between xcat client and xcatd will be setup without certificate verification and open to Man-In-The-Middle attacks.
Version 2.13.3 (git commit 1cbf0d1cd82482bf770dba69f7277a59a7e7c70d, built Fri Apr 21 02:41:44 EDT 2017)
````


