### PR TITLE
Handle the PowerSupplyRedundancy Sensor API issue where Value is lower case

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -4076,11 +4076,19 @@ sub rvitals_response {
             # Calculate the adjusted value based on the scale attribute
             #  
             $calc_value = $content{Value};
-            if ( $content{Scale} != 0 ) { 
+            if (!defined($calc_value)) {
+                # Handle the bug where the keyword in the API is lower case value 
+                $calc_value = $content{value};
+            }
+
+            if (defined $content{Scale} and $content{Scale} != 0) { 
                 $calc_value = ($content{Value} * (10 ** $content{Scale}));
             } 
 
-            $content_info = $label . ": " . $calc_value . " " . $sensor_units{ $content{Unit} };
+            $content_info = $label . ": " . $calc_value;
+            if (defined($content{Unit})) { 
+	        $content_info = $content_info . " " . $sensor_units{ $content{Unit} };
+            }
             push (@sorted_output, $content_info); #Save output in array
         } 
     }


### PR DESCRIPTION
Just by chance, I noticed that there was no output for `rvitals` for the new field PowerSupplyRedundancy was blank

```
[root@briggs01 Sensors]# rvitals mid05tor12cn05 | grep PowerSupply
mid05tor12cn05: PowerSupplyRedundancy:
```

Investigating this, it looks like the API returns the following data: 
```
{
  "data": {
    "/xyz/openbmc_project/sensors/chassis/PowerSupplyRedundancy": {
      "error": 0,
      "units": "",
      "value": "Enabled"
    },
...
    "/xyz/openbmc_project/sensors/fan_tach/fan0_0": {
      "Scale": 0,
      "Target": 3500,
      "Unit": "xyz.openbmc_project.Sensor.Value.Unit.RPMS",
      "Value": 3218
    },
...
```

All other fields are Upper case "Value" and this one is lower case "Value" 

```
[root@briggs01 Sensors]# grep Value output | wc -l
194
[root@briggs01 Sensors]# grep value output | wc -l
1
```

To quickly fix it, I am handling the problem in xCAT code but FW team said they probably will not fix it for now..  This PR patches the problem

Unit Test: 

Before: 
```
[root@briggs01 Sensors]# rvitals mid05tor12cn05 | grep PowerSupply
mid05tor12cn05: PowerSupplyRedundancy:
```

After:
```
[root@briggs01 Sensors]# rvitals mid05tor12cn05 | grep PowerSupply
mid05tor12cn05: PowerSupplyRedundancy: Enabled
```

