### PR TITLE
rpower support utilizing the python framework for OpenBMC

### DIFF
--- a/xCAT-server/lib/perl/xCAT/OPENBMC.pm
+++ b/xCAT-server/lib/perl/xCAT/OPENBMC.pm
@@ -123,6 +123,8 @@ sub submit_agent_request {
         kill('TERM', $pid);
         return;
     }
+    my $xcatdebugmode;
+    if ($::XCATSITEVALS{xcatdebugmode}) { $xcatdebugmode = $::XCATSITEVALS{xcatdebugmode} }
     my ($data, $sz, $ret, $buf);
     $data->{module} = 'openbmc';
     $data->{command} = $req->{command}->[0];
@@ -130,6 +132,7 @@ sub submit_agent_request {
     $data->{cwd} = $req->{cwd};
     $data->{nodes} = $req->{node};
     $data->{nodeinfo} = $nodeinfo;
+    $data->{debugmode} = $xcatdebugmode;
     $buf = encode_json($data);
     $sz = pack('i', length($buf));
     $ret = $sock->send($sz);

--- a/xCAT-server/lib/perl/xCAT/OPENBMC.pm
+++ b/xCAT-server/lib/perl/xCAT/OPENBMC.pm
@@ -123,8 +123,10 @@ sub submit_agent_request {
         kill('TERM', $pid);
         return;
     }
-    my $xcatdebugmode;
+    my $xcatdebugmode = 0;
     if ($::XCATSITEVALS{xcatdebugmode}) { $xcatdebugmode = $::XCATSITEVALS{xcatdebugmode} }
+    my %env_hash = ();
+    $env_hash{debugmode} = $xcatdebugmode;
     my ($data, $sz, $ret, $buf);
     $data->{module} = 'openbmc';
     $data->{command} = $req->{command}->[0];
@@ -132,7 +134,7 @@ sub submit_agent_request {
     $data->{cwd} = $req->{cwd};
     $data->{nodes} = $req->{node};
     $data->{nodeinfo} = $nodeinfo;
-    $data->{debugmode} = $xcatdebugmode;
+    $data->{envs} = \%env_hash;
     $buf = encode_json($data);
     $sz = pack('i', length($buf));
     $ret = $sock->send($sz);

--- a/xCAT-server/lib/python/agent/client.py
+++ b/xCAT-server/lib/python/agent/client.py
@@ -41,8 +41,8 @@ class ClientShell(object):
 
         s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         nodes = ['node1', 'node2']
-        nodeinfo = {'node1':{'bmc':'9.3.185.161', 'bmcip':'9.3.185.161', 'username':'root', 'password': '0penBmc1'},
-                    'node2':{'bmc':'10.6.17.100', 'bmcip': '10.6.17.100', 'username':'root', 'password': '0penBmc'}}
+        nodeinfo = {'node1':{'bmc':'10.0.0.1', 'bmcip':'10.0.0.1', 'username':'root', 'password': 'xxxxxx'},
+                    'node2':{'bmc':'10.0.0.2', 'bmcip':'10.0.0.2', 'username':'root', 'password': 'xxxxxx'}}
 
         s.connect(options.sock)
         req = {'module': 'openbmc',
@@ -51,7 +51,7 @@ class ClientShell(object):
                'cwd': os.getcwd(),
                'nodes': nodes,
                'nodeinfo': nodeinfo,
-               'debugmode': 1}
+               'envs': {'debugmode': 1}}
 
         buf = json.dumps(req)
         s.send(utils.int2bytes(len(buf)))

--- a/xCAT-server/lib/python/agent/client.py
+++ b/xCAT-server/lib/python/agent/client.py
@@ -40,18 +40,18 @@ class ClientShell(object):
             return 0
 
         s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        nodes = ['node%s' % i for i in range(100)]
-        nodeinfo = {node: {'username': 'admin', 'password': 'cluster'} for node
-                    in
-                    nodes}
+        nodes = ['node1', 'node2']
+        nodeinfo = {'node1':{'bmc':'9.3.185.161', 'bmcip':'9.3.185.161', 'username':'root', 'password': '0penBmc1'},
+                    'node2':{'bmc':'10.6.17.100', 'bmcip': '10.6.17.100', 'username':'root', 'password': '0penBmc'}}
 
         s.connect(options.sock)
         req = {'module': 'openbmc',
                'command': 'rpower',
-               'args': ['-d', 'firmware'],
+               'args': ['state'],
                'cwd': os.getcwd(),
                'nodes': nodes,
-               'nodeinfo': nodeinfo}
+               'nodeinfo': nodeinfo,
+               'debugmode': 1}
 
         buf = json.dumps(req)
         s.send(utils.int2bytes(len(buf)))

