### PR TITLE
Delete all '.' in mtm and serial string for OpenBMC

### DIFF
--- a/xCAT-genesis-scripts/bin/dodiscovery
+++ b/xCAT-genesis-scripts/bin/dodiscovery
@@ -159,10 +159,12 @@ fi
 
 flag_mtm=`echo '$MTM' | sed 's/0//g'`
 if [ $flag_mtm ] && [ "$MTM" != "unknown" ]; then
+	MTM=`echo $MTM | sed 's/\.//g'`
 	echo "<mtm>$MTM</mtm>" >> /tmp/discopacket
 fi
 flag_serial=`echo '$SERIAL' | sed 's/0//g'`
 if [ $flag_serial ] && [ "$SERIAL" != "unknown" ]; then
+	SERIAL=`echo $SERIAL | sed 's/\.//g'`
 	echo "<serial>$SERIAL</serial>" >> /tmp/discopacket
 fi
 if [ "$PLATFORM" != "unknown" ]; then

--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -1155,8 +1155,8 @@ sub bmcdiscovery_openbmc{
         }
 
         # delete space before and after
-        $mtm =~ s/^\s+|\s+$//g; 
-        $serial =~ s/^\s+|\s+$//g;
+        $mtm =~ s/^\s+|\s+$|\.+//g; 
+        $serial =~ s/^\s+|\s+$|\.+//g;
 
         $mtm = '' if ($mtm =~ /^0+$/);
         $serial = '' if ($serial =~ /^0+$/);


### PR DESCRIPTION
#3993
For current version of firmware, mtm and serial like this:
```
# rinv mid05tor12cn05 model
mid05tor12cn05: SYSTEM Model : 8335-GTC........
# rinv mid05tor12cn05 serial
mid05tor12cn05: SYSTEM SerialNumber : 1318C4A.........
```

Before modify:
```
# bmcdiscover --range 172.12.139.105
172.12.139.105,8335-GTC........,1318C4A.........,,,mp,bmc,,
```
After modify:
```
# bmcdiscover --range 172.12.139.105
172.12.139.105,8335-GTC,1318C4A,,,mp,bmc,,
```