### PR TITLE
Improve the message on the HTTP response on failure

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1777,7 +1777,7 @@ sub deal_with_response {
                 if ($node_info{$node}{cur_status} eq "RFLASH_DELETE_IMAGE_RESPONSE") { 
                     $error = "Invalid ID provided to delete.  Use the -l option to view valid firmware IDs.";
                 } else {
-                    $error = "[" . $response->code . "] Path or object not found: $1";
+                    $error = "[" . $response->code . "] " . $response_info->{'data'}->{'description'};
                 }
             } else {
                 $error = "[" . $response->code . "] " . $response_info->{'data'}->{'description'};

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1852,8 +1852,8 @@ sub login_request {
     my $login_response = $brower->request($login_request);
 
     # Check the return code
-    if ($login_response->code != 200) { 
-        # handle the errors generically
+    if ($login_response->code eq 500 or $login_response->code eq 404) { 
+        # handle only 404 and 504 in this code, defer to deal_with_response for the rest
         xCAT::SvrUtils::sendmsg([1 ,"[" . $login_response->code . "] Login to BMC failed: " . $login_response->status_line . "."], $callback, $node);
         return 1;
     }


### PR DESCRIPTION
Create this PR based on comments from #4407. 

@xuweibj for the login request, we should handle the response in this `login_request` function because if the BMC is not a OpenBMC node, it will respond to ping and then it will crap out in the `deal_with_response` because `$response->content` does not have anything in it.. 


UT: 
```
[root@stratton01 autotest]# rpower p9euh01 state
p9euh01: Error: [500] Login to BMC failed: 500 Can't connect to 10.6.7.254:443 (No route to host).
p9euh01: Error: BMC did not respond. Validate BMC configuration and retry the command.
[root@stratton01 autotest]# XCATBYPASS=1 rpower p9euh01 state
p9euh01: Error: [500] Login to BMC failed: 500 Can't connect to 10.6.7.254:443 (No route to host).
p9euh01: Error: BMC did not respond. Validate BMC configuration and retry the command.
```

Change to a machine that can ping, but BMC is not correct:
```
[root@stratton01 autotest]# chdef p9euh01 bmc=50.5.39.2
1 object definitions have been created or modified.
[root@stratton01 autotest]#  rpower p9euh01 state
p9euh01: Error: [404] Login to BMC failed: 404 Not Found.
p9euh01: Error: BMC did not respond. Validate BMC configuration and retry the command.
[root@stratton01 autotest]#  rpower p9euh01 state
p9euh01: Error: [404] Login to BMC failed: 404 Not Found.
p9euh01: Error: BMC did not respond. Validate BMC configuration and retry the command.
```

Running UT: 
```
------Total: 16 , Failed: 2------

```

the two failures are because of the ZeroConfigIB allowing for multiple inets to be set on the BMC, we don't have that supported yet. 