### PR TITLE
fix issue RHEL update caused boot failure due to selinux #2996

### DIFF
--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -859,7 +859,7 @@ sub mknetboot
         }
 
         # turn off the selinux
-        if ($osver =~ m/fedora12/ || $osver =~ m/fedora13/) {
+        if ($osver =~ m/(fedora12|fedora13|rhels7)/) {
             $kcmdline .= " selinux=0 ";
         }
 


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/2996:

pass "selinux=0" to the kernel cmdline for redhat7 diskless provision, so that selinux can be disabled on system bootup.

