### PR TITLE
Fix #4288, Show the milliseconds for elapsed time of command execution

### DIFF
--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -58,7 +58,7 @@ unless (($^O =~ /^aix/i) || ($os =~ /^sle[sc]10/) || (($os =~ /^rh.*5$/) && ($ar
 }
 use File::Basename;
 use File::Path;
-use Time::HiRes qw(sleep);
+use Time::HiRes qw(sleep time);
 use Thread qw(yield);
 use Fcntl qw/:DEFAULT :flock/;
 use xCAT::Client qw(submit_request);
@@ -594,7 +594,7 @@ sub grant_tcrequests {
     my $availableslots = $batchclients;
     if (not keys %{$requestors}) { return; }  # skip the interaction with SSL if
                                               # no requests are actually pending
-    my $oldtime = time() - 180; # drop requests older than three minutes if still around
+    my $oldtime = int(time()) - 180; # drop requests older than three minutes if still around
     my $msg;
     eval { store_fd({ 'req' => 'get_client_count' }, $sslctl); $msg = fd_retrieve($sslctl); };
 
@@ -813,7 +813,7 @@ sub do_udp_service {    # This function opens up a UDP port
                     } else {    # for *now*, we'll do a tiny YAML subset
                         if ($data =~ /^resourcerequest: xcatd$/) {
                             $socket->send("ackresourcerequest\n", 0, $packets{$pkey}->[0]);
-                            $tcclients->{$pkey} = { sockaddr => $packets{$pkey}->[0], timestamp => time() }
+                            $tcclients->{$pkey} = { sockaddr => $packets{$pkey}->[0], timestamp => int(time()) }
                         }
                     }    # JSON maybe one day if important
                     if ($quit) { last; }
@@ -2046,8 +2046,9 @@ sub plugin_command {
     my $nextxmittime = time() + 1;
     while (($plugin_numchildren > 0) and ($check_fds->count > 0)) { # this tracks end of useful data from children much more closely
         relay_fds($check_fds, $xcatresponses{xcatresponse});
-        if (time() > $nextxmittime) {
-            $nextxmittime = time() + 1;
+        my $currenttime = time();
+        if ($currenttime > $nextxmittime) {
+            $nextxmittime = $currenttime + 1;
             send_response(\%xcatresponses, $sock);
             $xcatresponses{xcatresponse} = [];
         }
@@ -2930,7 +2931,7 @@ sub service_connection {
     }
 
     # ----used for command log start-------
-    my $reqhandletime = time()-$cmdlog_starttime;
+    my $reqhandletime = sprintf("%.3f", time()-$cmdlog_starttime);
     $cmdlog_alllog .= "[ElapsedTime] $reqhandletime s\n";
     cmdlog_submitlog();
 
@@ -3002,7 +3003,7 @@ sub relay_fds { # Relays file descriptors from pipes to children to the SSL sock
 
             # ----used for command log start-------
             $cmdlog_alllog .= "Client abort requested\n";
-            my $reqhandletime = time()-$cmdlog_starttime;
+            my $reqhandletime = sprintf("%.3f", time()-$cmdlog_starttime);
             $cmdlog_alllog .= "[ElapsedTime] $reqhandletime s\n";
             cmdlog_submitlog();
 


### PR DESCRIPTION
In xcatd, we introduce Time::HiRes.time to replace the built-in time().
Except the cmd log, some of the origin codes used time() to get the seconds. Most of them are just wait for a while. We can use new time() without worry.

But for the information passed in socket message, we use int(time()) to get the integer so that no impact to previous logic.

UT:
```
[Date]       2017-11-13 21:55:37
[ClientType] cli
[Request]    rpower fake1 stat
[Response]
fake1: [openbmc_debug] curl -k -c cjar -H "Content-Type: application/json" -d '{ "data": ["root", "xxxxxx"] }' https://192.169.0.1/login
fake1: [openbmc_debug] login_response 200 OK
fake1: [openbmc_debug] curl -k -b cjar -X GET -H "Content-Type: application/json" https://192.169.0.1/xyz/openbmc_project/state/enumerate
fake1: [openbmc_debug] rpower_status_response 200 OK
fake1: on
[ElapsedTime] 3.349 s
```
OK, now the ElapsedTime is more accurate.