### PR TITLE
Add support for the rvitals option for openbmc based on the defined API

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rvitals.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rvitals.1.rst
@@ -56,11 +56,18 @@ BMC specific:
 \ **rvitals**\  \ *noderange*\  {\ **temp | voltage | wattage | fanspeed | power | leds | all**\ }
 
 
-OpenPOWER server specific:
+OpenPOWER (IPMI) specific:
 ==========================
 
 
 \ **rvitals**\  \ *noderange*\  [\ **temp | voltage | wattage | fanspeed | power | leds | all**\ ]
+
+
+OpenPOWER (OpenBMC) specific:
+=============================
+
+
+\ **rvitals**\  \ *noderange*\  [\ **temp | voltage | wattage | fanspeed | power | length | all**\ ]
 
 
 
@@ -69,7 +76,7 @@ OpenPOWER server specific:
 *******************
 
 
-\ **rvitals**\   retrieves hardware vital information from the on-board Service
+\ **rvitals**\   Retrieves hardware vital information from the on-board Service
 Processor for a single or range of nodes and groups.
 
 
@@ -130,6 +137,12 @@ Processor for a single or range of nodes and groups.
 \ **leds**\ 
  
  Retrieves LEDs status.
+ 
+
+
+\ **length**\ 
+ 
+ Retrieves length related attributes.
  
 
 

--- a/docs/source/guides/admin-guides/references/man1/rvitals.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rvitals.1.rst
@@ -67,7 +67,7 @@ OpenPOWER (OpenBMC) specific:
 =============================
 
 
-\ **rvitals**\  \ *noderange*\  [\ **temp | voltage | wattage | fanspeed | power | length | all**\ ]
+\ **rvitals**\  \ *noderange*\  [\ **temp | voltage | wattage | fanspeed | power | altitude | all**\ ]
 
 
 
@@ -140,9 +140,9 @@ Processor for a single or range of nodes and groups.
  
 
 
-\ **length**\ 
+\ **altitude**\ 
  
- Retrieves length related attributes.
+ Retrieves altitude related attributes.
  
 
 

