### PR TITLE
Handle more than one node for openbmc rflash

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -96,6 +96,7 @@ my %sensor_units = (
 my $http_protocol="https";
 my $openbmc_url = "/org/openbmc";
 my $openbmc_project_url = "/xyz/openbmc_project";
+$::SOFTWARE_URL = "$openbmc_project_url/software";
 #-------------------------------------------------------
 
 # The hash table to store method and url for request, 
@@ -161,7 +162,6 @@ my %status_info = (
     RFLASH_UPDATE_ACTIVATE_REQUEST  => {
         method         => "PUT",
         init_url       => "$openbmc_project_url/software",
-        orig_url       => "$openbmc_project_url/software",
         data           => "xyz.openbmc_project.Software.Activation.RequestedActivations.Active",
     },
     RFLASH_UPDATE_ACTIVATE_RESPONSE => {
@@ -170,7 +170,6 @@ my %status_info = (
     RFLASH_UPDATE_CHECK_STATE_REQUEST  => {
         method         => "GET",
         init_url       => "$openbmc_project_url/software",
-        orig_url       => "$openbmc_project_url/software",
     },
     RFLASH_UPDATE_CHECK_STATE_RESPONSE => {
         process        => \&rflash_response,
@@ -185,7 +184,6 @@ my %status_info = (
     RFLASH_SET_PRIORITY_REQUEST  => {
         method         => "PUT",
         init_url       => "$openbmc_project_url/software",
-        orig_url       => "$openbmc_project_url/software",
         data           => "false", # Priority state of 0 sets image to active
     },
     RFLASH_SET_PRIORITY_RESPONSE => {
@@ -2090,11 +2088,11 @@ sub rflash_response {
 
                     # Set the image id for the activation request
                     $status_info{RFLASH_UPDATE_ACTIVATE_REQUEST}{init_url} =
-                       $status_info{RFLASH_UPDATE_ACTIVATE_REQUEST}{orig_url} . "/$update_id/attr/RequestedActivation";
+                       $::SOFTWARE_URL . "/$update_id/attr/RequestedActivation";
                     $status_info{RFLASH_UPDATE_CHECK_STATE_REQUEST}{init_url} =
-                       $status_info{RFLASH_UPDATE_CHECK_STATE_REQUEST}{orig_url} . "/$update_id";
+                       $::SOFTWARE_URL . "/$update_id";
                     $status_info{RFLASH_SET_PRIORITY_REQUEST}{init_url} =
-                       $status_info{RFLASH_SET_PRIORITY_REQUEST}{orig_url} . "/$update_id/attr/Priority";
+                       $::SOFTWARE_URL . "/$update_id/attr/Priority";
 
                     # Set next steps to activate the image
                     $next_status{ $node_info{$node}{cur_status} } = "RFLASH_UPDATE_ACTIVATE_REQUEST";


### PR DESCRIPTION
This pull request fixes the problem where `rflash <noderange> -a <tar file>` command could not target more than one node in the noderange. All other `rflash <noderange>` commands still worked fine.

The problem was that for `-a` option, xCAT code was building a `{init_url}` entry using `.=`. That was ok for the first node in the noderange, but the `{init_url}` entry for the second node appended itself to the first entry.

The solution in this pull request is to add new entry - `{orig_url}`. This entry will not change and can be used to build the needed `{init_url}` entries for multiple nodes.

After the this pull request, the output:
```
[root@stratton01 gurevich]# rflash p9euh[01-02] -l
p9euh01: ID       Purpose State      Version
p9euh01: -------------------------------------------------------
p9euh01: 7d065891 BMC     Active(*)  v1.99.9-150-gfd7b67e-dirty
p9euh01: 0        BMC     Active     ibm-v1.99.9-94-g7d7329ba-test0-0-g7d7329b
p9euh01: d664c34b BMC     Ready      v1.99.9-123-gefaebe8
p9euh01: 32f129cd Host    Active     IBM-witherspoon-redbud-ibm-OP9_v1.17_1.68
p9euh01:
p9euh02: ID       Purpose State      Version
p9euh02: -------------------------------------------------------
p9euh02: 7d065891 BMC     Active(*)  v1.99.9-150-gfd7b67e-dirty
p9euh02: 4f7d9d22 BMC     Active     v1.99.9-109-gd278673
p9euh02: 32f129cd Host    Active     IBM-witherspoon-redbud-ibm-OP9_v1.17_1.68
p9euh02:
```

```
[root@stratton01 gurevich]# rflash p9euh[01-02] -a witherspoon.20170713s.pnor.squashfs.tar
p9euh01: Uploading /tmp/gurevich/witherspoon.20170713s.pnor.squashfs.tar ...
p9euh01: Successful, use -l option to list.
p9euh02: Uploading /tmp/gurevich/witherspoon.20170713s.pnor.squashfs.tar ...
p9euh02: Successful, use -l option to list.
p9euh01: rflash started, please wait...
p9euh01: Activating firmware update. 10%
p9euh02: rflash started, please wait...
p9euh01: Activating firmware update. 10%
p9euh02: Activating firmware update. 10%
p9euh01: Activating firmware update. 10%
p9euh02: Firmware update successfully activated
p9euh01: Firmware update successfully activated
[root@stratton01 gurevich]#
```

```
[root@stratton01 gurevich]# rflash p9euh[01-02] -l
p9euh02: ID       Purpose State      Version
p9euh02: -------------------------------------------------------
p9euh02: 7d065891 BMC     Active(*)  v1.99.9-150-gfd7b67e-dirty
p9euh02: 2a1022fe Host    Active(*)  IBM-witherspoon-sequoia-ibm-OP9_v1.17_1.67
p9euh02: 4f7d9d22 BMC     Active     v1.99.9-109-gd278673
p9euh02: 32f129cd Host    Active     IBM-witherspoon-redbud-ibm-OP9_v1.17_1.68
p9euh02:
p9euh01: ID       Purpose State      Version
p9euh01: -------------------------------------------------------
p9euh01: 7d065891 BMC     Active(*)  v1.99.9-150-gfd7b67e-dirty
p9euh01: 0        BMC     Active     ibm-v1.99.9-94-g7d7329ba-test0-0-g7d7329b
p9euh01: 2a1022fe Host    Active(*)  IBM-witherspoon-sequoia-ibm-OP9_v1.17_1.67
p9euh01: d664c34b BMC     Ready      v1.99.9-123-gefaebe8
p9euh01: 32f129cd Host    Active     IBM-witherspoon-redbud-ibm-OP9_v1.17_1.68
p9euh01:
[root@stratton01 gurevich]#
```