### PR TITLE
modify response for bmcdiscover when error

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -1215,7 +1215,7 @@ sub bmcdiscovery_openbmc{
         if ($login_response->status_line =~ /401 Unauthorized/) {
             xCAT::MsgUtils->message("W", { data => ["Invalid username or password for $ip"] }, $::CALLBACK); 
         } else {
-            xCAT::MsgUtils->message("W", { data => ["$login_response->status_line for $ip"] }, $::CALLBACK);
+            xCAT::MsgUtils->message("W", { data => ["Received response " . $login_response->status_line . " for $ip"] }, $::CALLBACK);
         }
         return;
     }


### PR DESCRIPTION
Before modify:
```
# bmcdiscover --range 10.3.5.99
Warning: HTTP::Response=HASH(0x100269b6fc8)->status_line for 10.3.5.99
```

After modified:
```
# bmcdiscover --range 10.3.5.99
Warning: Received response 500 read timeout for 10.3.5.99
```