### PR TITLE
updatenode MERGE mode does not support update an existing entry

### DIFF
--- a/xCAT-server/share/xcat/scripts/xdcpmerge.sh
+++ b/xCAT-server/share/xcat/scripts/xdcpmerge.sh
@@ -61,8 +61,8 @@ for i in $*; do
   # in the merge file and create a new backup 
   # first get a list of  duplicate lines to remove 
   # based on only username:  the first field in the file
- cut -d: -f1 $filebackup > $filebackup.userlist
- cut -d: -f1 $mergefile > $mergefile.userlist
+  cut -d: -f1 $filebackup > $filebackup.userlist
+  cut -d: -f1 $mergefile > $mergefile.userlist
   comm -12 <(sort $filebackup.userlist | uniq) <(sort $mergefile.userlist | uniq) > $filebackup.remove
  
   # now if there is a remove file,  use it to remove the dup lines in backup 
@@ -86,16 +86,15 @@ for i in $*; do
     userlist=$userlisttmp$listend
     grepcmd=$grepcmd$userlist
     #set -x
-    grepcmd="$grepcmd $mergefile > $mergefile.nodups"
-    #echo "grepcmd=$grepcmd"
+    grepcmd="$grepcmd $filebackup > $filebackup.nodups"
     # now run it
     eval $grepcmd
-  fi 
-  
-  # add new entries from mergefile, if any 
-  if [ -a "$mergefile.nodups" ]; then
-    cat $mergefile.nodups >> $curfile
-    rm $mergefile.nodups
+    #echo "grepcmd=$grepcmd"
+    cat $filebackup.nodups $mergefile > $curfile
+    #echo "$filebackup.nodups $mergefile > $curfile"
+  else
+    cat $filebackup $mergefile > $curfile
+    #echo "cat $filebackup $mergefile > $curfile"
   fi
   
   # now cleanup


### PR DESCRIPTION
Fix code error after #4328 , 
UT:
1, add user case
```
chdef -t osimage rhels7.3-ppc64le-install-compute synclists=/tmp/abc.lst
cat /tmp/abc.lst
MERGE:
/etc/mydir/mergepasswd -> /etc/passwd
/etc/mydir/mergegroup -> /etc/group

cat /etc/mydir/*
testuser:x:10007:


testuser:x:10007:10007:::/bin/bash

updatenode c910f03c05k30 -F
File synchronization has completed for nodes.
[root@c910f03c05k20 testcase]# xdsh c910f03c05k30 "grep testuser /etc/passwd"
c910f03c05k30: testuser:x:10007:10007:::/bin/bash
[root@c910f03c05k20 testcase]# xdsh c910f03c05k30 "grep testuser /etc/group"
```

2, modify user case
```
vi /etc/mydir/mergepasswd  (update the group id = 1)
updatenode c910f03c05k30 -F
File synchronization has completed for nodes.
xdsh c910f03c05k30 "grep testuser /etc/passwd"
c910f03c05k30: testuser:x:10007:1:::/bin/bash
```
3, using a whole file (not recommend usage as you must ensure the file is correct)
```
scp c910f03c05k30:/etc/passwd /etc/mydir/mergepasswd
root:x:0:0:root:/root:/bin/bash
passwd                                                                                                                                             100% 1835     1.8KB/s   00:00
updatenode c910f03c05k30 -F
File synchronization has completed for nodes.
```