### PR TITLE
Implement openbmc image delete function

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rflash.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rflash.1.rst
@@ -57,7 +57,7 @@ OpenPOWER OpenBMC specific :
 ============================
 
 
-\ **rflash**\  \ *noderange*\  [\ *tar_file_path*\  | \ *image_id*\ ] [\ **-c | -**\ **-check**\ ] [\ **-a | -**\ **-activate**\ ] [\ **-l | -**\ **-list**\ ] [\ **-u | -**\ **-upload**\ ]
+\ **rflash**\  \ *noderange*\  [\ *tar_file_path*\  | \ *image_id*\ ] [\ **-c | -**\ **-check**\ ] [\ **-a | -**\ **-activate**\ ] [\ **-l | -**\ **-list**\ ] [\ **-u | -**\ **-upload**\ ] [\ **-d | -**\ **-delete**\ ]
 
 
 
@@ -217,6 +217,12 @@ The command will update firmware for OpenPOWER OpenBMC when given an OpenPOWER n
 \ **-u|-**\ **-upload**\ 
  
  Upload update image. Specified file must be in .tar format.
+ 
+
+
+\ **-d|-**\ **-delete**\ 
+ 
+ Delete update image from BMC
  
 
 

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -345,7 +345,7 @@ my %usage = (
     PPC64LE (using IPMI Management) specific:
         rflash <noderange> [-c|--check] [--retry=<count>] [-V] [<hpm_file>|-d=<data_directory>]
     PPC64LE (using OpenBMC Management) specific:
-        rflash <noderange> [-c|--check] [-l|--list] [-a|--activate] [-u|--upload] [<tar_file>|<image_id>]",
+        rflash <noderange> [-c|--check] [-l|--list] [-a|--activate] [-u|--upload] [-d|--delete] [<tar_file>|<image_id>]",
     "mkhwconn" =>
       "Usage:
     mkhwconn [-h|--help]

--- a/xCAT-client/pods/man1/rflash.1.pod
+++ b/xCAT-client/pods/man1/rflash.1.pod
@@ -28,7 +28,7 @@ B<rflash> I<noderange> [I<hpm_file_path> | B<-d=>I<data_directory>] [B<-c>|B<--c
 
 =head2 OpenPOWER OpenBMC specific :
 
-B<rflash> I<noderange> [I<tar_file_path> | I<image_id>] [B<-c>|B<--check>] [B<-a>|B<--activate>] [B<-l>|B<--list>] [B<-u>|B<--upload>]
+B<rflash> I<noderange> [I<tar_file_path> | I<image_id>] [B<-c>|B<--check>] [B<-a>|B<--activate>] [B<-l>|B<--list>] [B<-u>|B<--upload>] [B<-d>|B<--delete>]
 
 =head1 B<Description>
 
@@ -144,6 +144,10 @@ List currently uploaded update images. "(*)" indicates currently active image.
 =item B<-u|--upload>
 
 Upload update image. Specified file must be in .tar format.
+
+=item B<-d|--delete>
+
+Delete update image from BMC
 
 =item B<-v|--version>
 


### PR DESCRIPTION
The pull request implements image delete action for openbmc `rflash command`. Issue #3158 

Initial state:
```
[root@stratton01 gurevich]# rflash p9euh02 -l
p9euh02: ID       Purpose State      Version
p9euh02: -------------------------------------------------------
p9euh02: 2a1022fe Host    Active(*)  IBM-witherspoon-sequoia-ibm-OP9_v1.17_1.67
p9euh02: 54c1c9c  BMC     Active     v1.99.8-178-g7a75570
p9euh02: 32f129cd Host    Active     IBM-witherspoon-redbud-ibm-OP9_v1.17_1.68
p9euh02:
```

Delete one of the images:
```
[root@stratton01 gurevich]# rflash p9euh02 -d 32f129cd
p9euh02: Firmware update successfully removed
[root@stratton01 gurevich]#
```

State after removal:
```
[root@stratton01 gurevich]# rflash p9euh02 -l
p9euh02: ID       Purpose State      Version
p9euh02: -------------------------------------------------------
p9euh02: 2a1022fe Host    Active(*)  IBM-witherspoon-sequoia-ibm-OP9_v1.17_1.67
p9euh02: 54c1c9c  BMC     Active     v1.99.8-178-g7a75570
p9euh02:
[root@stratton01 gurevich]#
```
```