### PR TITLE
Sync up the spelling to use:  OpenPOWER and OpenBMC

### DIFF
--- a/docs/source/advanced/cluster_maintenance/compute_node/replace/openpower.rst
+++ b/docs/source/advanced/cluster_maintenance/compute_node/replace/openpower.rst
@@ -1,10 +1,10 @@
-OpenPower Nodes
+OpenPOWER Nodes
 ===============
 
 
 When compute nodes are physically replaced in the frame, leverage xCAT to re-discover the compute nodes.  The following guide can be used for:
 
-  * IBM OpenPower S822LC for HPC 
+  * IBM OpenPOWER S822LC for HPC 
 
 
 #. Identify the machine(s) to be replaced: ``frame10cn02``.

--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/index.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/index.rst
@@ -1,11 +1,11 @@
-IBM Power LE / OpenPOWER
+IBM POWER LE / OpenPOWER
 =========================
 
-Most of the content is general information for xCAT, the focus and examples are for management of IBM OpenPower servers.
+Most of the content is general information for xCAT, the focus and examples are for management of IBM OpenPOWER servers.
 
-IBM OpenPower Servers
-  * based on Power8 Processor Technology is IPMI managed 
-  * based on Power9 Processor Technology is OpenBmc managed [**Alpha**]
+IBM OpenPOWER Servers
+  * based on POWER8 Processor Technology is IPMI managed 
+  * based on POWER9 Processor Technology is OpenBMC managed [**Alpha**]
 
 
 .. toctree::

--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/management/basic/rcons.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/management/basic/rcons.rst
@@ -7,11 +7,11 @@ Most enterprise servers do not have video adapters installed with the machine an
 
 Configure the correct console management by modifying the node definition:
 
-    * For OpenPower, **IPMI** managed server: ::
+    * For OpenPOWER, **IPMI** managed server: ::
 
         chdef -t node -o <noderange> cons=ipmi
 
-    * For OpenPower, **OpenBMC** managed servers: ::
+    * For OpenPOWER, **OpenBMC** managed servers: ::
  
         chdef -t node -o <noderange> cons=openbmc
 

--- a/docs/source/guides/admin-guides/references/man1/rpower.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rpower.1.rst
@@ -32,7 +32,7 @@ BMC (using IPMI):
 \ **rpower**\  \ *noderange*\  [\ **pduon | pduoff | pdustat | pdureset**\ ]
 
 
-OpenPower BMC (using IPMI):
+OpenPOWER BMC (using IPMI):
 ===========================
 
 
@@ -41,7 +41,7 @@ OpenPower BMC (using IPMI):
 \ **rpower**\  \ *noderange*\  [\ **pduon | pduoff | pdustat | pdureset**\ ]
 
 
-OpenPower OpenBMC:
+OpenPOWER OpenBMC:
 ==================
 
 

--- a/docs/source/guides/admin-guides/references/man5/openbmc.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/openbmc.5.rst
@@ -27,7 +27,7 @@ DESCRIPTION
 ***********
 
 
-Setting for nodes that are controlled by an on-board OpenBmc.
+Setting for nodes that are controlled by an on-board OpenBMC.
 
 
 *******************

--- a/docs/source/guides/admin-guides/references/man5/xcatdb.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/xcatdb.5.rst
@@ -567,7 +567,7 @@ notification(5)|notification.5
 
 openbmc(5)|openbmc.5
  
- Setting for nodes that are controlled by an on-board OpenBmc.
+ Setting for nodes that are controlled by an on-board OpenBMC.
  
 
 

--- a/docs/source/overview/xcat2_release.rst
+++ b/docs/source/overview/xcat2_release.rst
@@ -71,7 +71,7 @@ xCAT 2.12.x
 |                                 |               |             |                                  |
 +---------------------------------+---------------+-------------+----------------------------------+
 || xCAT 2.12.3                    |               |             |- GitHub Issues resolved          |
-|| 2016/09/30                     |               |             |- rinv options for OpenPower      |
+|| 2016/09/30                     |               |             |- rinv options for OpenPOWER      |
 ||                                |               |             |- switch based switch discovery   |
 | `2.12.3 Release Notes <https:// |               |             |- additional options added to     |
 | github.com/xcat2/xcat-core/wiki |               |             |  xcatprobe command               |
@@ -124,7 +124,7 @@ xCAT 2.11.x
 || 2015/12/11                     |- UBT 14.4.3 LE|- S822LC(GTA)|- Infiniband for OpenPOWER        |
 ||                                |- UBT 15.10 LE |- S812LC     |- SW KIT support for OpenPOWER    |
 | `2.11 Release Notes <https://   |- PowerKVM 3.1 |- NeuCloud OP|- renergy command for OpenPOWER   |
