### PR TITLE
Control openbmc Perl/Python commands with site attribute

### DIFF
--- a/perl-xCAT/xCAT/Utils.pm
+++ b/perl-xCAT/xCAT/Utils.pm
@@ -4968,5 +4968,26 @@ sub console_sleep {
     sleep($time);
 }
 
+#--------------------------------------------------------------------------------
+
+=head3 is_support_in_perl 
+      check if specified command is included in site attribute openbmcperl
+=cut
+
+#--------------------------------------------------------------------------------
+sub is_support_in_perl {
+    my ($class, $command) = @_;
+    my @entries = xCAT::TableUtils->get_site_attribute("openbmcperl");
+    my $site_entry = $entries[0];
+    if ($site_entry) {
+        if ($site_entry =~ $command) {
+            return (1, '');
+        } else {
+            return (0, '');
+        }
+    } else {
+        return (0, '');
+    }
+}
 
 1;

--- a/perl-xCAT/xCAT/Utils.pm
+++ b/perl-xCAT/xCAT/Utils.pm
@@ -4968,26 +4968,4 @@ sub console_sleep {
     sleep($time);
 }
 
-#--------------------------------------------------------------------------------
-
-=head3 is_support_in_perl 
-      check if specified command is included in site attribute openbmcperl
-=cut
-
-#--------------------------------------------------------------------------------
-sub is_support_in_perl {
-    my ($class, $command) = @_;
-    my @entries = xCAT::TableUtils->get_site_attribute("openbmcperl");
-    my $site_entry = $entries[0];
-    if ($site_entry) {
-        if ($site_entry =~ $command) {
-            return (1, '');
-        } else {
-            return (0, '');
-        }
-    } else {
-        return (0, '');
-    }
-}
-
 1;

--- a/xCAT-server/lib/perl/xCAT/OPENBMC.pm
+++ b/xCAT-server/lib/perl/xCAT/OPENBMC.pm
@@ -22,6 +22,7 @@ use File::Path;
 use Fcntl ":flock";
 use IO::Socket::UNIX qw( SOCK_STREAM );
 use xCAT_monitoring::monitorctrl;
+use xCAT::TableUtils;
 
 my $LOCK_DIR = "/var/lock/xcat/";
 my $LOCK_PATH = "/var/lock/xcat/agent.lock";

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -758,7 +758,7 @@ sub preprocess_request {
 
     $callback  = shift;
     my $command   = $request->{command}->[0];
-    my ($rc, $msg) = xCAT::Utils->is_support_in_perl($command);
+    my ($rc, $msg) = xCAT::OPENBMC->is_support_in_perl($command, $request->{environment});
     if ($rc == 0) { $request = {}; return;}
     if ($rc < 0) {
         $request = {};

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -758,21 +758,12 @@ sub preprocess_request {
 
     $callback  = shift;
     my $command   = $request->{command}->[0];
-    my $python_env = xCAT::OPENBMC->is_openbmc_python($request->{environment});
-    # Process command in this module only if PYTHON env is not ALL or command is
-    # listed in the PYTHON env list (without EXCEPT: prefix. 
-    # All other cases => return
-    SWITCH: {
-        if ($python_env eq "ALL") {$request = {}; return;}
-        if ($python_env eq "NO")  {last SWITCH;}
-        if ($python_env !~ $command) {
-            if ($python_env =~ /^EXCEPT:/) {$request = {}; return;}
-            else {last SWITCH;}
-        }
-        if ($python_env =~ $command) {
-            if ($python_env =~ /^EXCEPT:/) {last SWITCH;}
-            else {$request = {}; return;}
-        }
+    my ($rc, $msg) = xCAT::Utils->is_support_in_perl($command);
+    if ($rc == 0) { $request = {}; return;}
+    if ($rc < 0) {
+        $request = {};
+        $callback->({ errorcode => [1], data => [$msg] });
+        return;
     }
 
     if ($::XCATSITEVALS{xcatdebugmode}) { $xcatdebugmode = $::XCATSITEVALS{xcatdebugmode} }

--- a/xCAT-server/lib/xcat/plugins/openbmc2.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc2.pm
@@ -13,7 +13,6 @@ use warnings "all";
 
 use JSON;
 use Getopt::Long;
-use xCAT::Utils;
 use xCAT::Usage;
 use xCAT::SvrUtils;
 use xCAT::OPENBMC;
@@ -63,7 +62,7 @@ sub preprocess_request {
     $callback  = shift;
 
     my $command   = $request->{command}->[0];
-    my ($rc, $msg) = xCAT::Utils->is_support_in_perl($command);
+    my ($rc, $msg) = xCAT::OPENBMC->is_support_in_perl($command, $request->{environment});
     if ($rc != 0) { $request = {}; return;}
 
     my $noderange = $request->{node};

--- a/xCAT-server/lib/xcat/plugins/openbmc2.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc2.pm
@@ -63,23 +63,8 @@ sub preprocess_request {
     $callback  = shift;
 
     my $command   = $request->{command}->[0];
-    my $python_env = xCAT::OPENBMC->is_openbmc_python($request->{environment});
-    # Process command in this module only if PYTHON env is not NO or 
-    # command is listed in the PYTHON env list (without EXCEPT: prefix). 
-    # All other cases => return
-
-    SWITCH: {
-        if ($python_env eq "NO")  {$request = {}; return;}
-        if ($python_env eq "ALL") {last SWITCH;}
-        if ($python_env !~ $command) {
-            if ($python_env =~ /^EXCEPT:/) {last SWITCH}
-            else {$request = {}; return;}
-        }
-        if ($python_env =~ $command) {
-            if ($python_env =~ /^EXCEPT:/) {$request = {}; return;}
-            else {last SWITCH;}
-        }
-    }
+    my ($rc, $msg) = xCAT::Utils->is_support_in_perl($command);
+    if ($rc != 0) { $request = {}; return;}
 
     my $noderange = $request->{node};
     my $extrargs  = $request->{arg};


### PR DESCRIPTION
https://github.ibm.com/vhu/c910env/issues/234

Possible replacement for #4875 

Site attribute "openbmcperl" is used to indicate which command will go through Perl. If command not listed, will go through Python.

The policy:
Get value from `openbmcperl`, `XCAT_OPENBMC_DEVEL`, agent.py:
1. If agent.py not exist: ==>Go Perl
2. If `openbmcperl` not set or not include a command:
    if `XCAT_OPENBMC_DEVEL` set to `NO`:  ==> Go Perl
    else if set to `YES` or not set: ==> Go Python
3. If `openbmcperl` set and include a command
    if `XCAT_OPENBMC_DEVEL` set to `YES`: == >Go Python
    else ==> Go Perl
