### PR TITLE
Revert "Do operating system deployment in migration test cases"

### DIFF
--- a/xCAT-test/autotest/testcase/migration/redhat_migration
+++ b/xCAT-test/autotest/testcase/migration/redhat_migration
@@ -71,13 +71,11 @@ check:output=~$$MIGRATION1_VERSION
 cmd:xdsh $$CN "service xcatd status"
 check:rc==0
 check:output=~running
-cmd:lsdef $$SN -z | ssh $$CN "mkdef -z"
-cmd:ssh $$CN "chdef $$SN servicenode= monserver= nfsserver= tftpserver= xcatmaster="
-cmd:makedhcp -d $$SN
-cmd:scp $$ISO $$CN:/tmp/foobar.iso
-cmd:ssh $$CN "copycds /tmp/foobar.iso"
-cmd:ssh $$CN "makedhcp -n"
+cmd:xdsh $$CN "chdef -t node -o node0001  nodetype=osi groups=linux"
 check:rc==0
+cmd:xdsh $$CN "lsdef"
+check:output=~node0001
+cmd:check==0
 cmd:xdsh $$CN "cd /; scp -r $$MN:/core-rpms-snap.tar.bz2 /"
 check:rc==0
 cmd:xdsh $$CN "cd /; scp -r $$MN:/xcat-dep*.tar.bz2 /"
@@ -95,14 +93,11 @@ check:rc==0
 cmd:xdsh $$CN "service xcatd status"
 check:rc==0
 check:output=~running
+cmd:xdsh $$CN "lsdef"
+check:output=~node0001
+cmd:xdsh $$CN "noderm node0001"
+check:rc==0
 cmd:latest_version_info=`lsxcatd -v`;xdsh $$CN "lsxcatd -v" | grep "$latest_version_info"
-check:rc==0
-cmd:ssh $$CN "rinstall $$SN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute"
-check:rc==0
-cmd:sleep 300
-cmd:ssh $$CN "a=0; while ! `lsdef -l $$SN | grep status | grep booted >/dev/null`; do ((++a > 90)) && exit 99; sleep 20; done"
-check:rc==0
-cmd:ssh $$CN "xdsh $$SN date"
 check:rc==0
 cmd:if [[ -f /tmp/servicelabel ]];then chdef $$SN -p groups=service;rm -rf /tmp/servicelabel;fi
 check:rc==0
@@ -183,12 +178,10 @@ check:output=~$$MIGRATION2_VERSION
 cmd:xdsh $$CN "service xcatd status"
 check:rc==0
 check:output=~running
-cmd:lsdef $$SN -z | ssh $$CN "mkdef -z"
-cmd:ssh $$CN "chdef $$SN servicenode= monserver= nfsserver= tftpserver= xcatmaster="
-cmd:makedhcp -d $$SN
-cmd:scp $$ISO $$CN:/tmp/foobar.iso
-cmd:ssh $$CN "copycds /tmp/foobar.iso"
-cmd:ssh $$CN "makedhcp -n"
+cmd:xdsh $$CN "chdef -t node -o node0001  nodetype=osi groups=linux"
+check:rc==0
+cmd:xdsh $$CN "lsdef"
+check:output=~node0001
 cmd:check==0
 cmd:xdsh $$CN "cd /; scp -r $$MN:/core-rpms-snap.tar.bz2 /"
 check:rc==0
@@ -207,14 +200,9 @@ check:rc==0
 cmd:xdsh $$CN "service xcatd status"
 check:rc==0
 check:output=~running
-cmd:ssh $$CN "rinstall $$SN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute"
-check:rc==0
-cmd:sleep 300
-cmd:ssh $$CN "a=0; while ! `lsdef -l $$SN | grep status | grep booted >/dev/null`; do ((++a > 90)) && exit 99; sleep 20; done"
-check:rc==0
-cmd:ssh $$CN "xdsh $$SN date"
-check:rc==0
-cmd:xdsh $$CN "/opt/xcat/share/xcat/tools/go-xcat smoke-test"
+cmd:xdsh $$CN "lsdef"
+check:output=~node0001
+cmd:xdsh $$CN "noderm node0001"
 check:rc==0
 cmd:latest_version_info=`lsxcatd -v`;xdsh $$CN "lsxcatd -v" | grep "$latest_version_info"
 check:rc==0

