### PR TITLE
Fix 3722, move setNodesAttribute out of the node loop

### DIFF
--- a/xCAT-server/lib/xcat/plugins/destiny.pm
+++ b/xCAT-server/lib/xcat/plugins/destiny.pm
@@ -655,8 +655,8 @@ sub setdestiny {
         if ($reststates) {
             $updates->{$_}->{'currchain'} = $reststates;
         }
-        $chaintab->setNodesAttribs($updates);
     }
+    $chaintab->setNodesAttribs($updates);
     return getdestiny($flag + 1);
 }
 
@@ -784,6 +784,7 @@ sub getdestiny {
         @nodes = ($node);
     }
     my $node;
+    xCAT::MsgUtils->trace(0, "d", "destiny->process_request: getdestiny...");
     $restab = xCAT::Table->new('noderes');
     my $chaintab = xCAT::Table->new('chain');
     my $chainents = $chaintab->getNodesAttribs(\@nodes, [qw(currstate chain)]);


### PR DESCRIPTION
To fix #3722 
UT:
Still work as normal
```
1, clean the current chain and state
chdef perftest currchain= currstate=
2, run nodeset and check the DB
time nodeset perftest osimage=rhels7.3-ppc64le-netboot-compute
lsdef fake2|grep currstate
    currstate=netboot rhels7.3-ppc64le-compute
```

The time cost only half of previous when dhcpsetup=n