### PR TITLE
dodiscovery: fix syntax error in case flag_serial is not defined

### DIFF
--- a/xCAT-genesis-scripts/usr/bin/dodiscovery
+++ b/xCAT-genesis-scripts/usr/bin/dodiscovery
@@ -154,7 +154,7 @@ if [ "$flag_mtm" ] && [ "$MTM" != "unknown" ]; then
 	echo "<mtm>$MTM</mtm>" >> /tmp/discopacket
 fi
 flag_serial=`echo "$SERIAL" | sed 's/0//g'`
-if [ $flag_serial ] && [ "$SERIAL" != "unknown" ]; then
+if [ "$flag_serial" ] && [ "$SERIAL" != "unknown" ]; then
 	SERIAL=`echo $SERIAL | sed 's/\.//g'`
 	echo "<serial>$SERIAL</serial>" >> /tmp/discopacket
 fi


### PR DESCRIPTION
If `$flag_serial` is empty, `dodiscovery` generates an error:

```
[...]
xcat.genesis.dodiscovery: Beginning echo information to discovery packet file...
/usr/bin/dodiscovery: line 157: [: too many arguments
[...]
```

This PR fixes this.