### PR TITLE
Sort 'xcatprobe switch_macmap' ports in 'natural' order

### DIFF
--- a/xCAT-server/lib/xcat/plugins/switch.pm
+++ b/xCAT-server/lib/xcat/plugins/switch.pm
@@ -251,7 +251,7 @@ sub process_request {
                     $cb->({ node => [ { name => $switch, data => ["PASS"] } ] });
                     next;
                 }
-                foreach my $port (sort keys %{ $macinfo->{$switch} }) {
+                foreach my $port (map{$_->[0]}sort{$a->[1] cmp $b->[1] || $a->[2] <=> $b->[2]}map{[$_, /^(.*?)(\d+)?$/]} keys %{ $macinfo->{$switch} }) {
                     my $node = '';
                     if (defined($macinfo->{$switch}->{$port}->{Node})) {
                         $node = $macinfo->{$switch}->{$port}->{Node};


### PR DESCRIPTION
Old: swp1,swp11,swp12,swp2,swp20,swp21
New: swp1,swp2,swp11,swp12,swp20,swp21