### PR TITLE
Modify one bug:Use of implicit split to @_ is deprecated at xcattest line 1059

### DIFF
--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -1056,9 +1056,9 @@ sub load_case {
             #log_this($running_log_fd, "Miss attribute:", @{$invalidcases{"missattr"}});
             $$error_ref = "Miss attribute: " . join(",", @{ $invalidcases{"missattr"} });
             foreach my $line (@{ $invalidcases{"missattr"} }) {
-                my $name = split(" ", $line);
-                if (!(grep /$name/, @wrong_cases)) {
-                    push @wrong_cases, $name;
+                my @name = split(" ", $line);
+                if (!(grep /$name[0]/, @wrong_cases)) {
+                    push @wrong_cases, $name[0];
                 }
             }
             $caseerror = 1;


### PR DESCRIPTION
Fix bug for ``xcattest`` : ``Use of implicit split to @_ is deprecated at xcattest line 1059.``

Found this bug on sles.  The OS of our control node in production automation environment is sles.