### PR TITLE
Supermicro rflash wait for ready RC from BMC

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -1707,7 +1707,8 @@ sub calc_ipmitool_version {
 #        verbose:  verbose output
 #        use_rc:   Some machines, like IBM Power S822LC for Big Data (Supermicro), do not return
 #                  a "00" ready string from calling ipmi raw command. Instead they return RC=0. This
-#                  flag tells the check_bmc_status_with_ipmitool() to check the RC instead of "00" string
+#                  flag if 1, tells the check_bmc_status_with_ipmitool() to check the RC 
+#                  instead of "00" string. If set to 0, the "00" ready string is checked.
 #    Returns:
 #        1 when bmc is up
 #        0 when no response from bmc
@@ -1728,7 +1729,7 @@ sub check_bmc_status_with_ipmitool {
     my $code_type    = "ready";
 
     if ($use_rc) {
-        $cmd            = $pre_cmd . " raw 0x3a 0x0a >> /dev/null 2>&1 ; echo \$?";
+        $cmd            = $cmd . " >> /dev/null 2>&1 ; echo \$?";
         $bmc_ready_code = "0";
         $code_type      = "return";
     }
@@ -1874,7 +1875,7 @@ sub do_firmware_update {
     # only 1.8.15 or above support hpm update for firestone machines.
     if (calc_ipmitool_version($ipmitool_ver) < calc_ipmitool_version("1.8.15")) {
         $callback->({ error => "IPMITool $ipmitool_ver do not support firmware update for " .
-                  "firestone mathines, please setup IPMITool 1.8.15 or above.",
+                  "firestone machines, please setup IPMITool 1.8.15 or above.",
                 errorcode => 1 });
         exit -1;
     }
@@ -2191,7 +2192,7 @@ RETRY_UPGRADE:
     }
 
     # check reset status
-    unless (check_bmc_status_with_ipmitool($pre_cmd, 5, 60, 2, $sessdata, $verbose)) {
+    unless (check_bmc_status_with_ipmitool($pre_cmd, 5, 60, 2, $sessdata, $verbose, 0)) {
         $exit_with_error_func->($sessdata->{node}, $callback,
             "Timeout to check the bmc status");
     }
@@ -2257,7 +2258,7 @@ RETRY_UPGRADE:
         }
 
         # Wait for BMC to reboot before continuing to next step
-        unless (check_bmc_status_with_ipmitool($pre_cmd, 5, 60, 10, $sessdata, $verbose)) {
+        unless (check_bmc_status_with_ipmitool($pre_cmd, 5, 60, 10, $sessdata, $verbose, 0)) {
             $exit_with_error_func->($sessdata->{node}, $callback,
                 "Timeout waiting for the bmc ready status. Firmware update suspended");
         }
@@ -2321,7 +2322,7 @@ RETRY_UPGRADE:
 
     # step 5 power on
     # check reset status
-    unless (check_bmc_status_with_ipmitool($pre_cmd, 5, 60, 10, $sessdata, $verbose)) {
+    unless (check_bmc_status_with_ipmitool($pre_cmd, 5, 60, 10, $sessdata, $verbose, 0)) {
         $exit_with_error_func->($sessdata->{node}, $callback,
             "Timeout to check the bmc status");
     }

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -1705,6 +1705,9 @@ sub calc_ipmitool_version {
 #        zz_retry: minimum number of 00 to receive before exiting
 #        sessdata: session data for display
 #        verbose:  verbose output
+#        use_rc:   Some machines, like IBM Power S822LC for Big Data (Supermicro), do not return
+#                  a "00" ready string from calling ipmi raw command. Instead they return RC=0. This
+#                  flag tells the check_bmc_status_with_ipmitool() to check the RC instead of "00" string
 #    Returns:
 #        1 when bmc is up
 #        0 when no response from bmc
@@ -1716,11 +1719,19 @@ sub check_bmc_status_with_ipmitool {
     my $zz_retry     = shift;
     my $sessdata     = shift;
     my $verbose      = shift;
+    my $use_rc       = shift;
     my $count        = 0;
     my $zz_count     = 0;
     my $bmc_response = 0;
     my $cmd          = $pre_cmd . " raw 0x3a 0x0a";
+    my $bmc_ready_code = "00";
+    my $code_type    = "ready";
 
+    if ($use_rc) {
+        $cmd            = $pre_cmd . " raw 0x3a 0x0a >> /dev/null 2>&1 ; echo \$?";
+        $bmc_ready_code = "0";
+        $code_type      = "return";
+    }
     # BMC response of " c0" means BMC still running IPL
     # BMC response of " 00" means ready to flash
     #
@@ -1730,18 +1741,18 @@ sub check_bmc_status_with_ipmitool {
     # interrupts it.
     while ($count < $retry) {
         $bmc_response = xCAT::Utils->runcmd($cmd, -1);
-        if ($bmc_response =~ /00/) {
+        if ($bmc_response =~ /$bmc_ready_code/) {
             if ($zz_count > $zz_retry) {
                 # zero-zero ready code was received for $zz_count iterations - good to exit
                 if ($verbose) {
-                    xCAT::SvrUtils::sendmsg("Received BMC ready code 00 for $zz_count iterations - BMC is ready.", $callback, $sessdata->{node}, %allerrornodes);
+                    xCAT::SvrUtils::sendmsg("Received BMC $code_type code $bmc_ready_code for $zz_count iterations - BMC is ready.", $callback, $sessdata->{node}, %allerrornodes);
                 }
                 return 1;
             }
             else {
                 # check to make sure zero-zero is received again
                 if ($verbose) {
-                    xCAT::SvrUtils::sendmsg("($zz_count) BMC ready code - 00", $callback, $sessdata->{node}, %allerrornodes);
+                    xCAT::SvrUtils::sendmsg("($zz_count) BMC $code_type code - $bmc_ready_code", $callback, $sessdata->{node}, %allerrornodes);
                 }
                 $zz_count++;
             }
@@ -1751,7 +1762,7 @@ sub check_bmc_status_with_ipmitool {
                 # zero-zero was received before, but now we get something else.
                 # reset the zero-zero counter to make sure we get $zz_count iterations of zero-zero
                 if ($verbose) {
-                    xCAT::SvrUtils::sendmsg("Resetting counter because BMC ready code - $bmc_response", $callback, $sessdata->{node}, %allerrornodes);
+                    xCAT::SvrUtils::sendmsg("Resetting counter because BMC $code_type code - $bmc_response", $callback, $sessdata->{node}, %allerrornodes);
                 }
                 $zz_count = 0;
             }
@@ -1760,7 +1771,7 @@ sub check_bmc_status_with_ipmitool {
         $count++;
     }
     if ($verbose) {
-        xCAT::SvrUtils::sendmsg("Never received 00 code after $count retries - BMC not ready.", $callback, $sessdata->{node}, %allerrornodes);
+        xCAT::SvrUtils::sendmsg("Never received $code_type code $bmc_ready_code after $count retries - BMC not ready.", $callback, $sessdata->{node}, %allerrornodes);
     }
     return 0;
 }
@@ -2005,6 +2016,22 @@ sub do_firmware_update {
         # the specified data directory
         xCAT::SvrUtils::sendmsg("rflash started, Please wait...", $callback, $sessdata->{node});
 
+        # step 1 power off
+        $cmd = $pre_cmd . " chassis power off";
+        if ($verbose) {
+            xCAT::SvrUtils::sendmsg("Preparing to upgrade firmware, powering chassis off...", $callback, $sessdata->{node}, %allerrornodes);
+        }
+        $output = xCAT::Utils->runcmd($cmd, -1);
+        if ($::RUNCMD_RC != 0) {
+            $exit_with_error_func->($sessdata->{node}, $callback,
+                "Running ipmitool command $cmd failed: $output");
+        }
+        unless (check_bmc_status_with_ipmitool($pre_cmd, 5, 10, 2, $sessdata, $verbose, 1)) {
+            $exit_with_error_func->($sessdata->{node}, $callback,
+            "Timeout to check the bmc status");
+        }
+
+        # step 2 update BMC file or PNOR file, or both
         if ($bmc_file) {
             # BMC file was found in data directory, run update with it
             my $pUpdate_bmc_cmd = "$pUpdate_directory/pUpdate -f $bmc_file -i lan -h $bmc_addr -u $bmc_userid -p $bmc_password >".$rflash_log_file." 2>&1";
@@ -2018,10 +2045,12 @@ sub do_firmware_update {
                 $exit_with_error_func->($sessdata->{node}, $callback,
                     "Error running command $pUpdate_bmc_cmd");
             }
-            if ($verbose) {
-                xCAT::SvrUtils::sendmsg([ 0, "Waiting for BMC to reboot (2 min)..." ], $callback, $sessdata->{node});
+            # Wait for BMC to reboot before continuing to next step.
+            # Since this is a IBM Power S822LC for Big Data (Supermicro) machine, use RC to check if ready 
+            unless (check_bmc_status_with_ipmitool($pre_cmd, 5, 60, 10, $sessdata, $verbose, 1)) {
+                $exit_with_error_func->($sessdata->{node}, $callback,
+                "Timeout to check the bmc status");
             }
-            sleep (120);
         }
 
 
@@ -2039,8 +2068,15 @@ sub do_firmware_update {
                     "Error running command $pUpdate_pnor_cmd");
             }
         }
+        # step 3 power on
+        $cmd = $pre_cmd . " chassis power on";
+        $output = xCAT::Utils->runcmd($cmd, -1);
+        if ($::RUNCMD_RC != 0) {
+            $exit_with_error_func->($sessdata->{node}, $callback,
+                "Running ipmitool command $cmd failed: $output");
+        }
 
-        $exit_with_success_func->($sessdata->{node}, $callback, "Firmware updated");
+        $exit_with_success_func->($sessdata->{node}, $callback, "Firmware updated, powering chassis on to populate FRU information...");
     }
 
     if (($hpm_data_hash{deviceID} ne $sessdata->{device_id}) ||
@@ -2339,7 +2375,7 @@ sub rflash {
                 $sessdata->{subcommand} = "check";
                 # support verbose options for ipmitool command
             } elsif ($opt !~ /.*\.hpm$/i && $opt !~ /^-V{1,4}$|^--buffersize=|^--retry=|^-d=/) {
-                $callback->({ error => "The option $opt is not supported",
+                $callback->({ error => "The option $opt is not supported or invalid update file specified",
                         errorcode => 1 });
                 return;
             }


### PR DESCRIPTION
The pull request improves the `rflash` process for IBM Power S822LC for Big Data (Supermicro) machines.

1. Issue `chassis power off` before `rflash` process and `chassis power on` at the end.
2. Wait for BMC "ready" return code after firmware flash before issuing `chassis power on` 

Output:

1. The existing rflash process for Minsky and Firestone has not changed:
```
[root@fs1 xcat]# rflash frame45cn12 /tmp/gurevich/8335GTB_820.1642.20170327n_update.hpm -V
frame45cn12: rflash started, upgrade failure will be retried up to 2 times. Please wait...
frame45cn12: Preparing to upgrade firmware, powering chassis off...
frame45cn12: (0) BMC ready code - 00
frame45cn12: (1) BMC ready code - 00
frame45cn12: (2) BMC ready code - 00
frame45cn12: Received BMC ready code 00 for 3 iterations - BMC is ready.
frame45cn12: rflashing ... See the detail progress : "tail -f /var/log/xcat/rflash/frame45cn12.log"
frame45cn12: (0) BMC ready code - 00
frame45cn12: (1) BMC ready code - 00
frame45cn12: (2) BMC ready code - 00
frame45cn12: Resetting counter because BMC ready code - Error: Unable to establish IPMI v2 / RMCP+ session
frame45cn12: (0) BMC ready code - 00
frame45cn12: (1) BMC ready code - 00
frame45cn12: (2) BMC ready code - 00
frame45cn12: (3) BMC ready code - 00
frame45cn12: (4) BMC ready code - 00
frame45cn12: (5) BMC ready code - 00
frame45cn12: (6) BMC ready code - 00
frame45cn12: (7) BMC ready code - 00
frame45cn12: (8) BMC ready code - 00
frame45cn12: (9) BMC ready code - 00
frame45cn12: (10) BMC ready code - 00
frame45cn12: Received BMC ready code 00 for 11 iterations - BMC is ready.
frame45cn12: Firmware updated, powering chassis on to populate FRU information...
frame45cn12: Success updating firmware.
[root@fs1 xcat]#
```

2. The `rflash` process for Supermicro machines now displays:
```
[root@stratton01 xcat]# rflash briggs01 -d=/root/supermicro/OP825 -V
briggs01: rflash started, Please wait...
briggs01: Preparing to upgrade firmware, powering chassis off...
briggs01: (0) BMC return code - 0
briggs01: (1) BMC return code - 0
briggs01: (2) BMC return code - 0
briggs01: Received BMC return code 0 for 3 iterations - BMC is ready.
briggs01: rflashing BMC, see the detail progress : "tail -f /var/log/xcat/rflash/briggs01.log"
briggs01: (0) BMC return code - 0
briggs01: Resetting counter because BMC return code - 1
briggs01: (0) BMC return code - 0
briggs01: (1) BMC return code - 0
briggs01: (2) BMC return code - 0
briggs01: (3) BMC return code - 0
briggs01: (4) BMC return code - 0
briggs01: (5) BMC return code - 0
briggs01: (6) BMC return code - 0
briggs01: (7) BMC return code - 0
briggs01: (8) BMC return code - 0
briggs01: (9) BMC return code - 0
briggs01: (10) BMC return code - 0
briggs01: Received BMC return code 0 for 11 iterations - BMC is ready.
briggs01: rflashing PNOR, see the detail progress : "tail -f /var/log/xcat/rflash/briggs01.log"
briggs01: Firmware updated, powering chassis on to populate FRU information...
[root@stratton01 xcat]#
```