--- a/xCAT-server/lib/python/agent/xcatagent/__init__.py
+++ b/xCAT-server/lib/python/agent/xcatagent/__init__.py
@@ -1,2 +1,2 @@
 from gevent import monkey
-monkey.patch_socket()
+monkey.patch_all(thread=False)

--- a/xCAT-server/lib/python/agent/xcatagent/base.py
+++ b/xCAT-server/lib/python/agent/xcatagent/base.py
@@ -1,4 +1,5 @@
 from xcatagent import utils
+import gevent
 
 MODULE_MAP = {"openbmc": "OpenBMCManager"}
 
@@ -18,6 +19,25 @@ class BaseManager(object):
 
         class_name = MODULE_MAP[name]
         return utils.class_func(module_name, class_name)
+
+    def process_nodes_worker(self, name, classname, nodes, nodeinfo, command, args):
+        
+        glist = []
+        module_name = 'xcatagent.%s' % name
+        obj_func = utils.class_func(module_name, classname)
+
+        for node in nodes:
+            obj = obj_func(self.messager, node, nodeinfo[node])
+            if not hasattr(obj, command):
+                self.messager.error('%s: command %s is not supported for %s' % (node, command, classname))
+            func = getattr(obj, command)
+            try:
+                glist.append( gevent.spawn(func, args) )
+            except Exception:
+                error = '%s: Internel Error occured in gevent' % node
+                self.messager.error(error)
+
+        gevent.joinall(glist)
 
 
 class BaseDriver(object):

--- a/xCAT-server/lib/python/agent/xcatagent/openbmc.py
+++ b/xCAT-server/lib/python/agent/xcatagent/openbmc.py
@@ -223,11 +223,11 @@ class OpenBMC(base.BaseDriver):
 
 
 class OpenBMCManager(base.BaseManager):
-    def __init__(self, messager, cwd, nodes, debugmode):
+    def __init__(self, messager, cwd, nodes, envs):
         super(OpenBMCManager, self).__init__(messager, cwd)
         self.nodes = nodes
         global DEBUGMODE
-        DEBUGMODE = debugmode
+        DEBUGMODE = envs['debugmode']
 
     def rpower(self, nodeinfo, args):
         super(OpenBMCManager, self).process_nodes_worker('openbmc', 'OpenBMC', self.nodes, nodeinfo, 'rpower', args)

--- a/xCAT-server/lib/python/agent/xcatagent/openbmc.py
+++ b/xCAT-server/lib/python/agent/xcatagent/openbmc.py
@@ -1,26 +1,233 @@
 from xcatagent import base
