### PR TITLE
refine new confignetwork framework to use configeth

### DIFF
--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -6,6 +6,7 @@
 if [ "$(uname -s|tr 'A-Z' 'a-z')" = "linux" ];then
    str_dir_name=`dirname $0`
    . $str_dir_name/xcatlib.sh
+   . $str_dir_name/nicutils.sh
 fi
 
 function configipv4(){
@@ -354,16 +355,16 @@ fi
 
 
 logger -t xcat -p local4.err "configeth: os type: $str_os_type"
-echo "configeth on $NODE: os type: $str_os_type"
+log_info "configeth on $NODE: os type: $str_os_type"
 if [ "$1" = "-r" ];then
     if [ $# -ne 2 ];then
         logger -t xcat -p local4.err "configeth: remove nic, but the nic name is missed"
-        echo "configeth on $NODE: remove nic, but the nic name is missed"
+        log_error "configeth on $NODE: remove nic, but the nic name is missed"
         exit 1
     fi
     str_nic_name=$2
     logger -t xcat -p local4.err "configeth: remove nic $str_nic_name"
-    echo "configeth on $NODE: remove nic $str_nic_name"
+    log_info "configeth on $NODE: remove nic $str_nic_name"
 
     if [ "$str_os_type" = "aix" ];then
         old_ifs=$IFS
@@ -392,7 +393,7 @@ if [ "$1" = "-r" ];then
             fi
         done
         logger -t xcat -p local4.err "configeth run command: chdev -l $str_nic_name -a netaddr='' -a netmask='' -a netaddr6='' -a prefixlen='' -a state=down"
-        echo "configeth on $NODE run command: chdev -l $str_nic_name -a netaddr='' -a netmask='' -a netaddr6='' -a prefixlen='' -a state=down"
+        log_info "configeth on $NODE run command: chdev -l $str_nic_name -a netaddr='' -a netmask='' -a netaddr6='' -a prefixlen='' -a state=down"
         chdev -l $str_nic_name -a netaddr='' -a netmask='' -a netaddr6='' -a prefixlen='' -a state=down
     else
         #shut down the nic if it is on 
@@ -412,7 +413,7 @@ if [ "$1" = "-r" ];then
 elif [ "$1" = "-s" ];then
     if [ $# -lt 2 ];then
         logger -t xcat -p local4.err "configeth: config install nic, but the nic name is missed"
-        echo "configeth on $NODE: config install nic, but the nic name is missed"
+        log_error "configeth on $NODE: config install nic, but the nic name is missed"
         exit 1
     fi
     str_inst_nic=$2
@@ -423,8 +424,8 @@ elif [ "$1" = "-s" ];then
 
     if [ "$str_os_type" = "aix" ];then
         logger -t xcat -p local4.err "configeth: aix does not support -s flag"
-        echo "configeth on $NODE: aix does not support -s flag"
-        exit 0
+        log_error "configeth on $NODE: aix does not support -s flag"
+        exit 1
     elif [ -f "/etc/debian_version" ];then
         str_lease_file="/var/lib/dhcp/dhclient."$str_inst_nic".leases"
         if [ -e "$str_lease_file" ];then
@@ -502,7 +503,7 @@ elif [ "$1" = "-s" ];then
 
     if [ -z "$str_inst_ip" -o -z "$str_inst_mask" ];then
         logger -t xcat -p local4.err "configeth: config install nic, can not find the information from lease file, return."
-        echo "configeth on $NODE: config install nic, can not find information from dhcp lease file, return."
+        log_info "configeth on $NODE: config install nic, can not find information from dhcp lease file, return."
         exit 0
     fi
 
@@ -648,7 +649,7 @@ fi
 #3. on linux modify the configuration files
 if [ $# -ne 3 ];then
     logger -t xcat -p local4.err "configeth: paramters error currently is $@"
-    echo "configeth on $NODE: paramters error currently is $@"
+    log_error "configeth on $NODE: paramters error currently is $@"
     exit 1
 fi
 str_nic_name=$1
@@ -706,7 +707,7 @@ while [ $num_index -le $NETWORKS_LINES ];do
 done
 
 logger -t xcat -p local4.err "configeth: new configuration"
-echo "configeth on $NODE: new configuration"
+log_info "configeth on $NODE: new configuration"
 num_index=0
 str_ipv6_gateway=''
 while [ $num_index -lt ${#array_nic_ips[*]} ];do
@@ -715,7 +716,7 @@ while [ $num_index -lt ${#array_nic_ips[*]} ];do
     str_netname=${array_nic_networks[$num_index]}
     if [ ! $str_netname ];then
         logger -t xcat -p local4.err "configeth: Network name is not defined on $str_nic_name for $str_ip."
-        echo "configeth on $NODE: Network name is not defined on $str_nic_name for $str_ip."
+        log_error "configeth on $NODE: Network name is not defined on $str_nic_name for $str_ip."
         num_index=$((num_index+1))
         continue
     fi
@@ -724,7 +725,7 @@ while [ $num_index -lt ${#array_nic_ips[*]} ];do
     str_line=${array_nic_network_config[$num_index]}
     if [ ! $str_line ];then
         logger -t xcat -p local4.err "configeth: Network object $str_netname is not defined."
-        echo "configeth on $NODE: Network object $str_netname is not defined."
+        log_error "configeth on $NODE: Network object $str_netname is not defined."
         num_index=$((num_index+1))
         continue
     fi
@@ -737,7 +738,7 @@ while [ $num_index -lt ${#array_nic_ips[*]} ];do
  
     if [ ! $str_subnet -o ! $str_netmask ];then
         logger -t xcat -p local4.err "configeth: subnet or netmask is not defined in network object $str_netname."
-        echo "configeth on $NODE: subnet or netmask is not defined in network object $str_netname."
+        log_error "configeth on $NODE: subnet or netmask is not defined in network object $str_netname."
         num_index=$((num_index+1))
         continue
     fi
@@ -768,7 +769,7 @@ while [ $num_index -lt ${#array_nic_ips[*]} ];do
         str_ip_mask_pair=$str_ip_mask_pair"${str_ip}_${str_netmask} "
     else
         logger -t xcat -p local4.err "configeth: the ipaddress( $str_ip ) for $str_nic_name is invalid."
-        echo "configeth on $NODE: the ipaddress( $str_ip ) for $str_nic_name is invalid."
+        log_error "configeth on $NODE: the ipaddress( $str_ip ) for $str_nic_name is invalid."
     fi
     num_index=$((num_index+1))
 done
@@ -788,7 +789,7 @@ if [ "$str_os_type" = "aix" ];then
         else
             chdev -l $str_nic_name -a netaddr='' -a netmask=''
             logger -t xcat -p local4.err "configeth: delete undefined ip address $str_old_ip"
-            echo "configeth on $NODE: delete undefined ip address $str_old_ip"
+            log_error "configeth on $NODE: delete undefined ip address $str_old_ip"
         fi
     fi
 
@@ -856,7 +857,7 @@ if [ "$str_os_type" = "aix" ];then
         str_ip_status=$(hashget hash_new_config $str_new_ip)
         if [ "$str_ip_status" = "new" ];then
             logger -t xcat -p local4.err "configeth: add $str_new_ip for $str_nic_name temporary."
-            echo "configeth on $NODE: add $str_new_ip for $str_nic_name temporary."
+            log_info "configeth on $NODE: add $str_new_ip for $str_nic_name temporary."
             add_ip_temporary $str_new_ip $str_nic_name
         fi
     done
@@ -891,7 +892,7 @@ else
                     else
                         bool_modify_flag=1
                         logger -t xcat -p local4.err "configeth: delete $str_old_ip for $str_nic_name temporary."
-                        echo "configeth on $NODE: delete $str_old_ip for $str_nic_name temporary."
+                        log_info "configeth on $NODE: delete $str_old_ip for $str_nic_name temporary."
                         str_old_ip=`echo $str_old_ip | tr '_' '/'`
                         ip addr del $str_old_ip dev $str_nic_name
                     fi
@@ -929,7 +930,7 @@ else
                 bool_modify_flag=1
                 if [ $bool_restart_flag -eq 0 ];then
                     logger -t xcat -p local4.err "configeth: add $str_new_ip for $str_nic_name temporary."
-                    echo "configeth on $NODE: add $str_new_ip for $str_nic_name temporary."
+                    log_info "configeth on $NODE: add $str_new_ip for $str_nic_name temporary."
                     add_ip_temporary $str_new_ip $str_nic_name
                 fi
             fi
@@ -940,7 +941,7 @@ else
         ip -6 route | grep default | grep $str_ipv6_gateway
         if [ $? -ne 0 ];then
             logger -t xcat -p local4.err "configeth: the default ipv6 route changes to $str_ipv6_gateway."
-            echo "configeth on $NODE: the default ipv6 route changes to $str_ipv6_gateway."
+            log_info "configeth on $NODE: the default ipv6 route changes to $str_ipv6_gateway."
             ip -6 route del default
             ip -6 route add default $str_ipv6_gateway dev $str_dev_name
         fi
@@ -963,7 +964,7 @@ else
             done
         fi
         logger -t xcat -p local4.err "configeth: $str_nic_name changed, modify the configuration files"
-        echo "configeth on $NODE: $str_nic_name changed, modify the configuration files"
+        log_info "configeth on $NODE: $str_nic_name changed, modify the configuration files"
         num_ipv4_index=0
         num_ipv6_index=0
         num_index=0
@@ -1020,7 +1021,7 @@ else
         done
     else
         logger -t xcat -p local4.err "configeth: $str_nic_name no changed, return directly."
-        echo "configeth on $NODE: $str_nic_name no changed, return directly."
+        log_warn "configeth on $NODE: $str_nic_name no changed, return directly."
     fi
 
     #restart the nic

--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash 
 #-------------------------------------------------------------------------------
 #  confignetwork
 #  Used on Redhat only. Configure bond/vlan/linux bridge/ on the nodes
@@ -18,13 +18,13 @@ if [ x"$str_os_type" = "xLinux" ];then
     . $str_dir_name/nicutils.sh
 else
     log_error "Does NOT support non-Linux Operating System." 
-    exit -1
+    exit 1
 fi
 
 
 ######################################################################
 #
-# OS support
+# OS support checking
 # Check OS version and get the directory of network configuration file
 #
 #####################################################################
@@ -39,17 +39,74 @@ if [ -f "/etc/redhat-release" ];then
 elif [ -f "/etc/SuSE-release" -o -n "$str_temp" ];then
     is_sles=1
     nwdir="/etc/sysconfig/network"
-    log_error "Only supports RHEL"
-    exit -1
 elif [ -f "/etc/debian_version" ];then
     nwdir="/etc/network/interfaces.d"
     is_debian=1
-    log_error "Only supports RHEL" 
-    exit -1
 else
-    log_error "Only supports RHEL" 
-    exit -1
+    log_error "Only supports Linux"
+    exit 1
 fi
+
+######################################################################
+#
+# get network configuration file content
+#
+####################################################################
+function get_nic_cfg_file_content {
+    cfg_dev=$1
+    cfg_file=''
+    if [ $is_redhat -eq 1 ] || [ $is_sles -eq 1 ]; then
+         cfg_file="$nwdir/ifcfg-${cfg_dev}" 
+    elif [ $is_debian -eq 1 ]; then
+         cfg_file="$nwdir/${cfg_dev}"
+    fi
+
+    echo "['${cfg_file}']" >&2
+    cat ${cfg_file}| $sed -e 's/^/ >> /g' | log_lines info
+
+}
+
+######################################################################
+#
+# Parser input arguments
+#
+#####################################################################
+boot_install_nic=0
+for arg in "$@"
+do
+    if [ "$arg" = "-s" ];then
+        boot_install_nic=1
+    fi
+    #TODO: IB support is TBD
+done
+if [ "$SETINSTALLNIC" = "1" ] || [ "$SETINSTALLNIC" = "yes" ]; then
+    bool_install_nic=1
+fi
+
+
+
+######################################################################
+#
+# Preparation for installnic
+#
+#####################################################################
+function get_installnic {
+    tmp_installnic=''
+    if [ ! $INSTALLNIC ];then
+        tmp_installnic="mac"
+    else
+        tmp_installnic=$INSTALLNIC
+    fi
+
+    instnic=''
+    if [ "$tmp_installnic" = "mac" ];then
+        instnic=`ip -o link | grep -i "$MACADDRESS" | awk '{print $2;}' | sed s/://`
+    elif [ `echo $tmp_installnic | grep -E "e(n|th|m)[0-9a-zA-Z]+"` ];then
+        instnic=$str_temp
+    fi
+    echo $instnic
+}
+
 
 
 #######################################################################################
@@ -118,6 +175,23 @@ function find_nic_type {
     fi
     nic=$1
     echo $(hashget "nictypes" $nic)
+}
+
+################################################################
+#
+# find nic custom scripts
+#
+# input : nic
+#
+# output : niccustomscripts from nics table
+#
+###############################################################
+function find_nic_custom_scripts {
+    if [ ! "$1" ];then
+        return
+    fi
+    nic=$1
+    echo $(hashget "niccustomscripts" $nic)
 }
 
 
@@ -231,14 +305,29 @@ function sort_nics_device_order {
     while [ $num1 -lt $max1 ];
     do
         alonenic=`echo "$alone_nics"|sed -n "${num1}p"|sed "s/ //g"`
+        #make sure alonenic does not have base device
         echo "$nics_list"| grep "$alonenic" >/dev/null
         if [ $? -ne 0 ]; then
-            echo $alonenic
+            #pre-check nicips nictype nicnetworks for alone nic
+            #nicips nictype and nicnetworks should be configured in nics table for alone nic
+            alonenicips=`find_nic_ips $alonenic`
+            alonenictype=`find_nic_type $alonenic`
+            alonenicnetwork=`query_nicnetworks_net $alonenic`
+            if [ -n "$alonenicips" ] && [ -n "$alonenictype" ] && [ -n "$alonenicnetwork" ]; then
+                #if alone nic configure nicips, it is valid 
+                echo $alonenic
+            else
+                errorcode=1
+                echo "Error: nicips,nictype and nicnetwork should be configured in nics table for $alonenic."
+                ((num1+=1)) 
+                continue
+            fi
         fi
         ((num1+=1))
     done
-    #
-    if [ -n "$nics_list" ]; then 
+    
+    if [ -n "$nics_list" ]; then
+      if [ $is_redhat -eq 1 ]; then  
         num=1
         max=`echo "$nics_list"|wc -l`
         ((max+=1))
@@ -302,6 +391,9 @@ function sort_nics_device_order {
             fi
             ((num+=1))
         done
+      else
+        log_error "Error: only support configure bond/vlan/bridge on redhat."
+      fi
     fi
     new_order=$eth_slot" "$bond_slot" "$vlan_slot
     new_order_list=""
@@ -336,6 +428,36 @@ function configure_nicdevice {
     ((max+=1))
     while [ $num -lt $max ];
     do
+        nic_dev=`echo "$nics_pair" |sed -n "${num}p"|awk '{print $1}'`
+        #If install nic is configured, skip to reconfigure it
+        if [ x"$nic_dev" = x"$installnic" -a $instnic_conf -eq 1 ]; then
+            log_warn "install nic $nic_dev has been configured, skip to reconfigure it."
+            ((num+=1))
+            continue
+        fi
+        #processing custom scripts for nic
+        customcmd=`find_nic_custom_scripts $nic_dev`
+        customscript=`echo $customcmd|awk '{print $1}'`
+        if [ -n "$customscript" ]; then
+            if [ -f "/install/postscript/$customscript" ]; then
+                #if there is no custom script in /install/postscript,exit this loop
+                log_error "/install/postscript/$customscript does not exist."
+                errorcode=1
+                ((num+=1))
+                continue
+            fi
+            echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+            log_info "processing custom scripts:\"$customcmd\"  for interface $nic_dev"
+            $customcmd
+            if [ $? -ne 0 ]; then
+                errorcode=1
+            fi
+
+            #if custom script is finished, go to configure next nic/nic_pair
+            ((num+=1))
+            continue
+        fi
+        #get base nic and its type
         base_nic_dev=`echo "$nics_pair" |sed -n "${num}p"|awk '{print $2}'`
         if [ -n "$base_nic_dev" ]; then
             if echo "$base_nic_dev"|grep "@" >/dev/null; then
@@ -347,17 +469,23 @@ function configure_nicdevice {
         
             base_nic_type=`find_nic_type "$base_temp_nic" | $utolcmd`
         fi
-        nic_dev=`echo "$nics_pair" |sed -n "${num}p"|awk '{print $1}'`
         nic_dev_type=`find_nic_type "$nic_dev" | $utolcmd`
         echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
         nic_pair=`echo "$nics_pair" |sed -n "${num}p"`
         echo "configure nic and its device : $nic_pair"
+
         #configure standalone ethernet nic
         if [ x"$nic_dev_type" = "xethernet" ]; then
-            
-            ipaddr=`find_nic_ips $nic_dev|awk -F"|" '{print $1}'`
-            if [ -n "$ipaddr" ]; then
-                create_ethernet_interface ifname=$nic_dev _ipaddr=$ipaddr
+            xcatnet=`query_nicnetworks_net $nic_dev`            
+            ipaddrs=`find_nic_ips $nic_dev`
+            if [ -n "$ipaddrs" ]; then
+                log_info "configure $nic_dev"
+                log_info "call: configeth $nic_dev $ipaddrs $xcatnet"
+                configeth $nic_dev $ipaddrs $xcatnet
+                if [ $? -ne 0 ]; then
+                    errorcode=1
+                fi
+                get_nic_cfg_file_content $nic_dev
             else
                 log_warn "There is no ip for $nic_dev."
                 ((noip+=1))
@@ -367,6 +495,7 @@ function configure_nicdevice {
                 log_error "There is no any ip configured for any nic. Check nicips in nics table first."
                 errorcode=1
             fi 
+
         #configure bridge
         #linux bridge type is bridge
         #openvswitch bridge type is bridge_ovs
@@ -387,6 +516,8 @@ function configure_nicdevice {
         #configure bond 
         elif [ x"$nic_dev_type" = "xbond" ]; then
             create_bond_interface ifname=$nic_dev slave_ports=$base_nic_for_bond       
+        elif [ x"$nic_dev_type" = "xinfiniband" ]; then
+            log_error "confignetwork does not support configure IB. "
         else
             log_error "Error : please check nictypes for $nic_pair."
             errorcode=1
@@ -425,6 +556,27 @@ function enable_network_service {
 
 errorcode=0
 
+#get for installnic
+installnic=''
+installnic=`get_installnic`
+instnic_conf=0
+if [ $boot_install_nic -eq 1 ];then
+    #get installnic
+    installnic=''
+    installnic=`get_installnic`
+    echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+    log_info "configure the install nic. "
+    log_info "call 'configeth -s $installnic"
+    instnic_conf=1
+    configeth -s $installnic |log_lines info
+    if [ $? -ne 0 ]; then
+        errorcode=1
+    fi
+    get_nic_cfg_file_content $installnic
+    echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+fi
+
+
 #nictypes should support capital letters, for example, Ethernet and ethernet
 utolcmd="sed -e y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/"
 
@@ -440,6 +592,8 @@ parser_nic_attribute "$NICTYPES" "nictypes"
 #make hash for nicips
 parser_nic_attribute "$NICIPS" "nicips"
 
+#make hash for niccustomscripts
+parser_nic_attribute "$NICCUSTOMSCRIPTS" "niccustomscripts"
 
 #get nic and its device pair, for example
 #eth0.6 eth0
@@ -449,11 +603,8 @@ parser_nic_attribute "$NICIPS" "nicips"
 new_nicdevice=`find_nic_and_device_list $str_all_nics|sort -g -k1 -g -k2|uniq`
 if [ -z "$new_nicdevice" ]; then
     log_info "There is no nic device to configure."
-    exit 
+    exit 1 
 fi
-
-#enable network service
-enable_network_service
 
 #sort nics device pair based on nicdevice type
 sorted_nicdevice_list=`sort_nics_device_order "$new_nicdevice"`
@@ -461,14 +612,18 @@ sorted_nicdevice_list=`sort_nics_device_order "$new_nicdevice"`
 #If there is invalid nics pair, errorcode is 1
 invalid_nicdevice_pair=`echo "$sorted_nicdevice_list" | grep "Error"`
 if [ $? -eq 0 ]; then
-log_error $invalid_nicdevice_pair
-errorcode=1
+    echo "$invalid_nicdevice_pair"|log_lines error
+    errorcode=1
 fi
 
 #delete invalid nics device pair based on Error
-valid_sorted_nicdevice_list=`echo "$sorted_nicdevice_list" | sed '/Error/d'` 
-log_info "All valid nics and device list:"
-echo "$valid_sorted_nicdevice_list" |log_lines info
+valid_sorted_nicdevice_list=`echo "$sorted_nicdevice_list" | sed '/Error/d'`
+if [ -n "$valid_sorted_nicdevice_list" ]; then 
+    log_info "All valid nics and device list:"
+    echo "$valid_sorted_nicdevice_list" |log_lines info
+fi
+#enable network service
+enable_network_service
 
 #config nics and ifcfg files
 configure_nicdevice "$valid_sorted_nicdevice_list"


### PR DESCRIPTION
For task #3188 and #3071 

The unit test and output:
The networks table, "10_0_0_0-255_0_0_0" is provision network :
```
[root@bybc0602 postscripts]# tabdump networks
#netname,net,mask,mgtifname,gateway,dhcpserver,tftpserver,nameservers,ntpservers,logservers,dynamicrange,staticrange,staticrangeincrement,nodehostname,ddnsdomain,vlanid,domain,mtu,comments,disable
"10_0_0_0-255_0_0_0","10.0.0.0","255.0.0.0","eth0","<xcatmaster>",,"10.5.106.2",,,,,,,,,,,"1000",,
"30_0_0_0-255_0_0_0","30.0.0.0","255.0.0.0",,"<xcatmaster>",,"30.5.106.1",,,,,,,,,,,,,
"40_0_0_0-255_0_0_0","40.0.0.0","255.0.0.0",,"<xcatmaster>",,"40.5.106.1",,,,,,,,,,,,,
```
1.
There are ethernet eth0 eth2 eth3 in CN, user wants to configure eth0 as installnic,its ip is 10.5.106.9, eth2 as secondary ethernet nic, its ip is 30.5.106.9. He wants to create bridge br3 based on eth3, br3 ip is 40.5.106.9. He wants to run  custom script testbr for br1. He executes updatenode to call "confignetwork -s" to configure all above requests.

The nics table is as this node definition:
```
[root@bybc0602 postscripts]# lsdef bybc0609|sed 's/    //g'|grep ^nic
niccustomscripts.br1=testbr br1
nicdevices.br3=eth3
nicips.eth2=30.5.106.9
nicips.br3=40.5.106.9
nicips.br1=20.5.106.9
nicnetworks.eth2=30_0_0_0-255_0_0_0
nicnetworks.br3=40_0_0_0-255_0_0_0
nicnetworks.br1=20_0_0_0-255_0_0_0
nictypes.eth2=Ethernet
nictypes.eth3=Ethernet
nictypes.br3=bridge
nictypes.br1=bridge
```
confignetwork output:
```
[root@bybc0602 postscripts]# updatenode bybc0609 "confignetwork -s"
bybc0609: xcatdsklspost: downloaded postscripts successfully
bybc0609: Wed Jun 21 04:47:44 EDT 2017 Running postscript: confignetwork
bybc0609: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bybc0609: [I]: configure the install nic.
bybc0609: [I]: call 'configeth -s eth0
bybc0609: [I]: [I]: configeth on bybc0609: os type: redhat
bybc0609: [I]: GATEWAY=10.5.106.2
bybc0609: ['/etc/sysconfig/network-scripts/ifcfg-eth0']
bybc0609: [I]: >> DEVICE=eth0
bybc0609: [I]: >> IPADDR=10.5.106.9
bybc0609: [I]: >> NETMASK=255.0.0.0
bybc0609: [I]: >> BOOTPROTO=static
bybc0609: [I]: >> ONBOOT=yes
bybc0609: [I]: >> HWADDR=42:f5:0a:05:6a:09
bybc0609: [I]: >> MTU=1000
bybc0609: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bybc0609: [I]: All valid nics and device list:
bybc0609: [I]: br1
bybc0609: [I]: eth2
bybc0609: [I]: br3 eth3
bybc0609: [I]: NetworkManager is inactive.
bybc0609: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bybc0609: [I]: processing custom scripts:"testbr br1"  for interface br1
bybc0609: This is test script to test niccustomscripts for br1
bybc0609: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bybc0609: configure nic and its device : eth2
bybc0609: [I]: configure eth2
bybc0609: [I]: call: configeth eth2 30.5.106.9 30_0_0_0-255_0_0_0
bybc0609: [I]: configeth on bybc0609: os type: redhat
bybc0609: configeth on bybc0609: old configuration: 4: eth2: <BROADCAST,MULTICAST> mtu 1500 qdisc pfifo_fast state DOWN qlen 1000
bybc0609:     link/ether 42:47:0a:05:6a:09 brd ff:ff:ff:ff:ff:ff
bybc0609: [I]: configeth on bybc0609: new configuration
bybc0609:        30.5.106.9, 30.0.0.0, 255.0.0.0, <xcatmaster>
bybc0609: [I]: configeth on bybc0609: eth2 changed, modify the configuration files
bybc0609: eth2
bybc0609: bring up ip
bybc0609: ['/etc/sysconfig/network-scripts/ifcfg-eth2']
bybc0609: [I]: >> DEVICE=eth2
bybc0609: [I]: >> BOOTPROTO=static
bybc0609: [I]: >> NM_CONTROLLED=no
bybc0609: [I]: >> IPADDR=30.5.106.9
bybc0609: [I]: >> NETMASK=255.0.0.0
bybc0609: [I]: >> ONBOOT=yes
bybc0609: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bybc0609: configure nic and its device : br3 eth3
bybc0609: [I]: create_bridge_interface ifname=br3 _brtype=bridge _port=eth3 _pretype=ethernet
bybc0609: [I]: Pickup xcatnet, "40_0_0_0-255_0_0_0", from NICNETWORKS for interface "br3".
bybc0609: [I]: create_raw_eth_interface_for_br ifname=eth3 _bridge=br3 _mtu=
bybc0609: [I]: create_persistent_ifcfg ifname=eth3 inattrs=ONBOOT=yes,TYPE=Ethernet,BRIDGE=br3,BOOTPROTO=none
bybc0609: ['ifcfg-eth3']
bybc0609: [I]: >> DEVICE="eth3"
bybc0609: [I]: >> BOOTPROTO="none"
bybc0609: [I]: >> NAME="eth3"
bybc0609: [I]: >> HWADDR="42:82:0a:05:6a:09"
bybc0609: [I]: >> ONBOOT="yes"
bybc0609: [I]: >> TYPE="Ethernet"
bybc0609: [I]: >> BRIDGE="br3"
bybc0609: [I]: brctl addbr br3
bybc0609: [I]: brctl stp br3 on
bybc0609: [I]: brctl addif br3 eth3
bybc0609: [I]: migrate_ip ifname=br3 sports=eth3
bybc0609: [I]: create_persistent_ifcfg ifname=br3 xcatnet=40_0_0_0-255_0_0_0 inattrs=ONBOOT=yes,STP=on,TYPE=Bridge
bybc0609: ['ifcfg-br3']
bybc0609: [I]: >> DEVICE="br3"
bybc0609: [I]: >> BOOTPROTO="static"
bybc0609: [I]: >> IPADDR="40.5.106.9"
bybc0609: [I]: >> NETMASK="255.0.0.0"
bybc0609: [I]: >> NAME="br3"
bybc0609: [I]: >> ONBOOT="yes"
bybc0609: [I]: >> STP="on"
bybc0609: [I]: >> TYPE="Bridge"
bybc0609: postscript: confignetwork exited with code 0
bybc0609: Running of postscripts has completed.
```
2.
There are ethernet eth0 eth2 eth3 in CN, user does not want to configure eth0 as static, so he use updatenode to call "confignetwork" to finish his work.He wants to configure eth2 as secondary ethernet nic, its ip is 30.5.106.9. He wants to create bridge br3 based on eth3, br3 ip is 40.5.106.9. He wants to run  custom script testbr for br1.He entered wrong configuration for br2,so br2 is invalid.

nics table configuration for this CN:
```
[root@bybc0602 postscripts]# lsdef bybc0609|sed 's/    //g'|grep ^nic
niccustomscripts.br1=testbr br1
nicdevices.br3=eth3
nicips.eth2=30.5.106.9
nicips.br3=40.5.106.9
nicips.br1=20.5.106.9
nicnetworks.eth2=30_0_0_0-255_0_0_0
nicnetworks.br3=40_0_0_0-255_0_0_0
nicnetworks.br1=20_0_0_0-255_0_0_0
nictypes.eth2=Ethernet
nictypes.eth3=Ethernet
nictypes.br3=bridge
nictypes.br2=bridge
nictypes.br1=bridge
```
confignetwork output:
```
[root@bybc0602 postscripts]# updatenode bybc0609 confignetwork
bybc0609: xcatdsklspost: downloaded postscripts successfully
bybc0609: Wed Jun 21 04:43:12 EDT 2017 Running postscript: confignetwork
bybc0609: [E]: Error: nicips,nictype and nicnetwork should be configured in nics table for br2.
bybc0609: [I]: All valid nics and device list:
bybc0609: [I]: br1
bybc0609: [I]: eth2
bybc0609: [I]: br3 eth3
bybc0609: [I]: NetworkManager is inactive.
bybc0609: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bybc0609: [I]: processing custom scripts:"testbr br1"  for interface br1
bybc0609: This is test script to test niccustomscripts for br1
bybc0609: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bybc0609: configure nic and its device : eth2
bybc0609: [I]: configure eth2
bybc0609: [I]: call: configeth eth2 30.5.106.9 30_0_0_0-255_0_0_0
bybc0609: [I]: configeth on bybc0609: os type: redhat
bybc0609: configeth on bybc0609: old configuration: 4: eth2: <BROADCAST,MULTICAST> mtu 1500 qdisc pfifo_fast state DOWN qlen 1000
bybc0609:     link/ether 42:47:0a:05:6a:09 brd ff:ff:ff:ff:ff:ff
bybc0609: [I]: configeth on bybc0609: new configuration
bybc0609:        30.5.106.9, 30.0.0.0, 255.0.0.0, <xcatmaster>
bybc0609: [I]: configeth on bybc0609: eth2 changed, modify the configuration files
bybc0609: eth2
bybc0609: bring up ip
bybc0609: ['/etc/sysconfig/network-scripts/ifcfg-eth2']
bybc0609: [I]: >> DEVICE=eth2
bybc0609: [I]: >> BOOTPROTO=static
bybc0609: [I]: >> NM_CONTROLLED=no
bybc0609: [I]: >> IPADDR=30.5.106.9
bybc0609: [I]: >> NETMASK=255.0.0.0
bybc0609: [I]: >> ONBOOT=yes
bybc0609: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bybc0609: configure nic and its device : br3 eth3
bybc0609: [I]: create_bridge_interface ifname=br3 _brtype=bridge _port=eth3 _pretype=ethernet
bybc0609: [I]: Pickup xcatnet, "40_0_0_0-255_0_0_0", from NICNETWORKS for interface "br3".
bybc0609: [I]: create_raw_eth_interface_for_br ifname=eth3 _bridge=br3 _mtu=
bybc0609: [I]: create_persistent_ifcfg ifname=eth3 inattrs=ONBOOT=yes,TYPE=Ethernet,BRIDGE=br3,BOOTPROTO=none
bybc0609: ['ifcfg-eth3']
bybc0609: [I]: >> DEVICE="eth3"
bybc0609: [I]: >> BOOTPROTO="none"
bybc0609: [I]: >> NAME="eth3"
bybc0609: [I]: >> HWADDR="42:82:0a:05:6a:09"
bybc0609: [I]: >> ONBOOT="yes"
bybc0609: [I]: >> TYPE="Ethernet"
bybc0609: [I]: >> BRIDGE="br3"
bybc0609: [I]: brctl addbr br3
bybc0609: [I]: brctl stp br3 on
bybc0609: [I]: brctl addif br3 eth3
bybc0609: [I]: migrate_ip ifname=br3 sports=eth3
bybc0609: [I]: create_persistent_ifcfg ifname=br3 xcatnet=40_0_0_0-255_0_0_0 inattrs=ONBOOT=yes,STP=on,TYPE=Bridge
bybc0609: ['ifcfg-br3']
bybc0609: [I]: >> DEVICE="br3"
bybc0609: [I]: >> BOOTPROTO="static"
bybc0609: [I]: >> IPADDR="40.5.106.9"
bybc0609: [I]: >> NETMASK="255.0.0.0"
bybc0609: [I]: >> NAME="br3"
bybc0609: [I]: >> ONBOOT="yes"
bybc0609: [I]: >> STP="on"
bybc0609: [I]: >> TYPE="Bridge"
bybc0609: postscript: confignetwork exited with code 1
bybc0609: Running of postscripts has completed.
```
