### PR TITLE
Expose the rvitals command as part of openbmc support [DO NOT MERGE]

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -456,7 +456,6 @@ sub parse_args {
             }
         }  
     } elsif ($command eq "rvitals") {
-        $check = unsupported($callback); if (ref($check) eq "ARRAY") { return $check; }
         $subcommand = "all" if (!defined($ARGV[0]));
         unless ($subcommand =~ /^temp$|^voltage$|^wattage$|^fanspeed$|^power$|^leds$|^all$/) {
             return ([ 1, "Unsupported command: $command $subcommand" ]);


### PR DESCRIPTION
Adds support for rvitals, as part of issue #2816

After PR #3134 is merged, I believe that completes the development effort for rvitals and I think we could merge this and open up the function. 
