### PR TITLE
Make dbstat.py script could run by itself.

### DIFF
--- a/xCAT-probe/scripts/dbstats.py
+++ b/xCAT-probe/scripts/dbstats.py
@@ -1,5 +1,5 @@
+#!/usr/bin/env python
 # -*- encoding: utf-8 -*-
-# !/usr/bin/python
 from __future__ import print_function
 import argparse
 import json


### PR DESCRIPTION
To fix #4093, After fix:

```
./probe/scripts/dbstats.py
command,elapsed(precision: 1s),get_sub_time(s),set_sub_time(s),del_sub_time(s),get_sql_time(s),set_sql_time(s),del_sql_time(s),build_cache(times),cache_hit(times),get_tables(times),set_tables(times),del_tables(times)
getopenbmccons mid05tor12cn09 text(2017-10-12 21:48:33),0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,,,,,

getopenbmccons mid05tor12cn14 text(2017-10-12 21:48:33),0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,,,,,

getopenbmccons mid05tor12cn01 text(2017-10-12 21:48:33),0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,,,,,

getopenbmccons mid05tor12cn06 text(2017-10-12 21:48:33),0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,,,,,

getopenbmccons mid05tor12cn08 text(2017-10-12 21:48:33),0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,,,,,

getopenbmccons mid05tor12cn04 text(2017-10-12 21:48:32),1.000000,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,,,,,

getopenbmccons mid05tor12cn03 text(2017-10-12 21:48:32),0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,,,,,

getopenbmccons mid05tor12cn07 text(2017-10-12 21:48:32),0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,,,,,

getopenbmccons mid05tor12cn12 text(2017-10-12 21:48:32),0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,,,,,

getopenbmccons mid05tor12cn10 text(2017-10-12 21:48:30),0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,,,,,
```