### PR TITLE
xCAT-client:  allow pgsqlsetup(1) to accept additional pg_hba entries

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/pgsqlsetup.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/pgsqlsetup.1.rst
@@ -23,7 +23,7 @@ SYNOPSIS
 
 \ **pgsqlsetup**\  {\ **-v**\  | \ **-**\ **-version**\ }
 
-\ **pgsqlsetup**\  {\ **-i**\  | \ **-**\ **-init**\ } [\ **-N**\  | \ **-**\ **-nostart**\ ] [\ **-P**\  | \ **-**\ **-PCM**\ ] [\ **-o**\  | \ **-**\ **-odbc**\ ] [\ **-V**\  | \ **-**\ **-verbose**\ ]
+\ **pgsqlsetup**\  {\ **-i**\  | \ **-**\ **-init**\ } [\ **-N**\  | \ **-**\ **-nostart**\ ] [\ **-**\ **-listen**\  | \ **-l**\  \ *address*\ ] [\ **-**\ **-access**\  | \ **-a**\  \ *address*\ ] [\ **-P**\  | \ **-**\ **-PCM**\ ] [\ **-o**\  | \ **-**\ **-odbc**\ ] [\ **-V**\  | \ **-**\ **-verbose**\ ]
 
 \ **pgsqlsetup**\  {\ **-o**\  | \ **-**\ **-setupODBC**\ } [\ **-V**\  | \ **-**\ **-verbose**\ ]
 
@@ -65,7 +65,7 @@ OPTIONS
  
  The init option is used to setup an installed PostgreSQL database so that xCAT can use the database.  This involves creating the xcat database, the xcat admin id, allowing access to the xcatdb database by the Management Node. It customizes the postgresql.conf configuration file, adds the management server to the pg_hba.conf and starts the PostgreSQL server.  It also backs up the current xCAT database and restores it into the newly setup xcatdb PostgreSQL database.  It creates the /etc/xcat/cfgloc file to point the xcatd daemon to the PostgreSQL database and restarts the xcatd daemon using the database. 
  On AIX, it additionally setup the xcatadm unix id and the postgres id and group. For AIX, you should be using the PostgreSQL rpms available from the xCAT website. For Linux, you should use the PostgreSQL rpms shipped with the OS. You can chose the -o option, to run after the init.
- To add additional nodes to access the PostgreSQL server, setup on the Management Node,  edit the pg_hba.conf file.
+ To add additional nodes to access the PostgreSQL server, setup on the Management Node, use the -a option.
  
  For more documentation see:Setting_Up_PostgreSQL_as_the_xCAT_DB
  
@@ -74,6 +74,18 @@ OPTIONS
 \ **-N|-**\ **-nostart**\ 
  
  This option with the -i flag will create the database, but will not backup and restore xCAT tables into the database. It will create the cfgloc file such that the next start of xcatd will try and contact the database.  This can be used to setup the xCAT PostgreSQL database during or before install.
+ 
+
+
+\ **-l|-**\ **-listen**\  \ *address*\ 
+ 
+ This option is used to specify additional IP addresses on which the PostgreSQL database will listen.  Without it, only localhost (on Linux) and the management node's main IP (on Linux and AIX) will be configured.  This option can be specified multiple times.
+ 
+
+
+\ **-a|-**\ **-access**\  \ *address*\ 
+ 
+ This option is used to specify additional IP addresses from which the service nodes will connect to the PostgreSQL database.  Without it, only the management node will be configured for database access.  This option can be specified multiple times.
  
 
 

--- a/xCAT-client/bin/pgsqlsetup
+++ b/xCAT-client/bin/pgsqlsetup
@@ -747,8 +747,8 @@ sub initpgdb
     if ($debianflag) {
         $hbafile = $::debiancfgdir . "/pg_hba.conf";
     }
-		$cmd = "cp $hbafile $hbafile.org";    # backup the original
-		xCAT::Utils->runcmd($cmd, -1);
+    $cmd = "cp $hbafile $hbafile.org";    # backup the original
+    xCAT::Utils->runcmd($cmd, -1);
 
     push @ACCESSADDRS, $::MN;  # add management node to list
     my $insertstr = undef;     # start with empty string

--- a/xCAT-client/bin/pgsqlsetup
+++ b/xCAT-client/bin/pgsqlsetup
@@ -439,7 +439,7 @@ sub usage
 "Usage:\npgsqlsetup - Performs the setup of PostgreSQL for xCAT to use as its database. See man pgsqlsetup for more information."
     );
     my $msg =
