### PR TITLE
Stateless service node RTD update

### DIFF
--- a/docs/source/advanced/hierarchy/provision/diskful_sn.rst
+++ b/docs/source/advanced/hierarchy/provision/diskful_sn.rst
@@ -33,22 +33,22 @@ Configure ``otherpkgdir`` and ``otherpkglist`` for service node osimage
 
  * Verify the following entries are included in the package file specified by the ``otherpkglist`` attribute of the service node osimage. ::
 
-    xcat/xcat-dep/<os>/<arch>/xCATsn
+    xcat/xcat-core/xCATsn
     xcat/xcat-dep/<os>/<arch>/conserver-xcat
     xcat/xcat-dep/<os>/<arch>/perl-Net-Telnet
     xcat/xcat-dep/<os>/<arch>/perl-Expect
 
    For example, for the osimage *rhels7-x86_64-install-service* ::
 
-    [root@fs4 ~]# lsdef -t osimage rhels7-x86_64-install-service -i otherpkglist
-       Object name: rhels7-x86_64-install-service
+    lsdef -t osimage rhels7-x86_64-install-service -i otherpkglist
+    Object name: rhels7-x86_64-install-service
          otherpkglist=/opt/xcat/share/xcat/install/rh/service.rhels7.x86_64.otherpkgs.pkglist
-    [root@fs4 ~]# cat /opt/xcat/share/xcat/install/rh/service.rhels7.x86_64.otherpkgs.pkglist
+
+    cat /opt/xcat/share/xcat/install/rh/service.rhels7.x86_64.otherpkgs.pkglist
        xcat/xcat-core/xCATsn
        xcat/xcat-dep/rh7/x86_64/conserver-xcat
        xcat/xcat-dep/rh7/x86_64/perl-Net-Telnet
        xcat/xcat-dep/rh7/x86_64/perl-Expect
-    [root@fs4 ~]#
 
 **Note:** you will be installing the xCAT Service Node rpm xCATsn meta-package on the Service Node, not the xCAT Management Node meta-package. Do not install both.
 

--- a/docs/source/advanced/hierarchy/provision/diskless_sn.rst
+++ b/docs/source/advanced/hierarchy/provision/diskless_sn.rst
@@ -83,12 +83,19 @@ When you run ``copycds``, xCAT will only create a Service Node stateful osimage 
 
   ::
 
-    xcat/xcat-dep/<os>/<arch>/xCATsn
+    xcat/xcat-core/xCATsn
     xcat/xcat-dep/<os>/<arch>/conserver-xcat
     xcat/xcat-dep/<os>/<arch>/perl-Net-Telnet
     xcat/xcat-dep/<os>/<arch>/perl-Expect
 
-  These are required to install the xCAT Service Node function into your image.
+  For example, for the osimage *rhels7.3-ppc64le-netboot-service*: ::
+
+    xcat/xcat-core/xCATsn
+    xcat/xcat-dep/rh7/ppc64le/conserver-xcat
+    xcat/xcat-dep/rh7/ppc64le/perl-Net-Telnet
+    xcat/xcat-dep/rh7/ppc64le/perl-Expect
+
+  **Note:** you will be installing the xCAT Service Node rpm xCATsn meta-package on the Service Node, not the xCAT Management Node meta-package. Do not install both.
 
   2, Create the postinstall script.
 

--- a/docs/source/advanced/hierarchy/provision/diskless_sn.rst
+++ b/docs/source/advanced/hierarchy/provision/diskless_sn.rst
@@ -18,47 +18,57 @@ Build the Service Node Diskless Image
 
 This section assumes you can build the stateless image on the management node because the Service Nodes are the same OS and architecture as the management node. If this is not the case, you need to build the image on a machine that matches the Service Node's OS architecture.
 
-* Create an osimage definition. When you run ``copycds``, xCAT will create a Service Node osimage definitions for that distribution. For a stateless
-  Service Node, use the ``*-netboot-service`` definition.  ::
+* Create an osimage definition. When you run ``copycds``, xCAT will only create a Service Node stateful osimage definitions for that distribution. For a stateless Service Node, you may create it from a stateless Compute Node osimage definition.  ::
 
-    # lsdef -t osimage | grep -i service
-    rhels6.4-ppc64-install-service  (osimage)
-    rhels6.4-ppc64-netboot-service  (osimage)  <================
-    rhels6.4-ppc64-statelite-service  (osimage)
+    lsdef -t osimage | grep -i netboot
+    rhels7.3-ppc64le-netboot-compute  (osimage)
 
