### PR TITLE
Add bmc specific for rpower in usage & return if encountered error

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rpower.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rpower.1.rst
@@ -23,8 +23,8 @@ SYNOPSIS
 
 \ **rpower**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
-BMC (using IPMI) specific:
-==========================
+BMC (using IPMI):
+=================
 
 
 \ **rpower**\  \ *noderange*\  [\ **on | off | softoff | reset | boot | stat | state | status | wake | suspend**\  [\ **-w**\  \ *timeout*\ ] [\ **-o**\ ] [\ **-r**\ ]]
@@ -32,8 +32,17 @@ BMC (using IPMI) specific:
 \ **rpower**\  \ *noderange*\  [\ **pduon | pduoff | pdustat | pdureset**\ ]
 
 
-OpenBMC specific:
-=================
+OpenPower BMC (using IPMI):
+===========================
+
+
+\ **rpower**\  \ *noderange*\  [\ **on | off | reset | boot | stat | state | status**\ ]
+
+\ **rpower**\  \ *noderange*\  [\ **pduon | pduoff | pdustat | pdureset**\ ]
+
+
+OpenPower OpenBMC:
+==================
 
 
 \ **rpower**\  \ *noderange*\  [\ **off | on | reset | boot | stat | state | status**\ ]
@@ -95,6 +104,13 @@ Blade specific:
 
 
 \ **rpower**\  \ *noderange*\  [\ **cycle | softoff**\ ]
+
+
+Lenovo High-Density Server specific:
+====================================
+
+
+\ **rpower**\  \ *noderange*\  [\ **on | off | reset | boot | reseat**\ ]
 
 
 zVM specific:
@@ -267,6 +283,12 @@ OPTIONS
 \ **cycle**\ 
  
  Power off, then on.
