### PR TITLE
Get xCAT MASTER from dhcpclient lease file for configinterface postscripts

### DIFF
--- a/xCAT/postscripts/configinterface
+++ b/xCAT/postscripts/configinterface
@@ -9,7 +9,7 @@ fi
 
 xcat_intf="/etc/network/interfaces.d/xCAT.intf"
 
-MASTER=$(cat /var/lib/dhcp/dhclient.eth0.leases |grep cumulus-provision-url|tail -1|awk -F/ '{print $3}')
+MASTER=$(cat /var/lib/dhcp/dhclient.eth0.leases|sed -n 's/.*cumulus-provision-url.*http:\/\+\([^\/]\+\)\/.*/\1/p'|tail -1)
 if [ -z "$MASTER" ]; then
     echo "xCAT Master unset! Cannot download interface description"
     exit 2

--- a/xCAT/postscripts/configinterface
+++ b/xCAT/postscripts/configinterface
@@ -9,6 +9,7 @@ fi
 
 xcat_intf="/etc/network/interfaces.d/xCAT.intf"
 
+MASTER=$(cat /var/lib/dhcp/dhclient.eth0.leases |grep cumulus-provision-url|tail -1|awk -F/ '{print $3}')
 if [ -z "$MASTER" ]; then
     echo "xCAT Master unset! Cannot download interface description"
     exit 2


### PR DESCRIPTION
the configinterface postscripts gets xcat master from mypostscripts, but sometime,  mypostscripts didn't contain MASTER.  The configinterface postscripts will failed if there are no xCAT MASTER defined.