-import gevent
+import time
+import sys
+
+import xcat_exception
+import rest
+
+HTTP_PROTOCOL = "https://"
+PROJECT_URL = "/xyz/openbmc_project"
+
+RESULT_OK = 'ok'
+
+DEBUGMODE = False
+
+POWER_SET_OPTIONS = ('on', 'off', 'bmcreboot', 'softoff')
+POWER_GET_OPTIONS = ('bmcstate', 'state', 'stat', 'status')
+
+RPOWER_URLS = {
+    "on"        : {
+        "url"   : PROJECT_URL + "/state/host0/attr/RequestedHostTransition",
+        "field" : "xyz.openbmc_project.State.Host.Transition.On",
+    },
+    "off"       : {
+        "url"   : PROJECT_URL + "/state/chassis0/attr/RequestedPowerTransition",
+        "field" : "xyz.openbmc_project.State.Chassis.Transition.Off",
+    },
+    "softoff"   : {
+        "url"   : PROJECT_URL + "/state/host0/attr/RequestedHostTransition",
+        "field" : "xyz.openbmc_project.State.Host.Transition.Off",
+    },
+    "bmcreboot" : {
+        "url"   : PROJECT_URL + "/state/bmc0/attr/RequestedBMCTransition",
+        "field" : "xyz.openbmc_project.State.BMC.Transition.Reboot",
+    },
+    "state"     : {
+        "url"   : PROJECT_URL + "/state/enumerate",
+    },
+}
+
+RPOWER_STATE = {
+    "on"        : "on",
+    "off"       : "off",
+    "Off"       : "off",
+    "softoff"   : "softoff",
+    "boot"      : "reset",
+    "reset"     : "reset",
+    "bmcreboot" : "BMC reboot",
+    "Ready"     : "BMC Ready",
+    "NotReady"  : "BMC NotReady",
+    "chassison" : "on (Chassis)",
+    "Running"   : "on",
+    "Quiesced"  : "quiesced",
+}
+
+class OpenBMC(base.BaseDriver):
+
+    headers = {'Content-Type': 'application/json'}
+
+    def __init__(self, messager, name, node_info):
+        super(OpenBMC, self).__init__(messager)        
+        self.node = name
+        for key, value in node_info.items() :
+            setattr(self, key, value)
+        global DEBUGMODE
+        self.client = rest.RestSession(messager, DEBUGMODE)
+
+
+    def _login(self) :
+        """ Login
+        :raise: error message if failed
+        """
+        url = HTTP_PROTOCOL + self.bmcip + '/login'
+        data = { "data": [ self.username, self.password ] }
+        self.client.request('POST', url, OpenBMC.headers, data, self.node, 'login')
+        return RESULT_OK
+
+
+    def _set_power_onoff(self, subcommand) :
+        """ Set power on/off/softoff/bmcreboot
+        :param subcommand: subcommand for rpower
+        :returns: on/off/softoff/BMC reboot if success
+        :raise: error message if failed
+        """
+        url = HTTP_PROTOCOL + self.bmcip + RPOWER_URLS[subcommand]['url']
+        data = { "data": RPOWER_URLS[subcommand]['field'] }
+        try :
+            response = self.client.request('PUT', url, OpenBMC.headers, data, self.node, 'rpower_' + subcommand)
+        except (xcat_exception.SelfServerException,
+                xcat_exception.SelfClientException) as e :
+            if subcommand != 'bmcreboot':
+                result = e.message
+            return result
+
+        return RESULT_OK
+
+
+    def _get_power_state(self, subcommand) :
+        """ Get power current state
+        :param subcommand: state/stat/status/bmcstate
+        :returns: current state if success
+        :raise: error message if failed
+        """
+        result = ''
+        bmc_not_ready = 'NotReady'
+        url = HTTP_PROTOCOL + self.bmcip + RPOWER_URLS['state']['url']
+        try :
+            response = self.client.request('GET', url, OpenBMC.headers, '', self.node, 'rpower_' + subcommand)
+        except xcat_exception.SelfServerException, e :
+            if subcommand == 'bmcstate':
+                result = bmc_not_ready
+            else :
+                result = e.message
+        except xcat_exception.SelfClientException, e :
+            result = e.message
+
+        if result : 
+            return result
+
+        for key in response['data'] :
+            key_type = key.split('/')[-1]
+            if key_type == 'bmc0' :
+                bmc_current_state = response['data'][key]['CurrentBMCState'].split('.')[-1]
+            if key_type == 'chassis0' :
+                chassis_current_state = response['data'][key]['CurrentPowerState'].split('.')[-1]
+            if key_type == 'host0' :
+                host_current_state = response['data'][key]['CurrentHostState'].split('.')[-1]
+
+        if subcommand == 'bmcstate' :
+            if bmc_current_state == 'Ready' :
+                return bmc_current_state 
+            else :
+                return bmc_not_ready
+
+        if chassis_current_state == 'Off' :
+            return chassis_current_state
+        elif chassis_current_state == 'On' :
+            if host_current_state == 'Off' :
+                return 'chassison'
+            elif host_current_state == 'Quiesced' :
+                return host_current_state
+            elif host_current_state == 'Running' :
+                return host_current_state
+            else :
+                return 'Unexpected chassis state=' + host_current_state
+        else :
+            return 'Unexpected chassis state=' + chassis_current_state
+
+
+    def _rpower_boot(self) :
+        """Power boot
+        :returns: 'reset' if success
+        :raise: error message if failed
+        """
+        result = self._set_power_onoff('off')
+        if result != RESULT_OK :
+            return result
+
+        start_timeStamp = int(time.time())
+        for i in range (0,30) :
+            status = self._get_power_state('state')
+            if status in RPOWER_STATE.keys() and RPOWER_STATE[status] == 'off':
+                break
+            gevent.sleep( 2 )
+
+        end_timeStamp = int(time.time())
+
+        if status not in RPOWER_STATE.keys() or RPOWER_STATE[status] != 'off':
+            wait_time = str(end_timeStamp - start_timeStamp)
+            result = 'Error: Sent power-off command but state did not change to off after waiting ' + wait_time + ' seconds. (State=' + status + ').'
+            return result
+
+        result = self._set_power_onoff('on')
+        return result
+
+
+    def rpower(self, args) :
+        """handle rpower command
+        :param args: subcommands for rpower
+        """
+        subcommand = args[0]
+        try :
+            result = self._login()
+        except xcat_exception.SelfServerException as e :
+            if subcommand == 'bmcstate' :
+                result = self.node + ': ' + RPOWER_STATE[Notready]
+            else :
+                result = self.node + ': ' + e.message
+        except xcat_exception.SelfClientException as e :
+            result = self.node + ': ' + e.message 
+
+        if result != RESULT_OK :
+            self.messager.info(result)
+            return
+
+        if subcommand in POWER_SET_OPTIONS :
+            result = self._set_power_onoff(subcommand)
+            if result == RESULT_OK :
+                result = RPOWER_STATE[subcommand]
+
+        if subcommand in POWER_GET_OPTIONS :
+            tmp_result = self._get_power_state(subcommand)
+            if tmp_result in RPOWER_STATE.keys() :
+                result = RPOWER_STATE[tmp_result]
+            else :
+                result = tmp_result
+
+        if subcommand == 'boot' :
+            result = self._rpower_boot()
+            if result == RESULT_OK :
+                result = RPOWER_STATE[subcommand]
+
+        if subcommand == 'reset' :
+            status = self._get_power_state('state')
+            if status == 'Off' or status == 'chassison':
+                result = RPOWER_STATE['Off']
+            else :
+                result = self._rpower_boot()
+                if result == RESULT_OK :
+                    result = RPOWER_STATE[subcommand]
+
+        message = self.node + ": " + result
+        self.messager.info(message)
 
 
 class OpenBMCManager(base.BaseManager):
