### PR TITLE
Enhance MTM detection from FRU pages

### DIFF
--- a/xCAT-genesis-scripts/bin/dodiscovery
+++ b/xCAT-genesis-scripts/bin/dodiscovery
@@ -75,13 +75,17 @@ if [ -r /sys/devices/virtual/dmi/id/product_name ]; then  #x86
 		if [ -z "$MTM" ]; then
 			FRU=`ipmitool fru print 0`
 			if [ $? -eq 0 ]; then
-				MTM=`echo "$FRU" | awk -F': ' '/Product Manufacturer/ {m=$2} /Product Name/ {n=$2} END {print m":"n}'`
+				m=`echo "$FRU" | awk -F': ' '/Product Manufacturer/ {print $2}'`
+				n=`echo "$FRU" | awk -F': ' '/Product Name/ {print $2}'`
+				if [ -z "$n" ]; then
+					n=`echo "$FRU" | awk -F': ' '/Product Part Number/ {print $2}'`
+				fi
 			else
 				logger -s -t $log_label -p local4.warning "Couldn't find MTM information in FRU, falling back to DMI (MTMS-based discovery may fail)"
 				m=`cat /sys/devices/virtual/dmi/id/sys_vendor`
 				n=`cat /sys/devices/virtual/dmi/id/product_name`
-				MTM="$m:$n"
 			fi
+			MTM="$m:$n"
 		fi 
 		SERIAL=`cat /sys/devices/virtual/dmi/id/product_serial`
 	fi

--- a/xCAT-genesis-scripts/bin/dodiscovery
+++ b/xCAT-genesis-scripts/bin/dodiscovery
@@ -77,7 +77,7 @@ if [ -r /sys/devices/virtual/dmi/id/product_name ]; then  #x86
 			if [ $? -eq 0 ]; then
 				m=`echo "$FRU" | awk -F': ' '/Product Manufacturer/ {print $2}'`
 				n=`echo "$FRU" | awk -F': ' '/Product Name/ {print $2}'`
-				if [ -z "$n" ]; then
+				if [ -z "$n" -o "$n" == "NONE" ]; then
 					n=`echo "$FRU" | awk -F': ' '/Product Part Number/ {print $2}'`
 				fi
 			else


### PR DESCRIPTION
For systems that don't provide "Product Name", try to use "Product Part Number" instead. 

Supermicro does this, for instance:

    # ipmitool fru print 0
     Chassis Type          : Other
     Chassis Part Number   : CSE-118GQETS-R2K03P
     Chassis Serial        : [...]
     Board Mfg Date        : Sun Dec 31 16:00:00 1995
     Board Mfg             : Supermicro
     Board Serial          : [...]
     Board Part Number     : X10DGQ
     Product Manufacturer  : Supermicro
     Product Part Number   : SYS-1028GQ-TR
     Product Serial        : [...]


This will result in the following MTM information:
```
# lsdef sh-112-12 -i mtm
Object name: sh-112-12
    mtm=Supermicro:SYS-1028GQ-TR
```