### PR TITLE
mysql/mariadb package requirements

### DIFF
--- a/docs/source/advanced/hierarchy/databases/mysql_install.rst
+++ b/docs/source/advanced/hierarchy/databases/mysql_install.rst
@@ -26,20 +26,14 @@ Red Hat Enterprise Linux
        perl-DBD-MySQL*
        mysql-server-5.*
        mysql-5.*
-       mysql-devel-5.*
-       mysql-bench-5.*
        mysql-connector-odbc-*
 
 * MariaDB - Using ``yum``, ensure that the following packages are installed on the management node: ::
 
-       mariadb-devel-5.*
-       mariadb-libs-5.*
        mariadb-server-5.*
-       mariadb-bench-5.*
        mariadb-5.*
        perl-DBD-MySQL*
        mysql-connector-odbc-*
-       unixODBC*
 
 Suse Linux Enterprise Server
 ----------------------------


### PR DESCRIPTION
For issue #3392 
To install mysql/mariadb, mysql-devel /mysql-bench  or mariadb-devel/mariadb-bench are not requirement.
mariadb-libs will pick up by install mariadb
unixODBC will pick up by install mysql-connector-odbc