### PR TITLE
Add postscript to enable CAPI mode for mlnxofed

### DIFF
--- a/xCAT/postscripts/enablecapi
+++ b/xCAT/postscripts/enablecapi
@@ -14,51 +14,46 @@ fi
 #
 #---------------------------------------------------------------------------
 
-#check if mlnx ofed installed
-if [ ! -x /usr/bin/ofed_info ]; then
-   logger -t xcat -p local4.err "MOFED is not installed"
-   echo "MOFED is not installed on the system"
-   exit -1
-fi
+function logerr {
+    echo "$@"
+    logger -t xcat -p local4.err $@
+}
+
+
+#check if mlnx ofed commands are installed
+COMMANDS="ofed_info mst mlxconfig"
+for CMD in ${COMMANDS}; do
+    RC=`command -v ${CMD} >> /dev/nul 2>&1; echo $?`
+    if [[ ${RC} != 0 ]]; then
+        ERRMSG="Command: ${CMD} is not found, unable to run the scripts"
+        logerr $ERRMSG
+        exit 1
+    fi
+done
 
 #mofed version at least 4.3-1
 version=`/usr/bin/ofed_info -n`
 majorversion=`echo $version | cut -d- -f1`
 minorversion=`echo $version | cut -d- -f2`
 if (( $(echo "$majorversion < 4.3" |bc -l) )); then
-   logger -t xcat -p local4.err "Current MOFED version is $version and needs to be at least 4.3-1"
-   echo "Current MOFED version is $version and needs to be at least 4.3-1"
-   exit -1
+   ERRMSG="Current MOFED version is $version and needs to be at least 4.3-1"
+   logerr $ERRMSG
+   exit 1
 fi
 if (( $(echo "$majorversion == 4.3" |bc -l) )); then
    minor=`echo $minorversion | cut -d. -f1`
    if (( $(echo "$minor < 1") )); then
-       logger -t xcat -p local4.err "MOFED version needs to be at least 4.3-1"
-       echo "Current MOFED version is $version and needs to be at least 4.3-1"
-       exit -1
+       ERRMSG="Current MOFED version is $version and needs to be at least 4.3-1"
+       logerr $ERRMSG
+       exit 1
    fi 
-fi
-
-#check if mst is existed
-if [ ! -x /usr/bin/mst ]; then
-   logger -t xcat -p local4.err "mst command is not available"
-   echo "mst command is not available"
-   exit -1
 fi
 
 service mst restart >/dev/null 2>&1
 if [ "$?" != "0" ] ;then
-    logger -t xcat -p local4.err "[Error] failed to start mst."
-    echo "[Error] failed to start mst."
-    exit -1
-fi
-
-
-#check if mlxconfig is existed
-if [ ! -x /usr/bin/mlxconfig ]; then
-   logger -t xcat -p local4.err "mlxconfig command is not available"
-   echo "mlxconfig command is not available"
-   exit -1
+    ERRMSG "[Error] failed to start mst."
+    logerr $ERRMSG
+    exit 1
 fi
 
 reboot_flag=0
@@ -79,9 +74,7 @@ done
 
 if [[ $reboot_flag == 0 ]]; then
     echo "Didn't find ConnectX5 Devices, will not apply the new configuration"
-fi
-
-if [[ $reboot_flag == 1 ]]; then
+else
     echo "******************************************************"
     echo "     New configuration applied"
     echo "     Please reboot system to load new configurations"

