### PR TITLE
xCAT-client:  allow pgsqlsetup(1) to accept additional listen_addresses

### DIFF
--- a/xCAT-client/bin/pgsqlsetup
+++ b/xCAT-client/bin/pgsqlsetup
@@ -72,6 +72,7 @@ $::pgcmddir       = "/usr/bin";                   # pg cmds location
 $::debiancfgdir   = "/etc/postgresql/9.1/main";
 my $INIT;
 my $SETUPODBC;
+my @LISTENADDRS;
 my $NOSTART;
 my $SETUPPCM;
 my $HELP;
@@ -83,6 +84,7 @@ if (
     !GetOptions(
         'i|init'    => \$INIT,
         'o|odbc'    => \$SETUPODBC,
+        'l|listen=s'=> \@LISTENADDRS,
         'N|nostart' => \$NOSTART,
         'P|PCM'     => \$SETUPPCM,
         'h|help'    => \$HELP,
@@ -126,6 +128,13 @@ if ((!($INIT)) && ($SETUPODBC))
 {
     $odbconly = 1;
 
+}
+
+# create comma-separated list of additional listen addresses
+my $listenaddrs = undef;
+if (@LISTENADDRS)
+{
+    $listenaddrs = join ',', @LISTENADDRS;  
 }
 
 #
@@ -428,7 +437,7 @@ sub usage
 "Usage:\npgsqlsetup - Performs the setup of PostgreSQL for xCAT to use as its database. See man pgsqlsetup for more information."
     );
     my $msg =
-"pgsqlsetup <-h|--help>\n           <-v|--version>\n           <-i|--init> [-N|--nostart] [-P|--PCM] [-o|--odbc] [-V|--verbose]\n           <-o|--odbc> [-V|--verbose]";
+"pgsqlsetup <-h|--help>\n           <-v|--version>\n           <-i|--init> [-N|--nostart] [-l|--listen address] [-P|--PCM] [-o|--odbc] [-V|--verbose]\n           <-o|--odbc> [-V|--verbose]";
 
     xCAT::MsgUtils->message('I', "$msg");
 }
@@ -789,6 +798,10 @@ sub initpgdb
         if ($::osname eq 'Linux')
         {
             $cmd = qq~ echo listen_addresses = \\'localhost,$::MN\\' >> $pgconf~;
+             if ($::listenaddrs) 
+             {
+                 $cmd = qq~ echo listen_addresses = \\'localhost,$::MN,$::listenaddrs\\' >> $pgconf~;
+             }
             `$cmd`;
         }
 
@@ -796,6 +809,10 @@ sub initpgdb
         if ($::osname eq 'AIX')
         {
             $cmd = qq~ echo listen_addresses = \\'$::MN\\' >> $pgconf~;
+            if ($::listenaddrs)
+            {
+                $cmd = qq~ echo listen_addresses = \\'$::MN,$::listenaddrs\\' >> $pgconf~;
+            }
             `$cmd`;
             $cmd = qq~echo logging_collector = on >> $pgconf~;
             `$cmd`;

--- a/xCAT-client/pods/man1/pgsqlsetup.1.pod
+++ b/xCAT-client/pods/man1/pgsqlsetup.1.pod
@@ -9,7 +9,7 @@ B<pgsqlsetup> {B<-h> | B<--help>}
 
 B<pgsqlsetup> {B<-v> | B<--version>}
 
-B<pgsqlsetup> {B<-i> | B<--init>} [B<-N> | B<--nostart>] [B<-P> | B<--PCM>] [B<-o> | B<--odbc>] [B<-V> | B<--verbose>]
+B<pgsqlsetup> {B<-i> | B<--init>} [B<-N> | B<--nostart>] [B<--listen> | B<-l> I<address>] [B<-P> | B<--PCM>] [B<-o> | B<--odbc>] [B<-V> | B<--verbose>]
 
 B<pgsqlsetup> {B<-o> | B<--setupODBC>} [B<-V> | B<--verbose>] 
 
@@ -45,6 +45,10 @@ For more documentation see:Setting_Up_PostgreSQL_as_the_xCAT_DB
 =item B<-N|--nostart>
 
 This option with the -i flag will create the database, but will not backup and restore xCAT tables into the database. It will create the cfgloc file such that the next start of xcatd will try and contact the database.  This can be used to setup the xCAT PostgreSQL database during or before install.
+
+=item B<-l|--listen> I<address>
+
+This option is used to specify additional IP addresses on which the PostgreSQL database will listen.  Without it, only localhost (on Linux) and the management node's main IP (on Linux and AIX) will be configured.  This option can be specified multiple times.
 
 =item B<-P|--PCM>
 


### PR DESCRIPTION
On AIX, pgsqlsetup(1) only configures the management node IP in PostgreSQL's configuration. On Linux, it only configures localhost and the management node IP. This change creates a new option in pgsqlsetup(1) that allows the user to specify an additional address to be added in the listen_addresses line in PostgreSQL's configuration. If the user specifies this option more than once, all specified addresses are added to the line.

This is useful in cases where the management node has more than one IP, such as in HA configurations where an address is shared between multiple management nodes. In these cases, pgsqlsetup(1) may use the system's primary address, when it is preferred to listen on the shared address as well. This is also useful in situations where the cluster is fragmented across different subnets, and the management node needs to talk to service nodes that are on disparate networks.