### PR TITLE
Fixes to rinstall/winstall man pages

### DIFF
--- a/docs/source/guides/admin-guides/references/man8/makedns.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/makedns.8.rst
@@ -43,7 +43,7 @@ The \ **forwarders**\  value should be set to the IP address of one or more name
 
 An xCAT \ **network**\  definition must be defined for each network used in the cluster.  The \ **net**\  and \ **mask**\  attributes will be used by the \ **makedns**\  command.
 
-A network \ **domain**\  and \ **nameservers**\  values must be provided either in the \ **network**\  definiton corresponding to the node or in the \ **site**\  definition.
+A network \ **domain**\  and \ **nameservers**\  values must be provided either in the \ **network**\  definition corresponding to the node or in the \ **site**\  definition.
 
 Only entries in /etc/hosts or the hosts specified by \ **noderange**\  that have a corresponding xCAT network definition will be added to DNS.
 

--- a/docs/source/guides/admin-guides/references/man8/makeknownhosts.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/makeknownhosts.8.rst
@@ -19,7 +19,7 @@ SYNOPSIS
 ********
 
 
-\ **makeknownhosts**\  \ *noderange*\  [\ **-r | -d | -**\ **-remove**\ ] [\ **-V | -**\ **-verbose**\ ]
+\ **makeknownhosts**\  \ *noderange*\  [\ **-r | -**\ **-remove | -d | -**\ **-delete**\ ] [\ **-V | -**\ **-verbose**\ ]
 
 \ **makeknownhosts**\  [\ **-h | -**\ **-help**\ ]
 
@@ -53,9 +53,15 @@ OPTIONS
  
 
 
-\ **-r| -d| -**\ **-remove**\ 
+\ **-d|-**\ **-delete**\ 
  
  Only removes the entries for the nodes from the known_hosts file.
+ 
+
+
+\ **-r|-**\ **-remove**\ 
+ 
+ Synonymous to \ **-d|-**\ **-delete**\ .
  
 
 
@@ -97,10 +103,6 @@ EXAMPLES
  
  .. code-block:: perl
  
-   makeknownhosts node02 -r
-
-   or
-
    makeknownhosts node02 -d
  
  

--- a/docs/source/guides/admin-guides/references/man8/makenetworks.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/makenetworks.8.rst
@@ -35,7 +35,7 @@ The \ **makenetworks**\  command can be used to gather network information from 
 
 Every network that will be used to install a cluster node must be defined in the xCAT database.
 
-The default behavior is to gather network information from the managment node, and any configured xCAT service nodes, and automatically save this information in the xCAT database.
+The default behavior is to gather network information from the management node, and any configured xCAT service nodes, and automatically save this information in the xCAT database.
 
 You can use the "-d" option to display the network information without writing it to the database.
 

--- a/docs/source/guides/admin-guides/references/man8/makeroutes.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/makeroutes.8.rst
@@ -35,7 +35,7 @@ DESCRIPTION
 ***********
 
 
-The \ **makeroutes**\  command adds or deletes routes on the management node or any given nodes. The \ **noderange**\  specifies the nodes where the routes are to be added or removed. When the \ *noderange*\  is omitted, the action will be done on the management node. The \ **-r**\  option specifies the name of routes. The details of the routes are defined in the \ **routes**\  table which contians the route name, subnet, net mask and gateway. If -r option is omitted, the names of the routes found on \ **noderes.routenames**\  for the nodes or on \ **site.mnroutenames**\  for the management node will be used.
+The \ **makeroutes**\  command adds or deletes routes on the management node or any given nodes. The \ **noderange**\  specifies the nodes where the routes are to be added or removed. When the \ *noderange*\  is omitted, the action will be done on the management node. The \ **-r**\  option specifies the name of routes. The details of the routes are defined in the \ **routes**\  table which contains the route name, subnet, net mask and gateway. If -r option is omitted, the names of the routes found on \ **noderes.routenames**\  for the nodes or on \ **site.mnroutenames**\  for the management node will be used.
 
 If you want the routes be automatically setup during node deployment, first put a list of route names to \ **noderes.routenames**\  and then add \ *setroute*\  script name to the \ **postscripts.postbootscripts**\  for the nodes.
 

--- a/docs/source/guides/admin-guides/references/man8/nodeset.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/nodeset.8.rst
@@ -53,7 +53,7 @@ Assume that /tftpboot is the root for tftpd (set in site(5)|site.5).
 \ **nodeset**\   is  called  by \ **rinstall**\  and \ **winstall**\  and is also called by the
 installation process remotely to set the boot state back to "boot".
 
-A user can supply their own scripts to be run on the mn or on the service node (if a hierarchical cluster) for a node when the nodeset command is run. Such scripts are called \ **prescripts**\ . They should be copied to /install/prescripts dirctory. A table called \ *prescripts*\  is used to specify the scripts and their associated actions. The scripts to be run at the beginning of the nodeset command are stored in the 'begin' column of \ *prescripts*\  table. The scripts to be run at the end of the nodeset command are stored in the 'end' column of \ *prescripts*\  table. You can run 'tabdump -d prescripts' command for details. The following two environment variables will be passed to each script: NODES contains all the names of the nodes that need to run the script for and ACTION contains the current nodeset action. If \ *#xCAT setting:MAX_INSTANCE=number*\  is specified in the script, the script will get invoked for each node in parallel, but no more than \ *number*\  of instances will be invoked at at a time. If it is not specified, the script will be invoked once for all the nodes.
+A user can supply their own scripts to be run on the mn or on the service node (if a hierarchical cluster) for a node when the nodeset command is run. Such scripts are called \ **prescripts**\ . They should be copied to /install/prescripts directory. A table called \ *prescripts*\  is used to specify the scripts and their associated actions. The scripts to be run at the beginning of the nodeset command are stored in the 'begin' column of \ *prescripts*\  table. The scripts to be run at the end of the nodeset command are stored in the 'end' column of \ *prescripts*\  table. You can run 'tabdump -d prescripts' command for details. The following two environment variables will be passed to each script: NODES contains all the names of the nodes that need to run the script for and ACTION contains the current nodeset action. If \ *#xCAT setting:MAX_INSTANCE=number*\  is specified in the script, the script will get invoked for each node in parallel, but no more than \ *number*\  of instances will be invoked at a time. If it is not specified, the script will be invoked once for all the nodes.
 
 
 ***************
