### PR TITLE
nic interface check to avoid dot in short host name

### DIFF
--- a/perl-xCAT/xCAT/Schema.pm
+++ b/perl-xCAT/xCAT/Schema.pm
@@ -1551,14 +1551,14 @@ passed as argument rather than by table value',
                         If multiple ip addresses are associated with each NIC:
                             <nic1>!<ext1>|<ext2>,<nic2>!<ext1>|<ext2>,..., for example,  eth0!-eth0|-eth0-ipv6,ib0!-ib0|-ib0-ipv6. 
                         The xCAT object definition commands support to use nichostnamesuffixes.<nicname> as the sub attributes. 
-                        Note:  According to DNS rules a hostname must be a text string up to 24 characters drawn from the alphabet (A-Z), digits (0-9), minus sign (-),and period (.). When you are specifying "nichostnamesuffixes" or "nicaliases" make sure the resulting hostnames will conform to this naming convention',
+                        Note:  According to DNS rules a hostname must be a text string up to 24 characters drawn from the alphabet (A-Z), digits (0-9) and minus sign (-). When you are specifying "nichostnamesuffixes" or "nicaliases" make sure the resulting hostnames will conform to this naming convention',
             nichostnameprefixes => 'Comma-separated list of hostname prefixes per NIC. 
                         If only one ip address is associated with each NIC:
                             <nic1>!<ext1>,<nic2>!<ext2>,..., for example, eth0!eth0-,ib0!ib-
                         If multiple ip addresses are associated with each NIC:
                             <nic1>!<ext1>|<ext2>,<nic2>!<ext1>|<ext2>,..., for example,  eth0!eth0-|eth0-ipv6i-,ib0!ib-|ib-ipv6-. 
                         The xCAT object definition commands support to use nichostnameprefixes.<nicname> as the sub attributes. 
-                        Note:  According to DNS rules a hostname must be a text string up to 24 characters drawn from the alphabet (A-Z), digits (0-9), minus sign (-),and period (.). When you are specifying "nichostnameprefixes" or "nicaliases" make sure the resulting hostnames will conform to this naming convention',
+                        Note:  According to DNS rules a hostname must be a text string up to 24 characters drawn from the alphabet (A-Z), digits (0-9) and minus sign (-). When you are specifying "nichostnameprefixes" or "nicaliases" make sure the resulting hostnames will conform to this naming convention',
             nictypes => 'Comma-separated list of NIC types per NIC. <nic1>!<type1>,<nic2>!<type2>, e.g. eth0!Ethernet,ib0!Infiniband. The xCAT object definition commands support to use nictypes.<nicname> as the sub attributes.',
             niccustomscripts => 'Comma-separated list of custom scripts per NIC.  <nic1>!<script1>,<nic2>!<script2>, e.g. eth0!configeth eth0, ib0!configib ib0. The xCAT object definition commands support to use niccustomscripts.<nicname> as the sub attribute
 .',

--- a/xCAT-server/lib/xcat/plugins/hosts.pm
+++ b/xCAT-server/lib/xcat/plugins/hosts.pm
@@ -731,7 +731,7 @@ sub donics
 
                     if ($nic =~ /\./) {
                          my $rsp;
-                         push @{ $rsp->{data} }, "$node: since \'$nic\' contains dot, nics.nichostnamesuffixes should be configured without dot for \'$nic\' interface.";
+                         push @{ $rsp->{data} }, "$node: since \'$nic\' contains dot, nics.nichostnamesuffixes.$nic should be configured without dot for \'$nic\' interface.";
                          xCAT::MsgUtils->message("E", $rsp, $callback);
                          next;
                     }
@@ -741,13 +741,13 @@ sub donics
 
                 } elsif ($nich->{$nic}->{nicsufx}->[$i] && $nich->{$nic}->{nicsufx}->[$i] =~ /\./) {
                     my $rsp;
-                    push @{ $rsp->{data} }, "$node: the value \'$nich->{$nic}->{nicsufx}->[$i]\' of nics.nichostnamesuffixes should not contain dot.";
+                    push @{ $rsp->{data} }, "$node: the value \'$nich->{$nic}->{nicsufx}->[$i]\' of nics.nichostnamesuffixes.$nic should not contain dot.";
                     xCAT::MsgUtils->message("E", $rsp, $callback);
                     delete $nich->{$nic}->{nicsufx}->[$i];
                     next;
                 } elsif ($nich->{$nic}->{nicprfx}->[$i] && $nich->{$nic}->{nicprfx}->[$i] =~ /\./) {
                     my $rsp;
-                    push @{ $rsp->{data} }, "$node: the value \'$nich->{$nic}->{nicprfx}->[$i]\' of nics.nichostnameprefixes should not contain dot.";
+                    push @{ $rsp->{data} }, "$node: the value \'$nich->{$nic}->{nicprfx}->[$i]\' of nics.nichostnameprefixes.$nic should not contain dot.";
                     xCAT::MsgUtils->message("E", $rsp, $callback);
                     delete $nich->{$nic}->{nicprfx}->[$i];
                     next;

--- a/xCAT-server/lib/xcat/plugins/hosts.pm
+++ b/xCAT-server/lib/xcat/plugins/hosts.pm
@@ -165,7 +165,7 @@ sub build_line
         $longname  = "$node.$domain";
     }
 
