### PR TITLE
rsetboot for openbmc in python

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_setboot.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_setboot.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+###############################################################################
+# IBM(c) 2018 EPL license http://www.eclipse.org/legal/epl-v10.html
+###############################################################################
+# -*- coding: utf-8 -*-
+#
+from __future__ import print_function
+import gevent
+import time
+
+from common.task import ParallelNodesCommand
+from common.exceptions import SelfClientException, SelfServerException
+from hwctl import openbmc_client as openbmc
+
+import logging
+logger = logging.getLogger('xcatagent')
+
+
+class OpenBMCSetbootTask(ParallelNodesCommand):
+    """Executor for setboot-related actions."""
+
+    def get_state(self, **kw):
+
+        node = kw['node']
+        obmc = openbmc.OpenBMCRest(name=node, nodeinfo=kw['nodeinfo'], messager=self.callback,
+                                   debugmode=self.debugmode, verbose=self.verbose)
+
+        state = 'Unknown'
+        try:
+            obmc.login()
+            state = obmc.get_boot_state()
+
+            result = '%s: %s' % (node, state)
+
+        except (SelfServerException, SelfClientException) as e:
+            result = '%s: %s'  % (node, e.message)
+
+        self.callback.info(result)
+        return state
+
+    def set_state(self, state, persistant, **kw):
+
+        node = kw['node']
+        obmc = openbmc.OpenBMCRest(name=node, nodeinfo=kw['nodeinfo'], messager=self.callback,
+                                   debugmode=self.debugmode, verbose=self.verbose)
+
+        try:
+            obmc.login()
+            if persistant:
+                obmc.set_one_time_boot_enable(0)
+                obmc.set_boot_state(state)
+            else:
+                obmc.set_one_time_boot_enable(1)
+                obmc.set_one_time_boot_state(state)
+
+            state = obmc.get_boot_state()
+
+            result = '%s: %s' % (node, state)
+
+        except (SelfServerException, SelfClientException) as e:
+            result = '%s: %s'  % (node, e.message)
+
+        self.callback.info(result)
+

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_setboot.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_setboot.py
@@ -16,7 +16,7 @@ import logging
 logger = logging.getLogger('xcatagent')
 
 
-class OpenBMCSetbootTask(ParallelNodesCommand):
+class OpenBMCBootTask(ParallelNodesCommand):
     """Executor for setboot-related actions."""
 
     def get_state(self, **kw):

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -62,6 +62,37 @@ BMC_URLS = {
     },
 }
 
+RSETBOOT_URLS = {
+    "enable"       : {
+        "path"      : "/control/host0/boot/one_time/attr/Enabled",
+    },
+    "get"          : {
+        "path"      : "/control/host0/enumerate",
+    },
+    "set_one_time" : {
+        "path"      : "/control/host0/boot/one_time/attr/BootSource",
+    },
+    "set"          : {
+        "path"      : "/control/host0/boot/attr/BootSource",
+    },
+    "field"        : "xyz.openbmc_project.Control.Boot.Source.Sources.",
+}
+
+SETBOOT_GET_STATE = {
+    "Default"       : "Default",
+    "Disk"          : "Hard Drive",
+    "ExternalMedia" : "CD/DVD",
+    "Network"       : "Network",
+}
+
+SETBOOT_SET_STATE = {
+    "cd"      : "ExternalMedia",
+    "def"     : "Default",
+    "default" : "Default",
+    "hd"      : "Disk",
+    "net"     : "Network",
+}
+
 RESULT_OK = 'ok'
 RESULT_FAIL = 'fail'
 
@@ -225,3 +256,37 @@ class OpenBMCRest(object):
         except SelfServerException,SelfClientException:
             # TODO: Need special handling for bmc reset, as it is normal bmc may return error
             pass
