### PR TITLE
Modify bootloader label to be "xCAT Genesis shell" for petitboot

### DIFF
--- a/xCAT-server/lib/xcat/plugins/petitboot.pm
+++ b/xCAT-server/lib/xcat/plugins/petitboot.pm
@@ -203,8 +203,12 @@ sub setstate {
     } elsif ($kern and $kern->{kernel} and $cref and $cref->{currstate} ne "offline") {
 
         #It's time to set petitboot for this node to boot the kernel, but only if not offline directive
-        print $pcfg "default xCAT\n";
-        print $pcfg "label xCAT\n";
+        my $label = "xCAT";
+        if ($cref->{currstate} eq "shell") {
+            $label = "xCAT Genesis shell";
+        }
+        print $pcfg "default $label\n";
+        print $pcfg "label $label\n";
         print $pcfg "\tkernel $kern->{kernel}\n";
         if ($kern and $kern->{initrd}) {
             print $pcfg "\tinitrd " . $kern->{initrd} . "\n";


### PR DESCRIPTION
Fix issue #3003 
The petitboot configuration file looks like this after "nodeset shell"

```
[root@stratton01 ~]# cat /tftpboot/petitboot/p9euh01
#shell
default xCAT Genesis shell
label xCAT Genesis shell
	kernel http://10.6.29.1:80/tftpboot/xcat/genesis.kernel.ppc64
	initrd http://10.6.29.1:80/tftpboot/xcat/genesis.fs.ppc64.gz
	append "quiet xcatd=10.6.29.1:3001 destiny=shell rd.dm=0 rd.md=0 nodmraid inst.sshd"
```
In petitboot menu:
```
...
  [Network: enP5p1s0f0 / 70:e2:84:14:24:84]
    xCAT Genesis shell

  System information
  System configuration
  System status log
...
```