### PR TITLE
workaround python agent when /dev/log is not available

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/common/utils.py
+++ b/xCAT-openbmc-py/lib/python/agent/common/utils.py
@@ -23,7 +23,11 @@ def getxCATLog(name=None):
     return xl
 
 def enableSyslog(name='xcat'):
-    h = SysLogHandler(address='/dev/log', facility=SysLogHandler.LOG_LOCAL4)
+    try:
+        h = SysLogHandler(address='/dev/log', facility=SysLogHandler.LOG_LOCAL4)
+    except:
+        # this will connect localhost:514
+        h = SysLogHandler(facility=SysLogHandler.LOG_LOCAL4)
     h.setFormatter(logging.Formatter('%s: ' % name + '%(levelname)s %(message)s'))
     logging.getLogger('xcatagent').addHandler(h)
 

--- a/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
+++ b/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
@@ -33,8 +33,11 @@ from hwctl.eventlog import DefaultEventlogManager
 from xcatagent import base
 import logging
 logger = logging.getLogger('xcatagent')
-if not logger.handlers:
-    utils.enableSyslog('xcat.agent')
+try:
+    if not logger.handlers:
+        utils.enableSyslog('xcat.agent')
+except:
+    pass
 
 HTTP_PROTOCOL = "https://"
 PROJECT_URL = "/xyz/openbmc_project"


### PR DESCRIPTION
workaround fix for https://github.com/xcat2/xcat-core/issues/4929

UT:
1, stop systemd-journald.socket
2,stop rsyslog
3, and run hardware control commands via python
```
rpower mid08tor03cn01 stat -V
[boston02]: Running command in Python
[boston02]: Tue Apr  3 06:00:09 2018 mid08tor03cn01: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://172.21.226.1/login -d '{"data": ["root", "xxxxxx"]}'
[boston02]: Tue Apr  3 06:00:09 2018 mid08tor03cn01: [openbmc_debug] login 200 OK
[boston02]: Tue Apr  3 06:00:09 2018 mid08tor03cn01: [openbmc_debug] list_power_states curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://172.21.226.1/xyz/openbmc_project/state/enumerate
[boston02]: Tue Apr  3 06:00:10 2018 mid08tor03cn01: [openbmc_debug] list_power_states 200 OK
[boston02]: mid08tor03cn01: on
```