### PR TITLE
ignore bmc interfaces defined in the nics table

### DIFF
--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -524,8 +524,13 @@ function configure_nicdevice {
         nic_pair=`echo "$nics_pair" |sed -n "${num}p"`
         echo "configure nic and its device : $nic_pair"
 
+        #ignore bmc interfaces. They're allowed in the nics table to generate DNS/hostname records, but they
+        #can't be configured here (it's done in bmcsetup
+        if [ x"$nic_dev_type" = "xbmc" ]; then
+            log_info "$nic_dev is of type $nic_dev_type, ignoring"
+
         #configure standalone ethernet nic
-        if [ x"$nic_dev_type" = "xethernet" ]; then
+        elif [ x"$nic_dev_type" = "xethernet" ]; then
             xcatnet=`query_nicnetworks_net $nic_dev`            
             ipaddrs=`find_nic_ips $nic_dev`
             if [ -n "$ipaddrs" ]; then


### PR DESCRIPTION
workaround for #4538 

If BMC interfaces are defined in the `nics` table, just ignore them, so `confignetwork` doesn't exit with an error.

BMC interfaces may need to be defined in `nics` to generate proper DNS records, but `confignetwork` can't actually configure them. Their configuration is handled in `bmcsetup`.