### PR TITLE
Fix issue 4490, record any error when rflash active process

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2049,8 +2049,8 @@ sub deal_with_response {
         }
         if (!($node_info{$node}{cur_status} eq "RSPCONFIG_DUMP_CLEAR_RESPONSE" and $next_status{ $node_info{$node}{cur_status} })) {
             xCAT::SvrUtils::sendmsg([1, $error], $callback, $node);
-            if ($node_info{$node}{cur_status} eq "RFLASH_UPDATE_CHECK_STATE_RESPONSE") {
-                $node_info{$node}{rst} = $error if ($::VERBOSE);
+            if ($::UPLOAD_AND_ACTIVATE or $next_status{LOGIN_RESPONSE} eq "RFLASH_UPDATE_ACTIVATE_REQUEST") {
+                $node_info{$node}{rst} = $error;
                 my $rflash_log_file = xCAT::Utils->full_path($node.".log", $::XCAT_LOG_RFLASH_DIR);
                 open (RFLASH_LOG_FILE_HANDLE, ">> $rflash_log_file");
                 print RFLASH_LOG_FILE_HANDLE "$error\n";


### PR DESCRIPTION
#4490 

Before modify:
```
# rflash mid05tor12cn02 -a 1234567
Attempting to activate ID=1234567, please wait...
mid05tor12cn02: Error: Invalid ID provided to activate. Use the -l option to view valid firmware IDs.
-------------------------------------------------------
Firmware update complete: Total=1 Success=0 Failed=1
mid05tor12cn02: BMC is not ready
-------------------------------------------------------
```

After modify:
```
# rflash mid05tor12cn02 -a 1234567
Attempting to activate ID=1234567, please wait...
mid05tor12cn02: Error: Invalid ID provided to activate. Use the -l option to view valid firmware IDs.
-------------------------------------------------------
Firmware update complete: Total=1 Success=0 Failed=1
mid05tor12cn02: Invalid ID provided to activate. Use the -l option to view valid firmware IDs.
-------------------------------------------------------
```

Other error:
```
# rflash mid05tor12cn02 -a 1234567
Attempting to activate ID=1234567, please wait...
mid05tor12cn02: Error: [401] Invalid username or password
-------------------------------------------------------
Firmware update complete: Total=1 Success=0 Failed=1
mid05tor12cn02: [401] Invalid username or password
-------------------------------------------------------
```