### PR TITLE
enhance makehosts support tagged vlan

### DIFF
--- a/xCAT-server/lib/xcat/plugins/hosts.pm
+++ b/xCAT-server/lib/xcat/plugins/hosts.pm
@@ -165,8 +165,8 @@ sub build_line
         $longname  = "$node.$domain";
     }
 
-    # if shortname contains a dot then we have a bad syntax for name
-    if ($shortname =~ /\./) {
+    # if shortname contains a dot then we have a bad syntax for name except tagged vlan
+    if ($shortname =~ /\./ && $shortname !~ /\.(\d)+/) {
         my $rsp;
         push @{ $rsp->{data} }, "Invalid short node name \'$shortname\'. The short node name may not contain a dot. The short node name is considered to be anything preceeding the network domain name in the fully qualified node name \'$longname\'.\n";
         xCAT::MsgUtils->message("E", $rsp, $callback);

--- a/xCAT-server/lib/xcat/plugins/hosts.pm
+++ b/xCAT-server/lib/xcat/plugins/hosts.pm
@@ -166,7 +166,7 @@ sub build_line
     }
 
     # if shortname contains a dot then we have a bad syntax for name except tagged vlan
-    if ($shortname =~ /\./ && $shortname !~ /\.(\d)+/) {
+    if ($shortname =~ /\./ && $shortname !~ /\.\d{1,4}$/) {
         my $rsp;
         push @{ $rsp->{data} }, "Invalid short node name \'$shortname\'. The short node name may not contain a dot. The short node name is considered to be anything preceeding the network domain name in the fully qualified node name \'$longname\'.\n";
         xCAT::MsgUtils->message("E", $rsp, $callback);


### PR DESCRIPTION
#3939 

Unit test, 
enP1p12s0f0.a is invalid nic,  
c699mgt00 is for installnic, 
c699mgt00-enP1p12s0f0 is for 10.3.100.17, 
c699mgt00-eth0-6 is for 10.6.100.17, 
c699mgt00-enP1p12s0f0.5 is tagged vlan host name for 10.5.100.17

```
[root@bybc0602 /]# lsdef c699mgt00
Object name: c699mgt00
    arch=x86_64
    groups=kvm
    ip=10.5.106.99
    nichostnamesuffixes.enP1p12s0f1=-eth1
    nichostnamesuffixes.enP1p12s0f0.6=-eth0-6
    nichostnamesuffixes.enP1p12s0f3=-eth3
    nicips.enP1p12s0f0.a=10.4.100.17
    nicips.enP1p12s0f0.6=10.6.100.17
    nicips.enP1p12s0f0=10.3.100.17
    nicips.enP1p12s0f0.5=10.5.100.17
    nicnetworks.enP1p12s0f0.a=10_0_0_0-255_0_0_0
    nicnetworks.enP1p12s0f0.6=10_0_0_0-255_0_0_0
    nicnetworks.enP1p12s0f0=10_0_0_0-255_0_0_0
    nicnetworks.enP1p12s0f0.5=10_0_0_0-255_0_0_0
    nictypes.enP1p12s0f0.3=Ethernet
    nictypes.ib0=Infiniband
    nictypes.enP1p12s0f2=Ethernet
    nictypes.enP1p12s0f0=Ethernet
    nictypes.enP1p12s0f3=Ethernet
    nictypes.enP1p12s0f1=Ethernet
    nictypes.enP1p12s0f0.a=Ethernet
    nictypes.enP1p12s0f0.6=Ethernet
    nictypes.enP1p12s0f0.5=Ethernet
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
[root@bybc0602 /]# vim /etc/hosts
[root@bybc0602 /]# grep c699mgt00 /etc/hosts
[root@bybc0602 /]# makehosts c699mgt00
Error: Invalid short node name 'c699mgt00-enP1p12s0f0.a'. The short node name may not contain a dot. The short node name is considered to be anything preceeding the network domain name in the fully qualified node name 'c699mgt00-enP1p12s0f0.a.cluster.com'.

[root@bybc0602 /]# grep c699mgt00 /etc/hosts
10.5.106.99 c699mgt00 c699mgt00.cluster.com
10.3.100.17 c699mgt00-enP1p12s0f0 c699mgt00-enP1p12s0f0.cluster.com
10.6.100.17 c699mgt00-eth0-6 c699mgt00-eth0-6.cluster.com
10.5.100.17 c699mgt00-enP1p12s0f0.5 c699mgt00-enP1p12s0f0.5.cluster.com
```