### PR TITLE
Update man page for RTD for 2.13.10 release

### DIFF
--- a/docs/source/guides/admin-guides/references/man5/servicenode.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/servicenode.5.rst
@@ -68,7 +68,7 @@ servicenode Attributes:
 
 \ **conserver**\ 
  
- Do we set up console service on this service node?  Valid values: 0, 1, or 2. If 0, it does not change the current state of the service. If 1, configures and starts conserver daemon. If 2, configures and starts goconserver daemon. 
+ Do we set up console service on this service node?  Valid values: 0, 1, or 2. If 0, it does not change the current state of the service. If 1, configures and starts conserver daemon. If 2, configures and starts goconserver daemon.
  
 
 

--- a/docs/source/guides/admin-guides/references/man5/site.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/site.5.rst
@@ -136,6 +136,8 @@ site Attributes:
                 service nodes will ignore this value and always be configured to forward 
                 to the management node.
   
+   emptyzonesenable: (yes or no). This is to set empty-zones-enable value in named.conf options section. 
+  
    master:  The hostname of the xCAT management node, as known by the nodes.
   
    nameservers:  A comma delimited list of DNS servers that each node in the cluster should
@@ -259,6 +261,8 @@ site Attributes:
    defserialport:  The default serial port - currently only used by mknb.
   
    defserialspeed:  The default serial speed - currently only used by mknb.
+  
+   disablenodesetwarning:  Allow the legacy xCAT non-osimage style nodeset to execute.
   
    genmacprefix:  When generating mac addresses automatically, use this manufacturing
                   prefix (e.g. 00:11:aa)

--- a/docs/source/guides/admin-guides/references/man7/group.7.rst
+++ b/docs/source/guides/admin-guides/references/man7/group.7.rst
@@ -679,8 +679,7 @@ group Attributes:
 
 \ **nicsadapter**\  (nics.nicsadapter)
  
- Comma-separated list of extra parameters that will be used for each NIC configuration.
-                     <nic1>!<param1=value1 param2=value2>,<nic2>!<param4=value4 param5=value5>, for example, enP3p3s0f1!mac=98:be:94:59:fa:cd linkstate=DOWN,enP3p3s0f2!mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face
+ Comma-separated list of NIC information collected by getadapter. <nic1>!<param1=value1 param2=value2>,<nic2>!<param4=value4 param5=value5>, for example, enP3p3s0f1!mac=98:be:94:59:fa:cd linkstate=DOWN,enP3p3s0f2!mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face
  
 
 
@@ -975,7 +974,7 @@ group Attributes:
 
 \ **setupconserver**\  (servicenode.conserver)
  
- Do we set up Conserver on this service node?  Valid values:1 or 0. If 1, configures and starts conserver daemon. If 0, it does not change the current state of the service.
+ Do we set up console service on this service node?  Valid values: 0, 1, or 2. If 0, it does not change the current state of the service. If 1, configures and starts conserver daemon. If 2, configures and starts goconserver daemon.
  
 
 

--- a/docs/source/guides/admin-guides/references/man7/node.7.rst
+++ b/docs/source/guides/admin-guides/references/man7/node.7.rst
@@ -679,8 +679,7 @@ node Attributes:
 
 \ **nicsadapter**\  (nics.nicsadapter)
  
- Comma-separated list of extra parameters that will be used for each NIC configuration.
-                     <nic1>!<param1=value1 param2=value2>,<nic2>!<param4=value4 param5=value5>, for example, enP3p3s0f1!mac=98:be:94:59:fa:cd linkstate=DOWN,enP3p3s0f2!mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face
+ Comma-separated list of NIC information collected by getadapter. <nic1>!<param1=value1 param2=value2>,<nic2>!<param4=value4 param5=value5>, for example, enP3p3s0f1!mac=98:be:94:59:fa:cd linkstate=DOWN,enP3p3s0f2!mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face
  
 
 
@@ -987,7 +986,7 @@ node Attributes:
 
 \ **setupconserver**\  (servicenode.conserver)
  
- Do we set up Conserver on this service node?  Valid values:1 or 0. If 1, configures and starts conserver daemon. If 0, it does not change the current state of the service.
+ Do we set up console service on this service node?  Valid values: 0, 1, or 2. If 0, it does not change the current state of the service. If 1, configures and starts conserver daemon. If 2, configures and starts goconserver daemon.
  
 
 


### PR DESCRIPTION
Looks like some RTD generated man pages were missed for 2.13.10 release 

I did not check the content, just generated them. 