### PR TITLE
Fix bug for xcattest

### DIFF
--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -886,6 +886,9 @@ sub load_case {
                             }
                             $$case_name_index_map_ref{"$name"} = $i;
                             $newcmdstart                       = 0;
+                            if(grep (/$case_ref->[$i]->{name}/,@{ $invalidcases{"noruncases"} })){
+                                delete_item_from_array($case_ref->[$i]->{name}, $invalidcases{"noruncases"});
+                            }
                         } else {
                             $skip = 1;
                             push @{ $invalidcases{"invalidcasename"} }, $name;


### PR DESCRIPTION
This pull request to handle one case which have 2 implementations, which one is for specific platform, on is for all platforms.

For example:
```
start:rinv_dimm
description:get dimm information
Attribute: $$CN-The operation object of rinv command
cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rinv $$CN dimm
check:rc==0
end

start:rinv_dimm
description:this case is to test dimm option for rinv on x86_64 servers.
hcp:ipmi
arch:x86_64
cmd:rinv $$CN dimm
check:rc==0
check:output=~DIMM 1 :\s*\w+
check:output=~DIMM 1 Manufacture Date:\s*\w+
check:output=~DIMM 1 Manufacture Location:\s*\d+
check:output=~DIMM 1 Model:\s*\w+-\w+
end
```

Before changing, the ``rinv_dimm`` can not be loaded in openbmc scenario. 

The result after changing:
```
[root@c910f03c05k06 ~]# XCATTEST_CN=p9austin xcattest -t rinv_dimm
xCAT automated test started at Fri Dec  1 00:56:14 2017
******************************
To detect current test environment
******************************
Detecting: OS = linux
Detecting: ARCH = ppc64le
Detecting: HCP = openbmc
******************************
loading test cases
******************************
To run:
rinv_dimm
......
```