### PR TITLE
modify format of error msg for 2200 port to hash according to other msg

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -594,7 +594,9 @@ sub scan_process {
                         bmcdiscovery_ipmi(${$live_ip}[$i], $opz, $opw, $request_command);
                     }
                 } else {
-                    xCAT::MsgUtils->message("E", "Can not get status of 2200 port.", $::CALLBACK);
+                    my $rsp = {};
+                    push @{ $rsp->{data} }, "Can not get status of 2200 port for ip ${$live_ip}[$i].\n";
+                    xCAT::MsgUtils->message("E", $rsp, $::CALLBACK);
                     exit 1;
                 }
 


### PR DESCRIPTION
#3207 
Modified ``Can not get status of 2200 port`` format to hash according to other MsgUtils format.