### PR TITLE
rewrite if-clause in post.rhels7

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/post.rhels7
+++ b/xCAT-server/share/xcat/install/scripts/post.rhels7
@@ -9,11 +9,11 @@
 for i in $(find /etc/sysconfig/network-scripts/ifcfg-*|egrep -v ifcfg-lo )
 do 
   nicname=$(echo $i|awk -F 'ifcfg-' '{print $2}')
-  if ethtool $nicname|grep -E -i "Link detected.*yes" >/dev/null 2>&1
+  if ethtool $nicname|grep -E -i "Link detected.*yes" >/dev/null 2>&1; then
      if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
         msgutil_r "$MASTER_IP" "info" "set NIC $nicname to be activated on system boot" "/var/log/xcat/xcat.log"
      fi
-     then sed -i 's/ONBOOT=no/ONBOOT=yes/' $i 
+     sed -i 's/ONBOOT=no/ONBOOT=yes/' $i 
   fi
 
   #remove the entry 'HWADDR' from ifcfg-ethx, this is used to skip the 


### PR DESCRIPTION
the original if clause does not check the interfaces correctly. moving the "then" of the if up a bit makes it a) nice to read and b) work as expected.
I had trouble with enabled (onboot=yes) interfaces, despite not having a link at all.