### PR TITLE
If Activate status of firmware is Failed, return out 

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2112,6 +2112,8 @@ sub rflash_response {
         if ($activation_state =~ /Software.Activation.Activations.Failed/) {
             # Activation failed. Report error and exit
             xCAT::SvrUtils::sendmsg([1,"Activation of firmware failed"], $callback, $node);
+            $wait_node_num--;
+            return;
         } 
         elsif ($activation_state =~ /Software.Activation.Activations.Active/) { 
             if (scalar($priority_state) == 0) {


### PR DESCRIPTION
Resolves #4048 

It seems like when the Firmware Activate call returns an error, or the status is Failed, we forgot to decrement and return out , so constantly stuck in a loop.  

On the single case, before changes:
```
[root@briggs01 p9_generic]# rflash mid05tor12cn13 -a /mnt/xcat/iso/openbmc/910.1740.20171003b_1740A/witherspoon.pnor.squashfs.tar
mid05tor12cn13: Uploading /mnt/xcat/iso/openbmc/910.1740.20171003b_1740A/witherspoon.pnor.squashfs.tar ...
mid05tor12cn13: Upload successful. Attempting to activate firmware: IBM-witherspoon-ibm-OP9_v1.19_1.52
mid05tor12cn13: rflash started, please wait...
mid05tor12cn13: Activating firmware update. 10%
mid05tor12cn13: Activating firmware update. 10%
mid05tor12cn13: Activating firmware update. 10%
mid05tor12cn13: Activating firmware update. 10%
mid05tor12cn13: Activating firmware update. 10%
mid05tor12cn13: Activating firmware update. 10%
mid05tor12cn13: Error: Activation of firmware failed
mid05tor12cn13: Error: Activation of firmware failed
mid05tor12cn13: Error: Activation of firmware failed
mid05tor12cn13: Error: Activation of firmware failed
mid05tor12cn13: Error: Activation of firmware failed
mid05tor12cn13: Error: Activation of firmware failed
mid05tor12cn13: Error: Activation of firmware failed
mid05tor12cn13: Error: Activation of firmware failed
mid05tor12cn13: Error: Activation of firmware failed
mid05tor12cn13: Error: Activation of firmware failed
```

After fix: 
```
[root@briggs01 p9_generic]# rflash mid05tor12cn13 -d 776f6a74
mid05tor12cn13: Firmware update successfully removed
[root@briggs01 p9_generic]# rflash mid05tor12cn13 -a /mnt/xcat/iso/openbmc/910.1740.20171003b_1740A/witherspoon.pnor.squashfs.tar
mid05tor12cn13: Uploading /mnt/xcat/iso/openbmc/910.1740.20171003b_1740A/witherspoon.pnor.squashfs.tar ...
mid05tor12cn13: Successful, use -l option to list.
mid05tor12cn13: rflash started, please wait...
mid05tor12cn13: Activating firmware update. 10%
mid05tor12cn13: Activating firmware update. 10%
mid05tor12cn13: Activating firmware update. 10%
mid05tor12cn13: Error: Activation of firmware failed
```


With multiple nodes: 
```
[root@briggs01 ~]# rflash mid05tor12cn[05,13] -a /mnt/xcat/iso/openbmc/910.1740.20171003b_1740A/witherspoon.pnor.squashfs.tar
mid05tor12cn13: Uploading /mnt/xcat/iso/openbmc/910.1740.20171003b_1740A/witherspoon.pnor.squashfs.tar ...
mid05tor12cn13: Successful, use -l option to list.
mid05tor12cn05: Uploading /mnt/xcat/iso/openbmc/910.1740.20171003b_1740A/witherspoon.pnor.squashfs.tar ...
mid05tor12cn05: Successful, use -l option to list.
mid05tor12cn13: rflash started, please wait...
mid05tor12cn13: Error: Activation of firmware failed
mid05tor12cn05: rflash started, please wait...
mid05tor12cn05: Activating firmware update. 10%
mid05tor12cn05: Activating firmware update. 10%
mid05tor12cn05: Activating firmware update. 10%
mid05tor12cn05: Activating firmware update. 10%
mid05tor12cn05: Firmware update successfully activated
```