### PR TITLE
Support rpower softoff for openbmc 

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rpower.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rpower.1.rst
@@ -45,7 +45,7 @@ OpenPOWER OpenBMC:
 ==================
 
 
-\ **rpower**\  \ *noderange*\  [\ **off | on | reset | boot | stat | state | status**\ ]
+\ **rpower**\  \ *noderange*\  [\ **off | on | softoff | reset | boot | stat | state | status**\ ]
 
 
 PPC (with IVM or HMC) specific:

--- a/xCAT-client/pods/man1/rpower.1.pod
+++ b/xCAT-client/pods/man1/rpower.1.pod
@@ -22,7 +22,7 @@ B<rpower> I<noderange> [B<pduon>|B<pduoff>|B<pdustat>|B<pdureset>]
 
 =head2 OpenPOWER OpenBMC:
 
-B<rpower> I<noderange> [B<off>|B<on>|B<reset>|B<boot>|B<stat>|B<state>|B<status>]
+B<rpower> I<noderange> [B<off>|B<on>|B<softoff>|B<reset>|B<boot>|B<stat>|B<state>|B<status>]
 
 =head2 PPC (with IVM or HMC) specific:
 

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -168,6 +168,11 @@ my %status_info = (
     RPOWER_OFF_RESPONSE => {
         process        => \&rpower_response,
     },
+    RPOWER_SOFTOFF_REQUEST  => {
+        method         => "PUT",
+        init_url       => "$openbmc_project_url/state/host0/attr/RequestedHostTransition",
+        data           => "xyz.openbmc_project.State.Host.Transition.Off",
+    },
     RPOWER_RESET_REQUEST  => {
         method         => "PUT",
         init_url       => "$openbmc_project_url/state/host0/attr/RequestedHostTransition",
@@ -441,7 +446,7 @@ sub parse_args {
     }
 
     if ($command eq "rpower") {
-        unless ($subcommand =~ /^on$|^off$|^reset$|^boot$|^status$|^stat$|^state$/) {
+        unless ($subcommand =~ /^on$|^off$|^softoff$|^reset$|^boot$|^status$|^stat$|^state$/) {
             return ([ 1, "Unsupported command: $command $subcommand" ]);
         }
     } elsif ($command eq "rinv") {
@@ -566,6 +571,9 @@ sub parse_command_status {
         } elsif ($subcommand eq "off") {
             $next_status{LOGIN_RESPONSE} = "RPOWER_OFF_REQUEST";
             $next_status{RPOWER_OFF_REQUEST} = "RPOWER_OFF_RESPONSE";
+        } elsif ($subcommand eq "softoff") {
+            $next_status{LOGIN_RESPONSE} = "RPOWER_SOFTOFF_REQUEST";
+            $next_status{RPOWER_SOFTOFF_REQUEST} = "RPOWER_OFF_RESPONSE";
         } elsif ($subcommand eq "reset") {
             $next_status{LOGIN_RESPONSE} = "RPOWER_RESET_REQUEST";
             $next_status{RPOWER_RESET_REQUEST} = "RPOWER_RESET_RESPONSE";


### PR DESCRIPTION
Partially resolves #3422 

Based on the [README](https://github.com/openbmc/phosphor-dbus-interfaces/blob/master/xyz/openbmc_project/State/README.md) for the State API for OpenBMC,

Hardoff should be done against the chassis0 object and softoff is done against the host0 object.   The xCAT  rpower command had this backwards but prior to 1724B firmware, but sending OFF status on the host object powered off the chassis , so we didn't see an issue at the time.   




