### PR TITLE
Remove "dynamic" checking in the doxcat scripts

### DIFF
--- a/xCAT-genesis-scripts/usr/bin/doxcat
+++ b/xCAT-genesis-scripts/usr/bin/doxcat
@@ -247,7 +247,7 @@ else
 
             gripeiter=101
             logger -s -t $log_label -p local4.info "Acquiring network addresses.."
-            while ! ip -4 -o a show dev $bootnic|grep -v 'scope link'|grep -v 'dynamic'|grep -q inet; do
+            while ! ip -4 -o a show dev $bootnic|grep -v 'scope link'|grep -q inet; do
                 sleep 0.1
                 if [ $gripeiter = 1 ]; then
                     logger -s -t $log_label -p local4.info "It seems to be taking a while to acquire an IPv4 address, you may want to check spanning tree..."


### PR DESCRIPTION
Report this issue from PCM customer
````
I manage to generate a new kernel and include the net modules needed by our machines. The scripts in xcat/pcm are not really working, so I had to do most of the steps manually, but anyhow, I have an working kernel.
Now, we seem to have a different behavior from doxcat script. It is always getting stuck waiting for the interface to come up, although the interface is already up

As the address is dynamically provided the condition there will never be met
`````
exmaple of interface:
````

# ip addr show dev enP5p1s0f0
2: enP5p1s0f0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
    link/ether 70:e2:84:14:29:10 brd ff:ff:ff:ff:ff:ff
    inet 172.20.226.1/16 scope global dynamic enP5p1s0f0
       valid_lft forever preferred_lft forever

````
Talked this issue with @zet809 , and we didn't find good reason why we didn't choose "dynamic" interface.