### PR TITLE
fix issue 3324 Wrong grub2 config file will be generated when node.tftpserver="<xcatmaster>"

### DIFF
--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -607,7 +607,7 @@ sub mknetboot
             $xcatmaster = '!myipfn!'; #allow service nodes to dynamically nominate themselves as a good contact point, this is of limited use in the event that xcat is not the dhcp/tftp server
         }
 
-        if ($ient and $ient->{tftpserver})
+        if ($ient and $ient->{tftpserver} and $ient->{tftpserver} ne '<xcatmaster>')
         {
             $imgsrv = $ient->{tftpserver};
         }


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/:

when node.tftpserver="<xcatmaster>",  the " /tftpboot/boot/grub2/c910f03c17k42" is
````
[root@c910f03c05k21 xcat-core]# cat /tftpboot/boot/grub2/c910f03c17k42
#netboot rhels7.3-ppc64le-compute
set timeout=5
set default="xCAT OS Deployment"
menuentry "xCAT OS Deployment" {
    insmod http
    insmod tftp
    set root=tftp,10.3.5.21
    echo Loading Install kernel ...
    linux /xcat/osimage/rhels7.3-ppc64le-netboot-compute/kernel imgurl=http://10.3.5.21:80//install/netboot/rhels7.3/ppc64le/compute/rootimg.cpio.gz XCAT=10.3.5.21:3001 NODE=c910f03c17k42 FC=0 BOOTIF=42:7c:0a:03:11:2a  console=tty0 console=hvc0,115200n8r selinux=0
    echo Loading initial ramdisk ...
    initrd /xcat/osimage/rhels7.3-ppc64le-netboot-compute/initrd-stateless.gz
````

