### PR TITLE
[OpenBMC] rflash, fix bug where processing functional data is not a HASH

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1149,8 +1149,8 @@ sub get_functional_software_ids {
     #
     if (${ $response->{data} }{'/xyz/openbmc_project/software/functional'} ) { 
         my %func_data = %{ ${ $response->{data} }{'/xyz/openbmc_project/software/functional'} };
-        foreach my $fw_idx (keys %{ $func_data{endpoints} }) {
-            my $fw_id = (split(/\//, $func_data{endpoints}[$fw_idx]))[-1];
+        foreach ( @{$func_data{endpoints}} ) {
+            my $fw_id = (split '/', $_)[-1];
             $functional{$fw_id} = 1;
         }
     }


### PR DESCRIPTION
Fixes #4145 
Looks like I introduced a bug in the processing, but I'm not sure why it didn't appear in my UT but perhaps something in the framework changed.  I'm not sure... 

Using todays dev build that I created at 10am shows the issue: 

```
[root@briggs01 yum.repos.d]# rflash mid05tor12cn16 -l 
Error: openbmc plugin bug, pid 104591, process description: 'xcatd SSL: rflash to mid05tor12cn16 for root@localhost: openbmc instance' with error 'Not a HASH reference at /opt/xcat/lib/perl/xCAT_plugin/openbmc.pm line 1152.
' while trying to fulfill request for the following nodes: mid05tor12cn16
```

with the patch... 

### single node:
```
[root@briggs01 yum.repos.d]# rflash mid05tor12cn16 -l 
mid05tor12cn16: ID       Purpose State      Version
mid05tor12cn16: -------------------------------------------------------
mid05tor12cn16: 5c9938c  Host    Active(*)  IBM-witherspoon-ibm-OP9_v1.19_1.64
mid05tor12cn16: 776f6a74 Host    Active     IBM-witherspoon-ibm-OP9_v1.19_1.52
mid05tor12cn16: 0        BMC     Active     ibm-v1.99.10-0-r11-0-g9c65260
mid05tor12cn16: 12913e05 BMC     Active(*)  ibm-v1.99.10-113-g65edf7d-r1-0-g84427f0
mid05tor12cn16: 

```
### Multiple range:
```
[root@briggs01 yum.repos.d]# rflash p9up -l
mid05tor12cn13: WARNING, The current firmware is unable to detect running firmware version.
mid05tor12cn13: ID       Purpose State      Version
mid05tor12cn13: -------------------------------------------------------
mid05tor12cn13: 9e55358e BMC     Active(*)  ibm-v1.99.10-0-r11-0-g9c65260
mid05tor12cn13: 221d9020 Host    Active(*)  IBM-witherspoon-redbud-ibm-OP9_v1.19_1.33
mid05tor12cn13: 12913e05 BMC     Ready      ibm-v1.99.10-113-g65edf7d-r1-0-g84427f0
mid05tor12cn13: 
mid05tor12cn16: ID       Purpose State      Version
mid05tor12cn16: -------------------------------------------------------
mid05tor12cn16: 5c9938c  Host    Active(*)  IBM-witherspoon-ibm-OP9_v1.19_1.64
mid05tor12cn16: 776f6a74 Host    Active     IBM-witherspoon-ibm-OP9_v1.19_1.52
mid05tor12cn16: 0        BMC     Active     ibm-v1.99.10-0-r11-0-g9c65260
mid05tor12cn16: 12913e05 BMC     Active(*)  ibm-v1.99.10-113-g65edf7d-r1-0-g84427f0
mid05tor12cn16: 
mid05tor12cn02: WARNING, The current firmware is unable to detect running firmware version.
mid05tor12cn02: ID       Purpose State      Version
mid05tor12cn02: -------------------------------------------------------
mid05tor12cn02: 221d9020 Host    Active(*)  IBM-witherspoon-redbud-ibm-OP9_v1.19_1.33
mid05tor12cn02: 0        BMC     Active(*)  ibm-v1.99.10-0-r7-0-gcce0f1b
mid05tor12cn02: 
mid05tor12cn05: WARNING, The current firmware is unable to detect running firmware version.
mid05tor12cn05: ID       Purpose State      Version
mid05tor12cn05: -------------------------------------------------------
mid05tor12cn05: 9e55358e BMC     Active(*)  ibm-v1.99.10-0-r11-0-g9c65260
mid05tor12cn05: 221d9020 Host    Active(*)  IBM-witherspoon-redbud-ibm-OP9_v1.19_1.33
mid05tor12cn05: 0        BMC     Active     ibm-v1.99.10-0-r7-0-gcce0f1b
mid05tor12cn05: 
mid05tor12cn15: WARNING, The current firmware is unable to detect running firmware version.
mid05tor12cn15: ID       Purpose State      Version
mid05tor12cn15: -------------------------------------------------------
mid05tor12cn15: 221d9020 Host    Active(*)  IBM-witherspoon-redbud-ibm-OP9_v1.19_1.33
mid05tor12cn15: 0        BMC     Active(*)  ibm-v1.99.10-0-r7-0-gcce0f1b
mid05tor12cn15: 729a501a Host    Active     IBM-witherspoon-redbud-ibm-OP9_v1.19_1.2
mid05tor12cn15: 
mid05tor12cn18: WARNING, The current firmware is unable to detect running firmware version.
mid05tor12cn18: ID       Purpose State      Version
mid05tor12cn18: -------------------------------------------------------
mid05tor12cn18: 729a501a Host    Active(*)  IBM-witherspoon-redbud-ibm-OP9_v1.19_1.2
mid05tor12cn18: 8de2cc42 BMC     Active     ibm-v1.99.9-0-r4-0-gf0746a0
mid05tor12cn18: 
mid05tor12cn17: WARNING, The current firmware is unable to detect running firmware version.
mid05tor12cn17: ID       Purpose State      Version
mid05tor12cn17: -------------------------------------------------------
mid05tor12cn17: 729a501a Host    Active(*)  IBM-witherspoon-redbud-ibm-OP9_v1.19_1.2
mid05tor12cn17: 8de2cc42 BMC     Active     ibm-v1.99.9-0-r4-0-gf0746a0
mid05tor12cn17: 
mid05tor12cn11: ID       Purpose State      Version
mid05tor12cn11: -------------------------------------------------------
mid05tor12cn11: 9e55358e BMC     Active     ibm-v1.99.10-0-r11-0-g9c65260
mid05tor12cn11: 06edbc22 Host    Failed     IBM-witherspoon-ibm-OP9_v1.19_1.52
mid05tor12cn11: 12913e05 BMC     Active(*)  ibm-v1.99.10-113-g65edf7d-r1-0-g84427f0
mid05tor12cn11: ba02faa9 Host    Active     IBM-witherspoon-ibm-OP9_v1.19_1.64
mid05tor12cn11: 390e9d0f Host    Active(*)  IBM-witherspoon-ibm-OP9_v1.19_1.62
mid05tor12cn11: 
```