### PR TITLE
fix issue 3297: rinstall could not set runcmd and runimg's currchain

### DIFF
--- a/xCAT-server/lib/xcat/plugins/rinstall.pm
+++ b/xCAT-server/lib/xcat/plugins/rinstall.pm
@@ -132,9 +132,6 @@ sub rinstall {
         else {
             unless ($state =~ /-/) {
                 $STATES = $state;
-                if ($RESTSTATES) {
-                    $STATES .= ",$RESTSTATES";
-                }
             }
         }
 
@@ -265,6 +262,9 @@ sub rinstall {
     }
     elsif ($STATES) {
         push @parameter, "$STATES";
+        if ($RESTSTATES) {
+            $parameter[-1] .= ",$RESTSTATES";
+        }
     }
     else {
 

--- a/xCAT-server/lib/xcat/plugins/rinstall.pm
+++ b/xCAT-server/lib/xcat/plugins/rinstall.pm
@@ -69,6 +69,7 @@ sub rinstall {
     my $CONSOLE;
     my $OSIMAGE;
     my $STATES;
+    my $RESTSTATES;
     my $ignorekernelchk;
     my $VERBOSE;
     my $HELP;
@@ -108,8 +109,7 @@ sub rinstall {
         }
 
         my $state = $ARGV[0];
-        my $reststates;
-        ($state, $reststates) = split(/,/, $state, 2);
+        ($state, $RESTSTATES) = split(/,/, $state, 2);
         chomp($state);
         if ($state eq "image" or $state eq "winshell" or $state =~ /^osimage/) {
             my $target;
@@ -132,6 +132,9 @@ sub rinstall {
         else {
             unless ($state =~ /-/) {
                 $STATES = $state;
+                if ($RESTSTATES) {
+                    $STATES .= ",$RESTSTATES";
+                }
             }
         }
 
@@ -251,7 +254,11 @@ sub rinstall {
         #only provision the normal nodes
         @nodes = @validnodes;
 
-        push @parameter, "osimage=$OSIMAGE";
+        if ($RESTSTATES) {
+            push @parameter, "osimage=$OSIMAGE,$RESTSTATES";
+        } else {
+            push @parameter, "osimage=$OSIMAGE";
+        }
         if ($ignorekernelchk) {
             push @parameter, " --ignorekernelchk";
         }
@@ -310,8 +317,10 @@ sub rinstall {
 
         #only provision the normal nodes
         @nodes = @validnodes;
-
         push @parameter, "osimage";
+        if ($RESTSTATES) {
+            $parameter[-1] .= ",$RESTSTATES";
+        }
     }
 
     if (scalar(@nodes) == 0) {


### PR DESCRIPTION
Fix issue #3297 

```
root@c910f03c05k10:/tmp# tabdump chain | grep cn1
"cn1",,,,,,
root@c910f03c05k10:/tmp# rinstall cn1 shell,runcmd=runcmd,osimage=rhels7.3-ppc64le-install-compute
Provision node(s): cn1
...
root@c910f03c05k10:/tmp# tabdump chain | grep cn1
"cn1","shell","runcmd=runcmd,osimage=rhels7.3-ppc64le-install-compute",,,,
```