### PR TITLE
 Add test case for setting up env to support python by default 

### DIFF
--- a/xCAT-test/autotest/testcase/pythonsupport/cases0
+++ b/xCAT-test/autotest/testcase/pythonsupport/cases0
@@ -1,5 +1,5 @@
 start:set_up_env_for_support_openbmc_in_python
-description:this case is used to test set up environemtn for supporting openbmc in python
+description:this case is used to test environment setup for supporting openbmc in python
 os:Linux
 hcp:openbmc
 cmd:mkdir -p /tmp/set_up_env_for_support_openbmc_in_python

--- a/xCAT-test/autotest/testcase/pythonsupport/cases0
+++ b/xCAT-test/autotest/testcase/pythonsupport/cases0
@@ -1,0 +1,46 @@
+start:set_up_env_for_support_openbmc_in_python
+description:this case is used to test set up environemtn for supporting openbmc in python
+os:Linux
+hcp:openbmc
+cmd:mkdir -p /tmp/set_up_env_for_support_openbmc_in_python
+check:rc==0
+cmd: wget https://bootstrap.pypa.io/get-pip.py --retry-connrefused  -O /tmp/set_up_env_for_support_openbmc_in_python/get-pip.py
+check:rc==0
+cmd:python /tmp/set_up_env_for_support_openbmc_in_python/get-pip.py
+check:rc==0
+cmd:yum -y install gcc python-devel libffi-devel openssl-devel
+check:rc==0
+cmd:rpm -qa |grep "^gcc-"
+check:output=~ gcc-\d
+check:rc==0
+cmd:rpm -qa|grep "^python-devel"
+check:output=~ python-devel-\d
+check:rc==0
+cmd:rpm -qa|grep "^libffi-devel"
+check:output=~ libffi-devel-\d 
+check:rc==0
+cmd:rpm -qa|grep "^openssl-devel"
+check:output=~ openssl-devel-\d
+check:rc==0
+cmd:pip install gevent docopt requests paramiko  scp 
+check:rc==0
+cmd:pip list 2>/dev/null | grep "^gevent"
+check:output=~ gevent \(\d
+check:rc==0 
+cmd:pip list 2>/dev/null | grep "^docopt"
+check:output=~ docopt \(\d
+check:rc==0
+cmd:pip list 2>/dev/null | grep "^requests"
+check:output=~ requests \(\d
+check:rc==0
+cmd:pip list 2>/dev/null | grep "^paramiko"
+check:output=~ paramiko \(\d
+check:rc==0
+cmd:pip list 2>/dev/null | grep "^scp"
+check:output=~ scp \(\d
+check:rc==0
+cmd:rm -rf /tmp/set_up_env_for_support_openbmc_in_python
+check:rc==0
+end
+
+


### PR DESCRIPTION
Add test case for setting up env to support python by default 

The running result looks like below:
```
------START::set_up_env_for_support_openbmc_in_python::Time:Tue Mar  6 21:55:15 2018------

RUN:mkdir -p /tmp/set_up_env_for_support_openbmc_in_python [Tue Mar  6 21:55:15 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:wget https://bootstrap.pypa.io/get-pip.py --retry-connrefused  -O /tmp/set_up_env_for_support_openbmc_in_python/get-pip.py [Tue Mar  6 21:55:15 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
--2018-03-06 21:55:15--  https://bootstrap.pypa.io/get-pip.py
Resolving bootstrap.pypa.io (bootstrap.pypa.io)... 151.101.20.175
Connecting to bootstrap.pypa.io (bootstrap.pypa.io)|151.101.20.175|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 1595408 (1.5M) [text/x-python]
Saving to: '/tmp/set_up_env_for_support_openbmc_in_python/get-pip.py'

     0K .......... .......... .......... .......... ..........  3% 6.51M 0s
    50K .......... .......... .......... .......... ..........  6% 12.6M 0s
   100K .......... .......... .......... .......... ..........  9% 18.3M 0s
   150K .......... .......... .......... .......... .......... 12% 14.8M 0s
   200K .......... .......... .......... .......... .......... 16% 11.6M 0s
   250K .......... .......... .......... .......... .......... 19% 25.0M 0s
   300K .......... .......... .......... .......... .......... 22% 17.7M 0s
   350K .......... .......... .......... .......... .......... 25% 13.0M 0s
   400K .......... .......... .......... .......... .......... 28% 14.5M 0s
   450K .......... .......... .......... .......... .......... 32% 26.4M 0s
   500K .......... .......... .......... .......... .......... 35% 15.9M 0s
   550K .......... .......... .......... .......... .......... 38% 28.5M 0s
   600K .......... .......... .......... .......... .......... 41% 15.6M 0s
   650K .......... .......... .......... .......... .......... 44% 15.7M 0s
   700K .......... .......... .......... .......... .......... 48% 43.0M 0s
   750K .......... .......... .......... .......... .......... 51% 14.9M 0s
   800K .......... .......... .......... .......... .......... 54% 15.1M 0s
   850K .......... .......... .......... .......... .......... 57% 29.9M 0s
   900K .......... .......... .......... .......... .......... 60% 31.0M 0s
   950K .......... .......... .......... .......... .......... 64% 21.2M 0s
  1000K .......... .......... .......... .......... .......... 67% 31.5M 0s
  1050K .......... .......... .......... .......... .......... 70% 24.4M 0s
  1100K .......... .......... .......... .......... .......... 73% 35.8M 0s
  1150K .......... .......... .......... .......... .......... 77% 20.5M 0s
  1200K .......... .......... .......... .......... .......... 80% 32.5M 0s
  1250K .......... .......... .......... .......... .......... 83% 20.8M 0s
  1300K .......... .......... .......... .......... .......... 86% 47.9M 0s
  1350K .......... .......... .......... .......... .......... 89% 9.51M 0s
  1400K .......... .......... .......... .......... .......... 93%  257M 0s
  1450K .......... .......... .......... .......... .......... 96% 44.8M 0s
  1500K .......... .......... .......... .......... .......... 99% 83.0M 0s
  1550K ........                                              100% 8.49M=0.08s

2018-03-06 21:55:15 (19.1 MB/s) - '/tmp/set_up_env_for_support_openbmc_in_python/get-pip.py' saved [1595408/1595408]

CHECK:rc == 0	[Pass]

RUN:python /tmp/set_up_env_for_support_openbmc_in_python/get-pip.py [Tue Mar  6 21:55:15 2018]
ElapsedTime:4 sec
RETURN rc = 0
OUTPUT:
Collecting pip
  Downloading pip-9.0.1-py2.py3-none-any.whl (1.3MB)
Collecting setuptools
  Downloading setuptools-38.5.2-py2.py3-none-any.whl (490kB)
Collecting wheel
  Downloading wheel-0.30.0-py2.py3-none-any.whl (49kB)
Installing collected packages: pip, setuptools, wheel
Successfully installed pip-9.0.1 setuptools-38.5.2 wheel-0.30.0
CHECK:rc == 0	[Pass]

RUN:yum -y install gcc python-devel libffi-devel openssl-devel [Tue Mar  6 21:55:19 2018]
ElapsedTime:11 sec
RETURN rc = 0
OUTPUT:
Failed to set locale, defaulting to C
Loaded plugins: product-id, search-disabled-repos, subscription-manager
This system is not registered with an entitlement server. You can use subscription-manager to register.
Resolving Dependencies
--> Running transaction check
---> Package gcc.ppc64le 0:4.8.5-25.el7 will be installed
--> Processing Dependency: cpp = 4.8.5-25.el7 for package: gcc-4.8.5-25.el7.ppc64le
--> Processing Dependency: glibc-devel >= 2.2.90-12 for package: gcc-4.8.5-25.el7.ppc64le
--> Processing Dependency: libatomic.so.1()(64bit) for package: gcc-4.8.5-25.el7.ppc64le
--> Processing Dependency: libmpc.so.3()(64bit) for package: gcc-4.8.5-25.el7.ppc64le
--> Processing Dependency: libmpfr.so.4()(64bit) for package: gcc-4.8.5-25.el7.ppc64le
---> Package libffi-devel.ppc64le 0:3.0.13-18.el7 will be installed
---> Package openssl-devel.ppc64le 1:1.0.2k-12.el7 will be installed
--> Processing Dependency: krb5-devel(ppc-64) for package: 1:openssl-devel-1.0.2k-12.el7.ppc64le
--> Processing Dependency: zlib-devel(ppc-64) for package: 1:openssl-devel-1.0.2k-12.el7.ppc64le
---> Package python-devel.ppc64le 0:2.7.5-65.el7 will be installed
--> Running transaction check
---> Package cpp.ppc64le 0:4.8.5-25.el7 will be installed
---> Package glibc-devel.ppc64le 0:2.17-220.el7 will be installed
--> Processing Dependency: glibc-headers = 2.17-220.el7 for package: glibc-devel-2.17-220.el7.ppc64le
--> Processing Dependency: glibc-headers for package: glibc-devel-2.17-220.el7.ppc64le
---> Package krb5-devel.ppc64le 0:1.15.1-18.el7 will be installed
--> Processing Dependency: libkadm5(ppc-64) = 1.15.1-18.el7 for package: krb5-devel-1.15.1-18.el7.ppc64le
--> Processing Dependency: keyutils-libs-devel for package: krb5-devel-1.15.1-18.el7.ppc64le
--> Processing Dependency: libcom_err-devel for package: krb5-devel-1.15.1-18.el7.ppc64le
--> Processing Dependency: libselinux-devel for package: krb5-devel-1.15.1-18.el7.ppc64le
--> Processing Dependency: libverto-devel for package: krb5-devel-1.15.1-18.el7.ppc64le
---> Package libatomic.ppc64le 0:4.8.5-25.el7 will be installed
---> Package libmpc.ppc64le 0:1.0.1-3.el7 will be installed
---> Package mpfr.ppc64le 0:3.1.1-4.el7 will be installed
---> Package zlib-devel.ppc64le 0:1.2.7-17.el7 will be installed
--> Running transaction check
---> Package glibc-headers.ppc64le 0:2.17-220.el7 will be installed
--> Processing Dependency: kernel-headers >= 2.2.1 for package: glibc-headers-2.17-220.el7.ppc64le
--> Processing Dependency: kernel-headers for package: glibc-headers-2.17-220.el7.ppc64le
---> Package keyutils-libs-devel.ppc64le 0:1.5.8-3.el7 will be installed
---> Package libcom_err-devel.ppc64le 0:1.42.9-11.el7 will be installed
---> Package libkadm5.ppc64le 0:1.15.1-18.el7 will be installed
---> Package libselinux-devel.ppc64le 0:2.5-12.el7 will be installed
--> Processing Dependency: libsepol-devel(ppc-64) >= 2.5-6 for package: libselinux-devel-2.5-12.el7.ppc64le
--> Processing Dependency: pkgconfig(libpcre) for package: libselinux-devel-2.5-12.el7.ppc64le
--> Processing Dependency: pkgconfig(libsepol) for package: libselinux-devel-2.5-12.el7.ppc64le
---> Package libverto-devel.ppc64le 0:0.2.5-4.el7 will be installed
--> Running transaction check
---> Package kernel-headers.ppc64le 0:4.14.0-22.el7a will be installed
---> Package libsepol-devel.ppc64le 0:2.5-8.1.el7 will be installed
---> Package pcre-devel.ppc64le 0:8.32-17.el7 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package             Arch    Version         Repository                    Size
================================================================================
Installing:
 gcc                 ppc64le 4.8.5-25.el7    local-rhels7.5-alternate-ppc64le--install-rhels7.5-alternate-ppc64le
                                                                           15 M
 libffi-devel        ppc64le 3.0.13-18.el7   local-rhels7.5-alternate-ppc64le--install-rhels7.5-alternate-ppc64le
                                                                           23 k
 openssl-devel       ppc64le 1:1.0.2k-12.el7 local-rhels7.5-alternate-ppc64le--install-rhels7.5-alternate-ppc64le
                                                                          1.5 M
 python-devel        ppc64le 2.7.5-65.el7    local-rhels7.5-alternate-ppc64le--install-rhels7.5-alternate-ppc64le
                                                                          396 k
Installing for dependencies:
 cpp                 ppc64le 4.8.5-25.el7    local-rhels7.5-alternate-ppc64le--install-rhels7.5-alternate-ppc64le
                                                                          6.9 M
 glibc-devel         ppc64le 2.17-220.el7    local-rhels7.5-alternate-ppc64le--install-rhels7.5-alternate-ppc64le
                                                                          1.1 M
 glibc-headers       ppc64le 2.17-220.el7    local-rhels7.5-alternate-ppc64le--install-rhels7.5-alternate-ppc64le
                                                                          667 k
 kernel-headers      ppc64le 4.14.0-22.el7a  local-rhels7.5-alternate-ppc64le--install-rhels7.5-alternate-ppc64le
                                                                          1.1 M
 keyutils-libs-devel ppc64le 1.5.8-3.el7     local-rhels7.5-alternate-ppc64le--install-rhels7.5-alternate-ppc64le
                                                                           37 k
 krb5-devel          ppc64le 1.15.1-18.el7   local-rhels7.5-alternate-ppc64le--install-rhels7.5-alternate-ppc64le
                                                                          270 k
 libatomic           ppc64le 4.8.5-25.el7    local-rhels7.5-alternate-ppc64le--install-rhels7.5-alternate-ppc64le
                                                                           48 k
 libcom_err-devel    ppc64le 1.42.9-11.el7   local-rhels7.5-alternate-ppc64le--install-rhels7.5-alternate-ppc64le
                                                                           31 k
 libkadm5            ppc64le 1.15.1-18.el7   local-rhels7.5-alternate-ppc64le--install-rhels7.5-alternate-ppc64le
                                                                          176 k
 libmpc              ppc64le 1.0.1-3.el7     local-rhels7.5-alternate-ppc64le--install-rhels7.5-alternate-ppc64le
                                                                           52 k
 libselinux-devel    ppc64le 2.5-12.el7      local-rhels7.5-alternate-ppc64le--install-rhels7.5-alternate-ppc64le
                                                                          186 k
 libsepol-devel      ppc64le 2.5-8.1.el7     local-rhels7.5-alternate-ppc64le--install-rhels7.5-alternate-ppc64le
                                                                           77 k
 libverto-devel      ppc64le 0.2.5-4.el7     local-rhels7.5-alternate-ppc64le--install-rhels7.5-alternate-ppc64le
                                                                           12 k
 mpfr                ppc64le 3.1.1-4.el7     local-rhels7.5-alternate-ppc64le--install-rhels7.5-alternate-ppc64le
                                                                          210 k
 pcre-devel          ppc64le 8.32-17.el7     local-rhels7.5-alternate-ppc64le--install-rhels7.5-alternate-ppc64le
                                                                          480 k
 zlib-devel          ppc64le 1.2.7-17.el7    local-rhels7.5-alternate-ppc64le--install-rhels7.5-alternate-ppc64le
                                                                           50 k

Transaction Summary
================================================================================
Install  4 Packages (+16 Dependent packages)

Total download size: 28 M
Installed size: 70 M
Downloading packages:
--------------------------------------------------------------------------------
Total                                               48 MB/s |  28 MB  00:00
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : mpfr-3.1.1-4.el7.ppc64le                                    1/20
  Installing : libmpc-1.0.1-3.el7.ppc64le                                  2/20
  Installing : cpp-4.8.5-25.el7.ppc64le                                    3/20
  Installing : zlib-devel-1.2.7-17.el7.ppc64le                             4/20
  Installing : libkadm5-1.15.1-18.el7.ppc64le                              5/20
  Installing : libverto-devel-0.2.5-4.el7.ppc64le                          6/20
  Installing : kernel-headers-4.14.0-22.el7a.ppc64le                       7/20
  Installing : glibc-headers-2.17-220.el7.ppc64le                          8/20
  Installing : glibc-devel-2.17-220.el7.ppc64le                            9/20
  Installing : pcre-devel-8.32-17.el7.ppc64le                             10/20
  Installing : libatomic-4.8.5-25.el7.ppc64le                             11/20
  Installing : keyutils-libs-devel-1.5.8-3.el7.ppc64le                    12/20
  Installing : libcom_err-devel-1.42.9-11.el7.ppc64le                     13/20
  Installing : libsepol-devel-2.5-8.1.el7.ppc64le                         14/20
  Installing : libselinux-devel-2.5-12.el7.ppc64le                        15/20
  Installing : krb5-devel-1.15.1-18.el7.ppc64le                           16/20
  Installing : 1:openssl-devel-1.0.2k-12.el7.ppc64le                      17/20
  Installing : gcc-4.8.5-25.el7.ppc64le                                   18/20
  Installing : python-devel-2.7.5-65.el7.ppc64le                          19/20
  Installing : libffi-devel-3.0.13-18.el7.ppc64le                         20/20
  Verifying  : libsepol-devel-2.5-8.1.el7.ppc64le                          1/20
  Verifying  : glibc-headers-2.17-220.el7.ppc64le                          2/20
  Verifying  : libcom_err-devel-1.42.9-11.el7.ppc64le                      3/20
  Verifying  : keyutils-libs-devel-1.5.8-3.el7.ppc64le                     4/20
  Verifying  : gcc-4.8.5-25.el7.ppc64le                                    5/20
  Verifying  : libatomic-4.8.5-25.el7.ppc64le                              6/20
  Verifying  : pcre-devel-8.32-17.el7.ppc64le                              7/20
  Verifying  : kernel-headers-4.14.0-22.el7a.ppc64le                       8/20
  Verifying  : libffi-devel-3.0.13-18.el7.ppc64le                          9/20
  Verifying  : krb5-devel-1.15.1-18.el7.ppc64le                           10/20
  Verifying  : libverto-devel-0.2.5-4.el7.ppc64le                         11/20
  Verifying  : libkadm5-1.15.1-18.el7.ppc64le                             12/20
  Verifying  : libselinux-devel-2.5-12.el7.ppc64le                        13/20
  Verifying  : cpp-4.8.5-25.el7.ppc64le                                   14/20
  Verifying  : libmpc-1.0.1-3.el7.ppc64le                                 15/20
  Verifying  : python-devel-2.7.5-65.el7.ppc64le                          16/20
  Verifying  : 1:openssl-devel-1.0.2k-12.el7.ppc64le                      17/20
  Verifying  : zlib-devel-1.2.7-17.el7.ppc64le                            18/20
  Verifying  : glibc-devel-2.17-220.el7.ppc64le                           19/20
  Verifying  : mpfr-3.1.1-4.el7.ppc64le                                   20/20

Installed:
  gcc.ppc64le 0:4.8.5-25.el7              libffi-devel.ppc64le 0:3.0.13-18.el7
  openssl-devel.ppc64le 1:1.0.2k-12.el7   python-devel.ppc64le 0:2.7.5-65.el7

Dependency Installed:
  cpp.ppc64le 0:4.8.5-25.el7
  glibc-devel.ppc64le 0:2.17-220.el7
  glibc-headers.ppc64le 0:2.17-220.el7
  kernel-headers.ppc64le 0:4.14.0-22.el7a
  keyutils-libs-devel.ppc64le 0:1.5.8-3.el7
  krb5-devel.ppc64le 0:1.15.1-18.el7
  libatomic.ppc64le 0:4.8.5-25.el7
  libcom_err-devel.ppc64le 0:1.42.9-11.el7
  libkadm5.ppc64le 0:1.15.1-18.el7
  libmpc.ppc64le 0:1.0.1-3.el7
  libselinux-devel.ppc64le 0:2.5-12.el7
  libsepol-devel.ppc64le 0:2.5-8.1.el7
  libverto-devel.ppc64le 0:0.2.5-4.el7
  mpfr.ppc64le 0:3.1.1-4.el7
  pcre-devel.ppc64le 0:8.32-17.el7
  zlib-devel.ppc64le 0:1.2.7-17.el7

Complete!
CHECK:rc == 0	[Pass]

RUN:rpm -qa |grep 'gcc-' [Tue Mar  6 21:55:30 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
libgcc-4.8.5-25.el7.ppc64le
gcc-4.8.5-25.el7.ppc64le
CHECK:output =~ gcc-\d	[Pass]
CHECK:rc == 0	[Pass]

RUN:rpm -qa|grep 'python-devel' [Tue Mar  6 21:55:31 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
python-devel-2.7.5-65.el7.ppc64le
CHECK:output =~ python-devel-\d	[Pass]
CHECK:rc == 0	[Pass]

RUN:rpm -qa|grep 'libffi-devel' [Tue Mar  6 21:55:32 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
libffi-devel-3.0.13-18.el7.ppc64le
CHECK:output =~ libffi-devel-\d	[Pass]
CHECK:rc == 0	[Pass]

RUN:rpm -qa|grep 'openssl-devel' [Tue Mar  6 21:55:32 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
openssl-devel-1.0.2k-12.el7.ppc64le
CHECK:output =~ openssl-devel-\d	[Pass]
CHECK:rc == 0	[Pass]

RUN:pip install gevent docopt requests paramiko  scp [Tue Mar  6 21:55:33 2018]
ElapsedTime:205 sec
RETURN rc = 0
OUTPUT:
Collecting gevent
  Downloading gevent-1.2.2.tar.gz (3.1MB)
Collecting docopt
  Downloading docopt-0.6.2.tar.gz
Collecting requests
  Downloading requests-2.18.4-py2.py3-none-any.whl (88kB)
Collecting paramiko
  Downloading paramiko-2.4.0-py2.py3-none-any.whl (192kB)
Collecting scp
  Downloading scp-0.10.2-py2.py3-none-any.whl
Collecting greenlet>=0.4.10 (from gevent)
  Downloading greenlet-0.4.13.tar.gz (58kB)
Collecting chardet<3.1.0,>=3.0.2 (from requests)
  Downloading chardet-3.0.4-py2.py3-none-any.whl (133kB)
Collecting certifi>=2017.4.17 (from requests)
  Downloading certifi-2018.1.18-py2.py3-none-any.whl (151kB)
Collecting urllib3<1.23,>=1.21.1 (from requests)
  Downloading urllib3-1.22-py2.py3-none-any.whl (132kB)
Collecting idna<2.7,>=2.5 (from requests)
  Downloading idna-2.6-py2.py3-none-any.whl (56kB)
Collecting pyasn1>=0.1.7 (from paramiko)
  Downloading pyasn1-0.4.2-py2.py3-none-any.whl (71kB)
Collecting bcrypt>=3.1.3 (from paramiko)
  Downloading bcrypt-3.1.4.tar.gz (42kB)
Collecting cryptography>=1.5 (from paramiko)
  Downloading cryptography-2.1.4.tar.gz (441kB)
Collecting pynacl>=1.0.1 (from paramiko)
  Downloading PyNaCl-1.2.1.tar.gz (3.3MB)
Collecting cffi>=1.1 (from bcrypt>=3.1.3->paramiko)
  Downloading cffi-1.11.5.tar.gz (438kB)
Requirement already satisfied: six>=1.4.1 in /usr/lib/python2.7/site-packages (from bcrypt>=3.1.3->paramiko)
Collecting asn1crypto>=0.21.0 (from cryptography>=1.5->paramiko)
  Downloading asn1crypto-0.24.0-py2.py3-none-any.whl (101kB)
Collecting enum34 (from cryptography>=1.5->paramiko)
  Downloading enum34-1.1.6-py2-none-any.whl
Collecting ipaddress (from cryptography>=1.5->paramiko)
  Downloading ipaddress-1.0.19.tar.gz
Collecting pycparser (from cffi>=1.1->bcrypt>=3.1.3->paramiko)
  Downloading pycparser-2.18.tar.gz (245kB)
Building wheels for collected packages: gevent, docopt, greenlet, bcrypt, cryptography, pynacl, cffi, ipaddress, pycparser
  Running setup.py bdist_wheel for gevent: started
  Running setup.py bdist_wheel for gevent: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/c2/0e/3a/0fe9937cfeb4ad6e52c6b332ff69ebdd2a0ff014902e650300
  Running setup.py bdist_wheel for docopt: started
  Running setup.py bdist_wheel for docopt: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/b2/16/5f/c33a2bb5f2dce71205f8e65cbfd05647d79d441282be31fd82
  Running setup.py bdist_wheel for greenlet: started
  Running setup.py bdist_wheel for greenlet: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/ac/03/1c/645330f4cf8dd406adb2ea80dc50adc1ee30bab15e5b30693b
  Running setup.py bdist_wheel for bcrypt: started
  Running setup.py bdist_wheel for bcrypt: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/3c/3a/46/aebf133d0746d742726bcc9b31c4f7c5827f51a12c1f1c5b4b
  Running setup.py bdist_wheel for cryptography: started
  Running setup.py bdist_wheel for cryptography: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/e3/7b/98/e890b29317da1b29996aa27c5dcdd28104e09ffa2872408c13
  Running setup.py bdist_wheel for pynacl: started
  Running setup.py bdist_wheel for pynacl: still running...
  Running setup.py bdist_wheel for pynacl: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/36/ac/a9/7ff5a2285116623b4ecafc12c42282956abe48f3f246a91faa
  Running setup.py bdist_wheel for cffi: started
  Running setup.py bdist_wheel for cffi: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/6e/3e/ea/7c7a81e010f9ca4f1ee3ebf1005f316612274e3e44f90a5ada
  Running setup.py bdist_wheel for ipaddress: started
  Running setup.py bdist_wheel for ipaddress: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/d7/6b/69/666188e8101897abb2e115d408d139a372bdf6bfa7abb5aef5
  Running setup.py bdist_wheel for pycparser: started
  Running setup.py bdist_wheel for pycparser: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/95/14/9a/5e7b9024459d2a6600aaa64e0ba485325aff7a9ac7489db1b6
Successfully built gevent docopt greenlet bcrypt cryptography pynacl cffi ipaddress pycparser
Installing collected packages: greenlet, gevent, docopt, chardet, certifi, urllib3, idna, requests, pyasn1, pycparser, cffi, bcrypt, asn1crypto, enum34, ipaddress, cryptography, pynacl, paramiko, scp
  Found existing installation: chardet 2.2.1
    Uninstalling chardet-2.2.1:
      Successfully uninstalled chardet-2.2.1
Successfully installed asn1crypto-0.24.0 bcrypt-3.1.4 certifi-2018.1.18 cffi-1.11.5 chardet-3.0.4 cryptography-2.1.4 docopt-0.6.2 enum34-1.1.6 gevent-1.2.2 greenlet-0.4.13 idna-2.6 ipaddress-1.0.19 paramiko-2.4.0 pyasn1-0.4.2 pycparser-2.18 pynacl-1.2.1 requests-2.18.4 scp-0.10.2 urllib3-1.22
CHECK:rc == 0	[Pass]

RUN:pip list 2>/dev/null | grep gevent [Tue Mar  6 21:58:58 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
gevent (1.2.2)
CHECK:output =~ gevent \(\d	[Pass]
CHECK:rc == 0	[Pass]

RUN:pip list 2>/dev/null | grep docopt [Tue Mar  6 21:58:58 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
docopt (0.6.2)
CHECK:output =~ docopt \(\d	[Pass]
CHECK:rc == 0	[Pass]

RUN:pip list 2>/dev/null | grep requests [Tue Mar  6 21:58:59 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
requests (2.18.4)
CHECK:output =~ requests \(\d	[Pass]
CHECK:rc == 0	[Pass]

RUN:pip list 2>/dev/null | grep paramiko [Tue Mar  6 21:59:00 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
paramiko (2.4.0)
CHECK:output =~ paramiko \(\d	[Pass]
CHECK:rc == 0	[Pass]

RUN:pip list 2>/dev/null | grep scp [Tue Mar  6 21:59:01 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
scp (0.10.2)
CHECK:output =~ scp \(\d	[Pass]
CHECK:rc == 0	[Pass]

RUN:rm -rf /tmp/set_up_env_for_support_openbmc_in_python [Tue Mar  6 21:59:01 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::set_up_env_for_support_openbmc_in_python::Passed::Time:Tue Mar  6 21:59:01 2018 ::Duration::226 sec------
------Total: 1 , Failed: 0------
```