### PR TITLE
Close ssl verify for bmcdiscover on Ubuntu

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -360,7 +360,7 @@ sub process_request {
         }
     } 
 
-    $callback->({ errorcode => $check }) if ($check);
+    $callback->({ errorcode => [$check] }) if ($check);
     return;
 }
 
@@ -864,10 +864,9 @@ sub rpower_response {
             else {
                 xCAT::SvrUtils::sendmsg("$::POWER_STATE_ON", $callback, $node);
             }
-        }
-        else {
-                my $unexpected_state = $response_info->{'data'}->{CurrentHostState};
-                xCAT::SvrUtils::sendmsg("Unexpected state - $unexpected_state", $callback, $node);
+        } else {
+            my $unexpected_state = $response_info->{'data'}->{CurrentHostState};
+            xCAT::SvrUtils::sendmsg("Unexpected state - $unexpected_state", $callback, $node);
         }
     }
 


### PR DESCRIPTION
#3100 #3116 

1. If ``mtm`` or ``serial`` is null, print waring message.
2. Close SSL verify by add ``SSL_verify_mode => 0x00``. 

Before:
```
# bmcdiscover -s nmap --range 10.6.7.254 -u root -p 0penBmc
#
```
(There is no information printed) The error is certificate verify failed, need to add ``SSL_verify_mode => 0x00``
After:
```
# bmcdiscover -s nmap --range 10.6.7.254 -u root -p 0penBmc
10.6.7.254,,Y130UF72700T,root,0penBmc,mp,bmc
```

3. Fix callback error in openbmc.pm
4. Modify format in openbmc.pm