### PR TITLE
localdisk feature support sync contents from image  rootfs to localdisk

### DIFF
--- a/xCAT-server/share/xcat/netboot/add-on/statelite/rc.localdisk
+++ b/xCAT-server/share/xcat/netboot/add-on/statelite/rc.localdisk
@@ -346,7 +346,7 @@ while [ ! -s $LITEFILE ]; do
     # the file is empty, we should retry several times
     RETRY=$(( $RETRY+1 ))
     if [ $RETRY -eq $MAX_RETRIES ]; then
-        echo "Error: Cannot get the litefile configuration file from xCAT server." >>$LOG
+        echo "Error: Cannot get the litefile configuration from xCAT server." >>$LOG
         echo "Error to configure localdisk"
         exit 1
     fi
@@ -363,12 +363,27 @@ while [ ! -s $LITEFILE ]; do
 	> $LITEFILE
 done
 
-# If the first time, we need to sync from image to localdisk
-test -f "$MNTDIR$LOCAL/.NOTSYNCTOLOCAL"
-SYNCTOLOCAL=$?
+# If the first time, we need to sync from image to localdisk for stateless
+SYNCTOLOCAL=1
+# Node is statelite if /proc/cmdline have flag `STATEMNT='
+if [ -f "/proc/cmdline" ]; then
+    if grep --quiet --no-messages "STATEMNT=" "/proc/cmdline"; then
+        echo "DEBUG: Ignored syncing to local as this is a statelite installation." >>$LOG
+        SYNCTOLOCAL=0
+    fi
+fi
+# If stateless then check the flag file
+if [ $SYNCTOLOCAL -eq 1 ]; then
+    if [ -f "$MNTDIR$LOCAL/.NOTSYNC2LOCAL" ]; then
+        echo "DEBUG: Ignored syncing to local as flag file exists." >>$LOG
+        SYNCTOLOCAL=0
+    fi
+fi
+echo "DEBUG: SYNCTOLOCAL=$SYNCTOLOCAL" >>$LOG
 
 while read TYPE FPATH
 do
+    needsync=$SYNCTOLOCAL
     if [ x$TYPE = x"localdisk" ]; then
         dir=`echo $FPATH | egrep '\/$'`
         if [ x$dir = x ]; then
@@ -376,28 +391,32 @@ do
             if [ ! -f ${MNTDIR}${FPATH} ]; then
                 touch ${MNTDIR}${FPATH}
                 echo "touch ${MNTDIR}${FPATH}" >>$LOG
+                needsync=0
             fi 
             if [ ! -f ${MNTDIR}${LOCAL}${FPATH} ]; then
                 touch ${MNTDIR}${LOCAL}${FPATH}
                 echo "touch ${MNTDIR}${LOCAL}${FPATH}" >>$LOG
-                if [ $SYNCTOLOCAL -eq 1 ]; then
-                    echo "Sync contents of ${FPATH} to localdisk" >>$LOG
-                    echo "cp -af ${MNTDIR}${FPATH} ${MNTDIR}${LOCAL}${FPATH}" >>$LOG
-                fi
+            fi
+            if [ $needsync -eq 1 ]; then
+                echo "Sync contents of ${FPATH} to localdisk" >>$LOG
+                cp -af "${MNTDIR}${FPATH}" "${MNTDIR}${LOCAL}${FPATH}" >>$LOG 2>&1
             fi
         else
             # it's a dir
             if [ ! -d ${MNTDIR}${FPATH} ]; then
                 mkdir -p ${MNTDIR}${FPATH}
                 echo "mkdir -p ${MNTDIR}${FPATH}" >>$LOG
+                needsync=0
+            elif [ "x`ls -A $DIRECTORY`" = "x" ]; then
+                needsync=0
             fi
             if [ ! -d ${MNTDIR}${LOCAL}${FPATH} ]; then
                 mkdir -p ${MNTDIR}${LOCAL}${FPATH}
                 echo "mkdir -p ${MNTDIR}${LOCAL}${FPATH}" >>$LOG
-                if [ $SYNCTOLOCAL -eq 1 ]; then
-                    echo "Sync contents of ${FPATH} to localdisk" >>$LOG
-                    echo "cp -af ${MNTDIR}${FPATH}/* ${MNTDIR}${LOCAL}${FPATH}" >>$LOG
-                fi
+            fi
+            if [ $needsync -eq 1 ]; then
+                echo "Sync contents of ${FPATH} to localdisk" >>$LOG
+                cp -af "${MNTDIR}${FPATH}*" "${MNTDIR}${LOCAL}${FPATH}" >>$LOG 2>&1
             fi
         fi
 
