### PR TITLE
Change test case of rspconfit to satisfy the latest code

### DIFF
--- a/xCAT-test/autotest/testcase/rspconfig/cases0
+++ b/xCAT-test/autotest/testcase/rspconfig/cases0
@@ -256,7 +256,7 @@ hcp:openbmc
 cmd:lsdef $$CN -i bmc -c
 check:rc == 0
 cmd:rspconfig $$CN hostname=*
-check:rc == 0
+check:rc != 0
 check:output =~ Invalid OpenBMC Hostname
 cmd:ssh __GETNODEATTR(f6u03,bmc)__ "hostname"
 end


### PR DESCRIPTION
Due to the return code of ``rspconfig $$CN hostname=*`` is 0 when the command throw out error message before. But this was changed by pull request #5083, so update the related test case.

The UT output is 
```
------START::rspconfig_set_hostname_equal_star_with_bmc_is_ip::Time:Tue Apr 10 09:28:12 2018------

FILENAME:/opt/xcat/bin/../share/xcat/tools/autotest/testcase//rspconfig/cases0

RUN:lsdef f6u03 -i bmc -c [Tue Apr 10 09:28:12 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
f6u03: bmc=10.6.3.100
CHECK:rc == 0   [Pass]

RUN:rspconfig f6u03 hostname=* [Tue Apr 10 09:28:12 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
f6u03: Error: Invalid OpenBMC Hostname 10.6.3.100, can't set to OpenBMC
CHECK:rc != 0    [Pass]

RUN:ssh 10.6.3.100 "hostname" [Tue Apr 10 09:28:13 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Warning: Permanently added '10.6.3.100' (RSA) to the list of known hosts.^M
test_bogus_bmc_hostname
```