### PR TITLE
rspconfig dump in python

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/common/rest.py
+++ b/xCAT-openbmc-py/lib/python/agent/common/rest.py
@@ -37,7 +37,7 @@ class RestSession(object):
 
         return response
 
-    def request_download(self, method, url, headers, file_path, using_curl=False):
+    def request_download(self, method, url, headers, file_path, using_curl=True):
 
         if using_curl:
             response = self._download_by_curl(method, url, headers, file_path)

--- a/xCAT-openbmc-py/lib/python/agent/common/rest.py
+++ b/xCAT-openbmc-py/lib/python/agent/common/rest.py
@@ -37,6 +37,29 @@ class RestSession(object):
 
         return response
 
+    def request_download(self, method, url, headers, file_path, using_curl=False):
+
+        if using_curl:
+            response = self._download_by_curl(method, url, headers, file_path)
+        else:
+            response = self.session.request('GET', url, headers=headers)
+            file_handle = open(file_path, "wb")
+            for chunk in response.iter_content(chunk_size=1024):
+                if chunk:
+                    file_handle.write(chunk)
+
+        return response
+
+    def _download_by_curl(self, method, url, headers, file_path):
+
+        header_str = ' '.join([ "%s: %s" % (k, v) for k,v in headers.items() ])
+        request_cmd = 'curl -J -k -b sid=%s -H "%s" -X %s -o %s %s -s' % \
+                      (self.cookies['sid'], header_str, method, file_path, url)
+
+        sub = Popen(request_cmd, stdout=PIPE, shell=True)
+        response, err = sub.communicate()
+        return response
+
     def request_upload(self, method, url, headers, files, using_curl=True):
         if using_curl:
             return self._upload_by_curl(method, url, headers, files)

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/bmcconfig.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/bmcconfig.py
@@ -16,11 +16,11 @@ class BmcConfigInterface(object):
     def dump_generate(self, task):
         return task.run("dump_generate")
 
-    def dump_clear(self, task, id):
-        return task.run("dump_clear", id)
+    def dump_clear(self, task, clear_arg):
+        return task.run("dump_clear", clear_arg)
 
-    def dump_download(self, task, id):
-        return task.run("dump_download", id)
+    def dump_download(self, task, download_arg):
+        return task.run("dump_download", download_arg)
 
     def dump_process(self, task):
         return task.run("dump_process")

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
@@ -75,6 +75,7 @@ class OpenBMCBmcConfigTask(ParallelNodesCommand):
 
             if not dump_dict:
                 self.callback.info('%s: No attributes returned from the BMC.' % node)
+                return dump_info
 
             keys = dump_dict.keys()
             keys.sort()

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -327,7 +327,7 @@ class OpenBMCRest(object):
             raise
 
         if not response:
-            self._print_record_log('No response received', cmd=cmd)
+            self._print_record_log('No response received for command %s' % request_cmd, cmd=cmd)
             return True
 
         self._print_record_log(str(response.status_code), cmd=cmd)
@@ -603,7 +603,7 @@ class OpenBMCRest(object):
 
             return dump_dict
         except KeyError:
-            error = 'Error: Received wrong format response: %s' % inventory_data
+            error = 'Error: Received wrong format response: %s' % dump_data
             raise SelfServerException(error) 
 
     def download_dump(self, download_id, file_path):

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -29,6 +29,23 @@ RBEACON_URLS = {
     },
 }
 
+DUMP_URLS = {
+    "clear"     : {
+        "path"  : "/dump/entry/#ID#/action/Delete",
+        "field" : [],
+    },
+    "clear_all" : {
+        "path"  : "/dump/action/DeleteAll",
+        "field" : [],
+    },
+    "create"    : {
+        "path"  : "/dump/action/CreateDump",
+        "field" : [],
+    },
+    "download"  : "download/dump/#ID#",
+    "list"      : "/dump/enumerate", 
+}
+
 INVENTORY_URL = "/inventory/enumerate"
 
 LEDS_URL = "/led/physical/enumerate"
@@ -222,6 +239,7 @@ class OpenBMCRest(object):
 
         self.session = rest.RestSession()
         self.root_url = HTTP_PROTOCOL + self.bmcip + PROJECT_URL
+        self.download_root_url = HTTP_PROTOCOL + self.bmcip + '/'
 
     def _print_record_log (self, msg, cmd):
 
@@ -231,13 +249,16 @@ class OpenBMCRest(object):
             self.messager.info(localtime + ' ' + log)
             logger.debug(log)
 
