### PR TITLE
Add test case to check exit code when syncfiles failing

### DIFF
--- a/xCAT-test/autotest/testcase/updatenode/cases3
+++ b/xCAT-test/autotest/testcase/updatenode/cases3
@@ -1,0 +1,15 @@
+start:updatenode_diskful_syncfiles_failing
+cmd:mkdir -p /install/custom/install/__GETNODEATTR($$CN,os)__/ 
+check:rc==0
+cmd:echo "/tmp/non-existent -> /etc/motd" > /install/custom/install/__GETNODEATTR($$CN,os)__/booboo.synclist 
+check:rc==0
+cmd:chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute synclists=/install/custom/install/__GETNODEATTR($$CN,os)__/booboo.synclist
+check:rc==0
+cmd:updatenode $$CN -F >/tmp/updatenode.F.out
+check:rc!=0
+cmd:grep 'updatenode exited with code 1' /tmp/updatenode.F.out
+check:rc==0
+cmd:chdef -t osimage -o  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute synclists=
+check:rc==0
+cmd:rm -f /install/custom/install/__GETNODEATTR($$CN,os)__/booboo.synclist 
+end 

--- a/xCAT-test/autotest/testcase/updatenode/cases3
+++ b/xCAT-test/autotest/testcase/updatenode/cases3
@@ -1,4 +1,5 @@
 start:updatenode_diskful_syncfiles_failing
+description: Test exit code when syncfiles failing.
 cmd:mkdir -p /install/custom/install/__GETNODEATTR($$CN,os)__/ 
 check:rc==0
 cmd:echo "/tmp/non-existent -> /etc/motd" > /install/custom/install/__GETNODEATTR($$CN,os)__/booboo.synclist 


### PR DESCRIPTION
Add one cases in this pull request
This test case is for issue #2560
This pull request is for task #2929

[case 1]
Case Name: updatenode_diskful_syncfiles_failing
description: Test exit code when syncfiles failing.