### PR TITLE
Change to protect from user specifying multiple firmware to activate/delete

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -912,6 +912,7 @@ sub parse_command_status {
         my $upload = 0;
         my $activate = 0;
         my $update_file;
+        my @flash_arguments;
 
         foreach $subcommand (@$subcommands) {
             if ($subcommand =~ /-c|--check/) {
@@ -926,9 +927,17 @@ sub parse_command_status {
                 $activate = 1;
             } else {
                 $update_file = $subcommand;
+                push (@flash_arguments, $subcommand); 
             }
         }
 
+        if (scalar @flash_arguments > 1) {
+            my $flag = "";
+            if ($delete) { $flag = "to delete"; }
+            if ($activate) { $flag = "to activate"; }
+            xCAT::SvrUtils::sendmsg([1, "More than one firmware specified $flag is currently not supported."], $callback);
+            return 1;
+        }
         my $file_id = undef;
         my $grep_cmd = "/usr/bin/grep -a";
         my $version_tag = '"^version="';


### PR DESCRIPTION
Protects user from invoking rflash to activate/delete multiple firmware images, as pointed out in  #4053 

This is to first protect from invoking this until we can better support it.  

After Changes:
``` 
[root@briggs01 p9_generic]# rflash mid05tor12cn[05,11] -d abc 123 asdbas
Error: More than one firmware specified to delete is currently not supported.
[root@briggs01 p9_generic]# rflash mid05tor12cn[05,11] -a abc 123 asdbas
Error: More than one firmware specified to activate is currently not supported.
```