### PR TITLE
rspconfig configure bmc vlan will hung because of PR 4383

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2574,7 +2574,6 @@ sub rspconfig_response {
                     if ($next_state eq "RSPCONFIG_VLAN_REQUEST") {
                         $the_nic_to_config =~ s/(\_\d*)//g;
                         $status_info{$next_state}{data} =~ s/#NIC#/$the_nic_to_config/g;
-                        last;
                     }
                     $status_info{RSPCONFIG_IPOBJECT_REQUEST}{init_url} =~ s/#NIC#/$the_nic_to_config/g;
                     $node_info{$node}{nic} = $the_nic_to_config;


### PR DESCRIPTION
Fix an issue introduced by PR #4383 

Before fix:
```
[root@briggs01 ~]# rspconfig mid05tor12cn13 ip=172.11.139.130 netmask=255.255.0.0 gateway=0.0.0.0 vlan=11
Tue Dec  5 04:34:11 2017 mid05tor12cn13: [openbmc_debug] curl -k -c cjar -H "Content-Type: application/json" -d '{ "data": ["root", "xxxxxx"] }' https://172.11.139.13/login
Tue Dec  5 04:34:12 2017 mid05tor12cn13: [openbmc_debug] login_response 200 OK
Tue Dec  5 04:34:12 2017 mid05tor12cn13: [openbmc_debug] curl -k -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.13/xyz/openbmc_project/network/enumerate
Tue Dec  5 04:34:12 2017 mid05tor12cn13: [openbmc_debug] rspconfig_get_response 200 OK


```
After fix:
```
[root@briggs01 ~]# rspconfig mid05tor12cn13 ip=172.11.139.13 netmask=255.255.0.0 gateway=0.0.0.0 vlan=11
mid05tor12cn13: BMC IP: 172.11.139.13
mid05tor12cn13: BMC Netmask: 255.255.0.0
mid05tor12cn13: BMC Gateway: 0.0.0.0
mid05tor12cn13: BMC VLAN ID: 11

[root@briggs01 ~]# rspconfig mid05tor12cn13 ip=172.11.139.13 netmask=255.255.0.0 gateway=0.0.0.0
mid05tor12cn13: BMC IP: 172.11.139.13
mid05tor12cn13: BMC Netmask: 255.255.0.0
mid05tor12cn13: BMC Gateway: 0.0.0.0
```