### PR TITLE
add rbeacon test cases

### DIFF
--- a/xCAT-test/autotest/testcase/rbeacon/cases0
+++ b/xCAT-test/autotest/testcase/rbeacon/cases0
@@ -1,0 +1,59 @@
+start:rbeacon_null
+description: this case is to test rbeacon usage
+cmd:rbeacon
+check:rc==0
+check:output=~Usage
+end
+
+start:rbeacon_stat
+description: this case is to test rbeacon CN stat
+cmd:rbeacon $$CN stat
+check:rc==0
+check:output=~$$CN\s*:\s*Front:Off Rear:Off|Front:On Rear:On|Front:Off Rear:On|Front:On Rear:Off 
+end
+
+start:rbeacon_on_off
+description: this case is to test rbeacon CN on/off
+cmd:rbeacon $$CN stat |tee /tmp/rbeaconstat
+check:rc==0
+cmd:if grep "Front:Off Rear:Off" /tmp/rbeaconstat;then rbeacon $$CN on; fi
+check:rc==0
+check:output=~$$CN\s*:\s*on
+cmd:rbeacon $$CN stat
+check:output=~$$CN\s*:\s*Front:Blink Rear:Blink
+cmd:if grep "Front:Off Rear:Off" /tmp/rbeaconstat;then rbeacon $$CN off; fi
+check:rc==0
+check:output=~$$CN\s*:\s*off
+end
+
+start:rbeacon_help
+description: this case is to test rbeacon -h and --help output 
+cmd:rbeacon -h
+check:rc==0
+check:output=~Usage
+check:output =~OpenPOWER \(OpenBMC\) specific:
+cmd:rbeacon --help
+check:rc==0
+check:output=~Usage
+check:output =~OpenPOWER \(OpenBMC\) specific:
+end
+
+start:rbeacon_version
+description: this case is to test rbeacon -v and --version output
+cmd:rbeacon -v
+check:rc==0
+check:output=~Version
+check:output =~git commit
+cmd:rbeacon --version
+check:rc==0
+check:output=~~Version
+check:output =~git commit
+end
+
+start:rbeacon_false
+description: this case is to test rbeacon could process false input 
+cmd:rbeacon $$CN abc
+check:rc!=0
+check:output=~$$CN\s*:\s*Error:\s*Only \'on\', \'off\' or \'stat\' is supported
+end
+

--- a/xCAT-test/autotest/testcase/rbeacon/cases0
+++ b/xCAT-test/autotest/testcase/rbeacon/cases0
@@ -1,5 +1,7 @@
 start:rbeacon_null
 description: this case is to test rbeacon usage
+os:Linux
+hcp:openbmc
 cmd:rbeacon
 check:rc==0
 check:output=~Usage
@@ -7,27 +9,17 @@ end
 
 start:rbeacon_stat
 description: this case is to test rbeacon CN stat
+os:Linux
+hcp:openbmc
 cmd:rbeacon $$CN stat
 check:rc==0
 check:output=~$$CN\s*:\s*Front:Off Rear:Off|Front:On Rear:On|Front:Off Rear:On|Front:On Rear:Off 
 end
 
-start:rbeacon_on_off
-description: this case is to test rbeacon CN on/off
-cmd:rbeacon $$CN stat |tee /tmp/rbeaconstat
-check:rc==0
-cmd:if grep "Front:Off Rear:Off" /tmp/rbeaconstat;then rbeacon $$CN on; fi
-check:rc==0
-check:output=~$$CN\s*:\s*on
-cmd:rbeacon $$CN stat
-check:output=~$$CN\s*:\s*Front:Blink Rear:Blink
-cmd:if grep "Front:Off Rear:Off" /tmp/rbeaconstat;then rbeacon $$CN off; fi
-check:rc==0
-check:output=~$$CN\s*:\s*off
-end
-
 start:rbeacon_help
 description: this case is to test rbeacon -h and --help output 
+os:Linux
+hcp:openbmc
 cmd:rbeacon -h
 check:rc==0
 check:output=~Usage
@@ -40,6 +32,8 @@ end
 
 start:rbeacon_version
 description: this case is to test rbeacon -v and --version output
+os:Linux
+hcp:openbmc
 cmd:rbeacon -v
 check:rc==0
 check:output=~Version
@@ -52,6 +46,8 @@ end
 
 start:rbeacon_false
 description: this case is to test rbeacon could process false input 
+os:Linux
+hcp:openbmc
 cmd:rbeacon $$CN abc
 check:rc!=0
 check:output=~$$CN\s*:\s*Error:\s*Only \'on\', \'off\' or \'stat\' is supported


