### PR TITLE
enhance my_ip_facing when multiple ips found for xcatmaster

### DIFF
--- a/xCAT-server/lib/perl/xCAT/Postage.pm
+++ b/xCAT-server/lib/perl/xCAT/Postage.pm
@@ -417,22 +417,18 @@ sub makescript {
             #the ip address of the mn facing the compute node
             my @ipfnd = xCAT::NetworkUtils->my_ip_facing($node);
             my $ipfndscalar = @ipfnd;
-            if ($ipfnd[0]) {
-                if ($ipfndscalar ==2) {
-                    $::GLOBAL_TAB_HASH{noderes}{$node}{xcatmaster} = $ipfnd[1]; 
-                    $master = $ipfnd[1];
-                } elsif ($ipfndscalar > 2) {
+            unless ($ipfnd[0]) {
+                $master = $ipfnd[1];
+                if ($ipfndscalar > 2) {
                     foreach my $ipinfnd (@ipfnd) {
                         if ($::XCATSITEVALS{master} and $ipinfnd eq $::XCATSITEVALS{master}) {
-                            $::GLOBAL_TAB_HASH{noderes}{$node}{xcatmaster} = $ipinfnd;
                             $master = $ipinfnd;
                             last;
                         }
-                    }    
-                    unless ($master) {
-                        $::GLOBAL_TAB_HASH{noderes}{$node}{xcatmaster} = $ipfnd[1];
-                        $master = $ipfnd[1];
                     }
+                }
+                if ($master) {
+                    $::GLOBAL_TAB_HASH{noderes}{$node}{xcatmaster} = $master;
                 }
             }
         }
@@ -1562,22 +1558,20 @@ sub collect_all_attribs_for_tables_in_template
                                 my $value = undef;
                                 my @ipfnd = xCAT::NetworkUtils->my_ip_facing($node);
                                 my $ipfndscalar = @ipfnd;
-                                if ($ipfnd[0]) {
-                                    if ($ipfndscalar ==2) {
-                                        $value = $ipfnd[1];
-                                    } elsif ($ipfndscalar > 2) {
-                                    foreach my $ipinfnd (@ipfnd) {
-                                        if ($::XCATSITEVALS{master} and $ipinfnd eq $::XCATSITEVALS{master}) {
-                                            $value = $ipinfnd;
-                                            last;
+                                unless ($ipfnd[0]) {
+                                    $value = $ipfnd[1];
+                                    if ($ipfndscalar > 2) {
+                                        foreach my $ipinfnd (@ipfnd) {
+                                            if ($::XCATSITEVALS{master} and $ipinfnd eq $::XCATSITEVALS{master}) {
+                                                $value = $ipinfnd;
+                                                last;
+                                            }
                                         }
                                     }
-                                    unless ($value) {
-                                        $value = $ipfnd[1];
-                                    }         
-                                    }   
                                 }
-                                $::GLOBAL_TAB_HASH{$tabname}{$node}{$attrib} = $value;
+                                if ($value) {
+                                    $::GLOBAL_TAB_HASH{$tabname}{$node}{$attrib} = $value;
+                                }
                             }
 
                             # for nodetype.os and nodetype.arch


### PR DESCRIPTION
fix #4059 

The logic to determine the $ENV{XCATMASTER} confirm to the following priority(from high to low):
* Using noderes.xcatmaster
* Facing_IP on MN or SN to the CN (If multiple and the SITEMASTER is also there, using SITEMASTER). If the CN is using SN, should configure xcatmaster for the CN, this should be included in doc.
* using SITEMASTER

When there is no xcatmaster configured in node attribute, If multiple my facing ips are found and the SITEMASTER is also there, using SITEMASTER;

UT results:
In HA MN, there are 2 ips for management network, before and after code changes, the MASTER and MASTER_IP are different in mypostscript, vip 10.5.106.100 is the master ip;
```
In xCAT MN
]# ip addr show dev eth0| grep inet
    inet 10.5.106.9/8 brd 10.255.255.255 scope global eth0
    inet 10.5.106.100/8 brd 10.255.255.255 scope global secondary eth0:0
```

Before the code changes
```
]# grep "MASTER" mypostscript
......
SITEMASTER='10.5.106.100'
export SITEMASTER
MASTER='10.5.106.9'
export MASTER
MASTER_IP=10.5.106.9
export MASTER_IP
MONMASTER='10.5.106.100'
export MONMASTER
```
After the code changes
```
]# grep MASTER mypostscript
SITEMASTER='10.5.106.100'
export SITEMASTER
MASTER='10.5.106.100'
export MASTER
MASTER_IP=10.5.106.100
export MASTER_IP
MONMASTER='10.5.106.100'
export MONMASTER
```


