### PR TITLE
Check if the include line is already there before adding it to the file

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ddns.pm
+++ b/xCAT-server/lib/xcat/plugins/ddns.pm
@@ -1287,10 +1287,13 @@ sub update_namedconf {
         my @includes = split /[ ,]/, $site_entry;
         foreach (@includes) {
             if (defined($_)) {
-                push @newnamed, "include \"$_\";\n";
+                my $line = "include \"$_\";\n";
+                unless (grep{/$line/} @newnamed) {
+                    push @newnamed, "include \"$_\";\n";
+                }
             }
-        }
         push @newnamed, "\n";
+        }
     }
 
     unless ($slave) {


### PR DESCRIPTION
Fix for #4497: includes were added each time `makedns` was called. 

This patch checks that the `include` line doesn't already exist in the file before adding it.