### PR TITLE
Support syslog for Cumulus Switch

### DIFF
--- a/xCAT-server/share/xcat/scripts/configonie
+++ b/xCAT-server/share/xcat/scripts/configonie
@@ -176,7 +176,7 @@ sub config_ssh {
         $rc= xCAT::Utils->runcmd($cmd, 0);
         print "ssh configured for $csw\n";
         if ($::ALL) {
-            $cmd = "updatenode $csw -P hardeths,enablesnmp,configinterface";
+            $cmd = "updatenode $csw -P hardeths,syslog,enablesnmp,configinterface";
             $rc= xCAT::Utils->runcmd($cmd, 0); 
             if ($::RUNCMD_RC != 0) {
                 xCAT::MsgUtils->message("E","Failed to run updatenode, please check the switch");


### PR DESCRIPTION
For issue #3822 
Add syslog postscript to default options of ```switchdiscover --setup``` for Cumulus switch

