### PR TITLE
Integrate the simulators to performance baseline testing

### DIFF
--- a/xCAT-test/autotest/testcase/performance/Dockerfile
+++ b/xCAT-test/autotest/testcase/performance/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:latest
+MAINTAINER binxu <bxuxa@cn.ibm.com>
+RUN apk add --update openssh bash wget && \
+ ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa && \
+ sed -i "s/UsePrivilegeSeparation.*/UsePrivilegeSeparation no/g" /etc/ssh/sshd_config && sed -i "s/UsePAM.*/UsePAM no/g" /etc/ssh/sshd_config && sed -i "s/PermitRootLogin.*/PermitRootLogin yes/g" /etc/ssh/sshd_config && sed -i "s/#AuthorizedKeysFile/AuthorizedKeysFile/g" /etc/ssh/sshd_config && \
+ echo "root:cluster" | chpasswd
+EXPOSE 22
+CMD ["/usr/sbin/sshd","-D", "-o PermitRootLogin=yes"]

--- a/xCAT-test/autotest/testcase/performance/case0
+++ b/xCAT-test/autotest/testcase/performance/case0
@@ -67,10 +67,10 @@ cmd:makehosts -n perftest
 check:rc==0
 
 #Make sure SN and CN is deployed sucessfully
-cmd:a=0;while ! `lsdef $$CN -i status|grep -E "booted|failed" >/dev/null`; do sleep 20;((a++));if [ $a -gt 300 ];then break;fi done
+cmd:a=0;while ! `lsdef $$CN -i status|grep -E "booted|failed" >/dev/null`; do sleep 20;((a++));if [ $a -gt 50 ];then break;fi done
 cmd:ping $$CN -c 3
 check:rc==0
-cmd:a=0;while ! `lsdef $$SN -i status|grep -E "booted|failed" >/dev/null`; do sleep 20;((a++));if [ $a -gt 300 ];then break;fi done
+cmd:a=0;while ! `lsdef $$SN -i status|grep -E "booted|failed" >/dev/null`; do sleep 20;((a++));if [ $a -gt 50 ];then break;fi done
 cmd:ping $$SN -c 3
 check:rc==0
 
@@ -85,7 +85,7 @@ check:rc==0
 # For openbmc simulation setup on SN
 cmd:PERF_SIM_NIC=$$SECONDNIC xcatperftest create fake[1-1000] openbmc
 check:rc==0
-cmd:scp /opt/xcat/share/xcat/tools/autotest/result/perf-openbmc-create.sh root@$$CN:/tmp/perf
+cmd:scp /opt/xcat/share/xcat/tools/autotest/result/perf-openbmc-create.sh root@$$SN:/tmp/perf
 check:rc==0
 cmd:xdsh $$SN PERF_SIM_NIC=$$SECONDNIC PERF_SIM_ADDR=192.169.251.252 bash /tmp/perf/simulatorctl.sh setup openbmc
 check:rc==0
@@ -148,7 +148,6 @@ cmd:makehosts -n perftest
 check:rc==0
 
 #Make sure CN is deployed sucessfully
-cmd:a=0;while ! `lsdef $$CN -i status|grep -E "booted|failed" >/dev/null`; do sleep 20;((a++));if [ $a -gt 300 ];then break;fi done
 cmd:ping $$CN -c 3
 check:rc==0
 

--- a/xCAT-test/autotest/testcase/performance/case0
+++ b/xCAT-test/autotest/testcase/performance/case0
@@ -26,9 +26,9 @@ cmd:df -T
 
 cmd:MINIISO=NUll;if [[ "__GETNODEATTR($$CN,os)__" =~ "ubuntu" ]] && [[ "__GETNODEATTR($$CN,arch)__" =~ "ppc64" ]];then mkdir /tmp/iso; mount -o loop $$MINIISO /tmp/iso ;  mkdir -p  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot; cp  /tmp/iso/install/initrd.gz  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot;umount /tmp/iso; rmdir /tmp/iso; fi
 check:rc==0
-cmd:chdef -t node -o $$CN servicenode= monserver=$$MN nfsserver=$$MN tftpserver=$$MN  xcatmaster=$$MN status=
+cmd:chdef -t node -o $$CN servicenode= monserver= nfsserver= tftpserver=  xcatmaster= status=
 check:rc==0
