### PR TITLE
Fix VM doc: `mgt` required before changing vm attrs

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/common/kvm/manage_vm.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/kvm/manage_vm.rst
@@ -25,23 +25,23 @@ Specify VM attributes
 
 After the VM object is created, several key attributes need to be specified with ``chdef`` : 
 
-1. the number of virtual cpus in the VM: ::
+1. the hardware management module, "kvm" for PowerKVM: ::
+
+    chdef vm1 mgt=kvm
+
+2. the number of virtual cpus in the VM: ::
 
      chdef vm1 vmcpus=2
 
-2. the kvm hypervisor of the VM: ::
+3. the kvm hypervisor of the VM: ::
  
      chdef vm1 vmhost=kvmhost1
 
-3. the virtual memory size, with the unit "Megabit". Specify 1GB memory to "vm1" here: ::
+4. the virtual memory size, with the unit "Megabit". Specify 1GB memory to "vm1" here: ::
 
      chdef vm1 vmmemory=1024
 
 **Note**: For diskless node, the **vmmemory** should be at least 2048 MB, otherwise the node cannot boot up. 
-
-4. the hardware management module, "kvm" for PowerKVM: ::
-
-    chdef vm1 mgt=kvm
 
 5. Define the virtual network card, it should be set to the bridge "br0" which has been created in the hypervisor. If no bridge is specified, no network device will be created for the VM node "vm1": ::
 


### PR DESCRIPTION
VM creation docs are incorrect about the order of setting attributes for VM nodes.

xCAT version:
```
[samveen@xcatmn1 ~]$ lsxcatd -v
Version 2.13.7 (git commit 9ec6d0c0cce9f61a078a4dcd044927f5a65a606f, built Fri Sep 22 02:16:45 EDT 2017)
[samveen@xcatmn1 ~]$ lsxcatd -t
This is a Management Node
```
Error seen when following the docs:
```
[samveen@xcatmn1 ~]$ mkdef vm1 groups=vm,all
1 object definitions have been created or modified.
[samveen@xcatmn1 ~]$ chdef vm1 vmcpus=2
Cannot set the 'vmcpus' attribute unless a value is provided for 'mgt'.
mgt => The method to use to do general hardware management of the node.  This attribute is used as the default if power or getmac is not set.  Valid values: openbmc, ipmi, blade, hmc, ivm, fsp, bpa, kvm, esx, rhevm.  See the power attribute for more details.
Error: Cannot set the attr='vmcpus' attribute unless 'mgt=kvm'.
No object definitions have been created or modified.
```

This MR fixes the doc.