### PR TITLE
Modify some rpower and rspconfig test cases for debuging conveniently or synchronizing with with the latest code logic

### DIFF
--- a/xCAT-test/autotest/testcase/rpower/cases0
+++ b/xCAT-test/autotest/testcase/rpower/cases0
@@ -160,25 +160,23 @@ check:rc==0
 end
 
 start:rpower_suspend_OpenpowerBmc
+hcp:openbmc
 cmd:rpower $$CN suspend
-check:output=~Error: unsupported command rpower suspend for OpenPOWER
+check:output=~Error: Unsupported command: rpower suspend
 check:rc==1
 end
 
-start:rpower_softoff_OpenpowerBmc
-cmd:rpower $$CN softoff
-check:output=~Error: unsupported command rpower softoff for OpenPOWER
-check:rc==1
-end
 
 start:rpower_wake_OpenpowerBmc
+hcp:openbmc
 cmd:rpower $$CN wake
-check:output=~Error: unsupported command rpower wake for OpenPOWER
+check:output=~Error: Unsupported command: rpower wake
 check:rc==1
 end
 
 start:rpower_errorcommand_OpenpowerBmc
+hcp:openbmc
 cmd:rpower $$CN ddd
-check:output=~Unsupported command: 
+check:output=~Error: Unsupported command: rpower ddd 
 check:rc==1
 end

--- a/xCAT-test/autotest/testcase/rspconfig/cases0
+++ b/xCAT-test/autotest/testcase/rspconfig/cases0
@@ -142,35 +142,45 @@ end
 
 start:rspconfig_list_ip
 despcription:rspconfig list bmc ip
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig.sh -lip $$CN 
+cmd:rspconfig $$CN ip 
 check:rc==0
+check:output=~__GETNODEATTR($$CN,bmc)__
 end
 
 start:rspconfig_list_gateway
+hcp:openbmc
 description:rspconfig list openbmc gateway
 Attribute: $$CN-The operation object of rspconfig command
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig.sh -lg $$CN
+cmd:rspconfig $$CN gateway
+check:output=~$$CN: BMC Gateway:
 check:rc==0
 end
 
 start:rspconfig_list_netmask
+hcp:openbmc
 description:rspconfig list openbmc netmask
 Attribute: $$CN-The operation object of rspconfig command
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig.sh -ln $$CN
+cmd:rspconfig $$CN netmask 
 check:rc==0
+check:output=~$$CN: BMC Netmask:
 end
 
 start:rspconfig_list_vlan
-description:rspconfig list openbmc netmask
+description:rspconfig list openbmc vlan
 Attribute: $$CN-The operation object of rspconfig command
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig.sh -lv $$CN
+cmd: rspconfig $$CN vlan
 check:rc==0
+check:output=~$$CN: BMC VLAN ID:
 end
 
 start:rspconfig_list_all
-description:rspconfig list openbmc netmask
+description:rspconfig list openbmc ip gateway netmask vlan 
 Attribute: $$CN-The operation object of rspconfig command
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig.sh -la $$CN
+cmd: rspconfig $$CN ip gateway netmask vlan
 check:rc==0
+check:output=~$$CN: BMC VLAN ID:
+check:output=~$$CN: BMC Gateway:
+check:output=~$$CN: BMC Netmask:
+check:output=~__GETNODEATTR($$CN,bmc)__
 end
 


### PR DESCRIPTION
what to do in this PR
1 synchronize some rpower openbmc test cases with the latest code ouput
2 Modify some rspconfig test cases for debuging conveniently in automation environment

The UT output is as below:

For ``rpower``

