### PR TITLE
Add support to resolve OpenBMC logging events to clear out faults

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1067,15 +1067,17 @@ sub parse_args {
             return ([ 1, "Unsupported command: $command $subcommand" ]);
         }
     } elsif ($command eq "reventlog") {
-        # 
-        # TODO, resolved should NOT be supported if range is provided 
-        #
         $subcommand = "all" if (!defined($ARGV[0]));
         if ($subcommand =~ /^(\w+)=(.*)/) {
             my $key = $1;
             my $value = $2;
             if (not $value) { 
                 return ([ 1, "$usage_errormsg $reventlog_no_id_resolved_errormsg" ]);
+            }
+
+            my $nodes_num = @$noderange;
+            if (@$noderange > 1) { 
+                xCAT::SvrUtils::sendmsg("WARN: Resolving faults over a xCAT noderange is not recommended.", $callback);
             }
 
             xCAT::SvrUtils::sendmsg("Attempting to resolve the following log entries: $value...", $callback);

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2890,7 +2890,7 @@ sub reventlog_response {
             xCAT::SvrUtils::sendmsg("Resolved $log_id.", $callback, $node);
         }
         my @entries = split (',', $status_info{REVENTLOG_RESOLVED_REQUEST}{argv} );
-        if (@entries) {
+        if ((scalar @entries) > 0) {
             my $log_id = shift @entries;
             $next_status{"REVENTLOG_RESOLVED_RESPONSE"} = "REVENTLOG_RESOLVED_REQUEST";
             $next_status{"REVENTLOG_RESOLVED_REQUEST"} = "REVENTLOG_RESOLVED_RESPONSE";
@@ -2900,6 +2900,10 @@ sub reventlog_response {
             # If a list is provided, set the remaining log entries back to status_info 
             my $remaining = join (',', @entries);
             $status_info{REVENTLOG_RESOLVED_REQUEST}{argv} = $remaining;
+        } else {
+            # Break out of this loop if there are no more IDs to resolve 
+            $wait_node_num--;
+            return;
         }
     } else {
         my $entry_string = $status_info{REVENTLOG_RESPONSE}{argv};

--- a/xCAT-test/autotest/testcase/UT_openbmc/reventlog_resolved_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/reventlog_resolved_cases0
@@ -1,0 +1,35 @@
+start:reventlog_resolved_parse_error1
+description: Do not pass in any logs to clear
+os:Linux
+hcp:openbmc
+cmd:reventlog $$CN resolved
+check:rc==1
+check:output=~Error: Usage error. Provide a comma separated
+end
+
+start:reventlog_resolved_parse_error2
+description: Do not pass in any logs to clear, include = sign
+os:Linux
+hcp:openbmc
+cmd:reventlog $$CN resolved=
+check:rc==1
+check:output=~Error: Usage error. Provide a comma separated
+end
+
+start:reventlog_resolved_parse_error3
+description: forgot the = sign
+os:Linux
+hcp:openbmc
+cmd:reventlog $$CN resolved 1,2,3
+check:rc==1
+check:output=~Error: Usage error. Provide a comma separated
+end
+
+start:reventlog_resolved_parse_error4
+description: Pass in a negative number
+os:Linux
+hcp:openbmc
+cmd:reventlog $$CN resolved=-1
+check:rc==1
+check:output=~Error: Invalid ID=
+end


### PR DESCRIPTION
Resolves Issue #4571 

Example of command: 
```
[root@briggs01 autotest]# XCATBYPASS=1 reventlog mid05tor12cn[16,17,18] resolved=27,28,29
WARN: Resolving faults over a xCAT noderange is not recommended.
Attempting to resolve the following log entries: 27,28,29...
mid05tor12cn17: Error: [500] Login to BMC failed: 500 Can't connect to 172.12.139.117:443 (No route to host).
mid05tor12cn17: Error: BMC did not respond. Validate BMC configuration and retry the command.
mid05tor12cn18: Error: Invalid ID=27 provided to resolved. [403 Forbidden]
mid05tor12cn16: Resolved 27.
mid05tor12cn16: Error: Invalid ID=28 provided to resolved. [403 Forbidden]
[root@briggs01 autotest]#
```

Success case: 

Take a look at entries 24-26, `Resolved: 0`.
```
[root@briggs01 autotest]# reventlog mid05tor12cn16 | egrep "\[24\]|\[25\]|\[26\]"
mid05tor12cn16: 12/07/2017 03:08:03 [24]: Firmware/Software Failure, (Warning) Unable to read the manifest file (AffectedSubsystem: Systems Management - Core / Virtual Appliance, PID: 1322), Resolved: 0
mid05tor12cn16: 12/18/2017 16:04:59 [25]: Unrecoverable Hardware Failure, (Critical) Power supply 1 input fault detected (AffectedSubsystem: Power, PID: 1412), Resolved: 0
mid05tor12cn16: 12/18/2017 16:05:15 [26]: Unrecoverable Hardware Failure, (Critical) Power supply 0 input fault detected (AffectedSubsystem: Power, PID: 1413), Resolved: 0
```

Resolve a single entry
```
[root@briggs01 autotest]# reventlog mid05tor12cn16 resolved=24
Attempting to resolve the following log entries: 24...
mid05tor12cn16: Resolved 24.

[root@briggs01 autotest]# reventlog mid05tor12cn16 | egrep "\[24\]|\[25\]|\[26\]"
mid05tor12cn16: 12/07/2017 03:08:03 [24]: Firmware/Software Failure, (Warning) Unable to read the manifest file (AffectedSubsystem: Systems Management - Core / Virtual Appliance, PID: 1322), Resolved: 1
mid05tor12cn16: 12/18/2017 16:04:59 [25]: Unrecoverable Hardware Failure, (Critical) Power supply 1 input fault detected (AffectedSubsystem: Power, PID: 1412), Resolved: 0
mid05tor12cn16: 12/18/2017 16:05:15 [26]: Unrecoverable Hardware Failure, (Critical) Power supply 0 input fault detected (AffectedSubsystem: Power, PID: 1413), Resolved: 0
```

Resolving multiple entries: (25,26)
```
[root@briggs01 autotest]# reventlog mid05tor12cn16 resolved=25,26
Attempting to resolve the following log entries: 25,26...
mid05tor12cn16: Resolved 25.
mid05tor12cn16: Resolved 26.
```

After they are changed to `Resolved: 1` 
```
[root@briggs01 autotest]# reventlog mid05tor12cn16 | egrep "\[24\]|\[25\]|\[26\]"
mid05tor12cn16: 12/07/2017 03:08:03 [24]: Firmware/Software Failure, (Warning) Unable to read the manifest file (AffectedSubsystem: Systems Management - Core / Virtual Appliance, PID: 1322), Resolved: 1
mid05tor12cn16: 12/18/2017 16:04:59 [25]: Unrecoverable Hardware Failure, (Critical) Power supply 1 input fault detected (AffectedSubsystem: Power, PID: 1412), Resolved: 1
mid05tor12cn16: 12/18/2017 16:05:15 [26]: Unrecoverable Hardware Failure, (Critical) Power supply 0 input fault detected (AffectedSubsystem: Power, PID: 1413), Resolved: 1
[root@briggs01 autotest]#
```
