### PR TITLE
Refine test case: nodeset_cmdline, nodeset_runimage, nodeset_shell

### DIFF
--- a/xCAT-test/autotest/testcase/genesis/cases0
+++ b/xCAT-test/autotest/testcase/genesis/cases0
@@ -2,28 +2,31 @@ start:nodeset_shell
 description: verify could log in genesis shell
 cmd:perl /opt/xcat/share/xcat/tools/autotest/testcase/genesis/genesistest.pl  -n $$CN  -g
 check:rc==0
-cmd:perl /opt/xcat/share/xcat/tools/autotest/testcase/genesis/genesistest.pl  -n $$CN -s ;if [[ $? -eq 0 ]];then exit 0 ;else cat /var/log/consoles/$$CN; cat /tmp/genesistestlog/*;exit 1;fi
+cmd:perl /opt/xcat/share/xcat/tools/autotest/testcase/genesis/genesistest.pl  -n $$CN -s 
 check:rc==0
 cmd:perl /opt/xcat/share/xcat/tools/autotest/testcase/genesis/genesistest.pl  -n $$CN -c
 check:rc==0
+cmd:cat /tmp/genesistestlog/*
 end
 
 start:nodeset_cmdline
 description:verify could run cmdline successfully
 cmd:perl /opt/xcat/share/xcat/tools/autotest/testcase/genesis/genesistest.pl  -n $$CN  -g
 check:rc==0
-cmd:perl /opt/xcat/share/xcat/tools/autotest/testcase/genesis/genesistest.pl -n $$CN -d;if [[ $? -eq 0 ]];then exit 0 ;else cat /var/log/consoles/$$CN;cat /tmp/genesistestlog/*;exit 1;fi
+cmd:perl /opt/xcat/share/xcat/tools/autotest/testcase/genesis/genesistest.pl -n $$CN -d
 check:rc==0
 cmd:perl /opt/xcat/share/xcat/tools/autotest/testcase/genesis/genesistest.pl  -n $$CN -c 
 check:rc==0
+cmd:cat /tmp/genesistestlog/*
 end
 
 start:nodeset_runimg
 description:verify runimg could work
 cmd:perl /opt/xcat/share/xcat/tools/autotest/testcase/genesis/genesistest.pl  -n $$CN  -g
 check:rc==0
-cmd:perl /opt/xcat/share/xcat/tools/autotest/testcase/genesis/genesistest.pl -n $$CN -i;if [[ $? -eq 0 ]];then exit 0 ;else cat /var/log/consoles/$$CN;cat /tmp/genesistestlog/*;exit 1;fi 
+cmd:perl /opt/xcat/share/xcat/tools/autotest/testcase/genesis/genesistest.pl -n $$CN -i 
 check:rc==0
 cmd:perl /opt/xcat/share/xcat/tools/autotest/testcase/genesis/genesistest.pl -n $$CN -c
 check:rc==0
+cmd:cat /tmp/genesistestlog/*
 end

--- a/xCAT-test/autotest/testcase/genesis/cases0
+++ b/xCAT-test/autotest/testcase/genesis/cases0
@@ -2,7 +2,7 @@ start:nodeset_shell
 description: verify could log in genesis shell
 cmd:perl /opt/xcat/share/xcat/tools/autotest/testcase/genesis/genesistest.pl  -n $$CN  -g
 check:rc==0
-cmd:perl /opt/xcat/share/xcat/tools/autotest/testcase/genesis/genesistest.pl  -n $$CN -s 
+cmd:perl /opt/xcat/share/xcat/tools/autotest/testcase/genesis/genesistest.pl  -n $$CN -s ;if [[ $? -eq 0 ]];then exit 0 ;else cat /var/log/consoles/$$CN; cat /tmp/genesistestlog/*;exit 1;fi
 check:rc==0
 cmd:perl /opt/xcat/share/xcat/tools/autotest/testcase/genesis/genesistest.pl  -n $$CN -c
 check:rc==0
@@ -12,7 +12,7 @@ start:nodeset_cmdline
 description:verify could run cmdline successfully
 cmd:perl /opt/xcat/share/xcat/tools/autotest/testcase/genesis/genesistest.pl  -n $$CN  -g
 check:rc==0
-cmd:perl /opt/xcat/share/xcat/tools/autotest/testcase/genesis/genesistest.pl -n $$CN -d
+cmd:perl /opt/xcat/share/xcat/tools/autotest/testcase/genesis/genesistest.pl -n $$CN -d;if [[ $? -eq 0 ]];then exit 0 ;else cat /var/log/consoles/$$CN;cat /tmp/genesistestlog/*;exit 1;fi
 check:rc==0
 cmd:perl /opt/xcat/share/xcat/tools/autotest/testcase/genesis/genesistest.pl  -n $$CN -c 
 check:rc==0
@@ -22,7 +22,7 @@ start:nodeset_runimg
 description:verify runimg could work
 cmd:perl /opt/xcat/share/xcat/tools/autotest/testcase/genesis/genesistest.pl  -n $$CN  -g
 check:rc==0
-cmd:perl /opt/xcat/share/xcat/tools/autotest/testcase/genesis/genesistest.pl -n $$CN -i 
+cmd:perl /opt/xcat/share/xcat/tools/autotest/testcase/genesis/genesistest.pl -n $$CN -i;if [[ $? -eq 0 ]];then exit 0 ;else cat /var/log/consoles/$$CN;cat /tmp/genesistestlog/*;exit 1;fi 
 check:rc==0
 cmd:perl /opt/xcat/share/xcat/tools/autotest/testcase/genesis/genesistest.pl -n $$CN -c
 check:rc==0

--- a/xCAT-test/autotest/testcase/genesis/genesistest.pl
+++ b/xCAT-test/autotest/testcase/genesis/genesistest.pl
@@ -195,7 +195,7 @@ sub rungenesiscmd {
     }
     `rinstall $noderange "runcmd=cmdtest,shell"`;
     if ($?) {
-      send_msg(0, "nodeset noderange shell failed for runcmd test");
+      send_msg(0, "rinstall noderange shell failed for runcmd test");
     }
     return $value;
 }

--- a/xCAT-test/autotest/testcase/genesis/genesistest.pl
+++ b/xCAT-test/autotest/testcase/genesis/genesistest.pl
@@ -1,10 +1,5 @@
 #!/usr/bin/env perl
 # IBM(c) 2007 EPL license http://www.eclipse.org/legal/epl-v10.html
-BEGIN
-{
-    $::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : -d '/opt/xcat' ? '/opt/xcat' : '/usr';
-}
-use lib "$::XCATROOT/lib/perl";
 use strict;
 use warnings;
 use Getopt::Long;
@@ -71,7 +66,6 @@ if (!defined($noderange)) {
     exit 1;
 }
 my $os = &get_os;
-print "os is $os\n";
 if ($check_genesis_file) {
     send_msg(2, "[$$]:Check genesis file...............");
     &check_genesis_file(&get_arch);
@@ -171,7 +165,7 @@ sub check_genesis_file {
 sub rungenesiscmd {
     my $runcmd_script    = "/tmp/cmdtest";
     my $result           = "/tmp/testresult";
-    my $genesis_base_dir = "$::XCATROOT/share/xcat/netboot/genesis";
+    my $genesis_base_dir = "/opt/xcat/share/xcat/netboot/genesis";
     my $genesis_bin_dir;
     my $value = 0;
     my $arch  = shift;
@@ -211,7 +205,7 @@ sub rungenesiscmd {
 sub rungenesisimg {
     my $runimg_script    = "/tmp/imgtest";
     my $result           = "/tmp/testresult";
-    my $genesis_base_dir = "$::XCATROOT/share/xcat/netboot/genesis";
+    my $genesis_base_dir = "/opt/xcat/share/xcat/netboot/genesis";
     my $genesis_bin_dir;
     my $value = 0;
     mkdir("/install/my_image");
@@ -237,7 +231,6 @@ sub rungenesisimg {
     chmod 0755, "/install/my_image/runme.sh";
     `tar -zcvf /tmp/my_image.tgz -C /install/my_image .`;
     copy("/tmp/my_image.tgz", "/install/my_image") or die "Copy failed: $!";
-    print "master is $master\n";
     `rinstall $noderange "runimage=http://$master/install/my_image/my_image.tgz",shell`;
     if ($?) {
         send_msg(0, "rinstall noderange failed for runimg");
@@ -266,7 +259,7 @@ sub testxdsh {
     if (($value == 1) || ($value == 2) || ($value == 3)) {
         `xdsh $noderange -t 2 cat $checkfile |grep $checkstring`;
         if ($?) {
-            foreach (1 .. 15) {
+            foreach (1 .. 1500) {
                 `xdsh $noderange -t 2 cat $checkfile | grep $checkstring`;
                 last if ($? == 0);
             }
@@ -285,7 +278,7 @@ sub clearenv {
     my $runmetar            = "/install/my_image/my_image.tgz";
     my $runmetar_tmp         = "/tmp/my_image.tgz";
     my $runmedir         = "/install/my_image";
-    my $genesis_base_dir = "$::XCATROOT/share/xcat/netboot/genesis";
+    my $genesis_base_dir = "/opt/xcat/share/xcat/netboot/genesis";
     if (-e "$runimg_script") {
         unlink("$runme");
         unlink("$runmetar_tmp");

--- a/xCAT-test/autotest/testcase/genesis/genesistest.pl
+++ b/xCAT-test/autotest/testcase/genesis/genesistest.pl
@@ -77,6 +77,7 @@ if ($check_genesis_file) {
 }
 my $master=`lsdef -t site -i master -c  2>&1 | awk -F'=' '{print \$2}'`;
 if (!$master) { $master=hostname(); }
+chomp($master);
 print "master is $master\n"; 
 
 ####################################
@@ -260,7 +261,7 @@ sub testxdsh {
         `xdsh $noderange -t 2 cat $checkfile 2>&1|grep $checkstring `;
         if ($?) {
             foreach (1 .. 10) {
-                `sleep 300`;
+                sleep 300;
                 send_msg(1,"try to run xdsh to check the results again");
                 `xdsh $noderange -t 2 cat $checkfile 2>&1| grep $checkstring `;
                 last if ($? == 0);

--- a/xCAT-test/autotest/testcase/genesis/genesistest.pl
+++ b/xCAT-test/autotest/testcase/genesis/genesistest.pl
@@ -195,7 +195,7 @@ sub rungenesiscmd {
     }
     `rinstall $noderange "runcmd=cmdtest,shell"`;
     if ($?) {
-        send_msg(0, "rinstall noderange shell failed for runcmd test");
+      send_msg(0, "nodeset noderange shell failed for runcmd test");
     }
     return $value;
 }
@@ -257,10 +257,12 @@ sub testxdsh {
         $checkfile   = "/proc/cmdline";
     }
     if (($value == 1) || ($value == 2) || ($value == 3)) {
-        `xdsh $noderange -t 2 cat $checkfile |grep $checkstring`;
+        `xdsh $noderange -t 2 cat $checkfile 2>&1|grep $checkstring `;
         if ($?) {
-            foreach (1 .. 1500) {
-                `xdsh $noderange -t 2 cat $checkfile | grep $checkstring`;
+            foreach (1 .. 10) {
+                `sleep 300`;
+                send_msg(1,"try to run xdsh to check the results again");
+                `xdsh $noderange -t 2 cat $checkfile 2>&1| grep $checkstring `;
                 last if ($? == 0);
             }
         }


### PR DESCRIPTION
Refine test case: nodeset_cmdline, nodeset_runimage, nodeset_shell #2833
1 Fix issue #2442
2 Fix issue #1871
3 make code clearly for anyone to debug.
During this pull request I modify genesis releated testcase:
1.remove the dependency of perl-xCAT package by xCAT-test
2.add debug information for this testcase to make code clearly for anyone to debug
