### PR TITLE
fix issue [fvt]2.13.4 nodeset osimage have no right output if command wrong #2971

### DIFF
--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -620,3 +620,41 @@ sub parseCommand {
     return "";
 }
 
+#------------------------------------------------------------------------------
+
+=head3   validateArgs
+    This function validates the arguments of the specified command
+    Arguments:
+        command
+        arguments(array @)
+    Returns:
+        $ref:         a reference to array of [$retcode(integer),$info(string)]
+        $ref->[0]=0 : validation passed
+        $ret->[0]!=0: validation failed, the error info is returned in $ref->[1]
+
+=cut
+
+#-------------------------------------------------------------------------------
+
+sub validateArgs {
+    my $command=shift; 
+    if ($command =~ /xCAT::Usage/) { $command = shift; }
+  
+    my $count=0; 
+    my @extrargs=@_;
+    if($command =~ m/^(nodeset|rinstall|winstall)$/ ){
+        #suppose that argument like "-p foo" have been processed and 
+        #filtered by GetOpt subroutine 
+        #fortunately the commands in this branch does not have such options
+        foreach(@extrargs){
+            if($_ !~ m/^-[-]?\S+/){
+                $count+=1;
+            }
+        }
+        if ($count!=1) {
+           return [1,"Invalid argument: '".join(" ",@extrargs)."'"];
+        }
+    }
+
+    return [0]; 
+}

