### PR TITLE
modify rspconfig testcase  for get more debug information

### DIFF
--- a/xCAT-test/autotest/testcase/rspconfig/cases0
+++ b/xCAT-test/autotest/testcase/rspconfig/cases0
@@ -44,7 +44,7 @@ end
 start:rspconfig_ip
 description:rspconfig  change openbmc ip 
 Attribute: $$CN-The operation object of rspconfig command
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig.sh -i $$CN
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig.sh -i $$CN $NODEIP
 check:rc==0
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig.sh -c $$CN ip
 check:rc==0

--- a/xCAT-test/autotest/testcase/rspconfig/cases0
+++ b/xCAT-test/autotest/testcase/rspconfig/cases0
@@ -41,7 +41,7 @@ check:rc==0
 check:output=~__GETNODEATTR($$CN,hcp)__: \w+
 end
 
-start:rspconfig_ip
+start:rspconfig_set_ip
 description:rspconfig  change openbmc ip 
 Attribute: $$CN-The operation object of rspconfig command
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig.sh -i $$CN $NODEIP
@@ -64,7 +64,7 @@ cmd:rspconfig $$CN ip=
 check:rc!=0
 end
 
-start:rspconfig_netmask
+start:rspconfig_set_netmask
 description:rspconfig change openbmc netmask
 Attribute: $$CN-The operation object of rspconfig command
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig.sh -n $$CN netmask
@@ -78,10 +78,17 @@ cmd:rspconfig $$CN netmask=ddd
 check:rc!=0
 end
  
-start:rspconfig_gateway
+start:rspconfig_set_gateway
 description:rspconfig change openbmc gateway
 Attribute: $$CN-The operation object of rspconfig command
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig.sh -g  $$CN gateway
+check:rc==0
+end
+
+start:rspconfig_set_vlan
+description:rspconfig change openbmc gateway
+Attribute: $$CN-The operation object of rspconfig command
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig.sh -v  $$CN vlan
 check:rc==0
 end
  
@@ -101,4 +108,38 @@ check:rc!=0
 cmd:if [[ -e /tmp/testnode.stanza ]]; then cat /tmp/testnode.stanza | chdef -z;rm -rf /tmp/testnode.stanza;fi
 check:rc==0
 end
- 
+
+start:rspconfig_list_ip
+despcription:rspconfig list bmc ip
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig.sh -lip $$CN 
+check:rc==0
+end
+
+start:rspconfig_list_gateway
+description:rspconfig list openbmc gateway
+Attribute: $$CN-The operation object of rspconfig command
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig.sh -lg $$CN
+check:rc==0
+end
+
+start:rspconfig_list_netmask
+description:rspconfig list openbmc netmask
+Attribute: $$CN-The operation object of rspconfig command
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig.sh -ln $$CN
+check:rc==0
+end
+
+start:rspconfig_list_vlan
+description:rspconfig list openbmc netmask
+Attribute: $$CN-The operation object of rspconfig command
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig.sh -lv $$CN
+check:rc==0
+end
+
+start:rspconfig_list_all
+description:rspconfig list openbmc netmask
+Attribute: $$CN-The operation object of rspconfig command
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig.sh -la $$CN
+check:rc==0
+end
+

--- a/xCAT-test/autotest/testcase/rspconfig/cases0
+++ b/xCAT-test/autotest/testcase/rspconfig/cases0
@@ -91,6 +91,13 @@ Attribute: $$CN-The operation object of rspconfig command
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig.sh -v  $$CN vlan
 check:rc==0
 end
+
+start:rspconfig_set_all
+description:rspconfig change openbmc ip/netmask/gateway/vlan
+Attribute: $$CN-The operation object of rspconfig command
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig.sh -a  $$CN 
+check:rc==0
+end
  
 start:rspconfig_gateway_invalid
 despcription:rspconfig could not change openbmc gatway using invalid gateway
@@ -99,11 +106,35 @@ cmd:rspconfig $$CN gateway=ddd
 check:rc!=0
 end
 
+start:rspconfig_set_vlan_invalid
+despcription:rspconfig could not change openbmc gatway using invalid vlan
+Attribute: $$CN-The operation object of rspconfig command
+cmd:rspconfig $$CN vlan=dddsdsdfs
+check:rc!=0
+end
+
+start:rspconfig_set_all_invalid
+despcription:rspconfig could not change openbmc gatway using invalid vlan
+Attribute: $$CN-The operation object of rspconfig command
+cmd:rspconfig $$CN ip=dsd gateway=ooo netmask=asfsf vlan=dddsdsdfs
+check:rc!=0
+end
+
 start:rspconfig_node_invalid
 despcription:rspconfig could not do any action  using invalid node
 cmd:test=$(lsdef testnode);if [[ $? -eq 0 ]]; then lsdef -l testnode -z >/tmp/testnode.stanza ;rmdef testnode;fi
 check:rc==0
 cmd:rspconfig testnode ip
+check:rc!=0
+cmd:if [[ -e /tmp/testnode.stanza ]]; then cat /tmp/testnode.stanza | chdef -z;rm -rf /tmp/testnode.stanza;fi
+check:rc==0
+end
+
+start:rspconfig_noderange_invalid
+despcription:rspconfig could not do any action  using invalid node
+cmd:test=$(lsdef testnode);if [[ $? -eq 0 ]]; then lsdef -l testnode -z >/tmp/testnode.stanza ;rmdef testnode;fi
+check:rc==0
+cmd:rspconfig testnode,$$CN ip
 check:rc!=0
 cmd:if [[ -e /tmp/testnode.stanza ]]; then cat /tmp/testnode.stanza | chdef -z;rm -rf /tmp/testnode.stanza;fi
 check:rc==0

