### PR TITLE
Adding some packages that would help debug xCAT issues from service nodes

### DIFF
--- a/xCAT-server/share/xcat/install/rh/service.rhels7.ppc64le.pkglist
+++ b/xCAT-server/share/xcat/install/rh/service.rhels7.ppc64le.pkglist
@@ -34,3 +34,6 @@ perl-DBD-Pg
 wget
 util-linux-ng
 net-tools
+pciutils
+bind-utils
+tcpdump

--- a/xCAT-server/share/xcat/install/rh/service.rhels7.ppc64le.pkglist
+++ b/xCAT-server/share/xcat/install/rh/service.rhels7.ppc64le.pkglist
@@ -36,4 +36,5 @@ util-linux-ng
 net-tools
 pciutils
 bind-utils
+strace
 tcpdump


### PR DESCRIPTION
By default some of the xcatprobe utilities and diagnostics to validate configuration should be added to the service node package list so they do not need to be installed after the fact... 