### PR TITLE
Fix for #3981: update switch information during mtms discovery

### DIFF
--- a/xCAT-server/lib/xcat/plugins/typemtms.pm
+++ b/xCAT-server/lib/xcat/plugins/typemtms.pm
@@ -59,6 +59,7 @@ sub findme {
         $req->{command}   = ['discovered'];
         $req->{noderange} = [ $nodes[0] ];
         $req->{bmc_node}  = [$bmc_node];
+        $req->{updateswitch} = ['yes'];
         $subreq->($req);
         %{$req} = ();
     }


### PR DESCRIPTION
This MR fixes #3981 - MTMS now updates `switch` and `switchport` in node definitions for nodes discovered via `MTMS` discovery.