-    def _log_request (self, method, url, headers, data=None, files=None, cmd=''):
+    def _log_request (self, method, url, headers, data=None, files=None, file_path=None, cmd=''):
 
         header_str = ' '.join([ "%s: %s" % (k, v) for k,v in headers.items() ])
         msg = 'curl -k -c cjar -b cjar -X %s -H \"%s\" ' % (method, header_str)
 
         if files:
             msg += '-T \'%s\' %s -s' % (files, url)
+        elif file_path:
+            msg = 'curl -J -k -c cjar -b cjar -X %s -H \"%s\" %s -o %s' % \
+                  (method, header_str, url, file_path)
         elif data:
             if cmd == 'login':
                 data = data.replace(self.password, "xxxxxx")
@@ -285,6 +306,32 @@ class OpenBMCRest(object):
             error = 'Error: Received wrong format response: %s' % response
             self._print_record_log(error, cmd)
             raise SelfServerException(error)
+
+    def download(self, method, resource, file_path, headers=None, cmd=''):
+
+        httpheaders = headers or OpenBMCRest.headers
+        url = resource
+        if not url.startswith(HTTP_PROTOCOL):
+            url = self.download_root_url + resource
+
+        request_cmd = self._log_request(method, url, httpheaders, file_path=file_path, cmd=cmd)
+
+        try:
+            response = self.session.request_download(method, url, httpheaders, file_path)
+        except SelfServerException as e:
+            self._print_record_log(e.message, cmd=cmd)
+            raise
+        except SelfClientException as e:
+            error = e.message
+            self._print_record_log(error, cmd=cmd)
+            raise
+
+        if not response:
+            self._print_record_log('No response received', cmd=cmd)
+            return True
+
+        self._print_record_log(str(response.status_code), cmd=cmd)
+        return True
 
     def upload (self, method, resource, files, headers=None, cmd=''):
 
@@ -524,47 +571,46 @@ class OpenBMCRest(object):
             data={"data": attr_info['get_data']}
         return self.request(method, get_url, payload=data, cmd="get_%s" % key)
 
-    def get_netinfo(self):
-        data = self.request('GET', RSPCONFIG_NETINFO_URL['get_netinfo'], cmd="get_netinfo")
-        try:
-            netinfo = {}
-            for k, v in data.items():
-                if 'network/config' in k:
-                    if 'HostName' in v:
-                        netinfo["hostname"] = v["HostName"]
-                    if 'DefaultGateway' in v:
-                        netinfo["defaultgateway"] = v["DefaultGateway"]
-                    continue
-                dev,match,netid = k.partition("/ipv4/")
-                if netid:
-                    if 'LinkLocal' in v["Origin"] or v["Address"].startswith("169.254"):
-                        msg = "Found LinkLocal address %s for interface %s, Ignoring..." % (v["Address"], dev)
-                        self._print_record_log(msg, 'get_netinfo')
-                        continue
-                    nicid = dev.split('/')[-1]
-                    if nicid not in netinfo:
-                        netinfo[nicid] = {}
-                    if 'ip' in netinfo[nicid]:
-                        msg = "%s: Another valid ip %s found." % (node, v["Address"])
-                        self._print_record_log(msg, 'get_netinfo')
-                        continue
-                    utils.update2Ddict(netinfo, nicid, "ipsrc", v["Origin"].split('.')[-1])
-                    utils.update2Ddict(netinfo, nicid, "netmask", v["PrefixLength"])
-                    utils.update2Ddict(netinfo, nicid, "gateway", v["Gateway"])
-                    utils.update2Ddict(netinfo, nicid, "ip", v["Address"])
-                    if dev in data:
-                        info = data[dev]
-                        utils.update2Ddict(netinfo, nicid, "vlanid", info.get("Id", "Disable"))
-                        utils.update2Ddict(netinfo, nicid, "mac", info["MACAddress"])
-                        utils.update2Ddict(netinfo, nicid, "ntpservers", info["NTPServers"])            
-            return netinfo
-        except KeyError:
-            error = 'Error: Received wrong format response: %s' % data
-            raise SelfServerException(error)
-        
+    def clear_dump(self, clear_arg):
 
