### PR TITLE
Make sure credential files have a trailing newline

### DIFF
--- a/xCAT-server/lib/xcat/plugins/credentials.pm
+++ b/xCAT-server/lib/xcat/plugins/credentials.pm
@@ -321,6 +321,7 @@ sub process_request
             open($tmpfile, $tfilename);
             @filecontent = <$tmpfile>;
             close($tmpfile);
+            $filecontent[$#filecontent] =~ s/\n?$/\n/;
             $retdata = "\n" . join('', @filecontent);
             push @{ $rsp->{'data'} }, { content => [$retdata], desc => [$parm] };
             $retdata     = "";


### PR DESCRIPTION
The closing `</content>` needs to be on a line by itself, so ensure that the files have a trailing newline.
Closes #4414 