### PR TITLE
modify directory to copy bmcsetup/getipmi scripts

### DIFF
--- a/build-ubunturepo
+++ b/build-ubunturepo
@@ -250,7 +250,7 @@ then
                             # shipping bmcsetup and getipmi scripts as part of postscripts
                             files=("bmcsetup" "getipmi")
                             for f in "${files[@]}"; do
-                                 cp ${CURDIR}/../xCAT-genesis-scripts/bin/$f ${CURDIR}/postscripts/$f
+                                 cp ${CURDIR}/../xCAT-genesis-scripts/usr/bin/$f ${CURDIR}/postscripts/$f
                                  sed -i "s/xcat.genesis.$f/$f/g" ${CURDIR}/postscripts/$f
                             done
                         fi

--- a/makerpm
+++ b/makerpm
@@ -126,7 +126,7 @@ function makexcat {
 			# shipping bmcsetup and getipmi scripts as part of postscripts
 			files=("bmcsetup" "getipmi")
 			for f in "${files[@]}"; do
-				cp "xCAT-genesis-scripts/bin/"$f ${RPMNAME}/postscripts/$f
+				cp "xCAT-genesis-scripts/usr/bin/"$f ${RPMNAME}/postscripts/$f
 				sed -i  "s/xcat.genesis.$f/$f/g" ${RPMNAME}/postscripts/$f
 			done
 			cd `dirname $0`/$RPMNAME

--- a/xCAT-genesis-scripts/debian/rules
+++ b/xCAT-genesis-scripts/debian/rules
@@ -33,8 +33,7 @@ install:
 	dh_installdirs $(installdir)
 	dh_install -X".svn"
 	dh_install ./etc/ $(installtodir)
-	dh_install ./usr/bin/ $(installtodir)
-	dh_install ./usr/sbin/ $(installtodir)
+	dh_install ./usr/ $(installtodir)
 	dh_compress
 	dh_installdeb
 	dh_gencontrol


### PR DESCRIPTION
1. modify xcat-genesis-script debian/rule to include the correct directory
2. modify build script for xCAT-server to copy script from correct directory.