### PR TITLE
updatenode failed in rhel6.9 and sles 11.4

### DIFF
--- a/xCAT-server/lib/xcat/plugins/updatenode.pm
+++ b/xCAT-server/lib/xcat/plugins/updatenode.pm
@@ -1694,21 +1694,21 @@ sub updatenodesyncfiles
         }
     }
 
-    my $dhs_from_user_env;
+    my $dsh_from_user_env;
     # get the Environment Variables and set DSH_FROM_USERID if possible (From updatenode client)
     if (defined($request->{environment})) {
         foreach my $envar (@{ $request->{environment} })
         {
             if ($envar =~ /^DSH_FROM_USERID=/) {
-                $dhs_from_user_env = $envar;
+                $dsh_from_user_env = $envar;
                 last;
             }
         }
     }
-    unless ($dhs_from_user_env) {
+    unless ($dsh_from_user_env) {
         # $request->{username} is gotten from CN in client certificate
         if (($request->{username}) && defined($request->{username}->[0])) {
-            $dhs_from_user_env = 'DSH_FROM_USERID=' . $request->{username}->[0];
+            $dsh_from_user_env = 'DSH_FROM_USERID=' . $request->{username}->[0];
         }
     }
 
@@ -1762,8 +1762,8 @@ sub updatenodesyncfiles
             } else {               # else this is updatenode -F
                 $env = ["DSH_RSYNC_FILE=$synclist"];
             }
-            if ($dhs_from_user_env) {
-                push $env, $dhs_from_user_env;
+            if ($dsh_from_user_env) {
+                push @$env, $dsh_from_user_env;
             }
 
             push @$args, "--nodestatus";


### PR DESCRIPTION
(Fix #4517) 
The error is caused by using array ref in updatenode, the usage will cause wrong in old perl version. And this is introduced by PR#4484

UT:
Before fixing:
```
perl -c /opt/xcat/lib/perl/xCAT_plugin/updatenode.pm
Type of arg 1 to push must be array (not private variable) at /opt/xcat/lib/perl/xCAT_plugin/updatenode.pm line 1766, near "$dhs_from_user_env;"
BEGIN not safe after errors--compilation aborted at /opt/xcat/lib/perl/xCAT_plugin/updatenode.pm line 2150.
```
After fixing:
```
# perl -c /opt/xcat/lib/perl/xCAT_plugin/updatenode.pm
/opt/xcat/lib/perl/xCAT_plugin/updatenode.pm syntax OK
```