### PR TITLE
Support transition states for OpenBMC - phase1

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1294,7 +1294,11 @@ sub rpower_response {
             if ($status_info{RPOWER_ON_RESPONSE}{argv}) {
                 xCAT::SvrUtils::sendmsg("$::POWER_STATE_RESET", $callback, $node);
             } else {
-                xCAT::SvrUtils::sendmsg("$::POWER_STATE_ON", $callback, $node);
+                if (defined($::OPENBMC_PWR) and ($::OPENBMC_PWR eq "YES")) {
+                    xCAT::SvrUtils::sendmsg("$::STATUS_POWERING_ON", $callback, $node);
+                } else {
+                    xCAT::SvrUtils::sendmsg("$::POWER_STATE_ON", $callback, $node);
+                }
             }
             $new_status{$::STATUS_POWERING_ON} = [$node];
         }

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1365,7 +1365,8 @@ sub rpower_response {
         } else {
             if ($chassis_state =~ /Off$/) {
                 # Chassis state is Off, but check if we can detect transition states
-                if ($host_state =~ /Off$/ and $host_transition_state =~ /On$/) {
+                if ((defined($::OPENBMC_PWR) and ($::OPENBMC_PWR eq "YES")) and
+                        $host_state =~ /Off$/ and $host_transition_state =~ /On$/) {
                     xCAT::SvrUtils::sendmsg("$::POWER_STATE_POWERING_ON", $callback, $node);
                 } else {
                     xCAT::SvrUtils::sendmsg("$::POWER_STATE_OFF", $callback, $node) if (!$next_status{ $node_info{$node}{cur_status} });

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -37,6 +37,7 @@ $::BEACON_STATE_ON          = "on";
 # String constants for rpower states
 $::POWER_STATE_OFF          = "off";
 $::POWER_STATE_ON           = "on";
+$::POWER_STATE_ON_HOSTOFF   = "on (Chassis)";
 $::POWER_STATE_POWERING_OFF = "powering-off";
 $::POWER_STATE_POWERING_ON  = "powering-on";
 $::POWER_STATE_QUIESCED     = "quiesced";
@@ -1368,15 +1369,9 @@ sub rpower_response {
                 $all_status = $::POWER_STATE_OFF;
             } elsif ($chassis_state =~ /On$/) { 
                 if ($host_state =~ /Off$/) {
-                    # Host State is Off, but if requested, check transition states 
-                    if ((defined($::OPENBMC_PWR) and ($::OPENBMC_PWR eq "YES")) and
-                           $host_transition_state =~ /On$/) {
-                        xCAT::SvrUtils::sendmsg("$::POWER_STATE_OFF", $callback, $node) if (!$next_status{ $node_info{$node}{cur_status} });
-                        $all_status = $::POWER_STATE_OFF;
-                    } else {
-                        xCAT::SvrUtils::sendmsg("$::POWER_STATE_OFF", $callback, $node) if (!$next_status{ $node_info{$node}{cur_status} });
-                        $all_status = $::POWER_STATE_OFF;
-                    }
+                    # This is a debug scenario where the chassis is powered on but hostboot is not
+                    xCAT::SvrUtils::sendmsg("$::POWER_STATE_ON_HOSTOFF", $callback, $node) if (!$next_status{ $node_info{$node}{cur_status} });
+                    $all_status = $::POWER_STATE_ON_HOSTOFF;
                 } elsif ($host_state =~ /Quiesced$/) {
                     xCAT::SvrUtils::sendmsg("$::POWER_STATE_QUIESCED", $callback, $node) if (!$next_status{ $node_info{$node}{cur_status} });
                     $all_status = $::POWER_STATE_ON;


### PR DESCRIPTION
This is a little interesting here.   The problem comes because OpenBMC is using a RESTful interface. and so commands are non blocking, we send a command to the BMC And it returns.  

For power on and power off, there's a period of time where the power states do not yet reflect the intended transition state.  Take Power off for example: 

1.  Machine is on 
2. Power off requested 
3. Transition to Off,  At this point, if you use xCAT to query state, it will return on.  

So it looks like the following: 
```
# rpower cn01 state
cn01: on
# rpower cn01 off
cn01: off     <--- here we just print target state as a response
# rpower cn01 state. 
cn01: on
# rpower cn01 state
cn01: off     <--- after some time, it will be off.  
```

So this is misleading because the user does not know if the command took or not.  So with this, xCAT attempted to take the transition state that we are able to query from OpenBMC and create `powering-off` and `powering-on`.   However, with some testing of this, it turns out that doing a hard off on the server, transition states are not reflected correctly.  

The first phase of this PR is to scaffold in some code to be able to print out transition state code. 

## Example: 

Set the VARIABLE
```
[root@briggs01 vhu]# export XCAT_OPENBMC_POWER_TRANSITION=YES
```

Only accurate with softoff
```
[root@briggs01 vhu]# rpower mid05tor12cn[15-17] softoff
mid05tor12cn16: powering-off
mid05tor12cn15: powering-off
mid05tor12cn17: powering-off
[root@briggs01 vhu]# rpower mid05tor12cn[15-17] stat
mid05tor12cn16: powering-off
mid05tor12cn15: powering-off
mid05tor12cn17: powering-off
```

If we unset the variable, it will default to NOT showing transition state, but actual state:
```
[root@briggs01 vhu]# unset XCAT_OPENBMC_POWER_TRANSITION
[root@briggs01 vhu]# rpower mid05tor12cn[15-17] stat
mid05tor12cn16: on
mid05tor12cn17: on
mid05tor12cn15: on
```

Eventually, once it powered off, the state will reflect correctly:
```
[root@briggs01 vhu]# export XCAT_OPENBMC_POWER_TRANSITION=YES
[root@briggs01 vhu]# rpower mid05tor12cn[15-17] stat
mid05tor12cn16: powering-off
mid05tor12cn17: powering-off
mid05tor12cn15: powering-off
[root@briggs01 vhu]# rpower mid05tor12cn[15-17] stat
mid05tor12cn16: powering-off
mid05tor12cn17: powering-off
mid05tor12cn15: powering-off
[root@briggs01 vhu]# rpower mid05tor12cn[15-17] stat
mid05tor12cn16: off
mid05tor12cn15: powering-off
mid05tor12cn17: powering-off
[root@briggs01 vhu]# rpower mid05tor12cn[15-17] stat
mid05tor12cn16: off
mid05tor12cn15: off
mid05tor12cn17: off
```

Same idea with powering on...
```
root@briggs01 vhu]# rpower mid05tor12cn17 on
mid05tor12cn17: powering-on
[root@briggs01 vhu]# rpower mid05tor12cn17 stat
mid05tor12cn17: powering-on
[root@briggs01 vhu]# rpower mid05tor12cn17 stat
mid05tor12cn17: on
```