+ 
+
+
+\ **reseat**\ 
+ 
+ For Lenovo high-density servers, simulates unplugging and replugging the node into the chassis.
  
 
 

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -26,10 +26,13 @@ my %usage = (
     "rpower" =>
 "Usage: rpower <noderange> [--nodeps] [on|onstandby|off|suspend|reset|stat|state|boot] [-V|--verbose] [-m table.colum==expectedstatus][-m table.colum==expectedstatus...] [-r <retrycount>] [-t <timeout>]
        rpower [-h|--help|-v|--version]
-     BMC (using IPMI) specific:
+     BMC (using IPMI):
        rpower noderange [on|off|softoff|reset|boot|stat|state|status|wake|suspend [-w timeout] [-o] [-r]]
        rpower noderange [pduon|pduoff|pdustat]
-     OpenBMC specific:
+     OpenPower BMC:
+       rpower noderange [on|off|reset|boot|stat|state|status]
+       rpower noderange [pduon|pduoff|pdustat]
+     OpenPower OpenBMC:
        rpower noderange [on|off|reset|boot|stat|state|status]
      KVM Virtualization specific:
        rpower <noderange> [boot] [ -c <path to iso> ]

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -26,6 +26,9 @@ my %usage = (
     "rpower" =>
 "Usage: rpower <noderange> [--nodeps] [on|onstandby|off|suspend|reset|stat|state|boot] [-V|--verbose] [-m table.colum==expectedstatus][-m table.colum==expectedstatus...] [-r <retrycount>] [-t <timeout>]
        rpower [-h|--help|-v|--version]
+     BMC (using IPMI) specific:
+       rpower noderange [on|off|softoff|reset|boot|stat|state|status|wake|suspend [-w timeout] [-o] [-r]]
+       rpower noderange [pduon|pduoff|pdustat]
      OpenBMC specific:
        rpower noderange [on|off|reset|boot|stat|state|status]
      KVM Virtualization specific:

--- a/xCAT-client/pods/man1/rpower.1.pod
+++ b/xCAT-client/pods/man1/rpower.1.pod
@@ -8,13 +8,19 @@ B<rpower> I<noderange> [B<--nodeps>] [B<on>|B<onstandby>|B<off>|B<suspend>|B<sta
 
 B<rpower> [B<-h>|B<--help>|B<-v>|B<--version>]
 
-=head2 BMC (using IPMI) specific:
+=head2 BMC (using IPMI):
 
 B<rpower> I<noderange> [B<on>|B<off>|B<softoff>|B<reset>|B<boot>|B<stat>|B<state>|B<status>|B<wake>|B<suspend> [B<-w> I<timeout>] [B<-o>] [B<-r>]] 
 
 B<rpower> I<noderange> [B<pduon>|B<pduoff>|B<pdustat>|B<pdureset>]
 
-=head2 OpenBMC specific:
+=head2 OpenPower BMC (using IPMI):
+
+B<rpower> I<noderange> [B<on>|B<off>|B<reset>|B<boot>|B<stat>|B<state>|B<status>]
+
+B<rpower> I<noderange> [B<pduon>|B<pduoff>|B<pdustat>|B<pdureset>]
+
+=head2 OpenPower OpenBMC:
 
 B<rpower> I<noderange> [B<off>|B<on>|B<reset>|B<boot>|B<stat>|B<state>|B<status>]
 

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -2364,6 +2364,12 @@ sub power {
     my $rc = 0;
     my $text;
     my $code;
+
+    if (($sessdata->{subcommand} eq "suspend" or $sessdata->{subcommand} eq "wake") and isopenpower($sessdata)) {
+        xCAT::SvrUtils::sendmsg([ 1, "unsupported command power $sessdata->{subcommand} for OpenPower" ], $callback, $sessdata->{node}, %allerrornodes);
+        return;
+    }
+
     if ($sessdata->{subcommand} eq "reseat") {
         reseat_node($sessdata);
     } elsif (not $sessdata->{acpistate} and is_systemx($sessdata)) { #Only implemented for IBM servers

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -2510,6 +2510,7 @@ sub power_response {
         my $text = $codes{ $rsp->{code} };
         unless ($text) { $text = sprintf("Unknown response %02xh", $rsp->{code}); }
         xCAT::SvrUtils::sendmsg([ 1, $text ], $callback, $sessdata->{node}, %allerrornodes);
+        return;
     } else {
         my $command = $sessdata->{subcommand};
         my $status  = $sessdata->{powerstatus};

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -2365,7 +2365,7 @@ sub power {
     my $text;
     my $code;
 
-    if (($sessdata->{subcommand} eq "suspend" or $sessdata->{subcommand} eq "wake") and isopenpower($sessdata)) {
+    if (($sessdata->{subcommand} !~ /^on$|^off$|^reset$|^boot$|^stat$|^state$|^status$/) and isopenpower($sessdata)) {
         xCAT::SvrUtils::sendmsg([ 1, "unsupported command power $sessdata->{subcommand} for OpenPower" ], $callback, $sessdata->{node}, %allerrornodes);
         return;
     }

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -2366,7 +2366,7 @@ sub power {
     my $code;
 
     if (($sessdata->{subcommand} !~ /^on$|^off$|^reset$|^boot$|^stat$|^state$|^status$/) and isopenpower($sessdata)) {
-        xCAT::SvrUtils::sendmsg([ 1, "unsupported command power $sessdata->{subcommand} for OpenPower" ], $callback, $sessdata->{node}, %allerrornodes);
+        xCAT::SvrUtils::sendmsg([ 1, "unsupported command rpower $sessdata->{subcommand} for OpenPower" ], $callback, $sessdata->{node}, %allerrornodes);
         return;
     }
 


### PR DESCRIPTION
Resolves Issue #2948 

1. Add bmc specific for rpower in usage, make it is same with man page.
```
# rpower -h
Usage: rpower <noderange> [--nodeps] [on|onstandby|off|suspend|reset|stat|state|boot] [-V|--verbose] [-m table.colum==expectedstatus][-m table.colum==expectedstatus...] [-r <retrycount>] [-t <timeout>]
       rpower [-h|--help|-v|--version]
     BMC (using IPMI) specific:
       rpower noderange [on|off|softoff|reset|boot|stat|state|status|wake|suspend [-w timeout] [-o] [-r]]
       rpower noderange [pduon|pduoff|pdustat]
     OpenBMC specific:
       rpower noderange [on|off|reset|boot|stat|state|status]
     KVM Virtualization specific:
       rpower <noderange> [boot] [ -c <path to iso> ]
.............
```

2. If received error msg for rpower command, return.
So if print ``Error:........``, will not print other msg.

3. If command is not ``rpower [on|off|reset|boot|stat|state|status]`` and node is OpenPower, print error msg as below:
```
[root@fs1 ~]# rpower frame45cn07 suspend
frame45cn07: Error: unsupported command power suspend for OpenPower
```