-    # lsdef -t osimage -l rhels6.3-ppc64-netboot-service
-    Object name: rhels6.3-ppc64-netboot-service
-        exlist=/opt/xcat/share/xcat/netboot/rh/service.exlist
+    mkdef -t osimage -o rhels7.3-ppc64le-netboot-service \
+               --template rhels7.3-ppc64le-netboot-compute \
+               profile=service provmethod=netboot postscripts=servicenode \
+               exlist=/opt/xcat/share/xcat/netboot/rh/service.rhels7.ppc64le.exlist \
+               otherpkglist=/opt/xcat/share/xcat/netboot/rh/service.rhels7.ppc64le.otherpkgs.pkglist \
+               pkglist=/opt/xcat/share/xcat/netboot/rh/service.rhels7.ppc64le.pkglist \
+               postinstall=/opt/xcat/share/xcat/netboot/rh/service.rhels7.ppc64le.postinstall \
+               rootimgdir=/install/netboot/rhels7.3/ppc64le/service
+
+    lsdef -t osimage -l rhels7.3-ppc64le-netboot-service
+    Object name: rhels7.3-ppc64le-netboot-service
+        exlist=/opt/xcat/share/xcat/netboot/rh/service.rhels7.ppc64le.exlist
         imagetype=linux
-        osarch=ppc64
-        osdistroname=rhels6.3-ppc64
+        osarch=ppc64le
+        osdistroname=rhels7.3-ppc64le
         osname=Linux
-        osvers=rhels6.3
-        otherpkgdir=/install/post/otherpkgs/rhels6.3/ppc64
-        otherpkglist=/opt/xcat/share/xcat/netboot/rh/service.rhels6.ppc64.otherpkgs.pkglist
-        pkgdir=/install/rhels6.3/ppc64
-        pkglist=/opt/xcat/share/xcat/netboot/rh/service.rhels6.ppc64.pkglist
-        postinstall=/opt/xcat/share/xcat/netboot/rh/service.rhels6.ppc64.postinstall
+        osvers=rhels7.3
+        otherpkgdir=/install/post/otherpkgs/rhels7.3/ppc64le
+        otherpkglist=/opt/xcat/share/xcat/netboot/rh/service.rhels7.ppc64le.otherpkgs.pkglist
+        pkgdir=/install/rhels7.3/ppc64le
+        pkglist=/opt/xcat/share/xcat/netboot/rh/service.rhels7.ppc64le.pkglist
+        postinstall=/opt/xcat/share/xcat/netboot/rh/service.rhels7.ppc64le.postinstall
+        postscripts=servicenode
         profile=service
         provmethod=netboot
-        rootimgdir=/install/netboot/rhels6.3/ppc64/service
+        rootimgdir=/install/netboot/rhels7.3/ppc64le/service
 
 * You can check the Service Node packaging to see if it has all the rpms you require. We ship a basic requirements lists that will create a fully functional Service Node. However, you may want to customize your service node by adding additional operating system packages or modifying the files excluded by the exclude list. View the files referenced by the osimage pkglist, otherpkglist and exlist attributes: ::
 
     cd /opt/xcat/share/xcat/netboot/rh/
-    view service.rhels6.ppc64.pkglist
-    view service.rhels6.ppc64.otherpkgs.pkglist
-    view service.exlist
+    view service.rhels7.ppc64le.pkglist
+    view service.rhels7.ppc64le.otherpkgs.pkglist
+    view service.rhels7.ppc64le.exlist
 
   If you would like to change any of these files, copy them to a custom
   directory. This can be any directory you choose, but we recommend that you
   keep it /install somewhere. A good location is something like
-  ``/install/custom/netboot/<os>/service``. Make sure that your
+  ``/install/custom/netboot/<osimage>``. Make sure that your
   ``otherpkgs.pkglist`` file as an entry for
 
   ::
 
     xcat/xcat-core/xCATsn
+    xcat/xcat-dep/rh7/ppc64le/conserver-xcat
+    xcat/xcat-dep/rh7/ppc64le/perl-Net-Telnet
+    xcat/xcat-dep/rh7/ppc64le/perl-Expect
 
   This is required to install the xCAT Service Node function into your image.
 
