### PR TITLE
Enhance rpower bmcreboot, clear dumps if reboot to new firmware

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_power.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_power.py
@@ -179,7 +179,7 @@ class OpenBMCPowerTask(ParallelNodesCommand):
             try:
                 obmc.clear_dump('all')
             except (SelfServerException, SelfClientException) as e:
-                self.callback.warn('%s: Could not clear BMC diagnostics successfully %s, ignoring...' % (node, e.message))
+                self.callback.warn('%s: Could not clear BMC diagnostics successfully %s' % (node, e.message))
 
         try:
             obmc.reboot_bmc(optype)

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -3879,7 +3879,7 @@ sub rspconfig_dump_response {
             my $dump_id = $status_info{RSPCONFIG_DUMP_CLEAR_RESPONSE}{argv};
             xCAT::MsgUtils->message("I", { data => ["[$dump_id] clear"] }, $callback) unless ($next_status{ $node_info{$node}{cur_status} });
         } else {
-            my $error_msg = "Could not clear BMC diagnostics successfully (". $response_info->{'message'} . "), ignoring...";
+            my $error_msg = "Could not clear BMC diagnostics successfully (". $response_info->{'message'} . ")";
             xCAT::MsgUtils->message("W", { data => ["$node: $error_msg"] }, $callback) if ($next_status{ $node_info{$node}{cur_status} });
         }
     } 


### PR DESCRIPTION
https://github.com/xcat2/xcat2-task-management/issues/3

UT:
```
# rpower f6u03 bmcreboot
f6u03: Firmware will be flashed on reboot, deleting all BMC diagnostics...
f6u03: BMC reboot
```