-    def set_ipdhcp(self):
-        return self.request('PUT', RSPCONFIG_NETINFO_URL['ipdhcp'], cmd="set_bmcip_dhcp")
+        if clear_arg == 'all':
+            payload = { "data": DUMP_URLS['clear_all']['field'] }
+            self.request('POST', DUMP_URLS['clear_all']['path'], payload=payload, cmd='clear_dump_all')
+        else: 
+            path = DUMP_URLS['clear']['path'].replace('#ID#', clear_arg)
+            payload = { "data": DUMP_URLS['clear']['field'] }
+            self.request('POST', path, payload=payload, cmd='clear_dump')
+
+    def create_dump(self):
+
+        payload = payload = { "data": DUMP_URLS['create']['field'] }
+        return self.request('POST', DUMP_URLS['create']['path'], payload=payload, cmd='create_dump')
+
+    def list_dump_info(self):
+
+        dump_data = self.request('GET', DUMP_URLS['list'], cmd='list_dump_info')
+
+        try:
+            dump_dict = {}
+            for key, value in dump_data.items():
+                if 'Size' not in value or 'Elapsed' not in value:
+                    continue
+
+                key_id = int(key.split('/')[-1])
+                timestamp = value['Elapsed']
+                gen_time = time.strftime("%m/%d/%Y %H:%M:%S", time.localtime(timestamp))
+                dump_dict.update({key_id: {'Size': value['Size'], 'Generated': gen_time}})
+
+            return dump_dict
+        except KeyError:
+            error = 'Error: Received wrong format response: %s' % inventory_data
+            raise SelfServerException(error) 
+
+    def download_dump(self, download_id, file_path):
+
+        headers = {'Content-Type': 'application/octet-stream'}
+        path = DUMP_URLS['download'].replace('#ID#', download_id)
+        self.download('GET', path, file_path, headers=headers, cmd='download_dump')
 
 class OpenBMCImage(object):
     def __init__(self, rawid, data=None):

--- a/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
+++ b/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
@@ -724,9 +724,9 @@ class OpenBMCManager(base.BaseManager):
             elif opts['--generate']:
                 DefaultBmcConfigManager().dump_generate(runner)
             elif opts['--clear']:
-                DefaultBmcConfigManager().dump_clear(runner, opts['--clear'])
+                DefaultBmcConfigManager().dump_clear(runner, opts['--clear'][0])
             elif opts['--download']:
-                DefaultBmcConfigManager().dump_download(runner, opts['--download'])
+                DefaultBmcConfigManager().dump_download(runner, opts['--download'][0])
             else:
                 DefaultBmcConfigManager().dump_process(runner)
         elif opts['sshcfg']:


### PR DESCRIPTION
For **download**, have not fount better method so just use "curl" command. 

