### PR TITLE
Change the auto-detect for copycds to be a little more generic for RHEL ISOs

### DIFF
--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -2151,12 +2151,8 @@ sub copycd
     my $installroot = "/install";
     my $sitetab     = xCAT::Table->new('site');
 
-
     require xCAT::data::discinfo;
 
-    #if ($sitetab)
-    #{
-    #    (my $ref) = $sitetab->getAttribs({key => 'installdir'}, 'value');
     my @ents     = xCAT::TableUtils->get_site_attribute("installdir");
     my $site_ent = $ents[0];
     if (defined($site_ent))
@@ -2241,18 +2237,14 @@ sub copycd
         elsif ($desc =~ /Red Hat Enterprise Linux/)
         {
             #
-            # Attempt to auto-detect for RHEL OS.
-            # RHEL 7.3 description is: Red Hat Enterprise Linux 7.3
+            # Attempt to auto-detect for RHEL OS, the last element has typically been the verson
             #
             my @rhel_version = split / /, $desc;
-            #
-            # auto-detect pegas beta ISOs
-            #
-            if ( $rhel_version[4] =~ "Pegas") { 
-                $distname = "rhels" . $rhel_version[5] . "-pegas";
+            if ( $rhel_version[4] != $rhel_version[-1]) {
+                $distname = "rhels" . $rhel_version[-1] . "-" . lc($rhel_version[4]);
             } 
             else { 
-                $distname = "rhels" . $rhel_version[4];
+                $distname = "rhels" . $rhel_version[-1];
             }
             open($dinfo, $mntpath . "/.treeinfo");
             while (<$dinfo>) {

--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -2237,10 +2237,10 @@ sub copycd
         elsif ($desc =~ /Red Hat Enterprise Linux/)
         {
             #
-            # Attempt to auto-detect for RHEL OS, the last element has typically been the verson
+            # Attempt to auto-detect for RHEL OS, the last element has typically been the version
             #
             my @rhel_version = split / /, $desc;
-            if ( $rhel_version[4] != $rhel_version[-1]) {
+            if (scalar @rhel_version > 5) {
                 $distname = "rhels" . $rhel_version[-1] . "-" . lc($rhel_version[4]);
             } 
             else { 


### PR DESCRIPTION
In my unit testing, with the following snip of code... the distnames being generated look like the following:
```
[root@stratton01 vhu]# ./test.pl
Description: Red Hat Enterprise Linux Alternate Architectures 7.4
Resulting distname ==> rhels7.4-alternate

[root@stratton01 vhu]# ./test.pl
Description: Red Hat Enterprise Linux Pegas 7.4
Resulting distname ==> rhels7.4-pegas

[root@stratton01 vhu]# ./test.pl
Description: Red Hat Enterprise Linux 7.3
Resulting distname ==> rhels7.3
```

## Running the actual copycds code... 
 
### Before
```
# copycds /mnt/xcat/iso/pegas/7.4-ALT-EA-3/RHEL-ALT-7.4-20170626.4-Server-ppc64le-dvd1.iso
Copying media to /install/rhelsAlternate/ppc64le
```
### After 
```
# copycds /mnt/xcat/iso/pegas/7.4-ALT-EA-3/RHEL-ALT-7.4-20170626.4-Server-ppc64le-dvd1.iso
Copying media to /install/rhels7.4-alternate/ppc64le
```

Then some other iso files...
```
# copycds /mnt/xcat/iso/redhat/7.3/GA/RHEL-7.3-20161019.0-Server-ppc64le-dvd1.iso
Copying media to /install/rhels7.3/ppc64le
# copycds /mnt/xcat/iso/redhat/7.3/GA/RHEL-7.3-20161019.0-Server-x86_64-dvd1.iso
Copying media to /install/rhels7.3/x86_64
# copycds /mnt/xcat/iso/redhat/7.3/GA/RHEL-7.3-20161019.0-Server-ppc64-dvd1.iso
Copying media to /install/rhels7.3/ppc64
```