### PR TITLE
Allow copycds -n able to pass in any string without the OS name involved

### DIFF
--- a/xCAT-server/lib/perl/xCAT/SvrUtils.pm
+++ b/xCAT-server/lib/perl/xCAT/SvrUtils.pm
@@ -587,11 +587,13 @@ sub update_tables_with_templates
         }
     }
 
-    #for rhels5.1  genos=rhel5
+    # Set genos to hold the major version
     my $genos = $osver;
     $genos =~ s/\..*//;
     if ($genos =~ /rh.*s(\d*)/) {
         $genos = "rhels$1";
+    } elsif ($genos =~ /sles(\d*)/) {
+        $genos = "sles$1";
     }
 
 
@@ -785,11 +787,13 @@ sub update_tables_with_mgt_image
         return 0;
     }
 
-    #for rhels5.1  genos=rhel5
+    # Set genos to hold the major version
     my $genos = $osver;
     $genos =~ s/\..*//;
     if ($genos =~ /rh.*s(\d*)/) {
         $genos = "rhels$1";
+    } elsif ($genos =~ /sles(\d*)/) {
+        $genos = "sles$1";
     }
 
     #if the osver does not match the osver of MN, return
@@ -984,11 +988,13 @@ sub update_tables_with_diskless_image
         }
     }
 
-    #for rhels5.1  genos=rhel5
+    # Set genos to hold the major version
     my $genos = $osver;
     $genos =~ s/\..*//;
     if ($genos =~ /rh.*s(\d*)/) {
         $genos = "rhels$1";
+    } elsif ($genos =~ /sles(\d*)/) {
+        $genos = "sles$1";
     }
 
     #print "osver=$osver, arch=$arch, osname=$osname, genos=$genos, profile=$profile\n";

--- a/xCAT-server/lib/perl/xCAT/SvrUtils.pm
+++ b/xCAT-server/lib/perl/xCAT/SvrUtils.pm
@@ -225,8 +225,6 @@ sub get_nodeset_state
 
     if (defined($boottype))
     {
-        #my $boottype = $ent->{netboot};
-
         #get nodeset state from corresponding files
         if ($boottype eq "pxe")
         {
@@ -628,14 +626,6 @@ sub update_tables_with_templates
 
     #print "osver=$osver, arch=$arch, osname=$osname, genos=$genos\n";
     my $installroot = xCAT::TableUtils->getInstallDir();
-
-    #my $sitetab = xCAT::Table->new('site');
-    #if ($sitetab) {
-    #	(my $ref) = $sitetab->getAttribs({key => "installdir"}, "value");
-    #	if ($ref and $ref->{value}) {
-    #       $installroot = $ref->{value};
-    #	}
-    #}
     my @installdirs = xCAT::TableUtils->get_site_attribute("installdir");
     my $tmp         = $installdirs[0];
     if (defined($tmp)) {
@@ -658,8 +648,6 @@ sub update_tables_with_templates
         }
         $tmpf =~ /^([^\.]*)\..*$/;
         $tmpf = $1;
-
-        #print "$tmpf\n";
         $profiles{$tmpf} = 1;
     }
     @tmplfiles = glob($defpath . "/{compute,service}.*tmpl");
@@ -689,8 +677,6 @@ sub update_tables_with_templates
         }
     }
     foreach my $profile (keys %profiles) {
-
-        #print "profile=$profile\n";
         #get template file
         my $tmplfile = get_tmpl_file_name($cuspath, $profile, $osver, $arch, $genos);
         if (!$tmplfile) { $tmplfile = get_tmpl_file_name($defpath, $profile, $osver, $arch, $genos); }
@@ -713,7 +699,6 @@ sub update_tables_with_templates
         }
 
         if ($osimagetab) {
-
             #check if the image is already in the table
             if ($osimagetab) {
                 my $found = 0;
@@ -726,9 +711,6 @@ sub update_tables_with_templates
                         }
                     }
                 }
-
-                #		if ($found) { next; }
-
                 my $imagename = $osver . "-" . $arch . "-install-" . $profile;
 
                 #TODO: check if there happen to be a row that has the same imagename but with different contents
@@ -832,7 +814,6 @@ sub update_tables_with_mgt_image
         return 0;
     }
 
-
     #for rhels5.1  genos=rhel5
     my $genos = $osver;
     $genos =~ s/\..*//;
@@ -865,8 +846,6 @@ sub update_tables_with_mgt_image
         #get the profile name out of the file, TODO: this does not work if the profile name contains the '.'
         $tmpf =~ /^([^\.]*)\..*$/;
         $tmpf = $1;
-
-        #print "$tmpf\n";
         $profiles{$tmpf} = 1;
     }
     @tmplfiles = glob($defpath . "/{compute,service}.*tmpl");
@@ -886,8 +865,6 @@ sub update_tables_with_mgt_image
     my $linuximagetab;
     my $imagename = $osver . "-" . $arch . "-stateful" . "-mgmtnode";
     foreach my $profile (keys %profiles) {
-
-        #print "profile=$profile\n";
         #get template file
         my $tmplfile = get_tmpl_file_name($cuspath, $profile, $osver, $arch, $genos);
         if (!$tmplfile) { $tmplfile = get_tmpl_file_name($defpath, $profile, $osver, $arch, $genos); }
@@ -911,7 +888,6 @@ sub update_tables_with_mgt_image
 
 
         if ($osimagetab) {
-
             #check if the image is already in the table
             if ($osimagetab) {
                 my $found = 0;
@@ -924,9 +900,6 @@ sub update_tables_with_mgt_image
                         }
                     }
                 }
