### PR TITLE
Remove the error message when we come across associations in the OpenBMC inventory resposne

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1359,8 +1359,8 @@ sub rinv_response {
             }
         } else {
             if (! defined $content{Present}) {
-                # This should never happen, but if we find this, contact firmware team to fix...
-                xCAT::SvrUtils::sendmsg("ERROR: Invalid data for $key_url, contact firmware team!", $callback, $node);
+                # If the Present field is not part of the attribute, then it's most likely a callout
+                # Do not print as part of the inventory response
                 next; 
             }
 


### PR DESCRIPTION
Resolved: https://github.com/xcat2/xcat-core/issues/3205

Based on the conversation I had with OpenBMC team here : https://github.com/openbmc/openbmc/issues/1709#issuecomment-322621288

The values that we get back from inventory that do not have 'Present' are most likely associations.  So instead of printing an Error message to ask the firmware team about it, we will just ignore it 

So we will not print things like this: 
```
[root@stratton01 xcat]# rinv frame6u05 serial
frame6u05: ERROR: Invalid data for /xyz/openbmc_project/inventory/system/chassis/motherboard/cpu0/fault, contact firmware team!
frame6u05: ERROR: Invalid data for /xyz/openbmc_project/inventory/system/chassis/motherboard/cpu1/fault, contact firmware team!
frame6u05: ERROR: Invalid data for /xyz/openbmc_project/inventory/system/fault, contact firmware team!
frame6u05: ERROR: Invalid data for /xyz/openbmc_project/inventory/system/chassis, contact firmware team!
frame6u05: SYSTEM SerialNumber : 1318C4A

```