### PR TITLE
use rpm inside chroot to query dracut version

### DIFF
--- a/xCAT-server/share/xcat/netboot/sles/genimage
+++ b/xCAT-server/share/xcat/netboot/sles/genimage
@@ -615,7 +615,7 @@ if ((-d "$rootimg_dir/usr/share/dracut") or (-d "$rootimg_dir/usr/lib/dracut")) 
     $dracutmode = 1;
 
     # get dracut version
-    $dracutver = `rpm --root $rootimg_dir -qi dracut | grep Version | awk -F' ' '{print \$3}'     `;
+    $dracutver = `chroot $rootimg_dir rpm -qi dracut | grep Version | awk -F' ' '{print \$3}'     `;
     chomp($dracutver);
     if ($dracutver =~ /^\d\d\d$/) {
         if ($dracutver >= "033") {


### PR DESCRIPTION
if the version of rpm on the host differs from the version of rpm in the image (e.g. sles11 host creating a sles12 image) the "rpm --root" will fail. instead if we the rpm from the chroot environment itself we can wor around this.