### PR TITLE
Move sleep retry from xcat to goconserver

### DIFF
--- a/perl-xCAT/xCAT/Utils.pm
+++ b/perl-xCAT/xCAT/Utils.pm
@@ -4949,4 +4949,24 @@ sub natural_sort_cmp($$) {
     }
 }
 
+#--------------------------------------------------------------------------------
+
+=head3  console_sleep
+      A wrap for sleep subroutine, if goconserver is used, just exit immidiately
+      as goconserver has its own sleep mechanism.
+=cut
+
+#--------------------------------------------------------------------------------
+sub console_sleep {
+    my $time = shift;
+    my $message = shift;
+    if($ENV{CONSOLE_TYPE} && $ENV{CONSOLE_TYPE} eq "gocons") {
+        # sleep time is handled by goconserver itself
+        exit(1);
+    }
+    print $message if $message;
+    sleep($time);
+}
+
+
 1;

--- a/xCAT-server/share/xcat/cons/blade
+++ b/xCAT-server/share/xcat/cons/blade
@@ -24,21 +24,20 @@ BEGIN
     use File::Path;
     use Fcntl qw(:DEFAULT :flock);
     $::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : '/opt/xcat';
-    umask 0077;
-    mkpath("/tmp/xcat/");
-    unless (sysopen(LOCKHANDLE, "/tmp/xcat/consolelock", O_WRONLY | O_CREAT)) {
-        sleep 15;
-        print "Unable to open lock file";
-        exit 0;
-    }
-    get_lock();
 }
 my $sleepint = int(rand(10)); #Stagger start to avoid overwhelming conserver/xCATd
 use lib "$::XCATROOT/lib/perl";
 require xCAT::Client;
+require xCAT::Utils;
 require File::Basename;
-import File::Basename;
-my $scriptname = $0;
+
+umask 0077;
+mkpath("/tmp/xcat/");
+unless (sysopen(LOCKHANDLE, "/tmp/xcat/consolelock", O_WRONLY | O_CREAT)) {
+    xCAT::Utils::console_sleep(15, "Unable to open lock file");
+    exit 0;
+}
+get_lock();
 
 my $username  = "USERID";
 my $passsword = "PASSW0RD";
@@ -63,8 +62,7 @@ xCAT::Client::submit_request($cmdref, \&getans);
 until ($mm and $username and $slot) {
     release_lock();          #Let other clients have a go
     $sleepint = 10 + int(rand(20)); #Stagger to minimize lock collisions, but no big deal when it does happen
-    print "Console not ready, retrying in $sleepint seconds (Hit Ctrl-E,c,o to skip delay)\n";
-    sleep $sleepint;
+    xCAT::Utils::console_sleep($sleepint, "Console not ready, retrying in $sleepint seconds (Hit Ctrl-E,c,o to skip delay)\n");
     get_lock();
     xCAT::Client::submit_request($cmdref, \&getans);
 }
@@ -73,8 +71,7 @@ my $solchkcmd = "ssh -t $username" . "@" . "$mm sol -T blade[$slot]";
 my $solstatus = `$solchkcmd`;
 while ($solstatus !~ /SOL Session: Ready/ and $solstatus !~ /SOL Session: Active/) {
     $sleepint = 60 + int(rand(30)); #Stagger sleep to take it easy on AMM/hosting server
-    print "SOL unavailable, retrying in $sleepint seconds (hit Ctrl-E,c,o to skip)\n";
-    sleep $sleepint;
+    xCAT::Utils::console_sleep($sleepint, "SOL unavailable, retrying in $sleepint seconds (hit Ctrl-E,c,o to skip)\n");
     $solstatus = `$solchkcmd`;
 }
 exec "ssh -t $username" . "@" . "$mm console -o -T blade[$slot]";

--- a/xCAT-server/share/xcat/cons/hmc
+++ b/xCAT-server/share/xcat/cons/hmc
@@ -24,24 +24,23 @@ BEGIN
     use File::Path;
     use Fcntl qw(:DEFAULT :flock);
     $::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : '/opt/xcat';
