### PR TITLE
fix error 4989: The error message of bmcdiscover is disordered

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -1053,7 +1053,7 @@ sub bmcdiscovery_ipmi {
     if ($output =~ $bmcstr) {
         store_fd({data=>1}, $fd);
 
-        if ($output =~ /RAKP 2 message indicates an error : (.+)\nError: (.+)/) {
+        if ($output =~ /RAKP \d+ message indicates an error : (.+)\nError: (.+)/) {
             xCAT::MsgUtils->message("W", { data => ["$2: $1 for $ip"] }, $::CALLBACK);
             return;
         }
@@ -1126,6 +1126,9 @@ sub bmcdiscovery_ipmi {
             return;
         } elsif ($output =~ /RAKP \S* \S* is invalid/) {
             xCAT::MsgUtils->message("W", { data => ["BMC password is incorrect for $ip"] }, $::CALLBACK);
+            return;
+        } else {
+            xCAT::MsgUtils->message("W", { data => ["Unknown error get from $ip"] }, $::CALLBACK);
             return;
         }
 


### PR DESCRIPTION
Fix issue #4989 

The root cause is failed to deal with this error message:
```
root@c910f03c05k10:~# bmcdiscover --range  10.4.30.254 -u USERID -p PASSW0RD -z
:
	objtype=node
	groups=all
	bmc=10.4.30.254
	cons=ipmi
	mgt=ipmi
```
With the fix, the output looks like:
```
root@c910f03c05k10:~# bmcdiscover --range  10.4.30.254 -u USERID -p PASSW0RD -z
Warning: Unable to establish IPMI v2 / RMCP+ session: insufficient resources for session for 10.4.30.254
```