### PR TITLE
Initialized more_options variable to avoid uninitialized error message [cleanup]

### DIFF
--- a/xCAT-server/lib/xcat/plugins/nodestat.pm
+++ b/xCAT-server/lib/xcat/plugins/nodestat.pm
@@ -649,7 +649,10 @@ sub process_request_nmap {
 
     # get additional options from site table
     my @nmap_options = xCAT::TableUtils->get_site_attribute("nmapoptions");
-    my $more_options = $nmap_options[0];
+    my $more_options = "";
+    if (defined($nmap_options[0])) {
+        $more_options = $nmap_options[0];
+    }
 
     foreach my $ip6 (0, 1) {    #first pass, ipv4, second pass ipv6
         if ($ip6 and scalar(@ip6s)) {


### PR DESCRIPTION
With `XCATBYPASS=1` when I run `nodestat`... the following messages comes out:

```
[root@stratton01 ~]# nodestat p9
Use of uninitialized value $more_options in concatenation (.) or string at /opt/xcat/lib/perl/xCAT_plugin/nodestat.pm line 658.
p9euh01: noping
p9euh02: sshd
```

After the change: 
```
[root@stratton01 ~]# nodestat p9
p9euh01: noping
p9euh02: sshd
```