### PR TITLE
Add getopenbmccons to commands.log 's filter list

### DIFF
--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -3507,6 +3507,7 @@ sub cmdlog_submitlog() {
     $tmpreq =~ s/\[Request\]\s+(.+)/$1/g;
     if ($tmpreq =~ /getipmicons/) { return 1; }
     if ($tmpreq =~ /getcons/)     { return 1; }
+    if ($tmpreq =~ /getopenbmccons/) { return 1; }
 
     if ($cmdlog_alllog !~ /\n$/) {
         $cmdlog_alllog .= "\n";


### PR DESCRIPTION
For issue #4172 
Due to ``getopenbmccons`` will generate amount of useless log in ``commands.log``, to filter its output out.