### PR TITLE
Better message for --recover option

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rflash.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rflash.1.rst
@@ -236,7 +236,7 @@ This delete option will delete update image from BMC. It expects an ID as the in
  
  OpenPOWER BMC specific (using IPMI):
  
- Used for IBM Power S822LC for Big Data systems only. Used to recover the BMC with a BMC image downloaded from FixCentral.
+ Used for IBM Power S822LC for Big Data systems only. Used to recover the BMC with a BMC image downloaded from FixCentral. This option will only work if BMC is in "Brick protection" state.
  
 
 

--- a/xCAT-client/pods/man1/rflash.1.pod
+++ b/xCAT-client/pods/man1/rflash.1.pod
@@ -173,7 +173,7 @@ Used to recover the flash image in the permanent side of the chip to the tempora
 
 OpenPOWER BMC specific (using IPMI):
 
-Used for IBM Power S822LC for Big Data systems only. Used to recover the BMC with a BMC image downloaded from FixCentral.
+Used for IBM Power S822LC for Big Data systems only. Used to recover the BMC with a BMC image downloaded from FixCentral. This option will only work if BMC is in "Brick protection" state.
 
 =item B<--retry=>I<count>
 

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -2518,6 +2518,10 @@ sub do_rflash_process {
             my $cmd = "/usr/bin/tftp $bmcip -m binary -c put $recover_image ".basename($recover_image);
             my $output = xCAT::Utils->runcmd($cmd, -1);
             if ($::RUNCMD_RC != 0) {
+                if ($output =~ "timed out") {
+                    # Time out running tftp command. One possible reason is BMC not in "brick protection" mode
+                    $output .= " BMC might not be in 'Brick protection' state";
+                }
                 $callback->({ error => "Running tftp command \'$cmd\' failed. Error Code: $::RUNCMD_RC. Output: $output.",
                         errorcode => 1 });
                 exit(1);


### PR DESCRIPTION
#3374 

When `rflash --recover` fails with `Transfer timed out`, display a better message for the user.

```
[root@briggs01 xcat]# rflash sn02 --recover ./typescript
Error: Running tftp command '/usr/bin/tftp 172.11.254.102 -m binary -c put /opt/xcat/./typescript typescript' failed. Error Code: 69. Output: Transfer timed out. BMC might not be in 'Brick protection' mode.
[root@briggs01 xcat]#
```