### PR TITLE
fix issue 4353: rspconfig needs to support multiple IPs on the BMC and ignore ZeroConfigIPs

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2476,7 +2476,7 @@ sub rspconfig_response {
             }
         }
         if (scalar (keys %nicinfo) == 0) {
-            $error = "No valid BMC network information obtain";
+            $error = "No valid BMC network information";
             $node_info{$node}{cur_status} = "";  
         }
         if ($error) {
@@ -2649,9 +2649,19 @@ sub rspconfig_response {
         }
     }
 
-    if ($node_info{$node}{cur_status} eq "RSPCONFIG_IPOBJECT_RESPONSE" or $node_info{$node}{cur_status} eq "RSPCONFIG_VLAN_RESPONSE") {
-        # Doesn't work even send out next command 5 seconds later, may need to skip create vlan interface if it already exists.
-        retry_after($node, $next_status{ $node_info{$node}{cur_status} }, 5);
+    if ($node_info{$node}{cur_status} eq "RSPCONFIG_VLAN_RESPONSE") {
+        if ($xcatdebugmode) {
+             process_debug_info($node, "Wait 15 seconds for interface with VLAN tag be ready");
+        }
+        retry_after($node, $next_status{ $node_info{$node}{cur_status} }, 15);
+        return;
+    }
+
+    if ($node_info{$node}{cur_status} eq "RSPCONFIG_IPOBJECT_RESPONSE") {
+        if ($xcatdebugmode) {
+             process_debug_info($node, "Wait 3 seconds for the configuration done");
+        }
+        retry_after($node, $next_status{ $node_info{$node}{cur_status} }, 3);
         return;
     }
 

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2475,6 +2475,13 @@ sub rspconfig_response {
                 }
             }
         }
+        if ($grep_string =~ /(.*)hostname(.*)/) {
+            xCAT::SvrUtils::sendmsg("BMC hostname: $hostname", $callback, $node);
+            unless ($1 or $2) {
+                $wait_node_num--;
+                return;
+            }
+        }
         if (scalar (keys %nicinfo) == 0) {
             $error = "No valid BMC network information";
             $node_info{$node}{cur_status} = "";  
@@ -2514,8 +2521,6 @@ sub rspconfig_response {
                     push @output, @gateway; 
                 } elsif ($opt eq "vlan") {
                     push @output, @vlan;
-                } elsif ($opt eq "hostname") {
-                    push @output, "BMC Hostname: $hostname";
                 }
             }
             xCAT::SvrUtils::sendmsg("$_", $callback, $node) foreach (@output);


### PR DESCRIPTION
Fix issue #4353 
The issue #4397 is also fix in this PR
 
The idea of this fix are:
1. ignore the  LinkLocal ips
2. Only 1 valid IP is supported(The origin shall be DHCP or static)
    *But* support the following scenario:
        eth0: x.x.x.x
        eth0_11:x.x.x.x

```
[root@briggs01 tmp]# rspconfig mid05tor12cn18 ip netmask gateway ipsrc vlan
mid05tor12cn18: BMC IP: 172.11.139.18
mid05tor12cn18: BMC Netmask: 255.255.0.0
mid05tor12cn18: BMC Gateway: 0.0.0.0 (default: 172.11.253.27)
mid05tor12cn18: BMC IP Source: Static
mid05tor12cn18: BMC VLAN ID: 11
[root@briggs01 tmp]# rspconfig mid05tor12cn18 ip=172.11.139.180 netmask=255.255.0.0 gateway=0.0.0.0
mid05tor12cn18: BMC IP: 172.11.139.180
  d05tor12cn18: BMC Netmask: 255.255.0.0
▽id05tor12cn18: BMC Gateway: 0.0.0.0
[root@briggs01 tmp]# chdef mid05tor12cn18 bmc=172.11.139.180
1 object definitions have been created or modified.
[root@briggs01 tmp]# rspconfig mid05tor12cn18 ip netmask gateway ipsrc vlan
mid05tor12cn18: BMC IP: 172.11.139.180
mid05tor12cn18: BMC Netmask: 255.255.0.0
mid05tor12cn18: BMC Gateway: 0.0.0.0 (default: n/a)
mid05tor12cn18: BMC IP Source: Static
mid05tor12cn18: BMC VLAN ID: 11
[root@briggs01 tmp]# rspconfig mid05tor12cn18 ip=172.12.139.180 netmask=255.255.0.0 gateway=0.0.0.0
mid05tor12cn18: BMC IP: 172.12.139.180
mid05tor12cn18: BMC Netmask: 255.255.0.0
mid05tor12cn18: BMC Gateway: 0.0.0.0
[root@briggs01 tmp]# chdef mid05tor12cn18 bmc=172.12.139.180
1 object definitions have been created or modified.
[root@briggs01 tmp]# rspconfig mid05tor12cn18 ip netmask gateway ipsrc vlan
mid05tor12cn18: BMC IP: 172.12.139.180
mid05tor12cn18: BMC Netmask: 255.255.0.0
mid05tor12cn18: BMC Gateway: 0.0.0.0 (default: n/a)
mid05tor12cn18: BMC IP Source: Static
mid05tor12cn18: BMC VLAN ID: Disable
```