-
-                #               if ($found) { next; }
-
 
                 #TODO: check if there happen to be a row that has the same imagename but with different contents
                 #now we can wirte the info into db
@@ -1048,14 +1021,6 @@ sub update_tables_with_diskless_image
 
     #print "osver=$osver, arch=$arch, osname=$osname, genos=$genos, profile=$profile\n";
     my $installroot = xCAT::TableUtils->getInstallDir();
-
-    #my $sitetab = xCAT::Table->new('site');
-    #if ($sitetab) {
-    #	(my $ref) = $sitetab->getAttribs({key => "installdir"}, "value");
-    #	if ($ref and $ref->{value}) {
-    #	    $installroot = $ref->{value};
-    #	}
-    #}
     my @installdirs = xCAT::TableUtils->get_site_attribute("installdir");
     my $tmp         = $installdirs[0];
     if (defined($tmp)) {
@@ -1090,12 +1055,9 @@ sub update_tables_with_diskless_image
         }
     }
     foreach my $profile (keys %profiles) {
-
         #get the pkglist file
         my $pkglistfile = get_pkglist_file_name($cuspath, $profile, $osver, $arch);
         if (!$pkglistfile) { $pkglistfile = get_pkglist_file_name($defpath, $profile, $osver, $arch); }
-
-        #print "pkglistfile=$pkglistfile\n";
         if (!$pkglistfile) { next; }
 
         #get otherpkgs.pkglist file
@@ -1112,7 +1074,6 @@ sub update_tables_with_diskless_image
         #get postinstall script file name
         my $postfile = get_postinstall_file_name($cuspath, $profile, $osver, $arch);
         if (!$postfile) { $postfile = get_postinstall_file_name($defpath, $profile, $osver, $arch); }
-
 
         #now update the db
         if (!$osimagetab) {
@@ -1135,8 +1096,6 @@ sub update_tables_with_diskless_image
                 }
                 if ($found) {
                     print "The image is already in the db.\n";
-
-                    #                         next;
                 }
 
                 my $imagename = $osver . "-" . $arch . "-$provm-" . $profile;
@@ -1367,12 +1326,10 @@ sub subVars {
             foreach my $part (split('\$', $p)) {
                 if ($part eq '') { next; }
 
-                #$callback->({error=>["part is $part"],errorcode=>[1]});
                 # check if p is just the node name:
                 if ($part eq 'node') {
 
                     # it is so, just return the node.
-                    #$fdir .= "/$pre$node$suf";
                     push @fParts, $node;
                 } else {
 
@@ -1387,9 +1344,6 @@ sub subVars {
                     my $ent;
                     my $val;
                     if ($table eq 'site') {
-
-                        #$val = $tab->getAttribs( { key => "$col" }, 'value' );
-                        #$val = $val->{'value'};
                         my @vals = xCAT::TableUtils->get_site_attribute($col);
                         $val = $vals[0];
                     } else {
@@ -1397,7 +1351,6 @@ sub subVars {
                         $val = $ent->{$col};
                     }
                     unless ($val) {
-
                         # couldn't find the value!!
                         $val = "UNDEFINED"
                     }
@@ -1411,7 +1364,6 @@ sub subVars {
                 $fdir .= $pre . $val . $suf;
             }
         } else {
-
             # no substitution here
             $fdir .= "/$p";
         }
@@ -1426,11 +1378,9 @@ sub subVars {
                 $p =~ s/CMD=//;
                 my $cmd = $p;
 
-                #$callback->({info=>[$p]});
                 $p = `$p 2>&1`;
                 chomp($p);
 
-                #$callback->({info=>[$p]});
                 unless ($p) {
                     $p = "#CMD=$p did not return output#";
                 }
@@ -1478,7 +1428,6 @@ sub setupNFSTree {
             shift @entries;
             if (grep /\Q$nfsdirectory\E/, @entries) {
                 $callback->({ data => ["$nfsdirectory has been exported already!"] });
-
                 # nothing to do
             } else {
                 $cmd = "/usr/sbin/exportfs :$nfsdirectory";
@@ -1593,11 +1542,6 @@ sub sendmsg {
         $curptr = $curptr->{data}->[0];
         if ($descr) { $curptr->{desc} = [$descr]; }
     }
-
-    #        print $outfd freeze([$msg]);
-    #        print $outfd "\nENDOFFREEZE6sK4ci\n";
-    #        yield;
-    #        waitforack($outfd);
     $callback->($msg);
 }
 
@@ -1636,7 +1580,6 @@ sub build_deps()
         return undef;
     }
     foreach my $node (@$nodes) {
-
         # Delete the nodes without dependencies from the hash
         if (!defined($depset->{$node}[0])) {
             delete($depset->{$node});

--- a/xCAT-server/lib/perl/xCAT/SvrUtils.pm
+++ b/xCAT-server/lib/perl/xCAT/SvrUtils.pm
@@ -565,6 +565,7 @@ sub update_tables_with_templates
     my $arch         = shift;    #like ppc64, x86, x86_64
     my $ospkgdir     = shift;
     my $osdistroname = shift;
+    my $userdistname = shift;
     my %args         = @_;
 
     my $osname    = $osver;;     #like sles, rh, centos, windows
@@ -597,7 +598,7 @@ sub update_tables_with_templates
     }
 
 
-    print "update_tables_with_templates() osver=$osver, arch=$arch, ospkgdir=$ospkgdir, osdistroname=$osdistroname, osname=$osname, genos=$genos\n";
+    print "update_tables_with_templates() osver=$osver, arch=$arch, ospkgdir=$ospkgdir, osdistroname=$osdistroname, osname=$osname, genos=$genos userdistname=$userdistname\n";
     my $installroot = xCAT::TableUtils->getInstallDir();
     my @installdirs = xCAT::TableUtils->get_site_attribute("installdir");
     my $tmp         = $installdirs[0];
@@ -684,7 +685,7 @@ sub update_tables_with_templates
                         }
                     }
                 }
-                my $imagename = $osver . "-" . $arch . "-install-" . $profile;
+                my $imagename = $userdistname . "-" . $arch . "-install-" . $profile;
 
                 #TODO: check if there happen to be a row that has the same imagename but with different contents
                 #now we can wirte the info into db
@@ -759,6 +760,7 @@ sub update_tables_with_mgt_image
     my $arch         = shift;    #like ppc64, x86, x86_64
     my $ospkgdir     = shift;
     my $osdistroname = shift;
+    my $userdistname = shift;
 
     my $osname    = $osver;;     #like sles, rh, centos, windows
     my $ostype    = "Linux";     #like Linux, Windows
@@ -839,7 +841,7 @@ sub update_tables_with_mgt_image
     #update the osimage and linuximage table
     my $osimagetab;
     my $linuximagetab;
-    my $imagename = $osver . "-" . $arch . "-stateful" . "-mgmtnode";
+    my $imagename = $userdistname . "-" . $arch . "-stateful" . "-mgmtnode";
     foreach my $profile (keys %profiles) {
         #get template file
         my $tmplfile = get_tmpl_file_name($cuspath, $profile, $osver, $arch, $genos);
@@ -968,6 +970,7 @@ sub update_tables_with_diskless_image
     my $mode         = shift;
     my $ospkgdir     = shift;
     my $osdistroname = shift;
+    my $userdistname = shift;
 
     my $provm = "netboot";
     if ($mode) { $provm = $mode; }
@@ -1077,7 +1080,7 @@ sub update_tables_with_diskless_image
                     print "The image is already in the db.\n";
                 }
 
-                my $imagename = $osver . "-" . $arch . "-$provm-" . $profile;
+                my $imagename = $userdistname . "-" . $arch . "-$provm-" . $profile;
 
                 #TODO: check if there happen to be a row that has the same imagename but with different contents
                 #now we can wirte the info into db

--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -2151,12 +2151,8 @@ sub copycd
     my $installroot = "/install";
     my $sitetab     = xCAT::Table->new('site');
 
-
     require xCAT::data::discinfo;
 
-    #if ($sitetab)
-    #{
-    #    (my $ref) = $sitetab->getAttribs({key => 'installdir'}, 'value');
     my @ents     = xCAT::TableUtils->get_site_attribute("installdir");
     my $site_ent = $ents[0];
     if (defined($site_ent))
@@ -2182,9 +2178,9 @@ sub copycd
         'o'   => \$noosimage,
         'w'   => \$nonoverwrite,
     );
+
     unless ($mntpath)
     {
-
         #this plugin needs $mntpath...
         return;
     }
@@ -2341,7 +2337,6 @@ sub copycd
         return;
     }
 
-
     #tranverse the directory structure of the os media and get the fingerprint
     my @filelist = ();
     find(
@@ -2389,8 +2384,6 @@ sub copycd
         }
     }
     $tabosdistro->close();
-
-
 
     $callback->({ data => "Copying media to $path" });
     my $omask = umask 0022;
@@ -2460,8 +2453,6 @@ sub copycd
         }
     }
 
