### PR TITLE
Task 3406, add BMC MAC in bmcdiscover and discovery process

### DIFF
--- a/xCAT-genesis-scripts/bin/dodiscovery
+++ b/xCAT-genesis-scripts/bin/dodiscovery
@@ -141,10 +141,12 @@ if [ "$UUID" != "unknown" ]; then
         echo "<uuid>$UUID</uuid>" >> /tmp/discopacket
 fi
 
-if [ "$MTM" != "unknown" ]; then
+flag_mtm=`echo '$MTM' | sed 's/0//g'`
+if [ $flag_mtm ] && [ "$MTM" != "unknown" ]; then
 	echo "<mtm>$MTM</mtm>" >> /tmp/discopacket
 fi
-if [ "$SERIAL" != "unknown" ]; then
+flag_serial=`echo '$SERIAL' | sed 's/0//g'`
+if [ $flag_serial ] && [ "$SERIAL" != "unknown" ]; then
 	echo "<serial>$SERIAL</serial>" >> /tmp/discopacket
 fi
 if [ "$PLATFORM" != "unknown" ]; then
@@ -157,6 +159,11 @@ if [ "$IsStatic" ]; then
     if [ "$BMCIPADDR" ]; then
         echo "<bmc>$BMCIPADDR</bmc>" >> /tmp/discopacket
     fi
+fi
+
+BMCMAC=`ipmitool lan print 1 | grep 'MAC Address' | cut -d ":" -f2-7 | sed 's/ //'`
+if [ "$BMCMAC" ]; then
+    echo "<bmcmac>$BMCMAC</bmcmac>" >> /tmp/discopacket
 fi
 
 # Check whether the hardware support in-band BMC configuration with the IPMI device

--- a/xCAT-server/lib/xcat/plugins/seqdiscovery.pm
+++ b/xCAT-server/lib/xcat/plugins/seqdiscovery.pm
@@ -141,6 +141,14 @@ sub findme {
         }
     }
 
+    unless ($bmc_node) {
+        if ($request->{'bmcmac'}->[0]) {
+            my $bmcmac = lc($request->{'bmcmac'}->[0]);
+            $bmcmac =~ s/\://g;
+            my $tmp_node = "node-$bmcmac";
+            $bmc_node = $tmp_node if ($::XCATMPHASH{$tmp_node});
+        }
+    }
 
     if ($node) {
         my $skiphostip;

--- a/xCAT-server/lib/xcat/plugins/switch.pm
+++ b/xCAT-server/lib/xcat/plugins/switch.pm
@@ -346,6 +346,15 @@ sub process_request {
             }
         }
 
+        unless ($bmc_node) {
+            if ($req->{'bmcmac'}->[0]) {
+                my $bmcmac = lc($req->{'bmcmac'}->[0]);
+                $bmcmac =~ s/\://g;
+                my $tmp_node = "node-$bmcmac";
+                $bmc_node = $tmp_node if ($::XCATMPHASH{$tmp_node});
+            }
+        }
+
         if ($node) {
             xCAT::MsgUtils->message("S", "xcat.discovery.switch: ($req->{_xcat_clientmac}->[0]) Found node: $node");
 

--- a/xCAT-server/lib/xcat/plugins/typemtms.pm
+++ b/xCAT-server/lib/xcat/plugins/typemtms.pm
@@ -34,6 +34,16 @@ sub findme {
             push @nodes, $_;
         }
     }
+
+    unless ($bmc_node) {
+        if ($request->{'bmcmac'}->[0]) {
+            my $bmcmac = lc($request->{'bmcmac'}->[0]);
+            $bmcmac =~ s/\://g;
+            my $tmp_node = "node-$bmcmac";
+            $bmc_node = $tmp_node if ($::XCATMPHASH{$tmp_node});
+        }
+    }
+
     my $nodenum = $#nodes;
     if ($nodenum < 0) {
         xCAT::MsgUtils->message("S", "xcat.discovery.mtms: ($request->{_xcat_clientmac}->[0]) Warning: Could not find any node for $mtms using mtms-based discovery");


### PR DESCRIPTION
#3406 

1. For bmcdiscover.pm : 
    1.1 Get BMC MAC address when using ``nmap`` to get live IPs, and save in %ipmac hash.
    1.2 If can not get mtm or serial, define bmc node by ``node-$mac``.
    1.3 If can get mtm and serial, but is string like ``0000000000`` (all 0s), consider it as null. Define bmc node by ``node-$mac``.
    1.4 If can get valid mtm and serial, still use ``node-$mtm-$serial`` as bmc node name.

The output is when mtm is ``000000``.
```
# bmcdiscover --range 10.3.5.99 -w -z
node-42a5c12b1c3f:
	objtype=node
	groups=all
	bmc=10.3.5.99
	cons=openbmc
	mgt=openbmc
	serial=00TEST00
```

2. For dodiscovery:
    2.1 If mtm or serial is like ``0000000``(all 0s), will not be added into packet.
    2.2 Add BMC MAC into packet, will be sent to xcatd.

3. For discovery (switch.pm typemtm.pm seqdiscovery.pm):
    After checking whether there is bmc node in mp table by mtm and serial. Judge whether ``node-$mac`` in mp table. If has, it is the bmc node and remove it.

