### PR TITLE
fix issue 4983, get autoreboot info

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
@@ -401,8 +401,10 @@ rmdir \"/tmp/$userid\" \n")
 
         if isinstance(value, dict):
             str_value = value.values()[0]
+        elif value:
+            str_value = str(value)
         else:
-            str_value = value 
+            str_value = '0'
         result = '%s: %s: %s' % (node, openbmc.RSPCONFIG_APIS[key]['display_name'], str_value.split('.')[-1])
         self.callback.info(result)
 

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -183,7 +183,7 @@ RSPCONFIG_APIS = {
     'autoreboot' : {
         'baseurl': "/control/host0/auto_reboot/",
         'set_url': "attr/AutoReboot",
-        'get_url': "attr/AutoReboot",
+        'get_url': "",
         'display_name': "BMC AutoReboot",
         'attr_values': {
             '0': False,
@@ -203,9 +203,9 @@ RSPCONFIG_APIS = {
         },
     },
     'powerrestorepolicy': {
-        'baseurl': "/control/host0/power_restore_policy/",
-        'set_url': "attr/PowerRestorePolicy",
-        'get_url': "attr/PowerRestorePolicy",
+        'baseurl': "/control/host0/power_restore_policy",
+        'set_url': "/attr/PowerRestorePolicy",
+        'get_url': "",
         'display_name': "BMC PowerRestorePolicy",
          'attr_values': {
              'restore': "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.Restore",
@@ -214,9 +214,9 @@ RSPCONFIG_APIS = {
          },
     },
     'bootmode': {
-        'baseurl': "/control/host0/boot/",
-        'set_url': "attr/BootMode",
-        'get_url': "attr/BootMode",
+        'baseurl': "/control/host0/boot",
+        'set_url': "/attr/BootMode",
+        'get_url': "",
         'display_name':"BMC BootMode",
         'attr_values': {
             'regular': "xyz.openbmc_project.Control.Boot.Mode.Modes.Regular",


### PR DESCRIPTION
After fixed #4983 , encounter new bug.

Before modify no output for rspconfig autoreboot.

After modified:
```
# rspconfig f6u03 autoreboot
Tue Mar 27 00:04:30 2018 f6u03: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.3.100/login -d '{"data": ["root", "xxxxxx"]}'
Tue Mar 27 00:04:31 2018 f6u03: [openbmc_debug] login 200 OK
Tue Mar 27 00:04:31 2018 f6u03: [openbmc_debug] get_autoreboot curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://10.6.3.100/xyz/openbmc_project/control/host0/auto_reboot/
Tue Mar 27 00:04:31 2018 f6u03: [openbmc_debug] get_autoreboot 200 OK

f6u03: BMC AutoReboot: 0
```