UT:
```
# rspconfig f6u17 dump -l
Thu Feb 22 02:04:31 2018 f6u17: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.17.100/login -d '{"data": ["root", "xxxxxx"]}'
Thu Feb 22 02:04:32 2018 f6u17: [openbmc_debug] login 200 OK
Thu Feb 22 02:04:32 2018 f6u17: [openbmc_debug] list_dump_info curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/dump/enumerate
Thu Feb 22 02:04:32 2018 f6u17: [openbmc_debug] list_dump_info 200 OK
f6u17: [1] Generated: 12/13/2017 02:15:29, Size: 96596
f6u17: [2] Generated: 12/13/2017 02:18:25, Size: 96940
f6u17: [3] Generated: 12/14/2017 00:27:56, Size: 5896
f6u17: [5] Generated: 02/09/2018 00:52:04, Size: 89948
f6u17: [6] Generated: 02/09/2018 01:11:27, Size: 90348
f6u17: [7] Generated: 02/09/2018 01:13:24, Size: 90644
f6u17: [8] Generated: 02/09/2018 01:26:56, Size: 90820
f6u17: [9] Generated: 02/22/2018 01:19:09, Size: 91168

# rspconfig f6u17 dump -g
Thu Feb 22 02:05:11 2018 f6u17: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.17.100/login -d '{"data": ["root", "xxxxxx"]}'
Thu Feb 22 02:05:11 2018 f6u17: [openbmc_debug] login 200 OK
Thu Feb 22 02:05:11 2018 f6u17: [openbmc_debug] create_dump curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/dump/action/CreateDump -d '{"data": []}'
Thu Feb 22 02:05:11 2018 f6u17: [openbmc_debug] create_dump 200 OK
f6u17: [10] success

# rspconfig f6u17 dump -c 10
Thu Feb 22 02:06:06 2018 f6u17: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.17.100/login -d '{"data": ["root", "xxxxxx"]}'
Thu Feb 22 02:06:06 2018 f6u17: [openbmc_debug] login 200 OK
Thu Feb 22 02:06:06 2018 f6u17: [openbmc_debug] clear_dump curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/dump/entry/10/action/Delete -d '{"data": []}'
Thu Feb 22 02:06:06 2018 f6u17: [openbmc_debug] clear_dump 200 OK
f6u17: [10] clear

# rspconfig f6u17 dump -d 2
Thu Feb 22 02:06:30 2018 f6u17: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.17.100/login -d '{"data": ["root", "xxxxxx"]}'
Thu Feb 22 02:06:31 2018 f6u17: [openbmc_debug] login 200 OK
Thu Feb 22 02:06:31 2018 f6u17: [openbmc_debug] download_dump curl -J -k -c cjar -b cjar -X GET -H "Content-Type: application/octet-stream" https://10.6.17.100/download/dump/2 -o /var/log/xcat/dump/20180222-0206_f6u17_dump_2.tar.xz
Thu Feb 22 02:06:31 2018 f6u17: [openbmc_debug] download_dump 200
f6u17: Downloaded dump 2 to /var/log/xcat/dump/20180222-0206_f6u17_dump_2.tar.xz.

# rspconfig f6u17 dump -d all
Downloading all dumps...
f6u17: Downloaded dump 1 to /var/log/xcat/dump/20180222-0207_f6u17_dump_1.tar.xz.
f6u17: Downloaded dump 2 to /var/log/xcat/dump/20180222-0207_f6u17_dump_2.tar.xz.
f6u17: Downloaded dump 3 to /var/log/xcat/dump/20180222-0207_f6u17_dump_3.tar.xz.
f6u17: Downloaded dump 5 to /var/log/xcat/dump/20180222-0207_f6u17_dump_5.tar.xz.
f6u17: Downloaded dump 6 to /var/log/xcat/dump/20180222-0207_f6u17_dump_6.tar.xz.
f6u17: Downloaded dump 7 to /var/log/xcat/dump/20180222-0207_f6u17_dump_7.tar.xz.
f6u17: Downloaded dump 8 to /var/log/xcat/dump/20180222-0207_f6u17_dump_8.tar.xz.
f6u17: Downloaded dump 9 to /var/log/xcat/dump/20180222-0207_f6u17_dump_9.tar.xz.

# rspconfig f6u17 dump
Capturing BMC Diagnostic information, this will take some time...
f6u17: Dump requested. Target ID is 11, waiting for BMC to generate...
f6u17: Downloading dump 11 to /var/log/xcat/dump/20180222-0208_f6u17_dump_11.tar.xz
f6u17: Downloaded dump 11 to /var/log/xcat/dump/20180222-0208_f6u17_dump_11.tar.xz.

# rspconfig f6u17 dump
Capturing BMC Diagnostic information, this will take some time...
Thu Feb 22 02:08:48 2018 f6u17: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.17.100/login -d '{"data": ["root", "xxxxxx"]}'
Thu Feb 22 02:08:49 2018 f6u17: [openbmc_debug] login 200 OK
Thu Feb 22 02:08:49 2018 f6u17: [openbmc_debug] create_dump curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/dump/action/CreateDump -d '{"data": []}'
Thu Feb 22 02:08:49 2018 f6u17: [openbmc_debug] create_dump 200 OK
f6u17: Dump requested. Target ID is 12, waiting for BMC to generate...
Thu Feb 22 02:08:49 2018 f6u17: [openbmc_debug] list_dump_info curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/dump/enumerate
Thu Feb 22 02:08:49 2018 f6u17: [openbmc_debug] list_dump_info 200 OK
Thu Feb 22 02:09:04 2018 f6u17: [openbmc_debug] list_dump_info curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/dump/enumerate
Thu Feb 22 02:09:05 2018 f6u17: [openbmc_debug] list_dump_info 200 OK
Thu Feb 22 02:09:20 2018 f6u17: [openbmc_debug] list_dump_info curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/dump/enumerate
Thu Feb 22 02:09:21 2018 f6u17: [openbmc_debug] list_dump_info 200 OK
Thu Feb 22 02:09:36 2018 f6u17: [openbmc_debug] list_dump_info curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://10.6.17.100/xyz/openbmc_project/dump/enumerate
Thu Feb 22 02:09:36 2018 f6u17: [openbmc_debug] list_dump_info 200 OK
f6u17: Downloading dump 12 to /var/log/xcat/dump/20180222-0209_f6u17_dump_12.tar.xz
Thu Feb 22 02:09:36 2018 f6u17: [openbmc_debug] download_dump curl -J -k -c cjar -b cjar -X GET -H "Content-Type: application/octet-stream" https://10.6.17.100/download/dump/12 -o /var/log/xcat/dump/20180222-0209_f6u17_dump_12.tar.xz
Thu Feb 22 02:09:36 2018 f6u17: [openbmc_debug] download_dump 200
f6u17: Downloaded dump 12 to /var/log/xcat/dump/20180222-0209_f6u17_dump_12.tar.xz.
```