### PR TITLE
(#4973) add journal logs in xcatsnap for xcatd

### DIFF
--- a/xCAT-server/sbin/xcatsnap
+++ b/xCAT-server/sbin/xcatsnap
@@ -239,7 +239,7 @@ sub snap_it {
             "ls $installdir",            "/usr/bin/crontab -l",
             "find /tftpboot -size -32k", "ls -lR $xcatroot",
             "arp -a", "ps -edlf", "ps -aux", "ulimit -a", "df -k",
-"cat /etc/issue", "lsxcatd -a", "cat /proc/meminfo", "cat /proc/cpuinfo");
+"cat /etc/issue", "lsxcatd -a", "cat /proc/meminfo", "cat /proc/cpuinfo", "journalctl -b --no-pager -u xcatd");
     }
     foreach my $item (@Commands_array) {
         $Command = $item;


### PR DESCRIPTION
To fix #4973 
UT: just run xcatsnap and check if the content in tarball

```
-rw-r--r-- root/root        23 2018-03-27 04:19 ./commands_output/cat__etc_issue.out
-rw-r--r-- root/root       238 2018-03-27 04:19 ./commands_output/lsxcatd_a.out
-rw-r--r-- root/root      1012 2018-03-27 04:19 ./commands_output/cat__proc_meminfo.out
-rw-r--r-- root/root      1007 2018-03-27 04:19 ./commands_output/cat__proc_cpuinfo.out
-rw-r--r-- root/root    104446 2018-03-27 04:19 ./commands_output/journalctl_b_nopager_u_xcatd.out         <<  =====  here it is
```
