### PR TITLE
Enhancements to rinv code to complete development

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rinv.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rinv.1.rst
@@ -28,18 +28,18 @@ BMC/MPA specific:
 \ **rinv**\  \ *noderange*\  {\ **pci | model | serial | asset | vpd | mprom | deviceid | guid | firm | diag | dimm | bios | mparom | mac | all**\ }
 
 
-OpenPOWER (using ipmi) server specific:
-=======================================
+OpenPOWER (IPMI) server specific:
+=================================
 
 
 \ **rinv**\  \ *noderange*\  [\ **model | serial | deviceid | uuid | guid | vpd | mprom | firm | all**\ ]
 
 
-OpenPOWER (using openbmc) server specific:
-==========================================
+OpenPOWER (OpenBMC) server specific:
+====================================
 
 
-\ **rinv**\  \ *noderange*\  [\ **model | serial | deviceid | uuid | guid | vpd | mprom | firm | cpu | dimm | all**\ ]
+\ **rinv**\  \ *noderange*\  [\ **model | serial | mprom | firm | cpu | dimm | all**\ ]
 
 
 PPC (with HMC) specific:
@@ -195,25 +195,25 @@ Calling \ **rinv**\  for VMware will display the UUID/GUID, nuumber of CPUs, amo
 
 \ **mprom**\ 
  
- Retrieves mprom firmware level
+ Retrieves mprom firmware level.
  
 
 
 \ **deviceid**\ 
  
- Retrieves device identification. Usually device, manufacturing and product ids.
+ Retrieves device identification. Usually device, manufacturing and product IDs.
  
 
 
 \ **uuid**\ 
  
- Retrieves the universally unique identifier
+ Retrieves the universally unique identifier.
  
 
 
 \ **guid**\ 
  
- Retrieves the global unique identifier
+ Retrieves the global unique identifier .
  
 
 

--- a/docs/source/guides/admin-guides/references/man1/rinv.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rinv.1.rst
@@ -39,7 +39,7 @@ OpenPOWER (OpenBMC) server specific:
 ====================================
 
 
