### PR TITLE
Add test case for DNS master-slave mode

### DIFF
--- a/xCAT-test/autotest/testcase/installation/switch_to_dns_master_slave_mode
+++ b/xCAT-test/autotest/testcase/installation/switch_to_dns_master_slave_mode
@@ -1,0 +1,74 @@
+start:switch_to_dns_forward_mode
+description:The test case is used to switch the whole testing cluster to run in DNS master-slave mode. This test case should run after service node deployment.
+os:Linux
+
+#
+# xCAT management node will act as DNS master, xCAT service nodes will act as
+# DNS slaves. (supported in xCAT 2.8.4 and later)
+#
+##
+# Check if everything is fine
+##
+cmd:getent hosts $$MN
+check:rc==0
+cmd:getent hosts $$SN
+check:rc==0
+cmd:getent hosts $$CN
+check:rc==0
+
+# Turn off the DNS forward
+cmd:chdef -t site forwarders=
+check:rc==0
+cmd:chdef -t site nameservers='<xcatmaster>'
+check:rc==0
+cmd:makedns -n
+check:rc==0
+
+# Restart the named service
+cmd:service named restart
+cmd:sleep 1
+
+# Check if an outside host name resolving does not work
+cmd:xdsh $$CN "getent hosts w3.ibm.com"
+check:rc!=0
+
+##
+# Change to use the DNS server in c910
+##
+cmd:chdef -t site forwarders=10.0.0.103,10.0.0.101
+check:rc==0
+cmd:chdef -t site nameservers='<xcatmaster>,$$MNIP'
+check:rc==0
+cmd:chdef -t group service setupnameserver=2
+check:rc==0
+cmd:chdef -t group service setupdhcp=1
+check:rc==0
+cmd:makedns -n
+check:rc==0
+
+# Restart the named service on $$MN and $$SN
+cmd:service named restart
+cmd:sleep 1
+cmd:xdsh service 'service named restart'
+cmd:sleep 1
+cmd:xdsh service 'service xcatd restart'
+cmd:sleep 1
+
+##
+# Check if everything is still fine
+##
+cmd:getent hosts $$MN
+check:rc==0
+cmd:getent hosts $$SN
+check:rc==0
+cmd:getent hosts $$CN
+check:rc==0
+cmd:xdsh $$CN "getent hosts $$MN"
+check:rc==0
+cmd:xdsh $$CN "getent hosts $$SN"
+check:rc==0
+cmd:xdsh $$CN "getent hosts $$CN"
+check:rc==0
+# Check if an outside host name resolving works
+cmd:xdsh $$CN "getent hosts w3.ibm.com"
+check:rc==0


### PR DESCRIPTION
This pull request is for task #3947

```
start:switch_to_dns_forward_mode
description:The test case is used to switch the whole testing cluster to run in DNS master-slave mode. This test case should run after service node deployment.
```