### PR TITLE
Support hybrid mode for different access vlan other than 1

### DIFF
--- a/xCAT-server/share/xcat/scripts/configMellanox
+++ b/xCAT-server/share/xcat/scripts/configMellanox
@@ -43,7 +43,8 @@ if (
                 'ip'         => \$::IP,
                 'name'       => \$::NAME,
                 'snmp'       => \$::SNMP,
-                'vlan=s'     => \$::VLAN,
+                'accessvlan=s' => \$::PVID,
+                'allowvlan=s'  => \$::VID,
                 'port=s'     => \$::PORT,
                 'mode=s'     => \$::MODE,
                 'all'        => \$::ALL,
@@ -120,7 +121,7 @@ if (($::CONFIG) || ($::ALL)) {
     run_rspconfig();
 }
 
-if ($::VLAN) {
+if ( ($::PVID) || ($::VID) ) {
     config_vlan();
 }
 
@@ -363,6 +364,9 @@ sub config_vlan {
         exit(1);
     }
 
+    my $access_vlan = $::PVID;
+    my $allowed_vlan = $::VID;
+
     # will default to trunk mode
     if ($::MODE) {
        $mode = $::MODE;
@@ -372,11 +376,18 @@ sub config_vlan {
             &usage;
             exit(1);
        }
+       if ($mode =~ /hybrid/) 
+       {
+           if (!$access_vlan) {
+               print "NOTE: Hybrid mode will change access vlan back to 1\n"; 
+               print "please provide access vlan if other than 1\n"; 
+               $access_vlan = 1;
+           }
+       }
     } else {
        $mode = "access";
     }
 
-    $vlan = $::VLAN;
 
     foreach my $switch (@nodes) {
         my $devicetype;
@@ -394,10 +405,7 @@ sub config_vlan {
             next;
         }
 
-        print "Tagging VLAN=$vlan for $switch port $port_input\n";
-
-        # create vlan
-        my $vlan_cmd = `xdsh $switch --devicetype $devicetype "enable;configure terminal;vlan $vlan;exit;exit" `;
+        print "Tagging access vlan to $access_vlan and allowed vlan to $allowed_vlan with $mode mode for $switch port $port_input\n";
 
         my $cmd_prefix = "xdsh $switch --devicetype $devicetype";
         foreach my $port (@ports) {
@@ -405,12 +413,23 @@ sub config_vlan {
             # Build up the commands for easier readability
             $cmd = $cmd . "enable\;";
             $cmd = $cmd . "configure terminal\;";
+            if ($access_vlan){
+                $cmd = $cmd . "vlan $access_vlan\;";
+                $cmd = $cmd . "exit\;";
+            }
+            if ($allowed_vlan){
+                $cmd = $cmd . "vlan $allowed_vlan\;";
+                $cmd = $cmd . "exit\;";
+            }
             $cmd = $cmd . "interface ethernet 1/$port\;";
             $cmd = $cmd . "switchport mode $mode\;";
             if ($mode =~ /access/) {
-                $cmd = $cmd . "switchport access vlan $vlan\;";
+                $cmd = $cmd . "switchport access vlan $access_vlan\;";
+            } elsif ($mode =~ /hybrid/) {
+                $cmd = $cmd . "switchport $mode allowed-vlan $allowed_vlan\;";
+                $cmd = $cmd . "switchport access vlan $access_vlan\;";
             } else {
-                $cmd = $cmd . "switchport $mode allowed-vlan $vlan\;";
+                $cmd = $cmd . "switchport $mode allowed-vlan $allowed_vlan\;";
             }
             $cmd = $cmd . "exit\;exit\;exit\;";
             my $final_cmd = $cmd_prefix . " \"" . $cmd . "\"";
@@ -445,10 +464,10 @@ sub usage
         configMellanox --switches switchnames --config  
 
     To configure VLAN on a specified port (Mellanox Ethernet switch ONLY):
-        configMellanox --switches switchnames --port port --vlan vlan --mode mode
+        configMellanox --switches switchnames --port port --accessvlan vlan1 --allowvlan vlan2 --mode mode
 
             The following mode are supported for switchport:
-                * access        Only untagged ingress Ethernet packets are allowed
+                * access        Only untagged ingress Ethernet packets are allowed 
                 * trunk         Only tagged ingress Ethernet packets are allowed
                 * hybrid        Both tagged and untagged ingress Ethernet packets are allowed
                 * access-dcb    Only untagged ingress Ethernet packets are allowed. Egress packets will be priority tagged

--- a/xCAT-server/share/xcat/scripts/configMellanox
+++ b/xCAT-server/share/xcat/scripts/configMellanox
@@ -379,8 +379,9 @@ sub config_vlan {
        if ($mode =~ /hybrid/) 
        {
            if (!$access_vlan) {
-               print "NOTE: Hybrid mode will change access vlan back to 1\n"; 
-               print "please provide access vlan if other than 1\n"; 
+               print "NOTE: Hybrid mode will change access VLAN back to 1\n"; 
+               print "If other than 1, run the command again with access VLAN number: \n"
+               print "    configMellanox --switches switchnames --port port --accessvlan vlan1 --allowvlan vlan2 --mode mode\n"; 
                $access_vlan = 1;
            }
        }
@@ -405,7 +406,7 @@ sub config_vlan {
             next;
         }
 
-        print "Tagging access vlan to $access_vlan and allowed vlan to $allowed_vlan with $mode mode for $switch port $port_input\n";
+        print "Tagging access VLAN to $access_vlan and allowed VLAN to $allowed_vlan with $mode mode for $switch port $port_input\n";
 
         my $cmd_prefix = "xdsh $switch --devicetype $devicetype";
         foreach my $port (@ports) {

--- a/xCAT-server/share/xcat/scripts/configMellanox
+++ b/xCAT-server/share/xcat/scripts/configMellanox
@@ -380,7 +380,7 @@ sub config_vlan {
        {
            if (!$access_vlan) {
                print "NOTE: Hybrid mode will change access VLAN back to 1\n"; 
-               print "If other than 1, run the command again with access VLAN number: \n"
+               print "If other than 1, run the command again with access VLAN number: \n";
                print "    configMellanox --switches switchnames --port port --accessvlan vlan1 --allowvlan vlan2 --mode mode\n"; 
                $access_vlan = 1;
            }


### PR DESCRIPTION
Change mode to hybrid will change access vlan back to 1.  To avoid this,  the configMellanox scripts to setup vlan is required user pass in both access vlan and allowed vlan

Failed case:
```
[root@fs3 ~]# /opt/xcat/share/xcat/scripts/configMellanox --switches core01 --port 58 --vlan 30 --mode access
Tagging VLAN=30 for core01 port 58
```
after that, looks like this `Eth1/58         access       30`

```
[root@fs3 ~]# /opt/xcat/share/xcat/scripts/configMellanox --switches core01 --port 58 --vlan 31 --mode hybrid
Tagging VLAN=31 for core01 port 58
```
looks like this : `Eth1/58         hybrid       1                  31`

After script modification:
---------------------------
```
[root@fs3 ~]# /opt/xcat/share/xcat/scripts/configMellanox  --switches core01 --port 56 --accessvlan 20 --allowvlan 21 --mode hybrid
Tagging access vlan to 20 and allowed vlan to 21 with hybrid mode for core01 port 56
```
the vlan on port 56 will looks like this: `Eth1/56         hybrid       20                 21`
