### PR TITLE
Display a warning when setting NTP Server

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
@@ -345,6 +345,10 @@ rmdir \"/tmp/$userid\" \n")
         if nic in netinfo:
             ntpservers = netinfo[nic]['ntpservers']
         self.callback.info('%s: BMC NTP Servers: %s' % (node, ntpservers))
+        if ntpservers != None:
+            # Display a warning if the host in not powered off
+            # Time on the BMC is not synced while the host is powered on
+            self.callback.info('%s: Warning: time will not be synchronized until the host is powered off.' % node)
 
     def _get_facing_nic(self, bmcip, netinfo):
         for k,v in netinfo.items():

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -3379,6 +3379,7 @@ sub rspconfig_response {
             my @gateway = ();
             my @vlan = (); 
             my @ntpservers = ();
+            my $real_ntp_server = 0;
             my @nics = keys %nicinfo;
             foreach my $nic (@nics) {
                 my $addon_info = '';
@@ -3388,6 +3389,7 @@ sub rspconfig_response {
 
                 if ($nicinfo{$nic}{ntpservers}) {
                     push @ntpservers, "BMC NTP Servers$addon_info: $nicinfo{$nic}{ntpservers}";
+                    $real_ntp_server = 1;
                 } else {
                     push @ntpservers, "BMC NTP Servers$addon_info: None";
                 }
@@ -3410,6 +3412,11 @@ sub rspconfig_response {
                     push @output, "BMC Hostname: $hostname";
                 } elsif ($opt eq "ntpservers") {
                     push @output, @ntpservers;
+                    if (($real_ntp_server) && ($status_info{RSPCONFIG_SET_RESPONSE}{argv} =~ "NTPServers")) {
+                        # Display a warning if the host in not powered off
+                        # Time on the BMC is not synced while the host is powered on.
+                        push @output, "Warning: time will not be synchronized until the host is powered off.";
+                    }
                 }
 
                 if ($multiple_error and ($opt =~  /^ip$|^ipsrc$|^netmask$|^gateway$|^vlan$/)) {


### PR DESCRIPTION
#4771 

Perl
```
[root@briggs01 xcat]# rspconfig mid05tor12cn05 ntpservers
mid05tor12cn05: BMC NTP Servers: None

[root@briggs01 xcat]# rspconfig mid05tor12cn05 ntpservers=1.2.3.4
mid05tor12cn05: BMC Setting NTPServers...
mid05tor12cn05: BMC NTP Servers: 1.2.3.4
mid05tor12cn05: Warning: time will not be synchronized until the host is powered off

[root@briggs01 xcat]# rspconfig mid05tor12cn05 ntpservers=
mid05tor12cn05: BMC Setting NTPServers...
mid05tor12cn05: BMC NTP Servers: None

[root@briggs01 xcat]# rspconfig mid05tor12cn05 ntpservers=1.2.3.4,9.8.7.6
mid05tor12cn05: BMC Setting NTPServers...
mid05tor12cn05: BMC NTP Servers: 1.2.3.4,9.8.7.6
mid05tor12cn05: Warning: time will not be synchronized until the host is powered off
[root@briggs01 xcat]#
```

Python:
```
[root@briggs01 xcat]# rspconfig mid05tor12cn05 ntpservers
mid05tor12cn05: BMC NTP Servers: None

[root@briggs01 xcat]# rspconfig mid05tor12cn05 ntpservers=1.2.3.4
mid05tor12cn05: BMC Setting NTPServers...
mid05tor12cn05: BMC NTP Servers: 1.2.3.4
Warning: time will not be synchronized until the host is powered off

[root@briggs01 xcat]# rspconfig mid05tor12cn05 ntpservers=
mid05tor12cn05: BMC Setting NTPServers...
mid05tor12cn05: BMC NTP Servers: None

[root@briggs01 xcat]# rspconfig mid05tor12cn05 ntpservers=1.2.3.4,9.8.7.6
mid05tor12cn05: BMC Setting NTPServers...
mid05tor12cn05: BMC NTP Servers: 1.2.3.4,9.8.7.6
mid05tor12cn05: Warning: time will not be synchronized until the host is powered off
[root@briggs01 xcat]#
```