### PR TITLE
Fix the git short commit id to 7-byte long

### DIFF
--- a/build-ubunturepo
+++ b/build-ubunturepo
@@ -183,8 +183,8 @@ then
         short_short_ver=`cat Version|cut -d. -f 1`
         build_time=`date`
         build_machine=`hostname`
-        commit_id=`git rev-parse --short HEAD`
         commit_id_long=`git rev-parse HEAD`
+        commit_id="${commit_id_long:0:7}"
 
         package_dir_name=debs$REL
         #TODO: define the core path and tarball name

--- a/buildcore.sh
+++ b/buildcore.sh
@@ -188,8 +188,8 @@ function setversionvars {
     SHORTSHORTVER=`echo $VER|cut -d. -f 1`
     BUILD_TIME=`date`
     BUILD_MACHINE=`hostname`
-    COMMIT_ID=`git rev-parse --short HEAD`
     COMMIT_ID_LONG=`git rev-parse HEAD`
+    COMMIT_ID="${COMMIT_ID_LONG:0:7}"
     XCAT_RELEASE="snap$(date '+%Y%m%d%H%M')"
     echo "$XCAT_RELEASE" >Release
 }


### PR DESCRIPTION
Since different git version generate different output format for `git rev-parse --short HEAD`. In this patch, fix the COMMIT_ID to 7-byte long.