### PR TITLE
Recognize alternative path to fping

### DIFF
--- a/xCAT-client/bin/pping
+++ b/xCAT-client/bin/pping
@@ -162,7 +162,7 @@ sub fping_pping {
     }
     else
     {
-        if (!-x '/usr/bin/fping')
+        if (!-x '/usr/bin/fping' and !-x '/usr/sbin/fping')
         {
             print "fping is not available, please install missing package fping.\n";
             exit 1;


### PR DESCRIPTION
SLES12 places fping into /usr/sbin