### PR TITLE
[FVT] OpenBMC - Add UT automation testcases for rspconfig

### DIFF
--- a/xCAT-test/autotest/testcase/UT_openbmc/rinv_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rinv_cases0
@@ -1,3 +1,10 @@
+start:rinv_record_firmware_level
+description: Record the firmware level for the start of each testcase
+hcp:openbmc
+cmd: rinv $$CN firm
+check:rc==0
+end
+
 start:rinv_check_active_fw_count
 description: Ensure that there is only 2 active firmware, one for bmc and one for pnor
 hcp:openbmc

--- a/xCAT-test/autotest/testcase/UT_openbmc/rspconfig_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rspconfig_cases0
@@ -34,29 +34,38 @@ check:rc==1
 check:output=~Error: Can not set and query OpenBMC information at the same time
 end
 
-start:rspconfig_set_hostname 
-description: Check that we can set the hostname on the BMC 
+start:rspconfig_get_and_set_hostname
+description: Test setting and getting hostname on the BMC 
 os:Linux
 hcp:openbmc
-cmd:rspconfig $$CN hostname=$$CN-UTset 
+# Save the hostname to a file.... 
+cmd:rspconfig $$CN hostname | tee /tmp/xcattest.rspconfig.hostname
+check:rc==0
+check:output=~$$CN: BMC Hostname: 
+# Set to witherspoon first
+cmd:rspconfig $$CN hostname=witherspoon 
+check:rc==0
+check:output=~$$CN: BMC Setting Hostname...
+# Check that it's set to witherspoon
+cmd:rspconfig $$CN hostname 
+check:rc==0
+check:output=~$$CN: BMC Hostname: witherspoon
+# Set to <host>-UTset 
+cmd:rspconfig $$CN hostname=$$CN-UTset
+check:rc==0
+check:output=~$$CN: BMC Setting Hostname...
+# Check that it's set 
+cmd:rspconfig $$CN hostname 
 check:rc==0
 check:output=~$$CN: BMC Hostname: $$CN-UTset
-end 
-
-start:rspconfig_set_hostname_check
-description: Check that the value is correct on the BMC
-os:Linux
-hcp:openbmc
-cmd:rspconfig $$CN hostname
+# Restore to saved version 
+cmd:grep BMC /tmp/xcattest.rspconfig.hostname  | cut -d' ' -f4 | xargs -i{} rspconfig $$CN hostname={}
 check:rc==0
-check:output=~$$CN: BMC Hostname: $$CN-UTset
+check:output=~$$CN: BMC Setting Hostname...
+cmd:rspconfig $$CN hostname 
+check:rc==0
+check:output=~$$CN: BMC Hostname:
+cmd:rm /tmp/xcattest.rspconfig.hostname
+check:rc==0
 end
 
-start:rspconfig_set_hostname
-description: Check that we can set the hostname on the BMC
-os:Linux
-hcp:openbmc
-cmd:rspconfig $$CN hostname=witherspoon
-check:rc==0
-check:output=~$$CN: BMC Hostname: witherspoon 
-end

--- a/xCAT-test/autotest/testcase/UT_openbmc/rspconfig_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rspconfig_cases0
@@ -1,0 +1,62 @@
+start:rspconfig_record_firmware_level
+description: Record the firmware level for the start of each testcase
+hcp:openbmc
+cmd: rinv $$CN firm
+check:rc==0
+end
+
+start:rspconfig_get_all
+description: Check that we can get all the attributes from the BMC 
+os:Linux
+hcp:openbmc
+cmd:rspconfig $$CN ip netmask gateway hostname vlan
+check:rc==0
+check:output=~$$CN: BMC IP:
+check:output=~$$CN: BMC Netmask:
+check:output=~$$CN: BMC Gateway:
+check:output=~$$CN: BMC Hostname:
+check:output=~$$CN: BMC VLAN ID:
+end
+
+start:rspconfig_get_all_error
+description: Check the parsing code for rspconfig (error cases) 
+hcp: openbmc
+cmd: rspconfig $$CN ip,netmask,gateway,hostname,vlan
+check:rc==1
+check:output=~Error: Unsupported command
+end 
+
+start:rspconfig_get_set_error
+description: Check the parsing code for rspconfig (error cases) - Cannot get/set in same line
+hcp: openbmc
+cmd: rspconfig $$CN ip netmask=255.0.0.0
+check:rc==1
+check:output=~Error: Can not set and query OpenBMC information at the same time
+end
+
+start:rspconfig_set_hostname 
+description: Check that we can set the hostname on the BMC 
+os:Linux
+hcp:openbmc
+cmd:rspconfig $$CN hostname=$$CN-UTset 
+check:rc==0
+check:output=~$$CN: BMC Hostname: $$CN-UTset
+end 
+
+start:rspconfig_set_hostname_check
+description: Check that the value is correct on the BMC
+os:Linux
+hcp:openbmc
+cmd:rspconfig $$CN hostname
+check:rc==0
+check:output=~$$CN: BMC Hostname: $$CN-UTset
+end
+
+start:rspconfig_set_hostname
+description: Check that we can set the hostname on the BMC
+os:Linux
+hcp:openbmc
+cmd:rspconfig $$CN hostname=witherspoon
+check:rc==0
+check:output=~$$CN: BMC Hostname: witherspoon 
+end

--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -300,7 +300,7 @@ if ($restore) {
     }
 }
 
-log_this($running_log_fd, "xCAT automated test finished at" . scalar(localtime()));
+log_this($running_log_fd, "xCAT automated test finished at " . scalar(localtime()));
 log_this($running_log_fd, "Please check results in the $resultdir, \nand see $failed_log_name file for failed cases.");
 
 #To generate performance report


### PR DESCRIPTION
Resolves the testcase:requested for #4378 

This pull request creates UT automation testcases

Here's the cases created:
```
[root@briggs01 autotest]# ./create_bundle_file UT_openbmc rspconfig
Filter of rspconfig specified....
Creating bundle file for UT_openbmc...
rspconfig_record_firmware_level
rspconfig_get_all
rspconfig_get_all_error
rspconfig_get_set_error
rspconfig_set_hostname
rspconfig_set_hostname_check
rspconfig_set_hostname
-rw-r--r-- 1 root root 174 Nov 27 10:51 ./UT_openbmc.tmp.bundle
Run the test using:
   xcattest -f <config_file> -b ./UT_openbmc.tmp.bundle
   XCATTEST_CN=mid05tor12cn05  xcattest -b ./UT_openbmc.tmp.bundle
```

Here's the output before the issue is fixed, showing the errors. 
[rspconfig_UT.txt](https://github.com/xcat2/xcat-core/files/1506528/rspconfig_UT.txt)


Let's hold off on merging this PR until after #4378 is fixed, so that I can re-run the UT and make sure that we get 0 Failures. 