### PR TITLE
Improvements to `nodediscoverls`

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/nodediscoverls.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/nodediscoverls.1.rst
@@ -19,7 +19,7 @@ SYNOPSIS
 ********
 
 
-\ **nodediscoverls**\  [\ **-t seq | profile | switch | blade | manual | undef | all**\ ] [\ **-l**\ ]
+\ **nodediscoverls**\  [\ **-t seq | profile | switch | blade | manual | mtms | undef | all**\ ] [\ **-l**\ ]
 
 \ **nodediscoverls**\  [\ **-u**\  \ *uuid*\ ] [\ **-l**\ ]
 
@@ -47,7 +47,7 @@ OPTIONS
 
 
 
-\ **-t seq|profile|switch|blade|manual|undef|all**\ 
+\ **-t seq|profile|switch|blade|manual|mtms|undef|all**\ 
  
  Display the nodes that have been discovered by the specified discovery method:
  
@@ -69,6 +69,10 @@ OPTIONS
  
  
  \* \ **manual**\  - Manually discovery (used when defining node by nodediscoverdef command).
+ 
+ 
+ 
+ \* \ **mtms**\  - MTMS discovery (used when node mtm and serial fields are filled in).
  
  
  

--- a/xCAT-server/lib/xcat/plugins/seqdiscovery.pm
+++ b/xCAT-server/lib/xcat/plugins/seqdiscovery.pm
@@ -808,7 +808,7 @@ sub nodediscoverls {
 Usage: 
     nodediscoverls
     nodediscoverls [-h|--help|-v|--version] 
-    nodediscoverls [-t seq|profile|switch|blade|manual|undef|all] [-l] 
+    nodediscoverls [-t seq|profile|switch|blade|manual|mtms|undef|all] [-l] 
     nodediscoverls [-u uuid] [-l]
     ";
         $rsp = ();
@@ -843,7 +843,7 @@ Usage:
     # If the type is specified, display the corresponding type of nodes
     my @SEQDiscover;
     if ($type) {
-        if ($type !~ /^(seq|profile|switch|blade|manual|undef|all)$/) {
+        if ($type !~ /^(seq|profile|switch|blade|manual|mtms|undef|all)$/) {
             $usage->($callback, "The discovery type \'$type\' is not supported.");
             return;
         }

--- a/xCAT-server/lib/xcat/plugins/seqdiscovery.pm
+++ b/xCAT-server/lib/xcat/plugins/seqdiscovery.pm
@@ -917,7 +917,7 @@ Usage:
         } else {
             $ent->{'node'}   = 'undef' unless ($ent->{'node'});
             $ent->{'method'} = 'undef' unless ($ent->{'method'});
-            push @discoverednodes, sprintf("  %-40s%-20s%-15s%-10s%-20s", $ent->{'uuid'}, $ent->{'node'}, $ent->{'method'}, $ent->{'mtm'}, substr($ent->{'serial'}, 0, 19));
+            push @discoverednodes, sprintf("  %-40s%-20s%-15s%-10s %-20s", $ent->{'uuid'}, $ent->{'node'}, $ent->{'method'}, $ent->{'mtm'}, substr($ent->{'serial'}, 0, 19));
         }
     }
 
@@ -927,7 +927,7 @@ Usage:
     }
     if (@discoverednodes) {
         unless ($long) {
-            push @{ $rsp->{data} }, sprintf("  %-40s%-20s%-15s%-10s%-13s", 'UUID', 'NODE', 'METHOD', 'MTM', 'SERIAL');
+            push @{ $rsp->{data} }, sprintf("  %-40s%-20s%-15s%-10s %-20s", 'UUID', 'NODE', 'METHOD', 'MTM', 'SERIAL');
         }
         foreach (@discoverednodes) {
             push @{ $rsp->{data} }, "$_";


### PR DESCRIPTION
This MR introduces 2 changes:
* Changes to resolve #3904 (list discovered by type `mtms`)
* Add a space between MT and serial: I don't have even one node where the mtm values **does not** overflow into the serial field.