### PR TITLE
change empty_zones_enable in named.conf

### DIFF
--- a/perl-xCAT/xCAT/Schema.pm
+++ b/perl-xCAT/xCAT/Schema.pm
@@ -1057,7 +1057,7 @@ passed as argument rather than by table value',
 "              requests it does not know to these servers. Note that the DNS servers on the\n" .
 "              service nodes will ignore this value and always be configured to forward \n" .
 "              to the management node.\n\n" .
-" emptyzonesenable: (yes or no). This is to set empty-zones-enable value in named.conf options section. The default is yes. \n\n"
+" emptyzonesenable: (yes or no). This is to set empty-zones-enable value in named.conf options section. \n\n"
 " master:  The hostname of the xCAT management node, as known by the nodes.\n\n" .
 " nameservers:  A comma delimited list of DNS servers that each node in the cluster should\n" .
 "               use. This value will end up in the nameserver settings of the\n" .

--- a/perl-xCAT/xCAT/Schema.pm
+++ b/perl-xCAT/xCAT/Schema.pm
@@ -1057,6 +1057,7 @@ passed as argument rather than by table value',
 "              requests it does not know to these servers. Note that the DNS servers on the\n" .
 "              service nodes will ignore this value and always be configured to forward \n" .
 "              to the management node.\n\n" .
+" emptyzonesenable: (yes or no). This is to set empty-zones-enable value in named.conf options section. The default is yes. \n\n"
 " master:  The hostname of the xCAT management node, as known by the nodes.\n\n" .
 " nameservers:  A comma delimited list of DNS servers that each node in the cluster should\n" .
 "               use. This value will end up in the nameserver settings of the\n" .

--- a/xCAT-server/lib/xcat/plugins/ddns.pm
+++ b/xCAT-server/lib/xcat/plugins/ddns.pm
@@ -595,7 +595,8 @@ sub process_request {
         } else {
             my $rsp;
             push @{ $rsp->{data} }, "emptyzonesenable from xCAT site table should be yes or no.";
-            xCAT::MsgUtils->message("E", $rsp, $callback); 
+            xCAT::MsgUtils->message("E", $rsp, $callback);
+            return; 
         }
     }
     my @slave_ips;

