### PR TITLE
fix 3224 nodeset create dracut.* file in sles statelite cost too much…

### DIFF
--- a/xCAT-server/lib/xcat/plugins/sles.pm
+++ b/xCAT-server/lib/xcat/plugins/sles.pm
@@ -1707,9 +1707,7 @@ erver, if so, stop it first and try again" ],
 sub using_dracut
 {
     my $rootimgdir = shift;
-    my $chkcmd = "chroot $rootimgdir/rootimg dracut --list-modules";
-    my $rc = system($chkcmd);
-    if ($rc) {
+    if ( -f "$rootimgdir/rootimg/etc/dracut.conf" ) {
         return 0;
     } else {
         return 1;

--- a/xCAT-server/lib/xcat/plugins/sles.pm
+++ b/xCAT-server/lib/xcat/plugins/sles.pm
@@ -1708,9 +1708,9 @@ sub using_dracut
 {
     my $rootimgdir = shift;
     if ( -f "$rootimgdir/rootimg/etc/dracut.conf" ) {
-        return 0;
-    } else {
         return 1;
+    } else {
+        return 0;
     }
 }
 


### PR DESCRIPTION
fix #3224 
Replace dracut command in sles statelite nodeset  to check if dracut is used or not. So that there is no dracut.* files are created by nodeset , and the same time nodeset does not need to call shell command and system command, it can improve sles statelite nodeset performance.

Unit test:
```
] # nodeset bybc0605 osimage=sles12.2-x86_64-statelite-compute
bybc0605: statelite sles12.2-x86_64-compute
] # ls /install/netboot/sles12.2/x86_64/compute/rootimg/tmp
] #
```
