### PR TITLE
fix buildpythonrpm when there is no /root/rpmbuild/SOURCES directory

### DIFF
--- a/makepythonrpm
+++ b/makepythonrpm
@@ -22,7 +22,7 @@ VER=`cat Version`
 REL="--define"
 EASE='usedate 1'
 RPMROOT=/root/rpmbuild
-
+mkdir -p $RPMROOT/SOURCES
 rpmbuild --version > /dev/null
 if [ $? -gt 0 ]; then
     echo "Error: rpmbuild does not appear to be installed or working."


### PR DESCRIPTION
When executing buildpythonrpm, there is no /root/rpmbuild/SOURCES directory cause "tar (child): /root/rpmbuild/SOURCES/xCAT-openbmc-py-2.13.10.tar.gz: Cannot open: No such file or directory" error. 
After this fix, UT is as following:
```
[root@c910f03c11k08 xcat-core]# ./makepythonrpm xCAT-openbmc-py
xCAT-openbmc-py/
xCAT-openbmc-py/lib/
xCAT-openbmc-py/lib/python/
xCAT-openbmc-py/lib/python/agent/
xCAT-openbmc-py/lib/python/agent/agent.py
xCAT-openbmc-py/lib/python/agent/client.py
xCAT-openbmc-py/lib/python/agent/xcatagent/
xCAT-openbmc-py/lib/python/agent/xcatagent/__init__.py
xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
xCAT-openbmc-py/lib/python/agent/xcatagent/utils.py
xCAT-openbmc-py/lib/python/agent/xcatagent/server.py
xCAT-openbmc-py/lib/python/agent/xcatagent/base.py
xCAT-openbmc-py/lib/python/agent/xcatagent/rest.py
xCAT-openbmc-py/lib/python/agent/xcatagent/xcat_exception.py
xCAT-openbmc-py/xCAT-openbmc-py.spec
Building /root/rpmbuild/RPMS/noarch/xCAT-openbmc-py-2.13.10-snap*.noarch.rpm ...
```