### PR TITLE
Fix bug introduced into `bmcsetup` by commit `bb460dc`

### DIFF
--- a/xCAT-genesis-scripts/bin/bmcsetup
+++ b/xCAT-genesis-scripts/bin/bmcsetup
@@ -429,7 +429,7 @@ for user in $BMCUS; do
     if [ -z "$USERSLOT" ]; then
         USERSLOT=$((`ipmitool raw 6 0x44 1 1|awk '{print $3}'` + 1))
     fi
-    if [ "$USERSLOT" == 0 ]; then USERSLOT=2; fi
+    if [ "$USERSLOT" == 0 -o -z "$LOCKEDUSERS" ]; then USERSLOT=2; fi
     if [ "$ISITE" = 1 ]; then
         allowcred.awk &
         CREDPID=$!


### PR DESCRIPTION
Commit bb460dc introduced a minor bug, where the value of LOCKEDUSERS
was no longer considered while handling existing entries in the user
list. This fixes that by adding back the check. Fixes Issue #3583 .