### PR TITLE
[perl-xCAT] Allow `mysqlsetup` to configure mariadb too.

### DIFF
--- a/perl-xCAT/xCAT/Utils.pm
+++ b/perl-xCAT/xCAT/Utils.pm
@@ -4017,14 +4017,14 @@ sub servicemap {
     # (general service name) => {list of possible service names}
     #
     my %svchash = (
-        "dhcp" => [ "dhcp3-server", "dhcpd", "isc-dhcp-server" ],
-        "nfs" => [ "nfsserver", "nfs-server", "nfs", "nfs-kernel-server" ],
-        "named"     => [ "named",    "bind9" ],
-        "syslog"    => [ "syslog",   "syslogd", "rsyslog" ],
-        "firewall"  => [ "iptables", "firewalld", "ufw" ],
-        "http"      => [ "apache2",  "httpd" ],
-        "ntpserver" => [ "ntpd",     "ntp" ],
-        "mysql"     => [ "mysqld",   "mysql" ],
+        "dhcp"      => [ "dhcp3-server", "dhcpd", "isc-dhcp-server" ],
+        "nfs"       => [ "nfsserver",    "nfs-server", "nfs", "nfs-kernel-server" ],
+        "named"     => [ "named",        "bind9" ],
+        "syslog"    => [ "syslog",       "syslogd", "rsyslog" ],
+        "firewall"  => [ "iptables",     "firewalld", "ufw" ],
+        "http"      => [ "apache2",      "httpd" ],
+        "ntpserver" => [ "ntpd",         "ntp" ],
+        "mysql"     => [ "mysqld",       "mysql" ],
     );
 
     my $path       = undef;

--- a/perl-xCAT/xCAT/Utils.pm
+++ b/perl-xCAT/xCAT/Utils.pm
@@ -4024,7 +4024,7 @@ sub servicemap {
         "firewall"  => [ "iptables",     "firewalld", "ufw" ],
         "http"      => [ "apache2",      "httpd" ],
         "ntpserver" => [ "ntpd",         "ntp" ],
-        "mysql"     => [ "mysqld",       "mysql" ],
+        "mysql"     => [ "mysqld",       "mysql", "mariadb" ],
     );
 
     my $path       = undef;

--- a/travis.pl
+++ b/travis.pl
@@ -441,7 +441,11 @@ my @travis_env_attr = ("TRAVIS_REPO_SLUG",
                        "PASSWORD",
                        "PWD");
 foreach (@travis_env_attr){
-    print "$_ = $ENV{$_}\n";
+    if($ENV{$_}) {
+        print "$_ = '$ENV{$_}'\n";
+    } else {
+        print "$_ = ''\n";
+    }
 }
 
 my @os_info = runcmd("cat /etc/os-release");


### PR DESCRIPTION
While xCAT claims to support `mariadb` in addition to mysql, in the remote case where the service name is `mariadb` instead of `mysql`, the command `mysqlsetup` fails with the following error:

```
[root@xcatmn2 ~]# mysqlsetup -i
Input the alpha-numberic  password for xcatadmin in the MySQL database: 
Input the password for root in the MySQL database: 
 failed to start mysql/mariadb.
```

This PR allows mysqlsetup to work if the service name is `mariadb` instead of `mysqld`