### PR TITLE
fix issue 'lskmodules' cannot list the kernel modules #4575

### DIFF
--- a/xCAT-server/lib/xcat/plugins/kmodules.pm
+++ b/xCAT-server/lib/xcat/plugins/kmodules.pm
@@ -620,7 +620,7 @@ sub mods_in_rpm {
                 rmtree($tmp_path);
                 return; }
         } else {
-            if (system("cd $tmp_path; rpm2cpio $krpm | cpio -idum *.ko > /dev/null 2>&1 ; cd - > /dev/null 2>&1")) {
+            if (system("cd $tmp_path; rpm2cpio $krpm | cpio -idum  > /dev/null 2>&1 ; cd - > /dev/null 2>&1")) {
                 my $rsp;
                 push @{ $rsp->{data} }, "Unable to extract files from the rpm $krpm.";
                 xCAT::MsgUtils->message("E", $rsp, $::CALLBACK);
@@ -636,7 +636,7 @@ sub mods_in_rpm {
         return;
     }
 
-    my @ko_files = `find $tmp_path -name *.ko`;
+    my @ko_files = `find $tmp_path -regextype posix-egrep  -regex ".*/*\.ko(\.xz)?"`;
     foreach my $ko (@ko_files) {
         my %mod;
         chomp($ko);
@@ -650,7 +650,6 @@ sub mods_in_rpm {
         $mod{description} = $desc;
         push(@modlist, \%mod);
     }
-
     rmtree($tmp_path);
 
     return @modlist;

--- a/xCAT-test/autotest/testcase/copycds/cases0
+++ b/xCAT-test/autotest/testcase/copycds/cases0
@@ -10,6 +10,13 @@ cmd:ls /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__
 check:rc==0
 end
 
+start:lskmodules_o
+cmd:lskmodules -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__
+check:rc==0
+check:output=~.ko(.xz):
+end
+
+
 start:copycds_n
 os:Linux
 #cmd:umount /mnt/xca


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/4575
added test case for `lskmodules  -o`

in rhels7.4-x86_64, the kernel files insider the kernel-*.rpm files are compressed file with postfix "*.ko.xz" 

UT:
````
~:lskmodules -o rhels7.4-x86_64
...
parport_pc.ko.xz: PC-style parallel port driver
parport_serial.ko.xz: Driver for common parallel+serial multi-I/O PCI cards
pata_acpi.ko.xz: SCSI low-level driver for ATA in ACPI mode
pata_ali.ko.xz: low-level driver for ALi PATA
pata_amd.ko.xz: low-level driver for AMD and Nvidia PATA IDE
pata_arasan_cf.ko.xz: Arasan ATA Compact Flash driver
pata_artop.ko.xz: SCSI low-level driver for ARTOP PATA
pata_atiixp.ko.xz: low-level driver for ATI IXP200/300/400
pata_atp867x.ko.xz: low level driver for Artop/Acard 867x ATA controller
pata_cmd64x.ko.xz: low-level driver for CMD64x series PATA controllers
pata_cs5536.ko.xz: low-level driver for the CS5536 IDE controller
pata_hpt366.ko.xz: low-level driver for the Highpoint HPT366/368
pata_hpt37x.ko.xz: low-level driver for the Highpoint HPT37x/30x
pata_hpt3x2n.ko.xz: low-level driver for the Highpoint HPT3xxN
pata_hpt3x3.ko.xz: low-level driver for the Highpoint HPT343/363
pata_it8213.ko.xz: SCSI low-level driver for the ITE 8213
pata_it821x.ko.xz: low-level driver for the IT8211/IT8212 IDE RAID controller
pata_jmicron.ko.xz: SCSI low-level driver for Jmicron PATA ports
pata_marvell.ko.xz: SCSI low-level driver for Marvell ATA in legacy mode
pata_netcell.ko.xz: SCSI low-level driver for Netcell PATA RAID
pata_ninja32.ko.xz: low-level driver for Ninja32 ATA
pata_oldpiix.ko.xz: SCSI low-level driver for early PIIX series controllers
pata_pdc2027x.ko.xz: libata driver module for Promise PDC20268 to PDC20277
pata_pdc202xx_old.ko.xz: low-level driver for Promise 2024x and 20262-20267
pata_piccolo.ko.xz: Low level driver for Toshiba Piccolo ATA
pata_rdc.ko.xz: SCSI low-level driver for RDC PATA controllers
pata_sch.ko.xz: SCSI low-level driver for Intel SCH PATA controllers
pata_serverworks.ko.xz: low-level driver for Serverworks OSB4/CSB5/CSB6
pata_sil680.ko.xz: low-level driver for SI680 PATA
pata_sis.ko.xz: SCSI low-level driver for SiS ATA
pata_via.ko.xz: low-level driver for VIA PATA
pc87360.ko.xz: PC8736x hardware monitor
pc87427.ko.xz: PC87427 hardware monitoring driver
pcbc.ko.xz: PCBC block cipher algorithm
pcc-cpufreq.ko.xz: Processor Clocking Control interface driver
pcf8591.ko.xz: PCF8591 driver
pch_dma.ko.xz: Intel EG20T PCH / LAPIS Semicon ML7213/ML7223/ML7831 IOH DMA controller driver
pch_gbe.ko.xz: EG20T PCH Gigabit ethernet Driver
pch_phub.ko.xz: Intel EG20T PCH/LAPIS Semiconductor IOH(ML7213/ML7223) PHUB
pci-hyperv.ko.xz: Hyper-V PCI
pcnet32.ko.xz: Driver for PCnet32 and PCnetPCI based ethercards
pcrypt.ko.xz: Parallel crypto wrapper
pcspkr.ko.xz: PC Speaker beeper driver
pcwd_pci.ko.xz: Berkshire PCI-PC Watchdog driver
pcwd_usb.ko.xz: Berkshire USB-PC Watchdog driver
pdc_adma.ko.xz: Pacific Digital Corporation ADMA low-level driver
peak_pci.ko.xz: Socket-CAN driver for PEAK PCAN PCI family cards
peak_usb.ko.xz: CAN driver for PEAK-System USB adapters
pegasus.ko.xz: Pegasus/Pegasus II USB Ethernet driver
pinctrl-amd.ko.xz: AMD GPIO pinctrl driver
pktcdvd.ko.xz: Packet writing layer for CD/DVD drives
pktgen.ko.xz: Packet Generator tool
pl2303.ko.xz: Prolific PL2303 USB to serial adaptor driver
platform_lcd.ko.xz:
plusb.ko.xz: Prolific PL-2301/2302/25A1 USB Host to Host Link Driver
pluto2.ko.xz: Pluto2 driver
plx_pci.ko.xz: Socket-CAN driver for PLX90xx PCI-bridge cards with the SJA1000 chips
pm80xx.ko.xz: PMC-Sierra PM8001/8081/8088/8089/8074/8076/8077 SAS/SATA controller driver
pmbus.ko.xz: Generic PMBus driver
pmbus_core.ko.xz: PMBus core driver
pmcraid.ko.xz: PMC Sierra MaxRAID Controller Driver
poseidon.ko.xz: For tlg2300-based USB device
powermate.ko.xz: Griffin Technology, Inc PowerMate driver
powernow-k8.ko.xz: AMD Athlon 64 and Opteron processor frequency driver.
ppdev.ko.xz:
ppp_async.ko.xz:
ppp_deflate.ko.xz:
ppp_generic.ko.xz:
ppp_mppe.ko.xz: Point-to-Point Protocol Microsoft Point-to-Point Encryption support
ppp_synctty.ko.xz:
pppoatm.ko.xz: RFC2364 PPP over ATM/AAL5
pppoe.ko.xz: PPP over Ethernet driver
pppox.ko.xz: PPP over Ethernet driver (generic socket layer)
pps-gpio.ko.xz: Use GPIO pin as PPS source
pps-ldisc.ko.xz: PPS TTY device driver
pps_core.ko.xz: LinuxPPS support (RFC 2783) - ver. 5.3.6
pps_parport.ko.xz: parallel port PPS client
pptp.ko.xz: Point-to-Point Tunneling Protocol
psnap.ko.xz:
ptp.ko.xz: PTP clocks support
ptp_kvm.ko.xz: PTP clock using KVMCLOCK
ptp_pch.ko.xz: PTP clock using the EG20T timer
pvrusb2.ko.xz: Hauppauge WinTV-PVR-USB2 MPEG2 Encoder/Tuner
pwc.ko.xz: Philips & OEM USB webcam driver
pwm-lpss.ko.xz: PWM driver for Intel LPSS
qat_c3xxx.ko.xz: Intel(R) QuickAssist Technology
qat_c3xxxvf.ko.xz: Intel(R) QuickAssist Technology
qat_c62x.ko.xz: Intel(R) QuickAssist Technology
qat_c62xvf.ko.xz: Intel(R) QuickAssist Technology
qat_dh895xcc.ko.xz: Intel(R) QuickAssist Technology
qat_dh895xccvf.ko.xz: Intel(R) QuickAssist Technology
qcaux.ko.xz:
qcserial.ko.xz: Qualcomm USB Serial driver
qed.ko.xz: QLogic FastLinQ 4xxxx Core Module
qede.ko.xz: QLogic FastLinQ 4xxxx Ethernet Driver
qedf.ko.xz: QLogic QEDF 25/40/50/100Gb FCoE Driver
qedi.ko.xz: QLogic FastLinQ 4xxxx iSCSI Module
qedr.ko.xz: QLogic 40G/100G ROCE Driver
qla2xxx.ko.xz: QLogic Fibre Channel HBA Driver
qla3xxx.ko.xz: QLogic ISP3XXX Network Driver v2.03.00-k5
qla4xxx.ko.xz: QLogic iSCSI HBA Driver
qlcnic.ko.xz: QLogic 1/10 GbE Converged/Intelligent Ethernet Driver
qlge.ko.xz: QLogic 10 Gigabit PCI-E Ethernet Driver
qmi_wwan.ko.xz: Qualcomm MSM Interface (QMI) WWAN driver
qsemi.ko.xz: Quality Semiconductor PHY driver
qt1010.ko.xz: Quantek QT1010 silicon tuner driver
quatech2.ko.xz: Quatech 2nd gen USB to Serial Driver
qxl.ko.xz: RH QXL
r592.ko.xz: Ricoh R5C592 Memstick/Memstick PRO card reader driver
r8152.ko.xz: Realtek RTL8152/RTL8153 Based USB Ethernet Adapters
r8169.ko.xz: RealTek RTL-8169 Gigabit Ethernet driver
r8192e_pci.ko.xz: Linux driver for Realtek RTL819x WiFi cards
r820t.ko.xz: Rafael Micro r820t silicon tuner driver
r8712u.ko.xz: rtl871x wireless lan driver
radeon.ko.xz: ATI Radeon
raid0.ko.xz: RAID0 (striping) personality for MD
raid1.ko.xz: RAID1 (mirroring) personality for MD
raid10.ko.xz: RAID10 (striped mirror) personality for MD
raid456.ko.xz: RAID4/5/6 (striping with parity) personality for MD
raid6_pq.ko.xz: RAID6 Q-syndrome calculations
raid6test.ko.xz: asynchronous RAID-6 recovery self tests
raid_class.ko.xz: RAID device class
ramoops.ko.xz: RAM Oops/Panic logger/driver
rbd.ko.xz: RADOS Block Device (RBD) driver
rc-adstech-dvb-t-pci.ko.xz:
rc-alink-dtu-m.ko.xz:
rc-anysee.ko.xz:
rc-apac-viewcomp.ko.xz:
rc-asus-pc39.ko.xz:
rc-asus-ps3-100.ko.xz:
rc-ati-tv-wonder-hd-600.ko.xz:
rc-ati-x10.ko.xz:
rc-avermedia-a16d.ko.xz:
rc-avermedia-cardbus.ko.xz:
rc-avermedia-dvbt.ko.xz:
rc-avermedia-m135a.ko.xz:
rc-avermedia-m733a-rm-k6.ko.xz:
rc-avermedia-rm-ks.ko.xz:
rc-avermedia.ko.xz:
rc-avertv-303.ko.xz:
rc-azurewave-ad-tu700.ko.xz:
rc-behold-columbus.ko.xz:
rc-behold.ko.xz:
rc-budget-ci-old.ko.xz:
rc-cinergy-1400.ko.xz:
rc-cinergy.ko.xz:
rc-core.ko.xz:
rc-dib0700-nec.ko.xz:
rc-dib0700-rc5.ko.xz:
rc-digitalnow-tinytwin.ko.xz:
rc-digittrade.ko.xz:
rc-dm1105-nec.ko.xz:
rc-dntv-live-dvb-t.ko.xz:
rc-dntv-live-dvbt-pro.ko.xz:
rc-em-terratec.ko.xz:
rc-encore-enltv-fm53.ko.xz:
rc-encore-enltv.ko.xz:
rc-encore-enltv2.ko.xz:
rc-evga-indtube.ko.xz:
rc-eztv.ko.xz:
rc-flydvb.ko.xz:
rc-flyvideo.ko.xz:
rc-fusionhdtv-mce.ko.xz:
rc-gadmei-rm008z.ko.xz:
rc-genius-tvgo-a11mce.ko.xz:
rc-gotview7135.ko.xz:
rc-hauppauge.ko.xz:
rc-imon-mce.ko.xz:
rc-imon-pad.ko.xz:
rc-iodata-bctv7e.ko.xz:
rc-it913x-v1.ko.xz:
rc-it913x-v2.ko.xz:
rc-kaiomy.ko.xz:
rc-kworld-315u.ko.xz:
rc-kworld-pc150u.ko.xz:
rc-kworld-plus-tv-analog.ko.xz:
rc-leadtek-y04g0051.ko.xz:
rc-lirc.ko.xz:
rc-lme2510.ko.xz:
rc-loopback.ko.xz: Loopback device for rc-core debugging
rc-manli.ko.xz:
rc-medion-x10-digitainer.ko.xz: Medion X10 RF remote keytable (Digitainer variant)
rc-medion-x10-or2x.ko.xz: Medion X10 OR22/OR24 RF remote keytable
rc-medion-x10.ko.xz:
rc-msi-digivox-ii.ko.xz:
rc-msi-digivox-iii.ko.xz:
rc-msi-tvanywhere-plus.ko.xz:
rc-msi-tvanywhere.ko.xz:
rc-nebula.ko.xz:
rc-nec-terratec-cinergy-xs.ko.xz:
rc-norwood.ko.xz:
rc-npgtech.ko.xz:
rc-pctv-sedna.ko.xz:
rc-pinnacle-color.ko.xz:
rc-pinnacle-grey.ko.xz:
rc-pinnacle-pctv-hd.ko.xz:
rc-pixelview-002t.ko.xz:
rc-pixelview-mk12.ko.xz:
rc-pixelview-new.ko.xz:
rc-pixelview.ko.xz:
rc-powercolor-real-angel.ko.xz:
rc-proteus-2309.ko.xz:
rc-purpletv.ko.xz:
rc-pv951.ko.xz:
rc-rc6-mce.ko.xz:
rc-real-audio-220-32-keys.ko.xz:
rc-reddo.ko.xz:
rc-snapstream-firefly.ko.xz:
rc-streamzap.ko.xz:
rc-tbs-nec.ko.xz:
rc-technisat-usb2.ko.xz:
rc-terratec-cinergy-xs.ko.xz:
rc-terratec-slim-2.ko.xz:
rc-terratec-slim.ko.xz:
rc-tevii-nec.ko.xz:
rc-tivo.ko.xz:
rc-total-media-in-hand-02.ko.xz:
rc-total-media-in-hand.ko.xz:
rc-trekstor.ko.xz:
rc-tt-1500.ko.xz:
rc-twinhan1027.ko.xz:
rc-videomate-m1f.ko.xz:
rc-videomate-s350.ko.xz:
rc-videomate-tv-pvr.ko.xz:
rc-winfast-usbii-deluxe.ko.xz:
rc-winfast.ko.xz:
rdma_cm.ko.xz: Generic RDMA CM Agent
rdma_rxe.ko.xz: Soft RDMA transport
rdma_ucm.ko.xz: RDMA Userspace Connection Manager Access
rdmavt.ko.xz: RDMA Verbs Transport Library
realtek.ko.xz: Realtek PHY driver
redrat3.ko.xz: RedRat3 USB IR Transceiver Driver
reed_solomon.ko.xz: Reed Solomon encoder/decoder
regmap-i2c.ko.xz:
regmap-spi.ko.xz:
rfcomm.ko.xz: Bluetooth RFCOMM ver 1.11
rfkill.ko.xz: RF switch support
ring_buffer_benchmark.ko.xz: ring_buffer_benchmark
rmd128.ko.xz: RIPEMD-128 Message Digest
rmd160.ko.xz: RIPEMD-160 Message Digest
rmd256.ko.xz: RIPEMD-256 Message Digest
rmd320.ko.xz: RIPEMD-320 Message Digest
rndis_host.ko.xz: USB Host side RNDIS driver
rocker.ko.xz: Rocker switch device driver
rotary_encoder.ko.xz: GPIO rotary encoder driver
rpcrdma.ko.xz: RPC/RDMA Transport
rpcsec_gss_krb5.ko.xz:
rsa_generic.ko.xz: RSA generic algorithm
rt2800lib.ko.xz: Ralink RT2800 library
rt2800mmio.ko.xz: rt2800 MMIO library
rt2800pci.ko.xz: Ralink RT2800 PCI & PCMCIA Wireless LAN driver.
rt2800usb.ko.xz: Ralink RT2800 USB Wireless LAN driver.
rt2x00lib.ko.xz: rt2x00 library
rt2x00mmio.ko.xz: rt2x00 mmio library
rt2x00pci.ko.xz: rt2x00 pci library
rt2x00usb.ko.xz: rt2x00 usb library
rt61pci.ko.xz: Ralink RT61 PCI & PCMCIA Wireless LAN driver.
rt73usb.ko.xz: Ralink RT73 USB Wireless LAN driver.
rtc-bq32k.ko.xz: TI BQ32000 I2C RTC driver
rtc-bq4802.ko.xz: TI BQ4802 RTC driver
rtc-ds1286.ko.xz: DS1286 RTC driver
rtc-ds1307.ko.xz: RTC driver for DS1307 and similar chips
rtc-ds1374.ko.xz: Maxim/Dallas DS1374 RTC Driver
rtc-ds1511.ko.xz: Dallas DS1511 RTC driver
rtc-ds1553.ko.xz: Dallas DS1553 RTC driver
rtc-ds1672.ko.xz: Dallas/Maxim DS1672 timekeeper driver
rtc-ds1742.ko.xz: Dallas DS1742 RTC driver
rtc-ds2404.ko.xz: DS2404 RTC
rtc-ds3232.ko.xz: Maxim/Dallas DS3232 RTC Driver
rtc-em3027.ko.xz: EM Microelectronic EM3027 RTC driver
rtc-fm3130.ko.xz: RTC driver for FM3130
rtc-isl12022.ko.xz: ISL 12022 RTC driver
rtc-isl1208.ko.xz: Intersil ISL1208 RTC driver
rtc-m41t80.ko.xz: ST Microelectronics M41T80 series RTC I2C Client Driver
rtc-m48t35.ko.xz: M48T35 RTC driver
rtc-m48t59.ko.xz: M48T59/M48T02/M48T08 RTC driver
rtc-max6900.ko.xz: Maxim MAX6900 RTC driver
rtc-msm6242.ko.xz: Oki MSM6242 RTC driver
rtc-pcf8523.ko.xz: NXP PCF8523 RTC driver
rtc-pcf8563.ko.xz: Philips PCF8563/Epson RTC8564 RTC driver
rtc-pcf8583.ko.xz: PCF8583 I2C RTC driver
rtc-rp5c01.ko.xz: Ricoh RP5C01 RTC driver
rtc-rs5c372.ko.xz: Ricoh RS5C372 RTC driver
rtc-rv3029c2.ko.xz: Micro Crystal RV3029C2 RTC driver
rtc-rx4581.ko.xz: rx4581 spi RTC driver
rtc-rx8025.ko.xz: RX-8025 SA/NB RTC driver
rtc-rx8581.ko.xz: Epson RX-8581 RTC driver
rtc-stk17ta8.ko.xz: Simtek STK17TA8 RTC driver
rtc-v3020.ko.xz: V3020 RTC
rtc-x1205.ko.xz: Xicor/Intersil X1205 RTC driver
rtl2830.ko.xz: Realtek RTL2830 DVB-T demodulator driver
rtl2832.ko.xz: Realtek RTL2832 DVB-T demodulator driver
rtl8150.ko.xz: rtl8150 based usb-ethernet driver
rtl8187.ko.xz: RTL8187/RTL8187B USB wireless driver
rtl8188ee.ko.xz: Realtek 8188E 802.11n PCI wireless
rtl8192c-common.ko.xz: Realtek 8192C/8188C 802.11n PCI wireless
rtl8192ce.ko.xz: Realtek 8192C/8188C 802.11n PCI wireless
rtl8192cu.ko.xz: Realtek 8192C/8188C 802.11n USB wireless
rtl8192de.ko.xz: Realtek 8192DE 802.11n Dual Mac PCI wireless
rtl8192ee.ko.xz: Realtek 8192EE 802.11n PCI wireless
rtl8192se.ko.xz: Realtek 8192S/8191S 802.11n PCI wireless
rtl8723-common.ko.xz: Realtek RTL8723AE/RTL8723BE 802.11n PCI wireless common routines
rtl8723ae.ko.xz: Realtek 8723E 802.11n PCI wireless
rtl8723be.ko.xz: Realtek 8723BE 802.11n PCI wireless
rtl8821ae.ko.xz: Realtek 8821ae 802.11ac PCI wireless
rtl_pci.ko.xz: PCI basic driver for rtlwifi
rtl_usb.ko.xz: USB basic driver for rtlwifi
rtllib.ko.xz:
rtllib_crypt_ccmp.ko.xz:
rtllib_crypt_tkip.ko.xz:
rtllib_crypt_wep.ko.xz:
rtlwifi.ko.xz: Realtek 802.11n PCI wireless core
rtsx_pci.ko.xz: Realtek PCI-E Card Reader Driver
rtsx_pci_ms.ko.xz: Realtek PCI-E Memstick Card Host Driver
rtsx_pci_sdmmc.ko.xz: Realtek PCI-E SD/MMC Card Host Driver
rtsx_usb.ko.xz: Realtek USB Card Reader Driver
rtsx_usb_sdmmc.ko.xz: Realtek USB SD/MMC Card Host Driver
s2255drv.ko.xz: Sensoray 2255 Video for Linux driver
s5h1409.ko.xz: Samsung S5H1409 QAM-B/ATSC Demodulator driver
s5h1411.ko.xz: Samsung S5H1411 QAM-B/ATSC Demodulator driver
s5h1420.ko.xz: Samsung S5H1420/PnpNetwork PN1010 DVB-S Demodulator driver
s921.ko.xz: DVB Frontend module for Sharp S921 hardware
saa6588.ko.xz: v4l2 driver module for SAA6588 RDS decoder
saa6752hs.ko.xz: device driver for saa6752hs MPEG2 encoder
saa7115.ko.xz: Philips SAA7111/SAA7113/SAA7114/SAA7115/SAA7118 video decoder driver
saa7127.ko.xz: Philips SAA7127/9 video encoder driver
saa7134-alsa.ko.xz:
saa7134-dvb.ko.xz:
saa7134-empress.ko.xz:
saa7134.ko.xz: v4l2 driver module for saa7130/34 based TV cards
saa7146.ko.xz: driver for generic saa7146-based hardware
saa7146_vv.ko.xz: video4linux driver for saa7146-based hardware
saa7164.ko.xz: Driver for NXP SAA7164 based TV cards
saa717x.ko.xz: Philips SAA717x audio/video decoder driver
safe_serial.ko.xz: USB Safe Encapsulated Serial
salsa20-x86_64.ko.xz: Salsa20 stream cipher algorithm (optimized assembly version)
salsa20_generic.ko.xz: Salsa20 stream cipher algorithm
samsung-laptop.ko.xz: Samsung Backlight driver
samsung-q10.ko.xz: Samsung Q10 Driver
sata_mv.ko.xz: SCSI low-level driver for Marvell SATA controllers
sata_nv.ko.xz: low-level driver for NVIDIA nForce SATA controller
sata_promise.ko.xz: Promise ATA TX2/TX4/TX4000 low-level driver
sata_qstor.ko.xz: Pacific Digital Corporation QStor SATA low-level driver
sata_sil.ko.xz: low-level driver for Silicon Image SATA controller
sata_sil24.ko.xz: Silicon Image 3124/3132 SATA low-level driver
sata_sis.ko.xz: low-level driver for Silicon Integrated Systems SATA controller
sata_svw.ko.xz: low-level driver for K2 SATA controller
sata_sx4.ko.xz: Promise SATA low-level driver
sata_uli.ko.xz: low-level driver for ULi Electronics SATA controller
sata_via.ko.xz: SCSI low-level driver for VIA SATA controllers
sata_vsc.ko.xz: low-level driver for Vitesse VSC7174 SATA controller
sb_edac.ko.xz: MC Driver for Intel Sandy Bridge and Ivy Bridge memory controllers -  Ver: 1.1.1
sbc_fitpc2_wdt.ko.xz: SBC-FITPC2 Watchdog
sbs.ko.xz: Smart Battery System ACPI interface driver
sbshc.ko.xz: ACPI SMBus HC driver
sch311x_wdt.ko.xz: SMSC SCH311x WatchDog Timer Driver
sch5627.ko.xz: SMSC SCH5627 Hardware Monitoring Driver
sch5636.ko.xz: SMSC SCH5636 Hardware Monitoring Driver
sch56xx-common.ko.xz: SMSC SCH56xx Hardware Monitoring Common Code
sch_atm.ko.xz:
sch_cbq.ko.xz:
sch_choke.ko.xz:
sch_codel.ko.xz: Controlled Delay queue discipline
sch_drr.ko.xz:
sch_dsmark.ko.xz:
sch_fq.ko.xz:
sch_fq_codel.ko.xz:
sch_gred.ko.xz:
sch_hfsc.ko.xz:
sch_htb.ko.xz:
sch_ingress.ko.xz:
sch_mqprio.ko.xz:
sch_multiq.ko.xz:
sch_netem.ko.xz:
sch_plug.ko.xz:
sch_prio.ko.xz:
sch_qfq.ko.xz:
sch_red.ko.xz:
sch_sfb.ko.xz: Stochastic Fair Blue queue discipline
sch_sfq.ko.xz:
sch_tbf.ko.xz:
sch_teql.ko.xz:
scsi_debug.ko.xz: SCSI debug adapter driver
scsi_tgt.ko.xz: SCSI target core
scsi_transport_fc.ko.xz: FC Transport Attributes
scsi_transport_iscsi.ko.xz: iSCSI Transport Interface
scsi_transport_sas.ko.xz: SAS Transport Attributes
scsi_transport_spi.ko.xz: SPI Transport Attributes
scsi_transport_srp.ko.xz: SRP Transport Attributes
sctp.ko.xz: Support for the SCTP protocol (RFC2960)
sctp_diag.ko.xz:
sctp_probe.ko.xz: SCTP snooper
sd_mod.ko.xz: SCSI disk (sd) driver
sdhci-acpi.ko.xz: Secure Digital Host Controller Interface ACPI driver
sdhci-pci.ko.xz: Secure Digital Host Controller Interface PCI driver
sdhci-pltfm.ko.xz: SDHCI platform and OF driver helper
sdhci.ko.xz: Secure Digital Host Controller Interface core driver
sdio_uart.ko.xz:
seed.ko.xz: SEED Cipher Algorithm
ser_gigaset.ko.xz: Serial Driver for Gigaset 307x using Siemens M101
serio_raw.ko.xz: Raw serio driver
sermouse.ko.xz: Serial mouse driver
serpent-avx-x86_64.ko.xz: Serpent Cipher Algorithm, AVX optimized
serpent-avx2.ko.xz: Serpent Cipher Algorithm, AVX2 optimized
serpent-sse2-x86_64.ko.xz: Serpent Cipher Algorithm, SSE2 optimized
serpent_generic.ko.xz: Serpent and tnepres (kerneli compatible serpent reversed) Cipher Algorithm
ses.ko.xz: SCSI Enclosure Services (ses) driver
sfc-falcon.ko.xz: Solarflare Falcon network driver
sfc.ko.xz: Solarflare network driver
sg.ko.xz: SCSI generic (sg) driver
sha1-mb.ko.xz: SHA1 Secure Hash Algorithm, multi buffer accelerated
sha256-mb.ko.xz: SHA256 Secure Hash Algorithm, multi buffer accelerated
sha512-mb.ko.xz: SHA512 Secure Hash Algorithm, multi buffer accelerated
sha512-ssse3.ko.xz: SHA512 Secure Hash Algorithm, Supplemental SSE3 accelerated
sha512_generic.ko.xz: SHA-512 and SHA-384 Secure Hash Algorithms
shpchp.ko.xz: Standard Hot Plug PCI Controller Driver
sht15.ko.xz: Sensirion SHT15 temperature and humidity sensor driver
sht21.ko.xz: Sensirion SHT21 humidity and temperature sensor driver
si21xx.ko.xz: SL SI21XX DVB Demodulator driver
sierra.ko.xz: USB Driver for Sierra Wireless USB modems
sierra_net.ko.xz: USB-to-WWAN Driver for Sierra Wireless modems
sil164.ko.xz: Silicon Image sil164 TMDS transmitter driver
sis5595.ko.xz: SiS 5595 Sensor device
sisusbvga.ko.xz: sisusbvga - Driver for Net2280/SiS315-based USB2VGA dongles
sit.ko.xz:
sja1000.ko.xz: sja1000CAN netdevice driver
sja1000_platform.ko.xz: Socket-CAN driver for SJA1000 on the platform bus
skge.ko.xz: SysKonnect Gigabit Ethernet driver
skx_edac.ko.xz: MC Driver for Intel Skylake server processors
sky2.ko.xz: Marvell Yukon 2 Gigabit Ethernet driver
slcan.ko.xz: serial line CAN interface
slhc.ko.xz:
slip.ko.xz:
sm501.ko.xz: SM501 Core Driver
smartpqi.ko.xz: Driver for Microsemi Smart Family Controller version 0.9.14-100
smb347-charger.ko.xz: SMB347 battery charger driver
smsc.ko.xz: SMSC PHY driver
smsc47b397.ko.xz: SMSC LPC47B397 driver
smsc47m1.ko.xz: SMSC LPC47M1xx fan sensors driver
smsc47m192.ko.xz: SMSC47M192 driver
smsc75xx.ko.xz: SMSC75XX USB 2.0 Gigabit Ethernet Devices
smsc9420.ko.xz:
smsc95xx.ko.xz: SMSC95XX USB 2.0 Ethernet Devices
smsdvb.ko.xz: SMS DVB subsystem adaptation module
smsmdtv.ko.xz: Siano MDTV Core module
smssdio.ko.xz: Siano SMS1xxx SDIO driver
smsusb.ko.xz: Driver for the Siano SMS1xxx USB dongle
snd-ac97-codec.ko.xz: Universal interface for Audio Codec '97
snd-ad1889.ko.xz: Analog Devices AD1889 ALSA sound driver
snd-ak4113.ko.xz: AK4113 IEC958 (S/PDIF) receiver by Asahi Kasei
snd-ak4114.ko.xz: AK4114 IEC958 (S/PDIF) receiver by Asahi Kasei
snd-ak4xxx-adda.ko.xz: Routines for control of AK452x / AK43xx  AD/DA converters
snd-ali5451.ko.xz: ALI M5451
snd-aloop.ko.xz: A loopback soundcard
snd-asihpi.ko.xz: AudioScience ALSA ASI5xxx ASI6xxx ASI87xx ASI89xx 4.14.03
snd-atiixp-modem.ko.xz: ATI IXP MC97 controller
snd-atiixp.ko.xz: ATI IXP AC97 controller
snd-au8810.ko.xz: Aureal vortex
snd-au8820.ko.xz: Aureal vortex
snd-au8830.ko.xz: Aureal vortex
snd-bcd2000.ko.xz: Behringer BCD2000 driver
snd-bt87x.ko.xz: Brooktree Bt87x audio driver
snd-ca0106.ko.xz: CA0106
snd-cmipci.ko.xz: C-Media CMI8x38 PCI
snd-compress.ko.xz: ALSA Compressed offload framework
snd-cs46xx.ko.xz: Cirrus Logic Sound Fusion CS46XX
snd-cs8427.ko.xz: IEC958 (S/PDIF) receiver & transmitter by Cirrus Logic
snd-ctxfi.ko.xz: X-Fi driver version 1.03
snd-darla20.ko.xz: Echoaudio Darla20 soundcards driver
snd-darla24.ko.xz: Echoaudio Darla24 soundcards driver
snd-dummy.ko.xz: Dummy soundcard (/dev/null)
snd-echo3g.ko.xz: Echoaudio Echo3G soundcards driver
snd-emu10k1-synth.ko.xz: Routines for control of EMU10K1 WaveTable synth
snd-emu10k1.ko.xz: EMU10K1
snd-emu10k1x.ko.xz: EMU10K1X
snd-emux-synth.ko.xz: Routines for control of EMU WaveTable chip
snd-ens1370.ko.xz: Ensoniq AudioPCI ES1370
snd-ens1371.ko.xz: Ensoniq/Creative AudioPCI ES1371+
snd-es1968.ko.xz: ESS Maestro
snd-firewire-lib.ko.xz: FireWire audio helper functions
snd-firewire-speakers.ko.xz: FireWire speakers driver
snd-gina20.ko.xz: Echoaudio Gina20 soundcards driver
snd-gina24.ko.xz: Echoaudio Gina24 soundcards driver
snd-hda-codec-analog.ko.xz: Analog Devices HD-audio codec
snd-hda-codec-ca0110.ko.xz: Creative CA0110-IBG HD-audio codec
snd-hda-codec-ca0132.ko.xz: Creative Sound Core3D codec
snd-hda-codec-cirrus.ko.xz: Cirrus Logic HD-audio codec
snd-hda-codec-cmedia.ko.xz: C-Media HD-audio codec
snd-hda-codec-conexant.ko.xz: Conexant HD-audio codec
snd-hda-codec-generic.ko.xz: Generic HD-audio codec parser
snd-hda-codec-hdmi.ko.xz: HDMI HD-audio codec
snd-hda-codec-idt.ko.xz: IDT/Sigmatel HD-audio codec
snd-hda-codec-realtek.ko.xz: Realtek HD-audio codec
snd-hda-codec-si3054.ko.xz: Si3054 HD-audio modem codec
snd-hda-codec-via.ko.xz: VIA HD-audio codec
snd-hda-codec.ko.xz: HDA codec core
snd-hda-core.ko.xz: HD-audio bus
snd-hda-ext-core.ko.xz: HDA extended core
snd-hda-intel.ko.xz: Intel HDA driver
snd-hdsp.ko.xz: RME Hammerfall DSP
snd-hdspm.ko.xz: RME HDSPM
snd-hrtimer.ko.xz: ALSA hrtimer backend
snd-hwdep.ko.xz: Hardware dependent layer
snd-i2c.ko.xz: Generic i2c interface for ALSA
snd-ice1712.ko.xz: ICEnsemble ICE1712 (Envy24)
snd-ice1724.ko.xz: VIA ICEnsemble ICE1724/1720 (Envy24HT/PT)
snd-ice17xx-ak4xxx.ko.xz: ICEnsemble ICE17xx <-> AK4xxx AD/DA chip interface
snd-indigo.ko.xz: Echoaudio Indigo soundcards driver
snd-indigodj.ko.xz: Echoaudio Indigo DJ soundcards driver
snd-indigodjx.ko.xz: Echoaudio Indigo DJx soundcards driver
snd-indigoio.ko.xz: Echoaudio Indigo IO soundcards driver
snd-indigoiox.ko.xz: Echoaudio Indigo IOx soundcards driver
snd-intel-sst-acpi.ko.xz: Intel (R) SST(R) Audio Engine ACPI Driver
snd-intel-sst-core.ko.xz: Intel (R) SST(R) Audio Engine Driver
snd-intel8x0.ko.xz: Intel 82801AA,82901AB,i810,i820,i830,i840,i845,MX440; SiS 7012; Ali 5455
snd-intel8x0m.ko.xz: Intel 82801AA,82901AB,i810,i820,i830,i840,i845,MX440; SiS 7013; NVidia MCP/2/2S/3 modems
snd-isight.ko.xz: iSight audio driver
snd-korg1212.ko.xz: korg1212
snd-layla20.ko.xz: Echoaudio Layla20 soundcards driver
snd-layla24.ko.xz: Echoaudio Layla24 soundcards driver
snd-lola.ko.xz: Digigram Lola driver
snd-lx6464es.ko.xz: digigram lx6464es
snd-maestro3.ko.xz: ESS Maestro3 PCI
snd-mia.ko.xz: Echoaudio Mia soundcards driver
snd-mixart.ko.xz: Digigram miXart
snd-mona.ko.xz: Echoaudio Mona soundcards driver
snd-mpu401-uart.ko.xz: Routines for control of MPU-401 in UART mode
snd-mpu401.ko.xz: MPU-401 UART
snd-mtpav.ko.xz: MOTU MidiTimePiece AV multiport MIDI
snd-opl3-lib.ko.xz: Routines for control of AdLib FM cards (OPL2/OPL3/OPL4 chips)
snd-opl3-synth.ko.xz: ALSA driver for OPL3 FM synth
snd-oxygen-lib.ko.xz: C-Media CMI8788 helper library
snd-oxygen.ko.xz: C-Media CMI8788 driver
snd-pcm.ko.xz: Midlevel PCM code for ALSA.
snd-pcsp.ko.xz: PC-Speaker driver
snd-pcxhr.ko.xz: Digigram pcxhr 0.9.6
snd-pt2258.ko.xz: PT2258 volume controller (Princeton Technology Corp.)
snd-rawmidi.ko.xz: Midlevel RawMidi code for ALSA.
snd-rme32.ko.xz: RME Digi32, Digi32/8, Digi32 PRO
snd-rme96.ko.xz: RME Digi96, Digi96/8, Digi96/8 PRO, Digi96/8 PST, Digi96/8 PAD
snd-rme9652.ko.xz: RME Digi9652/Digi9636
snd-scs1x.ko.xz: SCS.1x MIDI driver
snd-seq-device.ko.xz: ALSA sequencer device management
snd-seq-dummy.ko.xz: ALSA sequencer MIDI-through client
snd-seq-midi-emul.ko.xz: Advanced Linux Sound Architecture sequencer MIDI emulation.
snd-seq-midi-event.ko.xz: MIDI byte <-> sequencer event coder
snd-seq-midi.ko.xz: Advanced Linux Sound Architecture sequencer MIDI synth.
snd-seq-oss.ko.xz: OSS-compatible sequencer module
snd-seq-virmidi.ko.xz: Virtual Raw MIDI client on Sequencer
snd-seq.ko.xz: Advanced Linux Sound Architecture sequencer.
snd-skl_nau88l25_max98357a.ko.xz: Audio Machine driver-NAU88L25 & MAX98357A in I2S mode
snd-soc-core.ko.xz: ALSA SoC Core
Dynamic Audio Power Management core for ALSA SoC
snd-soc-dmic.ko.xz: Generic DMIC driver
snd-soc-hdac-hdmi.ko.xz: HDMI HD codec
snd-soc-max98090.ko.xz: ALSA SoC MAX98090 driver
snd-soc-nau8825.ko.xz: ASoC nau8825 driver
snd-soc-rl6231.ko.xz: RL6231 class device shared support
snd-soc-rl6347a.ko.xz: RL6347A class device shared support
snd-soc-rt286.ko.xz: ASoC RT286 driver
snd-soc-rt5640.ko.xz: ASoC RT5640/RT5639 driver
snd-soc-rt5645.ko.xz: ASoC RT5645 driver
snd-soc-rt5651.ko.xz: ASoC RT5651 driver
snd-soc-rt5670.ko.xz: ASoC RT5670 driver
snd-soc-skl-ipc.ko.xz: Intel Skylake IPC driver
Intel Broxton IPC driver
snd-soc-skl.ko.xz: Intel Skylake ASoC HDA driver
snd-soc-skl_nau88l25_ssm4567.ko.xz: Intel Audio Machine driver for SKL with NAU88L25 and SSM4567 in I2S Mode
snd-soc-skl_rt286.ko.xz: Intel SST Audio for Skylake
snd-soc-ssm4567.ko.xz: ASoC SSM4567 driver
snd-soc-sst-acpi.ko.xz: Intel SST loader on ACPI systems
snd-soc-sst-bytcr-rt5640.ko.xz: ASoC Intel(R) Baytrail CR Machine driver
snd-soc-sst-bytcr-rt5651.ko.xz: ASoC Intel(R) Baytrail CR Machine driver for RT5651
snd-soc-sst-cht-bsw-max98090_ti.ko.xz: ASoC Intel(R) Braswell Machine driver
snd-soc-sst-cht-bsw-rt5645.ko.xz: ASoC Intel(R) Braswell Machine driver
snd-soc-sst-cht-bsw-rt5672.ko.xz: ASoC Intel(R) Baytrail CR Machine driver
snd-soc-sst-dsp.ko.xz: Intel SST Core
snd-soc-sst-ipc.ko.xz: Intel SST IPC generic
snd-soc-sst-match.ko.xz: Intel Common ACPI Match module
snd-soc-sst-mfld-platform.ko.xz: ASoC Intel(R) MID Platform driver
snd-soc-ts3a227e.ko.xz: ASoC ts3a227e driver
snd-tea575x-tuner.ko.xz: Routines for control of TEA5757/5759 Philips AM/FM radio tuner chips
snd-timer.ko.xz: ALSA timer interface
snd-trident.ko.xz: Trident 4D-WaveDX/NX & SiS SI7018
snd-ua101.ko.xz: Edirol UA-101/1000 driver
snd-usb-6fire.ko.xz: TerraTec DMX 6Fire USB audio driver
snd-usb-audio.ko.xz: USB Audio
snd-usb-caiaq.ko.xz: caiaq USB audio
snd-usb-hiface.ko.xz: M2Tech hiFace USB-SPDIF audio driver
snd-usb-line6.ko.xz: Line 6 USB Driver
snd-usb-pod.ko.xz: Line 6 POD USB driver
snd-usb-podhd.ko.xz: Line 6 PODHD USB driver
snd-usb-toneport.ko.xz: TonePort USB driver
snd-usb-us122l.ko.xz: TASCAM US-122L Version 0.5
snd-usb-usx2y.ko.xz: TASCAM US-X2Y Version 0.8.7.2
snd-usb-variax.ko.xz: Vairax Workbench USB driver
snd-usbmidi-lib.ko.xz: USB Audio/MIDI helper module
snd-util-mem.ko.xz: Generic memory management routines for soundcard memory allocation
snd-via82xx-modem.ko.xz: VIA VT82xx modem
snd-via82xx.ko.xz: VIA VT82xx audio
snd-virmidi.ko.xz: Dummy soundcard for virtual rawmidi devices
snd-virtuoso.ko.xz: Asus Virtuoso driver
snd-vx-lib.ko.xz: Common routines for Digigram VX drivers
snd-vx222.ko.xz: Digigram VX222 V2/Mic
snd.ko.xz: Advanced Linux Sound Architecture driver for soundcards.
softdog.ko.xz: Software Watchdog Device Driver
softing.ko.xz: Softing DPRAM CAN driver
sony-laptop.ko.xz: Sony laptop extras driver (SPIC and SNC ACPI device)
soundcore.ko.xz: Core sound module
sp5100_tco.ko.xz: TCO timer driver for SP5100/SB800 chipset
sp8870.ko.xz: Spase SP8870 DVB-T Demodulator driver
sp887x.ko.xz: Spase sp887x DVB-T demodulator driver
sparse-keymap.ko.xz: Generic support for sparse keymaps
spcp8x5.ko.xz: SPCP8x5 USB to serial adaptor driver
speedfax.ko.xz:
speedstep-lib.ko.xz: Library for Intel SpeedStep 1 or 2 cpufreq drivers.
speedtch.ko.xz: Alcatel SpeedTouch USB driver version 1.10
squashfs.ko.xz: squashfs 4.0, a compressed read-only filesystem
sr_mod.ko.xz: SCSI cdrom (sr) driver
ssb.ko.xz: Sonics Silicon Backplane driver
ssu100.ko.xz: Quatech SSU-100 USB to Serial Driver
st.ko.xz: SCSI tape (st) driver
stb0899.ko.xz: STB0899 Multi-Std frontend
stb6000.ko.xz: DVB STB6000 driver
stb6100.ko.xz: STB6100 Silicon tuner
ste10Xp.ko.xz: STMicroelectronics STe10Xp PHY driver
stex.ko.xz: Promise Technology SuperTrak EX Controllers
stk1160.ko.xz: STK1160 driver
stkwebcam.ko.xz: Syntek DC1125 webcam driver
stp.ko.xz:
streamzap.ko.xz: Streamzap Remote Control driver
stv0288.ko.xz: ST STV0288 DVB Demodulator driver
stv0297.ko.xz: ST STV0297 DVB-C Demodulator driver
stv0299.ko.xz: ST STV0299 DVB Demodulator driver
stv0367.ko.xz: ST STV0367 DVB-C/T demodulator driver
stv0900.ko.xz: ST STV0900 frontend
stv090x.ko.xz: STV090x Multi-Std Broadcast frontend
stv6110.ko.xz: ST STV6110 driver
stv6110x.ko.xz: STV6110x Silicon tuner
sunrpc.ko.xz:
sx8.ko.xz: Promise SATA SX8 block driver
symbolserial.ko.xz:
synaptics_i2c.ko.xz: Synaptics I2C touchpad driver
synaptics_usb.ko.xz: Synaptics USB device driver
synclink.ko.xz:
synclink_gt.ko.xz:
synclinkmp.ko.xz:
syscopyarea.ko.xz: Generic copyarea (sys-to-sys)
sysfillrect.ko.xz: Generic fill rectangle (sys-to-sys)
sysimgblt.ko.xz: 1-bit/8-bit to 1-32 bit color expansion (sys-to-sys)
t1pci.ko.xz: CAPI4Linux: Driver for AVM T1 PCI card
target_core_file.ko.xz: TCM FILEIO subsystem plugin
target_core_iblock.ko.xz: TCM IBLOCK subsystem plugin
target_core_mod.ko.xz: Target_Core_Mod/ConfigFS
target_core_pscsi.ko.xz: TCM PSCSI subsystem plugin
target_core_user.ko.xz: TCM USER subsystem plugin
tcm_fc.ko.xz: FC TCM fabric driver 0.4
tcm_loop.ko.xz: TCM loopback virtual Linux/SCSI fabric module
tcp_bic.ko.xz: BIC TCP
tcp_dctcp.ko.xz: DataCenter TCP (DCTCP)
tcp_diag.ko.xz:
tcp_highspeed.ko.xz: High Speed TCP
tcp_htcp.ko.xz: H-TCP
tcp_hybla.ko.xz: TCP Hybla
tcp_illinois.ko.xz: TCP Illinois
tcp_lp.ko.xz: TCP Low Priority
tcp_scalable.ko.xz: Scalable TCP
tcp_vegas.ko.xz: TCP Vegas
tcp_veno.ko.xz: TCP Veno
tcp_westwood.ko.xz: TCP Westwood+
tcp_yeah.ko.xz: YeAH TCP
tcrypt.ko.xz: Quick & dirty crypto testing module
tda10021.ko.xz: Philips TDA10021 DVB-C demodulator driver
tda10023.ko.xz: Philips TDA10023 DVB-C demodulator driver
tda10048.ko.xz: NXP TDA10048HN DVB-T Demodulator driver
tda1004x.ko.xz: Philips TDA10045H & TDA10046H DVB-T Demodulator
tda10071.ko.xz: NXP TDA10071 DVB-S/S2 demodulator driver
tda10086.ko.xz: Philips TDA10086 DVB-S Demodulator
tda18212.ko.xz: NXP TDA18212HN silicon tuner driver
tda18218.ko.xz: NXP TDA18218HN silicon tuner driver
tda18271.ko.xz: NXP TDA18271HD analog / digital tuner driver
tda18271c2dd.ko.xz: TDA18271C2 driver
tda665x.ko.xz: TDA665x driver
tda7432.ko.xz: bttv driver for the tda7432 audio processor chip
tda8083.ko.xz: Philips TDA8083 DVB-S Demodulator
tda8261.ko.xz: TDA8261 8PSK/QPSK Tuner
tda826x.ko.xz: DVB TDA826x driver
tda827x.ko.xz: DVB TDA827x driver
tda8290.ko.xz: Philips/NXP TDA8290/TDA8295 analog IF demodulator driver
tda9887.ko.xz:
tea.ko.xz: TEA, XTEA & XETA Cryptographic Algorithms
tea5761.ko.xz: Philips TEA5761 FM tuner driver
tea5767.ko.xz: Philips TEA5767 FM tuner driver
team.ko.xz: Ethernet team device driver
team_mode_activebackup.ko.xz: Active-backup mode for team
team_mode_broadcast.ko.xz: Broadcast mode for team
team_mode_loadbalance.ko.xz: Load-balancing mode for team
team_mode_random.ko.xz: Random mode for team
team_mode_roundrobin.ko.xz: Round-robin mode for team
test-string_helpers.ko.xz:
test_nx.ko.xz: Testcase for the NX infrastructure
tg3.ko.xz: Broadcom Tigon3 ethernet driver
tgr192.ko.xz: Tiger Message Digest Algorithm
thinkpad_acpi.ko.xz: ThinkPad ACPI Extras
thmc50.ko.xz: THMC50 driver
ti_usb_3410_5052.ko.xz: TI USB 3410/5052 Serial Driver
tifm_7xx1.ko.xz: TI FlashMedia host driver
tifm_core.ko.xz: TI FlashMedia core driver
tifm_ms.ko.xz: TI FlashMedia MemoryStick driver
tifm_sd.ko.xz: TI FlashMedia SD driver
timeriomem-rng.ko.xz: Timer IOMEM H/W RNG driver
tlan.ko.xz: Driver for TI ThunderLAN based ethernet PCI adapters
tlclk.ko.xz:
tm6000-alsa.ko.xz: ALSA driver module for tm5600/tm6000/tm6010 based TV cards
tm6000-dvb.ko.xz: DVB driver extension module for tm5600/6000/6010 based TV cards
tm6000.ko.xz: Trident TVMaster TM5600/TM6000/TM6010 USB2 adapter
tmp102.ko.xz: Texas Instruments TMP102 temperature sensor driver
tmp401.ko.xz: Texas Instruments TMP401 temperature sensor driver
tmp421.ko.xz: Texas Instruments TMP421/422/423 temperature sensor driver
topstar-laptop.ko.xz: Topstar Laptop ACPI Extras driver
toshiba_acpi.ko.xz: Toshiba Laptop ACPI Extras Driver
toshiba_bluetooth.ko.xz: Toshiba Laptop ACPI Bluetooth Enable Driver
tpm-rng.ko.xz: RNG driver for TPM devices
tpm_atmel.ko.xz: TPM Driver
tpm_crb.ko.xz: TPM2 Driver
tpm_i2c_atmel.ko.xz: Atmel TPM I2C Driver
tpm_i2c_infineon.ko.xz: TPM TIS I2C Infineon Driver
tpm_i2c_nuvoton.ko.xz: Nuvoton TPM I2C Driver
tpm_infineon.ko.xz: Driver for Infineon TPM SLD 9630 TT 1.1 / SLB 9635 TT 1.2
tpm_nsc.ko.xz: TPM Driver
tpm_st33zp24.ko.xz: ST33ZP24 TPM 1.2 driver
tpm_st33zp24_i2c.ko.xz: STM TPM 1.2 I2C ST33 Driver
ts2020.ko.xz: Montage Technology TS2020 - Silicon tuner driver module
ts_bm.ko.xz:
ts_fsm.ko.xz:
ts_kmp.ko.xz:
tsl2550.ko.xz: TSL2550 ambient light sensor driver
ttm.ko.xz: TTM memory manager subsystem (for DRM device)
ttpci-eeprom.ko.xz: Decode dvb_net MAC address from EEPROM of PCI DVB cards made by Siemens, Technotrend, Hauppauge
ttusb_dec.ko.xz: TechnoTrend/Hauppauge DEC USB
ttusbdecfe.ko.xz: TTUSB DEC DVB-T/S Demodulator driver
ttusbir.ko.xz: TechnoTrend USB IR Receiver
tua6100.ko.xz: DVB tua6100 driver
tua9001.ko.xz: Infineon TUA 9001 silicon tuner driver
tulip.ko.xz: Digital 21*4* Tulip ethernet driver
tun.ko.xz: Universal TUN/TAP device driver
tuner-simple.ko.xz: Simple 4-control-bytes style tuner driver
tuner-types.ko.xz: Simple tuner device type database
tuner-xc2028.ko.xz: Xceive xc2028/xc3028 tuner driver
tuner.ko.xz: device driver for various TV and TV+FM radio tuners
tuner_it913x.ko.xz: ITE Tech IT913X silicon tuner driver
tunnel4.ko.xz:
tunnel6.ko.xz:
tvaudio.ko.xz: device driver for various i2c TV sound decoder / audiomux chips
tveeprom.ko.xz: i2c Hauppauge eeprom decoder driver
tvp5150.ko.xz: Texas Instruments TVP5150A video decoder driver
twofish-avx-x86_64.ko.xz: Twofish Cipher Algorithm, AVX optimized
twofish-x86_64-3way.ko.xz: Twofish Cipher Algorithm, 3-way parallel asm optimized
twofish-x86_64.ko.xz: Twofish Cipher Algorithm, asm optimized
twofish_common.ko.xz: Twofish cipher common functions
twofish_generic.ko.xz: Twofish Cipher Algorithm
uas.ko.xz:
ubi.ko.xz: UBI - Unsorted Block Images
ucd9000.ko.xz: PMBus driver for TI UCD90xxx
ucd9200.ko.xz: PMBus driver for TI UCD922x, UCD924x
udf.ko.xz: Universal Disk Format Filesystem
udl.ko.xz:
udp_diag.ko.xz:
udp_tunnel.ko.xz:
ueagle-atm.ko.xz: ADI 930/Eagle USB ADSL Modem driver
ufshcd-pci.ko.xz: UFS host controller PCI glue driver
ufshcd.ko.xz: Generic UFS host controller driver Core
uhid.ko.xz: User-space I/O driver support for HID subsystem
uinput.ko.xz: User level driver support for input subsystem
uio.ko.xz:
uio_aec.ko.xz:
uio_cif.ko.xz:
uio_hv_generic.ko.xz: Generic UIO driver for VMBus devices
uio_pci_generic.ko.xz: Generic UIO driver for PCI 2.3 devices
uio_pdrv.ko.xz: Userspace I/O platform driver
uio_pdrv_genirq.ko.xz: Userspace I/O platform driver with generic IRQ handling
uio_sercos3.ko.xz: UIO driver for the Automata Sercos III PCI card
uli526x.ko.xz: ULi M5261/M5263 fast ethernet driver
umc.ko.xz: UWB Multi-interface Controller capability bus
ums-alauda.ko.xz: Driver for Alauda-based card readers
ums-cypress.ko.xz: SAT support for Cypress USB/ATA bridges with ATACB
ums-datafab.ko.xz: Driver for Datafab USB Compact Flash reader
ums-eneub6250.ko.xz: Driver for ENE UB6250 reader
ums-freecom.ko.xz: Driver for Freecom USB/IDE adaptor
ums-isd200.ko.xz: Driver for In-System Design, Inc. ISD200 ASIC
ums-jumpshot.ko.xz: Driver for Lexar "Jumpshot" Compact Flash reader
ums-karma.ko.xz: Driver for Rio Karma
ums-onetouch.ko.xz: Maxtor USB OneTouch hard drive button driver
ums-realtek.ko.xz: Driver for Realtek USB Card Reader
ums-sddr09.ko.xz: Driver for SanDisk SDDR-09 SmartMedia reader
ums-sddr55.ko.xz: Driver for SanDisk SDDR-55 SmartMedia reader
ums-usbat.ko.xz: Driver for SCM Microsystems (a.k.a. Shuttle) USB-ATAPI cable
unix_diag.ko.xz:
upd64031a.ko.xz: uPD64031A driver
upd64083.ko.xz: uPD64083 driver
usb-storage.ko.xz: USB Mass Storage driver for Linux
usb3503.ko.xz: USB3503 USB HUB driver
usb_8dev.ko.xz: CAN driver for 8 devices USB2CAN interfaces
usb_debug.ko.xz:
usb_gigaset.ko.xz: USB Driver for Gigaset 307x using M105
usb_wwan.ko.xz: USB Driver for GSM modems
usbatm.ko.xz: Generic USB ATM/DSL I/O, version 1.10
usbip-core.ko.xz: USB/IP Core
usblcd.ko.xz: USBLCD Driver Version 1.05
usblp.ko.xz: USB Printer Device Class driver
usbnet.ko.xz: USB network driver framework
usbsevseg.ko.xz: USB 7 Segment Driver
usbtmc.ko.xz:
usbvision.ko.xz: USBVision USB Video Device Driver for Linux
ushc.ko.xz: USB SD Host Controller driver
usnic_verbs.ko.xz: Cisco VIC (usNIC) Verbs Driver
uss720.ko.xz: USB Parport Cable driver for Cables using the Lucent Technologies USS720 Chip
uv_mmtimer.ko.xz: SGI UV Memory Mapped RTC Timer
uvcvideo.ko.xz: USB Video Class driver
uwb.ko.xz: Ultra Wide Band core
v4l2-common.ko.xz: misc helper functions for v4l2 device drivers
vcan.ko.xz: virtual CAN interface
ves1820.ko.xz: VLSI VES1820 DVB-C Demodulator driver
ves1x93.ko.xz: VLSI VES1x93 DVB-S Demodulator driver
veth.ko.xz: Virtual Ethernet Tunnel
vfat.ko.xz: VFAT filesystem support
vfio-pci.ko.xz: VFIO PCI - User Level meta-driver
vfio.ko.xz: VFIO - User Level meta-driver
vfio_iommu_type1.ko.xz: Type1 IOMMU driver for VFIO
vfio_mdev.ko.xz: VFIO based driver for Mediated device
vhost.ko.xz: Host kernel accelerator for virtio
vhost_net.ko.xz: Host kernel accelerator for virtio net
vhost_vsock.ko.xz: vhost transport for vsock
via-cputemp.ko.xz: VIA CPU temperature monitor
via-rng.ko.xz: H/W RNG driver for VIA CPU with PadLock
via-sdmmc.ko.xz: VIA SD/MMC Card Interface driver
via686a.ko.xz: VIA 686A Sensor device
via_wdt.ko.xz: Driver for watchdog timer on VIA chipset
video.ko.xz: ACPI Video Driver
videobuf-core.ko.xz: helper module to manage video4linux buffers
videobuf-dma-sg.ko.xz: helper module to manage video4linux dma sg buffers
videobuf-dvb.ko.xz:
videobuf-vmalloc.ko.xz: helper module to manage video4linux vmalloc buffers
videobuf2-core.ko.xz: Driver helper framework for Video for Linux 2
videobuf2-memops.ko.xz: common memory handling routines for videobuf2
videobuf2-vmalloc.ko.xz: vmalloc memory handling routines for videobuf2
videodev.ko.xz: Device registrar for Video4Linux drivers v2
viperboard.ko.xz: Nano River Technologies viperboard mfd core driver
virt-dma.ko.xz:
virtio-gpu.ko.xz: Virtio GPU driver
virtio-rng.ko.xz: Virtio random number driver
virtio.ko.xz:
virtio_balloon.ko.xz: Virtio balloon driver
virtio_blk.ko.xz: Virtio block driver
virtio_console.ko.xz: Virtio console driver
virtio_input.ko.xz: Virtio input device driver
virtio_net.ko.xz: Virtio network driver
virtio_pci.ko.xz: virtio-pci
virtio_ring.ko.xz:
virtio_scsi.ko.xz: Virtio SCSI HBA driver
visor.ko.xz: USB HandSpring Visor / Palm OS driver
vitesse.ko.xz: Vitesse PHY driver
vmac.ko.xz: VMAC hash algorithm
vmw_balloon.ko.xz: VMware Memory Control (Balloon) Driver
vmw_pvscsi.ko.xz: VMware PVSCSI driver
vmw_vmci.ko.xz: VMware Virtual Machine Communication Interface.
vmw_vsock_virtio_transport.ko.xz: virtio transport for vsock
vmw_vsock_virtio_transport_common.ko.xz: common code for virtio vsock
vmw_vsock_vmci_transport.ko.xz: VMCI transport for Virtual Sockets
vmwgfx.ko.xz: Standalone drm driver for the VMware SVGA device
vmxnet3.ko.xz: VMware vmxnet3 virtual NIC driver
vp27smpx.ko.xz: vp27smpx driver
vport-geneve.ko.xz: OVS: Geneve swiching port
vport-gre.ko.xz: OVS: GRE switching port
vport-vxlan.ko.xz: OVS: VXLAN switching port
vringh.ko.xz:
vsock.ko.xz: VMware Virtual Socket Family
vsxxxaa.ko.xz: Driver for DEC VSXXX-AA and -GA mice and VSXXX-AB tablet
vt1211.ko.xz: VT1211 sensors
vt8231.ko.xz: VT8231 sensors
vub300.ko.xz: VUB300 USB to SD/MMC/SDIO adapter driver
vx855.ko.xz: Driver for the VIA VX855 chipset
vxlan.ko.xz: Driver for VXLAN encapsulated traffic
w6692.ko.xz:
w83627ehf.ko.xz: W83627EHF driver
w83627hf.ko.xz: W83627HF driver
w83627hf_wdt.ko.xz: w83627hf/thf WDT driver
w83697hf_wdt.ko.xz: w83697hf/hg WDT driver
w83697ug_wdt.ko.xz: w83697ug/uf WDT driver
w83781d.ko.xz: W83781D driver
w83791d.ko.xz: W83791D driver
w83792d.ko.xz: W83792AD/D driver for linux-2.6
w83793.ko.xz: w83793 driver
w83795.ko.xz: W83795G/ADG hardware monitoring driver
w83877f_wdt.ko.xz: Driver for watchdog timer in w83877f chip
w83977f_wdt.ko.xz: Driver for watchdog timer in W83977F I/O chip
w83l785ts.ko.xz: W83L785TS-S driver
w83l786ng.ko.xz: w83l786ng driver
wacom.ko.xz: USB Wacom tablet driver
USB Wacom tablet driver
wacom_i2c.ko.xz: WACOM EMR I2C Driver
wacom_w8001.ko.xz: Wacom W8001 serial touchscreen driver
wdt_pci.ko.xz: Driver for the ICS PCI-WDT500/501 watchdog cards
whc-rc.ko.xz: Wireless Host Controller Radio Control Driver
whci.ko.xz: WHCI UWB Multi-interface Controller enumerator
whiteheat.ko.xz: USB ConnectTech WhiteHEAT driver
wil6210.ko.xz: Driver for 60g WiFi WIL6210 card
winbond-840.ko.xz: Winbond W89c840 Ethernet driver
winbond-cir.ko.xz: Winbond SuperI/O Consumer IR Driver
wm8739.ko.xz: wm8739 driver
wm8775.ko.xz: wm8775 driver
wmi.ko.xz: ACPI-WMI Mapping Driver
wp512.ko.xz: Whirlpool Message Digest Algorithm
wusb-cbaf.ko.xz: Wireless USB Cable Based Association
wusb-wa.ko.xz: Wireless USB Wire Adapter core
wusbcore.ko.xz: Wireless USB core
x38_edac.ko.xz: MC support for Intel X38 memory hub controllers
xc4000.ko.xz: Xceive xc4000 silicon tuner driver
xc5000.ko.xz: Xceive xc5000 silicon tuner driver
xcbc.ko.xz: XCBC keyed hash algorithm
xen-acpi-processor.ko.xz: Xen ACPI Processor P-states (and Cx) driver which uploads PM data to Xen hypervisor
xen-blkfront.ko.xz: Xen virtual block device frontend
xen-evtchn.ko.xz:
xen-kbdfront.ko.xz: Xen virtual keyboard/pointer device frontend
xen-netfront.ko.xz: Xen virtual network device frontend
xen-privcmd.ko.xz:
xen_wdt.ko.xz: Xen WatchDog Timer Driver
xenfs.ko.xz: Xen filesystem
xfrm4_mode_beet.ko.xz:
xfrm4_mode_transport.ko.xz:
xfrm4_mode_tunnel.ko.xz:
xfrm4_tunnel.ko.xz:
xfrm6_mode_beet.ko.xz:
xfrm6_mode_ro.ko.xz:
xfrm6_mode_transport.ko.xz:
xfrm6_mode_tunnel.ko.xz:
xfrm6_tunnel.ko.xz:
xfrm_ipcomp.ko.xz: IP Payload Compression Protocol (IPComp) - RFC3173
xfs.ko.xz: SGI XFS with ACLs, security attributes, no debug enabled
xgmac.ko.xz: Calxeda 10G XGMAC driver
xircom_cb.ko.xz: Xircom Cardbus ethernet driver
xor.ko.xz:
xp.ko.xz: Cross Partition (XP) base
xpc.ko.xz: Cross Partition Communication (XPC) support
xpnet.ko.xz: Cross Partition Network adapter (XPNET)
xsens_mt.ko.xz: USB-serial driver for Xsens motion trackers
xt_AUDIT.ko.xz: Xtables: creates audit records for dropped/accepted packets
xt_CHECKSUM.ko.xz: Xtables: checksum modification
xt_CLASSIFY.ko.xz: Xtables: Qdisc classification
xt_CONNSECMARK.ko.xz: Xtables: target for copying between connection and security mark
xt_CT.ko.xz: Xtables: connection tracking target
xt_DSCP.ko.xz: Xtables: DSCP/TOS field modification
xt_HL.ko.xz: Xtables: Hoplimit/TTL Limit field modification target
xt_HMARK.ko.xz: Xtables: packet marking using hash calculation
xt_IDLETIMER.ko.xz: Xtables: idle time monitor
xt_LED.ko.xz: Xtables: trigger LED devices on packet match
xt_LOG.ko.xz: Xtables: IPv4/IPv6 packet logging
xt_NETMAP.ko.xz: Xtables: 1:1 NAT mapping of subnets
xt_NFLOG.ko.xz: Xtables: packet logging to netlink using NFLOG
xt_NFQUEUE.ko.xz: Xtables: packet forwarding to netlink
xt_RATEEST.ko.xz: Xtables: packet rate estimator
xt_REDIRECT.ko.xz: Xtables: Connection redirection to localhost
xt_SECMARK.ko.xz: Xtables: packet security mark modification
xt_TCPMSS.ko.xz: Xtables: TCP Maximum Segment Size (MSS) adjustment
xt_TCPOPTSTRIP.ko.xz: Xtables: TCP option stripping
xt_TEE.ko.xz: Xtables: Reroute packet copy
xt_TPROXY.ko.xz: Netfilter transparent proxy (TPROXY) target module.
xt_TRACE.ko.xz: Xtables: packet flow tracing
xt_addrtype.ko.xz: Xtables: address type match
xt_bpf.ko.xz: Xtables: BPF filter match
xt_cgroup.ko.xz: Xtables: process control group matching
xt_cluster.ko.xz: Xtables: hash-based cluster match
xt_comment.ko.xz: Xtables: No-op match which can be tagged with a comment
xt_connbytes.ko.xz: Xtables: Number of packets/bytes per connection matching
xt_connlabel.ko.xz: Xtables: add/match connection trackling labels
xt_connlimit.ko.xz: Xtables: Number of connections matching
xt_connmark.ko.xz: Xtables: connection mark operations
xt_conntrack.ko.xz: Xtables: connection tracking state match
xt_cpu.ko.xz: Xtables: CPU match
xt_dccp.ko.xz: Xtables: DCCP protocol packet match
xt_devgroup.ko.xz: Xtables: Device group match
xt_dscp.ko.xz: Xtables: DSCP/TOS field match
xt_ecn.ko.xz: Xtables: Explicit Congestion Notification (ECN) flag match
xt_esp.ko.xz: Xtables: IPsec-ESP packet match
xt_hashlimit.ko.xz: Xtables: per hash-bucket rate-limit match
xt_helper.ko.xz: Xtables: Related connection matching
xt_hl.ko.xz: Xtables: Hoplimit/TTL field match
xt_iprange.ko.xz: Xtables: arbitrary IPv4 range matching
xt_ipvs.ko.xz: Xtables: match IPVS connection properties
xt_length.ko.xz: Xtables: Packet length (Layer3,4,5) match
xt_limit.ko.xz: Xtables: rate-limit match
xt_mac.ko.xz: Xtables: MAC address match
xt_mark.ko.xz: Xtables: packet mark operations
xt_multiport.ko.xz: Xtables: multiple port matching for TCP, UDP, UDP-Lite, SCTP and DCCP
xt_nat.ko.xz:
xt_nfacct.ko.xz: Xtables: match for the extended accounting infrastructure
xt_osf.ko.xz: Passive OS fingerprint matching.
xt_owner.ko.xz: Xtables: socket owner matching
xt_physdev.ko.xz: Xtables: Bridge physical device match
xt_pkttype.ko.xz: Xtables: link layer packet type match
xt_policy.ko.xz: Xtables: IPsec policy match
xt_quota.ko.xz: Xtables: countdown quota match
xt_rateest.ko.xz: xtables rate estimator match
xt_realm.ko.xz: Xtables: Routing realm match
xt_recent.ko.xz: Xtables: "recently-seen" host matching
xt_sctp.ko.xz: Xtables: SCTP protocol packet match
xt_set.ko.xz: Xtables: IP set match and target module
xt_socket.ko.xz: x_tables socket match module
xt_state.ko.xz: ip[6]_tables connection tracking state match module
xt_statistic.ko.xz: Xtables: statistics-based matching ("Nth", random)
xt_string.ko.xz: Xtables: string-based matching
xt_tcpmss.ko.xz: Xtables: TCP MSS match
xt_time.ko.xz: Xtables: time-based matching
xt_u32.ko.xz: Xtables: arbitrary byte matching
xts.ko.xz: XTS block cipher mode
xusbatm.ko.xz: Driver for USB ADSL modems initialized in userspace
yealink.ko.xz: Yealink phone driver
yenta_socket.ko.xz:
zaurus.ko.xz: Sharp Zaurus PDA, and compatible products
zl10036.ko.xz: DVB ZL10036 driver
zl10039.ko.xz: Zarlink ZL10039 DVB-S tuner driver
zl10353.ko.xz: Zarlink ZL10353 DVB-T demodulator driver
zl6100.ko.xz: PMBus driver for ZL6100 and compatibles
zlib.ko.xz: Zlib Compression Algorithm
zr364xx.ko.xz: Zoran 364xx
zram.ko.xz: Compressed RAM Block Device
````

