### PR TITLE
Draft CUDA installation test cases

### DIFF
--- a/xCAT-test/autotest/testcase/cuda/rhel-cuda-diskfull-install.sh
+++ b/xCAT-test/autotest/testcase/cuda/rhel-cuda-diskfull-install.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+########
+# Set all the variables below
+
+COMPUTE_NODE="c910f03c01p10"
+OSIMAGE_NAME="rhels7.3-ppc64le-install-cudafull"
+OSIMAGE_OTHERPKGDIR="/install/post/otherpkgs/rhels7.3/ppc64le"
+SOURCE_BASEDIR="/media/xcat"
+
+RHEL_ISO="${SOURCE_BASEDIR}/RHEL-7.3-20161019.0-Server-ppc64le-dvd1.iso"
+CUDA_RPMS=(
+	"${SOURCE_BASEDIR}/cuda-repo-rhel7-8-0-local-ga2v2-8.0.61-1.ppc64le.rpm"
+	"${SOURCE_BASEDIR}/cuda-repo-rhel7-8-0-local-cublas-performance-update-8.0.61-1.ppc64le.rpm"
+)
+DKMS_RPM="${SOURCE_BASEDIR}/dkms-2.3-5.20170523git8c3065c.el7.noarch.rpm"
+
+# Set all the variables above
+########
+
+[ -f "${RHEL_ISO}" ]
+[ "$?" -ne "0" ] && echo "File ${RHEL_ISO} not found." >&2 && exit 1
+copycds "${RHEL_ISO}"
+[ "$?" -ne "0" ] && echo "Copy CD failed." >&2 && exit 1
+
+rmdef -t osimage "${OSIMAGE_NAME}"
+mkdef -z <<-EOF
+# <xCAT data object stanza file>
+
+${OSIMAGE_NAME}:
+    objtype=osimage
+    imagetype=linux
+    osarch=ppc64le
+    osdistroname=rhels7.3-ppc64le
+    osname=Linux
+    osvers=rhels7.3
+    otherpkgdir="${OSIMAGE_OTHERPKGDIR}"
+    pkgdir=/install/rhels7.3/ppc64le
+    pkglist=/opt/xcat/share/xcat/install/rh/cudafull.rhels7.ppc64le.pkglist
+    profile=compute
+    provmethod=install
+    template=/opt/xcat/share/xcat/install/rh/compute.rhels7.tmpl
+EOF
+[ "$?" -ne "0" ] && echo "Make node definition failed." >&2 && exit 1
+
+rm -rf "${OSIMAGE_OTHERPKGDIR}"
+mkdir -p "${OSIMAGE_OTHERPKGDIR}"
+for f in "${CUDA_RPMS[@]}"
+do
+	[ -f "${f}" ]
+	[ "$?" -ne "0" ] && echo "File ${f} not found." >&2 && exit 1
+	rpm2cpio "${f}" | ( cd "${OSIMAGE_OTHERPKGDIR}" && cpio -ivd )
+done
+
+mkdir -p "${OSIMAGE_OTHERPKGDIR}"/dkms
+[ -f "${DKMS_RPM}" ]
+[ "$?" -ne "0" ] && echo "File ${DKMS_RPM} not found." >&2 && exit 1
+cp "${DKMS_RPM}" "${OSIMAGE_OTHERPKGDIR}/dkms"
+
+( cd "${OSIMAGE_OTHERPKGDIR}" && createrepo . )
+
+makedhcp -n
+rinstall "${COMPUTE_NODE}" "osimage=${OSIMAGE_NAME}"
+
+NETBOOT_TIMEOUT=600
+declare -i WAIT=0
+
+while sleep 10
+do
+	(( WAIT += 10 ))
+	nodestat "${COMPUTE_NODE}" | grep ': sshd$'
+	[ "$?" -eq "0" ] && break
+	[ "${WAIT}" -le "${NETBOOT_TIMEOUT}" ]
+	[ "$?" -ne "0" ] && echo "Netboot failed" >&2 && exit 1
+done
+
+# For workaround the GitHub issue #3549
+sleep 5
+
+xdsh "${COMPUTE_NODE}" date
+[ "$?" -ne "0" ] && echo "Failed connect to compute node via SSH." >&2 && exit 1
+
+xdsh "${COMPUTE_NODE}" 'rpm -q cuda' | grep ': cuda-'
+[ "$?" -ne "0" ] && echo "CUDA installation checking failed" >&2 && exit 1
+
+exit 0

--- a/xCAT-test/autotest/testcase/cuda/rhel-cuda-diskfull-install.sh
+++ b/xCAT-test/autotest/testcase/cuda/rhel-cuda-diskfull-install.sh
@@ -3,20 +3,102 @@
 ########
 # Set all the variables below
 
+LINUX_DISTRO="rhels7.4"
+LINUX_ARCH="ppc64le"
+
 COMPUTE_NODE="c910f03c01p10"
-OSIMAGE_NAME="rhels7.3-ppc64le-install-cudafull"
-OSIMAGE_OTHERPKGDIR="/install/post/otherpkgs/rhels7.3/ppc64le"
-SOURCE_BASEDIR="/media/xcat"
+SOURCE_DIR="/media/xcat"
 
-RHEL_ISO="${SOURCE_BASEDIR}/RHEL-7.3-20161019.0-Server-ppc64le-dvd1.iso"
-CUDA_RPMS=(
-	"${SOURCE_BASEDIR}/cuda-repo-rhel7-8-0-local-ga2v2-8.0.61-1.ppc64le.rpm"
-	"${SOURCE_BASEDIR}/cuda-repo-rhel7-8-0-local-cublas-performance-update-8.0.61-1.ppc64le.rpm"
-)
-DKMS_RPM="${SOURCE_BASEDIR}/dkms-2.3-5.20170523git8c3065c.el7.noarch.rpm"
-
-# Set all the variables above
 ########
