### PR TITLE
update the doc for steps on checking packages that changed in xcat-dep on update of xCAT

### DIFF
--- a/docs/source/guides/install-guides/yum/update_xcat.rst
+++ b/docs/source/guides/install-guides/yum/update_xcat.rst
@@ -6,5 +6,5 @@ If at a later date you want to update xCAT, first, update the software repositor
     yum clean metadata # or, yum clean all
     yum update '*xCAT*'
 
-
-
+    # To check and update the packages provided by xcat-dep:
+    yum update '*xcat*'

--- a/docs/source/guides/install-guides/zypper/update_xcat.rst
+++ b/docs/source/guides/install-guides/zypper/update_xcat.rst
@@ -6,4 +6,5 @@ If at a later date you want to update xCAT, first, update the software repositor
     zypper refresh
     zypper update "*xCAT*"
 
-
+    # To check and update the packages provided by xcat-dep:
+    zypper update "*xcat*"


### PR DESCRIPTION
Small change to resolve the issue mentioned in #3194  where the ipmitool-xcat and conserver-xcat packages are not picked up because of the non camel case spelling of `xCAT`