### PR TITLE
Fix command error in gocons caused by the env variable

### DIFF
--- a/xCAT-server/lib/perl/xCAT/Goconserver.pm
+++ b/xCAT-server/lib/perl/xCAT/Goconserver.pm
@@ -73,17 +73,14 @@ sub gen_request_data {
         if ($cmeth eq "openbmc") {
             push @openbmc_nodes, $k;
         }  else {
-            $cmd = $::XCATROOT . "/share/xcat/cons/$cmeth"." ".$k;
-            if (!(!$isSN && $v->{conserver} && xCAT::NetworkUtils->thishostisnot($v->{conserver}))) {
-                my $env;
-                my $locerror = $isSN ? "PERL_BADLANG=0 " : '';
-                if (defined($ENV{'XCATSSLVER'})) {
-                    $env = "XCATSSLVER=$ENV{'XCATSSLVER'} ";
-                }
-                $cmd = $locerror.$env.$cmd;
+            my $env = "";
+            my $locerror = $isSN ? "PERL_BADLANG=0 " : '';
+            if (defined($ENV{'XCATSSLVER'})) {
+                $env = "XCATSSLVER=$ENV{'XCATSSLVER'} ";
             }
+            $data->{$k}->{params}->{env} = $locerror.$env;
             $data->{$k}->{driver} = "cmd";
-            $data->{$k}->{params}->{cmd} = $cmd;
+            $data->{$k}->{params}->{cmd} = $::XCATROOT . "/share/xcat/cons/$cmeth"." ".$k;
             $data->{$k}->{name} = $k;
         }
         if (defined($v->{consoleondemand})) {


### PR DESCRIPTION
In hierarchical mode, xCAT insert variables in the command line,
but goconserver do not support this format. This patch put the
definition for environment variable to `{params}->{env}` field so
that the first argument of  `{params}->{cmd}` is executable.

fix-bug: #4951 