### PR TITLE
switch_macmap output showed mac address on the wrong port for cumulus switch

### DIFF
--- a/perl-xCAT/xCAT/MacMap.pm
+++ b/perl-xCAT/xCAT/MacMap.pm
@@ -760,6 +760,7 @@ sub refresh_switch {
                             printf $output "$mymac|%s\n", $self->{switches}->{$switch}->{$myport};
                         }
                     }
+                    $macport="swp".$macport;
                     push @{ $index_to_vlan{$macport} }, $macvlan;
                     push @{ $index_to_mac{$macport} }, $mymac;
                 }
@@ -840,15 +841,15 @@ sub refresh_switch {
             my $port_index = $boid;
             my $port_name  = $namemap->{ $bridgetoifmap->{$port_index} };
             my $mtu  = $iftomtumap->{ $bridgetoifmap->{$port_index} };
-            if (defined($index_to_mac{$port_index})) {
-                push @{ $self->{macinfo}->{$switch}->{$port_name} }, @{ $index_to_mac{$port_index} };
+            if (defined($index_to_mac{$port_name})) {
+                push @{ $self->{macinfo}->{$switch}->{$port_name} }, @{ $index_to_mac{$port_name} };
             }
             else {
                 $self->{macinfo}->{$switch}->{$port_name}->[0] = '';
             }
 
-            if (defined($index_to_vlan{$port_index})) {
-                push @{ $self->{vlaninfo}->{$switch}->{$port_name} }, @{ $index_to_vlan{$port_index} };
+            if (defined($index_to_vlan{$port_name})) {
+                push @{ $self->{vlaninfo}->{$switch}->{$port_name} }, @{ $index_to_vlan{$port_name} };
             }
             else {
                 $self->{vlaninfo}->{$switch}->{$port_name}->[0] = '';


### PR DESCRIPTION
The issue reported from coral research system.

xcatprobe switch_macmap c600tor00 output didn't match the output from bridge fdb show on the switch
````
root@c699tor00:~# bridge fdb show | grep swp36
70:e2:84:14:2d:40 dev swp36 vlan 3 master bridge
a8:2b:b5:41:71:e4 dev swp36 master bridge permanent
root@c699tor00:~# bridge fdb show | grep swp41
a8:2b:b5:41:71:e9 dev swp41 master bridge permanent

[root@c699mgt00 cxhong]# xcatprobe switch_macmap c699tor00 | grep 70:e2:84:14:2d:40
c699tor00  swp41(1500)      70:e2:84:14:2d:40(3)
````

On the c699tor00,  not all the switch port configured
```
auto bridge
 iface bridge
     bridge-ports swp1 swp2 swp3 swp4 swp5 swp6 swp7 swp8 swp9 swp10 swp11 swp12 swp13 swp14 swp15 swp16 swp17 swp18 swp19 swp20 swp21 swp23 swp24 swp25 swp26 swp27 swp29 swp31 swp32 swp33 swp35 swp36 swp37 swp39 swp40 swp41 swp42 swp43 swp44 swp45 swp46 swp47 swp48 swp49 swp50 swp51 swp52
     bridge-vids 2-6
     bridge-vlan-aware yes
````
in this case, swp22, swp28, swp30, swp34 and swp 38 are missing.   That cause index_to_mac hash table and bridgetoifmap hash table mismatched 


