### PR TITLE
Filter non-content lines when generating mypostscripts

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/post.debian
+++ b/xCAT-server/share/xcat/install/scripts/post.debian
@@ -59,7 +59,7 @@ do
          mv $i/postscripts /xcatpost
          rm -rf $i
          chmod +x /xcatpost/*
-         /xcatpost/getpostscript.awk |sed -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' | sed -e 's/&lt;/</g' -e 's/&gt;/>/g' -e 's/&amp;/\&/g' -e 's/&quot;/"/g' -e "s/&apos;/'/g" > /xcatpost/mypostscript
+         /xcatpost/getpostscript.awk |egrep '<data>' |sed -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' | sed -e 's/&lt;/</g' -e 's/&gt;/>/g' -e 's/&amp;/\&/g' -e 's/&quot;/"/g' -e "s/&apos;/'/g" > /xcatpost/mypostscript
          MYCONT=`grep MASTER /xcatpost/mypostscript`
          MAX_RETRIES=10
          RETRY=0
@@ -72,7 +72,7 @@ do
 
             let SLI=$RANDOM%10+10
             sleep $SLI
-            /xcatpost/getpostscript.awk |sed -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' | sed -e 's/&lt;/</g' -e 's/&gt;/>/g' -e 's/&amp;/\&/g' -e 's/&quot;/"/g' -e "s/&apos;/'/g" > /xcatpost/mypostscript
+            /xcatpost/getpostscript.awk |egrep '<data>'|sed -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' | sed -e 's/&lt;/</g' -e 's/&gt;/>/g' -e 's/&amp;/\&/g' -e 's/&quot;/"/g' -e "s/&apos;/'/g" > /xcatpost/mypostscript
             MYCONT=`grep MASTER /xcatpost/mypostscript`
          done
 

--- a/xCAT-server/share/xcat/install/scripts/post.rhel5.s390x
+++ b/xCAT-server/share/xcat/install/scripts/post.rhel5.s390x
@@ -47,7 +47,7 @@ do
             chmod +x /xcatpost/*
 
             # Get postscript to run on this node from xcat server
-            /xcatpost/getpostscript.awk |sed -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' > /xcatpost/mypostscript
+            /xcatpost/getpostscript.awk |egrep '<data>'|sed -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' > /xcatpost/mypostscript
             MYCONT=`grep MASTER /xcatpost/mypostscript`
             MAX_RETRIES=10
             RETRY=0
@@ -63,7 +63,7 @@ do
                 sleep $SLI
             
                 # Get postscript to run on this node from xcat server
-                /xcatpost/getpostscript.awk |sed -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' > /xcatpost/mypostscript
+                /xcatpost/getpostscript.awk |egrep '<data>'|sed -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' > /xcatpost/mypostscript
                 MYCONT=`grep MASTER /xcatpost/mypostscript`
             done
 

--- a/xCAT-server/share/xcat/install/scripts/post.rhel6.s390x
+++ b/xCAT-server/share/xcat/install/scripts/post.rhel6.s390x
@@ -47,7 +47,7 @@ do
             chmod +x /xcatpost/*
 
             # Get postscript to run on this node from xcat server
-            /xcatpost/getpostscript.awk |sed -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' > /xcatpost/mypostscript
+            /xcatpost/getpostscript.awk |egrep '<data>'|sed -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' > /xcatpost/mypostscript
             MYCONT=`grep MASTER /xcatpost/mypostscript`
             MAX_RETRIES=10
             RETRY=0
@@ -63,7 +63,7 @@ do
                 sleep $SLI
             
                 # Get postscript to run on this node from xcat server
-                /xcatpost/getpostscript.awk |sed -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' > /xcatpost/mypostscript
+                /xcatpost/getpostscript.awk |egrep '<data>'|sed -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' > /xcatpost/mypostscript
                 MYCONT=`grep MASTER /xcatpost/mypostscript`
             done
 

--- a/xCAT-server/share/xcat/install/scripts/post.sles10.s390x
+++ b/xCAT-server/share/xcat/install/scripts/post.sles10.s390x
@@ -52,7 +52,7 @@ do
             chmod +x /xcatpost/*
 
             # Get postscript to run on this node from xcat server
-            /xcatpost/getpostscript.awk |sed -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' > /tmp/mypostscript
+            /xcatpost/getpostscript.awk |egrep '<data>'|sed -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' > /tmp/mypostscript
             MYCONT=`grep MASTER /tmp/mypostscript`
             MAX_RETRIES=10
             RETRY=0
@@ -67,7 +67,7 @@ do
                 sleep $SLI
 
                 # Get postscript to run on this node from xcat server
-                /xcatpost/getpostscript.awk |sed -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' > /tmp/mypostscript
+                /xcatpost/getpostscript.awk |egrep '<data>'|sed -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' > /tmp/mypostscript
                 MYCONT=`grep MASTER /tmp/mypostscript`
             done
          

--- a/xCAT-server/share/xcat/install/scripts/post.sles11.s390x
+++ b/xCAT-server/share/xcat/install/scripts/post.sles11.s390x
@@ -53,7 +53,7 @@ do
             chmod +x /xcatpost/*
 
             # Get postscript to run on this node from xcat server
-            /xcatpost/getpostscript.awk |sed -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' > /tmp/mypostscript
+            /xcatpost/getpostscript.awk |egrep '<data>'|sed -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' > /tmp/mypostscript
             MYCONT=`grep MASTER /tmp/mypostscript`
             MAX_RETRIES=10
             RETRY=0
@@ -68,7 +68,7 @@ do
                 sleep $SLI
 
                 # Get postscript to run on this node from xcat server
-                /xcatpost/getpostscript.awk |sed -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' > /tmp/mypostscript
+                /xcatpost/getpostscript.awk |egrep '<data>'|sed -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' > /tmp/mypostscript
                 MYCONT=`grep MASTER /tmp/mypostscript`
             done
          

--- a/xCAT-server/share/xcat/install/scripts/post.xcat
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat
@@ -138,7 +138,7 @@ if [ ! -x /xcatpost/mypostscript ]; then
         /tmp/updateflag $MASTER $XCATIPORT "installstatus failed"
         sleep 36500d
     fi
-    /xcatpost/getpostscript.awk |sed -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' | sed -e 's/&lt;/</g' -e 's/&gt;/>/g' -e 's/&amp;/\&/g' -e 's/&quot;/"/g' -e "s/&apos;/'/g" > /xcatpost/mypostscript
+    /xcatpost/getpostscript.awk |egrep '<data>'|sed -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' | sed -e 's/&lt;/</g' -e 's/&gt;/>/g' -e 's/&amp;/\&/g' -e 's/&quot;/"/g' -e "s/&apos;/'/g" > /xcatpost/mypostscript
 
     MYCONT=`grep ^MASTER= /xcatpost/mypostscript`
     RETRY=0
@@ -150,7 +150,7 @@ if [ ! -x /xcatpost/mypostscript ]; then
 
         let SLI=$RANDOM%10+10
         sleep $SLI
-        /xcatpost/getpostscript.awk |sed -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' | sed -e 's/&lt;/</g' -e 's/&gt;/>/g' -e 's/&amp;/\&/g' -e 's/&quot;/"/g' -e "s/&apos;/'/g" > /xcatpost/mypostscript
+        /xcatpost/getpostscript.awk |egrep '<data>'|sed -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' | sed -e 's/&lt;/</g' -e 's/&gt;/>/g' -e 's/&amp;/\&/g' -e 's/&quot;/"/g' -e "s/&apos;/'/g" > /xcatpost/mypostscript
 
         MYCONT=`grep ^MASTER= /xcatpost/mypostscript`
     done

--- a/xCAT/postscripts/xcatdsklspost
+++ b/xCAT/postscripts/xcatdsklspost
@@ -637,7 +637,7 @@ if [ ! -x /$xcatpost/mypostscript ]; then
         useflowcontrol=0
       fi 
     fi
-    /$xcatpost/getpostscript.awk | sed  -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' | sed -e 's/&lt;/</g' -e 's/&gt;/>/g' -e 's/&amp;/\&/g' -e 's/&quot;/"/g' -e "s/&apos;/'/g" >  /$xcatpost/mypostscript;
+    /$xcatpost/getpostscript.awk | egrep  '<data>' | sed  -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' | sed -e 's/&lt;/</g' -e 's/&gt;/>/g' -e 's/&amp;/\&/g' -e 's/&quot;/"/g' -e "s/&apos;/'/g" >  /$xcatpost/mypostscript;
     MYCONT=`grep MASTER /$xcatpost/mypostscript`
     if [ ! -z "$MYCONT" ]; then
         break;


### PR DESCRIPTION
Fix #3697 
After adding a new `<xcatdsource></xcatdsource>` in response, the current post script cannot generate mypostscript correctly.  As all content lines are in `<data>`, we can filter by this keyword first. 

UT:
```
# cat mypostscript.output | egrep  '<data>' | sed  -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' | sed -e 's/&lt;/</g' -e 's/&gt;/>/g' -e 's/&amp;/\&/g' -e 's/&quot;/"/g' -e "s/&apos;/'/g" > afterfix
# cat mypostscript.output | sed  -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' | sed -e 's/&lt;/</g' -e 's/&gt;/>/g' -e 's/&amp;/\&/g' -e 's/&quot;/"/g' -e "s/&apos;/'/g" > beforefix

# diff -u afterfix beforefix
--- afterfix	2017-08-16 22:57:43.092433759 -0400
+++ beforefix	2017-08-16 22:58:24.023219023 -0400
@@ -168,3 +168,4 @@
 otherpkgs
 # defaults-postbootscripts-end-here
 # postbootscripts-end-here
+c910f03c01p09
```