### PR TITLE
enhance Installing a New Kernel in the Diskless Image doc

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/common/deployment/install_new_kernel.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/deployment/install_new_kernel.rst
@@ -20,6 +20,7 @@ For example, kernel-3.10.0-229.ael7b.ppc64le.rpm means kernelver=3.10.0-229.ael7
         mkdir -p /install/kernels/3.10.0-229.ael7b.ppc64le
         cp /tmp/kernel-3.10.0-229.ael7b.ppc64le.rpm /install/kernels/3.10.0-229.ael7b.ppc64le
         createrepo /install/kernels/3.10.0-229.ael7b.ppc64le/
+        chdef -t osimage <imagename> -p pkgdir=/install/kernels/3.10.0-229.ael7b.ppc64le/
 
 Run genimage/packimage to update the image with the new kernel. 
 Note: If downgrading the kernel, you may need to first remove the rootimg directory. ::
@@ -44,7 +45,7 @@ The "4.6.ppc64le" is replaced with "4-ppc64le": ::
          cp /tmp/kernel-default-3.12.28-4.6.ppc64le.rpm /install/kernels/3.12.28-4-ppc64le/
          cp /tmp/kernel-default-base-3.12.28-4.6.ppc64le.rpm /install/kernels/3.12.28-4-ppc64le/ 
          cp /tmp/kernel-default-devel-3.12.28-4.6.ppc64le.rpm /install/kernels/3.12.28-4-ppc64le/
-
+         chdef -t osimage <imagename> -p pkgdir=/install/kernels/3.12.28-4-ppc64le/
 
 Run genimage/packimage to update the image with the new kernel. 
 Note: If downgrading the kernel, you may need to first remove the rootimg directory.


### PR DESCRIPTION
For #4735 

In "Installing a New Kernel in the Diskless Image" doc, it missed "add kernel packages into pkgdir".
UT:
http://10.4.41.1/install/diskless/xcat-core/docs/build/html/guides/admin-guides/manage_clusters/ppc64le/diskless/customize_image/install_new_kernel.html