@@ -408,4 +427,4 @@ do
 done < $LITEFILE
 
 touch "$DONEFLAG"
-touch "$MNTDIR$LOCAL/.NOTSYNCTOLOCAL"
+touch "$MNTDIR$LOCAL/.NOTSYNC2LOCAL"

--- a/xCAT-server/share/xcat/netboot/add-on/statelite/rc.localdisk
+++ b/xCAT-server/share/xcat/netboot/add-on/statelite/rc.localdisk
@@ -346,7 +346,7 @@ while [ ! -s $LITEFILE ]; do
     # the file is empty, we should retry several times
     RETRY=$(( $RETRY+1 ))
     if [ $RETRY -eq $MAX_RETRIES ]; then
-        echo "Error: Cannot get the partition configuration file from xCAT server." >>$LOG
+        echo "Error: Cannot get the litefile configuration file from xCAT server." >>$LOG
         echo "Error to configure localdisk"
         exit 1
     fi
@@ -363,6 +363,10 @@ while [ ! -s $LITEFILE ]; do
 	> $LITEFILE
 done
 
+# If the first time, we need to sync from image to localdisk
+test -f "$MNTDIR$LOCAL/.NOTSYNCTOLOCAL"
+SYNCTOLOCAL=$?
+
 while read TYPE FPATH
 do
     if [ x$TYPE = x"localdisk" ]; then
@@ -376,7 +380,11 @@ do
             if [ ! -f ${MNTDIR}${LOCAL}${FPATH} ]; then
                 touch ${MNTDIR}${LOCAL}${FPATH}
                 echo "touch ${MNTDIR}${LOCAL}${FPATH}" >>$LOG
-            fi 
+                if [ $SYNCTOLOCAL -eq 1 ]; then
+                    echo "Sync contents of ${FPATH} to localdisk" >>$LOG
+                    echo "cp -af ${MNTDIR}${FPATH} ${MNTDIR}${LOCAL}${FPATH}" >>$LOG
+                fi
+            fi
         else
             # it's a dir
             if [ ! -d ${MNTDIR}${FPATH} ]; then
@@ -386,6 +394,10 @@ do
             if [ ! -d ${MNTDIR}${LOCAL}${FPATH} ]; then
                 mkdir -p ${MNTDIR}${LOCAL}${FPATH}
                 echo "mkdir -p ${MNTDIR}${LOCAL}${FPATH}" >>$LOG
+                if [ $SYNCTOLOCAL -eq 1 ]; then
+                    echo "Sync contents of ${FPATH} to localdisk" >>$LOG
+                    echo "cp -af ${MNTDIR}${FPATH}/* ${MNTDIR}${LOCAL}${FPATH}" >>$LOG
+                fi
             fi
         fi
 
@@ -396,3 +408,4 @@ do
 done < $LITEFILE
 
 touch "$DONEFLAG"
+touch "$MNTDIR$LOCAL/.NOTSYNCTOLOCAL"


### PR DESCRIPTION
To fix #3936 
For stateless node to use localdisk, as there might be some services rely on the contents in rootfs.
So it requires to sync the contents to local disk directory initially.

Like xCAT Service Node,  the httpd service depends on /var/log/dhcp/... to start successfully, if use define `/var/log` into `litefile` with `localdisk`,  then `/var/log` will be mounted from local disk without the previous contents.  And it cause the httpd is failed to started.

After this enhancement, the contents in `/var/log/` be synced to local directory at the first time, and httpd could be started successfully.

