### PR TITLE
fix a typo in rinstall -c/--console error message

### DIFF
--- a/xCAT-client/bin/rinstall
+++ b/xCAT-client/bin/rinstall
@@ -75,7 +75,7 @@ my $noderange = $cmdref->{noderange}->[0];    # save the noderange
 my @noderange=xCAT::NodeRange::noderange($noderange);
 
 if($bname eq "rinstall" and $startconsole==1 and scalar @noderange!=1 ){
-    xCAT::MsgUtils->message("E", "Error: rinstall can only be run against one node! Please use winstall for multiple nodes.");
+    xCAT::MsgUtils->message("E", "Error: rinstall -c/--console can only be run against one node! Please use winstall for multiple nodes.");
     exit 1;    
 }
 

--- a/xCAT-client/bin/rinstall
+++ b/xCAT-client/bin/rinstall
@@ -75,7 +75,7 @@ my $noderange = $cmdref->{noderange}->[0];    # save the noderange
 my @noderange=xCAT::NodeRange::noderange($noderange);
 
 if($bname eq "rinstall" and $startconsole==1 and scalar @noderange!=1 ){
-    xCAT::MsgUtils->message("E", "Error: rinstall -c/--console can only be run against one node! Please use winstall for multiple nodes.");
+    xCAT::MsgUtils->message("E", "Error: rinstall -c/--console can only be run against one node! Please use winstall -c/--console for multiple nodes.");
     exit 1;    
 }
 


### PR DESCRIPTION
modify the error message to be ``Error: rinstall -c/--console can only be run against one node! Please use winstall -c/--console for multiple nodes.``