### PR TITLE
enhance chdef for invalid attribute check

### DIFF
--- a/perl-xCAT/xCAT/DBobjUtils.pm
+++ b/perl-xCAT/xCAT/DBobjUtils.pm
@@ -949,6 +949,7 @@ sub setobjdefs
         my @setattrlist = ();
         my %checkedattrs;
         my $invalidattr;
+        my $conditionlist;
 
         foreach my $this_attr (@{ $datatype->{'attrs'} }) {
             my %keyhash;
@@ -1008,7 +1009,12 @@ sub setobjdefs
                         $checkedattrs{$attr_name} = 1;
                         if ($invalidattr->{$attr_name}->{valid} != 1) {
                             $invalidattr->{$attr_name}->{valid} = 0;
-                            $invalidattr->{$attr_name}->{condition} = "\'$check_attr=$check_value\'";
+                            $invalidattr->{$attr_name}->{condition}=$check_attr;
+                            if (defined($conditionlist->{$check_attr})) {
+                                $conditionlist->{$check_attr}=$conditionlist->{$check_attr}.",".$check_value;
+                            } else {
+                                $conditionlist->{$check_attr}=$check_value;
+                            }
                         }
 
                         next;
@@ -1017,8 +1023,12 @@ sub setobjdefs
                     if (!($objhash{$objname}{$check_attr} =~ /\b$check_value\b/) && !($DBattrvals{$objname}{$check_attr} =~ /\b$check_value\b/)) {
                         if ($invalidattr->{$attr_name}->{valid} != 1) {
                             $invalidattr->{$attr_name}->{valid} = 0;
-                            $invalidattr->{$attr_name}->{condition} = "\'$check_attr=$check_value\'";
-
+                            $invalidattr->{$attr_name}->{condition}=$check_attr;
+                            if (defined($conditionlist->{$check_attr})) {
+                                $conditionlist->{$check_attr}=$conditionlist->{$check_attr}.",".$check_value;
+                            } else {
+                                $conditionlist->{$check_attr}=$check_value;
+                            }
                         }
 
                         next;
@@ -1163,20 +1173,19 @@ sub setobjdefs
             if ($invalidattr->{$att}->{valid} != 1) {
                 my $tt = $invalidattr->{$att}->{valid};
                 #if attribute is set invalid, check if its pre-check attribute exists in group objects, pick the attribute into valid. 
-                # ex. if I want to set hdwctrlpoint I will have
-                # to match the right value for mgtmethod, but mgtmethod does exist in node object in chdef command
-                # if mgtmethod exists in group objects, set hdwctrlpoint valid 
-                my $conditionkv=$invalidattr->{$att}->{condition};
-                $conditionkv=~s/(^'|'$)//g;
-                my ($attk, $attv)=split("=", $conditionkv);
-                    foreach my $tmpgrp (@tmplgrplist) {
-                        if ($DBgroupsattr{$tmpgrp}{$attk} eq $attv) {
-                            $pickvalidattr=1;
-                            last;
-                        }
+                # ex. like if I want to set hdwctrlpoint I will have
+                # to match the right value for mgtmethod 
+                # if mgtmethod exists in group objects and its value match the one of only_if value, set hdwctrlpoint valid 
+                my $conditionkey=$invalidattr->{$att}->{condition};
+                foreach my $tmpgrp (@tmplgrplist) {
+                    if (($DBgroupsattr{$tmpgrp}{$conditionkey}) && ($conditionlist->{$conditionkey} =~ $DBgroupsattr{$tmpgrp}{$conditionkey})) {
+                        $pickvalidattr=1;
+                        last;
                     }
+                }
                 if ($pickvalidattr != 1) {
-                    push @{ $rsp->{data} }, "Cannot set the attr=\'$att\' attribute unless $invalidattr->{$att}->{condition}.";
+                    $conditionlist->{$conditionkey}=~s/,/ or /g;
+                    push @{ $rsp->{data} }, "Cannot set the attr=\'$att\' attribute unless $invalidattr->{$att}->{condition} value is $conditionlist->{$conditionkey}.";
                     xCAT::MsgUtils->message("E", $rsp, $::callback);
                 }
             }


### PR DESCRIPTION
For #4200 

If node attribute have different only_if in different table, in old code, it only picks up the last only_if value, this causes chdef always give the last only_if value as recommended value. In the fix, will give all possible only_if values as recommended value.

Part of UT results:
```
]# chdef abc bmc=1.1.1.1 groups=all
Error: Cannot set the attr='bmc' attribute unless mgt value is ipmi or openbmc.
1 object definitions have been created or modified.
New object definitions 'abc' have been created.
]# rmdef abc

]# chdef abc bmc=1.1.1.1 groups=all mgt=ipmi
1 object definitions have been created or modified.
New object definitions 'abc' have been created.
]# rmdef abc
1 object definitions have been removed.

]# chdef abc bmc=1.1.1.1 groups=all mgt=abc
Error: Cannot set the attr='bmc' attribute unless mgt value is ipmi or openbmc.
1 object definitions have been created or modified.
New object definitions 'abc' have been created.
]# rmdef abc
1 object definitions have been removed.

]# chdef -t group hw mgt=ipmi
1 object definitions have been created or modified.
New object definitions 'hw' have been created.
]# chdef abc bmc=1.1.1.1 groups=hw
1 object definitions have been created or modified.
New object definitions 'abc' have been created.
]# rmdef abc
1 object definitions have been removed.

]# chdef -t group hw mgt=abc
1 object definitions have been created or modified.
]# chdef abc bmc=1.1.1.1 groups=hw
Error: Cannot set the attr='bmc' attribute unless mgt value is ipmi or openbmc.
1 object definitions have been created or modified.
New object definitions 'abc' have been created.
]# lsdef abc
Object name: abc
    groups=hw
    mgt=abc
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
```