### PR TITLE
set rspconfig run in python default

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -917,7 +917,7 @@ class OpenBMCRest(object):
 
     def set_ipdhcp(self):
         payload = { "data": [] }
-        return self.request('PUT', RSPCONFIG_NETINFO_URL['ipdhcp'], payload=payload, cmd="set_bmcip_dhcp")
+        return self.request('POST', RSPCONFIG_NETINFO_URL['ipdhcp'], payload=payload, cmd="set_bmcip_dhcp")
 
 
 class OpenBMCImage(object):

--- a/xCAT-server/lib/perl/xCAT/OPENBMC.pm
+++ b/xCAT-server/lib/perl/xCAT/OPENBMC.pm
@@ -255,7 +255,7 @@ sub run_cmd_in_perl {
     }
 
     # List of commands currently not supported in Python
-    my @unsupported_in_python_commands = ('rflash', 'rspconfig', 'getopenbmccons');
+    my @unsupported_in_python_commands = ('rflash', 'getopenbmccons');
 
     if ($command ~~ @unsupported_in_python_commands) {
         # Command currently not supported in Python


### PR DESCRIPTION
rspconfig will run in python by default

modify method of rspconfig ip=dhcp to "POST".