### PR TITLE
delete XCAT_OPENBMC_DEVEL from perl rflash -d

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1878,10 +1878,6 @@ sub parse_command_status {
             } elsif ($subcommand =~ /^-a|^--activate/) {
                 $activate = 1;
             } elsif ($subcommand =~ /^-d/) {
-                my $check = unsupported($callback); if (ref($check) eq "ARRAY") {
-                    xCAT::SvrUtils::sendmsg($check, $callback);
-                    return 1;
-                }
                 $streamline = 1;
             } elsif ($subcommand =~ /^--no-host-reboot/) {
                 $nohost_reboot = 1;


### PR DESCRIPTION
For #4899 

XCAT_OPENBMC_DEVEL is being used to control openbmc code go to python and to enable/disable rflash -d at same time in RC2. it triggered ﻿﻿conflict. As discussed in China team, delete XCAT_OPENBMC_DEVEL control for perl  "rflash -d".

UT:
1,  enable ``XCAT_OPENBMC_DEVEL=NO``
2, before this fix, ``rflash -d`` return: 
```
]# rflash f6u03 -d /tmp
Error: This openbmc related function is not yet supported. Please contact xCAT development team.
```
3, after this fix, ``rflash -d`` return:
```
]# rflash f6u03 -d /tmp
Error: No BMC tar file found in /tmp
Error: No PNOR tar file found in /tmp
```
```

