### PR TITLE
Add "ipmi=on" to channel setaccess in "bmcsetup" script

### DIFF
--- a/xCAT-genesis-scripts/bin/bmcsetup
+++ b/xCAT-genesis-scripts/bin/bmcsetup
@@ -481,8 +481,8 @@ for user in $BMCUS; do
     fi
 
     TRIES=0
-    # Enable the channel link for the specified user
-    while ! ipmitool -d $idev channel setaccess $LANCHAN $USERSLOT link=on; do
+    # Enable the channel and ipmi link for the specified user
+    while ! ipmitool -d $idev channel setaccess $LANCHAN $USERSLOT link=on ipmi=on; do
         sleep 1
         let TRIES=TRIES+1
         if [ $TRIES -gt $TIMEOUT ]; then break; fi

--- a/xCAT-genesis-scripts/bin/bmcsetup
+++ b/xCAT-genesis-scripts/bin/bmcsetup
@@ -481,8 +481,13 @@ for user in $BMCUS; do
     fi
 
     TRIES=0
-    # Enable the channel and ipmi link for the specified user
-    while ! ipmitool -d $idev channel setaccess $LANCHAN $USERSLOT link=on ipmi=on; do
+    # Enable the channel link for the specified user
+    if [ "$IPMIMFG" == 343 -a "$XPROD" == 124 ]; then # For Intel S2600BP system boards
+        cmd="ipmitool -d $idev channel setaccess $LANCHAN $USERSLOT link=on ipmi=on"
+    else
+        cmd="ipmitool -d $idev channel setaccess $LANCHAN $USERSLOT link=on"
+    fi
+    while ! eval $cmd; do
         sleep 1
         let TRIES=TRIES+1
         if [ $TRIES -gt $TIMEOUT ]; then break; fi


### PR DESCRIPTION
Hello xCAT Team,

I noticed the "bmcsetup" script in genesis network image was successfully creating the ipmi user as defined in the passwd table.  However, for the Intel S2600BP compute boards, there is another attribute that must be set called "ipmi=on".  Without this, the ipmi user cannot query the bmc remotely.  To remedy this, I added the option into the bmcsetup script and re-ran "mknb x86_64".  Now when I run "nodeset nodename runcmd=bmcsetup" and reboot the node, bmcsetup runs correctly on next boot.  Subsequently I can now "rpower nodename status" without issue.

The BMC that is included in the Intel S2600BP compute board is the same family ASPEED BMC that is popping up all over (just like our Minskies and Newells :+1: ), so I'm not sure what impact the additional option could have on other MTMs during the bmcsetup process.