### PR TITLE
Fix test case xdcp_nonroot_user

### DIFF
--- a/xCAT-test/autotest/testcase/xdcp/cases1
+++ b/xCAT-test/autotest/testcase/xdcp/cases1
@@ -1,7 +1,7 @@
 start:xdcp_nonroot_user
 cmd:useradd -m xyzzy
 check:rc==0
-cmd:( cd ~ && tar cf - .xcat .ssh ) | ( cd ~xyzzy && tar xf - )
+cmd:bash -c "( cd ~root && tar cf - .xcat .ssh ) | ( cd ~xyzzy && tar xf - )"
 check:rc==0
 cmd:chown -R xyzzy ~xyzzy/.xcat ~xyzzy/.ssh
 check:rc==0


### PR DESCRIPTION
It seems xCAT-test cannot handle command line use sub-shell. This is a fix.