### PR TITLE
Add a test case for rvitals outputs format checking

### DIFF
--- a/xCAT-test/autotest/testcase/rvitals/cases1
+++ b/xCAT-test/autotest/testcase/rvitals/cases1
@@ -1,0 +1,5 @@
+start:rvitals_outputs_format_checking
+description: Check the output formats of rvitals
+cmd:rvitals $$CN | grep -v -E '^[^:]+:[^:]+:[^:]+$'
+check:rc==1
+end


### PR DESCRIPTION
Make sure each line of the outputs of command `rvitals` matches regular expression `^[^:]+:[^:]+:[^:]+$`. Otherwise, this test case will fail.