### PR TITLE
reventlog clear for OpenBMC

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -138,8 +138,8 @@ my %status_info = (
     },
     REVENTLOG_CLEAR_REQUEST => {
         method         => "POST",
-        init_url       => "$openbmc_project_url/logging//action/delete",
-        data           => '{ "data": [] }',
+        init_url       => "$openbmc_project_url/logging/action/deleteAll",
+        data           => "[]",
     },
     REVENTLOG_CLEAR_RESPONSE => {
         process        => \&reventlog_response,
@@ -788,8 +788,6 @@ sub parse_command_status {
         if ($subcommand eq "clear") {
             $next_status{LOGIN_RESPONSE} = "REVENTLOG_CLEAR_REQUEST";
             $next_status{REVENTLOG_CLEAR_REQUEST} = "REVENTLOG_CLEAR_RESPONSE";
-            xCAT::SvrUtils::sendmsg("Command $command is not available now!", $callback);
-            return 1;
         } else {
             $next_status{LOGIN_RESPONSE} = "REVENTLOG_REQUEST";
             $next_status{REVENTLOG_REQUEST} = "REVENTLOG_RESPONSE";
@@ -1631,12 +1629,14 @@ sub reventlog_response {
 
         my $count = 0;
         if ($option_s) {
+            xCAT::SvrUtils::sendmsg("$::NO_ATTRIBUTES_RETURNED", $callback, $node) if (!%output);
             foreach my $key ( sort { $b <=> $a } keys %output) {
                 xCAT::MsgUtils->message("I", { data => ["$node: $output{$key}"] }, $callback) if ($output{$key});
                 $count++;
                 last if ($entry_string ne "all" and $count >= $entry_num); 
             }
         } else {
+            xCAT::SvrUtils::sendmsg("$::NO_ATTRIBUTES_RETURNED", $callback, $node) if (!%output);
             foreach my $key (sort keys %output) {
                 xCAT::MsgUtils->message("I", { data => ["$node: $output{$key}"] }, $callback) if ($output{$key});
                 $count++;


### PR DESCRIPTION
#3745 #3673 

```
# reventlog mid05tor12cn13 clear
mid05tor12cn13: [openbmc_debug] curl -k -c cjar -H "Content-Type: application/json" -d '{ "data": ["root", "xxxxxx"] }' https://172.12.139.113/login
mid05tor12cn13: [openbmc_debug] login_response 200 OK
mid05tor12cn13: [openbmc_debug] curl -k -b cjar -X POST -H "Content-Type: application/json" -d '{"data":[]}' https://172.12.139.113/xyz/openbmc_project/logging/action/deleteAll
mid05tor12cn13: [openbmc_debug] reventlog_clear_response 200 OK
mid05tor12cn13: clear
```

If no eventlog info got from BMC, print ``mid05tor12cn13: No attributes returned from the BMC.``