### PR TITLE
add log for hardware discovery when no ip address can be resolved for…

### DIFF
--- a/xCAT-server/lib/xcat/plugins/nodediscover.pm
+++ b/xCAT-server/lib/xcat/plugins/nodediscover.pm
@@ -313,7 +313,7 @@ sub process_request {
                             push @hostnames_to_update, $hosttag;
                         }
                         elsif (!inet_aton($node)) {
-                            xCAT::MsgUtils->message("S", "xcat.discovery.nodediscover: Can not resolve IP for the matching node:$node, please makesure \"makehost $node\" and \"makedns $node\" have run before starting hardware discovery.");
+                            xCAT::MsgUtils->message("S", "xcat.discovery.nodediscover: Can not resolve IP for the matching node:$node. Make sure \"makehosts\" and \"makedns\" have been run for $node.");
                         }
                     }
                     #print Dumper($hosttag) . "\n";

--- a/xCAT-server/lib/xcat/plugins/nodediscover.pm
+++ b/xCAT-server/lib/xcat/plugins/nodediscover.pm
@@ -312,6 +312,9 @@ sub process_request {
                             $hosttag = "$node-$ifinfo[1]";
                             push @hostnames_to_update, $hosttag;
                         }
+                        elsif (!inet_aton($node)) {
+                            xCAT::MsgUtils->message("S", "xcat.discovery.nodediscover: Can not resolve IP for the matching node:$node, please makesure \"makehost $node\" and \"makedns $node\" have run before starting hardware discovery.");
+                        }
                     }
                     #print Dumper($hosttag) . "\n";
                     if ($hosttag) {


### PR DESCRIPTION
… the pre-defined node

The following log will be added in /var/log/xcat/cluster.log with this fix:
```
Aug 31 05:59:14 briggs01 xcat[22442]: xcat.discovery.nodediscover: Can not resolve IP for the matching node:<pre-defined-node>, please makesure "makehost <pre-defined-node>" and "makedns <pre-defined-node>" have run before starting hardware discovery.
```