### PR TITLE
Refine test case  xcatconfig_c

### DIFF
--- a/xCAT-test/autotest/testcase/xcatconfig/case0
+++ b/xCAT-test/autotest/testcase/xcatconfig/case0
@@ -96,18 +96,17 @@ description:To regenerate cretials
 os:Linux
 #step1:backup: /etc/xcat/ca /etc/xcat/cert
 cmd:cp -r /etc/xcat/ca /etc/xcat/cabak;cp -r /etc/xcat/cert /etc/xcat/certbak
-
 #step2:run command and check the output
-cmd:xcatconfig  -c >/tmp/xcatconfig.test 2>&1
+cmd:xcatconfig  -c 2>&1 | tee /tmp/xcatconfig.test 
 check:rc==0
-cmd:if [[ `cat /tmp/xcatconfig.test |grep FAILED` ]] || [[ `cat /tmp/xcatconfig.test |grep error` ]] || [[ `cat /tmp/xcatconfig.test |grep "fail"` ]] || [[ `cat /tmp/xcatconfig.test |grep Error` ]];then exit 1;fi
+cmd:if [[ `cat /tmp/xcatconfig.test |grep -i fail` ]] || [[ `cat /tmp/xcatconfig.test |grep -i error` ]] ;then exit 1;else exit 0;fi
 check:rc==0
 cmd:if [[ `cat /tmp/xcatconfig.test |grep "Created xCAT certificate"` ]] && [[ `cat /tmp/xcatconfig.test |grep "Signature ok"` ]];then exit 0;else exit 1;fi
 check:rc==0
 #step3:make sure the  /etc/xcat/ca /etc/xcat/cert is rewrite
-cmd:diff /etc/xcat/ca /etc/xcat/cabak
+cmd:diff -y /etc/xcat/ca /etc/xcat/cabak
 check:rc!=0
-cmd:diff /etc/xcat/cert /etc/xcat/certbak
+cmd:diff -y /etc/xcat/cert /etc/xcat/certbak
 check:rc!=0
 #step4:restore test environment
 cmd:rm -rf /tmp/xcatconfig.test


### PR DESCRIPTION
``xcatconfig_c`` could not offer useful information when it failed in automation test system, so refine this case to offer more valid debug information.