UT:
1, Define the stateless SN with localdisk.
```
lsdef -t osimage rhels7.4-snap2-ppc64le-netboot-service-mlnx
Object name: rhels7.4-snap2-ppc64le-netboot-service-mlnx
    exlist=/install/custom/netboot/rhels7.4-snap2-ppc64le-install-service-mlnx/service.exlist
    imagetype=linux
    osarch=ppc64le
    osdistroname=rhels7.4-snap2-ppc64le
    osname=Linux
    osvers=rhels7.4-snap2
    otherpkgdir=/install/custom/netboot/rhels7.4-snap2-ppc64le-install-service-mlnx/otherpkgdir
    otherpkglist=/install/custom/netboot/rhels7.4-snap2-ppc64le-install-service-mlnx/otherpkgs.pkglist
    partitionfile=/install/custom/netboot/rhels7.4-snap2-ppc64le-install-service-mlnx/partitionfile
    permission=755
    pkgdir=/install/rhels7.4-snap2/ppc64le
    pkglist=/install/custom/netboot/rhels7.4-snap2-ppc64le-install-service-mlnx/service.pkglist
    postinstall=/install/custom/netboot/rhels7.4-snap2-ppc64le-install-service-mlnx/service.postinstall
    postscripts=servicenode
    profile=service
    provmethod=netboot
    rootimgdir=/install/custom/netboot/rhels7.4-snap2-ppc64le-install-service-mlnx/service

cat /install/custom/netboot/rhels7.4-snap2-ppc64le-install-service-mlnx/partitionfile
enable=yes
enablepart=yes

[disk]
dev=/dev/sda
clear=yes
parts=10,50

[localspace]
dev=/dev/sda2
fstype=ext4

[swapspace]
dev=/dev/sda1

tabdump litefile
#image,file,options,comments,disable
"rhels7.4-snap2-ppc64le-netboot-service-mlnx","/install/","localdisk",,
"rhels7.4-snap2-ppc64le-netboot-service-mlnx","/tftpboot/","localdisk",,
"rhels7.4-snap2-ppc64le-netboot-service-mlnx","/var/log/","localdisk",,
"rhels7.4-snap2-ppc64le-netboot-service-mlnx","/tmp/","localdisk",,
```
genimage/packimage and then `nodeset sn02 osimage=rhels7.4-snap2-ppc64le-netboot-service-mlnx`

2, after provision, check if httpd is running
```
[root@sn02 ~]# systemctl status httpd
● httpd.service - The Apache HTTP Server
   Loaded: loaded (/usr/lib/systemd/system/httpd.service; enabled; vendor preset: disabled)
   Active: active (running) since Tue 2017-10-24 05:30:28 UTC; 2min 7s ago
     Docs: man:httpd(8)
           man:apachectl(8)
 Main PID: 4901 (httpd)
   Status: "Total requests: 0; Current requests/sec: 0; Current traffic:   0 B/sec"
   CGroup: /system.slice/httpd.service
           ├─4901 /usr/sbin/httpd -DFOREGROUND
           ├─4961 /usr/sbin/httpd -DFOREGROUND
           ├─4962 /usr/sbin/httpd -DFOREGROUND
           ├─4963 /usr/sbin/httpd -DFOREGROUND
           ├─4964 /usr/sbin/httpd -DFOREGROUND
           └─4965 /usr/sbin/httpd -DFOREGROUND

Oct 24 05:30:28 sn02.pok.stglabs.ibm.com systemd[1]: Starting The Apache HTTP Server...
Oct 24 05:30:28 sn02.pok.stglabs.ibm.com httpd[4901]: [Tue Oct 24 05:30:28.365858 2017] [so:warn] [pid 4901] AH01574: module rewrite_module is alre...skipping
Oct 24 05:30:28 sn02.pok.stglabs.ibm.com systemd[1]: Started The Apache HTTP Server.
Hint: Some lines were ellipsized, use -l to show in full.
```
3, check if the FLAG file is created
ls /.sllocal/localmnt/.NOTSYNC2LOCAL -al
-rw-r--r-- 1 root root 0 Oct 20 15:07 /.sllocal/localmnt/.NOTSYNC2LOCAL

4, check the localdisk log file
```
DEBUG: SYNCTOLOCAL=1
mkdir -p /sysroot/install/
mkdir -p /sysroot/.sllocal/localmnt/install/
mount --bind /sysroot/.sllocal/localmnt/install/ /sysroot/install/
mkdir -p /sysroot/.sllocal/localmnt/tftpboot/
Sync contents of /tftpboot/ to localdisk
mount --bind /sysroot/.sllocal/localmnt/tftpboot/ /sysroot/tftpboot/
mkdir -p /sysroot/tmp/
mkdir -p /sysroot/.sllocal/localmnt/tmp/
mount --bind /sysroot/.sllocal/localmnt/tmp/ /sysroot/tmp/
mkdir -p /sysroot/.sllocal/localmnt/var/log/
Sync contents of /var/log/ to localdisk
mount --bind /sysroot/.sllocal/localmnt/var/log/ /sysroot/var/log/
```

5, Make some chanage in localdisk, and change the disk to `enablepart=no` and restart the node to see if the content is still there and check the log file.
And check the log, no sync action there.
```
DEBUG: SYNCTOLOCAL=0
mkdir -p /sysroot/install/
mount --bind /sysroot/.sllocal/localmnt/install/ /sysroot/install/
mount --bind /sysroot/.sllocal/localmnt/tftpboot/ /sysroot/tftpboot/
mkdir -p /sysroot/tmp/
mount --bind /sysroot/.sllocal/localmnt/tmp/ /sysroot/tmp/
mount --bind /sysroot/.sllocal/localmnt/var/log/ /sysroot/var/log/
```
UT is Passed.
