### PR TITLE
Fix #4330, close the socket

### DIFF
--- a/xCAT-server/share/xcat/cons/openbmc
+++ b/xCAT-server/share/xcat/cons/openbmc
@@ -113,6 +113,7 @@ while (!defined($sock)) {
         Timeout => 10
         );
 }
+$sock->close();
 
 
 # To automatically connect to the console without the need to send over the ssh keys, 


### PR DESCRIPTION
As @neo954 pointed out in #4330, $sock will remain open for the duration of the console session. Best to close it.