-"pgsqlsetup <-h|--help>\n           <-v|--version>\n           <-i|--init> [-N|--nostart] [-l|--listen address] [-P|--PCM] [-o|--odbc] [-V|--verbose]\n           <-o|--odbc> [-V|--verbose]";
+"pgsqlsetup <-h|--help>\n           <-v|--version>\n           <-i|--init> [-N|--nostart] [-l|--listen address] [-a|--access address] [-P|--PCM] [-o|--odbc] [-V|--verbose]\n           <-o|--odbc> [-V|--verbose]";
 
     xCAT::MsgUtils->message('I', "$msg");
 }

--- a/xCAT-client/bin/pgsqlsetup
+++ b/xCAT-client/bin/pgsqlsetup
@@ -73,6 +73,7 @@ $::debiancfgdir   = "/etc/postgresql/9.1/main";
 my $INIT;
 my $SETUPODBC;
 my @LISTENADDRS;
+my @ACCESSADDRS;
 my $NOSTART;
 my $SETUPPCM;
 my $HELP;
@@ -85,6 +86,7 @@ if (
         'i|init'    => \$INIT,
         'o|odbc'    => \$SETUPODBC,
         'l|listen=s'=> \@LISTENADDRS,
+        'a|access=s'=> \@ACCESSADDRS,
         'N|nostart' => \$NOSTART,
         'P|PCM'     => \$SETUPPCM,
         'h|help'    => \$HELP,
@@ -735,7 +737,8 @@ sub initpgdb
     }
     &runpostgrescmd($cmd);
 
-    # insert  MN ip address in the # IPv4 local connections: stanza of
+    # insert  MN ip address and any -a addresses 
+    # in the # IPv4 local connections: stanza of
     # the /var/lib/pgsql/data/pg_hba.conf file
     # if it is not already there
 
@@ -744,43 +747,44 @@ sub initpgdb
     if ($debianflag) {
         $hbafile = $::debiancfgdir . "/pg_hba.conf";
     }
-    $cmd = "fgrep  $::MN $hbafile";
-    xCAT::Utils->runcmd($cmd, -1);
-    if ($::RUNCMD_RC != 0)    # not already there
-    {
-        $cmd = "cp $hbafile $hbafile.org";    # backup the original
+		$cmd = "cp $hbafile $hbafile.org";    # backup the original
+		xCAT::Utils->runcmd($cmd, -1);
+
+    push @ACCESSADDRS, $::MN;  # add management node to list
+    my $insertstr = undef;     # start with empty string
+    for my $hbaaccess (@ACCESSADDRS)
+      {
+        $cmd = "fgrep $hbaaccess $hbafile";
         xCAT::Utils->runcmd($cmd, -1);
-        my $insertstr = "host    all          all        ";
-        $insertstr .= $::MN;
-        $insertstr .= "\/32      md5 ";
-        $cmd =
-"awk '{gsub(\"\IPv4 local connections:\",\"\IPv4 local connections:\\n$insertstr \"); print}'   $hbafile > $hbafile.xcat";
-        xCAT::Utils->runcmd($cmd, 0);
-
-        if ($::RUNCMD_RC != 0)
+        if ($::RUNCMD_RC != 0)    # not already there
         {
-
-            xCAT::MsgUtils->message("E", " $cmd failed.");
-            exit(1);
+            $insertstr .= "host    all          all        ";
+            $insertstr .= $hbaaccess;
+            $insertstr .= "\/32      md5\n "; # add entry line to string
         }
-        $cmd = "cp -p  $hbafile.xcat $hbafile  ";
-        xCAT::Utils->runcmd($cmd, 0);
-        if ($::RUNCMD_RC != 0)
-        {
-
-            xCAT::MsgUtils->message("E", " $cmd failed.");
-            exit(1);
-        }
-        $cmd = "rm  $hbafile.xcat ";
-        xCAT::Utils->runcmd($cmd, 0);
-        if ($::RUNCMD_RC != 0)
-        {
-
-            xCAT::MsgUtils->message("E", " $cmd failed.");
-            exit(1);
-        }
-        $dbrestart = 1;
-    }
+      }
+    $cmd = "awk '{gsub(\"\IPv4 local connections:\",\"\IPv4 local connections:\\n$insertstr \"); print}'   $hbafile > $hbafile.xcat";
+    xCAT::Utils->runcmd($cmd, 0);
+    if ($::RUNCMD_RC != 0)
+      {
+         xCAT::MsgUtils->message("E", " $cmd failed.");
+         exit(1);
+      }
+    $cmd = "cp -p  $hbafile.xcat $hbafile  ";
+    xCAT::Utils->runcmd($cmd, 0);
+    if ($::RUNCMD_RC != 0)
+      {
+         xCAT::MsgUtils->message("E", " $cmd failed.");
+         exit(1);
+      }
+    $cmd = "rm  $hbafile.xcat ";
+    xCAT::Utils->runcmd($cmd, 0);
+    if ($::RUNCMD_RC != 0)
+      {
+        xCAT::MsgUtils->message("E", " $cmd failed.");
+        exit(1);
+      }
+	  $dbrestart = 1;
 
     # setup the postgresql.conf file
     my $pgconf = $::installdatadir;

