### PR TITLE
Comment KeyFile instead of replacing as key is included in CertFile

### DIFF
--- a/docs/source/advanced/restapi/restapi_setup/restapi_setup.rst
+++ b/docs/source/advanced/restapi/restapi_setup/restapi_setup.rst
@@ -63,7 +63,7 @@ The steps to configure the certificate for https server: ::
     export sslcfgfile=/etc/apache2/sites-enabled/ssl.conf     # ubuntu
 
     sed -i 's/^\(\s*\)SSLCertificateFile.*$/\1SSLCertificateFile \/etc\/xcat\/cert\/server-cred.pem/' $sslcfgfile    
-    sed -i 's/^\(\s*\)SSLCertificateKeyFile.*$/\1SSLCertificateKeyFile \/etc\/xcat\/cert\/server-cred.pem/' $sslcfgfile
+    sed -i 's/^\(\s*SSLCertificateKeyFile.*\)$/#\1/' $sslcfgfile
         
     service httpd restart        # rhel
     service apache2 restart      # sles/ubuntu


### PR DESCRIPTION
Quoting `ssl.conf`:
```
#   Server Private Key:
#   If the key is not combined with the certificate, use this
#   directive to point at the key file.  Keep in mind that if
#   you've both a RSA and a DSA private key you can configure
#   both in parallel (to also allow the use of DSA ciphers, etc.)
```
As the xCAT host SSLCertificateFile already contains the key, the substitution for `SSLCertificateKeyFile` can be changed to simpler one: which just comments it out.