### PR TITLE
[OpenBMC] Add timestamp to debug logging messages framework

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -537,13 +537,13 @@ sub process_request {
         } else {
             $login_url = "$http_protocol://$bmcip/login";
             $content = '{ "data": [ "' . $node_info{$node}{username} .'", "' . $node_info{$node}{password} . '" ] }';
-            $handle_id = xCAT::OPENBMC->new($async, $login_url, $content); 
-            $handle_id_node{$handle_id} = $node;
-            $node_info{$node}{cur_status} = $next_status{ $node_info{$node}{cur_status} };
             if ($xcatdebugmode) {
                 my $debug_info = "curl -k -c cjar -H \"Content-Type: application/json\" -d '{ \"data\": [\"$node_info{$node}{username}\", \"xxxxxx\"] }' $login_url";
                 process_debug_info($node, $debug_info);
             }
+            $handle_id = xCAT::OPENBMC->new($async, $login_url, $content); 
+            $handle_id_node{$handle_id} = $node;
+            $node_info{$node}{cur_status} = $next_status{ $node_info{$node}{cur_status} };
         }
     }  
 
@@ -1304,10 +1304,6 @@ sub gen_send_request {
     }
     $request_url = "$http_protocol://" . $node_info{$node}{bmc} . $request_url;
 
-    my $handle_id = xCAT::OPENBMC->send_request($async, $method, $request_url, $content);
-    $handle_id_node{$handle_id} = $node;
-    $node_info{$node}{cur_status} = $next_status{ $node_info{$node}{cur_status} };
-
     if ($xcatdebugmode) {
         my $debug_info;
         if ($method eq "GET") {
@@ -1322,6 +1318,9 @@ sub gen_send_request {
         }
         process_debug_info($node, $debug_info);
     }
+    my $handle_id = xCAT::OPENBMC->send_request($async, $method, $request_url, $content);
+    $handle_id_node{$handle_id} = $node;
+    $node_info{$node}{cur_status} = $next_status{ $node_info{$node}{cur_status} };
 
     return;
 }
@@ -1433,8 +1432,9 @@ sub deal_with_response {
 sub process_debug_info {
     my $node = shift;
     my $debug_msg = shift;
+    my $ts_node = localtime() . " " . $node;
 
-    xCAT::SvrUtils::sendmsg("$flag_debug $debug_msg", $callback, $node);
+    xCAT::SvrUtils::sendmsg("$flag_debug $debug_msg", $callback, $ts_node);
     xCAT::MsgUtils->trace(0, "D", "$flag_debug $node $debug_msg"); 
 }
 


### PR DESCRIPTION
Commit log: 

> Add timestamp into the debug message in order to help trace the time
being spent in certain areas against the BMC.  Re-ordered the debug
logging to print BEFORE we issue the command in order to capture the correct
timestamp

We need this to be able to trace down performance issues when we are running calls against the REST API on the BMC.  

The logs are being pushed into the cluster.log using the `trace` function, but I'm not 100% convinced that this is needed.  debug mode will print to the screen and also to the logs, but we don't have the command that is called, so the debug log in syslog is just [openbmc_debug] messages that have no context.... 

@xuweibj  this message: 
```
1432 sub process_debug_info {
1433     my $node = shift;
1434     my $debug_msg = shift;
1435     my $ts_node = localtime(). " " . $node;
1436 
1437     xCAT::SvrUtils::sendmsg("$flag_debug $debug_msg", $callback, $ts_node);
1438     xCAT::MsgUtils->trace(0, "D", "$flag_debug $node $debug_msg");  <---- should we delete it?
1439 }
1440 
```

With the PR, we can now better understand the time it takes to run against the BMC
```
[root@briggs01 opt]# time rpower mid05tor12cn[02,11] bmcstate
Thu Oct 26 10:49:50 2017 mid05tor12cn11: [openbmc_debug] curl -k -c cjar -H "Content-Type: application/json" -d '{ "data": ["root", "xxxxxx"] }' https://172.11.139.11/login
Thu Oct 26 10:49:50 2017 mid05tor12cn02: [openbmc_debug] curl -k -c cjar -H "Content-Type: application/json" -d '{ "data": ["root", "xxxxxx"] }' https://172.11.139.2/login
Thu Oct 26 10:49:50 2017 mid05tor12cn11: [openbmc_debug] login_response 200 OK
Thu Oct 26 10:49:50 2017 mid05tor12cn11: [openbmc_debug] curl -k -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.11/xyz/openbmc_project/state/enumerate
Thu Oct 26 10:49:50 2017 mid05tor12cn02: [openbmc_debug] login_response 200 OK
Thu Oct 26 10:49:50 2017 mid05tor12cn02: [openbmc_debug] curl -k -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.2/xyz/openbmc_project/state/enumerate
Thu Oct 26 10:49:51 2017 mid05tor12cn11: [openbmc_debug] rpower_status_response 200 OK
mid05tor12cn11: BMC Ready
Thu Oct 26 10:49:51 2017 mid05tor12cn02: [openbmc_debug] rpower_status_response 200 OK
mid05tor12cn02: BMC Ready

real	0m1.040s
user	0m0.088s
sys	0m0.019s
```