### PR TITLE
enhance bmcsetup logic for openbmc

### DIFF
--- a/xCAT-genesis-scripts/bin/bmcsetup
+++ b/xCAT-genesis-scripts/bin/bmcsetup
@@ -266,7 +266,7 @@ elif [ "$IPMIMFG" == "674" ]; then # DELL
         ipmitool delloem lan set shared with lom$BMCPORT &>/dev/null
         ipmitool delloem lan set shared with failover all loms &>dev/null
     fi
-elif [ "$IPMIMFG" == "42817" -a "$XPROD" == "16975" ]; then
+elif [ "$IPMIMFG" = "42817" -a "$XPROD" = "16975" ]; then
     ISOPENBMC=1
 fi
 
@@ -385,18 +385,40 @@ for b in $BMCVLAN; do
     let idev=idev+1
 done
 
-# After network commands are issued, pause to allow the BMC to apply (OpenPower)
-snooze 
+
 
 # update the node status to 'bmcready' for openbmc, no more configuration is needed.
 if [ ! -z "$ISOPENBMC" ]; then
+    # To enable network configuration for openbmc
+    let idev=0
+    TRIES=0
+    bmc_config_rc=0
+    # Set Channel Access to apply network setting 
+    #while ! ipmitool -d $idev lan set $LANCHAN access on; do
+    while ! ipmitool -d $idev raw 0x06 0x40 $LANCHAN 0x42 0x44 > /dev/null; do
+        snooze
+        let TRIES=TRIES+1
+        if [ $TRIES -gt $TIMEOUT ]; then 
+            bmc_config_rc=1
+            break;
+        fi
+    done
+
     # update the node status to 'bmcready'
     if [ ! -z "$XCATMASTER" ]; then
-        updateflag.awk $XCATMASTER 3002 "installstatus bmcready"
+        if [ "$bmc_config_rc" = "0" ]; then
+            # Wait for some time for the new network setting is ready 
+            snooze
+            updateflag.awk $XCATMASTER 3002 "installstatus bmcready"
+        else 
+            updateflag.awk $XCATMASTER 3002 "installstatus failed"
+        fi
     fi 
     rm -f /tmp/ipmicfg.xml
-    exit 0
+    exit $bmc_config_rc
 fi
+# After network commands are issued, pause to allow the BMC to apply (OpenPower)
+snooze 
 
 let idev=NUMBMCS-1
 for user in $BMCUS; do

--- a/xCAT-genesis-scripts/bin/bmcsetup
+++ b/xCAT-genesis-scripts/bin/bmcsetup
@@ -112,6 +112,13 @@ fi
 # Add ipmi_devintf module to allow the ipmitool operation in-band
 modprobe ipmi_devintf
 
+for parm in `cat /proc/cmdline`; do
+    key=`echo $parm|awk -F= '{print $1}'`
+    if [ "$key" = "xcatd" ]; then
+        XCATMASTER=`echo $parm|awk -F= '{print $2}'|awk -F: '{print $1}'`
+    fi
+done
+
 allowcred.awk &
 CREDPID=$!
 sleep 5
@@ -161,6 +168,7 @@ logger -s -t $log_label -p local4.info "IPMIVER=$IPMIVER, IPMIMFG=$IPMIMFG, XPRO
 #
 # IPMIMFG=2 = IBM
 # IPMIMFG=0 = OpenPower 
+# IPMIMFG=42817 and XPROD=16975 = OpenBMC
 #
 if [ "$IPMIMFG" == 2 ]; then #IBM
     if [ "$XPROD" == "220" ]; then
@@ -258,13 +266,20 @@ elif [ "$IPMIMFG" == "674" ]; then # DELL
         ipmitool delloem lan set shared with lom$BMCPORT &>/dev/null
         ipmitool delloem lan set shared with failover all loms &>dev/null
     fi
+elif [ "$IPMIMFG" == "42817" -a "$XPROD" == "16975" ]; then
+    ISOPENBMC=1
 fi
 
+if [ -z "$ISOPENBMC" ]; then
+    LAN_MED_TYPE="802.3"
+else 
+    LAN_MED_TYPE="Other LAN"
+fi
 while [ -z "$LANCHAN" ]; do 
     logger -s -t $log_label -p local4.info "Auto detecting LAN channel..."
     for TLANCHAN in {1..16}; do
         # Try to get the channel information; then get the MAC which is used for the channel
