### PR TITLE
merge 6961ce0a10743741a5612a0027e8d254be856e1c  to 2.13 

### DIFF
--- a/xCAT-server/share/xcat/cons/openbmc
+++ b/xCAT-server/share/xcat/cons/openbmc
@@ -93,12 +93,11 @@ if ($ENV{SSHCONSOLEPORT}) {
 
 # To automatically connect to the console without the need to send over the ssh keys, 
 # ensure sshpass is installed on the Management and/or Service Nodes.
+print "If unable to open the console, ensure sshpass is installed or ssh keys have been configured on the BMC.\n";
 if (-x '/usr/bin/sshpass') {
-    exec "/usr/bin/sshpass -p $password ssh -p $sshport -l $username $bmcip";
+    exec "/usr/bin/sshpass -p $password ssh -p $sshport -l $username -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $bmcip";
 } else {
-    # This will prompt the user to enter the password for the BMC 
-    # if ssh keys are not sent and sshpass is not being used
-    exec "ssh -p $sshport -l $username $bmcip";
+    exec "ssh -p $sshport -l $username -o PasswordAuthentication=no -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $bmcip";
 }
 
 


### PR DESCRIPTION
Disable the ssh prompt when connecting the openbmc console (#3815)
This patch force the ssh client to use the ssh key only. It also
disable the known host check to avoid of the error after rflash.

Fix-issue: #3543