### PR TITLE
Use CONGO_CLIENT_TYPE to tell goconserver the client type

### DIFF
--- a/xCAT-client/bin/rcons
+++ b/xCAT-client/bin/rcons
@@ -148,7 +148,8 @@ elif [ $USE_GOCONSERVER == "1" ]; then
     CONGO_ENV="CONGO_SSL_KEY=$HOME/.xcat/client-cred.pem \
                CONGO_SSL_CERT=$HOME/.xcat/client-cred.pem \
                CONGO_SSL_CA_CERT=$HOME/.xcat/ca.pem \
-               CONGO_PORT=12430"
+               CONGO_PORT=12430 \
+               CONGO_CLIENT_TYPE=xcat"
     if [ "$CONSERVER" == `hostname` ]; then
         host=`hostname -s`
         if [ $? -ne 0 ]; then


### PR DESCRIPTION
goconserver could send back message based on the client type
this commit set CONGO_CLIENT_TYPE to xcat to make the message
from goconserver more friendly.
```
[root@briggs01 chenglch]# makegocons -d sn02
sn02: Deleted
[root@briggs01 chenglch]# rcons sn02
Could not find node sn02, did you run 'makegocons sn02'?
[root@briggs01 chenglch]# makegocons sn02
sn02: Created
[root@briggs01 chenglch]# rcons sn02
[Enter `^Ec?' for help]
goconserver(2017-12-13 01:35:34): Hello 172.10.253.27:60474, welcome to the session of sn02

Red Hat Enterprise Linux Server 7.4 Beta (Pegas)
Kernel 4.11.0-30.el7a.ppc64le on an ppc64le

sn02 login: [root@briggs01 chenglch]#
```
close-issue: https://github.com/chenglch/goconserver/issues/13