### PR TITLE
fix issue noderange in xCAT commands might be broken by shell expansion #3319

### DIFF
--- a/docs/source/guides/admin-guides/references/man3/noderange.3.rst
+++ b/docs/source/guides/admin-guides/references/man3/noderange.3.rst
@@ -59,6 +59,8 @@ Name
 conveniently specify a list of nodes.  The result is that the  command  will
 be applied to a range of nodes, often in parallel.
 
+To avoid shell expansion, \ **noderange**\  should better be quoted with single quotes('') or double quotes("").
+
 \ **noderange**\  is a comma-separated list.  Each token (text between commas)
 in the list can be any of the forms listed below:
 

--- a/xCAT-client/pods/man3/noderange.3.pod
+++ b/xCAT-client/pods/man3/noderange.3.pod
@@ -36,6 +36,8 @@ B<noderange> is a syntax that can be used in most xCAT commands to
 conveniently specify a list of nodes.  The result is that the  command  will
 be applied to a range of nodes, often in parallel.
 
+To avoid shell expansion, B<noderange> should better be quoted with single quotes('') or double quotes(""). 
+
 B<noderange> is a comma-separated list.  Each token (text between commas)
 in the list can be any of the forms listed below:
 


### PR DESCRIPTION
for issue: https://github.com/xcat2/xcat-core/issues/3319

modify the documentation, suggest user to quote noderange string in xCAT commands to avoid shell expansion

Compiled Doc: http://10.3.5.21/xcat-doc/html/guides/admin-guides/references/man3/noderange.3.html