### PR TITLE
enhance rflash upload message

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1102,7 +1102,6 @@ sub parse_args {
             if ($option_flag !~ /^-c$|^--check$|^-u$|^--upload$|^-a$|^--activate$/) {
                 return ([ 1, "Invalid option specified when a file is provided: $option_flag" ]);
             }
-            xCAT::SvrUtils::sendmsg("Attempting to upload $flash_arguments[0], please wait...", $callback);
         }
         else {
             if ($updateid_passed) {
@@ -3706,7 +3705,7 @@ sub rflash_upload {
     if ($h->{message} eq $::RESPONSE_OK) {
          foreach my $upload_cmd(@curl_upload_cmds){
              while((my $file,my $version)=each(%fw_tar_files)){
-                 my $uploading_msg = "Uploading $file ...";
+                 my $uploading_msg = "Attempting to upload $file, please wait ...";
                  # Login successfull, upload the file
                  if ($::VERBOSE) {
                      xCAT::SvrUtils::sendmsg("$uploading_msg", $callback, $node);

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1637,6 +1637,11 @@ sub parse_command_status {
                 }
             }
         }
+        if ($upload or $::UPLOAD_AND_ACTIVATE) {
+            xCAT::SvrUtils::sendmsg("Attempting to upload $::UPLOAD_FILE, please wait...", $callback);
+        } elsif ($::UPLOAD_ACTIVATE_STREAM) {
+            xCAT::SvrUtils::sendmsg("Attempting to upload $::UPLOAD_FILE and $::UPLOAD_PNOR, please wait...", $callback);
+        }
         if ($check_version) {
             # Display firmware version on BMC
             $next_status{LOGIN_RESPONSE} = "RINV_FIRM_REQUEST";
@@ -3705,7 +3710,7 @@ sub rflash_upload {
     if ($h->{message} eq $::RESPONSE_OK) {
          foreach my $upload_cmd(@curl_upload_cmds){
              while((my $file,my $version)=each(%fw_tar_files)){
-                 my $uploading_msg = "Attempting to upload $file, please wait ...";
+                 my $uploading_msg = "Uploading $file ...";
                  # Login successfull, upload the file
                  if ($::VERBOSE) {
                      xCAT::SvrUtils::sendmsg("$uploading_msg", $callback, $node);


### PR DESCRIPTION
fix #4465 

UT messages in:
rflash -u <tar>
rflash -a <tar>
rflash -d </path/to/dir>
rflash -c tar

1, If using valid tar ball and upload, message like:
```
[root@briggs01 xCAT_plugin]# rflash mid05tor12cn16 -u /mnt/xcat/iso/openbmc/910.1746.20171116b_1742Ed/witherspoon.pnor.squashfs.tar --verbose
mid05tor12cn16: Attempting to upload /mnt/xcat/iso/openbmc/910.1746.20171116b_1742Ed/witherspoon.pnor.squashfs.tar, please wait ...
```

2, If using invalid tar ball, error message like:
```
[root@briggs01 xCAT_plugin]# rflash mid05tor12cn16 -u /mnt/xcat/iso/openbmc/910.1746.20171116b_1742Ed/withenor.squashfs.tar
Error: Cannot access /mnt/xcat/iso/openbmc/910.1746.20171116b_1742Ed/withenor.squashfs.tar. Check the management node and/or service nodes.
```

3, No "Attempting to upload" messages in ``rflash -c``:
```
[root@briggs01 xCAT_plugin]# XCATBYPASS=1 rflash mid05tor12cn16 -c /mnt/xcat/iso/openbmc/910.1746.20171116b_1742Ed/witherspoon.pnor.squashfs.tar
DEBUG filename=1, updateid=0, options=-c, invalid= rflash_arguments=/mnt/xcat/iso/openbmc/910.1746.20171116b_1742Ed/witherspoon.pnor.squashfs.tar
TAR xyz.openbmc_project.Software.Version.VersionPurpose.Host Firmware Product Version: IBM-witherspoon-ibm-OP9_v1.19_1.83
mid05tor12cn16: BMC Firmware Product:   ibm-v2.0-0-r9-0-gecda565 (Active)*
mid05tor12cn16: HOST Firmware Product:   IBM-witherspoon-ibm-OP9_v1.19_1.83 (Active)*
mid05tor12cn16: HOST Firmware Product: -- additional info: buildroot-2017.08-8-g5e23247
mid05tor12cn16: HOST Firmware Product: -- additional info: capp-ucode-p9-dd2-v2
... ...
```
