### PR TITLE
correct some typo

### DIFF
--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.osimage.validation
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.osimage.validation
@@ -7,7 +7,7 @@ cmd: mkdir -p /tmp/xcat_inventory_import_validation_osimage/trash/
 cmd: mkdir -p /tmp/xcat_inventory_import_validation_osimage/backup/
 cmd: lsdef -t osimage -o testosimage1 -z 2>/dev/null  >/tmp/xcat_inventory_import_validation_osimage/backup/testosimage1.stanza
 
-cmd: /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "osimage" "testosimage1" "role" "compute" "/tmp/tmp/xcat_inventory_import_validation_osimage/trash/"
+cmd: /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "osimage" "testosimage1" "role" "compute" "/tmp/xcat_inventory_import_validation_osimage/trash/"
 check: rc==0
 cmd: /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "osimage" "testosimage1" "role" "service" "/tmp/xcat_inventory_import_validation_osimage/trash/"
 check: rc==0

--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.site.validation
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.site.validation
@@ -7,7 +7,7 @@ cmd: mkdir -p /tmp/xcat_inventory_import_validation_site/trash/
 cmd: mkdir -p /tmp/xcat_inventory_import_validation_site/backup/
 cmd: lsdef -t site -o clustersite -z 2>/dev/null  >/tmp/xcat_inventory_import_validation_site/backup/clustersite.stanza
 
-cmd: /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "site" "clustersite" "dbtracelevel" "0" "/tmp/tmp/xcat_inventory_import_validation_site/trash/"
+cmd: /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "site" "clustersite" "dbtracelevel" "0" "/tmp/xcat_inventory_import_validation_site/trash/"
 check: rc==0
 cmd: /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "site" "clustersite" "dbtracelevel" "1" "/tmp/xcat_inventory_import_validation_site/trash/"
 check: rc==0


### PR DESCRIPTION
correct 2 typos in test cases
```
#xcattest -t xcat_inventory_import_validation_site
...
------END::xcat_inventory_import_validation_site::Passed::Time:Tue Apr  3 03:23:55 2018 ::Duration::49 sec------
------Total: 1 , Failed: 0------
xCAT automated test finished at Tue Apr  3 03:18:30 2018
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20180403031611 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20180403031611 file for time consumptio

# xcattest -t xcat_inventory_import_validation_osimage

------END::xcat_inventory_import_validation_osimage::Passed::Time:Tue Apr  3 03:23:55 2018 ::Duration::49 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished at Tue Apr  3 03:23:55 2018
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20180403032305 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20180403032305 file for time consumption
```