### PR TITLE
Add code to support timesyncmethod for OpenBMC using rspconfig

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
@@ -49,6 +49,14 @@ OpenBMC specific:
 
 \ **rspconfig**\  \ *noderange*\  {\ **ipsrc | ip | netmask | gateway | hostname | vlan | sshcfg**\ }
 
+\ **rspconfig**\  \ *noderange*\  \ **autoreboot**\ 
+
+\ **rspconfig**\  \ *noderange*\  \ **autoreboot={0|1}**\ 
+
+\ **rspconfig**\  \ *noderange*\  \ **bootmode**\ 
+
+\ **rspconfig**\  \ *noderange*\  \ **bootmode={safe|regular|setup}**\ 
+
 \ **rspconfig**\  \ *noderange*\  \ **dump**\  [\ **-l | -**\ **-list**\ ] [\ **-g | -**\ **-generate**\ ] [\ **-c | -**\ **-clear**\  {\ *id*\  | \ **all**\ }] [\ **-d | -**\ **-download**\  {\ *id*\  | \ **all**\ }]
 
 \ **rspconfig**\  \ *noderange*\  \ **powerrestorepolicy**\ 
@@ -59,13 +67,9 @@ OpenBMC specific:
 
 \ **rspconfig**\  \ *noderange*\  \ **powersupplyredundancy={disabled|enabled}**\ 
 
-\ **rspconfig**\  \ *noderange*\  \ **autoreboot**\ 
+\ **rspconfig**\  \ *noderange*\  \ **timesyncmethod**\ 
 
-\ **rspconfig**\  \ *noderange*\  \ **autoreboot={0|1}**\ 
-
-\ **rspconfig**\  \ *noderange*\  \ **bootmode**\ 
-
-\ **rspconfig**\  \ *noderange*\  \ **bootmode={safe|regular|setup}**\ 
+\ **rspconfig**\  \ *noderange*\  \ **timesyncmethod={manual|ntp}**\ 
 
 
 MPA specific:
@@ -450,31 +454,31 @@ OPTIONS
 
 \ **powerrestorepolicy**\ 
  
- Display or control BMC Power Restore Policy attribute setting.
+ Display or control BMC Power Restore Policy attribute setting. [OpenBMC]
  
 
 
 \ **powersupplyredundancy**\ 
  
- Display or control BMC Power Supply Redundancy attribute setting.
+ Display or control BMC Power Supply Redundancy attribute setting. [OpenBMC]
  
 
 
 \ **autoreboot**\ 
  
- Display or control BMC Auto Reboot attribute setting.
+ Display or control BMC Auto Reboot attribute setting. [OpenBMC]
  
 
 
 \ **bootmode**\ 
  
- Display or control BMC Boot Mode attribute setting.
+ Display or control BMC Boot Mode attribute setting. [OpenBMC]
  
 
 
 \ **dump**\ 
  
- Manage OpenBMC system dumps. If no sub-option is provided, will generate, wait, and download the dump.
+ Generate BMC system dump. If no sub-option is provided, will generate, wait, and download the dump. [OpenBMC]
  
  
  \ **-c**\  will clear a single specified dump, or use 'all' to clear all dumps on the BMC.
@@ -492,6 +496,12 @@ OPTIONS
  \ **-d**\  will download a single dump or all generated dumps from the BMC to /var/log/xcat/dump on management or service node.
  
  
+ 
+
+
+\ **timesyncmethod**\ 
+ 
+ Set the method for time synchronization on the BMC. [OpenBMC]
  
 
 

--- a/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
@@ -478,7 +478,7 @@ OPTIONS
 
 \ **dump**\ 
  
- Generate BMC system dump. If no sub-option is provided, will generate, wait, and download the dump. [OpenBMC]
+ Generate/Manage BMC system dumps. If no sub-option is provided, will generate, wait, and download the dump. [OpenBMC]
  
  
  \ **-c**\  will clear a single specified dump, or use 'all' to clear all dumps on the BMC.

--- a/xCAT-client/pods/man1/rspconfig.1.pod
+++ b/xCAT-client/pods/man1/rspconfig.1.pod
@@ -26,6 +26,14 @@ B<rspconfig> I<noderange> B<garp>=I<time>
 
 B<rspconfig> I<noderange> {B<ipsrc>|B<ip>|B<netmask>|B<gateway>|B<hostname>|B<vlan>|B<sshcfg>}
 
