### PR TITLE
Add some UT cases for rflash and rinv 

### DIFF
--- a/xCAT-test/autotest/testcase/UT_openbmc/rflash_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rflash_cases0
@@ -1,7 +1,7 @@
 start:rflash_check
 description: Make sure the --check option works
 os:Linux
-mgt:openbmc
+hcp:openbmc
 cmd:rflash $$CN --check
 check:rc==0
 check:output=~$$CN: BMC Firmware Product
@@ -11,6 +11,8 @@ end
 
 start:rflash_invalid_activate
 description: Provide an invalid option for activte, file does not end in .tar
+os:Linux
+hcp:openbmc
 cmd: rflash $$CN -a /tmp/abc123.tz
 check:rc==1
 check:output=~Error: Invalid option
@@ -18,6 +20,8 @@ end
 
 start:rflash_invalid_activate_and_delete
 description: Cannot specify -a and -d at the same time
+os:Linux
+hcp:openbmc
 cmd: rflash $$CN -a 123 -d 123
 check:rc==1
 check:output=~Error: Multiple options specified is not supported
@@ -25,6 +29,8 @@ end
 
 start:rflash_invalid_id 
 description: Passing an invalid ID to activate
+os:Linux
+hcp:openbmc
 cmd: rflash $$CN -a 123
 check:rc==1
 check:output=~Error: Invalid ID provided to activate
@@ -32,6 +38,8 @@ end
 
 start:rflash_invalid_multiple_id_3
 description: Code does not currently support multiple IDs to activate
+os:Linux
+hcp:openbmc
 cmd: rflash $$CN -a 123 abc asdbas 
 check:rc==1
 check:output=~Error: More than one firmware specified is not supported
@@ -39,6 +47,8 @@ end
 
 start:rflash_invalid_multiple_id_2
 description: Code does not currently support multiple IDs to activate
+os:Linux
+hcp:openbmc
 cmd: rflash $$CN -a asdbas 123
 check:rc==1
 check:output=~Error: More than one firmware specified is not supported
@@ -46,6 +56,8 @@ end
 
 start:rflash_invalid_node
 description: Activate a valid ID hash but forget to put in a node range 
+os:Linux
+hcp:openbmc
 cmd: rflash -a 221d9020
 check:rc==1 
 check:output=~Error: Invalid nodes and/or groups in noderange: 221d9020

--- a/xCAT-test/autotest/testcase/UT_openbmc/rflash_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rflash_cases0
@@ -1,4 +1,5 @@
 start:rflash_check
+description: Make sure the --check option works
 os:Linux
 mgt:openbmc
 cmd:rflash $$CN --check
@@ -9,36 +10,42 @@ check:rc==0
 end
 
 start:rflash_invalid_activate
+description: Provide an invalid option for activte, file does not end in .tar
 cmd: rflash $$CN -a /tmp/abc123.tz
 check:rc==1
 check:output=~Error: Invalid option
 end 
 
 start:rflash_invalid_activate_and_delete
+description: Cannot specify -a and -d at the same time
 cmd: rflash $$CN -a 123 -d 123
 check:rc==1
 check:output=~Error: Multiple options specified is not supported
 end 
 
 start:rflash_invalid_id 
+description: Passing an invalid ID to activate
 cmd: rflash $$CN -a 123
 check:rc==1
 check:output=~Error: Invalid ID provided to activate
 end 
 
 start:rflash_invalid_multiple_id_3
+description: Code does not currently support multiple IDs to activate
 cmd: rflash $$CN -a 123 abc asdbas 
 check:rc==1
 check:output=~Error: More than one firmware specified is not supported
 end 
 
 start:rflash_invalid_multiple_id_2
+description: Code does not currently support multiple IDs to activate
 cmd: rflash $$CN -a asdbas 123
 check:rc==1
 check:output=~Error: More than one firmware specified is not supported
 end 
 
 start:rflash_invalid_node
+description: Activate a valid ID hash but forget to put in a node range 
 cmd: rflash -a 221d9020
 check:rc==1 
 check:output=~Error: Invalid nodes and/or groups in noderange: 221d9020

