### PR TITLE
Fix 4338, remove all of  in child process

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2342,6 +2342,7 @@ sub rspconfig_sshcfg_response {
             xCAT::SvrUtils::sendmsg("Failed to fork child process for rspconfig sshcfg.", $callback, $node);
             sleep(1)
         } elsif ($child == 0) {
+            $async->remove_all;
             exit(sshcfg_process($node))
         } else {
             $child_node_map{$child} = $node;
@@ -2455,6 +2456,7 @@ sub rspconfig_dump_response {
             xCAT::SvrUtils::sendmsg("Failed to fork child process for rspconfig dump download.", $callback, $node);
             sleep(1)
         } elsif ($child == 0) {
+            $async->remove_all;
             exit(dump_download_process($node))
         } else {
             $child_node_map{$child} = $node;
@@ -2723,6 +2725,7 @@ sub rflash_response {
                 xCAT::SvrUtils::sendmsg("Failed to fork child process to upload firmware image.", $callback, $node);
                 sleep(1)
             } elsif ($child == 0) {
+                $async->remove_all;
                 exit(rflash_upload($node, $callback))
             } else {
                 $child_node_map{$child} = $node;
@@ -2886,7 +2889,7 @@ sub rflash_upload {
     my $curl_upload_cmd = "curl -b $cjar_id -k -H 'Content-Type: application/octet-stream' -X PUT -T " . $::UPLOAD_FILE . " $request_url/upload/image/";
 
     # Try to login
-    my $curl_login_result = `$curl_login_cmd`;
+    my $curl_login_result = `$curl_login_cmd -s`;
     my $h = from_json($curl_login_result); # convert command output to hash
     if ($h->{message} eq $::RESPONSE_OK) {
         # Login successfull, upload the file
@@ -2905,7 +2908,7 @@ sub rflash_upload {
                 xCAT::SvrUtils::sendmsg("Firmware upload successful. Use -l option to list.", $callback, $node);
             }
             # Try to logoff, no need to check result, as there is nothing else to do if failure
-            my $curl_logout_result = `$curl_logout_cmd`;
+            my $curl_logout_result = `$curl_logout_cmd -s`;
         }
         else {
             xCAT::SvrUtils::sendmsg("Failed to upload update file $::UPLOAD_FILE :" . $h->{message} . " - " . $h->{data}->{description}, $callback, $node);


### PR DESCRIPTION
#4338 
1. ``$async->remove_all`` to clear $async in child process to avoid warning msg when with "XCATBYPASS=1":
```
HTTP::Async object destroyed but still in use at /opt/xcat/bin/rflash line 0.
HTTP::Async INTERNAL ERROR: 'id_opts' not empty at /opt/xcat/bin/rflash line 0.
```

2. curl command for login and logout add ``-s`` to avoid "% Total    % Received % Xferd...." info.

Output:
```
# XCATBYPASS=1 rflash mid05tor12cn02,mid05tor12cn05 witherspoon.pnor.squashfs.tar -u
DEBUG filename=1, updateid=0, options=-u, verbose=, invalid=
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 21.1M  100    61  100 21.1M      8  2882k  0:00:07  0:00:07 --:--:-- 2559k0 63 1 901:k0 0 :00:10 0 :00:60 0 :00:50 03:20418 k 0:00:05 3190k
mid05tor12cn02: Firmware upload successful. Use -l option to list.
100 21.1M  100    61  100 21.1M      8  2844k  0:00:07  0:00:07 --:--:-- 2572k
mid05tor12cn05: Firmware upload successful. Use -l option to list.
```