--- a/xCAT-test/autotest/testcase/rspconfig/rspconfig.sh
+++ b/xCAT-test/autotest/testcase/rspconfig/rspconfig.sh
@@ -180,19 +180,20 @@ function change_all
 {
 	echo "Prepare to change all for bmc."
 	echo "Start to change all for bmc."
-	rspconfig $2 gateway netmask vlan ip
+	rspconfig $1 gateway netmask vlan ip
 	if [[ $? -eq 0 ]];then
-		BMCIP=`rspconfig $2 ip |awk -F":" '{print $3}'`;
-		BMCNETMASK=`rspconfig  $2 netmask |awk -F":" '{print $3}'`;
-		BMCGGATEWAY=`rspconfig  $2 gateway |awk -F":" '{print $3}'`;
-		output=`rspconfig  $2 vlan`
+		BMCIP=`rspconfig $1 ip |awk -F":" '{print $3}'|sed s/[[:space:]]//g`;
+		BMCNETMASK=`rspconfig  $1 netmask |awk -F":" '{print $3}'|sed s/[[:space:]]//g`;
+		BMCGGATEWAY=`rspconfig  $1 gateway |awk -F":" '{print $3}'|sed s/[[:space:]]//g`;
+		output=`rspconfig  $1 vlan`
 		if [[ $output =~ "BMC VLAN ID enabled" ]];then
-			BMCVLAN=`rspconfig  $2 vlan |awk -F":" '{print $3}'`
+			BMCVLAN=`rspconfig  $1 vlan |awk -F":" '{print $3}'|sed s/[[:space:]]//g`
 		else
 			echo "------------------Bmc vlan disabled so could not change vlan id using rspconfig.--------------------"
 			return 1;
 		fi
-	rspconfig $2 ip=$BMCIP netmask=$BMCNETMASK gateway=$BMCGGATEWAY vlan=$BMCVLAN
+
+		rspconfig $1 ip=$BMCIP netmask=$BMCNETMASK gateway=$BMCGGATEWAY vlan=$BMCVLAN
 		if [[ $? -eq 0 ]];then
 			echo "Could set BMC IP/netmask/gateway/vlan.";
 		else

--- a/xCAT-test/autotest/testcase/rspconfig/rspconfig.sh
+++ b/xCAT-test/autotest/testcase/rspconfig/rspconfig.sh
@@ -252,6 +252,7 @@ do
 			BMCIP=`rspconfig $2 ip |awk -F":" '{print $3}'`
 			BMCNETMASK=`rspconfig  $2 netmask |awk -F":" '{print $3}'`
 		else
+			echo "Run rspconfig $2 ip and return value is 1. "
 			exit 1; 
 		fi
 		change_ip $BMCIP $2 $BMCNETMASK $3
@@ -288,6 +289,7 @@ do
 		if [[ $? -eq 0 ]];then
 			BMCGATEWAYE=`rspconfig  $2 gateway |awk -F":" '{print $3}'`
 		else
+			echo "Run rspconfig  $2 gateway and return value is 1."
 			exit 1;
 		fi
 		change_nonip $BMCGATEWAYE $2 $3 gateway
@@ -320,6 +322,7 @@ do
 		if [[ $? -eq 0 ]];then
 			BMCNETMASK=`rspconfig  $2 netmask |awk -F":" '{print $3}'`
 		else
+			echo "Run rspconfig  $2 netmask and return value is 1."
 			exit 1;
 		fi
 		change_nonip $BMCNETMASK $2 $3 netmask

--- a/xCAT-test/autotest/testcase/rspconfig/rspconfig.sh
+++ b/xCAT-test/autotest/testcase/rspconfig/rspconfig.sh
@@ -40,7 +40,7 @@ function test_ip()
 	VALID_CHECK=$(echo $IP|awk -F. '$1<=255&&$2<=255&&$3<=255&&$4<=255{print "yes"}')
 	if echo $IP|grep -E "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$">/dev/null; then
        		if [ ${VALID_CHECK:-no} == "yes" ]; then
-                       	echo $1;
+                       	echo $1 is valid;
 		else
 			return 1;
 		fi
@@ -53,8 +53,6 @@ function net()
 {
 	LASTIP=`echo "$1 $2"|awk -F '[ .]+' 'BEGIN{OFS="."} END{print or($1,xor($5,255)),or($2,xor($6,255)),or($3,xor($7,255)),or($4,xor($8,255))}'`
 	FIRSTIP=`echo "$1 $2"|awk -F '[ .]+' 'BEGIN{OFS="."} END{print and($1,$5),and($2,$6),and($3,$7),and($4,$8)}'`
-	echo lastip is $LASTIP
-	echo first ip is $FIRSTIP
 }
 function change_ip()
 {

--- a/xCAT-test/autotest/testcase/rspconfig/rspconfig.sh
+++ b/xCAT-test/autotest/testcase/rspconfig/rspconfig.sh
@@ -1,4 +1,39 @@
 #!/bin/bash
+function usage()
+{
+	local script="${0##*/}"
+	while read -r ; do echo "${REPLY}" ; done <<-EOF
+Usage: ${script} [OPTION]... [ACTION]
+	Test rspconfig automatically
+
+Options:
+	Mandatory arguments to long options are mandatory for short options too.
+	-h, --help                    display this help and exit
+	-i|--ip                       To test rspconfig could change bmc's ip
+	-lip|--list ip                To test rspconfig could get bmc's ip
+	-g|--gateway                  To test rspconfig could change bmc's gateway
+	-lg|--list gateway            To test rspconfig could list bmc's gateway
+	-n|--netmask                  To test rspconfig could change bmc's netmask
+	-ln|--list netmask            To test rspconfig could list bmc's netmask
+	-v|--vlan                     To test rspconfig could change bmc's vlan
+ 	-lv|--list vlan               To test rspconfig could list bmc's vlan
+	-a|--all                      To test rspconfig could change bmc's ip,gateway,netmask,vlan
+	-la|--list all                To test rspconfig could list bmc's ip,gateway,netmask,vlan
+	-c|--clear                    To clear test environment 
+Examples:
+	${script} -i noderange nodeip=node's ip
+	${script} -n noderange netmask
+	${script} -g noderange gateway
+	${script} -v noderange vlan
+	${script} -lip noderange
+	${script} -ln noderange
+	${script} -lg noderange
+	${script} -lv noderange
+	${script} -a noderange
+	${script} -la noderange
+
+EOF
+}
 function test_ip()
 {
 	IP=$1
@@ -20,27 +55,26 @@ function net()
 	FIRSTIP=`echo "$1 $2"|awk -F '[ .]+' 'BEGIN{OFS="."} END{print and($1,$5),and($2,$6),and($3,$7),and($4,$8)}'`
 	echo lastip is $LASTIP
 	echo first ip is $FIRSTIP
-
 }
 function change_ip()
 {
-        echo "Prepare to change ip."
-        echo "Start to check ip valid."
-        NODEIP=$4;
+	echo "Prepare to change ip."
+	echo "Start to check ip valid."
+	NODEIP=$4;
 	test_ip $1;
 	if [[ $? -ne 0 ]];then echo "ip is invalid";return 1;fi
-        echo "ip is valid.";
+	echo "ip is valid.";
 	echo $1 > /tmp/BMCIP
-        net $1 $3
+	net $1 $3
 	ip1=`echo $1|awk -F. '{print $1}'`
 	ip2=`echo $1|awk -F. '{print $2}'`
 	ip3=`echo $1|awk -F. '{print $3}'`
-        ip4=`echo $1|awk -F. '{print $4}'`
+	ip4=`echo $1|awk -F. '{print $4}'`
 	ipfirst=`echo $FIRSTIP|awk -F. '{print $4}'`
-        ip=`expr "$ipfirst" "+" "1"`
+	ip=`expr "$ipfirst" "+" "1"`
 	iplast=`echo $LASTIP|awk -F. '{print $4}'`
-        ip5=`expr "$iplast" "-" "1"`
-        echo ip is $ip ,ip5 is $ip5
+	ip5=`expr "$iplast" "-" "1"`
+	echo ip is $ip ,ip5 is $ip5
 	while true;
 	do [[ $ip == "$ip5" ]] && echo "exit for using last ip."&&return 1;
 		ping $ip1.$ip2.$ip3.$ip -c 2 >/dev/null ;
@@ -48,23 +82,23 @@ function change_ip()
 			coutip="$ip1.$ip2.$ip3.$ip"
 			BMCNEWIP=$coutip;
 			echo $1,$2,$3
-                        echo "Start to set ip for node."
+			echo "Start to set ip for node."
 			rspconfig $2 ip=$BMCNEWIP
 			if [[ $? -eq 0 ]];then
 				echo "Could set bmc's ip for node using rspconfig.";
 			else
-                                echo "Could not set bmc's ip for node using rspconfig.";
+				echo "Could not set bmc's ip for node using rspconfig.";
 				return 1;
 			fi
 			chdef $2 bmc=$BMCNEWIP
-                        echo "Start to check bmc's ip setted successfully or not."
+			echo "Start to check bmc's ip setting."
 			check_result $2 ip $BMCNEWIP
 			if [[ $? -ne 0 ]] ;then
-                                echo "Set bmc's ip failed.";
+				echo "Set bmc's ip failed.";
 				return 1;
 			else
 				echo "Set bmc's ip successfully.";
-                                return 0;
+				return 0;
 			fi
 		fi
 		ip=`expr "$ip" "+" "1"`
@@ -114,8 +148,8 @@ function clear_env()
 }
 function change_nonip
 {
-echo "Prepare to change $4.";
-echo "Start to check $4 valid or not.";
+	echo "Prepare to change $4.";
+	echo "Start to check $4 valid or not.";
 	if [[ $4 =~ "gateway" ]]||[[ $4 =~ "netmask" ]];then 
         	test_ip $1;
 		if [[ $? -ne 0 ]];then 
@@ -126,45 +160,45 @@ echo "Start to check $4 valid or not.";
 	echo "Start to change bmc's $4.";
 	rspconfig $2 $4=$1;
 	if [[ $? -eq 0 ]];then
-                echo "Could set bmc's $4.";
-        else
-                echo "Could not set bmc's $4.";
-                return 1;
-        fi
-        echo "Start to check $4 setting successfully or not.";
-        check_result $2 $3 $1
-        if [[ $? -ne 0 ]] ;then
-                echo "Set bmc's $4 failed.";
-                return 1;
-        else
-                echo "Set bmc's $4 successfully.";
-                return 0;
-        fi
+		echo "Could set bmc's $4.";
+	else
+		echo "Could not set bmc's $4.";
+		return 1;
+	fi
+	echo "Start to check $4 setting.";
+	check_result $2 $3 $1
+	if [[ $? -ne 0 ]] ;then
+		echo "Set bmc's $4 failed.";
+		return 1;
+	else
+		echo "Set bmc's $4 successfully.";
+		return 0;
+	fi
 
 }
 function change_all
 {
-echo "Prepare to change all for bmc."
-echo "Start to change all for bmc."
+	echo "Prepare to change all for bmc."
+	echo "Start to change all for bmc."
 	rspconfig $2 gateway netmask vlan ip
 	if [[ $? -eq 0 ]];then
 		BMCIP=`rspconfig $2 ip |awk -F":" '{print $3}'`;
 		BMCNETMASK=`rspconfig  $2 netmask |awk -F":" '{print $3}'`;
 		BMCGGATEWAY=`rspconfig  $2 gateway |awk -F":" '{print $3}'`;
-                output=`rspconfig  $2 vlan`
-                if [[ $output =~ "BMC VLAN ID enabled" ]];then
-                        BMCVLAN=`rspconfig  $2 vlan |awk -F":" '{print $3}'`
-                else
-                        echo "------------------Bmc vlan disabled so could not change vlan id using rspconfig.--------------------"
-                        return 1;
-                fi
+		output=`rspconfig  $2 vlan`
+		if [[ $output =~ "BMC VLAN ID enabled" ]];then
+			BMCVLAN=`rspconfig  $2 vlan |awk -F":" '{print $3}'`
+		else
+			echo "------------------Bmc vlan disabled so could not change vlan id using rspconfig.--------------------"
+			return 1;
+		fi
 	rspconfig $2 ip=$BMCIP netmask=$BMCNETMASK gateway=$BMCGGATEWAY vlan=$BMCVLAN
 		if [[ $? -eq 0 ]];then
-                	echo "Could set bmc's all options.";
-        	else
-                	echo "Could not set bmc's all options.";
-                	return 1;
-        	fi
+			echo "Could set BMC IP/netmask/gateway/vlan.";
+		else
+			echo "Could not set BMC IP/netmask/gateway/vlan.";
+		return 1;
+		fi
 	fi
 
 }
@@ -198,11 +232,11 @@ do
 		fi
 		;;
 		"-lip"|"--list ip" )
-                echo "--------------------To test bmc ip could be listed using rspconfig.--------------------"
-                BMCIP_LSDEF=`lsdef $2 |grep "bmc=" |awk -F "=" '{print $2}'`
-                rspconfig $2 ip
-                if [[ $? -eq 0 ]];then
-                        BMCIP=`rspconfig $2 ip |awk -F":" '{print $3}'`
+		echo "--------------------To test bmc ip could be listed using rspconfig.--------------------"
+		BMCIP_LSDEF=`lsdef $2 |grep "bmc=" |awk -F "=" '{print $2}'`
+		rspconfig $2 ip
+		if [[ $? -eq 0 ]];then
+			BMCIP=`rspconfig $2 ip |awk -F":" '{print $3}'`
 				if [[ $BMCIP =~ "$BMCIP_LSDEF" ]];then 
 					echo "-----------------To test bmc ip could be listed using rspconfig successfully.-----------------"
 					exit 0;
@@ -210,11 +244,11 @@ do
 					echo "-------------------To test bmc ip could be listed using rspconfig failed.----------------"
 					exit 1;
 				fi
-                else
+		else
 			echo "------------------To test bmc ip could be listed using rspconfig failed.-------------------"
-                        exit 1;
-                fi
-                ;;
+			exit 1;
+		fi
+		;;
 
 		"-g"|"--gateway" )
 		echo "--------------------To test bmc gateway could be changed using rspconfig.---------------------"
