### PR TITLE
Fix autotest statelite case failure

### DIFF
--- a/xCAT-test/autotest/testcase/installation/litefile_sles.csv
+++ b/xCAT-test/autotest/testcase/installation/litefile_sles.csv
@@ -4,6 +4,7 @@
 "ALL","/etc/ntp.conf","tmpfs",,
 "ALL","/etc/ntp.conf.org","tmpfs",,
 "ALL","/etc/resolv.conf","tmpfs",,
+"ALL","/etc/hostname","tmpfs",,
 "ALL","/etc/ssh/","tmpfs",,
 "ALL","/etc/sysconfig/","tmpfs",,
 "ALL","/etc/syslog-ng/","tmpfs",,


### PR DESCRIPTION
Fix issue: #2616 

The litefile_sles.csv in autotest case is not updated as my issue described.

After fixed:
c910f03c11k12:~ # xdsh c910f03c11k14 hostname
c910f03c11k14: c910f03c11k14
c910f03c11k12:~ # xdsh c910f03c11k14 df -h
c910f03c11k14: Filesystem                                                       Size  Used Avail Use% Mounted on
c910f03c11k14: tmpfs                                                            4.0G   15M  4.0G   1% /run
c910f03c11k14: c910f03c11k13:/install/netboot/sles12.2/ppc64le/compute/rootimg   38G   12G   26G  31% /
c910f03c11k14: rw                                                               4.0G   42M  4.0G   2% /.statelite
c910f03c11k14: c910f03c11k13:/nodedata/c910f03c11k14                             38G   12G   26G  31% /.statelite/persistent
c910f03c11k14: rw                                                               4.0G   64K  4.0G   1% /.sllocal/log
c910f03c11k14: devtmpfs                                                         4.0G     0  4.0G   0% /dev
c910f03c11k14: tmpfs                                                            4.0G     0  4.0G   0% /dev/shm
c910f03c11k14: tmpfs                                                            4.0G     0  4.0G   0% /sys/fs/cgroup
c910f03c11k14: none                                                              10M     0   10M   0% /var/tmp
c910f03c11k14: tmpfs                                                            817M     0  817M   0% /run/user/0
