### PR TITLE
[openbmc] Better format the output of rinv <> firm command when multiple software is uploaded to the BMC

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1036,25 +1036,31 @@ sub rinv_response {
             # Handle printing out all posssible Software values in a generic format: 
             #    node: <Purpose> Software: <version> (<Activation>)
             #
+            my $sw_id = (split(/\//, $key_url))[-1];
             if (defined($content{Version}) and $content{Version}) {
                 my $purpose_value = uc ((split(/\./, $content{Purpose}))[-1]);
                 my $activation_value = (split(/\./, $content{Activation}))[-1];
                 #
-                # The space below between "SOFTWARE:" and $content{Version} is intentional
-                # to cause the sorting of this line before any additional info lines 
+                # For 'rinv firm', only print Active software.  'rflash list' will handle others
                 #
-                $content_info = "$purpose_value SOFTWARE:   $content{Version} ($activation_value)";
-                push (@sorted_output, $content_info); 
-
-                if ($content{ExtendedVersion} ne "") { 
-                    # ExtendedVersion is going to be a comma separated list of additional software
-                    my @versions = split(',', $content{ExtendedVersion});
-                    foreach my $ver (@versions) { 
-                        $content_info = "$purpose_value SOFTWARE: -- additional info: $ver";
-                        push (@sorted_output, $content_info);
+                if ($activation_value =~ "Active") {
+                    #
+                    # The space below between "SOFTWARE:" and $content{Version} is intentional
+                    # to cause the sorting of this line before any additional info lines 
+                    #
+                    $content_info = "$purpose_value SOFTWARE[$sw_id]:   $content{Version} ($activation_value)";
+                    push (@sorted_output, $content_info); 
+    
+                    if (defined($content{ExtendedVersion}) and $content{ExtendedVersion} ne "") { 
+                        # ExtendedVersion is going to be a comma separated list of additional software
+                        my @versions = split(',', $content{ExtendedVersion});
+                        foreach my $ver (@versions) { 
+                            $content_info = "$purpose_value SOFTWARE[$sw_id]: -- additional info: $ver";
+                            push (@sorted_output, $content_info);
+                        }
                     }
+                    next;
                 }
-                next;
             }
         } else {
             if (! defined $content{Present}) {


### PR DESCRIPTION
Change to only display the active firmware instead of any firmware that is listed and add in the software id into the output so that sorting would keep the various software information together.

Resolves #3274 

With the addition of the support for uploading various software firmware to openbmc, the rinv command prints a bunch of output that is not sorted correct and difficult to read.  This change only displays the Active firmware and also uses the ID to keep the various pieces sorted together. 

Sample output: 
```
# rinv p9euh0[1-2] firm
p9euh01: BMC SOFTWARE[6584ef1]: v1.99.6-19-gab8de5b (Active)
p9euh01: HOST SOFTWARE[488449a2]: IBM-witherspoon-ibm-OP9_v1.17_1.20 (Active)
p9euh02: BMC SOFTWARE[5ea407c0]: v1.99.6-130-g35cfa84 (Active)
```

