### PR TITLE
Fix typo in xcatprobe discovery precheck

### DIFF
--- a/xCAT-probe/subcmds/discovery
+++ b/xCAT-probe/subcmds/discovery
@@ -563,8 +563,12 @@ sub check_genesis_file {
         $genesis_v = `rpm -qi xCAT-genesis-base-ppc64`;
     }
 
-    if ($genesis_v !~ /Built in environment .+fc.* on (.+)\./) {
-        push @warn_msg, "xcat-genesis-base-ppc64 is built in environment fedora on $1.";
+    if ($genesis_v =~ /Built in environment .+fc(\d*).+ on (.+)\./) {
+        my $ver  = $1;
+        my $arch = $2;
+        push @warn_msg, "xcat-genesis-base-ppc64 is not built in environment fedora 26 or higher version on $arch." if ($ver < 26);
+    } else {
+        push @warn_msg, "xcat-genesis-base-ppc64 is not built in environment fedora.";
     }
 
     my $genesis_update_flag_p;


### PR DESCRIPTION
If xcat-genesis-base-ppc64 is not built in fedora environment, will print warning msg.
```
# xcatprobe discovery -n test_node -m mtms -c
Genesis files are avaliable                                                                                       [ OK ]
xcat-genesis-base-ppc64 is not built in environment fedora on ppc64.                                                    [WARN]
```