### PR TITLE
modify reventlog test case depending on the output of reventlog latest code

### DIFF
--- a/xCAT-test/autotest/testcase/reventlog/cases0
+++ b/xCAT-test/autotest/testcase/reventlog/cases0
@@ -3,16 +3,19 @@ cmd:reventlog
 check:rc==0
 check:output=~Usage
 end
+
 start:reventlog_all
 cmd:reventlog $$CN all
 check:rc==0
 check:output=~$$CN\s*:\s*.*\d\d/\d\d/\d\d\s*\S+
 end
+
 start:reventlog_clear
 cmd:reventlog $$CN clear
 check:rc==0
-check:output=~$$CN\s*:\s*clear|SEL cleared
+check:output=~$$CN\s*:\s*Logs cleared|SEL cleared
 end
+
 start:reventlog_numofentries
 cmd:reventlog $$CN 5
 check:rc==0


### PR DESCRIPTION
Due to the output of ``reventlog`` was changed, so update the test case ``reventlog_clear`` to sync up with the latest output. 

Before changing:

```
------START::reventlog_clear::Time:Wed Jan 10 19:39:40 2018------

FILENAME:/opt/xcat/bin/../share/xcat/tools/autotest/testcase//reventlog/cases0

RUN:reventlog f6u17 clear [Wed Jan 10 19:39:40 2018]
ElapsedTime:6 sec
RETURN rc = 0
OUTPUT:
f6u17: Logs cleared
CHECK:rc == 0	[Pass]
CHECK:output =~ f6u17\s*:\s*clear|SEL cleared	[Failed]

------END::reventlog_clear::Failed::Time:Wed Jan 10 19:39:46 2018 ::Duration::6 sec------
```

after changing:

```
------START::reventlog_clear::Time:Wed Jan 10 21:56:25 2018------

RUN:reventlog f6u17 clear [Wed Jan 10 21:56:25 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
f6u17: Logs cleared
CHECK:rc == 0	[Pass]
CHECK:output =~ f6u17\s*:\s*Logs cleared|SEL cleared	[Pass]

------END::reventlog_clear::Passed::Time:Wed Jan 10 21:56:28 2018 ::Duration::3 sec------
------Total: 1 , Failed: 0------
```