### PR TITLE
Sync Usage and Man pages for openbmc rflash command

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rflash.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rflash.1.rst
@@ -57,7 +57,11 @@ OpenPOWER OpenBMC specific :
 ============================
 
 
-\ **rflash**\  \ *noderange*\  [\ *tar_file_path*\  | \ *image_id*\ ] [\ **-c | -**\ **-check**\ ] [\ **-a | -**\ **-activate**\ ] [\ **-l | -**\ **-list**\ ] [\ **-u | -**\ **-upload**\ ] [\ **-d | -**\ **-delete**\ ]
+\ **rflash**\  \ *noderange*\  {[\ **-c | -**\ **-check**\ ] | [\ **-l | -**\ **-list**\ ]}
+
+\ **rflash**\  \ *noderange*\  \ *tar_file_path*\  {[\ **-c | -**\ **-check**\ ] | [\ **-u | -**\ **-upload**\ ]}
+
+\ **rflash**\  \ *noderange*\  \ *image_id*\  {[\ **-a | -**\ **-activate**\ ] | [\ **-d | -**\ **-delete**\ ]}
 
 
 

--- a/docs/source/guides/admin-guides/references/man5/nics.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/nics.5.rst
@@ -129,7 +129,7 @@ nics Attributes:
 \ **nicsadapter**\ 
  
  Comma-separated list of extra parameters that will be used for each NIC configuration.
-                     <nic1>!<param1=value1 param2=value2>|<param3=value3>,<nic2>!<param4=value4 param5=value5>|<param6=value6>, for example, eth0!MTU=1500|MTU=1460,ib0!MTU=65520 CONNECTED_MODE=yes.
+                     <nic1>!<param1=value1 param2=value2>,<nic2>!<param4=value4 param5=value5>, for example, enP3p3s0f1!mac=98:be:94:59:fa:cd linkstate=DOWN,enP3p3s0f2!mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face
  
 
 

--- a/docs/source/guides/admin-guides/references/man7/group.7.rst
+++ b/docs/source/guides/admin-guides/references/man7/group.7.rst
@@ -41,7 +41,7 @@ group Attributes:
 
 \ **addkcmdline**\  (bootparams.addkcmdline)
  
- User specified one or more parameters to be passed to the kernel. For the kernel options need to be persistent after installation, specify them with prefix "R::"
+ User specified kernel options for os provision process(no prefix) or the provisioned os(with prefix "R::"). The options should be delimited with spaces(" ")
  
 
 
@@ -669,7 +669,7 @@ group Attributes:
 \ **nicsadapter**\  (nics.nicsadapter)
  
  Comma-separated list of extra parameters that will be used for each NIC configuration.
-                     <nic1>!<param1=value1 param2=value2>|<param3=value3>,<nic2>!<param4=value4 param5=value5>|<param6=value6>, for example, eth0!MTU=1500|MTU=1460,ib0!MTU=65520 CONNECTED_MODE=yes.
+                     <nic1>!<param1=value1 param2=value2>,<nic2>!<param4=value4 param5=value5>, for example, enP3p3s0f1!mac=98:be:94:59:fa:cd linkstate=DOWN,enP3p3s0f2!mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face
  
 
 

--- a/docs/source/guides/admin-guides/references/man7/node.7.rst
+++ b/docs/source/guides/admin-guides/references/man7/node.7.rst
@@ -41,7 +41,7 @@ node Attributes:
 
 \ **addkcmdline**\  (bootparams.addkcmdline)
  
- User specified one or more parameters to be passed to the kernel. For the kernel options need to be persistent after installation, specify them with prefix "R::"
+ User specified kernel options for os provision process(no prefix) or the provisioned os(with prefix "R::"). The options should be delimited with spaces(" ")
  
 
 
@@ -669,7 +669,7 @@ node Attributes:
 \ **nicsadapter**\  (nics.nicsadapter)
  
  Comma-separated list of extra parameters that will be used for each NIC configuration.
-                     <nic1>!<param1=value1 param2=value2>|<param3=value3>,<nic2>!<param4=value4 param5=value5>|<param6=value6>, for example, eth0!MTU=1500|MTU=1460,ib0!MTU=65520 CONNECTED_MODE=yes.
+                     <nic1>!<param1=value1 param2=value2>,<nic2>!<param4=value4 param5=value5>, for example, enP3p3s0f1!mac=98:be:94:59:fa:cd linkstate=DOWN,enP3p3s0f2!mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face
  
 
 