### PR DESCRIPTION
Add 6 cases in this pull request

[case 1]
Case Name:rbeacon_null
description: this case is to test rbeacon usage

[case 2]
Case Name: rbeacon_stat
description: this case is to test rbeacon CN stat

[case 3]
Case Name: rbeacon_on_off
description: this case is to test rbeacon CN on/off

[case 4]
Case Name: rbeacon_help
description: this case is to test rbeacon -h and --help output

[case 5]
Case Name:rbeacon_version
description: this case is to test rbeacon -v and --version output

[case 6]
Case Name:rbeacon_false
description: this case is to test rbeacon could process false input

This is my UT output
```
xCAT automated test started at Tue Apr 10 03:17:03 2018
******************************
To detect current test environment
******************************
Detecting: OS = linux
Detecting: ARCH = ppc64le
Detecting: HCP = openbmc
******************************
loading test cases
******************************
To run:
rbeacon_null
rbeacon_stat
rbeacon_on_off
rbeacon_help
rbeacon_version
rbeacon_false
******************************
Start to run test cases
******************************
------START::rbeacon_null::Time:Tue Apr 10 03:17:04 2018------

RUN:rbeacon [Tue Apr 10 03:17:04 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Usage:
    Common:
       rbeacon [-h|--help|-v|--version|-V|--verbose]
    BMC specific:
       rbeacon [on|blink|off|stat]
    OpenPOWER (IPMI) specific:
       rbeacon [on|blink|off|stat]
    OpenPOWER (OpenBMC) specific:
       rbeacon [on|off|stat]

CHECK:rc == 0   [Pass]
CHECK:output =~ Usage   [Pass]

------END::rbeacon_null::Passed::Time:Tue Apr 10 03:17:04 2018 ::Duration::0 sec------
------START::rbeacon_stat::Time:Tue Apr 10 03:17:04 2018------

RUN:rbeacon mid08tor03cn01 stat [Tue Apr 10 03:17:04 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
Tue Apr 10 03:17:05 2018 mid08tor03cn01: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://172.21.226.1/login -d '{"data": ["root", "xxxxxx"]}'
Tue Apr 10 03:17:05 2018 mid08tor03cn01: [openbmc_debug] login 200 OK
Tue Apr 10 03:17:05 2018 mid08tor03cn01: [openbmc_debug] get_beacon_info curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://172.21.226.1/xyz/openbmc_project/led/physical/enumerate
Tue Apr 10 03:17:06 2018 mid08tor03cn01: [openbmc_debug] get_beacon_info 200 OK
mid08tor03cn01: Front:Off Rear:Off
CHECK:rc == 0   [Pass]
CHECK:output =~ mid08tor03cn01\s*:\s*Front:Off Rear:Off|Front:On Rear:On|Front:Off Rear:On|Front:On Rear:Off    [Pass]

------END::rbeacon_stat::Passed::Time:Tue Apr 10 03:17:06 2018 ::Duration::2 sec------
------START::rbeacon_on_off::Time:Tue Apr 10 03:17:06 2018------

RUN:rbeacon mid08tor03cn01 stat |tee /tmp/rbeaconstat [Tue Apr 10 03:17:06 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
Tue Apr 10 03:17:07 2018 mid08tor03cn01: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://172.21.226.1/login -d '{"data": ["root", "xxxxxx"]}'
Tue Apr 10 03:17:07 2018 mid08tor03cn01: [openbmc_debug] login 200 OK
Tue Apr 10 03:17:07 2018 mid08tor03cn01: [openbmc_debug] get_beacon_info curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://172.21.226.1/xyz/openbmc_project/led/physical/enumerate
Tue Apr 10 03:17:08 2018 mid08tor03cn01: [openbmc_debug] get_beacon_info 200 OK
mid08tor03cn01: Front:Off Rear:Off
CHECK:rc == 0   [Pass]

RUN:if grep "Front:Off Rear:Off" /tmp/rbeaconstat;then rbeacon mid08tor03cn01 on; fi [Tue Apr 10 03:17:08 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn01: Front:Off Rear:Off
Tue Apr 10 03:17:09 2018 mid08tor03cn01: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://172.21.226.1/login -d '{"data": ["root", "xxxxxx"]}'
Tue Apr 10 03:17:09 2018 mid08tor03cn01: [openbmc_debug] login 200 OK
.226.1/xyz/openbmc_project/led/physical/enumerate
Tue Apr 10 03:17:11 2018 mid08tor03cn01: [openbmc_debug] get_beacon_info 200 OK
mid08tor03cn01: Front:Blink Rear:Blink
CHECK:output =~ mid08tor03cn01\s*:\s*Front:Blink Rear:Blink     [Pass]

RUN:if grep "Front:Off Rear:Off" /tmp/rbeaconstat;then rbeacon mid08tor03cn01 off; fi [Tue Apr 10 03:17:11 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn01: Front:Off Rear:Off
Tue Apr 10 03:17:11 2018 mid08tor03cn01: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://172.21.226.1/login -d '{"data": ["root", "xxxxxx"]}'
Tue Apr 10 03:17:12 2018 mid08tor03cn01: [openbmc_debug] login 200 OK
Tue Apr 10 03:17:12 2018 mid08tor03cn01: [openbmc_debug] set_beacon_state curl -k -c cjar -b cjar -X PUT -H "Content-Type: application/json" https://172.21.226.1/xyz/openbmc_project/led/groups/enclosure_identify/attr/Asserted -d '{"data": false}'
Tue Apr 10 03:17:12 2018 mid08tor03cn01: [openbmc_debug] set_beacon_state 200 OK
mid08tor03cn01: off
CHECK:rc == 0   [Pass]
CHECK:output =~ mid08tor03cn01\s*:\s*off        [Pass]

------END::rbeacon_on_off::Passed::Time:Tue Apr 10 03:17:12 2018 ::Duration::6 sec------
------START::rbeacon_help::Time:Tue Apr 10 03:17:12 2018------
RUN:rbeacon -h [Tue Apr 10 03:17:12 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Usage:
    Common:
       rbeacon [-h|--help|-v|--version|-V|--verbose]
    BMC specific:
       rbeacon [on|blink|off|stat]
    OpenPOWER (IPMI) specific:
       rbeacon [on|blink|off|stat]
    OpenPOWER (OpenBMC) specific:
       rbeacon [on|off|stat]

CHECK:rc == 0   [Pass]
CHECK:output =~ Usage   [Pass]
CHECK:output =~ OpenPOWER \(OpenBMC\) specific: [Pass]

RUN:rbeacon --help [Tue Apr 10 03:17:12 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Usage:
    Common:
       rbeacon [-h|--help|-v|--version|-V|--verbose]
    BMC specific:
       rbeacon [on|blink|off|stat]
    OpenPOWER (IPMI) specific:
       rbeacon [on|blink|off|stat]
    OpenPOWER (OpenBMC) specific:
       rbeacon [on|off|stat]

CHECK:rc == 0   [Pass]
CHECK:output =~ Usage   [Pass]
CHECK:output =~ OpenPOWER \(OpenBMC\) specific: [Pass]

------END::rbeacon_help::Passed::Time:Tue Apr 10 03:17:13 2018 ::Duration::1 sec------
------START::rbeacon_version::Time:Tue Apr 10 03:17:13 2018------

RUN:rbeacon -v [Tue Apr 10 03:17:13 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Version 2.14 (git commit f7867c9e516f28843b498e69399c6029adf52bca, built Tue Apr  3 06:15:43 EDT 2018)
CHECK:rc == 0   [Pass]
CHECK:output =~ Version [Pass]
CHECK:output =~ git commit      [Pass]

RUN:rbeacon --version [Tue Apr 10 03:17:13 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Version 2.14 (git commit f7867c9e516f28843b498e69399c6029adf52bca, built Tue Apr  3 06:15:43 EDT 2018)
CHECK:rc == 0   [Pass]
CHECK:output =~~ Version        [Pass]
CHECK:output =~ git commit      [Pass]

------END::rbeacon_version::Passed::Time:Tue Apr 10 03:17:13 2018 ::Duration::0 sec------
------START::rbeacon_false::Time:Tue Apr 10 03:17:13 2018------

RUN:rbeacon mid08tor03cn01 abc [Tue Apr 10 03:17:13 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
mid08tor03cn01: Error: Only 'on', 'off' or 'stat' is supported for OpenBMC managed nodes.
CHECK:rc != 0   [Pass]
CHECK:output =~ mid08tor03cn01\s*:\s*Error:\s*Only \'on\', \'off\' or \'stat\' is supported     [Pass]

------END::rbeacon_false::Passed::Time:Tue Apr 10 03:17:13 2018 ::Duration::0 sec------
------Total: 6 , Failed: 0------

xCAT automated test finished at Tue Apr 10 03:17:13 2018
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20180410031703 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20180410031703 file for time consumption
```