### PR TITLE
Modify the order of nodeset_cmdline nodeset_shell and nodeset_runimg three test cases in bundle

### DIFF
--- a/xCAT-test/autotest/bundle/rhels6.9_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/rhels6.9_x86_64.bundle
@@ -206,9 +206,6 @@ switchdiscover_range_r
 switchdiscover_range_x
 switchdiscover_range_z
 switchdiscover_range_z_V
-nodeset_shell
-nodeset_cmdline
-nodeset_runimg
 nodeset_check_warninginfo
 xcatconfig_u_check_xcatsslversion_rhels_sles
 xcatconfig_c
@@ -252,6 +249,9 @@ packimage_m_invalid_archive_method
 packimage_m_invalid_compress_method
 confignetwork_vlan_false
 confignetwork__bridge_false
+nodeset_shell
+nodeset_cmdline
+nodeset_runimg
 reg_linux_statelite_installation_flat
 SN_setup_case
 reg_linux_diskfull_installation_hierarchy

--- a/xCAT-test/autotest/bundle/rhels7.4_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.4_ppc64le.bundle
@@ -271,9 +271,6 @@ switchdiscover_range_r
 switchdiscover_range_x
 switchdiscover_range_z
 switchdiscover_range_z_V
-nodeset_shell
-nodeset_cmdline
-nodeset_runimg
 makentp_v
 makentp_h
 nodeset_check_warninginfo
@@ -336,6 +333,9 @@ packimage_m_invalid_archive_method
 packimage_m_invalid_compress_method
 confignetwork_vlan_false
 confignetwork__bridge_false
+nodeset_shell
+nodeset_cmdline
+nodeset_runimg
 reg_linux_statelite_installation_flat
 SN_setup_case
 reg_linux_diskfull_installation_hierarchy

--- a/xCAT-test/autotest/bundle/rhels7.4_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.4_x86_64.bundle
@@ -233,9 +233,6 @@ switchdiscover_range_x
 switchdiscover_range_z
 switchdiscover_range_z_V
 nodeset_check_warninginfo
-nodeset_shell
-nodeset_cmdline
-nodeset_runimg
 xcatconfig_u_check_xcatsslversion_rhels_sles
 xcatconfig_c
 bmcdiscover_help
@@ -263,6 +260,9 @@ xdcp_nonroot_user
 xdsh_permission_denied
 confignetwork_vlan_false
 confignetwork__bridge_false
+nodeset_shell
+nodeset_cmdline
+nodeset_runimg
 reg_linux_diskless_installation_flat
 reg_linux_statelite_installation_flat
 SN_setup_case

--- a/xCAT-test/autotest/bundle/sles11.4_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/sles11.4_x86_64.bundle
@@ -211,9 +211,6 @@ switchdiscover_range_r
 switchdiscover_range_x
 switchdiscover_range_z
 switchdiscover_range_z_V
-nodeset_shell
-nodeset_cmdline
-nodeset_runimg
 nodeset_check_warninginfo
 xcatd_start
 xcatd_stop
@@ -253,6 +250,9 @@ packimage_m_tar_c_gzip
 packimage_m_tar_c_xz
 packimage_m_invalid_archive_method
 packimage_m_invalid_compress_method
+nodeset_shell
+nodeset_cmdline
+nodeset_runimg
 reg_linux_statelite_installation_flat
 SN_setup_case
 reg_linux_diskfull_installation_hierarchy

--- a/xCAT-test/autotest/bundle/sles12.2_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/sles12.2_ppc64le.bundle
@@ -226,9 +226,6 @@ switchdiscover_range_r
 switchdiscover_range_x
 switchdiscover_range_z
 switchdiscover_range_z_V
-nodeset_shell
-nodeset_cmdline
-nodeset_runimg
 xcatd_start_systemd
 xcatd_stop_systemd
 xcatd_restart_systemd
@@ -261,6 +258,9 @@ rmimage_diskless
 updatenode_diskful_syncfiles_failing
 xdcp_nonroot_user
 xdsh_permission_denied
+nodeset_shell
+nodeset_cmdline
+nodeset_runimg
 sles_migration1
 sles_migration2
 reg_linux_statelite_installation_flat

--- a/xCAT-test/autotest/bundle/sles12.2_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/sles12.2_x86_64.bundle
@@ -223,9 +223,6 @@ switchdiscover_range_r
 switchdiscover_range_x
 switchdiscover_range_z
 switchdiscover_range_z_V
