### PR TITLE
Fix bug in the output if rinv firm verbose that was displaying * for all listings

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1830,10 +1830,12 @@ sub rinv_response {
                     # to cause the sorting of this line before any additional info lines 
                     #
                     $content_info = "$purpose_value Firmware Product:   $content{Version} ($activation_value)";
-                    my $indicator = "*";
+                    my $indicator = "";
                     if ($priority_value == 0 and %{$functional} and !exists($functional->{$sw_id})) {
                         # indicate that a reboot is needed if priority = 0 and it's not in the functional list
                         $indicator = "+";
+                    } elsif ($priority_value == 0 and %{$functional} and exists($functional->{$sw_id})) {
+                        $indicator = "*";
                     }
                     $content_info .= $indicator;
                     push (@sorted_output, $content_info); 


### PR DESCRIPTION
Fix issue opened in #4236 

In this case for the verbose flag of `rinv <node> firm` , there is a bug initializing all the Active firmware to have the `*` indicator. 

Before fix, across 3 nodes, we see > 6 Active returned... 
```
[root@briggs01 910.1742.20171018a_1742B]# rinv mid05tor12cn[02,05,11] firm -V | grep "Active)\*"
mid05tor12cn02: [briggs01]: BMC Firmware Product: ibm-v1.99.10-113-g65edf7d-r10-0-gcdf7635 (Active)*
mid05tor12cn02: [briggs01]: BMC Firmware Product: ibm-v1.99.10-0-r11-0-g9c65260 (Active)*
mid05tor12cn02: [briggs01]: HOST Firmware Product: IBM-witherspoon-ibm-OP9_v1.19_1.73 (Active)*
mid05tor12cn02: [briggs01]: HOST Firmware Product: IBM-witherspoon-ibm-OP9_v1.19_1.73 (Active)*
mid05tor12cn11: [briggs01]: BMC Firmware Product: ibm-v1.99.10-113-g65edf7d-r3-0-g9e4f715 (Active)*
mid05tor12cn11: [briggs01]: BMC Firmware Product: ibm-v1.99.10-113-g65edf7d-r10-0-gcdf7635 (Active)*
mid05tor12cn11: [briggs01]: HOST Firmware Product: IBM-witherspoon-ibm-OP9_v1.19_1.73 (Active)*
mid05tor12cn11: [briggs01]: HOST Firmware Product: IBM-witherspoon-ibm-OP9_v1.19_1.68 (Active)*
mid05tor12cn05: [briggs01]: BMC Firmware Product: ibm-v1.99.10-113-g65edf7d-r10-0-gcdf7635 (Active)*
mid05tor12cn05: [briggs01]: BMC Firmware Product: ibm-v1.99.10-113-g65edf7d-r8-0-g713d86d (Active)*
mid05tor12cn05: [briggs01]: HOST Firmware Product: IBM-witherspoon-ibm-OP9_v1.19_1.112 (Active)*
mid05tor12cn05: [briggs01]: HOST Firmware Product: IBM-witherspoon-ibm-OP9_v1.19_1.73 (Active)*
[root@briggs01 910.1742.20171018a_1742B]# rinv mid05tor12cn[02,05,11] firm -V | grep "Active)\*"  | wc -l
12
```
After fix, across 3 nodes, we get 2 active per node (6 total) 

```
[root@briggs01 910.1742.20171018a_1742B]# rinv mid05tor12cn[02,05,11] firm -V | grep "Active)\*"
mid05tor12cn11: [briggs01]: BMC Firmware Product: ibm-v1.99.10-113-g65edf7d-r10-0-gcdf7635 (Active)*
mid05tor12cn11: [briggs01]: HOST Firmware Product: IBM-witherspoon-ibm-OP9_v1.19_1.73 (Active)*
mid05tor12cn02: [briggs01]: BMC Firmware Product: ibm-v1.99.10-113-g65edf7d-r10-0-gcdf7635 (Active)*
mid05tor12cn02: [briggs01]: HOST Firmware Product: IBM-witherspoon-ibm-OP9_v1.19_1.73 (Active)*
mid05tor12cn05: [briggs01]: BMC Firmware Product: ibm-v1.99.10-113-g65edf7d-r10-0-gcdf7635 (Active)*
mid05tor12cn05: [briggs01]: HOST Firmware Product: IBM-witherspoon-ibm-OP9_v1.19_1.73 (Active)*
```