### PR TITLE
Remove commented code and fix typo in dodiscovery 

### DIFF
--- a/xCAT-genesis-scripts/bin/dodiscovery
+++ b/xCAT-genesis-scripts/bin/dodiscovery
@@ -93,7 +93,6 @@ if [ -r /sys/devices/virtual/dmi/id/product_name ]; then  #x86
         UUID=`sed -e 's/\(..\)\(..\)\(..\)\(..\)-\(..\)\(..\)-\(..\)\(..\)/\4\3\2\1-\6\5-\8\7/' /sys/devices/virtual/dmi/id/product_uuid`
 
 elif [ -r /proc/device-tree/model ]; then #POWER
-	#MTM=`cat /proc/device-tree/model |awk -F, '{print $2}'`
         MTM=`cat /proc/device-tree/model -vT | sed -e 's/^.*,//' | sed -e 's/^[\t ]*//'| sed -e 's/[\t ]*\^@//'`
         CPUCOUNT=`cat /proc/cpuinfo |grep -e "^cpu\s*:"|wc -l`
         PLATFORM=`cat /proc/cpuinfo | grep -e "^platform\s*:" | awk '{print \$3}'`
@@ -107,25 +106,14 @@ elif [ -r /proc/device-tree/model ]; then #POWER
         UUID=unknown
 
 fi
-#CPUCOUNT=`cat /proc/cpuinfo |grep "model name"|wc -l`
 
 # The MEMORY will look like this: 32868920
 MEMORY=`cat /proc/meminfo |grep MemTotal|awk '{printf "%.0fMB\n", $2/1024}'`
-# The MEMORY will look like this: 32GiB
-#MEMORY=`lshw -C memory -short |grep "System Memory"|awk -F' ' '{print $3}'`
 
-# The DISKSIZE will look like this: /dev/sda:250GB,/dev/sdb:250GB
-#DISKSIZE=`lshw -C disk -short |grep disk |awk -F' ' '{print $2":"$4}'|sed 'N;s/\n/,/'`
 # The DISKSIZE will look like this: sdb:250GB,sda:250GB
 DISKSIZE=`cat /proc/partitions |grep -e "sd.\>" |awk -F' ' '{printf "%s:%.0fGB\n", $4, $3*0.000001024}' |sed 'N;s/\n/,/'`
 
-#UUID=`sed -e 's/\(..\)\(..\)\(..\)\(..\)-\(..\)\(..\)-\(..\)\(..\)/\4\3\2\1-\6\5-\8\7/' /sys/devices/virtual/dmi/id/product_uuid`
-#grep "model name" /proc/cpuinfo | while read line; do #to avoid pulling in tail, we do a goofy thing
-#	echo $line > /tmp/cpumod
-#done
-#CPUTYPE=`cat /tmp/cpumod|awk -F':' '{print $2}'|sed -e 's/^ //'`
-
-logger -s -t $log_label -p local4.info "Beginning echo infomation to discovery packet file..."
+logger -s -t $log_label -p local4.info "Beginning echo information to discovery packet file..."
 echo '<xcatrequest>' > /tmp/discopacket
 echo "<command>findme</command>" >> /tmp/discopacket
 echo "<sequential>1</sequential>" >> /tmp/discopacket


### PR DESCRIPTION
Small changes to fix spelling error, while in this file , removed some of the commented lines that are not being used. 