### PR TITLE
rm / from path of xcatpost folder when run rm command

### DIFF
--- a/xCAT/postscripts/xcatdsklspost
+++ b/xCAT/postscripts/xcatdsklspost
@@ -126,9 +126,8 @@ download_postscripts()
     retry=0
     rc=1  # this is a fail return 
     while [ 0 -eq 0 ]; do
-
-        if [ -e "\/$xcatpost" ]; then
-            rm -rf "\/$xcatpost"
+        if [ -e "$xcatpost" ]; then
+            rm -rf "$xcatpost"
         fi
 
         export LANG=C; wget -l inf -nH -N -r --waitretry=10 --random-wait -e robots=off -T 60 -nH --cut-dirs=2 --reject "index.html*" --no-parent http://$server$INSTALLDIR/postscripts/ -P /$xcatpost 2> /tmp/wget.log


### PR DESCRIPTION
When run ``updatenode``, the folder ``/xcatpost`` and files under it did not be deleted. So change path of the folder to correct one.