### PR TITLE
fix xHRM fails when installnic is not set

### DIFF
--- a/xCAT-server/share/xcat/scripts/xHRM
+++ b/xCAT-server/share/xcat/scripts/xHRM
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash  
 if [ "$(uname -s|tr 'A-Z' 'a-z')" = "linux" ];then
    str_dir_name=`dirname $0`
    . $str_dir_name/xcatlib.sh
@@ -127,15 +127,23 @@ elif [ "bridgeprereq" = "$1" ]; then
     # get the port for installation
     if [ -n "$INSTALLNIC" ]; then
         if [[ "$INSTALLNIC" = mac ]] || [[ "$INSTALLNIC" = MAC ]]; then
-            #INSPORT=`ifconfig -a|grep -v inet6| grep -i 'HWaddr '$MACADDRESS|head -n 1|awk '{print $1}'`
+            #INSPORT=`ifconfig -a|grep -v inet6| grep -i 'HWaddr '$MACADDRESS|head -n 1|awk '{print $1}'`            
             INSPORT=`ip -oneline link show|grep -i ether|grep -i $MACADDRESS|awk -F ':' '{print $2}'|grep -o "[^ ]\+\( \+[^ ]\+\)*"`
         else
             INSPORT=$INSTALLNIC
         fi
+    elif [ -n "$PRIMARYNIC" ]; then
+        if [[ "$PRIMARYNIC" = mac ]] || [[ "$PRIMARYNIC" = MAC ]]; then
+            INSPORT=`ip -oneline link show|grep -i ether|grep -i $MACADDRESS|awk -F ':' '{print $2}'|grep -o "[^ ]\+\( \+[^ ]\+\)*"`
+        else
+            INSPORT=$PRIMARYNIC
+        fi
+    elif [ -n "$MACADDRESS" ]; then      
+            INSPORT=`ip -oneline link show|grep -i ether|grep -i $MACADDRESS|awk -F ':' '{print $2}'|grep -o "[^ ]\+\( \+[^ ]\+\)*"`
     fi
 
     if [ -z "$NETDESC" ]; then
-        if [ -n "$INSTALLNIC" ]; then
+        if [ -n "$INSPORT" ]; then
           NETDESC=$INSPORT:default
         else
             echo "Incorrect usage"

--- a/xCAT-server/share/xcat/scripts/xHRM
+++ b/xCAT-server/share/xcat/scripts/xHRM
@@ -126,20 +126,17 @@ elif [ "bridgeprereq" = "$1" ]; then
     NETDESC="$2"
     # get the port for installation
     if [ -n "$INSTALLNIC" ]; then
-        if [[ "$INSTALLNIC" = mac ]] || [[ "$INSTALLNIC" = MAC ]]; then
-            #INSPORT=`ifconfig -a|grep -v inet6| grep -i 'HWaddr '$MACADDRESS|head -n 1|awk '{print $1}'`            
-            INSPORT=`ip -oneline link show|grep -i ether|grep -i $MACADDRESS|awk -F ':' '{print $2}'|grep -o "[^ ]\+\( \+[^ ]\+\)*"`
-        else
-            INSPORT=$INSTALLNIC
-        fi
+        INSPORT=$INSTALLNIC
     elif [ -n "$PRIMARYNIC" ]; then
-        if [[ "$PRIMARYNIC" = mac ]] || [[ "$PRIMARYNIC" = MAC ]]; then
-            INSPORT=`ip -oneline link show|grep -i ether|grep -i $MACADDRESS|awk -F ':' '{print $2}'|grep -o "[^ ]\+\( \+[^ ]\+\)*"`
-        else
-            INSPORT=$PRIMARYNIC
-        fi
-    elif [ -n "$MACADDRESS" ]; then      
-            INSPORT=`ip -oneline link show|grep -i ether|grep -i $MACADDRESS|awk -F ':' '{print $2}'|grep -o "[^ ]\+\( \+[^ ]\+\)*"`
+        INSPORT=$PRIMARYNIC
+    fi
+
+    if ([ -z "$INSPORT" ] || [[  "$INSPORT" =~ ^(mac|MAC)$ ]]) && [ -n "$MACADDRESS" ] ; then
+        INSPORT=$MACADDRESS;
+    fi
+
+    if [[ "$INSPORT"  =~ ^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$ ]] ; then
+        INSPORT=`ip -oneline link show|grep -i ether|grep -i $INSPORT |awk -F ':' '{print $2}'|grep -o "[^ ]\+\( \+[^ ]\+\)*"`
     fi
 
     if [ -z "$NETDESC" ]; then

--- a/xCAT-server/share/xcat/scripts/xHRM
+++ b/xCAT-server/share/xcat/scripts/xHRM
@@ -131,8 +131,13 @@ elif [ "bridgeprereq" = "$1" ]; then
         INSPORT=$PRIMARYNIC
     fi
 
-    if ([ -z "$INSPORT" ] || [[  "$INSPORT" =~ ^(mac|MAC)$ ]]) && [ -n "$MACADDRESS" ] ; then
-        INSPORT=$MACADDRESS;
+    if [ -z "$INSPORT" ] || [[ "$INSPORT" =~ ^(mac|MAC)$ ]]; then
+        if [ -n "$MACADDRESS" ] ; then   
+            INSPORT=$MACADDRESS;
+        else
+            echo "should configure mac in $NODE definition."
+            exit 1
+        fi
     fi
 
     if [[ "$INSPORT"  =~ ^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$ ]] ; then


### PR DESCRIPTION
fix #4058 
enhance xHRM based on doc:
"When installnic is not set in the noderes table, the documentation states that the value will default to primarynic, and then to the mac keyword in case primarynic is not defined either." 