### PR TITLE
fix issue 3490: "rscan <hmc> -w" will delete ip attribute of node whi…

### DIFF
--- a/perl-xCAT/xCAT/PPCdb.pm
+++ b/perl-xCAT/xCAT/PPCdb.pm
@@ -217,14 +217,16 @@ sub add_ppc {
         ###############################
         # Update hosts table
         ###############################
-        if ($otherinterfaces) {
-            $db{hosts}->setNodeAttribs($name,
-                { otherinterfaces => $ips });
-        } else {
-            $db{hosts}->setNodeAttribs($name,
-                { ip => $ips });
+        if ($ips) {
+            if ($otherinterfaces) {
+                $db{hosts}->setNodeAttribs($name,
+                    { otherinterfaces => $ips });
+            } else {
+                $db{hosts}->setNodeAttribs($name,
+                    { ip => $ips });
+            }
+            $db{hosts}{commit} = 1;
         }
-        $db{hosts}{commit} = 1;
 
         ###############################
         # Update mac table


### PR DESCRIPTION
Fix issue #3490 

```
[root@c910f02c01p13 xcat]# lsdef c910f02c01p07 -i ip -c
c910f02c01p07: ip=10.2.1.7
[root@c910f02c01p13 xcat]# rscan c910hmc01 -w
type    name           id      type-model  serial-number  side
cec     50.3.5.1               8286-42A    101102V
cec     50.5.11.101            7895-42X    102019B
cec     50.5.11.103            7895-42X    10201AB
cec     50.5.11.105            7895-42X    10201DB
....
[root@c910f02c01p13 xcat]# lsdef c910f02c01p07 -i ip -c
c910f02c01p07: ip=10.2.1.7
```