### PR TITLE
Move stop label from redhat_migration test case

### DIFF
--- a/xCAT-test/autotest/testcase/migration/redhat_migration
+++ b/xCAT-test/autotest/testcase/migration/redhat_migration
@@ -101,8 +101,7 @@ end
 start:redhat_migration2
 os:Linux
 description:update xCAT from $$MIGRATION2_VERSION to latest version, these two global parameter defined in config file
-stop:yes
-
+#stop:yes
 cmd:if ping -c 1 $$SN > /dev/null;then rpower $$SN off > /dev/null;fi
 cmd:chdef -t node -o $$CN servicenode= monserver=$$MN nfsserver=$$MN tftpserver=$$MN  xcatmaster=$$MN
 check:rc==0


### PR DESCRIPTION
Move stop label from redhat_migration test case. Do not let this case stop redhat daily regression.