### PR TITLE
When using go-xcat, continue to prompt the user for y/n before aborting

### DIFF
--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -2,7 +2,7 @@
 #
 # go-xcat - Install xCAT automatically.
 #
-# Version 1.0.19
+# Version 1.0.20
 #
 # Copyright (C) 2016 International Business Machines
 # Eclipse Public License, Version 1.0 (EPL-1.0)

--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -1567,14 +1567,22 @@ case "${GO_XCAT_ACTION}" in
 	then
 		echo
 		echo "xCAT is going to be ${GO_XCAT_ACTION/%e/}ed."
-		read -r -p "Continue? [y/n] "
-		case "${REPLY}" in
-		"Y"*|"y"*)
-			;;
-		*)
-			echo "Aborting ..."
-			exit 0
-		esac
+		while true; do
+
+			read -r -p "Continue? [y/n] "
+			case "${REPLY}" in
+			"Y"*|"y"*)
+				break	
+				;;
+			"N"*|"n"*)
+				echo "Good-bye!"
+				exit 0
+				;;
+			*)
+				echo "Invalid response!"
+				;;
+			esac
+		done
 	fi
 	# Use `-y' here. Since the STDOUT is redirect to tee.
 	# `yum' does not display the prompt message properly when

--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -1653,10 +1653,11 @@ case "${GO_XCAT_ACTION}" in
 		If this is the very first time xCAT has been installed, run the following
 		commands to set environment variables into your PATH:
 
-		    for sh,
-		        \`source /etc/profile.d/xcat.sh'
-		    or csh,
-		        \`source /etc/profile.d/xcat.csh'
+		For sh: 
+			source /etc/profile.d/xcat.sh
+
+		For csh: 
+			source /etc/profile.d/xcat.csh
 		EOF
 		;;
 	"update")


### PR DESCRIPTION
Minor usability issue, but when accidentally hitting a key (that is not y or n)  while go-xcat is reading the repositories will cause `go-xcat` to abort , so I added in a loop checking for the valid response before aborting. 

Here's the behavior with the changes: 


### Cancel case 
```
[root@fs2vm105 ~]#        /tmp/go-xcat --xcat-version devel install
Operating system:   linux
Architecture:       ppc64le
Linux Distribution: rhel
Version:            7.3

Reading repositories ...... done

xCAT is going to be installed.
Continue? [y/n] a
Unknown Response!
Continue? [y/n] b
Unknown Response!
Continue? [y/n] c
Unknown Response!
Continue? [y/n] d
Unknown Response!
Continue? [y/n] o
Unknown Response!
Continue? [y/n] n
Good-bye!
```

### Install case
```
[root@fs2vm105 ~]#        /tmp/go-xcat --xcat-version devel install
Operating system:   linux
Architecture:       ppc64le
Linux Distribution: rhel
Version:            7.3

Reading repositories ...... done

xCAT is going to be installed.
Continue? [y/n] a
Unknown Response!
Continue? [y/n] b
Unknown Response!
Continue? [y/n] y
Loaded plugins: product-id, search-disabled-repos, subscription-manager
This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.
Resolving Dependencies
--> Running transaction check
---> Package conserver-xcat.ppc64le 0:8.1.16-10 will be installed
---> Package elilo-xcat.noarch 0:3.14-4 will be installed
---> Package grub2-xcat.noarch 0:2.02-0.16.el7.snap201506090204 will be installed
---> Package ipmitool-xcat.ppc64le 0:1.8.17-1 will be installed
...
...
```
