### PR TITLE
clear "name-IP" cache in `install monitor` process

### DIFF
--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -469,6 +469,8 @@ sub do_installm_service {
                 alarm(0);
                 print $conn "done\n";
                 $text =~ s/\r//g;
+                # Clear IP-Name cache, Workaround (#4913) for IP changed cases.
+                xCAT::NetworkUtils->clearcache();
                 if ($text =~ /next/) {
                     my %request = (
                         command => ['nodeset'],


### PR DESCRIPTION
(#4913) clear cache before run 'nodeset <> next' to avoid using the old IP address after IP address is modified.

UT:
1, make sure dhcp has wrong IP address `10.3.5.29`, and use this IP address to send `/xcatpost/updateflag.awk 10.3.5.20 3002`, this will make install monitor cache `10.3.5.29` for `c910f03c05k30`
```
makedhcp -q c910f03c05k30
c910f03c05k30: ip-address = 10.3.5.29, hardware-address = 42:a1:0a:03:05:1e
```

2, change to the right IP address, and send it again
```
chdef c910f03c05k30 ip=10.3.5.30
1 object definitions have been created or modified.
makehosts c910f03c05k30
makedns -n c910f03c05k30
Handling c910f03c05k30 in /etc/hosts.
Getting reverse zones, this may take several minutes for a large cluster.
Completed getting reverse zones.
Updating zones.
Completed updating zones.
Restarting named
Restarting named complete
Updating DNS records, this may take several minutes for a large cluster.
Completed updating DNS records.
DNS setup is completed
 nslookup c910f03c05k30
Server:		10.3.5.20
Address:	10.3.5.20#53

Name:	c910f03c05k30.pok.stglabs.ibm.com
Address: 10.3.5.30
```
3, after run `/xcatpost/updateflag.awk 10.3.5.20 3002`, check the dhcp lease, we can see it is the right IP
```
makedhcp -q c910f03c05k30
c910f03c05k30: ip-address = 10.3.5.30, hardware-address = 42:a1:0a:03:05:1e
```

And not found performance impact.