### PR TITLE
fix missing graphics label

### DIFF
--- a/xCAT-server/lib/xcat/plugins/kvm.pm
+++ b/xCAT-server/lib/xcat/plugins/kvm.pm
@@ -1397,12 +1397,14 @@ sub makedom {
     }
     my $parseddom = $parser->parse_string($xml);
     my ($graphics) = $parseddom->findnodes("//graphics");
-    if ($confdata->{vm}->{$node}->[0]->{vidpassword}) {
-        $graphics->setAttribute("passwd", $confdata->{vm}->{$node}->[0]->{vidpassword});
-    } else {
-        $graphics->setAttribute("passwd", genpassword(20));
+    if (defined($graphics)) {
+        if ($confdata->{vm}->{$node}->[0]->{vidpassword}) {
+            $graphics->setAttribute("passwd", $confdata->{vm}->{$node}->[0]->{vidpassword});
+        } else {
+            $graphics->setAttribute("passwd", genpassword(20));
+        }
+        $graphics->setAttribute("listen", '0.0.0.0');
     }
-    $graphics->setAttribute("listen", '0.0.0.0');
     $xml = $parseddom->toString();
     eval {
         if ($::XCATSITEVALS{persistkvmguests}) {


### PR DESCRIPTION
fix #3769 

If there is no `graphics` label, it affects `rpower` and `wcons` command. Based on my investigate, this fix is for `rpower` command, if there is no `graphics` label in kvm xml, `wcons` will not be broken, it will print out `$DISPLAY  not set`, so it is no need to change anything for `wcons` command.

