### PR TITLE
Use all name servers from site.nameservers in mkresolvconf

### DIFF
--- a/xCAT/postscripts/mkresolvconf
+++ b/xCAT/postscripts/mkresolvconf
@@ -27,7 +27,8 @@ if [ -n "$master" ] && [ -n "$domain" ]; then
 	echo "search $domain" >$conf_file
     if [[ "$nameservers" != "" ]]; then
         for ns in ${nameservers//,/ }; do
-    	    echo "nameserver ${ns/<xcatmaster>/$master}" >>$conf_file
+    	    grep -q $ns $conf_file || \
+                echo "nameserver ${ns/<xcatmaster>/$master}" >>$conf_file
         done
     else
         echo "nameserver $master" >>$conf_file

--- a/xCAT/postscripts/mkresolvconf
+++ b/xCAT/postscripts/mkresolvconf
@@ -17,6 +17,7 @@ conf_file_bak="/etc/resolv.conf.bak"
 # get values set when the myxcatpost_<node> script was run
 master=$MASTER_IP  # this is the ip for the nodes xcatmaster attribute
 domain=$DOMAIN     # this is the domain name used in this cluster
+nameservers=$NAMESERVERS # nameservers defined in the site table
 node=$NODE
 
 if [ -n "$master" ] && [ -n "$domain" ]; then
@@ -24,7 +25,14 @@ if [ -n "$master" ] && [ -n "$domain" ]; then
 	#logger -t xcat "Created /etc/resolv.conf file on $node."
 	cp $conf_file $conf_file_bak > /dev/null 2>&1
 	echo "search $domain" >$conf_file
-	echo "nameserver $master" >>$conf_file
+    if [[ "$nameservers" != "" ]]; then
+        for ns in ${nameservers//,/ }; do
+    	    echo "nameserver ${ns/<xcatmaster>/$master}" >>$conf_file
+        done
+    else
+        echo "nameserver $master" >>$conf_file
+    fi
+
 else
 	logger -t xcat -p local4.err "Could not create resolv.conf on $node."
 	exit 1


### PR DESCRIPTION
`mkresolvconf` configures a single name server, even if several are defined in `site.nameservers`.

This patch uses all the name servers defined in `site` when generating `/etc/resolv.conf` on nodes.