### PR TITLE
Support pdudiscover command to discover PDU

### DIFF
--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -321,9 +321,12 @@ my %usage = (
       "Usage: lsslp [-h|--help|-v|--version]
        lsslp [<noderange>][-V|--verbose][-i ip[,ip..]][-w][-r|-x|-z][-n][-I][-s FRAME|CEC|MM|IVM|RSA|HMC|CMM|IMM2|FSP]
              [-u] [--range IPranges][-t tries][--vpdtable][-C counts][-T timeout]",
+    "pdudiscover" =>
+      "Usage: pdudiscover [-h|--help|-v|--version]
+       pdudiscover [<noderange>|--range ipranges] [-r|-x|-z] [-w] [-V|--verbose] [--setup]",
     "switchdiscover" =>
       "Usage: switchdiscover [-h|--help|-v|--version]
-       switchdiscover [<noderange>|--range ipranges] [-s scan_methods] [-r|-x|-z] [-w] [-V|--verbose] [--setup]",
+       switchdiscover [<noderange>|--range ipranges] [-s scan_methods] [-r|-x|-z] [-w] [-V|--verbose] [--setup] [--pdu]",
     "switchprobe" =>
       "Usage: switchprobe [<noderange>] [-V|--verbose | -c|--check]",
     "makentp" =>

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -326,7 +326,7 @@ my %usage = (
        pdudiscover [<noderange>|--range ipranges] [-r|-x|-z] [-w] [-V|--verbose] [--setup]",
     "switchdiscover" =>
       "Usage: switchdiscover [-h|--help|-v|--version]
-       switchdiscover [<noderange>|--range ipranges] [-s scan_methods] [-r|-x|-z] [-w] [-V|--verbose] [--setup] [--pdu]",
+       switchdiscover [<noderange>|--range ipranges] [-s scan_methods] [-r|-x|-z] [-w] [-V|--verbose] [--setup]",
     "switchprobe" =>
       "Usage: switchprobe [<noderange>] [-V|--verbose | -c|--check]",
     "makentp" =>

--- a/xCAT-client/debian/xcat-client.links
+++ b/xCAT-client/debian/xcat-client.links
@@ -126,6 +126,7 @@ opt/xcat/bin/xcatclientnnr opt/xcat/bin/rmzone
 opt/xcat/bin/xcatclientnnr opt/xcat/bin/slpdiscover
 opt/xcat/bin/xcatclient    opt/xcat/bin/xCATWorld
 opt/xcat/bin/xcatclientnnr opt/xcat/bin/switchdiscover
+opt/xcat/bin/xcatclientnnr opt/xcat/bin/pdudiscover
 opt/xcat/bin/xcatclientnnr opt/xcat/bin/bmcdiscover
 opt/xcat/bin/xcatclientnnr opt/xcat/bin/makentp
 opt/xcat/bin/xcatclientnnr opt/xcat/sbin/rescanplugins

--- a/xCAT-client/xCAT-client.spec
+++ b/xCAT-client/xCAT-client.spec
@@ -166,6 +166,7 @@ ln -sf ../bin/xcatclient $RPM_BUILD_ROOT/%{prefix}/bin/mkflexnode
 ln -sf ../bin/xcatclient $RPM_BUILD_ROOT/%{prefix}/bin/getadapter
 ln -sf ../bin/xcatclientnnr $RPM_BUILD_ROOT/%{prefix}/bin/lsslp
 ln -sf ../bin/xcatclientnnr $RPM_BUILD_ROOT/%{prefix}/bin/switchdiscover
+ln -sf ../bin/xcatclientnnr $RPM_BUILD_ROOT/%{prefix}/bin/pdudiscover
 ln -sf ../bin/xcatclientnnr $RPM_BUILD_ROOT/%{prefix}/bin/bmcdiscover
 ln -sf ../bin/xcatclientnnr $RPM_BUILD_ROOT/%{prefix}/bin/makentp
 ln -sf ../bin/xcatclient $RPM_BUILD_ROOT/%{prefix}/bin/imgcapture

--- a/xCAT-server/lib/xcat/plugins/pdu.pm
+++ b/xCAT-server/lib/xcat/plugins/pdu.pm
@@ -473,7 +473,7 @@ sub process_pdudiscover {
     Getopt::Long::Configure("no_pass_through");
     my %opt;
     if (!GetOptions( \%opt,
-                    qw(h|help V|Verbose x z w r n range=s setup))) {
+                    qw(h|help V|verbose x z w r range=s setup))) {
         my $usage_string = xCAT::Usage->getUsage($request->{command}->[0]);
         $callback->({ data => $usage_string });
         return;

--- a/xCAT-server/lib/xcat/plugins/pdu.pm
+++ b/xCAT-server/lib/xcat/plugins/pdu.pm
@@ -62,6 +62,7 @@ sub handled_commands
        rpower => ["nodehm:mgt","pduoutlet:pdu=\.\*"],
        rinv   => ["nodehm:mgt"],
        nodeset => ["nodehm:mgt"],
+       pdudiscover => "pdu",
     };
 }
 
@@ -85,6 +86,7 @@ sub preprocess_request {
     if (ref($extrargs)) {
         @exargs=@$extrargs;
     }
+
     my $usage_string=xCAT::Usage->parseCommand($command, @exargs);
     if ($usage_string) {
         $callback->({data=>[$usage_string]});
@@ -92,7 +94,7 @@ sub preprocess_request {
         return;
     }
 
-    if (!$noderange) {
+    if ((!$noderange) && ($command ne "pdudiscover") ){
         $usage_string = xCAT::Usage->getUsage($command);
         $callback->({ data => $usage_string });
         $req = {};
@@ -168,6 +170,8 @@ sub process_request
                 }
             }
         }
+    }elsif($command eq "pdudiscover") {
+        process_pdudiscover($request, $subreq, $callback);
     }elsif($command eq "nodeset") {
         $callback->({ errorcode => [1],error => "The input $command is not support for pdu"});
     }else{
@@ -450,6 +454,40 @@ sub connectTopdu {
     }
 
     return $session;
+
+}
+
+sub process_pdudiscover {
+    my $request  = shift;
+    my $sub_req  = shift;
+    my $callback = shift;
+    my $extrargs = $request->{arg};
+    my @exargs   = ($request->{arg});
+    if (ref($extrargs)) {
+        @exargs=@$extrargs;
+    }
+
+    #check case in GetOptions
+    $Getopt::Long::ignorecase = 0;
+    Getopt::Long::Configure( "bundling" );
+    Getopt::Long::Configure("no_pass_through");
+    my %opt;
+    if (!GetOptions( \%opt,
+                    qw(h|help V|Verbose x z w r n range=s setup))) {
+        my $usage_string = xCAT::Usage->getUsage($request->{command}->[0]);
+        $callback->({ data => $usage_string });
+        return;
+
+    }
+
+    push @exargs, "-s snmp --pdu";
+    my $cmd = "switchdiscover @exargs";
+    my $result = xCAT::Utils->runcmd($cmd, 0);
+
+    my $rsp = {};
+    push @{ $rsp->{data} }, "$result";
+    xCAT::MsgUtils->message("I", $rsp, $callback);
+
 
 }
 

--- a/xCAT-server/lib/xcat/plugins/switchdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/switchdiscover.pm
@@ -143,7 +143,7 @@ sub parse_args {
     # Process command-line flags
     #############################################
     if (!GetOptions( \%opt,
-            qw(h|help V|Verbose v|version x z w r n range=s s=s setup))) {
+            qw(h|help V|Verbose v|version x z w r n range=s s=s setup pdu))) {
         return( usage() );
     }
 
@@ -256,6 +256,10 @@ sub parse_args {
     #########################################################
     if ( exists( $opt{setup} )) {
             $globalopt{setup} = 1;
+    }
+
+    if ( exists( $opt{pdu} )) {
+            $globalopt{pdu} = 1;
     }
 
 
@@ -880,7 +884,7 @@ sub snmp_scan {
 
     # snmpwalk command has to be available for snmp_scan
     if (-x "/usr/bin/snmpwalk" ){
-        send_msg($request, 0, "Discovering switches using snmpwalk for @$ranges .....");
+        send_msg($request, 0, "Discovering devices using snmpwalk for @$ranges .....");
     } else {
         send_msg($request, 0, "snmpwalk is not available, please install snmpwalk command first");
         return 1;
@@ -968,7 +972,7 @@ sub snmp_scan {
             $switches->{$mac}->{vendor} = $vendor;
             $switches->{$mac}->{name} = $hostname;
             if (exists($globalopt{verbose}))    {
-               send_msg($request, 0, "found switch: $hostname, $ip, $stype, $vendor");
+               send_msg($request, 0, "found device: $hostname, $ip, $stype, $vendor");
             }
         }
     }
@@ -1006,8 +1010,15 @@ sub get_snmpvendorinfo {
         }
         return $snmpwalk_vendor;
     }
-
+   
     my ($desc,$model) = split /: /, $result;
+
+    if (exists($globalopt{pdu})) {
+        if ( ($model =~ /pdu/) || ($model =~ /PDU/) ) {
+            return $model;
+        }
+        return $snmpwalk_vendor;
+    }
 
     if (exists($globalopt{verbose}))    {
         send_msg($request, 0, "switch model = $model\n" );
@@ -1185,6 +1196,13 @@ sub xCATdB {
             $mac=" ";
         }
 
+        # check if this is for pdu or switches
+        my $device = "switch";
+        if (exists($globalopt{pdu})) {
+            $device = "pdu";
+        }
+
+
         #################################################
         # use lsdef command to check if this switch is
         # already in the switch table
@@ -1195,14 +1213,15 @@ sub xCATdB {
         $ret = xCAT::Utils->runxcmd( { command => ['lsdef'], arg => ['-t','node','-o',$host] }, $sub_req, 0, 1);
         if ($::RUNCMD_RC == 0)
         {
-            $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$host,"ip=$ip","mac=$mac",'nodetype=switch','mgt=switch',"switchtype=$stype","usercomment=$vendor"] }, $sub_req, 0, 1);
-            $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$host,'-p','groups=switch'] }, $sub_req, 0, 1);
+            $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$host,"ip=$ip","mac=$mac","nodetype=$device","mgt=$device","usercomment=$vendor"] }, $sub_req, 0, 1);
+            $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$host,'-p',"groups=$device"] }, $sub_req, 0, 1);
         } else {
-            $ret = xCAT::Utils->runxcmd( { command => ['mkdef'], arg => ['-t','node','-o',$host,'groups=switch',"ip=$ip","mac=$mac",'nodetype=switch','mgt=switch',"switchtype=$stype","usercomment=$vendor"] }, $sub_req, 0, 1);
+            $ret = xCAT::Utils->runxcmd( { command => ['mkdef'], arg => ['-t','node','-o',$host,"groups=$device","ip=$ip","mac=$mac","nodetype=$device","mgt=$device","usercomment=$vendor"] }, $sub_req, 0, 1);
         }
