### PR TITLE
Fix issue4354 :The XCATTEST_CN in xcattest can not detect HCP as config file

### DIFF
--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -252,6 +252,15 @@ if ($setup_env_by_config_file) {
 }
 
 log_this($running_log_fd, "******************************");
+log_this($running_log_fd, "To detect current test environment");
+log_this($running_log_fd, "******************************");
+$rst = detect_current_env(\%config, \$error);
+if ($rst) {
+    log_this($running_log_fd, "$error");
+    to_exit(1);
+}
+
+log_this($running_log_fd, "******************************");
 log_this($running_log_fd, "loading test cases");
 log_this($running_log_fd, "******************************");
 $rst = load_case(\@cases_to_be_run, \@cases, \%case_name_index_map, \$error, $RUN);
@@ -1419,9 +1428,27 @@ sub setup_env_by_configure_file {
         }
     }
 
+    return 0;
+}
+
+#--------------------------------------------------------
+# Fuction name: detect_current_env 
+# Description: detect some important attribute in current environment, such as os, arch, hcp... 
+# Atrributes:
+#          $config_ref (input attribute)
+#            The reference of global hash %config.
+#            The structure of %config please refer to the comment of function load_config_file
+#          $error_ref  (output attribe)
+#               The reference of scalar to save the error message generated during running current function
+# Retrun code:  0 Success  1 Failed
+#--------------------------------------------------------
+sub detect_current_env{
+    my $config_ref = shift;
+    my $error_ref  = shift;
+
     if (!exists $$config_ref{var}{OS}) {
         my @output = runcmd("uname");
-        $$config_ref{var}{OS} = $output[0];
+        $$config_ref{var}{OS} = lc($output[0]);
         log_this($running_log_fd, "Detecting: OS = $$config_ref{var}{OS}");
     } else {
         $$config_ref{var}{OS} = lc($$config_ref{var}{OS});
@@ -1433,11 +1460,11 @@ sub setup_env_by_configure_file {
             log_this($running_log_fd, "Warning: No compute node defined, can't get ARCH of compute node");
         } else {
             $$config_ref{var}{ARCH} = getnodeattr($$config_ref{var}{CN}, "arch");
-            if ($$config_ref{var}{ARCH} =~ /le|el/) {
+            if ($$config_ref{var}{ARCH} =~ /le|el/i) {
                 $$config_ref{var}{ARCH} = 'ppc64le';
-            } elsif ($$config_ref{var}{ARCH} =~ /ppc/) {
+            } elsif ($$config_ref{var}{ARCH} =~ /ppc/i) {
                 $$config_ref{var}{ARCH} = 'ppc';
-            } elsif ($$config_ref{var}{ARCH} =~ /86/) {
+            } elsif ($$config_ref{var}{ARCH} =~ /86/i) {
                 $$config_ref{var}{ARCH} = 'x86';
             }
             log_this($running_log_fd, "Detecting: ARCH = $$config_ref{var}{ARCH}");
@@ -1457,6 +1484,9 @@ sub setup_env_by_configure_file {
 
     return 0;
 }
+
+
+
 
 #--------------------------------------------------------
 # Fuction name: runcmd


### PR DESCRIPTION
Fix issue #4354 

The UT result like below:
```
[root@briggs01 hwh]# lsdef mid05tor12cn05 -i mgt
Object name: mid05tor12cn05
    mgt=openbmc

[root@briggs01 bin]# XCATTEST_CN=mid05tor12cn05  xcattest -t rinv_check_active_fw_count
xCAT automated test started at Tue Nov 21 01:21:47 2017
******************************
To detect current test environment
******************************
Detecting: OS = linux
Detecting: ARCH = ppc64le
Detecting: HCP = openbmc
******************************
loading test cases
******************************
To run:
rinv_check_active_fw_count
******************************
Start to run test cases
******************************
------START::rinv_check_active_fw_count::Time:Tue Nov 21 01:21:48 2017------

RUN:rinv mid05tor12cn05 firm | tee /tmp/xcattest.rinv_check_active_fw_count.output [Tue Nov 21 01:21:48 2017]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid05tor12cn05: BMC Firmware Product: ibm-v2.0-0-r9-0-gecda565 (Active)*
mid05tor12cn05: HOST Firmware Product: IBM-witherspoon-ibm-OP9_v1.19_1.73 (Active)*
mid05tor12cn05: HOST Firmware Product: -- additional info: buildroot-2017.08-8-g5e23247
mid05tor12cn05: HOST Firmware Product: -- additional info: capp-ucode-p9-dd2-v2
mid05tor12cn05: HOST Firmware Product: -- additional info: hostboot-5090f7e
mid05tor12cn05: HOST Firmware Product: -- additional info: hostboot-binaries-013fbba
mid05tor12cn05: HOST Firmware Product: -- additional info: linux-4.13.8-openpower2-pc69996b
mid05tor12cn05: HOST Firmware Product: -- additional info: machine-xml-755040c
mid05tor12cn05: HOST Firmware Product: -- additional info: occ-dbb4d7e
mid05tor12cn05: HOST Firmware Product: -- additional info: op-build-v1.19-224-g1fe4582
mid05tor12cn05: HOST Firmware Product: -- additional info: petitboot-v1.6.2-pdfbb2d0
mid05tor12cn05: HOST Firmware Product: -- additional info: sbe-e2cfab8
mid05tor12cn05: HOST Firmware Product: -- additional info: skiboot-v5.9
CHECK:rc == 0	[Pass]

RUN:grep -i ibm /tmp/xcattest.rinv_check_active_fw_count.output | grep -i 'HOST Firmware Product' | grep -i 'Active)\*' | wc -l [Tue Nov 21 01:21:50 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1
CHECK:rc == 0	[Pass]
CHECK:output =~ 1	[Pass]

RUN:grep -i ibm /tmp/xcattest.rinv_check_active_fw_count.output | grep -i 'BMC Firmware Product'|grep -i 'Active)\*' | wc -l [Tue Nov 21 01:21:50 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1
CHECK:rc == 0	[Pass]
CHECK:output =~ 1	[Pass]

RUN:rm -rf /tmp/xcattest.rinv_check_active_fw_count.output [Tue Nov 21 01:21:50 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::rinv_check_active_fw_count::Passed::Time:Tue Nov 21 01:21:50 2017 ::Duration::2 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished atTue Nov 21 01:21:50 2017
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20171121012147 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20171121012147 file for time consumption

[root@briggs01]# cat test.conf
#Table configuration
[Table_passwd]
key=system
username=root
password=cluster

#system varible for autotest
[System]
MN=briggs01
#SN=sn01
CN=mid05tor12cn05

[root@briggs01 hwh]# xcattest -f test.conf  -t rinv_check_active_fw_count
xCAT automated test started at Tue Nov 21 01:23:41 2017
******************************
loading Configure file
******************************
TABLE:passwd
    key = system
    password = cluster
    username = root
Varible:
    CN = mid05tor12cn05
    MN = briggs01
******************************
Initialize xCAT test environment by definition in configure file
******************************
chtab key=system passwd.password=cluster passwd.username=root
******************************
To detect current test environment
******************************
Detecting: OS = linux
Detecting: ARCH = ppc64le
Detecting: HCP = openbmc
******************************
loading test cases
******************************
To run:
rinv_check_active_fw_count
******************************
Start to run test cases
******************************
------START::rinv_check_active_fw_count::Time:Tue Nov 21 01:23:42 2017------

RUN:rinv mid05tor12cn05 firm | tee /tmp/xcattest.rinv_check_active_fw_count.output [Tue Nov 21 01:23:42 2017]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid05tor12cn05: BMC Firmware Product: ibm-v2.0-0-r9-0-gecda565 (Active)*
mid05tor12cn05: HOST Firmware Product: IBM-witherspoon-ibm-OP9_v1.19_1.73 (Active)*
mid05tor12cn05: HOST Firmware Product: -- additional info: buildroot-2017.08-8-g5e23247
mid05tor12cn05: HOST Firmware Product: -- additional info: capp-ucode-p9-dd2-v2
mid05tor12cn05: HOST Firmware Product: -- additional info: hostboot-5090f7e
mid05tor12cn05: HOST Firmware Product: -- additional info: hostboot-binaries-013fbba
mid05tor12cn05: HOST Firmware Product: -- additional info: linux-4.13.8-openpower2-pc69996b
mid05tor12cn05: HOST Firmware Product: -- additional info: machine-xml-755040c
mid05tor12cn05: HOST Firmware Product: -- additional info: occ-dbb4d7e
mid05tor12cn05: HOST Firmware Product: -- additional info: op-build-v1.19-224-g1fe4582
mid05tor12cn05: HOST Firmware Product: -- additional info: petitboot-v1.6.2-pdfbb2d0
mid05tor12cn05: HOST Firmware Product: -- additional info: sbe-e2cfab8
mid05tor12cn05: HOST Firmware Product: -- additional info: skiboot-v5.9
CHECK:rc == 0	[Pass]

RUN:grep -i ibm /tmp/xcattest.rinv_check_active_fw_count.output | grep -i 'HOST Firmware Product' | grep -i 'Active)\*' | wc -l [Tue Nov 21 01:23:43 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1
CHECK:rc == 0	[Pass]
CHECK:output =~ 1	[Pass]

RUN:grep -i ibm /tmp/xcattest.rinv_check_active_fw_count.output | grep -i 'BMC Firmware Product'|grep -i 'Active)\*' | wc -l [Tue Nov 21 01:23:43 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1
CHECK:rc == 0	[Pass]
CHECK:output =~ 1	[Pass]

RUN:rm -rf /tmp/xcattest.rinv_check_active_fw_count.output [Tue Nov 21 01:23:43 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::rinv_check_active_fw_count::Passed::Time:Tue Nov 21 01:23:43 2017 ::Duration::1 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished atTue Nov 21 01:23:43 2017
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20171121012341 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20171121012341 file for time consumption
```