### PR TITLE
Remove the plain text of user name and password of xcatbot

### DIFF
--- a/travis.pl
+++ b/travis.pl
@@ -450,8 +450,6 @@ my @travis_env_attr = ("TRAVIS_REPO_SLUG",
                        "GITHUB_TOKEN",
                        "USERNAME",
                        "PASSWORD",
-                       "xcatbotuser",
-                       "xcatbotpw",
                        "PWD");
 foreach (@travis_env_attr){
     print "$_ = $ENV{$_}\n";


### PR DESCRIPTION
The purpose of this pull request is to remove the plain text of user name and password of xcatbot in CI log. 