### PR TITLE
fix issue 3430 confignetwork could not config network if MTU is not set

### DIFF
--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -497,7 +497,7 @@ function create_persistent_ifcfg {
         if [ -z "$_netmask" ]; then
             _netmask=`get_network_attr $xcatnet mask`
             if [ $? -ne 0 ]; then
-                log_warn "There is no netmask configured for network $xcatnet in networks table"
+                log_error "There is no netmask configured for network $xcatnet in networks table"
                 _netmask=""
             fi
         fi
@@ -894,7 +894,6 @@ function create_bridge_interface {
     if [ -z "$_mtu" ]; then
         _mtu=`get_network_attr $xcatnet mtu`
         if [ $? -ne 0 ]; then
-            log_warn "There is no MTU configured for network $xcatnet in networks table."
             _mtu=""
         fi
     fi
@@ -1019,7 +1018,6 @@ function create_ethernet_interface {
     if [ -z "$_mtu" ]; then
         _mtu=`get_network_attr $xcatnet mtu`
         if [ $? -ne 0 ]; then
-            log_warn "There is no MTU configured for network $xcatnet in networks table."
             _mtu=""
         fi
 
@@ -1111,7 +1109,6 @@ function create_vlan_interface {
     if [ -z "$_mtu" ]; then
         _mtu=`get_network_attr $xcatnet mtu`
         if [ $? -ne 0 ]; then
-            log_warn "There is no MTU configured for network $xcatnet in networks table."
             _mtu=""
         fi
 
@@ -1293,7 +1290,6 @@ function create_bond_interface {
     if [ -z "$_mtu" ]; then
         _mtu=`get_network_attr $xcatnet mtu`
         if [ $? -ne 0 ]; then
-            log_warn "There is no MTU configured for network $xcatnet in networks table."
             _mtu=""
         fi
     fi

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -498,7 +498,7 @@ function create_persistent_ifcfg {
         if [ -z "$_netmask" ]; then
             _netmask=`get_network_attr $xcatnet mask`
             if [ $? -ne 0 ]; then
-                log_warn "There is no mask configure in network $xcatnet from networks table."
+                log_warn "There is no netmask configured for network $xcatnet in networks table"
                 _netmask=""
             fi
         fi
@@ -507,7 +507,6 @@ function create_persistent_ifcfg {
         if [ -z "$_mtu" ]; then
             _mtu=`get_network_attr $xcatnet mtu`
             if [ $? -ne 0 ]; then
-                log_warn "There is no mtu value configured in network $xcatnet from networks table."
                 _mtu=""
             fi
         fi
@@ -896,7 +895,7 @@ function create_bridge_interface {
     if [ -z "$_mtu" ]; then
         _mtu=`get_network_attr $xcatnet mtu`
         if [ $? -ne 0 ]; then
-            log_warn "There is no mtu value configured in network $xcatnet from networks table."
+            log_warn "There is no MTU configured for network $xcatnet in networks table."
             _mtu=""
         fi
     fi
@@ -1021,7 +1020,7 @@ function create_ethernet_interface {
     if [ -z "$_mtu" ]; then
         _mtu=`get_network_attr $xcatnet mtu`
         if [ $? -ne 0 ]; then
-            log_warn "There is no mtu value configured in network $xcatnet from networks table."
+            log_warn "There is no MTU configured for network $xcatnet in networks table."
             _mtu=""
         fi
 
@@ -1113,7 +1112,7 @@ function create_vlan_interface {
     if [ -z "$_mtu" ]; then
         _mtu=`get_network_attr $xcatnet mtu`
         if [ $? -ne 0 ]; then
-            log_warn "There is no mtu value configured in network $xcatnet from networks table."
+            log_warn "There is no MTU configured for network $xcatnet in networks table."
             _mtu=""
         fi
 
@@ -1295,7 +1294,7 @@ function create_bond_interface {
     if [ -z "$_mtu" ]; then
         _mtu=`get_network_attr $xcatnet mtu`
         if [ $? -ne 0 ]; then
-            log_warn "There is no mtu value configured in network $xcatnet from networks table."
+            log_warn "There is no MTU configured for network $xcatnet in networks table."
             _mtu=""
         fi
     fi

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -382,8 +382,7 @@ function get_network_attr {
    if [ $index -le $NETWORKS_LINES ]; then
        echo "$netline" | $sed -e 's/||/\n/g' | $awk -F'=' '$1 == "'$attrname'" {print $2}'
    else
-       log_error "Fail to get $attrname for network $netname"
-       exit 1
+       return 1
    fi
 }
 

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -288,6 +288,7 @@ function query_extra_params {
     if [ ${#array_nic_params[@]} -gt 0 ]; then
         #Current confignetwork only support one ip for vlan/bond/bridge
         #So only need the first ${array_nic_params[0]} for first nicips
+        #TODO: support multiple nicips for vlan/bond/bridge
         str_extra_params=${array_nic_params[0]}
         parse_nic_extra_params "$str_extra_params"
     fi
@@ -381,7 +382,7 @@ function get_network_attr {
    if [ $index -le $NETWORKS_LINES ]; then
        echo "$netline" | $sed -e 's/||/\n/g' | $awk -F'=' '$1 == "'$attrname'" {print $2}'
    else
-       log_error "Fail to get \"$attrname\" for network \"$netname\""
+       log_error "Fail to get $attrname for network $netname"
        exit 1
    fi
 }
@@ -496,11 +497,19 @@ function create_persistent_ifcfg {
         fi
         if [ -z "$_netmask" ]; then
             _netmask=`get_network_attr $xcatnet mask`
+            if [ $? -ne 0 ]; then
+                log_warn "There is no mask configure in network $xcatnet from networks table."
+                _netmask=""
+            fi
         fi
 
         # Query mtu value from "networks" table
         if [ -z "$_mtu" ]; then
             _mtu=`get_network_attr $xcatnet mtu`
+            if [ $? -ne 0 ]; then
+                log_warn "There is no mtu value configured in network $xcatnet from networks table."
+                _mtu=""
+            fi
         fi
 
     fi
@@ -886,6 +895,10 @@ function create_bridge_interface {
     # Query mtu value from "networks" table
     if [ -z "$_mtu" ]; then
         _mtu=`get_network_attr $xcatnet mtu`
+        if [ $? -ne 0 ]; then
+            log_warn "There is no mtu value configured in network $xcatnet from networks table."
+            _mtu=""
+        fi
     fi
 
     if [ x$_pretype == "xethernet" ]; then 
@@ -1007,6 +1020,11 @@ function create_ethernet_interface {
     # Query mtu value from "networks" table
     if [ -z "$_mtu" ]; then
         _mtu=`get_network_attr $xcatnet mtu`
+        if [ $? -ne 0 ]; then
+            log_warn "There is no mtu value configured in network $xcatnet from networks table."
+            _mtu=""
+        fi
+
     fi
 
     # define and bring up interface
@@ -1094,6 +1112,11 @@ function create_vlan_interface {
     # Query mtu value from "networks" table
     if [ -z "$_mtu" ]; then
         _mtu=`get_network_attr $xcatnet mtu`
+        if [ $? -ne 0 ]; then
+            log_warn "There is no mtu value configured in network $xcatnet from networks table."
+            _mtu=""
+        fi
+
     fi
 
 
@@ -1271,8 +1294,11 @@ function create_bond_interface {
     # Query mtu value from "networks" table   
     if [ -z "$_mtu" ]; then
         _mtu=`get_network_attr $xcatnet mtu`
+        if [ $? -ne 0 ]; then
+            log_warn "There is no mtu value configured in network $xcatnet from networks table."
+            _mtu=""
+        fi
     fi
- 
     ##############################
     # Create target bond interface
     # if target bond device was already exists, assume succ.


### PR DESCRIPTION
fix #3430 
Unit test:
```
[root@bybc0602 postscripts]# updatenode bybc0609 confignetwork
bybc0609: xcatdsklspost: downloaded postscripts successfully
bybc0609: Fri Jul 14 02:10:35 EDT 2017 Running postscript: confignetwork
bybc0609: [I]: All valid nics and device list:
bybc0609: [I]: bond0 eth2@eth3
bybc0609: [I]: NetworkManager is inactive.
bybc0609: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bybc0609: configure nic and its device : bond0 eth2@eth3
bybc0609: [I]: create_bond_interface ifname=bond0 slave_ports=eth2,eth3
bybc0609: [I]: Pickup xcatnet, "30_5_0_0-255_255_0_0", from NICNETWORKS for interface "bond0".
bybc0609: [W]: There is no mtu value configured in network 30_5_0_0-255_255_0_0 from networks table. -----> here is to check if there is mtu value in networks table
bybc0609: [I]: ip link set bond0 down
bybc0609: [I]: [bond.down] >> 18: bond0: <BROADCAST,MULTICAST,MASTER> mtu 1500 qdisc noop state DOWN mode DEFAULT qlen 1000
bybc0609: [I]: [bond.down] >>     link/ether 5a:6b:07:73:37:db brd ff:ff:ff:ff:ff:ff
bybc0609: [I]: [bond.slavesAft] >>
bybc0609: [I]: ip link set eth2 down
bybc0609: [I]: [slave]: >> 4: eth2: <BROADCAST,MULTICAST> mtu 1500 qdisc pfifo_fast state DOWN mode DEFAULT qlen 1000
bybc0609: [I]: [slave]: >>     link/ether 42:47:0a:05:6a:09 brd ff:ff:ff:ff:ff:ff
bybc0609: [I]: create_persistent_ifcfg ifname=eth2 inattrs=ONBOOT=yes,USERCTL=no,TYPE=Ethernet,SLAVE=yes,MASTER=bond0,BOOTPROTO=none
bybc0609: ['ifcfg-eth2']
bybc0609: [I]: >> DEVICE="eth2"
bybc0609: [I]: >> BOOTPROTO="none"
bybc0609: [I]: >> NAME="eth2"
bybc0609: [I]: >> ONBOOT="yes"
bybc0609: [I]: >> USERCTL="no"
bybc0609: [I]: >> TYPE="Ethernet"
bybc0609: [I]: >> SLAVE="yes"
bybc0609: [I]: >> MASTER="bond0"
bybc0609: [I]: ip link set eth3 down
bybc0609: [I]: [slave]: >> 5: eth3: <BROADCAST,MULTICAST> mtu 1500 qdisc pfifo_fast state DOWN mode DEFAULT qlen 1000
bybc0609: [I]: [slave]: >>     link/ether 42:82:0a:05:6a:09 brd ff:ff:ff:ff:ff:ff
bybc0609: [I]: create_persistent_ifcfg ifname=eth3 inattrs=ONBOOT=yes,USERCTL=no,TYPE=Ethernet,SLAVE=yes,MASTER=bond0,BOOTPROTO=none
bybc0609: ['ifcfg-eth3']
bybc0609: [I]: >> DEVICE="eth3"
bybc0609: [I]: >> BOOTPROTO="none"
bybc0609: [I]: >> NAME="eth3"
bybc0609: [I]: >> ONBOOT="yes"
bybc0609: [I]: >> USERCTL="no"
bybc0609: [I]: >> TYPE="Ethernet"
bybc0609: [I]: >> SLAVE="yes"
bybc0609: [I]: >> MASTER="bond0"
bybc0609: [I]: [bond.slavesNew] >> eth2 eth3
bybc0609: [I]: ip link set bond0 up
bybc0609: [I]: [ip.link] >> 18: bond0: <BROADCAST,MULTICAST,MASTER,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT qlen 1000
bybc0609: [I]: [ip.link] >>     link/ether 42:47:0a:05:6a:09 brd ff:ff:ff:ff:ff:ff
bybc0609: [I]: create_persistent_ifcfg ifname=bond0 xcatnet=30_5_0_0-255_255_0_0 inattrs=ONBOOT=yes,USERCTL=no,TYPE=Bond,BONDING_MASTER=yes,BONDING_OPTS='mode=802.3ad miimon=100',BOOTPROTO=none,DHCLIENTARGS='-timeout 200'
bybc0609: [W]: There is no mask configure in network 30_5_0_0-255_255_0_0 from networks table.      -----------> here is to check if there is mask in networks table
bybc0609: [W]: There is no mtu value configured in network 30_5_0_0-255_255_0_0 from networks table. ----------> here is to check if there is mtu in networks table
bybc0609: ['ifcfg-bond0']
bybc0609: [I]: >> DEVICE="bond0"
bybc0609: [I]: >> BOOTPROTO="none"
bybc0609: [I]: >> IPADDR="30.5.106.9"
bybc0609: [I]: >> NAME="bond0"
bybc0609: [I]: >> BONDING_MASTER="yes"
bybc0609: [I]: >> ONBOOT="yes"
bybc0609: [I]: >> USERCTL="no"
bybc0609: [I]: >> TYPE="Bond"
bybc0609: [I]: >> BONDING_OPTS="mode=802.3ad miimon=100"
bybc0609: [I]: >> DHCLIENTARGS="-timeout 200"
bybc0609: postscript: confignetwork exited with code 0
bybc0609: Running of postscripts has completed.
```
The point is 
```
... ...
bybc0609: [W]: There is no mtu value configured in network 30_5_0_0-255_255_0_0 from networks table. ----------> here is to check if there is mtu in networks table
... ...
bybc0609: [W]: There is no mask configure in network 30_5_0_0-255_255_0_0 from networks table.      -----------> here is to check if there is mask in networks table
bybc0609: [W]: There is no mtu value configured in network 30_5_0_0-255_255_0_0 from networks table. ----------> here is to check if there is mtu in networks table
... ...
```