### PR TITLE
add rspconfig test cases

### DIFF
--- a/xCAT-test/autotest/testcase/rspconfig/cases1
+++ b/xCAT-test/autotest/testcase/rspconfig/cases1
@@ -33,8 +33,7 @@ cmd:rspconfig $$CN dump -g|tee /tmp/dumpgenerate
 check:rc == 0
 check:output =~$$CN:\s*\[\d+\]\s* success
 cmd:sleep 300
-cmd:rspconfig $$CN dump -l
-check:output =~$$CN:\s*\[\d+\]\s* Generated:
+cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate `; rspconfig $$CN dump -l|grep "\[$dumpnumber\] Generated"
 check:rc == 0
 cmd:dumpnumber=`cat /tmp/dumpgenerate |awk -F '[' '{ print $2 }' | awk -F ']' '{ print $1 }'`;rspconfig $$CN dump --clear $dumpnumber
 check:rc == 0
@@ -46,8 +45,7 @@ cmd:rspconfig $$CN dump --generate|tee /tmp/dumpgenerate
 check:rc == 0
 check:output =~$$CN:\s*\[\d+\]\s* success
 cmd:sleep 300
-cmd:rspconfig $$CN dump -l
-check:output =~$$CN:\s*\[\d+\]\s* Generated:
+cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate `; rspconfig $$CN dump -l|grep "\[$dumpnumber\] Generated"
 check:rc == 0
 cmd:dumpnumber=`cat /tmp/dumpgenerate |awk -F '[' '{ print $2 }' | awk -F ']' '{ print $1 }'`;rspconfig $$CN dump --clear $dumpnumber
 check:rc == 0
@@ -68,7 +66,7 @@ check:output =~$$CN:\s*\[\d+\]\s* success
 cmd:sleep 300
 cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate `; rspconfig $$CN dump -l|grep "\[$dumpnumber\] Generated"
 check:rc == 0
-cmd:dumpnumber=`cat /tmp/dumpgenerate |awk -F '[' '{ print $2 }' | awk -F ']' '{ print $1 }'`;rspconfig $$CN dump --clear $dumpnumber
+cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;rspconfig $$CN dump --clear $dumpnumber
 check:rc == 0
 check:output =~$$CN:\s*\[\d+\]\s* clear
 cmd:rspconfig $$CN dump -g 
@@ -95,6 +93,7 @@ check:rc == 0
 check:output =~$$CN:\s*\[all\]\s* clear
 cmd:rspconfig $$CN dump -l
 check:output =~$$CN:\s*No attributes returned from the BMC.
+cmd:rm -rf /tmp/dumpgenerate
 end
 
 start:rspconfig_dump_download
@@ -105,37 +104,45 @@ cmd:rspconfig $$CN dump -g |tee /tmp/dumpgenerate
 check:rc == 0
 check:output =~$$CN:\s*\[\d+\]\s* success
 cmd:sleep 300
-cmd:dumpnumber=`cat /tmp/dumpgenerate |awk -F '[' '{ print $2 }' | awk -F ']' '{ print $1 }'`;rspconfig $$CN dump -d $dumpnumber |tee /tmp/dumpdown
+cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;rspconfig $$CN dump -d $dumpnumber |tee /tmp/dumpdown
 check:rc == 0
 cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;grep "Downloaded dump $dumpnumber to /var/log/xcat/dump/" /tmp/dumpdown
 check:rc == 0
 cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`rspconfig $$CN dump -l |grep "\[$dumpnumber\] Generated" |cut -d : -f 6`;ls -l /var/log/xcat/dump/*_$$CN_dump_$dumpnumber.tar.xz|grep $dumpsize
+check:rc == 0
 cmd:rspconfig $$CN dump -g |tee /tmp/dumpgenerate
 check:rc == 0
 check:output =~$$CN:\s*\[\d+\]\s* success
 cmd:sleep 300
-cmd:dumpnumber=`cat /tmp/dumpgenerate |awk -F '[' '{ print $2 }' | awk -F ']' '{ print $1 }'`;rspconfig $$CN dump --download $dumpnumber |tee /tmp/dumpdown
+cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;rspconfig $$CN dump --download $dumpnumber |tee /tmp/dumpdown
 check:rc == 0
 cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;grep "Downloaded dump $dumpnumber to /var/log/xcat/dump/" /tmp/dumpdown
 check:rc == 0
 cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`rspconfig $$CN dump -l |grep "\[$dumpnumber\] Generated" |cut -d : -f 6`;ls -l /var/log/xcat/dump/*_$$CN_dump_$dumpnumber.tar.xz|grep $dumpsize
+check:rc == 0
 cmd:rspconfig $$CN dump -d all
 check:rc == 0
 check:output =~Downloading all dumps
 cmd:rspconfig $$CN dump --download all
 check:rc == 0
 check:output =~Downloading all dumps 
-cmd:rm -rf /tmp/dumpgenerate
+cmd:rm -rf /tmp/dumpgenerate /tmp/dumpdown
 end
 
 start:rspconfig_dump_no_option
 description: To test "rspconfig <node> dump"
 os:Linux
 hcp:openbmc
-cmd:rspconfig $$CN dump 
+cmd:rspconfig $$CN dump  
 check:rc == 0
 check:output =~$$CN:\s*Dump requested
 check:output =~$$CN:\s*Downloading dump
+cmd:rspconfig $$CN dump -l |tail -n 1 |tee /tmp/dumpgenerate
+check:rc == 0
+#cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`cat /tmp/dumpgenerate |cut -d : -f 6`;ls -l /var/log/xcat/dump/*_$$CN_dump_$dumpnumber.tar.xz|grep $dumpsize
+cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`rspconfig $$CN dump -l |grep "\[$dumpnumber\] Generated" |cut -d : -f 6`;ls -l /var/log/xcat/dump/*_$$CN_dump_$dumpnumber.tar.xz|grep $dumpsize
+check:rc == 0
+cmd:rm -rf /tmp/dumpgenerate
 end
 
 start:rspconfig_gard

--- a/xCAT-test/autotest/testcase/rspconfig/cases1
+++ b/xCAT-test/autotest/testcase/rspconfig/cases1
@@ -66,13 +66,8 @@ cmd:rspconfig $$CN dump -g |tee /tmp/dumpgenerate
 check:rc == 0
 check:output =~$$CN:\s*\[\d+\]\s* success
 cmd:sleep 300
-cmd:dumpnumber=`cat /tmp/dumpgenerate |awk -F '[' '{ print $2 }' | awk -F ']' '{ print $1 }'`;rspconfig $$CN dump --clear $dumpnumber
+cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate `; rspconfig $$CN dump -l|grep "\[$dumpnumber\] Generated"
 check:rc == 0
-check:output =~$$CN:\s*\[\d+\]\s* clear
-cmd:rspconfig $$CN dump -g |tee /tmp/dumpgenerate
-check:rc == 0
-check:output =~$$CN:\s*\[\d+\]\s* success
-cmd:sleep 300
 cmd:dumpnumber=`cat /tmp/dumpgenerate |awk -F '[' '{ print $2 }' | awk -F ']' '{ print $1 }'`;rspconfig $$CN dump --clear $dumpnumber
 check:rc == 0
 check:output =~$$CN:\s*\[\d+\]\s* clear
@@ -110,12 +105,20 @@ cmd:rspconfig $$CN dump -g |tee /tmp/dumpgenerate
 check:rc == 0
 check:output =~$$CN:\s*\[\d+\]\s* success
 cmd:sleep 300
-cmd:dumpnumber=`cat /tmp/dumpgenerate |awk -F '[' '{ print $2 }' | awk -F ']' '{ print $1 }'`;rspconfig $$CN dump -d $dumpnumber
+cmd:dumpnumber=`cat /tmp/dumpgenerate |awk -F '[' '{ print $2 }' | awk -F ']' '{ print $1 }'`;rspconfig $$CN dump -d $dumpnumber |tee /tmp/dumpdown
 check:rc == 0
-check:output =~$$CN:\s*Downloaded dump \s*\d+\s* to /var/log/xcat/dump/
-cmd:dumpnumber=`cat /tmp/dumpgenerate |awk -F '[' '{ print $2 }' | awk -F ']' '{ print $1 }'`;rspconfig $$CN dump --download $dumpnumber
+cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;grep "Downloaded dump $dumpnumber to /var/log/xcat/dump/" /tmp/dumpdown
 check:rc == 0
