### PR TITLE
Support hostname and network setting changes for IRPDU

### DIFF
--- a/docs/source/advanced/pdu/irpdu.rst
+++ b/docs/source/advanced/pdu/irpdu.rst
@@ -47,6 +47,14 @@ The following commands are supported against a compute node:
 
 The following commands are supported against a PDU: 
 
+   * To change hostname of IR PDU: ::
+
+       # rspconfig f5pdu3 hosname=f5pdu3
+
+   * To change ip address of IR PDU: ::
+
+       # rsconfig f5pdu3 ip=x.x.x.x netmaks=255.x.x.x
+
    * Check the status of the full PDU: ::
 
        # rpower f5pdu3 stat

--- a/docs/source/advanced/pdu/pdu.rst
+++ b/docs/source/advanced/pdu/pdu.rst
@@ -20,7 +20,7 @@ xCAT uses snmp scan method to discover PDU.  Make sure net-snmp-utils package is
        -x        XML formatted output.
        -z        Stanza formatted output.
        -w        Writes output to xCAT database.
-       --setup   Process switch-based pdu discovery and configure the PDUs(it included passwordless , change ip address from dhcp to static and snmp configuration). It required predefined PDU node definition with switch name and switch port attributes for mapping. (Notes: only support for crpdu for now for this options)
+       --setup   Process switch-based pdu discovery and configure the PDUs. For crpdu, --setup options will configure passwordless , change ip address from dhcp to static, hostname changes and snmp v3 configuration. For irpdu, it will configure ip address and hostname.  It required predefined PDU node definition with switch name and switch port attributes for mapping.
 
 
 Define PDU Objects

--- a/xCAT-server/lib/xcat/plugins/pdu.pm
+++ b/xCAT-server/lib/xcat/plugins/pdu.pm
@@ -1406,6 +1406,7 @@ sub netcfg_for_irpdu {
         $login_ip = $discover_ip;
     } else {
         xCAT::SvrUtils::sendmsg(" is not reachable", $callback,$pdu);
+        return;
     }
     
     foreach my $cmd (@exargs) {

--- a/xCAT-server/lib/xcat/plugins/switchdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/switchdiscover.pm
@@ -1440,31 +1440,38 @@ sub switchsetup {
             @nets = $nettab->getAllAttribs('net','mask');
         }
         foreach my $mytype (keys %$nodes_to_config) {
-            if ( $mytype eq "irpdu" ) {
-                send_msg($request, 0, "the setup options for irpdu is not support yet\n");
-            } elsif ( $mytype eq "crpdu" ) {
-                my $nodetab = xCAT::Table->new('hosts');
-                my $nodehash = $nodetab->getNodesAttribs(\@{${nodes_to_config}->{$mytype}},['ip','otherinterfaces']);
-                foreach my $pdu(@{${nodes_to_config}->{$mytype}}) {
-                    my $cmd = "rspconfig $pdu sshcfg"; 
-                    xCAT::Utils->runcmd($cmd, 0);
-                    my $ip = $nodehash->{$pdu}->[0]->{ip};
-                    my $mask;
-                    foreach my $net (@nets) {
-                        if (xCAT::NetworkUtils::isInSameSubnet( $net->{'net'}, $ip, $net->{'mask'}, 0)) {
-                            $mask=$net->{'mask'};
-                        }
-                    }
-                    $cmd = "rspconfig $pdu hostname=$pdu ip=$ip netmask=$mask";
-                    xCAT::Utils->runcmd($cmd, 0);
-                    if ($::RUNCMD_RC == 0) {
-                        xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$pdu,"ip=$ip","otherinterfaces="] }, $sub_req, 0, 1);
-                    } else {
-                        send_msg($request, 0, "Failed to run rspconfig command to set ip/netmask\n");
+            my $nodetab = xCAT::Table->new('hosts');
+            my $nodehash = $nodetab->getNodesAttribs(\@{${nodes_to_config}->{$mytype}},['ip','otherinterfaces']);
+            foreach my $pdu(@{${nodes_to_config}->{$mytype}}) {
+                my $ip = $nodehash->{$pdu}->[0]->{ip};
+                my $mask;
+                foreach my $net (@nets) {
+                    if (xCAT::NetworkUtils::isInSameSubnet( $net->{'net'}, $ip, $net->{'mask'}, 0)) {
+                        $mask=$net->{'mask'};
                     }
                 }
-            } else {
-                send_msg($request, 0, "the pdu type $mytype is not support\n");
+                my $cmd;
+                my $rc = 0;
+                if ( $mytype eq "crpdu" ) {
+                    $cmd = "rspconfig $pdu sshcfg"; 
+                    send_msg($request, 0, "process command: $cmd\n");
+                    $rc = xCAT::Utils->runcmd($cmd, 0);
+                    $cmd = "rspconfig $pdu hostname=$pdu ip=$ip netmask=$mask";
+                    send_msg($request, 0, "process command: $cmd\n");
+                    $rc  = xCAT::Utils->runcmd($cmd, 0);
+                } elsif ( $mytype eq "irpdu" ) {
+                    $cmd = "rspconfig $pdu hostname=$pdu ip=$ip netmask=$mask";
+                    send_msg($request, 0, "process command: $cmd\n");
+                    $rc = xCAT::Utils->runcmd($cmd, 0);
+                } else {
+                    send_msg($request, 0, "the pdu type $mytype is not support\n");
+                    $rc = 1;
+                }
+                if ($rc == 0) {
+                    xCAT::Utils->runxcmd({ command => ['chdef'], arg => ['-t','node','-o',$pdu,'status=configured',"ip=$ip","otherinterfaces="] }, $sub_req, 0, 1);
+                } else {
+                    send_msg($request, 0, "Failed to run rspconfig command to set ip/netmask\n");
+                }
             }
         }
         return;


### PR DESCRIPTION
IR PDUs provides Untility to configure the PDU.
````
+=============================================================================+
|                     [ IBM PDU Configuration Utility ]                       |
+=============================================================================+

Please Login: ADMIN

Password: ****
+=============================================================================+
|                     [ IBM PDU Configuration Utility ]                       |
+=============================================================================+

      1. System Configuration
      2. PDU Firmware Reset
      3. Reset Configuration to Default
      4. PDU Firmware Upgrade
      5. Event Log
      6. History Log
      0. Exit

------------------------------------------------------------------------------
     Please Enter Your Selection =>
````
xCAT adds **rspconfig** command  to change hostname and network setting for IRPDU via Expect routine.
````
 rspconfig irpdunode [hostname=<NAME>|ip=<IP>|gateway=<GATEWAY>|mask=<MASK>]
````
this command is also included in the **pdudiscover --setup** options.
```
]# pdudiscover --range 172.21.253.115 --setup
Discovering pdu using snmpwalk for 172.21.253.115 .....
ip              name                    vendor                                                  mac
------------    ------------            ------------                                            ------------
172.21.253.115  f6pdu116                IBM PDU 46W1608(46M4003) OPDP_sIBM_v01.3_2 FreeRTOS_4.2.1 Lwip_1.2.0    00:18:23:05:84:10
pdu discovered and matched: f6pdu116 to f6pdu16
Configure pdu ....
process command: rspconfig f6pdu16 hostname=f6pdu16 ip=172.21.253.105 netmask=255.255.0.0
````