### PR TITLE
Fix man page and usage for MPA rinv command

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rinv.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rinv.1.rst
@@ -25,7 +25,7 @@ BMC/MPA specific:
 =================
 
 
-\ **rinv**\  \ *noderange*\  {\ **pci | model | serial | asset | vpd | mprom | deviceid | guid | firm | diag | dimm | bios | mparom | mac | all**\ }
+\ **rinv**\  \ *noderange*\  [\ **model | serial | asset | vpd | deviceid | guid | firm | dimm | mprom | all**\ ]
 
 
 OpenPOWER (IPMI) server specific:
@@ -126,12 +126,6 @@ Calling \ **rinv**\  for VMware will display the UUID/GUID, number of CPUs, amou
 
 
 
-\ **pci**\ 
- 
- Retrieves PCI bus information.
- 
-
-
 \ **bus**\ 
  
  List all buses for each I/O slot.
@@ -140,8 +134,7 @@ Calling \ **rinv**\  for VMware will display the UUID/GUID, number of CPUs, amou
 
 \ **config**\ 
  
- Retrieves number of processors, speed, total memory, and DIMM
- locations.
+ Retrieves number of processors, speed, total memory, and DIMM locations.
  
 
 
@@ -177,7 +170,7 @@ Calling \ **rinv**\  for VMware will display the UUID/GUID, number of CPUs, amou
 
 \ **asset**\ 
  
- Retrieves asset tag.  Usually it's the MAC address of eth0.
+ Retrieves asset tag. Usually it's the MAC address of eth0.
  
 
 
@@ -196,6 +189,12 @@ Calling \ **rinv**\  for VMware will display the UUID/GUID, number of CPUs, amou
 \ **mprom**\ 
  
  Retrieves mprom firmware level.
+ 
+
+
+\ **dimm**\ 
+ 
+ Retrieves dual in-line memory module information.
  
 
 

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -95,14 +95,12 @@ my %usage = (
     Common:
        rinv <noderange> [all|model|serial] [-V|--verbose]
        rinv [-h|--help|-v|--version]
-    BMC specific:
-       rinv <noderange> [mprom|deviceid|uuid|guid|vpd|dimm|all]
+    BMC/MPA specific:
+       rinv <noderange> [model|serial|asset|vpd|deviceid|guid|firm|dimm|mprom|all]
     OpenPOWER (IPMI) server specific:
        rinv <noderange> [model|serial|deviceid|uuid|guid|vpd|mprom|firm|all] 
     OpenPOWER (OpenBMC) server specific:
        rinv <noderange> [model|serial|firm|cpu|dimm|all]
-    MPA specific:
-       rinv <noderange> [firm|bios|diag|mprom|sprom|mparom|mac|mtm] 
     PPC specific(with HMC):
        rinv <noderange> [all|bus|config|serial|model|firm]
     PPC specific(using Direct FSP Management):

--- a/xCAT-client/pods/man1/rinv.1.pod
+++ b/xCAT-client/pods/man1/rinv.1.pod
@@ -8,7 +8,7 @@ B<rinv> [B<-h>|B<--help>|B<-v>|B<--version>]
 
 =head2 BMC/MPA specific:
 
-B<rinv> I<noderange> {B<pci>|B<model>|B<serial>|B<asset>|B<vpd>|B<mprom>|B<deviceid>|B<guid>|B<firm>|B<diag>|B<dimm>|B<bios>|B<mparom>|B<mac>|B<all>}
+B<rinv> I<noderange> [B<model>|B<serial>|B<asset>|B<vpd>|B<deviceid>|B<guid>|B<firm>|B<dimm>|B<mprom>|B<all>]
 
 =head2 OpenPOWER (IPMI) server specific:
   
@@ -39,7 +39,6 @@ B<rinv> I<noderange> [B<-t>]
 =head2 pdu specific:
 
 B<rinv> I<noderange> 
-
 
 =head2 zVM specific:
 
@@ -78,18 +77,13 @@ Calling B<rinv> for VMware will display the UUID/GUID, number of CPUs, amount of
 
 =over 7
 
-=item B<pci>
-
-Retrieves PCI bus information.
-
 =item B<bus>
 
 List all buses for each I/O slot.
 
 =item B<config>
 
-Retrieves number of processors, speed, total memory, and DIMM
-locations.
+Retrieves number of processors, speed, total memory, and DIMM locations.
 
 =item B<model>
 
@@ -113,7 +107,7 @@ To output the raw information of deconfigured resources for CEC.
 
 =item B<asset>
 
-Retrieves asset tag.  Usually it's the MAC address of eth0.
+Retrieves asset tag. Usually it's the MAC address of eth0.
 
 =item B<vpd>
 
@@ -126,6 +120,10 @@ Diagnostics information of firmware.
 =item B<mprom>
 
 Retrieves mprom firmware level.
+
+=item B<dimm>
+
+Retrieves dual in-line memory module information.
 
 =item B<deviceid>
 


### PR DESCRIPTION
Fixes Issue #3276 

1. Combined BMC and MPA in the "Usage" output.
2. Removed unsupported BMC/MPA options.
3. Added description of "dimm"