### PR TITLE
[Test Case] modify the existing case to cover #3474: CLI could show server info enhancement

### DIFF
--- a/xCAT-test/autotest/testcase/nodeset/cases0
+++ b/xCAT-test/autotest/testcase/nodeset/cases0
@@ -3,7 +3,11 @@ os:Linux
 cmd:nodeset $$CN stat
 check:rc==0
 check:output=~$$CN:\s+[discover|boot|reboot|install|netboot|shell|standby]
+cmd:nodeset $$CN stat -V
+check:rc==0
+check:output=~$$CN:\s+\[\w+\]:\s+[discover|boot|reboot|install|netboot|shell|standby]
 end
+
 start:nodeset_noderange
 os:Linux
 cmd:nodeset $$CN test

--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -220,6 +220,13 @@ if (defined($configfile)) {
     }
 } else {
     $setup_env_by_config_file = 0;
+    # Leverage environment variable to used in test case
+    foreach (keys %ENV) {
+        if (/^XCATTEST_/) {
+            my @envname=split("_",$_,2);
+            $config{var}{$envname[-1]} = $ENV{$_};
+        }
+    }
 }
 
 if ($restore) {


### PR DESCRIPTION
To cover #3474 test case.

As the CLI show server information is implemented by a general mechanism, we can select one CLI as an example for testing.  This PR contains below change:

1, test case for nodeset -V to show server info
2, allow xcattest get 'var' type config from environment variable when no config file specified.
For example, when given 'XCATTEST_CN=fake1', xcattest will set $$CN=fake1

UT:
```
# XCATTEST_CN=c910f03c05k24 xcattest -t nodeset_stat
xCAT automated test started at Thu Aug  3 04:36:57 2017
******************************
loading test cases
******************************
To run:
nodeset_stat
******************************
Start to run test cases
******************************
------START::nodeset_stat::Time:Thu Aug  3 04:36:58 2017------

RUN:nodeset c910f03c05k24 stat [Thu Aug  3 04:36:58 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
c910f03c05k24: offline
CHECK:rc == 0	[Pass]
CHECK:output =~ c910f03c05k24:\s+[discover|boot|reboot|install|netboot|shell|standby]	[Pass]

RUN:nodeset c910f03c05k24 stat -V [Thu Aug  3 04:36:58 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
c910f03c05k24: [c910f03c05k20]: offline
CHECK:rc == 0	[Pass]
CHECK:output =~ c910f03c05k24:\s+\[\w+\]:\s+[discover|boot|reboot|install|netboot|shell|standby]	[Pass]

------END::nodeset_stat::Passed::Time:Thu Aug  3 04:36:58 2017 ::Duration::0 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished atThu Aug  3 04:36:58 2017
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20170803043657 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20170803043657 file for time consumption
```