### PR TITLE
Add warning when xCAT throttles SSL connections

### DIFF
--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -65,6 +65,7 @@ use xCAT::Client qw(submit_request);
 my $clientselect  = new IO::Select;
 my $sslclients    = 0;                # THROTTLE
 my $maxsslclients = 64;               # default
+my $maxsslclientswarntime = 0;
 my $batchclients  = 50;
 my @deferredmsgargs;    # hold argumentlist for MsgUtils call until after fork
                         # parallelizing logging overhead with real work
@@ -1432,6 +1433,11 @@ until ($quit) {
     }
     unless (scalar @pendingconnections) { next; } # if for some reason we landed here without any accepted connections, carry on..
     if ($sslclients > $maxsslclients) { # we have enough children, wait for some to exit before spawning more
+        my $curtime = time();
+        if ($curtime > ($maxsslclientswarntime + 30)) {
+            xCAT::MsgUtils->message("S", "xcatd: Connections are being throttled. Current client count (" . ($sslclients + scalar @pendingconnections) . ") is greater than allowed ($maxsslclients)");
+            $maxsslclientswarntime=$curtime;
+        }
         $bothwatcher->can_read(0.1); # when next connection tries to come in or a tenth of a second, whichever comes first
         next;                        # just keep pulling things off listen queue onto our own
     }


### PR DESCRIPTION
I have a suspicion that we need to increase `xcatmaxconnections` but no way of knowing for sure.  This PR will warn every 30 seconds when the number of outstanding connections exceeds `xcatmaxconnections`.  I set the value low and then backgrounded a bunch of `xdsh some_node sleep 60` commands:
```
Dec 05 14:27:03 mgmt1 xcat[78090]: xcatd: Connections are being throttled. Current client count (12) is greater than allowed (10)
Dec 05 14:27:33 mgmt1 xcat[78090]: xcatd: Connections are being throttled. Current client count (24) is greater than allowed (10)
Dec 05 14:28:04 mgmt1 xcat[78090]: xcatd: Connections are being throttled. Current client count (14) is greater than allowed (10)
```