### PR TITLE
Task 4472, Allow rspconfig to set NTP servers for OpenBMC

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2789,8 +2789,8 @@ sub rspconfig_response {
                 if (defined($content{Address}) and $content{Address}) {
                     if ($content{Address} eq $node_info{$node}{bmcip} and $node_info{$node}{cur_status} eq "RSPCONFIG_GET_NIC_RESPONSE") {
                         $status_info{RSPCONFIG_SET_NTPSERVERS_REQUEST}{init_url} =~ s/#NIC#/$nic/g;
-                        if ($next_status{ $node_info{$node}{cur_status} }) {
-                            $node_info{$node}{cur_status} = $next_status{ $node_info{$node}{cur_status} };
+                        if ($next_status{"RSPCONFIG_GET_NIC_RESPONSE"}) {
+                            $node_info{$node}{cur_status} = $next_status{"RSPCONFIG_GET_NIC_RESPONSE"};
                             gen_send_request($node);
                             return;
                         }
@@ -2901,9 +2901,9 @@ sub rspconfig_response {
                 my ($check_ip,$check_netmask,$check_gateway) = @checks;
                 my $the_nic_to_config = undef;
                 foreach my $nic (@nics) {
-                    my $address = $nicinfo{$nic}{address};
-                    my $prefix = $nicinfo{$nic}{prefix};
-                    my $gateway = $nicinfo{$nic}{gateway};
+                    my $address = ${ $nicinfo{$nic}{address} }[0];
+                    my $prefix = ${ $nicinfo{$nic}{prefix} }[0];
+                    my $gateway = ${ $nicinfo{$nic}{gateway} }[0];
                     if ($check_ip eq $address and $check_netmask eq $prefix and $check_gateway eq $gateway) {
                         if (($check_vlan and $check_vlan eq $nicinfo{$nic}{vlan}) or !$check_vlan) {
                             $next_status{ $node_info{$node}{cur_status} } = "RSPCONFIG_PRINT_BMCINFO";

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2841,7 +2841,7 @@ sub rspconfig_response {
                 if ($nicinfo{$nic}{ntpservers}) {
                     push @ntpservers, "BMC NTP Servers$addon_info: $nicinfo{$nic}{ntpservers}";
                 } else {
-                    push @ntpservers, "BMC NTP Servers$addon_info Not Set";
+                    push @ntpservers, "BMC NTP Servers$addon_info: None";
                 }
 
                 next if ($multiple_error);
@@ -2859,7 +2859,7 @@ sub rspconfig_response {
                     push @netmask, "BMC Netmask$addon_info: " . join('.', unpack("C4", pack("N", $decimal_mask)));
                 }
                 push @gateway, "BMC Gateway$addon_info: ${ $nicinfo{$nic}{gateway} }[0 ] (default: $default_gateway)";
-                ${ $nicinfo{$nic}{vlan} }[0] = "Disabled" unless (@{ $nicinfo{$nic}{vlan} });
+                push @{ $nicinfo{$nic}{vlan} }, "Disabled" unless ($nicinfo{$nic}{vlan});
                 push @vlan, "BMC VLAN ID$addon_info: ${ $nicinfo{$nic}{vlan} }[0]";
             }
             my $mul_out = 0;

--- a/xCAT-test/autotest/testcase/rspconfig/cases0
+++ b/xCAT-test/autotest/testcase/rspconfig/cases0
@@ -41,6 +41,21 @@ check:rc==0
 check:output=~__GETNODEATTR($$CN,hcp)__: \w+
 end
 
+start:rspconfig_list_ntpservers
+description: rspconfig list ntpservers info
+Attribute: $$CN-The operation object of rspconfig command
+cmd:rspconfig $$CN ntpservers
+check:rc==0
+check:output=~$$CN: BMC NTP Servers:|BMC NTP Servers Not Set
+end
+
+start:rspconfig_set_ntpservers
+description: rspconfig set ntpservers
+Attribute: $$CN-The operation object of rspconfig command
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig_ntp.sh $$CN $$MN
+check:rc==0
+end
+
 start:rspconfig_set_ip
 description:rspconfig  change openbmc ip 
 Attribute: $$CN-The operation object of rspconfig command

--- a/xCAT-test/autotest/testcase/rspconfig/cases0
+++ b/xCAT-test/autotest/testcase/rspconfig/cases0
@@ -46,7 +46,7 @@ description: rspconfig list ntpservers info
 Attribute: $$CN-The operation object of rspconfig command
 cmd:rspconfig $$CN ntpservers
 check:rc==0
-check:output=~$$CN: BMC NTP Servers:|BMC NTP Servers Not Set
+check:output=~$$CN: BMC NTP Servers
 end
 
 start:rspconfig_set_ntpservers

--- a/xCAT-test/autotest/testcase/rspconfig/rspconfig_ntp.sh
+++ b/xCAT-test/autotest/testcase/rspconfig/rspconfig_ntp.sh
@@ -11,7 +11,7 @@ fi
 
 echo "The original BMC NTP Servers is $ntpservers"
 
-if [ $ntpservers ]; then
+if [ $ntpservers != "None" ]; then
    new_ntpservers=$ntpservers"_test"  
 else 
    new_ntpservers=$mn
@@ -23,7 +23,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-if [[ $output =~ "$cn: BMC NTP Servers: $new_ntpservers" ]]; then
+if [[ $output =~ "$cn: BMC NTP Servers" ]]  && [[ $output =~ "$new_ntpservers" ]]; then
     echo "Setting NTPServers as $new_ntpservers success"
 else 
     echo "Setting NTPServers as $new_ntpservers failed, the output is $output"
@@ -32,13 +32,19 @@ fi
 
 echo "To clear environment"
 
-output=`rspconfig $cn ntpservers=$ntpservers`
+if [ $ntpservers != "None" ]; then
+    original_ntpservers="$ntpservers"
+else
+    original_ntpservers=""
+fi
+
+output=`rspconfig $cn ntpservers=$original_ntpservers`
 if [ $? -ne 0 ]; then
     echo "rspconfig $cn ntpservers=$ntpservers failed when clearing environment"  
     exit 1
 fi
 
-if [[ $output =~ "$cn: BMC NTP Servers: $ntpservers" ]] || [[ $output =~ "$cn: BMC NTP Servers Not Set" ]]; then
+if [[ "$output" =~ "$cn: BMC NTP Servers" ]] && [[ $output =~ "$ntpservers" ]]; then
     echo "Setting NTPServers as $ntpservers success when clearing environment"
     exit 0
 fi

--- a/xCAT-test/autotest/testcase/rspconfig/rspconfig_ntp.sh
+++ b/xCAT-test/autotest/testcase/rspconfig/rspconfig_ntp.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+cn=$1
+mn=$2
+
+ntpservers=`rspconfig $cn ntpservers | awk -F":" '{print $3}' | sed 's/^ //;s/ $//'`
+if [ $? -ne 0 ]; then
+    echo "rspconfig $cn ntpservers failed"
+    exit 1
+fi
+
+echo "The original BMC NTP Servers is $ntpservers"
+
+if [ $ntpservers ]; then
+   new_ntpservers=$ntpservers"_test"  
+else 
+   new_ntpservers=$mn
+fi
+
+output=`rspconfig $cn ntpservers=$new_ntpservers`
+if [ $? -ne 0 ]; then
+    echo "rspconfig $cn ntpservers=$new_ntpservers failed"
+    exit 1
+fi
+
+if [[ $output =~ "$cn: BMC NTP Servers: $new_ntpservers" ]]; then
+    echo "Setting NTPServers as $new_ntpservers success"
+else 
+    echo "Setting NTPServers as $new_ntpservers failed, the output is $output"
+    exit 1
+fi
+
+echo "To clear environment"
+
+output=`rspconfig $cn ntpservers=$ntpservers`
+if [ $? -ne 0 ]; then
+    echo "rspconfig $cn ntpservers=$ntpservers failed when clearing environment"  
+    exit 1
+fi
+
+if [[ $output =~ "$cn: BMC NTP Servers: $ntpservers" ]] || [[ $output =~ "$cn: BMC NTP Servers Not Set" ]]; then
+    echo "Setting NTPServers as $ntpservers success when clearing environment"
+    exit 0
+fi
+
+echo "Setting NTPServers as $ntpservers failed when clearing environment"
+exit 1


### PR DESCRIPTION
#4472 

Result of xcattest
```
------START::rspconfig_list_ntpservers::Time:Thu Dec 14 00:20:08 2017------

RUN:rspconfig f6u17 ntpservers [Thu Dec 14 00:20:08 2017]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u17: BMC NTP Servers: None
CHECK:rc == 0	[Pass]
CHECK:output =~ f6u17: BMC NTP Servers	[Pass]

------END::rspconfig_list_ntpservers::Passed::Time:Thu Dec 14 00:20:09 2017 ::Duration::1 sec------
------Total: 1 , Failed: 0------

------START::rspconfig_set_ntpservers::Time:Thu Dec 14 00:48:50 2017------

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig_ntp.sh f6u17 c910f03c11k08 [Thu Dec 14 00:48:50 2017]
ElapsedTime:6 sec
RETURN rc = 0
OUTPUT:
The original BMC NTP Servers is None
Setting NTPServers as c910f03c11k08 success
To clear environment
Setting NTPServers as None success when clearing environment
CHECK:rc == 0	[Pass]

------END::rspconfig_set_ntpservers::Passed::Time:Thu Dec 14 00:48:56 2017 ::Duration::6 sec------
------Total: 1 , Failed: 0------
```

UT:
```
# rspconfig mid05tor12cn13,mid05tor12cn02 ntpservers=briggs01
mid05tor12cn13: BMC Setting NTPServers...
mid05tor12cn13: BMC NTP Servers: briggs01
mid05tor12cn02: BMC Setting NTPServers...
mid05tor12cn02: BMC NTP Servers: briggs01
# rspconfig mid05tor12cn13,mid05tor12cn02 ntpservers
mid05tor12cn13: BMC NTP Servers: briggs01
mid05tor12cn02: BMC NTP Servers: briggs01

# rspconfig mid05tor12cn13,mid05tor12cn05 ntpservers=
mid05tor12cn13: BMC Setting NTPServers...
mid05tor12cn05: BMC Setting NTPServers...
mid05tor12cn13: BMC NTP Servers: None
mid05tor12cn05: BMC NTP Servers: None
# rspconfig mid05tor12cn13,mid05tor12cn05 ntpservers
mid05tor12cn13: BMC NTP Servers: None
mid05tor12cn05: BMC NTP Servers: None
```

Run (get) with other options:
```
# rspconfig mid05tor12cn13 ntpservers ip
mid05tor12cn13: BMC NTP Servers: briggs01
mid05tor12cn13: BMC IP: 172.11.139.13
# rspconfig mid05tor12cn02 ntpservers ip
mid05tor12cn02: BMC NTP Servers: briggs01
mid05tor12cn02: Error: Interfaces with multiple IP addresses are not supported
# rspconfig mid05tor12cn13 ntpservers ip netmask gateway hostname
mid05tor12cn13: BMC NTP Servers: None
mid05tor12cn13: BMC IP: 172.11.139.13
mid05tor12cn13: BMC Netmask: 255.255.0.0
mid05tor12cn13: BMC Gateway: 0.0.0.0 (default: 172.11.253.27)
mid05tor12cn13: BMC Hostname: mid05tor12cn13-bmc-test
[root@briggs01 ~]# rspconfig mid05tor12cn02 ntpservers ip netmask gateway hostname
mid05tor12cn02: BMC NTP Servers: briggs01
mid05tor12cn02: BMC Hostname: mid05tor12cn02-bmc-test
mid05tor12cn02: Error: Interfaces with multiple IP addresses are not supported
```