### PR TITLE
Missing some 'echo' when running updatenode, and put it back

### DIFF
--- a/xCAT/postscripts/xcatdsklspost
+++ b/xCAT/postscripts/xcatdsklspost
@@ -881,7 +881,7 @@ run_ps () {
  fi
 
  if [ -f \$1 ]; then 
-  #echo \"\`date\` Running \$scriptype: \$1\"
+  echo \"\`date\` Running \$scriptype: \$1\"
   msgutil_r \"\$MASTER_IP\" \"info\" "\"Running \$scriptype: \$1\"" \"\$logfile\" \"xcat.mypostscript\"
   if [ \"\$XCATDEBUGMODE\" = \"1\" ] || [ \"\$XCATDEBUGMODE\" = \"2\" ]; then
      local compt=\$(file \$1)
@@ -901,10 +901,10 @@ run_ps () {
   if [ \"\$ret_local\" -ne \"0\" ]; then
      return_value=\$ret_local
   fi
-  #echo \"\$scriptype: \$1 exited with code \$ret_local\"
+  echo \"\$scriptype: \$1 exited with code \$ret_local\"
   msgutil_r \"\$MASTER_IP\" \"info\" "\"\$scriptype \$1 return with \$ret_local\"" \"\$logfile\" \"xcat.mypostscript\"
  else
-  #echo \"\`date\` \$scriptype \$1 does NOT exist.\"
+  echo \"\`date\` \$scriptype \$1 does NOT exist.\"
   msgutil_r \"\$MASTER_IP\" \"error\" "\"\$scriptype \$1 does NOT exist.\"" \"\$logfile\" \"xcat.mypostscript\"
   return_value=-1
  fi


### PR DESCRIPTION
To address the updatenode -P testcase failed issue after merge https://github.com/xcat2/xcat-core/pull/4648 for #4582 
UT:
Just patch `/install/postscripts/xcatdsklspost` , and run `updatenode <> -P foo_script`
```
# updatenode frame45cn07 -P ospkgs
frame45cn07: trying to download postscripts...
frame45cn07: postscripts downloaded successfully
frame45cn07: trying to get mypostscript from 192.168.3.29...
frame45cn07: Tue Jan 23 22:10:43 EST 2018 Running postscript: ospkgs   <====== here it is the echo output
frame45cn07: Please install yum on frame45cn07.
frame45cn07: postscript: ospkgs exited with code 1 <====== here it is the echo output
frame45cn07: Running of postscripts has completed.
```