### PR TITLE
Sync usage, man and code for ipmi rvitals

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/management/basic/rcons.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/management/basic/rcons.rst
@@ -46,7 +46,7 @@ The xCAT ``rcons`` command relies on conserver (http://www.conserver.com/).  The
 
 
 OpenBMC Specific
-```````````````
+````````````````
 
    #. For OpenBMC managed servers, the root user must be able to ssh passwordless to the BMC for the ``rcons`` function to work.  
 

--- a/docs/source/guides/admin-guides/references/man1/rvitals.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rvitals.1.rst
@@ -60,7 +60,7 @@ OpenPOWER (IPMI) specific:
 ==========================
 
 
-\ **rvitals**\  \ *noderange*\  [\ **temp | voltage | wattage | fanspeed | power | leds | all**\ ]
+\ **rvitals**\  \ *noderange*\  [\ **temp | voltage | wattage | fanspeed | power | leds | chassis | all**\ ]
 
 
 OpenPOWER (OpenBMC) specific:
@@ -137,6 +137,12 @@ Processor for a single or range of nodes and groups.
 \ **leds**\ 
  
  Retrieves LEDs status.
+ 
+
+
+\ **chassis**\ 
+ 
+ Retrieves chassis status.
  
 
 

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -82,7 +82,7 @@ my %usage = (
   BMC specific:
       rvitals noderange {temp|voltage|wattage|fanspeed|power|leds|all}
   OpenPOWER (IPMI) specific:
-      rvitals noderange [temp|voltage|wattage|fanspeed|power|leds|all]
+      rvitals noderange [temp|voltage|wattage|fanspeed|power|leds|chassis|all]
   OpenPOWER (OpenBMC) specific:
       rvitals noderange [temp|voltage|wattage|fanspeed|power|altitude|all]
   MIC specific:

--- a/xCAT-client/pods/man1/rvitals.1.pod
+++ b/xCAT-client/pods/man1/rvitals.1.pod
@@ -28,7 +28,7 @@ B<rvitals> I<noderange> {B<temp>|B<voltage>|B<wattage>|B<fanspeed>|B<power>|B<le
 
 =head2 OpenPOWER (IPMI) specific:
 
-B<rvitals> I<noderange> [B<temp>|B<voltage>|B<wattage>|B<fanspeed>|B<power>|B<leds>|B<all>]
+B<rvitals> I<noderange> [B<temp>|B<voltage>|B<wattage>|B<fanspeed>|B<power>|B<leds>|B<chassis>|B<all>]
 
 =head2 OpenPOWER (OpenBMC) specific:
 
@@ -78,6 +78,10 @@ Retrieves rack environmentals.
 =item B<leds>
 
 Retrieves LEDs status.
+
+=item B<chassis>
+
+Retrieves chassis status.
 
 =item B<altitude>
 

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -6506,30 +6506,30 @@ sub vitals {
         $sensor_filters{leds}    = 1;
         $doall                   = 1;
     }
-    if (grep /temp/, @textfilters) {
+    if (grep /^temp$/, @textfilters) {
         $sensor_filters{0x01} = 1;
     }
-    if (grep /volt/, @textfilters) {
+    if (grep /^voltage$/, @textfilters) {
         $sensor_filters{0x02} = 1;
     }
-    if (grep /watt/, @textfilters) {
+    if (grep /^wattage$/, @textfilters) {
         $sensor_filters{watt} = 1;
     }
-    if (grep /fan/, @textfilters) {
+    if (grep /^fanspeed$/, @textfilters) {
         $sensor_filters{0x04} = 1;
     }
-    if (grep /power/, @textfilters) { #power does not really include energy, but most people use 'power' to mean both
+    if (grep /^power$/, @textfilters) { #power does not really include energy, but most people use 'power' to mean both
         $sensor_filters{0x03}       = 1;
         $sensor_filters{powerstate} = 1;
         $sensor_filters{energy}     = 1;
     }
-    if (grep /energy/, @textfilters) {
+    if (grep /^energy$/, @textfilters) {
         $sensor_filters{energy} = 1;
     }
-    if (grep /led/, @textfilters) {
+    if (grep /^leds$/, @textfilters) {
         $sensor_filters{leds} = 1;
     }
-    if (grep /chassis/, @textfilters) {
+    if (grep /^chassis$/, @textfilters) {
         $sensor_filters{chassis} = 1;
     }
     unless (keys %sensor_filters) {


### PR DESCRIPTION
This PR fixes the problem reported by #3126 
1. For IPMI controlled BMC's make sure to only accept exact match of option spelling.
2. Synchronize usage and man page display with code. 