+
+    def set_one_time_boot_enable(self, enabled):
+
+        payload = { "data": enabled }
+        self.request('PUT', RSETBOOT_URLS['enable']['path'], payload=payload, cmd='set_one_time_boot_enable')
+
+    def set_boot_state(self, state):
+
+        payload = { "data": RSETBOOT_URLS['field'] + SETBOOT_SET_STATE[state] } 
+        self.request('PUT', RSETBOOT_URLS['set']['path'], payload=payload, cmd='set_boot_state')
+
+    def set_one_time_boot_state(self, state):
+
+        payload = { "data": RSETBOOT_URLS['field'] + SETBOOT_SET_STATE[state] }
+        self.request('PUT', RSETBOOT_URLS['set_one_time']['path'], payload=payload, cmd='set_one_time_boot_state')
+
+    def get_boot_state(self):
+
+        state = self.request('GET', RSETBOOT_URLS['get']['path'], cmd='get_boot_state')
+        try:
+            one_time_path = PROJECT_URL + '/control/host0/boot/one_time'
+            one_time_enabled =  state[one_time_path]['Enabled']
+            if one_time_enabled:
+                boot_source = state[one_time_path]['BootSource'].split('.')[-1]
+            else:
+                boot_source = state[PROJECT_URL + '/control/host0/boot']['BootSource'].split('.')[-1]
+
+            error = 'Can not get valid rsetboot status, the data is %s' % boot_source
+            boot_state = SETBOOT_GET_STATE.get(boot_source.split('.')[-1], error)
+            return boot_state
+        except KeyError:
+            error = 'Error: Received wrong format response: %s' % states
+            raise SelfServerException(error)
+

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -62,7 +62,7 @@ BMC_URLS = {
     },
 }
 
