### PR TITLE
using sshpass (if availble) connect to openbmc console

### DIFF
--- a/xCAT-server/share/xcat/cons/openbmc
+++ b/xCAT-server/share/xcat/cons/openbmc
@@ -91,7 +91,12 @@ if ($ENV{SSHCONSOLEPORT}) {
     $sshport= $ENV{SSHCONSOLEPORT};
 }
 
-print "If the console cannot connect, please verify whether ssh keys has been configured on the bmc for $username user\n";
+#user needs to download sshpass rpm if need to use it
+if (-x '/usr/bin/sshpass') {
+    exec "/usr/bin/sshpass -p $password ssh -p $sshport -l $username $bmcip";
+} else {
+    exec "ssh -p $sshport -l $username $bmcip";
+}
 
-exec "ssh -p $sshport -l $username $bmcip";
+
 

--- a/xCAT-server/share/xcat/cons/openbmc
+++ b/xCAT-server/share/xcat/cons/openbmc
@@ -91,10 +91,13 @@ if ($ENV{SSHCONSOLEPORT}) {
     $sshport= $ENV{SSHCONSOLEPORT};
 }
 
-#user needs to download sshpass rpm if need to use it
+# To automatically connect to the console without the need to send over the ssh keys, 
+# ensure sshpass is installed on the Management and/or Service Nodes.
 if (-x '/usr/bin/sshpass') {
     exec "/usr/bin/sshpass -p $password ssh -p $sshport -l $username $bmcip";
 } else {
+    # This will prompt the user to enter the password for the BMC 
+    # if ssh keys are not sent and sshpass is not being used
     exec "ssh -p $sshport -l $username $bmcip";
 }
 


### PR DESCRIPTION
connecting to openbmc console require user manually send SSH key over to openbmc.  

Sshpass is a tool for non-interactivly performing password authentication with SSH's so called "interactive keyboard password authentication".   xCAT will use this tool to connect openbmc console without user enter password.   currently, if user like to use this tool, needs to download sshpass from online http://rpmfind.net/linux/rpm2html/search.php?query=sshpass
 , then install to conserver server.  for near future,  we may add this package to xcat-dep.