### PR TITLE
Task 4235, rspconfig BMC dump for OpenBMC

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -819,10 +819,10 @@ sub parse_args {
             } elsif ($subcommand eq "dump") {
                 my $option = $ARGV[1];
                 if ($option =~ /^-d$|^--download$/) {
-                    return ([ 1, "Invalid parameter for $command $option" ]) unless ($ARGV[2]);
+                    return ([ 1, "No dump file ID specified" ]) unless ($ARGV[2]);
                     return ([ 1, "Invalid parameter for $command $option $ARGV[2]" ]) if ($ARGV[2] !~ /^\d*$/);
                 } elsif ($option =~ /^-c$|^--clear$/) {
-                    return ([ 1, "Invalid parameter for $command $option" ]) unless ($ARGV[2]);
+                    return ([ 1, "No dump file ID specified" ]) unless ($ARGV[2]);
                     return ([ 1, "Invalid parameter for $command $option $ARGV[2]" ]) if ($ARGV[2] !~ /^\d*$/ and $ARGV[2] ne "all");
                 } elsif ($option !~ /^-l$|^--list$|^-g$|^--generate$/) {
                     return ([ 1, "Invalid parameter for $command $option" ]);


### PR DESCRIPTION
#4235 

* rspconfig -l|--list
```
[root@briggs01 dump]# rspconfig mid05tor12cn02 dump --list
mid05tor12cn02: [1] Elapsed: 09/22/2017 14:41:05, Size: 4624
mid05tor12cn02: [2] Elapsed: 09/22/2017 14:46:29, Size: 3608
mid05tor12cn02: [3] Elapsed: 10/05/2017 22:46:59, Size: 180976
mid05tor12cn02: [4] Elapsed: 10/09/2017 22:10:46, Size: 8184
mid05tor12cn02: [5] Elapsed: 10/09/2017 22:10:51, Size: 8404
mid05tor12cn02: [6] Elapsed: 10/09/2017 22:10:57, Size: 8384
mid05tor12cn02: [7] Elapsed: 10/26/2017 10:29:16, Size: 3692
mid05tor12cn02: [8] Elapsed: 10/26/2017 10:29:16, Size: 3716
mid05tor12cn02: [9] Elapsed: 10/26/2017 10:29:16, Size: 3760
mid05tor12cn02: [10] Elapsed: 10/26/2017 10:29:16, Size: 3676
```

* rspconfig -g|--generate
```
[root@briggs01 dump]# rspconfig mid05tor12cn02 dump -g
mid05tor12cn02: [11] success
```
When testing, found that need to wait several minutes could saw it in the list.

* rspconfig -c|--clear
```
[root@briggs01 dump]# rspconfig mid05tor12cn02 dump --clear 11
mid05tor12cn02: [11] clear
```

* rspconfig -d|--download
```
[root@briggs01 dump]# rspconfig mid05tor12cn02 dump --download 2
mid05tor12cn02: Saved dump 2 as /var/log/xcat/dump/mid05tor12cn02_dump_2.tar.xz
```
I modified some code in the same line with #4254, may has conflicts.