### PR TITLE
Fix the issue for stateless node in debug mode, /dev/log is not available

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/patch/syslog/module-setup.sh
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/patch/syslog/module-setup.sh
@@ -16,7 +16,7 @@ install() {
     local _installs
     if type -P rsyslogd >/dev/null; then
         _installs="rsyslogd"
-        inst_libdir_file rsyslog/lmnet.so rsyslog/imklog.so rsyslog/imuxsock.so
+        inst_libdir_file rsyslog/lmnet.so rsyslog/imklog.so rsyslog/imuxsock.so rsyslog/imjournal.so
     elif type -P syslogd >/dev/null; then
         _installs="syslogd"
     elif type -P syslog-ng >/dev/null; then

--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/patch/syslog/rsyslogd-start.sh
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/patch/syslog/rsyslogd-start.sh
@@ -21,7 +21,12 @@ rsyslog_config() {
 #        echo "${filter} @${server}"
 #    done
 
-    
+    # In dracut 33, default rsyslogd configuration does not use journald. Then when
+    # rsyslog in debug mode, it causes `/dev/log` is not available after switch_root (#4929)
+    echo "\$ModLoad imjournal"
+    echo "\$OmitLocalLogging on"
+    echo "\$IMJournalStateFile imjournal.state"
+
     if [ -n "$filters" ];then
         confline="${filters}";
     else


### PR DESCRIPTION
 (#4929) - use imjournal to make rsyslogd work well with journald

UT:
1, patch xcat
2, genimage for a stateless osimage
3, set xcatdebugmode=1 in site
4, rinstall or nodeset the node with new osimage

After reprovisioned,  we can see that /dev/log is ready to use.
```
# cat /proc/cmdline
imgurl=http://172.20.254.2:80//install/ansible/custom/rhels7.5-alt-rc2-ppc64le-ANSIBLE-netboot-compute/rootimgdir/rootimg.cpio.gz XCAT=172.20.254.2:3001 NODE=mid08tor03cn10 FC=0  LOGSERVER=172.20.254.2  syslog.server=172.20.254.2 syslog.type=rsyslogd syslog.filter=*.*  xcatdebugmode=1 BOOTIF=**:**:**:**:**:**  selinux=0

#python -c "import logging;from logging.handlers import SysLogHandler;SysLogHandler(address='/dev/log', facility=SysLogHandler.LOG_LOCAL4)"
# echo $?
0
```