### PR TITLE
Change the dhcpinterface documentation to avoid confusion about xcatmn

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/configure/networks.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/configure/networks.rst
@@ -45,6 +45,10 @@ Configure DHCP to listen on different network interfaces [**Optional**]
 
    To set "eth1" and "eth3" on the management node and "bond0" on all nodes in the nodegroup="service", set ``dhcpinterfaces`` using: ::
 
+      chdef -t site dhcpinterfaces="eth1,eth3;service|bond0"
+
+   or, to explicitly identify the management node with hostname ``xcatmn``: ::
+
       chdef -t site dhcpinterfaces="xcatmn|eth1,eth3;service|bond0"
 
 **noboot**


### PR DESCRIPTION
In this example, when following it, I thought `xcatmn` was a special keyword, but it's actually the hostname of the xcat management node in the example.  Made a small change to make this more clear so users do not get hung up on this.  
