### PR TITLE
Include sample postscripts to help admins check firmware version and update mellanox adapter firmware

### DIFF
--- a/xCAT/postscripts/check_mlnx_firmware
+++ b/xCAT/postscripts/check_mlnx_firmware
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+# Sample postscript that can be executed to check the Mellanox OFED version
+# and adapter firmware level on the Mellanox adapters installed on the target nodes
+#
+#
+BINARIES="ofed_info mst ibdev2netdev"
+for PROG in ${BINARIES}; do 
+    RC=`command -v ${PROG} >> /dev/nul 2>&1; echo $?`
+    if [[ ${RC} != 0 ]]; then
+        echo "${PROG} is not installed on this node, unable to check firmware levels."
+        exit 1
+    fi 
+done
+
+MELLANOX_SOFTWARE=`ofed_info -s | cut -d: -f1`
+echo "Mellanox Software: $MELLANOX_SOFTWARE"
+
+
+mst start >> /dev/null 
+if [[ $? != 0 ]]; then
+   echo "Error:  Could not start mst, cannot check adapter firmware level."
+   exit 1
+fi
+
+ibdev2netdev -v
+
+exit 0

--- a/xCAT/postscripts/update_mlnx_adapter_firmware
+++ b/xCAT/postscripts/update_mlnx_adapter_firmware
@@ -1,0 +1,62 @@
+#!/bin/sh
+# 
+# Sample postscript that can be executed to help update the firmware level on 
+# Mellanox hardware adapters on the target nodes
+#
+# This script requires passing in the path of the Mellanox OFED ISO 
+# located on the xCAT Management node under the /install directory. 
+#
+# If OFED file is located here: 
+# /install/mlnxofed/MLNX_OFED_LINUX-4.1-4.0.7.1-rhel7.4alternate-ppc64le.iso
+#
+# Call the script as follows: 
+#    updatenode <noderange> -P "update_mlnx_adapter_firmware /install/mlnxofed/MLNX_OFED_LINUX-4.1-4.0.7.1-rhel7.4alternate-ppc64le.iso"
+#
+MLNX_OFED_PATH=${1}
+
+if [[ -z ${1} ]]; then 
+   echo "Error: you must provide the path of the MLNX OFED ISO file" 
+   exit 1
+fi 
+
+WORKING_DIR="/"
+MLNX_ISO_FILE=`basename ${MLNX_OFED_PATH}`
+TARGET_ISO_FILE="${WORKING_DIR}/${MLNX_ISO_FILE}"
+
+echo "==> Mellanox OFED PATH: ${MLNX_OFED_PATH}"
+echo "==> Mellanox ODEF ISO: ${MLNX_ISO_FILE}" 
+
+if [[ -e ${TARGET_ISO_FILE} ]]; then 
+   rm -f ${TARGET_ISO_FILE}
+fi 
+
+echo "==> Retrieving file from http://${MASTER}/${MLNX_OFED_PATH}"
+wget -q http://${MASTER}/${MLNX_OFED_PATH} -O ${TARGET_ISO_FILE}
+
+ls -ltr ${TARGET_ISO_FILE}
+
+MOUNT_DIR="${WORKING_DIR}/mlnx_tmp_iso_dir"
+mkdir -p ${MOUNT_DIR}
+
+mount -o ro,loop ${TARGET_ISO_FILE} ${MOUNT_DIR}
+ls -ltr ${MOUNT_DIR}
+
+${MOUNT_DIR}/mlnxofedinstall --fw-update-only
+
+#
+# Clean up
+#
+sleep 1
+umount ${MOUNT_DIR}
+rmdir ${MOUNT_DIR}
+
+rm -f ${TARGET_ISO_FILE}
+
+
+echo "==> "
+echo "==> "
+echo "==> REBOOT THIS MACHINE FOR THE NEW FIRMWARE LEVEL TO TAKE EFFECT."
+echo "==> "
+echo "==> "
+
+exit 0


### PR DESCRIPTION
Create some sample postscripts that users can run to check
Mellanox OFED/Adapter firmware levels and update the adapter
firmware level independent on installing a new version of OFED

Sample of the `check_mlnx_firmware` script:
```
[root@briggs01 postscripts]# updatenode mid05tor12cn02 -P "check_mlnx_firmware" 
mid05tor12cn02: xcatdsklspost: downloaded postscripts successfully
mid05tor12cn02: Tue Oct  3 15:56:36 UTC 2017 Running postscript: check_mlnx_firmware
mid05tor12cn02: Mellanox Software: MLNX_OFED_LINUX-4.1-4.0.7.1
mid05tor12cn02: 0003:01:00.0 mlx5_0 (MT4121 - 00WT176SN  ) "PCIe4 2-port 100Gb EDR Adapter x16 fw 16.21.0082 port 1 (DOWN  ) ==> ib0 (Down)
mid05tor12cn02: 0003:01:00.1 mlx5_1 (MT4121 - 00WT176SN  ) "PCIe4 2-port 100Gb EDR Adapter x16 fw 16.21.0082 port 1 (DOWN  ) ==> ib1 (Down)
mid05tor12cn02: 0033:01:00.0 mlx5_2 (MT4121 - 00WT176SN  ) "PCIe4 2-port 100Gb EDR Adapter x16 fw 16.21.0082 port 1 (DOWN  ) ==> ib2 (Down)
mid05tor12cn02: 0033:01:00.1 mlx5_3 (MT4121 - 00WT176SN  ) "PCIe4 2-port 100Gb EDR Adapter x16 fw 16.21.0082 port 1 (DOWN  ) ==> ib3 (Down)
mid05tor12cn02: postscript: check_mlnx_firmware exited with code 0
mid05tor12cn02: Running of postscripts has completed.
```

