### PR TITLE
return code on error should be 1 instead of 0 ---rpower

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -305,7 +305,7 @@ class OpenBMCRest(object):
 
         self._log_request(method, url, httpheaders, data=data, cmd=cmd)
         try:
-            response = self.session.request(method, url, httpheaders, data=data)
+            response = self.session.request(method, url, httpheaders, data=data, timeout=timeout)
             return self.handle_response(response, cmd=cmd)
         except SelfServerException as e:
             e.message = 'Error: BMC did not respond. ' \

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -703,7 +703,7 @@ my %allerrornodes = ();
 
 my $xcatdebugmode = 0;
 
-my $flag_debug = "[openbmc_debug]";
+my $flag_debug = "[openbmc_debug_perl]";
 
 my %login_pid_node; # used in process_request, record login fork pid map
 


### PR DESCRIPTION
#4871 

1. Modify for rpower "The return code on error should be 1 instead of 0".
2. modify 'openbmc_debug' to 'openbmc_debug_perl' for openbmc.pm
3. use timeout for openbmc restful request in xCAT-openbmc-py