### PR TITLE
Modify goconserver msg for SN

### DIFF
--- a/perl-xCAT/xCAT/Client.pm
+++ b/perl-xCAT/xCAT/Client.pm
@@ -1129,11 +1129,14 @@ sub handle_response {
         return;
     }
 
-    my $msgsource;
+    my $msgsource = "";
     if ($ENV{'XCATSHOWSVR'}) {
         unless ($rsp->{NoSvrPrefix}) { # some plugins could disable the prefix forcely by seting the flag in response.
             $msgsource = $rsp->{xcatdsource}->[0] if ($rsp->{xcatdsource});
         }
+    }
+    if ($rsp->{host}) {
+        $msgsource = $rsp->{xcatdsource}->[0] if ($rsp->{xcatdsource});
     }
 
     #print "in handle_response\n";
@@ -1148,10 +1151,6 @@ sub handle_response {
             $xCAT::Client::EXITCODE |= $rsp->{errorcode};
         }    # assume it is a non-reference scalar
     }
-    my $host = "";
-    if ($rsp->{host}) {
-        $host = "[".$rsp->{host}->[0]."]" if !$msgsource;
-    }
 
     if ($rsp->{error}) {
 
@@ -1160,14 +1159,14 @@ sub handle_response {
             foreach my $text (@{ $rsp->{error} }) {
                 my $desc = "$text";
                 $desc = "[$msgsource]: $desc" if ($msgsource && $desc);
-                $desc = "Error$host: $desc" unless ($rsp->{NoErrorPrefix});
+                $desc = "Error: $desc" unless ($rsp->{NoErrorPrefix});
                 print STDERR "$desc\n";
             }
         }
         else {
             my $desc = $rsp->{error};
             $desc = "[$msgsource]: $desc" if ($msgsource && $desc);
-            $desc = "Error$host: $desc" unless ($rsp->{NoErrorPrefix});
+            $desc = "Error: $desc" unless ($rsp->{NoErrorPrefix});
             print STDERR "$desc\n";
         }
     }
@@ -1178,14 +1177,14 @@ sub handle_response {
             foreach my $text (@{ $rsp->{warning} }) {
                 my $desc = "$text";
                 $desc = "[$msgsource]: $desc" if ($msgsource && $desc);
-                $desc = "Warning$host: $desc" unless ($rsp->{NoWarnPrefix});
+                $desc = "Warning: $desc" unless ($rsp->{NoWarnPrefix});
                 print STDERR "$desc\n";
             }
         }
         else {
             my $desc = $rsp->{warning};
             $desc = "[$msgsource]: $desc" if ($msgsource && $desc);
-            $desc = "Warning$host: $desc" unless ($rsp->{NoWarnPrefix});
+            $desc = "Warning: $desc" unless ($rsp->{NoWarnPrefix});
             print STDERR "$desc\n";
         }
     }
