### PR TITLE
Timeout the ntpd process if ntpd service is not running on ntpserver

### DIFF
--- a/xCAT/postscripts/setupntp
+++ b/xCAT/postscripts/setupntp
@@ -20,7 +20,7 @@ fi
 #for service node, the makentp -a command will call this postscript
 #so do not diable service node.
 
-
+exit_code=0;
 master=$MASTER
 setup=0
 conf_file="/etc/ntp.conf"
@@ -103,10 +103,11 @@ if [ $OS_TYPE = Linux ]; then
         echo "interface listen eth0" >>$conf_file
     fi
 
-    # ntpd will be hung if ntp service is not reachable
+    # will not exit here, let all the ntp configuration finish
+    # ntpd will timeout if ntp service is not reachable
     if ! ping $master -c 1 > /dev/null 2>&1 ; then
         echo "Error: ntpserver $master is not reachable, will not setup NTP"
-        exit 1
+        exit_code=1
     fi
 
     #ntpd/ntpdate/sntp conflict with ntpd, stop the service first
@@ -116,9 +117,10 @@ if [ $OS_TYPE = Linux ]; then
     fi
 
     logger -t xcat "setting current time"
-    if ! ntpd -gq  > /dev/null 2>&1 ; then
+    if ! timeout 120 ntpd -gq  > /dev/null 2>&1 ; then
         if ! ntpdate -t5 $master > /dev/null 2>&1; then
             logger -t xcat "WARNING: NTP Sync Failed!!"
+            exit_code=1
         fi
     fi
 
@@ -197,4 +199,4 @@ restrict 127.0.0.1" >>$conf_file
     fi
     /usr/sbin/chrctcp -S -a xntpd 
 fi
-exit $? 
+exit $exit_code 


### PR DESCRIPTION
For issue #4286 .   If ntp service is not running on ntpserver,  setupntp postscripts runs on compute node will hung and nerver return ntpd process back.  Add timeout for ntpd service and exit code with 1 if ntpd timeout or clock is not synced .  
````
# ps -ef | grep ntp
root       5888   5640  0 09:45 ?        00:00:00 bash -x ./setupntp
root       5933   5888  0 09:45 ?        00:00:00 timeout 120 ntpd -gq
root       5934   5933  0 09:45 ?        00:00:00 ntpd -gq
]# ps -ef | grep ntp
ntp        5993      1  0 09:47 ?        00:00:00 /usr/sbin/ntpd -u ntp:ntp -g
root       6081   5954  0 09:48 hvc0     00:00:00 grep --color=auto ntp
````
the xcat.log on the compute node:
```
Thu Nov 16 10:37:55 EST 2017 postbootscript setupntp return with 1
Thu Nov 16 10:37:55 EST 2017 Running postbootscript: otherpkgs
````
the status will report failed if setupntp postscript failed.
```
# lsdef mid05tor12cn16 -i status
Object name: mid05tor12cn16
    status=failed
```