### PR TITLE
To allow non-root user run xdcp in hierachy mode to push the files to site.SNsyncfiledir

### DIFF
--- a/xCAT-server/lib/xcat/plugins/xdsh.pm
+++ b/xCAT-server/lib/xcat/plugins/xdsh.pm
@@ -646,6 +646,12 @@ sub process_servicenodes_xdcp
         if (grep(/^--nodestatus$/, @$args)) {
             push(@{ $addreq->{arg} }, "--nodestatus");    # return nodestatus
         }
+
+        if (defined($req->{username}) && ($req->{username}->[0] ne "root")) {
+            # Using `root` when sync temporary files to `site.SNsyncfiledir` (default: /var/xcat/syncfiles)
+            push(@{ $addreq->{arg} }, "-l");
+            push(@{ $addreq->{arg} }, "root");
+        }
         push(@{ $addreq->{arg} }, "-v");
         push(@{ $addreq->{arg} }, "-s");
         push(@{ $addreq->{arg} }, "-F");


### PR DESCRIPTION
When xdcp files to CN and CN is controlled by a SN, xcat will push files to SN first (site.SNsyncfiledir). This should be run as admin
for normal user as they cannot touch that directory.

Note: this PR depends on some fix in https://github.com/xcat2/xcat-core/pull/5013,  need to be merged after it.

Before fix
```
[testme@c910f03c05k20 ~]$ updatenode c910f03c05k30 -F
c910f03c05k24: /bin/mkdir: cannot create directory '/var/xcat': Permission denied
c910f03c05k24: /bin/mkdir: cannot create directory '/var/xcat': Permission denied
c910f03c05k24: rsync: change_dir#3 "/var/xcat/syncfiles" failed: No such file or directory (2)
c910f03c05k24: rsync error: errors selecting input/output files, dirs (code 3) at main.c(625) [Receiver=3.0.9]
c910f03c05k24: rsync: connection unexpectedly closed (9 bytes received so far) [sender]
c910f03c05k24: rsync error: error in rsync protocol data stream (code 12) at io.c(605) [sender=3.0.9]
c910f03c05k24: rsync: change_dir#3 "/var/xcat/syncfiles" failed: No such file or directory (2)
c910f03c05k24: rsync error: errors selecting input/output files, dirs (code 3) at main.c(625) [Receiver=3.0.9]
c910f03c05k24: rsync: connection unexpectedly closed (9 bytes received so far) [sender]
c910f03c05k24: rsync error: error in rsync protocol data stream (code 12) at io.c(605) [sender=3.0.9]

The following servicenodes: c910f03c05k24, have errors and cannot be updated
 Until the error is fixed, xdcp will not work to nodes serviced by these service nodes.
```

After patch:
```
[testme@c910f03c05k20 ~]$ updatenode c910f03c05k30 -F
File synchronization has completed for nodes.
```

Note:  this will not bring security issue as normal user cannot fork a request to do that. MN to SN is only internal processing,  not expose to end-user.