### PR TITLE
Remove the openbmc version information when running xCAT commands

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -467,9 +467,6 @@ sub parse_args {
     my $extrargs = shift;
     my $noderange = shift;
     my $check = undef;
-
-    xCAT::SvrUtils::sendmsg("[OpenBMC development support] Using this version of xCAT, ensure firmware level is at v1.99.6-0-r1, or higher.", $callback);
-
     my $subcommand = undef;
     my $verbose    = undef;
     unless (GetOptions(


### PR DESCRIPTION
When running commands that invoke the openbmc plugin, a message prints out: 
```
[OpenBMC development support] Using this version of xCAT, ensure firmware level is at v1.99.6-0-r1, or higher.
```

This was intended to inform the user that at a specific version of xCAT, the firmware must be at a certain version due to function being integrated into the openbmc firmware.  As we get closer to GA, removing this message. It's also caused some confusion in our internal teams, so removing the message. 