-        if ipmitool channel info $TLANCHAN 2> /dev/null | grep 802.3 > /dev/null 2>&1 && ipmitool raw 0xc 2 $TLANCHAN 5 0 0 > /dev/null 2>&1; then
+        if ipmitool channel info $TLANCHAN 2> /dev/null | grep "$LAN_MED_TYPE" > /dev/null 2>&1 && ipmitool raw 0xc 2 $TLANCHAN 5 0 0 > /dev/null 2>&1; then
             LANCHAN=$TLANCHAN
             break; 
         fi; 
@@ -279,6 +294,9 @@ logger -s -t $log_label -p local4.info "Detected LAN channel $LANCHAN"
         
 let idev=NUMBMCS
 if [ $IPCFGMETHOD="static" ]; then
+    if [ ! -z "$ISOPENBMC" ]; then
+        let idev=0
+    fi
     while [ $idev -gt 0 ]; do
         let idev=idev-1
         TRIES=0
@@ -334,7 +352,11 @@ if [ $IPCFGMETHOD="static" ]; then
         done
     fi
 else
-    let idev=NUMBMCS
+    if [ -z "$ISOPENBMC" ];then
+        let idev=NUMBMCS
+    else 
+        let idev=0
+    fi
     while [ $idev -gt 0 ]; do
         let idev=idev-1
         TRIES=0
@@ -365,6 +387,16 @@ done
 
 # After network commands are issued, pause to allow the BMC to apply (OpenPower)
 snooze 
+
+# update the node status to 'bmcready' for openbmc, no more configuration is needed.
+if [ ! -z "$ISOPENBMC" ]; then
+    # update the node status to 'bmcready'
+    if [ ! -z "$XCATMASTER" ]; then
+        updateflag.awk $XCATMASTER 3002 "installstatus bmcready"
+    fi 
+    rm -f /tmp/ipmicfg.xml
+    exit 0
+fi
 
 let idev=NUMBMCS-1
 for user in $BMCUS; do
@@ -587,12 +619,6 @@ while [ $idev -gt 0 ]; do
     cold_reset_bmc
 
     # update the node status to 'bmcready'
-    for parm in `cat /proc/cmdline`; do
-        key=`echo $parm|awk -F= '{print $1}'`
-        if [ "$key" = "xcatd" ]; then
-            XCATMASTER=`echo $parm|awk -F= '{print $2}'|awk -F: '{print $1}'`
-        fi
-    done
     if [ ! -z "$XCATMASTER" ]; then
         updateflag.awk $XCATMASTER 3002 "installstatus bmcready"
     fi

--- a/xCAT-genesis-scripts/bin/bmcsetup
+++ b/xCAT-genesis-scripts/bin/bmcsetup
@@ -266,13 +266,13 @@ elif [ "$IPMIMFG" == "674" ]; then # DELL
         ipmitool delloem lan set shared with lom$BMCPORT &>/dev/null
         ipmitool delloem lan set shared with failover all loms &>dev/null
     fi
-elif [ "$IPMIMFG" = "42817" -a "$XPROD" = "16975" ]; then
+elif [ "$IPMIMFG" = "42817" -a "$XPROD" = "16975" ]; then # IBM OpenPOWER servers with OpenBMC
     ISOPENBMC=1
 fi
 
-if [ -z "$ISOPENBMC" ]; then
-    LAN_MED_TYPE="802.3"
-else 
+LAN_MED_TYPE="802.3"
+if [ ! -z "$ISOPENBMC" ]; then
+    # Overvide the default value for OpenBMC
     LAN_MED_TYPE="Other LAN"
 fi
 while [ -z "$LANCHAN" ]; do 
@@ -390,12 +390,11 @@ done
 # update the node status to 'bmcready' for openbmc, no more configuration is needed.
 if [ ! -z "$ISOPENBMC" ]; then
     # To enable network configuration for openbmc
-    let idev=0
     TRIES=0
     bmc_config_rc=0
     # Set Channel Access to apply network setting 
