### PR TITLE
Add rpower bmcreboot command for openbmc

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rpower.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rpower.1.rst
@@ -380,6 +380,12 @@ OPTIONS
  
 
 
+\ **bmcreboot**\ 
+ 
+ To reboot BMC.
+ 
+
+
 \ **bmcstate**\ 
  
  To get state of the BMC.

--- a/docs/source/guides/admin-guides/references/man1/rpower.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rpower.1.rst
@@ -45,7 +45,7 @@ OpenPOWER OpenBMC:
 ==================
 
 
-\ **rpower**\  \ *noderange*\  [\ **off | on | softoff | reset | boot | bmcstate | stat | state | status**\ ]
+\ **rpower**\  \ *noderange*\  [\ **off | on | softoff | reset | boot | bmcreboot | bmcstate | stat | state | status**\ ]
 
 
 PPC (with IVM or HMC) specific:

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -29,10 +29,10 @@ my %usage = (
        rpower noderange [on|off|softoff|reset|boot|stat|state|status|wake|suspend [-w timeout] [-o] [-r]]
        rpower noderange [pduon|pduoff|pdustat]
      OpenPOWER BMC:
-       rpower noderange [on|off|softoff|reset|boot|bmcstate|stat|state|status]
+       rpower noderange [on|off|reset|boot|stat|state|status]
        rpower noderange [pduon|pduoff|pdustat]
      OpenPOWER OpenBMC:
-       rpower noderange [on|off|reset|boot|stat|state|status]
+       rpower noderange [on|off|softoff|reset|boot|bmcreboot|bmcstate|stat|state|status]
      KVM Virtualization specific:
        rpower <noderange> [boot] [ -c <path to iso> ]
      PPC (with IVM or HMC) specific:

--- a/xCAT-client/pods/man1/rpower.1.pod
+++ b/xCAT-client/pods/man1/rpower.1.pod
@@ -247,6 +247,10 @@ To pause all processes in the instance.
 
 To unpause all processes in the instance.
 
+=item B<bmcreboot>
+
+To reboot BMC.
+
 =item B<bmcstate>
 
 To get state of the BMC.

--- a/xCAT-client/pods/man1/rpower.1.pod
+++ b/xCAT-client/pods/man1/rpower.1.pod
@@ -22,7 +22,7 @@ B<rpower> I<noderange> [B<pduon>|B<pduoff>|B<pdustat>|B<pdureset>]
 
 =head2 OpenPOWER OpenBMC:
 
-B<rpower> I<noderange> [B<off>|B<on>|B<softoff>|B<reset>|B<boot>|B<bmcstate>|B<stat>|B<state>|B<status>]
+B<rpower> I<noderange> [B<off>|B<on>|B<softoff>|B<reset>|B<boot>|B<bmcreboot>|B<bmcstate>|B<stat>|B<state>|B<status>]
 
 =head2 PPC (with IVM or HMC) specific:
 


### PR DESCRIPTION
#3436 

Output:
```
# rpower p9euh02 bmcreboot
p9euh02 BMC: reboot
```
Output when XCATBYPASS=1
```
# XCATBYPASS=1 rpower p9euh02 bmcreboot
$VAR1 = {
          'p9euh02' => {
                         'password' => '0penBmc',
                         'bmc' => '10.6.9.254',
                         'cur_status' => 'LOGIN_REQUEST',
                         'username' => 'root'
                       }
        };

[OpenBMC development support] Using this version of xCAT, ensure firware level is at v1.99.6-0-r1, or higher.
$VAR1 = {
          'RPOWER_BMCREBOOT_REQUEST' => 'RPOWER_RESET_RESPONSE',
          'LOGIN_REQUEST' => 'LOGIN_RESPONSE',
          'LOGIN_RESPONSE' => 'RPOWER_BMCREBOOT_REQUEST'
        };

p9euh02: DEBUG POST https://10.6.9.254/login -d { "data": [ "root", "0penBmc" ] }
p9euh02: DEBUG login_response 200 OK
p9euh02: DEBUG PUT https://10.6.9.254/xyz/openbmc_project/state/bmc0/attr/RequestedBMCTransition -d {"data":"xyz.openbmc_project.State.BMC.Transition.Reboot"}
p9euh02: DEBUG rpower_reset_response 200 OK
p9euh02 BMC: reboot
monitorctrl::setNodeStatusAttributes called
```

After reboot, will can not connect to BMC using restful, and it should ping again once it comes back up
```
p9euh02: Error: 503 Service Unavailable
```