### PR TITLE
fix issue 4758, add '-V' in rflash Usage and manpage

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rflash.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rflash.1.rst
@@ -19,15 +19,15 @@ Name
 ****************
 
 
-\ **rflash**\  [\ **-h | -**\ **-help**\  | \ **-v | -**\ **-version**\ ]
+\ **rflash**\  [\ **-h | -**\ **-help**\  | \ **-v | -**\ **-version**\  | \ **-V | -**\ **-verbose**\ ]
 
 PPC (with HMC) specific:
 ========================
 
 
-\ **rflash**\  \ *noderange*\  \ **-p**\  \ *directory*\  [\ **-**\ **-activate**\  {\ **concurrent | disruptive**\ }] [\ **-V | -**\ **-verbose**\ ]
+\ **rflash**\  \ *noderange*\  \ **-p**\  \ *directory*\  [\ **-**\ **-activate**\  {\ **concurrent | disruptive**\ }]
 
-\ **rflash**\  \ *noderange*\  {\ **-**\ **-commit | -**\ **-recover**\ } [\ **-V | -**\ **-verbose**\ ]
+\ **rflash**\  \ *noderange*\  {\ **-**\ **-commit | -**\ **-recover**\ }
 
 
 PPC (without HMC, using Direct FSP Management) specific:
@@ -50,7 +50,7 @@ OpenPOWER BMC specific (using IPMI):
 ====================================
 
 
-\ **rflash**\  \ *noderange*\  [\ *hpm_file_path*\  | \ **-d**\  \ *data_directory*\ ] [\ **-c | -**\ **-check**\ ] [\ **-**\ **-retry=**\ \ *count*\ ] [\ **-V**\ ]
+\ **rflash**\  \ *noderange*\  [\ *hpm_file_path*\  | \ **-d**\  \ *data_directory*\ ] [\ **-c | -**\ **-check**\ ] [\ **-**\ **-retry=**\ \ *count*\ ]
 
 \ **rflash**\  \ *noderange*\  \ **-**\ **-recover**\  \ *bmc_file_path*\ 
 

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -351,16 +351,16 @@ my %usage = (
        makentp [-a|--all] [-V|--verbose]",
     "rflash" =>
       "Usage: 
-    rflash [ -h|--help|-v|--version]
+    rflash [ -h|--help|-v|--version|-V|--verbose]
     PPC (with HMC) specific:
-	rflash <noderange> -p <rpm_directory> [--activate {concurrent | disruptive}] [-V|--verbose] 
-	rflash <noderange> {--commit | --recover} [-V|--verbose]
+	rflash <noderange> -p <rpm_directory> [--activate {concurrent | disruptive}] 
+	rflash <noderange> {--commit | --recover}
     PPC (using Direct FSP Management) specific:
 	rflash <noderange> -p <rpm_directory> [--activate {disruptive|deferred}] [-d <data_directory>]
-	rflash <noderange> [--commit | --recover] [-V|--verbose]
+	rflash <noderange> [--commit | --recover]
         rflash <noderange> [--bpa_acdl]
     OpenPOWER BMC specific (using IPMI):
-        rflash <noderange> [<hpm_file_path>|-d <data_directory>] [-c|--check] [--retry=<count>] [-V]
+        rflash <noderange> [<hpm_file_path>|-d <data_directory>] [-c|--check] [--retry=<count>]
         rflash <noderange> --recover <bmc_file_path>
     OpenPOWER OpenBMC specific:
         rflash <noderange> {[-c|--check] | [-l|--list]}

--- a/xCAT-client/pods/man1/rflash.1.pod
+++ b/xCAT-client/pods/man1/rflash.1.pod
@@ -4,13 +4,13 @@ B<rflash> - Performs Licensed Internal Code (LIC) update or firmware update on s
 
 =head1 B<Synopsis>
 
-B<rflash> [B<-h>|B<--help> | B<-v>|B<--version>]
+B<rflash> [B<-h>|B<--help> | B<-v>|B<--version> | B<-V>|B<--verbose>]
 
 =head2 PPC (with HMC) specific:
 
-B<rflash> I<noderange> B<-p> I<directory> [B<--activate> {B<concurrent>|B<disruptive>}] [B<-V>|B<--verbose>]
+B<rflash> I<noderange> B<-p> I<directory> [B<--activate> {B<concurrent>|B<disruptive>}]
 
-B<rflash> I<noderange> {B<--commit>|B<--recover>} [B<-V>|B<--verbose>]
+B<rflash> I<noderange> {B<--commit>|B<--recover>}
 
 =head2 PPC (without HMC, using Direct FSP Management) specific:
 
@@ -24,7 +24,7 @@ B<rflash> I<noderange> I<http_directory>
 
 =head2 OpenPOWER BMC specific (using IPMI):
 
-B<rflash> I<noderange> [I<hpm_file_path> | B<-d> I<data_directory>] [B<-c>|B<--check>] [B<--retry=>I<count>] [B<-V>]
+B<rflash> I<noderange> [I<hpm_file_path> | B<-d> I<data_directory>] [B<-c>|B<--check>] [B<--retry=>I<count>]
 
 B<rflash> I<noderange> B<--recover> I<bmc_file_path>
 


### PR DESCRIPTION
#4758 

```
# rflash f6u17 -h
Usage:
    rflash [ -h|--help|-v|--version|-V|--verbose]
    PPC (with HMC) specific:
	rflash <noderange> -p <rpm_directory> [--activate {concurrent | disruptive}]
	rflash <noderange> {--commit | --recover}
    PPC (using Direct FSP Management) specific:
	rflash <noderange> -p <rpm_directory> [--activate {disruptive|deferred}] [-d <data_directory>]
	rflash <noderange> [--commit | --recover]
        rflash <noderange> [--bpa_acdl]
    OpenPOWER BMC specific (using IPMI):
        rflash <noderange> [<hpm_file_path>|-d <data_directory>] [-c|--check] [--retry=<count>]
        rflash <noderange> --recover <bmc_file_path>
    OpenPOWER OpenBMC specific:
        rflash <noderange> {[-c|--check] | [-l|--list]}
        rflash <noderange> <tar_file_path> {[-c|--check] | [-a|--activate] | [-u|--upload]}
        rflash <noderange> <tar_file_diretory> [-d] [--no-host-reboot]
        rflash <noderange> <image_id> {[-a|--activate] | [--delete]}
```