### PR TITLE
Add test cases for rflash regular usage against openbmc

### DIFF
--- a/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
+++ b/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
@@ -399,3 +399,58 @@ check:output=~Error: Invalid ID provided to delete
 check:output!~Attempting to delete
 check:rc != 0
 end
+
+start:rflash_option_d_with_multiple_values
+description: basic usage check for option d. if there are multiple value assigned to d option, should throw out error message
+os:Linux
+hcp:openbmc
+cmd:rflash $$CN -d /123/   /234/
+check:output=~Error: More than one
+check:output!~Attempting to 
+check:rc != 0
+cmd:rflash $$CN /123/   /234/  -d
+check:output=~Error: More than one 
+check:output!~Attempting to
+check:rc != 0
+cmd:rflash $$CN /123/ -d /234/
+check:output=~Error: More than one 
+check:output!~Attempting to 
+check:rc != 0
+end
+
+
+start:rflash_option_d_with_non_existent_dir
+description: basic usage check for option -d. if try to oprate non-existent dir by d option, should throw out error message
+os:Linux
+hcp:openbmc
+cmd:rm -rf /tmp/bogus123
+check:rc == 0
+cmd:rflash $$CN -d /tmp/bogus123 
+check:output=~Error: Can't open directory
+check:output!~Attempting to 
+check:rc != 0
+cmd:mkdir -p /tmp/bogus123
+check:rc == 0
+cmd:rflash $$CN /tmp/bogus123 -d
+check:output =~Error: No BMC tar file found
+check:output =~Error: No PNOR tar file found
+check:output!~Attempting to
+check:rc != 0
+cmd:touch obmc-phosphor-image-witherspoon.ubi.mtd.tar /tmp/bogus123
+check:rc == 0
+cmd:rflash $$CN -d /tmp/bogus123
+check::output =~Error: No BMC tar file found
+check:output =~Error: No PNOR tar file found
+check:output!~Attempting to
+check:rc != 0
+cmd:touch witherspoon.pnor.squashfs.tar /tmp/bogus123
+check:rc == 0
+cmd:rflash $$CN -d /tmp/bogus123
+check:output =~Error: No BMC tar file found
+check:output =~Error: No PNOR tar file found
+check:output!~Attempting to
+check:rc != 0
+cmd:rm -rf /tmp/bogus123
+check:rc == 0
+end
+

