### PR TITLE
fix a syntax issue for perl v5.10.x

### DIFF
--- a/xCAT-server/lib/xcat/plugins/updatenode.pm
+++ b/xCAT-server/lib/xcat/plugins/updatenode.pm
@@ -330,7 +330,7 @@ sub preprocess_updatenode
            delete $allnodes{$node};
         }
         $request->{node}=[];
-        push $request->{node}, map  $_ ,keys %allnodes;
+        push @{$request->{node}}, map  $_ ,keys %allnodes;
     }
 
     unless (scalar @{$request->{node}}){


### PR DESCRIPTION


To fix https://github.com/xcat2/xcat-core/issues/4962



UT:
```
[root@c910f02c01p13 ~]# perl -I /opt/xcat/lib/perl/ -c /opt/xcat//lib/perl/xCAT_plugin/updatenode.pm
/opt/xcat//lib/perl/xCAT_plugin/updatenode.pm syntax OK

c910f02c01p14:~ # perl -I /opt/xcat/lib/perl/ -c /opt/xcat//lib/perl/xCAT_plugin/updatenode.pm
/opt/xcat//lib/perl/xCAT_plugin/updatenode.pm syntax OK
```