### PR TITLE
Check that there are failed nodes in the array before printing message 

### DIFF
--- a/xCAT-server/lib/xcat/plugins/rinstall.pm
+++ b/xCAT-server/lib/xcat/plugins/rinstall.pm
@@ -364,9 +364,11 @@ sub rinstall {
             }
         }
         my $rsp = {};
-        $rsp->{error}->[0] = "failed to run 'nodeset' against the following nodes: @failurenodes";
-        $rsp->{errorcode}->[0] = 1;
-        xCAT::MsgUtils->message("E", $rsp, $callback);
+        if (0+@failurenodes > 0) { 
+            $rsp->{error}->[0] = "Failed to run 'nodeset' against the following nodes: @failurenodes";
+            $rsp->{errorcode}->[0] = 1;
+            xCAT::MsgUtils->message("E", $rsp, $callback);
+        }
         @nodes = @successnodes;
     }
 
@@ -430,9 +432,11 @@ sub rinstall {
                     }
                 }
                 my $rsp = {};
-                $rsp->{error}->[0] = "failed to run 'rnetboot' against the following nodes: @failurenodes";
-                $rsp->{errorcode}->[0] = 1;
-                xCAT::MsgUtils->message("E", $rsp, $callback);
+                if (0+@failurenodes > 0) { 
+                    $rsp->{error}->[0] = "Failed to run 'rnetboot' against the following nodes: @failurenodes";
+                    $rsp->{errorcode}->[0] = 1;
+                    xCAT::MsgUtils->message("E", $rsp, $callback);
+                }
             }
         }
         else {
@@ -493,9 +497,11 @@ sub rinstall {
                         }
                     }
                     my $rsp = {};
-                    $rsp->{error}->[0] = "failed to run 'rsetboot' against the following nodes: @failurenodes";
-                    $rsp->{errorcode}->[0] = 1;
-                    xCAT::MsgUtils->message("E", $rsp, $callback);
+                    if (0+@failurenodes > 0) { 
+                        $rsp->{error}->[0] = "Failed to run 'rsetboot' against the following nodes: @failurenodes";
+                        $rsp->{errorcode}->[0] = 1;
+                        xCAT::MsgUtils->message("E", $rsp, $callback);
+                    }
                     @nodes = @successnodes;
                 }
             }
@@ -549,9 +555,11 @@ sub rinstall {
                     }
                 }
                 my $rsp = {};
-                $rsp->{error}->[0] = "failed to run 'rpower' against the following nodes: @failurenodes";
-                $rsp->{errorcode}->[0] = 1;
-                xCAT::MsgUtils->message("E", $rsp, $callback);
+                if (0+@failurenodes > 0) { 
+                    $rsp->{error}->[0] = "Failed to run 'rpower' against the following nodes: @failurenodes";
+                    $rsp->{errorcode}->[0] = 1;
+                    xCAT::MsgUtils->message("E", $rsp, $callback);
+                }
             }
         }
     }


### PR DESCRIPTION
When running some tests using `rinstall`, get back error messages with blank nodes. 

```
#  rinstall sn01 'osimage=rhels7.3-ppc64le-MLNX-install-service'
Provision node(s): sn01
sn01: install rhels7.3-ppc64le-service
Unable to dispatch hierarchical sub-command to sn03:3001.  Error: Connection failure: IO::Socket::INET: connect: No route to host at /opt/xcat/lib/perl/xCAT/Client.pm line 248.
Error: failed to run 'nodeset' against the following nodes:
#
```

This pull request just checks that there are failed nodes in the array before printing.  It does not test the validity of the checks.. 