### PR TITLE
fix confignics aliases related testcase

### DIFF
--- a/xCAT-test/autotest/testcase/confignics/cases0
+++ b/xCAT-test/autotest/testcase/confignics/cases0
@@ -186,10 +186,6 @@ cmd:rmdef -t network -o 11_1_0_0-255_255_0_0
 cmd:rmdef -t network -o 12_1_0_0-255_255_0_0
 cmd:rmdef -t network -o 13_1_0_0-255_255_0_0
 cmd:rmdef -t network -o 14_1_0_0-255_255_0_0
-cmd:ip addr del 11.1.0.100/16 dev $$SECONDNIC
-cmd:ip addr del 12.1.0.100/16 dev $$SECONDNIC
-cmd:ip addr del 13.1.0.100/16 dev $$THIRDNIC
-cmd:ip addr del 14.1.0.100/16 dev $$THIRDNIC
 cmd:if [ "$$OS" = "ubuntu" ];then xdsh $$CN rm -rf /etc/network/interfaces.d/$$SECONDNIC; else xdsh $$CN rm -rf /etc/sysconfig/network*/ifcfg-$$SECONDNIC; fi
 cmd:if [ "$$OS" = "ubuntu" ];then xdsh $$CN rm -rf /etc/network/interfaces.d/$$SECONDNIC:1; else xdsh $$CN rm -rf /etc/sysconfig/network*/ifcfg-$$SECONDNIC:1; fi
 cmd:if [ "$$OS" = "ubuntu" ];then xdsh $$CN rm -rf /etc/network/interfaces.d/$$THIRDNIC; else xdsh $$CN rm -rf /etc/sysconfig/network*/ifcfg-$$THIRDNIC; fi

--- a/xCAT-test/autotest/testcase/confignics/cases0
+++ b/xCAT-test/autotest/testcase/confignics/cases0
@@ -149,45 +149,47 @@ start:confignics_config_multiple_port_withnicaliases_multiple_value
 description:confignics
 cmd:lsdef $$CN;if [ $? -eq 0 ]; then lsdef -l $$CN -z >/tmp/CN.standa ;fi
 check:rc==0
-cmd:mkdef -t network -o 11_1_0_0-255_255_0_0 net=11.1.0.0 mask=255.255.0.0 mgtifname=$$SECONDNIC  mtu=1501
+cmd:mkdef -t network -o 11_1_0_0-255_255_0_0 net=11.1.0.0 mask=255.255.0.0 mgtifname=$$SECONDNIC
 check:rc==0
-cmd:mkdef -t network -o 12_1_0_0-255_255_0_0 net=12.1.0.0 mask=255.255.0.0 mgtifname=$$SECONDNIC   mtu=1501
+cmd:mkdef -t network -o 12_1_0_0-255_255_0_0 net=12.1.0.0 mask=255.255.0.0 mgtifname=$$SECONDNIC
 check:rc==0
-cmd:mkdef -t network -o 13_1_0_0-255_255_0_0 net=13.1.0.0 mask=255.255.0.0 mgtifname=$$THIRDNIC    mtu=1503
+cmd:mkdef -t network -o 13_1_0_0-255_255_0_0 net=13.1.0.0 mask=255.255.0.0 mgtifname=$$THIRDNIC
 check:rc==0
-cmd:mkdef -t network -o 14_1_0_0-255_255_0_0 net=14.1.0.0 mask=255.255.0.0 mgtifname=$$THIRDNIC     mtu=1503
+cmd:mkdef -t network -o 14_1_0_0-255_255_0_0 net=14.1.0.0 mask=255.255.0.0 mgtifname=$$THIRDNIC
 check:rc==0
-cmd:chdef $$CN nicips.$$SECONDNIC="11.1.0.100|12.1.0.100" nictypes.$$SECONDNIC=Ethernet nicnetworks.$$SECONDNIC="11_1_0_0-255_255_0_0|12_1_0_0-255_255_0_0" nicaliases.$$SECONDNIC="aliases1-1|aliases1-2" 
+cmd:chdef $$CN nicips.$$SECONDNIC="11.1.0.100|12.1.0.100" nictypes.$$SECONDNIC=Ethernet nicnetworks.$$SECONDNIC="11_1_0_0-255_255_0_0|12_1_0_0-255_255_0_0" nicaliases.$$SECONDNIC="aliases1-1 aliases1-1-1|aliases1-2" nichostnamesuffixes.$$SECONDNIC="-$$SECONDNIC|-$$SECONDNIC-1"
 check:rc==0
