### PR TITLE
Run all cases specified by command line, do not skip invalid case

### DIFF
--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -1016,7 +1016,7 @@ sub load_case {
                 }
             }
             log_this($running_log_fd, "To run:", @new_cases_to_be_run);
-            @{$cases_to_be_run_ref} = @new_cases_to_be_run;
+            #@{$cases_to_be_run_ref} = @new_cases_to_be_run;
         }
     }
     return $caseerror;


### PR DESCRIPTION
Background are:
* Depending on original design, there are some specific label in case definition, such like ``os``, ``arch``, ``hcp``..... The old ``xcattest`` will judge these label, to list which case will run and which will not run. The output in ``xcattest.log.xxxxxxxxx`` looks like below:

        Not to run:
        xcatstanzafile_normal
        xcatstanzafile_tab
        xcatstanzafile_multattr
        xcatstanzafile_defaultvalue
        To run:
        setup_vm
        reg_linux_diskless_installation_flat
        reg_linux_diskfull_installation_flat
        go_xcat_noinput
        updatenode_h
        ........
   
 * In the old ``xcattest`` (we can say it is a bug), when run test case,  it won't depending on the result calculated by above item 1, it will run all cases specified by command line option ``-b``,``-t``. So that means if using bundle, all cases in the bundle will run, even some cases were judged to no run by item 1.
 * The other fact is for many cases, we added labels to indicate it only can run in some specific scenario, but it can run in other scenario too.
 * One old history is many years ago, FVTs were used to use different cases with same case name to cover different platform, the key was using ``os``,``arch`` and so on label to distinguish the platform.  But it is hard to say the code can't be in common used by different platform.

So all above facts result in one thing, even old ``xcattest`` has bug, but in our automaton environment, those cases be judged to no run are still run and passed.  

But in new ``xcattest``, I skipped those case be judged to no run. That result in the automation report using the new version ``xcattest`` will always show some cases are ``Norun``. It looks differently than original report. 

    commit num: 28b68fd
    TotalCase 227 Pass 223 Failed 0 NoRun 4
    Failed cases: 

After think, I decided follow original code logic first. After going through cases and bundle files, then find a reasonable way to handle this problem.
