### PR TITLE
Add trace log in db subroutines

### DIFF
--- a/docs/source/guides/admin-guides/references/man5/site.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/site.5.rst
@@ -390,6 +390,15 @@ site Attributes:
    hierarchicalattrs:  Table attributes(e.g. postscripts, postbootscripts) that will be
                        included hierarchically. Attribute values for all the node's groups
                        will be applied to the node in the groups' order except the repeat one.
+   dbtracelevel:  The trace level for the database access log. To activate this setting, please. 
+                  restart xcatd or send HUP signal to the 'xcatd: DB Access' process, Like: .
+                  ps -ef | grep 'xcatd: DB Access' | grep -v grep | awk '{print $2}' | xargs kill -HUP  
+                  Currrent support values: 
+                  0: disable the trace log for db 
+                  1: trace the calls of database subroutines 
+                  2: Besides the log from level 1, trace the event to build the cache for the table 
+                  3: Besides the log from level 2, trace the event with cache hit 
+                  4: Besides the log from level 3, trace the SQL statement for the db access 
   
    -----------------------
   VIRTUALIZATION ATTRIBUTES

--- a/perl-xCAT/xCAT/Schema.pm
+++ b/perl-xCAT/xCAT/Schema.pm
@@ -1243,7 +1243,16 @@ passed as argument rather than by table value',
 "             Qualified Domain Name). Otherwise, the original behavior will be performed.\n\n" .
 " hierarchicalattrs:  Table attributes(e.g. postscripts, postbootscripts) that will be\n" .
 "                     included hierarchically. Attribute values for all the node's groups\n" .
-"                     will be applied to the node in the groups' order except the repeat one.\n\n" .
+"                     will be applied to the node in the groups' order except the repeat one.\n" .
+" dbtracelevel:  The trace level for the database access log. To activate this setting, please. \n".
+"                restart xcatd or send HUP signal to the 'xcatd: DB Access' process, Like: .\n".
+"                ps -ef | grep 'xcatd: DB Access' | grep -v grep | awk '{print \$2}' | xargs kill -HUP  \n".
+"                Currrent support values: \n" .
+"                0: disable the trace log for db \n" .
+"                1: trace the calls of database subroutines \n" .
+"                2: Besides the log from level 1, trace the event to build the cache for the table \n" .
+"                3: Besides the log from level 2, trace the event with cache hit \n" .
+"                4: Besides the log from level 3, trace the SQL statement for the db access \n\n" .
 " -----------------------\n" .
 "VIRTUALIZATION ATTRIBUTES\n" .
 " -----------------------\n" .


### PR DESCRIPTION
This patch add trace log for the db access. Currently support
5 log levels:
- 0: disable the trace log for db.
- 1: trace the calls of database subroutines.
- 2: trace the event to build the cache for the table
- 3: trace the event with cache hit
- 4: trace the SQL statement

implement-feature: #3612

Output example from xcat/cluster.log:
```
Aug  9 01:59:15 c910f05c01bc02k74 xcat[694]: [DB Trace]: {"msg":{"table":"site","method":"xCAT::Table::setAttribs"},"type":"end","elapsed":"0.00176s"}
Aug  9 01:59:15 c910f05c01bc02k74 xcat[694]: [DB Trace]: {"msg":{"table":"site","method":"xCAT::Table::setAttribs"},"type":"start"}
Aug  9 01:59:15 c910f05c01bc02k74 xcat[694]: [DB Trace]: {"msg":{"addon":"SELECT * FROM site WHERE \"value\" = ? AND \"comments\" = ? AND \"disable\" = ? AND \"key\" = ?","table":"site","method":"xCAT::Table::setAttribs"},"type":"start_sql"}
Aug  9 01:59:15 c910f05c01bc02k74 xcat[694]: [DB Trace]: {"msg":{"table":"site","method":"xCAT::Table::setAttribs"},"type":"end_sql","elapsed":"0.00043s"}
Aug  9 01:59:15 c910f05c01bc02k74 xcat[694]: [DB Trace]: {"msg":{"addon":"INSERT INTO site (\"value\",\"comments\",\"key\",\"disable\") VALUES (?,?,?,?)","table":"site","method":"xCAT::Table::setAttribs"},"type":"start_sql"}
Aug  9 01:59:15 c910f05c01bc02k74 xcat[694]: [DB Trace]: {"msg":{"addon":"INSERT INTO site (\"value\",\"comments\",\"key\",\"disable\") VALUES (?,?,?,?)","table":"site","method":"xCAT::Table::setAttribs"},"type":"end_sql","elapsed":"0.00043s"}
Aug  9 01:59:15 c910f05c01bc02k74 xcat[694]: [DB Trace]: {"msg":{"table":"site","method":"xCAT::Table::setAttribs"},"type":"end","elapsed":"0.00171s"}
Aug  9 01:59:15 c910f05c01bc02k74 xcat[694]: [DB Trace]: {"msg":{"table":"site","method":"xCAT::Table::getAttribs"},"type":"start"}
Aug  9 01:59:15 c910f05c01bc02k74 xcat[694]: [DB Trace]: {"msg":{"addon":"SELECT * FROM site WHERE \"key\" = ? and (\"disable\" is NULL or \"disable\" in ('0','no','NO','No','nO'))","table":"site","method":"xCAT::Table::getAttribs"},"type":"start_sql"}
Aug  9 01:59:15 c910f05c01bc02k74 xcat[694]: [DB Trace]: {"msg":{"table":"site","method":"xCAT::Table::getAttribs"},"type":"end_sql","elapsed":"0.00061s"}
Aug  9 01:59:15 c910f05c01bc02k74 xcat[694]: [DB Trace]: {"msg":{"table":"site","method":"xCAT::Table::getAttribs"},"type":"end","elapsed":"0.00125s"}
Aug  9 01:59:19 c910f05c01bc02k74 xcat[694]: [DB Trace]: {"msg":{"table":"site","method":"xCAT::Table::getAllAttribs"},"type":"start"}
Aug  9 01:59:19 c910f05c01bc02k74 xcat[694]: [DB Trace]: {"msg":{"addon":"SELECT * FROM site WHERE \"disable\" is NULL or \"disable\" in ('0','no','NO','No','nO')","table":"site","method":"xCAT::Table::getAllAttribs"},"type":"start_sql"}
Aug  9 01:59:19 c910f05c01bc02k74 xcat[694]: [DB Trace]: {"msg":{"addon":"SELECT * FROM site WHERE \"disable\" is NULL or \"disable\" in ('0','no','NO','No','nO')","table":"site","method":"xCAT::Table::getAllAttribs"},"type":"end_sql","elapsed":"0.00080s"}
```