### PR TITLE
fix issue: genimage tries direct DB access instead of via xCATd #4385

### DIFF
--- a/xCAT-client/bin/genimage
+++ b/xCAT-client/bin/genimage
@@ -116,7 +116,7 @@ if (@ARGV > 0) {
 }
 
 if ((!$imagename) && (!$profile) && (!$os) && (!$arch)) {
-    my $tmpimgs = `lsdef -t osimage -w provmethod=~'/statelite|netboot/' |cut -d' ' -f1`;
+    my $tmpimgs = `XCATXMLTRACE=0 XCATBYPASS=0 lsdef -t osimage -w provmethod=~'/statelite|netboot/' |cut -d' ' -f1`;
     if ($? == 0) {
         if (($tmpimgs) && ($tmpimgs !~ /^Could/)) { #Could is returned when the osimage table is empty
             my @images = split('\n', $tmpimgs);
@@ -162,8 +162,7 @@ if ((!$imagename) && (!$profile) && (!$os) && (!$arch)) {
 
 
 # get the install directory
-my @entries    = xCAT::TableUtils->get_site_attribute("installdir");
-my $installdir = $entries[0];
+my $installdir = `XCATXMLTRACE=0 XCATBYPASS=0 lsdef -t site -o clustersite -i installdir|grep -w 'installdir'|cut -d= -f2`;
 chomp($installdir);
 
 # lots of error checking to make sure it exists.


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/4385:

```
[root@c910f03c05k21 xcat-core]# tabdump policy
#priority,name,host,commands,noderange,parameters,time,rule,comments,disable
...
"7.4","myuser",,"lsdef,genimage",,,,"allow",,

[root@c910f03c05k21 xcat-core]# su myuser
[myuser@c910f03c05k21 xcat-core]$ genimage
Do you want to re-generate an existing image from the osimage table? [y/n] y
Available images:
   rhels6.5-x86_64-netboot-compute
   rhels6.5-x86_64-statelite-compute
   rhels7.3-ppc64le-netboot-compute
   rhels7.3-ppc64le-statelite-compute
   rhels7.4-ppc64le-netboot-compute
   rhels7.4-ppc64le-statelite-compute
   rhels7.4-x86_64-netboot-compute
   rhels7.4-x86_64-statelite-compute
   sles12.2-ppc64le-netboot-compute
   sles12.2-ppc64le-statelite-compute
   test
Which image do you want to re-generate? [rhels6.5-x86_64-netboot-compute] rhels7.4-ppc64le-netboot-compute
Generating image:
cd /opt/xcat/share/xcat/netboot/rh; ./genimage -a ppc64le -o rhels7.4 -p compute --permission 755 --srcdir "/install/rhels7.4/ppc64le" --pkglist /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist --otherpkgdir "/install/post/otherpkgs/rhels7.4/ppc64le" --postinstall /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.postinstall --rootimgdir /install/netboot/rhels7.4/ppc64le/compute --tempfile /tmp/xcat_genimage.2324 rhels7.4-ppc64le-netboot-compute
103 blocks
/opt/xcat/share/xcat/netboot/rh
103 blocks
/opt/xcat/share/xcat/netboot/rh
 yum -y -c /tmp/genimage.2363.yum.conf --installroot=/install/netboot/rhels7.4/ppc64le/compute/rootimg/ --disablerepo=* --enablerepo=rhels7.4-ppc64le-0 --enablerepo=rhels7.4-ppc64le-1 --enablerepo=rhels7.4-ppc64le-2  install  bash nfs-utils openssl dhclient kernel openssh-server openssh-clients wget rsyslog vim-minimal ntp rsyslog rpm rsync ppc64-utils iputils dracut dracut-network e2fsprogs bc file lsvpd irqbalance procps-ng parted net-tools gzip tar xz grub2 grub2-tools bzip2 ethtool
Package bash-4.2.46-28.el7.ppc64le already installed and latest version
Resolving Dependencies
There are unfinished transactions remaining. You might consider running yum-complete-transaction, or "yum-complete-transaction --cleanup-only" and "yum history redo last", first to finish them. If those don't work you'll have to try removing/installing packages by hand (maybe package-cleanup can help).
The program yum-complete-transaction is found in the yum-utils package.
--> Running transaction check
---> Package bc.ppc64le 0:1.06.95-13.el7 will be installed
--> Processing Dependency: libreadline.so.6()(64bit) for package: bc-1.06.95-13.el7.ppc64le
---> Package bzip2.ppc64le 0:1.0.6-13.el7 will be installed
---> Package dhclient.ppc64le 12:4.2.5-58.el7 will be installed
--> Processing Dependency: dhcp-common = 12:4.2.5-58.el7 for package: 12:dhclient-4.2.5-58.el7.ppc64le
--> Processing Dependency: dhcp-libs(ppc-64) = 12:4.2.5-58.el7 for package: 12:dhclient-4.2.5-58.el7.ppc64le
--> Processing Dependency: coreutils for package: 12:dhclient-4.2.5-58.el7.ppc64le
--> Processing Dependency: grep for package: 12:dhclient-4.2.5-58.el7.ppc64le
--> Processing Dependency: hostname for package: 12:dhclient-4.2.5-58.el7.ppc64le
--> Processing Dependency: initscripts for package: 12:dhclient-4.2.5-58.el7.ppc64le
--> Processing Dependency: iproute for package: 12:dhclient-4.2.5-58.el7.ppc64le
--> Processing Dependency: sed for package: 12:dhclient-4.2.5-58.el7.ppc64le
--> Processing Dependency: gawk for package: 12:dhclient-4.2.5-58.el7.ppc64le
...
```