### PR TITLE
Openbmc rflash activate pnor

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rflash.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rflash.1.rst
@@ -46,11 +46,18 @@ NeXtScale FPC specific:
 \ **rflash**\  \ *noderange*\  \ *http_directory*\ 
 
 
-OpenPOWER BMC specific:
-=======================
+OpenPOWER BMC specific (using IPMI):
+====================================
 
 
 \ **rflash**\  \ *noderange*\  [\ *hpm_file_path*\  | \ **-d=**\ \ *data_directory*\ ] [\ **-c | -**\ **-check**\ ] [\ **-**\ **-retry=**\ \ *count*\ ] [\ **-V**\ ]
+
+
+OpenPOWER OpenBMC specific :
+============================
+
+
+\ **rflash**\  \ *noderange*\  [\ *tar_file_path*\  | \ *image_id*\ ] [\ **-c | -**\ **-check**\ ] [\ **-a | -**\ **-activate**\ ] [\ **-l | -**\ **-list**\ ] [\ **-u | -**\ **-upload**\ ]
 
 
 
@@ -118,12 +125,20 @@ NeXtScale FPC specific:
 The command will update firmware for NeXtScale FPC when given an FPC node and the http information needed to access the firmware. The http information required includes both the MN IP address as well as the directory containing the firmware. It is recommended that the firmware be downloaded and placed in the /install directory structure as the xCAT MN /install directory is configured with the correct permissions for http.  Refer to the doc to get more details: XCAT_NeXtScale_Clusters
 
 
-OpenPOWER specific:
-===================
+OpenPOWER specific (using IPMI):
+================================
 
 
 The command will update firmware for OpenPOWER BMC when given an OpenPOWER node and either the hpm formatted file path or path to a data directory.
 \ **Note:**\  When using \ **rflash**\  in hierarchical environment, the hpm file or data directory must be accessible from Service Nodes.
+
+
+OpenPOWER OpenBMC specific:
+===========================
+
+
+The command will update firmware for OpenPOWER OpenBMC when given an OpenPOWER node and either an update .tar file or an uploaded image id.
+\ **Note:**\  When using \ **rflash**\  in hierarchical environment, the .tar file must be accessible from Service Nodes.
 
 
 
@@ -141,7 +156,7 @@ The command will update firmware for OpenPOWER BMC when given an OpenPOWER node 
 
 \ **-c|-**\ **-check**\ 
  
- Check the firmware version of BMC and HPM file.
+ Check the firmware version of BMC and an update file.
  
 
 
@@ -184,6 +199,24 @@ The command will update firmware for OpenPOWER BMC when given an OpenPOWER node 
 \ **-**\ **-retry=**\ \ *count*\ 
  
  Specify number of times to retry the update if failure is detected. Default value is 2. Value of 0 can be used to indicate no retries.
