### PR TITLE
makedhcp does not work well when disjointdhcps=1 

### DIFF
--- a/perl-xCAT/xCAT/Scope.pm
+++ b/perl-xCAT/xCAT/Scope.pm
@@ -219,6 +219,10 @@ sub get_broadcast_disjoint_scope_with_parallel {
     my $reqs = get_parallel_scope($req);
 
     my $handled4me = 0;  # indicate myself is already handled.
+    if (xCAT::Utils->isMN()) { # For MN, add itself always.
+        push @requests, @$reqs;
+        $handled4me = 1;
+    }
     my %prehandledhash = ();# the servers which is already handled.
     foreach (@$extras) {
         my $xcatdest = $_;


### PR DESCRIPTION
makedhcp does not work well when all service nodes not running dhcp but disjointdhcps=1 (#4426)

- if all service nodes not running dhcp, to treat it as disjointdhcps=0
- nodeset will send request to MN by default even if disjointdhcps=1
- Move out of the dhcp service checking from opts pre-check, and do it just before real makedhcp handling.