### PR TITLE
modify rflash args for docopt parse

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/common/task.py
+++ b/xCAT-openbmc-py/lib/python/agent/common/task.py
@@ -54,6 +54,7 @@ class ParallelNodesCommand(BaseCommand):
         """
         self.inventory = inventory
         self.callback = callback
+        self.cwd = kwargs.get('cwd')
         self.debugmode = kwargs.get('debugmode')
         self.verbose = kwargs.get('verbose')
 

--- a/xCAT-openbmc-py/lib/python/agent/common/utils.py
+++ b/xCAT-openbmc-py/lib/python/agent/common/utils.py
@@ -98,7 +98,7 @@ def mask_int2str(mask_int):
 
 def get_full_path(cwd, directory):
     if not os.path.isabs(directory): 
-        directory = '%s/%s' % (cwd, directory)
+        directory = os.path.join(cwd, directory)
     return directory
 
 class Messager(object):

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_inventory.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_inventory.py
@@ -34,7 +34,7 @@ class OpenBMCInventoryTask(ParallelNodesCommand):
                 if 'version=' in line:
                     version = line.split('=')[-1].strip()
                 if 'purpose=' in line:
-                    purpose = line.split('=')[-1].strip().split('.')[-1]
+                    purpose = line.split('=')[-1].strip()
                 if version and purpose:
                     break
 

--- a/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
+++ b/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
@@ -190,6 +190,9 @@ class OpenBMCManager(base.BaseManager):
         try:
             opts = docopt(rflash_usage, argv=args)
             self.verbose = opts.pop('--verbose')
+        except DocoptExit as e:
+            self.messager.error("Failed to parse args by docopt: %s" % e)
+            return
         except Exception as e:
             self.messager.error("Failed to parse arguments for rflash: %s" % args)
             return

--- a/xCAT-server/lib/xcat/plugins/openbmc2.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc2.pm
@@ -508,6 +508,23 @@ sub refactor_args {
             unshift @$extrargs, "list";
         }
     }
+    if ($command eq "rflash") {
+        my @new_args = ('') x 4;
+        foreach my $tmp (@$extrargs) {
+            if ($tmp =~ /^-/) {
+                if ($tmp !~ /^-V$|^--verbose$/) {
+                    $new_args[0] = $tmp;
+                } elsif ($tmp =~ /^--no-host-reboot$/) {
+                    $new_args[2] = $tmp;
+                } else {
+                    $new_args[3] = $tmp;
+                }
+            } else {
+                $new_args[1] = $tmp;
+            }
+        }
+        @$extrargs = grep(/.+/, @new_args);
+    } 
     return 0;
 }
 


### PR DESCRIPTION
1. #4766  Modify args format in openbmc2.pm, make that the args received by python is "-x [xxx] [-V|--verbose]"
2. Get "cwd" as task's member variable
3. use ``os.path.join`` to get full path
4. output for rspconfig -c
before modify:
```
TAR BMC Firmware Product Version: ibm-v2.0-0-r41-0-gd0c319e
```
after modify:
```
TAR xyz.openbmc_project.Software.Version.VersionPurpose.BMC Firmware Product Version: ibm-v2.0-0-r41-0-gd0c319e
```
5. catch "DocoptExit" error, and print out msg.