### PR TITLE
Update xCAT 2.12 with bug fix for #2392 and forward fit rflash message from xCAT 2.7.10.

### DIFF
--- a/perl-xCAT/xCAT/PPCrflash.pm
+++ b/perl-xCAT/xCAT/PPCrflash.pm
@@ -225,7 +225,7 @@ sub parse_args {
         return (usage());
     }
 
-    $request->{callback}->({ data => ["It may take considerable time to complete, depending on the number of systems being updated.  In particular, power subsystem updates may take an hour or more if there are many attached managed systems. Please waiting. "] });
+    $request->{callback}->({ data => ["The rflash process may take considerable time to complete, depending on the number of systems being updated. In particular, power subsystem updates (Auto Code DownLoad, or ACDL) may take an hour or more if there are many attached managed systems.  The prompt will return once the BPCs have been updated, but ACDL will continue for some time beyond that. Please wait. "] });
 
     if ($request->{hwtype} =~ /^(fsp|bpa)$/ && $opt{activate} =~ /^disruptive$/) {
         $request->{callback}->({ data => ["You can find the log files in the /var/log/xcatd/dfm/rflash/."] });

--- a/perl-xCAT/xCAT/Utils.pm
+++ b/perl-xCAT/xCAT/Utils.pm
@@ -4645,7 +4645,7 @@ sub splitkcmdline {
 
     my %cmdhash;
 
-    my @cmdlist = split(/[, ]/, $kcmdline);
+    my @cmdlist = split(/[ ]/, $kcmdline);
     foreach my $cmd (@cmdlist) {
         if ($cmd =~ /^R::(.*)$/) {
             $cmdhash{persistent} .= "$1 ";


### PR DESCRIPTION
Would like the following two commits to be added to xCAT 2.12
1 - updated rflash message from xcat 2.7 
2-  backported bug #2392 from xCAT 2.13.