### PR TITLE
Better handling multiple dots in copycds name

### DIFF
--- a/xCAT-server/lib/perl/xCAT/SvrUtils.pm
+++ b/xCAT-server/lib/perl/xCAT/SvrUtils.pm
@@ -469,13 +469,25 @@ sub get_file_name {
     elsif (($genos) && (-r "$searchpath/$profile.$genos.$extension")) {
         return "$searchpath/$profile.$genos.$extension";
     }
-    elsif (-r "$searchpath/$profile.$osbase.$arch.$extension") {
-        return "$searchpath/$profile.$osbase.$arch.$extension";
+    # If the osimge name was specified with -n, the name might contain multiple "."
+    # Chop them off one at a time until filename match is found
+    else {
+        while ($dotpos > 0) {
+
+            if (-r "$searchpath/$profile.$osbase.$arch.$extension") {
+                return "$searchpath/$profile.$osbase.$arch.$extension";
+            }
+            elsif (-r "$searchpath/$profile.$osbase.$extension") {
+                return "$searchpath/$profile.$osbase.$extension";
+            }
+            # Chop off "." from the end and try again
+            $dotpos = rindex($osbase, ".");
+            $osbase = substr($osbase, 0, $dotpos);
+        }
     }
-    elsif (-r "$searchpath/$profile.$osbase.$extension") {
-        return "$searchpath/$profile.$osbase.$extension";
-    }
-    elsif (-r "$searchpath/$profile.$arch.$extension") {
+
+    # No file matching OS name was found, next try just arch, if still nothing -> default to just profile
+    if (-r "$searchpath/$profile.$arch.$extension") {
         return "$searchpath/$profile.$arch.$extension";
     }
     elsif (-r "$searchpath/$profile.$extension") {


### PR DESCRIPTION
If a copycds name was passed in with multiple "." in the name, chop them off one at a time when looking for a matching package or temples file

```
[root@briggs01 xcat]# copycds -n "rhels7.4-pegas1.0GA_SP1" /mnt/xcat/iso/pegas/ALT-7.5-Snapshot-2/RHEL-ALT-7.5-20180201.1-Server-ppc64le-dvd1.iso
Copying media to /install/rhels7.4-pegas1.0GA_SP1/ppc64le
Media copy operation successful

[root@briggs01 xcat]# lsdef -t osimage rhels7.4-pegas1.0GA_SP1-ppc64le-install-compute -i template
Object name: rhels7.4-pegas1.0GA_SP1-ppc64le-install-compute
    template=/opt/xcat/share/xcat/install/rh/compute.rhels7.tmpl
```
```
[root@briggs01 xcat]# copycds -n "rhels7.4-pegas1_0GA_SP1" /mnt/xcat/iso/pegas/ALT-7.5-Snapshot-2/RHEL-ALT-7.5-20180201.1-Server-ppc64le-dvd1.iso
Copying media to /install/rhels7.4-pegas1_0GA_SP1/ppc64le
Media copy operation successful

[root@briggs01 xcat]# lsdef -t osimage rhels7.4-pegas1_0GA_SP1-ppc64le-install-compute -i template                        Object name: rhels7.4-pegas1_0GA_SP1-ppc64le-install-compute
    template=/opt/xcat/share/xcat/install/rh/compute.rhels7.tmpl
```
```
[root@briggs01 xcat]# copycds -n "rhels7.4-pegas1.0GA.SP1" /mnt/xcat/iso/pegas/ALT-7.5-Snapshot-2/RHEL-ALT-7.5-20180201.1-Server-ppc64le-dvd1.iso
Copying media to /install/rhels7.4-pegas1.0GA.SP1/ppc64le
Media copy operation successful

[root@briggs01 xcat]# lsdef -t osimage rhels7.4-pegas1.0GA.SP1-ppc64le-install-compute -i template                        Object name: rhels7.4-pegas1.0GA.SP1-ppc64le-install-compute
    template=/opt/xcat/share/xcat/install/rh/compute.rhels7.tmpl
```

```
[root@briggs01 xcat]# copycds  /mnt/xcat/iso/pegas/ALT-7.5-Snapshot-2/RHEL-ALT-7.5-20180201.1-Server-ppc64le-dvd1.iso
Copying media to /install/rhels7.5-alternate/ppc64le
Media copy operation successful

[root@briggs01 xcat]# lsdef -t osimage rhels7.5-alternate-ppc64le-install-compute -i template
Object name: rhels7.5-alternate-ppc64le-install-compute
    template=/opt/xcat/share/xcat/install/rh/compute.rhels7.tmpl
```