### PR TITLE
Fix issue 4361, modify some sendmsg to message

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -748,7 +748,7 @@ rmdir \"/tmp/\$userid\" \n";
                         push @{ $rflash_result{fail} }, "$node: $node_info{$node}{rst}";
                     }
                 }
-                xCAT::SvrUtils::sendmsg("-------------------------------------------------------", $callback);
+                xCAT::MsgUtils->message("I", { data => ["-------------------------------------------------------"] }, $callback);
                 my $summary = "Firmware update complete: ";
                 my $total = keys %node_info;
                 my $success = 0;
@@ -756,14 +756,14 @@ rmdir \"/tmp/\$userid\" \n";
                 $success = @{ $rflash_result{success} } if (defined $rflash_result{success} and @{ $rflash_result{success} });
                 $fail = @{ $rflash_result{fail} } if (defined $rflash_result{fail} and @{ $rflash_result{fail} });
                 $summary .= "Total=$total Success=$success Failed=$fail";
-                xCAT::SvrUtils::sendmsg("$summary", $callback);
+                xCAT::MsgUtils->message("I", { data => ["$summary"] }, $callback);
 
                 if ($rflash_result{fail}) {
                     foreach (@{ $rflash_result{fail} }) {
-                        xCAT::SvrUtils::sendmsg($_, $callback);
+                        xCAT::MsgUtils->message("I", { data => ["$_"] }, $callback);
                     }
                 }
-                xCAT::SvrUtils::sendmsg("-------------------------------------------------------", $callback);
+                xCAT::MsgUtils->message("I", { data => ["-------------------------------------------------------"] }, $callback);
             }
             last;
         }
@@ -2174,7 +2174,7 @@ sub rinv_response {
             # Remove this ID from the output to the user
             #
             $_ =~ s/\[.*?\]//;
-            xCAT::SvrUtils::sendmsg("$_", $callback, $node);
+            xCAT::MsgUtils->message("I", { data => ["$node: $_"] }, $callback);
         }
     } else {
         xCAT::SvrUtils::sendmsg("$::NO_ATTRIBUTES_RETURNED", $callback, $node);
@@ -2944,7 +2944,7 @@ sub rvitals_response {
     # If sorted array has any contents, sort it and print it
     if (scalar @sorted_output > 0) {
         # Sort the output, alpha, then numeric
-        xCAT::SvrUtils::sendmsg("$_", $callback, $node) foreach (sort natural_sort_cmp @sorted_output);
+        xCAT::MsgUtils->message("I", { data => ["$node: $_"] }, $callback) foreach (sort natural_sort_cmp @sorted_output);
     } else {
         xCAT::SvrUtils::sendmsg("$::NO_ATTRIBUTES_RETURNED", $callback, $node);
     }


### PR DESCRIPTION
#4361 
For "sendmsg", will lose some information when print out.
After modified:
```
# rinv test all
testnode: Error: Unable to get information from openbmc table
f6u17: BMC SerialNumber : 000000000000
f6u17: BMC UUID :
f6u17: CPU0 BuildDate : 1996-01-01 - 00:00:00
f6u17: CPU0 CORE4 Functional : 1
f6u17: CPU0 CORE4 Present : 1
f6u17: CPU0 CORE4 PrettyName :
........
f6u17: FAN0 Present : 1
f6u17: FAN0 PrettyName : fan0
f6u17: HOST Firmware Product: -- additional info: occ-e0be2d1
f6u17: HOST Firmware Product: -- additional info: op-build-v1.19-261-gab6c9f3-dirty
f6u17: HOST Firmware Product: -- additional info: petitboot-v1.6.3-p05d7453
f6u17: HOST Firmware Product: -- additional info: sbe-44274c7
f6u17: HOST Firmware Product: -- additional info: skiboot-v5.9.3
[root@c910f03c05k04 xcat-core]# echo $?
1
```