### PR TITLE
Fix typo in test case

### DIFF
--- a/xCAT-test/autotest/testcase/rpower/cases0
+++ b/xCAT-test/autotest/testcase/rpower/cases0
@@ -145,7 +145,8 @@ cmd:rpower $$CN onstandby
 cmd:a=0;while ! `rpower $$CN stat|grep "standby\|Standby" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 check:ouptut=~standby|Standby
 end
-start:rpower__wrongpasswd
+
+start:rpower_wrongpasswd
 description:rpower ipmi and openbmc using wrong passwd  
 Attribute: $$CN-The operation object of rpower command
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rpower/rpower_wrongpasswd_test.sh  -pt $$CN  $$rightbmcpasswd $$rightbmcusername
@@ -157,21 +158,25 @@ check:rc==0
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rpower/rpower_wrongpasswd_test.sh  -c $$CN
 check:rc==0
 end
+
 start:rpower_suspend_OpenpowerBmc
 cmd:rpower $$CN suspend
 check:output=~Error: unsupported command rpower suspend for OpenPOWER
 check:rc==1
 end
+
 start:rpower_softoff_OpenpowerBmc
 cmd:rpower $$CN softoff
 check:output=~Error: unsupported command rpower softoff for OpenPOWER
 check:rc==1
 end
+
 start:rpower_wake_OpenpowerBmc
 cmd:rpower $$CN wake
 check:output=~Error: unsupported command rpower wake for OpenPOWER
 check:rc==1
 end
+
 start:rpower_errorcommand_OpenpowerBmc
 cmd:rpower $$CN ddd
 check:output=~Unsupported command: 

--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -1182,18 +1182,18 @@ sub run_case {
 
                 #to run single line command
 
+                log_this($running_log_fd, "RUN:$cmd->[0] [$runstartstr]");
                 $cmd->[0]    = getfunc($cmd->[0]);
                 @output = &runcmd($cmd->[0]);
                 $rc     = $::RUNCMD_RC;
-                log_this($running_log_fd, "RUN:$cmd->[0] [$runstartstr]");
                 push(@caselog, "RUN:$cmd->[0] [$runstartstr]");
             } else {
 
                 #to run multiple lines command
 
+                log_this($running_log_fd, "RUN: [$runstartstr]", @{$cmd});
                 @output = runscript($cmd);
                 $rc     = $::RUNCMD_RC;
-                log_this($running_log_fd, "RUN: [$runstartstr]", @{$cmd});
                 push(@caselog, ("RUN: [$runstartstr]", @{$cmd}));
             }
 


### PR DESCRIPTION
what to change in this pull request:
1 fix a typo in case name, from ``rpower__wrongpasswd`` to ``rpower_wrongpasswd``
2 refine the format of ``xCAT-test/autotest/testcase/rpower/cases0``, make it easy to fine case
3 Refine xcattest, show log before command running. It is useful during debug.