### PR TITLE
add missed cases for hardware control commands. Fix bug 3269.

### DIFF
--- a/xCAT-test/autotest/testcase/rinv/cases2
+++ b/xCAT-test/autotest/testcase/rinv/cases2
@@ -1,0 +1,26 @@
+start:rinv_mprom
+hcp:ipmi
+arch:x86_64
+cmd:rinv $$CN mprom 
+check:rc==0
+check:output=~BMC Firmware:\s*\w+.\w+
+end
+
+start:rinv_guid
+hcp:ipmi
+arch:x86_64
+cmd:rinv $$CN guid 
+check:rc==0
+check:output=~UUID/GUID:\s*\w+-\w+-\w+-\w+-\w+
+end
+
+start:rinv_dimm
+hcp:ipmi
+arch:x86_64
+cmd:rinv $$CN dimm
+check:rc==0
+check:output=~DIMM 1 :\s*\w+
+check:output=~DIMM 1 Manufacture Date:\s*\w+
+check:output=~DIMM 1 Manufacture Location:\s*\d+
+check:output=~DIMM 1 Model:\s*\w+-\w+
+end

--- a/xCAT-test/autotest/testcase/rinv/cases2
+++ b/xCAT-test/autotest/testcase/rinv/cases2
@@ -1,4 +1,5 @@
 start:rinv_mprom
+description:this case is to test mprom option for rinv on x86_64 servers.
 hcp:ipmi
 arch:x86_64
 cmd:rinv $$CN mprom 
@@ -7,6 +8,7 @@ check:output=~BMC Firmware:\s*\w+.\w+
 end
 
 start:rinv_guid
+description:this case is to test guid option for rinv on x86_64 servers.
 hcp:ipmi
 arch:x86_64
 cmd:rinv $$CN guid 
@@ -15,6 +17,7 @@ check:output=~UUID/GUID:\s*\w+-\w+-\w+-\w+-\w+
 end
 
 start:rinv_dimm
+description:this case is to test dimm option for rinv on x86_64 servers.
 hcp:ipmi
 arch:x86_64
 cmd:rinv $$CN dimm

--- a/xCAT-test/autotest/testcase/rpower/cases0
+++ b/xCAT-test/autotest/testcase/rpower/cases0
@@ -1,6 +1,4 @@
 start:rpower_off
-description:This case is to test off option could remote power off nodes 
-Attribute: $$CN-The operation object of rpower command
 cmd:rpower $$CN on
 cmd:a=0;while ! `rpower $$CN stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 check:ouptut=~Running|on
@@ -12,8 +10,6 @@ check:output=~Not Activated|off
 end
 
 start:rpower_stat
-description:This case is to test stat option could show the power status of nodes
-Attribute: $$CN-The operation object of rpower command
 cmd:rpower $$CN on
 cmd:a=0;while ! `rpower $$CN stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 5 ];then break;fi done
 cmd:rpower $$CN stat
@@ -33,8 +29,6 @@ check:output=~Not Activated|off
 end
 
 start:rpower_boot
-description:This case is to test boot option could power on the nodes if nodes in off state.  Or could  hard reset the nodes if they are on. 
-Attribute: $$CN-The operation object of rpower command
 cmd:rpower $$CN off
 cmd:a=0;while ! `rpower $$CN stat|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$CN stat
@@ -47,8 +41,7 @@ check:output=~Running|on
 end
 
 start:rpower_status
-description:This case is to test status option could show the power status of nodes
-Attribute: $$CN-The operation object of rpower command
+description:checkout rpower node status could get node's stauts
 cmd:rpower $$CN off
 cmd:a=0;while ! `rpower $$CN status|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$CN status
@@ -61,8 +54,7 @@ check:output=~Running|on
 end
 
 start:rpower_state
-description:This case is to test state option could show the power status of nodes
-Attribute: $$CN-The operation object of rpower command
+description:checkout rpower node status could get node's stauts
 cmd:rpower $$CN off
 cmd:a=0;while ! `rpower $$CN state|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$CN state
@@ -75,8 +67,6 @@ check:output=~Running|on
 end
 
 start:rpower_on
-description:This case is to test on option could remote power on nodes
-Attribute: $$CN-The operation object of rpower command
 cmd:rpower $$CN off
 cmd:a=0;while ! `rpower $$CN stat|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$CN stat
@@ -89,8 +79,6 @@ check:output=~Running|on
 end
 
 start:rpower_reset
