### PR TITLE
Add default logrotate configuration for gocons

### DIFF
--- a/xCAT-server/debian/dirs
+++ b/xCAT-server/debian/dirs
@@ -8,6 +8,7 @@ opt/xcat/share/xcat/netboot
 opt/xcat/share/xcat/templates
 opt/xcat/share/xcat/ca
 opt/xcat/share/xcat/scripts
+opt/xcat/share/xcat/conf
 opt/xcat/share/xcat/tools
 opt/xcat/share/xcat/rollupdate
 opt/xcat/share/xcat/installp_bundles

--- a/xCAT-server/debian/install
+++ b/xCAT-server/debian/install
@@ -6,6 +6,7 @@ share/xcat/mypostscript/* opt/xcat/share/xcat/mypostscript/
 share/xcat/ca/* opt/xcat/share/xcat/ca
 
 share/xcat/scripts/* opt/xcat/share/xcat/scripts
+share/xcat/conf/* opt/xcat/share/xcat/conf
 share/xcat/tools/* opt/xcat/share/xcat/tools
 share/xcat/rollupdate/* opt/xcat/share/xcat/rollupdate
 share/xcat/installp_bundles/* opt/xcat/share/xcat/installp_bundles

--- a/xCAT-server/debian/rules
+++ b/xCAT-server/debian/rules
@@ -47,6 +47,7 @@ binary-arch:
 	chmod 755 $(rootdir)/bin/*
 	chmod 755 $(rootdir)/sbin/*
 	chmod 644 $(rootdir)/share/xcat/ca/*
+	chmod 644 $(rootdir)/share/xcat/conf/*
 	chmod 755 $(rootdir)/share/xcat/cons/*
 	chmod 755 $(rootdir)/share/xcat/ib/*
 	chmod 755 $(rootdir)/share/xcat/ib/netboot/sles/*

--- a/xCAT-server/lib/xcat/plugins/goconserver.pm
+++ b/xCAT-server/lib/xcat/plugins/goconserver.pm
@@ -6,6 +6,7 @@ BEGIN {
 }
 use lib "$::XCATROOT/lib/perl";
 use strict;
+use File::Copy;
 use xCAT::Table;
 use xCAT::Utils;
 use xCAT::TableUtils;
@@ -164,6 +165,9 @@ sub start_goconserver {
         if ($ret) {
             xCAT::MsgUtils->error_message("Failed to create configuration file for goconserver.", $::callback);
             return 1;
+        }
+        if (!copy($::XCATROOT."/share/xcat/conf/goconslogrotate", "/etc/logrotate.d/goconserver")) {
+            xCAT::MsgUtils->warn_message("Failed to create logrotate configuration for goconserver.", $::callback);
         }
     }
     $ret = xCAT::Goconserver::restart_service();

--- a/xCAT-server/share/xcat/conf/goconslogrotate
+++ b/xCAT-server/share/xcat/conf/goconslogrotate
@@ -1,0 +1,9 @@
+/var/log/consoles/*.log
+/var/log/goconserver/server.log
+{
+    missingok
+    sharedscripts
+    postrotate
+        kill -HUP `systemctl show -p MainPID goconserver.service 2> /dev/null |awk -F= '{print $2}'` 2> /dev/null || true
+    endscript
+}

--- a/xCAT-server/xCAT-server.spec
+++ b/xCAT-server/xCAT-server.spec
@@ -100,6 +100,7 @@ mkdir -p $RPM_BUILD_ROOT/%{prefix}/share/xcat/scripts
 mkdir -p $RPM_BUILD_ROOT/%{prefix}/share/xcat/samples
 mkdir -p $RPM_BUILD_ROOT/%{prefix}/share/xcat/tools
 mkdir -p $RPM_BUILD_ROOT/%{prefix}/share/xcat/cons
+mkdir -p $RPM_BUILD_ROOT/%{prefix}/share/xcat/conf
 mkdir -p $RPM_BUILD_ROOT/%{prefix}/share/xcat/rollupdate
 mkdir -p $RPM_BUILD_ROOT/%{prefix}/share/xcat/installp_bundles
 mkdir -p $RPM_BUILD_ROOT/%{prefix}/share/xcat/image_data
@@ -145,6 +146,7 @@ chmod 644 $RPM_BUILD_ROOT/%{prefix}/share/xcat/ca/*
 
 cp share/xcat/mypostscript/* $RPM_BUILD_ROOT/%{prefix}/share/xcat/mypostscript
 cp share/xcat/scripts/* $RPM_BUILD_ROOT/%{prefix}/share/xcat/scripts
+cp share/xcat/conf/* $RPM_BUILD_ROOT/%{prefix}/share/xcat/conf
 cp share/xcat/samples/* $RPM_BUILD_ROOT/%{prefix}/share/xcat/samples
 cp -r share/xcat/tools/* $RPM_BUILD_ROOT/%{prefix}/share/xcat/tools
 cp -r share/xcat/hamn/* $RPM_BUILD_ROOT/%{prefix}/share/xcat/hamn


### PR DESCRIPTION
Add logrotate conf for the console log files and log
of goconserver.

implement: https://github.com/xcat2/xcat2-task-management/issues/22

```
[root@c910f05c01bc02k74 goconserver]# ls -l /var/log/goconserver/server.log
-rw------- 1 root root 1550 Mar 27 04:27 /var/log/goconserver/server.log
[root@c910f05c01bc02k74 goconserver]# logrotate -fv /etc/logrotate.d/goconserver
reading config file /etc/logrotate.d/goconserver
Allocating hash table for state file, size 15360 B
removing old log /var/log/goconserver/server.log.1
[root@c910f05c01bc02k74 goconserver]# ls -l /var/log/goconserver/server.log
-rw------- 1 root root 0 Mar 27 04:27 /var/log/goconserver/server.log
[root@c910f05c01bc02k74 goconserver]# ls -l /var/log/goconserver/server.log
-rw------- 1 root root 666 Mar 27 04:27 /var/log/goconserver/server.log
```
