### PR TITLE
show server name by default for Error and Warn message

### DIFF
--- a/perl-xCAT/xCAT/Client.pm
+++ b/perl-xCAT/xCAT/Client.pm
@@ -1130,13 +1130,17 @@ sub handle_response {
     }
 
     my $msgsource = "";
+    $msgsource = $rsp->{xcatdsource}->[0] if ($rsp->{xcatdsource});
+
+    # To determine if the INFO msg need to be added with source server name. For ERROR/WARN, it always is shown.
+    my $showsource = 0;
+    if ($rsp->{host}) {
+        $showsource = 1;
+    }
     if ($ENV{'XCATSHOWSVR'}) {
         unless ($rsp->{NoSvrPrefix}) { # some plugins could disable the prefix forcely by seting the flag in response.
-            $msgsource = $rsp->{xcatdsource}->[0] if ($rsp->{xcatdsource});
+            $showsource = 1;
         }
-    }
-    if ($rsp->{host}) {
-        $msgsource = $rsp->{xcatdsource}->[0] if ($rsp->{xcatdsource});
     }
 
     #print "in handle_response\n";
@@ -1158,14 +1162,14 @@ sub handle_response {
         if (ref($rsp->{error}) eq 'ARRAY') {
             foreach my $text (@{ $rsp->{error} }) {
                 my $desc = "$text";
-                $desc = "[$msgsource]: $desc" if ($msgsource && $desc);
+                $desc = "[$msgsource]: $desc" if ($desc && $msgsource);
                 $desc = "Error: $desc" unless ($rsp->{NoErrorPrefix});
                 print STDERR "$desc\n";
             }
         }
         else {
             my $desc = $rsp->{error};
-            $desc = "[$msgsource]: $desc" if ($msgsource && $desc);
+            $desc = "[$msgsource]: $desc" if ($desc && $msgsource);
             $desc = "Error: $desc" unless ($rsp->{NoErrorPrefix});
             print STDERR "$desc\n";
         }
@@ -1176,14 +1180,14 @@ sub handle_response {
         if (ref($rsp->{warning}) eq 'ARRAY') {
             foreach my $text (@{ $rsp->{warning} }) {
                 my $desc = "$text";
-                $desc = "[$msgsource]: $desc" if ($msgsource && $desc);
+                $desc = "[$msgsource]: $desc" if ($desc && $msgsource);
                 $desc = "Warning: $desc" unless ($rsp->{NoWarnPrefix});
                 print STDERR "$desc\n";
             }
         }
         else {
             my $desc = $rsp->{warning};
-            $desc = "[$msgsource]: $desc" if ($msgsource && $desc);
+            $desc = "[$msgsource]: $desc" if ($desc && $msgsource);
             $desc = "Warning: $desc" unless ($rsp->{NoWarnPrefix});
             print STDERR "$desc\n";
         }
@@ -1193,13 +1197,13 @@ sub handle_response {
         if (ref($rsp->{info}) eq 'ARRAY') {
             foreach my $text (@{ $rsp->{info} }) {
                 my $desc = "$text";
-                $desc = "[$msgsource]: $desc" if ($msgsource && $desc);
+                $desc = "[$msgsource]: $desc" if ($showsource && $desc && $msgsource);
                 print "$desc\n";
             }
         }
         else {
             my $desc = $rsp->{info};
-            $desc = "[$msgsource]: $desc" if ($msgsource && $desc);
+            $desc = "[$msgsource]: $desc" if ($showsource && $desc && $msgsource);
             print "$desc\n";
         }
     }
@@ -1234,11 +1238,7 @@ sub handle_response {
             } else {
                 $desc = $node->{name};
             }
-            if ($desc) {
-                $desc = "$desc: [$msgsource]" if ($msgsource);
-            } else {
-                $desc = "[$msgsource]" if ($msgsource);
-            }
+
             if ($node->{errorcode}) {
                 if (ref($node->{errorcode}) eq 'ARRAY') {
                     foreach my $ecode (@{ $node->{errorcode} }) {
@@ -1250,14 +1250,29 @@ sub handle_response {
                 }    # assume it is a non-reference scalar
             }
             if ($node->{error}) {
+                if ($desc) {
+                    $desc = "$desc: [$msgsource]" if ($msgsource);
+                } else {
+                    $desc = "[$msgsource]" if ($msgsource);
+                }
                 $desc .= ": Error: " . $node->{error}->[0];
                 $errflg = 1;
             }
             if ($node->{warning}) {
+                if ($desc) {
+                    $desc = "$desc: [$msgsource]" if ($msgsource);
+                } else {
+                    $desc = "[$msgsource]" if ($msgsource);
+                }
                 $desc .= ": Warning: " . $node->{warning}->[0];
                 $errflg = 1;
             }
             if ($node->{data}) {
+                if ($desc) {
+                    $desc = "$desc: [$msgsource]" if ($showsource && $msgsource);
+                } else {
+                    $desc = "[$msgsource]" if ($showsource && $msgsource);
+                }
                 if (ref(\($node->{data})) eq 'SCALAR') {
                     $desc = $desc . ": " . $node->{data};
                 } elsif (ref($node->{data}) eq 'HASH') {
@@ -1322,7 +1337,7 @@ sub handle_response {
                 }
             }
             if ($desc) {
-                $desc = "[$msgsource]: $desc" if ($msgsource);
+                $desc = "[$msgsource]: $desc" if ($showsource && $msgsource);
                 print "$desc\n"; 
             }
         }

--- a/xCAT-test/autotest/testcase/rmdef/cases0
+++ b/xCAT-test/autotest/testcase/rmdef/cases0
@@ -135,6 +135,6 @@ description:try to delete a template, then error messages appear
 cmd:result=`lsdef | grep  switch-template`; if [[ $result =~ "switch-template" ]]; then echo $result; noderm switch-template; fi
 cmd:rmdef switch-template
 check:rc==1
-check:output=~Error\: Could not find an object named \'switch-template\' of type \'node\'
+check:output=~Error\: (\[.*?\]: )?Could not find an object named \'switch-template\' of type \'node\'
 check:output=~No objects have been removed from the xCAT database.
 end


### PR DESCRIPTION
For #4717 
Now xcat cli could show where the message is coming from (say mn01, or sn02, etc) when enable `-V`,  but in many case, user may forget to use it, especially for error/warn message, it will confuse user.

This PR is to show server name by default for Error and Warn message.
Before fix:
```
nodeset fake1 boot
fake1: boot
Error: dhcp server is not running.  please start the dhcp server.
fake1: boot
Error: dhcp server is not running.  please start the dhcp server.
```
After fix:
```
nodeset fake1 boot
fake1: boot
Error: [c910f03c05k20]: dhcp server is not running.  please start the dhcp server.
fake1: boot
Error: [c910f03c05k24]: dhcp server is not running.  please start the dhcp server.
```

For warnig message,  as below:
```
nodeset fake1 boot
fake1: boot
Warning: [c910f03c05k20]: Unable to find mac address for fake1
fake1: boot
Error: [c910f03c05k24]: dhcp server is not running.  please start the dhcp server.
```