### PR TITLE
Modify the matching condition of test case rmimage_diskless

### DIFF
--- a/xCAT-test/autotest/testcase/rmimage/case0
+++ b/xCAT-test/autotest/testcase/rmimage/case0
@@ -21,6 +21,6 @@ check:output=~Removing directory /tftpboot/xcat/osimage/__GETNODEATTR($$CN,os)__
 check:output=~Image files have been removed successfully from this management node.
 cmd:nodeset $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc!=0
-check:output=~kernel cannot be found at /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/kernel
+check:output=~kernel cannot be found
 cmd:ls /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute.bak/;if [ $? -eq 0 ];then mv -f /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute.bak /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute;fi
 end


### PR DESCRIPTION
Due to the output of ``nodeset`` are different between SLES, RHEL and UBUNTU. 
It is lower priority for developer to unified the output, so change the matching condition of test case ``rmimage_diskless`` first. 