### PR TITLE
enhance netname/net/mask duplicate or invalid in makenetworks,mkdef and chdef

### DIFF
--- a/xCAT-server/lib/xcat/plugins/networks.pm
+++ b/xCAT-server/lib/xcat/plugins/networks.pm
@@ -325,7 +325,6 @@ sub donets
                     # - compare net and mask values
                     my $foundmatch = 0;
                     foreach my $netn (@netlist) {
-
                         # split definition mask
                         my ($dm1, $dm2, $dm3, $dm4) = split('\.', $nethash{$netn}{'mask'});
 
@@ -359,7 +358,7 @@ sub donets
                         if ($foundmatch) {
                             next;
                         }
-
+                        
                         # add new network def
                         $nettab->setAttribs({ 'net' => $net, 'mask' => $netmask }, { 'netname' => $netname, 'gateway' => $gateway, 'mgtifname' => $i });
                     }
@@ -450,6 +449,7 @@ sub donets
         { #should be the lines to think about, do something with U, and something else with UG
 
             my $foundmatch = 0;
+            my $netnamematch = 0;
             my $rsp;
             my $net;
             my $mask;
@@ -504,7 +504,12 @@ sub donets
                 my ($n1, $n2, $n3, $n4) = split('\.', $net);
 
                 foreach my $netn (@netlist) {
-
+                    # check if this netname is already defined
+                    if ( $netname eq $netn ) {
+                        $netnamematch = 1;
+                        $callback->({ warning => "The network entry \'$netname\' already exists in xCAT networks table. Cannot create a definition for \'$netname\'" });
+                        last;
+                    }
                     # split definition mask
                     my ($dm1, $dm2, $dm3, $dm4) = split('\.', $nethash{$netn}{'mask'});
 
@@ -519,6 +524,10 @@ sub donets
                     }
                 }
 
+                # if this net entry exists, go to next line in networks table
+                if ($netnamematch) {
+                    last;
+                }
                 # get mtu value
                 my $mtu;
                 my @rowm;

--- a/xCAT-server/lib/xcat/plugins/networks.pm
+++ b/xCAT-server/lib/xcat/plugins/networks.pm
@@ -507,7 +507,6 @@ sub donets
                     # check if this netname is already defined
                     if ( $netname eq $netn ) {
                         $netnamematch = 1;
-                        $callback->({ warning => "The network entry \'$netname\' already exists in xCAT networks table. Cannot create a definition for \'$netname\'" });
                         last;
                     }
                     # split definition mask
@@ -524,10 +523,6 @@ sub donets
                     }
                 }
 
-                # if this net entry exists, go to next line in networks table
-                if ($netnamematch) {
-                    last;
-                }
                 # get mtu value
                 my $mtu;
                 my @rowm;
