### PR TITLE
rflash for Supermicro Briggs and Boston nodes

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rflash.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rflash.1.rst
@@ -11,7 +11,7 @@ Name
 ****
 
 
-\ **rflash**\  - Performs Licensed Internal Code (LIC) update support for HMC-attached POWER5 and POWER6 Systems, and POWER7 systems using Direct FSP management. \ **rflash**\  is also able to update firmware for NextScale Fan Power Controllers (FPC).
+\ **rflash**\  - Performs Licensed Internal Code (LIC) update support for HMC-attached POWER5 and POWER6 Systems, and POWER7 systems using Direct FSP management. POWER8 and POWER9 systems are also supported. \ **rflash**\  is also able to update firmware for NextScale Fan Power Controllers (FPC).
 
 
 ****************
@@ -50,7 +50,7 @@ OpenPOWER BMC specific:
 =======================
 
 
-\ **rflash**\  \ *noderange*\  \ *hpm_file_path*\  [\ **-c | -**\ **-check**\ ] [\ **-**\ **-retry=**\ \ *count*\ ] [\ **-V**\ ]
+\ **rflash**\  \ *noderange*\  [\ *hpm_file_path*\  | \ **-d=**\ \ *data_directory] [\ \*\*-c\*\*\ |\ \*\*-**\ **-check\*\*\ ] [\ \*\*-**\ **-retry=\*\*\ \ \*count\*\ ] [\ \*\*-V\*\*\ ]*\ 
 
 
 
@@ -122,7 +122,8 @@ OpenPOWER specific:
 ===================
 
 
-The command will update firmware for OpenPOWER BMC when given an OpenPOWER node and the hpm1 formatted file path.
+The command will update firmware for OpenPOWER BMC when given an OpenPOWER node and either the hpm formatted file path or path to a data directory.
+\ **Note:**\  When using \ **rflash**\  in hierarchical environment, the hpm file or data directory must be accessible from Service Nodes. Shared storage can be used to accomplish that, alternatively the hpm file or contents of the data directory can be copied to Service Nodes.
 
 
 
@@ -153,6 +154,12 @@ The command will update firmware for OpenPOWER BMC when given an OpenPOWER node 
 \ **-d**\  \ *data_directory*\ 
  
  Specifies the directory where the raw data from rpm packages for each CEC/Frame are located. The default directory is /tmp. The option is only used in Direct FSP/BPA Management.
+ 
+
+
+\ **-d=**\ \ *data_directory*\ 
+ 
+ Used for Supermicro systems only. Specifies the directory where the \ **pUpdate**\  utility and at least one of BMC or PNOR update files are located. The utility and update files can be downloaded from FixCentral.
  
 
 
@@ -263,6 +270,16 @@ The command will update firmware for OpenPOWER BMC when given an OpenPOWER node 
  .. code-block:: perl
  
    rflash fs3 /firmware/8335_810.1543.20151021b_update.hpm -V
+ 
+ 
+
+
+6. To update the firmware on OpenPOWER Supermicro machine specify the node name and the file path of the data directory containing pUpdate utility and BMC and/or PNOR update files:
+ 
+ 
+ .. code-block:: perl
+ 
+   rflash briggs01 -d=/root/supermicro/OP825
  
  
 

--- a/docs/source/guides/admin-guides/references/man1/rflash.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rflash.1.rst
@@ -11,7 +11,7 @@ Name
 ****
 
 
-\ **rflash**\  - Performs Licensed Internal Code (LIC) update support for HMC-attached POWER5 and POWER6 Systems, and POWER7 systems using Direct FSP management. POWER8 and POWER9 systems are also supported. \ **rflash**\  is also able to update firmware for NextScale Fan Power Controllers (FPC).
+\ **rflash**\  - Performs Licensed Internal Code (LIC) update or firmware update on supported xCAT managed nodes.
 
 
 ****************
@@ -50,7 +50,7 @@ OpenPOWER BMC specific:
 =======================
 
 
