### PR TITLE
Add makegocons -C|--cleanup to remove entries that do not exist

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rmdef.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rmdef.1.rst
@@ -90,7 +90,7 @@ OPTIONS
 
 \ **-C|-**\ **-cleanup**\ 
  
- Perform additional cleanup by running \ **nodeset offline**\  and \ **makeconservercf -d**\  on the objects specified in the \ *noderange*\ .
+ Perform additional cleanup by running \ **nodeset offline**\, \ **makeconservercf -d**\ and \ **makegocons --cleanup**\ on the objects specified in the \ *noderange*\ .
  
 
 

--- a/docs/source/guides/admin-guides/references/man8/makegocons.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/makegocons.8.rst
@@ -21,6 +21,8 @@ SYNOPSIS
 
 \ **makegocons**\  [\ **-V|-**\ **-verbose**\ ] [\ **-d|-**\ **-delete**\ ] [\ **-q|-**\ **-query**\ ] [\ *noderange*\ ]
 
+\ **makegocons**\  [\ **-V|-**\ **-verbose**\ ] [\ **-C|-**\ **-cleanup**\ ]
+
 
 ***********
 DESCRIPTION
@@ -67,6 +69,12 @@ OPTIONS
 \ **-d|-**\ **-delete**\ 
  
  Delete rather than add or refresh the nodes specified as a noderange.
+ 
+
+
+\ **-C|-**\ **-cleanup**\ 
+ 
+ Remove the entries for the nodes whose definitions have been removed from xCAT db.
  
 
 

--- a/xCAT-client/pods/man1/rmdef.1.pod
+++ b/xCAT-client/pods/man1/rmdef.1.pod
@@ -58,7 +58,7 @@ A set of comma delimited object types.
 
 =item B<-C|--cleanup>
 
-Perform additional cleanup by running B<nodeset offline> and B<makeconservercf -d> on the objects specified in the I<noderange>.
+Perform additional cleanup by running B<nodeset offline>, B<makeconservercf -d> and B<makegocons --cleanup> on the objects specified in the I<noderange>.
 
 =item B<-V|--verbose>
 

--- a/xCAT-client/pods/man8/makegocons.8.pod
+++ b/xCAT-client/pods/man8/makegocons.8.pod
@@ -6,6 +6,7 @@ B<makegocons> - Register or unregister the node in the goconserver service
 
 B<makegocons> [B<-V|--verbose>] [B<-d|--delete>] [B<-q|--query>] [I<noderange>]
 
+B<makegocons> [B<-V|--verbose>] [B<-C|--cleanup>]
 
 =head1 DESCRIPTION
 
@@ -47,6 +48,10 @@ B<Note:> goconserver only support the systemd based systems. It has been integra
 =item B<-d|--delete>
 
 Delete rather than add or refresh the nodes specified as a noderange.
+
+=item B<-C|--cleanup>
+
+Remove the entries for the nodes whose definitions have been removed from xCAT db.
 
 =item B<-q|--query>
 

--- a/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
+++ b/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
@@ -4423,6 +4423,12 @@ sub defrm
                 command => ['makeconservercf'],
                 node => [@allnodes],
                 arg => ['-d'],}, $doreq, 0, 1);
+            if (-x "/usr/bin/goconserver") {
+                require xCAT::Goconserver;
+                if (xCAT::Goconserver::is_goconserver_running()) {
+                    xCAT::Goconserver::cleanup_nodes(undef);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
`rmdef` command do not help clean up the recousrces that related to
the node when removing the node. this is a technical debt. This patch
is only a work around to add -C|--cleanup option to help remove the
entries in goconserver.

fix-issue: https://github.com/xcat2/goconserver/issues/29
implement: #4848
```
    [root@c910f05c01bc02k74 ~]# cat testfile | mkdef -z
    1 object definitions have been created or modified.
    [root@c910f05c01bc02k74 ~]# makegocons testnode
    testnode: Created
    [root@c910f05c01bc02k74 ~]# rmdef testnode
    1 object definitions have been removed.
    [root@c910f05c01bc02k74 ~]# congo list
    c460c022 (host: c910f05c01bc02k74, state: error)
    kvmguest1 (host: c910f05c01bc02k74, state: connected)
    mid05tor12cn11 (host: c910f05c01bc02k74, state: error)
    simulator_test0 (host: c910f05c01bc02k74, state: connected)
    simulator_test1 (host: c910f05c01bc02k74, state: connected)
    testnode (host: c910f05c01bc02k74, state: connected)
    [root@c910f05c01bc02k74 ~]# makegocons --cleanup
    testnode: Deleted
 ```