### PR TITLE
Properly fix updatenode syncfiles

### DIFF
--- a/xCAT-server/lib/xcat/plugins/updatenode.pm
+++ b/xCAT-server/lib/xcat/plugins/updatenode.pm
@@ -1833,6 +1833,7 @@ sub updatenodesyncfiles
                 {
                     command => ["xdcp"],
                     node    => $syncfile_node{$synclist},
+                    username => $request->{username},
                     arg     => $args,
                     env     => $env
                 },

--- a/xCAT-server/lib/xcat/plugins/xdsh.pm
+++ b/xCAT-server/lib/xcat/plugins/xdsh.pm
@@ -639,7 +639,6 @@ sub process_servicenodes_xdcp
         $addreq->{'_xcatdest'} = $::mnname;
         $addreq->{node}        = \@sn;
         $addreq->{noderange}   = \@sn;
-        $addreq->{forceroot}->[0]   = 1;
 
         # check input request for --nodestatus
         my $args = $req->{arg};    # argument
@@ -1215,9 +1214,6 @@ sub process_request
         if (($request->{username}) && defined($request->{username}->[0])) {
             $ENV{DSH_FROM_USERID} = $request->{username}->[0];
         }
-    }
-    if ($request->{forceroot}) {
-        $ENV{DSH_FROM_USERID} = 'root';
     }
     if ($command eq "xdsh")
     {


### PR DESCRIPTION
https://github.com/xcat2/xcat-core/pull/4484 went to fix updatenode, but in the process introduced a security exposure.

This peels back 'forceroot' and replaces it with using the trusted approach in xcatd sub validate function.