### PR TITLE
enhanced rflash when BMC response issue

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -4032,7 +4032,7 @@ sub rflash_upload {
     my $content_login = '{ "data": [ "' . $node_info{$node}{username} .'", "' . $node_info{$node}{password} . '" ] }';
     my $content_logout = '{ "data": [ ] }';
     my $cjar_id = "/tmp/_xcat_cjar.$node";
-    my @curl_upload_cmds;
+    my %curl_upload_cmds;
     # curl commands
     my $curl_login_cmd  = "curl -c $cjar_id -k -H 'Content-Type: application/json' -X POST $request_url/login -d '" . $content_login . "'";
     my $curl_logout_cmd = "curl -b $cjar_id -k -H 'Content-Type: application/json' -X POST $request_url/logout -d '" . $content_logout . "'";
@@ -4040,7 +4040,7 @@ sub rflash_upload {
     if (%fw_tar_files) {
         foreach my $key (keys %fw_tar_files) {
             my $curl_upload_cmd = "curl -b $cjar_id -k -H 'Content-Type: application/octet-stream' -X PUT -T " . $key . " $request_url/upload/image/";
-            push(@curl_upload_cmds, $curl_upload_cmd);
+            $curl_upload_cmds{$key}=$curl_upload_cmd;
         }
     }
 
@@ -4066,9 +4066,10 @@ sub rflash_upload {
         return 1;
     }
     if ($h->{message} eq $::RESPONSE_OK) {
-        foreach my $upload_cmd(@curl_upload_cmds){
+        if(%curl_upload_cmds){
             while((my $file,my $version)=each(%fw_tar_files)){
                 my $uploading_msg = "Uploading $file ...";
+                my $upload_cmd = $curl_upload_cmds{$file};
                 # Login successfull, upload the file
                 if ($::VERBOSE) {
                     xCAT::SvrUtils::sendmsg("$uploading_msg", $callback, $node);

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1862,7 +1862,6 @@ sub parse_command_status {
             $next_status{RFLASH_UPDATE_CHECK_STATE_REQUEST} = "RFLASH_UPDATE_CHECK_STATE_RESPONSE";
             $next_status{RFLASH_SET_PRIORITY_REQUEST} = "RFLASH_SET_PRIORITY_RESPONSE";
             $next_status{RFLASH_SET_PRIORITY_RESPONSE} = "RFLASH_UPDATE_CHECK_STATE_REQUEST";
-            $next_status{RFLASH_UPDATE_CHECK_STATE_REQUEST} = "RFLASH_UPDATE_CHECK_STATE_RESPONSE";
             $next_status{RFLASH_UPDATE_CHECK_STATE_RESPONSE} = "RPOWER_BMCREBOOT_REQUEST";
             $next_status{RPOWER_BMCREBOOT_REQUEST} = "RPOWER_RESET_RESPONSE";
             $status_info{RPOWER_RESET_RESPONSE}{argv} = "bmcreboot";
@@ -2132,7 +2131,7 @@ sub deal_with_response {
             $wait_node_num--;
             return;    
         }
-        if (defined $status_info{RPOWER_BMC_STATUS_RESPONSE}{argv} and $status_info{RPOWER_BMC_STATUS_RESPONSE}{argv} =~ /bmcstate$/) {
+        if ($node_info{$node}{cur_status} eq "RPOWER_BMC_STATUS_RESPONSE" and defined $status_info{RPOWER_BMC_STATUS_RESPONSE}{argv} and $status_info{RPOWER_BMC_STATUS_RESPONSE}{argv} =~ /bmcstate$/) {
             retry_check_times($node, "RPOWER_BMC_STATUS_REQUEST", "bmc_conn_check_times", $::BMC_CHECK_INTERVAL, $response->status_line);
             return;
         }   
@@ -3795,8 +3794,15 @@ sub rflash_response {
             }
         }
     }
-    if ($node_info{$node}{cur_status} eq "RFLASH_UPDATE_ACTIVATE_RESPONSE" or $node_info{$node}{cur_status} eq "RFLASH_UPDATE_HOST_ACTIVATE_RESPONSE") {
-        my $flash_started_msg = "rflash started, please wait...";
+    if ($node_info{$node}{cur_status} eq "RFLASH_UPDATE_ACTIVATE_RESPONSE") {
+        my $flash_started_msg = "rflash $::UPLOAD_FILE_VERSION started, please wait...";
+        if ($::VERBOSE) {
+            xCAT::SvrUtils::sendmsg("$flash_started_msg", $callback, $node);
+        }
+        print RFLASH_LOG_FILE_HANDLE "$flash_started_msg\n";
+    }
+    if ($node_info{$node}{cur_status} eq "RFLASH_UPDATE_HOST_ACTIVATE_RESPONSE") {
+        my $flash_started_msg = "rflash $::UPLOAD_PNOR_VERSION started, please wait...";
         if ($::VERBOSE) {
             xCAT::SvrUtils::sendmsg("$flash_started_msg", $callback, $node);
         }


### PR DESCRIPTION
for #4550 
enhanced 2 part:
1, During BMC response is not 200, find the correct machine status
2, duplicate message in verbose “rflash started, please wait...“

UT:
1, For #4550, I made a fake updateid which can cause response is not 200, before code fix, can reproduce the issue 
```
[root@briggs01 910.1746.20171215a]# rflash mid05tor12cn18 -d /mnt/xcat/iso/openbmc/910.1746.20171215a/ --no-host-reboot
Attempting to upload /mnt/xcat/iso/openbmc/910.1746.20171215a/obmc-phosphor-image-witherspoon.ubi.mtd.tar and /mnt/xcat/iso/openbmc/910.1746.20171215a/witherspoon.pnor.squashfs.tar, please wait...
mid05tor12cn18: Firmware upload successful. Attempting to activate firmware: ibm-v2.0-0-r21-0-ge3cbb5a (ID: e3b2aba5)
mid05tor12cn18: Firmware upload successful. Attempting to activate firmware: IBM-witherspoon-ibm-OP9_v1.19_1.98 (ID: 20ec75fe)
mid05tor12cn18: Retry BMC state, wait for 15 seconds ...
mid05tor12cn18: BMC Ready
```
After code fix, the result is 
```
[root@briggs01 910.1746.20171215a]# rflash mid05tor12cn18 -d /mnt/xcat/iso/openbmc/910.1746.20171215a/ --verbose
Attempting to upload /mnt/xcat/iso/openbmc/910.1746.20171215a/obmc-phosphor-image-witherspoon.ubi.mtd.tar and /mnt/xcat/iso/openbmc/910.1746.20171215a/witherspoon.pnor.squashfs.tar, please wait...
mid05tor12cn18: Uploading /mnt/xcat/iso/openbmc/910.1746.20171215a/obmc-phosphor-image-witherspoon.ubi.mtd.tar ...
mid05tor12cn18: Uploading /mnt/xcat/iso/openbmc/910.1746.20171215a/witherspoon.pnor.squashfs.tar ...
mid05tor12cn18: Uploading /mnt/xcat/iso/openbmc/910.1746.20171215a/obmc-phosphor-image-witherspoon.ubi.mtd.tar ...
mid05tor12cn18: Uploading /mnt/xcat/iso/openbmc/910.1746.20171215a/witherspoon.pnor.squashfs.tar ...
mid05tor12cn18: Firmware upload successful. Attempting to activate firmware: ibm-v2.0-0-r21-0-ge3cbb5a (ID: e3b2aba5)
mid05tor12cn18: Firmware upload successful. Attempting to activate firmware: IBM-witherspoon-ibm-OP9_v1.19_1.98 (ID: 20ec75fe)
mid05tor12cn18: Error: Invalid ID provided to activate. Use the -l option to view valid firmware IDs.
```

2. Duplicate message before code fix:
```
mid05tor12cn18: rflash started, please wait...
mid05tor12cn18: rflash started, please wait...
```
After fix:
```
mid05tor12cn18: rflash ibm-v2.0-0-r21-0-ge3cbb5a started, please wait...
mid05tor12cn18: rflash IBM-witherspoon-ibm-OP9_v1.19_1.98 started, please wait...
```
3.
The regression test result for normal case:
```
 [root@briggs01 xCAT_plugin]# rflash mid05tor12cn18 -d /mnt/xcat/iso/openbmc/910.1746.20171215a/ --verbose
Attempting to upload /mnt/xcat/iso/openbmc/910.1746.20171215a/obmc-phosphor-image-witherspoon.ubi.mtd.tar and /mnt/xcat/iso/openbmc/910.1746.20171215a/witherspoon.pnor.squashfs.tar, please wait...
mid05tor12cn18: Uploading /mnt/xcat/iso/openbmc/910.1746.20171215a/obmc-phosphor-image-witherspoon.ubi.mtd.tar ...
mid05tor12cn18: Uploading /mnt/xcat/iso/openbmc/910.1746.20171215a/witherspoon.pnor.squashfs.tar ...
mid05tor12cn18: Uploading /mnt/xcat/iso/openbmc/910.1746.20171215a/obmc-phosphor-image-witherspoon.ubi.mtd.tar ...
mid05tor12cn18: Uploading /mnt/xcat/iso/openbmc/910.1746.20171215a/witherspoon.pnor.squashfs.tar ...
mid05tor12cn18: Firmware upload successful. Attempting to activate firmware: ibm-v2.0-0-r21-0-ge3cbb5a (ID: e3b2aba5)
mid05tor12cn18: Firmware upload successful. Attempting to activate firmware: IBM-witherspoon-ibm-OP9_v1.19_1.98 (ID: 20ec75fe)
mid05tor12cn18: rflash ibm-v2.0-0-r21-0-ge3cbb5a started, please wait...
mid05tor12cn18: rflash IBM-witherspoon-ibm-OP9_v1.19_1.98 started, please wait...
mid05tor12cn18: Activating Firmware IBM-witherspoon-ibm-OP9_v1.19_1.98...  10%
mid05tor12cn18: Activating Firmware IBM-witherspoon-ibm-OP9_v1.19_1.98...  10%
mid05tor12cn18: Activating Firmware IBM-witherspoon-ibm-OP9_v1.19_1.98...  10%
mid05tor12cn18: Activating Firmware IBM-witherspoon-ibm-OP9_v1.19_1.98...  10%
mid05tor12cn18: Activating Firmware IBM-witherspoon-ibm-OP9_v1.19_1.98...  10%
mid05tor12cn18: Activating Firmware ibm-v2.0-0-r21-0-ge3cbb5a...  30%
mid05tor12cn18: Activating Firmware ibm-v2.0-0-r21-0-ge3cbb5a...  30%
mid05tor12cn18: Activating Firmware ibm-v2.0-0-r21-0-ge3cbb5a...  30%
mid05tor12cn18: Firmware IBM-witherspoon-ibm-OP9_v1.19_1.98 activation successful.
mid05tor12cn18: Firmware ibm-v2.0-0-r21-0-ge3cbb5a activation successful.
mid05tor12cn18: BMC reboot
mid05tor12cn18: Retry BMC state, wait for 15 seconds ...
mid05tor12cn18: Retry BMC state, wait for 15 seconds ...
mid05tor12cn18: Retry BMC state, wait for 15 seconds ...
mid05tor12cn18: Retry BMC state, wait for 15 seconds ...
mid05tor12cn18: BMC Ready
mid05tor12cn18: reset
```
