### PR TITLE
add test case for issue 3414 :  incorrect petitboot configuration for nodeset shell in flat 

### DIFF
--- a/xCAT-test/autotest/testcase/genesis/cases0
+++ b/xCAT-test/autotest/testcase/genesis/cases0
@@ -32,11 +32,11 @@ cmd:cat /tmp/genesistestlog/*
 end
 start:nodeset_shell_incorrectmasterip
 description:very if computenode need to do nodeset shell in different net with master will success
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh -check xnba
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh --check xnba
 check:rc==0
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh -check grub2
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh --check grub2
 check:rc==0
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh -check petitboot
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh --check petitboot
 check:rc==0
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh -c
 check:rc==0

--- a/xCAT-test/autotest/testcase/genesis/cases0
+++ b/xCAT-test/autotest/testcase/genesis/cases0
@@ -32,11 +32,11 @@ cmd:cat /tmp/genesistestlog/*
 end
 start:nodeset_shell_incorrectmasterip
 description:very if computenode need to do nodeset shell in different net with master will success
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh -cd xnba
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh -check xnba
 check:rc==0
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh -cd grub2
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh -check grub2
 check:rc==0
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh -cd petitboot
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh -check petitboot
 check:rc==0
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh -c
 check:rc==0

--- a/xCAT-test/autotest/testcase/genesis/cases0
+++ b/xCAT-test/autotest/testcase/genesis/cases0
@@ -30,19 +30,14 @@ cmd:perl /opt/xcat/share/xcat/tools/autotest/testcase/genesis/genesistest.pl -n 
 check:rc==0
 cmd:cat /tmp/genesistestlog/*
 end
-  
 start:nodeset_shell_incorrectmasterip
 description:very if computenode need to do nodeset shell in different net with master will success
-cmd:chdef testnode arch=ppc64le cons=ipmi groups=all ip=60.1.1.1 netboot=petitboot
-cmd:masterip=`lsdef -t site -i master -c  2>&1 | awk -F'=' '{print \$2}'`;echo $masterip;masternet=`ifconfig |awk "BEGIN{RS=\"\"}/\<$masterip\>/{print \$1}"|head -n 1 | awk -F ":" '{print \$1}'`;echo $masternet;net2=` netstat  -i |grep -v Kernel|grep  -v Iface |grep -v lo|grep -v $masternet|head -n 1|awk '{print \$1}'`;echo $net2;net2ip=`ifconfig $net2 |grep inet|grep -v inet6`;ifconfig $net2 60.3.3.3 ;makenetworks;makehosts;nodeset testnode  shell;cat /tftpboot/petitboot/testnode |grep "xcatd=60.3.3.3:3001 destiny=shell";if [[ $? -eq 0 ]] ;then if [[ -z $net2ip ]];then  ifconfig $net2 0.0.0.0;exit 0;else ifconfig $net2 $net2ip;exit 0;fi ;else exit 1;fi
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh -cd xnba
 check:rc==0
-cmd:chdef testnode arch=x86_64  netboot=xnba
-cmd:masterip=`lsdef -t site -i master -c  2>&1 | awk -F'=' '{print \$2}'`;echo $masterip;masternet=`ifconfig |awk "BEGIN{RS=\"\"}/\<$masterip\>/{print \$1}"|head -n 1 | awk -F ":" '{print \$1}'`;echo $masternet;net2=` netstat  -i |grep -v Kernel|grep  -v Iface |grep -v lo|grep -v $masternet|head -n 1|awk '{print \$1}'`;echo $net2;net2ip=`ifconfig $net2 |grep inet|grep -v inet6`;ifconfig $net2 60.3.3.3 ;makenetworks;makehosts;nodeset testnode  shell;cat /tftpboot/xcat/xnba/nodes/testnode |grep "xcatd=60.3.3.3:3001 destiny=shell";if [[ $? -eq 0 ]] ;then if [[ -z $net2ip ]];then  ifconfig $net2 0.0.0.0;exit 0;else ifconfig $net2 $net2ip;exit 0;fi ;else exit 1;fi
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh -cd grub2
 check:rc==0
-cmd:chdef testnode arch=x86_64  netboot=grub2
-cmd:masterip=`lsdef -t site -i master -c  2>&1 | awk -F'=' '{print \$2}'`;echo $masterip;masternet=`ifconfig |awk "BEGIN{RS=\"\"}/\<$masterip\>/{print \$1}"|head -n 1 | awk -F ":" '{print \$1}'`;echo $masternet;net2=` netstat  -i |grep -v Kernel|grep  -v Iface |grep -v lo|grep -v $masternet|head -n 1|awk '{print \$1}'`;echo $net2;net2ip=`ifconfig $net2 |grep inet|grep -v inet6`;ifconfig $net2 60.3.3.3 ;makenetworks;makehosts;nodeset testnode  shell; cat /tftpboot/boot/grub2/testnode |grep "xcatd=60.3.3.3:3001 destiny=shell";if [[ $? -eq 0 ]] ;then if [[ -z $net2ip ]];then  ifconfig $net2 0.0.0.0;exit 0;else ifconfig $net2 $net2ip;exit 0;fi ;else exit 1;fi
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh -cd petitboot
 check:rc==0
-cmd:makehosts -d testnode
-cmd:rmdef testnode
-cmd:rmdef -t network 60_0_0_0-255_0_0_0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh -c
+check:rc==0
 end

--- a/xCAT-test/autotest/testcase/genesis/cases0
+++ b/xCAT-test/autotest/testcase/genesis/cases0
@@ -30,3 +30,19 @@ cmd:perl /opt/xcat/share/xcat/tools/autotest/testcase/genesis/genesistest.pl -n 
 check:rc==0
 cmd:cat /tmp/genesistestlog/*
 end
+  
+start:nodeset_shell_incorrectmasterip
+description:very if computenode need to do nodeset shell in different net with master will success
+cmd:chdef testnode arch=ppc64le cons=ipmi groups=all ip=60.1.1.1 netboot=petitboot
+cmd:masterip=`lsdef -t site -i master -c  2>&1 | awk -F'=' '{print \$2}'`;echo $masterip;masternet=`ifconfig |awk "BEGIN{RS=\"\"}/\<$masterip\>/{print \$1}"|head -n 1 | awk -F ":" '{print \$1}'`;echo $masternet;net2=` netstat  -i |grep -v Kernel|grep  -v Iface |grep -v lo|grep -v $masternet|head -n 1|awk '{print \$1}'`;echo $net2;net2ip=`ifconfig $net2 |grep inet|grep -v inet6`;ifconfig $net2 60.3.3.3 ;makenetworks;makehosts;nodeset testnode  shell;cat /tftpboot/petitboot/testnode |grep "xcatd=60.3.3.3:3001 destiny=shell";if [[ $? -eq 0 ]] ;then if [[ -z $net2ip ]];then  ifconfig $net2 0.0.0.0;exit 0;else ifconfig $net2 $net2ip;exit 0;fi ;else exit 1;fi
+check:rc==0
+cmd:chdef testnode arch=x86_64  netboot=xnba
+cmd:masterip=`lsdef -t site -i master -c  2>&1 | awk -F'=' '{print \$2}'`;echo $masterip;masternet=`ifconfig |awk "BEGIN{RS=\"\"}/\<$masterip\>/{print \$1}"|head -n 1 | awk -F ":" '{print \$1}'`;echo $masternet;net2=` netstat  -i |grep -v Kernel|grep  -v Iface |grep -v lo|grep -v $masternet|head -n 1|awk '{print \$1}'`;echo $net2;net2ip=`ifconfig $net2 |grep inet|grep -v inet6`;ifconfig $net2 60.3.3.3 ;makenetworks;makehosts;nodeset testnode  shell;cat /tftpboot/xcat/xnba/nodes/testnode |grep "xcatd=60.3.3.3:3001 destiny=shell";if [[ $? -eq 0 ]] ;then if [[ -z $net2ip ]];then  ifconfig $net2 0.0.0.0;exit 0;else ifconfig $net2 $net2ip;exit 0;fi ;else exit 1;fi
+check:rc==0
+cmd:chdef testnode arch=x86_64  netboot=grub2
+cmd:masterip=`lsdef -t site -i master -c  2>&1 | awk -F'=' '{print \$2}'`;echo $masterip;masternet=`ifconfig |awk "BEGIN{RS=\"\"}/\<$masterip\>/{print \$1}"|head -n 1 | awk -F ":" '{print \$1}'`;echo $masternet;net2=` netstat  -i |grep -v Kernel|grep  -v Iface |grep -v lo|grep -v $masternet|head -n 1|awk '{print \$1}'`;echo $net2;net2ip=`ifconfig $net2 |grep inet|grep -v inet6`;ifconfig $net2 60.3.3.3 ;makenetworks;makehosts;nodeset testnode  shell; cat /tftpboot/boot/grub2/testnode |grep "xcatd=60.3.3.3:3001 destiny=shell";if [[ $? -eq 0 ]] ;then if [[ -z $net2ip ]];then  ifconfig $net2 0.0.0.0;exit 0;else ifconfig $net2 $net2ip;exit 0;fi ;else exit 1;fi
+check:rc==0
+cmd:makehosts -d testnode
+cmd:rmdef testnode
+cmd:rmdef -t network 60_0_0_0-255_0_0_0
+end

--- a/xCAT-test/autotest/testcase/genesis/test.sh
+++ b/xCAT-test/autotest/testcase/genesis/test.sh
@@ -45,7 +45,7 @@ SHELLFOLDER=""
 while [ "$#" -gt "0" ]
 do 
         case $1 in 
-                "-check"|"--check" )
+                "--check" )
                 NETBOOT=$2;
                     if [[ $NETBOOT =~ petitboot ]];then
                         SHELLFOLDER="/tftpboot/petitboot/";

--- a/xCAT-test/autotest/testcase/genesis/test.sh
+++ b/xCAT-test/autotest/testcase/genesis/test.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+function check_destiny(){
+chdef testnode arch=ppc64le cons=ipmi groups=all ip=60.1.1.1 netboot=$NETBOOT;
+masterip=`lsdef -t site -i master -c 2>&1 | awk -F'=' '{print $2}'`;
+masternet=`ifconfig  | awk "BEGIN{RS=\"\"}/\<$masterip\>/{print \$1}"|head -n 1 | awk -F ' ' '{print $1}'|awk -F ":"  '{print \$1}' 2>&1`;
+net2=`netstat -i -a|grep -v Kernel|grep -v Iface |grep -v lo|grep -v $masternet|head -n 1|awk '{print $1}'`;echo net2 is  $net2;
+net2ip="";
+    if [[ -z $net2 ]];then
+        echo null
+        return 1;
+    else
+        net2ipstring=`ifconfig $net2 |grep inet|grep -v inet6`;
+            if [[ $? -eq 0 ]];then
+                net2ip=`ifconfig $net2 |grep inet|grep -v inet6|awk -F ' ' '{print $2}'|awk -F ":" '{print $2}'`;
+                    if [[ -z $net2ip ]];then
+                        net2ip=`ifconfig $net2 |grep inet|grep -v inet6|awk -F ' ' '{print $2}'`;
+                    fi
+            else
+                net2ip=0.0.0.0;
+            fi
+        ifconfig $net2 60.3.3.3 ;
+        makenetworks;
+        makehosts testnode;
+        nodeset testnode  shell;
+        ifconfig $net2 "$net2ip";
+        cat "$SHELLFOLDER"testnode |grep "xcatd=60.3.3.3:3001 destiny=shell";
+            if [[ $? -eq 0 ]] ;then
+                return 0;
+            else 
+                echo wrong;
+                return 1;
+            fi
+    fi
+}
+function clear_env(){
+makehosts -d testnode
+rmdef testnode
+rmdef -t network 60_0_0_0-255_0_0_0
+    if [[ $? -eq 0 ]];then 
+       return 0;
+    else 
+       return 1;
+    fi
+}
+NETBOOT=""
+SHELLFOLDER=""
+while [ "$#" -gt "0" ]
+do 
+        case $1 in 
+                "-cd"|"--check" )
+                NETBOOT=$2;
+                    if [[ $NETBOOT =~ petitboot ]];then
+                        SHELLFOLDER="/tftpboot/petitboot/";
+                    elif [[ $NETBOOT =~  xnba ]];then
+                        SHELLFOLDER="/tftpboot/xcat/xnba/nodes/"
+                    else 
+                        SHELLFOLDER="/tftpboot/boot/grub2/";
+                    fi
+                    check_destiny ;
+                        if [[ $? -eq 1 ]];then
+                            exit 1
+                        else
+                            exit 0
+                        fi
+                ;;
+                "-c"|"--clear" )
+                clear_env; 
+                    if [[ $? -eq 1 ]];then
+                        exit 1
+                    else
+                        exit 0
+                    fi
+                ;;
+                *)
+                echo
+                echo "Please Insert $0: -cd|-c"
+                echo
+                exit 1;
+                ;;
+                esac
+done

--- a/xCAT-test/autotest/testcase/genesis/test.sh
+++ b/xCAT-test/autotest/testcase/genesis/test.sh
@@ -6,7 +6,7 @@ masternet=`ifconfig  | awk "BEGIN{RS=\"\"}/\<$masterip\>/{print \$1}"|head -n 1 
 net2=`netstat -i -a|grep -v Kernel|grep -v Iface |grep -v lo|grep -v $masternet|head -n 1|awk '{print $1}'`;echo net2 is  $net2;
 net2ip="";
     if [[ -z $net2 ]];then
-        echo null
+        echo "could not verify the test"
         return 1;
     else
         net2ipstring=`ifconfig $net2 |grep inet|grep -v inet6`;
@@ -19,7 +19,6 @@ net2ip="";
                 net2ip=0.0.0.0;
             fi
         ifconfig $net2 60.3.3.3 ;
-        makenetworks;
         makehosts testnode;
         nodeset testnode  shell;
         ifconfig $net2 "$net2ip";
@@ -35,7 +34,6 @@ net2ip="";
 function clear_env(){
 makehosts -d testnode
 rmdef testnode
-rmdef -t network 60_0_0_0-255_0_0_0
     if [[ $? -eq 0 ]];then 
        return 0;
     else 
@@ -47,7 +45,7 @@ SHELLFOLDER=""
 while [ "$#" -gt "0" ]
 do 
         case $1 in 
-                "-cd"|"--check" )
+                "-check"|"--check" )
                 NETBOOT=$2;
                     if [[ $NETBOOT =~ petitboot ]];then
                         SHELLFOLDER="/tftpboot/petitboot/";


### PR DESCRIPTION
nodeset shell in flat hierarchical #3480
This test case is used to test if master ip's network segment different with the compute node's ip's net,nodeset shell will success.