### PR TITLE
To support rhels7.4 DHCP response format in detect_dhcpd tool

### DIFF
--- a/xCAT-probe/subcmds/detect_dhcpd
+++ b/xCAT-probe/subcmds/detect_dhcpd
@@ -226,6 +226,8 @@ while (<FILE>) {
     }
     if ($line =~ /\s*DHCP-Message.*: Offer/) {
         $offer = 1;
+    } elsif ($line =~ /\s*file ".+"\[\|bootp\]/){
+        $offer = 1;
     } elsif ($line =~ /\s*DHCP-Message.*: NACK/) {
         $nack = 1;
     }


### PR DESCRIPTION
For issue #4028 

In rhels7.4, the DHCP response has changed to 

```
05:02:58.803189 IP (tos 0x10, ttl 128, id 0, offset 0, flags [none], proto UDP (17), length 368)
    172.12.253.27.bootps > 255.255.255.255.bootpc: [udp sum ok] BOOTP/DHCP, Reply, length 340, xid 0x3c3d3e3f, Flags [Broadcast] (0x8000)
	  Your-IP 172.12.139.11
	  Server-IP 172.12.253.27
	  Client-Ethernet-Address 70:e2:84:14:29:10
	  file "/yaboot"[|bootp]
```

This beyond to ``detect_dhcpd`` original handling scope. 

After fixing, the output of command will be:

```
[root@briggs01 subcmds]# xcatprobe  detect_dhcpd -i enP34p1s0f0.12 -m 70:e2:84:14:29:10
Start to detect DHCP, please wait 10 seconds                                                                      [INFO]
++++++++++++++++++++++++++++++++++                                                                                [INFO]
There are 1 servers replied to dhcp discover.                                                                     [INFO]
    Server:172.12.253.27 assign IP [172.12.139.11]. The next server is [172.12.253.27]!                           [INFO]
++++++++++++++++++++++++++++++++++                                                                                [INFO]
```