### PR TITLE
add the script to update nvme firmware

### DIFF
--- a/xCAT/postscripts/update_nvme_firmware
+++ b/xCAT/postscripts/update_nvme_firmware
@@ -1,0 +1,81 @@
+#!/bin/sh
+# 
+# If NVMe firmware file is located here: 
+# /install/MN12MN12.img
+#
+# Call the script as follows to update firmware for device /dev/nvme0: 
+#    updatenode <noderange> -P "update_nvme_firmware /install/MN12MN12.img [/dev/nvme0]"
+#
+
+if [[ -z ${1} ]]; then 
+   echo "Error: you must provide the path of the NVMe Firmware file" 
+   exit 1
+fi
+NVME_FILE_PATH=${1}
+if ! which nvme > /dev/null; then 
+    echo "Error: No nvme tool find, pls install nvme-cli first"
+    exit 1
+fi
+if [[ -z ${2} ]]; then
+    if ! ls /dev/nvme* 2>1 >/dev/nul; then 
+        echo "No NVMe device find"; 
+        exit 1
+    else 
+        TARGET_DEV=`ls /dev/nvme*| egrep "nvme[0-9]$"`
+    fi
+else
+    TARGET_DEV=${2}
+    if ! ls $TARGET_DEV 2>1 >/dev/null; then 
+        echo "Not find nvme device $TARGET_DEV"; 
+        exit 1
+    fi
+fi
+
+WORKING_DIR="/"
+NVME_FIRM_FILE=`basename ${NVME_FILE_PATH}`
+TARGET_FIRM_FILE="${WORKING_DIR}/${NVME_FIRM_FILE}"
+
+echo "==> NVMe Firmware File PATH: ${NVME_FILE_PATH}"
+echo "==> NVMe Firmware File: ${NVME_FIRM_FILE}" 
+
+if [[ -e ${TARGET_FIRM_FILE} ]]; then 
+   rm -f ${TARGET_FIRM_FILE}
+fi 
+
+echo "==> Retrieving file from http://${MASTER}/${NVME_FILE_PATH}"
+wget -q http://${MASTER}/${NVME_FILE_PATH} -O ${TARGET_FIRM_FILE}
+if [[ $? ]]; then
+    echo "Error: Download ${NVME_FILE_PATH} failed from ${MASTER}"
+    exit 1
+fi
+
+ls -ltr ${TARGET_FIRM_FILE}
+
+if ! nvme fw-download $TARGET_DEV --fw=${TARGET_FIRM_FILE}; then
+    echo "Firmware download to NVMe device $TARGET_DEV failed"
+    exit 1
+fi
+
+nvme fw-activate $TARGET_DEV -a 1 -s 1
+nvme fw-activate $TARGET_DEV -a 1 -s 2
+nvme fw-activate $TARGET_DEV -a 1 -s 3
+nvme fw-activate $TARGET_DEV -a 1 -s 4
+
+nvme reset $TARGET_DEV
+
+TARGET_VERSION=`nvme id-ctrl $TARGET_DEV | grep "fr " | awk '{ print $3}'`
+
+RC=0
+if [[ x"$NVME_FIRM_FILE" == x"${TARGET_VERSION}.img" ]]; then
+    echo "Update Succeed to $TARGET_VERSION"
+else
+    echo "Update failed, the current version is $TARGET_VERSION"
+    RC=1
+fi
+#
+# Clean up
+#
+sleep 1
+rm -f ${TARGET_FIRM_FILE}
+
+exit $RC

--- a/xCAT/postscripts/update_nvme_firmware
+++ b/xCAT/postscripts/update_nvme_firmware
@@ -6,32 +6,36 @@
 # Call the script as follows to update firmware for device /dev/nvme0: 
 #    updatenode <noderange> -P "update_nvme_firmware /install/MN12MN12.img [/dev/nvme0]"
 #
-
+function usage() {
+    echo "Usage: $0 </path_to/NVME.img> [nvme device]"
+}
 if [[ -z ${1} ]]; then 
    echo "Error: you must provide the path of the NVMe Firmware file" 
+   usage
    exit 1
 fi
 NVME_FILE_PATH=${1}
 if ! which nvme > /dev/null; then 
-    echo "Error: No nvme tool find, pls install nvme-cli first"
+    echo "Error: nvme utility not found, install 'nvme-cli' package and retry"
     exit 1
 fi
 if [[ -z ${2} ]]; then
-    if ! ls /dev/nvme* 2>1 >/dev/nul; then 
-        echo "No NVMe device find"; 
-        exit 1
+    if ! ls /dev/nvme* 2>1 >/dev/null; then 
+        echo "INFO: No NVMe device find, nothing to do"
+        exit 0
     else 
