### PR TITLE
fix issue 4652: extra warning message for bmcdiscover

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -1130,8 +1130,6 @@ sub bmcdiscovery_ipmi {
         }
 
         display_output($opz,$opw,$mtms_node,$mac_node,$node_data,"ipmi",$request_command);
-    } else {
-        store_fd({data=>0}, $fd);
     }
 }
 
@@ -1156,6 +1154,7 @@ sub bmcdiscovery_openbmc{
     my $mtms_node       = "";
     my $mac_node        = "";
 
+    store_fd({data=>1}, $fd);
     print "$ip: Detected openbmc, attempting to obtain system information...\n";
     my $http_protocol="https";
     my $openbmc_project_url = "xyz/openbmc_project";


### PR DESCRIPTION
Fix issue #4652:
```
[root@stratton01 ~]# lsdef p9euh01 -i bmc
Object name: p9euh01
    bmc=10.6.7.254
[root@stratton01 ~]# bmcdiscover --range 10.6.7.254
10.6.7.254,,,,,mp,bmc,,
Warning: No bmc found.
```
With this fix:
```
[root@stratton01 xcat]# bmcdiscover --range 10.6.7.254,50.6.3.1
10.6.7.254,,,,,mp,bmc,,
[root@stratton01 xcat]# bmcdiscover --range 10.6.7.254,50.6.3.1,10.3.5.10
10.6.7.254,,,,,mp,bmc,,
[root@stratton01 xcat]# bmcdiscover --range 50.6.3.1,10.3.5.10
Warning: No bmc found.

[root@stratton01 xcat]# bmcdiscover --range 50.6.31.1,10.3.5.10
Warning: Unable to establish IPMI v2 / RMCP+ session: invalid role for 50.6.31.1
[root@stratton01 xcat]# bmcdiscover --range 50.6.31.1
Warning: Unable to establish IPMI v2 / RMCP+ session: invalid role for 50.6.31.1
[root@stratton01 xcat]# bmcdiscover --range 50.6.31.1,10.3.5.4,10.3.5.10
Warning: Unable to establish IPMI v2 / RMCP+ session: invalid role for 50.6.31.1
```