### PR TITLE
[OpenBMC] rflash - Add messages to inform the user of the general action started via xCAT

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -878,7 +878,7 @@ sub parse_args {
             }
         }
         # show options parsed in bypass mode
-        print "DEBUG filename=$filename_passed, updateid=$updateid_passed, options=$option_flag, verbose=$verbose, invalid=$invalid_options\n";
+        print "DEBUG filename=$filename_passed, updateid=$updateid_passed, options=$option_flag, invalid=$invalid_options rflash_arguments=@flash_arguments\n";
 
         if ($option_flag =~ tr{ }{ } > 0) { 
             unless ($verbose) {
@@ -895,6 +895,7 @@ sub parse_args {
             if ($option_flag !~ /^-c$|^--check$|^-u$|^--upload$|^-a$|^--activate$/) {
                 return ([ 1, "Invalid option specified when a file is provided: $option_flag" ]);
             }
+            xCAT::SvrUtils::sendmsg("Attempting to upload $flash_arguments[0], please wait...", $callback);
         }
         else {
             if ($updateid_passed) {
@@ -902,6 +903,11 @@ sub parse_args {
                 if ($option_flag !~ /^-d$|^--delete$|^-a$|^--activate$/) {
                     return ([ 1, "Invalid option specified when an update id is provided: $option_flag" ]);
                 }
+                my $action = "activate";
+                if ($option_flag =~ /^-d$|^--delete$/) {
+                    $action = "delete";
+                } 
+                xCAT::SvrUtils::sendmsg("Attempting to $action ID=$flash_arguments[0], please wait...", $callback);
             }
             else {
                 # Neither Filename nor updateid was not passed, check flags allowed without file or updateid


### PR DESCRIPTION
Regarding my comment here: https://github.com/xcat2/xcat-core/issues/4287#issuecomment-345718248

Creating this pull request to print single message out to show that xCAT is starting either and upload,activate,upload and activate... 

UT output: 
```
[root@briggs01 910.1746.20171116b_1742Ed]# rflash $NODE -u ./obmc-phosphor-image-witherspoon.ubi.mtd.tar
Attempting to upload ./obmc-phosphor-image-witherspoon.ubi.mtd.tar, please wait...
mid05tor12cn18: Firmware upload successful. Use -l option to list.
mid05tor12cn02: Firmware upload successful. Use -l option to list.
[root@briggs01 910.1746.20171116b_1742Ed]# rflash $NODE -l
mid05tor12cn18: ID       Purpose State      Version
mid05tor12cn18: -------------------------------------------------------
mid05tor12cn18: b5273d71 BMC     Active     ibm-v1.99.10-113-g65edf7d-r8-0-g713d86d
mid05tor12cn18: 63521bb7 BMC     Active(*)  ibm-v2.0-0-r4-0-gbf51ab5
mid05tor12cn18: 18f3a974 Host    Active(*)  IBM-witherspoon-ibm-OP9_v1.19_1.77
mid05tor12cn18: 82087175 Host    Active(+)  IBM-witherspoon-ibm-OP9_v1.19_1.83
mid05tor12cn18: 608e9ebe BMC     Ready      ibm-v2.0-0-r9-0-gecda565
mid05tor12cn18:
mid05tor12cn02: ID       Purpose State      Version
mid05tor12cn02: -------------------------------------------------------
mid05tor12cn02: 6e71e1af BMC     Active(*)  ibm-v1.99.10-113-g65edf7d-r10-0-gcdf7635
mid05tor12cn02: 82087175 Host    Active(+)  IBM-witherspoon-ibm-OP9_v1.19_1.83
mid05tor12cn02: 608e9ebe BMC     Ready      ibm-v2.0-0-r9-0-gecda565
mid05tor12cn02: 52ee4a42 Host    Active(*)  IBM-witherspoon-ibm-OP9_v1.19_1.73
mid05tor12cn02: 29c0a606 BMC     Active     ibm-v2.0-0-r7-0-ge521a31
mid05tor12cn02:
[root@briggs01 910.1746.20171116b_1742Ed]# rflash $NODE -d 608e9ebe
Attempting to delete ID=608e9ebe, please wait...
mid05tor12cn18: Firmware removed
mid05tor12cn02: Firmware removed
[root@briggs01 910.1746.20171116b_1742Ed]# rflash $NODE -u ./obmc-phosphor-image-witherspoon.ubi.mtd.tar -V
[briggs01]: Attempting to upload ./obmc-phosphor-image-witherspoon.ubi.mtd.tar, please wait...
mid05tor12cn18: [briggs01]: Uploading /mnt/xcat/iso/openbmc/910.1746.20171116b_1742Ed/./obmc-phosphor-image-witherspoon.ubi.mtd.tar ...
mid05tor12cn02: [briggs01]: Uploading /mnt/xcat/iso/openbmc/910.1746.20171116b_1742Ed/./obmc-phosphor-image-witherspoon.ubi.mtd.tar ...
mid05tor12cn18: [briggs01]: Firmware upload successful. Use -l option to list.
mid05tor12cn02: [briggs01]: Firmware upload successful. Use -l option to list.
[root@briggs01 910.1746.20171116b_1742Ed]# rflash $NODE -l
mid05tor12cn02: ID       Purpose State      Version
mid05tor12cn02: -------------------------------------------------------
mid05tor12cn02: 6e71e1af BMC     Active(*)  ibm-v1.99.10-113-g65edf7d-r10-0-gcdf7635
mid05tor12cn02: 82087175 Host    Active(+)  IBM-witherspoon-ibm-OP9_v1.19_1.83
mid05tor12cn02: 608e9ebe BMC     Ready      ibm-v2.0-0-r9-0-gecda565
mid05tor12cn02: 52ee4a42 Host    Active(*)  IBM-witherspoon-ibm-OP9_v1.19_1.73
mid05tor12cn02: 29c0a606 BMC     Active     ibm-v2.0-0-r7-0-ge521a31
mid05tor12cn02:
mid05tor12cn18: ID       Purpose State      Version
mid05tor12cn18: -------------------------------------------------------
mid05tor12cn18: b5273d71 BMC     Active     ibm-v1.99.10-113-g65edf7d-r8-0-g713d86d
mid05tor12cn18: 63521bb7 BMC     Active(*)  ibm-v2.0-0-r4-0-gbf51ab5
mid05tor12cn18: 18f3a974 Host    Active(*)  IBM-witherspoon-ibm-OP9_v1.19_1.77
mid05tor12cn18: 82087175 Host    Active(+)  IBM-witherspoon-ibm-OP9_v1.19_1.83
mid05tor12cn18: 608e9ebe BMC     Ready      ibm-v2.0-0-r9-0-gecda565
mid05tor12cn18:
[root@briggs01 910.1746.20171116b_1742Ed]# rflash $NODE -a 608e9ebe
Attempting to activate ID=608e9ebe, please wait...
mid05tor12cn18: Error: DBusException("Unknown interface 'xyz.openbmc_project.Software.ActivationProgress'.",)
mid05tor12cn02: Firmware activation successful.
[root@briggs01 910.1746.20171116b_1742Ed]#
```
