### PR TITLE
Add test cases for command nodeset for grub2/petitboot/yaboot

### DIFF
--- a/xCAT-test/autotest/testcase/nodeset/cases0
+++ b/xCAT-test/autotest/testcase/nodeset/cases0
@@ -196,6 +196,95 @@ cmd:noderm testnode1
 cmd:rmdef -t osimage -o "__GETNODEATTR($$CN,os)__-x86_64-install-compute"
 cmd:cp -f /etc/hosts.xcattestbak /etc/hosts
 end
+
+start:nodeset_addkcmdline_grub2
+description: This case is to verify when netboot=grub2, addkcmdline is correctly supported. 
+cmd:rmdef testnode1
+cmd:rm -f /tftpboot/boot/grub2/{testnode1,grub.cfg{-e6-d4-d2-3a-ad-06,.0a0101c8}}
+cmd:mkdef -t node -o testnode1 arch=ppc64 cons=hmc groups=lpar ip=10.1.1.200 mac=e6:d4:d2:3a:ad:06 mgt=hmc monserver=10.1.1.1 nameservers=10.1.1.1 profile=compute tftpserver=10.1.1.1 xcatmaster=10.1.1.1
+os=__GETNODEATTR($$CN,os)__ 
+check:rc==0
+cmd:cp -f /etc/hosts /etc/hosts.xcattestbak
+cmd:echo "10.1.1.200 testnode1" >> /etc/hosts
+cmd:makedns -n
+check:rc==0
+cmd:chdef testnode1 netboot=grub2 addkcmdline=debug
+check:rc==0
+cmd: mkdef "__GETNODEATTR($$CN,os)__-ppc64-install-compute" -u profile=compute provmethod=install osvers=__GETNODEATTR($$CN,os)__
+check:rc==0
+cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-ppc64-install-compute
+check:rc==0
+cmd:grep "debug" /tftpboot/boot/grub2/testnode1
+check:rc==0
+cmd:grep "debug" /tftpboot/boot/grub2/grub.cfg-e6-d4-d2-3a-ad-06
+check:rc==0
+cmd:grep "debug" /tftpboot/boot/grub2/grub.cfg.0a0101c8
+check:rc==0
+cmd:nodeset testnode1 offline
+check:rc==0
+cmd:grep "debug" /tftpboot/boot/grub2/testnode1
+check:rc!=0
+cmd:noderm testnode1
+cmd:rmdef -t osimage -o "__GETNODEATTR($$CN,os)__-ppc64-install-compute"
+cmd:cp -f /etc/hosts.xcattestbak /etc/hosts
+end
+
+start:nodeset_addkcmdline_petitboot
+description: This case is to verify when netboot=petitboot, addkcmdline is correctly supported. 
+cmd:rmdef testnode1
+cmd:rm -f /tftpboot/petitboot/testnode1
+cmd:mkdef -t node -o testnode1 arch=ppc64le cons=bmc groups=ipmi ip=10.1.1.200 mac=e6:d4:d2:3a:ad:06 mgt=ipmi monserver=10.1.1.1 nameservers=10.1.1.1 profile=compute tftpserver=10.1.1.1 xcatmaster=10.1.1.1
+os=__GETNODEATTR($$CN,os)__ 
+check:rc==0
+cmd:cp -f /etc/hosts /etc/hosts.xcattestbak
+cmd:echo "10.1.1.200 testnode1" >> /etc/hosts
+cmd:makedns -n
+check:rc==0
+cmd:chdef testnode1 netboot=petitboot addkcmdline=debug
+check:rc==0
+cmd: mkdef "__GETNODEATTR($$CN,os)__-ppc64le-install-compute" -u profile=compute provmethod=install osvers=__GETNODEATTR($$CN,os)__
+check:rc==0
+cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-ppc64le-install-compute
+check:rc==0
+cmd:grep "debug" /tftpboot/petitboot/testnode1
+check:rc==0
+cmd:nodeset testnode1 offline
+check:rc==0
+cmd:grep "debug" /tftpboot/petitboot/testnode1
+check:rc!=0
+cmd:noderm testnode1
+cmd:rmdef -t osimage -o "__GETNODEATTR($$CN,os)__-ppc64le-install-compute"
+cmd:cp -f /etc/hosts.xcattestbak /etc/hosts
+end
+
+start:nodeset_addkcmdline_yaboot
+description: This case is to verify when netboot=yaboot, addkcmdline is correctly supported. 
+cmd:rmdef testnode1
+cmd:rm -f /tftpboot/yaboot.conf-e6-d4-d2-3a-ad-06
+cmd:mkdef -t node -o testnode1 arch=ppc64 cons=hmc groups=lpar ip=10.1.1.200 mac=e6:d4:d2:3a:ad:06 mgt=hmc monserver=10.1.1.1 nameservers=10.1.1.1 profile=compute tftpserver=10.1.1.1 xcatmaster=10.1.1.1
+os=__GETNODEATTR($$CN,os)__ 
+check:rc==0
+cmd:cp -f /etc/hosts /etc/hosts.xcattestbak
+cmd:echo "10.1.1.200 testnode1" >> /etc/hosts
+cmd:makedns -n
+check:rc==0
+cmd:chdef testnode1 netboot=yaboot addkcmdline=debug
+check:rc==0
+cmd: mkdef "__GETNODEATTR($$CN,os)__-ppc64-install-compute" -u profile=compute provmethod=install osvers=__GETNODEATTR($$CN,os)__
+check:rc==0
+cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-ppc64-install-compute
+check:rc==0
+cmd:grep "debug" /tftpboot/yaboot.conf-e6-d4-d2-3a-ad-06
+check:rc==0
+cmd:nodeset testnode1 offline
+check:rc==0
+cmd:grep "debug" /tftpboot/yaboot.conf-e6-d4-d2-3a-ad-06
+check:rc!=0
+cmd:noderm testnode1
+cmd:rmdef -t osimage -o "__GETNODEATTR($$CN,os)__-ppc64-install-compute"
+cmd:cp -f /etc/hosts.xcattestbak /etc/hosts
+end
+
 start:nodeset_errorcommand
 description:This testcase is to very nodeset osimage errorcommand could give right output
 Attribute: $$CN-The operation object of nodeset command

