### PR TITLE
remove the build mlx4-en and i40e section when building xcat-genesis-…

### DIFF
--- a/xCAT-genesis-builder/buildrpm
+++ b/xCAT-genesis-builder/buildrpm
@@ -5,7 +5,7 @@
 #            this whole dir into it somewhere (like /tmp).
 # Then run this script.  The optional 1st arg should be mcp if you are building against mcp.
 
-# Currently, *Fedora 23* is the only OS supported to build genesis-base for ppc64, and Centos 6.5 for x86_64
+# Currently, *Fedora 26* is the only OS supported to build genesis-base for ppc64, and Centos 6.5 for x86_64
 
 HOSTOS="$1"
 DIR=`dirname $0`
@@ -18,37 +18,9 @@ if [ $BUILDARCH = "ppc64le" ]; then
     BUILDARCH="ppc64"
 fi
 
-# For xcat-genesis-base-ppc64, we need to update mlx4-en driver for Mellanox ethernet nics. 
-# IF you are sure you have installed newer driver on the build server you can use 'buildrpm -y' to skip the nodification
 if [ -z $1 ]; then
-    HOSTOS="fedora23"
+    HOSTOS="fedora26"
 fi
-if [ $BUILDARCH = 'ppc64' -a $HOSTOS != 'mcp' -a $HOSTOS != '-y' ]; then
-    echo "The steps below are used to install mlnx driver 3.2-1 and i40e driver 1.5.16, if you are sure you have these or newer drivers, pls use \"-y\" to skip!"
-    echo "1. Install OS related packages"
-    echo "    yum install rpmbuild"
-    echo "    yum install kernel-devel-`uname -r`"
-    echo "    yum install kernel-headers-`uname -r`"
-    echo "    yum install gcc-c++"
-    echo "2. Download Mellanox EN Driver for Linux from http://www.mellanox.com/downloads/Drivers/mlnx-en-3.2-1.0.1.1.tgz"
-    echo "   Download Intel EN Driver follow this link and download from webpage https://downloadcenter.intel.com/downloads/eula/26370/Intel-Network-Adapter-Driver-for-PCI-E-Intel-40-Gigabit-Ethernet-Network-Connections-under-Linux-?httpDown=https%3A%2F%2Fdownloadmirror.intel.com%2F26370%2Feng%2Fi40e-1.5.16.tar.gz"
-    echo "3. To install Mellanox Driver, extract it and run ./install.sh from the extracted directory"
-    echo "    tar -xvf mlnx-en-3.2-1.0.1.1.tgz"
-    echo "    ./mlnx-en-3.2-1.0.1.1/install.sh"
-    echo "   To install Intel Driver, create rpm and install"
-    echo "    rpmbuild -tb i40e-1.5.16.tar.gz"
-    echo "    rpm -i /<path-to>/i40e-1.5.16-1.ppc64le.rpm"
-    echo "    Additional Intel instructions can be found in README included in i40e-1.5.16.tar.gz"
-    echo "4. Check whether the drivers are updated"
-    echo "    modprobe mlx4-en"
-    echo "    modinfo mlx4-en | grep version"
-    echo "    version:        3.2-1.0.1.1 (31 Jan 2016)"
-    echo "    modinfo i40e | grep version"
-    echo "    version:        1.5.16"
-    echo "5. Once the steps above done, run \"$0 -y\" to build xCAT-genesis-base-ppc64"
-    exit 0
-fi
-
 
 # get the input files for dracut in the right place
 # Fedora 20 ppc64 uses /usr/lib/dracut/modules.d

--- a/xCAT-genesis-builder/xCAT-genesis-base.spec
+++ b/xCAT-genesis-builder/xCAT-genesis-base.spec
@@ -37,6 +37,7 @@ Packager: IBM Corp.
 %Description
 xCAT genesis (Genesis Enhanced Netboot Environment for System Information and Servicing) is a small, embedded-like environment for xCAT's use in discovery and management actions when interaction with an OS is infeasible.
 This package comprises the base platform with most of the xCAT specific behavior left to xCAT-genesis-scripts package.
+Built in environment "%dist" on %{_arch}.
 %Prep
 
 


### PR DESCRIPTION
…base

* Can not find suitable mlx4-en driver for Fedora26.
* Fedora26 had shipped newer i40e driver than 1.5.16

So, remove the section to build those 2 drivers.