### PR TITLE
delete password from log for runsqlcmd

### DIFF
--- a/xCAT-server/sbin/runsqlcmd
+++ b/xCAT-server/sbin/runsqlcmd
@@ -356,6 +356,7 @@ sub runpgsqlcmd
     if ($? > 0)    # error
     {
         $rc = $? >> 8;
+        $cmd = "PGPASSWORD=xxxxxx $psql -d $dbname -h $hostname -U $admin -f $file   ";
         xCAT::MsgUtils->message("SE",
             "The command $cmd had errors. Return=$rc");
     }


### PR DESCRIPTION
for #5029 
UT:
```
Apr 10 04:16:10 rhmn xcat[20686]: The command PGPASSWORD=xxxxxx /usr/bin/psql -d xcatdb -h 10.5.106.100 -U xcatadm -f /tmp/runcmdfile.20686    had errors. Return=1
```