### PR TITLE
modify bmcdiscover testcase

### DIFF
--- a/xCAT-test/autotest/testcase/bmcdiscover/cases0
+++ b/xCAT-test/autotest/testcase/bmcdiscover/cases0
@@ -69,7 +69,7 @@ end
 start:bmcdiscover_range_w
 cmd:bmcdiscover --range  $$bmcrange -u $$bmcusername -p $$bmcpasswd -w
 check:rc==0
-check:output=~bmc=$$bmcrange
+check:output=~Writing node 
 end
 
 start:bmcdiscover_range_u_p_i_ipsource

--- a/xCAT-test/autotest/testcase/bmcdiscover/cases0
+++ b/xCAT-test/autotest/testcase/bmcdiscover/cases0
@@ -69,7 +69,8 @@ end
 start:bmcdiscover_range_w
 cmd:bmcdiscover --range  $$bmcrange -u $$bmcusername -p $$bmcpasswd -w
 check:rc==0
-check:output=~Writing node 
+check:output=~Writing node
+check:output=~$$bmcrange,\w*,\w*,$$bmcusername,$$bmcpasswd 
 end
 
 start:bmcdiscover_range_u_p_i_ipsource


### PR DESCRIPTION
I modify bmcdiscover testcase:bmcdiscover_range_w for code changed so the output the this command should be changed.
Such as the output now:
RUN:bmcdiscover --range  10.4.30.254 -u USERID -p PASSW0RD -w [Thu Sep 14 02:05:29 2017]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Writing node-7912ac1-06vag36 (10.4.30.254,7912AC1,06VAG36,USERID,PASSW0RD,mp,bmc,,) to database...
CHECK:rc == 0   [Pass]
CHECK:output =~ Writing node    [Pass]
