### PR TITLE
fix issue#3515: check the version of xCAT between MN and SN while processing the forwarded request

### DIFF
--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -42,6 +42,7 @@ if ($^O =~ /^aix/i) {
 }
 use lib "$::XCATROOT/lib/perl";
 use Storable qw(freeze thaw nstore_fd store_fd fd_retrieve);
+use Sys::Hostname;
 use xCAT::Utils;
 use xCAT::TableUtils;
 use xCAT::NetworkUtils;
@@ -2811,18 +2812,15 @@ sub service_connection {
                 if($req->{'_xcatver'} and $req->{'_xcatver'}->[0]){
                     my $myxcatver=xCAT::Version->Version();
                     if($req->{'_xcatver'}->[0] ne $myxcatver){
-                        require Sys::Hostname;
                         my $myhostname=Sys::Hostname::hostname;
-                        my $resp = { warning => ["$myhostname: my xCAT version \"$myxcatver\" does not match the forwarder's xCAT version \"$req->{'_xcatver'}->[0]\" on $peerhost"]};
+                        my $resp = { warning => ["xCAT Version mismatch! \"$myxcatver\" on $myhostname does not match \"$req->{'_xcatver'}->[0]\" on $peerhost!"]};
                         $resp->{serverdone} = [undef];
                         send_response($resp, $sock);
-                        #return;
                     }
                 }
 
     
                 # we have a full request..
-                #printf $request."\n";
                 $request = "";
                 if (xCAT::xcatd->validate($peername, $peerhost, $req, $peerhostorg, \@deferredmsgargs)) {
                     $req->{'_xcat_authname'}   = [$peername];

--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -2301,7 +2301,8 @@ sub dispatch_request {
                 my $errstr;
                 eval {
                     undef $_->{'_xcatdest'};
-
+                    #the xCAT version is included in the request which will be forwarded
+                    $_->{'_xcatver'}=xCAT::Version->Version();
                     # mainly used by SN to filter out the incorrect module that xcat command came into
                     $_->{'_modname'} = $modname;
 
@@ -2803,6 +2804,23 @@ sub service_connection {
                     delete($req->{tokenid});
                 }
 
+                #for xcat requests forwarded from other nodes, such as MN<-->SN
+                # compare the version of xCAT which forwarded the request and the
+                # one which processes the forwarded command
+                #if the 2 versions are different, a warning message is included in the response
+                if($req->{'_xcatver'} and $req->{'_xcatver'}->[0]){
+                    my $myxcatver=xCAT::Version->Version();
+                    if($req->{'_xcatver'}->[0] ne $myxcatver){
+                        require Sys::Hostname;
+                        my $myhostname=Sys::Hostname::hostname;
+                        my $resp = { warning => ["$myhostname: my xCAT version \"$myxcatver\" does not match the forwarder's xCAT version \"$req->{'_xcatver'}->[0]\" on $peerhost"]};
+                        $resp->{serverdone} = [undef];
+                        send_response($resp, $sock);
+                        #return;
+                    }
+                }
+
+    
                 # we have a full request..
                 #printf $request."\n";
                 $request = "";


### PR DESCRIPTION
a proposal for issue https://github.com/xcat2/xcat-core/issues/3515:

for the forwarded xCAT requests between xCAT MN and SN: 
(1) include xCAT version info in the forwarded request 
(2) on the Node which will process the forwarded requests, compare the xCAT version in the forwarded requests and the xCAT version on the node itself, if not same, prompt a warning in the resonse

Verification Result:
````
[root@c910f03c05k21 ~]# makedhcp c910f03c17k42
Warning: c910f03c05k27: my xCAT version "Version 2.13.5 (git commit c66de1d8e0fd979700a71a09fb081a89595xxf7b, built Fri Jun 18 02:08:59 EDT 2017)" does not match the forwarder's xCAT version "Version 2.13.5 (git commit 5cd9b632a18faabb540f722fba86488019afe629, built Fri Jun 23 03:06:06 EDT 2017)" on c910f03c05k21
Warning: c910f03c17k41: my xCAT version "Version 2.13.5 (git commit 5cd9b632a18faabb540f722fba86488019afe729, built Fri Jun 23 03:06:06 EDT 2017)" does not match the forwarder's xCAT version "Version 2.13.5 (git commit 5cd9b632a18faabb540f722fba86488019afe629, built Fri Jun 23 03:06:06 EDT 2017)" on c910f03c05k21
````