### PR TITLE
Fix issue 4408, modify error for rspconfig dump

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2812,7 +2812,7 @@ sub rspconfig_dump_response {
         if ($node_info{$node}{method} || $status_info{ $node_info{$node}{cur_status} }{method}) {
             gen_send_request($node);
         } elsif ($status_info{ $node_info{$node}{cur_status} }->{process}) {
-            $status_info{ $node_info{$node}{cur_status} }->{process}->($node, undef);
+            $status_info{ $node_info{$node}{cur_status} }->{process}->($node, undef) if ($node_info{$node}{cur_status} eq "RSPCONFIG_DUMP_DOWNLOAD_REQUEST");
         }
     } else {
         $wait_node_num--;


### PR DESCRIPTION
#4408 

UT result:
```
# rspconfig mid05tor12cn02,mid05tor12cn16 dump
Capturing BMC Diagnostic information, this will take some time...
mid05tor12cn02: Dump requested. Target ID is 39, waiting for BMC to generate...
mid05tor12cn16: Dump requested. Target ID is 46, waiting for BMC to generate...
mid05tor12cn02: Dump 39 generated. Downloading to /var/log/xcat/dump/20171130213_mid05tor12cn02_dump_39.tar.xz
mid05tor12cn16: Dump 46 generated. Downloading to /var/log/xcat/dump/20171130210_mid05tor12cn16_dump_46.tar.xz
```

with ``-V``:
```
# rspconfig mid05tor12cn02,mid05tor12cn16 dump -V
[briggs01]: Capturing BMC Diagnostic information, this will take some time...
mid05tor12cn16: [briggs01]: Dump requested. Target ID is 49, waiting for BMC to generate...
mid05tor12cn02: [briggs01]: Dump requested. Target ID is 48, waiting for BMC to generate...
mid05tor12cn16: [briggs01]: Dump 49 generated. Downloading to /var/log/xcat/dump/201711302111_mid05tor12cn16_dump_49.tar.xz
mid05tor12cn02: [briggs01]: Dump 48 generated. Downloading to /var/log/xcat/dump/201711302114_mid05tor12cn02_dump_48.tar.xz
mid05tor12cn16: [briggs01]: Downloaded Dump 49 to /var/log/xcat/dump/201711302111_mid05tor12cn16_dump_49.tar.xz
mid05tor12cn02: [briggs01]: Downloaded Dump 48 to /var/log/xcat/dump/201711302114_mid05tor12cn02_dump_48.tar.xz
```