### PR TITLE
Refine test cases based on new output

### DIFF
--- a/xCAT-test/autotest/testcase/reventlog/cases0
+++ b/xCAT-test/autotest/testcase/reventlog/cases0
@@ -33,7 +33,7 @@ cmd:reventlog $$CN 10 -s 1
 check:output=~The -s option is not supported for OpenBMC
 check:rc!=0
 cmd:reventlog $$CN -s all
-check:output=~The -s option is not supported for OpenBMC
+check:output=~The -s option is not supported for OpenBMC|Only one option is supported at the same time for reventlog
 check:rc!=0
 cmd:reventlog $$CN -s
 check:output=~Error: Unsupported command

--- a/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
+++ b/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
@@ -448,22 +448,19 @@ check:rc != 0
 cmd:mkdir -p /tmp/bogus123
 check:rc == 0
 cmd:rflash $$CN /tmp/bogus123 -d
-check:output =~Error: No BMC tar file found
-check:output =~Error: No Host tar file found
+check:output =~Error: No BMC tar file found|Can't open directory
 check:output!~Attempting to
 check:rc != 0
 cmd:touch /tmp/bogus123/obmc-phosphor-image-witherspoon.ubi.mtd.tar 
 check:rc == 0
 cmd:rflash $$CN -d /tmp/bogus123
-check:output =~Error: No BMC tar file found
-check:output =~Error: No Host tar file found
+check:output =~Error: No BMC tar file found|Can't open directory
 check:output!~Attempting to
 check:rc != 0
 cmd:touch /tmp/bogus123/witherspoon.pnor.squashfs.tar 
 check:rc == 0
 cmd:rflash $$CN -d /tmp/bogus123
-check:output =~Error: No BMC tar file found
-check:output =~Error: No Host tar file found
+check:output =~Error: No BMC tar file found|Can't open directory
 check:output!~Attempting to
 check:rc != 0
 cmd:rm -rf /tmp/bogus123

--- a/xCAT-test/autotest/testcase/rspconfig/cases0
+++ b/xCAT-test/autotest/testcase/rspconfig/cases0
@@ -127,7 +127,7 @@ start:rspconfig_set_vlan
 description:rspconfig change openbmc gateway
 Attribute: $$CN-The operation object of rspconfig command
 cmd:rspconfig $$CN vlan=0
-check:output=~Error: Invalid parameter for option vlan
+check:output=~Error: Invalid parameter for option vlan|Error: VLAN must be configured with IP, netmask and gateway
 check:rc!=0
 cmd:rspconfig $$CN vlan=111
 check:output=~Error: VLAN must be configured with IP, netmask and gateway
@@ -258,6 +258,7 @@ check:rc == 0
 cmd:rspconfig $$CN hostname=*
 check:rc == 0
 check:output =~ Invalid OpenBMC Hostname
+cmd:ssh __GETNODEATTR(f6u03,bmc)__ "hostname"
 end
 
 
@@ -342,17 +343,15 @@ cmd:rspconfig $$CN sshcfg
 check:rc == 0
 cmd:ssh __GETNODEATTR($$CN,bmc)__ "hostname" | tee /tmp/rspconfig_set_hostname/working_hostname
 check:rc == 0
-cmd:cat  /tmp/rspconfig_set_hostname/working_hostname
-check:rc == 0
 cmd:a=$(cat /tmp/rspconfig_set_hostname/working_hostname); rspconfig $$CN hostname=test_$a |tee /tmp/rspconfig_set_hostname/rspconfig_output 
 check:rc == 0
-cmd:grep -i 'BMC hostname' /tmp/rspconfig_set_hostname/rspconfig_output|awk -F':' '{print $3}'  |sed s/\\s//g > /tmp/rspconfig_set_hostname/rspconfig_get_hostname
+cmd:grep -i '$$CN: BMC hostname:' /tmp/rspconfig_set_hostname/rspconfig_output|awk -F':' '{print $3}'  |sed s/\\s//g |tee /tmp/rspconfig_set_hostname/rspconfig_get_hostname
 check:rc == 0
 cmd:ssh __GETNODEATTR($$CN,bmc)__ "hostname" | tee /tmp/rspconfig_set_hostname/new_working_hostname
 check:rc == 0
-cmd:diff /tmp/rspconfig_set_hostname/rspconfig_get_hostname /tmp/rspconfig_set_hostname/new_working_hostname
+cmd:diff -y /tmp/rspconfig_set_hostname/rspconfig_get_hostname /tmp/rspconfig_set_hostname/new_working_hostname
 check:rc == 0
-cmd:diff /tmp/rspconfig_set_hostname/new_working_hostname /tmp/rspconfig_set_hostname/working_hostname
+cmd:diff -y /tmp/rspconfig_set_hostname/new_working_hostname /tmp/rspconfig_set_hostname/working_hostname
 check:rc != 0
 cmd:a=test_$(cat /tmp/rspconfig_set_hostname/working_hostname);b=$(cat /tmp/rspconfig_set_hostname/new_working_hostname);echo "a=$a b=$b";if [ "$a" = "$b" ];then exit 0;else exit 1; fi
 check:rc == 0