--- a/xCAT-test/autotest/testcase/UT_openbmc/rflash_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rflash_cases0
@@ -6,7 +6,6 @@ cmd:rflash $$CN --check
 check:rc==0
 check:output=~$$CN: BMC Firmware Product
 check:output=~$$CN: HOST Firmware Product
-check:rc==0
 end
 
 start:rflash_invalid_activate

--- a/xCAT-test/autotest/testcase/UT_openbmc/rflash_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rflash_cases0
@@ -62,4 +62,11 @@ check:rc==1
 check:output=~Error: Invalid nodes and/or groups in noderange: 221d9020
 end
 
-
+start:rflash_invalid_delete_2
+description: Attempt to delete more than 1 ID from the FW
+os:Linux
+hcp:openbmc
+cmd: rflash $$CN -d 221d9020 221d9020
+check:rc==1 
+check:output=~Error: More than one firmware specified is not supported
+end

--- a/xCAT-test/autotest/testcase/UT_openbmc/rflash_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rflash_cases0
@@ -1,0 +1,47 @@
+start:rflash_check
+os:Linux
+mgt:openbmc
+cmd:rflash $$CN --check
+check:rc==0
+check:output=~$$CN: BMC Firmware Product
+check:output=~$$CN: HOST Firmware Product
+check:rc==0
+end
+
+start:rflash_invalid_activate
+cmd: rflash $$CN -a /tmp/abc123.tz
+check:rc==1
+check:output=~Error: Invalid option
+end 
+
+start:rflash_invalid_activate_and_delete
+cmd: rflash $$CN -a 123 -d 123
+check:rc==1
+check:output=~Error: Multiple options specified is not supported
+end 
+
+start:rflash_invalid_id 
+cmd: rflash $$CN -a 123
+check:rc==1
+check:output=~Error: Invalid ID provided to activate
+end 
+
+start:rflash_invalid_multiple_id_3
+cmd: rflash $$CN -a 123 abc asdbas 
+check:rc==1
+check:output=~Error: More than one firmware specified is not supported
+end 
+
+start:rflash_invalid_multiple_id_2
+cmd: rflash $$CN -a asdbas 123
+check:rc==1
+check:output=~Error: More than one firmware specified is not supported
+end 
+
+start:rflash_invalid_node
+cmd: rflash -a 221d9020
+check:rc==1 
+check:output=~Error: Invalid nodes and/or groups in noderange: 221d9020
+end
+
+