-        if ($::RUNCMD_RC != 0)
+
+        if (!exists($globalopt{pdu})) 
         {
-            send_msg($request, 0, "$$ret[0]");
+            $ret = xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$host,'-p',"switchtype=$stype"] }, $sub_req, 0, 1);
         }
     }
 }
@@ -1287,14 +1306,22 @@ sub format_stanza {
         if ($mac =~ /nomac/) {
             $mac = " ";
         }
+      
+        # check if this is for pdu or switches
+        my $device = "switch";
+        if (exists($globalopt{pdu})) {
+            $device = "pdu";
+        }
 
         $result .= "$host:\n\tobjtype=node\n";
-        $result .= "\tgroups=switch\n";
+        $result .= "\tgroups=$device\n";
         $result .= "\tip=$ip\n";
         $result .= "\tmac=$mac\n";
-        $result .= "\tmgt=switch\n";
-        $result .= "\tnodetype=switch\n";
-        $result .= "\tswitchtype=$stype\n";
+        $result .= "\tmgt=$device\n";
+        $result .= "\tnodetype=$device\n";
+        if (!exists($globalopt{pdu})) {
+            $result .= "\tswitchtype=$stype\n";
+        }
     }
     return ($result); 
 }
@@ -1327,14 +1354,22 @@ sub format_xml {
             $mac = " ";
         }
 
