### PR TITLE
Leave a log file there to debug issue while upgrading

### DIFF
--- a/xCAT/debian/postinst
+++ b/xCAT/debian/postinst
@@ -35,7 +35,9 @@ case "$1" in
             if [ -r "/tmp/xcat/mainservice.pid" ]; then
                 mv /tmp/xcat/mainservice.pid /var/run/xcat/mainservice.pid
             fi
-            xcatconfig -u
+            mkdir -p /var/log/xcat
+            date >> /var/log/xcat/upgrade.log
+            xcatconfig -u -V >> /var/log/xcat/upgrade.log
             rm /tmp/xCAT_upgrade.tmp
         else
             xcatconfig -i -d -s

--- a/xCAT/xCAT.spec
+++ b/xCAT/xCAT.spec
@@ -249,7 +249,9 @@ if [ -r "/tmp/xcat/mainservice.pid" ]; then
   mv /tmp/xcat/mainservice.pid /var/run/xcat/mainservice.pid
 fi
 
-$RPM_INSTALL_PREFIX0/sbin/xcatconfig -u
+mkdir -p /var/log/xcat
+date >> /var/log/xcat/upgrade.log
+$RPM_INSTALL_PREFIX0/sbin/xcatconfig -u -V >> /var/log/xcat/upgrade.log
 fi
 exit 0
 


### PR DESCRIPTION
It is related to #4365, and now cannot know the root cause. Here to add a logfile `/var/log/xcat/upgrade.log` to record the `xcatconfig -u -V` output.

UT:
1, manual built xCAT packages
2,run `yum update xCAT` with the new repository
3, check `/var/log/xcat`
```
tail /var/log/xcat/upgrade.log

Imported TERM=xterm-256color into systemd.
Running command on c910f03c05k20: type systemctl >/dev/null 2>&1 && systemctl daemon-reload 2>&1

Restarting xcatd (via systemctl):  [  OK  ]
Running command on c910f03c05k20: /usr/sbin/conserver -V 2>&1

Running command on c910f03c05k20: /bin/cat /etc/conserver.cf | grep sslauthority 2>&1

Running '/opt/xcat/sbin/mknb', triggered by the installation/update of xCAT-genesis-scripts ...
```