### PR TITLE
modify retry time for rpower reset

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -59,6 +59,9 @@ $::UPLOAD_WAIT_ATTEMPT      = 6;
 $::UPLOAD_WAIT_INTERVAL     = 10;
 $::UPLOAD_WAIT_TOTALTIME    = int($::UPLOAD_WAIT_ATTEMPT*$::UPLOAD_WAIT_INTERVAL);
 
+$::RPOWER_CHECK_INTERVAL = 2;
+$::RPOWER_MAX_RETRY = 30;
+
 sub unsupported {
     my $callback = shift;
     if (defined($::OPENBMC_DEVEL) && ($::OPENBMC_DEVEL eq "YES")) {
@@ -1332,7 +1335,7 @@ sub parse_node_info {
             }
 
             $node_info{$node}{cur_status} = "LOGIN_REQUEST";
-            $node_info{$node}{retry_times} = 0;
+            $node_info{$node}{rpower_check_times} = $::RPOWER_MAX_RETRY;
         } else {
             xCAT::SvrUtils::sendmsg("Error: Unable to get information from openbmc table", $callback, $node);
             $rst = 1;
@@ -1562,7 +1565,7 @@ sub login_logout_request {
         }
         return 1;
     } else {
-        my $curl_logout_result = `$curl_logout_cmd`;
+        my $curl_logout_result = `$curl_logout_cmd -s`;
     }
 
     return 0;
@@ -1610,7 +1613,6 @@ sub rpower_response {
     my $node = shift;
     my $response = shift;
     my %new_status = ();
-    my $max_retry_times = 5;
 
     my $response_info = decode_json $response->content;
 
@@ -1730,10 +1732,12 @@ sub rpower_response {
             if ($all_status eq "$::POWER_STATE_OFF") {
                 $node_info{$node}{cur_status} = $next_status{ $node_info{$node}{cur_status} }{OFF};
             } else {
-                $node_info{$node}{cur_status} = $next_status{ $node_info{$node}{cur_status} }{ON};
-                $node_info{$node}{retry_times}++;
-                if ($node_info{$node}{retry_times} >= $max_retry_times) {
-                    xCAT::SvrUtils::sendmsg("Internal Error, failed to rpower off, please try again", $callback, $node);
+                if ($node_info{$node}{rpower_check_times} > 0) {
+                    $node_info{$node}{rpower_check_times}--;
+                    retry_after($node, $next_status{ $node_info{$node}{cur_status} }{ON}, $::RPOWER_CHECK_INTERVAL);
+                    return;
+                } else {
+                    xCAT::SvrUtils::sendmsg([1, "Have run rpower off successfully, please run 'rpower $node on' after it's off"], $callback, $node);
                     $node_info{$node}{cur_status} = "";
                     $wait_node_num--;
                     return;

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1734,10 +1734,16 @@ sub rpower_response {
             } else {
                 if ($node_info{$node}{rpower_check_times} > 0) {
                     $node_info{$node}{rpower_check_times}--;
+                    if ($node_info{$node}{wait_start}) {
+                        $node_info{$node}{wait_end} = time();
+                    } else {
+                        $node_info{$node}{wait_start} = time();
+                    }
                     retry_after($node, $next_status{ $node_info{$node}{cur_status} }{ON}, $::RPOWER_CHECK_INTERVAL);
                     return;
                 } else {
-                    xCAT::SvrUtils::sendmsg([1, "Have run rpower off successfully, please run 'rpower $node on' after it's off"], $callback, $node);
+                    my $wait_time_X = $node_info{$node}{wait_end} - $node_info{$node}{wait_start};
+                    xCAT::SvrUtils::sendmsg([1, "Error: Sent power-off command but state did not change to $::POWER_STATE_OFF after waiting $wait_time_X seconds. (State=$all_status)."], $callback, $node);
                     $node_info{$node}{cur_status} = "";
                     $wait_node_num--;
                     return;


### PR DESCRIPTION
#3966 

After run rpower off against node, will check whether it's off.
Interval: 2s
Max retry times: 30

```
[root@briggs01 ~]# rpower mid05tor12cn05 reset
Tue Nov  7 00:57:36 2017 mid05tor12cn05: [openbmc_debug] curl -k -c cjar -H "Content-Type: application/json" -d '{ "data": ["root", "xxxxxx"] }' https://172.11.139.5/login
Tue Nov  7 00:57:36 2017 mid05tor12cn05: [openbmc_debug] login_response 200 OK
Tue Nov  7 00:57:36 2017 mid05tor12cn05: [openbmc_debug] curl -k -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.5/xyz/openbmc_project/state/enumerate
Tue Nov  7 00:57:37 2017 mid05tor12cn05: [openbmc_debug] rpower_status_response 200 OK
Tue Nov  7 00:57:37 2017 mid05tor12cn05: [openbmc_debug] curl -k -b cjar -X PUT -H "Content-Type: application/json" -d '{"data":"xyz.openbmc_project.State.Chassis.Transition.Off"}' https://172.11.139.5/xyz/openbmc_project/state/chassis0/attr/RequestedPowerTransition
Tue Nov  7 00:57:38 2017 mid05tor12cn05: [openbmc_debug] rpower_off_response 200 OK
Tue Nov  7 00:57:38 2017 mid05tor12cn05: [openbmc_debug] curl -k -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.5/xyz/openbmc_project/state/enumerate
Tue Nov  7 00:57:55 2017 mid05tor12cn05: [openbmc_debug] rpower_check_response 200 OK
Tue Nov  7 00:57:57 2017 mid05tor12cn05: [openbmc_debug] curl -k -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.5/xyz/openbmc_project/state/enumerate
Tue Nov  7 00:57:59 2017 mid05tor12cn05: [openbmc_debug] rpower_check_response 200 OK
Tue Nov  7 00:57:59 2017 mid05tor12cn05: [openbmc_debug] curl -k -b cjar -X PUT -H "Content-Type: application/json" -d '{"data":"xyz.openbmc_project.State.Host.Transition.On"}' https://172.11.139.5/xyz/openbmc_project/state/host0/attr/RequestedHostTransition
Tue Nov  7 00:58:00 2017 mid05tor12cn05: [openbmc_debug] rpower_on_response 200 OK
mid05tor12cn05: reset
```