### PR TITLE
Improve the error message when python dependencies are not met

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/xcatagent/server.py
+++ b/xCAT-openbmc-py/lib/python/agent/xcatagent/server.py
@@ -106,7 +106,7 @@ class Server(object):
                 self.server.stop()
                 os._exit(0)
         except ImportError:
-            messager.error("xCAT mgt=openbmc is using a Python based framework and there are some dependencies that are not met.")
+            messager.error("OpenBMC management is using a Python framework and some dependency libraries could not be imported.")
             print(traceback.format_exc(), file=sys.stderr)
             self.server.stop()
             os._exit(1)

--- a/xCAT-server/lib/perl/xCAT/OPENBMC.pm
+++ b/xCAT-server/lib/perl/xCAT/OPENBMC.pm
@@ -137,7 +137,7 @@ sub submit_agent_request {
         $retry++;
     }
     if (!defined($sock)) {
-        xCAT::MsgUtils->message("E", { data => ["Failed to connect to the agent"] }, $callback);
+        xCAT::MsgUtils->message("E", { data => ["OpenBMC management is using a Python framework. An error has occured when trying to create socket $AGENT_SOCK_PATH."] }, $callback);
         kill('TERM', $pid);
         return;
     }
@@ -195,7 +195,7 @@ sub wait_agent {
     my ($pid, $callback) = @_;
     waitpid($pid, 0);
     if ($? >> 8 != 0) {
-        xCAT::MsgUtils->message("E", { data => ["python agent exited unexpectedly. See $PYTHON_LOG_PATH for more details."] }, $callback);
+        xCAT::MsgUtils->message("E", { data => ["Agent exited unexpectedly.  See $PYTHON_LOG_PATH for details."] }, $callback);
     }
 }
 


### PR DESCRIPTION
PR #4881 does not completely help the user.  

When there are no dependencies met, we still see this message from OPENBMC.pm:

```
[root@fs2vm111 ~]# rpower f6u13 state
Error: Failed to connect to the agent
Error: python agent exited unexpectedly. See /var/log/xcat/agent.log for more details.
```

This is not very helpful. 

With the pull request changes, we will get the following output until `gevent` and `docopt` dependencies are fulfilled via pip...

```
[root@fs2vm111 ~]# rpower f6u13 state
Error: OpenBMC management is using a Python framework. An error has occured when trying to create socket /var/run/xcat/agent.sock.
Error: Agent exited unexpectedly.  See /var/log/xcat/agent.log for details.
```

After those two are installed (`gevent`, and `docopt`) then we will get the following message: 

```
[root@fs2vm111 ~]# rpower f6u13 state
Error: OpenBMC management is using a Python framework and some dependency libraries could not be imported.
Error: Agent exited unexpectedly.  See /var/log/xcat/agent.log for details.
[root@fs2vm111 ~]#
```
