### PR TITLE
show error msg for rpower bmcstate when username is wrong

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_power.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_power.py
@@ -75,6 +75,9 @@ class OpenBMCPowerTask(ParallelNodesCommand):
             login_message = "Login to BMC failed: Can't connect to {0} {1}.".format(e.host_and_port, e.detail_msg)
             self.callback.error(login_message, node)
             return bmc_state
+        except SelfClientException as e:
+            self.callback.error(e.message, node)
+            return bmc_state
 
         try:
             state = obmc.get_bmc_state()


### PR DESCRIPTION
#4999 

```
# rpower f6u03 bmcstate
f6u03: Error: [401] Invalid username or password
```