@@ -68,30 +78,31 @@ This section assumes you can build the stateless image on the management node be
 
   ::
 
-    cp /opt/xcat/share/xcat/netboot/rh/service.rhels6.ppc64.postinstall
-    /install/custom/netboot/rh
-    vi /install/custom/netboot/rh
-    # uncomment the sample fstab lines and change as needed:
-    proc /proc proc rw 0 0
-    sysfs /sys sysfs rw 0 0
-    devpts /dev/pts devpts rw,gid=5,mode=620 0 0
-    service_x86_64 / tmpfs rw 0 1
-    none /tmp tmpfs defaults,size=10m 0 2
-    none /var/tmp tmpfs defaults,size=10m 0 2
+    cp /opt/xcat/share/xcat/netboot/rh/service.rhels7.ppc64le.postinstall \
+    /install/custom/netboot/rhels7.3-ppc64le-netboot-service/my.postinstall
+
+    vi /install/custom/netboot/rhels7.3-ppc64le-netboot-service/my.postinstall
+      # uncomment the sample fstab lines and change as needed:
+      proc /proc proc rw 0 0
+      sysfs /sys sysfs rw 0 0
+      devpts /dev/pts devpts rw,gid=5,mode=620 0 0
+      service_ppc64le / tmpfs rw 0 1
+      none /tmp tmpfs defaults,size=10m 0 2
+      none /var/tmp tmpfs defaults,size=10m 0 2
 
   After modifying the files, you will need to update the osimage definition to
   reference these files. We recommend creating a new osimage definition for
   your custom image: ::
 
-    lsdef -t osimage -l rhels6.3-ppc64-netboot-service -z > /tmp/myservice.def
+    lsdef -t osimage -l rhels7.3-ppc64le-netboot-service -z > /tmp/myservice.def
     vi /tmp/myservice.def
-    # change the name of the osimage definition
-    # change any attributes that now need to reference your custom files
-    # change the rootimgdir attribute replacing 'service'
-    with a name to match your new osimage definition
+      # change the name of the osimage definition
+      # change any attributes that now need to reference your custom files
+      # change the rootimgdir attribute replacing 'service' with a name to match your new osimage definition
+
     cat /tmp/msyservice.def | mkdef -z
 
-  While you are here, if you'd like, you can do the same for your compute node
+  While you are here, if you'd like, you can do the same for your Service Node
   images, creating custom files and new custom osimage definitions as you need
   to.
 
@@ -100,10 +111,10 @@ This section assumes you can build the stateless image on the management node be
 * If you downloaded xCAT to your management node for installation, place a
   copy of your xcat-core and xcat-dep in your otherpkgdir directory ::
 
-    lsdef -t osimage -o rhels6.3-ppc64-netboot-service -i otherpkgdir
-    Object name: rhels6.3-ppc64-netboot-service
-    otherpkgdir=/install/post/otherpkgs/rhels6.3/ppc64
-    cd /install/post/otherpkgs/rhels6.3/ppc64
+    lsdef -t osimage -o rhels7.3-ppc64le-netboot-service -i otherpkgdir
+    Object name: rhels7.3-ppc64le-netboot-service
+        otherpkgdir=/install/post/otherpkgs/rhels7.3/ppc64le
+    cd /install/post/otherpkgs/rhels7.3/ppc64le
     mkdir xcat
     cd xcat
     cp -Rp <current location of xcat-core>/xcat-core
@@ -117,11 +128,11 @@ This section assumes you can build the stateless image on the management node be
 
     ::
 
-      lsdef -t osimage -o rhels6.3-ppc64-netboot-service -i otherpkgdir
-      Object name: rhels6.3-ppc64-netboot-service
-          otherpkgdir=/install/post/otherpkgs/rhels6.3/ppc64
-          
-      cd /install/post/otherpkgs/rhels6.3/ppc64
+      lsdef -t osimage -o rhels7.3-ppc64le-netboot-service -i otherpkgdir
+      Object name: rhels7.3-ppc64le-netboot-service
+          otherpkgdir=/install/post/otherpkgs/rhels7.3/ppc64le
+
+      cd /install/post/otherpkgs/rhels7.3/ppc64le
       mkdir xcat
       cd xcat
       
@@ -135,40 +146,110 @@ This section assumes you can build the stateless image on the management node be
 
   ::
 
