### PR TITLE
fix [OpenBMC] rspconfig sshcfg issue where keys are not copied seems to be in xCAT #4074

### DIFF
--- a/perl-xCAT/xCAT/RemoteShellExp.pm
+++ b/perl-xCAT/xCAT/RemoteShellExp.pm
@@ -466,7 +466,7 @@ sub testkeys
             return 0;
         } else {
             my $rsp = {};
-            $rsp->{error}->[0] = $msg;
+            $rsp->{error}->[0] = "Testing the ssh connection to $nodes failed:".$msg;
             xCAT::MsgUtils->message("E", $rsp, $::CALLBACK);
             return 1;
         }
@@ -598,7 +598,7 @@ sub sendnodeskeys
                     $rc = 0;
                 } else {
                     my $rsp = {};
-                    $rsp->{error}->[0] = "mkdir:$node has error,$msg";
+                    $rsp->{error}->[0] = "Failed to run \"/bin/mkdir -p /tmp/$to_userid/.ssh\" on $node: $msg";
                     xCAT::MsgUtils->message("E", $rsp, $::CALLBACK);
                     $rc = 1;
                 }
@@ -686,7 +686,7 @@ sub sendnodeskeys
                     $rc = 0;
                 } else {
                     my $rsp = {};
-                    $rsp->{error}->[0] = "copykeys:$node has error,$msg";
+                    $rsp->{error}->[0] = "Failed to copy ssh credentials and helper script to $node: $msg";
                     xCAT::MsgUtils->message("E", $rsp, $::CALLBACK);
                     $rc = 1;
                 }
@@ -771,7 +771,7 @@ sub sendnodeskeys
                     $rc = 0;
                 } else {
                     my $rsp = {};
-                    $rsp->{error}->[0] = "copy.sh:$node has error,$msg";
+                    $rsp->{error}->[0] = "Failed to apply the ssh keys on $node:$msg";
                     xCAT::MsgUtils->message("E", $rsp, $::CALLBACK);
                     $rc = 1;
                 }

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -21,6 +21,7 @@ use HTTP::Cookies;
 use File::Basename;
 use File::Spec;
 use File::Copy qw/copy cp mv move/;
+use File::Path;
 use Data::Dumper;
 use Getopt::Long;
 use xCAT::OPENBMC;
@@ -1978,7 +1979,8 @@ rmdir \"/tmp/$userid\" \n";
         $ENV{'DSH_FROM_USERID'}=$bak_DSH_FROM_USERID;
 
         #remove intermediate files
-        unlink "$home/.ssh/copy.sh","$home/.ssh/tmp/authorized_keys";
+        unlink "$home/.ssh/copy.sh";
+        File::Path->remove_tree("$home/.ssh/tmp/");
     }
 
     if ($next_status{ $node_info{$node}{cur_status} }) {

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1976,6 +1976,9 @@ rmdir \"/tmp/$userid\" \n";
         #restore env variables
         $ENV{'DSH_REMOTE_PASSWORD'}=$bak_DSH_REMOTE_PASSWORD;
         $ENV{'DSH_FROM_USERID'}=$bak_DSH_FROM_USERID;
+
+        #remove intermediate files
+        unlink "$home/.ssh/copy.sh","$home/.ssh/tmp/authorized_keys";
     }
 
     if ($next_status{ $node_info{$node}{cur_status} }) {

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1963,15 +1963,15 @@ rmdir \"/tmp/$userid\" \n";
         my $rc=xCAT::RemoteShellExp->remoteshellexp("s",$callback,"/usr/bin/ssh",$bmcip,10);
         if ($rc) {
             xCAT::SvrUtils::sendmsg("Error copying ssh keys to $bmcip\n", $callback, $node);
-        }
-
-        #check whether the ssh keys has been sent successfully
-        $rc=xCAT::RemoteShellExp->remoteshellexp("t",$callback,"/usr/bin/ssh",$bmcip,10);
-        if ($rc) {
-            xCAT::SvrUtils::sendmsg("Error copying ssh keys to $bmcip Rerun rspconfig command.", $callback, $node);
-        }
-        else {
-            xCAT::SvrUtils::sendmsg("ssh keys copied to $bmcip", $callback, $node);
+        }else{
+            #check whether the ssh keys has been sent successfully
+            $rc=xCAT::RemoteShellExp->remoteshellexp("t",$callback,"/usr/bin/ssh",$bmcip,10);
+            if ($rc) {
+                xCAT::SvrUtils::sendmsg("Testing the ssh connection to $bmcip failed. Please rerun rspconfig command.", $callback, $node);
+            }
+            else {
+                xCAT::SvrUtils::sendmsg("ssh keys copied to $bmcip", $callback, $node);
+            }
         }
 
         #restore env variables


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/4074:

replaced xCAT::RShellAPI::run_remote_shell_api with xCAT::RemoteShellExp->remoteshellexp, to upload the id_rsa.pub to bmc


UT:
````
[root@briggs01 vhu]# rspconfig fw1738 sshcfg
mid05tor12cn13: ssh keys copied to 172.11.139.13
mid05tor12cn11: ssh keys copied to 172.11.139.11
mid05tor12cn15: ssh keys copied to 172.11.139.15
mid05tor12cn02: ssh keys copied to 172.11.139.2

[root@briggs01 vhu]# ls /root/.ssh/copy.sh
ls: cannot access /root/.ssh/copy.sh: No such file or directory
[root@briggs01 vhu]# ls /root/.ssh/tmp/
[root@briggs01 vhu]#
````
