### PR TITLE
fix issue error message improvement when adding users in hierarchical configuration #4820

### DIFF
--- a/perl-xCAT/xCAT/RemoteShellExp.pm
+++ b/perl-xCAT/xCAT/RemoteShellExp.pm
@@ -541,7 +541,7 @@ sub sendnodeskeys
 
         # command to make the temp directory on the node
         my $spawnmkdir =
-          "$remoteshell $node -l $to_userid /bin/mkdir -p /tmp/$to_userid/.ssh";
+          "$remoteshell -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null $node -l $to_userid  /bin/mkdir -p /tmp/$to_userid/.ssh";
 
         # command to copy the needed files to the node
 
@@ -588,6 +588,11 @@ sub sendnodeskeys
         ##########################################
         # Expect error - report
         ##########################################
+        if($rc==1){
+            my $rsp = {};
+            $rsp->{error}->[0] = "Permission denied, please make sure the user $to_userid has been created on the node $node and the input password is right\n";
+            xCAT::MsgUtils->message("E", $rsp, $::CALLBACK);
+        }        
         if (defined($result[1]))
         {
             my $msg = $result[1];
@@ -629,11 +634,11 @@ sub sendnodeskeys
         my $spawncopyfiles;
         if ($ENV{'DSH_ENABLE_SSH'}) {    # we will enable node to node ssh
             $spawncopyfiles =
-"$remotecopy $home/.ssh/id_rsa $home/.ssh/id_rsa.pub $home/.ssh/copy.sh $home/.ssh/tmp/authorized_keys $to_userid\@$node:/tmp/$to_userid/.ssh";
+"$remotecopy -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null  $home/.ssh/id_rsa $home/.ssh/id_rsa.pub $home/.ssh/copy.sh $home/.ssh/tmp/authorized_keys $to_userid\@$node:/tmp/$to_userid/.ssh";
 
         } else {    # no node to node ssh ( don't send private key)
             $spawncopyfiles =
-"$remotecopy $home/.ssh/id_rsa.pub $home/.ssh/copy.sh $home/.ssh/tmp/authorized_keys $to_userid\@$node:/tmp/$to_userid/.ssh";
+"$remotecopy -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null $home/.ssh/id_rsa.pub $home/.ssh/copy.sh $home/.ssh/tmp/authorized_keys $to_userid\@$node:/tmp/$to_userid/.ssh";
         }
 
         # send copy command
@@ -715,7 +720,7 @@ sub sendnodeskeys
 
         # command to run copy.sh
         my $spawnruncopy =
-          "$remoteshell $node -l $to_userid /tmp/$to_userid/.ssh/copy.sh $to_userid";
+          "$remoteshell -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null  $node -l $to_userid /tmp/$to_userid/.ssh/copy.sh $to_userid";
 
         # send mkdir command
         unless ($sendkeys->spawn($spawnruncopy))


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/4820

1. refine the message to be more instructive
2. disable strict host check of ssh while sending ssh keys to the target nodes

UT:
```
[immarvin@c910f03c05k21 xcat-core]$  XCATSHOWSVR=1 xdsh c910f03c17k42 -K -T
Enter the password for the userid: immarvin on the node where the ssh keys
will be updated:

Error: [c910f03c05k27]: Cannot get the home directory for user "immarvin", please make sure "immarvin" user exists!
[c910f03c05k27]: return code = 1

[immarvin@c910f03c05k21 xcat-core]$  XCATSHOWSVR=1 xdsh c910f03c17k42 -K
Enter the password for the userid: immarvin on the node where the ssh keys
will be updated:

Error: [c910f03c05k27]: cannot create file /home/immarvin/.ssh/copy.sh, please make sure the directory "/home/immarvin/.ssh" exists and ssh keys have been setup on this node!

[c910f03c05k27]: return code = 1

[immarvin@c910f03c05k21 xcat-core]$ xdsh c910f03c05k27 -K
Enter the password for the userid: immarvin on the node where the ssh keys
will be updated:

Error: Permission denied, please make sure the user immarvin has been created on the node c910f03c05k27 and the input password is right

Error: remoteshellexp failed sending keys.
Error: SSH setup failed for the following nodes: c910f03c05k27.
return code = 1
 
````