### PR TITLE
OpenBMC reventlog "clear" and "resolved" in Python

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_eventlog.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_eventlog.py
@@ -26,7 +26,7 @@ class OpenBMCEventlogTask(ParallelNodesCommand):
         number_to_display = 0
         try:
             # Number of records to display from the end
-            number_to_display = 0-int(num_to_display[0])
+            number_to_display = 0-int(num_to_display)
         except Exception:
             # All records to display
             number_to_display = 0
@@ -69,3 +69,50 @@ class OpenBMCEventlogTask(ParallelNodesCommand):
     def resolve_ev_records(self, resolve_list, **kw):
 
         node = kw['node']
+        obmc = openbmc.OpenBMCRest(name=node, nodeinfo=kw['nodeinfo'], messager=self.callback, debugmode=self.debugmode, verbose=self.verbose)
+        try:
+            obmc.login()
+
+            # Get all eventlog records
+            eventlog_info_dict = obmc.get_eventlog_info()
+
+            keys = eventlog_info_dict.keys()
+            # Sort the keys in natural order
+            keys.sort(key=lambda x : int(x[0:]))
+
+            resolved, ids = resolve_list.split('=')
+            eventlog_ids_to_resolve = []
+            if ids.upper() == "LED":
+
+                # loop through eventlog_info_dict and collect LED ids to be resolved into a eventlog_ids_to_resolve array
+                for key in list(keys):
+                    if "[LED]" in eventlog_info_dict[key]:
+                        if "Resolved: 0" in eventlog_info_dict[key]:
+                            eventlog_ids_to_resolve.append(key)
+                        else:
+                            if self.verbose:
+                                self.callback.info('%s: Not resolving already resolved eventlog ID %s'  % (node, key))
+            else:
+                # loop through list of ids and collect ids to resolve into a eventlog_ids_to_resolve array
+                for id_to_resolve in ids.split(','):
+                    if id_to_resolve in eventlog_info_dict:
+                        if "Resolved: 0" in eventlog_info_dict[id_to_resolve]:
+                            eventlog_ids_to_resolve.append(id_to_resolve)
+                        else:
+                            if self.verbose:
+                                self.callback.info('%s: Not resolving already resolved eventlog ID %s'  % (node, id_to_resolve))
+                    else:
+                        self.callback.info('%s: Invalid ID: %s'  % (node, id_to_resolve))
+
+            if len(eventlog_ids_to_resolve) == 0:
+                # At the end and there are no entries to resolve
+                self.callback.info('%s: No event log entries needed to be resolved'  % node)
+            else:
+                # Resolve entries that were collected into the eventlog_ids_to_resolve array
+                obmc.resolve_event_log_entries(eventlog_ids_to_resolve)
+                for entry in eventlog_ids_to_resolve:
+                    self.callback.info('%s: Resolved %s'  % (node, entry))
+
+        except (SelfServerException, SelfClientException) as e:
+            self.callback.error('%s' % e.message, node)
+

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_eventlog.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_eventlog.py
@@ -60,11 +60,11 @@ class OpenBMCEventlogTask(ParallelNodesCommand):
         try:
             obmc.login()
             obmc.clear_all_eventlog_records()
+            self.callback.info('%s: %s'  % (node, "Logs cleared"))
 
         except (SelfServerException, SelfClientException) as e:
             self.callback.error('%s'  % e.message, node)
 
-        self.callback.info('%s: %s'  % (node, "Logs cleared"))
 
     def resolve_ev_records(self, resolve_list, **kw):
 

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_eventlog.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_eventlog.py
@@ -56,6 +56,15 @@ class OpenBMCEventlogTask(ParallelNodesCommand):
     def clear_all_ev_records(self, **kw):
 
         node = kw['node']
+        obmc = openbmc.OpenBMCRest(name=node, nodeinfo=kw['nodeinfo'], messager=self.callback, debugmode=self.debugmode, verbose=self.verbose) 
+        try:
+            obmc.login()
+            obmc.clear_all_eventlog_records()
+
+        except (SelfServerException, SelfClientException) as e:
+            self.callback.error('%s'  % e.message, node)
+
+        self.callback.info('%s: %s'  % (node, "Logs cleared"))
 
     def resolve_ev_records(self, resolve_list, **kw):
 

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -220,8 +220,9 @@ RSPCONFIG_APIS = {
 }
 
 EVENTLOG_URLS     = {
-        "list": "/logging/enumerate",
+        "list":      "/logging/enumerate",
         "clear_all": "/logging/action/deleteAll",
+        "resolve":   "/logging/entry/{}/attr/Resolved",
 }
 
 RAS_POLICY_TABLE  = "/opt/ibm/ras/lib/policyTable.json"
@@ -664,6 +665,14 @@ class OpenBMCRest(object):
         payload = { "data": [] }
         return self.request('POST', EVENTLOG_URLS['clear_all'], payload=payload, cmd='clear_all_eventlog_records')
 
