### PR TITLE
Set xcatmaster to facing IP in priority when the node is managed by service node.

### DIFF
--- a/xCAT-server/lib/perl/xCAT/Template.pm
+++ b/xCAT-server/lib/perl/xCAT/Template.pm
@@ -86,7 +86,6 @@ sub subvars {
     ## 2, the ip address of the mn/sn facing the compute node
     ## 3, the site.master
     my $master;
-    my $sitemaster;
 
     #the "xcatmaster" attribute of the node
     my $noderestab = xCAT::Table->new('noderes');
@@ -112,7 +111,7 @@ sub subvars {
         my @masters = xCAT::TableUtils->get_site_attribute("master");
         my $tmp     = $masters[0];
         if (defined($tmp)) {
-            $sitemaster = $tmp;
+            $master = $tmp;
         }
     }
 

--- a/xCAT-server/lib/perl/xCAT/Template.pm
+++ b/xCAT-server/lib/perl/xCAT/Template.pm
@@ -82,16 +82,23 @@ sub subvars {
     close($inh);
 
     #the logic to determine the $ENV{XCATMASTER} confirm to the following priority(from high to low):
-    #the "xcatmaster" attribute of the node
-    #the site.master
-    #the ip address of the mn facing the compute node
+    ## 1, the "xcatmaster" attribute of the node
+    #Route A: the node is managed by service node
+    ## A.2, the ip address of the mn facing the compute node
+    ## A.3, the site.master
+    #Route B: the node is not managed by service node
+    ## B.2, the site.master
+    ## B.3, the ip address of the mn facing the compute node
     my $master;
+    my $sitemaster;
+    my $parents;
 
     #the "xcatmaster" attribute of the node
     my $noderestab = xCAT::Table->new('noderes');
-    my $et = $noderestab->getNodeAttribs($node, ['xcatmaster']);
-    if ($et and $et->{'xcatmaster'}) {
+    my $et = $noderestab->getNodeAttribs($node, ['servicenode','xcatmaster']);
+    if ($et) {
         $master = $et->{'xcatmaster'};
+        $parents = $et->{'servicenode'};
     }
 
     unless ($master) {
@@ -100,18 +107,37 @@ sub subvars {
         my @masters = xCAT::TableUtils->get_site_attribute("master");
         my $tmp     = $masters[0];
         if (defined($tmp)) {
-            $master = $tmp;
+            $sitemaster = $tmp;
         }
     }
 
-    unless ($master) {
+    if ($parents) { # the CN is managed by service node
+        unless ($master) {
 
-        #the ip address of the mn facing the compute node
-        my $ipfn;
-        my @ipfnd = xCAT::NetworkUtils->my_ip_facing($node);
-        unless ($ipfnd[0]) { $ipfn = $ipfnd[1]; }
-        if ($ipfn) {
-            $master = $ipfn;
+            #the ip address of the mn facing the compute node
+            my $ipfn;
+            my @ipfnd = xCAT::NetworkUtils->my_ip_facing($node);
+            unless ($ipfnd[0]) { $ipfn = $ipfnd[1]; }
+            if ($ipfn) {
+                $master = $ipfn;
+            } else {
+                $master = $sitemaster;
+            }
+        }
+    } else {
+        unless ($master) {
+            $master = $sitemaster;
+        }
+
+        unless ($master) {
+
+            #the ip address of the mn facing the compute node
+            my $ipfn;
+            my @ipfnd = xCAT::NetworkUtils->my_ip_facing($node);
+            unless ($ipfnd[0]) { $ipfn = $ipfnd[1]; }
+            if ($ipfn) {
+                $master = $ipfn;
+            }
         }
     }
 
@@ -121,8 +147,7 @@ sub subvars {
     }
 
     $ENV{XCATMASTER} = $master;
-
-    my ($host, $ipaddr) = xCAT::NetworkUtils->gethostnameandip($master);
+    my $ipaddr = xCAT::NetworkUtils->getipaddr($master);
     if ($ipaddr) {
         $ENV{MASTER_IP} = "$ipaddr";
     }


### PR DESCRIPTION
…ananged by service node.

The previous priority:  noderes.xcatmaster -> site.master -> facing IP
In such design, it will bring issue when xcatmaster is not set and hierarchy layout (if CN cannot access MN),  here we make some changes on it  as below:

Fix #3428, set xcatmaster to facing IP in priority when the node is managed by service node.

```
    #the logic to determine the $ENV{XCATMASTER} confirm to the following priority(from high to low):
    ## 1, the "xcatmaster" attribute of the node
    #Route A: the node is managed by service node
    ## A.2, the ip address of the mn facing the compute node
    ## A.3, the site.master
    #Route B: the node is not managed by service node
    ## B.2, the site.master
    ## B.3, the ip address of the mn facing the compute node
```

Finally, we decide that only using one option,  always using facing IP in high priority.
```
    #the logic to determine the $ENV{XCATMASTER} confirm to the following priority(from high to low):
    ## 1, the "xcatmaster" attribute of the node
    ## 2, the ip address of the mn/sn facing the compute node
    ## 3, the site.master
```