### PR TITLE
fix issue #4299 `xdsh` return with no output when "site.master" is not set

### DIFF
--- a/perl-xCAT/xCAT/ServiceNodeUtils.pm
+++ b/perl-xCAT/xCAT/ServiceNodeUtils.pm
@@ -509,8 +509,11 @@ sub get_ServiceNode
 
     # get site.master this will be the default
     my $master = xCAT::TableUtils->get_site_Master();
-    $noderestab = xCAT::Table->new('noderes');
+    unless($master){
+        xCAT::MsgUtils->message('SW',"site.master is not set!\n");
+    }
 
+    $noderestab = xCAT::Table->new('noderes');
     unless ($noderestab)    # no noderes table, use default site.master
     {
         xCAT::MsgUtils->message('I',
@@ -548,7 +551,7 @@ sub get_ServiceNode
                     my $key = $rec->{$snattribute};
                     push @{ $snhash{$key} }, $node;
                 }
-                else                                  # use site.master
+                elsif($master)                                  # use site.master
                 {
                     push @{ $snhash{$master} }, $node;
                 }
@@ -595,7 +598,7 @@ sub get_ServiceNode
                             my $key = $rec->{$snattribute};
                             push @{ $snhash{$key} }, $node;
                         }
-                        else
+                        elsif($master)
                         {                                     # use site.master
                             push @{ $snhash{$master} }, $node;
                         }
@@ -631,7 +634,7 @@ sub get_ServiceNode
                                 my $key = $rec->{$snattribute};
                                 push @{ $snhash{$key} }, $node;
                             }
-                            else
+                            elsif($master)
                             {    # use site.master
                                 push @{ $snhash{$master} }, $node;
                             }
@@ -675,7 +678,7 @@ sub get_ServiceNode
                                 my $key = $sn->{$snattribute};
                                 push @{ $snhash{$key} }, $node;
                             }
-                            else
+                            elsif($master)
                             {          # no service node use master
                                 push @{ $snhash{$master} }, $node;
                             }


### PR DESCRIPTION
fix issue:
https://github.com/xcat2/xcat-core/issues/4299

UT:
````
[root@c910f03c05k21 ~]# lsdef -t site -o clustersite -i master
Object name: clustersite
[root@c910f03c05k21 ~]# xdsh c910f03c05k27   hostname
c910f03c05k27: c910f03c05k27
[root@c910f03c05k21 ~]# tail -n2 /var/log/xcat/cluster.log
Nov 16 01:33:27 c910f03c05k21 xcat[17388]: xCAT: Allowing xdsh to c910f03c05k27 hostname for root from localhost
Nov 16 01:33:27 c910f03c05k21 xcat[17389]: site.master is not set!
[root@c910f03c05k21 ~]#
````