### PR TITLE
Enhance rflash -c output for ipmi controlled machines

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -2427,9 +2427,9 @@ sub rflash {
                 my $c_id          = ${ $sessdata->{component_ids} }[$i];
                 my $version       = $firmware_version{$c_id};
                 my $format_string = $comp_string{$c_id};
-                my $format_ver    = sprintf("%3d.%02x %02X%02X%02X%02X",
-                    $version->[0], $version->[1], $version->[2],
-                    $version->[3], $version->[4], $version->[5]);
+                my $format_ver    = sprintf("%3d.%02x.%d%d%d%d",
+                    $version->[0], $version->[1], $version->[5],
+                    $version->[4], $version->[3], $version->[2]);
                 $msg = $msg . $sessdata->{node} . ": " .
 "Node firmware version for $format_string component: $format_ver";
                 if ($i != scalar(@{ $sessdata->{component_ids} }) - 1) {
@@ -8747,16 +8747,16 @@ sub hpm_action_version {
         return -1;
     }
     my $version = $hpm_data_hash{1}{action_version};
-    my $ver = sprintf("%3d.%02x %02X%02X%02X%02X", $version->[0], $version->[1], $version->[2],
-        $version->[3], $version->[4], $version->[5]);
+    my $ver = sprintf("%3d.%02x.%d%d%d%d", $version->[0], $version->[1], $version->[5],
+        $version->[4], $version->[3], $version->[2]);
     $callback->({ data => "HPM firmware version for BOOT component:$ver" });
     $version = $hpm_data_hash{2}{action_version};
-    $ver = sprintf("%3d.%02x %02X%02X%02X%02X", $version->[0], $version->[1], $version->[2],
-        $version->[3], $version->[4], $version->[5]);
+    $ver = sprintf("%3d.%02x.%d%d%d%d", $version->[0], $version->[1], $version->[5],
+        $version->[4], $version->[3], $version->[2]);
     $callback->({ data => "HPM firmware version for APP  component:$ver" });
     $version = $hpm_data_hash{4}{action_version};
-    $ver = sprintf("%3d.%02x %02X%02X%02X%02X", $version->[0], $version->[1], $version->[2],
-        $version->[3], $version->[4], $version->[5]);
+    $ver = sprintf("%3d.%02x.%d%d%d%d", $version->[0], $version->[1], $version->[5],
+        $version->[4], $version->[3], $version->[2]);
     $callback->({ data => "HPM firmware version for BIOS component:$ver" });
 }
 

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -2427,9 +2427,9 @@ sub rflash {
                 my $c_id          = ${ $sessdata->{component_ids} }[$i];
                 my $version       = $firmware_version{$c_id};
                 my $format_string = $comp_string{$c_id};
-                my $format_ver    = sprintf("%3d.%02x.%d%d%d%d",
-                    $version->[0], $version->[1], $version->[5],
-                    $version->[4], $version->[3], $version->[2]);
+                my $format_ver    = sprintf("%3d.%02x.%d",
+                    $version->[0], $version->[1],
+                    $version->[5]*0x1000000 +$version->[4]*0x10000+ $version->[3]*0x100+$version->[2]);
                 $msg = $msg . $sessdata->{node} . ": " .
 "Node firmware version for $format_string component: $format_ver";
                 if ($i != scalar(@{ $sessdata->{component_ids} }) - 1) {
@@ -8747,16 +8747,16 @@ sub hpm_action_version {
         return -1;
     }
     my $version = $hpm_data_hash{1}{action_version};
-    my $ver = sprintf("%3d.%02x.%d%d%d%d", $version->[0], $version->[1], $version->[5],
-        $version->[4], $version->[3], $version->[2]);
+    my $ver = sprintf("%3d.%02x.%d", $version->[0], $version->[1],
+        $version->[5]*0x1000000+$version->[4]*0x10000+$version->[3]*0x100+$version->[2]);
     $callback->({ data => "HPM firmware version for BOOT component:$ver" });
     $version = $hpm_data_hash{2}{action_version};
-    $ver = sprintf("%3d.%02x.%d%d%d%d", $version->[0], $version->[1], $version->[5],
-        $version->[4], $version->[3], $version->[2]);
+    $ver = sprintf("%3d.%02x.%d", $version->[0], $version->[1],
+        $version->[5]*0x1000000+$version->[4]*0x10000+$version->[3]*0x100+$version->[2]);
     $callback->({ data => "HPM firmware version for APP  component:$ver" });
     $version = $hpm_data_hash{4}{action_version};
-    $ver = sprintf("%3d.%02x.%d%d%d%d", $version->[0], $version->[1], $version->[5],
-        $version->[4], $version->[3], $version->[2]);
+    $ver = sprintf("%3d.%02x.%d", $version->[0], $version->[1],
+        $version->[5]*0x1000000+$version->[4]*0x10000+$version->[3]*0x100+$version->[2]);
     $callback->({ data => "HPM firmware version for BIOS component:$ver" });
 }
 


### PR DESCRIPTION
#4615 

`rflash -c` output for FW versions should match what is reported by `/proc/ractrends/Helper/FwInfo` file.

Old output:
```
[root@fs1 xCAT_plugin]# rflash frame45cn12 -c /home/chenglch/rflash/8335GTB_820.1636.20161005b_update.hpm
HPM firmware version for BOOT component:  2.13 37000000
HPM firmware version for APP  component:  2.13 37000000
HPM firmware version for BIOS component:  1.11 13000000
frame45cn12: Node firmware version for BOOT component:   2.13 4A000000
frame45cn12: Node firmware version for APP component:   2.13 4A000000
frame45cn12: Node firmware version for BIOS component:   1.12 46000000
[root@fs1 xCAT_plugin]#
```

New output:
```
rflash frame45cn12 -c /home/chenglch/rflash/8335GTB_820.1636.20161005b_update.hpm
HPM firmware version for BOOT component:  2.13.00055
HPM firmware version for APP  component:  2.13.00055
HPM firmware version for BIOS component:  1.11.00019
frame45cn12: Node firmware version for BOOT component:   2.13.00074
frame45cn12: Node firmware version for APP component:   2.13.00074
frame45cn12: Node firmware version for BIOS component:   1.12.00070
[root@fs1 xCAT_plugin]#
```