@@ -222,11 +256,11 @@ do
 		if [[ $? -eq 0 ]];then
 			BMCGATEWAYE=`rspconfig  $2 gateway |awk -F":" '{print $3}'`
 		else
-      			exit 1;
+			exit 1;
 		fi
 		change_nonip $BMCGATEWAYE $2 $3 gateway
 		if [[ $? -eq 1 ]];then
-                        echo "--------------------To test bmc gateway could be changed using rspconfig failed.--------------------"
+			echo "--------------------To test bmc gateway could be changed using rspconfig failed.--------------------"
 			exit 1
 		else
 			echo "--------------------To test bmc gateway could be changed using rspconfig successfully.--------------------"
@@ -235,7 +269,6 @@ do
 		;;
 		"-lg"|"--list gateway" )
 		output=`rspconfig $2 gateway`
-echo "output is $output"
 		if [[ $? -eq 0 ]];then
 			if [[ $output =~ "$2: BMC Gateway:" ]];then 
 				echo "--1-----------------To test bmc gateway could be listed using rspconfig successfully.-----------------"
@@ -266,70 +299,69 @@ echo "output is $output"
 			exit 0
 		fi
 		;;
-                "-ln"|"--list netmask" )
-                output=`rspconfig $2 netmask` 
-                if [[ $? -eq 0 ]];then
-                        if [[ $output =~ "$2: BMC Netmask:" ]];then
-                                echo "-------------------To test bmc Netmask could be listed using rspconfig successfully.-----------------"
-                                exit 0;
-                        else
-                                echo "-----------------To test bmc Netmask could be listed using rsconfig failed.-------------------"
-                                exit 1;
-                        fi
-                else
-                        echo "-------------------To test bmc Netmask could be listed using rspconfig failed.---------------"
-                        exit 1;
-                fi
-                ;;
-                "-v"|"--vlan" )
-                output=`rspconfig  $2 vlan`
-                echo "---------------------To test bmc vlan could be changed using rspconfig.--------------------"
-                if [[ $? -eq 0 ]]&&[[ $output =~ "BMC VLAN ID enabled" ]];then
-                        BMCVLAN=`rspconfig  $2 vlan |awk -F":" '{print $3}'`
-                else
-                        echo "------------------Bmc vlan disabled so could not change vlan id using rspconfig.--------------------"
+		"-ln"|"--list netmask" )
+		output=`rspconfig $2 netmask` 
+		if [[ $? -eq 0 ]];then
+			if [[ $output =~ "$2: BMC Netmask:" ]];then
+				echo "-------------------To test bmc Netmask could be listed using rspconfig successfully.-----------------"
+				exit 0;
+			else
+				echo "-----------------To test bmc Netmask could be listed using rsconfig failed.-------------------"
+				exit 1;
+			fi
+ 		else
+			echo "-------------------To test bmc Netmask could be listed using rspconfig failed.---------------"
 			exit 1;
