### PR TITLE
Fix for [PCM]Sequence disordered when synchronizing /etc/passwd that has special characters

### DIFF
--- a/perl-xCAT/xCAT/CFMUtils.pm
+++ b/perl-xCAT/xCAT/CFMUtils.pm
@@ -184,7 +184,7 @@ sub updateUserInfo {
 
         # update the merge file
         my $mergefile = $cfmdir . "/" . $file . ".merge";
-        my @diff = xCAT::CFMUtils->arrayops("D", \@newrecords, \@oldrecords);
+        my @diff = xCAT::CFMUtils->arrayops("D", \@newrecords, \@oldrecords, 1);
 
         # output the diff to merge files
         my $fp;
@@ -865,6 +865,7 @@ sub trim {
       $flag - "U"/"I"/"D"
       \@array1 - reference to an arrary
       \@array2 - reference to an arrary
+      $odered -  flag to keep pervious order
     Returns:
       @union/@intersection/@difference
     Globals:
@@ -878,7 +879,7 @@ sub trim {
 
 #-----------------------------------------------------------------------------
 sub arrayops {
-    my ($class, $ops, $array1, $array2) = @_;
+    my ($class, $ops, $array1, $array2, $ordered) = @_;
 
     my @union        = ();
     my @intersection = ();
@@ -886,21 +887,23 @@ sub arrayops {
     my %count        = ();
     foreach my $element (@$array1, @$array2)
     {
-        $count{$element}++
+        $count{$element}++;
+        push @union, $element unless ( $count{$element} > 1 );
     }
 
-    foreach my $element (keys %count) {
-        push @union, $element;
+    unless( defined($ordered) and $ordered ) {
+        @union = keys %count;
+    }
+
+    foreach my $element (@union) {
         push @{ $count{$element} > 1 ? \@intersection : \@difference }, $element;
     }
-
     if ($ops eq "U") { return @union; }
 
     if ($ops eq "I") { return @intersection; }
 
     if ($ops eq "D") { return @difference; }
 
-    #return (\@union, \@intersection, \@difference);
 }
 
 


### PR DESCRIPTION
Fix #3827, add a flag to `arrayops` to keep the order of result so thatthe user info in generated passwd.merge file could be kept the previous order.


UT: Passed on PCM internal environment.
Before patch:
```
cat /install/osimages/rhels7.2-x86_64-stateful-compute/cfmdir/etc/passwd.merge
+@p8users::::::
lsfadmin:x:30498:30498::/home/lsfadmin:/bin/bash
+:*:::::/sbin/nologin
mysql:x:27:27:MariaDB Server:/var/lib/mysql:/sbin/nologin
advocate:x:993:989:Advocate:/opt/IBM/advocate:/sbin/nologin
nscd:x:28:28:NSCD Daemon:/:/sbin/nologin
adit:x:30497:30497::/home/adit:/bin/bash
+@sysadmins::::::
nslcd:x:65:55:LDAP Client User:/:/sbin/nologin
pcmadmin:x:30496:30496:Spectrum Cluster Foundation Server:/var/lib/pcmadmin:/bin/sh
```
After patch:
```
[root@pcm19 xcat]# cat /install/osimages/rhels7.2-x86_64-stateful-compute/cfmdir/etc/passwd.merge
pcmadmin:x:30496:30496:Spectrum Cluster Foundation Server:/var/lib/pcmadmin:/bin/sh
adit:x:30497:30497::/home/adit:/bin/bash
nscd:x:28:28:NSCD Daemon:/:/sbin/nologin
nslcd:x:65:55:LDAP Client User:/:/sbin/nologin
lsfadmin:x:30498:30498::/home/lsfadmin:/bin/bash
mysql:x:27:27:MariaDB Server:/var/lib/mysql:/sbin/nologin
advocate:x:993:989:Advocate:/opt/IBM/advocate:/sbin/nologin
+@sysadmins::::::
+@p8users::::::
+:*:::::/sbin/nologin
```