### PR TITLE
fix nictypes capital letter failure in confignetwork

### DIFF
--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -326,6 +326,9 @@ function sort_nics_device_order {
 ###################################################################################
 function configure_nicdevice {
     nics_pair=$*
+    #nictypes support capital letters, for example, Ethernet and ethernet
+    #use $utolcmd to transform capital to lower case
+    utolcmd="sed -e y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/"
     #configure nic and its device pair one by one   
     num=1
     max=`echo "$nics_pair"|wc -l`
@@ -344,10 +347,10 @@ function configure_nicdevice {
                 base_temp_nic=$base_nic_dev
             fi
         
-            base_nic_type=`find_nic_type "$base_temp_nic"`
+            base_nic_type=`find_nic_type "$base_temp_nic" | $utolcmd`
         fi
         nic_dev=`echo "$nics_pair" |sed -n "${num}p"|awk '{print $1}'`
-        nic_dev_type=`find_nic_type "$nic_dev"`
+        nic_dev_type=`find_nic_type "$nic_dev" | $utolcmd`
         echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
         nic_pair=`echo "$nics_pair" |sed -n "${num}p"`
         echo "configure nic and its device : $nic_pair"


### PR DESCRIPTION
fix issue: confignetwork does not support capital letter in nictypes #3042 

Unit test:
Before code fix:
```
[root@byrh13 postscripts]# lsdef bytest15 |sed 's/    //g'|grep "^nic"
nicips.eth1=10.4.41.15
nicnetworks.eth1=10_0_0_0-255_0_0_0
nictypes.eth1=Ethernet

[root@byrh13 postscripts]# updatenode bytest15 confignetwork
bytest15: xcatdsklspost: downloaded postscripts successfully
bytest15: Fri May 12 07:19:49 UTC 2017 Running postscript: confignetwork
bytest15: [I]: NetworkManager is inactive.
bytest15: [I]: All valid nics and device list:
bytest15: [I]: eth1
bytest15: [I]: [E]: Error:   pair is invalid nic and nicdevice pair.
bytest15: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bytest15: configure nic and its device : eth1
bytest15: [E]: Error : please check nictypes for eth1.
bytest15: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bytest15: configure nic and its device : [E]: Error:   pair is invalid nic and nicdevice pair.
bytest15: [E]: Error : please check nictypes for [E]: Error:   pair is invalid nic and nicdevice pair..
bytest15: postscript: confignetwork exited with code 0
bytest15: Running of postscripts has completed.
```

After code fix:
```
[root@byrh13 postscripts]# updatenode bytest15 confignetwork
bytest15: xcatdsklspost: downloaded postscripts successfully
bytest15: Fri May 12 07:29:12 UTC 2017 Running postscript: confignetwork
bytest15: [I]: NetworkManager is inactive.
bytest15: [I]: All valid nics and device list:
bytest15: [I]: eth1
bytest15: [I]: [E]: Error:   pair is invalid nic and nicdevice pair.
bytest15: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bytest15: configure nic and its device : eth1
bytest15: [I]: create_ethernet_interface ifname=eth1 _ipaddr=10.4.41.15
bytest15: [I]: create_persistent_ifcfg ifname=eth1 xcatnet=10_0_0_0-255_0_0_0 _ipaddr=10.4.41.15 _netmask= inattrs=ONBOOT=yes,USERCTL=no,TYPE=Ethernet
bytest15: ['ifcfg-eth1']
bytest15: [I]: >> DEVICE="eth1"
bytest15: [I]: >> BOOTPROTO="static"
bytest15: [I]: >> IPADDR="10.4.41.15"
bytest15: [I]: >> NETMASK="255.0.0.0"
bytest15: [I]: >> NAME="eth1"
bytest15: [I]: >> HWADDR="42:e5:14:04:29:0f"
bytest15: [I]: >> ONBOOT="yes"
bytest15: [I]: >> USERCTL="no"
bytest15: [I]: >> TYPE="Ethernet"
bytest15: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bytest15: configure nic and its device : [E]: Error:   pair is invalid nic and nicdevice pair.
bytest15: [E]: Error : please check nictypes for [E]: Error:   pair is invalid nic and nicdevice pair..
bytest15: postscript: confignetwork exited with code 0
bytest15: Running of postscripts has completed.
```

script test:
```
[root@byrh13 postscripts]# cat test
#!/bin/bash
utolcmd="sed -e y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/"
nictype="Ethernet"
type=`echo $nictype|$utolcmd`
echo $type

[root@byrh13 postscripts]# sh -x test
+ utolcmd='sed -e y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/'
+ nictype=Ethernet
++ sed -e y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/
++ echo Ethernet
+ type=ethernet
+ echo ethernet
ethernet
```