-RSETBOOT_URLS = {
+BOOTSOURCE_URLS = {
     "enable"       : {
         "path"      : "/control/host0/boot/one_time/attr/Enabled",
     },
@@ -78,14 +78,14 @@ RSETBOOT_URLS = {
     "field"        : "xyz.openbmc_project.Control.Boot.Source.Sources.",
 }
 
-SETBOOT_GET_STATE = {
+BOOTSOURCE_GET_STATE = {
     "Default"       : "Default",
     "Disk"          : "Hard Drive",
     "ExternalMedia" : "CD/DVD",
     "Network"       : "Network",
 }
 
-SETBOOT_SET_STATE = {
+BOOTSOURCE_SET_STATE = {
     "cd"      : "ExternalMedia",
     "def"     : "Default",
     "default" : "Default",
@@ -260,21 +260,21 @@ class OpenBMCRest(object):
     def set_one_time_boot_enable(self, enabled):
 
         payload = { "data": enabled }
-        self.request('PUT', RSETBOOT_URLS['enable']['path'], payload=payload, cmd='set_one_time_boot_enable')
+        self.request('PUT', BOOTSOURCE_URLS['enable']['path'], payload=payload, cmd='set_one_time_boot_enable')
 
     def set_boot_state(self, state):
 
-        payload = { "data": RSETBOOT_URLS['field'] + SETBOOT_SET_STATE[state] } 
-        self.request('PUT', RSETBOOT_URLS['set']['path'], payload=payload, cmd='set_boot_state')
+        payload = { "data": BOOTSOURCE_URLS['field'] + BOOTSOURCE_SET_STATE[state] } 
+        self.request('PUT', BOOTSOURCE_URLS['set']['path'], payload=payload, cmd='set_boot_state')
 
     def set_one_time_boot_state(self, state):
 
-        payload = { "data": RSETBOOT_URLS['field'] + SETBOOT_SET_STATE[state] }
-        self.request('PUT', RSETBOOT_URLS['set_one_time']['path'], payload=payload, cmd='set_one_time_boot_state')
+        payload = { "data": BOOTSOURCE_URLS['field'] + BOOTSOURCE_SET_STATE[state] }
+        self.request('PUT', BOOTSOURCE_URLS['set_one_time']['path'], payload=payload, cmd='set_one_time_boot_state')
 
     def get_boot_state(self):
 
-        state = self.request('GET', RSETBOOT_URLS['get']['path'], cmd='get_boot_state')
+        state = self.request('GET', BOOTSOURCE_URLS['get']['path'], cmd='get_boot_state')
         try:
             one_time_path = PROJECT_URL + '/control/host0/boot/one_time'
             one_time_enabled =  state[one_time_path]['Enabled']
@@ -284,7 +284,7 @@ class OpenBMCRest(object):
                 boot_source = state[PROJECT_URL + '/control/host0/boot']['BootSource'].split('.')[-1]
 
             error = 'Can not get valid rsetboot status, the data is %s' % boot_source
-            boot_state = SETBOOT_GET_STATE.get(boot_source.split('.')[-1], error)
+            boot_state = BOOTSOURCE_GET_STATE.get(boot_source.split('.')[-1], error)
             return boot_state
         except KeyError:
             error = 'Error: Received wrong format response: %s' % states

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/setboot.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/setboot.py
@@ -5,31 +5,30 @@
 # -*- coding: utf-8 -*-
 #
 
-class SetbootInterface(object):
+class BootInterface(object):
     """Interface for setboot-related actions."""
     interface_type = 'setboot'
     version = '1.0'
 
-    def get_setboot_state(self, task):
+    def get_boot_state(self, task):
         """Return the setboot state of the task's nodes.
 
         :param task: a Task instance containing the nodes to act on.
-        :raises: MissingParameterValue if a required parameter is missing.
         :returns: a setboot state.
         """
         return task.run('get_state')
 
-    def set_setboot_state(self, task, setboot_state, persistant=False, timeout=None):
+    def set_boot_state(self, task, setboot_state, persistant=False, timeout=None):
         """Set the setboot state of the task's nodes.
 
         :param task: a Task instance containing the nodes to act on.
-        :param setboot_state: Any power state from :mod:`ironic.common.states`.
+        :param setboot_state: Any boot state allowed.
+        :param persistant: whether set boot state persistant
         :param timeout: timeout (in seconds) positive integer (> 0) for any
           setboot state. ``None`` indicates to use default timeout.
-        :raises: MissingParameterValue if a required parameter is missing.
         """
         return task.run('set_state', setboot_state, persistant, timeout=timeout)
 
-class DefaultSetbootManager(SetbootInterface):
+class DefaultBootManager(BootInterface):
     """Interface for setboot-related actions."""
     pass

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/setboot.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/setboot.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+###############################################################################
+# IBM(c) 2018 EPL license http://www.eclipse.org/legal/epl-v10.html
+###############################################################################
+# -*- coding: utf-8 -*-
+#
+
+class SetbootInterface(object):
+    """Interface for setboot-related actions."""
+    interface_type = 'setboot'
+    version = '1.0'
+
+    def get_setboot_state(self, task):
+        """Return the setboot state of the task's nodes.
+
+        :param task: a Task instance containing the nodes to act on.
+        :raises: MissingParameterValue if a required parameter is missing.
+        :returns: a setboot state.
+        """
+        return task.run('get_state')
+
+    def set_setboot_state(self, task, setboot_state, persistant=False, timeout=None):
+        """Set the setboot state of the task's nodes.
+
+        :param task: a Task instance containing the nodes to act on.
+        :param setboot_state: Any power state from :mod:`ironic.common.states`.
+        :param timeout: timeout (in seconds) positive integer (> 0) for any
+          setboot state. ``None`` indicates to use default timeout.
+        :raises: MissingParameterValue if a required parameter is missing.
+        """
+        return task.run('set_state', setboot_state, persistant, timeout=timeout)
+
+class DefaultSetbootManager(SetbootInterface):
+    """Interface for setboot-related actions."""
+    pass

--- a/xCAT-server/lib/xcat/plugins/openbmc2.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc2.pm
@@ -137,6 +137,13 @@ sub parse_args {
     my $noderange = shift;
     my $subcommand = undef;
 
+    my $verbose;
+    unless (GetOptions(
+        'V|verbose'  => \$verbose,
+    )) {
+        return ([ 1, "Error parsing arguments." ]);
+    }
+
     if (scalar(@ARGV) >= 2 and ($command =~ /rpower/)) {
         return ([ 1, "Only one option is supported at the same time for $command" ]);
     } elsif (scalar(@ARGV) == 0 and $command =~ /rpower|rflash/) {
@@ -146,7 +153,6 @@ sub parse_args {
     }
 
     if ($command eq "rflash") {
-        my $verbose;
         my ($activate, $check, $delete, $directory, $list, $upload) = (0) x 6;
         my $no_host_reboot;
         GetOptions(
@@ -156,7 +162,6 @@ sub parse_args {
             'd'          => \$directory,
             'l|list'     => \$list,
             'u|upload'   => \$upload,
-            'V|verbose'  => \$verbose,
             'no-host-reboot' => \$no_host_reboot,
         );
         my $option_num = $activate+$check+$delete+$directory+$list+$upload;
@@ -198,6 +203,14 @@ sub parse_args {
         }
     } elsif ($command eq "rpower") {
         unless ($subcommand =~ /^on$|^off$|^softoff$|^reset$|^boot$|^bmcreboot$|^bmcstate$|^status$|^stat$|^state$/) {
+            return ([ 1, "Unsupported command: $command $subcommand" ]);
+        }
+    } elsif ($command eq "rsetboot") {
+        my $persistant;
+        GetOptions('p'  => \$persistant);
+        return ([ 1, "Only one option is supported at the same time for $command" ]) if (@ARGV > 1);
+        $subcommand = "stat" if (!defined($ARGV[0]));
+        unless ($subcommand =~ /^net$|^hd$|^cd$|^def$|^default$|^stat$/) {
             return ([ 1, "Unsupported command: $command $subcommand" ]);
         }
     } else {


### PR DESCRIPTION
#4681 

UT:
```
[root@c910f03c05k04 agent]# rsetboot f6u17
Thu Feb  1 21:49:46 2018 f6u17: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.17.100/login -d '{"data": ["root", "xxxxxx"]}'
Thu Feb  1 21:49:47 2018 f6u17: [openbmc_debug] login 200 OK
Thu Feb  1 21:49:47 2018 f6u17: [openbmc_debug] get_boot_state curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/control/host0/enumerate
Thu Feb  1 21:49:47 2018 f6u17: [openbmc_debug] get_boot_state 200 OK
f6u17: Hard Drive
[root@c910f03c05k04 agent]# rsetboot f6u17 hd
Thu Feb  1 21:50:01 2018 f6u17: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.17.100/login -d '{"data": ["root", "xxxxxx"]}'
Thu Feb  1 21:50:01 2018 f6u17: [openbmc_debug] login 200 OK
Thu Feb  1 21:50:01 2018 f6u17: [openbmc_debug] set_one_time_boot_enable curl -k -c cjar -b cjar -X PUT -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/control/host0/boot/one_time/attr/Enabled -d '{"data": 1}'
Thu Feb  1 21:50:01 2018 f6u17: [openbmc_debug] set_one_time_boot_enable 200 OK
Thu Feb  1 21:50:01 2018 f6u17: [openbmc_debug] set_one_time_boot_state curl -k -c cjar -b cjar -X PUT -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/control/host0/boot/one_time/attr/BootSource -d '{"data": "xyz.openbmc_project.Control.Boot.Source.Sources.Disk"}'
Thu Feb  1 21:50:02 2018 f6u17: [openbmc_debug] set_one_time_boot_state 200 OK
Thu Feb  1 21:50:02 2018 f6u17: [openbmc_debug] get_boot_state curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/control/host0/enumerate
Thu Feb  1 21:50:02 2018 f6u17: [openbmc_debug] get_boot_state 200 OK
f6u17: Hard Drive
[root@c910f03c05k04 agent]# rsetboot f6u17 cd
Thu Feb  1 21:50:20 2018 f6u17: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.17.100/login -d '{"data": ["root", "xxxxxx"]}'
Thu Feb  1 21:50:20 2018 f6u17: [openbmc_debug] login 200 OK
Thu Feb  1 21:50:20 2018 f6u17: [openbmc_debug] set_one_time_boot_enable curl -k -c cjar -b cjar -X PUT -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/control/host0/boot/one_time/attr/Enabled -d '{"data": 1}'
Thu Feb  1 21:50:21 2018 f6u17: [openbmc_debug] set_one_time_boot_enable 200 OK
Thu Feb  1 21:50:21 2018 f6u17: [openbmc_debug] set_one_time_boot_state curl -k -c cjar -b cjar -X PUT -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/control/host0/boot/one_time/attr/BootSource -d '{"data": "xyz.openbmc_project.Control.Boot.Source.Sources.ExternalMedia"}'
Thu Feb  1 21:50:21 2018 f6u17: [openbmc_debug] set_one_time_boot_state 200 OK
Thu Feb  1 21:50:21 2018 f6u17: [openbmc_debug] get_boot_state curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/control/host0/enumerate
Thu Feb  1 21:50:21 2018 f6u17: [openbmc_debug] get_boot_state 200 OK
f6u17: CD/DVD
[root@c910f03c05k04 agent]# rsetboot f6u17 cd -p
Thu Feb  1 21:50:34 2018 f6u17: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.17.100/login -d '{"data": ["root", "xxxxxx"]}'
Thu Feb  1 21:50:35 2018 f6u17: [openbmc_debug] login 200 OK
Thu Feb  1 21:50:35 2018 f6u17: [openbmc_debug] set_one_time_boot_enable curl -k -c cjar -b cjar -X PUT -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/control/host0/boot/one_time/attr/Enabled -d '{"data": 0}'
Thu Feb  1 21:50:35 2018 f6u17: [openbmc_debug] set_one_time_boot_enable 200 OK
Thu Feb  1 21:50:35 2018 f6u17: [openbmc_debug] set_boot_state curl -k -c cjar -b cjar -X PUT -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/control/host0/boot/attr/BootSource -d '{"data": "xyz.openbmc_project.Control.Boot.Source.Sources.ExternalMedia"}'
Thu Feb  1 21:50:35 2018 f6u17: [openbmc_debug] set_boot_state 200 OK
Thu Feb  1 21:50:35 2018 f6u17: [openbmc_debug] get_boot_state curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/control/host0/enumerate
Thu Feb  1 21:50:35 2018 f6u17: [openbmc_debug] get_boot_state 200 OK
f6u17: CD/DVD
[root@c910f03c05k04 agent]# rsetboot f6u17 hd
Thu Feb  1 21:50:44 2018 f6u17: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.17.100/login -d '{"data": ["root", "xxxxxx"]}'
Thu Feb  1 21:50:44 2018 f6u17: [openbmc_debug] login 200 OK
Thu Feb  1 21:50:44 2018 f6u17: [openbmc_debug] set_one_time_boot_enable curl -k -c cjar -b cjar -X PUT -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/control/host0/boot/one_time/attr/Enabled -d '{"data": 1}'
Thu Feb  1 21:50:45 2018 f6u17: [openbmc_debug] set_one_time_boot_enable 200 OK
Thu Feb  1 21:50:45 2018 f6u17: [openbmc_debug] set_one_time_boot_state curl -k -c cjar -b cjar -X PUT -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/control/host0/boot/one_time/attr/BootSource -d '{"data": "xyz.openbmc_project.Control.Boot.Source.Sources.Disk"}'
Thu Feb  1 21:50:45 2018 f6u17: [openbmc_debug] set_one_time_boot_state 200 OK
Thu Feb  1 21:50:45 2018 f6u17: [openbmc_debug] get_boot_state curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/control/host0/enumerate
Thu Feb  1 21:50:45 2018 f6u17: [openbmc_debug] get_boot_state 200 OK
f6u17: Hard Drive
[root@c910f03c05k04 agent]# rsetboot f6u17 hd -V
[c910f03c05k04]: Thu Feb  1 21:51:01 2018 f6u17: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.17.100/login -d '{"data": ["root", "xxxxxx"]}'
[c910f03c05k04]: Thu Feb  1 21:51:01 2018 f6u17: [openbmc_debug] login 200 OK
[c910f03c05k04]: Thu Feb  1 21:51:01 2018 f6u17: [openbmc_debug] set_one_time_boot_enable curl -k -c cjar -b cjar -X PUT -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/control/host0/boot/one_time/attr/Enabled -d '{"data": 1}'
[c910f03c05k04]: Thu Feb  1 21:51:01 2018 f6u17: [openbmc_debug] set_one_time_boot_enable 200 OK
[c910f03c05k04]: Thu Feb  1 21:51:01 2018 f6u17: [openbmc_debug] set_one_time_boot_state curl -k -c cjar -b cjar -X PUT -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/control/host0/boot/one_time/attr/BootSource -d '{"data": "xyz.openbmc_project.Control.Boot.Source.Sources.Disk"}'
[c910f03c05k04]: Thu Feb  1 21:51:01 2018 f6u17: [openbmc_debug] set_one_time_boot_state 200 OK
[c910f03c05k04]: Thu Feb  1 21:51:01 2018 f6u17: [openbmc_debug] get_boot_state curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/control/host0/enumerate
[c910f03c05k04]: Thu Feb  1 21:51:02 2018 f6u17: [openbmc_debug] get_boot_state 200 OK
[c910f03c05k04]: f6u17: Hard Drive
```