### PR TITLE
xCAT-genesis-base - Handle directory to symlink change properly

### DIFF
--- a/xCAT-genesis-builder/xCAT-genesis-base.spec
+++ b/xCAT-genesis-builder/xCAT-genesis-base.spec
@@ -51,6 +51,79 @@ tar jxf %{SOURCE1}
 cd -
 
 
+%pretrans -p <lua>
+-- Lua block of code for removing a directory recursively
+-- The Lua function remove_directory_deep should be called
+-- with a directory name or, in a spec file, also with
+-- a rpm macro defined to a directory name. This function
+-- is a possible lua equivalent of the shell command "rm -rf"
+-- using the lua posix extension embedded in rpm
+local leaf_indent = '| '
+local tail_leaf_indent = ' '
+local leaf_prefix = '|-- '
+local tail_leaf_prefix = '`-- '
+local link_prefix = ' -> '
+
+local function printf(...)
+    io.write(string.format(unpack(arg)))
+end
+
+local function remove_directory(directory, level, prefix)
+    local num_dirs = 0
+    local num_files = 0
+    if posix.access(directory,"rw") then
+    local files = posix.dir(directory)
+    local last_file_index = table.getn(files)
+    table.sort(files)
+    for i, name in ipairs(files) do
+        if name ~= '.' and name ~= '..' then
+            local full_name = string.format('%s/%s', directory, name)
+            local info = assert(posix.stat(full_name))
+            local is_tail = (i==last_file_index)
+            local prefix2 = is_tail and tail_leaf_prefix or leaf_prefix
+            local link = ''
+            if info.type == 'link' then
+                linked_name = assert(posix.readlink(full_name))
+                link = string.format('%s%s', link_prefix, linked_name)
+                posix.unlink(full_name)
+            end
+
+             -- printf('%s%s%s%s\n', prefix, prefix2, name, link)
+
+            if info.type == 'directory' then
+                local indent = is_tail and tail_leaf_indent or leaf_indent
+                sub_dirs, sub_files = remove_directory(full_name, level+1,
+                    prefix .. indent)
+                num_dirs = num_dirs + sub_dirs + 1
+                num_files = num_files + sub_files
+                posix.rmdir(full_name)
+            else
+                posix.unlink(full_name)
+                num_files = num_files + 1
+            end
+        end
+    end
+    end -- if access
+    return num_dirs, num_files
+end
+
+local function remove_directory_deep(directory)
+
+    -- print(directory)
+
+    num_dirs, num_files = remove_directory(directory, 0, '')
+
+    -- printf('\ndropped %d directories, %d files\n', num_dirs, num_files)
+
+    posix.rmdir(directory)
+end
+
+remove_directory_deep("/opt/xcat/share/xcat/netboot/genesis/%{tarch}/fs/bin")
+remove_directory_deep("/opt/xcat/share/xcat/netboot/genesis/%{tarch}/fs/sbin")
+remove_directory_deep("/opt/xcat/share/xcat/netboot/genesis/%{tarch}/fs/lib")
+remove_directory_deep("/opt/xcat/share/xcat/netboot/genesis/%{tarch}/fs/lib64")
+remove_directory_deep("/opt/xcat/share/xcat/netboot/genesis/%{tarch}/fs/var/run")
+
 %post
 if [ "$1" == "2" ]; then #only on upgrade, as on install it's probably not going to work...
 	if [ -f "/proc/cmdline" ]; then   # prevent running it during install into chroot image

--- a/xCAT-genesis-builder/xCAT-genesis-base.spec
+++ b/xCAT-genesis-builder/xCAT-genesis-base.spec
@@ -29,6 +29,7 @@ Vendor: IBM Corp.
 Summary: xCAT Genesis netboot image
 URL:	 https://xcat.org/
 Source1: xCAT-genesis-base-%{tarch}.tar.bz2
+Conflicts: xCAT-genesis-scripts-%{tarch} < 1:2.13.9
 
 Buildroot: %{_localstatedir}/tmp/xCAT-genesis
 BuildRequires: /usr/sbin/ntp-wait


### PR DESCRIPTION
Add `%pretrans` script in `<lua>`. Handle directory to symlink change properly.

See comment `#3` of https://bugs.launchpad.net/rpm/+bug/633636