-    #my $rc = system("cd $path; find . | nice -n 20 cpio -dump $installroot/$distname/$arch");
-    #my $rc = system("cd $path;rsync -a . $installroot/$distname/$arch/");
     chmod 0755, "$path";
 
     #append the fingerprint to the .fingerprint file to indicate that the os media has been copied in
@@ -2495,15 +2486,9 @@ sub copycd
             }
 
             #hiding the messages about this not being found, since it may be intentional
-
             my @ret = xCAT::SvrUtils->update_tables_with_mgt_image($distname, $arch, $path, $osdistroname);
-
             my @ret = xCAT::SvrUtils->update_tables_with_diskless_image($distname, $arch, undef, "netboot", $path, $osdistroname);
-
-            #if ($ret[0] != 0) {
-            #$callback->({data => "Error when updating the osimage tables for stateless: " . $ret[1]});
-            #}
-            my @ret=xCAT::SvrUtils->update_tables_with_diskless_image($distname, $arch, undef, "statelite",$path,$osdistroname);
+            my @ret = xCAT::SvrUtils->update_tables_with_diskless_image($distname, $arch, undef, "statelite",$path,$osdistroname);
         }
     }
 }

--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -2324,7 +2324,7 @@ sub copycd
         );
         return;
     }
-    print "INFO - detected distname=$distname, arch=$arch\n";
+    print "INFO - detected distname=$distname, arch=$arch, userdistname=$userdistname\n";
 
     %{$request} = ();    #clear request we've got it.
     my $disccopiedin = 0;