-                fi
-                change_nonip $BMCVLAN $2 $3 vlan
-                if [[ $? -eq 1 ]];then
-                        echo "--------------------To test bmc vlan could be changed using rspconfig failed.------------------"
-                        exit 1
-                else
-                        echo "--------------------To test bmc vlan could be changed using rspconfig successfully.-------------------"
-                        exit 0
-                fi
-                ;;
-                "-lv"|"--list vlan" )
-                output=`rspconfig $2 vlan`
-                if [[ $? -eq 0 ]];then
-                        if [[ $output =~ "$2: BMC VLAN ID" ]];then
-                                echo "-------------------To test bmc Vlan could be listed using rspconfig successfully.-----------------"
-                                exit 0;
-                        else
-                                echo "-----------------To test bmc Vlan could be listed using rsconfig failed.-------------------"
-                                exit 1;
-                        fi
-                else
-                        echo "-------------------To test bmc Vlan could be listed using rspconfig failed.---------------"
-                        exit 1;
-                fi
-                ;;
-		"-a"|"--all" )
-                change_all $2
+		fi
+		;;
+		"-v"|"--vlan" )
+		output=`rspconfig  $2 vlan`
+		echo "---------------------To test bmc vlan could be changed using rspconfig.--------------------"
+		if [[ $? -eq 0 ]]&&[[ $output =~ "BMC VLAN ID enabled" ]];then
+			BMCVLAN=`rspconfig  $2 vlan |awk -F":" '{print $3}'`
+		else
+			echo "------------------Bmc vlan disabled so could not change vlan id using rspconfig.--------------------"
+			exit 1;
+		fi
+		change_nonip $BMCVLAN $2 $3 vlan
 		if [[ $? -eq 1 ]];then
-                        echo "--------------------To test bmc's all options could be changed using rspconfig failed.------------------"
-                        exit 1
+			echo "--------------------To test bmc vlan could be changed using rspconfig failed.------------------"
+			exit 1
+		else
+			echo "--------------------To test bmc vlan could be changed using rspconfig successfully.-------------------"
+			exit 0
+		fi
+		;;
+		"-lv"|"--list vlan" )
+		output=`rspconfig $2 vlan`
+		if [[ $? -eq 0 ]];then
+			if [[ $output =~ "$2: BMC VLAN ID" ]];then
+				echo "-------------------To test bmc Vlan could be listed using rspconfig successfully.-----------------"
+				exit 0;
+			else
+				echo "-----------------To test bmc Vlan could be listed using rsconfig failed.-------------------"
+				exit 1;
+			fi
+		else
+			echo "-------------------To test bmc Vlan could be listed using rspconfig failed.---------------"
+			exit 1;
+		fi
+		;;
+		"-a"|"--all" )
+		change_all $2
+		if [[ $? -eq 1 ]];then
+			echo "--------------------To test BMC IP/netmask/gateway/vlan could be changed using rspconfig failed.------------------"
+			exit 1
                 else
-                        echo "--------------------To test bmc's all options could be changed using rspconfig successfully.-------------------"
-                        exit 0
-                fi
+			echo "--------------------To test BMC IP/netmask/gateway/vlan could be changed using rspconfig successfully.-------------------"
+			exit 0
+		fi
 		;;
 		"-la"|"--list all" )
 		BMCIP_LSDEF=`lsdef $2 |grep "bmc=" |awk -F "=" '{print $2}'`
 		BMCIP=`rspconfig $2 ip |awk -F":" '{print $3}'`
 		output=`rspconfig $2 ip gateway netmask vlan`
 		if [[ $? -eq 0 ]];then
-			#if [[ $output =~ "BMC VLAN ID:" ]]&&[[ $output =~ "BMC Netmask:" ]]&&[[ $output =~ "BMC Gateway:" ]]&&[[ $BMCIP =~ "$BMCIP_LSDEF" ]];then 
 			if [[ $output =~ "$2: BMC VLAN ID" ]]&&[[ $output =~ "BMC Netmask:" ]]&&[[ $output =~ "BMC Gateway:" ]]&&[[ $BMCIP =~ "$BMCIP_LSDEF" ]];then 
 				echo "------------------To test bmc's all option could be listed using rspconfig succssfully.-----------------"
 				exit 0
@@ -340,7 +372,7 @@ echo "output is $output"
 		fi
 		;;
 		"-c"|"--clear" )
-                echo "--------------------To clear the test envionment.--------------------"
+		echo "--------------------To clear the test envionment.--------------------"
 		clear_env $1 $2 $3
 		if [[ $? -eq 1 ]];then
 			echo "--------------------To clear the test environment failed.-----------------"	
@@ -350,11 +382,16 @@ echo "output is $output"
 			exit 0
 		fi
 		;;
+		"-h"|"--help" )
+                usage
+                exit 0
+                ;;
 		*)
 		echo
-		echo "Please Insert $0: -i|-g|-n|-c"
+		echo "Please Insert $0: -i|-lip|-g|-lg|-n|-ln|-v|-lv|-c|-a|-la"
 		echo
 		exit 1;
 		;;
 		esac
+		shift
 done

