### PR TITLE
Fix issue 3951, rm all bmc nodes when discovered

### DIFF
--- a/xCAT-server/lib/xcat/plugins/nodediscover.pm
+++ b/xCAT-server/lib/xcat/plugins/nodediscover.pm
@@ -454,10 +454,16 @@ sub process_request {
             }
         }
     } else {
-
-        # Only BMC that doesn't support in-band configuration need to run rspconfig out-of-band, such as S822L running in OPAL model
-        xCAT::MsgUtils->message("S", "No bmcinband specified, need to configure BMC out-of-band");
-        xCAT::Utils->cleanup_for_powerLE_hardware_discovery($request, $doreq);
+        if (defined($request->{bmc_node}) and defined($request->{bmc_node}->[0])) {
+            my $bmc_node = $request->{bmc_node}->[0];
+            if ($bmc_node =~ /\,/) {
+                xCAT::MsgUtils->message("W", "Multiple BMC nodes matched with no bmcinband specified, please remove manually");
+            } else {
+                # Only BMC that doesn't support in-band configuration need to run rspconfig out-of-band, such as S822L running in OPAL model
+                xCAT::MsgUtils->message("S", "No bmcinband specified, need to configure BMC out-of-band");
+                xCAT::Utils->cleanup_for_powerLE_hardware_discovery($request, $doreq);
+            }
+        }
     }
 
 

--- a/xCAT-server/lib/xcat/plugins/seqdiscovery.pm
+++ b/xCAT-server/lib/xcat/plugins/seqdiscovery.pm
@@ -131,25 +131,25 @@ sub findme {
         }
     }
     my $bmc_node = undef;
+    my @bmc_nodes = ();
     if ($request->{'mtm'}->[0] and $request->{'serial'}->[0]) {
         my $mtms = $request->{'mtm'}->[0] . "*" . $request->{'serial'}->[0];
         my $tmp_nodes = $::XCATVPDHASH{$mtms};
         foreach (@$tmp_nodes) {
             if ($::XCATMPHASH{$_}) {
-                $bmc_node = $_;
+                push @bmc_nodes, $_;
             }
         }
     }
 
-    unless ($bmc_node) {
-        if ($request->{'bmcmac'}->[0]) {
-            my $bmcmac = lc($request->{'bmcmac'}->[0]);
-            $bmcmac =~ s/\://g;
-            my $tmp_node = "node-$bmcmac";
-            $bmc_node = $tmp_node if ($::XCATMPHASH{$tmp_node});
-        }
+    if ($request->{'bmcmac'}->[0]) {
+        my $bmcmac = lc($request->{'bmcmac'}->[0]);
+        $bmcmac =~ s/\://g;
+        my $tmp_node = "node-$bmcmac";
+        push @bmc_nodes, $tmp_node if ($::XCATMPHASH{$tmp_node});
     }
 
+    $bmc_node = join(",", @bmc_nodes);
     if ($node) {
         my $skiphostip;
         my $skipbmcip;

--- a/xCAT-server/lib/xcat/plugins/switch.pm
+++ b/xCAT-server/lib/xcat/plugins/switch.pm
@@ -336,25 +336,25 @@ sub process_request {
             }
         }
         my $bmc_node = undef;
+        my @bmc_nodes = ();
         if ($req->{'mtm'}->[0] and $req->{'serial'}->[0]) {
             my $mtms      = $req->{'mtm'}->[0] . "*" . $req->{'serial'}->[0];
             my $tmp_nodes = $::XCATVPDHASH{$mtms};
             foreach (@$tmp_nodes) {
                 if ($::XCATMPHASH{$_}) {
-                    $bmc_node = $_;
+                    push @bmc_nodes, $_;
                 }
             }
         }
 
-        unless ($bmc_node) {
-            if ($req->{'bmcmac'}->[0]) {
-                my $bmcmac = lc($req->{'bmcmac'}->[0]);
-                $bmcmac =~ s/\://g;
-                my $tmp_node = "node-$bmcmac";
-                $bmc_node = $tmp_node if ($::XCATMPHASH{$tmp_node});
-            }
+        if ($req->{'bmcmac'}->[0]) {
+            my $bmcmac = lc($req->{'bmcmac'}->[0]);
+            $bmcmac =~ s/\://g;
+            my $tmp_node = "node-$bmcmac";
+            push @bmc_nodes, $tmp_node if ($::XCATMPHASH{$tmp_node});
         }
 
+        $bmc_node = join(",", @bmc_nodes);
         if ($node) {
             xCAT::MsgUtils->message("S", "xcat.discovery.switch: ($req->{_xcat_clientmac}->[0]) Found node: $node");
 

--- a/xCAT-server/lib/xcat/plugins/typemtms.pm
+++ b/xCAT-server/lib/xcat/plugins/typemtms.pm
@@ -26,24 +26,24 @@ sub findme {
     my $mtms       = $request->{'mtm'}->[0] . "*" . $request->{'serial'}->[0];
     my $tmp_nodes  = $::XCATVPDHASH{$mtms};
     my @nodes      = ();
-    my $bmc_node;
+    my @bmc_nodes = ();
+    my $bmc_node = undef;
     foreach (@$tmp_nodes) {
         if ($::XCATMPHASH{$_}) {
-            $bmc_node = $_;
+            push @bmc_nodes, $_;
         } else {
             push @nodes, $_;
         }
     }
 
-    unless ($bmc_node) {
-        if ($request->{'bmcmac'}->[0]) {
-            my $bmcmac = lc($request->{'bmcmac'}->[0]);
-            $bmcmac =~ s/\://g;
-            my $tmp_node = "node-$bmcmac";
-            $bmc_node = $tmp_node if ($::XCATMPHASH{$tmp_node});
-        }
+    if ($request->{'bmcmac'}->[0]) {
+        my $bmcmac = lc($request->{'bmcmac'}->[0]);
+        $bmcmac =~ s/\://g;
+        my $tmp_node = "node-$bmcmac";
+        push @bmc_nodes, $tmp_node if ($::XCATMPHASH{$tmp_node});
     }
 
+    $bmc_node = join(",", @bmc_nodes);
     my $nodenum = $#nodes;
     if ($nodenum < 0) {
         xCAT::MsgUtils->message("S", "xcat.discovery.mtms: ($request->{_xcat_clientmac}->[0]) Warning: Could not find any node for $mtms using mtms-based discovery");


### PR DESCRIPTION
#3951 

Add all bmc nodes in ARRAY @bmc_nodes, rm all when node is discovered.
If BMC that doesn't support in-band configuration, show warning msg that rm bmc nodes manually.