### PR TITLE
setupntp: do not set exit_code to 1 when the clock is not synced before the timeout

### DIFF
--- a/xCAT/postscripts/setupntp
+++ b/xCAT/postscripts/setupntp
@@ -116,11 +116,14 @@ if [ $OS_TYPE = Linux ]; then
          stopservice ntpserver
     fi
 
-    logger -t xcat "setting current time"
+    msg='syncing the clock ...'
+    logger -t xcat $msg 
+    echo $msg
     if ! timeout 120 ntpd -gq  > /dev/null 2>&1 ; then
         if ! ntpdate -t5 $master > /dev/null 2>&1; then
-            logger -t xcat "WARNING: NTP Sync Failed!!"
-            exit_code=1
+            msg='WARNING: NTP Sync Failed before timeout. ntp server will try to sync...'
+            logger -t xcat $msg
+            echo $msg
         fi
     fi
 


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/4360:

do not set exit_code to 1 when the clock is not synced before the timeout
add several verbose message and log message

UT:
````
c910f03c09k09:~ # makentp -a
configuring management node: c910f03c09k09.
configuring service nodes: c910f03c09k10
c910f03c09k10: vpdupdate is not supported on the pSeries KVM Guest platform
c910f03c09k10: xcatdsklspost: updating VPD database
c910f03c09k10: xcatdsklspost: downloaded postscripts successfully
c910f03c09k10: Wed Nov 22 04:13:51 EST 2017 Running postscript: setupntp
c910f03c09k10: active
c910f03c09k10: systemctl stop ntpd
c910f03c09k10: syncing the clock ...
c910f03c09k10: WARNING: NTP Sync Failed before timeout. ntp server will try to sync...
c910f03c09k10: postscript: setupntp exited with code 0
c910f03c09k10: Running of postscripts has completed.


c910f03c09k09:~ # echo $?
0
````
