### PR TITLE
For ppc64le platforms, create a dependency to install xCAT-openbmc-py for 2.13.11

### DIFF
--- a/xCAT/xCAT.spec
+++ b/xCAT/xCAT.spec
@@ -87,6 +87,10 @@ Requires: ipmitool-xcat >= 1.8.17-1
 %ifarch ppc ppc64 ppc64le
 Requires: ipmitool-xcat >= 1.8.17-1
 %endif
+%ifarch ppc64le
+# only OpenBMC support
+Requires: xCAT-openbmc-py
+%endif
 %endif
 
 %if %notpcm

--- a/xCATsn/xCATsn.spec
+++ b/xCATsn/xCATsn.spec
@@ -69,6 +69,10 @@ Requires: ipmitool-xcat >= 1.8.17-1
 %ifarch ppc ppc64 ppc64le
 Requires: ipmitool-xcat >= 1.8.17-1
 %endif
+%ifarch ppc64le
+# only OpenBMC support
+Requires: xCAT-openbmc-py
+%endif
 %endif
 
 %if %notpcm


### PR DESCRIPTION
By default for 2.13.11, we want to install the Python code on ppc64le systems when installing/updating xCAT so that there's no additional step for the user to install.  This code will run to manage machines with `mgt=openbmc`

Didn't test service nodes, but new clean install of xCAT, `yum install xCAT` results in the xCAT-openbmc-py package getting pulled in... 
```
 xCAT-buildkit                        noarch           4:2.13.11-snap201803021259               xcat-2-core                                                            67 k
 xCAT-client                          noarch           4:2.13.11-snap201803021259               xcat-2-core                                                           519 k
 xCAT-genesis-base-ppc64              noarch           2:2.13.10-snap201801170133               xcat-dep                                                               91 M
 xCAT-genesis-base-x86_64             noarch           2:2.13.10-snap201801170129               xcat-dep                                                               87 M
 xCAT-genesis-scripts-ppc64           noarch           1:2.13.11-snap201803021259               xcat-2-core                                                            59 k
 xCAT-genesis-scripts-x86_64          noarch           1:2.13.11-snap201803021259               xcat-2-core                                                            59 k
 xCAT-openbmc-py                      noarch           1:2.13.11-snap201803021300               xcat-2-core                                                            75 k
 xCAT-probe                           noarch           4:2.13.11-snap201803021259               xcat-2-core                                                            87 k
 xCAT-server                          noarch           4:2.13.11-snap201803021259               xcat-2-core                                                           1.8 M
 xnba-undi                            noarch           1.0.3-131028                             xcat-dep                                                              151 k
```