### PR TITLE
Add Support for rspconfig to set/get hostname of the BMC

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
@@ -47,7 +47,7 @@ OpenBMC specific:
 =================
 
 
-\ **rspconfig**\  \ *noderange*\  {\ **ip | netmask | gateway | vlan | sshcfg**\ }
+\ **rspconfig**\  \ *noderange*\  {\ **ip | netmask | gateway | hostname | vlan | sshcfg**\ }
 
 
 MPA specific:
@@ -391,6 +391,12 @@ OPTIONS
 \ **iocap**\ ={\ **enable**\  | \ **disable**\ }
  
  Select the policy for I/O Adapter Enlarged Capacity. This option controls the size of PCI memory space allocated to each PCI slot.
+ 
+
+
+\ **hostname**\ 
+ 
+ Get or set hostname on the service processor.
  
 
 

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -143,7 +143,7 @@ my %usage = (
        rspconfig <noderange> [garp=<number of 1/2 second>]
        rspconfig <noderange> [userid=<userid> username=<username> password=<password>]
    OpenBMC specific:
-       rspconfig <noderange> [ip|netmask|gateway|vlan]
+       rspconfig <noderange> [ip|netmask|gateway|hostname|vlan]
    iDataplex specific:
        rspconfig <noderange> [thermprofile]
        rspconfig <noderange> [thermprofile=<two digit number from chassis>]

--- a/xCAT-client/pods/man1/rspconfig.1.pod
+++ b/xCAT-client/pods/man1/rspconfig.1.pod
@@ -24,7 +24,7 @@ B<rspconfig> I<noderange> B<garp>=I<time>
 
 =head2 OpenBMC specific:
 
-B<rspconfig> I<noderange> {B<ip>|B<netmask>|B<gateway>|B<vlan>|B<sshcfg>}
+B<rspconfig> I<noderange> {B<ip>|B<netmask>|B<gateway>|B<hostname>|B<vlan>|B<sshcfg>}
 
 =head2 MPA specific:
 
@@ -299,6 +299,10 @@ Set CEC/BPA system names to the names in xCAT DB or the input name.
 =item B<iocap>={B<enable> | B<disable>}
 
 Select the policy for I/O Adapter Enlarged Capacity. This option controls the size of PCI memory space allocated to each PCI slot.
+
+=item B<hostname>
+
+Get or set hostname on the service processor.   
 
 =item B<vlan>
 

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1620,6 +1620,8 @@ sub rspconfig_response {
 
     my $response_info = decode_json $response->content; 
 
+    my $bmc_node = "$node BMC";
+
     if ($node_info{$node}{cur_status} eq "RSPCONFIG_GET_RESPONSE") {
         my $address         = "n/a";
         my $gateway         = "n/a";
@@ -1672,37 +1674,36 @@ sub rspconfig_response {
         }
         else {
             if ($grep_string =~ "ip") {
-                push @output, "BMC IP: $address"; 
+                push @output, "IP: $address"; 
             } 
             if ($grep_string =~ "netmask") {
                 if ($address) {
                     my $decimal_mask = (2 ** $prefix - 1) << (32 - $prefix);
                     my $netmask = join('.', unpack("C4", pack("N", $decimal_mask)));
-                    push @output, "BMC Netmask: " . $netmask; 
+                    push @output, "Netmask: " . $netmask; 
                 }
             } 
             if ($grep_string =~ "gateway") {
-                push @output, "BMC Gateway: $gateway (default: $default_gateway)";
+                push @output, "Gateway: $gateway (default: $default_gateway)";
             }  
             if ($grep_string =~ "vlan") {
-                push @output, "BMC VLAN ID enabled: $vlan";
+                push @output, "VLAN ID enabled: $vlan";
             }
             if ($grep_string =~ "hostname") {
-                push @output, "BMC Hostname: $hostname";
+                push @output, "Hostname: $hostname";
             }
         }
 
-        xCAT::SvrUtils::sendmsg("$_", $callback, $node) foreach (@output);
+        xCAT::SvrUtils::sendmsg("$_", $callback, $bmc_node) foreach (@output);
     }
 
     if ($node_info{$node}{cur_status} eq "RSPCONFIG_SET_RESPONSE") {
         if ($response_info->{'message'} eq $::RESPONSE_OK) {
-            xCAT::SvrUtils::sendmsg("Setting BMC Hostname (requires bmcreboot to take effect)...", $callback, $node);
+            xCAT::SvrUtils::sendmsg("Setting Hostname (requires bmcreboot to take effect)...", $callback, $bmc_node);
         }
     }
     if ($node_info{$node}{cur_status} eq "RSPCONFIG_DHCP_RESPONSE") {
         if ($response_info->{'message'} eq $::RESPONSE_OK) {
-            my $bmc_node = "$node BMC";
             xCAT::SvrUtils::sendmsg("Setting IP to DHCP...", $callback, $bmc_node);
         }
     }

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -560,10 +560,6 @@ sub parse_args {
             return ([ 1, "Unsupported command: $command $subcommand" ]);
         }
     } elsif ($command eq "rspconfig") {
-        #
-        # disable function until fully tested
-        #
-        $check = unsupported($callback); if (ref($check) eq "ARRAY") { return $check; }
         my $setorget;
         foreach $subcommand (@ARGV) {
             if ($subcommand =~ /^(\w+)=(.*)/) {
@@ -582,10 +578,22 @@ sub parse_args {
                     }
                 }
                 $setorget = "set";
+                #
+                # disable function until fully tested
+                #
+                unless ($key eq "ip" or !($subcommand =~ /^hostname$/)) {
+                    $check = unsupported($callback); if (ref($check) eq "ARRAY") { return $check; }
+                }
                 if (ref($check) eq "ARRAY") { return $check; }
             } elsif ($subcommand =~ /^ip$|^netmask$|^gateway$|^hostname$|^vlan$/) {
                 return ([ 1, "Can not configure and display nodes' value at the same time" ]) if ($setorget and $setorget eq "set");
                 $setorget = "get";
+                #
+                # disable function until fully tested
+                #
+                unless ($subcommand =~ /^hostname$/) {
+                    $check = unsupported($callback); if (ref($check) eq "ARRAY") { return $check; }
+                }
                 if (ref($check) eq "ARRAY") { return $check; }
             } elsif ($subcommand =~ /^sshcfg$/) {
                 $setorget = ""; # SSH Keys are copied using a RShellAPI, not REST API

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -583,7 +583,7 @@ sub parse_args {
                 }
                 $setorget = "set";
                 if (ref($check) eq "ARRAY") { return $check; }
-            } elsif ($subcommand =~ /^ip$|^netmask$|^gateway$|^vlan$/) {
+            } elsif ($subcommand =~ /^ip$|^netmask$|^gateway$|^hostname$|^vlan$/) {
                 return ([ 1, "Can not configure and display nodes' value at the same time" ]) if ($setorget and $setorget eq "set");
                 $setorget = "get";
                 if (ref($check) eq "ARRAY") { return $check; }
@@ -794,7 +794,7 @@ sub parse_command_status {
     if ($command eq "rspconfig") {
         my @options = ();
         foreach $subcommand (@$subcommands) {
-            if ($subcommand =~ /^ip$|^netmask$|^gateway$|^vlan$/) {
+            if ($subcommand =~ /^ip$|^netmask$|^gateway$|^hostname$|^vlan$/) {
                 $next_status{LOGIN_RESPONSE} = "RSPCONFIG_GET_REQUEST";
                 $next_status{RSPCONFIG_GET_REQUEST} = "RSPCONFIG_GET_RESPONSE";
                 push @options, $subcommand;
@@ -1615,6 +1615,7 @@ sub rspconfig_response {
         my $gateway         = "n/a";
         my $prefix          = "n/a";
         my $vlan            = "n/a";
+        my $hostname        = "";
         my $default_gateway = "n/a";
         my $adapter_id      = "n/a";
         my $error;
@@ -1627,6 +1628,9 @@ sub rspconfig_response {
             if ($key_url =~ /network\/config/) {
                 if (defined($content{DefaultGateway}) and $content{DefaultGateway}) {
                     $default_gateway = $content{DefaultGateway};
+                }
+                if (defined($content{HostName}) and $content{HostName}) {
+                    $hostname = $content{HostName};
                 }
             }
 
@@ -1672,6 +1676,9 @@ sub rspconfig_response {
             }  
             if ($grep_string =~ "vlan") {
                 push @output, "BMC VLAN ID enabled: $vlan";
+            }
+            if ($grep_string =~ "hostname") {
+                push @output, "BMC Hostname: $hostname";
             }
         }
 

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1221,8 +1221,7 @@ sub rpower_response {
     if ($node_info{$node}{cur_status} eq "RPOWER_RESET_RESPONSE") {
         if ($response_info->{'message'} eq $::RESPONSE_OK) {
             if (defined $status_info{RPOWER_RESET_RESPONSE}{argv} and $status_info{RPOWER_RESET_RESPONSE}{argv} =~ /bmcreboot$/) {
-                my $bmc_node = "$node BMC";
-                xCAT::SvrUtils::sendmsg("$::POWER_STATE_REBOOT", $callback, $bmc_node);
+                xCAT::SvrUtils::sendmsg("BMC $::POWER_STATE_REBOOT", $callback, $node);
             } else {
                 xCAT::SvrUtils::sendmsg("$::POWER_STATE_RESET", $callback, $node);
             }
@@ -1262,9 +1261,8 @@ sub rpower_response {
         xCAT::SvrUtils::sendmsg("$flag_debug State RequestedHostTransition=$host_transition_state", $callback, $node) if ($xcatdebugmode);
 
         if (defined $status_info{RPOWER_STATUS_RESPONSE}{argv} and $status_info{RPOWER_STATUS_RESPONSE}{argv} =~ /bmcstate$/) { 
-            my $bmc_node = "$node BMC";
             my $bmc_short_state = (split(/\./, $bmc_state))[-1];
-            xCAT::SvrUtils::sendmsg($bmc_short_state, $callback, $bmc_node);
+            xCAT::SvrUtils::sendmsg("BMC $bmc_short_state", $callback, $node);
         } else {
             if ($chassis_state =~ /Off$/) {
                 xCAT::SvrUtils::sendmsg("$::POWER_STATE_OFF", $callback, $node);
@@ -1628,8 +1626,6 @@ sub rspconfig_response {
 
     my $response_info = decode_json $response->content; 
 
-    my $bmc_node = "$node BMC";
-
     if ($node_info{$node}{cur_status} eq "RSPCONFIG_GET_RESPONSE") {
         my $address         = "n/a";
         my $gateway         = "n/a";
@@ -1682,37 +1678,37 @@ sub rspconfig_response {
         }
         else {
             if ($grep_string =~ "ip") {
-                push @output, "IP: $address"; 
+                push @output, "BMC IP: $address"; 
             } 
             if ($grep_string =~ "netmask") {
                 if ($address) {
                     my $decimal_mask = (2 ** $prefix - 1) << (32 - $prefix);
                     my $netmask = join('.', unpack("C4", pack("N", $decimal_mask)));
-                    push @output, "Netmask: " . $netmask; 
+                    push @output, "BMC Netmask: " . $netmask; 
                 }
             } 
             if ($grep_string =~ "gateway") {
-                push @output, "Gateway: $gateway (default: $default_gateway)";
+                push @output, "BMC Gateway: $gateway (default: $default_gateway)";
             }  
             if ($grep_string =~ "vlan") {
-                push @output, "VLAN ID enabled: $vlan";
+                push @output, "BMC VLAN ID enabled: $vlan";
             }
             if ($grep_string =~ "hostname") {
-                push @output, "Hostname: $hostname";
+                push @output, "BMC Hostname: $hostname";
             }
         }
 
-        xCAT::SvrUtils::sendmsg("$_", $callback, $bmc_node) foreach (@output);
+        xCAT::SvrUtils::sendmsg("$_", $callback, $node) foreach (@output);
     }
 
     if ($node_info{$node}{cur_status} eq "RSPCONFIG_SET_RESPONSE") {
         if ($response_info->{'message'} eq $::RESPONSE_OK) {
-            xCAT::SvrUtils::sendmsg("Setting Hostname (requires bmcreboot to take effect)...", $callback, $bmc_node);
+            xCAT::SvrUtils::sendmsg("BMC Setting Hostname (requires bmcreboot to take effect)...", $callback, $node);
         }
     }
     if ($node_info{$node}{cur_status} eq "RSPCONFIG_DHCP_RESPONSE") {
         if ($response_info->{'message'} eq $::RESPONSE_OK) {
-            xCAT::SvrUtils::sendmsg("Setting IP to DHCP...", $callback, $bmc_node);
+            xCAT::SvrUtils::sendmsg("BMC Setting IP to DHCP...", $callback, $node);
         }
     }
 


### PR DESCRIPTION
Last commit Resolves #3295 

The hostname is contained in the `network/config` endpoint: 

```
[root@briggs01 mid05tor12cn05]# ./list.sh
+ curl -c cjar -b cjar -k -H 'Content-Type: application/json' -X GET https://172.11.140.5/xyz/openbmc_project/network/enumerate
{
  "data": {
    "/xyz/openbmc_project/network/config": {
      "DefaultGateway": "172.11.254.2",
      "HostName": "witherspoon"
    }
```

In this PR, I've added support for GET and SET of hostname using `rspconfig`.  

Externals:
```
rspconfig <noderange> hostname
rspconfig <noderange> hostname=f6u5-bmc
```

Here's what it looks like when executed: 



### GET
```
[root@briggs01 mid05tor12cn05]# rspconfig node-70e28414280d hostname
node-70e28414280d: BMC Hostname: witherspoon
```

On BMC: 
```
# cat /etc/hostname
witherspoon
```

### SET
```
[root@briggs01 mid05tor12cn05]# rspconfig node-70e28414280d hostname=abc123
node-70e28414280d: Setting BMC Hostname (requires bmcreboot to take effect)...
node-70e28414280d: BMC Hostname: abc123
```

On BMC:
```
# cat /etc/hostname
abc123
```

