### PR TITLE
Add test case to compare the output of perl vs python for bmcstate when bmc reboots 

### DIFF
--- a/xCAT-test/autotest/testcase/UT_openbmc/rpower_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rpower_cases0
@@ -25,6 +25,10 @@ description: Record the output file into the xCAT test framework
 cmd: cat /tmp/xcattest.rpower.bmcstate.perl.out
 end
 
+start:rpower_bmcreboot_remove_tmpfile_perl 
+description: Remove the temporary file, output is captures above 
+cmd: rm -f /tmp/xcattest.rpower.bmcstate.perl.out
+end
 
 start:rpower_bmcreboot_record_python_output
 description: Start the test for python code
@@ -51,5 +55,10 @@ end
 start:rpower_bmcreboot_record_logs_python
 description: Record the output file into the xCAT test framework
 cmd: cat /tmp/xcattest.rpower.bmcstate.python.out
+end
+
+start:rpower_bmcreboot_remove_tmpfile_python
+description: Remove the temporary file, output is captures above 
+cmd: rm -f /tmp/xcattest.rpower.bmcstate.python.out
 end
 

--- a/xCAT-test/autotest/testcase/UT_openbmc/rpower_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rpower_cases0
@@ -1,0 +1,55 @@
+start:rpower_bmcreboot_record_perl_output
+description: Start the test for perl code
+hcp:openbmc
+cmd: /opt/xcat/share/xcat/tools/autotest/testcase/UT_openbmc/scripts/bmcreboot.sh $$CN /tmp/xcattest.rpower.bmcstate.perl.out PERL
+check:rc==0
+end
+
+start:rpower_bmcreboot_check_lines_perl
+description: Check that we receive the correct output when we reboot the BMC - PERL
+hcp:openbmc
+cmd: grep "Login to BMC failed: 500" /tmp/xcattest.rpower.bmcstate.perl.out | sort | uniq | wc -l
+check:output=~3
+cmd: grep "timeout" /tmp/xcattest.rpower.bmcstate.perl.out | sort | uniq | wc -l
+check:output=~1
+cmd: grep "No route to host" /tmp/xcattest.rpower.bmcstate.perl.out | sort | uniq | wc -l
+check:output=~1
+cmd: grep "BMC NotReady" /tmp/xcattest.rpower.bmcstate.perl.out | sort | uniq | wc -l
+check:output=~1
+cmd: grep "BMC Ready" /tmp/xcattest.rpower.bmcstate.perl.out | sort | uniq | wc -l
+check:output=~1
+end
+
+start:rpower_bmcreboot_record_logs_perl
+description: Record the output file into the xCAT test framework
+cmd: cat /tmp/xcattest.rpower.bmcstate.perl.out
+end
+
+
+start:rpower_bmcreboot_record_python_output
+description: Start the test for python code
+hcp:openbmc
+cmd: /opt/xcat/share/xcat/tools/autotest/testcase/UT_openbmc/scripts/bmcreboot.sh $$CN /tmp/xcattest.rpower.bmcstate.python.out PYTHON
+check:rc==0
+end
+
+start:rpower_bmcreboot_check_lines_python
+description: Check that we receive the correct output when we reboot the BMC - PYTHON
+hcp:openbmc
+cmd: grep "Login to BMC failed: 500" /tmp/xcattest.rpower.bmcstate.python.out | sort | uniq | wc -l
+check:output=~3
+cmd: grep "timeout" /tmp/xcattest.rpower.bmcstate.python.out | sort | uniq | wc -l
+check:output=~1
+cmd: grep "No route to host" /tmp/xcattest.rpower.bmcstate.python.out | sort | uniq | wc -l
+check:output=~1
+cmd: grep "BMC NotReady" /tmp/xcattest.rpower.bmcstate.python.out | sort | uniq | wc -l
+check:output=~1
+cmd: grep "BMC Ready" /tmp/xcattest.rpower.bmcstate.python.out | sort | uniq | wc -l
+check:output=~1
+end
+
+start:rpower_bmcreboot_record_logs_python
+description: Record the output file into the xCAT test framework
+cmd: cat /tmp/xcattest.rpower.bmcstate.python.out
+end
+

--- a/xCAT-test/autotest/testcase/UT_openbmc/scripts/bmcreboot.sh
+++ b/xCAT-test/autotest/testcase/UT_openbmc/scripts/bmcreboot.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+if [[ -z ${1} ]]; then
+    echo "Provide the name of the node as the first argument of this script"
+    exit 1
+fi
+NODE=${1}
+
+if [[ -z ${2} ]]; then
+    echo "Provide the name of the log file as the second argument of this script"
+    exit 1
+fi
+LOGFILE=$2
+
+if [[ -z ${3} ]]; then
+    echo "Provide either PERL or PYTHON as the third argument of this script"
+    exit 1
+fi
+
+if [[ ${3} == "PERL" ]]; then
+   echo "Running the test in PERL"
+   unset XCAT_OPENBMC_PYTHON
+elif [[ ${3} == "PYTHON" ]]; then
+   echo "Running the test in PYTHON"
+   export XCAT_OPENBMC_PYTHON=YES
+else
+   echo "UNKNOWN SELECTED!"
+   exit 1
+fi
+
+ITERATIONS=20
+SLEEP_TIME=2
+
+# Turn off debug mode....
+#
+chdef -t site clustersite xcatdebugmode=
+
+# Create a new log file
+date > $LOGFILE
+
+rpower $NODE bmcstate
+
+# Reboot the bmc
+rpower $NODE bmcreboot | tee -a $LOGFILE 2>&1
+
+counter=1
+ready_cnt=0
+while [[ $counter -le $ITERATIONS ]]; do
+   sleep $SLEEP_TIME
+   RC=`rpower $NODE bmcstate >> $LOGFILE 2>&1 ; echo $?`
+   echo "Count: $counter, RC: $RC"
+    ((counter++))
+   if [[ $RC == 0 ]]; then
+       ((ready_cnt++))
+       if [[ $ready_cnd > 2 ]]; then
+           echo "Leaving loop...."
+           break
+       fi 
+   fi
+done
+
+echo "All done!"


### PR DESCRIPTION
Addresses the testcase_requested for #4855. 

After @gurevichmark completes the code change, will need to test out this again to see if it successfully runs for both Perl and Python, before we merge it in.

Here's a sample of running the test: [output.txt](https://github.com/xcat2/xcat-core/files/1764852/output.txt)

It finds some issues with the OpenBMC Python, return code... 