+    # Resolve eventlog records
+    def resolve_event_log_entries(self, eventlog_ids_to_resolve):
+
+        payload = { "data": "1" }
+        for event_id in eventlog_ids_to_resolve:
+            self.request('PUT', EVENTLOG_URLS['resolve'].format(event_id), payload=payload, cmd='resolve_event_log_entries')
+
+        return
 
     def set_apis_values(self, key, value):
         attr_info = RSPCONFIG_APIS[key]

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -661,7 +661,8 @@ class OpenBMCRest(object):
     # Clear all eventlog records
     def clear_all_eventlog_records(self):
 
-        return self.request('POST', EVENTLOG_URLS['clear_all'], cmd='clear_all_eventlog_records')
+        payload = { "data": [] }
+        return self.request('POST', EVENTLOG_URLS['clear_all'], payload=payload, cmd='clear_all_eventlog_records')
 
 
     def set_apis_values(self, key, value):

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -219,7 +219,11 @@ RSPCONFIG_APIS = {
     },
 }
 
-EVENTLOG_URL      = "/logging/enumerate"
+EVENTLOG_URLS     = {
+        "list": "/logging/enumerate",
+        "clear_all": "/logging/action/deleteAll",
+}
+
 RAS_POLICY_TABLE  = "/opt/ibm/ras/lib/policyTable.json"
 RAS_POLICY_MSG    = "Install the OpenBMC RAS package to obtain more details logging messages."
 RAS_NOT_FOUND_MSG = " Not found in policy table: "
@@ -559,7 +563,7 @@ class OpenBMCRest(object):
     # Extract all eventlog info and parse it
     def get_eventlog_info(self):
 
-        eventlog_data = self.request('GET', EVENTLOG_URL, cmd='get_eventlog_info')
+        eventlog_data = self.request('GET', EVENTLOG_URLS['list'], cmd='get_eventlog_info')
 
         return self.parse_eventlog_data(eventlog_data)
 
@@ -584,6 +588,11 @@ class OpenBMCRest(object):
                 id, event_log_line = self.parse_eventlog_data_record(value, ras_event_mapping)
                 if int(id) != 0:
                     eventlog_dict[str(id)] = event_log_line
+
+            if not eventlog_dict:
+                # Nothing was returned from BMC
+                eventlog_dict['0'] ='No attributes returned from the BMC.'
+
             return eventlog_dict
         except KeyError:
             error = 'Error: Received wrong format response: %s' % eventlog_data
@@ -648,6 +657,12 @@ class OpenBMCRest(object):
         if callout:
             formatted_line += LED_tag
         return id_str, formatted_line
+
+    # Clear all eventlog records
+    def clear_all_eventlog_records(self):
+
+        return self.request('POST', EVENTLOG_URLS['clear_all'], cmd='clear_all_eventlog_records')
+
 
     def set_apis_values(self, key, value):
         attr_info = RSPCONFIG_APIS[key]

--- a/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
+++ b/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
@@ -872,7 +872,6 @@ class OpenBMCManager(base.BaseManager):
 
         # 3, run the subcommands
         runner = OpenBMCEventlogTask(nodesinfo, callback=self.messager, debugmode=self.debugmode, verbose=self.verbose)
-        self.messager.info('revetlog.py processing action=%s args=%s' % (action, args))
         if action == 'clear':
             DefaultEventlogManager().clear_all_eventlog_records(runner)
         elif action == 'resolved':

--- a/xCAT-test/autotest/testcase/UT_openbmc/reventlog_resolved_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/reventlog_resolved_cases0
@@ -33,3 +33,30 @@ cmd:reventlog $$CN resolved=-1
 check:rc==1
 check:output=~Error: Invalid ID=
 end
+
+start:reventlog_resolved_parse_error5
+description: Pass in a string
+os:Linux
+hcp:openbmc
+cmd:reventlog $$CN resolved=abc
+check:rc==1
+check:output=~Error: Invalid ID=
+end
+
+start:reventlog_resolved_list
+description: Pass in a list of ids
+os:Linux
+hcp:openbmc
+cmd:reventlog $$CN resolved=100,101
+check:rc==0
+check:output=~Attempting to resolve the following log entries: 100,101...
+end
+
+start:reventlog_resolved_LED
+description: Pass in a LED keyword
+os:Linux
+hcp:openbmc
+cmd:reventlog $$CN resolved=Led
+check:rc==0
+check:output=~Attempting to resolve the following log entries: Led...
+end


### PR DESCRIPTION
Implement OpenBMC `reventlog clear` action in Python:

```
[root@briggs01 xcat]# reventlog mid05tor12cn16 clear
mid05tor12cn16: Logs cleared
[root@briggs01 xcat]#

[root@briggs01 xcat]# reventlog mid05tor12cn16
mid05tor12cn16: No attributes returned from the BMC.
[root@briggs01 xcat]#
```

