### PR TITLE
OpenBMC rspconfig dump timeout fixes

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -65,7 +65,7 @@ $::UPLOAD_WAIT_TOTALTIME    = int($::UPLOAD_WAIT_ATTEMPT*$::UPLOAD_WAIT_INTERVAL
 $::RPOWER_CHECK_INTERVAL    = 2;
 $::RPOWER_MAX_RETRY         = 30;
 
-$::RSPCONFIG_DUMP_INTERVAL  = 30;
+$::RSPCONFIG_DUMP_INTERVAL  = 15;
 $::RSPCONFIG_DUMP_MAX_RETRY = 20;
 $::RSPCONFIG_DUMP_WAIT_TOTALTIME = int($::RSPCONFIG_DUMP_INTERVAL*$::RSPCONFIG_DUMP_MAX_RETRY);
 
@@ -2762,6 +2762,9 @@ sub rspconfig_dump_response {
             if ( $node_info{$node}{dump_wait_attemp} > 0) {
                 $node_info{$node}{dump_wait_attemp} --; 
                 retry_after($node, "RSPCONFIG_DUMP_LIST_REQUEST", $::RSPCONFIG_DUMP_INTERVAL);
+                unless ($node_info{$node}{dump_wait_attemp} % int(8)) { # display message every 8 iterations of the interval
+                    xCAT::SvrUtils::sendmsg("Still waiting for dump $node_info{$node}{dump_id} to be generated...", $callback, $node);
+                }
                 return;
             } else {
                 xCAT::SvrUtils::sendmsg([1,"Could not find dump $node_info{$node}{dump_id} after waiting $::RSPCONFIG_DUMP_WAIT_TOTALTIME seconds."], $callback, $node);


### PR DESCRIPTION
Fixes issue #4404 

1. Reduce timeout to 5 min
2. Print "Still processing..." message every 2 min.

```
[root@briggs01 xCAT_plugin]# rspconfig mid05tor12cn16 dump
Capturing BMC Diagnostic information, this will take some time...
mid05tor12cn16: Dump requested. Target ID is 32, waiting for BMC to generate...
mid05tor12cn16: Still waiting for dump 32 to be generated...
mid05tor12cn16: Still waiting for dump 32 to be generated...
mid05tor12cn16: Still waiting for dump 32 to be generated...
mid05tor12cn16: Error: Could not find dump 32 after waiting 300 seconds.
[root@briggs01 xCAT_plugin]#
```