### PR TITLE
enhance chdef pre-check attribute

### DIFF
--- a/perl-xCAT/xCAT/DBobjUtils.pm
+++ b/perl-xCAT/xCAT/DBobjUtils.pm
@@ -902,6 +902,19 @@ sub setobjdefs
         }
 
         my @attrprovided = ();
+        #get group objects data
+        my %DBgroupsattr;
+        my %tmpghash;
+        my @tmplgrplist;
+        my %grpvalidattr;
+        if (defined($objhash{$objname}{'groups'})){
+
+            @tmplgrplist = split(",", $objhash{$objname}{'groups'});
+            foreach my $tmpgrp (@tmplgrplist) {
+                $tmpghash{$tmpgrp} = "group";
+            }
+            %DBgroupsattr=xCAT::DBobjUtils->getobjdefs(\%tmpghash);
+        }
 
         # check FINALATTRS to see if all the attrs are valid
         foreach my $attr (keys %{ $objhash{$objname} }) {
@@ -992,7 +1005,6 @@ sub setobjdefs
                                 }
                             }
                         }
-                        xCAT::MsgUtils->message("I", $rsp, $::callback);
                         $checkedattrs{$attr_name} = 1;
                         if ($invalidattr->{$attr_name}->{valid} != 1) {
                             $invalidattr->{$attr_name}->{valid} = 0;
@@ -1147,10 +1159,26 @@ sub setobjdefs
 
         my $rsp;
         foreach my $att (keys %$invalidattr) {
+            my $pickvalidattr=0;
             if ($invalidattr->{$att}->{valid} != 1) {
                 my $tt = $invalidattr->{$att}->{valid};
-                push @{ $rsp->{data} }, "Cannot set the attr=\'$att\' attribute unless $invalidattr->{$att}->{condition}.";
-                xCAT::MsgUtils->message("E", $rsp, $::callback);
+                #if attribute is set invalid, check if its pre-check attribute exists in group objects, pick the attribute into valid. 
+                # ex. if I want to set hdwctrlpoint I will have
+                # to match the right value for mgtmethod, but mgtmethod does exist in node object in chdef command
+                # if mgtmethod exists in group objects, set hdwctrlpoint valid 
+                my $conditionkv=$invalidattr->{$att}->{condition};
+                $conditionkv=~s/(^'|'$)//g;
+                my ($attk, $attv)=split("=", $conditionkv);
+                    foreach my $tmpgrp (@tmplgrplist) {
+                        if ($DBgroupsattr{$tmpgrp}{$attk} eq $attv) {
+                            $pickvalidattr=1;
+                            last;
+                        }
+                    }
+                if ($pickvalidattr != 1) {
+                    push @{ $rsp->{data} }, "Cannot set the attr=\'$att\' attribute unless $invalidattr->{$att}->{condition}.";
+                    xCAT::MsgUtils->message("E", $rsp, $::callback);
+                }
             }
         }
 


### PR DESCRIPTION
for #4039 
Enhance 2 perspective:
1, delete duplicate error message
2, enhance pre-check attribute. for example, "chdef c699c001 bmc=10.3.1.101 groups=all,ws_compute", in the new code, if mgt is in ws_compute group, chdef will not print error message.

UT:
1, mgt is in group:
```
[root@bybc0605 xCAT]# chdef -t group ws_compute mgt=openbmc
1 object definitions have been created or modified.
[root@bybc0605 xCAT]# /opt/xcat/bin/chdef c699c001 bmc=10.3.1.101 groups=all,ws_compute
1 object definitions have been created or modified.
New object definitions 'c699c001' have been created.
```
2, mgt is not in group
```
[root@bybc0605 xCAT]# chdef -t group ws_compute mgt=
1 object definitions have been created or modified.
[root@bybc0605 xCAT]# rmdef c699c001
1 object definitions have been removed.
[root@bybc0605 xCAT]# /opt/xcat/bin/chdef c699c001 bmc=10.3.1.101 groups=all,ws_compute
Error: Cannot set the attr='bmc' attribute unless 'mgt=openbmc'.
1 object definitions have been created or modified.
New object definitions 'c699c001' have been created.
```
3, chdef -z case:
```
[root@bybc0605 xCAT]# rmdef c699c001
1 object definitions have been removed.
[root@bybc0605 xCAT]# chdef -t group ws_compute mgt=openbmc
1 object definitions have been created or modified.
[root@bybc0605 xCAT]# chdef -z <<EOF
c699c001:
    objtype=node
    nodetype=mp
    bmc=10.3.1.101
    groups=all,compute,lsf,rh74_compute,witherspoon,ws_compute,ws_sequoiac699f01
    hostnames=c699f01-U04
    ip=10.3.1.1
    nicips.ib0=10.10.1.1
    nicips.ib1=10.11.1.1
    nicips.ib2=10.12.1.1
    nicips.ib3=10.13.1.1
    rack=c699f01
    switch=c699tor01
    switchport=1
    unit=u04
EOF
1 object definitions have been created or modified.
```
4, mgt is specified in chdef:
```
[root@bybc0605 tools]# rmdef c699c001
[root@bybc0605 tools]# /opt/xcat/bin/chdef c699c001 bmc=10.3.1.101 groups=all mgt=openbmc
1 object definitions have been created or modified.
New object definitions 'c699c001' have been created.
```
5, there is no mgt:
```
[root@bybc0605 tools]# rmdef c699c001
1 object definitions have been removed.
[root@bybc0605 tools]# /opt/xcat/bin/chdef c699c001 bmc=10.3.1.101 groups=all
Error: Cannot set the attr='bmc' attribute unless 'mgt=openbmc'.
1 object definitions have been created or modified.
New object definitions 'c699c001' have been created.
```