### PR TITLE
Add test case mkdef_regex_nicsip. Verification of the GitHub issue #3047

### DIFF
--- a/xCAT-test/autotest/testcase/mkdef/cases1
+++ b/xCAT-test/autotest/testcase/mkdef/cases1
@@ -64,24 +64,84 @@ end
 
 start:mkdef_regex_nicsip
 description:Verify the GitHub issue #3047.
-cmd:rmdef sn[01-16]
-cmd:rmdef -t group -o testnicips
-cmd:mkdef -t group -o testnicips
+cmd:rmdef xcattest_tmp_node_sn[01-16]
+cmd:rmdef -t group -o xcattest_tmp_group_regex
+cmd:mkdef -t group -o xcattest_tmp_group_regex
 check:rc==0
-cmd:chdef -t group -o testnicips 'ip=|\D+(\d+)|172.21.254.($1%100)|'
+cmd:chdef -t group -o xcattest_tmp_group_regex 'ip=|\D+(\d+)|172.21.254.($1%100)|'
 check:rc==0
-cmd:chdef -t group -o testnicips 'nicips.eth1=|\D+(\d+)|172.20.254.($1%100)|'
+cmd:chdef -t group -o xcattest_tmp_group_regex 'nicips.eth1=|\D+(\d+)|172.20.254.($1%100)|'
 check:rc==0
-cmd:lsdef -t group -o testnicips | grep -F 'nicips.eth1=|\D+(\d+)|172.20.254.($1%100)|'
+cmd:lsdef -t group -o xcattest_tmp_group_regex | grep -F 'nicips.eth1=|\D+(\d+)|172.20.254.($1%100)|'
 check:rc==0
-cmd:mkdef sn[01-16] groups=testnicips
+cmd:mkdef xcattest_tmp_node_sn[01-16] groups=xcattest_tmp_group_regex
 check:rc==0
-cmd:lsdef sn14 -c -i ip | grep -F 'ip=172.21.254.14'
+cmd:lsdef xcattest_tmp_node_sn01 -c -i ip | grep -F 'ip=172.21.254.1'
 check:rc==0
-cmd:lsdef sn09 -c -i nicips  | grep -F 'nicips.eth1=172.20.254.9'
+cmd:lsdef xcattest_tmp_node_sn01 -c -i nicips | grep -F 'nicips.eth1=172.20.254.1'
 check:rc==0
-cmd:rmdef sn[01-16]
+cmd:lsdef xcattest_tmp_node_sn02 -c -i ip | grep -F 'ip=172.21.254.2'
 check:rc==0
-cmd:rmdef -t group -o testnicips
+cmd:lsdef xcattest_tmp_node_sn02 -c -i nicips | grep -F 'nicips.eth1=172.20.254.2'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn03 -c -i ip | grep -F 'ip=172.21.254.3'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn03 -c -i nicips | grep -F 'nicips.eth1=172.20.254.3'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn04 -c -i ip | grep -F 'ip=172.21.254.4'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn04 -c -i nicips | grep -F 'nicips.eth1=172.20.254.4'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn05 -c -i ip | grep -F 'ip=172.21.254.5'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn05 -c -i nicips | grep -F 'nicips.eth1=172.20.254.5'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn06 -c -i ip | grep -F 'ip=172.21.254.6'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn06 -c -i nicips | grep -F 'nicips.eth1=172.20.254.6'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn07 -c -i ip | grep -F 'ip=172.21.254.7'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn07 -c -i nicips | grep -F 'nicips.eth1=172.20.254.7'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn08 -c -i ip | grep -F 'ip=172.21.254.8'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn08 -c -i nicips | grep -F 'nicips.eth1=172.20.254.8'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn09 -c -i ip | grep -F 'ip=172.21.254.9'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn09 -c -i nicips | grep -F 'nicips.eth1=172.20.254.9'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn10 -c -i ip | grep -F 'ip=172.21.254.10'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn10 -c -i nicips | grep -F 'nicips.eth1=172.20.254.10'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn11 -c -i ip | grep -F 'ip=172.21.254.11'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn11 -c -i nicips | grep -F 'nicips.eth1=172.20.254.11'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn12 -c -i ip | grep -F 'ip=172.21.254.12'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn12 -c -i nicips | grep -F 'nicips.eth1=172.20.254.12'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn13 -c -i ip | grep -F 'ip=172.21.254.13'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn13 -c -i nicips | grep -F 'nicips.eth1=172.20.254.13'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn14 -c -i ip | grep -F 'ip=172.21.254.14'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn14 -c -i nicips | grep -F 'nicips.eth1=172.20.254.14'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn15 -c -i ip | grep -F 'ip=172.21.254.15'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn15 -c -i nicips | grep -F 'nicips.eth1=172.20.254.15'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn16 -c -i ip | grep -F 'ip=172.21.254.16'
+check:rc==0
+cmd:lsdef xcattest_tmp_node_sn16 -c -i nicips | grep -F 'nicips.eth1=172.20.254.16'
+check:rc==0
+cmd:rmdef xcattest_tmp_node_sn[01-16]
+check:rc==0
+cmd:rmdef -t group -o xcattest_tmp_group_regex
 check:rc==0
 end

--- a/xCAT-test/autotest/testcase/mkdef/cases1
+++ b/xCAT-test/autotest/testcase/mkdef/cases1
@@ -61,3 +61,27 @@ check:rc==0
 cmd:chtab -d node=kvms vm
 check:rc==0
 end
+
+start:mkdef_regex_nicsip
+description:Verify the GitHub issue #3047.
+cmd:rmdef sn[01-16]
+cmd:rmdef -t group -o testnicips
+cmd:mkdef -t group -o testnicips
+check:rc==0
+cmd:chdef -t group -o testnicips 'ip=|\D+(\d+)|172.21.254.($1%100)|'
+check:rc==0
+cmd:chdef -t group -o testnicips 'nicips.eth1=|\D+(\d+)|172.20.254.($1%100)|'
+check:rc==0
+cmd:lsdef -t group -o testnicips | grep -F 'nicips.eth1=|\D+(\d+)|172.20.254.($1%100)|'
+check:rc==0
+cmd:mkdef sn[01-16] groups=testnicips
+check:rc==0
+cmd:lsdef sn14 -c -i ip | grep -F 'ip=172.21.254.14'
+check:rc==0
+cmd:lsdef sn09 -c -i nicips  | grep -F 'nicips.eth1=172.20.254.9'
+check:rc==0
+cmd:rmdef sn[01-16]
+check:rc==0
+cmd:rmdef -t group -o testnicips
+check:rc==0
+end


### PR DESCRIPTION
Add one cases in this pull request
This pull request is for task #3344 
This pull request is for issue #3047

[case 1]
Case Name: mkdef_regex_nicsip
description: Test of using regular expressions in xCAT table node.