### PR TITLE
chdef print warning when postscript is already included in the 'xcatd…

### DIFF
--- a/perl-xCAT/xCAT/DBobjUtils.pm
+++ b/perl-xCAT/xCAT/DBobjUtils.pm
@@ -1311,7 +1311,7 @@ sub setobjdefs
                             if (grep(/^$tempps$/, @xcatdefps)) {
                                 my $rsp;
                                 $rsp->{data}->[0] = "$obj: postscripts \'$tempps\' is already included in the \'xcatdefaults\'.";
-                                xCAT::MsgUtils->message("E", $rsp, $::callback);
+                                xCAT::MsgUtils->message("W", $rsp, $::callback);
                             } else {
                                 push @newps, $tempps;
                             }
@@ -1325,7 +1325,7 @@ sub setobjdefs
                             if (grep(/^$temppbs$/, @xcatdefpbs)) {
                                 my $rsp;
                                 $rsp->{data}->[0] = "$obj: postbootscripts \'$temppbs\' is already included in the \'xcatdefaults\'.";
-                                xCAT::MsgUtils->message("E", $rsp, $::callback);
+                                xCAT::MsgUtils->message("W", $rsp, $::callback);
                             } else {
                                 push @newpbs, $temppbs;
                             }


### PR DESCRIPTION
For #4073 
When scripts are included in the 'xcatdefaults', chdef should print warning instead of Error.
UT:
```
[root@bybc0602 xCAT]# chdef bybc0607 postscripts=syslog,remoteshell,syncfiles
Warning: bybc0607: postscripts 'syslog' is already included in the 'xcatdefaults'.
Warning: bybc0607: postscripts 'remoteshell' is already included in the 'xcatdefaults'.
Warning: bybc0607: postscripts 'syncfiles' is already included in the 'xcatdefaults'.
1 object definitions have been created or modified.

[root@bybc0602 xCAT]# chdef bybc0607 postbootscripts=otherpkgs
Warning: bybc0607: postbootscripts 'otherpkgs' is already included in the 'xcatdefaults'.
1 object definitions have been created or modified.
```