### PR TITLE
Fix 3787, code error when missing -l option for makedhcp in nodeset

### DIFF
--- a/xCAT-server/lib/xcat/plugins/grub2.pm
+++ b/xCAT-server/lib/xcat/plugins/grub2.pm
@@ -816,7 +816,7 @@ sub process_request {
                 if ($request->{'_disparatetftp'}->[0]) { #reading hint from preprocess_command
                     xCAT::MsgUtils->trace($verbose_on_off, "d", "grub2: issue makedhcp request");
                     $sub_req->({ command => ['makedhcp'],
-                            node => \@{ $osimagenodehash{$osimage} } }, $callback);
+                            node => \@{ $osimagenodehash{$osimage} }, arg => ['-l'] }, $callback);
                 } else {
                     xCAT::MsgUtils->trace($verbose_on_off, "d", "grub2: issue makedhcp request");
                     $sub_req->({ command => ['makedhcp'],

--- a/xCAT-server/lib/xcat/plugins/petitboot.pm
+++ b/xCAT-server/lib/xcat/plugins/petitboot.pm
@@ -656,7 +656,7 @@ sub process_request {
         }
         if ($do_dhcpsetup) {
             my @parameter;
-            push @parameter, '-l' if ($::request->{'_disparatetftp'}->[0]);
+            push @parameter, '-l' if ($request->{'_disparatetftp'}->[0]);
             xCAT::MsgUtils->trace($verbose_on_off, "d", "petitboot: issue makedhcp request");
 
             $sub_req->({ command => ['makedhcp'],

--- a/xCAT-server/lib/xcat/plugins/xnba.pm
+++ b/xCAT-server/lib/xcat/plugins/xnba.pm
@@ -711,7 +711,7 @@ sub process_request {
         }
         if ($do_dhcpsetup) {
             my @parameter;
-            push @parameter, '-l' if ($::request->{'_disparatetftp'}->[0]);
+            push @parameter, '-l' if ($::XNBA_request->{'_disparatetftp'}->[0]);
             xCAT::MsgUtils->trace($verbose_on_off, "d", "xnba: issue makedhcp request");
 
             $sub_req->({ command => ['makedhcp'],


### PR DESCRIPTION
To fix #3787, just fix code error there.

UT:  pass
```
nodeset fake1 osimage=rhels7.4-Alpha1-ppc64le-install-compute -V
fake1: [briggs01]: install rhels7.4-Alpha1-ppc64le-compute
fake1: [sn02]: install rhels7.4-Alpha1-ppc64le-compute
fake1: [sn01]: install rhels7.4-Alpha1-ppc64le-compute
```