### PR TITLE
Fix #3930, SN will dispatch "nodeset <node> offline" command back to MN

### DIFF
--- a/xCAT-server/lib/xcat/plugins/dhcp.pm
+++ b/xCAT-server/lib/xcat/plugins/dhcp.pm
@@ -1128,7 +1128,7 @@ sub preprocess_request
                     $callback->({ error => [ "Hierarchy requested, therefore networks.dhcpserver must be set for net=" . $_->{net} . "" ], errorcode => [1] });
                     return [];
                 }
-                push @dhcpsvrs, $_->{dhcpserver};
+                push @dhcpsvrs, $_->{dhcpserver} if (xCAT::NetworkUtils->nodeonmynet($_->{dhcpserver}));
                 xCAT::MsgUtils->trace($verbose_on_off, "d", "dhcp: dhcp server on $_->{net}: $_->{dhcpserver}");
             }
         }

--- a/xCAT-server/lib/xcat/plugins/grub2.pm
+++ b/xCAT-server/lib/xcat/plugins/grub2.pm
@@ -504,8 +504,7 @@ sub preprocess_request {
             if ($ntab) {
                 foreach (@{ $ntab->getAllEntries() }) {
                     next unless ($_->{dynamicrange});
-                    # if dynamicrange specified but dhcpserver was not - issue error message
-                    push @dhcpsvrs, $_->{dhcpserver} if ($_->{dhcpserver})
+                    push @dhcpsvrs, $_->{dhcpserver} if ($_->{dhcpserver} && xCAT::NetworkUtils->nodeonmynet($_->{dhcpserver}));
                 }
             }
             return xCAT::Scope->get_broadcast_disjoint_scope_with_parallel($req, $sn_hash, \@dhcpsvrs);
@@ -854,7 +853,11 @@ sub process_request {
                 push(@rmdhcp_nodes, $tmp_node);
             }
         }
-        $sub_req->({ command => ['makedhcp'], arg => ['-d'], node => \@rmdhcp_nodes }, $callback);
+        if ($request->{'_disparatetftp'}->[0]) {
+            $sub_req->({ command => ['makedhcp'], arg => ['-d', '-l'], node => \@rmdhcp_nodes }, $callback);
+        } else {
+            $sub_req->({ command => ['makedhcp'], arg => ['-d'], node => \@rmdhcp_nodes }, $callback);
+        }
     }
 
     #now run the end part of the prescripts

--- a/xCAT-server/lib/xcat/plugins/xnba.pm
+++ b/xCAT-server/lib/xcat/plugins/xnba.pm
@@ -442,8 +442,7 @@ sub preprocess_request {
             if ($ntab) {
                 foreach (@{ $ntab->getAllEntries() }) {
                     next unless ($_->{dynamicrange});
-                    # if dynamicrange specified but dhcpserver was not - issue error message
-                    push @dhcpsvrs, $_->{dhcpserver} if ($_->{dhcpserver})
+                    push @dhcpsvrs, $_->{dhcpserver} if ($_->{dhcpserver} && xCAT::NetworkUtils->nodeonmynet($_->{dhcpserver}));
                 }
             }
             return xCAT::Scope->get_broadcast_disjoint_scope_with_parallel($req, $sn_hash, \@dhcpsvrs);
@@ -696,22 +695,19 @@ sub process_request {
     }
     xCAT::MsgUtils->trace($verbose_on_off, "d", "xnba: Finish to handle configurations");
 
-    # for offline operation, remove the dhcp entries
-    if ($args[0] eq 'offline') {
-        $sub_req->({ command => ['makedhcp'], arg => ['-d'], node => \@nodes }, $::XNBA_callback);
-    }
-
     #dhcp stuff -- inittime is set when xcatd on sn is started
-    unless (($inittime) || ($args[0] eq 'offline')) {
+    unless ($inittime) {
         my $do_dhcpsetup = 1;
         my @entries = xCAT::TableUtils->get_site_attribute("dhcpsetup");
         my $t_entry = $entries[0];
         if (defined($t_entry)) {
             if ($t_entry =~ /0|n|N/) { $do_dhcpsetup = 0; }
         }
-        if ($do_dhcpsetup) {
+        # For offline operation, remove the dhcp entries whatever dhcpset is disabled in site ( existing code logic, just keep it as is)
+        if ($do_dhcpsetup || $args[0] eq 'offline') {
             my @parameter;
             push @parameter, '-l' if ($::XNBA_request->{'_disparatetftp'}->[0]);
+            push @parameter, '-d' if ($args[0] eq 'offline');
             xCAT::MsgUtils->trace($verbose_on_off, "d", "xnba: issue makedhcp request");
 
             $sub_req->({ command => ['makedhcp'],


### PR DESCRIPTION
Fix #3930, 
1, only re-distribute to accessible dhcpsrv; 2, for non-sha…redtftp mode, run makedhcp -d -l for offline

UT: Pass in a environment which can reproduce this issue and patch on both MN/SN
```
# nodeset mid05tor12cn02 offline
mid05tor12cn02: offline
mid05tor12cn02: offline
```