### PR TITLE
Resolve issues with xCAT-genesis-builder rpm to more easily create the xCAT-genesis-base

### DIFF
--- a/xCAT-genesis-builder/buildrpm
+++ b/xCAT-genesis-builder/buildrpm
@@ -13,6 +13,8 @@ DIR=`dirname $0`
 DIR=`readlink -f $DIR`
 BUILDARCH=`uname -m`
 
+rpmdev-setuptree
+
 #For Openpower
 if [ $BUILDARCH = "ppc64le" ]; then
     BUILDARCH="ppc64"

--- a/xCAT-genesis-builder/buildrpm
+++ b/xCAT-genesis-builder/buildrpm
@@ -16,12 +16,13 @@ BUILDARCH=`uname -m`
 rpmdev-setuptree
 
 #For Openpower
-if [ $BUILDARCH = "ppc64le" ]; then
-    BUILDARCH="ppc64"
-fi
-
 if [ -z $1 ]; then
-    HOSTOS="fedora26"
+    if [ $BUILDARCH = "ppc64le" ]; then
+        HOSTOS="Pegas1.0"
+        BUILDARCH="ppc64"
+    else
+        HOSTOS="fedora26"
+    fi
 fi
 
 # get the input files for dracut in the right place
@@ -107,6 +108,12 @@ if [ "$HOSTOS" = "mcp" ]; then
 # For ppc64 platform, needs to remove some files,
 # # and some files are in different directories
 elif [ $BUILDARCH = "ppc64" ]; then
+        if [ "$HOSTOS" = "Pegas1.0" ]; then
+	    sed -i 's/ mkreiserfs//' $DRACUTMODDIR/install
+	    sed -i 's/ reiserfstune//' $DRACUTMODDIR/install
+	    sed -i 's/ vconfig//' $DRACUTMODDIR/install
+	    sed -i 's/ ntp-wait//' $DRACUTMODDIR/install
+        fi
         sed -i 's/ efibootmgr//' $DRACUTMODDIR/install
         sed -i 's/ dmidecode//' $DRACUTMODDIR/install
         sed -i 's/\/lib\/terminfo\/l\/linux/\/usr\/share\/terminfo\/l\/linux/g' $DRACUTMODDIR/install

--- a/xCAT-genesis-builder/xCAT-genesis-builder.spec
+++ b/xCAT-genesis-builder/xCAT-genesis-builder.spec
@@ -4,7 +4,7 @@ Version: %{?version:%{version}}%{!?version:%(cat Version)}
 Release: %{?release:%{release}}%{!?release:%(cat Release)}
 Epoch: 1
 AutoReq: false
-Requires: ipmitool screen btrfs-progs lldpad rpm-build mstflint xfsprogs nc rpmdevtools libstdc++-devel pciutils bridge-utils ntp iprutils psmisc mdadm bind-utils dosfstools usbutils libusbx
+Requires: ipmitool screen btrfs-progs lldpad rpm-build mstflint xfsprogs nc rpmdevtools libstdc++-devel pciutils bridge-utils ntp ntp-perl iprutils psmisc mdadm bind-utils dosfstools usbutils libusbx
 Prefix: /opt/xcat
 AutoProv: false
 

--- a/xCAT-genesis-builder/xCAT-genesis-builder.spec
+++ b/xCAT-genesis-builder/xCAT-genesis-builder.spec
@@ -4,7 +4,7 @@ Version: %{?version:%{version}}%{!?version:%(cat Version)}
 Release: %{?release:%{release}}%{!?release:%(cat Release)}
 Epoch: 1
 AutoReq: false
-Requires: ipmitool screen btrfs-progs lldpad rpm-build compat-libstdc++-33 mstflint xfsprogs nc reiserfs-utils
+Requires: ipmitool screen btrfs-progs lldpad rpm-build mstflint xfsprogs nc rpmdevtools libstdc++-devel pciutils bridge-utils ntp iprutils psmisc mdadm bind-utils dosfstools usbutils libusbx
 Prefix: /opt/xcat
 AutoProv: false
 


### PR DESCRIPTION
Some issues with the xCAT-genesis-builder. 

* On a clean node, the `buildrpm` always fails the first time because the rpmbuild directories are not created 
* The dependencency rpms that are required to successful build the xCAT-genesis-base are not pulled in automatically. 

This pull request attempts to resolve the issues above. 

Even with the changes, I'm unable to resolve the following errors: 
```
[root@fs2vm112 ~]# /opt/xcat/share/xcat/netboot/genesis/builder/buildrpm
cp: omitting directory ‘/opt/xcat/share/xcat/netboot/genesis/builder/debian’
Creating the initramfs in /tmp/xcatgenesis.16102.rfs using dracut ...

dracut-install: ERROR: installing 'vconfig'
/usr/lib/dracut/dracut-install -D /var/tmp/dracut.Miu97D/initramfs -a mkswap df brctl vconfig ifenslave ssh-keygen scp clear dhclient lldpad
dracut-install: ERROR: installing 'ntp-wait'
/usr/lib/dracut/dracut-install -D /var/tmp/dracut.Miu97D/initramfs -a poweroff ntpq ntpd ntp-wait hwclock date /usr/share/terminfo/x/xterm /usr/share/terminfo/s/screen /etc/nsswitch.conf /etc/services
dracut-install: ERROR: installing 'mkreiserfs'
dracut-install: ERROR: installing 'reiserfstune'
/usr/lib/dracut/dracut-install -D /var/tmp/dracut.Miu97D/initramfs -a killall logger nc nslookup bc chown chroot dd expr kill mkdosfs parted rsync shutdown sort ssh-keygen tr blockdev findfs insmod kexec lvm mdadm mke2fs pivot_root sshd swapon tune2fs mkreiserfs reiserfstune pvcreate lvremove vgremove vgcreate lvcreate lvscan lvchange vgchange pvdisplay lvdisplay vgdisplay blkid dmsetup sfdisk
Expanding the initramfs into /tmp/xcatgenesis.16102/opt/xcat/share/xcat/netboot/genesis/ppc64/fs ...
204348 blocks
Adding perl libary /usr/share/perl5
Adding perl libary /usr/lib64/perl5
Adding kernel /boot/vmlinuz-ppc64 ...
/root
Tarring /tmp/xcatgenesis.16102/opt into /root/rpmbuild/SOURCES/xCAT-genesis-base-ppc64.tar.bz2 ...
Building xCAT-genesis-base rpm from /root/rpmbuild/SOURCES/xCAT-genesis-base-ppc64.tar.bz2 and /opt/xcat/share/xcat/netboot/genesis/builder/xCAT-genesis-base.spec ...
error: Failed build dependencies:
        /usr/sbin/ntp-wait is needed by xCAT-genesis-base-ppc64-2:2.13.7-snap201709121408.noarch
```