### PR TITLE
provision log enhancement for rhel7

### DIFF
--- a/xCAT-server/lib/perl/xCAT/xcatd.pm
+++ b/xCAT-server/lib/perl/xCAT/xcatd.pm
@@ -61,6 +61,8 @@ sub validate {
     my $peerhostorg     = shift;
     my $deferredmsgargs = shift;
 
+    my @filtered_cmds   = qw( getdestiny getbladecons getipmicons getopenbmccons getcons);
+
     # now check the policy table if user can run the command
     my $policytable = xCAT::Table->new('policy');
     unless ($policytable) {
@@ -192,7 +194,7 @@ sub validate {
                 $status = "Denied";
                 $rc     = 0;
             }
-            if (($request->{command}->[0] ne "getdestiny") && ($request->{command}->[0] ne "getbladecons") && ($request->{command}->[0] ne "getipmicons") && ($request->{command}->[0] ne "getopenbmccons")) {
+            if (! grep { /$request->{command}->[0]/ } @filtered_cmds) {
 
                 # set username authenticated to run command
                 # if from Trusted host, use input username,  else set from creds

--- a/xCAT-server/lib/xcat/plugins/credentials.pm
+++ b/xCAT-server/lib/xcat/plugins/credentials.pm
@@ -86,9 +86,10 @@ sub process_request
 
     # do your processing here
     # return info
-
+    my $origclient = $client;
     if ($client) { ($client) = noderange($client) }
     unless ($client) {    #Not able to do host authentication, abort
+        xCAT::MsgUtils->trace(0, "E", "Received getcredentials from $origclient, which couldn't be correlated to a node (domain mismatch?)");
         return;
     }
     my $credcheck;
@@ -97,9 +98,11 @@ sub process_request
     } elsif ($request->{'callback_https_port'} and $request->{'callback_https_port'}->[0] and $request->{'callback_https_port'}->[0] < 1024) {
         $credcheck = [ 1, $request->{'callback_https_port'}->[0] ];
     } else {
+        xCAT::MsgUtils->trace(0, 'E', "Received malformed getcredentials requesting, ignore it.");
         return;
     }
     unless (ok_with_node($client, $credcheck)) {
+        xCAT::MsgUtils->trace(0, 'E', "The node ($client) is not ready, ignore it.");
         return;
     }
 
@@ -131,10 +134,10 @@ sub process_request
             my ($rootkeyparm, $zonename) = split(/:/, $parm);
             if ($zonename) {
                 $parm = $rootkeyparm;           # take the zone off
-`logger -t xcat -p local4.info "credentials: The node is asking for zone:$zonename sshkeys ."`;
+                xCAT::MsgUtils->trace(0, 'I', "credentials: The node ($client) is asking for sshkeys of zone: $zonename.");
                 $sshrootkeydir = xCAT::Zone->getzonekeydir($zonename);
                 if ($sshrootkeydir == 1) {      # error return
-`logger -t xcat -p local4.info "credentials: The node is asking for zone:$zonename sshkeys and the $zonename is not defined."`;
+                    xCAT::MsgUtils->trace(0, 'W', "credentials: The zone: $zonename is not defined.");
                 } else {
                     $foundkeys = 1;    # don't want to read the zone data twice
                 }
@@ -144,85 +147,85 @@ sub process_request
         if ($parm =~ /ssh_root_key/) {
             unless (-r "$sshrootkeydir/id_rsa") {
                 push @{ $rsp->{'error'} }, "Unable to read root's private ssh key";
-`logger -t xcat -p local4.info "credentials: Unable to read root's private ssh key"`;
+                xCAT::MsgUtils->trace(0, 'E', "credentials: Unable to read root's private ssh key");
                 next;
             }
-            `logger -t xcat -p local4.info "credentials: sending $parm"`;
+            xCAT::MsgUtils->trace(0, 'I', "credentials: sending $parm to $client");
             $tfilename = "$sshrootkeydir/id_rsa";
-`logger -t xcat -p local4.info "credentials: The  ssh root private key is in $tfilename."`;
+            xCAT::MsgUtils->trace(0, 'I', "credentials: The root's private ssh key is in $tfilename.");
 
         } elsif ($parm =~ /ssh_root_pub_key/) {
             unless (-r "$sshrootkeydir/id_rsa.pub") {
                 push @{ $rsp->{'error'} }, "Unable to read root's public ssh key";
-`logger -t xcat -p local4.info "credentials: Unable to read root's public ssh key"`;
+                xCAT::MsgUtils->trace(0, 'E', "credentials: Unable to read root's public ssh key");
                 next;
             }
-            `logger -t xcat -p local4.info "credentials: sending $parm"`;
+            xCAT::MsgUtils->trace(0, 'I', "credentials: sending $parm to $client");
             $tfilename = "$sshrootkeydir/id_rsa.pub";
-`logger -t xcat -p local4.info "credentials: The  ssh root public key is in $tfilename."`;
+            xCAT::MsgUtils->trace(0, 'I', "credentials: The root's public ssh key is in $tfilename.");
 
         } elsif ($parm =~ /xcat_server_cred/) {
             unless (-r "/etc/xcat/cert/server-cred.pem") {
                 push @{ $rsp->{'error'} }, "Unable to read xcat_server_cred";
-`logger -t xcat -p local4.info "credentials: Unable to read xcat_server_cred"`;
+                xCAT::MsgUtils->trace(0, 'E', "credentials: Unable to read xcat_server_cred");
                 next;
             }
-            `logger -t xcat -p local4.info "credentials: sending $parm"`;
+            xCAT::MsgUtils->trace(0, 'I', "credentials: sending $parm to $client");
             $tfilename = "/etc/xcat/cert/server-cred.pem";
 
         } elsif (($parm =~ /xcat_client_cred/) or ($parm =~ /xcat_root_cred/)) {
             unless (-r "$root/.xcat/client-cred.pem") {
                 push @{ $rsp->{'error'} }, "Unable to read xcat_client_cred or xcat_root_cred";
-`logger -t xcat -p local4.info "credentials: Unable to read xcat_client_cred or xcat_root_cred"`;
+                xCAT::MsgUtils->trace(0, 'E', "credentials: Unable to read xcat_client_cred or xcat_root_cred");
                 next;
             }
-            `logger -t xcat -p local4.info "credentials: sending $parm"`;
+            xCAT::MsgUtils->trace(0, 'I', "credentials: sending $parm to $client");
             $tfilename = "$root/.xcat/client-cred.pem";
 
         } elsif ($parm =~ /ssh_dsa_hostkey/) {
-            `logger -t xcat -p local4.info "credentials: sending $parm"`;
+            xCAT::MsgUtils->trace(0, 'I', "credentials: sending $parm to $client");
             if (-r "/etc/xcat/hostkeys/$client/ssh_host_dsa_key") {
                 $tfilename = "/etc/xcat/hostkeys/$client/ssh_host_dsa_key";
             } elsif (-r "/etc/xcat/hostkeys/ssh_host_dsa_key") {
                 $tfilename = "/etc/xcat/hostkeys/ssh_host_dsa_key";
             } else {
                 push @{ $rsp->{'error'} }, "Unable to read private DSA key from /etc/xcat/hostkeys";
-`logger -t xcat -p local4.info "credentials: Unable to read private DSA key"`;
+                xCAT::MsgUtils->trace(0, 'E', "credentials: Unable to read private DSA key");
                 next;
             }
         } elsif ($parm =~ /ssh_rsa_hostkey/) {
-            `logger -t xcat -p local4.info "credentials: sending $parm"`;
+            xCAT::MsgUtils->trace(0, 'I', "credentials: sending $parm to $client");
             if (-r "/etc/xcat/hostkeys/$client/ssh_host_rsa_key") {
                 $tfilename = "/etc/xcat/hostkeys/$client/ssh_host_rsa_key";
             } elsif (-r "/etc/xcat/hostkeys/ssh_host_rsa_key") {
                 $tfilename = "/etc/xcat/hostkeys/ssh_host_rsa_key";
             } else {
                 push @{ $rsp->{'error'} }, "Unable to read private RSA key from /etc/xcat/hostkeys";
-`logger -t xcat -p local4.info "credentials: Unable to read private RSA key"`;
+                xCAT::MsgUtils->trace(0, 'E', "credentials: Unable to read private RSA key");
                 next;
             }
         } elsif ($parm =~ /ssh_ecdsa_hostkey/) {
-            `logger -t xcat -p local4.info "credentials: sending $parm"`;
+            xCAT::MsgUtils->trace(0, 'I', "credentials: sending $parm to $client");
             if (-r "/etc/xcat/hostkeys/$client/ssh_host_ecdsa_key") {
                 $tfilename = "/etc/xcat/hostkeys/$client/ssh_host_ecdsa_key";
             } elsif (-r "/etc/xcat/hostkeys/ssh_host_ecdsa_key") {
                 $tfilename = "/etc/xcat/hostkeys/ssh_host_ecdsa_key";
             } else {
                 push @{ $rsp->{'error'} }, "Unable to read private ECDSA key from /etc/xcat/hostkeys";
-`logger -t xcat -p local4.info "credentials: Unable to read private ECDSA key"`;
+                xCAT::MsgUtils->trace(0, 'E', "credentials: Unable to read private ECDSA key");
                 next;
             }
         } elsif ($parm =~ /xcat_cfgloc/) {
-            `logger -t xcat -p local4.info "credentials: sending $parm"`;
+            xCAT::MsgUtils->trace(0, 'I', "credentials: sending $parm to $client");
             unless (-r "/etc/xcat/cfgloc") {
                 push @{ $rsp->{'error'} }, "Unable to read /etc/xcat/cfgloc ";
-`logger -t xcat -p local4.info "credentials: Unable to read /etc/xcat/cfgloc"`;
+                xCAT::MsgUtils->trace(0, 'E', "credentials: Unable to read /etc/xcat/cfgloc");
                 next;
             }
             $tfilename = "/etc/xcat/cfgloc";
 
         } elsif ($parm =~ /krb5_keytab/) {    #TODO: MUST RELAY TO MASTER
-            `logger -t xcat -p local4.info "credentials: sending $parm"`;
+            xCAT::MsgUtils->trace(0, 'I', "credentials: sending $parm to $client");
             my $princsuffix = $request->{'_xcat_clientfqdn'}->[0];
             $ENV{KRB5CCNAME} = "/tmp/xcat/krb5cc_xcat_$$";
             system('kinit -S kadmin/admin -k -t /etc/xcat/krb5_pass xcat/admin');
@@ -248,7 +251,7 @@ sub process_request
             unlink "/tmp/xcat/keytab.$$";
             next;
         } elsif ($parm =~ /x509cert/) {
-            `logger -t xcat -p local4.info "credentials: sending $parm"`;
+            xCAT::MsgUtils->trace(0, 'I', "credentials: sending $parm to $client");
             my $csr = $request->{'csr'}->[0];
             my $csrfile;
             my $oldumask = umask 0077;
@@ -289,7 +292,8 @@ sub process_request
                 chomp;
                 my ($type, $expiry, $revoke, $serial, $fname, $subject) = split /\t/;
                 if ($type eq 'V' and $subject =~ /CN=$client\z/) { #we already have a valid certificate, new request replaces it, revoke old
-                    print "The time of replacing is at hand for $client\n";
+                    #print "The time of replacing is at hand for $client\n";
+                    xCAT::MsgUtils->trace(0, 'I', "credentials: The time of replacing is at hand for $client");
                     system("openssl ca -config /etc/xcat/ca/openssl.cnf -revoke /etc/xcat/ca/certs/$serial.pem");
                 }
             }
@@ -304,15 +308,16 @@ sub process_request
             my $certcontents = join('', @certdata);
             push @{ $rsp->{'data'} }, { content => [$certcontents], desc => [$parm] };
         } elsif ($parm =~ /xcat_dockerhost_cert/) {
-            `logger -t xcat -p local4.info "credentials: sending $parm"`;
+            xCAT::MsgUtils->trace(0, 'I', "credentials: sending $parm to $client");
             unless (-r "/etc/xcatdockerca/cert/dockerhost-cert.pem") {
                 push @{ $rsp->{'error'} }, "Unable to read /etc/xcatdockerca/cert/dockerhost-cert.pem ";
-`logger -t xcat -p local4.info "credentials: Unable to read /etc/xcatdockerca/cert/dockerhost-cert.pem"`;
+                xCAT::MsgUtils->trace(0, 'E', "credentials: Unable to read /etc/xcatdockerca/cert/dockerhost-cert.pem");
                 next;
             }
             $tfilename = "/etc/xcatdockerca/cert/dockerhost-cert.pem";
 
         } else {
+            xCAT::MsgUtils->trace(0, 'W', "credentials: Not supported type: $parm");
             next;
         }
 

--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -179,6 +179,7 @@ my $xcatdir;
 my $sitetab;
 my $retries = 0;
 
+xCAT::MsgUtils->trace(0, 'I', 'xcatd is going to start...');
 # The database initialization may take some time in the system boot scenario
 # wait for a while for the database initialization
 while (!($sitetab = xCAT::Table->new('site')) && $retries < 200)
@@ -188,13 +189,13 @@ while (!($sitetab = xCAT::Table->new('site')) && $retries < 200)
     $retries++;
 }
 unless ($sitetab) {
-    xCAT::MsgUtils->message("S", "ERROR: Unable to open basic site table for configuration");
+    xCAT::MsgUtils->message("SE", "ERROR: Unable to open basic site table for configuration");
     die;
 }
 
 my ($tmp) = $sitetab->getAttribs({ 'key' => 'xcatdport' }, 'value');
 unless ($tmp) {
-    xCAT::MsgUtils->message("S", "ERROR:Need xcatdport defined in site table, try chtab key=xcatdport site.value=3001");
+    xCAT::MsgUtils->message("SE", "ERROR: Need xcatdport defined in site table, try chtab key=xcatdport site.value=3001");
     die;
 }
 $port = $tmp->{value};
@@ -376,7 +377,7 @@ sub do_installm_service {
     }
 
     unless ($socket) {
-        xCAT::MsgUtils->message("S", "xcatd unable to open install monitor services on $sport");
+        xCAT::MsgUtils->message("SE", "xcatd unable to open install monitor services on $sport");
         die;
     }
 
@@ -401,6 +402,8 @@ sub do_installm_service {
                 }
             }
         }
