### PR TITLE
enhance setroute doc and routeop return code

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/common/deployment/network/cfg_routes.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/deployment/network/cfg_routes.rst
@@ -10,6 +10,8 @@ There are 2 ways to configure OS route in xCAT:
 
 Before using ``makeroutes`` or ``setroute`` to configure OS route, details of the routes data such as routename, subnet, net mask and gateway should be stored in ``routes`` table.
 
+**Notes**: the ``gateway`` in the ``networks`` table assigns ``gateway`` from DHCP to compute node, so if use ``makeroutes`` or ``setroute`` to configure OS static route for compute node, make sure there is no ``gateway`` for the specific network in ``networks`` table.
+
 Configure ``routes`` table
 ``````````````````````````
 

--- a/xCAT/postscripts/routeop
+++ b/xCAT/postscripts/routeop
@@ -271,7 +271,7 @@ replace_persistent_route()
             #echo "rh/fedora/centos"
             if [ -z "$ifname" ]; then
                 echo "Error: the device name is necessary to configure static route."
-                return
+                return 1
             fi
             
             if echo $net | grep : 2>&1 1>/dev/null
@@ -319,7 +319,7 @@ replace_persistent_route()
             # on debian/ubuntu need the network device name
             if [ -z "$ifname" ]; then
                 echo "Error: the device name is necessary to configure static route."
-                return
+                return 1
             fi
             filename="/etc/network/interfaces.d/$ifname"
 
@@ -901,7 +901,10 @@ elif [ "$op" = "replace" ]; then
     #replace the persistent route
     # the $cmd param is used for Ubuntu since it needs to run the specific cmd to enable 
     # the route during the up of the device
-    replace_persistent_route $net $mask $gw $ifname 
+    replace_persistent_route $net $mask $gw $ifname
+    if [ $? -ne 0 ]; then
+        exit 1
+    fi 
 fi
 
 exit 0


### PR DESCRIPTION
For #4743:
UT:
1, doc enhancement
http://10.4.41.1/install/doc/xcat-core/docs/build/html/guides/admin-guides/manage_clusters/ppc64le/diskless/customize_image/network/cfg_routes.html?highlight=setroute
2, code enhancement
```
bybc0605: trying to download postscripts...
bybc0605: postscripts downloaded successfully
bybc0605: trying to get mypostscript from 10.5.106.2...
bybc0605: Tue Feb  6 02:12:25 EST 2018 Running postscript: setroute
bybc0605: Error: 10net is configured incomplete from xCAT routes table.
bybc0605: postscript: setroute exited with code 1
bybc0605: Running of postscripts has completed.
```