### PR TITLE
fix xCAT should better support the service group (servicenode postscript) to avoid errors when using Hierarchy #3150

### DIFF
--- a/xCAT-server/lib/perl/xCAT/SvrUtils.pm
+++ b/xCAT-server/lib/perl/xCAT/SvrUtils.pm
@@ -742,6 +742,13 @@ sub update_tables_with_templates
                     osarch       => $arch,
                     synclists    => $synclistfile,
                     osdistroname => $osdistroname);
+
+                #for service node osimage, add service node to the postscripts attributes
+                if($profile eq "service"){
+                    $tb_cols{postscripts}="servicenode";
+                }
+
+
                 if ($args{description}) {
                     $tb_cols{description} = $args{description};
                 }


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/3150:

add postscript "servicenode"  to the postscripts attributes of ``xxxx-service-xxxx`` osimages

Verified with sles12.2 and rhels7.3:
````
[root@c910f03c05k21 ~]# lsdef -t osimage sles12.2-ppc64le-install-service
Object name: sles12.2-ppc64le-install-service
    imagetype=linux
    osarch=ppc64le
    osdistroname=sles12.2-ppc64le
    osname=Linux
    osvers=sles12.2
    otherpkgdir=/install/post/otherpkgs/sles12.2/ppc64le
    otherpkglist=/opt/xcat/share/xcat/install/sles/service.sles12.ppc64le.otherpkgs.pkglist
    pkgdir=/install/sles12.2/ppc64le
    pkglist=/opt/xcat/share/xcat/install/sles/service.sles12.pkglist
    **postscripts=servicenode**
    profile=service
    provmethod=install
    template=/opt/xcat/share/xcat/install/sles/service.sles12.tmpl
````