### PR TITLE
Enhance xcattest to better support the cases which have the same case name but with multiple implementation

### DIFF
--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -905,6 +905,9 @@ sub load_case {
                     foreach my $os (@newvalidoslist) {
                         if ($currentos =~ /$os/i) {
                             $valid = 1;
+                            if(grep (/$case_ref->[$i]->{name}/,@{ $invalidcases{"noruncases"} })){
+                                delete_item_from_array($case_ref->[$i]->{name}, $invalidcases{"noruncases"});
+                            }
                             last;
                         }
                     }
@@ -914,8 +917,10 @@ sub load_case {
                             $$case_name_index_map_ref{$case_ref->[$i]->{name}}=$case_name_index_map_bak{$case_ref->[$i]->{name}};
                         }else{
                             delete $$case_name_index_map_ref{$case_ref->[$i]->{name}};
+                            if(! grep (/$case_ref->[$i]->{name}/,@{ $invalidcases{"noruncases"} })){
+                                push @{ $invalidcases{"noruncases"} }, $case_ref->[$i]->{name};
+                            }
                         }
-                        push @{ $invalidcases{"noruncases"} }, $case_ref->[$i]->{name};
                     }
                 }
                 $newcmdstart = 0;
@@ -935,7 +940,12 @@ sub load_case {
                     }
 
                     my $env_arch = "";
-                    $env_arch = $config{var}{ARCH} if(exists($config{var}{ARCH}));
+                    if(exists($config{var}{ARCH})){
+                        $env_arch = $config{var}{ARCH};
+                    }else{
+                        $env_arch =`uname -m`;
+                        chomp($env_arch);
+                    }
                     if($env_arch =~ /ppc/i && $env_arch !~ /le|el/i){
                         $env_arch="ppc";
                     }elsif($env_arch =~ /ppc/i && $env_arch =~ /le|el/i){
@@ -947,14 +957,19 @@ sub load_case {
                     my $valid     = 0;
                     if ($case_arch eq $env_arch) {
                         $valid = 1;
+                        if(grep (/$case_ref->[$i]->{name}/,@{ $invalidcases{"noruncases"} })){
+                            delete_item_from_array($case_ref->[$i]->{name}, $invalidcases{"noruncases"});
+                        }
                     }
                     unless ($valid) {
                         if(exists($case_name_index_map_bak{$case_ref->[$i]->{name}})){
                             $$case_name_index_map_ref{$case_ref->[$i]->{name}}=$case_name_index_map_bak{$case_ref->[$i]->{name}};
                         }else{
                             delete $$case_name_index_map_ref{$case_ref->[$i]->{name}};
+                            if(! grep (/$case_ref->[$i]->{name}/,@{ $invalidcases{"noruncases"} })){
+                                push @{ $invalidcases{"noruncases"} }, $case_ref->[$i]->{name};
+                            }
                         }
-                        push @{ $invalidcases{"noruncases"} }, $case_ref->[$i]->{name};
                     }
                 }
                 $newcmdstart = 0;
@@ -966,14 +981,19 @@ sub load_case {
                     my $valid     = 0;
                     if (exists ($config{var}{HCP}) && ($case_ref->[$i]->{hcp} =~ /$config{var}{HCP}/i)) {
                         $valid = 1;
+                        if(grep (/$case_ref->[$i]->{name}/,@{ $invalidcases{"noruncases"} })){
+                            delete_item_from_array($case_ref->[$i]->{name}, $invalidcases{"noruncases"});
+                        }
                     }
                     unless ($valid) {
                         if(exists($case_name_index_map_bak{$case_ref->[$i]->{name}})){
                             $$case_name_index_map_ref{$case_ref->[$i]->{name}}=$case_name_index_map_bak{$case_ref->[$i]->{name}};
                         }else{
                             delete $$case_name_index_map_ref{$case_ref->[$i]->{name}};
+                            if(! grep (/$case_ref->[$i]->{name}/,@{ $invalidcases{"noruncases"} })){
+                                push @{ $invalidcases{"noruncases"} }, $case_ref->[$i]->{name};
+                            }
                         }
-                        push @{ $invalidcases{"noruncases"} }, $case_ref->[$i]->{name};
                     }
                 }
                 $newcmdstart = 0;
@@ -1067,7 +1087,7 @@ sub load_case {
             $caseerror = 2;
         }
 
-        if ($invalidcases{"noruncases"}) {
+        if ($invalidcases{"noruncases"} && @{$invalidcases{"noruncases"}}) {
             log_this($running_log_fd, "Unsuitable current environment:", @{ $invalidcases{"noruncases"} });
             push @wrong_cases, @{ $invalidcases{"noruncases"} };
             $caseerror = 2;
@@ -1772,4 +1792,14 @@ sub update_miss_attr {
     unless($insert_flag){
         push @{$miss_attr_arr_ref}, "$case_name $org_str";
     }
+}
+sub delete_item_from_array{
+    my $item = shift;
+    my $array_ref = shift; 
+      
+    my @tmp_arr=();
+    foreach (@$array_ref){
+        push @tmp_arr, $_ unless($_ eq $item);
+    }
+    @$array_ref = @tmp_arr;
 }


### PR DESCRIPTION
``xcattest`` does not well handle the cases which have the same case name but with multiple implementation. When the case have more than one implementation, ``xcattest`` maybe filter it as ``no run``. It depending on the sequence of these implementation. 

This PR fix this problem, to ensure always load correct implementation.

Below is the output of fix in ``rhels7.4+ppc64le+kvm`` environment.

If we have cases like below:
```
start:test
os:sles
arch:ppc64
cmd:echo 'this is for sles anc ppc64'
check:rc==0
end

start:test
os:ubuntu
arch:ppc64le
cmd:echo 'this is for ubuntu and ppc64le'
check:rc==0
end

start:test
os:rhel
arch:ppc64le
hcp:openbmc
cmd:echo 'this is for rhel and ppc64le and openbmc'
check:rc==0
end

start:test
os:rhel
arch:ppc64le
hcp:kvm
cmd:echo 'this is for rhel and ppc64le and kvm'
check:rc==0
end

start:test1
os:aix
cmd:echo 'this is for aix'
check:rc==0
end
```
The ``xcattest`` conf file is
```
[root@c910f03c09k03 autotest]# cat a.conf
[System]
HCP=kvm
CN=c910f03c09k05
```
The UT result is 
```
[root@c910f03c09k03 autotest]# xcattest -f a.conf  -t test,bogus,reg_linux_diskless_installation_flat,test1
xCAT automated test started at Mon Nov 13 22:31:15 2017
******************************
loading Configure file
******************************
Varible:
    CN = c910f03c09k05
    HCP = kvm
******************************
Initialize xCAT test environment by definition in configure file
******************************
Detecting: OS = Linux
Detecting: ARCH = ppc64le
******************************
loading test cases
******************************
Miss attribute:
reg_linux_diskless_installation_flat miss attribute MN ISO
Unsuitable current environment:
test1
Not existed:
bogus
To run:
test
******************************
Start to run test cases
******************************
------START::test::Time:Mon Nov 13 22:31:15 2017------

RUN:echo 'this is for rhel and ppc64le and kvm' [Mon Nov 13 22:31:15 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
this is for rhel and ppc64le and kvm
CHECK:rc == 0	[Pass]

------END::test::Passed::Time:Mon Nov 13 22:31:15 2017 ::Duration::0 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished atMon Nov 13 22:31:15 2017
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20171113223115 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20171113223115 file for time consumption
``