### PR TITLE
[OpenBMC] Check for LinkLocal and 169.254 IP for ZeroConfig to ignore

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2820,7 +2820,7 @@ sub rspconfig_response {
             
             if ($adapter_id) {
                 if ( (defined($content{Origin}) and $content{Origin} =~ /LinkLocal/) or 
-                     (defined($content{Address}) and $content{Address} =~ "169.254") ) {
+                     (defined($content{Address}) and $content{Address} =~ /^169.254/) ) {
                     # OpenBMC driver has a interim bug where ZeroConfigIP comes up as DHCP instead of LinkLocal.
                     # To protect xCAT while the drivers change, check the 169.254 IP also 
                     if ($xcatdebugmode) {

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2819,7 +2819,10 @@ sub rspconfig_response {
             my ($path, $adapter_id) = (split(/\/ipv4\//, $key_url));
             
             if ($adapter_id) {
-                if (defined($content{Origin}) and ($content{Origin} =~ /LinkLocal/)) {
+                if ( (defined($content{Origin}) and $content{Origin} =~ /LinkLocal/) or 
+                     (defined($content{Address}) and $content{Address} =~ "169.254") ) {
+                    # OpenBMC driver has a interim bug where ZeroConfigIP comes up as DHCP instead of LinkLocal.
+                    # To protect xCAT while the drivers change, check the 169.254 IP also 
                     if ($xcatdebugmode) {
                         my $debugmsg = "Found LocalLink " . $content{Address} . " for interface " . $key_url . " Ignoring...";
                         process_debug_info($node, $debugmsg);


### PR DESCRIPTION
This one I saw re-created on FVT machine, but I think it was running Regression so when I looked again, it did not happen.  @xuweibj @hu-weihua If you can re-create it, please let me know how.  

I thought it was with the 1742Eg firmware, but i don't see it all the time... .

Here's what the CURL command returns: 
```
[root@fs2vm110 Network]# ./list.sh
+ date
Wed Dec 13 14:07:19 EST 2017
+ curl -c cjar -b cjar -k -H 'Content-Type: application/json' -X GET https://10.6.17.100/xyz/openbmc_project/network/enumerate
{
  "data": {
    "/xyz/openbmc_project/network/config": {
      "DefaultGateway": "10.0.0.101",
      "HostName": "f6u17_bmc_7691"
    },
    "/xyz/openbmc_project/network/config/dhcp": {
      "DNSEnabled": 1,
      "HostNameEnabled": 1,
      "NTPEnabled": 1
    },
    "/xyz/openbmc_project/network/eth0": {
      "AutoNeg": 0,
      "DHCPEnabled": 1,
      "DomainName": [],
      "InterfaceName": "eth0",
      "MACAddress": "70:e2:84:14:32:84",
      "NTPServers": [],
      "Nameservers": [],
      "Speed": 0
    },
    "/xyz/openbmc_project/network/eth0/ipv4/893288e5": {
      "Address": "169.254.149.65",
      "Gateway": "0.0.0.0",
      "Origin": "xyz.openbmc_project.Network.IP.AddressOrigin.DHCP",   <------
      "PrefixLength": 16,
      "Type": "xyz.openbmc_project.Network.IP.Protocol.IPv4"
    },
    "/xyz/openbmc_project/network/eth0/ipv4/f09e3934": {
      "Address": "10.6.17.100",
      "Gateway": "0.0.0.0",
      "Origin": "xyz.openbmc_project.Network.IP.AddressOrigin.DHCP",
      "PrefixLength": 8,
      "Type": "xyz.openbmc_project.Network.IP.Protocol.IPv4"
    },
    "/xyz/openbmc_project/network/eth0/ipv6/65d89c89": {
      "Address": "fe80::72e2:84ff:fe14:3284",
      "Gateway": "",
      "Origin": "xyz.openbmc_project.Network.IP.AddressOrigin.DHCP",
      "PrefixLength": 64,
      "Type": "xyz.openbmc_project.Network.IP.Protocol.IPv6"
    },
    "/xyz/openbmc_project/network/host0/intf": {
      "MACAddress": "00:00:00:00:00:00"
    },
    "/xyz/openbmc_project/network/host0/intf/addr": {
      "Address": "0.0.0.0",
      "Gateway": "0.0.0.0",
      "Origin": "xyz.openbmc_project.Network.IP.AddressOrigin.Static",
      "PrefixLength": 0,
      "Type": "xyz.openbmc_project.Network.IP.Protocol.IPv4"
    }
  },
  "message": "200 OK",
  "status": "ok"
}
real	0m0.526s
user	0m0.056s
sys	0m0.056s
```

This is fixed by OpenBMC in this change: https://gerrit.openbmc-project.xyz/#/c/7927/ 

But in order to protect users of xCAT from NOT seeing this on an interim FW, adding the following check for 169.254... 

If we think this is good to have, let's merge it into the release.

I don't have a clean UT for this code because f6u17 changed while I was testing this.  @hu-weihua Is this because FVT regression is doing something here? 