@@ -2336,7 +2336,7 @@ sub copycd
         $path = $defaultpath;
     }
     if ($::XCATSITEVALS{osimagerequired}) {
-        my ($nohaveimages, $errstr) = xCAT::SvrUtils->update_tables_with_templates($distname, $arch, $path, $osdistroname, checkonly => 1);
+        my ($nohaveimages, $errstr) = xCAT::SvrUtils->update_tables_with_templates($userdistname, $arch, $path, $osdistroname, checkonly => 1);
         if ($nohaveimages) {
             $callback->({ error => "No Templates found to support $distname($arch)", errorcode => 2 });
             return;
@@ -2484,21 +2484,21 @@ sub copycd
     else
     {
         $callback->({ data => "Media copy operation successful" });
-        my @ret = xCAT::SvrUtils->update_osdistro_table($distname, $arch, $path, $osdistroname);
+        my @ret = xCAT::SvrUtils->update_osdistro_table($userdistname, $arch, $path, $osdistroname);
         if ($ret[0] != 0) {
             $callback->({ data => "Error when updating the osdistro tables: " . $ret[1] });
         }
 
         unless ($noosimage) {
-            my @ret = xCAT::SvrUtils->update_tables_with_templates($distname, $arch, $path, $osdistroname);
+            my @ret = xCAT::SvrUtils->update_tables_with_templates($userdistname, $arch, $path, $osdistroname);
             if ($ret[0] != 0) {
                 $callback->({ data => "Error when updating the osimage tables: " . $ret[1] });
             }
 
             #hiding the messages about this not being found, since it may be intentional
-            my @ret = xCAT::SvrUtils->update_tables_with_mgt_image($distname, $arch, $path, $osdistroname);
-            my @ret = xCAT::SvrUtils->update_tables_with_diskless_image($distname, $arch, undef, "netboot", $path, $osdistroname);
-            my @ret = xCAT::SvrUtils->update_tables_with_diskless_image($distname, $arch, undef, "statelite",$path,$osdistroname);
+            my @ret = xCAT::SvrUtils->update_tables_with_mgt_image($userdistname, $arch, $path, $osdistroname);
+            my @ret = xCAT::SvrUtils->update_tables_with_diskless_image($userdistname, $arch, undef, "netboot", $path, $osdistroname);
+            my @ret = xCAT::SvrUtils->update_tables_with_diskless_image($userdistname, $arch, undef, "statelite",$path,$osdistroname);
         }
     }
 }

--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -2336,7 +2336,7 @@ sub copycd
         $path = $defaultpath;
     }
     if ($::XCATSITEVALS{osimagerequired}) {
-        my ($nohaveimages, $errstr) = xCAT::SvrUtils->update_tables_with_templates($userdistname, $arch, $path, $osdistroname, checkonly => 1);
+        my ($nohaveimages, $errstr) = xCAT::SvrUtils->update_tables_with_templates($distname, $arch, $path, $osdistroname, $userdistname, checkonly => 1);
         if ($nohaveimages) {
             $callback->({ error => "No Templates found to support $distname($arch)", errorcode => 2 });
             return;
@@ -2484,21 +2484,21 @@ sub copycd
     else
     {
         $callback->({ data => "Media copy operation successful" });
-        my @ret = xCAT::SvrUtils->update_osdistro_table($userdistname, $arch, $path, $osdistroname);
+        my @ret = xCAT::SvrUtils->update_osdistro_table($distname, $arch, $path, $osdistroname, $userdistname);
         if ($ret[0] != 0) {
             $callback->({ data => "Error when updating the osdistro tables: " . $ret[1] });
         }
 
         unless ($noosimage) {
-            my @ret = xCAT::SvrUtils->update_tables_with_templates($userdistname, $arch, $path, $osdistroname);
+            my @ret = xCAT::SvrUtils->update_tables_with_templates($distname, $arch, $path, $osdistroname, $userdistname);
             if ($ret[0] != 0) {
                 $callback->({ data => "Error when updating the osimage tables: " . $ret[1] });
             }
 
             #hiding the messages about this not being found, since it may be intentional
-            my @ret = xCAT::SvrUtils->update_tables_with_mgt_image($userdistname, $arch, $path, $osdistroname);
-            my @ret = xCAT::SvrUtils->update_tables_with_diskless_image($userdistname, $arch, undef, "netboot", $path, $osdistroname);
-            my @ret = xCAT::SvrUtils->update_tables_with_diskless_image($userdistname, $arch, undef, "statelite",$path,$osdistroname);
+            my @ret = xCAT::SvrUtils->update_tables_with_mgt_image($distname, $arch, $path, $osdistroname, $userdistname);
+            my @ret = xCAT::SvrUtils->update_tables_with_diskless_image($distname, $arch, undef, "netboot", $path, $osdistroname, $userdistname);
+            my @ret = xCAT::SvrUtils->update_tables_with_diskless_image($distname, $arch, undef, "statelite",$path,$osdistroname, $userdistname);
         }
     }
 }

--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -2160,6 +2160,8 @@ sub copycd
         $installroot = $site_ent;
     }
 
