### PR TITLE
Sort nodels attribute names

### DIFF
--- a/xCAT-server/lib/xcat/plugins/tabutils.pm
+++ b/xCAT-server/lib/xcat/plugins/tabutils.pm
@@ -2066,7 +2066,7 @@ sub nodels
                     my %satisfiedreqs = ();
                     foreach my $rec (@$recs) {
 
-                        foreach (keys %$rec)
+                        foreach (sort keys %$rec)
                         {
                             if ($_ eq '!!xcatgroupattribution!!') { next; }
                             if ($_ eq $nodekey and $removenodecol) { next; }


### PR DESCRIPTION
The ordering of attribute names out of nodels
is inconsistent.  Use sort to provide consistent
output