### PR TITLE
Fix erroneous 'noping' in various circumstances

### DIFF
--- a/xCAT-client/bin/pping
+++ b/xCAT-client/bin/pping
@@ -199,7 +199,7 @@ sub nmap_pping {
         @nmap_options = xCAT::TableUtils->get_site_attribute("nmapoptions");
         $more_options = $nmap_options[0];
     }
-    open(FPING, "nmap -PE --system-dns --send-ip -sP $more_options " . join(' ', @$nodes) . " 2> /dev/null|") or die("Cannot open nmap pipe: $!");
+    open(FPING, "nmap -PE --system-dns --unprivileged --send-ip -sP $more_options " . join(' ', @$nodes) . " 2> /dev/null|") or die("Cannot open nmap pipe: $!");
     my $node;
     while (<FPING>) {
         if (/Host (.*) \(.*\) appears to be up/) {


### PR DESCRIPTION
nmap's raw IP facility is prone to mistakes in various
environments.  Disable the raw IP handling by
telling nmap to run as if it didn't have privilege
Note this was already done back in:

commit fb02c18853dd2004ed936c77afabd310d7f115dd
Author: jjohnson2 <jjohnson2@lenovo.com>
Date:   Fri Mar 20 10:58:26 2015 -0400

But it was broken since then..