### PR TITLE
modify usage and manpage for openbmc

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rbeacon.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rbeacon.1.rst
@@ -11,7 +11,7 @@ SYNOPSIS
 ********
 
 
-\ **rbeacon**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
+\ **rbeacon**\  [\ **-h | -**\ **-help | -v | -**\ **-version | -V | -**\ **-verbose**\ ]
 
 BMC (using IPMI):
 =================

--- a/docs/source/guides/admin-guides/references/man1/rbeacon.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rbeacon.1.rst
@@ -11,11 +11,28 @@ SYNOPSIS
 ********
 
 
+\ **rbeacon**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
+
+BMC (using IPMI):
+=================
+
+
 \ **rbeacon**\  \ *noderange*\  {\ **on | blink | off | stat**\ }
 
-\ **rbeacon**\  [\ **-h | -**\ **-help**\ ]
 
-\ **rbeacon**\  {\ **-v | -**\ **-version**\ }
+OpenPOWER BMC (using IPMI):
+===========================
+
+
+\ **rbeacon**\  \ *noderange*\  {\ **on | blink | off | stat**\ }
+
+
+OpenPOWER OpenBMC:
+==================
+
+
+\ **rbeacon**\  \ *noderange*\  {\ **on | off**\ }
+
 
 
 ***********

--- a/docs/source/guides/admin-guides/references/man1/rsetboot.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rsetboot.1.rst
@@ -62,7 +62,7 @@ OPTIONS
 
 \ **-u**\ 
  
- To specify the next boot mode to be "UEFI Mode".
+ To specify the next boot mode to be "UEFI Mode". (Not supported for OpenBMC)
  
 
 

--- a/docs/source/guides/admin-guides/references/man1/rsetboot.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rsetboot.1.rst
@@ -13,7 +13,7 @@ SYNOPSIS
 
 \ **rsetboot**\  \ *noderange*\  [\ **hd | net | cd | default | stat**\ ] [\ **-u**\ ] [\ **-p**\ ]
 
-\ **rsetboot**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
+\ **rsetboot**\  [\ **-h | -**\ **-help | -v | -**\ **-version | -V | -**\ **-verbose**\ ]
 
 
 ***********

--- a/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
@@ -19,7 +19,7 @@ SYNOPSIS
 ********
 
 
-\ **rspconfig**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
+\ **rspconfig**\  [\ **-h | -**\ **-help | -v | -**\ **-version | -V | -**\ **-verbose**\ ]
 
 BMC/MPA specific:
 =================

--- a/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
@@ -47,7 +47,9 @@ OpenBMC specific:
 =================
 
 
-\ **rspconfig**\  \ *noderange*\  {\ **ipsrc | ip | netmask | gateway | hostname | vlan | sshcfg**\ }
+\ **rspconfig**\  \ *noderange*\  {\ **ipsrc | ip | netmask | gateway | vlan**\ }
+
+\ **rspconfig**\  \ *noderange*\  \ **admin_passwd**\ ={\ *currentpasswd,newpasswd*\ }
 
 \ **rspconfig**\  \ *noderange*\  \ **autoreboot**\ 
 
@@ -59,6 +61,18 @@ OpenBMC specific:
 
 \ **rspconfig**\  \ *noderange*\  \ **dump**\  [\ **-l | -**\ **-list**\ ] [\ **-g | -**\ **-generate**\ ] [\ **-c | -**\ **-clear**\  {\ *id*\  | \ **all**\ }] [\ **-d | -**\ **-download**\  {\ *id*\  | \ **all**\ }]
 
+\ **rspconfig**\  \ *noderange*\  \ **gard -c|-**\ **-clear**\ 
+
+\ **rspconfig**\  \ *noderange*\  \ **ip=dhcp**\ 
+
+\ **rspconfig**\  \ *noderange*\  \ **hostname**\ 
+
+\ **rspconfig**\  \ *noderange*\  \ **hostname**\ ={\* | \ *name*\ }
+
+\ **rspconfig**\  \ *noderange*\  \ **ntpservers**\ 
+
+\ **rspconfig**\  \ *noderange*\  \ **ntpservers**\ ={\ *ntpservers*\ }
+
 \ **rspconfig**\  \ *noderange*\  \ **powerrestorepolicy**\ 
 
 \ **rspconfig**\  \ *noderange*\  \ **powerrestorepolicy={always_on|restore|always_off}**\ 
