### PR TITLE
Display Perl/Python for OpenBMC commands with -V

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -908,6 +908,9 @@ sub process_request {
     my $rst = parse_command_status($command, \@exargs);
     return if ($rst);
 
+    if ($::VERBOSE) {
+        xCAT::SvrUtils::sendmsg("Running command in Perl", $callback);
+    }
     if ($request->{command}->[0] ne "getopenbmccons") {
         $cookie_jar = HTTP::Cookies->new({});
         $async = HTTP::Async->new(

--- a/xCAT-server/lib/xcat/plugins/openbmc2.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc2.pm
@@ -47,6 +47,7 @@ my $reventlog_no_id_resolved_errormsg = "Provide a comma separated list of IDs t
 
 my %node_info = ();
 my $callback;
+$::VERBOSE = 0;
 
 #-------------------------------------------------------
 
@@ -92,6 +93,9 @@ sub preprocess_request {
         return;
     }
 
+    if ($::VERBOSE) {
+        xCAT::SvrUtils::sendmsg("Running command in Python", $callback);
+    }
     my $sn = xCAT::ServiceNodeUtils->get_ServiceNode($noderange, "xcat", "MN");
     foreach my $snkey (keys %$sn) {
         my $reqcopy = {%$request};
@@ -157,9 +161,8 @@ sub parse_args {
     my $noderange = shift;
     my $subcommand = undef;
 
-    my $verbose;
     unless (GetOptions(
-        'V|verbose'  => \$verbose,
+        'V|verbose'  => \$::VERBOSE,
     )) {
         return ([ 1, "Error parsing arguments." ]);
     }


### PR DESCRIPTION
To aid in future debugging, add a verbose message showing Perl/Python environment:

```
[root@briggs01 xcat]# rpower p9up stat
mid05tor12cn16: on
mid05tor12cn15: on
mid05tor12cn13: on
mid05tor12cn05: on

[root@briggs01 xcat]# rpower p9up stat -V
[briggs01]: Running command in Python
[briggs01]: mid05tor12cn05: on
[briggs01]: mid05tor12cn13: on
[briggs01]: mid05tor12cn15: on
[briggs01]: mid05tor12cn16: on

[root@briggs01 xcat]# rspconfig p9up netmask
mid05tor12cn13: BMC Netmask: 255.255.0.0
mid05tor12cn16: BMC Netmask: 255.255.0.0
mid05tor12cn15: BMC Netmask: 255.255.0.0
mid05tor12cn05: BMC Netmask: 255.255.0.0

[root@briggs01 xcat]# rspconfig p9up netmask -V
[briggs01]: Running command in Perl
mid05tor12cn13: [briggs01]: BMC Netmask: 255.255.0.0
mid05tor12cn16: [briggs01]: BMC Netmask: 255.255.0.0
mid05tor12cn15: [briggs01]: BMC Netmask: 255.255.0.0
mid05tor12cn05: [briggs01]: BMC Netmask: 255.255.0.0
[root@briggs01 xcat]#
```