### PR TITLE
Change format of rinv/rvitals output for PDU

### DIFF
--- a/xCAT-server/lib/xcat/plugins/pdu.pm
+++ b/xCAT-server/lib/xcat/plugins/pdu.pm
@@ -765,7 +765,6 @@ sub process_pdudiscover {
 sub showMFR {
     my $noderange = shift;
     my $callback = shift;
-    my $output;
 
     my $nodetab = xCAT::Table->new('hosts');
     my $nodehash = $nodetab->getNodesAttribs($noderange,['ip','otherinterfaces']);
@@ -784,7 +783,12 @@ sub showMFR {
             xCAT::SvrUtils::sendmsg("Failed to list MFR information: $err", $callback);
         }
         if (defined $ret) {
-            xCAT::SvrUtils::sendmsg("$ret", $callback);
+            foreach my $line (split /[\r\n]+/, $ret) {
+                if ($line) {
+                    $line = join(' ',split(' ',$line));
+                    xCAT::SvrUtils::sendmsg("$line", $callback,$pdu);
+                }
+            }
         }
 
         $exp->hard_close();
@@ -810,7 +814,6 @@ sub showMFR {
 sub showMonitorData {
     my $noderange = shift;
     my $callback = shift;
-    my $output;
 
     my $nodetab = xCAT::Table->new('hosts');
     my $nodehash = $nodetab->getNodesAttribs($noderange,['ip','otherinterfaces']);
@@ -829,7 +832,12 @@ sub showMonitorData {
             xCAT::SvrUtils::sendmsg("Failed to show monitor data: $err", $callback);
         }
         if (defined $ret) {
-            xCAT::SvrUtils::sendmsg("$ret", $callback,$pdu);
+            foreach my $line (split /[\r\n]+/, $ret) {
+                if ($line) {
+                    $line = join(' ',split(' ',$line));
+                    xCAT::SvrUtils::sendmsg("$line", $callback,$pdu);
+                }
+            }
         }
 
         $exp->hard_close();


### PR DESCRIPTION
Change format of rinv and rvitals output
```
# rvitals coral-pdu
coral-pdu: **********************************************************
coral-pdu: PowerMeter Monitor
coral-pdu: **********************************************************
coral-pdu: AC Input Voltage A: 278.83
coral-pdu: AC Input Voltage B: 278.94
coral-pdu: AC Input Voltage C: 278.61
coral-pdu: AC Input Current A: 18.04
coral-pdu: AC Input Current B: 16.75
coral-pdu: AC Input Current C: 15.52
coral-pdu: AC Input Power A: 4765.92
coral-pdu: AC Input Power B: 4422.57
coral-pdu: AC Input POwer C: 4085.99
coral-pdu: AC Input Total Power : 13274.48
coral-pdu: AC Input Total Current: 51.85
coral-pdu: **********************************************************
````
````
# rinv coral-pdu
coral-pdu: **********************************************************
coral-pdu: MFR Info List
coral-pdu: **********************************************************
coral-pdu: PDU MAC Address: 98BE947F0077
coral-pdu: PDU Product Name: IBM Coral PDU
coral-pdu: PDU Manufacture Date: 1724
coral-pdu: PDU Hardware Revision: EA
coral-pdu: PDU Serial Number: M131T7000DEAZ
coral-pdu: **********************************************************
````


