### PR TITLE
Fix issue 2350: Wcons IPMI not working due to xcat code

### DIFF
--- a/xCAT-server/share/xcat/cons/ipmi
+++ b/xCAT-server/share/xcat/cons/ipmi
@@ -125,7 +125,9 @@ if (grep /IPMI Version              : 1.5/, @mcinfo) {
     $solcom = "isol";
     $iface  = "lan";
 } elsif (grep /Manufacturer ID           : 343/, @mcinfo && ! grep /Product ID                : 117/,@mcinfo) {
-    $isintel = 1;
+    if (! grep /Product ID\s*:\s*64/,@mcinfo) {
+        $isintel = 1;
+    }
 }
 my $inteloption = "";
 if ($isintel) {


### PR DESCRIPTION
Fix issue #2350 

The modification is, if "Product ID" is "64", won't set the 'isintel' flag.