### PR TITLE
enhance mlnxofed_ib_install.v2 return 1 when service openibd restart …

### DIFF
--- a/xCAT-server/share/xcat/ib/scripts/Mellanox/mlnxofed_ib_install.v2
+++ b/xCAT-server/share/xcat/ib/scripts/Mellanox/mlnxofed_ib_install.v2
@@ -328,6 +328,10 @@ EOF
         #force openibd load all modules in need, restart again
         sleep 1
         service openibd restart
+        if [ "$?" != "0" ] ;then
+            echo "[Error] service openibd restart failed."
+            exit 1
+        fi
     fi
 
     if [[ "$NODESETSTATE" == "genimage" ]]; then


### PR DESCRIPTION
For #3701 
UT:
```
c910f03c01p10: Mon Mar 12 23:03:04 EDT 2018 Running postscript: mlnxofed_ib_install
c910f03c01p10: Mellanox OFED file path is /install/mlnx
c910f03c01p10: Mellanox OFED file is MLNX_OFED_LINUX-4.3-1.0.1.1-rhel7.5alternate-ppc64le.iso
c910f03c01p10: Mellanox OFED options are --add-kernel-support
c910f03c01p10: image root path is
c910f03c01p10: NODESETSTATE is boot
c910f03c01p10: Downloading Mellanox OFED file MLNX_OFED_LINUX-4.3-1.0.1.1-rhel7.5alternate-ppc64le.iso form http://10.3.1.9//install/mlnx ..........
c910f03c01p10: [OK]
c910f03c01p10: Mounting Mellanox OFED file MLNX_OFED_LINUX-4.3-1.0.1.1-rhel7.5alternate-ppc64le.iso .........
c910f03c01p10: mount: /dev/loop0 is write-protected, mounting read-only
c910f03c01p10: [OK]
c910f03c01p10: Start Mellanox OFED installation .........
c910f03c01p10: TERM environment variable not set.
c910f03c01p10: Detected rhel7u4 ppc64le. Disabling installing 32bit rpms...
c910f03c01p10: Error: The current MLNX_OFED_LINUX is intended for rhel7.5alternate
c910f03c01p10: Redirecting to /bin/systemctl restart openibd.service
c910f03c01p10: Failed to restart openibd.service: Unit not found.
c910f03c01p10: [Error] service openibd restart failed.
c910f03c01p10: postscript: mlnxofed_ib_install exited with code 1
c910f03c01p10: Mon Mar 12 23:03:06 EDT 2018 Running postscript: otherpkgs
c910f03c01p10: ./otherpkgs: no extra rpms to install
c910f03c01p10: postscript: otherpkgs exited with code 0
c910f03c01p10: //xcatpost/mypostscript return with 1
c910f03c01p10: Running of postscripts has completed.
```

