### PR TITLE
remove unsuitable cases from hardward control bundle

### DIFF
--- a/xCAT-test/autotest/bundle/hdctrl_openpower_ipmi.bundle
+++ b/xCAT-test/autotest/bundle/hdctrl_openpower_ipmi.bundle
@@ -1,10 +1,7 @@
 description:the cases in this bundle is to verify xCAT hardware control functions on servers which are managed using IPMI. 
 #INCLUDE:hdctrl_general.bundle#
-rinv_deviceid
 rinv_uuid
-rinv_guid
 rinv_vpd
-rinv_mprom
 rinv_wrongbmcpasswd
 rvitals_wattage
 rvitals_fanspeed

--- a/xCAT-test/autotest/bundle/hdctrl_openpower_openbmc.bundle
+++ b/xCAT-test/autotest/bundle/hdctrl_openpower_openbmc.bundle
@@ -1,6 +1,5 @@
 description:the cases in this bundle is to used to verify xCAT hardware control funtions on openpower servers which are mananged using openbmc. 
 #INCLUDE:hdctrl_general.bundle#
-rinv_deviceid
 rinv_uuid
 rinv_vpd
 rinv_cpu


### PR DESCRIPTION
Remove ``rinv_mprom`` and ``rinv_guid`` from ``hdctrl_openpower_ipmi.bundle`` since these 2 cases is just available in x86.  remove ``rinv_deviceid``  since it does not exist any more.