### PR TITLE
fix issue chroot, rpm -qa error: Failed to initialize NSS library #4959

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -520,7 +520,7 @@ unless ($onlyinitrd) {
         # Hack uname when deal otherpkgs
         use_hackuname($arch, $kernelver);
         use_devnull();
-
+        use_devurandom();
 
         foreach $pass (sort { $a <=> $b } (keys(%extra_hash))) {
             $yumcmd = $yumcmd_base;
@@ -2352,6 +2352,18 @@ sub use_devnull {
     }
     if (!-e "$rootimg_dir/dev/null") {
         system("mknod $rootimg_dir/dev/null c 1 3");
+    }
+}
+
+#in rhels7.5, the /dev/urandom does not exist in rootimg directory
+#which cause any rpm command fail with `error: Failed to initialize NSS library`
+#create urandom in genimage to avoid the error
+sub use_devurandom {
+    if (-e "$rootimg_dir/dev/urandom" and !-c "$rootimg_dir/dev/urandom") {
+        system("rm -f $rootimg_dir/dev/urandom");
+    }
+    if (!-e "$rootimg_dir/dev/urandom") {
+        system("mknod -m444 $rootimg_dir/dev/urandom c 1 9");
     }
 }
 


### PR DESCRIPTION
fix issue: https://github.com/xcat2/xcat-core/issues/4959

UT:
```
[root@boston02 rootimg]# genimage rhels7.5-alternate-ppc64le-netboot-service
Generating image:
cd /opt/xcat/share/xcat/netboot/rh; ./genimage -a ppc64le -o rhels7.5-alternate -p service --permission 755 --srcdir "/install/rhels7.5-alternate/ppc64le" --pkglist /opt/xcat/share/xcat/netboot/rh/service.rhels7.ppc64le.pkglist --otherpkgdir "/install/software/xcat/2.13.9" --otherpkglist /opt/xcat/share/xcat/netboot/rh/service.rhels7.ppc64le.otherpkgs.pkglist --postinstall /opt/xcat/share/xcat/netboot/rh/service.rhels7.ppc64le.postinstall --rootimgdir /install/netboot/rhels7.5-alternate-ppc64le/ppc64le/service --tempfile /tmp/xcat_genimage.31207 rhels7.5-alternate-ppc64le-netboot-service
 yum -y -c /tmp/genimage.31222.yum.conf --installroot=/install/netboot/rhels7.5-alternate-ppc64le/ppc64le/service/rootimg/ --disablerepo=* --enablerepo=rhels7.5-alternate-ppc64le-0  install  bash bc bind bind-utils busybox bzip2 cronie dhclient dhcp dracut dracut-network e2fsprogs expect gzip httpd iputils irqbalance kernel ksh lsvpd mysql-connector-odbc net-snmp-perl nfs-utils ntp openssh-clients openssh-server openssl parted perl-DBD-MySQL perl-DBD-Pg perl-IO-Socket-SSL perl-Net-Telnet perl-XML-Parser perl-XML-Simple postgresql postgresql-server ppc64-utils procps rootfiles rpm rsync tar unixODBC vim-minimal vsftpd wget xz rsyslog ethtool
Package bash-4.2.46-30.el7.ppc64le already installed and latest version
Package bc-1.06.95-13.el7.ppc64le already installed and latest version
Package 32:bind-9.9.4-61.el7.ppc64le already installed and latest version
Package 32:bind-utils-9.9.4-61.el7.ppc64le already installed and latest version
No package busybox available.
Package bzip2-1.0.6-13.el7.ppc64le already installed and latest version
...
...

Package xz-5.2.2-1.el7.ppc64le already installed and latest version
Package rsyslog-8.24.0-16.el7.ppc64le already installed and latest version
Package 2:ethtool-4.8-7.el7.ppc64le already installed and latest version
Nothing to do
Cleaning repos: otherpkgs1 otherpkgs2 rhels7.5-alternate-ppc64le-0
Cleaning up everything
 yum -y -c /tmp/genimage.31222.yum.conf --installroot=/install/netboot/rhels7.5-alternate-ppc64le/ppc64le/service/rootimg/ --disablerepo=* --enablerepo=rhels7.5-alternate-ppc64le-0 --enablerepo=otherpkgs1 --enablerepo=otherpkgs2 install   conserver-xcat perl-Net-Telnet perl-Expect xCATsn
Package conserver-xcat-8.2.1-1.ppc64le already installed and latest version
Package perl-Net-Telnet-3.03-19.el7.noarch already installed and latest version
Package perl-Expect-1.21-1.noarch already installed and latest version
Package 4:xCATsn-2.13.11-snap201803130615.ppc64le already installed and latest version
Nothing to do
No packages marked for update
Enter the dracut mode. Dracut version: 033. Dracut directory: dracut_033.
Try to load drivers: ext3 ext4 to initrd.
chroot /install/netboot/rhels7.5-alternate-ppc64le/ppc64le/service/rootimg dracut  -f /tmp/initrd.31222.gz 4.14.0-48.el7a.ppc64le
No '/dev/log' or 'logger' included for syslog logging
Turning off host-only mode: '/sys' is not mounted!
Turning off host-only mode: '/proc' is not mounted!
Turning off host-only mode: '/run' is not mounted!
Turning off host-only mode: '/dev' is not mounted!
the initial ramdisk for stateless is generated successfully.
Try to load drivers: ext3 ext4 to initrd.
chroot /install/netboot/rhels7.5-alternate-ppc64le/ppc64le/service/rootimg dracut  -f /tmp/initrd.31222.gz 4.14.0-48.el7a.ppc64le
No '/dev/log' or 'logger' included for syslog logging
Turning off host-only mode: '/sys' is not mounted!
Turning off host-only mode: '/proc' is not mounted!
Turning off host-only mode: '/run' is not mounted!
Turning off host-only mode: '/dev' is not mounted!
the initial ramdisk for statelite is generated successfully.

[root@boston02 rootimg]# cat /install/netboot/rhels7.5-alternate-ppc64le/ppc64le/service/rootimg/etc/httpd/conf.d/xcat.conf
#
# This configuration file allows a diskfull install to access the install images
# via http.  It also allows the xCAT documentation to be accessed via
# http://localhost/xcat-doc/
# Updates to xCAT/xcat.conf should also be made to xCATsn/xcat.conf
#
AliasMatch ^/install/(.*)$ "/install/$1"
AliasMatch ^/tftpboot/(.*)$ "/tftpboot/$1"

<Directory "/tftpboot">
    Options Indexes FollowSymLinks Includes MultiViews
    AllowOverride None
    Require all granted
</Directory>
<Directory "/install">
    Options Indexes FollowSymLinks Includes MultiViews
    AllowOverride None
    Require all granted
</Directory>

Alias /xcat-doc "/opt/xcat/share/doc"
<Directory "/opt/xcat/share/doc">
 Options Indexes
 AllowOverride None
 Require all granted
</Directory>


```