### PR TITLE
OpenBMC reventlog flag verification

### DIFF
--- a/xCAT-server/lib/perl/xCAT/OPENBMC.pm
+++ b/xCAT-server/lib/perl/xCAT/OPENBMC.pm
@@ -255,7 +255,7 @@ sub run_cmd_in_perl {
     }
 
     # List of commands currently not supported in Python
-    my @unsupported_in_python_commands = ('rflash', 'rspconfig', 'reventlog', 'getopenbmccons');
+    my @unsupported_in_python_commands = ('rflash', 'rspconfig', 'getopenbmccons');
 
     if ($command ~~ @unsupported_in_python_commands) {
         # Command currently not supported in Python

--- a/xCAT-server/lib/xcat/plugins/openbmc2.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc2.pm
@@ -364,7 +364,12 @@ sub parse_args {
         }
     } elsif ($command eq "reventlog") {
         $subcommand = "all" if (!defined($ARGV[0]));
-        if ($subcommand =~ /^resolved=(.*)/) {
+        if (scalar(@ARGV) >= 2) {
+            if ($ARGV[1] =~ /^-s$/) {
+                return ([ 1, "The -s option is not supported for OpenBMC." ]);
+            }
+            return ([ 1, "Only one option is supported at the same time for $command" ]);
+        } elsif ($subcommand =~ /^resolved=(.*)/) {
             my $value = $1;
             if (not $value) {
                 return ([ 1, "$usage_errormsg $reventlog_no_id_resolved_errormsg" ]);


### PR DESCRIPTION
#5026 

Catch `reventlog` `-s` flag and display an error similar to Perl.
Enable Python as default for `reventlog` command.

```
[root@briggs01 xcat]# reventlog mid05tor12cn15 all 2
mid05tor12cn15: Error: Only one option is supported at the same time for reventlog

[root@briggs01 xcat]# reventlog mid05tor12cn15 all
mid05tor12cn15: No attributes returned from the BMC.

[root@briggs01 xcat]# reventlog mid05tor12cn15 -s
mid05tor12cn15: Error: Unsupported command: reventlog -s

[root@briggs01 xcat]# reventlog mid05tor12cn15 2 -s
mid05tor12cn15: Error: The -s option is not supported for OpenBMC.
```