### PR TITLE
Display hostname even if multiple IP addresses

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2751,7 +2751,8 @@ sub rspconfig_response {
                         # an adapter with a single IP address set.
                         $error = "Interfaces with multiple IP addresses are not supported";
                         $node_info{$node}{cur_status} = "";
-                        last;
+                        # Terminate loop on this error unless we are looking for hostname to display
+                        last unless ($grep_string =~ /(.*)hostname(.*)/);
                     }
                     $nicinfo{$nic}{address} = $content{Address};
                 }
@@ -2783,7 +2784,7 @@ sub rspconfig_response {
             $node_info{$node}{cur_status} = "";  
         }
         if ($error) {
-            xCAT::SvrUtils::sendmsg("$error", $callback, $node);
+            xCAT::SvrUtils::sendmsg([1,"$error"], $callback, $node);
         } else {
             my @address = ();
             my @ipsrc = ();


### PR DESCRIPTION
#4473 

Before the fix:
```
[root@briggs01 xCAT_plugin]# rspconfig mid05tor12cn02 hostname
mid05tor12cn02: BMC hostname:
[root@briggs01 xCAT_plugin]#
```

After the fix:
```
[root@briggs01 xCAT_plugin]# rspconfig mid05tor12cn02 hostname
mid05tor12cn02: BMC hostname: mid05tor12cn02-bmc
[root@briggs01 xCAT_plugin]#
```

Other UT:
```
[root@briggs01 xCAT_plugin]# rspconfig mid05tor12cn02 hostname ip
mid05tor12cn02: BMC hostname: mid05tor12cn02-bmc
mid05tor12cn02: Error: Interfaces with multiple IP addresses are not supported
[root@briggs01 xCAT_plugin]#

[root@briggs01 xCAT_plugin]# rspconfig mid05tor12cn15 hostname
mid05tor12cn15: BMC hostname: witherspoon
[root@briggs01 xCAT_plugin]#

[root@briggs01 xCAT_plugin]# rspconfig mid05tor12cn15,mid05tor12cn02 hostname
mid05tor12cn02: BMC hostname: mid05tor12cn02-bmc
mid05tor12cn15: BMC hostname: witherspoon
[root@briggs01 xCAT_plugin]#

[root@briggs01 xCAT_plugin]# rspconfig mid05tor12cn15,mid05tor12cn02 ip
mid05tor12cn15: BMC IP: 172.11.139.15
mid05tor12cn02: Error: Interfaces with multiple IP addresses are not supported
[root@briggs01 xCAT_plugin]#
```