### PR TITLE
fix issue 3668, make rsetboot node do rsetboot stat

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rsetboot.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rsetboot.1.rst
@@ -11,7 +11,7 @@ SYNOPSIS
 ********
 
 
-\ **rsetboot**\  \ *noderange*\  {\ **hd | net | cd | default | stat**\ } [\ **-u**\ ] [\ **-p**\ ]
+\ **rsetboot**\  \ *noderange*\  [\ **hd | net | cd | default | stat**\ ] [\ **-u**\ ] [\ **-p**\ ]
 
 \ **rsetboot**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
@@ -99,6 +99,14 @@ EXAMPLES
  .. code-block:: perl
  
    rsetboot node[14-56],node[70-203] stat
+ 
+ 
+ Or:
+ 
+ 
+ .. code-block:: perl
+ 
+   rsetboot node[14-56],node[70-203]
  
  
 

--- a/docs/source/guides/admin-guides/references/man1/rsetboot.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rsetboot.1.rst
@@ -21,7 +21,7 @@ DESCRIPTION
 ***********
 
 
-\ **rsetboot**\  sets the boot media and boot mode that should be used on the next boot of the specified nodes.  After the nodes are booted with the specified device and boot mode (e.g. via rpower(1)|rpower.1), the nodes will return to using the default boot device specified in the BIOS.  Currently this command is only supported for IPMI nodes.
+\ **rsetboot**\  sets the boot media and boot mode that should be used on the next boot of the specified nodes.  After the nodes are booted with the specified device and boot mode (e.g. via rpower(1)|rpower.1), the nodes will return to using the default boot device specified in the BIOS.
 
 
 *******

--- a/xCAT-client/pods/man1/rsetboot.1.pod
+++ b/xCAT-client/pods/man1/rsetboot.1.pod
@@ -12,7 +12,7 @@ B<rsetboot> [B<-h>|B<--help>|B<-v>|B<--version>]
 
 =head1 DESCRIPTION
 
-B<rsetboot> sets the boot media and boot mode that should be used on the next boot of the specified nodes.  After the nodes are booted with the specified device and boot mode (e.g. via L<rpower(1)|rpower.1>), the nodes will return to using the default boot device specified in the BIOS.  Currently this command is only supported for IPMI nodes.
+B<rsetboot> sets the boot media and boot mode that should be used on the next boot of the specified nodes.  After the nodes are booted with the specified device and boot mode (e.g. via L<rpower(1)|rpower.1>), the nodes will return to using the default boot device specified in the BIOS.
 
 =head1 OPTIONS
 

--- a/xCAT-client/pods/man1/rsetboot.1.pod
+++ b/xCAT-client/pods/man1/rsetboot.1.pod
@@ -5,7 +5,7 @@ B<rsetboot> - Sets the boot device to be used for BMC-based servers for the next
 
 =head1 SYNOPSIS
 
-B<rsetboot> I<noderange> {B<hd>|B<net>|B<cd>|B<default>|B<stat>} [B<-u>] [B<-p>]
+B<rsetboot> I<noderange> [B<hd>|B<net>|B<cd>|B<default>|B<stat>] [B<-u>] [B<-p>]
 
 B<rsetboot> [B<-h>|B<--help>|B<-v>|B<--version>]
 
@@ -63,6 +63,10 @@ Set nodes 1 and 3 to boot from the network on the next boot:
 Display the next-boot value for nodes 14-56 and 70-203:
 
  rsetboot node[14-56],node[70-203] stat
+
+Or:
+
+ rsetboot node[14-56],node[70-203]
 
 =item 3.
 

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -651,7 +651,7 @@ sub parse_command_status {
     my $subcommands = shift;
     my $subcommand;
 
-    if ($$subcommands[-1] =~ /V|verbose/) {
+    if ($$subcommands[-1] and $$subcommands[-1] =~ /V|verbose/) {
         $::VERBOSE = 1;
         pop(@$subcommands);
     }
@@ -727,7 +727,11 @@ sub parse_command_status {
     }
 
     if ($command eq "rsetboot") {
-        $subcommand = $$subcommands[0];
+        if (defined($$subcommands[0])) {
+            $subcommand = $$subcommands[0];
+        } else {
+            $subcommand = "stat";
+        }
         if ($subcommand =~ /^hd$|^net$|^cd$|^default$|^def$/) {
             $next_status{LOGIN_RESPONSE} = "RSETBOOT_SET_REQUEST";
             $next_status{RSETBOOT_SET_REQUEST} = "RSETBOOT_SET_RESPONSE";
@@ -750,7 +754,7 @@ sub parse_command_status {
 
     if ($command eq "reventlog") {
         my $option_s = 0;
-        if ($$subcommands[-1] eq "-s") {
+        if ($$subcommands[-1] and $$subcommands[-1] eq "-s") {
             $option_s = 1; 
             pop(@$subcommands);
         }


### PR DESCRIPTION
#3668 

For command rsetboot <node>, need to change subcommand to ``stat``. I forgot to do that so #3668 happened.

After modified:

```
# XCATBYPASS=1 rsetboot redfishtest
$VAR1 = {
          'redfishtest' => {
                             'password' => '0penBmc',
                             'bmc' => '9.3.185.161',
                             'cur_status' => 'LOGIN_REQUEST',
                             'username' => 'root'
                           }
        };

$VAR1 = {
          'RSETBOOT_STATUS_REQUEST' => 'RSETBOOT_STATUS_RESPONSE',
          'LOGIN_REQUEST' => 'LOGIN_RESPONSE',
          'LOGIN_RESPONSE' => 'RSETBOOT_STATUS_REQUEST'
        };

redfishtest: [openbmc_debug] POST https: //9.3.185.161/login -d { "data": [ "root", "0penBmc" ] }
redfishtest: [openbmc_debug] login_response 200 OK
redfishtest: [openbmc_debug] GET https: //9.3.185.161/xyz/openbmc_project/control/host0/boot_source
redfishtest: [openbmc_debug] rsetboot_status_response 200 OK
redfishtest: Default
```