+        # check if this is for pdu or switches
+        my $device = "switch";
+        if (exists($globalopt{pdu})) {
+            $device = "pdu";
+        }
+
         $result .= "hostname=$host\n";
         $result .= "objtype=node\n";
-        $result .= "groups=switch\n";
+        $result .= "groups=$device\n";
         $result .= "ip=$ip\n";
         $result .= "mac=$mac\n";
-        $result .= "mgt=switch\n";
-        $result .= "nodetype=switch\n";
-        $result .= "switchtype=$stype\n";
+        $result .= "mgt=$device\n";
+        $result .= "nodetype=$device\n";
+        if (!exists($globalopt{pdu})) {
+            $result .= "switchtype=$stype\n";
+        }
 
         my $href = {
             Switch => { }
@@ -1353,7 +1388,7 @@ sub format_xml {
     return ($xml);    
 }
 
-#--------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------
 =head3 matchPredefineSwitch 
       find discovered switches with predefine switches
       for each discovered switches:
@@ -1388,7 +1423,7 @@ sub matchPredefineSwitch {
 
         my $node = $macmap->find_mac($mac,0,1);
         if (!$node) {
-            send_msg($request, 0, "Switch discovered: $dswitch ");
+            send_msg($request, 0, "Device discovered: $dswitch ");
             $discoverswitch->{$mac}->{ip} = $ip;
             $discoverswitch->{$mac}->{vendor} = $vendor;
             $discoverswitch->{$mac}->{name} = $dswitch;
@@ -1397,11 +1432,14 @@ sub matchPredefineSwitch {
 
         my $stype = get_switchtype($vendor);
 
-        send_msg($request, 0, "Switch discovered and matched: $dswitch to $node" );
+        send_msg($request, 0, "Device discovered and matched: $dswitch to $node" );
 
         # only write to xcatdb if -w or --setup option specified
         if ( (exists($globalopt{w})) || (exists($globalopt{setup})) ) {
             xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"otherinterfaces=$ip",'status=Matched',"mac=$mac","switchtype=$stype","usercomment=$vendor"] }, $sub_req, 0, 1);
+            if (!exists($globalopt{pdu})) {
+                xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$node,"switchtype=$stype"] }, $sub_req, 0, 1);
+            }
         }
 
         push (@{$configswitch->{$stype}}, $node);
