### PR TITLE
[DO NOT MERGE] travis CI: grant traivis permission to run xcat commands

### DIFF
--- a/xCAT-server/sbin/xcatconfig
+++ b/xCAT-server/sbin/xcatconfig
@@ -1330,6 +1330,9 @@ sub initDB
         {
             $chtabcmds =
 "$::XCATROOT/sbin/chtab priority=1 policy.name=root policy.rule=allow;";
+            #for travis CI
+            $chtabcmds =
+"$::XCATROOT/sbin/chtab priority=1.1 policy.name=travis policy.rule=allow;";
             if (defined($MNname)) {
                 $chtabcmds .=
 "$::XCATROOT/sbin/chtab priority=1.2 policy.name=$MNname policy.rule=trusted;";


### PR DESCRIPTION
For travis CI:

in the travis CI VM, the granted user is "travis" instead of "root", there is no chance to run tab/obj commands after xCAT installation, do this during xCAT installation
