### PR TITLE
enhance HA scripts deactivate-mn and activate-mn

### DIFF
--- a/docs/source/advanced/hamn/setup_ha_mgmt_node_with_shared_data.rst
+++ b/docs/source/advanced/hamn/setup_ha_mgmt_node_with_shared_data.rst
@@ -289,7 +289,20 @@ In a planned failover, you can do necessary cleanup work on the previous primary
 Take down the Current Primary Management Node
 ---------------------------------------------
 
-xCAT ships a sample script ``/opt/xcat/share/xcat/hamn/deactivate-mn`` to make the machine be a standby management node. Before using this script, you need to review the script carefully and make updates accordingly, here is an example of how to use this script: ::
+xCAT ships a sample script ``/opt/xcat/share/xcat/hamn/deactivate-mn`` to make the machine be a standby management node. Before using this script, you need to review the script carefully and make updates accordingly, correct the following variable values in this script: ::
+
+    SHAREDVG=sharedvg # For AIX, shared volumn group name
+    DBDIR=/var/lib/pgsql # database directory
+    SHAREDFS="/install /etc/xcat /root/.xcat /tftpboot" # Shared file systems
+    USEDB2=no # if DB2 is being used
+    USETEAL=no # if TEAL is being used
+    USEDFM=no # if DFM is being used
+    USEUNMOUNT=yes # umount share data directory
+    POWER775=no # Power 775 cluster
+    CHANGEHOSTNAME=no # change the hostname from virtual ip hostname to the original hostname
+    xcatdb=postgresql # support postgrel,DB2,mysql
+
+Here is an example of how to use this script: ::
 
     /opt/xcat/share/xcat/hamn/deactivate-mn -i eth1:2 -v 9.114.47.97
 
@@ -341,7 +354,21 @@ If the management node is still available and running the cluster, perform the f
 
 Bring up the New Primary Management Node
 ----------------------------------------
-xCAT ships a sample script ``/opt/xcat/share/xcat/hamn/activate-mn`` to make the machine be a new primary management node. Before using this script, you need to review the script carefully and make updates accordingly, here is an example of how to use this script to make the machine be a primary management node: ::
+xCAT ships a sample script ``/opt/xcat/share/xcat/hamn/activate-mn`` to make the machine be a new primary management node. Before using this script, you need to review the script carefully and make updates accordingly, correct the following variable values in this script: ::
+
+    SHAREDVG=sharedvg # For AIX, shared volumn group name
+    DBDIR=/var/lib/pgsql # database directory
+    SHAREDFS="/install /etc/xcat /root/.xcat" # Shared file systems
+    USEDFM=no # if DFM is being used
+    USENTP=no # if NTP is being used
+    POWER775=no # Power 775 cluster
+    USETEAL=no # if TEAL is being used
+    USEMOUNT=yes # mounted filesystems in the file /etc/fstab
+    CHANGEHOSTNAME=yes # set the hostname to the virtual ip address hostname
+    RESTARTDNS=yes # if yes, will execute "makedns -n"
+    xcatdb=postgresql # support postgrel,DB2,mysql
+
+Here is an example of how to use this script to make the machine be a primary management node: ::
 
      /opt/xcat/share/xcat/hamn/activate-mn -i eth1:2 -v 9.114.47.97 -m 255.255.255.0
 

--- a/docs/source/advanced/hamn/setup_ha_mgmt_node_with_shared_data.rst
+++ b/docs/source/advanced/hamn/setup_ha_mgmt_node_with_shared_data.rst
@@ -293,6 +293,8 @@ xCAT ships a sample script ``/opt/xcat/share/xcat/hamn/deactivate-mn`` to make t
 
     /opt/xcat/share/xcat/hamn/deactivate-mn -i eth1:2 -v 9.114.47.97
 
+**Notes**: This script will be over-written after xCAT is upgraded. If this script is customized, make sure backup it before upgrading xCAT.
+
 On the current primary management node:
 
 If the management node is still available and running the cluster, perform the following steps to shutdown.
@@ -339,10 +341,11 @@ If the management node is still available and running the cluster, perform the f
 
 Bring up the New Primary Management Node
 ----------------------------------------