@@ -1423,6 +1461,10 @@ sub switchsetup {
     my $nodes_to_config = shift;
     my $request = shift;
     my $sub_req = shift;
+    if (exists($globalopt{pdu})) {
+        return;
+    }
+
     foreach my $mytype (keys %$nodes_to_config) {
         my $config_script = "$::XCATROOT/share/xcat/scripts/config".$mytype;
         if (-r -x $config_script) {


### PR DESCRIPTION
Create a pdudiscover command, it scans the subnets and discovers all the PDUs on the subnets.  Since methodologies  is same as switchdiscover, pdudiscover will call switchdiscover and with default options -s snmp and --pdu

```
# pdudiscover --help
Usage: pdudiscover [-h|--help|-v|--version]
       pdudiscover [<noderange>|--range ipranges] [-r|-x|-z] [-w] [-V|--verbose] [--setup]
````
The sample example of pdudiscover and switchdiscover (9.114.82.92 is a coralPDU, 172.10.2.4 is a cumulus switch )
```
# pdudiscover --range 9.114.82.92,172.10.2.4
Discovering devices using snmpwalk for 9.114.82.92 172.10.2.4 .....
ip              name                         vendor                                                  mac
------------    ------------            ------------                                           ------------
9.114.82.92     coral-pdu           Linux coral-pdu 3.14.52+g5f6f0a5       8:be:94:7f:00:3b
Device discovered: coral-pdu
`````
`````
# switchdiscover --range 9.114.82.92,172.10.2.4
Discovering switches using nmap for 9.114.82.92 172.10.2.4. It may take long time...
ip                   name                    vendor                                        mac
------------    ------------            ------------                                 ------------
172.10.2.4      c685f2u28sw        Edgecore Networks Switch       8C:EA:1B:E8:74:C0
Device discovered: c685f2u28sw
`````

 

