### PR TITLE
unify chdef and mkdef some actions for node type

### DIFF
--- a/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
+++ b/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
@@ -2406,6 +2406,7 @@ sub defch
         }
         unless(isobjnamevalid($obj,$type)){
             $invalidobjname .= ",$obj";
+            delete($::FINALATTRS{$obj});
             next;
         }
         if (defined($objTypeListsHash{$type}{$obj}) && ($objTypeListsHash{$type}{$obj} == 1))
@@ -2962,11 +2963,8 @@ sub defch
                 my $newobj          = ();
                 my $invalidnodename = ();
                 foreach my $node (keys %newobjects) {
-                    if (((!$::opt_t) && (!$::FILEATTRS{$node}{'objtype'})) || ($::FILEATTRS{$node}{'objtype'} eq "node") || ($::opt_t eq "node")) {
-                        if($node =~ /[A-Z]/){
-                            $invalidnodename .= ",$node";
-                        }
-                            
+                    if (($node =~ /[A-Z]/) && (((!$::opt_t) && (!$::FILEATTRS{$node}{'objtype'})) || ($::FILEATTRS{$node}{'objtype'} eq "node") || ($::opt_t eq "node"))) {
+                        $invalidnodename .= ",$node";
                     }
                     $newobj .= ",$node";
                 }

--- a/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
+++ b/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
@@ -2374,7 +2374,8 @@ sub defch
             $objTypeListsHash{$objk}{$obj} = 1;
         }
     }
-
+    my $nodewithdomain = ();
+    my $invalidobjname = ();
     foreach my $obj (keys %::FINALATTRS)
     {
 
@@ -2397,7 +2398,17 @@ sub defch
             $error = 1;
             next;
         }
-
+        if ($obj =~ /\./ && $type eq "node")
+        {
+            $nodewithdomain .= ",$obj";
+            delete($::FINALATTRS{$obj});
+            next;
+        }
+        unless(isobjnamevalid($obj,$type)){
+            $invalidobjname .= ",$obj";
+            #delete($::FINALATTRS{$obj});
+            next;
+        }
         if (defined($objTypeListsHash{$type}{$obj}) && ($objTypeListsHash{$type}{$obj} == 1))
         {
             $isDefined = 1;
@@ -2860,7 +2871,17 @@ sub defch
         }
 
     }    # end - for each object to update
-
+    my $rsp;
+    if ($nodewithdomain) {
+        $nodewithdomain =~ s/,//;
+        $rsp->{data}->[0] = "The object name \'$nodewithdomain\' is invalid, Cannot use '.' in node name.";
+        xCAT::MsgUtils->message("E", $rsp, $::callback);
+    }
+    if ($invalidobjname) {
+        $invalidobjname =~ s/,//;
+        $rsp->{data}->[0] = "The object name \'$invalidobjname\' is invalid, please refer to \"man xcatdb\" for the valid \"xCAT Object Name Format\"";
+        xCAT::MsgUtils->message("E", $rsp, $::callback);
+    }
     #
     #  write each object into the tables in the xCAT database
     #
@@ -2942,8 +2963,11 @@ sub defch
                 my $newobj          = ();
                 my $invalidnodename = ();
                 foreach my $node (keys %newobjects) {
-                    if (($node =~ /[A-Z]/) && (((!$::opt_t) && (!$::FILEATTRS{$node}{'objtype'})) || ($::FILEATTRS{$node}{'objtype'} eq "node") || ($::opt_t eq "node"))) {
-                        $invalidnodename .= ",$node";
+                    if (((!$::opt_t) && (!$::FILEATTRS{$node}{'objtype'})) || ($::FILEATTRS{$node}{'objtype'} eq "node") || ($::opt_t eq "node")) {
+                        if($node =~ /[A-Z]/){
+                            $invalidnodename .= ",$node";
+                        }
+                            
                     }
                     $newobj .= ",$node";
                 }

--- a/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
+++ b/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
@@ -2374,7 +2374,7 @@ sub defch
             $objTypeListsHash{$objk}{$obj} = 1;
         }
     }
-    my $nodewithdomain = ();
+    my $nodewithdomain;
     my $invalidobjname = ();
     foreach my $obj (keys %::FINALATTRS)
     {
@@ -2406,7 +2406,6 @@ sub defch
         }
         unless(isobjnamevalid($obj,$type)){
             $invalidobjname .= ",$obj";
-            #delete($::FINALATTRS{$obj});
             next;
         }
         if (defined($objTypeListsHash{$type}{$obj}) && ($objTypeListsHash{$type}{$obj} == 1))


### PR DESCRIPTION
For #4930 
fixed 2 issues:
1, node object name can not contain "."
2, group object cannot support range

1, node object UT:
```
[root@bybc0602 xCAT_plugin]# cat 01
test01:
    objtype=node
    groups=all
    ip=20.0.0.1
    switch=virtswitch2
    switchport=1

bai01.01:
    objtype=node
    groups=all
    ip=20.0.0.1
    switch=virtswitch2
    switchport=1
[root@bybc0602 xCAT_plugin]# cat 01|chdef -z
Error: The object name 'bai01.01' is invalid, Cannot use '.' in node name.
1 object definitions have been created or modified.
New object definitions 'test01' have been created.
[root@bybc0602 xCAT_plugin]# echo $?
1

[root@bybc0602 xCAT_plugin]# chdef bai01.01 groups=all
Error: The object name 'bai01.01' is invalid, Cannot use '.' in node name.
No object definitions have been created or modified.
[root@bybc0602 xCAT_plugin]# chdef -t node bai01.01 groups=all
Error: The object name 'bai01.01' is invalid, Cannot use '.' in node name.
No object definitions have been created or modified.
[root@bybc0602 xCAT_plugin]# chdef -t node -o bai01.01 groups=all
Error: The object name 'bai01.01' is invalid, Cannot use '.' in node name.
No object definitions have been created or modified.
[root@bybc0602 xCAT_plugin]# echo $?
1
```
2, group object UT:
```
[root@bybc0602 xCAT_plugin]# chdef -t group service[1-3]
Error: The object name 'service[1-3]' is invalid, please refer to "man xcatdb" for the valid "xCAT Object Name Format"
No object definitions have been created or modified.
[root@bybc0602 xCAT_plugin]# echo $?
1
[root@bybc0602 xCAT_plugin]# chdef -t group service1-service3
Error: The object name 'service1-service3' is invalid, please refer to "man xcatdb" for the valid "xCAT Object Name Format"
No object definitions have been created or modified.
[root@bybc0602 xCAT_plugin]# echo $?
1
[root@bybc0602 xCAT_plugin]# chdef -t group service1
1 object definitions have been created or modified.
New object definitions 'service1' have been created.
[root@bybc0602 xCAT_plugin]# echo $?
0
[root@bybc0602 xCAT_plugin]# chdef -t group service[1]
Error: The object name 'service[1]' is invalid, please refer to "man xcatdb" for the valid "xCAT Object Name Format"
No object definitions have been created or modified.
```