### PR TITLE
The MAC is not got correct when doing hardware discovery

### DIFF
--- a/xCAT-genesis-scripts/bin/dodiscovery
+++ b/xCAT-genesis-scripts/bin/dodiscovery
@@ -188,7 +188,7 @@ for dev in `ip link|grep -B1 ether|grep UP|awk '{print $2}'|sed -e s/://|grep -v
 	DRIVER=`grep DRIVER /sys/class/net/$dev/device/uevent|awk -F= '{print $2}'`
 	PCI_SLOT=`grep PCI_SLOT_NAME /sys/class/net/$dev/device/uevent|awk -F= '{print $2}'`
 	ADDRESS=`ip -4 -o a show dev $dev|awk '/global/{print $4}'`
-	MAC=`ip -o l show dev $dev|awk '/ether/{print $15}'| tr /a-f/ /A-F/`
+        MAC=`ip link show dev $dev|grep ether|awk '{print $2}'| tr /a-f/ /A-F/`
         if [ "$MAC_OF_FIRST_UP_NIC" == "unknown" ]; then
             MAC_OF_FIRST_UP_NIC=`echo $MAC | sed -e s/://g`
         fi


### PR DESCRIPTION
An issue introduced by the pull request #2763 
Which will cause the incorrect MAC address got by hardware discovery.
The issue:
```
<nic>
<devname>enP1p1s0f0</devname>
<driver>tg3</driver>
<hwaddr>1000</hwaddr>   ==> shall be MAC address here
```
After fix:
```
<nic>
<devname>enP1p1s0f0</devname>
<driver>tg3</driver>
<hwaddr>98:BE:94:05:D7:80</hwaddr>
```