### PR TITLE
fix setroute failed during updatenode

### DIFF
--- a/xCAT/postscripts/routeop
+++ b/xCAT/postscripts/routeop
@@ -25,9 +25,13 @@
 
 if [ "$(uname -s|tr 'A-Z' 'a-z')" = "linux" ];then
    str_dir_name=`dirname $0`
-   ([ -f $str_dir_name/xcatlib.sh ] && . $str_dir_name/xcatlib.sh) || \
-   ([ -f /install/postscripts/xcatlib.sh ] && . /install/postscripts/xcatlib.sh) || \
-   ([ -f /xcatpost/xcatlib.sh ] && . /xcatpost/xcatlib.sh)
+   if [ -f $str_dir_name/xcatlib.sh ]; then
+       . $str_dir_name/xcatlib.sh
+   elif [ -f /install/postscripts/xcatlib.sh ]; then
+       . /install/postscripts/xcatlib.sh
+   elif [ -f /xcatpost/xcatlib.sh ]; then
+       . /xcatpost/xcatlib.sh
+   fi
 fi
 
 op=$1


### PR DESCRIPTION
fix #3596 

Unit test:
```
[root@bybc0602 postscripts]# chdef bybc0605 -p routenames=10net
1 object definitions have been created or modified.
[root@bybc0602 postscripts]# ssh bybc0605
Last login: Wed Aug  2 03:24:48 2017 from gateway

[root@bybc0609 ~]# route
Kernel IP routing table
Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
default         gateway         0.0.0.0         UG    0      0        0 eth0
10.0.0.0        0.0.0.0         255.0.0.0       U     0      0        0 eth0
link-local      0.0.0.0         255.255.0.0     U     1002   0        0 eth0
[root@bybc0609 ~]# route del default
[root@bybc0609 ~]# exit
logout
Connection to bybc0605 closed.

[root@bybc0602 postscripts]# updatenode bybc0605 setroute
bybc0605: xcatdsklspost: downloaded postscripts successfully
bybc0605: Wed Aug  2 05:47:36 EDT 2017 Running postscript: setroute
bybc0605: Adding temporary route: ip route replace 10.0.0.0/8 via 10.0.0.103; Persistent route "10.0.0.0/8 via 10.0.0.103" has been added in /etc/sysconfig/network-scripts/route-eth0.
bybc0605: postscript: setroute exited with code 0
bybc0605: Running of postscripts has completed.

[root@bybc0602 postscripts]# xdsh bybc0605 "cat /etc/sysconfig/network-scripts/route-eth0"
bybc0605: 10.0.0.0/8 via 10.0.0.103
```