### PR TITLE
rspconfig dump to allow admins capture logs

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2717,7 +2717,7 @@ sub rspconfig_dump_response {
                     xCAT::SvrUtils::sendmsg("[$dump_id] success", $callback, $node);
                 }
             } else {
-                xCAT::SvrUtils::sendmsg("Did not get new dump ID from OpenBMC", $callback, $node);
+                xCAT::SvrUtils::sendmsg([1, "BMC returned $::RESPONSE_OK but no ID was returned.  Verify manually on the BMC."], $callback, $node);
                 $next_status{ $node_info{$node}{cur_status} } = "";
             }
         } 


### PR DESCRIPTION
#4331 

Output of ``rspconfig dump``
```
# rspconfig mid05tor12cn11,mid05tor12cn16 dump
mid05tor12cn16: Capturing BMC Dump information, this will take some time...
mid05tor12cn11: Capturing BMC Dump information, this will take some time...
mid05tor12cn16: Generated BMC Dump 40
mid05tor12cn11: Generated BMC Dump 33
mid05tor12cn16: Downloaded Dump 40 to /var/log/xcat/dump/mid05tor12cn16_dump_40.tar.xz
mid05tor12cn11: Downloaded Dump 33 to /var/log/xcat/dump/mid05tor12cn11_dump_33.tar.xz
```

Output of ``rspconfig dump -V``
```
# rspconfig mid05tor12cn11,mid05tor12cn16 dump -V
mid05tor12cn16: [briggs01]: Capturing BMC Dump information, this will take some time...
mid05tor12cn11: [briggs01]: Capturing BMC Dump information, this will take some time...
mid05tor12cn16: [briggs01]: Generating BMC Dump...
mid05tor12cn11: [briggs01]: Generating BMC Dump...
mid05tor12cn11: [briggs01]: Generating BMC Dump...
mid05tor12cn16: [briggs01]: Generating BMC Dump...
mid05tor12cn16: [briggs01]: Generated BMC Dump 41
mid05tor12cn16: [briggs01]: Downloading Dump...
mid05tor12cn11: [briggs01]: Generated BMC Dump 34
mid05tor12cn11: [briggs01]: Downloading Dump...
mid05tor12cn16: [briggs01]: Downloaded Dump 41 to /var/log/xcat/dump/mid05tor12cn16_dump_41.tar.xz
mid05tor12cn11: [briggs01]: Downloaded Dump 34 to /var/log/xcat/dump/mid05tor12cn11_dump_34.tar.xz
```