### PR TITLE
Enhance bmcdiscovery to fix issue 

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -47,6 +47,7 @@ my $bmc_user;
 my $bmc_pass;
 my $openbmc_user;
 my $openbmc_pass;
+my $done_num = 0;
 $::P9_WITHERSPOON_MFG_ID     = "42817";
 $::P9_WITHERSPOON_PRODUCT_ID = "16975";
 
@@ -724,6 +725,12 @@ sub scan_process {
         while($children > 0) {
             sleep(1);
         }
+        unless ($done_num) {
+            my %rsp;
+            $rsp{data} = ["No bmc found.\n"];
+            xCAT::MsgUtils->message("W", \%rsp, $::CALLBACK);
+        }
+
     }
     else
     {
@@ -855,18 +862,12 @@ sub forward_data {
     if (!($@ and $@ =~ /^Magic number checking on storable file/)) { #this most likely means we ran over the end of available input
         $callback->($responses);
     }
-    my $num = 0;
     eval {
         $responses = fd_retrieve($cfd);
         if ($responses->{data}) {
-            $num += $responses->{data};
+            $done_num += $responses->{data};
         }
     };
-    unless ($num) {
-        my %rsp;
-        $rsp{data} = ["No bmc found.\n"];
-        xCAT::MsgUtils->message("W", \%rsp, $::CALLBACK);
-    }
 }
 
 


### PR DESCRIPTION
Enhance the fix in #4710  for issue 4652

The fix output in #4710 
```
[root@stratton01 ~]# bmcdiscover --range 50.6.30.1,50.11.1.1,10.6.31.1,10.3.5.10
Warning: No bmc found.

Warning: No bmc found.
```
The fix in this PR:
```
[root@stratton01 ~]# bmcdiscover --range 50.6.30.1,50.11.1.1,10.6.31.1,10.3.5.10
Warning: No bmc found.

[root@stratton01 ~]# bmcdiscover --range 50.6.30.1,50.11.1.1,10.6.31.1,10.3.5.10,10.3.5.4
Warning: No bmc found.
```