--- a/docs/source/guides/admin-guides/references/man7/osimage.7.rst
+++ b/docs/source/guides/admin-guides/references/man7/osimage.7.rst
@@ -41,7 +41,7 @@ osimage Attributes:
 
 \ **addkcmdline**\  (linuximage.addkcmdline)
  
- User specified arguments to be passed to the kernel.  The user arguments are appended to xCAT.s default kernel arguments. For the kernel options need to be persistent after installation, specify them with prefix "R::".  This attribute is ignored if linuximage.boottarget is set.
+ User specified kernel options for os provision process(no prefix) or the provisioned os(with prefix "R::"). The options should be delimited with spaces(" "). This attribute is ignored if linuximage.boottarget is set.
  
 
 

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -345,7 +345,9 @@ my %usage = (
     OpenPOWER BMC specific (using IPMI):
         rflash <noderange> [<hpm_file_path>|-d=<data_directory>] [-c|--check] [--retry=<count>] [-V]
     OpenPOWER OpenBMC specific:
-        rflash <noderange> [<tar_file_path>|<image_id>] [-c|--check] [-a|--activate] [-l|--list] [-u|--upload] [-d|--delete]",
+        rflash <noderange> {[-c|--check] | [-l|--list]}
+        rflash <noderange> <tar_file_path> {[-c|--check] | [-u|--upload]}
+        rflash <noderange> <image_id> {[-a|--activate] | [-d|--delete]}",
     "mkhwconn" =>
       "Usage:
     mkhwconn [-h|--help]

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -342,10 +342,10 @@ my %usage = (
 	rflash <noderange> -p <rpm_directory> [--activate {disruptive|deferred}] [-d <data_directory>]
 	rflash <noderange> [--commit | --recover] [-V|--verbose]
         rflash <noderange> [--bpa_acdl]
-    PPC64LE (using IPMI Management) specific:
-        rflash <noderange> [-c|--check] [--retry=<count>] [-V] [<hpm_file>|-d=<data_directory>]
-    PPC64LE (using OpenBMC Management) specific:
-        rflash <noderange> [-c|--check] [-l|--list] [-a|--activate] [-u|--upload] [-d|--delete] [<tar_file>|<image_id>]",
+    OpenPOWER BMC specific (using IPMI):
+        rflash <noderange> [<hpm_file_path>|-d=<data_directory>] [-c|--check] [--retry=<count>] [-V]
+    OpenPOWER OpenBMC specific :
+        rflash <noderange> [<tar_file_path>|<image_id>] [-c|--check] [-a|--activate] [-l|--list] [-u|--upload] [-d|--delete]",
     "mkhwconn" =>
       "Usage:
     mkhwconn [-h|--help]

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -344,7 +344,7 @@ my %usage = (
         rflash <noderange> [--bpa_acdl]
     OpenPOWER BMC specific (using IPMI):
         rflash <noderange> [<hpm_file_path>|-d=<data_directory>] [-c|--check] [--retry=<count>] [-V]
-    OpenPOWER OpenBMC specific :
+    OpenPOWER OpenBMC specific:
         rflash <noderange> [<tar_file_path>|<image_id>] [-c|--check] [-a|--activate] [-l|--list] [-u|--upload] [-d|--delete]",
     "mkhwconn" =>
       "Usage:

--- a/xCAT-client/pods/man1/rflash.1.pod
+++ b/xCAT-client/pods/man1/rflash.1.pod
@@ -28,7 +28,11 @@ B<rflash> I<noderange> [I<hpm_file_path> | B<-d=>I<data_directory>] [B<-c>|B<--c
 
 =head2 OpenPOWER OpenBMC specific :
 
-B<rflash> I<noderange> [I<tar_file_path> | I<image_id>] [B<-c>|B<--check>] [B<-a>|B<--activate>] [B<-l>|B<--list>] [B<-u>|B<--upload>] [B<-d>|B<--delete>]
+B<rflash> I<noderange> {[B<-c>|B<--check>] | [B<-l>|B<--list>]}
+
+B<rflash> I<noderange> I<tar_file_path> {[B<-c>|B<--check>] | [B<-u>|B<--upload>]}
+
+B<rflash> I<noderange> I<image_id> {[B<-a>|B<--activate>] | [B<-d>|B<--delete>]}
 
 =head1 B<Description>
 


### PR DESCRIPTION
Modify usage output to sync up with man page for openbmc `rflash` command.
Also checking out of sync `.rst` files that were missed by previous updates to Schema.pm