-    umask 0077;
-    mkpath("/tmp/xcat/");
-    unless (sysopen(LOCKHANDLE, "/tmp/xcat/consolelock", O_WRONLY | O_CREAT)) {
-        sleep 15;
-        print "Unable to open lock file";
-        exit 0;
-    }
-    get_lock();
 }
 my $sleepint = int(rand(10));
 use lib "$::XCATROOT/lib/perl";
 require xCAT::Client;
+require xCAT::Utils;
 use strict;
 use xCAT::PPCcli qw(SUCCESS EXPECT_ERROR RC_ERROR NR_ERROR);
 use Data::Dumper;
 require File::Basename;
-import File::Basename;
-my $scriptname = $0;
+
+umask 0077;
+mkpath("/tmp/xcat/");
+unless (sysopen(LOCKHANDLE, "/tmp/xcat/consolelock", O_WRONLY | O_CREAT)) {
+    xCAT::Utils::console_sleep(15, "Unable to open lock file");
+    exit 0;
+}
+get_lock();
 
 ##############################################
 # Globals
@@ -109,8 +108,7 @@ xCAT::Client::submit_request($cmdref, \&getans);
 until ($lparid and $host and $mtms) {
     release_lock();    #Let other clients have a go
     $sleepint = 10 + int(rand(20)); #Stagger to minimize lock collisions, but no big deal when it does happen
-    print "Console not ready, retrying in $sleepint seconds (Hit Ctrl-E,c,o to skip delay)\n";
-    sleep $sleepint;
+    xCAT::Utils::console_sleep($sleepint, "Console not ready, retrying in $sleepint seconds (Hit Ctrl-E,c,o to skip delay)\n");
     get_lock();
     xCAT::Client::submit_request($cmdref, \&getans);
 }

--- a/xCAT-server/share/xcat/cons/hpblade
+++ b/xCAT-server/share/xcat/cons/hpblade
@@ -30,22 +30,21 @@ BEGIN
     use File::Path;
     use Fcntl qw(:DEFAULT :flock);
     $::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : '/opt/xcat';
-    umask 0077;
-    mkpath("/tmp/xcat/");
-    unless (sysopen(LOCKHANDLE, "/tmp/xcat/consolelock", O_WRONLY | O_CREAT)) {
-        sleep 15;
-        print "Unable to open lock file";
-        exit 0;
-    }
-    get_lock();
 }
 my $sleepint = int(rand(10)); #Stagger start to avoid overwhelming conserver/xCATd
 use lib "$::XCATROOT/lib/perl";
 $ENV{HOME} = '/root/';
 require xCAT::Client;
-
+require xCAT::Utils;
 require File::Basename;
-import File::Basename;
+umask 0077;
+mkpath("/tmp/xcat/");
+unless (sysopen(LOCKHANDLE, "/tmp/xcat/consolelock", O_WRONLY | O_CREAT)) {
+    xCAT::Utils::console_sleep(15, "Unable to open lock file");
+    exit 0;
+}
+get_lock();
+
 my $scriptname = $0;
 my $username  = "admin";
 my $passsword = "PASSW0RD";
@@ -69,8 +68,7 @@ xCAT::Client::submit_request($cmdref, \&getans);
 until ($mm and $username and $slot) {
     release_lock();    #Let other clients have a go
     $sleepint = 10 + int(rand(20)); #Stagger to minimize lock collisions, but no big deal when it does happen
-    print "Console not ready, retrying in $sleepint seconds (Hit Ctrl-E,c,o to skip delay)\n";
-    sleep $sleepint;
+    xCAT::Utils::console_sleep($sleepint, "Console not ready, retrying in $sleepint seconds (Hit Ctrl-E,c,o to skip delay)\n");
     get_lock();
     xCAT::Client::submit_request($cmdref, \&getans);
 }

--- a/xCAT-server/share/xcat/cons/ipmi
+++ b/xCAT-server/share/xcat/cons/ipmi
@@ -6,6 +6,10 @@ use File::Path;
 BEGIN {
     $::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : -d '/opt/xcat' ? '/opt/xcat' : '/usr';
 }
