### PR TITLE
fix issue [FVT]:nodeset against diskless osimage output is not consistent on rhels and sles/ubuntu #3783

### DIFF
--- a/xCAT-server/lib/xcat/plugins/debian.pm
+++ b/xCAT-server/lib/xcat/plugins/debian.pm
@@ -957,6 +957,8 @@ sub mknetboot
     my $xcatdport  = "3001";
     my $xcatiport  = "3002";
     my $nodestatus = "y";
+    my @myself     = xCAT::NetworkUtils->determinehostname();
+    my $myname     = $myself[ (scalar @myself) - 1 ];
 
     if ($sitetab)
     {
@@ -1170,7 +1172,7 @@ sub mknetboot
         if ($statelite) {
             unless (-r "$rootimgdir/kernel") {
                 $callback->({
-                        error => [qq{Did you run "genimage" before running "liteimg"? kernel cannot be found...}],
+                        error => [qq{Did you run "genimage" before running "liteimg"? kernel cannot be found at $rootimgdir/kernel on $myname}],
                         errorcode => [1]
                 });
                 next;
@@ -1197,7 +1199,7 @@ sub mknetboot
         } else {
             unless (-r "$rootimgdir/kernel") {
                 $callback->({
-                        error => [qq{Did you run "genimage" before running "packimage"? kernel cannot be found}],
+                        error => [qq{Did you run "genimage" before running "packimage"? kernel cannot be found at $rootimgdir/kernel on $myname}],
                         errorcode => [1]
                 });
                 next;


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/3783:
 
refine the message of mknetwork



