### PR TITLE
Display correct rpower openbmc transition states

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -848,11 +848,23 @@ sub rpower_response {
 
     if ($node_info{$node}{cur_status} eq "RPOWER_STATUS_RESPONSE" and !$next_status{ $node_info{$node}{cur_status} }) { 
         if ($response_info->{'data'}->{CurrentHostState} =~ /Off$/) {
-            xCAT::SvrUtils::sendmsg("off", $callback, $node);
+            # State is off, but check if it is transitioning
+            if ($response_info->{'data'}->{RequestedHostTransition} =~ /On$/) {
+                xCAT::SvrUtils::sendmsg("powering-on", $callback, $node);
+            }
+            else {
+                xCAT::SvrUtils::sendmsg("off", $callback, $node);
+            }
         } elsif ($response_info->{'data'}->{CurrentHostState} =~ /Quiesced$/) {
             xCAT::SvrUtils::sendmsg("quiesced", $callback, $node);
         } else {
-            xCAT::SvrUtils::sendmsg("on", $callback, $node);
+            # State is on, but check if it is transitioning
+            if ($response_info->{'data'}->{RequestedHostTransition} =~ /Off$/) {
+                xCAT::SvrUtils::sendmsg("powering-off", $callback, $node);
+            }
+            else {
+                xCAT::SvrUtils::sendmsg("on", $callback, $node);
+            }
         }
     }
 

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -29,6 +29,14 @@ use xCAT::SvrUtils;
 use xCAT::GlobalDef;
 use xCAT_monitoring::monitorctrl;
 
+# String constants for rpower states
+$::POWER_STATE_OFF="off";
+$::POWER_STATE_ON="on";
+$::POWER_STATE_POWERING_OFF="powering-off";
+$::POWER_STATE_POWERING_ON="powering-on";
+$::POWER_STATE_QUIESCED="quiesced";
+$::POWER_STATE_RESET="reset";
+
 sub unsupported {
     my $callback = shift;
     if (defined($::OPENBMC_DEVEL) && ($::OPENBMC_DEVEL eq "YES")) {
@@ -825,21 +833,21 @@ sub rpower_response {
 
     if ($node_info{$node}{cur_status} eq "RPOWER_ON_RESPONSE") {
         if ($response_info->{'message'} eq $::RESPONSE_OK) {
-            xCAT::SvrUtils::sendmsg("on", $callback, $node);
+            xCAT::SvrUtils::sendmsg("$::POWER_STATE_ON", $callback, $node);
             $new_status{$::STATUS_POWERING_ON} = [$node];
         }
     } 
 
     if ($node_info{$node}{cur_status} eq "RPOWER_OFF_RESPONSE") {
         if ($response_info->{'message'} eq $::RESPONSE_OK) {
-            xCAT::SvrUtils::sendmsg("off", $callback, $node);
+            xCAT::SvrUtils::sendmsg("$::POWER_STATE_OFF", $callback, $node);
             $new_status{$::STATUS_POWERING_OFF} = [$node];
         }
     }
 
     if ($node_info{$node}{cur_status} eq "RPOWER_RESET_RESPONSE") {
         if ($response_info->{'message'} eq $::RESPONSE_OK) {
-            xCAT::SvrUtils::sendmsg("reset", $callback, $node);
+            xCAT::SvrUtils::sendmsg("$::POWER_STATE_RESET", $callback, $node);
             $new_status{$::STATUS_POWERING_ON} = [$node];
         }
     }
@@ -850,21 +858,25 @@ sub rpower_response {
         if ($response_info->{'data'}->{CurrentHostState} =~ /Off$/) {
             # State is off, but check if it is transitioning
             if ($response_info->{'data'}->{RequestedHostTransition} =~ /On$/) {
-                xCAT::SvrUtils::sendmsg("powering-on", $callback, $node);
+                xCAT::SvrUtils::sendmsg("$::POWER_STATE_POWERING_ON", $callback, $node);
             }
             else {
-                xCAT::SvrUtils::sendmsg("off", $callback, $node);
+                xCAT::SvrUtils::sendmsg("$::POWER_STATE_OFF", $callback, $node);
             }
         } elsif ($response_info->{'data'}->{CurrentHostState} =~ /Quiesced$/) {
-            xCAT::SvrUtils::sendmsg("quiesced", $callback, $node);
-        } else {
+            xCAT::SvrUtils::sendmsg("$::POWER_STATE_QUIESCED", $callback, $node);
+        } elsif ($response_info->{'data'}->{CurrentHostState} =~ /Running$/) {
             # State is on, but check if it is transitioning
             if ($response_info->{'data'}->{RequestedHostTransition} =~ /Off$/) {
-                xCAT::SvrUtils::sendmsg("powering-off", $callback, $node);
+                xCAT::SvrUtils::sendmsg("$::POWER_STATE_POWERING_OFF", $callback, $node);
             }
             else {
-                xCAT::SvrUtils::sendmsg("on", $callback, $node);
+                xCAT::SvrUtils::sendmsg("$::POWER_STATE_ON", $callback, $node);
             }
+        }
+        else {
+                my $unexpected_state = $response_info->{'data'}->{CurrentHostState};
+                xCAT::SvrUtils::sendmsg("Unexpected state - $unexpected_state", $callback, $node);
         }
     }
 


### PR DESCRIPTION
Fixes issue #3014 

When `rpower on` or `rpower off` commands are issued, the state of the machine takes a several seconds to change. `rpower stat` needs to return correct state while in that transition.

```
[root@stratton01 xcat]# rpower p9euh01 on; while true; do rpower p9euh01 stat; done
Warning: Currently running development code, use at your own risk.  Unset XCAT_OPENBMC_DEVEL to disable.
p9euh01: on
Warning: Currently running development code, use at your own risk.  Unset XCAT_OPENBMC_DEVEL to disable.
p9euh01: powering-on
Warning: Currently running development code, use at your own risk.  Unset XCAT_OPENBMC_DEVEL to disable.
p9euh01: powering-on
Warning: Currently running development code, use at your own risk.  Unset XCAT_OPENBMC_DEVEL to disable.
p9euh01: powering-on
Warning: Currently running development code, use at your own risk.  Unset XCAT_OPENBMC_DEVEL to disable.
p9euh01: powering-on
Warning: Currently running development code, use at your own risk.  Unset XCAT_OPENBMC_DEVEL to disable.
p9euh01: powering-on
Warning: Currently running development code, use at your own risk.  Unset XCAT_OPENBMC_DEVEL to disable.
p9euh01: on
Warning: Currently running development code, use at your own risk.  Unset XCAT_OPENBMC_DEVEL to disable.
p9euh01: on
Warning: Currently running development code, use at your own risk.  Unset XCAT_OPENBMC_DEVEL to disable.
p9euh01: on

```

and

```
[root@stratton01 xcat]# rpower p9euh01 off; while true; do rpower p9euh01 stat; done
Warning: Currently running development code, use at your own risk.  Unset XCAT_OPENBMC_DEVEL to disable.
p9euh01: off
Warning: Currently running development code, use at your own risk.  Unset XCAT_OPENBMC_DEVEL to disable.
p9euh01: powering-off
Warning: Currently running development code, use at your own risk.  Unset XCAT_OPENBMC_DEVEL to disable.
p9euh01: powering-off
Warning: Currently running development code, use at your own risk.  Unset XCAT_OPENBMC_DEVEL to disable.
p9euh01: powering-off
Warning: Currently running development code, use at your own risk.  Unset XCAT_OPENBMC_DEVEL to disable.
p9euh01: off
Warning: Currently running development code, use at your own risk.  Unset XCAT_OPENBMC_DEVEL to disable.
p9euh01: off
Warning: Currently running development code, use at your own risk.  Unset XCAT_OPENBMC_DEVEL to disable.
p9euh01: off
```