### PR TITLE
add xcat-inventory passwd network route validation testcase

### DIFF
--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.network
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.network
@@ -4,32 +4,46 @@ cmd:lsdef -t network -o autotestnet > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsd
 check:rc==0
 cmd:mkdir -p /tmp/xcat_inventory_import_validation_network_bak
 check:rc==0
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "net" "200.0.0.0" "/tmp/xcat_inventory_import_validation_network"
+
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "basic_attr.net" "200.0.0.0" "/tmp/xcat_inventory_import_validation_network"
 check:rc==0
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "net" "234abc" "/tmp/xcat_inventory_import_validation_network"
+
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "basic_attr.net" "234abc" "/tmp/xcat_inventory_import_validation_network"
 check:rc!=0
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "net" "" "/tmp/xcat_inventory_import_validation_network"
+
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "basic_attr.net" "" "/tmp/xcat_inventory_import_validation_network"
 check:rc!=0
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "net" "234.abc.456.789" "/tmp/xcat_inventory_import_validation_network"
+
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "basic_attr.net" "234.abc.456.789" "/tmp/xcat_inventory_import_validation_network"
 check:rc!=0
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "mask" "234.abc.456.789" "/tmp/xcat_inventory_import_validation_network"
+
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "basic_attr.mask" "234.abc.456.789" "/tmp/xcat_inventory_import_validation_network"
 check:rc!=0
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "mask" "" "/tmp/xcat_inventory_import_validation_network"
+
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "basic_attr.mask" "" "/tmp/xcat_inventory_import_validation_network"
 check:rc!=0
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "mask" "234.0.0.0" "/tmp/xcat_inventory_import_validation_network"
+
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "basic_attr.mask" "234.0.0.0" "/tmp/xcat_inventory_import_validation_network"
 check:rc==0
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "dynamicrange" "200.0.0.100-200.0.0.200" "/tmp/xcat_inventory_import_validation_network"
+
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "pool.dynamicrange" "200.0.0.100-200.0.0.200" "/tmp/xcat_inventory_import_validation_network"
 check:rc==0
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "dynamicrange" "200.0.0.100" "/tmp/xcat_inventory_import_validation_network"
+
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "pool.dynamicrange" "200.0.0.100" "/tmp/xcat_inventory_import_validation_network"
 check:rc==0
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "dynamicrange" "abc-bcd" "/tmp/xcat_inventory_import_validation_network"
+
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "pool.dynamicrange" "abc-bcd" "/tmp/xcat_inventory_import_validation_network"
 check:rc!=0
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "staticrange" "200.0.0.100-200.0.0.200" "/tmp/xcat_inventory_import_validation_network"
+
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "pool.staticrange" "200.0.0.100-200.0.0.200" "/tmp/xcat_inventory_import_validation_network"
 check:rc==0
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "staticrange" "200.0.0.100" "/tmp/xcat_inventory_import_validation_network"
+
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "pool.staticrange" "200.0.0.100" "/tmp/xcat_inventory_import_validation_network"
 check:rc==0
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "staticrange" "abc-bcd" "/tmp/xcat_inventory_import_validation_network"
+
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "pool.staticrange" "abc-bcd" "/tmp/xcat_inventory_import_validation_network"
 check:rc!=0
+
 cmd:if [[ -e /tmp/xcat_inventory_import_validation_network_bak/autotestnet.stanza ]]; then cat /tmp/xcat_inventory_import_validation_network_bak/autotestnet.stanza | mkdef -z; fi
 check:rc==0
 cmd:rm -rf /tmp/xcat_inventory_import_validation_network_bak

--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.network
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.network
@@ -1,0 +1,37 @@
+start:xcat_inventory_import_validation_network
+description:This case is used to test network validation function of xcat-inventory import yaml and json file. To test "net" "mask" "dynamicrange" and "staticrange" attributes
+cmd:lsdef -t network -o autotestnet > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t network -o autotestnet -z >/tmp/xcat_inventory_import_validation_network_bak/autotestnet.stanza ;rmdef -t network -o autotestnet;fi
+check:rc==0
+cmd:mkdir -p /tmp/xcat_inventory_import_validation_network_bak
+check:rc==0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "net" "200.0.0.0" "/tmp/xcat_inventory_import_validation_network"
+check:rc==0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "net" "234abc" "/tmp/xcat_inventory_import_validation_network"
+check:rc!=0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "net" "" "/tmp/xcat_inventory_import_validation_network"
+check:rc!=0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "net" "234.abc.456.789" "/tmp/xcat_inventory_import_validation_network"
+check:rc!=0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "mask" "234.abc.456.789" "/tmp/xcat_inventory_import_validation_network"
+check:rc!=0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "mask" "" "/tmp/xcat_inventory_import_validation_network"
+check:rc!=0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "mask" "234.0.0.0" "/tmp/xcat_inventory_import_validation_network"
+check:rc==0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "dynamicrange" "200.0.0.100-200.0.0.200" "/tmp/xcat_inventory_import_validation_network"
+check:rc==0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "dynamicrange" "200.0.0.100" "/tmp/xcat_inventory_import_validation_network"
+check:rc==0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "dynamicrange" "abc-bcd" "/tmp/xcat_inventory_import_validation_network"
+check:rc!=0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "staticrange" "200.0.0.100-200.0.0.200" "/tmp/xcat_inventory_import_validation_network"
+check:rc==0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "staticrange" "200.0.0.100" "/tmp/xcat_inventory_import_validation_network"
+check:rc==0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "staticrange" "abc-bcd" "/tmp/xcat_inventory_import_validation_network"
+check:rc!=0
+cmd:if [[ -e /tmp/xcat_inventory_import_validation_network_bak/autotestnet.stanza ]]; then cat /tmp/xcat_inventory_import_validation_network_bak/autotestnet.stanza | mkdef -z; fi
+check:rc==0
+cmd:rm -rf /tmp/xcat_inventory_import_validation_network_bak
+check:rc==0
+end