--- a/xCAT-test/autotest/testcase/nodeset/cases0
+++ b/xCAT-test/autotest/testcase/nodeset/cases0
@@ -191,14 +191,14 @@ cmd:grep "debug" /tftpboot/xcat/xnba/nodes/testnode1
 check:rc==0
 cmd:grep "debug" /tftpboot/xcat/xnba/nodes/testnode1.elilo
 check:rc==0
-cmd:makedhcp -q testnode1 | grep ^testnode1:
-check:rc==0
+#cmd:makedhcp -q testnode1 | grep ^testnode1:
+#check:rc==0
 cmd:nodeset testnode1 offline
 check:rc==0
 cmd:grep "debug" /tftpboot/xcat/xnba/nodes/testnode1
 check:rc!=0
-cmd:makedhcp -q testnode1 | grep ^testnode1:
-check:rc!=0
+#cmd:makedhcp -q testnode1 | grep ^testnode1:
+#check:rc!=0
 cmd:chdef -t node -o testnode1 ip=
 check:rc==0
 cmd:getent hosts testnode1 | grep testnode1
@@ -233,14 +233,14 @@ cmd:grep "debug" /tftpboot/boot/grub2/grub.cfg-e6-d4-d2-3a-ad-06
 check:rc==0
 cmd:grep "debug" /tftpboot/boot/grub2/grub.cfg.0a0101c8
 check:rc==0
-cmd:makedhcp -q testnode1 | grep ^testnode1:
-check:rc==0
+#cmd:makedhcp -q testnode1 | grep ^testnode1:
+#check:rc==0
 cmd:nodeset testnode1 offline
 check:rc==0
 cmd:grep "debug" /tftpboot/boot/grub2/testnode1
 check:rc!=0
-cmd:makedhcp -q testnode1 | grep ^testnode1:
-check:rc!=0
+#cmd:makedhcp -q testnode1 | grep ^testnode1:
+#check:rc!=0
 cmd:chdef -t node -o testnode1 ip=
 check:rc==0
 cmd:getent hosts testnode1 | grep testnode1
@@ -263,7 +263,7 @@ cmd:cp -f /etc/hosts /etc/hosts.xcattestbak
 cmd:echo "10.1.1.200 testnode1" >> /etc/hosts
 cmd:makedns -n
 check:rc==0
-cmd:chdef testnode1 netboot=petitboot addkcmdline=debug
+Gcmd:chdef testnode1 netboot=petitboot addkcmdline=debug
 check:rc==0
 cmd: mkdef "__GETNODEATTR($$CN,os)__-ppc64le-install-compute" -u profile=compute provmethod=install osvers=__GETNODEATTR($$CN,os)__
 check:rc==0
