### PR TITLE
Failed to run dhcpd if tftpserver defined as <xcatmaster> in the network table

### DIFF
--- a/xCAT-server/lib/xcat/plugins/dhcp.pm
+++ b/xCAT-server/lib/xcat/plugins/dhcp.pm
@@ -2457,10 +2457,11 @@ sub addnet
             {
                 $tftp = $ent->{tftpserver};
             }
-            else
-            {    #presume myself to be it, dhcp no longer does this for us
+            if (!$tftp || ($tftp eq '<xcatmaster>'))
+            {
                 $tftp = $myip;
             }
+
             if ($ent and $ent->{gateway})
             {
                 $gateway = $ent->{gateway};


### PR DESCRIPTION
 the dhcpd failed to run because the tftpserver is set to <xcatmaster> in the networks table 
````
# tabdump networks #netname,net,mask,mgtifname,gateway,dhcpserver,tftpserver,nameservers,ntpservers,logservers,dynamicrange,staticrange,staticrangeincrement,nodehostname,ddnsdomain,vlanid,domain,mtu,comments,disable 
"10_0_0_0-255_0_0_0","10.0.0.0","255.0.0.0","enP4p1s0f0","10.0.0.101",,"10.200.3.27",,,,,,,,,,,,, 
"172_20_0_0-255_255_0_0","172.20.0.0","255.255.0.0","enP3p3s0","<xcatmaster>","<xcatmaster>","<xcatmaster>","<xcatmaster>","<xcatmaster>",,"172.20.253.100-172.20.253.200",,,,,,,"9000",, 
"172_21_0_0-255_255_0_0","172.21.0.0","255.255.0.0","enP3p3s0d1","172.21.253.27","172.21.253.27","172.21.253.27","172.21.253.27",,,"172.21.253.100-172.21.253.200",,,,,,,
````

the status of dhcpd:
````
Jun 05 14:51:36 fs3 dhcpd[105370]: All rights reserved. 
Jun 05 14:51:36 fs3 dhcpd[105370]: For info, please visit https://www.isc.org/software/dhcp/ 
Jun 05 14:51:36 fs3 dhcpd[105370]: /etc/dhcp/dhcpd.conf line 86: < (60): expecting IP address or hostname 
Jun 05 14:51:36 fs3 dhcpd[105370]:     next-server  < Jun 05 14:51:36 fs3 dhcpd[105370]:                   ^ Jun 05 14:51:36 fs3 dhcpd[105370]: /etc/dhcp/dhcpd.conf line 86: expecting a parameter or declaration Jun 05 14:51:36 fs3 systemd[1]: dhcpd.service: main process exited, code=exited, status=1/FAILURE 
Jun 05 14:51:36 fs3 systemd[1]: Failed to start DHCPv4 Server Daemon. 
Jun 05 14:51:36 fs3 systemd[1]: Unit dhcpd.service entered failed state. 
Jun 05 14:51:36 fs3 systemd[1]: dhcpd.service failed 
````
````
[root@fs3 dhcp]# grep next-server dhcpd.conf    
next-server  172.21.253.27;    
next-server  <xcatmaster>;
````