### PR TITLE
Fix Updatenode returncode

### DIFF
--- a/xCAT-server/lib/xcat/plugins/updatenode.pm
+++ b/xCAT-server/lib/xcat/plugins/updatenode.pm
@@ -1791,11 +1791,17 @@ sub updatenodesyncfiles
         if ($request->{SNFileSyncing}->[0] eq "yes") {
             my $rsp = {};
             $rsp->{data}->[0] = "File synchronization has completed for service nodes.";
+            if (@::FAILEDNODES) {
+                $rsp->{errorcode}->[0] = 1;
+            }
             $callback->($rsp);
         }
         if ($request->{FileSyncing}->[0] eq "yes") {
             my $rsp = {};
             $rsp->{data}->[0] = "File synchronization has completed for nodes.";
+            if (@::FAILEDNODES) {
+                $rsp->{errorcode}->[0] = 1;
+            }
             $callback->($rsp);
         }
     }


### PR DESCRIPTION
Fix #3737 when some nodes is failed when file syncing, the updatenode will return non-zero. 

UT:
```
# updatenode sn02 -F
sn02: rsync: link_stat "/tmp/non-existent" failed: No such file or directory (2)
sn02: rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1052) [sender=3.0.9]
File synchronization has completed for nodes with error.
[root@briggs01 ~]# echo $?
1
```