### PR TITLE
Fix 3026, ignore the rsetboot for openbmc box in petitboot during the stateful installation

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -390,6 +390,9 @@ my $flag_debug = "[openbmc_debug]";
 #-------------------------------------------------------
 sub preprocess_request {
     my $request = shift;
+    if (defined $request->{_xcat_ignore_flag}->[0] and $request->{_xcat_ignore_flag}->[0] eq 'openbmc') {
+        return [];#workaround the bug 3026, to ignore it for openbmc
+    }
     if (defined $request->{_xcatpreprocessed}->[0] and $request->{_xcatpreprocessed}->[0] == 1) {
         return [$request];
     }

--- a/xCAT-server/lib/xcat/plugins/petitboot.pm
+++ b/xCAT-server/lib/xcat/plugins/petitboot.pm
@@ -561,6 +561,8 @@ sub process_request {
         $sub_req->({ command => ['rsetboot'],
                 node => \@nodes,
                 arg  => ['default'],
+                #workaround the bug 3026, to ignore it for openbmc
+                _xcat_ignore_flag => ['openbmc'],
                 #todo: do not need to pass the XCAT_OPENBMC_DEVEL after the openbmc dev work finish
                 #this does not hurt anything for other plugins
                 environment => {XCAT_OPENBMC_DEVEL=>"YES"}


### PR DESCRIPTION
This is a workaround fix #3026, to bypass the rsetboot running in petitiboot for "nodeset next".
- set a flag in request, and then openbmc plugin will check it and if flag is set then do nothing.

As this is not a best fix, but small codes changes and not introducing extra DB impacts.

UT:
set debug flag in `site` table, and define a openbmc node with `netboot=petitiboot` 
```
nodeset fake1 osimage=rhels7.3-ppc64le-install-compute
nodeset fake1 next
```
And check the cluster.log
```
Oct 27 04:15:28 c910f03c05k29 xcat[21480]: DEBUG xcatd: dispatch request 'rsetboot default' to plugin 'openbmc'
Oct 27 04:15:28 c910f03c05k29 xcat[21480]: DEBUG xcatd: handle request 'rsetboot' by plugin 'openbmc''s preprocess_request
Oct 27 04:15:28 c910f03c05k29 xcat[21480]: xCAT: petitboot netboot: clear node(s): fake1 boot device setting.
Oct 27 04:15:28 c910f03c05k29 xcat[21480]: DEBUG petitboot: starting to handle configuration...
Oct 27 04:15:28 c910f03c05k29 xcat[21480]: DEBUG petitboot: Finish to handle configurations
```
we can see that, only `preprocess_request` is executed.

And change it to `mgt=ipmi`, rerun `nodeset fake1 next`
```
Oct 27 04:15:49 c910f03c05k29 xcat[21539]: DEBUG destiny->process_request: processing is finished for setdestiny
Oct 27 04:15:49 c910f03c05k29 xcat[21539]: DEBUG xcatd: dispatch request 'rsetboot default' to plugin 'ipmi'
Oct 27 04:15:49 c910f03c05k29 xcat[21539]: DEBUG xcatd: handle request 'rsetboot' by plugin 'ipmi''s preprocess_request
Oct 27 04:15:49 c910f03c05k29 xcat[21539]: DEBUG xcatd: handle request 'rsetboot' by plugin 'ipmi''s process_request
Oct 27 04:16:02 c910f03c05k29 xcat[21539]: xCAT: petitboot netboot: clear node(s): fake1 boot device setting.
```
`process_request` is also called.

As the previous `Died` issue is taken place in openbmc's `process_request`, so this will workaround it.