-\ **rinv**\  \ *noderange*\  [\ **model | serial | mprom | firm | cpu | dimm | all**\ ]
+\ **rinv**\  \ *noderange*\  [\ **model | serial | firm | cpu | dimm | all**\ ]
 
 
 PPC (with HMC) specific:

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -97,10 +97,10 @@ my %usage = (
        rinv [-h|--help|-v|--version]
     BMC specific:
        rinv <noderange> [mprom|deviceid|uuid|guid|vpd|dimm|all]
-    OpenPOWER (using ipmi) server specific:
+    OpenPOWER (IPMI) server specific:
        rinv <noderange> [model|serial|deviceid|uuid|guid|vpd|mprom|firm|all] 
-    OpenPOWER (using openbmc) server specific:
-       rinv <noderange> [model|serial|deviceid|uuid|guid|vpd|mprom|firm|cpu|dimm|all]
+    OpenPOWER (OpenBMC) server specific:
+       rinv <noderange> [model|serial|firm|cpu|dimm|all]
     MPA specific:
        rinv <noderange> [firm|bios|diag|mprom|sprom|mparom|mac|mtm] 
     PPC specific(with HMC):

--- a/xCAT-client/pods/man1/rinv.1.pod
+++ b/xCAT-client/pods/man1/rinv.1.pod
@@ -16,7 +16,7 @@ B<rinv> I<noderange> [B<model>|B<serial>|B<deviceid>|B<uuid>|B<guid>|B<vpd>|B<mp
 
 =head2 OpenPOWER (OpenBMC) server specific:
 
-B<rinv> I<noderange> [B<model>|B<serial>|B<mprom>|B<firm>|B<cpu>|B<dimm>|B<all>]
+B<rinv> I<noderange> [B<model>|B<serial>|B<firm>|B<cpu>|B<dimm>|B<all>]
 
 =head2 PPC (with HMC) specific:
 

--- a/xCAT-client/pods/man1/rinv.1.pod
+++ b/xCAT-client/pods/man1/rinv.1.pod
@@ -10,13 +10,13 @@ B<rinv> [B<-h>|B<--help>|B<-v>|B<--version>]
 
 B<rinv> I<noderange> {B<pci>|B<model>|B<serial>|B<asset>|B<vpd>|B<mprom>|B<deviceid>|B<guid>|B<firm>|B<diag>|B<dimm>|B<bios>|B<mparom>|B<mac>|B<all>}
 
-=head2 OpenPOWER (using ipmi) server specific:
+=head2 OpenPOWER (IPMI) server specific:
   
 B<rinv> I<noderange> [B<model>|B<serial>|B<deviceid>|B<uuid>|B<guid>|B<vpd>|B<mprom>|B<firm>|B<all>] 
 
-=head2 OpenPOWER (using openbmc) server specific:
+=head2 OpenPOWER (OpenBMC) server specific:
 
-B<rinv> I<noderange> [B<model>|B<serial>|B<deviceid>|B<uuid>|B<guid>|B<vpd>|B<mprom>|B<firm>|B<cpu>|B<dimm>|B<all>]
+B<rinv> I<noderange> [B<model>|B<serial>|B<mprom>|B<firm>|B<cpu>|B<dimm>|B<all>]
 
 =head2 PPC (with HMC) specific:
 
@@ -125,19 +125,19 @@ Diagnostics information of firmware.
 
 =item B<mprom>
 
-Retrieves mprom firmware level
+Retrieves mprom firmware level.
 
 =item B<deviceid>
 
-Retrieves device identification. Usually device, manufacturing and product ids. 
+Retrieves device identification. Usually device, manufacturing and product IDs. 
 
 =item B<uuid>
 
-Retrieves the universally unique identifier
+Retrieves the universally unique identifier.
 
 =item B<guid>
 
-Retrieves the global unique identifier 
+Retrieves the global unique identifier .
 
 =item B<all>
 

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -935,9 +935,17 @@ sub rinv_response {
         my %content = %{ ${ $response_info->{data} }{$key_url} };
 
         if ($grep_string eq "firm") {
+            # This handles the data from the /xyz/openbmc_project/Software endpoint.
+            #
+            # Handle printing out all posssible Software values in a generic format: 
+            #    node: <Purpose> Software: <version> (<Activation>)
+            #
             if (defined($content{Version}) and $content{Version}) {
-                my $firm_ver = "System Firmware Product Version: " . "$content{Version}";
-                xCAT::SvrUtils::sendmsg("$firm_ver", $callback, $node);
+                # TODO: In future, if we want to support ExtendedVersion, we should enable Verbose output.
+                my $purpose_value = (split(/\./, $content{Purpose}))[-1];
+                my $activation_value = (split(/\./, $content{Activation}))[-1];
+                my $software_str = "$purpose_value Software: $content{Version} (Activation=$activation_value)";
+                xCAT::SvrUtils::sendmsg("$software_str", $callback, $node);
                 next;
             }
         }

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -922,10 +922,10 @@ sub rinv_response {
 
     my $grep_string;
     if ($node_info{$node}{cur_status} eq "RINV_FIRM_RESPONSE") {
-         $grep_string = "firm";
-     } else {
-         $grep_string = $status_info{RINV_RESPONSE}{argv};
-     }
+        $grep_string = "firm";
+    } else {
+        $grep_string = $status_info{RINV_RESPONSE}{argv};
+    }
 
     my $src;
     my $content_info;
@@ -1000,13 +1000,13 @@ sub rinv_response {
                 push (@sorted_output, $node . ": ". $content_info); #Save output in array
             }
         }
-     }
-     # If sorted array has any contents, sort it and print it
-     if (scalar @sorted_output > 0) {
-         @sorted_output = sort @sorted_output; #Sort all output
-         my $result = join "\n", @sorted_output; #Join into a single string for easier display
-         xCAT::SvrUtils::sendmsg("$result", $callback);
-     }
+    }
+    # If sorted array has any contents, sort it and print it
+    if (scalar @sorted_output > 0) {
+        @sorted_output = sort @sorted_output; #Sort all output
+        my $result = join "\n", @sorted_output; #Join into a single string for easier display
+        xCAT::SvrUtils::sendmsg("$result", $callback);
+    }
 
     if ($next_status{ $node_info{$node}{cur_status} }) {
         $node_info{$node}{cur_status} = $next_status{ $node_info{$node}{cur_status} };

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -978,6 +978,8 @@ sub rinv_response {
         my @sorted_output = grep {s/(^|\D)0+(\d)/$1$2/g,1} sort 
             grep {s/(\d+)/sprintf"%06.6d",$1/ge,1} @sorted_output;
         xCAT::SvrUtils::sendmsg("$_", $callback, $node) foreach (@sorted_output);
+    } else {
+        xCAT::SvrUtils::sendmsg("$::NO_ATTRIBUTES_RETURNED", $callback, $node);
     }
 
     if ($next_status{ $node_info{$node}{cur_status} }) {

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -967,6 +967,13 @@ sub rinv_response {
                 next; 
             }
 
+            # SPECIAL CASE: If 'serial' or 'model' is specified, only return the system level information
+            if ($grep_string eq "serial" or $grep_string eq "model") {
+                if ($key_url ne "$openbmc_project_url/inventory/system") {
+                    next;
+                }
+            }
+
             if ($key_url =~ /\/(cpu\d*)\/(\w+)/) {
                 $src = "$1 $2";
             } else {

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -976,7 +976,7 @@ sub rinv_response {
             foreach my $key (keys %content) {
                 # If not all options is specified, check whether the key string contains
                 # the keyword option.  If so, add it to the return data
-                if ($grep_string ne "all" and lc($key) !~ m/$grep_string/i ) {
+                if ($grep_string ne "all" and ((lc($key) !~ m/$grep_string/i) and ($key_url !~ m/$grep_string/i)) ) {
                     next;
                 }
                 $content_info = uc ($src) . " " . $key . " : " . $content{$key};

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -956,9 +956,6 @@ sub rinv_response {
             next; 
         }
 
-        # If the item is not found on the server, do not bother printing it out 
-        if ($content{Present} eq 0) { next; }
-
         #
         # Need to re-visit this code, commenting out for now...
         #


### PR DESCRIPTION
Help resolve issue #2664 

Inventory Information is provided by this API: [Inventory](https://github.com/openbmc/phosphor-dbus-interfaces/tree/master/xyz/openbmc_project/Inventory)

In this pull request, I'm looking to fix up the rinv code and attempt to complete all the development required based on the API.  

Some things that are fixed: 
* sorting based on alpha, then numeric 
* only contain the commands that plan to have data , for example, we can probably remove guid and uuid
* Still need to re-evaluate the way we are selecting options in the rinv 