### PR TITLE
Fix typo associated with pull request #3180, in makeknownhosts.pm

### DIFF
--- a/xCAT-server/lib/xcat/plugins/makeknownhosts.pm
+++ b/xCAT-server/lib/xcat/plugins/makeknownhosts.pm
@@ -71,7 +71,7 @@ sub process_request
     if (!GetOptions(
             'h|help'    => \$::opt_h,
             'V|verbose' => \$::opt_V,
-            'r|remove'  => \$::opt_r
+            'r|remove'  => \$::opt_r,
             'd|delete'  => \$::opt_d
         ))
     {


### PR DESCRIPTION
Fix typo from #3180  causing

```
String found where operator expected at /opt/xcat/lib/perl/xCAT_plugin/makeknownhosts.pm line 75, near "$::opt_r
            'd|delete'"
        (Missing operator before 'd|delete'?)
Error loading module /opt/xcat/lib/perl/xCAT_plugin/makeknownhosts.pm  ...skipping

```

@bybai @samveen  FYI, no need to spend time on it.  I created this pull request instead of just fixing in master so we are all in sync. 