### PR TITLE
Modify output for rpower state when openbmc return Quiesced 

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -830,6 +830,8 @@ sub rpower_response {
     if ($node_info{$node}{cur_status} eq "RPOWER_STATUS_RESPONSE" and !$next_status{ $node_info{$node}{cur_status} }) { 
         if ($response_info->{'data'}->{CurrentHostState} =~ /Off$/) {
             xCAT::SvrUtils::sendmsg("off", $callback, $node);
+        } elsif ($response_info->{'data'}->{CurrentHostState} =~ /Quiesced$/) {
+            xCAT::SvrUtils::sendmsg("quiesced", $callback, $node);
         } else {
             xCAT::SvrUtils::sendmsg("on", $callback, $node);
         }


### PR DESCRIPTION
#2937 

If receive ``CurrentHostState:   xyz.openbmc_project.State.Host.HostState.Quiesced`` info when use ``power state`` command to get openbmc's status, output will be like this:

```
# rpower simulation_test stat
simulation_test: quiesced
```