### PR TITLE
Refine openbmc python support error message, and information about switch to perl

### DIFF
--- a/xCAT-server/lib/perl/xCAT/OPENBMC.pm
+++ b/xCAT-server/lib/perl/xCAT/OPENBMC.pm
@@ -137,7 +137,7 @@ sub submit_agent_request {
         $retry++;
     }
     if (!defined($sock)) {
-        xCAT::MsgUtils->message("E", { data => ["OpenBMC management is using a Python framework. An error has occured when trying to create socket $AGENT_SOCK_PATH."] }, $callback);
+        xCAT::MsgUtils->message("E", { data => ["OpenBMC management is using a Python framework. An error has occurred when trying to create socket $AGENT_SOCK_PATH."] }, $callback);
         kill('TERM', $pid);
         return;
     }
@@ -196,6 +196,7 @@ sub wait_agent {
     waitpid($pid, 0);
     if ($? >> 8 != 0) {
         xCAT::MsgUtils->message("E", { data => ["Agent exited unexpectedly.  See $PYTHON_LOG_PATH for details."] }, $callback);
+        xCAT::MsgUtils->message("I", { data => ["To revert to Perl framework: chdef -t site clustersite openbmcperl=ALL"] }, $callback);
     }
 }
 


### PR DESCRIPTION
The return message looks like this right now:
```
[root@briggs01 ~]# rpower mid05tor12cn13 state
Error: OpenBMC management is using a Python framework and some dependency libraries could not be imported.
Error: Agent exited unexpectedly.  See /var/log/xcat/agent.log for details.
To revert to Perl framework: chdef -t site clustersite openbmcperl=ALL
```