@@ -66,6 +80,8 @@ OpenBMC specific:
 \ **rspconfig**\  \ *noderange*\  \ **powersupplyredundancy**\ 
 
 \ **rspconfig**\  \ *noderange*\  \ **powersupplyredundancy={disabled|enabled}**\ 
+
+\ **rspconfig**\  \ *noderange*\  \ **sshcfg**\ 
 
 \ **rspconfig**\  \ *noderange*\  \ **timesyncmethod**\ 
 
@@ -135,9 +151,9 @@ FSP/CEC specific:
 
 \ **rspconfig**\  \ *noderange*\  \ **admin_passwd**\ ={\ *currentpasswd,newpasswd*\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **general_passwd**\ ={\ **currentpasswd,newpasswd**\ }
+\ **rspconfig**\  \ *noderange*\  \ **general_passwd**\ ={\ *currentpasswd,newpasswd*\ }
 
-\ **rspconfig**\  \ *noderange*\  \*\ **_passwd**\ ={\ **currentpasswd,newpasswd**\ }
+\ **rspconfig**\  \ *noderange*\  \*\ **_passwd**\ ={\ *currentpasswd,newpasswd*\ }
 
 \ **rspconfig**\  \ *noderange*\  {\ *hostname*\ }
 
@@ -198,9 +214,9 @@ FSP/CEC (using Direct FSP Management) Specific:
 
 \ **rspconfig**\  \ *noderange*\  \ **admin_passwd**\ ={\ *currentpasswd,newpasswd*\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **general_passwd**\ ={\ **currentpasswd,newpasswd**\ }
+\ **rspconfig**\  \ *noderange*\  \ **general_passwd**\ ={\ *currentpasswd,newpasswd*\ }
 
-\ **rspconfig**\  \ *noderange*\  \*\ **_passwd**\ ={\ **currentpasswd,newpasswd**\ }
+\ **rspconfig**\  \ *noderange*\  \*\ **_passwd**\ ={\ *currentpasswd,newpasswd*\ }
 
 \ **rspconfig**\  \ *noderange*\  {\ **sysname**\ }
 
@@ -237,9 +253,9 @@ BPA/Frame (using Direct FSP Management) Specific:
 
 \ **rspconfig**\  \ *noderange*\  \ **admin_passwd**\ ={\ *currentpasswd,newpasswd*\ }
 
-\ **rspconfig**\  \ *noderange*\  \ **general_passwd**\ ={\ **currentpasswd,newpasswd**\ }
+\ **rspconfig**\  \ *noderange*\  \ **general_passwd**\ ={\ *currentpasswd,newpasswd*\ }
 
-\ **rspconfig**\  \ *noderange*\  \*\ **_passwd**\ ={\ **currentpasswd,newpasswd**\ }
+\ **rspconfig**\  \ *noderange*\  \*\ **_passwd**\ ={\ *currentpasswd,newpasswd*\ }
 
 \ **rspconfig**\  \ *noderange*\  {\ **frame**\ }
 
@@ -359,6 +375,12 @@ OPTIONS
 \ **frequency**\ 
  
  The NTP update frequency (in minutes).
+ 
+
+
+\ **gard -c|-**\ **-clear**\ 
+ 
+ Clear gard file. [OpenBMC]
  
 
 
@@ -549,6 +571,12 @@ OPTIONS
 \ **ntpserver**\ 
  
  Get or set NTP server IP address or name.
+ 
+
+
+\ **ntpservers**\ 
+ 
+ Get or set NTP servers name. [OpenBMC]
  
 
 

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -72,9 +72,22 @@ my %usage = (
        rpower noderange [off|on|stat|status|reset]
        rpower noderange [pduoff|pduon|pdustat|pdustatus|pdureset]
 ",
-    "rbeacon" =>
-      "Usage: rbeacon <noderange> [on|off|stat] [-V|--verbose]
-       rbeacon [-h|--help|-v|--version]",
+    "rbeacon" =>"",
+    "rbeacon.common" =>
+      "Usage: 
+    Common:
+       rbeacon [-h|--help|-v|--version]
+    ",
+    "rbeacon.begin" =>
+    "BMC specific:
+       rbeacon [on|blink|off|stat]
+    OpenPOWER (IPMI) specific:
+       rbeacon [on|blink|off|stat]
+    ",
+    "rbeacon.openbmc" =>
+    "OpenPOWER (OpenBMC) specific:
+       rbeacon [on|off]
+    ",    
     "rvitals" => "",
     "rvitals.common" =>
       "Usage:
@@ -165,8 +178,13 @@ my %usage = (
    ",
     "rspconfig.openbmc" =>
       "OpenBMC specific:
-       rspconfig <noderange> [ipsrc|ip|netmask|gateway|hostname|vlan]
+       rspconfig <noderange> [ipsrc|ip|netmask|gateway|vlan]
+       rspconfig <noderange> admin_passwd=<currentpasswd,newpasswd>
        rspconfig <noderange> dump [-l|--list] [-g|--generate] [-c|--clear {<id>|all}] [-d|--download {<id>|all}]
+       rspconfig <noderange> gard -c|--clear
+       rspconfig <noderange> [hostname|ntpservers]
+       rspconfig <noderange> [hostname=<*|hostname>|ntpservers=<ntpservers>]
+       rspconfig <noderange> sshcfg
 ",
     "rspconfig.begin" =>
    "BMC/MPA Common:
@@ -593,6 +611,13 @@ $usage{"rinv"} = $usage{"rinv.common"} .
 
 $usage{"rinv.openbmc"} = $usage{"rinv.common"} .
                       $usage{"rinv.openbmc"};
+
+$usage{"rbeacon"} = $usage{"rbeacon.common"} .
+                      $usage{"rbeacon.begin"} .
+                      $usage{"rbeacon.openbmc"};
+
+$usage{"rbeacon.openbmc"} = $usage{"rbeacon.common"} .
+                      $usage{"rbeacon.openbmc"};
 
 $usage{"rvitals"} = $usage{"rvitals.common"} . 
                       $usage{"rvitals.begin"} .

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -76,7 +76,7 @@ my %usage = (
     "rbeacon.common" =>
       "Usage: 
     Common:
-       rbeacon [-h|--help|-v|--version]
+       rbeacon [-h|--help|-v|--version|-V|--verbose]
     ",
     "rbeacon.begin" =>
     "BMC specific:

--- a/xCAT-client/pods/man1/rbeacon.1.pod
+++ b/xCAT-client/pods/man1/rbeacon.1.pod
@@ -5,7 +5,7 @@ B<rbeacon> - Turns beacon on/off/blink or gives status of a node or noderange.
 
 =head1 SYNOPSIS
 
-B<rbeacon> [B<-h>|B<--help>|B<-v>|B<--version>]
+B<rbeacon> [B<-h>|B<--help>|B<-v>|B<--version>|B<-V>|B<--verbose>]
 
 =head2 BMC (using IPMI):
 

--- a/xCAT-client/pods/man1/rbeacon.1.pod
+++ b/xCAT-client/pods/man1/rbeacon.1.pod
@@ -5,11 +5,19 @@ B<rbeacon> - Turns beacon on/off/blink or gives status of a node or noderange.
 
 =head1 SYNOPSIS
 
+B<rbeacon> [B<-h>|B<--help>|B<-v>|B<--version>]
+
+=head2 BMC (using IPMI):
+
 B<rbeacon> I<noderange> {B<on>|B<blink>|B<off>|B<stat>}
 
-B<rbeacon> [B<-h>|B<--help>]
+=head2 OpenPOWER BMC (using IPMI):
 
-B<rbeacon> {B<-v>|B<--version>}
+B<rbeacon> I<noderange> {B<on>|B<blink>|B<off>|B<stat>}
+
+=head2 OpenPOWER OpenBMC:
+
+B<rbeacon> I<noderange> {B<on>|B<off>}
 
 
 =head1 DESCRIPTION

--- a/xCAT-client/pods/man1/rsetboot.1.pod
+++ b/xCAT-client/pods/man1/rsetboot.1.pod
@@ -7,7 +7,7 @@ B<rsetboot> - Sets the boot device to be used for BMC-based servers for the next
 
 B<rsetboot> I<noderange> [B<hd>|B<net>|B<cd>|B<default>|B<stat>] [B<-u>] [B<-p>]
 
-B<rsetboot> [B<-h>|B<--help>|B<-v>|B<--version>]
+B<rsetboot> [B<-h>|B<--help>|B<-v>|B<--version>|B<-V>|B<--verbose>]
 
 
 =head1 DESCRIPTION

--- a/xCAT-client/pods/man1/rsetboot.1.pod
+++ b/xCAT-client/pods/man1/rsetboot.1.pod
@@ -40,7 +40,7 @@ Display the current boot setting.
 
 =item B<-u>
 
-To specify the next boot mode to be "UEFI Mode". 
+To specify the next boot mode to be "UEFI Mode". (Not supported for OpenBMC)
 
 =item B<-p>
 

--- a/xCAT-client/pods/man1/rspconfig.1.pod
+++ b/xCAT-client/pods/man1/rspconfig.1.pod
@@ -4,7 +4,7 @@ B<rspconfig> - Configures nodes' service processors
 
 =head1 SYNOPSIS
 
-B<rspconfig> [B<-h>|B<--help>|B<-v>|B<--version>]
+B<rspconfig> [B<-h>|B<--help>|B<-v>|B<--version>|B<-V>|B<--verbose>]
 
 =head2 BMC/MPA specific:
 

--- a/xCAT-client/pods/man1/rspconfig.1.pod
+++ b/xCAT-client/pods/man1/rspconfig.1.pod
@@ -24,7 +24,9 @@ B<rspconfig> I<noderange> B<garp>=I<time>
 
 =head2 OpenBMC specific:
 
-B<rspconfig> I<noderange> {B<ipsrc>|B<ip>|B<netmask>|B<gateway>|B<hostname>|B<vlan>|B<sshcfg>}
+B<rspconfig> I<noderange> {B<ipsrc>|B<ip>|B<netmask>|B<gateway>|B<vlan>}
+
+B<rspconfig> I<noderange> B<admin_passwd>={I<currentpasswd,newpasswd>}
 
 B<rspconfig> I<noderange> B<autoreboot>
 
@@ -36,6 +38,18 @@ B<rspconfig> I<noderange> B<bootmode={safe|regular|setup}>
 
 B<rspconfig> I<noderange> B<dump> [B<-l>|B<--list>] [B<-g>|B<--generate>] [B<-c>|B<--clear> {I<id> | B<all>}] [B<-d>|B<--download> {I<id> | B<all>}]
 
+B<rspconfig> I<noderange> B<gard -c|--clear>
+
+B<rspconfig> I<noderange> B<ip=dhcp>
+
+B<rspconfig> I<noderange> B<hostname>
+
+B<rspconfig> I<noderange> B<hostname>={* | I<name>}
+
+B<rspconfig> I<noderange> B<ntpservers>
+
+B<rspconfig> I<noderange> B<ntpservers>={I<ntpservers>}
+
 B<rspconfig> I<noderange> B<powerrestorepolicy>
 
 B<rspconfig> I<noderange> B<powerrestorepolicy={always_on|restore|always_off}>
@@ -43,6 +57,8 @@ B<rspconfig> I<noderange> B<powerrestorepolicy={always_on|restore|always_off}>
 B<rspconfig> I<noderange> B<powersupplyredundancy>
 
 B<rspconfig> I<noderange> B<powersupplyredundancy={disabled|enabled}>
+
+B<rspconfig> I<noderange> B<sshcfg>
 
 B<rspconfig> I<noderange> B<timesyncmethod>
 
@@ -106,9 +122,9 @@ B<rspconfig> I<noderange> B<HMC_passwd>={I<currentpasswd,newpasswd>}
 
 B<rspconfig> I<noderange> B<admin_passwd>={I<currentpasswd,newpasswd>}
 
-B<rspconfig> I<noderange> B<general_passwd>={B<currentpasswd,newpasswd>}
+B<rspconfig> I<noderange> B<general_passwd>={I<currentpasswd,newpasswd>}
 
-B<rspconfig> I<noderange> *B<_passwd>={B<currentpasswd,newpasswd>}
+B<rspconfig> I<noderange> *B<_passwd>={I<currentpasswd,newpasswd>}
 
 B<rspconfig> I<noderange> {I<hostname>}
 
@@ -161,9 +177,9 @@ B<rspconfig> I<noderange> B<HMC_passwd>={I<currentpasswd,newpasswd>}
 
 B<rspconfig> I<noderange> B<admin_passwd>={I<currentpasswd,newpasswd>}
 
-B<rspconfig> I<noderange> B<general_passwd>={B<currentpasswd,newpasswd>}
+B<rspconfig> I<noderange> B<general_passwd>={I<currentpasswd,newpasswd>}
 
-B<rspconfig> I<noderange> *B<_passwd>={B<currentpasswd,newpasswd>}
+B<rspconfig> I<noderange> *B<_passwd>={I<currentpasswd,newpasswd>}
 
 B<rspconfig> I<noderange> {B<sysname>}
 
@@ -197,9 +213,9 @@ B<rspconfig> I<noderange> B<HMC_passwd>={I<currentpasswd,newpasswd>}
 
 B<rspconfig> I<noderange> B<admin_passwd>={I<currentpasswd,newpasswd>}
 
-B<rspconfig> I<noderange> B<general_passwd>={B<currentpasswd,newpasswd>}
+B<rspconfig> I<noderange> B<general_passwd>={I<currentpasswd,newpasswd>}
 
-B<rspconfig> I<noderange> *B<_passwd>={B<currentpasswd,newpasswd>}
+B<rspconfig> I<noderange> *B<_passwd>={I<currentpasswd,newpasswd>}
 
 B<rspconfig> I<noderange> {B<frame>}
 
@@ -285,6 +301,10 @@ Change the passwords of the userids B<HMC>, B<admin> and B<general> for CEC/Fram
 =item B<frequency>
 
 The NTP update frequency (in minutes).
+
+=item B<gard -c|--clear>
+
+Clear gard file. [OpenBMC]
 
 =item B<garp>=I<time>
 
@@ -418,6 +438,10 @@ Enable or disable NTP (enable|disable).
 =item B<ntpserver>
 
 Get or set NTP server IP address or name.
+
+=item B<ntpservers>
+
+Get or set NTP servers name. [OpenBMC]
 
 =item B<pd1>={B<nonred>|B<redwoperf>|B<redwperf>}
 


### PR DESCRIPTION
related commands: rbeacon, rsetboot, rspconfig

doc url:

http://10.3.5.4/install/build/html/guides/admin-guides/references/man1/rspconfig.1.html

Output of Usage:
```
# rbeacon -h
Usage:
    Common:
       rbeacon [-h|--help|-v|--version|-V|--verbose]
    BMC specific:
       rbeacon [on|blink|off|stat]
    OpenPOWER (IPMI) specific:
       rbeacon [on|blink|off|stat]
    OpenPOWER (OpenBMC) specific:
       rbeacon [on|off]

# rbeacon f6u17 -h
Usage:
    Common:
       rbeacon [-h|--help|-v|--version|-V|--verbose]
    OpenPOWER (OpenBMC) specific:
       rbeacon [on|off]

# rspconfig f6u17 -h
Usage:
   Common:
       rspconfig [-h|--help|-v|--version|-V|--verbose]
   OpenBMC specific:
       rspconfig <noderange> [ipsrc|ip|netmask|gateway|vlan]
       rspconfig <noderange> admin_passwd=<currentpasswd,newpasswd>
       rspconfig <noderange> dump [-l|--list] [-g|--generate] [-c|--clear {<id>|all}] [-d|--download {<id>|all}]
       rspconfig <noderange> gard -c|--clear
       rspconfig <noderange> [hostname|ntpservers]
       rspconfig <noderange> [hostname=<*|hostname>|ntpservers=<ntpservers>]
       rspconfig <noderange> sshcfg
       rspconfig <noderange> powerrestorepolicy
       rspconfig <noderange> powerrestorepolicy={always_on|restore|always_off}
       rspconfig <noderange> powersupplyredundancy
       rspconfig <noderange> powersupplyredundancy={disabled|enabled}
       rspconfig <noderange> timesyncmethod
       rspconfig <noderange> timesyncmethod={ntp|manual}
       rspconfig <noderange> bootmode
       rspconfig <noderange> bootmode={safe|regular|setup}
       rspconfig <noderange> autoreboot
       rspconfig <noderange> autoreboot={0|1}
```