### PR TITLE
Use the boxelder/bmc information if inventory/system information is not found

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -83,6 +83,11 @@ sub process_request
     $::CALLBACK = $callback;
 
     #$::args     = $request->{arg};
+    if (ref($request->{environment}) eq 'ARRAY' and ref($request->{environment}->[0]->{XCAT_DEV_WITHERSPOON}) eq 'ARRAY') {
+        $::XCAT_DEV_WITHERSPOON = $request->{environment}->[0]->{XCAT_DEV_WITHERSPOON}->[0];
+    } else {
+        $::XCAT_DEV_WITHERSPOON = $request->{environment}->{XCAT_DEV_WITHERSPOON};
+    }
 
     unless (defined($request->{arg})) {
         bmcdiscovery_usage();
@@ -1089,6 +1094,10 @@ sub bmcdiscovery_openbmc{
         if (defined($response->{data})) {
             if (defined($response->{data}->{Model}) and defined($response->{data}->{SerialNumber})) {
                 $mtm = $response->{data}->{Model};
+                if (defined($::XCAT_DEV_WITHERSPOON) && ($::XCAT_DEV_WITHERSPOON eq "TRUE")) {
+                    print "XCAT_DEV_WITHERSPOON=TRUE, forcing MTM to blank string (ORIG MTM=$mtm)\n";
+                    $mtm = "";
+                }
                 $serial = $response->{data}->{SerialNumber}; 
             } else {
                 xCAT::MsgUtils->message("W", { data => ["Could not obtain Model Type and/or Serial Number for BMC at $ip"] }, $::CALLBACK);

--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -1095,7 +1095,7 @@ sub bmcdiscovery_openbmc{
             if (defined($response->{data}->{Model}) and defined($response->{data}->{SerialNumber})) {
                 $mtm = $response->{data}->{Model};
                 if (defined($::XCAT_DEV_WITHERSPOON) && ($::XCAT_DEV_WITHERSPOON eq "TRUE")) {
-                    print "XCAT_DEV_WITHERSPOON=TRUE, forcing MTM to blank string (ORIG MTM=$mtm)\n";
+                    xCAT::MsgUtils->message("I", { data => ["XCAT_DEV_WITHERSPOON=TRUE, forcing MTM to empty string for $ip (Original MTM=$mtm)"] }, $::CALLBACK);
                     $mtm = "";
                 }
                 $serial = $response->{data}->{SerialNumber}; 


### PR DESCRIPTION
Found out that for Witherspoon machines, if the host has not been booted
there is no system information returned, so check for the boxelder bmc
for a model/serial combination to use

Temporarily Resolves Issues #3320 

The issue here is that the inventory/chassis information is not returned until the compute host is powered on. We are seeing this now because we have just obtained our ITC machines.   So the only information right now that we can obtain from machines that have not yet booted is the following: 
```
  "data": {
    "/xyz/openbmc_project/inventory/system/chassis/motherboard/boxelder/bmc": {
      "BuildDate": "", 
      "FieldReplaceable": 0, 
      "Manufacturer": "IBM", 
      "Model": "", 
      "PartNumber": "01DH118", 
      "Present": 1, 
      "PrettyName": "BMC PLANAR  ", 
      "SerialNumber": "000000000000"
    }, 
    "/xyz/openbmc_project/inventory/system/chassis/motherboard/boxelder/bmc/ethernet": {
      "FieldReplaceable": 0, 
      "MACAddress": "00:00:00:00:00:00", 
      "Present": 1, 
      "PrettyName": ""
    }
  }
```

I'm talking to openbmc firmware team in issue https://github.com/openbmc/openbmc/issues/1829 about potentially using a different UUID instead of this Model/Serial combination since it seems like it's not programmed into the VPD yet.  

The proposed change will first check the `inventory/system` so that the external is similar to what we are used to, if it doesn't find it, then check the inventory/system/chassis/motherboard/boxelder/bmc endpoint for any information there.  

When the UUID support is implemented, will consider switching to that. 

Here's the behavior....

### ITC machine never powered on...

```
[root@fs3 vhu]# bmcdiscover --range 172.20.253.103
172.20.253.103,,000000000000,,,mp,bmc
[root@fs3 vhu]# bmcdiscover --range 172.20.253.103 -z
node-ac14fd67:
	objtype=node
	groups=all
	bmc=172.20.253.103
	cons=openbmc
	mgt=openbmc
	serial=000000000000
```

### EUH that has already been powered on...

```
[root@stratton01 ~]# bmcdiscover --range 10.6.7.254,10.6.9.254
10.6.7.254,0000000000000000,0000000000000000,,,mp,bmc
10.6.9.254,0000000000000000,0000000000000000,,,mp,bmc
[root@stratton01 ~]# bmcdiscover --range 10.6.7.254,10.6.9.254 -z
node-0000000000000000-0000000000000000:
	objtype=node
	groups=all
	bmc=10.6.7.254
	cons=openbmc
	mgt=openbmc
	mtm=0000000000000000
	serial=0000000000000000

node-0000000000000000-0000000000000000:
	objtype=node
	groups=all
	bmc=10.6.9.254
	cons=openbmc
	mgt=openbmc
	mtm=0000000000000000
	serial=0000000000000000
```

