### PR TITLE
Fix issue 4293: remove conservercf entry for removed nodes

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rmdef.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rmdef.1.rst
@@ -90,7 +90,7 @@ OPTIONS
 
 \ **-C|-**\ **-cleanup**\ 
  
- Perform additional cleanup by running \ **nodeset offline**\  on the objects specified in the \ *noderange*\ .
+ Perform additional cleanup by running \ **nodeset offline**\  and \ **makeconservercf -d**\  on the objects specified in the \ *noderange*\ .
  
 
 

--- a/docs/source/guides/admin-guides/references/man8/makeconservercf.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/makeconservercf.8.rst
@@ -44,7 +44,7 @@ does not have nodehm.cons set, it will not be written to the file.
 
 If \ **-d**\  is specified, \ **makeconservercf**\  will remove specified nodes from /etc/conserver.cf file. If \ *noderange*\  is not specified, all xCAT nodes will be removed from /etc/conserver.cf file.
 
-If \ **-C|-**\ **-cleanup**\  is specified, \ **makeconservercf**\  will remove console configuration entries from /etc/conserver.cf for the nodes whose definition have been removed from xCATdb. \ **Don't**\  specify any noderange.
+If \ **-C|-**\ **-cleanup**\  is specified, \ **makeconservercf**\  will remove console configuration entries from /etc/conserver.cf for the nodes whose definitions have been removed from xCATdb. \ **Don't**\  specify any noderange.
 
 In the case of a hierarchical cluster (i.e. one with service nodes) \ **makeconservercf**\  will determine
 which nodes will have their consoles accessed from the management node and which from a service node
@@ -66,7 +66,7 @@ OPTIONS
 
 \ **-C|-**\ **-cleanup**\ 
  
- Remove the entries for the nodes whose definition have been removed from xCAT db.
+ Remove the entries for the nodes whose definitions have been removed from xCAT db.
  
 
 

--- a/docs/source/guides/admin-guides/references/man8/makeconservercf.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/makeconservercf.8.rst
@@ -21,6 +21,8 @@ SYNOPSIS
 
 \ **makeconservercf**\  [\ **-V|-**\ **-verbose**\ ] [\ **-d|-**\ **-delete**\ ] [\ *noderange*\ ]
 
+\ **makeconservercf**\  [\ **-V|-**\ **-verbose**\ ] [\ **-C|-**\ **-cleanup**\ ]
+
 \ **makeconservercf**\  [\ **-V|-**\ **-verbose**\ ] [\ **-l|-**\ **-local**\ ] [\ *noderange*\ ]
 
 \ **makeconservercf**\  [\ **-V|-**\ **-verbose**\ ] [\ **-c|-**\ **-conserver**\ ] [\ *noderange*\ ]
@@ -42,6 +44,8 @@ does not have nodehm.cons set, it will not be written to the file.
 
 If \ **-d**\  is specified, \ **makeconservercf**\  will remove specified nodes from /etc/conserver.cf file. If \ *noderange*\  is not specified, all xCAT nodes will be removed from /etc/conserver.cf file.
 
+If \ **-C|-**\ **-cleanup**\  is specified, \ **makeconservercf**\  will remove console configuration entries from /etc/conserver.cf for the nodes whose definition have been removed from xCATdb. \ **Don't**\  specify any noderange.
+
 In the case of a hierarchical cluster (i.e. one with service nodes) \ **makeconservercf**\  will determine
 which nodes will have their consoles accessed from the management node and which from a service node
 (based on the nodehm.conserver attribute).  The /etc/conserver.cf file will be created accordingly on
@@ -57,6 +61,12 @@ OPTIONS
 \ **-d|-**\ **-delete**\ 
  
  Delete rather than add or refresh the nodes specified as a noderange.
+ 
+
+
+\ **-C|-**\ **-cleanup**\ 
+ 
+ Remove the entries for the nodes whose definition have been removed from xCAT db.
  
 
 

--- a/xCAT-client/pods/man1/rmdef.1.pod
+++ b/xCAT-client/pods/man1/rmdef.1.pod
@@ -58,7 +58,7 @@ A set of comma delimited object types.
 
 =item B<-C|--cleanup>
 
-Perform additional cleanup by running B<nodeset offline> on the objects specified in the I<noderange>.
+Perform additional cleanup by running B<nodeset offline> and B<makeconservercf -d> on the objects specified in the I<noderange>.
 
 =item B<-V|--verbose>
 

--- a/xCAT-client/pods/man8/makeconservercf.8.pod
+++ b/xCAT-client/pods/man8/makeconservercf.8.pod
@@ -26,7 +26,7 @@ does not have nodehm.cons set, it will not be written to the file.
 
 If B<-d> is specified, B<makeconservercf> will remove specified nodes from /etc/conserver.cf file. If I<noderange> is not specified, all xCAT nodes will be removed from /etc/conserver.cf file. 
 
