### PR TITLE
support rinv/rvitals run with Verbose option only

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
+++ b/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
@@ -217,8 +217,8 @@ class OpenBMCManager(base.BaseManager):
     def rinv(self, nodesinfo, args):
 
         # 1, parse agrs
-        if not args:
-            args = ['all']
+        if not args or (len(args) == 1 and args[0] in ['-V', '--verbose']):
+            args.append('all')
 
         rinv_usage = """
         Usage:
@@ -385,8 +385,8 @@ class OpenBMCManager(base.BaseManager):
     def rvitals(self, nodesinfo, args):
 
         # 1, parse agrs
-        if not args:
-            args = ['all']
+        if not args or (len(args) == 1 and args[0] in ['-V', '--verbose']):
+            args.append('all')
 
         rvitals_usage = """
         Usage:


### PR DESCRIPTION
#4937 

before modify:
```
# rvitals mid05tor12cn13 -V
Error: [briggs01]: Failed to parse arguments for rvitals: ['-V']
```

UT:
```
# rinv f6u03 -V
[c910f03c05k04]: f6u03: BMC BuildDate :
[c910f03c05k04]: f6u03: BMC FieldReplaceable : 0
[c910f03c05k04]: f6u03: BMC Manufacturer : IBM
[c910f03c05k04]: f6u03: BMC Model :
......
```

```
# rvitals f6u03 -V
[c910f03c05k04]: f6u03: Ambient: 24.635 C
[c910f03c05k04]: f6u03: Fan0 0: 0 RPMS
[c910f03c05k04]: f6u03: Fan0 1: 0 RPMS
[c910f03c05k04]: f6u03: Fan1 0: 0 RPMS
[c910f03c05k04]: f6u03: Fan1 1: 0 RPMS
....
```