### PR TITLE
fix rspconfig issues API related

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
@@ -375,11 +375,12 @@ rmdir \"/tmp/$userid\" \n")
         node = kw['node']
         obmc = openbmc.OpenBMCRest(name=node, nodeinfo=kw['nodeinfo'], messager=self.callback,
                                    debugmode=self.debugmode, verbose=self.verbose)
+
         try:
             obmc.login()
             obmc.set_apis_values(key, value)
         except (SelfServerException, SelfClientException) as e:
-            self.callback.error(e.message, node)
+            return self.callback.error(e.message, node)
 
         self.callback.info("%s: BMC Setting %s..." % (node, openbmc.RSPCONFIG_APIS[key]['display_name']))
 
@@ -392,9 +393,12 @@ rmdir \"/tmp/$userid\" \n")
             value = obmc.get_apis_values(key)
 
         except (SelfServerException, SelfClientException) as e:
-            self.callback.error(e.message, node)
+            return self.callback.error(e.message, node)
 
-        str_value = '0.'+str(value)
+        if isinstance(value, dict):
+            str_value = value.values()[0]
+        else:
+            str_value = value 
         result = '%s: %s: %s' % (node, openbmc.RSPCONFIG_APIS[key]['display_name'], str_value.split('.')[-1])
         self.callback.info(result)
 

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -185,13 +185,17 @@ RSPCONFIG_APIS = {
         'set_url': "attr/AutoReboot",
         'get_url': "attr/AutoReboot",
         'display_name': "BMC AutoReboot",
+        'attr_values': {
+            '0': False,
+            '1': True,
+         },
     },
     'powersupplyredundancy':{
         'baseurl': "/sensors/chassis/PowerSupplyRedundancy/",
-        'set_url': "/action/setValue",
-        'get_url': "/action/getValue",
+        'set_url': "action/setValue",
+        'get_url': "action/getValue",
         'get_method': 'POST',
-        'get_data': '[]',
+        'get_data': [],
         'display_name': "BMC PowerSupplyRedundancy",
         'attr_values': {
             'disabled': "Disables",
@@ -218,6 +222,16 @@ RSPCONFIG_APIS = {
             'regular': "xyz.openbmc_project.Control.Boot.Mode.Modes.Regular",
             'safe': "xyz.openbmc_project.Control.Boot.Mode.Modes.Safe",
             'setup': "xyz.openbmc_project.Control.Boot.Mode.Modes.Setup",
+        },
+    },
+    'timesyncmethod': {
+        'baseurl': '/time/sync_method',
+        'get_url': '',
+        'set_url': '/attr/TimeSyncMethod',
+        'display_name': 'BMC TimeSyncMethod',
+        'attr_values': {
+            'ntp': 'xyz.openbmc_project.Time.Synchronization.Method.NTP',
+            'manual': 'xyz.openbmc_project.Time.Synchronization.Method.Manual',
         },
     },
 }

--- a/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
+++ b/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
@@ -82,7 +82,7 @@ RFLASH_URLS = {
     }
 }
 
-RSPCONFIG_GET_OPTIONS = ['ip','ipsrc','netmask','gateway','vlan','ntpservers','hostname','bootmode','autoreboot','powersupplyredundancy','powerrestorepolicy']
+RSPCONFIG_GET_OPTIONS = ['ip','ipsrc','netmask','gateway','vlan','ntpservers','hostname','bootmode','autoreboot','powersupplyredundancy','powerrestorepolicy', 'timesyncmethod']
 RSPCONFIG_SET_OPTIONS = {
     'ip':'.*',
     'netmask':'.*',
@@ -95,6 +95,7 @@ RSPCONFIG_SET_OPTIONS = {
     'powerrestorepolicy':"^always_on$|^always_off$|^restore$",
     'bootmode':"^regular$|^safe$|^setup$",
     'admin_passwd':'.*,.*',
+    'timesyncmethod':'^ntp$|^manual$',
 }
 RSPCONFIG_USAGE = """
 Handle rspconfig operations.
@@ -124,6 +125,7 @@ The supported attributes and its values to set are:
    autoreboot={0|1}
    powersupplyredundancy={enabled|disabled}
    powerrestorepolicy={always_on|always_off|restore}
+   timesyncmethod={ntp|manual}
 """ % RSPCONFIG_GET_OPTIONS
 
 XCAT_LOG_DIR = "/var/log/xcat"

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1643,7 +1643,13 @@ sub parse_command_status {
                     # Everything else is invalid
                         xCAT::SvrUtils::sendmsg([1, "Invalid value '$subcommand_value' for '$subcommand_key'"], $callback);
                         my @valid_values = keys %{ $api_config_info{$::RSPCONFIG_CONFIGURED_API_KEY}{attr_value} };
-                        xCAT::SvrUtils::sendmsg([1, "Valid values: " . join(",", @valid_values)], $callback);
+                        if (!@valid_values) {
+                            if ($api_config_info{$::RSPCONFIG_CONFIGURED_API_KEY}{type} eq "boolean") {
+                                xCAT::SvrUtils::sendmsg([1, "Valid values: 0,1"], $callback);
+                            }
+                        } else {
+                            xCAT::SvrUtils::sendmsg([1, "Valid values: " . join(",", @valid_values)], $callback);
+                        }
                         return 1;
                 }
             }


### PR DESCRIPTION
#4982 
Before modified:
```
# rspconfig f6u03 autoreboot=2
Error: Invalid value '2' for 'autoreboot'
Error: Valid values:
```
After modified:
```
# rspconfig f6u03 autoreboot=2
Error: Invalid value '2' for 'autoreboot'
Error: Valid values: 0,1
```

#4983 
After modified:
```
# rspconfig f6u03 autoreboot=0
f6u03: BMC Setting BMC AutoReboot...
# rspconfig f6u03 autoreboot
f6u03: BMC AutoReboot: 0
```

#4984 
Support timesyncmethod:
```
# rspconfig f6u03 timesyncmethod
Thu Mar 22 03:07:12 2018 f6u03: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.3.100/login -d '{"data": ["root", "xxxxxx"]}'
Thu Mar 22 03:07:13 2018 f6u03: [openbmc_debug] login 200 OK
Thu Mar 22 03:07:13 2018 f6u03: [openbmc_debug] get_timesyncmethod curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://10.6.3.100/xyz/openbmc_project/time/sync_method
Thu Mar 22 03:07:13 2018 f6u03: [openbmc_debug] get_timesyncmethod 200 OK
f6u03: BMC TimeSyncMethod: NTP
```

#4985 
```
# rspconfig f6u03 powersupplyredundancy
Thu Mar 22 03:08:07 2018 f6u03: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.3.100/login -d '{"data": ["root", "xxxxxx"]}'
Thu Mar 22 03:08:07 2018 f6u03: [openbmc_debug] login 200 OK
Thu Mar 22 03:08:07 2018 f6u03: [openbmc_debug] get_powersupplyredundancy curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.3.100/xyz/openbmc_project/sensors/chassis/PowerSupplyRedundancy/action/getValue -d '{"data": []}'
Thu Mar 22 03:08:07 2018 f6u03: [openbmc_debug] get_powersupplyredundancy 200 OK
f6u03: BMC PowerSupplyRedundancy: Enabled
```