@@ -271,14 +271,14 @@ cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-ppc64le-install-compute
 check:rc==0
 cmd:grep "debug" /tftpboot/petitboot/testnode1
 check:rc==0
-cmd:makedhcp -q testnode1 | grep ^testnode1:
-check:rc==0
+#cmd:makedhcp -q testnode1 | grep ^testnode1:
+#check:rc==0
 cmd:nodeset testnode1 offline
 check:rc==0
 cmd:grep "debug" /tftpboot/petitboot/testnode1
 check:rc!=0
-cmd:makedhcp -q testnode1 | grep ^testnode1:
-check:rc!=0
+#cmd:makedhcp -q testnode1 | grep ^testnode1:
+#check:rc!=0
 cmd:chdef -t node -o testnode1 ip=
 check:rc==0
 cmd:getent hosts testnode1 | grep testnode1
@@ -309,14 +309,14 @@ cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-ppc64-install-compute
 check:rc==0
 cmd:grep "debug" /tftpboot/yaboot.conf-e6-d4-d2-3a-ad-06
 check:rc==0
-cmd:makedhcp -q testnode1 | grep ^testnode1:
-check:rc==0
+#cmd:makedhcp -q testnode1 | grep ^testnode1:
+#check:rc==0
 cmd:nodeset testnode1 offline
 check:rc==0
 cmd:grep "debug" /tftpboot/yaboot.conf-e6-d4-d2-3a-ad-06
 check:rc!=0
-cmd:makedhcp -q testnode1 | grep ^testnode1:
-check:rc!=0
+#cmd:makedhcp -q testnode1 | grep ^testnode1:
+#check:rc!=0
 cmd:chdef -t node -o testnode1 ip=
 check:rc==0
 cmd:getent hosts testnode1 | grep testnode1

--- a/xCAT-test/autotest/testcase/nodeset/cases0
+++ b/xCAT-test/autotest/testcase/nodeset/cases0
@@ -173,8 +173,8 @@ check:output=~Warning: testnode1: petitboot might be invalid|testnode1 could not
 cmd:noderm testnode1
 end
 
-start:nodeset_addkcmdline
-description: This case is to verify when netboot=xnba, addkcmdline is correctly supported. 
+start:nodeset_xnba
+description: Verify when xnba is used for OS loader, whether the configuration files under /tftpboot can be generated corrently
 cmd:mkdef -t node -o testnode1 arch=x86_64 cons=kvm groups=kvm ip=10.1.1.200 mac=e6:d4:d2:3a:ad:06 mgt=kvm monserver=10.1.1.1 nameservers=10.1.1.1 profile=compute tftpserver=10.1.1.1 xcatmaster=10.1.1.1
 os=__GETNODEATTR($$CN,os)__ 
 check:rc==0
@@ -182,23 +182,31 @@ cmd:cp -f /etc/hosts /etc/hosts.xcattestbak
 cmd:echo "10.1.1.200 testnode1" >> /etc/hosts
 cmd:makedns -n
 check:rc==0
-cmd:chdef testnode1 netboot=xnba addkcmdline=rd.break=pre-pivot
+cmd:chdef testnode1 netboot=xnba addkcmdline=debug
 check:rc==0
 cmd: mkdef "__GETNODEATTR($$CN,os)__-x86_64-install-compute" -u profile=compute provmethod=install osvers=__GETNODEATTR($$CN,os)__
 check:rc==0
 cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-x86_64-install-compute
 check:rc==0
-cmd:grep "rd.break=pre-pivot" /tftpboot/xcat/xnba/nodes/testnode1
+cmd:grep "debug" /tftpboot/xcat/xnba/nodes/testnode1
 check:rc==0
-cmd:grep "rd.break=pre-pivot" /tftpboot/xcat/xnba/nodes/testnode1.elilo
+cmd:grep "debug" /tftpboot/xcat/xnba/nodes/testnode1.elilo
 check:rc==0
+cmd:nodeset testnode1 offline
+check:rc==0
+cmd:grep "debug" /tftpboot/xcat/xnba/nodes/testnode1
+check:rc!=0
+cmd:chdef -t node -o testnode1 ip=
+check:rc==0
+cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-x86_64-install-compute
+check:rc!=0
 cmd:noderm testnode1
 cmd:rmdef -t osimage -o "__GETNODEATTR($$CN,os)__-x86_64-install-compute"
 cmd:cp -f /etc/hosts.xcattestbak /etc/hosts
 end
 
