### PR TITLE
fix issue https://github.com/xcat2/xcat-core/issues/4411

### DIFF
--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -555,11 +555,33 @@ sub mknetboot
             $ient = $reshash->{$node}->[0];
             $imgsrv = $xcatmaster;
         }
+
         unless ($imgsrv) {
             xCAT::MsgUtils->report_node_error($callback, $node, "Unable to determine or reasonably guess the image server for $node");
             next;
         }
  
+        my $imgsrvip;
+        unless($imgsrv eq '!myipfn!' or xCAT::NetworkUtils->validate_ip($imgsrv)==0){
+            # if xcatmaster is hostname, convert it to ip address
+            # the host name might not be resolved inside initrd
+            $imgsrvip = xCAT::NetworkUtils->getipaddr($imgsrv);
+        }
+        unless($imgsrvip){
+            $imgsrvip=$imgsrv;
+        }
+
+        my $xcatmasterip;
+        # if xcatmaster is hostname, convert it to ip address
+        if (xCAT::NetworkUtils->validate_ip($xcatmaster)) {
+            # Using XCAT=<hostname> will cause problems rc.statelite.ppc.redhat
+            # when trying to run chroot command
+            $xcatmasterip = xCAT::NetworkUtils->getipaddr($xcatmaster);
+        }
+        unless($xcatmasterip){
+            $xcatmasterip=$xcatmaster
+        }
+
         # Start to build kcmdline
         my $kcmdline;
 
@@ -597,9 +619,9 @@ sub mknetboot
                 }
             } else {
                 if (-r "$rootimgdir/rootimg-statelite.gz.metainfo") {
-                    $kcmdline = "imgurl=$httpmethod://$imgsrv:$httpport/$rootimgdir/rootimg-statelite.gz.metainfo STATEMNT=";
+                    $kcmdline = "imgurl=$httpmethod://$imgsrvip:$httpport/$rootimgdir/rootimg-statelite.gz.metainfo STATEMNT=";
                 } else {
-                    $kcmdline = "imgurl=$httpmethod://$imgsrv:$httpport/$rootimgdir/rootimg-statelite.gz STATEMNT=";
+                    $kcmdline = "imgurl=$httpmethod://$imgsrvip:$httpport/$rootimgdir/rootimg-statelite.gz STATEMNT=";
                 }
             }
 
@@ -626,21 +648,6 @@ sub mknetboot
                 }
             }
             $kcmdline .= $statemnt . " ";
-            my $xcatmasterip;
-
-            # if xcatmaster is hostname, convert it to ip address
-            if (xCAT::NetworkUtils->validate_ip($xcatmaster)) {
-
-                # Using XCAT=<hostname> will cause problems rc.statelite.ppc.redhat
-                # when trying to run chroot command
-                $xcatmasterip = xCAT::NetworkUtils->getipaddr($xcatmaster);
-                if (!$xcatmasterip)
-                {
-                    $xcatmasterip = $xcatmaster;
-                }
-            } else {
-                $xcatmasterip = $xcatmaster;
-            }
 
             $kcmdline .= "XCAT=$xcatmasterip:$xcatdport ";
 
@@ -669,11 +676,11 @@ sub mknetboot
         }
         else {
             if (-r "$rootimgdir/$compressedrootimg.metainfo") {
-                $kcmdline = "imgurl=$httpmethod://$imgsrv:$httpport/$rootimgdir/$compressedrootimg.metainfo ";
+                $kcmdline = "imgurl=$httpmethod://$imgsrvip:$httpport/$rootimgdir/$compressedrootimg.metainfo ";
             } else {
-                $kcmdline = "imgurl=$httpmethod://$imgsrv:$httpport/$rootimgdir/$compressedrootimg ";
+                $kcmdline = "imgurl=$httpmethod://$imgsrvip:$httpport/$rootimgdir/$compressedrootimg ";
             }
-            $kcmdline .= "XCAT=$xcatmaster:$xcatdport ";
+            $kcmdline .= "XCAT=$xcatmasterip:$xcatdport ";
             $kcmdline .= "NODE=$node ";
 
             # add flow control setting

--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -563,7 +563,7 @@ sub mknetboot
  
         my $imgsrvip;
         unless($imgsrv eq '!myipfn!' or xCAT::NetworkUtils->validate_ip($imgsrv)==0){
-            # if xcatmaster is hostname, convert it to ip address
+            # if imgsrv is hostname, convert it to ip address
             # the host name might not be resolved inside initrd
             $imgsrvip = xCAT::NetworkUtils->getipaddr($imgsrv);
         }
@@ -572,10 +572,9 @@ sub mknetboot
         }
 
         my $xcatmasterip;