-
-Execute script ``/opt/xcat/share/xcat/hamn/activate-mn`` to make the machine be a primary management node: ::
+xCAT ships a sample script ``/opt/xcat/share/xcat/hamn/activate-mn`` to make the machine be a new primary management node. Before using this script, you need to review the script carefully and make updates accordingly, here is an example of how to use this script to make the machine be a primary management node: ::
 
      /opt/xcat/share/xcat/hamn/activate-mn -i eth1:2 -v 9.114.47.97 -m 255.255.255.0
+
+**Notes**: This script will be over-written after xCAT is upgraded. If this script is customized, make sure backup it before upgrading xCAT.
 
 On the new primary management node:
 

--- a/xCAT-server/share/xcat/hamn/activate-mn
+++ b/xCAT-server/share/xcat/hamn/activate-mn
@@ -33,7 +33,7 @@ USEDFM=no # if DFM is being used
 USENTP=no # if NTP is being used
 POWER775=no # Power 775 cluster
 USETEAL=no # if TEAL is being used
-USEMOUNT=yes # mounted  filesystems in the file /etc/fstab
+USEMOUNT=yes # mounted filesystems in the file /etc/fstab
 CHANGEHOSTNAME=yes # set the hostname to the virtual ip address hostname
 RESTARTDNS=yes # if yes, will execute "makedns -n"
 exit_code=0
@@ -160,6 +160,35 @@ then
     done
 else
     echo "Warning: share data $SHAREDFS $DBDIR should be mounted before."
+fi
+
+# check if DB is matched in linux
+if [ `uname` = "Linux" ]; then
+    echo "Check DB...."
+    if [ -n "/etc/xcat/cfgloc" ]
+    then
+        xcatcfg=`cat /etc/xcat/cfgloc|cut -f 1 -d : 2>/dev/null`
+    else
+        xcatcfg=`XCATBYPASS=1 /opt/xcat/bin/lsxcatd -d | cut -f 2 -d "=" 2>/dev/null`
+    fi
+    if [ -n $xcatcfg ]; then
+        current_db=$xcatcfg
+        if [ $xcatcfg = "Pg" ]
+        then
+            current_db="postgresql"
+        fi
+        echo "Current database is $current_db."
+        if [ $current_db != "$xcatdb" ]
+        then
+            echo "Error: current DB $current_db is not matched with $xcatdb. [Failed]"
+            exit_code=1
+        else
+            echo "DB is matched with $xcatdb [Passed]."
+        fi
+    else
+        echo "Error: can not get current DB. [Failed]"
+        exit_code=1
+    fi
 fi
 
 # Start NFS

--- a/xCAT-server/share/xcat/hamn/activate-mn
+++ b/xCAT-server/share/xcat/hamn/activate-mn
@@ -33,7 +33,7 @@ USEDFM=no # if DFM is being used
 USENTP=no # if NTP is being used
 POWER775=no # Power 775 cluster
 USETEAL=no # if TEAL is being used
-USEMOUNT=yes # mounted filesystems in the file /etc/fstab
+USEMOUNT=yes # mounted  filesystems in the file /etc/fstab
 CHANGEHOSTNAME=yes # set the hostname to the virtual ip address hostname
 RESTARTDNS=yes # if yes, will execute "makedns -n"
 exit_code=0
@@ -69,6 +69,12 @@ runcmd()
            a=$[$a+1]
         fi
     done
+}
+
+clear_env()
+{
+    NIC=$1
+    ifconfig $NIC 0.0.0.0 0.0.0.0 2>/dev/null
 }
 
 ################################################################################
@@ -165,13 +171,16 @@ fi
 # check if DB is matched in linux
 if [ `uname` = "Linux" ]; then
     echo "Check DB...."
-    if [ -n "/etc/xcat/cfgloc" ]
+    if [ -s /etc/xcat/cfgloc ]
     then
         xcatcfg=`cat /etc/xcat/cfgloc|cut -f 1 -d : 2>/dev/null`
-    else
+    else  
+        # SQLsite 
         xcatcfg=`XCATBYPASS=1 /opt/xcat/bin/lsxcatd -d | cut -f 2 -d "=" 2>/dev/null`
+        # filter Error message from lsxcatd 
+        echo "$xcatcfg" | grep "Error" && xcatcfg="" 
     fi
-    if [ -n $xcatcfg ]; then
+    if [ -n "$xcatcfg" ]; then
         current_db=$xcatcfg
         if [ $xcatcfg = "Pg" ]
         then
