### PR TITLE
xcatd failed to start in rhels7.5-snap2 diskless service node

### DIFF
--- a/perl-xCAT/xCAT/MsgUtils.pm
+++ b/perl-xCAT/xCAT/MsgUtils.pm
@@ -484,7 +484,8 @@ sub message
         if ($errstr)
         {
             print $stdouterrf
-              "Unable to log $rsp to syslog because of $errstr\n";
+              "Error: Unable to log to syslog: $errstr\n";
+            print "$rsp\n";
         }
     }
 
@@ -794,9 +795,6 @@ sub trace() {
     if (($level eq "I") || ($level eq "i")) { $prefix = "INFO"; }
     if (($level eq "D") || ($level eq "d")) { $prefix = "DEBUG"; }
 
-    my @tmp           = xCAT::TableUtils->get_site_attribute("xcatdebugmode");
-    my $xcatdebugmode = $tmp[0];
-
     if (($level eq "E")
         || ($level eq "e")
         || ($level eq "I")
@@ -809,8 +807,15 @@ sub trace() {
             syslog("$prefix", $msg);
             closelog();
         };
+        if ($@) {
+            print "Error: Unable to log to syslog: $@\n";
+            print "$msg\n";
+        }
+        return;
     }
 
+    my @tmp           = xCAT::TableUtils->get_site_attribute("xcatdebugmode");
+    my $xcatdebugmode = $tmp[0];
     if (($level eq "D")
         || ($level eq "d")) {
         if (($verbose == 1) || ($xcatdebugmode eq "1") || ($xcatdebugmode eq "2")) {
@@ -819,6 +824,10 @@ sub trace() {
                 openlog("xcat", "nofatal,pid", "local4");
                 syslog("$prefix", $msg);
                 closelog();
+            };
+            if ($@) {
+                print "Error: Unable to log to syslog: $@\n";
+                print "$msg\n";
             }
         }
     }


### PR DESCRIPTION
Workaround (#4929) the MsgUtil.pm first to make sure xcatd will not crash when /dev/log is not ready.
And also move access DB for debug message only to improve the performance.

UT: 
```
[root@sn02 ~]# vi /opt/xcat/lib/perl/xCAT/MsgUtils.pm
[root@sn02 ~]# systemctl start xcatd

[root@sn02 ~]#
[root@sn02 ~]# systemctl status xcatd
● xcatd.service - LSB: xcatd
   Loaded: loaded (/etc/rc.d/init.d/xcatd; bad; vendor preset: disabled)
   Active: active (running) since Tue 2018-03-20 04:43:22 EDT; 6s ago
     Docs: man:systemd-sysv-generator(8)
  Process: 8355 ExecStart=/etc/rc.d/init.d/xcatd start (code=exited, status=0/SUCCESS)
   CGroup: /system.slice/xcatd.service
           ├─8458 xcatd: SSL listener
           ├─8459 xcatd: DB Access
           ├─8460 xcatd: UDP listener
           ├─8461 xcatd: install monitor
           ├─8462 xcatd: Discovery worker
           └─8463 xcatd: Command log writer

Mar 20 04:42:41 sn02.pok.stglabs.ibm.com xcatd[8355]: Subroutine is_valid_config_api redefined at /opt/xcat/lib/perl/xCAT_plugin/openbmc.pm line 4607.
Mar 20 04:42:41 sn02.pok.stglabs.ibm.com xcatd[8355]: Subroutine build_config_api_usage redefined at /opt/xcat/lib/perl/xCAT_plugin/openbmc.pm line 4639.
Mar 20 04:43:02 sn02.pok.stglabs.ibm.com xcatd[8355]: dns server has been enabled on boot.
Mar 20 04:43:02 sn02.pok.stglabs.ibm.com xcatd[8355]: Error: Unable to log to syslog: no connection to syslog available
Mar 20 04:43:02 sn02.pok.stglabs.ibm.com xcatd[8355]: - unix dgram connect: Connection refused
Mar 20 04:43:02 sn02.pok.stglabs.ibm.com xcatd[8355]: - stream can't open /dev/log: No such device or address at /opt/xcat/lib/perl/xCAT/MsgUtils.pm line 479.
Mar 20 04:43:02 sn02.pok.stglabs.ibm.com xcatd[8355]: dns server has been enabled on boot.
Mar 20 04:43:02 sn02.pok.stglabs.ibm.com xcatd[8355]: Job for httpd.service failed because the control process exited with error code. See "systemc...details.
Mar 20 04:43:22 sn02.pok.stglabs.ibm.com xcatd[8355]: [  OK  ]
Mar 20 04:43:22 sn02.pok.stglabs.ibm.com systemd[1]: Started LSB: xcatd.
Hint: Some lines were ellipsized, use -l to show in full.
```

2, update MsgUtil.pm and run `packimage` again, then reinstall service node in debugmode, now xcatd can survive when log is not ready.