### PR TITLE
[WIP]Fix for #2939: Add `-d` option for `makeknownhosts` as alias for `-r`

### DIFF
--- a/xCAT-client/pods/man8/makeknownhosts.8.pod
+++ b/xCAT-client/pods/man8/makeknownhosts.8.pod
@@ -4,7 +4,7 @@ B<makeknownhosts> - Make a known_hosts file under $ROOTHOME/.ssh for input noder
 
 =head1 SYNOPSIS
 
-B<makeknownhosts> I<noderange> [B<-r>|B<--remove>] [B<-V>|B<--verbose>]
+B<makeknownhosts> I<noderange> [B<-r>|B<--remove>|B<-d>|B<--delete>] [B<-V>|B<--verbose>]
 
 B<makeknownhosts> [B<-h>|B<--help>]
 
@@ -29,9 +29,13 @@ The file should be distributed using B<xdcp> to all the nodes, if you want node 
 A set of comma delimited node names and/or group names.
 See the I<noderange> man page for details on supported formats.
 
-=item B<-r|--remove>
+=item B<-d|--delete>
 
 Only removes the entries for the nodes from the known_hosts file.
+
+=item B<-r|--remove>
+
+Synonymous to B<-d|--delete>.
 
 =item B<-V|--verbose>
 
@@ -56,7 +60,7 @@ To build the known_hosts entry for the nodes in the lpars and service groups
 =item 3.
 To remove the known_hosts entry for node02
 
- makeknownhosts node02 -r
+ makeknownhosts node02 -d
 
 =back
 

--- a/xCAT-server/lib/xcat/plugins/00kitnodebase.pm
+++ b/xCAT-server/lib/xcat/plugins/00kitnodebase.pm
@@ -130,7 +130,7 @@ sub process_request {
         if ($runconservercmd) {
             push @commandslist, [ 'makeconservercf', '-d' ];
         }
-        push @commandslist, [ 'makeknownhosts', '-r' ];
+        push @commandslist, [ 'makeknownhosts', '-d' ];
         if ($macflag) {
             push @commandslist, [ 'makedhcp', '-d' ];
         }

--- a/xCAT-test/autotest/testcase/makeknownhosts/cases0
+++ b/xCAT-test/autotest/testcase/makeknownhosts/cases0
@@ -28,6 +28,18 @@ check:rc!=0
 check:output!~$$CN
 end
 
+start:makeknownhosts_node_d
+description:delete known node entry from $ROOTHOME/.ssh
+cmd:makeknownhosts $$CN 
+cmd:cat ~/.ssh/known_hosts|grep $$CN
+check:output=~$$CN
+cmd:makeknownhosts $$CN -d
+check:rc==0
+cmd:cat ~/.ssh/known_hosts|grep $$CN
+check:rc!=0
+check:output!~$$CN
+end
+
 start:makeknownhosts_node_v
 description:verbose
 cmd:makeknownhosts $$CN -V


### PR DESCRIPTION
This is an effort to fix issue #2939

@whowutwut I have not made changes to `docs/source/guides/admin-guides/references/man8/makeknownhosts.8.rst` as I found that the file was not in unix `fileformat` (`^M` characters showed up when editing with `vim`)

Should I leave that file out from this MR?