### PR TITLE
Fix bug #3737 in automation environment

### DIFF
--- a/xCAT-test/autotest/testcase/updatenode/cases3
+++ b/xCAT-test/autotest/testcase/updatenode/cases3
@@ -6,6 +6,8 @@ cmd:echo "/tmp/non-existent -> /etc/motd" > /install/custom/install/__GETNODEATT
 check:rc==0
 cmd:chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute synclists=/install/custom/install/__GETNODEATTR($$CN,os)__/booboo.synclist
 check:rc==0
+cmd:nodeset $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+check:rc==0
 cmd:updatenode $$CN -F >/tmp/updatenode.F.out
 check:rc!=0
 cmd:grep '"/tmp/non-existent" failed: No such file or directory' /tmp/updatenode.F.out


### PR DESCRIPTION
For bug #3737.

In automation environment, test case ``updatenode_diskful_syncfiles_failing`` is run after test case ``rmimage_diskless``. 

In test case ``rmimage_diskless``, it changed `` provmethod`` of ``$$CN`` to another value, not the ``__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute``. So when ``updatenode_diskful_syncfiles_failing`` run, it does not work as expected. 

It is also a defect of ``updatenode_diskful_syncfiles_failing`` itself, so fix defect in this pull request.