### PR TITLE
modify return code of rspconfig hostname error for perl code

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -983,7 +983,7 @@ sub process_request {
         if ($next_status{LOGIN_RESPONSE} eq "RSPCONFIG_SET_HOSTNAME_REQUEST" and $status_info{RSPCONFIG_SET_HOSTNAME_REQUEST}{data} =~ /^\*$/) {
             if ($node_info{$node}{bmc} =~ /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/) {
                 my $info_msg = "Invalid OpenBMC Hostname $node_info{$node}{bmc}, can't set to OpenBMC";
-                xCAT::SvrUtils::sendmsg($info_msg, $callback, $node);
+                xCAT::SvrUtils::sendmsg([1, $info_msg], $callback, $node);
                 $wait_node_num--;
                 next; 
             }


### PR DESCRIPTION
before modify:
```
# rspconfig f6u03 hostname=*
Tue Apr 10 21:53:44 2018 OpenBMC: [openbmc_debug_perl]
f6u03: Invalid OpenBMC Hostname 10.6.3.100, can't set to OpenBMC
# echo $?
0
```

After modify:
```
# rspconfig f6u03 hostname=*
Tue Apr 10 21:53:13 2018 OpenBMC: [openbmc_debug_perl]
f6u03: Error: Invalid OpenBMC Hostname 10.6.3.100, can't set to OpenBMC
# echo $?
1
```