### PR TITLE
Fix bug of test case updatenode_syncfile_MERGE

### DIFF
--- a/xCAT-test/autotest/testcase/updatenode/cases0
+++ b/xCAT-test/autotest/testcase/updatenode/cases0
@@ -211,35 +211,58 @@ check:rc==0
 end
 
 start:updatenode_syncfile_MERGE
-cmd:echo "bin:x:1:1:bin:/bin:/bin/bash" > /tmp/passwd
-cmd:echo "test:x:1:1:bin:/bin:/bin/bash" >> /tmp/passwd
-cmd:echo "bin:*:15385::::::" > /tmp/shadow
-cmd:echo "test:*:15385::::::" >> /tmp/shadow
-cmd:echo "bin:x:1:daemon" > /tmp/group
-cmd:echo "test:x:1:daemon" >> /tmp/group
-cmd:echo "MERGE:" > /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
-cmd:echo "/tmp/passwd -> /etc/passwd" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
-cmd:echo "/tmp/shadow -> /etc/shadow" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
-cmd:echo "/tmp/group -> /etc/group" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
-cmd:chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute synclists=/install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
+cmd:mkdir -p /tmp/updatenode_syncfile_MERGE
+check:rc==0
+cmd:xdsh $$CN "mkdir -p /tmp/updatenode_syncfile_MERGE"
+check:rc==0
+cmd:xdsh $$CN "cp /etc/passwd /etc/shadow /etc/group /tmp/updatenode_syncfile_MERGE"
+check:rc==0
+cmd:xdsh $$CN "groupadd -g 19999 bogusgroup"
+check:rc==0
+cmd:xdsh $$CN "useradd  -g bogusgroup  bogususer"
+check:rc==0
+cmd:xdsh $$CN "grep bogususer /etc/passwd"
+cmd:xdsh $$CN "grep bogususer /etc/shadow"
+cmd:xdsh $$CN "grep bogusgroup /etc/group"
+cmd:echo "bogususer:x:1000:19998::/home/bogususer:/bin/bash" > /tmp/updatenode_syncfile_MERGE/passwd
+cmd:echo "bogususer1:x:1001:19998::/home/bogususer1:/bin/bash" >> /tmp/updatenode_syncfile_MERGE/passwd
+cmd:echo "bogususer:*:15385::::::" > /tmp/updatenode_syncfile_MERGE/shadow
+cmd:echo "bogususer1:*:15385::::::" >> /tmp/updatenode_syncfile_MERGE/shadow
+cmd:echo "bogusgroup:x:29999:" > /tmp/updatenode_syncfile_MERGE/group
+cmd:echo "bogusgroup1:x:19998:" >> /tmp/updatenode_syncfile_MERGE/group
+cmd:echo "MERGE:" > /tmp/updatenode_syncfile_MERGE/compute.synclist
+cmd:echo "/tmp/updatenode_syncfile_MERGE/passwd -> /etc/passwd" >> /tmp/updatenode_syncfile_MERGE/compute.synclist
+cmd:echo "/tmp/updatenode_syncfile_MERGE/shadow -> /etc/shadow" >> /tmp/updatenode_syncfile_MERGE/compute.synclist
+cmd:echo "/tmp/updatenode_syncfile_MERGE/group -> /etc/group" >> /tmp/updatenode_syncfile_MERGE/compute.synclist
+cmd:cat   /tmp/updatenode_syncfile_MERGE/compute.synclist
+cmd:chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute synclists=/tmp/updatenode_syncfile_MERGE/compute.synclist
 check:rc==0
 cmd:updatenode $$CN -F
 check:rc==0
-cmd:xdsh $$CN "cat /etc/passwd |grep -i \"bin:x:1:1:bin:/bin:/bin/bash\"|wc -l"
-check:output=~1
-cmd:xdsh $$CN "cat /etc/passwd |grep -i \"test:x:1:1:bin:/bin:/bin/bash\""
+cmd:xdsh $$CN "cat /etc/passwd |grep -i \"bogususer1:x:1001:19998::/home/bogususer1:/bin/bash\""
 check:rc==0
