### PR TITLE
fix issue 4065: bmcsetup as postscript hangs due to background process

### DIFF
--- a/xCAT-genesis-scripts/bin/bmcsetup
+++ b/xCAT-genesis-scripts/bin/bmcsetup
@@ -640,6 +640,16 @@ while [ $idev -gt 0 ]; do
 
     logger -s -t $log_label -p local4.info "Lighting Identify Light"
     if [ "$XPROD" = "43707" -a "$IPMIMFG" = '0' ]; then
+        ISOPENPOEWR=1
+    elif [ "$IPMIMFG" = "10876" ];then
+        # MFG=10876 and PROD=2437 is for BOSTON server and MFG=10876 and PROD=2355 is for B&S server
+        if [ "$XPROD" = "2437" -o "$XPROD" = "2355" ]; then
+            ISOPENPOEWR=1
+        fi
+    fi
+ 
+    
+    if [ "$ISOPENPOEWR" = '1' ]; then
         # OpenPOWER BMC specific, turn on the LED beacon light.  
         #   - default interval, # ipmitool chassis identify
         #                         Chassis identify interval: default (15 seconds)

--- a/xCAT-genesis-scripts/bin/bmcsetup
+++ b/xCAT-genesis-scripts/bin/bmcsetup
@@ -640,17 +640,17 @@ while [ $idev -gt 0 ]; do
 
     logger -s -t $log_label -p local4.info "Lighting Identify Light"
     if [ "$XPROD" = "43707" -a "$IPMIMFG" = '0' ]; then
-        ISOPENPOEWR=1
+        ISOPENPOWER=1
     elif [ "$IPMIMFG" = "10876" ];then
         # Handle Supermicro Servers (MFG=10876)
         # Boston (PROD=2437), Briggs/Stratton (PROD=2355)
         if [ "$XPROD" = "2437" -o "$XPROD" = "2355" ]; then
-            ISOPENPOEWR=1
+            ISOPENPOWER=1
         fi
     fi
  
     
-    if [ "$ISOPENPOEWR" = '1' ]; then
+    if [ "$ISOPENPOWER" = '1' ]; then
         # OpenPOWER BMC specific, turn on the LED beacon light.  
         #   - default interval, # ipmitool chassis identify
         #                         Chassis identify interval: default (15 seconds)

--- a/xCAT-genesis-scripts/bin/bmcsetup
+++ b/xCAT-genesis-scripts/bin/bmcsetup
@@ -642,7 +642,8 @@ while [ $idev -gt 0 ]; do
     if [ "$XPROD" = "43707" -a "$IPMIMFG" = '0' ]; then
         ISOPENPOEWR=1
     elif [ "$IPMIMFG" = "10876" ];then
-        # MFG=10876 and PROD=2437 is for BOSTON server and MFG=10876 and PROD=2355 is for B&S server
+        # Handle Supermicro Servers (MFG=10876)
+        # Boston (PROD=2437), Briggs/Stratton (PROD=2355)
         if [ "$XPROD" = "2437" -o "$XPROD" = "2355" ]; then
             ISOPENPOEWR=1
         fi


### PR DESCRIPTION
Fix issue #4065 

The current output will be:
```
...
bmcsetup: Enabling SOL for channel 1
bmcsetup: Enabling SOL for channel 1: OK
bmcsetup: Enabling SOL for ADMIN
bmcsetup: Enabling SOL for ADMIN: OK
bmcsetup: Lighting Identify Light
Chassis identify interval: 250 seconds
Wed Oct 11 04:24:34 EDT 2017 postscript bmcsetup return with 0
returned from postscript
```