### PR TITLE
xcatprobe nodecheck verify if any nodes at all

### DIFF
--- a/xCAT-probe/subcmds/nodecheck
+++ b/xCAT-probe/subcmds/nodecheck
@@ -92,10 +92,10 @@ sub check_for_duplicate_mtms_sn {
     chomp($all_nodes_mtm_serial);
     my @all_nodes_mtm_serial_lines = split("[\n\r]", $all_nodes_mtm_serial);
 
-    if ($all_nodes_mtm_serial =~ /Usage:/) {
+    if ($all_nodes_mtm_serial =~ /Usage:|Could not find any object definitions to display/) {
 
-        # lsdef command displayed a Usage message. Must be some noderange formatting problem.
-        # Issue a warning and exit.
+        # lsdef command displayed a Usage message. Must be some noderange formatting problem,
+        # or no nodes defined at all. Issue a warning and exit.
         probe_utils->send_msg("$output", "w", "Can not get a list of nodes from specified noderange.");
         return 1;
     }


### PR DESCRIPTION
Fixes issue #3834 

Add an extra check for the output of `lsdef` command to catch a case when there are no nodes defined:

```
[root@fs2vm111 subcmds]# lsdef
Could not find any object definitions to display.
[root@fs2vm111 subcmds]#
```

```
[root@fs2vm111 subcmds]# xcatprobe nodecheck
Can not get a list of nodes from specified noderange.                                         [WARN]
[root@fs2vm111 subcmds]#
```