### PR TITLE
Add Node name to the /opt/xcat/xcatinfo for diskfull installation

### DIFF
--- a/xCAT/postscripts/xcatinstallpost
+++ b/xCAT/postscripts/xcatinstallpost
@@ -10,6 +10,7 @@ if [ -f /xcatpost/mypostscript.post ]; then
     XCATDEBUGMODE=`grep 'XCATDEBUGMODE=' /xcatpost/mypostscript.post |cut -d= -f2 | tr -d \'\" | tr A-Z a-z `
     MASTER_IP=`grep '^MASTER_IP=' /xcatpost/mypostscript.post |cut -d= -f2|sed s/\'//g`
     OSVER=`grep '^OSVER=' /xcatpost/mypostscript.post |cut -d= -f2|sed s/\'//g`
+    NODE=`grep '^NODE=' /xcatpost/mypostscript.post |cut -d= -f2|sed s/\'//g`
 fi
 
 
@@ -74,6 +75,15 @@ if [ $? -eq 0 ]; then
 else
     echo "REBOOT=TRUE" >> /opt/xcat/xcatinfo
 fi
+
+#add node name to xcatinfo
+grep 'NODE' /opt/xcat/xcatinfo > /dev/null 2>&1 
+if [ $? -eq 0 ]; then
+    sed -i "s/NODE=.*/NODE=$NODE/" /opt/xcat/xcatinfo
+else
+    echo "NODE=$NODE" >> /opt/xcat/xcatinfo
+fi
+
 # Store the SERVICEGROUP into the xcatinfo file for statful installation
 sn_group=`grep '^SERVICEGROUP' /xcatpost/mypostscript |cut -d= -f2 | tr -d \'\"`
 if [ "x" != "x$sn_group" ]; then


### PR DESCRIPTION
for issue #4169 

After diskfull node provision, file /opt/xcat/xcatinfo will contain Node name
```
# cat /opt/xcat/xcatinfo
XCATSERVER=172.12.253.27
INSTALLDIR=/install
REBOOT=TRUE
NODE=mid05tor12cn18
````