### PR TITLE
Remove deprecated SSH option KeyRegenerationInterval from remoteshell

### DIFF
--- a/xCAT/postscripts/remoteshell
+++ b/xCAT/postscripts/remoteshell
@@ -56,8 +56,6 @@ then
         #delete all occurance of the attribute and then add xCAT settings
         sed -i '/X11Forwarding /'d /etc/ssh/sshd_config
         echo "X11Forwarding yes" >>/etc/ssh/sshd_config
-        sed -i '/KeyRegenerationInterval /'d /etc/ssh/sshd_config
-        echo "KeyRegenerationInterval 0" >>/etc/ssh/sshd_config
         sed -i '/MaxStartups /'d /etc/ssh/sshd_config
         echo "MaxStartups 1024" >>/etc/ssh/sshd_config
  


### PR DESCRIPTION
Avoid a syslog message like:
`/etc/ssh/sshd_config line 144: Deprecated option KeyRegenerationInterval`
That option is only for SSHv1, which has already been deprecated and is being removed from OpenSSH