### PR TITLE
Fix issue 4062, modify method of node type check in bmcdiscover

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -47,6 +47,8 @@ my $bmc_user;
 my $bmc_pass;
 my $openbmc_user;
 my $openbmc_pass;
+$::P9_WITHERSPOON_MFG_ID     = "42817";
+$::P9_WITHERSPOON_PRODUCT_ID = "16975";
 
 #-------------------------------------------------------
 
@@ -667,14 +669,19 @@ sub scan_process {
                 # Set child process default, if not the function runcmd may return error
                 $SIG{CHLD} = 'DEFAULT';
 
-                my @mc_cmds = ("/opt/xcat/bin/ipmitool-xcat -I lanplus -H ${$live_ip}[$i] -P $openbmc_pass mc info",
-                              "/opt/xcat/bin/ipmitool-xcat -I lanplus -H ${$live_ip}[$i] -U $bmc_user -P $bmc_pass mc info");
+                my $bmcusername;
+                my $bmcpassword;
+                $bmcusername = "-U $bmc_user" if ($bmc_user);
+                $bmcpassword = "-P $bmc_pass" if ($bmc_pass);
+                
+                my @mc_cmds = ("/opt/xcat/bin/ipmitool-xcat -I lanplus -H ${$live_ip}[$i] -P $openbmc_pass mc info -N 1 -R 1",
+                              "/opt/xcat/bin/ipmitool-xcat -I lanplus -H ${$live_ip}[$i] $bmcusername $bmcpassword mc info -N 1 -R 1");
                 my $mc_info;
                 my $flag;
                 foreach my $mc_cmd (@mc_cmds) {
                     $mc_info = xCAT::Utils->runcmd($mc_cmd, -1);
                     if ($mc_info =~ /Manufacturer ID\s*:\s*(\d+)\s*Manufacturer Name.+\s*Product ID\s*:\s*(\d+)/) {
-                        if ($1 eq "42817" and $2 eq "16975") {
+                        if ($1 eq $::P9_WITHERSPOON_MFG_ID and $2 eq $::P9_WITHERSPOON_PRODUCT_ID) {
                             bmcdiscovery_openbmc(${$live_ip}[$i], $opz, $opw, $request_command);
                             $flag = 1;
                             last; 


### PR DESCRIPTION
#4062 

Using `` ipmitool-xcat -I lanplus mc info`` to get "Manufacturer ID" and "Product ID" to check whether it‘s OpenBMC. 
For OpenBMC node, `` ipmitool-xcat -I lanplus -H x.x.x.x -P 0penBmc mc info``. If is "42817" and "16975", consider it as OpenBMC node.
For IPMI node, ``ipmitool-xcat -I lanplus -H x.x.x.x -U USERID -P PASSW0RD mc info``. If not"42817" and "16975", IPMI node.   
If can't get by using openbmc and ipmi password, consider it as OpenBMC node(For OpenBMC nodes, may not support ipmi service).

Output is the same with before.