### PR TITLE
add --noips for confignetwork to ignore no nicips error 

### DIFF
--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -81,12 +81,17 @@ function get_nic_cfg_file_content {
 boot_install_nic=0
 str_ib_nics=''
 num_iba_ports=
+ignore_nicips=0
 for arg in "$@"
 do
     if [ "$arg" = "-s" ];then
         boot_install_nic=1
     elif [ "${arg:0:10}" = "--ibaports" ];then
         num_iba_ports=${arg#--ibaports=}
+    fi
+    # --noips means ignore if nicips are not configured or not
+    if [ "$arg" = "--noips" ]; then
+        ignore_nicips=1
     fi
 done
 if [ "$SETINSTALLNIC" = "1" ] || [ "$SETINSTALLNIC" = "yes" ]; then
@@ -336,8 +341,12 @@ function sort_nics_device_order {
                     echo $alonenic
                 fi
             else
-                errorcode=1
-                echo "Error: nicips,nictypes and nicnetworks should be configured in nics table for $alonenic."
+                if [ $ignore_nicips -eq 0 ]; then
+                    errorcode=1
+                    echo "Error: nicips,nictypes and nicnetworks should be configured in nics table for $alonenic."
+                else
+                    echo "nic $alonenic found, but incomplete configuration in node definition."
+                fi
                 ((num1+=1))
                 continue
             fi
@@ -659,8 +668,14 @@ if [ $? -eq 0 ]; then
     errorcode=1
 fi
 
+#when --noips is used, print incomplete nics 
+nonicips_list=`echo "$sorted_nicdevice_list" | grep "incomplete"`
+if [ $? -eq 0 ]; then
+    echo "$nonicips_list"| log_lines info
+fi
+
 #delete invalid nics device pair based on Error
-valid_sorted_nicdevice_list=`echo "$sorted_nicdevice_list" | sed '/Error/d'`
+valid_sorted_nicdevice_list=`echo "$sorted_nicdevice_list" | sed '/Error/d' | sed '/incomplete configuration/d'`
 if [ -n "$valid_sorted_nicdevice_list" ]; then 
     log_info "All valid nics and device list:"
     echo "$valid_sorted_nicdevice_list" |log_lines info

--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -89,8 +89,8 @@ do
     elif [ "${arg:0:10}" = "--ibaports" ];then
         num_iba_ports=${arg#--ibaports=}
     fi
-    # --noips means ignore if nicips are not configured or not
-    if [ "$arg" = "--noips" ]; then
+    # --allownoip means ignore if nicips are not configured or not
+    if [ "$arg" = "--allownoip" ]; then
         ignore_nicips=1
     fi
 done
@@ -341,11 +341,11 @@ function sort_nics_device_order {
                     echo $alonenic
                 fi
             else
-                if [ $ignore_nicips -eq 0 ]; then
+                if [ $ignore_nicips -eq 1 ] && [ -z "$alonenicips" ]; then
+                    echo "nic $alonenic found, but incomplete configuration in node definition."
+                else
                     errorcode=1
                     echo "Error: nicips,nictypes and nicnetworks should be configured in nics table for $alonenic."
-                else
-                    echo "nic $alonenic found, but incomplete configuration in node definition."
                 fi
                 ((num1+=1))
                 continue
@@ -644,6 +644,9 @@ parser_nic_attribute "$NICTYPES" "nictypes"
 #make hash for nicips
 parser_nic_attribute "$NICIPS" "nicips"
 
+#make hash for nicnetworks
+parser_nic_attribute "$NICNETWORKS" "nicnetworks"
+
 #make hash for niccustomscripts
 parser_nic_attribute "$NICCUSTOMSCRIPTS" "niccustomscripts"
 
@@ -668,7 +671,7 @@ if [ $? -eq 0 ]; then
     errorcode=1
 fi
 
-#when --noips is used, print incomplete nics 
+#when --allownoip is used, print incomplete nics
 nonicips_list=`echo "$sorted_nicdevice_list" | grep "incomplete"`
 if [ $? -eq 0 ]; then
     echo "$nonicips_list"| log_lines info


### PR DESCRIPTION
for #4116 

When "--noips" is used, if nicips is not configured for nics.nicips, confignetwork will print remind information and not set return code. When "--noips" is not used, if nicips,nictypes or nicnetworks is not set for one nic, confignetwork will print error and set return code 1.

UT:
1,  call `confignetwork` without "--noips", print error and set return code 1:
```
........
bybc0607: xcatdsklspost: downloaded postscripts successfully
bybc0607: Wed Oct 18 23:17:47 EDT 2017 Running postscript: confignetwork
bybc0607: [E]:Error: nicips,nictypes and nicnetworks should be configured in nics table for enP48p1s0f1.
bybc0607: [E]:Error: nicips,nictypes and nicnetworks should be configured in nics table for enP5p1s0f1.
bybc0607: [E]:Error: nicips,nictypes and nicnetworks should be configured in nics table for enP5p1s0f1.4.
bybc0607: [E]:Error: nicips,nictypes and nicnetworks should be configured in nics table for enP5p1s0f1.5.
bybc0607: [E]:Error: nicips,nictypes and nicnetworks should be configured in nics table for enP5p1s0f1.6.
bybc0607: [E]:Error: nicips,nictypes and nicnetworks should be configured in nics table for ib2.
bybc0607: [E]:Error: nicips,nictypes and nicnetworks should be configured in nics table for ib3.
bybc0607: [I]: All valid nics and device list:
bybc0607: [I]: enP48p1s0f0
bybc0607: [I]: ib0,ib1
...........
```
2, call `confignetwork --noips`, print remind information and do not set return code
```
..........
bybc0607: xcatdsklspost: downloaded postscripts successfully
bybc0607: Thu Oct 19 02:21:04 EDT 2017 Running postscript: confignetwork
bybc0607: [I]: nic enP48p1s0f1 found, but incomplete configuration in node definition.
bybc0607: [I]: nic enP5p1s0f1 found, but incomplete configuration in node definition.
bybc0607: [I]: nic enP5p1s0f1.4 found, but incomplete configuration in node definition.
bybc0607: [I]: nic enP5p1s0f1.5 found, but incomplete configuration in node definition.
bybc0607: [I]: nic enP5p1s0f1.6 found, but incomplete configuration in node definition.
bybc0607: [I]: nic ib2 found, but incomplete configuration in node definition.
bybc0607: [I]: nic ib3 found, but incomplete configuration in node definition.
bybc0607: [I]: All valid nics and device list:
bybc0607: [I]: enP48p1s0f0
bybc0607: [I]: ib0,ib1
bybc0607: [I]: NetworkManager is inactive.
........
```