### PR TITLE
fix issue args pass for rflash activate

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_flash.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_flash.py
@@ -98,7 +98,7 @@ class OpenBMCFlashTask(ParallelNodesCommand):
             os.makedirs(XCAT_LOG_RFLASH_DIR)
 
         if activate_arg.endswith('.tar'):
-            version = self._get_firmware_version()
+            version = self._get_firmware_version(self.firmware_file)
             self.firmware.update(version) 
             self.callback.info('Attempting to upload %s, please wait...' % self.firmware_file)
         else:


### PR DESCRIPTION
before modify:
error in agent.log
```
TypeError: _get_firmware_version() takes exactly 2 arguments (1 given)
```
After modify:
```
# rflash mid08tor03cn01 witherspoon.pnor.squashfs.tar -a -V
[boston02]: Running command in Python
[boston02]: Attempting to upload /firmnew/witherspoon.pnor.squashfs.tar, please wait...
[boston02]: mid08tor03cn01: Firmware upload successful. Attempting to activate firmware: IBM-witherspoon-ibm-OP9_v1.19_1.154 (ID: 4f901d3d)
[boston02]: mid08tor03cn01: rflash IBM-witherspoon-ibm-OP9_v1.19_1.154 started, please wait...
[boston02]: mid08tor03cn01: Firmware IBM-witherspoon-ibm-OP9_v1.19_1.154 activation successful.
[boston02]: -------------------------------------------------------
[boston02]: Firmware update complete: Total=1 Success=1 Failed=0
[boston02]: -------------------------------------------------------
```