### PR TITLE
fix issue chroot, rpm -qa error: Failed to initialize NSS library #4959

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -85,7 +85,7 @@ sub majversion {
     my $version = shift;
     my $majorrel;
 
-    if ($osver =~ /^\D*(\d*)[.\d]*$/) {
+    if ($osver =~ /^\D*(\d*)[.\d]*.*$/) {
         $majorrel = $1;
     }
 
@@ -141,6 +141,9 @@ sub umount_chroot {
         #only remove the /dev in rootimg directory if it is not a mount point
         system("findmnt $rootimage_dir/dev/ >/dev/null 2>&1 || rm -rf $rootimage_dir/dev/*");
     }
+    
+    #rpm complains "Failed to initialize NSS library" when /dev/urandom does not exist,  leave /dev/urandom
+    use_devurandom();
 }
 
 #check whether a dir is NFS mounted
@@ -375,8 +378,6 @@ unless ($onlyinitrd) {
 
 
     mount_chroot($rootimg_dir);
-    use_devurandom();
-
     my %pkg_hash = imgutils::get_package_names($pkglist);
 
     my $index = 1;

--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -375,6 +375,7 @@ unless ($onlyinitrd) {
 
 
     mount_chroot($rootimg_dir);
+    use_devurandom();
 
     my %pkg_hash = imgutils::get_package_names($pkglist);
 
@@ -520,7 +521,7 @@ unless ($onlyinitrd) {
         # Hack uname when deal otherpkgs
         use_hackuname($arch, $kernelver);
         use_devnull();
-        use_devurandom();
+
 
         foreach $pass (sort { $a <=> $b } (keys(%extra_hash))) {
             $yumcmd = $yumcmd_base;


### PR DESCRIPTION
UT:
```
[root@c910f03c09k12 rootimg]# genimage rhels7.5-alternate-ppc64le-netboot-compute
...
[root@c910f03c09k12 rootimg]# chroot /install/netboot/rhels7.5-alternate/ppc64le/compute/rootimg
[root@c910f03c09k12 /]# rpm
RPM version 4.11.3
Copyright (C) 1998-2002 - Red Hat, Inc.
This program may be freely redistributed under the terms of the GNU GPL

Usage: rpm [-aKfgpqVcdLilsiv?] [-a|--all] [-f|--file] [-g|--group] [-p|--package] [--pkgid] [--hdrid] [--triggeredby]
        [--whatrequires] [--whatprovides] [--nomanifest] [-c|--configfiles] [-d|--docfiles] [-L|--licensefiles] [--dump]
        [-l|--list] [--queryformat=QUERYFORMAT] [-s|--state] [--nofiledigest] [--nofiles] [--nodeps] [--noscript]
        [--allfiles] [--allmatches] [--badreloc] [-e|--erase <package>+] [--excludedocs] [--excludepath=<path>] [--force]
        [-F|--freshen <packagefile>+] [-h|--hash] [--ignorearch] [--ignoreos] [--ignoresize] [-i|--install] [--justdb]
        [--nodeps] [--nofiledigest] [--nocontexts] [--noorder] [--noscripts] [--notriggers] [--nocollections]
        [--oldpackage] [--percent] [--prefix=<dir>] [--relocate=<old>=<new>] [--replacefiles] [--replacepkgs] [--test]
        [-U|--upgrade <packagefile>+] [--reinstall=<packagefile>+] [-D|--define 'MACRO EXPR'] [--undefine=MACRO]
        [-E|--eval 'EXPR'] [--macros=<FILE:...>] [--noplugins] [--nodigest] [--nosignature] [--rcfile=<FILE:...>]
        [-r|--root ROOT] [--dbpath=DIRECTORY] [--querytags] [--showrc] [--quiet] [-v|--verbose] [--version] [-?|--help]
        [--usage] [--scripts] [--setperms] [--setugids] [--conflicts] [--obsoletes] [--provides] [--requires] [--info]
        [--changelog] [--xml] [--triggers] [--last] [--dupes] [--filesbypkg] [--fileclass] [--filecolor] [--fscontext]
        [--fileprovide] [--filerequire] [--filecaps]

[root@c910f03c09k12 xcat]# genimage rhels7.5-alternate-ppc64le-netboot-service
...
[root@c910f03c09k12 xcat]# cat /install/netboot/rhels7.5-alternate/ppc64le/compute/rootimg/etc/httpd/conf.d/xcat.conf
#
# This configuration file allows a diskfull install to access the install images
# via http.  It also allows the xCAT documentation to be accessed via
# http://localhost/xcat-doc/
# Updates to xCAT/xcat.conf should also be made to xCATsn/xcat.conf
#
AliasMatch ^/install/(.*)$ "/install/$1"
AliasMatch ^/tftpboot/(.*)$ "/tftpboot/$1"

<Directory "/tftpboot">
    Options Indexes FollowSymLinks Includes MultiViews
    AllowOverride None
    Require all granted
</Directory>
<Directory "/install">
    Options Indexes FollowSymLinks Includes MultiViews
    AllowOverride None
    Require all granted
</Directory>

Alias /xcat-doc "/opt/xcat/share/doc"
<Directory "/opt/xcat/share/doc">
 Options Indexes
 AllowOverride None
 Require all granted
</Directory>

[root@c910f03c09k12 xcat]# xdsh -i /install/netboot/rhels7.5-alternate/ppc64le/compute/rootimg  "rpm -qa|grep uuid"
compute-rhels7.5-alternate-ppc64le: libuuid-2.23.2-52.el7.ppc64le

```