### PR TITLE
Add agent example with gevent to work with xcat

### DIFF
--- a/xCAT-server/debian/dirs
+++ b/xCAT-server/debian/dirs
@@ -23,6 +23,9 @@ opt/xcat/share/xcat/ib/netboot/sles
 opt/xcat/share/xcat/ib/netboot/rh
 opt/xcat/lib
 opt/xcat/lib/perl
+opt/xcat/lib/python
+opt/xcat/lib/python/agent
+opt/xcat/lib/python/agent/xcatagent
 opt/xcat/lib/perl/Confluent
 opt/xcat/lib/perl/xCAT
 opt/xcat/lib/perl/xCAT_plugin

--- a/xCAT-server/debian/install
+++ b/xCAT-server/debian/install
@@ -20,6 +20,8 @@ share/xcat/ib/netboot/sles/* opt/xcat/share/xcat/ib/netboot/sles
 share/xcat/ib/netboot/rh/* opt/xcat/share/xcat/ib/netboot/rh
 
 lib/perl/xCAT/* opt/xcat/lib/perl/xCAT/
+lib/python/agent/* opt/xcat/lib/python/agent/
+lib/python/agent/xcatagent/* opt/xcat/lib/python/agent/xcatagent/
 lib/xcat/plugins/* opt/xcat/lib/perl/xCAT_plugin/
 lib/xcat/schema/* opt/xcat/lib/perl/xCAT_schema/
 lib/xcat/monitoring/* opt/xcat/lib/perl/xCAT_monitoring/

--- a/xCAT-server/debian/rules
+++ b/xCAT-server/debian/rules
@@ -53,6 +53,8 @@ binary-arch:
 	chmod 755 $(rootdir)/share/xcat/ib/netboot/rh/*
 	chmod 644 $(rootdir)/lib/perl/xCAT_plugin/*
 	chmod 644 $(rootdir)/lib/perl/xCAT/*
+	chmod 755 $(rootdir)/lib/python/agent/client.py
+	chmod 755 $(rootdir)/lib/python/agent/agent.py
 	chmod 644 $(rootdir)/xdsh/Context/*
 	chmod 644 $(rootdir)/lib/perl/xCAT_monitoring/*
 	chmod 755 $(rootdir)/lib/perl/xCAT_monitoring/samples

--- a/xCAT-server/lib/perl/xCAT/OPENBMC.pm
+++ b/xCAT-server/lib/perl/xCAT/OPENBMC.pm
@@ -16,6 +16,18 @@ use HTTP::Request;
 use HTTP::Headers;
 use HTTP::Cookies;
 use Data::Dumper;
+use Time::HiRes qw(sleep time);
+use JSON;
+use File::Path;
+use Fcntl ":flock";
+use IO::Socket::UNIX qw( SOCK_STREAM );
+
+my $LOCK_DIR = "/var/lock/xcat/";
+my $LOCK_PATH = "/var/lock/xcat/agent.lock";
+my $AGENT_SOCK_PATH = "/var/run/xcat/agent.sock";
+my $PYTHON_LOG_PATH = "/var/log/xcat/agent.log";
+my $MSG_TYPE = "message";
+my $lock_fd;
 
 my $header = HTTP::Headers->new('Content-Type' => 'application/json');
 
@@ -41,6 +53,123 @@ sub send_request {
     my $request = HTTP::Request->new( $method, $url, $header, $content );
     my $id = $async->add_with_opts($request, {});
     return $id;
+}
+
+# if lock is released unexpectedly, python side would aware of the error after
+# getting this lock
+sub acquire_lock {
+    mkpath($LOCK_DIR);
+    # always create a new lock file
+    unlink($LOCK_PATH);
+    open($lock_fd, ">>", $LOCK_PATH) or return undef;
+    flock($lock_fd, LOCK_EX) or return undef;
+    return $lock_fd;
+}
+sub start_python_agent {
+    if (!defined(acquire_lock())) {
+        xCAT::MsgUtils->message("S", "Error: Faild to require lock");
+        return undef;
+    }
+    my $fd;
+    open($fd, '>', $AGENT_SOCK_PATH) && close($fd);
+    my $pid = fork;
+    if (!defined $pid) {
+        xCAT::MsgUtils->message("S", "Error: Unable to fork process");
+        return undef;
+    }
+    $SIG{CHLD} = 'DEFAULT';
+    if (!$pid) {
+        # child
+        open($fd, ">>", $PYTHON_LOG_PATH) && close($fd);
+        open(STDOUT, '>>', $PYTHON_LOG_PATH) or die("open: $!");
+        open(STDERR, '>>&', \*STDOUT) or die("open: $!");
+        my $ret = exec ("/opt/xcat/lib/python/agent/agent.py");
+        if (!defined($ret)) {
+            xCAT::MsgUtils->message("S", "Error: Failed to start python agent");
+        }
+    }
+    return $pid;
+}
+
+sub handle_message {
+    my ($data, $callback) = @_;
+    if($data->{type} eq $MSG_TYPE) {
+        my $msg = $data->{msg};
+        if ($msg->{type} eq 'info') {
+            xCAT::MsgUtils->message("I", { data => [$msg->{data}] }, $callback);
+        } elsif ($msg->{type} eq 'error'){
+            xCAT::MsgUtils->message("E", { data => [$msg->{data}] }, $callback);
+        } elsif ($msg->{type} eq 'syslog'){
+            xCAT::MsgUtils->message("S", $msg->{data});
+        }
+    }
+}
+
+sub submit_agent_request {
+    my ($pid, $req, $nodeinfo, $callback) = @_;
+    my $sock;
+    my $retry = 0;
+    while($retry < 30) {
+        $sock = IO::Socket::UNIX->new(Peer => $AGENT_SOCK_PATH, Type => SOCK_STREAM, Timeout => 10, Blocking => 1);
+        if (!defined($sock)) {
+            sleep(0.1);
+        } else {
+            last;
+        }
+        $retry++;
+    }
+    if (!defined($sock)) {
+        xCAT::MsgUtils->message("E", { data => ["Error: Failed to connect to the agent"] }, $callback);
+        kill('TERM', $pid);
+        return;
+    }
+    my ($data, $sz, $ret, $buf);
+    $data->{module} = 'openbmc';
+    $data->{command} = $req->{command}->[0];
+    $data->{args} = $req->{arg};
+    $data->{cwd} = $req->{cwd};
+    $data->{nodes} = $req->{node};
+    $data->{nodeinfo} = $nodeinfo;
+    $buf = encode_json($data);
+    $sz = pack('i', length($buf));
+    $ret = $sock->send($sz);
+    if (!$ret) {
+        xCAT::MsgUtils->message("E", { data => ["Error: Failed to send message to the agent"] }, $callback);
+        $sock->close();
+        kill('TERM', $pid);
+        return;
+    }
+    $ret = $sock->send($buf);
+    if (!$ret) {
+        xCAT::MsgUtils->message("E", { data => ["Error: Failed to send message to the agent"] }, $callback);
+        $sock->close();
+        kill('TERM', $pid);
+        return;
+    }
+    while(1) {
+        $ret = $sock->recv($buf, 4);
+        if (!$ret) {
+            last;
+        }
+        $sz = unpack('i', $buf);
+        $ret = $sock->recv($buf, $sz);
+        if (!$ret) {
+            xCAT::MsgUtils->message("E", { data => ["Error: receive data from python agent unexpectedly"] }, $callback);
+            last;
+        }
+        $data = decode_json($buf);
+        handle_message($data, $callback);
+    }
+    # no message received, the socket on the agent side should be closed.
+    $sock->close();
+}
+
+sub wait_agent {
+    my ($pid, $callback) = @_;
+    waitpid($pid, 0);
+    if ($? >> 8 != 0) {
+        xCAT::MsgUtils->message("E", { data => ["Error: python agent exited unexpectedly"] }, $callback);
+    }
 }
 
 1;

--- a/xCAT-server/lib/python/agent/agent.py
+++ b/xCAT-server/lib/python/agent/agent.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+from __future__ import print_function
+import argparse
+import sys
+from xcatagent import server
+
+
+class AgentShell(object):
+    def get_base_parser(self):
+        parser = argparse.ArgumentParser(
+            prog='xcatagent',
+            add_help=False,
+            formatter_class=HelpFormatter,
+        )
+        parser.add_argument('-h', '--help',
+                            action='store_true',
+                            help=argparse.SUPPRESS,
+                            )
+        parser.add_argument('--standalone',
+                            help="Start xcat agent as a standalone service, "
+                                 "mostly work for test purpose. ",
+                            action='store_true')
+        parser.add_argument('--sock',
+                            help="The unix domain sock file to communicate "
+                                 "with the client",
+                            default='/var/run/xcat/agent.sock',
+                            type=str)
+        return parser
+
+    def do_help(self, args):
+        self.parser.print_help()
+
+    def main(self, argv):
+        self.parser = self.get_base_parser()
+        (options, args) = self.parser.parse_known_args(argv)
+
+        if options.help:
+            self.do_help(options)
+            return 0
+        s = server.Server(options.sock, options.standalone)
+        s.start()
+
+class HelpFormatter(argparse.HelpFormatter):
+    def start_section(self, heading):
+        # Title-case the headings
+        heading = '%s%s' % (heading[0].upper(), heading[1:])
+        super(HelpFormatter, self).start_section(heading)
+
+
+if __name__ == '__main__':
+    AgentShell().main(sys.argv[1:])

--- a/xCAT-server/lib/python/agent/client.py
+++ b/xCAT-server/lib/python/agent/client.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+# just for test
+from __future__ import print_function
+
+import argparse
+import json
+import os
+import socket
+import sys
+from xcatagent import utils
+
+class ClientShell(object):
+    def get_base_parser(self):
+        parser = argparse.ArgumentParser(
+            prog='agentclient',
+            add_help=False,
+            formatter_class=HelpFormatter,
+        )
+        parser.add_argument('-h', '--help',
+                            action='store_true',
+                            help=argparse.SUPPRESS,
+                            )
+        parser.add_argument('--sock',
+                            help="The unix domain sock file to communicate "
+                                 "with the server",
+                            default='/var/run/xcat/agent.sock',
+                            type=str)
+        return parser
+
+    def do_help(self, args):
+        self.parser.print_help()
+
+    def main(self, argv):
+        self.parser = self.get_base_parser()
+        (options, args) = self.parser.parse_known_args(argv)
+
+        if options.help:
+            self.do_help(options)
+            return 0
+
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        nodes = ['node%s' % i for i in range(100)]
+        nodeinfo = {node: {'username': 'admin', 'password': 'cluster'} for node
+                    in
+                    nodes}
+
+        s.connect(options.sock)
+        req = {'module': 'openbmc',
+               'command': 'rpower',
+               'args': ['-d', 'firmware'],
+               'cwd': os.getcwd(),
+               'nodes': nodes,
+               'nodeinfo': nodeinfo}
+
+        buf = json.dumps(req)
+        s.send(utils.int2bytes(len(buf)))
+        s.send(buf)
+        while True:
+            sz = s.recv(4)
+            if len(sz) == 0:
+                break
+            sz = utils.bytes2int(sz)
+            data = s.recv(sz)
+            print(data)
+
+
+class HelpFormatter(argparse.HelpFormatter):
+    def start_section(self, heading):
+        # Title-case the headings
+        heading = '%s%s' % (heading[0].upper(), heading[1:])
+        super(HelpFormatter, self).start_section(heading)
+
+
+if __name__ == '__main__':
+    ClientShell().main(sys.argv[1:])

--- a/xCAT-server/lib/python/agent/xcatagent/__init__.py
+++ b/xCAT-server/lib/python/agent/xcatagent/__init__.py
@@ -1,0 +1,2 @@
+from gevent import monkey
+monkey.patch_socket()

--- a/xCAT-server/lib/python/agent/xcatagent/base.py
+++ b/xCAT-server/lib/python/agent/xcatagent/base.py
@@ -1,0 +1,25 @@
+from xcatagent import utils
+
+MODULE_MAP = {"openbmc": "OpenBMCManager"}
+
+
+class BaseManager(object):
+    def __init__(self, messager, cwd):
+        self.messager = messager
+        self.cwd = cwd
+
+    @classmethod
+    def get_manager_func(self, name):
+        module_name = 'xcatagent.%s' % name
+        try:
+            __import__(module_name)
+        except ImportError:
+            return None
+
+        class_name = MODULE_MAP[name]
+        return utils.class_func(module_name, class_name)
+
+
+class BaseDriver(object):
+    def __init__(self, messager):
+        self.messager = messager

--- a/xCAT-server/lib/python/agent/xcatagent/openbmc.py
+++ b/xCAT-server/lib/python/agent/xcatagent/openbmc.py
@@ -1,0 +1,26 @@
+from xcatagent import base
+import gevent
+
+
+class OpenBMCManager(base.BaseManager):
+    def __init__(self, messager, cwd, nodes):
+        super(OpenBMCManager, self).__init__(messager, cwd)
+        self.nodes = nodes
+
+    def rpower(self, nodeinfo, args):
+        driver = OpenBMCDriver(self.messager)
+        lst = [gevent.spawn(driver.rpower, node, nodeinfo[node],
+                            args) for node in self.nodes]
+        gevent.joinall(lst)
+
+
+class OpenBMCDriver(base.BaseDriver):
+    def __init__(self, messager):
+        super(OpenBMCDriver, self).__init__(messager)
+
+    def rpower(self, node, info, args):
+        if node == 'node1':
+            self.messager
+            gevent.sleep(3)
+        self.messager.info(
+            "%s: rpower called info=%s args=%s" % (node, info, args))

--- a/xCAT-server/lib/python/agent/xcatagent/server.py
+++ b/xCAT-server/lib/python/agent/xcatagent/server.py
@@ -1,0 +1,121 @@
+# -*- encoding: utf-8 -*-
+from __future__ import print_function
+import json
+import sys
+import os
+import threading
+import fcntl
+import traceback
+from gevent import socket
+from gevent.server import StreamServer
+from gevent.lock import BoundedSemaphore
+from xcatagent import utils
+from xcatagent import base as xcat_manager
+
+MSG_TYPE = 'message'
+LOCK_FILE = '/var/lock/xcat/agent.lock'
+
+
+class Messager(object):
+    def __init__(self, sock):
+        self.sock = sock
+        self.sem = BoundedSemaphore(1)
+
+    def info(self, msg):
+        d = {'type': MSG_TYPE, 'msg': {'type': 'info', 'data': msg}}
+        buf = json.dumps(d)
+        self.sem.acquire()
+        self.sock.send(utils.int2bytes(len(buf)))
+        self.sock.send(buf)
+        self.sem.release()
+
+    def error(self, msg):
+        d = {'type': MSG_TYPE, 'msg': {'type': 'error', 'data': msg}}
+        buf = json.dumps(d)
+        self.sem.acquire()
+        self.sock.send(utils.int2bytes(len(buf)))
+        self.sock.send(buf)
+        self.sem.release()
+
+    def syslog(self, msg):
+        d = {'type': MSG_TYPE, 'msg': {'type': 'syslog', 'data': msg}}
+        buf = json.dumps(d)
+        self.sem.acquire()
+        self.sock.send(utils.int2bytes(len(buf)))
+        self.sock.send(buf)
+        self.sem.release()
+
+
+class Server(object):
+    def __init__(self, address, standalone):
+        try:
+            os.unlink(address)
+        except OSError:
+            if os.path.exists(address):
+                raise
+        self.address = address
+        self.standalone = standalone
+        self.server = StreamServer(self._serve(), self._handle)
+
+    def _serve(self):
+        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        listener.bind(self.address)
+        listener.listen(1)
+        return listener
+
+    def _handle(self, sock, address):
+        try:
+            messager = Messager(sock)
+            buf = sock.recv(4)
+            sz = utils.bytes2int(buf)
+            buf = sock.recv(sz)
+            req = json.loads(buf)
+            if not 'command' in req:
+                messager.error("Could not find command")
+                return
+            if not 'module' in req:
+                messager.error("Please specify the request module")
+                return
+            if not 'cwd' in req:
+                messager.error("Please specify the cwd parameter")
+                return
+
+            manager_func = xcat_manager.BaseManager.get_manager_func(
+                req['module'])
+            if manager_func is None:
+                messager.error("Could not find manager for %s" % req['module'])
+                return
+            nodes = req.get("nodes", None)
+            manager = manager_func(messager, req['cwd'], nodes)
+            if not hasattr(manager, req['command']):
+                messager.error("coomand %s is not supported" % req['command'])
+            func = getattr(manager, req['command'])
+            # call the function in the specified manager
+            func(req['nodeinfo'], req['args'])
+            # after the method returns, the request should be handled
+            # completely, close the socket for client
+            if not self.standalone:
+                sock.close()
+                self.server.stop()
+                os._exit(0)
+        except Exception:
+            print(traceback.format_exc(), file=sys.stderr)
+            self.server.stop()
+            os._exit(1)
+
+    def keep_peer_alive(self):
+        def acquire():
+            fd = open(LOCK_FILE, "r+")
+            fcntl.flock(fd.fileno(), fcntl.LOCK_EX)
+            # if reach here, parent process may exit
+            print("xcat process exit unexpectedly.", file=sys.stderr)
+            self.server.stop()
+            os._exit(1)
+
+        t = threading.Thread(target=acquire)
+        t.start()
+
+    def start(self):
+        if not self.standalone:
+            self.keep_peer_alive()
+        self.server.serve_forever()

--- a/xCAT-server/lib/python/agent/xcatagent/utils.py
+++ b/xCAT-server/lib/python/agent/xcatagent/utils.py
@@ -1,0 +1,25 @@
+import struct
+import sys
+import inspect
+
+
+def int2bytes(num):
+    return struct.pack('i', num)
+
+
+def bytes2int(buf):
+    return struct.unpack('i', buf)[0]
+
+
+def get_classes(module_name):
+    ret = []
+    for name, obj in inspect.getmembers(sys.modules[module_name]):
+        if inspect.isclass(obj):
+            ret.append(obj)
+
+    return ret
+
+
+def class_func(module_name, class_name):
+    func = getattr(sys.modules[module_name], class_name)
+    return func

--- a/xCAT-server/lib/xcat/plugins/openbmc2.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc2.pm
@@ -1,0 +1,213 @@
+#!/usr/bin/perl
+### IBM(c) 2017 EPL license http://www.eclipse.org/legal/epl-v10.html
+
+package xCAT_plugin::openbmc2;
+
+BEGIN
+    {
+        $::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : '/opt/xcat';
+    }
+use lib "$::XCATROOT/lib/perl";
+use strict;
+use warnings "all";
+
+use JSON;
+use xCAT::Utils;
+use xCAT::Usage;
+use xCAT::SvrUtils;
+use xCAT::OPENBMC;
+
+#-------------------------------------------------------
+
+=head3  handled_commands
+
+  Return list of commands handled by this plugin
+
+=cut
+
+#-------------------------------------------------------
+
+sub handled_commands {
+    return {
+        # rpower         => 'nodehm:mgt=openbmc',
+    };
+}
+
+my %node_info = ();
+my $callback;
+
+#-------------------------------------------------------
+
+=head3  preprocess_request
+
+  preprocess the command
+
+=cut
+
+#-------------------------------------------------------
+sub preprocess_request {
+    my $request = shift;
+    $callback  = shift;
+
+    my $command   = $request->{command}->[0];
+    my $noderange = $request->{node};
+    my $extrargs  = $request->{arg};
+    my @exargs    = ($request->{arg});
+    my @requests;
+
+    if (ref($extrargs)) {
+        @exargs = @$extrargs;
+    }
+    my $usage_string = xCAT::Usage->parseCommand($command, @exargs);
+    if ($usage_string) {
+        $callback->({ data => [$usage_string] });
+        $request = {};
+        return;
+    }
+
+    my $parse_result = parse_args($command, $extrargs, $noderange);
+    if (ref($parse_result) eq 'ARRAY') {
+        my $error_data;
+        foreach my $node (@$noderange) {
+            $error_data .= "\n" if ($error_data);
+            $error_data .= "$node: Error: " . "$parse_result->[1]";
+        }
+        $callback->({ errorcode => [$parse_result->[0]], data => [$error_data] });
+        $request = {};
+        return;
+    }
+
+    my $sn = xCAT::ServiceNodeUtils->get_ServiceNode($noderange, "xcat", "MN");
+    foreach my $snkey (keys %$sn) {
+        my $reqcopy = {%$request};
+        $reqcopy->{node}                   = $sn->{$snkey};
+        $reqcopy->{'_xcatdest'}            = $snkey;
+        $reqcopy->{_xcatpreprocessed}->[0] = 1;
+        push @requests, $reqcopy;
+    }
+
+    return \@requests;
+}
+
+#-------------------------------------------------------
+
+=head3  process_request
+
+  Process the command
+
+=cut
+
+#-------------------------------------------------------
+sub process_request {
+    my $request = shift;
+    $callback = shift;
+    my $noderange = $request->{node};
+    my $check = parse_node_info($noderange);
+    $callback->({ errorcode => [$check] }) if ($check);
+    my $pid = xCAT::OPENBMC::start_python_agent();
+    if (!defined($pid)) {
+        xCAT::MsgUtils->message("E", { data => ["Error: Failed to start python agent"] }, $callback);
+        return;
+    }
+    xCAT::OPENBMC::submit_agent_request($pid, $request, \%node_info, $callback);
+    xCAT::OPENBMC::wait_agent($pid, $callback);
+}
+
+#-------------------------------------------------------
+
+=head3  parse_args
+
+  Parse the command line options and operands
+
+=cut
+
+#-------------------------------------------------------
+sub parse_args {
+    my $command  = shift;
+    my $extrargs = shift;
+    my $noderange = shift;
+    my $subcommand = undef;
+
+    if (scalar(@ARGV) >= 2 and ($command =~ /rpower/)) {
+        return ([ 1, "Only one option is supported at the same time for $command" ]);
+    } elsif (scalar(@ARGV) == 0 and $command =~ /rpower/) {
+        return ([ 1, "No option specified for $command" ]);
+    } else {
+        $subcommand = $ARGV[0];
+    }
+
+    if ($command eq "rpower") {
+        unless ($subcommand =~ /^on$|^off$|^softoff$|^reset$|^boot$|^bmcreboot$|^bmcstate$|^status$|^stat$|^state$/) {
+            return ([ 1, "Unsupported command: $command $subcommand" ]);
+        }
+    }
+}
+
+#-------------------------------------------------------
+
+=head3  parse_node_info
+
+  Parse the node information: bmc, bmcip, username, password
+
+=cut
+
+#-------------------------------------------------------
+sub parse_node_info {
+    my $noderange = shift;
+    my $rst = 0;
+
+    my $passwd_table = xCAT::Table->new('passwd');
+    my $passwd_hash = $passwd_table->getAttribs({ 'key' => 'openbmc' }, qw(username password));
+
+    my $openbmc_table = xCAT::Table->new('openbmc');
+    my $openbmc_hash = $openbmc_table->getNodesAttribs(\@$noderange, ['bmc', 'username', 'password']);
+
+    foreach my $node (@$noderange) {
+        if (defined($openbmc_hash->{$node}->[0])) {
+            if ($openbmc_hash->{$node}->[0]->{'bmc'}) {
+                $node_info{$node}{bmc} = $openbmc_hash->{$node}->[0]->{'bmc'};
+                $node_info{$node}{bmcip} = xCAT::NetworkUtils::getNodeIPaddress($openbmc_hash->{$node}->[0]->{'bmc'});
+            }
+            unless($node_info{$node}{bmc}) {
+                xCAT::SvrUtils::sendmsg("Error: Unable to get attribute bmc", $callback, $node);
+                $rst = 1;
+                next;
+            }
+            unless($node_info{$node}{bmcip}) {
+                xCAT::SvrUtils::sendmsg("Error: Unable to resolve ip address for bmc: $node_info{$node}{bmc}", $callback, $node);
+                delete $node_info{$node};
+                $rst = 1;
+                next;
+            }
+            if ($openbmc_hash->{$node}->[0]->{'username'}) {
+                $node_info{$node}{username} = $openbmc_hash->{$node}->[0]->{'username'};
+            } elsif ($passwd_hash and $passwd_hash->{username}) {
+                $node_info{$node}{username} = $passwd_hash->{username};
+            } else {
+                xCAT::SvrUtils::sendmsg("Error: Unable to get attribute username", $callback, $node);
+                delete $node_info{$node};
+                $rst = 1;
+                next;
+            }
+
+            if ($openbmc_hash->{$node}->[0]->{'password'}) {
+                $node_info{$node}{password} = $openbmc_hash->{$node}->[0]->{'password'};
+            } elsif ($passwd_hash and $passwd_hash->{password}) {
+                $node_info{$node}{password} = $passwd_hash->{password};
+            } else {
+                xCAT::SvrUtils::sendmsg("Error: Unable to get attribute password", $callback, $node);
+                delete $node_info{$node};
+                $rst = 1;
+                next;
+            }
+        } else {
+            xCAT::SvrUtils::sendmsg("Error: Unable to get information from openbmc table", $callback, $node);
+            $rst = 1;
+            next;
+        }
+    }
+
+    return $rst;
+}
+
+1;

--- a/xCAT-server/xCAT-server.spec
+++ b/xCAT-server/xCAT-server.spec
@@ -116,6 +116,7 @@ mkdir -p $RPM_BUILD_ROOT/%{prefix}/lib/perl/xCAT_monitoring/pcp
 mkdir -p $RPM_BUILD_ROOT/%{prefix}/lib/perl/Confluent
 mkdir -p $RPM_BUILD_ROOT/%{prefix}/lib/perl/xCAT_schema/samples
 mkdir -p $RPM_BUILD_ROOT/%{prefix}/lib/perl/xCAT
+mkdir -p $RPM_BUILD_ROOT/%{prefix}/lib/python
 
 %ifos linux
 cp -a share/xcat/install/* $RPM_BUILD_ROOT/%{prefix}/share/xcat/install/
@@ -168,6 +169,9 @@ cp lib/xcat/plugins/* $RPM_BUILD_ROOT/%{prefix}/lib/perl/xCAT_plugin
 chmod 644 $RPM_BUILD_ROOT/%{prefix}/lib/perl/xCAT_plugin/*
 
 cp lib/perl/xCAT/* $RPM_BUILD_ROOT/%{prefix}/lib/perl/xCAT
+cp -r lib/python/agent $RPM_BUILD_ROOT/%{prefix}/lib/python/
+chmod 755 $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/client.py
+chmod 755 $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/agent.py
 chmod 644 $RPM_BUILD_ROOT/%{prefix}/lib/perl/xCAT/*
 
 chmod 755 $RPM_BUILD_ROOT/%{prefix}/share/xcat/netboot/sles/*.postinstall
@@ -188,6 +192,7 @@ rm $RPM_BUILD_ROOT/%{prefix}/lib/perl/xCAT_plugin/vbox.pm
 rm $RPM_BUILD_ROOT/%{prefix}/lib/perl/xCAT_plugin/activedirectory.pm
 rm $RPM_BUILD_ROOT/%{prefix}/lib/perl/xCAT_plugin/kit.pm
 rm $RPM_BUILD_ROOT/%{prefix}/lib/perl/xCAT_plugin/confluent.pm
+rm -rf $RPM_BUILD_ROOT/%{prefix}/lib/python
 %endif
 
 cp lib/xcat/dsh/Context/* $RPM_BUILD_ROOT/%{prefix}/xdsh/Context


### PR DESCRIPTION
This patch add a framework to communicate betwwen python and perl
modules. Orignal xcat plugin run a python agent, then send the request
info and the data from db to the python agent with unix domain socket.

Below is the UT example, some overhead to fork the process, but not too
much.
```
# time rpower simulator_test0,simulator_test1 status
simulator_test0: rpower called info={u'bmcip': u'10.5.102.73', u'bmc': u'10.5.102.73', u'username': u'root', u'password': u'cluster'} args=[u'status']
simulator_test1: rpower called info={u'bmcip': u'10.5.102.73', u'bmc': u'10.5.102.73', u'username': u'root', u'password': u'cluster'} args=[u'status']
real   	0m0.310s
user   	0m0.071s
sys    	0m0.016s
```

implement #4561 
```
# /opt/xcat/lib/perl/xCAT_plugin/agent/agent.py --help
usage: xcatagent [--standalone] [--sock SOCK]

Optional arguments:
  --standalone  Start xcat agent as a standalone service, mostly work for test
                purpose.
  --sock SOCK   The unix domain sock file to communicate with the client

# /opt/xcat/lib/perl/xCAT_plugin/agent/client.py --help
usage: agentclient [--sock SOCK]

Optional arguments:
  --sock SOCK  The unix domain sock file to communicate with the server
```