-nodeset_shell
-nodeset_cmdline
-nodeset_runimg
 nodeset_check_warninginfo
 xcatd_start_systemd
 xcatd_stop_systemd
@@ -257,6 +254,9 @@ rmimage_diskless
 updatenode_diskful_syncfiles_failing
 xdcp_nonroot_user
 xdsh_permission_denied
+nodeset_shell
+nodeset_cmdline
+nodeset_runimg
 sles_migration1
 sles_migration2
 reg_linux_diskless_installation_flat

--- a/xCAT-test/autotest/bundle/ubuntu14.04.4_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu14.04.4_ppc64le.bundle
@@ -256,9 +256,6 @@ switchdiscover_range_r
 switchdiscover_range_x
 switchdiscover_range_z
 switchdiscover_range_z_V
-nodeset_shell
-nodeset_cmdline
-nodeset_runimg
 xcatd_start
 xcatd_stop
 xcatd_restart
@@ -290,5 +287,8 @@ rmimage_diskless
 updatenode_diskful_syncfiles_failing
 xdcp_nonroot_user
 xdsh_permission_denied
+nodeset_shell
+nodeset_cmdline
+nodeset_runimg
 ubuntu_migration1_p8le
 ubuntu_migration2_p8le

--- a/xCAT-test/autotest/bundle/ubuntu14.04.4_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu14.04.4_x86_64.bundle
@@ -261,9 +261,6 @@ switchdiscover_range_r
 switchdiscover_range_x
 switchdiscover_range_z
 switchdiscover_range_z_V
-nodeset_shell
-nodeset_cmdline
-nodeset_runimg
 nodeset_check_warninginfo
 Full_installation_flat_docker
 rpower_stop_docker
@@ -303,5 +300,8 @@ rmimage_diskless
 updatenode_diskful_syncfiles_failing
 xdcp_nonroot_user
 xdsh_permission_denied
+nodeset_shell
+nodeset_cmdline
+nodeset_runimg
 ubuntu_migration1_vm
 ubuntu_migration2_vm

--- a/xCAT-test/autotest/bundle/ubuntu16.04.1_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu16.04.1_ppc64le.bundle
@@ -257,9 +257,6 @@ switchdiscover_range_r
 switchdiscover_range_x
 switchdiscover_range_z
 switchdiscover_range_z_V
-nodeset_shell
-nodeset_cmdline
-nodeset_runimg
 xcatd_start_systemd
 xcatd_stop_systemd
 xcatd_restart_systemd
@@ -291,6 +288,9 @@ rmimage_diskless
 updatenode_diskful_syncfiles_failing
 xdcp_nonroot_user
 xdsh_permission_denied
+nodeset_shell
+nodeset_cmdline
+nodeset_runimg
 ubuntu_migration1_p8le
 ubuntu_migration2_p8le
 

--- a/xCAT-test/autotest/bundle/ubuntu16.04.1_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu16.04.1_x86_64.bundle
@@ -261,9 +261,6 @@ switchdiscover_range_r
 switchdiscover_range_x
 switchdiscover_range_z
 switchdiscover_range_z_V
-nodeset_shell
-nodeset_cmdline
-nodeset_runimg
 xcatd_start_systemd
 xcatd_stop_systemd
 xcatd_restart_systemd
@@ -295,5 +292,8 @@ rmimage_diskless
 updatenode_diskful_syncfiles_failing
 xdcp_nonroot_user
 xdsh_permission_denied
+nodeset_shell
+nodeset_cmdline
+nodeset_runimg
 ubuntu_migration1_vm
 ubuntu_migration2_vm

--- a/xCAT-test/autotest/bundle/ubuntu16.04_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu16.04_ppc64le.bundle
@@ -233,12 +233,12 @@ switchdiscover_range_r
 switchdiscover_range_x
 switchdiscover_range_z
 switchdiscover_range_z_V
-nodeset_shell
-nodeset_cmdline
-nodeset_runimg
 xcatd_start_systemd
 xcatd_stop_systemd
 xcatd_restart_systemd
 run_command_with_XCATBYPASS_systemd
 disable_root_permission_in_policy_table_systemd
 assign_certain_command_permission_systemd
+nodeset_shell
+nodeset_cmdline
+nodeset_runimg


### PR DESCRIPTION
Due to these 3 test cases ``nodeset_cmdline nodeset_shell  nodeset_runimg`` will trigger CN enter into genesis, although before exit, these cases try to recover CN to original status, but the code is not good enough, they can not guarantee CN back to original status. So these three cases always effect other test cases which need to operate CN. So move these 3 cases to a place where won't effect other test cases.