### PR TITLE
CUDA 9 support on RHEL 7

### DIFF
--- a/xCAT/postscripts/cuda_power9_setup
+++ b/xCAT/postscripts/cuda_power9_setup
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Copyright (C) 2018 International Business Machines
+# Eclipse Public License, Version 1.0 (EPL-1.0)
+#     <http://www.eclipse.org/legal/epl-v10.html>
+#
+# 2018-03-21 GONG Jie <gongjie@linux.vnet.ibm.com>
+#
+# This script is used for doing extra setup steps for NVIDIA POWER9 CUDA driver
+# on RHEL 7. Please refer document below for details.
+#
+# http://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#power9-setup
+#
+
+umask 0022
+
+grep '^#' /usr/lib/systemd/system/nvidia-persistenced.service >/tmp/nvidia-persistenced.service
+cat >>/tmp/nvidia-persistenced.service <<-EOF
+
+[Unit]
+Description=NVIDIA Persistence Daemon
+Wants=syslog.target
+
+[Service]
+Type=forking
+PIDFile=/var/run/nvidia-persistenced/nvidia-persistenced.pid
+Restart=always
+ExecStart=/usr/bin/nvidia-persistenced --user root --verbose
+ExecStopPost=/bin/rm -rf /var/run/nvidia-persistenced
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+mv /tmp/nvidia-persistenced.service /usr/lib/systemd/system/nvidia-persistenced.service
+
+chown root.root /usr/lib/systemd/system/nvidia-persistenced.service
+chmod 0644 /usr/lib/systemd/system/nvidia-persistenced.service
+
+systemctl enable nvidia-persistenced
+
+rm -f /lib/udev/rules.d/40-redhat.rules


### PR DESCRIPTION
This script is used for doing extra setup steps for NVIDIA POWER9 CUDA driver on RHEL 7. Please refer document below for details.

http://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#power9-setup