### PR TITLE
updatenode -F not work in hierachy env as the user name is FQDN of MN

### DIFF
--- a/perl-xCAT/xCAT/DSHCLI.pm
+++ b/perl-xCAT/xCAT/DSHCLI.pm
@@ -835,7 +835,7 @@ sub fork_fanout_dcp
 
                 my @target_file = split '/', $$options{'source'};
                 $rcp_config{'dest-file'} =
-"$$options{'target'}/$target_file[$#target_file]._$$target_properties{'hostname'}";
+                "$$options{'target'}/$target_file[$#target_file]._$$target_properties{'hostname'}";
 
             }
 
@@ -850,6 +850,8 @@ sub fork_fanout_dcp
                   $$options{'destDir_srcFile'}{$user_target};
             }
 
+            $dsh_trace
+                && ($rcp_config{'trace'} = 1);
             #eval "require RemoteShell::$rsh_extension";
             eval "require xCAT::$rsh_extension";
             my $remoteshell = "xCAT::$rsh_extension";

--- a/perl-xCAT/xCAT/RSYNC.pm
+++ b/perl-xCAT/xCAT/RSYNC.pm
@@ -156,7 +156,11 @@ sub remote_copy_command
             $dest_user_host =
               "$$config{'dest-user'}@" . "$$config{'dest-host'}";
         }
-        print RSCYCCMDFILE "#!/bin/sh\n";
+        if ($$config{'trace'}) {
+            print RSCYCCMDFILE "#!/bin/sh -x\n";
+        } else {
+            print RSCYCCMDFILE "#!/bin/sh\n";
+        }
         if ($localhost == 1) {    # running to the MN from the MN
             print RSCYCCMDFILE
               "/bin/mkdir -p $dest_dir_list\n";

--- a/xCAT-server/lib/xcat/plugins/updatenode.pm
+++ b/xCAT-server/lib/xcat/plugins/updatenode.pm
@@ -686,7 +686,6 @@ sub preprocess_updatenode
     }
 
     # Get the MN names
-    my @MNip         = xCAT::NetworkUtils->determinehostname;
     my @MNnodeinfo   = xCAT::NetworkUtils->determinehostname;
     my $MNnodename   = pop @MNnodeinfo;                         # hostname
     my @MNnodeipaddr = @MNnodeinfo;                             # ipaddresses
@@ -1745,6 +1744,15 @@ sub updatenodesyncfiles
             } else {               # else this is updatenode -F
                 $env = ["DSH_RSYNC_FILE=$synclist"];
             }
+
+            # get the Environment Variables and set DSH_FROM_USERID if possible (From updatenode client)
+            foreach my $envar (@{ $request->{environment} })
+            {
+                if ($envar =~ /^DSH_FROM_USERID=/) {
+                    push $env, $envar;
+                    last;
+                }
+            }
             push @$args, "--nodestatus";
             if (defined($::fanout)) {    # fanout
                 push @$args, "-f";
@@ -1765,6 +1773,7 @@ sub updatenodesyncfiles
 
             if ($::VERBOSE)
             {
+                push @$args, "-T";
                 my $rsp = {};
                 $rsp->{data}->[0] =
 "  $localhostname: Internal call command: xdcp $nodestring " . join(' ', @$args);

--- a/xCAT-server/lib/xcat/plugins/xdsh.pm
+++ b/xCAT-server/lib/xcat/plugins/xdsh.pm
@@ -639,6 +639,7 @@ sub process_servicenodes_xdcp
         $addreq->{'_xcatdest'} = $::mnname;
         $addreq->{node}        = \@sn;
         $addreq->{noderange}   = \@sn;
+        $addreq->{forceroot}->[0]   = 1;
 
         # check input request for --nodestatus
         my $args = $req->{arg};    # argument
@@ -1214,6 +1215,9 @@ sub process_request
         if (($request->{username}) && defined($request->{username}->[0])) {
             $ENV{DSH_FROM_USERID} = $request->{username}->[0];
         }
+    }
+    if ($request->{forceroot}) {
+        $ENV{DSH_FROM_USERID} = 'root';
     }
     if ($command eq "xdsh")
     {


### PR DESCRIPTION
updatenode -F not work in hierachy env (#4455)
when run `updatenode -F`, we will get the user name in request and set it to `xdcp` via `DSH_FROM_USERID`.

UT:
1, updatenode -F from MN
```
# updatenode c910f03c09k05 -F -V
Running command on c910f03c09k03.pok.stglabs.ibm.com: ip -4 --oneline addr show |awk -F ' ' '{print $4}'|awk -F '/' '{print $1}' 2>&1

Running command on c910f03c09k03.pok.stglabs.ibm.com: chmod -R a+r /install/postscripts 2>&1

  c910f03c09k03.pok.stglabs.ibm.com: Internal call command: xdcp c910f03c09k05 --nodestatus -F /tmp/sync.list
Running internal xCAT command: xdcp ...

Running command on c910f03c09k03.pok.stglabs.ibm.com: ip -4 --oneline addr show |awk -F ' ' '{print $4}'|awk -F '/' '{print $1}' 2>&1

Running command on c910f03c09k03.pok.stglabs.ibm.com: rm /tmp/xdcpsynclist.30297 2>&1
File synchronization has completed for nodes.
```
2, updatenode -F from SN
```
# updatenode c910f03c09k05 -F -V
Running command on c910f03c09k04.pok.stglabs.ibm.com: ip -4 --oneline addr show |awk -F ' ' '{print $4}'|awk -F '/' '{print $1}' 2>&1

Running command on c910f03c09k04.pok.stglabs.ibm.com: chmod -R a+r /install/postscripts 2>&1

  c910f03c09k04.pok.stglabs.ibm.com: Internal call command: xdcp c910f03c09k05 --nodestatus -F /tmp/sync.list
Running internal xCAT command: xdcp ...

Running command on c910f03c09k04.pok.stglabs.ibm.com: ip -4 --oneline addr show |awk -F ' ' '{print $4}'|awk -F '/' '{print $1}' 2>&1

File synchronization has completed for nodes.
```
3, updatenode -F from MN for the node not behind SN
```
# chdef c910f03c09k05 servicenode=
1 object definitions have been created or modified.

# updatenode c910f03c09k05 -F -V
Running command on c910f03c09k03.pok.stglabs.ibm.com: ip -4 --oneline addr show |awk -F ' ' '{print $4}'|awk -F '/' '{print $1}' 2>&1

Running command on c910f03c09k03.pok.stglabs.ibm.com: chmod -R a+r /install/postscripts 2>&1

  c910f03c09k03.pok.stglabs.ibm.com: Internal call command: xdcp c910f03c09k05 --nodestatus -F /tmp/sync.list
Running internal xCAT command: xdcp ...

Running command on c910f03c09k03.pok.stglabs.ibm.com: ip -4 --oneline addr show |awk -F ' ' '{print $4}'|awk -F '/' '{print $1}' 2>&1

File synchronization has completed for nodes.
```

