### PR TITLE
`Canada/East-Saskatchewan` obsoleted by tzdata-2017c

### DIFF
--- a/xCAT-genesis-builder/install
+++ b/xCAT-genesis-builder/install
@@ -473,7 +473,6 @@ dracut_install /usr/share/zoneinfo/posix/Asia/Phnom_Penh
 dracut_install /usr/share/zoneinfo/posix/Asia/Ulan_Bator
 dracut_install /usr/share/zoneinfo/posix/Asia/Sakhalin
 dracut_install /usr/share/zoneinfo/posix/MST7MDT
-dracut_install /usr/share/zoneinfo/posix/Canada/East-Saskatchewan
 dracut_install /usr/share/zoneinfo/posix/Canada/Atlantic
 dracut_install /usr/share/zoneinfo/posix/Canada/Central
 dracut_install /usr/share/zoneinfo/posix/Canada/Eastern

--- a/xCAT-genesis-builder/install.ubuntu
+++ b/xCAT-genesis-builder/install.ubuntu
@@ -498,7 +498,6 @@ dracut_install /usr/share/zoneinfo/posix/Asia/Phnom_Penh
 dracut_install /usr/share/zoneinfo/posix/Asia/Ulan_Bator
 dracut_install /usr/share/zoneinfo/posix/Asia/Sakhalin
 dracut_install /usr/share/zoneinfo/posix/MST7MDT
-dracut_install /usr/share/zoneinfo/posix/Canada/East-Saskatchewan
 dracut_install /usr/share/zoneinfo/posix/Canada/Atlantic
 dracut_install /usr/share/zoneinfo/posix/Canada/Central
 dracut_install /usr/share/zoneinfo/posix/Canada/Eastern


### PR DESCRIPTION
As per the The 2017c release announcement, the zone `Canada/East-Saskatchewan` is
now obsolete: http://mm.icann.org/pipermail/tz-announce/2017-October/000047.html