### PR TITLE
Add ipsrc for rspconfig, fix rspconfig vlan reading

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
@@ -408,13 +408,13 @@ OPTIONS
 
 \ **ipsrc**\ 
  
- Get the ip source for OpenBMC.
+ Get the IP source for OpenBMC.
  
 
 
 \ **ip**\ 
  
- The ip address.
+ The IP address.
  
 
 

--- a/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
@@ -47,7 +47,7 @@ OpenBMC specific:
 =================
 
 
-\ **rspconfig**\  \ *noderange*\  {\ **ip | netmask | gateway | hostname | vlan | sshcfg**\ }
+\ **rspconfig**\  \ *noderange*\  {\ **ipsrc | ip | netmask | gateway | hostname | vlan | sshcfg**\ }
 
 
 MPA specific:
@@ -403,6 +403,12 @@ OPTIONS
 \ **vlan**\ 
  
  Get or set vlan ID. For get vlan ID, if vlan is not enabled, 'BMC VLAN disabled' will be outputed. For set vlan ID, the valid value are [1-4096].
+ 
+
+
+\ **ipsrc**\ 
+ 
+ Get the ip source for OpenBMC.
  
 
 

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -145,7 +145,7 @@ my %usage = (
        rspconfig <noderange> [garp=<number of 1/2 second>]
        rspconfig <noderange> [userid=<userid> username=<username> password=<password>]
    OpenBMC specific:
-       rspconfig <noderange> [ip|netmask|gateway|hostname|vlan]
+       rspconfig <noderange> [ipsrc|ip|netmask|gateway|hostname|vlan]
    iDataplex specific:
        rspconfig <noderange> [thermprofile]
        rspconfig <noderange> [thermprofile=<two digit number from chassis>]

--- a/xCAT-client/pods/man1/rspconfig.1.pod
+++ b/xCAT-client/pods/man1/rspconfig.1.pod
@@ -310,11 +310,11 @@ Get or set vlan ID. For get vlan ID, if vlan is not enabled, 'BMC VLAN disabled'
 
 =item B<ipsrc>
 
-Get the ip source for OpenBMC.
+Get the IP source for OpenBMC.
 
 =item B<ip>
 
-The ip address.
+The IP address.
 
 =item B<memdecfg>={B<configure | deconfigure>:I<processingunit>:I<unit|bank>:I<id,...>}
 

--- a/xCAT-client/pods/man1/rspconfig.1.pod
+++ b/xCAT-client/pods/man1/rspconfig.1.pod
@@ -24,7 +24,7 @@ B<rspconfig> I<noderange> B<garp>=I<time>
 
 =head2 OpenBMC specific:
 
-B<rspconfig> I<noderange> {B<ip>|B<netmask>|B<gateway>|B<hostname>|B<vlan>|B<sshcfg>}
+B<rspconfig> I<noderange> {B<ipsrc>|B<ip>|B<netmask>|B<gateway>|B<hostname>|B<vlan>|B<sshcfg>}
 
 =head2 MPA specific:
 
@@ -307,6 +307,10 @@ Get or set hostname on the service processor.
 =item B<vlan>
 
 Get or set vlan ID. For get vlan ID, if vlan is not enabled, 'BMC VLAN disabled' will be outputed. For set vlan ID, the valid value are [1-4096].
+
+=item B<ipsrc>
+
+Get the ip source for OpenBMC.
 
 =item B<ip>
 

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -630,7 +630,7 @@ sub parse_args {
                 return ([ 1, "Can not configure and display nodes' value at the same time" ]) if ($setorget and $setorget eq "get");
                 my $key = $1;
                 my $value = $2;
-                return ([ 1, "Unsupport to configure ipsrc" ]) if ($key eq "ipsrc");
+                return ([ 1, "Changing ipsrc value is currently not supported." ]) if ($key eq "ipsrc");
                 return ([ 1, "Unsupported command: $command $key" ]) unless ($key =~ /^ip$|^netmask$|^gateway$|^hostname$|^vlan$/);
 
                 my $nodes_num = @$noderange;
@@ -1845,9 +1845,6 @@ sub rspconfig_response {
             if ($adapter_id) {
                 if (defined($content{Address}) and $content{Address}) {
                     unless ($address =~ /n\/a/) {
-                        if ($ipsrc eq "DHCP" and $xcatdebugmode) {
-                            process_debug_info($node, "There is an IP address:$address got through DHCP");
-                        }
                         # We have already processed an entry with adapter information.
                         # This must be a second entry. Display an error. Currently only supporting
                         # an adapter with a single IP address set.


### PR DESCRIPTION
To replace pull request #3843 
1. add option ipsrc for rspconfig
2. fix rspconfig vlan reading

The output looks like this:
```
[root@briggs01 xCAT_plugin]# XCAT_OPENBMC_DEVEL=YES rspconfig mid05tor12cn13,mid05tor12cn05 netmask gateway vlan ip ipsrc
mid05tor12cn13: BMC Netmask: 255.255.0.0
mid05tor12cn13: BMC Gateway: 0.0.0.0 (default: n/a)
mid05tor12cn13: BMC VLAN ID: 11
mid05tor12cn13: BMC IP: 172.11.139.13
mid05tor12cn13: BMC IP Source: Static
mid05tor12cn05: BMC Netmask: 255.255.0.0
mid05tor12cn05: BMC Gateway: 0.0.0.0 (default: 172.12.253.27)
mid05tor12cn05: BMC VLAN ID: Disabled
mid05tor12cn05: BMC IP: 172.12.253.100
mid05tor12cn05: BMC IP Source: DHCP
```