@@ -553,6 +548,11 @@ sub donets
                         push @{ $rsp->{data} }, "    mtu=$mtu";                      
                     }
                 } else {
+                    # if this net entry exists, go to next line in networks table
+                    if ($netnamematch) {
+                        $callback->({ warning => "The network entry \'$netname\' already exists in xCAT networks table. Cannot create a definition for \'$netname\'" });
+                        last;
+                    }
                     if (!$foundmatch) {
                         $nettab->setAttribs({ 'net' => $net, 'mask' => $mask }, { 'netname' => $netname, 'mgtifname' => $mgtifname, 'gateway' => $gw, 'mtu' => $mtu });
                     }


### PR DESCRIPTION
For task #3571, enhanced in makenetworks, mkdef and chdef.
Discussion results about this enhancement from China team as following:
In `makenetworks`:
a. When netname exists, makenetworks cannot add duplicate network entry into networks table, return error.
b. When netname does do exists, makenetworks can add network entry into networks table.
c. When net and mask are the same, network is duplicate,return error.

In `mkdef`:
a. When netname exists, mkdef cannot add duplicate network entry into networks table. 
b. When netname does not exists, net or mask is not set in mkdef, print net or mask should not be empty, return error.
c. When net and mask are the same, network is duplicate, cannot create new network object, return error.

In `chdef`:
a. When netname does not exists, net or mask is not set in chdef, print net or mask should not be empty, return error.
b. When netname does not exists, another netwok entry contains the same net and mask, it is duplicate, return error. 
c. When netname exists, there is net or mask missing from this network entry in networks table, chdef should add net or mask into this entry, or else, return error.

1, Unit test for **makenetworks**:
```
]# tabdump networks
#netname,net,mask,mgtifname,gateway,dhcpserver,tftpserver,nameservers,ntpservers,logservers,dynamicrange,staticrange,staticrangeincrement,nodehostname,ddnsdomain,vlanid,domain,mtu,comments,disable
"10_0_0_0-255_0_0_0",,,,,,,,,,,,,,,,,,,
]# makenetworks
Warning: The network entry '10_0_0_0-255_0_0_0' already exists in networks table.
```

2, Unit test for **makedef**
```
]# lsdef -t network aaa
Object name: aaa

]# mkdef -t network aaa mtu=1500
Error: A network definition called 'aaa' already exists that contains the same net and mask values. Cannot create a definition for 'aaa'.
Error: One or more errors occured when attempting to create or modify xCAT
object definitions.

]# rmdef -t network aaa
1 object definitions have been removed.
]# lsdef -t network aaa
Error: Could not find an object named 'aaa' of type 'network'.

]# mkdef -t network aaa mtu=1500
Error: Net or mask value should not be empty for xCAT network object 'aaa'.
Error: One or more errors occured when attempting to create or modify xCAT
object definitions.

]# mkdef -t network aaa net=10.0.0.0 mtu=1500
Error: Net or mask value should not be empty for xCAT network object 'aaa'.
Error: One or more errors occured when attempting to create or modify xCAT
object definitions.

]# mkdef -t network aaa mask=255.0.0.0 mtu=1500
Error: Net or mask value should not be empty for xCAT network object 'aaa'.
Error: One or more errors occured when attempting to create or modify xCAT
object definitions.

]# mkdef -t network aaa net=10.0.0.0 mask=255.0.0.0 mtu=1500
1 object definitions have been created or modified.

]# mkdef -t network aaa net=10.0.0.0 mask=255.0.0.0 mtu=1500
Error: A network definition called 'aaa' already exists that contains the same net and mask values. Cannot create a definition for 'aaa'.
Error: One or more errors occured when attempting to create or modify xCAT
object definitions.

]# mkdef -t network bbb net=10.0.0.0 mask=255.0.0.0 mtu=1500
Error: A network definition called 'aaa' already exists that contains the same net and mask values. Cannot create a definition for 'bbb'.
Error: One or more errors occured when attempting to create or modify xCAT
object definitions.

]# vim aaa
aaa:
    objtype=network
    mask=255.0.0.0
    mtu=1500
    net=10.0.0.0
]# cat aaa|mkdef -z
Error: A network definition called 'aaa' already exists that contains the same net and mask values. Cannot create a definition for 'aaa'.
Error: One or more errors occured when attempting to create or modify xCAT
object definitions.
```

3, Unit test for **chdef**:
At first , there is no aaa entry in networks table.
```
]# chdef -t network aaa mtu=1500
Error: Net or mask value should not be empty for xCAT network object 'aaa'.
Error: One or more errors occured when attempting to create or modify xCAT
object definitions.

]# chdef -t network aaa net=10.0.0.0 mtu=1500
Error: Net or mask value should not be empty for xCAT network object 'aaa'.
Error: One or more errors occured when attempting to create or modify xCAT
object definitions.

]# chdef -t network aaa mask=10.0.0.0 mtu=1500
Error: Net or mask value should not be empty for xCAT network object 'aaa'.
Error: One or more errors occured when attempting to create or modify xCAT
object definitions.

]# chdef -t network aaa mask=10.0.0.0 net=10.0.0.0 mtu=1500
1 object definitions have been created or modified.
New object definitions 'aaa' have been created.

]# lsdef -t network aaa
Object name: aaa
    mask=10.0.0.0
    mtu=1500
    net=10.0.0.0

]# chdef -t network aaa gateway=10.0.0.101
1 object definitions have been created or modified.

]# lsdef -t network aaa
Object name: aaa
    gateway=10.0.0.101
    mask=10.0.0.0
    mtu=1500
    net=10.0.0.0

]# chdef -t network bbb  mask=10.0.0.0 net=10.0.0.0
Error: A network definition called 'aaa' already exists that contains the same net and mask values. Cannot create a definition for 'bbb'.
Error: One or more errors occured when attempting to create or modify xCAT
object definitions.

]# tabedit network
Error: No such table: network
No file modifications detected, not restoring.

]# tabedit networks
]# lsdef -t network bbb
Object name: bbb
    net=50.0.0.0

]# chdef -t network bbb mtu=1500
Error: Attribute 'mask' is not specified for network entry 'bbb', skipping.
Error: One or more errors occured when attempting to create or modify xCAT
object definitions.

]# chdef -t network bbb mask=255.0.0.0 mtu=1500
1 object definitions have been created or modified.

]# lsdef -t network bbb
Object name: bbb
    mask=255.0.0.0
    mtu=1500
    net=50.0.0.0
```