### PR TITLE
modify the testcase for synclist could not work on hierarchy install

### DIFF
--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_hierarchy
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_hierarchy
@@ -36,7 +36,7 @@ check:rc==0
 cmd:if [[ -f /test.synclist ]] ;then mv -f /test.synclist /test.synclist.bak;fi;
 cmd:echo "/test.synclist -> /test.synclist" > /test.synclist;chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute synclists=/test.synclist
 check:rc==0
-cmd:nodeset $$CN osimage= __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+cmd:nodeset $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
 cmd:updatenode $$CN -f
 check:rc==0

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_hierarchy
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_hierarchy
@@ -37,16 +37,16 @@ check:rc==0
 cmd:if [[ -f /test.synclist ]] ;then mv -f /test.synclist /test.synclist.bak;fi;
 cmd:echo "/test.synclist -> /test.synclist" > /test.synclist;chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute synclists=/test.synclist
 check:rc==0
-cmd:nodeset $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
-check:rc==0
-cmd:updatenode $$CN -f
-check:rc==0
 cmd:genimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 cmd:packimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 
+cmd:nodeset $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+check:rc==0
 
+cmd:updatenode $$CN -f
+check:rc==0
 cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN


### PR DESCRIPTION
Modify testcase for synnlist could not work on hierachy install
Before:
1.
````
[nodeset c910f02c08p07 osimage= rhels7.3-ppc64-install-compute] Running Time:0 sec
RETURN: rc = 1
OUTPUT:
Error: No packed image for platform rhels7.3, architecture ppc64 and profile compute, please run "liteimg" to create it.
````
2.
````
[nodeset c910f02c08p07 osimage=rhels7.3-ppc64-netboot-compute] Running Time:1 sec
RETURN: rc = 1
OUTPUT:
Error: Did you run "genimage" before running "packimage"? kernel cannot be found at /install/netboot/rhels7.3/ppc64/compute/kernel on c910f02c08p05
````
After modify testcases:
 "nodeset osimage" will be used right command in diskfull provision and will be used after packimage for diskless provision.