--- a/xCAT-test/autotest/testcase/rspconfig/rspconfig.sh
+++ b/xCAT-test/autotest/testcase/rspconfig/rspconfig.sh
@@ -25,7 +25,7 @@ function net()
 function change_ip()
 {
         echo "Prepare to change ip."
-        echo "Start to check ip valid ."
+        echo "Start to check ip valid."
         NODEIP=$4;
 	test_ip $1;
 	if [[ $? -ne 0 ]];then echo "ip is invalid";return 1;fi
@@ -51,19 +51,19 @@ function change_ip()
                         echo "Start to set ip for node."
 			rspconfig $2 ip=$BMCNEWIP
 			if [[ $? -eq 0 ]];then
-				echo "Could set ip for node.";
+				echo "Could set bmc's ip for node using rspconfig.";
 			else
-                                echo "Could not set ip for node";
+                                echo "Could not set bmc's ip for node using rspconfig.";
 				return 1;
 			fi
 			chdef $2 bmc=$BMCNEWIP
-                        echo "Start to check ip setted successfully or not."
+                        echo "Start to check bmc's ip setted successfully or not."
 			check_result $2 ip $BMCNEWIP
 			if [[ $? -ne 0 ]] ;then
-                                echo "Ip could  not be setted.";
+                                echo "Set bmc's ip failed.";
 				return 1;
 			else
-				echo "Ip could be setted.";
+				echo "Set bmc's ip successfully.";
                                 return 0;
 			fi
 		fi
@@ -88,25 +88,25 @@ function check_result()
 }
 function clear_env()
 {
-echo "Start to clear test environment.";
+	echo "Start to clear test environment.";
 	if [[ -f /tmp/BMCIP ]];then 
         	originip=$(cat /tmp/BMCIP);
         	echo originip is $originip;
         	rspconfig $2 ip=$originip
         	if [[ $? -eq 0 ]];then
-            		echo "Could set the node's bmc ip to originip";
+            		echo "Could set bmc's ip to originip using rspconfig.";
         	else
-            		echo "Could not set the node's bmc ip to originip";
+            		echo "Could not set bmc's ip to originip using rspconfig.";
             		return 1;
         	fi
         	rm -rf /tmp/BMCIP
         	chdef $2 bmc=$originip
         	check_result $2 $3 $originip
        		if [[ $? -ne 0 ]] ;then
-            		echo "Could set the node's bmc ip to originip sucessfully.";
+            		echo "Set bmc's ip to originip failed.";
       			return 1;
        		else
-            		echo "Could set the node's bmc ip to originip successfully.";
+            		echo "Set bmc's ip to originip successfully.";
                         return 0; 
        		fi
     	fi
@@ -114,25 +114,25 @@ echo "Start to clear test environment.";
 }
 function change_gateway 
 {
- 	echo "Prepare to change gateway.";
-        echo "Start to check gateway valid or not.";
+	echo "Prepare to change gateway.";
+	echo "Start to check gateway valid or not.";
         test_ip $1;
 	if [[ $? -ne 0 ]];then echo "Gateway is invalid";return 1;fi
-                echo "Start to change gateway.";
+                echo "Start to change bmc's gateway.";
 		rspconfig $2 gateway=$1;
 	if [[ $? -eq 0 ]];then
-		echo "Could set gateway.";
+		echo "Could set bmc's gateway.";
 	else
-		echo "Could not set gateway.";
+		echo "Could not set bmc's gateway.";
                 return 1;
 	fi
-        echo "Start to check gateway setted successfully or not.";
+        echo "Start to check gateway setting successfully or not.";
 	check_result $2 $3 $1
 	if [[ $? -ne 0 ]] ;then
-                echo "Could not set gateway successfully.";
+                echo "Set bmc's gateway failed.";
 		return 1;
 	else
-		echo "Could set gateway successfully.";
+		echo "Set bmc's gateway successfully.";
                 return 0;
 	fi
 }
@@ -144,17 +144,17 @@ function change_netmask
 	if [[ $? -ne 0 ]];then echo "Net mask is invalid.";return 1;fi
 	rspconfig $2 netmask=$1;
 	if [[ $? -eq 0 ]];then
-		echo "Could set netmask.";
+		echo "Could set bmc's netmask using rspconfig.";
 	else
-                echo "Could not set netmask.";
+                echo "Could not set bmc's netmask using rspconfig.";
 		return 1;
 	fi
 	check_result $2 $3 $1
 	if [[ $? -ne 0 ]] ;then
-                echo "Could not set netmask successfully.";
+                echo "Set bmc's netmask failed.";
 		return 1;
 	else
-		echo "Could set netmask successfully.";
+		echo "Set bmc's netmask successfully.";
                 return 0;
 	fi
 }

--- a/xCAT-test/autotest/testcase/rspconfig/rspconfig.sh
+++ b/xCAT-test/autotest/testcase/rspconfig/rspconfig.sh
@@ -26,7 +26,7 @@ function change_ip()
 {
         echo "Prepare to change ip."
         echo "Start to check ip valid ."
-        $NODEIP=$4;
+        NODEIP=$4;
 	test_ip $1;
 	if [[ $? -ne 0 ]];then echo "ip is invalid";return 1;fi
         echo "ip is valid.";

--- a/xCAT-test/autotest/testcase/rspconfig/rspconfig.sh
+++ b/xCAT-test/autotest/testcase/rspconfig/rspconfig.sh
@@ -112,55 +112,67 @@ function clear_env()
     	fi
         return 1;
 }
-function change_gateway 
+function change_nonip
 {
-	echo "Prepare to change gateway.";
-	echo "Start to check gateway valid or not.";
-        test_ip $1;
-	if [[ $? -ne 0 ]];then echo "Gateway is invalid";return 1;fi
-                echo "Start to change bmc's gateway.";
-		rspconfig $2 gateway=$1;
+echo "Prepare to change $4.";
+echo "Start to check $4 valid or not.";
+	if [[ $4 =~ "gateway" ]]||[[ $4 =~ "netmask" ]];then 
+        	test_ip $1;
+		if [[ $? -ne 0 ]];then 
+			echo "$4 is invalid";
+			return 1;
+		fi
+	fi
+	echo "Start to change bmc's $4.";
+	rspconfig $2 $4=$1;
 	if [[ $? -eq 0 ]];then
-		echo "Could set bmc's gateway.";
-	else
-		echo "Could not set bmc's gateway.";
+                echo "Could set bmc's $4.";
+        else
+                echo "Could not set bmc's $4.";
                 return 1;
-	fi
-        echo "Start to check gateway setting successfully or not.";
-	check_result $2 $3 $1
-	if [[ $? -ne 0 ]] ;then
-                echo "Set bmc's gateway failed.";
-		return 1;
-	else
-		echo "Set bmc's gateway successfully.";
+        fi
+        echo "Start to check $4 setting successfully or not.";
+        check_result $2 $3 $1
+        if [[ $? -ne 0 ]] ;then
+                echo "Set bmc's $4 failed.";
+                return 1;
+        else
+                echo "Set bmc's $4 successfully.";
                 return 0;
-	fi
+        fi
+
 }
