### PR TITLE
Fix issue #2794, Nodeset fails to generate /tftpboot config files if …

### DIFF
--- a/xCAT-server/lib/xcat/plugins/grub2.pm
+++ b/xCAT-server/lib/xcat/plugins/grub2.pm
@@ -513,11 +513,35 @@ sub process_request {
     #if not shared tftpdir, then filter, otherwise, set up everything
     if ($request->{'_disparatetftp'}->[0]) { #reading hint from preprocess_command
         @nodes = ();
+        my $cur_xmaster;
+        my %managed = {};
+
+        # Get current server managed node list
+        my $sn_hash = xCAT::ServiceNodeUtils->getSNformattedhash(\@rnodes, "xcat", "MN");
+        foreach my $nn (keys %$sn_hash) {
+            unless ( xCAT::NetworkUtils->thishostisnot($nn) ) {
+                $cur_xmaster = $nn;
+                foreach (@{ $sn_hash->{$cur_xmaster} }) { $managed{$_} = 1; }
+                last;
+            }
+        }
+
         foreach (@rnodes) {
             if (xCAT::NetworkUtils->nodeonmynet($_)) {
                 push @nodes, $_;
             } else {
-                xCAT::MsgUtils->message("S", "$_: grub2 netboot: stop configuration because of none sharedtftp and not on same network with its xcatmaster.");
+                my $msg = "grub2 configuration file was not created for node [$_] because sharedtftp attribute is not set and the node is not on same network as this xcatmaster";
+                if ( $cur_xmaster ) {
+                    $msg .= ": $cur_xmaster";
+                }
+                if ( exists( $managed{$_} ) ) {
+                    # report error when it is under my control but I cannot handle it.
+                    my $rsp;
+                    $rsp->{data}->[0] = $msg;
+                    xCAT::MsgUtils->message("E", $rsp, $callback);
+                } else {
+                    xCAT::MsgUtils->message("S", $msg);
+                }
             }
         }
     } else {

--- a/xCAT-server/lib/xcat/plugins/grub2.pm
+++ b/xCAT-server/lib/xcat/plugins/grub2.pm
@@ -513,18 +513,14 @@ sub process_request {
     #if not shared tftpdir, then filter, otherwise, set up everything
     if ($request->{'_disparatetftp'}->[0]) { #reading hint from preprocess_command
         @nodes = ();
-        my $cur_xmaster;
-        my %managed = {};
+        my @hostinfo = xCAT::NetworkUtils->determinehostname();
+        my $cur_xmaster = pop @hostinfo;
+        xCAT::MsgUtils->trace(0, "d", "xnba: running on $cur_xmaster");
 
         # Get current server managed node list
         my $sn_hash = xCAT::ServiceNodeUtils->getSNformattedhash(\@rnodes, "xcat", "MN");
-        foreach my $nn (keys %$sn_hash) {
-            unless ( xCAT::NetworkUtils->thishostisnot($nn) ) {
-                $cur_xmaster = $nn;
-                foreach (@{ $sn_hash->{$cur_xmaster} }) { $managed{$_} = 1; }
-                last;
-            }
-        }
+        my %managed = {};
+        foreach (@{ $sn_hash->{$cur_xmaster} }) { $managed{$_} = 1; }
 
         foreach (@rnodes) {
             if (xCAT::NetworkUtils->nodeonmynet($_)) {

--- a/xCAT-server/lib/xcat/plugins/petitboot.pm
+++ b/xCAT-server/lib/xcat/plugins/petitboot.pm
@@ -404,11 +404,35 @@ sub process_request {
     #if not shared tftpdir, then filter, otherwise, set up everything
     if ($request->{'_disparatetftp'}->[0]) { #reading hint from preprocess_command
         @nodes = ();
+        my $cur_xmaster;
+        my %managed = {};
+
+        # Get current server managed node list
+        my $sn_hash = xCAT::ServiceNodeUtils->getSNformattedhash(\@rnodes, "xcat", "MN");
+        foreach my $nn (keys %$sn_hash) {
+            unless ( xCAT::NetworkUtils->thishostisnot($nn) ) {
+                $cur_xmaster = $nn;
+                foreach (@{ $sn_hash->{$cur_xmaster} }) { $managed{$_} = 1; }
+                last;
+            }
+        }
+
         foreach (@rnodes) {
             if (xCAT::NetworkUtils->nodeonmynet($_)) {
                 push @nodes, $_;
             } else {
-                xCAT::MsgUtils->message("S", "$_: petitboot netboot: stop configuration because of none sharedtftp and not on same network with its xcatmaster.");
+                my $msg = "petitboot configuration file was not created for node [$_] because sharedtftp attribute is not set and the node is not on same network as this xcatmaster";
+                if ( $cur_xmaster ) {
+                    $msg .= ": $cur_xmaster";
+                }
+                if ( exists( $managed{$_} ) ) {
+                    # report error when it is under my control but I cannot handle it.
+                    my $rsp;
+                    $rsp->{data}->[0] = $msg;
+                    xCAT::MsgUtils->message("E", $rsp, $callback);
+                } else {
+                    xCAT::MsgUtils->message("S", $msg);
+                }
             }
         }
     } else {

--- a/xCAT-server/lib/xcat/plugins/petitboot.pm
+++ b/xCAT-server/lib/xcat/plugins/petitboot.pm
@@ -404,18 +404,14 @@ sub process_request {
     #if not shared tftpdir, then filter, otherwise, set up everything
     if ($request->{'_disparatetftp'}->[0]) { #reading hint from preprocess_command
         @nodes = ();
-        my $cur_xmaster;
-        my %managed = {};
+        my @hostinfo = xCAT::NetworkUtils->determinehostname();
+        my $cur_xmaster = pop @hostinfo;
+        xCAT::MsgUtils->trace(0, "d", "xnba: running on $cur_xmaster");
 
         # Get current server managed node list
         my $sn_hash = xCAT::ServiceNodeUtils->getSNformattedhash(\@rnodes, "xcat", "MN");
-        foreach my $nn (keys %$sn_hash) {
-            unless ( xCAT::NetworkUtils->thishostisnot($nn) ) {
-                $cur_xmaster = $nn;
-                foreach (@{ $sn_hash->{$cur_xmaster} }) { $managed{$_} = 1; }
-                last;
-            }
-        }
+        my %managed = {};
+        foreach (@{ $sn_hash->{$cur_xmaster} }) { $managed{$_} = 1; }
 
         foreach (@rnodes) {
             if (xCAT::NetworkUtils->nodeonmynet($_)) {

--- a/xCAT-server/lib/xcat/plugins/xnba.pm
+++ b/xCAT-server/lib/xcat/plugins/xnba.pm
@@ -449,18 +449,14 @@ sub process_request {
     #if not shared, then help sync up
     if ($::XNBA_request->{'_disparatetftp'}->[0]) { #reading hint from preprocess_command
         @nodes = ();
-        my $cur_xmaster;
-        my %managed = {};
+        my @hostinfo = xCAT::NetworkUtils->determinehostname();
+        my $cur_xmaster = pop @hostinfo;
+        xCAT::MsgUtils->trace(0, "d", "xnba: running on $cur_xmaster");
         
         # Get current server managed node list
         my $sn_hash = xCAT::ServiceNodeUtils->getSNformattedhash(\@rnodes, "xcat", "MN");
-        foreach my $nn (keys %$sn_hash) {
-            unless ( xCAT::NetworkUtils->thishostisnot($nn) ) {
-                $cur_xmaster = $nn;
-                foreach (@{ $sn_hash->{$cur_xmaster} }) { $managed{$_} = 1; }
-                last;
-            }
-        }
+        my %managed = {};
+        foreach (@{ $sn_hash->{$cur_xmaster} }) { $managed{$_} = 1; }
 
         # Whatever the node managed by this xcatmaster explicitly, if the node in same subnet, we need to handle its boot configuration files
         foreach (@rnodes) {

--- a/xCAT-server/lib/xcat/plugins/xnba.pm
+++ b/xCAT-server/lib/xcat/plugins/xnba.pm
@@ -449,11 +449,37 @@ sub process_request {
     #if not shared, then help sync up
     if ($::XNBA_request->{'_disparatetftp'}->[0]) { #reading hint from preprocess_command
         @nodes = ();
+        my $cur_xmaster;
+        my %managed = {};
+        
+        # Get current server managed node list
+        my $sn_hash = xCAT::ServiceNodeUtils->getSNformattedhash(\@rnodes, "xcat", "MN");
+        foreach my $nn (keys %$sn_hash) {
+            unless ( xCAT::NetworkUtils->thishostisnot($nn) ) {
+                $cur_xmaster = $nn;
+                foreach (@{ $sn_hash->{$cur_xmaster} }) { $managed{$_} = 1; }
+                last;
+            }
+        }
+
+        # Whatever the node managed by this xcatmaster explicitly, if the node in same subnet, we need to handle its boot configuration files
         foreach (@rnodes) {
             if (xCAT::NetworkUtils->nodeonmynet($_)) {
                 push @nodes, $_;
             } else {
-                xCAT::MsgUtils->message("S", "$_: xnba netboot: stop configuration because of none sharedtftp and not on same network with its xcatmaster.");
+                my $msg = "xnba configuration file was not created for node [$_] because sharedtftp attribute is not set and the node is not on same network as this xcatmaster";
+                if ( $cur_xmaster ) { 
+                    $msg .= ": $cur_xmaster"; 
+                }
+                if ( exists( $managed{$_} ) ) {
+                    # report error when it is under my control but I cannot handle it.
+                    my $rsp;
+                    $rsp->{data}->[0] = $msg;
+                    xCAT::MsgUtils->message("E", $rsp, $::XNBA_callback);
+                } else {
+                    xCAT::MsgUtils->message("S", $msg);
+                }
+
             }
         }
     } else {


### PR DESCRIPTION
Resolve #2794 

When sharedtftp=0 in site table, xcatd will broadcast the 'nodeset' request with the whole Node Range to all SNs. We cannot filter the node range first by explicit 'servicenode' definition in 'noderes' table prior to the broadcasting,  as all SNs or MN in the same subnet should be notified to make the changes on the corresponding boot configuration.

In previous implementation,  if the node does not have IP or the IP is not in the same network, it will only log but not complain to user. And the RC is still zero. It will cause confusing.

Now the patch will add some error reporting in such case, and to avoid too many redundant message.  **It is decided that only if 'servicenode' is explicitly defined for a node, but this service node cannot handle nodeset request for the node,  it will report error.**

