### PR TITLE
modify test case "nodeset_check_warning" depending on the latest nodeset code logic

### DIFF
--- a/xCAT-test/autotest/testcase/nodeset/cases0
+++ b/xCAT-test/autotest/testcase/nodeset/cases0
@@ -167,12 +167,13 @@ check:rc==0
 cmd:rmdef -t osimage -o "rhels7.5-ppc64el-install-compute"
 cmd:noderm testnode1
 end
+
 start:nodeset_check_warninginfo
-cmd:mkdef -t node -o testnode1 arch=ppc64el cons=ipmi groups=pbmc mgt=ipmi ip=10.1.1.200 mac=e6:d4:d2:3a:ad:06  monserver=10.1.1.1 nameservers=10.1.1.1 nodetype=ppc,osi profile=compute tftpserver=10.1.1.1 xcatmaster=10.1.1.1 netboot=petitboot
+cmd:if [[ "__GETNODEATTR($$CN,arch)__" =~ "el" || "__GETNODEATTR($$CN,arch)__" =~ "le" ]]; then bootloader=xnba; else bootloader=petitboot; fi; mkdef -t node -o testnode1 arch=ppc64el cons=ipmi groups=pbmc mgt=ipmi ip=10.1.1.200 mac=e6:d4:d2:3a:ad:06  monserver=10.1.1.1 nameservers=10.1.1.1 nodetype=ppc,osi profile=compute tftpserver=10.1.1.1 xcatmaster=10.1.1.1 netboot=$bootloader
 check:rc==0
+cmd:lsdef testnode1
 cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
-check:rc==0
-check:output=~Warning: testnode1: petitboot might be invalid|testnode1 could not be resolved
+check:output=~Warning: testnode1:.+might be invalid
 cmd:noderm testnode1
 end
 


### PR DESCRIPTION
Due to the code logic of ``nodeset`` was changed, so the case ``nodeset_check_warning`` is incorrect. update the case depending on the latest ``nodeset`` code logic.

The test result on ``sles11.4+x86``:
```
------START::nodeset_check_warninginfo::Time:Wed Oct 18 01:42:01 2017------

RUN:if [[ "__GETNODEATTR(c910f04x35v04,arch)__" =~ "el" || "__GETNODEATTR(c910f04x35v04,arch)__" =~ "le" ]]; then bootloader=xnba; else bootloader=petitboot; fi; mkdef -t node -o testnode1 arch=ppc64el cons=ipmi groups=pbmc mgt=ipmi ip=10.1.1.200 mac=e6:d4:d2:3a:ad:06  monserver=10.1.1.1 nameservers=10.1.1.1 nodetype=ppc,osi profile=compute tftpserver=10.1.1.1 xcatmaster=10.1.1.1 netboot=$bootloader [Wed Oct 18 01:42:01 2017]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:lsdef testnode1 [Wed Oct 18 01:42:02 2017]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Object name: testnode1
    arch=ppc64el
    cons=ipmi
    groups=pbmc
    ip=10.1.1.200
    mac=e6:d4:d2:3a:ad:06
    mgt=ipmi
    monserver=10.1.1.1
    nameservers=10.1.1.1
    netboot=petitboot
    nodetype=ppc,osi
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
    profile=compute
    tftpserver=10.1.1.1
    xcatmaster=10.1.1.1

RUN:nodeset testnode1 osimage=__GETNODEATTR(c910f04x35v04,os)__-__GETNODEATTR(c910f04x35v04,arch)__-install-compute [Wed Oct 18 01:42:03 2017]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Warning: testnode1: petitboot might be invalid when provisioning sles11.4-x86_64-install-compute,valid options: "xnba,pxe".
For more details see the 'netboot' description in the output of "tabdump -d noderes".
testnode1: Error: xCAT unable to resolve IP for testnode1 in petitboot plugin.
Error: Failed to generate petitboot configurations for some node(s) on c910f04x35v02. Check xCAT log file for more details.
testnode1: install sles11.4-x86_64-compute
CHECK:output =~ Warning: testnode1:.+might be invalid	[Pass]

RUN:noderm testnode1 [Wed Oct 18 01:42:04 2017]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

------END::nodeset_check_warninginfo::Passed::Time:Wed Oct 18 01:42:05 2017 ::Duration::4 sec------
```

The result on ``ubuntu16.04.1-ppc64el``:
```
------START::nodeset_check_warninginfo::Time:Wed Oct 18 01:32:26 2017------

RUN:if [[ "__GETNODEATTR(c910f03c09k11,arch)__" =~ "el" || "__GETNODEATTR(c910f03c09k11,arch)__" =~ "le" ]]; then bootloader=xnba; else bootloader=petitboot; fi; mkdef -t node -o testnode1 arch=ppc64el cons=ipmi groups=pbmc mgt=ipmi ip=10.1.1.200 mac=e6:d4:d2:3a:ad:06  monserver=10.1.1.1 nameservers=10.1.1.1 nodetype=ppc,osi profile=compute tftpserver=10.1.1.1 xcatmaster=10.1.1.1 netboot=$bootloader [Wed Oct 18 01:32:26 2017]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:lsdef testnode1 [Wed Oct 18 01:32:27 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Object name: testnode1
    arch=ppc64el
    cons=ipmi
    groups=pbmc
    ip=10.1.1.200
    mac=e6:d4:d2:3a:ad:06
    mgt=ipmi
    monserver=10.1.1.1
    nameservers=10.1.1.1
    netboot=xnba
    nodetype=ppc,osi
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
    profile=compute
    tftpserver=10.1.1.1
    xcatmaster=10.1.1.1

RUN:nodeset testnode1 osimage=__GETNODEATTR(c910f03c09k11,os)__-__GETNODEATTR(c910f03c09k11,arch)__-install-compute [Wed Oct 18 01:32:27 2017]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
Warning: testnode1: xnba might be invalid when provisioning ubuntu16.04.1-ppc64el-install-compute,valid options: "petitboot,grub2,grub2-tftp,grub2-http".
For more details see the 'netboot' description in the output of "tabdump -d noderes".
Warning: rcons may not work since no serialport is specified for testnode1
Warning: The hostname testnode1 of node testnode1 could not be resolved.
testnode1: install ubuntu16.04.1-ppc64el-compute
CHECK:output =~ Warning: testnode1:.+might be invalid	[Pass]

RUN:noderm testnode1 [Wed Oct 18 01:32:29 2017]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

------END::nodeset_check_warninginfo::Passed::Time:Wed Oct 18 01:32:30 2017 ::Duration::4 sec------
```