### PR TITLE
fis issue [REST] xCAT restful API xcatws cannot work #4622

### DIFF
--- a/xCAT-server/xCAT-wsapi/xcat-ws.conf.apache22
+++ b/xCAT-server/xCAT-wsapi/xcat-ws.conf.apache22
@@ -7,8 +7,8 @@ RewriteCond %{HTTPS} !=on
 RewriteRule ^/?xcatws/(.*) https://%{SERVER_NAME}/xcatws/$1 [R,L]
 RewriteRule ^/?xcatwsv2/(.*) https://%{SERVER_NAME}/xcatwsv2/$1 [R,L]
 
-<Files (xcatws.cgi|zvmxcatws.cgi)>
+<FilesMatch "^(xcatws.cgi|zvmxcatws.cgi)$">
     Order allow,deny
     Allow from all
-</Files>
+</FilesMatch>
 

--- a/xCAT-server/xCAT-wsapi/xcat-ws.conf.apache24
+++ b/xCAT-server/xCAT-wsapi/xcat-ws.conf.apache24
@@ -5,7 +5,6 @@ RewriteCond %{HTTPS} !=on
 RewriteRule ^/?xcatws/(.*) https://%{SERVER_NAME}/xcatws/$1 [R,L]
 RewriteRule ^/?xcatwsv2/(.*) https://%{SERVER_NAME}/xcatwsv2/$1 [R,L]
 
-<Files (xcatws.cgi|zvmxcatws.cgi)>
+<FilesMatch "^(xcatws.cgi|zvmxcatws.cgi)$">
 Require all granted
-</Files>
-
+</FilesMatch>


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/4622:


fix the syntax of apache config file

UT passed on rhels7.4