-\ **rflash**\  \ *noderange*\  [\ *hpm_file_path*\  | \ **-d=**\ \ *data_directory] [\ \*\*-c\*\*\ |\ \*\*-**\ **-check\*\*\ ] [\ \*\*-**\ **-retry=\*\*\ \ \*count\*\ ] [\ \*\*-V\*\*\ ]*\ 
+\ **rflash**\  \ *noderange*\  [\ *hpm_file_path*\  | \ **-d=**\ \ *data_directory*\ ] [\ **-c | -**\ **-check**\ ] [\ **-**\ **-retry=**\ \ *count*\ ] [\ **-V**\ ]
 
 
 
@@ -123,7 +123,7 @@ OpenPOWER specific:
 
 
 The command will update firmware for OpenPOWER BMC when given an OpenPOWER node and either the hpm formatted file path or path to a data directory.
-\ **Note:**\  When using \ **rflash**\  in hierarchical environment, the hpm file or data directory must be accessible from Service Nodes. Shared storage can be used to accomplish that, alternatively the hpm file or contents of the data directory can be copied to Service Nodes.
+\ **Note:**\  When using \ **rflash**\  in hierarchical environment, the hpm file or data directory must be accessible from Service Nodes.
 
 
 
@@ -159,7 +159,7 @@ The command will update firmware for OpenPOWER BMC when given an OpenPOWER node 
 
 \ **-d=**\ \ *data_directory*\ 
  
- Used for Supermicro systems only. Specifies the directory where the \ **pUpdate**\  utility and at least one of BMC or PNOR update files are located. The utility and update files can be downloaded from FixCentral.
+ Used for IBM Power S822LC for Big Data systems only. Specifies the directory where the \ **pUpdate**\  utility and at least one of BMC or PNOR update files are located. The utility and update files can be downloaded from FixCentral.
  
 
 
@@ -274,7 +274,7 @@ The command will update firmware for OpenPOWER BMC when given an OpenPOWER node 
  
 
 
