### PR TITLE
add another several mac prefixes for edgecore network devices

### DIFF
--- a/perl-xCAT/xCAT/data/switchinfo.pm
+++ b/perl-xCAT/xCAT/data/switchinfo.pm
@@ -18,7 +18,10 @@ our %global_mac_identity = (
     "fc:cf:62" => "BNT G8124 switch",
     "7c:fe:90" => "Mellanox IB switch",
     "cc:37:ab" => "Edgecore Networks Switch",
-    "8c:ea:1b" => "Edgecore Networks Switch"
+    "8c:ea:1b" => "Edgecore Networks Switch",
+    "a8:2b:b5" => "Edgecore Networks Switch",
+    "3c:2c:99" => "Edgecore Networks Switch",
+    "70:72:cf" => "Edgecore Networks Switch"
 );
 
 #the hash to lookup switch type with vendor


### PR DESCRIPTION
add mac prefix of edgecore switches from http://standards-oui.ieee.org/oui.txt:
````
[root@c910f03c05k21 ~]# cat /tmp/oui.txt |grep -i "edgecore"
CC-37-AB   (hex)		Edgecore Networks Corportation
CC37AB     (base 16)		Edgecore Networks Corportation
70-72-CF   (hex)		EdgeCore Networks
7072CF     (base 16)		EdgeCore Networks
8C-EA-1B   (hex)		Edgecore Networks Corporation
8CEA1B     (base 16)		Edgecore Networks Corporation
A8-2B-B5   (hex)		Edgecore Networks Corporation
A82BB5     (base 16)		Edgecore Networks Corporation
3C-2C-99   (hex)		Edgecore Networks Corporation
3C2C99     (base 16)		Edgecore Networks Corporation
````