### PR TITLE
rspconfig gard&admin_passwd&ntpservers in python

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/bmcconfig.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/bmcconfig.py
@@ -25,6 +25,9 @@ class BmcConfigInterface(object):
     def dump_process(self, task):
         return task.run("dump_process")
 
+    def gard_clear(self, task):
+        return task.run("gard_clear")
+
     def set_sshcfg(self, task):
         return task.run("set_sshcfg")
 

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
@@ -328,10 +328,10 @@ rmdir \"/tmp/$userid\" \n")
         if not netinfo:
             return self.callback.error("%s: No network information get" % node)
 
-        nic = None
-        for k,v in netinfo.items():
-            if 'ip' in v and v['ip'] == node_info['bmcip']:
-                nic = k
+        bmcip = node_info['bmcip']
+        nic = self._get_facing_nic(bmcip, netinfo)
+        if not nic:
+            return self.callback.error('%s: Can not get facing NIC for %s' % (node, bmcip))
 
         try:
             obmc.set_ntp_servers(nic, servers)
@@ -345,6 +345,12 @@ rmdir \"/tmp/$userid\" \n")
         if nic in netinfo:
             ntpservers = netinfo[nic]['ntpservers']
         self.callback.info('%s: BMC NTP Servers: %s' % (node, ntpservers))
+
+    def _get_facing_nic(self, bmcip, netinfo):
+        for k,v in netinfo.items():
+            if 'ip' in v and v['ip'] == bmcip:
+                return k
+        return None
 
     def _set_admin_password(self, admin_passwd, **kw):
         node = kw['node']

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -46,6 +46,8 @@ DUMP_URLS = {
     "list"      : "/dump/enumerate", 
 }
 
+GARD_CLEAR_URL = "/org/open_power/control/gard/action/Reset"
+
 INVENTORY_URL = "/inventory/enumerate"
 
 LEDS_URL = "/led/physical/enumerate"
@@ -165,6 +167,8 @@ RSPCONFIG_NETINFO_URL = {
     'ipdhcp': "/network/action/Reset",
     'ntpserver': "/network/#NIC#/attr/NTPServers",
 }