+
+# $SOURCE_DIR is a directory this test case will be searched for.
+# Files with the name looked like the following will be searched.
+#
+# -rw-r--r-- 1 nobody nobody  124064759 Jun 28 16:58 cuda-repo-rhel7-8-0-local-cublas-performance-update-8.0.61-1.ppc64le.rpm
+# -rw-r--r-- 1 nobody nobody 1331397445 Feb 10 18:17 cuda-repo-rhel7-8-0-local-ga2v2-8.0.61-1.ppc64le.rpm
+# -rw-r--r-- 1 nobody nobody      79404 Jul 27 01:20 dkms-2.3-5.20170523git8c3065c.el7.noarch.rpm
+# -rwxrwxrwx 2 nobody nobody 3283865600 Jul 27 23:21 RHEL-7.4-20170711.0-Server-ppc64le-dvd1.iso
+
+########
+# Auto detect all the source packages from the ${SOURCE_DIR}
+
+[ -d "${SOURCE_DIR}" ]
+[ "$?" -ne "0" ] && echo "Directory ${SOURCE_DIR} not found." >&2 && exit 1
+
+declare RHEL_ISO
+declare -a CUDA_RPMS
+declare DKMS_RPM
+
+for f in "${SOURCE_DIR}"/*
+do
+	r="$(realpath "${f}")"
+	[ -f "${r}" ] || continue
+	case "${r##*/}" in
+	"RHEL-"*"-"*"-Server-${LINUX_ARCH}-dvd1.iso")
+		RHEL_ISO="${r}"
+		;;
+	"cuda-repo-rhel"*"-"*"-local-"*".${LINUX_ARCH}.rpm")
+		if [[ "$(echo "${r##*/}" |
+			sed -e 's#.*\([0-9]\+.[0-9]\+.[0-9]\+-[0-9]\+\).*#\1#')" \
+			> \
+			"$(echo "${CUDA_RPMS[0]}" |
+			sed -e 's#.*\([0-9]\+.[0-9]\+.[0-9]\+-[0-9]\+\).*#\1#')" ]]
+		then
+			CUDA_RPMS=("${r}")
+		elif [[ "$(echo "${r##*/}" |
+			sed -e 's#.*\([0-9]\+.[0-9]\+.[0-9]\+-[0-9]\+\).*#\1#')" \
+			= \
+			"$(echo "${CUDA_RPMS[0]}" |
+			sed -e 's#.*\([0-9]\+.[0-9]\+.[0-9]\+-[0-9]\+\).*#\1#')" ]]
+		then
+			CUDA_RPMS+=("${r}")
+		fi
+		;;
+	"dkms-"*".el7.noarch.rpm")
+		DKMS_RPM="${r}"
+		;;
+	esac
+done
+
+########
+# Override the auto detect results here.
+
+#RHEL_ISO="${SOURCE_DIR}/RHEL-7.4-20170711.0-Server-ppc64le-dvd1.iso"
+#CUDA_RPMS=(
+#	"${SOURCE_DIR}/cuda-repo-rhel7-8-0-local-ga2v2-8.0.61-1.ppc64le.rpm"
+#	"${SOURCE_DIR}/cuda-repo-rhel7-8-0-local-cublas-performance-update-8.0.61-1.ppc64le.rpm"
+#)
+#DKMS_RPM="${SOURCE_DIR}/dkms-2.3-5.20170523git8c3065c.el7.noarch.rpm"
+
+########
+echo "Red Hat Enterprise Linux Server ISO"
+echo "==================================="
+echo "${RHEL_ISO}"
+echo
+echo "CUDA RPM(s)"
+echo "==========="
+for f in "${CUDA_RPMS[@]}"
+do
+	echo "${f}"
+done
+echo
+echo "DKMS RPM"
+echo "========"
+echo "${DKMS_RPM}"
+echo
+
+echo "The files listed above were found and will be used for this test case"
+echo "Press Ctrl-C to abort!"
+for t in {5..1}
+do
+	echo -n " ... ${t}"
+	sleep 1
+	echo -n -e "\b\b\b\b\b\b"
+done
+########
+
+OSIMAGE_NAME="${LINUX_DISTRO}-${LINUX_ARCH}-install-cudafull"
+OSIMAGE_OTHERPKGDIR="/install/post/otherpkgs/${LINUX_DISTRO}/${LINUX_ARCH}"
 
 [ -f "${RHEL_ISO}" ]
 [ "$?" -ne "0" ] && echo "File ${RHEL_ISO} not found." >&2 && exit 1
@@ -30,16 +112,16 @@ mkdef -z <<-EOF
 ${OSIMAGE_NAME}:
     objtype=osimage
     imagetype=linux
-    osarch=ppc64le
-    osdistroname=rhels7.3-ppc64le
+    osarch=${LINUX_ARCH}
+    osdistroname=${LINUX_DISTRO}-${LINUX_ARCH}
     osname=Linux
-    osvers=rhels7.3
+    osvers=${LINUX_DISTRO}
     otherpkgdir="${OSIMAGE_OTHERPKGDIR}"
-    pkgdir=/install/rhels7.3/ppc64le
-    pkglist=/opt/xcat/share/xcat/install/rh/cudafull.rhels7.ppc64le.pkglist
+    pkgdir=/install/${LINUX_DISTRO}/${LINUX_ARCH}
+    pkglist=/opt/xcat/share/xcat/install/rh/cudafull.${LINUX_DISTRO%%.*}.${LINUX_ARCH}.pkglist
     profile=compute
     provmethod=install
-    template=/opt/xcat/share/xcat/install/rh/compute.rhels7.tmpl
+    template=/opt/xcat/share/xcat/install/rh/compute.${LINUX_DISTRO%%.*}.tmpl
 EOF
 [ "$?" -ne "0" ] && echo "Make node definition failed." >&2 && exit 1
 

--- a/xCAT-test/autotest/testcase/cuda/rhel-cuda-diskfull-install.sh
+++ b/xCAT-test/autotest/testcase/cuda/rhel-cuda-diskfull-install.sh
@@ -123,7 +123,7 @@ ${OSIMAGE_NAME}:
     provmethod=install
     template=/opt/xcat/share/xcat/install/rh/compute.${LINUX_DISTRO%%.*}.tmpl
 EOF
-[ "$?" -ne "0" ] && echo "Make node definition failed." >&2 && exit 1
+[ "$?" -ne "0" ] && echo "Make osimage definition failed." >&2 && exit 1
 
 rm -rf "${OSIMAGE_OTHERPKGDIR}"
 mkdir -p "${OSIMAGE_OTHERPKGDIR}"

--- a/xCAT-test/autotest/testcase/cuda/rhel-cuda-diskless-install.sh
+++ b/xCAT-test/autotest/testcase/cuda/rhel-cuda-diskless-install.sh
@@ -7,16 +7,94 @@ LINUX_DISTRO="rhels7.4"
 LINUX_ARCH="ppc64le"
 
 COMPUTE_NODE="c910f03c01p10"
-SOURCE_BASEDIR="/media/xcat"
+SOURCE_DIR="/media/xcat"
 
-RHEL_ISO="${SOURCE_BASEDIR}/RHEL-7.4-20170711.0-Server-ppc64le-dvd1.iso"
-CUDA_RPMS=(
-	"${SOURCE_BASEDIR}/cuda-repo-rhel7-8-0-local-ga2v2-8.0.61-1.ppc64le.rpm"
-	"${SOURCE_BASEDIR}/cuda-repo-rhel7-8-0-local-cublas-performance-update-8.0.61-1.ppc64le.rpm"
-)
-DKMS_RPM="${SOURCE_BASEDIR}/dkms-2.3-5.20170523git8c3065c.el7.noarch.rpm"
+########
 
-# Set all the variables above
+# $SOURCE_DIR is a directory this test case will be searched for.
+# Files with the name looked like the following will be searched.
+#
+# -rw-r--r-- 1 nobody nobody  124064759 Jun 28 16:58 cuda-repo-rhel7-8-0-local-cublas-performance-update-8.0.61-1.ppc64le.rpm
+# -rw-r--r-- 1 nobody nobody 1331397445 Feb 10 18:17 cuda-repo-rhel7-8-0-local-ga2v2-8.0.61-1.ppc64le.rpm
+# -rw-r--r-- 1 nobody nobody      79404 Jul 27 01:20 dkms-2.3-5.20170523git8c3065c.el7.noarch.rpm
+# -rwxrwxrwx 2 nobody nobody 3283865600 Jul 27 23:21 RHEL-7.4-20170711.0-Server-ppc64le-dvd1.iso
+
+########
+# Auto detect all the source packages from the ${SOURCE_DIR}
+
+[ -d "${SOURCE_DIR}" ]
+[ "$?" -ne "0" ] && echo "Directory ${SOURCE_DIR} not found." >&2 && exit 1
+
+declare RHEL_ISO
+declare -a CUDA_RPMS
+declare DKMS_RPM
+
+for f in "${SOURCE_DIR}"/*
+do
+	r="$(realpath "${f}")"
+	[ -f "${r}" ] || continue
+	case "${r##*/}" in
+	"RHEL-"*"-"*"-Server-${LINUX_ARCH}-dvd1.iso")
+		RHEL_ISO="${r}"
+		;;
+	"cuda-repo-rhel"*"-"*"-local-"*".${LINUX_ARCH}.rpm")
+		if [[ "$(echo "${r##*/}" |
+			sed -e 's#.*\([0-9]\+.[0-9]\+.[0-9]\+-[0-9]\+\).*#\1#')" \
+			> \
+			"$(echo "${CUDA_RPMS[0]}" |
+			sed -e 's#.*\([0-9]\+.[0-9]\+.[0-9]\+-[0-9]\+\).*#\1#')" ]]
+		then
+			CUDA_RPMS=("${r}")
+		elif [[ "$(echo "${r##*/}" |
+			sed -e 's#.*\([0-9]\+.[0-9]\+.[0-9]\+-[0-9]\+\).*#\1#')" \
+			= \
+			"$(echo "${CUDA_RPMS[0]}" |
+			sed -e 's#.*\([0-9]\+.[0-9]\+.[0-9]\+-[0-9]\+\).*#\1#')" ]]
+		then
+			CUDA_RPMS+=("${r}")
+		fi
+		;;
+	"dkms-"*".el7.noarch.rpm")
+		DKMS_RPM="${r}"
+		;;
+	esac
+done
+
+########
+# Override the auto detect results here.
+
+#RHEL_ISO="${SOURCE_DIR}/RHEL-7.4-20170711.0-Server-ppc64le-dvd1.iso"
+#CUDA_RPMS=(
+#	"${SOURCE_DIR}/cuda-repo-rhel7-8-0-local-ga2v2-8.0.61-1.ppc64le.rpm"
+#	"${SOURCE_DIR}/cuda-repo-rhel7-8-0-local-cublas-performance-update-8.0.61-1.ppc64le.rpm"
+#)
+#DKMS_RPM="${SOURCE_DIR}/dkms-2.3-5.20170523git8c3065c.el7.noarch.rpm"
+
+########
+echo "Red Hat Enterprise Linux Server ISO"
+echo "==================================="
+echo "${RHEL_ISO}"
+echo
+echo "CUDA RPM(s)"
+echo "==========="
+for f in "${CUDA_RPMS[@]}"
+do
+	echo "${f}"
+done
+echo
+echo "DKMS RPM"
+echo "========"
+echo "${DKMS_RPM}"
+echo
+
+echo "The files listed above were found and will be used for this test case"
+echo "Press Ctrl-C to abort!"
+for t in {5..1}
+do
+	echo -n " ... ${t}"
+	sleep 1
+	echo -n -e "\b\b\b\b\b\b"
+done
 ########
 
 OSIMAGE_NAME="${LINUX_DISTRO}-${LINUX_ARCH}-netboot-cudafull"

--- a/xCAT-test/autotest/testcase/cuda/rhel-cuda-diskless-install.sh
+++ b/xCAT-test/autotest/testcase/cuda/rhel-cuda-diskless-install.sh
@@ -128,7 +128,7 @@ ${OSIMAGE_NAME}:
     provmethod=netboot
     rootimgdir=${OSIMAGE_ROOTIMGDIR}
 EOF
-[ "$?" -ne "0" ] && echo "Make node definition failed." >&2 && exit 1
+[ "$?" -ne "0" ] && echo "Make osimage definition failed." >&2 && exit 1
 
 rm -rf "${OSIMAGE_OTHERPKGDIR}"
 mkdir -p "${OSIMAGE_OTHERPKGDIR}"

--- a/xCAT-test/autotest/testcase/cuda/rhel-cuda-diskless-install.sh
+++ b/xCAT-test/autotest/testcase/cuda/rhel-cuda-diskless-install.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+########
+# Set all the variables below
+
+COMPUTE_NODE="c910f03c01p10"
+OSIMAGE_NAME="rhels7.3-ppc64le-netboot-cudafull"
+OSIMAGE_OTHERPKGDIR="/install/post/otherpkgs/rhels7.3/ppc64le"
+SOURCE_BASEDIR="/media/xcat"
+
+RHEL_ISO="${SOURCE_BASEDIR}/RHEL-7.3-20161019.0-Server-ppc64le-dvd1.iso"
+CUDA_RPMS=(
+	"${SOURCE_BASEDIR}/cuda-repo-rhel7-8-0-local-ga2v2-8.0.61-1.ppc64le.rpm"
+	"${SOURCE_BASEDIR}/cuda-repo-rhel7-8-0-local-cublas-performance-update-8.0.61-1.ppc64le.rpm"
+)
+DKMS_RPM="${SOURCE_BASEDIR}/dkms-2.3-5.20170523git8c3065c.el7.noarch.rpm"
+
+# Set all the variables above
+########
+
+OSIMAGE_ROOTIMGDIR="/install/netboot/rhels7.3/ppc64le/${OSIMAGE_NAME}"
+
+[ -f "${RHEL_ISO}" ]
+[ "$?" -ne "0" ] && echo "File ${RHEL_ISO} not found." >&2 && exit 1
+copycds "${RHEL_ISO}"
+[ "$?" -ne "0" ] && echo "Copy CD failed." >&2 && exit 1
+
+rmdef -t osimage "${OSIMAGE_NAME}"
+mkdef -z <<-EOF
+# <xCAT data object stanza file>
+
+${OSIMAGE_NAME}:
+    objtype=osimage
+    exlist=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.exlist
+    imagetype=linux
+    osarch=ppc64le
+    osdistroname=rhels7.3-ppc64le
+    osname=Linux
+    osvers=rhels7.3
+    otherpkgdir="${OSIMAGE_OTHERPKGDIR}"
+    otherpkglist=/opt/xcat/share/xcat/netboot/rh/cudafull.rhels7.ppc64le.otherpkgs.pkglist
+    permission=755
+    pkgdir=/install/rhels7.3/ppc64le
+    pkglist=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist
+    postinstall=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.postinstall
+    profile=compute
+    provmethod=netboot
+    rootimgdir=${OSIMAGE_ROOTIMGDIR}
+EOF
+[ "$?" -ne "0" ] && echo "Make node definition failed." >&2 && exit 1
+
+rm -rf "${OSIMAGE_OTHERPKGDIR}"
+mkdir -p "${OSIMAGE_OTHERPKGDIR}"
+for f in "${CUDA_RPMS[@]}"
+do
+	[ -f "${f}" ]
+	[ "$?" -ne "0" ] && echo "File ${f} not found." >&2 && exit 1
+	rpm2cpio "${f}" | ( cd "${OSIMAGE_OTHERPKGDIR}" && cpio -ivd )
+done
+
+mkdir -p "${OSIMAGE_OTHERPKGDIR}"/dkms
+[ -f "${DKMS_RPM}" ]
+[ "$?" -ne "0" ] && echo "File ${DKMS_RPM} not found." >&2 && exit 1
+cp "${DKMS_RPM}" "${OSIMAGE_OTHERPKGDIR}/dkms"
+
+( cd "${OSIMAGE_OTHERPKGDIR}" && createrepo . )
+
+rm -rf "${OSIMAGE_ROOTIMGDIR}"
+
+genimage "${OSIMAGE_NAME}"
+[ "$?" -ne "0" ] && echo "genimage failed" >&2 && exit 1
+packimage "${OSIMAGE_NAME}"
+[ "$?" -ne "0" ] && echo "packimage failed" >&2 && exit 1
+
+makedhcp -n
+rinstall "${COMPUTE_NODE}" "osimage=${OSIMAGE_NAME}"
+
+NETBOOT_TIMEOUT=600
+declare -i WAIT=0
+
+while sleep 10
+do
+	(( WAIT += 10 ))
+	nodestat "${COMPUTE_NODE}" | grep ': sshd$'
+	[ "$?" -eq "0" ] && break
+	[ "${WAIT}" -le "${NETBOOT_TIMEOUT}" ]
+	[ "$?" -ne "0" ] && echo "Netboot failed" >&2 && exit 1
+done
+
+# For workaround the GitHub issue #3549
+sleep 5
+
+xdsh "${COMPUTE_NODE}" date
+[ "$?" -ne "0" ] && echo "Failed connect to compute node via SSH." >&2 && exit 1
+
+xdsh "${COMPUTE_NODE}" 'rpm -q cuda' | grep ': cuda-'
+[ "$?" -ne "0" ] && echo "CUDA installation checking failed" >&2 && exit 1
+
+exit 0

--- a/xCAT-test/autotest/testcase/cuda/rhel-cuda-diskless-install.sh
+++ b/xCAT-test/autotest/testcase/cuda/rhel-cuda-diskless-install.sh
@@ -3,12 +3,13 @@
 ########
 # Set all the variables below
 
+LINUX_DISTRO="rhels7.4"
+LINUX_ARCH="ppc64le"
+
 COMPUTE_NODE="c910f03c01p10"
-OSIMAGE_NAME="rhels7.3-ppc64le-netboot-cudafull"
-OSIMAGE_OTHERPKGDIR="/install/post/otherpkgs/rhels7.3/ppc64le"
 SOURCE_BASEDIR="/media/xcat"
 
-RHEL_ISO="${SOURCE_BASEDIR}/RHEL-7.3-20161019.0-Server-ppc64le-dvd1.iso"
+RHEL_ISO="${SOURCE_BASEDIR}/RHEL-7.4-20170711.0-Server-ppc64le-dvd1.iso"
 CUDA_RPMS=(
 	"${SOURCE_BASEDIR}/cuda-repo-rhel7-8-0-local-ga2v2-8.0.61-1.ppc64le.rpm"
 	"${SOURCE_BASEDIR}/cuda-repo-rhel7-8-0-local-cublas-performance-update-8.0.61-1.ppc64le.rpm"
@@ -18,7 +19,9 @@ DKMS_RPM="${SOURCE_BASEDIR}/dkms-2.3-5.20170523git8c3065c.el7.noarch.rpm"
 # Set all the variables above
 ########
 
-OSIMAGE_ROOTIMGDIR="/install/netboot/rhels7.3/ppc64le/${OSIMAGE_NAME}"
+OSIMAGE_NAME="${LINUX_DISTRO}-${LINUX_ARCH}-netboot-cudafull"
+OSIMAGE_OTHERPKGDIR="/install/post/otherpkgs/${LINUX_DISTRO}/${LINUX_ARCH}"
+OSIMAGE_ROOTIMGDIR="/install/netboot/${LINUX_DISTRO}/${LINUX_ARCH}/${OSIMAGE_NAME}"
 
 [ -f "${RHEL_ISO}" ]
 [ "$?" -ne "0" ] && echo "File ${RHEL_ISO} not found." >&2 && exit 1
@@ -31,18 +34,18 @@ mkdef -z <<-EOF
 
 ${OSIMAGE_NAME}:
     objtype=osimage
-    exlist=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.exlist
+    exlist=/opt/xcat/share/xcat/netboot/rh/compute.${LINUX_DISTRO%%.*}.${LINUX_ARCH}.exlist
     imagetype=linux
-    osarch=ppc64le
-    osdistroname=rhels7.3-ppc64le
+    osarch=${LINUX_ARCH}
+    osdistroname=${LINUX_DISTRO}-${LINUX_ARCH}
     osname=Linux
-    osvers=rhels7.3
+    osvers=${LINUX_DISTRO}
     otherpkgdir="${OSIMAGE_OTHERPKGDIR}"
-    otherpkglist=/opt/xcat/share/xcat/netboot/rh/cudafull.rhels7.ppc64le.otherpkgs.pkglist
+    otherpkglist=/opt/xcat/share/xcat/netboot/rh/cudafull.${LINUX_DISTRO%%.*}.${LINUX_ARCH}.otherpkgs.pkglist
     permission=755
-    pkgdir=/install/rhels7.3/ppc64le
-    pkglist=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist
-    postinstall=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.postinstall
+    pkgdir=/install/${LINUX_DISTRO}/${LINUX_ARCH}
+    pkglist=/opt/xcat/share/xcat/netboot/rh/compute.${LINUX_DISTRO%%.*}.${LINUX_ARCH}.pkglist
+    postinstall=/opt/xcat/share/xcat/netboot/rh/compute.${LINUX_DISTRO%%.*}.${LINUX_ARCH}.postinstall
     profile=compute
     provmethod=netboot
     rootimgdir=${OSIMAGE_ROOTIMGDIR}

--- a/xCAT-test/autotest/testcase/cuda/ubuntu-cuda-diskfull-install.sh
+++ b/xCAT-test/autotest/testcase/cuda/ubuntu-cuda-diskfull-install.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+
+########
+# Set all the variables below
+
+LINUX_DISTRO="ubuntu16.04.2"
+LINUX_ARCH="ppc64el"
+
+COMPUTE_NODE="c910f03c11k06"
+SOURCE_DIR="/media/xcat"
+
+########
+
+# $SOURCE_DIR is a directory this test case will be searched for.
+# Files with the name looked like the following will be searched.
+#
+# -rw-r--r-- 1 nobody nobody  124037944 Jun 28 17:00 cuda-repo-ubuntu1604-8-0-local-cublas-performance-update_8.0.61-1_ppc64el.deb
+# -rw-r--r-- 1 nobody nobody 1321330418 Feb 10 18:18 cuda-repo-ubuntu1604-8-0-local-ga2v2_8.0.61-1_ppc64el.deb
+# -rw-r--r-- 1 nobody nobody   69365760 Jul 27 20:35 mini.iso
+# -rw-r--r-- 1 nobody nobody  927946752 Feb 15 15:57 ubuntu-16.04.2-server-ppc64el.iso
+
+########
+# Auto detect all the source packages from the ${SOURCE_DIR}
+
+[ -d "${SOURCE_DIR}" ]
+[ "$?" -ne "0" ] && echo "Directory ${SOURCE_DIR} not found." >&2 && exit 1
+
+declare UBUNTU_ISO
+declare UBUNTU_MINI_ISO
+declare -a CUDA_DEBS
+
+for f in "${SOURCE_DIR}"/*
+do
+	r="$(realpath "${f}")"
+	[ -f "${r}" ] || continue
+	case "${r##*/}" in
+	"ubuntu-"*"-server-${LINUX_ARCH}.iso")
+		UBUNTU_ISO="${r}"
+		;;
+	*"mini.iso")
+		UBUNTU_MINI_ISO="${r}"
+		;;
+	"cuda-repo-ubuntu"*"-"*"-local-"*"_${LINUX_ARCH}.deb")
+		if [[ "$(echo "${r##*/}" |
+			sed -e 's#.*\([0-9]\+.[0-9]\+.[0-9]\+-[0-9]\+\).*#\1#')" \
+			> \
+			"$(echo "${CUDA_DEBS[0]}" |
+			sed -e 's#.*\([0-9]\+.[0-9]\+.[0-9]\+-[0-9]\+\).*#\1#')" ]]
+		then
+			CUDA_DEBS=("${r}")
+		elif [[ "$(echo "${r##*/}" |
+			sed -e 's#.*\([0-9]\+.[0-9]\+.[0-9]\+-[0-9]\+\).*#\1#')" \
+			= \
+			"$(echo "${CUDA_DEBS[0]}" |
+			sed -e 's#.*\([0-9]\+.[0-9]\+.[0-9]\+-[0-9]\+\).*#\1#')" ]]
+		then
+			CUDA_DEBS+=("${r}")
+		fi
+		;;
+	esac
+done
+
+########
+# Override the auto detect results here.
+
+#UBUNTU_ISO="${SOURCE_DIR}/ubuntu-16.04.2-server-ppc64el.iso"
+#UBUNTU_MINI_ISO="${SOURCE_DIR}/mini.iso"
+#CUDA_DEBS=(
+#	"${SOURCE_DIR}/cuda-repo-ubuntu1604-8-0-local-ga2v2_8.0.61-1_ppc64el.deb"
+#	"${SOURCE_DIR}/cuda-repo-ubuntu1604-8-0-local-cublas-performance-update_8.0.61-1_ppc64el.deb"
+#)
+
+########
+echo "Ubuntu ISO"
+echo "==================================="
+echo "${UBUNTU_ISO}"
+echo
+echo "Ubuntu mini ISO"
+echo "==================================="
+echo "${UBUNTU_MINI_ISO}"
+echo
+echo "CUDA DEB(s)"
+echo "==========="
+for f in "${CUDA_DEBS[@]}"
+do
+	echo "${f}"
+done
+echo
+
+echo "The files listed above were found and will be used for this test case"
+echo "Press Ctrl-C to abort!"
+for t in {5..1}
+do
+	echo -n " ... ${t}"
+	sleep 1
+	echo -n -e "\b\b\b\b\b\b"
+done
+########
+
+OSIMAGE_NAME="${LINUX_DISTRO}-${LINUX_ARCH}-install-cudafull"
+OSIMAGE_OTHERPKGDIR="/install/post/otherpkgs/${LINUX_DISTRO}/${LINUX_ARCH}"
+
+[ -f "${UBUNTU_ISO}" ]
+[ "$?" -ne "0" ] && echo "File ${UBUNTU_ISO} not found." >&2 && exit 1
+copycds "${UBUNTU_ISO}"
+[ "$?" -ne "0" ] && echo "Copy CD failed." >&2 && exit 1
+
+[ -f "${UBUNTU_MINI_ISO}" ]
+[ "$?" -ne "0" ] && echo "File ${UBUNTU_MINI_ISO} not found." >&2 && exit 1
+MOUNT_POINT="/tmp/ubuntu-mini-iso-$$"
+mkdir -p "${MOUNT_POINT}"
+mount -o loop "${UBUNTU_MINI_ISO}" "${MOUNT_POINT}"
+mkdir -p "/install/${LINUX_DISTRO}/${LINUX_ARCH}/install/netboot"
+cp "${MOUNT_POINT}/install/"* "/install/${LINUX_DISTRO}/${LINUX_ARCH}/install/netboot"
+umount "${MOUNT_POINT}"
+rmdir "${MOUNT_POINT}"
+
+rmdef -t osimage "${OSIMAGE_NAME}"
+mkdef -z <<-EOF
+# <xCAT data object stanza file>
+
+${OSIMAGE_NAME}:
+    objtype=osimage
+    imagetype=linux
+    osarch=${LINUX_ARCH}
+    osname=Linux
+    osvers=${LINUX_DISTRO}
+    otherpkgdir=${OSIMAGE_OTHERPKGDIR}/var/cuda/repo-8-0-local-ga2v2,http://ports.ubuntu.com/ubuntu-ports/ xenial
+    pkgdir=/install/${LINUX_DISTRO}/${LINUX_ARCH}
+    pkglist=/opt/xcat/share/xcat/install/ubuntu/compute.${LINUX_DISTRO}.${LINUX_ARCH}.pkglist
+    profile=compute
+    provmethod=install
+    template=/opt/xcat/share/xcat/install/ubuntu/compute.tmpl
+EOF
+[ "$?" -ne "0" ] && echo "Make node definition failed." >&2 && exit 1
+
+rm -rf "${OSIMAGE_OTHERPKGDIR}"
+mkdir -p "${OSIMAGE_OTHERPKGDIR}"
+for f in "${CUDA_DEBS[@]}"
+do
+	[ -f "${f}" ]
+	[ "$?" -ne "0" ] && echo "File ${f} not found." >&2 && exit 1
+	dpkg -x "${f}" "${OSIMAGE_OTHERPKGDIR}"
+done
+
+makedhcp -n
+rinstall "${COMPUTE_NODE}" "osimage=${OSIMAGE_NAME}"
+
+NETBOOT_TIMEOUT=600
+declare -i WAIT=0
+
+while sleep 10
+do
+	(( WAIT += 10 ))
+	nodestat "${COMPUTE_NODE}" | grep ': sshd$'
+	[ "$?" -eq "0" ] && break
+	[ "${WAIT}" -le "${NETBOOT_TIMEOUT}" ]
+	[ "$?" -ne "0" ] && echo "Netboot failed" >&2 && exit 1
+done
+
+# For workaround the GitHub issue #3549
+sleep 5
+
+xdsh "${COMPUTE_NODE}" date
+[ "$?" -ne "0" ] && echo "Failed connect to compute node via SSH." >&2 && exit 1
+
+xdsh "${COMPUTE_NODE}" 'rpm -q cuda' | grep ': cuda-'
+[ "$?" -ne "0" ] && echo "CUDA installation checking failed" >&2 && exit 1
+
+exit 0

--- a/xCAT-test/autotest/testcase/cuda/ubuntu-cuda-diskfull-install.sh
+++ b/xCAT-test/autotest/testcase/cuda/ubuntu-cuda-diskfull-install.sh
@@ -127,12 +127,12 @@ ${OSIMAGE_NAME}:
     osvers=${LINUX_DISTRO}
     otherpkgdir=${OSIMAGE_OTHERPKGDIR}/var/cuda/repo-8-0-local-ga2v2,http://ports.ubuntu.com/ubuntu-ports/ xenial
     pkgdir=/install/${LINUX_DISTRO}/${LINUX_ARCH}
-    pkglist=/opt/xcat/share/xcat/install/ubuntu/compute.${LINUX_DISTRO}.${LINUX_ARCH}.pkglist
+    pkglist=/opt/xcat/share/xcat/install/ubuntu/cudafull.${LINUX_DISTRO}.${LINUX_ARCH}.pkglist
     profile=compute
     provmethod=install
     template=/opt/xcat/share/xcat/install/ubuntu/compute.tmpl
 EOF
-[ "$?" -ne "0" ] && echo "Make node definition failed." >&2 && exit 1
+[ "$?" -ne "0" ] && echo "Make osimage definition failed." >&2 && exit 1
 
 rm -rf "${OSIMAGE_OTHERPKGDIR}"
 mkdir -p "${OSIMAGE_OTHERPKGDIR}"
@@ -164,7 +164,7 @@ sleep 5
 xdsh "${COMPUTE_NODE}" date
 [ "$?" -ne "0" ] && echo "Failed connect to compute node via SSH." >&2 && exit 1
 
-xdsh "${COMPUTE_NODE}" 'rpm -q cuda' | grep ': cuda-'
+xdsh "${COMPUTE_NODE}" 'dpkg -l' | grep 'cuda-'
 [ "$?" -ne "0" ] && echo "CUDA installation checking failed" >&2 && exit 1
 
 exit 0

--- a/xCAT-test/autotest/testcase/cuda/ubuntu-cuda-diskless-install.sh
+++ b/xCAT-test/autotest/testcase/cuda/ubuntu-cuda-diskless-install.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+
+########
+# Set all the variables below
+
+LINUX_DISTRO="ubuntu16.04.2"
+LINUX_ARCH="ppc64el"
+
+COMPUTE_NODE="c910f03c11k06"
+SOURCE_DIR="/media/xcat"
+
+########
+
+# $SOURCE_DIR is a directory this test case will be searched for.
+# Files with the name looked like the following will be searched.
+#
+# -rw-r--r-- 1 nobody nobody  124037944 Jun 28 17:00 cuda-repo-ubuntu1604-8-0-local-cublas-performance-update_8.0.61-1_ppc64el.deb
+# -rw-r--r-- 1 nobody nobody 1321330418 Feb 10 18:18 cuda-repo-ubuntu1604-8-0-local-ga2v2_8.0.61-1_ppc64el.deb
+# -rw-r--r-- 1 nobody nobody   69365760 Jul 27 20:35 mini.iso
+# -rw-r--r-- 1 nobody nobody  927946752 Feb 15 15:57 ubuntu-16.04.2-server-ppc64el.iso
+
+########
+# Auto detect all the source packages from the ${SOURCE_DIR}
+
+[ -d "${SOURCE_DIR}" ]
+[ "$?" -ne "0" ] && echo "Directory ${SOURCE_DIR} not found." >&2 && exit 1
+
+declare UBUNTU_ISO
+declare UBUNTU_MINI_ISO
+declare -a CUDA_DEBS
+
+for f in "${SOURCE_DIR}"/*
+do
+	r="$(realpath "${f}")"
+	[ -f "${r}" ] || continue
+	case "${r##*/}" in
+	"ubuntu-"*"-server-${LINUX_ARCH}.iso")
+		UBUNTU_ISO="${r}"
+		;;
+	*"mini.iso")
+		UBUNTU_MINI_ISO="${r}"
+		;;
+	"cuda-repo-ubuntu"*"-"*"-local-"*"_${LINUX_ARCH}.deb")
+		if [[ "$(echo "${r##*/}" |
+			sed -e 's#.*\([0-9]\+.[0-9]\+.[0-9]\+-[0-9]\+\).*#\1#')" \
+			> \
+			"$(echo "${CUDA_DEBS[0]}" |
+			sed -e 's#.*\([0-9]\+.[0-9]\+.[0-9]\+-[0-9]\+\).*#\1#')" ]]
+		then
+			CUDA_DEBS=("${r}")
+		elif [[ "$(echo "${r##*/}" |
+			sed -e 's#.*\([0-9]\+.[0-9]\+.[0-9]\+-[0-9]\+\).*#\1#')" \
+			= \
+			"$(echo "${CUDA_DEBS[0]}" |
+			sed -e 's#.*\([0-9]\+.[0-9]\+.[0-9]\+-[0-9]\+\).*#\1#')" ]]
+		then
+			CUDA_DEBS+=("${r}")
+		fi
+		;;
+	esac
+done
+
+########
+# Override the auto detect results here.
+
+#UBUNTU_ISO="${SOURCE_DIR}/ubuntu-16.04.2-server-ppc64el.iso"
+#UBUNTU_MINI_ISO="${SOURCE_DIR}/mini.iso"
+#CUDA_DEBS=(
+#	"${SOURCE_DIR}/cuda-repo-ubuntu1604-8-0-local-ga2v2_8.0.61-1_ppc64el.deb"
+#	"${SOURCE_DIR}/cuda-repo-ubuntu1604-8-0-local-cublas-performance-update_8.0.61-1_ppc64el.deb"
+#)
+
+########
+echo "Ubuntu ISO"
+echo "==================================="
+echo "${UBUNTU_ISO}"
+echo
+echo "Ubuntu mini ISO"
+echo "==================================="
+echo "${UBUNTU_MINI_ISO}"
+echo
+echo "CUDA DEB(s)"
+echo "==========="
+for f in "${CUDA_DEBS[@]}"
+do
+	echo "${f}"
+done
+echo
+
+echo "The files listed above were found and will be used for this test case"
+echo "Press Ctrl-C to abort!"
+for t in {5..1}
+do
+	echo -n " ... ${t}"
+	sleep 1
+	echo -n -e "\b\b\b\b\b\b"
+done
+########
+
+OSIMAGE_NAME="${LINUX_DISTRO}-${LINUX_ARCH}-netboot-cudafull"
+OSIMAGE_OTHERPKGDIR="/install/post/otherpkgs/${LINUX_DISTRO}/${LINUX_ARCH}"
+OSIMAGE_ROOTIMGDIR="/install/netboot/${LINUX_DISTRO}/${LINUX_ARCH}/${OSIMAGE_NAME}"
+
+[ -f "${UBUNTU_ISO}" ]
+[ "$?" -ne "0" ] && echo "File ${UBUNTU_ISO} not found." >&2 && exit 1
+copycds "${UBUNTU_ISO}"
+[ "$?" -ne "0" ] && echo "Copy CD failed." >&2 && exit 1
+
+[ -f "${UBUNTU_MINI_ISO}" ]
+[ "$?" -ne "0" ] && echo "File ${UBUNTU_MINI_ISO} not found." >&2 && exit 1
+MOUNT_POINT="/tmp/ubuntu-mini-iso-$$"
+mkdir -p "${MOUNT_POINT}"
+mount -o loop "${UBUNTU_MINI_ISO}" "${MOUNT_POINT}"
+mkdir -p "/install/${LINUX_DISTRO}/${LINUX_ARCH}/install/netboot"
+cp "${MOUNT_POINT}/install/"* "/install/${LINUX_DISTRO}/${LINUX_ARCH}/install/netboot"
+umount "${MOUNT_POINT}"
+rmdir "${MOUNT_POINT}"
+
+rmdef -t osimage "${OSIMAGE_NAME}"
+mkdef -z <<-EOF
+# <xCAT data object stanza file>
+
+${OSIMAGE_NAME}:
+    objtype=osimage
+    exlist=/opt/xcat/share/xcat/netboot/ubuntu/compute.exlist
+    imagetype=linux
+    osarch=${LINUX_ARCH}
+    osname=Linux
+    osvers=${LINUX_DISTRO}
+    otherpkgdir=${OSIMAGE_OTHERPKGDIR}/var/cuda/repo-8-0-local-ga2v2,http://ports.ubuntu.com/ubuntu-ports/ xenial
+    otherpkglist=/opt/xcat/share/xcat/netboot/ubuntu/cudafull.otherpkgs.pkglist
+    permission=755
+    pkgdir=/install/${LINUX_DISTRO}/${LINUX_ARCH}
+    pkglist=/opt/xcat/share/xcat/netboot/ubuntu/compute.${LINUX_DISTRO}.pkglist
+    postinstall=/opt/xcat/share/xcat/netboot/ubuntu/compute.postinstall
+    profile=compute
+    provmethod=netboot
+    rootimgdir=${OSIMAGE_ROOTIMGDIR}
+EOF
+[ "$?" -ne "0" ] && echo "Make node definition failed." >&2 && exit 1
+
+rm -rf "${OSIMAGE_OTHERPKGDIR}"
+mkdir -p "${OSIMAGE_OTHERPKGDIR}"
+for f in "${CUDA_DEBS[@]}"
+do
+	[ -f "${f}" ]
+	[ "$?" -ne "0" ] && echo "File ${f} not found." >&2 && exit 1
+	dpkg -x "${f}" "${OSIMAGE_OTHERPKGDIR}"
+done
+
+rm -rf "${OSIMAGE_ROOTIMGDIR}"
+
+genimage "${OSIMAGE_NAME}"
+[ "$?" -ne "0" ] && echo "genimage failed" >&2 && exit 1
+packimage "${OSIMAGE_NAME}"
+[ "$?" -ne "0" ] && echo "packimage failed" >&2 && exit 1
+
+makedhcp -n
+rinstall "${COMPUTE_NODE}" "osimage=${OSIMAGE_NAME}"
+
+NETBOOT_TIMEOUT=600
+declare -i WAIT=0
+
+while sleep 10
+do
+	(( WAIT += 10 ))
+	nodestat "${COMPUTE_NODE}" | grep ': sshd$'
+	[ "$?" -eq "0" ] && break
+	[ "${WAIT}" -le "${NETBOOT_TIMEOUT}" ]
+	[ "$?" -ne "0" ] && echo "Netboot failed" >&2 && exit 1
+done
+
+# For workaround the GitHub issue #3549
+sleep 5
+
+xdsh "${COMPUTE_NODE}" date
+[ "$?" -ne "0" ] && echo "Failed connect to compute node via SSH." >&2 && exit 1
+
+xdsh "${COMPUTE_NODE}" 'rpm -q cuda' | grep ': cuda-'
+[ "$?" -ne "0" ] && echo "CUDA installation checking failed" >&2 && exit 1
+
+exit 0

--- a/xCAT-test/autotest/testcase/cuda/ubuntu-cuda-diskless-install.sh
+++ b/xCAT-test/autotest/testcase/cuda/ubuntu-cuda-diskless-install.sh
@@ -137,7 +137,7 @@ ${OSIMAGE_NAME}:
     provmethod=netboot
     rootimgdir=${OSIMAGE_ROOTIMGDIR}
 EOF
-[ "$?" -ne "0" ] && echo "Make node definition failed." >&2 && exit 1
+[ "$?" -ne "0" ] && echo "Make osimage definition failed." >&2 && exit 1
 
 rm -rf "${OSIMAGE_OTHERPKGDIR}"
 mkdir -p "${OSIMAGE_OTHERPKGDIR}"
@@ -176,7 +176,7 @@ sleep 5
 xdsh "${COMPUTE_NODE}" date
 [ "$?" -ne "0" ] && echo "Failed connect to compute node via SSH." >&2 && exit 1
 
-xdsh "${COMPUTE_NODE}" 'rpm -q cuda' | grep ': cuda-'
+xdsh "${COMPUTE_NODE}" 'dpkg -l' | grep 'cuda-'
 [ "$?" -ne "0" ] && echo "CUDA installation checking failed" >&2 && exit 1
 
 exit 0


### PR DESCRIPTION
This pull request is for task #3478.

These are the draft test cases for CUDA installation verification. Please do not merge at this time.

Any comment is welcome.

Additional comments:

This test cases are plan bash scripts, and can be run standalone without `xCAT-test`. I believe in this way, it is much easier for the user to run a quick integration test.