### PR TITLE
enhance nodediscovery process: don't write "NOIP" if the node can not be resloved to an IP

### DIFF
--- a/xCAT-server/lib/xcat/plugins/blade.pm
+++ b/xCAT-server/lib/xcat/plugins/blade.pm
@@ -4579,6 +4579,10 @@ sub process_request {
         $req->{noderange}       = [$node];
         $req->{discoverymethod} = ['blade'];
         $doreq->($req);
+        if (defined($req->{error})) {
+            $request->{error}->[0] = '1';
+            $request->{error_msg}->[0] = $req->{error_msg}->[0];
+        }
         %{$req} = ();    #Clear request. it is done
         return 0;
     }

--- a/xCAT-server/lib/xcat/plugins/hpblade.pm
+++ b/xCAT-server/lib/xcat/plugins/hpblade.pm
@@ -771,6 +771,10 @@ sub process_request {
         my $req = {%$request};
         $req->{command}   = ['discovered'];
         $req->{noderange} = [ $macmap{$mac} ];
+        if (defined($req->{error})) {
+            $request->{error}->[0] = '1';
+            $request->{error_msg}->[0] = $req->{error_msg}->[0];
+        }
         $doreq->($req);
         %{$req} = ();    #Clear request. it is done
                          #undef $mactab;

--- a/xCAT-server/lib/xcat/plugins/nodediscover.pm
+++ b/xCAT-server/lib/xcat/plugins/nodediscover.pm
@@ -274,6 +274,7 @@ sub process_request {
         my @hostnames_to_update = ();
         my %bydriverindex;
         my $forcenic = 0; #-1 is force skip, 0 is use default behavior, 1 is force to be declared even if hosttag is skipped to do so
+        my $macs_withip = 0;
         foreach (@{ $request->{mac} }) {
             @ifinfo = split /\|/;
 
@@ -308,6 +309,7 @@ sub process_request {
             if ($ifinfo[3]) {
                 (my $ip, my $netbits) = split /\//, $ifinfo[3];
                 if ($ip =~ /\d+\.\d+\.\d+\.\d+/) {
+                    $macs_withip++;
                     my $ipn = unpack("N", inet_aton($ip));
                     my $mask = 2**$netbits - 1 << (32 - $netbits);
                     my $netn = inet_ntoa(pack("N", $ipn & $mask));
@@ -348,6 +350,9 @@ sub process_request {
             } else {
                 if ($forcenic == 1) { $macstring .= $currmac . "|"; }
             }
+        }
+        if ($macs_withip == 1 and $macstring =~ /\*NOIP\*/) {
+            return;
         }
         $macstring =~ s/\|\z//;
         $mactab->setNodeAttribs($node, { mac => $macstring });

--- a/xCAT-server/lib/xcat/plugins/seqdiscovery.pm
+++ b/xCAT-server/lib/xcat/plugins/seqdiscovery.pm
@@ -397,10 +397,15 @@ sub findme {
         my $req = {%$request};
         $req->{command}      = ['discovered'];
         $req->{noderange}    = [$node];
-        $request->{bmc_node} = [$bmc_node];
+        $req->{bmc_node} = [$bmc_node];
 
         $req->{updateswitch} = ['yes'];
         $subreq->($req);
+        if (defined($req->{error})) {
+            $request->{error}->[0] = '1';
+            $request->{error_msg}->[0] = $req->{error_msg}->[0];
+        }
+
         %{$req} = ();    #Clear req structure, it's done..
         undef $mactab;
     } else {

--- a/xCAT-server/lib/xcat/plugins/switch.pm
+++ b/xCAT-server/lib/xcat/plugins/switch.pm
@@ -373,6 +373,10 @@ sub process_request {
             $request->{noderange} = [$node];
             $request->{bmc_node}  = [$bmc_node];
             $doreq->($request);
+            if (defined($request->{error})) {
+                $req->{error}->[0] = '1';
+                $req->{error_msg}->[0] = $request->{error_msg}->[0];
+            }
             %{$request} = ();    #Clear req structure, it's done..
             undef $mactab;
         } else {

--- a/xCAT-server/lib/xcat/plugins/typemtms.pm
+++ b/xCAT-server/lib/xcat/plugins/typemtms.pm
@@ -60,6 +60,10 @@ sub findme {
         $req->{noderange} = [ $nodes[0] ];
         $req->{bmc_node}  = [$bmc_node];
         $subreq->($req);
+        if (defined($req->{error})) {
+            $request->{error}->[0] = '1';
+            $request->{error_msg}->[0] = $req->{error_msg}->[0];
+        }
         %{$req} = ();
     }
 }

--- a/xCAT-server/lib/xcat/plugins/zzzdiscovery.pm
+++ b/xCAT-server/lib/xcat/plugins/zzzdiscovery.pm
@@ -22,11 +22,15 @@ sub process_request {
     my $doreq = shift;
     if ($req->{command}->[0] eq 'findme') {
 
-        if (!defined($req->{discoverymethod}) or !defined($req->{discoverymethod}->[0]) or ($req->{discoverymethod}->[0] eq 'undef')) {
+        if (!defined($req->{discoverymethod}) or !defined($req->{discoverymethod}->[0]) or ($req->{discoverymethod}->[0] eq 'undef') or defined($req->{error})) {
+            my $error_msg = ".";
+            if (defined($req->{error_msg}) and defined($req->{error_msg}->[0])) {
+                $error_msg = ": ". $req->{error_msg}->[0];
+            }
             my $rsp = {};
-            $rsp->{error}->[0] = "The discovery request can not be processed";
+            $rsp->{error}->[0] = "The discovery request can not be processed".$error_msg;
             $cb->($rsp);
-            xCAT::MsgUtils->message("S", "xcat.discovery.zzzdiscovery: ($req->{_xcat_clientmac}->[0]) Failed to discover the node.");
+            xCAT::MsgUtils->message("S", "xcat.discovery.zzzdiscovery: ($req->{_xcat_clientmac}->[0]) Failed for node discovery".$error_msg);
 
             #now, notify the node that its findme request has been processed
             my $client_ip = $req->{'_xcat_clientip'};


### PR DESCRIPTION
The fix for #1270

enhance_nodediscover_process, don't write mac table and don't generate dhcp lease entry

In the client, it will be in the sending findme request loop, after admin run "makehosts <pre-defined-node>", the hardware discovery can update MAC address successfully after send out the next findme request.

The /var/log/xcat/cluster.log will show this right now:
```
Nov 15 11:16:34 briggs01 xcat[47212]: xcat.discovery.aaadiscovery: (70:e2:84:14:28:0e) Got a discovery request, attempting to discover the node...
Nov 15 11:16:34 briggs01 xcat[47212]: DEBUG xcatd: call plugin <blade> to handle command <findme>
Nov 15 11:16:34 briggs01 xcat[47212]: xcat.discovery.blade: (70:e2:84:14:28:0e) Warning: Could not find any nodes using blade-based discovery
Nov 15 11:16:34 briggs01 xcat[47212]: DEBUG xcatd: call plugin <profilednodes> to handle command <findme>
Nov 15 11:16:34 briggs01 xcat[47212]: DEBUG xcatd: call plugin <seqdiscovery> to handle command <findme>
Nov 15 11:16:34 briggs01 xcat[47212]: DEBUG xcatd: call plugin <switch> to handle command <findme>
Nov 15 11:16:34 briggs01 xcat[47212]: xcat.discovery.switch: (70:e2:84:14:28:0e) Found node: mid05tor12cn05
Nov 15 11:16:34 briggs01 xcat[47212]: DEBUG xcatd: call plugin <nodediscover> to handle command <discovered>
Nov 15 11:16:35 briggs01 xcat[47212]: xcat.discovery.nodediscover: Can not resolve IP for the matching node:mid05tor12cn05. Make sure "makehosts" and "makedns" have been run for mid05tor12cn05.
Nov 15 11:16:35 briggs01 xcat[47212]: xcat.discovery.zzzdiscovery: (70:e2:84:14:28:0e) Failed for node discovery: Can not resolve IP for the matching node:mid05tor12cn05.
Nov 15 11:16:35 briggs01 xcat[47212]: xcat.discovery.zzzdiscovery: Notify 172.12.139.5 that its findme request has been processed
```