### PR TITLE
dodiscovery: get lan channel, dont use `1` (eg. `HP` uses `2`)

### DIFF
--- a/xCAT-genesis-scripts/bin/dodiscovery
+++ b/xCAT-genesis-scripts/bin/dodiscovery
@@ -167,15 +167,16 @@ if [ "$PLATFORM" != "unknown" ]; then
         echo "<platform>$PLATFORM</platform>" >> /tmp/discopacket
 fi
 
-IsStatic=`ipmitool lan print 1 | grep 'IP Address Source' | grep 'Static'`
+LANCHAN=$(ipmitool sol info |awk '/Payload Channel/{print $4}')
+IsStatic=`ipmitool lan print $LANCHAN | grep 'IP Address Source' | grep 'Static'`
 if [ "$IsStatic" ]; then
-    BMCIPADDR=`ipmitool lan print 1 | grep 'IP Address' | grep -v 'IP Address Source' | cut -d ":" -f2 | sed 's/ //'`
+    BMCIPADDR=`ipmitool lan print $LANCHAN | grep 'IP Address' | grep -v 'IP Address Source' | cut -d ":" -f2 | sed 's/ //'`
     if [ "$BMCIPADDR" ]; then
         echo "<bmc>$BMCIPADDR</bmc>" >> /tmp/discopacket
     fi
 fi
 
-BMCMAC=`ipmitool lan print 1 | grep 'MAC Address' | cut -d ":" -f2-7 | sed 's/ //'`
+BMCMAC=`ipmitool lan print $LANCHAN | grep 'MAC Address' | cut -d ":" -f2-7 | sed 's/ //'`
 if [ "$BMCMAC" ]; then
     echo "<bmcmac>$BMCMAC</bmcmac>" >> /tmp/discopacket
 fi


### PR DESCRIPTION
`dodiscovery` hardcodes the lan channel number to `1` while some IPMI implementations use other values for the channel. This MR fixes that bug.

Example of the bug:
```
[xCAT Genesis running on spare-12345678 /]# ipmitool mc info |grep '^Manufacturer ' 
Manufacturer ID           : 11
Manufacturer Name         : Hewlett-Packard
[xCAT Genesis running on spare-12345678 /]# ipmitool lan print 1                            
Invalid channel: 1
[xCAT Genesis running on spare-12345678 /]# ipmitool sol info |awk '/Payload Channel/{print $4}'
2
[xCAT Genesis running on spare-12345678 /]# ipmitool lan print 2 |grep '^IP Address'                                                
IP Address Source       : Static Address
IP Address              : 10.2.0.39
```