### PR TITLE
enhance setroute error check and return code.

### DIFF
--- a/xCAT/postscripts/setroute
+++ b/xCAT/postscripts/setroute
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh 
 # IBM(c) 2011 EPL license http://www.eclipse.org/legal/epl-v10.html
 
 #-------------------------------------------------------------------------------
@@ -14,10 +14,12 @@
 #-------------------------------------------------------------------------------
 
 if [ -z "$NODEROUTENAMES" ]; then
+    echo "no routenames is configured in node definition."
     exit 0
 fi
 
 OP="replace"
+exit_code=0
 
 if [ -n "$1" ] && [ "$1" = "add" ]; then
     OP="add"
@@ -26,26 +28,46 @@ fi
 for rn in `echo "$NODEROUTENAMES" | tr "," "\n"`
 do
     eval route_string=\$ROUTE_$rn
-    net=`echo $route_string |cut -d',' -f1`
-    mask=`echo $route_string |cut -d',' -f2`
-    gw=`echo $route_string |cut -d',' -f3`
-    ifname=`echo $route_string |cut -d',' -f4`
+    if [ -n "$route_string" ]; then
+        net=`echo $route_string |cut -d',' -f1`
+        mask=`echo $route_string |cut -d',' -f2`
+        gw=`echo $route_string |cut -d',' -f3`
+        ifname=`echo $route_string |cut -d',' -f4`
+  
+        if [ -z "$gw" ]; then
+            echo "Error: gateway is not configured for $rn in xCAT routes table."
+            exit_code=1
+            continue  
+        fi
 
-    # remove the suffix /64 from ipv6 net
-    if echo $net | grep "/" 2>&1 1>/dev/null
-    then
-        net=`echo $net | awk -F'/' '{print $1}'`
+        if [ -z "$ifname" ]; then
+            echo "Error: ifname is not configured for $rn in xCAT routes table."
+            exit_code=1
+            continue
+        fi
+
+        # remove the suffix /64 from ipv6 net
+        if echo $net | grep "/" 2>&1 1>/dev/null
+        then
+            net=`echo $net | awk -F'/' '{print $1}'`
+        fi
+
+        # remove the prefix "/" from ipv6 mask
+        if echo $mask | grep "/" 2>&1 1>/dev/null
+        then
+            mask=`echo $mask | awk -F'/' '{print $2}'`
+        fi
+
+        cmd="routeop $OP $net $mask $gw $ifname"
+        result=`$cmd 2>&1`
+        if [ $? -ne 0 ]; then
+            exit_code=1
+        fi
+        echo $result
+    else
+        echo "Error: $rn is configured incomplete from xCAT routes table."
+        exit_code=1
     fi
-
-    # remove the prefix "/" from ipv6 mask
-    if echo $mask | grep "/" 2>&1 1>/dev/null
-    then
-        mask=`echo $mask | awk -F'/' '{print $2}'`
-    fi
-
-    cmd="routeop $OP $net $mask $gw $ifname"
-    result=`$cmd 2>&1`
-    echo $result
 done
 
-exit 0
+exit $exit_code

--- a/xCAT/postscripts/setroute
+++ b/xCAT/postscripts/setroute
@@ -1,4 +1,4 @@
-#!/bin/sh 
+#!/bin/bash
 # IBM(c) 2011 EPL license http://www.eclipse.org/legal/epl-v10.html
 
 #-------------------------------------------------------------------------------
@@ -14,7 +14,7 @@
 #-------------------------------------------------------------------------------
 
 if [ -z "$NODEROUTENAMES" ]; then
-    echo "no routenames is configured in node definition."
+    echo "No static routes need be configured on this node."
     exit 0
 fi
 
@@ -33,19 +33,11 @@ do
         mask=`echo $route_string |cut -d',' -f2`
         gw=`echo $route_string |cut -d',' -f3`
         ifname=`echo $route_string |cut -d',' -f4`
-  
         if [ -z "$gw" ]; then
-            echo "Error: gateway is not configured for $rn in xCAT routes table."
+            echo "Error: Failed to configure route $rn as gateway is not configured."
             exit_code=1
             continue  
