### PR TITLE
With mid June, 2017 firmware update, model number is moved from PartNumber -> Model

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -1074,8 +1074,8 @@ sub bmcdiscovery_openbmc{
         my $serial;
 
         if (defined($response->{data})) {
-            if (defined($response->{data}->{PartNumber}) and defined($response->{data}->{SerialNumber})) {
-                $mtm = $response->{data}->{PartNumber};
+            if (defined($response->{data}->{Model}) and defined($response->{data}->{SerialNumber})) {
+                $mtm = $response->{data}->{Model};
                 $serial = $response->{data}->{SerialNumber}; 
             } else {
                 xCAT::MsgUtils->message("W", { data => ["Could not obtain Model Type and/or Serial Number for BMC at $ip"] }, $::CALLBACK);


### PR DESCRIPTION
It's unfortunate that we are bouncing back and forth on this.. but due to sheer luck, while Investigating a separate issue, I compared the json data being returned from one p9 machine to another which was recently updated to the following levels... 

```
[root@stratton01 openbmc]# ./show_firmware_level p9euh02
PRETTY_NAME="Phosphor OpenBMC (Phosphor OpenBMC Project Reference Distro) v1.99.6-130"
[                                                  ] 0%IBM-witherspoon-ibm-OP9_v1.17_1.20
```

When looking at the diff, the model information has been moved from PartNumber -> ModelNumber.  
![image](https://user-images.githubusercontent.com/10049070/27232375-d53c1db2-5283-11e7-9081-4ffc5d6d5699.png)

Creating this PR to sync up... 