### PR TITLE
Change bmcdiscover for OpenBMC to look at Model instead of PartNumber

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -1172,8 +1172,8 @@ sub bmcdiscovery_openbmc{
         my $serial;
 
         if (defined($response->{data})) {
-            if (defined($response->{data}->{PartNumber}) and defined($response->{data}->{SerialNumber})) {
-                $mtm = $response->{data}->{PartNumber};
+            if (defined($response->{data}->{Model}) and defined($response->{data}->{SerialNumber})) {
+                $mtm = $response->{data}->{Model};
                 $serial = $response->{data}->{SerialNumber}; 
             }
  


### PR DESCRIPTION
Resolvesr one issue in #3691 

The later builds today have the following info: 
```
    "/xyz/openbmc_project/inventory/system": {
      "BuildDate": "",
      "Cached": 0,
      "FieldReplaceable": 0,
      "Manufacturer": "",
      "Model": "8335-GTC",
      "PartNumber": "",
      "Present": 1,
      "PrettyName": "",
      "SerialNumber": "1318C4A"
    }
```

Before change: 
```
[root@fs2vm110 ~]# bmcdiscover --range 9.114.120.110 -z -w
node-:
        objtype=node
        groups=all
        bmc=9.114.120.110
        cons=openbmc
        mgt=openbmc
        serial=1318C4A
```

After the change... 
```
[root@fs2vm110 frame6u05]# bmcdiscover --range 9.114.120.110 -z
node-8335-gtc-1318c4a:
        objtype=node
        groups=all
        bmc=9.114.120.110
        cons=openbmc
        mgt=openbmc
        mtm=8335-GTC
        serial=1318C4A
```
