### PR TITLE
notify the nodes which are sending findme requestd about the status of the processing

### DIFF
--- a/perl-xCAT/xCAT/Utils.pm
+++ b/perl-xCAT/xCAT/Utils.pm
@@ -4903,4 +4903,39 @@ sub acquire_lock_imageop {
     return (0,$lock);
 }
 
+#--------------------------------------------------------------------------------
+
+=head3  send_tcp_msg
+      establish a tcp socket to the specified IP address and port, then send the specifid message via the socket
+      Arguments:
+         $destip  : the destination IP address
+         $destport: the destination TCP port
+         $msg     : the message to send
+      Returns:
+         0  on success, 1 on fail
+=cut
+
+#--------------------------------------------------------------------------------
+sub send_tcp_msg {
+    my $self=shift;
+    my $destip=shift;
+    my $destport=shift;
+    my $msg=shift;
+
+    my $sock = new IO::Socket::INET(
+                PeerAddr => $destip,
+                PeerPort => $destport,
+                Timeout  => '1',
+                Proto    => 'tcp'
+            );
+    if ($sock) {
+        print $sock $msg;
+        close($sock);
+        return 0;
+    }else{
+        return 1;
+    }
+}
+
+
 1;

--- a/xCAT-server/lib/xcat/plugins/aaadiscovery.pm
+++ b/xCAT-server/lib/xcat/plugins/aaadiscovery.pm
@@ -28,21 +28,6 @@ sub process_request {
         }
         my $client_ip = $req->{'_xcat_clientip'};
 
-        #now, notify the node that its findme request is under processing
-        xCAT::MsgUtils->message("S", "Notify $client_ip that its findme request is processing\n");
-        my $sock = new IO::Socket::INET(
-            PeerAddr => $client_ip,
-            PeerPort => '3001',
-            Timeout  => '1',
-            Proto    => 'tcp'
-        );
-        if ($sock) { 
-            print $sock "processing";
-            close($sock);
-        }else{ 
-            xCAT::MsgUtils->message("S", "Failed to notify $client_ip that its findme request is processing."); 
-        }
-
         my $arptable;
         if (-x "/usr/sbin/arp") {
             $arptable = `/usr/sbin/arp -n`;

--- a/xCAT-server/lib/xcat/plugins/zzzdiscovery.pm
+++ b/xCAT-server/lib/xcat/plugins/zzzdiscovery.pm
@@ -7,6 +7,8 @@ BEGIN
     $::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : '/opt/xcat';
 }
 use lib "$::XCATROOT/lib/perl";
+use xCAT::Utils;
+
 
 sub handled_commands {
     return {
@@ -28,18 +30,11 @@ sub process_request {
 
             #now, notify the node that its findme request has been processed
             my $client_ip = $req->{'_xcat_clientip'};
-            xCAT::MsgUtils->message("S","Notify $client_ip that its findme request has been processed");
-            my $sock = new IO::Socket::INET(
-                PeerAddr => $client_ip,
-                PeerPort => '3001',
-                Timeout  => '1',
-                Proto    => 'tcp'
-            );
-            if ($sock) { 
-                print $sock "processed";
-                close($sock);
-            }else{
-                xCAT::MsgUtils->message("S", "Failed to notify $client_ip that its findme request has been processed"); 
+            xCAT::MsgUtils->message("S","xcat.discovery.zzzdiscovery: Notify $client_ip that its findme request has been processed");
+            #notify the client that its request is been processing
+            my $ret=xCAT::Utils->send_tcp_msg($client_ip,3001,"processed");
+            if($ret){
+                xCAT::MsgUtils->message("S", "xcat.discovery.zzzdiscovery: Failed to notify $client_ip that its findme request has been processed"); 
             }
         }else{
             xCAT::MsgUtils->message("S", "xcat.discovery.zzzdiscovery: ($req->{_xcat_clientmac}->[0]) Successfully discovered the node using $req->{discoverymethod}->[0] discovery method.");

--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -801,10 +801,23 @@ sub do_udp_service {    # This function opens up a UDP port
                 foreach my $pkey (keys %packets) {
                     my $saddr = $packets{$pkey}->[0];
                     $data = $packets{$pkey}->[1];
+                    my ($err, $srcip, $servicename) = Socket::getnameinfo($saddr,Socket::NI_NUMERICHOST,Socket::NIx_NOSERV);
+                    
                     if ($data =~ /^\037\213/) { # per rfc 1952, these two bytes are gzip, and they are invalid for
                         store_fd({ data => $data, sockaddr => $saddr }, $discoctl); # for now, punt the gunzip to the worker process
+                        #notify the client that its request is been processing
+                        my $ret=xCAT::Utils->send_tcp_msg($srcip,3001,"processing");
+                        if($ret){
+                            xCAT::MsgUtils->message("S", "INFO xcatd: fail to notify $srcip that its 'findme' request is been processing");
+                        }
                     } elsif ($data =~ /^<xcat/) {    # xml format
                         store_fd({ data => $data, sockaddr => $saddr }, $discoctl);
+                        #notify the client that its request is been processing
+                        my $ret=xCAT::Utils->send_tcp_msg($srcip,3001,"processing");
+                        if($ret){
+                            xCAT::MsgUtils->message("S", "INFO xcatd: fail to notify $srcip that its 'findme' request is been processing");
+                        }
+
                     } else {    # for *now*, we'll do a tiny YAML subset
                         if ($data =~ /^resourcerequest: xcatd$/) {
                             $socket->send("ackresourcerequest\n", 0, $packets{$pkey}->[0]);


### PR DESCRIPTION
for task https://github.com/xcat2/xcat-core/issues/3621:
1. enhancement of PR https://github.com/xcat2/xcat-core/pull/3601
2. notify the client that its "findme" request is processing when the findme request has been pushed into the pipe
3. create a new subroutine ``send_tcp_msg`` to send message to the client