### PR TITLE
fix issue The line 71 of postbootscript setbootfromnet is wrong in rhels7.4GA #3562

### DIFF
--- a/xCAT/postscripts/setbootfromnet
+++ b/xCAT/postscripts/setbootfromnet
@@ -47,7 +47,7 @@ if [ ! -z $NODE_NAME ]; then
    if [[ $OS = "Linux" ]]; then
       CLIENT_IP=`ping -c 3 $NODE_NAME | sed '/icmp_seq/!d;s/.*(\([0-9.]\+\)).*/\1/' | uniq  2>&1`
       RET=`echo $?`
-      NIC=`ip route | grep "src $CLIENT_IP" | sed -r 's/.*dev (.*)  proto.*/\1/'  2>&1`
+      NIC=`ip route | grep "src $CLIENT_IP" | sed -r 's/.*dev (.*) +proto.*/\1/'  2>&1`
       NRET=`echo $?`
    else ## for AIX
       CLIENT_IP=`ping -c 3 $NODE_NAME | grep "icmp_seq" | sed 's/.*from \([0-9.]*\):.*/\1/' | uniq 2>&1`


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/3562

in rhels7.4:
````
[root@c910f02c08p05 xcat]# ip route
default via 10.0.0.103 dev eth0
10.0.0.0/8 dev eth0 proto kernel scope link src 10.2.8.5  #1 space between "eth0" and "proto"
````

in rhels7.3 or earlier version:
````
[root@c910f03c05k21 xcat-core]# ip route
default via 10.3.5.10 dev eth0
10.0.0.0/8 dev eth0  proto kernel  scope link  src 10.3.5.21  #2 spaces between "eth0" and "proto"
````

