### PR TITLE
Fix 3151, Backup service node is not reflected in the /opt/xcat/xcatinfo file

### DIFF
--- a/xCAT-server/share/xcat/mypostscript/mypostscript.tmpl
+++ b/xCAT-server/share/xcat/mypostscript/mypostscript.tmpl
@@ -43,6 +43,8 @@ export PRIMARYNIC
 
 MASTER=#TABLE:noderes:$NODE:xcatmaster#
 export MASTER
+SERVICEGROUP=#TABLE:noderes:$NODE:servicenode#
+export SERVICEGROUP
 
 SYSLOG=#TABLE:noderes:$NODE:syslog#
 export SYSLOG

--- a/xCAT/postscripts/xcatdsklspost
+++ b/xCAT/postscripts/xcatdsklspost
@@ -19,9 +19,7 @@
 #
 #####################################################
 
-
 [ -f "/xcatpost/xcatlib.sh" ] &&  . /xcatpost/xcatlib.sh 
-
 
 if [ -f /xcatpost/mypostscript.post ]; then
     XCATDEBUGMODE=`grep 'XCATDEBUGMODE=' /xcatpost/mypostscript.post | cut -d= -f2 | tr -d \'\" | tr A-Z a-z`
@@ -39,6 +37,7 @@ else
     done
 fi
 
+XCATINFOFILE=/opt/xcat/xcatinfo
 
 #echolog: process message log and echo in xcatdsklspost
 #arguments:
@@ -693,10 +692,18 @@ fi
 
 # Store the SERVICEGROUP into the xcatinfo file for node deployment, and also for updatenode -s
 if [ $NODE_DEPLOYMENT -eq 1 ] || [ "$MODE" = "1" ]; then
-    sed -i "/SERVICEGROUP=.*/d" /opt/xcat/xcatinfo
     sn_group=`grep '^SERVICEGROUP' /$xcatpost/mypostscript |cut -d= -f2 | tr -d \'\"`
     if [ "x" != "x$sn_group" ]; then
-      echo "SERVICEGROUP=$sn_group" >> /opt/xcat/xcatinfo
+      # Change or add SERVICEGROUP line if service node pool defined.
+      grep 'SERVICEGROUP=' $XCATINFOFILE > /dev/null 2>&1
+      if [ $? -eq 0 ]; then
+        sed -i "s/SERVICEGROUP=.*/SERVICEGROUP=$sn_group/" $XCATINFOFILE
+      else
+        echo "SERVICEGROUP=$sn_group" >> $XCATINFOFILE
+      fi
+    else
+      # Remove SERVICEGROUP line if no service node pool defined.
+      sed -i "/SERVICEGROUP=.*/d" $XCATINFOFILE
     fi
 fi
 

--- a/xCAT/postscripts/xcatdsklspost
+++ b/xCAT/postscripts/xcatdsklspost
@@ -691,6 +691,14 @@ else
     echo "USEFLOWCONTROL=NO" >> /opt/xcat/xcatinfo
 fi
 
+# Store the SERVICEGROUP into the xcatinfo file for node deployment, and also for updatenode -s
+if [ $NODE_DEPLOYMENT -eq 1 ] || [ "$MODE" = "1" ]; then
+    sed -i "/SERVICEGROUP=.*/d" /opt/xcat/xcatinfo
+    sn_group=`grep '^SERVICEGROUP' /$xcatpost/mypostscript |cut -d= -f2 | tr -d \'\"`
+    if [ "x" != "x$sn_group" ]; then
+      echo "SERVICEGROUP=$sn_group" >> /opt/xcat/xcatinfo
+    fi
+fi
 
 # when called by the updatenode command  MODE=1,2
 # the nodename is passed in by xdsh in the NODE environment variable by xdsh.

--- a/xCAT/postscripts/xcatinstallpost
+++ b/xCAT/postscripts/xcatinstallpost
@@ -74,7 +74,12 @@ if [ $? -eq 0 ]; then
 else
     echo "REBOOT=TRUE" >> /opt/xcat/xcatinfo
 fi
-
+# Store the SERVICEGROUP into the xcatinfo file for statful installation
+sed -i "/SERVICEGROUP=.*/d" /opt/xcat/xcatinfo
+sn_group=`grep '^SERVICEGROUP' /$xcatpost/mypostscript |cut -d= -f2 | tr -d \'\"`
+if [ "x" != "x$sn_group" ]; then
+    echo "SERVICEGROUP=$sn_group" >> /opt/xcat/xcatinfo
+fi
 
 CNS=`grep NODESTATUS= /xcatpost/mypostscript.post |awk -F = '{print $2}' | tr -d \'\" | tr A-Z a-z`
 if [ -z "$CNS" ] || [[ "$CNS" =~ ^(1|yes|y)$ ]]; then