-    def __init__(self, messager, cwd, nodes):
+    def __init__(self, messager, cwd, nodes, debugmode):
         super(OpenBMCManager, self).__init__(messager, cwd)
         self.nodes = nodes
+        global DEBUGMODE
+        DEBUGMODE = debugmode
 
     def rpower(self, nodeinfo, args):
-        driver = OpenBMCDriver(self.messager)
-        lst = [gevent.spawn(driver.rpower, node, nodeinfo[node],
-                            args) for node in self.nodes]
-        gevent.joinall(lst)
-
-
-class OpenBMCDriver(base.BaseDriver):
-    def __init__(self, messager):
-        super(OpenBMCDriver, self).__init__(messager)
-
-    def rpower(self, node, info, args):
-        if node == 'node1':
-            self.messager
-            gevent.sleep(3)
-        self.messager.info(
-            "%s: rpower called info=%s args=%s" % (node, info, args))
+        super(OpenBMCManager, self).process_nodes_worker('openbmc', 'OpenBMC', self.nodes, nodeinfo, 'rpower', args)

--- a/xCAT-server/lib/python/agent/xcatagent/rest.py
+++ b/xCAT-server/lib/python/agent/xcatagent/rest.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+import requests
+import json
+import time
+import urllib3
+urllib3.disable_warnings()
+
+import xcat_exception
+
+class RestSession :
+
+    def __init__(self, messager, debugmode) :
+        self.session = requests.Session()
+        self.messager = messager
+        self.debugmode = debugmode
+
+    def _print_record_log (self, node, log_string, status) :
+        if self.debugmode :
+            localtime = time.asctime( time.localtime(time.time()) )
+            log = node + ': [openbmc_debug] ' + status + ' ' + log_string
+            self.messager.info(localtime + ' ' + log)
+            self.messager.syslog(log)
+
+    def _request_log (self, method, url, headers, data):
+        log_string = 'curl -k -c cjar'
+        log_string += ' -X %s' % method
+        for key,value in headers.items() :
+            header_data = key + ": " + value 
+        log_string += ' -H "' + header_data + '"'
+        log_string += ' %s' % url
+
+        if data :
+            log_string += ' -d \'%s\'' % data
+
+        return log_string
+
+    def request (self, method, url, headers, in_data, node, status) :
+        if in_data :
+            data = json.dumps(in_data)
+        else :
+            data = ''
+
+        if status == 'login' :
+            in_data['data'][1] = 'xxxxxx'
+            log_data = json.dumps(in_data)
+        else :
+            log_data = data
+
+        log_string = self._request_log(method, url, headers, log_data)
+        self._print_record_log(node, log_string, status)
+
+        response = ''
+        error = ''
+        try :
+            response = self.session.request(method, url,
+                                        data=data,
+                                        headers=headers,
+                                        verify=False,
+                                        timeout=30)
+        except requests.exceptions.ConnectionError :
+            error = 'Unable to connect to server'
+        except requests.exceptions.Timeout :
+            error = 'Timeout to connect to server'
+
+        if error :
+            self._print_record_log(node, error, status)
+            raise xcat_exception.SelfServerException(error)
+
+        try :
+            response_dict = response.json()
+        except ValueError :
+            error = 'Received wrong format response:' + response_dict
+            self._print_record_log(node, error, status)
+            raise xcat_exception.SelfServerException(error)
+
+        if response.status_code != requests.codes.ok :
+            description = ''.join(response_dict['data']['description'])
+            error = '[%d] %s' % (response.status_code, description)
+            self._print_record_log(node, error, status)
+            raise xcat_exception.SelfClientException(error)
+        else :
+            self._print_record_log(node, response_dict['message'], status)
+
+        return response_dict

