### PR TITLE
Do not query noderes table in subvars subroutine

### DIFF
--- a/xCAT-server/lib/perl/xCAT/Template.pm
+++ b/xCAT-server/lib/perl/xCAT/Template.pm
@@ -56,6 +56,7 @@ sub subvars {
     my $media_dir        = shift;
     my $platform         = shift;
     my $partitionfileval = shift;
+    my $tmpl_hash = shift;
     my %namedargs = @_; #further expansion of this function will be named arguments, should have happened sooner.
 
     unless ($namedargs{reusemachinepass}) {
@@ -88,10 +89,8 @@ sub subvars {
     my $master;
 
     #the "xcatmaster" attribute of the node
-    my $noderestab = xCAT::Table->new('noderes');
-    my $et = $noderestab->getNodeAttribs($node, ['xcatmaster']);
-    if ($et and $et->{'xcatmaster'}) {
-        $master = $et->{'xcatmaster'};
+    if ($tmpl_hash->{'xcatmaster'}) {
+        $master = $tmpl_hash->{'xcatmaster'};
     }
 
     unless ($master) {
@@ -375,9 +374,7 @@ sub subvars {
             $inc =~ s/#UNCOMMENTOENABLESSH#/ /g;
         }
 
-        my $nrtab = xCAT::Table->new("noderes");
-        my $tftpserver = $nrtab->getNodeAttribs($node, ['tftpserver']);
-        my $sles_sdk_media = "http://" . $tftpserver->{tftpserver} . $media_dir . "/sdk1";
+        my $sles_sdk_media = "http://" . $tmpl_hash->{tftpserver} . $media_dir . "/sdk1";
 
         $inc =~ s/#SLES_SDK_MEDIA#/$sles_sdk_media/eg;
 

--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -1021,7 +1021,7 @@ sub mkinstall
     my $mactab = xCAT::Table->new('mac');
     my %osents = %{ $ostab->getNodesAttribs(\@nodes, [ 'profile', 'os', 'arch', 'provmethod' ]) };
     my %rents = %{ $restab->getNodesAttribs(\@nodes,
-            [ 'xcatmaster', 'nfsserver', 'tftpdir', 'primarynic', 'installnic' ]) };
+            [ 'xcatmaster', 'nfsserver', 'tftpdir', 'primarynic', 'installnic', 'tftpserver' ]) };
     my %hents = %{ $hmtab->getNodesAttribs(\@nodes,
             [ 'serialport', 'serialspeed', 'serialflow' ]) };
     my %macents = %{ $mactab->getNodesAttribs(\@nodes, ['mac']) };
@@ -1068,13 +1068,18 @@ sub mkinstall
         my $netdrivers;
         my $driverupdatesrc;
         my $osupdir;
+        my %tmpl_hash;
 
         my $ient = $rents{$node}->[0];
         if ($ient and $ient->{xcatmaster})
         {
             $xcatmaster = $ient->{xcatmaster};
+            $tmpl_hash{"xcatmaster"} = $xcatmaster;
         } else {
             $xcatmaster = '!myipfn!';
+        }
+        if ($ient and $ient->{tftpserver}) {
+            $tmpl_hash{"tftpserver"} = $ient->{tftpserver};
         }
 
         my $osinst;
@@ -1330,6 +1335,7 @@ sub mkinstall
                 $pkgdir,
                 $platform,
                 $partfile,
+                \%tmpl_hash,
                 $os
               );
         }

--- a/xCAT-server/lib/xcat/plugins/debian.pm
+++ b/xCAT-server/lib/xcat/plugins/debian.pm
@@ -496,7 +496,7 @@ sub mkinstall {
     my %osents = %{ $ostab->getNodesAttribs(\@nodes, [ 'profile', 'os', 'arch', 'provmethod' ]) };
     my %rents =
       %{ $restab->getNodesAttribs(\@nodes,
-            [ 'xcatmaster', 'nfsserver', 'primarynic', 'installnic' ]) };
+            [ 'xcatmaster', 'nfsserver', 'primarynic', 'installnic', 'tftpserver' ]) };
     my %hents =
       %{ $hmtab->getNodesAttribs(\@nodes,
             [ 'serialport', 'serialspeed', 'serialflow' ]) };
