### PR TITLE
Modify xcatprobe xcatmn depending on new requirement #4092

### DIFF
--- a/xCAT-probe/subcmds/xcatmn
+++ b/xCAT-probe/subcmds/xcatmn
@@ -48,7 +48,7 @@ Description:
 Options:
     -h : Get usage information of $program_name
     -V : Output more information for debug
-    -i : Required. Specify the network interface name of provision network on management node
+    -i : Specify the network interface name of provision network on management node. if not specified, will guess the provision network from site table master attribute. Recommand to use -i option. If there is vlan in the network interface, provide the network interface with vlan infomation, such as '-i <nic>.<vlan>'.
 ";
 
 sub do_main_job {
@@ -400,21 +400,39 @@ sub check_network {
             $rst = 1;
         }
     } else {    # on MN
-        my $nics = `ip addr show $installnic >/dev/null 2>&1`;
-        if ($?) {
-            push @$error_ref, "There isn't NIC '$installnic' in current server";
-            $rst = 1;
-        } else {
-            $$serverip_ref = `ip addr show $installnic 2>&1| awk -F" " '/inet / {print \$2}'|awk -F"/" '{print \$1}'`;
-            chomp($$serverip_ref);
-            if (!defined($$serverip_ref) || ($$serverip_ref eq "")) {
-                push @$error_ref, "There isn't IP address assigned to NIC $installnic";
+        if($installnic){
+            #if customer specified install NIC by '-i' option, use that
+            my $nics = `ip -4 -o a|grep '$installnic\\\\' >/dev/null 2>&1`;
+            if ($?) {
+                push @$error_ref, "There isn't NIC '$installnic' in current server";
                 $rst = 1;
             } else {
-                if ($$serverip_ref ne $sitetable_ref->{master}) {
-                    push @$error_ref, "The IP $$serverip_ref of $installnic doesn't equal the value of 'master' in 'site' table";
+                $$serverip_ref = `ip -4 -o a|awk -F' ' '/$installnic\\\\/ {print \$4}'|awk -F'/' '{print \$1}'`;
+                chomp($$serverip_ref);
+                if (!defined($$serverip_ref) || ($$serverip_ref eq "")) {
+                    push @$error_ref, "There isn't IP address assigned to NIC $installnic";
                     $rst = 1;
+                } else {
+                    if ($$serverip_ref ne $sitetable_ref->{master}) {
+                        push @$error_ref, "The IP $$serverip_ref of $installnic doesn't equal the value of 'master' in 'site' table";
+                        $rst = 1;
+                    }
                 }
+            }
+        }else{
+            #if customer does not specified install NIC by '-i' option, suppose the network which <master> attribute in site table belongs to is install network.
+            $$serverip_ref = $sitetable_ref->{master};
+            my $str = `ip -4 -o a|grep '$$serverip_ref'`;
+            if($?) {
+                push @$error_ref, "The value $$serverip_ref of master attribute in site table doesn't belong to any NIC in current server";
+                $rst = 1;
+            }else{
+                chomp($str);
+                my @tmp1 = split("\\\\", $str);
+                my @tmp2 = split(" ", $tmp1[0]);
+                $installnic=$tmp2[-1];
+                probe_utils->send_msg("$output", "w", "No interface provided by '-i' option, detected site table IP attribute $$serverip_ref, checking xCAT configuration using interface: $installnic");
+                probe_utils->send_msg("$output", "w", "If this is incorrect, rerun with -i <ifname> option");
             }
         }
     }
@@ -978,11 +996,6 @@ if ($test) {
     exit 0;
 }
 
-if (!$installnic){
-    probe_utils->send_msg("$output", "f", "Option '-i' is required");
-    probe_utils->send_msg("$output", "d", "$::USAGE");
-    exit 1;
-}
 
 #Handle the interrupt signal from STDIN
 $SIG{TERM} = $SIG{INT} = sub {
@@ -1019,12 +1032,21 @@ while ($hierarchy_instance->read_reply(\%reply_cache)) {
                 my $msg    = "";
                 my $logmsg = "";
 
+                #print ">>>$reply_cache{$servers}->[$_]<<<\n";
                 #For cases like below:
                 #c910f02c04p04: [ok]     :All xCAT deamons are running
                 if ($reply_cache{$servers}->[$_] =~ /^(\w+)\s*:\s*(\[\w+\]\s*):\s*(.*)/) {
                     if ("$1" eq "$server") {
                         $logmsg = "$2: $3";
                         $msg    = "$2:[$server]: $3";
+                    }
+
+                    #For cases like below:
+                    #sn02: ssh: connect to host sn02 port 22: No route to host
+                } elsif ($reply_cache{$servers}->[$_] =~ /^(\w+)\s*:\s*(ssh:.+)/){
+                    if("$1" eq "$server") {
+                        $logmsg = "$2";
+                        $msg    = "[failed] :[$server]: $2"; 
                     }
 
                     #For cases like below:


### PR DESCRIPTION
Modify xcatprobe xcatmn depending on new requirement #4092

*  If no interface provided, detected site table master attribute to guess provision network
* Support vlan configuration in network interface
* Fix a bug, if sn can not work, can handle ``ssh: connect to host sn01 port 22: No route to host`` error information

Below are some UT results:

1 if no interface provided, detected site table to guess provision network
```
[root@briggs01 subcmds]# xcatprobe  -w xcatmn
[mn]: Checking all xCAT deamons are running...                                                                    [ OK ]
[mn]: Checking xcatd can receive command request...                                                               [ OK ]
[mn]: Checking 'site' table is configured...                                                                      [ OK ]
[mn]: No interface provided by '-i' option, detected site table IP attribute 172.10.253.27, checking xCAT configuration
using interface: enP34p1s0f0                                                                                      [WARN]
[mn]: If this is incorrect, rerun with -i <ifname> option                                                         [WARN]
[mn]: Checking provision network is configured...                                                                 [ OK ]
[mn]: Checking 'passwd' table is configured...                                                                    [ OK ]
[mn]: Checking important directories(installdir,tftpdir) are configured...                                        [ OK ]
[mn]: Checking SELinux is disabled...                                                                             [ OK ]
[mn]: Checking HTTP service is configured...                                                                      [ OK ]
[mn]: Checking TFTP service is configured...                                                                      [ OK ]
[sn01]: ssh: connect to host sn01 port 22: No route to host                                                       [FAIL]
[sn02]: ssh: connect to host sn02 port 22: No route to host                                                       [FAIL]
[mn]: Checking DNS service is configured...                                                                       [ OK ]
[mn]: Checking DHCP service is configured...                                                                      [ OK ]
[mn]: Checking NTP service is configured...                                                                       [ OK ]
[mn]: Checking firewall is disabled...                                                                            [ OK ]
[mn]: Checking minimum disk space for xCAT ['/var' needs 1GB;'/install' needs 10GB;'/tmp' needs 1GB]...           [ OK ]
[mn]: Checking xCAT management node IP: <172.10.253.27> is configured to static...                                [ OK ]
[mn]: Checking dhcpd.leases file is less than 100M...                                                             [ OK ]
=================================== SUMMARY ====================================
[MN]: Checking on MN...                                                                                           [ OK ]
    No interface provided by '-i' option, detected site table IP attribute 172.10.253.27, checking xCAT configuration us
ing interface: enP34p1s0f0                                                                                        [WARN]
    If this is incorrect, rerun with -i <ifname> option                                                           [WARN]
[SN:sn01]: Checking on SN sn01...                                                                                 [FAIL]
    ssh: connect to host sn01 port 22: No route to host                                                           [FAIL]
[SN:sn02]: Checking on SN sn02...                                                                                 [FAIL]
    ssh: connect to host sn02 port 22: No route to host                                                           [FAIL]
```

Support vlan in network interface
```
[root@briggs01 subcmds]# ip -o -4 a
1: lo    inet 127.0.0.1/8 scope host lo\       valid_lft forever preferred_lft forever
2: enP34p1s0f0    inet 172.10.253.27/16 brd 172.10.255.255 scope global enP34p1s0f0\       valid_lft forever preferred_lft forever
.......
9: enP34p1s0f0.12    inet 172.12.253.27/16 brd 172.12.255.255 scope global enP34p1s0f0.12\       valid_lft forever preferred_lft forever

[root@briggs01 subcmds]# xcatprobe  xcatmn -i  enP34p1s0f0.12
[mn]: Checking all xCAT deamons are running...                                                                    [ OK ]
[mn]: Checking xcatd can receive command request...                                                               [ OK ]
[mn]: Checking 'site' table is configured...                                                                      [ OK ]
[mn]: Checking provision network is configured...                                                                 [FAIL]
[mn]: The IP 172.12.253.27 of enP34p1s0f0.12 doesn't equal the value of 'master' in 'site' table
[sn01]: ssh: connect to host sn01 port 22: No route to host                                                       [FAIL]
[sn02]: ssh: connect to host sn02 port 22: No route to host                                                       [FAIL]
=================================== SUMMARY ====================================
[MN]: Checking on MN...                                                                                           [FAIL]
    Checking provision network is configured...                                                                   [FAIL]
        The IP 172.12.253.27 of enP34p1s0f0.12 doesn't equal the value of 'master' in 'site' table
[SN:sn01]: Checking on SN sn01...                                                                                 [FAIL]
    ssh: connect to host sn01 port 22: No route to host                                                           [FAIL]
[SN:sn02]: Checking on SN sn02...                                                                                 [FAIL]
    ssh: connect to host sn02 port 22: No route to host                                                           [FAIL]
 
[root@briggs01 subcmds]# xcatprobe  -w xcatmn -i  enP34p1s0f0
[mn]: Checking all xCAT deamons are running...                                                                    [ OK ]
[mn]: Checking xcatd can receive command request...                                                               [ OK ]
[mn]: Checking 'site' table is configured...                                                                      [ OK ]
[mn]: Checking provision network is configured...                                                                 [ OK ]
[mn]: Checking 'passwd' table is configured...                                                                    [ OK ]
[mn]: Checking important directories(installdir,tftpdir) are configured...                                        [ OK ]
[mn]: Checking SELinux is disabled...                                                                             [ OK ]
[mn]: Checking HTTP service is configured...                                                                      [ OK ]
[mn]: Checking TFTP service is configured...                                                                      [ OK ]
[sn01]: ssh: connect to host sn01 port 22: No route to host                                                       [FAIL]
[sn02]: ssh: connect to host sn02 port 22: No route to host                                                       [FAIL]
[mn]: Checking DNS service is configured...                                                                       [ OK ]
[mn]: Checking DHCP service is configured...                                                                      [ OK ]
[mn]: Checking NTP service is configured...                                                                       [ OK ]
[mn]: Checking firewall is disabled...                                                                            [ OK ]
[mn]: Checking minimum disk space for xCAT ['/var' needs 1GB;'/install' needs 10GB;'/tmp' needs 1GB]...           [ OK ]
[mn]: Checking xCAT management node IP: <172.10.253.27> is configured to static...                                [ OK ]
[mn]: Checking dhcpd.leases file is less than 100M...                                                             [ OK ]
=================================== SUMMARY ====================================
[MN]: Checking on MN...                                                                                           [ OK ]
[SN:sn01]: Checking on SN sn01...                                                                                 [FAIL]
    ssh: connect to host sn01 port 22: No route to host                                                           [FAIL]
[SN:sn02]: Checking on SN sn02...                                                                                 [FAIL]
    ssh: connect to host sn02 port 22: No route to host                                                           [FAIL]
```