### PR TITLE
Format the ouput of getadapter result

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/getadapter.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/getadapter.1.rst
@@ -31,7 +31,7 @@ DESCRIPTION
 
 Traditionally, network interfaces in Linux are enumerated as eth[0123...], but these names do not necessarily correspond to actual labels on the chassis. \ **getadapter**\  help customer to get predictable network device name and some other network adapter information before provision or network configuration.
 
-\ **getadapter**\  use genesis to collect network adapters information, so that mean it need to restart the target node.
+\ **Since getadpter uses genesis to collect network adapters information, the target node will be restarted.**\ 
 
 \ **getadapter**\  For each node within the <noderange>, follows below scheme:
 
@@ -41,14 +41,40 @@ If user hopes to scan the adapter information for the node but these information
 
 \ **getadapter**\  tries to collect more information for the  target network device,  but doesn't guarantee collect same much information for every network device.
 
-Below are the possible information can be collect up to now:
+
+******************************
+\ **Collected information:**\ 
+******************************
+
+
+
 \ **name**\ : the consistent name which can be used by confignic directly in operating system which follow the same naming scheme with rhels7
+
+
+
 \ **pci**\ : the pci location
+
+
+
 \ **mac**\ : the MAC address
+
+
+
 \ **candidatename**\ : All the names which satisfy predictable network device naming scheme. \ *(if xcat enhance confignic command later, user can use these names to configure their network adapter, even customize their name)*\ 
+
+
+
 \ **vender**\ :  the vender of network device
+
+
+
 \ **model**\ :  the model of network device
+
+
+
 \ **linkstate**\ :  the link state of network device
+
+
 
 
 *******

--- a/xCAT-client/pods/man1/getadapter.1.pod
+++ b/xCAT-client/pods/man1/getadapter.1.pod
@@ -12,7 +12,7 @@ B<getadapter> [B<-h>|B<--help>|B<-v>|B<--version>|B<-V>]
 
 Traditionally, network interfaces in Linux are enumerated as eth[0123...], but these names do not necessarily correspond to actual labels on the chassis. B<getadapter> help customer to get predictable network device name and some other network adapter information before provision or network configuration.
 
-B<getadapter> use genesis to collect network adapters information, so that mean it need to restart the target node.
+B<Since getadpter uses genesis to collect network adapters information, the target node will be restarted.>
 
 B<getadapter> For each node within the <noderange>, follows below scheme:
 
@@ -22,14 +22,25 @@ If user hopes to scan the adapter information for the node but these information
 
 B<getadapter> tries to collect more information for the  target network device,  but doesn't guarantee collect same much information for every network device.
 
-Below are the possible information can be collect up to now:
-B<name>: the consistent name which can be used by confignic directly in operating system which follow the same naming scheme with rhels7
-B<pci>: the pci location
-B<mac>: the MAC address
-B<candidatename>: All the names which satisfy predictable network device naming scheme. I<(if xcat enhance confignic command later, user can use these names to configure their network adapter, even customize their name)>
-B<vender>:  the vender of network device
-B<model>:  the model of network device
-B<linkstate>:  the link state of network device
+=head1 B<Collected information:>
+
+=over 2
+
+=item B<name>: the consistent name which can be used by confignic directly in operating system which follow the same naming scheme with rhels7
+
+=item B<pci>: the pci location
+
+=item B<mac>: the MAC address
+
+=item B<candidatename>: All the names which satisfy predictable network device naming scheme. I<(if xcat enhance confignic command later, user can use these names to configure their network adapter, even customize their name)>
+
+=item B<vender>:  the vender of network device
+
+=item B<model>:  the model of network device
+
+=item B<linkstate>:  the link state of network device
+
+=back
 
 =head1 OPTIONS
 


### PR DESCRIPTION
This patch format the result of getadapter command and update
the man page to notice that `getadapter` will boot into genesis.

Fix-issue: #3046

Command example:
root@c910f05c01bc01k10:~# getadapter kvmguest1 -f
kvmguest1: Booting into genesis, this could take several minutes...
[kvmguest1] scan successfully below is result:
kvmguest1:[0]->mac=42:af:0a:05:65:6b|linkstate=UP
kvmguest1:[1]->pci=00:03.0|model=Red Hat, Inc Virtio network device

kvmguest1: nics talbe will not be updated as not any useful information could be found with udevadm command.