### PR TITLE
docker version updated and the output for docker command changed so m…

### DIFF
--- a/xCAT-test/autotest/testcase/dockercommand/cases0
+++ b/xCAT-test/autotest/testcase/dockercommand/cases0
@@ -244,7 +244,6 @@ cmd:rpower $$DOCKERCN start
 check:rc==0
 cmd:rmdocker $$DOCKERCN
 chec:rc!=0
-check:output=~Stop the container before attempting removal or use -f
 cmd:rmdocker $$DOCKERCN -f
 check:rc==0
 check:output=~$$DOCKERCN: success

--- a/xCAT-test/autotest/testcase/dockercommand/cases0
+++ b/xCAT-test/autotest/testcase/dockercommand/cases0
@@ -243,7 +243,8 @@ check:rc==0
 cmd:rpower $$DOCKERCN start
 check:rc==0
 cmd:rmdocker $$DOCKERCN
-chec:rc!=0
+check:rc!=0
+check:output=~Stop the container
 cmd:rmdocker $$DOCKERCN -f
 check:rc==0
 check:output=~$$DOCKERCN: success


### PR DESCRIPTION
…odify the testcase

Modify dockercommand testcase for the docker  changed and docker command's output will changed .So we could not using output to check the test result and only using return value .

Before modify the case:
1.The output should be:
........ "Stop the container before attempting removal or use -f"
When using rmdocker $$CONTAINER if container is running
2.But now the docker version changed:
host12c04: Error: {"message": "You cannot remove a running container c35494a228182b1b9167ecb547cd7917087f0dc83123106d19353d63c15a430f. Stop the container before attempting removal or force remove"}
