### PR TITLE
Fix issue 4507, add parameter check for rspconfig admin_passwd

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -993,6 +993,9 @@ sub parse_args {
                 if ($key eq "admin_passwd") {
                     my $comma_num = $value =~ tr/,/,/;
                     return ([ 1, "Invalid parameter for option $key: $value" ]) if ($comma_num != 1);
+                    if ($subcommand =~ /^admin_passwd=(.*),(.*)/) {
+                        return ([ 1, "Invalid parameter for option $key: $value" ]) if ($1 eq "" or $2 eq "");
+                    }
                 }
 
                 my $nodes_num = @$noderange;


### PR DESCRIPTION
#4507 

```
# rspconfig simulation_test admin_passwd=,sss
simulation_test: Error: Invalid parameter for option admin_passwd: ,sss
[root@c910f03c05k04 xcat-core]# rspconfig simulation_test admin_passwd=aaa,
simulation_test: Error: Invalid parameter for option admin_passwd: aaa,
```