### PR TITLE
Fix the issue that the IP configuration will fail if bmc attribute is a hostname

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2843,7 +2843,7 @@ sub rspconfig_response {
                         }
                     }
                     # Only deal with the nic whose IP matching the BMC IP configured for the node
-                    if ($address eq $node_info{$node}{bmc}) {
+                    if ($address eq $node_info{$node}{bmcip}) {
                         $the_nic_to_config = $nic;
                         last;
                     }


### PR DESCRIPTION
It is failed to use ip address of BMC attribute to match the correct BMC nic. 

Before modification:
```
[root@briggs01 xcat]# lsdef mid05tor12cn05,mid05tor12cn13 -i bmc -c
mid05tor12cn05: bmc=mid05tor12cn05-bmc
mid05tor12cn13: bmc=172.11.139.13
[root@briggs01 xcat]# rspconfig mid05tor12cn05 ip=172.11.139.50 netmask=255.255.0.0 gateway=0.0.0.0
mid05tor12cn05: Can not find the correct device to configure
[root@briggs01 xcat]# rspconfig mid05tor12cn13 ip=172.11.139.130 netmask=255.255.0.0 gateway=0.0.0.0
mid05tor12cn13: BMC IP: 172.11.139.130
mid05tor12cn13: BMC Netmask: 255.255.0.0
mid05tor12cn13: BMC Gateway: 0.0.0.0
```
After fix:
```
[root@briggs01 xcat]# lsdef mid05tor12cn05 -i bmc -c
mid05tor12cn05: bmc=mid05tor12cn05-bmc
[root@briggs01 xcat]# rspconfig mid05tor12cn05 ip=172.11.139.50 netmask=255.255.0.0 gateway=0.0.0.0
mid05tor12cn05: BMC IP: 172.11.139.50
mid05tor12cn05: BMC Netmask: 255.255.0.0
mid05tor12cn05: BMC Gateway: 0.0.0.0
```