### PR TITLE
Support rspconfig powersupplyredundancy

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -578,10 +578,14 @@ my %api_config_info = (
     RSPCONFIG_POWERSUPPLY_REDUNDENCY => {
         command      => "rspconfig",
         url          => "/sensors/chassis/PowerSupplyRedundancy",
-        attr_url     => "PowerSupplyRedundency",
-        display_name => "PowerSupplyRedundency",
-        type         => "boolean",
-        subcommand   => "powersupplyredundency",
+        attr_url     => "value",
+        display_name => "PowerSupplyRedundancy",
+        type         => "attribute",
+        subcommand   => "powersupplyredundancy",
+        attr_value   => {
+            enabled     => "Enabled",
+            disabled    => "Disabled",
+        },
     },
     RSPCONFIG_POWERRESTORE_POLICY => {
         command      => "rspconfig",


### PR DESCRIPTION
Implements issue #4435

Replacement for PR #4572 

Support openbmc *powersupplyredundancy* attribute, which now takes "Enabled"/"Disabled" values.

```
[root@briggs01 xCAT_plugin]# rspconfig mid05tor12cn05 powersupplyredundancy
mid05tor12cn05: PowerSupplyRedundancy: Disabled

[root@briggs01 xCAT_plugin]# rspconfig mid05tor12cn05 powersupplyredundancy=enabled
mid05tor12cn05: BMC Setting PowerSupplyRedundancy...

[root@briggs01 xCAT_plugin]# rspconfig mid05tor12cn05 powersupplyredundancy
mid05tor12cn05: PowerSupplyRedundancy: Enabled
[root@briggs01 xCAT_plugin]#
```