--- a/xCAT-test/autotest/testcase/UT_openbmc/rinv_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rinv_cases0
@@ -1,0 +1,39 @@
+start:rinv_check_active_fw
+description: Ensure that there is only 1 active BMC and 1 Active PNOR
+os:Linux
+mgt:openbmc
+cmd:rinv $$CN firm | grep -i ibm
+check:rc==0
+check:output=~$$CN: BMC Firmware Product
+check:rc==0
+check:output=~$$CN: HOST Firmware Product
+check:rc==0
+end
+
+start:rinv_check_active_fw_count 
+description: Ensure that there are only 2 active firmware (if previous test is OK)
+os:Linux
+mgt:openbmc
+# show the output
+cmd:rinv $$CN firm | grep -i ibm 
+check:rc==0
+# check based on wc 
+cmd:rinv $$CN firm | grep -i ibm | wc -l
+check:output=~2
+check:rc==0
+end
+
+start:rinv_check_active_fw_verbose_count
+description: Ensure that there is only 2 active firmware (in verbose mode) (Issue #4236)
+os:Linux
+mgt:openbmc
+# show the output
+cmd:rinv $$CN firm -V | grep -i Active 
+check:rc==0
+# validate test cased on word count
+cmd:rinv $$CN firm -V | grep -i Active | wc -l
+check:rc==0
+check:rc==0
+check:output=~2
+check:rc==0
+end

--- a/xCAT-test/autotest/testcase/UT_openbmc/rinv_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rinv_cases0
@@ -1,35 +1,29 @@
-start:rinv_check_active_fw
-description: Ensure that there is only 1 active BMC and 1 Active PNOR
-os:Linux
+start:rinv_check_active_fw_count
+description: Ensure that there is only 2 active firmware, one for bmc and one for pnor
 hcp:openbmc
-cmd:rinv $$CN firm | grep -i ibm
+cmd: rinv $$CN firm | tee /tmp/xcattest.rinv_check_active_fw_count.output
 check:rc==0
-check:output=~$$CN: BMC Firmware Product
-check:output=~$$CN: HOST Firmware Product
+cmd: grep -i ibm /tmp/xcattest.rinv_check_active_fw_count.output | grep -i 'HOST Firmware Product' | grep -i 'Active)*' | wc -l
+check:rc==0
+check:output=~1
+cmd: grep -i ibm /tmp/xcattest.rinv_check_active_fw_count.output | grep -i 'BMC Firmware Product'|grep -i 'Active)*' | wc -l
+check:rc==0
+check:output=~1
+cmd : rm -rf /tmp/xcattest.rinv_check_active_fw_count.output
+check:rc==0
 end
 
-start:rinv_check_active_fw_count 
-description: Ensure that there are only 2 active firmware (if previous test is OK)
-os:Linux
+start:rinv_check_active_fw_count_verbose
+description: Ensure that there is only 2 active firmware, one for bmc and one for pnor (in verbose mode) (Issue #4236)
 hcp:openbmc
-# show the output
-cmd:rinv $$CN firm | grep -i ibm 
+cmd: rinv $$CN firm -V | tee /tmp/xcattest.rinv_check_active_fw_count_verbose.output
 check:rc==0
-# check based on wc 
-cmd:rinv $$CN firm | grep -i ibm | wc -l
+cmd: grep -i ibm /tmp/xcattest.rinv_check_active_fw_count_verbose.output| grep -i 'HOST Firmware Product' | grep -i 'Active)*' | wc -l
 check:rc==0
-check:output=~2
-end
-
-start:rinv_check_active_fw_verbose_count
-description: Ensure that there is only 2 active firmware (in verbose mode) (Issue #4236)
-os:Linux
-hcp:openbmc
-# show the output
-cmd:rinv $$CN firm -V | grep -i Active 
+check:output=~1
+cmd: grep -i ibm /tmp/xcattest.rinv_check_active_fw_count_verbose.output | grep -i 'BMC Firmware Product'|grep -i 'Active)*' | wc -l
 check:rc==0
-# validate test cased on word count
-cmd:rinv $$CN firm -V | grep -i Active | wc -l
+check:output=~1
+cmd : rm -rf /tmp/xcattest.rinv_check_active_fw_count_verbose.output
 check:rc==0
-check:output=~2
 end

--- a/xCAT-test/autotest/testcase/UT_openbmc/rinv_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rinv_cases0
@@ -5,9 +5,7 @@ hcp:openbmc
 cmd:rinv $$CN firm | grep -i ibm
 check:rc==0
 check:output=~$$CN: BMC Firmware Product
-check:rc==0
 check:output=~$$CN: HOST Firmware Product
-check:rc==0
 end
 
 start:rinv_check_active_fw_count 
@@ -19,8 +17,8 @@ cmd:rinv $$CN firm | grep -i ibm
 check:rc==0
 # check based on wc 
 cmd:rinv $$CN firm | grep -i ibm | wc -l
-check:output=~2
 check:rc==0
+check:output=~2
 end
 
 start:rinv_check_active_fw_verbose_count
@@ -33,7 +31,5 @@ check:rc==0
 # validate test cased on word count
 cmd:rinv $$CN firm -V | grep -i Active | wc -l
 check:rc==0
-check:rc==0
 check:output=~2
-check:rc==0
 end

--- a/xCAT-test/autotest/testcase/UT_openbmc/rinv_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rinv_cases0
@@ -1,7 +1,7 @@
 start:rinv_check_active_fw
 description: Ensure that there is only 1 active BMC and 1 Active PNOR
 os:Linux
-mgt:openbmc
+hcp:openbmc
 cmd:rinv $$CN firm | grep -i ibm
 check:rc==0
 check:output=~$$CN: BMC Firmware Product
@@ -13,7 +13,7 @@ end
 start:rinv_check_active_fw_count 
 description: Ensure that there are only 2 active firmware (if previous test is OK)
 os:Linux
-mgt:openbmc
+hcp:openbmc
 # show the output
 cmd:rinv $$CN firm | grep -i ibm 
 check:rc==0
@@ -26,7 +26,7 @@ end
 start:rinv_check_active_fw_verbose_count
 description: Ensure that there is only 2 active firmware (in verbose mode) (Issue #4236)
 os:Linux
-mgt:openbmc
+hcp:openbmc
 # show the output
 cmd:rinv $$CN firm -V | grep -i Active 
 check:rc==0

--- a/xCAT-test/autotest/testcase/UT_openbmc/rinv_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rinv_cases0
@@ -3,10 +3,10 @@ description: Ensure that there is only 2 active firmware, one for bmc and one fo
 hcp:openbmc
 cmd: rinv $$CN firm | tee /tmp/xcattest.rinv_check_active_fw_count.output
 check:rc==0
-cmd: grep -i ibm /tmp/xcattest.rinv_check_active_fw_count.output | grep -i 'HOST Firmware Product' | grep -i 'Active)*' | wc -l
+cmd: grep -i ibm /tmp/xcattest.rinv_check_active_fw_count.output | grep -i 'HOST Firmware Product' | grep -i 'Active)\*' | wc -l
 check:rc==0
 check:output=~1
-cmd: grep -i ibm /tmp/xcattest.rinv_check_active_fw_count.output | grep -i 'BMC Firmware Product'|grep -i 'Active)*' | wc -l
+cmd: grep -i ibm /tmp/xcattest.rinv_check_active_fw_count.output | grep -i 'BMC Firmware Product'|grep -i 'Active)\*' | wc -l
 check:rc==0
 check:output=~1
 cmd : rm -rf /tmp/xcattest.rinv_check_active_fw_count.output
@@ -18,10 +18,10 @@ description: Ensure that there is only 2 active firmware, one for bmc and one fo
 hcp:openbmc
 cmd: rinv $$CN firm -V | tee /tmp/xcattest.rinv_check_active_fw_count_verbose.output
 check:rc==0
-cmd: grep -i ibm /tmp/xcattest.rinv_check_active_fw_count_verbose.output| grep -i 'HOST Firmware Product' | grep -i 'Active)*' | wc -l
+cmd: grep -i ibm /tmp/xcattest.rinv_check_active_fw_count_verbose.output| grep -i 'HOST Firmware Product' | grep -i 'Active)\*' | wc -l
 check:rc==0
 check:output=~1
-cmd: grep -i ibm /tmp/xcattest.rinv_check_active_fw_count_verbose.output | grep -i 'BMC Firmware Product'|grep -i 'Active)*' | wc -l
+cmd: grep -i ibm /tmp/xcattest.rinv_check_active_fw_count_verbose.output | grep -i 'BMC Firmware Product'|grep -i 'Active)\*' | wc -l
 check:rc==0
 check:output=~1
 cmd : rm -rf /tmp/xcattest.rinv_check_active_fw_count_verbose.output


### PR DESCRIPTION
These UT test cases check the rflash option parsing code and Resolves **testcase_requested** for #4053 

Here's the run of the UT testcases: 
```
------START::rflash_check::Time:Wed Nov  8 12:50:55 2017------

RUN:rflash mid05tor12cn05 --check [Wed Nov  8 12:50:55 2017]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid05tor12cn05: BMC Firmware Product: ibm-v1.99.10-113-g65edf7d-r8-0-g713d86d (Active)*
mid05tor12cn05: HOST Firmware Product: IBM-witherspoon-ibm-OP9_v1.19_1.112 (Active)*
mid05tor12cn05: HOST Firmware Product: -- additional info: buildroot-2017.8-8-g5e23247
mid05tor12cn05: HOST Firmware Product: -- additional info: capp-ucode-p9-dd2-v2
mid05tor12cn05: HOST Firmware Product: -- additional info: hostboot-binaries-edd7653
mid05tor12cn05: HOST Firmware Product: -- additional info: hostboot-e8c85bb
mid05tor12cn05: HOST Firmware Product: -- additional info: linux-4.13.7-openpower1-p1c46946
mid05tor12cn05: HOST Firmware Product: -- additional info: machine-xml-eee619a
mid05tor12cn05: HOST Firmware Product: -- additional info: occ-cff91e5
mid05tor12cn05: HOST Firmware Product: -- additional info: op-build-v1.7-1507-g9a24243
mid05tor12cn05: HOST Firmware Product: -- additional info: petitboot-v1.6.1-p1d8f7a
mid05tor12cn05: HOST Firmware Product: -- additional info: sbe-ec9a99e
mid05tor12cn05: HOST Firmware Product: -- additional info: skiboot-v5.9-rc4
CHECK:rc == 0	[Pass]
CHECK:output =~ mid05tor12cn05: BMC Firmware Product	[Pass]
CHECK:output =~ mid05tor12cn05: HOST Firmware Product	[Pass]
CHECK:rc == 0	[Pass]
 
------END::rflash_check::Passed::Time:Wed Nov  8 12:50:57 2017 ::Duration::2 sec------
------START::rflash_invalid_activate::Time:Wed Nov  8 12:50:57 2017------

RUN:rflash mid05tor12cn05 -a /tmp/abc123.tz [Wed Nov  8 12:50:57 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
mid05tor12cn05: Error: Invalid option specified with -a: /tmp/abc123.tz 
CHECK:rc == 1	[Pass]
CHECK:output =~ Error: Invalid option	[Pass]
 
------END::rflash_invalid_activate::Passed::Time:Wed Nov  8 12:50:57 2017 ::Duration::0 sec------
------START::rflash_invalid_activate_and_delete::Time:Wed Nov  8 12:50:57 2017------

RUN:rflash mid05tor12cn05 -a 123 -d 123 [Wed Nov  8 12:50:57 2017]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
mid05tor12cn05: Error: Multiple options specified is not supported.  Options specified: -a -d
CHECK:rc == 1	[Pass]
CHECK:output =~ Error: Multiple options specified is not supported	[Pass]
 
------END::rflash_invalid_activate_and_delete::Passed::Time:Wed Nov  8 12:50:58 2017 ::Duration::1 sec------
------START::rflash_invalid_id::Time:Wed Nov  8 12:50:58 2017------

RUN:rflash mid05tor12cn05 -a 123 [Wed Nov  8 12:50:58 2017]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
mid05tor12cn05: Error: Invalid ID provided to activate. Use the -l option to view valid firmware IDs.
CHECK:rc == 1	[Pass]
CHECK:output =~ Error: Invalid ID provided to activate	[Pass]
 
------END::rflash_invalid_id::Passed::Time:Wed Nov  8 12:50:59 2017 ::Duration::1 sec------
------START::rflash_invalid_multiple_id_3::Time:Wed Nov  8 12:50:59 2017------

RUN:rflash mid05tor12cn05 -a 123 abc asdbas [Wed Nov  8 12:50:59 2017]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
mid05tor12cn05: Error: More than one firmware specified is not supported.
CHECK:rc == 1	[Pass]
CHECK:output =~ Error: More than one firmware specified is not supported	[Pass]
 
------END::rflash_invalid_multiple_id_3::Passed::Time:Wed Nov  8 12:51:00 2017 ::Duration::1 sec------
------START::rflash_invalid_multiple_id_2::Time:Wed Nov  8 12:51:00 2017------

RUN:rflash mid05tor12cn05 -a asdbas 123 [Wed Nov  8 12:51:00 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
mid05tor12cn05: Error: More than one firmware specified is not supported.
CHECK:rc == 1	[Pass]
CHECK:output =~ Error: More than one firmware specified is not supported	[Pass]
 
------END::rflash_invalid_multiple_id_2::Passed::Time:Wed Nov  8 12:51:00 2017 ::Duration::0 sec------
------START::rflash_invalid_node::Time:Wed Nov  8 12:51:00 2017------

RUN:rflash -a 221d9020 [Wed Nov  8 12:51:00 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Error: Invalid nodes and/or groups in noderange: 221d9020
CHECK:rc == 1	[Pass]
CHECK:output =~ Error: Invalid nodes and/or groups in noderange: 221d9020	[Pass]
 
------END::rflash_invalid_node::Passed::Time:Wed Nov  8 12:51:00 2017 ::Duration::0 sec------
------Total: 7 , Failed: 0------
```
