### PR TITLE
bmcdiscover blathering garbage on non OpenBMC nodes

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -692,8 +692,6 @@ sub scan_process {
                         }
                     }
                 }
-                bmcdiscovery_openbmc(${$live_ip}[$i], $opz, $opw, $request_command) unless ($flag);
-
                 close($parent_fd);
                 exit 0;
             } else {


### PR DESCRIPTION
For issue #4221 .
run bmcdiscover command to one of switches:
````
[root@briggs01 xCAT_plugin]# bmcdiscover --range 172.11.205.12
Warning: HTTP::Response=HASH(0x100067bf5b0)->status_line for 172.11.205.12
````
If ip address is not ipmi or openbmc node, should not fall to openbmc_discovery routine.  