### PR TITLE
fix issue 3809: doxcat can not deal with destiny osimage

### DIFF
--- a/xCAT-genesis-scripts/bin/doxcat
+++ b/xCAT-genesis-scripts/bin/doxcat
@@ -355,6 +355,10 @@ while :; do
 		logger -s -t $log_label -p local4.info "Running nextdestiny $XCATMASTER:$XCATPORT..."
 		/bin/nextdestiny $XCATMASTER:$XCATPORT      
 		logger -s -t $log_label -p local4.info "nextdestiny - Complete."
+        elif [ "$dest" = osimage ]; then
+		logger -s -t $log_label -p local4.info "Running nextdestiny $XCATMASTER:$XCATPORT..."
+		destiny=`/bin/nextdestiny $XCATMASTER:$XCATPORT`
+		logger -s -t $log_label -p local4.info "nextdestiny - Complete."
 	elif [ "$dest" = runcmd ]; then
 		logger -s -t $log_label -p local4.info "Running nextdestiny $XCATMASTER:$XCATPORT..."
 		destiny=`/bin/nextdestiny $XCATMASTER:$XCATPORT`


### PR DESCRIPTION
Fix issue #3809 

With the fix, the console looks like this right now: 

```
<166>Aug 31 05:25:08 xcat.genesis.doxcat: The destiny=osimage, destiny parameters=rhels7.4-Alpha1-ppc64le-netboot-compute-mlnx
<166>Aug 31 05:25:08 xcat.genesis.doxcat: Running nextdestiny 172.12.253.27:3001...  
                    ===> If destiny=osimage, will run nextdestiny to do OS deployment
<166>Aug 31 05:25:08 xcat.genesis.doxcat: nextdestiny - Complete.
<166>Aug 31 05:25:08 xcat.genesis.doxcat: The destiny=error, destiny parameters=Did you run &quot;genimage&quot; before running &quot;packimage&quot;? kernel cannot be found at /install/custom/rhels7.4-Alpha1-ppc64le-netboot-compute-mlnx/compute/kernel on briggs01.pok.stglabs.ibm.com
<166>Aug 31 05:25:08 xcat.genesis.doxcat: Did you run &quot;genimage&quot; before running &quot;packimage&quot;? kernel cannot be found at /install/custom/rhels7.4-Alpha1-ppc64le-netboot-compute-mlnx/compute/kernel on briggs01.pok.stglabs.ibm.com
<166>Aug 31 05:25:13 xcat.genesis.doxcat: ... Will retry xCAT in 250 seconds
...
<166>Aug 31 05:29:13 xcat.genesis.doxcat: ... Will retry xCAT in 10 seconds
<166>Aug 31 05:29:23 xcat.genesis.doxcat: Running getdestiny --> 172.12.253.27:3001

<166>Aug 31 05:29:24 xcat.genesis.doxcat: Received destiny=osimage=rhels7.4-Alpha1-ppc64le-netboot-compute-mlnx
<166>Aug 31 05:29:24 xcat.genesis.doxcat: The destiny=osimage, destiny parameters=rhels7.4-Alpha1-ppc64le-netboot-compute-mlnx
<166>Aug 31 05:29:24 xcat.genesis.doxcat: Running nextdestiny 172.12.253.27:3001...

<166>Aug 31 05:29:25 xcat.genesis.doxcat: nextdestiny - Complete.
<166>Aug 31 05:29:25 xcat.genesis.doxcat: The destiny=netboot, destiny parameters=netboot rhels7.4-Alpha1-ppc64le-compute
Set Boot Device to pxe
<166>Aug 31 05:29:25 xcat.genesis.doxcat: Reboot...
Rebooting.
```