### PR TITLE
Ignore the ZeroConfigIP addresses in the display function of rspconfig

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2425,6 +2425,8 @@ sub rspconfig_response {
         my $path;
         my @output;
         my $grep_string = $status_info{RSPCONFIG_GET_RESPONSE}{argv};
+        my $zeroConfigPrefix = "169.254";
+
         foreach my $key_url (keys %{$response_info->{data}}) {
             my %content = %{ ${ $response_info->{data} }{$key_url} };
 
@@ -2442,6 +2444,14 @@ sub rspconfig_response {
             
             if ($adapter_id) {
                 if (defined($content{Address}) and $content{Address}) {
+                    # Do not count the ZeroConfigIP inet as part of valid IP addresses to display
+                    if ($content{Address} =~ m/$zeroConfigPrefix/) { 
+                        if ($xcatdebugmode) {
+                            my $debugmsg = "Found ZeroConfigIP " . $content{Address} . " for interface " . $key_url . " Ignoring...";
+                            process_debug_info($node, $debugmsg);
+                        }
+                        next;
+                    }
                     unless ($address =~ /n\/a/) {
                         # We have already processed an entry with adapter information.
                         # This must be a second entry. Display an error. Currently only supporting


### PR DESCRIPTION
Quickly unblock issue in #4353

For OpenBMC version 2.0 and higher, ZeroConfigIPs were introduced.  This broke some of existing function that we had worked on for xCAT.  

These IP addresses start with 169.254.. and they should not be modified by the Admin.  So let's not display them as part of rspconfig.  Maybe in the future if we wanted to display all using a verbose we could bring it back in. 

UT 

## Before Fix:

Here's an example of before the fix, the effect of the ZeroConfigIP on xCAT
```
[root@briggs01 ~]# rspconfig p9up hostname
mid05tor12cn13: BMC Hostname: f6u13-bmc
mid05tor12cn16: BMC Hostname: cn16-bmc
mid05tor12cn11: Interfaces with multiple IP addresses are not supported
mid05tor12cn15: BMC Hostname: f6u15-bmc
mid05tor12cn02: BMC Hostname: witherspoon
mid05tor12cn05: Interfaces with multiple IP addresses are not supported
mid05tor12cn18: Interfaces with multiple IP addresses are not supported
```

Running UT on the 7 nodes:
```
[root@briggs01 autotest]# egrep "Total|Running" before_fix4431.log
==> Sun Dec  3 20:13:39 EST 2017 - Running test on mid05tor12cn02...
------Total: 16 , Failed: 0------
==> Sun Dec  3 20:14:03 EST 2017 - Running test on mid05tor12cn05...
------Total: 16 , Failed: 2------
==> Sun Dec  3 20:14:33 EST 2017 - Running test on mid05tor12cn11...
------Total: 16 , Failed: 2------
==> Sun Dec  3 20:15:00 EST 2017 - Running test on mid05tor12cn13...
------Total: 16 , Failed: 0------
==> Sun Dec  3 20:15:26 EST 2017 - Running test on mid05tor12cn15...
------Total: 16 , Failed: 0------
==> Sun Dec  3 20:15:56 EST 2017 - Running test on mid05tor12cn16...
------Total: 16 , Failed: 0------
==> Sun Dec  3 20:16:30 EST 2017 - Running test on mid05tor12cn18...
------Total: 16 , Failed: 2------
```

## After Fix

Running hostname:
```
[root@briggs01 ~]# rspconfig p9up hostname
mid05tor12cn13: BMC Hostname: f6u13-bmc
mid05tor12cn16: BMC Hostname: cn16-bmc
mid05tor12cn11: BMC Hostname: mid05tor12cn11-UTset
mid05tor12cn02: BMC Hostname: witherspoon
mid05tor12cn15: BMC Hostname: f6u15-bmc
mid05tor12cn05: BMC Hostname: mid05tor12cn05-UTset
mid05tor12cn18: BMC Hostname: mid05tor12cn18-UTset
```

Running UT cases again:
```
[root@briggs01 autotest]# egrep "Total|Running" after_fix4431.log
==> Sun Dec  3 20:33:18 EST 2017 - Running test on mid05tor12cn02...
------Total: 16 , Failed: 0------
==> Sun Dec  3 20:33:42 EST 2017 - Running test on mid05tor12cn05...
------Total: 16 , Failed: 0------
==> Sun Dec  3 20:34:14 EST 2017 - Running test on mid05tor12cn11...
------Total: 16 , Failed: 0------
==> Sun Dec  3 20:34:46 EST 2017 - Running test on mid05tor12cn13...
------Total: 16 , Failed: 0------
==> Sun Dec  3 20:35:10 EST 2017 - Running test on mid05tor12cn15...
------Total: 16 , Failed: 0------
==> Sun Dec  3 20:35:40 EST 2017 - Running test on mid05tor12cn16...
------Total: 16 , Failed: 0------
==> Sun Dec  3 20:36:13 EST 2017 - Running test on mid05tor12cn18...
------Total: 16 , Failed: 0------
```

## With `xcatdebugmode=1` we can easily see what is going on...
```
[root@briggs01 Logging]# rspconfig mid05tor12cn18 hostname
Sun Dec  3 20:34:36 2017 mid05tor12cn18: [openbmc_debug] curl -k -c cjar -H "Content-Type: application/json" -d '{ "data": ["root", "xxxxxx"] }' https://172.11.139.18/login
Sun Dec  3 20:34:36 2017 mid05tor12cn18: [openbmc_debug] login_response 200 OK
Sun Dec  3 20:34:36 2017 mid05tor12cn18: [openbmc_debug] curl -k -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.18/xyz/openbmc_project/network/enumerate
Sun Dec  3 20:34:37 2017 mid05tor12cn18: [openbmc_debug] rspconfig_get_response 200 OK
Sun Dec  3 20:34:37 2017 mid05tor12cn18: [openbmc_debug] Found ZeroConfigIP 169.254.80.3 for interface /xyz/openbmc_project/network/eth0/ipv4/370b212a Ignoring...
Sun Dec  3 20:34:37 2017 mid05tor12cn18: [openbmc_debug] Found ZeroConfigIP 169.254.181.81 for interface /xyz/openbmc_project/network/eth0_11/ipv4/ebbb9b13 Ignoring...
mid05tor12cn18: BMC Hostname: mid05tor12cn18-UTset
```