### PR TITLE
Remove not existing table fields in PDU table

### DIFF
--- a/perl-xCAT/xCAT/Schema.pm
+++ b/perl-xCAT/xCAT/Schema.pm
@@ -4245,22 +4245,7 @@ push(@{ $defspec{group}->{'attrs'} }, @nodeattrs);
         tabentry        => 'pdu.outlet',
         access_tabentry => 'pdu.node=attr:node',
     },
-    {   attr_name => 'machinetype',
-        only_if         => 'nodetype=pdu',
-        tabentry        => 'pdu.machinetype',
-        access_tabentry => 'pdu.node=attr:node',
-    },
-    { attr_name => 'modelnum',
-        only_if         => 'nodetype=pdu',
-        tabentry        => 'pdu.modelnum',
-        access_tabentry => 'pdu.node=attr:node',
-    },
-    { attr_name => 'serialnum',
-        only_if         => 'nodetype=pdu',
-        tabentry        => 'pdu.serialnum',
-        access_tabentry => 'pdu.node=attr:node',
-    },
-);
+  );
 
 
 


### PR DESCRIPTION
For issue #4739 

Remove not existing attributes for pdu table. machine type, model number and serial number.  Those information can get from rinv command.

The current attributes for PDU table are:
```
# tabdump pdu
#node,nodetype,pdutype,outlet,username,password,snmpversion,community,snmpuser,authtype,authkey,privtype,privkey,seclevel,comments,disable
````