@@ -181,13 +190,15 @@ if [ `uname` = "Linux" ]; then
         if [ $current_db != "$xcatdb" ]
         then
             echo "Error: current DB $current_db is not matched with $xcatdb. [Failed]"
-            exit_code=1
+            clear_env $NIC
+            exit 1
         else
-            echo "DB is matched with $xcatdb [Passed]."
+            echo "DB is matched with $xcatdb [Passed]"
         fi
     else
         echo "Error: can not get current DB. [Failed]"
-        exit_code=1
+        clear_env $NIC 
+        exit 1
     fi
 fi
 
@@ -214,7 +225,6 @@ then
 fi
 
 ##############################################################################
-
 echo "Starting $xcatdb...."
 if [ `uname` = "AIX" ]
 then
@@ -229,16 +239,43 @@ else # Linux
     if [ $xcatdb != "SQLite" ]
     then
         runcmd "service $xcatdb start"
+        if [ $? -eq 0 ]
+        then
+            XCATBYPASS=1 tabdump site >/dev/null
+            if [ $? -ne 0 ]
+            then
+                echo "Error: cannot connect $xcatdb [Failed], exit...."
+                clear_env $NIC
+                exit 1
+            fi
+        else
+            echo "Error: service $xcatdb start [Failed], exit...."
+            clear_env $NIC 
+            exit 1
+        fi
     fi
 fi
     
-
 echo "Starting xCAT...."
 if [ `uname` = "AIX" ]
 then
     runcmd "/opt/xcat/sbin/restartxcatd"
 else # Linux
     runcmd "service xcatd restart"
+    if [ $? -ne 0 ]
+    then
+        echo "Error: failed to restart xcatd. exiting...."
+        clear_env $NIC
+        exit 1
+    else
+        tabdump site >/dev/null
+        if [ $? -ne 0 ]
+        then
+            echo "Error: failed to restart xcatd. exiting...."
+            clear_env $NIC
+            exit 1
+        fi
+    fi
 fi
 
 #echo "Start xCAT on the Service Nodes...."

--- a/xCAT-server/share/xcat/hamn/activate-mn
+++ b/xCAT-server/share/xcat/hamn/activate-mn
@@ -25,18 +25,19 @@
 # -----------------------------------------------------------------------------
 # 2011-12-08   JDW     1.0     Original
 # 2013-06-06   xCAT    1.1     Updated version to ship with xCAT
-
+# 2017-10-17   xCAT    2.13.8  Enhance 
 SHAREDVG=sharedvg # For AIX, shared volumn group name
-SHAREDFS="/install /etc/xcat ~/.xcat" # Shared file systems
-DB2DIR=/db2database # DB2 only, the db2 database directory
+DBDIR=/var/lib/pgsql # database directory
+SHAREDFS="/install /etc/xcat /root/.xcat" # Shared file systems
 USEDFM=no # if DFM is being used
 USENTP=no # if NTP is being used
 POWER775=no # Power 775 cluster
 USETEAL=no # if TEAL is being used
