### PR TITLE
enhance packimage to exclude statelite related dir

### DIFF
--- a/xCAT-server/lib/xcat/plugins/packimage.pm
+++ b/xCAT-server/lib/xcat/plugins/packimage.pm
@@ -484,7 +484,7 @@ sub process_request {
     unlink glob("$destdir/rootimg.*");   
  
     if ($method =~ /cpio/) {
-        if (!$exlistloc) {
+        if (!$excludestr) {
             $excludestr = "find . -xdev -print0 | cpio -H newc -o -0 | $compress -c - > ../rootimg.$suffix";
         } else {
             chdir("$rootimg_dir");
@@ -505,7 +505,7 @@ sub process_request {
         if ($checkoption2 !~ /unrecognized/) {
             $option .= "--selinux ";
         }
-        if (!$exlistloc) {
+        if (!$excludestr) {
             $excludestr = "find . -xdev -print0 | tar $option --no-recursion --use-compress-program=$compress --null -T - -cf ../rootimg.$suffix";
         } else {
             chdir("$rootimg_dir");
@@ -526,7 +526,6 @@ sub process_request {
         }
         $excludestr = "cat $xcat_packimg_tmpfile|cpio -dump $temppath";
     }
-
     chdir("$rootimg_dir");
     my $outputmsg = `$excludestr 2>&1`;
     unless($?){


### PR DESCRIPTION
fix #3912 and #3244 

After fix, `packimage` will exclude statelite related dir if there is exlist in osimage or not.

Unit test:
```
]# lsdef -t osimage rhels7.3-x86_64-netboot-compute -i exlist
Object name: rhels7.3-x86_64-netboot-compute
    exlist=

]# packimage rhels7.3-x86_64-netboot-compute
Packing contents of /install/netboot/rhels7.3/x86_64/compute/rootimg
archive method:cpio
compress method:gzip

]#mv rootimg.cpio.gz new/
]#gunzip rootimg.cpio.gz
]#cpio -idmv < rootimg.cpio
]# ls -la
total 651192
drwxr-xr-x 19 root root       276 Sep 14 04:39 .
drwxr-xr-x  4 root root       123 Sep 14 04:40 ..
lrwxrwxrwx  1 root root         7 Sep 14 04:39 bin -> usr/bin
dr-xr-xr-x  2 root root       245 Aug  3 04:23 boot
drwxr-xr-x  2 root root        30 Sep 13 21:26 dev
drwxr-xr-x 57 root root      4096 Aug  3 04:23 etc
drwxr-xr-x  2 root root         6 Mar 10  2016 home
lrwxrwxrwx  1 root root         7 Sep 14 04:39 lib -> usr/lib
lrwxrwxrwx  1 root root         9 Sep 14 04:39 lib64 -> usr/lib64
drwxr-xr-x  2 root root         6 Mar 10  2016 media
drwxr-xr-x  2 root root         6 Mar 10  2016 mnt
drwxr-xr-x  3 root root        18 Aug  3 04:23 opt
drwxr-xr-x  2 root root         6 Aug  3 04:22 proc
dr-xr-x---  2 root root        62 Aug  3 04:23 root
-rw-r--r--  1 root root 666803712 Sep 14 04:37 rootimg.cpio
drwxr-xr-x 12 root root       160 Sep 13 21:26 run
lrwxrwxrwx  1 root root         8 Sep 14 04:39 sbin -> usr/sbin
drwxr-xr-x  4 root root        33 Aug  3 04:23 .sllocal
drwxr-xr-x  2 root root         6 Mar 10  2016 srv
drwxr-xr-x  2 root root         6 Aug  3 04:22 sys
drwxrwxrwt  7 root root        93 Sep 13 21:28 tmp
drwxr-xr-x 13 root root       155 Aug  3 04:22 usr
drwxr-xr-x 18 root root       238 Aug  3 04:22 var
drwxr-xr-x  7 root root      4096 Sep 14 04:36 xcatpost
```
