### PR TITLE
Fix issue 3998, check node's status before send login request

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -362,6 +362,8 @@ my $xcatdebugmode = 0;
 
 my $flag_debug = "[openbmc_debug]";
 
+my @node_bmc_ips = ();
+
 #-------------------------------------------------------
 
 =head3  preprocess_request
@@ -482,12 +484,24 @@ sub process_request {
     $wait_node_num = keys %node_info;
     my @donargs = ();
 
+    my $all_bmc = join(" ", @node_bmc_ips);
+    my $valid_bmc = `nmap -sn -n $all_bmc | grep -B1 up | grep "Nmap scan report" |cut -d ' ' -f5 | tr -s '\n' ' '`;
+
     foreach my $node (keys %node_info) {
         $bmcip = $node_info{$node}{bmc};
 
         if ($request->{command}->[0] eq "getopenbmccons") {
             push @donargs, [ $node,$bmcip,$node_info{$node}{username}, $node_info{$node}{password}];
         } else {
+            if ($valid_bmc !~ /$bmcip/) {
+                if ($xcatdebugmode) {
+                    my $debug_info = "UNAVAILABLE Node by 'nmap -sP -n $bmcip'";
+                    process_debug_info($node, $debug_info);
+                } 
+                xCAT::SvrUtils::sendmsg($::RESPONSE_SERVICE_UNAVAILABLE, $callback, $node); 
+                $wait_node_num--;
+                next;
+            }
             $login_url = "$http_protocol://$bmcip/login";
             $content = '{ "data": [ "' . $node_info{$node}{username} .'", "' . $node_info{$node}{password} . '" ] }';
             $handle_id = xCAT::OPENBMC->new($async, $login_url, $content); 
@@ -1084,6 +1098,7 @@ sub parse_node_info {
             }
 
             $node_info{$node}{cur_status} = "LOGIN_REQUEST";
+            push @node_bmc_ips, $node_info{$node}{bmc};
         } else {
             xCAT::SvrUtils::sendmsg("Error: Unable to get information from openbmc table", $callback, $node);
             $rst = 1;


### PR DESCRIPTION
#3998 

rpower on against 500 nodes (Unavailable)
Before modify: **48 minutes**
After modify:    22~24s

Test result (against openbmc simulator)
```
Nodes/rpower       100/on     100/status   200/on     200/status  500/on     500/status   1000/on     1000/status   1000(500 Unavailable)
Befor modify:      9.838s     9.015s       19.545s    17.2s       47.205s    42.925s      1m33.809s    1m25.232s         43m28s
After modify:      10.238s    9.364s       19.916s    18.06s      48.12s     44.04s       1m35.388s    1m26.558s         46.195s
```