### PR TITLE
routeop: support setting the default route on RHEL

### DIFF
--- a/xCAT/postscripts/routeop
+++ b/xCAT/postscripts/routeop
@@ -269,7 +269,7 @@ replace_persistent_route()
 
         redhat)
             #echo "rh/fedora/centos"
-            if [ -z "$ifname" ]; then
+            if [ -z "$ifname" -a "$net" != "default" ]; then
                 echo "Error: the device name is necessary to configure static route."
                 return
             fi
@@ -295,6 +295,12 @@ replace_persistent_route()
                     route="$net/$mask via $gw"
                     route1="$net\/$mask via $gw"
                 fi
+            fi
+            # default route is handled separately
+            if [ "$net" = "default" ]; then
+                filename="/etc/sysconfig/network"
+                route="GATEWAY=$gw"
+                routedest="$route"
             fi
             if [ -f $filename ]; then
                 egrep "^$routedest" $filename 2>&1 1>/dev/null


### PR DESCRIPTION
Using an interface name is not necessary to set the default route, and somehow that case was not supported in `routeop`.

This PR allows setting the default route on RHEL, by using the `GATEWAY=` syntax in `/etc/sysconfig/network`. 

The main advantage of this approach is that it doesn't require any interface name in the `routes` table, which could be very useful in environments where the default NIC is not named consistently (because of hardware diversity).

For instance, if nodes have NICs named with different naming conventions such as `em1`,  `eno1`,  `enp5s0` because of various hardware/BIOS characteristics, the current `setroute` postscript would require one route definition in the `routes` table for each NIC name. With that PR, a single route definition can be used.