### PR TITLE
add kdump test case

### DIFF
--- a/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
+++ b/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
@@ -1,17 +1,10 @@
 start:linux_diskless_kdump
 os:Linux
-cmd:fdisk -l
-cmd:df -T
 cmd:chdef -t node -o $$CN servicenode= monserver=$$MN nfsserver=$$MN tftpserver=$$MN  xcatmaster=$$MN
 check:rc==0
 
 cmd:makedns -n
 check:rc==0
-cmd:makeconservercf $$CN
-check:rc==0
-cmd:cat /etc/conserver.cf | grep $$CN
-check:output=~$$CN
-cmd:sleep 20
 cmd:if [[ "__GETNODEATTR($$CN,arch)__" = "ppc64" ]] && [[ "__GETNODEATTR($$CN,mgt)__" != "ipmi" ]]; then getmacs -D $$CN; fi
 check:rc==0
 cmd:makedhcp -n
@@ -25,16 +18,22 @@ check:rc==0
 
 cmd:rootimgdir=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir ]; then mv $rootimgdir $rootimgdir.regbak -f;fi
 check:rc==0
+
+cmd:pkglistfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep pkglist|awk -F'=' '{print $2}'`;cp $pkglistfile $pkglistfile.bak
 cmd:pkglistfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep pkglist|awk -F'=' '{print $2}'`; if grep SUSE /etc/*release;then echo -e "kdump\nkexec-tools\nmakedumpfile\n" >> $pkglistfile; elif grep "Red Hat" /etc/*release;then echo -e "kexec-tools\ncrash\n" >> $pkglistfile;fi
 check:rc==0
 
+cmd:exlistfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep exlist|awk -F'=' '{print $2}'`;cp $exlistfile $exlistfile.bak
 cmd:exlistfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep exlist|awk -F'=' '{print $2}'`; sed -i '/boot/d' $exlistfile
 check:rc==0
 
+cmd:postinstallfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep postinstall|awk -F'=' '{print $2}'`;cp $postinstallfile $postinstallfile.bak
 cmd:postinstallfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep postinstall|awk -F'=' '{print $2}'`; if grep SUSE /etc/*release;then sed -i "/\/tmp/ s/10/200/g" $postinstallfile; elif grep "Red Hat" /etc/*release;then sed -i /devpts/a"tmpfs         /var/tmp    tmpfs   defaults,size=200m   0 2" $postinstallfile;fi
 check:rc==0
 
 cmd:if [ ! -d /kdumpdir ]; then mkdir -p /kdumpdir && chmod 777 /kdumpdir; fi
+cmd:if [ ! -f /etc/exports ] ;then touch /etc/exports;else cp /etc/exports /etc/exports.bak;fi
+cmd:echo -e "/kdumpdir *(rw,no_root_squash,sync,no_subtree_check)" >> /etc/exports && exportfs /etc/exports  fi;
 cmd:chdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute dump=nfs://$$MN/kdumpdir
 check:rc==0
 
@@ -54,7 +53,6 @@ cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-ne
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 
-cmd:if [[ -f /var/lib/dhcp/db/dhcpd.leases ]]; then cat /var/lib/dhcp/db/dhcpd.leases; elif [[ -f /var/lib/dhcpd/dhcpd.leases ]];then cat /var/lib/dhcpd/dhcpd.leases;elif [[ -f /var/lib/dhcp/dhcpd.leases ]];then cat /var/lib/dhcp/dhcpd.leases; fi
 cmd:sleep 900
 cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 10;((a++));if [ $a -gt 60 ];then break;fi done
 
@@ -67,18 +65,17 @@ check:output=~booted
 cmd:xdsh $$CN date
 check:rc==0
 check:output=~\d\d:\d\d:\d\d
-cmd:xdsh $$CN mount
-check:rc==0
-check:output=~on / type tmpfs
-cmd:sleep 120
-cmd:ping $$CN -c 3
-check:rc==0
-check:output=~64 bytes from $$CN
 
 cmd:xdsh $$CN echo 1 > /proc/sys/kernel/sysrq
 cmd:xdsh $$CN echo c > /proc/sysrq-trigger
 cmd:sleep 600
 
-cmd:find /kdumpdir -name vmcore
-check:rc==0
+cmd:if [[ -s /hello ]]; then echo "this file is not empty";else echo "this file is empty"; fi
+check:output=~not empty
+
+cmd:pkglistfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep pkglist|awk -F'=' '{print $2}'`;mv -f $pkglistfile.bak $pkglistfile
+cmd:exlistfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep exlist|awk -F'=' '{print $2}'`;mv -f $exlistfile.bak $exlistfile
+cmd:postinstallfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep postinstall|awk -F'=' '{print $2}'`;mv -f $postinstallfile.bak $postinstallfile
+
+cmd:if [ -f /etc/exports.bak ] ;then mv -f /etc/exports.bak /etc/exports; fi
 end

--- a/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
+++ b/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
@@ -1,5 +1,7 @@
 start:linux_diskless_kdump
 os:Linux
+cmd:lsdef -z $$CN > /tmp/node.stanza
+cmd:lsdef -t osimage -z __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute > /tmp/osimage.stanza
 cmd:chdef -t node -o $$CN servicenode= monserver=$$MN nfsserver=$$MN tftpserver=$$MN  xcatmaster=$$MN
 check:rc==0
 
@@ -78,5 +80,7 @@ cmd:exlistfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arc
 cmd:postinstallfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep postinstall|awk -F'=' '{print $2}'`;mv -f $postinstallfile.bak $postinstallfile
 
 cmd:if [ -f /etc/exports.bak ] ;then mv -f /etc/exports.bak /etc/exports; fi
-#cmd:rm -rf /kdumpdir
+cmd:rm -rf /kdumpdir
+cmd:cat /tmp/node.stanza | chdef -z;rm -rf /tmp/node.stanza
+cmd:cat /tmp/osimage.stanza | chdef -z;rm -rf /tmp/osimage.stanza
 end

--- a/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
+++ b/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
@@ -1,0 +1,84 @@
+start:linux_diskless_kdump
+os:Linux
+cmd:fdisk -l
+cmd:df -T
+cmd:chdef -t node -o $$CN servicenode= monserver=$$MN nfsserver=$$MN tftpserver=$$MN  xcatmaster=$$MN
+check:rc==0
+
+cmd:makedns -n
+check:rc==0
+cmd:makeconservercf $$CN
+check:rc==0
+cmd:cat /etc/conserver.cf | grep $$CN
+check:output=~$$CN
+cmd:sleep 20
+cmd:if [[ "__GETNODEATTR($$CN,arch)__" = "ppc64" ]] && [[ "__GETNODEATTR($$CN,mgt)__" != "ipmi" ]]; then getmacs -D $$CN; fi
+check:rc==0
+cmd:makedhcp -n
+check:rc==0
+cmd:makedhcp -a
+check:rc==0
+cmd:a=0;while true; do [ $a -eq 100 ] && exit 1;output=$(makedhcp -q $$CN);[ $? -ne 0 ] && exit 1;echo $output|grep $$CN 2>/dev/null && exit 0;a=$[$a+1];sleep 1;done
+check:rc==0
+cmd:copycds $$ISO
+check:rc==0
+
+cmd:rootimgdir=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir ]; then mv $rootimgdir $rootimgdir.regbak -f;fi
+check:rc==0
+cmd:pkglistfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep pkglist|awk -F'=' '{print $2}'`; if grep SUSE /etc/*release;then echo -e "kdump\nkexec-tools\nmakedumpfile\n" >> $pkglistfile; elif grep "Red Hat" /etc/*release;then echo -e "kexec-tools\ncrash\n" >> $pkglistfile;fi
+check:rc==0
+
+cmd:exlistfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep exlist|awk -F'=' '{print $2}'`; sed -i '/boot/d' $exlistfile
+check:rc==0
+
+cmd:postinstallfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep postinstall|awk -F'=' '{print $2}'`; if grep SUSE /etc/*release;then sed -i "/\/tmp/ s/10/200/g" $postinstallfile; elif grep "Red Hat" /etc/*release;then sed -i /devpts/a"tmpfs         /var/tmp    tmpfs   defaults,size=200m   0 2" $postinstallfile;fi
+check:rc==0
+
+cmd:if [ ! -d /kdumpdir ]; then mkdir -p /kdumpdir && chmod 777 /kdumpdir; fi
+cmd:chdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute dump=nfs://$$MN/kdumpdir
+check:rc==0
+
+cmd:chdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute crashkernelsize=auto
+check:rc==0
+
+cmd:chdef -t node $$CN -p postscripts=enablekdump
+check:rc==0
+
+
+cmd:genimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+check:rc==0
+cmd:packimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+check:rc==0
+
+cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+check:rc==0
+check:output=~Provision node\(s\)\: $$CN
+
+cmd:if [[ -f /var/lib/dhcp/db/dhcpd.leases ]]; then cat /var/lib/dhcp/db/dhcpd.leases; elif [[ -f /var/lib/dhcpd/dhcpd.leases ]];then cat /var/lib/dhcpd/dhcpd.leases;elif [[ -f /var/lib/dhcp/dhcpd.leases ]];then cat /var/lib/dhcp/dhcpd.leases; fi
+cmd:sleep 900
+cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 10;((a++));if [ $a -gt 60 ];then break;fi done
+
+cmd:ping $$CN -c 3
+check:rc==0
+check:output=~64 bytes from $$CN
+cmd:lsdef -l $$CN | grep status
+check:rc==0
+check:output=~booted
+cmd:xdsh $$CN date
+check:rc==0
+check:output=~\d\d:\d\d:\d\d
+cmd:xdsh $$CN mount
+check:rc==0
+check:output=~on / type tmpfs
+cmd:sleep 120
+cmd:ping $$CN -c 3
+check:rc==0
+check:output=~64 bytes from $$CN
+
+cmd:xdsh $$CN echo 1 > /proc/sys/kernel/sysrq
+cmd:xdsh $$CN echo c > /proc/sysrq-trigger
+cmd:sleep 600
+
+cmd:find /kdumpdir -name vmcore
+check:rc==0
+end

--- a/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
+++ b/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
@@ -66,11 +66,11 @@ cmd:xdsh $$CN date
 check:rc==0
 check:output=~\d\d:\d\d:\d\d
 
-cmd:xdsh $$CN echo 1 > /proc/sys/kernel/sysrq
-cmd:xdsh $$CN echo c > /proc/sysrq-trigger
+cmd:xdsh $$CN "echo 1 > /proc/sys/kernel/sysrq"
+cmd:xdsh $$CN "echo c > /proc/sysrq-trigger"
 cmd:sleep 600
 
-cmd:if [[ -s /hello ]]; then echo "this file is not empty";else echo "this file is empty"; fi
+cmd:vmcorefile=`find /kdumpdir/ -name vmcore`;if [[ -s $vmcorefile ]]; then echo "this file is not empty";else echo "this file is empty"; fi
 check:output=~not empty
 
 cmd:pkglistfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep pkglist|awk -F'=' '{print $2}'`;mv -f $pkglistfile.bak $pkglistfile
@@ -78,4 +78,5 @@ cmd:exlistfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arc
 cmd:postinstallfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep postinstall|awk -F'=' '{print $2}'`;mv -f $postinstallfile.bak $postinstallfile
 
 cmd:if [ -f /etc/exports.bak ] ;then mv -f /etc/exports.bak /etc/exports; fi
+#cmd:rm -rf /kdumpdir
 end


### PR DESCRIPTION
Case Name:linux_diskless_kdump
description: this case is to test enable kdump Over Ethernet. This case will  use MN and ISO as parameter. 

Here is the UT test log
```
xCAT automated test started at Thu Mar 22 05:11:14 2018
******************************
loading Configure file
******************************
Varible:
    CN = c910f03c17k23
    ISO = RHEL-ALT-7.4-20171030.0-Server-ppc64le-dvd1.iso
    MN = c910f03c17k22
******************************
Initialize xCAT test environment by definition in configure file
******************************
******************************
To detect current test environment
******************************
Detecting: OS = linux
Detecting: ARCH = ppc64le
Detecting: HCP = kvm
******************************
loading test cases
******************************
To run:
linux_diskless_kdump
******************************
Start to run test cases
******************************
------START::linux_diskless_kdump::Time:Thu Mar 22 05:11:15 2018------

RUN:lsdef -z c910f03c17k23 > /tmp/node.stanza [Sat Mar 24 11:46:51 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:lsdef -t osimage -z __GETNODEATTR(c910f03c17k23,os)__-__GETNODEATTR(c910f03c17k23,arch)__-netboot-compute > /tmp/osimage.stanza [Sat Mar 24 11:46:52 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:chdef -t node -o c910f03c17k23 servicenode= monserver=c910f03c17k22 nfsserver=c910f03c17k22 tftpserver=c910f03c17k22  xcatmaster=c910f03c17k22 [Thu Mar 22 05:11:15 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0   [Pass]

RUN:makedns -n [Thu Mar 22 05:11:16 2018]
ElapsedTime:6 sec
RETURN rc = 0
OUTPUT:
Handling c910hmc04 in /etc/hosts.
Handling c910f03fsp03v06.pok.stglabs.ibm.com in /etc/hosts.
Handling c910f02c01p10 in /etc/hosts.
Handling c910f03c03k27 in /etc/hosts.
Handling c910f02c09p04 in /etc/hosts.
Handling c910f02c07p30 in /etc/hosts.
Handling c910f02c07p18 in /etc/hosts.
Handling c910f02c01p25 in /etc/hosts.
Handling c910f02c05p19 in /etc/hosts.
Handling c910f03c01p18 in /etc/hosts.
Handling c910f03c05k21 in /etc/hosts.
Handling c910f03c17k28 in /etc/hosts.
Handling c910f02c03p30 in /etc/hosts.
Handling c910f02c01v01 in /etc/hosts.
Handling c910f04x18v07 in /etc/hosts.
Handling c910f03c02p09 in /etc/hosts.
Handling c910f02c05p09 in /etc/hosts.
Handling c910f04x18 in /etc/hosts.
Handling c910f04x31 in /etc/hosts.
Handling c910f02c08p12 in /etc/hosts.
Handling c910f02c02p28.pok.stglabs.ibm.com in /etc/hosts.
Handling c910f02c04p02 in /etc/hosts.
Handling c910mnx04 in /etc/hosts.
Handling c910f03c17k31 in /etc/hosts.
Handling c910f03c02p19 in /etc/hosts.
Handling c910f03c02p23 in /etc/hosts.
Handling c910f02c02p30 in /etc/hosts.
Handling c910f04x21v07 in /etc/hosts.
Handling c910f04x35v06 in /etc/hosts.
Handling c910f02c06p09 in /etc/hosts.
Handling c910f03c11k19 in /etc/hosts.
Handling c910f02c09p17 in /etc/hosts.
Handling c910f04x14v07 in /etc/hosts.
Handling c910f02c01p06 in /etc/hosts.
Handling c910gpfs05 in /etc/hosts.
Handling c910f03c11k10 in /etc/hosts.
Handling c910gpfs02 in /etc/hosts.
Handling c910f03c01p26 in /etc/hosts.
Handling c910f02c03v01 in /etc/hosts.
Handling c910f02c08p03 in /etc/hosts.
Handling c910f03c03k09 in /etc/hosts.
Handling c910f02c06p11 in /etc/hosts.
Handling c910f02c01p13.pok.stglabs.ibm.com in /etc/hosts.
Handling c910f02c07p24 in /etc/hosts.
Handling c910f02c03p10 in /etc/hosts.
Handling c910f03c03k20 in /etc/hosts.
Handling c910f02c09p13 in /etc/hosts.
Handling c910f02c08p19 in /etc/hosts.
Handling c910f02c07p21 in /etc/hosts.
Handling c910f02c05p11 in /etc/hosts.
Handling c910f03c04k22 in /etc/hosts.
Handling c910f02c01p16 in /etc/hosts.
Handling c910f02c07p15 in /etc/hosts.
Handling c910f02c07v01 in /etc/hosts.
Handling c910f02c04p09 in /etc/hosts.
Handling c910f02c02p21 in /etc/hosts.
Handling c910f03c03k17 in /etc/hosts.
Handling c910f02c05p22 in /etc/hosts.
Handling c910f03c04k18 in /etc/hosts.
Handling c910f02c03p15 in /etc/hosts.
Handling c910f04x27 in /etc/hosts.
Handling c910f02c03p04 in /etc/hosts.
Handling c910f03c11 in /etc/hosts.
Handling c910f03c01p08 in /etc/hosts.
Handling c910f02c04p12 in /etc/hosts.
Handling c910f03c01p31 in /etc/hosts.
Handling c910f03c09k12 in /etc/hosts.
Handling c910f03c04k03 in /etc/hosts.
Handling c910f02c04p31 in /etc/hosts.
Handling c910f02c06p23 in /etc/hosts.
Handling c910f02c09p26 in /etc/hosts.
Handling c910f02c02p13 in /etc/hosts.
Handling c910f02c02p04 in /etc/hosts.
Handling c910f03c01p03 in /etc/hosts.
Handling c910f03c05k07 in /etc/hosts.
Handling c910f03c03k26 in /etc/hosts.
Handling c910f04x14v02 in /etc/hosts.
Handling c910f02c03p03 in /etc/hosts.
Handling c910f02c03p11 in /etc/hosts.
Getting reverse zones, this may take several minutes for a large cluster.
Completed getting reverse zones.
Updating zones.
Completed updating zones.
Restarting named
Restarting named complete
Updating DNS records, this may take several minutes for a large cluster.
Completed updating DNS records.
DNS setup is completed
CHECK:rc == 0   [Pass]

RUN:if [[ "__GETNODEATTR(c910f03c17k23,arch)__" = "ppc64" ]] && [[ "__GETNODEATTR(c910f03c17k23,mgt)__" != "ipmi" ]]; then getmacs -D c910f03c17k23; fi [Thu Mar 22 05:11:22 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0   [Pass]

RUN:makedhcp -n [Thu Mar 22 05:11:22 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Warning: No dynamic range specified for 10.0.0.0. If hardware discovery is being used, a dynamic range is required.
Warning: No dynamic range specified for 10.0.0.0. If hardware discovery is being used, a dynamic range is required.
Renamed existing dhcp configuration file to  /etc/dhcp/dhcpd.conf.xcatbak

Renamed existing dhcp configuration file to  /etc/dhcp/dhcpd.conf.xcatbak

CHECK:rc == 0   [Pass]

RUN:makedhcp -a [Thu Mar 22 05:11:23 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Warning: The hostname f6u03 of node f6u03 could not be resolved.
CHECK:rc == 0   [Pass]

RUN:a=0;while true; do [ $a -eq 100 ] && exit 1;output=$(makedhcp -q c910f03c17k23);[ $? -ne 0 ] && exit 1;echo $output|grep c910f03c17k23 2>/dev/null && exit 0;a=$[$a+1];sleep 1;done [Thu Mar 22 05:11:24 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
c910f03c17k23: ip-address = 10.3.17.23, hardware-address = 42:81:aa:53:37:03 c910f03c17k23: ip-address = 10.3.17.23, hardware-address = 42:81:aa:53:37:03
CHECK:rc == 0   [Pass]

RUN:copycds /RHEL-ALT-7.4-20171030.0-Server-ppc64le-dvd1.iso [Thu Mar 22 05:11:24 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0   [Failed]

RUN:rootimgdir=`lsdef -t osimage __GETNODEATTR(c910f03c17k23,os)__-__GETNODEATTR(c910f03c17k23,arch)__-netboot-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir ]; then mv $rootimgdir $rootimgdir.regbak -f;fi [Thu Mar 22 05:11:25 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
mv: cannot move '/install/netboot/rhels7.4-alternate/ppc64le/compute' to '/install/netboot/rhels7.4-alternate/ppc64le/compute.regbak/compute': Directory not empty

RUN:pkglistfile=`lsdef -t osimage __GETNODEATTR(c910f03c17k23,os)__-__GETNODEATTR(c910f03c17k23,arch)__-netboot-compute|grep pkglist|awk -F'=' '{print $2}'`;cp $pkglistfile $pkglistfile.bak [Thu Mar 22 05:11:26 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:pkglistfile=`lsdef -t osimage __GETNODEATTR(c910f03c17k23,os)__-__GETNODEATTR(c910f03c17k23,arch)__-netboot-compute|grep pkglist|awk -F'=' '{print $2}'`; if grep SUSE /etc/*release;then echo -e "kdump\nkexec-tools\nmakedumpfile\n" >> $pkglistfile; elif grep "Red Hat" /etc/*release;then echo -e "kexec-tools\ncrash\n" >> $pkglistfile;fi [Thu Mar 22 05:11:27 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
/etc/os-release:NAME="Red Hat Enterprise Linux Server"
/etc/os-release:PRETTY_NAME="Red Hat Enterprise Linux Server 7.4 (Maipo)"
/etc/os-release:REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
/etc/os-release:REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
/etc/redhat-release:Red Hat Enterprise Linux Server release 7.4 (Maipo)
/etc/system-release:Red Hat Enterprise Linux Server release 7.4 (Maipo)
RUN:exlistfile=`lsdef -t osimage __GETNODEATTR(c910f03c17k23,os)__-__GETNODEATTR(c910f03c17k23,arch)__-netboot-compute|grep exlist|awk -F'=' '{print $2}'`;cp $exlistfile $exlistfile.bak [Thu Mar 22 05:11:28 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:

RUN:exlistfile=`lsdef -t osimage __GETNODEATTR(c910f03c17k23,os)__-__GETNODEATTR(c910f03c17k23,arch)__-netboot-compute|grep exlist|awk -F'=' '{print $2}'`; sed -i '/boot/d' $exlistfile [Thu Mar 22 05:11:30 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:postinstallfile=`lsdef -t osimage __GETNODEATTR(c910f03c17k23,os)__-__GETNODEATTR(c910f03c17k23,arch)__-netboot-compute|grep postinstall|awk -F'=' '{print $2}'`;cp $postinstallfile $postinstallfile.bak [Thu Mar 22 05:11:31 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:postinstallfile=`lsdef -t osimage __GETNODEATTR(c910f03c17k23,os)__-__GETNODEATTR(c910f03c17k23,arch)__-netboot-compute|grep postinstall|awk -F'=' '{print $2}'`; if grep SUSE /etc/*release;then sed -i "/\/tmp/ s/10/200/g" $postinstallfile; elif grep "Red Hat" /etc/*release;then sed -i /devpts/a"tmpfs         /var/tmp    tmpfs   defaults,size=200m   0 2" $postinstallfile;fi [Thu Mar 22 05:11:32 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
/etc/os-release:NAME="Red Hat Enterprise Linux Server"
/etc/os-release:PRETTY_NAME="Red Hat Enterprise Linux Server 7.4 (Maipo)"
/etc/os-release:REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
/etc/os-release:REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
/etc/redhat-release:Red Hat Enterprise Linux Server release 7.4 (Maipo)
/etc/system-release:Red Hat Enterprise Linux Server release 7.4 (Maipo)

RUN:if [ ! -d /kdumpdir ]; then mkdir -p /kdumpdir && chmod 777 /kdumpdir; fi [Thu Mar 22 05:11:33 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:if [ ! -f /etc/exports ] ;then touch /etc/exports;else cp /etc/exports /etc/exports.bak;fi [Thu Mar 22 05:11:33 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo -e "/kdumpdir *(rw,no_root_squash,sync,no_subtree_check)" >> /etc/exports && exportfs /etc/exports  fi; [Thu Mar 22 05:11:33 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:chdef -t osimage __GETNODEATTR(c910f03c17k23,os)__-__GETNODEATTR(c910f03c17k23,arch)__-netboot-compute dump=nfs://c910f03c17k22/kdumpdir [Thu Mar 22 05:11:33 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.

RUN:chdef -t osimage __GETNODEATTR(c910f03c17k23,os)__-__GETNODEATTR(c910f03c17k23,arch)__-netboot-compute crashkernelsize=auto [Thu Mar 22 05:11:34 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.

RUN:chdef -t node c910f03c17k23 -p postscripts=enablekdump [Thu Mar 22 05:11:36 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.

RUN:genimage  __GETNODEATTR(c910f03c17k23,os)__-__GETNODEATTR(c910f03c17k23,arch)__-netboot-compute [Thu Mar 22 05:11:36 2018]
ElapsedTime:75 sec
RETURN rc = 0
OUTPUT:
Generating image:
cd /opt/xcat/share/xcat/netboot/rh; ./genimage -a ppc64le -o rhels7.4-alternate -p compute --permission 755 --srcdir "/install/rhels7.4-alternate/ppc64le" --pkglist /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist --otherpkgdir "/install/post/otherpkgs/rhels7.4-alternate/ppc64le" --postinstall /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.postinstall --rootimgdir /install/netboot/rhels7.4-alternate/ppc64le/compute --tempfile /tmp/xcat_genimage.8304 rhels7.4-alternate-ppc64le-netboot-compute
 yum -y -c /tmp/genimage.8312.yum.conf --installroot=/install/netboot/rhels7.4-alternate/ppc64le/compute/rootimg/ --disablerepo=* --enablerepo=rhels7.4-alternate-ppc64le-0  install  bash nfs-utils openssl dhclient kernel openssh-server openssh-clients wget rsyslog vim-minimal ntp rsyslog rpm rsync ppc64-utils iputils dracut dracut-network e2fsprogs bc file lsvpd irqbalance procps-ng parted net-tools gzip tar xz grub2 grub2-tools bzip2 ethtool kexec-tools\ncrash\n kexec-toolsncrashn kexec-tools crash kexec-tools crash kexec-tools crash kexec-tools crash kexec-tools crash kexec-tools crash kexec-tools crash kexec-tools crash kexec-tools crash kexec-tools crash \n
Package bash-4.2.46-29.el7_4.ppc64le already installed and latest version
Package 1:nfs-utils-1.3.0-0.48.el7_4.ppc64le already installed and latest version
Package 1:openssl-1.0.2k-8.el7.ppc64le already installed and latest version
Package 12:dhclient-4.2.5-58.el7.ppc64le already installed and latest version
Package kernel-4.11.0-44.el7a.ppc64le already installed and latest version
Package openssh-server-7.4p1-13.el7_4.ppc64le already installed and latest version
Package openssh-clients-7.4p1-13.el7_4.ppc64le already installed and latest version
Package wget-1.14-15.el7.ppc64le already installed and latest version
Package rsyslog-8.24.0-12.el7.ppc64le already installed and latest version
Package 2:vim-minimal-7.4.160-2.el7.ppc64le already installed and latest version
Package ntp-4.2.6p5-25.el7_3.2.ppc64le already installed and latest version
Package rsyslog-8.24.0-12.el7.ppc64le already installed and latest version
Package rpm-4.11.3-25.el7.ppc64le already installed and latest version
Package rsync-3.0.9-18.el7.ppc64le already installed and latest version
Package ppc64-utils-0.14-16.el7.ppc64le already installed and latest version
Package iputils-20160308-10.el7.ppc64le already installed and latest version
Package dracut-033-502.el7.ppc64le already installed and latest version
Package dracut-network-033-502.el7.ppc64le already installed and latest version
Try to load drivers: ext3 ext4 to initrd.
chroot /install/netboot/rhels7.4-alternate/ppc64le/compute/rootimg dracut  -f /tmp/initrd.8312.gz 4.11.0-44.el7a.ppc64le
No '/dev/log' or 'logger' included for syslog logging
Turning off host-only mode: '/sys' is not mounted!
Turning off host-only mode: '/proc' is not mounted!
Turning off host-only mode: '/run' is not mounted!
Turning off host-only mode: '/dev' is not mounted!
the initial ramdisk for stateless is generated successfully.
Try to load drivers: ext3 ext4 to initrd.
chroot /install/netboot/rhels7.4-alternate/ppc64le/compute/rootimg dracut  -f /tmp/initrd.8312.gz 4.11.0-44.el7a.ppc64le
No '/dev/log' or 'logger' included for syslog logging
Turning off host-only mode: '/sys' is not mounted!
Turning off host-only mode: '/proc' is not mounted!
Turning off host-only mode: '/run' is not mounted!
Turning off host-only mode: '/dev' is not mounted!
the initial ramdisk for statelite is generated successfully.

RUN:packimage __GETNODEATTR(c910f03c17k23,os)__-__GETNODEATTR(c910f03c17k23,arch)__-netboot-compute [Thu Mar 22 05:12:51 2018]
ElapsedTime:40 sec
RETURN rc = 0
OUTPUT:
Packing contents of /install/netboot/rhels7.4-alternate/ppc64le/compute/rootimg
archive method:cpio
compress method:gzip


RUN:rinstall c910f03c17k23 osimage=__GETNODEATTR(c910f03c17k23,os)__-__GETNODEATTR(c910f03c17k23,arch)__-netboot-compute [Thu Mar 22 05:13:31 2018]
ElapsedTime:5 sec
RETURN rc = 0
OUTPUT:
Provision node(s): c910f03c17k23

RUN:sleep 900 [Thu Mar 22 05:13:36 2018]
ElapsedTime:900 sec
RETURN rc = 0
OUTPUT:

RUN:a=0;while ! `lsdef -l c910f03c17k23|grep status|grep booted >/dev/null`; do sleep 10;((a++));if [ $a -gt 60 ];then break;fi done [Thu Mar 22 05:28:36 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:ping c910f03c17k23 -c 3 [Thu Mar 22 05:28:37 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
PING c910f03c17k23 (10.3.17.23) 56(84) bytes of data.
64 bytes from c910f03c17k23 (10.3.17.23): icmp_seq=1 ttl=64 time=0.370 ms
64 bytes from c910f03c17k23 (10.3.17.23): icmp_seq=2 ttl=64 time=0.176 ms
64 bytes from c910f03c17k23 (10.3.17.23): icmp_seq=3 ttl=64 time=0.203 ms

--- c910f03c17k23 ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2096ms

RUN:lsdef -l c910f03c17k23 | grep status [Thu Mar 22 05:28:39 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
    status=booted
    statustime=03-22-2018 05:17:24

RUN:xdsh c910f03c17k23 date [Thu Mar 22 05:28:39 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f03c17k23: Thu Mar 22 05:07:38 EDT 2018

RUN:xdsh c910f03c17k23 "echo 1 > /proc/sys/kernel/sysrq" [Thu Mar 22 05:28:40 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:xdsh c910f03c17k23 "echo c > /proc/sysrq-trigger" [Thu Mar 22 05:28:41 2018]
ElapsedTime:7 sec
RETURN rc = 1
OUTPUT:
c910f03c17k23: packet_write_wait: Connection to 10.3.17.23 port 22: Broken pipe


RUN:sleep 600 [Thu Mar 22 05:28:48 2018]
ElapsedTime:600 sec
RETURN rc = 0
OUTPUT:

RUN:vmcorefile=`find /kdumpdir/ -name vmcore`;if [[ -s $vmcorefile ]]; then echo "this file is not empty";else echo "this file is empty"; fi [Thu Mar 22 05:38:48 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
this file is not empty

RUN:pkglistfile=`lsdef -t osimage __GETNODEATTR(c910f03c17k23,os)__-__GETNODEATTR(c910f03c17k23,arch)__-netboot-compute|grep pkglist|awk -F'=' '{print $2}'`;mv -f $pkglistfile.bak $pkglistfile [Thu Mar 22 05:38:48 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:exlistfile=`lsdef -t osimage __GETNODEATTR(c910f03c17k23,os)__-__GETNODEATTR(c910f03c17k23,arch)__-netboot-compute|grep exlist|awk -F'=' '{print $2}'`;mv -f $exlistfile.bak $exlistfile [Thu Mar 22 05:38:49 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:

RUN:postinstallfile=`lsdef -t osimage __GETNODEATTR(c910f03c17k23,os)__-__GETNODEATTR(c910f03c17k23,arch)__-netboot-compute|grep postinstall|awk -F'=' '{print $2}'`;mv -f $postinstallfile.bak $postinstallfile [Thu Mar 22 05:38:51 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:if [ -f /etc/exports.bak ] ;then mv -f /etc/exports.bak /etc/exports; fi [Thu Mar 22 05:38:52 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:cat /tmp/node.stanza | chdef -z;rm -rf /tmp/node.stanza [Sat Mar 24 11:45:28 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.

RUN:cat /tmp/osimage.stanza | chdef -z;rm -rf /tmp/osimage.stanza [Sat Mar 24 11:45:28 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.

------END::linux_diskless_kdump::Passed::Time:Thu Mar 22 05:38:52 2018 ::Duration::1657 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished at Thu Mar 22 05:38:52 2018
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20180322051114 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20180322051114 file for time consumption





```