### PR TITLE
[OpenBMC] Initialize variables to Unknown in loop incase BMC doesn't respond with values

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2444,6 +2444,11 @@ sub rflash_response {
         xCAT::SvrUtils::sendmsg("-" x 55, $callback, $node);
 
         foreach my $key_url (keys %{$response_info->{data}}) {
+            # Initialize values to Unknown for each loop, incase they are not defined in the BMC
+            $update_activation = "Unknown";
+            $update_purpose = "Unknown";
+            $update_version = "Unknown";
+
             my %content = %{ ${ $response_info->{data} }{$key_url} };
 
             $update_id = (split(/\//, $key_url))[ -1 ];


### PR DESCRIPTION
@markprez trying to load some special pnor resulted in the following display from rflash -l

```
[root@mgt03 Software]# rflash f7n01 -l
f7n01: ID       Purpose State      Version
f7n01: -------------------------------------------------------
f7n01: 18f3a974 Host    Unknown    IBM-witherspoon-ibm-OP9_v1.19_1.77
f7n01: f6590ce0 BMC     Active     ibm-v1.99.10-113-g65edf7d-r8-0-g713d86d
f7n01: 1fc944e5 Host    Active     open-power-witherspoon-v1.19-243-g48159a6
f7n01: 5901a2d6 BMC     Active(*)  ibm-v2.0-0-r5-0-g2fd869c
f7n01:
```

I think something is not quite right so this is an error case.    But looking at the REST API, the two `18f3a974` and `1fc944e5` do not have good data coming back...


```
    "/xyz/openbmc_project/software/18f3a974": {
      "Path": "/tmp/images/18f3a974",
      "Purpose": "xyz.openbmc_project.Software.Version.VersionPurpose.Host",
      "Version": "IBM-witherspoon-ibm-OP9_v1.19_1.77"
    },
    "/xyz/openbmc_project/software/1fc944e5": {
      "Path": "/tmp/images/1fc944e5",
      "Purpose": "xyz.openbmc_project.Software.Version.VersionPurpose.Host",
      "Version": "open-power-witherspoon-v1.19-243-g48159a6"
    },
```


Just to protect our code... I added the initialization of the variables inside the loop. With the changes, at least we do not take the Activate from the previous loop and print "Unknown" if we cannot detect the correct information. 
```
f7n01: ID       Purpose State      Version
f7n01: -------------------------------------------------------
f7n01: 18f3a974 Host    Unknown    IBM-witherspoon-ibm-OP9_v1.19_1.77
f7n01: f6590ce0 BMC     Active     ibm-v1.99.10-113-g65edf7d-r8-0-g713d86d
f7n01: 1fc944e5 Host    Unknown    open-power-witherspoon-v1.19-243-g48159a6
f7n01: 5901a2d6 BMC     Active(*)  ibm-v2.0-0-r5-0-g2fd869c
f7n01:
```
