### PR TITLE
[OpenBMC] rflash - Improve the error message to help admin figure out where the missing file is

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1365,7 +1365,7 @@ sub parse_command_status {
                 }
                 # Verify file exists and is readable
                 unless (-r $::UPLOAD_FILE) {
-                    xCAT::SvrUtils::sendmsg([1,"Cannot access $::UPLOAD_FILE"], $callback);
+                    xCAT::SvrUtils::sendmsg([1,"Cannot access $::UPLOAD_FILE. Check the management node and/or service nodes."], $callback);
                     return 1;
                 }
                 if ($activate) {


### PR DESCRIPTION
Today, we again was asked about the following error message, meaning that there is still confusion about it.  

```
[root@mgmt1 OP910_1742C_prime_prime]# rflash -a a01,a02,a03 obmc-phosphor-image-witherspoon.ubi.mtd.tar
Error: Cannot access /root/ghh/firmware/OP910_1742C_prime_prime/obmc-phosphor-image-witherspoon.ubi.mtd.tar
```

In a hierarchy environment, the file must be present on the service nodes as the service nodes will be doing the code execution, so attempting to improve the message to help the admin figure out where the file is missing: 

After the PR: 
```
[root@briggs01 910.1746.20171109b_1742E]# rflash $NODE -a ./witherspoon.tar
Attempting to upload ./witherspoon.tar, please wait...
Error: Cannot access /mnt/xcat/iso/openbmc/910.1746.20171109b_1742E/./witherspoon.tar. Check the management node and/or service nodes.
```