### PR TITLE
Support configuration of local syslog files on the Service Node

### DIFF
--- a/makerpm
+++ b/makerpm
@@ -145,6 +145,8 @@ function makexcat {
 			cp xcat.conf $RPMROOT/SOURCES
 			cp xcat.conf.apach24 $RPMROOT/SOURCES
 			cp xCATSN $RPMROOT/SOURCES
+                        cp -a ../xCAT/etc/rsyslog.d $RPMROOT/
+                        cp -a ../xCAT/etc/logrotate.d $RPMROOT/ 
 			cd - >/dev/null
 		elif [ "$RPMNAME" = "xCAT-buildkit" ]; then
 			ARCH="noarch"

--- a/xCAT-server/share/xcat/netboot/rh/service.rhels7.ppc64le.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/service.rhels7.ppc64le.pkglist
@@ -45,3 +45,4 @@ vim-minimal
 vsftpd
 wget
 xz
+rsyslog

--- a/xCAT-server/share/xcat/netboot/rh/service.rhels7.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/service.rhels7.x86_64.pkglist
@@ -44,3 +44,4 @@ vim-minimal
 vsftpd
 wget
 xz
+rsyslog

--- a/xCAT/postscripts/syslog
+++ b/xCAT/postscripts/syslog
@@ -243,6 +243,14 @@ config_rsyslog_V8()
                 s/#module(load="imtcp")/module(load="imtcp")/;
                 s/#input(type="imtcp" port="514")/input(type="imtcp" port="514")/' $conf_file
     fi
+    
+    if [ $isSN -eq 1 ] ; then
+        [ -d "/etc/xcat/rsyslog.conf" ] && cp -a /etc/xcat/rsyslog.conf/* /etc/rsyslog.d/
+        if [ -d "/etc/xcat/logrotate.conf" ];then 
+            mkdir -p "/etc/logrotate.d/"
+            cp -a /etc/xcat/logrotate.conf/* /etc/logrotate.d/
+        fi
+    fi
 
     # Mark the end of xCAT section
     echo "# $xCATSettingsEND" >> $conf_file
@@ -261,6 +269,13 @@ config_rsyslog_V8()
 
         [ -f "$conf_file" ] && sed -i '/#\$ModLoad \+imudp\|imtcp\|imudp.so\|imtcp.so/s/^#//;
                        /#\$InputTCPServerRun\|UDPServerRun.*/s/^#//' $conf_file
+
+        [ -f "/etc/rsyslog.d/xcat-cluster.conf" ] && rm -f "/etc/rsyslog.d/xcat-cluster.conf" ;
+        [ -f "/etc/rsyslog.d/xcat-compute.conf" ] && rm -f "/etc/rsyslog.d/xcat-compute.conf" ;
+        [ -f "/etc/rsyslog.d/xcat-debug.conf" ] && rm -f "/etc/rsyslog.d/xcat-debug.conf" ;
+
+        [ -f "/etc/logrotate.d/xcat" ] && rm -f "/etc/logrotate.d/xcat"
+        
     fi
 
 

--- a/xCATsn/xCATsn.spec
+++ b/xCATsn/xCATsn.spec
@@ -93,6 +93,8 @@ tar -xf license.tar
 %install
 %ifos linux
 mkdir -p $RPM_BUILD_ROOT/etc/xcat/conf.orig
+mkdir -p $RPM_BUILD_ROOT/etc/xcat/rsyslog.conf
+mkdir -p $RPM_BUILD_ROOT/etc/xcat/logrotate.conf
 mkdir -p $RPM_BUILD_ROOT/etc/apache2/conf.d
 mkdir -p $RPM_BUILD_ROOT/etc/httpd/conf.d/
 mkdir -p $RPM_BUILD_ROOT/%{prefix}/share/xcat/
@@ -102,6 +104,8 @@ cp %{SOURCE1} $RPM_BUILD_ROOT/etc/httpd/conf.d/xcat.conf
 cp %{SOURCE3} $RPM_BUILD_ROOT/etc/xCATSN
 cp %{SOURCE1} $RPM_BUILD_ROOT/etc/xcat/conf.orig/xcat.conf.apach22
 cp %{SOURCE6} $RPM_BUILD_ROOT/etc/xcat/conf.orig/xcat.conf.apach24
+cp -a  etc/rsyslog.d/* $RPM_BUILD_ROOT/etc/xcat/rsyslog.conf/
+cp -a  etc/logrotate.d/* $RPM_BUILD_ROOT/etc/xcat/logrotate.conf/
 
 mkdir -p $RPM_BUILD_ROOT/%{prefix}/share/doc/packages/xCAT
 cp LICENSE.html $RPM_BUILD_ROOT/%{prefix}/share/doc/packages/xCAT
@@ -249,6 +253,8 @@ fi
 /etc/xcat/conf.orig/xcat.conf.apach22
 /etc/httpd/conf.d/xcat.conf
 /etc/apache2/conf.d/xcat.conf
+/etc/xcat/logrotate.conf/
+/etc/xcat/rsyslog.conf/
 %endif
 /etc/xCATSN
 %defattr(-,root,root)


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/3552

1)ship logrotate and log filter rule files in xCATsn;
2)refine syslog script to enable log filter and rotate rules