### PR TITLE
fix issue updatenode -P return nothing when xcatmaster not set

### DIFF
--- a/xCAT-server/lib/xcat/plugins/updatenode.pm
+++ b/xCAT-server/lib/xcat/plugins/updatenode.pm
@@ -309,7 +309,7 @@ sub preprocess_updatenode
 
     # get server names as known by the nodes
     my %servernodes =
-      %{ xCAT::InstUtils->get_server_nodes($callback, $request->{node}) };
+      %{ xCAT::InstUtils->get_server_nodes($callback, $request->{node},1) };
 
     # it's possible that the nodes could have diff server names
     # do all the nodes for a particular server at once
@@ -1555,7 +1555,7 @@ sub updatenoderunps
 
     # get server names as known by the nodes
     my %servernodes =
-      %{ xCAT::InstUtils->get_server_nodes($callback, \@$nodes,1) };
+      %{ xCAT::InstUtils->get_server_nodes($callback, \@$nodes) };
 
     # it's possible that the nodes could have diff server names
     # do all the nodes for a particular server at once


### PR DESCRIPTION
fix issue that updatenode -P return nothing when xcatmaster not set
UT:
```
[root@bybc0602 xCAT_plugin]# updatenode bybc0605 -P
bybc0605: trying to download postscripts...
bybc0605: postscripts downloaded successfully
bybc0605: trying to get mypostscript from 10.5.106.2...
bybc0605: Thu Mar 22 04:09:44 EDT 2018 Running postscript: syslog
bybc0605: postscript: syslog exited with code 0
bybc0605: Thu Mar 22 04:09:44 EDT 2018 Running postscript: remoteshell
bybc0605:
bybc0605: postscript: remoteshell exited with code 0
bybc0605: Thu Mar 22 04:09:46 EDT 2018 Running postscript: syncfiles
bybc0605: postscript: syncfiles exited with code 0
bybc0605: Thu Mar 22 04:09:46 EDT 2018 Running postscript: otherpkgs
bybc0605: ./otherpkgs: no extra rpms to install
bybc0605: postscript: otherpkgs exited with code 0
bybc0605: Running of postscripts has completed.
[root@bybc0602 xCAT_plugin]#
```