### PR TITLE
Fix 2794 - Nodeset fails to generate /tftpboot config files if ip attribute is not set

### DIFF
--- a/xCAT-server/lib/xcat/plugins/grub2.pm
+++ b/xCAT-server/lib/xcat/plugins/grub2.pm
@@ -515,7 +515,7 @@ sub process_request {
         @nodes = ();
         my @hostinfo = xCAT::NetworkUtils->determinehostname();
         my $cur_xmaster = pop @hostinfo;
-        xCAT::MsgUtils->trace(0, "d", "xnba: running on $cur_xmaster");
+        xCAT::MsgUtils->trace(0, "d", "grub2: running on $cur_xmaster");
 
         # Get current server managed node list
         my $sn_hash = xCAT::ServiceNodeUtils->getSNformattedhash(\@rnodes, "xcat", "MN");

--- a/xCAT-server/lib/xcat/plugins/petitboot.pm
+++ b/xCAT-server/lib/xcat/plugins/petitboot.pm
@@ -406,7 +406,7 @@ sub process_request {
         @nodes = ();
         my @hostinfo = xCAT::NetworkUtils->determinehostname();
         my $cur_xmaster = pop @hostinfo;
-        xCAT::MsgUtils->trace(0, "d", "xnba: running on $cur_xmaster");
+        xCAT::MsgUtils->trace(0, "d", "petitboot: running on $cur_xmaster");
 
         # Get current server managed node list
         my $sn_hash = xCAT::ServiceNodeUtils->getSNformattedhash(\@rnodes, "xcat", "MN");


### PR DESCRIPTION
This is a amend fix for #2794 - correct the wrong plugin name in trace log