### PR TITLE
[OpenBMC] Help the user figure out the problem when using -d to delete FW

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1187,7 +1187,12 @@ sub parse_args {
             if ($updateid_passed) {
                 # Updateid was passed, check flags allowed with update id
                 if ($option_flag !~ /^--delete$|^-a$|^--activate$/) {
-                    return ([ 1, "Invalid option specified when an update id is provided: $option_flag" ]);
+                    my $optional_help_msg = "";
+                    if ($option_flag == "-d") {
+                        # For this special case, -d was changed to pass in a directory.
+                        $optional_help_msg = "Did you mean --delete?"
+                    }
+                    return ([ 1, "Invalid option specified when an update id is provided: $option_flag. $optional_help_msg" ]);
                 }
                 my $action = "activate";
                 if ($option_flag =~ /^--delete$/) {


### PR DESCRIPTION
I got caught up on this today since I have been familiar using the `-d` option to delete firmware. 

```
[root@fs2vm110 ~]# rflash f6u17 -l
f6u17: ID       Purpose State      Version
f6u17: -------------------------------------------------------
f6u17: b3000fc6 BMC     Active(*)  ibm-v2.0-0-r13.3-0-gd624923
f6u17: 3a7f1407 BMC     Active     ibm-v2.0-0-r13-0-g3a160ac
f6u17: 78abd177 Host    Active     IBM-witherspoon-ibm-OP9_v1.19_1.88
f6u17: df4b8673 Host    Active(*)  IBM-witherspoon-ibm-OP9_v1.19_1.90
f6u17:
[root@fs2vm110 ~]# rflash f6u17 -d 78abd177
f6u17: Error: Invalid option specified when an update id is provided: -d
```

And had forgotten that we changed `--delete` to delete and `-d` to specify a directory

Simple code PR to help the user figure this out. 

```
[root@fs2vm110 ~]# rflash f6u17 -d 78abd177
f6u17: Error: Invalid option specified when an update id is provided: -d. Did you mean --delete?
[root@fs2vm110 ~]#
```