### PR TITLE
natural_sort_cmp: recursion to iterative implementation

### DIFF
--- a/perl-xCAT/xCAT/Utils.pm
+++ b/perl-xCAT/xCAT/Utils.pm
@@ -4925,7 +4925,7 @@ sub acquire_lock_imageop {
 =cut
 
 #--------------------------------------------------------------------------------
-sub natural_sort_cmp {
+sub natural_sort_cmp($$) {
     my $left = shift;
     my $right = shift;
     while() {

--- a/perl-xCAT/xCAT/Utils.pm
+++ b/perl-xCAT/xCAT/Utils.pm
@@ -4921,30 +4921,31 @@ sub acquire_lock_imageop {
 #--------------------------------------------------------------------------------
 
 =head3  natural_sort_cmp
-      compare $left and $right by natrual.
+      compare $left and $right by natural ordering.
 =cut
 
 #--------------------------------------------------------------------------------
 sub natural_sort_cmp {
     my $left = shift;
     my $right = shift;
-    if( !($left =~ /\d+(\.\d+)?/) ) {
-        return $left cmp $right;
-    }
-    my $before = $`;
-    my $match = $&;
-    my $after = $';
-    if( !($right =~ /\d+(\.\d+)?/) ) {
-        return $left cmp $right;
-    }
-    if( $before eq $` ) {
-        if( $match == $& ) {
-            return natural_sort_cmp( $after, $' );
-        } else {
-            return $match <=> $&;
+    while() {
+        if( !($left =~ /\d+(\.\d+)?/) ) {
+            return $left cmp $right;
         }
-    } else {
-        return $left cmp $right;
+        my $before = $`;
+        my $match = $&;
+        my $after = $';
+        if( !($right =~ /\d+(\.\d+)?/) ) {
+            return $left cmp $right;
+        }
+        if( $before ne $` ) {
+            return $left cmp $right;
+        } elsif( $match != $& ) {
+            return $match <=> $&;
+        } else {
+            $left = $after;
+            $right = $';
+        }
     }
 }
 

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -72,10 +72,6 @@ sub unsupported {
     }
 }
 
-sub natural_sorter {
-    natural_sort_cmp( $a, $b );
-}
-
 #-------------------------------------------------------
 
 =head3  handled_commands
@@ -1895,7 +1891,7 @@ sub rinv_response {
     # If sorted array has any contents, sort it naturally and print it
     if (scalar @sorted_output > 0) {
         # sort alpha, then numeric 
-        foreach (sort natural_sorter @sorted_output) {
+        foreach (sort natural_sort_cmp @sorted_output) {
             #
             # The firmware output requires the ID to be part of the string to sort correctly.
             # Remove this ID from the output to the user
@@ -2394,7 +2390,7 @@ sub rvitals_response {
     # If sorted array has any contents, sort it and print it
     if (scalar @sorted_output > 0) {
         # Sort the output, alpha, then numeric
-        xCAT::SvrUtils::sendmsg("$_", $callback, $node) foreach (sort natural_sorter @sorted_output);
+        xCAT::SvrUtils::sendmsg("$_", $callback, $node) foreach (sort natural_sort_cmp @sorted_output);
     } else {
         xCAT::SvrUtils::sendmsg("$::NO_ATTRIBUTES_RETURNED", $callback, $node);
     }


### PR DESCRIPTION
Improve the implementation of `natural_sort_cmp` to be iterative rather than recursive (speedup for large output sets).

This is a follow up to #4307 