### PR TITLE
enhance genimage for sles12sp2 dracut update 

### DIFF
--- a/xCAT-server/share/xcat/netboot/sles/genimage
+++ b/xCAT-server/share/xcat/netboot/sles/genimage
@@ -615,7 +615,7 @@ if ((-d "$rootimg_dir/usr/share/dracut") or (-d "$rootimg_dir/usr/lib/dracut")) 
     $dracutmode = 1;
 
     # get dracut version
-    $dracutver = `chroot $rootimg_dir rpm -qi dracut | awk '/Version/{print \$3}'     `;
+    $dracutver = `chroot $rootimg_dir rpm -qi dracut | awk '/Version/{print \$3}' | awk -F. '{print \$1}'`;
     chomp($dracutver);
     if ($dracutver =~ /^\d\d\d$/) {
         if ($dracutver >= "033") {


### PR DESCRIPTION
For #4372 

genimage UT:

```
bybc0607:/ # genimage sles12.2-x86_64-netboot-compute |tee log
Generating image:
cd /opt/xcat/share/xcat/netboot/sles; ./genimage -a x86_64 -o sles12.2 -p compute --permission 755 --srcdir "/install/sles12.2/x86_64" --pkglist /opt/xcat/share/xcat/netboot/sles/compute.sles12.x86_64.pkglist --otherpkgdir "/install/post/otherpkgs/sles12.2/x86_64" --postinstall /opt/xcat/share/xcat/netboot/sles/compute.sles12.x86_64.postinstall --rootimgdir /install/netboot/sles12.2/x86_64/compute --tempfile /tmp/xcat_genimage.13206 --timezone America/New_York sles12.2-x86_64-netboot-compute
Warning: The /etc/products.d/baseproduct symlink is dangling or missing!
The link must point to your core products .prod file in /etc/products.d.
Adding repository 'sles12.2-0' [......done]
Repository 'sles12.2-0' successfully added
Enabled     : Yes
Autorefresh : No
GPG Check   : Yes
Priority    : 99
URI         : file:/install/sles12.2/x86_64/1
Reading custom repositories
Warning: The /etc/products.d/baseproduct symlink is dangling or missing!
The link must point to your core products .prod file in /etc/products.d.
Retrieving repository 'sles12.2-0' metadata [.
Warning: The gpg key signing file 'content' has expired.
  Repository:       sles12.2-0
  Key Name:         SuSE Package Signing Key <build@suse.de>
  Key Fingerprint:  FEAB5025 39D846DB 2C0961CA 70AF9E81 39DB7C82
  Key Created:      Thu Jan 31 11:06:03 2013
  Key Expires:      Mon Jan 30 11:06:03 2017 (EXPIRED)
  Rpm Name:         gpg-pubkey-39db7c82-510a966b
done]
Building repository 'sles12.2-0' cache [....done]
All repositories have been refreshed.
 zypper -R /install/netboot/sles12.2/x86_64/compute/rootimg --non-interactive --no-gpg-checks --gpg-auto-import-keys install -l --no-recommends   aaa_base coreutils bash nfs-kernel-server keyutils lvm2 openssl dhcp-client openssh procps psmisc wget sysconfig rsyslog vim rsync timezone bc ntp gzip e2fsprogs parted binutils tar open-iscsi curl plymouth btrfsprogs cryptsetup dmraid mdadm multipath-tools gpg2 which cifs-utils open-lldp fcoe-utils util-linux-systemd plymouth-dracut udev kernel-default kernel-firmware adaptec-firmware xz
Warning: The /etc/products.d/baseproduct symlink is dangling or missing!
The link must point to your core products .prod file in /etc/products.d.
Loading repository data...
Reading installed packages...
'coreutils' is already installed.
No update candidate for 'coreutils-8.25-12.8.x86_64'. The highest available version is already installed.
'xz' is already installed.
... ...
'kernel-firmware' is already installed.
No update candidate for 'kernel-firmware-20160516git-17.6.noarch'. The highest available version is already installed.
'nfs-kernel-server' is already installed.
No update candidate for 'nfs-kernel-server-1.3.0-26.3.x86_64'. The highest available version is already installed.
'adaptec-firmware' is already installed.
No update candidate for 'adaptec-firmware-1.35-22.17.noarch'. The highest available version is already installed.
'dhcp-client' is already installed.
No update candidate for 'dhcp-client-4.3.3-9.1.x86_64'. The highest available version is already installed.
'open-lldp' is already installed.
No update candidate for 'open-lldp-0.9.46-5.14.x86_64'. The highest available version is already installed.
'fcoe-utils' is already installed.
No update candidate for 'fcoe-utils-1.0.31-10.7.x86_64'. The highest available version is already installed.
'plymouth-dracut' is already installed.
No update candidate for 'plymouth-dracut-0.9.2-29.5.x86_64'. The highest available version is already installed.
Resolving package dependencies...
Nothing to do.
[genimage] setting services to start at boot time...
Failed to connect to bus: No such file or directory
Failed to connect to bus: No such file or directory
Enter the dracut mode. Dracut version: 044. Dracut directory: dracut_033.
ln: failed to create symbolic link '/install/netboot/sles12.2/x86_64/compute/rootimg/usr/bin/keyctl': File exists
Added libahci.ko as an autodetected dependency
Added virtio_ring.ko as an autodetected dependency
Added virtio.ko as an autodetected dependency
Added crc16.ko as an autodetected dependency
Added jbd2.ko as an autodetected dependency
Added mbcache.ko as an autodetected dependency
Added vxlan.ko as an autodetected dependency
Added ip6_udp_tunnel.ko as an autodetected dependency
Added udp_tunnel.ko as an autodetected dependency
Added mlx4_core.ko as an autodetected dependency
Added ptp.ko as an autodetected dependency
Added pps_core.ko as an autodetected dependency
Added i2c-algo-bit.ko as an autodetected dependency
Added dca.ko as an autodetected dependency
Added geneve.ko as an autodetected dependency
Added mdio.ko as an autodetected dependency
Added libcrc32c.ko as an autodetected dependency
Added libphy.ko as an autodetected dependency
Added crc32c.ko as an autodetected dependency
Try to load drivers: scsi_mod pps_core crc32c udp_tunnel ip6_udp_tunnel libata libphy ptp libcrc32c mdio vxlan geneve virtio virtio_ring dca i2c-algo-bit mlx4_core mbcache jbd2 crc16 libahci af_packet tg3 bnx2 bnx2x e1000 e1000e virtio_net virtio_balloon igb mlx4_en be2net ext3 ext4 virtio_pci virtio_blk scsi_dh ahci megaraid_sas sd_mod ibmvscsi to initrd.
chroot /install/netboot/sles12.2/x86_64/compute/rootimg dracut  -N --compress "/usr/bin/pigz -p 1 " -f /tmp/initrd.13213.gz 4.4.21-69-default
dracut: Executing: /usr/bin/dracut -N --compress "/usr/bin/pigz -p 1 " -f /tmp/initrd.13213.gz 4.4.21-69-default
dracut: *** Including module: network ***
dracut: *** Including module: dm ***
dracut: Skipping udev rule: 64-device-mapper.rules
dracut: Skipping udev rule: 60-persistent-storage-dm.rules
dracut: Skipping udev rule: 55-dm.rules
dracut: *** Including module: kernel-modules ***
dracut: Possible missing firmware "sd8688.bin" for kernel module "libertas_sdio.ko"
dracut: Possible missing firmware "sd8688_helper.bin" for kernel module "libertas_sdio.ko"
dracut: Possible missing firmware "sd8686.bin" for kernel module "libertas_sdio.ko"
dracut: Possible missing firmware "sd8686_helper.bin" for kernel module "libertas_sdio.ko"
dracut: Possible missing firmware "sd8385.bin" for kernel module "libertas_sdio.ko"
dracut: Possible missing firmware "sd8385_helper.bin" for kernel module "libertas_sdio.ko"
dracut: *** Including module: kernel-network-modules ***
dracut: Possible missing firmware "cxgb4/t6fw.bin" for kernel module "cxgb4.ko"
dracut: *** Including module: lvm ***
dracut: Skipping udev rule: 64-device-mapper.rules
dracut: Skipping udev rule: 56-lvm.rules
dracut: Skipping udev rule: 60-persistent-storage-lvm.rules
dracut: *** Including module: nfs ***
findmnt: can't read /proc/mounts: No such file or directory
findmnt: can't read /proc/mounts: No such file or directory
dracut: *** Including module: rootfs-block ***
findmnt: can't read /proc/mounts: No such file or directory
dracut: *** Including module: udev-rules ***
dracut: Skipping udev rule: 40-redhat.rules
dracut: Skipping udev rule: 50-firmware.rules
dracut: Skipping udev rule: 50-udev.rules
dracut: Skipping udev rule: 91-permissions.rules
dracut: Skipping udev rule: 80-drivers-modprobe.rules
dracut: *** Including module: xcat ***
dracut: *** Including module: syslog ***
dracut: *** Including module: base ***
dracut: *** Including module: fs-lib ***
dracut: *** Including modules done ***
dracut: *** Installing kernel module dependencies and firmware ***
dracut: *** Installing kernel module dependencies and firmware done ***
dracut: *** Resolving executable dependencies ***
dracut: *** Resolving executable dependencies done***
dracut: *** Hardlinking files ***
dracut: *** Hardlinking files done ***
dracut: *** Stripping files ***
dracut: *** Stripping files done ***
dracut: *** Generating early-microcode cpio image ***
dracut: *** Store current command line parameters ***
dracut: Stored kernel commandline:
dracut: No dracut internal kernel commandline stored in the initramfs
dracut: *** Creating image file '/tmp/initrd.13213.gz' ***
dracut: *** Creating initramfs image file '/tmp/initrd.13213.gz' done ***
the initial ramdisk for stateless is generated successfully.
Try to load drivers: scsi_mod pps_core crc32c udp_tunnel ip6_udp_tunnel libata libphy ptp libcrc32c mdio vxlan geneve virtio virtio_ring dca i2c-algo-bit mlx4_core mbcache jbd2 crc16 libahci af_packet tg3 bnx2 bnx2x e1000 e1000e virtio_net virtio_balloon igb mlx4_en be2net ext3 ext4 virtio_pci virtio_blk scsi_dh ahci megaraid_sas sd_mod ibmvscsi to initrd.
chroot /install/netboot/sles12.2/x86_64/compute/rootimg dracut  -N --compress "/usr/bin/pigz -p 1 " -f /tmp/initrd.13213.gz 4.4.21-69-default
dracut: Executing: /usr/bin/dracut -N --compress "/usr/bin/pigz -p 1 " -f /tmp/initrd.13213.gz 4.4.21-69-default
dracut: *** Including module: network ***
dracut: *** Including module: dm ***
dracut: Skipping udev rule: 64-device-mapper.rules
dracut: Skipping udev rule: 60-persistent-storage-dm.rules
dracut: Skipping udev rule: 55-dm.rules
dracut: *** Including module: kernel-modules ***
dracut: Possible missing firmware "sd8688.bin" for kernel module "libertas_sdio.ko"
dracut: Possible missing firmware "sd8688_helper.bin" for kernel module "libertas_sdio.ko"
dracut: Possible missing firmware "sd8686.bin" for kernel module "libertas_sdio.ko"
dracut: Possible missing firmware "sd8686_helper.bin" for kernel module "libertas_sdio.ko"
dracut: Possible missing firmware "sd8385.bin" for kernel module "libertas_sdio.ko"
dracut: Possible missing firmware "sd8385_helper.bin" for kernel module "libertas_sdio.ko"
dracut: *** Including module: kernel-network-modules ***
dracut: Possible missing firmware "cxgb4/t6fw.bin" for kernel module "cxgb4.ko"
dracut: *** Including module: lvm ***
dracut: Skipping udev rule: 64-device-mapper.rules
dracut: Skipping udev rule: 56-lvm.rules
dracut: Skipping udev rule: 60-persistent-storage-lvm.rules
dracut: *** Including module: nfs ***
findmnt: can't read /proc/mounts: No such file or directory
findmnt: can't read /proc/mounts: No such file or directory
dracut: *** Including module: rootfs-block ***
findmnt: can't read /proc/mounts: No such file or directory
dracut: *** Including module: udev-rules ***
dracut: Skipping udev rule: 40-redhat.rules
dracut: Skipping udev rule: 50-firmware.rules
dracut: Skipping udev rule: 50-udev.rules
dracut: Skipping udev rule: 91-permissions.rules
dracut: Skipping udev rule: 80-drivers-modprobe.rules
dracut: *** Including module: xcat ***
dracut: *** Including module: base ***
dracut: *** Including module: fs-lib ***
dracut: *** Including modules done ***
dracut: *** Installing kernel module dependencies and firmware ***
dracut: *** Installing kernel module dependencies and firmware done ***
dracut: *** Resolving executable dependencies ***
dracut: *** Resolving executable dependencies done***
dracut: *** Hardlinking files ***
dracut: *** Hardlinking files done ***
dracut: *** Stripping files ***
dracut: *** Stripping files done ***
dracut: *** Generating early-microcode cpio image ***
dracut: *** Store current command line parameters ***
dracut: Stored kernel commandline:
dracut: No dracut internal kernel commandline stored in the initramfs
dracut: *** Creating image file '/tmp/initrd.13213.gz' ***
dracut: *** Creating initramfs image file '/tmp/initrd.13213.gz' done ***
the initial ramdisk for statelite is generated successfully.
```

