### PR TITLE
Give summary after flash active when no debugmode

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -830,7 +830,7 @@ rmdir \"/tmp/\$userid\" \n";
                 unlink "$home/.ssh/copy.sh";
                 File::Path->remove_tree("$home/.ssh/tmp/");
             }
-            if (($::UPLOAD_AND_ACTIVATE or $next_status{LOGIN_RESPONSE} eq "RFLASH_UPDATE_ACTIVATE_REQUEST") and $::VERBOSE) {
+            if ($::UPLOAD_AND_ACTIVATE or $next_status{LOGIN_RESPONSE} eq "RFLASH_UPDATE_ACTIVATE_REQUEST") {
                 my %rflash_result = ();
                 foreach my $node (keys %node_info) {
                     if ($node_info{$node}{rst} =~ /successful/) {


### PR DESCRIPTION
#4246 
Output:

```
# rflash f6u17 -a obmc-phosphor-image-witherspoon.ubi.mtd.tar
Attempting to upload obmc-phosphor-image-witherspoon.ubi.mtd.tar, please wait...
f6u17: Firmware upload successful. Attempting to activate firmware: ibm-v2.0-0-r13.3-0-gd624923 (ID: b3000fc6)
f6u17: Firmware ibm-v2.0-0-r13.3-0-gd624923 activation successful.
-------------------------------------------------------
Firmware update complete: Total=1 Success=1 Failed=0
-------------------------------------------------------
```