-cmd:xdsh $$CN "cat /etc/shadow |grep -i \"bin:*:15385::::::\"|wc -l"
-check:output=~1
-cmd:xdsh $$CN "cat /etc/shadow |grep -i test"
+cmd:xdsh $$CN "cat /etc/passwd |grep -i bogususer||grep -v -i bogususer1|grep 19998"
 check:rc==0
-cmd:xdsh $$CN "cat /etc/group |grep -i \"bin:x:1:daemon\"|wc -l" 
+cmd:xdsh $$CN "cat /etc/shadow |grep -i \"bogususer:\*:15385::::::\""
+check:rc==0
+cmd:xdsh $$CN "cat /etc/shadow |grep -i \"bogususer1:\*:15385::::::\""
+check:rc==0
+cmd:xdsh $$CN "cat /etc/group |grep -i bogusgroup1|grep 19998" 
 check:output=~1
-cmd:xdsh $$CN "cat /etc/group |grep -i test"
+cmd:xdsh $$CN "cat /etc/group |grep -i bogusgroup|grep 29999" 
+check:rc==0
+cmd:xdsh $$CN "mv -f /tmp/updatenode_syncfile_MERGE/passwd /etc/passwd"
+check:rc==0 
+cmd:xdsh $$CN "mv -f /tmp/updatenode_syncfile_MERGE/group /etc/group"
+check:rc==0
+cmd:xdsh $$CN "mv -f /tmp/updatenode_syncfile_MERGE/shadow /etc/shadow"
+check:rc==0
+cmd:xdsh  $$CN "rm -rf /tmp/updatenode_syncfile_MERGE"
 check:rc==0
 cmd:chdef -t osimage -o  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute synclists=
 check:rc==0
-cmd:rm -rf /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
+cmd:rm -rf /tmp/updatenode_syncfile_MERGE 
+check:rc==0
 end
 
 start:updatenode_P_script1


### PR DESCRIPTION
There are some bugs in test case ``updatenode_syncfile_MERGE``
1 can not verify case which update existed user 
2 one check point was not correct

