### PR TITLE
fix issue 4805, support rspconfig openbmc in hierarchy

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1199,6 +1199,7 @@ sub parse_args {
         foreach $subcommand (@ARGV) {
             $::RSPCONFIG_CONFIGURED_API_KEY = &is_valid_config_api($subcommand, $callback);
             if ($::RSPCONFIG_CONFIGURED_API_KEY ne -1) {
+                return ([ 1, "Can not query $api_config_info{$::RSPCONFIG_CONFIGURED_API_KEY}{subcommand} information with other options at the same time" ]) if ($#ARGV > 1);
                 # subcommand defined in the configured API hash, return from here, the RSPCONFIG_CONFIGURED_API_KEY is the key into the hash
                 return;
             }
@@ -1601,8 +1602,9 @@ sub parse_command_status {
         my @options = ();
         my $num_subcommand = @$subcommands;
         #Setup chain to process the configured command
+        $subcommand = $$subcommands[0];
+        $::RSPCONFIG_CONFIGURED_API_KEY = &is_valid_config_api($subcommand, $callback);
         if ($::RSPCONFIG_CONFIGURED_API_KEY ne -1) {
-            $subcommand = $$subcommands[0];
             # Check if setting or quering
             if ($subcommand =~ /^(\w+)=(.*)/) {
                 # setting


### PR DESCRIPTION
#4805 

1. Any variable modified in preprocess_request(including the function it called), could not pass to SN. In parse_command_status use ``$::RSPCONFIG_CONFIGURED_API_KEY`` to check whether api subcommand. For hierarchy env, it just get the initial value.
So run ``$::RSPCONFIG_CONFIGURED_API_KEY = &is_valid_config_api($subcommand, $callback);`` again.

2. To avoid the scenario:

```
# rspconfig f6u17 ip netmask powersupplyredundancy
f6u17: BMC IP: 10.6.17.100
f6u17: BMC Netmask: 255.0.0.0
# rspconfig f6u17 powersupplyredundancy ip netmask
f6u17: BMC PowerSupplyRedundancy : Enabled
```
Do not allow "powersupplyredundancy" run with others. (**Will allow in python version**)
```
# rspconfig f6u17 ip netmask powersupplyredundancy
Wed Feb  7 21:05:31 2018 OpenBMC: [openbmc_debug]
f6u17: Error: Can not query powersupplyredundancy information with other options at the same time
```