### PR TITLE
Support passwordless ssh for pdu

### DIFF
--- a/xCAT-server/lib/xcat/plugins/pdu.pm
+++ b/xCAT-server/lib/xcat/plugins/pdu.pm
@@ -487,7 +487,8 @@ sub process_sshcfg {
         xCAT::SvrUtils::sendmsg($msg, $callback, $pdu, %allerrornodes);
 
         #remove old host key from /root/.ssh/known_hosts
-        $cmd = `ssh-keygen -R $pdu`;
+        $cmd = "ssh-keygen -R $pdu";
+        my $result = xCAT::Utils->runcmd($cmd, 0);
 
         my $static_ip = $nodehash->{$pdu}->[0]->{ip};
         my $discover_ip = $nodehash->{$pdu}->[0]->{otherinterfaces};

--- a/xCAT-server/lib/xcat/plugins/pdu.pm
+++ b/xCAT-server/lib/xcat/plugins/pdu.pm
@@ -488,7 +488,7 @@ sub process_sshcfg {
 
         #remove old host key from /root/.ssh/known_hosts
         $cmd = "ssh-keygen -R $pdu";
-        my $result = xCAT::Utils->runcmd($cmd, 0);
+        xCAT::Utils->runcmd($cmd, 0);
 
         my $static_ip = $nodehash->{$pdu}->[0]->{ip};
         my $discover_ip = $nodehash->{$pdu}->[0]->{otherinterfaces};


### PR DESCRIPTION
for Epic #3516 ,   use rspconfig command to config ssh passwordless for PDU
usage:

```
#rspconfig c685f2coralpdu sshcfg
# ssh c685f2coralpdu
Warning: Permanently added 'c685f2coralpdu' (ECDSA) to the list of known hosts.
Last login: Sun Jan 15 00:16:43 2017 from 172.10.1.5
root@c685f2coralpdu:~#

```