### PR TITLE
Assume that any bmc that has nmap response on the openbmc_port is a openbmc server

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -670,8 +670,8 @@ sub scan_process {
 
                 my $nmap_cmd = "nmap ${$live_ip}[$i] -p $openbmc_port -Pn";
                 my $nmap_output = xCAT::Utils->runcmd($nmap_cmd, -1);
-                if ($nmap_output =~ /$openbmc_port(.+)/) {
-                    # if the openbmc_port exists at any nmap status, assume it's an OpenBMC server
+                if ($nmap_output !~ /$openbmc_port(.+)closed/) {
+                    # If the openbmc_port is anything execpt 'closed' assume it's OpenBMC server
                     bmcdiscovery_openbmc(${$live_ip}[$i], $opz, $opw, $request_command);
                 } else {
                     bmcdiscovery_ipmi(${$live_ip}[$i], $opz, $opw, $request_command);

--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -670,7 +670,8 @@ sub scan_process {
 
                 my $nmap_cmd = "nmap ${$live_ip}[$i] -p $openbmc_port -Pn";
                 my $nmap_output = xCAT::Utils->runcmd($nmap_cmd, -1);
-                if ($nmap_output =~ /$openbmc_port(.+)open/) {
+                if ($nmap_output =~ /$openbmc_port(.+)/) {
+                    # if the openbmc_port exists at any nmap status, assume it's an OpenBMC server
                     bmcdiscovery_openbmc(${$live_ip}[$i], $opz, $opw, $request_command);
                 } else {
                     bmcdiscovery_ipmi(${$live_ip}[$i], $opz, $opw, $request_command);


### PR DESCRIPTION
If the openbmc console port is returned by nmap, assume that it's openbmc

Resolves the bmcdiscover command for #4011 

Otherwise if the nmap state is anything other than `open` then we will fall into IPMI code, which is confusing... 