### PR TITLE
Listen on 0.0.0.0 instead of the hostname for goconserver

### DIFF
--- a/xCAT-client/bin/rcons
+++ b/xCAT-client/bin/rcons
@@ -149,7 +149,8 @@ elif [ $USE_GOCONSERVER == "1" ]; then
                CONGO_SSL_CERT=$HOME/.xcat/client-cred.pem \
                CONGO_SSL_CA_CERT=$HOME/.xcat/ca.pem \
                CONGO_PORT=12430 \
-               CONGO_SERVER_HOST=$CONSERVER"
+               CONGO_SERVER_HOST=$CONSERVER \
+               CONGO_URL=https://$CONSERVER:12429"
 
     if [ "$CONSERVER" == `hostname` ]; then
         exec env $CONGO_ENV /usr/bin/congo console $1

--- a/xCAT-server/lib/xcat/plugins/goconserver.pm
+++ b/xCAT-server/lib/xcat/plugins/goconserver.pm
@@ -324,7 +324,7 @@ sub start_goconserver {
     xCAT::Utils->runcmd($cmd, 0);
     if ($::RUNCMD_RC != 0) {
         my $config= "global:\n".
-                    "  host: $host\n".
+                    "  host: 0.0.0.0\n".
                     "  ssl_key_file: /etc/xcat/cert/server-key.pem\n".
                     "  ssl_cert_file: /etc/xcat/cert/server-cert.pem\n".
                     "  ssl_ca_cert_file: /etc/xcat/cert/ca.pem\n".


### PR DESCRIPTION
This patch modify the configuration of `makegocons` and `rcons`
for goconserver.

`cat /etc/goconserver/server.conf`
```
global:
  host: 0.0.0.0
  ssl_key_file: /etc/xcat/cert/server-key.pem
  ssl_cert_file: /etc/xcat/cert/server-cert.pem
  ssl_ca_cert_file: /etc/xcat/cert/ca.pem
  logfile: /var/log/goconserver/server.log
api:
  port: 12429
console:
  port: 12430
```

The modification for environment variable used by`congo` from `goconserver` is not included (usually, this is not used by the end user), user should edit it by hand, below is an example:
```
CONGO_PORT=12430
CONGO_URL=https://c910f05c01bc02k74:12429
CONGO_SERVER_HOST=c910f05c01bc02k74
CONGO_SSL_CA_CERT=/root/.xcat/ca.pem
CONGO_SSL_CERT=/root/.xcat/client-cred.pem
CONGO_SSL_KEY=/root/.xcat/client-key.pem
```
