### PR TITLE
fix wrong type for vlan in confignetwork and enhance testcases typo error

### DIFF
--- a/xCAT-test/autotest/testcase/confignetwork/cases0
+++ b/xCAT-test/autotest/testcase/confignetwork/cases0
@@ -490,7 +490,7 @@ cmd:mkdef -t network -o 60_0_0_0-255_0_0_0 net=60.0.0.0 mask=255.0.0.0 mgtifname
 check:rc==0
 cmd:mkdef -t network -o 70_0_0_0-255_0_0_0 net=70.0.0.0 mask=255.0.0.0 mgtifname=$$SECONDNIC
 check:rc==0
-cmd:chdef $$CN nicnetworks.$$SECONDNIC.6="60_0 _0_0-255_0_0_0" nicnetworks.$$SECONDNIC.7="70_0 _0_0-255_0_0_0" nictypes.$$SECONDNIC.6=vlan nictypes.$$SECONDNIC.7=vlan nicips.$$SECONDNIC.6=60.5.106.9 nicips.$$SECONDNIC.7=70.5.106.9 nicdevices.$$SECONDNIC.6=$$SECONDNIC nicdevices.$$SECONDNIC.7=$$SECONDNIC nictypes.$$SECONDNIC=ethernet
+cmd:chdef $$CN nicnetworks.$$SECONDNIC.6="60_0_0_0-255_0_0_0" nicnetworks.$$SECONDNIC.7="70_0_0_0-255_0_0_0" nictypes.$$SECONDNIC.6=vlan nictypes.$$SECONDNIC.7=vlan nicips.$$SECONDNIC.6=60.5.106.9 nicips.$$SECONDNIC.7=70.5.106.9 nicdevices.$$SECONDNIC.6=$$SECONDNIC nicdevices.$$SECONDNIC.7=$$SECONDNIC nictypes.$$SECONDNIC=ethernet
 check:rc==0
 cmd:updatenode $$CN -P confignetwork
 check:rc==0
@@ -541,11 +541,11 @@ cmd:mkdef -t network -o 60_0_0_0-255_0_0_0 net=60.0.0.0 mask=255.0.0.0 mgtifname
 check:rc==0
 cmd:mkdef -t network -o 70_0_0_0-255_0_0_0 net=70.0.0.0 mask=255.0.0.0 mgtifname=$$SECONDNIC mtu=1500
 check:rc==0
-cmd:chdef $$CN nicnetworks.$$SECONDNIC.6="60_0 _0_0-255_0_0_0" nicnetworks.$$SECONDNIC.7="70_0 _0_0-255_0_0_0" nictypes.$$SECONDNIC.6=vlan nictypes.$$SECONDNIC.7=vlan nicips.$$SECONDNIC.6=60.5.106.9 nicips.$$SECONDNIC.7=70.5.106.9 
+cmd:chdef $$CN nicnetworks.$$SECONDNIC.6="60_0_0_0-255_0_0_0" nicnetworks.$$SECONDNIC.7="70_0_0_0-255_0_0_0" nictypes.$$SECONDNIC.6=vlan nictypes.$$SECONDNIC.7=vlan nicips.$$SECONDNIC.6=60.5.106.9 nicips.$$SECONDNIC.7=70.5.106.9 
 check:rc==0
 cmd:updatenode $$CN -P confignetwork
 check:rc!=0
-cmd:chdef $$CN  nicnetworks.$$SECONDNIC.6="60_0 _0_0-255_0_0_0" nicnetworks.$$SECONDNIC.7="70_0 _0_0-255_0_0_0" nictypes.$$SECONDNIC.6=vlan nictypes.$$SECONDNIC.7=vlan nicips.$$SECONDNIC.6=60.5.106.9 nicips.$$SECONDNIC.7=70.5.106.9 nicdevices.$$SECONDNIC.6=$$SECONDNIC.6 nicdevices.$$SECONDNIC.7=$$SECONDNIC.7
+cmd:chdef $$CN  nicnetworks.$$SECONDNIC.6="60_0_0_0-255_0_0_0" nicnetworks.$$SECONDNIC.7="70_0_0_0-255_0_0_0" nictypes.$$SECONDNIC.6=vlan nictypes.$$SECONDNIC.7=vlan nicips.$$SECONDNIC.6=60.5.106.9 nicips.$$SECONDNIC.7=70.5.106.9 nicdevices.$$SECONDNIC.6=$$SECONDNIC.6 nicdevices.$$SECONDNIC.7=$$SECONDNIC.7
 cmd:updatenode $$CN -P confignetwork
 check:rc!=0
 cmd:rmdef -t network -o 11_1_0_0-255_255_0_0

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -803,7 +803,6 @@ function create_raw_vlan_for_br {
     fi
 
     cfg="${cfg}${cfg:+,}USERCTL=no"
-    cfg="${cfg}${cfg:+,}TYPE=Ethernet"
     cfg="${cfg}${cfg:+,}VLAN=yes"
     cfg="${cfg}${cfg:+,}BRIDGE=$_bridge"
     [ -n "$_mtu" ] && \
@@ -1180,7 +1179,6 @@ function create_vlan_interface {
     fi
     
     cfg="${cfg}${cfg:+,}USERCTL=no"
-    cfg="${cfg}${cfg:+,}TYPE=Ethernet"
     cfg="${cfg}${cfg:+,}VLAN=yes"
     [ -n "$_mtu" ] && \
     cfg="${cfg}${cfg:+,}MTU=$_mtu"


### PR DESCRIPTION
For #4205, fix wrong type for vlan
UT: run the following auto test cases and passed.
```
------END::confignetwork_vlan_eth0::Passed::Time:Tue Oct 31 03:13:21 2017 ::Duration::39 sec------
------END::confignetwork_vlan_false::Passed::Time:Tue Oct 31 03:13:47 2017 ::Duration::26 sec------
------END::confignetwork_vlan_bond::Passed::Time:Tue Oct 31 03:14:39 2017 ::Duration::52 sec------
```

For #4208, syntax "./nicutils.sh: line 1189: [: too many arguments" is gone 

```
bybc0609: [I]: create_persistent_ifcfg ifname=eth2.6 xcatnet=60_0_0_0-255_0_0_0 inattrs=ONBOOT=yes,USERCTL=no,VLAN=yes
bybc0609: ['ifcfg-eth2.6']
bybc0609: [I]: >> DEVICE="eth2.6"
bybc0609: [I]: >> BOOTPROTO="static"
bybc0609: [I]: >> IPADDR="60.5.106.9"
bybc0609: [I]: >> NETMASK="255.0.0.0"
bybc0609: [I]: >> NAME="eth2.6"
bybc0609: [I]: >> VLAN="yes"
bybc0609: [I]: >> ONBOOT="yes"
bybc0609: [I]: >> USERCTL="no"
bybc0609: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bybc0609: configure nic and its device : eth2.7 eth2
bybc0609: [I]: create_vlan_interface ifname=eth2 vlanid=7
bybc0609: [I]: Pickup xcatnet, "70_0_0_0-255_0_0_0", from NICNETWORKS for interface "eth2".
bybc0609: [I]: ip link add link eth2 name eth2.7 type vlan id 7
bybc0609: [I]: ip link set eth2.7 up
bybc0609: [I]: create_persistent_ifcfg ifname=eth2.7 xcatnet=70_0_0_0-255_0_0_0 inattrs=ONBOOT=yes,USERCTL=no,VLAN=yes
bybc0609: ['ifcfg-eth2.7']
```