### PR TITLE
delete synclist debug information and modify the testcase for synclist could not work on hierarchy install

### DIFF
--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_hierarchy
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_hierarchy
@@ -36,10 +36,8 @@ check:rc==0
 cmd:if [[ -f /test.synclist ]] ;then mv -f /test.synclist /test.synclist.bak;fi;
 cmd:echo "/test.synclist -> /test.synclist" > /test.synclist;chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute synclists=/test.synclist
 check:rc==0
-#wang jun xia add debug information here to trace synlist could not work on provison
-cmd:sleep 20
-cmd:lsdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
-#will delete the debug information after get the root cause
+cmd:nodeset $$CN osimage= __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+check:rc==0
 cmd:updatenode $$CN -f
 check:rc==0
 cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_hierarchy
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_hierarchy
@@ -37,10 +37,8 @@ check:rc==0
 cmd:if [[ -f /test.synclist ]] ;then mv -f /test.synclist /test.synclist.bak;fi;
 cmd:echo "/test.synclist -> /test.synclist" > /test.synclist;chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute synclists=/test.synclist
 check:rc==0
-#wang jun xia add debug information here to trace synlist could not work on provison
-cmd:sleep 20
-cmd:lsdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-comput 
-#will delete the debug information after get the root cause
+cmd:nodeset $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+check:rc==0
 cmd:updatenode $$CN -f
 check:rc==0
 cmd:genimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute


### PR DESCRIPTION

Modify hierarchy testcases for synlist could not work 
Add nodeset CN osimage before "updatenode $$CN -f"  
Delete synlist debug information for we could not use it.