-        # if xcatmaster is hostname, convert it to ip address
         if (xCAT::NetworkUtils->validate_ip($xcatmaster)) {
-            # Using XCAT=<hostname> will cause problems rc.statelite.ppc.redhat
-            # when trying to run chroot command
+            # if xcatmaster is hostname, convert it to ip address
+            # the host name might not be resolved inside initrd
             $xcatmasterip = xCAT::NetworkUtils->getipaddr($xcatmaster);
         }
         unless($xcatmasterip){
@@ -693,23 +692,10 @@ sub mknetboot
         }
 
         if (($::XCATSITEVALS{xcatdebugmode} eq "1") or ($::XCATSITEVALS{xcatdebugmode} eq "2")) {
-
-            my ($host, $ipaddr) = xCAT::NetworkUtils->gethostnameandip($xcatmaster);
-            if ($ipaddr) {
-
-                #for use in postscript and postbootscript in xcatdsklspost in the rootimg
-                $kcmdline .= " LOGSERVER=$ipaddr ";
-
-                #for use in syslog dracut module in the initrd
-                $kcmdline .= " syslog.server=$ipaddr syslog.type=rsyslogd syslog.filter=*.* ";
-            }
-            else {
-                #for use in postscript and postbootscript in xcatdsklspost in the rootimg
-                $kcmdline .= " LOGSERVER=$xcatmaster ";
-
-                #for use in syslog dracut module in the initrd
-                $kcmdline .= " syslog.server=$xcatmaster syslog.type=rsyslogd syslog.filter=*.* ";
-            }
+            #for use in postscript and postbootscript in xcatdsklspost in the rootimg
+            $kcmdline .= " LOGSERVER=$xcatmasterip ";
+            #for use in syslog dracut module in the initrd
+            $kcmdline .= " syslog.server=$xcatmasterip syslog.type=rsyslogd syslog.filter=*.* ";
             $kcmdline .= " xcatdebugmode=$::XCATSITEVALS{xcatdebugmode} ";
         }
 


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/4411:
for redhat diskless and statelite, use ip address instead of hostname in kernel options `XCAT=` and `imgurl=` in case the hostname cannot be resolved inside initrd for some reason

UT:
```
[root@c910f03c05k21 xcat-core]# lsdef c910f03c05k27 -i xcatmaster,tftpserver
Object name: c910f03c05k27
    tftpserver=c910f03c05k27
    xcatmaster=c910f03c05k21
[root@c910f03c05k21 xcat-core]# nodeset c910f03c05k27 osimage=rhels7.3-ppc64le-netboot-compute
c910f03c05k27: netboot rhels7.3-ppc64le-compute
[root@c910f03c05k21 xcat-core]# cat /tftpboot/boot/grub2/c910f03c05k27
#netboot rhels7.3-ppc64le-compute
set debug=all
set timeout=5
set default="xCAT OS Deployment"
menuentry "xCAT OS Deployment" {
    insmod http
    insmod tftp
    set root=tftp,10.3.5.27
    echo Loading Install kernel ...
    linux /xcat/osimage/rhels7.3-ppc64le-netboot-compute/kernel imgurl=http://10.3.5.27:80//install/netboot/rhels7.3/ppc64le/compute/rootimg.cpio.gz XCAT=10.3.5.21:3001 NODE=c910f03c05k27 FC=0  LOGSERVER=10.3.5.21  syslog.server=10.3.5.21 syslog.type=rsyslogd syslog.filter=*.*  xcatdebugmode=1 BOOTIF=42:dc:da:97:e5:ab  console=tty0 console=hvc0,115200n8r selinux=0   uftp=true uftpdelay=30 uftpport=1044 md5sum=3cd1b6109a74ba924d2720beffd7423e
    echo Loading initial ramdisk ...
    initrd /xcat/osimage/rhels7.3-ppc64le-netboot-compute/initrd-stateless.gz
```