--- a/xCAT-client/pods/man1/pgsqlsetup.1.pod
+++ b/xCAT-client/pods/man1/pgsqlsetup.1.pod
@@ -52,7 +52,7 @@ This option is used to specify additional IP addresses on which the PostgreSQL d
 
 =item B<-a|--access> I<address>
 
-This option is used to specify additional IP addresses from which the service nodes will connect to the PostgreSQL database.  Without it, the management node will be configured for database access.  This option can be specified multiple times.
+This option is used to specify additional IP addresses from which the service nodes will connect to the PostgreSQL database.  Without it, only the management node will be configured for database access.  This option can be specified multiple times.
 
 =item B<-P|--PCM>
 

--- a/xCAT-client/pods/man1/pgsqlsetup.1.pod
+++ b/xCAT-client/pods/man1/pgsqlsetup.1.pod
@@ -9,7 +9,7 @@ B<pgsqlsetup> {B<-h> | B<--help>}
 
 B<pgsqlsetup> {B<-v> | B<--version>}
 
-B<pgsqlsetup> {B<-i> | B<--init>} [B<-N> | B<--nostart>] [B<--listen> | B<-l> I<address>] [B<-P> | B<--PCM>] [B<-o> | B<--odbc>] [B<-V> | B<--verbose>]
+B<pgsqlsetup> {B<-i> | B<--init>} [B<-N> | B<--nostart>] [B<--listen> | B<-l> I<address>] [B<--access> | B<-a> I<address>] [B<-P> | B<--PCM>] [B<-o> | B<--odbc>] [B<-V> | B<--verbose>]
 
 B<pgsqlsetup> {B<-o> | B<--setupODBC>} [B<-V> | B<--verbose>] 
 

--- a/xCAT-client/pods/man1/pgsqlsetup.1.pod
+++ b/xCAT-client/pods/man1/pgsqlsetup.1.pod
@@ -38,7 +38,7 @@ Displays verbose messages.
 
 The init option is used to setup an installed PostgreSQL database so that xCAT can use the database.  This involves creating the xcat database, the xcat admin id, allowing access to the xcatdb database by the Management Node. It customizes the postgresql.conf configuration file, adds the management server to the pg_hba.conf and starts the PostgreSQL server.  It also backs up the current xCAT database and restores it into the newly setup xcatdb PostgreSQL database.  It creates the /etc/xcat/cfgloc file to point the xcatd daemon to the PostgreSQL database and restarts the xcatd daemon using the database. 
 On AIX, it additionally setup the xcatadm unix id and the postgres id and group. For AIX, you should be using the PostgreSQL rpms available from the xCAT website. For Linux, you should use the PostgreSQL rpms shipped with the OS. You can chose the -o option, to run after the init.
-To add additional nodes to access the PostgreSQL server, setup on the Management Node,  edit the pg_hba.conf file.   
+To add additional nodes to access the PostgreSQL server, setup on the Management Node, use the -a option.   
 
 For more documentation see:Setting_Up_PostgreSQL_as_the_xCAT_DB
 
@@ -49,6 +49,10 @@ This option with the -i flag will create the database, but will not backup and r
 =item B<-l|--listen> I<address>
 
 This option is used to specify additional IP addresses on which the PostgreSQL database will listen.  Without it, only localhost (on Linux) and the management node's main IP (on Linux and AIX) will be configured.  This option can be specified multiple times.
+
+=item B<-a|--access> I<address>
+
+This option is used to specify additional IP addresses from which the service nodes will connect to the PostgreSQL database.  Without it, the management node will be configured for database access.  This option can be specified multiple times.
 
 =item B<-P|--PCM>
 


### PR DESCRIPTION
Currently pgsqlsetup(1) only sets up the MN ip address for access via
pg_hba.conf.  This change adds an -a flag to allow the user to specify
additional addresses for use in that file.

This is useful for users who already know what IP addresses will be
used by their service nodes, so they can pass them directly to the
pgsqlsetup program, without needing to edit pg_hba.conf (and avoiding
needing to restart postgresql and xcat after the edit).