### PR TITLE
Adjust the order of nodeset_disjointdhcps_petitboot in daily regression bundles

### DIFF
--- a/xCAT-test/autotest/bundle/rhels7.4_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.4_ppc64le.bundle
@@ -149,7 +149,6 @@ noderm_null
 noderm_err_node
 nodeset_stat
 nodeset_noderange
-nodeset_disjointdhcps_petitboot
 nodeset_shell_incorrectmasterip
 nodestat_err_node
 rinv_noderange_err
@@ -343,6 +342,7 @@ reg_linux_diskfull_installation_hierarchy
 reg_linux_diskless_installation_hierarchy
 reg_linux_statelite_installation_hierarchy_by_ramdisk
 reg_linux_statelite_installation_hierarchy_by_nfs
+nodeset_disjointdhcps_petitboot
 redhat_migration1
 redhat_migration2
 clean_up_env

--- a/xCAT-test/autotest/bundle/sles12.2_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/sles12.2_ppc64le.bundle
@@ -255,7 +255,6 @@ mkdef_regex_nicsip
 nodeset_errorcommand
 nodeset_grub2
 nodeset_petitboot
-nodeset_disjointdhcps_petitboot
 nodeset_shell_incorrectmasterip
 nodestat_usage
 rmimage_diskless
@@ -270,4 +269,5 @@ reg_linux_diskfull_installation_hierarchy
 reg_linux_diskless_installation_hierarchy
 reg_linux_statelite_installation_hierarchy_by_ramdisk
 reg_linux_statelite_installation_hierarchy_by_nfs
+nodeset_disjointdhcps_petitboot
 clean_up_env

--- a/xCAT-test/autotest/bundle/ubuntu14.04.4_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu14.04.4_ppc64le.bundle
@@ -116,7 +116,6 @@ noderm_null
 noderm_err_node
 nodeset_stat
 nodeset_noderange
-nodeset_disjointdhcps_petitboot
 nodeset_shell_incorrectmasterip
 nodestat_err_node
 rmdef_null

--- a/xCAT-test/autotest/bundle/ubuntu16.04.1_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu16.04.1_ppc64le.bundle
@@ -117,7 +117,6 @@ noderm_null
 noderm_err_node
 nodeset_stat
 nodeset_noderange
-nodeset_disjointdhcps_petitboot
 nodeset_shell_incorrectmasterip
 nodestat_err_node
 rmdef_null


### PR DESCRIPTION
Due to ``nodeset_disjointdhcps_petitboot`` needs hierarchy environment, so move this case after SN setup. Due to there are not hierarchy in ubuntu environments, so delete this case from ubuntu.