### PR TITLE
Fix issue 4477, if has node-<mac> will not create node-<mtms> for the same node

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -50,6 +50,8 @@ my $openbmc_pass;
 $::P9_WITHERSPOON_MFG_ID     = "42817";
 $::P9_WITHERSPOON_PRODUCT_ID = "16975";
 
+my %node_in_list = ();
+
 #-------------------------------------------------------
 
 =head3  handled_commands
@@ -621,6 +623,17 @@ sub scan_process {
             $ipmac{$_} = $new_mac;
         }
 
+        my $nodelisttab;
+        if ($nodelisttab = xCAT::Table->new("nodelist")) {
+            my @nodes_in_list = $nodelisttab->getAllAttribs("node");
+            foreach my $node (@nodes_in_list) {
+                $node_in_list{$node->{node}} = 1;
+            }
+        } else {
+            xCAT::MsgUtils->message("E", " Could not read the nodelist table\n");
+            return 1;
+        }
+
         ###############################
         # Set the signal handler for ^c
         ###############################
@@ -679,17 +692,14 @@ sub scan_process {
                 my @mc_cmds = ("/opt/xcat/bin/ipmitool-xcat -I lanplus -H ${$live_ip}[$i] -P $openbmc_pass mc info -N 1 -R 1",
                               "/opt/xcat/bin/ipmitool-xcat -I lanplus -H ${$live_ip}[$i] $bmcusername $bmcpassword mc info -N 1 -R 1");
                 my $mc_info;
-                my $flag;
                 foreach my $mc_cmd (@mc_cmds) {
                     $mc_info = xCAT::Utils->runcmd($mc_cmd, -1);
                     if ($mc_info =~ /Manufacturer ID\s*:\s*(\d+)\s*Manufacturer Name.+\s*Product ID\s*:\s*(\d+)/) {
                         if ($1 eq $::P9_WITHERSPOON_MFG_ID and $2 eq $::P9_WITHERSPOON_PRODUCT_ID) {
                             bmcdiscovery_openbmc(${$live_ip}[$i], $opz, $opw, $request_command);
-                            $flag = 1;
                             last; 
                         } else {
                             bmcdiscovery_ipmi(${$live_ip}[$i], $opz, $opw, $request_command);
-                            $flag = 1;
                             last;
                         }
                     }
@@ -1011,7 +1021,6 @@ sub bmcdiscovery_ipmi {
     my $opz             = shift;
     my $opw             = shift;
     my $request_command = shift;
-    my $node            = sprintf("node-%08x", unpack("N*", inet_aton($ip)));
     my $bmcstr          = "BMC Session ID";
     my $bmcusername     = '';
     my $bmcpassword     = '';
@@ -1021,6 +1030,9 @@ sub bmcdiscovery_ipmi {
     if ($bmc_pass) {
         $bmcpassword = "-P $bmc_pass";
     }
+
+    my $mtms_node = "";
+    my $mac_node = "";
 
     my $node_data = $ip;
     my $icmd = "/opt/xcat/bin/ipmitool-xcat -vv -I lanplus $bmcusername $bmcpassword -H $ip chassis status ";
@@ -1088,11 +1100,12 @@ sub bmcdiscovery_ipmi {
             }
             $node_data .= ",mp,bmc,$::opt_SN,$::opt_SN";
             if ($mtm and $serial) {
-                $node = "node-$mtm-$serial";
-                $node =~ s/(.*)/\L$1/g;
-                $node =~ s/[\s:\._]/-/g;
-            } else {
-                $node = "node-$ipmac{$ip}";
+                $mtms_node = "node-$mtm-$serial";
+                $mtms_node =~ s/(.*)/\L$1/g;
+                $mtms_node =~ s/[\s:\._]/-/g;
+            } 
+            if ($ipmac{$ip}) {
+                $mac_node = "node-$ipmac{$ip}";
             }
         } elsif ($output =~ /error : unauthorized name/) {
             xCAT::MsgUtils->message("W", { data => ["BMC username is incorrect for $ip"] }, $::CALLBACK);
@@ -1102,7 +1115,7 @@ sub bmcdiscovery_ipmi {
             return;
         }
 
-        display_output($opz,$opw,$node,$node_data,"ipmi",$request_command);
+        display_output($opz,$opw,$mtms_node,$mac_node,$node_data,"ipmi",$request_command);
     }
 }
 
@@ -1123,7 +1136,8 @@ sub bmcdiscovery_openbmc{
     my $opz             = shift;
     my $opw             = shift;
     my $request_command = shift;
-    my $node            = sprintf("node-%08x", unpack("N*", inet_aton($ip)));
+    my $mtms_node       = "";
+    my $mac_node        = "";
 
     print "$ip: Detected openbmc, attempting to obtain system information...\n";
     my $http_protocol="https";
@@ -1199,11 +1213,12 @@ sub bmcdiscovery_openbmc{
         }
         $node_data .= ",mp,bmc,$::opt_SN,$::opt_SN";
         if ($mtm and $serial) {
-            $node = "node-$mtm-$serial";
-            $node =~ s/(.*)/\L$1/g;
-            $node =~ s/[\s:\._]/-/g;
-        } else {
-            $node = "node-$ipmac{$ip}";
+            $mtms_node = "node-$mtm-$serial";
+            $mtms_node =~ s/(.*)/\L$1/g;
+            $mtms_node =~ s/[\s:\._]/-/g;
+        }
+        if ($ipmac{$ip}) {
+            $mac_node = "node-$ipmac{$ip}";
         }
     } else {
         if ($login_response->status_line =~ /401 Unauthorized/) {
@@ -1213,7 +1228,7 @@ sub bmcdiscovery_openbmc{
         }
         return;
     }
-    display_output($opz,$opw,$node,$node_data,"openbmc",$request_command);
+    display_output($opz,$opw,$mtms_node,$mac_node,$node_data,"openbmc",$request_command);
 }
 
 
@@ -1229,10 +1244,18 @@ sub bmcdiscovery_openbmc{
 sub display_output {
     my $opz             = shift;
     my $opw             = shift;
-    my $node            = shift;
+    my $mtms_node       = shift;
+    my $mac_node        = shift;
     my $node_data       = shift;
     my $mgttype         = shift;
     my $request_command = shift;
+
+    my $node;
+    if (($node_in_list{$mac_node} and !$node_in_list{$mtms_node}) or (!$node_in_list{$mac_node} and !$mtms_node)) {
+        $node = $mac_node;
+    } else {
+        $node = $mtms_node;
+    }
 
     if (defined($opw)) {
         my $rsp = {};


### PR DESCRIPTION
#4477 

If has node named "node-<mac>", update node-<mac> data but not create new node definition.

```
# bmcdiscover --range 172.11.139.2 -w
172.11.139.2: Detected openbmc, attempting to obtain system information...
Writing node-70e284142897 (172.11.139.2,8335-GTC,1318D3A,,,mp,bmc,,) to database...
```