### PR TITLE
BMC update image check and upload+activate rflash options

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -898,7 +898,7 @@ sub parse_command_status {
 
         my $file_id = undef;
         my $grep_cmd = "/usr/bin/grep -a";
-        my $version_tag = '"version=IBM"';
+        my $version_tag = '"^version="';
         my $purpose_tag = '"purpose="';
         my $purpose_value;
         my $version_value;


### PR DESCRIPTION
Small change to enable BMC update images to be correctly handled by `rflash -c` and `rflash -a` options.

Extract version number from the BMC MANIFEST update file using the same code as PHOR MANIFEST file.