### PR TITLE
Add missing dependency package for pre_deploy_sn used by SN setup test case

### DIFF
--- a/xCAT-test/autotest/testcase/installation/pre_deploy_sn
+++ b/xCAT-test/autotest/testcase/installation/pre_deploy_sn
@@ -1,4 +1,5 @@
 #!/usr/bin/env perl
+use Time::Local;
 
 $ENV{TERM} = "xterm-256color";
 
@@ -16,10 +17,10 @@ sub runcmd {
     chomp(@output);
     print "$_\n" foreach (@output);
     if ($?) {
-        print ">>>To run $cmd ....[error]\n";
+        print ">>>Run $cmd ....[error]\n";
         exit 1;
     }else{
-        print ">>>To run: $cmd ....[ok]\n";
+        print ">>>Run: $cmd ....[ok]\n";
     }
 }
 


### PR DESCRIPTION
In last day fix #3784, missed dependency package. Add it in this pull request. 