### PR TITLE
add GPGSIGN env variable to avoid sign for ubuntu build

### DIFF
--- a/build-ubunturepo
+++ b/build-ubunturepo
@@ -22,6 +22,8 @@
 #                           When you are ready to release this build, use PROMOTE=1 without PREGA
 #               BUILDALL=1 - build all rpms, whether they changed or not.  Should be used for snap builds that are in
 #                            prep for a release.
+#               GPGSIGN=0 -  Do not sign the repo in the end of the build. The repo will be signed by default 
+#                            
 #               LOG=<filename> - provide an LOG file option to redirect some output into log file
 #
 # For the dependency packages 1. All the xcat dependency deb packages should be uploaded to
@@ -125,16 +127,20 @@ if [ ! -z ${LOG} ]; then
     WGET_CMD="wget -o ${LOG}"
 fi
 
-#sync the gpg key to the build machine local
-gsa_url=http://pokgsa.ibm.com/projects/x/xcat/build/linux
-mkdir -p $HOME/.gnupg
-for key_name in pubring.gpg secring.gpg trustdb.gpg; do
-    if [ ! -f $HOME/.gnupg/$key_name ] || [ `wc -c $HOME/.gnupg/$key_name|cut -f 1 -d' '` == 0 ]; then
-        rm -f $HOME/.gnupg/$key_name
-        ${WGET_CMD} -P $HOME/.gnupg $gsa_url/keys/$key_name
-        chmod 600 $HOME/.gnupg/$key_name
-    fi
-done
+if [ "$GPGSIGN" = "0" ];then
+    echo "GPGSIGN=$GPGSIGN specified, skip gnupg key downloading"
+else
+    #sync the gpg key to the build machine local
+    gsa_url=http://pokgsa.ibm.com/projects/x/xcat/build/linux
+    mkdir -p $HOME/.gnupg
+    for key_name in pubring.gpg secring.gpg trustdb.gpg; do
+        if [ ! -f $HOME/.gnupg/$key_name ] || [ `wc -c $HOME/.gnupg/$key_name|cut -f 1 -d' '` == 0 ]; then
+            rm -f $HOME/.gnupg/$key_name
+            ${WGET_CMD} -P $HOME/.gnupg $gsa_url/keys/$key_name
+            chmod 600 $HOME/.gnupg/$key_name
+        fi
+    done
+fi
 
 if [ "$c_flag" ]
 then
@@ -323,9 +329,15 @@ Codename: $dist
 Architectures: $tmp_out_arch
 Components: main
 Description: Repository automatically genereted conf
-SignWith: yes
-
 __EOF__
+
+       if [ "$GPGSIGN" = "0" ];then
+           echo "GPGSIGN=$GPGSIGN specified, the repo will not be signed"
+           echo "" >> conf/distributions
+       else 
+           echo "SignWith: yes" >> conf/distributions
+           echo "" >> conf/distributions
+       fi
      done
 
     cat << __EOF__ > conf/options
@@ -444,10 +456,16 @@ Codename: $dist
 Architectures: $tmp_out_arch
 Components: main
 Description: Repository automatically genereted conf
-SignWith: yes
-
 __EOF__
     done
+
+    if [ "$GPGSIGN" = "0" ];then
+        echo "GPGSIGN=$GPGSIGN specified, the repo will not be signed"
+        echo "" >> conf/distributions
+    else
+        echo "SignWith: yes" >> conf/distributions
+        echo "" >> conf/distributions
+    fi
 
     cat << __EOF__ > conf/options
 verbose


### PR DESCRIPTION
for the travis CI:

SIGN=0 can be passed to avoid gpg sign

Since travis CI will build xcat-core and xcat-dep in travis CI VM, it is not appropriate to transfer xcat private keys to it.

Verified on 
NAME="Ubuntu"
VERSION="14.04.2 LTS, Trusty Tahr"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 14.04.2 LTS"