### PR TITLE
OpenBMC rbeacon stat support in Python

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rbeacon.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rbeacon.1.rst
@@ -31,7 +31,7 @@ OpenPOWER OpenBMC:
 ==================
 
 
-\ **rbeacon**\  \ *noderange*\  {\ **on | off**\ }
+\ **rbeacon**\  \ *noderange*\  {\ **on | off | stat**\ }
 
 
 
@@ -40,7 +40,7 @@ DESCRIPTION
 ***********
 
 
-\ **rbeacon**\  Turns beacon (a light on the front of the physical server) on/off/blink or gives status of a node or noderange.
+\ **rbeacon**\  Turns beacon (a light on the front and/or rear of the physical server) on/off/blink or gives status of a node or noderange.
 
 
 ********

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -86,7 +86,7 @@ my %usage = (
     ",
     "rbeacon.openbmc" =>
     "OpenPOWER (OpenBMC) specific:
-       rbeacon [on|off]
+       rbeacon [on|off|stat]
     ",    
     "rvitals" => "",
     "rvitals.common" =>

--- a/xCAT-client/pods/man1/rbeacon.1.pod
+++ b/xCAT-client/pods/man1/rbeacon.1.pod
@@ -17,12 +17,12 @@ B<rbeacon> I<noderange> {B<on>|B<blink>|B<off>|B<stat>}
 
 =head2 OpenPOWER OpenBMC:
 
-B<rbeacon> I<noderange> {B<on>|B<off>}
+B<rbeacon> I<noderange> {B<on>|B<off>|B<stat>}
 
 
 =head1 DESCRIPTION
 
-B<rbeacon> Turns beacon (a light on the front of the physical server) on/off/blink or gives status of a node or noderange.
+B<rbeacon> Turns beacon (a light on the front and/or rear of the physical server) on/off/blink or gives status of a node or noderange.
 
 =head1 EXAMPLES
 

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_sensor.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_sensor.py
@@ -32,9 +32,14 @@ SENSOR_POWER_UNITS = ("Amperes", "Joules", "Watts")
 class OpenBMCSensorTask(ParallelNodesCommand):
     """Executor for sensor-related actions."""
 
-    def _get_beacon_info(self, beacon_dict):
+    def _get_beacon_info(self, beacon_dict, display_type='full'):
 
         info_list = []
+        # display_type == 'full'    for detailed output for 'rvitals leds' command
+        # display_type == 'compact' for compact  output for 'rbeacon stat' command
+        if display_type == 'compact':
+            info_list.append('Front:%s Rear:%s' % (beacon_dict.get('front_id'), beacon_dict.get('rear_id', 'N/A'))) 
+            return info_list
         info_list.append('Front . . . . . : Power:%s Fault:%s Identify:%s' %
                          (beacon_dict.get('front_power', 'N/A'),
                           beacon_dict.get('front_fault', 'N/A'),
@@ -92,7 +97,7 @@ class OpenBMCSensorTask(ParallelNodesCommand):
 
         return sensor_info
 
-    def get_beacon_info(self, **kw):
+    def get_beacon_info(self, display_type, **kw):
 
         node = kw['node']
         obmc = openbmc.OpenBMCRest(name=node, nodeinfo=kw['nodeinfo'], messager=self.callback,
@@ -102,7 +107,7 @@ class OpenBMCSensorTask(ParallelNodesCommand):
         try:
             obmc.login()
             beacon_dict = obmc.get_beacon_info()
-            beacon_info = self._get_beacon_info(beacon_dict)
+            beacon_info = self._get_beacon_info(beacon_dict, display_type)
 
             if not beacon_info:
                 beacon_info = ['No attributes returned from the BMC.']

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/sensor.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/sensor.py
@@ -19,13 +19,14 @@ class SensorInterface(object):
         """
         return task.run('get_sensor_info', sensor_type) 
 
-    def get_beacon_info(self, task):
+    def get_beacon_info(self, task, display_type='full'):
         """Return the beacon info of the task's nodes.
 
+        :param task: type of display to produce - full (rvitals leds) or compact (rbeacon stat)
         :param task: a Task instance containing the nodes to act on.
         :return: beacon info list
         """
-        return task.run('get_beacon_info')
+        return task.run('get_beacon_info', display_type)
 
 class DefaultSensorManager(SensorInterface):
     """Interface for sensor-related actions."""

--- a/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
+++ b/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
@@ -48,7 +48,7 @@ VERBOSE = False
 all_nodes_result = {}
 
 # global variables of rbeacon
-BEACON_SET_OPTIONS = ('on', 'off')
+BEACON_OPTIONS = ('on', 'off', 'stat')
 
 # global variables of rflash
 RFLASH_OPTIONS = {
@@ -614,7 +614,7 @@ class OpenBMCManager(base.BaseManager):
         # 1, parse args
         rbeacon_usage = """
         Usage:
-            rbeacon [-V|--verbose] [on|off]
+            rbeacon [-V|--verbose] [on|off|stat]
 
         Options:
             -V --verbose   rbeacon verbose mode.
@@ -631,16 +631,20 @@ class OpenBMCManager(base.BaseManager):
 
         # 2, validate the args
         if action is None:
-            self.messager.error("Not specify the subcommand for rbeacon")
+            self.messager.error("Subcommand for rbeacon was not specified")
             return
 
-        if action not in BEACON_SET_OPTIONS:
+        if action not in BEACON_OPTIONS:
             self.messager.error("Not supported subcommand for rbeacon: %s" % action)
             return
 
         # 3, run the subcommands
-        runner = OpenBMCBeaconTask(nodesinfo, callback=self.messager, debugmode=self.debugmode, verbose=self.verbose)
-        DefaultBeaconManager().set_beacon_state(runner, beacon_state=action)
+        runnerB = OpenBMCBeaconTask(nodesinfo, callback=self.messager, debugmode=self.debugmode, verbose=self.verbose)
+        runnerS = OpenBMCSensorTask(nodesinfo, callback=self.messager, debugmode=self.debugmode, verbose=self.verbose)
+        if action == 'stat':
+            DefaultSensorManager().get_beacon_info(runnerS, display_type='compact')
+        else:
+            DefaultBeaconManager().set_beacon_state(runnerB, beacon_state=action)
 
     def rinv(self, nodesinfo, args):
 

--- a/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
+++ b/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
@@ -639,12 +639,13 @@ class OpenBMCManager(base.BaseManager):
             return
 
         # 3, run the subcommands
-        runnerB = OpenBMCBeaconTask(nodesinfo, callback=self.messager, debugmode=self.debugmode, verbose=self.verbose)
-        runnerS = OpenBMCSensorTask(nodesinfo, callback=self.messager, debugmode=self.debugmode, verbose=self.verbose)
         if action == 'stat':
-            DefaultSensorManager().get_beacon_info(runnerS, display_type='compact')
+            runner = OpenBMCSensorTask(nodesinfo, callback=self.messager, debugmode=self.debugmode, verbose=self.verbose)
+
+            DefaultSensorManager().get_beacon_info(runner, display_type='compact')
         else:
-            DefaultBeaconManager().set_beacon_state(runnerB, beacon_state=action)
+            runner = OpenBMCBeaconTask(nodesinfo, callback=self.messager, debugmode=self.debugmode, verbose=self.verbose)
+            DefaultBeaconManager().set_beacon_state(runner, beacon_state=action)
 
     def rinv(self, nodesinfo, args):
 

--- a/xCAT-server/lib/xcat/plugins/openbmc2.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc2.pm
@@ -186,8 +186,8 @@ sub parse_args {
     }
 
     if ($command eq "rbeacon") {
-        unless ($subcommand =~ /^on$|^off$/) {
-            return ([ 1, "Only 'on' or 'off' is supported for OpenBMC managed nodes."]);
+        unless ($subcommand =~ /^on$|^off$|^stat$/) {
+            return ([ 1, "Only 'on', 'off' or 'stat' is supported for OpenBMC managed nodes."]);
         }
     } elsif ($command eq "rflash") {
         my ($activate, $check, $delete, $directory, $list, $upload) = (0) x 6;


### PR DESCRIPTION
#4853 
Support Python `rbeacon stat` for OpenBMC

```
[root@briggs01 xcat]# rbeacon mid05tor12cn15 stat
mid05tor12cn15: Front:Off Rear:Off

[root@briggs01 xcat]# rvitals mid05tor12cn15 leds
mid05tor12cn15: Front . . . . . : Power:On Fault:Off Identify:Off
mid05tor12cn15: Front Fans  . . : No LEDs On
mid05tor12cn15: Rear  . . . . . : Power:On Fault:Off Identify:Off

[root@briggs01 xcat]# rbeacon mid05tor12cn15 on
mid05tor12cn15: on

[root@briggs01 xcat]# rbeacon mid05tor12cn15 stat
mid05tor12cn15: Front:Blink Rear:Blink

[root@briggs01 xcat]# rvitals mid05tor12cn15 leds
mid05tor12cn15: Front . . . . . : Power:On Fault:Off Identify:Blink
mid05tor12cn15: Front Fans  . . : No LEDs On
mid05tor12cn15: Rear  . . . . . : Power:On Fault:Off Identify:Blink

[root@briggs01 xcat]# rbeacon mid05tor12cn15 abc
mid05tor12cn15: Error: Only 'on', 'off' or 'stat' is supported for OpenBMC managed nodes.
[root@briggs01 xcat]#
```