### PR TITLE
Modify xcat-genesis-builder script for Fedora26 ppc64

### DIFF
--- a/xCAT-genesis-builder/buildrpm
+++ b/xCAT-genesis-builder/buildrpm
@@ -133,30 +133,32 @@ if [ "$HOSTOS" = "mcp" ]; then
 # For ppc64 platform, needs to remove some files,
 # # and some files are in different directories
 elif [ $BUILDARCH = "ppc64" ]; then
-        sed -i 's/dracut_install efibootmgr//' $DRACUTMODDIR/install
+        sed -i 's/ efibootmgr//' $DRACUTMODDIR/install
         sed -i 's/ dmidecode//' $DRACUTMODDIR/install
-        sed -i 's/\/lib\/libncurses.so.5.7/\/lib64\/libncurses.so.5.7/' $DRACUTMODDIR/install
-        sed -i 's/\/usr\/lib\/libstdc++.so.6.0.13/\/usr\/lib64\/libstdc++.so.6.0.13/' $DRACUTMODDIR/install
-        sed -i 's/\/lib\/libgcc_s.so.1/\/lib64\/libgcc_s.so.1/' $DRACUTMODDIR/install
-        sed -i 's/\/lib\/libtinfo.so.5.7/\/lib64\/libtinfo.so.5.7/' $DRACUTMODDIR/install
+        # Remove the libraries with special version number, starting from Fedora 26 Alpha ppc64
+        # ==========================================================
+        #sed -i 's/\/lib\/libncurses.so.5.7/\/lib64\/libncurses.so.5.7/' $DRACUTMODDIR/install
+        #sed -i 's/\/usr\/lib\/libstdc++.so.6.0.13/\/usr\/lib64\/libstdc++.so.6.0.13/' $DRACUTMODDIR/install
+        #sed -i 's/\/lib\/libgcc_s.so.1/\/lib64\/libgcc_s.so.1/' $DRACUTMODDIR/install
+        #sed -i 's/\/lib\/libtinfo.so.5.7/\/lib64\/libtinfo.so.5.7/' $DRACUTMODDIR/install
         # following changes are required on Fedora 20 ppc64
         # sed -i 's/\/lib64\/libnss_dns-2.12.so/\/lib64\/libnss_dns-2.18.so/' $DRACUTMODDIR/install
-        # following changes are required on Fedora 23 ppc64
-        sed -i 's/\/lib64\/libnss_dns-2.12.so/\/lib64\/libnss_dns-2.22.so/' $DRACUTMODDIR/install
-        sed -i 's/\/lib\/libc.so.6/\/lib64\/libc.so.6/' $DRACUTMODDIR/install
+        # following changes are required on Fedora 26 Alpha ppc64
+        #sed -i 's/\/lib64\/libnss_dns-2.12.so/\/lib64\/libnss_dns-2.25.so/' $DRACUTMODDIR/install
+        #sed -i 's/\/lib\/libc.so.6/\/lib64\/libc.so.6/' $DRACUTMODDIR/install
         # following changes are required on Fedora 23 ppc64
         #sed -i 's/\/lib\/ld-linux.so.2/\/lib64\/ld-2.18.so/' $DRACUTMODDIR/install
-        sed -i 's/\/lib\/ld-linux.so.2/\/lib64\/ld-2.22.so/' $DRACUTMODDIR/install
-        sed -i 's/\/lib\/libdl.so.2/\/lib64\/libdl.so.2/' $DRACUTMODDIR/install
-        sed -i 's/\/lib\/libm.so.6/\/lib64\/libm.so.6/' $DRACUTMODDIR/install
-        sed -i 's/\/lib\/libpthread.so.0/\/lib64\/libpthread.so.0/' $DRACUTMODDIR/install
-        sed -i 's/\/lib64\/libncurses.so.5.7/\/lib64\/libncurses.so.5.9/' $DRACUTMODDIR/install
-        # following changes are required on Fedora 22 ppc64
+        #sed -i 's/\/lib\/ld-linux.so.2/\/lib64\/ld-2.25.so/' $DRACUTMODDIR/install
+        #sed -i 's/\/lib\/libdl.so.2/\/lib64\/libdl.so.2/' $DRACUTMODDIR/install
+        #sed -i 's/\/lib\/libm.so.6/\/lib64\/libm.so.6/' $DRACUTMODDIR/install
+        #sed -i 's/\/lib\/libpthread.so.0/\/lib64\/libpthread.so.0/' $DRACUTMODDIR/install
+        #sed -i 's/\/lib64\/libncurses.so.5.7/\/lib64\/libncurses.so.6.0/' $DRACUTMODDIR/install
         #sed -i 's/\/usr\/lib64\/libstdc++.so.6.0.13/\/usr\/lib64\/libstdc++.so.6.0.19/' $DRACUTMODDIR/install
