### PR TITLE
Support new option to rpower: bmcstate, which will return the state of the BMC 

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rpower.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rpower.1.rst
@@ -45,7 +45,7 @@ OpenPOWER OpenBMC:
 ==================
 
 
-\ **rpower**\  \ *noderange*\  [\ **off | on | softoff | reset | boot | stat | state | status**\ ]
+\ **rpower**\  \ *noderange*\  [\ **off | on | softoff | reset | boot | bmcstate | stat | state | status**\ ]
 
 
 PPC (with IVM or HMC) specific:
@@ -377,6 +377,12 @@ OPTIONS
 \ **unpause**\ 
  
  To unpause all processes in the instance.
+ 
+
+
+\ **bmcstate**\ 
+ 
+ To get state of the BMC.
  
 
 

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -29,7 +29,7 @@ my %usage = (
        rpower noderange [on|off|softoff|reset|boot|stat|state|status|wake|suspend [-w timeout] [-o] [-r]]
        rpower noderange [pduon|pduoff|pdustat]
      OpenPOWER BMC:
-       rpower noderange [on|off|reset|boot|stat|state|status]
+       rpower noderange [on|off|softoff|reset|boot|stat|state|status]
        rpower noderange [pduon|pduoff|pdustat]
      OpenPOWER OpenBMC:
        rpower noderange [on|off|reset|boot|stat|state|status]

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -29,7 +29,7 @@ my %usage = (
        rpower noderange [on|off|softoff|reset|boot|stat|state|status|wake|suspend [-w timeout] [-o] [-r]]
        rpower noderange [pduon|pduoff|pdustat]
      OpenPOWER BMC:
-       rpower noderange [on|off|softoff|reset|boot|stat|state|status]
+       rpower noderange [on|off|softoff|reset|boot|bmcstate|stat|state|status]
        rpower noderange [pduon|pduoff|pdustat]
      OpenPOWER OpenBMC:
        rpower noderange [on|off|reset|boot|stat|state|status]

--- a/xCAT-client/pods/man1/rpower.1.pod
+++ b/xCAT-client/pods/man1/rpower.1.pod
@@ -22,7 +22,7 @@ B<rpower> I<noderange> [B<pduon>|B<pduoff>|B<pdustat>|B<pdureset>]
 
 =head2 OpenPOWER OpenBMC:
 
-B<rpower> I<noderange> [B<off>|B<on>|B<softoff>|B<reset>|B<boot>|B<stat>|B<state>|B<status>]
+B<rpower> I<noderange> [B<off>|B<on>|B<softoff>|B<reset>|B<boot>|B<bmcstate>|B<stat>|B<state>|B<status>]
 
 =head2 PPC (with IVM or HMC) specific:
 
@@ -246,6 +246,10 @@ To pause all processes in the instance.
 =item B<unpause>
 
 To unpause all processes in the instance.
+
+=item B<bmcstate>
+
+To get state of the BMC.
 
 =item B<state>
 


### PR DESCRIPTION
Created a new option to rpower to display the BMC state based on this API [BMC.interface.yaml](https://github.com/openbmc/phosphor-dbus-interfaces/blob/master/xyz/openbmc_project/State/BMC.interface.yaml)

Here's what it looks like from the externals: 
```
[root@fs2vm110 ~]# rpower p9euh[01,02] bmcstatus
[OpenBMC development support] Using this version of xCAT, ensure firware level is at v1.99.6-0-r1, or higher.
p9euh01 BMC: Ready
p9euh02 BMC: Ready
```