### PR TITLE
fix testcase clear_openbmc_simulator error

### DIFF
--- a/xCAT-test/autotest/testcase/simulator/change_ip.sh
+++ b/xCAT-test/autotest/testcase/simulator/change_ip.sh
@@ -13,7 +13,9 @@ elif [ $flag = "-c" ]; then
     cnip=`cat /tmp/simulator`
     chdef $cnhn bmc=$cnip
     process=`ps aux | grep "simulator" | grep "python" | awk -F ' ' '{print $2}'`
-    kill $process
+    if [ $process ]; then
+        kill $process
+    fi
     rm -rf "openbmc_simulator"
 fi
 exit $?

--- a/xCAT-test/autotest/testcase/simulator/clear_simulator
+++ b/xCAT-test/autotest/testcase/simulator/clear_simulator
@@ -1,5 +1,5 @@
 start:clear_openbmc_simulator
 description:clear evironment
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/setup_simulator/change_ip.sh -c $$MN $$CN
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/simulator/change_ip.sh -c $$MN $$CN
 check:rc==0
 end


### PR DESCRIPTION
1. modified path of change_ip.sh in testcase
2. add protection for kill simulation process