### PR TITLE
Reduce the output of bmcdiscover when writing entries to the DB

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -1082,19 +1082,8 @@ sub bmcdiscovery_ipmi {
             xCAT::MsgUtils->message("W", { data => ["BMC password is incorrect for $ip"] }, $::CALLBACK);
             return;
         }
-        if (defined($opz) || defined($opw))
-        {
-            format_stanza($node, $node_data, "ipmi");
-            if (defined($opw))
-            {
-                write_to_xcatdb($node, $node_data, "ipmi", $request_command);
-            }
-        }
-        else {
-            my $rsp = {};
-            push @{ $rsp->{data} }, "$node_data";
-            xCAT::MsgUtils->message("I", $rsp, $::CALLBACK);
-        }
+
+        display_output($opz,$opw,$node,$node_data,"ipmi",$request_command);
     }
 }
 
@@ -1205,12 +1194,38 @@ sub bmcdiscovery_openbmc{
         }
         return;
     }
+    display_output($opz,$opw,$node,$node_data,"openbmc",$request_command);
+}
 
-    if (defined($opz) || defined($opw)) {
-        format_stanza($node, $node_data, "openbmc");
-        if (defined($opw)) {
-            write_to_xcatdb($node, $node_data, "openbmc", $request_command);
+
+#-----------------------------------------------------------------------------
+
+=head3  display_output
+
+        Common code to print output of bmcdiscover
+
+=cut
+
+#-----------------------------------------------------------------------------
+sub display_output {
+    my $opz             = shift;
+    my $opw             = shift;
+    my $node            = shift;
+    my $node_data       = shift;
+    my $mgttype         = shift;
+    my $request_command = shift;
+
+    if (defined($opw)) {
+        my $rsp = {};
+        push @{ $rsp->{data} }, "Writing $node ($node_data) to database...";
+        xCAT::MsgUtils->message("I", $rsp, $::CALLBACK);
+        if (defined($opz)) {
+            format_stanza($node, $node_data, $mgttype);
         }
+        write_to_xcatdb($node, $node_data, $mgttype, $request_command);
+    }
+    elsif (defined($opz)) {
+        format_stanza($node, $node_data, $mgttype);
     } else {
         my $rsp = {};
         push @{ $rsp->{data} }, "$node_data";


### PR DESCRIPTION
Resolves #3781 

Change the output of bmcdiscover to NOT print the stanza format
when only the -w option is specified to write data into the database.
This helps when we are doing bmcdiscover over a very large range of IPs

Here's examples of the new behavior of the command: 

### IPMI
```
[root@briggs01 ~]# bmcdiscover --range 172.12.140.123
172.12.140.123,8335-GTB,2109E4A,,,mp,bmc,,
[root@briggs01 ~]# bmcdiscover --range 172.12.140.123 -z
node-8335-gtb-2109e4a:
	objtype=node
	groups=all
	bmc=172.12.140.123
	cons=ipmi
	mgt=ipmi
	mtm=8335-GTB
	serial=2109E4A

[root@briggs01 ~]# bmcdiscover --range 172.12.140.123 -w
Writing node-8335-gtb-2109e4a (172.12.140.123,8335-GTB,2109E4A,,,mp,bmc,,) to database...
[root@briggs01 ~]# bmcdiscover --range 172.12.140.123 -w -z 
Writing node-8335-gtb-2109e4a (172.12.140.123,8335-GTB,2109E4A,,,mp,bmc,,) to database...
node-8335-gtb-2109e4a:
	objtype=node
	groups=all
	bmc=172.12.140.123
	cons=ipmi
	mgt=ipmi
	mtm=8335-GTB
	serial=2109E4A
```

### OpenBMC 

```
[root@briggs01 ~]# bmcdiscover --range 172.11.253.202 
172.11.253.202,8335-GTC,1318C4A,,,mp,bmc,,
[root@briggs01 ~]# bmcdiscover --range 172.11.253.202 -z 
node-8335-gtc-1318c4a:
	objtype=node
	groups=all
	bmc=172.11.253.202
	cons=openbmc
	mgt=openbmc
	mtm=8335-GTC
	serial=1318C4A

[root@briggs01 ~]# bmcdiscover --range 172.11.253.202 -w
Writing node-8335-gtc-1318c4a (172.11.253.202,8335-GTC,1318C4A,,,mp,bmc,,) to database...
[root@briggs01 ~]# bmcdiscover --range 172.11.253.202 -w -z 
Writing node-8335-gtc-1318c4a (172.11.253.202,8335-GTC,1318C4A,,,mp,bmc,,) to database...
node-8335-gtc-1318c4a:
	objtype=node
	groups=all
	bmc=172.11.253.202
	cons=openbmc
	mgt=openbmc
	mtm=8335-GTC
	serial=1318C4A
```

When scaling up, here's the difference, for 4 nodes, will generate 4 lines of output, instead of 36 lines. 
```
[root@briggs01 ~]# bmcdiscover --range 172.12.138.123,172.12.140.102,172.11.253.202,172.12.140.211 -w
Writing node-8335-gtc-1318c4a (172.11.253.202,8335-GTC,1318C4A,,,mp,bmc,,) to database...
Writing node-8335-gtc-1318d3a (172.12.140.102,8335-GTC,1318D3A,,,mp,bmc,,) to database...
Writing node-8335-gtc-13189ca (172.12.140.211,8335-GTC,13189CA,,,mp,bmc,,) to database...
Writing node-8335-gtc-1318daa (172.12.138.123,8335-GTC,1318DAA,,,mp,bmc,,) to database...
```

