### PR TITLE
openbmc rflash command support for -u --upload option

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -689,7 +689,7 @@ sub parse_command_status {
                 $::UPLOAD_FILE = $update_file; # Save filename to upload
                 # Verify file exists and is readable
                 unless (-r $filename) {
-                    xCAT::SvrUtils::sendmsg("Error accessing update file $filename", $callback);
+                    xCAT::SvrUtils::sendmsg([1,"Cannot access $filename"], $callback);
                     return 1;
                 }
                 if ($check_version) {


### PR DESCRIPTION
Implements issue #3159 

Upload update `.tar` file to BMC using `curl` command.
Unable at this point to implement the upload using HTTP::Request(), so for now using `curl` command so as to not block the development progress.

Successful upload:
```
[root@stratton01 ~]# rflash p9euh02,p9euh01 /tmp/gurevich/pnor.squashfs.tar -u
p9euh01: Update file /tmp/gurevich/pnor.squashfs.tar successfully uploaded
p9euh02: Update file /tmp/gurevich/pnor.squashfs.tar successfully uploaded
[root@stratton01 ~]#
```

Login problems:
```
[root@stratton01 ~]# rflash p9euh02,p9euh01 /tmp/gurevich/pnor.squashfs.tar -u
p9euh01: Unable to login : 401 Unauthorized - Invalid username or password
p9euh02: Unable to login : 401 Unauthorized - Invalid username or password
[root@stratton01 ~]#
```

Upload problems:
```
[root@stratton01 ~]# rflash p9euh02,p9euh01 /tmp/gurevich/pnor.squashfs.tar -u
p9euh01: Failed to upload update file /tmp/gurevich/pnor.squashfs.tar : 403 Forbidden - The specified resource cannot be created: '/upload/imagea/pnor.squashfs.tar'
p9euh02: Failed to upload update file /tmp/gurevich/pnor.squashfs.tar : 403 Forbidden - The specified resource cannot be created: '/upload/imagea/pnor.squashfs.tar'
```