### PR TITLE
OpenBMC rinv sorted output

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rinv.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rinv.1.rst
@@ -32,14 +32,14 @@ OpenPOWER (using ipmi) server specific:
 =======================================
 
 
-\ **rinv**\  \ *noderange*\  {\ **model | serial | deviceid | uuid | guid | vpd | mprom | firm | all**\ }
+\ **rinv**\  \ *noderange*\  [\ **model | serial | deviceid | uuid | guid | vpd | mprom | firm | all**\ ]
 
 
 OpenPOWER (using openbmc) server specific:
 ==========================================
 
 
-\ **rinv**\  \ *noderange*\  {\ **model | serial | deviceid | uuid | guid | vpd | mprom | firm | cpu | dimm | all**\ }
+\ **rinv**\  \ *noderange*\  [\ **model | serial | deviceid | uuid | guid | vpd | mprom | firm | cpu | dimm | all**\ ]
 
 
 PPC (with HMC) specific:

--- a/xCAT-client/pods/man1/rinv.1.pod
+++ b/xCAT-client/pods/man1/rinv.1.pod
@@ -12,11 +12,11 @@ B<rinv> I<noderange> {B<pci>|B<model>|B<serial>|B<asset>|B<vpd>|B<mprom>|B<devic
 
 =head2 OpenPOWER (using ipmi) server specific:
   
-B<rinv> I<noderange> {B<model>|B<serial>|B<deviceid>|B<uuid>|B<guid>|B<vpd>|B<mprom>|B<firm>|B<all>} 
+B<rinv> I<noderange> [B<model>|B<serial>|B<deviceid>|B<uuid>|B<guid>|B<vpd>|B<mprom>|B<firm>|B<all>] 
 
 =head2 OpenPOWER (using openbmc) server specific:
 
-B<rinv> I<noderange> {B<model>|B<serial>|B<deviceid>|B<uuid>|B<guid>|B<vpd>|B<mprom>|B<firm>|B<cpu>|B<dimm>|B<all>}
+B<rinv> I<noderange> [B<model>|B<serial>|B<deviceid>|B<uuid>|B<guid>|B<vpd>|B<mprom>|B<firm>|B<cpu>|B<dimm>|B<all>]
 
 =head2 PPC (with HMC) specific:
 

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -893,23 +893,23 @@ sub rinv_response {
             next if ($grep_string eq "serial");
         } 
 
-        if (($grep_string eq "vpd" or $grep_string eq "mprom")) {
-            xCAT::SvrUtils::sendmsg("No information can be obtained for $grep_string", $callback, $node);
-            last;
+        if (($grep_string eq "vpd" or $grep_string eq "mprom") and $key_url =~ /\/motherboard$/) {
+            xCAT::SvrUtils::sendmsg("No mprom information is available", $callback, $node);
+            next if ($grep_string eq "mprom");
         } 
 
-        if (($grep_string eq "vpd" or $grep_string eq "deviceid")) {
-            xCAT::SvrUtils::sendmsg("No information can be obtained for $grep_string", $callback, $node);
-            last;
+        if (($grep_string eq "vpd" or $grep_string eq "deviceid") and $key_url =~ /\/motherboard$/) {
+            xCAT::SvrUtils::sendmsg("No deviceid information is available", $callback, $node);
+            next if ($grep_string eq "deviceid");
         } 
 
         if ($grep_string eq "uuid") {
-            xCAT::SvrUtils::sendmsg("No information can be obtained for $grep_string", $callback, $node);
+            xCAT::SvrUtils::sendmsg("No uuid information is available", $callback, $node);
             last;
         } 
 
         if ($grep_string eq "guid") {
-            xCAT::SvrUtils::sendmsg("No information can be obtained for $grep_string", $callback, $node);
+            xCAT::SvrUtils::sendmsg("No guid information is available", $callback, $node);
             last;
         } 
 

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -876,6 +876,7 @@ sub rinv_response {
     my $grep_string = $status_info{RINV_RESPONSE}{argv};
     my $src;
     my $content_info;
+    my @sorted_output;
 
     foreach my $key_url (keys %{$response_info->{data}}) {
         my %content = %{ ${ $response_info->{data} }{$key_url} };
@@ -893,19 +894,23 @@ sub rinv_response {
         } 
 
         if (($grep_string eq "vpd" or $grep_string eq "mprom")) {
-            # wait for interface
+            xCAT::SvrUtils::sendmsg("No information can be obtained for $grep_string", $callback, $node);
+            last;
         } 
 
         if (($grep_string eq "vpd" or $grep_string eq "deviceid")) {
-            # wait for interface      
+            xCAT::SvrUtils::sendmsg("No information can be obtained for $grep_string", $callback, $node);
+            last;
         } 
 
         if ($grep_string eq "uuid") {
-            # wait for interface 
+            xCAT::SvrUtils::sendmsg("No information can be obtained for $grep_string", $callback, $node);
+            last;
         } 
 
         if ($grep_string eq "guid") {
-            # wait for interface
+            xCAT::SvrUtils::sendmsg("No information can be obtained for $grep_string", $callback, $node);
+            last;
         } 
 
         if ($grep_string eq "mac" and $key_url =~ /\/ethernet/) {
@@ -923,9 +928,15 @@ sub rinv_response {
 
             foreach my $key (keys %content) {
                 $content_info = uc ($src) . " " . $key . " : " . $content{$key};
-                xCAT::SvrUtils::sendmsg("$content_info", $callback, $node);
+                push (@sorted_output, $node . ": ". $content_info); #Save output in array
             }
         }
+     }
+     # If sorted array has any contents, sort it and print it
+     if (scalar @sorted_output > 0) {
+         @sorted_output = sort @sorted_output; #Sort all output
+         my $result = join "\n", @sorted_output; #Join into a single string for easier display
+         xCAT::SvrUtils::sendmsg("$result", $callback);
      }
 
     if ($next_status{ $node_info{$node}{cur_status} }) {


### PR DESCRIPTION
This PR fixes openbmc `rinv` formatting as reported by issue #3034 
1. The output is sorted
2. Message is displayed for command options that do not return any data yet.
3. Fix `rinv` man page to indicate that all flags are optional. ("all" is a default if no options are listed)

Output after this pull request (first and last screen full):
```
p9euh02: BMC BuildDate :
p9euh02: BMC FieldReplaceable : 0
p9euh02: BMC Manufacturer : IBM
p9euh02: BMC Model :
p9euh02: BMC PartNumber : 01DH051
p9euh02: BMC Present : 1
p9euh02: BMC PrettyName : BMC PLANAR
p9euh02: BMC SerialNumber : 000000000000
p9euh02: CPU0 BuildDate :
p9euh02: CPU0 CORE0 Functional : 1
p9euh02: CPU0 CORE0 Present : 0
p9euh02: CPU0 CORE0 PrettyName :
p9euh02: CPU0 CORE1 Functional : 1
p9euh02: CPU0 CORE1 Present : 0
p9euh02: CPU0 CORE1 PrettyName :
p9euh02: CPU0 CORE10 Functional : 1
p9euh02: CPU0 CORE10 Present : 0
p9euh02: CPU0 CORE10 PrettyName :
p9euh02: CPU0 CORE11 Functional : 1
p9euh02: CPU0 CORE11 Present : 0
p9euh02: CPU0 CORE11 PrettyName :
p9euh02: CPU0 CORE12 Functional : 1
p9euh02: CPU0 CORE12 Present : 0
p9euh02: CPU0 CORE12 PrettyName :
p9euh02: CPU0 CORE13 Functional : 1
p9euh02: CPU0 CORE13 Present : 0
p9euh02: CPU0 CORE13 PrettyName :
p9euh02: CPU0 CORE14 Functional : 1
p9euh02: CPU0 CORE14 Present : 0
p9euh02: CPU0 CORE14 PrettyName :
p9euh02: CPU0 CORE15 Functional : 1
p9euh02: CPU0 CORE15 Present : 0
p9euh02: CPU0 CORE15 PrettyName :
p9euh02: CPU0 CORE16 Functional : 1
p9euh02: CPU0 CORE16 Present : 1
p9euh02: CPU0 CORE16 PrettyName :
p9euh02: CPU0 CORE17 Functional : 1
p9euh02: CPU0 CORE17 Present : 0
p9euh02: CPU0 CORE17 PrettyName :
p9euh02: CPU0 CORE18 Functional : 1
p9euh02: CPU0 CORE18 Present : 0
p9euh02: CPU0 CORE18 PrettyName :
p9euh02: CPU0 CORE19 Functional : 1
p9euh02: CPU0 CORE19 Present : 0
p9euh02: CPU0 CORE19 PrettyName :
p9euh02: CPU0 CORE2 Functional : 1
:
:
p9euh02: DIMM8 Functional : 1
p9euh02: DIMM8 Manufacturer : 0xce80
p9euh02: DIMM8 Model : M393A4K40BB2-CTD
p9euh02: DIMM8 PartNumber :
p9euh02: DIMM8 Present : 1
p9euh02: DIMM8 PrettyName : 0x0c
p9euh02: DIMM8 SerialNumber : 0x347a72d8
p9euh02: DIMM8 Version : 0x00
p9euh02: DIMM9 BuildDate :
p9euh02: DIMM9 Cached : 0
p9euh02: DIMM9 FieldReplaceable : 1
p9euh02: DIMM9 Functional : 1
p9euh02: DIMM9 Manufacturer : 0xce80
p9euh02: DIMM9 Model : M393A4K40BB2-CTD
p9euh02: DIMM9 PartNumber :
p9euh02: DIMM9 Present : 1
p9euh02: DIMM9 PrettyName : 0x0c
p9euh02: DIMM9 SerialNumber : 0x342a9a26
p9euh02: DIMM9 Version : 0x00
p9euh02: ETHERNET FieldReplaceable : 0
p9euh02: ETHERNET MACAddress : 00:00:00:00:00:00
p9euh02: ETHERNET Present : 1
p9euh02: ETHERNET PrettyName :
p9euh02: FAN0 Present : 1
p9euh02: FAN0 PrettyName : fan0
p9euh02: FAN1 Present : 1
p9euh02: FAN1 PrettyName : fan1
p9euh02: FAN2 Present : 1
p9euh02: FAN2 PrettyName : fan2
p9euh02: FAN3 Present : 1
p9euh02: FAN3 PrettyName : fan3
p9euh02: MOTHERBOARD BuildDate :
p9euh02: MOTHERBOARD Manufacturer : 0000000000000000
p9euh02: MOTHERBOARD Model :
p9euh02: MOTHERBOARD PartNumber : 00VK525
p9euh02: MOTHERBOARD Present : 0
p9euh02: MOTHERBOARD PrettyName : SYSTEM PLANAR
p9euh02: MOTHERBOARD SerialNumber : Y130UF72701M
p9euh02: SYSTEM BuildDate :
p9euh02: SYSTEM Cached : 0
p9euh02: SYSTEM FieldReplaceable : 0
p9euh02: SYSTEM Manufacturer :
p9euh02: SYSTEM Model : 2
p9euh02: SYSTEM PartNumber : 0000000000000000
p9euh02: SYSTEM Present : 1
p9euh02: SYSTEM PrettyName :
p9euh02: SYSTEM SerialNumber : 0000000000000000
[root@stratton01 xcat]#
```