### PR TITLE
[OpenBMC] Inform the user of the workaround when running rsetboot with FW < 1738

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1383,8 +1383,12 @@ sub deal_with_response {
                 if ($node_info{$node}{cur_status} eq "RFLASH_UPDATE_ACTIVATE_RESPONSE") {
                     # If 403 is received for an activation, that means the activation ID is incorrect
                     $error = "Invalid ID provided to activate. Use the -l option to view valid firmware IDs.";
+                } elsif ($node_info{$node}{cur_status} eq "RSETBOOT_ENABLE_RESPONSE" ) {
+                    # If 403 is received setting boot method, API endpoint changed in 1738 FW, inform the user of work around.
+                    $error = "Invalid endpoint used to set boot method. If running firmware < ibm-v1.99.10-0-r7, 'export XCAT_OPENBMC_FIRMWARE=1736' and retry.";
+                    
                 } else {
-                    $error = "$::RESPONSE_FORBIDDEN - This function is not yet available in OpenBMC firmware.";
+                    $error = "$::RESPONSE_FORBIDDEN - Requested endpoint does not exists and may indicate function is not yet supported by OpenBMC firmware.";
                 }
             } elsif ($response_info->{'data'}->{'description'} =~ /path or object not found: (.+)/) {
                 #


### PR DESCRIPTION
Very temporary problem, but it's something that lots of users in-house are running into until we get all users of xCAT up to FW 1738 or higher. 

OpenBMC changed the endpoint for the API with 1.99.10-0-r7....

Instead of fielding these issues, add a message to inform the user of the work around for lower level firmware.  

Before: 
```
[root@briggs01 xcat]# XCATBYPASS=1 rsetboot mid05tor12cn18 net
mid05tor12cn18: Error: 403 Forbidden - Requested endpoint does not exists and may indicate function not yet supported by OpenBMC.
```

After: 
```
[root@briggs01 xcat]# rsetboot mid05tor12cn18 net
mid05tor12cn18: Error: Invalid endpoint used to set boot method. If running firmware < ibm-v1.99.10-0-r7, 'export XCAT_OPENBMC_FIRMWARE=1736' and retry.
[root@briggs01 xcat]# export XCAT_OPENBMC_FIRMWARE=1736
[root@briggs01 xcat]# rsetboot mid05tor12cn18 net
mid05tor12cn18: Network
```

