### PR TITLE
Catch BMC status error from get status request

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_power.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_power.py
@@ -82,17 +82,13 @@ class OpenBMCPowerTask(ParallelNodesCommand):
 
             if bmc_state != 'Ready':
                 bmc_state = bmc_not_ready
-                bmc_state_error = state.get('error')
-                if bmc_state_error is not None:
-                    # BMC is not ready and we have some error as to why
-                    self.callback.info('%s: %s (%s)' % (node, openbmc.RPOWER_STATES.get(bmc_state, bmc_state), bmc_state_error))
-                    return bmc_state
 
             self.callback.info('%s: %s' % (node, openbmc.RPOWER_STATES.get(bmc_state, bmc_state)))
 
-        except SelfServerException, SelfClientException:
-            # There is no response when BMC is not ready
+        except SelfServerException as e:
             self.callback.error(openbmc.RPOWER_STATES[bmc_not_ready], node)
+        except SelfClientException as e:
+            self.callback.error("%s (%s)" % (openbmc.RPOWER_STATES[bmc_not_ready], e.message), node)
 
         return bmc_state
 

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_power.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_power.py
@@ -82,6 +82,11 @@ class OpenBMCPowerTask(ParallelNodesCommand):
 
             if bmc_state != 'Ready':
                 bmc_state = bmc_not_ready
+                bmc_state_error = state.get('error')
+                if bmc_state_error is not None:
+                    # BMC is not ready and we have some error as to why
+                    self.callback.info('%s: %s (%s)' % (node, openbmc.RPOWER_STATES.get(bmc_state, bmc_state), bmc_state_error))
+                    return bmc_state
 
             self.callback.info('%s: %s' % (node, openbmc.RPOWER_STATES.get(bmc_state, bmc_state)))
 

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -320,6 +320,8 @@ class OpenBMCRest(object):
                         'Validate BMC configuration and retry the command.'
             self._print_error_log(e.message, cmd)
             raise
+        except SelfClientException as e:
+            raise SelfClientException(e.message, e.code)
         except ValueError:
             error = 'Received wrong format response: %s' % response
             self._print_error_log(error, cmd)
@@ -410,9 +412,12 @@ class OpenBMCRest(object):
 
     def get_bmc_state(self):
 
-        state = self.request('GET', BMC_URLS['state']['path'], cmd='get_bmc_state')
         try:
+            state = self.request('GET', BMC_URLS['state']['path'], cmd='get_bmc_state')
             return {'bmc': state.split('.')[-1]}
+        except SelfClientException as e:
+            # Return error message received from the request
+            return {'bmc': "NotReady", 'error': e.message}
         except KeyError:
             error = 'Received wrong format response: %s' % state
             raise SelfServerException(error)

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -320,8 +320,6 @@ class OpenBMCRest(object):
                         'Validate BMC configuration and retry the command.'
             self._print_error_log(e.message, cmd)
             raise
-        except SelfClientException as e:
-            raise SelfClientException(e.message, e.code)
         except ValueError:
             error = 'Received wrong format response: %s' % response
             self._print_error_log(error, cmd)
@@ -415,9 +413,6 @@ class OpenBMCRest(object):
         try:
             state = self.request('GET', BMC_URLS['state']['path'], cmd='get_bmc_state')
             return {'bmc': state.split('.')[-1]}
-        except SelfClientException as e:
-            # Return error message received from the request
-            return {'bmc': "NotReady", 'error': e.message}
         except KeyError:
             error = 'Received wrong format response: %s' % state
             raise SelfServerException(error)


### PR DESCRIPTION
#4855 
Catch client exception from get state request and display error message as part of `rpower bmcstate` 

UT:
```
[root@boston02 xcat]# rpower mid08tor03cn01 bmcreboot
mid08tor03cn01: BMC reboot

[root@boston02 xcat]# while true; do  sleep 5; date; rpower mid08tor03cn01 bmcstate ; done
Wed Mar 21 14:51:19 EDT 2018
mid08tor03cn01: Error: Login to BMC failed: Can't connect to 172.21.226.1 (Connection reset by peer).
Wed Mar 21 14:51:26 EDT 2018
mid08tor03cn01: Error: Login to BMC failed: Can't connect to 172.21.226.1 (Connection reset by peer).
Wed Mar 21 14:51:32 EDT 2018
mid08tor03cn01: Error: Login to BMC failed: Can't connect to 172.21.226.1:443 (timeout).
Wed Mar 21 14:51:57 EDT 2018
mid08tor03cn01: Error: Login to BMC failed: Can't connect to 172.21.226.1 (Connection reset by peer).
Wed Mar 21 14:52:22 EDT 2018
mid08tor03cn01: Error: Login to BMC failed: Can't connect to 172.21.226.1 (Connection reset by peer).
Wed Mar 21 14:52:28 EDT 2018
mid08tor03cn01: Error: Login to BMC failed: Can't connect to 172.21.226.1 (Connection reset by peer).
Wed Mar 21 14:52:37 EDT 2018
mid08tor03cn01: Error: Login to BMC failed: Can't connect to 172.21.226.1 (Connection reset by peer).
Wed Mar 21 14:52:43 EDT 2018
mid08tor03cn01: Error: Login to BMC failed: Can't connect to 172.21.226.1:443 (timeout).
Wed Mar 21 14:53:09 EDT 2018
mid08tor03cn01: Error: Login to BMC failed: Can't connect to 172.21.226.1:443 (timeout).
Wed Mar 21 14:53:35 EDT 2018
mid08tor03cn01: BMC NotReady ([404] org.freedesktop.DBus.Error.FileNotFound: path or object not found: /xyz/openbmc_project/state/bmc0)
Wed Mar 21 14:53:56 EDT 2018
mid08tor03cn01: BMC NotReady ([404] org.freedesktop.DBus.Error.FileNotFound: path or object not found: /xyz/openbmc_project/state/bmc0)
Wed Mar 21 14:54:02 EDT 2018
mid08tor03cn01: BMC NotReady ([404] org.freedesktop.DBus.Error.FileNotFound: path or object not found: /xyz/openbmc_project/state/bmc0)
Wed Mar 21 14:54:08 EDT 2018
mid08tor03cn01: BMC NotReady
Wed Mar 21 14:54:15 EDT 2018
mid08tor03cn01: BMC NotReady
Wed Mar 21 14:54:24 EDT 2018
mid08tor03cn01: BMC NotReady
Wed Mar 21 14:54:32 EDT 2018
mid08tor03cn01: BMC NotReady
Wed Mar 21 14:54:38 EDT 2018
mid08tor03cn01: BMC Ready
```