-        fi
-
-        if [ -z "$ifname" ]; then
-            echo "Error: ifname is not configured for $rn in xCAT routes table."
-            exit_code=1
-            continue
-        fi
-
+        fi 
         # remove the suffix /64 from ipv6 net
         if echo $net | grep "/" 2>&1 1>/dev/null
         then


### PR DESCRIPTION
For #4181 

enhance setroute error check and return code, UT is as following:

1, there is no gateway in routes table:
```
tabdump routes
#routename,net,mask,gateway,ifname,comments,disable
"30net","30.0.0.0","255.0.0.0",,"eth1",,
"40net","40.0.0.0","255.0.0.0",,"eth2",,

]# updatenode bybc0609 setroute |tee log
bybc0609: xcatdsklspost: downloaded postscripts successfully
bybc0609: Wed Nov  1 04:24:48 EDT 2017 Running postscript: setroute
bybc0609: Error: gateway is not configured for 30net in xCAT routes table.
bybc0609: Error: gateway is not configured for 40net in xCAT routes table.
bybc0609: postscript: setroute exited with code 1
bybc0609: Running of postscripts has completed.
```

2, there is no ifname for 30net in routes table:
```
]# tabdump routes
#routename,net,mask,gateway,ifname,comments,disable
"30net","30.0.0.0","255.0.0.0","0.0.0.0",,,
"40net","40.0.0.0","255.0.0.0","0.0.0.0","eth2",

]# updatenode bybc0609 setroute 
bybc0609: xcatdsklspost: downloaded postscripts successfully
bybc0609: Wed Nov  1 04:29:29 EDT 2017 Running postscript: setroute
bybc0609: Error: ifname is not configured for 30net in xCAT routes table.
bybc0609: Adding temporary route: ip route replace 40.0.0.0/8 dev eth2; Persistent route "40.0.0.0/8 dev eth2" has been replaced in /etc/sysconfig/network-scripts/route-eth2.
bybc0609: postscript: setroute exited with code 1
bybc0609: Running of postscripts has completed.
```

3, routes table is configured correctly:
```
]# tabdump routes
#routename,net,mask,gateway,ifname,comments,disable
"30net","30.0.0.0","255.0.0.0","0.0.0.0","eth1",,
"40net","40.0.0.0","255.0.0.0","0.0.0.0","eth2",,

]# updatenode bybc0609 setroute 
bybc0609: xcatdsklspost: downloaded postscripts successfully
bybc0609: Wed Nov  1 04:26:39 EDT 2017 Running postscript: setroute
bybc0609: Adding temporary route: ip route replace 30.0.0.0/8 dev eth1; Persistent route "30.0.0.0/8 dev eth1" has been replaced in /etc/sysconfig/network-scripts/route-eth1.
bybc0609: Adding temporary route: ip route replace 40.0.0.0/8 dev eth2; Persistent route "40.0.0.0/8 dev eth2" has been added in /etc/sysconfig/network-scripts/route-eth2.
bybc0609: postscript: setroute exited with code 0
bybc0609: Running of postscripts has completed.
```

4, in routes table, there is no 50net, and there is no net for 40net, and 30net is correctly configured:
```
]# chdef bybc0609 routenames="30net,40net,50net"
]# tabdump routes
#routename,net,mask,gateway,ifname,comments,disable
"30net","30.0.0.0","255.0.0.0","0.0.0.0","eth1",,
"40net",,"255.0.0.0","0.0.0.0","eth2",,

]# updatenode bybc0609 setroute 
bybc0609: xcatdsklspost: downloaded postscripts successfully
bybc0609: Wed Nov  1 04:33:02 EDT 2017 Running postscript: setroute
bybc0609: Adding temporary route: ip route replace 30.0.0.0/8 dev eth1; Persistent route "30.0.0.0/8 dev eth1" has been replaced in /etc/sysconfig/network-scripts/route-eth1.
bybc0609: Error: 40net is configured incomplete from xCAT routes table.
bybc0609: Error: 50net is configured incomplete from xCAT routes table.
bybc0609: postscript: setroute exited with code 1
bybc0609: Running of postscripts has completed.
```