-cmd:chdef $$CN nicips.$$THIRDNIC="13.1.0.100|14.1.0.100" nictypes.$$THIRDNIC=Ethernet nicnetworks.$$THIRDNIC="13_1_0_0-255_255_0_0|14_1_0_0-255_255_0_0" nicaliases.$$THIRDNIC="aliases2-1|aliases2-2"
+cmd:chdef $$CN nicips.$$THIRDNIC="13.1.0.100|14.1.0.100" nictypes.$$THIRDNIC=Ethernet nicnetworks.$$THIRDNIC="13_1_0_0-255_255_0_0|14_1_0_0-255_255_0_0" nicaliases.$$THIRDNIC="aliases2-1|aliases2-2" nichostnamesuffixes.$$THIRDNIC="-$$THIRDNIC|-$$THIRDNIC-1"
 check:rc==0
 cmd:makehosts $$CN
 check:rc==0
-#cmd:cat /etc/hosts
-#check:output=~aliases1-1
-#check:output=~aliases1-2
-#check:output=~aliases2-1
-#check:output=~aliases2-2
+cmd:cat /etc/hosts
+check:output=~aliases1-1
+check:output=~aliases1-2
+check:output=~aliases2-1
+check:output=~aliases2-2
 cmd:updatenode $$CN -P confignics
 check:rc==0
 cmd:if [ "$$OS" = "ubuntu" ];then xdsh $$CN cat /etc/network/interfaces.d/$$SECONDNIC; else xdsh $$CN cat /etc/sysconfig/network*/ifcfg-$$SECONDNIC; fi
 check:output=~11.1.0.100
 check:output!~dhcp
-output=~MTU=1501
-cmd:if [ "$$OS" = "ubuntu" ];then xdsh $$CN cat /etc/network/interfaces.d/$$SECONDNIC:1 ; elif [ "$$OS" = "rhels" ]; then xdsh $$CN cat /etc/sysconfig/network*/ifcfg-$$SECONDNIC:1;else xdsh $$CN cat /etc/sysconfig/network*/ifcfg-$$SECONDNIC; fi
+cmd:if [ "$$OS" = "ubuntu" ];then xdsh $$CN cat /etc/network/interfaces.d/$$SECONDNIC:1 ; elif [ "$$OS" = "rhels" ]; then xdsh $$CN cat /etc/sysconfig/network*/ifcfg-$$SECONDNIC:1;else xdsh $$CN cat /etc/sysconfig/network*/ifcfg-$$SECONDNIC:1; fi
 check:output=~12.1.0.100
 check:output!~dhcp
 cmd:if [ "$$OS" = "ubuntu" ];then xdsh $$CN cat /etc/network/interfaces.d/$$THIRDNIC; else xdsh $$CN cat /etc/sysconfig/network*/ifcfg-$$THIRDNIC; fi
 check:output=~13.1.0.100
 check:output!~dhcp
-output=~MTU=1503
-cmd:if [ "$$OS" = "ubuntu" ];then xdsh $$CN cat /etc/network/interfaces.d/$$THIRDNIC:1 ; elif [ "$$OS" = "rhels" ]; then xdsh $$CN cat /etc/sysconfig/network*/ifcfg-$$THIRDNIC:1;else xdsh $$CN cat /etc/sysconfig/network*/ifcfg-$$THIRDNIC; fi
+cmd:if [ "$$OS" = "ubuntu" ];then xdsh $$CN cat /etc/network/interfaces.d/$$THIRDNIC:1 ; elif [ "$$OS" = "rhels" ]; then xdsh $$CN cat /etc/sysconfig/network*/ifcfg-$$THIRDNIC:1;else xdsh $$CN cat /etc/sysconfig/network*/ifcfg-$$THIRDNIC:1; fi
 check:output=~14.1.0.100
 check:output!~dhcp
 cmd:rmdef -t network -o 11_1_0_0-255_255_0_0
 cmd:rmdef -t network -o 12_1_0_0-255_255_0_0
 cmd:rmdef -t network -o 13_1_0_0-255_255_0_0
 cmd:rmdef -t network -o 14_1_0_0-255_255_0_0