+        my $conn_peer_addr = $conn->peerhost();
+        xCAT::MsgUtils->trace(0, "I", "xcatd received a connection request from $conn_peer_addr");
 
         my $client_name;
         my $client_aliases;
@@ -411,11 +414,12 @@ sub do_installm_service {
         } else {
             ($client_name, $client_aliases) = gethostbyaddr($conn->peeraddr, AF_INET);
         }
+
         unless ($client_name) {
-	    my $addrfamily=sockaddr_family(getpeername($conn));
-	    my $myaddr=Socket::inet_ntop($addrfamily,$conn->peeraddr);
-            xCAT::MsgUtils->message("S", "xcatd received a connection request from unknown host with ip address $myaddr, please check whether the reverse name resolution works correctly. The connection request will be ignored");
-            print "xcatd received a connection request from unknown host with ip address $myaddr, please check whether the reverse name resolution works correctly. The connection request will be ignored\n";
+            my $addrfamily=sockaddr_family(getpeername($conn));
+            my $myaddr=Socket::inet_ntop($addrfamily,$conn->peeraddr);
+            xCAT::MsgUtils->message("SE", "xcatd received a connection request from unknown host with ip address $myaddr, please check whether the reverse name resolution works correctly. The connection request will be ignored");
+            #print "xcatd received a connection request from unknown host with ip address $myaddr, please check whether the reverse name resolution works correctly. The connection request will be ignored\n";
             close($conn);
             next;
         }
@@ -447,8 +451,8 @@ sub do_installm_service {
                 $validclient = 1;
                 last;
             } else {
-                xCAT::MsgUtils->message("S", "xcatd received a connection request from $client, which can not be found in xCAT nodelist table. The connection request will be ignored");
-                print "xcatd received a connection request from $client, which can not be found in xCAT nodelist table. The connection request will be ignored\n";
+                xCAT::MsgUtils->message("SE", "xcatd received a connection request from $client, which can not be found in xCAT nodelist table. The connection request will be ignored");
+                #print "xcatd received a connection request from $client, which can not be found in xCAT nodelist table. The connection request will be ignored\n";
             }
 
         }
@@ -475,6 +479,7 @@ sub do_installm_service {
                     # node should be blocked, race condition may occur otherwise
                     #my $pid=xCAT::Utils->xfork();
                     #unless ($pid) { # fork off the nodeset and potential slowness
+                    xCAT::MsgUtils->trace(0, "I", "xcatd: triggering \'nodeset $node next\'...");
                     plugin_command(\%request, undef, \&build_response);
 
                     #exit(0);
@@ -563,7 +568,7 @@ sub do_installm_service {
 
                     # remove the BASECUST_REMOVAL line from /tftpboot/hostname.info file
                     my $myfile = "/tftpboot/$text" . ".info";
-`/usr/bin/cat $myfile | /usr/bin/sed "/BASECUST_REMOVAL/d">/tmp/$text.nimtmp`;
+                    `/usr/bin/cat $myfile | /usr/bin/sed "/BASECUST_REMOVAL/d">/tmp/$text.nimtmp`;
                     `/usr/bin/mv /tmp/$text.nimtmp $myfile`;
                     close($conn);
                 }
@@ -573,9 +578,10 @@ sub do_installm_service {
         };
         if ($@) {
             if ($@ =~ /XCATTIMEOUT/) {
-                xCAT::MsgUtils->message("S", "xcatd installmonitor timed out talking to $node");
+                xCAT::MsgUtils->message("S", "xcatd: install monitor timed out talking to $node");
             } else {
                 xCAT::MsgUtils->message("S", "xcatd: possible BUG encountered by xCAT install monitor service: " . $@);
+                close($conn);
             }
         }
     }