### PR DESCRIPTION
Refine some test cases based on new output.

The UT are:
```
------START::rspconfig_set_vlan::Time:Wed Apr  4 01:16:25 2018------

RUN:rspconfig f6u03 vlan=0 [Wed Apr  4 01:16:25 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u03: Error: VLAN must be configured with IP, netmask and gateway
CHECK:output =~ Error: Invalid parameter for option vlan|Error: VLAN must be configured with IP, netmask and gateway	[Pass]
CHECK:rc != 0	[Pass]

RUN:rspconfig f6u03 vlan=111 [Wed Apr  4 01:16:25 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
f6u03: Error: VLAN must be configured with IP, netmask and gateway
CHECK:output =~ Error: VLAN must be configured with IP, netmask and gateway	[Pass]
CHECK:rc != 0	[Pass]

------END::rspconfig_set_vlan::Passed::Time:Wed Apr  4 01:16:26 2018 ::Duration::1 sec------
------START::rspconfig_set_hostname::Time:Wed Apr  4 01:16:26 2018------

RUN:mkdir -p /tmp/rspconfig_set_hostname [Wed Apr  4 01:16:26 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:rspconfig f6u03 sshcfg [Wed Apr  4 01:16:26 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
ssh keys copied to 10.6.3.100
CHECK:rc == 0	[Pass]

RUN:ssh __GETNODEATTR(f6u03,bmc)__ "hostname" | tee /tmp/rspconfig_set_hostname/working_hostname [Wed Apr  4 01:16:27 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
10.6.3.100
CHECK:rc == 0	[Pass]

RUN:a=$(cat /tmp/rspconfig_set_hostname/working_hostname); rspconfig f6u03 hostname=test_$a |tee /tmp/rspconfig_set_hostname/rspconfig_output [Wed Apr  4 01:16:28 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
Wed Apr  4 01:16:29 2018 f6u03: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.3.100/login -d '{"data": ["root", "xxxxxx"]}'
Wed Apr  4 01:16:29 2018 f6u03: [openbmc_debug] login 200 OK
Wed Apr  4 01:16:29 2018 f6u03: [openbmc_debug] set_hostname curl -k -c cjar -b cjar -X PUT -H "Content-Type: application/json" https://10.6.3.100/xyz/openbmc_project/network/config/attr/HostName -d '{"data": "test_10.6.3.100"}'
Wed Apr  4 01:16:30 2018 f6u03: [openbmc_debug] set_hostname 200 OK
f6u03: BMC Setting BMC Hostname...
Wed Apr  4 01:16:30 2018 f6u03: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.3.100/login -d '{"data": ["root", "xxxxxx"]}'
Wed Apr  4 01:16:30 2018 f6u03: [openbmc_debug] login 200 OK
Wed Apr  4 01:16:30 2018 f6u03: [openbmc_debug] get_netinfo curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://10.6.3.100/xyz/openbmc_project/network/enumerate
Wed Apr  4 01:16:30 2018 f6u03: [openbmc_debug] get_netinfo 200 OK
Wed Apr  4 01:16:30 2018 f6u03: [openbmc_debug] get_netinfo Found LinkLocal address 169.254.164.2 for interface /xyz/openbmc_project/network/eth0, Ignoring...
f6u03: BMC Hostname: test_10.6.3.100
CHECK:rc == 0	[Pass]

RUN:grep -i 'f6u03: BMC hostname:' /tmp/rspconfig_set_hostname/rspconfig_output|awk -F':' '{print $3}'  |sed s/\\s//g |tee /tmp/rspconfig_set_hostname/rspconfig_get_hostname [Wed Apr  4 01:16:30 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
test_10.6.3.100
CHECK:rc == 0	[Pass]

RUN:ssh __GETNODEATTR(f6u03,bmc)__ "hostname" | tee /tmp/rspconfig_set_hostname/new_working_hostname [Wed Apr  4 01:16:30 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
test_10.6.3.100
CHECK:rc == 0	[Pass]

RUN:diff -y /tmp/rspconfig_set_hostname/rspconfig_get_hostname /tmp/rspconfig_set_hostname/new_working_hostname [Wed Apr  4 01:16:31 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
test_10.6.3.100							test_10.6.3.100
CHECK:rc == 0	[Pass]

RUN:diff -y /tmp/rspconfig_set_hostname/new_working_hostname /tmp/rspconfig_set_hostname/working_hostname [Wed Apr  4 01:16:31 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
test_10.6.3.100						      |	10.6.3.100
CHECK:rc != 0	[Pass]

RUN:a=test_$(cat /tmp/rspconfig_set_hostname/working_hostname);b=$(cat /tmp/rspconfig_set_hostname/new_working_hostname);echo "a=$a b=$b";if [ "$a" = "$b" ];then exit 0;else exit 1; fi [Wed Apr  4 01:16:31 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
a=test_10.6.3.100 b=test_10.6.3.100
CHECK:rc == 0	[Pass]

RUN:rm -rf /tmp/rspconfig_set_hostname [Wed Apr  4 01:16:31 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::rspconfig_set_hostname::Passed::Time:Wed Apr  4 01:16:31 2018 ::Duration::5 sec------
------START::rflash_option_d_with_non_existent_dir::Time:Wed Apr  4 01:16:31 2018------

RUN:rm -rf /tmp/bogus123 [Wed Apr  4 01:16:31 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:rflash f6u03 -d /tmp/bogus123 [Wed Apr  4 01:16:31 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: Can't open directory : /tmp/bogus123
Wed Apr  4 01:16:32 2018 OpenBMC: [openbmc_debug_perl]
CHECK:output =~ Error: Can't open directory	[Pass]
CHECK:output !~ Attempting to	[Pass]
CHECK:rc != 0	[Pass]

RUN:rflash f6u03 /tmp/bogus123 [Wed Apr  4 01:16:32 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Wed Apr  4 01:16:32 2018 OpenBMC: [openbmc_debug_perl]
f6u03: Error: Invalid option specified
CHECK:output =~ Error: Invalid option specified	[Pass]
CHECK:rc != 0	[Pass]

RUN:mkdir -p /tmp/bogus123 [Wed Apr  4 01:16:32 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:rflash f6u03 /tmp/bogus123 -d [Wed Apr  4 01:16:32 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: Can't open directory : /tmp/bogus123
Wed Apr  4 01:16:32 2018 OpenBMC: [openbmc_debug_perl]
CHECK:output =~ Error: No BMC tar file found|Can't open directory	[Pass]
CHECK:output !~ Attempting to	[Pass]
CHECK:rc != 0	[Pass]

RUN:touch /tmp/bogus123/obmc-phosphor-image-witherspoon.ubi.mtd.tar [Wed Apr  4 01:16:33 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:rflash f6u03 -d /tmp/bogus123 [Wed Apr  4 01:16:33 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Error: Can't open directory : /tmp/bogus123
Wed Apr  4 01:16:33 2018 OpenBMC: [openbmc_debug_perl]
CHECK:output =~ Error: No BMC tar file found|Can't open directory	[Pass]
CHECK:output !~ Attempting to	[Pass]
CHECK:rc != 0	[Pass]

RUN:touch /tmp/bogus123/witherspoon.pnor.squashfs.tar [Wed Apr  4 01:16:33 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:rflash f6u03 -d /tmp/bogus123 [Wed Apr  4 01:16:33 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: Can't open directory : /tmp/bogus123
Wed Apr  4 01:16:33 2018 OpenBMC: [openbmc_debug_perl]
CHECK:output =~ Error: No BMC tar file found|Can't open directory	[Pass]
CHECK:output !~ Attempting to	[Pass]
CHECK:rc != 0	[Pass]

RUN:rm -rf /tmp/bogus123 [Wed Apr  4 01:16:34 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::rflash_option_d_with_non_existent_dir::Passed::Time:Wed Apr  4 01:16:34 2018 ::Duration::3 sec------
------START::reventlog_s_openbmc::Time:Wed Apr  4 01:16:34 2018------

RUN:reventlog f6u03 10 -s [Wed Apr  4 01:16:34 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u03: Error: The -s option is not supported for OpenBMC.
CHECK:output =~ The -s option is not supported for OpenBMC	[Pass]
CHECK:rc != 0	[Pass]

RUN:reventlog f6u03 10 -s 1 [Wed Apr  4 01:16:34 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u03: Error: The -s option is not supported for OpenBMC.
CHECK:output =~ The -s option is not supported for OpenBMC	[Pass]
CHECK:rc != 0	[Pass]

RUN:reventlog f6u03 -s all [Wed Apr  4 01:16:34 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
f6u03: Error: Only one option is supported at the same time for reventlog
CHECK:output =~ The -s option is not supported for OpenBMC|Only one option is supported at the same time for reventlog	[Pass]
CHECK:rc != 0	[Pass]

RUN:reventlog f6u03 -s [Wed Apr  4 01:16:35 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u03: Error: Unsupported command: reventlog -s
CHECK:output =~ Error: Unsupported command	[Pass]
CHECK:rc != 0	[Pass]

RUN:reventlog f6u03 all aaa [Wed Apr  4 01:16:35 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u03: Error: Only one option is supported at the same time for reventlog
CHECK:output =~ Error: Only one option is supported at the same time	[Pass]
CHECK:rc != 0	[Pass]

------END::reventlog_s_openbmc::Passed::Time:Wed Apr  4 01:16:35 2018 ::Duration::1 sec------
------Total: 4 , Failed: 0------
```