### PR TITLE
Support rinv command for Intelligent PDU

### DIFF
--- a/perl-xCAT/xCAT/MacMap.pm
+++ b/perl-xCAT/xCAT/MacMap.pm
@@ -510,7 +510,7 @@ sub refresh_table {
         # if we are doing switch discovery and the node is not a switch, skip
         # if we are NOT doing switch discovery, and the node is a switch, skip
         my $ntype = $typehash->{$entry->{node}}->[0]->{nodetype};
-        if ( (($discover_switch) and ( $ntype ne "switch"))
+        if ( (($discover_switch) and ($ntype ne "switch") and ($ntype ne "pdu") )
             or ( !($discover_switch) and ( $ntype eq "switch")) ){
             xCAT::MsgUtils->trace(0, "d", "refresh_table: skip node=$entry->{node} switch=$entry->{switch} discover_switch=$discover_switch nodetype=$ntype\n");
             next;

--- a/perl-xCAT/xCAT/data/switchinfo.pm
+++ b/perl-xCAT/xCAT/data/switchinfo.pm
@@ -42,6 +42,8 @@ our %global_switch_type = (
     Cumulus => "onie",
     cumulus => "onie",
     Edgecore => "onie",
+    sLEN => "irpdu",
+    sIBM => "irpdu",
     coral => "crpdu"
 );
 

--- a/xCAT-server/lib/xcat/plugins/pdu.pm
+++ b/xCAT-server/lib/xcat/plugins/pdu.pm
@@ -953,10 +953,6 @@ sub rinv_for_irpdu
         $callback->({ errorcode => [1],error => "Couldn't connect to $pdu"});
         next;
     }
-    my $line = "**********************************************************";
-    xCAT::SvrUtils::sendmsg("$line", $callback,$pdu);
-    xCAT::SvrUtils::sendmsg("MFR Info List", $callback,$pdu);
-    xCAT::SvrUtils::sendmsg("$line", $callback,$pdu);
     #ibmPduSoftwareVersion
     $output = $session->get(".1.3.6.1.4.1.2.6.223.7.3.0");
     if ($output) {
@@ -992,7 +988,6 @@ sub rinv_for_irpdu
     if ($output) {
         xCAT::SvrUtils::sendmsg("PDU Description: $output", $callback,$pdu);
     }
-    xCAT::SvrUtils::sendmsg("$line", $callback,$pdu);
 
 }
 

--- a/xCAT-server/lib/xcat/plugins/pdu.pm
+++ b/xCAT-server/lib/xcat/plugins/pdu.pm
@@ -913,7 +913,7 @@ sub showMFR {
 
     foreach my $pdu (@$noderange) {
         unless ($pduhash->{$pdu}->[0]->{pdutype} eq "crpdu") {
-            xCAT::SvrUtils::sendmsg("This command only supports CONSTELLATION PDU with pdutype=crpdu", $callback,$pdu);
+            rinv_for_irpdu($pdu, $callback);
             next;
         }
 
@@ -941,6 +941,61 @@ sub showMFR {
         $exp->hard_close();
     }
 }
+
+sub rinv_for_irpdu
+{
+    my $pdu = shift;
+    my $callback = shift;
+    my $output;
+
+    my $session = connectTopdu($pdu,$callback);
+    if (!$session) {
+        $callback->({ errorcode => [1],error => "Couldn't connect to $pdu"});
+        next;
+    }
+    my $line = "**********************************************************";
+    xCAT::SvrUtils::sendmsg("$line", $callback,$pdu);
+    xCAT::SvrUtils::sendmsg("MFR Info List", $callback,$pdu);
+    xCAT::SvrUtils::sendmsg("$line", $callback,$pdu);
+    #ibmPduSoftwareVersion
+    $output = $session->get(".1.3.6.1.4.1.2.6.223.7.3.0");
+    if ($output) {
+        xCAT::SvrUtils::sendmsg("PDU Software Version: $output", $callback,$pdu);
+    }
+    #ibmPduMachineType
+    $output = $session->get(".1.3.6.1.4.1.2.6.223.7.4.0");
+    if ($output) {
+        xCAT::SvrUtils::sendmsg("PDU Machine Type: $output", $callback,$pdu);
+    }
+    #ibmPduModelNumber
+    $output = $session->get(".1.3.6.1.4.1.2.6.223.7.5.0");
+    if ($output) {
+        xCAT::SvrUtils::sendmsg("PDU Model Number: $output", $callback,$pdu);
+    }
+    #ibmPduPartNumber
+    $output = $session->get(".1.3.6.1.4.1.2.6.223.7.6.0");
+    if ($output) {
+        xCAT::SvrUtils::sendmsg("PDU Part Number: $output", $callback,$pdu);
+    }
+    #ibmPduName
+    $output = $session->get(".1.3.6.1.4.1.2.6.223.7.7.0");
+    if ($output) {
+        xCAT::SvrUtils::sendmsg("PDU Name: $output", $callback,$pdu);
+    }
+    #ibmPduSerialNumber
+    $output = $session->get(".1.3.6.1.4.1.2.6.223.7.9.0");
+    if ($output) {
+        xCAT::SvrUtils::sendmsg("PDU Serial Number: $output", $callback,$pdu);
+    }
+    #ibmPduDescription
+    $output = $session->get(".1.3.6.1.4.1.2.6.223.7.10.0");
+    if ($output) {
+        xCAT::SvrUtils::sendmsg("PDU Description: $output", $callback,$pdu);
+    }
+    xCAT::SvrUtils::sendmsg("$line", $callback,$pdu);
+
+}
+
 
 
 #-------------------------------------------------------


### PR DESCRIPTION
Add code to support pdudiscover and rinv command for Intelligent PDU
```
# pdudiscover --range 172.21.253.104-105
Discovering pdu using snmpwalk for 172.21.253.104-105 .....
ip              name                    vendor                                                  mac
------------    ------------            ------------                                            ------------
172.21.253.104  IBM PDU                 IBM PDU 46W1608(46M4003) OPDP_sIBM_v01.3_2 FreeRTOS_4.2.1 Lwip_1.2.0    00:18:23:05:84:0e
172.21.253.105  IBM PDU-001823058410    IBM PDU 46W1608(46M4003) OPDP_sIBM_v01.3_2 FreeRTOS_4.2.1 Lwip_1.2.0    00:18:23:05:84:10
pdu discovered and matched: IBM PDU to f6pdu15
pdu discovered and matched: IBM PDU-001823058410 to f6pdu16
````

Currently, we are support following info for rinv command.  we can add more based on users request.
````
# rinv f6pdu15
f6pdu15: **********************************************************
f6pdu15: MFR Info List
f6pdu15: **********************************************************
f6pdu15: PDU Software Version: "OPDP_sIBM_v01.3_2"
f6pdu15: PDU Machine Type: "1U"
f6pdu15: PDU Model Number: "dPDU4230"
f6pdu15: PDU Part Number: "46W1608"
f6pdu15: PDU Name: "IBM PDU"
f6pdu15: PDU Serial Number: "4571S5"
f6pdu15: PDU Description: "description"
f6pdu15: **********************************************************
````