### PR TITLE
Allow choosing individual openbmc commands to use Python

### DIFF
--- a/xCAT-server/lib/perl/xCAT/OPENBMC.pm
+++ b/xCAT-server/lib/perl/xCAT/OPENBMC.pm
@@ -201,7 +201,13 @@ sub wait_agent {
 sub is_openbmc_python {
     my $environment = shift;
     $environment = shift if (($environment) && ($environment =~ /OPENBMC/));
-    # If XCAT_OPENBMC_PYTHON is YES, will run openbmc2.pm. If not, run openbmc.pm
+    # If XCAT_OPENBMC_PYTHON is YES, 
+    # will return "ALL" and caller will run openbmc2.pm. 
+    # If XCAT_OPENBMC_PYTHON is not set or is set to NO, return "NO" and caller
+    # will run openbmc.pm
+    # If XCAT_OPENBMC_PYTHON is a list of commands, return that list and caller
+    # will run openbmc2.pm if the command is on the list, caller will run
+    # openbmc.pm if command is not on the list
     if (ref($environment) eq 'ARRAY' and ref($environment->[0]->{XCAT_OPENBMC_PYTHON}) eq 'ARRAY') {
         $::OPENBMC_PYTHON = $environment->[0]->{XCAT_OPENBMC_PYTHON}->[0];
     } elsif (ref($environment) eq 'ARRAY') {
@@ -209,11 +215,19 @@ sub is_openbmc_python {
     } else {
         $::OPENBMC_PYTHON = $environment->{XCAT_OPENBMC_PYTHON};
     }
-    if (defined($::OPENBMC_PYTHON) and $::OPENBMC_PYTHON eq "YES") {
-        return 1;
+    if (defined($::OPENBMC_PYTHON)) { 
+        if ($::OPENBMC_PYTHON eq "YES") {
+            return "ALL";
+        }
+        elsif ($::OPENBMC_PYTHON eq "NO") {
+            return "NO";
+        }
+        else {
+            return $::OPENBMC_PYTHON;
+        }
     }
 
-    return 0;
+    return "NO";
 }
 
 1;

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -756,12 +756,16 @@ sub preprocess_request {
     }
     ##############################################
 
-    if (xCAT::OPENBMC->is_openbmc_python($request->{environment})) {
+    $callback  = shift;
+    my $command   = $request->{command}->[0];
+    my $python_env = xCAT::OPENBMC->is_openbmc_python($request->{environment});
+    # Process command in this module only if PYTHON env is not ALL or command is
+    # listed in the PYTHON env list. All other cases => return
+    if (($python_env eq "ALL") ||
+       (($python_env ne "NO") && ($python_env =~ $command))) {
         $request = {};
         return;
     }
-
-    $callback  = shift;
 
     if ($::XCATSITEVALS{xcatdebugmode}) { $xcatdebugmode = $::XCATSITEVALS{xcatdebugmode} }
 
@@ -769,7 +773,6 @@ sub preprocess_request {
         process_debug_info("OpenBMC");
     }
 
-    my $command   = $request->{command}->[0];
     my $noderange = $request->{node};
     my $extrargs  = $request->{arg};
     my @exargs    = ($request->{arg});

--- a/xCAT-server/lib/xcat/plugins/openbmc2.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc2.pm
@@ -60,11 +60,20 @@ sub preprocess_request {
     my $command   = $request->{command}->[0];
     my $python_env = xCAT::OPENBMC->is_openbmc_python($request->{environment});
     # Process command in this module only if PYTHON env is not NO or 
-    # command is listed in the PYTHON env list. All other cases => return
-    if (($python_env eq "NO") || 
-       (($python_env ne "ALL") && ($python_env !~ $command))) {
-        $request = {};
-        return;
+    # command is listed in the PYTHON env list (without EXCEPT: prefix). 
+    # All other cases => return
+
+    SWITCH: {
+        if ($python_env eq "NO")  {$request = {}; return;}
+        if ($python_env eq "ALL") {last SWITCH;}
+        if ($python_env !~ $command) {
+            if ($python_env =~ /^EXCEPT:/) {last SWITCH}
+            else {$request = {}; return;}
+        }
+        if ($python_env =~ $command) {
+            if ($python_env =~ /^EXCEPT:/) {$request = {}; return;}
+            else {last SWITCH;}
+        }
     }
 
     my $noderange = $request->{node};

--- a/xCAT-server/lib/xcat/plugins/openbmc2.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc2.pm
@@ -57,12 +57,16 @@ sub preprocess_request {
     my $request = shift;
     $callback  = shift;
 
-    if (!xCAT::OPENBMC->is_openbmc_python($request->{environment})) {
+    my $command   = $request->{command}->[0];
+    my $python_env = xCAT::OPENBMC->is_openbmc_python($request->{environment});
+    # Process command in this module only if PYTHON env is not NO or 
+    # command is listed in the PYTHON env list. All other cases => return
+    if (($python_env eq "NO") || 
+       (($python_env ne "ALL") && ($python_env !~ $command))) {
         $request = {};
         return;
     }
 
-    my $command   = $request->{command}->[0];
     my $noderange = $request->{node};
     my $extrargs  = $request->{arg};
     my @exargs    = ($request->{arg});


### PR DESCRIPTION
Allow setting `XCAT_OPENBMC_PYTHON=` to be the list of commands to run in Python.
If `XCAT_OPENBMC_PYTHON=YES` all openbmc commands will run in Python
If `XCAT_OPENBMC_PYTHON=NO` or not set all openbmc commands will run in Perl
If `XCAT_OPENBMC_PYTHON=command,command,...` commands listed will run in Python, commands not listed will run in Perl.
If `XCAT_OPENBMC_PYTHON=EXCEPT:command,command,...` commands listed will run in Perl, commands not listed will run in Python.