--- a/xCAT-server/lib/xcat/plugins/destiny.pm
+++ b/xCAT-server/lib/xcat/plugins/destiny.pm
@@ -187,8 +187,15 @@ sub setdestiny {
         chomp($state);
         my $target;
         my $action;
+        my $rawstate=$state;
         if ($state =~ /=/) {
             ($state, $target) = split '=', $state, 2;
+
+            if(!$target){
+                $callback->({ error => "invalid argument: \"$rawstate\"", errorcode => [1] });
+                return;
+            }
+ 
             if ($target =~ /:/) {
                 ($target, $action) = split ':', $target, 2;
             }

--- a/xCAT-server/lib/xcat/plugins/grub2.pm
+++ b/xCAT-server/lib/xcat/plugins/grub2.pm
@@ -12,7 +12,7 @@ use File::Path;
 use Socket;
 use Getopt::Long;
 use xCAT::Table;
-
+use xCAT::Usage;
 my $request;
 my %breaknetbootnodes;
 our %normalnodes;
@@ -426,10 +426,13 @@ sub preprocess_request {
         return;
     }
 
-    if (@ARGV == 0) {
+   my $ret=xCAT::Usage->validateArgs($command,@ARGV);
+   if ($ret->[0]!=0) {
         if ($usage{$command}) {
             my %rsp;
-            $rsp{data}->[0] = $usage{$command};
+            $rsp{error}->[0] = $ret->[1];
+            $rsp{data}->[1] = $usage{$command};
+            $rsp{errorcode}->[0] = $ret->[0];
             $callback1->(\%rsp);
         }
         return;

--- a/xCAT-server/lib/xcat/plugins/petitboot.pm
+++ b/xCAT-server/lib/xcat/plugins/petitboot.pm
@@ -6,7 +6,7 @@ use Getopt::Long;
 use xCAT::Table;
 use Sys::Syslog;
 use xCAT::Scope;
-
+use xCAT::Usage;
 my $globaltftpdir = xCAT::TableUtils->getTftpDir();
 
 my %usage = (
@@ -322,11 +322,14 @@ sub preprocess_request {
         return;
     }
 
-    if (@ARGV == 0) {
-        if ($usage{$command}) {
-            my %rsp;
-            $rsp{data}->[0] = $usage{$command};
-            $callback1->(\%rsp);
+    my $ret=xCAT::Usage->validateArgs($command,@ARGV);
+    if ($ret->[0]!=0) {
+         if ($usage{$command}) {
+             my %rsp;
+             $rsp{error}->[0] = $ret->[1];
+             $rsp{data}->[1] = $usage{$command};
+             $rsp{errorcode}->[0] = $ret->[0];
+             $callback1->(\%rsp);
         }
         return;
     }

--- a/xCAT-server/lib/xcat/plugins/rinstall.pm
+++ b/xCAT-server/lib/xcat/plugins/rinstall.pm
@@ -18,6 +18,7 @@ require xCAT::Utils;
 require xCAT::MsgUtils;
 use xCAT::NodeRange;
 use xCAT::Table;
+use xCAT::Usage;
 
 use Data::Dumper;
 use Getopt::Long;
@@ -96,6 +97,16 @@ sub rinstall {
     }
 
     if (($command =~ /rinstall/) or ($command =~ /winstall/)) {
+        my $ret=xCAT::Usage->validateArgs($command,@ARGV);
+        if ($ret->[0]!=0) {
+             my $rsp={};
+             $rsp->{error}->[0] = $ret->[1];
+             $rsp->{errorcode}->[0] = $ret->[0];
+             xCAT::MsgUtils->message("E", $rsp, $callback);
+             &usage($command,$callback);
+             return;
+        }
+
         my $state = $ARGV[0];
         my $reststates;
         ($state, $reststates) = split(/,/, $state, 2);

--- a/xCAT-server/lib/xcat/plugins/xnba.pm
+++ b/xCAT-server/lib/xcat/plugins/xnba.pm
@@ -11,6 +11,7 @@ use Getopt::Long;
 use xCAT::Utils;
 use xCAT::TableUtils;
 use xCAT::ServiceNodeUtils;
+use xCAT::Usage;
 
 my $dhcpconf = "/etc/dhcpd.conf";
 
@@ -367,11 +368,14 @@ sub preprocess_request {
         return;
     }
 
-    if (@ARGV == 0) {
-        if ($usage{$command}) {
-            my %rsp;
-            $rsp{data}->[0] = $usage{$command};
-            $callback1->(\%rsp);
+    my $ret=xCAT::Usage->validateArgs($command,@ARGV);
+    if ($ret->[0]!=0) {
+         if ($usage{$command}) {
+             my %rsp;
+             $rsp{error}->[0] = $ret->[1];
+             $rsp{data}->[1] = $usage{$command};
+             $rsp{errorcode}->[0] = $ret->[0];
+             $callback1->(\%rsp);
         }
         return;
     }

--- a/xCAT-server/lib/xcat/plugins/yaboot.pm
+++ b/xCAT-server/lib/xcat/plugins/yaboot.pm
@@ -12,6 +12,7 @@ use File::Path;
 use Socket;
 use Getopt::Long;
 use xCAT::Table;
+use xCAT::Usage;
 
 my %breaknetbootnodes;
 our %normalnodes;
@@ -422,15 +423,18 @@ sub preprocess_request {
         return;
     }
 
-    if (@ARGV == 0) {
-        if ($usage{$command}) {
-            my %rsp;
-            $rsp{data}->[0] = $usage{$command};
-            $callback1->(\%rsp);
+
+    my $ret=xCAT::Usage->validateArgs($command,@ARGV);
+    if ($ret->[0]!=0) {
+         if ($usage{$command}) {
+             my %rsp;
+             $rsp{error}->[0] = $ret->[1];
+             $rsp{data}->[1] = $usage{$command};
+             $rsp{errorcode}->[0] = $ret->[0];
+             $callback1->(\%rsp);
         }
         return;
-    }
-
+    }    
 
     #Assume shared tftp directory for boring people, but for cool people, help sync up tftpdirectory contents when
     #if they specify no sharedtftp in site table


### PR DESCRIPTION
fix issue: https://github.com/xcat2/xcat-core/issues/2971

complain and return if the argument is invalid, i.e, ``nodeset xxx osimage= [xxxx]``  or ``osimage= [xxxx]``in the chain

````
[root@c910f03c05k21 ~]# nodeset c910f03c05k27 osimage= rhels7.3-ppc64le-netboot-compute
Error: Invalid argument: 'osimage=rhels7.3-ppc64le-install-compute xxxx'
Usage: nodeset <noderange> [shell|boot|runcmd=bmcsetup|iscsiboot|osimage[=<imagename>]|offline]
[root@c910f03c05k21 perl]# echo $?
1
````

