### PR TITLE
[openbmc] Add --verbose option and improve readability for `rinv <> firm` 

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rinv.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rinv.1.rst
@@ -39,7 +39,7 @@ OpenPOWER (OpenBMC) server specific:
 ====================================
 
 
-\ **rinv**\  \ *noderange*\  [\ **model | serial | firm | cpu | dimm | all**\ ]
+\ **rinv**\  \ *noderange*\  [\ **model | serial | firm | cpu | dimm | all**\ ] [\ **-V | -**\ **-verbose**\ ]
 
 
 PPC (with HMC) specific:
@@ -231,6 +231,12 @@ Calling \ **rinv**\  for VMware will display the UUID/GUID, number of CPUs, amou
 \ **-v | -**\ **-version**\ 
  
  Print version.
+ 
+
+
+\ **-V | -**\ **-verbose**\ 
+ 
+ Not supported for all managed machines.  Prints verbose output.
  
 
 

--- a/docs/source/guides/admin-guides/references/man1/rinv.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rinv.1.rst
@@ -236,7 +236,7 @@ Calling \ **rinv**\  for VMware will display the UUID/GUID, number of CPUs, amou
 
 \ **-V | -**\ **-verbose**\ 
  
- Not supported for all managed machines.  Prints verbose output.
+ Prints verbose output, if available.
  
 
 

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -100,7 +100,7 @@ my %usage = (
     OpenPOWER (IPMI) server specific:
        rinv <noderange> [model|serial|deviceid|uuid|guid|vpd|mprom|firm|all] 
     OpenPOWER (OpenBMC) server specific:
-       rinv <noderange> [model|serial|firm|cpu|dimm|all]
+       rinv <noderange> [model|serial|firm|cpu|dimm|all] [-V|--verbose]
     PPC specific(with HMC):
        rinv <noderange> [all|bus|config|serial|model|firm]
     PPC specific(using Direct FSP Management):

--- a/xCAT-client/pods/man1/rinv.1.pod
+++ b/xCAT-client/pods/man1/rinv.1.pod
@@ -16,7 +16,7 @@ B<rinv> I<noderange> [B<model>|B<serial>|B<deviceid>|B<uuid>|B<guid>|B<vpd>|B<mp
 
 =head2 OpenPOWER (OpenBMC) server specific:
 
-B<rinv> I<noderange> [B<model>|B<serial>|B<firm>|B<cpu>|B<dimm>|B<all>]
+B<rinv> I<noderange> [B<model>|B<serial>|B<firm>|B<cpu>|B<dimm>|B<all>] [B<-V>|B<--verbose>]
 
 =head2 PPC (with HMC) specific:
 
@@ -148,6 +148,10 @@ Print help.
 =item B<-v>|B<--version>
 
 Print version.
+
+=item B<-V>|B<--verbose>
+
+Not supported for all managed machines.  Prints verbose output.
 
 =item B<-t>
 

--- a/xCAT-client/pods/man1/rinv.1.pod
+++ b/xCAT-client/pods/man1/rinv.1.pod
@@ -151,7 +151,7 @@ Print version.
 
 =item B<-V>|B<--verbose>
 
-Not supported for all managed machines.  Prints verbose output.
+Prints verbose output, if available.
 
 =item B<-t>
 


### PR DESCRIPTION
This pull request is a result of conversation with @robin2008 starting from: https://github.com/xcat2/xcat-core/issues/3274#issuecomment-309942598

So there was a reason that the output was formatted in such a way and I should have added some output examples in PR https://github.com/xcat2/xcat-core/pull/3145 because I had forgotten the reason why.  

With P8 OpenPower machines [ipmi] managed, it didn't support multiple firmware uploaded to the BMC to be on standby so the output was more easily read.  But for OpenBMC, once we start to display multiple firmware levels, it becomes a larger mess.   

## Here's what it would look like if we attempted to match IPMI based OpenPower machines:

```
[root@fs2vm110 ~]# rinv  p9euh02 firm --verbose
p9euh02: BMC Firmware Product Version: v1.99.6-130-g35cfa84 (Active)
p9euh02: HOST Firmware Product Version: IBM-witherspoon-ibm-OP9_v1.17_1.20 (Ready)
p9euh02: HOST Firmware Product Version: Additional Info: buildroot-2017.2.2-7-g23118ce
p9euh02: HOST Firmware Product Version: Additional Info: capp-ucode-9c73e9f
p9euh02: HOST Firmware Product Version: Additional Info: hostboot-binaries-d8f4ab7
p9euh02: HOST Firmware Product Version: Additional Info: hostboot-d2273f
p9euh02: HOST Firmware Product Version: Additional Info: linux-4.11.1-openpower1-p77ac250
p9euh02: HOST Firmware Product Version: Additional Info: machine-xml-e536539
p9euh02: HOST Firmware Product Version: Additional Info: occ-8a7df3
p9euh02: HOST Firmware Product Version: Additional Info: op-build-v1.16-87-g5e69953-dirty
p9euh02: HOST Firmware Product Version: Additional Info: petitboot-v1.4.2-pf0e80a2
p9euh02: HOST Firmware Product Version: Additional Info: sbe-d770027
p9euh02: HOST Firmware Product Version: Additional Info: skiboot-5b8834-p7542d9b
p9euh02: HOST Firmware Product Version: IBM-witherspoon-ibm-OP9_v1.16_1.24 (Ready)
p9euh02: HOST Firmware Product Version: Additional Info: buildroot-2017.2.2-7-g23118ce
p9euh02: HOST Firmware Product Version: Additional Info: capp-ucode-9c73e9f
p9euh02: HOST Firmware Product Version: Additional Info: hostboot-binaries-d8f4ab7
p9euh02: HOST Firmware Product Version: Additional Info: hostboot-d2273f
p9euh02: HOST Firmware Product Version: Additional Info: linux-4.11.1-openpower1-pc11ec3
p9euh02: HOST Firmware Product Version: Additional Info: machine-xml-e536539
p9euh02: HOST Firmware Product Version: Additional Info: occ-8a7df3
p9euh02: HOST Firmware Product Version: Additional Info: op-build-v1.16-83-ge67b53c-dirty
p9euh02: HOST Firmware Product Version: Additional Info: petitboot-v1.4.2-pcb6424c
p9euh02: HOST Firmware Product Version: Additional Info: sbe-d770027
p9euh02: HOST Firmware Product Version: Additional Info: skiboot-5.6.0-rc2
p9euh02: HOST Firmware Product Version: IBM-witherspoon-ibm-OP9_v1.17_1.10 (Ready)
p9euh02: HOST Firmware Product Version: Additional Info: buildroot-2017.2.2-7-g23118ce
p9euh02: HOST Firmware Product Version: Additional Info: capp-ucode-9c73e9f
p9euh02: HOST Firmware Product Version: Additional Info: hostboot-binaries-bc600e6
p9euh02: HOST Firmware Product Version: Additional Info: hostboot-dff36e4
p9euh02: HOST Firmware Product Version: Additional Info: linux-4.11.2-openpower1-p62f2cf
p9euh02: HOST Firmware Product Version: Additional Info: machine-xml-96746e9
p9euh02: HOST Firmware Product Version: Additional Info: occ-bc34ad5
p9euh02: HOST Firmware Product Version: Additional Info: op-build-v1.17-20-gbaac7a6-dirty
p9euh02: HOST Firmware Product Version: Additional Info: petitboot-v1.4.2-p9717304
p9euh02: HOST Firmware Product Version: Additional Info: sbe-d770027
p9euh02: HOST Firmware Product Version: Additional Info: skiboot-d673ecc
``` 

I feel this is hard to read.  In this pull request, I made the output more closely resemble the past, but I think we still should change it slightly to improve the readability.  

Here's what it looks like with the code changes: 

## without verbose, now display the non Active software

This is so that users can use rinv to get firmware information if they wanted to validate that all their compute nodes had the same FW levels , without going to the `rflash` command for that.  I feel that rflash means the user is intending to do flashing of firmware, but this is really a query command. 

```
[root@fs2vm110 ~]# rinv  p9euh02 firm 
p9euh02: BMC Firmware Product: v1.99.6-130-g35cfa84 (Active)
p9euh02: HOST Firmware Product: IBM-witherspoon-ibm-OP9_v1.17_1.20 (Ready)
p9euh02: HOST Firmware Product: IBM-witherspoon-ibm-OP9_v1.16_1.24 (Ready)
p9euh02: HOST Firmware Product: IBM-witherspoon-ibm-OP9_v1.17_1.10 (Ready)
```

## With verbose, we now display the additional info 
```
[root@fs2vm110 ~]# rinv  p9euh02 firm --verbose
p9euh02: BMC Firmware Product: v1.99.6-130-g35cfa84 (Active)
p9euh02: HOST Firmware Product: IBM-witherspoon-ibm-OP9_v1.17_1.20 (Ready)
p9euh02: HOST Firmware Product: -- additional info: buildroot-2017.2.2-7-g23118ce
p9euh02: HOST Firmware Product: -- additional info: capp-ucode-9c73e9f
p9euh02: HOST Firmware Product: -- additional info: hostboot-binaries-d8f4ab7
p9euh02: HOST Firmware Product: -- additional info: hostboot-d2273f
p9euh02: HOST Firmware Product: -- additional info: linux-4.11.1-openpower1-p77ac250
p9euh02: HOST Firmware Product: -- additional info: machine-xml-e536539
p9euh02: HOST Firmware Product: -- additional info: occ-8a7df3
p9euh02: HOST Firmware Product: -- additional info: op-build-v1.16-87-g5e69953-dirty
p9euh02: HOST Firmware Product: -- additional info: petitboot-v1.4.2-pf0e80a2
p9euh02: HOST Firmware Product: -- additional info: sbe-d770027
p9euh02: HOST Firmware Product: -- additional info: skiboot-5b8834-p7542d9b
p9euh02: HOST Firmware Product: IBM-witherspoon-ibm-OP9_v1.16_1.24 (Ready)
p9euh02: HOST Firmware Product: -- additional info: buildroot-2017.2.2-7-g23118ce
p9euh02: HOST Firmware Product: -- additional info: capp-ucode-9c73e9f
p9euh02: HOST Firmware Product: -- additional info: hostboot-binaries-d8f4ab7
p9euh02: HOST Firmware Product: -- additional info: hostboot-d2273f
p9euh02: HOST Firmware Product: -- additional info: linux-4.11.1-openpower1-pc11ec3
p9euh02: HOST Firmware Product: -- additional info: machine-xml-e536539
p9euh02: HOST Firmware Product: -- additional info: occ-8a7df3
p9euh02: HOST Firmware Product: -- additional info: op-build-v1.16-83-ge67b53c-dirty
p9euh02: HOST Firmware Product: -- additional info: petitboot-v1.4.2-pcb6424c
p9euh02: HOST Firmware Product: -- additional info: sbe-d770027
p9euh02: HOST Firmware Product: -- additional info: skiboot-5.6.0-rc2
p9euh02: HOST Firmware Product: IBM-witherspoon-ibm-OP9_v1.17_1.10 (Ready)
p9euh02: HOST Firmware Product: -- additional info: buildroot-2017.2.2-7-g23118ce
p9euh02: HOST Firmware Product: -- additional info: capp-ucode-9c73e9f
p9euh02: HOST Firmware Product: -- additional info: hostboot-binaries-bc600e6
p9euh02: HOST Firmware Product: -- additional info: hostboot-dff36e4
p9euh02: HOST Firmware Product: -- additional info: linux-4.11.2-openpower1-p62f2cf
p9euh02: HOST Firmware Product: -- additional info: machine-xml-96746e9
p9euh02: HOST Firmware Product: -- additional info: occ-bc34ad5
p9euh02: HOST Firmware Product: -- additional info: op-build-v1.17-20-gbaac7a6-dirty
p9euh02: HOST Firmware Product: -- additional info: petitboot-v1.4.2-p9717304
p9euh02: HOST Firmware Product: -- additional info: sbe-d770027
p9euh02: HOST Firmware Product: -- additional info: skiboot-d673ecc
```
 
Let me know your thoughts. 