+cmd:ip addr del 11.1.0.100/16 dev $$SECONDNIC
+cmd:ip addr del 12.1.0.100/16 dev $$SECONDNIC
+cmd:ip addr del 13.1.0.100/16 dev $$THIRDNIC
+cmd:ip addr del 14.1.0.100/16 dev $$THIRDNIC
 cmd:if [ "$$OS" = "ubuntu" ];then xdsh $$CN rm -rf /etc/network/interfaces.d/$$SECONDNIC; else xdsh $$CN rm -rf /etc/sysconfig/network*/ifcfg-$$SECONDNIC; fi
 cmd:if [ "$$OS" = "ubuntu" ];then xdsh $$CN rm -rf /etc/network/interfaces.d/$$SECONDNIC:1; else xdsh $$CN rm -rf /etc/sysconfig/network*/ifcfg-$$SECONDNIC:1; fi
 cmd:if [ "$$OS" = "ubuntu" ];then xdsh $$CN rm -rf /etc/network/interfaces.d/$$THIRDNIC; else xdsh $$CN rm -rf /etc/sysconfig/network*/ifcfg-$$THIRDNIC; fi

--- a/xCAT-test/autotest/testcase/confignics/cases0
+++ b/xCAT-test/autotest/testcase/confignics/cases0
@@ -149,13 +149,13 @@ start:confignics_config_multiple_port_withnicaliases_multiple_value
 description:confignics
 cmd:lsdef $$CN;if [ $? -eq 0 ]; then lsdef -l $$CN -z >/tmp/CN.standa ;fi
 check:rc==0
-cmd:mkdef -t network -o 11_1_0_0-255_255_0_0 net=11.1.0.0 mask=255.255.0.0 mgtifname=$$SECONDNIC
+cmd:mkdef -t network -o 11_1_0_0-255_255_0_0 net=11.1.0.0 mask=255.255.0.0 mgtifname=$$SECONDNIC 
 check:rc==0
 cmd:mkdef -t network -o 12_1_0_0-255_255_0_0 net=12.1.0.0 mask=255.255.0.0 mgtifname=$$SECONDNIC
 check:rc==0
-cmd:mkdef -t network -o 13_1_0_0-255_255_0_0 net=13.1.0.0 mask=255.255.0.0 mgtifname=$$THIRDNIC
+cmd:mkdef -t network -o 13_1_0_0-255_255_0_0 net=13.1.0.0 mask=255.255.0.0 mgtifname=$$THIRDNIC   
 check:rc==0
-cmd:mkdef -t network -o 14_1_0_0-255_255_0_0 net=14.1.0.0 mask=255.255.0.0 mgtifname=$$THIRDNIC
+cmd:mkdef -t network -o 14_1_0_0-255_255_0_0 net=14.1.0.0 mask=255.255.0.0 mgtifname=$$THIRDNIC    
 check:rc==0
 cmd:chdef $$CN nicips.$$SECONDNIC="11.1.0.100|12.1.0.100" nictypes.$$SECONDNIC=Ethernet nicnetworks.$$SECONDNIC="11_1_0_0-255_255_0_0|12_1_0_0-255_255_0_0" nicaliases.$$SECONDNIC="aliases1-1 aliases1-1-1|aliases1-2" nichostnamesuffixes.$$SECONDNIC="-$$SECONDNIC|-$$SECONDNIC-1"
 check:rc==0
@@ -186,6 +186,10 @@ cmd:rmdef -t network -o 11_1_0_0-255_255_0_0
 cmd:rmdef -t network -o 12_1_0_0-255_255_0_0
 cmd:rmdef -t network -o 13_1_0_0-255_255_0_0
 cmd:rmdef -t network -o 14_1_0_0-255_255_0_0