-start:nodeset_addkcmdline_grub2
-description: This case is to verify when netboot=grub2, addkcmdline is correctly supported. 
+start:nodeset_grub2
+description: Verify when grub2 is used for OS loader, whether the configuration files under /tftpboot can be generated corrently
 cmd:rmdef testnode1
 cmd:rm -f /tftpboot/boot/grub2/{testnode1,grub.cfg{-e6-d4-d2-3a-ad-06,.0a0101c8}}
 cmd:mkdef -t node -o testnode1 arch=ppc64 cons=hmc groups=lpar ip=10.1.1.200 mac=e6:d4:d2:3a:ad:06 mgt=hmc monserver=10.1.1.1 nameservers=10.1.1.1 profile=compute tftpserver=10.1.1.1 xcatmaster=10.1.1.1
@@ -224,13 +232,17 @@ cmd:nodeset testnode1 offline
 check:rc==0
 cmd:grep "debug" /tftpboot/boot/grub2/testnode1
 check:rc!=0
+cmd:chdef -t node -o testnode1 ip=
+check:rc==0
+cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-ppc64-install-compute
+check:rc!=0
 cmd:noderm testnode1
 cmd:rmdef -t osimage -o "__GETNODEATTR($$CN,os)__-ppc64-install-compute"
 cmd:cp -f /etc/hosts.xcattestbak /etc/hosts
 end
 
-start:nodeset_addkcmdline_petitboot
-description: This case is to verify when netboot=petitboot, addkcmdline is correctly supported. 
+start:nodeset_petitboot
+description: Verify when petitboot is used for OS loader, whether the configuration files under /tftpboot can be generated corrently
 cmd:rmdef testnode1
 cmd:rm -f /tftpboot/petitboot/testnode1
 cmd:mkdef -t node -o testnode1 arch=ppc64le cons=bmc groups=ipmi ip=10.1.1.200 mac=e6:d4:d2:3a:ad:06 mgt=ipmi monserver=10.1.1.1 nameservers=10.1.1.1 profile=compute tftpserver=10.1.1.1 xcatmaster=10.1.1.1
@@ -252,13 +264,17 @@ cmd:nodeset testnode1 offline
 check:rc==0
 cmd:grep "debug" /tftpboot/petitboot/testnode1
 check:rc!=0
+cmd:chdef -t node -o testnode1 ip=
+check:rc==0
+cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-ppc64le-install-compute
+check:rc!=0
 cmd:noderm testnode1
 cmd:rmdef -t osimage -o "__GETNODEATTR($$CN,os)__-ppc64le-install-compute"
 cmd:cp -f /etc/hosts.xcattestbak /etc/hosts
 end
 
-start:nodeset_addkcmdline_yaboot
-description: This case is to verify when netboot=yaboot, addkcmdline is correctly supported. 
+start:nodeset_yaboot
+description: Verify when yaboot is used for OS loader, whether the configuration files under /tftpboot can be generated corrently
 cmd:rmdef testnode1
 cmd:rm -f /tftpboot/yaboot.conf-e6-d4-d2-3a-ad-06
 cmd:mkdef -t node -o testnode1 arch=ppc64 cons=hmc groups=lpar ip=10.1.1.200 mac=e6:d4:d2:3a:ad:06 mgt=hmc monserver=10.1.1.1 nameservers=10.1.1.1 profile=compute tftpserver=10.1.1.1 xcatmaster=10.1.1.1
@@ -279,6 +295,10 @@ check:rc==0
 cmd:nodeset testnode1 offline
 check:rc==0
 cmd:grep "debug" /tftpboot/yaboot.conf-e6-d4-d2-3a-ad-06
+check:rc!=0
+cmd:chdef -t node -o testnode1 ip=
+check:rc==0
+cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-ppc64-install-compute
 check:rc!=0
 cmd:noderm testnode1
 cmd:rmdef -t osimage -o "__GETNODEATTR($$CN,os)__-ppc64-install-compute"

--- a/xCAT-test/autotest/testcase/nodeset/cases0
+++ b/xCAT-test/autotest/testcase/nodeset/cases0
@@ -174,18 +174,20 @@ end
 
 start:nodeset_xnba
 description: Verify when xnba is used for OS loader, whether the configuration files under /tftpboot can be generated corrently
