### PR TITLE
modify rpower testcase using unsurpported command for openpowerbmc

### DIFF
--- a/xCAT-test/autotest/testcase/rpower/cases0
+++ b/xCAT-test/autotest/testcase/rpower/cases0
@@ -152,3 +152,32 @@ cmd:rpower $$CN onstandby
 cmd:a=0;while ! `rpower $$CN stat|grep "standby\|Standby" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 check:ouptut=~standby|Standby
 end
+start:rpower_suspend_OpenpowerBmc
+description:rpower openpowerbmc using suspend
+Attribute: $$CN-The operation object of rpower command
+cmd:rpower $$CN suspend
+check:output=~Error: unsupported command rpower suspend for OpenPOWER
+check:rc==1
+end
+start:rpower_softoff_OpenpowerBmc
+description:rpower openpowerbmc using softoff
+Attribute: $$CN-The operation object of rpower command
+cmd:rpower $$CN softoff
+check:output=~Error: unsupported command rpower softoff for OpenPOWER
+check:rc==1
+end
+start:rpower_wake_OpenpowerBmc
+description:rpower openpowerbmc using wake
+Attribute: $$CN-The operation object of rpower command
+cmd:rpower $$CN wake
+check:output=~Error: unsupported command rpower wake for OpenPOWER
+check:rc==1
+end
+start:rpower_errorcommand_OpenpowerBmc
+description:rpower openpowerbmc using errorcommand
+Attribute: $$CN-The operation object of rpower command
+cmd:rpower $$CN ddd
+check:output=~Unsupported command:
+check:rc==1
+end
+


### PR DESCRIPTION
add test case for issue 2948: rpower commands run against OpenPower BMC should be blocked if not supported #3345