@@ -114,7 +114,7 @@ A user can supply their own scripts to be run on the mn or on the service node (
 
 \ **shell**\ 
  
- This instructs tho node to boot to the xCAT genesis environment, and present a shell prompt on console.
+ This instructs the node to boot to the xCAT genesis environment, and present a shell prompt on console.
  The node will also be able to be sshed into and have utilities such as wget, tftp, scp, nfs, and cifs.  It will have storage drivers available for many common systems.
  
 

--- a/docs/source/guides/admin-guides/references/man8/rinstall.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/rinstall.8.rst
@@ -19,9 +19,9 @@ Name
 ****************
 
 
-\ **rinstall**\  \ *noderange*\  \ **boot**\  | \ **shell**\  | \ **runcmd=bmcsetup**\  [\ **-c | -**\ **-console**\ ] [\ **-V | -**\ **-verbose**\ ]
+\ **rinstall**\  \ *noderange*\  [\ **boot**\  | \ **shell**\  | \ **runcmd=bmcsetup**\ ] [\ **runimage=**\ \ *task*\ ] [\ **-c | -**\ **-console**\ ] [\ **-V | -**\ **-verbose**\ ]
 
-\ **rinstall**\  \ *noderange*\  \ **osimage**\ =\ *imagename*\  | [\ **-O**\ ] \ *imagename*\  [\ **-**\ **-ignorekernelchk**\ ] [\ **-c | -**\ **-console**\ ] [\ **-u | -**\ **-uefimode**\ ] [\ **-V | -**\ **-verbose**\ ]
+\ **rinstall**\  \ *noderange*\  [\ **osimage**\ =\ *imagename*\  | \ *imagename*\ ] [\ **-**\ **-ignorekernelchk**\ ] [\ **-c | -**\ **-console**\ ] [\ **-u | -**\ **-uefimode**\ ] [\ **-V | -**\ **-verbose**\ ]
 
 \ **rinstall**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
@@ -31,11 +31,11 @@ Name
 *******************
 
 
-\ **rinstall**\  is a convenience command to begin OS provision on a noderange(support nodes with "nodetype.mgt=ipmi,blade,hmc,ivm,fsp,kvm,esx,rhevm").
+\ **rinstall**\  is a convenience command to begin OS provision on a noderange.
 
-If \ **osimage**\ =\ *imagename*\  | \ **-O**\  \ *imagename*\  is specified or nodetype.provmethod=\ **osimage**\  is set, provision the noderange with the osimage specified/configured.
+If \ **osimage**\ =\ *imagename*\  | \ *imagename*\  is specified or nodetype.provmethod=\ **osimage**\  is set, provision the noderange with the osimage specified/configured.
 
-If -c is specified, it will then run rcons on the node. This is allowed only if one node in the noderange.   If need consoles on multiple nodes , see winstall(8)|winstall.8.
+If \ **-c**\  is specified, it will then run rcons on the node. This is allowed only if one node in the noderange. If need consoles on multiple nodes, see winstall(8)|winstall.8.
 
 
 ***************
@@ -50,9 +50,9 @@ If -c is specified, it will then run rcons on the node. This is allowed only if 
  
 
 
-\ **osimage | osimage=**\ \ *imagename*\ |\ **-O**\ \ *imagename*\ 
+\ *imagename*\  | \ **osimage=**\ \ *imagename*\ 
  
- Prepare server for installing a node using the specified os image. The os image is defined in the \ *osimage*\  table and \ *linuximage*\  table. If the <imagename> is omitted, the os image name will be obtained from \ *nodetype.provmethod*\  for the node.
+ Prepare server for installing a node using the specified os image. The os image is defined in the \ *osimage*\  table and \ *linuximage*\  table. If the \ *imagename*\  is omitted, the os image name will be obtained from \ *nodetype.provmethod*\  for the node.
  
 
 
@@ -62,7 +62,7 @@ If -c is specified, it will then run rcons on the node. This is allowed only if 
  
 
 
-\ **runimage**\ =\ *task*\ 
+\ **runimage=**\ \ *task*\ 
  
  If you would like to run a task after deployment, you can define that task with this attribute.
  
@@ -70,14 +70,13 @@ If -c is specified, it will then run rcons on the node. This is allowed only if 
 
 \ **runcmd=bmcsetup**\ 
  
- This instructs the node to boot to the xCAT nbfs environment and proceed to configure BMC
- for basic remote access.  This causes the IP, netmask, gateway, username, and password to be programmed according to the configuration table.
+ This instructs the node to boot to the xCAT nbfs environment and proceed to configure BMC for basic remote access.  This causes the IP, netmask, gateway, username, and password to be programmed according to the configuration table.
  
 
 
 \ **shell**\ 
  
- This instructs tho node to boot to the xCAT genesis environment, and present a shell prompt on console.
+ This instructs the node to boot to the xCAT genesis environment, and present a shell prompt on console.
  The node will also be able to be sshed into and have utilities such as wget, tftp, scp, nfs, and cifs.  It will have storage drivers available for many common systems.
  
 
@@ -100,7 +99,7 @@ If -c is specified, it will then run rcons on the node. This is allowed only if 
  
 
 
-\ **-V | -**\ **-Verbose**\ 
+\ **-V | -**\ **-verbose**\ 
  
  Verbose output.
  

--- a/docs/source/guides/admin-guides/references/man8/winstall.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/winstall.8.rst
@@ -19,11 +19,11 @@ Name
 ****************
 
 
-\ **rinstall**\  \ *noderange*\  \ **boot**\  | \ **shell**\  | \ **runcmd=bmcsetup**\  [\ **-c | -**\ **-console**\ ] [\ **-V | -**\ **-verbose**\ ]
+\ **winstall**\  \ *noderange*\  [\ **boot**\  | \ **shell**\  | \ **runcmd=bmcsetup**\ ] [\ **runimage=**\ \ *task*\ ] [\ **-V | -**\ **-verbose**\ ]
 
-\ **rinstall**\  \ *noderange*\  \ **osimage**\ =\ *imagename*\  | [\ **-O**\ ] \ *imagename*\  [\ **-**\ **-ignorekernelchk**\ ] [\ **-c | -**\ **-console**\ ] [\ **-u | -**\ **-uefimode**\ ] [\ **-V | -**\ **-verbose**\ ]
+\ **winstall**\  \ *noderange*\  [\ **osimage**\ =\ *imagename*\  | \ *imagename*\ ] [\ **-**\ **-ignorekernelchk**\ ] [\ **-u | -**\ **-uefimode**\ ] [\ **-V | -**\ **-verbose**\ ]
 
-\ **rinstall**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
+\ **winstall**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
 
 *******************
@@ -31,11 +31,11 @@ Name
 *******************
 
 
-\ **winstall**\  is a convenience command to begin OS provision on a noderange(support nodes with "nodetype.mgt=ipmi,blade,hmc,ivm,fsp,kvm,esx,rhevm").
+\ **winstall**\  is a convenience command to begin OS provision on a noderange.
 
-If \ **osimage**\ =\ *imagename*\  | \ **-O**\  \ *imagename*\  is specified or nodetype.provmethod=\ **osimage**\  is set, provision the noderange with the osimage specified/configured.
+If \ **osimage**\ =\ *imagename*\  | \ *imagename*\  is specified or nodetype.provmethod=\ **osimage**\  is set, provision the noderange with the osimage specified/configured.
 
-It  will then run wcons on the nodes.
+It  will then run \ **wcons**\  on the noderange.
 
 
 ***************
@@ -50,9 +50,9 @@ It  will then run wcons on the nodes.
  
 
 
-\ **osimage | osimage=**\ \ *imagename*\ |\ **-O**\ \ *imagename*\ 
+\ *imagename*\  | \ **osimage=**\ \ *imagename*\ 
  
- Prepare server for installing a node using the specified os image. The os image is defined in the \ *osimage*\  table and \ *linuximage*\  table. If the <imagename> is omitted, the os image name will be obtained from \ *nodetype.provmethod*\  for the node.
+ Prepare server for installing a node using the specified os image. The os image is defined in the \ *osimage*\  table and \ *linuximage*\  table. If the \ *imagename*\  is omitted, the os image name will be obtained from \ *nodetype.provmethod*\  for the node.
  
 
 
@@ -62,7 +62,7 @@ It  will then run wcons on the nodes.
  
 
 
-\ **runimage**\ =\ *task*\ 
+\ **runimage=**\ \ *task*\ 
  
  If you would like to run a task after deployment, you can define that task with this attribute.
  
@@ -70,14 +70,13 @@ It  will then run wcons on the nodes.
 
 \ **runcmd=bmcsetup**\ 
  
- This instructs the node to boot to the xCAT nbfs environment and proceed to configure BMC
- for basic remote access.  This causes the IP, netmask, gateway, username, and password to be programmed according to the configuration table.
+ This instructs the node to boot to the xCAT nbfs environment and proceed to configure BMC for basic remote access.  This causes the IP, netmask, gateway, username, and password to be programmed according to the configuration table.
  
 
 
 \ **shell**\ 
  
- This instructs tho node to boot to the xCAT genesis environment, and present a shell prompt on console.
+ This instructs the node to boot to the xCAT genesis environment, and present a shell prompt on console.
  The node will also be able to be sshed into and have utilities such as wget, tftp, scp, nfs, and cifs.  It will have storage drivers available for many common systems.
  
 
@@ -100,15 +99,9 @@ It  will then run wcons on the nodes.
  
 
 
-\ **-V | -**\ **-Verbose**\ 
+\ **-V | -**\ **-verbose**\ 
  
  Verbose output.
- 
-
-
-\ **-c | -**\ **-console**\ 
- 
- Requests that rinstall runs rcons once the provision starts.  This will only work if there is only one node in the noderange. See winstall(8)|winstall.8 for starting consoles on multiple nodes.
  
 
 
@@ -119,7 +112,7 @@ It  will then run wcons on the nodes.
 
 
 
-1. Provison nodes 1 through 20, using their current configuration.
+1. Provision nodes 1 through 20, using their current configuration.
  
  
  .. code-block:: perl
@@ -134,7 +127,7 @@ It  will then run wcons on the nodes.
  
  .. code-block:: perl
  
-   winstall node1-node20 -O rhels6.4-ppc64-netboot-compute
+   winstall node1-node20 osimage=rhels6.4-ppc64-netboot-compute
  
  
 

--- a/docs/source/guides/admin-guides/references/man8/xcatconfig.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/xcatconfig.8.rst
@@ -66,19 +66,19 @@ OPTIONS
 
 \ **-i|-**\ **-initialinstall**\ 
  
- The install option is normally run as a post operation from the rpm xCAT.spec file during the initial install of xCAT on the Management Node. It will setup the root ssh keys, ssh node keys, xCAT credentials, initialize the datebase, export directories, start syslog and other daemons as needed after the initial install of xCAT.
+ The install option is normally run as a post operation from the rpm xCAT.spec file during the initial install of xCAT on the Management Node. It will setup the root ssh keys, ssh node keys, xCAT credentials, initialize the database, export directories, start syslog and other daemons as needed after the initial install of xCAT.
  
 
 
 \ **-u|-**\ **-updateinstall**\ 
  
- The update install option is normally run as a post operation from the rpm xCAT.spec file during an update install of xCAT on the Management Node. It will check the setup the root ssh keys, ssh node keys, xCAT credentials, datebase, exported directories, syslog and the state of daemons needed by xCAT, after the updateinstall of xCAT. If setup is required, it will perform the operation.  It will restart the necessary daemons.
+ The update install option is normally run as a post operation from the rpm xCAT.spec file during an update install of xCAT on the Management Node. It will check the setup the root ssh keys, ssh node keys, xCAT credentials, database, exported directories, syslog and the state of daemons needed by xCAT, after the updateinstall of xCAT. If setup is required, it will perform the operation.  It will restart the necessary daemons.
  
 
 
 \ **-k|-**\ **-sshkeys**\ 
  
- This option will remove and regenerate the root id_rsa keys.  It should only be used, if the keys are  deleted or corrupted. The keys must then be distribute to the nodes by installing, running updatenode -k, or using xdsh -K option, for root to be able to ssh to the nodes without being prompted for a password. 
+ This option will remove and regenerate the root id_rsa keys. It should only be used, if the keys are deleted or corrupted. The keys must then be distributed to the nodes by installing, running updatenode -k, or using xdsh -K option, for root to be able to ssh to the nodes without being prompted for a password. 
  rspconfig will need to be run to distribute the key to the MM and HMCs. Any device, we need to ssh from the MN to the device will also have to be updated with the new ssh keys.
  
 
@@ -91,7 +91,7 @@ OPTIONS
 
 \ **-c|-**\ **-credentials**\ 
  
- This option will remove all xcat credentials for root and any userids where credentials have been created. It will regenerate roots credentials,  but the admin will have to add back all the userid credentials needed with the /opt/xcat/share/xcat/scripts/setup-local-client.sh <username> command.  It should only be used, if they are deleted or become corrupted. The root credentials must be redistribed to the service nodes by installing the service node or using updatenode -k.  makeconservercf must be rerun to pick up the new credentials,  and conserver must be stop and started.
+ This option will remove all xcat credentials for root and any userids where credentials have been created. It will regenerate roots credentials, but the admin will have to add back all the userid credentials needed with the /opt/xcat/share/xcat/scripts/setup-local-client.sh <username> command. It should only be used, if they are deleted or become corrupted. The root credentials must be redistributed to the service nodes by installing the service node or using updatenode -k.  makeconservercf must be rerun to pick up the new credentials, and conserver must be stopped and started.
  
 
 
@@ -103,9 +103,9 @@ OPTIONS
 
 \ **-f|-**\ **-force**\ 
  
- The force option may  be used after the install to reinitialize the Management Node. This option will  regenerate keys, credential and reinititialize the site table. This option should be used, if keys or credentials become corrupt or lost. 
+ The force option may be used after the install to reinitialize the Management Node. This option will regenerate keys, credential and reinitialize the site table. This option should be used, if keys or credentials become corrupt or lost. 
  Additional action must be taken after using the force options.  ssh keys must be redistributed to the nodes, site table attributes might need to be restored, makeconservercf needs to be rerun to pick up the new credentials and conserver stopped and started, rspconfig needs to be rerun to distribute the new keys to the MM and the HMCs. 
- A new set of common ssh host keys will have  been generated for the nodes. If you wish your nodes to be able to ssh to each other with out password intervention,  then you should redistribute these new keys to the nodes. If the nodes hostkeys are updated then you will need to remove their entries from the known_hosts files on the management node before using ssh, xdsh, xdcp. 
+ A new set of common ssh host keys will have been generated for the nodes. If you wish your nodes to be able to ssh to each other with out password intervention, then you should redistribute these new keys to the nodes. If the nodes hostkeys are updated then you will need to remove their entries from the known_hosts files on the management node before using ssh, xdsh, xdcp. 
  Redistribute credentials and ssh keys to the service nodes and ssh keys to the nodes by using the updatenode -k command.
  
 

--- a/docs/source/guides/admin-guides/references/man8/xcatsetup.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/xcatsetup.8.rst
@@ -124,7 +124,7 @@ Configuration File
 
 
 The \ **config file**\  is organized in stanza format and supports the keywords in the sample file below.  Comment lines
-begin with "#".  Stanzas can be ommitted if you do not want to define that type of object.
+begin with "#".  Stanzas can be omitted if you do not want to define that type of object.
 The only hostname formats supported are those shown in this sample file, although you can change the base
 text and the numbers.  For example, hmc1-hmc3 could be changed to hwmgmt01-hwmgmt12.
 The hostnames specified must sort correctly.  I.e. use node01-node80, instead of node1-node80.

--- a/xCAT-client/pods/man8/makedns.8.pod
+++ b/xCAT-client/pods/man8/makedns.8.pod
@@ -24,7 +24,7 @@ The B<forwarders> value should be set to the IP address of one or more nameserve
 
 An xCAT B<network> definition must be defined for each network used in the cluster.  The B<net> and B<mask> attributes will be used by the B<makedns> command.
 
-A network B<domain> and B<nameservers> values must be provided either in the B<network> definiton corresponding to the node or in the B<site> definition.
+A network B<domain> and B<nameservers> values must be provided either in the B<network> definition corresponding to the node or in the B<site> definition.
 
 Only entries in /etc/hosts or the hosts specified by B<noderange> that have a corresponding xCAT network definition will be added to DNS.
 

--- a/xCAT-client/pods/man8/makenetworks.8.pod
+++ b/xCAT-client/pods/man8/makenetworks.8.pod
@@ -16,7 +16,7 @@ The B<makenetworks> command can be used to gather network information from an xC
 
 Every network that will be used to install a cluster node must be defined in the xCAT database.
 
-The default behavior is to gather network information from the managment node, and any configured xCAT service nodes, and automatically save this information in the xCAT database.
+The default behavior is to gather network information from the management node, and any configured xCAT service nodes, and automatically save this information in the xCAT database.
 
 You can use the "-d" option to display the network information without writing it to the database.
 

--- a/xCAT-client/pods/man8/makeroutes.8.pod
+++ b/xCAT-client/pods/man8/makeroutes.8.pod
@@ -16,7 +16,7 @@ B<makeroutes> [B<-h>|B<--help>|B<-v>|B<--version>]
 
 =head1 DESCRIPTION
 
-The B<makeroutes> command adds or deletes routes on the management node or any given nodes. The B<noderange> specifies the nodes where the routes are to be added or removed. When the I<noderange> is omitted, the action will be done on the management node. The B<-r> option specifies the name of routes. The details of the routes are defined in the B<routes> table which contians the route name, subnet, net mask and gateway. If -r option is omitted, the names of the routes found on B<noderes.routenames> for the nodes or on B<site.mnroutenames> for the management node will be used.
+The B<makeroutes> command adds or deletes routes on the management node or any given nodes. The B<noderange> specifies the nodes where the routes are to be added or removed. When the I<noderange> is omitted, the action will be done on the management node. The B<-r> option specifies the name of routes. The details of the routes are defined in the B<routes> table which contains the route name, subnet, net mask and gateway. If -r option is omitted, the names of the routes found on B<noderes.routenames> for the nodes or on B<site.mnroutenames> for the management node will be used.
 
 If you want the routes be automatically setup during node deployment, first put a list of route names to B<noderes.routenames> and then add I<setroute> script name to the B<postscripts.postbootscripts> for the nodes. 
 

--- a/xCAT-client/pods/man8/nodeset.8.pod
+++ b/xCAT-client/pods/man8/nodeset.8.pod
@@ -34,7 +34,7 @@ B<nodeset> only sets the next boot state, but does not reboot.
 B<nodeset>  is  called  by B<rinstall> and B<winstall> and is also called by the
 installation process remotely to set the boot state back to "boot".
 
-A user can supply their own scripts to be run on the mn or on the service node (if a hierarchical cluster) for a node when the nodeset command is run. Such scripts are called B<prescripts>. They should be copied to /install/prescripts dirctory. A table called I<prescripts> is used to specify the scripts and their associated actions. The scripts to be run at the beginning of the nodeset command are stored in the 'begin' column of I<prescripts> table. The scripts to be run at the end of the nodeset command are stored in the 'end' column of I<prescripts> table. You can run 'tabdump -d prescripts' command for details. The following two environment variables will be passed to each script: NODES contains all the names of the nodes that need to run the script for and ACTION contains the current nodeset action. If I<#xCAT setting:MAX_INSTANCE=number> is specified in the script, the script will get invoked for each node in parallel, but no more than I<number> of instances will be invoked at at a time. If it is not specified, the script will be invoked once for all the nodes.
+A user can supply their own scripts to be run on the mn or on the service node (if a hierarchical cluster) for a node when the nodeset command is run. Such scripts are called B<prescripts>. They should be copied to /install/prescripts directory. A table called I<prescripts> is used to specify the scripts and their associated actions. The scripts to be run at the beginning of the nodeset command are stored in the 'begin' column of I<prescripts> table. The scripts to be run at the end of the nodeset command are stored in the 'end' column of I<prescripts> table. You can run 'tabdump -d prescripts' command for details. The following two environment variables will be passed to each script: NODES contains all the names of the nodes that need to run the script for and ACTION contains the current nodeset action. If I<#xCAT setting:MAX_INSTANCE=number> is specified in the script, the script will get invoked for each node in parallel, but no more than I<number> of instances will be invoked at a time. If it is not specified, the script will be invoked once for all the nodes.
 
 
 =head1 B<Options>
@@ -77,7 +77,7 @@ for basic remote access.  This causes the IP, netmask, gateway, username, and pa
 
 =item B<shell>
 
-This instructs tho node to boot to the xCAT genesis environment, and present a shell prompt on console.
+This instructs the node to boot to the xCAT genesis environment, and present a shell prompt on console.
 The node will also be able to be sshed into and have utilities such as wget, tftp, scp, nfs, and cifs.  It will have storage drivers available for many common systems.
 
 =item B<shutdown>

--- a/xCAT-client/pods/man8/rinstall.8.pod
+++ b/xCAT-client/pods/man8/rinstall.8.pod
@@ -4,19 +4,19 @@ B<rinstall> - Begin OS provision on a noderange
 
 =head1 B<Synopsis>
 
-B<rinstall> I<noderange> B<boot> | B<shell> | B<runcmd=bmcsetup> [B<-c>|B<--console>] [B<-V>|B<--verbose>]
+B<rinstall> I<noderange> [B<boot> | B<shell> | B<runcmd=bmcsetup>] [B<runimage=>I<task>] [B<-c>|B<--console>] [B<-V>|B<--verbose>]
 
-B<rinstall> I<noderange> B<osimage>=I<imagename> | [B<-O>] I<imagename> [B<--ignorekernelchk>] [B<-c>|B<--console>] [B<-u>|B<--uefimode>] [B<-V>|B<--verbose>]
+B<rinstall> I<noderange> [B<osimage>=I<imagename> | I<imagename>] [B<--ignorekernelchk>] [B<-c>|B<--console>] [B<-u>|B<--uefimode>] [B<-V>|B<--verbose>]
 
 B<rinstall> [B<-h>|B<--help>|B<-v>|B<--version>]
 
 =head1 B<Description>
 
-B<rinstall> is a convenience command to begin OS provision on a noderange(support nodes with "nodetype.mgt=ipmi,blade,hmc,ivm,fsp,kvm,esx,rhevm").
+B<rinstall> is a convenience command to begin OS provision on a noderange.
 
-If B<osimage>=I<imagename> | B<-O> I<imagename> is specified or nodetype.provmethod=B<osimage> is set, provision the noderange with the osimage specified/configured.
+If B<osimage>=I<imagename> | I<imagename> is specified or nodetype.provmethod=B<osimage> is set, provision the noderange with the osimage specified/configured.
 
-If -c is specified, it will then run rcons on the node. This is allowed only if one node in the noderange.   If need consoles on multiple nodes , see L<winstall(8)|winstall.8>.
+If B<-c> is specified, it will then run rcons on the node. This is allowed only if one node in the noderange. If need consoles on multiple nodes, see L<winstall(8)|winstall.8>.
 
 =head1 B<Options>
 
@@ -26,26 +26,25 @@ If -c is specified, it will then run rcons on the node. This is allowed only if 
 
 Instruct network boot loader to be skipped, generally meaning boot to hard disk
 
-=item B<osimage>|B<osimage=>I<imagename>|B<-O>I<imagename>
+=item I<imagename> | B<osimage=>I<imagename>
 
-Prepare server for installing a node using the specified os image. The os image is defined in the I<osimage> table and I<linuximage> table. If the <imagename> is omitted, the os image name will be obtained from I<nodetype.provmethod> for the node.  
+Prepare server for installing a node using the specified os image. The os image is defined in the I<osimage> table and I<linuximage> table. If the I<imagename> is omitted, the os image name will be obtained from I<nodetype.provmethod> for the node.  
 
 =item B<--ignorekernelchk>
 
 Skip the kernel version checking when injecting drivers from osimage.driverupdatesrc. That means all drivers from osimage.driverupdatesrc will be injected to initrd for the specific target kernel.
 
-=item B<runimage>=I<task>
+=item B<runimage=>I<task>
 
 If you would like to run a task after deployment, you can define that task with this attribute.    
 
 =item B<runcmd=bmcsetup>
 
-This instructs the node to boot to the xCAT nbfs environment and proceed to configure BMC
-for basic remote access.  This causes the IP, netmask, gateway, username, and password to be programmed according to the configuration table.
+This instructs the node to boot to the xCAT nbfs environment and proceed to configure BMC for basic remote access.  This causes the IP, netmask, gateway, username, and password to be programmed according to the configuration table.
 
 =item B<shell>
 
-This instructs tho node to boot to the xCAT genesis environment, and present a shell prompt on console.
+This instructs the node to boot to the xCAT genesis environment, and present a shell prompt on console.
 The node will also be able to be sshed into and have utilities such as wget, tftp, scp, nfs, and cifs.  It will have storage drivers available for many common systems.
 
 =item B<-h>|B<--help>
@@ -60,7 +59,7 @@ Display version.
 
 For BMC-based servers, to specify the next boot mode to be "UEFI Mode". 
 
-=item B<-V>|B<--Verbose>
+=item B<-V>|B<--verbose>
 
 Verbose output. 
 

--- a/xCAT-client/pods/man8/winstall.8.pod
+++ b/xCAT-client/pods/man8/winstall.8.pod
@@ -4,19 +4,19 @@ B<winstall> - Begin OS provision on a noderange
 
 =head1 B<Synopsis>
 
-B<rinstall> I<noderange> B<boot> | B<shell> | B<runcmd=bmcsetup> [B<-c>|B<--console>] [B<-V>|B<--verbose>]
+B<winstall> I<noderange> [B<boot> | B<shell> | B<runcmd=bmcsetup>] [B<runimage=>I<task>] [B<-V>|B<--verbose>]
 
-B<rinstall> I<noderange> B<osimage>=I<imagename> | [B<-O>] I<imagename> [B<--ignorekernelchk>] [B<-c>|B<--console>] [B<-u>|B<--uefimode>] [B<-V>|B<--verbose>]
+B<winstall> I<noderange> [B<osimage>=I<imagename> | I<imagename>] [B<--ignorekernelchk>] [B<-u>|B<--uefimode>] [B<-V>|B<--verbose>]
 
-B<rinstall> [B<-h>|B<--help>|B<-v>|B<--version>]
+B<winstall> [B<-h>|B<--help>|B<-v>|B<--version>]
 
 =head1 B<Description>
 
-B<winstall> is a convenience command to begin OS provision on a noderange(support nodes with "nodetype.mgt=ipmi,blade,hmc,ivm,fsp,kvm,esx,rhevm").
+B<winstall> is a convenience command to begin OS provision on a noderange.
 
-If B<osimage>=I<imagename> | B<-O> I<imagename> is specified or nodetype.provmethod=B<osimage> is set, provision the noderange with the osimage specified/configured.
-
-It  will then run wcons on the nodes. 
+If B<osimage>=I<imagename> | I<imagename> is specified or nodetype.provmethod=B<osimage> is set, provision the noderange with the osimage specified/configured.
+ 
+It  will then run B<wcons> on the noderange.
 
 =head1 B<Options>
 
@@ -26,26 +26,25 @@ It  will then run wcons on the nodes.
 
 Instruct network boot loader to be skipped, generally meaning boot to hard disk
 
-=item B<osimage>|B<osimage=>I<imagename>|B<-O>I<imagename>
+=item I<imagename> | B<osimage=>I<imagename>
 
-Prepare server for installing a node using the specified os image. The os image is defined in the I<osimage> table and I<linuximage> table. If the <imagename> is omitted, the os image name will be obtained from I<nodetype.provmethod> for the node.  
+Prepare server for installing a node using the specified os image. The os image is defined in the I<osimage> table and I<linuximage> table. If the I<imagename> is omitted, the os image name will be obtained from I<nodetype.provmethod> for the node.  
 
 =item B<--ignorekernelchk>
 
 Skip the kernel version checking when injecting drivers from osimage.driverupdatesrc. That means all drivers from osimage.driverupdatesrc will be injected to initrd for the specific target kernel.
 
-=item B<runimage>=I<task>
+=item B<runimage=>I<task>
 
 If you would like to run a task after deployment, you can define that task with this attribute.    
 
 =item B<runcmd=bmcsetup>
 
-This instructs the node to boot to the xCAT nbfs environment and proceed to configure BMC
-for basic remote access.  This causes the IP, netmask, gateway, username, and password to be programmed according to the configuration table.
+This instructs the node to boot to the xCAT nbfs environment and proceed to configure BMC for basic remote access.  This causes the IP, netmask, gateway, username, and password to be programmed according to the configuration table.
 
 =item B<shell>
 
-This instructs tho node to boot to the xCAT genesis environment, and present a shell prompt on console.
+This instructs the node to boot to the xCAT genesis environment, and present a shell prompt on console.
 The node will also be able to be sshed into and have utilities such as wget, tftp, scp, nfs, and cifs.  It will have storage drivers available for many common systems.
 
 =item B<-h>|B<--help>
@@ -60,31 +59,28 @@ Display version.
 
 For BMC-based servers, to specify the next boot mode to be "UEFI Mode". 
 
-=item B<-V>|B<--Verbose>
+=item B<-V>|B<--verbose>
 
 Verbose output. 
 
-=item B<-c>|B<--console>
-
-Requests that rinstall runs rcons once the provision starts.  This will only work if there is only one node in the noderange. See L<winstall(8)|winstall.8> for starting consoles on multiple nodes.
-
 =back
+
 
 =head1 B<Examples>
 
 =over 2
 
 =item 1.
-Provison nodes 1 through 20, using their current configuration.
+Provision nodes 1 through 20, using their current configuration.
 
  winstall node1-node20
 
 =item 2.
 Provision nodes 1 through 20 with the osimage rhels6.4-ppc64-netboot-compute.
 
- winstall node1-node20 -O rhels6.4-ppc64-netboot-compute
+ winstall node1-node20 osimage=rhels6.4-ppc64-netboot-compute
 
-=back
+=back 
 
 =head1 B<See> B<Also>
 

--- a/xCAT-client/pods/man8/xcatconfig.8.pod
+++ b/xCAT-client/pods/man8/xcatconfig.8.pod
@@ -38,15 +38,15 @@ Displays verbose messages.
 
 =item B<-i|--initialinstall>
 
-The install option is normally run as a post operation from the rpm xCAT.spec file during the initial install of xCAT on the Management Node. It will setup the root ssh keys, ssh node keys, xCAT credentials, initialize the datebase, export directories, start syslog and other daemons as needed after the initial install of xCAT.
+The install option is normally run as a post operation from the rpm xCAT.spec file during the initial install of xCAT on the Management Node. It will setup the root ssh keys, ssh node keys, xCAT credentials, initialize the database, export directories, start syslog and other daemons as needed after the initial install of xCAT.
 
 =item B<-u|--updateinstall>
 
-The update install option is normally run as a post operation from the rpm xCAT.spec file during an update install of xCAT on the Management Node. It will check the setup the root ssh keys, ssh node keys, xCAT credentials, datebase, exported directories, syslog and the state of daemons needed by xCAT, after the updateinstall of xCAT. If setup is required, it will perform the operation.  It will restart the necessary daemons.
+The update install option is normally run as a post operation from the rpm xCAT.spec file during an update install of xCAT on the Management Node. It will check the setup the root ssh keys, ssh node keys, xCAT credentials, database, exported directories, syslog and the state of daemons needed by xCAT, after the updateinstall of xCAT. If setup is required, it will perform the operation.  It will restart the necessary daemons.
 
 =item B<-k|--sshkeys>
 
-This option will remove and regenerate the root id_rsa keys.  It should only be used, if the keys are  deleted or corrupted. The keys must then be distribute to the nodes by installing, running updatenode -k, or using xdsh -K option, for root to be able to ssh to the nodes without being prompted for a password. 
+This option will remove and regenerate the root id_rsa keys. It should only be used, if the keys are deleted or corrupted. The keys must then be distributed to the nodes by installing, running updatenode -k, or using xdsh -K option, for root to be able to ssh to the nodes without being prompted for a password. 
 rspconfig will need to be run to distribute the key to the MM and HMCs. Any device, we need to ssh from the MN to the device will also have to be updated with the new ssh keys.
 
 =item B<-s|--sshnodehostkeys>
@@ -55,7 +55,7 @@ This option will remove and regenerate the node host ssh keys.  It should only b
 
 =item B<-c|--credentials>
 
-This option will remove all xcat credentials for root and any userids where credentials have been created. It will regenerate roots credentials,  but the admin will have to add back all the userid credentials needed with the /opt/xcat/share/xcat/scripts/setup-local-client.sh <username> command.  It should only be used, if they are deleted or become corrupted. The root credentials must be redistribed to the service nodes by installing the service node or using updatenode -k.  makeconservercf must be rerun to pick up the new credentials,  and conserver must be stop and started.
+This option will remove all xcat credentials for root and any userids where credentials have been created. It will regenerate roots credentials, but the admin will have to add back all the userid credentials needed with the /opt/xcat/share/xcat/scripts/setup-local-client.sh <username> command. It should only be used, if they are deleted or become corrupted. The root credentials must be redistributed to the service nodes by installing the service node or using updatenode -k.  makeconservercf must be rerun to pick up the new credentials, and conserver must be stopped and started.
 
 =item B<-d|--database>
 
@@ -63,9 +63,9 @@ This option will reinitialize the basic xCAT database table setup.  It will not 
 
 =item B<-f|--force>
 
-The force option may  be used after the install to reinitialize the Management Node. This option will  regenerate keys, credential and reinititialize the site table. This option should be used, if keys or credentials become corrupt or lost. 
+The force option may be used after the install to reinitialize the Management Node. This option will regenerate keys, credential and reinitialize the site table. This option should be used, if keys or credentials become corrupt or lost. 
 Additional action must be taken after using the force options.  ssh keys must be redistributed to the nodes, site table attributes might need to be restored, makeconservercf needs to be rerun to pick up the new credentials and conserver stopped and started, rspconfig needs to be rerun to distribute the new keys to the MM and the HMCs. 
-A new set of common ssh host keys will have  been generated for the nodes. If you wish your nodes to be able to ssh to each other with out password intervention,  then you should redistribute these new keys to the nodes. If the nodes hostkeys are updated then you will need to remove their entries from the known_hosts files on the management node before using ssh, xdsh, xdcp. 
+A new set of common ssh host keys will have been generated for the nodes. If you wish your nodes to be able to ssh to each other with out password intervention, then you should redistribute these new keys to the nodes. If the nodes hostkeys are updated then you will need to remove their entries from the known_hosts files on the management node before using ssh, xdsh, xdcp. 
 Redistribute credentials and ssh keys to the service nodes and ssh keys to the nodes by using the updatenode -k command.   
 
 =item B<-m|--mgtnode>

--- a/xCAT-client/pods/man8/xcatsetup.8.pod
+++ b/xCAT-client/pods/man8/xcatsetup.8.pod
@@ -85,7 +85,7 @@ The B<xcatsetup> command has only been implemented and tested for system p serve
 =head2 Configuration File
 
 The B<config file> is organized in stanza format and supports the keywords in the sample file below.  Comment lines
-begin with "#".  Stanzas can be ommitted if you do not want to define that type of object.
+begin with "#".  Stanzas can be omitted if you do not want to define that type of object.
 The only hostname formats supported are those shown in this sample file, although you can change the base
 text and the numbers.  For example, hmc1-hmc3 could be changed to hwmgmt01-hwmgmt12.
 The hostnames specified must sort correctly.  I.e. use node01-node80, instead of node1-node80.

--- a/xCAT-server/lib/xcat/plugins/rinstall.pm
+++ b/xCAT-server/lib/xcat/plugins/rinstall.pm
@@ -622,8 +622,8 @@ sub usage {
     my $callback = shift;
     my $rsp      = {};
     $rsp->{data}->[0] = "Usage:";
-    $rsp->{data}->[1] = "   $command <noderange> boot | shell | runcmd=bmcsetup [-c|--console] [-u|--uefimode] [-V|--verbose]";
-    $rsp->{data}->[2] = "   $command <noderange> osimage=<imagename> | -O <imagename> [--ignorekernelchk] [-c|--console] [-u|--uefimode] [-V|--verbose]";
+    $rsp->{data}->[1] = "   $command <noderange> [boot | shell | runcmd=bmcsetup] [runimage=<task>] [-c|--console] [-u|--uefimode] [-V|--verbose]";
+    $rsp->{data}->[2] = "   $command <noderange> [osimage=<imagename> | <imagename>] [--ignorekernelchk] [-c|--console] [-u|--uefimode] [-V|--verbose]";
     $rsp->{data}->[3] = "   $command [-h|--help|-v|--version]";
     xCAT::MsgUtils->message("I", $rsp, $callback);
 }


### PR DESCRIPTION
This PR fixes:
1. Man pages for rinstall/winstall
2. Usage output for rinstall/winstall
3. Spelling and grammar in man8 section