### PR TITLE
fix issue 4705, modify usage output

### DIFF
--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -221,6 +221,9 @@ my %usage = (
        rspconfig <noderange>  [sshcfg]
        rspconfig <noderange>  [sshcfg=<enable|disable>]
     ",
+    "rspreset" =>
+      "Usage:
+        rspreset <noderange>",
     "getmacs" =>
       "Usage: 
    Common:
@@ -534,6 +537,13 @@ Options:
     "clonevm" =>
       "Usage:
     clonevm noderange [-t createmaster -f | -b basemaster -d | -h]",
+    "rmigrate" =>
+      "Usage:
+    Common:
+        rmigrate <noderange> target_host
+    zVM specific:
+        rmigrate <noderange> [destination=target_host|action=action|force=force|immediate=yes_no|max_total=total|max_quiesce=quiesce]
+    ",
 );
 
 # Rebuild full command usage from its components
@@ -558,6 +568,7 @@ my %version = (
     "rbootseq"       => "$vers",
     "rscan"          => "$vers",
     "rspconfig"      => "$vers",
+    "rspreset"       => "$vers",
     "getmacs"        => "$vers",
     "mkvm"           => "$vers",
     "lsvm"           => "$vers",
@@ -576,6 +587,7 @@ my %version = (
     "cfgve"          => "$vers",
     "chhypervisor"   => "$vers",
     "rmhypervisor"   => "$vers",
+    "rmigrate"       => "$vers",
     "clonevm"        => "$vers",
 );
 

--- a/xCAT-server/lib/xcat/plugins/AAAusage.pm
+++ b/xCAT-server/lib/xcat/plugins/AAAusage.pm
@@ -37,7 +37,11 @@ sub handled_commands {
         rmhwconn => 'AAAusage',
         lshwconn => 'AAAusage',
         renergy  => 'AAAusage',
-        nodeset  => 'AAAusage'
+        nodeset  => 'AAAusage',
+        rspreset => 'AAAusage',
+        rmhypervisor => 'AAAusage',
+        rmigrate => 'AAAusage',
+        rshutdown => 'AAAusage',
     };
 }
 

--- a/xCAT-server/lib/xcat/plugins/blade.pm
+++ b/xCAT-server/lib/xcat/plugins/blade.pm
@@ -4157,7 +4157,9 @@ sub preprocess_request {
 
     my $usage_string = xCAT::Usage->parseCommand($command, @exargs);
     if ($usage_string) {
-        $callback->({ data => $usage_string });
+        if ($command !~ /renergy|rspconfig/) {
+            $callback->({ data => $usage_string });
+        }
         $request = {};
         return;
     }

--- a/xCAT-server/lib/xcat/plugins/kvm.pm
+++ b/xCAT-server/lib/xcat/plugins/kvm.pm
@@ -3671,7 +3671,9 @@ sub preprocess_request {
 
     my $usage_string = xCAT::Usage->parseCommand($command, @exargs);
     if ($usage_string) {
-        $callback->({ data => $usage_string });
+        if ($command ne "rscan") {
+            $callback->({ data => $usage_string });
+        }
         $request = {};
         return;
     }


### PR DESCRIPTION
#4705 

* For commands ``rscan|renergy|rspconfig <noderange> -h``, mgt is "ipmi"
Before modified, print usage twice.
After modified, in blade.pm and kvm.pm, will not print Usage for that commands.

* For commands ``rspreset|rmhypervisor|rmigrate|rshutdown -h`` will handle in AAAUsage.pm.

* For commands ``rspreset|rmhypervisor|rmigrate`` added Usage info in Usage.pm
```
# rspreset -h
Usage:
        rspreset <noderange>

# rmhypervisor -h
Usage:
    rmhypervisor noderange [-f | -h]

# rmigrate -h
Usage:
    Common:
        rmigrate noderange target_host
    zVM specific:
        rmigrate noderange [destination=target_host|action=action|force=force|immediate=yes_no|max_total=total|max_quiesce=quiesce]
```