### PR TITLE
doxcat improvements

### DIFF
--- a/xCAT-genesis-scripts/bin/doxcat
+++ b/xCAT-genesis-scripts/bin/doxcat
@@ -29,9 +29,11 @@ logger -s -t $log_label -p local4.info "Beginning doxcat process..."
 modprobe acpi_cpufreq 2>/dev/null		# on some machines this fails
 modprobe cpufreq_ondemand
 if ls /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor &>/dev/null; then
-	for gov in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do
-		echo -n ondemand > $gov
-	done
+    if grep -q ondemand /sys/devices/system/cpu/cpu*/cpufreq/scaling_available_governors; then 
+        for gov in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do
+            echo -n ondemand > $gov
+        done
+    fi
 fi
 if [ ! -z "$BOOTIF" ]; then
 	BOOTIF=`echo $BOOTIF|sed -e s/01-// -e s/-/:/g`


### PR DESCRIPTION
This PR adds a check if the `cpufreq` governor being applied is available or not.