### PR TITLE
[openbmc]Do not send exec command to bmc console if bmc is not reachable

### DIFF
--- a/xCAT-server/lib/perl/xCAT/xcatd.pm
+++ b/xCAT-server/lib/perl/xCAT/xcatd.pm
@@ -192,7 +192,7 @@ sub validate {
                 $status = "Denied";
                 $rc     = 0;
             }
-            if (($request->{command}->[0] ne "getdestiny") && ($request->{command}->[0] ne "getbladecons") && ($request->{command}->[0] ne "getipmicons")) {
+            if (($request->{command}->[0] ne "getdestiny") && ($request->{command}->[0] ne "getbladecons") && ($request->{command}->[0] ne "getipmicons") && ($request->{command}->[0] ne "getopenbmccons")) {
 
                 # set username authenticated to run command
                 # if from Trusted host, use input username,  else set from creds

--- a/xCAT-server/share/xcat/cons/openbmc
+++ b/xCAT-server/share/xcat/cons/openbmc
@@ -91,6 +91,19 @@ if ($ENV{SSHCONSOLEPORT}) {
     $sshport= $ENV{SSHCONSOLEPORT};
 }
 
+#check if sshport is up 
+my $nmap_output = `/usr/bin/nmap $bmcip -p $sshport -Pn`;
+while ($nmap_output =~ /0 hosts up/) {
+    $sleepint = 10 + int(rand(20));
+    print "Failure to reach openbmc, retrying in $sleepint seconds (Hit Ctrl-E,c,o to skip)\n";
+    sleep ($sleepint);
+    acquire_lock();
+    sleep(0.1);
+    release_lock();
+    $nmap_output = `/usr/bin/nmap $bmcip -p $sshport -Pn`;
+}
+
+
 # To automatically connect to the console without the need to send over the ssh keys, 
 # ensure sshpass is installed on the Management and/or Service Nodes.
 print "Unable to open console.  If BMC pings, ensure sshpass is installed or ssh keys have been configured on the BMC.\n";

--- a/xCAT-server/share/xcat/cons/openbmc
+++ b/xCAT-server/share/xcat/cons/openbmc
@@ -95,7 +95,7 @@ if ($ENV{SSHCONSOLEPORT}) {
 my $nmap_output = `/usr/bin/nmap $bmcip -p $sshport -Pn`;
 while ($nmap_output =~ /0 hosts up/) {
     $sleepint = 10 + int(rand(20));
-    print "Failure to reach openbmc, retrying in $sleepint seconds (Hit Ctrl-E,c,o to skip)\n";
+    print "No BMC active at IP $bmcip, retrying in $sleepint seconds (Hit Ctrl-E,c,o to skip)\n";
     sleep ($sleepint);
     acquire_lock();
     sleep(0.1);


### PR DESCRIPTION
If bmc is not reachable,  will not send exec command to connect to bmc console.
```
# rcons mid05tor12cn04
[Enter `^Ec?' for help]
Acquiring startup lock...done
Failure to reach openbmc, retrying in 16 seconds (Hit Ctrl-E,c,o to skip)
Acquiring startup lock...done
Failure to reach openbmc, retrying in 15 seconds (Hit Ctrl-E,c,o to skip)
Acquiring startup lock...done
Failure to reach openbmc, retrying in 11 seconds (Hit Ctrl-E,c,o to skip)

````
Add getopenbmccons xcatd.pm to reduce the log (similar as did for getipmicons) 