### PR TITLE
Fix #4363 - discovery broken

### DIFF
--- a/xCAT-genesis-scripts/bin/dodiscovery
+++ b/xCAT-genesis-scripts/bin/dodiscovery
@@ -50,7 +50,7 @@ if [ $timewaiting != 700 -a $timewaiting -gt 450 ]; then
 	logger -s -t $log_label -p local4.warning "Obtained an IP address $NICSGETTINGADDR but it took $timewaiting cycles, you may want to check the spanning tree configuration in the switch."
 fi
 logger -s -t $log_label -p local4.info "Network configuration complete, commencing transmit of discovery packets"
-read XCATMASTER XCATPORT < <(grep xcatd= /proc/cmdline| sed 's/.* xcatd=\([^ ]*\) .*/\1/' |tr ':' ' ')
+read XCATMASTER XCATPORT < <(grep xcatd= /proc/cmdline| sed 's/.*xcatd=\([^ ]*\).*/\1/' |tr ':' ' ')
 if [[ -z $XCATPORT ]]; then 
     XCATPORT=3001
 fi


### PR DESCRIPTION
Fix `dodiscovery` if `xcatd=` is the last thing on Genesis' kernel cmdline
Closes #4363.