### PR TITLE
Make reventlog resolved=LED case insensitive

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1581,7 +1581,7 @@ sub parse_command_status {
         if ($subcommand eq "clear") {
             $next_status{LOGIN_RESPONSE} = "REVENTLOG_CLEAR_REQUEST";
             $next_status{REVENTLOG_CLEAR_REQUEST} = "REVENTLOG_CLEAR_RESPONSE";
-        } elsif ($subcommand =~ /resolved=LED/) {
+        } elsif (uc($subcommand) =~ /RESOLVED=LED/) {
             $next_status{LOGIN_RESPONSE} = "REVENTLOG_REQUEST";
             $next_status{REVENTLOG_REQUEST} = "REVENTLOG_RESOLVED_RESPONSE_LED";
         } elsif ($subcommand =~ /resolved=(.+)/) {


### PR DESCRIPTION
```
[root@briggs01 xcat]# reventlog mid05tor12cn13 resolved=led
Attempting to resolve the following log entries: led...
mid05tor12cn13: Resolved 52.
mid05tor12cn13: Resolved 74.
mid05tor12cn13: Resolved 71.
mid05tor12cn13: Resolved 53.
mid05tor12cn13: Resolved 55.
mid05tor12cn13: Resolved 51.
mid05tor12cn13: Resolved 64.
mid05tor12cn13: Resolved 58.
mid05tor12cn13: Resolved 57.
mid05tor12cn13: Resolved 73.
mid05tor12cn13: Resolved 66.
mid05tor12cn13: Resolved 67.
```
```
[root@briggs01 xcat]# reventlog mid05tor12cn13 resolved=Led
Attempting to resolve the following log entries: Led...
mid05tor12cn13: Resolved 52.
mid05tor12cn13: Resolved 74.
mid05tor12cn13: Resolved 71.
mid05tor12cn13: Resolved 53.
mid05tor12cn13: Resolved 55.
mid05tor12cn13: Resolved 51.
mid05tor12cn13: Resolved 64.
mid05tor12cn13: Resolved 58.
mid05tor12cn13: Resolved 57.
mid05tor12cn13: Resolved 73.
mid05tor12cn13: Resolved 66.
mid05tor12cn13: Resolved 67.
```
```
[root@briggs01 xcat]# reventlog mid05tor12cn13 resolved=LED
Attempting to resolve the following log entries: LED...
mid05tor12cn13: Resolved 52.
mid05tor12cn13: Resolved 74.
mid05tor12cn13: Resolved 71.
mid05tor12cn13: Resolved 53.
mid05tor12cn13: Resolved 55.
mid05tor12cn13: Resolved 51.
mid05tor12cn13: Resolved 64.
mid05tor12cn13: Resolved 58.
mid05tor12cn13: Resolved 57.
mid05tor12cn13: Resolved 73.
mid05tor12cn13: Resolved 66.
mid05tor12cn13: Resolved 67.
```
```
[root@briggs01 xcat]# reventlog mid05tor12cn13 resolved=72
Attempting to resolve the following log entries: 72...
mid05tor12cn13: Resolved 72.
```