### PR TITLE
Upgrade conserver to 8.2.1 version

### DIFF
--- a/perl-xCAT/xCAT/Utils.pm
+++ b/perl-xCAT/xCAT/Utils.pm
@@ -581,6 +581,69 @@ sub Version
 
 #-------------------------------------------------------------------------------
 
+=head3    get_conserver_version
+    Returns:
+       consever version number like 8.1.16, undef if error happens
+    Globals:
+        none
+    Error:
+        none
+    Example:
+         $version=xCAT::Utils->get_conserver_version();
+    Comments:
+        none
+=cut
+
+#-------------------------------------------------------------------------------
+sub get_conserver_version
+{
+    my $cmd = "/usr/sbin/conserver -V";
+    # output format:
+    # conserver: conserver.com version 8.2.1
+    # conserver: default access type `r'
+    my @out  = xCAT::Utils->runcmd("$cmd", 0);
+    if ($::RUNCMD_RC != 0 || @out < 1) {
+        return undef;
+    }
+    my @parts = split(' ',$out[0]);
+    if (@parts < 4) {
+        return undef;
+    }
+    my @count = $parts[3] =~ /\./g;
+    if (@count < 2) {
+        return undef;
+    }
+    return $parts[3];
+}
+
+#-------------------------------------------------------------------------------
+
+=head3    calc_conserver_version
+    Arguments:
+        version in string format
+    Returns:
+        version number
+    Globals:
+        none
+    Error:
+        none
+    Example:
+         $version=xCAT::Utils->calc_conserver_version("8.2.1");
+    Comments:
+        none
+=cut
+
+#-------------------------------------------------------------------------------
+sub calc_conserver_version
+{
+    my $ver_str = shift;
+    my @vers = split(/\./, $ver_str);
+    return ord($vers[2]) + ord($vers[1]) * 10000 + ord($vers[0]) * 100000000;
+}
+
+
+#-------------------------------------------------------------------------------
+
 =head3    make_node_list_file
 
         Makes a node list file.

--- a/xCAT-client/bin/rcons
+++ b/xCAT-client/bin/rcons
@@ -127,12 +127,22 @@ elif [ -f "/usr/bin/console" ] || [ -f "/bin/console" ]; then
     #NOTE: IPv6 is not good with the below if going by IP, needs more sophisticated
     #parsing
     CONSERVER=`echo $CONSERVER|cut -d: -f 1`
-
+    CONSOLE_VER=`console -V | awk '/conserver.com version/ {print $4}'`
     #Detect console support of SSL, only fixup consolerc if encryption is detected
     if ! console -h 2>&1 | grep "encryption not compiled" > /dev/null; then
         # generate .consolerc if it does not exist or is empty
         if [ ! -s $HOME/.consolerc ]; then
-            cat > $HOME/.consolerc << EOF
+            if [ "$CONSOLE_VER" != "8.1.16" ]; then
+                cat > $HOME/.consolerc << EOF
+config * {
+      port 782;
+      sslenabled yes;
+      sslcacertificatefile $HOME/.xcat/ca.pem;
+      sslcredentials $HOME/.xcat/client-cred.pem;
+}
+EOF
+            else
+                cat > $HOME/.consolerc << EOF
 config * {
       port 782;
       sslenabled yes;
@@ -140,6 +150,7 @@ config * {
       sslcredentials $HOME/.xcat/client-cred.pem;
 }
 EOF
+            fi
         fi
     else
         # ssl is not enabled, comment out the ssl settings in .consolerc
@@ -147,7 +158,10 @@ EOF
             sed -i 's/\Wssl/#ssl/1' $HOME/.consolerc
 	fi
     fi
-
+    # for migration, upgrade conserver
+    if [ "$CONSOLE_VER" != "8.1.16" ]; then
+        sed -i 's/sslauthority/sslcacertificatefile/1' $HOME/.consolerc
+    fi
     exec console $FORCE -M $CONSERVER $1
 else 
     if [[ "$FORCE" == "-s" ]]; then

--- a/xCAT-server/lib/xcat/plugins/conserver.pm
+++ b/xCAT-server/lib/xcat/plugins/conserver.pm
@@ -207,7 +207,16 @@ sub docfheaders {
         {
             push @newheaders, "config * {\n";
             push @newheaders, "  sslrequired yes;\n";
-            push @newheaders, "  sslauthority /etc/xcat/cert/ca.pem;\n";
+            my $version = xCAT::Utils::get_conserver_version();
+            if (!$version) {
+                xCAT::SvrUtils::sendmsg([ 1, "Failed to get conserver version" ], $cb);
+                return;
+            }
+            if (xCAT::Utils::calc_conserver_version($version) < xCAT::Utils::calc_conserver_version("8.1.19")) {
+                push @newheaders, "  sslauthority /etc/xcat/cert/ca.pem;\n";
+            } else {
+                push @newheaders, "  sslcacertificatefile /etc/xcat/cert/ca.pem;\n";
+            }
             push @newheaders, "  sslcredentials /etc/xcat/cert/server-cred.pem;\n";
             push @newheaders, "}\n";
         }

--- a/xCAT-server/sbin/xcatconfig
+++ b/xCAT-server/sbin/xcatconfig
@@ -464,6 +464,10 @@ if ($::INITIALINSTALL || $::FORCE || $::UPDATEINSTALL || $::genCredentials)
 
 }
 
+if ($::UPDATEINSTALL) {
+    upgrade_conserver();
+}
+
 # more  config needed after xcatd start
 if ($::INITIALINSTALL || $::FORCE)
 {
@@ -2336,5 +2340,47 @@ sub startnamedonboot
         {
             xCAT::MsgUtils->message("I", "dns server has been enabled on boot.");
         }
+    }
+}
+
+#-----------------------------------------------------------------------------
+
+=head3    upgrade_conserver
+
+     Update conserver configuration files while upgrading xcat
+
+=cut
+
+#-----------------------------------------------------------------------------
+sub upgrade_conserver
+{
+    my $version = xCAT::Utils::get_conserver_version();
+    if (!$version) {
+        return;
+    }
+    if (xCAT::Utils::calc_conserver_version($version) < xCAT::Utils::calc_conserver_version("8.1.19")) {
+        return;
+    }
+    my $cmd = "/bin/cat /etc/conserver.cf | grep sslauthority";
+    xCAT::Utils->runcmd($cmd, -1);
+    if ($::RUNCMD_RC != 0) {
+        return;
+    }
+    $cmd = "sed -i 's/sslauthority/sslcacertificatefile/1' /etc/conserver.cf";
+    xCAT::Utils->runcmd($cmd, 0);
+    if ($::RUNCMD_RC != 0) {
+        return;
+    }
+    #restart conserver daemon
+    if (xCAT::Utils->isAIX()) {
+        $cmd = "stopsrc -s conserver";
+        xCAT::Utils->runcmd($cmd, 0);
+        $cmd = "startsrc -s conserver";
+        xCAT::Utils->runcmd($cmd, 0);
+    } else {
+        $cmd = "/etc/init.d/conserver stop";
+        xCAT::Utils->runcmd($cmd, 0);
+        $cmd = "/etc/init.d/conserver start";
+        xCAT::Utils->runcmd($cmd, 0);
     }
 }


### PR DESCRIPTION
This patch change the `sslauthority` to `sslcacertificatefile` to
support the latest version of conserver. It also add scripts to
update the `conserver.cf` and $HOME/.consolerc to make sure
migration works correctly.

implement: #3239