### PR TITLE
Add image name to /opt/xcat/xcatinfo on compute node

### DIFF
--- a/xCAT/postscripts/xcatinstallpost
+++ b/xCAT/postscripts/xcatinstallpost
@@ -11,6 +11,7 @@ if [ -f /xcatpost/mypostscript.post ]; then
     MASTER_IP=`grep '^MASTER_IP=' /xcatpost/mypostscript.post |cut -d= -f2|sed s/\'//g`
     OSVER=`grep '^OSVER=' /xcatpost/mypostscript.post |cut -d= -f2|sed s/\'//g`
     NODE=`grep '^NODE=' /xcatpost/mypostscript.post |cut -d= -f2|sed s/\'//g`
+    IMAGE=`grep '^PROVMETHOD=' /xcatpost/mypostscript.post |cut -d= -f2|sed s/\'//g`
 fi
 
 
@@ -82,6 +83,14 @@ if [ $? -eq 0 ]; then
     sed -i "s/NODE=.*/NODE=$NODE/" /opt/xcat/xcatinfo
 else
     echo "NODE=$NODE" >> /opt/xcat/xcatinfo
+fi
+
+#add image name to xcatinfo
+grep 'IMAGENAME' /opt/xcat/xcatinfo > /dev/null 2>&1 
+if [ $? -eq 0 ]; then
+    sed -i "s/IMAGENAME=.*/IMAGENAME=$IMAGE/" /opt/xcat/xcatinfo
+else
+    echo "IMAGENAME=$IMAGE" >> /opt/xcat/xcatinfo
 fi
 
 # Store the SERVICEGROUP into the xcatinfo file for statful installation


### PR DESCRIPTION
for issue #4341 .  
After added imagename, the /opt/xcat/xcatinfo file will have something like that:
```
# xdsh mid05tor12cn15 "cat /opt/xcat/xcatinfo"
mid05tor12cn15: XCATSERVER=172.12.253.27
mid05tor12cn15: INSTALLDIR=/install
mid05tor12cn15: REBOOT=TRUE
mid05tor12cn15: NODE=mid05tor12cn15
mid05tor12cn15: IMAGENAME=rhels7.4-alternate-ppc64le-install-compute
```