-check:output =~$$CN:\s*Downloaded dump \s*\d+\s* to /var/log/xcat/dump/
+cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`rspconfig $$CN dump -l |grep "\[$dumpnumber\] Generated" |cut -d : -f 6`;ls -l /var/log/xcat/dump/*_$$CN_dump_$dumpnumber.tar.xz|grep $dumpsize
+cmd:rspconfig $$CN dump -g |tee /tmp/dumpgenerate
+check:rc == 0
+check:output =~$$CN:\s*\[\d+\]\s* success
+cmd:sleep 300
+cmd:dumpnumber=`cat /tmp/dumpgenerate |awk -F '[' '{ print $2 }' | awk -F ']' '{ print $1 }'`;rspconfig $$CN dump --download $dumpnumber |tee /tmp/dumpdown
+check:rc == 0
+cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;grep "Downloaded dump $dumpnumber to /var/log/xcat/dump/" /tmp/dumpdown
+check:rc == 0
+cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`rspconfig $$CN dump -l |grep "\[$dumpnumber\] Generated" |cut -d : -f 6`;ls -l /var/log/xcat/dump/*_$$CN_dump_$dumpnumber.tar.xz|grep $dumpsize
 cmd:rspconfig $$CN dump -d all
 check:rc == 0
 check:output =~Downloading all dumps

--- a/xCAT-test/autotest/testcase/rspconfig/cases1
+++ b/xCAT-test/autotest/testcase/rspconfig/cases1
@@ -32,12 +32,11 @@ check:rc == 0
 cmd:rspconfig $$CN dump -g|tee /tmp/dumpgenerate
 check:rc == 0
 check:output =~$$CN:\s*\[\d+\]\s* success
-end
 cmd:sleep 300
 cmd:rspconfig $$CN dump -l
 check:output =~$$CN:\s*\[\d+\]\s* Generated:
 check:rc == 0
-cmd:dumpnumber=`cat /tmp/dumpgenerate |awk -F '[' '{ print $2 }' | awk -F ']' '{ print $1 }'`|rspconfig $$CN dump --clear $dumpnumber
+cmd:dumpnumber=`cat /tmp/dumpgenerate |awk -F '[' '{ print $2 }' | awk -F ']' '{ print $1 }'`;rspconfig $$CN dump --clear $dumpnumber
 check:rc == 0
 check:output =~$$CN:\s*\[\d+\]\s* clear
 cmd:rspconfig $$CN dump -l|tee /tmp/dumplistnew
@@ -168,11 +167,13 @@ cmd:rspconfig $$CN powerrestorepolicy=always_on
 check:output =~$$CN:\s*BMC Setting BMC PowerRestorePolicy...
 check:rc == 0
 cmd:rspconfig $$CN powerrestorepolicy
+check:rc == 0
 check:output =~$$CN:\s*BMC PowerRestorePolicy:\s*AlwaysOn
 cmd:rspconfig $$CN powerrestorepolicy=always_off
 check:output =~$$CN:\s*BMC Setting BMC PowerRestorePolicy...
 check:rc == 0
 cmd:rspconfig $$CN powerrestorepolicy
+check:rc == 0
 check:output =~$$CN:\s*BMC PowerRestorePolicy:\s*AlwaysOff
 cmd:rspconfig $$CN powerrestorepolicy=restore
 check:output =~$$CN:\s*BMC Setting BMC PowerRestorePolicy...
@@ -181,6 +182,7 @@ cmd:rspconfig $$CN powerrestorepolicy=abc
 check:output =~$$CN:\s*Error: Invalid value '\S*' for 'powerrestorepolicy', Valid values: restore,always_on,always_off 
 check:rc != 0
 cmd:rspconfig $$CN powerrestorepolicy
+check:rc == 0
 check:output =~$$CN:\s*BMC PowerRestorePolicy:\s*Restore
 cmd:policy=`cat /tmp/powerrestorepolicy | awk -F ":" '{print $3}'`;newpolicy=`echo $policy |tr 'A-Z' 'a-z'`;rspconfig $$CN powerrestorepolicy=$newpolicy
 check:rc == 0
@@ -197,12 +199,14 @@ check:rc == 0
 cmd:rspconfig $$CN powersupplyredundancy=enabled
 check:output =~$$CN:\s*BMC Setting BMC PowerSupplyRedundancy...
 check:rc == 0
-cmd:rspconfig $$CN powersupplyredundancy 
+cmd:rspconfig $$CN powersupplyredundancy
+check:rc == 0 
 check:output =~$$CN:\s*BMC PowerSupplyRedundancy:\s*Enabled
 cmd:rspconfig $$CN powersupplyredundancy=disabled
 check:output =~$$CN:\s*BMC Setting BMC PowerSupplyRedundancy...
 check:rc == 0
 cmd:rspconfig $$CN powersupplyredundancy 
+check:rc == 0
 check:output =~$$CN:\s*BMC PowerSupplyRedundancy:\s*Disabled 
 cmd:rspconfig $$CN powersupplyredundancy=abc
 check:output =~$$CN:\s*Error: Invalid value \S* for 'powersupplyredundancy', Valid values: disabled,enabled 
@@ -223,11 +227,13 @@ cmd:rspconfig $$CN  timesyncmethod=ntp
 check:output =~$$CN:\s*BMC Setting BMC TimeSyncMethod...
 check:rc == 0
 cmd:rspconfig $$CN timesyncmethod 
+check:rc == 0
 check:output =~$$CN:\s*BMC TimeSyncMethod:\s*NTP
 cmd:rspconfig $$CN  timesyncmethod=manual
 check:output =~$$CN:\s*BMC Setting BMC TimeSyncMethod...
 check:rc == 0
 cmd:rspconfig $$CN timesyncmethod
+check:rc == 0
 check:output =~$$CN:\s*BMC TimeSyncMethod:\s*Manual
 cmd:rspconfig $$CN  timesyncmethod=abc
 check:output =~$$CN:\s*Error: Invalid value \S* for 'timesyncmethod', Valid values: ntp,manual
@@ -247,17 +253,20 @@ check:rc == 0
 cmd:rspconfig $$CN bootmode=regular 
 check:output =~$$CN:\s*BMC Setting BMC BootMode...
 check:rc == 0
-cmd:rspconfig $$CN bootmode 
+cmd:rspconfig $$CN bootmode
+check:rc == 0 
 check:output =~$$CN:\s*BMC BootMode:\s*Regular
 cmd:rspconfig $$CN bootmode=safe
 check:output =~$$CN:\s*BMC Setting BMC BootMode...
 check:rc == 0
 cmd:rspconfig $$CN bootmode
+check:rc == 0
 check:output =~$$CN:\s*BMC BootMode:\s*Safe
 cmd:rspconfig $$CN bootmode=setup
 check:output =~$$CN:\s*BMC Setting BMC BootMode...
 check:rc == 0
 cmd:rspconfig $$CN bootmode
+check:rc == 0
 check:output =~$$CN:\s*BMC BootMode:\s*Setup
 cmd:rspconfig $$CN bootmode=abc
 check:output =~$$CN:\s*Error: Invalid value \S* for 'bootmode', Valid values: regular,safe,setup
@@ -278,11 +287,13 @@ cmd:rspconfig $$CN autoreboot=1
 check:output =~$$CN:\s*BMC Setting BMC AutoReboot...
 check:rc == 0
 cmd:rspconfig $$CN autoreboot 
+check:rc == 0
 check:output =~$$CN:\s*BMC AutoReboot:\s*1
 cmd:rspconfig $$CN autoreboot=0
 check:output =~$$CN:\s*BMC Setting BMC AutoReboot...
 check:rc == 0
 cmd:rspconfig $$CN autoreboot
+check:rc == 0
 check:output =~$$CN:\s*BMC AutoReboot:\s*0
 cmd:rspconfig $$CN autoreboot=2
 check:output =~$$CN:\s*Error: Invalid value \S* for 'autoreboot', Valid values: 0,1

--- a/xCAT-test/autotest/testcase/rspconfig/cases1
+++ b/xCAT-test/autotest/testcase/rspconfig/cases1
@@ -139,8 +139,7 @@ check:output =~$$CN:\s*Dump requested
 check:output =~$$CN:\s*Downloading dump
 cmd:rspconfig $$CN dump -l |tail -n 1 |tee /tmp/dumpgenerate
 check:rc == 0
-#cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`cat /tmp/dumpgenerate |cut -d : -f 6`;ls -l /var/log/xcat/dump/*_$$CN_dump_$dumpnumber.tar.xz|grep $dumpsize
-cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`rspconfig $$CN dump -l |grep "\[$dumpnumber\] Generated" |cut -d : -f 6`;ls -l /var/log/xcat/dump/*_$$CN_dump_$dumpnumber.tar.xz|grep $dumpsize
+cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`grep "\[$dumpnumber\] Generated" /tmp/dumpgenerate |cut -d : -f 6`;ls -l /var/log/xcat/dump/*_$$CN_dump_$dumpnumber.tar.xz|grep $dumpsize
 check:rc == 0
 cmd:rm -rf /tmp/dumpgenerate
 end

--- a/xCAT-test/autotest/testcase/rspconfig/cases1
+++ b/xCAT-test/autotest/testcase/rspconfig/cases1
@@ -1,0 +1,303 @@
+start:rspconfig_ipsrc
+description: To test "rspconfig <node> ipsrc",to get the IP source for OpenBMC 
+os:Linux
+hcp:openbmc
+cmd:rspconfig $$CN ipsrc 
+check:output=~$$CN\s*:\s*BMC IP Source: Static|BMC IP Source: Dynamic 
+check:rc == 0
+cmd:rspconfig $$CN  hostname sshcfg
+check:output =~Error: Configure sshcfg must be issued without other options.
+check:rc != 0
+end
+
+start:rspconfig_dump_list
+description: To test "rspconfig <node> dump -l" and "rspconfig <node> dump --list" 
+os:Linux
+hcp:openbmc
+cmd:rspconfig $$CN dump -l  
+check:output =~$$CN:\s*No attributes returned from the BMC.|\s*\[\d+\]\s* Generated:
+check:rc == 0
+cmd:rspconfig $$CN dump --list 
+check:output =~$$CN:\s*No attributes returned from the BMC.|\s*\[\d+\]\s* Generated:
+check:rc == 0
+end
+
+start:rspconfig_dump_generate
+description: To test "rspconfig <node> dump -g" and "rspconfig <node> dump --generate" 
+os:Linux
+hcp:openbmc
+cmd:rspconfig $$CN dump -l|tee /tmp/dumplistold
+check:output =~$$CN:\s*No attributes returned from the BMC.|\s*\[\d+\]\s* Generated:
+check:rc == 0 
+cmd:rspconfig $$CN dump -g|tee /tmp/dumpgenerate
+check:rc == 0
+check:output =~$$CN:\s*\[\d+\]\s* success
+end
+cmd:sleep 300
+cmd:rspconfig $$CN dump -l
+check:output =~$$CN:\s*\[\d+\]\s* Generated:
+check:rc == 0
+cmd:dumpnumber=`cat /tmp/dumpgenerate |awk -F '[' '{ print $2 }' | awk -F ']' '{ print $1 }'`|rspconfig $$CN dump --clear $dumpnumber
+check:rc == 0
+check:output =~$$CN:\s*\[\d+\]\s* clear
+cmd:rspconfig $$CN dump -l|tee /tmp/dumplistnew
+cmd:diff /tmp/dumplistold /tmp/dumplistnew
+check:rc == 0
+cmd:rspconfig $$CN dump --generate|tee /tmp/dumpgenerate
+check:rc == 0
+check:output =~$$CN:\s*\[\d+\]\s* success
+cmd:sleep 300
+cmd:rspconfig $$CN dump -l
+check:output =~$$CN:\s*\[\d+\]\s* Generated:
+check:rc == 0
+cmd:dumpnumber=`cat /tmp/dumpgenerate |awk -F '[' '{ print $2 }' | awk -F ']' '{ print $1 }'`;rspconfig $$CN dump --clear $dumpnumber
+check:rc == 0
+check:output =~$$CN:\s*\[\d+\]\s* clear
+cmd:rspconfig $$CN dump -l|tee /tmp/dumplistnew
+cmd:diff /tmp/dumplistold /tmp/dumplistnew
+check:rc == 0
+cmd:rm -rf /tmp/dumplistold /tmp/dumplistnew /tmp/dumpgenerate
+end
+
+start:rspconfig_dump_clear
+description: To test "rspconfig <node> dump -c" and "rspconfig <node> dump --clear" 
+os:Linux
+hcp:openbmc
+cmd:rspconfig $$CN dump -g |tee /tmp/dumpgenerate
+check:rc == 0
+check:output =~$$CN:\s*\[\d+\]\s* success
+cmd:sleep 300
+cmd:dumpnumber=`cat /tmp/dumpgenerate |awk -F '[' '{ print $2 }' | awk -F ']' '{ print $1 }'`;rspconfig $$CN dump --clear $dumpnumber
+check:rc == 0
+check:output =~$$CN:\s*\[\d+\]\s* clear
+cmd:rspconfig $$CN dump -g |tee /tmp/dumpgenerate
+check:rc == 0
+check:output =~$$CN:\s*\[\d+\]\s* success
+cmd:sleep 300
+cmd:dumpnumber=`cat /tmp/dumpgenerate |awk -F '[' '{ print $2 }' | awk -F ']' '{ print $1 }'`;rspconfig $$CN dump --clear $dumpnumber
+check:rc == 0
+check:output =~$$CN:\s*\[\d+\]\s* clear
+cmd:rspconfig $$CN dump -g 
+check:rc == 0
+check:output =~$$CN:\s*\[\d+\]\s* success
+cmd:rspconfig $$CN dump -g
+check:rc == 0
+check:output =~$$CN:\s*\[\d+\]\s* success
+cmd:sleep 300
+cmd:rspconfig $$CN dump -c all
+check:rc == 0
+check:output =~$$CN:\s*\[all\]\s* clear
+cmd:rspconfig $$CN dump -l
+check:output =~$$CN:\s*No attributes returned from the BMC.
+cmd:rspconfig $$CN dump -g
+check:rc == 0
+check:output =~$$CN:\s*\[\d+\]\s* success
+cmd:rspconfig $$CN dump -g
+check:rc == 0
+check:output =~$$CN:\s*\[\d+\]\s* success
+cmd:sleep 300
+cmd:rspconfig $$CN dump --clear all
+check:rc == 0
+check:output =~$$CN:\s*\[all\]\s* clear
+cmd:rspconfig $$CN dump -l
+check:output =~$$CN:\s*No attributes returned from the BMC.
+end
+
+start:rspconfig_dump_download
+description: To test rspconfig <node> dump -d" and "rspconfig <node> dump --download"
+os:Linux
+hcp:openbmc
+cmd:rspconfig $$CN dump -g |tee /tmp/dumpgenerate
+check:rc == 0
+check:output =~$$CN:\s*\[\d+\]\s* success
+cmd:sleep 300
+cmd:dumpnumber=`cat /tmp/dumpgenerate |awk -F '[' '{ print $2 }' | awk -F ']' '{ print $1 }'`;rspconfig $$CN dump -d $dumpnumber
+check:rc == 0
+check:output =~$$CN:\s*Downloaded dump \s*\d+\s* to /var/log/xcat/dump/
+cmd:dumpnumber=`cat /tmp/dumpgenerate |awk -F '[' '{ print $2 }' | awk -F ']' '{ print $1 }'`;rspconfig $$CN dump --download $dumpnumber
+check:rc == 0
+check:output =~$$CN:\s*Downloaded dump \s*\d+\s* to /var/log/xcat/dump/
+cmd:rspconfig $$CN dump -d all
+check:rc == 0
+check:output =~Downloading all dumps
+cmd:rspconfig $$CN dump --download all
+check:rc == 0
+check:output =~Downloading all dumps 
+cmd:rm -rf /tmp/dumpgenerate
+end
+
+start:rspconfig_dump_no_option
+description: To test "rspconfig <node> dump"
+os:Linux
+hcp:openbmc
+cmd:rspconfig $$CN dump 
+check:rc == 0
+check:output =~$$CN:\s*Dump requested
+check:output =~$$CN:\s*Downloading dump
+end
+
+start:rspconfig_gard
+description: To test "rspconfig <node> gard -c" 
+os:Linux
+hcp:openbmc
+cmd:rspconfig $$CN gard -c 
+check:output =~$$CN:\s*GARD cleared
+check:rc == 0
+cmd:rspconfig $$CN gard --clear
+check:output =~$$CN:\s*GARD cleared
+check:rc == 0
+end
+
+start:rspconfig_ntpserver
+description: To test "rspconfig <node> ntpservers" to show the ntp server of the node 
+os:Linux
+hcp:openbmc
+cmd:rspconfig $$CN ntpservers 
+check:output =~$$CN:\s*BMC NTP Servers:\s*None|\s*\d+.\d+.\d+.\d+
+check:rc == 0
+end
+
+start:rspconfig_powerrestorepolicy
+description: To test "rspconfig <node> powerrestorepolicy" to show the policy 
+os:Linux
+hcp:openbmc
+cmd:rspconfig $$CN powerrestorepolicy |tee /tmp/powerrestorepolicy 
+check:output =~$$CN:\s*BMC PowerRestorePolicy:\s*AlwaysOff|AlwaysOn|Restore
+check:rc == 0
+cmd:rspconfig $$CN powerrestorepolicy=always_on 
+check:output =~$$CN:\s*BMC Setting BMC PowerRestorePolicy...
+check:rc == 0
+cmd:rspconfig $$CN powerrestorepolicy
+check:output =~$$CN:\s*BMC PowerRestorePolicy:\s*AlwaysOn
+cmd:rspconfig $$CN powerrestorepolicy=always_off
+check:output =~$$CN:\s*BMC Setting BMC PowerRestorePolicy...
+check:rc == 0
+cmd:rspconfig $$CN powerrestorepolicy
+check:output =~$$CN:\s*BMC PowerRestorePolicy:\s*AlwaysOff
+cmd:rspconfig $$CN powerrestorepolicy=restore
+check:output =~$$CN:\s*BMC Setting BMC PowerRestorePolicy...
+check:rc == 0
+cmd:rspconfig $$CN powerrestorepolicy=abc
+check:output =~$$CN:\s*Error: Invalid value '\S*' for 'powerrestorepolicy', Valid values: restore,always_on,always_off 
+check:rc != 0
+cmd:rspconfig $$CN powerrestorepolicy
+check:output =~$$CN:\s*BMC PowerRestorePolicy:\s*Restore
+cmd:policy=`cat /tmp/powerrestorepolicy | awk -F ":" '{print $3}'`;newpolicy=`echo $policy |tr 'A-Z' 'a-z'`;rspconfig $$CN powerrestorepolicy=$newpolicy
+check:rc == 0
+cmd:rm -rf /tmp/powerrestorepolicy 
+end
+
+start:rspconfig_powersupplyredundancy
+description: To test "rspconfig <node> powersupplyredundancy" to show the powersupplyredundancy state 
+os:Linux
+hcp:openbmc
+cmd:rspconfig $$CN powersupplyredundancy |tee /tmp/powersupplyredundancy 
+check:output =~$$CN:\s*BMC PowerSupplyRedundancy:\s*Enabled|Disabled
+check:rc == 0
+cmd:rspconfig $$CN powersupplyredundancy=enabled
+check:output =~$$CN:\s*BMC Setting BMC PowerSupplyRedundancy...
+check:rc == 0
+cmd:rspconfig $$CN powersupplyredundancy 
+check:output =~$$CN:\s*BMC PowerSupplyRedundancy:\s*Enabled
+cmd:rspconfig $$CN powersupplyredundancy=disabled
+check:output =~$$CN:\s*BMC Setting BMC PowerSupplyRedundancy...
+check:rc == 0
+cmd:rspconfig $$CN powersupplyredundancy 
+check:output =~$$CN:\s*BMC PowerSupplyRedundancy:\s*Disabled 
+cmd:rspconfig $$CN powersupplyredundancy=abc
+check:output =~$$CN:\s*Error: Invalid value \S* for 'powersupplyredundancy', Valid values: disabled,enabled 
+check:rc != 0
+cmd:redundancy=`cat /tmp/powersupplyredundancy | awk -F ":" '{print $3}'`;newredundancy=`echo $redundancy |tr 'A-Z' 'a-z'`;rspconfig $$CN powersupplyredundancy=$newredundancy
+check:rc == 0
+cmd:rm -rf /tmp/powersupplyredundancy
+end
+
+start:rspconfig_timesyncmethod
+description: To test "rspconfig <node> timesyncmethod" to show the timesyncmethod 
+os:Linux
+hcp:openbmc
+cmd:rspconfig $$CN timesyncmethod |tee /tmp/timesyncmethod
+check:output =~$$CN:\s*BMC TimeSyncMethod:\s*NTP|Manual
+check:rc == 0
+cmd:rspconfig $$CN  timesyncmethod=ntp
+check:output =~$$CN:\s*BMC Setting BMC TimeSyncMethod...
+check:rc == 0
+cmd:rspconfig $$CN timesyncmethod 
+check:output =~$$CN:\s*BMC TimeSyncMethod:\s*NTP
+cmd:rspconfig $$CN  timesyncmethod=manual
+check:output =~$$CN:\s*BMC Setting BMC TimeSyncMethod...
+check:rc == 0
+cmd:rspconfig $$CN timesyncmethod
+check:output =~$$CN:\s*BMC TimeSyncMethod:\s*Manual
+cmd:rspconfig $$CN  timesyncmethod=abc
+check:output =~$$CN:\s*Error: Invalid value \S* for 'timesyncmethod', Valid values: ntp,manual
+check:rc != 0
+cmd:syncmethod=`cat /tmp/timesyncmethod | awk -F ":" '{print $3}'`;newsyncmethod=`echo $syncmethod |tr 'A-Z' 'a-z'`;rspconfig $$CN timesyncmethod=$newsyncmethod
+check:rc == 0
+cmd:rm -rf /tmp/timesyncmethod
+end
+
+start:rspconfig_bootmode
+description: To test "rspconfig <node> bootmode" to show and change bootmode 
+os:Linux
+hcp:openbmc
+cmd:rspconfig $$CN bootmode|tee /tmp/bootmode
+check:output =~$$CN:\s*BMC BootMode:\s*Regular|Safe|Setup
+check:rc == 0
+cmd:rspconfig $$CN bootmode=regular 
+check:output =~$$CN:\s*BMC Setting BMC BootMode...
+check:rc == 0
+cmd:rspconfig $$CN bootmode 
+check:output =~$$CN:\s*BMC BootMode:\s*Regular
+cmd:rspconfig $$CN bootmode=safe
+check:output =~$$CN:\s*BMC Setting BMC BootMode...
+check:rc == 0
+cmd:rspconfig $$CN bootmode
+check:output =~$$CN:\s*BMC BootMode:\s*Safe
+cmd:rspconfig $$CN bootmode=setup
+check:output =~$$CN:\s*BMC Setting BMC BootMode...
+check:rc == 0
+cmd:rspconfig $$CN bootmode
+check:output =~$$CN:\s*BMC BootMode:\s*Setup
+cmd:rspconfig $$CN bootmode=abc
+check:output =~$$CN:\s*Error: Invalid value \S* for 'bootmode', Valid values: regular,safe,setup
+check:rc != 0
+cmd:mode=`cat /tmp/bootmode |awk -F ":" '{print $3}'`;newmode=`echo $mode |tr 'A-Z' 'a-z'`;rspconfig $$CN bootmode=$newmode
+check:rc == 0
+cmd:rm -rf /tmp/bootmode
+end
+
+start:rspconfig_autoreboot
+description: To test "rspconfig <node> autoreboot" to show and change autoreboot 
+os:Linux
+hcp:openbmc
+cmd:rspconfig $$CN autoreboot|tee /tmp/autoreboot
+check:output =~$$CN:\s*BMC AutoReboot:\s*1|0
+check:rc == 0
+cmd:rspconfig $$CN autoreboot=1
+check:output =~$$CN:\s*BMC Setting BMC AutoReboot...
+check:rc == 0
+cmd:rspconfig $$CN autoreboot 
+check:output =~$$CN:\s*BMC AutoReboot:\s*1
+cmd:rspconfig $$CN autoreboot=0
+check:output =~$$CN:\s*BMC Setting BMC AutoReboot...
+check:rc == 0
+cmd:rspconfig $$CN autoreboot
+check:output =~$$CN:\s*BMC AutoReboot:\s*0
+cmd:rspconfig $$CN autoreboot=2
+check:output =~$$CN:\s*Error: Invalid value \S* for 'autoreboot', Valid values: 0,1
+check:rc != 0
+cmd:autoreboot=`cat /tmp/autoreboot |awk -F ":" '{print $3}'`;newautoreboot=`echo $autoreboot |tr 'A-Z' 'a-z'`;rspconfig $$CN autoreboot=$newautoreboot
+check:rc == 0
+cmd:rm -rf /tmp/autoreboot
+end
+
+start:rspconfig_invalid
+description: To test "rspconfig <node> invalid_value"  should throw out error message
+os:Linux
+hcp:openbmc
+cmd:rspconfig $$CN aaa
+check:output =~Error: Unsupported command: rspconfig aaa 
+check:rc != 0
+end
+


### PR DESCRIPTION
Add 14 cases in this pull request

[case 1]
Case Name:start:rspconfig_ipsrc
description: To test "rspconfig <node> ipsrc",to get the IP source for OpenBMC

[case 2]
Case Name:start:rspconfig_dump_list
description: To test "rspconfig <node> dump -l" and "rspconfig <node> dump --list"

[case 3]
start:rspconfig_dump_generate
description: To test "rspconfig <node> dump -g" and "rspconfig <node> dump --generate"

[case 4]
start:rspconfig_dump_clear
description: To test "rspconfig <node> dump -c" and "rspconfig <node> dump --clear"

[case 5]
start:rspconfig_dump_download
description: To test rspconfig <node> dump -d" and "rspconfig <node> dump --download"

[case 6]
start:rspconfig_dump_no_option
description: To test "rspconfig <node> dump"

[case 7]
start:rspconfig_gard
description: To test "rspconfig <node> gard -c"

[case 8]
start:rspconfig_ntpserver
description: To test "rspconfig <node> ntpservers" to show the ntp server of the node

[case 9]
start:rspconfig_powerrestorepolicy
description: To test "rspconfig <node> powerrestorepolicy" to show the policy

[case 10]
start:rspconfig_powersupplyredundancy
description: To test "rspconfig <node> powersupplyredundancy" to show the powersupplyredundancy state

[case 11]
start:rspconfig_timesyncmethod
description: To test "rspconfig <node> timesyncmethod" to show the timesyncmethod

[case 12]
start:rspconfig_bootmode
description: To test "rspconfig <node> bootmode" to show and change bootmode

[case 13]
start:rspconfig_autoreboot
description: To test "rspconfig <node> autoreboot" to show and change autoreboot

[case 14]
start:rspconfig_invalid
description: To test "rspconfig <node> invalid_value"  should throw out error message

UT result
```
xCAT automated test started at Tue Apr 17 01:54:50 2018
******************************
To detect current test environment
******************************
Detecting: OS = linux
Detecting: ARCH = ppc64le
Detecting: HCP = openbmc
******************************
loading test cases
******************************
To run:
rspconfig_ipsrc
rspconfig_dump_list
rspconfig_dump_generate
rspconfig_dump_clear
rspconfig_dump_download
rspconfig_dump_no_option
rspconfig_gard
rspconfig_ntpserver
rspconfig_powerrestorepolicy
rspconfig_powersupplyredundancy
rspconfig_timesyncmethod
rspconfig_bootmode
rspconfig_autoreboot
rspconfig_invalid
******************************
Start to run test cases
******************************
------START::rspconfig_ipsrc::Time:Tue Apr 17 01:54:52 2018------

RUN:rspconfig mid08tor03cn10 ipsrc [Tue Apr 17 01:54:52 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC IP Source: Static
CHECK:output =~ mid08tor03cn10\s*:\s*BMC IP Source: Static|BMC IP Source: Dynamic       [Pass]
CHECK:rc == 0   [Pass]

RUN:rspconfig mid08tor03cn10  hostname sshcfg [Tue Apr 17 01:54:53 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
mid08tor03cn10: Error: Configure sshcfg must be issued without other options.
CHECK:output =~ Error: Configure sshcfg must be issued without other options.   [Pass]
CHECK:rc != 0   [Pass]

------END::rspconfig_ipsrc::Passed::Time:Tue Apr 17 01:54:54 2018 ::Duration::2 sec------
------START::rspconfig_dump_list::Time:Tue Apr 17 01:54:54 2018------

RUN:rspconfig mid08tor03cn10 dump -l [Tue Apr 17 01:54:54 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: [81] Generated: 04/17/2018 00:30:25, Size: 85464
mid08tor03cn10: [82] Generated: 04/17/2018 00:35:33, Size: 85752
mid08tor03cn10: [83] Generated: 04/17/2018 01:39:17, Size: 85960
mid08tor03cn10: [84] Generated: 04/17/2018 01:45:26, Size: 86016
CHECK:output =~ mid08tor03cn10:\s*No attributes returned from the BMC.|\s*\[\d+\]\s* Generated: [Pass]
CHECK:rc == 0   [Pass]

RUN:rspconfig mid08tor03cn10 dump --list [Tue Apr 17 01:54:55 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: [81] Generated: 04/17/2018 00:30:25, Size: 85464
mid08tor03cn10: [82] Generated: 04/17/2018 00:35:33, Size: 85752
mid08tor03cn10: [83] Generated: 04/17/2018 01:39:17, Size: 85960
mid08tor03cn10: [84] Generated: 04/17/2018 01:45:26, Size: 86016
CHECK:output =~ mid08tor03cn10:\s*No attributes returned from the BMC.|\s*\[\d+\]\s* Generated: [Pass]
CHECK:rc == 0   [Pass]

------END::rspconfig_dump_list::Passed::Time:Tue Apr 17 01:54:56 2018 ::Duration::2 sec------
------START::rspconfig_dump_generate::Time:Tue Apr 17 01:54:56 2018------

RUN:rspconfig mid08tor03cn10 dump -l|tee /tmp/dumplistold [Tue Apr 17 01:54:56 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: [81] Generated: 04/17/2018 00:30:25, Size: 85464
OUTPUT:
mid08tor03cn10: [81] Generated: 04/17/2018 00:30:25, Size: 85464
mid08tor03cn10: [82] Generated: 04/17/2018 00:35:33, Size: 85752
mid08tor03cn10: [83] Generated: 04/17/2018 01:39:17, Size: 85960
mid08tor03cn10: [84] Generated: 04/17/2018 01:45:26, Size: 86016
CHECK:output =~ mid08tor03cn10:\s*No attributes returned from the BMC.|\s*\[\d+\]\s* Generated: [Pass]
CHECK:rc == 0   [Pass]

RUN:rspconfig mid08tor03cn10 dump -g|tee /tmp/dumpgenerate [Tue Apr 17 01:54:58 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: [85] success
CHECK:rc == 0   [Pass]
CHECK:output =~ mid08tor03cn10:\s*\[\d+\]\s* success    [Pass]

------END::rspconfig_dump_generate::Passed::Time:Tue Apr 17 01:55:00 2018 ::Duration::4 sec------
------START::rspconfig_dump_clear::Time:Tue Apr 17 01:55:00 2018------

RUN:rspconfig mid08tor03cn10 dump -g |tee /tmp/dumpgenerate [Tue Apr 17 01:55:00 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: [86] success
CHECK:rc == 0   [Pass]
CHECK:output =~ mid08tor03cn10:\s*\[\d+\]\s* success    [Pass]

RUN:sleep 300 [Tue Apr 17 01:55:01 2018]
ElapsedTime:300 sec
RETURN rc = 0
OUTPUT:

RUN:dumpnumber=`cat /tmp/dumpgenerate |awk -F '[' '{ print $2 }' | awk -F ']' '{ print $1 }'`;rspconfig mid08tor03cn10 dump --clear $dumpnumber [Tue Apr 17 02:00:01 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: [86] clear
CHECK:rc == 0   [Pass]
CHECK:output =~ mid08tor03cn10:\s*\[\d+\]\s* clear      [Pass]
CHECK:rc == 0   [Pass]
CHECK:output =~ mid08tor03cn10:\s*\[\d+\]\s* clear      [Pass]

RUN:rspconfig mid08tor03cn10 dump -g |tee /tmp/dumpgenerate [Tue Apr 17 02:00:03 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: [87] success
CHECK:rc == 0   [Pass]
CHECK:output =~ mid08tor03cn10:\s*\[\d+\]\s* success    [Pass]

RUN:sleep 300 [Tue Apr 17 02:00:04 2018]
ElapsedTime:300 sec
RETURN rc = 0
OUTPUT:

RUN:dumpnumber=`cat /tmp/dumpgenerate |awk -F '[' '{ print $2 }' | awk -F ']' '{ print $1 }'`;rspconfig mid08tor03cn10 dump --clear $dumpnumber [Tue Apr 17 02:05:04 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: [87] clear
CHECK:rc == 0   [Pass]
CHECK:output =~ mid08tor03cn10:\s*\[\d+\]\s* clear      [Pass]

RUN:rspconfig mid08tor03cn10 dump -g [Tue Apr 17 02:05:06 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: [88] success
CHECK:rc == 0   [Pass]
CHECK:output =~ mid08tor03cn10:\s*\[\d+\]\s* success    [Pass]

RUN:rspconfig mid08tor03cn10 dump -g [Tue Apr 17 02:05:07 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: [89] success
CHECK:rc == 0   [Pass]
CHECK:output =~ mid08tor03cn10:\s*\[\d+\]\s* success    [Pass]
CHECK:rc == 0   [Pass]
CHECK:output =~ mid08tor03cn10:\s*\[\d+\]\s* success    [Pass]

RUN:sleep 300 [Tue Apr 17 02:05:09 2018]
ElapsedTime:300 sec
RETURN rc = 0
OUTPUT:

RUN:rspconfig mid08tor03cn10 dump -c all [Tue Apr 17 02:10:09 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: [all] clear
CHECK:rc == 0   [Pass]
CHECK:output =~ mid08tor03cn10:\s*[all]\s* clear        [Failed]

RUN:rspconfig mid08tor03cn10 dump -l [Tue Apr 17 02:10:11 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: No attributes returned from the BMC.

RUN:rspconfig mid08tor03cn10 dump -g [Tue Apr 17 02:10:13 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: [90] success

RUN:rspconfig mid08tor03cn10 dump -g [Tue Apr 17 02:10:14 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: [91] success

RUN:sleep 300 [Tue Apr 17 02:10:17 2018]
ElapsedTime:300 sec
RETURN rc = 0
OUTPUT:

RUN:rspconfig mid08tor03cn10 dump --clear all [Tue Apr 17 02:15:17 2018]
RUN:rspconfig mid08tor03cn10 dump --clear all [Tue Apr 17 02:15:17 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: [all] clear

RUN:rspconfig mid08tor03cn10 dump -l [Tue Apr 17 02:15:19 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: No attributes returned from the BMC.

------END::rspconfig_dump_clear::Failed::Time:Tue Apr 17 02:15:20 2018 ::Duration::1220 sec------
------START::rspconfig_dump_download::Time:Tue Apr 17 02:15:20 2018------

RUN:rspconfig mid08tor03cn10 dump -g |tee /tmp/dumpgenerate [Tue Apr 17 02:15:20 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: [92] success
CHECK:rc == 0   [Pass]
CHECK:output =~ mid08tor03cn10:\s*\[\d+\]\s* success    [Pass]

RUN:sleep 300 [Tue Apr 17 02:15:22 2018]
ElapsedTime:300 sec
RETURN rc = 0
OUTPUT:

RUN:dumpnumber=`cat /tmp/dumpgenerate |awk -F '[' '{ print $2 }' | awk -F ']' '{ print $1 }'`;rspconfig mid08tor03cn10 dump -d $dumpnumber [Tue Apr 17 02:20:22 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: Downloaded dump 92 to /var/log/xcat/dump/20180417-0220_mid08tor03cn10_dump_92.tar.xz.
CHECK:rc == 0   [Pass]
CHECK:output =~ mid08tor03cn10:\s*Downloaded dump \s*\d+\s* to /var/log/xcat/dump/      [Pass]

RUN:dumpnumber=`cat /tmp/dumpgenerate |awk -F '[' '{ print $2 }' | awk -F ']' '{ print $1 }'`;rspconfig mid08tor03cn10 dump --download $dumpnumber [Tue Apr 17 02:20:24 2018]


RUN:dumpnumber=`cat /tmp/dumpgenerate |awk -F '[' '{ print $2 }' | awk -F ']' '{ print $1 }'`;rspconfig mid08tor03cn10 dump --download $dumpnumber [Tue Apr 17 02:20:24 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: Downloaded dump 92 to /var/log/xcat/dump/20180417-0220_mid08tor03cn10_dump_92.tar.xz.
CHECK:rc == 0   [Pass]
CHECK:output =~ mid08tor03cn10:\s*Downloaded dump \s*\d+\s* to /var/log/xcat/dump/      [Pass]

RUN:rspconfig mid08tor03cn10 dump -d all [Tue Apr 17 02:20:26 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Downloading all dumps...
mid08tor03cn10: Downloaded dump 92 to /var/log/xcat/dump/20180417-0220_mid08tor03cn10_dump_92.tar.xz.
CHECK:rc == 0   [Pass]
CHECK:output =~ Downloading all dumps   [Pass]

RUN:rspconfig mid08tor03cn10 dump --download all [Tue Apr 17 02:20:27 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
Downloading all dumps...
mid08tor03cn10: Downloaded dump 92 to /var/log/xcat/dump/20180417-0220_mid08tor03cn10_dump_92.tar.xz.
CHECK:rc == 0   [Pass]
CHECK:output =~ Downloading all dumps   [Pass]

RUN:rm -rf /tmp/dumpgenerate [Tue Apr 17 02:20:29 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::rspconfig_dump_download::Passed::Time:Tue Apr 17 02:20:29 2018 ::Duration::309 sec------
------START::rspconfig_dump_no_option::Time:Tue Apr 17 02:20:29 2018------

RUN:rspconfig mid08tor03cn10 dump [Tue Apr 17 02:20:29 2018]
ElapsedTime:145 sec
RETURN rc = 0
OUTPUT:
RETURN rc = 0
OUTPUT:
Capturing BMC Diagnostic information, this will take some time...
mid08tor03cn10: Dump requested. Target ID is 93, waiting for BMC to generate...
mid08tor03cn10: Still waiting for dump 93 to be generated...
mid08tor03cn10: Downloading dump 93 to /var/log/xcat/dump/20180417-0222_mid08tor03cn10_dump_93.tar.xz
mid08tor03cn10: Downloaded dump 93 to /var/log/xcat/dump/20180417-0222_mid08tor03cn10_dump_93.tar.xz.
CHECK:rc == 0   [Pass]
CHECK:output =~ mid08tor03cn10:\s*Dump requested        [Pass]
CHECK:output =~ mid08tor03cn10:\s*Downloading dump      [Pass]

------END::rspconfig_dump_no_option::Passed::Time:Tue Apr 17 02:22:54 2018 ::Duration::145 sec------
------START::rspconfig_gard::Time:Tue Apr 17 02:22:54 2018------

RUN:rspconfig mid08tor03cn10 gard -c [Tue Apr 17 02:22:54 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: GARD cleared
CHECK:output =~ mid08tor03cn10:\s*GARD cleared  [Pass]
CHECK:rc == 0   [Pass]

RUN:rspconfig mid08tor03cn10 gard --clear [Tue Apr 17 02:22:55 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: GARD cleared
CHECK:output =~ mid08tor03cn10:\s*GARD cleared  [Pass]
CHECK:rc == 0   [Pass]

------END::rspconfig_gard::Passed::Time:Tue Apr 17 02:22:57 2018 ::Duration::3 sec------
------START::rspconfig_ntpserver::Time:Tue Apr 17 02:22:57 2018------

RUN:rspconfig mid08tor03cn10 ntpservers [Tue Apr 17 02:22:57 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC NTP Servers: None
CHECK:output =~ mid08tor03cn10:\s*BMC NTP Servers:\s*None|\s*\d+.\d+.\d+.\d+    [Pass]
CHECK:rc == 0   [Pass]

CHECK:output =~ mid08tor03cn10:\s*BMC NTP Servers:\s*None|\s*\d+.\d+.\d+.\d+    [Pass]
CHECK:rc == 0   [Pass]

------END::rspconfig_ntpserver::Passed::Time:Tue Apr 17 02:22:59 2018 ::Duration::2 sec------
------START::rspconfig_powerrestorepolicy::Time:Tue Apr 17 02:22:59 2018------

RUN:rspconfig mid08tor03cn10 powerrestorepolicy |tee /tmp/powerrestorepolicy [Tue Apr 17 02:22:59 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC PowerRestorePolicy: Restore
CHECK:output =~ mid08tor03cn10:\s*BMC PowerRestorePolicy:\s*AlwaysOff|AlwaysOn|Restore  [Pass]
CHECK:rc == 0   [Pass]

RUN:rspconfig mid08tor03cn10 powerrestorepolicy=always_on [Tue Apr 17 02:23:00 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC Setting BMC PowerRestorePolicy...
CHECK:output =~ mid08tor03cn10:\s*BMC Setting BMC PowerRestorePolicy... [Pass]
CHECK:rc == 0   [Pass]

RUN:rspconfig mid08tor03cn10 powerrestorepolicy [Tue Apr 17 02:23:02 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC PowerRestorePolicy: AlwaysOn
CHECK:output =~ mid08tor03cn10:\s*BMC PowerRestorePolicy:\s*AlwaysOn    [Pass]

RUN:rspconfig mid08tor03cn10 powerrestorepolicy=always_off [Tue Apr 17 02:23:03 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC Setting BMC PowerRestorePolicy...
CHECK:output =~ mid08tor03cn10:\s*BMC Setting BMC PowerRestorePolicy... [Pass]
CHECK:rc == 0   [Pass]

RUN:rspconfig mid08tor03cn10 powerrestorepolicy [Tue Apr 17 02:23:04 2018]
ElapsedTime:2 sec
RETURN rc = 0

ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC PowerRestorePolicy: AlwaysOff
CHECK:output =~ mid08tor03cn10:\s*BMC PowerRestorePolicy:\s*AlwaysOff   [Pass]

RUN:rspconfig mid08tor03cn10 powerrestorepolicy=restore [Tue Apr 17 02:23:06 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC Setting BMC PowerRestorePolicy...
CHECK:output =~ mid08tor03cn10:\s*BMC Setting BMC PowerRestorePolicy... [Pass]
CHECK:rc == 0   [Pass]

RUN:rspconfig mid08tor03cn10 powerrestorepolicy=abc [Tue Apr 17 02:23:07 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
mid08tor03cn10: Error: Invalid value 'abc' for 'powerrestorepolicy', Valid values: restore,always_on,always_off
CHECK:output =~ mid08tor03cn10:\s*Error: Invalid value '\S*' for 'powerrestorepolicy', Valid values: restore,always_on,always_off       [Pass]
CHECK:rc != 0   [Pass]

RUN:rspconfig mid08tor03cn10 powerrestorepolicy [Tue Apr 17 02:23:07 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC PowerRestorePolicy: Restore
CHECK:output =~ mid08tor03cn10:\s*BMC PowerRestorePolicy:\s*Restore     [Pass]

RUN:policy=`cat /tmp/powerrestorepolicy | awk -F ":" '{print $3}'`;newpolicy=`echo $policy |tr 'A-Z' 'a-z'`;rspconfig mid08tor03cn10 powerrestorepolicy=$newpolicy [Tue Apr 17 02:23:09 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC Setting BMC PowerRestorePolicy...
CHECK:rc == 0   [Pass]

RUN:rm -rf /tmp/powerrestorepolicy [Tue Apr 17 02:23:10 2018]
ElapsedTime:0 sec
RETURN rc = 0
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::rspconfig_powerrestorepolicy::Passed::Time:Tue Apr 17 02:23:10 2018 ::Duration::11 sec------
------START::rspconfig_powersupplyredundancy::Time:Tue Apr 17 02:23:10 2018------

RUN:rspconfig mid08tor03cn10 powersupplyredundancy |tee /tmp/powersupplyredundancy [Tue Apr 17 02:23:10 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC PowerSupplyRedundancy: Disabled
CHECK:output =~ mid08tor03cn10:\s*BMC PowerSupplyRedundancy:\s*Enabled|Disabled [Pass]
CHECK:rc == 0   [Pass]

RUN:rspconfig mid08tor03cn10 powersupplyredundancy=enabled [Tue Apr 17 02:23:12 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC Setting BMC PowerSupplyRedundancy...
CHECK:output =~ mid08tor03cn10:\s*BMC Setting BMC PowerSupplyRedundancy...      [Pass]
CHECK:rc == 0   [Pass]

RUN:rspconfig mid08tor03cn10 powersupplyredundancy [Tue Apr 17 02:23:14 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC PowerSupplyRedundancy: Enabled
CHECK:output =~ mid08tor03cn10:\s*BMC PowerSupplyRedundancy:\s*Enabled  [Pass]

RUN:rspconfig mid08tor03cn10 powersupplyredundancy=disabled [Tue Apr 17 02:23:16 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC Setting BMC PowerSupplyRedundancy...
CHECK:output =~ mid08tor03cn10:\s*BMC Setting BMC PowerSupplyRedundancy...      [Pass]
CHECK:rc == 0   [Pass]

RUN:rspconfig mid08tor03cn10 powersupplyredundancy [Tue Apr 17 02:23:18 2018]
ElapsedTime:1 sec
RUN:rspconfig mid08tor03cn10 powersupplyredundancy [Tue Apr 17 02:23:18 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC PowerSupplyRedundancy: Disabled
CHECK:output =~ mid08tor03cn10:\s*BMC PowerSupplyRedundancy:\s*Disabled [Pass]

RUN:rspconfig mid08tor03cn10 powersupplyredundancy=abc [Tue Apr 17 02:23:19 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
mid08tor03cn10: Error: Invalid value 'abc' for 'powersupplyredundancy', Valid values: disabled,enabled
CHECK:output =~ mid08tor03cn10:\s*Error: Invalid value \S* for 'powersupplyredundancy', Valid values: disabled,enabled  [Pass]
CHECK:rc != 0   [Pass]

RUN:redundancy=`cat /tmp/powersupplyredundancy | awk -F ":" '{print $3}'`;newredundancy=`echo $redundancy |tr 'A-Z' 'a-z'`;rspconfig mid08tor03cn10 powersupplyredundancy=$newredundancy [Tue Apr 17 02:23:20 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC Setting BMC PowerSupplyRedundancy...
CHECK:rc == 0   [Pass]

RUN:rm -rf /tmp/powersupplyredundancy [Tue Apr 17 02:23:21 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::rspconfig_powersupplyredundancy::Passed::Time:Tue Apr 17 02:23:21 2018 ::Duration::11 sec------
------START::rspconfig_timesyncmethod::Time:Tue Apr 17 02:23:21 2018------

RUN:rspconfig mid08tor03cn10 timesyncmethod |tee /tmp/timesyncmethod [Tue Apr 17 02:23:21 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC TimeSyncMethod: Manual
CHECK:output =~ mid08tor03cn10:\s*BMC TimeSyncMethod:\s*NTP|Manual      [Pass]
CHECK:rc == 0   [Pass]

RUN:rspconfig mid08tor03cn10  timesyncmethod=ntp [Tue Apr 17 02:23:22 2018]

RUN:rspconfig mid08tor03cn10  timesyncmethod=ntp [Tue Apr 17 02:23:22 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC Setting BMC TimeSyncMethod...
CHECK:output =~ mid08tor03cn10:\s*BMC Setting BMC TimeSyncMethod...     [Pass]
CHECK:rc == 0   [Pass]

RUN:rspconfig mid08tor03cn10 timesyncmethod [Tue Apr 17 02:23:24 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC TimeSyncMethod: NTP
CHECK:output =~ mid08tor03cn10:\s*BMC TimeSyncMethod:\s*NTP     [Pass]

RUN:rspconfig mid08tor03cn10  timesyncmethod=manual [Tue Apr 17 02:23:25 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC Setting BMC TimeSyncMethod...
CHECK:output =~ mid08tor03cn10:\s*BMC Setting BMC TimeSyncMethod...     [Pass]
CHECK:rc == 0   [Pass]

RUN:rspconfig mid08tor03cn10 timesyncmethod [Tue Apr 17 02:23:27 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC TimeSyncMethod: Manual
CHECK:output =~ mid08tor03cn10:\s*BMC TimeSyncMethod:\s*Manual  [Pass]

RUN:rspconfig mid08tor03cn10  timesyncmethod=abc [Tue Apr 17 02:23:28 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
mid08tor03cn10: Error: Invalid value 'abc' for 'timesyncmethod', Valid values: ntp,manual
CHECK:output =~ mid08tor03cn10:\s*Error: Invalid value \S* for 'timesyncmethod', Valid values: ntp,manual       [Pass]
CHECK:rc != 0   [Pass]

CHECK:rc != 0   [Pass]

RUN:syncmethod=`cat /tmp/timesyncmethod | awk -F ":" '{print $3}'`;newsyncmethod=`echo $syncmethod |tr 'A-Z' 'a-z'`;rspconfig mid08tor03cn10 timesyncmethod=$newsyncmethod [Tue Apr 17 02:23:28 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC Setting BMC TimeSyncMethod...
CHECK:rc == 0   [Pass]

RUN:rm -rf /tmp/timesyncmethod [Tue Apr 17 02:23:30 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::rspconfig_timesyncmethod::Passed::Time:Tue Apr 17 02:23:30 2018 ::Duration::9 sec------
------START::rspconfig_bootmode::Time:Tue Apr 17 02:23:30 2018------

RUN:rspconfig mid08tor03cn10 bootmode|tee /tmp/bootmode [Tue Apr 17 02:23:30 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC BootMode: Setup
CHECK:output =~ mid08tor03cn10:\s*BMC BootMode:\s*Regular|Safe|Setup    [Pass]
CHECK:rc == 0   [Pass]

RUN:rspconfig mid08tor03cn10 bootmode=regular [Tue Apr 17 02:23:31 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC Setting BMC BootMode...
CHECK:output =~ mid08tor03cn10:\s*BMC Setting BMC BootMode...   [Pass]
CHECK:rc == 0   [Pass]

RUN:rspconfig mid08tor03cn10 bootmode [Tue Apr 17 02:23:33 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC BootMode: Regular
CHECK:output =~ mid08tor03cn10:\s*BMC BootMode:\s*Regular       [Pass]
mid08tor03cn10: BMC BootMode: Regular
CHECK:output =~ mid08tor03cn10:\s*BMC BootMode:\s*Regular       [Pass]

RUN:rspconfig mid08tor03cn10 bootmode=safe [Tue Apr 17 02:23:34 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC Setting BMC BootMode...
CHECK:output =~ mid08tor03cn10:\s*BMC Setting BMC BootMode...   [Pass]
CHECK:rc == 0   [Pass]

RUN:rspconfig mid08tor03cn10 bootmode [Tue Apr 17 02:23:36 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC BootMode: Safe
CHECK:output =~ mid08tor03cn10:\s*BMC BootMode:\s*Safe  [Pass]

RUN:rspconfig mid08tor03cn10 bootmode=setup [Tue Apr 17 02:23:37 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC Setting BMC BootMode...
CHECK:output =~ mid08tor03cn10:\s*BMC Setting BMC BootMode...   [Pass]
CHECK:rc == 0   [Pass]

RUN:rspconfig mid08tor03cn10 bootmode [Tue Apr 17 02:23:39 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC BootMode: Setup
CHECK:output =~ mid08tor03cn10:\s*BMC BootMode:\s*Setup [Pass]

RUN:rspconfig mid08tor03cn10 bootmode=abc [Tue Apr 17 02:23:40 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
mid08tor03cn10: Error: Invalid value 'abc' for 'bootmode', Valid values: regular,safe,setup
CHECK:output =~ mid08tor03cn10:\s*Error: Invalid value \S* for 'bootmode', Valid values: regular,safe,setup     [Pass]
CHECK:rc != 0   [Pass]
CHECK:output =~ mid08tor03cn10:\s*Error: Invalid value \S* for 'bootmode', Valid values: regular,safe,setup     [Pass]
CHECK:rc != 0   [Pass]

RUN:mode=`cat /tmp/bootmode |awk -F ":" '{print $3}'`;newmode=`echo $mode |tr 'A-Z' 'a-z'`;rspconfig mid08tor03cn10 bootmode=$newmode [Tue Apr 17 02:23:41 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC Setting BMC BootMode...
CHECK:rc == 0   [Pass]

RUN:rm -rf /tmp/bootmode [Tue Apr 17 02:23:42 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::rspconfig_bootmode::Passed::Time:Tue Apr 17 02:23:42 2018 ::Duration::12 sec------
------START::rspconfig_autoreboot::Time:Tue Apr 17 02:23:42 2018------

RUN:rspconfig mid08tor03cn10 autoreboot|tee /tmp/autoreboot [Tue Apr 17 02:23:42 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC AutoReboot: 0
CHECK:output =~ mid08tor03cn10:\s*BMC AutoReboot:\s*1|0 [Pass]
CHECK:rc == 0   [Pass]

RUN:rspconfig mid08tor03cn10 autoreboot=1 [Tue Apr 17 02:23:44 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC Setting BMC AutoReboot...
CHECK:output =~ mid08tor03cn10:\s*BMC Setting BMC AutoReboot... [Pass]
CHECK:rc == 0   [Pass]

RUN:rspconfig mid08tor03cn10 autoreboot [Tue Apr 17 02:23:46 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC AutoReboot: 1
OUTPUT:
mid08tor03cn10: BMC AutoReboot: 1
CHECK:output =~ mid08tor03cn10:\s*BMC AutoReboot:\s*1   [Pass]

RUN:rspconfig mid08tor03cn10 autoreboot=0 [Tue Apr 17 02:23:47 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC Setting BMC AutoReboot...
CHECK:output =~ mid08tor03cn10:\s*BMC Setting BMC AutoReboot... [Pass]
CHECK:rc == 0   [Pass]

RUN:rspconfig mid08tor03cn10 autoreboot [Tue Apr 17 02:23:49 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC AutoReboot: 0
CHECK:output =~ mid08tor03cn10:\s*BMC AutoReboot:\s*0   [Pass]

RUN:rspconfig mid08tor03cn10 autoreboot=2 [Tue Apr 17 02:23:50 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
mid08tor03cn10: Error: Invalid value '2' for 'autoreboot', Valid values: 0,1
CHECK:output =~ mid08tor03cn10:\s*Error: Invalid value \S* for 'autoreboot', Valid values: 0,1  [Pass]
CHECK:rc != 0   [Pass]

RUN:autoreboot=`cat /tmp/autoreboot |awk -F ":" '{print $3}'`;newautoreboot=`echo $autoreboot |tr 'A-Z' 'a-z'`;rspconfig mid08tor03cn10 autoreboot=$newautoreboot [Tue Apr 17 02:23:51 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
mid08tor03cn10: BMC Setting BMC AutoReboot...
CHECK:rc == 0   [Pass]

RUN:rm -rf /tmp/autoreboot [Tue Apr 17 02:23:53 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
OUTPUT:

------END::rspconfig_autoreboot::Passed::Time:Tue Apr 17 02:23:53 2018 ::Duration::11 sec------
------START::rspconfig_invalid::Time:Tue Apr 17 02:23:53 2018------

RUN:rspconfig mid08tor03cn10 aaa [Tue Apr 17 02:23:53 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
mid08tor03cn10: Error: Unsupported command: rspconfig aaa
CHECK:output =~ Error: Unsupported command: rspconfig aaa       [Pass]
CHECK:rc != 0   [Pass]

------END::rspconfig_invalid::Passed::Time:Tue Apr 17 02:23:53 2018 ::Duration::0 sec------
------Total: 14 , Failed: 1------

xCAT automated test finished at Tue Apr 17 02:23:53 2018
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20180417015450 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20180417015450 file for time consumption

```


