### PR TITLE
rflash -d relative path support

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -60,7 +60,7 @@ $::RSETBOOT_URL_PATH        = "boot";
 $::UPLOAD_AND_ACTIVATE      = 0;
 $::UPLOAD_ACTIVATE_STREAM   = 0;
 $::RFLASH_STREAM_NO_HOST_REBOOT = 0;
-
+$::TAR_FILE_PATH = "";
 $::NO_ATTRIBUTES_RETURNED   = "No attributes returned from the BMC.";
 
 $::UPLOAD_WAIT_ATTEMPT      = 6;
@@ -648,7 +648,7 @@ sub preprocess_request {
     my $extrargs  = $request->{arg};
     my @exargs    = ($request->{arg});
     my @requests;
-
+    $::cwd = $request->{cwd}->[0];
     if (ref($extrargs)) {
         @exargs = @$extrargs;
     }
@@ -1149,17 +1149,24 @@ sub parse_args {
                     }
                 }
             }
-            elsif ($opt =~ /.*\//) {
+            elsif ($opt =~ /^\//) {
                 $filepath_passed = 1;
                 push (@tarball_path, $opt);
             }
             else {
-                push (@flash_arguments, $opt);
-                $invalid_options .= $opt . " ";
+                my $tmppath = xCAT::Utils->full_path($opt, $::cwd);
+                if (opendir(TDIR, $tmppath)) {
+                    $filepath_passed = 1;
+                    push (@tarball_path, $tmppath);
+                    close(TDIR);
+                } else {
+                    push (@flash_arguments, $opt);
+                    $invalid_options .= $opt . " ";
+                }
             }
         }
         # show options parsed in bypass mode
