### PR TITLE
Add support for the "file -> (noderange) file" syntax in synclist with ServiceNodes

### DIFF
--- a/perl-xCAT/xCAT/DSHCLI.pm
+++ b/perl-xCAT/xCAT/DSHCLI.pm
@@ -5182,9 +5182,9 @@ sub parse_rsync_input_file_on_MN
                 foreach my $target_node (@dest_host)
                 {
                     # skip the node if it's NOT in the permitted list and if
-                    # it's not a SN
-                    if ($dest_node && !(grep /^$target_node$/, @dest_nodes) &&
-                        !(xCAT::Utils->isSN($target_node)) ) {
+                    # it's not a SN doing a hierarchical mode transfer
+                    if ($dest_node && !(grep /^$target_node$/, @dest_nodes)
+                        && ($rsyncSN != 1) ) {
                         next;
                     }
                     $$options{'destDir_srcFile'}{$target_node} ||= {};


### PR DESCRIPTION
Fixes #4425

This patch ensures that:
1. the synclist is correctly parsed when running on a Service Node
2. all files from the synclist are synchronized to the SN in hierarchical mode

See #4425 for more details about the original issue.

A more elegant solution may be to only synchronize files that are meant to be copied on nodes that a given ServiceNode services, but that seems to require adding a lot of overhead in the code.