### PR TITLE
Update the bmcdiscover man page , remove --check and --ipsource options.

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/bmcdiscover.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/bmcdiscover.1.rst
@@ -25,10 +25,6 @@ SYNOPSIS
 
 \ **bmcdiscover**\  [\ **-**\ **-sn**\  \ *SN_nodename*\ ] [\ **-s**\  \ *scan_method*\ ] [\ **-u**\  \ *bmc_user*\ ] [\ **-p**\  \ *bmc_passwd*\ ] [\ **-z**\ ] [\ **-w**\ ] \ **-**\ **-range**\  \ *ip_ranges*\ 
 
-\ **bmcdiscover**\  \ **-u**\  \ *bmc_user*\  \ **-p**\  \ *bmc_passwd*\  \ **-i**\  \ *bmc_ip*\  \ **-**\ **-check**\ 
-
-\ **bmcdiscover**\  [\ **-u**\  \ *bmc_user*\ ] [\ **-p**\  \ *bmc_passwd*\ ] \ **-i**\  \ *bmc_ip*\  \ **-**\ **-ipsource**\ 
-
 
 ***********
 DESCRIPTION
@@ -95,18 +91,6 @@ OPTIONS
 \ **-p|-**\ **-bmcpasswd**\ 
  
  BMC user password.
- 
-
-
-\ **-**\ **-check**\ 
- 
- Check BMC administrator User/Password.
- 
-
-
-\ **-**\ **-ipsource**\ 
- 
- Display the BMC IP configuration.
  
 
 
@@ -185,22 +169,6 @@ Output is similar to:
 .. code-block:: perl
 
      bmcdiscover -s nmap --range "10.4.22-23.100-254" -w -z
-
-
-5. To check if the username or password is correct against the BMC:
-
-
-.. code-block:: perl
-
-     bmcdiscover -i 10.4.23.254 -u USERID -p PASSW0RD --check
-
-
-6. Get BMC IP Address source, DHCP Address or static Address
-
-
-.. code-block:: perl
-
-     bmcdiscover -i 10.4.23.254 -u USERID -p PASSW0RD --ipsource
 
 
 

--- a/xCAT-client/pods/man1/bmcdiscover.1.pod
+++ b/xCAT-client/pods/man1/bmcdiscover.1.pod
@@ -10,10 +10,6 @@ B<bmcdiscover> [B<-v>|B<--version>]
 
 B<bmcdiscover> [B<--sn> I<SN_nodename>] [B<-s> I<scan_method>] [B<-u> I<bmc_user>] [B<-p> I<bmc_passwd>] [B<-z>] [B<-w>] B<--range> I<ip_ranges>
 
-B<bmcdiscover> B<-u> I<bmc_user> B<-p> I<bmc_passwd> B<-i> I<bmc_ip> B<--check>
-
-B<bmcdiscover> [B<-u> I<bmc_user>] [B<-p> I<bmc_passwd>] B<-i> I<bmc_ip> B<--ipsource> 
-
 
 =head1 DESCRIPTION
 
@@ -60,14 +56,6 @@ BMC user name.
 =item B<-p|--bmcpasswd>   
 
 BMC user password.
-
-=item B<--check>    
-
-Check BMC administrator User/Password.
-
-=item B<--ipsource>    
-
-Display the BMC IP configuration.
 
 =item B<-h|--help>
 
@@ -116,14 +104,6 @@ Output is similar to:
 4. Discover the BMCs and write the discovered-node definitions into the xCAT database and write out the stanza foramt to the console:
 
     bmcdiscover -s nmap --range "10.4.22-23.100-254" -w -z 
-
-5. To check if the username or password is correct against the BMC:
-
-    bmcdiscover -i 10.4.23.254 -u USERID -p PASSW0RD --check
-
-6. Get BMC IP Address source, DHCP Address or static Address
-
-    bmcdiscover -i 10.4.23.254 -u USERID -p PASSW0RD --ipsource
 
 =head1 SEE ALSO
 

--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -194,12 +194,6 @@ sub bmcdiscovery_usage {
     push @{ $rsp->{data} }, "\tbmcdiscover [-v|--version]";
     push @{ $rsp->{data} }, "\tbmcdiscover [--sn <SN_nodename>] [-s scan_method] [-u bmc_user] [-p bmc_passwd] [-z] [-w] --range ip_range\n";
 
-    push @{ $rsp->{data} }, "\tCheck BMC administrator User/Password:\n";
-    push @{ $rsp->{data} }, "\t\tbmcdiscover -u bmc_user -p bmc_password -i bmc_ip --check\n";
-
-    push @{ $rsp->{data} }, "\tDisplay the BMC IP configuration:\n";
-    push @{ $rsp->{data} }, "\t\tbmcdiscover [-u bmc_user] [-p bmc_passwd] -i bmc_ip --ipsource";
-
     xCAT::MsgUtils->message("I", $rsp, $::CALLBACK);
     return 0;
 }

--- a/xCAT-test/autotest/testcase/bmcdiscover/cases0
+++ b/xCAT-test/autotest/testcase/bmcdiscover/cases0
@@ -51,19 +51,13 @@ end
 start:bmcdiscover_check_paswd
 cmd:bmcdiscover -i $$bmcrange -u $$bmcusername -p $$bmcpasswd --check
 check:rc==0
-check:output=~Correct ADMINISTRATOR
-end
-
-start:bmcdiscover_check_passwd_wrong
-cmd:bmcdiscover -i $$bmcrange -u $$bmcusername -p test$$bmcpasswd --check
-check:rc==0
-check:output=~Invalid username or password | Wrong BMC password
+check:output=~is not supported
 end
 
 start:bmcdiscover_get_ipsource
 cmd:bmcdiscover -i $$bmcrange -u $$bmcusername -p $$bmcpasswd --ipsource
 check:rc==0
-check:output=~Static Address
+check:output=~is not supported
 end
 
 start:bmcdiscover_range_w
@@ -73,12 +67,6 @@ check:output=~Writing node
 check:output=~$$bmcrange,\w*,\w*,$$bmcusername,$$bmcpasswd 
 end
 
-start:bmcdiscover_range_u_p_i_ipsource
-description:check the bmcrange is which type address
-cmd:bmcdiscover -i  $$bmcrange -u $$bmcusername -p $$bmcpasswd --ipsource
-check:rc==0
-check:output=~IP Address Source       : Static Address
-end
 start:bmcdiscover_range_z
 cmd:bmcdiscover --range  $$bmcrange -u $$bmcusername -p $$bmcpasswd -z
 check:rc==0

--- a/xCAT-test/autotest/testcase/bmcdiscover/cases0
+++ b/xCAT-test/autotest/testcase/bmcdiscover/cases0
@@ -50,13 +50,13 @@ end
 
 start:bmcdiscover_check_paswd
 cmd:bmcdiscover -i $$bmcrange -u $$bmcusername -p $$bmcpasswd --check
-check:rc==0
+check:rc==1
 check:output=~is not supported
 end
 
 start:bmcdiscover_get_ipsource
 cmd:bmcdiscover -i $$bmcrange -u $$bmcusername -p $$bmcpasswd --ipsource
-check:rc==0
+check:rc==1
 check:output=~is not supported
 end
 


### PR DESCRIPTION
Resolves #4398

Removed in #4258, but never updated the associated xCAT documentation: 

```
[root@briggs01 dump]# bmcdiscover -u root -p 0penBmc -i 172.11.139.16 --check
Error: The option '--check' is not supported
[root@briggs01 dump]# bmcdiscover -u root -p 0penBmc -i 172.11.139.16 --ipsource
Error: The option '--ipsource' is not supported
```