### PR TITLE
Print a better message for rbeacon indicating that only on and off is supported

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -3048,7 +3048,7 @@ sub beacon {
         $ipmiv2 = 1;
     }
     if ($subcommand ne "on" and $subcommand ne "off") {
-        xCAT::SvrUtils::sendmsg([ 1, "please specify on or off for ipmi nodes (stat impossible)" ], $callback, $sessdata->{node}, %allerrornodes);
+        xCAT::SvrUtils::sendmsg([ 1, "Only 'on' or 'off' is supported for IPMI managed nodes."], $callback, $sessdata->{node}, %allerrornodes);
     }
 
     #if stuck with 1.5, say light for 255 seconds.  In 2.0, specify to turn it on forever

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -559,7 +559,7 @@ sub parse_args {
 
     if ($command eq "rbeacon") { 
         unless ($subcommand =~ /^on$|^off$/) {
-	    return ([ 1, "Unsupported command: $command $subcommand" ]);
+	    return ([ 1, "Only 'on' or 'off' is supported for OpenBMC managed nodes."]);
         }
     } elsif ($command eq "rpower") {
         unless ($subcommand =~ /^on$|^off$|^softoff$|^reset$|^boot$|^bmcreboot$|^bmcstate$|^status$|^stat$|^state$/) {


### PR DESCRIPTION
Resolves #4010 

For IPMI and OpenBMC, we only support the `on` and `off` function.  

Sync up the output message for both using this Pull Request:

```
[root@stratton01 c910env]# rbeacon boston01 blink
boston01: Error: Only 'on' or 'off' is supported for IPMI managed nodes.
[root@stratton01 c910env]# rbeacon boston01 stat
boston01: Error: Only 'on' or 'off' is supported for IPMI managed nodes.
```

and OpenBMC
```
[root@stratton01 c910env]# rbeacon p9euh02 blink
Only 'on' or 'off' is supported for OpenBMC managed nodes.
[root@stratton01 c910env]# rbeacon p9euh02 stat
Only 'on' or 'off' is supported for OpenBMC managed nodes.
```