### PR TITLE
let agent.py can be executed

### DIFF
--- a/xCAT-openbmc-py/xCAT-openbmc-py.spec
+++ b/xCAT-openbmc-py/xCAT-openbmc-py.spec
@@ -30,8 +30,7 @@ xCAT-openbmc-py provides openbmc related functions.
 rm -rf $RPM_BUILD_ROOT
 install -d $RPM_BUILD_ROOT/%{prefix}/lib/python/agent
 install -d $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/xcatagent
-install -m755 lib/python/agent/agent.py $RPM_BUILD_ROOT/%{prefix}/lib/python/agent
-install -m644 lib/python/agent/client.py $RPM_BUILD_ROOT/%{prefix}/lib/python/agent
+install -m755 lib/python/agent/*.py $RPM_BUILD_ROOT/%{prefix}/lib/python/agent
 install -m644 lib/python/agent/xcatagent/*.py $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/xcatagent
 
 %ifnos linux

--- a/xCAT-openbmc-py/xCAT-openbmc-py.spec
+++ b/xCAT-openbmc-py/xCAT-openbmc-py.spec
@@ -30,7 +30,8 @@ xCAT-openbmc-py provides openbmc related functions.
 rm -rf $RPM_BUILD_ROOT
 install -d $RPM_BUILD_ROOT/%{prefix}/lib/python/agent
 install -d $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/xcatagent
-install -m644 lib/python/agent/*.py $RPM_BUILD_ROOT/%{prefix}/lib/python/agent
+install -m755 lib/python/agent/agent.py $RPM_BUILD_ROOT/%{prefix}/lib/python/agent
+install -m644 lib/python/agent/client.py $RPM_BUILD_ROOT/%{prefix}/lib/python/agent
 install -m644 lib/python/agent/xcatagent/*.py $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/xcatagent
 
 %ifnos linux


### PR DESCRIPTION
for #4659 

UT:
```
[root@c910f03c11k08 xcat-core]# ./makepythonrpm xCAT-openbmc-py
xCAT-openbmc-py/
xCAT-openbmc-py/lib/
xCAT-openbmc-py/lib/python/
xCAT-openbmc-py/lib/python/agent/
xCAT-openbmc-py/lib/python/agent/xcatagent/
xCAT-openbmc-py/lib/python/agent/xcatagent/utils.py
xCAT-openbmc-py/lib/python/agent/xcatagent/base.py
xCAT-openbmc-py/lib/python/agent/xcatagent/__init__.py
xCAT-openbmc-py/lib/python/agent/xcatagent/rest.py
xCAT-openbmc-py/lib/python/agent/xcatagent/xcat_exception.py
xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
xCAT-openbmc-py/lib/python/agent/xcatagent/server.py
xCAT-openbmc-py/lib/python/agent/client.py
xCAT-openbmc-py/lib/python/agent/agent.py
xCAT-openbmc-py/xCAT-openbmc-py.spec
Building /root/rpmbuild/RPMS/noarch/xCAT-openbmc-py-2.13.10-snap*.noarch.rpm ...
[root@c910f03c11k08 xcat-core]# cd /root/rpmbuild/RPMS/noarch/
[root@c910f03c11k08 noarch]# ls
xCAT-openbmc-py-2.13.10-snap201801190259.noarch.rpm
[root@c910f03c11k08 noarch]# rpm -ivh xCAT-openbmc-py-2.13.10-snap201801190259.noarch.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:xCAT-openbmc-py-1:2.13.10-snap201################################# [100%]

[root@c910f03c11k08 agent]# ls /opt/xcat/lib/python/agent/
agent.py  agent.pyc  agent.pyo  client.py  client.pyc  client.pyo  xcatagent

[root@c910f03c11k08 rpm]# rpower f6u17 status
f6u17: off
```