### PR TITLE
Fix rinv firm issue that no BMC firmware info show

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1466,6 +1466,12 @@ sub rinv_response {
                     }
                     next;
                 }
+
+                if ($purpose_value =~ "BMC" and $activation_value =~ "Active" and $priority_value == 255) {
+                    $content_info = "$purpose_value Firmware Product:   $content{Version} ($activation_value)";
+                    $content_info .= "*";
+                    push (@sorted_output, $content_info);
+                }
             }
         } else {
             if (! defined $content{Present}) {


### PR DESCRIPTION
OpenBMC firmware issue: https://github.com/openbmc/openbmc/issues/2373
```
'/xyz/openbmc_project/software/0' => {
                                                             'associations' => [
                                                                                 [
                                                                                   'inventory',
                                                                                   'activation',
                                                                                   '/xyz/openbmc_project/inventory/system/chassis/motherboard/boxelder/bmc'
                                                                                 ]
                                                                               ],
                                                             'Version' => 'ibm-v1.99.10-0-r7-0-gcce0f1b',
                                                             'RequestedActivation' => 'xyz.openbmc_project.Software.Activation.RequestedActivations.None',
                                                             'Path' => '',
                                                             'Purpose' => 'xyz.openbmc_project.Software.Version.VersionPurpose.BMC',
                                                             'Priority' => 255,
                                                             'Activation' => 'xyz.openbmc_project.Software.Activation.Activations.Active'
                                                           },
```
For 1738, BMC firmware  Priority value maybe 255 not 0. So if did not get BMC firmware info that priority 0, read the info that priority 255.

Before modify:
```
# rinv mid05tor12cn02 firm
mid05tor12cn02: HOST Firmware Product: IBM-witherspoon-redbud-ibm-OP9_v1.19_1.33 (Active)*
mid05tor12cn02: HOST Firmware Product: -- additional info: buildroot-2017.8-6-g319c6e1
mid05tor12cn02: HOST Firmware Product: -- additional info: capp-ucode-9c73e9f
mid05tor12cn02: HOST Firmware Product: -- additional info: hostboot-3d6c541
mid05tor12cn02: HOST Firmware Product: -- additional info: hostboot-binaries-836385d
mid05tor12cn02: HOST Firmware Product: -- additional info: linux-4.13-openpower1-pe8fb223
mid05tor12cn02: HOST Firmware Product: -- additional info: machine-xml-f8aaa73-p5482dba
mid05tor12cn02: HOST Firmware Product: -- additional info: occ-a43395b
mid05tor12cn02: HOST Firmware Product: -- additional info: op-build-450d9d7
mid05tor12cn02: HOST Firmware Product: -- additional info: petitboot-v1.5.1-p36336db
mid05tor12cn02: HOST Firmware Product: -- additional info: sbe-8d90ab2
mid05tor12cn02: HOST Firmware Product: -- additional info: skiboot-v5.8-73-g4a2b8317fd3f-p6faaa2d
```

After modify:
```
# rinv mid05tor12cn02 firm
mid05tor12cn02: BMC Firmware Product: ibm-v1.99.10-0-r7-0-gcce0f1b (Active)*
mid05tor12cn02: HOST Firmware Product: IBM-witherspoon-redbud-ibm-OP9_v1.19_1.33 (Active)*
mid05tor12cn02: HOST Firmware Product: -- additional info: buildroot-2017.8-6-g319c6e1
mid05tor12cn02: HOST Firmware Product: -- additional info: capp-ucode-9c73e9f
mid05tor12cn02: HOST Firmware Product: -- additional info: hostboot-3d6c541
mid05tor12cn02: HOST Firmware Product: -- additional info: hostboot-binaries-836385d
mid05tor12cn02: HOST Firmware Product: -- additional info: linux-4.13-openpower1-pe8fb223
mid05tor12cn02: HOST Firmware Product: -- additional info: machine-xml-f8aaa73-p5482dba
mid05tor12cn02: HOST Firmware Product: -- additional info: occ-a43395b
mid05tor12cn02: HOST Firmware Product: -- additional info: op-build-450d9d7
mid05tor12cn02: HOST Firmware Product: -- additional info: petitboot-v1.5.1-p36336db
mid05tor12cn02: HOST Firmware Product: -- additional info: sbe-8d90ab2
mid05tor12cn02: HOST Firmware Product: -- additional info: skiboot-v5.8-73-g4a2b8317fd3f-p6faaa2d
```