The UT of new case:
```
------START::updatenode_syncfile_MERGE::Time:Tue Apr  3 04:56:00 2018------

RUN:mkdir -p /tmp/updatenode_syncfile_MERGE [Tue Apr  3 04:56:00 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xdsh f6u03 "mkdir -p /tmp/updatenode_syncfile_MERGE" [Tue Apr  3 04:56:00 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xdsh f6u03 "cp /etc/passwd /etc/shadow /etc/group /tmp/updatenode_syncfile_MERGE" [Tue Apr  3 04:56:01 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xdsh f6u03 "groupadd -g 19999 bogusgroup" [Tue Apr  3 04:56:02 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xdsh f6u03 "useradd  -g bogusgroup  bogususer" [Tue Apr  3 04:56:03 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u03: useradd: warning: the home directory already exists.
f6u03: Not copying any file from skel directory into it.
f6u03: Creating mailbox file: File exists
CHECK:rc == 0	[Pass]

RUN:xdsh f6u03 "grep bogususer /etc/passwd" [Tue Apr  3 04:56:04 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
f6u03: bogususer:x:1000:19999::/home/bogususer:/bin/bash

RUN:xdsh f6u03 "grep bogususer /etc/shadow" [Tue Apr  3 04:56:04 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u03: bogususer:!!:17624:0:99999:7:::

RUN:xdsh f6u03 "grep bogusgroup /etc/group" [Tue Apr  3 04:56:05 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u03: bogusgroup:x:19999:

RUN:echo "bogususer:x:1000:19998::/home/bogususer:/bin/bash" > /tmp/updatenode_syncfile_MERGE/passwd [Tue Apr  3 04:56:06 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "bogususer1:x:1001:19998::/home/bogususer1:/bin/bash" >> /tmp/updatenode_syncfile_MERGE/passwd [Tue Apr  3 04:56:06 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "bogususer:*:15385::::::" > /tmp/updatenode_syncfile_MERGE/shadow [Tue Apr  3 04:56:06 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "bogususer1:*:15385::::::" >> /tmp/updatenode_syncfile_MERGE/shadow [Tue Apr  3 04:56:06 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "bogusgroup:x:29999:" > /tmp/updatenode_syncfile_MERGE/group [Tue Apr  3 04:56:06 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "bogusgroup1:x:19998:" >> /tmp/updatenode_syncfile_MERGE/group [Tue Apr  3 04:56:06 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "MERGE:" > /tmp/updatenode_syncfile_MERGE/compute.synclist [Tue Apr  3 04:56:06 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "/tmp/updatenode_syncfile_MERGE/passwd -> /etc/passwd" >> /tmp/updatenode_syncfile_MERGE/compute.synclist [Tue Apr  3 04:56:06 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "/tmp/updatenode_syncfile_MERGE/shadow -> /etc/shadow" >> /tmp/updatenode_syncfile_MERGE/compute.synclist [Tue Apr  3 04:56:06 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "/tmp/updatenode_syncfile_MERGE/group -> /etc/group" >> /tmp/updatenode_syncfile_MERGE/compute.synclist [Tue Apr  3 04:56:06 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:cat   /tmp/updatenode_syncfile_MERGE/compute.synclist [Tue Apr  3 04:56:06 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
MERGE:
/tmp/updatenode_syncfile_MERGE/passwd -> /etc/passwd
/tmp/updatenode_syncfile_MERGE/shadow -> /etc/shadow
/tmp/updatenode_syncfile_MERGE/group -> /etc/group

RUN:chdef -t osimage -o __GETNODEATTR(f6u03,os)__-__GETNODEATTR(f6u03,arch)__-install-compute synclists=/tmp/updatenode_syncfile_MERGE/compute.synclist [Tue Apr  3 04:56:06 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:updatenode f6u03 -F [Tue Apr  3 04:56:07 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
File synchronization has completed for nodes.
CHECK:rc == 0	[Pass]

RUN:xdsh f6u03 "cat /etc/passwd |grep -i \"bogususer1:x:1001:19998::/home/bogususer1:/bin/bash\"" [Tue Apr  3 04:56:09 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u03: bogususer1:x:1001:19998::/home/bogususer1:/bin/bash
CHECK:rc == 0	[Pass]

RUN:xdsh f6u03 "cat /etc/passwd |grep -i bogususer||grep -v -i bogususer1|grep 19998" [Tue Apr  3 04:56:10 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u03: bogususer:x:1000:19998::/home/bogususer:/bin/bash
f6u03: bogususer1:x:1001:19998::/home/bogususer1:/bin/bash
CHECK:rc == 0	[Pass]

RUN:xdsh f6u03 "cat /etc/shadow |grep -i \"bogususer:\*:15385::::::\"" [Tue Apr  3 04:56:11 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
f6u03: bogususer:*:15385::::::
CHECK:rc == 0	[Pass]

RUN:xdsh f6u03 "cat /etc/shadow |grep -i \"bogususer1:\*:15385::::::\"" [Tue Apr  3 04:56:11 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u03: bogususer1:*:15385::::::
CHECK:rc == 0	[Pass]

RUN:xdsh f6u03 "cat /etc/group |grep -i bogusgroup1|grep 19998" [Tue Apr  3 04:56:12 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u03: bogusgroup1:x:19998:
CHECK:output =~ 1	[Pass]

RUN:xdsh f6u03 "cat /etc/group |grep -i bogusgroup|grep 29999" [Tue Apr  3 04:56:13 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u03: bogusgroup:x:29999:
CHECK:rc == 0	[Pass]

RUN:xdsh f6u03 "mv -f /tmp/updatenode_syncfile_MERGE/passwd /etc/passwd" [Tue Apr  3 04:56:14 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xdsh f6u03 "mv -f /tmp/updatenode_syncfile_MERGE/group /etc/group" [Tue Apr  3 04:56:14 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xdsh f6u03 "mv -f /tmp/updatenode_syncfile_MERGE/shadow /etc/shadow" [Tue Apr  3 04:56:15 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xdsh  f6u03 "rm -rf /tmp/updatenode_syncfile_MERGE" [Tue Apr  3 04:56:16 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:chdef -t osimage -o  __GETNODEATTR(f6u03,os)__-__GETNODEATTR(f6u03,arch)__-install-compute synclists= [Tue Apr  3 04:56:17 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:rm -rf /tmp/updatenode_syncfile_MERGE [Tue Apr  3 04:56:18 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::updatenode_syncfile_MERGE::Passed::Time:Tue Apr  3 04:56:18 2018 ::Duration::18 sec------
------Total: 1 , Failed: 0------

```