-function change_netmask 
+function change_all
 {
-	echo "Prepare to change netmask";
-        echo "Start to check netmask valid or not.";
-        test_ip $1;
-	if [[ $? -ne 0 ]];then echo "Net mask is invalid.";return 1;fi
-	rspconfig $2 netmask=$1;
+echo "Prepare to change all for bmc."
+echo "Start to change all for bmc."
+	rspconfig $2 gateway netmask vlan ip
 	if [[ $? -eq 0 ]];then
-		echo "Could set bmc's netmask using rspconfig.";
-	else
-                echo "Could not set bmc's netmask using rspconfig.";
-		return 1;
+		BMCIP=`rspconfig $2 ip |awk -F":" '{print $3}'`;
+		BMCNETMASK=`rspconfig  $2 netmask |awk -F":" '{print $3}'`;
+		BMCGGATEWAY=`rspconfig  $2 gateway |awk -F":" '{print $3}'`;
+                output=`rspconfig  $2 vlan`
+                if [[ $output =~ "BMC VLAN ID enabled" ]];then
+                        BMCVLAN=`rspconfig  $2 vlan |awk -F":" '{print $3}'`
+                else
+                        echo "------------------Bmc vlan disabled so could not change vlan id using rspconfig.--------------------"
+                        return 1;
+                fi
+	rspconfig $2 ip=$BMCIP netmask=$BMCNETMASK gateway=$BMCGGATEWAY vlan=$BMCVLAN
+		if [[ $? -eq 0 ]];then
+                	echo "Could set bmc's all options.";
+        	else
+                	echo "Could not set bmc's all options.";
+                	return 1;
+        	fi
 	fi
-	check_result $2 $3 $1
-	if [[ $? -ne 0 ]] ;then
-                echo "Set bmc's netmask failed.";
-		return 1;
-	else
-		echo "Set bmc's netmask successfully.";
-                return 0;
-	fi
+
 }
 BMCIP=""
+BMCIP_LSDEF=""
 BMCGTEWAT=""
 BMCNETMASK=""
+BMCVLAN=""
 FIRSTIP=""
 LASTIP=""
 NODEIP=""
@@ -168,6 +180,7 @@ while [ "$#" -gt "0" ]
 do
 	case $1 in
 		"-i"|"--ip" )
+		echo "--------------------To test bmc ip could be changed using rspconfig.--------------------"
 		rspconfig $2 ip
 		if [[ $? -eq 0 ]];then
 			BMCIP=`rspconfig $2 ip |awk -F":" '{print $3}'`
@@ -177,44 +190,161 @@ do
 		fi
 		change_ip $BMCIP $2 $BMCNETMASK $3
 		if [[ $? -eq 1 ]];then
+			echo "--------------------To test bmc ip could be changed using rspconfig failed.--------------------"
 			exit 1
-		else 
+		else
+			echo "--------------------To test bmc ip could be change using rspconfig successfully.-------------------" 
 			exit 0
 		fi
 		;;
+		"-lip"|"--list ip" )
+                echo "--------------------To test bmc ip could be listed using rspconfig.--------------------"
+                BMCIP_LSDEF=`lsdef $2 |grep bmc |awk -F "=" '{print $2}'`
+                rspconfig $2 ip
+                if [[ $? -eq 0 ]];then
+                        BMCIP=`rspconfig $2 ip |awk -F":" '{print $3}'`
+				if [[ $BMCIP =~ "$BMCIP_LSDEF" ]];then 
+					echo "-----------------To test bmc ip could be listed using rspconfig successfully.-----------------"
+					exit 0;
+				else
+					echo "-------------------To test bmc ip could be listed using rspconfig failed.----------------"
+					exit 1;
+				fi
+                else
+			echo "------------------To test bmc ip could be listed using rspconfig failed.-------------------"
+                        exit 1;
+                fi
+                ;;
+
 		"-g"|"--gateway" )
+		echo "--------------------To test bmc gateway could be changed using rspconfig.---------------------"
 		rspconfig  $2 gateway
 		if [[ $? -eq 0 ]];then
 			BMCGATEWAYE=`rspconfig  $2 gateway |awk -F":" '{print $3}'`
 		else
       			exit 1;
 		fi
-		change_gateway $BMCGATEWAYE $2 $3 
+		change_nonip $BMCGATEWAYE $2 $3 gateway
 		if [[ $? -eq 1 ]];then
+                        echo "--------------------To test bmc gateway could be changed using rspconfig failed.--------------------"
 			exit 1
 		else
+			echo "--------------------To test bmc gateway could be changed using rspconfig successfully.--------------------"
 			exit 0
+		fi
+		;;
+		"-lg"|"--list gateway" )
+		output=rpconfig $2 gateway
+		if [[ $? -eq 0 ]];then
+			if [[ $output =~ "$2 BMC Gateway:" ]];then 
+				echo "-------------------To test bmc gateway could be listed using rspconfig successfully.-----------------"
+				exit 0;
+			else
+				echo "-----------------To test bmc gateway could be listed using rsconfig failed.-------------------"
+				exit 1;
+			fi
+		else
+			echo "-------------------To test bmc gateway could be listed using rspconfig failed.---------------"
+			exit 1;	
 		fi
 		;;
 		"-n"|"--netmask" )
 		rspconfig  $2 netmask
+		echo "---------------------To test bmc netmask could be changed using rspconfig.--------------------"
 		if [[ $? -eq 0 ]];then
 			BMCNETMASK=`rspconfig  $2 netmask |awk -F":" '{print $3}'`
 		else
 			exit 1;
 		fi
-		change_netmask $BMCNETMASK $2 $3
+		change_nonip $BMCNETMASK $2 $3 netmask
 		if [[ $? -eq 1 ]];then
+			echo "--------------------To test bmc netmask could be changed using rspconfig failed.------------------"
 			exit 1
 		else
+			echo "--------------------To test bmc netmask could be changed using rspconfig successfully.-------------------"
 			exit 0
 		fi
 		;;
+                "-ln"|"--list netmask" )
+                output=rpconfig $2 netmask 
+                if [[ $? -eq 0 ]];then
+                        if [[ $output =~ "$2 BMC Netmask:" ]];then
+                                echo "-------------------To test bmc Netmask could be listed using rspconfig successfully.-----------------"
+                                exit 0;
+                        else
+                                echo "-----------------To test bmc Netmask could be listed using rsconfig failed.-------------------"
+                                exit 1;
+                        fi
+                else
+                        echo "-------------------To test bmc Netmask could be listed using rspconfig failed.---------------"
+                        exit 1;
+                fi
+                ;;
+                "-v"|"--vlan" )
+                output=rspconfig  $2 vlan
+                echo "---------------------To test bmc vlan could be changed using rspconfig.--------------------"
+                if [[ $? -eq 0 ]]&&[[ $output =~ "BMC VLAN ID enabled" ]];then
+                        BMCVLAN=`rspconfig  $2 vlan |awk -F":" '{print $3}'`
+                else
+                        echo "------------------Bmc vlan disabled so could not change vlan id using rspconfig.--------------------"
+			exit 1;
+                fi
+                change_nonip $BMCVLAN $2 $3 vlan
+                if [[ $? -eq 1 ]];then
+                        echo "--------------------To test bmc vlan could be changed using rspconfig failed.------------------"
+                        exit 1
+                else
+                        echo "--------------------To test bmc vlan could be changed using rspconfig successfully.-------------------"
+                        exit 0
+                fi
+                ;;
+                "-lv"|"--list vlan" )
+                output=rpconfig $2 vlan
+                if [[ $? -eq 0 ]];then
+                        if [[ $output =~ "$2 BMC VLAN ID:" ]];then
+                                echo "-------------------To test bmc Vlan could be listed using rspconfig successfully.-----------------"
+                                exit 0;
+                        else
+                                echo "-----------------To test bmc Vlan could be listed using rsconfig failed.-------------------"
+                                exit 1;
+                        fi
+                else
+                        echo "-------------------To test bmc Vlan could be listed using rspconfig failed.---------------"
+                        exit 1;
+                fi
+                ;;
+		"-a"|"--all" )
+                change_all $2
+		if [[ $? -eq 1 ]];then
+                        echo "--------------------To test bmc's all options could be changed using rspconfig failed.------------------"
+                        exit 1
+                else
+                        echo "--------------------To test bmc's all options could be changed using rspconfig successfully.-------------------"
+                        exit 0
+                fi
+		;;
+		"-la"|"--list all" )
+		BMCIP_LSDEF=`lsdef $2 |grep bmc |awk -F "=" '{print $2}'`
+		BMCIP=`rspconfig $2 ip |awk -F":" '{print $3}'`
+		output=rspconfig $2 ip gateway netmask vlan
+		if [[ $? -eq 0 ]];then
+			if [[ $output =~ "$2 BMC VLAN ID:" ]]&&[[ $output =~ "$2 BMC Netmask:" ]]&&[[ $output =~ "$2 BMC Gateway:" ]]&&[[ $BMCIP =~ "$BMCIP_LSDEF" ]];then 
+				echo "------------------To test bmc's all option could be listed using rspconfig succssfully.-----------------"
+				exit 0
+			else
+				echo "--------------------To test bmc's all options could be listed using rspconfig failed.--------------------"
+				exit 1
+			fi
+		fi
+		;;
 		"-c"|"--clear" )
