### PR TITLE
Print out error message if receive nothing when uploading firmware file

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -3702,6 +3702,7 @@ sub rflash_upload {
     my $curl_login_result = `$curl_login_cmd -s`;
     my $h = from_json($curl_login_result); # convert command output to hash
     if ($h->{message} eq $::RESPONSE_OK) {
+<<<<<<< HEAD
          foreach my $upload_cmd(@curl_upload_cmds){
              while((my $file,my $version)=each(%fw_tar_files)){
                  my $uploading_msg = "Uploading $file ...";
@@ -3737,6 +3738,43 @@ sub rflash_upload {
         }
         # Try to logoff, no need to check result, as there is nothing else to do if failure
         my $curl_logout_result = `$curl_logout_cmd -s`;
+=======
+        my $uploading_msg = "Uploading $::UPLOAD_FILE ...";
+        # Login successfull, upload the file
+        if ($::VERBOSE) {
+            xCAT::SvrUtils::sendmsg("$uploading_msg", $callback, $node);
+        }
+        print RFLASH_LOG_FILE_HANDLE "$uploading_msg\n";
+
+        if ($xcatdebugmode) {
+            my $debugmsg = "RFLASH_FILE_UPLOAD_RESPONSE: CMD: $curl_upload_cmd";
+            process_debug_info($node, $debugmsg);
+        }
+        my $curl_upload_result = `$curl_upload_cmd`;
+        if (!$curl_upload_result) {
+            xCAT::SvrUtils::sendmsg("Error: Did not receive response from OpenBMC when run command '$curl_upload_cmd'", $callback, $node);
+            return 1;
+        }
+        $h = from_json($curl_upload_result); # convert command output to hash
+        if ($h->{message} eq $::RESPONSE_OK) {
+            # Upload successful, display message
+            my $upload_success_msg = "Firmware upload successful. Use -l option to list.";
+            unless ($::UPLOAD_AND_ACTIVATE) {
+                xCAT::SvrUtils::sendmsg("$upload_success_msg", $callback, $node);
+            }
+            print RFLASH_LOG_FILE_HANDLE "$upload_success_msg\n";
+            # Try to logoff, no need to check result, as there is nothing else to do if failure
+            my $curl_logout_result = `$curl_logout_cmd -s`;
+        }
+        else {
+            my $upload_fail_msg = "Failed to upload update file $::UPLOAD_FILE :" . $h->{message} . " - " . $h->{data}->{description};
+            xCAT::SvrUtils::sendmsg("$upload_fail_msg", $callback, $node);
+            print RFLASH_LOG_FILE_HANDLE "$upload_fail_msg\n";
+            close (RFLASH_LOG_FILE_HANDLE);
+            $node_info{$node}{rst} = "$upload_fail_msg";
+            return 1;
+        }
+>>>>>>> modified error msg
     }
     else {
         my $unable_login_msg = "Unable to login :" . $h->{message} . " - " . $h->{data}->{description};

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -3726,10 +3726,13 @@ sub rflash_upload {
                     process_debug_info($node, $debugmsg);
                 }    
                 my $curl_upload_result = `$upload_cmd`;
+                if (!$curl_upload_result) {
+                    xCAT::SvrUtils::sendmsg([1, "Did not receive response from OpenBMC after running command '$upload_cmd'"], $callback, $node);
+                    return 1;
+                }
                 eval { $h = from_json($curl_upload_result) }; # convert command output to hash
                 if ($@) {
-                     xCAT::SvrUtils::sendmsg([1, "Received wrong format response from command '$upload_cmd'"], $callback, $node);
-                     xCAT::SvrUtils::sendmsg([1, "Received wrong format response '$curl_upload_result'"], $callback, $node);
+                     xCAT::SvrUtils::sendmsg([1, "Received wrong format response from command '$upload_cmd': $curl_upload_result"], $callback, $node);
                      return 1;
                 }
                 if ($h->{message} eq $::RESPONSE_OK) {

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -3219,9 +3219,13 @@ sub dump_download_process {
 
     my $curl_login_result = `$curl_login_cmd -s`;
     my $h;
+    if (!$curl_login_result) {
+        xCAT::SvrUtils::sendmsg([1, "Did not receive response from OpenBMC after running command '$curl_login_cmd'"], $callback, $node);
+        return 1;
+    }
     eval { $h = from_json($curl_login_result) };
     if ($@) {
-        xCAT::SvrUtils::sendmsg([1, "Received wrong format response for command '$curl_login_cmd'"], $callback, $node);
+        xCAT::SvrUtils::sendmsg([1, "Received wrong format response for command '$curl_login_cmd': $curl_login_result)"], $callback, $node);
         return 1;
     }
     if ($h->{message} eq $::RESPONSE_OK) {
@@ -3706,9 +3710,13 @@ sub rflash_upload {
     # Try to login
     my $curl_login_result = `$curl_login_cmd -s`;
     my $h;
+    if (!$curl_login_result) {
+        xCAT::SvrUtils::sendmsg([1, "Did not receive response from OpenBMC after running command '$curl_login_cmd'"], $callback, $node);
+        return 1;
+    } 
     eval { $h = from_json($curl_login_result) }; # convert command output to hash
     if ($@) {
-        xCAT::SvrUtils::sendmsg([1, "Received wrong format response for command '$curl_login_cmd'"], $callback, $node);
+        xCAT::SvrUtils::sendmsg([1, "Received wrong format response for command '$curl_login_cmd': $curl_login_result"], $callback, $node);
         return 1;
     }
     if ($h->{message} eq $::RESPONSE_OK) {

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -3221,7 +3221,7 @@ sub dump_download_process {
     my $h;
     eval { $h = from_json($curl_login_result) };
     if ($@) {
-        xCAT::SvrUtils::sendmsg([1, "Out own error message for command '$curl_login_cmd'"], $callback, $node);
+        xCAT::SvrUtils::sendmsg([1, "Received wrong format response for command '$curl_login_cmd'"], $callback, $node);
         return 1;
     }
     if ($h->{message} eq $::RESPONSE_OK) {
@@ -3708,7 +3708,7 @@ sub rflash_upload {
     my $h;
     eval { $h = from_json($curl_login_result) }; # convert command output to hash
     if ($@) {
-        xCAT::SvrUtils::sendmsg([1, "Out own error message for command '$curl_login_cmd'"], $callback, $node);
+        xCAT::SvrUtils::sendmsg([1, "Received wrong format response for command '$curl_login_cmd'"], $callback, $node);
         return 1;
     }
     if ($h->{message} eq $::RESPONSE_OK) {
@@ -3728,8 +3728,8 @@ sub rflash_upload {
                 my $curl_upload_result = `$upload_cmd`;
                 eval { $h = from_json($curl_upload_result) }; # convert command output to hash
                 if ($@) {
-                     xCAT::SvrUtils::sendmsg([1, "Out own error message for command '$upload_cmd'"], $callback, $node);
-                     xCAT::SvrUtils::sendmsg([1, "Out own error message '$curl_upload_result'"], $callback, $node);
+                     xCAT::SvrUtils::sendmsg([1, "Received wrong format response from command '$upload_cmd'"], $callback, $node);
+                     xCAT::SvrUtils::sendmsg([1, "Received wrong format response '$curl_upload_result'"], $callback, $node);
                      return 1;
                 }
                 if ($h->{message} eq $::RESPONSE_OK) {


### PR DESCRIPTION
#4394 (currently, not sure whether this is the root cause)

If do not receive response when uploading file, will print out the error msg:

``Error: openbmc plugin bug, pid 25027, process description: 'xcatd SSL: rflash to mid05tor12cn05 for root@localhost: openbmc instance' with error 'malformed JSON string, neither array, object, number, string or atom, at character offset 0 (before "(end of string)") at /opt/xcat/lib/perl/xCAT_plugin/openbmc.pm line 3208.
' while trying to fulfill request for the following nodes: mid05tor12cn05``

After modified:
```
# rflash mid05tor12cn05 obmc-phosphor-image-witherspoon.ubi.mtd.tar -u
Attempting to upload obmc-phosphor-image-witherspoon.ubi.mtd.tar, please wait...
 mid05tor12cn02: Error: Out own error message for command 'curl -b /tmp/_xcat_cjar.mid05tor12cn02 -k -H 'Content-Type: application/octet-stream' -X PUT -T /mnt/xcat/iso/openbmc/910.1746.20171128a_1742Ef/witherspoon.pnor.squashfs.tar https://172.11.139.2/upload/image/'
 mid05tor12cn02: Error: Out own error message ''
```