### PR TITLE
Detect invalid dump id

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -3926,12 +3926,7 @@ sub dump_download_process {
         return 1;
     }
     if ($h->{message} eq $::RESPONSE_OK) {
-        if ($::RSPCONFIG_DUMP_DOWNLOAD_ALL_REQUESTED) {
-            # Slightly different message if downloading dumps as part of "download all" processing
-            xCAT::SvrUtils::sendmsg("Downloading dump $dump_id to $file_name", $callback, $node);
-        } else {
-            xCAT::SvrUtils::sendmsg("Dump $dump_id generated. Downloading to $file_name", $callback, $node);
-        }
+        xCAT::SvrUtils::sendmsg("Downloading dump $dump_id to $file_name", $callback, $node);
         my $curl_dwld_result = `$curl_dwld_cmd -s`;
         if (!$curl_dwld_result) {
             if ($xcatdebugmode) {
@@ -3941,7 +3936,17 @@ sub dump_download_process {
             `$curl_logout_cmd -s`;
             # Verify the file actually got downloaded
             if (-e $file_name) {
-                xCAT::SvrUtils::sendmsg("Downloaded dump $dump_id to $file_name", $callback, $node) if ($::VERBOSE);
+                # Check inside downloaded file, if there is a "Path not found" -> invalid ID
+                my $grep_cmd = "/usr/bin/grep -a";
+                my $path_not_found = "Path not found";
+                my $grep_for_path = `$grep_cmd $path_not_found $file_name`;
+                if ($grep_for_path) {
+                    xCAT::SvrUtils::sendmsg([1, "Invalid dump $dump_id was specified. Use -l option to list."], $callback, $node);
+                    # Remove downloaded file, nothing useful inside of it
+                    unlink $file_name;
+                } else {
+                    xCAT::SvrUtils::sendmsg("Downloaded dump $dump_id to $file_name", $callback, $node) if ($::VERBOSE);
+                }
             }
             else {
                 xCAT::SvrUtils::sendmsg([1, "Failed to download dump $dump_id to $file_name. Verify destination directory exists and has correct access permissions."], $callback, $node);


### PR DESCRIPTION
#4653 

Detect when the downloaded dump file contains "Path not found" error, which indicates that invalid dump id was specified.

UT:

```
[root@briggs01 xCAT_plugin]# rspconfig mid05tor12cn16 dump
Capturing BMC Diagnostic information, this will take some time...
mid05tor12cn16: Dump requested. Target ID is 8, waiting for BMC to generate...
mid05tor12cn16: Still waiting for dump 8 to be generated...
mid05tor12cn16: Downloading dump 8 to /var/log/xcat/dump/20180129-1045_mid05tor12cn16_dump_8.tar.xz
[root@briggs01 xCAT_plugin]#
```
```
[root@briggs01 xCAT_plugin]# rspconfig mid05tor12cn16 dump -d 4
mid05tor12cn16: Downloading dump 4 to /var/log/xcat/dump/20180129-1047_mid05tor12cn16_dump_4.tar.xz
[root@briggs01 xCAT_plugin]#
```
```
[root@briggs01 xCAT_plugin]# rspconfig mid05tor12cn16 dump -d 44
mid05tor12cn16: Downloading dump 44 to /var/log/xcat/dump/20180129-1047_mid05tor12cn16_dump_44.tar.xz
mid05tor12cn16: Error: Invalid dump 44 was specified. Use -l option to list.
[root@briggs01 xCAT_plugin]#
```
```
[root@briggs01 xCAT_plugin]# rspconfig mid05tor12cn16 dump -d all
Downloading all dumps...
mid05tor12cn16: Downloading dump 6 to /var/log/xcat/dump/20180129-1047_mid05tor12cn16_dump_6.tar.xz
mid05tor12cn16: Downloading dump 3 to /var/log/xcat/dump/20180129-1047_mid05tor12cn16_dump_3.tar.xz
mid05tor12cn16: Downloading dump 7 to /var/log/xcat/dump/20180129-1047_mid05tor12cn16_dump_7.tar.xz
mid05tor12cn16: Downloading dump 2 to /var/log/xcat/dump/20180129-1047_mid05tor12cn16_dump_2.tar.xz
mid05tor12cn16: Downloading dump 8 to /var/log/xcat/dump/20180129-1047_mid05tor12cn16_dump_8.tar.xz
mid05tor12cn16: Downloading dump 1 to /var/log/xcat/dump/20180129-1047_mid05tor12cn16_dump_1.tar.xz
mid05tor12cn16: Downloading dump 4 to /var/log/xcat/dump/20180129-1047_mid05tor12cn16_dump_4.tar.xz
mid05tor12cn16: Downloading dump 5 to /var/log/xcat/dump/20180129-1047_mid05tor12cn16_dump_5.tar.xz
[root@briggs01 xCAT_plugin]#
```