--- a/xCAT-server/lib/python/agent/xcatagent/rest.py
+++ b/xCAT-server/lib/python/agent/xcatagent/rest.py
@@ -58,9 +58,9 @@ class RestSession :
                                         verify=False,
                                         timeout=30)
         except requests.exceptions.ConnectionError :
-            error = 'Unable to connect to server'
+            error = 'Error: Unable to connect to server'
         except requests.exceptions.Timeout :
-            error = 'Timeout to connect to server'
+            error = 'Error: Timeout to connect to server'
 
         if error :
             self._print_record_log(node, error, status)
@@ -69,13 +69,13 @@ class RestSession :
         try :
             response_dict = response.json()
         except ValueError :
-            error = 'Received wrong format response:' + response_dict
+            error = 'Error: Received wrong format response:' + response_dict
             self._print_record_log(node, error, status)
             raise xcat_exception.SelfServerException(error)
 
         if response.status_code != requests.codes.ok :
             description = ''.join(response_dict['data']['description'])
-            error = '[%d] %s' % (response.status_code, description)
+            error = 'Error: [%d] %s' % (response.status_code, description)
             self._print_record_log(node, error, status)
             raise xcat_exception.SelfClientException(error)
         else :

--- a/xCAT-server/lib/python/agent/xcatagent/server.py
+++ b/xCAT-server/lib/python/agent/xcatagent/server.py
@@ -86,9 +86,9 @@ class Server(object):
                 messager.error("Could not find manager for %s" % req['module'])
                 return
             nodes = req.get("nodes", None)
-            manager = manager_func(messager, req['cwd'], nodes)
+            manager = manager_func(messager, req['cwd'], nodes, req['debugmode'])
             if not hasattr(manager, req['command']):
-                messager.error("coomand %s is not supported" % req['command'])
+                messager.error("command %s is not supported" % req['command'])
             func = getattr(manager, req['command'])
             # call the function in the specified manager
             func(req['nodeinfo'], req['args'])

--- a/xCAT-server/lib/python/agent/xcatagent/server.py
+++ b/xCAT-server/lib/python/agent/xcatagent/server.py
@@ -86,7 +86,7 @@ class Server(object):
                 messager.error("Could not find manager for %s" % req['module'])
                 return
             nodes = req.get("nodes", None)
-            manager = manager_func(messager, req['cwd'], nodes, req['debugmode'])
+            manager = manager_func(messager, req['cwd'], nodes, req['envs'])
             if not hasattr(manager, req['command']):
                 messager.error("command %s is not supported" % req['command'])
             func = getattr(manager, req['command'])

--- a/xCAT-server/lib/python/agent/xcatagent/xcat_exception.py
+++ b/xCAT-server/lib/python/agent/xcatagent/xcat_exception.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+class SelfServerException(Exception) :
+    pass
+
+class SelfClientException(Exception) :
+    pass

--- a/xCAT-server/lib/xcat/plugins/openbmc2.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc2.pm
@@ -29,7 +29,7 @@ use xCAT::OPENBMC;
 
 sub handled_commands {
     return {
-        # rpower         => 'nodehm:mgt=openbmc',
+        rpower         => 'nodehm:mgt=openbmc2',
     };
 }
 


### PR DESCRIPTION
#4554 

UT:
```
# rpower f6u17 state
f6u17: on
```
UT with "xcatdebugmode" is 1:
```
# rpower f6u17 bmcreboot
Wed Dec 27 02:08:47 2017 f6u17: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.17.100/login -d '{"data": ["root", "xxxxxx"]}'
Wed Dec 27 02:08:47 2017 f6u17: [openbmc_debug] login 200 OK
Wed Dec 27 02:08:47 2017 f6u17: [openbmc_debug] rpower_bmcreboot curl -k -c cjar -b cjar -X PUT -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/state/bmc0/attr/RequestedBMCTransition -d '{"data": "xyz.openbmc_project.State.BMC.Transition.Reboot"}'
Wed Dec 27 02:08:47 2017 f6u17: [openbmc_debug] rpower_bmcreboot 200 OK
f6u17: BMC reboot
```
UT when password is wrong:
```
# rpower openbmctest state
openbmctest: Error: [401] Invalid username or password
```
  