### PR TITLE
OpenBMC rspconfig dump enhancements

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -585,6 +585,12 @@ sub preprocess_request {
 
     $callback  = shift;
 
+    if ($::XCATSITEVALS{xcatdebugmode}) { $xcatdebugmode = $::XCATSITEVALS{xcatdebugmode} }
+
+    if ($xcatdebugmode) {
+        process_debug_info("OpenBMC");
+    }
+
     my $command   = $request->{command}->[0];
     my $noderange = $request->{node};
     my $extrargs  = $request->{arg};
@@ -704,8 +710,6 @@ sub process_request {
     if (ref($extrargs)) {
         @exargs = @$extrargs;
     }
-
-    if ($::XCATSITEVALS{xcatdebugmode}) { $xcatdebugmode = $::XCATSITEVALS{xcatdebugmode} }
 
     my $check = parse_node_info($noderange);
     my $rst = parse_command_status($command, \@exargs);
@@ -1739,9 +1743,6 @@ sub fork_process_login {
         sleep(1);
         $rst = 1;
     } elsif ($child == 0) {
-        if ($xcatdebugmode) {
-            process_debug_info($node, "Attempting to login");
-        }
         exit(login_request($node));
     } else {
         $login_pid_node{$child} = $node;

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1739,6 +1739,9 @@ sub fork_process_login {
         sleep(1);
         $rst = 1;
     } elsif ($child == 0) {
+        if ($xcatdebugmode) {
+            process_debug_info($node, "Attempting to login");
+        }
         exit(login_request($node));
     } else {
         $login_pid_node{$child} = $node;


### PR DESCRIPTION
Some enhancements to `rspconfig dump` command suggested in #4423 

This pull request:

1. Uses the time of the `rspconfig` command in the name of the dump file instead of the time of the dump generation
2. Checks that dump directory exists before downloading file there.
3. Builds a path to the `dump` and `rflash` directories instead of constants, so that in the future we can add a flag to specify a directory.

* Dumps downloaded:
```
[root@briggs01 xCAT_plugin]# rspconfig mid05tor12cn16,mid05tor12cn05 dump
Capturing BMC Diagnostic information, this will take some time...
mid05tor12cn16: Dump requested. Target ID is 89, waiting for BMC to generate...
mid05tor12cn05: Dump requested. Target ID is 39, waiting for BMC to generate...
mid05tor12cn05: Still waiting for dump 39 to be generated...
mid05tor12cn16: Still waiting for dump 89 to be generated...
mid05tor12cn05: Dump 39 generated. Downloading to /var/log/xcat/dump/20171201-1644_mid05tor12cn05_dump_39.tar.xz
mid05tor12cn16: Dump 89 generated. Downloading to /var/log/xcat/dump/20171201-1644_mid05tor12cn16_dump_89.tar.xz
[root@briggs01 xCAT_plugin]#
```

* Dump download directory was not created:
```
[root@briggs01 xCAT_plugin]# rspconfig mid05tor12cn16,mid05tor12cn05 dump
Capturing BMC Diagnostic information, this will take some time...
mid05tor12cn16: Dump requested. Target ID is 90, waiting for BMC to generate...
mid05tor12cn05: Dump requested. Target ID is 40, waiting for BMC to generate...
mid05tor12cn16: Still waiting for dump 90 to be generated...
mid05tor12cn05: Still waiting for dump 40 to be generated...
mid05tor12cn16: Error: Unable to find directory /var/log/xcat/dump/ to download dump file
mid05tor12cn05: Error: Unable to find directory /var/log/xcat/dump/ to download dump file
[root@briggs01 xCAT_plugin]#
```