### PR TITLE
Update the message printed in Genesis to help user figure out configuration issues during discovery 

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcconfig.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcconfig.pm
@@ -149,7 +149,7 @@ sub process_request {
     foreach my $sbmc (split /,/, $bmc) {
         (my $ip, my $mask, my $gw) = net_parms($sbmc);
         unless ($ip and $mask and $username and $password) {
-            xCAT::MsgUtils->message('S', "Unable to determine IP, Netmask, Username, or Password for $sbmc. Ensure that hostname resolution is working. [IP=$ip Netmask=$mask Username=$username Password=$password]",);
+            xCAT::MsgUtils->message('S', "Unable to determine IP, Netmask, Username, or Password for $sbmc. Ensure that hostname resolution is working. [IP=$ip Netmask=$mask User=$username Pass=$password]",);
             $callback->({ error => ["Invalid/Missing BMC related attributes in the node defintion (IP=$ip Netmask=$mask User=$username Pass=$password). Unable to configure the BMC, check the node definition."], errorcode => [1] });
             return 1;
         }

--- a/xCAT-server/lib/xcat/plugins/bmcconfig.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcconfig.pm
@@ -141,16 +141,16 @@ sub process_request {
         $clipassword = $password;
     }
     unless (defined $bmc) {
-        xCAT::MsgUtils->message('S', "Received request from host=$node but unable to determine $bmc_mgmt_type.bmc value for the node.  Verify mgt attribute is configured correctly for the node and the BMC is defined.");
-        $callback->({ error => ["Unable to detect BMC configuration value for bmcconfig"], errorcode => [1] });
+        xCAT::MsgUtils->message('S', "Received request from host=$node but unable to determine the $bmc_mgmt_type.bmc value for the node. Verify the node.mgt attribute is configured and the node.bmc is defined.");
+        $callback->({ error => ["No value specified for '$node.bmc'. Unable to configure the BMC, check the node definition."], errorcode => [1] });
         return 1;
     }
     my $bmcport_counter = 0;
     foreach my $sbmc (split /,/, $bmc) {
         (my $ip, my $mask, my $gw) = net_parms($sbmc);
         unless ($ip and $mask and $username and $password) {
-            xCAT::MsgUtils->message('S', "Unable to determine IP, netmask, username, and/or pasword for $sbmc, ensure that host resolution is working.  Best guess parameters would have been: IP: '$ip', netmask: '$mask', username: '$username', password: '$password'",);
-            $callback->({ error => ["Invalid table configuration for bmcconfig"], errorcode => [1] });
+            xCAT::MsgUtils->message('S', "Unable to determine IP, Netmask, Username, or Password for $sbmc. Ensure that hostname resolution is working. [IP=$ip Netmask=$mask Username=$username Password=$password]",);
+            $callback->({ error => ["Invalid/Missing BMC related attributes in the node defintion (IP=$ip Netmask=$mask User=$username Pass=$password). Unable to configure the BMC, check the node definition."], errorcode => [1] });
             return 1;
         }
         if ($request->{command}->[0] eq 'remoteimmsetup') {


### PR DESCRIPTION
Resolves #3615 

Update the message that returns back to the BMC in discovery tosomething that is more helpful to debug the problem

New messages that come out to the console: 
```
[xCAT Genesis running on mid05tor12cn02 /]# /bin/bmcsetup
ipmitool version 1.8.18
Invalid channel: 16
  <error>No value specified for 'mid05tor12cn02.bmc'. Unable to configure the BMC, check the node definition.</error>
  <errorcode>1</errorcode>


[xCAT Genesis running on mid05tor12cn02 /]# /bin/bmcsetup
ipmitool version 1.8.18
Invalid channel: 16
  <error>Invalid/Missing BMC related attributes in the node defintion (IP=172.12.140.102 Netmask=255.255.0.0 User=root Pass=0penBmc). Unable to configure the BMC, check the node definition.</error>
  <errorcode>1</errorcode>

```