### PR TITLE
Support Vlan info of Cumulus Switch for switch_macmap command

### DIFF
--- a/perl-xCAT/xCAT/MacMap.pm
+++ b/perl-xCAT/xCAT/MacMap.pm
@@ -726,7 +726,7 @@ sub refresh_switch {
         my $myport;
 
         my @res=xCAT::Utils->runcmd("ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no $switch 'bridge fdb show|grep -i -v permanent|tr A-Z a-z  2>/dev/null' 2>/dev/null",-1);
-        unless (@res) {
+        if ($::RUNCMD_RC) {
             xCAT::MsgUtils->message("S", "Failed to get mac table with ssh to $switch, fall back to snmp! To obtain mac table with ssh, please make sure the passwordless root ssh to $switch is available");
         }else{
             foreach (@res){


### PR DESCRIPTION
For issue #3700 

the output from switch_macmap command 
````
[root@briggs01 xCAT]# xcatprobe switch_macmap mid05tor12 | grep -v "N/A"
Switch      Port(MTU)        MAC address(VLAN)           Node
--------------------------------------------------------------------------------------
mid05tor12  swp2(1500)       70:e2:84:14:28:97(11)       mid05tor12cn02
mid05tor12  swp5(1500)       70:e2:84:14:28:0d(12)       mid05tor12cn05
mid05tor12  swp5(1500)       70:e2:84:14:28:0e(12)       mid05tor12cn05
mid05tor12  swp11(1500)      70:e2:84:14:29:10(12)       mid05tor12cn11
mid05tor12  swp11(1500)      70:e2:84:14:29:0f(11)       mid05tor12cn11
mid05tor12  swp13(1500)      70:e2:84:14:28:7c(11)       mid05tor12cn13
mid05tor12  swp17(1500)      70:e2:84:14:32:85(12)       mid05tor12cn17
mid05tor12  swp23(1500)      70:e2:84:14:0f:08(12)
mid05tor12  swp50(1500)      0c:c4:7a:ea:9e:02(11)
mid05tor12  swp50(1500)      70:e2:84:14:0a:70(11)
mid05tor12  swp50(1500)      70:e2:84:14:09:f5(12)
mid05tor12  swp50(1500)      f4:52:14:47:de:37(11)
mid05tor12  swp50(1500)      0c:c4:7a:ea:9e:03(12)
````