### PR TITLE
Improve the debug message when bmc value cannot be obtained from getbmcconfig

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcconfig.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcconfig.pm
@@ -105,7 +105,6 @@ sub process_request {
         return;
     }
 
-    #my $sitetable = xCAT::Table->new('site');
     my $ipmitable = xCAT::Table->new("$bmc_mgmt_type");
     my $tmphash;
     my $username;
@@ -142,8 +141,8 @@ sub process_request {
         $clipassword = $password;
     }
     unless (defined $bmc) {
-        xCAT::MsgUtils->message('S', "Unable to identify bmc for $node, refusing to give config data");
-        $callback->({ error => ["Invalid table configuration for bmcconfig"], errorcode => [1] });
+        xCAT::MsgUtils->message('S', "Received request from host=$node but unable to determine $bmc_mgmt_type.bmc value for the node.  Verify mgt attribute is configured correctly for the node and the BMC is defined.");
+        $callback->({ error => ["Unable to detect BMC configuration value for bmcconfig"], errorcode => [1] });
         return 1;
     }
     my $bmcport_counter = 0;


### PR DESCRIPTION
Resolves #3356 

Improve the debug message when bmc value cannot be obtained from getbmcconfig
because the value is missing or the mgt= is incorrect for the machine being discovered. 

After the change the following message comes out in the cluster.log
```
Jun 27 16:18:12 fs3 xcat[130960]: xCAT: Allowing getbmcconfig for mid05tor12cn02 from mid05tor12cn02
Jun 27 16:18:12 fs3 xcat[130963]: Received request from host=mid05tor12cn02 but unable to determine openbmc.bmc value for the node.  Verify mgt attribute is configured correctly for the node and the BMC is defined.
```

Genesis message: 
```
  <error>Unable to detect BMC configuration value for bmcconfig</error>
  <errorcode>1</errorcode>
```