+                echo "--------------------To clear the test envionment.--------------------"
 		clear_env $1 $2 $3
 		if [[ $? -eq 1 ]];then
+			echo "--------------------To clear the test environment failed.-----------------"	
 			exit 1
 		else
+			echo "--------------------To clear the test environment sucessfully.-----------------"
 			exit 0
 		fi
 		;;

--- a/xCAT-test/autotest/testcase/rspconfig/rspconfig.sh
+++ b/xCAT-test/autotest/testcase/rspconfig/rspconfig.sh
@@ -81,9 +81,9 @@ function change_ip()
 			echo "Start to set node's bmc ip to $BMCNEWIP."
 			rspconfig $2 ip=$BMCNEWIP
 			if [[ $? -eq 0 ]];then
-				echo "Set node's bmc ip for node using rspconfig successfully.";
+				echo "Run  rspconfig $2 ip=$BMCNEWIP and return value is 0.";
 			else
-				echo "Set node's bmc ip for node using rspconfig failed.";
+				echo "Run rspconfig $2 ip=$BMCNEWIP and return value is 1.";
 				return 1;
 			fi
 			chdef $2 bmc=$BMCNEWIP
@@ -121,9 +121,9 @@ function clear_env()
         	originip=$(cat /tmp/BMCIP);
         	rspconfig $2 ip=$originip
         	if [[ $? -eq 0 ]];then
-            		echo "Set node's bmc ip to originip using rspconfig successfully.";
+            		echo "Run rspconfig $2 ip=$originip and return value is 0.";
         	else
-            		echo "Set node's bmc ip to originip using rspconfig failed.";
+            		echo "Run rspconfig $2 ip=$originip and return value is 1.";
             		return 1;
         	fi
         	rm -rf /tmp/BMCIP
@@ -153,9 +153,9 @@ function change_nonip
 	echo "Start to change bmc's $4.";
 	rspconfig $2 $4=$1;
 	if [[ $? -eq 0 ]];then
-		echo "Set node's bmc $4 using rspconfig successfully.";
+		echo "Run rspconfig $2 $4=$1 and return value is 0.";
 	else
-		echo "Set node's bmc $4 using rspconfig failed.";
+		echo "Run rspconfig $2 $4=$1 and return value is 1.";
 		return 1;
 	fi
 	echo "Start to check node's bmc $4 really setted using rspconfig.";
@@ -183,9 +183,9 @@ function change_all
 			BMCVLAN=`rspconfig  $1 vlan |awk -F":" '{print $3}'|sed s/[[:space:]]//g`
 			rspconfig $1 ip=$BMCIP netmask=$BMCNETMASK gateway=$BMCGGATEWAY vlan=$BMCVLAN
 				if [[ $? -eq 0 ]];then
-		               		echo "Node's BMC IP/netmask/gateway/vlan setted successfully using rspconfig.";
+		               		echo "Run rspconfig $1 ip=$BMCIP netmask=$BMCNETMASK gateway=$BMCGGATEWAY vlan=$BMCVLAN and return value is 0.";
 		       		else
-	                      		echo "Node's BMC IP/netmask/gateway/vlan setted failed using rspconfig.";
+	                      		echo "Run rspconfig $1 ip=$BMCIP netmask=$BMCNETMASK gateway=$BMCGGATEWAY vlan=$BMCVLAN and return value is 1.";
 			             	return 1;
 		     		 fi
 				echo "Start to check node's BMC IP/netmask/gateway/vlan really setted using rspconfig.";
@@ -210,9 +210,9 @@ function change_all
 			echo "------------------Bmc vlan disabled so could not change vlan id using rspconfig.--------------------"
 			rspconfig $1 ip=$BMCIP netmask=$BMCNETMASK gateway=$BMCGGATEWAY 
 				if [[ $? -eq 0 ]];then
-		               		echo "Node's BMC IP/netmask/gateway setted successfully using rspconfig.";
+		               		echo "Run rspconfig $1 ip=$BMCIP netmask=$BMCNETMASK gateway=$BMCGGATEWAY and return value is 0.";
 		       		else
-	                      		echo "Node's BMC IP/netmask/gateway setted failed using rspconfig.";
+	                      		echo "Run rspconfig $1 ip=$BMCIP netmask=$BMCNETMASK gateway=$BMCGGATEWAY and return value is 1.";
 			             	return 1;
           			 fi
 				echo "Start to check node's BMC IP/netmask/gateway really setted using rspconfig.";

--- a/xCAT-test/autotest/testcase/rspconfig/rspconfig.sh
+++ b/xCAT-test/autotest/testcase/rspconfig/rspconfig.sh
@@ -199,7 +199,7 @@ do
 		;;
 		"-lip"|"--list ip" )
                 echo "--------------------To test bmc ip could be listed using rspconfig.--------------------"
-                BMCIP_LSDEF=`lsdef $2 |grep bmc |awk -F "=" '{print $2}'`
+                BMCIP_LSDEF=`lsdef $2 |grep "bmc=" |awk -F "=" '{print $2}'`
                 rspconfig $2 ip
                 if [[ $? -eq 0 ]];then
                         BMCIP=`rspconfig $2 ip |awk -F":" '{print $3}'`
@@ -234,17 +234,18 @@ do
 		fi
 		;;
 		"-lg"|"--list gateway" )
-		output=rpconfig $2 gateway
+		output=`rspconfig $2 gateway`
+echo "output is $output"
 		if [[ $? -eq 0 ]];then
-			if [[ $output =~ "$2 BMC Gateway:" ]];then 
-				echo "-------------------To test bmc gateway could be listed using rspconfig successfully.-----------------"
+			if [[ $output =~ "$2: BMC Gateway:" ]];then 
+				echo "--1-----------------To test bmc gateway could be listed using rspconfig successfully.-----------------"
 				exit 0;
 			else
-				echo "-----------------To test bmc gateway could be listed using rsconfig failed.-------------------"
+				echo "---2--------------To test bmc gateway could be listed using rsconfig failed.-------------------"
 				exit 1;
 			fi
 		else
