### PR TITLE
Add debug information for isntallation failed case in automation

### DIFF
--- a/xCAT-test/autotest/testcase/installation/customize_sleep_for_sn
+++ b/xCAT-test/autotest/testcase/installation/customize_sleep_for_sn
@@ -1,13 +1,18 @@
 #!/usr/bin/env perl
 
+use File::Basename;
+my $program_name             = basename($0);
+
 my $os   = $ARGV[0];
 my $arch = $ARGV[1];
-my $log  = "/tmp/pre_deploy_sn.log";
+#my $log  = "/tmp/pre_deploy_sn.log";
 
+print ">>>Enter $program_name\n";
 my $orgclusterconffile = "/opt/xcat/share/xcat/tools/autotest/default.conf";
 my $snnodename = `cat $orgclusterconffile |grep -E '^SN\s*='|awk -F'=' '{print \$2}'`;
 chomp($snnodename);
-`echo "SN=$snnodename" >> $log`;
+#`echo "SN=$snnodename" >> $log`;
+print "The target SN = $snnodename\n";
 sleep 300;
 
 my $timecnt = 0;
@@ -18,11 +23,13 @@ while ($timecnt < 120) {
     if ($os =~ /rhel/i && $arch =~ /^ppc64$/i) {
         my $booting = system("lsdef -l $snnodename|grep status|grep booting > /dev/null 2>&1");
         system("xdsh $snnodename \"echo 1\"") if ($booting == 0);
-        `echo "send signal to $snnodename for the $timecnt times" >> $log`;
+        print "send signal to $snnodename for the $timecnt times\n";
+        #`echo "send signal to $snnodename for the $timecnt times" >> $log`;
     }
 
     sleep 30;
     $timecnt++;
 }
 
+print ">>>Leave $program_name\n"; 
 exit 0;

--- a/xCAT-test/autotest/testcase/installation/pre_deploy_sn
+++ b/xCAT-test/autotest/testcase/installation/pre_deploy_sn
@@ -4,15 +4,22 @@ $ENV{TERM} = "xterm-256color";
 
 my $os   = $ARGV[0];
 my $arch = $ARGV[1];
-my $log  = "/tmp/pre_deploy_sn.log";
 
 sub runcmd {
     my $cmd = shift;
-    `$cmd >> $log 2>&1`;
-    if ($?) {
 
-        #print "run $cmd ....[error]\n";
+    my $case_start_time     = timelocal(localtime());
+    my $case_start_time_str = scalar(localtime());
+    print ">>>To run: $cmd  [$case_start_time_str]\n";
+
+    my @output = `$cmd 2>&1`;
+    chomp(@output);
+    print "$_\n" foreach (@output);
+    if ($?) {
+        print ">>>To run $cmd ....[error]\n";
         exit 1;
+    }else{
+        print ">>>To run: $cmd ....[ok]\n";
     }
 }
 


### PR DESCRIPTION
In sles11.4+ppc64 project in automation, sn provision test case always failed recently.
After debug, I found MYSQL was installed twice, but I could not found where triggered the second time MYSQL installation. So add some information for further debug. 