### PR TITLE
add mlx5_ib,mlx5_core to genesis_base

### DIFF
--- a/xCAT-genesis-builder/installkernel
+++ b/xCAT-genesis-builder/installkernel
@@ -1,9 +1,9 @@
 #!/bin/bash
 instmods nfs sunrpc
-instmods e1000 e1000e virtio_net virtio_pci igb ines sfc mlx4_en cxgb3 cxgb4 tg3 bnx2 bnx2x bna ixgb ixgbe qlge mptsas mpt2sas mpt3sas ata_piix megaraid_sas virtio_blk ahci ibmaem xhci-hcd sd_mod pmcraid be2net vfat ext3 ext4 btrfs reiserfs usb_storage scsi_wait_scan kvm kvm-intel kvm-amd ipmi_powernv ipmi_si ipmi_devintf qlcnic xfs
+instmods e1000 e1000e virtio_net virtio_pci igb ines sfc mlx4_en mlx5_core cxgb3 cxgb4 tg3 bnx2 bnx2x bna ixgb ixgbe qlge mptsas mpt2sas mpt3sas ata_piix megaraid_sas virtio_blk ahci ibmaem xhci-hcd sd_mod pmcraid be2net vfat ext3 ext4 btrfs reiserfs usb_storage scsi_wait_scan kvm kvm-intel kvm-amd ipmi_powernv ipmi_si ipmi_devintf qlcnic xfs
 instmods macvlan macvtap 8021q bridge bonding vmxnet3 cpufreq_ondemand acpi-cpufreq powernow-k8 cdc_ether
 instmods mptctl #LSI firmware management requires this
-instmods mlx4_ib ib_umad #make the mellanox ib available enough to examine /sys
+instmods mlx4_ib mlx5_ib ib_umad #make the mellanox ib available enough to examine /sys
 instmods reiserfs #reiserfs on sysclone
 instmods ibmveth # ppc64 virtual ethernet
 instmods ibmvscsi # ppc64 virtual disk


### PR DESCRIPTION
To include mlx5_ib and mlx5_core driver in genesis_base

Fix issue #4128 

```
[root@frame45cn02v1 ~]# rpm -qpl /root/rpmbuild/RPMS/noarch/xCAT-genesis-base-ppc64-2.13.8-snap201710190425.noarch.rpm | grep mlx5_core
/opt/xcat/share/xcat/netboot/genesis/ppc64/fs/usr/lib/modules/4.11.0-30.el7a.ppc64le/extra/mlnx-ofa_kernel/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko
```