### PR TITLE
Fix issue 3420: Changes required to support more detailed firmware in…

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -1610,9 +1610,10 @@ sub isfpc {
 sub isopenpower {
     my $sessdata = shift;
     if ($sessdata->{prod_id} == 43707 and $sessdata->{mfg_id} == 0) {
+        # mft_id 0 and prod_id 43707 is for Firestone,Minsky
         return 1;
-    # mfg_id 10876 is for Supermicro, prod_id 2355 for B&S, and 0 for Boston
     } elsif (($sessdata->{prod_id} == 0 or $sessdata->{prod_id} == 2355) and $sessdata->{mfg_id} == 10876) {
+        # mfg_id 10876 is for Supermicro, prod_id 2355 for B&S, and 0 for Boston
         return 1;
     } else {
         return 0;

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -1611,8 +1611,10 @@ sub isopenpower {
     my $sessdata = shift;
     if ($sessdata->{prod_id} == 43707 and $sessdata->{mfg_id} == 0) {
         return 1;
-    }
-    else {
+    # mfg_id 10876 is for Supermicro, prod_id 2355 for B&S, and 0 for Boston
+    } elsif (($sessdata->{prod_id} == 0 or $sessdata->{prod_id} == 2355) and $sessdata->{mfg_id} == 10876) {
+        return 1;
+    } else {
         return 0;
     }
 }
@@ -3971,7 +3973,7 @@ sub add_fruhash {
                 $fru->rec_type("hw");
             }
             $fru->value($err);
-            if (exists($sessdata->{currfrusdr})) {
+            if ($sessdata->{currfrusdr}) {
                 $fru->desc($sessdata->{currfrusdr}->id_string);
             }
             if (exists($sessdata->{frudex})) {
@@ -4213,6 +4215,9 @@ sub parsefru {
         } else { #some meaning suggested, but not parsable, xCAT shouldn't meddle
             return "Unrecognized FRU format", undef;
         }
+    }
+    elsif (!$bytes->[1] and !$bytes->[2] and !$bytes->[3] and !$bytes->[4] and !$bytes->[5]) {
+        return "No data available", undef;
     }
     if ($bytes->[1]) { #The FRU spec, unfortunately, gave no easy way to tell the size of internal area
          #consequently, will find the next defined field and preserve the addressing and size of current FRU


### PR DESCRIPTION
…formation for LC Big Data boxes

To fix issue #3420 
Before fix:
```
[root@stratton01 ~]# rinv briggs01 firm
briggs01: BMC Firmware: 1.21
```
The output with the fix:
```
[root@stratton01 xcat]# rinv briggs01 firm
briggs01: BMC Firmware: 1.21
briggs01: System Firmware Product Version: open-power-IBM-P8DTU-V2.00.GA2-20170512-prod
briggs01: System Firmware Product Additional Info: op-build-ce794ed
briggs01: System Firmware Product Additional Info: hostboot-7fdfb37
briggs01: System Firmware Product Additional Info: occ-301b535
briggs01: System Firmware Product Additional Info: skiboot-5.4.2
briggs01: System Firmware Product Additional Info: linux-4.4.24-openpower1-dfd621a
briggs01: System Firmware Product Additional Info: petitboot-v1.4.0-d979a86
briggs01: System Firmware Product Additional Info: p8dtu-xml-04e8a01
```