### PR TITLE
Support ZTP process for Cumulus Switch

### DIFF
--- a/xCAT-server/lib/xcat/plugins/dhcp.pm
+++ b/xCAT-server/lib/xcat/plugins/dhcp.pm
@@ -2271,6 +2271,7 @@ sub addnet6
             push @netent, "    option domain-search  $domainstring;\n";
         }
     }
+    
 
     my $nameservers = $netcfgs{$net}->{nameservers};
     if ($nameservers and $nameservers =~ /:/) {
@@ -2574,6 +2575,7 @@ sub addnet
             push @netent, "    option interface-mtu $mtu;\n";
         }
 
+
         #  add domain-search if not sles10 or rh5
         my $osv = xCAT::Utils->osver();
         unless (($osv =~ /^sle[sc]10/) || ($osv =~ /^rh.*5$/)) {
@@ -2591,6 +2593,8 @@ sub addnet
                 push @netent, "    option domain-search  $domainstring;\n";
             }
         }
+        #for cumulus ZTP process
+        push @netent, "    option cumulus-provision-url \"http://$tftp/install/postscripts/onieztp\";\n";
 
         my $ddnserver = $nameservers;
         $ddnserver =~ s/,.*//;
@@ -2928,6 +2932,7 @@ sub newconfig
     }
     push @dhcpconf, "option gpxe.no-pxedhcp 1;\n";
     push @dhcpconf, "option www-server code 114 = string;\n";
+    push @dhcpconf, "option cumulus-provision-url code 239 = text;\n";
     push @dhcpconf, "\n";
     push @dhcpconf, "omapi-port 7911;\n";            #Enable omapi...
     push @dhcpconf, "key xcat_key {\n";

--- a/xCAT-server/lib/xcat/plugins/dhcp.pm
+++ b/xCAT-server/lib/xcat/plugins/dhcp.pm
@@ -2594,7 +2594,7 @@ sub addnet
             }
         }
         #for cumulus ZTP process
-        push @netent, "    option cumulus-provision-url \"http://$tftp/install/postscripts/onieztp\";\n";
+        push @netent, "    option cumulus-provision-url \"http://$tftp/install/postscripts/cumulusztp\";\n";
 
         my $ddnserver = $nameservers;
         $ddnserver =~ s/,.*//;

--- a/xCAT/postscripts/cumulusztp
+++ b/xCAT/postscripts/cumulusztp
@@ -1,12 +1,4 @@
 #!/bin/bash
-
-# this postscripts will fetched from ZTP process for cumulus switch
-# To enable the ZTP process on cumulus switch with OS and licenses already installed
-#   ssh -l cumulus cumulus_switch
-#   sudo ztp -R
-#   sudo reboot
-# the MN will get DHCP request after reboot, and will send DHCP responds with this script.
-
 function error() {
   echo -e "\e[0;33mERROR: The Zero Touch Provisioning script failed while running the command $BASH_COMMAND at line $BASH_LINENO.\e[0m" >&2
   exit 1
@@ -20,18 +12,21 @@ trap error ERR
 #Add Debian Repositories
 echo "deb http://http.us.debian.org/debian jessie main" >> /etc/apt/sources.list
 echo "deb http://security.debian.org/ jessie/updates main" >> /etc/apt/sources.list
+
+#get ip address for server node
+server_ip=`grep cumulus-provision-url /var/lib/dhcp/dhclient.eth0.leases | tail -1 | awk -F/ '{print $3}'`
  
 #push root ssh keys, config passwordless
 echo "CumulusLinux!" | sudo -S mkdir -p /root/.ssh
-echo "CumulusLinux!" | sudo -S /usr/bin/wget -O /root/.ssh/authorized_keys http://172.21.253.27/install/postscripts/_ssh/authorized_keys
+echo "CumulusLinux!" | sudo -S /usr/bin/wget -O /root/.ssh/authorized_keys http://$server_ip/install/postscripts/_ssh/authorized_keys
  
 #enable and config snmpd
-echo "CumulusLinux!" | sudo -S /usr/bin/wget -O /home/cumulus/enablesnmp http://172.21.253.27/install/postscripts/enablesnmp
+echo "CumulusLinux!" | sudo -S /usr/bin/wget -O /home/cumulus/enablesnmp http://$server_ip/install/postscripts/enablesnmp
 sudo chmod +x /home/cumulus/enablesnmp
 sudo /home/cumulus/enablesnmp
 
 #config base interface
-echo "CumulusLinux!" | sudo -S /usr/bin/wget -O /home/cumulus/configinterface http://172.21.253.27/install/postscripts/configinterface
+echo "CumulusLinux!" | sudo -S /usr/bin/wget -O /home/cumulus/configinterface http://$server_ip/install/postscripts/configinterface
 sudo chmod +x /home/cumulus/configinterface
 sudo /home/cumulus/configinterface
 

--- a/xCAT/postscripts/onieztp
+++ b/xCAT/postscripts/onieztp
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# this postscripts will fetched from ZTP process for cumulus switch
+# To enable the ZTP process on cumulus switch with OS and licenses already installed
+#   ssh -l cumulus cumulus_switch
+#   sudo ztp -R
+#   sudo reboot
+# the MN will get DHCP request after reboot, and will send DHCP responds with this script.
+
+function error() {
+  echo -e "\e[0;33mERROR: The Zero Touch Provisioning script failed while running the command $BASH_COMMAND at line $BASH_LINENO.\e[0m" >&2
+  exit 1
+}
+ 
+# Log all output from this script
+exec >/var/log/autoprovision 2>&1
+ 
+trap error ERR
+ 
+#Add Debian Repositories
+echo "deb http://http.us.debian.org/debian jessie main" >> /etc/apt/sources.list
+echo "deb http://security.debian.org/ jessie/updates main" >> /etc/apt/sources.list
+ 
+#push root ssh keys, config passwordless
+echo "CumulusLinux!" | sudo -S mkdir -p /root/.ssh
+echo "CumulusLinux!" | sudo -S /usr/bin/wget -O /root/.ssh/authorized_keys http://172.21.253.27/install/postscripts/_ssh/authorized_keys
+ 
+#enable and config snmpd
+echo "CumulusLinux!" | sudo -S /usr/bin/wget -O /home/cumulus/enablesnmp http://172.21.253.27/install/postscripts/enablesnmp
+sudo chmod +x /home/cumulus/enablesnmp
+sudo /home/cumulus/enablesnmp
+
+#config base interface
+echo "CumulusLinux!" | sudo -S /usr/bin/wget -O /home/cumulus/configinterface http://172.21.253.27/install/postscripts/configinterface
+sudo chmod +x /home/cumulus/configinterface
+sudo /home/cumulus/configinterface
+
+# CUMULUS-AUTOPROVISIONING
+exit 0


### PR DESCRIPTION
That's the init steps to support ZTP process on Cumulus switch.  for issue #3060 and #2662 
on the lab, cumulus switch already has OS and licensed installed.  ZTP service will disabled.  To enable the ZTP service and reset ZTP process for next reboot,  need to do following:
```
#ssh -l cumulus x.x.x.x
#$ sudo ztp -R
[sudo] password for cumulus:
Created symlink from /etc/systemd/system/multi-user.target.wants/ztp.service to /lib/systemd/system/ztp.service.
#sudo reboot
````
xCAT will receive DHCP request from cumulus switch with cumulus-provision-url option, then xCAT will send back DHCP Ack with the ZTP scripts.