### PR TITLE
fix typo error of rspconfig powersupplyredundancy

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -198,7 +198,7 @@ RSPCONFIG_APIS = {
         'get_data': [],
         'display_name': "BMC PowerSupplyRedundancy",
         'attr_values': {
-            'disabled': ["Disables"],
+            'disabled': ["Disabled"],
             'enabled': ["Enabled"],
         },
     },


### PR DESCRIPTION
#5053 

```
# rspconfig f6u03 powersupplyredundancy=disabled
Wed Apr 11 04:22:29 2018 f6u03: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.3.100/login -d '{"data": ["root", "xxxxxx"]}'
Wed Apr 11 04:22:29 2018 f6u03: [openbmc_debug] login 200 OK
Wed Apr 11 04:22:29 2018 f6u03: [openbmc_debug] set_powersupplyredundancy curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.3.100/xyz/openbmc_project/sensors/chassis/PowerSupplyRedundancy/action/setValue -d '{"data": ["Disabled"]}'
Wed Apr 11 04:22:29 2018 f6u03: [openbmc_debug] set_powersupplyredundancy 200 OK
f6u03: BMC Setting BMC PowerSupplyRedundancy...
# rspconfig f6u03 powersupplyredundancy
Wed Apr 11 04:22:32 2018 f6u03: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.3.100/login -d '{"data": ["root", "xxxxxx"]}'
Wed Apr 11 04:22:32 2018 f6u03: [openbmc_debug] login 200 OK
Wed Apr 11 04:22:32 2018 f6u03: [openbmc_debug] get_powersupplyredundancy curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.3.100/xyz/openbmc_project/sensors/chassis/PowerSupplyRedundancy/action/getValue -d '{"data": []}'
Wed Apr 11 04:22:33 2018 f6u03: [openbmc_debug] get_powersupplyredundancy 200 OK
f6u03: BMC PowerSupplyRedundancy: Disabled
```