### PR TITLE
Remove mess information form ssh keys and credential files

### DIFF
--- a/xCAT/postscripts/getcredentials.awk
+++ b/xCAT/postscripts/getcredentials.awk
@@ -16,7 +16,9 @@ BEGIN {
         print "</xcatrequest>" |& server
 
         while (server |& getline) {
-                print $0 
+                if (match($0,"<xcatdsource>") == 0) {
+                  print $0
+                }
                 if (match($0,"<serverdone>")) {
                   quit = "yes"
                 }

--- a/xCAT/postscripts/getpostscript.awk
+++ b/xCAT/postscripts/getpostscript.awk
@@ -22,7 +22,9 @@ BEGIN {
                   start = 1
                 }
                 if (start == 1) {
-                  print $0
+                  if (match($0,"<xcatdsource>") == 0) {
+                    print $0
+                  }
                 }
 
                 if (match($0,"<serverdone>")) {
@@ -31,6 +33,6 @@ BEGIN {
                 if (match($0,"</xcatresponse>") && match(quit,"yes")) {
                   close(server)
                   exit
-               }
+                }
         }
 }


### PR DESCRIPTION
Fix #3856 
Remove the mess info `<xcatdsource>` from the content when call `getcredentials.awk`

Root cause: 
 we introduce `<xcatdsource>` in xcat response, but some awk script does not handle it.
Then it will be written to the final file on CN.

Now just filter the line with `<xcatdsource>` in such awk scripts.

UT: Passed.
1, Patch the awk script on MN
2, To check if there mess information on MN's files (if there are, we need to clean up first)
3, reprovision CN
4, grep "xcatdsource"  in /root/.ssh,  /etc/

There should be no `<xcatdsource>` line.
```
# cd ~/.ssh
# grep -r xcatdsource ./*
# cd /etc
# grep -r xcatdsource ./*
```