### PR TITLE
fix confignetwork_static_installnic failure on ubuntu

### DIFF
--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -534,8 +534,7 @@ elif [ "$1" = "-s" ];then
 		parse_nic_extra_params "$str_extra_params"
 	fi 
 
-    # Bring the interface down before cofniguring the interface
-    ifdown $str_inst_nic
+    # cofniguring the interface
 
     if [ -f "/etc/debian_version" ];then
         str_conf_file="/etc/network/interfaces.d/${str_inst_nic}"
@@ -641,7 +640,7 @@ elif [ "$1" = "-s" ];then
         fi
     fi
 
-    ifup $str_inst_nic
+    ifdown $str_inst_nic;ifup $str_inst_nic
     if [ $? -ne 0 ]; then
         log_error "ifup $str_inst_nic failed."
         error_code=1


### PR DESCRIPTION
fix #3845 

Restarting nics operation should be executed after all configure files are ready.

Unit test is to run all install/second nics related test cases on autotest rh7.4 and ubuntu16.04 ppc64el env, all are passed.

RH7.4 PPC64EL:
```
[root@c910f03c11k12 result]# cat xcattest.log.20170905042331 |grep confignetwork|grep END
------END::confignetwork_static_installnic::Passed::Time:Tue Sep  5 04:25:54 2017 ::Duration::139 sec------
------END::confignetwork_s_installnic_secondarynic_updatenode::Passed::Time:Tue Sep  5 04:26:11 2017 ::Duration::17 sec------
------END::confignetwork_secondarynic_updatenode::Passed::Time:Tue Sep  5 04:26:20 2017 ::Duration::9 sec------
------END::confignetwork_secondarynic_nicaliases_updatenode::Passed::Time:Tue Sep  5 04:26:32 2017 ::Duration::12 sec------
------END::confignetwork_secondarynic_nicextraparams_updatenode::Passed::Time:Tue Sep  5 04:26:53 2017 ::Duration::21 sec------
------END::confignetwork_disable_set_to_yes::Passed::Time:Tue Sep  5 04:26:58 2017 ::Duration::5 sec------
------END::confignetwork_disable_set_to_1::Passed::Time:Tue Sep  5 04:27:03 2017 ::Duration::5 sec------
------END::confignetwork_niccustomscripts::Passed::Time:Tue Sep  5 04:27:10 2017 ::Duration::7 sec------
------END::confignetwork_secondarynic_thirdnic_multiplevalue_updatenode::Passed::Time:Tue Sep  5 04:27:26 2017 ::Duration::16 sec------
------END::confignetwork_secondarynic_nicnetworks_updatenode_false::Passed::Time:Tue Sep  5 04:27:31 2017 ::Duration::5 sec------
------END::confignetwork_secondarynic_nicips_updatenode_false::Passed::Time:Tue Sep  5 04:27:35 2017 ::Duration::4 sec------
------END::confignetwork_secondarynic_nictype_updatenode_false::Passed::Time:Tue Sep  5 04:27:40 2017 ::Duration::5 sec------
```
ubuntu16.04 ppc64el:
```
t# cat xcattest.log.20170905043950 |grep END
------END::confignetwork_s_installnic_secondarynic_updatenode::Passed::Time:Tue Sep  5 04:40:15 2017 ::Duration::21 sec------
------END::confignetwork_secondarynic_updatenode::Passed::Time:Tue Sep  5 04:40:27 2017 ::Duration::12 sec------
------END::confignetwork_secondarynic_nicaliases_updatenode::Passed::Time:Tue Sep  5 04:40:42 2017 ::Duration::15 sec------
------END::confignetwork_secondarynic_nicextraparams_updatenode::Passed::Time:Tue Sep  5 04:41:02 2017 ::Duration::20 sec------
------END::confignetwork_secondarynic_nicnetworks_updatenode_false::Passed::Time:Tue Sep  5 04:41:08 2017 ::Duration::6 sec------
------END::confignetwork_secondarynic_nicips_updatenode_false::Passed::Time:Tue Sep  5 04:41:14 2017 ::Duration::6 sec------
------END::confignetwork_secondarynic_nictype_updatenode_false::Passed::Time:Tue Sep  5 04:41:20 2017 ::Duration::6 sec------
------END::confignetwork_static_installnic::Passed::Time:Tue Sep  5 04:41:38 2017 ::Duration::18 sec------
```
