### PR TITLE
Adding more OpenBMC Unit Testing test cases to quickly test success case

### DIFF
--- a/xCAT-test/autotest/testcase/UT_openbmc/rflash_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rflash_cases0
@@ -70,3 +70,14 @@ cmd: rflash $$CN --delete 221d9020 221d9020
 check:rc==1 
 check:output=~Error: More than one firmware specified is not supported
 end
+
+start:rflash_delete_active_bmc
+description: Attempt to delete the active BMC firmware
+os:Linux
+hcp:openbmc
+cmd: rflash $$CN -l | grep \* | grep BMC | awk '{print $2}' | xargs -i{} rflash $$CN --delete {}
+check:rc==1
+check:output=~
+
+
+./xCAT-test/autotest/testcase/UT_openbmc/rflash_cases0

--- a/xCAT-test/autotest/testcase/UT_openbmc/rflash_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rflash_cases0
@@ -77,7 +77,5 @@ os:Linux
 hcp:openbmc
 cmd: rflash $$CN -l | grep \* | grep BMC | awk '{print $2}' | xargs -i{} rflash $$CN --delete {}
 check:rc==1
-check:output=~
-
-
-./xCAT-test/autotest/testcase/UT_openbmc/rflash_cases0
+check:output=~$$CN: Error: Deleting currently active firmware is not supported
+end

--- a/xCAT-test/autotest/testcase/UT_openbmc/supported_commands_case0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/supported_commands_case0
@@ -25,7 +25,7 @@ check:rc==0
 check:output=~$$CN: SYSTEM SerialNumber
 cmd: rinv $$CN firm
 check:rc==0
-check:output=~$$CN: HOST Firmware
+check:output=~$$CN: Host Firmware
 check:output=~$$CN: BMC Firmware
 cmd: rinv $$CN cpu
 check:rc==0
@@ -34,3 +34,123 @@ cmd: rinv $$CN dimm
 check:rc==0
 check:output=~$$CN: DIMM
 end 
+
+start:supported_cmds_rvitals
+description: Make sure that the rvitals command works...
+os:Linux
+hcp:openbmc
+cmd: rvitals $$CN
+check:rc==0
+check:output=~$$CN:
+cmd: rvitals $$CN temp
+check:rc==0
+check:output=~$$CN: Ambient:
+cmd: rvitals $$CN voltage
+check:rc==0
+check:output=~$$CN: Ps0 Input Voltage:
+cmd: rvitals $$CN wattage
+check:rc==0
+check:output=~$$CN: Total Power:
+cmd: rvitals $$CN fanspeed
+check:rc==0
+check:output=~$$CN: Fan
+cmd: rvitals $$CN power
+check:rc==0
+check:output=~$$CN: Total Power:
+cmd: rvitals $$CN leds
+check:rc==0
+check:output=~$$CN: Front
+check:output=~$$CN: Front Fans
+check:output=~$$CN: Rear
+cmd: rvitals $$CN all
+check:rc==0
+check:output=~$$CN: Ambient:
+end 
+
+start:supported_cmds_rbeacon
+description: Make sure the rbeacon command works ...
+os:Linux
+hcp:openbmc
+cmd:rbeacon $$CN on
+check:rc==0
+check:output=~$$CN: on 
+cmd: rbeacon $$CN off
+check:rc==0
+check:output=~$$CN: off
+end
+
+start:supported_cmds_reventlog
+description: Make sure the reventlog command works ...
+os:Linux
+hcp:openbmc
+cmd:reventlog $$CN
+check:rc==0
+check:output=~$$CN:
+cmd: reventlog $$CN 1
+check:rc==0
+check:output=~$$CN:
+cmd: reventlog $$CN all
+check:rc==0
+check:output=~$$CN:
+end
+
+start:supported_cmds_rflash
+description: Make sure the rflash command works ...
+os:Linux
+hcp:openbmc
+cmd:rflash $$CN -c
+check:rc==0
+check:output=~$$CN: BMC Firmware Product:
+check:output=~$$CN: HOST Firmware Product:
+cmd:rflash $$CN -l
+check:rc==0
+check:output=~$$CN: ID
+end
+
+start:supported_cmds_rsetboot
+description: Make sure the rsetboot command works ...
+os:Linux
+hcp:openbmc
+cmd:rsetboot $$CN stat
+check:rc==0
+check:output=~$$CN:
+end
+
+start:supported_cmds_rspconfig
+description: Make sure the rspconfig command works ...
+os:Linux
+hcp:openbmc
+cmd:rspconfig $$CN ipsrc
+check:rc==0
+check:output=~$$CN: BMC IP Source:
+cmd:rspconfig $$CN ip
+check:rc==0
+check:output=~$$CN: BMC IP:
+cmd:rspconfig $$CN netmask
+check:rc==0
+check:output=~$$CN: BMC Netmask:
+cmd:rspconfig $$CN gateway
+check:rc==0
+check:output=~$$CN: BMC Gateway:
+cmd:rspconfig $$CN hostname
+check:rc==0
+check:output=~$$CN: BMC Hostname:
+cmd:rspconfig $$CN vlan
+check:rc==0
+check:output=~$$CN: BMC VLAN ID:
+cmd:rspconfig $$CN dump -l
+check:rc==0
+check:output=~$$CN:
+cmd:rspconfig $$CN powerrestorepolicy
+check:rc==0
+check:output=~$$CN: BMC PowerRestorePolicy
+cmd:rspconfig $$CN powersupplyredundancy
+check:rc==0
+check:output=~$$CN: BMC PowerSupplyRedundancy
+cmd:rspconfig $$CN autoreboot
+check:rc==0
+check:output=~$$CN: BMC AutoReboot
+cmd:rspconfig $$CN bootmode
+check:rc==0
+check:output=~$$CN: BMC BootMode
+end

