### PR TITLE
fix issue Weird problem with rinstall #3877

### DIFF
--- a/xCAT-client/bin/rinstall
+++ b/xCAT-client/bin/rinstall
@@ -21,7 +21,6 @@ use Getopt::Long;
 use xCAT::MsgUtils;
 use xCAT::Utils;
 use xCAT::Client;
-use xCAT::NodeRange;
 use Cwd;
 use strict;
 
@@ -72,12 +71,6 @@ if(grep m/^-c|--console$/,@ARGV){
 }
 
 my $noderange = $cmdref->{noderange}->[0];    # save the noderange
-my @noderange=xCAT::NodeRange::noderange($noderange);
-
-if($bname eq "rinstall" and $startconsole==1 and scalar @noderange!=1 ){
-    xCAT::MsgUtils->message("E", "Error: rinstall -c/--console can only be run against one node! Please use winstall -c/--console for multiple nodes.");
-    exit 1;    
-}
 
 # Allow to print server information when -V/--verbose
 foreach (reverse(@ARGV)) {

--- a/xCAT-server/lib/xcat/plugins/rinstall.pm
+++ b/xCAT-server/lib/xcat/plugins/rinstall.pm
@@ -166,6 +166,14 @@ sub rinstall {
         return 1;
     }
 
+    if($command eq "rinstall" and scalar(@nodes) > 1 and $CONSOLE){
+       my $rsp;
+       $rsp->{errorcode}->[0]=1;
+       $rsp->{error}->[0]="rinstall -c/--console can only be run against one node! Please use winstall -c/--console for multiple nodes.";
+       xCAT::MsgUtils->message("E",$rsp,$callback);
+       return 1;
+    }
+
     my $rc = 0;
     my @parameter;
 


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/3877:
1. remove Noderange::noderange  in rinstall client
2. add the validation of --console in rinstall.pm

````
[root@c910f03c05k21 xcat-core]# su immarvin
[immarvin@c910f03c05k21 xcat-core]$ rinstall testrinstall boot -c
Error: rinstall -c/--console can only be run against one node! Please use winstall -c/--console for multiple nodes.
[immarvin@c910f03c05k21 xcat-core]$ rinstall c910f03c17k42 boot -c
Provision node(s): c910f03c17k42
[Enter `^Ec?' for help]
````