### PR TITLE
Add documentation for xcatsslversion and xcatsslconfig to RTD

### DIFF
--- a/docs/source/advanced/security/index.rst
+++ b/docs/source/advanced/security/index.rst
@@ -6,4 +6,5 @@ The security of a system covers a wide range of elements, from the security of s
 .. toctree::
    :maxdepth: 2
 
-   security
+   ssl_config.rst
+   security.rst

--- a/docs/source/advanced/security/ssl_config.rst
+++ b/docs/source/advanced/security/ssl_config.rst
@@ -1,0 +1,56 @@
+OpenSSL Configuration
+=====================
+
+xCAT does not ship OpenSSL RPMS nor does it statically link to any OpenSSL libraries.  Communication between the xCAT client and daemon utilizes OpenSSL and the administrator can configure SSL_version and SSL_cipher that should be used by xCAT daemons.
+
+The configuration is stored in the xCAT site table using the ``site.xcatsslversion`` and ``site.xcatsslciphers`` variables. 
+
+Configuration
+-------------
+
+By default, xCAT ships with ``TLSv1`` configured.  The current highest SSL version that can be supported is ``TLSv1.2``.
+
+* For rhels7.x and sles12.x and higher: ::
+
+    chtab key=xcatsslversion site.value=TLSv12
+
+* For ubuntu 14.x and higher: :: 
+
+    chtab key=xcatsslversion site.value=TLSv1_2
+
+* For AIX 7.1.3.x: ::
+
+    chtab key=xcatsslversion site.value=TLSv1_2
+
+
+If running > ``TLSv1``, it is possible to disable insecure ciphers.  Here's an example of one possible configuration: ::
+
+    "xcatsslciphers","kDH:kEDH:kRSA:!SSLv3:!SSLv2:!aNULL:!eNULL:!MEDIUM:!LOW:!MD5:!EXPORT:!CAMELLIA:!ECDH",,
+
+After making any changes to these configuration values, ``xcatd`` must be restarted: ::
+
+    service restart xcatd
+
+
+If any mistakes have been made and communiation is lost to xCAT, use ``XCATBYPASS`` to fix/remove the bad configuration: ::
+
+    XCATBYPASS=1 tabedit site
+
+
+Validation
+----------
+
+Use the ``openssl`` command to validate the SSL configuration is valid and expected. 
+
+* To check whether TLSv1 is supported by xcatd: :: 
+
+    openssl s_client -connect 127.0.0.1:3001 -tls1
+
+* To check if SSLv3 is disabled on ``xcatd``: :: 
+
+    openssl s_client -connect localhost:3001 -ssl3
+
+  You should get a reponse similar to: ::
+
+    70367087597568:error:14094410:SSL routines:SSL3_READ_BYTES:sslv3 alert handshake failure:s3_pkt.c:1259:SSL alert number 40
+    70367087597568:error:1409E0E5:SSL routines:SSL3_WRITE_BYTES:ssl handshake failure:s3_pkt.c:598:


### PR DESCRIPTION
Commit Log: 
> Add a section into RTD that explains to the users how to configure
xcatsslversion and xcatsslconfig.  Currently the only documentation
is in the security bulletins

Content was taken from here: https://sourceforge.net/p/xcat/wiki/SSLv3%20POODLE%20Attack%20CVE-2014-3566/

Recently had to help someone configure xCAT to pass a vulnerability scan and didn't like how the documentation to configure and validate was not somewhere inside xCAT RTD.  Adding it. 