### PR TITLE
Workaround switches that report ifindex in bridge

### DIFF
--- a/perl-xCAT/xCAT/MacMap.pm
+++ b/perl-xCAT/xCAT/MacMap.pm
@@ -878,6 +878,21 @@ sub refresh_switch {
             }
             return;
         }
+        my $bridgeifvalid = 0;
+        foreach (keys %$mactoindexmap) {
+            my $index     = $mactoindexmap->{$_};
+            if (defined($bridgetoifmap->{$index})) {
+                $bridgeifvalid = 1;
+                last;
+            }
+        }
+        unless ($bridgeifvalid) {
+            # create a dummy bridgetoifmap to cover switches that thing it should go straight to ifindex
+            $bridgetoifmap = {};
+            foreach (keys %$namemap) {
+                $bridgetoifmap->{$_} = $_;
+            }
+        }
         if (defined($self->{collect_mac_info})) {
             my %index_to_mac = ();
             my %index_to_vlan = ();


### PR DESCRIPTION
Some switches report ifindex instead of bridge index.

This is not compliant behavior.  However, we can detect
that every last mac was a dead end, and assume this is
the case to try to get better result.  This won't work
if there is overlap in interface and bridge indexes, so
in that case, the spec compliant behavior is assumed.