### PR TITLE
Delete bmcdiscover_check_paswd,bmcdiscover_check_passwd_wrong,bmcdiscover_get_ipsource from bundles

### DIFF
--- a/xCAT-test/autotest/bundle/rhels6.7_ppc64.bundle
+++ b/xCAT-test/autotest/bundle/rhels6.7_ppc64.bundle
@@ -270,9 +270,6 @@ updatenode_postscripts_loginfo
 bmcdiscover_h
 bmcdiscover_nmap_range
 bmcdiscover_v
-bmcdiscover_check_paswd
-bmcdiscover_check_passwd_wrong
-bmcdiscover_get_ipsource
 bmcdiscover_range_w
 bmcdiscover_range_z
 xcatd_start

--- a/xCAT-test/autotest/bundle/rhels6.8_ppc64.bundle
+++ b/xCAT-test/autotest/bundle/rhels6.8_ppc64.bundle
@@ -279,9 +279,6 @@ updatenode_postscripts_loginfo
 bmcdiscover_h
 bmcdiscover_nmap_range
 bmcdiscover_v
-bmcdiscover_check_paswd
-bmcdiscover_check_passwd_wrong
-bmcdiscover_get_ipsource
 bmcdiscover_range_w
 bmcdiscover_range_z
 xcatd_start

--- a/xCAT-test/autotest/bundle/rhels6.9_ppc64.bundle
+++ b/xCAT-test/autotest/bundle/rhels6.9_ppc64.bundle
@@ -286,9 +286,6 @@ updatenode_postscripts_loginfo
 bmcdiscover_h
 bmcdiscover_nmap_range
 bmcdiscover_v
-bmcdiscover_check_paswd
-bmcdiscover_check_passwd_wrong
-bmcdiscover_get_ipsource
 bmcdiscover_range_w
 bmcdiscover_range_z
 xcatd_start

--- a/xCAT-test/autotest/bundle/rhels7.2_ppc64.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.2_ppc64.bundle
@@ -283,9 +283,6 @@ updatenode_postscripts_loginfo
 bmcdiscover_h
 bmcdiscover_nmap_range
 bmcdiscover_v
-bmcdiscover_check_paswd
-bmcdiscover_check_passwd_wrong
-bmcdiscover_get_ipsource
 bmcdiscover_range_w
 bmcdiscover_range_z
 xcatd_start

--- a/xCAT-test/autotest/bundle/rhels7.2_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.2_ppc64le.bundle
@@ -276,9 +276,6 @@ updatenode_postscripts_loginfo
 bmcdiscover_h
 bmcdiscover_nmap_range
 bmcdiscover_v
-bmcdiscover_check_paswd
-bmcdiscover_check_passwd_wrong
-bmcdiscover_get_ipsource
 bmcdiscover_range_w
 bmcdiscover_range_z
 xcatd_start

--- a/xCAT-test/autotest/bundle/rhels7.3_ppc64.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.3_ppc64.bundle
@@ -285,9 +285,6 @@ updatenode_postscripts_loginfo
 bmcdiscover_h
 bmcdiscover_nmap_range
 bmcdiscover_v
-bmcdiscover_check_paswd
-bmcdiscover_check_passwd_wrong
-bmcdiscover_get_ipsource
 bmcdiscover_range_w
 bmcdiscover_range_z
 xcatd_start

--- a/xCAT-test/autotest/bundle/rhels7.3_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.3_ppc64le.bundle
@@ -282,9 +282,6 @@ updatenode_postscripts_loginfo
 bmcdiscover_h
 bmcdiscover_nmap_range
 bmcdiscover_v
-bmcdiscover_check_paswd
-bmcdiscover_check_passwd_wrong
-bmcdiscover_get_ipsource
 bmcdiscover_range_w
 bmcdiscover_range_z
 xcatd_start

--- a/xCAT-test/autotest/bundle/rhels7.4-pegas_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.4-pegas_ppc64le.bundle
@@ -5,9 +5,6 @@ bmcdiscover_version
 bmcdiscover_h
 bmcdiscover_nmap_range
 bmcdiscover_v
-bmcdiscover_check_paswd
-bmcdiscover_check_passwd_wrong
-bmcdiscover_get_ipsource
 bmcdiscover_range_w
 bmcdiscover_range_u_p_i_ipsource
 bmcdiscover_range_z

--- a/xCAT-test/autotest/bundle/rhels7.4_ppc64.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.4_ppc64.bundle
@@ -287,9 +287,6 @@ updatenode_postscripts_loginfo
 bmcdiscover_h
 bmcdiscover_nmap_range
 bmcdiscover_v
-bmcdiscover_check_paswd
-bmcdiscover_check_passwd_wrong
-bmcdiscover_get_ipsource
 bmcdiscover_range_w
 bmcdiscover_range_z
 xcatd_start

--- a/xCAT-test/autotest/bundle/rhels7.4_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.4_ppc64le.bundle
@@ -282,9 +282,6 @@ updatenode_postscripts_loginfo
 bmcdiscover_h
 bmcdiscover_nmap_range
 bmcdiscover_v
-bmcdiscover_check_paswd
-bmcdiscover_check_passwd_wrong
-bmcdiscover_get_ipsource
 bmcdiscover_range_w
 bmcdiscover_range_z
 xcatd_start


### PR DESCRIPTION
Depending on @zet809 's latest information, we won't support ``--check`` and ``--ipsource`` option in discovery, so delete these related 3 cases ``bmcdiscover_check_paswd``,``bmcdiscover_check_passwd_wrong``,``bmcdiscover_get_ipsource`` from daily bundles. 