### PR TITLE
Change bmcdiscover to look at system information instead of motherboard info for OpenBMC

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -1072,8 +1072,8 @@ sub bmcdiscovery_openbmc{
         my $serial;
 
         if (defined($response->{data})) {
-            if (defined($response->{data}->{Model}) and defined($response->{data}->{SerialNumber})) {
-                $mtm = $response->{data}->{Model};
+            if (defined($response->{data}->{PartNumber}) and defined($response->{data}->{SerialNumber})) {
+                $mtm = $response->{data}->{PartNumber};
                 $serial = $response->{data}->{SerialNumber}; 
             } else {
                 xCAT::MsgUtils->message("W", { data => ["Could not obtain Model Type and/or Serial Number for BMC at $ip"] }, $::CALLBACK);


### PR DESCRIPTION
Resolves #3205 

Change bmcdiscover to look at system information instead of motherboard info for OpenBMC.
And use variables for building up then endpoint for OpenBMC

Sample Output: 
```
[root@fs2vm104 ~]#  bmcdiscover --range 10.6.9.254 -z
node-2-0000000000000000:
	objtype=node
	groups=all
	bmc=10.6.9.254
	cons=openbmc
	mgt=openbmc
	mtm=2
	serial=0000000000000000
```

Here's a sample of the output that is returned from OpenBMC at this time.
```
    "/xyz/openbmc_project/inventory/system": {
      "BuildDate": "",
      "Cached": 0,
      "FieldReplaceable": 0,
      "Manufacturer": "",
      "Model": "2",
      "PartNumber": "0000000000000000",
      "Present": 1,
      "PrettyName": "",
      "SerialNumber": "0000000000000000"
    },
    "/xyz/openbmc_project/inventory/system/chassis/motherboard": {
      "BuildDate": "",
      "Manufacturer": "0000000000000000",
      "Model": "",
      "PartNumber": "00VK525         ",
      "Present": 0,
      "PrettyName": "SYSTEM PLANAR   ",
      "SerialNumber": "Y130UF72701M    "
    },
```
