### PR TITLE
Remove the call to logger before rsyslog is started in Genesis doxcat 

### DIFF
--- a/xCAT-genesis-scripts/bin/doxcat
+++ b/xCAT-genesis-scripts/bin/doxcat
@@ -8,8 +8,6 @@ log_label="xcat.genesis.doxcat"
 # Start rsyslogd and log into a local file specified in /etc/rsyslog.conf
 # Later, once xCAT MN is known, dhclient-script will change 
 # rsyslog.conf file to send log entries to xCAT MN
-logger -s -t $log_label -p local4.info "Starting syslog..."
-ls /var/run/
 RSYSLOGD_VERSION=`rsyslogd -v | grep "rsyslogd" | cut -d" " -f2 | cut -d"." -f1`
 
 # if syslog is running and there's a pid file, kill it before restarting syslogd


### PR DESCRIPTION
This was introduced in PR #1366, but removing the lines to clean up the messages that appear in Genesis

The output when Genesis runs is the following: 
```
logger: socket /dev/log: No such file or directory
initramfs  lock  log  mount  screen  udev         
<166>Aug 30 22:17:21 xcat.genesis.doxcat: Beginning doxcat process...
Done                                                      
```

* The first is caused by logger being called before syslog is started
* The second is listing out /var/run.  I'm not sure why I added that, but I don't think there's any value to printing that out...