+    # user specified name
+    my $userdistname = undef;
     my $distname;
     my $arch;
     my $path;
@@ -2170,7 +2172,7 @@ sub copycd
 
     @ARGV = @{ $request->{arg} };
     GetOptions(
-        'n=s' => \$distname,
+        'n=s' => \$userdistname,
         'a=s' => \$arch,
         'p=s' => \$path,
         'm=s' => \$mntpath,
@@ -2184,13 +2186,13 @@ sub copycd
         #this plugin needs $mntpath...
         return;
     }
-    if ($distname
-        and $distname !~ /^centos/
-        and $distname !~ /^fedora/
-        and $distname !~ /^SL/
-        and $distname !~ /^ol/
-        and $distname !~ /^pkvm/
-        and $distname !~ /^rh/)
+    if ($userdistname
+        and $userdistname !~ /^centos/
+        and $userdistname !~ /^fedora/
+        and $userdistname !~ /^SL/
+        and $userdistname !~ /^ol/
+        and $userdistname !~ /^pkvm/
+        and $userdistname !~ /^rh/)
     {
 
         #If they say to call it something unidentifiable, give up?
@@ -2216,6 +2218,7 @@ sub copycd
         $darch = "x86";
     }
     close($dinfo);
+
     if ($xCAT::data::discinfo::distnames{$did})
     {
         unless ($distname)
@@ -2282,6 +2285,13 @@ sub copycd
             return;    #Do nothing, not ours..
         }
     }
