### PR TITLE
fix bug of test case go_xcat_with_x

### DIFF
--- a/xCAT-test/autotest/testcase/go-xcat/case1
+++ b/xCAT-test/autotest/testcase/go-xcat/case1
@@ -53,10 +53,9 @@ cmd:xdsh $$CN "rm -rf /tmp/go-xcat.log"
 cmd:migration_version=`echo $$MIGRATION2_VERSION |cut -d "." -f -2`; xdsh $$CN "cd /; ./go-xcat -x $migration_version -y install"
 check:rc==0
 cmd:xdsh $$CN "cat /tmp/go-xcat.log"
-cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;lsxcatd -v"
+cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;lsxcatd -v" |tee /tmp/version
 check:rc==0
 cmd:migration_version=`echo $$MIGRATION2_VERSION |cut -d "." -f -2`;cd /;if grep Ubuntu /etc/*release;then cd / ; wget http://xcat.org/files/xcat/repos/apt/$migration_version/xcat-core/buildinfo;else cd / ; wget http://xcat.org/files/xcat/repos/yum/$migration_version/xcat-core/buildinfo; fi
-cmd:xdsh $$CN "lsxcatd -v" |tee /tmp/version
 cmd:if [ -e /buildinfo ]; then xcatversion=`grep VERSION /buildinfo |awk -F'=' '{print $2}'`;grep $xcatversion /tmp/version; fi
 check:rc==0
 cmd:migration_version=`echo $$MIGRATION2_VERSION |cut -d "." -f -2`;grep $migration_version /tmp/version


### PR DESCRIPTION
After install xcat by ``go-xcat``, the PATH attribute is not set by default, so all xcat command can not use directly unless running ``source /etc/profile.d/xcat.sh``. 

So the 59 line of test case ``go_xcat_with_x`` can not work as expected. 

The output of ``go_xcat_with_x`` before fix:
```
RUN:xdsh c910f03c09k05 "source /etc/profile.d/xcat.sh;lsxcatd -v" [Mon Apr  9 17:03:31 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f03c09k05: Version 2.13.11 (git commit 6b51474e72575f0432973016d2114f07083e9356, built Tue Mar 13 07:47:18 EDT 2018)
CHECK:rc == 0   [Pass]

RUN:migration_version=`echo 2.13.1 |cut -d "." -f -2`;cd /;if grep Ubuntu /etc/*release;then cd / ; wget http://xcat.org/files/xcat/repos/apt/$migration_version/xcat-core/buildinfo;else cd / ; wget http://xcat.org/files/xcat/repos/yum/$migration_version/xcat-core/buildinfo; fi [Mon Apr  9 17:03:32 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
/etc/lsb-release:DISTRIB_ID=Ubuntu
/etc/lsb-release:DISTRIB_DESCRIPTION="Ubuntu 16.04.1 LTS"
/etc/os-release:NAME="Ubuntu"
/etc/os-release:PRETTY_NAME="Ubuntu 16.04.1 LTS"
--2018-04-09 17:03:32--  http://xcat.org/files/xcat/repos/apt/2.13/xcat-core/buildinfo
Resolving xcat.org (xcat.org)... 166.70.135.166
Connecting to xcat.org (xcat.org)|166.70.135.166|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 183
Saving to: 'buildinfo'

     0K                                                       100% 45.9M=0s

2018-04-09 17:03:32 (45.9 MB/s) - 'buildinfo' saved [183/183]


RUN:xdsh c910f03c09k05 "lsxcatd -v" |tee /tmp/version [Mon Apr  9 17:03:32 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:if [ -e /buildinfo ]; then xcatversion=`grep VERSION /buildinfo |awk -F'=' '{print $2}'`;grep $xcatversion /tmp/version; fi [Mon Apr  9 17:03:32 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
CHECK:rc == 0   [Failed]
```


The output after fix
```
RUN:xdsh c910f03c09k05 "source /etc/profile.d/xcat.sh;lsxcatd -v" |tee /tmp/version [Mon Apr  9 17:03:31 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f03c09k05: Version 2.13.11 (git commit 6b51474e72575f0432973016d2114f07083e9356, built Tue Mar 13 07:47:18 EDT 2018)
CHECK:rc == 0   [Pass]

RUN:migration_version=`echo 2.13.1 |cut -d "." -f -2`;cd /;if grep Ubuntu /etc/*release;then cd / ; wget http://xcat.org/files/xcat/repos/apt/$migration_version/xcat-core/buildinfo;else cd / ; wget http://xcat.org/files/xcat/repos/yum/$migration_version/xcat-core/buildinfo; fi [Mon Apr  9 17:03:32 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
/etc/lsb-release:DISTRIB_ID=Ubuntu
/etc/lsb-release:DISTRIB_DESCRIPTION="Ubuntu 16.04.1 LTS"
/etc/os-release:NAME="Ubuntu"
/etc/os-release:PRETTY_NAME="Ubuntu 16.04.1 LTS"
--2018-04-09 17:03:32--  http://xcat.org/files/xcat/repos/apt/2.13/xcat-core/buildinfo
Resolving xcat.org (xcat.org)... 166.70.135.166
Connecting to xcat.org (xcat.org)|166.70.135.166|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 183
Saving to: 'buildinfo'

     0K                                                       100% 45.9M=0s

2018-04-09 17:03:32 (45.9 MB/s) - 'buildinfo' saved [183/183]

RUN:if [ -e /buildinfo ]; then xcatversion=`grep VERSION /buildinfo |awk -F'=' '{print $2}'`;grep $xcatversion /tmp/version; fi [Mon Apr  9 17:03:32 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f03c09k05: Version 2.13.11 (git commit 6b51474e72575f0432973016d2114f07083e9356, built Tue Mar 13 07:47:18 EDT 2018)
CHECK:rc == 0   [Pass]
```