--- a/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
+++ b/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
@@ -1,0 +1,375 @@
+start:rflash_option_c_without_specify_noderange
+description: basic usage check for option c. if without specify noderange for rflash command, should offer usage message
+os:Linux
+hcp:openbmc
+cmd:rflash -c
+check:output=~Usage:
+cmd:rflash -c 1.tar
+check:rc != 0
+check:output=~Error: Invalid nodes and/or groups in noderange
+end
+
+start:rflash_option_l_without_specify_noderange
+description: basic usage check for option l. if without specify noderange for rflash command, should offer usage message
+os:Linux
+hcp:openbmc
+cmd:rflash -l
+check:output=~Usage:
+end
+
+start:rflash_option_a_without_specify_noderange
+description: basic usage check for option a. if without specify noderange for rflash command, should offer usage message
+os:Linux
+hcp:openbmc
+cmd:rflash -a
+check:output=~Usage:
+cmd:rflash -a 1.tar
+check:rc != 0
+check:output=~Error: Invalid nodes and/or groups in noderange
+end
+
+start:rflash_option_u_without_specify_noderange
+description: basic usage check for option u. if without specify noderange for rflash command, should offer usage message
+os:Linux
+hcp:openbmc
+cmd:rflash -u
+check:output=~Usage:
+cmd:rflash -u  1.tar
+check:rc != 0
+check:output=~Error: Invalid nodes and/or groups in noderange
+end
+
+start:rflash_option_d_without_specify_noderange
+description: basic usage check for option d. if without specify noderange for rflash command, should offer usage message
+os:Linux
+hcp:openbmc
+cmd:rflash -d
+check:output=~Usage:
+cmd:rflash -d 1234
+check:rc != 0
+check:output=~Error: Invalid nodes and/or groups in noderange
+end
+
+start:rflash_without_option
+description: basic usage check, if without option, should throw out a error
+os:Linux
+hcp:openbmc
+cmd:rflash $$CN 1.tar
+check:rc != 0
+check:output=~Error: Invalid option specified when a file is provided:
+end
+
+start:rflash_unsupport_multiple_option_a_u
+description: basic usage check. If specify multiple options a+u, should throw out error message
+os:Linux
+hcp:openbmc
+cmd:rflash $$CN -a 1.tz -u
+check:output=~Error: Multiple options are not supported
+check:rc != 0
+end
+
+start:rflash_unsupport_multiple_option_a_c
+description: basic usage check. If specify multiple options a+c, should throw out error message
+os:Linux
+hcp:openbmc
+cmd:rflash $$CN -a 1.tz -c
+check:output=~Error: Multiple options are not supported
+check:rc != 0
+end
+
+start:rflash_unsupport_multiple_option_a_l
+description: basic usage check. If specify multiple options a+l, should throw out error message
+os:Linux
+hcp:openbmc
+cmd:rflash $$CN -a 1.tz -l
+check:output=~Error: Multiple options are not supported
+check:rc != 0
+end
+
+start:rflash_unsupport_multiple_option_a_d
+description: basic usage check. If specify multiple options a+d, should throw out error message
+os:Linux
+hcp:openbmc
+cmd:rflash $$CN -a 1.tz -d
+check:output=~Error: Multiple options are not supported
+check:rc != 0
+end
+
+start:rflash_unsupport_multiple_option_c_l
+description: basic usage check. If specify multiple options c+l, should throw out error message
+os:Linux
+hcp:openbmc
+cmd:rflash $$CN -c 1.tz -l
+check:output=~Error: Multiple options are not supported
+check:rc != 0
+end
+
+start:rflash_unsupport_multiple_option_c_u
+description: basic usage check. If specify multiple options c+u, should throw out error message
+os:Linux
+hcp:openbmc
+cmd:rflash $$CN -c 1.tz -u
+check:output=~Error: Multiple options are not supported
+check:rc != 0
+end
+
+start:rflash_unsupport_multiple_option_c_d
+description: basic usage check. If specify multiple options c+d, should throw out error message
+os:Linux
+hcp:openbmc
+cmd:rflash $$CN -c 1.tz -d
+check:output=~Error: Multiple options are not supported
+check:rc != 0
+end
+
+start:rflash_unsupport_multiple_option_l_d
+description: basic usage check. If specify multiple options l+d, should throw out error message
+os:Linux
+hcp:openbmc
+cmd:rflash $$CN -l -d
+check:output=~Error: Multiple options are not supported
+check:rc != 0
+end
+
+start:rflash_unsupport_multiple_option_l_u
+description: basic usage check. If specify multiple options l+u, should throw out error message
+os:Linux
+hcp:openbmc
+cmd:rflash $$CN -l -u
+check:output=~Error: Multiple options are not supported
+check:rc != 0
+end
+
+start:rflash_unsupport_multiple_option_u_d
+description: basic usage check. If specify multiple options u+d, should throw out error message
+os:Linux
+hcp:openbmc
+cmd:rflash $$CN -u -d
+check:output=~Error: Multiple options are not supported
+check:rc != 0
+end
+
+start:rflash_option_c_file_not_exist
+description: basic usage check for option c. if the file does not exist, should throw out error message
+os:Linux
+hcp:openbmc
+cmd:rflash $$CN -c /tmp/abc123.tz
+check:output=~Error: Invalid option
+check:rc != 0
+cmd:rflash $$CN -c /tmp/
+check:output=~Error: Invalid option
+check:rc != 0
+cmd:rflash $$CN /tmp/abc123.tz -c
+check:output=~Error: Invalid option
+check:rc != 0
+cmd:rflash $$CN /tmp/ -c
+check:output=~Error: Invalid option
+check:rc != 0
+cmd:rflash $$CN  1.tar -c
+check:output=~Error: Cannot access
+check:rc != 0
+cmd:rflash $$CN -c /tmp/1.tar
+check:output=~Error: Cannot access
+check:rc != 0
+end
+
+start:rflash_option_c_with_multiple_values
+description: basic usage check for option c. if there are multiple value assigned to c option,  should throw out error message
+os:Linux
+hcp:openbmc
+cmd:rflash $$CN -c /tmp/abc123.tz /tmp/abc124.tz
+check:output=~Invalid option specified when an directory is provided
+check:rc != 0
+cmd:rflash $$CN -c  1.tz 2.tz 3.tz 
+check:output=~Error: More than one firmware specified is not supported
+check:rc != 0
+cmd:rflash $$CN 1.tz 2.tz 3.tz -c
+check:output=~Error: More than one firmware specified is not supported
+check:rc != 0
+cmd:rflash $$CN 1.tz -c 2.tz
+check:output=~Error: More than one firmware specified is not supported
+check:rc != 0
+end
+
+start:rflash_option_c_against_node
+description:  Make sure the -c option against node works
+os:Linux
+hcp:openbmc
+cmd:rflash $$CN -c |tee /tmp/rflash_option_c.output
+check:rc == 0
+cmd:grep -i ibm /tmp/rflash_option_c.output |grep -i 'HOST Firmware Product' | grep -i 'Active)\*' | wc -l
+check:rc==0
+check:output=~1
+cmd:grep -i ibm /tmp/rflash_option_c.output |grep -i 'BMC Firmware Product' | grep -i 'Active)\*' | wc -l
+check:rc==0
+check:output=~1
+cmd:rm -rf /tmp/rflash_option_c.output
+check:rc==0
+end
+
+start:rflash_option_check_with_V_against_node
+description:  Make sure the --check option with V works
+os:Linux
+hcp:openbmc
+cmd:rflash $$CN --check -V |tee /tmp/rflash_option_check_with_V.output
+check:rc == 0
+cmd:grep -i ibm /tmp/rflash_option_check_with_V.output |grep -i 'HOST Firmware Product' | grep -i 'Active)\*' | wc -l
+check:rc==0
+check:output=~1
+cmd:grep -i ibm /tmp/rflash_option_check_with_V.output |grep -i 'BMC Firmware Product' | grep -i 'Active)\*' | wc -l
+check:rc==0
+check:output=~1
+cmd:rm -rf /tmp/rflash_option_check_with_V.output
+check:rc==0
+end
+
+
+start:rflash_option_l_with_value
+description: basic usage check for option l. if there is value for l option,  should throw out error message
+os:Linux
+hcp:openbmc
+cmd:rflash $$CN -l /tmp/abc123.tz
+check:output=~Error: Invalid option
+check:rc != 0
+cmd: rflash $$CN /tmp/abc123.tz -l
+check:output=~Error: Invalid option
+check:rc != 0
+end
+
+start:rflash_option_l
+description:  Make sure the -l option works
+os:Linux
+hcp:openbmc
+cmd:rflash $$CN -l |tee /tmp/rflash_option_l.output
+check:rc == 0
+cmd:grep -i ' bmc ' /tmp/rflash_option_l.output | grep -i 'Active(\*)' | wc -l
+check:rc==0
+check:output=~1
+cmd:grep -i ' host ' /tmp/rflash_option_l.output | grep -i 'Active(\*)' | wc -l
+check:rc==0
+check:output=~1
+cmd:rm -rf /tmp/rflash_option_l.output
+check:rc==0
+end
+
+
+start:rflash_option_u_file_not_exist
+description: basic usage check for option u. if the file does not exist, should throw out error message
+os:Linux
+hcp:openbmc
+cmd:rflash $$CN -u /tmp/abc123.tz
+check:output=~Error: Invalid option
+check:rc != 0
+cmd:rflash $$CN -u /tmp/
+check:output=~Error: Invalid option
+check:rc != 0
+cmd:rflash $$CN /tmp/abc123.tz -u
+check:output=~Error: Invalid option
+check:rc != 0
+cmd:rflash $$CN /tmp/ -u
+check:output=~Error: Invalid option
+check:rc != 0
+cmd:rflash $$CN 1.tar -u
+check:output=~Error: Cannot access
+check:rc != 0
+cmd:rflash $$CN -u /tmp/1.tar
+check:output=~Error: Cannot access
+check:rc != 0
+end
+
+start:rflash_option_u_with_multiple_values
+description: basic usage check for option u. if there are multiple value assigned to u option,  should throw out error message
+os:Linux
+hcp:openbmc
+cmd:rflash $$CN -u /tmp/abc123.tz /tmp/abc124.tz
+check:output=~Error: Invalid option specified when an directory is provided
+check:rc != 0
+cmd:rflash $$CN -u 1.tz 2.tz 3.tz 
+check:output=~Error: More than one firmware specified is not supported
+check:rc != 0
+cmd:rflash $$CN 1.tz 2.tz 3.tz -u
+check:output=~Error: More than one firmware specified is not supported
+check:rc != 0
+cmd:rflash $$CN 1.tz -u 2.tz
+check:output=~Error: More than one firmware specified is not supported
+check:rc != 0
+end
+
+start:rflash_option_a_file_not_exist
+description: basic usage check for option a. if the file does not exist, should throw out error message
+os:Linux
+hcp:openbmc
+cmd:rflash $$CN -a /tmp/abc123.tz
+check:output=~Error: Invalid option
+check:rc != 0
+cmd:rflash $$CN -a /tmp/
+check:output=~Error: Invalid option
+check:rc != 0
+cmd:rflash $$CN /tmp/abc123.tz -a
+check:output=~Error: Invalid option
+check:rc != 0
+cmd:rflash $$CN /tmp/ -a
+check:output=~Error: Invalid option
+check:rc != 0
+cmd:rflash $$CN 1.tar -a
+check:output=~Error: Cannot access
+check:rc != 0
+cmd:rflash $$CN -a /tmp/1.tar
+check:output=~Error: Cannot access
+check:rc != 0
+end
+
+start:rflash_option_a_with_multiple_values
+description: basic usage check for option a. if there are multiple value assigned to a option, should throw out error message
+os:Linux
+hcp:openbmc
+cmd:rflash $$CN -a /tmp/abc123.tz /tmp/abc124.tz
+check:output=~Error: Invalid option specified when an directory is provided
+check:rc != 0
+cmd:rflash $$CN -a 1.tz 2.tz 3.tz
+check:output=~Error: More than one firmware specified is not supported
+check:rc != 0
+cmd:rflash $$CN 1.tz 2.tz 3.tz -a
+check:output=~Error: More than one firmware specified is not supported
+check:rc != 0
+cmd:rflash $$CN 1.tz -a 2.tz
+check:output=~Error: More than one firmware specified is not supported
+check:rc != 0
+cmd:rflash $$CN 1234567 -a 2345678
+check:output=~Error: More than one firmware specified is not supported
+check:rc != 0
+end
+
+
+start:rflash_option_a_with_non_existent_id
+description: basic usage check for option a. if active a non-existent firmware ID, should throw out error message
+os:Linux
+hcp:openbmc
+cmd:rflash $$CN -a 1234567
+check:output=~Error: Invalid ID provided to activate
+check:rc != 0
+end
+
+start:rflash_option_delete_with_multiple_values
+description: basic usage check for option delete. if there are multiple value assigned to delete option, should throw out error message
+os:Linux
+hcp:openbmc
+cmd:rflash $$CN --delete 1234567 2345678 
+check:output=~Error: More than one firmware specified is not supported
+check:rc != 0
+cmd:rflash $$CN 1234567 2345678 --delete
+check:output=~Error: More than one firmware specified is not supported
+check:rc != 0
+cmd:rflash $$CN 1234567 --delete 2345678
+check:output=~Error: More than one firmware specified is not supported
+check:rc != 0
+end
+
+start:rflash_option_delete_with_non_existent_id
+description: basic usage check for option --delete. if delete a non-existent firmware ID, should throw out error message
+os:Linux
+hcp:openbmc
+cmd:rflash $$CN --delete 1234567
+check:output=~Error: Invalid ID provided to delete
+check:rc != 0
+end

