### PR TITLE
Better processing mkdef if object already exists

### DIFF
--- a/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
+++ b/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
@@ -1750,11 +1750,8 @@ sub defmk
 
                 #  won't remove the old one unless the force option is used
                 my $rsp;
-                $rsp->{data}->[0] = "\nA definition for \'$obj\' already exists.";
-                $rsp->{data}->[1] = "To remove the old definition and replace it with \na new definition use the force \'-f\' option.";
-                $rsp->{data}->[2] = "To change the existing definition use the \'chdef\' command.";
-                xCAT::MsgUtils->message("E", $rsp, $::callback);
-                $error = 1;
+                $rsp->{data}->[0] = "A definition for \'$obj\' already exists. No changes will be made.  Run again with \'-f\' option to force replace.";
+                xCAT::MsgUtils->message("W", $rsp, $::callback);
                 delete $::FINALATTRS{$obj};
                 next;
 
@@ -2007,7 +2004,6 @@ sub defmk
 
             #  give results
             my $rsp;
-            $rsp->{data}->[0] = "The database was updated for the following objects:";
             xCAT::MsgUtils->message("I", $rsp, $::callback);
 
             my $n = 1;
@@ -2016,14 +2012,30 @@ sub defmk
                 $rsp->{data}->[$n] = "$o";
                 $n++;
             }
-            xCAT::MsgUtils->message("I", $rsp, $::callback);
+            if ($n > 1) {
+                # Some objects were created ($n was increased), report as success
+                $rsp->{data}->[0] = "The database was updated for the following objects:";
+                xCAT::MsgUtils->message("I", $rsp, $::callback);
+            }
+            else {
+                # No objects were created, report as error
+                $rsp->{data}->[0] = "The database was not updated.";
+                xCAT::MsgUtils->message("E", $rsp, $::callback);
+            }
         }
         else
         {
             my $rsp;
             my $nodenum = scalar(keys %::FINALATTRS);
             $rsp->{data}->[0] = "$nodenum object definitions have been created or modified.";
-            xCAT::MsgUtils->message("I", $rsp, $::callback);
+            if ($nodenum > 0) {
+                # Some objects were created, report as success
+                xCAT::MsgUtils->message("I", $rsp, $::callback);
+            }
+            else {
+                # No objects were created, report as error
+                xCAT::MsgUtils->message("E", $rsp, $::callback);
+            }
         }
         return 0;
     }


### PR DESCRIPTION
Fixes problem reported by #3023 

1. Modify message to be a single "Warning" line if object already exists.
2. RC=1 if no objects at all were created, RC=0 if at least one object was created from the given range, even if some failed.

Example output:

1. Range given, no new objects created:
```
fs2vm101:/opt/xcat/lib/perl/xCAT_plugin # mkdef mkdef_test[001-005] groups="all"
Warning: A definition for 'mkdef_test001' already exists. No changes will be made.  Run again with '-f' option to force replace.
Warning: A definition for 'mkdef_test005' already exists. No changes will be made.  Run again with '-f' option to force replace.
Warning: A definition for 'mkdef_test004' already exists. No changes will be made.  Run again with '-f' option to force replace.
Warning: A definition for 'mkdef_test002' already exists. No changes will be made.  Run again with '-f' option to force replace.
Warning: A definition for 'mkdef_test003' already exists. No changes will be made.  Run again with '-f' option to force replace.
Error: 0 object definitions have been created or modified.
fs2vm101:/opt/xcat/lib/perl/xCAT_plugin # echo $?
1
fs2vm101:/opt/xcat/lib/perl/xCAT_plugin #
```

2. Range given, at least one new object created:
```
fs2vm101:/opt/xcat/lib/perl/xCAT_plugin # mkdef mkdef_test[001-006] groups="all"
Warning: A definition for 'mkdef_test003' already exists. No changes will be made.  Run again with '-f' option to force replace.
Warning: A definition for 'mkdef_test004' already exists. No changes will be made.  Run again with '-f' option to force replace.
Warning: A definition for 'mkdef_test005' already exists. No changes will be made.  Run again with '-f' option to force replace.
Warning: A definition for 'mkdef_test001' already exists. No changes will be made.  Run again with '-f' option to force replace.
Warning: A definition for 'mkdef_test002' already exists. No changes will be made.  Run again with '-f' option to force replace.
1 object definitions have been created or modified.
fs2vm101:/opt/xcat/lib/perl/xCAT_plugin # echo $?
0
fs2vm101:/opt/xcat/lib/perl/xCAT_plugin #
```
3. Range given, no new objects created, -V verbose:
```
Warning: A definition for 'mkdef_test003' already exists. No changes will be made.  Run again with '-f' option to force replace.
Warning: A definition for 'mkdef_test005' already exists. No changes will be made.  Run again with '-f' option to force replace.
Warning: A definition for 'mkdef_test004' already exists. No changes will be made.  Run again with '-f' option to force replace.
Warning: A definition for 'mkdef_test001' already exists. No changes will be made.  Run again with '-f' option to force replace.
Warning: A definition for 'mkdef_test002' already exists. No changes will be made.  Run again with '-f' option to force replace.
Error: The database was not updated.
fs2vm101:/opt/xcat/lib/perl/xCAT_plugin # echo $?
1
fs2vm101:/opt/xcat/lib/perl/xCAT_plugin #
```

4. Range given, at least one new object created, -V verbose:
```
Warning: A definition for 'mkdef_test002' already exists. No changes will be made.  Run again with '-f' option to force replace.
Warning: A definition for 'mkdef_test005' already exists. No changes will be made.  Run again with '-f' option to force replace.
Warning: A definition for 'mkdef_test001' already exists. No changes will be made.  Run again with '-f' option to force replace.
Warning: A definition for 'mkdef_test004' already exists. No changes will be made.  Run again with '-f' option to force replace.
Warning: A definition for 'mkdef_test003' already exists. No changes will be made.  Run again with '-f' option to force replace.
The database was updated for the following objects:
mkdef_test006
fs2vm101:/opt/xcat/lib/perl/xCAT_plugin # echo $?
0
fs2vm101:/opt/xcat/lib/perl/xCAT_plugin #
```