### PR TITLE
Support rflash command -c option for OpenBMC

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -463,6 +463,10 @@ sub parse_args {
             return ([ 1, "Unsupported command: $command $subcommand" ]);
         }
     } elsif ($command eq "rflash") {
+        #
+        # disable function until fully tested
+        #
+        $check = unsupported($callback); if (ref($check) eq "ARRAY") { return $check; }
         my $filename_passed = 0;
         foreach my $opt (@$extrargs) {
             # Only files ending on .tar are allowed


### PR DESCRIPTION
Implement code for issue #3156 
This pull request produces the following output when running `rflash` command against OpenBMC endopoint:

1. Unsupported flag specified, no update file specified:
```
[root@stratton01 xcat]# rflash p9euh01 -a
Unsupported no file command command option: -a
[root@stratton01 xcat]#
```

2. Unsupported flag specified, update file specified:
```
[root@stratton01 xcat]# rflash p9euh01  /tmp/gurevich/pnor.squashfs.tar -a
Unsupported file command option: -a
[root@stratton01 xcat]#
```

3. Supported flag specified, function not yet implemented:
```
[root@stratton01 xcat]# rflash p9euh01 -l
List option is not yet supported.
[root@stratton01 xcat]#
```

4. Supported flag specified, but not valid with an update file specification
```
[root@stratton01 xcat]# rflash p9euh01  /tmp/gurevich/pnor.squashfs.tar -l
Unsupported file command option: -l
[root@stratton01 xcat]#
```

5. Supported flag specified, but not valid without an update file specification
```
[root@stratton01 xcat]# rflash p9euh01 -d
Unsupported no file command command option: -d
[root@stratton01 xcat]#
```

6. Check version flag without update file specification, single node endpoint
```
[root@stratton01 xcat]# rflash p9euh01 -c
p9euh01: System Firmware Product Version: v1.99.6-19-gab8de5b
p9euh01: System Firmware Product Version: IBM-witherspoon-ibm-OP9_v1.16_1.24
[root@stratton01 xcat]#
```

7. Check version flag without update file specification, multiple node endpoint
```
[root@stratton01 xcat]# rflash p9euh01,p9euh02 -c
p9euh01: System Firmware Product Version: v1.99.6-19-gab8de5b
p9euh01: System Firmware Product Version: IBM-witherspoon-ibm-OP9_v1.16_1.24
p9euh02: System Firmware Product Version: v1.99.6-10-g1d22c22
p9euh02: System Firmware Product Version: IBM-witherspoon-ibm-OP9_v1.16_1.24
[root@stratton01 xcat]#
```

8. Check version flag with update file specification, multiple node endpoint
```
[root@stratton01 xcat]# rflash p9euh01,p9euh02  /tmp/gurevich/pnor.squashfs.tar -c
TAR Host Firmware Product Version: IBM-witherspoon-ibm-OP9_v1.16_1.24
p9euh01: System Firmware Product Version: v1.99.6-19-gab8de5b
p9euh01: System Firmware Product Version: IBM-witherspoon-ibm-OP9_v1.16_1.24
p9euh02: System Firmware Product Version: v1.99.6-10-g1d22c22
p9euh02: System Firmware Product Version: IBM-witherspoon-ibm-OP9_v1.16_1.24
[root@stratton01 xcat]#
```