@@ -668,13 +674,13 @@ sub do_discovery_process {
 }
 
 sub do_udp_service {    # This function opens up a UDP port
-        # It will do similar to the standard service, except:
-        # -Obviously, unencrypted and messages are not guaranteed
-        # -For that reason, more often than not plugins designed with
-        # -this method will not expect to have a callback
-     # Also, this throttles to handle one message at a time, so no forking either
-     # Explicitly, to handle whatever operations nodes periodically send during discover state
-     # Could be used for heartbeating and such as desired
+    # It will do similar to the standard service, except:
+    # -Obviously, unencrypted and messages are not guaranteed
+    # -For that reason, more often than not plugins designed with
+    # -this method will not expect to have a callback
+    # Also, this throttles to handle one message at a time, so no forking either
+    # Explicitly, to handle whatever operations nodes periodically send during discover state
+    # Could be used for heartbeating and such as desired
     my %args     = @_;
     my $discoctl = $args{discoctl};
     $dispatch_requests = 0;
@@ -730,7 +736,7 @@ sub do_udp_service {    # This function opens up a UDP port
 
     openlog("xcat", '', 'local4');
     unless ($socket) {
-        xCAT::MsgUtils->message("S", "xCAT UDP service unable to open port $port: $!");
+        xCAT::MsgUtils->message("SE", "xCAT UDP service unable to open port $port: $!");
         closelog();
         die "Unable to start UDP on $port";
     }
@@ -756,7 +762,7 @@ sub do_udp_service {    # This function opens up a UDP port
             my $tcclients;    # hash reference to store traffic control requests
             while (1) {
                 unless ($actualpid == $$) { # This really should be impossible now...
-                    xCAT::MsgUtils->message("S", "xcatd: Something absolutely ludicrous happpened, xCAT developers think this message is impossible to see, post if you see it, fork bomb averted");
+                    xCAT::MsgUtils->message("SE", "xcatd: Something absolutely ludicrous happpened, xCAT developers think this message is impossible to see, post if you see it, fork bomb averted");
                     exit(1);
                 }
                 until ($select->can_read(5)) {    # Wait for data
@@ -928,7 +934,7 @@ if (defined $pid_init) {
         exit(0);
     }
 } else {
-    print "Unable to branch the initialization portion, will use more memory\n";
+    xCAT::MsgUtils->message("SW", "WARN: Unable to branch the plugins initialization portion, will use more memory");
     scan_plugins();
 }
 
@@ -1870,7 +1876,7 @@ sub plugin_command {
                     $$progname = $oldprogname;
                 };    # REMOVEEVALFORDEBUG
                 if ($@) { # We are still alive, should be alive, but yet we have an error.  This means we are in the case of 'do_request' or something similar.  Forward up the death since our communication channel is intact..
-                    xCAT::MsgUtils->message("S", "$@");
+                    xCAT::MsgUtils->trace(0, "E", "$@");
                     die $@;
                 }
             } else {
@@ -2012,7 +2018,8 @@ sub plugin_command {
                         $callback->({ error => [$error], errorcode => [1] });
                         xexit(0);             # Die like we should have done
                     } elsif ($@) { # We are still alive, should be alive, but yet we have an error.  This means we are in the case of 'do_request' or something similar.  Forward up the death since our communication channel is intact..
-                        xCAT::MsgUtils->message("S", "$@");
+                        xCAT::MsgUtils->trace(0, "E", "$@");
+                        $$progname = $oldprogname;
                         die $@;
                     }
                 } else {

--- a/xCAT-server/share/xcat/install/scripts/post.xcat
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat
@@ -38,15 +38,18 @@ EOF
 chmod 0755 /tmp/updateflag
 
 cd /tmp
+log_label="xcat.deployment"
+msgutil_r "$MASTER_IP" "info" "Executing post.xcat to prepare for firstbooting ..." "/var/log/xcat/xcat.log" "$log_label"
+
 RAND=$(perl -e 'print int(rand(50)). "\n"')
 if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-   msgutil_r "$MASTER_IP" "debug" "sleep $RAND" "/var/log/xcat/xcat.log"
+   msgutil_r "$MASTER_IP" "debug" "sleep $RAND" "/var/log/xcat/xcat.log" "$log_label"
 fi
 sleep $RAND
 
 # Stop if no openssl to help the next bit
 if [ ! -x /usr/bin/openssl ]; then
-    msgutil_r "$MASTER_IP" "debug" "/usr/bin/openssl does not exist, halt ..." "/var/log/xcat/xcat.log"
+    msgutil_r "$MASTER_IP" "error" "/usr/bin/openssl does not exist, halt ..." "/var/log/xcat/xcat.log" "$log_label"
     /tmp/updateflag $MASTER $XCATIPORT "installstatus failed"
     sleep 36500d
 fi
@@ -72,33 +75,27 @@ else
 fi
 
 if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-    msgutil_r "$MASTER_IP" "debug" "/opt/xcat/xcatinfo generated" "/var/log/xcat/xcat.log"
+    msgutil_r "$MASTER_IP" "debug" "/opt/xcat/xcatinfo generated" "/var/log/xcat/xcat.log" "$log_label"
 fi
-
 
 # download the postscripts
-if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-    msgutil_r "$MASTER_IP" "debug" "trying to download postscripts from http://$MASTER_IP$INSTALLDIR/postscripts/" "/var/log/xcat/xcat.log"
-fi
+msgutil_r "$MASTER_IP" "info" "trying to download postscripts from $MASTER_IP..." "/var/log/xcat/xcat.log" "$log_label"
 
 # Stop if no wget to help the next bit
 if [ ! -x /usr/bin/wget ]; then
-    msgutil_r "$MASTER_IP" "debug" "/usr/bin/wget does not exist, halt ..." "/var/log/xcat/xcat.log"
+    msgutil_r "$MASTER_IP" "error" "/usr/bin/wget does not exist, halt ..." "/var/log/xcat/xcat.log" "$log_label"
     /tmp/updateflag $MASTER $XCATIPORT "installstatus failed"
     sleep 36500d
 fi
 
 wget -l inf -N -r --waitretry=10 --random-wait --retry-connrefused  -e robots=off -nH --cut-dirs=2 --reject "index.html*" --no-parent -t 20 -T 60 http://$MASTER_IP$INSTALLDIR/postscripts/ -P /xcatpost
 if [ "$?" != "0" ]; then
-    msgutil_r "$MASTER_IP" "debug" "failed to download postscripts from http://$MASTER_IP$INSTALLDIR/postscripts/, halt ..." "/var/log/xcat/xcat.log"
+    msgutil_r "$MASTER_IP" "error" "failed to download postscripts from http://$MASTER_IP$INSTALLDIR/postscripts/, halt ..." "/var/log/xcat/xcat.log" "$log_label"
     /tmp/updateflag $MASTER $XCATIPORT "installstatus failed"
     sleep 36500d
 fi
 chmod -R +x `find /xcatpost/ -maxdepth 1 -print | grep -E -v '^(/xcatpost/|/xcatpost/_xcat|/xcatpost/_ssh|/xcatpost/ca|/xcatpost/hostkeys)$'`
-if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-    msgutil_r "$MASTER_IP" "debug" "postscripts downloaded successfully" "/var/log/xcat/xcat.log"
-fi
-
+msgutil_r "$MASTER_IP" "info" "postscripts downloaded successfully" "/var/log/xcat/xcat.log" "$log_label"
 
 # get the precreated mypostscript file
 if [ -x /xcatpost/mypostscript ]; then
@@ -106,14 +103,12 @@ if [ -x /xcatpost/mypostscript ]; then
 fi
 export NODE=#TABLE:nodelist:THISNODE:node#
 
-if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-    msgutil_r "$MASTER_IP" "debug" "trying to download precreated mypostscript file http://$MASTER_IP$TFTPDIR/mypostscripts/mypostscript.$NODE" "/var/log/xcat/xcat.log"
-fi
+msgutil_r "$MASTER_IP" "info" "trying to get mypostscript from $MASTER_IP..." "/var/log/xcat/xcat.log" "$log_label"
 
 wget -N --waitretry=10 --random-wait --retry-connrefused -t 20 -T 60 http://$MASTER_IP$TFTPDIR/mypostscripts/mypostscript.$NODE  -P /xcatpost 2> /tmp/wget.log
 if [ "$?" = "0" ]; then
     if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-        msgutil_r "$MASTER_IP" "debug" "precreated mypostscript downloaded successfully" "/var/log/xcat/xcat.log"
+        msgutil_r "$MASTER_IP" "debug" "precreated mypostscript downloaded successfully" "/var/log/xcat/xcat.log" "$log_label"
     fi
     mv /xcatpost/mypostscript.$NODE /xcatpost/mypostscript
     chmod 700 /xcatpost/mypostscript
@@ -127,14 +122,14 @@ export XCATSERVER
 # If mypostscript doesn't exist, we will get it through getpostscript.awk
 if [ ! -x /xcatpost/mypostscript ]; then
     if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-        msgutil_r "$MASTER_IP" "debug" "failed to download precreated mypostscript, trying to generate with getpostscript.awk" "/var/log/xcat/xcat.log"
+        msgutil_r "$MASTER_IP" "debug" "no pre-generated mypostscript.<nodename>, trying to get it with getpostscript.awk..." "/var/log/xcat/xcat.log" "$log_label"
     fi
 
     # To support the postscripts in the subdirectories under /install/postscripts
     # chmod +x /xcatpost/*
     # Stop if no getpostscript.awk to help the next bit
     if [ ! -x /xcatpost/getpostscript.awk ]; then
-        msgutil_r "$MASTER_IP" "debug" "/xcatpost/getpostscript.awk does not exist, halt ..." "/var/log/xcat/xcat.log"
+        msgutil_r "$MASTER_IP" "error" "/xcatpost/getpostscript.awk does not exist, halt ..." "/var/log/xcat/xcat.log" "$log_label"
         /tmp/updateflag $MASTER $XCATIPORT "installstatus failed"
         sleep 36500d
     fi
@@ -203,7 +198,7 @@ run_ps () {
     fi
 
     if [ -f \$1 ]; then
-        msgutil_r \"\$MASTER_IP\" \"info\" "\"\`date\` Running \$scriptype: \$1\"" \"\$logfile\"
+        msgutil_r \"\$MASTER_IP\" \"info\" "\"Running \$scriptype: \$1\"" \"\$logfile\" \"xcat.mypostscript\"
         if [ \"\$XCATDEBUGMODE\" = \"1\" ] || [ \"\$XCATDEBUGMODE\" = \"2\" ]; then
             local compt=\$(file \$1)
             local reg=\"shell script\"
@@ -222,9 +217,9 @@ run_ps () {
         if [ \"\$ret_local\" -ne \"0\" ]; then
             return_value=\$ret_local
         fi
-        msgutil_r \"\$MASTER_IP\" \"info\" "\"\`date\` \$scriptype \$1 return with \$ret_local\"" \"\$logfile\"
+        msgutil_r \"\$MASTER_IP\" \"info\" "\"\$scriptype \$1 return with \$ret_local\"" \"\$logfile\" \"xcat.mypostscript\"
     else
-        msgutil_r \"\$MASTER_IP\" \"info\" "\"\`date\` \$scriptype \$1 does NOT exist.\"" \"\$logfile\"
+        msgutil_r \"\$MASTER_IP\" \"error\" "\"\$scriptype \$1 does NOT exist.\"" \"\$logfile\" \"xcat.mypostscript\"
         return_value=-1
     fi
 
@@ -242,12 +237,12 @@ fi
 
 chmod +x /xcatpost/mypostscript
 if [ ! -x /xcatpost/mypostscript ]; then
-    msgutil_r "$MASTER_IP" "debug" "generate mypostscript file failure, halt ..." "/var/log/xcat/xcat.log"
+    msgutil_r "$MASTER_IP" "error" "failed to generate mypostscript file, halt ..." "/var/log/xcat/xcat.log" "$log_label"
     /tmp/updateflag $MASTER $XCATIPORT "installstatus failed"
     sleep 36500d
 else
     if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-        msgutil_r "$MASTER_IP" "debug" "generate mypostscript file successfully" "/var/log/xcat/xcat.log"
+        msgutil_r "$MASTER_IP" "debug" "generate mypostscript file successfully" "/var/log/xcat/xcat.log" "$log_label"
     fi
 fi
 
@@ -258,12 +253,10 @@ echo "$TMP" > /xcatpost/mypostscript.post
 chmod 755 /xcatpost/mypostscript.post
 
 if [ ! -x /xcatpost/mypostscript.post ]; then
-    if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-        msgutil_r "$MASTER_IP" "debug" "failed to generate /xcatpost/mypostscript.post" "/var/log/xcat/xcat.log"
-    fi
+    msgutil_r "$MASTER_IP" "error" "failed to generate /xcatpost/mypostscript.post" "/var/log/xcat/xcat.log" "$log_label"
 else
     if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-        msgutil_r "$MASTER_IP" "debug" "/xcatpost/mypostscript.post generated" "/var/log/xcat/xcat.log"
+        msgutil_r "$MASTER_IP" "debug" "generate mypostscript.post file successfully" "/var/log/xcat/xcat.log" "$log_label"
     fi
 fi
 
@@ -280,11 +273,15 @@ if [ $hassystemd -eq 1 ] ; then
     cat >/etc/systemd/system/xcatpostinit1.service <<'EOF'
 #INCLUDE:/install/postscripts/xcatpostinit1.service#
 EOF
-    msgutil_r "$MASTER_IP" "debug" "/etc/systemd/system/xcatpostinit1.service generated" "/var/log/xcat/xcat.log"
+    if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
+        msgutil_r "$MASTER_IP" "debug" "/etc/systemd/system/xcatpostinit1.service generated" "/var/log/xcat/xcat.log" "$log_label"
+    fi
 
-    ln -s /etc/systemd/system/xcatpostinit1.service /etc/systemd/system/multi-user.target.wants/xcatpostinit1.service    
-    msgutil_r "$MASTER_IP" "debug" "xcatpostinit1.service enabled" "/var/log/xcat/xcat.log"
+    ln -s /etc/systemd/system/xcatpostinit1.service /etc/systemd/system/multi-user.target.wants/xcatpostinit1.service 
 
+    if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
+        msgutil_r "$MASTER_IP" "debug" "xcatpostinit1.service enabled" "/var/log/xcat/xcat.log" "$log_label"
+    fi
     cat >/opt/xcat/xcatpostinit1 << 'EOF'
 #INCLUDE:/install/postscripts/xcatpostinit1.install#
 EOF
@@ -296,12 +293,10 @@ EOF
     chmod 755 /etc/init.d/xcatpostinit1
 
     if [ ! -x /etc/init.d/xcatpostinit1 ]; then
-        if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-            msgutil_r "$MASTER_IP" "debug" "failed to generate /etc/init.d/xcatpostinit1" "/var/log/xcat/xcat.log"
-        fi
+        msgutil_r "$MASTER_IP" "error" "failed to generate /etc/init.d/xcatpostinit1" "/var/log/xcat/xcat.log" "$log_label"
     else
         if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-            msgutil_r "$MASTER_IP" "debug" "/etc/init.d/xcatpostinit1 generated" "/var/log/xcat/xcat.log"
+            msgutil_r "$MASTER_IP" "debug" "/etc/init.d/xcatpostinit1 generated" "/var/log/xcat/xcat.log" "$log_label"
         fi
     fi
     
@@ -326,7 +321,7 @@ EOF
         #chkconfig --add xcatpostinit1
         chkconfig xcatpostinit1 on
         if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-            msgutil_r "$MASTER_IP" "debug" "service xcatpostinit1 enabled" "/var/log/xcat/xcat.log"
+            msgutil_r "$MASTER_IP" "debug" "service xcatpostinit1 enabled" "/var/log/xcat/xcat.log" "$log_label"
         fi
     fi
 fi
@@ -345,13 +340,13 @@ if [[ $OSVER == ubuntu* ]]; then
         update-rc.d -f xcatpostinit1 remove
     fi
     if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-        msgutil_r "$MASTER_IP" "debug" "update-rc.d -f xcatpostinit1 remove" "/var/log/xcat/xcat.log"
+        msgutil_r "$MASTER_IP" "debug" "update-rc.d -f xcatpostinit1 remove" "/var/log/xcat/xcat.log" "xcat.xcatinstallpost"
     fi
 else
     if [[ ! "$RUNBOOTSCRIPTS" =~ ^(1|yes|y)$ ]] && [[ ! "$NODESTATUS" =~ ^(1|yes|y)$ ]]; then
         chkconfig xcatpostinit1 off
         if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-            msgutil_r "$MASTER_IP" "debug" "service xcatpostinit1 disabled" "/var/log/xcat/xcat.log"
+            msgutil_r "$MASTER_IP" "debug" "service xcatpostinit1 disabled" "/var/log/xcat/xcat.log" "xcat.xcatinstallpost"
         fi
     fi
 
@@ -361,12 +356,10 @@ EOF
 chmod 755 /opt/xcat/xcatinstallpost
 
 if [ ! -x /opt/xcat/xcatinstallpost ]; then
-    if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-        msgutil_r "$MASTER_IP" "debug" "failed to generate /opt/xcat/xcatinstallpost" "/var/log/xcat/xcat.log"
-    fi
+    msgutil_r "$MASTER_IP" "error" "failed to generate /opt/xcat/xcatinstallpost" "/var/log/xcat/xcat.log" "$log_label"
 else
     if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-        msgutil_r "$MASTER_IP" "debug" "/opt/xcat/xcatinstallpost generated" "/var/log/xcat/xcat.log"
+        msgutil_r "$MASTER_IP" "debug" "/opt/xcat/xcatinstallpost generated" "/var/log/xcat/xcat.log" "$log_label"
     fi
 fi
 
@@ -378,12 +371,10 @@ EOF
 chmod 755 /opt/xcat/xcatdsklspost
 
 if [ ! -x /opt/xcat/xcatdsklspost ]; then
-    if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-        msgutil_r "$MASTER_IP" "debug" "failed to generate /opt/xcat/xcatdsklspost" "/var/log/xcat/xcat.log"
-    fi
+    msgutil_r "$MASTER_IP" "error" "failed to generate /opt/xcat/xcatdsklspost" "/var/log/xcat/xcat.log" "$log_label"
 else
     if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-        msgutil_r "$MASTER_IP" "debug" "/opt/xcat/xcatdsklspost generated" "/var/log/xcat/xcat.log"
+        msgutil_r "$MASTER_IP" "debug" "/opt/xcat/xcatdsklspost generated" "/var/log/xcat/xcat.log" "$log_label"
     fi
 fi
 
@@ -415,11 +406,11 @@ export CONSOLEPORT=#TABLEBLANKOKAY:nodehm:THISNODE:serialport#
 #WRITEREPO#
 
 if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-   msgutil_r "$MASTER_IP" "info" "running mypostscript" "/var/log/xcat/xcat.log"
+   msgutil_r "$MASTER_IP" "info" "running mypostscript" "/var/log/xcat/xcat.log" "$log_label"
 fi
 /xcatpost/mypostscript
 if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-   msgutil_r "$MASTER_IP" "info" "mypostscript returned" "/var/log/xcat/xcat.log"
+   msgutil_r "$MASTER_IP" "info" "mypostscript returned" "/var/log/xcat/xcat.log" "$log_label"
 fi
 
 
@@ -482,14 +473,12 @@ else
     [ -f /boot/grub/grub.conf  ] && sed -i 's/^serial/#serial/' /boot/grub/grub.conf
     [ -f /boot/grub/grub.conf  ] && sed -i 's/^terminal/#terminal/' /boot/grub/grub.conf
     if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-       msgutil_r "$MASTER_IP" "debug" "/boot/grub/grub.conf updated" "/var/log/xcat/xcat.log"
+       msgutil_r "$MASTER_IP" "debug" "/boot/grub/grub.conf updated" "/var/log/xcat/xcat.log" "$log_label"
     fi
 fi
 
 
-if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-   msgutil_r "$MASTER_IP" "info" "finished node installation, reporting status..." "/var/log/xcat/xcat.log"
-fi
+msgutil_r "$MASTER_IP" "info" "finished firstboot preparation, sending request to $MASTER:3002 for changing status..." "/var/log/xcat/xcat.log" "$log_label"
 #the following command should always be run to prevent infinite installation loops
 updateflag.awk $MASTER 3002
 

--- a/xCAT-server/share/xcat/install/scripts/scriptlib
+++ b/xCAT-server/share/xcat/install/scripts/scriptlib
@@ -3,24 +3,29 @@ declare -F msgutil_r &>/dev/null  || function msgutil_r {
    local msgtype=$2
    local msgstr=$3
    local logfile=$4
+   local logtag=$5
 
    if [ -z "$msgtype"  ]; then
       msgtype="debug"
    fi
-   
+
+   if [ -z "$logtag" ]; then
+      logtag="xcat"
+   fi
+
    if [ -n "$logserver" ];then
-      logger -n $logserver -t xcat -p local4.$msgtype "$msgstr" 
+      logger -n $logserver -t $logtag -p local4.$msgtype "$msgstr"
       if [ "$?" != "0" ];then
-         exec 3<>/dev/udp/$logserver/514 >/dev/null;logger -s -t xcat -p local4.$msgtype "$msgstr" 2>&3
+         exec 3<>/dev/udp/$logserver/514 >/dev/null;logger -s -t $logtag -p local4.$msgtype "$msgstr" 2>&3
          if [ "$?" != "0" ];then
-            logger -s -t xcat -p local4.$msgtype "$msgstr" 2>&1|nc $logserver 514 >/dev/null 2>&1
+            logger -s -t $logtag -p local4.$msgtype "$msgstr" 2>&1|nc $logserver 514 >/dev/null 2>&1
             if [ "$?" != "0" ];then
-               logger -t xcat -p local4.$msgtype "$msgstr"
+               logger -t $logtag -p local4.$msgtype "$msgstr"
             fi
          fi
       fi
    else
-       logger -t xcat -p local4.$msgtype "$msgstr"
+       logger -t $logtag -p local4.$msgtype "$msgstr"
    fi
    if [ -n "$logfile"  ]; then
       local logdir="$(dirname $logfile)"
@@ -29,7 +34,7 @@ declare -F msgutil_r &>/dev/null  || function msgutil_r {
          touch "$logfile"
       fi
 
-      echo "$msgstr" >> $logfile
+      echo "$(date) [$msgtype]: $logtag: $msgstr" >> $logfile
    fi
 
 }

--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
@@ -1,5 +1,5 @@
 #!/bin/sh
-log_label="xcat.dracut_033"
+log_label="xcat.deployment"
 
 NEWROOT=$3
 RWDIR=.statelite
@@ -11,7 +11,6 @@ STATEMNT="$(getarg STATEMNT=)"
 rootlimit="$(getarg rootlimit=)"
 xcatdebugmode="$(getarg xcatdebugmode=)"
 
-[ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "in dracut, executing xcatroot..."
 getarg nonodestatus
 NODESTATUS=$?
 
@@ -21,10 +20,13 @@ if [ $? -ne 0 ]; then
     XCATIPORT="3002"
 fi
 
+[ "$xcatdebugmode" = "1" -o "$xcatdebugmode" = "2" ] && SYSLOGHOST="" || SYSLOGHOST="-n $MASTER"
+
+logger $SYSLOGHOST -t $log_label -p local4.info "Executing xcatroot to prepare for netbooting (dracut_33)..."
 [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "MASTER=$MASTER XCATIPORT=$XCATIPORT NODESTATUS=$NODESTATUS"
 
 if [ "$NODESTATUS" != "0" ]; then
-[ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Reporting installstatus=netbooting..."
+    logger $SYSLOGHOST -t $log_label -p local4.info "Sending request to $MASTER:$XCATIPORT for changing status to netbooting..."
     /tmp/updateflag $MASTER $XCATIPORT "installstatus netbooting"
 fi
 
@@ -32,14 +34,16 @@ fi
 imgurl="$(getarg imgurl=)";
 if [ ! -z "$imgurl" ]; then
     if [ xhttp = x${imgurl%%:*} ]; then
+        logger $SYSLOGHOST -t $log_label -p local4.info "Downloading rootfs image from $imgurl..."
         NFS=0
         FILENAME=${imgurl##*/}
         while [ ! -r "$FILENAME" ]; do
             [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Downloading $imgurl..."
             echo Getting $imgurl...
             if ! wget -nv $imgurl; then
-                [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Downloading $imgurl FAILED, retrying..."
+                logger $SYSLOGHOST -t $log_label -p local4.error "Downloading $imgurl FAILED, retrying..."
                 rm -f $FILENAME
+                echo Failed to get the image, waiting for next retrying...
                 sleep 27
             fi
         done
@@ -53,6 +57,7 @@ if [ ! -z "$imgurl" ]; then
         SERVER=${SERVER%%/*}
         SERVER=${SERVER%:}
         ROOTDIR=/${ROOTDIR#*/} 
+        [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "SERVER=$SERVER ROOTDIR=$ROOTDIR"
     fi
 fi
 #echo 0 > /proc/sys/vm/zone_reclaim_mode #Avoid kernel bug
@@ -70,7 +75,7 @@ if [ -r /rootimg.sfs ]; then
     mount --move /ro $NEWROOT/ro
     mount --move /rw $NEWROOT/rw
 elif [ -r /rootimg.cpio.gz ] || [ -r /rootimg.cpio.xz ]; then
-    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Downloaded rootimg.cpio.[gz/xz]...Setting up RAM-root tmpfs."
+    logger $SYSLOGHOST -t $log_label -p local4.info "Setting up RAM-root tmpfs on downloaded rootimg.cpio.[gz/xz]..."
     echo Setting up RAM-root tmpfs.
     if [ -z $rootlimit ];then
         mount -t tmpfs -o mode=755 rootfs $NEWROOT
@@ -98,7 +103,7 @@ elif [ -r /rootimg.cpio.gz ] || [ -r /rootimg.cpio.xz ]; then
     [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Done extracting the root filesystem..."
     echo "Done extracting the root filesystem..."
 elif [ -r /rootimg.tar.gz ] || [ -r /rootimg.tar.xz ]; then
-    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Downloaded rootimg.tar.[gz/xz]...Setting up RAM-root tmpfs."
+    logger $SYSLOGHOST -t $log_label -p local4.info "Setting up RAM-root tmpfs on downloaded rootimg.tar.[gz/xz]..."
     echo Setting up RAM-root tmpfs.
     if [ -z $rootlimit ];then
         mount -t tmpfs -o mode=755 rootfs $NEWROOT
@@ -121,11 +126,13 @@ elif [ -r /rootimg.tar.gz ] || [ -r /rootimg.tar.xz ]; then
         fi
     fi
     $NEWROOT/etc/init.d/localdisk
-    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Done extracting the root filesystem."
-    echo "Done extracting the root filesystem."
+    msg="Done extracting the root filesystem."
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "$msg"
+    echo "$msg"
 elif [ -r /rootimg-statelite.gz ]; then
-    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Setting up RAM-root tmpfs for statelite mode."
-    echo Setting up RAM-root tmpfs for statelite mode.
+    msg="Setting up RAM-root tmpfs for statelite mode."
+    logger $SYSLOGHOST -t $log_label -p local4.info "$msg"
+    echo "$msg"
  
     if [ -z $rootlimit];then
         mount -t tmpfs -o mode=755 rootfs $NEWROOT
@@ -134,17 +141,22 @@ elif [ -r /rootimg-statelite.gz ]; then
     fi
 
     cd $NEWROOT
-    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Extracting the root filesystem..."
-    echo "Extracting root filesystem..."
+    msg="Extracting root filesystem..."
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "$msg"
+    echo "$msg"
     if [ -x /bin/cpio ]; then
         gzip -cd /rootimg-statelite.gz |/bin/cpio -idum
     else
         gzip -cd /rootimg-statelite.gz |cpio -idum
     fi
-    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Done extracting the root filesystem."
-    echo "Done extracting the root filesystem."
+    msg="Done extracting the root filesystem."
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "$msg"
+    echo "$msg"
     # then, the statelite staffs will be processed
-    echo Setting up Statelite 
+    msg="Setting up Statelite..."
+    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "$msg"
+    echo "$msg"
+
     modprobe nfs
     MAXTRIES=7
     ITER=0
@@ -194,8 +206,8 @@ elif [ -r /rootimg-statelite.gz ]; then
             if [ "$ITER" == "$MAXTRIES" ]; then
                 echo "You are dead, rpower $ME boot to play again."
                 echo "Possible problems:
-1.  $SNAPSHOTSERVER is not exporting $SNAPSHOTROOT ?
-2.  Is DNS set up? Maybe that's why I can't mount $SNAPSHOTSERVER."
+    1.  $SNAPSHOTSERVER is not exporting $SNAPSHOTROOT ?
+    2.  Is DNS set up? Maybe that's why I can't mount $SNAPSHOTSERVER."
                 /bin/sh
                 exit
             fi
@@ -249,8 +261,9 @@ elif [ -r /rootimg-statelite.gz ]; then
     mount -n --bind /sys $NEWROOT/sys
 
 else
-    [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "Failed to download image, panic in 5..."
-    echo -n Failed to download image, panic in 5...
+    msg="Failed to download image, panic in 5..."
+    logger $SYSLOGHOST -t $log_label -p local4.error "$msg"
+    echo -n "$msg"
     for i in 4 3 2 1 0; do
         /bin/sleep 1
         [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "$i..."
@@ -342,7 +355,7 @@ if [ -d "$NEWROOT/etc/sysconfig" -a ! -e "$NEWROOT/etc/sysconfig/selinux" ]; the
     echo "SELINUX=disabled" >> "$NEWROOT/etc/sysconfig/selinux"
 fi
 
-[ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "exiting xcatroot..."
+logger $SYSLOGHOST -t $log_label -p local4.info "Exiting xcatroot..."
 # inject new exit_if_exists
 echo 'settle_exit_if_exists="--exit-if-exists=/dev/root"; rm "$job"' > $hookdir/initqueue/xcat.sh
 # force udevsettle to break

--- a/xCAT/etc/rsyslog.d/xcat-cluster.conf
+++ b/xCAT/etc/rsyslog.d/xcat-cluster.conf
@@ -1,2 +1,3 @@
 $template xCATTraditionalFormat0,"%timegenerated% %HOSTNAME% %syslogtag% %msg:::drop-last-lf%\n"
 :programname, isequal, "xcat" /var/log/xcat/cluster.log;xCATTraditionalFormat0
+:programname, startswith, "xcat." /var/log/xcat/cluster.log;xCATTraditionalFormat0

--- a/xCAT/postscripts/xcatdsklspost
+++ b/xCAT/postscripts/xcatdsklspost
@@ -19,7 +19,7 @@
 #
 #####################################################
 
-[ -f "/xcatpost/xcatlib.sh" ] &&  . /xcatpost/xcatlib.sh 
+[ -f "/xcatpost/xcatlib.sh" ] &&  . /xcatpost/xcatlib.sh
 
 if [ -f /xcatpost/mypostscript.post ]; then
     XCATDEBUGMODE=`grep 'XCATDEBUGMODE=' /xcatpost/mypostscript.post | cut -d= -f2 | tr -d \'\" | tr A-Z a-z`
@@ -68,11 +68,11 @@ echolog()
          echo "$msgstr"
       fi
       if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-            msgutil_r  "$MASTER_IP" "$msgtype" "$msgstr" "/var/log/xcat/xcat.log"
+            msgutil_r  "$MASTER_IP" "$msgtype" "$msgstr" "/var/log/xcat/xcat.log" "xcat.xcatdsklspost"
       fi
    else
       echo "$msgstr"  
-      msgutil_r "$MASTER_IP"  "$msgtype" "$msgstr" "/var/log/xcat/xcat.log" 
+      msgutil_r "$MASTER_IP"  "$msgtype" "$msgstr" "/var/log/xcat/xcat.log" "xcat.xcatdsklspost"
    fi
    
    #reload the functions defined in./xcatlib.sh
@@ -90,8 +90,8 @@ update_VPD()
 {
     if [ -f /usr/sbin/vpdupdate ]; then
         vpdupdate
-	#logger -t xCAT -p local4.info "xcatdsklspost: updating VPD database"
-        echolog "info" "xcatdsklspost: updating VPD database"
+        #logger -t xCAT -p local4.info "xcatdsklspost: updating VPD database"
+        echolog "info" "updating VPD database"
     fi
 }
 
@@ -107,7 +107,7 @@ download_postscripts()
 {
     server=$1
     if [ -z $server ]; then
-	return 1;
+        return 1;
     fi
 
     # Do not override the parameter --installdir
@@ -120,8 +120,7 @@ download_postscripts()
         fi
     fi
 
-    #logger -t xCAT -p local4.debug "$0 : trying to download postscripts from http://$server$INSTALLDIR/postscripts/"
-    echolog "debug" "xcatdsklspost : trying to download postscripts from http://$server$INSTALLDIR/postscripts/"
+    echolog "debug" "trying to download postscripts from http://$server$INSTALLDIR/postscripts/"
     max_retries=5
     retry=0
     rc=1  # this is a fail return 
@@ -131,31 +130,31 @@ download_postscripts()
         fi
 
         export LANG=C; wget -l inf -nH -N -r --waitretry=10 --random-wait -e robots=off -T 60 -nH --cut-dirs=2 --reject "index.html*" --no-parent http://$server$INSTALLDIR/postscripts/ -P /$xcatpost 2> /tmp/wget.log
-         rc=$?
-         if [ $rc -eq 0 ]; then   
-           # return from wget was 0 but some OS do not return errors, so we
-           # have additional checks for
-           # failed: Connection httpd not running
-           # 404: Not Found  - if directory does not exist
-           grep -i -E "... failed: Connection refused.$" /tmp/wget.log 
-           rc1=$?
-           grep -i -E "ERROR 404: Not Found.$" /tmp/wget.log 
-           rc2=$?
-           # check to see no errors at all, grep returns 1
-           if [ $rc1 -eq 1 ] && [ $rc2 -eq 1 ]; then  
-              echolog "debug" "$0 : download_postscripts return successfully " 
-              return 0 
-           fi
-         fi
+        rc=$?
+        if [ $rc -eq 0 ]; then
+            # return from wget was 0 but some OS do not return errors, so we
+            # have additional checks for
+            # failed: Connection httpd not running
+            # 404: Not Found  - if directory does not exist
+            grep -i -E "... failed: Connection refused.$" /tmp/wget.log
+            rc1=$?
+            grep -i -E "ERROR 404: Not Found.$" /tmp/wget.log
+            rc2=$?
+            # check to see no errors at all, grep returns 1
+            if [ $rc1 -eq 1 ] && [ $rc2 -eq 1 ]; then
+              echolog "debug" "postscripts are downloaded from $server successfully."
+              return 0
+            fi
+        fi
 
-	retry=$(($retry+1))
+        retry=$(($retry+1))
         echolog "debug" "download_postscripts retry $retry"
-	if [ $retry -eq $max_retries ]; then
-            echolog "debug" "$0 : download_postscripts failed"
+        if [ $retry -eq $max_retries ]; then
+            echolog "debug" "failed to download postscripts from http://$server$INSTALLDIR/postscripts/ after several retries."
             break
-	fi
+        fi
 
-	SLI=$(awk 'BEGIN{srand(); printf("%d\n",rand()*20)}')
+        SLI=$(awk 'BEGIN{srand(); printf("%d\n",rand()*20)}')
         sleep $SLI
     done
     return $rc
@@ -169,7 +168,7 @@ download_mypostscript()
     max_retries=$3
     TFTPDIR=$4
     if [ -z $server ]; then
-	return 1;
+      return 1;
     fi
     if [ -z "$TFTPDIR" ]; then
         TFTPDIR="/tftpboot"
@@ -178,23 +177,23 @@ download_mypostscript()
     rc=1
  
 
-    echolog "debug" "$0 :  trying to download http://$server$TFTPDIR/mypostscripts/mypostscript.$node"
+    echolog "debug" "trying to download http://$server$TFTPDIR/mypostscripts/mypostscript.$node..."
     while [ 0 -eq 0 ]; do
-        wget -N --waitretry=10 --random-wait -T 60 http://$server$TFTPDIR/mypostscripts/mypostscript.$node  -P /$xcatpost 2>> /tmp/wget.log
+        wget -N --waitretry=10 --random-wait -T 60 http://$server$TFTPDIR/mypostscripts/mypostscript.$node -P /$xcatpost 2>> /tmp/wget.log
         rc=$?
         # if no error and the file  was downloaded
         if [ $rc -eq 0 ] && [ -f /$xcatpost/mypostscript.$node ]; then
-                mv /$xcatpost/mypostscript.$node /$xcatpost/mypostscript
-                echolog "debug" "$0 download_mypostscript return successfully "
-	        return 0;
+            mv /$xcatpost/mypostscript.$node /$xcatpost/mypostscript
+            echolog "debug" "mypostscript.$node is downloaded successfully."
+            return 0
         fi
 
         
-	retry=$(($retry+1))
-	if [ $retry -eq $max_retries ]; then
-            echolog "debug" "$0 : download_mypostscript failed"
+        retry=$(($retry+1))
+        if [ $retry -eq $max_retries ]; then
+            echolog "debug" "http://$server$TFTPDIR/mypostscripts/mypostscript.$node is not available."
             break
-	fi
+        fi
 
     done
     return $rc
@@ -276,7 +275,7 @@ fi
 xcatpost="/xcatpost"
 # Check for debug mode and you have nodename available you can change the path for debug
 
-echolog "debug" "running $0 $*"
+echolog "debug" "Running $0 $*"
 
 
 if [ -n "$XCATDEBUG" ]; then
@@ -295,7 +294,7 @@ if [ "$FC" = "1" ] || [ "$FC" = "yes" ] || [ "$FC" = "YES" ]; then
   useflowcontrol=1
 fi
 
- 
+
 # If on AIX node
 if [ ! `uname` = Linux ]; then
    #Get a new copy of xcataixpost on the node
@@ -304,7 +303,7 @@ if [ ! `uname` = Linux ]; then
    if [ "$NFSV4" = "yes" ]; then
          mount -o vers=4 $P_SIP:$INSTALLDIR/postscripts /xcatmnt
    else
-         mount $P_SIP:$INSTALLDIR/postscripts /xcatmnt 
+         mount $P_SIP:$INSTALLDIR/postscripts /xcatmnt
    fi
    cp /xcatmnt/xcataixpost /$xcatpost
    umount /xcatmnt
@@ -331,7 +330,7 @@ rm -R -f /tmp/postage/*
 #here we get all the postscripts.  Please do not change this behaviour because some scripts depend on others
 cd /tmp/postage
 
-
+echolog "info" "trying to download postscripts..."
 if [ "$MODE" = "4" ]; then # for statelite mode
     # We have written the xCATSERVER info into the kernel command line!!
     for i in `cat /proc/cmdline`; do
@@ -359,38 +358,38 @@ if [ "$MODE" = "4" ]; then # for statelite mode
         fi
     else
         #echo "xCAT management server IP can't be determined.";
-	#echo "exiting...";
+        #echo "exiting...";
         #logger -t xCAT -p local4.err "xcatdsklspost:xCAT management server IP can't be determined.\nexiting...";
-        echolog "err" "xcatdsklspost:xCAT management server IP can't be determined.\nexiting..."
+        echolog "err" "xCAT management server IP can't be determined.\nexiting..."
         exit;
     fi
 
 
 else # for common mode  MODE=1,2,3,5 (updatenode,moncfg,node deployment)
-     # non-Statelite MODE
+    # non-Statelite MODE
 
-     # If we have written the NODE info into the kernel command line,
-     # put in in xcatinfo
-     if [ ! -f /opt/xcat/xcatinfo ]; then
+    # If we have written the NODE info into the kernel command line,
+    # put in in xcatinfo
+    if [ ! -f /opt/xcat/xcatinfo ]; then
         mkdir -p /opt/xcat
         touch /opt/xcat/xcatinfo
-     fi
-     for i in `cat /proc/cmdline`; do
+    fi
+    for i in `cat /proc/cmdline`; do
         KEY=`echo $i | awk -F= '{print $1}'`
         if [ "$KEY" =  "NODE" ]; then
             NODE=`echo $i | awk -F= '{print $2}'`
             break
         fi
-     done
-     if [ -z "$NODE" ]; then
+    done
+    if [ -z "$NODE" ]; then
          NODE=`hostname -s`
-     fi
-     grep 'NODE' /opt/xcat/xcatinfo > /dev/null  2>&1
-     if [ $? -eq 0 ]; then
+    fi
+    grep 'NODE' /opt/xcat/xcatinfo > /dev/null  2>&1
+    if [ $? -eq 0 ]; then
         sed -i "s/NODE=.*/NODE=$NODE/" /opt/xcat/xcatinfo
-     else
+    else
         echo "NODE=$NODE" >> /opt/xcat/xcatinfo
-     fi
+    fi
 
     downloaded=0;  #  have not downloaded the postscripts
     # try the -m/-M input (P_SIP) if it is specified,
@@ -401,8 +400,8 @@ else # for common mode  MODE=1,2,3,5 (updatenode,moncfg,node deployment)
     if [ -n "$P_SIP" ]; then   # passed in with updatenode on -M/-m
         SIP=$P_SIP
         download_postscripts $SIP
-        if [ $? -eq 0 ]; then 
-             downloaded=1
+        if [ $? -eq 0 ]; then
+            downloaded=1
         fi
     fi
     # if the download failed then, if not updatenode 
@@ -417,20 +416,20 @@ else # for common mode  MODE=1,2,3,5 (updatenode,moncfg,node deployment)
             hn=`hostname`
             #echo "Cannot download the postscripts from $SIP  for $hn check /tmp/wget.log on the node."
             #logger -t xCAT -p local4.err "xcatdsklspost:Cannot download the postscripts from the xCAT server $SIP for node $hn check /tmp/wget.log on the node."
-            echolog "err" "xcatdsklspost:Cannot download the postscripts from the xCAT server $SIP for node $hn check /tmp/wget.log on the node."
+            echolog "err" "cannot download the postscripts from the xCAT server $SIP for node $hn check /tmp/wget.log on the node."
             exit  
         fi
 
         # if not updatenode, then look in xcatinfo for the xcatmaster
-	if [ -f /opt/xcat/xcatinfo ]; then
+        if [ -f /opt/xcat/xcatinfo ]; then
             SIP=`grep 'XCATSERVER' /opt/xcat/xcatinfo |cut -d= -f2`
             if [ -n "$SIP" ]; then
-		download_postscripts $SIP
-		if [ $? -eq 0 ]; then 
-                    downloaded=1
-		fi
+                download_postscripts $SIP
+                if [ $? -eq 0 ]; then
+                  downloaded=1
+                fi
             fi
-	fi
+        fi
     fi
 
     # download postscripts has not worked yet 
@@ -496,10 +495,10 @@ else # for common mode  MODE=1,2,3,5 (updatenode,moncfg,node deployment)
         hn=`hostname`
         #echo "Cannot download the postscripts from the xCAT server for node $hn"
         #logger -t xCAT -p local4.err "xcatdsklspost:Cannot download the postscripts from the xCAT server for node $hn"
-        echolog "err" "xcatdsklspost: Cannot download the postscripts from the xCAT server for node $hn"
-        exit
+        echolog "err" "failed to download the postscripts from the xCAT server for node $hn"
+        exit 1
     else
-        echolog "info" "xcatdsklspost: downloaded postscripts successfully"  
+        echolog "info" "postscripts downloaded successfully"
     fi
 
 fi # finish the postscripts download
@@ -510,7 +509,7 @@ rm -rf /$xcatpost/mypostscript
 # if NODE is exported ( updatenode call or from kernel parameter)
 # use it as the nodename to get the mypostscript file. 
 if [ -n "$NODE" ]; then
- node_short=$NODE
+  node_short=$NODE
 else
   #get node name and download the mypostscript.$node file
   #try to get the node ip address that connects to the server.
@@ -520,28 +519,28 @@ else
     real_SIP=$SIP
   fi
 
- NIP=`ip route get $real_SIP | head -n 1 | sed 's/^.*src//g' | awk {'print $1'}`
- if [ $? -eq 0 ] && [ -n "$NIP" ]; then
+  NIP=`ip route get $real_SIP | head -n 1 | sed 's/^.*src//g' | awk {'print $1'}`
+  if [ $? -eq 0 ] && [ -n "$NIP" ]; then
     #resolve the name of the node from ip address
     result=`getent hosts $NIP`
     if [ $? -eq 0 ]; then
-	node1=`echo $result | awk {'print $2'}`
-	node2=`echo $result | awk {'print $3'}`
-	if [ ${#node1} -gt ${#node2} ]; then 
-	    node=$node1 
-	    node_short=$node2
-	else
-	    node=$node2 
-	    node_short=$node1
-	fi	
-	if [ -z "$node_short" ]; then
-	    node_short=`echo $node |awk -F. {'print $1'}`
-	fi
+      node1=`echo $result | awk {'print $2'}`
+      node2=`echo $result | awk {'print $3'}`
+      if [ ${#node1} -gt ${#node2} ]; then
+        node=$node1
+        node_short=$node2
+      else
+        node=$node2
+        node_short=$node1
+      fi
+      if [ -z "$node_short" ]; then
+        node_short=`echo $node |awk -F. {'print $1'}`
+      fi
     else 
-	if [ -z "$node" ]; then
-	    node=`hostname`
-	    node_short=`hostname -s`
-	fi
+      if [ -z "$node" ]; then
+        node=`hostname`
+        node_short=`hostname -s`
+      fi
     fi
   else
     node=`hostname`
@@ -549,18 +548,18 @@ else
   fi
 fi
 
+echolog "info" "trying to get mypostscript from $SIP..."
 max_retries=2
 # try short hostname first
 if [ -n "$node_short" ]; then 
     download_mypostscript $SIP $node_short $max_retries $TFTPDIR
     if [ $? -ne 0 ]; then
         # try long hostname 
-    	if [ "$node" != "$node_short" ]; then
-    	    download_mypostscript $SIP $node $postfix $max_retries $TFTPDIR
-    	fi
+        if [ "$node" != "$node_short" ]; then
+          download_mypostscript $SIP $node $postfix $max_retries $TFTPDIR
+        fi
     fi
 fi
-
 
 # on reboot and shutdown, make sure /ro and /rw are not stuck mounted
 if grep 'rw /rw tmpfs ' /proc/mounts  >/dev/null 2>&1; then
@@ -592,20 +591,20 @@ fi
 # We need to call getpostscript.awk .
 
 if [ ! -x /$xcatpost/mypostscript ]; then
-  echolog "info" "xcatdsklspost: failed to download mypostscript.<nodename>, trying to call getpostscript.awk..."
+  echolog "debug" "no pre-generated mypostscript.<nodename>, trying to get it with getpostscript.awk..."
   if [ $useflowcontrol = "1" ]; then
     # first contact daemon  xcatflowrequest <server> 3001
     #logger -t xCAT -p local4.info "xcatdsklspost:sending xcatflowrequest $SIP 3001"
-    echolog "debug" "xcatdsklspost:sending xcatflowrequest $SIP 3001"
-   /$xcatpost/xcatflowrequest $SIP 3001
-   rc=$?
-   #logger -t xCAT -p local4.info "xcatdsklspost:xcatflowrequest return=$rc"
-   echolog "debug" "xcatdsklspost:xcatflowrequest return=$rc"
-   if [ $rc -ne 0 ]; then
+    echolog "debug" "sending xcatflowrequest $SIP 3001"
+    /$xcatpost/xcatflowrequest $SIP 3001
+    rc=$?
+    #logger -t xCAT -p local4.info "xcatdsklspost:xcatflowrequest return=$rc"
+    echolog "debug" "xcatflowrequest return=$rc"
+    if [ $rc -ne 0 ]; then
       #logger -t xCAT -p local4.info "xcatdsklspost: error from xcatflowrequest, will not use flow control"
-      echolog "debug" "xcatdsklspost: error from xcatflowrequest, will not use flow control"
+      echolog "debug" "error from xcatflowrequest, will not use flow control"
       useflowcontrol=0
-   fi 
+    fi
   fi
   /$xcatpost/getpostscript.awk | egrep  '<data>' | sed  -e 's/<[^>]*>//g'|egrep -v '^ *$'|sed -e 's/^ *//' | sed -e 's/&lt;/</g' -e 's/&gt;/>/g' -e 's/&amp;/\&/g' -e 's/&quot;/"/g' -e "s/&apos;/'/g" >  /$xcatpost/mypostscript;
 
@@ -630,14 +629,14 @@ if [ ! -x /$xcatpost/mypostscript ]; then
     if [ $useflowcontrol = "1" ]; then
       # contact daemon  xcatflowrequest <server> 3001
       #logger -t xCAT -p local4.info "xcatdsklspost: sending xcatflowrequest $SIP 3001"
-      echolog "debug" "xcatdsklspost: sending xcatflowrequest $SIP 3001"
+      echolog "debug" "sending xcatflowrequest $SIP 3001"
       /$xcatpost/xcatflowrequest $SIP 3001
       rc=$?
       #logger -t xCAT -p local4.info "xcatdsklspost:xcatflowrequest return=$rc"
-      echolog "debug" "xcatdsklspost:xcatflowrequest return=$rc"
+      echolog "debug" "xcatflowrequest return=$rc"
       if [ $rc -ne 0 ]; then
         #logger -t xCAT -p local4.info "xcatdsklspost: error from xcatflowrequest, will not use flow control"
-        echolog "debug" "xcatdsklspost: error from xcatflowrequest, will not use flow control"
+        echolog "debug" "error from xcatflowrequest, will not use flow control"
         useflowcontrol=0
       fi 
     fi
@@ -656,14 +655,14 @@ if [ $NODE_DEPLOYMENT -eq 1 ] || [ "$MODE" = "4" ]; then
 fi
 if [ -n "$new_ms" ]; then
     if [ ! -f /opt/xcat/xcatinfo ]; then
-	mkdir -p /opt/xcat
-	touch /opt/xcat/xcatinfo
+      mkdir -p /opt/xcat
+      touch /opt/xcat/xcatinfo
     fi
     grep 'XCATSERVER' /opt/xcat/xcatinfo > /dev/null  2>&1
     if [ $? -eq 0 ]; then
-	sed -i "s/XCATSERVER=.*/XCATSERVER=$new_ms/" /opt/xcat/xcatinfo
+      sed -i "s/XCATSERVER=.*/XCATSERVER=$new_ms/" /opt/xcat/xcatinfo
     else
-	echo "XCATSERVER=$new_ms" >> /opt/xcat/xcatinfo
+      echo "XCATSERVER=$new_ms" >> /opt/xcat/xcatinfo
     fi
 fi
 
@@ -673,8 +672,8 @@ if [ $NODE_DEPLOYMENT -eq 1 ] || [ "$MODE" = "4" ]; then
     useflowcontrol=`grep '^USEFLOWCONTROL' /$xcatpost/mypostscript |cut -d= -f2 | tr -d \'\" | tr A-Z a-z`
 fi
 if [ ! -f /opt/xcat/xcatinfo ]; then
-	mkdir -p /opt/xcat
-	touch /opt/xcat/xcatinfo
+  mkdir -p /opt/xcat
+  touch /opt/xcat/xcatinfo
 fi
 if [ -n "$useflowcontrol" ]; then
     # lets just put YES or NO in xcatinfo
@@ -720,17 +719,17 @@ if [ "$MODE" = "1" ] || [ "$MODE" = "2" ]; then
   TMP=`sed -e 's/UPDATENODE=0/UPDATENODE=1/g' /$xcatpost/mypostscript`;
   echo "$TMP" > /$xcatpost/mypostscript;
   if [ ! -f /opt/xcat/xcatinfo ]; then
-	mkdir -p /opt/xcat
-	touch /opt/xcat/xcatinfo
+    mkdir -p /opt/xcat
+    touch /opt/xcat/xcatinfo
   fi
   if [ -z "$NODE" ]; then
-         NODE=`hostname -s`
+    NODE=`hostname -s`
   fi
   grep 'NODE' /opt/xcat/xcatinfo > /dev/null  2>&1
   if [ $? -eq 0 ]; then
-	sed -i "s/NODE=.*/NODE=$NODE/" /opt/xcat/xcatinfo
+    sed -i "s/NODE=.*/NODE=$NODE/" /opt/xcat/xcatinfo
   else
-	echo "NODE=$NODE" >> /opt/xcat/xcatinfo
+    echo "NODE=$NODE" >> /opt/xcat/xcatinfo
   fi
 #echo "xcatdsklspost:my nodename in the database is $NODE"
 fi
@@ -882,16 +881,16 @@ run_ps () {
  fi
 
  if [ -f \$1 ]; then 
-  echo \"\`date\` Running \$scriptype: \$1\" 
-  msgutil_r \"\$MASTER_IP\" \"info\" "\"\`date\` Running \$scriptype: \$1\"" \"\$logfile\"
+  #echo \"\`date\` Running \$scriptype: \$1\"
+  msgutil_r \"\$MASTER_IP\" \"info\" "\"Running \$scriptype: \$1\"" \"\$logfile\" \"xcat.mypostscript\"
   if [ \"\$XCATDEBUGMODE\" = \"1\" ] || [ \"\$XCATDEBUGMODE\" = \"2\" ]; then
      local compt=\$(file \$1)
      local reg=\"shell script\"
      if [[ \"\$compt\" =~ \$reg ]]; then
-        bash -x ./\$@ 2>&1 | tee -a \$logfile | tee >(logger -t xcat -p debug)
+        bash -x ./\$@ 2>&1 | tee -a \$logfile | tee >(logger -t xcat.mypostscript -p debug)
         ret_local=\${PIPESTATUS[0]}
      else
-        ./\$@ 2>&1 | tee -a \$logfile | logger -t xcat -p debug
+        ./\$@ 2>&1 | tee -a \$logfile | logger -t xcat.mypostscript -p debug
         ret_local=\${PIPESTATUS[0]}
      fi
   else
@@ -902,11 +901,11 @@ run_ps () {
   if [ \"\$ret_local\" -ne \"0\" ]; then
      return_value=\$ret_local
   fi
-  echo \"\$scriptype: \$1 exited with code \$ret_local\" 
-  msgutil_r \"\$MASTER_IP\" \"info\" "\"\`date\` \$scriptype \$1 return with \$ret_local\"" \"\$logfile\"
+  #echo \"\$scriptype: \$1 exited with code \$ret_local\"
+  msgutil_r \"\$MASTER_IP\" \"info\" "\"\$scriptype \$1 return with \$ret_local\"" \"\$logfile\" \"xcat.mypostscript\"
  else
-  echo \"\`date\` \$scriptype \$1 does NOT exist.\" 
-  msgutil_r \"\$MASTER_IP\" \"info\" "\"\`date\` \$scriptype \$1 does NOT exist.\"" \"\$logfile\"
+  #echo \"\`date\` \$scriptype \$1 does NOT exist.\"
+  msgutil_r \"\$MASTER_IP\" \"error\" "\"\$scriptype \$1 does NOT exist.\"" \"\$logfile\" \"xcat.mypostscript\"
   return_value=-1
  fi
 
@@ -932,22 +931,23 @@ if [ $NODE_DEPLOYMENT -eq 1 ] || [ "$MODE" = "4" ] || [ "$MODE" = "6" ]; then
     if [ "$MODE" = "6" ]; then
         echo "
 if [ \"\$return_value\" -eq \"0\" ]; then
-    msgutil_r \$MASTER_IP \"debug\" \"node booted successfully,reporting status...\" \"/var/log/xcat/xcat.log\"
+    msgutil_r \$MASTER_IP \"debug\" \"node booted successfully, reporting status...\" \"/var/log/xcat/xcat.log\" \"xcat.mypostscript\"
     updateflag.awk \$MASTER 3002 \"installstatus booted\"
 else
-    msgutil_r \$MASTER_IP \"debug\" \"node boot failed,reporting status...\" \"/var/log/xcat/xcat.log\"
+    msgutil_r \$MASTER_IP \"debug\" \"node boot failed, reporting status...\" \"/var/log/xcat/xcat.log\" \"xcat.mypostscript\"
     updateflag.awk \$MASTER 3002 \"installstatus failed\"
 fi
         " >> /$xcatpost/mypostscript
     else
         echo "
 if [ \"\$return_value\" -eq \"0\" ]; then
-    msgutil_r \$MASTER_IP \"debug\" \"node booted successfully,reporting status...\" \"/var/log/xcat/xcat.log\"
+    msgutil_r \$MASTER_IP \"debug\" \"node booted successfully, reporting status...\" \"/var/log/xcat/xcat.log\" \"xcat.mypostscript\"
     updateflag.awk \$MASTER 3002 \"installstatus booted\"
-    msgutil_r \$MASTER_IP \"info\" \"provision completed.(\$NODE)\" \"/var/log/xcat/xcat.log\"
+    msgutil_r \$MASTER_IP \"info\" \"provision completed.(\$NODE)\" \"/var/log/xcat/xcat.log\" \"xcat.mypostscript\"
 else
-    msgutil_r \$MASTER_IP \"debug\" \"node boot failed,reporting status...\" \"/var/log/xcat/xcat.log\"
+    msgutil_r \$MASTER_IP \"debug\" \"node boot failed, reporting status...\" \"/var/log/xcat/xcat.log\" \"xcat.mypostscript\"
     updateflag.awk \$MASTER 3002 \"installstatus failed\"
+    msgutil_r \$MASTER_IP \"error\" \"provision completed with error.(\$NODE)\" \"/var/log/xcat/xcat.log\" \"xcat.mypostscript\"
 fi
         " >> /$xcatpost/mypostscript
     fi
@@ -972,10 +972,10 @@ fi
 
 chmod 700 /$xcatpost/mypostscript
 if [ -x /$xcatpost/mypostscript ];then
-   echolog "debug" "running /$xcatpost/mypostscript"   
+   echolog "debug" "Running /$xcatpost/mypostscript"
    /$xcatpost/mypostscript
-   VRET_POST=$?   
-   echolog "debug" "/$xcatpost/mypostscript return with $VRET_POST"   
+   VRET_POST=$?
+   echolog "debug" "/$xcatpost/mypostscript return with $VRET_POST"
 fi
 
 #tell user it is done when this is called by updatenode command

--- a/xCAT/postscripts/xcatinstallpost
+++ b/xCAT/postscripts/xcatinstallpost
@@ -6,6 +6,7 @@
 #################################################################
 
 . /xcatpost/xcatlib.sh
+log_label="xcat.xcatinstallpost"
 if [ -f /xcatpost/mypostscript.post ]; then
     XCATDEBUGMODE=`grep 'XCATDEBUGMODE=' /xcatpost/mypostscript.post |cut -d= -f2 | tr -d \'\" | tr A-Z a-z `
     MASTER_IP=`grep '^MASTER_IP=' /xcatpost/mypostscript.post |cut -d= -f2|sed s/\'//g`
@@ -16,7 +17,7 @@ fi
 
 
 if [ ! `uname` = Linux ]; then
-   msgutil_r "$MASTER_IP" "err" "$0: the OS name is not Linux" "/var/log/xcat/xcat.log"
+   msgutil_r "$MASTER_IP" "error" "The OS is not Linux" "/var/log/xcat/xcat.log" "$log_label"
    exit
 fi
 SLI=$(awk 'BEGIN{srand(); printf("%d\n",rand()*10)}')
@@ -38,7 +39,7 @@ while true; do
 
     if [ $RETRY -eq 90 ];then
        #timeout, complain and exit
-       msgutil_r "$MASTER_IP" "err" "`date`: xcatinstallpost: the network between the node and $MASTER_IP is not ready, please check[retry=$RETRY]..." "/var/log/xcat/xcat.log"
+       msgutil_r "$MASTER_IP" "error" "the network between the node and $MASTER_IP is not ready, please check[retry=$RETRY]..." "/var/log/xcat/xcat.log" "$log_label"
        exit 1
     fi
     
@@ -124,15 +125,16 @@ echo "
 
 if [ \"\$return_value\" -eq \"0\" ]; then
     if [ \"\$XCATDEBUGMODE\" = \"1\" ] || [ \"\$XCATDEBUGMODE\" = \"2\" ]; then
-        msgutil_r \"\$MASTER_IP\" \"info\" \"node booted, reporting status...\" \"/var/log/xcat/xcat.log\"
+        msgutil_r \"\$MASTER_IP\" \"debug\" \"node booted, reporting status...\" \"/var/log/xcat/xcat.log\" \"xcat.mypostscript\"
     fi
     updateflag.awk \$MASTER 3002 \"installstatus booted\"
-    msgutil_r \$MASTER_IP \"info\" \"provision completed.(\$NODE)\" \"/var/log/xcat/xcat.log\"
+    msgutil_r \$MASTER_IP \"info\" \"provision completed.(\$NODE)\" \"/var/log/xcat/xcat.log\" \"xcat.mypostscript\"
 else
     if [ \"\$XCATDEBUGMODE\" = \"1\" ] || [ \"\$XCATDEBUGMODE\" = \"2\" ]; then
-        msgutil_r \"\$MASTER_IP\" \"info\" \"node boot failed, reporting status...\" \"/var/log/xcat/xcat.log\"
+        msgutil_r \"\$MASTER_IP\" \"debug\" \"node boot failed, reporting status...\" \"/var/log/xcat/xcat.log\" \"xcat.mypostscript\"
     fi
     updateflag.awk \$MASTER 3002 \"installstatus failed\"
+    msgutil_r \$MASTER_IP \"error\" \"provision completed with error.(\$NODE)\" \"/var/log/xcat/xcat.log\" \"xcat.mypostscript\"
 fi
 " >> /xcatpost/mypostscript.post
 fi
@@ -140,7 +142,7 @@ fi
 
 chmod +x /xcatpost/mypostscript.post
 if [ -x /xcatpost/mypostscript.post ];then
-   msgutil_r "$MASTER_IP" "info" "running /xcatpost/mypostscript.post" "/var/log/xcat/xcat.log"
+   msgutil_r "$MASTER_IP" "info" "Running /xcatpost/mypostscript.post" "/var/log/xcat/xcat.log" "$log_label"
    /xcatpost/mypostscript.post
-   msgutil_r "$MASTER_IP" "info" "/xcatpost/mypostscript.post return" "/var/log/xcat/xcat.log"
+   msgutil_r "$MASTER_IP" "info" "/xcatpost/mypostscript.post return" "/var/log/xcat/xcat.log" "$log_label"
 fi

--- a/xCAT/postscripts/xcatlib.sh
+++ b/xCAT/postscripts/xcatlib.sh
@@ -754,11 +754,14 @@ function msgutil_r {
    local msgtype=$2
    local msgstr=$3
    local logfile=$4
+   local logtag=$5
 
-   if [ -z "$msgtype"  ]; then
+   if [ -z "$msgtype" ]; then
       msgtype="debug"
    fi
-
+   if [ -z "$logtag" ]; then
+      logtag="xcat"
+   fi
 
    if [ -n "$logserver" ];then
        #In Ubuntu, there is a bug in some logger version that "-n" is ignored. The workaround is to specify the 
@@ -770,24 +773,24 @@ function msgutil_r {
         then
             eval $(logger -V 2>/dev/null | awk '{print $4}' | awk -F '.' '{printf("var1=%s; var2=%s",$1,$2)}')
             if [ $var1 -eq 2 ] && [ $var2 -lt 25 ]; then
-                logger -u /tmp/ignored -n $logserver -t xcat -p local4.$msgtype "$msgstr" >/dev/null 2>&1
+                logger -u /tmp/ignored -n $logserver -t $logtag -p local4.$msgtype "$msgstr" >/dev/null 2>&1
             else
-                logger -n $logserver -t xcat -p local4.$msgtype "$msgstr" >/dev/null 2>&1
+                logger -n $logserver -t $logtag -p local4.$msgtype "$msgstr" >/dev/null 2>&1
             fi
         else
-            logger -n $logserver -t xcat -p local4.$msgtype "$msgstr" >/dev/null 2>&1
+            logger -n $logserver -t $logtag -p local4.$msgtype "$msgstr" >/dev/null 2>&1
         fi
       if [ "$?" != "0" ];then
-         exec 3<>/dev/udp/$logserver/514 && logger -s -t xcat -p local4.$msgtype "$msgstr" 1>&3  2>&1 && exec 3>&-
+         exec 3<>/dev/udp/$logserver/514 && logger -s -t $logtag -p local4.$msgtype "$msgstr" 1>&3  2>&1 && exec 3>&-
          if [ "$?" != "0" ];then
-            logger -s -t xcat -p local4.$msgtype "$msgstr" 2>&1|nc $logserver 514 >/dev/null 2>&1
+            logger -s -t $logtag -p local4.$msgtype "$msgstr" 2>&1|nc $logserver 514 >/dev/null 2>&1
             if [ "$?" != "0" ];then
-               logger -t xcat -p local4.$msgtype "$msgstr"
+               logger -t $logtag -p local4.$msgtype "$msgstr"
             fi
          fi
       fi
    else
-       logger -t xcat -p local4.$msgtype "$msgstr"
+       logger -t $logtag -p local4.$msgtype "$msgstr"
    fi
 
    if [ -n "$logfile"  ]; then
@@ -799,7 +802,7 @@ function msgutil_r {
 
       #   echo "$msgstr" | tee -a $logfile
       #else
-      echo "$msgstr" >> $logfile
+      echo "$(date) [$msgtype]: $logtag: $msgstr" >> $logfile
    fi
 
 }

--- a/xCAT/postscripts/xcatpostinit1.netboot
+++ b/xCAT/postscripts/xcatpostinit1.netboot
@@ -34,7 +34,7 @@ status)
 stop)
   echo -n "nothing to stop "
   logger -t xcat -p local4.info "nothing to stop"
-  grep nonodestatus /proc/cmdline 2>/dev/null || [ -n "$XCATSERVER" ] &&  /xcatpost/updateflag.awk $XCATSERVER 3002 "installstatus powering-off" 
+  grep nonodestatus /proc/cmdline 2>/dev/null || [ -n "$XCATSERVER" ] &&  /xcatpost/updateflag.awk $XCATSERVER 3002 "installstatus powering-off"
   ;;
 start)
         # Node is stateless by default
@@ -56,10 +56,12 @@ start)
         # Test for script existance
         if ! [ -x "$SCRIPT" ]; then
             msg "can't locate executable $SCRIPT"
+            grep nonodestatus /proc/cmdline 2>/dev/null || [ -n "$XCATSERVER" ] &&  /xcatpost/updateflag.awk $XCATSERVER 3002 "installstatus failed"
             exit -1
         fi
 
         # Run $SCRIPT according to node type
+        grep nonodestatus /proc/cmdline 2>/dev/null || [ -n "$XCATSERVER" ] &&  /xcatpost/updateflag.awk $XCATSERVER 3002 "installstatus postbooting"
         if [ $STATELITE -ne 0 ]; then
             logger -t xcat -p local4.info "Call $SCRIPT for statelite mode"
             "$SCRIPT" 4


### PR DESCRIPTION
Partial address #4582 
 - clear logs in the key components during provisioning (not only debug mode, but debug mode will have more logs)
 - now only cover rhel7 stateful and stateless
 - make more syslogs into cluster.log (tag = xcat or xcat.*)
 - enhance the `msgutil_r` to make logs to file and syslog has better format
 - when install monitor die due to some plugin, the progname will be recovered.
 - the changes will not impact other distro