### PR TITLE
fix issue 3913: support rpower cycle for ipmi managing severs

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rpower.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rpower.1.rst
@@ -27,7 +27,7 @@ BMC (using IPMI):
 =================
 
 
-\ **rpower**\  \ *noderange*\  [\ **on | off | softoff | reset | boot | stat | state | status | wake | suspend**\  [\ **-w**\  \ *timeout*\ ] [\ **-o**\ ] [\ **-r**\ ]]
+\ **rpower**\  \ *noderange*\  [\ **on | off | softoff | reset | boot | cycle | stat | state | status | wake | suspend**\  [\ **-w**\  \ *timeout*\ ] [\ **-o**\ ] [\ **-r**\ ]]
 
 \ **rpower**\  \ *noderange*\  [\ **pduon | pduoff | pdustat | pdureset**\ ]
 

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -26,7 +26,7 @@ my %usage = (
 "Usage: rpower <noderange> [--nodeps] [on|onstandby|off|suspend|reset|stat|state|boot] [-V|--verbose] [-m table.colum==expectedstatus][-m table.colum==expectedstatus...] [-r <retrycount>] [-t <timeout>]
        rpower [-h|--help|-v|--version]
      BMC (using IPMI):
-       rpower noderange [on|off|softoff|reset|boot|stat|state|status|wake|suspend [-w timeout] [-o] [-r]]
+       rpower noderange [on|off|softoff|reset|boot|cycle|stat|state|status|wake|suspend [-w timeout] [-o] [-r]]
        rpower noderange [pduon|pduoff|pdustat]
      OpenPOWER BMC:
        rpower noderange [on|off|reset|boot|stat|state|status]

--- a/xCAT-client/pods/man1/rpower.1.pod
+++ b/xCAT-client/pods/man1/rpower.1.pod
@@ -10,7 +10,7 @@ B<rpower> [B<-h>|B<--help>|B<-v>|B<--version>]
 
 =head2 BMC (using IPMI):
 
-B<rpower> I<noderange> [B<on>|B<off>|B<softoff>|B<reset>|B<boot>|B<stat>|B<state>|B<status>|B<wake>|B<suspend> [B<-w> I<timeout>] [B<-o>] [B<-r>]] 
+B<rpower> I<noderange> [B<on>|B<off>|B<softoff>|B<reset>|B<boot>|B<cycle>|B<stat>|B<state>|B<status>|B<wake>|B<suspend> [B<-w> I<timeout>] [B<-o>] [B<-r>]] 
 
 B<rpower> I<noderange> [B<pduon>|B<pduoff>|B<pdustat>|B<pdureset>]
 

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -2849,7 +2849,8 @@ sub power_with_context {
         "off"     => 0,
         "softoff" => 5,
         "reset"   => 3,
-        "nmi"     => 4
+        "nmi"     => 4,
+        "cycle"   => 2,
     );
     if ($subcommand eq "on") {
         if ($sessdata->{powerstatus} eq "on") {


### PR DESCRIPTION
Fix issue #3913 : rpower cycle support for BMC/IPMI
```
# rpower c910f05c01bc07 cycle
c910f05c01bc07: cycle
```
From rcons:
```
c910f05c01bc07 login: [3034768.198608] br-admin: port 2(vnet0) entered disabled state
[3034768.200219] device vnet0 left promiscuous mode
[3034768.200225] br-admin: port 2(vnet0) entered disabled state
[3034768.210420] br-admin: port 3(vnet1) entered disabled state
[3034768.212029] device vnet1 left promiscuous mode
[3034768.212035] br-admin: port 3(vnet1) entered disabled state
[  OK  ] Started Show Plymouth Power Off Screen.
[  OK  ] Stopped Load/Save Random Seed.
[  OK  ] Stopped Update UTMP about System Boot/Shutdown.[3034768.617063] type=1305 audit(1518070667.274:9726772): audit_pid=0 old=1087 auid=4294967295 ses=4294967295 res=1
...
```