### PR TITLE
Check if cons script is excutable before register into console server

### DIFF
--- a/xCAT-server/lib/perl/xCAT/Goconserver.pm
+++ b/xCAT-server/lib/perl/xCAT/Goconserver.pm
@@ -192,6 +192,10 @@ sub init_local_console {
             unless ($_->{cons}) {
                 $_->{cons} = $_->{mgt};
             }
+            if ( $_->{cons} ne 'openbmc' && ! -x $::XCATROOT . "/share/xcat/cons/".$_->{cons}) {
+                xCAT::MsgUtils->message("S", $_->{node} .": ignore, ". $::XCATROOT . "/share/xcat/cons/".$_->{cons}." is not excutable. Please check mgt or cons attribute.");
+                next;
+            }
             if ($_->{conserver} && exists($iphash{ $_->{conserver} })) {
                 $cons_map{ $_->{node} } = $_;
             }
@@ -406,6 +410,11 @@ sub get_cons_map {
         if ($_->{cons} or defined($_->{'serialport'})) {
             unless ($_->{cons}) { $_->{cons} = $_->{mgt}; } #populate with fallback
             if ($isSN && $_->{conserver} && exists($iphash{ $_->{conserver} }) || !$isSN) {
+                if ( $_->{cons} ne 'openbmc' && ! -x $::XCATROOT . "/share/xcat/cons/".$_->{cons}) {
+                    $rsp->{data}->[0] = $_->{node} .": ignore, ". $::XCATROOT . "/share/xcat/cons/".$_->{cons}." is not excutable. Please check mgt or cons attribute.";
+                    xCAT::MsgUtils->message("I", $rsp, $::callback);
+                    next;
+                }
                 $cons_map{ $_->{node} } = $_; # also put the ref to the entry in a hash for quick look up
             } else {
                 $rsp->{data}->[0] = $_->{node} .": ignore, the host for conserver could not be determined.";

--- a/xCAT-server/lib/xcat/plugins/conserver.pm
+++ b/xCAT-server/lib/xcat/plugins/conserver.pm
@@ -201,6 +201,7 @@ sub preprocess_request {
 sub process_request {
     my $req = shift;
     my $cb  = shift;
+    $::callback = $cb;
     if ($req->{command}->[0] eq "makeconservercf") {
         if (-x "/usr/bin/goconserver") {
             require xCAT::Goconserver;
@@ -602,6 +603,10 @@ sub donodeent {
 
             # either there is no console method (shouldnt happen) or not one of the supported terminal servers
             return $node;
+        }
+        if (!grep(/^$cmeth$/, @cservers) && ! -x $::XCATROOT . "/share/xcat/cons/" . $cmeth) {
+            xCAT::SvrUtils::sendmsg([ 0, "ignore, ". $::XCATROOT . "/share/xcat/cons/$cmeth is not excutable. Please check mgt or cons attribute." ], $::callback, $node);
+            next;
         }
         push @$content, "#xCAT BEGIN $node CONS\n";
         push @$content, "console $node {\n";


### PR DESCRIPTION
This patch check the script file, if it is not excutable, just print
ignore message.

fix-issue: #4009 
```
[root@c910f05c01bc02k74 ~]# makegocons
testnode: ignore, cons attribute or serialport attribute is not specified.
tz998: ignore, /opt/xcat/share/xcat/cons/foo is not excutable. Please check mgt or cons attribute.
simulator_test0: Created
mid05tor12cn11: Created
kvmguest1: Created
c460c022: Created
simulator_test1: Created
[root@c910f05c01bc02k74 ~]# service goconserver stop
Redirecting to /bin/systemctl stop  goconserver.service
[root@c910f05c01bc02k74 ~]# makeconservercf
tz998: ignore, /opt/xcat/share/xcat/cons/foo is not excutable. Please check mgt or cons attribute.
[root@c910f05c01bc02k74 ~]# makeconservercf tz998
tz998: ignore, /opt/xcat/share/xcat/cons/foo is not excutable. Please check mgt or cons attribute.
```