### PR TITLE
modify rvitals_voltage test

### DIFF
--- a/xCAT-test/autotest/testcase/rvitals/cases0
+++ b/xCAT-test/autotest/testcase/rvitals/cases0
@@ -46,7 +46,6 @@ end
 start:rvitals_voltage
 description:Retrieves power supply and VRM voltage readings
 Attribute: $$CN-The operation object of rvitals command
-hcp:hmc,ivm,fsp,ipmi
 cmd:rvitals $$CN voltage
 check:rc==0
 check:output=~Frame Voltages|CPU VDD Volt|SysBrd


### PR DESCRIPTION
For openbmc testcases do not need to add hcp attributes so I delete this .