### PR TITLE
fix issue 3460: Changes required for 'rflash -c' to support more deta…

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -1622,6 +1622,13 @@ sub isopenpower {
 
 sub check_firmware_version {
 
+    sub _on_receive_ugp {
+        my $rsp     = shift;
+        my $sessdta = shift;
+        shift @{ $rsp->{data} };
+        return;
+    }
+
     sub _on_receive_version {
         my $rsp      = shift;
         my $sessdata = shift;
@@ -1650,6 +1657,15 @@ sub check_firmware_version {
     my $sessdata         = shift;
     my $firmware_version = shift;
     my $component_string = shift;
+
+    # GET TARGET UPGRADE CAPABILITIES
+    $sessdata->{ipmisession}->subcmd(netfn => 0x2c, command => 0x2e,
+            data => [ 0 ],
+            callback      => \&_on_receive_ugp,
+            callback_args => $sessdata);
+        while (xCAT::IPMI->waitforrsp()) { yield }
+
+
     foreach my $c_id (@{ $sessdata->{component_ids} }) {
         $sessdata->{c_id} = $c_id;
 


### PR DESCRIPTION
…iled firmware information for LC Big Data boxes

Fix issue #3460 

After checking the target upgrade capabilities, the hpm version on BMC is available:
Before the fix:
```
[root@stratton01 ~]# rflash briggs01 -c
briggs01: Node firmware version for SMC BMC FW   component:   0.00 00000000
briggs01: Node firmware version for PNOR FW      component:   0.00 00000000
briggs01: Node firmware version for  component:   0.00 00000000
```
After fix:
```
[root@stratton01 ~]# rflash briggs01 -c
briggs01: Node firmware version for SMC BMC FW   component:   1.21 00000000
briggs01: Node firmware version for PNOR FW      component:   5.12 20170000
briggs01: Node firmware version for  component:   0.00 00000000
```