@@ -537,6 +537,15 @@ sub mkinstall {
         my $pkglistfile;
         my $imagename;    # set it if running of 'nodeset osimage=xxx'
         my $platform;
+        my %tmpl_hash;
+
+        my $ient = $rents{$node}->[0];
+        if ($ient and $ient->{xcatmaster}) {
+            $tmpl_hash{"xcatmaster"} = $ient->{xcatmaster};
+        }
+        if ($ient and $ient->{tftpserver}) {
+            $tmpl_hash{"tftpserver"} = $ient->{tftpserver};
+        }
 
         my $osinst;
         my $ent = $osents{$node}->[0]; #$ostab->getNodeAttribs($node, ['profile', 'os', 'arch']);
@@ -732,7 +741,8 @@ sub mkinstall {
                 $pkglistfile,
                 $pkgdir,
                 $platform,
-                $partitionfile
+                $partitionfile,
+                \%tmpl_hash
               );
         }
 
@@ -752,14 +762,20 @@ sub mkinstall {
                 "",
                 "",
                 "",
-                $partitionfile
+                $partitionfile,
+                \%tmpl_hash
             );
         }
 
         if (-r "$postscript") {
             $posterr = xCAT::Template->subvars($postscript,
                 "$installroot/autoinst/" . $node . ".post",
-                $node
+                $node,
+                "",
+                "",
+                "",
+                "",
+                \%tmpl_hash
             );
         }
 

--- a/xCAT-server/lib/xcat/plugins/sles.pm
+++ b/xCAT-server/lib/xcat/plugins/sles.pm
@@ -804,7 +804,7 @@ sub mkinstall
         \@nodes,
         [
             'nfsserver', 'tftpdir', 'xcatmaster',
-            'primarynic', 'installnic'
+            'primarynic', 'installnic', 'tftpserver'
         ]
       );
     my $hments =
@@ -868,11 +868,19 @@ sub mkinstall
         my $driverupdatesrc;
         my $osupdir;
         my $imagename;    # set it if running of 'nodeset osimage=xxx'
+        my %tmpl_hash;
 
         if ($resents->{$node} and $resents->{$node}->[0]->{tftpdir}) {
             $tftpdir = $resents->{$node}->[0]->{tftpdir};
         } else {
             $tftpdir = $globaltftpdir;
+        }
+
+        if ($resents and $resents->{$node}->[0]->{xcatmaster} ) {
+            $tmpl_hash{"xcatmaster"} = $resents->{$node}->[0]->{xcatmaster};
+        }
+        if ($resents and $resents->{$node}->[0]->{tftpserver}) {
+            $tmpl_hash{"tftpserver"} = $resents->{$node}->[0]->{tftpserver};
         }
 
         xCAT::MsgUtils->trace($verbose_on_off, "d", "sles->mkinstall: tftpdir=$tftpdir");
@@ -1060,7 +1068,8 @@ sub mkinstall
                 $pkglistfile,
                 $tmppkgdir,
                 $os,
-                $partfile
+                $partfile,
+                \%tmpl_hash
               );
         }
 

--- a/xCAT-server/lib/xcat/plugins/windows.pm
+++ b/xCAT-server/lib/xcat/plugins/windows.pm
@@ -243,6 +243,8 @@ sub mkinstall
     my $bootparams = ${$request->{bootparams}};
     my $hmtab    = xCAT::Table->new('nodehm');
     my $vpdtab   = xCAT::Table->new('vpd');
+    my $restab = xCAT::Table->new('noderes');
+    my $resents = $restab->getNodesAttribs(\@nodes, ['xcatmaster', 'tftpserver']);
     my $vpdhash  = $vpdtab->getNodesAttribs(\@nodes, ['uuid']);
     my %img_hash = ();
     my $winimagetab;
@@ -282,6 +284,14 @@ sub mkinstall
         my $partfile;
         my $installto;
         my $winpepath;
+        my %tmpl_hash;
+
+        if ($resents and $resents->{$node}->[0]->{xcatmaster} ) {
+        $tmpl_hash{"xcatmaster"} = $resents->{$node}->[0]->{xcatmaster};
+    }
+        if ($resents and $resents->{$node}->[0]->{tftpserver}) {
+            $tmpl_hash{"tftpserver"} = $resents->{$node}->[0]->{tftpserver};
+        }
 
         my $ent = $osents->{$node}->[0];
         if ($ent and $ent->{provmethod} and ($ent->{provmethod} ne 'install') and ($ent->{provmethod} ne 'netboot') and ($ent->{provmethod} ne 'statelite')) {
@@ -465,7 +475,7 @@ sub mkinstall
                 $tmplfile,
                 "$installroot/autoinst/$node.xml",
                 $node,
-                0);
+                0,undef ,undef, undef, \%tmpl_hash);
         }
 
         if ($tmperr) {


### PR DESCRIPTION
This patch refactor the interface to get xcatmaster and tftpserver
attributes in the subvars subroutine to improve the performance.

partial-issue: #3958