### PR TITLE
fix kdump auto test case failure

### DIFF
--- a/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
+++ b/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
@@ -22,7 +22,7 @@ cmd:rootimgdir=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arc
 check:rc==0
 
 cmd:pkglistfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep pkglist|awk -F'=' '{print $2}'`;cp $pkglistfile $pkglistfile.bak
-cmd:pkglistfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep pkglist|awk -F'=' '{print $2}'`; if grep SUSE /etc/*release;then echo -e "kdump\nkexec-tools\nmakedumpfile\n" >> $pkglistfile; elif grep "Red Hat" /etc/*release;then echo -e "kexec-tools\ncrash\n" >> $pkglistfile;fi
+cmd:pkglistfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep pkglist|awk -F'=' '{print $2}'`; if grep SUSE /etc/*release;then echo -e "kdump\nkexec-tools\nmakedumpfile\nat\n" >> $pkglistfile; elif grep "Red Hat" /etc/*release;then echo -e "kexec-tools\ncrash\nat\n" >> $pkglistfile;fi
 check:rc==0
 
 cmd:exlistfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep exlist|awk -F'=' '{print $2}'`;cp $exlistfile $exlistfile.bak
@@ -46,7 +46,6 @@ check:rc==0
 cmd:chdef -t node $$CN -p postscripts=enablekdump
 check:rc==0
 
-
 cmd:genimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 cmd:packimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
@@ -69,7 +68,10 @@ cmd:xdsh $$CN date
 check:rc==0
 check:output=~\d\d:\d\d:\d\d
 
-cmd:xdsh $$CN "setsid 'echo 1 > /proc/sys/kernel/sysrq; echo c > /proc/sysrq-trigger'"
+cmd:xdsh $$CN "echo 'echo 1 > /proc/sys/kernel/sysrq; echo c > /proc/sysrq-trigger' > /tmp/kdump.trigger"
+cmd:xdsh $$CN "chmod 755 /tmp/kdump.trigger"
+cmd:xdsh $$CN "service atd start"
+cmd:xdsh $$CN "at now +1 minutes <<< /tmp/kdump.trigger"
 cmd:sleep 300
 
 cmd:vmcorefile=`find /kdumpdir/ -name vmcore`;if [[ -s $vmcorefile ]]; then echo "this file is not empty";else echo "this file is empty"; fi
@@ -83,4 +85,5 @@ cmd:if [ -f /etc/exports.bak ] ;then mv -f /etc/exports.bak /etc/exports; fi
 cmd:rm -rf /kdumpdir
 cmd:cat /tmp/node.stanza | chdef -z;rm -rf /tmp/node.stanza
 cmd:cat /tmp/osimage.stanza | chdef -z;rm -rf /tmp/osimage.stanza
+cmd:rootimgdir=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir.regbak ]; then mv $rootimgdir.regbak $rootimgdir -f;fi
 end


### PR DESCRIPTION
UT:
```
... ...
RUN:xdsh f6u03 "echo 'echo 1 > /proc/sys/kernel/sysrq; echo c > /proc/sysrq-trigger' > /tmp/kdump.trigger" [Mon Apr 16 02:56:21 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:xdsh f6u03 "chmod 755 /tmp/kdump.trigger" [Mon Apr 16 02:56:22 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:xdsh f6u03 "service atd start" [Mon Apr 16 02:56:22 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u03: Redirecting to /bin/systemctl start atd.service

RUN:xdsh f6u03 "at now +1 minutes <<< /tmp/kdump.trigger" [Mon Apr 16 02:56:23 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u03: job 1 at Mon Apr 16 02:44:00 2018

RUN:sleep 200 [Mon Apr 16 02:56:24 2018]
ElapsedTime:200 sec
RETURN rc = 0
OUTPUT:

RUN:vmcorefile=`find /kdumpdir/ -name vmcore`;if [[ -s $vmcorefile ]]; then echo "this file is not empty";else echo "this file is empty"; fi [Mon Apr 16 02:59:44 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
this file is not empty
CHECK:output =~ not empty	[Pass]
......
```