### PR TITLE
add site attribute 'openbmc_perl_commands' as switch to run openbmc command in perl

### DIFF
--- a/perl-xCAT/xCAT/Utils.pm
+++ b/perl-xCAT/xCAT/Utils.pm
@@ -4968,5 +4968,36 @@ sub console_sleep {
     sleep($time);
 }
 
+#--------------------------------------------------------------------------------
+
+=head3 is_support_in_perl 
+      Based on the specified module and command, check whether included in site attribute cmds_in_perl
+=cut
+
+#--------------------------------------------------------------------------------
+sub is_support_in_perl {
+    my ($class, $module, $command) = @_;
+    my @entries = xCAT::TableUtils->get_site_attribute("cmds_in_perl");
+    my $site_entry = $entries[0];
+    if ($site_entry) {
+        if ($site_entry eq 'NO') {
+            return (0, '');
+        } elsif ($site_entry eq 'YES') {
+            return (1, '');
+        } elsif ($site_entry =~ /^(EXCEPT:)?(\w+\.\w+,?)+$/) {
+            my $except = $1;
+            if ($site_entry =~ $module.'.'.$command) {
+                return (($except ? 0 : 1), '');
+            } else {
+                return (($except ? 1 : 0), '');
+            }
+        } else {
+            return (-1, "The value format is invalid, shall be \"$module.$command,...\" or  \
+                         \"EXCEPT:$module.$command,...\"");
+        }
+    } else {
+        return (0, '');
+    }
+}
 
 1;

--- a/xCAT-server/lib/perl/xCAT/OPENBMC.pm
+++ b/xCAT-server/lib/perl/xCAT/OPENBMC.pm
@@ -22,7 +22,8 @@ use File::Path;
 use Fcntl ":flock";
 use IO::Socket::UNIX qw( SOCK_STREAM );
 use xCAT_monitoring::monitorctrl;
-
+use xCAT::TableUtils;
+ 
 my $LOCK_DIR = "/var/lock/xcat/";
 my $LOCK_PATH = "/var/lock/xcat/agent.lock";
 my $AGENT_SOCK_PATH = "/var/run/xcat/agent.sock";
@@ -196,6 +197,21 @@ sub wait_agent {
     if ($? >> 8 != 0) {
         xCAT::MsgUtils->message("E", { data => ["python agent exited unexpectedly. See $PYTHON_LOG_PATH for more details."] }, $callback);
     }
+}
+
+sub is_openbmc_perl {
+    my @entries    = xCAT::TableUtils->get_site_attribute("openbmc_perl_commands");
+    my $site_entry = $entries[0];
+    if (defined($site_entry)) {
+        if ($site_entry eq "YES") {
+            return "ALL";
+        } elsif ($site_entry eq "NO") {
+            return "NO";
+        } else {
+            return $site_entry;
+        }
+    }
+    return "NO";
 }
 
 sub is_openbmc_python {

--- a/xCAT-server/lib/perl/xCAT/OPENBMC.pm
+++ b/xCAT-server/lib/perl/xCAT/OPENBMC.pm
@@ -199,21 +199,6 @@ sub wait_agent {
     }
 }
 