-    #while ! ipmitool -d $idev lan set $LANCHAN access on; do
-    while ! ipmitool -d $idev raw 0x06 0x40 $LANCHAN 0x42 0x44 > /dev/null; do
+    #while ! ipmitool -d 0 lan set $LANCHAN access on; do
+    while ! ipmitool -d 0 raw 0x06 0x40 $LANCHAN 0x42 0x44 > /dev/null; do
         snooze
         let TRIES=TRIES+1
         if [ $TRIES -gt $TIMEOUT ]; then 

--- a/xCAT-genesis-scripts/bin/getipmi
+++ b/xCAT-genesis-scripts/bin/getipmi
@@ -29,10 +29,17 @@ for LANCHAN in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
 done
 BMCMAC=`ipmitool lan print $LANCHAN|grep ^MAC|awk '{print $4}'` #bmcconfig may opt to use DHCP, if so we need to feed up the mac address
 #TODO: need a way to get the DUID the service processor may use, perhaps reserve that for 'ibmsetup' since spec doesn't touch ipv6?
-
+IPMIMFG=`ipmitool mc info |grep "^Manufacturer ID"|awk  '{print $4}'`
+XPROD=`ipmitool mc info | grep "^Product ID"|awk '{print $4}'`
+if [ "$IPMIMFG" == "42817" -a "$XPROD" == "16975" ]; then
+    ISOPENBMC=1
+else
+    ISOPENBMC=0
+fi
 echo "<xcatrequest>
 <command>getbmcconfig</command>
 <callback_port>300</callback_port>
+<isopenbmc>$ISOPENBMC</isopenbmc>
 <bmcmac>$BMCMAC</bmcmac>
 </xcatrequest>" > /tmp/bmcreq.xml
 rm -f /tmp/ipmicfg.xml