--- a/xCAT-test/autotest/testcase/migration/sles_migration
+++ b/xCAT-test/autotest/testcase/migration/sles_migration
@@ -74,12 +74,10 @@ check:output=~$$MIGRATION1_VERSION
 cmd:xdsh $$CN "service xcatd status"
 check:rc==0
 check:output=~running
-cmd:lsdef $$SN -z | ssh $$CN "mkdef -z"
-cmd:ssh $$CN "chdef $$SN servicenode= monserver= nfsserver= tftpserver= xcatmaster="
-cmd:makedhcp -d $$SN
-cmd:scp $$ISO $$CN:/tmp/foobar.iso
-cmd:ssh $$CN "copycds /tmp/foobar.iso"
-cmd:ssh $$CN "makedhcp -n"
+cmd:xdsh $$CN "chdef -t node -o node0001  nodetype=osi groups=linux"
+check:rc==0
+cmd:xdsh $$CN "lsdef"
+check:output=~node0001
 cmd:xdsh $$CN "cd /; scp -r $$MN:/core-rpms-snap.tar.bz2 /"
 check:rc==0
 cmd:xdsh $$CN "cd /; scp -r $$MN:/xcat-dep*.tar.bz2 /"
@@ -97,14 +95,9 @@ check:rc==0
 cmd:xdsh $$CN "service xcatd status"
 check:rc==0
 check:output=~running
-cmd:ssh $$CN "rinstall $$SN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute"
-check:rc==0
-cmd:sleep 300
-cmd:ssh $$CN "a=0; while ! `lsdef -l $$SN | grep status | grep booted >/dev/null`; do ((++a > 90)) && exit 99; sleep 20; done"
-check:rc==0
-cmd:ssh $$CN "xdsh $$SN date"
-check:rc==0
-cmd:xdsh $$CN "/opt/xcat/share/xcat/tools/go-xcat smoke-test"
+cmd:xdsh $$CN "lsdef"
+check:output=~node0001
+cmd:xdsh $$CN "noderm node0001"
 check:rc==0
 cmd:latest_version_info=`lsxcatd -v`;xdsh $$CN "lsxcatd -v" | grep "$latest_version_info"
 check:rc==0
@@ -191,12 +184,10 @@ check:output=~$$MIGRATION2_VERSION
 cmd:xdsh $$CN "service xcatd status"
 check:rc==0
 check:output=~running
-cmd:lsdef $$SN -z | ssh $$CN "mkdef -z"
-cmd:ssh $$CN "chdef $$SN servicenode= monserver= nfsserver= tftpserver= xcatmaster="
-cmd:makedhcp -d $$SN
-cmd:scp $$ISO $$CN:/tmp/foobar.iso
-cmd:ssh $$CN "copycds /tmp/foobar.iso"
-cmd:ssh $$CN "makedhcp -n"
+cmd:xdsh $$CN "chdef -t node -o node0001  nodetype=osi groups=linux"
+check:rc==0
+cmd:xdsh $$CN "lsdef"
+check:output=~node0001
 cmd:xdsh $$CN "cd /; scp -r $$MN:/core-rpms-snap.tar.bz2 /"
 check:rc==0
 cmd:xdsh $$CN "cd /; scp -r $$MN:/xcat-dep*.tar.bz2 /"
@@ -214,14 +205,9 @@ check:rc==0
 cmd:xdsh $$CN "service xcatd status"
 check:rc==0
 check:output=~running
-cmd:ssh $$CN "rinstall $$SN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute"
-check:rc==0
-cmd:sleep 300
-cmd:ssh $$CN "a=0; while ! `lsdef -l $$SN | grep status | grep booted >/dev/null`; do ((++a > 90)) && exit 99; sleep 20; done"
-check:rc==0
-cmd:ssh $$CN "xdsh $$SN date"
-check:rc==0
-cmd:xdsh $$CN "/opt/xcat/share/xcat/tools/go-xcat smoke-test"
+cmd:xdsh $$CN "lsdef"
+check:output=~node0001
+cmd:xdsh $$CN "noderm node0001"
 check:rc==0
 cmd:latest_version_info=`lsxcatd -v`;xdsh $$CN "lsxcatd -v" | grep "$latest_version_info"
 check:rc==0

