### PR TITLE
Fix confignetwork bond nic_type detection with multiple bonds

### DIFF
--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -366,6 +366,7 @@ function sort_nics_device_order {
             #find nicdevice type as base_nic_type
             base_nic_dev=`echo "$nics_list" |sed -n "${num}p"|awk '{print $2}'`
             if echo "$base_nic_dev"|grep "@" >/dev/null; then
+                temp_base_nic_type_one=''
                 for i in `echo "$base_nic_dev" |sed 's/@/ /g'`
                 do
                     temp_base_nic_type=`find_nic_type "$i" | $utolcmd`


### PR DESCRIPTION
When there is more than one bond, the `temp_base_nic_type_one` variable needs to be reset when evaluating each bond.
Closes #4433 