### PR TITLE
modify rsetboot depending on URL & data

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1364,10 +1364,18 @@ sub rsetboot_response {
     my $response_info = decode_json $response->content;    
 
     if ($node_info{$node}{cur_status} eq "RSETBOOT_STATUS_RESPONSE") {
-        xCAT::SvrUtils::sendmsg("Hard Drive", $callback, $node) if ($response_info->{'data'}->{BootSource} =~ /Disk$/);
-        xCAT::SvrUtils::sendmsg("Network", $callback, $node) if ($response_info->{'data'}->{BootSource} =~ /Network$/);
-        xCAT::SvrUtils::sendmsg("CD/DVD", $callback, $node) if ($response_info->{'data'}->{BootSource} =~ /ExternalMedia$/);
-        xCAT::SvrUtils::sendmsg("Default", $callback, $node) if ($response_info->{'data'}->{BootSource} =~ /Default$/);
+        if ($response_info->{'data'}->{BootSource} =~ /Disk$/) {
+            xCAT::SvrUtils::sendmsg("Hard Drive", $callback, $node);
+        } elsif ($response_info->{'data'}->{BootSource} =~ /Network$/) {
+            xCAT::SvrUtils::sendmsg("Network", $callback, $node);
+        } elsif ($response_info->{'data'}->{BootSource} =~ /ExternalMedia$/) {
+            xCAT::SvrUtils::sendmsg("CD/DVD", $callback, $node);
+        } elsif ($response_info->{'data'}->{BootSource} =~ /Default$/) {
+            xCAT::SvrUtils::sendmsg("Default", $callback, $node);
+        } else {
+            my $error_msg = "Can not get valid rsetboot status, the data is " . $response_info->{'data'}->{BootSource};
+            xCAT::SvrUtils::sendmsg("$error_msg", $callback, $node);
+        }
     }
 
     if ($next_status{ $node_info{$node}{cur_status} }) {

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1367,7 +1367,7 @@ sub rsetboot_response {
         xCAT::SvrUtils::sendmsg("Hard Drive", $callback, $node) if ($response_info->{'data'}->{BootSource} =~ /Disk$/);
         xCAT::SvrUtils::sendmsg("Network", $callback, $node) if ($response_info->{'data'}->{BootSource} =~ /Network$/);
         xCAT::SvrUtils::sendmsg("CD/DVD", $callback, $node) if ($response_info->{'data'}->{BootSource} =~ /ExternalMedia$/);
-        xCAT::SvrUtils::sendmsg("boot override inactive", $callback, $node) if ($response_info->{'data'}->{BootSource} =~ /Default$/);
+        xCAT::SvrUtils::sendmsg("Default", $callback, $node) if ($response_info->{'data'}->{BootSource} =~ /Default$/);
     }
 
     if ($next_status{ $node_info{$node}{cur_status} }) {

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -217,15 +217,15 @@ my %status_info = (
 
     RSETBOOT_SET_REQUEST => {
         method         => "PUT",
-        init_url       => "$openbmc_project_url/control/boot/bootsource/attr/Sources",
-        data           => "xyz.openbmc_project.Control.Boot.Sources.",
+        init_url       => "$openbmc_project_url/control/host0/boot_source/attr/BootSource",
+        data           => "xyz.openbmc_project.Control.Boot.Source.Sources.",
     },
     RSETBOOT_SET_RESPONSE => {
         process        => \&rsetboot_response,
     },
     RSETBOOT_STATUS_REQUEST  => {
         method         => "GET",
-        init_url       => "$openbmc_project_url/control/boot/bootsource",
+        init_url       => "$openbmc_project_url/control/host0/boot_source",
     },
     RSETBOOT_STATUS_RESPONSE => {
         process        => \&rsetboot_response,
@@ -1363,7 +1363,7 @@ sub rsetboot_response {
 
     my $response_info = decode_json $response->content;    
 
-    if ($node_info{$node}{cur_status} eq "RSETBOOT_GET_RESPONSE") {
+    if ($node_info{$node}{cur_status} eq "RSETBOOT_STATUS_RESPONSE") {
         xCAT::SvrUtils::sendmsg("Hard Drive", $callback, $node) if ($response_info->{'data'}->{BootSource} =~ /Disk$/);
         xCAT::SvrUtils::sendmsg("Network", $callback, $node) if ($response_info->{'data'}->{BootSource} =~ /Network$/);
         xCAT::SvrUtils::sendmsg("CD/DVD", $callback, $node) if ($response_info->{'data'}->{BootSource} =~ /ExternalMedia$/);


### PR DESCRIPTION
Interface: (Version v1.99.8-79-g246c6f9-dirty)
```
 # curl -k -b cjar -X PUT -H "Content-Type: application/json" -d '{"data" : "xyz.openbmc_project.Control.Boot.Source.Sources.Default"}' https://9.3.185.161/xyz/openbmc_project/control/host0/boot_source/attr/BootSource
{
  "data": null,
  "message": "200 OK",
  "status": "ok"
}

# curl -k -b cjar -X GET https://9.3.185.161/xyz/openbmc_project/control/host0/boot_source
{
  "data": {
    "BootSource": "xyz.openbmc_project.Control.Boot.Source.Sources.Default"
  },
  "message": "200 OK",
  "status": "ok"
}
```

Output:
```
# rsetboot redfishtest hd
[OpenBMC development support] Using this version of xCAT, ensure firware level is at v1.99.6-0-r1, or higher.
redfishtest: Hard Drive
# rsetboot redfishtest stat
[OpenBMC development support] Using this version of xCAT, ensure firware level is at v1.99.6-0-r1, or higher.
redfishtest: boot override inactive
```