### PR TITLE
Add the mlnxofedinstall default parameters xcat recommended into mlnx diskless installation document

### DIFF
--- a/docs/source/advanced/networks/infiniband/mlnxofed_ib_install_v2_diskless.rst
+++ b/docs/source/advanced/networks/infiniband/mlnxofed_ib_install_v2_diskless.rst
@@ -28,10 +28,10 @@ Diskless Installation
     
               *Note: The $1 is a argument that is passed to the the postinstall script at runtime.*
 
-   **[kernel mismatch issue]** The Mellanox OFED ISO is built against a series of specific kernel version.  If the version of the linux kernel does not match any of the Mellanox offered pre-built kernel modules, you can pass the ``--add-kernel-support`` argument to the Mellanox installation script to build the kernel modules based on the version you are using. ::
+   **[kernel mismatch issue]** The Mellanox OFED ISO is built against a series of specific kernel version.  If the version of the linux kernel does not match any of the Mellanox offered pre-built kernel modules, you can pass the ``--add-kernel-support --without-32bit --without-fw-update --force`` arguments to the Mellanox installation script to build the kernel modules based on the version you are using. ::
 
        /install/postscripts/mlnxofed_ib_install \
-         -p /install/<path-to>/<MLNX_OFED_LINUX.iso> -m --add-kernel-support -end- \
+         -p /install/<path-to>/<MLNX_OFED_LINUX.iso> -m --add-kernel-support --without-32bit --without-fw-update --force -end- \
          -i $1 -n genimage
     
 #. Generate the diskless image 


### PR DESCRIPTION
Add the mlnxofedinstall default parameters xcat recommended into mlnx diskless installation document depending on the suggestion of #5100.