### PR TITLE
[openbmc] Open rpower and rinv commands for normal xCAT use

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -32,10 +32,9 @@ use xCAT_monitoring::monitorctrl;
 sub unsupported {
     my $callback = shift;
     if (defined($::OPENBMC_DEVEL) && ($::OPENBMC_DEVEL eq "YES")) {
-        xCAT::SvrUtils::sendmsg("Warning: Currently running development code, use at your own risk.  Unset XCAT_OPENBMC_DEVEL to disable.",  $callback);
         return;
     } else {
-        return ([ 1, "This openbmc related function is unsupported and disabled. To bypass, run the following: \n\texport XCAT_OPENBMC_DEVEL=YES" ]);
+        return ([ 1, "This openbmc related function is not yet supported. Please contact xCAT development team." ]);
     }
 }
 
@@ -382,24 +381,16 @@ sub parse_args {
 
     my $subcommand = $ARGV[0];
     if ($command eq "rpower") {
-        #
-        # disable function until fully tested
-        #
-        $check = unsupported($callback); if (ref($check) eq "ARRAY") { return $check; }
         unless ($subcommand =~ /^on$|^off$|^reset$|^boot$|^status$|^stat$|^state$/) {
             return ([ 1, "Unsupported command: $command $subcommand" ]);
         }
     } elsif ($command eq "rinv") {
-        #
-        # disable function until fully tested
-        #
-        $check = unsupported($callback); if (ref($check) eq "ARRAY") { return $check; }
         $subcommand = "all" if (!defined($ARGV[0]));
         unless ($subcommand =~ /^cpu$|^dimm$|^model$|^serial$|^firm$|^mac$|^vpd$|^mprom$|^deviceid$|^guid$|^uuid$|^all$/) {
             return ([ 1, "Unsupported command: $command $subcommand" ]);
         }
     } elsif ($command eq "getopenbmccons") {
-        #command for openbmc rcons
+        # command for openbmc rcons
     } elsif ($command eq "rsetboot") {
         #
         # disable function until fully tested
@@ -754,7 +745,7 @@ sub deal_with_response {
     if ($response->status_line ne $::RESPONSE_OK) {
         my $error;
         if ($response->status_line eq $::RESPONSE_SERVICE_UNAVAILABLE) {
-            $error = "Service Unavailable";
+            $error = $::RESPONSE_SERVICE_UNAVAILABLE;
         } else {
             my $response_info = decode_json $response->content;
             if ($response->status_line eq $::RESPONSE_SERVER_ERROR) {


### PR DESCRIPTION
Since there are more folks that are starting to use xCAT to manage the P9 machines running openbmc firmware, I'd like to expose some basic behavior in xCAT's support for openbmc and "hide" the environment variable that we use to bypass the check.  

Opening this function should allow users to provision OS on the node and power control.  We can use the environment variable to block function.  

There is essentially 2 levels of blocking that we have not yet implemented. 
* Function is working, allow FVT to test before we open to all users 
* function is not yet implemented in firmware side.  (This one wasn't planned because we had expected function to be all there, but it's not the case) 



## External behavior changes 

```
[root@stratton01 xcat]# env | grep XCAT_OPENBMC
[root@stratton01 xcat]# rpower p9euh01 stat
p9euh01: on
[root@stratton01 xcat]# rpower p9 stat
p9euh01: on
p9euh02: on
[root@stratton01 xcat]# rinv p9 firm
p9euh01: System Firmware Product Version: v1.99.4-77-g62286ef
p9euh02: System Firmware Product Version: v1.99.4-77-g62286ef
[root@stratton01 xcat]# rsetboot p9 net
This openbmc related function is not yet supported. Please contact xCAT development team.
```