-If B<-C|--cleanup> is specified, B<makeconservercf> will remove console configuration entries from /etc/conserver.cf for the nodes whose definition have been removed from xCATdb. B<Don't> specify any noderange.
+If B<-C|--cleanup> is specified, B<makeconservercf> will remove console configuration entries from /etc/conserver.cf for the nodes whose definitions have been removed from xCATdb. B<Don't> specify any noderange.
 
 In the case of a hierarchical cluster (i.e. one with service nodes) B<makeconservercf> will determine
 which nodes will have their consoles accessed from the management node and which from a service node
@@ -44,7 +44,7 @@ Delete rather than add or refresh the nodes specified as a noderange.
 
 =item B<-C|--cleanup>
 
-Remove the entries for the nodes whose definition have been removed from xCAT db.
+Remove the entries for the nodes whose definitions have been removed from xCAT db.
 
 =item B<-c|--conserver>
 

--- a/xCAT-client/pods/man8/makeconservercf.8.pod
+++ b/xCAT-client/pods/man8/makeconservercf.8.pod
@@ -6,6 +6,8 @@ B<makeconservercf> - creates the conserver configuration file from info in the x
 
 B<makeconservercf> [B<-V|--verbose>] [B<-d|--delete>] [I<noderange>]
 
+B<makeconservercf> [B<-V|--verbose>] [B<-C|--cleanup>]
+
 B<makeconservercf> [B<-V|--verbose>] [B<-l|--local>] [I<noderange>]
 
 B<makeconservercf> [B<-V|--verbose>] [B<-c|--conserver>] [I<noderange>]
@@ -24,6 +26,8 @@ does not have nodehm.cons set, it will not be written to the file.
 
 If B<-d> is specified, B<makeconservercf> will remove specified nodes from /etc/conserver.cf file. If I<noderange> is not specified, all xCAT nodes will be removed from /etc/conserver.cf file. 
 
+If B<-C|--cleanup> is specified, B<makeconservercf> will remove console configuration entries from /etc/conserver.cf for the nodes whose definition have been removed from xCATdb. B<Don't> specify any noderange.
+
 In the case of a hierarchical cluster (i.e. one with service nodes) B<makeconservercf> will determine
 which nodes will have their consoles accessed from the management node and which from a service node
 (based on the nodehm.conserver attribute).  The /etc/conserver.cf file will be created accordingly on
@@ -37,6 +41,10 @@ all relevant management/service nodes.  If B<-l> is specified, it will only crea
 =item B<-d|--delete>
 
 Delete rather than add or refresh the nodes specified as a noderange.
+
+=item B<-C|--cleanup>
+
+Remove the entries for the nodes whose definition have been removed from xCAT db.
 
 =item B<-c|--conserver>
 

--- a/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
+++ b/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
@@ -4417,6 +4417,12 @@ sub defrm
                 node => [@allnodes],
                 arg  => ['offline'],
             }, $doreq, 0 ,1);
+
+            # Run makeconservercf -d <node>
+            @output = xCAT::Utils->runxcmd({
+                command => ['makeconservercf'],
+                node => [@allnodes],
+                arg => ['-d'],}, $doreq, 0, 1);
         }
     }
 

--- a/xCAT-server/lib/xcat/plugins/conserver.pm
+++ b/xCAT-server/lib/xcat/plugins/conserver.pm
@@ -29,7 +29,7 @@ my $usage_string =
                      The default goes down to all the conservers on
                      the server nodes and set them up
     -d|--delete      Conserver has the relevant entries for the given noderange removed immediately from configuration
-    -C|--cleanup     To remove the entries for the nodes not exists in xCAT db
+    -C|--cleanup     To remove the entries for the nodes that do not exist in xCAT db
     -t|--trust       Add additional trusted hosts.
     -h|--help        Display this usage statement.
     -V|--verbose     Verbose mode.

--- a/xCAT-server/lib/xcat/plugins/conserver.pm
+++ b/xCAT-server/lib/xcat/plugins/conserver.pm
@@ -8,6 +8,7 @@ use xCAT::TableUtils;
 use Getopt::Long;
 use Sys::Hostname;
 use xCAT::SvrUtils;
+use xCAT::Scope;
 
 use strict;
 use Data::Dumper;
@@ -28,6 +29,7 @@ my $usage_string =
                      The default goes down to all the conservers on
                      the server nodes and set them up
     -d|--delete      Conserver has the relevant entries for the given noderange removed immediately from configuration
+    -C|--cleanup     To remove the entries for the nodes not exists in xCAT db
     -t|--trust       Add additional trusted hosts.
     -h|--help        Display this usage statement.
     -V|--verbose     Verbose mode.
