### PR TITLE
Support custom udev rules in the initrd

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/install.netboot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/install.netboot
@@ -4,6 +4,10 @@ dracut_install wget tar cpio gzip modprobe touch echo cut wc xz
 dracut_install grep ifconfig hostname awk egrep grep dirname expr
 dracut_install mount.nfs
 dracut_install parted mke2fs bc mkswap swapon chmod
+dracut_install ethtool
 inst "$moddir/xcat-updateflag" "/tmp/updateflag"
 inst "$moddir/xcatroot" "/sbin/xcatroot"
 inst_hook cmdline 10 "$moddir/xcat-cmdline.sh" 
+for file in /etc/udev/rules.d/*;do
+	grep -qi xcat $file && inst_rules $(basename $file)
+done

--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/install.statelite
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/install.statelite
@@ -3,6 +3,10 @@ echo $drivers
 dracut_install wget cpio gzip modprobe wc touch echo cut
 dracut_install grep ifconfig hostname awk egrep grep dirname expr
 dracut_install parted mke2fs bc mkswap swapon chmod
+dracut_install ethtool
 inst "$moddir/xcat-updateflag" "/tmp/updateflag"
 inst_hook pre-mount 5 "$moddir/xcat-premount.sh"
 inst_hook pre-pivot 5 "$moddir/xcat-prepivot.sh"
+for file in /etc/udev/rules.d/*;do
+	grep -qi xcat $file && inst_rules $(basename $file)
+done


### PR DESCRIPTION
This allows any udev rules in `/etc/udev/rules.d` that have the case-insensitive word `xcat` in them to be pulled into the initrd.  Admins should create their own udev rules from an RPM or using a postinstall script, or modify an existing rule by appending a comment
```
echo "# Please install me xCAT" >> $IMG_ROOTIMGDIR/etc/udev/rules.d/10-preexisting-rule.rules
```
This also pulls in ethtool, which is currently required on WSP nodes.
Closes #4489