### PR TITLE
Test case against confignetwork - reconfigure installnic without dhclient lease file

### DIFF
--- a/xCAT-test/autotest/testcase/confignetwork/cases0
+++ b/xCAT-test/autotest/testcase/confignetwork/cases0
@@ -945,6 +945,8 @@ cmd:xdsh $$CN "mkdir -p /tmp/backupnet"
 check:rc==0
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network/ifcfg-* /tmp/backupnet/"; elif grep "Red Hat" /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network-scripts/ifcfg-* /tmp/backupnet/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /etc/network/interfaces.d/* /tmp/backupnet/;cp -f /etc/network/interfaces /tmp";else echo "Sorry,this is not supported os"; fi
 check:rc==0
+cmd:xdsh $$CN 'killall dhclient'
+cmd:xdsh $$CN 'killall -KILL dhclient'
 cmd:xdsh $$CN 'rm -f /var/lib/dhcp/dhclient.leases /var/lib/dhclient/dhclient.leases'
 check:rc==0
 cmd:updatenode $$CN 'confignetwork -s'
@@ -955,4 +957,5 @@ check:rc==0
 cmd:test -e /tmp/CN.stanza && rmdef $$CN && mkdef -z </tmp/CN.stanza; rm -rf /tmp/CN.stanza
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network/"; elif grep "Red Hat" /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network-scripts/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/network/interfaces.d/;cp -f /tmp/interfaces /etc/network/";else echo "Sorry,this is not supported os"; fi
 cmd:xdsh $$CN "rm -rf /tmp/backupnet/ /tmp/interfaces"
+cmd:xdsh $$CN "if [ -f /etc/init.d/network ] then ; /etc/init.d/network restart ; elif [ -f /etc/init.d/networking ] then ; /etc/init.d/networking restart ; fi
 end

--- a/xCAT-test/autotest/testcase/confignetwork/cases0
+++ b/xCAT-test/autotest/testcase/confignetwork/cases0
@@ -936,3 +936,23 @@ check:rc==0
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network/"; elif grep "Red Hat" /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network-scripts/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/network/interfaces.d/;cp -f /tmp/interfaces /etc/network/";else echo "Sorry,this is not supported os"; fi
 cmd:xdsh $$CN "rm -rf /tmp/backupnet/ /tmp/interfaces"
 end
+
+start:confignetwork_static_installnic
+description:Reconfigure installnic without dhclient lease file
+cmd:lsdef $$CN -z && lsdef -l $$CN -z >/tmp/CN.stanza
+check:rc==0
+cmd:xdsh $$CN "mkdir -p /tmp/backupnet"
+check:rc==0
+cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network/ifcfg-* /tmp/backupnet/"; elif grep "Red Hat" /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network-scripts/ifcfg-* /tmp/backupnet/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /etc/network/interfaces.d/* /tmp/backupnet/;cp -f /etc/network/interfaces /tmp";else echo "Sorry,this is not supported os"; fi
+check:rc==0
+cmd:xdsh $$CN 'rm -f /var/lib/dhcp/dhclient.leases /var/lib/dhclient/dhclient.leases'
+check:rc==0
+cmd:updatenode $$CN 'confignetwork -s'
+check:rc==0
+cmd:xdsh $$CN date
+check:rc==0
+# Clean up
+cmd:test -e /tmp/CN.stanza && rmdef $$CN && mkdef -z </tmp/CN.stanza; rm -rf /tmp/CN.stanza
+cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network/"; elif grep "Red Hat" /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network-scripts/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/network/interfaces.d/;cp -f /tmp/interfaces /etc/network/";else echo "Sorry,this is not supported os"; fi
+cmd:xdsh $$CN "rm -rf /tmp/backupnet/ /tmp/interfaces"
+end

--- a/xCAT-test/autotest/testcase/confignetwork/cases0
+++ b/xCAT-test/autotest/testcase/confignetwork/cases0
@@ -945,9 +945,9 @@ cmd:xdsh $$CN "mkdir -p /tmp/backupnet"
 check:rc==0
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network/ifcfg-* /tmp/backupnet/"; elif grep "Red Hat" /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network-scripts/ifcfg-* /tmp/backupnet/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /etc/network/interfaces.d/* /tmp/backupnet/;cp -f /etc/network/interfaces /tmp";else echo "Sorry,this is not supported os"; fi
 check:rc==0