-description:This case is to test reset option could hard reset nodes when nodes are in on state.
-Attribute: $$CN-The operation object of rpower command
 cmd:rpower $$CN on
 cmd:a=0;while ! `rpower $$CN stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$CN stat
@@ -103,25 +91,46 @@ check:output=~Running|on
 end
 
 start:rpower_noderange
-description:This case is to test rpower could process error usage and return help information.
-Attribute: $$CN-The operation object of rpower command
 cmd:rpower $$CN
 check:rc!=0
 check:output=~Unsupported|Usage
 end
 
 start:rpower_noderange_nodeps
-description:This case is to test rpower could process error usage and return help information.
-Attribute: $$CN-The operation object of rpower command
 cmd:rpower $$CN --nodeps
 check:rc!=0
 check:output=~Unsupported|Usage
 end
 
 start:rpower_err_noderange
-description:This case is to test rpower could process error usage and return help information.
-Attribute:N/A 
 cmd:rpower testnode stat
 check:rc!=0
 check:output=~Error
+end
+
+start:rpower_softoff
+description:This case is to test softoff option could remote shutdown nodes 
+Attribute: $$CN-The operation object of rpower command
+cmd:rpower $$CN on
+cmd:a=0;while ! `rpower $$CN stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
+check:ouptut=~Running|on
+cmd:rpower $$CN softoff
+check:rc==0
+cmd:a=0;while ! `rpower $$CN stat|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
+cmd:rpower $$CN stat
+check:output=~Not Activated|off
+end
+
+start:rpower_onstandby
+description:This case is to test onstandby option could bring server to standby state 
+Attribute: $$CN-The operation object of rpower command
+arch:ppc64
+cmd:rpower $$CN off
+check:rc==0
+cmd:a=0;while ! `rpower $$CN stat|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
+cmd:rpower $$CN stat
+check:output=~Not Activated|off
+cmd:rpower $$CN onstandby
+cmd:a=0;while ! `rpower $$CN stat|grep "standby\|Standby" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
+check:ouptut=~standby|Standby
 end

--- a/xCAT-test/autotest/testcase/rpower/cases0
+++ b/xCAT-test/autotest/testcase/rpower/cases0
@@ -1,4 +1,6 @@
 start:rpower_off
+description:This case is to test off option could remote power off nodes 
+Attribute: $$CN-The operation object of rpower command
 cmd:rpower $$CN on
 cmd:a=0;while ! `rpower $$CN stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 check:ouptut=~Running|on
@@ -10,6 +12,8 @@ check:output=~Not Activated|off
 end
 
 start:rpower_stat
+description:This case is to test stat option could show the power status of nodes
+Attribute: $$CN-The operation object of rpower command
 cmd:rpower $$CN on
 cmd:a=0;while ! `rpower $$CN stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 5 ];then break;fi done
 cmd:rpower $$CN stat
@@ -29,6 +33,8 @@ check:output=~Not Activated|off
 end
 
 start:rpower_boot
+description:This case is to test boot option could power on the nodes if nodes in off state.  Or could  hard reset the nodes if they are on. 
+Attribute: $$CN-The operation object of rpower command
 cmd:rpower $$CN off
 cmd:a=0;while ! `rpower $$CN stat|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$CN stat
@@ -41,7 +47,8 @@ check:output=~Running|on
 end
 
 start:rpower_status
-description:checkout rpower node status could get node's stauts
+description:This case is to test status option could show the power status of nodes
+Attribute: $$CN-The operation object of rpower command
 cmd:rpower $$CN off
 cmd:a=0;while ! `rpower $$CN status|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$CN status
@@ -54,7 +61,8 @@ check:output=~Running|on
 end
 
 start:rpower_state
-description:checkout rpower node status could get node's stauts
+description:This case is to test state option could show the power status of nodes
+Attribute: $$CN-The operation object of rpower command
 cmd:rpower $$CN off
 cmd:a=0;while ! `rpower $$CN state|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$CN state
@@ -67,6 +75,8 @@ check:output=~Running|on
 end
 
 start:rpower_on
+description:This case is to test on option could remote power on nodes
+Attribute: $$CN-The operation object of rpower command
 cmd:rpower $$CN off
 cmd:a=0;while ! `rpower $$CN stat|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$CN stat
@@ -79,6 +89,8 @@ check:output=~Running|on
 end
 
 start:rpower_reset
+description:This case is to test reset option could hard reset nodes when nodes are in on state.
+Attribute: $$CN-The operation object of rpower command
 cmd:rpower $$CN on
 cmd:a=0;while ! `rpower $$CN stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$CN stat
@@ -91,18 +103,24 @@ check:output=~Running|on
 end
 
 start:rpower_noderange
+description:This case is to test rpower could process error usage and return help information.
+Attribute: $$CN-The operation object of rpower command
 cmd:rpower $$CN
 check:rc!=0
 check:output=~Unsupported|Usage
 end
 
 start:rpower_noderange_nodeps
+description:This case is to test rpower could process error usage and return help information.
+Attribute: $$CN-The operation object of rpower command
 cmd:rpower $$CN --nodeps
 check:rc!=0
 check:output=~Unsupported|Usage
 end
 
 start:rpower_err_noderange
+description:This case is to test rpower could process error usage and return help information.
+Attribute:N/A 
 cmd:rpower testnode stat
 check:rc!=0
 check:output=~Error


### PR DESCRIPTION
Add 5 cases in this pull request
This pull request is for task #3181.

[case 1]
Case Name:rpower_softoff
description:This case is to test softoff option could remote shutdown nodes

[case 2]
Case Name: rpower_onstandby
description:This case is to test onstandby option could bring server to standby state

[case 3]
Case Name: rinv_mprom
description:this case is to test mprom option for rinv on x86_64 servers.

[case 4]
Case Name: rinv_guid
description:this case is to test guid option for rinv on x86_64 servers.

[case 5]
Case Name:rinv_dimm
description:this case is to test dimm option for rinv on x86_64 servers.