+use lib "$::XCATROOT/lib/perl";
+require xCAT::Client;
+require xCAT::Utils;
+
 my $sleepint = int(rand(10)); #Stagger start to avoid overwhelming conserver/xCATd
 my ($lockfd, $bmc);
 my $username = 'USERID';
@@ -20,21 +24,18 @@ sub acquire_lock {
     mkpath(CONSOLE_LOCK_DIR);
     print "Acquiring startup lock...";
     unless (sysopen($lockfd, CONSOLE_LOCK_FILE, O_WRONLY | O_CREAT)) {
-        print "Unable to open file ".CONSOLE_LOCK_FILE."\n";
-        sleep(15);
+        xCAT::Utils::console_sleep(15, "Unable to open file ".CONSOLE_LOCK_FILE."\n");
         exit 1;
     }
     unless (flock($lockfd, LOCK_EX)) {
-        print "Unable to lock file ".CONSOLE_LOCK_FILE."\n";
         close($lockfd);
-        sleep(15);
+        xCAT::Utils::console_sleep(15, "Unable to lock file ".CONSOLE_LOCK_FILE."\n");
         exit 1;
     }
     print "done\n";
     unless (syswrite($lockfd, $$, length($$))) {
-        print "Unable to write file ".CONSOLE_LOCK_FILE."\n";
         close($lockfd);
-        sleep(15);
+        xCAT::Utils::console_sleep(15, "Unable to write file ".CONSOLE_LOCK_FILE."\n");
         exit 1;
     }
 }
@@ -43,10 +44,6 @@ sub release_lock {
     flock($lockfd, LOCK_UN);
     close($lockfd);
 }
