### PR TITLE
fix issue dodiscovery sending findme packet 4 times for each node #3408

### DIFF
--- a/xCAT-genesis-scripts/bin/dodiscovery
+++ b/xCAT-genesis-scripts/bin/dodiscovery
@@ -1,6 +1,13 @@
 #!/bin/bash
 log_label="xcat.genesis.dodiscovery"
 
+#the time when the latest findme request is sent to master
+reqtime=0
+#the timeout value on the waiting for the "processed" response from master
+#when the xcatd on master finished the processing of my findme request, 
+#a "processed" response will be replied
+maxresptime=180
+
 minixcatd.awk &
 PUBKEY=`openssl rsa -in /etc/xcat/privkey.pem -pubout 2> /dev/null|grep -v "PUBLIC KEY"`
 PUBKEY=`echo $PUBKEY|sed -e 's/ //g'`
@@ -56,6 +63,23 @@ done
 	
 #time to make our packet...
 while [ ! -r /restart ]; do
+
+    #record the current time
+    curtime=$(date +%s)       
+
+    #the existence of "/processing" indicates that my  findme request is under processing
+    if [ -f "/processing"  ]; then
+        if [ $curtime -gt $[ $reqtime + $maxresptime ] ]; then
+           #I think my findme request processing is timeout, I will resend the findme request
+           logger -s -t $log_label -p local4.info  "seems the processing of my findme request cost more than $maxresptime, send new findme request"
+           rm -rf /processing
+        else
+           logger -s -t $log_label -p local4.info  "My findme request is still under processing, do not send new request"
+           sleep 5
+        fi
+        continue
+    fi
+
 MTM=unknown
 SERIAL=unknown
 ARCH=unknown
@@ -287,6 +311,9 @@ gzip -9 /tmp/discopacket
 		logger -s -t $log_label -p local4.info "Sending the discovery packet to xCAT ($dhcps:$XCATPORT)..."
 		(cat /tmp/discopacket.gz | udpcat.awk $dhcps $XCATPORT ) &
 	done
+      
+        #record the time when the "findme request is sent to master"
+        reqtime=$(date +%s) 
 	#cat /tmp/discopacket
 	logger -s -t $log_label -p local4.info "Sleeping 5 seconds..."
 	sleep 5

--- a/xCAT-genesis-scripts/bin/minixcatd.awk
+++ b/xCAT-genesis-scripts/bin/minixcatd.awk
@@ -1,18 +1,24 @@
 #!/usr/bin/awk -f
 # IBM(c) 2007 EPL license http://www.eclipse.org/legal/epl-v10.html
 BEGIN {
-	port = 3001
-	listener = "/inet/tcp/" port "/0/0"
-    quit = "no"
-	while (match(quit,"no")) {
-		while (match(quit,"no") && (listener |& getline) > 0) {
-			if (match($0,"restart")) {
-				print "restarting bootstrap process" |& listener
-                quit="yes"
-				system("echo \"" $0 "\" > /restart")
-		        close(listener)
-			}
-		}
-		close(listener)
-	}
+        port = 3001
+        listener = "/inet/tcp/" port "/0/0"
+        quit = "no"
+        while (match(quit,"no")) {
+            while (match(quit,"no") && (listener |& getline) > 0) {
+                if (match($0,"restart")) {
+                    print "restarting bootstrap process" |& listener
+                    quit="yes"
+                    system("echo \"" $0 "\" > /restart")
+                    close(listener)
+                }else if(match($0,"processing")){
+                    print "processing request" |& listener
+                    system("echo \"" $0 "\" > /processing")
+                }else if(match($0,"processed")){
+                    print "finished request process" |& listener
+                    system("rm -rf /processing")
+                }
+           }
+           close(listener)
+        }
 }

--- a/xCAT-server/lib/xcat/plugins/aaadiscovery.pm
+++ b/xCAT-server/lib/xcat/plugins/aaadiscovery.pm
@@ -27,6 +27,22 @@ sub process_request {
             return;
         }
         my $client_ip = $req->{'_xcat_clientip'};
+
+        #now, notify the node that its findme request is under processing
+        xCAT::MsgUtils->message("S", "Notify $client_ip that its findme request is processing\n");
+        my $sock = new IO::Socket::INET(
+            PeerAddr => $client_ip,
+            PeerPort => '3001',
+            Timeout  => '1',
+            Proto    => 'tcp'
+        );
+        if ($sock) { 
+            print $sock "processing";
+            close($sock);
+        }else{ 
+            xCAT::MsgUtils->message("S", "Failed to notify $client_ip that its findme request is processing."); 
+        }
+
         my $arptable;
         if (-x "/usr/sbin/arp") {
             $arptable = `/usr/sbin/arp -n`;

--- a/xCAT-server/lib/xcat/plugins/nodediscover.pm
+++ b/xCAT-server/lib/xcat/plugins/nodediscover.pm
@@ -470,7 +470,7 @@ sub process_request {
         Timeout  => '1',
         Proto    => 'tcp'
     );
-    unless ($sock) { xCAT::MsgUtils->message("S", "Failed to notify $clientip that it's actually $node."); return; }
+    unless ($sock) { xCAT::MsgUtils->message("S", "xcat.discovery.nodediscover: Failed to notify $clientip that it's actually $node."); return; }
     print $sock $restartstring;
     close($sock);
 

--- a/xCAT-server/lib/xcat/plugins/zzzdiscovery.pm
+++ b/xCAT-server/lib/xcat/plugins/zzzdiscovery.pm
@@ -19,14 +19,32 @@ sub process_request {
     my $cb    = shift;
     my $doreq = shift;
     if ($req->{command}->[0] eq 'findme') {
+
         if (!defined($req->{discoverymethod}) or !defined($req->{discoverymethod}->[0]) or ($req->{discoverymethod}->[0] eq 'undef')) {
             my $rsp = {};
             $rsp->{error}->[0] = "The discovery request can not be processed";
             $cb->($rsp);
             xCAT::MsgUtils->message("S", "xcat.discovery.zzzdiscovery: ($req->{_xcat_clientmac}->[0]) Failed to discover the node.");
-            return;
+
+            #now, notify the node that its findme request has been processed
+            my $client_ip = $req->{'_xcat_clientip'};
+            xCAT::MsgUtils->message("S","Notify $client_ip that its findme request has been processed");
+            my $sock = new IO::Socket::INET(
+                PeerAddr => $client_ip,
+                PeerPort => '3001',
+                Timeout  => '1',
+                Proto    => 'tcp'
+            );
+            if ($sock) { 
+                print $sock "processed";
+                close($sock);
+            }else{
+                xCAT::MsgUtils->message("S", "Failed to notify $client_ip that its findme request has been processed"); 
+            }
+        }else{
+            xCAT::MsgUtils->message("S", "xcat.discovery.zzzdiscovery: ($req->{_xcat_clientmac}->[0]) Successfully discovered the node using $req->{discoverymethod}->[0] discovery method.");
         }
-        xCAT::MsgUtils->message("S", "xcat.discovery.zzzdiscovery: ($req->{_xcat_clientmac}->[0]) Successfully discovered the node using $req->{discoverymethod}->[0] discovery method.");
+
         return;
     }
 }


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/3408

1. notify the node when the processing of its "findme" start and finish.
2. the node whose "findme" request is under processing won't send new "findme" request until:
     (1). its request has been processed but it does not receive the "restart" response.
     (2). its request is still under processing but the wait time exceeds the timeout value(180s by default)
