### PR TITLE
Processor DD version check before firmware upload

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_flash.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_flash.py
@@ -527,6 +527,16 @@ class OpenBMCFlashTask(ParallelNodesCommand):
 
         try:
             obmc.login()
+            # Before uploading file, check CPU DD version
+            inventory_info_dict = obmc.get_inventory_info()
+            cpu_info = inventory_info_dict["CPU"]
+            for info in cpu_info:
+                if info.startswith("CPU0 Version : 20"):
+                    # Display warning the only certain firmware versions are supported on DD 2.0
+                    self.callback.info( '%s: Warning: DD 2.0 processor detected on this node, should not have firmware > ibm-v2.0-0-r13.6 (BMC) and > v1.19_1.94 (Host).' % node)
+                if info.startswith("CPU0 Version : 21"):
+                    if self.verbose:
+                        self.callback.info( '%s: DD 2.1 processor' % node)
         except (SelfServerException, SelfClientException) as e:
             return self._msg_process(node, e.message, msg_type='E')
 

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -4615,6 +4615,7 @@ sub rflash_upload {
     # curl commands
     my $curl_login_cmd  = "curl -c $cjar_id -k -H 'Content-Type: application/json' -X POST $request_url/login -d '" . $content_login . "'";
     my $curl_logout_cmd = "curl -b $cjar_id -k -H 'Content-Type: application/json' -X POST $request_url/logout -d '" . $content_logout . "'";
+     my $curl_check_cpu_dd_cmd = "curl -b $cjar_id -k -H 'Content-Type: application/json' -X GET $request_url/xyz/openbmc_project/inventory/system/chassis/motherboard/cpu0 | grep Version | cut -d: -f2";
 
     if (%fw_tar_files) {
         foreach my $key (keys %fw_tar_files) {
@@ -4646,6 +4647,17 @@ sub rflash_upload {
     }
     if ($h->{message} eq $::RESPONSE_OK) {
         if(%curl_upload_cmds){
+            # Before uploading file, check CPU DD version
+            my $curl_dd_check_result = `$curl_check_cpu_dd_cmd`;
+            if ($curl_dd_check_result =~ "20") {
+                # Display warning the only certain firmware versions are supported on DD 2.0
+                xCAT::SvrUtils::sendmsg("Warning: DD 2.0 processor detected on this node, should not have firmware > ibm-v2.0-0-r13.6 (BMC) and > v1.19_1.94 (Host).", $callback, $node);
+            }
+            if ($curl_dd_check_result =~ "21") {
+                if ($::VERBOSE) {
+                    xCAT::SvrUtils::sendmsg("DD 2.1 processor", $callback, $node);
+                }
+            }
             while((my $file,my $version)=each(%fw_tar_files)){
                 my $uploading_msg = "Uploading $file ...";
                 my $upload_cmd = $curl_upload_cmds{$file};


### PR DESCRIPTION
Check processor DD version on firmware file upload and firmware activation with file and report what FW is supported if CPU DD is 2.0

* DD 2.1
```
[root@briggs01 xcat]# rflash mid05tor12cn13 -u /mnt/iso/openbmc/910.1804.20180314a_1742Fx-r3/./witherspoon.pnor.squashfs.tar -V
[briggs01]: Attempting to upload /mnt/iso/openbmc/910.1804.20180314a_1742Fx-r3/./witherspoon.pnor.squashfs.tar, please wait...
[briggs01]: Running command in Perl
mid05tor12cn13: [briggs01]: DD 2.1 processor
mid05tor12cn13: [briggs01]: Uploading /mnt/iso/openbmc/910.1804.20180314a_1742Fx-r3/./witherspoon.pnor.squashfs.tar ...
mid05tor12cn13: [briggs01]: Firmware upload successful. Use -l option to list.
[root@briggs01 xcat]#
```

```
[root@briggs01 xcat]# rflash mid05tor12cn13 -u /mnt/iso/openbmc/910.1804.20180314a_1742Fx-r3/./witherspoon.pnor.squashfs.tar
Attempting to upload /mnt/iso/openbmc/910.1804.20180314a_1742Fx-r3/./witherspoon.pnor.squashfs.tar, please wait...
mid05tor12cn13: Firmware upload successful. Use -l option to list.
[root@briggs01 xcat]#
```

* DD 2.0
```
[root@boston02 910.1804.20180228a_1742Fx-r2]# rflash mid08tor03cn01 -u ./obmc-phosphor-image-witherspoon.ubi.mtd.tar -V
[boston02]: Attempting to upload /mnt/xcat/iso/openbmc/910.1804.20180228a_1742Fx-r2/./obmc-phosphor-image-witherspoon.ubi.mtd.tar, please wait...
[boston02]: Running command in Perl
mid08tor03cn01: [boston02]: Warning: DD 2.0 processor detected on this node, should not have firmware > ibm-v2.0-0-r13.6 (BMC) and > v1.19_1.94 (Host).
mid08tor03cn01: [boston02]: Uploading /mnt/xcat/iso/openbmc/910.1804.20180228a_1742Fx-r2/./obmc-phosphor-image-witherspoon.ubi.mtd.tar ...
mid08tor03cn01: [boston02]: Firmware upload successful. Use -l option to list.
[root@boston02 910.1804.20180228a_1742Fx-r2]#
```

```
rflash mid08tor03cn01 -u ./obmc-phosphor-image-witherspoon.ubi.mtd.tar
Attempting to upload /mnt/xcat/iso/openbmc/910.1804.20180228a_1742Fx-r2/./obmc-phosphor-image-witherspoon.ubi.mtd.tar, please wait...
mid08tor03cn01: Warning: DD 2.0 processor detected on this node, should not have firmware > ibm-v2.0-0-r13.6 (BMC) and > v1.19_1.94 (Host).
mid08tor03cn01: Firmware upload successful. Use -l option to list.
[root@boston02 910.1804.20180228a_1742Fx-r2]#
```