### PR TITLE
modify rpower testcase if ipmi using wrong passwd

### DIFF
--- a/xCAT-test/autotest/testcase/rpower/cases0
+++ b/xCAT-test/autotest/testcase/rpower/cases0
@@ -152,6 +152,34 @@ cmd:rpower $$CN onstandby
 cmd:a=0;while ! `rpower $$CN stat|grep "standby\|Standby" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 check:ouptut=~standby|Standby
 end
+start:rpower_suspend_OpenpowerBmc
+description:rpower openpowerbmc using suspend
+Attribute: $$CN-The operation object of rpower command
+cmd:rpower $$CN suspend
+check:output=~Error: unsupported command rpower suspend for OpenPOWER
+check:rc==1
+end
+start:rpower_softoff_OpenpowerBmc
+description:rpower openpowerbmc using softoff
+Attribute: $$CN-The operation object of rpower command
+cmd:rpower $$CN softoff
+check:output=~Error: unsupported command rpower softoff for OpenPOWER
+check:rc==1
+end
+start:rpower_wake_OpenpowerBmc
+description:rpower openpowerbmc using wake
+Attribute: $$CN-The operation object of rpower command
+cmd:rpower $$CN wake
+check:output=~Error: unsupported command rpower wake for OpenPOWER
+check:rc==1
+end
+start:rpower_errorcommand_OpenpowerBmc
+description:rpower openpowerbmc using errorcommand
+Attribute: $$CN-The operation object of rpower command
+cmd:rpower $$CN ddd
+check:output=~Unsupported command:
+check:rc==1
+end
 start:rpower_ipmi_wrongpasswd
 description:rpower ipmi and its password wrong
 Attribute: $$CN-The operation object of rpower command

--- a/xCAT-test/autotest/testcase/rpower/cases0
+++ b/xCAT-test/autotest/testcase/rpower/cases0
@@ -152,3 +152,13 @@ cmd:rpower $$CN onstandby
 cmd:a=0;while ! `rpower $$CN stat|grep "standby\|Standby" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 check:ouptut=~standby|Standby
 end
+start:rpower_ipmi_wrongpasswd
+description:rpower ipmi and its passwd wrong
+Attribute: $$CN-The operation object of rpower command
+cmd:tabdump passwd |grep ipmi>/tmp/ipmipasswd;Username=`cat /tmp/ipmipasswd |awk -F "\""  '{print $4}'`;Passwd=`cat /tmp/ipmipasswd |awk -F "\""  '{print $6}'`;`chtab key=ipmi passwd.password=$Passwd.wrong passwd.username=$Username`;tabdump passwd;
+check:rc==0
+cmd:rpower $$CN stat
+check:output=~Error: ERROR: Incorrect password provided
+check:rc!=0
+cmd:Username=`cat /tmp/ipmipasswd |awk -F "\""  '{print $4}'`;Passwd=`cat /tmp/ipmipasswd |awk -F "\""  '{print $6}'`;chtab key=ipmi passwd.password=$Passwd passwd.username=$Username;tabdump passwd;`rm -rf /tmp/ipmipasswd`
+end

--- a/xCAT-test/autotest/testcase/rpower/cases0
+++ b/xCAT-test/autotest/testcase/rpower/cases0
@@ -185,10 +185,11 @@ description:rpower ipmi and its password wrong
 Attribute: $$CN-The operation object of rpower command
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rpower/rpower_ipmi_wrongpasswd_test.sh  -pt $$CN  $$ipmipasswd $$ipminame
 check:rc==0
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rpower/rpower_ipmi_wrongpasswd_test.sh  -c $$CN 
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rpower/rpower_ipmi_wrongpasswd_test.sh  -c $$CN
 check:rc==0
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rpower/rpower_ipmi_wrongpasswd_test.sh  -apt $$CN  $$ipmipasswd $$ipminame
 check:rc==0
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rpower/rpower_ipmi_wrongpasswd_test.sh  -c $$CN
 check:rc==0
 end
+

--- a/xCAT-test/autotest/testcase/rpower/cases0
+++ b/xCAT-test/autotest/testcase/rpower/cases0
@@ -153,12 +153,14 @@ cmd:a=0;while ! `rpower $$CN stat|grep "standby\|Standby" >/dev/null`; do sleep 
 check:ouptut=~standby|Standby
 end
 start:rpower_ipmi_wrongpasswd
-description:rpower ipmi and its passwd wrong
+description:rpower ipmi and its password wrong
 Attribute: $$CN-The operation object of rpower command
-cmd:tabdump passwd |grep ipmi>/tmp/ipmipasswd;Username=`cat /tmp/ipmipasswd |awk -F "\""  '{print $4}'`;Passwd=`cat /tmp/ipmipasswd |awk -F "\""  '{print $6}'`;`chtab key=ipmi passwd.password=$Passwd.wrong passwd.username=$Username`;tabdump passwd;
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rpower/rpower_ipmi_wrongpasswd_test.sh  -pt $$CN  $$ipmipasswd $$ipminame
 check:rc==0