+B<rspconfig> I<noderange> B<autoreboot>
+
+B<rspconfig> I<noderange> B<autoreboot={0|1}>
+
+B<rspconfig> I<noderange> B<bootmode>
+
+B<rspconfig> I<noderange> B<bootmode={safe|regular|setup}>
+
 B<rspconfig> I<noderange> B<dump> [B<-l>|B<--list>] [B<-g>|B<--generate>] [B<-c>|B<--clear> {I<id> | B<all>}] [B<-d>|B<--download> {I<id> | B<all>}]
 
 B<rspconfig> I<noderange> B<powerrestorepolicy>
@@ -36,13 +44,9 @@ B<rspconfig> I<noderange> B<powersupplyredundancy>
 
 B<rspconfig> I<noderange> B<powersupplyredundancy={disabled|enabled}>
 
-B<rspconfig> I<noderange> B<autoreboot>
+B<rspconfig> I<noderange> B<timesyncmethod>
 
-B<rspconfig> I<noderange> B<autoreboot={0|1}>
-
-B<rspconfig> I<noderange> B<bootmode>
-
-B<rspconfig> I<noderange> B<bootmode={safe|regular|setup}>
+B<rspconfig> I<noderange> B<timesyncmethod={manual|ntp}>
 
 =head2 MPA specific:
 
@@ -344,23 +348,23 @@ The subnet mask.
 
 =item B<powerrestorepolicy>
 
-Display or control BMC Power Restore Policy attribute setting.
+Display or control BMC Power Restore Policy attribute setting. [OpenBMC]
 
 =item B<powersupplyredundancy>
 
-Display or control BMC Power Supply Redundancy attribute setting.
+Display or control BMC Power Supply Redundancy attribute setting. [OpenBMC]
 
 =item B<autoreboot>
 
-Display or control BMC Auto Reboot attribute setting.
+Display or control BMC Auto Reboot attribute setting. [OpenBMC]
 
 =item B<bootmode>
 
-Display or control BMC Boot Mode attribute setting.
+Display or control BMC Boot Mode attribute setting. [OpenBMC]
 
 =item B<dump>
 
-Manage OpenBMC system dumps. If no sub-option is provided, will generate, wait, and download the dump.
+Generate BMC system dump. If no sub-option is provided, will generate, wait, and download the dump. [OpenBMC]
 
 =over 4
 
@@ -377,6 +381,10 @@ B<-g> will generate a new dump on the BMC. Dump generation can take a few minute
 B<-d> will download a single dump or all generated dumps from the BMC to /var/log/xcat/dump on management or service node.
 
 =back
+
+=item B<timesyncmethod>
+
+Set the method for time synchronization on the BMC. [OpenBMC]
 
 =item B<network>={[I<ip>],[I<host>],[I<gateway>],[I<netmask>]|*}
 

--- a/xCAT-client/pods/man1/rspconfig.1.pod
+++ b/xCAT-client/pods/man1/rspconfig.1.pod
@@ -364,7 +364,7 @@ Display or control BMC Boot Mode attribute setting. [OpenBMC]
 
 =item B<dump>
 
-Generate BMC system dump. If no sub-option is provided, will generate, wait, and download the dump. [OpenBMC]
+Generate/Manage BMC system dumps. If no sub-option is provided, will generate, wait, and download the dump. [OpenBMC]
 
 =over 4
 

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -638,6 +638,19 @@ my %api_config_info = (
             always_off  => "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOff",
         },
     },
+    RSPCONFIG_TIME_SYNC_METHOD => {
+        command      => "rspconfig",
+        url          => "/time/sync_method",
+        attr_url     => "TimeSyncMethod",
+        display_name => "BMC TimeSyncMethod",
+        instruct_msg => "",
+        type         => "attribute",
+        subcommand   => "timesyncmethod",
+        attr_value   => {
+            ntp         => "xyz.openbmc_project.Time.Synchronization.Method.NTP",
+            manual      => "xyz.openbmc_project.Time.Synchronization.Method.Manual",
+        },
+    },
 );
 
 $::RESPONSE_OK                  = "200 OK";


### PR DESCRIPTION
Resolves #4771 

UT: 
```
[root@fs2vm110 Time]# rspconfig f6u17 timesyncmethod
f6u17: BMC TimeSyncMethod : NTP
[root@fs2vm110 Time]# rspconfig f6u17 timesyncmethod=manual
f6u17: BMC Setting BMC TimeSyncMethod...
[root@fs2vm110 Time]# rspconfig f6u17 timesyncmethod
f6u17: BMC TimeSyncMethod : Manual
[root@fs2vm110 Time]# rspconfig f6u17 timesyncmethod=ntp
f6u17: BMC Setting BMC TimeSyncMethod...
[root@fs2vm110 Time]# rspconfig f6u17 timesyncmethod
f6u17: BMC TimeSyncMethod : NTP
```

