### PR TITLE
Failed to discover nodes as the discovery method is set  to undef by wrong

### DIFF
--- a/xCAT-genesis-scripts/usr/bin/dodiscovery
+++ b/xCAT-genesis-scripts/usr/bin/dodiscovery
@@ -163,7 +163,7 @@ if [ "$PLATFORM" != "unknown" ]; then
         echo "<platform>$PLATFORM</platform>" >> /tmp/discopacket
 fi
 
-LANCHAN=$(ipmitool sol info |awk '/Payload Channel/{print $4}')
+LANCHAN=$(ipmitool sol info 2>/dev/null|awk '/Payload Channel/{print $4}')
 IsStatic=`ipmitool lan print $LANCHAN | grep 'IP Address Source' | grep 'Static'`
 if [ "$IsStatic" ]; then
     BMCIPADDR=`ipmitool lan print $LANCHAN | grep 'IP Address' | grep -v 'IP Address Source' | cut -d ":" -f2 | sed 's/ //'`

--- a/xCAT-genesis-scripts/usr/bin/minixcatd.awk
+++ b/xCAT-genesis-scripts/usr/bin/minixcatd.awk
@@ -11,12 +11,16 @@ BEGIN {
                     quit="yes"
                     system("echo \"" $0 "\" > /restart")
                     close(listener)
+                    system("rm -rf /processing")
+                    system("logger -s -t 'xcat.genesis.minixcatd' -p local4.info 'The request is processed by xCAT master successfully.'")
                 }else if(match($0,"processing")){
                     print "processing request" |& listener
                     system("echo \"" $0 "\" > /processing")
+                    system("logger -s -t 'xcat.genesis.minixcatd' -p local4.info 'The request is processing by xCAT master...'")
                 }else if(match($0,"processed")){
                     print "finished request process" |& listener
                     system("rm -rf /processing")
+                    system("logger -s -t 'xcat.genesis.minixcatd' -p local4.warning 'The request is already processed by xCAT master, but not matched.'")
                 }
            }
            close(listener)

--- a/xCAT-server/lib/xcat/plugins/aaadiscovery.pm
+++ b/xCAT-server/lib/xcat/plugins/aaadiscovery.pm
@@ -36,12 +36,16 @@ sub process_request {
             $arptable = `/sbin/arp -n`;
         }
         my @arpents = split /\n/, $arptable;
-        my $mac = "$req->{mtm}->[0]*$req->{serial}->[0]";
+        my $mac;
         foreach (@arpents) {
             if (m/^($client_ip)\s+\S+\s+(\S+)\s/) {
                 $mac = $2;
                 last;
             }
+        }
+        unless ($mac) {
+            xCAT::MsgUtils->message("S", "xcat.discovery.aaadiscovery: Failed to get MAC address for $client_ip in arp cache.");
+            $mac = "$req->{mtm}->[0]*$req->{serial}->[0]";
         }
 
         xCAT::MsgUtils->message("S", "xcat.discovery.aaadiscovery: ($mac) Got a discovery request, attempting to discover the node...");

