### PR TITLE
fix issue 3617: Output of command nodeset stat is with MN's long hostname

### DIFF
--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -941,7 +941,9 @@ unless ($foreground) {
 }
 
 # Cache the hostname, restart xcatd if hostname is changed after xcatd running
-my $MYXCATSERVER = Sys::Hostname::hostname;
+my $myhostname = Sys::Hostname::hostname;
+my @mynamearray = split(/\./, $myhostname);
+my $MYXCATSERVER = $mynamearray[0];
 
 $dbmaster = xCAT::Table::init_dbworker;
 if ($enable_perf) {


### PR DESCRIPTION
Fix issue #3617 
The output before:
```
[root@c910f02c08p05 ~]# nodeset c910f02c08p07 stat -V
c910f02c08p07: [c910f02c08p05.pok.stglabs.ibm.com]: boot```
The output now:
```
[root@c910f02c08p05 sbin]# nodeset c910f02c08p07 stat -V
c910f02c08p07: [c910f02c08p05]: boot
```