### PR TITLE
Crude attempt at including external configuration files in named.conf

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ddns.pm
+++ b/xCAT-server/lib/xcat/plugins/ddns.pm
@@ -1280,6 +1280,19 @@ sub update_namedconf {
         push @newnamed, "};\n\n";
     }
 
+    # include external configuration file(s) if present in site.namedincludes
+    my @entries = xCAT::TableUtils->get_site_attribute("namedincludes");
+    my $site_entry = $entries[0];
+    if (defined($site_entry)) {
+        my @includes = split /[ ,]/, $site_entry;
+        foreach (@includes) {
+            if (defined($_)) {
+                push @newnamed, "include \"$_\";\n";
+            }
+        }
+        push @newnamed, "\n";
+    }
+
     unless ($slave) {
         unless ($gotkey) {
             unless ($ctx->{privkey}) {    #need to generate one


### PR DESCRIPTION
This is a first try at including external configuration files in the `/etc/named.conf` file that xCAT generates, as described in #2423 .

It takes the `namedincludes` attributes from the `site` table, split it on `,`, and adds an 
```
include "path/to/file";
```
line in `/etc/named.conf` for each entry. 
No include line is added if the attribute doesn't exist in the `site` table.


For instance, with:
```
# tabdump site | grep namedincludes
"namedincludes","/etc/named/local.conf,/etc/named/more.conf",,
```
`makedns` generates the following `named.conf` file:
```
options {
[...]
};

include "/etc/named/local.conf";
include "/etc/named/more.conf";

zone "[...]
```

No check is done to verify that the files in `site.namedincludes` actually exists, and it assumes the same includes on all the DNS servers (master, forwarding server, slaves).

There's clearly much improvement to do:
- [ ] checking include files existence
- [ ] allowing different includes on master and slaves
- [ ] generalizing the mechanism to allow inclusion of additional files in other generated files, such as `/etc/hosts` or `/etc/dhcpd.conf`
- [ ] documentation

But that's a first step. And it works for me. :)