### PR TITLE
enhance exlist without typo and duplicate lines

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels7.ppc64.exlist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels7.ppc64.exlist
@@ -8,13 +8,13 @@
 ./usr/lib64/perl5/Encode/KR*
 ./lib/kbd/keymaps/i386*
 ./lib/kbd/keymaps/mac*
-./lib/kdb/keymaps/include*
+./lib/kbd/keymaps/include*
 ./usr/local/include*
 ./usr/local/share/man*
 ./usr/share/man*
 ./usr/share/cracklib*
 ./usr/share/doc*
-./usr/share/doc/packages/cyrus-sasl/doc*
+#./usr/share/doc/packages/cyrus-sasl/doc*
 ./usr/share/gnome*
 ./usr/share/i18n*
 +./usr/share/i18n/en_US*
@@ -25,7 +25,6 @@
 +./usr/share/locale/locale.alias
 +./usr/lib/locale/locale-archive
 +./usr/lib/locale/en*
-./usr/share/man*
 ./usr/share/omf*
 ./usr/share/vim/site/doc*
 ./usr/share/vim/vim74/doc*


### PR DESCRIPTION
For #5023 

UT:
```
1, use updated exlist in osimage rhels7.5-ppc64le-netboot-compute

2, genimage rhels7.5-ppc64le-netboot-compute

3, packimage rhels7.5-ppc64le-netboot-compute

4, gunzip rootimg.cpio.gz; cpio -idmv < rootimg.cpio

5, check results:
tmp]# ls usr/share/man
ls: cannot access usr/share/man: No such file or directory
tmp]# ls usr/share/doc
ls: cannot access usr/share/doc: No such file or directory
tmp]# ls lib/kbd/keymaps/include
ls: cannot access lib/kbd/keymaps/include: No such file or directory
 ```