### PR TITLE
OpenBMC PNOR upload and activate firmware image file

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rflash.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rflash.1.rst
@@ -59,7 +59,7 @@ OpenPOWER OpenBMC specific :
 
 \ **rflash**\  \ *noderange*\  {[\ **-c | -**\ **-check**\ ] | [\ **-l | -**\ **-list**\ ]}
 
-\ **rflash**\  \ *noderange*\  \ *tar_file_path*\  {[\ **-c | -**\ **-check**\ ] | [\ **-u | -**\ **-upload**\ ]}
+\ **rflash**\  \ *noderange*\  \ *tar_file_path*\  {[\ **-c | -**\ **-check**\ ] | [\ **-a | -**\ **-activate**\ ] | [\ **-u | -**\ **-upload**\ ]}
 
 \ **rflash**\  \ *noderange*\  \ *image_id*\  {[\ **-a | -**\ **-activate**\ ] | [\ **-d | -**\ **-delete**\ ]}
 
@@ -208,7 +208,7 @@ The command will update firmware for OpenPOWER OpenBMC when given an OpenPOWER n
 
 \ **-a|-**\ **-activate**\ 
  
- Activate update image. Image id must be specified.
+ Activate update image. Image id or update file must be specified.
  
 
 
@@ -322,7 +322,17 @@ The command will update firmware for OpenPOWER OpenBMC when given an OpenPOWER n
  
  .. code-block:: perl
  
-   rflash briggs01 -d=/root/supermicro/OP825
+   rflash briggs01 -d /root/supermicro/OP825
+ 
+ 
+
+
+7. To update the firmware on the OpenBMC machine, specify the firmare update file to upload and activate:
+ 
+ 
+ .. code-block:: perl
+ 
+    rflash p9euh02 -a /tmp/witherspoon.pnor.squashfs.tar
  
  
 

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -346,7 +346,7 @@ my %usage = (
         rflash <noderange> [<hpm_file_path>|-d <data_directory>] [-c|--check] [--retry=<count>] [-V]
     OpenPOWER OpenBMC specific:
         rflash <noderange> {[-c|--check] | [-l|--list]}
-        rflash <noderange> <tar_file_path> {[-c|--check] | [-u|--upload]}
+        rflash <noderange> <tar_file_path> {[-c|--check] | [-a|--activate] | [-u|--upload]}
         rflash <noderange> <image_id> {[-a|--activate] | [-d|--delete]}",
     "mkhwconn" =>
       "Usage:

--- a/xCAT-client/pods/man1/rflash.1.pod
+++ b/xCAT-client/pods/man1/rflash.1.pod
@@ -30,7 +30,7 @@ B<rflash> I<noderange> [I<hpm_file_path> | B<-d> I<data_directory>] [B<-c>|B<--c
 
 B<rflash> I<noderange> {[B<-c>|B<--check>] | [B<-l>|B<--list>]}
 
-B<rflash> I<noderange> I<tar_file_path> {[B<-c>|B<--check>] | [B<-u>|B<--upload>]}
+B<rflash> I<noderange> I<tar_file_path> {[B<-c>|B<--check>] | [B<-a>|B<--activate>] | [B<-u>|B<--upload>]}
 
 B<rflash> I<noderange> I<image_id> {[B<-a>|B<--activate>] | [B<-d>|B<--delete>]}
 
@@ -141,7 +141,7 @@ Specify number of times to retry the update if failure is detected. Default valu
 
 =item B<-a|--activate>
 
-Activate update image. Image id must be specified.
+Activate update image. Image id or update file must be specified.
 
 =item B<-l|--list>
 
@@ -207,7 +207,12 @@ Print verbose message to rflash log file (/var/log/xcat/rflash/fs3.log) when upd
 =item 6.
 To update the firmware on IBM Power S822LC for Big Data machine specify the node name and the file path of the data directory containing pUpdate utility and BMC and/or PNOR update files:
 
- rflash briggs01 -d=/root/supermicro/OP825
+ rflash briggs01 -d /root/supermicro/OP825
+
+=item 7.
+To update the firmware on the OpenBMC machine, specify the firmare update file to upload and activate: 
+
+  rflash p9euh02 -a /tmp/witherspoon.pnor.squashfs.tar
 
 =back
 


### PR DESCRIPTION
Implements `rflash` upload and activate image file in one step for issue #3173 

Output:
```
[root@stratton01 xcat]# rflash p9euh02 -a /tmp/gurevich/witherspoon.20170713s.pnor.squashfs.tar
p9euh02: Uploading /tmp/gurevich/witherspoon.20170713s.pnor.squashfs.tar ...
p9euh02: Successful, use -l option to list.
p9euh02: rflash started, please wait...
p9euh02: Activating firmware update. 10%
p9euh02: Activating firmware update. 60%
p9euh02: Activating firmware update. 60%
p9euh02: Firmware update successfully activated
[root@stratton01 xcat]#
```

```
[root@stratton01 xcat]# rflash p9euh02 -l
p9euh02: ID       Purpose State      Version
p9euh02: -------------------------------------------------------
p9euh02: 2a1022fe Host    Active(*)  IBM-witherspoon-sequoia-ibm-OP9_v1.17_1.67
p9euh02: a66e68f6 BMC     Active     v1.99.9-30-gaaafab8
p9euh02: 39885ab3 Host    Active     IBM-witherspoon-redbud-ibm-OP9_v1.18_1.37
p9euh02:
[root@stratton01 xcat]#
```