### PR TITLE
Copy ssh keys to BMC with rspconfig command

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
@@ -47,7 +47,7 @@ OpenBMC specific:
 =================
 
 
-\ **rspconfig**\  \ *noderange*\  {\ **ip | netmask | gateway | vlan**\ }
+\ **rspconfig**\  \ *noderange*\  {\ **ip | netmask | gateway | vlan | sshcfg**\ }
 
 
 MPA specific:
@@ -251,8 +251,7 @@ DESCRIPTION
 ***********
 
 
-\ **rspconfig**\  configures various settings in the nodes' service processors.  If only a keyword is
-specified, without the \ **=**\ , it displays the current value.
+\ **rspconfig**\  configures various settings in the nodes' service processors.
 
 For options \ **autopower | iocap | decfg | memdecfg | procdecfg | time | date | spdump | sysdump | network**\ , user need to use \ *chdef -t site enableASMI=yes*\  to enable ASMI first.
 
@@ -523,6 +522,12 @@ OPTIONS
 \ **sshcfg**\ ={\ **enable | disable**\ }
  
  Enable or disable SSH on MPA.
+ 
+
+
+\ **sshcfg**\ 
+ 
+ Copy SSH keys.
  
 
 

--- a/xCAT-client/pods/man1/rspconfig.1.pod
+++ b/xCAT-client/pods/man1/rspconfig.1.pod
@@ -24,7 +24,7 @@ B<rspconfig> I<noderange> B<garp>=I<time>
 
 =head2 OpenBMC specific:
 
-B<rspconfig> I<noderange> {B<ip>|B<netmask>|B<gateway>|B<vlan>}
+B<rspconfig> I<noderange> {B<ip>|B<netmask>|B<gateway>|B<vlan>|B<sshcfg>}
 
 =head2 MPA specific:
 
@@ -204,8 +204,7 @@ B<rspconfig> I<noderange> B<--resetnet>
 
 =head1 DESCRIPTION
 
-B<rspconfig> configures various settings in the nodes' service processors.  If only a keyword is
-specified, without the B<=>, it displays the current value.
+B<rspconfig> configures various settings in the nodes' service processors.
 
 For options B<autopower>|B<iocap>|B<decfg>|B<memdecfg>|B<procdecfg>|B<time>|B<date>|B<spdump>|B<sysdump>|B<network>, user need to use I<chdef -t site enableASMI=yes> to enable ASMI first.
 
@@ -389,6 +388,10 @@ Performs a service processor dump.
 =item B<sshcfg>={B<enable>|B<disable>}
 
 Enable or disable SSH on MPA.
+
+=item B<sshcfg>
+
+Copy SSH keys.
 
 =item B<swnet>={[I<ip>],[I<gateway>],[I<netmask>]}
 


### PR DESCRIPTION
Implementing `rspconfig sshcfg` command to copy sshkeys to the BMC.
Issue #3308 

Success output:
```
[root@stratton01 xcat]# rspconfig p9euh02 sshcfg
p9euh02: ssh keys copied to 10.6.9.254
[root@stratton01 xcat]#
```

Invalid pw error output:
```
[root@stratton01 xcat]# rspconfig p9euh02 sshcfg
p9euh02: Error copying ssh keys to 10.6.9.254:
start SSH session...
Incorrect Password.

Warning: SSH failed, will try Telnet. Please set switches.protocol=telnet next time if you wish to use telnet directly.
start Telnet session...
problem connecting to "10.6.9.254", port 23: Connection refused

[root@stratton01 xcat]#
```