### PR TITLE
fix issue 2797 and enhance confignetwork 

### DIFF
--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -457,17 +457,18 @@ enable_network_service
 
 #sort nics device pair based on nicdevice type
 sorted_nicdevice_list=`sort_nics_device_order "$new_nicdevice"`
-log_info "All valid nics and device list:"
-echo "$sorted_nicdevice_list" |log_lines info
 
 #If there is invalid nics pair, errorcode is 1
-echo "$sorted_nicdevice_list" | grep "Error" > /dev/null
+invalid_nicdevice_pair=`echo "$sorted_nicdevice_list" | grep "Error"`
 if [ $? -eq 0 ]; then
+log_error $invalid_nicdevice_pair
 errorcode=1
 fi
 
 #delete invalid nics device pair based on Error
 valid_sorted_nicdevice_list=`echo "$sorted_nicdevice_list" | sed '/Error/d'` 
+log_info "All valid nics and device list:"
+echo "$valid_sorted_nicdevice_list" |log_lines info
 
 #config nics and ifcfg files
 configure_nicdevice "$valid_sorted_nicdevice_list"

--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -215,93 +215,94 @@ function find_nic_and_device_list {
 #
 ###############################################################################
 function sort_nics_device_order {
+
     all_nics_list=$*
     eth_slot=""
     bond_slot=""
     vlan_slot=""
     num=1
-
     alone_nics=`echo "$all_nics_list"|awk '{if(0<NF&&NF<2) print $0}'`
     nics_list=`echo "$all_nics_list"|awk '{if(NF>1) print $0}'`
-
+ 
     #find stand alone nic
     num1=1
     max1=`echo "$alone_nics"|wc -l`
     ((max1+=1))
     while [ $num1 -lt $max1 ];
     do
-        alonenic=`echo "$alone_nics"|sed -n "${num1}p"`
+        alonenic=`echo "$alone_nics"|sed -n "${num1}p"|sed "s/ //g"`
         echo "$nics_list"| grep "$alonenic" >/dev/null
         if [ $? -ne 0 ]; then
             echo $alonenic
         fi
         ((num1+=1))
     done
-
     #
-    num=1
-    max=`echo "$nics_list"|wc -l`
-    ((max+=1))
-    while [ $num -lt $max ];
-    do
-        #for each nic and nicdevice : nic_dev base_nic_dev
-        #find nic type as nic_dev_type
-        #find nicdevice type as base_nic_type
-        base_nic_dev=`echo "$nics_list" |sed -n "${num}p"|awk '{print $2}'`
-        if echo "$base_nic_dev"|grep "@" >/dev/null; then
-            for i in `echo "$base_nic_dev" |sed 's/@/ /g'`
-            do
-                temp_base_nic_type=`find_nic_type "$i"`
-                if [ x"$temp_base_nic_type_one" = x ]; then
-                    temp_base_nic_type_one=$temp_base_nic_type
-                elif [ x"$temp_base_nic_type" != x"$temp_base_nic_type_one" ]; then
-                    log_error "different nic device types in $base_nic_dev."
-                    break 2
-                fi
-            done
-        else
-            temp_base_nic_dev=$base_nic_dev
-            temp_base_nic_type=`find_nic_type "$temp_base_nic_dev"`
-        fi
+    if [ -n "$nics_list" ]; then 
+        num=1
+        max=`echo "$nics_list"|wc -l`
+        ((max+=1))
+        while [ $num -lt $max ];
+        do
+            #for each nic and nicdevice : nic_dev base_nic_dev
+            #find nic type as nic_dev_type
+            #find nicdevice type as base_nic_type
+            base_nic_dev=`echo "$nics_list" |sed -n "${num}p"|awk '{print $2}'`
+            if echo "$base_nic_dev"|grep "@" >/dev/null; then
+                for i in `echo "$base_nic_dev" |sed 's/@/ /g'`
+                do
+                    temp_base_nic_type=`find_nic_type "$i" | $utolcmd`
+                    if [ x"$temp_base_nic_type_one" = x ]; then
+                        temp_base_nic_type_one=$temp_base_nic_type
+                    elif [ x"$temp_base_nic_type" != x"$temp_base_nic_type_one" ]; then
+                        log_error "different nic device types in $base_nic_dev."
+                        break 2
+                    fi
+                done
+            else
+                temp_base_nic_dev=$base_nic_dev
+                temp_base_nic_type=`find_nic_type "$temp_base_nic_dev" | $utolcmd`
+            fi
 
-        base_nic_type=$temp_base_nic_type
-        nic_dev=`echo "$nics_list" |sed -n "${num}p"|awk '{print $1}'`
-        nic_dev_type=`find_nic_type "$nic_dev"`
+            base_nic_type=$temp_base_nic_type
+            nic_dev=`echo "$nics_list" |sed -n "${num}p"|awk '{print $1}'`
+            nic_dev_type=`find_nic_type "$nic_dev" | $utolcmd`
 
-        #valid nic_dev and base_nic_dev pair as  bond-ethernet or vlan-ethernet or bridge-ethernet
-        if [ x"$base_nic_type" = "xethernet" ]&& \
-           [ x"$nic_dev_type" = "xbond" -o x"$nic_dev_type" = "xvlan" -o x"$nic_dev_type" = "xbridge" -o x"$nic_dev_type" = "xbridge_ovs" ]; then
+            #valid nic_dev and base_nic_dev pair as  bond-ethernet or vlan-ethernet or bridge-ethernet
+            if [ x"$base_nic_type" = "xethernet" ]&& \
+               [ x"$nic_dev_type" = "xbond" -o x"$nic_dev_type" = "xvlan" -o x"$nic_dev_type" = "xbridge" -o x"$nic_dev_type" = "xbridge_ovs" ]; then
             
-            if [ x"$eth_slot" = x ]; then
-                eth_slot=$num
+                if [ x"$eth_slot" = x ]; then
+                    eth_slot=$num
+                else
+                    eth_slot=$eth_slot" "$num
+                fi
+
+            #valid nic_dev and base_nic_dev pair as vlan-bond or bridge-bond
+            elif [ x"$base_nic_type" = "xbond" ]&& \
+                [ x"$nic_dev_type" = "xvlan" -o x"$nic_dev_type" = "xbridge" -o x"$nic_dev_type" = "xbridge_ovs" ]; then
+
+                if [ x"$bond_slot" = x ]; then
+                     bond_slot=$num
+                else
+                     bond_slot=$bond_slot" "$num
+                fi
+
+            #valid nic_dev and base_nic_dev pair as bridge-vlan
+            elif [ x"$base_nic_type" = "xvlan" ]&& \
+                [ x"$nic_dev_type" = "xbridge" -o x"$nic_dev_type" = "xbridge_ovs" ]; then
+
+                if [ x"$vlan_slot" = x ]; then
+                    vlan_slot=$num
+                else
+                    vlan_slot=$vlan_slot" "$num
+                fi
             else
-                eth_slot=$eth_slot" "$num
+                echo "Error: $nic_dev $base_nic_dev pair is invalid nic and nicdevice pair."
             fi
-
-        #valid nic_dev and base_nic_dev pair as vlan-bond or bridge-bond
-        elif [ x"$base_nic_type" = "xbond" ]&& \
-            [ x"$nic_dev_type" = "xvlan" -o x"$nic_dev_type" = "xbridge" -o x"$nic_dev_type" = "xbridge_ovs" ]; then
-
-            if [ x"$bond_slot" = x ]; then
-                bond_slot=$num
-            else
-                bond_slot=$bond_slot" "$num
-            fi
-
-        #valid nic_dev and base_nic_dev pair as bridge-vlan
-        elif [ x"$base_nic_type" = "xvlan" ]&& \
-            [ x"$nic_dev_type" = "xbridge" -o x"$nic_dev_type" = "xbridge_ovs" ]; then
-
-            if [ x"$vlan_slot" = x ]; then
-                vlan_slot=$num
-            else
-                vlan_slot=$vlan_slot" "$num
-            fi
-        else
-            log_error "Error: $nic_dev $base_nic_dev pair is invalid nic and nicdevice pair."
-        fi
-        ((num+=1))
-    done
+            ((num+=1))
+        done
+    fi
     new_order=$eth_slot" "$bond_slot" "$vlan_slot
     new_order_list=""
     if [ -n "$new_order" ]; then
@@ -312,7 +313,6 @@ function sort_nics_device_order {
             echo "$nics_list" |sed -n "${i}p"
         done`
     fi
-
     echo "$new_order_list" 
 }
 
@@ -326,15 +326,13 @@ function sort_nics_device_order {
 ###################################################################################
 function configure_nicdevice {
     nics_pair=$*
-    #nictypes support capital letters, for example, Ethernet and ethernet
-    #use $utolcmd to transform capital to lower case
-    utolcmd="sed -e y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/"
     #configure nic and its device pair one by one   
     num=1
     max=`echo "$nics_pair"|wc -l`
     base_temp_nic=""
     base_nic_for_bond=""
     line_num=""
+    noip=1
     ((max+=1))
     while [ $num -lt $max ];
     do
@@ -354,22 +352,25 @@ function configure_nicdevice {
         echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
         nic_pair=`echo "$nics_pair" |sed -n "${num}p"`
         echo "configure nic and its device : $nic_pair"
-
         #configure standalone ethernet nic
         if [ x"$nic_dev_type" = "xethernet" ]; then
-
+            
             ipaddr=`find_nic_ips $nic_dev|awk -F"|" '{print $1}'`
             if [ -n "$ipaddr" ]; then
                 create_ethernet_interface ifname=$nic_dev _ipaddr=$ipaddr
             else
-                log_error "There is no ip for $nic_dev."
+                log_warn "There is no ip for $nic_dev."
+                ((noip+=1))
             fi
-
+            #All Ethernet nics have no nicips
+            if [ $noip -eq $max ]; then
+                log_error "There is no any ip configured for any nic. Check nicips in nics table first."
+                errorcode=1
+            fi 
         #configure bridge
         #linux bridge type is bridge
         #openvswitch bridge type is bridge_ovs
         elif [ x"$nic_dev_type" = "xbridge_ovs" -o x"$nic_dev_type" = "xbridge" ]; then
-
             create_bridge_interface ifname=$nic_dev _brtype=$nic_dev_type _port=$base_nic_dev _pretype=$base_nic_type
      
         #configure vlan 
@@ -388,10 +389,12 @@ function configure_nicdevice {
             create_bond_interface ifname=$nic_dev slave_ports=$base_nic_for_bond       
         else
             log_error "Error : please check nictypes for $nic_pair."
+            errorcode=1
         fi 
 
         ((num+=1))
     done
+    return $errorcode
 }
 
 ############################################################################
@@ -419,6 +422,11 @@ function enable_network_service {
 # Main process
 #
 ############################################################################
+
+errorcode=0
+
+#nictypes should support capital letters, for example, Ethernet and ethernet
+utolcmd="sed -e y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/"
 
 #replace | with "@", for example, eth1|eth2  ---->   eth1@eth2
 nicdevice=`echo "$NICDEVICES" | sed 's/|/@/g'`
@@ -452,7 +460,15 @@ sorted_nicdevice_list=`sort_nics_device_order "$new_nicdevice"`
 log_info "All valid nics and device list:"
 echo "$sorted_nicdevice_list" |log_lines info
 
+#If there is invalid nics pair, errorcode is 1
+echo "$sorted_nicdevice_list" | grep "Error" > /dev/null
+if [ $? -eq 0 ]; then
+errorcode=1
+fi
 
+#delete invalid nics device pair based on Error
+valid_sorted_nicdevice_list=`echo "$sorted_nicdevice_list" | sed '/Error/d'` 
 
 #config nics and ifcfg files
-configure_nicdevice "$sorted_nicdevice_list"
+configure_nicdevice "$valid_sorted_nicdevice_list"
+exit $errorcode

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -635,11 +635,11 @@ function add_br() {
      BRIDGE=$2
 
      if [[ $BRIDGE == "bridge_ovs" ]]; then
-         type brctl >/dev/null 2>/dev/null || echo "There is no ovs-vsctl" >&2 && exit 1
+         type brctl >/dev/null 2>/dev/null || (echo "There is no ovs-vsctl" >&2 && exit 1)
          log_info "ovs-vsctl add-br $BNAME"
          ovs-vsctl add-br $BNAME
      elif [[ $BRIDGE == "bridge" ]]; then
-         type brctl >/dev/null 2>/dev/null || echo "There is no brctl" >&2 && exit 1
+         type brctl >/dev/null 2>/dev/null || (echo "There is no brctl" >&2 && exit 1)
          log_info "brctl addbr $BNAME" 
          brctl addbr $BNAME
          log_info "brctl stp $BNAME on"


### PR DESCRIPTION
fix issue #2797 

fix the issue:
nicutils.sh
1, if there is no brctl, print error and exit 1.

confignetwork enhance framework always return 0:
1, if user only configures Ethernet nic, and there is no any nicips in nics table, exit 1; If there is one or  nicips, configure ips, exit 0; 
2, if user configure both Ethernet nic and other nics, when nic base device does not match nic device, exit 1;
3, enhance support capital letter in nictypes;

Unit test:
1, Only configure Ethernet nic and there is no any nicips in nics talbe issue #2797 :
```
[root@byrh13 postscripts]# tabdump nics
#node,nicips,nichostnamesuffixes,nichostnameprefixes,nictypes,niccustomscripts,nicnetworks,nicaliases,nicextraparams,nicdevices,nicsadapter,comments,disable
"bytest15",,,,"eth1!Ethernet,eth0!Ethernet",,"eth0!10_0_0_0-255_0_0_0,eth0!20_0_0_0-255_0_0_0",,,,,,
[root@byrh13 postscripts]# updatenode bytest15 confignetwork -V
Running command on byrh13: /bin/hostname 2>&1

Running command on byrh13: ip -4 --oneline addr show |awk -F ' ' '{print $4}'|awk -F '/' '{print $1}' 2>&1

Running command on byrh13: /bin/hostname 2>&1

Running command on byrh13: ip -4 --oneline addr show |awk -F ' ' '{print $4}'|awk -F '/' '{print $1}' 2>&1

Running command on byrh13: chmod -R a+r /install/postscripts 2>&1

  byrh13: Internal call command: xdsh bytest15 --nodestatus -s -v -e /install/postscripts/xcatdsklspost 1 -m 20.4.41.13 'confignetwork' --tftp /tftpboot --installdir /install --nfsv4 no -c -V
Running command on byrh13: /bin/hostname 2>&1
Running command on byrh13: ip -4 --oneline addr show |awk -F ' ' '{print $4}'|awk -F '/' '{print $1}' 2>&1
Running command on byrh13: hostname 2>&1
Running command on byrh13: /opt/xcat/bin/pping bytest15 2>&1
bytest15: running /tmp/filedf4Ofm.dsh 1 -m 20.4.41.13 confignetwork --tftp /tftpboot --installdir /install --nfsv4 no -c -V
bytest15: xcatdsklspost : trying to download postscripts from http://20.4.41.13/install/postscripts/
bytest15: /tmp/filedf4Ofm.dsh : download_postscripts return successfully
bytest15: xcatdsklspost: downloaded postscripts successfully
bytest15: /tmp/filedf4Ofm.dsh :  trying to download http://20.4.41.13/tftpboot/mypostscripts/mypostscript.bytest15
bytest15: /tmp/filedf4Ofm.dsh download_mypostscript return successfully
bytest15: running //xcatpost/mypostscript
bytest15: Thu Jun  1 02:56:35 UTC 2017 Running postscript: confignetwork
bytest15: [I]: NetworkManager is inactive.
bytest15: [I]: All valid nics and device list:
bytest15: [I]: eth0
bytest15: [I]: eth1
bytest15: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bytest15: configure nic and its device : eth0
bytest15: [W]: There is no ip for eth0.
bytest15: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bytest15: configure nic and its device : eth1
bytest15: [W]: There is no ip for eth1.
bytest15: [E]: There is no any ip configured for any nic. Check nicips in nics table first.
bytest15: postscript: confignetwork exited with code 1
bytest15: //xcatpost/mypostscript return with 1
bytest15: Running of postscripts has completed.
```
2, user wants to configure one Ethernet nic and one bridge, all work well and exit 0:
```
[root@byrh13 postscripts]# tabdump nics
#node,nicips,nichostnamesuffixes,nichostnameprefixes,nictypes,niccustomscripts,nicnetworks,nicaliases,nicextraparams,nicdevices,nicsadapter,comments,disable
"bytest15","eth0!20.4.41.15,br0!10.4.41.15",,,"eth1!Ethernet,eth0!Ethernet,br0!bridge",,"br0!10_0_0_0-255_0_0_0,eth0!20_0_0_0-255_0_0_0",,,"br0!eth1",,,
[root@byrh13 postscripts]#
[root@byrh13 postscripts]# updatenode bytest15 confignetwork -V
Running command on byrh13: /bin/hostname 2>&1

Running command on byrh13: ip -4 --oneline addr show |awk -F ' ' '{print $4}'|awk -F '/' '{print $1}' 2>&1

Running command on byrh13: /bin/hostname 2>&1

Running command on byrh13: ip -4 --oneline addr show |awk -F ' ' '{print $4}'|awk -F '/' '{print $1}' 2>&1

Running command on byrh13: chmod -R a+r /install/postscripts 2>&1

  byrh13: Internal call command: xdsh bytest15 --nodestatus -s -v -e /install/postscripts/xcatdsklspost 1 -m 20.4.41.13 'confignetwork' --tftp /tftpboot --installdir /install --nfsv4 no -c -V
Running command on byrh13: /bin/hostname 2>&1
Running command on byrh13: ip -4 --oneline addr show |awk -F ' ' '{print $4}'|awk -F '/' '{print $1}' 2>&1
Running command on byrh13: hostname 2>&1
Running command on byrh13: /opt/xcat/bin/pping bytest15 2>&1
bytest15: running /tmp/fileeCWt4S.dsh 1 -m 20.4.41.13 confignetwork --tftp /tftpboot --installdir /install --nfsv4 no -c -V
bytest15: xcatdsklspost : trying to download postscripts from http://20.4.41.13/install/postscripts/
bytest15: /tmp/fileeCWt4S.dsh : download_postscripts return successfully
bytest15: xcatdsklspost: downloaded postscripts successfully
bytest15: /tmp/fileeCWt4S.dsh :  trying to download http://20.4.41.13/tftpboot/mypostscripts/mypostscript.bytest15
bytest15: /tmp/fileeCWt4S.dsh download_mypostscript return successfully
bytest15: running //xcatpost/mypostscript
bytest15: Thu Jun  1 02:59:48 UTC 2017 Running postscript: confignetwork
bytest15: [I]: NetworkManager is inactive.
bytest15: [I]: All valid nics and device list:
bytest15: [I]: eth0
bytest15: [I]: eth1
bytest15: [I]: br0 eth1
bytest15: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bytest15: configure nic and its device : eth0
bytest15: [I]: create_ethernet_interface ifname=eth0 _ipaddr=20.4.41.15
bytest15: [I]: create_persistent_ifcfg ifname=eth0 xcatnet=20_0_0_0-255_0_0_0 _ipaddr=20.4.41.15 _netmask= inattrs=ONBOOT=yes,USERCTL=no,TYPE=Ethernet,MTU=1500
bytest15: ['ifcfg-eth0']
bytest15: [I]: >> DEVICE="eth0"
bytest15: [I]: >> BOOTPROTO="static"
bytest15: [I]: >> IPADDR="20.4.41.15"
bytest15: [I]: >> NETMASK="255.0.0.0"
bytest15: [I]: >> MTU="1500"
bytest15: [I]: >> NAME="eth0"
bytest15: [I]: >> HWADDR="42:84:14:04:29:0f"
bytest15: [I]: >> ONBOOT="yes"
bytest15: [I]: >> USERCTL="no"
bytest15: [I]: >> TYPE="Ethernet"
bytest15: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bytest15: configure nic and its device : eth1
bytest15: [W]: There is no ip for eth1.
bytest15: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bytest15: configure nic and its device : br0 eth1
bytest15: [I]: create_bridge_interface ifname=br0 _brtype=bridge _port=eth1 _pretype=ethernet
bytest15: [I]: Pickup xcatnet, "10_0_0_0-255_0_0_0", from NICNETWORKS for interface "br0".
bytest15: [I]: create_raw_eth_interface_for_br ifname=eth1 _bridge=br0 _mtu=1500
bytest15: [I]: create_persistent_ifcfg ifname=eth1 inattrs=ONBOOT=yes,TYPE=Ethernet,BRIDGE=br0,BOOTPROTO=none,MTU=1500
bytest15: ['ifcfg-eth1']
bytest15: [I]: >> DEVICE="eth1"
bytest15: [I]: >> BOOTPROTO="none"
bytest15: [I]: >> NAME="eth1"
bytest15: [I]: >> HWADDR="42:e5:14:04:29:0f"
bytest15: [I]: >> ONBOOT="yes"
bytest15: [I]: >> TYPE="Ethernet"
bytest15: [I]: >> BRIDGE="br0"
bytest15: [I]: >> MTU="1500"
bytest15: [I]: brctl addbr br0
bytest15: [I]: brctl stp br0 on
bytest15: [I]: brctl addif br0 eth1
bytest15: [I]: migrate_ip ifname=br0 sports=eth1
bytest15: [I]: create_persistent_ifcfg ifname=br0 xcatnet=10_0_0_0-255_0_0_0 inattrs=ONBOOT=yes,STP=on,TYPE=Bridge,MTU=1500
bytest15: ['ifcfg-br0']
bytest15: [I]: >> DEVICE="br0"
bytest15: [I]: >> BOOTPROTO="static"
bytest15: [I]: >> IPADDR="10.4.41.15"
bytest15: [I]: >> NETMASK="255.0.0.0"
bytest15: [I]: >> MTU="1500"
bytest15: [I]: >> NAME="br0"
bytest15: [I]: >> ONBOOT="yes"
bytest15: [I]: >> STP="on"
bytest15: [I]: >> TYPE="Bridge"
bytest15: postscript: confignetwork exited with code 0
bytest15: //xcatpost/mypostscript return with 0
bytest15: Running of postscripts has completed.
```

3, user wants to configure one Ethernet ip, and create one bridge, but he writes wrong nicdevices eth1!br0:
```
[root@byrh13 postscripts]# tabdump nics
#node,nicips,nichostnamesuffixes,nichostnameprefixes,nictypes,niccustomscripts,nicnetworks,nicaliases,nicextraparams,nicdevices,nicsadapter,comments,disable
"bytest15","eth0!20.4.41.15,br0!10.4.41.15",,,"eth1!Ethernet,eth0!Ethernet,br0!bridge",,"br0!10_0_0_0-255_0_0_0,eth0!20_0_0_0-255_0_0_0",,,"eth1!br0",,,
[root@byrh13 postscripts]# updatenode bytest15 confignetwork -V
Running command on byrh13: /bin/hostname 2>&1

Running command on byrh13: ip -4 --oneline addr show |awk -F ' ' '{print $4}'|awk -F '/' '{print $1}' 2>&1

Running command on byrh13: /bin/hostname 2>&1

Running command on byrh13: ip -4 --oneline addr show |awk -F ' ' '{print $4}'|awk -F '/' '{print $1}' 2>&1

Running command on byrh13: chmod -R a+r /install/postscripts 2>&1

  byrh13: Internal call command: xdsh bytest15 --nodestatus -s -v -e /install/postscripts/xcatdsklspost 1 -m 20.4.41.13 'confignetwork' --tftp /tftpboot --installdir /install --nfsv4 no -c -V
Running command on byrh13: /bin/hostname 2>&1
Running command on byrh13: ip -4 --oneline addr show |awk -F ' ' '{print $4}'|awk -F '/' '{print $1}' 2>&1
Running command on byrh13: hostname 2>&1
Running command on byrh13: /opt/xcat/bin/pping bytest15 2>&1
bytest15: running /tmp/fileZpH5xK.dsh 1 -m 20.4.41.13 confignetwork --tftp /tftpboot --installdir /install --nfsv4 no -c -V
bytest15: xcatdsklspost : trying to download postscripts from http://20.4.41.13/install/postscripts/
bytest15: /tmp/fileZpH5xK.dsh : download_postscripts return successfully
bytest15: xcatdsklspost: downloaded postscripts successfully
bytest15: /tmp/fileZpH5xK.dsh :  trying to download http://20.4.41.13/tftpboot/mypostscripts/mypostscript.bytest15
bytest15: /tmp/fileZpH5xK.dsh download_mypostscript return successfully
bytest15: running //xcatpost/mypostscript
bytest15: Thu Jun  1 08:15:07 UTC 2017 Running postscript: confignetwork
bytest15: [I]: NetworkManager is inactive.
bytest15: [I]: All valid nics and device list:
bytest15: [I]: eth0
bytest15: [I]: Error: eth1 br0 pair is invalid nic and nicdevice pair.
bytest15: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bytest15: configure nic and its device : eth0
bytest15: [I]: create_ethernet_interface ifname=eth0 _ipaddr=20.4.41.15
bytest15: [I]: create_persistent_ifcfg ifname=eth0 xcatnet=20_0_0_0-255_0_0_0 _ipaddr=20.4.41.15 _netmask= inattrs=ONBOOT=yes,USERCTL=no,TYPE=Ethernet,MTU=1500
bytest15: ['ifcfg-eth0']
bytest15: [I]: >> DEVICE="eth0"
bytest15: [I]: >> BOOTPROTO="static"
bytest15: [I]: >> IPADDR="20.4.41.15"
bytest15: [I]: >> NETMASK="255.0.0.0"
bytest15: [I]: >> MTU="1500"
bytest15: [I]: >> NAME="eth0"
bytest15: [I]: >> HWADDR="42:84:14:04:29:0f"
bytest15: [I]: >> ONBOOT="yes"
bytest15: [I]: >> USERCTL="no"
bytest15: [I]: >> TYPE="Ethernet"
bytest15: postscript: confignetwork exited with code 1
bytest15: //xcatpost/mypostscript return with 1
bytest15: Running of postscripts has completed.
```