### PR TITLE
return when current status is RSPCONFIG_DUMP_DOWNLOAD_REQUEST

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2789,6 +2789,8 @@ sub rspconfig_dump_response {
         } else {
             $child_node_map{$child} = $node;
         }
+        $node_info{$node}{cur_status} = $next_status{ $node_info{$node}{cur_status} };
+        return;
     }
 
     if ($node_info{$node}{cur_status} eq "RSPCONFIG_DUMP_CREATE_RESPONSE") {
@@ -2820,7 +2822,7 @@ sub rspconfig_dump_response {
         if ($node_info{$node}{method} || $status_info{ $node_info{$node}{cur_status} }{method}) {
             gen_send_request($node);
         } elsif ($status_info{ $node_info{$node}{cur_status} }->{process}) {
-            $status_info{ $node_info{$node}{cur_status} }->{process}->($node, undef) if ($node_info{$node}{cur_status} eq "RSPCONFIG_DUMP_DOWNLOAD_REQUEST");
+            $status_info{ $node_info{$node}{cur_status} }->{process}->($node, undef);
         }
     } else {
         $wait_node_num--;


### PR DESCRIPTION
Handle status change in "RSPCONFIG_DUMP_DOWNLOAD_REQUEST" main process.

```
# rspconfig mid05tor12cn02,mid05tor12cn16 dump
Capturing BMC Diagnostic information, this will take some time...
mid05tor12cn16: Dump requested. Target ID is 55, waiting for BMC to generate...
mid05tor12cn02: Dump requested. Target ID is 49, waiting for BMC to generate...
mid05tor12cn02: Dump 49 generated. Downloading to /var/log/xcat/dump/201712118_mid05tor12cn02_dump_49.tar.xz
mid05tor12cn16: Still waiting for dump 55 to be generated...
mid05tor12cn16: Dump 55 generated. Downloading to /var/log/xcat/dump/201712115_mid05tor12cn16_dump_55.tar.xz
```