### PR TITLE
fix not set domain in site table will cause dhcp service failed to start

### DIFF
--- a/xCAT-server/lib/xcat/plugins/dhcp.pm
+++ b/xCAT-server/lib/xcat/plugins/dhcp.pm
@@ -2441,7 +2441,7 @@ sub addnet
                 $callback->(
                     {
                         error => [
-                            "No $net specific entry for domain, and no domain defined in site table."
+                            "No domain defined for $net entry in networks table, and no domain defined in site table."
                           ],
                         errorcode => [1]
                     });

--- a/xCAT-server/lib/xcat/plugins/dhcp.pm
+++ b/xCAT-server/lib/xcat/plugins/dhcp.pm
@@ -2440,9 +2440,10 @@ sub addnet
             } else {
                 $callback->(
                     {
-                        warning => [
+                        error => [
                             "No $net specific entry for domain, and no domain defined in site table."
-                          ]
+                          ],
+                        errorcode => [1]
                     });
             }
 

--- a/xCAT-server/lib/xcat/plugins/dhcp.pm
+++ b/xCAT-server/lib/xcat/plugins/dhcp.pm
@@ -59,6 +59,7 @@ my $dhcpconffile = $^O eq 'aix' ? '/etc/dhcpsd.cnf' : '/etc/dhcpd.conf';
 my %dynamicranges; #track dynamic ranges defined to see if a host that resolves is actually a dynamic address
 my %netcfgs;
 my $distro = xCAT::Utils->osver();
+my $checkdomain=0;
 
 # dhcp 4.x will use /etc/dhcp/dhcpd.conf as the config file
 my $dhcp6conffile;
@@ -1931,6 +1932,14 @@ sub process_request
             addnet($line[0], $line[2]);
         }
     }
+    if ($checkdomain)
+    {
+         $callback->({ error => [ "above error fail to generate new dhcp configuration file, restore dhcp configuration file $dhcpconffile" ], errorcode => [1] });
+         my $backupfile = $dhcpconffile.".xcatbak";
+         rename("$backupfile", $dhcpconffile);
+         xCAT::MsgUtils->trace($verbose_on_off, "d", "dhcp: Restore dhcp configuration file to  $dhcpconffile"); 
+         exit 1;
+    }
     foreach (@nrn6) {    #do the ipv6 networks
         addnet6($_);     #already did all the filtering before putting into nrn6
     }
@@ -2445,6 +2454,7 @@ sub addnet
                           ],
                         errorcode => [1]
                     });
+                $checkdomain=1;
             }
 
             if ($ent and $ent->{nameservers})


### PR DESCRIPTION
for #4811 

When there is no domain in site table, all networks entry should have domain configured, or else, dhcp service will be failed. So I modified the original warning as error and return code is 1.

UT covered the following scenarios:
1, refresh install xcat will not generate new dhcp configuration file, domain in site table has non-empty value. 
2, if `domain` is not set in `site` table, all networks entry have domains, `makedhcp -n` works, dhcp service works.
3, if `domain` is set in `site` table, there is no domain configured in `networks` table, `makedhcp -n` works, dhcp service works.
4, if `domain` is not set in `site` table, there are multiple networks entries in `networks` table, all or one networks entry has no domain configured, `makedhcp -n` return error message , will not generate new dhcp configuration file, return code is 1, example is as following.
```
[root@rhmn xCAT_plugin]# makedhcp -n
Renamed existing dhcp configuration file to  /etc/dhcp/dhcpd.conf.xcatbak

Error: No domain defined for 10.0.0.0 entry in networks table, and no domain defined in site table.
Warning: No dynamic range specified for 10.0.0.0. If hardware discovery is being used, a dynamic range is required.
Error: No domain defined for 30.0.0.0 entry in networks table, and no domain defined in site table.
Warning: No dynamic range specified for 30.0.0.0. If hardware discovery is being used, a dynamic range is required.
Error: above error fail to generate new dhcp configuration file, restore dhcp configuration file /etc/dhcp/dhcpd.conf
```
In cluster.log:
```
Feb 26 22:43:21 rhmn xcat[27022]: DEBUG dhcp: Renamed existing dhcp configuration file to  /etc/dhcp/dhcpd.conf.xcatbak
Feb 26 22:43:21 rhmn xcat[27022]: DEBUG dhcp: Restore dhcp configuration file to  /etc/dhcp/dhcpd.conf
```
5, when there is no `domain` in `site` table, `makedns` will return error message.
6, when there is no `domain` in `site` table, no domain in `networks` table, `makehosts` generate only short hostname for node.