### PR TITLE
Add debug information for openbmc to show Host State and Host Transition State

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -734,6 +734,11 @@ sub rpower_response {
 
     my $response_info = decode_json $response->content;
 
+    foreach my $key (keys %{$response_info->{data}}) {
+        # Debug, print out the Current and Transition States     
+        print "$node: DEBUG host_states $key=$response_info->{'data'}->{$key}\n";
+    }
+
     if ($node_info{$node}{cur_status} eq "RPOWER_ON_RESPONSE") {
         if ($response_info->{'message'} eq $::RESPONSE_OK) {
             xCAT::SvrUtils::sendmsg("on", $callback, $node);


### PR DESCRIPTION
In order to correctly display the states, we need to take into account the Requested Transition States and the Current Host state.    This information comes back in the response data.   Creating this pull request to start printed the information in the response of stat so we can start to see what states we need to take into account to display a "transition" state in xCAT... i.e "Powering-off"  until the machine actually turns off.  

```
$VAR1 = {
          'status' => 'ok',
          'data' => {
                      'RequestedHostTransition' => 'xyz.openbmc_project.State.Host.Transition.Reboot',
                      'CurrentHostState' => 'xyz.openbmc_project.State.Host.HostState.Running'
                    },
          'message' => '200 OK'
        };
```

When we set `XCATBYPASS=1` to turn on debug info, the following output will be displayed: 

When doing `rpower <node> stat`, the following extra messages will appear:
```
...
...
p9euh02: DEBUG GET https://10.6.9.254/xyz/openbmc_project/state/host0
p9euh02: DEBUG rpower_status_response 200 OK
p9euh02: DEBUG host_states RequestedHostTransition=xyz.openbmc_project.State.Host.Transition.On
p9euh02: DEBUG host_states CurrentHostState=xyz.openbmc_project.State.Host.HostState.Running
p9euh02: on
```

On power on and power off, there's nothing returned in data, so nothing will print out 