--- a/xCAT-server/lib/perl/xCAT/PasswordUtils.pm
+++ b/xCAT-server/lib/perl/xCAT/PasswordUtils.pm
@@ -30,10 +30,14 @@ sub getIPMIAuth {
     my $noderange = $args{noderange};
     my $ipmihash  = $args{ipmihash};
     my $mphash    = $args{mphash};
+    my $key       = $args{keytype};
+    unless($key) {
+        $key = "ipmi";
+    }
     my $tmp;
     my %authmap;
     unless ($ipmihash) { #in the event that calling code does not pass us a prefetched set of values, pull it ourselves
-        my $ipmitab = xCAT::Table->new('ipmi', -create => 0);
+        my $ipmitab = xCAT::Table->new("$key", -create => 0);
         if ($ipmitab) { $ipmihash = $ipmitab->getNodesAttribs($noderange, [ 'username', 'password' ]); }
     }
     unless ($mphash) {
@@ -42,7 +46,7 @@ sub getIPMIAuth {
     }
     my $passtab = xCAT::Table->new('passwd');
     if ($passtab) {
-        ($tmp) = $passtab->getAttribs({ 'key' => 'ipmi' }, 'username', 'password');
+        ($tmp) = $passtab->getAttribs({ 'key' => "$key" }, 'username', 'password');
         if (defined($tmp)) {
             $ipmiuser = $tmp->{username};
             $ipmipass = $tmp->{password};

--- a/xCAT-server/lib/xcat/plugins/bmcconfig.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcconfig.pm
@@ -96,20 +96,24 @@ sub process_request {
     my $request  = shift;
     my $callback = shift;
     my $node     = $request->{'_xcat_clienthost'}->[0];
+    my $open_table = "ipmi";
+    if ($request->{isopenbmc}->[0]) {
+        $open_table = "openbmc";
+    }
     unless (ok_with_node($node, 300)) {
         $callback->({ error => ["Unable to prove root on your IP approves of this request"], errorcode => [1] });
         return;
     }
 
     #my $sitetable = xCAT::Table->new('site');
-    my $ipmitable = xCAT::Table->new('ipmi');
+    my $ipmitable = xCAT::Table->new("$open_table");
     my $tmphash;
     my $username;
     my $gennedpassword = 0;
     my $bmc;
     my $password;
     $tmphash = $ipmitable->getNodesAttribs([$node], [ 'bmc', 'username', 'bmcport', 'password', 'taggedvlan' ]);
-    my $authmap = xCAT::PasswordUtils::getIPMIAuth(noderange => [$node], ipmihash => $tmphash);
+    my $authmap = xCAT::PasswordUtils::getIPMIAuth(noderange => [$node], ipmihash => $tmphash, keytype => $open_table);
 
     if ($::XCATSITEVALS{genpasswords} eq "1" or $::XCATSITEVALS{genpasswords} =~ /y(es)?/i) {
         $password       = genpassword(10) . "1cA!";

--- a/xCAT-server/lib/xcat/plugins/bmcconfig.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcconfig.pm
@@ -96,9 +96,9 @@ sub process_request {
     my $request  = shift;
     my $callback = shift;
     my $node     = $request->{'_xcat_clienthost'}->[0];
-    my $open_table = "ipmi";
+    my $bmc_mgmt_type = "ipmi";
     if ($request->{isopenbmc}->[0]) {
-        $open_table = "openbmc";
+        $bmc_mgmt_type = "openbmc";
     }
     unless (ok_with_node($node, 300)) {
         $callback->({ error => ["Unable to prove root on your IP approves of this request"], errorcode => [1] });
@@ -106,14 +106,14 @@ sub process_request {
     }
 
     #my $sitetable = xCAT::Table->new('site');
-    my $ipmitable = xCAT::Table->new("$open_table");
+    my $ipmitable = xCAT::Table->new("$bmc_mgmt_type");
     my $tmphash;
     my $username;
     my $gennedpassword = 0;
     my $bmc;
     my $password;
     $tmphash = $ipmitable->getNodesAttribs([$node], [ 'bmc', 'username', 'bmcport', 'password', 'taggedvlan' ]);
-    my $authmap = xCAT::PasswordUtils::getIPMIAuth(noderange => [$node], ipmihash => $tmphash, keytype => $open_table);
+    my $authmap = xCAT::PasswordUtils::getIPMIAuth(noderange => [$node], ipmihash => $tmphash, keytype => $bmc_mgmt_type);
 
     if ($::XCATSITEVALS{genpasswords} eq "1" or $::XCATSITEVALS{genpasswords} =~ /y(es)?/i) {
         $password       = genpassword(10) . "1cA!";


### PR DESCRIPTION
Include 3 main modification:
1. add `isopenbmc` attribute for the `getbmcconfig` command send by `getipmi` script in xcat-genesis-scripts
2. modify `bmcsetup` script to disable unsupported ipmitool in-band command for openbmc
3. in bmcconfig.pm, read bmc information from `openbmc` table if the request come from an openbmc.
4. read default password with key `openbmc` from `passwd` table if the request come from an openbmc.

Before modifying:
```
[p9euh02 /]# ipmitool lan print 1
Set in Progress         : Set Complete
...
IP Address              : 10.6.9.200
Subnet Mask             : 255.0.0.0
MAC Address             : 70:e2:84:14:24:74
Default Gateway IP      : 10.0.0.101
...
```
Configuring BMC:
```
[p9euh02 /]# /bin/bmcsetup
ipmitool version 1.8.18
Invalid channel: 16
/bin/bmcsetup: line 151:  3709 Terminated              allowcred.awk
<167>May  8 05:24:45 xcat.genesis.bmcsetup: BMC Information obtained from xCAT
<167>May  8 05:24:45 xcat.genesis.bmcsetup: NUMBMCS=1 ==> BMC IP=10.6.9.254/255.0.0.0, GW=10.0.0.101, VLAN=off
<166>May  8 05:24:45 xcat.genesis.bmcsetup: IPMIVER=2.0, IPMIMFG=42817, XPROD=16975
<166>May  8 05:24:45 xcat.genesis.bmcsetup: Auto detecting LAN channel...
<166>May  8 05:24:45 xcat.genesis.bmcsetup: Detected LAN channel 1
Setting LAN IP Address to 10.6.9.254
Setting LAN Subnet Mask to 255.0.0.0
Setting LAN Default Gateway IP to 10.0.0.101
<167>May  8 05:24:47 xcat.genesis.bmcsetup: snooze for 1 second...
```
After modifying:
```
[p9euh02 /]# ipmitool lan print 1
Set in Progress         : Set Complete
...
IP Address              : 10.6.9.254
Subnet Mask             : 255.0.0.0
MAC Address             : 70:e2:84:14:24:74
Default Gateway IP      : 10.0.0.101
...
```
For the task #2810 