### PR TITLE
Add milestone and labels checking in the CI test system

### DIFF
--- a/travis.pl
+++ b/travis.pl
@@ -104,7 +104,7 @@ sub check_pr_format{
         my $pr_milestone = $pr_content->{milestone};
 
         #print "[check_pr_format] Dumper pr_content:\n";
-        #print Dumper $pr_content;
+        print Dumper $pr_content;
         print "[check_pr_format] pr title = $pr_title\n";
         print "[check_pr_format] pr body = $pr_body \n";
         

--- a/travis.pl
+++ b/travis.pl
@@ -102,7 +102,7 @@ sub check_pr_format{
         my $pr_title = $pr_content->{title};
         my $pr_body  = $pr_content->{body};
         my $pr_milestone = $pr_content->{milestone};
-        my $pr_labels = $pr_content->{labels};
+        my $pr_labels_len = @{$pr_content->{labels}};
 
         #print "[check_pr_format] Dumper pr_content:\n";
         #print Dumper $pr_content;
@@ -121,7 +121,7 @@ sub check_pr_format{
              $checkrst.="Miss milestone.";
         }
 
-        if(! $pr_labels){
+        if(! $pr_labels_len){
              $checkrst.="Miss labels.";
         }
 

--- a/travis.pl
+++ b/travis.pl
@@ -102,9 +102,10 @@ sub check_pr_format{
         my $pr_title = $pr_content->{title};
         my $pr_body  = $pr_content->{body};
         my $pr_milestone = $pr_content->{milestone};
+        my $pr_labels = $pr_content->{labels};
 
         #print "[check_pr_format] Dumper pr_content:\n";
-        print Dumper $pr_content;
+        #print Dumper $pr_content;
         print "[check_pr_format] pr title = $pr_title\n";
         print "[check_pr_format] pr body = $pr_body \n";
         
@@ -118,6 +119,10 @@ sub check_pr_format{
         
         if(! $pr_milestone){
              $checkrst.="Miss milestone.";
+        }
+
+        if(! $pr_labels){
+             $checkrst.="Miss labels.";
         }
 
         if(length($checkrst) == 0){

--- a/travis.pl
+++ b/travis.pl
@@ -101,6 +101,7 @@ sub check_pr_format{
         my $pr_content = decode_json($pr_url_resp);
         my $pr_title = $pr_content->{title};
         my $pr_body  = $pr_content->{body};
+        my $pr_milestone = $pr_content->{milestone};
 
         #print "[check_pr_format] Dumper pr_content:\n";
         #print Dumper $pr_content;
@@ -115,6 +116,10 @@ sub check_pr_format{
              $checkrst.="Miss description.";
         }
         
+        if(! $pr_milestone){
+             $checkrst.="Miss milestone.";
+        }
+
         if(length($checkrst) == 0){
             $check_result_str .= "> **PR FORMAT CORRECT**";
             send_back_comment("$check_result_str"); 


### PR DESCRIPTION
Add **milestone** checking in the CI test system. For issue #4787 

The output looks like:

``CI CHECK RESULT`` : > **PR FORMAT ERROR** : Miss milestone.
``CI CHECK RESULT`` : > **PR FORMAT ERROR** : Miss labels.