-        sed -i 's/\/usr\/lib64\/libstdc++.so.6.0.13/\/usr\/lib64\/libstdc++.so.6.0.21/' $DRACUTMODDIR/install
-        sed -i 's/\/lib64\/libtinfo.so.5.7/\/lib64\/libtinfo.so.5.9/' $DRACUTMODDIR/install
-        sed -i 's/\/usr\/lib64\/libsasl2.so.2/\/usr\/lib64\/libsasl2.so.3/' $DRACUTMODDIR/install
+        #sed -i 's/\/usr\/lib64\/libstdc++.so.6.0.13/\/usr\/lib64\/libstdc++.so.6.0.23/' $DRACUTMODDIR/install
+        #sed -i 's/\/lib64\/libtinfo.so.5.7/\/lib64\/libtinfo.so.6.0/' $DRACUTMODDIR/install
+        #sed -i 's/\/usr\/lib64\/libsasl2.so.2/\/usr\/lib64\/libsasl2.so.3/' $DRACUTMODDIR/install
         #sed -i 's/\/lib64\/libnss_dns-2.12.so/\/lib64\/libnss_dns-2.18.so/' $DRACUTMODDIR/install
+        # ==========================================================
         sed -i 's/\/lib\/terminfo\/l\/linux/\/usr\/share\/terminfo\/l\/linux/g' $DRACUTMODDIR/install
         sed -i 's/\/lib\/terminfo\/v\/vt100/\/usr\/share\/terminfo\/v\/vt100/g' $DRACUTMODDIR/install
 fi
@@ -189,7 +191,8 @@ cd /tmp/xcatgenesis.$$/opt/xcat/share/xcat/netboot/genesis/$BUILDARCH/fs
 zcat /tmp/xcatgenesis.$$.rfs|cpio -dumi
 
 # add the perl library
-PERL_LIB_DIR="/usr/share/perl5 /usr/lib64/perl5 /usr/local/lib64/perl5 /usr/local/share/perl5"
+# add /usr/share/ntp/lib for Fedora26 ppc64, the ntp-perl will installed libraries under it
+PERL_LIB_DIR="/usr/share/perl5 /usr/lib64/perl5 /usr/local/lib64/perl5 /usr/local/share/perl5 /usr/share/ntp/lib"
 for d in `echo $PERL_LIB_DIR`; do
     if [ -e $d ]; then
         echo Adding perl libary "$d"

--- a/xCAT-genesis-builder/buildrpm
+++ b/xCAT-genesis-builder/buildrpm
@@ -135,30 +135,6 @@ if [ "$HOSTOS" = "mcp" ]; then
 elif [ $BUILDARCH = "ppc64" ]; then
         sed -i 's/ efibootmgr//' $DRACUTMODDIR/install
         sed -i 's/ dmidecode//' $DRACUTMODDIR/install
