### PR TITLE
Allow -d <directory name> flag for rflash

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rflash.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rflash.1.rst
@@ -50,7 +50,7 @@ OpenPOWER BMC specific (using IPMI):
 ====================================
 
 
-\ **rflash**\  \ *noderange*\  [\ *hpm_file_path*\  | \ **-d=**\ \ *data_directory*\ ] [\ **-c | -**\ **-check**\ ] [\ **-**\ **-retry=**\ \ *count*\ ] [\ **-V**\ ]
+\ **rflash**\  \ *noderange*\  [\ *hpm_file_path*\  | \ **-d**\  \ *data_directory*\ ] [\ **-c | -**\ **-check**\ ] [\ **-**\ **-retry=**\ \ *count*\ ] [\ **-V**\ ]
 
 
 OpenPOWER OpenBMC specific :
@@ -172,11 +172,11 @@ The command will update firmware for OpenPOWER OpenBMC when given an OpenPOWER n
 
 \ **-d**\  \ *data_directory*\ 
  
+ PPC (without HMC, using Direct FSP Management) specific:
+ 
  Specifies the directory where the raw data from rpm packages for each CEC/Frame are located. The default directory is /tmp. The option is only used in Direct FSP/BPA Management.
  
-
-
-\ **-d=**\ \ *data_directory*\ 
+ OpenPOWER BMC specific (using IPMI):
  
  Used for IBM Power S822LC for Big Data systems only. Specifies the directory where the \ **pUpdate**\  utility and at least one of BMC or PNOR update files are located. The utility and update files can be downloaded from FixCentral.
  

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -343,7 +343,7 @@ my %usage = (
 	rflash <noderange> [--commit | --recover] [-V|--verbose]
         rflash <noderange> [--bpa_acdl]
     OpenPOWER BMC specific (using IPMI):
-        rflash <noderange> [<hpm_file_path>|-d=<data_directory>] [-c|--check] [--retry=<count>] [-V]
+        rflash <noderange> [<hpm_file_path>|-d <data_directory>] [-c|--check] [--retry=<count>] [-V]
     OpenPOWER OpenBMC specific:
         rflash <noderange> {[-c|--check] | [-l|--list]}
         rflash <noderange> <tar_file_path> {[-c|--check] | [-u|--upload]}

--- a/xCAT-client/pods/man1/rflash.1.pod
+++ b/xCAT-client/pods/man1/rflash.1.pod
@@ -24,7 +24,7 @@ B<rflash> I<noderange> I<http_directory>
 
 =head2 OpenPOWER BMC specific (using IPMI):
 
-B<rflash> I<noderange> [I<hpm_file_path> | B<-d=>I<data_directory>] [B<-c>|B<--check>] [B<--retry=>I<count>] [B<-V>]
+B<rflash> I<noderange> [I<hpm_file_path> | B<-d> I<data_directory>] [B<-c>|B<--check>] [B<--retry=>I<count>] [B<-V>]
 
 =head2 OpenPOWER OpenBMC specific :
 
@@ -115,9 +115,11 @@ Specifies the directory where the packages are located.
 
 =item B<-d> I<data_directory>
 
+PPC (without HMC, using Direct FSP Management) specific:
+
 Specifies the directory where the raw data from rpm packages for each CEC/Frame are located. The default directory is /tmp. The option is only used in Direct FSP/BPA Management. 
 
-=item B<-d=>I<data_directory>
+OpenPOWER BMC specific (using IPMI):
 
 Used for IBM Power S822LC for Big Data systems only. Specifies the directory where the B<pUpdate> utility and at least one of BMC or PNOR update files are located. The utility and update files can be downloaded from FixCentral. 
 


### PR DESCRIPTION
This pull request is for issue #3733 and allows `-d <directory name> parameter to be passed for Supermicro `rflash` command.
Messages are also improved for when pUpdate utility is not found or not executable.

Output:

1. pUpdate utility is not there
```
[root@stratton01 xcat]# rflash briggs01  -d /tmp
Error: briggs01: Can not find pUpdate utility in data directory /tmp.
[root@stratton01 xcat]#
```

2. pUpdate utility is there, but not executable
```
[root@stratton01 xcat]# rflash briggs01  -d /tmp
Error: briggs01: Execute permission is not set for pUpdate utility in data directory /tmp.
[root@stratton01 xcat]#
```

3. No directory specified:
```
[root@stratton01 xcat]# rflash briggs01  -d
Error: briggs01: Data directory must be specified.
[root@stratton01 xcat]#
```

4. Invalid directory is specified:
```
[root@stratton01 xcat]# rflash briggs01  -d /junk
Error: briggs01: Can not access data directory /junk
[root@stratton01 xcat]#
```