### PR TITLE
fix issue If service node is down, control to OpenBMC node never returns #3888

### DIFF
--- a/docs/source/troubleshooting/os_installation/debug_port.rst
+++ b/docs/source/troubleshooting/os_installation/debug_port.rst
@@ -3,7 +3,7 @@ Enabling Debug Port: Running commands in the installer from MN
 
 **This mode is supported with debug level set to 1 or 2**
 
-xCAT creates a server in the **installer**, listening on port ``3001``. It executes commands sent to it from the xCAT MN and returns the response output.
+xCAT creates a service inside the **installer**, listening on port ``3054``. It executes commands sent to it from the xCAT MN and returns the response output.
 
 The command ``runcmdinstaller`` can be used to send request to installer:
 

--- a/xCAT-server/sbin/runcmdinstaller
+++ b/xCAT-server/sbin/runcmdinstaller
@@ -58,5 +58,5 @@ if [ "$retcode" != "0" ];then
     exit $retcode
 fi
 
-echo "sh $cmd 2>&1" | nc -w 20 $node 3001 
+echo "sh $cmd 2>&1" | nc -w 20 $node 3004 
 

--- a/xCAT-server/sbin/runcmdinstaller
+++ b/xCAT-server/sbin/runcmdinstaller
@@ -58,5 +58,5 @@ if [ "$retcode" != "0" ];then
     exit $retcode
 fi
 
-echo "sh $cmd 2>&1" | nc -w 20 $node 3004 
+echo "sh $cmd 2>&1" | nc -w 20 $node 3054 
 

--- a/xCAT-server/share/xcat/install/scripts/pre.debian
+++ b/xCAT-server/share/xcat/install/scripts/pre.debian
@@ -36,7 +36,7 @@ cat >/tmp/foo.awk <<EOF
 #!$AWK -f
 
 BEGIN {
-	ns = "/inet/tcp/3001/0/0"
+	ns = "/inet/tcp/3004/0/0"
 
 	while(1) {
 		ns |& getline

--- a/xCAT-server/share/xcat/install/scripts/pre.debian
+++ b/xCAT-server/share/xcat/install/scripts/pre.debian
@@ -36,7 +36,7 @@ cat >/tmp/foo.awk <<EOF
 #!$AWK -f
 
 BEGIN {
-	ns = "/inet/tcp/3004/0/0"
+	ns = "/inet/tcp/3054/0/0"
 
 	while(1) {
 		ns |& getline

--- a/xCAT-server/share/xcat/install/scripts/pre.rh
+++ b/xCAT-server/share/xcat/install/scripts/pre.rh
@@ -71,7 +71,7 @@ sock.close()
 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
-port = 3004
+port = 3054
 sock.bind(('', port))
 
 sock.listen(5)

--- a/xCAT-server/share/xcat/install/scripts/pre.rh
+++ b/xCAT-server/share/xcat/install/scripts/pre.rh
@@ -71,7 +71,7 @@ sock.close()
 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
-port = 3001
+port = 3004
 sock.bind(('', port))
 
 sock.listen(5)

--- a/xCAT-server/share/xcat/install/scripts/pre.rh.rhels7
+++ b/xCAT-server/share/xcat/install/scripts/pre.rh.rhels7
@@ -60,7 +60,7 @@ sock.close()
 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
-port = 3004
+port = 3054
 sock.bind(('', port))
 
 sock.listen(5)

--- a/xCAT-server/share/xcat/install/scripts/pre.rh.rhels7
+++ b/xCAT-server/share/xcat/install/scripts/pre.rh.rhels7
@@ -60,7 +60,7 @@ sock.close()
 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
-port = 3001
+port = 3004
 sock.bind(('', port))
 
 sock.listen(5)

--- a/xCAT-server/share/xcat/install/scripts/pre.sles
+++ b/xCAT-server/share/xcat/install/scripts/pre.sles
@@ -39,7 +39,7 @@ cat >/tmp/foo.awk <<EOF
 #!$AWK -f
 
 BEGIN {
-	ns = "/inet/tcp/3004/0/0"
+	ns = "/inet/tcp/3054/0/0"
 
 	while(1) {
 		ns |& getline

--- a/xCAT-server/share/xcat/install/scripts/pre.sles
+++ b/xCAT-server/share/xcat/install/scripts/pre.sles
@@ -39,7 +39,7 @@ cat >/tmp/foo.awk <<EOF
 #!$AWK -f
 
 BEGIN {
-	ns = "/inet/tcp/3001/0/0"
+	ns = "/inet/tcp/3004/0/0"
 
 	while(1) {
 		ns |& getline

--- a/xCAT-server/share/xcat/install/scripts/pre.ubuntu
+++ b/xCAT-server/share/xcat/install/scripts/pre.ubuntu
@@ -46,7 +46,7 @@ if [ \$# -eq 0 ]; then
     fi
 
     while true; do
-        /usr/bin/nc -l -p 3001 -e /tmp/foo.sh serve_client
+        /usr/bin/nc -l -p 3004 -e /tmp/foo.sh serve_client
     done
 
     exit 1                        # never reached; reboot ends this

--- a/xCAT-server/share/xcat/install/scripts/pre.ubuntu
+++ b/xCAT-server/share/xcat/install/scripts/pre.ubuntu
@@ -46,7 +46,7 @@ if [ \$# -eq 0 ]; then
     fi
 
     while true; do
-        /usr/bin/nc -l -p 3004 -e /tmp/foo.sh serve_client
+        /usr/bin/nc -l -p 3054 -e /tmp/foo.sh serve_client
     done
 
     exit 1                        # never reached; reboot ends this

--- a/xCAT-server/share/xcat/install/scripts/pre.ubuntu.ppc64
+++ b/xCAT-server/share/xcat/install/scripts/pre.ubuntu.ppc64
@@ -46,7 +46,7 @@ if [ \$# -eq 0 ]; then
     fi
 
     while true; do
-        /usr/bin/nc -l -p 3001 -e /tmp/foo.sh serve_client
+        /usr/bin/nc -l -p 3004 -e /tmp/foo.sh serve_client
     done
 
     exit 1                        # never reached; reboot ends this

--- a/xCAT-server/share/xcat/install/scripts/pre.ubuntu.ppc64
+++ b/xCAT-server/share/xcat/install/scripts/pre.ubuntu.ppc64
@@ -46,7 +46,7 @@ if [ \$# -eq 0 ]; then
     fi
 
     while true; do
-        /usr/bin/nc -l -p 3004 -e /tmp/foo.sh serve_client
+        /usr/bin/nc -l -p 3054 -e /tmp/foo.sh serve_client
     done
 
     exit 1                        # never reached; reboot ends this


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/3888:
use port 3054 instead of 3001 to run debug commands inside installer