-        print "DEBUG filename=$filename_passed, updateid=$updateid_passed, options=$option_flag, invalid=$invalid_options rflash_arguments=@flash_arguments\n";
+        print "DEBUG filename=$filename_passed, updateid=$updateid_passed, options=$option_flag, tar_file_path=@tarball_path, invalid=$invalid_options rflash_arguments=@flash_arguments\n";
 
         if ($option_flag =~ tr{ }{ } > 0) { 
             unless ($verbose or $option_flag =~/^-d --no-host-reboot$/) {
@@ -1204,8 +1211,10 @@ sub parse_args {
                     }
                     if (!opendir(DIR, $tarball_path[0])) {
                         return ([1, "Can't open directory : $tarball_path[0]"]);
+                    } else {
+                        $::TAR_FILE_PATH = $tarball_path[0];
+                        closedir(DIR);
                     }
-                    closedir(DIR);
                 } elsif ($option_flag =~ /^-c$|^--check$|^-u$|^--upload$|^-a$|^--activate$/) {
                     return ([ 1, "Invalid firmware specified with $option_flag" ]);
                 } else {
@@ -1697,13 +1706,13 @@ sub parse_command_status {
                     # Display firmware version of the specified .tar file
                     xCAT::SvrUtils::sendmsg("TAR $purpose_value Firmware Product Version\: $version_value", $callback);
                 }
-            } elsif (opendir(DIR, $update_file)) {
+            } elsif (opendir(DIR, $::TAR_FILE_PATH)) {
                 my @tar_files = readdir(DIR);
                 foreach my $file (@tar_files) {
                     if ($file !~ /.*\.tar$/) {
                         next;
                     } else {
-                        my $full_path_file = $update_file."/".$file;
+                        my $full_path_file = $::TAR_FILE_PATH."/".$file;
                         $full_path_file=~s/\/\//\//g;
                         my $firmware_version_in_file = `$grep_cmd $version_tag $full_path_file`;
                         my $purpose_version_in_file = `$grep_cmd $purpose_tag $full_path_file`;


### PR DESCRIPTION
For #4511 

UT:
1, there is directory bai, but no firmware tar files, exit error
```
[root@briggs01 xCAT_plugin]# export XCAT_OPENBMC_DEVEL=YES
[root@briggs01 xCAT_plugin]# rflash mid05tor12cn13 -d ./bai
Fri Dec 15 02:15:47 2017 OpenBMC: [openbmc_debug]
Error: No BMC tar file found in ./bai
Error: No PNOR tar file found in ./bai
```
2, there is no directory yuan, exit error
```
[root@briggs01 xCAT_plugin]# rflash mid05tor12cn13 -d ./yuan
Fri Dec 15 02:15:59 2017 OpenBMC: [openbmc_debug]
mid05tor12cn13: Error: Invalid option specified with -d: ./yuan
```
3, there is no firmware files in ./, exit error
```
[root@briggs01 xCAT_plugin]# rflash mid05tor12cn13 -d ./
Fri Dec 15 02:16:11 2017 OpenBMC: [openbmc_debug]
Error: No BMC tar file found in ./
Error: No PNOR tar file found in ./
```
4, there is empty directory bai, exit error
```
[root@briggs01 xCAT_plugin]# rflash mid05tor12cn13 -d bai
Fri Dec 15 02:16:16 2017 OpenBMC: [openbmc_debug]
Error: No BMC tar file found in bai
Error: No PNOR tar file found in bai
```
5, there is directory test contains 2 firmware tar files, work well
```
[root@briggs01 xCAT_plugin]# rflash mid05tor12cn13 -d test/
Fri Dec 15 02:16:24 2017 OpenBMC: [openbmc_debug]
Attempting to upload /opt/xcat/lib/perl/xCAT_plugin/test/obmc-phosphor-image-witherspoon.ubi.mtd.tar and /opt/xcat/lib/perl/xCAT_plugin/test/witherspoon.pnor.squashfs.tar, please wait...
Fri Dec 15 02:16:24 2017 mid05tor12cn13: [openbmc_debug] curl -k -c cjar -H "Content-Type: application/json" -d '{ "data": ["root", "xxxxxx"] }' https://172.11.139.13/login
Fri Dec 15 02:16:24 2017 mid05tor12cn13: [openbmc_debug] login_response 200 OK
Fri Dec 15 02:16:25 2017 mid05tor12cn13: [openbmc_debug] RFLASH_FILE_UPLOAD_RESPONSE: CMD: curl -b /tmp/_xcat_cjar.mid05tor12cn13 -k -H 'Content-Type: application/octet-stream' -X PUT -T /opt/xcat/lib/perl/xCAT_plugin/test/witherspoon.pnor.squashfs.tar https://172.11.139.13/upload/image/
Fri Dec 15 02:16:34 2017 mid05tor12cn13: [openbmc_debug] RFLASH_FILE_UPLOAD_RESPONSE: CMD: curl -b /tmp/_xcat_cjar.mid05tor12cn13 -k -H 'Content-Type: application/octet-stream' -X PUT -T /opt/xcat/lib/perl/xCAT_plugin/test/witherspoon.pnor.squashfs.tar https://172.11.139.13/upload/image/
Fri Dec 15 02:16:45 2017 mid05tor12cn13: [openbmc_debug] RFLASH_FILE_UPLOAD_RESPONSE: CMD: curl -b /tmp/_xcat_cjar.mid05tor12cn13 -k -H 'Content-Type: application/octet-stream' -X PUT -T /opt/xcat/lib/perl/xCAT_plugin/test/obmc-phosphor-image-witherspoon.ubi.mtd.tar https://172.11.139.13/upload/image/
... ...
```
6, multiple directories are not supported, exit error
```
[root@briggs01 xCAT_plugin]# rflash mid05tor12cn13 -d test/ ./bai
Fri Dec 15 02:23:10 2017 OpenBMC: [openbmc_debug]
mid05tor12cn13: Error: More than one directory specified is not supported

[root@briggs01 xCAT_plugin]# rflash mid05tor12cn13 -d test/ ./bai --no-host-reboot
Fri Dec 15 02:23:24 2017 OpenBMC: [openbmc_debug]
mid05tor12cn13: Error: More than one directory specified is not supported
```
7, there is no directory yuan, exit error
```
[root@briggs01 xCAT_plugin]# rflash mid05tor12cn13 -d bai yuan --no-host-reboot
Fri Dec 15 02:23:57 2017 OpenBMC: [openbmc_debug]
mid05tor12cn13: Error: Invalid option specified yuan
```
8, regression test for -a, exit error
```
[root@briggs01 xCAT_plugin]# rflash mid05tor12cn13 -a bai yuan --no-host-reboot
Fri Dec 15 02:24:20 2017 OpenBMC: [openbmc_debug]
mid05tor12cn13: Error: Multiple options are not supported. Options specified: -a --no-host-reboot
```
9, normal directories contain 2 firmware tar files,work well
```
[root@briggs01 xCAT_plugin]# rflash mid05tor12cn13 -d /opt/xcat/lib/perl/xCAT_plugin/test/ --no-host-reboot
Fri Dec 15 02:26:02 2017 OpenBMC: [openbmc_debug]
Attempting to upload /opt/xcat/lib/perl/xCAT_plugin/test/obmc-phosphor-image-witherspoon.ubi.mtd.tar and /opt/xcat/lib/perl/xCAT_plugin/test/witherspoon.pnor.squashfs.tar, please wait...
Fri Dec 15 02:26:03 2017 mid05tor12cn13: [openbmc_debug] curl -k -c cjar -H "Content-Type: application/json" -d '{ "data": ["root", "xxxxxx"] }' https://172.11.139.13/login
Fri Dec 15 02:26:03 2017 mid05tor12cn13: [openbmc_debug] login_response 200 OK
Fri Dec 15 02:26:03 2017 mid05tor12cn13: [openbmc_debug] RFLASH_FILE_UPLOAD_RESPONSE: CMD: curl -b /tmp/_xcat_cjar.mid05tor12cn13 -k -H 'Content-Type: application/octet-stream' -X PUT -T /opt/xcat/lib/perl/xCAT_plugin/test/witherspoon.pnor.squashfs.tar https://172.11.139.13/upload/image/
......
```
10, tar file as input, exit error
```
[root@briggs01 xCAT_plugin]# rflash mid05tor12cn13 -d test/obmc-phosphor-image-witherspoon.ubi.mtd.tar --no-host-reboot
Fri Dec 15 02:33:24 2017 OpenBMC: [openbmc_debug]
mid05tor12cn13: Error: Invalid option specified when a file is provided: -d --no-host-reboot
```
11, regression test for normal -a option test, work well
```
[root@briggs01 xCAT_plugin]# rflash mid05tor12cn13 -a test/obmc-phosphor-image-witherspoon.ubi.mtd.tar
Fri Dec 15 02:33:44 2017 OpenBMC: [openbmc_debug]
Attempting to upload /opt/xcat/lib/perl/xCAT_plugin/test/obmc-phosphor-image-witherspoon.ubi.mtd.tar, please wait...
Fri Dec 15 02:33:44 2017 mid05tor12cn13: [openbmc_debug] curl -k -c cjar -H "Content-Type: application/json" -d '{ "data": ["root", "xxxxxx"] }' https://172.11.139.13/login
Fri Dec 15 02:33:45 2017 mid05tor12cn13: [openbmc_debug] login_response 200 OK
Fri Dec 15 02:33:46 2017 mid05tor12cn13: [openbmc_debug] RFLASH_FILE_UPLOAD_RESPONSE: CMD: curl -b /tmp/_xcat_cjar.mid05tor12cn13 -k -H 'Content-Type: application/octet-stream' -X PUT -T /opt/xcat/lib/perl/xCAT_plugin/test/obmc-phosphor-image-witherspoon.ubi.mtd.tar https://172.11.139.13/upload/image/
Fri Dec 15 02:33:57 2017 mid05tor12cn13: [openbmc_debug] curl -k -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.13/xyz/openbmc_project/software/enumerate
Fri Dec 15 02:33:58 2017 mid05tor12cn13: [openbmc_debug] rflash_update_check_id_response 200 
... ...
```

