### PR TITLE
Add all modules when build xCAT-genesis-base

### DIFF
--- a/xCAT-genesis-builder/buildrpm
+++ b/xCAT-genesis-builder/buildrpm
@@ -35,6 +35,16 @@ else
     DRACUTMODDIR=/usr/lib/dracut/modules.d/97xcat
 fi
 
+# get all modules in the kernel
+mv ./installkernel ./default_module_list
+echo "#!/bin/bash" > ./installkernel
+#instmods
+for line in `cat /lib/modules/4.11.8-300.fc26.ppc64/modules.dep | awk -F: '{print \$1}'`; do 
+    basename $line >> ./installkernel; 
+done
+sed -i 's/\(.*\)\.ko/instmods \1/g' ./installkernel
+chmod +x ./installkernel
+
 mkdir -p $DRACUTMODDIR
 cp $DIR/* $DRACUTMODDIR
 
@@ -158,6 +168,7 @@ for d in `echo $PERL_LIB_DIR`; do
         cp -a -t $TEMP_DIR $d/.
     fi
 done
+
 
 # create the predictable naming for nics
 LIB_UDEV_RULES="/lib/udev/rules.d/"


### PR DESCRIPTION
When build xCAT-genesis-base, include all the kernel modules include in the host kernel. 

For ppc64 based on Fedora26, the package size is increase from 49M to 92M. And after installed on MN and run mknb,  the genesis rootfs size is increase from 55M to 123M. 
So, it seems OK to include all the kernel modules. 
```
[root@c910f03c05k03 noarch]# ls -lh xCAT-genesis-base-ppc64*
-rw-r--r-- 1 root root 49M Nov 10 03:09 xCAT-genesis-base-ppc64-2.13.7-snap201711100308.noarch.rpm
-rw-r--r-- 1 root root 92M Nov 10 05:10 xCAT-genesis-base-ppc64-2.13.7-snap201711100509.noarch.rpm
```
```
[root@fs1 ~]# ls -lh /tftpboot/xcat/genesis.fs.ppc64.gz
-rw-r--r-- 1 root root 55M Nov 10 05:18 /tftpboot/xcat/genesis.fs.ppc64.gz
[root@fs1 ~]# ls -lh /tftpboot/xcat/genesis.fs.ppc64.gz
-rw-r--r-- 1 root root 123M Nov 10 04:26 /tftpboot/xcat/genesis.fs.ppc64.gz
```