### PR TITLE
Support user defined ip address for cumulus switch

### DIFF
--- a/xCAT-server/share/xcat/scripts/configonie
+++ b/xCAT-server/share/xcat/scripts/configonie
@@ -125,11 +125,28 @@ sub config_ssh {
     my $cmd;
     my @config_switches;
 
+    my $nodetab = xCAT::Table->new('hosts');
+    my $nodehash = $nodetab->getNodesAttribs(\@nodes,['ip','otherinterfaces']);
+
     foreach my $switch (@nodes) {
         #remove old host key from /root/.ssh/known_hosts
         $cmd = `ssh-keygen -R $switch`;
 
-        my ($exp, $errstr) = cumulus_connect($switch, $userid, $password, $timeout);
+        my $static_ip = $nodehash->{$switch}->[0]->{ip};
+        my $discover_ip = $nodehash->{$switch}->[0]->{otherinterfaces};
+        my $ssh_ip;
+
+        my $p = Net::Ping->new();
+        if ($p->ping($static_ip)) {
+            $ssh_ip = $static_ip;
+        } elsif ($p->ping($discover_ip)) {
+            $ssh_ip = $discover_ip;
+        } else {
+            print "$switch is not reachable\n";
+            next;
+        }
+
+        my ($exp, $errstr) = cumulus_connect($ssh_ip, $userid, $password, $timeout);
         if (!defined $exp) {
             print ("connect failed $errstr\n");
             next;
@@ -142,6 +159,10 @@ sub config_ssh {
         ($ret, $err) = cumulus_exec($exp, "chmod 700 /root/.ssh");
         ($ret, $err) = cumulus_exec($exp, "echo \"$rootkey\" >/root/.ssh/authorized_keys");
         ($ret, $err) = cumulus_exec($exp, "chmod 644 /root/.ssh/authorized_keys");
+        #config dhcp ip address to static
+        if ($ssh_ip eq $discover_ip) {
+            ($ret, $err) = cumulus_exec($exp, "ifconfig eth0 $static_ip");
+        }
 
         $exp->hard_close();
         push (@config_switches, $switch);


### PR DESCRIPTION
Add Support to change dhcp ip address to fixed ip address for cumulus switch.
1) user predefine cumulus switch
````
# lsdef mid05tor10
Object name: mid05tor10
    arch=armv7l
    groups=switch
    ip=172.21.205.10
    nodetype=switch
    supportedarchs=armv7l
    switch=mgmtsw01
    switchport=10
    switchtype=onie
````    
2) run switchdiscover command, it will find the switch, then add dhcp ip address to otherinterface attribute
````
#switchdiscover --range 172.21.253.100  -s snmp -w
## lsdef mid05tor10
Object name: mid05tor10
    arch=armv7l
    groups=switch
    ip=172.21.205.10
    mac=8c:ea:1b:e8:78:c0
    nodetype=switch
    otherinterfaces=172.21.253.100
    supportedarchs=armv7l
    switch=mgmtsw01
    switchport=10
    switchtype=onie
    usercomment=Cumulus Linux 3.2.1 (Linux Kernel 4.1.33-1+cl3u7)
`````

3) run configonie script will able to set up passwordless and change ip address to predefine ip address for the switch 
````
# /opt/xcat/share/xcat/scripts/configonie --switches mid05tor10 --ssh
# ping -c 4 mid05tor10
PING mid05tor10 (172.21.205.10) 56(84) bytes of data.
64 bytes from mid05tor10 (172.21.205.10): icmp_seq=1 ttl=64 time=0.188 ms
64 bytes from mid05tor10 (172.21.205.10): icmp_seq=2 ttl=64 time=0.218 ms
64 bytes from mid05tor10 (172.21.205.10): icmp_seq=3 ttl=64 time=0.161 ms
64 bytes from mid05tor10 (172.21.205.10): icmp_seq=4 ttl=64 time=0.173 ms

--- mid05tor10 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 2998ms
rtt min/avg/max/mdev = 0.161/0.185/0.218/0.021 ms
[root@fs3 scripts]# xdsh mid05tor10 date
mid05tor10: Thu Jun  8 16:50:24 UTC 2017

````