-CHANGEHOSTNAME=no # set the hostname to the virtual ip address hostname
-
-
-xcatdb=`XCATBYPASS=1 /opt/xcat/bin/lsxcatd -d | cut -f 2 -d "=" 2>/dev/null`
+USEMOUNT=yes # mounted  filesystems in the file /etc/fstab
+CHANGEHOSTNAME=yes # set the hostname to the virtual ip address hostname
+RESTARTDNS=yes # if yes, will execute "makedns -n"
+exit_code=0
+xcatdb=postgresql # support postgrel,DB2,mysql 
 
 usage()
 {
@@ -49,7 +50,25 @@ EOF
 runcmd()
 {
     echo "Running command: $@"
-    $@
+    a=0
+    while true
+    do
+        if [ $a -eq 5 ]; then
+            echo "$@ [Failed]"
+            exit_code=1
+            return 1
+        elif [ $a -gt 0 ]; then
+            sleep 3
+            echo "Retry $a ...... $@"
+        fi
+        $@
+        if [ $? -eq 0 ]; then
+            echo "$@ [Passed]"
+            return 0
+        else
+           a=$[$a+1]
+        fi
+    done
 }
 
 ################################################################################
@@ -133,15 +152,14 @@ then
     runcmd "varyonvg $SHAREDVG"
 fi
 
-for fs in $SHAREDFS
-do
-    runcmd "mount $fs"
-done
-
-#DB2 only
-if [ $xcatdb = "DB2" ]
+if [ $USEMOUNT = "yes" ]
 then
-    runcmd "mount $DB2DIR"
+    for fs in $SHAREDFS $DBDIR
+    do
+        runcmd "mount $fs"
+    done
+else
+    echo "Warning: share data $SHAREDFS $DBDIR should be mounted before."
 fi
 
 # Start NFS
@@ -174,14 +192,14 @@ then
     if [ $xcatdb = "DB2" ]
     then
         runcmd "su - xcatdb -c \"db2start\""
-    elif [ $xcatdb = "mysql" ]
+    elif [ $DATABASE = "mysql" ]
     then
         runcmd "startsrc -g mysql"
     fi
 else # Linux
     if [ $xcatdb != "SQLite" ]
     then
-        runcmd "service $xcatdb start 2>&1 1>/dev/null"
+        runcmd "service $xcatdb start"
     fi
 fi
     
@@ -230,6 +248,11 @@ then
 fi
 
 ##############################################################################
+#Re-make dns
+if [ $RESTARTDNS = "yes" ]
+then
+    runcmd "makedns -n"
+fi
 
 # Re-make DHCP definitions
 echo "Making upto date DHCP configuration file...."
@@ -281,5 +304,9 @@ fi
 
 echo ""
 echo ""
-echo "This machine is set to active management node successfully, enjoy..."
-exit 0
+if [ $exit_code -eq 0 ]; then
+    echo "This machine is set to active management node successfully, enjoy..."
+else
+    echo "This machine is set to active management node, but some service failed..."
+fi
+exit $exit_code

--- a/xCAT-server/share/xcat/hamn/deactivate-mn
+++ b/xCAT-server/share/xcat/hamn/deactivate-mn
@@ -24,15 +24,18 @@
 # -----------------------------------------------------------------------------
 # 2011-12-08   JDW     1.0     Original
 # 2013-06-06   xCAT    1.1     Updated version to ship with xCAT
+# 2017-10-12   xCAT    2.13.8  Enhance 
 SHAREDVG=sharedvg # For AIX, shared volumn group name
-SHAREDFS="/install /etc/xcat ~/.xcat" # Shared file systems
-DB2DIR=/db2database # DB2 only, the db2 database directory
+DBDIR=/var/lib/pgsql # database directory
+SHAREDFS="/install /etc/xcat /root/.xcat /tftpboot" # Shared file systems
+USEDB2=no # if DB2 is being used
 USETEAL=no # if TEAL is being used
 USEDFM=no # if DFM is being used
+USEUNMOUNT=yes # umount share data directory
 POWER775=no # Power 775 cluster
 CHANGEHOSTNAME=no # change the hostname from virtual ip hostname to the original hostname
-
-xcatdb=`XCATBYPASS=1 /opt/xcat/bin/lsxcatd -d | cut -f 2 -d "=" 2>/dev/null`
+exit_code=0
+xcatdb=postgresql # support postgrel,DB2,mysql
 
 usage()
 {
@@ -45,7 +48,25 @@ EOF
 runcmd()
 {
     echo "Running command: $@"
-    $@
+    a=0
+    while true 
+    do 
+        if [ $a -eq 5 ]; then
+            echo "$@ [Failed]"
+            exit_code=1
+            return 1
+        elif [ $a -gt 0 ]; then
+            sleep 3
+            echo "Retry $a ...... $@"
+        fi
+        $@
+        if [ $? -eq 0 ]; then
+            echo "$@ [Passed]" 
+            return 0
+        else 
+           a=$[$a+1]
+        fi
+    done
 }
 
 ################################################################################
@@ -154,7 +175,7 @@ if [ `uname` = "AIX" ]
 then
     stopsrc -s xcatd
 else # Linux
-    service xcatd stop
+    runcmd "service xcatd stop"
 fi
 
 echo "Stopping database $xcatdb...."
@@ -170,15 +191,16 @@ then
 else # Linux
     if [ $xcatdb != "SQLite" ]
     then
-        runcmd "service $xcatdb stop 2>&1 1>/dev/null"
+        runcmd "service $xcatdb stop"
     fi
 fi
 
 ##############################################################################
-
-# Kill nicely, wait a little time for processes to clean-up....
-for fs in $SHAREDFS $DB2DIR
-do
+if [ $USEDB2 = "yes" ]
+then
+    # Kill nicely, wait a little time for processes to clean-up....
+    for fs in $SHAREDFS $DBDIR
+    do
 	echo "Killing processes (nicely) accessing filesystem ${fs}...."
         if [ `uname` = "AIX" ]
         then
@@ -186,7 +208,8 @@ do
         else # Linux
             runcmd "fuser -u -k ${fs}"
         fi
-done
+    done
+fi
 
 # AIX only, Linux has the -l flag could hanldle everything
 if [ `uname` = "AIX" ]
@@ -231,13 +254,14 @@ then
         runcmd "umount $fs"
     done
 else
-    for fs in $SHAREDFS
-    do
-        runcmd "umount -l $fs"
-    done
+    if [ $USEUNMOUNT = "yes" ]
+    then
+        for fs in $SHAREDFS $DBDIR
+        do
+            runcmd "umount -l $fs"
+        done
+    fi
 fi
-
-
 
 if [ `uname` = "AIX" ]
 then
@@ -257,22 +281,32 @@ then
             BOOT_HOSTNAME=`grep HOSTNAME /etc/sysconfig/network | cut -f 2 -d "="`
         fi
     fi
-    hostname ${BOOT_HOSTNAME}
+    runcmd "hostname ${BOOT_HOSTNAME}"
 fi
 
 # Remove virtual ip addresses
 
 # Firstly determine the correct IP addresses for each interface
-echo "Removing IP Aliases...."
+echo "Removing IP Aliase...."
 if [ `uname` = "AIX" ]
 then
     runcmd "ifconfig $NIC delete $VIP"
 else # Linux
-    runcmd "ifconfig $NIC 0.0.0.0 0.0.0.0"
+    ifconfig $NIC 0.0.0.0 0.0.0.0
+    ip addr show |grep 10.5.106.100 2>&1 1>/dev/null
+    if [ $? -ne 0 ]; then
+         echo "IP Aliase $NIC $VIP is removed.[Passed]"
+    else
+         echo "Fail to remove IP Aliase $NIC $VIP. [Failed]"
+    fi 
 fi
 
 echo ""
 echo ""
-echo "This machine is set to standby management node successfully..."
-
-exit 0
+if [ $exit_code -eq 0 ]
+then
+    echo "This machine is set to standby management node successfully..."
+else
+    echo "This machine is set to standby management node, but some service are failed."
+fi
+exit $exit_code

--- a/xCAT-server/share/xcat/hamn/deactivate-mn
+++ b/xCAT-server/share/xcat/hamn/deactivate-mn
@@ -293,7 +293,7 @@ then
     runcmd "ifconfig $NIC delete $VIP"
 else # Linux
     ifconfig $NIC 0.0.0.0 0.0.0.0
-    ip addr show |grep 10.5.106.100 2>&1 1>/dev/null
+    ip addr show |grep $VIP 2>&1 1>/dev/null
     if [ $? -ne 0 ]; then
          echo "IP Aliase $NIC $VIP is removed.[Passed]"
     else


### PR DESCRIPTION
for #4076 :
Including the following 2 scripts:
/opt/xcat/share/xcat/hamn/deactivate-mn
/opt/xcat/share/xcat/hamn/activate-mn

UT:
doc link: http://10.4.41.1/install/pgsql/xcat-core/docs/build/html/advanced/hamn/setup_ha_mgmt_node_with_shared_data.html#setup-ha-mgmt-node-with-shared-data

scripts UT:
Take nfs based share data solution as an example:
1, prepare share data:
```
mount -o rw c910f05c01bc06:/HA/etc/xcat /etc/xcat
mount -o rw c910f05c01bc06:/HA/root/.xcat ~/.xcat
mount -o rw c910f05c01bc06:/HA/var/lib/pgsql /var/lib/pgsql
mount -o rw 10.5.106.1:/HA/tftpboot /tftpboot
mount -o rw c910f05c01bc06:/HA/install /install
```

2, de-active mn:
```
[root@bybc0605 /]# /opt/xcat/share/xcat/hamn/deactivate-mn -i eth0:0 -v 10.5.106.100
Stopping Console Server....
Running command: service conserver stop
Stopping conserver (via systemctl):                        [  OK  ]
service conserver stop [Passed]
Stopping DHCP....
Running command: service dhcpd stop
Redirecting to /bin/systemctl stop dhcpd.service
service dhcpd stop [Passed]
Stopping xCAT....
Running command: service xcatd stop
Stopping xcatd (via systemctl):                            [  OK  ]
service xcatd stop [Passed]
Stopping database postgresql....
Running command: service postgresql stop
Redirecting to /bin/systemctl stop postgresql.service
service postgresql stop [Passed]
Re-configuring NTP....
Running command: service ntpd restart
Redirecting to /bin/systemctl restart ntpd.service
service ntpd restart [Passed]
Un-exporting NFS filesystems and stop NFS....
Running command: exportfs -ua
exportfs -ua [Passed]
Running command: service nfs stop
Redirecting to /bin/systemctl stop nfs.service
service nfs stop [Passed]
Unmounting shared filesystems ....
Running command: umount -l /install
umount -l /install [Passed]
Running command: umount -l /etc/xcat
umount -l /etc/xcat [Passed]
Running command: umount -l /root/.xcat
umount -l /root/.xcat [Passed]
Running command: umount -l /tftpboot
umount -l /tftpboot [Passed]
Running command: umount -l /var/lib/pgsql
umount -l /var/lib/pgsql [Passed]
Removing IP Aliase....
SIOCSIFFLAGS: Cannot assign requested address
SIOCSIFFLAGS: Cannot assign requested address
IP Aliase eth0:0 10.5.106.100 is removed.[Passed]


This machine is set to standby management node successfully...
[root@bybc0605 /]#
```
3, active mn:
edit activate-mn set "USEMOUNT=no"
```
[root@bybc0605 /]# /opt/xcat/share/xcat/hamn/activate-mn -i eth0:0 -v 10.5.106.100 -m 255.0.0.0
Changing IP addreses/aliases....
Running command: ifconfig eth0:0 10.5.106.100 netmask 255.0.0.0
ifconfig eth0:0 10.5.106.100 netmask 255.0.0.0 [Passed]
Running command: hostname
bybc0605
hostname  [Passed]
Warning: share data /install /etc/xcat /root/.xcat /var/lib/pgsql should be mounted before.
Export NFS filesystems and start NFS....
Running command: exportfs -a
exportfs: /install does not support NFS export
exportfs: /tftpboot does not support NFS export
Retry 1 ...... exportfs -a
exportfs: /install does not support NFS export
exportfs: /tftpboot does not support NFS export
Retry 2 ...... exportfs -a
exportfs: /install does not support NFS export
exportfs: /tftpboot does not support NFS export
Retry 3 ...... exportfs -a
exportfs: /install does not support NFS export
exportfs: /tftpboot does not support NFS export
Retry 4 ...... exportfs -a
exportfs: /install does not support NFS export
exportfs: /tftpboot does not support NFS export
exportfs -a [Failed]
Running command: service nfs restart
Redirecting to /bin/systemctl restart nfs.service
service nfs restart [Passed]
Starting postgresql....
Running command: service postgresql start
Redirecting to /bin/systemctl start postgresql.service
service postgresql start [Passed]
Starting xCAT....
Running command: service xcatd restart
Restarting xcatd (via systemctl):                          [  OK  ]
service xcatd restart [Passed]
Running command: makedns -n
Handling bybc0607 in /etc/hosts.
Handling c910f05c01bc06 in /etc/hosts.
Handling byrhmn in /etc/hosts.
Handling localhost in /etc/hosts.
Handling bybc0609 in /etc/hosts.
Handling bybc0605 in /etc/hosts.
Handling localhost in /etc/hosts.
Getting reverse zones, this may take several minutes for a large cluster.
Completed getting reverse zones.
Updating zones.
Completed updating zones.
Restarting named
Restarting named complete
Updating DNS records, this may take several minutes for a large cluster.
Completed updating DNS records.
DNS setup is completed
makedns -n [Passed]
Making upto date DHCP configuration file....
Running command: makedhcp -n
Renamed existing dhcp configuration file to  /etc/dhcp/dhcpd.conf.xcatbak

Warning: No dynamic range specified for 10.0.0.0. If hardware discovery is being used, a dynamic range is required.
makedhcp -n [Passed]
Running command: makedhcp -a
makedhcp -a [Passed]
Running command: makeconservercf
makeconservercf [Passed]

This machine is set to active management node, but some service failed...
```