--- a/xCAT-server/lib/xcat/plugins/nodediscover.pm
+++ b/xCAT-server/lib/xcat/plugins/nodediscover.pm
@@ -459,7 +459,7 @@ sub process_request {
     if (defined($request->{bmcinband})) {
         if (defined($request->{bmc_node}) and defined($request->{bmc_node}->[0])) {
             my $bmc_node = $request->{bmc_node}->[0];
-            xCAT::MsgUtils->message("S", "xcat.discovery.nodediscover: Removing discovered node definition: $bmc_node...");
+            xCAT::MsgUtils->message("S", "xcat.discovery.nodediscover: Removing discovered BMC nodes definition: $bmc_node...");
             my $rmcmd = "rmdef $bmc_node";
             xCAT::Utils->runcmd($rmcmd, 0);
             if ($::RUNCMD_RC != 0)
@@ -495,7 +495,7 @@ sub process_request {
         Timeout  => '1',
         Proto    => 'tcp'
     );
-    unless ($sock) { xCAT::MsgUtils->message("S", "xcat.discovery.nodediscover: Failed to notify $clientip that it's actually $node."); return; }
+    unless ($sock) { xCAT::MsgUtils->message("S", "xcat.discovery.nodediscover: Failed to notify $clientip that it's actually $node. $node has not been discovered."); return; }
     print $sock $restartstring;
     close($sock);
 

--- a/xCAT-server/lib/xcat/plugins/switch.pm
+++ b/xCAT-server/lib/xcat/plugins/switch.pm
@@ -371,7 +371,7 @@ sub process_request {
             my $request = {%$req};
             $request->{command}   = ['discovered'];
             $request->{noderange} = [$node];
-            $request->{bmc_node}  = [$bmc_node];
+            $request->{bmc_node}  = [$bmc_node] if $bmc_node;
             $doreq->($request);
             if (defined($request->{error})) {
                 $req->{error}->[0] = '1';

--- a/xCAT-server/lib/xcat/plugins/zvmdiscovery.pm
+++ b/xCAT-server/lib/xcat/plugins/zvmdiscovery.pm
@@ -852,7 +852,7 @@ sub getSiteVal {
 #-------------------------------------------------------
 sub handled_commands {
     return {
-        findme             => 'zvmdiscovery',
+        #findme             => 'zvmdiscovery',   # Not handle findme in this plugin, #4860
         #nodediscoverdef   => 'zvmdiscovery',    # Handled by sequential discovery
         nodediscoverls     => 'zvmdiscovery',
         nodediscoverstart  => 'zvmdiscovery',
@@ -1710,6 +1710,11 @@ sub process_request {
     my $args = $request->{arg};
 
     if ($command eq "findme"){
+        if (defined($request->{discoverymethod}) and defined($request->{discoverymethod}->[0]) and ($request->{discoverymethod}->[0] ne 'undef')) {
+
+            # The findme request had been processed by other module, just return
+            return;
+        }
         findme( $request, $callback, $request_command );
     } elsif ($command eq "nodediscoverls") {
         nodediscoverls( $callback, $args );


### PR DESCRIPTION
Failed to discover nodes as the discovery method is set to undef by wrong (#4860)

 - when method is set, zvmdiscovery plugin will not handle findme
 - not change request if no temp discovered bmc nodes, to avoid the confusing error message
 - Ignore the `ipmitool sol info` error output

UT:
```
Feb 28 05:03:34 mid05tor12cn16 [localhost] xcat.genesis.dodiscovery: Beginning node discovery process...
Feb 28 05:03:34 mid05tor12cn16 [localhost] xcat.genesis.dodiscovery: Waiting for nics to get addresses
Feb 28 05:03:34 mid05tor12cn16 [localhost] xcat.genesis.dodiscovery: Network configuration complete, commencing transmit of discovery packets
Feb 28 05:03:34 mid05tor12cn16 [localhost] xcat.genesis.dodiscovery: seems the processing of my findme request cost more than 180, send new findme request
Feb 28 05:03:34 mid05tor12cn16 [localhost] xcat.genesis.dodiscovery: Beginning echo information to discovery packet file...
Feb 28 05:03:38 mid05tor12cn16 [localhost] xcat.genesis.dodiscovery: Discovery packet file is ready.
Feb 28 05:03:38 mid05tor12cn16 [localhost] xcat.genesis.dodiscovery: Sending the discovery packet to xCAT (briggs01:3001)...
Feb 28 05:03:38 mid05tor12cn16 [localhost] xcat.genesis.dodiscovery: Sleeping 5 seconds...
Feb 28 05:03:36 briggs01 xcat[127572]: xcatd: Processing discovery request from 172.12.139.16
Feb 28 05:03:36 briggs01 xcat[127572]: xcat.discovery.aaadiscovery: (AA:BB:CC:DD:EE:FF) Got a discovery request, attempting to discover the node...
Feb 28 05:03:37 briggs01 xcat[127572]: xcat.discovery.blade: (AA:BB:CC:DD:EE:FF) Warning: Could not find any nodes using blade-based discovery
Feb 28 10:16:50 mid05tor12 sshd[17664]: Accepted publickey for root from 172.11.253.27 port 39782 ssh2: RSA ---
Feb 28 10:16:50 mid05tor12 sshd[17664]: Received disconnect from 172.11.253.27: 11: disconnected by user
Feb 28 05:03:39 briggs01 xcat[127572]: refresh_table ElapsedTime:2 sec
Feb 28 05:03:39 briggs01 xcat[127572]: xcat.discovery.switch: (AA:BB:CC:DD:EE:FF) Found node: mid05tor12cn16
Feb 28 05:03:40 briggs01 xcat[127572]: xcat.discovery.nodediscover: mid05tor12cn16 has been discovered
Feb 28 05:03:40 briggs01 xcat[127572]: xcat.discovery.zzzdiscovery: (AA:BB:CC:DD:EE:FF) Successfully discovered the node using switch discovery method.
Feb 28 05:03:43 mid05tor12cn16 [localhost] xcat.genesis.dodiscovery: Restart network interfaces...
Feb 28 05:03:43 mid05tor12cn16 [localhost] dhclient[29261]: DHCPRELEASE on enP5p1s0f0 to 172.12.253.27 port 67 (xid=0x66f6c6e6)
Feb 28 05:03:41 briggs01 dhcpd: DHCPRELEASE of 172.12.139.16 from AA:BB:CC:DD:EE:FF via enP34p1s0f0.12 (not found)
Feb 28 05:03:42 briggs01 dhcpd: DHCPDISCOVER from AA:BB:CC:DD:EE:FF via enP34p1s0f0.12
Feb 28 05:03:42 briggs01 dhcpd: DHCPOFFER on 172.12.139.16 to AA:BB:CC:DD:EE:FF via enP34p1s0f0.12
Feb 28 05:03:42 briggs01 dhcpd: DHCPREQUEST for 172.12.139.16 (172.12.253.27) from AA:BB:CC:DD:EE:FF via enP34p1s0f0.12
Feb 28 05:03:42 briggs01 dhcpd: DHCPACK on 172.12.139.16 to AA:BB:CC:DD:EE:FF via enP34p1s0f0.12
```

check by `nodediscoverls`,  now the method is `switch`.
