### PR TITLE
modify login error msg for openbmc python

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_power.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_power.py
@@ -51,12 +51,7 @@ class OpenBMCPowerTask(ParallelNodesCommand):
         bmc_not_ready = bmc_state = 'NotReady'
         try:
             obmc.login()
-        except SelfServerException as e:
-            # Special exception handling for login failure
-            login_message = "Login to BMC failed: Can't connect to {0} {1}.".format(e.host_and_port, e.detail_msg)
-            self.callback.error(login_message, node)
-            return bmc_state
-        except SelfClientException as e:
+        except (SelfServerException, SelfClientException) as e:
             self.callback.error(e.message, node)
             return bmc_state
 

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -335,8 +335,11 @@ class OpenBMCRest(object):
             response = self.session.request(method, url, httpheaders, data=data, timeout=timeout)
             return self.handle_response(response, cmd=cmd)
         except SelfServerException as e:
-            e.message = 'BMC did not respond. ' \
-                        'Validate BMC configuration and retry the command.'
+            if cmd == 'login':
+                e.message = "Login to BMC failed: Can't connect to {0} {1}.".format(e.host_and_port, e.detail_msg)
+            else:
+                e.message = 'BMC did not respond. ' \
+                            'Validate BMC configuration and retry the command.'
             self._print_error_log(e.message, cmd)
             raise
         except ValueError:


### PR DESCRIPTION
#4942 

If login failed with SelfServerException, will return msg like `` Login to BMC failed: Can't connect to 10.6.17.100:443 (No route to host).``.
If other request failed with SelfServerException, will return msg ``BMC did not respond. Validate BMC configuration and retry the command.``
```
# rpower f6u17 state
Tue Mar 27 21:57:43 2018 f6u17: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.17.100/login -d '{"data": ["root", "xxxxxx"]}'
Tue Mar 27 21:57:46 2018 f6u17: [openbmc_debug] login Login to BMC failed: Can't connect to 10.6.17.100:443 (No route to host).
f6u17: Error: Login to BMC failed: Can't connect to 10.6.17.100:443 (No route to host).
```