### PR TITLE
[OpenBMC] Improve the error for rflash activate/delete to return something more meaningful to the user

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1334,9 +1334,24 @@ sub deal_with_response {
             if ($response->status_line eq $::RESPONSE_SERVER_ERROR) {
                 $error = $response_info->{'data'}->{'exception'};
             } elsif ($response->status_line eq $::RESPONSE_FORBIDDEN) {
-                $error = "$::RESPONSE_FORBIDDEN - This function is not yet available in OpenBMC firmware.";
+                #
+                # For any invalid data that we can detect, provide a better response message
+                #
+                if ($node_info{$node}{cur_status} eq "RFLASH_UPDATE_ACTIVATE_RESPONSE") {
+                    # If 403 is received for an activation, that means the activation ID is incorrect
+                    $error = "Invalid ID provided to activate. Use the -l option to view valid firmware IDs.";
+                } else {
+                    $error = "$::RESPONSE_FORBIDDEN - This function is not yet available in OpenBMC firmware.";
+                }
             } elsif ($response_info->{'data'}->{'description'} =~ /path or object not found: (.+)/) {
-                $error = "path or object not found $1";
+                #
+                # For any invalid data that we can detect, provide a better response message
+                #
+                if ($node_info{$node}{cur_status} eq "RFLASH_DELETE_IMAGE_RESPONSE") { 
+                    $error = "Invalid ID provided to delete.  Use the -l option to view valid firmware IDs.";
+                } else {
+                    $error = "Path or object not found: $1";
+                }
             } else {
                 $error = $response_info->{'data'}->{'description'};
             }

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2312,14 +2312,14 @@ sub rflash_response {
 
         if ($activation_state =~ /Software.Activation.Activations.Failed/) {
             # Activation failed. Report error and exit
-            xCAT::SvrUtils::sendmsg([1,"Activation of firmware failed"], $callback, $node);
+            xCAT::SvrUtils::sendmsg([1,"Firmware activation Failed."], $callback, $node);
             $wait_node_num--;
             return;
         } 
         elsif ($activation_state =~ /Software.Activation.Activations.Active/) { 
             if (scalar($priority_state) == 0) {
                 # Activation state of active and priority of 0 indicates the activation has been completed
-                xCAT::SvrUtils::sendmsg("Firmware update successfully activated", $callback, $node);
+                xCAT::SvrUtils::sendmsg("Firmware activation Successful.", $callback, $node);
                 $wait_node_num--;
                 return;
             }
@@ -2330,7 +2330,7 @@ sub rflash_response {
             }
         }
         elsif ($activation_state =~ /Software.Activation.Activations.Activating/) {
-            xCAT::SvrUtils::sendmsg("Activating firmware update. $progress_state\%", $callback, $node);
+            xCAT::SvrUtils::sendmsg("Activating firmware . . . $progress_state\%", $callback, $node);
             # Activation still going, sleep for a bit, then print the progress value
             # Set next state to come back here to chect the activation status again.
             retry_after($node, "RFLASH_UPDATE_CHECK_STATE_REQUEST", 15);
@@ -2404,7 +2404,7 @@ sub rflash_response {
     }
 
     if ($node_info{$node}{cur_status} eq "RFLASH_DELETE_IMAGE_RESPONSE") {
-            xCAT::SvrUtils::sendmsg("Firmware update successfully removed", $callback, $node);
+            xCAT::SvrUtils::sendmsg("Firmware removed", $callback, $node);
     }
 
     if ($next_status{ $node_info{$node}{cur_status} }) {
@@ -2444,9 +2444,9 @@ sub rflash_upload {
         if ($h->{message} eq $::RESPONSE_OK) {
             # Upload successful, display message
             if ($::UPLOAD_AND_ACTIVATE) {
-                xCAT::SvrUtils::sendmsg("Upload successful. Attempting to activate firmware: $::UPLOAD_FILE_VERSION", $callback, $node);
+                xCAT::SvrUtils::sendmsg("Firmware upload successful. Attempting to activate firmware: $::UPLOAD_FILE_VERSION", $callback, $node);
             } else {
-                xCAT::SvrUtils::sendmsg("Successful, use -l option to list.", $callback, $node);
+                xCAT::SvrUtils::sendmsg("Firmware upload successful. Use -l option to list.", $callback, $node);
             }
             # Try to logoff, no need to check result, as there is nothing else to do if failure
             my $curl_logout_result = `$curl_logout_cmd`;


### PR DESCRIPTION
Resolves #4064 

Here, we are smarter with the return code of 403 and 404 and leverage the REST API endpoint to do error validation for us.  If the user provides an ID that does not exist against the REST API endpoint, then it's an invalid ID.  

Instead of printing the generic framework error messages:
```
Error: 403 Forbidden - This function is not yet available in OpenBMC firmware.
Error: path or object not found /xyz/openbmc_project/software/212a22a
```

We can guide the admin to the correct action: 

```
[root@briggs01 vhu]# rflash mid05tor12cn05 -l 
mid05tor12cn05: WARNING, The current firmware is unable to detect running firmware version.
mid05tor12cn05: ID       Purpose State      Version
mid05tor12cn05: -------------------------------------------------------
mid05tor12cn05: 9e55358e BMC     Active(*)  ibm-v1.99.10-0-r11-0-g9c65260
mid05tor12cn05: 221d9020 Host    Active     IBM-witherspoon-redbud-ibm-OP9_v1.19_1.33
mid05tor12cn05: 776f6a74 Host    Active(*)  IBM-witherspoon-ibm-OP9_v1.19_1.52
mid05tor12cn05: 0        BMC     Active     ibm-v1.99.10-0-r7-0-gcce0f1b
mid05tor12cn05: 
[root@briggs01 vhu]#  rflash mid05tor12cn05 -d 212a22a
mid05tor12cn05: Error: Invalid ID provided to delete.  Use the -l option to view valid firmware IDs.
[root@briggs01 vhu]# rflash mid05tor12cn05 -a 212a22a
mid05tor12cn05: Error: Invalid ID provided to activate. Use the -l option to view valid firmware IDs.
```

And the testing against a range: 
```
[root@briggs01 vhu]# rflash mid05tor12cn[02,05,13,15] -a 212a22a
mid05tor12cn13: Error: Invalid ID provided to activate. Use the -l option to view valid firmware IDs.
mid05tor12cn15: Error: Invalid ID provided to activate. Use the -l option to view valid firmware IDs.
mid05tor12cn02: Error: Invalid ID provided to activate. Use the -l option to view valid firmware IDs.
mid05tor12cn05: Error: Invalid ID provided to activate. Use the -l option to view valid firmware IDs.
[root@briggs01 vhu]# rflash mid05tor12cn[02,05,13,15] -d 212a22a
mid05tor12cn13: Error: Invalid ID provided to delete.  Use the -l option to view valid firmware IDs.
mid05tor12cn15: Error: Invalid ID provided to delete.  Use the -l option to view valid firmware IDs.
mid05tor12cn02: Error: Invalid ID provided to delete.  Use the -l option to view valid firmware IDs.
mid05tor12cn05: Error: Invalid ID provided to delete.  Use the -l option to view valid firmware IDs.
```