-cmd:rpower $$CN stat
-check:output=~Error: ERROR: Incorrect password provided
-check:rc!=0
-cmd:Username=`cat /tmp/ipmipasswd |awk -F "\""  '{print $4}'`;Passwd=`cat /tmp/ipmipasswd |awk -F "\""  '{print $6}'`;chtab key=ipmi passwd.password=$Passwd passwd.username=$Username;tabdump passwd;`rm -rf /tmp/ipmipasswd`
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rpower/rpower_ipmi_wrongpasswd_test.sh  -c $$CN 
+check:rc==0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rpower/rpower_ipmi_wrongpasswd_test.sh  -apt $$CN  $$ipmipasswd $$ipminame
+check:rc==0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rpower/rpower_ipmi_wrongpasswd_test.sh  -c $$CN
+check:rc==0
 end

--- a/xCAT-test/autotest/testcase/rpower/rpower_ipmi_wrongpasswd_test.sh
+++ b/xCAT-test/autotest/testcase/rpower/rpower_ipmi_wrongpasswd_test.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+function check_passwd_table(){
+tabdump passwd |grep ipmi
+    if [ $? -eq 0 ];then
+        `tabdump passwd |grep ipmi>/tmp/xcat_test_rpower_ipmi_wrongpasswd`
+    else
+        return 1;
+    fi
+}
+function modify_passwd_table(){
+Username=`cat /tmp/xcat_test_rpower_ipmi_wrongpasswd |awk -F "\""  '{print $4}'`;
+Passwd=`cat /tmp/xcat_test_rpower_ipmi_wrongpasswd |awk -F "\""  '{print $6}'`;
+`chtab key=ipmi passwd.password=$Passwd.wrong passwd.username=$Username`;
+tabdump passwd;
+}
+function add_passwd_table()
+{
+echo i is $1,$2,$3
+`chtab key=ipmi passwd.password=$2 passwd.username=$3`;
+rpower $1 stat
+    if [ $? -eq 0 ];then
+        `chtab key=ipmi passwd.password=$2.wrong passwd.username=$3`;
+        tabdump passwd;
+    else
+        echo "wrong password";
+    fi
+}
+function modify_node_definition()
+{
+echo node is  $1,$2,$3
+chdef $1 bmcpassword=$2  bmcusername=$3
+rpower $1 stat
+    if [ $? -eq 0 ];then
+        chdef $1 bmcpassword=$2.wrong  bmcusername=$3;
+        tabdump passwd;
+    else
+         echo "wrong password";
+    fi
+}
+function clear_env(){
+    if [ -f /tmp/xcat_test_rpower_ipmi_wrongpasswd ];then
+        Username=`cat /tmp/xcat_test_rpower_ipmi_wrongpasswd |awk -F "\""  '{print $4}'`;
+        Passwd=`cat /tmp/xcat_test_rpower_ipmi_wrongpasswd |awk -F "\""  '{print $6}'`;
+        chtab key=ipmi passwd.password=$Passwd passwd.username=$Username;tabdump passwd; 
+        rm -rf /tmp/xcat_test_rpower_ipmi_wrongpasswd;
+    else
+        `chtab -d key=ipmi passwd`;
+        chdef $1 bmcpassword= bmcusername=;
+    fi
+}
+function check_result(){
+echo node is $1;
+output=$(rpower $1 stat /dev/null  2>&1)
+echo output is $output
+    if [[ $output =~ "Incorrect password provided" ]];then
+        return 0;
+    else
+        return 1;
+    fi
+}
+while [ "$#" -gt "0" ]
+do
+        case $1 in
+                "-pt"|"--passwdtable" )
+                check_passwd_table
+                    if [[ $? -eq 0 ]];then  
+                        modify_passwd_table
+                        check_result $2
+                            if [[ $? -eq 1 ]];then
+                                exit 1
+                            else
+                                exit 0
+                            fi
+
+                    else
+                        add_passwd_table $2 $3 $4
+                        check_result $2
+                            if [[ $? -eq 1 ]];then
+                                exit 1
+                            else
+                                exit 0
+                            fi
+                    fi
+                ;;
+                "-apt"|"--addpasswdtable" )
+                check_passwd_table
+                    if [[ $? -eq 0 ]];then
+                        `chtab -d key=ipmi passwd`;                        
+                            if [[ $? -eq 1 ]];then
+                                exit 1
+                            fi
+                    fi
+                    modify_node_definition  $2 $3 $4
+                    check_result $2
+                        if [[ $? -eq 1 ]];then
+                            exit 1
+                        else
+                            exit 0
+                        fi
+                ;;
+                "-c"|"--clear" )
+                clear_env $2 
+                if [[ $? -eq 1 ]];then
+                    exit 1
+                else
+                    exit 0
+                fi
+                ;;
+                *)
+                echo
+                echo "Please Insert $0: -pt|-apt|-c"
+                echo
+                exit 1;
+                ;;
+                esac
+done
+
+


### PR DESCRIPTION
add test case for issue 1950: Setting the ipmi password incorrectly in the site table causes infinite loop in rpower: Unauthorized name #3347