### PR TITLE
When xCAT-openbmc-py is not installed on Service Node, log does not help describe the problem

### DIFF
--- a/xCAT-server/lib/perl/xCAT/OPENBMC.pm
+++ b/xCAT-server/lib/perl/xCAT/OPENBMC.pm
@@ -69,11 +69,14 @@ sub acquire_lock {
     flock($lock_fd, LOCK_EX) or return undef;
     return $lock_fd;
 }
-sub start_python_agent {
-    if (! -e $PYTHON_AGENT_FILE) {
-        xCAT::MsgUtils->message("S", "start_python_agent() Error: '$PYTHON_AGENT_FILE' does not exist");
-        return undef;
+
+sub exists_python_agent {
+    if ( -e $PYTHON_AGENT_FILE) {
+        return 1;
     }
+    return 0;
+}
+sub start_python_agent {
 
     if (!defined(acquire_lock())) {
         xCAT::MsgUtils->message("S", "start_python_agent() Error: Failed to acquire lock");

--- a/xCAT-server/lib/xcat/plugins/openbmc2.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc2.pm
@@ -117,6 +117,10 @@ sub process_request {
     my $request = shift;
     $callback = shift;
 
+    if (!xCAT::OPENBMC::exists_python_agent()) {
+        xCAT::MsgUtils->message("E", { data => ["The xCAT Python agent does not exist. Check if xCAT-openbmc-py package is installed on management node and service nodes."] }, $callback);
+        return;
+    }
     # If we can't start the python agent, exit immediately
     my $pid = xCAT::OPENBMC::start_python_agent();
     if (!defined($pid)) {


### PR DESCRIPTION
To fix #4908
check if agent exists in process_request and give more clear message.

After the fix, if xCAT-openbmc-py is not installed on SN, it will print error message
```
Error: The xCAT Python agent does not exists. Check if xCAT-openbmc-py package is installed on management node and service nodes.
mid08tor03cn10: on
```