### PR TITLE
Wrong mac address showing for switchdiscover command

### DIFF
--- a/xCAT-server/lib/perl/xCAT/SvrUtils.pm
+++ b/xCAT-server/lib/perl/xCAT/SvrUtils.pm
@@ -1266,7 +1266,7 @@ sub get_mac_by_arp ()
                 } else {
                     ($ip, $mac) = (undef, undef);
                 }
-                if (@$IP[1] !~ $ip) {
+                if (@$IP[1] ne $ip) {
                     ($ip, $mac) = (undef, undef);
                 } else {
                     last;

--- a/xCAT-server/lib/xcat/plugins/switchdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/switchdiscover.pm
@@ -38,6 +38,7 @@ my %global_mac_identity = (
     "6c:ae:8b" => "BNT G8264-T switch",
     "fc:cf:62" => "BNT G8124 switch",
     "7c:fe:90" => "Mellanox IB switch",
+    "cc:37:ab" => "Edgecore Networks Switch",
     "8c:ea:1b" => "Edgecore Networks Switch"
 );
 
@@ -54,6 +55,8 @@ my %global_switch_type = (
     mellanox => "Mellanox",
     MLNX => "Mellanox",
     MELLAN => "Mellanox",
+    Cumulus => "onie",
+    cumulus => "onie",
     Edgecore => "onie"
 );
 


### PR DESCRIPTION
for issue #3130 , the switchdiscover command called get_mac_by_arp() routine to get mac address for specified ip.   In that routine, used !~ to compare two ip address, which caused issue. 
Verified with Clive,   changed !~ to ne, the command return correct mac address.

this PR also added two global identity to define cumulus switch for switchdiscover command.