-cmd:mkdef -t node -o testnode1 arch=x86_64 cons=kvm groups=kvm ip=10.1.1.200 mac=e6:d4:d2:3a:ad:06 mgt=kvm monserver=10.1.1.1 nameservers=10.1.1.1 profile=compute tftpserver=10.1.1.1 xcatmaster=10.1.1.1
-os=__GETNODEATTR($$CN,os)__ 
+cmd:rmdef testnode1
+cmd:rm -f /tftpboot/xcat/xnba/nodes/testnode1 /tftpboot/xcat/xnba/nodes/testnode1.elilo
+cmd:mkdef -t node -o testnode1 arch=x86_64 cons=kvm groups=kvm ip=10.1.1.200 mac=e6:d4:d2:3a:ad:06 mgt=kvm profile=compute os=rhels6.99
 check:rc==0
 cmd:cp -f /etc/hosts /etc/hosts.xcattestbak
 cmd:echo "10.1.1.200 testnode1" >> /etc/hosts
-cmd:makedns -n
 check:rc==0
 cmd:chdef testnode1 netboot=xnba addkcmdline=debug
 check:rc==0
-cmd: mkdef "__GETNODEATTR($$CN,os)__-x86_64-install-compute" -u profile=compute provmethod=install osvers=__GETNODEATTR($$CN,os)__
-check:rc==0
-cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-x86_64-install-compute
+cmd:mkdef "rhels6.99-x86_64-install-compute" -u profile=compute provmethod=install osvers=rhels6.99 osarch=x86_64
+cmd:mkdir -p /install/rhels6.99/x86_64/images/pxeboot
+cmd:echo blah >/install/rhels6.99/x86_64/images/pxeboot/vmlinuz
+cmd:echo blah >/install/rhels6.99/x86_64/images/pxeboot/initrd.img
+cmd:nodeset testnode1 osimage=rhels6.99-x86_64-install-compute
 check:rc==0
 cmd:grep "debug" /tftpboot/xcat/xnba/nodes/testnode1
 check:rc==0
@@ -201,21 +203,21 @@ check:rc!=0
 #check:rc!=0
 cmd:chdef -t node -o testnode1 ip=
 check:rc==0
+cmd:cp -f /etc/hosts.xcattestbak /etc/hosts
 cmd:getent hosts testnode1 | grep testnode1
 check:rc!=0
-cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-x86_64-install-compute
+cmd:nodeset testnode1 osimage=rhels6.99-x86_64-install-compute
 check:rc!=0
 cmd:noderm testnode1
-cmd:rmdef -t osimage -o "__GETNODEATTR($$CN,os)__-x86_64-install-compute"
-cmd:cp -f /etc/hosts.xcattestbak /etc/hosts
+cmd:rmdef -t osimage -o "rhels6.99-x86_64-install-compute"
+cmd:rm -rf /install/rhels6.99
 end
 
 start:nodeset_grub2
 description: Verify when grub2 is used for OS loader, whether the configuration files under /tftpboot can be generated corrently
 cmd:rmdef testnode1
-cmd:rm -f /tftpboot/boot/grub2/{testnode1,grub.cfg{-e6-d4-d2-3a-ad-06,.0a0101c8}}
-cmd:mkdef -t node -o testnode1 arch=ppc64 cons=hmc groups=lpar ip=10.1.1.200 mac=e6:d4:d2:3a:ad:06 mgt=hmc monserver=10.1.1.1 nameservers=10.1.1.1 profile=compute tftpserver=10.1.1.1 xcatmaster=10.1.1.1
-os=__GETNODEATTR($$CN,os)__ 
+cmd:rm -f /tftpboot/boot/grub2/{testnode1,grub.cfg-{01-e6-d4-d2-3a-ad-06,0[aA]0101[cC]8}}
+cmd:mkdef -t node -o testnode1 arch=ppc64 cons=hmc groups=lpar ip=10.1.1.200 mac=e6:d4:d2:3a:ad:06 mgt=hmc profile=compute os=rhels7.99
 check:rc==0
 cmd:cp -f /etc/hosts /etc/hosts.xcattestbak
 cmd:echo "10.1.1.200 testnode1" >> /etc/hosts
@@ -223,15 +225,17 @@ cmd:makedns -n
 check:rc==0
 cmd:chdef testnode1 netboot=grub2 addkcmdline=debug
 check:rc==0
