### PR TITLE
Verify hash ID before activating uploaded firmware

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -50,6 +50,7 @@ $::POWER_STATE_RESET        = "reset";
 $::POWER_STATE_REBOOT       = "reboot";
 $::UPLOAD_FILE              = "";
 $::UPLOAD_FILE_VERSION      = "";
+$::UPLOAD_FILE_HASH_ID      = "";
 $::RSETBOOT_URL_PATH        = "boot";
 # To improve the output to users, store this value as a global
 $::UPLOAD_AND_ACTIVATE      = 0;
@@ -1127,6 +1128,8 @@ sub parse_command_status {
 
         my $file_id = undef;
         my $grep_cmd = "/usr/bin/grep -a";
+        my $tr_cmd = "/usr/bin/tr";
+        my $sha512sum_cmd = "/usr/bin/sha512sum";
         my $version_tag = '"^version="';
         my $purpose_tag = '"purpose="';
         my $purpose_value;
@@ -1166,6 +1169,11 @@ sub parse_command_status {
                         $purpose_value = "Host";
                     } 
                     $::UPLOAD_FILE_VERSION = $version_value;
+                    if (-x $sha512sum_cmd) {
+                        # Save hash id this firmware version should resolve to:
+                        # take version string, get rid of newline, run through sha512sum, take first 8 characters
+                        $::UPLOAD_FILE_HASH_ID = substr(`echo $::UPLOAD_FILE_VERSION | $tr_cmd -d '\n' | $sha512sum_cmd`, 0,8);
+                    }
                 }
 
                 if ($check_version) {
@@ -2607,6 +2615,12 @@ sub rflash_response {
                     $found_match = 1;
                     # Found a match of uploaded file version with the image in software/enumerate
 
+                    # If we have a saved expected hash ID, compare it to the one just found 
+                    if ($::UPLOAD_FILE_HASH_ID && ($::UPLOAD_FILE_HASH_ID ne $update_id)) {
+                        xCAT::SvrUtils::sendmsg([1,"Firmware uploaded, but not activated. ID $update_id did not match expected ID $::UPLOAD_FILE_HASH_ID "], $callback, $node);
+                        $wait_node_num--;
+                        return; # Stop processing for this node, do not activate. Firmware shold be left in "Ready" state.
+                    }
                     # Set the image id for the activation request
                     $status_info{RFLASH_UPDATE_ACTIVATE_REQUEST}{init_url} =
                        $::SOFTWARE_URL . "/$update_id/attr/RequestedActivation";


### PR DESCRIPTION
Implements issue #4310 

Make sure when uploading and activating a firmware file, its hash ID matches expected hash ID.
If it does not, stop firmware activation for that node and leave firmware in "Ready" state.

Tested with 2 nodes, cn13 is running with 1740A level, which reports an older hash ID. cn15 is running with a level that reports newer hash ID.

Initially:

```
mid05tor12cn13: ID       Purpose State      Version
mid05tor12cn13: -------------------------------------------------------
mid05tor12cn13: 30ee1c48 Host    Active     IBM-witherspoon-ibm-OP9_v1.19_1.112
mid05tor12cn13: f6590ce0 BMC     Active     ibm-v1.99.10-113-g65edf7d-r8-0-g713d86d
mid05tor12cn13: 6341cb71 BMC     Active(*)  ibm-v1.99.10-0-r11-0-g9c65260
mid05tor12cn13:
mid05tor12cn15: ID       Purpose State      Version
mid05tor12cn15: -------------------------------------------------------
mid05tor12cn15: b5273d71 BMC     Active(*)  ibm-v1.99.10-113-g65edf7d-r8-0-g713d86d
mid05tor12cn15: 63521bb7 BMC     Active     ibm-v2.0-0-r4-0-gbf51ab5
mid05tor12cn15: 30ee1c48 Host    Active(+)  IBM-witherspoon-ibm-OP9_v1.19_1.112
mid05tor12cn15: 48f968f9 Host    Active(*)  IBM-witherspoon-ibm-OP9_v1.19_1.112
mid05tor12cn15:
[root@briggs01 xCAT_plugin]#
```

Upload and activate:
```
# rflash mid05tor12cn13,mid05tor12cn15 -a /mnt/xcat/iso/openbmc/910.1742.20171104a_1742D/obmc-phosphor-image-witherspoon.ubi.mtd.tar
mid05tor12cn13: Error: Firmware uploaded, but not activated. ID 6e71e1af did not match expected ID efc8a851
mid05tor12cn15: Firmware upload successful. Attempting to activate firmware: ibm-v1.99.10-113-g65edf7d-r10-0-gcdf7635 (ID: efc8a851)
mid05tor12cn15: Firmware activation successful.
#
```

After:
```
mid05tor12cn13: ID       Purpose State      Version
mid05tor12cn13: -------------------------------------------------------
mid05tor12cn13: 6e71e1af BMC     Ready      ibm-v1.99.10-113-g65edf7d-r10-0-gcdf7635
mid05tor12cn13: 30ee1c48 Host    Active     IBM-witherspoon-ibm-OP9_v1.19_1.112
mid05tor12cn13: f6590ce0 BMC     Active     ibm-v1.99.10-113-g65edf7d-r8-0-g713d86d
mid05tor12cn13: 6341cb71 BMC     Active(*)  ibm-v1.99.10-0-r11-0-g9c65260
mid05tor12cn13:
mid05tor12cn15: ID       Purpose State      Version
mid05tor12cn15: -------------------------------------------------------
mid05tor12cn15: b5273d71 BMC     Active(*)  ibm-v1.99.10-113-g65edf7d-r8-0-g713d86d
mid05tor12cn15: 63521bb7 BMC     Active     ibm-v2.0-0-r4-0-gbf51ab5
mid05tor12cn15: efc8a851 BMC     Active(+)  ibm-v1.99.10-113-g65edf7d-r10-0-gcdf7635
mid05tor12cn15: 30ee1c48 Host    Active(+)  IBM-witherspoon-ibm-OP9_v1.19_1.112
mid05tor12cn15: 48f968f9 Host    Active(*)  IBM-witherspoon-ibm-OP9_v1.19_1.112
mid05tor12cn15:
```