### PR TITLE
[RFC] Do not comment out rsyslog /var/log/messages on MN

### DIFF
--- a/xCAT/etc/rsyslog.d/xcat-debug.conf
+++ b/xCAT/etc/rsyslog.d/xcat-debug.conf
@@ -1,3 +1,3 @@
-# By default, dhcpd use the ``daemon'' facility. Thus dhcp logs will go here.
-# ftp.* is for tftp log.
-daemon.debug;ftp.*		/var/log/messages
+# Make sure dhcpd requests and responses (daemon.=debug) and
+# tftp messages (ftp.*) are logged.
+daemon.=debug;ftp.*		/var/log/messages

--- a/xCAT/postscripts/syslog
+++ b/xCAT/postscripts/syslog
@@ -117,11 +117,8 @@ config_Rsyslog_C3()
 
   #enable to send the logging to master
   if [ $isLocal -eq 1 ]; then
-      #enable the MN to log all the logs from CN and MN itself
-      sed -i 's/\(^[^\#].*\/var\/log\/messages\)/\#\1/g' $2
-      echo "#*.debug  /var/log/messages" >> $2
-      touch  /var/log/messages  
       if ( pmatch $OSVER "ubuntu*" ) || ( is_lsb_ubuntu ) || ( pmatch $OSVER "debian*" ); then
+        touch /var/log/messages
         chown syslog:adm /var/log/messages
         sed -i 's/\$PrivDropToGroup syslog/\$PrivDropToGroup adm/' $2
         chown syslog:adm /var/log/xcat
@@ -200,7 +197,7 @@ config_rsyslog_V8()
 
   if [ $goLocal -eq 1 ]; then
     #logging is local, do not forward
-    #making sure all the messages goes to /var/log/messages
+    #making sure /var/log/messages is setup for xcat-debug
     touch  /var/log/messages
     if ( pmatch $OSVER "ubuntu*" ) || ( is_lsb_ubuntu ) || ( pmatch $OSVER "debian*" ); then
       chown syslog:adm /var/log/messages
@@ -208,14 +205,9 @@ config_rsyslog_V8()
       chown syslog:adm /var/log/xcat
     fi
 
-    #comment out the rules which will write logs to /var/log/messages
-    # to prevent duplicate logs after "syslog" script is run 
-    sed -i '/^[^#].*\/var\/log\/messages/s/^/#/' $conf_file
-
     # Mark the start of xCAT section
     echo "# $xCATSettingsSTART" >> $conf_file
     echo "# $xCATSettingsInfo" >> $conf_file
-    echo "#*.debug   /var/log/messages"  >> $conf_file
     # Need to uncomment the lines $ModLoad imudp.so and $UDPServerRun 514,
     # to make the MN be able to receive syslog from remote hosts
     if [ -f "$remoteconf" ]; then


### PR DESCRIPTION
Since xCAT 2.11, the rule `*.debug /var/log/messages` is no longer added to rsyslog.conf on the MN, but all pre-existing rules ending with "/var/log/messages" are still commented out. Is this a mistake? I cannot imagine that xCAT is supposed to disable all logging to /var/log/messages (though, it enables the daemon and ftp facilities in the config file `/etc/rsyslog.d/xcat-debug.conf`, still leading to a "/var/log/messages" that is missing a lot of messages).

This PR has a commit that solves the problem, though I am not sure how to properly solve duplicate messages coming from `/etc/rsyslog.d/xcat-debug.conf`, hence the RFC tag. Still, duplicate messages are better than missing messages!