-cmd: mkdef "__GETNODEATTR($$CN,os)__-ppc64-install-compute" -u profile=compute provmethod=install osvers=__GETNODEATTR($$CN,os)__
-check:rc==0
-cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-ppc64-install-compute
+cmd:mkdef "rhels7.99-ppc64-install-compute" -u profile=compute provmethod=install osvers=rhels7.99 osarch=ppc64
+cmd:mkdir -p /install/rhels7.99/ppc64/ppc/ppc64
+cmd:echo blah >/install/rhels7.99/ppc64/ppc/ppc64/vmlinuz
+cmd:echo blah >/install/rhels7.99/ppc64/ppc/ppc64/initrd.img
+cmd:nodeset testnode1 osimage=rhels7.99-ppc64-install-compute
 check:rc==0
 cmd:grep "debug" /tftpboot/boot/grub2/testnode1
 check:rc==0
-cmd:grep "debug" /tftpboot/boot/grub2/grub.cfg-e6-d4-d2-3a-ad-06
+cmd:grep "debug" /tftpboot/boot/grub2/grub.cfg-01-e6-d4-d2-3a-ad-06
 check:rc==0
-cmd:grep "debug" /tftpboot/boot/grub2/grub.cfg.0a0101c8
+cmd:grep "debug" /tftpboot/boot/grub2/grub.cfg-0[aA]0101[cC]8
 check:rc==0
 #cmd:makedhcp -q testnode1 | grep ^testnode1:
 #check:rc==0
@@ -243,31 +247,34 @@ check:rc!=0
 #check:rc!=0
 cmd:chdef -t node -o testnode1 ip=
 check:rc==0
+cmd:cp -f /etc/hosts.xcattestbak /etc/hosts
 cmd:getent hosts testnode1 | grep testnode1
 check:rc!=0
-cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-ppc64-install-compute
+cmd:nodeset testnode1 osimage=rhels7.99-ppc64-install-compute
 check:rc!=0
 cmd:noderm testnode1
-cmd:rmdef -t osimage -o "__GETNODEATTR($$CN,os)__-ppc64-install-compute"
-cmd:cp -f /etc/hosts.xcattestbak /etc/hosts
+cmd:rmdef -t osimage -o "rhels7.99-ppc64-install-compute"
+cmd:rm -rf /install/rhels7.99
 end
 
 start:nodeset_petitboot
 description: Verify when petitboot is used for OS loader, whether the configuration files under /tftpboot can be generated corrently
 cmd:rmdef testnode1
 cmd:rm -f /tftpboot/petitboot/testnode1
-cmd:mkdef -t node -o testnode1 arch=ppc64le cons=bmc groups=ipmi ip=10.1.1.200 mac=e6:d4:d2:3a:ad:06 mgt=ipmi monserver=10.1.1.1 nameservers=10.1.1.1 profile=compute tftpserver=10.1.1.1 xcatmaster=10.1.1.1
-os=__GETNODEATTR($$CN,os)__ 
+cmd:mkdef -t node -o testnode1 arch=ppc64le cons=bmc groups=ipmi ip=10.1.1.200 mac=e6:d4:d2:3a:ad:06 mgt=ipmi profile=compute os=rhels7.99
 check:rc==0
 cmd:cp -f /etc/hosts /etc/hosts.xcattestbak
 cmd:echo "10.1.1.200 testnode1" >> /etc/hosts
 cmd:makedns -n
 check:rc==0
-Gcmd:chdef testnode1 netboot=petitboot addkcmdline=debug
+cmd:chdef testnode1 netboot=petitboot addkcmdline=debug
 check:rc==0
-cmd: mkdef "__GETNODEATTR($$CN,os)__-ppc64le-install-compute" -u profile=compute provmethod=install osvers=__GETNODEATTR($$CN,os)__
-check:rc==0
-cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-ppc64le-install-compute
+cmd:mkdef "rhels7.99-ppc64le-install-compute" -u profile=compute provmethod=install osvers=rhels7.99 osarch=ppc64le
+cmd:mkdir -p /install/rhels7.99/ppc64le
+cmd:mkdir -p /install/rhels7.99/ppc64le/ppc/ppc64le
+cmd:echo blah >/install/rhels7.99/ppc64le/ppc/ppc64le/vmlinuz
+cmd:echo blah >/install/rhels7.99/ppc64le/ppc/ppc64le/initrd.img
+cmd:nodeset testnode1 osimage=rhels7.99-ppc64le-install-compute
 check:rc==0
 cmd:grep "debug" /tftpboot/petitboot/testnode1
 check:rc==0
