### PR TITLE
clear cache for IP change case in node discovery(#4890)

### DIFF
--- a/perl-xCAT/xCAT/NetworkUtils.pm
+++ b/perl-xCAT/xCAT/NetworkUtils.pm
@@ -388,6 +388,26 @@ sub getipaddr
 
 #-------------------------------------------------------------------------------
 
+=head3  clearcache
+    Workaround: Clear the IP address cache in case that the long running process
+    (discovery/install monitor) could work as normal when the node's IP address
+    is changed.
+    Globals:
+        cache: %::hostiphash
+    Error:
+        none
+    Example:
+        xCAT::NetworkUtils->clearcache();
+=cut
+
+#-------------------------------------------------------------------------------
+sub clearcache
+{
+    undef %::hostiphash;
+}
+
+#-------------------------------------------------------------------------------
+
 =head3  linklocaladdr
     Only for IPv6.               
     Takes a mac address, calculate the IPv6 link local address

--- a/xCAT-server/lib/xcat/plugins/aaadiscovery.pm
+++ b/xCAT-server/lib/xcat/plugins/aaadiscovery.pm
@@ -8,6 +8,7 @@ BEGIN
 }
 use lib "$::XCATROOT/lib/perl";
 use xCAT::DiscoveryUtils;
+use xCAT::NetworkUtils;
 
 sub handled_commands {
     return {
@@ -51,6 +52,8 @@ sub process_request {
         xCAT::MsgUtils->message("S", "xcat.discovery.aaadiscovery: ($mac) Got a discovery request, attempting to discover the node...");
         $req->{discoverymethod}->[0] = 'undef';
         $req->{_xcat_clientmac}->[0] = $mac;
+        #Workaround (#4890) for IP changed cases.
+        xCAT::NetworkUtils->clearcache();
         xCAT::DiscoveryUtils->update_discovery_data($req);
         return;
     }


### PR DESCRIPTION
To fix #4890,  after apply this.  The changed IP address could be applied to re-discovered nodes.
UT:
```
1, define a node with IP 192.168.139.16 and discover it
2, change its IP to 192.168.149.16 and rediscover it
# chdef mid05tor12cn16 ip=192.168.149.16
1 object definitions have been created or modified.
# makehosts mid05tor12cn16
# makedns -n mid05tor12cn16
Handling mid05tor12cn16 in /etc/hosts.
Getting reverse zones, this may take several minutes for a large cluster.
Completed getting reverse zones.
Updating zones.
Completed updating zones.
Restarting named
Restarting named complete
Updating DNS records, this may take several minutes for a large cluster.
Completed updating DNS records.
DNS setup is completed
# nslookup mid05tor12cn16
Name:   mid05tor12cn16.example.com
Address: 192.168.149.16
```
3, after the node is discovered, to check `makedhcp -q xxx`
```
makedhcp -q mid05tor12cn16
mid05tor12cn16: ip-address = 192.168.149.16, hardware-address = 11:22:33:44:55:66
```