### PR TITLE
blacklist HP trunk interfaces

### DIFF
--- a/perl-xCAT/xCAT/MacMap.pm
+++ b/perl-xCAT/xCAT/MacMap.pm
@@ -147,6 +147,12 @@ OID, and have the switch table port value match exactly the format suggested by 
         return 0;
     }
 
+    #HP calls their PortChannel interfaces "trunks"
+    #designated as Trk1, etc. don't match those
+    if ($namepersnmp =~ /Trk/) {
+        return 0;
+    }
+
     #The blacklist approach has been exhausted.  For now, assuming that means good,
     #if something ambiguous happens, the whitelist would have been:
     #'Port','Port #','/' (if namepercfg has no /, then / would be...),


### PR DESCRIPTION
As discovered when trying to do switch-based discovery on a cluster I was trying to set up, the HP port-channel interfaces are called "trunks" and labelled as Trk1, Trk2, etc.

This meant if a node was assigned to switchport 1 on switch sw2, but switch sw1 had an interface Trk1 that could see the MAC address, it would default to the first match and choose switchport 1 (dropping the leading non-digits from 'Trk1') of sw1.