### PR TITLE
Fix the calculation error for conserver version number

### DIFF
--- a/perl-xCAT/xCAT/Utils.pm
+++ b/perl-xCAT/xCAT/Utils.pm
@@ -638,7 +638,7 @@ sub calc_conserver_version
 {
     my $ver_str = shift;
     my @vers = split(/\./, $ver_str);
-    return ord($vers[2]) + ord($vers[1]) * 10000 + ord($vers[0]) * 100000000;
+    return int($vers[2]) + int($vers[1]) * 10000 + int($vers[0]) * 100000000;
 }
 
 


### PR DESCRIPTION
This patch fix the error while calculating the version number.
Use int instead of ord to convert string to integer.

fix-issue: #3286