+
+    unless ($userdistname) 
+    {
+        # If not userdefined, set to detected distname.
+        $userdistname = $distname;
+    }
+
     if ($darch)
     {
         unless ($arch)
@@ -2320,7 +2330,7 @@ sub copycd
     my $disccopiedin = 0;
     my $osdistroname = $distname . "-" . $arch;
 
-    my $defaultpath = "$installroot/$distname/$arch";
+    my $defaultpath = "$installroot/$userdistname/$arch";
     unless ($path)
     {
         $path = $defaultpath;

--- a/xCAT-server/lib/xcat/plugins/debian.pm
+++ b/xCAT-server/lib/xcat/plugins/debian.pm
@@ -182,6 +182,7 @@ sub copycd
     my $callback    = shift;
     my $doreq       = shift;
     my $distname    = "";
+    my $userdistname = undef;
     my $detdistname = "";
     my $installroot;
     my $arch;
@@ -202,7 +203,7 @@ sub copycd
 
     @ARGV = @{ $request->{arg} };
     GetOptions(
-        'n=s' => \$distname,
+        'n=s' => \$userdistname,
         'a=s' => \$arch,
         'p=s' => \$copypath,
         'm=s' => \$path,
@@ -212,15 +213,13 @@ sub copycd
     );
     unless ($path)
     {
-
         #this plugin needs $path...
         return;
     }
-    if ($distname
-        and $distname !~ /^debian/i
-        and $distname !~ /^ubuntu/i)
+    if ($userdistname
+        and $userdistname !~ /^debian/i
+        and $userdistname !~ /^ubuntu/i)
     {
-
         #If they say to call it something unidentifiable, give up?
         return;
     }
@@ -287,6 +286,12 @@ sub copycd
     {
         return;
     }
+    print "VKHU_DEBUG - info picked out... prod=$prod, ver=$ver, darch=$darch\n";
+    unless ($userdistname)
+    {
+        # if not userdefined, set to the detected distname
+        $userdistname = $distname;
+    }
 
     # So that I can use amd64 below
     my $debarch = $darch;
@@ -307,9 +312,8 @@ sub copycd
     {
         $darch = "x86_64";
     }
-
     if ($darch)
-    {
+    { 
         unless ($arch)
         {
             $arch = $darch;
@@ -330,18 +334,23 @@ sub copycd
         $callback->(
             {
                 info =>
-"DISTNAME:$distname\n" . "ARCH:$debarch\n" . "DISCNO:$discno\n"
+"DISTNAME:$distname\n" . "USERDISTNAME:$userdistname\n" . "ARCH:$debarch\n" . "DISCNO:$discno\n"
             }
         );
         return;
     }
     %{$request} = ();    #clear request we've got it.
+    my $defaultpath = "$installroot/$userdistname/$arch";
+    unless ($path)
+    {
+        $path = $defaultpath;
+    }
 
     $callback->(
-        { data => "Copying media to $installroot/$distname/$arch" });
+        { data => "Copying media to $defaultpath" });
     my $omask = umask 0022;
-    mkpath("$installroot/$distname/$arch");
-    mkpath("$installroot/$distname/$arch/install/netboot") if ($isnetinst);
+    mkpath("$defaultpath");
+    mkpath("$defaultpath/install/netboot") if ($isnetinst);
     umask $omask;
     my $rc;
     $SIG{INT} = $SIG{TERM} = sub {
@@ -370,7 +379,7 @@ sub copycd
         close($kid);
         $rc = $?;
     } else {
-        my $c = "nice -n 20 cpio -vdump $installroot/$distname/$arch";
+        my $c = "nice -n 20 cpio -vdump $defaultpath";
         my $k2 = open(PIPE, "$c 2>&1 |") ||
           $callback->({ error => "Media copy operation fork failure" });
         push @cpiopid, $k2;
@@ -386,30 +395,27 @@ sub copycd
         exit;
     }
 
-    #  system(
-    #    "cd $path; find . | nice -n 20 cpio -dump $installroot/$distname/$arch/"
-    #    );
-    chmod 0755, "$installroot/$distname/$arch";
+    chmod 0755, "$defaultpath";
 
     # Need to do this otherwise there will be warning about corrupt Packages file
     # when installing a system
 
     # Grabs the distribution codename
-    my @line = split(" ", `ls -lh $installroot/$distname/$arch/dists/ | grep dr`);
+    my @line = split(" ", `ls -lh $defaultpath/dists/ | grep dr`);
     my $dist = $line[ @line - 1 ];
 
     # touches the Packages file so that deb packaging works
-    system("touch $installroot/$distname/$arch/dists/$dist/restricted/binary-$debarch/Packages");
+    system("touch $defaultpath/dists/$dist/restricted/binary-$debarch/Packages");
 
     # removes the links unstable and testing, otherwise the repository does not work for debian
-    system("rm -f $installroot/$distname/$arch/dists/unstable");
-    system("rm -f $installroot/$distname/$arch/dists/testing");
+    system("rm -f $defaultpath/dists/unstable");
+    system("rm -f $defaultpath/dists/testing");
 
     # copies the netboot files for debian
     if ($isnetinst)
     {
-        system("cp install.*/initrd.gz $installroot/$distname/$arch/install/netboot/.");
-        system("cp install.*/vmlinuz $installroot/$distname/$arch/install/netboot/.");
+        system("cp install.*/initrd.gz $defaultpath/install/netboot/.");
+        system("cp install.*/vmlinuz $defaultpath/install/netboot/.");
     }
 
     if ($rc != 0)
@@ -419,19 +425,18 @@ sub copycd
     else
     {
         my $osdistoname = $distname . "-" . $arch;
-        my $temppath    = "$installroot/$distname/$arch";
-        my @ret = xCAT::SvrUtils->update_osdistro_table($distname, $arch, $temppath, $osdistroname);
+        my @ret = xCAT::SvrUtils->update_osdistro_table($distname, $arch, $path, $osdistroname, $userdistname);
         if ($ret[0] != 0) {
             $callback->({ data => "Error when updating the osdistro tables: " . $ret[1] });
         }
 
         $callback->({ data => "Media copy operation successful" });
         unless ($noosimage) {
-            my @ret = xCAT::SvrUtils->update_tables_with_templates($distname, $arch, $temppath, $osdistroname);
+            my @ret = xCAT::SvrUtils->update_tables_with_templates($distname, $arch, $path, $osdistroname, $userdistname);
             if ($ret[0] != 0) {
                 $callback->({ data => "Error when updating the osimage tables: " . $ret[1] });
             }
-            my @ret = xCAT::SvrUtils->update_tables_with_diskless_image($distname, $arch, undef, "netboot", $temppath, $osdistroname);
+            my @ret = xCAT::SvrUtils->update_tables_with_diskless_image($distname, $arch, undef, "netboot", $path, $osdistroname, $userdistname);
             if ($ret[0] != 0) {
                 $callback->({ data => "Error when updating the osimage tables for stateless: " . $ret[1] });
             }

--- a/xCAT-server/lib/xcat/plugins/sles.pm
+++ b/xCAT-server/lib/xcat/plugins/sles.pm
@@ -1724,6 +1724,7 @@ sub copycd
     my $installroot;
     my $arch;
     my $path;
+    my $userdistname = undef;
     my $mntpath      = undef;
     my $inspection   = undef;
     my $noosimage    = undef;
@@ -1738,7 +1739,7 @@ sub copycd
 
     @ARGV = @{ $request->{arg} };
     GetOptions(
-        'n=s' => \$distname,
+        'n=s' => \$userdistname,
         'a=s' => \$arch,
         'm=s' => \$mntpath,
         'i'   => \$inspection,
@@ -1761,9 +1762,8 @@ sub copycd
         $path =~ s,//*,/,g;
     }
 
-    if ($distname and $distname !~ /^sles|^suse/)
+    if ($userdistname and $userdistname !~ /^sles|^suse/)
     {
-
         #If they say to call it something other than SLES or SUSE, give up?
         return;
     }
@@ -1889,7 +1889,11 @@ sub copycd
         #failed to parse the disc info
         return;
     }
-
+    unless ($userdistname)
+    {
+        # if not userdefined, set to the detected distname
+        $userdistname = $distname;
+    }
     if ($darch and $darch =~ /i.86/)
     {
         $darch = "x86";
@@ -1925,21 +1929,21 @@ sub copycd
         $callback->(
             {
                 info =>
-"DISTNAME:$distname\n" . "ARCH:$arch\n" . "DISCNO:$discnumber\n"
+"DISTNAME:$distname\n" . "USERDISTNAME:$userdistname\n" . "ARCH:$arch\n" . "DISCNO:$discnumber\n"
             }
         );
         return;
     }
 
     %{$request} = ();    #clear request we've got it.
-    my $defaultpath = "$installroot/$distname/$arch";
+    my $defaultpath = "$installroot/$userdistname/$arch";
     unless ($path)
     {
         $path = $defaultpath;
     }
     my $osdistroname = $distname . "-" . $arch;
     if ($::XCATSITEVALS{osimagerequired}) {
-        my ($nohaveimages, $errstr) = xCAT::SvrUtils->update_tables_with_templates($distname, $arch, $path, $osdistroname, checkonly => 1);
+        my ($nohaveimages, $errstr) = xCAT::SvrUtils->update_tables_with_templates($userdistname, $arch, $path, $osdistroname, checkonly => 1);
         if ($nohaveimages) {
             $callback->({ error => "No Templates found to support $distname($arch)", errorcode => 2 });
             return;
@@ -2118,9 +2122,9 @@ sub copycd
         if ($arch eq "x86") {
             $ycparch = "i386";
         }
-        system("mount -o loop $installroot/$distname/$arch/$discnumber/boot/$ycparch/root $tmnt");
+        system("mount -o loop $installroot/$userdistname/$arch/$discnumber/boot/$ycparch/root $tmnt");
         system("cd $tmnt;find . |cpio -dump $tdir");
-        system("umount $tmnt;rm $installroot/$distname/$arch/$discnumber/boot/$ycparch/root");
+        system("umount $tmnt;rm $installroot/$userdistname/$arch/$discnumber/boot/$ycparch/root");
         open($startupfile, "<", "$tdir/usr/share/YaST2/clients/inst_startup.ycp");
         my @ycpcontents = <$startupfile>;
         my @newcontents;
@@ -2143,7 +2147,7 @@ sub copycd
             print $startupfile $_;
         }
         close($startupfile);
-        system("cd $tdir;mkfs.cramfs . $installroot/$distname/$arch/$discnumber/boot/$ycparch/root");
+        system("cd $tdir;mkfs.cramfs . $installroot/$userdistname/$arch/$discnumber/boot/$ycparch/root");
         system("rm -rf $tmnt $tdir");
     }
 
@@ -2155,28 +2159,28 @@ sub copycd
     {
         $callback->({ data => "Media copy operation successful" });
 
-        my @ret = xCAT::SvrUtils->update_osdistro_table($distname, $arch, $path, $osdistroname);
+        my @ret = xCAT::SvrUtils->update_osdistro_table($userdistname, $arch, $path, $osdistroname);
         if ($ret[0] != 0) {
             $callback->({ data => "Error when updating the osdistro tables: " . $ret[1] });
         }
 
         #if --noosimage option is not specified, create the relevant osimage and linuximage entris
         unless ($noosimage) {
-            my @ret = xCAT::SvrUtils->update_tables_with_templates($distname, $arch, $path, $osdistroname);
+            my @ret = xCAT::SvrUtils->update_tables_with_templates($userdistname, $arch, $path, $osdistroname);
             if ($ret[0] != 0) {
                 $callback->({ data => "Error when updating the osimage tables: " . $ret[1] });
             }
 
-            my @ret = xCAT::SvrUtils->update_tables_with_mgt_image($distname, $arch, $path, $osdistroname);
+            my @ret = xCAT::SvrUtils->update_tables_with_mgt_image($userdistname, $arch, $path, $osdistroname);
             if ($ret[0] != 0) {
                 $callback->({ data => "Error when updating the osimage tables for management node " . $ret[1] });
             }
 
-            my @ret = xCAT::SvrUtils->update_tables_with_diskless_image($distname, $arch, undef, "netboot", $path, $osdistroname);
+            my @ret = xCAT::SvrUtils->update_tables_with_diskless_image($userdistname, $arch, undef, "netboot", $path, $osdistroname);
             if ($ret[0] != 0) {
                 $callback->({ data => "Error when updating the osimage tables for stateless: " . $ret[1] });
             }
-            my @ret=xCAT::SvrUtils->update_tables_with_diskless_image($distname, $arch, undef, "statelite",$path,$osdistroname);
+            my @ret=xCAT::SvrUtils->update_tables_with_diskless_image($userdistname, $arch, undef, "statelite",$path,$osdistroname);
             if ($ret[0] != 0) {
               $callback->({data => "Error when updating the osimage tables for statelite: " . $ret[1]});
             }

--- a/xCAT-server/lib/xcat/plugins/sles.pm
+++ b/xCAT-server/lib/xcat/plugins/sles.pm
@@ -2159,28 +2159,28 @@ sub copycd
     {
         $callback->({ data => "Media copy operation successful" });
 
-        my @ret = xCAT::SvrUtils->update_osdistro_table($userdistname, $arch, $path, $osdistroname);
+        my @ret = xCAT::SvrUtils->update_osdistro_table($distname, $arch, $path, $osdistroname, $userdistname);
         if ($ret[0] != 0) {
             $callback->({ data => "Error when updating the osdistro tables: " . $ret[1] });
         }
 
         #if --noosimage option is not specified, create the relevant osimage and linuximage entris
         unless ($noosimage) {
-            my @ret = xCAT::SvrUtils->update_tables_with_templates($userdistname, $arch, $path, $osdistroname);
+            my @ret = xCAT::SvrUtils->update_tables_with_templates($distname, $arch, $path, $osdistroname, $userdistname);
             if ($ret[0] != 0) {
                 $callback->({ data => "Error when updating the osimage tables: " . $ret[1] });
             }
 
-            my @ret = xCAT::SvrUtils->update_tables_with_mgt_image($userdistname, $arch, $path, $osdistroname);
+            my @ret = xCAT::SvrUtils->update_tables_with_mgt_image($distname, $arch, $path, $osdistroname, $userdistname);
             if ($ret[0] != 0) {
                 $callback->({ data => "Error when updating the osimage tables for management node " . $ret[1] });
             }
 
-            my @ret = xCAT::SvrUtils->update_tables_with_diskless_image($userdistname, $arch, undef, "netboot", $path, $osdistroname);
+            my @ret = xCAT::SvrUtils->update_tables_with_diskless_image($distname, $arch, undef, "netboot", $path, $osdistroname, $userdistname);
             if ($ret[0] != 0) {
                 $callback->({ data => "Error when updating the osimage tables for stateless: " . $ret[1] });
             }
-            my @ret=xCAT::SvrUtils->update_tables_with_diskless_image($userdistname, $arch, undef, "statelite",$path,$osdistroname);
+            my @ret=xCAT::SvrUtils->update_tables_with_diskless_image($distname, $arch, undef, "statelite",$path,$osdistroname, $userdistname);
             if ($ret[0] != 0) {
               $callback->({data => "Error when updating the osimage tables for statelite: " . $ret[1]});
             }

--- a/xCAT-server/lib/xcat/plugins/sles.pm
+++ b/xCAT-server/lib/xcat/plugins/sles.pm
@@ -1730,19 +1730,11 @@ sub copycd
     my $nonoverwrite = undef;
 
     $installroot = "/install";
-
-    #my $sitetab = xCAT::Table->new('site');
-    #if ($sitetab)
-    #{
-    #(my $ref) = $sitetab->getAttribs({key => 'installdir'}, 'value');
-    #print Dumper($ref);
     my @entries = xCAT::TableUtils->get_site_attribute("installdir");
     my $t_entry = $entries[0];
     if (defined($t_entry)) {
         $installroot = $t_entry;
     }
-
-    #}
 
     @ARGV = @{ $request->{arg} };
     GetOptions(
@@ -2082,13 +2074,8 @@ sub copycd
             exit(1);
         }
     }
-
-    #  system(
-    #    "cd $path; find . | nice -n 20 cpio -dump $installroot/$distname/$arch/$discnumber/"
-    #    );
     chmod 0755, "$path";
     chmod 0755, "$ospkgpath";
-
 
     #append the fingerprint to the .fingerprint file to indicate that the os media has been copied in
     unless ($disccopiedin)


### PR DESCRIPTION
The following pull request attempts to make `copycds -n` more flexible.   The distribution name and path where we copy the image to is taken from the string that is passed in, but xCAT continues to attempt to determine the REAL OS name from either the `discinfo.pm` file or by auto-detection.  

This allows the user to specify a name that does not require a format like "rhels7.3..."  Currently, the code fails to be able to determine the correct template files to used, depending on `.` separted vs `-` separated.  

For example, For rhels 7.0 (ppc64), running the following command without `-n` option correctly determines the `osvers` and `pkglist` template files: 
```
[root@c910f02c05p02 opt]# copycds /mnt/xcat/iso/redhat/7/RHEL-7.0-20140507.0-Server-ppc64-dvd1.iso
Copying media to /install/rhels7/ppc64
Media copy operation successful
[root@c910f02c05p02 opt]# lsdef -t osimage -o rhels7-ppc64-install-compute -i osvers,pkglist,template
Object name: rhels7-ppc64-install-compute
    osvers=rhels7
    pkglist=/opt/xcat/share/xcat/install/rh/compute.rhels7.pkglist
    template=/opt/xcat/share/xcat/install/rh/compute.rhels7.tmpl
```

But using `-n rhels7-ipmitool` causes a break.... 
```
[root@c910f02c05p02 opt]# copycds -n rhels7-ipmitool /mnt/xcat/iso/redhat/7/RHEL-7.0-20140507.0-Server-ppc64-dvd1.iso
Copying media to /install/rhels7-ipmitool/ppc64
Media copy operation successful
[root@c910f02c05p02 opt]# lsdef -t osimage -o rhels7-ipmitool-ppc64-install-compute -i osvers,pkglist,template
Object name: rhels7-ipmitool-ppc64-install-compute
    osvers=rhels7-ipmitool
    pkglist=/opt/xcat/share/xcat/install/rh/compute.ppc64.pkglist
    template=/opt/xcat/share/xcat/install/rh/compute.ppc64.tmpl
```
It defaults to the `compute.ppc64.pkglist` and `compute.ppc64.tmpl`

