### PR TITLE
fix issue If multiple IP addresses used in xcatmaster field, updatenode will not work leaving node in bad state #3688

### DIFF
--- a/perl-xCAT/xCAT/InstUtils.pm
+++ b/perl-xCAT/xCAT/InstUtils.pm
@@ -716,7 +716,8 @@ sub getOSnodes
    		Determines the server node names as known by a lists of nodes. 
 
     Arguments:
-		A list of node names.
+                $nodes: A list of node names.
+                $skipfacing: do not get facing ip when noderes.xcatmaster is not set
 
     Returns:
 		A hash ref  of arrays, the key is the service node pointing to
@@ -736,6 +737,7 @@ sub get_server_nodes
     my $class    = shift;
     my $callback = shift;
     my $nodes    = shift;
+    my $skipfacing=shift;
 
     my @nodelist;
     if ($nodes)
@@ -760,11 +762,14 @@ sub get_server_nodes
             my $xcatmaster = $xcatmasters->{$node}->[0]->{xcatmaster};
             $serv = xCAT::NetworkUtils->getipaddr($xcatmaster);
         }
-        else
+        elsif (!$skipfacing)
         {
             #  get ip facing node
             my @servd = xCAT::NetworkUtils->my_ip_facing($node);
             unless ($servd[0]) { $serv = $servd[1]; }
+        }
+        else{
+            continue;
         }
         chomp $serv;
 

--- a/xCAT-server/lib/perl/xCAT/Postage.pm
+++ b/xCAT-server/lib/perl/xCAT/Postage.pm
@@ -573,6 +573,13 @@ sub makescript {
             $master_ip = "$ipaddr";
         }
 
+        unless($master_ip){
+            my $rsp;
+            $rsp->{data}->[0] = "makescript failed: unable to resolve xcatmaster \"$master\" for $node";
+            xCAT::MsgUtils->message("SE", $rsp, $callback, 1);
+            return;
+        }
+
         #ok, now do everything else..
         #$inc =~ s/#XCATVAR:([^#]+)#/envvar($1)/eg;
         #$inc =~ s/#ENV:([^#]+)#/xCAT::Template::envvar($1)/eg;

--- a/xCAT-server/lib/xcat/plugins/updatenode.pm
+++ b/xCAT-server/lib/xcat/plugins/updatenode.pm
@@ -306,6 +306,37 @@ sub preprocess_updatenode
         return;
     }
 
+
+    # get server names as known by the nodes
+    my %servernodes =
+      %{ xCAT::InstUtils->get_server_nodes($callback, $request->{node}) };
+
+    # it's possible that the nodes could have diff server names
+    # do all the nodes for a particular server at once
+
+    my @invalidnodes;
+    if($servernodes{undef}){
+        push @invalidnodes,@{$servernodes{undef}};
+    }
+
+    if ($servernodes{""}){
+        push @invalidnodes,@{$servernodes{""}};
+    }
+
+    if (@invalidnodes){
+        my %allnodes=map {$_,1} @{$request->{node}};
+        foreach my $node (@invalidnodes){
+           xCAT::MsgUtils->report_node_error($callback,$node,"Could not determine or resolve xcatmaster for $node. Will skip this node.")
+           delete $allnodes{$node};
+        }
+        $request->{node}=[];
+        push $request->{node}, map  $_ ,keys %allnodes;
+    }
+
+    unless (scalar @{$request->{node}}){
+        return;
+    }
+
     # preprocess generate mypostscripts files (-g) for hierarchy
     # if no sharedtftp then we need to broadcast this updatenode -g to all service nodes inorder
     # to be able to support service node pools
@@ -1524,7 +1555,7 @@ sub updatenoderunps
 
     # get server names as known by the nodes
     my %servernodes =
-      %{ xCAT::InstUtils->get_server_nodes($callback, \@$nodes) };
+      %{ xCAT::InstUtils->get_server_nodes($callback, \@$nodes,1) };
 
     # it's possible that the nodes could have diff server names
     # do all the nodes for a particular server at once
@@ -1534,6 +1565,7 @@ sub updatenoderunps
         if ((!defined($snkey)) or ($snkey eq "")) { # if we could not find the xcatmaster
 
             my $rsp = {};
+            $rsp->{errorcode}->[0]=1;
             $rsp->{error}->[0] = "Could not find xcatmaster for @{$servernodes{$snkey}}. Will skip this node. ";
             $callback->($rsp);
             next;


### PR DESCRIPTION
fix issue:
https://github.com/xcat2/xcat-core/issues/3688

UT:
```
[root@c910f03c05k21 xcat-core]# lsdef c910f03c17k42 -i xcatmaster
Object name: c910f03c17k42
    xcatmaster=c910f03c05k21,c910f03c05k27

[root@c910f03c05k21 xcat-core]# updatenode c910f03c17k42,c910f03c05k27
Error: Could not determine or resolve xcatmaster for c910f03c17k42. Will skip this node.
c910f03c05k27: bash: /usr/bin/rsync: No such file or directory
c910f03c05k27: rsync: connection unexpectedly closed (0 bytes received so far) [sender]
c910f03c05k27: rsync error: remote command not found (code 127) at io.c(605) [sender=3.0.9]
File synchronization has completed for nodes.
Performing software maintenance operations. This could take a while, if there are packages to install.

c910f03c05k27: vpdupdate is not supported on the pSeries KVM Guest platform
c910f03c05k27: updating VPD database
c910f03c05k27: trying to download postscripts...
c910f03c05k27: postscripts downloaded successfully
c910f03c05k27: trying to get mypostscript from 10.3.5.21...
c910f03c05k27: Tue Mar 13 04:40:09 EDT 2018 Running postscr
...
[root@c910f03c05k21 xcat-core]# echo $?
1
```