--- a/perl-xCAT/xCAT/FSPvitals.pm
+++ b/perl-xCAT/xCAT/FSPvitals.pm
@@ -375,7 +375,6 @@ sub rackenv {
                 push @result, [ $name, $td, $Rc ];
                 if (!exists($request->{verbose})) {
 
-                    #if( $td =~ /^Rack altitude in meters/ ) {
                     if ($td =~ /^BPA-B total output in watts/) {
                         last;
                     }

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -81,8 +81,10 @@ my %usage = (
       rvitals noderange {temp|wattage|fanspeed|leds|summary|all}
   BMC specific:
       rvitals noderange {temp|voltage|wattage|fanspeed|power|leds|all}
-  OpenPOWER server specific:
+  OpenPOWER (IPMI) specific:
       rvitals noderange [temp|voltage|wattage|fanspeed|power|leds|all]
+  OpenPOWER (OpenBMC) specific:
+      rvitals noderange [temp|voltage|wattage|fanspeed|power|length|all]
   MIC specific:
       rvitals noderange {thermal|all}",
     "reventlog" =>

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -84,7 +84,7 @@ my %usage = (
   OpenPOWER (IPMI) specific:
       rvitals noderange [temp|voltage|wattage|fanspeed|power|leds|all]
   OpenPOWER (OpenBMC) specific:
-      rvitals noderange [temp|voltage|wattage|fanspeed|power|length|all]
+      rvitals noderange [temp|voltage|wattage|fanspeed|power|altitude|all]
   MIC specific:
       rvitals noderange {thermal|all}",
     "reventlog" =>

--- a/xCAT-client/pods/man1/rvitals.1.pod
+++ b/xCAT-client/pods/man1/rvitals.1.pod
@@ -26,13 +26,17 @@ B<rvitals> I<noderange> {B<temp>|B<wattage>|B<fanspeed>|B<leds>|B<summary>|B<all
 
 B<rvitals> I<noderange> {B<temp>|B<voltage>|B<wattage>|B<fanspeed>|B<power>|B<leds>|B<all>}
 
-=head2 OpenPOWER server specific:
+=head2 OpenPOWER (IPMI) specific:
 
 B<rvitals> I<noderange> [B<temp>|B<voltage>|B<wattage>|B<fanspeed>|B<power>|B<leds>|B<all>]
 
+=head2 OpenPOWER (OpenBMC) specific:
+
+B<rvitals> I<noderange> [B<temp>|B<voltage>|B<wattage>|B<fanspeed>|B<power>|B<length>|B<all>]
+
 =head1 B<Description>
 
-B<rvitals>  retrieves hardware vital information from the on-board Service
+B<rvitals>  Retrieves hardware vital information from the on-board Service
 Processor for a single or range of nodes and groups.
 
 =head1 B<Options>
@@ -74,6 +78,10 @@ Retrieves rack environmentals.
 =item B<leds>
 
 Retrieves LEDs status.
+
+=item B<length>
+
+Retrieves length related attributes.
 
 =item B<power>
 

--- a/xCAT-client/pods/man1/rvitals.1.pod
+++ b/xCAT-client/pods/man1/rvitals.1.pod
@@ -32,7 +32,7 @@ B<rvitals> I<noderange> [B<temp>|B<voltage>|B<wattage>|B<fanspeed>|B<power>|B<le
 
 =head2 OpenPOWER (OpenBMC) specific:
 
-B<rvitals> I<noderange> [B<temp>|B<voltage>|B<wattage>|B<fanspeed>|B<power>|B<length>|B<all>]
+B<rvitals> I<noderange> [B<temp>|B<voltage>|B<wattage>|B<fanspeed>|B<power>|B<altitude>|B<all>]
 
 =head1 B<Description>
 
@@ -79,9 +79,9 @@ Retrieves rack environmentals.
 
 Retrieves LEDs status.
 
-=item B<length>
+=item B<altitude>
 
-Retrieves length related attributes.
+Retrieves altitude related attributes.
 
 =item B<power>
 

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -37,6 +37,8 @@ $::POWER_STATE_POWERING_ON="powering-on";
 $::POWER_STATE_QUIESCED="quiesced";
 $::POWER_STATE_RESET="reset";
 
+$::NO_ATTRIBUTES_RETURNED="No attributes returned from the BMC.";
+
 sub unsupported {
     my $callback = shift;
     if (defined($::OPENBMC_DEVEL) && ($::OPENBMC_DEVEL eq "YES")) {
@@ -458,7 +460,7 @@ sub parse_args {
     } elsif ($command eq "rvitals") {
         $check = unsupported($callback); if (ref($check) eq "ARRAY") { return $check; }
         $subcommand = "all" if (!defined($ARGV[0]));
-        unless ($subcommand =~ /^temp$|^voltage$|^wattage$|^fanspeed$|^power$|^length$|^all$/) {
+        unless ($subcommand =~ /^temp$|^voltage$|^wattage$|^fanspeed$|^power$|^altitude$|^all$/) {
             return ([ 1, "Unsupported command: $command $subcommand" ]);
         }
     } else {
@@ -1235,7 +1237,7 @@ sub rvitals_response {
         if ($grep_string =~ "power") {
             unless ( $content{Unit} =~ "Amperes" || $content{Unit} =~ "Joules" || $content{Unit} =~ "Watts" ) { next; } 
         } 
-        if ($grep_string =~ "length") {
+        if ($grep_string =~ "altitude") {
             unless ( $content{Unit} =~ "Meters" ) { next; }
         } 
 
@@ -1262,6 +1264,8 @@ sub rvitals_response {
         my @sorted_output = grep {s/(^|\D)0+(\d)/$1$2/g,1} sort 
             grep {s/(\d+)/sprintf"%06.6d",$1/ge,1} @sorted_output;
         xCAT::SvrUtils::sendmsg("$_", $callback, $node) foreach (@sorted_output);
+    } else {
+        xCAT::SvrUtils::sendmsg("$::NO_ATTRIBUTES_RETURNED", $callback, $node);
     }
 
     if ($next_status{ $node_info{$node}{cur_status} }) {


### PR DESCRIPTION
_Based on the OpenBMC Sensor API, complete the development code
for the supported options based on the possible values that are
currently allowed to be returned.  As more data is added, the code
should be able to handle the printing of the data automatically_

Adds support for `rvitals`, as part of issue #2816 

Looking at the [Value.yaml](https://github.com/openbmc/phosphor-dbus-interfaces/blob/fca9cc6df49f623126858ad7ec0a13ffae17c3f6/xyz/openbmc_project/Sensor/Value.interface.yaml) file as part of the openbmc/sensor API, complete the support for the options in `rvitals`


### External Interfaces supported based on the possible valid values: 

```
rvitals noderange [temp|voltage|wattage|fanspeed|power|length|all]
```

### Example output:

No options specified
```
[root@fs2vm110 ~]# rvitals p9euh02 
p9euh02: fan_tach/fan1: 7470 RPMS
p9euh02: temperature/pcie: 29.75 C
p9euh02: fan_tach/fan2: 7560 RPMS
p9euh02: fan_tach/fan0: 7440 RPMS
p9euh02: fan_tach/fan3: 7530 RPMS
```

Getting `temp` only
```
[root@fs2vm110 ~]# rvitals p9euh02 temp
p9euh02: temperature/pcie: 29.75 C
```

Getting `fanspeed` only:
```
[root@fs2vm110 ~]# rvitals p9euh02 fanspeed
p9euh02: fan_tach/fan1: 7440 RPMS
p9euh02: fan_tach/fan2: 7530 RPMS
p9euh02: fan_tach/fan0: 7500 RPMS
p9euh02: fan_tach/fan3: 7500 RPMS
```