### PR TITLE
Fix issue 4126, sort firmware with B/H

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1799,7 +1799,11 @@ sub rinv_response {
             my $sw_id = (split(/\//, $key_url))[-1];
             if (defined($content{Version}) and $content{Version}) {
                 my $purpose_value = uc ((split(/\./, $content{Purpose}))[-1]);
-                $purpose_value = "[$sw_id]$purpose_value";
+                if ($purpose_value =~ /BMC/) {
+                    $purpose_value = "[B$sw_id]$purpose_value";
+                } else {
+                    $purpose_value = "[H$sw_id]$purpose_value";
+                }
                 my $activation_value = (split(/\./, $content{Activation}))[-1];
                 my $priority_value = -1;
                 if (defined($content{Priority})) {


### PR DESCRIPTION
#4126 

To sort firmware information, need to add ``$sw_id`` with each content to make the additional info with the HOST version together. If the BMC's $sw_id larger than HOST's, the BMC info will be behind HOST. 
Add "B/H" in content string before $sw_id to make BMC info in the top.

Before modify:
```
# rinv mid05tor12cn05 firm
mid05tor12cn05: HOST Firmware Product: IBM-witherspoon-ibm-OP9_v1.19_1.112 (Active)*
mid05tor12cn05: HOST Firmware Product: -- additional info: buildroot-2017.8-8-g5e23247
mid05tor12cn05: HOST Firmware Product: -- additional info: capp-ucode-p9-dd2-v2
mid05tor12cn05: HOST Firmware Product: -- additional info: hostboot-binaries-edd7653
mid05tor12cn05: HOST Firmware Product: -- additional info: hostboot-e8c85bb
mid05tor12cn05: HOST Firmware Product: -- additional info: linux-4.13.7-openpower1-p1c46946
mid05tor12cn05: HOST Firmware Product: -- additional info: machine-xml-eee619a
mid05tor12cn05: HOST Firmware Product: -- additional info: occ-cff91e5
mid05tor12cn05: HOST Firmware Product: -- additional info: op-build-v1.7-1507-g9a24243
mid05tor12cn05: HOST Firmware Product: -- additional info: petitboot-v1.6.1-p1d8f7a
mid05tor12cn05: HOST Firmware Product: -- additional info: sbe-ec9a99e
mid05tor12cn05: HOST Firmware Product: -- additional info: skiboot-v5.9-rc4
mid05tor12cn05: BMC Firmware Product: ibm-v1.99.10-113-g65edf7d-r8-0-g713d86d (Active)*
```
After modify:
```
# rinv mid05tor12cn05 firm
mid05tor12cn05: BMC Firmware Product: ibm-v1.99.10-113-g65edf7d-r8-0-g713d86d (Active)*
mid05tor12cn05: HOST Firmware Product: IBM-witherspoon-ibm-OP9_v1.19_1.112 (Active)*
mid05tor12cn05: HOST Firmware Product: -- additional info: buildroot-2017.8-8-g5e23247
mid05tor12cn05: HOST Firmware Product: -- additional info: capp-ucode-p9-dd2-v2
mid05tor12cn05: HOST Firmware Product: -- additional info: hostboot-binaries-edd7653
mid05tor12cn05: HOST Firmware Product: -- additional info: hostboot-e8c85bb
mid05tor12cn05: HOST Firmware Product: -- additional info: linux-4.13.7-openpower1-p1c46946
mid05tor12cn05: HOST Firmware Product: -- additional info: machine-xml-eee619a
mid05tor12cn05: HOST Firmware Product: -- additional info: occ-cff91e5
mid05tor12cn05: HOST Firmware Product: -- additional info: op-build-v1.7-1507-g9a24243
mid05tor12cn05: HOST Firmware Product: -- additional info: petitboot-v1.6.1-p1d8f7a
mid05tor12cn05: HOST Firmware Product: -- additional info: sbe-ec9a99e
mid05tor12cn05: HOST Firmware Product: -- additional info: skiboot-v5.9-rc4
```