### PR TITLE
Cherry-pick Fix for 3749, handle '+' and '-' in id when merging /etc/passwd

### DIFF
--- a/xCAT-server/share/xcat/scripts/xdcpmerge.sh
+++ b/xCAT-server/share/xcat/scripts/xdcpmerge.sh
@@ -76,7 +76,9 @@ for i in $*; do
     delim="|"
     for u in $removeusers
     do
-      userlist=$userlist$u$delim
+      # For special char +/-, need to escape
+      [[ "${u:0:1}x" =~ ^\+|\-x ]] && uu="\\$u" || uu="$u"
+      userlist=$userlist$uu$delim
     done
     # remove the last delimiter
     userlisttmp="${userlist%?}"


### PR DESCRIPTION
* Fix #3749, handle '+' and '-' in id when merging /etc/passwd