### PR TITLE
openbmc rflash command support for -l --list option

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -119,6 +119,14 @@ my %status_info = (
         process        => \&reventlog_response,
     },
 
+    RFLASH_LIST_REQUEST  => {
+        method         => "GET",
+        init_url       => "$openbmc_project_url/software/enumerate",
+    },
+    RFLASH_LIST_RESPONSE => {
+        process        => \&rflash_response,
+    },
+
     RINV_REQUEST => {
         method         => "GET",
         init_url       => "$openbmc_project_url/inventory/enumerate",
@@ -203,13 +211,6 @@ my %status_info = (
     },
     RVITALS_RESPONSE => {
         process        => \&rvitals_response,
-    },
-    RFLASH_LIST_REQUEST  => {
-        method         => "GET",
-        init_url       => "$openbmc_project_url/software/enumerate",
-    },
-    RFLASH_LIST_RESPONSE => {
-        process        => \&rflash_response,
     },
 );
 
@@ -484,13 +485,13 @@ sub parse_args {
             if ($filename_passed) {
                 # Filename was passed, check flags allowed with file
                 if ($opt !~ /^-c$|^--check$|^-d$|^--delete$|^-u$|^--upload$/) {
-                    return ([ 1, "Unsupported file command option: $opt" ]);
+                    return ([ 1, "Invalid option specified when a file is provided: $opt" ]);
                 }
             }
             else {
                 # Filename was not passed, check flags allowed without file
                 if ($opt !~ /^-c$|^--check$|^-l$|^--list/) {
-                    return ([ 1, "Unsupported no file command option: $opt" ]);
+                    return ([ 1, "Invalid option specified: $opt" ]);
                 }
             }
         }
@@ -691,16 +692,16 @@ sub parse_command_status {
                 }
             }
             else {
-                #TODO Process file id passed in
+                # TODO Process file id passed in
             }
         }
         if ($check_version) {
-            #Display firmware version on BMC
+            # Display firmware version on BMC
             $next_status{LOGIN_RESPONSE} = "RINV_FIRM_REQUEST";
             $next_status{RINV_FIRM_REQUEST} = "RINV_FIRM_RESPONSE";
         }
         if ($list) {
-            #Display firmware update files uploaded to BMC
+            # Display firmware update files uploaded to BMC
             $next_status{LOGIN_RESPONSE} = "RFLASH_LIST_REQUEST";
             $next_status{RFLASH_LIST_REQUEST} = "RFLASH_LIST_RESPONSE";
         }


### PR DESCRIPTION
Implements issue #3157 

List in a table format each uploaded update file.

Single endpoint:
```
[root@stratton01 xcat]# rflash p9euh02 -l
p9euh02: ID       Purpose State    Version
p9euh02: -------------------------------------------------------
p9euh02: deb46041 BMC     Active   v1.99.6-71-g0980d39
p9euh02: b7389829 Host    Ready    IBM-witherspoon-ibm-OP9_v1.16_1.24
p9euh02:
```

Two endpoints:
```
[root@stratton01 xcat]# rflash p9euh02,p9euh01 --list
p9euh01: ID       Purpose State    Version
p9euh01: -------------------------------------------------------
p9euh01: 6584ef1  BMC     Invalid  v1.99.6-19-gab8de5b
p9euh01: b7389829 Host    Ready    IBM-witherspoon-ibm-OP9_v1.16_1.24
p9euh01:
p9euh02: ID       Purpose State    Version
p9euh02: -------------------------------------------------------
p9euh02: deb46041 BMC     Active   v1.99.6-71-g0980d39
p9euh02: b7389829 Host    Ready    IBM-witherspoon-ibm-OP9_v1.16_1.24
p9euh02:
```