### PR TITLE
fix 3496, depends on xcatdebugmode to print debug msg

### DIFF
--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -118,7 +118,7 @@ my %usage = (
     pdu specific:
        rinv noderange ",
     "rsetboot" =>
-"Usage: rsetboot <noderange> [net|hd|cd|floppy|def|stat] [-V|--verbose] [-u] [-p]
+"Usage: rsetboot <noderange> [net|hd|cd|floppy|def|stat] [-u] [-p]
        rsetboot [-h|--help|-v|--version]",
     "rbootseq" =>
       "Usage: 

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -485,7 +485,7 @@ sub parse_args {
 
     if (scalar(@ARGV) >= 2 and ($command =~ /rpower|rinv|rsetboot|rvitals/)) {
         return ([ 1, "Only one option is supported at the same time for $command" ]);
-    } elsif (scalar(@ARGV) == 0 and $command =~ /rpower|rsetboot|rspconfig|rflash/) {
+    } elsif (scalar(@ARGV) == 0 and $command =~ /rpower|rspconfig|rflash/) {
         return ([ 1, "No option specified for $command" ]);
     } else { 
         $subcommand = $ARGV[0];
@@ -511,10 +511,15 @@ sub parse_args {
         # disable function until fully tested
         #
         $check = unsupported($callback); if (ref($check) eq "ARRAY") { return $check; }
+        $subcommand = "stat" if (!defined($ARGV[0]));
         unless ($subcommand =~ /^net$|^hd$|^cd$|^def$|^default$|^stat$/) {
             return ([ 1, "Unsupported command: $command $subcommand" ]);
         }
     } elsif ($command eq "reventlog") {
+        #
+        # disable function until fully tested
+        #
+        $check = unsupported($callback); if (ref($check) eq "ARRAY") { return $check; }
         my $option_s = 0;
         unless (GetOptions("s" => \$option_s,)) {
             return ([1, "Error parsing arguments." ]);


### PR DESCRIPTION
#3496
1. If ``xcatdebugmode`` is ``1`` or ``2``, will print debug msg.
```
[root@fs3 ~]# rpower mid05tor12cn02 stat
[OpenBMC development support] Using this version of xCAT, ensure firware level is at v1.99.6-0-r1, or higher.
mid05tor12cn02: [openbmc_debug] POST https: //172.20.140.102/login -d { "data": [ "root", "0penBmc" ] }
mid05tor12cn02: [openbmc_debug] login_response 200 OK
mid05tor12cn02: [openbmc_debug] GET https: //172.20.140.102/xyz/openbmc_project/state/enumerate
mid05tor12cn02: [openbmc_debug] rpower_status_response 200 OK
mid05tor12cn02: [openbmc_debug] State CurrentBMCState=xyz.openbmc_project.State.BMC.BMCState.Ready
mid05tor12cn02: [openbmc_debug] State RequestedBMCTransition=xyz.openbmc_project.State.BMC.Transition.None
mid05tor12cn02: [openbmc_debug] State CurrentPowerState=xyz.openbmc_project.State.Chassis.PowerState.On
mid05tor12cn02: [openbmc_debug] State RequestedPowerTransition=xyz.openbmc_project.State.Chassis.Transition.Off
mid05tor12cn02: [openbmc_debug] State CurrentHostState=xyz.openbmc_project.State.Host.HostState.Running
mid05tor12cn02: [openbmc_debug] State RequestedHostTransition=xyz.openbmc_project.State.Host.Transition.Reboot
mid05tor12cn02: on
```

2. For hierarchy env, ``GetOptions`` could not get option value. So modified to use parameters input.

3. If ``-V`` or ``--verbose`` is not the last parameter, will print error msg
```
# rpower mid05tor12cn02 -V state
[OpenBMC development support] Using this version of xCAT, ensure firware level is at v1.99.6-0-r1, or higher.
Error parsing arguments.
```