### PR TITLE
OpenBMC commands default to Python

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -758,7 +758,7 @@ sub preprocess_request {
 
     $callback  = shift;
     my $command   = $request->{command}->[0];
-    my ($rc, $msg) = xCAT::OPENBMC->is_support_in_perl($command, $request->{environment});
+    my ($rc, $msg) = xCAT::OPENBMC->run_cmd_in_perl($command, $request->{environment});
     if ($rc == 0) { $request = {}; return;}
     if ($rc < 0) {
         $request = {};

--- a/xCAT-server/lib/xcat/plugins/openbmc2.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc2.pm
@@ -62,7 +62,7 @@ sub preprocess_request {
     $callback  = shift;
 
     my $command   = $request->{command}->[0];
-    my ($rc, $msg) = xCAT::OPENBMC->is_support_in_perl($command, $request->{environment});
+    my ($rc, $msg) = xCAT::OPENBMC->run_cmd_in_perl($command, $request->{environment});
     if ($rc != 0) { $request = {}; return;}
 
     my $noderange = $request->{node};


### PR DESCRIPTION
All openbmc commands default to Python.
Exceptions (run in Perl): 
   a. command listed in table attribute "openbmcperl"
   b. command listed in `unsupported_in_python_commands` list in `run_cmd_in_perl()` function

Exception "a" is can not be overwritten
Exception "b" is overwritten (run on Python) by setting XCAT_OPENBMC_DEVEL=YES