@@ -71,6 +73,7 @@ sub preprocess_request {
             'l|local'     => \$::LOCAL,
             'h|help'      => \$::HELP,
             'D|debug'     => \$::DEBUG,
+            'C|cleanup'   => \$::CLEANUP,
             'v|version'   => \$::VERSION,
             'V|verbose'   => \$::VERBOSE)) {
         $request = {};
@@ -98,8 +101,25 @@ sub preprocess_request {
         $request = {};
         return;
     }
-
-
+    if ($::CLEANUP && ($::CONSERVER or $::LOCAL)) {
+        $callback->({ data => "Can not specify -l|--local or -c|--conserver together with -C|--cleanup." });
+        $request = {};
+        return;
+    }
+    # The cleanup shall run on both MN and all SNs
+    if ($::CLEANUP) {
+        if ($noderange && @$noderange > 0) {
+            $callback->({ data => "Can not specify noderange together with -C|--cleanup." });
+            $request = {};
+            return;
+        }
+        my @sns = xCAT::ServiceNodeUtils->getSNList();
+        unless ( @sns > 0 ) {
+            return xCAT::Scope->get_parallel_scope($request);
+        }
+        return xCAT::Scope->get_broadcast_scope_with_parallel($request, \@sns);
+    }
+   
     # get site master
     my $master = xCAT::TableUtils->get_site_Master();
     if (!$master) { $master = hostname(); }
@@ -335,7 +355,8 @@ sub makeconservercf {
     #$Getopt::Long::pass_through=1;
     my $delmode;
     GetOptions('d|delete' => \$delmode,
-        't|trust=s' => \$::TRUSTED_HOST
+        't|trust=s' => \$::TRUSTED_HOST,
+        'C|cleanup' => \$::CLEANUP,
     );
     my $nodes  = $req->{node};
     my $svboot = 0;
@@ -409,6 +430,18 @@ sub makeconservercf {
             #$cb->({node=>[{name=>$node,error=>"Bad configuration, check attributes under the nodehm category",errorcode=>1}]});
             xCAT::SvrUtils::sendmsg([ 1, "Bad configuration, check attributes under the nodehm category" ], $cb, $node);
         }
+    } elsif ($::CLEANUP) {
+        my $nodelstab = xCAT::Table->new('nodelist');
+        my @allnodeset = $nodelstab->getAllAttribs('node');
+        my %allnodehash = map { $_->{node} => 1 } @allnodeset;
+        my $rmnodes = delete_undefined_nodes_entry(\@filecontent, \%allnodehash);
+        my $rsp;
+        if (!defined($rmnodes)) {
+            $rsp->{data}->[0] = "Nothing removed";
+        } else{
+            $rsp->{data}->[0] = "Remove console entry for the nodes:".join(',', @$rmnodes);
+        }
+        xCAT::MsgUtils->message("I", $rsp, $cb); 
     } else {    #no nodes specified, do em all up
         zapcfg(\@filecontent);    # strip all xCAT configured nodes from config
 
@@ -607,6 +640,41 @@ sub donodeent {
         push @$content, "#xCAT END $node CONS\n";
     }
     return 0;
+}
+# Remove cons entries for the undefined nodes
+sub delete_undefined_nodes_entry {
+    my $content = shift;
+    my $allnodeshash = shift;
+    my $idx      = 0;
+    my $toidx    = -1;
+    my $skip     = 0;
+    my $skipnext = 0;
+    my @rmnodes = ();
+    while ($idx <= $#$content) {
+        if ($content->[$idx] =~ /^#xCAT BEGIN (\S+) CONS/) {
+            $toidx   = $idx;
+            my $node = $1;
+            unless (exists($allnodeshash->{$node})) {
+                $skip  = 1;
+                $skipnext = 1; 
+                push @rmnodes, $node;
+                print __LINE__."===== push node: $node==\n";
+            }
+        } elsif ($content->[$idx] =~ /^#xCAT END/) {
+            $skipnext = 0;
+        }
+        if ($skip) {
+            splice(@$content, $idx, 1);
+        } else {
+            $idx++;
+        }
+        $skip = $skipnext;
+    }
+    if (scalar(@rmnodes) > 0) {
+        return \@rmnodes;
+    } else {
+        return undef;
+    }
 }
 
 # Delete any xcat added node entries from the file


### PR DESCRIPTION
Fix issue #4293 
The UT is as below:
```
root@c910f03c05k10:/tmp# mkdef -t node test01 groups=all mgt=ipmi cons=ipmi
1 object definitions have been created or modified.
root@c910f03c05k10:/tmp# makeconservercf test01
root@c910f03c05k10:/tmp# cat /etc/conserver.cf | grep test01 -A2
#xCAT BEGIN test01 CONS
console test01 {
  type exec;
  exec /opt/xcat/share/xcat/cons/ipmi test01;
}
#xCAT END test01 CONS
root@c910f03c05k10:/tmp# rmdef test01
1 object definitions have been removed.
root@c910f03c05k10:/tmp# cp /etc/conserver.cf /etc/conserver.cf_bak
root@c910f03c05k10:/tmp# makeconservercf -C
Remove console entry for the nodes:test01
root@c910f03c05k10:/tmp# diff /etc/conserver.cf /etc/conserver.cf_bak
342a343,348
> #xCAT BEGIN test01 CONS
> console test01 {
>   type exec;
>   exec /opt/xcat/share/xcat/cons/ipmi test01;
> }
> #xCAT END test01 CONS
root@c910f03c05k10:/tmp#
```
Hi, @whowutwut , do you think we can add the steps above as a test case for `makeconserver`?