--- a/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
+++ b/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
@@ -26,6 +26,9 @@ check:output=~Usage:
 cmd:rflash -a 1.tar
 check:rc != 0
 check:output=~Error: Invalid nodes and/or groups in noderange
+cmd:rflash -a 123abc
+check:rc != 0
+check:output=~Error: Invalid nodes and/or groups in noderange
 end
 
 start:rflash_option_u_without_specify_noderange
@@ -45,7 +48,10 @@ os:Linux
 hcp:openbmc
 cmd:rflash -d
 check:output=~Usage:
-cmd:rflash -d 1234
+cmd:rflash -d /1234
+check:rc != 0
+check:output=~Error: Invalid nodes and/or groups in noderange
+cmd:rflash --delete 1234abc
 check:rc != 0
 check:output=~Error: Invalid nodes and/or groups in noderange
 end
@@ -359,6 +365,10 @@ cmd:rflash $$CN 1234567 -a 2345678
 check:output=~Error: More than one firmware specified is not supported
 check:output!~Attempting to 
 check:rc != 0
+cmd:rflash $$CN -a 123 abc asdbas 
+check:output=~Error: More than one firmware specified is not supported
+check:output!~Attempting to
+check:rc != 0
 end
 
 
@@ -369,6 +379,10 @@ hcp:openbmc
 cmd:rflash $$CN -a 1234567
 check:output=~Error: Invalid ID provided to activate
 check:output!~Attempting to activate 
+check:rc != 0
+cmd:rflash $$CN -a 123abcm
+check:output=~Error: Invalid ID provided to activate
+check:output!~Attempting to activate
 check:rc != 0
 end
 
@@ -395,6 +409,10 @@ description: basic usage check for option --delete. if delete a non-existent fir
 os:Linux
 hcp:openbmc
 cmd:rflash $$CN --delete 1234567
+check:output=~Error: Invalid ID provided to delete
+check:output!~Attempting to delete
+check:rc != 0
+cmd:rflash $$CN --delete 123abcm
 check:output=~Error: Invalid ID provided to delete
 check:output!~Attempting to delete
 check:rc != 0
@@ -439,7 +457,7 @@ check:rc != 0
 cmd:touch obmc-phosphor-image-witherspoon.ubi.mtd.tar /tmp/bogus123
 check:rc == 0
 cmd:rflash $$CN -d /tmp/bogus123
-check::output =~Error: No BMC tar file found
+check:output =~Error: No BMC tar file found
 check:output =~Error: No PNOR tar file found
 check:output!~Attempting to
 check:rc != 0
@@ -451,6 +469,18 @@ check:output =~Error: No PNOR tar file found
 check:output!~Attempting to
 check:rc != 0
 cmd:rm -rf /tmp/bogus123
+check:rc == 0
+end
+
+start:rflash_usage
+description:checke the usage of rflash for openbmc
+os:Linux
+hcp:openbmc
+cmd:rflash -h
+check:output =~Usage:
+check:output =~OpenPOWER OpenBMC specific:
+check:output =~ -d
+check:output =~ image_id.+--delete 
 check:rc == 0
 end
 

--- a/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
+++ b/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
@@ -178,7 +178,7 @@ description: basic usage check for option c. if there are multiple value assigne
 os:Linux
 hcp:openbmc
 cmd:rflash $$CN -c /tmp/abc123.tz /tmp/abc124.tz
-check:output=~Invalid option specified when an directory is provided
+check:output=~Error: More than one firmware specified is not supported
 check:rc != 0
 cmd:rflash $$CN -c  1.tz 2.tz 3.tz 
 check:output=~Error: More than one firmware specified is not supported
@@ -259,21 +259,27 @@ os:Linux
 hcp:openbmc
 cmd:rflash $$CN -u /tmp/abc123.tz
 check:output=~Error: Invalid option
+check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN -u /tmp/
 check:output=~Error: Invalid option
+check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN /tmp/abc123.tz -u
 check:output=~Error: Invalid option
+check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN /tmp/ -u
 check:output=~Error: Invalid option
+check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN 1.tar -u
 check:output=~Error: Cannot access
+check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN -u /tmp/1.tar
 check:output=~Error: Cannot access
+check:output!~Attempting to
 check:rc != 0
 end
 
@@ -282,16 +288,20 @@ description: basic usage check for option u. if there are multiple value assigne
 os:Linux
 hcp:openbmc
 cmd:rflash $$CN -u /tmp/abc123.tz /tmp/abc124.tz
-check:output=~Error: Invalid option specified when an directory is provided
+check:output=~Error: More than one firmware specified is not supported
+check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN -u 1.tz 2.tz 3.tz 
 check:output=~Error: More than one firmware specified is not supported
+check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN 1.tz 2.tz 3.tz -u
 check:output=~Error: More than one firmware specified is not supported
+check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN 1.tz -u 2.tz
 check:output=~Error: More than one firmware specified is not supported
+check:output!~Attempting to
 check:rc != 0
 end
 
@@ -301,21 +311,27 @@ os:Linux
 hcp:openbmc
 cmd:rflash $$CN -a /tmp/abc123.tz
 check:output=~Error: Invalid option
+check:output!~Attempting to 
 check:rc != 0
 cmd:rflash $$CN -a /tmp/
 check:output=~Error: Invalid option
+check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN /tmp/abc123.tz -a
 check:output=~Error: Invalid option
+check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN /tmp/ -a
 check:output=~Error: Invalid option
+check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN 1.tar -a
 check:output=~Error: Cannot access
+check:output!~Attempting to 
 check:rc != 0
 cmd:rflash $$CN -a /tmp/1.tar
 check:output=~Error: Cannot access
+check:output!~Attempting to
 check:rc != 0
 end
 
@@ -324,19 +340,24 @@ description: basic usage check for option a. if there are multiple value assigne
 os:Linux
 hcp:openbmc
 cmd:rflash $$CN -a /tmp/abc123.tz /tmp/abc124.tz
-check:output=~Error: Invalid option specified when an directory is provided
+check:output=~Error: More than one foirmware specified is not supported
+check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN -a 1.tz 2.tz 3.tz
 check:output=~Error: More than one firmware specified is not supported
+check:output!~Attempting to 
 check:rc != 0
 cmd:rflash $$CN 1.tz 2.tz 3.tz -a
 check:output=~Error: More than one firmware specified is not supported
+check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN 1.tz -a 2.tz
 check:output=~Error: More than one firmware specified is not supported
+check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN 1234567 -a 2345678
 check:output=~Error: More than one firmware specified is not supported
+check:output!~Attempting to 
 check:rc != 0
 end
 
@@ -347,6 +368,7 @@ os:Linux
 hcp:openbmc
 cmd:rflash $$CN -a 1234567
 check:output=~Error: Invalid ID provided to activate
+check:output!~Attempting to activate 
 check:rc != 0
 end
 
@@ -356,12 +378,15 @@ os:Linux
 hcp:openbmc
 cmd:rflash $$CN --delete 1234567 2345678 
 check:output=~Error: More than one firmware specified is not supported
+check:output!~Attempting to delete
 check:rc != 0
 cmd:rflash $$CN 1234567 2345678 --delete
 check:output=~Error: More than one firmware specified is not supported
+check:output!~Attempting to delete
 check:rc != 0
 cmd:rflash $$CN 1234567 --delete 2345678
 check:output=~Error: More than one firmware specified is not supported
+check:output!~Attempting to delete
 check:rc != 0
 end
 
@@ -371,5 +396,6 @@ os:Linux
 hcp:openbmc
 cmd:rflash $$CN --delete 1234567
 check:output=~Error: Invalid ID provided to delete