+ 
+
+
+\ **-a|-**\ **-activate**\ 
+ 
+ Activate update image. Image id must be specified.
+ 
+
+
+\ **-l|-**\ **-list**\ 
+ 
+ List currently uploaded update images. "(\*)" indicates currently active image.
+ 
+
+
+\ **-u|-**\ **-upload**\ 
+ 
+ Upload update image. Specified file must be in .tar format.
  
 
 

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -342,8 +342,10 @@ my %usage = (
 	rflash <noderange> -p <rpm_directory> [--activate {disruptive|deferred}] [-d <data_directory>]
 	rflash <noderange> [--commit | --recover] [-V|--verbose]
         rflash <noderange> [--bpa_acdl]
-    PPC64LE (using BMC Management) specific:
-        rflash <noderange> [-c | --check] [--retry=<count>] [-V] [<hpm_file>|-d=<data_directory>]",
+    PPC64LE (using IPMI Management) specific:
+        rflash <noderange> [-c|--check] [--retry=<count>] [-V] [<hpm_file>|-d=<data_directory>]
+    PPC64LE (using OpenBMC Management) specific:
+        rflash <noderange> [-c|--check] [-l|--list] [-a|--activate] [-u|--upload] [<tar_file>|<image_id>]",
     "mkhwconn" =>
       "Usage:
     mkhwconn [-h|--help]

--- a/xCAT-client/pods/man1/rflash.1.pod
+++ b/xCAT-client/pods/man1/rflash.1.pod
@@ -22,9 +22,13 @@ B<rflash> I<noderange> {B<--commit>|B<--recover>}
 
 B<rflash> I<noderange> I<http_directory>
 
-=head2 OpenPOWER BMC specific:
+=head2 OpenPOWER BMC specific (using IPMI):
 
 B<rflash> I<noderange> [I<hpm_file_path> | B<-d=>I<data_directory>] [B<-c>|B<--check>] [B<--retry=>I<count>] [B<-V>]
+
+=head2 OpenPOWER OpenBMC specific :
+
+B<rflash> I<noderange> [I<tar_file_path> | I<image_id>] [B<-c>|B<--check>] [B<-a>|B<--activate>] [B<-l>|B<--list>] [B<-u>|B<--upload>]
 
 =head1 B<Description>
 
@@ -79,10 +83,15 @@ For more details about the Firmware Update using Direct FSP/BPA Management, refe
 
 The command will update firmware for NeXtScale FPC when given an FPC node and the http information needed to access the firmware. The http information required includes both the MN IP address as well as the directory containing the firmware. It is recommended that the firmware be downloaded and placed in the /install directory structure as the xCAT MN /install directory is configured with the correct permissions for http.  Refer to the doc to get more details: XCAT_NeXtScale_Clusters 
 
-=head2 OpenPOWER specific:
+=head2 OpenPOWER specific (using IPMI):
 
 The command will update firmware for OpenPOWER BMC when given an OpenPOWER node and either the hpm formatted file path or path to a data directory.
 B<Note:> When using B<rflash> in hierarchical environment, the hpm file or data directory must be accessible from Service Nodes.
+
+=head2 OpenPOWER OpenBMC specific:
+
+The command will update firmware for OpenPOWER OpenBMC when given an OpenPOWER node and either an update .tar file or an uploaded image id.
+B<Note:> When using B<rflash> in hierarchical environment, the .tar file must be accessible from Service Nodes.
 
 =head1 B<Options>
 
@@ -94,7 +103,7 @@ Writes the command's usage statement to standard output.
 
 =item B<-c|--check>
 
-Check the firmware version of BMC and HPM file.
+Check the firmware version of BMC and an update file.
 
 =item B<-p> I<directory>
 
@@ -123,6 +132,18 @@ Used to recover the flash image in the permanent side of the chip to the tempora
 =item B<--retry=>I<count>
 
 Specify number of times to retry the update if failure is detected. Default value is 2. Value of 0 can be used to indicate no retries.
+
+=item B<-a|--activate>
+
+Activate update image. Image id must be specified.
+
+=item B<-l|--list>
+
+List currently uploaded update images. "(*)" indicates currently active image.
+
+=item B<-u|--upload>
+
+Upload update image. Specified file must be in .tar format.
 
 =item B<-v|--version>
 

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -808,7 +808,6 @@ sub parse_command_status {
 
     if ($command eq "rflash") {
         my $check_version = 0;
-<<<<<<< HEAD
         my $list = 0;
         my $delete = 0;
         my $upload = 0;

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -582,6 +582,11 @@ sub parse_args {
             return ([ 1, "Unsupported command: $command $subcommand" ]);
         }
     } elsif ($command eq "rflash") {
+        #
+        # disable function until fully supported by openbmc 
+        # Currently waiting for issue https://github.com/openbmc/openbmc/issues/2074 to be fixed
+        #
+        $check = unsupported($callback); if (ref($check) eq "ARRAY") { return $check; }
         my $filename_passed = 0;
         my $updateid_passed = 0;
         my $option_flag;
@@ -1888,6 +1893,11 @@ sub rflash_response {
             if ($key_url eq "Priority") {
                 $priority_state = ${ $response_info->{data} }{$key_url};
             }
+        }
+
+        if ($activation_state =~ /Software.Activation.Activations.Failed/) {
+            # Activation failed. Report error and exit
+            xCAT::SvrUtils::sendmsg([1,"Activation of firmware failed"], $callback, $node);
         }
 
         if ($activation_state =~ /Software.Activation.Activations.Active/) { 

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1,5 +1,6 @@
 #!/usr/bin/perl
 ## IBM(c) 2017 EPL license http://www.eclipse.org/legal/epl-v10.html
+#MG June 26
 
 package xCAT_plugin::openbmc;
 
@@ -162,6 +163,14 @@ my %status_info = (
         data           => "xyz.openbmc_project.Software.Activation.RequestedActivations.Active",
     },
     RFLASH_UPDATE_ACTIVATE_RESPONSE => {
+        process        => \&rflash_response,
+    },
+    RFLASH_UPDATE_PRIORITY_REQUEST  => {
+        method         => "PUT",
+        init_url       => "$openbmc_project_url/software",
+        data           => "xyz.openbmc_project.Software.Activation.RequestedPriority.0",
+    },
+    RFLASH_UPDATE_PRIORITY_RESPONSE => {
         process        => \&rflash_response,
     },
 
@@ -856,6 +865,7 @@ sub parse_command_status {
                 if ($update_file =~ /^[[:xdigit:]]+$/i) {
                     # Update init_url to include the id of the update to activate
                     $status_info{RFLASH_UPDATE_ACTIVATE_REQUEST}{init_url} .= "/$update_file/attr/RequestedActivation";
+                    $status_info{RFLASH_UPDATE_ACTIVATE_REQUEST}{init_url} .= "/$update_file/attr/RequestedActivation";
                 }
             }
         }
@@ -883,6 +893,8 @@ sub parse_command_status {
             print "Current value of activate request $status_info{RFLASH_UPDATE_ACTIVATE_REQUEST}{init_url} \n";
             $next_status{LOGIN_RESPONSE} = "RFLASH_UPDATE_ACTIVATE_REQUEST";
             $next_status{"RFLASH_UPDATE_ACTIVATE_REQUEST"} = "RFLASH_UPDATE_ACTIVATE_RESPONSE";
+            $next_status{"RFLASH_UPDATE_ACTIVATE_RESPOSNE"} = "RFLASH_UPDATE_PRIORITY_REQUEST";
+            $next_status{"RFLASH_UPDATE_PRIORITY_REQUEST"} = "RFLASH_UPDATE_PRIORITY_RESPONSE";
             #xCAT::SvrUtils::sendmsg("Activate option is not yet supported.", $callback);
             #return 1;
         }
@@ -1840,7 +1852,10 @@ sub rflash_response {
         }
     }
     if ($node_info{$node}{cur_status} eq "RFLASH_UPDATE_ACTIVATE_RESPONSE") {
-        print "Update activatiion response\n";
+        print "Update activation response\n";
+    }
+    if ($node_info{$node}{cur_status} eq "RFLASH_UPDATE_PRIORITY_RESPONSE") {
+        print "Update priority response\n";
     }
 
     if ($next_status{ $node_info{$node}{cur_status} }) {

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -156,6 +156,14 @@ my %status_info = (
     RFLASH_FILE_UPLOAD_RESPONSE => {
         process        => \&rflash_response,
     },
+    RFLASH_UPDATE_ACTIVATE_REQUEST  => {
+        method         => "PUT",
+        init_url       => "$openbmc_project_url/software",
+        data           => "xyz.openbmc_project.Software.Activation.RequestedActivations.Active",
+    },
+    RFLASH_UPDATE_ACTIVATE_RESPONSE => {
+        process        => \&rflash_response,
+    },
 
     RINV_REQUEST => {
         method         => "GET",
@@ -564,10 +572,19 @@ sub parse_args {
         #
         $check = unsupported($callback); if (ref($check) eq "ARRAY") { return $check; }
         my $filename_passed = 0;
+        my $updateid_passed = 0;
         foreach my $opt (@$extrargs) {
+            print "Examening $opt \n";
             # Only files ending on .tar are allowed
             if ($opt =~ /.*\.tar$/i) {
                 $filename_passed = 1;
+                print "Opt matches filename ending on .tar \n";
+                next;
+            }
+            # Check if hex number for the updateid is passed
+            if ($opt =~ /^[[:xdigit:]]+$/i) {
+                $updateid_passed = 1;
+                print "Opt matches hex fileid \n";
                 next;
             }
             if ($filename_passed) {
@@ -577,9 +594,17 @@ sub parse_args {
                 }
             }
             else {
-                # Filename was not passed, check flags allowed without file
-                if ($opt !~ /^-c$|^--check$|^-l$|^--list/) {
-                    return ([ 1, "Invalid option specified: $opt" ]);
+                if ($updateid_passed) {
+                    # Updateid was passed, check flags allowed with update id
+                    if ($opt !~ /^^-d$|^--delete$|^-a$|^--activate$/) {
+                        return ([ 1, "Invalid option specified when an update id is provided: $opt" ]);
+                    }
+                }
+                else {
+                   # Neither Filename nor updateid was not passed, check flags allowed without file or updateid
+                   if ($opt !~ /^-c$|^--check$|^-l$|^--list/) {
+                       return ([ 1, "Invalid option specified: $opt" ]);
+                   }
                 }
             }
         }
@@ -772,9 +797,11 @@ sub parse_command_status {
 
     if ($command eq "rflash") {
         my $check_version = 0;
+<<<<<<< HEAD
         my $list = 0;
         my $delete = 0;
         my $upload = 0;
+        my $activate = 0;
 
         if ($$subcommands[-1] =~ /c|check/) {
             $check_version = 1;
@@ -787,6 +814,9 @@ sub parse_command_status {
             pop(@$subcommands);
         } elsif ($$subcommands[-1] =~ /u|upload/) {
             $upload = 1;
+            pop(@$subcommands);
+        } elsif ($$subcommands[-1] =~ /a|activate/) {
+            $activate = 1;
             pop(@$subcommands);
         }
 
@@ -822,7 +852,11 @@ sub parse_command_status {
                 }
             }
             else {
-                # TODO Process file id passed in
+                # Check if hex number for the updateid is passed
+                if ($update_file =~ /^[[:xdigit:]]+$/i) {
+                    # Update init_url to include the id of the update to activate
+                    $status_info{RFLASH_UPDATE_ACTIVATE_REQUEST}{init_url} .= "/$update_file/attr/RequestedActivation";
+                }
             }
         }
         if ($check_version) {
@@ -843,6 +877,14 @@ sub parse_command_status {
             # Upload specified update file to  BMC
             $next_status{LOGIN_RESPONSE} = "RFLASH_FILE_UPLOAD_REQUEST";
             $next_status{"RFLASH_FILE_UPLOAD_REQUEST"} = "RFLASH_FILE_UPLOAD_RESPONSE";
+        }
+        if ($activate) {
+            # MG
+            print "Current value of activate request $status_info{RFLASH_UPDATE_ACTIVATE_REQUEST}{init_url} \n";
+            $next_status{LOGIN_RESPONSE} = "RFLASH_UPDATE_ACTIVATE_REQUEST";
+            $next_status{"RFLASH_UPDATE_ACTIVATE_REQUEST"} = "RFLASH_UPDATE_ACTIVATE_RESPONSE";
+            #xCAT::SvrUtils::sendmsg("Activate option is not yet supported.", $callback);
+            #return 1;
         }
     }
 
@@ -1796,6 +1838,9 @@ sub rflash_response {
                 xCAT::SvrUtils::sendmsg("Unable to login :" . $h->{message} . " - " . $h->{data}->{description}, $callback, $node);
             }
         }
+    }
+    if ($node_info{$node}{cur_status} eq "RFLASH_UPDATE_ACTIVATE_RESPONSE") {
+        print "Update activatiion response\n";
     }
 
     if ($next_status{ $node_info{$node}{cur_status} }) {

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -165,6 +165,13 @@ my %status_info = (
     RFLASH_UPDATE_ACTIVATE_RESPONSE => {
         process        => \&rflash_response,
     },
+    RFLASH_UPDATE_CHECK_STATE_REQUEST  => {
+        method         => "GET",
+        init_url       => "$openbmc_project_url/software",
+    },
+    RFLASH_UPDATE_CHECK_STATE_RESPONSE => {
+        process        => \&rflash_response,
+    },
     RFLASH_UPDATE_PRIORITY_REQUEST  => {
         method         => "PUT",
         init_url       => "$openbmc_project_url/software",
@@ -864,8 +871,10 @@ sub parse_command_status {
                 # Check if hex number for the updateid is passed
                 if ($update_file =~ /^[[:xdigit:]]+$/i) {
                     # Update init_url to include the id of the update to activate
+                    # MG
                     $status_info{RFLASH_UPDATE_ACTIVATE_REQUEST}{init_url} .= "/$update_file/attr/RequestedActivation";
-                    $status_info{RFLASH_UPDATE_ACTIVATE_REQUEST}{init_url} .= "/$update_file/attr/RequestedActivation";
+                    # Update init_url to include the id of the update to check state
+                    $status_info{RFLASH_UPDATE_CHECK_STATE_REQUEST}{init_url} .= "/$update_file";
                 }
             }
         }
@@ -893,8 +902,8 @@ sub parse_command_status {
             print "Current value of activate request $status_info{RFLASH_UPDATE_ACTIVATE_REQUEST}{init_url} \n";
             $next_status{LOGIN_RESPONSE} = "RFLASH_UPDATE_ACTIVATE_REQUEST";
             $next_status{"RFLASH_UPDATE_ACTIVATE_REQUEST"} = "RFLASH_UPDATE_ACTIVATE_RESPONSE";
-            $next_status{"RFLASH_UPDATE_ACTIVATE_RESPOSNE"} = "RFLASH_UPDATE_PRIORITY_REQUEST";
-            $next_status{"RFLASH_UPDATE_PRIORITY_REQUEST"} = "RFLASH_UPDATE_PRIORITY_RESPONSE";
+            $next_status{"RFLASH_UPDATE_ACTIVATE_RESPONSE"} = "RFLASH_UPDATE_CHECK_STATE_REQUEST";
+            $next_status{"RFLASH_UPDATE_CHECK_STATE_REQUEST"} = "RFLASH_UPDATE_CHECK_STATE_RESPONSE";
             #xCAT::SvrUtils::sendmsg("Activate option is not yet supported.", $callback);
             #return 1;
         }
@@ -1852,10 +1861,41 @@ sub rflash_response {
         }
     }
     if ($node_info{$node}{cur_status} eq "RFLASH_UPDATE_ACTIVATE_RESPONSE") {
-        print "Update activation response\n";
+        # We get here after the activation of the image file. No processing. Just a landing spot 
     }
-    if ($node_info{$node}{cur_status} eq "RFLASH_UPDATE_PRIORITY_RESPONSE") {
-        print "Update priority response\n";
+    if ($node_info{$node}{cur_status} eq "RFLASH_UPDATE_CHECK_STATE_RESPONSE") {
+        my $activation_state;
+        my $progress_state;
+        my $priority_state;
+        foreach my $key_url (keys %{$response_info->{data}}) {
+            my $content = ${ $response_info->{data} }{$key_url};
+            # Get values of some attributes to determine activation status 
+            if ($key_url eq "Activation") {
+                $activation_state = ${ $response_info->{data} }{$key_url};
+            }
+            if ($key_url eq "Progress") {
+                $progress_state = ${ $response_info->{data} }{$key_url};
+            }
+            if ($key_url eq "Priority") {
+                $priority_state = ${ $response_info->{data} }{$key_url};
+            }
+        }
+
+        if ($activation_state eq "xyz.openbmc_project.Software.Activation.Activations.Active" && $priority_state eq "0") {
+            # Activation state of active and priority of 0 indicates the avtivation has been completed
+            xCAT::SvrUtils::sendmsg("Firmware update successfully activated", $callback, $node);
+            $wait_node_num--;
+            return;
+        }
+
+        if ($activation_state eq "xyz.openbmc_project.Software.Activation.Activations.Activating") {
+            # Activation still going, sleep for a bit, then print the progress value
+            sleep(15);
+            xCAT::SvrUtils::sendmsg("Activating firmware update. $progress_state\%", $callback, $node);
+
+            # Set next state to come back here to chect the activation status again.
+            $next_status{ $node_info{$node}{cur_status} } = "RFLASH_UPDATE_CHECK_STATE_REQUEST";
+        }
     }
 
     if ($next_status{ $node_info{$node}{cur_status} }) {

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1,6 +1,5 @@
 #!/usr/bin/perl
 ## IBM(c) 2017 EPL license http://www.eclipse.org/legal/epl-v10.html
-#MG June 26
 
 package xCAT_plugin::openbmc;
 
@@ -172,12 +171,12 @@ my %status_info = (
     RFLASH_UPDATE_CHECK_STATE_RESPONSE => {
         process        => \&rflash_response,
     },
-    RFLASH_UPDATE_PRIORITY_REQUEST  => {
+    RFLASH_SET_PRIORITY_REQUEST  => {
         method         => "PUT",
         init_url       => "$openbmc_project_url/software",
-        data           => "xyz.openbmc_project.Software.Activation.RequestedPriority.0",
+        data           => "false", # Priority state of 0 sets image to active
     },
-    RFLASH_UPDATE_PRIORITY_RESPONSE => {
+    RFLASH_SET_PRIORITY_RESPONSE => {
         process        => \&rflash_response,
     },
 
@@ -583,10 +582,6 @@ sub parse_args {
             return ([ 1, "Unsupported command: $command $subcommand" ]);
         }
     } elsif ($command eq "rflash") {
-        #
-        # disable function until fully tested
-        #
-        $check = unsupported($callback); if (ref($check) eq "ARRAY") { return $check; }
         my $filename_passed = 0;
         my $updateid_passed = 0;
         foreach my $opt (@$extrargs) {
@@ -870,10 +865,9 @@ sub parse_command_status {
             else {
                 # Check if hex number for the updateid is passed
                 if ($update_file =~ /^[[:xdigit:]]+$/i) {
-                    # Update init_url to include the id of the update to activate
-                    # MG
-                    $status_info{RFLASH_UPDATE_ACTIVATE_REQUEST}{init_url} .= "/$update_file/attr/RequestedActivation";
-                    # Update init_url to include the id of the update to check state
+                    # Update init_url to include the id of the update
+                    $status_info{RFLASH_UPDATE_ACTIVATE_REQUEST}{init_url}    .= "/$update_file/attr/RequestedActivation";
+                    $status_info{RFLASH_SET_PRIORITY_REQUEST}{init_url}       .= "/$update_file/attr/Priority";
                     $status_info{RFLASH_UPDATE_CHECK_STATE_REQUEST}{init_url} .= "/$update_file";
                 }
             }
@@ -898,14 +892,17 @@ sub parse_command_status {
             $next_status{"RFLASH_FILE_UPLOAD_REQUEST"} = "RFLASH_FILE_UPLOAD_RESPONSE";
         }
         if ($activate) {
-            # MG
-            print "Current value of activate request $status_info{RFLASH_UPDATE_ACTIVATE_REQUEST}{init_url} \n";
+            # Activation of an update was requested.
+            # First we query the update image for its Activation state. If image is in "Ready" we
+            # need to set "RequestedActivation" attribute to "Active". If image is in "Active" we
+            # need to set "Priority" to 0.
             $next_status{LOGIN_RESPONSE} = "RFLASH_UPDATE_ACTIVATE_REQUEST";
             $next_status{"RFLASH_UPDATE_ACTIVATE_REQUEST"} = "RFLASH_UPDATE_ACTIVATE_RESPONSE";
             $next_status{"RFLASH_UPDATE_ACTIVATE_RESPONSE"} = "RFLASH_UPDATE_CHECK_STATE_REQUEST";
             $next_status{"RFLASH_UPDATE_CHECK_STATE_REQUEST"} = "RFLASH_UPDATE_CHECK_STATE_RESPONSE";
-            #xCAT::SvrUtils::sendmsg("Activate option is not yet supported.", $callback);
-            #return 1;
+
+            $next_status{"RFLASH_SET_PRIORITY_REQUEST"} = "RFLASH_SET_PRIORITY_RESPONSE";
+            $next_status{"RFLASH_SET_PRIORITY_RESPONSE"} = "RFLASH_UPDATE_CHECK_STATE_REQUEST";
         }
     }
 
@@ -1800,10 +1797,11 @@ sub rflash_response {
     my $update_activation;
     my $update_purpose;
     my $update_version;
+    my $update_priority = -1;
 
     if ($node_info{$node}{cur_status} eq "RFLASH_LIST_RESPONSE") {
         # Display "list" option header and data
-        xCAT::SvrUtils::sendmsg("ID       Purpose State    Version", $callback, $node);
+        xCAT::SvrUtils::sendmsg("ID       Purpose State      Version", $callback, $node);
         xCAT::SvrUtils::sendmsg("-" x 55, $callback, $node);
 
         foreach my $key_url (keys %{$response_info->{data}}) {
@@ -1819,7 +1817,15 @@ sub rflash_response {
             if (defined($content{Purpose}) and $content{Purpose}) {
                 $update_purpose = (split(/\./, $content{Purpose}))[ -1 ];
             }
-            xCAT::SvrUtils::sendmsg(sprintf("%-8s %-7s %-8s %s", $update_id, $update_purpose, $update_activation, $update_version), $callback, $node);
+            if (defined($content{Priority}))  {
+                $update_priority = (split(/\./, $content{Priority}))[ -1 ];
+            }
+            # Priority attribute of 0 indicates the "really" active update image
+            if ($update_priority == 0) {
+                $update_activation = $update_activation . "(*)";
+                $update_priority = -1; # Reset update priority for next loop iteration
+            }
+            xCAT::SvrUtils::sendmsg(sprintf("%-8s %-7s %-10s %s", $update_id, $update_purpose, $update_activation, $update_version), $callback, $node);
         }
         xCAT::SvrUtils::sendmsg("", $callback, $node); #Separate output in case more than 1 endpoint
     }
@@ -1861,7 +1867,10 @@ sub rflash_response {
         }
     }
     if ($node_info{$node}{cur_status} eq "RFLASH_UPDATE_ACTIVATE_RESPONSE") {
-        # We get here after the activation of the image file. No processing. Just a landing spot 
+        xCAT::SvrUtils::sendmsg("rflash started, please wait...", $callback, $node);
+    }
+    if ($node_info{$node}{cur_status} eq "RFLASH_SET_PRIORITY_RESPONSE") {
+        print "Update priority has been set";
     }
     if ($node_info{$node}{cur_status} eq "RFLASH_UPDATE_CHECK_STATE_RESPONSE") {
         my $activation_state;
@@ -1881,14 +1890,22 @@ sub rflash_response {
             }
         }
 
-        if ($activation_state eq "xyz.openbmc_project.Software.Activation.Activations.Active" && $priority_state eq "0") {
-            # Activation state of active and priority of 0 indicates the avtivation has been completed
-            xCAT::SvrUtils::sendmsg("Firmware update successfully activated", $callback, $node);
-            $wait_node_num--;
-            return;
+        if ($activation_state =~ /Software.Activation.Activations.Active/) { 
+            if (scalar($priority_state) == 0) {
+                # Activation state of active and priority of 0 indicates the activation has been completed
+                xCAT::SvrUtils::sendmsg("Firmware update successfully activated", $callback, $node);
+                $wait_node_num--;
+                return;
+            }
+            else {
+                # Activation state of active and priority of non 0 - need to just set priority to 0 to activate
+                print "Update is already active, just need to set priority to 0";
+                $next_status{ $node_info{$node}{cur_status} } = "RFLASH_SET_PRIORITY_REQUEST";
+            }
         }
 
-        if ($activation_state eq "xyz.openbmc_project.Software.Activation.Activations.Activating") {
+        #if ($activation_state eq "xyz.openbmc_project.Software.Activation.Activations.Activating") {
+        if ($activation_state =~ /Software.Activation.Activations.Activating/) {
             # Activation still going, sleep for a bit, then print the progress value
             sleep(15);
             xCAT::SvrUtils::sendmsg("Activating firmware update. $progress_state\%", $callback, $node);


### PR DESCRIPTION
Replaces #3550  

This pull request implements the "activate" action for openbmc `rflash` command. Issue #3273 

Example output:

1. Two host update files have been uploaded and `rflash --list` shows:
```
[root@stratton01 xcat]# rflash p9euh02 -l
p9euh02: ID       Purpose State      Version
p9euh02: -------------------------------------------------------
p9euh02: 2a1022fe Host    Ready      IBM-witherspoon-sequoia-ibm-OP9_v1.17_1.67
p9euh02: f3b29aa8 BMC     Active     0.1.0
p9euh02: 32f129cd Host    Ready      IBM-witherspoon-redbud-ibm-OP9_v1.17_1.68
p9euh02:
[root@stratton01 xcat]#
```

2. Activate one of the updates in "Ready" state:
```
[root@stratton01 xcat]# rflash p9euh02 2a1022fe -a
p9euh02: rflash started, please wait...
p9euh02: Activating firmware update. 10%
p9euh02: Activating firmware update. 60%
p9euh02: Activating firmware update. 60%
p9euh02: Activating firmware update. 60%
p9euh02: Activating firmware update. 60%
p9euh02: Firmware update successfully activated
[root@stratton01 xcat]# 
```

3. List will show:
```
[root@stratton01 xcat]# rflash p9euh02 -l
p9euh02: ID       Purpose State      Version
p9euh02: -------------------------------------------------------
p9euh02: 2a1022fe Host    Active(*)  IBM-witherspoon-sequoia-ibm-OP9_v1.17_1.67
p9euh02: f3b29aa8 BMC     Active     0.1.0
p9euh02: 32f129cd Host    Ready      IBM-witherspoon-redbud-ibm-OP9_v1.17_1.68
p9euh02:
```

4. Activate another update in "Ready" state:
```
[root@stratton01 xcat]# rflash p9euh02 32f129cd -a
[OpenBMC development support] Using this version of xCAT, ensure firmware level is at v1.99.6-0-r1, or higher.
p9euh02: rflash started, please wait...
p9euh02: Activating firmware update. 10%
p9euh02: Activating firmware update. 60%
p9euh02: Activating firmware update. 60%
p9euh02: Activating firmware update. 60%
p9euh02: Activating firmware update. 60%
p9euh02: Firmware update successfully activated
[root@stratton01 xcat]#
```

5. List will show:
```
[root@stratton01 xcat]# rflash p9euh02 -l
p9euh02: ID       Purpose State      Version
p9euh02: -------------------------------------------------------
p9euh02: 2a1022fe Host    Active     IBM-witherspoon-sequoia-ibm-OP9_v1.17_1.67
p9euh02: f3b29aa8 BMC     Active     0.1.0
p9euh02: 32f129cd Host    Active(*)  IBM-witherspoon-redbud-ibm-OP9_v1.17_1.68
p9euh02:
[root@stratton01 xcat]#
```

6. Activate update already in the "Active" state:
```
[root@stratton01 xcat]# rflash p9euh02 2a1022fe -a
p9euh02: rflash started, please wait...
p9euh02: Firmware update successfully activated
[root@stratton01 xcat]#
```

7. List will show:
```
[root@stratton01 xcat]# rflash p9euh02 -l
p9euh02: ID       Purpose State      Version
p9euh02: -------------------------------------------------------
p9euh02: 2a1022fe Host    Active(*)  IBM-witherspoon-sequoia-ibm-OP9_v1.17_1.67
p9euh02: f3b29aa8 BMC     Active     0.1.0
p9euh02: 32f129cd Host    Active     IBM-witherspoon-redbud-ibm-OP9_v1.17_1.68
p9euh02:
[root@stratton01 xcat]#
```