### PR TITLE
Add switch_type lookup via MAC for Penguin Computing switches

### DIFF
--- a/perl-xCAT/xCAT/data/switchinfo.pm
+++ b/perl-xCAT/xCAT/data/switchinfo.pm
@@ -18,7 +18,8 @@ our %global_mac_identity = (
     "fc:cf:62" => "BNT G8124 switch",
     "7c:fe:90" => "Mellanox IB switch",
     "cc:37:ab" => "Edgecore Networks Switch",
-    "8c:ea:1b" => "Edgecore Networks Switch"
+    "8c:ea:1b" => "Edgecore Networks Switch",
+    "6c:64:1a" => "Penguin Computing switch"
 );
 
 #the hash to lookup switch type with vendor


### PR DESCRIPTION
switchdiscover fails to discover Penguin Computing bare-metal switches on current branch due to not being able to identify vendor. This adds Penguin Computing's vendor MAC to the global_mac_identity hash to allow the discovery of Penguin hardware.