### PR TITLE
[OpenBMC] Improve the output message for reventlog to indicate missing PolicyTable file

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -81,6 +81,7 @@ $::RSPCONFIG_WAIT_IP_DONE   = 3;
 $::RSPCONFIG_DUMP_CMD_TIME  = 0;
 
 $::XCAT_LOG_DIR             = "/var/log/xcat";
+$::RAS_POLICY_TABLE         = "/opt/ibm/ras/lib/policyTable.json";
 $::XCAT_LOG_RFLASH_DIR      = $::XCAT_LOG_DIR . "/rflash/";
 $::XCAT_LOG_DUMP_DIR        = $::XCAT_LOG_DIR . "/dump/";
 
@@ -837,7 +838,7 @@ rmdir \"/tmp/\$userid\" \n";
     while (1) { 
         unless ($wait_node_num) {
             if ($event_mapping and (ref($event_mapping) ne "HASH")) {
-                xCAT::SvrUtils::sendmsg("$event_mapping, all event messages above are original", $callback);
+                xCAT::SvrUtils::sendmsg("$event_mapping, install the OpenBMC RAS package to obtain more details logging messages.", $callback);
             }
             if ($next_status{LOGIN_RESPONSE} eq "RSPCONFIG_SSHCFG_REQUEST") {
                 my $home = xCAT::Utils->getHomeDir("root");
@@ -1325,17 +1326,16 @@ sub parse_command_status {
             $next_status{LOGIN_RESPONSE} = "REVENTLOG_REQUEST";
             $next_status{REVENTLOG_REQUEST} = "REVENTLOG_RESPONSE";
             $status_info{REVENTLOG_RESPONSE}{argv} = "$subcommand";
-            my $policy_table = "/opt/ibm/ras/lib/policyTable.json";
-            if (-e "$policy_table") {
-                my $policy_json = `cat $policy_table`;
+            if (-e "$::RAS_POLICY_TABLE") {
+                my $policy_json = `cat $::RAS_POLICY_TABLE`;
                 if ($policy_json) {
                     my $policy_hash = decode_json $policy_json;
                     $event_mapping = $policy_hash->{events};
                 } else {
-                    $event_mapping = "No data in $policy_table";
+                    $event_mapping = "No data in $::RAS_POLICY_TABLE";
                 }
             } else {
-                $event_mapping = "Could not found '$policy_table'";
+                $event_mapping = "Could not find '$::RAS_POLICY_TABLE'";
             }
         }
     }

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2095,6 +2095,9 @@ sub process_debug_info {
     my $node = shift;
     my $debug_msg = shift;
     my $ts_node = localtime() . " " . $node;
+    if (!$debug_msg) {
+        $debug_msg = "";
+    }
 
     xCAT::SvrUtils::sendmsg("$flag_debug $debug_msg", $callback, $ts_node);
     xCAT::MsgUtils->trace(0, "D", "$flag_debug $node $debug_msg"); 


### PR DESCRIPTION
When running the command: 

```
[root@briggs01 ~]# reventlog mid05tor12cn13 10
mid05tor12cn13: 12/05/2017 20:55:15 [33]: xyz.openbmc_project.Common.Error.InternalFailure (PID: 1147), Resolved: 0
mid05tor12cn13: 12/06/2017 11:39:43 [34]: xyz.openbmc_project.Software.Version.Error.ManifestFileFailure (PID: 1292), Resolved: 0
mid05tor12cn13: 12/06/2017 11:46:57 [35]: org.open_power.Host.Boot.Error.Checkstop (PID: 2316), Resolved: 0
mid05tor12cn13: 12/06/2017 11:58:08 [36]: xyz.openbmc_project.Software.Version.Error.ManifestFileFailure (PID: 1387), Resolved: 0
mid05tor12cn13: 12/06/2017 12:05:06 [37]: org.open_power.Host.Boot.Error.Checkstop (PID: 4414), Resolved: 0
mid05tor12cn13: 12/06/2017 20:36:11 [38]: xyz.openbmc_project.Software.Version.Error.ManifestFileFailure (PID: 1387), Resolved: 0
mid05tor12cn13: 12/13/2017 02:59:20 [39]: xyz.openbmc_project.Software.Version.Error.ManifestFileFailure (PID: 1301), Resolved: 0
mid05tor12cn13: 12/13/2017 03:32:28 [40]: xyz.openbmc_project.Software.Version.Error.ManifestFileFailure (PID: 1392), Resolved: 0
mid05tor12cn13: 12/13/2017 04:39:45 [41]: xyz.openbmc_project.Software.Version.Error.ManifestFileFailure (PID: 1343), Resolved: 0
mid05tor12cn13: 12/13/2017 04:46:09 [42]: xyz.openbmc_project.Software.Version.Error.ManifestFileFailure (PID: 1369), Resolved: 0
Could not found '/opt/ibm/ras/lib/policyTable.json', all event messages above are original
```

I didn't think that message at the end was useful for the user....  but since the `ibm-crassd` RPM packaging may change, changing the message to the following with this Pull Request: 

```
[root@briggs01 xCAT_plugin]# reventlog mid05tor12cn13 10
mid05tor12cn13: 12/05/2017 20:55:15 [33]: xyz.openbmc_project.Common.Error.InternalFailure (PID: 1147), Resolved: 0
mid05tor12cn13: 12/06/2017 11:39:43 [34]: xyz.openbmc_project.Software.Version.Error.ManifestFileFailure (PID: 1292), Resolved: 0
mid05tor12cn13: 12/06/2017 11:46:57 [35]: org.open_power.Host.Boot.Error.Checkstop (PID: 2316), Resolved: 0
mid05tor12cn13: 12/06/2017 11:58:08 [36]: xyz.openbmc_project.Software.Version.Error.ManifestFileFailure (PID: 1387), Resolved: 0
mid05tor12cn13: 12/06/2017 12:05:06 [37]: org.open_power.Host.Boot.Error.Checkstop (PID: 4414), Resolved: 0
mid05tor12cn13: 12/06/2017 20:36:11 [38]: xyz.openbmc_project.Software.Version.Error.ManifestFileFailure (PID: 1387), Resolved: 0
mid05tor12cn13: 12/13/2017 02:59:20 [39]: xyz.openbmc_project.Software.Version.Error.ManifestFileFailure (PID: 1301), Resolved: 0
mid05tor12cn13: 12/13/2017 03:32:28 [40]: xyz.openbmc_project.Software.Version.Error.ManifestFileFailure (PID: 1392), Resolved: 0
mid05tor12cn13: 12/13/2017 04:39:45 [41]: xyz.openbmc_project.Software.Version.Error.ManifestFileFailure (PID: 1343), Resolved: 0
mid05tor12cn13: 12/13/2017 04:46:09 [42]: xyz.openbmc_project.Software.Version.Error.ManifestFileFailure (PID: 1369), Resolved: 0
Could not find '/opt/ibm/ras/lib/policyTable.json', install the OpenBMC RAS package to obtain more details logging messages.
```