--- a/xCAT-test/autotest/testcase/migration/ubuntu_migration1_p8le
+++ b/xCAT-test/autotest/testcase/migration/ubuntu_migration1_p8le
@@ -80,12 +80,10 @@ check:rc==0
 cmd:xdsh $$CN "service xcatd status"
 check:rc==0
 check:output=~running
-cmd:lsdef $$SN -z | ssh $$CN "/opt/xcat/bin/mkdef -z"
-cmd:ssh $$CN "/opt/xcat/bin/chdef $$SN servicenode= monserver= nfsserver= tftpserver= xcatmaster="
-cmd:makedhcp -d $$SN
-cmd:scp $$ISO $$CN:/tmp/foobar.iso
-cmd:ssh $$CN "/opt/xcat/sbin/copycds /tmp/foobar.iso"
-cmd:ssh $$CN "/opt/xcat/sbin/makedhcp -n"
+cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;chdef -t node -o node0001  nodetype=osi groups=linux"
+check:rc==0
+cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;lsdef"
+check:output=~node0001
 cmd:xdsh $$CN "rm -rf /newxcat"
 cmd:xdsh $$CN "mkdir -p /newxcat"
 check:rc==0
@@ -116,15 +114,10 @@ check:rc==0
 cmd:xdsh $$CN "service xcatd status"
 check:rc==0
 check:output=~running
-cmd:ssh $$CN "/opt/xcat/bin/rinstall $$SN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute"
+cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;rmdef node0001"
 check:rc==0
-cmd:sleep 300
-cmd:ssh $$CN "a=0; while ! `/opt/xcat/bin/lsdef -l $$SN | grep status | grep booted >/dev/null`; do ((++a > 90)) && exit 99; sleep 20; done"
-check:rc==0
-cmd:ssh $$CN "/opt/xcat/bin/xdsh $$SN date"
-check:rc==0
-cmd:xdsh $$CN "/opt/xcat/share/xcat/tools/go-xcat smoke-test"
-check:rc==0
+cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;lsdef"
+check:output!~node0001
 cmd:xdsh $$CN "diff /oldxcat/old_version /newxcat/new_version"
 check:rc!=0
 

--- a/xCAT-test/autotest/testcase/migration/ubuntu_migration1_vm
+++ b/xCAT-test/autotest/testcase/migration/ubuntu_migration1_vm
@@ -79,12 +79,10 @@ check:rc==0
 cmd:xdsh $$CN "service xcatd status"
 check:rc==0
 check:output=~running
-cmd:lsdef $$SN -z | ssh $$CN "/opt/xcat/bin/mkdef -z"
-cmd:ssh $$CN "/opt/xcat/bin/chdef $$SN servicenode= monserver= nfsserver= tftpserver= xcatmaster="
-cmd:makedhcp -d $$SN
-cmd:scp $$ISO $$CN:/tmp/foobar.iso
-cmd:ssh $$CN "/opt/xcat/sbin/copycds /tmp/foobar.iso"
-cmd:ssh $$CN "/opt/xcat/sbin/makedhcp -n"
+cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;chdef -t node -o node0001  nodetype=osi groups=linux"
+check:rc==0
+cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;lsdef"
+check:output=~node0001
 cmd:xdsh $$CN "rm -rf /newxcat"
 cmd:xdsh $$CN "mkdir -p /newxcat"
 check:rc==0
@@ -115,15 +113,10 @@ check:rc==0
 cmd:xdsh $$CN "service xcatd status"
 check:rc==0
 check:output=~running
-cmd:ssh $$CN "/opt/xcat/bin/rinstall $$SN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute"
+cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;rmdef node0001"
 check:rc==0
-cmd:sleep 300
-cmd:ssh $$CN "a=0; while ! `/opt/xcat/bin/lsdef -l $$SN | grep status | grep booted >/dev/null`; do ((++a > 90)) && exit 99; sleep 20; done"
-check:rc==0
-cmd:ssh $$CN "/opt/xcat/bin/xdsh $$SN date"
-check:rc==0
-cmd:xdsh $$CN "/opt/xcat/share/xcat/tools/go-xcat smoke-test"
-check:rc==0
+cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;lsdef"
+check:output!~node0001
 cmd:xdsh $$CN "diff /oldxcat/old_version /newxcat/new_version"
 check:rc!=0
 end

