### PR TITLE
routeop: support remove GATEWAY from /etc/sysconfig/network

### DIFF
--- a/xCAT/postscripts/routeop
+++ b/xCAT/postscripts/routeop
@@ -758,7 +758,7 @@ rm_persistent_route()
         fi
         filename="/etc/sysconfig/network";
         if [ "$net" = "default" -a -f $filename ]; then
-            grep "GATEWAY" $filename >/dev/null 2>&1
+            grep "GATEWAY=$gw" $filename >/dev/null 2>&1
             if [ $? -eq 0 ]; then
                 sed -i '/GATEWAY=/d' $filename
                 echo "Persistent GATEWAY=$gw removed from $filename."

--- a/xCAT/postscripts/routeop
+++ b/xCAT/postscripts/routeop
@@ -756,6 +756,14 @@ rm_persistent_route()
         else
             echo "Persistent route file $filename does not exist."
         fi
+        filename="/etc/sysconfig/network";
+        if [ "$net" = "default" -a -f $filename ]; then
+            grep "GATEWAY" $filename >/dev/null 2>&1
+            if [ $? -eq 0 ]; then
+                sed -i '/GATEWAY=/d' $filename
+                echo "Persistent GATEWAY=$gw removed from $filename."
+            fi
+        fi
         ;;
     esac
     else #AIX


### PR DESCRIPTION
refer to #4803, it add GATEWAY in /etc/sysconfig/network in redhat without configuring nic for default route. Since routeop also support delete default route, GATEWAY in /etc/sysconfig/network should be removed when executing delete option.

related to #4743 

UT:
```
bybc0605: + filename=/etc/sysconfig/network
bybc0605: + '[' default = default -a -f /etc/sysconfig/network ']'
bybc0605: + grep GATEWAY /etc/sysconfig/network
bybc0605: + '[' 0 -eq 0 ']'
bybc0605: + sed -i /GATEWAY=/d /etc/sysconfig/network
bybc0605: + echo 'Persistent GATEWAY=10.0.0.101 removed from /etc/sysconfig/network.'
bybc0605: + exit 0
```