### PR TITLE
Add new 7 test cases to hardware control bundles

### DIFF
--- a/xCAT-test/autotest/bundle/hdctrl_general.bundle
+++ b/xCAT-test/autotest/bundle/hdctrl_general.bundle
@@ -17,6 +17,7 @@ rinv_serial
 rinv_model
 rinv_firm
 rinv_all
+rinv_mixnode
 rvitals_h
 rvitals_v
 rvitals_errorcommand

--- a/xCAT-test/autotest/bundle/hdctrl_openpower_ipmi.bundle
+++ b/xCAT-test/autotest/bundle/hdctrl_openpower_ipmi.bundle
@@ -5,7 +5,12 @@ rinv_uuid
 rinv_guid
 rinv_vpd
 rinv_mprom
+rinv_wrongbmcpasswd
 rvitals_wattage
 rvitals_fanspeed
 rvitals_power
 rvitals_leds
+rpower_errorcommand_OpenpowerBmc
+rpower_softoff_OpenpowerBmc
+rpower_suspend_OpenpowerBmc
+rpower_wake_OpenpowerBmc

--- a/xCAT-test/autotest/bundle/hdctrl_openpower_openbmc.bundle
+++ b/xCAT-test/autotest/bundle/hdctrl_openpower_openbmc.bundle
@@ -5,10 +5,12 @@ rinv_uuid
 rinv_vpd
 rinv_cpu
 rinv_dimm
+rinv_wrongbmcpasswd
 rvitals_wattage
 rvitals_fanspeed
 rvitals_power
 rvitals_leds
+rvitals_altitude
 rsetboot_net_statcheck
 rsetboot_cd_statcheck
 rsetboot_default_statcheck

--- a/xCAT-test/autotest/bundle/hdctrl_ppc_hmc.bundle
+++ b/xCAT-test/autotest/bundle/hdctrl_ppc_hmc.bundle
@@ -4,4 +4,5 @@ rpower_softoff
 rpower_onstandby
 rinv_bus
 rinv_config
+rinv_wrongbmcpasswd
 rvitals_lcds


### PR DESCRIPTION
From 2.13.4sprint1 to now, 5 sprints, FVT have added 42 new cases about hardware control. 

35 cases have been added and 7 have not. Add these 7 cases this time.

The 7 cases are: 

    rinv_wrongbmcpasswd
    rinv_mixnode
    rpower_errorcommand_OpenpowerBmc
    rpower_softoff_OpenpowerBmc
    rpower_suspend_OpenpowerBmc
    rpower_wake_OpenpowerBmc
    rvitals_altitude
