### PR TITLE
openbmc rflash reduce output and msg enhancements

### DIFF
--- a/xCAT-test/autotest/testcase/UT_openbmc/rflash_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rflash_cases0
@@ -23,7 +23,7 @@ os:Linux
 hcp:openbmc
 cmd: rflash $$CN -a 123 -d 123
 check:rc==1
-check:output=~Error: Multiple options specified is not supported
+check:output=~Error: Multiple options are not supported
 end 
 
 start:rflash_invalid_id 


### PR DESCRIPTION
Implements suggestions in #4287 

Display fewer output messages by default from openbmc `rflash` command.
Instead introduce `-V` flag for more verbose output.
Also fix a wording in a few messages.

New output as follows:

* Upload file only with -V:
```
[root@briggs01 autotest]# rflash mid05tor12cn13,mid05tor12cn15 -u /mnt/xcat/iso/openbmc/910.1742.20171027m_1742C/witherspoon.pnor.squashfs.tar -V
mid05tor12cn13: [briggs01]: Uploading /mnt/xcat/iso/openbmc/910.1742.20171027m_1742C/witherspoon.pnor.squashfs.tar ...
mid05tor12cn15: [briggs01]: Uploading /mnt/xcat/iso/openbmc/910.1742.20171027m_1742C/witherspoon.pnor.squashfs.tar ...
mid05tor12cn13: [briggs01]: Firmware upload successful. Use -l option to list.
mid05tor12cn15: [briggs01]: Firmware upload successful. Use -l option to list.
[root@briggs01 autotest]#
```

* Upload file only without -V:
```
[root@briggs01 autotest]# rflash mid05tor12cn13,mid05tor12cn15 -u /mnt/xcat/iso/openbmc/910.1742.20171027m_1742C/witherspoon.pnor.squashfs.tar
mid05tor12cn13: Firmware upload successful. Use -l option to list.
mid05tor12cn15: Firmware upload successful. Use -l option to list.
[root@briggs01 autotest]#
```

* Upload and activate file with -V:
```
[root@briggs01 autotest]# rflash mid05tor12cn13,mid05tor12cn15 -a /mnt/xcat/iso/openbmc/910.1742.20171027m_1742C/witherspoon.pnor.squashfs.tar -V
mid05tor12cn13: [briggs01]: Uploading /mnt/xcat/iso/openbmc/910.1742.20171027m_1742C/witherspoon.pnor.squashfs.tar ...
mid05tor12cn15: [briggs01]: Uploading /mnt/xcat/iso/openbmc/910.1742.20171027m_1742C/witherspoon.pnor.squashfs.tar ...
mid05tor12cn13: [briggs01]: Firmware upload successful. Attempting to activate firmware: IBM-witherspoon-ibm-OP9_v1.19_1.112 (ID: 30ee1c48)
mid05tor12cn13: [briggs01]: rflash started, please wait...
mid05tor12cn13: [briggs01]: Activating firmware . . . 10%
mid05tor12cn15: [briggs01]: Firmware upload successful. Attempting to activate firmware: IBM-witherspoon-ibm-OP9_v1.19_1.112 (ID: 30ee1c48)
mid05tor12cn15: [briggs01]: rflash started, please wait...
mid05tor12cn15: [briggs01]: Activating firmware . . . 10%
mid05tor12cn13: [briggs01]: Activating firmware . . . 10%
mid05tor12cn15: [briggs01]: Activating firmware . . . 10%
mid05tor12cn13: [briggs01]: Activating firmware . . . 10%
mid05tor12cn15: [briggs01]: Activating firmware . . . 10%
mid05tor12cn13: [briggs01]: Firmware activation successful.
mid05tor12cn15: [briggs01]: Firmware activation successful.
[root@briggs01 autotest]#
```

* Upload and activate file without -V:
```
[root@briggs01 autotest]# rflash mid05tor12cn13,mid05tor12cn15 -a /mnt/xcat/iso/openbmc/910.1742.20171027m_1742C/witherspoon.pnor.squashfs.tar
mid05tor12cn13: Firmware upload successful. Attempting to activate firmware: IBM-witherspoon-ibm-OP9_v1.19_1.112 (ID: 30ee1c48)
mid05tor12cn15: Firmware upload successful. Attempting to activate firmware: IBM-witherspoon-ibm-OP9_v1.19_1.112 (ID: 30ee1c48)
mid05tor12cn13: Firmware activation successful.
mid05tor12cn15: Firmware activation successful.
[root@briggs01 autotest]#
```