### PR TITLE
Fix the documentation from #3891

### DIFF
--- a/docs/source/guides/admin-guides/basic_concepts/xcat_db/regexp_db.rst
+++ b/docs/source/guides/admin-guides/basic_concepts/xcat_db/regexp_db.rst
@@ -95,6 +95,63 @@ Using easy regular expression support you would put this in the hosts table. ::
 In the easy regx example, the expression only has the 2nd part of the expression from the previous example. xCAT will evaluate the node name, matching the number part of the node name, and create the 1st part of the expression . The 2nd part supplied is what value to give the ip attribute. The resulting output is the same.
 
 
+Regular Expression Helper Functions
+-----------------------------------
+
+xCAT provides several functions that can simplify regular expressions.
+
+\ **a2idx** ASCII Character to Index\
+  Usage: ``a2idx(character)``
+
+  Turns a single character into a 1-indexed index. ‘a’ maps to 1 and ‘z’ maps to 26.
+
+\ **a2zidx** ASCII Character to 0-Index\
+  Usage: ``a2zidx(character)``
+
+  Turns a single character into a 0-indexed index. ‘a’ maps to 0 and ‘z’ maps to 25.
+
+\ **dim2idx** Dimensions to Index\
+  Usage: ``dim2idx(value, [count, value...])``
+
+  Converts dimensions (such as row, column, chassis, etc) into an index.  An example system consists of 8 racks, two rows with four columns each.
+
+  +-----------+-----------+-----------+-----------+
+  | row1-col1 | row1-col2 | row1-col3 | row1-col4 |
+  +-----------+-----------+-----------+-----------+
+  | row2-col1 | row2-col2 | row2-col3 | row2-col4 |
+  +-----------+-----------+-----------+-----------+
+  To obtain the rack index, use ``|row(\d+)-col(\d+)|(dim2idx($1, 4, $2))|``.  This maps the racks to:
+
+  +---+---+---+---+
+  | 1 | 2 | 3 | 4 |
+  +---+---+---+---+
+  | 5 | 6 | 7 | 8 |
+  +---+---+---+---+
+  Note that the size of the highest dimension (2 rows) is not needed, and all values are one-indexed.
+
+  If each rack contains 20 nodes, use ``|row(\d+)-col(\d+)-node(\d+)|(dim2idx($1, 4, $2, 20, $3)`` to determine a node index (useful for determining IP addresses).
+
+\ **skip** Skip indices\
+  Usage: ``skip(index, skiplist)``
+
+  Return an index with certain values skipped.  The skip list uses the format ``start[:count][,start[:count]...]``.  Using the example above, to skip racks 3 and 4, use:
+
+  ``|row(\d+)-col(\d+)|(skip(dim2idx($1, 4, $2),'3:2')|``
+
+  The result would be:
+
+  +---+---+---+---+
+  | 1 | 2 |   |   |
+  +---+---+---+---+
+  | 3 | 4 | 5 | 6 |
+  +---+---+---+---+
+
+\ **ipadd** Add to an IP address\
+  Usage: ``ipadd(octet1, octet2, octet3, octet4, toadd, skipstart, skipend)``
+
+  This function is useful when you need to cross octets. Optionally skip addresses at the start and end of octets (like .0 or .255 - technically those are valid IP addresses, but sometimes software makes poor assumptions about which broadcast and gateway addresses). 
+
+
 Verify your regular expression
 ------------------------------
 

--- a/docs/source/guides/admin-guides/references/man5/xcatdb.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/xcatdb.5.rst
@@ -157,27 +157,6 @@ Before you panic, let me explain each column:
 See http://www.perl.com/doc/manual/html/pod/perlre.html for information on perl regular expressions.
 
 
-Regular Expression Helper Functions
-============================
-
-xCAT provides several functions that can simplify regular expressions.
-
-\ **a2idx(character) **\
- Turns a single character into a 1-indexed index. ‘a’ maps to 1 and ‘z’ maps to 26.
-
-\ **a2zidx(character) **\
- Turns a single character into a 0-indexed index. ‘a’ maps to 0 and ‘z’ maps to 25.
-
-\ **dim2idx(value, [count, value...]) **\
- Converts dimensions (such as row, column, chassis, etc) into an index.  If each rack has 18 nodes, use dim2idx(racknum, 18, nodenum). Additional dimensions should be added at the beginning. All values are 1-indexed.
-
-\ **skip(index, skiplist) **\
- Return an index with certain values skipped.  The skip list uses the format start[:count][,start[:count]...]
-
-\ **ipadd(octet1, octet2, octet3, octet4, toadd, skipstart, skipend) **\
- Add to an IP address. Generally only necessary when you cross octets. Optionally skip addresses at the start and end of octets (like .0 or .255). Technically those are valid IP addresses, but sometimes software makes poor assumptions about which broadcast and gateway addresses. 
-
-
 Easy Regular Expressions
 ========================
 
@@ -185,6 +164,46 @@ Easy Regular Expressions
 As of xCAT 2.8.1, you can use a modified version of the regular expression support described in the previous section. You do not need to enter the node information (1st part of the expression), it will be derived from the input nodename. You only need to supply the 2nd part of the expression to determine the value to give the attribute. For examples, see
 
 http://xcat-docs.readthedocs.org/en/latest/guides/admin-guides/basic_concepts/xcat_db/regexp_db.html#easy-regular-expressions
+
+
+Regular Expression Helper Functions
+===================================
+
+
+xCAT provides several functions that can simplify regular expressions.
+
+
+\ **a2idx**\ 
+ 
+ ASCII Character to Index
+ 
+
+
+\ **a2zidx**\ 
+ 
+ ASCII Character to 0-Index
+ 
+
+
+\ **dim2idx**\ 
+ 
+ Dimensions to Index
+ 
+
+
+\ **skip**\ 
+ 
+ Skip indices
+ 
+
+
+\ **ipadd**\ 
+ 
+ Add to an IP address
+ 
+
+
+http://xcat-docs.readthedocs.org/en/latest/guides/admin-guides/basic_concepts/xcat_db/regexp_db.html#regular-expression-helper-functions
 
 
 

--- a/perl-xCAT/db2man
+++ b/perl-xCAT/db2man
@@ -271,6 +271,36 @@ As of xCAT 2.8.1, you can use a modified version of the regular expression suppo
 
 http://xcat-docs.readthedocs.org/en/latest/guides/admin-guides/basic_concepts/xcat_db/regexp_db.html#easy-regular-expressions
 
+=head2 Regular Expression Helper Functions
+
+xCAT provides several functions that can simplify regular expressions.
+
+=over 4
+
+=item B<a2idx>
+
+ASCII Character to Index
+
+=item B<a2zidx>
+
+ASCII Character to 0-Index
+
+=item B<dim2idx>
+
+Dimensions to Index
+
+=item B<skip>
+
+Skip indices
+
+=item B<ipadd>
+
+Add to an IP address
+
+=back
+
+http://xcat-docs.readthedocs.org/en/latest/guides/admin-guides/basic_concepts/xcat_db/regexp_db.html#regular-expression-helper-functions
+
 =head1 OBJECT DEFINITIONS
 
 Because it can get confusing what attributes need to go in what tables, the xCAT database can also


### PR DESCRIPTION
Add more examples of using the regex helpers.  Previous commit modified a man page directly instead of the db2man script.