--- a/xCAT/postscripts/enablecapi
+++ b/xCAT/postscripts/enablecapi
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+if [ "$(uname -s|tr 'A-Z' 'a-z')" = "linux" ];then
+   str_dir_name=`dirname $0`
+   . $str_dir_name/xcatlib.sh
+fi
+
+#---------------------------------------------------------------------------
+#=head1  enablecapi
+#=head2  enable CAPI and tunnel Atomics for compute nodes
+#        at least MOFED 4.3.1 has to be installed and only support on ConnectX5 
+#
+#        updatenode <node> enablecapi
+#
+#---------------------------------------------------------------------------
+
+#check if mlnx ofed installed
+if [ ! -x /usr/bin/ofed_info ]; then
+   logger -t xcat -p local4.err "MOFED is not installed"
+   echo "MOFED is not installed on the system"
+   exit -1
+fi
+
+#mofed version at least 4.3-1
+version=`/usr/bin/ofed_info -n`
+majorversion=`echo $version | cut -d- -f1`
+minorversion=`echo $version | cut -d- -f2`
+if (( $(echo "$majorversion < 4.3" |bc -l) )); then
+   logger -t xcat -p local4.err "Current MOFED version is $version and needs to be at least 4.3-1"
+   echo "Current MOFED version is $version and needs to be at least 4.3-1"
+   exit -1
+fi
+if (( $(echo "$majorversion == 4.3" |bc -l) )); then
+   minor=`echo $minorversion | cut -d. -f1`
+   if (( $(echo "$minor < 1") )); then
+       logger -t xcat -p local4.err "MOFED version needs to be at least 4.3-1"
+       echo "Current MOFED version is $version and needs to be at least 4.3-1"
+       exit -1
+   fi 
+fi
+
+#check if mst is existed
+if [ ! -x /usr/bin/mst ]; then
+   logger -t xcat -p local4.err "mst command is not available"
+   echo "mst command is not available"
+   exit -1
+fi
+
+service mst restart >/dev/null 2>&1
+if [ "$?" != "0" ] ;then
+    logger -t xcat -p local4.err "[Error] failed to start mst."
+    echo "[Error] failed to start mst."
+    exit -1
+fi
+
+
+#check if mlxconfig is existed
+if [ ! -x /usr/bin/mlxconfig ]; then
+   logger -t xcat -p local4.err "mlxconfig command is not available"
+   echo "mlxconfig command is not available"
+   exit -1
+fi
+
+reboot_flag=0
+
+for x in `ls /dev/mst/mt*`
+do
+    mlxconfig -y -d $x q | grep 'ConnectX5' >/dev/null 2>&1 
+    if [ $? == 0 ]; then
+        mlxconfig -y -d $x set ADVANCED_PCI_SETTINGS=true >/dev/null 2>&1
+        mlxconfig -y -d $x set IBM_CAPI_EN=true  >/dev/null 2>&1
+        mlxconfig -y -d $x set IBM_TUNNELED_ATOMIC_EN=true  >/dev/null 2>&1
+        mlxconfig -y -d $x set IBM_AS_NOTIFY_EN=true  >/dev/null 2>&1
+        echo "Apply new Configuration for $x:"
+        mlxconfig -y -d $x q | grep  'IBM'
+        reboot_flag=1
+    fi
+done
+
+if [[ $reboot_flag == 0 ]]; then
+    echo "Didn't find ConnectX5 Devices, will not apply the new configuration"
+fi
+
+if [[ $reboot_flag == 1 ]]; then
+    echo "******************************************************"
+    echo "     New configuration applied"
+    echo "     Please reboot system to load new configurations"
+    echo "******************************************************"
+fi
+
+exit 0
+


### PR DESCRIPTION
New Postscript to enable CAPI mode for Mellanox OFED Drivers .  This scripts only support  ConnectX5 and mlnxofed version must at least 4.3.1.

They system needs to reboot after run `updatenode <nodename> enablecapi`   

````
# updatenode mid08tor03cn01 enablecapi
mid08tor03cn01: trying to download postscripts...
mid08tor03cn01: postscripts downloaded successfully
mid08tor03cn01: trying to get mypostscript from 172.20.253.31...
mid08tor03cn01: Thu Apr  5 09:27:14 EDT 2018 Running postscript: enablecapi
mid08tor03cn01: Apply new Configuration for /dev/mst/mt4121_pciconf0:
mid08tor03cn01:          IBM_TUNNELED_ATOMIC_EN              True(1)
mid08tor03cn01:          IBM_AS_NOTIFY_EN                    True(1)
mid08tor03cn01:          IBM_CAPI_EN                         True(1)
mid08tor03cn01: Apply new Configuration for /dev/mst/mt4121_pciconf0.1:
mid08tor03cn01:          IBM_TUNNELED_ATOMIC_EN              True(1)
mid08tor03cn01:          IBM_AS_NOTIFY_EN                    True(1)
mid08tor03cn01:          IBM_CAPI_EN                         True(1)
mid08tor03cn01: Apply new Configuration for /dev/mst/mt4121_pciconf1:
mid08tor03cn01:          IBM_TUNNELED_ATOMIC_EN              True(1)
mid08tor03cn01:          IBM_AS_NOTIFY_EN                    True(1)
mid08tor03cn01:          IBM_CAPI_EN                         True(1)
mid08tor03cn01: Apply new Configuration for /dev/mst/mt4121_pciconf1.1:
mid08tor03cn01:          IBM_TUNNELED_ATOMIC_EN              True(1)
mid08tor03cn01:          IBM_AS_NOTIFY_EN                    True(1)
mid08tor03cn01:          IBM_CAPI_EN                         True(1)
mid08tor03cn01: ******************************************************
mid08tor03cn01:      New configuration applied
mid08tor03cn01:      Please reboot system to load new configurations
mid08tor03cn01: ******************************************************
mid08tor03cn01: postscript: enablecapi exited with code 0
mid08tor03cn01: Running of postscripts has completed.
````