### PR TITLE
Will not print EnergyManager error msg when run rvitals power

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -6702,9 +6702,9 @@ sub vitals {
     if ($sensor_filters{energy}) {
         if ($iem_support) {
             push @{ $sessdata->{sensorstoread} }, "energy";
-        } elsif (not $doall) {
-            xCAT::SvrUtils::sendmsg([ 1, ":Energy data requires additional IBM::EnergyManager plugin in conjunction with IMM managed IBM equipment" ], $callback, $sessdata->{node}, %allerrornodes);
-        }
+        } #elsif (not $doall) {
+            #xCAT::SvrUtils::sendmsg([ 1, ":Energy data requires additional IBM::EnergyManager plugin in conjunction with IMM managed IBM equipment" ], $callback, $sessdata->{node}, %allerrornodes);
+        #}
 
         #my @energies;
         #($rc,@energies)=readenergy();


### PR DESCRIPTION
When run ``rvitals power``, if did not install IBM::EnergyManager will print error msg and return 1.
Modified that will not print error msg and return 0.

Before change:
```
# rvitals c910f04x29 power
c910f04x29: Error: :Energy data requires additional IBM::EnergyManager plugin in conjunction with IMM managed IBM equipment
c910f04x29: AC Avg Power: 180 Watts (614 BTUs/hr)
c910f04x29: CPU Avg Power: 34 Watts (116 BTUs/hr)
c910f04x29: Chassis Fan Pwr: 7 Watts (24 BTUs/hr)
c910f04x29: Domain A AvgPwr: 65 Watts (222 BTUs/hr)
c910f04x29: Domain B AvgPwr: 70 Watts (239 BTUs/hr)
c910f04x29: MEM Avg Power: 6 Watts (20 BTUs/hr)
c910f04x29: Power Status: on
```

After change:
```
# rvitals c910f04x29 power
c910f04x29: AC Avg Power: 180 Watts (614 BTUs/hr)
c910f04x29: CPU Avg Power: 34 Watts (116 BTUs/hr)
c910f04x29: Chassis Fan Pwr: 6 Watts (20 BTUs/hr)
c910f04x29: Domain A AvgPwr: 65 Watts (222 BTUs/hr)
c910f04x29: Domain B AvgPwr: 65 Watts (222 BTUs/hr)
c910f04x29: MEM Avg Power: 6 Watts (20 BTUs/hr)
c910f04x29: Power Status: on
```