@@ -1193,7 +1192,7 @@ sub handle_response {
         #print "printing info\n";
         if (ref($rsp->{info}) eq 'ARRAY') {
             foreach my $text (@{ $rsp->{info} }) {
-                my $desc = "$host$text";
+                my $desc = "$text";
                 $desc = "[$msgsource]: $desc" if ($msgsource && $desc);
                 print "$desc\n";
             }

--- a/perl-xCAT/xCAT/Client.pm
+++ b/perl-xCAT/xCAT/Client.pm
@@ -1148,6 +1148,10 @@ sub handle_response {
             $xCAT::Client::EXITCODE |= $rsp->{errorcode};
         }    # assume it is a non-reference scalar
     }
+    my $host = "";
+    if ($rsp->{host}) {
+        $host = "[".$rsp->{host}->[0]."]" if !$msgsource;
+    }
 
     if ($rsp->{error}) {
 
@@ -1156,14 +1160,14 @@ sub handle_response {
             foreach my $text (@{ $rsp->{error} }) {
                 my $desc = "$text";
                 $desc = "[$msgsource]: $desc" if ($msgsource && $desc);
-                $desc = "Error: $desc" unless ($rsp->{NoErrorPrefix});
+                $desc = "Error$host: $desc" unless ($rsp->{NoErrorPrefix});
                 print STDERR "$desc\n";
             }
         }
         else {
             my $desc = $rsp->{error};
             $desc = "[$msgsource]: $desc" if ($msgsource && $desc);
-            $desc = "Error: $desc" unless ($rsp->{NoErrorPrefix});
+            $desc = "Error$host: $desc" unless ($rsp->{NoErrorPrefix});
             print STDERR "$desc\n";
         }
     }
@@ -1174,23 +1178,22 @@ sub handle_response {
             foreach my $text (@{ $rsp->{warning} }) {
                 my $desc = "$text";
                 $desc = "[$msgsource]: $desc" if ($msgsource && $desc);
-                $desc = "Warning: $desc" unless ($rsp->{NoWarnPrefix});
+                $desc = "Warning$host: $desc" unless ($rsp->{NoWarnPrefix});
                 print STDERR "$desc\n";
             }
         }
         else {
             my $desc = $rsp->{warning};
             $desc = "[$msgsource]: $desc" if ($msgsource && $desc);
-            $desc = "Warning: $desc" unless ($rsp->{NoWarnPrefix});
+            $desc = "Warning$host: $desc" unless ($rsp->{NoWarnPrefix});
             print STDERR "$desc\n";
         }
     }
     if ($rsp->{info}) {
-
         #print "printing info\n";
         if (ref($rsp->{info}) eq 'ARRAY') {
             foreach my $text (@{ $rsp->{info} }) {
-                my $desc = "$text";
+                my $desc = "$host$text";
                 $desc = "[$msgsource]: $desc" if ($msgsource && $desc);
                 print "$desc\n";
             }

--- a/perl-xCAT/xCAT/MsgUtils.pm
+++ b/perl-xCAT/xCAT/MsgUtils.pm
@@ -18,6 +18,8 @@ use Socket;
 use File::Path;
 use constant PERF_LOG => "/var/log/xcat/perf.log";
 
+my $host = "";
+my $isSN = xCAT::Utils->isServiceNode();
 $::NOK = -1;
 $::OK  = 0;
 
@@ -545,6 +547,73 @@ sub message
     }
     return;
 }
+
+
+#-----------------------------------------------------------------------------
+
+=head3 error_message
+
+  A wrap function for message. If $callback is not defined, send the log to
+  syslog, otherwise, send error message to client. Print service host if runs
+  on service node.
+
+  Example:
+
+          $rsp->{data}->[0] = "message";
+          xCAT::MsgUtils->error_message($rsp, $callback);
+=cut
+
+#-----------------------------------------------------------------------------
+sub error_message
+{
+    shift;
+    my $rsp = shift;
+    my $callback = shift;
+    if (!defined($callback)) {
+        message(undef, "S", $rsp, undef);
+        return;
+    }
+    if ($isSN && !$host) {
+        my @hostinfo = xCAT::NetworkUtils->determinehostname();
+        $host = $hostinfo[-1];
+    }
+    $rsp->{host} = $host if $host;
+    message(undef, "E", $rsp, $callback);
+}
+
+#-----------------------------------------------------------------------------
+
+=head3 info_message
+
+  A wrap function for message. If $callback is not defined, send the log to
+  syslog, otherwise, send info message to client. Print service host if runs
+  on service node.
+
+  Example:
+
+          $rsp->{data}->[0] = "message";
+          xCAT::MsgUtils->info_message($rsp, $callback);
+=cut
+
+#-----------------------------------------------------------------------------
+sub info_message
+{
+    shift;
+    my $rsp = shift;
+    my $callback = shift;
+    if (!defined($callback)) {
+        message(undef, "S", $rsp, undef);
+        return;
+    }
+    if ($isSN && !$host) {
+        my @hostinfo = xCAT::NetworkUtils->determinehostname();
+        $host = $hostinfo[-1];
+    }
+    $rsp->{host} = $host if $host;
+    message(undef, "I", $rsp, $callback);
+}
+
+
 
 #--------------------------------------------------------------------------------
 

