### PR TITLE
Disable option --check and --ipsource for bmcdiscover

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -107,11 +107,11 @@ sub preprocess_request {
         }
         return \@requests;
     } elsif (grep /--check/, @ARGV) {
-        $callback->({ error => ["The option '--check' is not supported at present"], errorcode=>[1]});
+        $callback->({ error => ["The option '--check' is not supported"], errorcode=>[1]});
         $request = ();
         return;
     } elsif (grep /--ipsource/, @ARGV) {
-        $callback->({ error => ["The option '--ipsource' is not supported at present"], errorcode=>[1]});
+        $callback->({ error => ["The option '--ipsource' is not supported"], errorcode=>[1]});
         $request = ();
         return;
     } else {

--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -106,6 +106,14 @@ sub preprocess_request {
             push @requests, $reqcopy;
         }
         return \@requests;
+    } elsif (grep /--check/, @ARGV) {
+        $callback->({ error => ["The option '--check' is not supported at present"], errorcode=>[1]});
+        $request = ();
+        return;
+    } elsif (grep /--ipsource/, @ARGV) {
+        $callback->({ error => ["The option '--ipsource' is not supported at present"], errorcode=>[1]});
+        $request = ();
+        return;
     } else {
         return [$request];
     }


### PR DESCRIPTION
For #4240 

Disable option `--check` and `--ipsource` for bmcdiscover.

```
[root@briggs01 xCAT_plugin]# bmcdiscover -i 172.11.139.2 -p 0penBmc --ipsource
Error: The option '--ipsource' is not support at present
[root@briggs01 xCAT_plugin]# echo $?
1
[root@briggs01 xCAT_plugin]# bmcdiscover -i 172.11.139.2 -p 0penBmc --check
Error: The option '--check' is not support at present
[root@briggs01 xCAT_plugin]# echo $?
1
```