### PR TITLE
Add ondiscover support for chain table

### DIFF
--- a/xCAT-genesis-scripts/usr/bin/doxcat
+++ b/xCAT-genesis-scripts/usr/bin/doxcat
@@ -364,16 +364,12 @@ while :; do
 		destiny=`/bin/nextdestiny $XCATMASTER:$XCATPORT`
 		logger -s -t $log_label -p local4.info "nextdestiny (ondiscover) - Complete."
 	elif [ "$dest" = runcmd ]; then
+		$destparameter
 		logger -s -t $log_label -p local4.info "Running nextdestiny $XCATMASTER:$XCATPORT..."
 		destiny=`/bin/nextdestiny $XCATMASTER:$XCATPORT`
 		dest=`echo $destiny|awk -F= '{print $1}'`
-		$destparameter
 		logger -s -t $log_label -p local4.info "nextdestiny - Complete."
 	elif [ "$dest" = runimage ]; then
-		logger -s -t $log_label -p local4.info "Running nextdestiny $XCATMASTER:$XCATPORT..."
-		destiny=`/bin/nextdestiny $XCATMASTER:$XCATPORT`
-		dest=`echo $destiny|awk -F= '{print $1}'`
-		logger -s -t $log_label -p local4.info "nextdestiny - Complete."
 		mkdir /tmp/`basename $destparameter`
 		cd /tmp/`basename $destparameter`
 		eval destparameter=$destparameter
@@ -393,6 +389,11 @@ while :; do
 		tar xvf `basename $destparameter`
 		./runme.sh
 		cd -
+                logger -s -t $log_label -p local4.info "Running nextdestiny $XCATMASTER:$XCATPORT..."
+		destiny=`/bin/nextdestiny $XCATMASTER:$XCATPORT`
+		dest=`echo $destiny|awk -F= '{print $1}'`
+		logger -s -t $log_label -p local4.info "nextdestiny - Complete."
+
 	elif [ "$dest" = "reboot" -o "$dest" = "boot" ]; then
 		logger -s -t $log_label -p local4.info "Running nextdestiny $XCATMASTER:$XCATPORT..."
 		/bin/nextdestiny $XCATMASTER:$XCATPORT

--- a/xCAT-genesis-scripts/usr/bin/doxcat
+++ b/xCAT-genesis-scripts/usr/bin/doxcat
@@ -399,7 +399,10 @@ while :; do
 		/bin/nextdestiny $XCATMASTER:$XCATPORT
 		logger -s -t $log_label -p local4.info "nextdestiny - Complete."
 		if [ $IPMI_SUPPORT -ne 0 ]; then
-		    ipmitool chassis bootdev pxe
+                    # Set boot from network will cause OpenPOWER server wait at petitboot menu, so do nothing here
+                    if uname -m | grep x86_64; then
+		        ipmitool chassis bootdev pxe
+                    fi
 		fi
 		reboot -f
 	elif [ "$dest" = "install" -o "$dest" = "netboot" ]; then

--- a/xCAT-genesis-scripts/usr/bin/doxcat
+++ b/xCAT-genesis-scripts/usr/bin/doxcat
@@ -359,6 +359,10 @@ while :; do
 		logger -s -t $log_label -p local4.info "Running nextdestiny $XCATMASTER:$XCATPORT..."
 		destiny=`/bin/nextdestiny $XCATMASTER:$XCATPORT`
 		logger -s -t $log_label -p local4.info "nextdestiny - Complete."
+        elif [ "$dest" = ondiscover ]; then
+		logger -s -t $log_label -p local4.info "Running nextdestiny (ondiscover) $XCATMASTER:$XCATPORT..."
+		destiny=`/bin/nextdestiny $XCATMASTER:$XCATPORT`
+		logger -s -t $log_label -p local4.info "nextdestiny (ondiscover) - Complete."
 	elif [ "$dest" = runcmd ]; then
 		logger -s -t $log_label -p local4.info "Running nextdestiny $XCATMASTER:$XCATPORT..."
 		destiny=`/bin/nextdestiny $XCATMASTER:$XCATPORT`

--- a/xCAT-server/lib/xcat/plugins/destiny.pm
+++ b/xCAT-server/lib/xcat/plugins/destiny.pm
@@ -235,21 +235,11 @@ sub setdestiny {
             $callback->({ error => "invalid argument: \"$state\"", errorcode => [1] });
             return;
         }
-        my @cmds = ();
-        while ($target ) {
-             my ($cmd, $next_cmds) = split '\|', $target, 2;
-             push (@cmds, $cmd);
-             if (!$next_cmds) {
-                 last;
-             } else {
-                 $target = $next_cmds;
-             }
-        }
-
+        my @cmds = split '\|', $target;
         foreach my $tmpnode (@{ $req->{node} }) {
             foreach my $cmd (@cmds) {
                 my $action;
-               ($cmd, $action) = split ':', $cmd, 2;
+               ($cmd, $action) = split ':', $cmd;
                 my $runcmd = "$cmd $tmpnode $action";
                 xCAT::Utils->runcmd($runcmd, 0);
                 xCAT::MsgUtils->trace($verbose, "d", "run ondiscover command: $runcmd");

--- a/xCAT-server/lib/xcat/plugins/destiny.pm
+++ b/xCAT-server/lib/xcat/plugins/destiny.pm
@@ -226,6 +226,35 @@ sub setdestiny {
             if ($ient->{initrd})   { $bphash->{initrd}   = $ient->{initrd} }
             if ($ient->{kcmdline}) { $bphash->{kcmdline} = $ient->{kcmdline} }
         }
+    } elsif ($state =~ /ondiscover/) {
+        my $target;
+        if ($state =~ /=/) {
+            ($state, $target) = split '=', $state, 2;
+        }
+        if(!$target){
+            $callback->({ error => "invalid argument: \"$state\"", errorcode => [1] });
+            return;
+        }
+        my @cmds = ();
+        while ($target ) {
+             my ($cmd, $next_cmds) = split '\|', $target, 2;
+             push (@cmds, $cmd);
+             if (!$next_cmds) {
+                 last;
+             } else {
+                 $target = $next_cmds;
+             }
+        }
+
+        foreach my $tmpnode (@{ $req->{node} }) {
+            foreach my $cmd (@cmds) {
+                my $action;
+               ($cmd, $action) = split ':', $cmd, 2;
+                my $runcmd = "$cmd $tmpnode $action";
+                xCAT::Utils->runcmd($runcmd, 0);
+                xCAT::MsgUtils->trace($verbose, "d", "run ondiscover command: $runcmd");
+            }
+        }
     } elsif ($state =~ /^install[=\$]/ or $state eq 'install' or $state =~ /^netboot[=\$]/ or $state eq 'netboot' or $state eq "image" or $state eq "winshell" or $state =~ /^osimage/ or $state =~ /^statelite/) {
         my $target;
         my $action;


### PR DESCRIPTION
For issue #4294 
Add ondiscover command to chain attribute of node definition.  During the node discovery phase,   the genesis will process those command before compute nodes provisioned.

Use "|" as delimited for each command, and use ":" for command and action
```
chdef mid08tor03cn01 chain=runcmd=bmcsetup,ondiscover='makegocons|rspconfig:sshcfg',osimage=rhels7.5-snap2-ppc64le-netboot-compute
```