### PR TITLE
return errorcode 1 if failed for xcatprobe switch_macmap

### DIFF
--- a/xCAT-probe/subcmds/switch_macmap
+++ b/xCAT-probe/subcmds/switch_macmap
@@ -120,6 +120,7 @@ foreach (<$fd>) {
     }
 }
 close($fd);
+my $rc = 0;
 if (-f $normal_file) {
     unlink($normal_file);
 }
@@ -129,8 +130,10 @@ if (-f $error_file) {
 if (@error_nodes) {
     my $error_node = join(",", @error_nodes);
     probe_utils->send_msg("$output", "d", "[$error_node] : Error, switch-macmap can only be run against xCAT objects that have 'nodetype=switch'");
+    $rc = 1;
 }
 foreach (@fails) {
     probe_utils->send_msg("$output", "f", "$_");
+    $rc = 1;
 }
-exit 0;
+exit $rc;


### PR DESCRIPTION
Before modification, the return code will be 0 even failed:
```
root@c910f03c05k10:~/level0/level1/level2/xcat-core# xcatprobe switch_macmap switch1
No switch configuration info find for switch1                                                                     [FAIL]
root@c910f03c05k10:~/level0/level1/level2/xcat-core# echo $?
0
root@c910f03c05k10:~/level0/level1/level2/xcat-core# xcatprobe switch_macmap switch12
Invalid nodes and/or groups in noderange: switch12                                                                [FAIL]
root@c910f03c05k10:~/level0/level1/level2/xcat-core# echo $?
0
```
After
```
root@c910f03c05k10:~/level0/level1/level2/xcat-core# xcatprobe switch_macmap switch12
Invalid nodes and/or groups in noderange: switch12                                                                [FAIL]
root@c910f03c05k10:~/level0/level1/level2/xcat-core# echo $?
1
```