### PR TITLE
disable rpower reset and boot command for OpenBMC

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -545,6 +545,13 @@ sub parse_args {
         unless ($subcommand =~ /^on$|^off$|^softoff$|^reset$|^boot$|^bmcreboot$|^bmcstate$|^status$|^stat$|^state$/) {
             return ([ 1, "Unsupported command: $command $subcommand" ]);
         }
+        if ($subcommand =~ /^reset$|^boot$/) {
+            $check = unsupported($callback); 
+            if (ref($check) eq "ARRAY") { 
+                @$check[1] = "Command $command $subcommand is not supported now.\nPlease run 'rpower <node> off' and then 'rpower <node> on' instead.";
+                return $check;
+            }
+        }
     } elsif ($command eq "rinv") {
         $subcommand = "all" if (!defined($ARGV[0]));
         unless ($subcommand =~ /^model$|^serial$|^firm$|^cpu$|^dimm$|^all$/) {

--- a/xCAT-server/lib/xcat/plugins/rinstall.pm
+++ b/xCAT-server/lib/xcat/plugins/rinstall.pm
@@ -548,11 +548,6 @@ sub rinstall {
                     arg     => \@rpowerarg
             );
               
-            #TODO: When OPENBMC support is finished, this line should be removed     
-            if($hmkey =~ /^openbmc$/){
-                $req{environment}{XCAT_OPENBMC_DEVEL} = "YES";    
-            }
-
             my $res =
               xCAT::Utils->runxcmd(
                 \%req,


### PR DESCRIPTION
```
# rpower openbmc156 reset
Command rpower reset is not supported now.
Please run 'rpower <node> off' and then 'rpower <node> on' instead.
# rpower openbmc156 boot
Command rpower boot is not supported now.
Please run 'rpower <node> off' and then 'rpower <node> on' instead.
```

For rinstall:
```
# rinstall mid05tor12cn05 osimage=rhels7.4-snap2-ppc64le-install-compute
Provision node(s): mid05tor12cn05
Command rpower boot is not supported now.
Please run 'rpower <node> off' and then 'rpower <node> on' instead.
Error: Failed to run 'rpower' against the following nodes: mid05tor12cn05
```