### PR TITLE
Complete the rsetboot development effort and expose the the function

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -508,6 +508,7 @@ sub parse_args {
     } elsif ($command eq "getopenbmccons") {
         # command for openbmc rcons
     } elsif ($command eq "rsetboot") {
+        $subcommand = "stat" if (!defined($ARGV[0]));
         unless ($subcommand =~ /^net$|^hd$|^cd$|^def$|^default$|^stat$/) {
             return ([ 1, "Unsupported command: $command $subcommand" ]);
         }


### PR DESCRIPTION
Based on the changes that @xuweibj put in https://github.com/xcat2/xcat-core/pull/3378 that puts in the code against the documented API, the initial logic is complete, and we are waiting for the firmware to be exposed in the drivers.  Let's just open it up ... 

* Open up the rsetboot function for OpenBMC
* Print message that informs user and dev teams that function is not yet exposed in the firmware

The message printed now will also let us know when firmware drivers respond to endpoints that do NOT exist in official driver code. 

Here's what it looks like before: 

```
[root@fs3 ~]# rsetboot mid05tor12cn02 net
This openbmc related function is not yet supported. Please contact xCAT development team.
```

After the PR: 
```
[root@fs2vm110 ~]# env | grep OPENBMC
[root@fs2vm110 ~]# rsetboot p9euh01 net
p9euh01: Error: 403 Forbidden - This function is not yet available in OpenBMC firmware.

```

And with BYPASS...
```
[root@fs2vm110 ~]# XCATBYPASS=1 rsetboot p9euh01 net
$VAR1 = {
          'p9euh01' => {
                         'password' => '0penBmc',
                         'bmc' => '10.6.7.254',
                         'cur_status' => 'LOGIN_REQUEST',
                         'username' => 'root'
                       }
        };

$VAR1 = {
          'RSETBOOT_SET_REQUEST' => 'RSETBOOT_SET_RESPONSE',
          'RSETBOOT_STATUS_REQUEST' => 'RSETBOOT_STATUS_RESPONSE',
          'RSETBOOT_SET_RESPONSE' => 'RSETBOOT_STATUS_REQUEST',
          'LOGIN_REQUEST' => 'LOGIN_RESPONSE',
          'LOGIN_RESPONSE' => 'RSETBOOT_SET_REQUEST'
        };

p9euh01: DEBUG POST https://10.6.7.254/login -d { "data": [ "root", "0penBmc" ] }
p9euh01: DEBUG login_response 200 OK
p9euh01: DEBUG PUT https://10.6.7.254/xyz/openbmc_project/control/boot/bootsource/attr/Sources -d {"data":"xyz.openbmc_project.Control.Boot.Sources.Network"}
p9euh01: DEBUG rsetboot_set_response 403 Forbidden
p9euh01: Error: 403 Forbidden - This function is not yet available in OpenBMC firmware.

```
