### PR TITLE
fix configeth get netmask in postscript

### DIFF
--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -487,9 +487,9 @@ elif [ "$1" = "-s" ];then
                 if [ ! -z "${inst_nic}" ];then
                     str_inst_ip=`ip -4 -o addr|grep -i ${inst_nic} |awk '{print $4}'|awk -F/ '{print $1}'`
                     if [ ! -z "$str_inst_ip" ];then
-                        inst_ip_pre=`ip ro ls|grep -i ${str_inst_ip}|awk '{print $1}'|awk -F/ '{print $1}'`
-                        if [ ! -z "$inst_ip_pre" ];then
-                            str_inst_mask=`route |grep ^${inst_ip_pre}|awk '{print $3}'|head -1`
+                        inst_prefix=`ip ro ls|grep -i ${str_inst_ip}|awk '{print $1}'|awk -F/ '{print $2}'`
+                        if [ ! -z "$inst_prefix" ];then
+                            str_inst_mask=`v4prefix2mask $inst_prefix`
                         fi
                     fi
                 fi


### PR DESCRIPTION
fix #3595 

unit test:
```
[I]: str_inst_mask 255.0.0.0
[I]: Device 'eth0' successfully disconnected.
[I]: Connection successfully activated (D-Bus active path: /org/freedesktop/Netww
orkManager/ActiveConnection/2)
['/etc/sysconfig/network-scripts/ifcfg-eth0']
[I]: >> DEVICE=eth0
[I]: >> IPADDR=10.2.8.7
[I]: >> NETMASK=255.0.0.0
[I]: >> BOOTPROTO=static
[I]: >> ONBOOT=yes
[I]: >> HWADDR=4a:c8:fd:4a:c0:03
[I]: >> MTU=1500
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
++++++++++++++++
[I]: There is no other nic device to configure.
Wed Aug  2 04:57:09 EDT 2017 postscript confignetwork return with 0
Wed Aug  2 04:57:10 EDT 2017 Running postscript: setbootfromdisk
setbootfromdisk: setting up /dev/sda2 as the default bootup device
Wed Aug  2 04:57:10 EDT 2017 postscript setbootfromdisk return with 0
```