### PR TITLE
Print out error msg for xcatprobe switch_macmap command if switch passwordless is not enabled

### DIFF
--- a/perl-xCAT/xCAT/MacMap.pm
+++ b/perl-xCAT/xCAT/MacMap.pm
@@ -356,7 +356,7 @@ sub dump_mac_info {
                 $ret{$switch}->{ErrorStr} = $self->{macinfo}->{$switch}->{ErrorStr};
 
                 # To show the error message that the username/password related error is for SNMP only
-                if ($ret{$switch}->{ErrorStr} =~ /user\s*name|password/i) {
+                if ($ret{$switch}->{ErrorStr} =~ /user\s*name|password$/i) {
                     $ret{$switch}->{ErrorStr} .= " through SNMP";
                 }
             } else {
@@ -728,7 +728,12 @@ sub refresh_switch {
 
         my @res=xCAT::Utils->runcmd("ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no $switch 'bridge fdb show|grep -i -v permanent|tr A-Z a-z  2>/dev/null' 2>/dev/null",-1);
         if ($::RUNCMD_RC) {
-            xCAT::MsgUtils->message("S", "Failed to get mac table with ssh to $switch, fall back to snmp! To obtain mac table with ssh, please make sure the passwordless root ssh to $switch is available");
+            my $errmsg = "Failed to get MAC table from $switch. Make sure passwordless SSH to the switch is enabled.";
+            xCAT::MsgUtils->message("S", $errmsg);
+            if ($self->{collect_mac_info}) {
+                $self->{macinfo}->{$switch}->{ErrorStr} = $errmsg;
+            }
+            return;
         }else{
             foreach (@res){
                 if($_ =~ m/^([0-9a-z]{2}:[0-9a-z]{2}:[0-9a-z]{2}:[0-9a-z]{2}:[0-9a-z]{2}:[0-9a-z]{2}) dev swp([0-9]+) vlan ([0-9]+) .*/){

--- a/perl-xCAT/xCAT/MacMap.pm
+++ b/perl-xCAT/xCAT/MacMap.pm
@@ -728,12 +728,12 @@ sub refresh_switch {
 
         my @res=xCAT::Utils->runcmd("ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no $switch 'bridge fdb show|grep -i -v permanent|tr A-Z a-z  2>/dev/null' 2>/dev/null",-1);
         if ($::RUNCMD_RC) {
-            my $errmsg = "Failed to get MAC table from $switch. Make sure passwordless SSH to the switch is enabled.";
-            xCAT::MsgUtils->message("S", $errmsg);
+            xCAT::MsgUtils->message("S", "Failed to get mac table with ssh to $switch, fall back to snmp! To obtain mac table with ssh, please make sure the passwordless root ssh to $switch is available");
             if ($self->{collect_mac_info}) {
+                my $errmsg = "Failed to get MAC table from $switch. Make sure passwordless SSH to the switch is enabled.";
                 $self->{macinfo}->{$switch}->{ErrorStr} = $errmsg;
+                return;
             }
-            return;
         }else{
             foreach (@res){
                 if($_ =~ m/^([0-9a-z]{2}:[0-9a-z]{2}:[0-9a-z]{2}:[0-9a-z]{2}:[0-9a-z]{2}:[0-9a-z]{2}) dev swp([0-9]+) vlan ([0-9]+) .*/){


### PR DESCRIPTION
For issue #5060 

For the cumulus switch, xCAT get Mac table from ssh command instead of SNMP commands.  If switch passwordless is not enabled.  the command will failed and mac address fields from `xcatprobe switch_macmap` will be empty.   Instead of no mac address return to user,  we will log a error message.

```
# xcatprobe switch_macmap mid08tor03
mid08tor03 - Failed to get MAC table. Make sure passwordless SSH to the switch is enabled.                        [FAIL]
```