@@ -281,21 +288,21 @@ check:rc!=0
 #check:rc!=0
 cmd:chdef -t node -o testnode1 ip=
 check:rc==0
+cmd:cp -f /etc/hosts.xcattestbak /etc/hosts
 cmd:getent hosts testnode1 | grep testnode1
 check:rc!=0
-cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-ppc64le-install-compute
+cmd:nodeset testnode1 osimage=rhels7.99-ppc64le-install-compute
 check:rc!=0
 cmd:noderm testnode1
-cmd:rmdef -t osimage -o "__GETNODEATTR($$CN,os)__-ppc64le-install-compute"
-cmd:cp -f /etc/hosts.xcattestbak /etc/hosts
+cmd:rmdef -t osimage -o "rhels7.99-ppc64le-install-compute"
+cmd:rm -rf /install/rhels7.99
 end
 
 start:nodeset_yaboot
 description: Verify when yaboot is used for OS loader, whether the configuration files under /tftpboot can be generated corrently
 cmd:rmdef testnode1
 cmd:rm -f /tftpboot/yaboot.conf-e6-d4-d2-3a-ad-06
-cmd:mkdef -t node -o testnode1 arch=ppc64 cons=hmc groups=lpar ip=10.1.1.200 mac=e6:d4:d2:3a:ad:06 mgt=hmc monserver=10.1.1.1 nameservers=10.1.1.1 profile=compute tftpserver=10.1.1.1 xcatmaster=10.1.1.1
-os=__GETNODEATTR($$CN,os)__ 
+cmd:mkdef -t node -o testnode1 arch=ppc64 cons=hmc groups=lpar ip=10.1.1.200 mac=e6:d4:d2:3a:ad:06 mgt=hmc profile=compute os=rhels6.99
 check:rc==0
 cmd:cp -f /etc/hosts /etc/hosts.xcattestbak
 cmd:echo "10.1.1.200 testnode1" >> /etc/hosts
@@ -303,9 +310,12 @@ cmd:makedns -n
 check:rc==0
 cmd:chdef testnode1 netboot=yaboot addkcmdline=debug
 check:rc==0
-cmd: mkdef "__GETNODEATTR($$CN,os)__-ppc64-install-compute" -u profile=compute provmethod=install osvers=__GETNODEATTR($$CN,os)__
-check:rc==0
-cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-ppc64-install-compute
+cmd:mkdef "rhels6.99-ppc64-install-compute" -u profile=compute provmethod=install osvers=rhels6.99 osarch=ppc64
+cmd:mkdir -p /install/rhels6.99/ppc64/ppc/{chrp,ppc64}
+cmd:echo blah >/install/rhels6.99/ppc64/ppc/ppc64/vmlinuz
+cmd:echo blah >/install/rhels6.99/ppc64/ppc/ppc64/initrd.img
+cmd:echo blah >/install/rhels6.99/ppc64/ppc/chrp/yaboot
+cmd:nodeset testnode1 osimage=rhels6.99-ppc64-install-compute
 check:rc==0
 cmd:grep "debug" /tftpboot/yaboot.conf-e6-d4-d2-3a-ad-06
 check:rc==0
@@ -319,13 +329,14 @@ check:rc!=0
 #check:rc!=0
 cmd:chdef -t node -o testnode1 ip=
 check:rc==0
+cmd:cp -f /etc/hosts.xcattestbak /etc/hosts
 cmd:getent hosts testnode1 | grep testnode1
 check:rc!=0
-cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-ppc64-install-compute
+cmd:nodeset testnode1 osimage=rhels6.99-ppc64-install-compute
 check:rc!=0
 cmd:noderm testnode1
-cmd:rmdef -t osimage -o "__GETNODEATTR($$CN,os)__-ppc64-install-compute"
-cmd:cp -f /etc/hosts.xcattestbak /etc/hosts
+cmd:rmdef -t osimage -o "rhels6.99-ppc64-install-compute"
+cmd:rm -rf /install/rhels6.99
 end
 
 start:nodeset_errorcommand

--- a/xCAT-test/autotest/testcase/nodeset/cases0
+++ b/xCAT-test/autotest/testcase/nodeset/cases0
@@ -27,7 +27,6 @@ cmd:rmdef -t osimage -o "rhels7.5-ppc64-install-compute"
 cmd:noderm testnode1
 end
 
