### PR TITLE
fix routeop does not use xcatlib.sh for issue 3359

### DIFF
--- a/xCAT/postscripts/routeop
+++ b/xCAT/postscripts/routeop
@@ -23,12 +23,6 @@
 #=cut
 #-------------------------------------------------------------------------------
 
-
-if [ "$(uname -s|tr 'A-Z' 'a-z')" = "linux" ];then
-   str_dir_name=`dirname $0`
-   . $str_dir_name/xcatlib.sh
-fi
-
 op=$1
 
 net=$2

--- a/xCAT/postscripts/routeop
+++ b/xCAT/postscripts/routeop
@@ -23,6 +23,13 @@
 #=cut
 #-------------------------------------------------------------------------------
 
+if [ "$(uname -s|tr 'A-Z' 'a-z')" = "linux" ];then
+   str_dir_name=`dirname $0`
+   ([ -f $str_dir_name/xcatlib.sh ] && . $str_dir_name/xcatlib.sh) || \
+   ([ -f /install/postscripts/xcatlib.sh ] && . /install/postscripts/xcatlib.sh) || \
+   ([ -f /xcatpost/xcatlib.sh ] && . /xcatpost/xcatlib.sh)
+fi
+
 op=$1
 
 net=$2


### PR DESCRIPTION
fix #3359 
routeop does not use xcatlib.sh, and routeop is called by makeroutes.  