+
+PASSWD_URL = '/user/root/action/SetPassword'
 
 RSPCONFIG_APIS = {
     'hostname': {
@@ -571,6 +575,11 @@ class OpenBMCRest(object):
             data={"data": attr_info['get_data']}
         return self.request(method, get_url, payload=data, cmd="get_%s" % key)
 
+    def set_admin_passwd(self, passwd):
+
+        payload = { "data": [passwd] }
+        self.request('POST', PASSWD_URL, payload=payload, cmd='set_admin_password')
+
     def clear_dump(self, clear_arg):
 
         if clear_arg == 'all':
@@ -611,6 +620,12 @@ class OpenBMCRest(object):
         headers = {'Content-Type': 'application/octet-stream'}
         path = DUMP_URLS['download'].replace('#ID#', download_id)
         self.download('GET', path, file_path, headers=headers, cmd='download_dump')
+
+    def clear_gard(self):
+
+        payload = { "data": [] }
+        url = HTTP_PROTOCOL + self.bmcip + GARD_CLEAR_URL
+        return self.request('POST', url, payload=payload, cmd='clear_gard')
 
     def get_netinfo(self):
         data = self.request('GET', RSPCONFIG_NETINFO_URL['get_netinfo'], cmd="get_netinfo")

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -165,7 +165,7 @@ RSPCONFIG_NETINFO_URL = {
     'nic_ip': "/network/#NIC#/action/IP",
     'vlan': "/network/action/VLAN",
     'ipdhcp': "/network/action/Reset",
-    'ntpserver': "/network/#NIC#/attr/NTPServers",
+    'ntpservers': "/network/#NIC#/attr/NTPServers",
 }
 
 PASSWD_URL = '/user/root/action/SetPassword'
@@ -580,6 +580,12 @@ class OpenBMCRest(object):
         payload = { "data": [passwd] }
         self.request('POST', PASSWD_URL, payload=payload, cmd='set_admin_password')
 
+    def set_ntp_servers(self, nic, servers):
+
+        payload = { "data": [servers] }
+        url = RSPCONFIG_NETINFO_URL['ntpservers'].replace('#NIC#', nic)
+        self.request('PUT', url, payload=payload, cmd='set_ntp_servers')
+
     def clear_dump(self, clear_arg):
 
         if clear_arg == 'all':
@@ -659,7 +665,11 @@ class OpenBMCRest(object):
                         info = data[dev]
                         utils.update2Ddict(netinfo, nicid, "vlanid", info.get("Id", "Disable"))
                         utils.update2Ddict(netinfo, nicid, "mac", info["MACAddress"])
-                        utils.update2Ddict(netinfo, nicid, "ntpservers", info["NTPServers"])            
+                        ntpservers = None
+                        tmp_ntpservers = ''.join(info["NTPServers"])
+                        if tmp_ntpservers:
+                            ntpservers = tmp_ntpservers
+                        utils.update2Ddict(netinfo, nicid, "ntpservers", ntpservers)            
             return netinfo
         except KeyError:
             error = 'Error: Received wrong format response: %s' % data

--- a/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
+++ b/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
@@ -80,13 +80,14 @@ RFLASH_URLS = {
     }
 }
 
-RSPCONFIG_GET_OPTIONS = ['ip','ipsrc','netmask','gateway','vlan','hostname','bootmode','autoreboot','powersupplyredundancy','powerrestorepolicy']
+RSPCONFIG_GET_OPTIONS = ['ip','ipsrc','netmask','gateway','vlan','ntpservers','hostname','bootmode','autoreboot','powersupplyredundancy','powerrestorepolicy']
 RSPCONFIG_SET_OPTIONS = {
     'ip':'.*',
     'netmask':'.*',
     'gateway':'.*',
     'vlan':'\d+',
     'hostname':"\*|.*",
+    'ntpservers':'.*',
     'autoreboot':"^0|1$",
     'powersupplyredundancy':"^enabled$|^disabled$",
     'powerrestorepolicy':"^always_on$|^always_off$|^restore$",

--- a/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
+++ b/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
@@ -91,13 +91,15 @@ RSPCONFIG_SET_OPTIONS = {
     'powersupplyredundancy':"^enabled$|^disabled$",
     'powerrestorepolicy':"^always_on$|^always_off$|^restore$",
     'bootmode':"^regular$|^safe$|^setup$",
+    'admin_passwd':'.*,.*',
 }
 RSPCONFIG_USAGE = """
 Handle rspconfig operations.
 
 Usage:
        rspconfig -h|--help
-       rspconfig dump [[-l|--list] | [-g|--generate] | [-c|--clear <arg>] | [-d|--download <arg>]] [-V|--verbose]
+       rspconfig dump [[-l|--list] | [-g|--generate] | [-c|--clear --id <arg>] | [-d|--download --id <arg>]] [-V|--verbose]
+       rspconfig gard -c|--clear [-V|--verbose]
        rspconfig sshcfg [-V|--verbose]
        rspconfig ip=dhcp [-V|--verbose]
        rspconfig get [<args>...] [-V|--verbose]
@@ -107,8 +109,9 @@ Options:
   -V,--verbose        Show verbose message
   -l,--list           List are dump files
   -g,--generate       Trigger a new dump file
-  -c,--clear <arg>    The id of file to clear or all if specify 'all'
-  -d,--download <arg> The id of file to download or all if specify 'all'
+  -c,--clear          To clear the specified dump file
+  -d,--download       To download specified dump file
+  --id <arg>          The dump file id or 'all'
 
 The supported attributes to get are: %s
 
@@ -724,11 +727,14 @@ class OpenBMCManager(base.BaseManager):
             elif opts['--generate']:
                 DefaultBmcConfigManager().dump_generate(runner)
             elif opts['--clear']:
-                DefaultBmcConfigManager().dump_clear(runner, opts['--clear'][0])
+                DefaultBmcConfigManager().dump_clear(runner, opts['--id'])
             elif opts['--download']:
-                DefaultBmcConfigManager().dump_download(runner, opts['--download'][0])
+                DefaultBmcConfigManager().dump_download(runner, opts['--id'])
             else:
                 DefaultBmcConfigManager().dump_process(runner)
+        elif opts['gard']:
+            if opts['--clear']:
+                DefaultBmcConfigManager().gard_clear(runner)
         elif opts['sshcfg']:
             DefaultBmcConfigManager().set_sshcfg(runner)
         elif opts['ip=dhcp']:

--- a/xCAT-server/lib/xcat/plugins/openbmc2.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc2.pm
@@ -344,11 +344,16 @@ sub refactor_args {
     my $extrargs  = $request->{arg};    
     if ($command eq "rspconfig") {
         my $subcommand = $extrargs->[0];
-        if ($subcommand !~ /^dump$|^sshcfg$|^ip=dhcp$/) {
+        if ($subcommand !~ /^dump$|^sshcfg$|^ip=dhcp$|^gard$/) {
             if (grep /=/, @$extrargs) {
                 unshift @$extrargs, "set";
             } else {
                 unshift @$extrargs, "get";
+            }
+        }
+        if ($subcommand eq "dump") {
+            if (defined($extrargs->[1]) and $extrargs->[1] =~ /-c|--clear|-d|--download/){
+                splice(@$extrargs, 2, 0, "--id");
             }
         }
     }

--- a/xCAT-server/lib/xcat/plugins/openbmc2.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc2.pm
@@ -342,8 +342,9 @@ sub refactor_args {
     my $request = shift;
     my $command   = $request->{command}->[0];
     my $extrargs  = $request->{arg};    
+    my $subcommand; 
     if ($command eq "rspconfig") {
-        my $subcommand = $extrargs->[0];
+        $subcommand = $extrargs->[0];
         if ($subcommand !~ /^dump$|^sshcfg$|^ip=dhcp$|^gard$/) {
             if (grep /=/, @$extrargs) {
                 unshift @$extrargs, "set";


### PR DESCRIPTION
Add rspconfig gard -c & rspconfig admin_passwd in python

UT:

```
# rspconfig mid05tor12cn05 gard -c
Mon Feb 26 02:57:42 2018 mid05tor12cn05: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://172.11.139.5/login -d '{"data": ["root", "xxxxxx"]}'
Mon Feb 26 02:57:43 2018 mid05tor12cn05: [openbmc_debug] login 200 OK
Mon Feb 26 02:57:43 2018 mid05tor12cn05: [openbmc_debug] clear_gard curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://172.11.139.5/org/open_power/control/gard/action/Reset -d '{"data": []}'
Mon Feb 26 02:57:43 2018 mid05tor12cn05: [openbmc_debug] clear_gard 200 OK
mid05tor12cn05: GARD cleared

# rspconfig mid05tor12cn05 admin_passwd=0penBmc1,0penBmc
Mon Feb 26 02:51:12 2018 mid05tor12cn05: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://172.11.139.5/login -d '{"data": ["root", "xxxxxx"]}'
Mon Feb 26 02:51:12 2018 mid05tor12cn05: [openbmc_debug] login 200 OK
Mon Feb 26 02:51:12 2018 mid05tor12cn05: [openbmc_debug] set_admin_password curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://172.11.139.5/xyz/openbmc_project/user/root/action/SetPassword -d '{"data": ["0penBmc"]}'
Mon Feb 26 02:51:12 2018 mid05tor12cn05: [openbmc_debug] set_admin_password 200 OK
mid05tor12cn05: BMC Setting Password...

# rspconfig f6u03 ip ntpservers
Tue Feb 27 01:22:49 2018 f6u03: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.3.100/login -d '{"data": ["root", "xxxxxx"]}'
Tue Feb 27 01:22:49 2018 f6u03: [openbmc_debug] login 200 OK
Tue Feb 27 01:22:49 2018 f6u03: [openbmc_debug] get_netinfo curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://10.6.3.100/xyz/openbmc_project/network/enumerate
Tue Feb 27 01:22:50 2018 f6u03: [openbmc_debug] get_netinfo 200 OK
Tue Feb 27 01:22:50 2018 f6u03: [openbmc_debug] get_netinfo Found LinkLocal address 169.254.164.2 for interface /xyz/openbmc_project/network/eth0, Ignoring...
f6u03: BMC IP: 10.6.3.100
f6u03: BMC NTP Servers: None

# rspconfig f6u03 ntpservers=c910f03c05k04
Tue Feb 27 01:24:00 2018 f6u03: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.3.100/login -d '{"data": ["root", "xxxxxx"]}'
Tue Feb 27 01:24:00 2018 f6u03: [openbmc_debug] login 200 OK
Tue Feb 27 01:24:00 2018 f6u03: [openbmc_debug] get_netinfo curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://10.6.3.100/xyz/openbmc_project/network/enumerate
Tue Feb 27 01:24:00 2018 f6u03: [openbmc_debug] get_netinfo 200 OK
Tue Feb 27 01:24:00 2018 f6u03: [openbmc_debug] get_netinfo Found LinkLocal address 169.254.164.2 for interface /xyz/openbmc_project/network/eth0, Ignoring...
Tue Feb 27 01:24:00 2018 f6u03: [openbmc_debug] set_ntp_servers curl -k -c cjar -b cjar -X PUT -H "Content-Type: application/json" https://10.6.3.100/xyz/openbmc_project/network/eth0/attr/NTPServers -d '{"data": ["c910f03c05k04"]}'
Tue Feb 27 01:24:01 2018 f6u03: [openbmc_debug] set_ntp_servers 200 OK
f6u03: BMC Setting NTPServers...
Tue Feb 27 01:24:01 2018 f6u03: [openbmc_debug] get_netinfo curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://10.6.3.100/xyz/openbmc_project/network/enumerate
Tue Feb 27 01:24:01 2018 f6u03: [openbmc_debug] get_netinfo 200 OK
Tue Feb 27 01:24:01 2018 f6u03: [openbmc_debug] get_netinfo Found LinkLocal address 169.254.164.2 for interface /xyz/openbmc_project/network/eth0, Ignoring...
f6u03: BMC NTP Servers: c910f03c05k04
```

If password is not correct:
```
# rspconfig mid05tor12cn05 admin_passwd=0penBmc1,0penBmc
mid05tor12cn05: Current BMC password is incorrect, cannot set the new password.
```