### PR TITLE
enhance makehosts support regex in nicips

### DIFF
--- a/xCAT-server/lib/xcat/plugins/hosts.pm
+++ b/xCAT-server/lib/xcat/plugins/hosts.pm
@@ -660,7 +660,7 @@ sub donics
             if (!$nicip) {
                 next;
             }
-            #Only format for nicips:<nic1>!<ip1>|<ip2>|... or <nic1>!<one regular expression>
+            #Only support format for nicips is :<nic1>!<ip1>|<ip2>|... or <nic1>!<one regular expression>
             if ($nicip =~ /^\|\S*\|$/) {
                 $nicip = xCAT::Table::transRegexAttrs($node, $nicip);
             }

--- a/xCAT-server/lib/xcat/plugins/hosts.pm
+++ b/xCAT-server/lib/xcat/plugins/hosts.pm
@@ -72,7 +72,6 @@ sub addnode
     # if this ip was already added then just update the entry
     while ($idx <= $#hosts)
     {
-
         if ($hosts[$idx] =~ /^${ip}\s/
             or $hosts[$idx] =~ /^\d+\.\d+\.\d+\.\d+\s+${node}[\s\.\r]/)
         {
@@ -661,7 +660,12 @@ sub donics
             if (!$nicip) {
                 next;
             }
-
+            #If there is one nicip in  nicips, and it is regular expression
+            #for example: eth0!|\D+(\d+)\D+|10.80.1.($1*2+103)|
+            #Does not support: there is regular expression in multple nicips
+            if ($nicip =~ /^\|\S*\|$/) {
+                $nicip = xCAT::Table::transRegexAttrs($node, $nicip);
+            }
             if ($nicip =~ /\|/) {
                 my @ips = split(/\|/, $nicip);
                 foreach my $ip (@ips) {

--- a/xCAT-server/lib/xcat/plugins/hosts.pm
+++ b/xCAT-server/lib/xcat/plugins/hosts.pm
@@ -660,9 +660,7 @@ sub donics
             if (!$nicip) {
                 next;
             }
-            #If there is one nicip in  nicips, and it is regular expression
-            #for example: eth0!|\D+(\d+)\D+|10.80.1.($1*2+103)|
-            #Does not support: there is regular expression in multple nicips
+            #Only format for nicips:<nic1>!<ip1>|<ip2>|... or <nic1>!<one regular expression>
             if ($nicip =~ /^\|\S*\|$/) {
                 $nicip = xCAT::Table::transRegexAttrs($node, $nicip);
             }


### PR DESCRIPTION
fix #3409 
Discussed with team member; Support there is only one regex in nicips.
Does not support there are multiple nicips for one nic, and nicips contain regex.

unit test:
```
[root@bybc0602 xCAT_plugin]# cat /etc/hosts|grep sn4b
[root@bybc0602 xCAT_plugin]# lsdef -t group regex
Object name: regex
    grouptype=static
    ip=|\D+(\d+)\D+|20.80.1.($1*2+103)|
    members=sn4b
    nichostnamesuffixes.eth0=-eth0
    nicips.eth0=|\D+(\d+)\D+|10.80.1.($1*2+103)|
    nicnetworks.eth0=10_0_0_0-255_0_0_0
[root@bybc0602 xCAT_plugin]# makehosts sn4b
[root@bybc0602 xCAT_plugin]#  cat /etc/hosts|grep sn4b
20.80.1.111 sn4b sn4b.cluster.com
10.80.1.111 sn4b-eth0 sn4b-eth0.cluster.com
```