### PR TITLE
modify migration test for environment's servicenode need to clear

### DIFF
--- a/xCAT-test/autotest/testcase/migration/redhat_migration
+++ b/xCAT-test/autotest/testcase/migration/redhat_migration
@@ -2,7 +2,10 @@ start:redhat_migration1
 os:Linux
 description:update xCAT from $$MIGRATION1_VERSION to latest version, these two global parameter defined in config file
 
-cmd:if ping -c 1 $$SN > /dev/null;then rpower $$SN off > /dev/null;fi
+cmd:if ping -c 1 $$SN > /dev/null;then rpower $$SN off > /dev/null;echo "poweroffsn">/tmp/poweroffsn;fi
+check:rc==0
+cmd:if [[ "__GETNODEATTR($$SN,groups)__" =~ "service" ]];then chdef $$SN -m groups=service;echo "servicelabel" >/tmp/servicelabel;fi
+check:rc==0
 cmd:chdef -t node -o $$CN servicenode= monserver=$$MN nfsserver=$$MN tftpserver=$$MN  xcatmaster=$$MN
 check:rc==0
 cmd:rscan __GETNODEATTR($$CN,hcp)__ -w
@@ -96,13 +99,20 @@ cmd:xdsh $$CN "noderm node0001"
 check:rc==0
 cmd:latest_version_info=`lsxcatd -v`;xdsh $$CN "lsxcatd -v" | grep "$latest_version_info"
 check:rc==0
+cmd:if [[ -f /tmp/servicelabel ]];then chdef $$SN -p groups=service;rm -rf /tmp/servicelabel;fi
+check:rc==0
+cmd:if [[ -f /tmp/poweroffsn ]];then rpower $$SN on > /dev/null;rm -rf /tmp/poweroffsn;fi
+check:rc==0
 end
 
 start:redhat_migration2
 os:Linux
 description:update xCAT from $$MIGRATION2_VERSION to latest version, these two global parameter defined in config file
 #stop:yes
-cmd:if ping -c 1 $$SN > /dev/null;then rpower $$SN off > /dev/null;fi
+cmd:if ping -c 1 $$SN > /dev/null;then rpower $$SN off > /dev/null;echo "poweroffsn">/tmp/poweroffsn;fi
+check:rc==0
+cmd:if [[ "__GETNODEATTR($$SN,groups)__" =~ "service" ]];then chdef $$SN -m groups=service;echo "servicelabel" >/tmp/servicelabel;fi
+check:rc==0
 cmd:chdef -t node -o $$CN servicenode= monserver=$$MN nfsserver=$$MN tftpserver=$$MN  xcatmaster=$$MN
 check:rc==0
 cmd:rscan __GETNODEATTR($$CN,hcp)__ -w
@@ -195,6 +205,10 @@ check:output=~node0001
 cmd:xdsh $$CN "noderm node0001"
 check:rc==0
 cmd:latest_version_info=`lsxcatd -v`;xdsh $$CN "lsxcatd -v" | grep "$latest_version_info"
+check:rc==0
+cmd:if [[ -f /tmp/servicelabel ]];then chdef $$SN -p groups=service;rm -rf /tmp/servicelabel;fi
+check:rc==0
+cmd:if [[ -f /tmp/poweroffsn ]];then rpower $$SN on > /dev/null;rm -rf /tmp/poweroffsn;fi
 check:rc==0
 end
 

--- a/xCAT-test/autotest/testcase/migration/sles_migration
+++ b/xCAT-test/autotest/testcase/migration/sles_migration
@@ -1,8 +1,10 @@
 start:sles_migration1
 os:Linux
 description:update xCAT from $$MIGRATION1_VERSION to latest version, these two global parameter defined in config file
-
-cmd:if ping -c 1 $$SN > /dev/null;then rpower $$SN off > /dev/null;fi
+cmd:if ping -c 1 $$SN > /dev/null;then rpower $$SN off > /dev/null;echo "poweroffsn">/tmp/poweroffsn;fi
+check:rc==0
+cmd:if [[ "__GETNODEATTR($$SN,groups)__" =~ "service" ]];then chdef $$SN -m groups=service;echo "servicelabel" >/tmp/servicelabel;fi
+check:rc==0
 cmd:chdef -t node -o $$CN servicenode= monserver=$$MN nfsserver=$$MN tftpserver=$$MN  xcatmaster=$$MN
 check:rc==0
 cmd:rscan __GETNODEATTR($$CN,hcp)__ -w
@@ -99,13 +101,20 @@ cmd:xdsh $$CN "noderm node0001"
 check:rc==0
 cmd:latest_version_info=`lsxcatd -v`;xdsh $$CN "lsxcatd -v" | grep "$latest_version_info"
 check:rc==0
+cmd:if [[ -f /tmp/servicelabel ]];then chdef $$SN -p groups=service;rm -rf /tmp/servicelabel;fi
+check:rc==0
+cmd:if [[ -f /tmp/poweroffsn ]];then rpower $$SN on > /dev/null;rm -rf /tmp/poweroffsn;fi
+check:rc==0
 end
 
 start:sles_migration2
 os:Linux
 description:update xCAT from $$MIGRATION22VERSION to latest version, these two global parameter defined in config file
 
-cmd:if ping -c 1 $$SN > /dev/null;then rpower $$SN off > /dev/null;fi
+cmd:if ping -c 1 $$SN > /dev/null;then rpower $$SN off > /dev/null;echo "poweroffsn">/tmp/poweroffsn;fi
+check:rc==0
+cmd:if [[ "__GETNODEATTR($$SN,groups)__" =~ "service" ]];then chdef $$SN -m groups=service;echo "servicelabel" >/tmp/servicelabel;fi
+check:rc==0
 cmd:chdef -t node -o $$CN servicenode= monserver=$$MN nfsserver=$$MN tftpserver=$$MN  xcatmaster=$$MN
 check:rc==0
 cmd:rscan __GETNODEATTR($$CN,hcp)__ -w
@@ -201,6 +210,10 @@ check:output=~node0001
 cmd:xdsh $$CN "noderm node0001"
 check:rc==0
 cmd:latest_version_info=`lsxcatd -v`;xdsh $$CN "lsxcatd -v" | grep "$latest_version_info"
+check:rc==0
+cmd:if [[ -f /tmp/servicelabel ]];then chdef $$SN -p groups=service;rm -rf /tmp/servicelabel;fi
+check:rc==0
+cmd:if [[ -f /tmp/poweroffsn ]];then rpower $$SN on > /dev/null;rm -rf /tmp/poweroffsn;fi
 check:rc==0
 end
 


### PR DESCRIPTION
Modify migration testcases for testcase sometimes fail due to servicenode's dns service influence .
1. power off service node
2.
Before modify we only "power off" servicenode but "makdhcp " always wrong for servicenode off .So I delete the servicenode's definition "groups=service"
