### PR TITLE
Add netmask to configonie script for change ip

### DIFF
--- a/xCAT-server/share/xcat/scripts/configonie
+++ b/xCAT-server/share/xcat/scripts/configonie
@@ -120,12 +120,19 @@ if ($::VLAN)
 sub config_ssh {
     my $password = "CumulusLinux!";
     my $userid = "cumulus";
-    my $timeout = 10;
+    my $timeout = 30;
     my $keyfile = "/root/.ssh/id_rsa.pub";
     my $rootkey = `cat /root/.ssh/id_rsa.pub`;
     my $cmd;
     my @config_switches;
 
+    # get netmask from network table
+    my $nettab = xCAT::Table->new("networks");
+    my @nets;
+    if ($nettab) {
+        @nets = $nettab->getAllAttribs('net','mask');
+    }
+    
     my $nodetab = xCAT::Table->new('hosts');
     my $nodehash = $nodetab->getNodesAttribs(\@nodes,['ip','otherinterfaces']);
 
@@ -160,9 +167,18 @@ sub config_ssh {
         ($ret, $err) = cumulus_exec($exp, "chmod 700 /root/.ssh");
         ($ret, $err) = cumulus_exec($exp, "echo \"$rootkey\" >/root/.ssh/authorized_keys");
         ($ret, $err) = cumulus_exec($exp, "chmod 644 /root/.ssh/authorized_keys");
+
         #config dhcp ip address to static
         if ($ssh_ip eq $discover_ip) {
-            ($ret, $err) = cumulus_exec($exp, "ifconfig eth0 $static_ip");
+            #get netmask
+            my $mask;
+            foreach my $net (@nets) {
+                if (xCAT::NetworkUtils::isInSameSubnet( $net->{'net'}, $static_ip, $net->{'mask'}, 0)) {
+                    $mask=$net->{'mask'};
+                    last;
+                }
+            }
+            ($ret, $err) = cumulus_exec($exp, "ifconfig eth0 $static_ip netmask $mask");
         }
 
         $exp->hard_close();

--- a/xCAT/postscripts/hardeths
+++ b/xCAT/postscripts/hardeths
@@ -99,6 +99,13 @@ for nic in `ip link |grep "BROADCAST" |awk '{print $2}'   | sed s/://`; do
         NETWORK=`network_ipv4calc $IPADDR $NETMASK`
         #BROADCAST=`ifconfig $nic | grep Bcast | awk '{print $3}' | awk -F: '{print $2}'`
         BROADCAST=`ip -4 -oneline addr show $nic|grep brd| awk -F ' ' '{print $6}'`
+
+        if [ ! -z "$BROADCAST" ]; then
+            broadcast_line="broadcast $BROADCAST"
+        else
+            broadcast_line=""
+        fi
+
         
         if [ ! -z "$defgw" ]; then
             gateway_line="gateway $defgw"
@@ -114,7 +121,7 @@ auto $nic
 iface $nic inet static
     address $IPADDR
     netmask $NETMASK
-    broadcast $BROADCAST
+    $broadcast_line
     $gateway_line
 
 
@@ -126,7 +133,7 @@ iface $nic inet static
     address $IPADDR
     network $NETWORK
     netmask $NETMASK
-    broadcast $BROADCAST
+    $broadcast_line
     $gateway_line
 
 


### PR DESCRIPTION
The switch is not able to reach any more after change ip address via ```switchdiscover --setup``` command.
The netmask defined in the networks table is different than the one on the cumulus switch.  So, when xCAT change dhcp ip address to static ip address for the switch, need to set correct netmask too.

modify postscripts hardeths to remove broadcast line from interfaces file if there is no broadcast address.