### PR TITLE
catch all type error for rspconfig options

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
@@ -145,7 +145,7 @@ class OpenBMCBmcConfigTask(ParallelNodesCommand):
 
             for key in keys:
                 self._dump_download(obmc, node, str(key))
-        except SelfServerException as e:
+        except (SelfServerException, SelfClientException) as e:
             self.callback.error(e.message, node)
 
     def dump_process(self, **kw):
@@ -174,7 +174,7 @@ class OpenBMCBmcConfigTask(ParallelNodesCommand):
             else:
                 self.callback.error('Could not find dump %s after waiting %d seconds.' % (dump_id, 20 * 15), node)
 
-        except SelfServerException as e:
+        except (SelfServerException, SelfClientException) as e:
             self.callback.error(e.message, node)
 
     def gard_clear(self, **kw):
@@ -188,7 +188,7 @@ class OpenBMCBmcConfigTask(ParallelNodesCommand):
             obmc.clear_gard()
             self.callback.info('%s: GARD cleared' % node)
 
-        except SelfServerException as e:
+        except (SelfServerException, SelfClientException) as e:
             self.callback.error(e.message, node)
 
     def pre_set_sshcfg(self, *arg, **kw):

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -198,8 +198,8 @@ RSPCONFIG_APIS = {
         'get_data': [],
         'display_name': "BMC PowerSupplyRedundancy",
         'attr_values': {
-            'disabled': "Disables",
-            'enabled': "Enabled",
+            'disabled': ["Disables"],
+            'enabled': ["Enabled"],
         },
     },
     'powerrestorepolicy': {
@@ -751,7 +751,11 @@ class OpenBMCRest(object):
             data = attr_info['attr_values'][value]
         else:
             data = value
-        self.request('PUT', set_url, payload={"data": data}, cmd="set_%s" % key)
+
+        method = 'PUT'
+        if key == 'powersupplyredundancy':
+            method = 'POST'
+        self.request(method, set_url, payload={"data": data}, cmd="set_%s" % key)
 
     def get_apis_values(self, key):
         attr_info = RSPCONFIG_APIS[key]


### PR DESCRIPTION
* Catch all error
before modify
```
# rspconfig mid08tor03cn01 gard -c
Tue Apr  3 04:29:16 2018 mid08tor03cn01: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://172.21.226.1/login -d '{"data": ["root", "xxxxxx"]}'
Tue Apr  3 04:29:16 2018 mid08tor03cn01: [openbmc_debug] login 200 OK
Tue Apr  3 04:29:16 2018 mid08tor03cn01: [openbmc_debug] clear_gard curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://172.21.226.1/org/open_power/control/gard/action/Reset -d '{"data": []}'
Tue Apr  3 04:29:16 2018 mid08tor03cn01: [openbmc_debug] clear_gard [404] org.freedesktop.DBus.Error.FileNotFound: path or object not found: /org/open_power/control/gard
```
After modify
```
# rspconfig mid08tor03cn01 gard -c
Tue Apr  3 04:29:16 2018 mid08tor03cn01: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://172.21.226.1/login -d '{"data": ["root", "xxxxxx"]}'
Tue Apr  3 04:29:16 2018 mid08tor03cn01: [openbmc_debug] login 200 OK
Tue Apr  3 04:29:16 2018 mid08tor03cn01: [openbmc_debug] clear_gard curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://172.21.226.1/org/open_power/control/gard/action/Reset -d '{"data": []}'
Tue Apr  3 04:29:16 2018 mid08tor03cn01: [openbmc_debug] clear_gard [404] org.freedesktop.DBus.Error.FileNotFound: path or object not found: /org/open_power/control/gard
mid08tor03cn01: Error: [404] org.freedesktop.DBus.Error.FileNotFound: path or object not found: /org/open_power/control/gard
```

* modify method and data for ``powersupplyredundancy``.