### PR TITLE
Add code to support rbeacon in openbmc 

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -607,7 +607,7 @@ sub parse_command_status {
     }
 
     if ($command eq "rbeacon") { 
-        $subcommand = $ARGV[0];
+        $subcommand = $$subcommands[0];
 
         if ($subcommand eq "on") {
             $next_status{LOGIN_RESPONSE} = "RBEACON_ON_REQUEST";

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -945,7 +945,12 @@ sub gen_send_request {
     }
 
     if ($status_info{ $node_info{$node}{cur_status} }{data}) {
-        $content = '{"data":"' . $status_info{ $node_info{$node}{cur_status} }{data} . '"}';
+        # Handle boolean values by create the json objects without wrapping with quotes
+        if ($status_info{ $node_info{$node}{cur_status} }{data} =~ /^1$|^true$|^True$|^0$|^false$|^False$/) {
+            $content = '{"data":' . $status_info{ $node_info{$node}{cur_status} }{data} . '}';
+        } else {
+            $content = '{"data":"' . $status_info{ $node_info{$node}{cur_status} }{data} . '"}';
+        }
     }
 
     if ($node_info{$node}{cur_url}) {


### PR DESCRIPTION
Initial code changes required to turn on and off the chassis identification light.

The  [LED](https://github.com/openbmc/phosphor-dbus-interfaces/tree/master/xyz/openbmc_project/Led) API currently supports the following group identify properties

```
 curl -c cjar -b cjar -k -H 'Content-Type: application/json' -X GET https://172.20.140.111/xyz/openbmc_project/led/groups/list | grep identify 
    "/xyz/openbmc_project/led/groups/fan0_identify",
    "/xyz/openbmc_project/led/groups/fan1_identify",
    "/xyz/openbmc_project/led/groups/fan2_identify",
    "/xyz/openbmc_project/led/groups/enclosure_identify",
    "/xyz/openbmc_project/led/groups/fan3_identify",
```

Right now we will just support the `enclosure_identify` by running the following commands:

Turn on: 
```
 curl -b cjar -k -H Content-Type:application/json -X PUT -d '{"data":1}' https://172.20.140.111//xyz/openbmc_project/led/groups/enclosure_identify/attr/Asserted
{
  "data": null,
  "message": "200 OK",
  "status": "ok"
```

Turn off 
```
 curl -b cjar -k -H Content-Type:application/json -X PUT -d '{"data":0}' https://172.20.140.111//xyz/openbmc_project/led/groups/fan0_identify/attr/Asserted
{
  "data": null,
  "message": "200 OK",
  "status": "ok"
}
```
