### PR TITLE
Fix regular expression issue while listing group object

### DIFF
--- a/perl-xCAT/xCAT/DBobjUtils.pm
+++ b/perl-xCAT/xCAT/DBobjUtils.pm
@@ -2503,6 +2503,7 @@ sub judge_node
         nicsattr value, like niccsips=eth0!1.1.1.1|2.1.1.1,eth1!3.1.1.1|4.1.1.1
         node name, like frame10node10
         nicnames: only return the value for specific nics, like "eth0,eth1"
+        is_group: bool value indicates whether the type of object is group
     Returns:
         expanded format, like:
         nicsips.eth0=1.1.1.1|2.1.1.1
@@ -2524,8 +2525,7 @@ sub expandnicsattr()
     if (($nicstr) && ($nicstr =~ /xCAT::/)) {
         $nicstr = shift;
     }
-    my $node = shift;
-    my $nicnames = shift;
+    my ($node, $nicnames, $is_group) = @_;
     my $ret;
 
     $nicstr =~ /^(.*?)=(.*?)$/;
@@ -2574,8 +2574,10 @@ sub expandnicsattr()
                 }
             }
         }
-
-        $nicv[1]= xCAT::Table::transRegexAttrs($node, $nicv[1]);
+        # print group attributes in original format
+        if (!$is_group) {
+            $nicv[1]= xCAT::Table::transRegexAttrs($node, $nicv[1]);
+        }
         # ignore the line that does not have nicname or value
         if ($nicv[0] && $nicv[1]) {
             $ret .= "    $nicattr.$nicv[0]=$nicv[1]\n";

--- a/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
+++ b/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
@@ -3862,13 +3862,14 @@ sub defls
                                             $nicnames = join(',', @{ $::NicsAttrHash{$showattr} });
                                         }
                                         my $nicsstr;
+                                        my $is_group = $defhash{$obj}{'objtype'} eq 'group';
                                         if ($nicnames)
                                         {
-                                            $nicsstr = xCAT::DBobjUtils->expandnicsattr($nicval, $obj, $nicnames);
+                                            $nicsstr = xCAT::DBobjUtils->expandnicsattr($nicval, $obj, $nicnames, $is_group);
                                         }
                                         else
                                         {
-                                            $nicsstr = xCAT::DBobjUtils->expandnicsattr($nicval, $obj);
+                                            $nicsstr = xCAT::DBobjUtils->expandnicsattr($nicval, $obj, undef, $is_group);
                                         }
 
                                         # Compress mode, format the output
@@ -3921,7 +3922,8 @@ sub defls
                                     if ($showattr =~ /^nic/)
                                     {
                                         my $nicval = "$showattr=$attrval";
-                                        my $nicsstr = xCAT::DBobjUtils->expandnicsattr($nicval, $obj);
+                                        my $is_group = $defhash{$obj}{'objtype'} eq 'group';
+                                        my $nicsstr = xCAT::DBobjUtils->expandnicsattr($nicval, $obj, undef, $is_group);
                                         if ($nicsstr)
                                         {
                                             push(@{ $rsp_info->{data} }, "$nicsstr");


### PR DESCRIPTION
Group object should not be translated with the object name even if
the attribute contains regular expression.

Fix-issue: #3047

Before changes:
```
[root@fs3 IB]#  mkdef -t group -o testnicips
Warning: Cannot determine a member list for group 'testnicips'.
1 object definitions have been created or modified.
[root@fs3 IB]#  chdef -t group -o testnicips ip='|\D+(\d+)\D+(\d+)|10.1.($1).($2)|'
1 object definitions have been created or modified.
[root@fs3 IB]# chdef -t group -o testnicips nicips.eth1='|\D+(\d+)\D+(\d+)|10.1.($1).($2)|'
1 object definitions have been created or modified.
[root@fs3 IB]# lsdef -t group -o testnicips
Object name: testnicips
    grouptype=static
    ip=|\D+(\d+)\D+(\d+)|10.1.($1).($2)|
    members=
    nicips.eth1=testnicips   <---- this is even worse, it's resolving to the name of the object?!
```
After changes:
```
root@c910f05c01bc01k10:~# mkdef -t group -o testnicips
Warning: Cannot determine a member list for group 'testnicips'.
1 object definitions have been created or modified.
root@c910f05c01bc01k10:~# chdef -t group -o testnicips ip='|\D+(\d+)\D+(\d+)|10.1.($1).($2)|'
1 object definitions have been created or modified.
root@c910f05c01bc01k10:~# chdef -t group -o testnicips nicips.eth1='|\D+(\d+)\D+(\d+)|10.1.($1).($2)|'
1 object definitions have been created or modified.
root@c910f05c01bc01k10:~# lsdef -t group -o testnicips
Object name: testnicips
    grouptype=static
    ip=|\D+(\d+)\D+(\d+)|10.1.($1).($2)|
    members=
    nicips.eth1=|\D+(\d+)\D+(\d+)|10.1.($1).($2)|
root@c910f05c01bc01k10:~# chdef frame10node10 groups=testnicips
1 object definitions have been created or modified.
New object definitions 'frame10node10' have been created.
root@c910f05c01bc01k10:~# lsdef frame10node10
Object name: frame10node10
    groups=testnicips
    ip=10.1.10.10
    nicips.eth1=10.1.10.10
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
root@c910f05c01bc01k10:~# lsdef -t group testnicips
Object name: testnicips
    grouptype=static
    ip=|\D+(\d+)\D+(\d+)|10.1.($1).($2)|
    members=frame10node10
    nicips.eth1=|\D+(\d+)\D+(\d+)|10.1.($1).($2)|
```