### PR TITLE
Show error msg when set hostname as IP address

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
@@ -301,9 +301,10 @@ rmdir \"/tmp/$userid\" \n")
     def _set_hostname(self, hostname, **kw):
         node = kw['node']
         if hostname == '*':
-            if kw['nodeinfo']['bmc'] == kw['nodeinfo']['bmcip']:
-                self.callback.info("%s: set BMC ip as BMC Hostname" % node)
-            hostname = kw['nodeinfo']['bmc']
+            if kw['nodeinfo']['bmc'] != kw['nodeinfo']['bmcip']:
+                hostname = kw['nodeinfo']['bmc']
+            else:
+                return self.callback.error("Invalid OpenBMC Hostname %s, can't set to OpenBMC" % kw['nodeinfo']['bmc'], node)
         self._set_apis_values("hostname", hostname, **kw)
         self._get_netinfo(hostname=True, ntpserver=False, **kw) 
         return
@@ -383,7 +384,15 @@ rmdir \"/tmp/$userid\" \n")
         try:
             obmc.login()
             obmc.set_apis_values(key, value)
-        except (SelfServerException, SelfClientException) as e:
+        except SelfServerException as e:
+            return self.callback.error(e.message, node)
+        except SelfClientException:
+            if e.code == 404:
+                return self.callback.error('404 Not Found - Requested endpoint does not exists and may \
+                                            indicate function is not supported on this OpenBMC firmware.', node)
+            if e.code == 403:
+                return self.callback.error('403 Forbidden - Requested endpoint does not exists and may \
+                                            indicate function is not yet supported by OpenBMC firmware.', node)
             return self.callback.error(e.message, node)
 
         self.callback.info("%s: BMC Setting %s..." % (node, openbmc.RSPCONFIG_APIS[key]['display_name']))
@@ -396,7 +405,15 @@ rmdir \"/tmp/$userid\" \n")
             obmc.login()
             value = obmc.get_apis_values(key)
 
-        except (SelfServerException, SelfClientException) as e:
+        except SelfServerException as e:
+            return self.callback.error(e.message, node)
+        except SelfClientException:
+            if e.code == 404:
+                return self.callback.error('404 Not Found - Requested endpoint does not exists and may \
+                                            indicate function is not supported on this OpenBMC firmware.', node)
+            if e.code == 403:
+                return self.callback.error('403 Forbidden - Requested endpoint does not exists and may \
+                                            indicate function is not yet supported by OpenBMC firmware.', node)
             return self.callback.error(e.message, node)
 
         if isinstance(value, dict):

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
@@ -388,10 +388,10 @@ rmdir \"/tmp/$userid\" \n")
             return self.callback.error(e.message, node)
         except SelfClientException:
             if e.code == 404:
-                return self.callback.error('404 Not Found - Requested endpoint does not exists and may \
+                return self.callback.error('404 Not Found - Requested endpoint does not exist or may \
                                             indicate function is not supported on this OpenBMC firmware.', node)
             if e.code == 403:
-                return self.callback.error('403 Forbidden - Requested endpoint does not exists and may \
+                return self.callback.error('403 Forbidden - Requested endpoint does not exist or may \
                                             indicate function is not yet supported by OpenBMC firmware.', node)
             return self.callback.error(e.message, node)
 
@@ -409,10 +409,10 @@ rmdir \"/tmp/$userid\" \n")
             return self.callback.error(e.message, node)
         except SelfClientException:
             if e.code == 404:
-                return self.callback.error('404 Not Found - Requested endpoint does not exists and may \
+                return self.callback.error('404 Not Found - Requested endpoint does not exist or may \
                                             indicate function is not supported on this OpenBMC firmware.', node)
             if e.code == 403:
-                return self.callback.error('403 Forbidden - Requested endpoint does not exists and may \
+                return self.callback.error('403 Forbidden - Requested endpoint does not exist or may \
                                             indicate function is not yet supported by OpenBMC firmware.', node)
             return self.callback.error(e.message, node)
 

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2423,7 +2423,7 @@ sub deal_with_response {
                     my $log_id = (split ('/', $cur_url))[5];
                     $error = "Invalid ID=$log_id provided to be resolved. [$::RESPONSE_FORBIDDEN]";
                 } else{
-                    $error = "$::RESPONSE_FORBIDDEN - Requested endpoint does not exists and may indicate function is not yet supported by OpenBMC firmware.";
+                    $error = "$::RESPONSE_FORBIDDEN - Requested endpoint does not exist or may indicate function is not yet supported by OpenBMC firmware.";
                 }
             # Handle 404 
             } elsif ($response->status_line eq $::RESPONSE_NOT_FOUND) {
@@ -2434,7 +2434,7 @@ sub deal_with_response {
                     $error = "Invalid ID provided to delete.  Use the -l option to view valid firmware IDs.";
                 } elsif (($node_info{$node}{cur_status} eq "RSPCONFIG_API_CONFIG_QUERY_RESPONSE") || 
                          ($node_info{$node}{cur_status} eq "RSPCONFIG_API_CONFIG_ATTR_RESPONSE")) { 
-                    $error = "$::RESPONSE_NOT_FOUND - Requested endpoint does not exists and may indicate function is not supported on this OpenBMC firmware.";
+                    $error = "$::RESPONSE_NOT_FOUND - Requested endpoint does not exist or may indicate function is not supported on this OpenBMC firmware.";
                 } else {
                     $error = "[" . $response->code . "] " . $response_info->{'data'}->{'description'};
                 }


### PR DESCRIPTION
#5056 

UT:
Run ``rspconfig hostname=*``, but attribute "bmc" is IP address:
```
# rspconfig f6u03 hostname=*
f6u03: Error: Invalid OpenBMC Hostname 10.6.3.100, can't set to OpenBMC
```

#5053 -- Modify error msg when get "404" response for rspconfig api
```
f6u03: Error: 404 Not Found - Requested endpoint does not exists and may indicate function is not supported on this OpenBMC firmware.
```