### PR TITLE
fix nodeset not properly creating autoinst file for repo #3572

### DIFF
--- a/xCAT-server/lib/perl/xCAT/Template.pm
+++ b/xCAT-server/lib/perl/xCAT/Template.pm
@@ -302,7 +302,7 @@ sub subvars {
                         $source .= "repo --name=pkg$c --baseurl=http://#TABLE:noderes:\$NODE:nfsserver#/$pkgdir\n"; #for rhels5.9
                     }
                     my $distrepofile="/install/postscripts/repos/$pkgdir/local-repository.tmpl";
-                    if( -f "$distrepofile"){
+                    if( -f "$distrepofile" and -s "$distrepofile"){
                         my $repofd;
                         my $repo_in_post;
                         local $/=undef;


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/3572:

 do no…t add yum repo entry for the directories without valid repodata under pkgdir

UT:
```
[root@c910f03c05k21 xCAT]# lsdef -t osimage -o rhels7.4-ppc64le-install-compute
Object name: rhels7.4-ppc64le-install-compute
    imagetype=linux
    osarch=ppc64le
    osdistroname=rhels7.4-ppc64le
    osname=Linux
    osvers=rhels7.4
    otherpkgdir=/install/post/otherpkgs/rhels7.4/ppc64le
    pkgdir=/install/rhels7.4/ppc64le,/tmp/yy
    pkglist=/opt/xcat/share/xcat/install/rh/compute.rhels7.pkglist
    profile=compute
    provmethod=install
    template=/opt/xcat/share/xcat/install/rh/compute.rhels7.tmpl
[root@c910f03c05k21 xCAT]# ll /tmp/yy
total 0
[root@c910f03c05k21 xCAT]# nodeset c910f03c05k27 osimage=rhels7.4-ppc64le-install-compute
c910f03c05k27: install rhels7.4-ppc64le-compute
[root@c910f03c05k21 xcat-core]# cat /install/autoinst/c910f03c05k27|grep repo -A10
cat >/etc/yum.repos.d/local-repository-0.repo << 'EOF'
[local-rhels7.4-ppc64le--install-rhels7.4-ppc64le]
name=xCAT configured yum repository for /install/rhels7.4/ppc64le
baseurl=http://c910f03c05k21//install/rhels7.4/ppc64le
enabled=1
gpgcheck=0

[local-rhels7.4-ppc64le--install-rhels7.4-ppc64le-addons-ResilientStorage]
name=xCAT configured yum repository for /install/rhels7.4/ppc64le/addons/ResilientStorage
baseurl=http://c910f03c05k21//install/rhels7.4/ppc64le/addons/ResilientStorage
enabled=1
gpgcheck=0

[local-rhels7.4-ppc64le--install-rhels7.4-ppc64le-addons-HighAvailability]
name=xCAT configured yum repository for /install/rhels7.4/ppc64le/addons/HighAvailability
baseurl=http://c910f03c05k21//install/rhels7.4/ppc64le/addons/HighAvailability
enabled=1
gpgcheck=0


EOF


if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
   msgutil_r "$MASTER_IP" "info" "running mypostscript" "/var/log/xcat/xcat.log" "$log_label"
```