### PR TITLE
Remove the "access on" for OpenBMC and use raw command instead

### DIFF
--- a/xCAT-genesis-scripts/bin/bmcsetup
+++ b/xCAT-genesis-scripts/bin/bmcsetup
@@ -396,7 +396,11 @@ fi
 # update the node status to 'bmcready' for openbmc, no more configuration is needed.
 if [ ! -z "$ISOPENBMC" ]; then
     # To enable network configuration for openbmc
-    ipmitool -d 0 lan set $LANCHAN access on
+    # 
+    # For OpenBMC, FW team still suggest running the raw command instead of access on, use raw for now
+    #
+    # ipmitool -d 0 lan set $LANCHAN access on
+    ipmitool -d 0 raw 0x06 0x40 $LANCHAN 0x42 0x44
     # update the node status to 'bmcready'
     if [ ! -z "$XCATMASTER" ]; then
         # Wait for some time for the new network setting is ready 


### PR DESCRIPTION
Resolves #4242 

Flip flopping this back to using the raw command since some issues have arisen and seems like even though the command does take effect one some cases, not all of them work without issues. 

There still is an error message that comes out from issuing the raw command: 
```
Unable to send RAW command (channel=0x0 netfn=0x6 lun=0x0 cmd=0x40 rsp=0xce): Command response could not be provided
```

But the changes do take effect... 