-
-
-use lib "$::XCATROOT/lib/perl";
-require xCAT::Client;
 
 sub getans {
     my $rsp = shift;
@@ -74,8 +71,7 @@ xCAT::Client::submit_request($cmdref, \&getans);
 until (($username or $password) and $bmc) {
     #Let other clients have a go
     $sleepint = 10 + int(rand(20));
-    print "Console not ready, retrying in $sleepint seconds (Ctrl-e,c,o to skip delay) \n";
-    sleep ($sleepint);
+    xCAT::Utils::console_sleep($sleepint, "Console not ready, retrying in $sleepint seconds (Ctrl-e,c,o to skip delay) \n");
     acquire_lock();
     sleep(0.1);
     release_lock();
@@ -109,8 +105,7 @@ if ($rc) { #some shoddy vendors ignore the IPMI 2.0 requirement to support IPMI 
 }
 while ($rc != 0) {
     $sleepint = 10 + int(rand(20));
-    print "Failure to reach IPMI device, retrying in $sleepint seconds (Hit Ctrl-E,c,o to skip)\n";
-    sleep ($sleepint);
+    xCAT::Utils::console_sleep($sleepint, "Failure to reach IPMI device, retrying in $sleepint seconds (Hit Ctrl-E,c,o to skip)\n");
     @mcinfo = `$ipmitool -I lanplus $user $pass -H $bmc mc info`;
     $rc     = $?;
     if ($rc) {    #repeat workaround for shoddy vendors

--- a/xCAT-server/share/xcat/cons/ivm
+++ b/xCAT-server/share/xcat/cons/ivm
@@ -25,31 +25,17 @@ BEGIN
     use File::Path;
     use Fcntl qw(:DEFAULT :flock);
     $::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : '/opt/xcat';
-    umask 0077;
-    mkpath("/tmp/xcat/");
-    unless (sysopen(LOCKHANDLE, "/tmp/xcat/consolelock", O_WRONLY | O_CREAT)) {
-        sleep 15;
-        print "Unable to open lock file";
-        exit 0;
-    }
-    get_lock();
-    my $sleepint = int(rand(10)); #Stagger start to avoid overwhelming conserver/xCATd
-    print "Opening console in " . (2 + (0.5 * $sleepint)) . " seconds...\n";
-    sleep $sleepint;
+
 }
 my $sleepint = int(rand(10));
 use lib "$::XCATROOT/lib/perl";
 require xCAT::Client;
+require xCAT::Utils;
 use strict;
 
-#use Getopt::Long;
-#use xCAT::Table;
-#use xCAT::PPCdb;
 use xCAT::PPCcli qw(SUCCESS EXPECT_ERROR RC_ERROR NR_ERROR);
 use Data::Dumper;
 require File::Basename;
-import File::Basename;
-my $scriptname = $0;
 
 ##############################################
 # Globals
@@ -61,6 +47,15 @@ my $lparid;
 my $mtms;
 my @cred;
 my $credencial;
+umask 0077;
+mkpath("/tmp/xcat/");
+unless (sysopen(LOCKHANDLE, "/tmp/xcat/consolelock", O_WRONLY | O_CREAT)) {
+    xCAT::Utils::console_sleep(15, "Unable to open lock file");
+    exit 0;
+}
+get_lock();
+my $sleepint = int(rand(10)); #Stagger start to avoid overwhelming conserver/xCATd
+xCAT::Utils::console_sleep($sleepint, "Opening console in " . (2 + (0.5 * $sleepint)) . " seconds...\n");
 
 ##########################################################################
 # Open remote console
@@ -121,8 +116,7 @@ xCAT::Client::submit_request($cmdref, \&getans);
 until ($lparid and $host and $mtms) {
     release_lock();    #Let other clients have a go
     $sleepint = 10 + int(rand(20)); #Stagger to minimize lock collisions, but no big deal when it does happen
-    print "Console not ready, retrying in $sleepint seconds (Hit Ctrl-E,c,o to skip delay)\n";
-    sleep $sleepint;
+    xCAT::Utils::console_sleep($sleepint, "Console not ready, retrying in $sleepint seconds (Hit Ctrl-E,c,o to skip delay)\n");
     get_lock();
     xCAT::Client::submit_request($cmdref, \&getans);
 }

--- a/xCAT-server/share/xcat/cons/kvm
+++ b/xCAT-server/share/xcat/cons/kvm
@@ -1,5 +1,6 @@
 #!/usr/bin/env perl
 # IBM(c) 2007 EPL license http://www.eclipse.org/legal/epl-v10.html
+use strict;
 use Fcntl qw(:DEFAULT :flock);
 
 sub get_lock {
@@ -25,23 +26,22 @@ BEGIN
     use Fcntl qw(:DEFAULT :flock);
     $::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : '/opt/xcat';
     umask 0077;
-    mkpath("/tmp/xcat/");
-    unless (sysopen(LOCKHANDLE, "/tmp/xcat/consolelock", O_WRONLY | O_CREAT)) {
-        sleep 15;
-        print "Unable to open lock file";
-        exit 0;
-    }
-    get_lock();
-
 }
 
 my $sleepint;
 use lib "$::XCATROOT/lib/perl";
 require xCAT::Client;
-
+require xCAT::Utils;
 require File::Basename;
-import File::Basename;
+
 my $scriptname = $0;
+
+mkpath("/tmp/xcat/");
+unless (sysopen(LOCKHANDLE, "/tmp/xcat/consolelock", O_WRONLY | O_CREAT)) {
+    xCAT::Utils::console_sleep(15, "Unable to open lock file");
+    exit 0;
+}
+get_lock();
 
 my $cmdref = {
     command   => ["getcons"],
@@ -65,8 +65,7 @@ xCAT::Client::submit_request($cmdref, \&getans);
 until ($dsthost and $speed and $dstty) {
     release_lock();
     $sleepint = int(rand(30)) + 60;
-    print "Console not ready, retrying in $sleepint seconds (Ctrl-C to skip delay)\n";
-    exec "sleep $sleepint";
+    xCAT::Utils::console_sleep($sleepint, "Console not ready, retrying in $sleepint seconds ( Ctrl-E c o to skip delay)\n");
 }
 release_lock();
 

--- a/xCAT-server/share/xcat/cons/multiple
+++ b/xCAT-server/share/xcat/cons/multiple
@@ -24,23 +24,23 @@ BEGIN
     use File::Path;
     use Fcntl qw(:DEFAULT :flock);
     $::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : '/opt/xcat';
-    umask 0077;
-    mkpath("/tmp/xcat/");
-    unless (sysopen(LOCKHANDLE, "/tmp/xcat/consolelock", O_WRONLY | O_CREAT)) {
-        sleep 15;
-        print "Unable to open lock file";
-        exit 0;
-    }
-    get_lock();
 }
 my $sleepint = int(rand(10));
 use lib "$::XCATROOT/lib/perl";
 require xCAT::Client;
+require xCAT::Utils;
 use strict;
 use Expect;
 use xCAT::PPCcli qw(SUCCESS EXPECT_ERROR RC_ERROR NR_ERROR);
 require File::Basename;
-import File::Basename;
+
+umask 0077;
+mkpath("/tmp/xcat/");
+unless (sysopen(LOCKHANDLE, "/tmp/xcat/consolelock", O_WRONLY | O_CREAT)) {
+    xCAT::Utils::console_sleep(15, "Unable to open lock file");
+    exit 0;
+}
+get_lock();
 
 ##############################################
 # Globals
@@ -182,8 +182,7 @@ xCAT::Client::submit_request($cmdref, \&getans);
 until ($hcps) {
     release_lock();    #Let other clients have a go
     $sleepint = 10 + int(rand(20)); #Stagger to minimize lock collisions, but no big deal when it does happen
-    print "Console not ready, retrying in $sleepint seconds (Hit Ctrl-E,c,o to skip delay)\n";
-    sleep $sleepint;
+    xCAT::Utils::console_sleep($sleepint, "Console not ready, retrying in $sleepint seconds (Hit Ctrl-E,c,o to skip delay)\n");
     get_lock();
     xCAT::Client::submit_request($cmdref, \&getans);
 }

--- a/xCAT-server/share/xcat/cons/xen
+++ b/xCAT-server/share/xcat/cons/xen
@@ -24,23 +24,21 @@ BEGIN
     use File::Path;
     use Fcntl qw(:DEFAULT :flock);
     $::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : '/opt/xcat';
-    umask 0077;
-    mkpath("/tmp/xcat/");
-    unless (sysopen(LOCKHANDLE, "/tmp/xcat/consolelock", O_WRONLY | O_CREAT)) {
-        sleep 15;
-        print "Unable to open lock file";
-        exit 0;
-    }
-    get_lock();
 }
 
 my $sleepint;
 use lib "$::XCATROOT/lib/perl";
 require xCAT::Client;
-
+require xCAT::Utils;
 require File::Basename;
-import File::Basename;
-my $scriptname = $0;
+
+umask 0077;
+mkpath("/tmp/xcat/");
+unless (sysopen(LOCKHANDLE, "/tmp/xcat/consolelock", O_WRONLY | O_CREAT)) {
+    xCAT::Utils::console_sleep(15, "Unable to open lock file");
+    exit 0;
+}
+get_lock();
 
 my $cmdref = {
     command   => "getxencons",
@@ -64,8 +62,7 @@ xCAT::Client::submit_request($cmdref, \&getans);
 until ($dsthost and $speed and $dstty) {
     release_lock();
     $sleepint = int(rand(30)) + 60;
-    print "Console not ready, retrying in $sleepint seconds (Ctrl-C to skip delay)\n";
-    exec "sleep $sleepint";
+    xCAT::Utils::console_sleep($sleepint, "Console not ready, retrying in $sleepint seconds (Ctrl-C to skip delay)\n");
 }
 release_lock();
 exec "ssh -t $dsthost screen -U -a -O -e ^]a -d -R -S serial-" . $ARGV[0] . "-cons -A $dstty $speed";


### PR DESCRIPTION
If cons script is waiting, goconserver could not aware of
the status of the console connection. This patch check
the environment when running the script, if it is gocons
and retrying is needed, exit immediately.

implement: #4670