+check:output!~Attempting to delete
 check:rc != 0
 end


### PR DESCRIPTION
These test cases are added for testing ``rflash`` regular usage against ``openbmc``. 
Just include common usage check, not include function check. 
Function check will still be covered by [rflash manual test against openbmc](https://github.ibm.com/xcat2/team_process/blob/master/FVT/docs/rflash_Manual_Test_Steps.md#for-witherspoon-physical-machine----openbmc)

@xuweibj @whowutwut @gurevichmark, could you pay more attention to the output of every command, make sure they are what we expected. If not, I will update case. thanks. 

The UT result against 20171206.0615 build

```
[root@c910f03c11k08 home]# awk -F":" '/start:/ {print $2}' /opt/xcat/share/xcat/tools/autotest/testcase/rflash/rflash_openbmc.0   >./rflash.bundle
[root@c910f03c11k08 home]# XCATTEST_CN=f6u17 xcattest -b ./rflash.bundle
xCAT automated test started at Thu Dec  7 05:27:59 2017
******************************
To detect current test environment
******************************
Detecting: OS = linux
Detecting: ARCH = ppc64le
Detecting: HCP = openbmc
******************************
loading test cases
******************************
To run:
rflash_option_c_without_specify_noderange
rflash_option_l_without_specify_noderange
rflash_option_a_without_specify_noderange
rflash_option_u_without_specify_noderange
rflash_option_d_without_specify_noderange
rflash_without_option
rflash_unsupport_multiple_option_a_u
rflash_unsupport_multiple_option_a_c
rflash_unsupport_multiple_option_a_l
rflash_unsupport_multiple_option_a_d
rflash_unsupport_multiple_option_c_l
rflash_unsupport_multiple_option_c_u
rflash_unsupport_multiple_option_c_d
rflash_unsupport_multiple_option_l_d
rflash_unsupport_multiple_option_l_u
rflash_unsupport_multiple_option_u_d
rflash_option_c_file_not_exist
rflash_option_c_with_multiple_values
rflash_option_c_against_node
rflash_option_check_with_V_against_node
rflash_option_l_with_value
rflash_option_l
rflash_option_u_file_not_exist
rflash_option_u_with_multiple_values
rflash_option_a_file_not_exist
rflash_option_a_with_multiple_values
rflash_option_a_with_non_existent_id
rflash_option_delete_with_multiple_values
rflash_option_delete_with_non_existent_id
rflash_option_d_with_multiple_values
rflash_option_d_with_non_existent_dir
******************************
Start to run test cases
******************************
------START::rflash_option_c_without_specify_noderange::Time:Thu Dec  7 05:28:00 2017------

RUN:rflash -c [Thu Dec  7 05:28:00 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Usage:
    rflash [ -h|--help|-v|--version]
    PPC (with HMC) specific:
	rflash <noderange> -p <rpm_directory> [--activate {concurrent | disruptive}] [-V|--verbose]
	rflash <noderange> {--commit | --recover} [-V|--verbose]
    PPC (using Direct FSP Management) specific:
	rflash <noderange> -p <rpm_directory> [--activate {disruptive|deferred}] [-d <data_directory>]
	rflash <noderange> [--commit | --recover] [-V|--verbose]
        rflash <noderange> [--bpa_acdl]
    OpenPOWER BMC specific (using IPMI):
        rflash <noderange> [<hpm_file_path>|-d <data_directory>] [-c|--check] [--retry=<count>] [-V]
        rflash <noderange> --recover <bmc_file_path>
    OpenPOWER OpenBMC specific:
        rflash <noderange> {[-c|--check] | [-l|--list]}
        rflash <noderange> <tar_file_path> {[-c|--check] | [-a|--activate] | [-u|--upload]}
        rflash <noderange> <image_id> {[-a|--activate] | [-d|--delete]}
CHECK:output =~ Usage:	[Pass]

RUN:rflash -c 1.tar [Thu Dec  7 05:28:00 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Error: Invalid nodes and/or groups in noderange: 1.tar
CHECK:rc != 0	[Pass]
CHECK:output =~ Error: Invalid nodes and/or groups in noderange	[Pass]

------END::rflash_option_c_without_specify_noderange::Passed::Time:Thu Dec  7 05:28:00 2017 ::Duration::0 sec------
------START::rflash_option_l_without_specify_noderange::Time:Thu Dec  7 05:28:00 2017------

RUN:rflash -l [Thu Dec  7 05:28:00 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Usage:
    rflash [ -h|--help|-v|--version]
    PPC (with HMC) specific:
	rflash <noderange> -p <rpm_directory> [--activate {concurrent | disruptive}] [-V|--verbose]
	rflash <noderange> {--commit | --recover} [-V|--verbose]
    PPC (using Direct FSP Management) specific:
	rflash <noderange> -p <rpm_directory> [--activate {disruptive|deferred}] [-d <data_directory>]
	rflash <noderange> [--commit | --recover] [-V|--verbose]
        rflash <noderange> [--bpa_acdl]
    OpenPOWER BMC specific (using IPMI):
        rflash <noderange> [<hpm_file_path>|-d <data_directory>] [-c|--check] [--retry=<count>] [-V]
        rflash <noderange> --recover <bmc_file_path>
    OpenPOWER OpenBMC specific:
        rflash <noderange> {[-c|--check] | [-l|--list]}
        rflash <noderange> <tar_file_path> {[-c|--check] | [-a|--activate] | [-u|--upload]}
        rflash <noderange> <image_id> {[-a|--activate] | [-d|--delete]}
CHECK:output =~ Usage:	[Pass]

------END::rflash_option_l_without_specify_noderange::Passed::Time:Thu Dec  7 05:28:00 2017 ::Duration::0 sec------
------START::rflash_option_a_without_specify_noderange::Time:Thu Dec  7 05:28:00 2017------

RUN:rflash -a [Thu Dec  7 05:28:00 2017]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Usage:
    rflash [ -h|--help|-v|--version]
    PPC (with HMC) specific:
	rflash <noderange> -p <rpm_directory> [--activate {concurrent | disruptive}] [-V|--verbose]
	rflash <noderange> {--commit | --recover} [-V|--verbose]
    PPC (using Direct FSP Management) specific:
	rflash <noderange> -p <rpm_directory> [--activate {disruptive|deferred}] [-d <data_directory>]
	rflash <noderange> [--commit | --recover] [-V|--verbose]
        rflash <noderange> [--bpa_acdl]
    OpenPOWER BMC specific (using IPMI):
        rflash <noderange> [<hpm_file_path>|-d <data_directory>] [-c|--check] [--retry=<count>] [-V]
        rflash <noderange> --recover <bmc_file_path>
    OpenPOWER OpenBMC specific:
        rflash <noderange> {[-c|--check] | [-l|--list]}
        rflash <noderange> <tar_file_path> {[-c|--check] | [-a|--activate] | [-u|--upload]}
        rflash <noderange> <image_id> {[-a|--activate] | [-d|--delete]}
CHECK:output =~ Usage:	[Pass]

RUN:rflash -a 1.tar [Thu Dec  7 05:28:01 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Error: Invalid nodes and/or groups in noderange: 1.tar
CHECK:rc != 0	[Pass]
CHECK:output =~ Error: Invalid nodes and/or groups in noderange	[Pass]

------END::rflash_option_a_without_specify_noderange::Passed::Time:Thu Dec  7 05:28:01 2017 ::Duration::1 sec------
------START::rflash_option_u_without_specify_noderange::Time:Thu Dec  7 05:28:01 2017------

RUN:rflash -u [Thu Dec  7 05:28:01 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Usage:
    rflash [ -h|--help|-v|--version]
    PPC (with HMC) specific:
	rflash <noderange> -p <rpm_directory> [--activate {concurrent | disruptive}] [-V|--verbose]
	rflash <noderange> {--commit | --recover} [-V|--verbose]
    PPC (using Direct FSP Management) specific:
	rflash <noderange> -p <rpm_directory> [--activate {disruptive|deferred}] [-d <data_directory>]
	rflash <noderange> [--commit | --recover] [-V|--verbose]
        rflash <noderange> [--bpa_acdl]
    OpenPOWER BMC specific (using IPMI):
        rflash <noderange> [<hpm_file_path>|-d <data_directory>] [-c|--check] [--retry=<count>] [-V]
        rflash <noderange> --recover <bmc_file_path>
    OpenPOWER OpenBMC specific:
        rflash <noderange> {[-c|--check] | [-l|--list]}
        rflash <noderange> <tar_file_path> {[-c|--check] | [-a|--activate] | [-u|--upload]}
        rflash <noderange> <image_id> {[-a|--activate] | [-d|--delete]}
CHECK:output =~ Usage:	[Pass]

RUN:rflash -u  1.tar [Thu Dec  7 05:28:01 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Error: Invalid nodes and/or groups in noderange: 1.tar
CHECK:rc != 0	[Pass]
CHECK:output =~ Error: Invalid nodes and/or groups in noderange	[Pass]

------END::rflash_option_u_without_specify_noderange::Passed::Time:Thu Dec  7 05:28:01 2017 ::Duration::0 sec------
------START::rflash_option_d_without_specify_noderange::Time:Thu Dec  7 05:28:01 2017------

RUN:rflash -d [Thu Dec  7 05:28:01 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Usage:
    rflash [ -h|--help|-v|--version]
    PPC (with HMC) specific:
	rflash <noderange> -p <rpm_directory> [--activate {concurrent | disruptive}] [-V|--verbose]
	rflash <noderange> {--commit | --recover} [-V|--verbose]
    PPC (using Direct FSP Management) specific:
	rflash <noderange> -p <rpm_directory> [--activate {disruptive|deferred}] [-d <data_directory>]
	rflash <noderange> [--commit | --recover] [-V|--verbose]
        rflash <noderange> [--bpa_acdl]
    OpenPOWER BMC specific (using IPMI):
        rflash <noderange> [<hpm_file_path>|-d <data_directory>] [-c|--check] [--retry=<count>] [-V]
        rflash <noderange> --recover <bmc_file_path>
    OpenPOWER OpenBMC specific:
        rflash <noderange> {[-c|--check] | [-l|--list]}
        rflash <noderange> <tar_file_path> {[-c|--check] | [-a|--activate] | [-u|--upload]}
        rflash <noderange> <image_id> {[-a|--activate] | [-d|--delete]}
CHECK:output =~ Usage:	[Pass]

RUN:rflash -d 1234 [Thu Dec  7 05:28:01 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Error: Invalid nodes and/or groups in noderange: node1234
CHECK:rc != 0	[Pass]
CHECK:output =~ Error: Invalid nodes and/or groups in noderange	[Pass]

------END::rflash_option_d_without_specify_noderange::Passed::Time:Thu Dec  7 05:28:01 2017 ::Duration::0 sec------
------START::rflash_without_option::Time:Thu Dec  7 05:28:01 2017------

RUN:rflash f6u17 1.tar [Thu Dec  7 05:28:01 2017]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Invalid option specified when a file is provided:
CHECK:rc != 0	[Pass]
CHECK:output =~ Error: Invalid option specified when a file is provided:	[Pass]

------END::rflash_without_option::Passed::Time:Thu Dec  7 05:28:02 2017 ::Duration::1 sec------
------START::rflash_unsupport_multiple_option_a_u::Time:Thu Dec  7 05:28:02 2017------

RUN:rflash f6u17 -a 1.tz -u [Thu Dec  7 05:28:02 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Multiple options are not supported. Options specified: -a -u
CHECK:output =~ Error: Multiple options are not supported	[Pass]
CHECK:rc != 0	[Pass]

------END::rflash_unsupport_multiple_option_a_u::Passed::Time:Thu Dec  7 05:28:02 2017 ::Duration::0 sec------
------START::rflash_unsupport_multiple_option_a_c::Time:Thu Dec  7 05:28:02 2017------

RUN:rflash f6u17 -a 1.tz -c [Thu Dec  7 05:28:02 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Multiple options are not supported. Options specified: -a -c
CHECK:output =~ Error: Multiple options are not supported	[Pass]
CHECK:rc != 0	[Pass]

------END::rflash_unsupport_multiple_option_a_c::Passed::Time:Thu Dec  7 05:28:02 2017 ::Duration::0 sec------
------START::rflash_unsupport_multiple_option_a_l::Time:Thu Dec  7 05:28:02 2017------

RUN:rflash f6u17 -a 1.tz -l [Thu Dec  7 05:28:02 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Multiple options are not supported. Options specified: -a -l
CHECK:output =~ Error: Multiple options are not supported	[Pass]
CHECK:rc != 0	[Pass]

------END::rflash_unsupport_multiple_option_a_l::Passed::Time:Thu Dec  7 05:28:02 2017 ::Duration::0 sec------
------START::rflash_unsupport_multiple_option_a_d::Time:Thu Dec  7 05:28:02 2017------

RUN:rflash f6u17 -a 1.tz -d [Thu Dec  7 05:28:02 2017]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Multiple options are not supported. Options specified: -a -d
CHECK:output =~ Error: Multiple options are not supported	[Pass]
CHECK:rc != 0	[Pass]

------END::rflash_unsupport_multiple_option_a_d::Passed::Time:Thu Dec  7 05:28:03 2017 ::Duration::1 sec------
------START::rflash_unsupport_multiple_option_c_l::Time:Thu Dec  7 05:28:03 2017------

RUN:rflash f6u17 -c 1.tz -l [Thu Dec  7 05:28:03 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Multiple options are not supported. Options specified: -c -l
CHECK:output =~ Error: Multiple options are not supported	[Pass]
CHECK:rc != 0	[Pass]

------END::rflash_unsupport_multiple_option_c_l::Passed::Time:Thu Dec  7 05:28:03 2017 ::Duration::0 sec------
------START::rflash_unsupport_multiple_option_c_u::Time:Thu Dec  7 05:28:03 2017------

RUN:rflash f6u17 -c 1.tz -u [Thu Dec  7 05:28:03 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Multiple options are not supported. Options specified: -c -u
CHECK:output =~ Error: Multiple options are not supported	[Pass]
CHECK:rc != 0	[Pass]

------END::rflash_unsupport_multiple_option_c_u::Passed::Time:Thu Dec  7 05:28:03 2017 ::Duration::0 sec------
------START::rflash_unsupport_multiple_option_c_d::Time:Thu Dec  7 05:28:03 2017------

RUN:rflash f6u17 -c 1.tz -d [Thu Dec  7 05:28:03 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Multiple options are not supported. Options specified: -c -d
CHECK:output =~ Error: Multiple options are not supported	[Pass]
CHECK:rc != 0	[Pass]

------END::rflash_unsupport_multiple_option_c_d::Passed::Time:Thu Dec  7 05:28:03 2017 ::Duration::0 sec------
------START::rflash_unsupport_multiple_option_l_d::Time:Thu Dec  7 05:28:03 2017------

RUN:rflash f6u17 -l -d [Thu Dec  7 05:28:03 2017]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Multiple options are not supported. Options specified: -l -d
CHECK:output =~ Error: Multiple options are not supported	[Pass]
CHECK:rc != 0	[Pass]

------END::rflash_unsupport_multiple_option_l_d::Passed::Time:Thu Dec  7 05:28:04 2017 ::Duration::1 sec------
------START::rflash_unsupport_multiple_option_l_u::Time:Thu Dec  7 05:28:04 2017------

RUN:rflash f6u17 -l -u [Thu Dec  7 05:28:04 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Multiple options are not supported. Options specified: -l -u
CHECK:output =~ Error: Multiple options are not supported	[Pass]
CHECK:rc != 0	[Pass]

------END::rflash_unsupport_multiple_option_l_u::Passed::Time:Thu Dec  7 05:28:04 2017 ::Duration::0 sec------
------START::rflash_unsupport_multiple_option_u_d::Time:Thu Dec  7 05:28:04 2017------

RUN:rflash f6u17 -u -d [Thu Dec  7 05:28:04 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Multiple options are not supported. Options specified: -u -d
CHECK:output =~ Error: Multiple options are not supported	[Pass]
CHECK:rc != 0	[Pass]

------END::rflash_unsupport_multiple_option_u_d::Passed::Time:Thu Dec  7 05:28:04 2017 ::Duration::0 sec------
------START::rflash_option_c_file_not_exist::Time:Thu Dec  7 05:28:04 2017------

RUN:rflash f6u17 -c /tmp/abc123.tz [Thu Dec  7 05:28:04 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Invalid option specified when an directory is provided: -c
CHECK:output =~ Error: Invalid option	[Pass]
CHECK:rc != 0	[Pass]

RUN:rflash f6u17 -c /tmp/ [Thu Dec  7 05:28:04 2017]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Invalid option specified when an directory is provided: -c
CHECK:output =~ Error: Invalid option	[Pass]
CHECK:rc != 0	[Pass]

RUN:rflash f6u17 /tmp/abc123.tz -c [Thu Dec  7 05:28:05 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Invalid option specified when an directory is provided: -c
CHECK:output =~ Error: Invalid option	[Pass]
CHECK:rc != 0	[Pass]

RUN:rflash f6u17 /tmp/ -c [Thu Dec  7 05:28:05 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Invalid option specified when an directory is provided: -c
CHECK:output =~ Error: Invalid option	[Pass]
CHECK:rc != 0	[Pass]

RUN:rflash f6u17  1.tar -c [Thu Dec  7 05:28:05 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Error: Cannot access /home/1.tar. Check the management node and/or service nodes.
Attempting to upload 1.tar, please wait...
CHECK:output =~ Error: Cannot access	[Pass]
CHECK:rc != 0	[Pass]

RUN:rflash f6u17 -c /tmp/1.tar [Thu Dec  7 05:28:05 2017]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: Cannot access /tmp/1.tar. Check the management node and/or service nodes.
Attempting to upload /tmp/1.tar, please wait...
CHECK:output =~ Error: Cannot access	[Pass]
CHECK:rc != 0	[Pass]

------END::rflash_option_c_file_not_exist::Passed::Time:Thu Dec  7 05:28:06 2017 ::Duration::2 sec------
------START::rflash_option_c_with_multiple_values::Time:Thu Dec  7 05:28:06 2017------

RUN:rflash f6u17 -c /tmp/abc123.tz /tmp/abc124.tz [Thu Dec  7 05:28:06 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Invalid option specified when an directory is provided: -c
CHECK:output =~ Error: More than one firmware specified is not supported	[Failed]

RUN:rflash f6u17 -c  1.tz 2.tz 3.tz [Thu Dec  7 05:28:06 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: More than one firmware specified is not supported.

RUN:rflash f6u17 1.tz 2.tz 3.tz -c [Thu Dec  7 05:28:06 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: More than one firmware specified is not supported.

RUN:rflash f6u17 1.tz -c 2.tz [Thu Dec  7 05:28:06 2017]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: More than one firmware specified is not supported.

------END::rflash_option_c_with_multiple_values::Failed::Time:Thu Dec  7 05:28:07 2017 ::Duration::1 sec------
------START::rflash_option_c_against_node::Time:Thu Dec  7 05:28:07 2017------

RUN:rflash f6u17 -c |tee /tmp/rflash_option_c.output [Thu Dec  7 05:28:07 2017]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
f6u17: BMC Firmware Product:   ibm-v2.0-0-r13.3-0-gd624923 (Active)*
f6u17: HOST Firmware Product:   IBM-witherspoon-ibm-OP9_v1.19_1.90 (Active)*
f6u17: HOST Firmware Product: -- additional info: buildroot-2017.08-8-g5e23247
f6u17: HOST Firmware Product: -- additional info: capp-ucode-p9-dd2-v2
f6u17: HOST Firmware Product: -- additional info: hostboot-binaries-b4606e0
f6u17: HOST Firmware Product: -- additional info: hostboot-c646b78
f6u17: HOST Firmware Product: -- additional info: linux-4.13.11-openpower1-p5bc6a1c
f6u17: HOST Firmware Product: -- additional info: machine-xml-bcd4a40
f6u17: HOST Firmware Product: -- additional info: occ-51965bd
f6u17: HOST Firmware Product: -- additional info: op-build-v1.19-276-g91e7614
f6u17: HOST Firmware Product: -- additional info: petitboot-v1.6.3-pd4b114c
f6u17: HOST Firmware Product: -- additional info: sbe-6d7627a
f6u17: HOST Firmware Product: -- additional info: skiboot-v5.9.4
CHECK:rc == 0	[Pass]

RUN:grep -i ibm /tmp/rflash_option_c.output |grep -i 'HOST Firmware Product' | grep -i 'Active)\*' | wc -l [Thu Dec  7 05:28:09 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1
CHECK:rc == 0	[Pass]
CHECK:output =~ 1	[Pass]

RUN:grep -i ibm /tmp/rflash_option_c.output |grep -i 'BMC Firmware Product' | grep -i 'Active)\*' | wc -l [Thu Dec  7 05:28:09 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1
CHECK:rc == 0	[Pass]
CHECK:output =~ 1	[Pass]

RUN:rm -rf /tmp/rflash_option_c.output [Thu Dec  7 05:28:09 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::rflash_option_c_against_node::Passed::Time:Thu Dec  7 05:28:09 2017 ::Duration::2 sec------
------START::rflash_option_check_with_V_against_node::Time:Thu Dec  7 05:28:09 2017------

RUN:rflash f6u17 --check -V |tee /tmp/rflash_option_check_with_V.output [Thu Dec  7 05:28:09 2017]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
[c910f03c11k08]: f6u17: BMC Firmware Product:   ibm-v2.0-0-r13-0-g3a160ac (Active)
[c910f03c11k08]: f6u17: BMC Firmware Product:   ibm-v2.0-0-r13.3-0-gd624923 (Active)*
[c910f03c11k08]: f6u17: HOST Firmware Product:   IBM-witherspoon-ibm-OP9_v1.19_1.88 (Active)
[c910f03c11k08]: f6u17: HOST Firmware Product: -- additional info: buildroot-2017.08-8-g5e23247
[c910f03c11k08]: f6u17: HOST Firmware Product: -- additional info: capp-ucode-p9-dd2-v2
[c910f03c11k08]: f6u17: HOST Firmware Product: -- additional info: hostboot-47e26a3
[c910f03c11k08]: f6u17: HOST Firmware Product: -- additional info: hostboot-binaries-325a008
[c910f03c11k08]: f6u17: HOST Firmware Product: -- additional info: linux-4.13.11-openpower1-p502d202
[c910f03c11k08]: f6u17: HOST Firmware Product: -- additional info: machine-xml-bcd4a40
[c910f03c11k08]: f6u17: HOST Firmware Product: -- additional info: occ-51965bd
[c910f03c11k08]: f6u17: HOST Firmware Product: -- additional info: op-build-v1.19-272-g7e6959e
[c910f03c11k08]: f6u17: HOST Firmware Product: -- additional info: petitboot-v1.6.3-p393c40d
[c910f03c11k08]: f6u17: HOST Firmware Product: -- additional info: sbe-93ed873
[c910f03c11k08]: f6u17: HOST Firmware Product: -- additional info: skiboot-v5.9.4
[c910f03c11k08]: f6u17: HOST Firmware Product:   IBM-witherspoon-ibm-OP9_v1.19_1.90 (Active)*
[c910f03c11k08]: f6u17: HOST Firmware Product: -- additional info: buildroot-2017.08-8-g5e23247
[c910f03c11k08]: f6u17: HOST Firmware Product: -- additional info: capp-ucode-p9-dd2-v2
[c910f03c11k08]: f6u17: HOST Firmware Product: -- additional info: hostboot-binaries-b4606e0
[c910f03c11k08]: f6u17: HOST Firmware Product: -- additional info: hostboot-c646b78
[c910f03c11k08]: f6u17: HOST Firmware Product: -- additional info: linux-4.13.11-openpower1-p5bc6a1c
[c910f03c11k08]: f6u17: HOST Firmware Product: -- additional info: machine-xml-bcd4a40
[c910f03c11k08]: f6u17: HOST Firmware Product: -- additional info: occ-51965bd
[c910f03c11k08]: f6u17: HOST Firmware Product: -- additional info: op-build-v1.19-276-g91e7614
[c910f03c11k08]: f6u17: HOST Firmware Product: -- additional info: petitboot-v1.6.3-pd4b114c
[c910f03c11k08]: f6u17: HOST Firmware Product: -- additional info: sbe-6d7627a
[c910f03c11k08]: f6u17: HOST Firmware Product: -- additional info: skiboot-v5.9.4
CHECK:rc == 0	[Pass]

RUN:grep -i ibm /tmp/rflash_option_check_with_V.output |grep -i 'HOST Firmware Product' | grep -i 'Active)\*' | wc -l [Thu Dec  7 05:28:12 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1
CHECK:rc == 0	[Pass]
CHECK:output =~ 1	[Pass]

RUN:grep -i ibm /tmp/rflash_option_check_with_V.output |grep -i 'BMC Firmware Product' | grep -i 'Active)\*' | wc -l [Thu Dec  7 05:28:12 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1
CHECK:rc == 0	[Pass]
CHECK:output =~ 1	[Pass]

RUN:rm -rf /tmp/rflash_option_check_with_V.output [Thu Dec  7 05:28:12 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::rflash_option_check_with_V_against_node::Passed::Time:Thu Dec  7 05:28:12 2017 ::Duration::3 sec------
------START::rflash_option_l_with_value::Time:Thu Dec  7 05:28:12 2017------

RUN:rflash f6u17 -l /tmp/abc123.tz [Thu Dec  7 05:28:12 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Invalid option specified when an directory is provided: -l
CHECK:output =~ Error: Invalid option	[Pass]
CHECK:rc != 0	[Pass]

RUN:rflash f6u17 /tmp/abc123.tz -l [Thu Dec  7 05:28:12 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Invalid option specified when an directory is provided: -l
CHECK:output =~ Error: Invalid option	[Pass]
CHECK:rc != 0	[Pass]

------END::rflash_option_l_with_value::Passed::Time:Thu Dec  7 05:28:12 2017 ::Duration::0 sec------
------START::rflash_option_l::Time:Thu Dec  7 05:28:12 2017------

RUN:rflash f6u17 -l |tee /tmp/rflash_option_l.output [Thu Dec  7 05:28:12 2017]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
f6u17: ID       Purpose State      Version
f6u17: -------------------------------------------------------
f6u17: b3000fc6 BMC     Active(*)  ibm-v2.0-0-r13.3-0-gd624923
f6u17: 3a7f1407 BMC     Active     ibm-v2.0-0-r13-0-g3a160ac
f6u17: 78abd177 Host    Active     IBM-witherspoon-ibm-OP9_v1.19_1.88
f6u17: df4b8673 Host    Active(*)  IBM-witherspoon-ibm-OP9_v1.19_1.90
f6u17:
CHECK:rc == 0	[Pass]

RUN:grep -i ' bmc ' /tmp/rflash_option_l.output | grep -i 'Active(\*)' | wc -l [Thu Dec  7 05:28:14 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1
CHECK:rc == 0	[Pass]
CHECK:output =~ 1	[Pass]

RUN:grep -i ' host ' /tmp/rflash_option_l.output | grep -i 'Active(\*)' | wc -l [Thu Dec  7 05:28:14 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1
CHECK:rc == 0	[Pass]
CHECK:output =~ 1	[Pass]

RUN:rm -rf /tmp/rflash_option_l.output [Thu Dec  7 05:28:14 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::rflash_option_l::Passed::Time:Thu Dec  7 05:28:14 2017 ::Duration::2 sec------
------START::rflash_option_u_file_not_exist::Time:Thu Dec  7 05:28:14 2017------

RUN:rflash f6u17 -u /tmp/abc123.tz [Thu Dec  7 05:28:14 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Invalid option specified when an directory is provided: -u
CHECK:output =~ Error: Invalid option	[Pass]
CHECK:output !~ Attempting to	[Pass]
CHECK:rc != 0	[Pass]

RUN:rflash f6u17 -u /tmp/ [Thu Dec  7 05:28:14 2017]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Invalid option specified when an directory is provided: -u
CHECK:output =~ Error: Invalid option	[Pass]
CHECK:output !~ Attempting to	[Pass]
CHECK:rc != 0	[Pass]

RUN:rflash f6u17 /tmp/abc123.tz -u [Thu Dec  7 05:28:15 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Invalid option specified when an directory is provided: -u
CHECK:output =~ Error: Invalid option	[Pass]
CHECK:output !~ Attempting to	[Pass]
CHECK:rc != 0	[Pass]

RUN:rflash f6u17 /tmp/ -u [Thu Dec  7 05:28:15 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Invalid option specified when an directory is provided: -u
CHECK:output =~ Error: Invalid option	[Pass]
CHECK:output !~ Attempting to	[Pass]
CHECK:rc != 0	[Pass]

RUN:rflash f6u17 1.tar -u [Thu Dec  7 05:28:15 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Error: Cannot access /home/1.tar. Check the management node and/or service nodes.
Attempting to upload 1.tar, please wait...
CHECK:output =~ Error: Cannot access	[Pass]
CHECK:output !~ Attempting to	[Failed]

RUN:rflash f6u17 -u /tmp/1.tar [Thu Dec  7 05:28:15 2017]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: Cannot access /tmp/1.tar. Check the management node and/or service nodes.
Attempting to upload /tmp/1.tar, please wait...

------END::rflash_option_u_file_not_exist::Failed::Time:Thu Dec  7 05:28:16 2017 ::Duration::2 sec------
------START::rflash_option_u_with_multiple_values::Time:Thu Dec  7 05:28:16 2017------

RUN:rflash f6u17 -u /tmp/abc123.tz /tmp/abc124.tz [Thu Dec  7 05:28:16 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Invalid option specified when an directory is provided: -u
CHECK:output =~ Error: More than one firmware specified is not supported	[Failed]

RUN:rflash f6u17 -u 1.tz 2.tz 3.tz [Thu Dec  7 05:28:16 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: More than one firmware specified is not supported.

RUN:rflash f6u17 1.tz 2.tz 3.tz -u [Thu Dec  7 05:28:16 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: More than one firmware specified is not supported.

RUN:rflash f6u17 1.tz -u 2.tz [Thu Dec  7 05:28:16 2017]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: More than one firmware specified is not supported.

------END::rflash_option_u_with_multiple_values::Failed::Time:Thu Dec  7 05:28:17 2017 ::Duration::1 sec------
------START::rflash_option_a_file_not_exist::Time:Thu Dec  7 05:28:17 2017------

RUN:rflash f6u17 -a /tmp/abc123.tz [Thu Dec  7 05:28:17 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Invalid option specified when an directory is provided: -a
CHECK:output =~ Error: Invalid option	[Pass]
CHECK:output !~ Attempting to	[Pass]
CHECK:rc != 0	[Pass]

RUN:rflash f6u17 -a /tmp/ [Thu Dec  7 05:28:17 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Invalid option specified when an directory is provided: -a
CHECK:output =~ Error: Invalid option	[Pass]
CHECK:output !~ Attempting to	[Pass]
CHECK:rc != 0	[Pass]

RUN:rflash f6u17 /tmp/abc123.tz -a [Thu Dec  7 05:28:17 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Invalid option specified when an directory is provided: -a
CHECK:output =~ Error: Invalid option	[Pass]
CHECK:output !~ Attempting to	[Pass]
CHECK:rc != 0	[Pass]

RUN:rflash f6u17 /tmp/ -a [Thu Dec  7 05:28:17 2017]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Invalid option specified when an directory is provided: -a
CHECK:output =~ Error: Invalid option	[Pass]
CHECK:output !~ Attempting to	[Pass]
CHECK:rc != 0	[Pass]

RUN:rflash f6u17 1.tar -a [Thu Dec  7 05:28:18 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Error: Cannot access /home/1.tar. Check the management node and/or service nodes.
Attempting to upload 1.tar, please wait...
CHECK:output =~ Error: Cannot access	[Pass]
CHECK:output !~ Attempting to	[Failed]

RUN:rflash f6u17 -a /tmp/1.tar [Thu Dec  7 05:28:18 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Error: Cannot access /tmp/1.tar. Check the management node and/or service nodes.
Attempting to upload /tmp/1.tar, please wait...

------END::rflash_option_a_file_not_exist::Failed::Time:Thu Dec  7 05:28:18 2017 ::Duration::1 sec------
------START::rflash_option_a_with_multiple_values::Time:Thu Dec  7 05:28:18 2017------

RUN:rflash f6u17 -a /tmp/abc123.tz /tmp/abc124.tz [Thu Dec  7 05:28:18 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Invalid option specified when an directory is provided: -a
CHECK:output =~ Error: More than one foirmware specified is not supported	[Failed]

RUN:rflash f6u17 -a 1.tz 2.tz 3.tz [Thu Dec  7 05:28:18 2017]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: More than one firmware specified is not supported.

RUN:rflash f6u17 1.tz 2.tz 3.tz -a [Thu Dec  7 05:28:19 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: More than one firmware specified is not supported.

RUN:rflash f6u17 1.tz -a 2.tz [Thu Dec  7 05:28:19 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: More than one firmware specified is not supported.

RUN:rflash f6u17 1234567 -a 2345678 [Thu Dec  7 05:28:19 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: More than one firmware specified is not supported.

------END::rflash_option_a_with_multiple_values::Failed::Time:Thu Dec  7 05:28:19 2017 ::Duration::1 sec------
------START::rflash_option_a_with_non_existent_id::Time:Thu Dec  7 05:28:19 2017------

RUN:rflash f6u17 -a 1234567 [Thu Dec  7 05:28:19 2017]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Invalid ID provided to activate. Use the -l option to view valid firmware IDs.
Attempting to activate ID=1234567, please wait...
CHECK:output =~ Error: Invalid ID provided to activate	[Pass]
CHECK:output !~ Attempting to activate	[Failed]

------END::rflash_option_a_with_non_existent_id::Failed::Time:Thu Dec  7 05:28:20 2017 ::Duration::1 sec------
------START::rflash_option_delete_with_multiple_values::Time:Thu Dec  7 05:28:20 2017------

RUN:rflash f6u17 --delete 1234567 2345678 [Thu Dec  7 05:28:20 2017]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: More than one firmware specified is not supported.
CHECK:output =~ Error: More than one firmware specified is not supported	[Pass]
CHECK:output !~ Attempting to delete	[Pass]
CHECK:rc != 0	[Pass]

RUN:rflash f6u17 1234567 2345678 --delete [Thu Dec  7 05:28:21 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: More than one firmware specified is not supported.
CHECK:output =~ Error: More than one firmware specified is not supported	[Pass]
CHECK:output !~ Attempting to delete	[Pass]
CHECK:rc != 0	[Pass]

RUN:rflash f6u17 1234567 --delete 2345678 [Thu Dec  7 05:28:21 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: More than one firmware specified is not supported.
CHECK:output =~ Error: More than one firmware specified is not supported	[Pass]
CHECK:output !~ Attempting to delete	[Pass]
CHECK:rc != 0	[Pass]

------END::rflash_option_delete_with_multiple_values::Passed::Time:Thu Dec  7 05:28:21 2017 ::Duration::1 sec------
------START::rflash_option_delete_with_non_existent_id::Time:Thu Dec  7 05:28:21 2017------

RUN:rflash f6u17 --delete 1234567 [Thu Dec  7 05:28:21 2017]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Invalid ID provided to delete.  Use the -l option to view valid firmware IDs.
Attempting to delete ID=1234567, please wait...
CHECK:output =~ Error: Invalid ID provided to delete	[Pass]
CHECK:output !~ Attempting to delete	[Failed]

------END::rflash_option_delete_with_non_existent_id::Failed::Time:Thu Dec  7 05:28:22 2017 ::Duration::1 sec------
------START::rflash_option_d_with_multiple_values::Time:Thu Dec  7 05:28:22 2017------

RUN:rflash f6u17 -d /123/   /234/ [Thu Dec  7 05:28:22 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Can't open directory : /234/
CHECK:output =~ Error: More than one	[Failed]

RUN:rflash f6u17 /123/   /234/  -d [Thu Dec  7 05:28:22 2017]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Can't open directory : /234/

RUN:rflash f6u17 /123/ -d /234/ [Thu Dec  7 05:28:23 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Can't open directory : /234/

------END::rflash_option_d_with_multiple_values::Failed::Time:Thu Dec  7 05:28:23 2017 ::Duration::1 sec------
------START::rflash_option_d_with_non_existent_dir::Time:Thu Dec  7 05:28:23 2017------

RUN:rm -rf /tmp/bogus123 [Thu Dec  7 05:28:23 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:rflash f6u17 -d /tmp/bogus123 [Thu Dec  7 05:28:23 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u17: Error: Can't open directory : /tmp/bogus123
CHECK:output =~ Error: Can't open directory	[Pass]
CHECK:output !~ Attempting to	[Pass]
CHECK:rc != 0	[Pass]

RUN:mkdir -p /tmp/bogus123 [Thu Dec  7 05:28:23 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:rflash f6u17 /tmp/bogus123 -d [Thu Dec  7 05:28:23 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Error: No BMC tar file found in /tmp/bogus123
Error: No PNOR tar file found in /tmp/bogus123
CHECK:output =~ Error: No BMC tar file found	[Pass]
CHECK:output =~ Error: No PNOR tar file found	[Pass]
CHECK:output !~ Attempting to	[Pass]
CHECK:rc != 0	[Pass]

RUN:touch obmc-phosphor-image-witherspoon.ubi.mtd.tar /tmp/bogus123 [Thu Dec  7 05:28:23 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN: [Thu Dec  7 05:28:23 2017]
rflash f6u17 -d /tmp/bogus123
check::output =~Error: No BMC tar file found
ElapsedTime:1 sec
RETURN rc = 127
OUTPUT:
Error: No BMC tar file found in /tmp/bogus123
Error: No PNOR tar file found in /tmp/bogus123
/tmp/xCATautotest1512642503//script: line 2: check::output: command not found
CHECK:output =~ Error: No PNOR tar file found	[Pass]
CHECK:output !~ Attempting to	[Pass]
CHECK:rc != 0	[Pass]

RUN:touch witherspoon.pnor.squashfs.tar /tmp/bogus123 [Thu Dec  7 05:28:24 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:rflash f6u17 -d /tmp/bogus123 [Thu Dec  7 05:28:24 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Error: No BMC tar file found in /tmp/bogus123
Error: No PNOR tar file found in /tmp/bogus123
CHECK:output =~ Error: No BMC tar file found	[Pass]
CHECK:output =~ Error: No PNOR tar file found	[Pass]
CHECK:output !~ Attempting to	[Pass]
CHECK:rc != 0	[Pass]

RUN:rm -rf /tmp/bogus123 [Thu Dec  7 05:28:24 2017]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::rflash_option_d_with_non_existent_dir::Passed::Time:Thu Dec  7 05:28:24 2017 ::Duration::1 sec------
------Total: 31 , Failed: 8------

xCAT automated test finished at Thu Dec  7 05:28:24 2017
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20171207052759 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20171207052759 file for time consumption
```