--- a/xCAT/postscripts/xcatinstallpost
+++ b/xCAT/postscripts/xcatinstallpost
@@ -20,7 +20,7 @@ fi
 SLI=$(awk 'BEGIN{srand(); printf("%d\n",rand()*10)}')
 sleep $SLI
 
-
+XCATINFOFILE=/opt/xcat/xcatinfo
 MACADDR=`grep MACADDRESS= /xcatpost/mypostscript.post |awk -F = '{print $2}'|sed s/\'//g`
 INSTALLNIC=`ip -o link|grep -i $MACADDR|awk  '{print $2}'|sed s/://`
 
@@ -75,10 +75,18 @@ else
     echo "REBOOT=TRUE" >> /opt/xcat/xcatinfo
 fi
 # Store the SERVICEGROUP into the xcatinfo file for statful installation
-sed -i "/SERVICEGROUP=.*/d" /opt/xcat/xcatinfo
-sn_group=`grep '^SERVICEGROUP' /$xcatpost/mypostscript |cut -d= -f2 | tr -d \'\"`
+sn_group=`grep '^SERVICEGROUP' /xcatpost/mypostscript |cut -d= -f2 | tr -d \'\"`
 if [ "x" != "x$sn_group" ]; then
-    echo "SERVICEGROUP=$sn_group" >> /opt/xcat/xcatinfo
+  # Change or add SERVICEGROUP line if service node pool defined.
+  grep 'SERVICEGROUP=' $XCATINFOFILE > /dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    sed -i "s/SERVICEGROUP=.*/SERVICEGROUP=$sn_group/" $XCATINFOFILE
+  else
+    echo "SERVICEGROUP=$sn_group" >> $XCATINFOFILE
+  fi
+else
+  # Remove SERVICEGROUP line if no service node pool defined.
+  sed -i "/SERVICEGROUP=.*/d" $XCATINFOFILE
 fi
 
 CNS=`grep NODESTATUS= /xcatpost/mypostscript.post |awk -F = '{print $2}' | tr -d \'\" | tr A-Z a-z`


### PR DESCRIPTION
Fix 3151
populate node attribute servicenode into mypostscript, and then inject into /opt/xcat/xcatinfo
cover both updatenode -s and os installation case.

UT:
Patch the files on both MN and SNs

Stateful provision:
1, set node servicenode attribute to a service pool
chdef mid05tor12cn07 servicenode=sn02,sn01
2, provision it using stateful osimage
nodeset mid05tor12cn07 osimage=rhels7.3-ppc64le-install-compute
rsetboot mid05tor12cn07 net
rpower mid05tor12cn07 reset
3, after installation, check /opt/xcat/xcatinfo on CN
```
cat /opt/xcat/xcatinfo
XCATSERVER=172.20.253.104
INSTALLDIR=/install
REBOOT=TRUE
SERVICEGROUP=sn02,sn01
```

updatenode case:
1, chdef mid05tor12cn07 servicenode=sn01,sn02
2, updatenode mid05tor12cn07 -s
3, check the file
```
cat /opt/xcat/xcatinfo
XCATSERVER=172.20.253.104
INSTALLDIR=/install
REBOOT=TRUE
NODE=mid05tor12cn07
USEFLOWCONTROL=NO
SERVICEGROUP=sn01,sn02
RUNBOOTSCRIPTS=no
```
stateless provisioning:
1, reprovision it as stateless node
chdef mid05tor12cn07 servicenode=sn02,sn01
nodeset mid05tor12cn07 osimage=rhels7.3-ppc64le-netboot-compute
rsetboot mid05tor12cn07 net
rpower mid05tor12cn07 reset
2, check the file
```
IMAGENAME='rhels7.3-ppc64le-netboot-compute'
IMAGEUUID='623a1a32-f81e-403b-9eef-f8faeafb2d18'
TIMESTAMP='Tue Jul 11 00:44:10 EDT 2017'
NODE=mid05tor12cn07
XCATSERVER='172.20.253.104'
USEFLOWCONTROL=NO
SERVICEGROUP=sn02,sn01
```

Note:  not try state-lite yet.