-      genimage rhels6.3-ppc64-netboot-service
+      genimage rhels7.3-ppc64le-netboot-service
 
 * Prevent DHCP from starting up until xcatd has had a chance to configure it:
 
   ::
 
-    chroot /install/netboot/rhels6.3/ppc64/service/rootimg chkconfig dhcpd off
-    chroot /install/netboot/rhels6.3/ppc64/service/rootimg chkconfig dhcrelay off
+    chroot /install/netboot/rhels7.3/ppc64le/service/rootimg chkconfig dhcpd off
+    chroot /install/netboot/rhels7.3/ppc64le/service/rootimg chkconfig dhcrelay off
 
 * IF using NFS hybrid mode, export /install read-only in Service Node image:
 
   ::
 
-    cd /install/netboot/rhels6.3/ppc64/service/rootimg/etc
+    cd /install/netboot/rhels7.3/ppc64le/service/rootimg/etc
     echo '/install *(ro,no_root_squash,sync,fsid=13)' >exports
 
 * Pack the image for your osimage definition:
 
   ::
 
-    packimage rhels6.3-ppc64-netboot-service
+    packimage rhels7.3-ppc64le-netboot-service
 
 * Set the node status to ready for netboot using your osimage definition and
   your 'service' nodegroup:
 
   ::
 
-    nodeset service osimage=rhels6.3-ppc64-netboot-service
+    nodeset service osimage=rhels7.3-ppc64le-netboot-service
 
 *  To diskless boot the Service Nodes
 
   ::
 
-    rnetboot service
+    rsetboot service
+
+Monitor install and boot
+------------------------
+
+::
+
+    wcons service # make sure DISPLAY is set to your X server/VNC or
+    rcons <one-node-at-a-time> # or do rcons for each node
+    tail -f /var/log/messages
+
+
+Enable localdisk for stateless Service Node (Optional)
+------------------------------------------------------
+
+If you want, your can leverage local disk to contain some directories during the
+stateless nodes running. For Service Node, it is recommended to put below directories
+on local disk. ::
+
+    #/install         (Not required when using shared /install directory)
+    #/tftpboot        (Not required when using shared /tftpboot directory)
+    /var/log
+    /tmp
+
+The following section explains how to accomplish this.
+
+*  Change the Service Node osimage definition to enable ``localdisk``
+
+::
+
+    #create a partition file to partition and mount the disk
+    export OSIMAGE=rhels7.3-ppc64le-netboot-service
+    cat<<EOF > /install/custom/netboot/$OSIMAGE/partitionfile
+    enable=yes
+    enablepart=yes
+
+    [disk]
+    dev=/dev/sda
+    clear=yes
+    parts=10,50
+
+    [localspace]
+    dev=/dev/sda2
+    fstype=ext4
+
+    [swapspace]
+    dev=/dev/sda1
+    EOF
+
+    #add the partition file to Service Node osimage definition and configure ``policy`` table
+    chdef -t osimage -o $OSIMAGE partitionfile=/install/custom/netboot/$OSIMAGE/partitionfile
+    chtab priority=7.1 policy.commands=getpartition policy.rule=allow
+
+    #define files or directories which are required to be put on local disk
+    #chtab litefile.image=$OSIMAGE litefile.file=/install/ litefile.options=localdisk
+    #chtab litefile.image=$OSIMAGE litefile.file=/tftpboot/ litefile.options=localdisk
+    chtab litefile.image=$OSIMAGE litefile.file=/var/log/ litefile.options=localdisk
+    chtab litefile.image=$OSIMAGE litefile.file=/tmp/ litefile.options=localdisk
+
+* Run image generation and repacking for your osimage definition:
+
+  ::
+
+    genimage rhels7.3-ppc64le-netboot-service
+    packimage rhels7.3-ppc64le-netboot-service
+
+
+Note: ``enablepart=yes`` in partition file will make partition on the locak disk at every boot time. If you want to keep the contents
+on local disk at next boot, remmber changing to ``enablepart=no`` after the first time provisioning.
+
+For more information on ``localdisk`` option, refer to :ref:`setup_localdisk_label`
 
 Update Service Node Stateless Image
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -182,23 +263,14 @@ To update the xCAT software in the image at a later time:
 
   ::
 
