### PR TITLE
Add dhcp-client-identifier to lease block

### DIFF
--- a/xCAT-server/lib/xcat/plugins/dhcp.pm
+++ b/xCAT-server/lib/xcat/plugins/dhcp.pm
@@ -747,6 +747,7 @@ sub addnode
             print $omshell "new host\n";
             print $omshell "set name = \"$hostname\"\n";
             print $omshell "set hardware-address = " . $mac . "\n";
+            print $omshell "set dhcp-client-identifier = " . $mac . "\n";
             print $omshell "set hardware-type = $hardwaretype\n";
 
             if ($ip eq "DENIED")


### PR DESCRIPTION
Machines that use Infiniband for PXE booting need to have the
dhcp-client-identifier set in the lease block.
Without it, they will not get the lease from the server.

This change adds dhcp-client-identifier along side the hardware address.
The line appears as "uid <mac>" in the lease file.
