### PR TITLE
Remove : for the output error message

### DIFF
--- a/xCAT-server/lib/xcat/plugins/kvm.pm
+++ b/xCAT-server/lib/xcat/plugins/kvm.pm
@@ -2712,7 +2712,9 @@ sub promote_vm_to_master {
         $target = $sourcedir . "/" . $target;
     }
     unless ($target =~ /^nfs:\/\//) {
-        xCAT::SvrUtils::sendmsg([ 1, "KVM plugin only has nfs://<server>/<path>/<mastername> support for cloning at this moment" ], $callback, $node);
+        my $rsp;
+        push @{ $rsp->{data} }, "VM cloning is only supported for nfs server vmstorage attribute. Current setting is $target";
+        xCAT::MsgUtils->message('E', $rsp, $callback);
         return;
     }
     my $dom;


### PR DESCRIPTION
This pull request fixes issue #2805 

`xCAT::SvrUtils::sendmsg()` function has a problem dealing with a `:` in the message text for error message types.
This pull request removes used `xCAT::MsgUtils->message()` instead of `xCAT::MsgUtils->message()`