### PR TITLE
[OpenBMC] The return code on error should be 1 instead of 0

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/common/utils.py
+++ b/xCAT-openbmc-py/lib/python/agent/common/utils.py
@@ -92,8 +92,11 @@ class Messager(object):
     def warn(self, msg):
         self.logger.warn(msg)
 
-    def error(self, msg):
-        self.logger.error(msg)
+    def error(self, msg, node=''):
+        if node:
+            self.logger.error('%s: Error: %s' % (node, msg))
+        else:
+            self.logger.error('Error: %s' % msg)
 
     def syslog(self, msg):
         pass

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_beacon.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_beacon.py
@@ -27,9 +27,8 @@ class OpenBMCBeaconTask(ParallelNodesCommand):
         try:
             obmc.login()
             obmc.set_beacon_state(state)
-            result = '%s: %s' % (node, state)
+            self.callback.info('%s: %s' % (node, state))
 
         except (SelfServerException, SelfClientException) as e:
-            result = '%s: %s'  % (node, e.message)
+            self.callback.error(e.message, node)
 
-        self.callback.info(result)

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
@@ -227,11 +227,11 @@ rmdir \"/tmp/$userid\" \n")
             ssh_client.set_missing_host_key_policy(paramiko.MissingHostKeyPolicy())
             ssh_client.connect(nodeinfo['bmcip'], username=nodeinfo['username'], password=nodeinfo['password'])
         except (NoValidConnectionsError) as e:
-            return self.callback.error("%s: Unable to connect to bmc %s" % (node, nodeinfo['bmcip']))
+            return self.callback.error("Unable to connect to bmc %s" % nodeinfo['bmcip'], node)
         if not ssh_client.get_transport().is_active():
-            return self.callback.error("%s: SSH session to bmc %s is not active" % (node, nodeinfo['bmcip']))
+            return self.callback.error("SSH session to bmc %s is not active" % nodeinfo['bmcip'], node)
         if not ssh_client.get_transport().is_authenticated():
-            return self.callback.error("%s: SSH session to bmc %s is not authenticated" % (node, nodeinfo['bmcip']))
+            return self.callback.error("SSH session to bmc %s is not authenticated" % nodeinfo['bmcip'], node)
         ssh_client.exec_command("/bin/mkdir -p %s\n" % tmp_remote_dir)
         scp = SCPClient(ssh_client.get_transport())
         scp.put(self.copy_sh_file, tmp_remote_dir + "copy.sh")

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_eventlog.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_eventlog.py
@@ -49,7 +49,7 @@ class OpenBMCEventlogTask(ParallelNodesCommand):
                 eventlog_info += eventlog_info_dict[key]
 
         except (SelfServerException, SelfClientException) as e:
-            self.callback.info('%s: %s'  % (node, e.message))
+            self.callback.error(e.message, node)
 
         return eventlog_info
 

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_inventory.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_inventory.py
@@ -93,7 +93,7 @@ class OpenBMCInventoryTask(ParallelNodesCommand):
                 self.callback.info( '%s: %s' % (node, info))
 
         except (SelfServerException, SelfClientException) as e:
-            self.callback.info('%s: %s'  % (node, e.message))
+            self.callback.error(e.message, node)
 
         return inventory_info 
 
@@ -113,7 +113,7 @@ class OpenBMCInventoryTask(ParallelNodesCommand):
                 self.callback.info( '%s: %s' % (node, info))
 
         except (SelfServerException, SelfClientException) as e:
-            self.callback.info('%s: %s'  % (node, e.message))
+            self.callback.error(e.message, node)
 
         return firm_info
 

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_sensor.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_sensor.py
@@ -88,7 +88,7 @@ class OpenBMCSensorTask(ParallelNodesCommand):
                 self.callback.info( '%s: %s' % (node, info))
 
         except (SelfServerException, SelfClientException) as e:
-            self.callback.info('%s: %s'  % (node, e.message))
+            self.callback.error(e.message, node)
 
         return sensor_info
 
@@ -111,7 +111,7 @@ class OpenBMCSensorTask(ParallelNodesCommand):
                 self.callback.info( '%s: %s' % (node, info))
 
         except (SelfServerException, SelfClientException) as e:
-            self.callback.info('%s: %s'  % (node, e.message))
+            self.callback.error(e.message, node)
 
         return beacon_info
                 

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_setboot.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_setboot.py
@@ -30,12 +30,11 @@ class OpenBMCBootTask(ParallelNodesCommand):
             obmc.login()
             state = obmc.get_boot_state()
 
-            result = '%s: %s' % (node, state)
+            self.callback.info('%s: %s' % (node, state))
 
         except (SelfServerException, SelfClientException) as e:
-            result = '%s: %s'  % (node, e.message)
+            self.callback.error(e.message, node)
 
-        self.callback.info(result)
         return state
 
     def set_state(self, state, persistant, **kw):
@@ -55,10 +54,9 @@ class OpenBMCBootTask(ParallelNodesCommand):
 
             state = obmc.get_boot_state()
 
-            result = '%s: %s' % (node, state)
+            self.callback.info('%s: %s' % (node, state))
 
         except (SelfServerException, SelfClientException) as e:
-            result = '%s: %s'  % (node, e.message)
+            self.callback.error(e.message, node)
 
-        self.callback.info(result)
 

--- a/xCAT-openbmc-py/lib/python/agent/xcatagent/server.py
+++ b/xCAT-openbmc-py/lib/python/agent/xcatagent/server.py
@@ -36,8 +36,8 @@ class XCATMessager(utils.Messager):
         d = {'type': MSG_TYPE, 'msg': {'type': 'warning', 'data': msg}}
         self._send(d)
 
-    def error(self, msg):
-        d = {'type': MSG_TYPE, 'msg': {'type': 'error', 'data': msg}}
+    def error(self,  msg, node=''):
+        d = {'type': MSG_TYPE, 'msg': {'type': 'error', 'node': node, 'data': msg}}
         self._send(d)
 
     def syslog(self, msg):

--- a/xCAT-server/lib/perl/xCAT/OPENBMC.pm
+++ b/xCAT-server/lib/perl/xCAT/OPENBMC.pm
@@ -109,7 +109,7 @@ sub handle_message {
         } elsif ($msg->{type} eq 'warning') {
             xCAT::MsgUtils->message("W", { data => [$msg->{data}] }, $callback);
         } elsif ($msg->{type} eq 'error'){
-            xCAT::MsgUtils->message("E", { data => [$msg->{data}] }, $callback);
+            xCAT::SvrUtils::sendmsg([ 1, $msg->{data} ], $callback, $msg->{node});
         } elsif ($msg->{type} eq 'syslog'){
             xCAT::MsgUtils->message("S", $msg->{data});
         }


### PR DESCRIPTION
#4854 

If has error, exit code is '1'.

```
# rinv f6u17
f6u17: Error: BMC did not respond. Validate BMC configuration and retry the command.
# echo $?
1
```

The file **openbmc_power.py** has not modified.