### PR TITLE
[OpenBMC] rflash -l, Reset the update_priority on each loop, or it will pick up the priority from the previous

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2292,7 +2292,8 @@ sub rflash_response {
             if (defined($content{Purpose}) and $content{Purpose}) {
                 $update_purpose = (split(/\./, $content{Purpose}))[ -1 ];
             }
-            if (defined($content{Priority}) and $content{Priority})  {
+            # Just check defined because priority=0 is a valid value
+            if (defined($content{Priority}))  {
                 $update_priority = (split(/\./, $content{Priority}))[ -1 ];
             }
             if (exists($functional->{$update_id}) ) {

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2277,13 +2277,22 @@ sub rflash_response {
                 # Entry has no Version attribute, skip listing it
                 next;
             }
+            if ($xcatdebugmode) {
+                # Only print if xcatdebugmode is set and XCATBYPASS
+                print "\n\n================================= XCATBYPASS DEBUG START =================================\n";
+                print "==> KEY_URL=$key_url\n";
+                print "==> VERSION=$content{Version}\n";
+                print "==> Dump out JSON data:\n";
+                print Dumper(%content);
+                print "================================= XCATBYPASS DEBUG END   =================================\n";
+            }
             if (defined($content{Activation}) and $content{Activation}) {
                 $update_activation = (split(/\./, $content{Activation}))[ -1 ];
             }
             if (defined($content{Purpose}) and $content{Purpose}) {
                 $update_purpose = (split(/\./, $content{Purpose}))[ -1 ];
             }
-            if (defined($content{Priority}))  {
+            if (defined($content{Priority}) and $content{Priority})  {
                 $update_priority = (split(/\./, $content{Priority}))[ -1 ];
             }
             if (exists($functional->{$update_id}) ) {
@@ -2299,9 +2308,9 @@ sub rflash_response {
                     $indicator = "(*)";
                 }
                 $update_activation = $update_activation . $indicator;
-                $update_priority = -1; # Reset update priority for next loop iteration
             }
             xCAT::SvrUtils::sendmsg(sprintf("%-8s %-7s %-10s %s", $update_id, $update_purpose, $update_activation, $update_version), $callback, $node);
+            $update_priority = -1; # Reset update priority for next loop iteration
         }
         xCAT::SvrUtils::sendmsg("", $callback, $node); #Separate output in case more than 1 endpoint
     }

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2252,7 +2252,6 @@ sub rflash_response {
     my $update_activation = "Unknown";
     my $update_purpose;
     my $update_version;
-    my $update_priority = -1;
 
     if ($node_info{$node}{cur_status} eq "RFLASH_LIST_RESPONSE") {
         # Get the functional IDs to accurately mark the active running FW
@@ -2292,10 +2291,14 @@ sub rflash_response {
             if (defined($content{Purpose}) and $content{Purpose}) {
                 $update_purpose = (split(/\./, $content{Purpose}))[ -1 ];
             }
-            # Just check defined because priority=0 is a valid value
+
+            my $update_priority = -1;
+            # Just check defined, because priority=0 is a valid value
             if (defined($content{Priority}))  {
                 $update_priority = (split(/\./, $content{Priority}))[ -1 ];
             }
+
+            # Add indicators to the active firmware
             if (exists($functional->{$update_id}) ) {
                 #
                 # If the firmware ID exists in the hash, this indicates the really active running FW
@@ -2311,7 +2314,6 @@ sub rflash_response {
                 $update_activation = $update_activation . $indicator;
             }
             xCAT::SvrUtils::sendmsg(sprintf("%-8s %-7s %-10s %s", $update_id, $update_purpose, $update_activation, $update_version), $callback, $node);
-            $update_priority = -1; # Reset update priority for next loop iteration
         }
         xCAT::SvrUtils::sendmsg("", $callback, $node); #Separate output in case more than 1 endpoint
     }


### PR DESCRIPTION
Resolves #4167
 
I also added some debug that is printed out when `xcatdebugmode=1` AND `XCATBYPASS=1` so that we don't need to make code changes or hit the REST API to see what how xCAT is parsing out the JSON data to help speed up debug.. 

### Without changes 

```
mid05tor12cn11: ID       Purpose State      Version
mid05tor12cn11: -------------------------------------------------------
mid05tor12cn11: 9e55358e BMC     Active     ibm-v1.99.10-0-r11-0-g9c65260
mid05tor12cn11: 06edbc22 Host    Failed     IBM-witherspoon-ibm-OP9_v1.19_1.52
mid05tor12cn11: 12913e05 BMC     Active(*)  ibm-v1.99.10-113-g65edf7d-r1-0-g84427f0
mid05tor12cn11: b48d27e1 BMC     Ready(+)   ibm-v1.99.10-113-g65edf7d-r3-0-g9e4f715.  <-----
mid05tor12cn11: ba02faa9 Host    Active     IBM-witherspoon-ibm-OP9_v1.19_1.64
mid05tor12cn11: 390e9d0f Host    Active(*)  IBM-witherspoon-ibm-OP9_v1.19_1.62
mid05tor12cn11: 
```

## After

### No Debug 

```
[root@briggs01 ~]# rflash $HOST -l 
mid05tor12cn16: ID       Purpose State      Version
mid05tor12cn16: -------------------------------------------------------
mid05tor12cn16: 5c9938c  Host    Active(*)  IBM-witherspoon-ibm-OP9_v1.19_1.64
mid05tor12cn16: 776f6a74 Host    Active     IBM-witherspoon-ibm-OP9_v1.19_1.52
mid05tor12cn16: 12913e05 BMC     Active(*)  ibm-v1.99.10-113-g65edf7d-r1-0-g84427f0
mid05tor12cn16: 0        BMC     Active     ibm-v1.99.10-0-r11-0-g9c65260
mid05tor12cn16: b48d27e1 BMC     Ready      ibm-v1.99.10-113-g65edf7d-r3-0-g9e4f715
mid05tor12cn16: 
```

### `xcatdebugmode=1`

```
[root@briggs01 ~]# rflash $HOST -l 
mid05tor12cn16: [openbmc_debug] curl -k -c cjar -H "Content-Type: application/json" -d '{ "data": ["root", "xxxxxx"] }' https://172.11.139.16/login
mid05tor12cn16: [openbmc_debug] login_response 200 OK
mid05tor12cn16: [openbmc_debug] curl -k -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.16/xyz/openbmc_project/software/enumerate
mid05tor12cn16: [openbmc_debug] rflash_list_response 200 OK
mid05tor12cn16: ID       Purpose State      Version
mid05tor12cn16: -------------------------------------------------------
mid05tor12cn16: 5c9938c  Host    Active(*)  IBM-witherspoon-ibm-OP9_v1.19_1.64
mid05tor12cn16: 776f6a74 Host    Active     IBM-witherspoon-ibm-OP9_v1.19_1.52
mid05tor12cn16: 12913e05 BMC     Active(*)  ibm-v1.99.10-113-g65edf7d-r1-0-g84427f0
mid05tor12cn16: 0        BMC     Active     ibm-v1.99.10-0-r11-0-g9c65260
mid05tor12cn16: b48d27e1 BMC     Ready      ibm-v1.99.10-113-g65edf7d-r3-0-g9e4f715
mid05tor12cn16: 
```

### `xcatdebugmode=1` and XCATBYPASS=1

```
[root@briggs01 ~]# XCATBYPASS=1 rflash $HOST -l 
mid05tor12cn16: [openbmc_debug] curl -k -c cjar -H "Content-Type: application/json" -d '{ "data": ["root", "xxxxxx"] }' https://172.11.139.16/login
mid05tor12cn16: [openbmc_debug] login_response 200 OK
mid05tor12cn16: [openbmc_debug] curl -k -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.16/xyz/openbmc_project/software/enumerate
mid05tor12cn16: [openbmc_debug] rflash_list_response 200 OK
mid05tor12cn16: ID       Purpose State      Version
mid05tor12cn16: -------------------------------------------------------


================================= XCATBYPASS DEBUG START =================================
==> KEY_URL=/xyz/openbmc_project/software/5c9938c
==> VERSION=IBM-witherspoon-ibm-OP9_v1.19_1.64
==> Dump out JSON data 
$VAR1 = 'ExtendedVersion';
$VAR2 = 'op-build-v1.7-1472-g9b410c9,buildroot-2017.08-8-g5e23247,skiboot-v5.9-rc2,hostboot-b01e6bb,linux-4.13.5-openpower1-p25f4095,petitboot-v1.6.0-pc27d9eb,machine-xml-389c56f,occ-ba4e81e,hostboot-binaries-da1227e,capp-ucode-p9-dd2-v2,sbe-374add4';
$VAR3 = 'Purpose';
$VAR4 = 'xyz.openbmc_project.Software.Version.VersionPurpose.Host';
$VAR5 = 'Activation';
$VAR6 = 'xyz.openbmc_project.Software.Activation.Activations.Active';
$VAR7 = 'Version';
$VAR8 = 'IBM-witherspoon-ibm-OP9_v1.19_1.64';
$VAR9 = 'associations';
$VAR10 = [
           [
             'inventory',
             'activation',
             '/xyz/openbmc_project/inventory/system/chassis'
           ]
         ];
$VAR11 = 'Path';
$VAR12 = '';
$VAR13 = 'RequestedActivation';
$VAR14 = 'xyz.openbmc_project.Software.Activation.RequestedActivations.None';
$VAR15 = 'Priority';
$VAR16 = 0;
================================= XCATBYPASS DEBUG END   =================================
mid05tor12cn16: 5c9938c  Host    Active(*)  IBM-witherspoon-ibm-OP9_v1.19_1.64


================================= XCATBYPASS DEBUG START =================================
==> KEY_URL=/xyz/openbmc_project/software/776f6a74
==> VERSION=IBM-witherspoon-ibm-OP9_v1.19_1.52
==> Dump out JSON data 
$VAR1 = 'ExtendedVersion';
$VAR2 = 'op-build-v1.7-1421-g2f4cbfe,buildroot-2017.08-6-g319c6e1,skiboot-v5.8-130-g712837cedca0,hostboot-8e7e2ad,linux-4.13.4-openpower1-p1c668f0,petitboot-v1.6.0-p85a1eab,machine-xml-1bd247d-p7c6c471,occ-60c09cd,hostboot-binaries-b7d8417,capp-ucode-p9-dd2-v1,sbe-ff713df';
$VAR3 = 'Purpose';
$VAR4 = 'xyz.openbmc_project.Software.Version.VersionPurpose.Host';
$VAR5 = 'Activation';
$VAR6 = 'xyz.openbmc_project.Software.Activation.Activations.Active';
$VAR7 = 'associations';
$VAR8 = [
          [
            'inventory',
            'activation',
            '/xyz/openbmc_project/inventory/system/chassis'
          ]
        ];
$VAR9 = 'Version';
$VAR10 = 'IBM-witherspoon-ibm-OP9_v1.19_1.52';
$VAR11 = 'RequestedActivation';
$VAR12 = 'xyz.openbmc_project.Software.Activation.RequestedActivations.None';
$VAR13 = 'Path';
$VAR14 = '';
$VAR15 = 'Priority';
$VAR16 = 1;
================================= XCATBYPASS DEBUG END   =================================
mid05tor12cn16: 776f6a74 Host    Active     IBM-witherspoon-ibm-OP9_v1.19_1.52


================================= XCATBYPASS DEBUG START =================================
==> KEY_URL=/xyz/openbmc_project/software/12913e05
==> VERSION=ibm-v1.99.10-113-g65edf7d-r1-0-g84427f0
==> Dump out JSON data 
$VAR1 = 'Purpose';
$VAR2 = 'xyz.openbmc_project.Software.Version.VersionPurpose.BMC';
$VAR3 = 'Activation';
$VAR4 = 'xyz.openbmc_project.Software.Activation.Activations.Active';
$VAR5 = 'Version';
$VAR6 = 'ibm-v1.99.10-113-g65edf7d-r1-0-g84427f0';
$VAR7 = 'associations';
$VAR8 = [
          [
            'inventory',
            'activation',
            '/xyz/openbmc_project/inventory/system/chassis/motherboard/boxelder/bmc'
          ]
        ];
$VAR9 = 'Path';
$VAR10 = '';
$VAR11 = 'RequestedActivation';
$VAR12 = 'xyz.openbmc_project.Software.Activation.RequestedActivations.None';
$VAR13 = 'Priority';
$VAR14 = 0;
================================= XCATBYPASS DEBUG END   =================================
mid05tor12cn16: 12913e05 BMC     Active(*)  ibm-v1.99.10-113-g65edf7d-r1-0-g84427f0


================================= XCATBYPASS DEBUG START =================================
==> KEY_URL=/xyz/openbmc_project/software/0
==> VERSION=ibm-v1.99.10-0-r11-0-g9c65260
==> Dump out JSON data 
$VAR1 = 'Purpose';
$VAR2 = 'xyz.openbmc_project.Software.Version.VersionPurpose.BMC';
$VAR3 = 'Activation';
$VAR4 = 'xyz.openbmc_project.Software.Activation.Activations.Active';
$VAR5 = 'Version';
$VAR6 = 'ibm-v1.99.10-0-r11-0-g9c65260';
$VAR7 = 'associations';
$VAR8 = [
          [
            'inventory',
            'activation',
            '/xyz/openbmc_project/inventory/system/chassis/motherboard/boxelder/bmc'
          ]
        ];
$VAR9 = 'Path';
$VAR10 = '';
$VAR11 = 'RequestedActivation';
$VAR12 = 'xyz.openbmc_project.Software.Activation.RequestedActivations.None';
$VAR13 = 'Priority';
$VAR14 = 255;
================================= XCATBYPASS DEBUG END   =================================
mid05tor12cn16: 0        BMC     Active     ibm-v1.99.10-0-r11-0-g9c65260


================================= XCATBYPASS DEBUG START =================================
==> KEY_URL=/xyz/openbmc_project/software/b48d27e1
==> VERSION=ibm-v1.99.10-113-g65edf7d-r3-0-g9e4f715
==> Dump out JSON data 
$VAR1 = 'Purpose';
$VAR2 = 'xyz.openbmc_project.Software.Version.VersionPurpose.BMC';
$VAR3 = 'Activation';
$VAR4 = 'xyz.openbmc_project.Software.Activation.Activations.Ready';
$VAR5 = 'Version';
$VAR6 = 'ibm-v1.99.10-113-g65edf7d-r3-0-g9e4f715';
$VAR7 = 'associations';
$VAR8 = [
          [
            'inventory',
            'activation',
            '/xyz/openbmc_project/inventory/system/chassis/motherboard/boxelder/bmc'
          ]
        ];
$VAR9 = 'Path';
$VAR10 = '/tmp/images/b48d27e1';
$VAR11 = 'RequestedActivation';
$VAR12 = 'xyz.openbmc_project.Software.Activation.RequestedActivations.None';
================================= XCATBYPASS DEBUG END   =================================
mid05tor12cn16: b48d27e1 BMC     Ready      ibm-v1.99.10-113-g65edf7d-r3-0-g9e4f715
mid05tor12cn16: 
```

If we think this is too much DEBUG, I can remove the debug changes. 