### PR TITLE
Clear all BMC Dump logs when BMC firmware flash

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2836,7 +2836,8 @@ sub rspconfig_dump_response {
             my $dump_id = $status_info{RSPCONFIG_DUMP_CLEAR_RESPONSE}{argv};
             xCAT::MsgUtils->message("I", { data => ["[$dump_id] clear"] }, $callback) unless ($next_status{ $node_info{$node}{cur_status} });
         } else {
-            xCAT::MsgUtils->message("W", { data => ["$node: Could not clear BMC diagnostics successfully (MSG?), ignoring..."] }, $callback) if ($next_status{ $node_info{$node}{cur_status} });
+            my $error_msg = "Could not clear BMC diagnostics successfully (". $response_info->{'message'} . "), ignoring...";
+            xCAT::MsgUtils->message("W", { data => ["$node: $error_msg"] }, $callback) if ($next_status{ $node_info{$node}{cur_status} });
         }
     } 
 

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2194,7 +2194,11 @@ sub rinv_response {
             xCAT::MsgUtils->message("I", { data => ["$node: $_"] }, $callback);
         }
     } else {
-        xCAT::SvrUtils::sendmsg("$::NO_ATTRIBUTES_RETURNED", $callback, $node) if (!$status_info{RINV_FIRM_RESPONSE}{check});
+        if ($status_info{RINV_FIRM_RESPONSE}{check}) {
+            xCAT::MsgUtils->message("I", { data => ["$node: Firmware will be flashed on reboot, deleting all BMC diagnostics..."] }, $callback);
+        } else {
+            xCAT::MsgUtils->message("I", { data => ["$node: $::NO_ATTRIBUTES_RETURNED"] }, $callback);
+        }
     }
 
     if ($next_status{ $node_info{$node}{cur_status} }) {
@@ -2828,7 +2832,9 @@ sub rspconfig_dump_response {
     if ($node_info{$node}{cur_status} eq "RSPCONFIG_DUMP_CLEAR_RESPONSE") {
         if ($response_info->{'message'} eq $::RESPONSE_OK) {
             my $dump_id = $status_info{RSPCONFIG_DUMP_CLEAR_RESPONSE}{argv};
-            xCAT::SvrUtils::sendmsg("[$dump_id] clear", $callback, $node) unless ($next_status{ $node_info{$node}{cur_status} });
+            xCAT::MsgUtils->message("I", { data => ["[$dump_id] clear"] }, $callback) unless ($next_status{ $node_info{$node}{cur_status} });
+        } else {
+            xCAT::MsgUtils->message("W", { data => ["$node: Could not clear BMC diagnostics successfully (MSG?), ignoring..."] }, $callback) if ($next_status{ $node_info{$node}{cur_status} });
         }
     } 
 

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1782,16 +1782,18 @@ sub deal_with_response {
                 $error = $response_info->{'data'}->{'description'};
             }
         }
-        xCAT::SvrUtils::sendmsg([1, $error], $callback, $node);
-        if ($node_info{$node}{cur_status} eq "RFLASH_UPDATE_CHECK_STATE_RESPONSE") {
-            $node_info{$node}{rst} = $error if ($::VERBOSE);
-            my $rflash_log_file = xCAT::Utils->full_path($node.".log", RFLASH_LOG_DIR);
-            open (RFLASH_LOG_FILE_HANDLE, ">> $rflash_log_file");
-            print RFLASH_LOG_FILE_HANDLE "$error\n";
-            close (RFLASH_LOG_FILE_HANDLE);
+        if (!($node_info{$node}{cur_status} eq "RSPCONFIG_DUMP_CLEAR_RESPONSE" and $next_status{ $node_info{$node}{cur_status} })) {
+            xCAT::SvrUtils::sendmsg([1, $error], $callback, $node);
+            if ($node_info{$node}{cur_status} eq "RFLASH_UPDATE_CHECK_STATE_RESPONSE") {
+                $node_info{$node}{rst} = $error if ($::VERBOSE);
+                my $rflash_log_file = xCAT::Utils->full_path($node.".log", RFLASH_LOG_DIR);
+                open (RFLASH_LOG_FILE_HANDLE, ">> $rflash_log_file");
+                print RFLASH_LOG_FILE_HANDLE "$error\n";
+                close (RFLASH_LOG_FILE_HANDLE);
+            }
+            $wait_node_num--;
+            return;
         }
-        $wait_node_num--;
-        return;    
     }
 
     if ($status_info{ $node_info{$node}{cur_status} }->{process}) {

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1105,9 +1105,15 @@ sub parse_command_status {
             $next_status{RPOWER_ON_REQUEST} = "RPOWER_ON_RESPONSE";
             $status_info{RPOWER_ON_RESPONSE}{argv} = "$subcommand";
         } elsif ($subcommand eq "bmcreboot") {
-            $next_status{LOGIN_RESPONSE} = "RPOWER_BMCREBOOT_REQUEST";
+            $next_status{LOGIN_RESPONSE} = "RINV_FIRM_REQUEST";
+            $next_status{RINV_FIRM_REQUEST} = "RINV_FIRM_RESPONSE";
+            $next_status{RINV_FIRM_RESPONSE}{PENDING} = "RSPCONFIG_DUMP_CLEAR_ALL_REQUEST";
+            $next_status{RSPCONFIG_DUMP_CLEAR_ALL_REQUEST} = "RSPCONFIG_DUMP_CLEAR_RESPONSE";
+            $next_status{RSPCONFIG_DUMP_CLEAR_RESPONSE} = "RPOWER_BMCREBOOT_REQUEST";
+            $next_status{RINV_FIRM_RESPONSE}{NO_PENDING} = "RPOWER_BMCREBOOT_REQUEST";
             $next_status{RPOWER_BMCREBOOT_REQUEST} = "RPOWER_RESET_RESPONSE";
             $status_info{RPOWER_RESET_RESPONSE}{argv} = "$subcommand";
+            $status_info{RINV_FIRM_RESPONSE}{check} = 1;    
         }
     } 
 
@@ -2080,6 +2086,7 @@ sub rinv_response {
     my $src;
     my $content_info;
     my @sorted_output;
+    my $to_clear_dump = 0;
 
     # Get the functional IDs to accurately mark the active running FW
     my $functional = get_functional_software_ids($response_info);
@@ -2102,6 +2109,16 @@ sub rinv_response {
                 if (defined($content{Priority})) {
                     $priority_value = $content{Priority};
                 }
+
+                if ($status_info{RINV_FIRM_RESPONSE}{check}) {
+                    if (($purpose_value =~ /BMC/) and
+                        ($priority_value == 0 and %{$functional} and !exists($functional->{$sw_id}))) {
+                        $to_clear_dump = 1;
+                    }
+                    @sorted_output = ();
+                    last;
+                }
+
                 #
                 # For 'rinv firm', only print Active software, unless verbose is specified
                 #
@@ -2177,11 +2194,19 @@ sub rinv_response {
             xCAT::MsgUtils->message("I", { data => ["$node: $_"] }, $callback);
         }
     } else {
-        xCAT::SvrUtils::sendmsg("$::NO_ATTRIBUTES_RETURNED", $callback, $node);
+        xCAT::SvrUtils::sendmsg("$::NO_ATTRIBUTES_RETURNED", $callback, $node) if (!$status_info{RINV_FIRM_RESPONSE}{check});
     }
 
     if ($next_status{ $node_info{$node}{cur_status} }) {
-        $node_info{$node}{cur_status} = $next_status{ $node_info{$node}{cur_status} };
+        if ($status_info{RINV_FIRM_RESPONSE}{check}) {
+            if ($to_clear_dump) {
+                $node_info{$node}{cur_status} = $next_status{ $node_info{$node}{cur_status} }{PENDING};
+            } else {
+                $node_info{$node}{cur_status} = $next_status{ $node_info{$node}{cur_status} }{NO_PENDING}
+            }
+        } else {
+            $node_info{$node}{cur_status} = $next_status{ $node_info{$node}{cur_status} };
+        }
         gen_send_request($node);
     } else {
         $wait_node_num--;
@@ -2803,7 +2828,7 @@ sub rspconfig_dump_response {
     if ($node_info{$node}{cur_status} eq "RSPCONFIG_DUMP_CLEAR_RESPONSE") {
         if ($response_info->{'message'} eq $::RESPONSE_OK) {
             my $dump_id = $status_info{RSPCONFIG_DUMP_CLEAR_RESPONSE}{argv};
-            xCAT::SvrUtils::sendmsg("[$dump_id] clear", $callback, $node);
+            xCAT::SvrUtils::sendmsg("[$dump_id] clear", $callback, $node) unless ($next_status{ $node_info{$node}{cur_status} });
         }
     } 
 


### PR DESCRIPTION
#4327 

Test scenario:

```
# rflash mid05tor12cn11, mid05tor12cn16 -l
mid05tor12cn16: ID       Purpose State      Version
mid05tor12cn16: -------------------------------------------------------
mid05tor12cn16: 82087175 Host    Active     IBM-witherspoon-ibm-OP9_v1.19_1.83
mid05tor12cn16: 52ee4a42 Host    Active(*)  IBM-witherspoon-ibm-OP9_v1.19_1.73
mid05tor12cn16: 3a7f1407 BMC     Active(*)  ibm-v2.0-0-r13-0-g3a160ac
mid05tor12cn16: b48d27e1 BMC     Active     ibm-v1.99.10-113-g65edf7d-r3-0-g9e4f715
mid05tor12cn16:
mid05tor12cn11: ID       Purpose State      Version
mid05tor12cn11: -------------------------------------------------------
mid05tor12cn11: 82087175 Host    Active     IBM-witherspoon-ibm-OP9_v1.19_1.83
mid05tor12cn11: 608e9ebe BMC     Active(+)  ibm-v2.0-0-r9-0-gecda565
mid05tor12cn11: 7c4d7d61 Host    Active(*)  IBM-witherspoon-ibm-OP9_v1.19_1.87
mid05tor12cn11: 3a7f1407 BMC     Active(*)  ibm-v2.0-0-r13-0-g3a160ac
mid05tor12cn11:
```

Run bmcreboot:
```
# rpower mid05tor12cn11,mid05tor12cn16 bmcreboot
Tue Nov 28 21:54:04 2017 mid05tor12cn16: [openbmc_debug] curl -k -c cjar -H "Content-Type: application/json" -d '{ "data": ["root", "xxxxxx"] }' https://172.11.139.16/login
Tue Nov 28 21:54:04 2017 mid05tor12cn11: [openbmc_debug] curl -k -c cjar -H "Content-Type: application/json" -d '{ "data": ["root", "xxxxxx"] }' https://172.11.139.11/login
Tue Nov 28 21:54:04 2017 mid05tor12cn16: [openbmc_debug] login_response 200 OK
Tue Nov 28 21:54:04 2017 mid05tor12cn16: [openbmc_debug] curl -k -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.16/xyz/openbmc_project/software/enumerate
Tue Nov 28 21:54:05 2017 mid05tor12cn11: [openbmc_debug] login_response 200 OK
Tue Nov 28 21:54:05 2017 mid05tor12cn11: [openbmc_debug] curl -k -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.11/xyz/openbmc_project/software/enumerate
Tue Nov 28 21:54:05 2017 mid05tor12cn16: [openbmc_debug] rinv_firm_response 200 OK
Tue Nov 28 21:54:05 2017 mid05tor12cn16: [openbmc_debug] curl -k -b cjar -X PUT -H "Content-Type: application/json" -d '{"data":"xyz.openbmc_project.State.BMC.Transition.Reboot"}' https://172.11.139.16/xyz/openbmc_project/state/bmc0/attr/RequestedBMCTransition
Tue Nov 28 21:54:05 2017 mid05tor12cn11: [openbmc_debug] rinv_firm_response 200 OK
mid05tor12cn11: No attributes returned from the BMC.
Tue Nov 28 21:54:05 2017 mid05tor12cn11: [openbmc_debug] curl -k -b cjar -X POST -H "Content-Type: application/json" -d '{"data":[]}' https://172.11.139.11/xyz/openbmc_project/dump/action/DeleteAll
Tue Nov 28 21:54:06 2017 mid05tor12cn16: [openbmc_debug] rpower_reset_response 200 OK
mid05tor12cn16: BMC reboot
Tue Nov 28 21:54:06 2017 mid05tor12cn11: [openbmc_debug] rspconfig_dump_clear_response 200 OK
Tue Nov 28 21:54:06 2017 mid05tor12cn11: [openbmc_debug] curl -k -b cjar -X PUT -H "Content-Type: application/json" -d '{"data":"xyz.openbmc_project.State.BMC.Transition.Reboot"}' https://172.11.139.11/xyz/openbmc_project/state/bmc0/attr/RequestedBMCTransition
Tue Nov 28 21:54:07 2017 mid05tor12cn11: [openbmc_debug] rpower_reset_response 200 OK
mid05tor12cn11: BMC reboot
```