### PR TITLE
partial fix for [openbmc]xcatd reported "Died at /opt/xcat/sbin/xcatd " when openbmc nodes updated its status from "installing" to "booting" #3026

### DIFF
--- a/xCAT-server/lib/xcat/plugins/petitboot.pm
+++ b/xCAT-server/lib/xcat/plugins/petitboot.pm
@@ -501,7 +501,11 @@ sub process_request {
     if ($args[0] eq 'next') {
         $sub_req->({ command => ['rsetboot'],
                 node => \@nodes,
-                arg  => ['default'] });
+                arg  => ['default'],
+                #todo: do not need to pass the XCAT_OPENBMC_DEVEL after the openbmc dev work finish
+                #this does not hurt anything for other plugins
+                environment => {XCAT_OPENBMC_DEVEL=>"YES"}
+                });
         xCAT::MsgUtils->message("S", "xCAT: petitboot netboot: clear node(s): @nodes boot device setting.");
     }
     my $chaintab = xCAT::Table->new('chain', -create => 1);


### PR DESCRIPTION
partial fix for issue https://github.com/xcat2/xcat-core/issues/3026:

pass environment variable XCAT_OPENBMC_DEVEL to rsetboot to run ``rsetboot`` for openbmc, this won't hurt anything for other mgt types. 