### PR TITLE
add testcases for openbmc simulator delay response and modify timeout of async

### DIFF
--- a/xCAT-test/autotest/testcase/simulator/config_simulator.sh
+++ b/xCAT-test/autotest/testcase/simulator/config_simulator.sh
@@ -6,6 +6,8 @@ cnhn=$3  # CN hostname
 username=$4  # bmcusername
 password=$5  # bmcpassword
 nodes=$6  # number of IPs want to config
+delay_type=$7 # delay type "constant" or "random"
+delay_time=$8 # delay time
 
 if [ $nodes -gt 10000 ]; then
     echo "Unsupported number of nodes: $nodes"
@@ -42,11 +44,16 @@ if [ $flag = "-s" ]; then
 
     cd /root/ && git clone git@github.com:xuweibj/openbmc_simulator.git
 
-    if [ $nodes ]; then
+    if [ $nodes ] && [ $nodes -gt 0 ]; then
         lsdef $cnhn -z > /tmp/$cnhn.stanza
         rmdef $cnhn
 
-        /root/openbmc_simulator/simulator -n $nic -r $range 
+        if [ $delay_type ] && [ $delay_time ]; then 
+            option_string="-d $delay_type -t $delay_time -n $nic -r $range"
+        else
+            option_string="-n $nic -r $range"
+        fi
+        /root/openbmc_simulator/simulator $option_string 
         if [ $? != 0 ]; then
             echo "Start simulator Failed"
             exit 1
@@ -54,16 +61,20 @@ if [ $flag = "-s" ]; then
 
         node_end=$[nodes-1]
         chdef -t group $cnhn mgt=openbmc bmc="|\D+(\d+)$|10.100.(1+((\$1)/100)).((\$1)%100+1)|" bmcusername=$username bmcpassword=$password
-        chdef simulator_test_[0-$node_end] groups=$cnhn  # use CN hostname as group, so when run command against CN will rpower against all nodes added here
+        chdef simulator_test[0-$node_end] groups=$cnhn  # use CN hostname as group, so when run command against CN will rpower against all nodes added here
     else 
         cnip=`lsdef $cnhn -i bmc -c | awk -F '=' '{print $2}'`
         echo $cnip > "/tmp/simulator"
         mnip=`ping $mnhn -c 1 | grep "64 bytes from" |awk -F'(' '{print $2}'|awk -F')' '{print $1}'`
         chdef $cnhn bmc=$mnip
-        /root/openbmc_simulator/simulator
+        if [ $delay_type ] && [ $delay_time ]; then
+            /root/openbmc_simulator/simulator -d $delay_type -t $delay_time
+        else
+            /root/openbmc_simulator/simulator
+        fi
     fi
 elif [ $flag = "-c" ]; then
-    if [ $nodes ]; then
+    if [ $nodes ] && [ $nodes -gt 0 ]; then
         /root/openbmc_simulator/simulator -c -n $nic -r $range
         rmdef $cnhn
         cat /tmp/$cnhn.stanza | mkdef -z

--- a/xCAT-test/autotest/testcase/simulator/setup_simulator
+++ b/xCAT-test/autotest/testcase/simulator/setup_simulator
@@ -1,6 +1,6 @@
 start:setup_openbmc_simulator
 description:install dependent packaages, setup and start openbmc simulator
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/simulator/config_simulator.sh -s $$MN $$CN
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/simulator/config_simulator.sh -s $$MN $$CN $$bmcusername $$bmcpasswd 0
 check:rc==0
 end
 
@@ -19,5 +19,29 @@ end
 start:setup_openbmc_simulator_multiple_5000
 description:install dependent packaages, setup and start 5000 openbmc simulator
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/simulator/config_simulator.sh -s $$MN $$CN $$bmcusername $$bmcpasswd 5000
+check:rc==0
+end
+
+start:setup_openbmc_simulator_multiple_1000_delay_random_1m
+description:install dependent packaages, setup and start 1000 openbmc simulator with random that the most delay time 1 minute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/simulator/config_simulator.sh -s $$MN $$CN $$bmcusername $$bmcpasswd 1000 random 1m
+check:rc==0
+end
+
+start:setup_openbmc_simulator_multiple_5000_delay_random_1m
+description:install dependent packaages, setup and start 5000 openbmc simulator with random that the most delay time 1 minute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/simulator/config_simulator.sh -s $$MN $$CN $$bmcusername $$bmcpasswd 5000 constant 1m
+check:rc==0
+end
+
+start:setup_openbmc_simulator_multiple_1000_delay_random_1m30
+description:install dependent packaages, setup and start 1000 openbmc simulator with random that the most delay time 1m30s
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/simulator/config_simulator.sh -s $$MN $$CN $$bmcusername $$bmcpasswd 1000 random 1m30
+check:rc==0
+end
+
+start:setup_openbmc_simulator_multiple_1000_delay_random_30
+description:install dependent packaages, setup and start 1000 openbmc simulator with random that the most delay time 30s
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/simulator/config_simulator.sh -s $$MN $$CN $$bmcusername $$bmcpasswd 1000 random 0m30
 check:rc==0
 end


### PR DESCRIPTION
1. Change timeout, max_request_time, slots of Async. 
   Timeout will be 1 minute.
   Max wait for 500 response.

Avoid issue #3405 .

If timeout, output will be as below:
```
CN1: Error: 504 Gateway Timeout
```

2. Add delay response cases. (random delay)
    2.1 1000 nodes delay  0～～1m
    2.2 1000 nodes delay 0～～30s
    2.3 1000 nodes delay 0～～1m30s
    2.4 5000 nodes delay 0～～1m

Results for random delay:
For 2.1 : 111s
For 2.2 : 60s
For 2.3 :  129s
For 2.4 : 377s


My test results: (constant delay)

1. 1000 nodes delay 10m : 1215s
2. 5000 nodes delay 1m : 468s
3. 5000 nodes delay 5m : 2150s
4. 5000 nodes delay 10m : 4249s