### PR TITLE
Use short hostname in rcons for goconserver

### DIFF
--- a/xCAT-client/bin/rcons
+++ b/xCAT-client/bin/rcons
@@ -148,13 +148,26 @@ elif [ $USE_GOCONSERVER == "1" ]; then
     CONGO_ENV="CONGO_SSL_KEY=$HOME/.xcat/client-cred.pem \
                CONGO_SSL_CERT=$HOME/.xcat/client-cred.pem \
                CONGO_SSL_CA_CERT=$HOME/.xcat/ca.pem \
-               CONGO_PORT=12430 \
-               CONGO_SERVER_HOST=$CONSERVER \
-               CONGO_URL=https://$CONSERVER:12429"
-
+               CONGO_PORT=12430"
     if [ "$CONSERVER" == `hostname` ]; then
+        host=`hostname -s`
+        if [ $? -ne 0 ]; then
+            echo "Error: could not get the short hostname for $CONSERVER."
+            exit 1
+        fi
+        CONGO_ENV="$CONGO_ENV \
+                   CONGO_SERVER_HOST=$host \
+                   CONGO_URL=https://$host:12429"
         exec env $CONGO_ENV /usr/bin/congo console $1
     else
+        host=`ssh $CONSERVER hostname -s`
+        if [ $? -ne 0 ]; then
+            echo "Error: could not get the short hostname for $CONSERVER."
+            exit 1
+        fi
+        CONGO_ENV="$CONGO_ENV \
+                   CONGO_SERVER_HOST=$host \
+                   CONGO_URL=https://$host:12429"
         exec ssh -t $CONSERVER "$CONGO_ENV /usr/bin/congo console $1"
     fi
 

--- a/xCAT-server/lib/perl/xCAT/Goconserver.pm
+++ b/xCAT-server/lib/perl/xCAT/Goconserver.pm
@@ -15,6 +15,7 @@ use HTTP::Request;
 use HTTP::Headers;
 use LWP;
 use JSON;
+use IO::Socket::SSL qw( SSL_VERIFY_PEER );
 
 sub http_request {
     my ($method, $url, $data) = @_;
@@ -26,7 +27,7 @@ sub http_request {
             SSL_cert_file   => xCAT::Utils->getHomeDir() . "/.xcat/client-cred.pem",
             SSL_ca_file     => xCAT::Utils->getHomeDir() . "/.xcat/ca.pem",
             SSL_use_cert    => 1,
-            SSL_verify_mode => 'SSL_VERIFY_PEER',  }, );
+            SSL_verify_mode => SSL_VERIFY_PEER,  }, );
     my $header = HTTP::Headers->new('Content-Type' => 'application/json');
     #    $data = encode_json $data if defined($data);
     $data = JSON->new->encode($data) if defined($data);


### PR DESCRIPTION
As the certificate of xcat is signed with short hostname, this
commit force to use the short hostname in  the environment variable for
`congo console`.