### PR TITLE
using docopt here for arguments parsing

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/common/utils.py
+++ b/xCAT-openbmc-py/lib/python/agent/common/utils.py
@@ -1,8 +1,30 @@
+#!/usr/bin/env python
+###############################################################################
+# IBM(c) 2018 EPL license http://www.eclipse.org/legal/epl-v10.html
+###############################################################################
+# -*- coding: utf-8 -*-
+#
 import struct
 import sys
 import inspect
 import logging
+from logging.handlers import SysLogHandler
 
+XCAT_LOG_FMT = logging.Formatter("%(asctime)s %(levelname)s " +
+                                 "%(name)s %(process)d " +
+                                 "(%(filename)s:%(lineno)d) "+
+                                 "%(message)s")
+XCAT_LOG_FMT.datefmt = '%Y-%m-%d %H:%M:%S'
+
+def getxCATLog(name=None):
+    xl = logging.getLogger(name)
+    xl.fmt = XCAT_LOG_FMT
+    return xl
+
+def enableSyslog(name='xcat'):
+    h = SysLogHandler(address='/dev/log', facility=SysLogHandler.LOG_LOCAL4)
+    h.setFormatter(logging.Formatter('%s: ' % name + '%(levelname)s %(message)s'))
+    logging.getLogger('xcatagent').addHandler(h)
 
 def int2bytes(num):
     return struct.pack('i', num)

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/power.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/power.py
@@ -14,7 +14,6 @@ class PowerInterface(object):
         """Return the power state of the task's nodes.
 
         :param task: a Task instance containing the nodes to act on.
-        :raises: MissingParameterValue if a required parameter is missing.
         :returns: a power state.
         """
         return task.run('get_state')
@@ -23,18 +22,14 @@ class PowerInterface(object):
         """Set the power state of the task's nodes.
 
         :param task: a Task instance containing the nodes to act on.
-        :param power_state: Any power state from :mod:`ironic.common.states`.
+        :param power_state: Any supported power state.
         :param timeout: timeout (in seconds) positive integer (> 0) for any
           power state. ``None`` indicates to use default timeout.
-        :raises: MissingParameterValue if a required parameter is missing.
         """
         return task.run('set_state', power_state, timeout=timeout)
 
     def reboot(self, task, optype='boot', timeout=None):
         """Perform a hard reboot of the task's nodes.
-
-        Drivers are expected to properly handle case when node is powered off
-        by powering it on.
 
         :param task: a Task instance containing the node to act on.
         :param timeout: timeout (in seconds) positive integer (> 0) for any
@@ -46,16 +41,14 @@ class PowerInterface(object):
         """Return the bmc state of the task's nodes.
 
         :param task: a Task instance containing the nodes to act on.
-        :raises: MissingParameterValue if a required parameter is missing.
-        :returns: a power state.
+        :returns: a bmc state.
         """
         return task.run('get_bmcstate')
 
     def reboot_bmc(self, task, optype='warm'):
-        """Return the bmc state of the task's nodes.
+        """Set the BMC state of the task's nodes.
 
         :param task: a Task instance containing the nodes to act on.
-        :raises: MissingParameterValue if a required parameter is missing.
         :returns: a power state.
         """
         return task.run('reboot_bmc', optype)


### PR DESCRIPTION
As we will implement seperate tool for openbmc, `docopt` will be the preferred library for parsing CLI arguments and options.

Note:  it will introduct a new dependency python module `docopt`, it is a single file module, MIT license,  it will be included into xcat-dep, now using pip to install it.

For how to use `docopt`, refer to https://github.com/docopt/docopt/blob/master/README.rst

And you can use `http://try.docopt.org/` to parse your usage online to verify if your usage is okay for docopt

UT:
```
XCAT_OPENBMC_PYTHON=YES rpower fake1 -V bmcstate
[c910f03c05k20]: Sun Feb  4 23:55:15 2018 fake1: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.17.100/login -d '{"data": ["root", "xxxxxx"]}'
[c910f03c05k20]: Sun Feb  4 23:55:15 2018 fake1: [openbmc_debug] login 200 OK
[c910f03c05k20]: Sun Feb  4 23:55:15 2018 fake1: [openbmc_debug] get_bmc_state curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/state/bmc0/attr/CurrentBMCState
[c910f03c05k20]: Sun Feb  4 23:55:15 2018 fake1: [openbmc_debug] get_bmc_state 200 OK
[c910f03c05k20]: fake1: BMC Ready
```

```
XCAT_OPENBMC_PYTHON=YES rpower fake1 bmcstate -V
[c910f03c05k20]: Sun Feb  4 23:55:03 2018 fake1: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.17.100/login -d '{"data": ["root", "xxxxxx"]}'
[c910f03c05k20]: Sun Feb  4 23:55:03 2018 fake1: [openbmc_debug] login 200 OK
[c910f03c05k20]: Sun Feb  4 23:55:03 2018 fake1: [openbmc_debug] get_bmc_state curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/state/bmc0/attr/CurrentBMCState
[c910f03c05k20]: Sun Feb  4 23:55:03 2018 fake1: [openbmc_debug] get_bmc_state 200 OK
[c910f03c05k20]: fake1: BMC Ready
```