-        # Remove the libraries with special version number, starting from Fedora 26 Alpha ppc64
-        # ==========================================================
-        #sed -i 's/\/lib\/libncurses.so.5.7/\/lib64\/libncurses.so.5.7/' $DRACUTMODDIR/install
-        #sed -i 's/\/usr\/lib\/libstdc++.so.6.0.13/\/usr\/lib64\/libstdc++.so.6.0.13/' $DRACUTMODDIR/install
-        #sed -i 's/\/lib\/libgcc_s.so.1/\/lib64\/libgcc_s.so.1/' $DRACUTMODDIR/install
-        #sed -i 's/\/lib\/libtinfo.so.5.7/\/lib64\/libtinfo.so.5.7/' $DRACUTMODDIR/install
-        # following changes are required on Fedora 20 ppc64
-        # sed -i 's/\/lib64\/libnss_dns-2.12.so/\/lib64\/libnss_dns-2.18.so/' $DRACUTMODDIR/install
-        # following changes are required on Fedora 26 Alpha ppc64
-        #sed -i 's/\/lib64\/libnss_dns-2.12.so/\/lib64\/libnss_dns-2.25.so/' $DRACUTMODDIR/install
-        #sed -i 's/\/lib\/libc.so.6/\/lib64\/libc.so.6/' $DRACUTMODDIR/install
-        # following changes are required on Fedora 23 ppc64
-        #sed -i 's/\/lib\/ld-linux.so.2/\/lib64\/ld-2.18.so/' $DRACUTMODDIR/install
-        #sed -i 's/\/lib\/ld-linux.so.2/\/lib64\/ld-2.25.so/' $DRACUTMODDIR/install
-        #sed -i 's/\/lib\/libdl.so.2/\/lib64\/libdl.so.2/' $DRACUTMODDIR/install
-        #sed -i 's/\/lib\/libm.so.6/\/lib64\/libm.so.6/' $DRACUTMODDIR/install
-        #sed -i 's/\/lib\/libpthread.so.0/\/lib64\/libpthread.so.0/' $DRACUTMODDIR/install
-        #sed -i 's/\/lib64\/libncurses.so.5.7/\/lib64\/libncurses.so.6.0/' $DRACUTMODDIR/install
-        #sed -i 's/\/usr\/lib64\/libstdc++.so.6.0.13/\/usr\/lib64\/libstdc++.so.6.0.19/' $DRACUTMODDIR/install
-        #sed -i 's/\/usr\/lib64\/libstdc++.so.6.0.13/\/usr\/lib64\/libstdc++.so.6.0.23/' $DRACUTMODDIR/install
-        #sed -i 's/\/lib64\/libtinfo.so.5.7/\/lib64\/libtinfo.so.6.0/' $DRACUTMODDIR/install
-        #sed -i 's/\/usr\/lib64\/libsasl2.so.2/\/usr\/lib64\/libsasl2.so.3/' $DRACUTMODDIR/install
-        #sed -i 's/\/lib64\/libnss_dns-2.12.so/\/lib64\/libnss_dns-2.18.so/' $DRACUTMODDIR/install
-        # ==========================================================
         sed -i 's/\/lib\/terminfo\/l\/linux/\/usr\/share\/terminfo\/l\/linux/g' $DRACUTMODDIR/install
         sed -i 's/\/lib\/terminfo\/v\/vt100/\/usr\/share\/terminfo\/v\/vt100/g' $DRACUTMODDIR/install
 fi

--- a/xCAT-genesis-builder/install
+++ b/xCAT-genesis-builder/install
@@ -5,18 +5,16 @@ dracut_install netstat # broadcom update requires
 dracut_install uniq # mellanox update requires
 dracut_install grep ip hostname /usr/bin/awk egrep grep dirname expr
 dracut_install mount.nfs sshd vi reboot lspci parted screen mkfs mkfs.ext4 mkfs.xfs xfs_db #mkfs.btrfs removed
-dracut_install efibootmgr
 #dracut_install libvirtd /usr/share/libvirt/cpu_map.xml /usr/bin/qemu-img /usr/libexec/qemu-kvm
 dracut_install mkswap df brctl vconfig ifenslave ssh-keygen scp clear dhclient lldpad
-dracut_install lldptool /lib64/libnss_dns-2.12.so /lib64/libnss_dns.so.2
 dracut_install poweroff ntpq ntpd ntp-wait hwclock date /usr/share/terminfo/x/xterm /usr/share/terminfo/s/screen /etc/nsswitch.conf /etc/services
 dracut_install /sbin/rsyslogd /etc/protocols umount /bin/rpm /usr/lib/rpm/rpmrc
