### PR TITLE
Treat 5104-22C as a ESS Boston node for rflash command

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -1991,10 +1991,10 @@ sub do_firmware_update {
     }
 
     # For IBM Power S822LC for Big Data (Supermicro) machines such as 
-    # P9 Boston (9006-22C, 9006-12) or P8 Briggs (8001-22C) 
+    # P9 Boston (9006-22C, 9006-12C, 5104-22C) or P8 Briggs (8001-22C) 
     # firmware update is done using pUpdate utility expected to be in the 
     # specified data directory along with the update files .bin for BMC or .pnor for Host
-    if ($output =~ /8001-22C|9006-22C|9006-12C/) {
+    if ($output =~ /8001-22C|9006-22C|5104-22C|9006-12C/) {
         # Verify valid data directory was specified
         unless ($pUpdate_directory) {
             $exit_with_error_func->($sessdata->{node}, $callback,


### PR DESCRIPTION
Add another Chassis ID for Boston node: 5104-22C