--- a/xCAT-server/lib/perl/xCAT/Goconserver.pm
+++ b/xCAT-server/lib/perl/xCAT/Goconserver.pm
@@ -60,7 +60,7 @@ sub http_request {
 
 sub gen_request_data {
     my ($cons_map, $siteondemand, $callback) = @_;
-    my (@openbmc_nodes, $data);
+    my (@openbmc_nodes, $data, $rsp);
     while (my ($k, $v) = each %{$cons_map}) {
         my $ondemand;
         if ($siteondemand) {
@@ -104,11 +104,8 @@ sub gen_request_data {
         foreach my $node (@openbmc_nodes) {
             if (defined($openbmc_hash->{$node}->[0])) {
                 if (!$openbmc_hash->{$node}->[0]->{'bmc'}) {
-                    if($callback) {
-                        xCAT::SvrUtils::sendmsg("Error: Unable to get attribute bmc", $callback, $node);
-                    } else {
-                        xCAT::MsgUtils->message("S", "$node: Error: Unable to get attribute bmc");
-                    }
+                    $rsp->{data}->[0] = "$node: Failed to send delete request.";
+                    xCAT::MsgUtils->error_message($rsp, $callback);
                     delete $data->{$node};
                     next;
                 }
@@ -118,11 +115,8 @@ sub gen_request_data {
                 } elsif ($passwd_hash and $passwd_hash->{username}) {
                     $data->{$node}->{params}->{user} = $passwd_hash->{username};
                 } else {
-                    if ($callback) {
-                        xCAT::SvrUtils::sendmsg("Error: Unable to get attribute username", $callback, $node)
-                    } else {
-                        xCAT::MsgUtils->message("S", "$node: Error: Unable to get attribute username");
-                    }
+                    $rsp->{data}->[0] = "$node: Unable to get attribute username.";
+                    xCAT::MsgUtils->error_message($rsp, $callback);
                     delete $data->{$node};
                     next;
                 }
@@ -131,11 +125,8 @@ sub gen_request_data {
                 } elsif ($passwd_hash and $passwd_hash->{password}) {
                     $data->{$node}->{params}->{password} = $passwd_hash->{password};
                 } else {
-                    if ($callback) {
-                        xCAT::SvrUtils::sendmsg("Error: Unable to get attribute password", $callback, $node)
-                    } else {
-                        xCAT::MsgUtils->message("S", "$node: Error: Unable to get attribute password");
-                    }
+                    $rsp->{data}->[0] = "$node: Unable to get attribute password.";
+                    xCAT::MsgUtils->error_message($rsp, $callback);
                     delete $data->{$node};
                     next;
                 }
@@ -268,22 +259,14 @@ sub delete_nodes {
     $ret = 0;
     my $response = http_request("DELETE", $url, $data);
     if (!defined($response)) {
-        if ($callback) {
-            $rsp->{data}->[0] = "Failed to send delete request.";
-            xCAT::MsgUtils->message("E", $rsp, $callback)
-        } else {
-            xCAT::MsgUtils->message("S", "Failed to send delete request.");
-        }
+        $rsp->{data}->[0] = "Failed to send delete request.";
+        xCAT::MsgUtils->error_message($rsp, $callback);
         return 1;
     } elsif ($delmode) {
         while (my ($k, $v) = each %{$response}) {
             if ($v ne "Deleted") {
-                if ($callback) {
-                    $rsp->{data}->[0] = "$k: Failed to delete entry in goconserver: $v";
-                    xCAT::MsgUtils->message("E", $rsp, $callback)
-                } else {
-                    xCAT::MsgUtils->message("S", "$k: Failed to delete entry in goconserver: $v");
-                }
+                $rsp->{data}->[0] = "$k: Failed to delete entry in goconserver: $v";
+                xCAT::MsgUtils->error_message($rsp, $callback);
                 $ret = 1;
             } else {
                 if ($callback) {
@@ -296,12 +279,8 @@ sub delete_nodes {
     }
     if (@update_nodes) {
         if (disable_nodes_in_db(\@update_nodes)) {
-            if ($callback) {
-                $rsp->{data}->[0] = "Failed to update consoleenabled status in db.";
-                xCAT::MsgUtils->message("E", $rsp, $callback);
-            } else {
-                xCAT::MsgUtils->message("S", "Failed to update consoleenabled status in db.");
-            }
+            $rsp->{data}->[0] = "Failed to update consoleenabled status in db.";
+            xCAT::MsgUtils->error_message($rsp, $callback);
         }
     }
     return $ret;
@@ -318,22 +297,14 @@ sub create_nodes {
     $ret = 0;
     my $response = http_request("POST", $url, $data);
     if (!defined($response)) {
-        if ($callback) {
-            $rsp->{data}->[0] = "Failed to send create request.";
-            xCAT::MsgUtils->message("E", $rsp, $callback)
-        } else {
-            xCAT::MsgUtils->message("S", "Failed to send create request.");
-        }
+        $rsp->{data}->[0] = "Failed to send create request.";
+        xCAT::MsgUtils->error_message($rsp, $callback);
         return 1;
     } elsif ($response) {
         while (my ($k, $v) = each %{$response}) {
             if ($v ne "Created") {
-                if ($callback) {
-                    $rsp->{data}->[0] = "$k: Failed to create console entry in goconserver: $v";
-                    xCAT::MsgUtils->message("E", $rsp, $callback);
-                } else {
-                    xCAT::MsgUtils->message("S", "$k: Failed to create console entry in goconserver: $v");
-                }
+                $rsp->{data}->[0] = "$k: Failed to create console entry in goconserver: $v";
+                xCAT::MsgUtils->error_message($rsp, $callback);
                 $ret = 1;
             } else {
                 $rsp->{data}->[0] = "$k: $v";
@@ -344,12 +315,8 @@ sub create_nodes {
     }
     if (@update_nodes) {
         if (enable_nodes_in_db(\@update_nodes)) {
-            if ($callback) {
-                $rsp->{data}->[0] = "Failed to update consoleenabled status in db.";
-                xCAT::MsgUtils->message("E", $rsp, $callback);
-            } else {
-                CAT::MsgUtils->message("S", "Failed to update consoleenabled status in db.");
-            }
+            $rsp->{data}->[0] = "Failed to update consoleenabled status in db.";
+            xCAT::MsgUtils->error_message($rsp, $callback);
         }
     }
     return $ret;
@@ -361,13 +328,13 @@ sub list_nodes {
     my $rsp;
     my $response = http_request("GET", $url);
     if (!defined($response)) {
-        $rsp->{data}->[0] = "Failed to send list request.";
-        xCAT::MsgUtils->message("E", $rsp, $callback);
+        $rsp->{data}->[0] = "Failed to send list request. Is goconserver service started?";
+        xCAT::MsgUtils->error_message($rsp, $callback);
         return 1;
     }
     if (!$response->{nodes}) {
         $rsp->{data}->[0] = "Could not find any node.";
-        xCAT::MsgUtils->message("I", $rsp, $callback);
+        xCAT::MsgUtils->info_message($rsp, $callback);
         return 0;
     }
     $rsp->{data}->[0] = sprintf("\n".PRINT_FORMAT, "NODE", "SERVER", "STATE");
@@ -379,7 +346,7 @@ sub list_nodes {
         $node_map->{$node->{name}}->{vis} = 1;
         if (!$node->{host} || !$node->{state}) {
             $rsp->{data}->[0] = sprintf(PRINT_FORMAT, $node->{name}, "", "Unable to parse the response message");
-            xCAT::MsgUtils->message("E", $rsp, $callback);
+            xCAT::MsgUtils->error_message("E", $rsp, $callback);
             next;
         }
         $rsp->{data}->[0] = sprintf(PRINT_FORMAT, $node->{name}, $node->{host}, substr($node->{state}, 0, 16));
@@ -403,12 +370,8 @@ sub cleanup_nodes {
     my $rsp;
     my $response = http_request("GET", "$api_url/nodes");
     if (!defined($response)) {
-        if ($callback) {
-            $rsp->{data}->[0] = "Failed to send list request.";
-            xCAT::MsgUtils->message("E", $rsp, $callback);
-        } else {
-            xCAT::MsgUtils->message("S", "Failed to send list request.");
-        }
+        $rsp->{data}->[0] = "Failed to send list request. Is goconserver service started?";
+        xCAT::MsgUtils->error_message("E", $rsp, $callback);
         return 1;
     }
     if (!$response->{nodes}) {

--- a/xCAT-server/lib/xcat/plugins/goconserver.pm
+++ b/xCAT-server/lib/xcat/plugins/goconserver.pm
@@ -143,13 +143,13 @@ sub start_goconserver {
     my ($rsp, $running, $ready, $ret);
     unless (-x "/usr/bin/goconserver") {
         $rsp->{data}->[0] = "goconserver is not installed.";
-        xCAT::MsgUtils->message("E", $rsp, $::callback);
+        xCAT::MsgUtils->error_message($rsp, $::callback);
         return 1;
     }
     # if goconserver is installed, check the status of conserver service.
     if (xCAT::Goconserver::is_conserver_running()) {
         $rsp->{data}->[0] = "conserver is started, please stop it at first.";
-        xCAT::MsgUtils->message("E", $rsp, $::callback);
+        xCAT::MsgUtils->error_message($rsp, $::callback);
         return 1;
     }
     $running = xCAT::Goconserver::is_goconserver_running();
@@ -164,18 +164,18 @@ sub start_goconserver {
         $ret = xCAT::Goconserver::build_conf();
         if ($ret) {
             $rsp->{data}->[0] = "Failed to create configuration file for goconserver.";
-            xCAT::MsgUtils->message("E", $rsp, $::callback);
+            xCAT::MsgUtils->error_message($rsp, $::callback);
             return 1;
         }
     }
     $ret = xCAT::Goconserver::restart_service();
     if ($ret) {
         $rsp->{data}->[0] = "Failed to start goconserver service.";
-        xCAT::MsgUtils->message("E", $rsp, $::callback);
+        xCAT::MsgUtils->error_message($rsp, $::callback);
         return 1;
     }
     $rsp->{data}->[0] = "Starting goconserver service ...";
-    xCAT::MsgUtils->message("I", $rsp, $::callback);
+    xCAT::MsgUtils->info_message($rsp, $::callback);
     sleep(3);
     return 0;
 }
@@ -197,19 +197,22 @@ sub makegocons {
     );
 
     my $svboot = 0;
+    my $rsp;
     if (exists($req->{svboot})) {
         $svboot = 1;
     }
     if ($cleanupmode) {
         if (exists($req->{_allnodes}) && $req->{_allnodes}->[0] != 1) {
-            xCAT::SvrUtils::sendmsg([ 1, "Can not specify noderange together with -C|--cleanup." ], $::callback);
+            $rsp->{data}->[0] = "Failed to start goconserver service.";
+            xCAT::MsgUtils->error_message($rsp, $::callback);
             return 1;
         }
         return xCAT::Goconserver::cleanup_nodes($::callback);
     }
     my %cons_map = xCAT::Goconserver::get_cons_map($req);
     if (! %cons_map) {
-        xCAT::SvrUtils::sendmsg([ 1, "Could not get any console request entry" ], $::callback);
+        $rsp->{data}->[0] = "Could not get any console request entry.";
+        xCAT::MsgUtils->error_message($rsp, $::callback);
         return 1;
     }
     my $api_url = "https://$host:". xCAT::Goconserver::get_api_port();
@@ -230,13 +233,15 @@ sub makegocons {
         }
         elsif (lc($site_entry) ne "no") {
             # consoleondemand attribute is set, but it is not "yes" or "no"
-            xCAT::SvrUtils::sendmsg([ 1, "Unexpected value $site_entry for consoleondemand attribute in site table" ], $::callback);
+            $rsp->{data}->[0] = "Unexpected value $site_entry for consoleondemand attribute in site table.";
+            xCAT::MsgUtils->error_message($rsp, $::callback);
         }
     }
     my (@nodes);
     my $data = xCAT::Goconserver::gen_request_data(\%cons_map, $siteondemand, $::callback);
     if (! $data) {
-        xCAT::SvrUtils::sendmsg([ 1, "Could not generate the request data" ], $::callback);
+        $rsp->{data}->[0] = "Could not generate the request data.";
+        xCAT::MsgUtils->error_message($rsp, $::callback);
         return 1;
     }
     $ret = xCAT::Goconserver::delete_nodes($api_url, $data, $delmode, $::callback);
@@ -245,7 +250,8 @@ sub makegocons {
     }
     $ret = xCAT::Goconserver::create_nodes($api_url, $data, $::callback);
     if ($ret != 0) {
-        xCAT::SvrUtils::sendmsg([ 1, "Failed to create console entry in goconserver. "], $::callback);
+        $rsp->{data}->[0] = "Failed to create console entry in goconserver.";
+        xCAT::MsgUtils->error_message($rsp, $::callback);
         return $ret;
     }
     return 0;


### PR DESCRIPTION
The message util from xCAT framework do not print where the message
comes from by default. This patch add [service host] prefix for the
message if message is from SN.

```
    [root@c910f03c09k03 ~]# makegocons
    c910f03c09k05: Created
    c910f03c09k04: Created
    Error[c910f03c09k04]: conserver is started, please stop it at first.

    [root@c910f03c09k03 ~]# xdsh c910f03c09k04 service conserver stop
    c910f03c09k04: Stopping conserver (via systemctl):  [  OK  ]

    [root@c910f03c09k03 ~]# makegocons
    c910f03c09k05: Created
    c910f03c09k04: Created
    [c910f03c09k04]Starting goconserver service ...
    node-7912ac1-06vag36: Created

    [root@c910f03c09k03 ~]# xdsh c910f03c09k04 service goconserver stop
    c910f03c09k04: Redirecting to /bin/systemctl stop goconserver.service
    [root@c910f03c09k03 ~]# makegocons -q

    NODE                             SERVER                           STATE
    c910f03c09k04                    c910f03c09k03                    connected
    c910f03c09k05                    c910f03c09k03                    connected
    Error[c910f03c09k04]: Failed to send list request. Is goconserver service started?

    [root@c910f03c09k03 ~]# xdsh c910f03c09k04 service goconserver start
    c910f03c09k04: Redirecting to /bin/systemctl start goconserver.service

    [root@c910f03c09k03 ~]# makegocons -q

    NODE                             SERVER                           STATE
    c910f03c09k04                    c910f03c09k03                    connected
    c910f03c09k05                    c910f03c09k03                    connected

    NODE                             SERVER                           STATE
    node-7912ac1-06vag36             c910f03c09k04                    connected
    [root@c910f03c09k03 ~]# rcons node-7912ac1-06vag36
    [Enter `^Ec?' for help]
   goconserver(2018-03-19T05:47:13-04:00): Hello 10.3.9.4:46896, welcome to the session of 
   node-7912ac1-06vag36

   Red Hat Enterprise Linux Server 7.1 (Maipo)
   Kernel 3.10.0-229.el7.x86_64 on an x86_64

   c910f04x30 login: Connection to c910f03c09k04 closed.
```
fix-bug: #4940