### PR TITLE
modify makehosts_n_r testcase

### DIFF
--- a/xCAT-test/autotest/testcase/makehosts/cases0
+++ b/xCAT-test/autotest/testcase/makehosts/cases0
@@ -138,26 +138,36 @@ cmd:rc1=`cat /etc/hosts | grep "70.2.0.254" | grep s01`;rc2=`cat /etc/hosts | gr
 check:rc==0
 cmd:makehosts s01
 check:rc==0
+cmd:sleep 20
+cmd:cat /etc/hosts
 cmd:rc1=`cat /etc/hosts | grep "70.2.0.254" | grep s01`;rc2=`cat /etc/hosts | grep "80.2.0.254" | grep s01r1b01`;if [[ $rc1 =~ "70.2.0.254 s01" ]] && [[ $rc2 =~ "80.2.0.254 s01r1b01" ]];then exit 0;else exit 1;fi
 check:rc==0
 cmd:makehosts service
 check:rc==0
+cmd:sleep 20
+cmd:cat /etc/hosts
 cmd:rc1=`cat /etc/hosts | grep "70.2.0.254" | grep s01`;rc2=`cat /etc/hosts | grep "80.2.0.254" | grep s01r1b01`;if [[ $rc1 =~ "70.2.0.254 s01" ]] && [[ $rc2 =~ "80.2.0.254 s01r1b01" ]];then exit 0;else exit 1;fi
 check:rc==0
 cmd:makehosts -d s01
 check:rc==0
+cmd:sleep 20
+cmd:cat /etc/hosts
 cmd:rc1=`cat /etc/hosts | grep "70.2.0.254" | grep s01`;rc2=`cat /etc/hosts | grep "80.2.0.254" | grep s01r1b01`;if [[ $rc1 = "" ]] && [[ $rc2 =~ "80.2.0.254 s01r1b01" ]];then exit 0;else exit 1;fi
 check:rc==0
 cmd:makehosts
 check:rc==0
 cmd:makehosts -d service 
 check:rc==0
+cmd:sleep 20
+cmd:cat /etc/hosts
 cmd:rc1=`cat /etc/hosts | grep "70.2.0.254" | grep s01`;rc2=`cat /etc/hosts | grep "80.2.0.254" | grep s01r1b01`;if [[ $rc1 = "" ]] && [[ $rc2 =~ "80.2.0.254 s01r1b01" ]];then exit 0;else exit 1;fi
 check:rc==0
 cmd:makehosts
 check:rc==0
 cmd:makehosts -d s01r1b01
 check:rc==0
+cmd:sleep 20
+cmd:cat /etc/hosts
 cmd:rc1=`cat /etc/hosts | grep "70.2.0.254" | grep s01`;rc2=`cat /etc/hosts | grep "80.2.0.254" | grep s01r1b01`;if [[ $rc1 =~ "70.2.0.254 s01" ]] && [[ $rc2 = "" ]];then exit 0;else exit 1;fi
 check:rc==0
 cmd:if [ -e /tmp/s01.standa ]; then rmdef s01; cat /tmp/s01.standa | mkdef -z; rm -rf /tmp/s01.standa; else rmdef s01;fi


### PR DESCRIPTION
Modify makehost_n_r testcase 
For sometime autotest could not get the node information in "/etc/hosts",so I add sleep after makehosts and cat /etc/hosts to probe the issue.