-dracut_install chmod /lib/libc.so.6 /lib/ld-linux.so.2 /lib/libdl.so.2 /lib/libm.so.6 /sbin/route /sbin/ifconfig /usr/bin/whoami /usr/bin/head /usr/bin/tail basename /etc/redhat-release ping tr lsusb /usr/share/hwdata/usb.ids #ibm fw wrapper requirements
-dracut_install dmidecode /usr/lib64/libstdc++.so.6 #uxspi prereqs, but will use dmidecode to improve decision on loading ipmi_si
-dracut_install dmidecode /usr/lib64/libstdc++.so.5 #broadcom firmware update links against old lib
-dracut_install /lib/libpthread.so.0 #32 bit lib because UXSPI will not ship a native 64 bit build
-dracut_install /lib/libncurses.so.5.7 /usr/lib/libstdc++.so.6.0.13 /lib/libgcc_s.so.1  /lib/libtinfo.so.5.7
-dracut_install /lib64/libldap-2.4.so.2 /lib64/liblber-2.4.so.2 /usr/lib64/libsasl2.so.2 #uxspi has incurred these...
+dracut_install chmod /sbin/route /sbin/ifconfig /usr/bin/whoami /usr/bin/head /usr/bin/tail basename /etc/redhat-release ping tr lsusb /usr/share/hwdata/usb.ids #ibm fw wrapper requirements
+dracut_install efibootmgr lldptool dmidecode #uxspi prereqs, but will use dmidecode to improve decision on loading ipmi_si
+#dracut_install dmidecode /usr/lib64/libstdc++.so.5 #broadcom firmware update links against old lib
+#dracut_install /lib/libpthread.so.0 #32 bit lib because UXSPI will not ship a native 64 bit build
+#dracut_install /lib/libncurses.so.5.7 /usr/lib/libstdc++.so.6.0.13 /lib/libgcc_s.so.1  /lib/libtinfo.so.5.7
+#dracut_install /lib64/libldap-2.4.so.2 /lib64/liblber-2.4.so.2 /usr/lib64/libsasl2.so.2 #uxspi has incurred these...
 dracut_install /usr/share/zoneinfo/posix/Zulu
 dracut_install /usr/share/zoneinfo/posix/GMT-0
 dracut_install /usr/share/zoneinfo/posix/Europe/Istanbul
@@ -594,7 +592,6 @@ inst_dir /var/lib/nfs/statd/sm
 inst_dir /var/lib/nfs/statd/sm.bak
 inst_dir /var/lib/nfs/rpc_pipefs/nfs
 inst "/bin/bash" "/bin/sh"
-inst "/lib64/libnss_dns-2.12.so"
 inst "/lib/terminfo/l/linux" "/lib/terminfo/l/linux"
 inst "/lib/terminfo/v/vt100" "/lib/terminfo/v/vt100"
 inst_hook cmdline 10 "$moddir/xcat-cmdline.sh" 
@@ -624,4 +621,4 @@ dracut_install /lib/udev/rules.d/95-dm-notify.rules
 dracut_install /usr/share/hwdata/pci.ids
 # The DB files for udevadm
 dracut_install /etc/udev/hwdb.bin
-dracut_install /lib64/libform.so.5 /lib64/libpanel.so.5 /lib64/libmenu.so.5 /lib64/libsysfs.so.2 /usr/sbin/iprconfig # iprconfig for IBM Power RAID configuration
+dracut_install /usr/sbin/iprconfig # iprconfig for IBM Power RAID configuration

--- a/xCAT-genesis-builder/install
+++ b/xCAT-genesis-builder/install
@@ -11,10 +11,6 @@ dracut_install poweroff ntpq ntpd ntp-wait hwclock date /usr/share/terminfo/x/xt
 dracut_install /sbin/rsyslogd /etc/protocols umount /bin/rpm /usr/lib/rpm/rpmrc
 dracut_install chmod /sbin/route /sbin/ifconfig /usr/bin/whoami /usr/bin/head /usr/bin/tail basename /etc/redhat-release ping tr lsusb /usr/share/hwdata/usb.ids #ibm fw wrapper requirements
 dracut_install efibootmgr lldptool dmidecode #uxspi prereqs, but will use dmidecode to improve decision on loading ipmi_si
-#dracut_install dmidecode /usr/lib64/libstdc++.so.5 #broadcom firmware update links against old lib
-#dracut_install /lib/libpthread.so.0 #32 bit lib because UXSPI will not ship a native 64 bit build
-#dracut_install /lib/libncurses.so.5.7 /usr/lib/libstdc++.so.6.0.13 /lib/libgcc_s.so.1  /lib/libtinfo.so.5.7
-#dracut_install /lib64/libldap-2.4.so.2 /lib64/liblber-2.4.so.2 /usr/lib64/libsasl2.so.2 #uxspi has incurred these...
 dracut_install /usr/share/zoneinfo/posix/Zulu
 dracut_install /usr/share/zoneinfo/posix/GMT-0
 dracut_install /usr/share/zoneinfo/posix/Europe/Istanbul


### PR DESCRIPTION
For the task #2933 

1. remove version number specified libraries from the installation modules
2. add ntp libraries special for ntp-perl on Fedora26 ppc64