### PR TITLE
[openbmc] rpower off called against chassis object, rpower state aware of chassis state.

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -162,8 +162,8 @@ my %status_info = (
     },
     RPOWER_OFF_REQUEST  => {
         method         => "PUT",
-        init_url       => "$openbmc_project_url/state/host0/attr/RequestedHostTransition",
-        data           => "xyz.openbmc_project.State.Host.Transition.Off",
+        init_url       => "$openbmc_project_url/state/chassis0/attr/RequestedPowerTransition",
+        data           => "xyz.openbmc_project.State.Chassis.Transition.Off",
     },
     RPOWER_OFF_RESPONSE => {
         process        => \&rpower_response,


### PR DESCRIPTION
Partially resolves #3422 

This is required to allow us to power off machines immediately with firmware 1724B or higher...   because of the "softoff" now effective in OpenBMC

Update the code that processes the chassis state to be aware of the power off on the chassis0 object.  This is a temporary work around due to issue with https://github.com/openbmc/openbmc/issues/1933 that need to sync up the CurrentHostState and CurrentPowerState. 

Example of the code: 

### rpower off now acts as hard off 
```
[root@fs3 ~]# rpower mid05tor12cn04 off 
mid05tor12cn04: off
```

### With the code change, `rpower <> state` reflect the correct state:
```
mid05tor12cn04: DEBUG - State CurrentPowerState=xyz.openbmc_project.State.Chassis.PowerState.Off
mid05tor12cn04: DEBUG - State RequestedPowerTransition=xyz.openbmc_project.State.Chassis.Transition.Off
mid05tor12cn04: DEBUG - State CurrentHostState=xyz.openbmc_project.State.Host.HostState.Running
mid05tor12cn04: DEBUG - State RequestedHostTransition=xyz.openbmc_project.State.Host.Transition.On
mid05tor12cn04: off
```

Even though CurrentHostState is "Running" 

### Now when we power back on... the machine will report "off" until the ChassisPowerState is updated...

```
[root@fs3 ~]# rpower mid05tor12cn04 on
mid05tor12cn04: on
[root@fs3 ~]# rpower mid05tor12cn04 state
mid05tor12cn04: off
...
mid05tor12cn04: DEBUG - State CurrentPowerState=xyz.openbmc_project.State.Chassis.PowerState.On
mid05tor12cn04: DEBUG - State RequestedPowerTransition=xyz.openbmc_project.State.Chassis.Transition.Off
mid05tor12cn04: DEBUG - State CurrentHostState=xyz.openbmc_project.State.Host.HostState.Running
mid05tor12cn04: DEBUG - State RequestedHostTransition=xyz.openbmc_project.State.Host.Transition.On
mid05tor12cn04: on

```

