### PR TITLE
Fix the rcons Console not ready issue but the bmc is accessible in fact

### DIFF
--- a/xCAT-server/lib/perl/xCAT/OPENBMC.pm
+++ b/xCAT-server/lib/perl/xCAT/OPENBMC.pm
@@ -255,7 +255,7 @@ sub run_cmd_in_perl {
     }
 
     # List of commands currently not supported in Python
-    my @unsupported_in_python_commands = ('rflash', 'rspconfig', 'reventlog');
+    my @unsupported_in_python_commands = ('rflash', 'rspconfig', 'reventlog', 'getopenbmccons');
 
     if ($command ~~ @unsupported_in_python_commands) {
         # Command currently not supported in Python


### PR DESCRIPTION
For openbmc console, the getopenbmccons return nothing because the using of `run_cmd_in_perl`
```
[root@c910f03c11k08 xcat]# rcons f6u03 -f
[Enter `^Ec?' for help]
Acquiring startup lock...done
Console not ready, retrying in 29 seconds (Ctrl-e,c,o to skip delay)
```
With this fix:
```
[root@c910f03c11k08 xcat]# rcons f6u03 -f
[Enter `^Ec?' for help]

Red Hat Enterprise Linux Server 7.5 (Maipo)
Kernel 4.14.0-48.el7a.ppc64le on an ppc64le

f6u03 login:
```