--- a/xCAT-test/autotest/testcase/UT_openbmc/supported_commands_case0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/supported_commands_case0
@@ -1,0 +1,36 @@
+start:supported_cmds_rpower
+description: Make sure the rpower command works ...
+os:Linux
+hcp:openbmc
+cmd:rpower $$CN state
+check:rc==0
+check:output=~$$CN: 
+cmd: rpower $$CN bmcstate
+check:rc==0
+check:output=~$$CN: BMC
+end
+
+start:supported_cmds_rinv
+description: Make sure that the rinv command works...
+os:Linux
+hcp:openbmc
+cmd: rinv $$CN
+check:rc==0
+check:output=~$$CN:
+cmd: rinv $$CN model
+check:rc==0
+check:output=~$$CN: SYSTEM Model
+cmd: rinv $$CN serial
+check:rc==0
+check:output=~$$CN: SYSTEM SerialNumber
+cmd: rinv $$CN firm
+check:rc==0
+check:output=~$$CN: HOST Firmware
+check:output=~$$CN: BMC Firmware
+cmd: rinv $$CN cpu
+check:rc==0
+check:output=~$$CN: CPU
+cmd: rinv $$CN dimm
+check:rc==0
+check:output=~$$CN: DIMM
+end 


### PR DESCRIPTION
The idea here is to quickly be able to run some sanity test against all the OpenBMC commands that xCAT supports leveraging xCAT-test but not getting hung up on the complexity of setting up the bundle and configuration file 

Using the shared scripts: 
```
[root@fs2vm112 autotest]# ./create_bundle_file  UT_openbmc supported
Filter of supported specified....
Creating bundle file for UT_openbmc...
cat: /opt/xcat/share/xcat/tools/autotest/testcase/UT_openbmc/scripts: Is a directory
supported_cmds_rpower
supported_cmds_rinv
-rw-r--r-- 1 root root 42 Mar 13 11:30 ./UT_openbmc.tmp.bundle
Run the test using:
   xcattest -f <config_file> -b ./UT_openbmc.tmp.bundle
   XCATTEST_CN=mid05tor12cn05  xcattest -b ./UT_openbmc.tmp.bundle
[root@fs2vm112 autotest]#
```