### PR TITLE
fix issue 5047, modify url for rspconfig autoreboot

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
@@ -400,7 +400,7 @@ rmdir \"/tmp/$userid\" \n")
             return self.callback.error(e.message, node)
 
         if isinstance(value, dict):
-            str_value = value.values()[0]
+            str_value = str(value.values()[0])
         elif value:
             str_value = str(value)
         else:

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -181,8 +181,8 @@ RSPCONFIG_APIS = {
         'display_name': "BMC Hostname",
     },
     'autoreboot' : {
-        'baseurl': "/control/host0/auto_reboot/",
-        'set_url': "attr/AutoReboot",
+        'baseurl': "/control/host0/auto_reboot",
+        'set_url': "/attr/AutoReboot",
         'get_url': "",
         'display_name': "BMC AutoReboot",
         'attr_values': {


### PR DESCRIPTION
#5047 

UT:
```
# rspconfig mid05tor12cn05 autoreboot
Tue Apr  3 06:20:13 2018 mid05tor12cn05: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://172.11.139.5/login -d '{"data": ["root", "xxxxxx"]}'
Tue Apr  3 06:20:13 2018 mid05tor12cn05: [openbmc_debug] login 200 OK
Tue Apr  3 06:20:13 2018 mid05tor12cn05: [openbmc_debug] get_autoreboot curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.5/xyz/openbmc_project/control/host0/auto_reboot
Tue Apr  3 06:20:13 2018 mid05tor12cn05: [openbmc_debug] get_autoreboot 200 OK
mid05tor12cn05: BMC AutoReboot: 1
```