-			echo "-------------------To test bmc gateway could be listed using rspconfig failed.---------------"
+			echo "------------3-------To test bmc gateway could be listed using rspconfig failed.---------------"
 			exit 1;	
 		fi
 		;;
@@ -266,9 +267,9 @@ do
 		fi
 		;;
                 "-ln"|"--list netmask" )
-                output=rpconfig $2 netmask 
+                output=`rspconfig $2 netmask` 
                 if [[ $? -eq 0 ]];then
-                        if [[ $output =~ "$2 BMC Netmask:" ]];then
+                        if [[ $output =~ "$2: BMC Netmask:" ]];then
                                 echo "-------------------To test bmc Netmask could be listed using rspconfig successfully.-----------------"
                                 exit 0;
                         else
@@ -281,7 +282,7 @@ do
                 fi
                 ;;
                 "-v"|"--vlan" )
-                output=rspconfig  $2 vlan
+                output=`rspconfig  $2 vlan`
                 echo "---------------------To test bmc vlan could be changed using rspconfig.--------------------"
                 if [[ $? -eq 0 ]]&&[[ $output =~ "BMC VLAN ID enabled" ]];then
                         BMCVLAN=`rspconfig  $2 vlan |awk -F":" '{print $3}'`
@@ -299,9 +300,9 @@ do
                 fi
                 ;;
                 "-lv"|"--list vlan" )
-                output=rpconfig $2 vlan
+                output=`rspconfig $2 vlan`
                 if [[ $? -eq 0 ]];then
-                        if [[ $output =~ "$2 BMC VLAN ID:" ]];then
+                        if [[ $output =~ "$2: BMC VLAN ID" ]];then
                                 echo "-------------------To test bmc Vlan could be listed using rspconfig successfully.-----------------"
                                 exit 0;
                         else
@@ -324,11 +325,12 @@ do
                 fi
 		;;
 		"-la"|"--list all" )
-		BMCIP_LSDEF=`lsdef $2 |grep bmc |awk -F "=" '{print $2}'`
+		BMCIP_LSDEF=`lsdef $2 |grep "bmc=" |awk -F "=" '{print $2}'`
 		BMCIP=`rspconfig $2 ip |awk -F":" '{print $3}'`
-		output=rspconfig $2 ip gateway netmask vlan
+		output=`rspconfig $2 ip gateway netmask vlan`
 		if [[ $? -eq 0 ]];then
-			if [[ $output =~ "$2 BMC VLAN ID:" ]]&&[[ $output =~ "$2 BMC Netmask:" ]]&&[[ $output =~ "$2 BMC Gateway:" ]]&&[[ $BMCIP =~ "$BMCIP_LSDEF" ]];then 
+			#if [[ $output =~ "BMC VLAN ID:" ]]&&[[ $output =~ "BMC Netmask:" ]]&&[[ $output =~ "BMC Gateway:" ]]&&[[ $BMCIP =~ "$BMCIP_LSDEF" ]];then 
+			if [[ $output =~ "$2: BMC VLAN ID" ]]&&[[ $output =~ "BMC Netmask:" ]]&&[[ $output =~ "BMC Gateway:" ]]&&[[ $BMCIP =~ "$BMCIP_LSDEF" ]];then 
 				echo "------------------To test bmc's all option could be listed using rspconfig succssfully.-----------------"
 				exit 0
 			else


### PR DESCRIPTION
Modify rspconfig testcase to get more debug infor for issue:#3804
Such as some output for the testcase:
------START::rspconfig_set_ip::Time:Wed Sep 13 03:22:27 2017------

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig.sh -i frame45cn05 $NODEIP [Wed Sep 13 03:22:27 2017]
ElapsedTime:46 sec
RETURN rc = 0
OUTPUT:
--------------------Start to test rspconfig change node's bmc ip .--------------------
frame45cn05: BMC IP: 50.45.5.1
Prepare to change node's bmc ip.
Start to check node's bmc original ip valid.
50.45.5.1 is valid
node's bmc original ip is valid.
Start to set node's bmc ip to 50.45.5.2.
frame45cn05: BMC IP: 50.45.5.2
Run  rspconfig frame45cn05 ip=50.45.5.2 and return value is 0.
1 object definitions have been created or modified.
Start to check node's bmc's ip really setted using rspconfig.
frame45cn05: Error: ERROR: timeout
frame45cn05: Error: ERROR: timeout
Node's bmc ip really setted successfully.
--------------------Restult for test rspconfig change node's bmc ip successfully.-------------------
CHECK:rc == 0   [Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig.sh -c frame45cn05 ip [Wed Sep 13 03:23:13 2017]
ElapsedTime:30 sec
RETURN rc = 0
OUTPUT:
--------------------To clear the test envionment.--------------------
Start to clear test environment.
frame45cn05: BMC IP: 50.45.5.1
Run rspconfig frame45cn05 ip=50.45.5.1 and return value is 0.
1 object definitions have been created or modified.
frame45cn05: Error: ERROR: timeout
Node's bmc ip really setted to originip successfully.
--------------------To clear the test environment sucessfully.-----------------
CHECK:rc == 0   [Pass]

------END::rspconfig_set_ip::Passed::Time:Wed Sep 13 03:23:43 2017 ::Duration::76 sec------
------START::rspconfig_set_netmask::Time:Wed Sep 13 03:23:43 2017------

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig.sh -n frame45cn05 netmask [Wed Sep 13 03:23:43 2017]
ElapsedTime:5 sec
RETURN rc = 0
OUTPUT:
frame45cn05: BMC Netmask: 255.0.0.0
---------------------Start to test rspconfig change node's bmc netmask .--------------------
Prepare to change node's bmc netmask.
Start to check node's bmc netmask valid or not.
255.0.0.0 is valid
Start to change bmc's netmask.
frame45cn05: BMC Netmask: 255.0.0.0
Run rspconfig frame45cn05 netmask=255.0.0.0 and return value is 0.
Start to check node's bmc netmask really setted using rspconfig.
Node's bmc netmask really setted successfully.
--------------------Result for rspconfig change node's bmc netmask successfully.-------------------
CHECK:rc == 0   [Pass]

------END::rspconfig_set_netmask::Passed::Time:Wed Sep 13 03:23:48 2017 ::Duration::5 sec------
------START::rspconfig_set_gateway::Time:Wed Sep 13 03:23:48 2017------

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig.sh -g  frame45cn05 gateway [Wed Sep 13 03:23:48 2017]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
--------------------Start to test rspconfig change node's bmc gateway .---------------------
frame45cn05: BMC Gateway: 0.0.0.0
Prepare to change node's bmc gateway.
Start to check node's bmc gateway valid or not.
0.0.0.0 is valid
Start to change bmc's gateway.
frame45cn05: BMC Gateway: 0.0.0.0
Run rspconfig frame45cn05 gateway=0.0.0.0 and return value is 0.
Start to check node's bmc gateway really setted using rspconfig.
Node's bmc gateway really setted successfully.
--------------------Result for test rspconfig change node's bmc gateway successfully.--------------------
CHECK:rc == 0   [Pass]

------END::rspconfig_set_gateway::Passed::Time:Wed Sep 13 03:23:50 2017 ::Duration::2 sec------
