### PR TITLE
Adjust the server used for kernel/initrd and imgurl for petitboot

### DIFF
--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -549,10 +549,11 @@ sub mknetboot
             $xcatmaster = '!myipfn!'; #allow service nodes to dynamically nominate themselves as a good contact point, this is of limited use in the event that xcat is not the dhcp/tftp server
         }
 
-        if ($ient and $ient->{tftpserver} and $ient->{tftpserver} ne '<xcatmaster>') {
+        if ($ient and $ient->{nfsserver} and $ient->{nfsserver} ne '<xcatmaster>') {
+            $imgsrv = $ient->{nfsserver};
+        }elsif ($ient and $ient->{tftpserver} and $ient->{tftpserver} ne '<xcatmaster>') {
             $imgsrv = $ient->{tftpserver};
         } else {
-            $ient = $reshash->{$node}->[0];
             $imgsrv = $xcatmaster;
         }
 
@@ -591,11 +592,8 @@ sub mknetboot
 
                 # get entry for nfs root if it exists:
                 # have to get nfssvr and nfsdir from noderes table
-                my $nfssrv = $imgsrv;
+                my $nfssrv = $imgsrvip;
                 my $nfsdir = $rootimgdir;
-                if ($ient->{nfsserver}) {
-                    $nfssrv = $ient->{nfsserver};
-                }
                 if ($ient->{nfsdir} ne '') {
                     $nfsdir = $ient->{nfsdir} . "/netboot/$osver/$arch/$profile";
 

--- a/xCAT-server/lib/xcat/plugins/debian.pm
+++ b/xCAT-server/lib/xcat/plugins/debian.pm
@@ -1267,44 +1267,24 @@ sub mknetboot
         my $xcatmaster;
 
         $ient = $reshash->{$node}->[0]; #$restab->getNodeAttribs($node, ['tftpserver']);
-
-        if ($ient and $ient->{xcatmaster})
-        {
+        if ($ient and $ient->{xcatmaster}) {
             $xcatmaster = $ient->{xcatmaster};
         } else {
             $xcatmaster = '!myipfn!'; #allow service nodes to dynamically nominate themselves as a good contact point, this is of limited use in the event that xcat is not the dhcp/tftp server
         }
 
-        if ($ient and $ient->{tftpserver})
-        {
+        if ($ient and $ient->{nfsserver} and $ient->{nfsserver} ne '<xcatmaster>') {
+            $imgsrv = $ient->{nfsserver};
+        }elsif ($ient and $ient->{tftpserver} and $ient->{tftpserver} ne '<xcatmaster>') {
             $imgsrv = $ient->{tftpserver};
-        }
-        else
-        {
-            $ient = $reshash->{$node}->[0]; #$restab->getNodeAttribs($node, ['xcatmaster']);
-                                            #if ($ient and $ient->{xcatmaster})
-                                            #{
-                                            #    $imgsrv = $ient->{xcatmaster};
-                                            #}
-                                            #else
-                                            #{
-                                            # master not correct for service node pools
-                 #$ient = $sitetab->getAttribs({key => master}, value);
-                 #if ($ient and $ient->{value})
-                 #{
-                 #    $imgsrv = $ient->{value};
-                 #}
-                 #else
-                 #{
-                 #   $imgsrv = '!myipfn!';
-                 #}
-                 #}
+        } else {
             $imgsrv = $xcatmaster;
         }
         unless ($imgsrv) {
             xCAT::MsgUtils->report_node_error($callback, $node, "Unable to determine or reasonably guess the image server for $node");
             next;
         }
+
         my $kcmdline;
         if ($statelite) {
             if (rootfstype ne "ramdisk") {
@@ -1313,9 +1293,6 @@ sub mknetboot
                 # have to get nfssvr and nfsdir from noderes table
                 my $nfssrv = $imgsrv;
                 my $nfsdir = $rootimgdir;
-                if ($ient->{nfsserver}) {
-                    $nfssrv = $ient->{nfsserver};
-                }
                 if ($ient->{nfsdir} ne '') {
                     $nfsdir = $ient->{nfsdir} . "/netboot/$osver/$arch/$profile";
 

--- a/xCAT-server/lib/xcat/plugins/petitboot.pm
+++ b/xCAT-server/lib/xcat/plugins/petitboot.pm
@@ -94,8 +94,8 @@ sub setstate {
     if ($kern->{kernel} !~ /^$tftpdir/) {
         my $nodereshash = $nrhash{$node}->[0];
         my $installsrv;
-        if ($nodereshash and $nodereshash->{nfsserver}) {
-            $installsrv = $nodereshash->{nfsserver};
+        if ($nodereshash and $nodereshash->{tftpserver}) {
+            $installsrv = $nodereshash->{tftpserver};
         } elsif ($nodereshash->{xcatmaster}) {
             $installsrv = $nodereshash->{xcatmaster};
         } else {
@@ -574,7 +574,7 @@ sub process_request {
     my $chaintab = xCAT::Table->new('chain', -create => 1);
     my $chainhash = $chaintab->getNodesAttribs(\@nodes, ['currstate']);
     my $noderestab = xCAT::Table->new('noderes', -create => 1);
-    my $nodereshash = $noderestab->getNodesAttribs(\@nodes, [ 'tftpdir', 'xcatmaster', 'nfsserver', 'servicenode' ]);
+    my $nodereshash = $noderestab->getNodesAttribs(\@nodes, [ 'tftpdir', 'xcatmaster', 'tftpserver', 'servicenode' ]);
     my $typetab = xCAT::Table->new('nodetype', -create => 1);
     my $typehash = $typetab->getNodesAttribs(\@nodes, [ 'os', 'provmethod', 'arch', 'profile' ]);
     my $linuximgtab = xCAT::Table->new('linuximage', -create => 1);

--- a/xCAT-server/lib/xcat/plugins/sles.pm
+++ b/xCAT-server/lib/xcat/plugins/sles.pm
@@ -411,41 +411,21 @@ sub mknetboot
         my $ient;
         my $xcatmaster;
 
-        $ient = $restab->getNodeAttribs($node, ['xcatmaster']);
-        if ($ient and $ient->{xcatmaster})
-        {
+        $ient = $reshash->{$node}->[0]; #$restab->getNodeAttribs($node, ['tftpserver']);
+        if ($ient and $ient->{xcatmaster}) {
             $xcatmaster = $ient->{xcatmaster};
         } else {
             $xcatmaster = '!myipfn!'; #allow service nodes to dynamically nominate themselves as a good contact point, this is of limited use in the event that xcat is not the dhcp/tftp server
         }
 
-        $ient = $restab->getNodeAttribs($node, ['tftpserver']);
-        if ($ient and $ient->{tftpserver})
-        {
+        if ($ient and $ient->{nfsserver} and $ient->{nfsserver} ne '<xcatmaster>') {
+            $imgsrv = $ient->{nfsserver};
+        }elsif ($ient and $ient->{tftpserver} and $ient->{tftpserver} ne '<xcatmaster>') {
             $imgsrv = $ient->{tftpserver};
-        }
-        else
-        {
-            #    $ient = $restab->getNodeAttribs($node, ['xcatmaster']);
-            #    if ($ient and $ient->{xcatmaster})
-            #    {
-            #        $imgsrv = $ient->{xcatmaster};
-            #    }
-            #    else
-            #    {
-            #        # master removed, does not work for servicenode pools
-            #        #$ient = $sitetab->getAttribs({key => master}, value);
-            #        #if ($ient and $ient->{value})
-            #        #{
-            #         #   $imgsrv = $ient->{value};
-            #        #}
-            #        #else
-            #        #{
-            #        $imgsrv = '!myipfn!';
-            #        #}
-            #    }
+        } else {
             $imgsrv = $xcatmaster;
         }
+
         unless ($imgsrv)
         {
             xCAT::MsgUtils->report_node_error($callback, $node, "Unable to determine or reasonably guess the image server for $node");
@@ -463,14 +443,8 @@ sub mknetboot
                 my $nfssrv = $imgsrv;
                 my $nfsdir = $rootimgdir;
 
-                if ($restab) {
-                    my $resHash = $restab->getNodeAttribs($node, [ 'nfsserver', 'nfsdir' ]);
-                    if ($resHash and $resHash->{nfsserver}) {
-                        $nfssrv = $resHash->{nfsserver};
-                    }
-                    if ($resHash and $resHash->{nfsdir} ne '') {
-                        $nfsdir = $resHash->{nfsdir} . "/netboot/$osver/$arch/$profile";
-                    }
+                if ($ient->{nfsdir} ne '') {
+                    $nfsdir = $ient->{nfsdir} . "/netboot/$osver/$arch/$profile";
                 }
                 if (&using_dracut($rootimgdir)) {
                     $kcmdline = "root=nfs:$nfssrv:$nfsdir/rootimg:ro STATEMNT=";


### PR DESCRIPTION
Adjust the server used for kernel/initrd and imgurl for petitboot (#4416)

 - URL for kernel/initrd, get the value from below value tftpserver -> xcatmaster -> myipfn
 - URL for image, get the value from below value nfsserver -> tftpserver -> xcatmaster -> myipfn

UT:  
```
# nslookup c910f03c05k20
Server:		127.0.0.1
Address:	127.0.0.1#53

Name:	c910f03c05k20.test.zone
Address: 10.3.5.20

# lsdef fake1 -i xcatmaster,tftpserver,nfsserver
Object name: fake1
    nfsserver=
    tftpserver=c910f03c05k20
    xcatmaster=c910f03c05k24
```
After running `nodeset fake1 osimage`, to check the petitboot file
```
cat /tftpboot/petitboot/fake1
#netboot rhels7.3-ppc64le-compute
default xCAT
label xCAT
	kernel http://c910f03c05k20:80/tftpboot/xcat/osimage/rhels7.3-ppc64le-netboot-compute/kernel
	initrd http://c910f03c05k20:80/tftpboot/xcat/osimage/rhels7.3-ppc64le-netboot-compute/initrd-stateless.gz
	append "imgurl=http://10.3.5.20:80//install/netboot/rhels7.3/ppc64le/compute/rootimg.cpio.gz XCAT=10.3.5.24:3001 NODE=fake1 FC=0  LOGSERVER=10.3.5.24  syslog.server=10.3.5.24 syslog.type=rsyslogd syslog.filter=*.*  xcatdebugmode=1 BOOTIF=11:22:33:55:44  console=tty0 console=hvc0,115200 selinux=0 "
```
okay, we can see that the `tftpserver` is used for kernel/initrd and also for `imgurl` (resolved to IP address)

using `nfsserver` now
```
# chdef fake1 nfsserver=11.1.1.1
nodeset fake1 osimage
#netboot rhels7.3-ppc64le-compute
default xCAT
label xCAT
	kernel http://c910f03c05k20:80/tftpboot/xcat/osimage/rhels7.3-ppc64le-netboot-compute/kernel
	initrd http://c910f03c05k20:80/tftpboot/xcat/osimage/rhels7.3-ppc64le-netboot-compute/initrd-stateless.gz
	append "imgurl=http://11.1.1.1:80//install/netboot/rhels7.3/ppc64le/compute/rootimg.cpio.gz XCAT=10.3.5.24:3001 NODE=fake1 FC=0  LOGSERVER=10.3.5.24  syslog.server=10.3.5.24 syslog.type=rsyslogd syslog.filter=*.*  xcatdebugmode=1 BOOTIF=11:22:33:55:44  console=tty0 console=hvc0,115200 selinux=0 "
```
Now, the `imgurl` will use `nfsserver`.


As the fix also cover sles/ubuntu,  need be covered by daily automation testing.