### PR TITLE
update paramiko dependency for xCAT-openbmc-py

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
+++ b/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
@@ -20,7 +20,6 @@ from hwctl.executor.openbmc_flash import OpenBMCFlashTask
 from hwctl.executor.openbmc_inventory import OpenBMCInventoryTask
 from hwctl.executor.openbmc_power import OpenBMCPowerTask
 from hwctl.executor.openbmc_sensor import OpenBMCSensorTask
-from hwctl.executor.openbmc_bmcconfig import OpenBMCBmcConfigTask
 from hwctl.executor.openbmc_eventlog import OpenBMCEventlogTask
 from hwctl.beacon import DefaultBeaconManager
 from hwctl.setboot import DefaultBootManager
@@ -287,6 +286,9 @@ class OpenBMCManager(base.BaseManager):
             DefaultPowerManager().set_power_state(runner, power_state=action)
 
     def rspconfig(self, nodesinfo, args):
+
+        from hwctl.executor.openbmc_bmcconfig import OpenBMCBmcConfigTask
+
         try:
             opts=docopt(RSPCONFIG_USAGE, argv=args)
         except DocoptExit as e:

--- a/xCAT-openbmc-py/xCAT-openbmc-py.spec
+++ b/xCAT-openbmc-py/xCAT-openbmc-py.spec
@@ -20,7 +20,8 @@ BuildArch: noarch
 Requires: xCAT-server 
 Requires: python-gevent >= 1.2.2-2
 Requires: python-greenlet >= 0.4.13-2
-Requires: python2-docopt python-requests python-paramiko python-scp
+Requires: python-paramiko >= 2.0.0
+Requires: python2-docopt python-requests python-scp
 
 %description
 xCAT-openbmc-py provides openbmc related functions. 


### PR DESCRIPTION
To fix #5034, Need paramiko >= 2.0.0, only rspconfig need paramiko 

UT:
```
# cd /usr/lib/python2.7/site-packages/
# mv paramiko paramiko.bak
[root@briggs01 site-packages]# rspconfig mid05tor12cn05 dump -l
Error: OpenBMC management is using a Python framework and some dependency libraries could not be imported.
Error: Agent exited unexpectedly.  See /var/log/xcat/agent.log for details.
To revert to Perl framework: chdef -t site clustersite openbmcperl=ALL
---------------------------------
Traceback (most recent call last):
  File "/opt/xcat/lib/python/agent/xcatagent/server.py", line 102, in _handle
    func(req['nodeinfo'], new_args)
  File "/opt/xcat/lib/python/agent/xcatagent/openbmc.py", line 290, in rspconfig
    from hwctl.executor.openbmc_bmcconfig import OpenBMCBmcConfigTask
  File "/usr/lib64/python2.7/site-packages/gevent/builtins.py", line 93, in __import__
    result = _import(*args, **kwargs)
  File "/opt/xcat/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py", line 15, in <module>
    import paramiko
  File "/usr/lib64/python2.7/site-packages/gevent/builtins.py", line 93, in __import__
    result = _import(*args, **kwargs)
ImportError: No module named paramiko
---------------------------------

# rpower mid05tor12cn05 stat
Mon Apr  2 03:12:35 2018 mid05tor12cn05: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://172.11.139.5/login -d '{"data": ["root", "xxxxxx"]}'
Mon Apr  2 03:12:35 2018 mid05tor12cn05: [openbmc_debug] login 200 OK
Mon Apr  2 03:12:35 2018 mid05tor12cn05: [openbmc_debug] list_power_states curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.5/xyz/openbmc_project/state/enumerate
Mon Apr  2 03:12:35 2018 mid05tor12cn05: [openbmc_debug] list_power_states 200 OK
mid05tor12cn05: on
```