### PR TITLE
enhance invalid node name error msg

### DIFF
--- a/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
+++ b/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
@@ -1554,6 +1554,7 @@ sub defmk
     } else {
         my $invalidobjname = ();
         my $invalidnodename = ();
+        my $nodewithdomain = ();
         foreach my $node (@::allobjnames) {
             my $myobjtype=$::opt_t;
             if(!$myobjtype and $::FILEATTRS{$node}{'objtype'}){
@@ -1563,9 +1564,21 @@ sub defmk
             unless(isobjnamevalid($node,$myobjtype)){
                $invalidobjname .= ",$node";
             }
-            if (($node =~ /[A-Z]/) && (((!$::opt_t) && (!$::FILEATTRS{$node}{'objtype'})) || ($::FILEATTRS{$node}{'objtype'} eq "node") || ($::opt_t eq "node"))) { 
-               $invalidnodename .= ",$node";
+            if (((!$::opt_t) && (!$::FILEATTRS{$node}{'objtype'})) || ($::FILEATTRS{$node}{'objtype'} eq "node") || ($::opt_t eq "node")) { 
+                if($node =~ /[A-Z]/){
+                    $invalidnodename .= ",$node";
+                }elsif($node =~ /\./){
+                    $nodewithdomain .= ",$node"; 
+                }
             }
+        }
+        if ($nodewithdomain) {
+            $nodewithdomain =~ s/,//;
+            my $rsp;
+            $rsp->{data}->[0] = "The object name \'$nodewithdomain\' is invalid, Cannot use '.' in node name.";
+            xCAT::MsgUtils->message("E", $rsp, $::callback);
+            $error = 1;
+            return 1;
         }
         if ($invalidobjname) {
             $invalidobjname =~ s/,//;


### PR DESCRIPTION
for #4792 
Before enhancement, the error message is :
```
]# cat test.stanza  | mkdef -z
Error: The object name 'c100.domain.com' is invalid, please refer to "man xcatdb" for the valid "xCAT Object Name Format"
```
After enhancement, the error message is :
```
]# cat test.stanza |mkdef -z
Error: The object name 'c100.domain.com' is invalid, Cannot use '.' in node name.

]# mkdef -t node -o abc.cluster.com groups=all
Error: The object name 'abc.cluster.com' is invalid, Cannot use '.' in node name.

]# mkdef abc.cluster.com groups=all
Error: The object name 'abc.cluster.com' is invalid, Cannot use '.' in node name.

]# mkdef ABC groups=all
Warning: The node name 'ABC' contains capital letters which may not be resolved correctly by the dns server.
1 object definitions have been created or modified.

]# mkdef abc%^ groups=all
Error: The object name 'abc%^' is invalid, please refer to "man xcatdb" for the valid "xCAT Object Name Format"
```