-        TARGET_DEV=`ls /dev/nvme*| egrep "nvme[0-9]$"`
+        TARGET_DEV=`ls /dev/nvme* | egrep "nvme[0-9]*$"`
     fi
 else
     TARGET_DEV=${2}
     if ! ls $TARGET_DEV 2>1 >/dev/null; then 
-        echo "Not find nvme device $TARGET_DEV"; 
+        echo "Error: Could not find NVMe device: $TARGET_DEV"
         exit 1
     fi
 fi
 
-WORKING_DIR="/"
+WORKING_DIR="/tmp/xcat.nvme"
+/usr/bin/mkdir -p ${WORKING_DIR}
 NVME_FIRM_FILE=`basename ${NVME_FILE_PATH}`
 TARGET_FIRM_FILE="${WORKING_DIR}/${NVME_FIRM_FILE}"
 
@@ -44,38 +48,40 @@ fi
 
 echo "==> Retrieving file from http://${MASTER}/${NVME_FILE_PATH}"
 wget -q http://${MASTER}/${NVME_FILE_PATH} -O ${TARGET_FIRM_FILE}
-if [[ $? ]]; then
+if [[ $? -ne 0 ]]; then
     echo "Error: Download ${NVME_FILE_PATH} failed from ${MASTER}"
     exit 1
 fi
 
 ls -ltr ${TARGET_FIRM_FILE}
-
-if ! nvme fw-download $TARGET_DEV --fw=${TARGET_FIRM_FILE}; then
-    echo "Firmware download to NVMe device $TARGET_DEV failed"
-    exit 1
-fi
-
-nvme fw-activate $TARGET_DEV -a 1 -s 1
-nvme fw-activate $TARGET_DEV -a 1 -s 2
-nvme fw-activate $TARGET_DEV -a 1 -s 3
-nvme fw-activate $TARGET_DEV -a 1 -s 4
-
-nvme reset $TARGET_DEV
-
-TARGET_VERSION=`nvme id-ctrl $TARGET_DEV | grep "fr " | awk '{ print $3}'`
-
 RC=0
-if [[ x"$NVME_FIRM_FILE" == x"${TARGET_VERSION}.img" ]]; then
-    echo "Update Succeed to $TARGET_VERSION"
-else
-    echo "Update failed, the current version is $TARGET_VERSION"
-    RC=1
-fi
+for DEV in $TARGET_DEV; do
+    if ! nvme fw-download $DEV --fw=${TARGET_FIRM_FILE} 2>1 >/dev/null ; then
+        echo "${DEV}: Firmware download to device failed"
+        RC=1
+        continue
+    fi
+
+    nvme fw-activate $DEV -a 1 -s 1
+    nvme fw-activate $DEV -a 1 -s 2
+    nvme fw-activate $DEV -a 1 -s 3
+    nvme fw-activate $DEV -a 1 -s 4
+
+    nvme reset $DEV
+
+    TARGET_VERSION=`nvme id-ctrl $DEV | grep "fr " | awk '{ print $3}'`
+
+    if [[ x"$NVME_FIRM_FILE" == x"${TARGET_VERSION}.img" ]]; then
+        echo "${DEV}: Firmware successfully updated to $TARGET_VERSION"
+    else
+        echo "${DEV}: Firmware update failed, current version is ${TARGET_VERSION}"
+        RC=1
+    fi
+done
 #
 # Clean up
 #
-sleep 1
 rm -f ${TARGET_FIRM_FILE}
+/usr/bin/rmdir ${WORKING_DIR}
 
 exit $RC


### PR DESCRIPTION
For task #3974 
The script can be used to update nvme firmware:

```
[root@briggs01 postscripts]# updatenode mid05tor12cn17 -P "update_nvme_firmware /install/MN12MN12.img"
mid05tor12cn17: xcatdsklspost: downloaded postscripts successfully
mid05tor12cn17: Thu Oct 26 08:53:56 UTC 2017 Running postscript: update_nvme_firmware
mid05tor12cn17: ==> NVMe Firmware File PATH: /install/MN12MN12.img
mid05tor12cn17: ==> NVMe Firmware File: MN12MN12.img
mid05tor12cn17: ==> Retrieving file from http://172.12.253.27//install/MN12MN12.img
mid05tor12cn17: -rw-r--r-- 1 root root 3198976 Oct 18 09:18 //MN12MN12.img
mid05tor12cn17: Firmware download success
mid05tor12cn17: Success activating firmware action:1 slot:1
mid05tor12cn17: NVME Admin command error:FIRMWARE_IMAGE(107)
mid05tor12cn17: NVME Admin command error:FIRMWARE_IMAGE(107)
mid05tor12cn17: NVME Admin command error:FIRMWARE_SLOT(106)
mid05tor12cn17: Update Succeed to MN12MN12
mid05tor12cn17: postscript: update_nvme_firmware exited with code 0
mid05tor12cn17: Running of postscripts has completed.
```