### PR TITLE
enhance extra params support for confignetwork

### DIFF
--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -259,9 +259,15 @@ function load_kmod {
 #################################################################
 # 
 # query nicextraparams from nics table
-# input: nic
+# example: nicextraparams.eth0="MTU=9000 something=yes"
+# input: nic, here is eth0
 # output: set value for globe ${array_extra_param_names}
 #         and ${array_extra_param_values}
+#         example: 
+#         array_extra_param_names[0]="MTU"
+#         array_extra_param_values[0]="9000"
+#         array_extra_param_names[1]="something"
+#         array_extra_param_values[0]="yes"
 #
 #################################################################
 function query_extra_params {
@@ -274,12 +280,15 @@ function query_extra_params {
     j=0
     while [ $j -lt ${#array_nic_params[@]} ]
     do
-        token1="${array_nic_params[$j]}"
-        echo "array_nic_params $j=$token1"
+        #get key=value pair from nicextraparams
+        #for example: MTU=9000
+        exparampair="${array_nic_params[$j]}"
         j=$((j+1))
     done
     if [ ${#array_nic_params[@]} -gt 0 ]; then
-        str_extra_params=${array_nic_params[$ipindex-1]}
+        #Current confignetwork only support one ip for vlan/bond/bridge
+        #So only need the first ${array_nic_params[0]} for first nicips
+        str_extra_params=${array_nic_params[0]}
         parse_nic_extra_params "$str_extra_params"
     fi
 


### PR DESCRIPTION
For #3189 

Unit test:
```
[root@bybc0602 postscripts]# lsdef bybc0609 -i nicextraparams.br3
Object name: bybc0609
    nicextraparams.br3=MTU=1200

[root@bybc0602 postscripts]# lsdef -t network "40_0_0_0-255_0_0_0"
Object name: 40_0_0_0-255_0_0_0
    gateway=<xcatmaster>
    mask=255.0.0.0
    net=40.0.0.0
    tftpserver=40.5.106.1

[root@bybc0602 postscripts]# updatenode bybc0609 confignetwork
bybc0609: xcatdsklspost: downloaded postscripts successfully
bybc0609: Wed Jul  5 04:57:48 EDT 2017 Running postscript: confignetwork
bybc0609: [I]: All valid nics and device list:
bybc0609: [I]: br3 eth3
bybc0609: [I]: NetworkManager is inactive.
bybc0609: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bybc0609: configure nic and its device : br3 eth3
bybc0609: [I]: create_bridge_interface ifname=br3 _brtype=bridge _port=eth3 _pretype=ethernet
bybc0609: [I]: Pickup xcatnet, "40_0_0_0-255_0_0_0", from NICNETWORKS for interface "br3".
bybc0609: [I]: create_raw_eth_interface_for_br ifname=eth3 _bridge=br3 _mtu=
bybc0609: [I]: create_persistent_ifcfg ifname=eth3 inattrs=ONBOOT=yes,TYPE=Ethernet,BRIDGE=br3,BOOTPROTO=none
bybc0609: br3!MTU=1200
bybc0609: ['ifcfg-eth3']
bybc0609: [I]: >> DEVICE="eth3"
bybc0609: [I]: >> BOOTPROTO="none"
bybc0609: [I]: >> NAME="eth3"
bybc0609: [I]: >> HWADDR="42:82:0a:05:6a:09"
bybc0609: [I]: >> ONBOOT="yes"
bybc0609: [I]: >> TYPE="Ethernet"
bybc0609: [I]: >> BRIDGE="br3"
bybc0609: [I]: brctl addbr br3
bybc0609: [I]: brctl stp br3 on
bybc0609: [I]: brctl addif br3 eth3
bybc0609: [I]: migrate_ip ifname=br3 sports=eth3
bybc0609: [I]: create_persistent_ifcfg ifname=br3 xcatnet=40_0_0_0-255_0_0_0 inattrs=ONBOOT=yes,STP=on,TYPE=Bridge
bybc0609: br3!MTU=1200
bybc0609: array_nic_params 0=MTU=1200
bybc0609: ['ifcfg-br3']
bybc0609: [I]: >> DEVICE="br3"
bybc0609: [I]: >> BOOTPROTO="static"
bybc0609: [I]: >> IPADDR="40.5.106.9"
bybc0609: [I]: >> NETMASK="255.0.0.0"
bybc0609: [I]: >> NAME="br3"
bybc0609: [I]: >> MTU="1200"
bybc0609: [I]: >> ONBOOT="yes"
bybc0609: [I]: >> STP="on"
bybc0609: [I]: >> TYPE="Bridge"
bybc0609: postscript: confignetwork exited with code 0
bybc0609: Running of postscripts has completed.

[root@bybc0602 postscripts]# xdsh bybc0609 "cat /etc/sysconfig/network-scripts/ifcfg-br3|grep MTU"
bybc0609: MTU="1200"
```