### PR TITLE
Add rflash recovery support for Supermicro based firmware

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rflash.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rflash.1.rst
@@ -52,6 +52,8 @@ OpenPOWER BMC specific (using IPMI):
 
 \ **rflash**\  \ *noderange*\  [\ *hpm_file_path*\  | \ **-d**\  \ *data_directory*\ ] [\ **-c | -**\ **-check**\ ] [\ **-**\ **-retry=**\ \ *count*\ ] [\ **-V**\ ]
 
+\ **rflash**\  \ *noderange*\  \ **-**\ **-recover**\  \ *bmc_file_path*\ 
+
 
 OpenPOWER OpenBMC specific :
 ============================
@@ -196,7 +198,13 @@ The command will update firmware for OpenPOWER OpenBMC when given an OpenPOWER n
 
 \ **-**\ **-recover**\ 
  
+ PPC (with HMC) and PPC (without HMC, using Direct FSP Management) specific:
+ 
  Used to recover the flash image in the permanent side of the chip to the temporary side for both managed systems and power subsystems.
+ 
+ OpenPOWER BMC specific (using IPMI):
+ 
+ Used for IBM Power S822LC for Big Data systems only. Used to recover the BMC with a BMC image downloaded from FixCentral.
  
 
 

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -344,6 +344,7 @@ my %usage = (
         rflash <noderange> [--bpa_acdl]
     OpenPOWER BMC specific (using IPMI):
         rflash <noderange> [<hpm_file_path>|-d <data_directory>] [-c|--check] [--retry=<count>] [-V]
+        rflash <noderange> --recover <bmc_file_path>
     OpenPOWER OpenBMC specific:
         rflash <noderange> {[-c|--check] | [-l|--list]}
         rflash <noderange> <tar_file_path> {[-c|--check] | [-a|--activate] | [-u|--upload]}

--- a/xCAT-client/pods/man1/rflash.1.pod
+++ b/xCAT-client/pods/man1/rflash.1.pod
@@ -26,6 +26,8 @@ B<rflash> I<noderange> I<http_directory>
 
 B<rflash> I<noderange> [I<hpm_file_path> | B<-d> I<data_directory>] [B<-c>|B<--check>] [B<--retry=>I<count>] [B<-V>]
 
+B<rflash> I<noderange> B<--recover> I<bmc_file_path>
+
 =head2 OpenPOWER OpenBMC specific :
 
 B<rflash> I<noderange> {[B<-c>|B<--check>] | [B<-l>|B<--list>]}
@@ -133,7 +135,13 @@ Used to commit the flash image in the temporary side of the chip to the permanen
 
 =item B<--recover>
 
+PPC (with HMC) and PPC (without HMC, using Direct FSP Management) specific:
+
 Used to recover the flash image in the permanent side of the chip to the temporary side for both managed systems and power subsystems.
+
+OpenPOWER BMC specific (using IPMI):
+
+Used for IBM Power S822LC for Big Data systems only. Used to recover the BMC with a BMC image downloaded from FixCentral.
 
 =item B<--retry=>I<count>
 


### PR DESCRIPTION
This commit add recover option for rflash command to upload
bmc image with tftp when the BMC is in Brick Protection state.

Example:
```
rflash <node> --recover <image>
```
implement #3873