### PR TITLE
enhance switchdiscover to deal with finding nodes hash

### DIFF
--- a/xCAT-server/lib/xcat/plugins/switchdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/switchdiscover.pm
@@ -351,6 +351,9 @@ sub process_request {
                 #appending mac address to end of hostname
                 my $name = $result->{$_}->{name};
                 if (exists $username_hash{$name}) {
+                    if ($name eq '') {
+                        $name = "$device";
+                    }
                     my $mac_str = lc($_);
                     $mac_str =~ s/\://g;
                     $result->{$_}->{name} = "$name-$mac_str";


### PR DESCRIPTION
The issue to enhance the processing logic for the finding nodes hash in #3953 .

The modification:
1. the nodes hash is using 'mac' as the keys, so no need to compare whether this is multiple entries for same mac address.
2. for difference MAC with same IP, the original process is merge verdor together and create a new entry. No special process in this modification.
No modification from outside.  