### PR TITLE
disable group range for mkdef

### DIFF
--- a/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
+++ b/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
@@ -4721,12 +4721,20 @@ sub initialize_variables
 sub isobjnamevalid{
     my $objname=shift;
     my $objtype=shift;
+    my %options;
+    $options{keepmissing}=1;
+    $options{genericrange}=1;
     $objtype="node" unless(defined $objtype and ($objtype ne ""));
     if($objtype eq "node"){
         #the ip address as a valid node object name is a hack for p7IH support   
         if(($objname !~ /^[a-zA-Z0-9-_]+$/) and !xCAT::NetworkUtils->isIpaddr($objname)){
             return 0;
         }
+    } elsif ($objtype eq "group"){
+        my @tmpnodes=xCAT::NodeRange::noderange($objname,0,0,%options);
+        if(scalar(@tmpnodes)>1 || $tmpnodes[0] ne $objname ){
+           return 0;
+        }    
     }
     return 1;
 }


### PR DESCRIPTION
For #4487 

UT:
```
]# mkdef -t group service[2]
Error: The object name 'service[2]' is invalid, please refer to "man xcatdb" for the valid "xCAT Object Name Format"

]# mkdef -t group service[2-5]
Error: The object name 'service[2-5]' is invalid, please refer to "man xcatdb" for the valid "xCAT Object Name Format"

]# mkdef -t group service1-service5
Error: The object name 'service1-service5' is invalid, please refer to "man xcatdb" for the valid "xCAT Object Name Format"

]# mkdef -t group service1+2
Error: The object name 'service1+2' is invalid, please refer to "man xcatdb" for the valid "xCAT Object Name Format"

]# mkdef -t group service2
Warning: Cannot determine a member list for group 'service2'.
1 object definitions have been created or modified.

]# lsdef -t group
service2  (group)

]# mkdef -t group service2
Warning: A definition for 'service2' already exists. No changes will be made.  Run again with '-f' option to force replace.
Error: 0 object definitions have been created or modified.
```