### PR TITLE
Avoiding error log for `installmonitor` requesting during provisioning

### DIFF
--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -598,7 +598,8 @@ sub do_installm_service {
                     chomp $text;
                     xCAT::MsgUtils->trace(0, "E", "xcatd: install monitor does not support \'$text\', the connection request from $conn_peer_addr will be ignored.");
                     close($conn); #close it to avoid the DDOS attack
-                    last;
+                    alarm(2);
+                    next;
                 }
                 xCAT::MsgUtils->trace(0, "I", "xcatd: finish a connection request for $node from $conn_peer_addr");
                 alarm(2);

--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -409,7 +409,7 @@ sub do_installm_service {
                 }
             }
             $conn_peer_addr = $conn->peerhost();
-            xCAT::MsgUtils->trace(0, "I", "xcatd: received a connection request from $conn_peer_addr");
+            xCAT::MsgUtils->trace(0, "I", "xcatd: install monitor received a connection request from $conn_peer_addr");
 
             my $client_name;
             my $client_aliases;
@@ -590,12 +590,15 @@ sub do_installm_service {
                     `/usr/bin/cat $myfile | /usr/bin/sed "/BASECUST_REMOVAL/d">/tmp/$text.nimtmp`;
                     `/usr/bin/mv /tmp/$text.nimtmp $myfile`;
                     close($conn);
+                } elsif ($text =~ /installmonitor/) {
+                    xCAT::MsgUtils->trace(0, "I", "xcatd: handle installmonitor requesting from $text...");
+                    close($conn);
                 } else {
                     sleep 0.01;
                     chomp $text;
                     xCAT::MsgUtils->trace(0, "E", "xcatd: install monitor does not support \'$text\', the connection request from $conn_peer_addr will be ignored.");
                     close($conn); #close it to avoid the DDOS attack
-                    next;
+                    last;
                 }
                 xCAT::MsgUtils->trace(0, "I", "xcatd: finish a connection request for $node from $conn_peer_addr");
                 alarm(2);


### PR DESCRIPTION
To fix #5067 

UT:
1, patch xcatd and restart xcatd
2,reprovision a stateful node, and check if the ERR logs not found.

```
Apr  9 04:26:47 sn02 xcat[21777]:  INFO xcatd: install monitor received a connection request from 172.20.226.10
Apr  9 04:26:47 sn02 xcat[21777]:  INFO xcatd: 172.20.226.10 is matched with node mid08tor03cn10
Apr  9 04:26:47 sn02 xcat[21777]:  INFO xcatd: triggering 'updatenodestat mid08tor03cn10 installing'...
Apr  9 04:26:47 sn02 xcat[21777]:  mid08tor03cn10 status: installing statustime: 04-09-2018 04:26:47
Apr  9 04:26:47 sn02 xcat[21777]:  INFO xcatd: finish a connection request for mid08tor03cn10 from 172.20.226.10
Apr  9 04:26:47 sn02 xcat[21777]:  INFO xcatd: install monitor received a connection request from 172.20.226.10
Apr  9 04:26:47 sn02 xcat[21777]:  INFO xcatd: 172.20.226.10 is matched with node mid08tor03cn10
Apr  9 04:26:47 sn02 xcat[21777]:  INFO xcatd: handle installmonitor requesting from installmonitor#012...
Apr  9 04:26:47 sn02 xcat[21777]:  INFO xcatd: finish a connection request for mid08tor03cn10 from 172.20.226.10
```