### PR TITLE
Add another key `bmcip` for node_info for openbmc support

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1583,14 +1583,20 @@ sub parse_node_info {
     foreach my $node (@$noderange) {
         if (defined($openbmc_hash->{$node}->[0])) {
             if ($openbmc_hash->{$node}->[0]->{'bmc'}) {
-                $node_info{$node}{bmc} = xCAT::NetworkUtils::getNodeIPaddress($openbmc_hash->{$node}->[0]->{'bmc'});
+                $node_info{$node}{bmc} = $openbmc_hash->{$node}->[0]->{'bmc'};
+                $node_info{$node}{bmcip} = xCAT::NetworkUtils::getNodeIPaddress($openbmc_hash->{$node}->[0]->{'bmc'});
             }
             unless($node_info{$node}{bmc}) {
                 xCAT::SvrUtils::sendmsg("Error: Unable to get attribute bmc", $callback, $node);
                 $rst = 1;
                 next;
             }
-
+            unless($node_info{$node}{bmcip}) {
+                xCAT::SvrUtils::sendmsg("Error: Unable to resolve ip address for bmc: $node_info{$node}{bmc}", $callback, $node);
+                delete $node_info{$node};
+                $rst = 1;
+                next;
+            }
             if ($openbmc_hash->{$node}->[0]->{'username'}) {
                 $node_info{$node}{username} = $openbmc_hash->{$node}->[0]->{'username'};
             } elsif ($passwd_hash and $passwd_hash->{username}) {
@@ -2592,7 +2598,7 @@ sub rspconfig_response {
             my ($path, $adapter_id) = (split(/\/ipv4\//, $key_url));
             if ($adapter_id) {
                 if (defined($content{Address}) and $content{Address}) {
-                    if ($content{Address} eq $node_info{$node}{bmc}) {
+                    if ($content{Address} eq $node_info{$node}{bmcip}) {
                         if ($content{Origin} =~ /Static/) {
                             $origin_type = "STATIC";
                             $status_info{RSPCONFIG_DELETE_REQUEST}{init_url} = "$key_url";


### PR DESCRIPTION
Fix for #4383:

For openbmc support, the command `rspconfig node hostname=*` can set the bmc attribute of a node to be the hostname of the related OpenBMC if it is not an ip address.

In PR #4383 , it resolve the bmc attribute to an IP directly which will affect the function above, so this PR is used to fix this scenario.
The output looks like this:
```
[root@briggs01 xCAT_plugin]# lsdef p9up -i bmc -c
mid05tor12cn02: bmc=mid05tor12cn02-bmc
mid05tor12cn05: bmc=mid05tor12cn05-bmc
mid05tor12cn11: bmc=172.11.139.11
mid05tor12cn13: bmc=172.11.139.13
mid05tor12cn15: bmc=172.11.139.15
mid05tor12cn16: bmc=172.11.139.16
mid05tor12cn18: bmc=172.11.139.18
[root@briggs01 xCAT_plugin]# rspconfig p9up hostname | grep -v openbmc_debug
mid05tor12cn13: BMC hostname: f6u13-bmc
mid05tor12cn16: BMC hostname: cn16-bmc
mid05tor12cn15: BMC hostname: f6u15-bmc
mid05tor12cn02: BMC hostname: witherspoon
mid05tor12cn11: BMC hostname: mid05tor12cn11-UTset
mid05tor12cn18: BMC hostname: mid05tor12cn18-UTset
mid05tor12cn05: BMC hostname: mid05tor12cn05-UTset
[root@briggs01 xCAT_plugin]# rspconfig p9up hostname=* | grep -v openbmc_debug
mid05tor12cn02: BMC Setting Hostname...
mid05tor12cn02: BMC hostname: mid05tor12cn02-bmc
mid05tor12cn13: BMC Setting Hostname...
mid05tor12cn05: BMC Setting Hostname...
mid05tor12cn13: BMC hostname: f6u13-bmc
mid05tor12cn11: BMC Setting Hostname...
mid05tor12cn05: BMC hostname: mid05tor12cn05-bmc
mid05tor12cn11: BMC hostname: mid05tor12cn11-UTset
mid05tor12cn16: BMC Setting Hostname...
mid05tor12cn18: BMC Setting Hostname...
mid05tor12cn15: BMC Setting Hostname...
mid05tor12cn16: BMC hostname: cn16-bmc
mid05tor12cn18: BMC hostname: mid05tor12cn18-UTset
mid05tor12cn15: BMC hostname: f6u15-bmc
```