--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.passwd
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.passwd
@@ -4,18 +4,25 @@ cmd:tabdump -w 'key==autotest' passwd |grep autotest > /dev/null 2>&1;if [[ $? -
 check:rc==0
 cmd:mkdir -p /tmp/xcat_inventory_import_validation_passwd_bak
 check:rc==0
+
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "passwd" "autotest" "cryptmethod" "" "/tmp/xcat_inventory_import_validation_passwd" 
 check:rc==0
+
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "passwd" "autotest" "cryptmethod" "md5" "/tmp/xcat_inventory_import_validation_passwd"
 check:rc==0
+
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "passwd" "autotest" "cryptmethod" "sha256" "/tmp/xcat_inventory_import_validation_passwd"
 check:rc==0
+
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "passwd" "autotest" "cryptmethod" "sha512" "/tmp/xcat_inventory_import_validation_passwd"
 check:rc==0
+
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "passwd" "autotest" "cryptmethod" "a.a" "/tmp/xcat_inventory_import_validation_passwd"
 check:rc!=0
+
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "passwd" "autotest" "cryptmethod" "MD5" "/tmp/xcat_inventory_import_validation_passwd"
 check:rc!=0
+
 cmd:if [[ -e /tmp/xcat_inventory_import_validation_passwd_bak/autotest ]]; then xcat-inventory import -f /tmp/xcat_inventory_import_validation_passwd_bak/autotest; fi
 check:rc==0
 cmd:rm -rf /tmp/xcat_inventory_import_validation_passwd_bak

--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.passwd
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.passwd
@@ -1,0 +1,23 @@
+start:xcat_inventory_import_validation_passwd
+description:This case is used to test passwd validation function of xcat-inventory import yaml and json file. To test "cryptmethod" attribute
+cmd:tabdump -w 'key==autotest' passwd |grep autotest > /dev/null 2>&1;if [[ $? -eq 0 ]]; then xcat-inventory export -t passwd -o autotest >/tmp/xcat_inventory_import_validation_passwd_bak/autotest ;tabch -d 'key==autotest' passwd;fi
+check:rc==0
+cmd:mkdir -p /tmp/xcat_inventory_import_validation_passwd_bak
+check:rc==0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "passwd" "autotest" "cryptmethod" "" "/tmp/xcat_inventory_import_validation_passwd" 
+check:rc==0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "passwd" "autotest" "cryptmethod" "md5" "/tmp/xcat_inventory_import_validation_passwd"
+check:rc==0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "passwd" "autotest" "cryptmethod" "sha256" "/tmp/xcat_inventory_import_validation_passwd"
+check:rc==0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "passwd" "autotest" "cryptmethod" "sha512" "/tmp/xcat_inventory_import_validation_passwd"
+check:rc==0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "passwd" "autotest" "cryptmethod" "a.a" "/tmp/xcat_inventory_import_validation_passwd"
+check:rc!=0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "passwd" "autotest" "cryptmethod" "MD5" "/tmp/xcat_inventory_import_validation_passwd"
+check:rc!=0
+cmd:if [[ -e /tmp/xcat_inventory_import_validation_passwd_bak/autotest ]]; then xcat-inventory import -f /tmp/xcat_inventory_import_validation_passwd_bak/autotest; fi
+check:rc==0
+cmd:rm -rf /tmp/xcat_inventory_import_validation_passwd_bak
+check:rc==0
+end

--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.route
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.route
@@ -1,0 +1,21 @@
+start:xcat_inventory_import_validation_route
+description:This case is used to test route validation function of xcat-inventory import yaml and json file. To test "net" and "mask" attributes
+cmd:mkdir -p /tmp/xcat_inventory_import_validation_route_bak
+check:rc==0
+cmd:lsdef -t route -o autotestnet > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t route -o autotestnet -z >/tmp/xcat_inventory_import_validation_route_bak/autotestnet.stanza ;rmdef -t route -o autotestnet;fi
+check:rc==0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "route" "autotestnet" "net" "200.0.0.0" "/tmp/xcat_inventory_import_validation_route" 
+check:rc==0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "route" "autotestnet" "net" "200.0" "/tmp/xcat_inventory_import_validation_route"
+check:rc!=0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "route" "autotestnet" "net" "" "/tmp/xcat_inventory_import_validation_route"
+check:rc!=0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "route" "autotestnet" "net" "default" "/tmp/xcat_inventory_import_validation_route"
+check:rc==0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "route" "autotestnet" "net" "abc.345.123.202" "/tmp/xcat_inventory_import_validation_route"
+check:rc!=0
+cmd:if [[ -e /tmp/xcat_inventory_import_validation_route_bak/autotestnet.stanza ]]; then cat /tmp/xcat_inventory_import_validation_route_bak/autotestnet.stanza | mkdef -z;fi
+check:rc==0
+cmd:rm -rf /tmp/xcat_inventory_import_validation_route_bak
+check:rc==0
+end

--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.route
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.route
@@ -4,16 +4,22 @@ cmd:mkdir -p /tmp/xcat_inventory_import_validation_route_bak
 check:rc==0
 cmd:lsdef -t route -o autotestnet > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t route -o autotestnet -z >/tmp/xcat_inventory_import_validation_route_bak/autotestnet.stanza ;rmdef -t route -o autotestnet;fi
 check:rc==0
+
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "route" "autotestnet" "net" "200.0.0.0" "/tmp/xcat_inventory_import_validation_route" 
 check:rc==0
+
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "route" "autotestnet" "net" "200.0" "/tmp/xcat_inventory_import_validation_route"
 check:rc!=0
+
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "route" "autotestnet" "net" "" "/tmp/xcat_inventory_import_validation_route"
 check:rc!=0
+
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "route" "autotestnet" "net" "default" "/tmp/xcat_inventory_import_validation_route"
 check:rc==0
+
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "route" "autotestnet" "net" "abc.345.123.202" "/tmp/xcat_inventory_import_validation_route"
 check:rc!=0
+
 cmd:if [[ -e /tmp/xcat_inventory_import_validation_route_bak/autotestnet.stanza ]]; then cat /tmp/xcat_inventory_import_validation_route_bak/autotestnet.stanza | mkdef -z;fi
 check:rc==0
 cmd:rm -rf /tmp/xcat_inventory_import_validation_route_bak

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/network.json
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/network.json
@@ -1,0 +1,16 @@
+{
+    "network": {
+        "autotestnet": {
+            "basic_attr": {
+                "gateway": "123.0.0.100",
+                "mask": "255.0.0.0",
+                "net": "123.0.0.0"
+            },
+            "pool": {
+                "dynamicrange": "123.0.0.100-123.0.0.200",
+                "staticrange": "123.0.0.201-123.0.0.222"
+            }
+        }
+    },
+    "schema_version": "1.0"
+}

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/network.yaml
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/network.yaml
@@ -1,0 +1,11 @@
+network:
+  autotestnet:
+    basic_attr:
+      gateway: 123.0.0.100
+      mask: 255.0.0.0
+      net: 123.0.0.0
+    pool:
+      dynamicrange: 123.0.0.100-123.0.0.200
+      staticrange: 123.0.0.201-123.0.0.222
+schema_version: '1.0'
+

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/passwd.json
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/passwd.json
@@ -1,0 +1,10 @@
+{
+    "passwd": {
+        "autotest": {
+            "cryptmethod": "md5",
+            "password": "cluster",
+            "username": "root"
+        }
+    },
+    "schema_version": "1.0"
+}

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/passwd.yaml
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/passwd.yaml
@@ -1,0 +1,7 @@
+passwd:
+  autotest:
+    cryptmethod: md5
+    password: cluster
+    username: root
+schema_version: '1.0'
+

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/route.json
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/route.json
@@ -1,0 +1,12 @@
+{
+    "route": {
+        "autotestnet": {
+            "gateway": "0.0.0.0",
+            "ifname": "eth1",
+            "mask": "255.0.0.0",
+            "net": "100.0.0.0",
+            "usercomment": "hello world"
+        }
+    },
+    "schema_version": "1.0"
+}

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/route.yaml
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/route.yaml
@@ -1,0 +1,9 @@
+route:
+  autotestnet:
+    gateway: 0.0.0.0
+    ifname: eth1
+    mask: 255.0.0.0
+    net: 100.0.0.0
+    usercomment: hello world
+schema_version: '1.0'
+


### PR DESCRIPTION
For 
https://github.com/xcat2/xcat2-task-management/issues/24

add xcat-inventory passwd network route validation testcase
UT:
```
xCAT automated test started at Fri Mar 23 05:08:09 2018
******************************
loading Configure file
******************************
OBJECT:bybc0609,TYPE:node
    profile = compute;
    arch = x86_64;
    os = rhels7.3;
TABLE:passwd
    key = system
    password = cluster
    username = root
Varible:
    CN = bybc0609
    THIRDNIC = eth3
    SECONDNIC = eth2
    KITDATA = kitdata
    NETBOOTDIR = /opt/xcat/share/xcat/netboot/rh
******************************
Initialize xCAT test environment by definition in configure file
******************************
chdef -t node -o bybc0609 profile=compute arch=x86_64 os=rhels7.3
chtab key=system passwd.password=cluster passwd.username=root
******************************
To detect current test environment
******************************
Detecting: OS = linux
Detecting: ARCH = x86
Detecting: HCP = kvm
******************************
loading test cases
******************************
To run:
xcat_inventory_import_validation_passwd
xcat_inventory_import_validation_network
xcat_inventory_import_validation_network
******************************
Start to run test cases
******************************
------START::xcat_inventory_import_validation_passwd::Time:Fri Mar 23 05:08:11 2018------

RUN:tabdump -w 'key==autotest' passwd |grep autotest > /dev/null 2>&1;if [[ $? -e
q 0 ]]; then xcat-inventory export -t passwd -o autotest >/tmp/xcat_inventory_imp
ort_validation_passwd_bak/autotest ;tabch -d 'key==autotest' passwd;fi [Fri Mar 2
3 05:08:11 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:mkdir -p /tmp/xcat_inventory_import_validation_passwd_bak [Fri Mar 23 05:08:1
1 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "p
asswd" "autotest" "cryptmethod" "" "/tmp/xcat_inventory_import_validation_passwd"
 [Fri Mar 23 05:08:11 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
objtype="passwd"
objname="autotest"
attribute="cryptmethod"
attrvalue=""
tmpdir="/tmp/xcat_inventory_import_validation_passwd"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_valida
tion_passwd
=================the inventory file to import: /tmp/xcat_inventory_import_validation_passwd/passwd.yaml=====================
passwd:
  autotest:
    password: cluster
    username: root
schema_version: '1.0'

==============================================================================
removing existing "passwd" type object "autotest" from xCAT
import the inventory file /tmp/xcat_inventory_import_validation_passwd/passwd.yaml
Importing object: autotest
Inventory import successfully!
the inventory file /tmp/xcat_inventory_import_validation_passwd/passwd.yaml imported successfully
export the "passwd" type object "autotest" just imported
the inventory data of the "passwd" type object "autotest" exported to /tmp/xcat_inventory_import_validation_passwd/passwd.out.yaml
==============the exported inventory file /tmp/xcat_inventory_import_validation_passwd/passwd.out.yaml======================
passwd:
  autotest:
    password: cluster
    username: root
schema_version: '1.0'

===========================================================================
make sure the attribute  cryptmethod is imported and exported successfully
yaml validation passed
removing existing "passwd" type object "autotest" from xCAT
=================the inventory file to import: /tmp/xcat_inventory_import_validation_passwd/passwd.json=====================
passwd:
  autotest:
    password: cluster
    username: root
schema_version: '1.0'

===========================================================================
make sure the attribute  cryptmethod is imported and exported successfully
yaml validation passed
removing existing "passwd" type object "autotest" from xCAT
=================the inventory file to import: /tmp/xcat_inventory_import_validation_passwd/passwd.json=====================
{
    "passwd": {
        "autotest": {
            "password": "cluster",
            "username": "root"
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_passwd/passwd.json
Importing object: autotest
Inventory import successfully!
the inventory data of the "passwd" type object "autotest" exported to /tmp/xcat_inventory_import_validation_passwd/passwd.out.json
{
    "passwd": {
        "autotest": {
            "password": "cluster",
            "username": "root"
        }
    },
    "schema_version": "1.0"
}
===========================================================================
make sure the attribute  cryptmethod is imported and exported successfully
json validation passed
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "p
asswd" "autotest" "cryptmethod" "md5" "/tmp/xcat_inventory_import_validation_pass
wd" [Fri Mar 23 05:08:13 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
objtype="passwd"
objname="autotest"
attribute="cryptmethod"
attrvalue="md5"
tmpdir="/tmp/xcat_inventory_import_validation_passwd"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_valida
tion_passwd
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_passwd/passwd.yaml=====================
passwd:
  autotest:
    cryptmethod: md5
    password: cluster
    username: root
schema_version: '1.0'

==============================================================================
removing existing "passwd" type object "autotest" from xCAT
import the inventory file /tmp/xcat_inventory_import_validation_passwd/passwd.yam
l
Importing object: autotest
Inventory import successfully!
the inventory file /tmp/xcat_inventory_import_validation_passwd/passwd.yaml impor
ted successfully
export the "passwd" type object "autotest" just imported
the inventory data of the "passwd" type object "autotest" exported to /tmp/xcat_i
nventory_import_validation_passwd/passwd.out.yaml
==============the exported inventory file /tmp/xcat_inventory_import_validation_p
asswd/passwd.out.yaml======================
passwd:
  autotest:
    cryptmethod: md5
    password: cluster
    username: root
schema_version: '1.0'

===========================================================================
make sure the attribute  cryptmethod is imported and exported successfully
yaml validation passed
removing existing "passwd" type object "autotest" from xCAT
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_passwd/passwd.json=====================
{
    "passwd": {
        "autotest": {
            "cryptmethod": "md5",
            "password": "cluster",
            "username": "root"
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_passwd/passwd.jso
n
Importing object: autotest
Inventory import successfully!
the inventory data of the "passwd" type object "autotest" exported to /tmp/xcat_i
nventory_import_validation_passwd/passwd.out.json
==============the exported inventory file /tmp/xcat_inventory_import_validation_p
asswd/passwd.out.json======================
{
    "passwd": {
        "autotest": {
            "cryptmethod": "md5",
            "password": "cluster",
            "username": "root"
        }
    },
    "schema_version": "1.0"
}
===========================================================================
make sure the attribute  cryptmethod is imported and exported successfully
json validation passed
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "p
asswd" "autotest" "cryptmethod" "sha256" "/tmp/xcat_inventory_import_validation_p
asswd" [Fri Mar 23 05:08:16 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
objtype="passwd"
objname="autotest"
attribute="cryptmethod"
attrvalue="sha256"
tmpdir="/tmp/xcat_inventory_import_validation_passwd"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_valida
tion_passwd
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_passwd/passwd.yaml=====================
passwd:
  autotest:
    cryptmethod: sha256
    password: cluster
    username: root
schema_version: '1.0'

==============================================================================
removing existing "passwd" type object "autotest" from xCAT
import the inventory file /tmp/xcat_inventory_import_validation_passwd/passwd.yam
l
Importing object: autotest
Inventory import successfully!
the inventory file /tmp/xcat_inventory_import_validation_passwd/passwd.yaml impor
ted successfully
export the "passwd" type object "autotest" just imported
the inventory data of the "passwd" type object "autotest" exported to /tmp/xcat_i
nventory_import_validation_passwd/passwd.out.yaml
==============the exported inventory file /tmp/xcat_inventory_import_validation_p
asswd/passwd.out.yaml======================
passwd:
  autotest:
    cryptmethod: sha256
    password: cluster
    username: root
schema_version: '1.0'
===========================================================================
make sure the attribute  cryptmethod is imported and exported successfully
yaml validation passed
removing existing "passwd" type object "autotest" from xCAT
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_passwd/passwd.json=====================
{
    "passwd": {
        "autotest": {
            "cryptmethod": "sha256",
            "password": "cluster",
            "username": "root"
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_passwd/passwd.jso
n
Importing object: autotest
Inventory import successfully!
the inventory data of the "passwd" type object "autotest" exported to /tmp/xcat_i
nventory_import_validation_passwd/passwd.out.json
==============the exported inventory file /tmp/xcat_inventory_import_validation_p
asswd/passwd.out.json======================
{
    "passwd": {
        "autotest": {
            "cryptmethod": "sha256",
            "password": "cluster",
            "username": "root"
        }
    },
    "schema_version": "1.0"
}
===========================================================================
make sure the attribute  cryptmethod is imported and exported successfully
json validation passed
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "p
asswd" "autotest" "cryptmethod" "sha512" "/tmp/xcat_inventory_import_validation_p
asswd" [Fri Mar 23 05:08:18 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
objtype="passwd"
objname="autotest"
attribute="cryptmethod"
attrvalue="sha512"
tmpdir="/tmp/xcat_inventory_import_validation_passwd"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_valida
tion_passwd
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_passwd/passwd.yaml=====================
passwd:
  autotest:
    cryptmethod: sha512
    password: cluster
    username: root
schema_version: '1.0'

==============================================================================
removing existing "passwd" type object "autotest" from xCAT
import the inventory file /tmp/xcat_inventory_import_validation_passwd/passwd.yam
l
Importing object: autotest
Inventory import successfully!
the inventory file /tmp/xcat_inventory_import_validation_passwd/passwd.yaml impor
ted successfully
export the "passwd" type object "autotest" just imported
the inventory data of the "passwd" type object "autotest" exported to /tmp/xcat_i
nventory_import_validation_passwd/passwd.out.yaml
==============the exported inventory file /tmp/xcat_inventory_import_validation_p
asswd/passwd.out.yaml======================
passwd:
  autotest:
    cryptmethod: sha512
    password: cluster
    username: root
schema_version: '1.0'

===========================================================================
make sure the attribute  cryptmethod is imported and exported successfully
yaml validation passed
removing existing "passwd" type object "autotest" from xCAT
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_passwd/passwd.json=====================
{
    "passwd": {
        "autotest": {
            "cryptmethod": "sha512",
            "password": "cluster",
            "username": "root"
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_passwd/passwd.jso
n
Importing object: autotest
Inventory import successfully!
the inventory data of the "passwd" type object "autotest" exported to /tmp/xcat_i
nventory_import_validation_passwd/passwd.out.json
==============the exported inventory file /tmp/xcat_inventory_import_validation_p
asswd/passwd.out.json======================
{
    "passwd": {
        "autotest": {
            "cryptmethod": "sha512",
            "password": "cluster",
            "username": "root"
        }
    },
    "schema_version": "1.0"
}
===========================================================================
make sure the attribute  cryptmethod is imported and exported successfully
json validation passed
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "p
asswd" "autotest" "cryptmethod" "a.a" "/tmp/xcat_inventory_import_validation_pass
wd" [Fri Mar 23 05:08:21 2018]
ElapsedTime:2 sec
RETURN rc = 1
OUTPUT:
objtype="passwd"
objname="autotest"
attribute="cryptmethod"
attrvalue="a.a"
tmpdir="/tmp/xcat_inventory_import_validation_passwd"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_valida
tion_passwd
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_passwd/passwd.yaml=====================
passwd:
  autotest:
    cryptmethod: a.a
    password: cluster
    username: root
schema_version: '1.0'

==============================================================================
removing existing "passwd" type object "autotest" from xCAT
import the inventory file /tmp/xcat_inventory_import_validation_passwd/passwd.yam
l
Error: failed to validate attribute [cryptmethod] of object "autotest", criteria:
 "option='a.a': True if str(option) in ('','md5','sha256','sha512') else False"
failed to import the inventory file /tmp/xcat_inventory_import_validation_passwd/
passwd.yaml
yaml validation failed
removing existing "passwd" type object "autotest" from xCAT
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_passwd/passwd.json=====================
{
    "passwd": {
        "autotest": {
            "cryptmethod": "a.a",
            "password": "cluster",
            "username": "root"
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_passwd/passwd.jso
n
Error: failed to validate attribute [cryptmethod] of object "autotest", criteria:
 "option='a.a': True if str(option) in ('','md5','sha256','sha512') else False"
failed to import the inventory file /tmp/xcat_inventory_import_validation_passwd/
passwd.json
json validation failed
CHECK:rc != 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "p
asswd" "autotest" "cryptmethod" "MD5" "/tmp/xcat_inventory_import_validation_pass
wd" [Fri Mar 23 05:08:23 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
objtype="passwd"
objname="autotest"
attribute="cryptmethod"
attrvalue="MD5"
tmpdir="/tmp/xcat_inventory_import_validation_passwd"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_valida
tion_passwd
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_passwd/passwd.yaml=====================
passwd:
  autotest:
    cryptmethod: MD5
    password: cluster
    username: root
schema_version: '1.0'

==============================================================================
removing existing "passwd" type object "autotest" from xCAT
import the inventory file /tmp/xcat_inventory_import_validation_passwd/passwd.yam
l
Error: failed to validate attribute [cryptmethod] of object "autotest", criteria:
 "option='MD5': True if str(option) in ('','md5','sha256','sha512') else False"
failed to import the inventory file /tmp/xcat_inventory_import_validation_passwd/
passwd.yaml
yaml validation failed
removing existing "passwd" type object "autotest" from xCAT
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_passwd/passwd.json=====================
{
    "passwd": {
        "autotest": {
            "cryptmethod": "MD5",
            "password": "cluster",
            "username": "root"
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_passwd/passwd.jso
n
Error: failed to validate attribute [cryptmethod] of object "autotest", criteria:
 "option='MD5': True if str(option) in ('','md5','sha256','sha512') else False"
failed to import the inventory file /tmp/xcat_inventory_import_validation_passwd/
passwd.json
json validation failed
CHECK:rc != 0	[Pass]

RUN:if [[ -e /tmp/xcat_inventory_import_validation_passwd_bak/autotest ]]; then x
cat-inventory import -f /tmp/xcat_inventory_import_validation_passwd_bak/autotest
; fi [Fri Mar 23 05:08:24 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:rm -rf /tmp/xcat_inventory_import_validation_passwd_bak [Fri Mar 23 05:08:24
2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::xcat_inventory_import_validation_passwd::Passed::Time:Fri Mar 23 05:08
:24 2018 ::Duration::13 sec------
------START::xcat_inventory_import_validation_network::Time:Fri Mar 23 05:08:24 2
018------

RUN:lsdef -t network -o autotestnet > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsde
f -t network -o autotestnet -z >/tmp/xcat_inventory_import_validation_network_bak
/autotestnet.stanza ;rmdef -t network -o autotestnet;fi [Fri Mar 23 05:08:24 2018
]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:mkdir -p /tmp/xcat_inventory_import_validation_network_bak [Fri Mar 23 05:08:
25 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "n
etwork" "autotestnet" "net" "200.0.0.0" "/tmp/xcat_inventory_import_validation_ne
twork" [Fri Mar 23 05:08:25 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
objtype="network"
objname="autotestnet"
attribute="net"
attrvalue="200.0.0.0"
tmpdir="/tmp/xcat_inventory_import_validation_network"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_valida
tion_network
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.yaml=====================
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 200.0.0.0
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'

==============================================================================
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
import the inventory file /tmp/xcat_inventory_import_validation_network/network.y
aml
Importing object: autotestnet
Inventory import successfully!
the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml imp
orted successfully
export the "network" type object "autotestnet" just imported
the inventory data of the "network" type object "autotestnet" exported to /tmp/xc
at_inventory_import_validation_network/network.out.yaml
==============the exported inventory file /tmp/xcat_inventory_import_validation_n
etwork/network.out.yaml======================
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 200.0.0.0
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'

===========================================================================
make sure the attribute  net is imported and exported successfully
yaml validation passed
removing existing "network" type object "autotestnet" from xCAT
1 object definitions have been removed.
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.json=====================
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "200.0.0.0"
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_network/network.j
son
Importing object: autotestnet
Inventory import successfully!
the inventory data of the "network" type object "autotestnet" exported to /tmp/xc
at_inventory_import_validation_network/network.out.json
==============the exported inventory file /tmp/xcat_inventory_import_validation_n
etwork/network.out.json======================
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "200.0.0.0"
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
===========================================================================
make sure the attribute  net is imported and exported successfully
json validation passed
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "n
etwork" "autotestnet" "net" "234abc" "/tmp/xcat_inventory_import_validation_netwo
rk" [Fri Mar 23 05:08:28 2018]
ElapsedTime:2 sec
RETURN rc = 1
OUTPUT:
objtype="network"
objname="autotestnet"
attribute="net"
attrvalue="234abc"
tmpdir="/tmp/xcat_inventory_import_validation_network"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_valida
tion_network
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.yaml=====================
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 234abc
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'

==============================================================================
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
import the inventory file /tmp/xcat_inventory_import_validation_network/network.y
aml
Error: failed to validate attribute [basic_attr.net] of object "autotestnet", cri
teria: "value='234abc': vutil.isIPaddr(value)"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network
/network.yaml
yaml validation failed
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.json=====================
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "234abc"
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_network/network.j
son
Error: failed to validate attribute [basic_attr.net] of object "autotestnet", cri
teria: "value='234abc': vutil.isIPaddr(value)"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network
/network.json
json validation failed
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
CHECK:rc != 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "n
etwork" "autotestnet" "net" "" "/tmp/xcat_inventory_import_validation_network" [F
ri Mar 23 05:08:30 2018]
ElapsedTime:2 sec
RETURN rc = 1
OUTPUT:
objtype="network"
objname="autotestnet"
attribute="net"
attrvalue=""
tmpdir="/tmp/xcat_inventory_import_validation_network"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_valida
tion_network
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.yaml=====================
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'

==============================================================================
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
import the inventory file /tmp/xcat_inventory_import_validation_network/network.y
aml
Error: failed to validate attribute [basic_attr.net] of object "autotestnet", cri
teria: "value='': vutil.isIPaddr(value)"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network
/network.yaml
yaml validation failed
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.json=====================
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_network/network.j
son
Error: failed to validate attribute [basic_attr.net] of object "autotestnet", cri
teria: "value='': vutil.isIPaddr(value)"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network
/network.json
json validation failed
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
CHECK:rc != 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "n
etwork" "autotestnet" "net" "234.abc.456.789" "/tmp/xcat_inventory_import_validat
ion_network" [Fri Mar 23 05:08:32 2018]
ElapsedTime:2 sec
RETURN rc = 1
OUTPUT:
objtype="network"
objname="autotestnet"
attribute="net"
attrvalue="234.abc.456.789"
tmpdir="/tmp/xcat_inventory_import_validation_network"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_valida
tion_network
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.yaml=====================
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 234.abc.456.789
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'

==============================================================================
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
import the inventory file /tmp/xcat_inventory_import_validation_network/network.y
aml
Error: failed to validate attribute [basic_attr.net] of object "autotestnet", cri
teria: "value='234.abc.456.789': vutil.isIPaddr(value)"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network
/network.yaml
yaml validation failed
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.json=====================
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "234.abc.456.789"
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_network/network.j
son
Error: failed to validate attribute [basic_attr.net] of object "autotestnet", cri
teria: "value='234.abc.456.789': vutil.isIPaddr(value)"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network
/network.json
json validation failed
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
CHECK:rc != 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "n
etwork" "autotestnet" "mask" "234.abc.456.789" "/tmp/xcat_inventory_import_valida
tion_network" [Fri Mar 23 05:08:34 2018]
ElapsedTime:2 sec
RETURN rc = 1
OUTPUT:
objtype="network"
objname="autotestnet"
attribute="mask"
attrvalue="234.abc.456.789"
tmpdir="/tmp/xcat_inventory_import_validation_network"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_valida
tion_network
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.yaml=====================
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 234.abc.456.789
      net: 123.0.0.0
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'

==============================================================================
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
import the inventory file /tmp/xcat_inventory_import_validation_network/network.y
aml
Error: failed to validate attribute [basic_attr.mask] of object "autotestnet", cr
iteria: "value='234.abc.456.789': vutil.isIPaddr(value)"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network
/network.yaml
yaml validation failed
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.json=====================
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "234.abc.456.789",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_network/network.j
son
Error: failed to validate attribute [basic_attr.mask] of object "autotestnet", cr
iteria: "value='234.abc.456.789': vutil.isIPaddr(value)"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network
/network.json
json validation failed
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
CHECK:rc != 0	[Pass]
RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "n
etwork" "autotestnet" "mask" "" "/tmp/xcat_inventory_import_validation_network" [
Fri Mar 23 05:08:36 2018]
ElapsedTime:2 sec
RETURN rc = 1
OUTPUT:
objtype="network"
objname="autotestnet"
attribute="mask"
attrvalue=""
tmpdir="/tmp/xcat_inventory_import_validation_network"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_valida
tion_network
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.yaml=====================
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      net: 123.0.0.0
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'
==============================================================================
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
import the inventory file /tmp/xcat_inventory_import_validation_network/network.y
aml
Error: failed to validate attribute [basic_attr.mask] of object "autotestnet", cr
iteria: "value='': vutil.isIPaddr(value)"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network
/network.yaml
yaml validation failed
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.json=====================
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_network/network.j
son
Error: failed to validate attribute [basic_attr.mask] of object "autotestnet", cr
iteria: "value='': vutil.isIPaddr(value)"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network
/network.json
json validation failed
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
CHECK:rc != 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "n
etwork" "autotestnet" "mask" "234.0.0.0" "/tmp/xcat_inventory_import_validation_n
etwork" [Fri Mar 23 05:08:38 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
objtype="network"
objname="autotestnet"
attribute="mask"
attrvalue="234.0.0.0"
tmpdir="/tmp/xcat_inventory_import_validation_network"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_valida
tion_network
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.yaml=====================
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 234.0.0.0
      net: 123.0.0.0
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'

==============================================================================
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
import the inventory file /tmp/xcat_inventory_import_validation_network/network.y
aml
Importing object: autotestnet
Inventory import successfully!
the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml imp
orted successfully
export the "network" type object "autotestnet" just imported
the inventory data of the "network" type object "autotestnet" exported to /tmp/xc
at_inventory_import_validation_network/network.out.yaml
==============the exported inventory file /tmp/xcat_inventory_import_validation_n
etwork/network.out.yaml======================
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 234.0.0.0
      net: 123.0.0.0
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'

===========================================================================
make sure the attribute  mask is imported and exported successfully
yaml validation passed
removing existing "network" type object "autotestnet" from xCAT
1 object definitions have been removed.
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.json=====================
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "234.0.0.0",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_network/network.j
son
Importing object: autotestnet
Inventory import successfully!
the inventory data of the "network" type object "autotestnet" exported to /tmp/xc
at_inventory_import_validation_network/network.out.json
==============the exported inventory file /tmp/xcat_inventory_import_validation_n
etwork/network.out.json======================
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "234.0.0.0",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
===========================================================================
make sure the attribute  mask is imported and exported successfully
json validation passed
1 object definitions have been removed.
CHECK:rc == 0	[Pass]
RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "n
etwork" "autotestnet" "dynamicrange" "200.0.0.100-200.0.0.200" "/tmp/xcat_invento
ry_import_validation_network" [Fri Mar 23 05:08:41 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
objtype="network"
objname="autotestnet"
attribute="dynamicrange"
attrvalue="200.0.0.100-200.0.0.200"
tmpdir="/tmp/xcat_inventory_import_validation_network"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_valida
tion_network
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.yaml=====================
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 123.0.0.0
    pool:
      dynamicrange: 200.0.0.100-200.0.0.200
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'
==============================================================================
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
import the inventory file /tmp/xcat_inventory_import_validation_network/network.y
aml
Importing object: autotestnet
Inventory import successfully!
the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml imp
orted successfully
export the "network" type object "autotestnet" just imported
the inventory data of the "network" type object "autotestnet" exported to /tmp/xc
at_inventory_import_validation_network/network.out.yaml
==============the exported inventory file /tmp/xcat_inventory_import_validation_n
etwork/network.out.yaml======================
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 123.0.0.0
    pool:
      dynamicrange: 200.0.0.100-200.0.0.200
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'
===========================================================================
make sure the attribute  dynamicrange is imported and exported successfully
yaml validation passed
removing existing "network" type object "autotestnet" from xCAT
1 object definitions have been removed.
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.json=====================
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "200.0.0.100-200.0.0.200",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_network/network.j
son
Importing object: autotestnet
Inventory import successfully!
the inventory data of the "network" type object "autotestnet" exported to /tmp/xc
at_inventory_import_validation_network/network.out.json
==============the exported inventory file /tmp/xcat_inventory_import_validation_n
etwork/network.out.json======================
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "200.0.0.100-200.0.0.200",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
===========================================================================
make sure the attribute  dynamicrange is imported and exported successfully
json validation passed
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "n
etwork" "autotestnet" "dynamicrange" "200.0.0.100" "/tmp/xcat_inventory_import_va
lidation_network" [Fri Mar 23 05:08:44 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
objtype="network"
objname="autotestnet"
attribute="dynamicrange"
attrvalue="200.0.0.100"
tmpdir="/tmp/xcat_inventory_import_validation_network"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_valida
tion_network
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.yaml=====================
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 123.0.0.0
    pool:
      dynamicrange: 200.0.0.100
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'
==============================================================================
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
import the inventory file /tmp/xcat_inventory_import_validation_network/network.y
aml
Importing object: autotestnet
Inventory import successfully!
the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml imp
orted successfully
export the "network" type object "autotestnet" just imported
the inventory data of the "network" type object "autotestnet" exported to /tmp/xc
at_inventory_import_validation_network/network.out.yaml
==============the exported inventory file /tmp/xcat_inventory_import_validation_n
etwork/network.out.yaml======================
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 123.0.0.0
    pool:
      dynamicrange: 200.0.0.100
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'
===========================================================================
make sure the attribute  dynamicrange is imported and exported successfully
yaml validation passed
removing existing "network" type object "autotestnet" from xCAT
1 object definitions have been removed.
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.json=====================
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "200.0.0.100",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_network/network.j
son
Importing object: autotestnet
Inventory import successfully!
the inventory data of the "network" type object "autotestnet" exported to /tmp/xc
at_inventory_import_validation_network/network.out.json
==============the exported inventory file /tmp/xcat_inventory_import_validation_n
etwork/network.out.json======================
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "200.0.0.100",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
===========================================================================
make sure the attribute  dynamicrange is imported and exported successfully
json validation passed
1 object definitions have been removed.
CHECK:rc == 0	[Pass]
RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "n
etwork" "autotestnet" "dynamicrange" "abc-bcd" "/tmp/xcat_inventory_import_valida
tion_network" [Fri Mar 23 05:08:47 2018]
ElapsedTime:2 sec
RETURN rc = 1
OUTPUT:
objtype="network"
objname="autotestnet"
attribute="dynamicrange"
attrvalue="abc-bcd"
tmpdir="/tmp/xcat_inventory_import_validation_network"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_valida
tion_network
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.yaml=====================
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 123.0.0.0
    pool:
      dynamicrange: abc-bcd
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'
==============================================================================
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
import the inventory file /tmp/xcat_inventory_import_validation_network/network.y
aml
Error: failed to validate attribute [pool.dynamicrange] of object "autotestnet",
criteria: " value='abc-bcd': True if str(value) in ('') or vutil.isIPaddr(value)
or vutil.isIPrange(value) else False"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network
/network.yaml
yaml validation failed
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.json=====================
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "abc-bcd",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_network/network.j
son
Error: failed to validate attribute [pool.dynamicrange] of object "autotestnet",
criteria: " value='abc-bcd': True if str(value) in ('') or vutil.isIPaddr(value)
or vutil.isIPrange(value) else False"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network
/network.json
json validation failed
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
CHECK:rc != 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "n
etwork" "autotestnet" "staticrange" "200.0.0.100-200.0.0.200" "/tmp/xcat_inventor
y_import_validation_network" [Fri Mar 23 05:08:49 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
objtype="network"
objname="autotestnet"
attribute="staticrange"
attrvalue="200.0.0.100-200.0.0.200"
tmpdir="/tmp/xcat_inventory_import_validation_network"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_valida
tion_network
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.yaml=====================
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 123.0.0.0
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: 200.0.0.100-200.0.0.200
schema_version: '1.0'

==============================================================================
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
import the inventory file /tmp/xcat_inventory_import_validation_network/network.y
aml
Importing object: autotestnet
Inventory import successfully!
the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml imp
orted successfully
export the "network" type object "autotestnet" just imported
the inventory data of the "network" type object "autotestnet" exported to /tmp/xc
at_inventory_import_validation_network/network.out.yaml
==============the exported inventory file /tmp/xcat_inventory_import_validation_n
etwork/network.out.yaml======================
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 123.0.0.0
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: 200.0.0.100-200.0.0.200
schema_version: '1.0'

===========================================================================
make sure the attribute  staticrange is imported and exported successfully
yaml validation passed
removing existing "network" type object "autotestnet" from xCAT
1 object definitions have been removed.
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.json=====================
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "200.0.0.100-200.0.0.200"
            }
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_network/network.j
son
Importing object: autotestnet
Inventory import successfully!
the inventory data of the "network" type object "autotestnet" exported to /tmp/xc
at_inventory_import_validation_network/network.out.json
==============the exported inventory file /tmp/xcat_inventory_import_validation_n
etwork/network.out.json======================
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "200.0.0.100-200.0.0.200"
            }
        }
    },
    "schema_version": "1.0"
}
===========================================================================
make sure the attribute  staticrange is imported and exported successfully
json validation passed
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "n
etwork" "autotestnet" "staticrange" "200.0.0.100" "/tmp/xcat_inventory_import_val
idation_network" [Fri Mar 23 05:08:52 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
objtype="network"
objname="autotestnet"
attribute="staticrange"
attrvalue="200.0.0.100"
tmpdir="/tmp/xcat_inventory_import_validation_network"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_valida
tion_network
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.yaml=====================
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 123.0.0.0
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: 200.0.0.100
schema_version: '1.0'

==============================================================================
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
import the inventory file /tmp/xcat_inventory_import_validation_network/network.y
aml
Importing object: autotestnet
Inventory import successfully!
the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml imp
orted successfully
export the "network" type object "autotestnet" just imported
the inventory data of the "network" type object "autotestnet" exported to /tmp/xc
at_inventory_import_validation_network/network.out.yaml
==============the exported inventory file /tmp/xcat_inventory_import_validation_n
etwork/network.out.yaml======================
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 123.0.0.0
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: 200.0.0.100
schema_version: '1.0'

===========================================================================
make sure the attribute  staticrange is imported and exported successfully
yaml validation passed
removing existing "network" type object "autotestnet" from xCAT
1 object definitions have been removed.
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.json=====================
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "200.0.0.100"
            }
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_network/network.j
son
Importing object: autotestnet
Inventory import successfully!
the inventory data of the "network" type object "autotestnet" exported to /tmp/xc
at_inventory_import_validation_network/network.out.json
==============the exported inventory file /tmp/xcat_inventory_import_validation_n
etwork/network.out.json======================
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "200.0.0.100"
            }
        }
    },
    "schema_version": "1.0"
}
===========================================================================
make sure the attribute  staticrange is imported and exported successfully
json validation passed
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "n
etwork" "autotestnet" "staticrange" "abc-bcd" "/tmp/xcat_inventory_import_validat
ion_network" [Fri Mar 23 05:08:55 2018]
ElapsedTime:2 sec
RETURN rc = 1
OUTPUT:
objtype="network"
objname="autotestnet"
attribute="staticrange"
attrvalue="abc-bcd"
tmpdir="/tmp/xcat_inventory_import_validation_network"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_valida
tion_network
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.yaml=====================
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 123.0.0.0
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: abc-bcd
schema_version: '1.0'

==============================================================================
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
import the inventory file /tmp/xcat_inventory_import_validation_network/network.y
aml
Error: failed to validate attribute [pool.staticrange] of object "autotestnet", c
riteria: " value='abc-bcd': True if str(value) in ('') or vutil.isIPrange(value)
or vutil.isIPaddr(value) else False"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network
/network.yaml
yaml validation failed
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.json=====================
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "abc-bcd"
            }
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_network/network.j
son
Error: failed to validate attribute [pool.staticrange] of object "autotestnet", c
riteria: " value='abc-bcd': True if str(value) in ('') or vutil.isIPrange(value)
or vutil.isIPaddr(value) else False"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network
/network.json
json validation failed
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
CHECK:rc != 0	[Pass]

RUN:if [[ -e /tmp/xcat_inventory_import_validation_network_bak/autotestnet.stanza
 ]]; then cat /tmp/xcat_inventory_import_validation_network_bak/autotestnet.stanz
a | mkdef -z; fi [Fri Mar 23 05:08:57 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:rm -rf /tmp/xcat_inventory_import_validation_network_bak [Fri Mar 23 05:08:57
 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]
------END::xcat_inventory_import_validation_network::Passed::Time:Fri Mar 23 05:0
8:57 2018 ::Duration::33 sec------
------START::xcat_inventory_import_validation_network::Time:Fri Mar 23 05:08:57 2
018------

RUN:lsdef -t network -o autotestnet > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsde
f -t network -o autotestnet -z >/tmp/xcat_inventory_import_validation_network_bak
/autotestnet.stanza ;rmdef -t network -o autotestnet;fi [Fri Mar 23 05:08:57 2018
]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:mkdir -p /tmp/xcat_inventory_import_validation_network_bak [Fri Mar 23 05:08:
57 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "n
etwork" "autotestnet" "net" "200.0.0.0" "/tmp/xcat_inventory_import_validation_ne
twork" [Fri Mar 23 05:08:57 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
objtype="network"
objname="autotestnet"
attribute="net"
attrvalue="200.0.0.0"
tmpdir="/tmp/xcat_inventory_import_validation_network"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_valida
tion_network
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.yaml=====================
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 200.0.0.0
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'

==============================================================================
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
import the inventory file /tmp/xcat_inventory_import_validation_network/network.y
aml
Importing object: autotestnet
Inventory import successfully!
the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml imp
orted successfully
export the "network" type object "autotestnet" just imported
the inventory data of the "network" type object "autotestnet" exported to /tmp/xc
at_inventory_import_validation_network/network.out.yaml
==============the exported inventory file /tmp/xcat_inventory_import_validation_n
etwork/network.out.yaml======================
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 200.0.0.0
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'

===========================================================================
make sure the attribute  net is imported and exported successfully
yaml validation passed
removing existing "network" type object "autotestnet" from xCAT
1 object definitions have been removed.
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.json=====================
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "200.0.0.0"
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_network/network.j
son
Importing object: autotestnet
Inventory import successfully!
the inventory data of the "network" type object "autotestnet" exported to /tmp/xc
at_inventory_import_validation_network/network.out.json
==============the exported inventory file /tmp/xcat_inventory_import_validation_n
etwork/network.out.json======================
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "200.0.0.0"
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
===========================================================================
make sure the attribute  net is imported and exported successfully
json validation passed
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "n
etwork" "autotestnet" "net" "234abc" "/tmp/xcat_inventory_import_validation_netwo
rk" [Fri Mar 23 05:09:00 2018]
ElapsedTime:3 sec
RETURN rc = 1
OUTPUT:
objtype="network"
objname="autotestnet"
attribute="net"
attrvalue="234abc"
tmpdir="/tmp/xcat_inventory_import_validation_network"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_valida
tion_network
=================the inventory file to import: /tmp/xcat_inventory_import_validat
ion_network/network.yaml=====================
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 234abc
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'

==============================================================================
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
import the inventory file /tmp/xcat_inventory_import_validation_network/network.y
aml
Error: failed to validate attribute [basic_attr.net] of object "autotestnet", cri
teria: "value='234abc': vutil.isIPaddr(value)"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml
yaml validation failed
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
=================the inventory file to import: /tmp/xcat_inventory_import_validation_network/network.json========
=============
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "234abc"
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_network/network.json
Error: failed to validate attribute [basic_attr.net] of object "autotestnet", criteria: "value='234abc': vutil.is
IPaddr(value)"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network/network.json
json validation failed
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
CHECK:rc != 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "net" "" "
/tmp/xcat_inventory_import_validation_network" [Fri Mar 23 05:09:03 2018]
ElapsedTime:2 sec
RETURN rc = 1
OUTPUT:
objtype="network"
objname="autotestnet"
attribute="net"
attrvalue=""
tmpdir="/tmp/xcat_inventory_import_validation_network"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_validation_network
=================the inventory file to import: /tmp/xcat_inventory_import_validation_network/network.yaml========
=============
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'

==============================================================================
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
import the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml
Error: failed to validate attribute [basic_attr.net] of object "autotestnet", criteria: "value='': vutil.isIPaddr
(value)"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml
yaml validation failed
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
=================the inventory file to import: /tmp/xcat_inventory_import_validation_network/network.json========
=============
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_network/network.json
Error: failed to validate attribute [basic_attr.net] of object "autotestnet", criteria: "value='': vutil.isIPaddr
(value)"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network/network.json
json validation failed
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
CHECK:rc != 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "net" "234
.abc.456.789" "/tmp/xcat_inventory_import_validation_network" [Fri Mar 23 05:09:05 2018]
ElapsedTime:2 sec
RETURN rc = 1
OUTPUT:
objtype="network"
objname="autotestnet"
attribute="net"
attrvalue="234.abc.456.789"
tmpdir="/tmp/xcat_inventory_import_validation_network"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_validation_network
=================the inventory file to import: /tmp/xcat_inventory_import_validation_network/network.yaml========
=============
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 234.abc.456.789
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'

==============================================================================
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
import the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml
Error: failed to validate attribute [basic_attr.net] of object "autotestnet", criteria: "value='234.abc.456.789':
 vutil.isIPaddr(value)"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml
yaml validation failed
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
=================the inventory file to import: /tmp/xcat_inventory_import_validation_network/network.json========
=============
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "234.abc.456.789"
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_network/network.json
Error: failed to validate attribute [basic_attr.net] of object "autotestnet", criteria: "value='234.abc.456.789':
 vutil.isIPaddr(value)"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network/network.json
json validation failed
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
CHECK:rc != 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "mask" "23
4.abc.456.789" "/tmp/xcat_inventory_import_validation_network" [Fri Mar 23 05:09:07 2018]
ElapsedTime:2 sec
RETURN rc = 1
OUTPUT:
objtype="network"
objname="autotestnet"
attribute="mask"
attrvalue="234.abc.456.789"
tmpdir="/tmp/xcat_inventory_import_validation_network"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_validation_network
=================the inventory file to import: /tmp/xcat_inventory_import_validation_network/network.yaml========
=============
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 234.abc.456.789
      net: 123.0.0.0
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'

==============================================================================
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
import the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml
Error: failed to validate attribute [basic_attr.mask] of object "autotestnet", criteria: "value='234.abc.456.789'
failed to import the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml
yaml validation failed
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
=================the inventory file to import: /tmp/xcat_inventory_import_validation_network/network.json========
=============
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "234.abc.456.789",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_network/network.json
Error: failed to validate attribute [basic_attr.mask] of object "autotestnet", criteria: "value='234.abc.456.789'
: vutil.isIPaddr(value)"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network/network.json
json validation failed
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
CHECK:rc != 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "mask" ""
"/tmp/xcat_inventory_import_validation_network" [Fri Mar 23 05:09:09 2018]
ElapsedTime:2 sec
RETURN rc = 1
OUTPUT:
objtype="network"
objname="autotestnet"
attribute="mask"
attrvalue=""
tmpdir="/tmp/xcat_inventory_import_validation_network"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_validation_network
=================the inventory file to import: /tmp/xcat_inventory_import_validation_network/network.yaml========
=============
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      net: 123.0.0.0
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'

==============================================================================
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
import the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml
Error: failed to validate attribute [basic_attr.mask] of object "autotestnet", criteria: "value='': vutil.isIPadd
r(value)"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml
yaml validation failed
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
=================the inventory file to import: /tmp/xcat_inventory_import_validation_network/network.json========
=============
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_network/network.json
Error: failed to validate attribute [basic_attr.mask] of object "autotestnet", criteria: "value='': vutil.isIPadd
r(value)"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network/network.json
json validation failed
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
CHECK:rc != 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "mask" "23
4.0.0.0" "/tmp/xcat_inventory_import_validation_network" [Fri Mar 23 05:09:11 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
objtype="network"
objname="autotestnet"
attribute="mask"
attrvalue="234.0.0.0"
tmpdir="/tmp/xcat_inventory_import_validation_network"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_validation_network
=================the inventory file to import: /tmp/xcat_inventory_import_validation_network/network.yaml========
=============
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 234.0.0.0
      net: 123.0.0.0
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'

==============================================================================
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
import the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml
Importing object: autotestnet
Inventory import successfully!
the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml imported successfully
export the "network" type object "autotestnet" just imported
the inventory data of the "network" type object "autotestnet" exported to /tmp/xcat_inventory_import_validation_n
etwork/network.out.yaml
==============the exported inventory file /tmp/xcat_inventory_import_validation_network/network.out.yaml=========
=============
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 234.0.0.0
      net: 123.0.0.0
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'

===========================================================================
make sure the attribute  mask is imported and exported successfully
yaml validation passed
removing existing "network" type object "autotestnet" from xCAT
1 object definitions have been removed.
=================the inventory file to import: /tmp/xcat_inventory_import_validation_network/network.json========
=============
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "234.0.0.0",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_network/network.json
Importing object: autotestnet
Inventory import successfully!
the inventory data of the "network" type object "autotestnet" exported to /tmp/xcat_inventory_import_validation_n
etwork/network.out.json
==============the exported inventory file /tmp/xcat_inventory_import_validation_network/network.out.json=========
=============
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "234.0.0.0",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
===========================================================================
make sure the attribute  mask is imported and exported successfully
json validation passed
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "dynamicra
nge" "200.0.0.100-200.0.0.200" "/tmp/xcat_inventory_import_validation_network" [Fri Mar 23 05:09:14 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
objtype="network"
objname="autotestnet"
attribute="dynamicrange"
attrvalue="200.0.0.100-200.0.0.200"
tmpdir="/tmp/xcat_inventory_import_validation_network"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_validation_network
=================the inventory file to import: /tmp/xcat_inventory_import_validation_network/network.yaml========
=============
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 123.0.0.0
    pool:
      dynamicrange: 200.0.0.100-200.0.0.200
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'

==============================================================================
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
import the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml
Importing object: autotestnet
Inventory import successfully!
the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml imported successfully
export the "network" type object "autotestnet" just imported
the inventory data of the "network" type object "autotestnet" exported to /tmp/xcat_inventory_import_validation_n
etwork/network.out.yaml
==============the exported inventory file /tmp/xcat_inventory_import_validation_network/network.out.yaml=========
=============
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 123.0.0.0
    pool:
      dynamicrange: 200.0.0.100-200.0.0.200
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'
===========================================================================
make sure the attribute  dynamicrange is imported and exported successfully
yaml validation passed
removing existing "network" type object "autotestnet" from xCAT
1 object definitions have been removed.
=================the inventory file to import: /tmp/xcat_inventory_import_validation_network/network.json========
=============
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "200.0.0.100-200.0.0.200",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_network/network.json
Importing object: autotestnet
Inventory import successfully!
the inventory data of the "network" type object "autotestnet" exported to /tmp/xcat_inventory_import_validation_n
etwork/network.out.json
==============the exported inventory file /tmp/xcat_inventory_import_validation_network/network.out.json=========
=============
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "200.0.0.100-200.0.0.200",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
===========================================================================
make sure the attribute  dynamicrange is imported and exported successfully
json validation passed
1 object definitions have been removed.
CHECK:rc == 0	[Pass]
RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "dynamicra
nge" "200.0.0.100" "/tmp/xcat_inventory_import_validation_network" [Fri Mar 23 05:09:17 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
objtype="network"
objname="autotestnet"
attribute="dynamicrange"
attrvalue="200.0.0.100"
tmpdir="/tmp/xcat_inventory_import_validation_network"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_validation_network
=================the inventory file to import: /tmp/xcat_inventory_import_validation_network/network.yaml========
=============
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 123.0.0.0
    pool:
      dynamicrange: 200.0.0.100
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'

==============================================================================
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
import the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml
Importing object: autotestnet
Inventory import successfully!
the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml imported successfully
export the "network" type object "autotestnet" just imported
the inventory data of the "network" type object "autotestnet" exported to /tmp/xcat_inventory_import_validation_n
etwork/network.out.yaml
==============the exported inventory file /tmp/xcat_inventory_import_validation_network/network.out.yaml=========
=============
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 123.0.0.0
    pool:
      dynamicrange: 200.0.0.100
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'

===========================================================================
make sure the attribute  dynamicrange is imported and exported successfully
yaml validation passed
removing existing "network" type object "autotestnet" from xCAT
1 object definitions have been removed.
=================the inventory file to import: /tmp/xcat_inventory_import_validation_network/network.json========
=============
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "200.0.0.100",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_network/network.json
Importing object: autotestnet
Inventory import successfully!
the inventory data of the "network" type object "autotestnet" exported to /tmp/xcat_inventory_import_validation_n
etwork/network.out.json
==============the exported inventory file /tmp/xcat_inventory_import_validation_network/network.out.json=========
=============
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "200.0.0.100",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
===========================================================================
make sure the attribute  dynamicrange is imported and exported successfully
json validation passed
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "dynamicra
nge" "abc-bcd" "/tmp/xcat_inventory_import_validation_network" [Fri Mar 23 05:09:20 2018]
ElapsedTime:2 sec
RETURN rc = 1
OUTPUT:
objtype="network"
objname="autotestnet"
attribute="dynamicrange"
attrvalue="abc-bcd"
tmpdir="/tmp/xcat_inventory_import_validation_network"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_validation_network
=================the inventory file to import: /tmp/xcat_inventory_import_validation_network/network.yaml========
=============
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 123.0.0.0
    pool:
      dynamicrange: abc-bcd
      staticrange: 123.0.0.201-123.0.0.222
schema_version: '1.0'

==============================================================================
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
import the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml
Error: failed to validate attribute [pool.dynamicrange] of object "autotestnet", criteria: " value='abc-bcd': Tru
e if str(value) in ('') or vutil.isIPaddr(value) or vutil.isIPrange(value) else False"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml
yaml validation failed
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
=================the inventory file to import: /tmp/xcat_inventory_import_validation_network/network.json========
=============
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "abc-bcd",
                "staticrange": "123.0.0.201-123.0.0.222"
            }
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_network/network.json
Error: failed to validate attribute [pool.dynamicrange] of object "autotestnet", criteria: " value='abc-bcd': Tru
e if str(value) in ('') or vutil.isIPaddr(value) or vutil.isIPrange(value) else False"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network/network.json
json validation failed
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
CHECK:rc != 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "staticran
ge" "200.0.0.100-200.0.0.200" "/tmp/xcat_inventory_import_validation_network" [Fri Mar 23 05:09:22 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
objtype="network"
objname="autotestnet"
attribute="staticrange"
attrvalue="200.0.0.100-200.0.0.200"
tmpdir="/tmp/xcat_inventory_import_validation_network"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_validation_network
=================the inventory file to import: /tmp/xcat_inventory_import_validation_network/network.yaml========
=============
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 123.0.0.0
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: 200.0.0.100-200.0.0.200
schema_version: '1.0'

==============================================================================
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
import the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml
Importing object: autotestnet
Inventory import successfully!
the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml imported successfully
export the "network" type object "autotestnet" just imported
the inventory data of the "network" type object "autotestnet" exported to /tmp/xcat_inventory_import_validation_n
etwork/network.out.yaml
==============the exported inventory file /tmp/xcat_inventory_import_validation_network/network.out.yaml=========
=============
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 123.0.0.0
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: 200.0.0.100-200.0.0.200
schema_version: '1.0'
===========================================================================
make sure the attribute  staticrange is imported and exported successfully
yaml validation passed
removing existing "network" type object "autotestnet" from xCAT
1 object definitions have been removed.
=================the inventory file to import: /tmp/xcat_inventory_import_validation_network/network.json========
=============
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "200.0.0.100-200.0.0.200"
            }
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_network/network.json
Importing object: autotestnet
Inventory import successfully!
the inventory data of the "network" type object "autotestnet" exported to /tmp/xcat_inventory_import_validation_n
etwork/network.out.json
==============the exported inventory file /tmp/xcat_inventory_import_validation_network/network.out.json=========
=============
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "200.0.0.100-200.0.0.200"
            }
        }
    },
    "schema_version": "1.0"
}
===========================================================================
make sure the attribute  staticrange is imported and exported successfully
json validation passed
1 object definitions have been removed.
CHECK:rc == 0	[Pass]
RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "staticran
ge" "200.0.0.100" "/tmp/xcat_inventory_import_validation_network" [Fri Mar 23 05:09:25 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
objtype="network"
objname="autotestnet"
attribute="staticrange"
attrvalue="200.0.0.100"
tmpdir="/tmp/xcat_inventory_import_validation_network"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_validation_network
=================the inventory file to import: /tmp/xcat_inventory_import_validation_network/network.yaml========
=============
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 123.0.0.0
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: 200.0.0.100
schema_version: '1.0'

==============================================================================
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
import the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml
Importing object: autotestnet
Inventory import successfully!
the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml imported successfully
export the "network" type object "autotestnet" just imported
the inventory data of the "network" type object "autotestnet" exported to /tmp/xcat_inventory_import_validation_n
etwork/network.out.yaml
==============the exported inventory file /tmp/xcat_inventory_import_validation_network/network.out.yaml=========
=============
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 123.0.0.0
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: 200.0.0.100
schema_version: '1.0'

===========================================================================
make sure the attribute  staticrange is imported and exported successfully
yaml validation passed
removing existing "network" type object "autotestnet" from xCAT
1 object definitions have been removed.
=================the inventory file to import: /tmp/xcat_inventory_import_validation_network/network.json========
=============
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "200.0.0.100"
            }
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_network/network.json
Importing object: autotestnet
Inventory import successfully!
the inventory data of the "network" type object "autotestnet" exported to /tmp/xcat_inventory_import_validation_n
etwork/network.out.json
==============the exported inventory file /tmp/xcat_inventory_import_validation_network/network.out.json=========
=============
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "200.0.0.100"
            }
        }
    },
    "schema_version": "1.0"
}
===========================================================================
make sure the attribute  staticrange is imported and exported successfully
json validation passed
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "network" "autotestnet" "staticran
ge" "abc-bcd" "/tmp/xcat_inventory_import_validation_network" [Fri Mar 23 05:09:28 2018]
ElapsedTime:2 sec
RETURN rc = 1
OUTPUT:
objtype="network"
objname="autotestnet"
attribute="staticrange"
attrvalue="abc-bcd"
tmpdir="/tmp/xcat_inventory_import_validation_network"
Temporary directory to hold intermediate files: /tmp/xcat_inventory_import_validation_network
=================the inventory file to import: /tmp/xcat_inventory_import_validation_network/network.yaml========
=============
network:
  autotestnet:
    basic_attr:
      gateway: 123.0.0.100
      mask: 255.0.0.0
      net: 123.0.0.0
    pool:
      dynamicrange: 123.0.0.100-123.0.0.200
      staticrange: abc-bcd
schema_version: '1.0'

==============================================================================
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
import the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml
Error: failed to validate attribute [pool.staticrange] of object "autotestnet", criteria: " value='abc-bcd': True
 if str(value) in ('') or vutil.isIPrange(value) or vutil.isIPaddr(value) else False"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network/network.yaml
yaml validation failed
removing existing "network" type object "autotestnet" from xCAT
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
=================the inventory file to import: /tmp/xcat_inventory_import_validation_network/network.json========
=============
{
    "network": {
        "autotestnet": {
            "basic_attr": {
                "gateway": "123.0.0.100",
                "mask": "255.0.0.0",
                "net": "123.0.0.0"
            },
            "pool": {
                "dynamicrange": "123.0.0.100-123.0.0.200",
                "staticrange": "abc-bcd"
            }
        }
    },
    "schema_version": "1.0"
}
==============================================================================
import the inventory file /tmp/xcat_inventory_import_validation_network/network.json
Error: failed to validate attribute [pool.staticrange] of object "autotestnet", criteria: " value='abc-bcd': True
 if str(value) in ('') or vutil.isIPrange(value) or vutil.isIPaddr(value) else False"
failed to import the inventory file /tmp/xcat_inventory_import_validation_network/network.json
json validation failed
Error: Could not find an object named 'autotestnet' of type 'network'.
No objects have been removed from the xCAT database.
CHECK:rc != 0	[Pass]

RUN:if [[ -e /tmp/xcat_inventory_import_validation_network_bak/autotestnet.stanza ]]; then cat /tmp/xcat_inventor
y_import_validation_network_bak/autotestnet.stanza | mkdef -z; fi [Fri Mar 23 05:09:30 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:rm -rf /tmp/xcat_inventory_import_validation_network_bak [Fri Mar 23 05:09:30 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::xcat_inventory_import_validation_network::Passed::Time:Fri Mar 23 05:09:30 2018 ::Duration::33 sec----
--
------Total: 3 , Failed: 0------

xCAT automated test finished at Fri Mar 23 05:09:30 2018
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20180323050809 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20180323050809 file for time consumption
```

