### PR TITLE
Remove 'stop' label from all provision cases

### DIFF
--- a/xCAT-test/autotest/testcase/installation/SN_setup_case
+++ b/xCAT-test/autotest/testcase/installation/SN_setup_case
@@ -1,6 +1,6 @@
 start:SN_setup_case
 os:Linux
-stop:yes
+#stop:yes
 cmd:fdisk -l
 cmd:df -T
 cmd:XCAT_DATABASE=$$XCAT_DATABASE /opt/xcat/share/xcat/tools/autotest/testcase/installation/pre_deploy_sn __GETNODEATTR($$SN,os)__  __GETNODEATTR($$SN,arch)__

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_flat
@@ -1,6 +1,6 @@
 start:reg_linux_diskfull_installation_flat
 os:Linux
-stop:yes
+#stop:yes
 cmd:fdisk -l
 cmd:df -T
 cmd:if ping -c 1 $$SN > /dev/null;then rpower $$SN off > /dev/null;fi

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_hierarchy
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_hierarchy
@@ -1,6 +1,6 @@
 start:reg_linux_diskfull_installation_hierarchy
 os:Linux
-stop:yes
+#stop:yes
 cmd:xdsh $$SN fdisk -l
 cmd:xdsh $$SN df -T
 cmd:xdsh $$SN "echo "test"> /test.hierarchy"

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat
@@ -1,6 +1,6 @@
 start:reg_linux_diskless_installation_flat
 os:Linux
-stop:yes
+#stop:yes
 cmd:fdisk -l
 cmd:df -T
 cmd:chdef -t node -o $$CN servicenode= monserver=$$MN nfsserver=$$MN tftpserver=$$MN  xcatmaster=$$MN

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_hierarchy
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_hierarchy
@@ -1,6 +1,6 @@
 start:reg_linux_diskless_installation_hierarchy
 os:Linux
-stop:yes
+#stop:yes
 cmd:xdsh $$SN fdisk -l
 cmd:xdsh $$SN df -T
 cmd:xdsh $$SN "echo "test"> /test.hierarchy"

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_flat
@@ -1,6 +1,6 @@
 start:reg_linux_statelite_installation_flat
 os:Linux
-stop:yes
+#stop:yes
 cmd:fdisk -l
 cmd:df -T
 

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_nfs
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_nfs
@@ -1,6 +1,6 @@
 start:reg_linux_statelite_installation_hierarchy_by_nfs
 os:Linux
-stop:yes
+#stop:yes
 cmd:xdsh $$SN fdisk -l
 cmd:xdsh $$SN df -T
 cmd:xdsh $$SN "echo "test"> /test.hierarchy"

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_ramdisk
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_ramdisk
@@ -1,6 +1,6 @@
 start:reg_linux_statelite_installation_hierarchy_by_ramdisk
 os:Linux
-stop:yes
+#stop:yes
 cmd:xdsh $$SN fdisk -l
 cmd:xdsh $$SN df -T
 cmd:xdsh $$SN "echo "test"> /test.hierarchy"


### PR DESCRIPTION
Due to not find useful information and can not stop any more, so remove ``stop`` label from provision cases. Will add in the future if needed.