### PR TITLE
Support synclist for cumulus switch

### DIFF
--- a/perl-xCAT/xCAT/CFMUtils.pm
+++ b/perl-xCAT/xCAT/CFMUtils.pm
@@ -340,6 +340,11 @@ sub updateCFMSynclistFile {
 
     foreach my $osimg (@osimgs)
     {
+
+        # this is for Cumulus switch 
+        if ($osimg eq "onie") {
+            next;
+        }
         my $cfmdir;
         $cfmdir = xCAT::CFMUtils->setCFMSynclistFile($osimg);
         if ($cfmdir)    # check for /install/osiamges/$osimg/cfmdir

--- a/perl-xCAT/xCAT/TableUtils.pm
+++ b/perl-xCAT/xCAT/TableUtils.pm
@@ -2000,10 +2000,18 @@ sub getimagenames()
     my @nodelist = @$nodes;
     my $nodetab  = xCAT::Table->new('nodetype');
     my $images =
-      $nodetab->getNodesAttribs(\@nodelist, [ 'node', 'provmethod', 'profile' ]);
+      $nodetab->getNodesAttribs(\@nodelist, [ 'node', 'provmethod', 'profile', 'nodetype' ]);
     my @imagenames;
     foreach my $node (@nodelist)
     {
+        #set imagename as "onie" if it is switch
+        #it used for cumulus switch
+        if ($images->{$node}->[0]->{nodetype} eq "switch" )
+        {
+            push  @imagenames, "onie";
+            next;
+        }
+        
         my $imgname;
         if ($images->{$node}->[0]->{provmethod})
         {

--- a/xCAT-server/lib/perl/xCAT/SvrUtils.pm
+++ b/xCAT-server/lib/perl/xCAT/SvrUtils.pm
@@ -373,7 +373,7 @@ sub getsynclistfile()
         unless ($nodetype_t) {
             return;
         }
-        my $nodetype_v = $nodetype_t->getNodesAttribs($nodes, [ 'profile', 'os', 'arch', 'provmethod' ]);
+        my $nodetype_v = $nodetype_t->getNodesAttribs($nodes, [ 'profile', 'os', 'arch', 'provmethod', 'nodetype' ]);
 
         my $osimage_t = xCAT::Table->new('osimage');
         unless ($osimage_t) {
@@ -381,6 +381,13 @@ sub getsynclistfile()
         }
         foreach my $node (@$nodes) {
             my $provmethod = $nodetype_v->{$node}->[0]->{'provmethod'};
+            my $nodetype = $nodetype_v->{$node}->[0]->{'nodetype'};
+            my $nodeprofile = $nodetype_v->{$node}->[0]->{'profile'};
+            #This is for cumulus switch
+            if ($nodetype eq "switch") {
+                $node_syncfile{$node} = $nodeprofile;
+                next;
+            }
             if (($provmethod) && ($provmethod ne "install") && ($provmethod ne "netboot") && ($provmethod ne "statelite")) {
 
                 # get the syncfiles base on the osimage


### PR DESCRIPTION
for issue #2962 

Pre-requirement for this PR:  
rsync command needs to be available on the cumulus switch.  Currently, we are request Mellanox/edgecore to pull into rsync package to the newer cumulus OS.  Meanwhile, user can get rsync package from cumulus repo:
http://repo3.cumulusnetworks.com/repo/pool/upstream/r/rsync/rsync_3.1.1-3_armel.deb

After rsync command installed on the cumulus switch,   user needs to set syncfiles to the **profile** attribute for the cumulus switch definition
```
#chdef mid08tor10 profile=/install/custom/switch/onie.syslist
# updatenode mid08tor10 -F
File synchronization has completed for nodes.
````