### PR TITLE
Change bmcdiscover for openbmc to look at Part Number

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -1086,8 +1086,8 @@ sub bmcdiscovery_openbmc{
         my $serial;
 
         if (defined($response->{data})) {
-            if (defined($response->{data}->{Model}) and defined($response->{data}->{SerialNumber})) {
-                $mtm = $response->{data}->{Model};
+            if (defined($response->{data}->{PartNumber}) and defined($response->{data}->{SerialNumber})) {
+                $mtm = $response->{data}->{PartNumber};
                 if (defined($::XCAT_DEV_WITHERSPOON) && ($::XCAT_DEV_WITHERSPOON eq "TRUE")) {
                     xCAT::MsgUtils->message("I", { data => ["XCAT_DEV_WITHERSPOON=TRUE, forcing MTM to empty string for $ip (Original MTM=$mtm)"] }, $::CALLBACK);
                     $mtm = "";


### PR DESCRIPTION
In latest ITC machine, the Model Type is in the PartNumber Field

```
[root@fs3 UT]# time curl -c cjar -b cjar -k -H "Content-Type: application/json" -X GET https://$IP/xyz/openbmc_project/inventory/system
{
  "data": {
    "BuildDate": "",
    "Cached": 0,
    "FieldReplaceable": 0,
    "Manufacturer": "",
    "Model": "2",
    "PartNumber": "8335-GTC",
    "Present": 1,
    "PrettyName": "",
    "SerialNumber": "1318C4A"
  },
  "message": "200 OK",
  "status": "ok"
}
real    0m0.386s
user    0m0.109s
sys     0m0.030s
```

This is still a problem with discovery to use this field because it's not AVAIL until the first time the host side boots...  