### PR TITLE
Add node name in output of reventlog for OpenBMC

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1631,13 +1631,13 @@ sub reventlog_response {
         my $count = 0;
         if ($option_s) {
             foreach my $key ( sort { $b <=> $a } keys %output) {
-                xCAT::MsgUtils->message("I", { data => [$output{$key}] }, $callback, $node) if ($output{$key});
+                xCAT::MsgUtils->message("I", { data => ["$node: $output{$key}"] }, $callback) if ($output{$key});
                 $count++;
                 last if ($entry_string ne "all" and $count >= $entry_num); 
             }
         } else {
             foreach my $key (sort keys %output) {
-                xCAT::MsgUtils->message("I", { data => [$output{$key}] }, $callback, $node) if ($output{$key});
+                xCAT::MsgUtils->message("I", { data => ["$node: $output{$key}"] }, $callback) if ($output{$key});
                 $count++;
                 last if ($entry_string ne "all" and $count >= $entry_num);
             }


### PR DESCRIPTION
After modified:
```
# reventlog austintest -s
austintest: 09/17/2017 08:10:30 [42] org.open_power.Host.Error.WatchdogTimedOut
austintest: 09/17/2017 08:08:47 [41] org.open_power.Host.Error.Checkstop
austintest: 09/17/2017 08:08:40 [40] org.open_power.Host.Event.Error.Event
austintest: 09/17/2017 08:08:39 [39] org.open_power.Host.Event.Error.Event
austintest: 09/17/2017 08:08:35 [38] org.open_power.Host.Event.Error.Event
```