-sub is_openbmc_perl {
-    my @entries    = xCAT::TableUtils->get_site_attribute("openbmc_perl_commands");
-    my $site_entry = $entries[0];
-    if (defined($site_entry)) {
-        if ($site_entry eq "YES") {
-            return "ALL";
-        } elsif ($site_entry eq "NO") {
-            return "NO";
-        } else {
-            return $site_entry;
-        }
-    }
-    return "NO";
-}
-
 sub is_openbmc_python {
     my $environment = shift;
     $environment = shift if (($environment) && ($environment =~ /OPENBMC/));

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -758,20 +758,20 @@ sub preprocess_request {
 
     $callback  = shift;
     my $command   = $request->{command}->[0];
-    my $python_env = xCAT::OPENBMC->is_openbmc_python($request->{environment});
+    my $perl_env = xCAT::OPENBMC->is_openbmc_perl();
     # Process command in this module only if PYTHON env is not ALL or command is
     # listed in the PYTHON env list (without EXCEPT: prefix. 
     # All other cases => return
     SWITCH: {
-        if ($python_env eq "ALL") {$request = {}; return;}
-        if ($python_env eq "NO")  {last SWITCH;}
-        if ($python_env !~ $command) {
-            if ($python_env =~ /^EXCEPT:/) {$request = {}; return;}
-            else {last SWITCH;}
-        }
-        if ($python_env =~ $command) {
-            if ($python_env =~ /^EXCEPT:/) {last SWITCH;}
+        if ($perl_env eq "NO")  {$request = {}; return;}
+        if ($perl_env eq "ALL") {last SWITCH;}
+        if ($perl_env !~ $command) {
+            if ($perl_env =~ /^EXCEPT:/) {last SWITCH}
             else {$request = {}; return;}
+        }
+        if ($perl_env =~ $command) {
+            if ($perl_env =~ /^EXCEPT:/) {$request = {}; return;}
+            else {last SWITCH;}
         }
     }
 

--- a/xCAT-server/lib/xcat/plugins/openbmc2.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc2.pm
@@ -63,21 +63,21 @@ sub preprocess_request {
     $callback  = shift;
 
     my $command   = $request->{command}->[0];
-    my $python_env = xCAT::OPENBMC->is_openbmc_python($request->{environment});
+    my $perl_env = xCAT::OPENBMC->is_openbmc_perl();
     # Process command in this module only if PYTHON env is not NO or 
     # command is listed in the PYTHON env list (without EXCEPT: prefix). 
     # All other cases => return
 
     SWITCH: {
-        if ($python_env eq "NO")  {$request = {}; return;}
-        if ($python_env eq "ALL") {last SWITCH;}
-        if ($python_env !~ $command) {
-            if ($python_env =~ /^EXCEPT:/) {last SWITCH}
-            else {$request = {}; return;}
-        }
-        if ($python_env =~ $command) {
-            if ($python_env =~ /^EXCEPT:/) {$request = {}; return;}
+        if ($perl_env eq "ALL")  {$request = {}; return;}
+        if ($perl_env eq "NO") {last SWITCH;}
+        if ($perl_env !~ $command) {
+            if ($perl_env =~ /^EXCEPT:/) {$request = {}; return;}
             else {last SWITCH;}
+        }
+        if ($perl_env =~ $command) {
+            if ($perl_env =~ /^EXCEPT:/) {last SWITCH;}
+            else {$request = {}; return;}
         }
     }
 

--- a/xCAT-server/lib/xcat/plugins/openbmc2.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc2.pm
@@ -63,23 +63,8 @@ sub preprocess_request {
     $callback  = shift;
 
     my $command   = $request->{command}->[0];
-    my $perl_env = xCAT::OPENBMC->is_openbmc_perl();
-    # Process command in this module only if PYTHON env is not NO or 
-    # command is listed in the PYTHON env list (without EXCEPT: prefix). 
-    # All other cases => return
-
-    SWITCH: {
-        if ($perl_env eq "ALL")  {$request = {}; return;}
-        if ($perl_env eq "NO") {last SWITCH;}
-        if ($perl_env !~ $command) {
-            if ($perl_env =~ /^EXCEPT:/) {$request = {}; return;}
-            else {last SWITCH;}
-        }
-        if ($perl_env =~ $command) {
-            if ($perl_env =~ /^EXCEPT:/) {last SWITCH;}
-            else {$request = {}; return;}
-        }
-    }
+    my ($rc, $msg) = xCAT::Utils->is_support_in_perl("openbmc", $command);
+    if ($rc != 0) { $request = {}; return;}
 
     my $noderange = $request->{node};
     my $extrargs  = $request->{arg};


### PR DESCRIPTION
To complete task xcat2/xcat2-task-management#2

Add site attribute `openbmc_perl_commands` to indicate which commands are run in perl.

If openbmc_perl_commands=YES all openbmc commands will run in Perl
If openbmc_perl_commands=NO or not set all openbmc commands will run in Perl
If openbmc_perl_commands=command,command,... commands listed will run in Perl, commands not listed will run in Python.
If openbmc_perl_commands=EXCEPT:command,command,... commands listed will run in Python, commands not listed will run in Perl.

The opposite to PR #4815 

The UT:
```
root@c910f03c05k10:/opt/xcat# lsdef -t site -i openbmc_perl_commands -c
root@c910f03c05k10:/opt/xcat# rpower f6u13 state
Thu Mar  1 22:56:41 2018 f6u13: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.13.100/login -d '{"data": ["root", "xxxxxx"]}'
Thu Mar  1 22:56:42 2018 f6u13: [openbmc_debug] login 200 OK
Thu Mar  1 22:56:42 2018 f6u13: [openbmc_debug] list_power_states curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://10.6.13.100/xyz/openbmc_project/state/enumerate
Thu Mar  1 22:56:42 2018 f6u13: [openbmc_debug] list_power_states 200 OK
f6u13: on
root@c910f03c05k10:/opt/xcat# chdef -t site openbmc_perl_commands=YES
1 object definitions have been created or modified.
root@c910f03c05k10:/opt/xcat# lsdef -t site -i openbmc_perl_commands -c
clustersite: openbmc_perl_commands=YES
root@c910f03c05k10:/opt/xcat# rpower f6u13 state
Thu Mar  1 22:57:29 2018 OpenBMC: [openbmc_debug_perl]
Thu Mar  1 22:57:29 2018 f6u13: [openbmc_debug_perl] curl -k -c cjar -H "Content-Type: application/json" -d '{ "data": ["root", "xxxxxx"] }' https://10.6.13.100/login
Thu Mar  1 22:57:30 2018 f6u13: [openbmc_debug_perl] login_response 200 OK
Thu Mar  1 22:57:30 2018 f6u13: [openbmc_debug_perl] curl -k -b cjar -X GET -H "Content-Type: application/json" https://10.6.13.100/xyz/openbmc_project/state/enumerate
Thu Mar  1 22:57:30 2018 f6u13: [openbmc_debug_perl] rpower_status_response 200 OK
f6u13: on
```
*Note:* I didn't change flag `openbmc_debug` to  `openbmc_debug_perl` in the PR, just to show the difference of output.