### PR TITLE
fix issue 3289: Changing site table attributes using chdef does not r…

### DIFF
--- a/perl-xCAT/xCAT/DBobjUtils.pm
+++ b/perl-xCAT/xCAT/DBobjUtils.pm
@@ -780,6 +780,7 @@ sub setobjdefs
 
             $montable->commit;
             $monsettable->commit;
+            $objhash{$objname}{updated} = 1;
             next;
         }    #if ($type eq 'monitoring')
 
@@ -869,6 +870,9 @@ sub setobjdefs
                     }
                 }
 
+            }
+            unless ($ret) {
+                $objhash{$objname}{updated} = 1;
             }
 
             $thistable->commit;


### PR DESCRIPTION
…eturn the correct message
Fix issue #3289 

The modification is:
1. After commit is done for 'site', update the flag that there is update for site type.
2. Also modified for "monitoring"

The output before:
```
[root@stratton01 ~]# lsdef -t site clustersite -i dhcplease,xcatdebugmode -c
clustersite: dhcplease=43200
clustersite: xcatdebugmode=0
[root@stratton01 ~]# chdef -t site clustersite dhcplease=300 xcatdebugmode=1
No object definitions have been created or modified.
```
The output looks like this with the fix:
```
[root@stratton01 ~]# lsdef -t site clustersite -i dhcplease,xcatdebugmode -c
clustersite: dhcplease=300
clustersite: xcatdebugmode=1
[root@stratton01 ~]# chdef -t site clustersite dhcplease=43200 xcatdebugmode=0
1 object definitions have been created or modified.
[root@stratton01 ~]# lsdef -t site clustersite -i dhcplease,xcatdebugmode -c
clustersite: dhcplease=43200
clustersite: xcatdebugmode=0
```