### PR TITLE
[OpenBMC] Fix bug with rinv <> firm to display active firmware

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1925,7 +1925,7 @@ sub rinv_response {
                     if ($priority_value == 0 and %{$functional} and !exists($functional->{$sw_id})) {
                         # indicate that a reboot is needed if priority = 0 and it's not in the functional list
                         $indicator = "+";
-                    } elsif ($priority_value == 0 and %{$functional} and exists($functional->{$sw_id})) {
+                    } elsif (%{$functional} and exists($functional->{$sw_id})) {
                         $indicator = "*";
                     }
                     $content_info .= $indicator;


### PR DESCRIPTION
This was actually caught by the UT_openbmc suite!  
I ran it against a compute node that had a pending firmware to be flashed.  In this case, the priority of the existing running FW is 1 and the priority of the pending FW is 0, so the initial test fails. 

Before:
```
mid05tor12cn05: BMC Firmware Product: ibm-v2.0-0-r9-0-gecda565 (Active)*
mid05tor12cn05: HOST Firmware Product: IBM-witherspoon-ibm-OP9_v1.19_1.73 (Active)
mid05tor12cn05: HOST Firmware Product: -- additional info: buildroot-2017.08-8-g5e23247
mid05tor12cn05: HOST Firmware Product: -- additional info: capp-ucode-p9-dd2-v2
mid05tor12cn05: HOST Firmware Product: -- additional info: hostboot-5090f7e
mid05tor12cn05: HOST Firmware Product: -- additional info: hostboot-binaries-013fbba
mid05tor12cn05: HOST Firmware Product: -- additional info: linux-4.13.8-openpower2-pc69996b
mid05tor12cn05: HOST Firmware Product: -- additional info: machine-xml-755040c
mid05tor12cn05: HOST Firmware Product: -- additional info: occ-dbb4d7e
mid05tor12cn05: HOST Firmware Product: -- additional info: op-build-v1.19-224-g1fe4582
mid05tor12cn05: HOST Firmware Product: -- additional info: petitboot-v1.6.2-pdfbb2d0
mid05tor12cn05: HOST Firmware Product: -- additional info: sbe-e2cfab8
mid05tor12cn05: HOST Firmware Product: -- additional info: skiboot-v5.9
```

The Host firmware is not starrred....


After:
```
mid05tor12cn05: BMC Firmware Product: ibm-v2.0-0-r9-0-gecda565 (Active)*
mid05tor12cn05: HOST Firmware Product: IBM-witherspoon-ibm-OP9_v1.19_1.73 (Active)*
mid05tor12cn05: HOST Firmware Product: -- additional info: buildroot-2017.08-8-g5e23247
mid05tor12cn05: HOST Firmware Product: -- additional info: capp-ucode-p9-dd2-v2
mid05tor12cn05: HOST Firmware Product: -- additional info: hostboot-5090f7e
mid05tor12cn05: HOST Firmware Product: -- additional info: hostboot-binaries-013fbba
mid05tor12cn05: HOST Firmware Product: -- additional info: linux-4.13.8-openpower2-pc69996b
mid05tor12cn05: HOST Firmware Product: -- additional info: machine-xml-755040c
mid05tor12cn05: HOST Firmware Product: -- additional info: occ-dbb4d7e
mid05tor12cn05: HOST Firmware Product: -- additional info: op-build-v1.19-224-g1fe4582
mid05tor12cn05: HOST Firmware Product: -- additional info: petitboot-v1.6.2-pdfbb2d0
mid05tor12cn05: HOST Firmware Product: -- additional info: sbe-e2cfab8
mid05tor12cn05: HOST Firmware Product: -- additional info: skiboot-v5.9
```

and with verbose...
```
mid05tor12cn05: [briggs01]: BMC Firmware Product: ibm-v2.0-0-r9-0-gecda565 (Active)*
mid05tor12cn05: [briggs01]: BMC Firmware Product: ibm-v1.99.10-113-g65edf7d-r10-0-gcdf7635 (Active)
mid05tor12cn05: [briggs01]: HOST Firmware Product: IBM-witherspoon-ibm-OP9_v1.19_1.73 (Active)*
mid05tor12cn05: [briggs01]: HOST Firmware Product: -- additional info: buildroot-2017.08-8-g5e23247
mid05tor12cn05: [briggs01]: HOST Firmware Product: -- additional info: capp-ucode-p9-dd2-v2
mid05tor12cn05: [briggs01]: HOST Firmware Product: -- additional info: hostboot-5090f7e
mid05tor12cn05: [briggs01]: HOST Firmware Product: -- additional info: hostboot-binaries-013fbba
mid05tor12cn05: [briggs01]: HOST Firmware Product: -- additional info: linux-4.13.8-openpower2-pc69996b
mid05tor12cn05: [briggs01]: HOST Firmware Product: -- additional info: machine-xml-755040c
mid05tor12cn05: [briggs01]: HOST Firmware Product: -- additional info: occ-dbb4d7e
mid05tor12cn05: [briggs01]: HOST Firmware Product: -- additional info: op-build-v1.19-224-g1fe4582
mid05tor12cn05: [briggs01]: HOST Firmware Product: -- additional info: petitboot-v1.6.2-pdfbb2d0
mid05tor12cn05: [briggs01]: HOST Firmware Product: -- additional info: sbe-e2cfab8
mid05tor12cn05: [briggs01]: HOST Firmware Product: -- additional info: skiboot-v5.9
mid05tor12cn05: [briggs01]: HOST Firmware Product: IBM-witherspoon-ibm-OP9_v1.19_1.83 (Active)+
mid05tor12cn05: [briggs01]: HOST Firmware Product: -- additional info: buildroot-2017.08-8-g5e23247
mid05tor12cn05: [briggs01]: HOST Firmware Product: -- additional info: capp-ucode-p9-dd2-v2
mid05tor12cn05: [briggs01]: HOST Firmware Product: -- additional info: hostboot-59e91a5
mid05tor12cn05: [briggs01]: HOST Firmware Product: -- additional info: hostboot-binaries-fe2394b
mid05tor12cn05: [briggs01]: HOST Firmware Product: -- additional info: linux-4.13.11-openpower1-p80e0b78
mid05tor12cn05: [briggs01]: HOST Firmware Product: -- additional info: machine-xml-adcd6d4
mid05tor12cn05: [briggs01]: HOST Firmware Product: -- additional info: occ-dbfefba
mid05tor12cn05: [briggs01]: HOST Firmware Product: -- additional info: op-build-v1.19-254-gc52aaca
mid05tor12cn05: [briggs01]: HOST Firmware Product: -- additional info: petitboot-v1.6.3-pb798598
mid05tor12cn05: [briggs01]: HOST Firmware Product: -- additional info: sbe-16c6bc8
mid05tor12cn05: [briggs01]: HOST Firmware Product: -- additional info: skiboot-v5.9.2
```

Was not completely resolved for #4111 