### PR TITLE
[OpenBMC] Fix argument parsing based on failure from UT cases 

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1180,7 +1180,7 @@ sub parse_args {
         }
         
         if (scalar @flash_arguments > 1) {
-            if (($option_flag =~ /^-a$|^--delete$/) or ($filename_passed and $option_flag !~ /^-d$/)) { 
+            if (($option_flag =~ /^-a$|^--activate$|^--delete$/) or ($filename_passed and $option_flag !~ /^-d$/)) { 
                 # Handles: 
                 #   - Multiple options not supported to activate/delete at the same time 
                 #   - Filename passed in and option is not -d for directory

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1180,7 +1180,10 @@ sub parse_args {
         }
         
         if (scalar @flash_arguments > 1) {
-            if ($filename_passed and $option_flag !~ /^-d$/) {
+            if (($option_flag =~ /^-a$|^--delete$/) or ($filename_passed and $option_flag !~ /^-d$/)) { 
+                # Handles: 
+                #   - Multiple options not supported to activate/delete at the same time 
+                #   - Filename passed in and option is not -d for directory
                 return ([1, "More than one firmware specified is not supported."]);
             } elsif ($option_flag =~ /^-d$/) {
                 return ([1, "More than one directory specified is not supported."]);

--- a/xCAT-test/autotest/testcase/UT_openbmc/rflash_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rflash_cases0
@@ -14,14 +14,14 @@ os:Linux
 hcp:openbmc
 cmd: rflash $$CN -a /tmp/abc123.tz
 check:rc==1
-check:output=~Error: Invalid option
+check:output=~Error: Invalid firmware specified with -a
 end 
 
 start:rflash_invalid_activate_and_delete
-description: Cannot specify -a and -d at the same time
+description: Cannot specify -a and --delete at the same time
 os:Linux
 hcp:openbmc
-cmd: rflash $$CN -a 123 -d 123
+cmd: rflash $$CN -a 123 --delete 123
 check:rc==1
 check:output=~Error: Multiple options are not supported
 end 
@@ -66,7 +66,7 @@ start:rflash_invalid_delete_2
 description: Attempt to delete more than 1 ID from the FW
 os:Linux
 hcp:openbmc
-cmd: rflash $$CN -d 221d9020 221d9020
+cmd: rflash $$CN --delete 221d9020 221d9020
 check:rc==1 
 check:output=~Error: More than one firmware specified is not supported
 end


### PR DESCRIPTION
Running the OpenBMC UT cases on todays build resulted in the following failures. 

# Failures that need testcase changes 

The `-d` option is for directory, need to update testcase to use `--delete`

```

------START::rflash_invalid_delete_2::Time:Fri Dec 15 16:25:24 2017------

RUN:rflash mid05tor12cn05 -d 221d9020 221d9020 [Fri Dec 15 16:25:24 2017]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Fri Dec 15 16:25:25 2017 OpenBMC: [openbmc_debug]
mid05tor12cn05: Error: More than one directory specified is not supported.
CHECK:rc == 1	[Pass]
CHECK:output =~ Error: More than one firmware specified is not supported	[Failed]

------END::rflash_invalid_delete_2::Failed::Time:Fri Dec 15 16:25:25 2017 ::Duration::1 sec------
```

```
------START::rflash_invalid_activate::Time:Fri Dec 15 16:25:22 2017------

RUN:rflash mid05tor12cn05 -a /tmp/abc123.tz [Fri Dec 15 16:25:22 2017]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Fri Dec 15 16:25:22 2017 OpenBMC: [openbmc_debug]
mid05tor12cn05: Error: Invalid firmware specified with -a
CHECK:rc == 1	[Pass]
CHECK:output =~ Error: Invalid option	[Failed]

------END::rflash_invalid_activate::Failed::Time:Fri Dec 15 16:25:23 2017 ::Duration::1 sec------
```


# Failures that broke argument parsing 
```
------START::rflash_invalid_multiple_id_3::Time:Fri Dec 15 16:25:24 2017------

RUN:rflash mid05tor12cn05 -a 123 abc asdbas [Fri Dec 15 16:25:24 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Fri Dec 15 16:25:24 2017 OpenBMC: [openbmc_debug]
mid05tor12cn05: Error: Invalid firmware specified with -a
CHECK:rc == 1	[Pass]
CHECK:output =~ Error: More than one firmware specified is not supported	[Failed]

------END::rflash_invalid_multiple_id_3::Failed::Time:Fri Dec 15 16:25:24 2017 ::Duration::0 sec------
------START::rflash_invalid_multiple_id_2::Time:Fri Dec 15 16:25:24 2017------

RUN:rflash mid05tor12cn05 -a asdbas 123 [Fri Dec 15 16:25:24 2017]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Fri Dec 15 16:25:24 2017 OpenBMC: [openbmc_debug]
mid05tor12cn05: Error: Invalid firmware specified with -a
CHECK:rc == 1	[Pass]
CHECK:output =~ Error: More than one firmware specified is not supported	[Failed]

------END::rflash_invalid_multiple_id_2::Failed::Time:Fri Dec 15 16:25:24 2017 ::Duration::0 sec------```

After running with the changes in this PR in both xCAT-test and openbmc.pm, the results for the 16 cases are:

```
------Total: 16 , Failed: 0------
```