### PR TITLE
fix issue MN and SN version mismatch checking prevent hard block of functions from executing. #3849

### DIFF
--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -2813,8 +2813,7 @@ sub service_connection {
                     my $myxcatver=xCAT::Version->Version();
                     if($req->{'_xcatver'}->[0] ne $myxcatver){
                         my $myhostname=Sys::Hostname::hostname;
-                        my $resp = { warning => ["xCAT Version mismatch! \"$myxcatver\" on $myhostname does not match \"$req->{'_xcatver'}->[0]\" on $peerhost!"]};
-                        $resp->{serverdone} = [undef];
+                        my $resp = { warning => ["xCAT Version mismatch! \n         $myhostname: $myxcatver\n         $peerhost: $req->{'_xcatver'}->[0]\n"]};
                         send_response($resp, $sock);
                     }
                 }


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/3849:


after modification :
````
[root@c910f03c05k21 ~]# nodeset c910f03c17k42 boot
c910f03c17k42: boot
Warning: xCAT Version mismatch!
         c910f03c05k27: Version 2.13.6 (git commit f8c0d11ff2c7c97d6e62389c0aafcdfa06cee1f6, built Mon Aug  7 07:15:47 EDT 2017)
         c910f03c05k21: Version 2.13.7 (git commit ccbbaa39c4e7081f2d13154708f97b8e0433b7f63a26a0, built Thu Aug 17 04:07:40 EDT 2017)

c910f03c17k42: boot
````