### PR TITLE
Add man page and usage help for 'leds' option for OpenBMC

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rflash.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rflash.1.rst
@@ -150,31 +150,19 @@ The command will update firmware for OpenPOWER BMC when given an OpenPOWER node 
 
 \ **-l|-**\ **-list**\ :
 
+The list option will list out available firmware on the BMC.  It provides an interface to display the ID of the various firmware levels.
 
-.. code-block:: perl
+The (\*) symbol indicates the active running firmware on the server.
 
-    The list option will list out available firmware on the BMC.  It provides an interface to display the ID of the various firmware levels.  
- 
-    The (*) symbol indicates the active running firmware on the server.  
- 
-    The (+) symbol indicates the firmware that is pending and a reboot is required to set it to be the active running firmware level.
-
+The (+) symbol indicates the firmware that is pending and a reboot is required to set it to be the active running firmware level.
 
 \ **-u|-**\ **-upload**\ :
 
-
-.. code-block:: perl
-
-    The upload option expects a .tar file as the input and will upload the file to the BMC.  Use the list option to view the result.
-
+The upload option expects a .tar file as the input and will upload the file to the BMC.  Use the list option to view the result.
 
 \ **-a|-**\ **-activate**\ :
 
-
-.. code-block:: perl
-
-    The activate option expects either a .tar file or an ID as the input.  If a .tar file is provided, it will upload and activate the firmware in a single step
-
+The activate option expects either a .tar file or an ID as the input.  If a .tar file is provided, it will upload and activate the firmware in a single step
 
 To apply the firmware level, a reboot is required to BMC and HOST.
 
@@ -182,21 +170,13 @@ To apply the firmware level, a reboot is required to BMC and HOST.
 
 \ **-d**\ :
 
-
-.. code-block:: perl
-
-    This option steamlines the update, activate, reboot BMC and reboot HOST procedure. It expects a directory containing both BMC and PNOR .tar files. When BMC and PNOR tar files are provided, the command will upload and activate firmware. After BMC becomes activate, it will reboot BMC. If BMC state is Ready, the command will reboot the HOST. If BMC state is NotReady, the command will exit.
-
+This option steamlines the update, activate, reboot BMC and reboot HOST procedure. It expects a directory containing both BMC and PNOR .tar files. When BMC and PNOR tar files are provided, the command will upload and activate firmware. After BMC becomes activate, it will reboot BMC. If BMC state is Ready, the command will reboot the HOST. If BMC state is NotReady, the command will exit.
 
 \ **Note:**\  When using \ **-**\ **-no-host-reboot**\ , it will not reboot the host after BMC is reboot.
 
 \ **-**\ **-delete**\ :
 
-
-.. code-block:: perl
-
-    This delete option will delete update image from BMC. It expects an ID as the input.
-
+This delete option will delete update image from BMC. It expects an ID as the input.
 
 
 

--- a/docs/source/guides/admin-guides/references/man1/rflash.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rflash.1.rst
@@ -199,21 +199,6 @@ To apply the firmware level, a reboot is required to BMC and HOST.
 
 
 
-\ **-d**\ :
-
-.. code-block:: perl
-
-    This option steamlines the update, activate, reboot BMC and reboot HOST procedure. It expects a directory containing both BMC and PNOR .tar files. When BMC and PNOR tar files are provided, the command will upload and activate firmware. After BMC becomes activate, it will reboot BMC. If BMC state is Ready, the command will reboot the HOST. If BMC state is NotReady, the command will exit.
-
-\ **Note:**\ When using \ **--no-host-reboot**\, it will not reboot the host after BMC is reboot. 
-
-
-\ **-**\ **-delete**\ :
-
-.. code-block:: perl
-
-    The delete option will delete update image from BMC. It expects an ID as the input.
-
 
 ***************
 \ **Options**\ 

--- a/docs/source/guides/admin-guides/references/man1/rvitals.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rvitals.1.rst
@@ -67,7 +67,7 @@ OpenPOWER (OpenBMC) specific:
 =============================
 
 
