### PR TITLE
Remove go-xcat test cases from all platforms except rhels7.3_ppc64le and ubuntu16.04.1_ppc64le

### DIFF
--- a/xCAT-test/autotest/bundle/rhels6.8_ppc64.bundle
+++ b/xCAT-test/autotest/bundle/rhels6.8_ppc64.bundle
@@ -1,9 +1,4 @@
 reg_linux_diskfull_installation_flat
-go_xcat_local_repo_case7
-go_xcat_noinput
-go_xcat_with_x
-go_xcat_with_xcat-version-1
-go_xcat_online_repo_case6
 updatenode_h
 updatenode_v
 updatenode_diskful_syncfiles

--- a/xCAT-test/autotest/bundle/rhels6.8_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/rhels6.8_x86_64.bundle
@@ -1,10 +1,5 @@
 setup_vm
 reg_linux_diskfull_installation_flat
-go_xcat_local_repo_case7
-go_xcat_noinput
-go_xcat_with_x
-go_xcat_with_xcat-version-1
-go_xcat_online_repo_case6
 makehosts_h
 makehosts_help
 makehosts_n

--- a/xCAT-test/autotest/bundle/rhels6.9_ppc64.bundle
+++ b/xCAT-test/autotest/bundle/rhels6.9_ppc64.bundle
@@ -1,9 +1,4 @@
 reg_linux_diskfull_installation_flat
-go_xcat_local_repo_case7
-go_xcat_noinput
-go_xcat_with_x
-go_xcat_with_xcat-version-1
-go_xcat_online_repo_case6
 updatenode_h
 updatenode_v
 updatenode_diskful_syncfiles

--- a/xCAT-test/autotest/bundle/rhels6.9_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/rhels6.9_x86_64.bundle
@@ -1,10 +1,5 @@
 setup_vm
 reg_linux_diskfull_installation_flat
-go_xcat_local_repo_case7
-go_xcat_noinput
-go_xcat_with_x
-go_xcat_with_xcat-version-1
-go_xcat_online_repo_case6
 makehosts_h
 makehosts_help
 makehosts_n

--- a/xCAT-test/autotest/bundle/rhels7.2_ppc64.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.2_ppc64.bundle
@@ -1,9 +1,4 @@
 reg_linux_diskfull_installation_flat
-go_xcat_local_repo_case7
-go_xcat_noinput
-go_xcat_with_x
-go_xcat_with_xcat-version-1
-go_xcat_online_repo_case6
 updatenode_h
 updatenode_v
 updatenode_diskful_syncfiles

--- a/xCAT-test/autotest/bundle/rhels7.2_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.2_ppc64le.bundle
@@ -1,11 +1,6 @@
 setup_vm
 Diskless_installation_flat_p8_le
 Full_installation_flat_p8_le
-go_xcat_local_repo_case7
-go_xcat_noinput
-go_xcat_with_x
-go_xcat_with_xcat-version-1
-go_xcat_online_repo_case6
 updatenode_h
 updatenode_v
 updatenode_diskful_syncfiles

--- a/xCAT-test/autotest/bundle/rhels7.2_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.2_x86_64.bundle
@@ -1,10 +1,5 @@
 setup_vm
 reg_linux_diskfull_installation_flat
-go_xcat_local_repo_case7
-go_xcat_noinput
-go_xcat_with_x
-go_xcat_with_xcat-version-1
-go_xcat_online_repo_case6
 makehosts_h
 makehosts_help
 makehosts_n

--- a/xCAT-test/autotest/bundle/rhels7.3_ppc64.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.3_ppc64.bundle
@@ -1,9 +1,4 @@
 reg_linux_diskfull_installation_flat
-go_xcat_local_repo_case7
-go_xcat_noinput
-go_xcat_with_x
-go_xcat_with_xcat-version-1
-go_xcat_online_repo_case6
 updatenode_h
 updatenode_v
 updatenode_diskful_syncfiles

--- a/xCAT-test/autotest/bundle/rhels7.3_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.3_ppc64le.bundle
@@ -1,11 +1,7 @@
 setup_vm
 reg_linux_diskless_installation_flat
 reg_linux_diskfull_installation_flat
-go_xcat_local_repo_case7
 go_xcat_noinput
-go_xcat_with_x
-go_xcat_with_xcat-version-1
-go_xcat_online_repo_case6
 updatenode_h
 updatenode_v
 updatenode_diskful_syncfiles

--- a/xCAT-test/autotest/bundle/rhels7.3_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.3_x86_64.bundle
@@ -1,10 +1,5 @@
 setup_vm
 reg_linux_diskfull_installation_flat
-go_xcat_local_repo_case7
-go_xcat_noinput
-go_xcat_with_x
-go_xcat_with_xcat-version-1
-go_xcat_online_repo_case6
 makehosts_h
 makehosts_help
 makehosts_n

--- a/xCAT-test/autotest/bundle/sles11.4_ppc64.bundle
+++ b/xCAT-test/autotest/bundle/sles11.4_ppc64.bundle
@@ -1,9 +1,4 @@
 reg_linux_diskfull_installation_flat
-go_xcat_local_repo_case7
-go_xcat_noinput
-go_xcat_with_x
-go_xcat_with_xcat-version-1
-go_xcat_online_repo_case6
 chdef_null
 chdef_t_node
 chdef_t_network