+cmd:xdsh $$CN "ip addr del 11.1.0.100/16 dev $$SECONDNIC"
+cmd:xdsh $$CN "ip addr del 12.1.0.100/16 dev $$SECONDNIC"
+cmd:xdsh $$CN "ip addr del 13.1.0.100/16 dev $$THIRDNIC"
+cmd:xdsh $$CN "ip addr del 14.1.0.100/16 dev $$THIRDNIC"
 cmd:if [ "$$OS" = "ubuntu" ];then xdsh $$CN rm -rf /etc/network/interfaces.d/$$SECONDNIC; else xdsh $$CN rm -rf /etc/sysconfig/network*/ifcfg-$$SECONDNIC; fi
 cmd:if [ "$$OS" = "ubuntu" ];then xdsh $$CN rm -rf /etc/network/interfaces.d/$$SECONDNIC:1; else xdsh $$CN rm -rf /etc/sysconfig/network*/ifcfg-$$SECONDNIC:1; fi
 cmd:if [ "$$OS" = "ubuntu" ];then xdsh $$CN rm -rf /etc/network/interfaces.d/$$THIRDNIC; else xdsh $$CN rm -rf /etc/sysconfig/network*/ifcfg-$$THIRDNIC; fi


### PR DESCRIPTION
fix #3242:

unit test:
```
OBJECT:bybc0609,TYPE:node
    profile = compute;
    arch = x86_64;
    os = rhels7.3;
TABLE:passwd
    key = system
    password = cluster
    username = root
Varible:
    CN = bybc0609
    THIRDNIC = eth3
    SECONDNIC = eth2
    KITDATA = kitdata
    NETBOOTDIR = /opt/xcat/share/xcat/netboot/rh
******************************
Initialize xCAT test environment by definition in configure file
******************************
chdef -t node -o bybc0609 profile=compute arch=x86_64 os=rhels7.3
chtab key=system passwd.password=cluster passwd.username=root
Detecting: OS = Linux
Detecting: ARCH = x86
Detecting: HCP = kvm
******************************
loading test cases
******************************
To run:
confignics_config_multiple_port_withnicaliases_multiple_value
******************************
Start to run test cases
******************************
------START::confignics_config_multiple_port_withnicaliases_multiple_value::Time:Thu Jun 22 04:53:39 2017------

RUN:lsdef bybc0609;if [ $? -eq 0 ]; then lsdef -l bybc0609 -z >/tmp/CN.standa ;fi [Thu Jun 22 04:53:39 2017]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Object name: bybc0609
    arch=x86_64
    currchain=boot
    currstate=boot
    groups=kvm,vm,all
    initrd=xcat/osimage/rhels7.3-x86_64-statelite-compute/initrd-statelite.gz
    installnic=mac
    ip=10.5.106.9
    kcmdline=root=nfs:!myipfn!:/install/netboot/rhels7.3/x86_64/compute/rootimg:ro STATEMNT= XCAT=!myipfn!:3001 NODE=bybc0609  console=tty0 console=ttyS0,115200 MNTOPTS=
    kernel=xcat/osimage/rhels7.3-x86_64-statelite-compute/kernel
    mac=42:f5:0a:05:6a:09|42:aa:0a:05:6a:09!*NOIP*|42:47:0a:05:6a:09!*NOIP*|42:82:0a:05:6a:09!*NOIP*
    mgt=kvm
    netboot=xnba
    os=rhels7.3
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
    primarynic=mac
    profile=compute
    serialport=0
    serialspeed=115200
    status=powering-on
    statustime=06-14-2017 03:14:45
    updatestatus=synced
    updatestatustime=06-22-2017 03:06:35
    vmcpus=1
    vmhost=c910f05c01bc06
    vmmemory=2000
    vmnicnicmodel=virtio
    vmnics=br-eno1,br-eno1.2,br-eno1.3
    vmstorage=dir:///baiyuan/kvm
CHECK:rc == 0   [Pass]

RUN:mkdef -t network -o 11_1_0_0-255_255_0_0 net=11.1.0.0 mask=255.255.0.0 mgtifname=eth2 [Thu Jun 22 04:53:40 2017]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0   [Pass]

RUN:mkdef -t network -o 12_1_0_0-255_255_0_0 net=12.1.0.0 mask=255.255.0.0 mgtifname=eth2 [Thu Jun 22 04:53:41 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0   [Pass]

RUN:mkdef -t network -o 13_1_0_0-255_255_0_0 net=13.1.0.0 mask=255.255.0.0 mgtifname=eth3 [Thu Jun 22 04:53:41 2017]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0   [Pass]

RUN:mkdef -t network -o 14_1_0_0-255_255_0_0 net=14.1.0.0 mask=255.255.0.0 mgtifname=eth3 [Thu Jun 22 04:53:42 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0   [Pass]

RUN:chdef bybc0609 nicips.eth2="11.1.0.100|12.1.0.100" nictypes.eth2=Ethernet nicnetworks.eth2="11_1_0_0-255_255_0_0|12_1_0_0-255_255_0_0" nicaliases.eth2="aliases1-1 aliases1-1-1|aliases1-2" nichostnamesuffixes.eth2="-eth2|-eth2-1" [Thu Jun 22 04:53:42 2017]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0   [Pass]

RUN:chdef bybc0609 nicips.eth3="13.1.0.100|14.1.0.100" nictypes.eth3=Ethernet nicnetworks.eth3="13_1_0_0-255_255_0_0|14_1_0_0-255_255_0_0" nicaliases.eth3="aliases2-1|aliases2-2" nichostnamesuffixes.eth3="-eth3|-eth3-1" [Thu Jun 22 04:53:43 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0   [Pass]

RUN:makehosts bybc0609 [Thu Jun 22 04:53:43 2017]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0   [Pass]

RUN:cat /etc/hosts [Thu Jun 22 04:53:44 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
10.5.106.1 c910f05c01bc06.cluster.com c910f05c01bc06
10.5.106.2 bybc0602.cluster.com bybc0602
10.5.106.3 bybc0603 bybc0603.cluster.com
10.5.106.5 bybc0605 bybc0605.cluster.com
10.5.106.7 bybc0607 bybc0607.cluster.com
20.5.106.7 node1
10.10.0.51 testnode testnode.cluster.com
20.11.0.11 testnode-bmc testnode-bmc.ipmi testnode
10.5.106.9 bybc0609 bybc0609.cluster.com
10.2.0.1 s01r1b01 s01r1b01.cluster.com
10.2.0.254 s01 s01.cluster.com
11.1.0.100 bybc0609-eth2 bybc0609-eth2.cluster.com aliases1-1 aliases1-1-1
13.1.0.100 bybc0609-eth3 bybc0609-eth3.cluster.com aliases2-1
12.1.0.100 bybc0609-eth2-1 bybc0609-eth2-1.cluster.com aliases1-2
14.1.0.100 bybc0609-eth3-1 bybc0609-eth3-1.cluster.com aliases2-2
CHECK:output =~ aliases1-1      [Pass]
CHECK:output =~ aliases1-2      [Pass]
CHECK:output =~ aliases2-1      [Pass]
CHECK:output =~ aliases2-2      [Pass]

RUN:updatenode bybc0609 -P confignics [Thu Jun 22 04:53:44 2017]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
bybc0609: xcatdsklspost: downloaded postscripts successfully
bybc0609: Thu Jun 22 04:53:49 EDT 2017 Running postscript: confignics
bybc0609: confignics on bybc0609: config install nic:0, remove: 0, iba ports:
bybc0609: eth2!11.1.0.100|12.1.0.100
bybc0609: eth3!13.1.0.100|14.1.0.100
bybc0609: confignics on bybc0609: call 'configeth eth2 11.1.0.100|12.1.0.100 11_1_0_0-255_255_0_0|12_1_0_0-255_255_0_0|'
bybc0609: [I]: configeth on bybc0609: os type: redhat
bybc0609: configeth on bybc0609: old configuration: 4: eth2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1496 qdisc pfifo_fast state UP qlen 1000
bybc0609:     link/ether 42:47:0a:05:6a:09 brd ff:ff:ff:ff:ff:ff
bybc0609:     inet6 fe80::4047:aff:fe05:6a09/64 scope link
bybc0609:        valid_lft forever preferred_lft forever
bybc0609: [I]: configeth on bybc0609: new configuration
bybc0609:        11.1.0.100, 11.1.0.0, 255.255.0.0,
bybc0609:        12.1.0.100, 12.1.0.0, 255.255.0.0,
bybc0609: 4: eth2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1496 qdisc pfifo_fast state UP mode DEFAULT qlen 1000
bybc0609: eth2
bybc0609: [I]: configeth on bybc0609: add 11.1.0.100_16 for eth2 temporary.
bybc0609: [I]: configeth on bybc0609: add 12.1.0.100_16 for eth2 temporary.
bybc0609:     inet 11.1.0.100/16 brd 11.1.255.255 scope global eth2
bybc0609: [I]: configeth on bybc0609: eth2 changed, modify the configuration files
bybc0609: eth2
bybc0609: confignics on bybc0609: call 'configeth eth3 13.1.0.100|14.1.0.100 13_1_0_0-255_255_0_0|14_1_0_0-255_255_0_0|'
bybc0609: [I]: configeth on bybc0609: os type: redhat
bybc0609: configeth on bybc0609: old configuration: 5: eth3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
bybc0609:     link/ether 42:82:0a:05:6a:09 brd ff:ff:ff:ff:ff:ff
bybc0609:     inet6 fe80::4082:aff:fe05:6a09/64 scope link
bybc0609:        valid_lft forever preferred_lft forever
bybc0609: [I]: configeth on bybc0609: new configuration
bybc0609:        13.1.0.100, 13.1.0.0, 255.255.0.0,
bybc0609:        14.1.0.100, 14.1.0.0, 255.255.0.0,
bybc0609: 5: eth3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP mode DEFAULT qlen 1000
bybc0609: eth3
bybc0609: [I]: configeth on bybc0609: add 13.1.0.100_16 for eth3 temporary.
bybc0609: [I]: configeth on bybc0609: add 14.1.0.100_16 for eth3 temporary.
bybc0609:     inet 13.1.0.100/16 brd 13.1.255.255 scope global eth3
bybc0609: [I]: configeth on bybc0609: eth3 changed, modify the configuration files
bybc0609: eth3
bybc0609: postscript: confignics exited with code 0
bybc0609: Running of postscripts has completed.
CHECK:rc == 0   [Pass]

RUN:if [ "Linux" = "ubuntu" ];then xdsh bybc0609 cat /etc/network/interfaces.d/eth2; else xdsh bybc0609 cat /etc/sysconfig/network*/ifcfg-eth2; fi [Thu Jun 22 04:53:46 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
bybc0609: DEVICE=eth2
bybc0609: BOOTPROTO=static
bybc0609: NM_CONTROLLED=no
bybc0609: IPADDR=11.1.0.100
bybc0609: NETMASK=255.255.0.0
bybc0609: ONBOOT=yes
CHECK:output =~ 11.1.0.100      [Pass]
CHECK:output !~ dhcp    [Pass]

RUN:if [ "Linux" = "ubuntu" ];then xdsh bybc0609 cat /etc/network/interfaces.d/eth2:1 ; elif [ "Linux" = "rhels" ]; then xdsh bybc0609 cat /etc/sysconfig/network*/ifcfg-eth2:1;else xdsh bybc0609 cat /etc/sysconfig/network*/ifcfg-eth2:1; fi [Thu Jun 22 04:53:46 2017]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
bybc0609: DEVICE=eth2:1
bybc0609: BOOTPROTO=static
bybc0609: NM_CONTROLLED=no
bybc0609: IPADDR=12.1.0.100
bybc0609: NETMASK=255.255.0.0
bybc0609: ONBOOT=yes
CHECK:output =~ 12.1.0.100      [Pass]
CHECK:output !~ dhcp    [Pass]

RUN:if [ "Linux" = "ubuntu" ];then xdsh bybc0609 cat /etc/network/interfaces.d/eth3; else xdsh bybc0609 cat /etc/sysconfig/network*/ifcfg-eth3; fi [Thu Jun 22 04:53:47 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
bybc0609: DEVICE=eth3
bybc0609: BOOTPROTO=static
bybc0609: NM_CONTROLLED=no
bybc0609: IPADDR=13.1.0.100
bybc0609: NETMASK=255.255.0.0
bybc0609: ONBOOT=yes
CHECK:output =~ 13.1.0.100      [Pass]
CHECK:output !~ dhcp    [Pass]

RUN:if [ "Linux" = "ubuntu" ];then xdsh bybc0609 cat /etc/network/interfaces.d/eth3:1 ; elif [ "Linux" = "rhels" ]; then xdsh bybc0609 cat /etc/sysconfig/network*/ifcfg-eth3:1;else xdsh bybc0609 cat /etc/sysconfig/network*/ifcfg-eth3:1; fi [Thu Jun 22 04:53:47 2017]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
bybc0609: DEVICE=eth3:1
bybc0609: BOOTPROTO=static
bybc0609: NM_CONTROLLED=no
bybc0609: IPADDR=14.1.0.100
bybc0609: NETMASK=255.255.0.0
bybc0609: ONBOOT=yes
CHECK:output =~ 14.1.0.100      [Pass]
CHECK:output !~ dhcp    [Pass]

RUN:rmdef -t network -o 11_1_0_0-255_255_0_0 [Thu Jun 22 04:53:48 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.

RUN:rmdef -t network -o 12_1_0_0-255_255_0_0 [Thu Jun 22 04:53:48 2017]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.

RUN:rmdef -t network -o 13_1_0_0-255_255_0_0 [Thu Jun 22 04:53:49 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.

RUN:rmdef -t network -o 14_1_0_0-255_255_0_0 [Thu Jun 22 04:53:49 2017]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.

RUN:xdsh bybc0609 ip addr del 11.1.0.100/16 dev eth2 [Thu Jun 22 04:53:50 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:xdsh bybc0609 ip addr del 12.1.0.100/16 dev eth2 [Thu Jun 22 04:53:50 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:xdsh bybc0609 ip addr del 13.1.0.100/16 dev eth3 [Thu Jun 22 04:53:50 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:xdsh bybc0609 ip addr del 14.1.0.100/16 dev eth3 [Thu Jun 22 04:53:50 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:if [ "Linux" = "ubuntu" ];then xdsh bybc0609 rm -rf /etc/network/interfaces.d/eth2; else xdsh bybc0609 rm -rf /etc/sysconfig/network*/ifcfg-eth2; fi [Thu Jun 22 04:53:50 2017]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:if [ "Linux" = "ubuntu" ];then xdsh bybc0609 rm -rf /etc/network/interfaces.d/eth2:1; else xdsh bybc0609 rm -rf /etc/sysconfig/network*/ifcfg-eth2:1; fi [Thu Jun 22 04:53:51 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:if [ "Linux" = "ubuntu" ];then xdsh bybc0609 rm -rf /etc/network/interfaces.d/eth3; else xdsh bybc0609 rm -rf /etc/sysconfig/network*/ifcfg-eth3; fi [Thu Jun 22 04:53:51 2017]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:if [ "Linux" = "ubuntu" ];then xdsh bybc0609 rm -rf /etc/network/interfaces.d/eth3:1;  else xdsh bybc0609 rm -rf /etc/sysconfig/network*/ifcfg-eth3:1; fi [Thu Jun 22 04:53:52 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:if [ -e /tmp/CN.standa ]; then rmdef bybc0609; cat /tmp/CN.standa | mkdef -z; rm -rf /tmp/CN.standa; fi [Thu Jun 22 04:53:52 2017]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
1 object definitions have been created or modified.
CHECK:rc == 0   [Pass]

------END::confignics_config_multiple_port_withnicaliases_multiple_value::Passed::Time:Thu Jun 22 04:53:55 2017 ::Duration::16 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished atThu Jun 22 04:53:55 2017
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20170622045336 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20170622045336 file for time consumption
```