### PR TITLE
Ignore syslog error in monitorctrl when setNodeStatusAttributes

### DIFF
--- a/xCAT-server/lib/xcat/monitoring/monitorctrl.pm
+++ b/xCAT-server/lib/xcat/monitoring/monitorctrl.pm
@@ -704,9 +704,7 @@ sub setNodeStatusAttributes {
                 $updates{'status'}     = $_;
                 $updates{'statustime'} = $currtime;
                 my $nodestate = "@$nodes status: $updates{'status'} statustime: $updates{'statustime'}";
-                openlog('xcat', 'ndelay', 'local4');
-                syslog('local4|info', '%s', $nodestate);
-                closelog();
+                xCAT::MsgUtils->message('S', "$nodestate");
                 my $where_clause;
                 my $dbname = xCAT::Utils->get_DBName();
 


### PR DESCRIPTION
Issue:
```
Error: openbmc plugin bug, pid 30251, process description: 'xcatd SSL: rpower for mgmt1.summit.olcf.ornl.gov@mgmt1: openbmc instance' with error 'no connection to syslog available        - unix dgram connect: Connection refused        - stream can't open /dev/log: No such device or address at /opt/xcat/lib/perl/xCAT_monitoring/monitorctrl.pm line 707.' while trying to fulfill request for the following nodes: b01n01
--
```

Solution:
If 'syslog' failed, do not exit.