### PR TITLE
Task 3808, ignore transition state until get stable firmware for rpower state

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1284,9 +1284,10 @@ sub rpower_response {
                 if ($host_state =~ /Off$/) {
                     # State is off, but check if it is transitioning
                     if ($host_transition_state =~ /On$/) {
-                        xCAT::SvrUtils::sendmsg("$::POWER_STATE_POWERING_ON", $callback, $node);
-                    }
-                    else {
+                        #xCAT::SvrUtils::sendmsg("$::POWER_STATE_POWERING_ON", $callback, $node);
+                        # ignore transition state until get stable firmware
+                        xCAT::SvrUtils::sendmsg("$::POWER_STATE_OFF", $callback, $node);
+                    } else {
                         xCAT::SvrUtils::sendmsg("$::POWER_STATE_OFF", $callback, $node);
                     }
                 } elsif ($host_state =~ /Quiesced$/) {
@@ -1294,9 +1295,10 @@ sub rpower_response {
                 } elsif ($host_state =~ /Running$/) {
                     # State is on, but check if it is transitioning
                     if ($host_transition_state =~ /Off$/) {
-                        xCAT::SvrUtils::sendmsg("$::POWER_STATE_POWERING_OFF", $callback, $node);
-                    }
-                    else {
+                        #xCAT::SvrUtils::sendmsg("$::POWER_STATE_POWERING_OFF", $callback, $node);
+                        # ignore transition state until get stable firmware
+                        xCAT::SvrUtils::sendmsg("$::POWER_STATE_ON", $callback, $node);
+                    } else {
                         xCAT::SvrUtils::sendmsg("$::POWER_STATE_ON", $callback, $node);
                     }
                 } else {


### PR DESCRIPTION
#3808 

After modified:
Whatever the host transition state is, if the host state if off, print ``off``. If the host state is on, print ``on``.

If we get the stable firmware version, will modify to before, so did not modify the code logic.