-\ **rvitals**\  \ *noderange*\  [\ **temp | voltage | wattage | fanspeed | power | altitude | all**\ ]
+\ **rvitals**\  \ *noderange*\  [\ **temp | voltage | wattage | fanspeed | power | leds | altitude | all**\ ]
 
 
 

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -83,7 +83,7 @@ my %usage = (
   OpenPOWER (IPMI) specific:
       rvitals noderange [temp|voltage|wattage|fanspeed|power|leds|chassis|all]
   OpenPOWER (OpenBMC) specific:
-      rvitals noderange [temp|voltage|wattage|fanspeed|power|altitude|all]
+      rvitals noderange [temp|voltage|wattage|fanspeed|power|leds|altitude|all]
   MIC specific:
       rvitals noderange {thermal|all}
   pdu specific:

--- a/xCAT-client/pods/man1/rflash.1.pod
+++ b/xCAT-client/pods/man1/rflash.1.pod
@@ -103,19 +103,19 @@ The command will update firmware for OpenPOWER BMC when given an OpenPOWER node 
 
 B<-l|--list>:
 
-   The list option will list out available firmware on the BMC.  It provides an interface to display the ID of the various firmware levels.  
+The list option will list out available firmware on the BMC.  It provides an interface to display the ID of the various firmware levels.  
 
-   The (*) symbol indicates the active running firmware on the server.  
+The (*) symbol indicates the active running firmware on the server.  
 
-   The (+) symbol indicates the firmware that is pending and a reboot is required to set it to be the active running firmware level. 
+The (+) symbol indicates the firmware that is pending and a reboot is required to set it to be the active running firmware level. 
 
 B<-u|--upload>:
 
-   The upload option expects a .tar file as the input and will upload the file to the BMC.  Use the list option to view the result. 
+The upload option expects a .tar file as the input and will upload the file to the BMC.  Use the list option to view the result. 
 
 B<-a|--activate>: 
 
-   The activate option expects either a .tar file or an ID as the input.  If a .tar file is provided, it will upload and activate the firmware in a single step 
+The activate option expects either a .tar file or an ID as the input.  If a .tar file is provided, it will upload and activate the firmware in a single step 
 
 To apply the firmware level, a reboot is required to BMC and HOST. 
 
@@ -123,13 +123,13 @@ B<Note:> When using B<rflash> in hierarchical environment, the .tar file must be
 
 B<-d>:
 
-   This option steamlines the update, activate, reboot BMC and reboot HOST procedure. It expects a directory containing both BMC and PNOR .tar files. When BMC and PNOR tar files are provided, the command will upload and activate firmware. After BMC becomes activate, it will reboot BMC. If BMC state is Ready, the command will reboot the HOST. If BMC state is NotReady, the command will exit. 
+This option steamlines the update, activate, reboot BMC and reboot HOST procedure. It expects a directory containing both BMC and PNOR .tar files. When BMC and PNOR tar files are provided, the command will upload and activate firmware. After BMC becomes activate, it will reboot BMC. If BMC state is Ready, the command will reboot the HOST. If BMC state is NotReady, the command will exit. 
 
 B<Note:> When using B<--no-host-reboot>, it will not reboot the host after BMC is reboot. 
 
 B<--delete>:
 
-   This delete option will delete update image from BMC. It expects an ID as the input.
+This delete option will delete update image from BMC. It expects an ID as the input.
 
 =head1 B<Options>
 

--- a/xCAT-client/pods/man1/rvitals.1.pod
+++ b/xCAT-client/pods/man1/rvitals.1.pod
@@ -32,7 +32,7 @@ B<rvitals> I<noderange> [B<temp>|B<voltage>|B<wattage>|B<fanspeed>|B<power>|B<le
 
 =head2 OpenPOWER (OpenBMC) specific:
 
-B<rvitals> I<noderange> [B<temp>|B<voltage>|B<wattage>|B<fanspeed>|B<power>|B<altitude>|B<all>]
+B<rvitals> I<noderange> [B<temp>|B<voltage>|B<wattage>|B<fanspeed>|B<power>|B<leds>|B<altitude>|B<all>]
 
 =head1 B<Description>
 


### PR DESCRIPTION
Missed in PR #4570  and partially resolves #4476 

Adding man page  and usage addition for the "leds" support option for OpenBMC - rvitals
  
First commit includes some rflash changes that was missed to push to RTD 