### PR TITLE
Fix a bug that if children process over 32, sleep 1 second

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -686,9 +686,9 @@ sub scan_process {
                 $pipe_map{$child} = $cfd;
             }
 
-            do {
+            while ($children >= 32) {
                 sleep(1);
-            } until ($children < 32);
+            }
         }
         while($children > 0) {
             sleep(1);


### PR DESCRIPTION
#3658 

When run ``bmcdiscover`` against 2000 IPs (500 Hosts UP).
Before change: 
Run ``ps aux | grep bmcdiscover`` could see most 7 bmcdiscover processes at the same time.

After change: could see most 32 processes.