### PR TITLE
Improve the message when BMC is not responding correctly 

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1519,7 +1519,7 @@ sub fork_process_login {
         sleep(1);
         $rst = 1;
     } elsif ($child == 0) {
-        exit(login_logout_request($node));
+        exit(login_request($node));
     } else {
         $login_pid_node{$child} = $node;
     }
@@ -1820,7 +1820,7 @@ sub process_debug_info {
 
 #-------------------------------------------------------
 
-=head3  login_logout_request
+=head3  login_request
 
   Send login request using curl command
   Input:
@@ -1829,7 +1829,7 @@ sub process_debug_info {
 =cut
 
 #-------------------------------------------------------
-sub login_logout_request {
+sub login_request {
     my $node = shift;
 
     my $login_url = "$http_protocol://" . $node_info{$node}{bmc} . "/login";

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -685,7 +685,7 @@ sub process_request {
 
     foreach my $node (keys %node_info) {
         if (!$valid_nodes{$node}) {
-            xCAT::SvrUtils::sendmsg([1, "BMC did not respond. Verify BMC is in BMCReady state and retry the command."], $callback, $node);
+            xCAT::SvrUtils::sendmsg([1, "BMC did not respond. Validate BMC configuration and retry the command."], $callback, $node);
             $wait_node_num--;
         } else {
             $login_url = "$http_protocol://$node_info{$node}{bmc}/login";
@@ -1844,10 +1844,7 @@ sub login_logout_request {
     my $login_response = $brower->request($login_request);
 
     if  ($login_response->status_line =~ /500 Can't connect to/ or $login_response->status_line =~ /500 read timeout/) {
-        if ($xcatdebugmode) {
-            my $debug_info = "LOGIN Failed using curl command";
-            process_debug_info($node, $debug_info);
-        }
+        xCAT::SvrUtils::sendmsg([1 ,"Login to BMC failed. Status: " . $login_response->status_line . "."], $callback, $node);
         return 1;
     }
 

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -441,6 +441,7 @@ $::RESPONSE_OK                  = "200 OK";
 $::RESPONSE_SERVER_ERROR        = "500 Internal Server Error";
 $::RESPONSE_SERVICE_UNAVAILABLE = "503 Service Unavailable";
 $::RESPONSE_FORBIDDEN           = "403 Forbidden";
+$::RESPONSE_NOT_FOUND           = "404 Not Found";
 $::RESPONSE_METHOD_NOT_ALLOWED  = "405 Method Not Allowed";
 $::RESPONSE_SERVICE_TIMEOUT     = "504 Gateway Timeout";
 
@@ -1843,7 +1844,9 @@ sub login_request {
     my $login_request = HTTP::Request->new( 'POST', $login_url, $header, $data );
     my $login_response = $brower->request($login_request);
 
-    if  ($login_response->status_line =~ /500 Can't connect to/ or $login_response->status_line =~ /500 read timeout/) {
+    # Check the return code
+    if ($login_response->code != 200) { 
+        # handle the errors generically
         xCAT::SvrUtils::sendmsg([1 ,"Login to BMC failed. Status: " . $login_response->status_line . "."], $callback, $node);
         return 1;
     }


### PR DESCRIPTION
Resolve #4403 

* Improve the message when BMC does not respond correctly, asking admins to verify BMCReady is not helpful because we can't get that state back if the BMC is configured incorrectly.
* Make sure the RC is 200 OK before processing past the login request 

## Before changes: 

BMC IP down
```
[root@stratton01 ~]# chdef p9euh01 bmc=10.6.7.254
1 object definitions have been created or modified.
[root@stratton01 ~]#  rpower p9euh01 state
p9euh01: Error: BMC did not respond. Verify BMC is in BMCReady state and retry the command.
```

Set node to non OpenBMC IP, pingable
```
[root@stratton01 ~]# chdef p9euh01 bmc=50.5.39.2
1 object definitions have been created or modified.
[root@stratton01 ~]#  rpower p9euh02 state
p9euh02: Error: BMC did not respond. Verify BMC is in BMCReady state and retry the command.
[root@stratton01 ~]# XCATBYPASS=1 rpower p9euh01 state
malformed JSON string, neither array, object, number, string or atom, at character offset 0 (before "<?xml version="1.0" ...") at /opt/xcat/lib/perl/xCAT_plugin/openbmc.pm line 1748.
```


## After: 

BMC IP down 
```
[root@stratton01 ~]# chdef p9euh01 bmc=10.6.7.254
1 object definitions have been created or modified.
[root@stratton01 ~]# rpower p9euh01 state
p9euh01: Error: Login to BMC failed. Status: 500 Can't connect to 10.6.7.254:443 (No route to host).
p9euh01: Error: BMC did not respond. Validate BMC configuration and retry the command.
[root@stratton01 ~]# XCATBYPASS=1 rpower p9euh01 state
p9euh01: Error: Login to BMC failed. Status: 500 Can't connect to 10.6.7.254:443 (No route to host).
p9euh01: Error: BMC did not respond. Validate BMC configuration and retry the command.
[root@stratton01 ~]#
```
Set node to non OpenBMC IP, pingable 
```
[root@stratton01 ~]# chdef p9euh01 bmc=50.5.39.2
1 object definitions have been created or modified.
[root@stratton01 ~]# rpower p9euh01 state
p9euh01: Error: Login to BMC failed. Status: 404 Not Found.
p9euh01: Error: BMC did not respond. Validate BMC configuration and retry the command.
[root@stratton01 ~]# XCATBYPASS=1 rpower p9euh01 state
p9euh01: Error: Login to BMC failed. Status: 404 Not Found.
p9euh01: Error: BMC did not respond. Validate BMC configuration and retry the command.
[root@stratton01 ~]#
```

## Success case 

```
[root@stratton01 ~]# chdef p9euh01 bmc=9.114.120.111
1 object definitions have been created or modified.
[root@stratton01 ~]# rpower p9euh01 state
p9euh01: off
[root@stratton01 ~]# XCATBYPASS=1 rpower p9euh01 state
p9euh01: off
```