### PR TITLE
enhance confignetwork_secondarynic_nictype_updatenode_false based on …

### DIFF
--- a/xCAT-test/autotest/testcase/confignetwork/cases0
+++ b/xCAT-test/autotest/testcase/confignetwork/cases0
@@ -333,7 +333,7 @@ check:rc==0
 cmd:chdef $$CN nicips.$$SECONDNIC= nictypes.$$SECONDNIC= nicnetworks.$$SECONDNIC=11_1_0_0-255_255_0_0
 check:rc==0
 cmd:updatenode $$CN -P confignetwork
-check:rc==0
+check:rc==1
 #TODO check the error message
 cmd:rmdef -t network -o 11_1_0_0-255_255_0_0
 check:rc==0


### PR DESCRIPTION
For issue #4134 
For PR #4116 

Since adding `parser nics.networks into hash` to pick up nics only configured nics.networks in confignetwork, the error message and return code is changed. so enhance the test case.

UT:
```
RUN:updatenode bybc0609 -P confignetwork [Thu Oct 19 22:18:54 2017]
ElapsedTime:3 sec
RETURN rc = 1
OUTPUT:
bybc0609: xcatdsklspost: downloaded postscripts successfully
bybc0609: Thu Oct 19 22:19:09 EDT 2017 Running postscript: confignetwork
bybc0609: [E]:Error: nicips,nictypes and nicnetworks should be configured in nics table for eth2.
bybc0609: [I]: NetworkManager is inactive.
bybc0609: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bybc0609: configure nic and its device :
bybc0609: [E]:Error: Check the NIC data in the 'nics' table.
bybc0609: postscript: confignetwork exited with code 1
bybc0609: Running of postscripts has completed.
CHECK:rc == 1	[Pass]
``` 