--- a/xCAT-server/lib/xcat/plugins/ddns.pm
+++ b/xCAT-server/lib/xcat/plugins/ddns.pm
@@ -589,8 +589,14 @@ sub process_request {
 
     my @options = xCAT::TableUtils->get_site_attribute("emptyzonesenable");
     my $empty_zones = $options[0];
-    if (defined($empty_zones) and $empty_zones =~ /^yes$|^no$/) {
-        $ctx->{empty_zones_enable} = $empty_zones;
+    if (defined($empty_zones)) {
+        if ($empty_zones =~ /^yes$|^no$/) {
+            $ctx->{empty_zones_enable} = $empty_zones;
+        } else {
+            my $rsp;
+            push @{ $rsp->{data} }, "emptyzonesenable from xCAT site table should be yes or no.";
+            xCAT::MsgUtils->message("E", $rsp, $callback); 
+        }
     }
     my @slave_ips;
     my $dns_slaves = get_dns_slave();
@@ -1104,8 +1110,7 @@ sub update_namedconf {
                         }
                         push @newnamed, "\t};\n";
                     } elsif ($ctx->{empty_zones_enable} and $line =~ /empty-zones-enable/) {
-                        push @newnamed, "\tempty-zones-enable " . $_ . ";\n";
-                        $skip = 1;
+                        push @newnamed, "\tempty-zones-enable " . $ctx->{empty_zones_enable} . ";\n";
                     } elsif ($ctx->{slaves} and $line =~ /allow-transfer \{/) {
                         push @newnamed, "\tallow-transfer \{\n";
                         $skip = 1;

--- a/xCAT-server/lib/xcat/plugins/ddns.pm
+++ b/xCAT-server/lib/xcat/plugins/ddns.pm
@@ -587,6 +587,11 @@ sub process_request {
         $ctx->{forwarders} = \@forwarders;
     }
 
+    my @options = xCAT::TableUtils->get_site_attribute("emptyzonesenable");
+    my $empty_zones = $options[0];
+    if (defined($empty_zones) and $empty_zones =~ /^yes$|^no$/) {
+        $ctx->{empty_zones_enable} = $empty_zones;
+    }
     my @slave_ips;
     my $dns_slaves = get_dns_slave();
     if (scalar @$dns_slaves) {
@@ -1098,6 +1103,9 @@ sub update_namedconf {
                             push @newnamed, "\t\t" . $_ . ";\n";
                         }
                         push @newnamed, "\t};\n";
+                    } elsif ($ctx->{empty_zones_enable} and $line =~ /empty-zones-enable/) {
+                        push @newnamed, "\tempty-zones-enable " . $_ . ";\n";
+                        $skip = 1;
                     } elsif ($ctx->{slaves} and $line =~ /allow-transfer \{/) {
                         push @newnamed, "\tallow-transfer \{\n";
                         $skip = 1;
@@ -1235,6 +1243,10 @@ sub update_namedconf {
                 push @newnamed, "\t\t$_;\n";
             }
             push @newnamed, "\t};\n";
+        }
+
+        if ($ctx->{empty_zones_enable}){
+            push @newnamed, "\tempty-zones-enable " . $ctx->{empty_zones_enable} . ";\n";
         }
 
         if ($slave) {


### PR DESCRIPTION
For PMR 36104,227,000
For #4629 

UT:
```
[root@bybc0602 xCAT]# service xcatd restart
Restarting xcatd (via systemctl):                          [  OK  ]

[root@bybc0602 xCAT]# chdef -t site emptyzonesenable=no
1 object definitions have been created or modified.

[root@bybc0602 xCAT]# makedns -n
Handling bybc0607 in /etc/hosts.
Handling abc1 in /etc/hosts.
Ignoring host abc1, it does not belong to any nets defined in networks table or the net it belongs to is configured to use an external nameserver.
Handling node1-ib0 in /etc/hosts.
Handling c910f05c01bc06 in /etc/hosts.
Handling localhost in /etc/hosts.
Handling abc in /etc/hosts.
Handling bybc0605 in /etc/hosts.
Handling bybc0609 in /etc/hosts.
Handling bybc0602 in /etc/hosts.
Getting reverse zones, this may take several minutes for a large cluster.
Completed getting reverse zones.
Updating zones.
Completed updating zones.
Restarting named
Restarting named complete
Updating DNS records, this may take several minutes for a large cluster.
Completed updating DNS records.
DNS setup is completed

[root@bybc0602 xCAT]# cat /etc/named.conf
#generated by xCAT: /opt/xcat/sbin/makedns command
options {
	directory "/var/named/";
	allow-recursion { any; };
	forwarders {
		10.5.106.1;
	};
	empty-zones-enable no;
};
... ...

[root@bybc0602 xCAT]# chdef -t site emptyzonesenable=yes
1 object definitions have been created or modified.

[root@bybc0602 xCAT]# makedns -n
Handling bybc0607 in /etc/hosts.
Handling abc1 in /etc/hosts.
Ignoring host abc1, it does not belong to any nets defined in networks table or the net it belongs to is configured to use an external nameserver.
Handling node1-ib0 in /etc/hosts.
Handling c910f05c01bc06 in /etc/hosts.
Handling localhost in /etc/hosts.
Handling abc in /etc/hosts.
Handling bybc0605 in /etc/hosts.
Handling bybc0609 in /etc/hosts.
Handling bybc0602 in /etc/hosts.
Getting reverse zones, this may take several minutes for a large cluster.
Completed getting reverse zones.
Updating zones.
Completed updating zones.
Restarting named
Restarting named complete
Updating DNS records, this may take several minutes for a large cluster.
Completed updating DNS records.
DNS setup is completed

[root@bybc0602 xCAT]# cat /etc/named.conf
#generated by xCAT: /opt/xcat/sbin/makedns command
options {
	directory "/var/named/";
	allow-recursion { any; };
	forwarders {
		10.5.106.1;
	};
	empty-zones-enable yes;
};
... ...

[root@bybc0602 xCAT]# chdef -t site emptyzonesenable=
1 object definitions have been created or modified.

[root@bybc0602 xCAT]# makedns -n
Handling bybc0607 in /etc/hosts.
Handling abc1 in /etc/hosts.
Ignoring host abc1, it does not belong to any nets defined in networks table or the net it belongs to is configured to use an external nameserver.
Handling node1-ib0 in /etc/hosts.
Handling c910f05c01bc06 in /etc/hosts.
Handling localhost in /etc/hosts.
Handling abc in /etc/hosts.
Handling bybc0605 in /etc/hosts.
Handling bybc0609 in /etc/hosts.
Handling bybc0602 in /etc/hosts.
Getting reverse zones, this may take several minutes for a large cluster.
Completed getting reverse zones.
Updating zones.
Completed updating zones.
Restarting named
Restarting named complete
Updating DNS records, this may take several minutes for a large cluster.
Completed updating DNS records.
DNS setup is completed

[root@bybc0602 xCAT]# cat /etc/named.conf
#generated by xCAT: /opt/xcat/sbin/makedns command
options {
	directory "/var/named/";
	allow-recursion { any; };
	forwarders {
		10.5.106.1;
	};
};
... ...
```