### PR TITLE
[OpenBMC] Hide the 504 timeout when doing a reboot of BMC since the REST service may be down

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -47,7 +47,6 @@ $::POWER_STATE_POWERING_ON  = "powering-on";
 $::POWER_STATE_QUIESCED     = "quiesced";
 $::POWER_STATE_RESET        = "reset";
 $::POWER_STATE_REBOOT       = "reboot";
-$::POWER_STATE_REBOOT_ERR   = "reboot*";
 $::UPLOAD_FILE              = "";
 $::UPLOAD_FILE_VERSION      = "";
 $::RSETBOOT_URL_PATH        = "boot";
@@ -1372,8 +1371,8 @@ sub deal_with_response {
 
             return;
         } elsif ($response->status_line eq $::RESPONSE_SERVICE_TIMEOUT) {
-            if ($node_info{$node}{cur_status} eq "RPOWER_RESET_RESPONSE") { 
-                my $infomsg = "BMC $::POWER_STATE_REBOOT_ERR";
+            if ($node_info{$node}{cur_status} eq "RPOWER_RESET_RESPONSE" and defined $status_info{RPOWER_RESET_RESPONSE}{argv} and $status_info{RPOWER_RESET_RESPONSE}{argv} =~ /bmcreboot$/) { 
+                my $infomsg = "BMC $::POWER_STATE_REBOOT";
                 xCAT::SvrUtils::sendmsg($infomsg, $callback, $node);
                 $wait_node_num--;
                 return;    


### PR DESCRIPTION
Resolves #4105 and #3832 

Talking to OpenBMC team in https://github.com/openbmc/openbmc/issues/2241 and also in Slack seems like it's not that easy for them to just add a wait for the command to respond before shutting down the BMC, so for this case, I think xCAT would just "hide" it from the user. .

In our testing, this succeeds 100% of the time to reboot the BMC, but, it's a small testing environment. 

Currently it would just put a star next to it....

```
[root@briggs01 p9]# rpower $HOST bmcreboot
mid05tor12cn16: BMC reboot
mid05tor12cn11: BMC reboot*
```

I'm not sure I like this....    But having a message is kind of intrusive... such as...

```
[root@briggs01 p9]# rpower $HOST bmcreboot
mid05tor12cn16: BMC reboot
mid05tor12cn11: BMC reboot [504, command sent to BMC]
```
