### PR TITLE
makenetworks detect mtu automatically to add entry into networks table 

### DIFF
--- a/xCAT-server/lib/xcat/plugins/networks.pm
+++ b/xCAT-server/lib/xcat/plugins/networks.pm
@@ -372,8 +372,10 @@ sub donets
         # For Linux systems
         my @ip6table = split /\n/, `/sbin/ip -6 route`;
         my @rtable   = split /\n/, `/bin/netstat -rn`;
+        my @mtable   = split /\n/, `/bin/netstat -i`;  
 
         splice @rtable, 0, 2;
+        splice @mtable, 0, 2;
 
         my %netgw = ();
         foreach my $rtent (@rtable)
@@ -517,6 +519,15 @@ sub donets
                     }
                 }
 
+                # get mtu value
+                my $mtu;
+                my @rowm;
+                foreach (grep /\s*$mgtifname\b/, @mtable)
+                {
+                    @rowm = split(/\s+/, $_);
+                    $mtu = $rowm[1];
+                }
+
                 if ($::DISPLAY) {
                     push @{ $rsp->{data} }, "\n#From $host.";
                     push @{ $rsp->{data} }, "$netname:";
@@ -528,9 +539,13 @@ sub donets
                         push @{ $rsp->{data} }, "    gateway=$gw";
                     }
                     push @{ $rsp->{data} }, "    mgtifname=$mgtifname";
+                    if ($mtu)
+                    {
+                        push @{ $rsp->{data} }, "    mtu=$mtu";                      
+                    }
                 } else {
                     if (!$foundmatch) {
-                        $nettab->setAttribs({ 'net' => $net, 'mask' => $mask }, { 'netname' => $netname, 'mgtifname' => $mgtifname, 'gateway' => $gw });
+                        $nettab->setAttribs({ 'net' => $net, 'mask' => $mask }, { 'netname' => $netname, 'mgtifname' => $mgtifname, 'gateway' => $gw, 'mtu' => $mtu });
                     }
                 }
 


### PR DESCRIPTION
makenetworks detect mtu automatically to add entry into networks table #2694 
Unit test:
```
]# makenetworks -d

#From byrh13.
10_0_0_0-255_0_0_0:
    objtype=network
    net=10.0.0.0
    mask=255.0.0.0
    gateway=<xcatmaster>
    mgtifname=eth1
    mtu=1500
    tftpserver=10.4.41.13

#From byrh13.
20_0_0_0-255_0_0_0:
    objtype=network
    net=20.0.0.0
    mask=255.0.0.0
    gateway=20.4.41.4
    mgtifname=eth0
    mtu=1500
    tftpserver=20.4.41.13
# Note: An equivalent xCAT network definition already exists.

[root@byrh13 xCAT_plugin]# tabdump networks
#netname,net,mask,mgtifname,gateway,dhcpserver,tftpserver,nameservers,ntpservers,logservers,dynamicrange,staticrange,staticrangeincrement,nodehostname,ddnsdomain,vlanid,domain,mtu,comments,disable
"20_0_0_0-255_0_0_0","20.0.0.0","255.0.0.0","eth0","20.4.41.4",,"20.4.41.13",,,,,,,,,,,"1500",,
[root@byrh13 xCAT_plugin]# makenetworks
[root@byrh13 xCAT_plugin]# tabdump networks
#netname,net,mask,mgtifname,gateway,dhcpserver,tftpserver,nameservers,ntpservers,logservers,dynamicrange,staticrange,staticrangeincrement,nodehostname,ddnsdomain,vlanid,domain,mtu,comments,disable
"20_0_0_0-255_0_0_0","20.0.0.0","255.0.0.0","eth0","20.4.41.4",,"20.4.41.13",,,,,,,,,,,"1500",,
"10_0_0_0-255_0_0_0","10.0.0.0","255.0.0.0","eth1","<xcatmaster>",,"10.4.41.13",,,,,,,,,,,"1500",,
```