### PR TITLE
modify error msg for rflash unsupported option

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc2.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc2.pm
@@ -163,6 +163,11 @@ sub parse_args {
         if ($option_num >= 2) {
             return ([ 1, "Multiple options are not supported."]);
         } elsif ($option_num == 0) {
+            for my $arg (@ARGV) {
+                if ($arg =~ /^-/) {
+                    return ([ 1, "Unsupported command: $command $arg" ]);
+                }
+            }
             return ([ 1, "No options specified."]);
         }
         if ($activate or $check or $delete or $upload) {


### PR DESCRIPTION
#4764 
Before modify:
```
# rflash f6u17 df4b8673 --active
mid05tor12cn05: Error: No options specified.
```
After modify:
```
# rflash f6u17 df4b8673 --active
f6u17: Error: Unsupported command: rflash --active
```