### PR TITLE
Fix merging in xdcpmerge.sh

### DIFF
--- a/xCAT-server/share/xcat/scripts/xdcpmerge.sh
+++ b/xCAT-server/share/xcat/scripts/xdcpmerge.sh
@@ -91,14 +91,13 @@ for i in $*; do
     # now run it
     eval $grepcmd
   fi 
-  # Now update the currentfile  
-  cat $filebackup > $curfile
+  
   # add new entries from mergefile, if any 
   if [ -a "$mergefile.nodups" ]; then
     cat $mergefile.nodups >> $curfile
     rm $mergefile.nodups
   fi
-  #echo "cat $filebackup $mergefile > $curfile"
+  
   # now cleanup
   rm $filebackup.userlist 
   #  echo "rm $filebackup.userlist"

--- a/xCAT-server/share/xcat/scripts/xdcpmerge.sh
+++ b/xCAT-server/share/xcat/scripts/xdcpmerge.sh
@@ -90,15 +90,14 @@ for i in $*; do
     #echo "grepcmd=$grepcmd"
     # now run it
     eval $grepcmd
-    # if no dups file created
-    if [ -a "$mergefile.nodups" ]; then
-      cp -p $mergefile.nodups $mergefile
-      #echo "cp -p $mergefile.nodups $mergefile" 
-      rm $mergefile.nodups
-    fi 
   fi 
   # Now update the currentfile  
-  cat $filebackup $mergefile > $curfile
+  cat $filebackup > $curfile
+  # add new entries from mergefile, if any 
+  if [ -a "$mergefile.nodups" ]; then
+    cat $mergefile.nodups >> $curfile
+    rm $mergefile.nodups
+  fi
   #echo "cat $filebackup $mergefile > $curfile"
   # now cleanup
   rm $filebackup.userlist 

--- a/xCAT-server/share/xcat/scripts/xdcpmerge.sh
+++ b/xCAT-server/share/xcat/scripts/xdcpmerge.sh
@@ -82,19 +82,19 @@ for i in $*; do
     done
     # remove the last delimiter
     userlisttmp="${userlist%?}"
-    listend=")'"
+    listend="):'"
     userlist=$userlisttmp$listend
     grepcmd=$grepcmd$userlist
     #set -x
-    grepcmd="$grepcmd $filebackup > $filebackup.nodups"
+    grepcmd="$grepcmd $mergefile > $mergefile.nodups"
     #echo "grepcmd=$grepcmd"
     # now run it
     eval $grepcmd
     # if no dups file created
-    if [ -s "$filebackup.nodups" ]; then
-      cp -p $filebackup.nodups $filebackup
-      #echo "cp -p $filebackup.nodups $filebackup" 
-      rm $filebackup.nodups
+    if [ -a "$mergefile.nodups" ]; then
+      cp -p $mergefile.nodups $mergefile
+      #echo "cp -p $mergefile.nodups $mergefile" 
+      rm $mergefile.nodups
     fi 
   fi 
   # Now update the currentfile  


### PR DESCRIPTION
Two fixes:
1. The grep pattern when finding duplicate usernames is missing ":" at the end. So, for example user "test" would also match "test2, etc.". Adding the ":" delimiter fixes the issue.
2. Another issue happens when the file to be merged is a superset of the files on the nodes. For example, if a new user is added and entire passwd file (that is otherwise identical) is sent to be merged. In this case, the $filebackup.nodups file, i.e. the original file with duplicates removed, becomes empty and the condition "if [ -s "$filebackup.nodups" ]" does not execute. Then the merged file ends up being the original file with the merge file fully appended, clearly not what was intended.

This is solved by changing the condition to check for file existence "-a" rather then for size. Additionally, I also turn the logic around so that the duplicates are removed from the merge file and then added to the original file. I think this makes logic a bit cleaner and also ensures that existing entries are not reordered or changed in any way.