--- a/xCAT-test/autotest/testcase/migration/ubuntu_migration2_p8le
+++ b/xCAT-test/autotest/testcase/migration/ubuntu_migration2_p8le
@@ -80,12 +80,10 @@ check:rc==0
 cmd:xdsh $$CN "service xcatd status"
 check:rc==0
 check:output=~running
-cmd:lsdef $$SN -z | ssh $$CN "/opt/xcat/bin/mkdef -z"
-cmd:ssh $$CN "/opt/xcat/bin/chdef $$SN servicenode= monserver= nfsserver= tftpserver= xcatmaster="
-cmd:makedhcp -d $$SN
-cmd:scp $$ISO $$CN:/tmp/foobar.iso
-cmd:ssh $$CN "/opt/xcat/sbin/copycds /tmp/foobar.iso"
-cmd:ssh $$CN "/opt/xcat/sbin/makedhcp -n"
+cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;chdef -t node -o node0001  nodetype=osi groups=linux"
+check:rc==0
+cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;lsdef"
+check:output=~node0001
 cmd:xdsh $$CN "rm -rf /newxcat"
 cmd:xdsh $$CN "mkdir -p /newxcat"
 check:rc==0
@@ -116,15 +114,10 @@ check:rc==0
 cmd:xdsh $$CN "service xcatd status"
 check:rc==0
 check:output=~running
-cmd:ssh $$CN "/opt/xcat/bin/rinstall $$SN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute"
+cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;rmdef node0001"
 check:rc==0
-cmd:sleep 300
-cmd:ssh $$CN "a=0; while ! `/opt/xcat/bin/lsdef -l $$SN | grep status | grep booted >/dev/null`; do ((++a > 90)) && exit 99; sleep 20; done"
-check:rc==0
-cmd:ssh $$CN "/opt/xcat/bin/xdsh $$SN date"
-check:rc==0
-cmd:xdsh $$CN "/opt/xcat/share/xcat/tools/go-xcat smoke-test"
-check:rc==0
+cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;lsdef"
+check:output!~node0001
 cmd:xdsh $$CN "diff /oldxcat/old_version /newxcat/new_version"
 check:rc!=0
 

--- a/xCAT-test/autotest/testcase/migration/ubuntu_migration2_vm
+++ b/xCAT-test/autotest/testcase/migration/ubuntu_migration2_vm
@@ -79,12 +79,10 @@ check:rc==0
 cmd:xdsh $$CN "service xcatd status"
 check:rc==0
 check:output=~running
-cmd:lsdef $$SN -z | ssh $$CN "/opt/xcat/bin/mkdef -z"
-cmd:ssh $$CN "/opt/xcat/bin/chdef $$SN servicenode= monserver= nfsserver= tftpserver= xcatmaster="
-cmd:makedhcp -d $$SN
-cmd:scp $$ISO $$CN:/tmp/foobar.iso
-cmd:ssh $$CN "/opt/xcat/sbin/copycds /tmp/foobar.iso"
-cmd:ssh $$CN "/opt/xcat/sbin/makedhcp -n"
+cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;chdef -t node -o node0001  nodetype=osi groups=linux"
+check:rc==0
+cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;lsdef"
+check:output=~node0001
 cmd:xdsh $$CN "rm -rf /newxcat"
 cmd:xdsh $$CN "mkdir -p /newxcat"
 check:rc==0
@@ -115,15 +113,10 @@ check:rc==0
 cmd:xdsh $$CN "service xcatd status"
 check:rc==0
 check:output=~running
-cmd:ssh $$CN "/opt/xcat/bin/rinstall $$SN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute"
+cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;rmdef node0001"
 check:rc==0
-cmd:sleep 300
-cmd:ssh $$CN "a=0; while ! `/opt/xcat/bin/lsdef -l $$SN | grep status | grep booted >/dev/null`; do ((++a > 90)) && exit 99; sleep 20; done"
-check:rc==0
-cmd:ssh $$CN "/opt/xcat/bin/xdsh $$SN date"
-check:rc==0
-cmd:xdsh $$CN "/opt/xcat/share/xcat/tools/go-xcat smoke-test"
-check:rc==0
+cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;lsdef"
+check:output!~node0001
 cmd:xdsh $$CN "diff /oldxcat/old_version /newxcat/new_version"
 check:rc!=0
 end


### PR DESCRIPTION
Reverts xcat2/xcat-core#3163, since these modified test cases cause auto test failures.