-    genimage rhels6.3-ppc64-netboot-service
-    packimage rhels6.3-ppc64-netboot-service
-    nodeset service osimage=rhels6.3-ppc64-netboot-service
-    rnetboot service
+    genimage rhels7.3-ppc64le-netboot-service
+    packimage rhels7.3-ppc64le-netboot-service
+    nodeset service osimage=rhels7.3-ppc64le-netboot-service
+    rsetboot service
 
 Note: The Service Nodes are set up as NFS-root servers for the compute nodes.
 Any time changes are made to any compute image on the mgmt node it will be
 necessary to sync all changes to all Service Nodes. In our case the
 ``/install`` directory is mounted on the servicenodes, so the update to the
 compute node image is automatically available.
-
-Monitor install and boot
-------------------------
-
-::
-
-    wcons service # make sure DISPLAY is set to your X server/VNC or
-    rcons <one-node-at-a-time> # or do rcons for each node
-    tail -f /var/log/messages
 

--- a/docs/source/guides/admin-guides/manage_clusters/common/deployment/enable_localdisk.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/deployment/enable_localdisk.rst
@@ -80,6 +80,6 @@ For the files/directories that you would like xCAT to store on the local disk, a
 
 ``Note``: you do not need to specify the swap space in the litefile table. Just putting it in the partitionfile config file is enough.
 
-Add an entry in policy table to permit the running of the ``getpartitioin`` command from the node ::
+Add an entry in policy table to permit the running of the ``getpartition`` command from the node ::
 
     chtab priority=7.1 policy.commands=getpartition policy.rule=allow

--- a/docs/source/guides/admin-guides/manage_clusters/common/deployment/enable_localdisk.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/deployment/enable_localdisk.rst
@@ -1,3 +1,5 @@
+.. _setup_localdisk_label:
+
 Enabling the localdisk Option
 -----------------------------
 

--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/diskless/customize_image/localdisk.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/diskless/customize_image/localdisk.rst
@@ -1,1 +1,4 @@
 .. include:: ../../../common/deployment/enable_localdisk.rst
+
+``Note``:
+    * To keep the contents on local disk after you using ``enablepart=yes`` to do the disk partitioning, make sure to set ``enablepart=no`` in partition configuration file after the node is booted.

--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/diskless/localdisk.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/diskless/localdisk.rst
@@ -1,6 +1,4 @@
 .. include:: ../../../common/deployment/enable_localdisk.rst
 
 ``Note``:
-    * `localdisk` feature won't syncronize the files/directories defined in `litefile` table from diskless image to local disk at the node boot time. It might casue issue to the application which depends on some of those directories. For example, the ``httpd`` service cannot be started if ``/var/log/`` is defined in `litefile` table. To work around this, you may copy the required contents to local disk and restart service manually at the first time.
-
-    * To keep the contents on local disk after you use ``enablepart=yes`` to do partitioin, make sure to set ``enablepart=no`` in partitioin configuration file after the node is booted.
+    * To keep the contents on local disk after you using ``enablepart=yes`` to do the disk partitioning, make sure to set ``enablepart=no`` in partition configuration file after the node is booted.

--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/diskless/localdisk.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/diskless/localdisk.rst
@@ -1,4 +1,0 @@
-.. include:: ../../../common/deployment/enable_localdisk.rst
-
-``Note``:
-    * To keep the contents on local disk after you using ``enablepart=yes`` to do the disk partitioning, make sure to set ``enablepart=no`` in partition configuration file after the node is booted.

--- a/xCAT-server/lib/xcat/plugins/getpartition.pm
+++ b/xCAT-server/lib/xcat/plugins/getpartition.pm
@@ -3,7 +3,7 @@
 
 =head1
   xCAT plugin package to handle getpartition command
-  Generally, the getpartitioin command is called from the stateless 
+  Generally, the getpartition command is called from the stateless
     node during the booting period to get the partition configureation
     infomation to part the hard disk on the stateless node and to 
     manage the local disk space for statelite and swap space.


### PR DESCRIPTION
For #3955 

1, the previous document is using rhel6.4 ppc64 as example, now replaced with rhel7.3 ppc64le, and update the steps to reflect the new xCAT release.

2,add the `localdisk` option here
  - remove the limitation to sync the directory manually from osimage rootfs
  - using the right file `source/guides/admin-guides/manage_clusters/ppc64le/diskless/customize_image/localdisk.rst`, and remove the old one.
  - Fix a typo `getpartitioin` there

For new generate document, you could access below link:
http://10.3.5.29/install/html/advanced/hierarchy/provision/diskless_sn.html