### PR TITLE
fix issue2726 remoteshell failed in line 488 in statelite

### DIFF
--- a/xCAT/postscripts/remoteshell
+++ b/xCAT/postscripts/remoteshell
@@ -486,7 +486,7 @@ else
     # sshd is not enabled on SLES 12 by default
     # does not hurt anything to re-enable if it is enabled already
     # and disable enable service for diskless and statelite
-    if [[ $NODESETSTATE == install ]]; then
+    if [ "$NODESETSTATE" == install ]; then
         enableservice sshd
     fi
     restartservice sshd

--- a/xCAT/postscripts/remoteshell
+++ b/xCAT/postscripts/remoteshell
@@ -486,7 +486,7 @@ else
     # sshd is not enabled on SLES 12 by default
     # does not hurt anything to re-enable if it is enabled already
     # and disable enable service for diskless and statelite
-    if [ "$NODESETSTATE" == install ]; then
+    if [ "$NODESETSTATE" = install ]; then
         enableservice sshd
     fi
     restartservice sshd

--- a/xCAT/postscripts/remoteshell
+++ b/xCAT/postscripts/remoteshell
@@ -485,10 +485,12 @@ else
     #service sshd restart
     # sshd is not enabled on SLES 12 by default
     # does not hurt anything to re-enable if it is enabled already
-    enableservice sshd
+    # and disable enable service for diskless and statelite
+    if [[ $NODESETSTATE == install ]]; then
+        enableservice sshd
+    fi
     restartservice sshd
 fi
-
 #if the service restart with "service/systemctl" failed
 #try to kill the process and start
 if [ "$?" != "0" ];then


### PR DESCRIPTION
fix issue #2726 

remoteshell script is common for both diskless and diskful.  'enable sshd' is necessary for diskful. Just disable the 'sshd enablement' for diskless and statelite.