### PR TITLE
Fix 3368, noboot option does not seem to be working correctly to disable on the various interfaces

### DIFF
--- a/perl-xCAT/xCAT/NetworkUtils.pm
+++ b/perl-xCAT/xCAT/NetworkUtils.pm
@@ -736,7 +736,7 @@ sub get_nic_ip
     my %iphash;
     my $mode            = "MULTICAST";
     my $payingattention = 0;
-    my $interface;
+    my $interface       = "";
     my $keepcurrentiface;
 
 
@@ -793,6 +793,7 @@ sub get_nic_ip
                     delete $iphash{$interface};
                 }
                 $keepcurrentiface = 0;
+                $interface = "";
                 if (!($line =~ /LOOPBACK/) and
                     $line =~ /UP( |,|>)/ and
                     $line =~ /$mode/) {


### PR DESCRIPTION
Fix 3368, noboot option does not seem to be working correctly to disable on the various interfaces

Root cause:
get_nic_ip does net reset the $interface when finding a new interface, and it will cause the previous interface to be removed from the result set when more interfaces w/o IP there.

UT: 
Hot fix on fs3, and now it can return the right nic list.  Without this fix, it can only return the first 1 entry.

[root@fs3 xcat]# XCATBYPASS=1 mknb ppc64
VKHU_DEBUG , dhcp interfaces: enP3p3s0,enP3p3s0d1
VKHU_DEBUG - nicips from xCAT::NetworkUtils->get_nic_ip()
$VAR1 = {
          'enP3p3s0d1' => '172.21.253.27',
          'enP3p3s0' => '172.20.253.27',
          'enP4p1s0f0' => '10.200.3.27'
        };