### PR TITLE
ddns.pm: specify the "directory" option for DNS slaves too

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ddns.pm
+++ b/xCAT-server/lib/xcat/plugins/ddns.pm
@@ -1229,8 +1229,8 @@ sub update_namedconf {
     }
     unless ($gotoptions) {
         push @newnamed, "options {\n";
+        push @newnamed, "\tdirectory \"" . $ctx->{zonesdir} . "\";\n";
         unless ($slave && xCAT::Utils->isLinux()) {
-            push @newnamed, "\tdirectory \"" . $ctx->{zonesdir} . "\";\n";
             push @newnamed, "\tallow-recursion { any; };\n";
         }
 


### PR DESCRIPTION
This is a tentative fix for issue #4392 

Without the "directory" option, `named`'s working directory defaults to the directory the process has been started from (ie. `/` when started as a daemon). This prevents temporary files to be created, which is required for zone transfers.

This change allows the "directory" option to be specified in `/etc/named.conf` for DNS slave too.