### PR TITLE
report clear error message when lacking python dependency.

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/xcatagent/server.py
+++ b/xCAT-openbmc-py/lib/python/agent/xcatagent/server.py
@@ -105,6 +105,11 @@ class Server(object):
                 sock.close()
                 self.server.stop()
                 os._exit(0)
+        except ImportError:
+            messager.error("xCAT mgt=openbmc is using a Python based framework and there are some dependencies that are not met.")
+            print(traceback.format_exc(), file=sys.stderr)
+            self.server.stop()
+            os._exit(1)
         except Exception:
             print(traceback.format_exc(), file=sys.stderr)
             self.server.stop()


### PR DESCRIPTION
UT:
```
rpower mid05tor12cn16 stat
Error: xCAT mgt=openbmc is using a Python based framework and there are some dependencies that are not met.
Error: python agent exited unexpectedly. See /var/log/xcat/agent.log for more details.
# pip install requests
Collecting requests
  Using cached requests-2.18.4-py2.py3-none-any.whl
Requirement already satisfied: certifi>=2017.4.17 in /usr/lib/python2.7/site-packages (from requests)
Requirement already satisfied: chardet<3.1.0,>=3.0.2 in /usr/lib/python2.7/site-packages (from requests)
Requirement already satisfied: idna<2.7,>=2.5 in /usr/lib/python2.7/site-packages (from requests)
Requirement already satisfied: urllib3<1.23,>=1.21.1 in /usr/lib/python2.7/site-packages (from requests)
Installing collected packages: requests
Successfully installed requests-2.18.4
# rpower mid05tor12cn16 stat
mid05tor12cn16: on
```