### PR TITLE
enhance confignetwork integrate configib

### DIFF
--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -79,12 +79,15 @@ function get_nic_cfg_file_content {
 #
 #####################################################################
 boot_install_nic=0
+str_ib_nics=''
+num_iba_ports=
 for arg in "$@"
 do
     if [ "$arg" = "-s" ];then
         boot_install_nic=1
+    elif [ "${arg:0:10}" = "--ibaports" ];then
+        num_iba_ports=${arg#--ibaports=}
     fi
-    #TODO: IB support is TBD
 done
 if [ "$SETINSTALLNIC" = "1" ] || [ "$SETINSTALLNIC" = "yes" ]; then
     bool_install_nic=1
@@ -179,7 +182,7 @@ function find_nic_type {
     if [ ! "$1" ];then
         return
     fi
-    nic=$1
+    nic=$1 
     echo $(hashget "nictypes" $nic)
 }
 
@@ -296,6 +299,7 @@ function sort_nics_device_order {
     eth_slot=""
     bond_slot=""
     vlan_slot=""
+    ib_slots=""
     num=1
     alone_nics=`echo "$all_nics_list"|awk '{if(0<NF&&NF<2) print $0}'`
     nics_list=`echo "$all_nics_list"|awk '{if(NF>1) print $0}'`
@@ -313,11 +317,20 @@ function sort_nics_device_order {
             #pre-check nicips nictype nicnetworks for alone nic
             #nicips nictype and nicnetworks should be configured in nics table for alone nic
             alonenicips=`find_nic_ips $alonenic`
-            alonenictype=`find_nic_type $alonenic`
+            alonenictype=`find_nic_type $alonenic | $utolcmd`
             alonenicnetwork=`query_nicnetworks_net $alonenic`
+            #if alone nic configure nicips, it is valid
             if [ -n "$alonenicips" ] && [ -n "$alonenictype" ] && [ -n "$alonenicnetwork" ]; then
-                #if alone nic configure nicips, it is valid 
-                echo $alonenic
+                #if alone nic is ib type, append all ib nics in ib_slots
+                if [ x"$alonenictype" = "xinfiniband" ]; then
+                    if [ -z $ib_slots ]; then
+                        ib_slots=$alonenic
+                    else
+                        ib_slots=$ib_slots,$alonenic
+                    fi
+                else
+                    echo $alonenic
+                fi
             else
                 errorcode=1
                 echo "Error: nicips,nictypes and nicnetworks should be configured in nics table for $alonenic."
@@ -327,7 +340,11 @@ function sort_nics_device_order {
         fi
         ((num1+=1))
     done
-    
+    #get all ib nics, format is ib0,ib1,...
+    if [ -n "$ib_slots" ]; then
+        echo "$ib_slots"
+    fi   
+ 
     if [ -n "$nics_list" ]; then
       if [ $is_redhat -eq 1 ]; then  
         num=1
@@ -426,6 +443,7 @@ function configure_nicdevice {
     base_temp_nic=""
     base_nic_for_bond=""
     line_num=""
+    custom_configured=0
     noip=1
     ((max+=1))
     while [ $num -lt $max ];
@@ -437,26 +455,34 @@ function configure_nicdevice {
             ((num+=1))
             continue
         fi
-        #processing custom scripts for nic
-        customcmd=`find_nic_custom_scripts $nic_dev`
-        customscript=`echo $customcmd|awk '{print $1}'`
-        if [ -n "$customscript" ]; then
-            if [ -f "/install/postscript/$customscript" ]; then
-                #if there is no custom script in /install/postscript,exit this loop
-                log_error "/install/postscript/$customscript does not exist."
-                errorcode=1
-                ((num+=1))
-                continue
-            fi
-            echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
-            log_info "processing custom scripts:\"$customcmd\"  for interface $nic_dev"
-            $customcmd
-            if [ $? -ne 0 ]; then
-                errorcode=1
+        #All IB devices are in one string format as "ib0,ib1,..." in $nic_dev
+        #Find customcmd and customscript for each sub-nic device
+        for subdev in `echo $nic_dev|sed 's/,/\n/g'`
+        do
+            #processing custom scripts for nic
+            customcmd=`find_nic_custom_scripts $subdev`
+            customscript=`echo $customcmd|awk '{print $1}'`
+            if [ -n "$customscript" ]; then
+                custom_configured=1
+                if [ -f "/install/postscript/$customscript" ]; then
+                    #if there is no custom script in /install/postscript,exit this loop
+                    log_error "/install/postscript/$customscript does not exist."
+                    errorcode=1
+                    continue
+                fi
+                echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+                log_info "processing custom scripts:\"$customcmd\"  for interface $subdev"
+                $customcmd
+                if [ $? -ne 0 ]; then
+                    errorcode=1
+                fi
             fi
 
-            #if custom script is finished, go to configure next nic/nic_pair
+        done
+        #If the $nic_dev is costom configured, go to configure next nic/nic_pair
+        if [ $custom_configured -eq 1 ]; then
             ((num+=1))
+            custom_configured=0
             continue
         fi
         #get base nic and its type
@@ -471,7 +497,9 @@ function configure_nicdevice {
         
             base_nic_type=`find_nic_type "$base_temp_nic" | $utolcmd`
         fi
-        nic_dev_type=`find_nic_type "$nic_dev" | $utolcmd`
+        #if there is ib nics
+        first_nic_dev=`echo "$nic_dev"|awk -F, '{print $1}'`
+        nic_dev_type=`find_nic_type "$first_nic_dev" | $utolcmd`
         echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
         nic_pair=`echo "$nics_pair" |sed -n "${num}p"`
         echo "configure nic and its device : $nic_pair"
@@ -519,7 +547,13 @@ function configure_nicdevice {
         elif [ x"$nic_dev_type" = "xbond" ]; then
             create_bond_interface ifname=$nic_dev slave_ports=$base_nic_for_bond       
         elif [ x"$nic_dev_type" = "xinfiniband" ]; then
-            log_error "confignetwork does not support configure IB. "
+            log_info "Call configib for IB nics: $nic_dev, ports: $num_iba_ports"
+            log_info "NIC_IBNICS=$nic_dev NIC_IBAPORTS=$num_iba_ports configib"
+            NIC_IBNICS=$nic_dev NIC_IBAPORTS=$num_iba_ports configib
+            if [ $? -ne 0 ]; then
+                log_error "configib failed."
+                errorcode=1
+            fi
         else
             log_error "Error : please check nic data in nics table."
             errorcode=1


### PR DESCRIPTION
`confignetwork` Integrate `configib` the same as `confignics` #3072 

Unit test, compare confignetwork output with confignics output using the same nics table data:
nics table:
```
]# lsdef bybc0609 |sed 's/    //g'|grep ^nic
niccustomscripts.br0=testbr br0
nicdevices.bond0=eth2|eth3
nicips.ib0=30.1.1.9|20.0.0.3|1:2::3|2:2::3
nicips.ib1=40.1.1.9
nicips.bond0=30.5.106.9
nicips.eth1=30.0.0.9
nicips.br0=30.0.1.9
nicnetworks.bond0=30_0_0_0-255_0_0_0
nicnetworks.ib0=30_0_0_0-255_0_0_0|ib0ipv41|ib0ipv61|ib0ipv62
nicnetworks.ib1=40_0_0_0-255_0_0_0
nicnetworks.eth1=30_0_0_0-255_0_0_0
nicnetworks.br0=30_0_0_0-255_0_0_0
nictypes.ib0=infiniband
nictypes.ib1=infiniband
nictypes.eth2=ethernet
nictypes.bond0=bond
nictypes.eth3=ethernet
nictypes.eth1=ethernet
nictypes.br0=bridge
```
The old way in confignics, confignics can configure ethernet and IB, run custom script testbr:
```
s]# updatenode bybc0609 -P "confignics --ibaports=2"
bybc0609: xcatdsklspost: downloaded postscripts successfully
bybc0609: Wed Jul 19 02:02:04 EDT 2017 Running postscript: confignics
bybc0609: confignics on bybc0609: config install nic:0, remove: 0, iba ports: 2
bybc0609: ib0!30.1.1.9|20.0.0.3|1:2::3|2:2::3
bybc0609: ib1!40.1.1.9
bybc0609: bond0!30.5.106.9
bybc0609: eth1!30.0.0.9
bybc0609: br0!30.0.1.9
bybc0609: br0!testbr br0
bybc0609: confignics on bybc0609: unknown nic type for bond0: 30.5.106.9 .
bybc0609: confignics on bybc0609: call 'configeth eth1 30.0.0.9 30_0_0_0-255_0_0_0|'
bybc0609: [I]: configeth on bybc0609: os type: redhat
bybc0609: configeth on bybc0609: old configuration: 3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
bybc0609:     link/ether 42:aa:0a:05:6a:09 brd ff:ff:ff:ff:ff:ff
bybc0609:     inet 30.0.0.9/8 brd 30.255.255.255 scope global eth1
bybc0609:        valid_lft forever preferred_lft forever
bybc0609:     inet6 fe80::40aa:aff:fe05:6a09/64 scope link
bybc0609:        valid_lft forever preferred_lft forever
bybc0609: [I]: configeth on bybc0609: new configuration
bybc0609:        30.0.0.9, 30.0.0.0, 255.0.0.0, <xcatmaster>
bybc0609: 3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP mode DEFAULT qlen 1000
bybc0609: eth1
bybc0609: [W]: configeth on bybc0609: eth1 no changed, return directly.
bybc0609: confignics on bybc0609: processing custom scripts: testbr br0 for interface br0
bybc0609: This is test script to test niccustomscripts for br0
bybc0609: confignics on bybc0609: executed script: configib for nics: ib0,ib1, ports: 2
bybc0609: postscript: confignics exited with code 1
bybc0609: Running of postscripts has completed.
```
The new way in confignetwork, confignetwork can configure ethernet, bond, IB and run custom script testbr:
```
]# updatenode bybc0609 -P "confignetwork --ibaports=2"
bybc0609: xcatdsklspost: downloaded postscripts successfully
bybc0609: Wed Jul 19 02:31:19 EDT 2017 Running postscript: confignetwork
bybc0609: [I]: All valid nics and device list:
bybc0609: [I]: br0
bybc0609: [I]: eth1
bybc0609: [I]: ib0,ib1
bybc0609: [I]: bond0 eth2@eth3
bybc0609: [I]: NetworkManager is inactive.
bybc0609: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bybc0609: [I]: processing custom scripts:"testbr br0"  for interface br0
bybc0609: This is test script to test niccustomscripts for br0
bybc0609: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bybc0609: configure nic and its device : eth1
bybc0609: [I]: configure eth1
bybc0609: [I]: call: configeth eth1 30.0.0.9 30_0_0_0-255_0_0_0
bybc0609: [I]: configeth on bybc0609: os type: redhat
bybc0609: configeth on bybc0609: old configuration: 3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
bybc0609:     link/ether 42:aa:0a:05:6a:09 brd ff:ff:ff:ff:ff:ff
bybc0609:     inet 30.0.0.9/8 brd 30.255.255.255 scope global eth1
bybc0609:        valid_lft forever preferred_lft forever
bybc0609:     inet6 fe80::40aa:aff:fe05:6a09/64 scope link
bybc0609:        valid_lft forever preferred_lft forever
bybc0609: [I]: configeth on bybc0609: new configuration
bybc0609:        30.0.0.9, 30.0.0.0, 255.0.0.0, <xcatmaster>
bybc0609: 3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP mode DEFAULT qlen 1000
bybc0609: eth1
bybc0609: [W]: configeth on bybc0609: eth1 no changed, return directly.
bybc0609: ['/etc/sysconfig/network-scripts/ifcfg-eth1']
bybc0609: [I]: >> DEVICE=eth1
bybc0609: [I]: >> BOOTPROTO=static
bybc0609: [I]: >> NM_CONTROLLED=no
bybc0609: [I]: >> IPADDR=30.0.0.9
bybc0609: [I]: >> NETMASK=255.0.0.0
bybc0609: [I]: >> ONBOOT=yes
bybc0609: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bybc0609: configure nic and its device : ib0,ib1
bybc0609: [I]: Call configib for IB nics: ib0,ib1, ports: 2
bybc0609: [I]: NIC_IBNICS=ib0,ib1 NIC_IBAPORTS=2 configib
bybc0609: [E]: configib failed.
bybc0609: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bybc0609: configure nic and its device : bond0 eth2@eth3
bybc0609: [I]: create_bond_interface ifname=bond0 slave_ports=eth2,eth3
bybc0609: [I]: Pickup xcatnet, "30_0_0_0-255_0_0_0", from NICNETWORKS for interface "bond0".
bybc0609: [I]: ip link set bond0 down
bybc0609: [I]: [bond.down] >> 37: bond0: <BROADCAST,MULTICAST,MASTER> mtu 1500 qdisc noop state DOWN mode DEFAULT qlen 1000
bybc0609: [I]: [bond.down] >>     link/ether d2:d9:f6:66:0d:a7 brd ff:ff:ff:ff:ff:ff
bybc0609: [I]: [bond.slavesAft] >>
bybc0609: [I]: ip link set eth2 down
bybc0609: [I]: [slave]: >> 4: eth2: <BROADCAST,MULTICAST> mtu 1500 qdisc pfifo_fast state DOWN mode DEFAULT qlen 1000
bybc0609: [I]: [slave]: >>     link/ether 42:47:0a:05:6a:09 brd ff:ff:ff:ff:ff:ff
bybc0609: [I]: create_persistent_ifcfg ifname=eth2 inattrs=ONBOOT=yes,USERCTL=no,TYPE=Ethernet,SLAVE=yes,MASTER=bond0,BOOTPROTO=none
bybc0609: ['ifcfg-eth2']
bybc0609: [I]: >> DEVICE="eth2"
bybc0609: [I]: >> BOOTPROTO="none"
bybc0609: [I]: >> NAME="eth2"
bybc0609: [I]: >> ONBOOT="yes"
bybc0609: [I]: >> USERCTL="no"
bybc0609: [I]: >> TYPE="Ethernet"
bybc0609: [I]: >> SLAVE="yes"
bybc0609: [I]: >> MASTER="bond0"
bybc0609: [I]: ip link set eth3 down
bybc0609: [I]: [slave]: >> 5: eth3: <BROADCAST,MULTICAST> mtu 1500 qdisc pfifo_fast state DOWN mode DEFAULT qlen 1000
bybc0609: [I]: [slave]: >>     link/ether 42:82:0a:05:6a:09 brd ff:ff:ff:ff:ff:ff
bybc0609: [I]: create_persistent_ifcfg ifname=eth3 inattrs=ONBOOT=yes,USERCTL=no,TYPE=Ethernet,SLAVE=yes,MASTER=bond0,BOOTPROTO=none
bybc0609: ['ifcfg-eth3']
bybc0609: [I]: >> DEVICE="eth3"
bybc0609: [I]: >> BOOTPROTO="none"
bybc0609: [I]: >> NAME="eth3"
bybc0609: [I]: >> ONBOOT="yes"
bybc0609: [I]: >> USERCTL="no"
bybc0609: [I]: >> TYPE="Ethernet"
bybc0609: [I]: >> SLAVE="yes"
bybc0609: [I]: >> MASTER="bond0"
bybc0609: [I]: [bond.slavesNew] >> eth2 eth3
bybc0609: [I]: ip link set bond0 up
bybc0609: [I]: [ip.link] >> 37: bond0: <BROADCAST,MULTICAST,MASTER,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT qlen 1000
bybc0609: [I]: [ip.link] >>     link/ether 42:47:0a:05:6a:09 brd ff:ff:ff:ff:ff:ff
bybc0609: [I]: create_persistent_ifcfg ifname=bond0 xcatnet=30_0_0_0-255_0_0_0 inattrs=ONBOOT=yes,USERCTL=no,TYPE=Bond,BONDING_MASTER=yes,BONDING_OPTS='mode=802.3ad miimon=100',BOOTPROTO=none,DHCLIENTARGS='-timeout 200'
bybc0609: ['ifcfg-bond0']
bybc0609: [I]: >> DEVICE="bond0"
bybc0609: [I]: >> BOOTPROTO="none"
bybc0609: [I]: >> IPADDR="30.0.1.9"
bybc0609: [I]: >> NETMASK="255.0.0.0"
bybc0609: [I]: >> NAME="bond0"
bybc0609: [I]: >> BONDING_MASTER="yes"
bybc0609: [I]: >> ONBOOT="yes"
bybc0609: [I]: >> USERCTL="no"
bybc0609: [I]: >> TYPE="Bond"
bybc0609: [I]: >> BONDING_OPTS="mode=802.3ad miimon=100"
bybc0609: [I]: >> DHCLIENTARGS="-timeout 200"
bybc0609: postscript: confignetwork exited with code 1
bybc0609: Running of postscripts has completed.
[root@bybc0602 postscripts]#
```
