### PR TITLE
support confignetwork to extend nictypes=unused

### DIFF
--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -341,7 +341,7 @@ function sort_nics_device_order {
                     echo $alonenic
                 fi
             else
-                if [ $ignore_nicips -eq 1 ] && [ -z "$alonenicips" ]; then
+                if [ $ignore_nicips -eq 1 ] && [ -z "$alonenicips" ] || [ -n "$alonenictype" ] && [ $alonenictype = "unused" ]; then
                     echo "nic $alonenic found, but incomplete configuration in node definition."
                 else
                     errorcode=1
@@ -671,7 +671,7 @@ if [ $? -eq 0 ]; then
     errorcode=1
 fi
 
-#when --allownoip is used, print incomplete nics
+#when --allownoip is used or nictypes=unused, print incomplete nics
 nonicips_list=`echo "$sorted_nicdevice_list" | grep "incomplete"`
 if [ $? -eq 0 ]; then
     echo "$nonicips_list"| log_lines info

--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -81,17 +81,12 @@ function get_nic_cfg_file_content {
 boot_install_nic=0
 str_ib_nics=''
 num_iba_ports=
-ignore_nicips=0
 for arg in "$@"
 do
     if [ "$arg" = "-s" ];then
         boot_install_nic=1
     elif [ "${arg:0:10}" = "--ibaports" ];then
         num_iba_ports=${arg#--ibaports=}
-    fi
-    # --allownoip means ignore if nicips are not configured or not
-    if [ "$arg" = "--allownoip" ]; then
-        ignore_nicips=1
     fi
 done
 if [ "$SETINSTALLNIC" = "1" ] || [ "$SETINSTALLNIC" = "yes" ]; then
@@ -341,8 +336,8 @@ function sort_nics_device_order {
                     echo $alonenic
                 fi
             else
-                if [ $ignore_nicips -eq 1 ] && [ -z "$alonenicips" ] || [ -n "$alonenictype" ] && [ $alonenictype = "unused" ]; then
-                    echo "nic $alonenic found, but incomplete configuration in node definition."
+                if [ -n "$alonenictype" ] && [ $alonenictype = "unused" ]; then
+                    echo "nic $alonenic found, but nictypes.$alonenic=unused, ignore configuring $alonenic."
                 else
                     errorcode=1
                     echo "Error: nicips,nictypes and nicnetworks should be configured in nics table for $alonenic."
@@ -671,14 +666,14 @@ if [ $? -eq 0 ]; then
     errorcode=1
 fi
 
-#when --allownoip is used or nictypes=unused, print incomplete nics
-nonicips_list=`echo "$sorted_nicdevice_list" | grep "incomplete"`
+#when nictypes=unused, print unused nics
+nonicips_list=`echo "$sorted_nicdevice_list" | grep "unused"`
 if [ $? -eq 0 ]; then
     echo "$nonicips_list"| log_lines info
 fi
 
 #delete invalid nics device pair based on Error
-valid_sorted_nicdevice_list=`echo "$sorted_nicdevice_list" | sed '/Error/d' | sed '/incomplete configuration/d'`
+valid_sorted_nicdevice_list=`echo "$sorted_nicdevice_list" | sed '/Error/d' | sed '/unused/d'`
 if [ -n "$valid_sorted_nicdevice_list" ]; then 
     log_info "All valid nics and device list:"
     echo "$valid_sorted_nicdevice_list" |log_lines info


### PR DESCRIPTION
enhance for #4116 

extend “nics.nictypes=unused" to cover the requirement of Not-be-Configured

UT:
1, nics table:
```
]# lsdef bybc0607 -i nicips,nicnetworks,nictypes
Object name: bybc0607
    nicips.ib0=10.10.100.9
    nicips.enP48p1s0f0=129.40.234.11
    nicips.ib1=10.11.100.9
    nicnetworks.enP5p1s0f1.4=xcat_bmc
    nicnetworks.enP48p1s0f1=xcat_util
    nicnetworks.ib0=IB00
    nicnetworks.enP48p1s0f0=pub_yellow
    nicnetworks.ib3=IB03
    nicnetworks.ib2=IB02
    nicnetworks.enP5p1s0f1=xcat_compute
    nicnetworks.ib1=IB01
    nicnetworks.enP5p1s0f1.5=xcat_infra
    nicnetworks.enP5p1s0f1.6=xcat_pdu
    nictypes.enP5p1s0f1.4=unused
    nictypes.enP48p1s0f1=unused
    nictypes.ib0=Infiniband
    nictypes.enP48p1s0f0=Ethernet
    nictypes.ib3=unused
    nictypes.enP5p1s0f1=unused
    nictypes.ib1=Infiniband
    nictypes.enP5p1s0f1.5=unused
    nictypes.enP5p1s0f1.6=unused
    nictypes.ib2=unused
```
2, execute "updatenode bybc0607 confignetwork":
```
......
bybc0607: xcatdsklspost: downloaded postscripts successfully
bybc0607: Wed Oct 25 02:55:45 EDT 2017 Running postscript: confignetwork
bybc0607: [I]: nic enP48p1s0f1 found, but incomplete configuration in node definition.
bybc0607: [I]: nic enP5p1s0f1 found, but incomplete configuration in node definition.
bybc0607: [I]: nic enP5p1s0f1.4 found, but incomplete configuration in node definition.
bybc0607: [I]: nic enP5p1s0f1.5 found, but incomplete configuration in node definition.
bybc0607: [I]: nic enP5p1s0f1.6 found, but incomplete configuration in node definition.
bybc0607: [I]: nic ib2 found, but incomplete configuration in node definition.
bybc0607: [I]: nic ib3 found, but incomplete configuration in node definition.
bybc0607: [I]: All valid nics and device list:
bybc0607: [I]: enP48p1s0f0
bybc0607: [I]: ib0,ib1
......
```