### PR TITLE
Fix issue 3327, check environment of request type in openbmc and bmcdiscover

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -85,6 +85,8 @@ sub process_request
     #$::args     = $request->{arg};
     if (ref($request->{environment}) eq 'ARRAY' and ref($request->{environment}->[0]->{XCAT_DEV_WITHERSPOON}) eq 'ARRAY') {
         $::XCAT_DEV_WITHERSPOON = $request->{environment}->[0]->{XCAT_DEV_WITHERSPOON}->[0];
+    } elsif (ref($request->{environment}) eq 'ARRAY') {
+        $::XCAT_DEV_WITHERSPOON = $request->{environment}->[0]->{XCAT_DEV_WITHERSPOON};
     } else {
         $::XCAT_DEV_WITHERSPOON = $request->{environment}->{XCAT_DEV_WITHERSPOON};
     }

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -283,6 +283,8 @@ sub preprocess_request {
 
     if (ref($request->{environment}) eq 'ARRAY' and ref($request->{environment}->[0]->{XCAT_OPENBMC_DEVEL}) eq 'ARRAY') {
         $::OPENBMC_DEVEL = $request->{environment}->[0]->{XCAT_OPENBMC_DEVEL}->[0];
+    } elsif (ref($request->{environment}) eq 'ARRAY') {
+        $::OPENBMC_DEVEL = $request->{environment}->[0]->{XCAT_OPENBMC_DEVEL};
     } else {
         $::OPENBMC_DEVEL = $request->{environment}->{XCAT_OPENBMC_DEVEL};
     }


### PR DESCRIPTION
#3327
 
If have exported ``XCAT_OPENBMC_DEVEL`` and did not export ``XCAT_DEV_WITHERSPOON``, when run bmcdiscover command, will print ``Error: bmcdiscover plugin bug, pid 29886, process description: 'xcatd SSL: bmcdiscover for root@localhost: bmcdiscover instance' with error 'Not a HASH reference at /opt/xcat/lib/perl/xCAT_plugin/bmcdiscover.pm line 89.``

So modified like below:

If ``$request->{environment}`` is 'ARRAY', use ``$request->{environment}->[0]->{XCAT_xxxx}`` to get env value.