### PR TITLE
Fix issue 3137: bmcdiscover can not get mtms if fru only had board information

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -979,6 +979,11 @@ sub bmcdiscovery_ipmi {
                         $serial = $3;
                         last;
                     }
+                    if (($fru_output =~ /Board Serial\s+:\s+(\S*).*Board Part Number\s+:\s+(\S*)/)) {
+                        $mtm    = $1;
+                        $serial = $2;
+                        last;
+                    }
 
                 }
             }


### PR DESCRIPTION
For issue #3137 