-| github.com/xcat2/xcat-core/     |               |- ZoomNet RP |- rflash command for OpenPower    |
+| github.com/xcat2/xcat-core/     |               |- ZoomNet RP |- rflash command for OpenPOWER    |
 | wiki/XCAT_2.11_Release_Notes>`_ |               |             |- Add xCAT Troubleshooting Log    |
 |                                 |               |             |- xCAT Log Classification         |
 |                                 |               |             |- RAID Configuration              |

--- a/perl-xCAT/xCAT/ProfiledNodeUtils.pm
+++ b/perl-xCAT/xCAT/ProfiledNodeUtils.pm
@@ -1365,7 +1365,7 @@ sub gen_chain_for_profiles {
 
     #run bmcsetups.
     #PowerNV nodes can't use 'runcmd=bmcsetup' to set BMC.
-    #But OpenPower need to support bmcsetup
+    #But OpenPOWER need to support bmcsetup
     my $nodehmtab       = xCAT::Table->new('nodehm');
     my $comments        = "";
     my $nodehmtab_entry = $nodehmtab->getNodeAttribs($hwprofile, ['comments']);

--- a/perl-xCAT/xCAT/Schema.pm
+++ b/perl-xCAT/xCAT/Schema.pm
@@ -446,7 +446,7 @@ passed as argument rather than by table value',
     openbmc => {
         cols => [qw(node bmc consport taggedvlan username password comments disable)],
         keys => [qw(node)],
-        table_desc => 'Setting for nodes that are controlled by an on-board OpenBmc.',
+        table_desc => 'Setting for nodes that are controlled by an on-board OpenBMC.',
         descriptions => {
             node => 'The node name or group name.',
             bmc => 'The hostname of the BMC adapter.',

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -29,10 +29,10 @@ my %usage = (
      BMC (using IPMI):
        rpower noderange [on|off|softoff|reset|boot|stat|state|status|wake|suspend [-w timeout] [-o] [-r]]
        rpower noderange [pduon|pduoff|pdustat]
-     OpenPower BMC:
+     OpenPOWER BMC:
        rpower noderange [on|off|reset|boot|stat|state|status]
        rpower noderange [pduon|pduoff|pdustat]
-     OpenPower OpenBMC:
+     OpenPOWER OpenBMC:
        rpower noderange [on|off|reset|boot|stat|state|status]
      KVM Virtualization specific:
        rpower <noderange> [boot] [ -c <path to iso> ]

--- a/xCAT-client/pods/man1/rpower.1.pod
+++ b/xCAT-client/pods/man1/rpower.1.pod
@@ -14,13 +14,13 @@ B<rpower> I<noderange> [B<on>|B<off>|B<softoff>|B<reset>|B<boot>|B<stat>|B<state
 
 B<rpower> I<noderange> [B<pduon>|B<pduoff>|B<pdustat>|B<pdureset>]
 
-=head2 OpenPower BMC (using IPMI):
+=head2 OpenPOWER BMC (using IPMI):
 
 B<rpower> I<noderange> [B<on>|B<off>|B<reset>|B<boot>|B<stat>|B<state>|B<status>]
 
 B<rpower> I<noderange> [B<pduon>|B<pduoff>|B<pdustat>|B<pdureset>]
 
-=head2 OpenPower OpenBMC:
+=head2 OpenPOWER OpenBMC:
 
 B<rpower> I<noderange> [B<off>|B<on>|B<reset>|B<boot>|B<stat>|B<state>|B<status>]
 

--- a/xCAT-genesis-scripts/bin/bmcsetup
+++ b/xCAT-genesis-scripts/bin/bmcsetup
@@ -37,7 +37,7 @@ function cold_reset_bmc() {
     fi
     if [ "$XPROD" = "309" -o "$XPROD" = "43707" ] ; then
         if [ "$XPROD" = "43707" ]; then
-            # OpenPower SPECIFIC, the OpenPower machines with AMI BMC should NOT need a 
+            # OpenPOWER SPECIFIC, the OpenPOWER machines with AMI BMC should NOT need a 
             # reset after applying ipmitool commands.  However, it seems there is a problem with 
             # the BMC where after 15 seconds, it stops responding.  To work around, sleep 30
             # seconds before issuing the reset of the BMC.
@@ -49,7 +49,7 @@ function cold_reset_bmc() {
         fi
 
         if [ "$XPROD" = "43707" ]; then
-            # OpenPower SPECIFIC, check the BMC with the following raw command to
+            # OpenPOWER SPECIFIC, check the BMC with the following raw command to
             # make sure that the bmc is really in a "ready" state before continuing 
             SLEEP_INTERVAL=3
             MAX_ITERATION=100
@@ -65,7 +65,7 @@ function cold_reset_bmc() {
             TOTAL_SEC=$((${SLEEP_INTERVAL} * ${MAX_ITERATION}))
             logger -s -t $log_label -p local4.error "ERROR, After waiting ${TOTAL_SEC} seconds, the BMC is not in a ready state."
         else
-            # for Non OpenPower servers, just sleep for some set time.
+            # for Non OpenPOWER servers, just sleep for some set time.
             sleep 15 
 
             TRIES=0
@@ -82,7 +82,7 @@ function cold_reset_bmc() {
 #
 # Function snooze()
 #
-# The purpose of this is to work around the issue with OpenPower BMCs after 
+# The purpose of this is to work around the issue with OpenPOWER BMCs after 
 # making a change to network configuration, sleep 30 to be sure the changes apply.
 #
 function snooze() { 
@@ -95,8 +95,8 @@ function snooze() {
         return
     fi
     if [ "$XPROD" = "43707" ]; then
-        # For OpenPower Machines 
-        logger -s -t $log_label -p local4.debug "OpenPower, snooze for 30 seconds..."
+        # For OpenPOWER Machines 
+        logger -s -t $log_label -p local4.debug "OpenPOWER, snooze for 30 seconds..."
         sleep 30
     else
         logger -s -t $log_label -p local4.debug "snooze for 1 second..."
@@ -167,7 +167,7 @@ logger -s -t $log_label -p local4.info "IPMIVER=$IPMIVER, IPMIMFG=$IPMIMFG, XPRO
 
 #
 # IPMIMFG=2 = IBM
-# IPMIMFG=0 = OpenPower 
+# IPMIMFG=0 = OpenPOWER 
 # IPMIMFG=42817 and XPROD=16975 = OpenBMC
 #
 if [ "$IPMIMFG" == 2 ]; then #IBM
@@ -416,7 +416,7 @@ if [ ! -z "$ISOPENBMC" ]; then
     rm -f /tmp/ipmicfg.xml
     exit $bmc_config_rc
 fi
-# After network commands are issued, pause to allow the BMC to apply (OpenPower)
+# After network commands are issued, pause to allow the BMC to apply (OpenPOWER)
 snooze 
 
 let idev=NUMBMCS-1
@@ -646,7 +646,7 @@ while [ $idev -gt 0 ]; do
 
     logger -s -t $log_label -p local4.info "Lighting Identify Light"
     if [ "$XPROD" = "43707" -a "$IPMIMFG" = '0' ]; then
-        # OpenPower BMC specific, turn on the LED beacon light.  
+        # OpenPOWER BMC specific, turn on the LED beacon light.  
         #   - default interval, # ipmitool chassis identify
         #                         Chassis identify interval: default (15 seconds)
         #   - 275 is too large, # ipmitool chassis identify 275

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -2535,7 +2535,7 @@ sub power {
     my $code;
 
     if (($sessdata->{subcommand} !~ /^on$|^off$|^reset$|^boot$|^stat$|^state$|^status$/) and isopenpower($sessdata)) {
-        xCAT::SvrUtils::sendmsg([ 1, "unsupported command rpower $sessdata->{subcommand} for OpenPower" ], $callback, $sessdata->{node}, %allerrornodes);
+        xCAT::SvrUtils::sendmsg([ 1, "unsupported command rpower $sessdata->{subcommand} for OpenPOWER" ], $callback, $sessdata->{node}, %allerrornodes);
         return;
     }
 


### PR DESCRIPTION
In the various places, document, comment, man pages, sync up the spelling to be
* OpenPOWER
* OpenBMC 
