### PR TITLE
enhance configeth configure instnic

### DIFF
--- a/xCAT-server/lib/perl/xCAT/Postage.pm
+++ b/xCAT-server/lib/perl/xCAT/Postage.pm
@@ -421,6 +421,9 @@ sub makescript {
         #get the node type, service node or compute node
         my $nodetype = getNodeType($node);
 
+        #get the node ip address
+        my $cnipaddr = xCAT::NetworkUtils->getipaddr($node);
+        #print "hello $cnipaddr $node";
         #print Dumper($noderesent);
         #print Dumper($routes);
         #routes
@@ -556,7 +559,7 @@ sub makescript {
         #$inc =~ s/#NODE#/$node/eg;
         $inc =~ s/#MASTER_IP_ADDR#/$master_ip/eg;
         $inc =~ s/\$NODE/$node/eg;
-
+        $inc =~ s/#IPADDR#/$cnipaddr/eg;
         #$inc =~ s/#TABLE:([^:]+):([^:]+):([^:]+):BLANKOKAY#/tabdb($1,$2,$3,1)/eg;
         $inc =~ s/#TABLE:([^:]+):([^:]+):([^#]+)#/xCAT::Template::tabdb($1,$2,$3)/eg;
         $inc =~ s/#ROUTES_VARS_EXPORT#/$route_vars/eg;

--- a/xCAT-server/share/xcat/mypostscript/mypostscript.tmpl
+++ b/xCAT-server/share/xcat/mypostscript/mypostscript.tmpl
@@ -25,6 +25,10 @@ tabdump(networks)
 NODE=$NODE
 export NODE
 
+#get compute node ip address
+IPADDR=#IPADDR#
+export IPADDR
+
 # get GROUP list
 GROUP=#TABLE:nodelist:$NODE:groups#
 export GROUP 

--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -425,7 +425,6 @@ elif [ "$1" = "-s" ];then
     str_inst_mask=''
     str_inst_gateway=''
     str_inst_mtu=''
-
     if [ "$str_os_type" = "aix" ];then
         logger -t xcat -p local4.err "configeth: aix does not support -s flag"
         log_error "configeth on $NODE: aix does not support -s flag"
@@ -476,7 +475,7 @@ elif [ "$1" = "-s" ];then
             fi
        fi
     else
-        str_lease_file=`ls /var/lib/dhclient/*$str_inst_nic* | grep lease >& /dev/null`
+        str_lease_file=`ls /var/lib/dhclient/*$str_inst_nic* | grep lease`
         if [ -e "$str_lease_file" ];then
             str_inst_ip=`grep fixed-address $str_lease_file | tail -n 1 | awk '{print $2}' | sed 's/;$//'`
             str_inst_mask=`grep subnet-mask $str_lease_file | tail -n 1 | awk '{print $3}' | sed 's/;$//'`
@@ -498,13 +497,16 @@ elif [ "$1" = "-s" ];then
             fi
         fi
     fi
+    if [ -n "$IPADDR" ];then
+        str_inst_ip=$IPADDR
+    fi
+    
     if [ -n "$MACADDRESS" ];then
         str_inst_mac=$MACADDRESS
     else
         #str_inst_mac=`ifconfig $str_inst_nic | grep HWaddr | awk -F'HWaddr' '{print $2}' | sed 's/\s*//'`
         str_inst_mac=`ip link show $netdev | grep ether | awk '{print $2}'`
     fi
-
     if [ -z "$str_inst_ip" -o -z "$str_inst_mask" ];then
         logger -t xcat -p local4.err "configeth: config install nic, can not find the information from lease file, return."
         log_info "configeth on $NODE: config install nic, can not find information from dhcp lease file, return."


### PR DESCRIPTION
enhance #3426 

Unit test:
In this case, ip from dhclient lease is 10.5.106.9, ip from node definition or DNS is 10.5.106.29
It is no need to configure nics table.
```
[root@bybc0602 postscripts]# updatenode bybc0609 "confignetwork -s"
bybc0609: xcatdsklspost: downloaded postscripts successfully
bybc0609: Fri Jul 21 05:32:37 EDT 2017 Running postscript: confignetwork
bybc0609: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bybc0609: [I]: configure the install nic eth0.
bybc0609: [I]: [I]: configeth on bybc0609: os type: redhat
bybc0609: [I]: GATEWAY=10.0.0.103
bybc0609: ['/etc/sysconfig/network-scripts/ifcfg-eth0']
bybc0609: [I]: >> DEVICE=eth0
bybc0609: [I]: >> IPADDR=10.5.106.29
bybc0609: [I]: >> NETMASK=255.0.0.0
bybc0609: [I]: >> BOOTPROTO=static
bybc0609: [I]: >> ONBOOT=yes
bybc0609: [I]: >> HWADDR=42:f5:0a:05:6a:09
bybc0609: [I]: >> MTU=1496
bybc0609: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
... ... 
```