```
[root@briggs01 xcat]# reventlog mid05tor12cn02 clear
mid05tor12cn02: Error: Error: BMC did not respond. Validate BMC configuration and retry the command.
[root@briggs01 xcat]#
```

```
[root@briggs01 xcat]# reventlog mid05tor12cn15 clearme
mid05tor12cn15: Error: Unsupported command: reventlog clearme
[root@briggs01 xcat]#
```

Implement OpenBMC `reventlog resolved` action in Python:

* Invalid eventlog ID:
```
[root@briggs01 xcat]# XCAT_OPENBMC_DEVEL=YES reventlog mid05tor12cn05 resolved=500
Attempting to resolve the following log entries: 500...
mid05tor12cn05: Invalid ID: 500
mid05tor12cn05: No event log entries needed to be resolved

[root@briggs01 xcat]# XCAT_OPENBMC_DEVEL=YES reventlog mid05tor12cn05 resolved=abc
Attempting to resolve the following log entries: abc...
mid05tor12cn05: Invalid ID: abc
mid05tor12cn05: No event log entries needed to be resolved
[root@briggs01 xcat]#
```

* Resolve a list of IDs:
```
[root@briggs01 xcat]# XCAT_OPENBMC_DEVEL=YES reventlog mid05tor12cn05 resolved=131,132,133 -V
[briggs01]: Attempting to resolve the following log entries: 131,132,133...
[briggs01]: mid05tor12cn05: Not resolving already resolved eventlog ID 132
[briggs01]: mid05tor12cn05: Not resolving already resolved eventlog ID 133
[briggs01]: mid05tor12cn05: Resolved 131
[root@briggs01 xcat]#

[root@briggs01 xcat]# XCAT_OPENBMC_DEVEL=YES reventlog mid05tor12cn05 resolved=131,132,133 -V
[briggs01]: Attempting to resolve the following log entries: 131,132,133...
[briggs01]: mid05tor12cn05: Not resolving already resolved eventlog ID 131
[briggs01]: mid05tor12cn05: Not resolving already resolved eventlog ID 132
[briggs01]: mid05tor12cn05: Not resolving already resolved eventlog ID 133
[briggs01]: mid05tor12cn05: No event log entries needed to be resolved
[root@briggs01 xcat]#

[root@briggs01 xcat]# XCAT_OPENBMC_DEVEL=YES reventlog mid05tor12cn05 resolved=131,132,133
Attempting to resolve the following log entries: 131,132,133...
mid05tor12cn05: No event log entries needed to be resolved
[root@briggs01 xcat]#
```

* Resolve all LED entries:
```
[root@briggs01 xcat]# XCAT_OPENBMC_DEVEL=YES reventlog mid05tor12cn05 resolved=LED
Attempting to resolve the following log entries: LED...
mid05tor12cn05: Resolved 30
mid05tor12cn05: Resolved 31
mid05tor12cn05: Resolved 35
mid05tor12cn05: Resolved 37
mid05tor12cn05: Resolved 38
mid05tor12cn05: Resolved 40
mid05tor12cn05: Resolved 42
mid05tor12cn05: Resolved 43
mid05tor12cn05: Resolved 46
mid05tor12cn05: Resolved 48
mid05tor12cn05: Resolved 49
mid05tor12cn05: Resolved 51
mid05tor12cn05: Resolved 55
mid05tor12cn05: Resolved 57
mid05tor12cn05: Resolved 59
mid05tor12cn05: Resolved 60
mid05tor12cn05: Resolved 64
mid05tor12cn05: Resolved 66
mid05tor12cn05: Resolved 67
mid05tor12cn05: Resolved 69
mid05tor12cn05: Resolved 71
mid05tor12cn05: Resolved 73
mid05tor12cn05: Resolved 74
mid05tor12cn05: Resolved 76
mid05tor12cn05: Resolved 87
mid05tor12cn05: Resolved 89
mid05tor12cn05: Resolved 90
mid05tor12cn05: Resolved 96
mid05tor12cn05: Resolved 98
mid05tor12cn05: Resolved 99
mid05tor12cn05: Resolved 102
mid05tor12cn05: Resolved 104
mid05tor12cn05: Resolved 105
mid05tor12cn05: Resolved 108
mid05tor12cn05: Resolved 110
mid05tor12cn05: Resolved 111
mid05tor12cn05: Resolved 113
mid05tor12cn05: Resolved 124
mid05tor12cn05: Resolved 126
mid05tor12cn05: Resolved 127
mid05tor12cn05: Resolved 130
mid05tor12cn05: Resolved 132
mid05tor12cn05: Resolved 133
[root@briggs01 xcat]# 

[root@briggs01 xcat]# XCAT_OPENBMC_DEVEL=YES reventlog mid05tor12cn05 resolved=LED
Attempting to resolve the following log entries: LED...
mid05tor12cn05: No event log entries needed to be resolved
[root@briggs01 xcat]#
```