### PR TITLE
Fix 3749, handle '+' and '-' in id when merging /etc/passwd

### DIFF
--- a/xCAT-server/share/xcat/scripts/xdcpmerge.sh
+++ b/xCAT-server/share/xcat/scripts/xdcpmerge.sh
@@ -76,6 +76,7 @@ for i in $*; do
     delim="|"
     for u in $removeusers
     do
+      # For special char +/-, need to escape
       [[ "${u:0:1}x" =~ ^\+|\-x ]] && uu="\\$u" || uu="$u"
       userlist=$userlist$uu$delim
     done

--- a/xCAT-server/share/xcat/scripts/xdcpmerge.sh
+++ b/xCAT-server/share/xcat/scripts/xdcpmerge.sh
@@ -76,7 +76,8 @@ for i in $*; do
     delim="|"
     for u in $removeusers
     do
-      userlist=$userlist$u$delim
+      [[ "${u:0:1}x" =~ ^\+|\-x ]] && uu="\\$u" || uu="$u"
+      userlist=$userlist$uu$delim
     done
     # remove the last delimiter
     userlisttmp="${userlist%?}"


### PR DESCRIPTION
To fix #3749,

For updatenode merge feature, it is required to handle the special char '+' and '-' so as to meet some NIS authentication requirement.

UT: PASS
1, logon a compute node and patch the merge script
2, add below content for merge 
```
cd /var/xcat/node/syncfiles
cat merge/mergefiles/install/osimages/rhels7.2-x86_64-stateful-compute/cfmdir/etc/passwd.merge
+@p8users::::::
lsfadmin:x:30498:30498::/home/lsfadmin:/bin/bash
+:*:::::/sbin/nologin
mysql:x:27:27:MariaDB Server:/var/lib/mysql:/sbin/nologin
-@mytesting::::::
advocate:x:993:989:Advocate:/opt/IBM/advocate:/sbin/nologin
nscd:x:28:28:NSCD Daemon:/:/sbin/nologin
adit:x:30497:30497::/home/adit:/bin/bash
+@sysadmins::::::
nslcd:x:65:55:LDAP Client User:/:/sbin/nologin
pcmadmin:x:30496:30496:Spectrum Cluster Foundation Server:/var/lib/pcmadmin:/bin/sh
```

3, run the merge script multiple times
```
cd /var/xcat/node/syncfiles
merge/opt/xcat/share/xcat/scripts/xdcpmerge.sh `pwd` /install/osimages/rhels7.2-x86_64-stateful-compute/cfmdir/etc/passwd.merge:/etc/passwd
```
4, check the target file /etc/passwd,  there is no duplicate entries again.


