### PR TITLE
Do not dispay firmware entry if no Version attribute

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1910,6 +1910,10 @@ sub rflash_response {
             if (defined($content{Version}) and $content{Version}) {
                 $update_version = $content{Version};
             }
+            else {
+                # Entry has no Version attribute, skip listing it
+                next;
+            }
             if (defined($content{Activation}) and $content{Activation}) {
                 $update_activation = (split(/\./, $content{Activation}))[ -1 ];
             }


### PR DESCRIPTION
When listing openbmc firmware updates with `rflash <node> -l`, do not display entries that do not have "Version" attribute.

This is done to avoid displaying entries returned by `software/enumerate` which are not firmware images, like the newly introduced:
```
"/xyz/openbmc_project/software/32f129cd/activation": {
      "endpoints": [
        "/xyz/openbmc_project/inventory/system/chassis"
      ]
},
```