### PR TITLE
modify rinv testcase for different arch has different output

### DIFF
--- a/xCAT-test/autotest/testcase/rinv/cases0
+++ b/xCAT-test/autotest/testcase/rinv/cases0
@@ -121,7 +121,7 @@ cmd:chdef $$CN bmcpassword=test
 check:rc==0
 cmd:rinv $$CN all
 check:rc==1
-check:output=~$$CN: Error: Invalid username or password
+check:output=~$$CN: Error: Invalid username or password|Error: ERROR: Incorrect password provided
 cmd:cat /tmp/testnode.stanza | chdef -z;rm -rf /tmp/testnode.stanza 
 check:rc==0
 end


### PR DESCRIPTION
Modify rinv testcase for different arch has different output if using wrong passwd .