### PR TITLE
remove python-requests from xCAT-openbmc-py.spec

### DIFF
--- a/xCAT-openbmc-py/xCAT-openbmc-py.spec
+++ b/xCAT-openbmc-py/xCAT-openbmc-py.spec
@@ -17,7 +17,7 @@ AutoReqProv: no
 %endif
 
 BuildArch: noarch
-Requires: xCAT-server, python-requests 
+Requires: xCAT-server 
 
 %description
 xCAT-openbmc-py provides openbmc related functions. 


### PR DESCRIPTION
For #4682 
```
[root@c910f03c11k08 noarch]# yum localinstall xCAT-openbmc-py-2.13.10-snap201801250418.noarch.rpm
Loaded plugins: product-id, search-disabled-repos, subscription-manager
This system is not registered with an entitlement server. You can use subscription-manager to register.
Examining xCAT-openbmc-py-2.13.10-snap201801250418.noarch.rpm: 1:xCAT-openbmc-py-2.13.10-snap201801250418.noarch
Marking xCAT-openbmc-py-2.13.10-snap201801250418.noarch.rpm as an update to 1:xCAT-openbmc-py-2.13.10-snap201801230426.noarch
Resolving Dependencies
--> Running transaction check
---> Package xCAT-openbmc-py.noarch 1:2.13.10-snap201801230426 will be updated
---> Package xCAT-openbmc-py.noarch 1:2.13.10-snap201801250418 will be an update
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package Arch   Version  Repository                                        Size
================================================================================
Updating:
 xCAT-openbmc-py
         noarch 1:2.13.10-snap201801250418
                         /xCAT-openbmc-py-2.13.10-snap201801250418.noarch  91 k

Transaction Summary
================================================================================
Upgrade  1 Package

Total size: 91 k
Is this ok [y/d/N]: y
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Updating   : 1:xCAT-openbmc-py-2.13.10-snap201801250418.noarch            1/2
  Cleanup    : 1:xCAT-openbmc-py-2.13.10-snap201801230426.noarch            2/2
  Verifying  : 1:xCAT-openbmc-py-2.13.10-snap201801250418.noarch            1/2
  Verifying  : 1:xCAT-openbmc-py-2.13.10-snap201801230426.noarch            2/2

Updated:
  xCAT-openbmc-py.noarch 1:2.13.10-snap201801250418

Complete!
[root@c910f03c11k08 noarch]# ls
xCAT-openbmc-py-2.13.10-snap201801250418.noarch.rpm
```