### PR TITLE
fix issue 3142 delete useless dracut.* files under rootimg/tmp in liteimg

### DIFF
--- a/xCAT-server/lib/xcat/plugins/statelite.pm
+++ b/xCAT-server/lib/xcat/plugins/statelite.pm
@@ -357,7 +357,7 @@ sub process_request {
 
     #delete useless rootimg/tmp/dracut.* files
     #fix copy many dracut.* files cost too much time in liteimg
-    $verbose && $callback->({ info => ["unlink glob \"$rootimg_dir/tmp/dracut.*\""] });
+    $verbose && $callback->({ info => ["removing \"$rootimg_dir/tmp/dracut.*\""] });
     unlink glob "$rootimg_dir/tmp/dracut.*"; 
         
     # recovery the files in litefile.save if necessary

--- a/xCAT-server/lib/xcat/plugins/statelite.pm
+++ b/xCAT-server/lib/xcat/plugins/statelite.pm
@@ -355,14 +355,11 @@ sub process_request {
         xCAT::Utils->runcmd("mkdir $rootimg_dir/.statebackup", 0, 1);
     }
 
-    #delete useless dracut.* files
-    #copy many dracut.* files cost too much time in liteimg
-    if ( !`ls $rootimg_dir/tmp/dracut.* >/dev/null  2>&1` ) {
-        $verbose && $callback->({ info => ["rm -f $rootimg_dir/tmp/dracut.*"] });
-        xCAT::Utils->runcmd("rm -f $rootimg_dir/tmp/dracut.*", 0, 1);
-    }
-
-
+    #delete useless rootimg/tmp/dracut.* files
+    #fix copy many dracut.* files cost too much time in liteimg
+    $verbose && $callback->({ info => ["unlink glob \"$rootimg_dir/tmp/dracut.*\""] });
+    unlink glob "$rootimg_dir/tmp/dracut.*"; 
+        
     # recovery the files in litefile.save if necessary
     foreach my $line (keys %hashSaved) {
         my @oldentry = split(/\s+/, $line);

--- a/xCAT-server/lib/xcat/plugins/statelite.pm
+++ b/xCAT-server/lib/xcat/plugins/statelite.pm
@@ -355,6 +355,14 @@ sub process_request {
         xCAT::Utils->runcmd("mkdir $rootimg_dir/.statebackup", 0, 1);
     }
 
+    #delete useless dracut.* files
+    #copy many dracut.* files cost too much time in liteimg
+    if ( !`ls $rootimg_dir/tmp/dracut.* >/dev/null  2>&1` ) {
+        $verbose && $callback->({ info => ["rm -f $rootimg_dir/tmp/dracut.*"] });
+        xCAT::Utils->runcmd("rm -f $rootimg_dir/tmp/dracut.*", 0, 1);
+    }
+
+
     # recovery the files in litefile.save if necessary
     foreach my $line (keys %hashSaved) {
         my @oldentry = split(/\s+/, $line);


### PR DESCRIPTION
Fix issue #3142 
Unit test:
```
bybc0607:/opt/xcat/lib/perl/xCAT_plugin # nodeset bybc0605 osimage
bybc0605: statelite sles12.2-x86_64-compute

bybc0607:/opt/xcat/lib/perl/xCAT_plugin # ls /install/netboot/sles12.2/x86_64/compute/rootimg/tmp
dracut.AN5qBKWnjS  dracut.M6vWTE1WpL

bybc0607:/opt/xcat/lib/perl/xCAT_plugin # liteimg sles12.2-x86_64-statelite-compute -V |grep dracut
rm -f /install/netboot/sles12.2/x86_64/compute/rootimg/tmp/dracut.*

bybc0607:/opt/xcat/lib/perl/xCAT_plugin # ls /install/netboot/sles12.2/x86_64/compute/rootimg/tmp
bybc0607:/opt/xcat/lib/perl/xCAT_plugin # ls /install/netboot/sles12.2/x86_64/compute/rootimg/.default/tmp/
.font-unix  .ICE-unix  .Test-unix  .X11-unix  .XIM-unix
```