```
[root@c910f03c11k08 rpower]# XCATTEST_CN=f6u17 xcattest -t rpower_suspend_OpenpowerBmc,rpower_wake_OpenpowerBmc,rpower_errorcommand_OpenpowerBmc
xCAT automated test started at Mon Nov 27 03:08:40 2017
******************************
To detect current test environment
******************************
Detecting: OS = linux
Detecting: ARCH = ppc64le
Detecting: HCP = openbmc
******************************
loading test cases
******************************
To run:
rpower_suspend_OpenpowerBmc
rpower_wake_OpenpowerBmc
rpower_errorcommand_OpenpowerBmc
******************************
Start to run test cases
******************************
------START::rpower_suspend_OpenpowerBmc::Time:Mon Nov 27 03:08:41 2017------

RUN:rpower f6u17 suspend [Mon Nov 27 03:08:41 2017]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Unsupported command: rpower suspend
CHECK:output =~ Error: Unsupported command: rpower suspend	[Pass]
CHECK:rc == 1	[Pass]

------END::rpower_suspend_OpenpowerBmc::Passed::Time:Mon Nov 27 03:08:42 2017 ::Duration::1 sec------
------START::rpower_wake_OpenpowerBmc::Time:Mon Nov 27 03:08:42 2017------

RUN:rpower f6u17 wake [Mon Nov 27 03:08:42 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Unsupported command: rpower wake
CHECK:output =~ Error: Unsupported command: rpower wake	[Pass]
CHECK:rc == 1	[Pass]

------END::rpower_wake_OpenpowerBmc::Passed::Time:Mon Nov 27 03:08:42 2017 ::Duration::0 sec------
------START::rpower_errorcommand_OpenpowerBmc::Time:Mon Nov 27 03:08:42 2017------

RUN:rpower f6u17 ddd [Mon Nov 27 03:08:42 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Unsupported command: rpower ddd
CHECK:output =~ Error: Unsupported command: rpower ddd	[Pass]
CHECK:rc == 1	[Pass]

------END::rpower_errorcommand_OpenpowerBmc::Passed::Time:Mon Nov 27 03:08:42 2017 ::Duration::0 sec------
------Total: 3 , Failed: 0------
```
For ``rspconfig``

```
[root@c910f03c11k08 rpower]# XCATTEST_CN=f6u17 xcattest -t rspconfig_list_ip,rspconfig_list_gateway,rspconfig_list_netmask,rspconfig_list_vlan,rspconfig_list_all
xCAT automated test started at Mon Nov 27 03:36:44 2017
******************************
To detect current test environment
******************************
Detecting: OS = linux
Detecting: ARCH = ppc64le
Detecting: HCP = openbmc
******************************
loading test cases
******************************
To run:
rspconfig_list_ip
rspconfig_list_gateway
rspconfig_list_netmask
rspconfig_list_vlan
rspconfig_list_all
******************************
Start to run test cases
******************************
------START::rspconfig_list_ip::Time:Mon Nov 27 03:36:45 2017------

RUN:rspconfig f6u17 ip [Mon Nov 27 03:36:45 2017]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
f6u17: BMC IP: 10.6.17.100
CHECK:rc == 0	[Pass]
CHECK:output =~ 10.6.17.100	[Pass]

------END::rspconfig_list_ip::Passed::Time:Mon Nov 27 03:36:47 2017 ::Duration::2 sec------
------START::rspconfig_list_gateway::Time:Mon Nov 27 03:36:47 2017------

RUN:rspconfig f6u17 gateway [Mon Nov 27 03:36:47 2017]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u17: BMC Gateway: 0.0.0.0 (default: 10.0.0.101)
CHECK:output =~ f6u17: BMC Gateway:	[Pass]
CHECK:rc == 0	[Pass]

------END::rspconfig_list_gateway::Passed::Time:Mon Nov 27 03:36:48 2017 ::Duration::1 sec------
------START::rspconfig_list_netmask::Time:Mon Nov 27 03:36:48 2017------

RUN:rspconfig f6u17 netmask [Mon Nov 27 03:36:48 2017]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
f6u17: BMC Netmask: 255.0.0.0
CHECK:rc == 0	[Pass]
CHECK:output =~ f6u17: BMC Netmask:	[Pass]

------END::rspconfig_list_netmask::Passed::Time:Mon Nov 27 03:36:50 2017 ::Duration::2 sec------
------START::rspconfig_list_vlan::Time:Mon Nov 27 03:36:50 2017------

RUN:rspconfig f6u17 vlan [Mon Nov 27 03:36:50 2017]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u17: BMC VLAN ID: Disabled
CHECK:rc == 0	[Pass]
CHECK:output =~ f6u17: BMC VLAN ID:	[Pass]

------END::rspconfig_list_vlan::Passed::Time:Mon Nov 27 03:36:51 2017 ::Duration::1 sec------
------START::rspconfig_list_all::Time:Mon Nov 27 03:36:51 2017------

RUN:rspconfig f6u17 ip gateway netmask vlan [Mon Nov 27 03:36:51 2017]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u17: BMC IP: 10.6.17.100
f6u17: BMC Gateway: 0.0.0.0 (default: 10.0.0.101)
f6u17: BMC Netmask: 255.0.0.0
f6u17: BMC VLAN ID: Disabled
CHECK:rc == 0	[Pass]
CHECK:output =~ f6u17: BMC VLAN ID:	[Pass]
CHECK:output =~ f6u17: BMC Gateway:	[Pass]
CHECK:output =~ f6u17: BMC Netmask:	[Pass]
CHECK:output =~ 10.6.17.100	[Pass]

------END::rspconfig_list_all::Passed::Time:Mon Nov 27 03:36:53 2017 ::Duration::2 sec------
------Total: 5 , Failed: 0------
```