-6. To update the firmware on OpenPOWER Supermicro machine specify the node name and the file path of the data directory containing pUpdate utility and BMC and/or PNOR update files:
+6. To update the firmware on IBM Power S822LC for Big Data machine specify the node name and the file path of the data directory containing pUpdate utility and BMC and/or PNOR update files:
  
  
  .. code-block:: perl

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -340,7 +340,7 @@ my %usage = (
 	rflash <noderange> [--commit | --recover] [-V|--verbose]
         rflash <noderange> [--bpa_acdl]
     PPC64LE (using BMC Management) specific:
-        rflash <noderange> [-c | --check] [--retry=<count>] [-V] <hpm_file>",
+        rflash <noderange> [-c | --check] [--retry=<count>] [-V] [<hpm_file>|-d=<data_directory>]",
     "mkhwconn" =>
       "Usage:
     mkhwconn [-h|--help]

--- a/xCAT-client/pods/man1/rflash.1.pod
+++ b/xCAT-client/pods/man1/rflash.1.pod
@@ -1,6 +1,6 @@
 =head1 Name
 
-B<rflash> - Performs Licensed Internal Code (LIC) update support for HMC-attached POWER5 and POWER6 Systems, and POWER7 systems using Direct FSP management. POWER8 and POWER9 systems are also supported. B<rflash> is also able to update firmware for NextScale Fan Power Controllers (FPC).
+B<rflash> - Performs Licensed Internal Code (LIC) update or firmware update on supported xCAT managed nodes.
 
 =head1 B<Synopsis>
 
@@ -82,7 +82,7 @@ The command will update firmware for NeXtScale FPC when given an FPC node and th
 =head2 OpenPOWER specific:
 
 The command will update firmware for OpenPOWER BMC when given an OpenPOWER node and either the hpm formatted file path or path to a data directory.
-B<Note:> When using B<rflash> in hierarchical environment, the hpm file or data directory must be accessible from Service Nodes. Shared storage can be used to accomplish that, alternatively the hpm file or contents of the data directory can be copied to Service Nodes.
+B<Note:> When using B<rflash> in hierarchical environment, the hpm file or data directory must be accessible from Service Nodes.
 
 =head1 B<Options>
 
@@ -106,7 +106,7 @@ Specifies the directory where the raw data from rpm packages for each CEC/Frame 
 
 =item B<-d=>I<data_directory>
 
-Used for Supermicro systems only. Specifies the directory where the B<pUpdate> utility and at least one of BMC or PNOR update files are located. The utility and update files can be downloaded from FixCentral. 
+Used for IBM Power S822LC for Big Data systems only. Specifies the directory where the B<pUpdate> utility and at least one of BMC or PNOR update files are located. The utility and update files can be downloaded from FixCentral. 
 
 =item B<--activate> {B<concurrent> | B<disruptive>}
 
@@ -174,7 +174,7 @@ Print verbose message to rflash log file (/var/log/xcat/rflash/fs3.log) when upd
  rflash fs3 /firmware/8335_810.1543.20151021b_update.hpm -V
 
 =item 6.
-To update the firmware on OpenPOWER Supermicro machine specify the node name and the file path of the data directory containing pUpdate utility and BMC and/or PNOR update files:
+To update the firmware on IBM Power S822LC for Big Data machine specify the node name and the file path of the data directory containing pUpdate utility and BMC and/or PNOR update files:
 
  rflash briggs01 -d=/root/supermicro/OP825
 

--- a/xCAT-client/pods/man1/rflash.1.pod
+++ b/xCAT-client/pods/man1/rflash.1.pod
@@ -1,6 +1,6 @@
 =head1 Name
 
-B<rflash> - Performs Licensed Internal Code (LIC) update support for HMC-attached POWER5 and POWER6 Systems, and POWER7 systems using Direct FSP management. B<rflash> is also able to update firmware for NextScale Fan Power Controllers (FPC).
+B<rflash> - Performs Licensed Internal Code (LIC) update support for HMC-attached POWER5 and POWER6 Systems, and POWER7 systems using Direct FSP management. POWER8 and POWER9 systems are also supported. B<rflash> is also able to update firmware for NextScale Fan Power Controllers (FPC).
 
 =head1 B<Synopsis>
 
@@ -24,7 +24,7 @@ B<rflash> I<noderange> I<http_directory>
 
 =head2 OpenPOWER BMC specific:
 
-B<rflash> I<noderange> I<hpm_file_path> [B<-c>|B<--check>] [B<--retry=>I<count>] [B<-V>]
+B<rflash> I<noderange> [I<hpm_file_path> | B<-d=>I<data_directory>] [B<-c>|B<--check>] [B<--retry=>I<count>] [B<-V>]
 
 =head1 B<Description>
 
@@ -37,6 +37,7 @@ The POWER5  and POWER6 systems contain several components that use Licensed Inte
 The I<noderange> can be an CEC or CEC list, a Lpar or Lpar list and a Frame or Frame list. But CEC (or Lpar) and Frame B<can't> be used at the same time. When the I<noderange> is an CEC or CEC list, B<rflash> will upgrade the firmware of the CEC or CECs in the cec list. If I<noderange> is a Lpar or Lpar list, B<rflash> will update Licensed Internal Code (LIC) on  HMC-attached POWER5 and POWER6 pSeries nodes, and POWER7 systems using Direct FSP management.  If I<noderange> is a Frame or Frame list, B<rflash> will update Licensed Internal Code (LIC) of the power subsystem on  HMC-attached POWER5 and POWER6 pSeries nodes. The I<noderange> can also be the specified node groups. You  can  specify a  comma or space-separated list of node group ranges. See the I<noderange>  man  page  for  detailed usage information. 
 
 The command will update firmware for NeXtScale FPC when given an FPC node and the http information needed to access the firmware. 
+
 
 =head2 PPC (with HMC) specific:
 
@@ -80,7 +81,8 @@ The command will update firmware for NeXtScale FPC when given an FPC node and th
 
 =head2 OpenPOWER specific:
 
-The command will update firmware for OpenPOWER BMC when given an OpenPOWER node and the hpm1 formatted file path.
+The command will update firmware for OpenPOWER BMC when given an OpenPOWER node and either the hpm formatted file path or path to a data directory.
+B<Note:> When using B<rflash> in hierarchical environment, the hpm file or data directory must be accessible from Service Nodes. Shared storage can be used to accomplish that, alternatively the hpm file or contents of the data directory can be copied to Service Nodes.
 
 =head1 B<Options>
 
@@ -101,6 +103,10 @@ Specifies the directory where the packages are located.
 =item B<-d> I<data_directory>
 
 Specifies the directory where the raw data from rpm packages for each CEC/Frame are located. The default directory is /tmp. The option is only used in Direct FSP/BPA Management. 
+
+=item B<-d=>I<data_directory>
+
+Used for Supermicro systems only. Specifies the directory where the B<pUpdate> utility and at least one of BMC or PNOR update files are located. The utility and update files can be downloaded from FixCentral. 
 
 =item B<--activate> {B<concurrent> | B<disruptive>}
 
@@ -166,6 +172,11 @@ To update the firmware on OpenPOWER machine specify the node name and the file p
 Print verbose message to rflash log file (/var/log/xcat/rflash/fs3.log) when updading firmware:
 
  rflash fs3 /firmware/8335_810.1543.20151021b_update.hpm -V
+
+=item 6.
+To update the firmware on OpenPOWER Supermicro machine specify the node name and the file path of the data directory containing pUpdate utility and BMC and/or PNOR update files:
+
+ rflash briggs01 -d=/root/supermicro/OP825
 
 =back
 

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -1613,7 +1613,7 @@ sub isopenpower {
         # mft_id 0 and prod_id 43707 is for Firestone,Minsky
         return 1;
     } elsif (($sessdata->{prod_id} == 0 or $sessdata->{prod_id} == 2355) and $sessdata->{mfg_id} == 10876) {
-        # mfg_id 10876 is for Supermicro, prod_id 2355 for B&S, and 0 for Boston
+        # mfg_id 10876 is for IBM Power S822LC for Big Data (Supermicro), prod_id 2355 for B&S, and 0 for Boston
         return 1;
     } else {
         return 0;
@@ -1953,7 +1953,7 @@ sub do_firmware_update {
         }
     }
 
-    # For Supermicro machines such as P9 Boston (9006-22C) or P8 Briggs (8001-22C) 
+    # For IBM Power S822LC for Big Data (Supermicro) machines such as P9 Boston (9006-22C) or P8 Briggs (8001-22C) 
     # firmware update is done using pUpdate utility expected to be in the 
     # specified data directory along with the update files .bin for BMC or .pnor for Host
     if ($output =~ /8001-22C|9006-22C/) {


### PR DESCRIPTION
This pull request implements issue #3421 

1. `rflash` command for supermicro nodes uses `pUpdate` utility
2. Updates to usage and man pages

Some output examples:

1. Invalid data directory:
```
[root@stratton01 xcat]# rflash briggs01 -d=/testme
Error: briggs01: Can not access data directory /testme
[root@stratton01 xcat]#
```

2. Data directory does not contain pUpdate utility:
```
[root@stratton01 xcat]# rflash briggs01 -d=/tmp/gurevich
Error: briggs01: Can not find executable pUpdate utility in data directory /tmp/gurevich.
[root@stratton01 xcat]#
```

3. Data directory contains more than 1 update file:
```
[root@stratton01 xcat]# rflash briggs01 -d=/root/supermicro/OP825 -V
Error: briggs01: Multiple BMC update files detected in data directory /root/supermicro/OP825.
[root@stratton01 xcat]#
```

4. Data directory contains pUpdate utility but no update files:
```
[root@stratton01 xcat]# rflash briggs01 -d=/tmp/gurevich
Error: briggs01: At least one update file (.bin or .pnor) needs to be in data directory /tmp/gurevich.
[root@stratton01 xcat]#
```

5. Successful verbose update. Lines displayed for verbose flag are marked with (V):
```
[root@stratton01 xcat]# rflash briggs01 -d=/root/supermicro/OP825 -V
briggs01: rflash started, Please wait...
briggs01: rflashing BMC, see the detail progress : "tail -f /var/log/xcat/rflash/briggs01.log" (V)
briggs01: Waiting for BMC to reboot (2 min)... (V)
briggs01: rflashing PNOR, see the detail progress : "tail -f /var/log/xcat/rflash/briggs01.log" (V)
briggs01: Firmware updated
[root@stratton01 xcat]#
``` 