### PR TITLE
remove the /etc/localtime before copy timezone file

### DIFF
--- a/xCAT-server/lib/xcat/plugins/packimage.pm
+++ b/xCAT-server/lib/xcat/plugins/packimage.pm
@@ -629,6 +629,7 @@ sub copybootscript {
 
         copy("$installroot/postscripts/xcatdsklspost", "$rootimg_dir/opt/xcat/xcatdsklspost");
         if ($timezone[0]) {
+            unlink("$rootimg_dir/etc/localtime");
             copy("$rootimg_dir/usr/share/zoneinfo/$timezone[0]", "$rootimg_dir/etc/localtime");
         }
 


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/4520:

remove the existing `$rootimg_dir/etc/localtime` first before apply the timezone 