### PR TITLE
fixes to default stanza handling

### DIFF
--- a/perl-xCAT/xCAT/DBobjUtils.pm
+++ b/perl-xCAT/xCAT/DBobjUtils.pm
@@ -1676,13 +1676,10 @@ sub readFileInput
 
             #  could have different default stanzas for different object types
 
-            if ($objectname =~ /default/) {
+            if ($objectname =~ /^default-([^-]+)$/) {
 
-                ($junk1, $objtype) = split(/-/, $objectname);
-
-                if ($objtype) {
-                    $objectname = 'default';
-                }
+                $objtype = $1;
+                $objectname = 'default';
 
                 next;
             }


### PR DESCRIPTION
At present if one has the word "default" in a stanza object name xCAT assumes it's a default stanza even if it's not. 

The cause that turned this up is storing the kernel name in the xCAT image name which with SLES includes "default" (e.g. 3.0.101-0.47.105-default). Cloning images or creating new ones using mkdef became problematic because xCAT would assume it to be a default stanza and produce the error: `Error: No object names were provided`. 

This PR makes the default object name more explicit so as not to catch object names that contain the word default but aren't default stanzas.

-Aaron 