### PR TITLE
Fix issue 4135, the syntax error of openbmc.pm

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1101,7 +1101,7 @@ sub get_functional_software_ids {
     #
     if (${ $response->{data} }{'/xyz/openbmc_project/software/functional'} ) { 
         my %func_data = %{ ${ $response->{data} }{'/xyz/openbmc_project/software/functional'} };
-        foreach my $fw_idx (keys $func_data{endpoints}) {
+        foreach my $fw_idx (keys %{ $func_data{endpoints} }) {
             my $fw_id = (split(/\//, $func_data{endpoints}[$fw_idx]))[-1];
             $functional{$fw_id} = 1;
         }


### PR DESCRIPTION
#4135 

Found on old perl version.

Befor change:
```
c910f04x12v02:~ # perl -c /opt/xcat/lib/perl/xCAT_plugin/openbmc.pm -I /opt/xcat/lib/perl/
Type of arg 1 to keys must be hash (not hash element) at /opt/xcat/lib/perl/xCAT_plugin/openbmc.pm line 1104, near "}) "
/opt/xcat/lib/perl/xCAT_plugin/openbmc.pm had compilation errors
```
After change:
```
# perl -c /opt/xcat/lib/perl/xCAT_plugin/openbmc.pm -I /opt/xcat/lib/perl/
/opt/xcat/lib/perl/xCAT_plugin/openbmc.pm syntax OK
```