-cmd:xdsh $$CN 'killall dhclient'
-cmd:xdsh $$CN 'killall -KILL dhclient'
-cmd:xdsh $$CN 'rm -f /var/lib/dhcp/dhclient.leases /var/lib/dhclient/dhclient.leases'
+cmd:xdsh $$CN "kill $(ps -A | awk '/dhclient/ { print $1 }')"
+cmd:xdsh $$CN "kill -KILL $(ps -A | awk '/dhclient/ { print $1 }')"
+cmd:xdsh $$CN 'rm -f /var/lib/dhcp/dhclient*.lease* /var/lib/dhclient/dhclient*.lease*'
 check:rc==0
 cmd:updatenode $$CN 'confignetwork -s'
 check:rc==0
@@ -957,5 +957,5 @@ check:rc==0
 cmd:test -e /tmp/CN.stanza && rmdef $$CN && mkdef -z </tmp/CN.stanza; rm -rf /tmp/CN.stanza
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network/"; elif grep "Red Hat" /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network-scripts/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/network/interfaces.d/;cp -f /tmp/interfaces /etc/network/";else echo "Sorry,this is not supported os"; fi
 cmd:xdsh $$CN "rm -rf /tmp/backupnet/ /tmp/interfaces"
-cmd:xdsh $$CN "if [ -f /etc/init.d/network ] then ; /etc/init.d/network restart ; elif [ -f /etc/init.d/networking ] then ; /etc/init.d/networking restart ; fi
+cmd:xdsh $$CN "if [ -f /etc/init.d/network ] then ; /etc/init.d/network restart ; elif [ -f /etc/init.d/networking ] then ; /etc/init.d/networking restart ; fi"
 end

--- a/xCAT-test/autotest/testcase/confignetwork/cases0
+++ b/xCAT-test/autotest/testcase/confignetwork/cases0
@@ -945,8 +945,8 @@ cmd:xdsh $$CN "mkdir -p /tmp/backupnet"
 check:rc==0
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network/ifcfg-* /tmp/backupnet/"; elif grep "Red Hat" /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network-scripts/ifcfg-* /tmp/backupnet/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /etc/network/interfaces.d/* /tmp/backupnet/;cp -f /etc/network/interfaces /tmp";else echo "Sorry,this is not supported os"; fi
 check:rc==0
-cmd:xdsh $$CN "kill $(ps -A | awk '/dhclient/ { print $1 }')"
-cmd:xdsh $$CN "kill -KILL $(ps -A | awk '/dhclient/ { print $1 }')"
+cmd:xdsh $$CN "ps -A --format pid,comm | awk '/dhclient/ { print \$1 }' | xargs -r -n 1 kill"
+cmd:xdsh $$CN "ps -A --format pid,comm | awk '/dhclient/ { print \$1 }' | xargs -r -n 1 kill -KILL"
 cmd:xdsh $$CN 'rm -f /var/lib/dhcp/dhclient*.lease* /var/lib/dhclient/dhclient*.lease*'
 check:rc==0
 cmd:updatenode $$CN 'confignetwork -s'
@@ -957,5 +957,5 @@ check:rc==0
 cmd:test -e /tmp/CN.stanza && rmdef $$CN && mkdef -z </tmp/CN.stanza; rm -rf /tmp/CN.stanza
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network/"; elif grep "Red Hat" /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network-scripts/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/network/interfaces.d/;cp -f /tmp/interfaces /etc/network/";else echo "Sorry,this is not supported os"; fi
 cmd:xdsh $$CN "rm -rf /tmp/backupnet/ /tmp/interfaces"
-cmd:xdsh $$CN "if [ -f /etc/init.d/network ] then ; /etc/init.d/network restart ; elif [ -f /etc/init.d/networking ] then ; /etc/init.d/networking restart ; fi"
+cmd:xdsh $$CN "if [ -f /etc/init.d/network ] ; then /etc/init.d/network restart ; elif [ -f /etc/init.d/networking ] ; then /etc/init.d/networking restart ; fi"
 end


### PR DESCRIPTION
Add one cases in this pull request
This pull request is for task #3488
This pull request is for issue #3426

[case 1]
Case Name: Add a test case against confignetwork
description: Reconfigure installnic without dhclient lease file