-
 start:nodeset_check_yaboot_yes
 os:rhels
 cmd:mkdef -t node -o testnode1 arch=ppc64 cons=hmc groups=lpar hcp=hmc1 hwtype=lpar  id=1 ip=10.1.1.200 mac=e6:d4:d2:3a:ad:06 mgt=hmc monserver=10.1.1.1 nameservers=10.1.1.1 nodetype=ppc,osi parent=fsp1 pprofile=testnode1 profile=compute tftpserver=10.1.1.1 xcatmaster=10.1.1.1
@@ -192,12 +191,18 @@ cmd:grep "debug" /tftpboot/xcat/xnba/nodes/testnode1
 check:rc==0
 cmd:grep "debug" /tftpboot/xcat/xnba/nodes/testnode1.elilo
 check:rc==0
+cmd:makedhcp -q testnode1 | grep ^testnode1:
+check:rc==0
 cmd:nodeset testnode1 offline
 check:rc==0
 cmd:grep "debug" /tftpboot/xcat/xnba/nodes/testnode1
 check:rc!=0
+cmd:makedhcp -q testnode1 | grep ^testnode1:
+check:rc!=0
 cmd:chdef -t node -o testnode1 ip=
 check:rc==0
+cmd:getent hosts testnode1 | grep testnode1
+check:rc!=0
 cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-x86_64-install-compute
 check:rc!=0
 cmd:noderm testnode1
@@ -228,12 +233,18 @@ cmd:grep "debug" /tftpboot/boot/grub2/grub.cfg-e6-d4-d2-3a-ad-06
 check:rc==0
 cmd:grep "debug" /tftpboot/boot/grub2/grub.cfg.0a0101c8
 check:rc==0
+cmd:makedhcp -q testnode1 | grep ^testnode1:
+check:rc==0
 cmd:nodeset testnode1 offline
 check:rc==0
 cmd:grep "debug" /tftpboot/boot/grub2/testnode1
 check:rc!=0
+cmd:makedhcp -q testnode1 | grep ^testnode1:
+check:rc!=0
 cmd:chdef -t node -o testnode1 ip=
 check:rc==0
+cmd:getent hosts testnode1 | grep testnode1
+check:rc!=0
 cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-ppc64-install-compute
 check:rc!=0
 cmd:noderm testnode1
@@ -260,12 +271,18 @@ cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-ppc64le-install-compute
 check:rc==0
 cmd:grep "debug" /tftpboot/petitboot/testnode1
 check:rc==0
+cmd:makedhcp -q testnode1 | grep ^testnode1:
+check:rc==0
 cmd:nodeset testnode1 offline
 check:rc==0
 cmd:grep "debug" /tftpboot/petitboot/testnode1
 check:rc!=0
+cmd:makedhcp -q testnode1 | grep ^testnode1:
+check:rc!=0
 cmd:chdef -t node -o testnode1 ip=
 check:rc==0
+cmd:getent hosts testnode1 | grep testnode1
+check:rc!=0
 cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-ppc64le-install-compute
 check:rc!=0
 cmd:noderm testnode1
@@ -292,12 +309,18 @@ cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-ppc64-install-compute
 check:rc==0
 cmd:grep "debug" /tftpboot/yaboot.conf-e6-d4-d2-3a-ad-06
 check:rc==0
+cmd:makedhcp -q testnode1 | grep ^testnode1:
+check:rc==0
 cmd:nodeset testnode1 offline
 check:rc==0
 cmd:grep "debug" /tftpboot/yaboot.conf-e6-d4-d2-3a-ad-06
 check:rc!=0
+cmd:makedhcp -q testnode1 | grep ^testnode1:
+check:rc!=0
 cmd:chdef -t node -o testnode1 ip=
 check:rc==0
+cmd:getent hosts testnode1 | grep testnode1
+check:rc!=0
 cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-ppc64-install-compute
 check:rc!=0
 cmd:noderm testnode1


### PR DESCRIPTION
Add 3 cases in this pull request
This pull request is for task #2904

[case 1]
Case Name: nodeset_addkcmdline_grub2
description: This case is to verify when netboot=grub2, addkcmdline is correctly supported.

[case 2]
Case Name: nodeset_addkcmdline_petitboot
description: This case is to verify when netboot=petitboot, addkcmdline is correctly supported.

[case 3]
Case Name: nodeset_addkcmdline_yaboot
description: This case is to verify when netboot=yaboot, addkcmdline is correctly supported.