### PR TITLE
let rflash error message flexible

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1094,10 +1094,12 @@ sub parse_args {
         }
         
         if (scalar @flash_arguments > 1) {
-            if ($filename_passed) {
+            if ($filename_passed and $option_flag !~ /^-d$/) {
                 return ([1, "More than one firmware specified is not supported."]);
+            } elsif ($option_flag =~ /^-d$/) {
+                return ([1, "More than one directory specified is not supported."]);
             } else {
-                return ([ 1, "Invalid firmware tar file format specified with $option_flag" ]);
+                return ([ 1, "Invalid firmware specified with $option_flag" ]);
             }
         }
 
@@ -1114,7 +1116,7 @@ sub parse_args {
                     return ([ 1, "Invalid option specified when an update id is provided: $option_flag" ]);
                 }
                 my $action = "activate";
-                if ($option_flag =~ /^-d$|^--delete$/) {
+                if ($option_flag =~ /^--delete$/) {
                     $action = "delete";
                 }
                 xCAT::SvrUtils::sendmsg("Attempting to $action ID=$flash_arguments[0], please wait...", $callback);
@@ -1131,7 +1133,7 @@ sub parse_args {
                     }
                     closedir(DIR);
                 } elsif ($option_flag =~ /^-c$|^--check$|^-u$|^--upload$|^-a$|^--activate$/) {
-                    return ([ 1, "Invalid firmware tar file format specified with $option_flag" ]);
+                    return ([ 1, "Invalid firmware specified with $option_flag" ]);
                 }
             } else {
                 # Neither Filename nor updateid was not passed, check flags allowed without file or updateid


### PR DESCRIPTION
enhance #4466 
For ``rflash`` options:
If there are empty file names or wrong update_id in test case to test the invalid input parameter, the error messages cannot identify if the name is wrong update_id or wrong_tar_file_name or wrong number of files.

So let ``rflash`` error message flexible:
```
[root@bybc0602 xCAT_plugin]# rflash simulation_test -d abc dbc
Mon Dec 11 23:40:39 2017 OpenBMC: [openbmc_debug]
simulation_test: Error: More than one directory specified is not supported.

[root@bybc0602 xCAT_plugin]# rflash simulation_test -d abc
Mon Dec 11 23:40:46 2017 OpenBMC: [openbmc_debug]
simulation_test: Error: Invalid option specified when an update id is provided: -d

[root@bybc0602 xCAT_plugin]# rflash simulation_test -d /abc
Mon Dec 11 23:41:06 2017 OpenBMC: [openbmc_debug]
simulation_test: Error: Can't open directory : /abc

[root@bybc0602 xCAT_plugin]# rflash simulation_test -d abc.tar
Mon Dec 11 23:41:21 2017 OpenBMC: [openbmc_debug]
simulation_test: Error: Invalid option specified when a file is provided: -d

[root@bybc0602 xCAT_plugin]# rflash simulation_test -d /abc /bcd
Mon Dec 11 23:41:37 2017 OpenBMC: [openbmc_debug]
simulation_test: Error: More than one directory specified is not supported

[root@bybc0602 xCAT_plugin]# rflash simulation_test -d abc.tgz bc.gz
Mon Dec 11 23:41:54 2017 OpenBMC: [openbmc_debug]
simulation_test: Error: More than one directory specified is not supported.

[root@bybc0602 xCAT_plugin]# rflash simulation_test -a abc.tar
Mon Dec 11 23:42:36 2017 OpenBMC: [openbmc_debug]
Attempting to upload abc.tar, please wait...
Error: Cannot access /opt/xcat/lib/perl/xCAT_plugin/abc.tar. Check the management node and/or service nodes.

[root@bybc0602 xCAT_plugin]# rflash simulation_test -a abc.tar bc.gz
Mon Dec 11 23:42:43 2017 OpenBMC: [openbmc_debug]
simulation_test: Error: More than one firmware specified is not supported.

[root@bybc0602 xCAT_plugin]# rflash simulation_test -a abc bcd
Mon Dec 11 23:42:52 2017 OpenBMC: [openbmc_debug]
simulation_test: Error: Invalid firmware specified with -a

[root@bybc0602 xCAT_plugin]# rflash simulation_test -a /abc /bcf
Mon Dec 11 23:43:18 2017 OpenBMC: [openbmc_debug]
simulation_test: Error: Invalid firmware specified with -a

[root@bybc0602 xCAT_plugin]# rflash simulation_test -c abc
Mon Dec 11 23:43:33 2017 OpenBMC: [openbmc_debug]
simulation_test: Error: Invalid option specified when an update id is provided: -c

[root@bybc0602 xCAT_plugin]# rflash simulation_test -c abc bcd
Mon Dec 11 23:44:02 2017 OpenBMC: [openbmc_debug]
simulation_test: Error: Invalid firmware specified with -c

[root@bybc0602 xCAT_plugin]# rflash simulation_test -u /abc
Mon Dec 11 23:44:23 2017 OpenBMC: [openbmc_debug]
simulation_test: Error: Invalid firmware specified with -u

[root@bybc0602 xCAT_plugin]# rflash simulation_test -u abc
Mon Dec 11 23:44:29 2017 OpenBMC: [openbmc_debug]
simulation_test: Error: Invalid option specified when an update id is provided: -u

[root@bybc0602 xCAT_plugin]# rflash simulation_test -u abc.tar
Mon Dec 11 23:44:37 2017 OpenBMC: [openbmc_debug]
Attempting to upload abc.tar, please wait...
Error: Cannot access /opt/xcat/lib/perl/xCAT_plugin/abc.tar. Check the management node and/or service nodes.

[root@bybc0602 xCAT_plugin]# rflash simulation_test -u abc.tar bc.tar
Mon Dec 11 23:44:46 2017 OpenBMC: [openbmc_debug]
simulation_test: Error: More than one firmware specified is not supported.
```