### PR TITLE
enhance pgsqlseup manpage about access addresses

### DIFF
--- a/xCAT-client/pods/man1/pgsqlsetup.1.pod
+++ b/xCAT-client/pods/man1/pgsqlsetup.1.pod
@@ -52,7 +52,7 @@ This option is used to specify additional IP addresses on which the PostgreSQL d
 
 =item B<-a|--access> I<address>
 
-This option is used to specify additional IP addresses from which the service nodes will connect to the PostgreSQL database.  Without it, only the management node will be configured for database access.  This option can be specified multiple times.
+This option is used to specify additional IP addresses from which the additional nodes will connect to the PostgreSQL database, for example, service nodes IP addresses or MN HA primary/standby nodes physical IP addresses.  Without it, only the management node will be configured for database access.  This option can be specified multiple times.
 
 =item B<-P|--PCM>
 


### PR DESCRIPTION
for #4067 

UT : after executing `pgsqlsetup -i -a 10.5.106.5 -a 10.5.106.9`, these 2 nodes can access the postgresql DB. 
