### PR TITLE
fix issue 4856: rewrite parse_args for rspconfig

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc2.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc2.pm
@@ -144,7 +144,13 @@ sub process_request {
 my @rsp_common_options = qw/autoreboot bootmode powersupplyredundancy powerrestorepolicy timesyncmethod
                             ip netmask gateway hostname vlan ntpservers/;
 my @rspconfig_set_options = (@rsp_common_options, qw/admin_passwd/);
-
+my %rsp_set_valid_values = (
+    autoreboot            => "0|1",
+    bootmode              => "regular|safe|setup",
+    powersupplyredundancy => "disabled|enabled",
+    powerrestorepolicy    => "restore|always_on|always_off",
+    timesyncmethod        => "ntp|manual",
+);
 my @rspconfig_get_options = (@rsp_common_options, qw/ipsrc sshcfg gard dump/);
 #-------------------------------------------------------
 
@@ -270,6 +276,10 @@ sub parse_args {
                 return ([1, "Can not set and query OpenBMC information at the same time"]);
             } elsif ($set and $value eq '' and ($key ne "ntpservers")) {
                 return ([1, "Invalid parameter for option $key"]);
+            } elsif ($set and $value ne '' and exists($rsp_set_valid_values{$key})) {
+                unless ($value =~ /^($rsp_set_valid_values{$key})$/) {
+                    return([1, "Invalid value '$value' for '$key', Valid values: " . join(',', split('\|',$rsp_set_valid_values{$key}))]);
+                }
             }
             if (($set and !grep /$key/, @rspconfig_set_options) or
                 ($get and !grep /$key/, @rspconfig_get_options)) {


### PR DESCRIPTION
To fix issue #4856 

The test result with the fix, pls *ignore rspconfig is fine*, just show the args is correct.
```
root@c910f03c05k10:~/level0/level1/level2/xcat-core# XCAT_OPENBMC_DEVEL=YES rspconfig f6u13 ip
rspconfig is fine
root@c910f03c05k10:~/level0/level1/level2/xcat-core# XCAT_OPENBMC_DEVEL=YES rspconfig f6u13 ip=
f6u13: Error: Invalid parameter for option ip
root@c910f03c05k10:~/level0/level1/level2/xcat-core# XCAT_OPENBMC_DEVEL=YES rspconfig f6u13 ip=a.b.c.d
f6u13: Error: Invalid parameter for option ip: a.b.c.d
root@c910f03c05k10:~/level0/level1/level2/xcat-core# XCAT_OPENBMC_DEVEL=YES rspconfig f6u13 ip=10.6.13.100
f6u13: Error: IP, netmask and gateway must be configured together.
root@c910f03c05k10:~/level0/level1/level2/xcat-core# XCAT_OPENBMC_DEVEL=YES rspconfig f6u13 ip=10.6.13.100 netmask=255.0.0.0 gateway=0.0.0.0
rspconfig is fine
root@c910f03c05k10:~/level0/level1/level2/xcat-core# XCAT_OPENBMC_DEVEL=YES rspconfig f6u13 ip=10.6.13.100 netmask=255.0.0.0 gateway=0.0.0.0 vlan=1
rspconfig is fine
root@c910f03c05k10:~/level0/level1/level2/xcat-core# XCAT_OPENBMC_DEVEL=YES rspconfig f6u13 ip=10.6.13.100 netmask=255.0.0.0 gateway=0.0.0.0 vlan=1 ntp
f6u13: Error: Can not set and query OpenBMC information at the same time
root@c910f03c05k10:~/level0/level1/level2/xcat-core# XCAT_OPENBMC_DEVEL=YES rspconfig f6u13 ip dump
f6u13: Error: Invalid parameter for rspconfig dump
root@c910f03c05k10:~/level0/level1/level2/xcat-core# XCAT_OPENBMC_DEVEL=YES rspconfig f6u13 ip netmask gard
f6u13: Error: Clear GARD cannot be issued with other options.
```