### PR TITLE
conserver message change

### DIFF
--- a/xCAT-server/lib/xcat/plugins/conserver.pm
+++ b/xCAT-server/lib/xcat/plugins/conserver.pm
@@ -205,7 +205,7 @@ sub process_request {
         if (-x "/usr/bin/goconserver") {
             require xCAT::Goconserver;
             if (xCAT::Goconserver::is_goconserver_running()) {
-                my $rsp->{data}->[0] = "goconserver is started, please stop it at first.";
+                my $rsp->{data}->[0] = "goconserver is being used as the console service, did you mean: makegocons <noderange>? If not, stop goconserver and retry.";
                 xCAT::MsgUtils->message("E", $rsp, $cb);
                 return;
             }


### PR DESCRIPTION
Improve message when `makeconservercf` is issued while goconserver service is running, giving the user a hint that perhaps whey wanted to issue `makegocons` instead.

Before:
```
[root@briggs01 xcat]# makeconservercf mid05tor12cn02
Error: goconserver is started, please stop it at first.
[root@briggs01 xcat]#
```

After:
```
[root@briggs01 xcat]# makeconservercf mid05tor12cn02
Error: goconserver is being used as the console service, did you mean: makegocons <node>? If not, stop goconserver and retry.
[root@briggs01 xcat]#
```