### PR TITLE
Fix xcattest bug: failed to load config file which value include comma in object section

### DIFF
--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -682,7 +682,7 @@ sub load_config_file {
             }
         } elsif ($type eq "Object") {
             ##OBJECT BLOCK##
-            if ($line =~ /(\w+)\s*=\s*([:\w\.\-\/]+)/) {
+            if ($line =~ /(\w+)\s*=\s*([:,\w\.\-\/]+)/) {
                 $attr  = $1;
                 $value = $2;
                 if ($attr eq "Name") {


### PR DESCRIPTION
If the value include ``,`` in object section in xcattest config file, ``xcattest`` failed to load the whole value.

If config file looks like below:

     [Object_node] #CN
     Name=c910f03c11k11
          id=11
          .......
          vmnics=br10,br50,br4093

After being loaded by xcattest, ``br50,br4093`` will be dropped. 

    ******************************
    Initialize xCAT test environment by definition in configure file
    ******************************
    chdef -t node -o c910f03c11k11 arch=ppc64le netboot=grub2 ip=10.3.11.11 vmcpus=4 vmhost=c910f03c11 serialport=0 serialspeed=115200 os=rhels7.3 mgt=kvm groups=all id=11 serialflow=hard vmstorage=phy:/dev/mapper/vdiskvg-vdisk00n11 vmnics=br10 cons=kvm vmnicnicmodel=virtio-net-pci vmmemory=8192


This is a bug. fix it in this PR.
