### PR TITLE
fix nicips regular expression in mypostscript

### DIFF
--- a/xCAT-server/lib/perl/xCAT/Postage.pm
+++ b/xCAT-server/lib/perl/xCAT/Postage.pm
@@ -18,7 +18,6 @@ use xCAT::Template;
 use xCAT::SvrUtils;
 use xCAT::Zone;
 
-use Data::Dumper;
 use File::Basename;
 use Socket;
 use strict;

--- a/xCAT-server/lib/perl/xCAT/Postage.pm
+++ b/xCAT-server/lib/perl/xCAT/Postage.pm
@@ -18,7 +18,7 @@ use xCAT::Template;
 use xCAT::SvrUtils;
 use xCAT::Zone;
 
-#use Data::Dumper;
+use Data::Dumper;
 use File::Basename;
 use Socket;
 use strict;
@@ -1530,12 +1530,6 @@ sub collect_all_attribs_for_tables_in_template
                     if ($ent->{$node}->[0]) {
                         foreach my $attrib (@attribs) {
                             $::GLOBAL_TAB_HASH{$tabname}{$node}{$attrib} = $ent->{$node}->[0]->{$attrib};
-                            #If nicips contains regular expression 
-                            if ($tabname =~ /^nics$/ && $attrib =~ /^nicips$/ &&  
-                                $::GLOBAL_TAB_HASH{nics}{$node}{nicips} =~ /\S*\!\|\S*/)
-                            {
-                                $::GLOBAL_TAB_HASH{nics}{$node}{nicips}=get_nics_nicips($node,$::GLOBAL_TAB_HASH{nics}{$node}{nicips});
-                            }
                             #for noderes.xcatmaster
                             if ($tabname =~ /^noderes$/ && $attrib =~ /^xcatmaster$/ &&
                                 (!exists($::GLOBAL_TAB_HASH{noderes}{$node}{xcatmaster}) ||
@@ -1572,7 +1566,11 @@ sub collect_all_attribs_for_tables_in_template
                         !defined($::GLOBAL_TAB_HASH{noderes}{$node}{xcatmaster})) {
                         $::GLOBAL_TAB_HASH{noderes}{$node}{xcatmaster} = $::XCATSITEVALS{master};
                     }
-
+                    #If nicips contains regular expression
+                    if (exists($::GLOBAL_TAB_HASH{nics}{$node}{nicips}) && $::GLOBAL_TAB_HASH{nics}{$node}{nicips} =~ /\S*\!\|\S*/)
+                    {
+                        $::GLOBAL_TAB_HASH{nics}{$node}{nicips}=get_nics_nicips($node,$ent->{$node}->[0]->{nicips});
+                    }
                     if (!defined($::GLOBAL_TAB_HASH{noderes}{$node}{nfsserver})) {
                         $::GLOBAL_TAB_HASH{noderes}{$node}{nfsserver} = $::GLOBAL_TAB_HASH{noderes}{$node}{xcatmaster};
                     }


### PR DESCRIPTION
fix #3602 
unit test:

Cover nics tables 3 scenarios as:
```
1. 
[root@bybc0602 ~]# tabdump nics
#node,nicips,nichostnamesuffixes,nichostnameprefixes,nictypes,niccustomscripts,nicnetworks,nicaliases,nicextraparams,nicdevices,nicsadapter,comments,disable
"regex1","eth1!|\D+(\d+)|30.0.0.($1%100)|,eth2!40.0.0.9",,,"eth1!ethernet,eth2!ethernet",,"eth1!30_0_0_0-255_0_0_0,eth2!40_0_0_0-255_0_0_0",,,,,,

2.
[root@bybc0602 ~]# tabdump nics
#node,nicips,nichostnamesuffixes,nichostnameprefixes,nictypes,niccustomscripts,nicnetworks,nicaliases,nicextraparams,nicdevices,nicsadapter,comments,disable
"regex1","eth1!|\D+(\d+)|30.0.0.($1%100)|,eth2!|\D+(\d+)|40.0.0.($1%100)|",,,"eth1!ethernet,eth2!ethernet",,"eth1!30_0_0_0-255_0_0_0,eth2!40_0_0_0-255_0_0_0",,,,,,

3.
[root@bybc0602 ~]# tabdump nics
#node,nicips,nichostnamesuffixes,nichostnameprefixes,nictypes,niccustomscripts,nicnetworks,nicaliases,nicextraparams,nicdevices,nicsadapter,comments,disable
"regex1","eth1!30.0.0.9,eth2!40.0.0.9",,,"eth1!ethernet,eth2!ethernet",,"eth1!30_0_0_0-255_0_0_0,eth2!40_0_0_0-255_0_0_0",,,,,,


Got the same result:
Thu Aug  3 08:49:30 UTC 2017 Running postscript: confignetwork
[I]: All valid nics and device list:
[I]: eth1
[I]: eth2
[I]: NetworkManager is inactive.
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
configure nic and its device : eth1
[I]: configure eth1
[I]: call: configeth eth1 30.0.0.9 30_0_0_0-255_0_0_0
[I]: configeth on bybc0609: os type: redhat
configeth on bybc0609: old configuration: 3: eth1: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN qlen 1000
    link/ether 42:aa:0a:05:6a:09 brd ff:ff:ff:ff:ff:ff
[I]: configeth on bybc0609: new configuration
       30.0.0.9, 30.0.0.0, 255.0.0.0, <xcatmaster>
[I]: configeth on bybc0609: eth1 changed, modify the configuration files
bring up ip
['/etc/sysconfig/network-scripts/ifcfg-eth1']
[I]: >> DEVICE=eth1
[I]: >> BOOTPROTO=static
[I]: >> NM_CONTROLLED=no
[I]: >> IPADDR=30.0.0.9
[I]: >> NETMASK=255.0.0.0
[I]: >> ONBOOT=yes
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
configure nic and its device : eth2
[I]: configure eth2
[I]: call: configeth eth2 40.0.0.9 40_0_0_0-255_0_0_0
[I]: configeth on bybc0609: os type: redhat
configeth on bybc0609: old configuration: 4: eth2: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN qlen 1000
    link/ether 42:47:0a:05:6a:09 brd ff:ff:ff:ff:ff:ff
[I]: configeth on bybc0609: new configuration
       40.0.0.9, 40.0.0.0, 255.0.0.0, <xcatmaster>
[I]: configeth on bybc0609: eth2 changed, modify the configuration files
bring up ip
['/etc/sysconfig/network-scripts/ifcfg-eth2']
[I]: >> DEVICE=eth2
[I]: >> BOOTPROTO=static
[I]: >> NM_CONTROLLED=no
[I]: >> IPADDR=40.0.0.9
[I]: >> NETMASK=255.0.0.0
[I]: >> ONBOOT=yes
Thu Aug  3 08:49:38 UTC 2017 postscript confignetwork return with 0
returned from postscript

[root@bybc0602 ~]# xdsh bybc0609 "cat /xcatpost/mypostscript|grep NICIPS"
bybc0609: NICIPS='eth1!30.0.0.9,eth2!40.0.0.9'
bybc0609: export NICIPS
```