-    # if shortname contains a dot then we have a bad syntax for name
+    # if shortname contains a dot then we have a bad syntax for name 
     if ($shortname =~ /\./) {
         my $rsp;
         push @{ $rsp->{data} }, "Invalid short node name \'$shortname\'. The short node name may not contain a dot. The short node name is considered to be anything preceeding the network domain name in the fully qualified node name \'$longname\'.\n";
@@ -729,9 +729,28 @@ sub donics
             for (my $i = 0 ; $i < $nicindex{$nic} ; $i++) {
                 if (!$nich->{$nic}->{nicsufx}->[$i] && !$nich->{$nic}->{nicprfx}->[$i]) {
 
+                    if ($nic =~ /\./) {
+                         my $rsp;
+                         push @{ $rsp->{data} }, "$node: since \'$nic\' contains dot, nics.nichostnamesuffixes should be configured without dot for \'$nic\' interface.";
+                         xCAT::MsgUtils->message("E", $rsp, $callback);
+                         next;
+                    }
                     # then we have no suffix at all for this
                     # so set a default
                     $nich->{$nic}->{nicsufx}->[$i] = "-$nic";
+
+                } elsif ($nich->{$nic}->{nicsufx}->[$i] && $nich->{$nic}->{nicsufx}->[$i] =~ /\./) {
+                    my $rsp;
+                    push @{ $rsp->{data} }, "$node: the value \'$nich->{$nic}->{nicsufx}->[$i]\' of nics.nichostnamesuffixes should not contain dot.";
+                    xCAT::MsgUtils->message("E", $rsp, $callback);
+                    delete $nich->{$nic}->{nicsufx}->[$i];
+                    next;
+                } elsif ($nich->{$nic}->{nicprfx}->[$i] && $nich->{$nic}->{nicprfx}->[$i] =~ /\./) {
+                    my $rsp;
+                    push @{ $rsp->{data} }, "$node: the value \'$nich->{$nic}->{nicprfx}->[$i]\' of nics.nichostnameprefixes should not contain dot.";
+                    xCAT::MsgUtils->message("E", $rsp, $callback);
+                    delete $nich->{$nic}->{nicprfx}->[$i];
+                    next;
                 }
             }
         }


### PR DESCRIPTION
#3939 

Unit test:

```
[root@bybc0602 xCAT_plugin]# lsdef c699mgt00
Object name: c699mgt00
    arch=x86_64
    groups=kvm
    ip=10.5.106.99
    nichostnameprefixes.enP1p12s0f0.4=-f0.4
    nichostnamesuffixes.enP1p12s0f1=-eth1
    nichostnamesuffixes.enP1p12s0f0.6=-eth0-6
    nichostnamesuffixes.enP1p12s0f3=-eth3
    nichostnamesuffixes.enP1p12s0f0.7=-enP1p12s0f0.7
    nicips.enP1p12s0f0.4=10.4.100.17
    nicips.enP1p12s0f0.6=10.6.100.17
    nicips.enP1p12s0f0=10.3.100.17
    nicips.enP1p12s0f0.7=10.7.100.17
    nicips.enP1p12s0f0.5=10.5.100.17
    nicnetworks.enP1p12s0f0.6=10_0_0_0-255_0_0_0
    nicnetworks.enP1p12s0f0=10_0_0_0-255_0_0_0
    nicnetworks.enP1p12s0f0.4=10_0_0_0-255_0_0_0
    nicnetworks.enP1p12s0f0.7=10_0_0_0-255_0_0_0
    nicnetworks.enP1p12s0f0.5=10_0_0_0-255_0_0_0
    nictypes.enP1p12s0f0.3=Ethernet
    nictypes.ib0=Infiniband
    nictypes.enP1p12s0f2=Ethernet
    nictypes.enP1p12s0f0=Ethernet
    nictypes.enP1p12s0f3=Ethernet
    nictypes.enP1p12s0f0.7=Ethernet
    nictypes.enP1p12s0f1=Ethernet
    nictypes.enP1p12s0f0.6=Ethernet
    nictypes.enP1p12s0f0.4=Ethernet
    nictypes.enP1p12s0f0.5=Ethernet
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles

[root@bybc0602 xCAT_plugin]# grep c699mgt00 /etc/hosts

[root@bybc0602 xCAT_plugin]# makehosts c699mgt00
Error: c699mgt00: the value '-f0.4' of nics.nichostnameprefixes should not contain dot.
Error: c699mgt00: the value '-enP1p12s0f0.7' of nics.nichostnamesuffixes should not contain dot.
Error: c699mgt00: since 'enP1p12s0f0.5' contains dot, nics.nichostnamesuffixes should be configured without dot for 'enP1p12s0f0.5' interface.

[root@bybc0602 xCAT_plugin]# grep c699mgt00 /etc/hosts
10.5.100.17 c699mgt00 c699mgt00.cluster.com
10.3.100.17 c699mgt00-enP1p12s0f0 c699mgt00-enP1p12s0f0.cluster.com
10.6.100.17 c699mgt00-eth0-6 c699mgt00-eth0-6.cluster.com
```