### PR TITLE
Add the units/scale to the output that is being returned from rvitals 

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -71,6 +71,18 @@ sub handled_commands {
     };
 }
 
+my $prefix = "xyz.openbmc_project";
+
+my %sensor_units = (
+    "$prefix.Sensor.Value.Unit.DegreesC" => "C",
+    "$prefix.Sensor.Value.Unit.RPMS" => "RPMS",
+    "$prefix.Sensor.Value.Unit.Volts" => "Volts",
+    "$prefix.Sensor.Value.Unit.Meters" => "Meters",
+    "$prefix.Sensor.Value.Unit.Amperes" => "Amps",
+    "$prefix.Sensor.Value.Unit.Watts" => "Watts",
+    "$prefix.Sensor.Value.Unit.Joules" => "Joules"
+); 
+
 my $http_protocol="https";
 my $openbmc_url = "/org/openbmc";
 my $openbmc_project_url = "/xyz/openbmc_project";
@@ -1199,7 +1211,7 @@ sub rvitals_response {
     my $content_info;
     my $sensor_value;
     
-    print "$node DEBUG Processing command: rvitals $grep_string \n";
+    print "$node: DEBUG Processing command: rvitals $grep_string \n";
     print Dumper(%{$response_info->{data}}) . "\n";
 
     foreach my $key_url (keys %{$response_info->{data}}) {
@@ -1208,7 +1220,7 @@ sub rvitals_response {
         # $key_url is "/xyz/openbmc_project/sensors/xxx/yyy
         # For now display xxx/yyy as a label
         my ($junk, $label) = split("/sensors/", $key_url);
-        $sensor_value = $label . " " . $content{Value};
+        $sensor_value = $label . ": " . $content{Value} . " " . $sensor_units{ $content{Unit} };
         xCAT::SvrUtils::sendmsg("$sensor_value", $callback, $node);
     }
 

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1220,7 +1220,14 @@ sub rvitals_response {
         # $key_url is "/xyz/openbmc_project/sensors/xxx/yyy
         # For now display xxx/yyy as a label
         my ($junk, $label) = split("/sensors/", $key_url);
-        $sensor_value = $label . ": " . $content{Value} . " " . $sensor_units{ $content{Unit} };
+        #
+        # Calculate the value based on the scale
+        #  
+        my $calc_value = $content{Value};
+        if ( $content{Scale} != 0 ) { 
+            $calc_value = ($content{Value} * (10 ** $content{Scale}));
+        } 
+        $sensor_value = $label . ": " . $calc_value . " " . $sensor_units{ $content{Unit} };
         xCAT::SvrUtils::sendmsg("$sensor_value", $callback, $node);
     }
 


### PR DESCRIPTION
Adds to the support for `rvitals` in issue #2816 . 

Add the units to the output that is being returned from 
the rvitals command to make the output more similar to
existing OpenPower BMC based servers

### Before: 
```
[root@fs2vm110 ~]# rvitals p9euh02
p9euh02: fan_tach/fan1 7470
p9euh02: temperature/pcie 29750
p9euh02: fan_tach/fan2 7545
p9euh02: fan_tach/fan0 7440
p9euh02: fan_tach/fan3 7500
```

### After: 

```
[root@fs2vm110 ~]# rvitals p9euh02
p9euh02: fan_tach/fan1: 7485 RPMS
p9euh02: temperature/pcie: 29375 C
p9euh02: fan_tach/fan2: 7560 RPMS
p9euh02: fan_tach/fan0: 7440 RPMS
p9euh02: fan_tach/fan3: 7485 RPMS
```