### PR TITLE
when no server name infor with --verbose, but -…

### DIFF
--- a/xCAT-client/bin/xcatclient
+++ b/xCAT-client/bin/xcatclient
@@ -102,9 +102,9 @@ foreach (keys %ENV) {
     }
 }
 
-# Allow to print server information when -V
+# Allow to print server information when -V/--verbose
 foreach (reverse(@ARGV)) {
-    if ($_ eq '-V') {
+    if ($_ eq '-V' || $_ eq '--verbose') {
         $ENV{'XCATSHOWSVR'} = 1;
         last;
     }


### PR DESCRIPTION
Fix the issue (#5041) when no server name info with --verbose, but -V does

```
rpower mid05tor12cn05 stat
mid05tor12cn05: on

# rpower mid05tor12cn05 stat -V
[briggs01]: Running command in Python
[briggs01]: mid05tor12cn05: on

# rpower mid05tor12cn05 stat --verbose
[briggs01]: Running command in Python
[briggs01]: mid05tor12cn05: on
```
Okay, now --verbose is the same as -V for commands with node range.