### PR TITLE
Add more details for the rflash documentaion for OpenBMC

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rflash.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rflash.1.rst
@@ -135,15 +135,47 @@ OpenPOWER specific (using IPMI):
 ================================
 
 
-The command will update firmware for OpenPOWER BMC when given an OpenPOWER node and either the hpm formatted file path or path to a data directory.
+The command will update firmware for OpenPOWER BMC when given an OpenPOWER node with \ *mgt=ipmi*\  and either the hpm formatted file path or path to a data directory.
+
 \ **Note:**\  When using \ **rflash**\  in hierarchical environment, the hpm file or data directory must be accessible from Service Nodes.
 
 
-OpenPOWER OpenBMC specific:
-===========================
+OpenPOWER specific (using OpenBMC):
+===================================
 
 
-The command will update firmware for OpenPOWER OpenBMC when given an OpenPOWER node and either an update .tar file or an uploaded image id.
+The command will update firmware for OpenPOWER BMC when given an OpenPOWER node with \ *mgt=openbmc*\  and either an update .tar file or an uploaded image id.
+
+\ **-l|-**\ **-list**\ :
+
+
+.. code-block:: perl
+
+    The list option will list out available firmware on the BMC.  It provides an interface to display the ID of the various firmware levels.  
+ 
+    The (*) symbol indicates the active running firmware on the server.  
+ 
+    The (+) symbol indicates the firmware that is pending and a reboot is required to set it to be the active running firmware level.
+
+
+\ **-u|-**\ **-upload**\ :
+
+
+.. code-block:: perl
+
+    The upload option expects a .tar file as the input and will upload the file to the BMC.  Use the list option to view the result.
+
+
+\ **-a|-**\ **-activate**\ :
+
+
+.. code-block:: perl
+
+    The activate option expects either a .tar file or an ID as the input.  If a .tar file is provided, it will upload and activate the firmware in a single step
+
+
+To apply the firmware level, a reboot is required to BMC and HOST.
+
 \ **Note:**\  When using \ **rflash**\  in hierarchical environment, the .tar file must be accessible from Service Nodes.
 
 

--- a/xCAT-client/pods/man1/rflash.1.pod
+++ b/xCAT-client/pods/man1/rflash.1.pod
@@ -91,12 +91,32 @@ The command will update firmware for NeXtScale FPC when given an FPC node and th
 
 =head2 OpenPOWER specific (using IPMI):
 
-The command will update firmware for OpenPOWER BMC when given an OpenPOWER node and either the hpm formatted file path or path to a data directory.
+The command will update firmware for OpenPOWER BMC when given an OpenPOWER node with I<mgt=ipmi> and either the hpm formatted file path or path to a data directory.
+
 B<Note:> When using B<rflash> in hierarchical environment, the hpm file or data directory must be accessible from Service Nodes.
 
-=head2 OpenPOWER OpenBMC specific:
+=head2 OpenPOWER specific (using OpenBMC):
 
-The command will update firmware for OpenPOWER OpenBMC when given an OpenPOWER node and either an update .tar file or an uploaded image id.
+The command will update firmware for OpenPOWER BMC when given an OpenPOWER node with I<mgt=openbmc> and either an update .tar file or an uploaded image id.
+
+B<-l|--list>:
+
+   The list option will list out available firmware on the BMC.  It provides an interface to display the ID of the various firmware levels.  
+
+   The (*) symbol indicates the active running firmware on the server.  
+
+   The (+) symbol indicates the firmware that is pending and a reboot is required to set it to be the active running firmware level. 
+
+B<-u|--upload>:
+
+   The upload option expects a .tar file as the input and will upload the file to the BMC.  Use the list option to view the result. 
+
+B<-a|--activate>: 
+
+   The activate option expects either a .tar file or an ID as the input.  If a .tar file is provided, it will upload and activate the firmware in a single step 
+
+To apply the firmware level, a reboot is required to BMC and HOST. 
+
 B<Note:> When using B<rflash> in hierarchical environment, the .tar file must be accessible from Service Nodes.
 
 =head1 B<Options>


### PR DESCRIPTION
Resolves #4218 

>Add better documentation to describe the process of flashing firmware  for OpenBMC managed servers and what symbols mean when listing out the firmware

The flashing of firmware for OpenBMC is more complicated than the other IPMI based servers because OpenBMC gives the flexibility for loading various images onto the BMC and flipping the activation on one or another PNOR or BMC. 

The initial support for rflash is to push the action of flashing firmware to the admin, although I do have an issue open #4245  that adds function to run flash unattended. 

Rendered page is here: http://c910loginx03.pok.stglabs.ibm.com/~vhu/rflash/guides/admin-guides/references/man1/rflash.1.html