### PR TITLE
add template for openbmc controlled Power LE  server

### DIFF
--- a/xCAT/templates/objects/node/ppc64le-ipmi.stanza
+++ b/xCAT/templates/objects/node/ppc64le-ipmi.stanza
@@ -1,4 +1,4 @@
-# <the template for PowerLE NV node definition>
+# <the template for ipmi controlled PowerLE NV node definition>
 
 ppc64le-template:
     objtype=node
@@ -15,4 +15,4 @@ ppc64le-template:
     nodetype=mp
     serialport=0
     serialspeed=115200
-    usercomment="the template for PowerLE NV node definition"
+    usercomment="the template for ipmi controlled PowerLE NV node definition"

--- a/xCAT/templates/objects/node/ppc64le-openbmc.stanza
+++ b/xCAT/templates/objects/node/ppc64le-openbmc.stanza
@@ -1,0 +1,18 @@
+# <the template for openbmc controlled PowerLE NV node definition>
+
+ppc64le-openbmc-template:
+    objtype=node
+    arch=ppc64le
+    bmc="MANDATORY:The hostname or ip address of the BMC adapater"
+    bmcpassword="MANDATORY:the password of the BMC"
+    bmcusername="MANDATORY:the username of the BMC"
+    cons=openbmc
+    groups=all
+    ip=OPTIONAL:the ip address of the node
+    mac=OPTIONAL:the mac of the node
+    mgt=openbmc
+    netboot=petitboot
+    nodetype=mp
+    serialport=0
+    serialspeed=115200
+    usercomment="the template for openbmc controlled PowerLE NV node definition"


### PR DESCRIPTION
fix issue:
https://github.com/xcat2/xcat-core/issues/4285

```
[root@c910f03c05k21 node]# mkdef -t node openbmcnode1 --template ppc64le-openbmc-template bmcusername=USERID bmcpassword=PASSW0RD bmc=10.0.0.1
1 object definitions have been created or modified.
[root@c910f03c05k21 node]# lsdef openbmcnode1
Object name: openbmcnode1
    arch=ppc64le
    bmc=10.0.0.1
    bmcpassword=PASSW0RD
    bmcusername=USERID
    cons=openbmc
    groups=all
    mgt=openbmc
    netboot=petitboot
    nodetype=mp
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
    serialport=0
    serialspeed=115200
    usercomment=the template for openbmc controlled PowerLE NV node definition
[root@c910f03c05k21 node]# lsdef -t node --template
cec-template  (node)
hmc-template  (node)
onieswitch  (node)
ppc64le-ipmi-template  (node)
ppc64le-openbmc-template  (node)
ppc64lekvmguest-template  (node)
switch-template  (node)
x86_64-template  (node)
x86_64kvmguest-template  (node)
[root@c910f03c05k21 node]# lsdef -t node --template ppc64le-openbmc-template
Object name: ppc64le-openbmc-template
    arch=ppc64le
    bmc=MANDATORY:The hostname or ip address of the BMC adapater
    bmcpassword=MANDATORY:the password of the BMC
    bmcusername=MANDATORY:the username of the BMC
    cons=openbmc
    groups=all
    ip=OPTIONAL:the ip address of the node
    mac=OPTIONAL:the mac of the node
    mgt=openbmc
    netboot=petitboot
    nodetype=mp
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
    serialport=0
    serialspeed=115200
    usercomment=the template for openbmc controlled PowerLE NV node definition
```