### PR TITLE
Add support to configure Cumulus switch via switchdiscover --setup options

### DIFF
--- a/xCAT-server/lib/xcat/plugins/switchdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/switchdiscover.pm
@@ -1428,7 +1428,9 @@ sub switchsetup {
         if (-r -x $config_script) {
             my $switches = join(",",@{${nodes_to_config}->{$mytype}});
             if ($mytype eq "onie") {
-                send_msg($request, 0, "onie switch needs to take 50 mins to install, please run /opt/xcat/share/xcat/script/configonie after Cumulus OS installed on switch\n");
+                send_msg($request, 0, "Call to config $switches\n");
+                my $out = `$config_script --switches $switches --all`;
+                send_msg($request, 0, "output = $out\n");
             } else {
                 send_msg($request, 0, "call to config $mytype switches $switches\n");
                 my $out = `$config_script --switches $switches --all`;

--- a/xCAT-server/share/xcat/scripts/configonie
+++ b/xCAT-server/share/xcat/scripts/configonie
@@ -99,16 +99,17 @@ if (($::SSH) || ($::ALL))
     config_ssh();
 }
 
-if (($::LICENSE) || ($::ALL))
+if ($::LICENSE)
 {
     install_license();
 }
 
-if (($::SNMP) || ($::ALL))
+if ($::SNMP)
 {
     config_snmp();
 }
-if (($::NTP) || ($::ALL))
+
+if ($::NTP)
 {
     config_ntp();
 }
@@ -171,9 +172,19 @@ sub config_ssh {
     if (@config_switches) {
         #update switch status
         my $csw = join(",",@config_switches);
-        $cmd = "chdef $csw status=ssh_configed ";
+        $cmd = "chdef $csw status=ssh_configured otherinterfaces=";
         $rc= xCAT::Utils->runcmd($cmd, 0);
         print "ssh configured for $csw\n";
+        if ($::ALL) {
+            $cmd = "updatenode $csw -P hardeths,enablesnmp,configinterface";
+            $rc= xCAT::Utils->runcmd($cmd, 0); 
+            if ($::RUNCMD_RC != 0) {
+                xCAT::MsgUtils->message("E","Failed to run updatenode, please check the switch");
+            }
+            $cmd = "chdef $csw status=configured";
+            $rc= xCAT::Utils->runcmd($cmd, 0);
+            print "switch: $csw configured\n";
+        }
     }
 }
 
@@ -369,7 +380,7 @@ sub config_ntp {
     if (@config_switches) {
         #update switch status
         my $csw = join(",",@config_switches);
-        $cmd = "chdef $csw status=ntp_configed";
+        $cmd = "chdef $csw status=ntp_configured";
         $rc= xCAT::Utils->runcmd($cmd, 0);
     }
 
@@ -394,7 +405,7 @@ sub usage
     configonie --switches switchnames --snmp
     configonie --switches switchnames --ntp 
 
-    To set ssh, install license(license file: /root/license.txt), config snmp and ntp:
+    To setup ssh passwordless, change ip to static, enable snmp configuration and configure basic interface :
         configonie --switches switchnames --all 
     \n";
 }


### PR DESCRIPTION
for issue #3369,  if option --setup is specified  for switchdiscover command, it will
1) discover switch, match with predefined switch, update predefined switch attributes
2) if switchtype=onie, it will call configonie --all  script
3) configonie --all scripts will setup ssh passwordless, change ip to static, enable snmp configruation, and configure basic interfaces.

````
[root@fs3 scripts]# makehosts mid05tor10
[root@fs3 scripts]# switchdiscover --range 172.21.205.10 --setup
Discovering switches using nmap for 172.21.205.10. It may take long time...
ip              name                    vendor                                                  mac 
------------    ------------            ------------                                            ------------
172.21.205.10   mid05tor10.pok.stglabs.ibm.com  Edgecore Networks Switch                           8C:EA:1B:E8:78:C0
Switch discovered and matched: mid05tor10.pok.stglabs.ibm.com to mid05tor10
Call to config mid05tor10

output = ssh configured for mid05tor10
switch: mid05tor10 configured
````
the status of switch will be updated to configured.