Sample of the `update_mlnx_adapter_firmware` script: 
```
[root@briggs01 postscripts]# updatenode mid05tor12cn02 -P "update_mlnx_adapter_firmware /install/mlnxofed/MLNX_OFED_LINUX-4.1-4.0.7.1-rhel7.4alternate-ppc64le.iso"
mid05tor12cn02: xcatdsklspost: downloaded postscripts successfully
mid05tor12cn02: Tue Oct  3 16:40:16 UTC 2017 Running postscript: update_mlnx_adapter_firmware
mid05tor12cn02: ==> Mellanox OFED PATH: /install/mlnxofed/MLNX_OFED_LINUX-4.1-4.0.7.1-rhel7.4alternate-ppc64le.iso
mid05tor12cn02: ==> Mellanox ODEF ISO: MLNX_OFED_LINUX-4.1-4.0.7.1-rhel7.4alternate-ppc64le.iso
mid05tor12cn02: ==> Retrieving file from http://172.12.253.27//install/mlnxofed/MLNX_OFED_LINUX-4.1-4.0.7.1-rhel7.4alternate-ppc64le.iso
mid05tor12cn02: -rw-r--r-- 1 root root 157132800 Sep 14 06:06 //MLNX_OFED_LINUX-4.1-4.0.7.1-rhel7.4alternate-ppc64le.iso
mid05tor12cn02: total 317
mid05tor12cn02: -r-xr-xr-x 1 root root  12851 Aug  8 15:53 uninstall.sh
mid05tor12cn02: -r-xr-xr-x 1 root root 230229 Aug  8 15:53 mlnxofedinstall
mid05tor12cn02: -r-xr-xr-x 1 root root  23106 Aug  8 15:53 mlnx_add_kernel_support.sh
mid05tor12cn02: -r-xr-xr-x 1 root root   4721 Aug  8 15:53 is_kmp_compat.sh
mid05tor12cn02: -r--r--r-- 1 root root     17 Aug  8 15:53 distro
mid05tor12cn02: -r-xr-xr-x 1 root root  21025 Aug  8 15:53 create_mlnx_ofed_installers.pl
mid05tor12cn02: -r-xr-xr-x 1 root root   5583 Aug  8 15:53 common.pl
mid05tor12cn02: -r--r--r-- 1 root root   2764 Aug  8 15:53 RPM-GPG-KEY-Mellanox
mid05tor12cn02: dr-xr-xr-x 2 root root   2048 Aug  8 15:53 src
mid05tor12cn02: dr-xr-xr-x 8 root root   2048 Aug  8 15:53 docs
mid05tor12cn02: -r--r--r-- 1 root root    956 Aug  8 15:53 LICENSE
mid05tor12cn02: dr-xr-xr-x 3 root root  16384 Aug  8 15:53 RPMS
mid05tor12cn02: TERM environment variable not set.
mid05tor12cn02: Detected rhel7u4alternate ppc64le. Disabling installing 32bit rpms...
mid05tor12cn02: Logs dir: /tmp/MLNX_OFED_LINUX-4.1-4.0.7.1.7265.logs
mid05tor12cn02: Removing old version of mlnx-fw-updater...
mid05tor12cn02: Preparing...                          ########################################
mid05tor12cn02: Updating / installing...
mid05tor12cn02: mlnx-fw-updater-4.1-4.0.7.1           ########################################
mid05tor12cn02: 
mid05tor12cn02: Added 'RUN_FW_UPDATER_ONBOOT=no to /etc/infiniband/openib.conf
mid05tor12cn02: Attempting to perform Firmware update...
mid05tor12cn02: Querying Mellanox devices firmware ...
mid05tor12cn02: 
mid05tor12cn02: Device #1:
mid05tor12cn02: ----------
mid05tor12cn02: 
mid05tor12cn02:   Device Type:      ConnectX5
mid05tor12cn02:   Part Number:      00WT174_Ax
mid05tor12cn02:   Description:      ConnectX-5 adapter card; EDR IB (100Gb/s); Dual-port QSFP28; PCIe4.0 x16; High Profile Multi/Single Host; ROHS R6; CORAL/POWER 9
mid05tor12cn02:   PSID:             IBM0000000002
mid05tor12cn02:   PCI Device Name:  0003:01:00.0
mid05tor12cn02:   Base GUID:        248a070300a472f8
mid05tor12cn02:   Versions:         Current        Available     
mid05tor12cn02:      FW             16.21.0082     16.21.0082    
mid05tor12cn02: 
mid05tor12cn02:   Status:           Up to date
mid05tor12cn02: Log File: /tmp/MLNX_OFED_LINUX-4.1-4.0.7.1.7265.logs/fw_update.log
mid05tor12cn02: ==> 
mid05tor12cn02: ==> 
mid05tor12cn02: ==> REBOOT THIS MACHINE FOR THE NEW FIRMWARE LEVEL TO TAKE EFFECT.
mid05tor12cn02: ==> 
mid05tor12cn02: ==> 
mid05tor12cn02: postscript: update_mlnx_adapter_firmware exited with code 0
mid05tor12cn02: Running of postscripts has completed.
```