### PR TITLE
Fix test case nodeset_disjointdhcps_petitboot

### DIFF
--- a/xCAT-test/autotest/testcase/nodeset/cases0
+++ b/xCAT-test/autotest/testcase/nodeset/cases0
@@ -365,6 +365,10 @@ check:rc==0
 cmd:chdef testnode1 netboot=petitboot addkcmdline=debug
 check:rc==0
 cmd:mkdef "rhels7.99-ppc64le-install-compute" -u profile=compute provmethod=install osvers=rhels7.99 osarch=ppc64le
+cmd:xdsh $$SN 'mkdir -p /install/rhels7.99/ppc64le'
+cmd:xdsh $$SN 'mkdir -p /install/rhels7.99/ppc64le/ppc/ppc64le'
+cmd:xdsh $$SN 'echo blah >/install/rhels7.99/ppc64le/ppc/ppc64le/vmlinuz'
+cmd:xdsh $$SN 'echo blah >/install/rhels7.99/ppc64le/ppc/ppc64le/initrd.img'
 cmd:mkdir -p /install/rhels7.99/ppc64le
 cmd:mkdir -p /install/rhels7.99/ppc64le/ppc/ppc64le
 cmd:echo blah >/install/rhels7.99/ppc64le/ppc/ppc64le/vmlinuz
@@ -440,4 +444,5 @@ check:rc!=0
 cmd:noderm testnode1
 cmd:rmdef -t osimage -o "rhels7.99-ppc64le-install-compute"
 cmd:rm -rf /install/rhels7.99
+cmd:xdsh $$SN 'rm -rf /install/rhels7.99'
 end


### PR DESCRIPTION
Force to create the fake osimage directory on SN, in case it could cover the case /install is not mounted. (The feature is #3088, and the test case issue is #3487)