### PR TITLE
From 2.13.10, the genesis scripts is moved to usr/bin or usr/sbin

### DIFF
--- a/xCAT-genesis-scripts/debian/control-amd64
+++ b/xCAT-genesis-scripts/debian/control-amd64
@@ -7,7 +7,7 @@ Standards-Version: 3.9.4
 
 Package: xcat-genesis-scripts-amd64
 Architecture: all
-Depends: xcat-genesis-base-amd64 (>=2.13.2)
+Depends: xcat-genesis-base-amd64 (>= 2.13.10)
 Conflicts: xcat-genesis-scripts, xcat-genesis-scripts-x86-64
 Replaces: xcat-genesis-scripts, xcat-genesis-scripts-x86-64
 Description: xCAT genesis

--- a/xCAT-genesis-scripts/debian/control-ppc64el
+++ b/xCAT-genesis-scripts/debian/control-ppc64el
@@ -7,7 +7,7 @@ Standards-Version: 3.9.4
 
 Package: xcat-genesis-scripts-ppc64
 Architecture: all
-Depends: xcat-genesis-base-ppc64 (>=2.13.2)
+Depends: xcat-genesis-base-ppc64 (>= 2.13.10)
 Conflicts: xcat-genesis-scripts
 Replaces: xcat-genesis-scripts
 Description: xCAT genesis

--- a/xCAT-genesis-scripts/xCAT-genesis-scripts.spec
+++ b/xCAT-genesis-scripts/xCAT-genesis-scripts.spec
@@ -29,7 +29,7 @@ Vendor: IBM Corp.
 Summary: xCAT Genesis netboot image - Core content
 URL:	 https://xcat.org/
 Source1: xCAT-genesis-scripts.tar.bz2
-Requires: xCAT-genesis-base-%{tarch} >= 2:2.13.2
+Requires: xCAT-genesis-base-%{tarch} >= 2:2.13.10
 
 Buildroot: %{_localstatedir}/tmp/xCAT-genesis
 Packager: IBM Corp.


### PR DESCRIPTION
From 2.13.10, the genesis scripts will be moved to usr/bin or usr/sbin from bin or sbin.