### PR TITLE
Reduce the number of firmware that is displayed by rinv to the active firmware (partial) 

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1399,7 +1399,10 @@ sub rinv_response {
                 my $purpose_value = uc ((split(/\./, $content{Purpose}))[-1]);
                 $purpose_value = "[$sw_id]$purpose_value";
                 my $activation_value = (split(/\./, $content{Activation}))[-1];
-                my $priority_value = $content{Priority};
+                my $priority_value = -1;
+                if (defined($content{Priority})) {
+                    $priority_value = $content{Priority};
+                }
                 #
                 # For 'rinv firm', only print Active software, unless verbose is specified
                 #

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1399,15 +1399,20 @@ sub rinv_response {
                 my $purpose_value = uc ((split(/\./, $content{Purpose}))[-1]);
                 $purpose_value = "[$sw_id]$purpose_value";
                 my $activation_value = (split(/\./, $content{Activation}))[-1];
+                my $priority_value = $content{Priority};
                 #
                 # For 'rinv firm', only print Active software, unless verbose is specified
                 #
-                if ($activation_value =~ "Active" or $::VERBOSE) {
+                if (($activation_value =~ "Active" and $priority_value == 0) or $::VERBOSE) {
                     #
                     # The space below between "Firmware Product Version:" and $content{Version} is intentional
                     # to cause the sorting of this line before any additional info lines 
                     #
                     $content_info = "$purpose_value Firmware Product:   $content{Version} ($activation_value)";
+                    if ($priority_value == 0) {
+                        # For now, indicate priority 0 software levels with an '*'
+                        $content_info .= "*";
+                    }
                     push (@sorted_output, $content_info); 
     
                     if (defined($content{ExtendedVersion}) and $content{ExtendedVersion} ne "") { 


### PR DESCRIPTION
Partially resolves #3851 in the interim as we wait OpenBMC to indicate the firmware that is currently running. 

There are a few possible states.. 
1. firmware is uploaded (Ready)
2. Firmware is Active (Active)
3. Firmware is set to apply on next reboot (Active)+
4. Firmware is currently running (Active)* 

Currently we can't tell the difference between 3 and 4 (Waiting for FW team to give us more function) but we don't want to display all the Active firmwares, we only want to display the one with Priority 0.  

### Before code changes: 

```
[root@briggs01 ~]# rinv mid05tor12cn05 firm
mid05tor12cn05: HOST Firmware Product: IBM-witherspoon-redbud-ibm-OP9_v1.18_1.41 (Active)
mid05tor12cn05: HOST Firmware Product: -- additional info: buildroot-2017.5-163-g8035745
mid05tor12cn05: HOST Firmware Product: -- additional info: capp-ucode-9c73e9f
mid05tor12cn05: HOST Firmware Product: -- additional info: hostboot-binaries-c24fccd
mid05tor12cn05: HOST Firmware Product: -- additional info: hostboot-f523eaa
mid05tor12cn05: HOST Firmware Product: -- additional info: linux-4.12.1-openpower1-p7e4a3c8
mid05tor12cn05: HOST Firmware Product: -- additional info: machine-xml-5575e7e
mid05tor12cn05: HOST Firmware Product: -- additional info: occ-ca84830
mid05tor12cn05: HOST Firmware Product: -- additional info: op-build-v1.18-2-g17c6e5
mid05tor12cn05: HOST Firmware Product: -- additional info: petitboot-v1.5.1-p3f2a1fc
mid05tor12cn05: HOST Firmware Product: -- additional info: sbe-2021c6-pe5688f7
mid05tor12cn05: HOST Firmware Product: -- additional info: skiboot-v5.7-p3498935
mid05tor12cn05: HOST Firmware Product: IBM-witherspoon-redbud-ibm-OP9_v1.19_1.2 (Active)
mid05tor12cn05: HOST Firmware Product: -- additional info: buildroot-2017.5-163-g8035745
mid05tor12cn05: HOST Firmware Product: -- additional info: capp-ucode-9c73e9f
mid05tor12cn05: HOST Firmware Product: -- additional info: hostboot-binaries-67a15fd
mid05tor12cn05: HOST Firmware Product: -- additional info: hostboot-c68be97
mid05tor12cn05: HOST Firmware Product: -- additional info: linux-4.12.8-openpower1-p5e99141
mid05tor12cn05: HOST Firmware Product: -- additional info: machine-xml-c1e49a6-p1c7cc59
mid05tor12cn05: HOST Firmware Product: -- additional info: occ-854999a
mid05tor12cn05: HOST Firmware Product: -- additional info: op-build-v1.7-1321-g53c41e3-dirty
mid05tor12cn05: HOST Firmware Product: -- additional info: petitboot-v1.5.1-p6b4d24f
mid05tor12cn05: HOST Firmware Product: -- additional info: sbe-4a62126-pd206ccb
mid05tor12cn05: HOST Firmware Product: -- additional info: skiboot-v5.8-rc1-p2f3f436
mid05tor12cn05: BMC Firmware Product: v1.99.9-106-g7eb398a-dirty (Active)
```

### After 
```
[root@briggs01 frame6u05]# rinv mid05tor12cn05  firm
mid05tor12cn05: HOST Firmware Product: IBM-witherspoon-redbud-ibm-OP9_v1.19_1.2 (Active)*
mid05tor12cn05: HOST Firmware Product: -- additional info: buildroot-2017.5-163-g8035745
mid05tor12cn05: HOST Firmware Product: -- additional info: capp-ucode-9c73e9f
mid05tor12cn05: HOST Firmware Product: -- additional info: hostboot-binaries-67a15fd
mid05tor12cn05: HOST Firmware Product: -- additional info: hostboot-c68be97
mid05tor12cn05: HOST Firmware Product: -- additional info: linux-4.12.8-openpower1-p5e99141
mid05tor12cn05: HOST Firmware Product: -- additional info: machine-xml-c1e49a6-p1c7cc59
mid05tor12cn05: HOST Firmware Product: -- additional info: occ-854999a
mid05tor12cn05: HOST Firmware Product: -- additional info: op-build-v1.7-1321-g53c41e3-dirty
mid05tor12cn05: HOST Firmware Product: -- additional info: petitboot-v1.5.1-p6b4d24f
mid05tor12cn05: HOST Firmware Product: -- additional info: sbe-4a62126-pd206ccb
mid05tor12cn05: HOST Firmware Product: -- additional info: skiboot-v5.8-rc1-p2f3f436
mid05tor12cn05: BMC Firmware Product: v1.99.9-106-g7eb398a-dirty (Active)*
```

All firmware that is uploaded to the BMC can still be viewed by using the `-V` verbose option. 