### PR TITLE
Fix issues found while validating function to control of PowerSupplyRedundancy [DO NOT MERGE]

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -534,13 +534,13 @@ my %api_config_info = (
         type         => "boolean",
         subcommand   => "autoreboot",
     },
-    RSPCONFIG_POWERSUPPLY_REDUNDENCY => {
+    RSPCONFIG_POWER_SUPPLY_REDUNDANCY => {
         command      => "rspconfig",
         url          => "/sensors/chassis/PowerSupplyRedundancy",
-        attr_url     => "PowerSupplyRedundency",
-        display_name => "PowerSupplyRedundency",
+        attr_url     => "value",
+        display_name => "PowerSupplyRedundancy",
         type         => "boolean",
-        subcommand   => "powersupplyredundency",
+        subcommand   => "powersupplyredundancy",
     },
 );
 
@@ -1052,7 +1052,7 @@ sub parse_args {
         my $all_subcommand = "";
         foreach $subcommand (@ARGV) {
             $::RSPCONFIG_CONFIGURED_API_KEY = &is_valid_config_api($subcommand, $callback);
-            if ($::RSPCONFIG_CONFIGURED_API_KEY != -1) {
+            if ($::RSPCONFIG_CONFIGURED_API_KEY ne "-1") {
                 # subcommand defined in the configured API hash, return from here, the RSPCONFIG_CONFIGURED_API_KEY is the key into the hash
                 return;
             }
@@ -1426,7 +1426,7 @@ sub parse_command_status {
         my @options = ();
         my $num_subcommand = @$subcommands;
         #Setup chain to process the configured command
-        if ($::RSPCONFIG_CONFIGURED_API_KEY != -1) {
+        if ($::RSPCONFIG_CONFIGURED_API_KEY ne "-1") {
             $subcommand = $$subcommands[0];
             # Check if setting or quering
             if ($subcommand =~ /^(\w+)=(.*)/) {
@@ -3279,7 +3279,7 @@ sub rspconfig_api_config_response {
                         last;
                     }
                 }
-                if (scalar($value) >= 0) {
+                if (length $value >= 0) {
                     xCAT::SvrUtils::sendmsg($api_config_info{$::RSPCONFIG_CONFIGURED_API_KEY}{display_name} . ": $value", $callback, $node);
                 }
                 else {
@@ -4152,6 +4152,6 @@ sub is_valid_config_api {
             }
         }
     }
-    return -1;
+    return "-1";
 }
 1;


### PR DESCRIPTION
Resolves issues when validating #4435 

There is a side effect of this set/get function in that the defaults for this value is "Enable" 

```
+ curl -c cjar -b cjar -k -H 'Content-Type: application/json' -X GET https://172.11.139.5/xyz/openbmc_project/sensors/chassis/PowerSupplyRedundancy
{
  "data": {
    "error": 0,
    "units": "",
    "value": "Enabled"
  },
  "message": "200 OK",
  "status": "ok"
}
```

But when we run it through this code to get and set the value, we change this to boolean 0 and 1...

```
[root@briggs01 Sensors]# XCATBYPASS=1 rspconfig mid05tor12cn05 powersupplyredundancy
mid05tor12cn05: PowerSupplyRedundancy: Enabled
[root@briggs01 Sensors]# XCATBYPASS=1 rspconfig mid05tor12cn18 powersupplyredundancy
mid05tor12cn18: PowerSupplyRedundancy: 1
```

Opened issue: https://w3.rchland.ibm.com/projects/bestquest/?defect=SW411816 