--- a/xCAT-test/autotest/bundle/sles11.4_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/sles11.4_x86_64.bundle
@@ -1,10 +1,5 @@
 setup_vm
 reg_linux_diskfull_installation_flat
-go_xcat_local_repo_case7
-go_xcat_noinput
-go_xcat_with_x
-go_xcat_with_xcat-version-1
-go_xcat_online_repo_case6
 makehosts_h
 makehosts_help
 makehosts_n

--- a/xCAT-test/autotest/bundle/sles12.1_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/sles12.1_ppc64le.bundle
@@ -1,11 +1,6 @@
 setup_vm
 reg_linux_diskless_installation_flat
 reg_linux_diskfull_installation_flat
-go_xcat_local_repo_case7
-go_xcat_noinput
-go_xcat_with_x
-go_xcat_with_xcat-version-1
-go_xcat_online_repo_case6
 makehosts_h
 makehosts_help
 makehosts_n

--- a/xCAT-test/autotest/bundle/sles12.1_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/sles12.1_x86_64.bundle
@@ -1,10 +1,5 @@
 setup_vm
 reg_linux_diskfull_installation_flat
-go_xcat_local_repo_case7
-go_xcat_noinput
-go_xcat_with_x
-go_xcat_with_xcat-version-1
-go_xcat_online_repo_case6
 makehosts_h
 makehosts_help
 makehosts_n

--- a/xCAT-test/autotest/bundle/sles12.2_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/sles12.2_ppc64le.bundle
@@ -1,11 +1,6 @@
 setup_vm
 reg_linux_diskless_installation_flat
 reg_linux_diskfull_installation_flat
-go_xcat_local_repo_case7
-go_xcat_noinput
-go_xcat_with_x
-go_xcat_with_xcat-version-1
-go_xcat_online_repo_case6
 makehosts_h
 makehosts_help
 makehosts_n

--- a/xCAT-test/autotest/bundle/sles12.2_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/sles12.2_x86_64.bundle
@@ -1,10 +1,5 @@
 setup_vm
 reg_linux_diskfull_installation_flat
-go_xcat_local_repo_case7
-go_xcat_noinput
-go_xcat_with_x
-go_xcat_with_xcat-version-1
-go_xcat_online_repo_case6
 makehosts_h
 makehosts_help
 makehosts_n

--- a/xCAT-test/autotest/bundle/ubuntu14.04.4_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu14.04.4_ppc64le.bundle
@@ -1,10 +1,6 @@
 setup_vm
 reg_linux_diskless_installation_flat
 reg_linux_diskfull_installation_flat
-go_xcat_local_repo_case7
-go_xcat_noinput
-go_xcat_with_xcat-version-1
-go_xcat_online_repo_case6
 makehosts_h
 makehosts_help
 makehosts_n_noderange

--- a/xCAT-test/autotest/bundle/ubuntu14.04.4_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu14.04.4_x86_64.bundle
@@ -1,10 +1,6 @@
 setup_vm
 reg_linux_diskless_installation_flat
 reg_linux_diskfull_installation_flat
-go_xcat_local_repo_case7
-go_xcat_noinput
-go_xcat_with_xcat-version-1
-go_xcat_online_repo_case6
 makehosts_h
 makehosts_help
 makehosts_n_noderange

--- a/xCAT-test/autotest/bundle/ubuntu16.04.1_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu16.04.1_ppc64le.bundle
@@ -1,10 +1,7 @@
 setup_vm
 reg_linux_diskless_installation_flat
 reg_linux_diskfull_installation_flat
-go_xcat_local_repo_case7
 go_xcat_noinput
-go_xcat_with_xcat-version-1
-go_xcat_online_repo_case6
 makehosts_h
 makehosts_help
 makehosts_n_noderange

--- a/xCAT-test/autotest/bundle/ubuntu16.04.1_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu16.04.1_x86_64.bundle
@@ -1,10 +1,6 @@
 setup_vm
 reg_linux_diskless_installation_flat
 reg_linux_diskfull_installation_flat
-go_xcat_local_repo_case7
-go_xcat_noinput
-go_xcat_with_xcat-version-1
-go_xcat_online_repo_case6
 makehosts_h
 makehosts_help
 makehosts_n_noderange

--- a/xCAT-test/autotest/bundle/ubuntu16.04_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu16.04_ppc64le.bundle
@@ -1,11 +1,7 @@
 setup_vm
 reg_linux_diskless_installation_flat
 reg_linux_diskfull_installation_flat
-go_xcat_local_repo_case7
 go_xcat_noinput
-go_xcat_with_x
-go_xcat_with_xcat-version-1
-go_xcat_online_repo_case6
 makehosts_h
 makehosts_help
 makehosts_n_noderange

--- a/xCAT-test/autotest/bundle/ubuntu16.04_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu16.04_x86_64.bundle
@@ -1,11 +1,6 @@
 setup_vm
 reg_linux_diskless_installation_flat
 reg_linux_diskfull_installation_flat
-go_xcat_local_repo_case7
-go_xcat_noinput
-go_xcat_with_x
-go_xcat_with_xcat-version-1
-go_xcat_online_repo_case6
 makehosts_h
 makehosts_help
 makehosts_n_noderange


### PR DESCRIPTION
This is due to these test cases consume too much Internet traffic.