### PR TITLE
Add -c option for switchdiscover command to pass in community string

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/switchdiscover.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/switchdiscover.1.rst
@@ -15,7 +15,7 @@ SYNOPSIS
 
 \ **switchdiscover [-v| -**\ **-version]**\ 
 
-\ **switchdiscover**\  [\ *noderange*\  | \ **-**\ **-range**\  \ *ip_ranges*\ ] \ **[-V] [-w][-r|-x|-z][-s**\  \ *scan_methods*\  \ **-**\ **-setup**\ ]
+\ **switchdiscover**\  [\ *noderange*\  | \ **-**\ **-range**\  \ *ip_ranges*\ ] \ **[-V] [-w][-r|-x|-z][-s**\  \ *scan_methods*\ ] [\ **-**\ **-setup**\ ] [\ **-c**\  \ *community*\ ]
 
 
 ***********
@@ -31,7 +31,7 @@ To view all the switches defined in the xCAT database use \ **lsdef -w "nodetype
 
 For lldp method, make sure that lldpd package is installed and lldpd is running on the xCAT management node. lldpd comes from xcat-dep package or you can get it from http://vincentbernat.github.io/lldpd/installation.html.
 
-For snmp method, make sure that snmpwalk command is installed and snmp is enabled for switches. To install snmpwalk, "yum install net-snmp-utils" for redhat and sles,  "apt-get install snmp" for Ubuntu.
+For snmp method, make sure that snmpwalk command is installed and snmp is enabled for switches. To install snmpwalk, "yum install net-snmp-utils" for redhat and sles,  "apt-get install snmp" for Ubuntu. The switchdiscover command only check the switches with default community string, if user already configured switch with other commmunity string, need to pass in with \ **-c**\  option for switchdiscover command to be able to discover.
 
 
 *******
@@ -115,6 +115,12 @@ OPTIONS
 \ **-**\ **-setup**\ 
  
  Process switch-based switch discovery. Update discovered switch's ip address, hostname and enable snmpv3 configuration based on the predefined switch.
+ 
+
+
+\ **-c**\ 
+ 
+ User defined community string for snmp scan.
  
 
 

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -328,7 +328,7 @@ my %usage = (
        pdudiscover [<noderange>|--range ipranges] [-r|-x|-z] [-w] [-V|--verbose] [--setup]",
     "switchdiscover" =>
       "Usage: switchdiscover [-h|--help|-v|--version]
-       switchdiscover [<noderange>|--range ipranges] [-s scan_methods] [-r|-x|-z] [-w] [-V|--verbose] [--setup]",
+       switchdiscover [<noderange>|--range ipranges] [-s scan_methods] [-c community] [-r|-x|-z] [-w] [-V|--verbose] [--setup]",
     "switchprobe" =>
       "Usage: switchprobe [<noderange>] [-V|--verbose | -c|--check]",
     "makentp" =>

--- a/xCAT-client/pods/man1/switchdiscover.1.pod
+++ b/xCAT-client/pods/man1/switchdiscover.1.pod
@@ -10,7 +10,7 @@ B<switchdiscover [-h| --help]>
 
 B<switchdiscover [-v| --version]>
 
-B<switchdiscover> [I<noderange> | B<--range> I<ip_ranges>] B<[-V] [-w][-r|-x|-z][-s> I<scan_methods> B<--setup>]
+B<switchdiscover> [I<noderange> | B<--range> I<ip_ranges>] B<[-V] [-w][-r|-x|-z][-s> I<scan_methods>] [B<--setup>] [B<-c> I<community>]
 
 
 
@@ -24,7 +24,7 @@ To view all the switches defined in the xCAT database use B<lsdef -w "nodetype=s
 
 For lldp method, make sure that lldpd package is installed and lldpd is running on the xCAT management node. lldpd comes from xcat-dep package or you can get it from http://vincentbernat.github.io/lldpd/installation.html. 
 
-For snmp method, make sure that snmpwalk command is installed and snmp is enabled for switches. To install snmpwalk, "yum install net-snmp-utils" for redhat and sles,  "apt-get install snmp" for Ubuntu. 
+For snmp method, make sure that snmpwalk command is installed and snmp is enabled for switches. To install snmpwalk, "yum install net-snmp-utils" for redhat and sles,  "apt-get install snmp" for Ubuntu. The switchdiscover command only check the switches with default community string, if user already configured switch with other commmunity string, need to pass in with B<-c> option for switchdiscover command to be able to discover. 
 
 
 =head1 OPTIONS
@@ -86,6 +86,10 @@ Stanza formatted output.
 =item B<--setup>
 
 Process switch-based switch discovery. Update discovered switch's ip address, hostname and enable snmpv3 configuration based on the predefined switch. 
+
+=item B<-c>          
+
+User defined community string for snmp scan.
 
 =back
 

--- a/xCAT-server/lib/xcat/plugins/switchdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/switchdiscover.pm
@@ -25,7 +25,7 @@ use xCAT::data::switchinfo;
 
 #global variables for this module
 my $device;
-my $community;
+my $community="public";
 my %globalopt;
 my @filternodes;
 my @iprange;
@@ -144,7 +144,7 @@ sub parse_args {
     # Process command-line flags
     #############################################
     if (!GetOptions( \%opt,
-            qw(h|help V|verbose v|version x z w r n range=s s=s setup pdu))) {
+            qw(h|help V|verbose v|version x z w r n range=s s=s c=s setup pdu))) {
         return( usage() );
     }
 
@@ -251,6 +251,14 @@ sub parse_args {
     if ( exists( $opt{n} )) {
         $globalopt{n} = 1;
     }
+
+    #########################################################
+    # Accept the community string from user
+    #########################################################
+    if ( exists( $opt{c} )) {
+        $community=$opt{c};
+    }
+
 
     #########################################################
     # setup discover switch
@@ -892,13 +900,6 @@ sub snmp_scan {
     }
     my @lines = split /\n/, $result;
   
-    #set community string for switch
-    $community = "public";
-    my @snmpcs = xCAT::TableUtils->get_site_attribute("snmpc");
-    my $tmp    = $snmpcs[0];
-    if (defined($tmp)) { $community = $tmp }
-
-
     foreach my $line (@lines) {
         my @array = split / /, $line;
         if ($line =~ /\b(\d{1,3}(?:\.\d{1,3}){3})\b/)


### PR DESCRIPTION
For issue #3977,

The default community string for switch and pdu will be **public**.  if user define different community other than default on those device already,  need to pass in the user defined community to switchdiscover command to be able to discover the device.  otherwise, snmpwalk command will failed and nothing will be discovered.