### PR TITLE
Add test cases for support diskless SN installation and python environment setup

### DIFF
--- a/xCAT-test/autotest/testcase/installation/SN_diskless_setup_case
+++ b/xCAT-test/autotest/testcase/installation/SN_diskless_setup_case
@@ -1,0 +1,123 @@
+start:SN_diskless_setup_case
+description:this case is used to test diskless service node installation
+os:Linux
+#stop:yes
+cmd:fdisk -l
+cmd:df -T
+cmd:XCAT_DATABASE=$$XCAT_DATABASE /opt/xcat/share/xcat/tools/autotest/testcase/installation/pre_deploy_sn __GETNODEATTR($$SN,os)__  __GETNODEATTR($$SN,arch)__
+check:rc==0
+cmd:chtab key=nameservers site.value="<xcatmaster>"
+check:rc==0
+cmd:makedns -n
+check:rc==0
+cmd:makeconservercf $$SN
+check:rc==0
+cmd:cat /etc/conserver.cf | grep $$SN
+check:output=~$$SN
+cmd:sleep 20
+cmd:if [[ "__GETNODEATTR($$SN,arch)__" = "ppc64" ]]; then getmacs -D $$SN -V; fi
+check:rc==0
+cmd:makedhcp -n
+check:rc==0
+cmd:makedhcp -a
+check:rc==0
+cmd:if cat /etc/*release |grep SUSE >/dev/null;then cat /var/lib/dhcp/db/dhcpd.leases|grep $$SN;elif cat /etc/*release |grep "Red Hat" >/dev/null;then cat /var/lib/dhcpd/dhcpd.leases|grep $$SN;fi
+check:output=~$$SN
+cmd:chdef -t node $$SN groups=service,all
+check:rc==0
+cmd:chdef -t group -o service profile=service  primarynic=mac installnic=mac
+check:rc==0
+cmd:chdef -t group -o service setupnfs=1 setupdhcp=1 setuptftp=1 setupnameserver=1 setupconserver=1 setupntp=1
+check:rc==0
+cmd:chdef -t group -o service nfsserver=$$MN tftpserver=$$MN xcatmaster=$$MN monserver=$$MN
+check:rc==0
+cmd:chtab node=service postscripts.postscripts="servicenode"
+check:rc==0
+
+cmd:if ! lsdef -t osimage |grep -q __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-netboot-compute; then copycds $$ISO; fi
+check:rc==0
+
+cmd:chdef -t site clustersite installloc="/install"
+check:rc==0
+
+
+cmd:cd /install/post/otherpkgs/__GETNODEATTR($$SN,os)__/__GETNODEATTR($$SN,arch)__/xcat/xcat-core && createrepo .
+check:rc==0
+
+cmd:if [[ "__GETNODEATTR($$SN,os)__" =~ "rh" ]]; then path="rh";elif [[ "__GETNODEATTR($$SN,os)__" =~ "sles" ]];then path="sles";fi; ver="__GETNODEATTR($$SN,os)__"; tmp=${ver%.*};ver=`echo "$tmp"|sed 's:[a-zA-Z]::g'`;cd /install/post/otherpkgs/__GETNODEATTR($$SN,os)__/__GETNODEATTR($$SN,arch)__/xcat/xcat-dep/$path$ver/__GETNODEATTR($$SN,arch)__ && createrepo .;
+check:rc==0
+
+cmd:mkdef -t osimage -o __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-netboot-service --template __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-netboot-compute  profile=service provmethod=netboot postscripts=servicenode
+check:rc==0
+
+cmd:chdef -t osimage __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-netboot-service otherpkgdir=/install/post/otherpkgs/__GETNODEATTR($$SN,os)__/__GETNODEATTR($$SN,arch)__
+check:rc==0
+
+cmd:if [[ "__GETNODEATTR($$SN,os)__" =~ "rh" ]]; then path="rh";elif [[ "__GETNODEATTR($$SN,os)__" =~ "sles" ]];then path="sles";fi; ver="__GETNODEATTR($$SN,os)__"; chdef -t osimage __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-netboot-service otherpkglist=/opt/xcat/share/xcat/netboot/$path/service.${ver%.*}.__GETNODEATTR($$SN,arch)__.otherpkgs.pkglist pkglist=/opt/xcat/share/xcat/netboot/$path/service.${ver%.*}.__GETNODEATTR($$SN,arch)__.pkglist exlist=/opt/xcat/share/xcat/netboot/$path/service.${ver%.*}.__GETNODEATTR($$SN,arch)__.exlist postinstall=/opt/xcat/share/xcat/netboot/$path/service.${ver%.*}.__GETNODEATTR($$SN,arch)__.postinstall; echo "xcat/xcat-core/xCAT-openbmc-py" >> /opt/xcat/share/xcat/netboot/$path/service.${ver%.*}.__GETNODEATTR($$SN,arch)__.otherpkgs.pkglist; cat /opt/xcat/share/xcat/netboot/$path/service.${ver%.*}.__GETNODEATTR($$SN,arch)__.otherpkgs.pkglist
+check:rc==0
+
+
+cmd:path="/install/netboot/__GETNODEATTR($$SN,os)__/__GETNODEATTR($$SN,arch)__/service"; if [ -d "$path" ]; then mv $path $path."org"; fi; mkdir -p $path 
+check:rc==0
+cmd:chdef -t osimage __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-netboot-service rootimgdir=/install/netboot/__GETNODEATTR($$SN,os)__/__GETNODEATTR($$SN,arch)__/service
+check:rc==0
+
+cmd:chdef -t osimage __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-netboot-service -p pkgdir=$$PYTHON_DEP_EPEL_DIR,$$PYTHON_DEP_EXTRAS_DIR,$$PYTHON_DEP_FED_DIR
+check:rc==0
+
+cmd:lsdef -t osimage __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-netboot-service
+check:rc==0
+
+
+cmd:if [ ! -d /tmp/mountoutput ]; then mkdir -p /tmp/mountoutput; fi
+cmd:mount |sort > /tmp/mountoutput/file.org
+
+cmd:genimage __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-netboot-service 
+check:rc==0
+
+cmd:mount |sort > /tmp/mountoutput/file.new
+cmd:diff -y /tmp/mountoutput/file.org /tmp/mountoutput/file.new
+check:rc==0
+cmd:rm -rf /tmp/mountoutput
+
+cmd:packimage __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-netboot-service 
+check:rc==0
+
+cmd:rinstall $$SN osimage=__GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-netboot-service
+check:rc==0
+check:output=~Provision node\(s\)\: $$SN
+
+
+cmd:if [[ -f /var/lib/dhcp/db/dhcpd.leases ]]; then cat /var/lib/dhcp/db/dhcpd.leases; elif [[ -f /var/lib/dhcpd/dhcpd.leases ]];then cat /var/lib/dhcpd/dhcpd.leases;elif [[ -f /var/lib/dhcp/dhcpd.leases ]];then cat /var/lib/dhcp/dhcpd.leases; fi
+
+cmd:sleep 180
+
+cmd:a=0;while ! `lsdef -l $$SN|grep status|grep booted >/dev/null`; do sleep 10;((a++));if [ $a -gt 60 ];then break;fi done
+
+cmd:ping $$SN -c 3
+check:rc==0
+check:output=~64 bytes from $$SN
+cmd:lsdef -l $$SN | grep status
+check:rc==0
+check:output=~booted
+cmd:xdsh $$SN date
+check:rc==0
+check:output=~\d\d:\d\d:\d\d
+cmd:xdsh $$SN mount
+check:rc==0
+check:output=~on / type tmpfs
+cmd:xdsh $$SN rpm -qa|grep "xCAT-openbmc-py"
+check:rc==0
+check:output=~xCAT-openbmc-py-\d
+cmd:xdsh $$SN rpm -qa|grep "gevent"
+check:rc==0
+check:output=~ gevent-\d
+cmd:xdsh $$SN "service httpd status"
+check:rc==0
+cmd:xdsh $$SN "service systemd status"
+#check:rc==0
+
+cmd:rootimgdir=`lsdef -t osimage  __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-netboot-service|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir.org ]; then rm -rf $rootimgdir; mv $rootimgdir.org $rootimgdir; fi
+check:rc==0
+cmd:xdsh $$SN  "cat /var/log/xcat/xcat.log"
+end

--- a/xCAT-test/autotest/testcase/pythonsupport/cases0
+++ b/xCAT-test/autotest/testcase/pythonsupport/cases0
@@ -1,43 +1,40 @@
 start:set_up_env_for_support_openbmc_in_python
 description:this case is used to test environment setup for supporting openbmc in python
 os:Linux
-hcp:openbmc
+hcp:openbmc,kvm
 cmd:mkdir -p /tmp/set_up_env_for_support_openbmc_in_python
 check:rc==0
-cmd: wget https://bootstrap.pypa.io/get-pip.py --retry-connrefused  -O /tmp/set_up_env_for_support_openbmc_in_python/get-pip.py
+cmd:#!/usr/bin/bash
+echo "[xcat-python-dep-EPEL]
+name=epel generated repo
+baseurl=file://__REPLACE_PATH__EPEL__
+enabled=1
+gpgcheck=0
+
+[xcat-python-dep-EXTRAS]
+name=extras generated repo
+baseurl=file://__REPLACE_PATH__EXTRAS__
+enabled=1
+gpgcheck=0
+
+[xcat-python-dep-FEDORA28]
+name=FC28 generated repo
+baseurl=file://__REPLACE_PATH__FED__
+enabled=1
+gpgcheck=0" > /etc/yum.repos.d/xcat-dep-python-local.repo
 check:rc==0
-cmd:python /tmp/set_up_env_for_support_openbmc_in_python/get-pip.py
+cmd:sed -i "s|__REPLACE_PATH__EPEL__|$$PYTHON_DEP_EPEL_DIR|g" /etc/yum.repos.d/xcat-dep-python-local.repo
 check:rc==0
-cmd:yum -y install gcc python-devel libffi-devel openssl-devel
+cmd:sed -i "s|__REPLACE_PATH__EXTRAS__|$$PYTHON_DEP_EXTRAS_DIR|g" /etc/yum.repos.d/xcat-dep-python-local.repo
 check:rc==0
-cmd:rpm -qa |grep "^gcc-"
-check:output=~ gcc-\d
+cmd:sed -i "s|__REPLACE_PATH__FED__|$$PYTHON_DEP_FED_DIR|" /etc/yum.repos.d/xcat-dep-python-local.repo
 check:rc==0
-cmd:rpm -qa|grep "^python-devel"
-check:output=~ python-devel-\d
+cmd: cat /etc/yum.repos.d/xcat-dep-python-local.repo
 check:rc==0
-cmd:rpm -qa|grep "^libffi-devel"
-check:output=~ libffi-devel-\d 
+cmd:yum install -y  xCAT-openbmc-py  
 check:rc==0
-cmd:rpm -qa|grep "^openssl-devel"
-check:output=~ openssl-devel-\d
-check:rc==0
-cmd:pip install gevent docopt requests paramiko  scp 
-check:rc==0
-cmd:pip list 2>/dev/null | grep "^gevent"
-check:output=~ gevent \(\d
-check:rc==0 
-cmd:pip list 2>/dev/null | grep "^docopt"
-check:output=~ docopt \(\d
-check:rc==0
-cmd:pip list 2>/dev/null | grep "^requests"
-check:output=~ requests \(\d
-check:rc==0
-cmd:pip list 2>/dev/null | grep "^paramiko"
-check:output=~ paramiko \(\d
-check:rc==0
-cmd:pip list 2>/dev/null | grep "^scp"
-check:output=~ scp \(\d
+cmd:rpm -qa|grep "^xCAT-openbmc-py"
+check:output=~ xCAT-openbmc-py-\d
 check:rc==0
 cmd:rm -rf /tmp/set_up_env_for_support_openbmc_in_python
 check:rc==0


### PR DESCRIPTION
This pull request adds 2 test cases,  diskless SN installation and python environment setup.
The related task is xcat2/xcat2-task-management#15

The UT is 
```
------START::SN_diskless_setup_case::Time:Fri Mar 30 05:38:26 2018------

RUN:fdisk -l [Fri Mar 30 05:38:26 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

Disk /dev/sda: 42.9 GB, 42949672960 bytes, 83886080 sectors
Units = sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disk label type: dos
Disk identifier: 0x000b804e

   Device Boot      Start         End      Blocks   Id  System
/dev/sda1   *        2048       18431        8192   41  PPC PReP Boot
/dev/sda2           18432     1067007      524288   83  Linux
/dev/sda3         1067008     9455615     4194304   82  Linux swap / Solaris
/dev/sda4         9455616    83886079    37215232    5  Extended
/dev/sda5         9457664    83886079    37214208   8e  Linux LVM

Disk /dev/mapper/system-root: 38.1 GB, 38105251840 bytes, 74424320 sectors
Units = sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes


RUN:df -T [Fri Mar 30 05:38:26 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Filesystem                           Type      1K-blocks       Used  Available Use% Mounted on
devtmpfs                             devtmpfs    1804160          0    1804160   0% /dev
tmpfs                                tmpfs       1817664          0    1817664   0% /dev/s 
....
tmpfs                                tmpfs        363584          0     363584   0% /run/user/0

RUN:XCAT_DATABASE=PostgreSQL /opt/xcat/share/xcat/tools/autotest/testcase/installation/pre_deploy_sn __GETNODEATTR(f6u13k11,os)__  __GETNODEATTR(f6u13k11,arch)__ [Fri Mar 30 05:38:26 2018]
ElapsedTime:5 sec
RETURN rc = 0
OUTPUT:
>>>To run: XCATPGPW=12345 /opt/xcat/bin/pgsqlsetup -i -V  [Fri Mar 30 05:38:27 2018]
Running command on f6u13k10: rpm -qa | grep perl-DBD-Pg 2>&1

Running command on f6u13k10: rpm -qa | grep postgresql | grep server 2>&1

Running command on f6u13k10: ps -ef | grep postgres 2>&1

Running command on f6u13k10: fgrep Pg /etc/xcat/cfgloc 2>&1

The /etc/xcat/cfgloc file is already configured for PostgreSQL. xcat database initialization will not take place.
>>>Run: XCATPGPW=12345 /opt/xcat/bin/pgsqlsetup -i -V ....[ok]
>>>To run: service postgresql restart  [Fri Mar 30 05:38:28 2018]
Redirecting to /bin/systemctl restart postgresql.service
>>>Run: service postgresql restart ....[ok]
>>>To run: mkdir -p /install/post/otherpkgs/rhels7.5-alternate/ppc64le/xcat/xcat-core && cp -r /xcat-core/* /install/post/otherpkgs/rhels7.5-alternate/ppc64le/xcat/xcat-core && cp -r /xcat-dep /install/post/otherpkgs/rhels7.5-alternate/ppc64le/xcat  [Fri Mar 30 05:38:30 2018]
>>>Run: mkdir -p /install/post/otherpkgs/rhels7.5-alternate/ppc64le/xcat/xcat-core && cp -r /xcat-core/* /install/post/otherpkgs/rhels7.5-alternate/ppc64le/xcat/xcat-core && cp -r /xcat-dep /install/post/otherpkgs/rhels7.5-alternate/ppc64le/xcat ....[ok]
CHECK:rc == 0	[Pass]

RUN:chtab key=nameservers site.value="<xcatmaster>" [Fri Mar 30 05:38:31 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:makedns -n [Fri Mar 30 05:38:31 2018]
ElapsedTime:4 sec
RETURN rc = 0
OUTPUT:
Handling c910f03c09k03 in /etc/hosts.
......
Handling c910f03c09k05 in /etc/hosts.
Getting reverse zones, this may take several minutes for a large cluster.
Completed getting reverse zones.
Updating zones.
Completed updating zones.
Restarting named
Restarting named complete
Updating DNS records, this may take several minutes for a large cluster.
Completed updating DNS records.
DNS setup is completed
CHECK:rc == 0	[Pass]

RUN:makeconservercf f6u13k11 [Fri Mar 30 05:38:35 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:cat /etc/conserver.cf | grep f6u13k11 [Fri Mar 30 05:38:35 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
#xCAT BEGIN f6u13k11 CONS
console f6u13k11 {
  exec /opt/xcat/share/xcat/cons/kvm f6u13k11;
#xCAT END f6u13k11 CONS
CHECK:output =~ f6u13k11	[Pass]

RUN:sleep 20 [Fri Mar 30 05:38:35 2018]
ElapsedTime:20 sec
RETURN rc = 0
OUTPUT:

RUN:if [[ "__GETNODEATTR(f6u13k11,arch)__" = "ppc64" ]]; then getmacs -D f6u13k11 -V; fi [Fri Mar 30 05:38:55 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:makedhcp -n [Fri Mar 30 05:38:56 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Warning: No dynamic range specified for 10.0.0.0. If hardware discovery is being used, a dynamic range is required.
Renamed existing dhcp configuration file to  /etc/dhcp/dhcpd.conf.xcatbak

The dhcp server must be restarted for OMAPI function to work
CHECK:rc == 0	[Pass]

RUN:makedhcp -a [Fri Mar 30 05:38:56 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:if cat /etc/*release |grep SUSE >/dev/null;then cat /var/lib/dhcp/db/dhcpd.leases|grep f6u13k11;elif cat /etc/*release |grep "Red Hat" >/dev/null;then cat /var/lib/dhcpd/dhcpd.leases|grep f6u13k11;fi [Fri Mar 30 05:38:56 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
host f6u13k11 {
        supersede server.ddns-hostname = "f6u13k11";
        supersede host-name = "f6u13k11";
        supersede server.filename = "/boot/grub2/grub2-f6u13k11";
host f6u13k11-noip42c80a060d0b {
host f6u13k11-noip425b0a060d0b {
CHECK:output =~ f6u13k11	[Pass]

RUN:chdef -t node f6u13k11 groups=service,all [Fri Mar 30 05:38:56 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:chdef -t group -o service profile=service  primarynic=mac installnic=mac [Fri Mar 30 05:38:57 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:chdef -t group -o service setupnfs=1 setupdhcp=1 setuptftp=1 setupnameserver=1 setupconserver=1 setupntp=1 [Fri Mar 30 05:38:57 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:chdef -t group -o service nfsserver=f6u13k10 tftpserver=f6u13k10 xcatmaster=f6u13k10 monserver=f6u13k10 [Fri Mar 30 05:38:58 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:chtab node=service postscripts.postscripts="servicenode" [Fri Mar 30 05:38:58 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:if ! lsdef -t osimage |grep -q __GETNODEATTR(f6u13k11,os)__-__GETNODEATTR(f6u13k11,arch)__-netboot-compute; then copycds /Pegas-7.5-Server-ppc64le-dvd1-stable.iso; fi [Fri Mar 30 05:38:58 2018]
ElapsedTime:35 sec
RETURN rc = 0
OUTPUT:
Copying media to /install/rhels7.5-alternate/ppc64le
Media copy operation successful
CHECK:rc == 0	[Pass]

RUN:chdef -t site clustersite installloc="/install" [Fri Mar 30 05:39:33 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:cd /install/post/otherpkgs/__GETNODEATTR(f6u13k11,os)__/__GETNODEATTR(f6u13k11,arch)__/xcat/xcat-core && createrepo . [Fri Mar 30 05:39:33 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
Spawning worker 0 with 11 pkgs
Spawning worker 1 with 10 pkgs
Workers Finished
Saving Primary metadata
Saving file lists metadata
Saving other metadata
Generating sqlite DBs
Sqlite DBs complete
CHECK:rc == 0	[Pass]

RUN:if [[ "__GETNODEATTR(f6u13k11,os)__" =~ "rh" ]]; then path="rh";elif [[ "__GETNODEATTR(f6u13k11,os)__" =~ "sles" ]];then path="sles";fi; ver="__GETNODEATTR(f6u13k11,os)__"; tmp=${ver%.*};ver=`echo "$tmp"|sed 's:[a-zA-Z]::g'`;cd /install/post/otherpkgs/__GETNODEATTR(f6u13k11,os)__/__GETNODEATTR(f6u13k11,arch)__/xcat/xcat-dep/$path$ver/__GETNODEATTR(f6u13k11,arch)__ && createrepo .; [Fri Mar 30 05:39:35 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
Spawning worker 0 with 17 pkgs
Spawning worker 1 with 16 pkgs
Workers Finished
Saving Primary metadata
Saving file lists metadata
Saving other metadata
Generating sqlite DBs
Sqlite DBs complete
CHECK:rc == 0	[Pass]

RUN:mkdef -t osimage -o __GETNODEATTR(f6u13k11,os)__-__GETNODEATTR(f6u13k11,arch)__-netboot-service --template __GETNODEATTR(f6u13k11,os)__-__GETNODEATTR(f6u13k11,arch)__-netboot-compute  profile=service provmethod=netboot postscripts=servicenode [Fri Mar 30 05:39:37 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:chdef -t osimage __GETNODEATTR(f6u13k11,os)__-__GETNODEATTR(f6u13k11,arch)__-netboot-service otherpkgdir=/install/post/otherpkgs/__GETNODEATTR(f6u13k11,os)__/__GETNODEATTR(f6u13k11,arch)__ [Fri Mar 30 05:39:39 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:if [[ "__GETNODEATTR(f6u13k11,os)__" =~ "rh" ]]; then path="rh";elif [[ "__GETNODEATTR(f6u13k11,os)__" =~ "sles" ]];then path="sles";fi; ver="__GETNODEATTR(f6u13k11,os)__"; chdef -t osimage __GETNODEATTR(f6u13k11,os)__-__GETNODEATTR(f6u13k11,arch)__-netboot-service otherpkglist=/opt/xcat/share/xcat/netboot/$path/service.${ver%.*}.__GETNODEATTR(f6u13k11,arch)__.otherpkgs.pkglist pkglist=/opt/xcat/share/xcat/netboot/$path/service.${ver%.*}.__GETNODEATTR(f6u13k11,arch)__.pkglist exlist=/opt/xcat/share/xcat/netboot/$path/service.${ver%.*}.__GETNODEATTR(f6u13k11,arch)__.exlist postinstall=/opt/xcat/share/xcat/netboot/$path/service.${ver%.*}.__GETNODEATTR(f6u13k11,arch)__.postinstall; echo "xcat/xcat-core/xCAT-openbmc-py" >> /opt/xcat/share/xcat/netboot/$path/service.${ver%.*}.__GETNODEATTR(f6u13k11,arch)__.otherpkgs.pkglist; cat /opt/xcat/share/xcat/netboot/$path/service.${ver%.*}.__GETNODEATTR(f6u13k11,arch)__.otherpkgs.pkglist [Fri Mar 30 05:39:40 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
xcat/xcat-core/xCATsn
xcat/xcat-dep/rh7/ppc64le/conserver-xcat
xcat/xcat-dep/rh7/ppc64le/perl-Net-Telnet
xcat/xcat-dep/rh7/ppc64le/perl-Expect
xcat/xcat-core/xCAT-openbmc-py
CHECK:rc == 0	[Pass]

RUN:path="/install/netboot/__GETNODEATTR(f6u13k11,os)__/__GETNODEATTR(f6u13k11,arch)__/service"; if [ -d "$path" ]; then mv $path $path."org"; fi; mkdir -p $path [Fri Mar 30 05:39:41 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:chdef -t osimage __GETNODEATTR(f6u13k11,os)__-__GETNODEATTR(f6u13k11,arch)__-netboot-service rootimgdir=/install/netboot/__GETNODEATTR(f6u13k11,os)__/__GETNODEATTR(f6u13k11,arch)__/service [Fri Mar 30 05:39:42 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:chdef -t osimage __GETNODEATTR(f6u13k11,os)__-__GETNODEATTR(f6u13k11,arch)__-netboot-service -p pkgdir=/tmp/automation_mountpoint/iso/python_dep_internal/epel/ppc64le,/tmp/automation_mountpoint/iso/python_dep_internal/extras/ppc64le,/tmp/automation_mountpoint/iso/python_dep_internal/fedora28/ppc64le [Fri Mar 30 05:39:43 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:lsdef -t osimage __GETNODEATTR(f6u13k11,os)__-__GETNODEATTR(f6u13k11,arch)__-netboot-service [Fri Mar 30 05:39:45 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Object name: rhels7.5-alternate-ppc64le-netboot-service
    exlist=/opt/xcat/share/xcat/netboot/rh/service.rhels7.ppc64le.exlist
    imagetype=linux
    osarch=ppc64le
    osdistroname=rhels7.5-alternate-ppc64le
    osname=Linux
    osvers=rhels7.5-alternate
    otherpkgdir=/install/post/otherpkgs/rhels7.5-alternate/ppc64le
    otherpkglist=/opt/xcat/share/xcat/netboot/rh/service.rhels7.ppc64le.otherpkgs.pkglist
    pkgdir=/install/rhels7.5-alternate/ppc64le,/tmp/automation_mountpoint/iso/python_dep_internal/epel/ppc64le,/tmp/automation_mountpoint/iso/python_dep_internal/extras/ppc64le,/tmp/automation_mountpoint/iso/python_dep_internal/fedora28/ppc64le
    pkglist=/opt/xcat/share/xcat/netboot/rh/service.rhels7.ppc64le.pkglist
    postinstall=/opt/xcat/share/xcat/netboot/rh/service.rhels7.ppc64le.postinstall
    postscripts=servicenode
    profile=service
    provmethod=netboot
    rootimgdir=/install/netboot/rhels7.5-alternate/ppc64le/service
CHECK:rc == 0	[Pass]

RUN:if [ ! -d /tmp/mountoutput ]; then mkdir -p /tmp/mountoutput; fi [Fri Mar 30 05:39:46 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:mount |sort > /tmp/mountoutput/file.org [Fri Mar 30 05:39:46 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:genimage __GETNODEATTR(f6u13k11,os)__-__GETNODEATTR(f6u13k11,arch)__-netboot-service [Fri Mar 30 05:39:46 2018]
ElapsedTime:213 sec
RETURN rc = 0
OUTPUT:
Generating image:
cd /opt/xcat/share/xcat/netboot/rh; ./genimage -a ppc64le -o rhels7.5-alternate -p service --srcdir "/install/rhels7.5-alternate/ppc64le,/tmp/automation_mountpoint/iso/python_dep_internal/epel/ppc64le,/tmp/automation_mountpoint/iso/python_dep_internal/extras/ppc64le,/tmp/automation_mountpoint/iso/python_dep_internal/fedora28/ppc64le" --pkglist /opt/xcat/share/xcat/netboot/rh/service.rhels7.ppc64le.pkglist --otherpkgdir "/install/post/otherpkgs/rhels7.5-alternate/ppc64le" --otherpkglist /opt/xcat/share/xcat/netboot/rh/service.rhels7.ppc64le.otherpkgs.pkglist --postinstall /opt/xcat/share/xcat/netboot/rh/service.rhels7.ppc64le.postinstall --rootimgdir /install/netboot/rhels7.5-alternate/ppc64le/service --tempfile /tmp/xcat_genimage.13682 rhels7.5-alternate-ppc64le-netboot-service
91 blocks
/opt/xcat/share/xcat/netboot/rh
91 blocks
/opt/xcat/share/xcat/netboot/rh
 yum -y -c /tmp/genimage.13697.yum.conf --installroot=/install/netboot/rhels7.5-alternate/ppc64le/service/rootimg/ --disablerepo=* --enablerepo=rhels7.5-alternate-ppc64le-0 --enablerepo=rhels7.5-alternate-ppc64le-1 --enablerepo=rhels7.5-alternate-ppc64le-2 --enablerepo=rhels7.5-alternate-ppc64le-3  install  bash bc bind bind-utils busybox bzip2 cronie dhclient dhcp dracut dracut-network e2fsprogs expect gzip httpd iputils irqbalance kernel ksh lsvpd mysql-connector-odbc net-snmp-perl nfs-utils ntp openssh-clients openssh-server openssl parted perl-DBD-MySQL perl-DBD-Pg perl-IO-Socket-SSL perl-Net-Telnet perl-XML-Parser perl-XML-Simple postgresql postgresql-server ppc64-utils procps rootfiles rpm rsync tar unixODBC vim-minimal vsftpd wget xz rsyslog ethtool
No package busybox available.
No package net-snmp-perl available.
No package perl-Net-Telnet available.
Resolving Dependencies
--> Running transaction check
---> Package bash.ppc64le 0:4.2.46-30.el7 will be installed
--> Processing Dependency: libdl.so.2(GLIBC_2.17)(64bit) for package: bash-4.2.46-30.el7.ppc64le
--> Processing Dependency: rtld(GNU_HASH) for package: bash-4.2.46-30.el7.ppc64le
--> Processing Dependency: libc.so.6(GLIBC_2.17)(64bit) for package: bash-4.2.46-30.el7.ppc64le
--> Processing Dependency: libdl.so.2()(64bit) for package: bash-4.2.46-30.el7.ppc64le
--> Processing Dependency: libtinfo.so.5()(64bit) for package: bash-4.2.46-30.el7.ppc64le
---> Package bc.ppc64le 0:1.06.95-13.el7 will be installed
--> Processing Dependency: /sbin/install-info for package: bc-1.06.95-13.el7.ppc64le
--> Processing Dependency: /sbin/install-info for package: bc-1.06.95-13.el7.ppc64le
--> Processing Dependency: libreadline.so.6()(64bit) for package: bc-1.06.95-13.el7.ppc64le
---> Package bind.ppc64le 32:9.9.4-61.el7 will be installed
...........
--> Finished Dependency Resolution
Dependencies Resolved
================================================================================
 Package            Arch    Version          Repository                    Size
================================================================================
Installing:
 bash               ppc64le 4.2.46-30.el7    rhels7.5-alternate-ppc64le-0 1.0 M
 bc                 ppc64le 1.06.95-13.el7   rhels7.5-alternate-ppc64le-0 117 k
 bind               ppc64le 32:9.9.4-61.el7  rhels7.5-alternate-ppc64le-0 1.8 M
...........
 zlib               ppc64le 1.2.7-17.el7     rhels7.5-alternate-ppc64le-0  97 k
Transaction Summary
================================================================================
Install  46 Packages (+281 Dependent packages)
Total download size: 229 M
Installed size: 957 M
Downloading packages:
--------------------------------------------------------------------------------
Total                                              172 MB/s | 229 MB  00:01
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : libgcc-4.8.5-28.el7.ppc64le                                1/327
  Installing : redhat-release-server-7.5-7.el7a.ppc64le                   2/327
  Installing : setup-2.8.71-9.el7.noarch                                  3/327
  .....
  Installing : 2:ethtool-4.8-7.el7.ppc64le                              326/327
  Installing : rootfiles-8.1-11.el7.noarch                              327/327
Turning off host-only mode: '/run' is not mounted!
Turning off host-only mode: '/dev' is not mounted!
  Verifying  : vsftpd-3.0.2-22.el7.ppc64le                                1/327
  Verifying  : perl-HTTP-Tiny-0.033-3.el7.noarch                          2/327
  .................
  Verifying  : libevent-2.0.21-4.el7.ppc64le                            326/327
  Verifying  : elfutils-default-yama-scope-0.170-4.el7.noarch           327/327
Installed:
  bash.ppc64le 0:4.2.46-30.el7
  bc.ppc64le 0:1.06.95-13.el7
  ..........
  zlib.ppc64le 0:1.2.7-17.el7
Complete!
Cleaning repos: otherpkgs1 otherpkgs2 rhels7.5-alternate-ppc64le-0
              : rhels7.5-alternate-ppc64le-1 rhels7.5-alternate-ppc64le-2
              : rhels7.5-alternate-ppc64le-3
Cleaning up everything
 yum -y -c /tmp/genimage.13697.yum.conf --installroot=/install/netboot/rhels7.5-alternate/ppc64le/service/rootimg/ --disablerepo=* --enablerepo=rhels7.5-alternate-ppc64le-0 --enablerepo=rhels7.5-alternate-ppc64le-1 --enablerepo=rhels7.5-alternate-ppc64le-2 --enablerepo=rhels7.5-alternate-ppc64le-3 --enablerepo=otherpkgs1 --enablerepo=otherpkgs2 install   conserver-xcat perl-Net-Telnet perl-Expect xCATsn xCAT-openbmc-py
Resolving Dependencies
--> Running transaction check
---> Package conserver-xcat.ppc64le 0:8.2.1-1 will be installed
............
---> Package trousers.ppc64le 0:0.3.14-2.el7 will be installed
--> Finished Dependency Resolution
Dependencies Resolved
================================================================================
 Package             Arch    Version         Repository                    Size
================================================================================
Installing:
 conserver-xcat      ppc64le 8.2.1-1         otherpkgs1                   184 k
 perl-Expect         noarch  1.21-1          otherpkgs1                    71 k
 ..........
 xCAT-probe          noarch  4:2.14-snap201803300510
                                             otherpkgs2                    86 k
 xCAT-server         noarch  4:2.14-snap201803300510
                                             otherpkgs2                   1.7 M
 xnba-undi           noarch  1.0.3-131028    otherpkgs1                   151 k
 yajl                ppc64le 2.0.4-4.el7     rhels7.5-alternate-ppc64le-0  37 k
Transaction Summary
================================================================================
Install  5 Packages (+76 Dependent packages)
Total download size: 206 M
Installed size: 748 M
Downloading packages:
--------------------------------------------------------------------------------
Total                                              199 MB/s | 206 MB  00:01
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : python-ipaddress-1.0.16-2.el7.noarch                        1/81
  Installing : perl-Sys-Syslog-0.33-3.el7.ppc64le                          2/81
  Installing : 1:net-snmp-libs-5.7.2-32.el7.ppc64le                        3/81
  Installing : python-six-1.9.0-2.el7.noarch                               4/81
  Installing : perl-IO-Tty-1.07-1.ppc64le                                  5/81
  Installing : perl-Expect-1.21-1.noarch                                   6/81
  Installing : python2-greenlet-0.4.13-2.fc28.ppc64le                      7/81
  Installing : 14:libpcap-1.5.3-11.el7.ppc64le                             8/81
  Installing : 2:nmap-ncat-6.40-13.el7.ppc64le                             9/81
  Installing : 2:nmap-6.40-13.el7.ppc64le                                 10/81
  Installing : perl-JSON-2.59-2.el7.noarch                                11/81
  Installing : 1:perl-XML-LibXML-2.0018-5.el7.ppc64le                     12/81
  Installing : cyrus-sasl-2.1.26-23.el7.ppc64le                           13/81
  Installing : cyrus-sasl-gssapi-2.1.26-23.el7.ppc64le                    14/81
  Installing : perl-Crypt-CBC-2.33-2.el7.noarch                           15/81
  Installing : python-chardet-2.2.1-1.el7_1.noarch                        16/81
  Installing : c-ares-1.10.0-3.el7.ppc64le                                17/81
  Installing : perl-HTML-Form-6.03-6.el7.noarch                           18/81
  Installing : yajl-2.0.4-4.el7.ppc64le                                   19/81
  Installing : ipmitool-xcat-1.8.18-0.ppc64le                             20/81
  Installing : perl-Crypt-Rijndael-1.09-2.ael7a.ppc64le                   21/81
  Installing : perl-HTTP-Async-0.30-2.noarch                              22/81
  Installing : grub2-xcat-2.02-0.16.el7.snap201506090204.noarch           23/81
  Installing : python-ply-3.4-11.el7.noarch                               24/81
  Installing : python-pycparser-2.14-1.el7.noarch                         25/81
  Installing : python-cffi-1.6.0-5.el7.ppc64le                            26/81
  Installing : net-tools-2.0-0.22.20131004git.el7.ppc64le                 27/81
  Installing : xnba-undi-1.0.3-131028.noarch                              28/81
  Installing : trousers-0.3.14-2.el7.ppc64le                              29/81
  Installing : lm_sensors-libs-3.4.0-4.20160601gitf9185e5.el7.ppc64le     30/81
  Installing : 1:net-snmp-agent-libs-5.7.2-32.el7.ppc64le                 31/81
  Installing : 1:net-snmp-perl-5.7.2-20.ael7b.ppc64le                     32/81
  Installing : 2:xCAT-genesis-base-x86_64-2.14-snap201803282249.noarch    33/81
  Installing : 1:xCAT-genesis-scripts-x86_64-2.14-snap201803300510.noar   34/81
If you are installing/updating xCAT-genesis-base separately, not as part of installing/updating all of xCAT, run 'mknb <arch>' manually
  Installing : nettle-2.7.1-8.el7.ppc64le                                 35/81
  Installing : gnutls-3.3.26-9.el7.ppc64le                                36/81
  Installing : perl-Crypt-SSLeay-0.64-5.el7.ppc64le                       37/81
  Installing : goconserver-0.2.2-snap201803292225.ppc64le                 38/81
  Installing : 2:xCAT-genesis-base-ppc64-2.14-snap201803282253.noarch     39/81
  Installing : 1:xCAT-genesis-scripts-ppc64-2.14-snap201803300510.noarc   40/81
If you are installing/updating xCAT-genesis-base separately, not as part of installing/updating all of xCAT, run 'mknb <arch>' manually
  Installing : elilo-xcat-3.14-4.noarch                                   41/81
  Installing : python2-pyasn1-0.1.9-7.el7.noarch                          42/81
  Installing : python-idna-2.4-1.el7.noarch                               43/81
  Installing : perl-DBD-SQLite-1.39-3.el7.ppc64le                         44/81
  Installing : conserver-xcat-8.2.1-1.ppc64le                             45/81
  Installing : syslinux-xcat-3.86-2.noarch                                46/81
  Installing : perl-Net-Telnet-3.03-19.el7.noarch                         47/81
  Installing : perl-DB_File-1.830-6.el7.ppc64le                           48/81
  Installing : tftp-server-5.2-22.el7.ppc64le                             49/81
  Installing : psmisc-22.20-15.el7.ppc64le                                50/81
  Installing : 1:perl-FCGI-0.74-8.el7.ppc64le                             51/81
  Installing : perl-CGI-3.63-4.el7.noarch                                 52/81
  Installing : perl-IO-Stty-0.03-1.noarch                                 53/81
  Installing : 1:perl-Digest-SHA-5.85-4.el7.ppc64le                       54/81
  Installing : perl-Digest-HMAC-1.03-5.el7.noarch                         55/81
  Installing : perl-Net-DNS-0.72-6.el7.ppc64le                            56/81
  Installing : perl-LWP-Protocol-https-6.04-4.el7.noarch                  57/81
  Installing : python-backports-1.0-8.el7.ppc64le                         58/81
  Installing : python-backports-ssl_match_hostname-3.5.0.1-1.el7.noarch   59/81
  Installing : python-setuptools-0.9.8-7.el7.noarch                       60/81
  Installing : python-urllib3-1.10.2-5.el7.noarch                         61/81
  Installing : python-requests-2.6.0-1.el7_1.noarch                       62/81
  Installing : python-enum34-1.0.4-1.el7.noarch                           63/81
  Installing : python2-cryptography-1.7.2-2.el7.ppc64le                   64/81
  Installing : python-paramiko-2.1.1-2.el7.noarch                         65/81
  Installing : python-scp-0.7.1-3.el7.noarch                              66/81
  Installing : python2-docopt-0.6.2-7.el7.noarch                          67/81
  Installing : libnl3-3.2.28-4.el7.ppc64le                                68/81
  Installing : libvirt-libs-3.9.0-14.el7.ppc64le                          69/81
  Installing : perl-Sys-Virt-3.9.0-2.el7.ppc64le                          70/81
  Installing : tftp-5.2-22.el7.ppc64le                                    71/81
  Installing : 4:xCAT-probe-2.14-snap201803300510.noarch                  72/81
  Installing : perl-Digest-SHA1-2.13-9.el7.ppc64le                        73/81
  Installing : libev-4.15-7.el7.ppc64le                                   74/81
  Installing : python2-gevent-1.2.2-2.fc28.ppc64le                        75/81
  Installing : perl-Net-HTTPS-NB-0.14-2.noarch                            76/81
  Installing : 4:xCAT-client-2.14-snap201803300510.noarch                 77/81
  Installing : 4:xCAT-server-2.14-snap201803300510.noarch                 78/81
  Installing : 4:perl-xCAT-2.14-snap201803300510.noarch                   79/81
  Installing : 4:xCATsn-2.14-snap201803300510.ppc64le                     80/81
Created symlink /etc/systemd/system/multi-user.target.wants/httpd.service, pointing to /usr/lib/systemd/system/httpd.service.
xCATsn is now installed
  Installing : 1:xCAT-openbmc-py-2.14-snap201803300511.noarch             81/81
  Verifying  : 1:perl-XML-LibXML-2.0018-5.el7.ppc64le                      1/81
  Verifying  : perl-Net-HTTPS-NB-0.14-2.noarch                             2/81
  Verifying  : python-backports-ssl_match_hostname-3.5.0.1-1.el7.noarch    3/81
  Verifying  : perl-JSON-2.59-2.el7.noarch                                 4/81
  Verifying  : python2-cryptography-1.7.2-2.el7.ppc64le                    5/81
  Verifying  : 1:net-snmp-perl-5.7.2-20.ael7b.ppc64le                      6/81
  Verifying  : libev-4.15-7.el7.ppc64le                                    7/81
  Verifying  : perl-Digest-SHA1-2.13-9.el7.ppc64le                         8/81
  Verifying  : tftp-5.2-22.el7.ppc64le                                     9/81
  Verifying  : 14:libpcap-1.5.3-11.el7.ppc64le                            10/81
  Verifying  : libnl3-3.2.28-4.el7.ppc64le                                11/81
  Verifying  : python2-docopt-0.6.2-7.el7.noarch                          12/81
  Verifying  : python-enum34-1.0.4-1.el7.noarch                           13/81
  Verifying  : perl-Sys-Syslog-0.33-3.el7.ppc64le                         14/81
  Verifying  : python-backports-1.0-8.el7.ppc64le                         15/81
  Verifying  : libvirt-libs-3.9.0-14.el7.ppc64le                          16/81
  Verifying  : 4:xCAT-client-2.14-snap201803300510.noarch                 17/81
  Verifying  : perl-LWP-Protocol-https-6.04-4.el7.noarch                  18/81
  Verifying  : 1:perl-Digest-SHA-5.85-4.el7.ppc64le                       19/81
  Verifying  : perl-IO-Stty-0.03-1.noarch                                 20/81
  Verifying  : 1:perl-FCGI-0.74-8.el7.ppc64le                             21/81
  Verifying  : python-setuptools-0.9.8-7.el7.noarch                       22/81
  Verifying  : python-scp-0.7.1-3.el7.noarch                              23/81
  Verifying  : python-cffi-1.6.0-5.el7.ppc64le                            24/81
  Verifying  : psmisc-22.20-15.el7.ppc64le                                25/81
  Verifying  : 4:xCATsn-2.14-snap201803300510.ppc64le                     26/81
  Verifying  : tftp-server-5.2-22.el7.ppc64le                             27/81
  Verifying  : perl-DB_File-1.830-6.el7.ppc64le                           28/81
  Verifying  : perl-Net-Telnet-3.03-19.el7.noarch                         29/81
  Verifying  : 1:xCAT-genesis-scripts-x86_64-2.14-snap201803300510.noar   30/81
  Verifying  : syslinux-xcat-3.86-2.noarch                                31/81
  Verifying  : conserver-xcat-8.2.1-1.ppc64le                             32/81
  Verifying  : 1:xCAT-genesis-scripts-ppc64-2.14-snap201803300510.noarc   33/81
  Verifying  : perl-DBD-SQLite-1.39-3.el7.ppc64le                         34/81
  Verifying  : python2-greenlet-0.4.13-2.fc28.ppc64le                     35/81
  Verifying  : perl-Digest-HMAC-1.03-5.el7.noarch                         36/81
  Verifying  : python-urllib3-1.10.2-5.el7.noarch                         37/81
  Verifying  : python-idna-2.4-1.el7.noarch                               38/81
  Verifying  : 4:xCAT-probe-2.14-snap201803300510.noarch                  39/81
  Verifying  : python2-pyasn1-0.1.9-7.el7.noarch                          40/81
  Verifying  : elilo-xcat-3.14-4.noarch                                   41/81
  Verifying  : 1:xCAT-openbmc-py-2.14-snap201803300511.noarch             42/81
  Verifying  : 2:xCAT-genesis-base-ppc64-2.14-snap201803282253.noarch     43/81
  Verifying  : 2:nmap-6.40-13.el7.ppc64le                                 44/81
  Verifying  : goconserver-0.2.2-snap201803292225.ppc64le                 45/81
  Verifying  : perl-Crypt-SSLeay-0.64-5.el7.ppc64le                       46/81
  Verifying  : nettle-2.7.1-8.el7.ppc64le                                 47/81
  Verifying  : 2:xCAT-genesis-base-x86_64-2.14-snap201803282249.noarch    48/81
  Verifying  : perl-Expect-1.21-1.noarch                                  49/81
  Verifying  : perl-Sys-Virt-3.9.0-2.el7.ppc64le                          50/81
  Verifying  : gnutls-3.3.26-9.el7.ppc64le                                51/81
  Verifying  : lm_sensors-libs-3.4.0-4.20160601gitf9185e5.el7.ppc64le     52/81
  Verifying  : perl-IO-Tty-1.07-1.ppc64le                                 53/81
  Verifying  : python-paramiko-2.1.1-2.el7.noarch                         54/81
  Verifying  : trousers-0.3.14-2.el7.ppc64le                              55/81
  Verifying  : xnba-undi-1.0.3-131028.noarch                              56/81
  Verifying  : net-tools-2.0-0.22.20131004git.el7.ppc64le                 57/81
  Verifying  : python-ply-3.4-11.el7.noarch                               58/81
  Verifying  : grub2-xcat-2.02-0.16.el7.snap201506090204.noarch           59/81
  Verifying  : python2-gevent-1.2.2-2.fc28.ppc64le                        60/81
  Verifying  : python-six-1.9.0-2.el7.noarch                              61/81
  Verifying  : perl-HTTP-Async-0.30-2.noarch                              62/81
  Verifying  : perl-Crypt-Rijndael-1.09-2.ael7a.ppc64le                   63/81
  Verifying  : perl-CGI-3.63-4.el7.noarch                                 64/81
  Verifying  : 4:xCAT-server-2.14-snap201803300510.noarch                 65/81
  Verifying  : ipmitool-xcat-1.8.18-0.ppc64le                             66/81
  Verifying  : 4:perl-xCAT-2.14-snap201803300510.noarch                   67/81
  Verifying  : yajl-2.0.4-4.el7.ppc64le                                   68/81
  Verifying  : python-requests-2.6.0-1.el7_1.noarch                       69/81
  Verifying  : perl-HTML-Form-6.03-6.el7.noarch                           70/81
  Verifying  : c-ares-1.10.0-3.el7.ppc64le                                71/81
  Verifying  : 1:net-snmp-agent-libs-5.7.2-32.el7.ppc64le                 72/81
  Verifying  : 2:nmap-ncat-6.40-13.el7.ppc64le                            73/81
  Verifying  : python-ipaddress-1.0.16-2.el7.noarch                       74/81
  Verifying  : python-chardet-2.2.1-1.el7_1.noarch                        75/81
  Verifying  : 1:net-snmp-libs-5.7.2-32.el7.ppc64le                       76/81
  Verifying  : perl-Crypt-CBC-2.33-2.el7.noarch                           77/81
  Verifying  : cyrus-sasl-gssapi-2.1.26-23.el7.ppc64le                    78/81
  Verifying  : python-pycparser-2.14-1.el7.noarch                         79/81
  Verifying  : cyrus-sasl-2.1.26-23.el7.ppc64le                           80/81
  Verifying  : perl-Net-DNS-0.72-6.el7.ppc64le                            81/81
Installed:
  conserver-xcat.ppc64le 0:8.2.1-1
  perl-Expect.noarch 0:1.21-1
  perl-Net-Telnet.noarch 0:3.03-19.el7
  xCAT-openbmc-py.noarch 1:2.14-snap201803300511
  xCATsn.ppc64le 4:2.14-snap201803300510
Dependency Installed:
  c-ares.ppc64le 0:1.10.0-3.el7
  cyrus-sasl.ppc64le 0:2.1.26-23.el7
  cyrus-sasl-gssapi.ppc64le 0:2.1.26-23.el7
  elilo-xcat.noarch 0:3.14-4
  gnutls.ppc64le 0:3.3.26-9.el7
  goconserver.ppc64le 0:0.2.2-snap201803292225
  grub2-xcat.noarch 0:2.02-0.16.el7.snap201506090204
  ipmitool-xcat.ppc64le 0:1.8.18-0
  libev.ppc64le 0:4.15-7.el7
  libnl3.ppc64le 0:3.2.28-4.el7
  libpcap.ppc64le 14:1.5.3-11.el7
  libvirt-libs.ppc64le 0:3.9.0-14.el7
  lm_sensors-libs.ppc64le 0:3.4.0-4.20160601gitf9185e5.el7
  net-snmp-agent-libs.ppc64le 1:5.7.2-32.el7
  net-snmp-libs.ppc64le 1:5.7.2-32.el7
  net-snmp-perl.ppc64le 1:5.7.2-20.ael7b
  net-tools.ppc64le 0:2.0-0.22.20131004git.el7
  nettle.ppc64le 0:2.7.1-8.el7
  nmap.ppc64le 2:6.40-13.el7
  nmap-ncat.ppc64le 2:6.40-13.el7
  perl-CGI.noarch 0:3.63-4.el7
  perl-Crypt-CBC.noarch 0:2.33-2.el7
  perl-Crypt-Rijndael.ppc64le 0:1.09-2.ael7a
  perl-Crypt-SSLeay.ppc64le 0:0.64-5.el7
  perl-DBD-SQLite.ppc64le 0:1.39-3.el7
  perl-DB_File.ppc64le 0:1.830-6.el7
  perl-Digest-HMAC.noarch 0:1.03-5.el7
  perl-Digest-SHA.ppc64le 1:5.85-4.el7
  perl-Digest-SHA1.ppc64le 0:2.13-9.el7
  perl-FCGI.ppc64le 1:0.74-8.el7
  perl-HTML-Form.noarch 0:6.03-6.el7
  perl-HTTP-Async.noarch 0:0.30-2
  perl-IO-Stty.noarch 0:0.03-1
  perl-IO-Tty.ppc64le 0:1.07-1
  perl-JSON.noarch 0:2.59-2.el7
  perl-LWP-Protocol-https.noarch 0:6.04-4.el7
  perl-Net-DNS.ppc64le 0:0.72-6.el7
  perl-Net-HTTPS-NB.noarch 0:0.14-2
  perl-Sys-Syslog.ppc64le 0:0.33-3.el7
  perl-Sys-Virt.ppc64le 0:3.9.0-2.el7
  perl-XML-LibXML.ppc64le 1:2.0018-5.el7
  perl-xCAT.noarch 4:2.14-snap201803300510
  psmisc.ppc64le 0:22.20-15.el7
  python-backports.ppc64le 0:1.0-8.el7
  python-backports-ssl_match_hostname.noarch 0:3.5.0.1-1.el7
  python-cffi.ppc64le 0:1.6.0-5.el7
  python-chardet.noarch 0:2.2.1-1.el7_1
  python-enum34.noarch 0:1.0.4-1.el7
  python-idna.noarch 0:2.4-1.el7
  python-ipaddress.noarch 0:1.0.16-2.el7
  python-paramiko.noarch 0:2.1.1-2.el7
  python-ply.noarch 0:3.4-11.el7
  python-pycparser.noarch 0:2.14-1.el7
  python-requests.noarch 0:2.6.0-1.el7_1
  python-scp.noarch 0:0.7.1-3.el7
  python-setuptools.noarch 0:0.9.8-7.el7
  python-six.noarch 0:1.9.0-2.el7
  python-urllib3.noarch 0:1.10.2-5.el7
  python2-cryptography.ppc64le 0:1.7.2-2.el7
  python2-docopt.noarch 0:0.6.2-7.el7
  python2-gevent.ppc64le 0:1.2.2-2.fc28
  python2-greenlet.ppc64le 0:0.4.13-2.fc28
  python2-pyasn1.noarch 0:0.1.9-7.el7
  syslinux-xcat.noarch 0:3.86-2
  tftp.ppc64le 0:5.2-22.el7
  tftp-server.ppc64le 0:5.2-22.el7
  trousers.ppc64le 0:0.3.14-2.el7
  xCAT-client.noarch 4:2.14-snap201803300510
  xCAT-genesis-base-ppc64.noarch 2:2.14-snap201803282253
  xCAT-genesis-base-x86_64.noarch 2:2.14-snap201803282249
  xCAT-genesis-scripts-ppc64.noarch 1:2.14-snap201803300510
  xCAT-genesis-scripts-x86_64.noarch 1:2.14-snap201803300510
  xCAT-probe.noarch 4:2.14-snap201803300510
  xCAT-server.noarch 4:2.14-snap201803300510
  xnba-undi.noarch 0:1.0.3-131028
  yajl.ppc64le 0:2.0.4-4.el7
Complete!
No packages marked for update
Enter the dracut mode. Dracut version: 033. Dracut directory: dracut_033.
Try to load drivers: ext3 ext4 to initrd.
chroot /install/netboot/rhels7.5-alternate/ppc64le/service/rootimg dracut  -f /tmp/initrd.13697.gz 4.14.0-49.el7a.ppc64le
No '/dev/log' or 'logger' included for syslog logging
Turning off host-only mode: '/sys' is not mounted!
Turning off host-only mode: '/proc' is not mounted!
Turning off host-only mode: '/run' is not mounted!
Turning off host-only mode: '/dev' is not mounted!
the initial ramdisk for stateless is generated successfully.
Try to load drivers: ext3 ext4 to initrd.
chroot /install/netboot/rhels7.5-alternate/ppc64le/service/rootimg dracut  -f /tmp/initrd.13697.gz 4.14.0-49.el7a.ppc64le
No '/dev/log' or 'logger' included for syslog logging
Turning off host-only mode: '/sys' is not mounted!
Turning off host-only mode: '/proc' is not mounted!
Turning off host-only mode: '/run' is not mounted!
Turning off host-only mode: '/dev' is not mounted!
the initial ramdisk for statelite is generated successfully.
CHECK:rc == 0	[Pass]

RUN:mount |sort > /tmp/mountoutput/file.new [Fri Mar 30 05:43:19 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:diff -y /tmp/mountoutput/file.org /tmp/mountoutput/file.new [Fri Mar 30 05:43:19 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
/dev/mapper/system-root on / type ext4 (rw,relatime,data=orde	/dev/mapper/system-root on / type ext4 (rw,relatime,data=orde
/dev/sda2 on /boot type ext3 (rw,relatime,data=ordered)		/dev/sda2 on /boot type ext3 (rw,relatime,data=ordered)
10.0.0.122:/gpfs/cnfs01/data/xcat/jk on /tmp/automation_mount	10.0.0.122:/gpfs/cnfs01/data/xcat/jk on /tmp/automation_mount
cgroup on /sys/fs/cgroup/blkio type cgroup (rw,nosuid,nodev,n	cgroup on /sys/fs/cgroup/blkio type cgroup (rw,nosuid,nodev,n
cgroup on /sys/fs/cgroup/cpu,cpuacct type cgroup (rw,nosuid,n	cgroup on /sys/fs/cgroup/cpu,cpuacct type cgroup (rw,nosuid,n
cgroup on /sys/fs/cgroup/cpuset type cgroup (rw,nosuid,nodev,	cgroup on /sys/fs/cgroup/cpuset type cgroup (rw,nosuid,nodev,
cgroup on /sys/fs/cgroup/devices type cgroup (rw,nosuid,nodev	cgroup on /sys/fs/cgroup/devices type cgroup (rw,nosuid,nodev
cgroup on /sys/fs/cgroup/freezer type cgroup (rw,nosuid,nodev	cgroup on /sys/fs/cgroup/freezer type cgroup (rw,nosuid,nodev
cgroup on /sys/fs/cgroup/hugetlb type cgroup (rw,nosuid,nodev	cgroup on /sys/fs/cgroup/hugetlb type cgroup (rw,nosuid,nodev
cgroup on /sys/fs/cgroup/memory type cgroup (rw,nosuid,nodev,	cgroup on /sys/fs/cgroup/memory type cgroup (rw,nosuid,nodev,
cgroup on /sys/fs/cgroup/net_cls,net_prio type cgroup (rw,nos	cgroup on /sys/fs/cgroup/net_cls,net_prio type cgroup (rw,nos
cgroup on /sys/fs/cgroup/perf_event type cgroup (rw,nosuid,no	cgroup on /sys/fs/cgroup/perf_event type cgroup (rw,nosuid,no
cgroup on /sys/fs/cgroup/pids type cgroup (rw,nosuid,nodev,no	cgroup on /sys/fs/cgroup/pids type cgroup (rw,nosuid,nodev,no
cgroup on /sys/fs/cgroup/systemd type cgroup (rw,nosuid,nodev	cgroup on /sys/fs/cgroup/systemd type cgroup (rw,nosuid,nodev
configfs on /sys/kernel/config type configfs (rw,relatime)	configfs on /sys/kernel/config type configfs (rw,relatime)
debugfs on /sys/kernel/debug type debugfs (rw,relatime)		debugfs on /sys/kernel/debug type debugfs (rw,relatime)
devpts on /dev/pts type devpts (rw,nosuid,noexec,relatime,gid	devpts on /dev/pts type devpts (rw,nosuid,noexec,relatime,gid
devtmpfs on /dev type devtmpfs (rw,nosuid,size=1804160k,nr_in	devtmpfs on /dev type devtmpfs (rw,nosuid,size=1804160k,nr_in
hugetlbfs on /dev/hugepages type hugetlbfs (rw,relatime,pages	hugetlbfs on /dev/hugepages type hugetlbfs (rw,relatime,pages
mqueue on /dev/mqueue type mqueue (rw,relatime)			mqueue on /dev/mqueue type mqueue (rw,relatime)
nfsd on /proc/fs/nfsd type nfsd (rw,relatime)			nfsd on /proc/fs/nfsd type nfsd (rw,relatime)
proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)	proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)
pstore on /sys/fs/pstore type pstore (rw,nosuid,nodev,noexec,	pstore on /sys/fs/pstore type pstore (rw,nosuid,nodev,noexec,
securityfs on /sys/kernel/security type securityfs (rw,nosuid	securityfs on /sys/kernel/security type securityfs (rw,nosuid
sunrpc on /var/lib/nfs/rpc_pipefs type rpc_pipefs (rw,relatim	sunrpc on /var/lib/nfs/rpc_pipefs type rpc_pipefs (rw,relatim
sysfs on /sys type sysfs (rw,nosuid,nodev,noexec,relatime)	sysfs on /sys type sysfs (rw,nosuid,nodev,noexec,relatime)
systemd-1 on /proc/sys/fs/binfmt_misc type autofs (rw,relatim	systemd-1 on /proc/sys/fs/binfmt_misc type autofs (rw,relatim
tmpfs on /dev/shm type tmpfs (rw,nosuid,nodev)			tmpfs on /dev/shm type tmpfs (rw,nosuid,nodev)
tmpfs on /run type tmpfs (rw,nosuid,nodev,mode=755)		tmpfs on /run type tmpfs (rw,nosuid,nodev,mode=755)
tmpfs on /run/user/0 type tmpfs (rw,nosuid,nodev,relatime,siz	tmpfs on /run/user/0 type tmpfs (rw,nosuid,nodev,relatime,siz
tmpfs on /sys/fs/cgroup type tmpfs (ro,nosuid,nodev,noexec,mo	tmpfs on /sys/fs/cgroup type tmpfs (ro,nosuid,nodev,noexec,mo
CHECK:rc == 0	[Pass]

RUN:rm -rf /tmp/mountoutput [Fri Mar 30 05:43:19 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:packimage __GETNODEATTR(f6u13k11,os)__-__GETNODEATTR(f6u13k11,arch)__-netboot-service [Fri Mar 30 05:43:19 2018]
ElapsedTime:103 sec
RETURN rc = 0
OUTPUT:
Packing contents of /install/netboot/rhels7.5-alternate/ppc64le/service/rootimg
archive method:cpio
compress method:gzip

CHECK:rc == 0	[Pass]

RUN:rinstall f6u13k11 osimage=__GETNODEATTR(f6u13k11,os)__-__GETNODEATTR(f6u13k11,arch)__-netboot-service [Fri Mar 30 05:45:02 2018]
ElapsedTime:4 sec
RETURN rc = 0
OUTPUT:
Provision node(s): f6u13k11
CHECK:rc == 0	[Pass]
CHECK:output =~ Provision node\(s\)\: f6u13k11	[Pass]

RUN:if [[ -f /var/lib/dhcp/db/dhcpd.leases ]]; then cat /var/lib/dhcp/db/dhcpd.leases; elif [[ -f /var/lib/dhcpd/dhcpd.leases ]];then cat /var/lib/dhcpd/dhcpd.leases;elif [[ -f /var/lib/dhcp/dhcpd.leases ]];then cat /var/lib/dhcp/dhcpd.leases; fi [Fri Mar 30 05:45:06 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
# The format of this file is documented in the dhcpd.leases(5) manual page.
# This lease file was written by isc-dhcp-4.2.5

server-duid "\000\001\000\001\"P\3020BP\012\006\015\012";

host f6u13k12 {
  dynamic;
  hardware ethernet 42:8b:0a:06:0d:0c;
  uid 42:8b:0a:06:0d:0c;
  fixed-address 10.6.13.12;
        supersede server.ddns-hostname = "f6u13k12";
        supersede host-name = "f6u13k12";
        supersede server.filename = "/boot/grub2/grub2-f6u13k12";
}
host f6u13k12-noip424b0a060d0c {
  dynamic;
  hardware ethernet 42:4b:0a:06:0d:0c;
  uid 42:4b:0a:06:0d:0c;
        supersede server.allow-booting = 00;
}
host f6u13k12-noip424a0a060d0c {
  dynamic;
  hardware ethernet 42:4a:0a:06:0d:0c;
  uid 42:4a:0a:06:0d:0c;
        supersede server.allow-booting = 00;
}
host f6u13k11 {
  dynamic;
  hardware ethernet 42:03:0a:06:0d:0b;
  uid 42:03:0a:06:0d:0b;
  fixed-address 10.6.13.11;
        supersede server.ddns-hostname = "f6u13k11";
        supersede host-name = "f6u13k11";
        supersede server.filename = "/boot/grub2/grub2-f6u13k11";
}
host f6u13k11-noip42c80a060d0b {
  dynamic;
  hardware ethernet 42:c8:0a:06:0d:0b;
  uid 42:c8:0a:06:0d:0b;
        supersede server.allow-booting = 00;
}
host f6u13k11-noip425b0a060d0b {
  dynamic;
  hardware ethernet 42:5b:0a:06:0d:0b;
  uid 42:5b:0a:06:0d:0b;
        supersede server.allow-booting = 00;
}
host f6u13k11 {
  dynamic;
  deleted;
}
host f6u13k11 {
  dynamic;
  hardware ethernet 42:03:0a:06:0d:0b;
  uid 42:03:0a:06:0d:0b;
  fixed-address 10.6.13.11;
        supersede server.ddns-hostname = "f6u13k11";
        supersede host-name = "f6u13k11";
        supersede server.filename = "/boot/grub2/grub2-f6u13k11";
        supersede server.next-server = 0a:06:0d:0a;
}
host f6u13k11-noip42c80a060d0b {
  dynamic;
  deleted;
}
host f6u13k11-noip42c80a060d0b {
  dynamic;
  hardware ethernet 42:c8:0a:06:0d:0b;
  uid 42:c8:0a:06:0d:0b;
        supersede server.allow-booting = 00;
}
host f6u13k11-noip425b0a060d0b {
  dynamic;
  deleted;
}
host f6u13k11-noip425b0a060d0b {
  dynamic;
  hardware ethernet 42:5b:0a:06:0d:0b;
  uid 42:5b:0a:06:0d:0b;
        supersede server.allow-booting = 00;
}

RUN:sleep 180 [Fri Mar 30 05:45:06 2018]
ElapsedTime:180 sec
RETURN rc = 0
OUTPUT:

RUN:a=0;while ! `lsdef -l f6u13k11|grep status|grep booted >/dev/null`; do sleep 10;((a++));if [ $a -gt 60 ];then break;fi done [Fri Mar 30 05:48:06 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:ping f6u13k11 -c 3 [Fri Mar 30 05:48:06 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
PING f6u13k11 (10.6.13.11) 56(84) bytes of data.
64 bytes from f6u13k11 (10.6.13.11): icmp_seq=1 ttl=64 time=0.255 ms
64 bytes from f6u13k11 (10.6.13.11): icmp_seq=2 ttl=64 time=0.232 ms
64 bytes from f6u13k11 (10.6.13.11): icmp_seq=3 ttl=64 time=0.330 ms

--- f6u13k11 ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2053ms
rtt min/avg/max/mdev = 0.232/0.272/0.330/0.043 ms
CHECK:rc == 0	[Pass]
CHECK:output =~ 64 bytes from f6u13k11	[Pass]

RUN:lsdef -l f6u13k11 | grep status [Fri Mar 30 05:48:08 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
    status=booted
    statustime=03-30-2018 05:46:44
CHECK:rc == 0	[Pass]
CHECK:output =~ booted	[Pass]

RUN:xdsh f6u13k11 date [Fri Mar 30 05:48:09 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u13k11: Fri Mar 30 05:34:58 EDT 2018
f6u13k11: Warning: Permanently added 'f6u13k11,10.6.13.11' (ECDSA) to the list of known hosts.

CHECK:rc == 0	[Pass]
CHECK:output =~ \d\d:\d\d:\d\d	[Pass]

RUN:xdsh f6u13k11 mount [Fri Mar 30 05:48:10 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
f6u13k11: sysfs on /sys type sysfs (rw,relatime)
f6u13k11: proc on /proc type proc (rw,relatime)
f6u13k11: devtmpfs on /dev type devtmpfs (rw,nosuid,size=4153856k,nr_inodes=64904,mode=755)
f6u13k11: securityfs on /sys/kernel/security type securityfs (rw,nosuid,nodev,noexec,relatime)
f6u13k11: tmpfs on /dev/shm type tmpfs (rw)
f6u13k11: devpts on /dev/pts type devpts (rw,relatime,gid=5,mode=620,ptmxmode=000)
f6u13k11: tmpfs on /run type tmpfs (rw,nosuid,nodev,mode=755)
f6u13k11: tmpfs on /sys/fs/cgroup type tmpfs (ro,nosuid,nodev,noexec,mode=755)
f6u13k11: cgroup on /sys/fs/cgroup/systemd type cgroup (rw,nosuid,nodev,noexec,relatime,xattr,release_agent=/usr/lib/systemd/systemd-cgroups-agent,name=systemd)
f6u13k11: pstore on /sys/fs/pstore type pstore (rw,nosuid,nodev,noexec,relatime)
f6u13k11: cgroup on /sys/fs/cgroup/hugetlb type cgroup (rw,nosuid,nodev,noexec,relatime,hugetlb)
f6u13k11: cgroup on /sys/fs/cgroup/freezer type cgroup (rw,nosuid,nodev,noexec,relatime,freezer)
f6u13k11: cgroup on /sys/fs/cgroup/net_cls,net_prio type cgroup (rw,nosuid,nodev,noexec,relatime,net_cls,net_prio)
f6u13k11: cgroup on /sys/fs/cgroup/cpu,cpuacct type cgroup (rw,nosuid,nodev,noexec,relatime,cpu,cpuacct)
f6u13k11: cgroup on /sys/fs/cgroup/cpuset type cgroup (rw,nosuid,nodev,noexec,relatime,cpuset)
f6u13k11: cgroup on /sys/fs/cgroup/memory type cgroup (rw,nosuid,nodev,noexec,relatime,memory)
f6u13k11: cgroup on /sys/fs/cgroup/perf_event type cgroup (rw,nosuid,nodev,noexec,relatime,perf_event)
f6u13k11: cgroup on /sys/fs/cgroup/devices type cgroup (rw,nosuid,nodev,noexec,relatime,devices)
f6u13k11: cgroup on /sys/fs/cgroup/pids type cgroup (rw,nosuid,nodev,noexec,relatime,pids)
f6u13k11: cgroup on /sys/fs/cgroup/blkio type cgroup (rw,nosuid,nodev,noexec,relatime,blkio)
f6u13k11: configfs on /sys/kernel/config type configfs (rw,relatime)
f6u13k11: rootfs on / type tmpfs (rw,relatime,mode=755)
f6u13k11: rw on /.sllocal/log type tmpfs (rw,relatime)
f6u13k11: rpc_pipefs on /var/lib/nfs/rpc_pipefs type rpc_pipefs (rw,relatime)
f6u13k11: systemd-1 on /proc/sys/fs/binfmt_misc type autofs (rw,relatime,fd=31,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=10129)
f6u13k11: debugfs on /sys/kernel/debug type debugfs (rw,relatime)
f6u13k11: mqueue on /dev/mqueue type mqueue (rw,relatime)
f6u13k11: hugetlbfs on /dev/hugepages type hugetlbfs (rw,relatime,pagesize=2M)
f6u13k11: binfmt_misc on /proc/sys/fs/binfmt_misc type binfmt_misc (rw,relatime)
f6u13k11: f6u13k10:/install on /install type nfs4 (rw,relatime,vers=4.1,rsize=524288,wsize=524288,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,clientaddr=10.6.13.11,local_lock=none,addr=10.6.13.10)
f6u13k11: f6u13k10:/tftpboot on /tftpboot type nfs4 (rw,relatime,vers=4.1,rsize=524288,wsize=524288,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,clientaddr=10.6.13.11,local_lock=none,addr=10.6.13.10)
f6u13k11: nfsd on /proc/fs/nfsd type nfsd (rw,relatime)
f6u13k11: tmpfs on /run/user/0 type tmpfs (rw,nosuid,nodev,relatime,size=835008k,mode=700)
CHECK:rc == 0	[Pass]
CHECK:output =~ on / type tmpfs	[Pass]

RUN:xdsh f6u13k11 rpm -qa|grep "xCAT-openbmc-py" [Fri Mar 30 05:48:10 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u13k11: xCAT-openbmc-py-2.14-snap201803300511.noarch
CHECK:rc == 0	[Pass]
CHECK:output =~ xCAT-openbmc-py-\d	[Pass]

RUN:xdsh f6u13k11 rpm -qa|grep "gevent" [Fri Mar 30 05:48:11 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u13k11: python2-gevent-1.2.2-2.fc28.ppc64le
CHECK:rc == 0	[Pass]
CHECK:output =~ gevent-\d	[Pass]

RUN:xdsh f6u13k11 "service httpd status" [Fri Mar 30 05:48:12 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u13k11: * httpd.service - The Apache HTTP Server
f6u13k11:    Loaded: loaded (/usr/lib/systemd/system/httpd.service; enabled; vendor preset: disabled)
f6u13k11:    Active: active (running) since Fri 2018-03-30 05:33:03 EDT; 1min 57s ago
f6u13k11:      Docs: man:httpd(8)
f6u13k11:            man:apachectl(8)
f6u13k11:  Main PID: 1313 (httpd)
f6u13k11:    Status: "Total requests: 0; Current requests/sec: 0; Current traffic:   0 B/sec"
f6u13k11:    CGroup: /system.slice/httpd.service
f6u13k11:            |-1313 /usr/sbin/httpd -DFOREGROUND
f6u13k11:            |-1350 /usr/sbin/httpd -DFOREGROUND
f6u13k11:            |-1351 /usr/sbin/httpd -DFOREGROUND
f6u13k11:            |-1352 /usr/sbin/httpd -DFOREGROUND
f6u13k11:            |-1353 /usr/sbin/httpd -DFOREGROUND
f6u13k11:            `-1354 /usr/sbin/httpd -DFOREGROUND
f6u13k11:
f6u13k11: Mar 30 05:33:03 f6u13k11.pok.stglabs.ibm.com systemd[1]: Starting The Apache HTTP Server...
f6u13k11: Mar 30 05:33:03 f6u13k11.pok.stglabs.ibm.com httpd[1313]: [Fri Mar 30 05:33:03.751041 2018] [so:warn] [pid 1313] AH01574: module rewrite_module is already loaded, skipping
f6u13k11: Mar 30 05:33:03 f6u13k11.pok.stglabs.ibm.com systemd[1]: Started The Apache HTTP Server.
f6u13k11: Redirecting to /bin/systemctl status httpd.service
CHECK:rc == 0	[Pass]

RUN:xdsh f6u13k11 "service systemd status" [Fri Mar 30 05:48:13 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u13k11: Redirecting to /bin/systemctl status systemd.service
f6u13k11: Unit systemd.service could not be found.

RUN:rootimgdir=`lsdef -t osimage  __GETNODEATTR(f6u13k11,os)__-__GETNODEATTR(f6u13k11,arch)__-netboot-service|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir.org ]; then rm -rf $rootimgdir; mv $rootimgdir.org $rootimgdir; fi [Fri Mar 30 05:48:13 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xdsh f6u13k11  "cat /var/log/xcat/xcat.log" [Fri Mar 30 05:48:15 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
f6u13k11: Fri Mar 30 05:33:03 EDT 2018 [info]: xcat.xcatdsklspost: updating VPD database
f6u13k11: Fri Mar 30 05:33:03 EDT 2018 [info]: xcat.xcatdsklspost: trying to download postscripts...
f6u13k11: Fri Mar 30 05:33:04 EDT 2018 [info]: xcat.xcatdsklspost: postscripts downloaded successfully
f6u13k11: Fri Mar 30 05:33:04 EDT 2018 [info]: xcat.xcatdsklspost: trying to get mypostscript from 10.6.13.10...
f6u13k11: Fri Mar 30 05:33:04 EDT 2018 [info]: xcat.mypostscript: Running postbootscript: syslog
f6u13k11: grep: /etc/rsyslog.d/remote.conf: No such file or directory
f6u13k11: grep: /etc/rsyslog.d/remote.conf: No such file or directory
f6u13k11: Fri Mar 30 05:33:04 EDT 2018 [info]: xcat.mypostscript: postbootscript syslog return with 0
f6u13k11: Fri Mar 30 05:33:04 EDT 2018 [info]: xcat.mypostscript: Running postbootscript: remoteshell
f6u13k11:
f6u13k11: Fri Mar 30 05:33:06 EDT 2018 [info]: xcat.mypostscript: postbootscript remoteshell return with 0
f6u13k11: Fri Mar 30 05:33:06 EDT 2018 [info]: xcat.mypostscript: Running postbootscript: syncfiles
f6u13k11:   Did not sync any files.
f6u13k11: Fri Mar 30 05:33:06 EDT 2018 [info]: xcat.mypostscript: postbootscript syncfiles return with 0
f6u13k11: Fri Mar 30 05:33:06 EDT 2018 [info]: xcat.mypostscript: Running postbootscript: servicenode
f6u13k11: Fri Mar 30 05:33:32 EDT 2018 [info]: xcat.mypostscript: postbootscript servicenode return with 0
f6u13k11: Fri Mar 30 05:33:32 EDT 2018 [info]: xcat.mypostscript: Running postbootscript: otherpkgs
f6u13k11:   Did not install any extra packages.
f6u13k11: Fri Mar 30 05:33:32 EDT 2018 [info]: xcat.mypostscript: postbootscript otherpkgs return with 0
f6u13k11: Fri Mar 30 05:33:32 EDT 2018 [debug]: xcat.mypostscript: node booted successfully, reporting status...
f6u13k11: Fri Mar 30 05:33:32 EDT 2018 [info]: xcat.mypostscript: provision completed.(f6u13k11)

------END::SN_diskless_setup_case::Passed::Time:Fri Mar 30 05:48:15 2018 ::Duration::589 sec------


```