### PR TITLE
Return NotReady when looking for bmcstate if response is not OK

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1235,6 +1235,14 @@ sub deal_with_response {
 
     if ($response->status_line ne $::RESPONSE_OK) {
         my $error;
+        if (defined $status_info{RPOWER_STATUS_RESPONSE}{argv} and $status_info{RPOWER_STATUS_RESPONSE}{argv} =~ /bmcstate$/) {
+            # Handle the special case to return "NotReady" if the BMC does not return a success response.
+            # If the REST service is not up, it can't return "NotReady" itself, during reboot.:w
+            $error = "BMC NotReady";
+            xCAT::SvrUtils::sendmsg($error, $callback, $node);
+            $wait_node_num--;
+            return;    
+        }
         if ($response->status_line eq $::RESPONSE_SERVICE_UNAVAILABLE) {
             $error = $::RESPONSE_SERVICE_UNAVAILABLE;
         } elsif ($response->status_line eq $::RESPONSE_METHOD_NOT_ALLOWED) {


### PR DESCRIPTION
Resolves #3965 

After the PR changes, when we reboot the BMC and the service goes down, it looks like the following: 

```
[root@briggs01 fixPNOR]# rpower mid05tor12cn16 bmcreboot 
mid05tor12cn16: BMC reboot
[root@briggs01 fixPNOR]# while true ; do  date ;rpower mid05tor12cn16 bmcstate; sleep 2; done
Wed Oct 18 16:28:01 EDT 2017
mid05tor12cn16: BMC NotReady
Wed Oct 18 16:28:05 EDT 2017
mid05tor12cn16: BMC NotReady
Wed Oct 18 16:28:07 EDT 2017
mid05tor12cn16: BMC NotReady
Wed Oct 18 16:28:44 EDT 2017
mid05tor12cn16: BMC NotReady
Wed Oct 18 16:28:47 EDT 2017
mid05tor12cn16: BMC NotReady
Wed Oct 18 16:28:50 EDT 2017
mid05tor12cn16: BMC NotReady
Wed Oct 18 16:28:53 EDT 2017
mid05tor12cn16: BMC NotReady
Wed Oct 18 16:28:56 EDT 2017
mid05tor12cn16: BMC NotReady
Wed Oct 18 16:28:59 EDT 2017
mid05tor12cn16: BMC NotReady
Wed Oct 18 16:29:02 EDT 2017
mid05tor12cn16: BMC NotReady
Wed Oct 18 16:29:05 EDT 2017
mid05tor12cn16: BMC NotReady
Wed Oct 18 16:29:09 EDT 2017
mid05tor12cn16: BMC NotReady
Wed Oct 18 16:29:12 EDT 2017
mid05tor12cn16: BMC NotReady
Wed Oct 18 16:30:14 EDT 2017
mid05tor12cn16: BMC NotReady
Wed Oct 18 16:30:26 EDT 2017
mid05tor12cn16: BMC NotReady
Wed Oct 18 16:30:32 EDT 2017
mid05tor12cn16: BMC NotReady
Wed Oct 18 16:30:37 EDT 2017
mid05tor12cn16: BMC NotReady
Wed Oct 18 16:30:45 EDT 2017
mid05tor12cn16: BMC NotReady
Wed Oct 18 16:30:50 EDT 2017
mid05tor12cn16: BMC Ready
Wed Oct 18 16:30:53 EDT 2017
mid05tor12cn16: BMC Ready
Wed Oct 18 16:30:56 EDT 2017
mid05tor12cn16: BMC Ready
Wed Oct 18 16:30:58 EDT 2017
mid05tor12cn16: BMC Ready
Wed Oct 18 16:31:01 EDT 2017
mid05tor12cn16: BMC Ready
Wed Oct 18 16:31:04 EDT 2017
mid05tor12cn16: BMC Ready
Wed Oct 18 16:31:07 EDT 2017
mid05tor12cn16: BMC Ready
Wed Oct 18 16:31:10 EDT 2017
mid05tor12cn16: BMC Ready
```

During this time, I also tried to run it across the range, I'm not sure why it took this long... 

```
====================================================
[Date]       2017-10-18 16:29:39
[ClientType] cli
[Request]    rpower p9up bmcstate
[Response]
mid05tor12cn13: BMC Ready
mid05tor12cn15: BMC Ready
mid05tor12cn02: BMC Ready
mid05tor12cn11: BMC Ready
mid05tor12cn05: BMC Ready
mid05tor12cn16: BMC NotReady
mid05tor12cn17: BMC Ready
mid05tor12cn18: BMC Ready
[ElapsedTime] 47 s
====================================================
```

Running it again when all BMC is responsive....

```
[root@briggs01 opt]# time rpower p9up bmcstate
mid05tor12cn13: BMC Ready
mid05tor12cn16: BMC Ready
mid05tor12cn15: BMC Ready
mid05tor12cn02: BMC Ready
mid05tor12cn05: BMC Ready
mid05tor12cn11: BMC Ready
mid05tor12cn18: BMC Ready
mid05tor12cn17: BMC Ready

real	0m3.734s
user	0m0.082s
sys	0m0.018s
```


Yea, so something strange here... Running without my changes results in the same: 
```
[root@briggs01 opt]# time rpower p9up bmcstate
time rpower mid05tor12cn16 bmcstate
mid05tor12cn13: BMC Ready
mid05tor12cn15: BMC Ready
mid05tor12cn02: BMC Ready
mid05tor12cn05: BMC Ready
mid05tor12cn11: BMC Ready
mid05tor12cn18: BMC Ready
mid05tor12cn17: BMC Ready
mid05tor12cn16: Error: path or object not found /xyz/openbmc_project/state

real	0m47.243s
user	0m0.117s
sys	0m0.000s
[root@briggs01 opt]# time rpower mid05tor12cn16 bmcstate
mid05tor12cn16: Error: path or object not found /xyz/openbmc_project/state

real	0m4.609s
user	0m0.102s
sys	0m0.011s
[root@briggs01 opt]#
```

So it's not caused by this code change, @xuweibj  I thought you did some investigation when the BMC is not responding, do we have an issue open for it? 