-cmd:chdef -t node -o $$SN servicenode= monserver=$$MN nfsserver=$$MN tftpserver=$$MN  xcatmaster=$$MN status=
+cmd:chdef -t node -o $$SN servicenode= monserver= nfsserver= tftpserver=  xcatmaster= status=
 check:rc==0
 cmd:makeconservercf
 check:rc==0

--- a/xCAT-test/autotest/testcase/performance/case0
+++ b/xCAT-test/autotest/testcase/performance/case0
@@ -8,11 +8,198 @@ cmd:xcatperftest 5000 /opt/xcat/share/xcat/tools/autotest/perfcmds.lst
 check:rc==0
 end
 
-start:perftest_5000_without_conf
-description:Default performance testing on 5000 fake nodes without extra configuraiton on MN
+start:UT_perftest_5000_MN_only
+description:Default performance testing on 5000 fake nodes without extra configuration on MN
 os:Linux
 cmd:which yum &>/dev/null && yum install -y bridge-utils || apt install -y bridge-utils
 check:rc==0
 cmd:xcatperftest 5000 /opt/xcat/share/xcat/tools/autotest/perfcmds.lst
 check:rc==0
+end
+
+start:perftest_5000_with_simulators
+description:Default performance testing on 5000 fake nodes
+os:Linux
+### From reg_linux_diskfull_installation_flat
+cmd:fdisk -l
+cmd:df -T
+
+cmd:MINIISO=NUll;if [[ "__GETNODEATTR($$CN,os)__" =~ "ubuntu" ]] && [[ "__GETNODEATTR($$CN,arch)__" =~ "ppc64" ]];then mkdir /tmp/iso; mount -o loop $$MINIISO /tmp/iso ;  mkdir -p  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot; cp  /tmp/iso/install/initrd.gz  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot;umount /tmp/iso; rmdir /tmp/iso; fi
+check:rc==0
+cmd:chdef -t node -o $$CN servicenode= monserver=$$MN nfsserver=$$MN tftpserver=$$MN  xcatmaster=$$MN status=
+check:rc==0
+cmd:chdef -t node -o $$SN servicenode= monserver=$$MN nfsserver=$$MN tftpserver=$$MN  xcatmaster=$$MN status=
+check:rc==0
+cmd:makeconservercf
+check:rc==0
+cmd:cat /etc/conserver.cf | grep $$CN
+check:output=~$$CN
+cmd:cat /etc/conserver.cf | grep $$SN
+check:output=~$$SN
+cmd:sleep 20
+cmd:makedhcp -n
+check:rc==0
+cmd:makedhcp -a
+check:rc==0
+cmd:sleep 10
+cmd:a=0;while true; do [ $a -eq 100 ] && exit 1;output=$(makedhcp -q $$CN);[ $? -ne 0 ] && exit 1;echo $output|grep $$CN 2>/dev/null && exit 0;a=$[$a+1];sleep 1;done
+check:rc==0
+cmd:a=0;while true; do [ $a -eq 100 ] && exit 1;output=$(makedhcp -q $$SN);[ $? -ne 0 ] && exit 1;echo $output|grep $$SN 2>/dev/null && exit 0;a=$[$a+1];sleep 1;done
+check:rc==0
+cmd:copycds $$ISO
+check:rc==0
+cmd:lsdef -l $$SN,$$CN
+check:rc==0
+cmd:rinstall $$SN,$$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+check:rc==0
+#check:output=~Provision node\(s\)\: $$CN
+#check:output=~Provision node\(s\)\: $$SN
+cmd:if [[ -f /var/lib/dhcp/db/dhcpd.leases ]]; then cat /var/lib/dhcp/db/dhcpd.leases; elif [[ -f /var/lib/dhcpd/dhcpd.leases ]];then cat /var/lib/dhcpd/dhcpd.leases;elif [[ -f /var/lib/dhcp/dhcpd.leases ]];then cat /var/lib/dhcp/dhcpd.leases; fi
+
+#After starting installation, began run fake nodes testing on MN
+cmd:which yum &>/dev/null && yum install -y bridge-utils || apt install -y bridge-utils
+cmd:FAKE_NETWORK_PRO=173.18 FAKE_NETWORK_BMC=192.169 xcatperftest 5000 /opt/xcat/share/xcat/tools/autotest/perfcmds.lst
+check:rc==0
+
+cmd:PERF_CREATE_ONLY=y FAKE_NETWORK_PRO=173.18 FAKE_NETWORK_BMC=192.169 xcatperftest 5000 /opt/xcat/share/xcat/tools/autotest/perfcmds.lst
+check:rc==0
+cmd:makehosts -n perftest
+check:rc==0
+
+#Make sure SN and CN is deployed sucessfully
+cmd:a=0;while ! `lsdef $$CN -i status|grep -E "booted|failed" >/dev/null`; do sleep 20;((a++));if [ $a -gt 300 ];then break;fi done
+cmd:ping $$CN -c 3
+check:rc==0
+cmd:a=0;while ! `lsdef $$SN -i status|grep -E "booted|failed" >/dev/null`; do sleep 20;((a++));if [ $a -gt 300 ];then break;fi done
+cmd:ping $$SN -c 3
+check:rc==0
+
+#Setup Simulater environment on SN/CN
+cmd:xdsh $$SN,$$CN "rm -rf /tmp/perf && mkdir -p /tmp/perf"
+check:rc==0
+cmd:scp /opt/xcat/share/xcat/tools/autotest/testcase/performance/* root@$$CN:/tmp/perf
+check:rc==0
+cmd:scp /opt/xcat/share/xcat/tools/autotest/testcase/performance/* root@$$SN:/tmp/perf
+check:rc==0
+
+# For openbmc simulation setup on SN
+cmd:PERF_SIM_NIC=$$SECONDNIC xcatperftest create fake[1-1000] openbmc
+check:rc==0
+cmd:scp /opt/xcat/share/xcat/tools/autotest/result/perf-openbmc-create.sh root@$$CN:/tmp/perf
+check:rc==0
+cmd:xdsh $$SN PERF_SIM_NIC=$$SECONDNIC PERF_SIM_ADDR=192.169.251.252 bash /tmp/perf/simulatorctl.sh setup openbmc
+check:rc==0
+cmd:PERF_SIM_NIC=$$SECONDNIC PERF_SIM_ADDR=192.169.251.251 bash /opt/xcat/share/xcat/tools/autotest/testcase/performance/simulatorctl.sh setup openbmc --mn
+check:rc==0
+cmd:ping 192.169.251.252 -c 3
+check:rc==0
+
+# Testing for HW remote control CLIs
+cmd:PERF_NOCREATE=1 xcatperftest 5000 /opt/xcat/share/xcat/tools/autotest/testcase/performance/hwcmd.lst
+check:rc==0
+cmd:xdsh $$SN PERF_SIM_NIC=$$SECONDNIC PERF_SIM_ADDR=192.169.251.252 bash /tmp/perf/simulatorctl.sh clean openbmc
+check:rc==0
+cmd:PERF_SIM_NIC=$$SECONDNIC PERF_SIM_ADDR=192.169.251.251 bash /opt/xcat/share/xcat/tools/autotest/testcase/performance/simulatorctl.sh clean openbmc --mn
+check:rc==0
+
+# For container simulation setup on SN/CN
+cmd:xcatperftest create fake[1-100] docker
+check:rc==0
+cmd:scp /opt/xcat/share/xcat/tools/autotest/result/perf-docker-create.sh root@$$CN:/tmp/perf
+check:rc==0
+
+cmd:xcatperftest create fake[501-600] docker
+check:rc==0
+cmd:scp /opt/xcat/share/xcat/tools/autotest/result/perf-docker-create.sh root@$$SN:/tmp/perf
+check:rc==0
+
+cmd:xdsh $$CN PERF_SIM_NIC=$$SECONDNIC PERF_SIM_ADDR=173.18.251.252 bash /tmp/perf/simulatorctl.sh setup docker
+check:rc==0
+
+cmd:xdsh $$SN PERF_SIM_NIC=$$SECONDNIC PERF_SIM_ADDR=173.18.251.253 bash /tmp/perf/simulatorctl.sh setup docker
+check:rc==0
+
+cmd:PERF_SIM_NIC=$$SECONDNIC PERF_SIM_ADDR=173.18.251.251 bash /opt/xcat/share/xcat/tools/autotest/testcase/performance/simulatorctl.sh setup docker --mn
+check:rc==0
+cmd:ping 173.18.251.252 -c 3
+check:rc==0
+
+# Testing for updatenode, xdsh, nodestat, pping, etc
+cmd:PERF_NOCREATE=1 xcatperftest 5000 /opt/xcat/share/xcat/tools/autotest/testcase/performance/nodecmd.lst
+check:rc==0
+
+cmd:xdsh $$CN,$$SN PERF_SIM_NIC=$$SECONDNIC bash /tmp/perf/simulatorctl.sh clean docker
+check:rc==0
+
+cmd:PERF_SIM_NIC=$$SECONDNIC PERF_SIM_ADDR=173.18.251.251 bash /opt/xcat/share/xcat/tools/autotest/testcase/performance/simulatorctl.sh clean docker --mn
+check:rc==0
+
+end
+
+
+start:UT_perftest_1000_with_simulators
+description: UT for performance testing with simulators on an existing environment with one compute node.
+os:Linux
+
+# Create fake nodes
+cmd:PERF_CREATE_ONLY=y FAKE_NETWORK_PRO=173.18 FAKE_NETWORK_BMC=192.169 xcatperftest 1000 /opt/xcat/share/xcat/tools/autotest/perfcmds.lst
+check:rc==0
+cmd:makehosts -n perftest
+check:rc==0
+
+#Make sure CN is deployed sucessfully
+cmd:a=0;while ! `lsdef $$CN -i status|grep -E "booted|failed" >/dev/null`; do sleep 20;((a++));if [ $a -gt 300 ];then break;fi done
+cmd:ping $$CN -c 3
+check:rc==0
+
+#Setup Simulater environment
+cmd:xdsh $$CN "rm -rf /tmp/perf && mkdir -p /tmp/perf"
+check:rc==0
+cmd:scp /opt/xcat/share/xcat/tools/autotest/testcase/performance/* root@$$CN:/tmp/perf
+check:rc==0
+
+# For openbmc simulation setup
+cmd:xcatperftest create fake[1-1000] openbmc
+check:rc==0
+cmd:scp /opt/xcat/share/xcat/tools/autotest/result/perf-openbmc-create.sh root@$$CN:/tmp/perf
+check:rc==0
+cmd:xdsh $$CN PERF_SIM_ADDR=192.169.251.252 bash /tmp/perf/simulatorctl.sh setup openbmc
+check:rc==0
+cmd:PERF_SIM_ADDR=192.169.251.251 bash /opt/xcat/share/xcat/tools/autotest/testcase/performance/simulatorctl.sh setup openbmc --mn
+check:rc==0
+cmd:ping 192.169.251.252 -c 3
+check:rc==0
+
+# Testing for HW remote control CLIs
+cmd:PERF_NOCREATE=1 xcatperftest 1000 /opt/xcat/share/xcat/tools/autotest/testcase/performance/hwcmd.lst
+check:rc==0
+cmd:xdsh $$CN PERF_SIM_ADDR=192.169.251.252 bash /tmp/perf/simulatorctl.sh clean openbmc
+check:rc==0
+cmd:PERF_SIM_ADDR=192.169.251.251 bash /opt/xcat/share/xcat/tools/autotest/testcase/performance/simulatorctl.sh clean openbmc --mn
+check:rc==0
+
+# For container simulation setup
+cmd:xcatperftest create fake[1-50] docker
+check:rc==0
+cmd:scp /opt/xcat/share/xcat/tools/autotest/result/perf-docker-create.sh root@$$CN:/tmp/perf
+check:rc==0
+
+cmd:xdsh $$CN PERF_SIM_ADDR=173.18.251.252 bash /tmp/perf/simulatorctl.sh setup docker
+check:rc==0
+
+cmd:PERF_SIM_ADDR=173.18.251.251 bash /opt/xcat/share/xcat/tools/autotest/testcase/performance/simulatorctl.sh setup docker --mn
+check:rc==0
+cmd:ping 173.18.251.252 -c 3
+check:rc==0
+
+# Testing for updatenode, xdsh, nodestat, pping, etc
+cmd:PERF_NOCREATE=1 xcatperftest 1000 /opt/xcat/share/xcat/tools/autotest/testcase/performance/nodecmd.lst
+check:rc==0
+
+cmd:xdsh $$CN bash /tmp/perf/simulatorctl.sh clean docker
+check:rc==0
+
+cmd:PERF_SIM_ADDR=173.18.251.251 bash /opt/xcat/share/xcat/tools/autotest/testcase/performance/simulatorctl.sh clean docker --mn
+check:rc==0
+
 end

--- a/xCAT-test/autotest/testcase/performance/hwcmd.lst
+++ b/xCAT-test/autotest/testcase/performance/hwcmd.lst
@@ -1,0 +1,5 @@
+#SERIES# 1,50,100,250,500,1000
+rsetboot #NODES# default
+rpower #NODES# stat
+rinv #NODES# all
+rflash #NODES# -l

--- a/xCAT-test/autotest/testcase/performance/nodecmd.lst
+++ b/xCAT-test/autotest/testcase/performance/nodecmd.lst
@@ -1,0 +1,4 @@
+#SERIES# 1,50,100,250,500,1000
+nodestat #NODES#
+pping #NODES#
+xdsh #NODES# true

--- a/xCAT-test/autotest/testcase/performance/simulatorctl.sh
+++ b/xCAT-test/autotest/testcase/performance/simulatorctl.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+# IBM(c) 2017 EPL license http://www.eclipse.org/legal/epl-v10.html
+#(C)IBM Corp
+#
+if [ -z $LC_ALL ]; then
+  export LC_ALL=C
+fi
+# Give a simple usage
+if [ -z "$1" ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  echo "Setup, run and clean the simulators for performance testing..."
+  echo "     $0 run <simulator>"
+  exit
+fi
+
+if [ -z $PERF_SIM_ADDR ]; then
+  PERF_SIM_ADDR='192.168.251.251'
+fi
+
+if [ -z $PERF_SIM_MASK ]; then
+  PERF_SIM_MASK='255.255.0.0'
+fi
+
+# Optional, The NIC used by simulator.
+if [ -z $PERF_SIM_NIC ]; then
+  PERF_SIM_NIC='eth1'
+fi
+
+#IBM_POWER_TOOLS_URL='http://public.dhe.ibm.com/software/server/POWER/Linux/yum/OSS/RHEL/7/ppc64le'
+OPEN_POWER_TOOLS_URL='http://ftp.unicamp.br/pub/ppc64el/rhel/7/docker-ppc64el'
+arch=`arch`
+driver="$2"
+if [ "$driver" != "docker" ] && [ "$driver" != "openbmc" ]; then
+    echo "Error: not supported simulator type '$driver'."
+    exit -1
+fi
+
+setup_docker()
+{
+    if [ ! -z $1 ]; then # run on MN with --mn
+        echo "Prepare on management node side..."
+        prefix=$(ipcalc -p $PERF_SIM_ADDR $PERF_SIM_MASK|awk -F= '{print $2}')
+        ip addr add $PERF_SIM_ADDR/$prefix dev $PERF_SIM_NIC #label $PERF_SIM_NIC:100
+        return
+    fi
+
+    if [[ $arch =~ 'ppc64' ]]; then
+        # The URL is from OpenPOWER Linux Community
+        echo "[docker] name=Docker baseurl=$OPEN_POWER_TOOLS_URL enabled=1 gpgcheck=0" | \
+        awk 'BEGIN{RS=" ";ORS="\n";}{print $0}' > /etc/yum.repos.d/docker.repo
+        yum repolist
+        yum install -y docker-ce bridge-utils initscripts
+        service docker start
+        sleep 5
+
+    else
+        echo "Error: not supported platform."
+    fi
+
+    # Create the bridge network for testing, and add the physical interface inside
+    #docker network ls|grep perf-net > /dev/null && docker network rm perf-net
+    netaddr=$(ipcalc -n $PERF_SIM_ADDR $PERF_SIM_MASK|awk -F= '{print $2}')
+    prefix=$(ipcalc -p $PERF_SIM_ADDR $PERF_SIM_MASK|awk -F= '{print $2}')
+    docker network create --gateway $PERF_SIM_ADDR --subnet $netaddr/$prefix perf-net
+    bruuid=$(docker network ls | awk '/perf-net/ {print $1}')
+    brctl addif br-$bruuid $PERF_SIM_NIC
+    brctl show br-$bruuid
+
+    # Prepare the docker image
+    [ -f /tmp/perf/Dockerfile ] && rootpath=/tmp/perf || rootpath=/opt/xcat/share/xcat/tools/autotest/testcase/performance
+    docker build -t perf-alpine-ssh $rootpath
+    docker images
+
+    # run the containers
+    run_docker
+}
+
+run_docker()
+{
+    echo "Run docker simulator for node range..."
+    script=/tmp/perf/perf-docker-create.sh
+    if [ -f $script ]; then
+       sh -x $script
+       return
+    fi
+
+    script=/opt/xcat/share/xcat/tools/autotest/result/perf-docker-create.sh
+    if [ -f $script ]; then
+       sh -x $script
+       return
+    fi
+    echo "WARN: Not found the script for run docker simulator..."
+}
+
+clean_docker()
+{
+    if [ ! -z $1 ]; then
+        echo "Cleanup on management node side..."
+        prefix=$(ipcalc -p $PERF_SIM_ADDR $PERF_SIM_MASK|awk -F= '{print $2}')
+        ip addr del $PERF_SIM_ADDR/$prefix dev $PERF_SIM_NIC #label $PERF_SIM_NIC:100
+        return
+    fi
+
+    ids=$(docker ps -a -q)
+    [ "x" = "x$ids" ] || docker rm -f $ids
+    docker network ls| grep perf-net && docker network rm perf-net
+    brctl show
+}
+
+setup_openbmc()
+{
+    ip addr flush dev $PERF_SIM_NIC
+    prefix=$(ipcalc -p $PERF_SIM_ADDR $PERF_SIM_MASK|awk -F= '{print $2}')
+    #ip addr flush dev $PERF_SIM_NIC
+    ip addr add $PERF_SIM_ADDR/$prefix dev $PERF_SIM_NIC #label $PERF_SIM_NIC:100
+
+    if [ ! -z $1 ]; then
+        echo "Prepare on management node side..."
+        return
+    fi
+
+    which yum &>/dev/null && yum install -y git || apt install -y git
+    mkdir -p /tmp/perf && cd /tmp/perf && git clone https://github.com/xuweibj/openbmc_simulator
+    chmod +x /tmp/perf/openbmc_simulator/simulator
+    run_openbmc
+}
+
+run_openbmc()
+{
+    echo "Run openbmc simulator for node range..."
+    script=/tmp/perf/perf-openbmc-create.sh
+    if [ -f $script ]; then
+       sh $script setup
+       return
+    fi
+
+    script=/opt/xcat/share/xcat/tools/autotest/result/perf-openbmc-create.sh
+    if [ -f $script ]; then
+       sh $script setup
+       return
+    fi
+    echo "WARN: Not found the script for run openbmc simulator..."
+}
+
+clean_openbmc()
+{
+    prefix=$(ipcalc -p $PERF_SIM_ADDR $PERF_SIM_MASK|awk -F= '{print $2}')
+    if [ ! -z $1 ]; then
+        echo "Cleanup on management node side..."
+        ip addr del $PERF_SIM_ADDR/$prefix dev $PERF_SIM_NIC #label $PERF_SIM_NIC:100
+        return
+    fi
+
+    echo "Cleanup openbmc simulator for node range..."
+
+    script=/tmp/perf/perf-openbmc-create.sh
+    if [ -f $script ]; then
+       sh $script clean
+       ip addr del $PERF_SIM_ADDR/$prefix dev $PERF_SIM_NIC #label $PERF_SIM_NIC:100
+       return
+    fi
+
+    script=/opt/xcat/share/xcat/tools/autotest/result/perf-openbmc-create.sh
+    if [ -f $script ]; then
+       sh $script clean
+       ip addr del $PERF_SIM_ADDR/$prefix dev $PERF_SIM_NIC #label $PERF_SIM_NIC:100
+       return
+    fi
+    echo "WARN: Not found the script for run openbmc simulator..."
+}
+
+
+# Mail program
+if [ "$1" = "setup" ]; then
+    eval "setup_$driver $3"
+elif [ "$1" = "clean" ]; then
+    eval "clean_$driver $3"
+else
+    echo "Error: not supported action."
+    exit -1
+fi

--- a/xCAT-test/autotest/testcase/performance/simulatorctl.sh
+++ b/xCAT-test/autotest/testcase/performance/simulatorctl.sh
@@ -48,6 +48,8 @@ setup_docker()
         echo "[docker] name=Docker baseurl=$OPEN_POWER_TOOLS_URL enabled=1 gpgcheck=0" | \
         awk 'BEGIN{RS=" ";ORS="\n";}{print $0}' > /etc/yum.repos.d/docker.repo
         yum repolist
+        #workaround as the public repo has issue to install container-selinux
+        yum install http://ftp.unicamp.br/pub/ppc64el/rhel/7/docker-ppc64el/container-selinux-2.9-4.el7.noarch.rpm
         yum install -y docker-ce bridge-utils initscripts
         service docker start
         sleep 5

--- a/xCAT-test/bin/xcatperftest
+++ b/xCAT-test/bin/xcatperftest
@@ -15,7 +15,7 @@
 #       $prog <total> [command-list-file]
 #
 ###################################################################
-
+#set -x
 if [ -z $LC_ALL ]; then
   export LC_ALL=C
 fi
@@ -38,12 +38,16 @@ if [ -z "$1" ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
   echo " "
   echo "Generate a bunch of fake nodes and Run the performance testing for the commands listed in file:"
   echo "        [PERF_DRYRUN=y] [PERF_NOCREATE=y] $0 <total number of fake nodes> [command-list-file]"
+  echo " "
+  echo "Generate the script for creating the fake simulators for the given node range:"
+  echo "        $0 create <noderange> [ docker | openbmc ]"
   exit
 fi
 
-PERF_RUN_WITH_ENV=0
 if [ "$1" = "run" ]; then
   PERF_RUN_WITH_ENV=1
+elif [ "$1" = "create" ]; then
+  PERF_RUN_WITH_SIM=1
 else
   isNumber $1
   if [ ! $? -eq 0 ]; then
@@ -70,7 +74,7 @@ preChecking()
   echo $val | sed s/,$//
 }
 
-if [ "$PERF_RUN_WITH_ENV" = "0" ] && [ -z $PERF_DRYRUN ]; then
+if [ -z $PERF_RUN_WITH_ENV ] && [ -z $PERF_RUN_WITH_SIM ] && [ -z $PERF_DRYRUN ]; then
   pass=$(preChecking)
   if [ ! -z "$pass" ]; then
     echo "Error: Missing required tools: $pass"
@@ -80,7 +84,9 @@ fi
 
 # If the command list file is not specified, the tool will only create the stanz file for fake nodes.
 # If it is specified but not exists, the tool will exit with error.
-if [ ! -z $2 ]; then
+if [ "$PERF_RUN_WITH_SIM" = "1" ]; then
+  [ -z $2 ] && echo "ERROR: Not specify the node range." && exit -1
+elif [ ! -z $2 ]; then
   if [ -f $2 ]; then
     RUN_CMD_LIST=$2
   else
@@ -147,6 +153,11 @@ if [ -z $PERF_NODETEMPL ]; then
   PERF_NODETEMPL="`arch`-template"
 fi
 
+# Optional, The NIC used by simulator.
+if [ -z $PERF_SIM_NIC ]; then
+  PERF_SIM_NIC='eth1'
+fi
+
 # Optional, The delimiter which is used for CSV.
 # By default, it is comma, but it could be changed when you set environment variable `PERF_CSV_CHAR`
 if [ -z $PERF_CSV_CHAR ]; then
@@ -178,13 +189,17 @@ genStanz()
   else
     echo -n .
   fi
-
+  mgt='ipmi'
+  if [[ `arch` =~ 'ppc64' ]]; then
+    mgt='openbmc'
+  fi
   sed -e '/Object name:/c \'"$1"':\n    objtype=node' \
       -e '/ip=/c \    ip='"$3"'' \
       -e '/mac=/c \    mac='"$2"'' \
       -e '/bmc=/c \    bmc='"$4"'' \
-      -e '/bmcusername=/c \    bmcusername=fake' \
-      -e '/bmcpassword=/c \    bmcpassword=fake' \
+      -e '/mgt=/c \    mgt='"$mgt"'' \
+      -e '/bmcusername=/c \    bmcusername=root' \
+      -e '/bmcpassword=/c \    bmcpassword=0penBmc' \
       -e '/groups=/c \    groups=all,'"$FAKE_NODE_GROUP"'' \
       -e '/postscripts=/c \    postscripts=mypostboot' \
       -e '/postbootscripts=/c \    postbootscripts=mypostboot' \
@@ -203,11 +218,11 @@ fakeNode()
 # Create a fake xCAT network definition
 fakeNetwork()
 {
-    lsdef -t network -o net-$FAKE_NODE_PREFIX > /dev/null 2>&1
+    lsdef -t network -o perf-net-$FAKE_NODE_PREFIX > /dev/null 2>&1
     if [ 0 != $? ]; then
-      mkdef -t network net-$FAKE_NODE_PREFIX net=$FAKE_NETWORK_PRO.0.0 mask=$FAKE_NETWORK_MASK > /dev/null
+      mkdef -t network perf-net-$FAKE_NODE_PREFIX net=$FAKE_NETWORK_PRO.0.0 mask=$FAKE_NETWORK_MASK > /dev/null
     else
-      chdef -t network -o net-$FAKE_NODE_PREFIX net=$FAKE_NETWORK_PRO.0.0 mask=$FAKE_NETWORK_MASK > /dev/null
+      chdef -t network -o perf-net-$FAKE_NODE_PREFIX net=$FAKE_NETWORK_PRO.0.0 mask=$FAKE_NETWORK_MASK > /dev/null
     fi
 }
 
@@ -218,7 +233,9 @@ fakeInterface()
   if [ -z "$2" ]; then
     [  -z "$result" ] && brctl addbr $1
     ifconfig $1 $FAKE_NETWORK_PRO.251.254 netmask $FAKE_NETWORK_MASK || echo "$1 is not configured successfully"
+    ifconfig $1:0 $FAKE_NETWORK_BMC.251.254 netmask $FAKE_NETWORK_MASK || echo "$1:0 is not configured successfully"
   elif [ ! -z "$result" ]; then
+    ifconfig $1:0 0.0.0.0
     ifconfig $1 down
     brctl delbr $1 || echo "$1 is not removed successfully, you may need to clean up manually."
   fi
@@ -371,6 +388,37 @@ if [ "$PERF_RUN_WITH_ENV" = "1" ]; then
   exit 0
 fi
 
+if [ "$PERF_RUN_WITH_SIM" = "1" ]; then
+  simmode="docker"
+  [ ! -z $3 ] && simmode=$3
+  echo "Generate the $simmode simulators for $2 ..."
+
+  PERFORMANCE_SCRIPT=$PERFORMANCE_DIR/perf-$simmode-create.sh
+  echo "#!/bin/bash" > $PERFORMANCE_SCRIPT
+
+  if [ "$simmode" = "docker" ]; then
+    lsdef $2 -i ip -c | \
+    awk -F '=' '{ print substr($1, 0 ,index($1,":")-1),$2}' | \
+    while read name ip; \
+    do \
+      echo "docker run -itd --rm --name $name --net perf-net --ip $ip --hostname $name -v /root/.ssh:/root/.ssh perf-alpine-ssh" >> $PERFORMANCE_SCRIPT; \
+    done
+  elif [ "$simmode" = "openbmc" ]; then
+    options="-d random -t 10"
+    bmcips=`lsdef $2 -i bmc -c | awk -F '=' '{printf "%s ", $2}'`
+    echo "if [ \"\$1\" = \"setup\" ]; then /tmp/perf/openbmc_simulator/simulator -n $PERF_SIM_NIC $options -r $bmcips; fi" >> $PERFORMANCE_SCRIPT
+    echo "if [ \"\$1\" = \"clean\" ]; then /tmp/perf/openbmc_simulator/simulator -c -n $PERF_SIM_NIC -r $bmcips; fi" >> $PERFORMANCE_SCRIPT
+  else
+    echo "Not supported simulator type: $simmode"
+    rm -f $PERFORMANCE_SCRIPT
+    exit -1
+  fi
+
+  echo
+  echo "Done. Check the performance script in $PERFORMANCE_SCRIPT"
+  exit 0
+fi
+
 #Get available OS image, it will be used for nodeset if possible
 osimage=$(getOSimage)
 if [ -z "$osimage" ]; then
@@ -411,6 +459,8 @@ if [ -z $PERF_NOCREATE ]; then
   #create fake network for makedns, makedhcp etc...
   fakeNetwork
   execCmd "cat $PERFORMANCE_STANZ | mkdef -z -f" "$FAKE_NODE_TOTAL"
+
+  [ -z $PERF_CREATE_ONLY ] || exit 0
   # fake interface is required for topology with service nodes as it will determine if then Mn/Sn are
   # in the same subnet with CNs
   fakeInterface $FAKE_NETWORK_INTF


### PR DESCRIPTION
It is for #4206 and cover below:

1, Using docker container to test updatenode/pping/nodestat/xdsh...
2, And also openbmc simulators to test HW related CLI
3, Implement the xcattest case and UT case for performance testing