### PR TITLE
Support copycds command to create cumulus osimage

### DIFF
--- a/xCAT-server/lib/xcat/plugins/copycds.pm
+++ b/xCAT-server/lib/xcat/plugins/copycds.pm
@@ -97,7 +97,7 @@ sub process_request {
         else { $file = $_; }
 
         # handle the copycds for tar file
-        # if the source file is tar format, call the 'copytar' command to handle it.
+        # if the source file is tar format, call the 'opytar' command to handle it.
         # currently it's used for Xeon Phi (mic) support
         if (-r $file) {
             my @filestat = `file $file`;
@@ -109,6 +109,15 @@ sub process_request {
                 $newreq->{arg} = [ "-f", $file, "-n", $distname ];
                 $doreq->($newreq, $callback);
 
+                return;
+            }
+            if (grep /armel/, @filestat) {
+                $distname="cumulus";
+                $callback->({ info => "run copycds for cumulus OS file = $file, distname=$distname" });
+                my $newreq = dclone($request);
+                $newreq->{command} = ['copycd']; #Note the singular, it's different
+                $newreq->{arg} = [ "-f", $file, "-n", $distname ];
+                $doreq->($newreq, $callback);
                 return;
             }
         }

--- a/xCAT-server/lib/xcat/plugins/copycds.pm
+++ b/xCAT-server/lib/xcat/plugins/copycds.pm
@@ -121,10 +121,20 @@ sub process_request {
                 }
                 my $newreq = dclone($request);
                 $newreq->{command} = ['copydata']; #Note the singular, it's different
-                unless ($nonoverwrite) {
-                    $nonoverwrite=0;
+                $newreq->{arg} = [ "-f", $file ];
+                if ($inspection)
+                {
+                    push @{ $newreq->{arg} }, ("-i");
                 }
-                $newreq->{arg} = [ "-f", $file, "-w", $nonoverwrite ];
+                if ($nonoverwrite)
+                {
+                    push @{ $newreq->{arg} }, ("-w");
+                }
+                if ($noosimage)
+                {
+                    push @{ $newreq->{arg} }, ("-o");
+                }
+
                 $doreq->($newreq, $callback);
                 return;
             }

--- a/xCAT-server/lib/xcat/plugins/copycds.pm
+++ b/xCAT-server/lib/xcat/plugins/copycds.pm
@@ -14,6 +14,7 @@ use Cwd;
 Getopt::Long::Configure("bundling");
 Getopt::Long::Configure("pass_through");
 
+my $xcatdebugmode = 0;
 my $processed = 0;
 my $callback;
 
@@ -75,6 +76,9 @@ sub process_request {
         $callback->({ error => "copycds needs at least one full path to ISO currently.", errorcode => [1] });
         return;
     }
+
+    if ($::XCATSITEVALS{xcatdebugmode}) { $xcatdebugmode = $::XCATSITEVALS{xcatdebugmode} }
+
     my $file;
     foreach (@args) {
         $identified = 0;
@@ -97,7 +101,7 @@ sub process_request {
         else { $file = $_; }
 
         # handle the copycds for tar file
-        # if the source file is tar format, call the 'copytar' command to handle it.
+        # if the source file is tar format, call the 'opytar' command to handle it.
         # currently it's used for Xeon Phi (mic) support
         if (-r $file) {
             my @filestat = `file $file`;
@@ -113,7 +117,9 @@ sub process_request {
             }
             if (grep /$file: data/, @filestat) {
                 $distname="cumulus";
-                $callback->({ info => "run copycds for cumulus OS file = $file, distname=$distname" });
+                if ($xcatdebugmode) {
+                    $callback->({ info => "run copycds for cumulus OS file = $file, distname=$distname" });
+                }
                 my $newreq = dclone($request);
                 $newreq->{command} = ['copycd']; #Note the singular, it's different
                 $newreq->{arg} = [ "-f", $file, "-n", $distname ];

--- a/xCAT-server/lib/xcat/plugins/copycds.pm
+++ b/xCAT-server/lib/xcat/plugins/copycds.pm
@@ -97,7 +97,7 @@ sub process_request {
         else { $file = $_; }
 
         # handle the copycds for tar file
-        # if the source file is tar format, call the 'opytar' command to handle it.
+        # if the source file is tar format, call the 'copytar' command to handle it.
         # currently it's used for Xeon Phi (mic) support
         if (-r $file) {
             my @filestat = `file $file`;

--- a/xCAT-server/lib/xcat/plugins/copycds.pm
+++ b/xCAT-server/lib/xcat/plugins/copycds.pm
@@ -111,7 +111,7 @@ sub process_request {
 
                 return;
             }
-            if (grep /armel/, @filestat) {
+            if (grep /$file: data/, @filestat) {
                 $distname="cumulus";
                 $callback->({ info => "run copycds for cumulus OS file = $file, distname=$distname" });
                 my $newreq = dclone($request);

--- a/xCAT-server/lib/xcat/plugins/copycds.pm
+++ b/xCAT-server/lib/xcat/plugins/copycds.pm
@@ -101,7 +101,7 @@ sub process_request {
         else { $file = $_; }
 
         # handle the copycds for tar file
-        # if the source file is tar format, call the 'opytar' command to handle it.
+        # if the source file is tar format, call the 'copytar' command to handle it.
         # currently it's used for Xeon Phi (mic) support
         if (-r $file) {
             my @filestat = `file $file`;
@@ -116,13 +116,15 @@ sub process_request {
                 return;
             }
             if (grep /$file: data/, @filestat) {
-                $distname="cumulus";
                 if ($xcatdebugmode) {
-                    $callback->({ info => "run copycds for cumulus OS file = $file, distname=$distname" });
+                    $callback->({ info => "run copydata for data file = $file" });
                 }
                 my $newreq = dclone($request);
-                $newreq->{command} = ['copycd']; #Note the singular, it's different
-                $newreq->{arg} = [ "-f", $file, "-n", $distname ];
+                $newreq->{command} = ['copydata']; #Note the singular, it's different
+                unless ($nonoverwrite) {
+                    $nonoverwrite=0;
+                }
+                $newreq->{arg} = [ "-f", $file, "-w", $nonoverwrite ];
                 $doreq->($newreq, $callback);
                 return;
             }

--- a/xCAT-server/lib/xcat/plugins/onie.pm
+++ b/xCAT-server/lib/xcat/plugins/onie.pm
@@ -126,7 +126,6 @@ sub copycd {
     }
 
     if ($osname !~ /^cumulus/) {
-        xCAT::MsgUtils->message("E", { error => ["$osname is not support"], errorcode => ["1"] }, $callback);
         return;
     }
 

--- a/xCAT-server/lib/xcat/plugins/onie.pm
+++ b/xCAT-server/lib/xcat/plugins/onie.pm
@@ -199,11 +199,6 @@ sub copydata {
     my $pkgdir = "$defaultpath/$filename";
     my $imgdir = $litab->getAttribs({ 'imagename' => $imagename }, 'pkgdir');
 
-    if ( ($pkgdir eq $imgdir->{'pkgdir'}) && ($nooverwrite) ) {
-        $callback->({ data => "$imagename is available, will not overwrite" });
-        return;
-    }
-
     if ($::VERBOSE) {
         $callback->({ data => "creating image $imagename with osarch=$arch, osvers=$distname" });
     }

--- a/xCAT-server/lib/xcat/plugins/onie.pm
+++ b/xCAT-server/lib/xcat/plugins/onie.pm
@@ -1,0 +1,210 @@
+#!/usr/bin/env perl
+## IBM(c) 20013 EPL license http://www.eclipse.org/legal/epl-v10.html
+#
+# This plugin is used to handle the command requests for cumulus OS support
+#
+
+
+package xCAT_plugin::onie;
+
+BEGIN
+{
+    $::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : '/opt/xcat';
+}
+use lib "$::XCATROOT/lib/perl";
+
+use strict;
+use Getopt::Long;
+use File::Path;
+use File::Basename;
+
+use xCAT::Utils;
+use xCAT::MsgUtils;
+use xCAT::TableUtils;
+use xCAT::Table;
+
+sub handled_commands {
+    return {
+        nodeset => "nodehm:mgt",    
+        copycd => 'onie',
+      }
+}
+
+my $CALLBACK;                       # used to hanel the output from xdsh
+
+sub preprocess_request {
+    my $request  = shift;
+    my $callback = shift;
+
+    if ($request->{command}->[0] eq 'copycd')
+    {
+        return [$request];
+    }
+
+    # if already preprocessed, go straight to request
+    if ((defined($request->{_xcatpreprocessed}->[0]))
+        && ($request->{_xcatpreprocessed}->[0] == 1)) {
+        return [$request];
+    }
+
+    my $nodes     = $request->{node};
+    my $command   = $request->{command}->[0];
+    my $extraargs = $request->{arg};
+
+    if ($extraargs) {
+        @ARGV = @{$extraargs};
+        my ($verbose, $help, $ver);
+        GetOptions("V" => \$verbose, 'h|help' => \$help, 'v|version' => \$ver);
+        if ($help) {
+            my $usage_string = xCAT::Usage->getUsage($command);
+            my $rsp;
+            push @{ $rsp->{data} }, $usage_string;
+            xCAT::MsgUtils->message("I", $rsp, $callback);
+            return ();
+        }
+        if ($ver) {
+            my $ver_string = xCAT::Usage->getVersion($command);
+            my $rsp;
+            push @{ $rsp->{data} }, $ver_string;
+            xCAT::MsgUtils->message("I", $rsp, $callback);
+            return ();
+        }
+    }
+
+    return [$request];
+}
+
+sub process_request {
+    my $request  = shift;
+    my $callback = shift;
+    my $subreq   = shift;
+
+    my $nodes   = $request->{node};
+    my $command = $request->{command}->[0];
+    my $args    = $request->{arg};
+
+    my %hosts;
+
+    if ($command eq "copycd") {
+        copycd($request, $callback);
+    } elsif ($command eq "nodeset") {
+        nodeset($request, $callback, $subreq, \%hosts);
+    }
+
+}
+
+# build cumulus OS image 
+sub copycd {
+    my $request  = shift;
+    my $callback = shift;
+    
+    #get install dir
+    my $installroot = "/install";
+    my $sitetab     = xCAT::Table->new('site');
+    my @ents     = xCAT::TableUtils->get_site_attribute("installdir");
+    my $site_ent = $ents[0];
+    if (defined($site_ent))
+    {
+        $installroot = $site_ent;
+    }
+
+    my $args = $request->{arg};
+    my ($osname, $file);
+    if ($args) {
+        @ARGV = @{$args};
+        GetOptions('n=s' => \$osname,
+            'f=s' => \$file);
+    }
+
+    if ($osname !~ /^cumulus/) {
+        return;
+    }
+
+    my $filename = basename($file);
+
+    #xCAT::MsgUtils->message("I", { data => ["running copycd for onie image: $file"] }, $callback);
+    my $release = `$file | grep 'Release' | cut -d' ' -f2`;
+    chomp $release;
+    #xCAT::MsgUtils->message("I", { data => ["running copycd for onie image: $release"] }, $callback);
+    my $arch = `$file | grep '^Architecture' | cut -d' ' -f2 `;
+    chomp $arch;
+    #xCAT::MsgUtils->message("I", { data => ["running copycd for onie image: $arch"] }, $callback);
+    my $imagename = $osname . "-" . $release . "-" . $arch;
+    #xCAT::MsgUtils->message("I", { data => ["running copycd for onie image: $imagename"] }, $callback);
+    my $distname = $osname . $release;
+    my $defaultpath = "$installroot/$distname/$imagename";
+    #xCAT::MsgUtils->message("I", { data => ["running copycd for onie image: $distname, $defaultpath"] }, $callback);
+
+    $callback->({ data => "Copying media to $defaultpath" });
+    mkpath ("$defaultpath");
+    system("cp $file $defaultpath");
+
+    # generate the image objects
+    my $oitab = xCAT::Table->new('osimage');
+    unless ($oitab) {
+        xCAT::MsgUtils->message("E", { error => ["Error: Cannot open table osimage."], errorcode => ["1"] }, $callback);
+        return 1;
+    }
+
+    my %values;
+    $values{'imagetype'}   = "linux";
+    $values{'provmethod'} = "onie";
+    $values{'description'} = "Cumulus Linux";
+    $values{'osname'}      = "$osname";
+    $values{'osvers'}      = "$distname";
+    $values{'osarch'}      = "$arch";
+
+    $oitab->setAttribs({ 'imagename' => $imagename }, \%values);
+
+    my $litab = xCAT::Table->new('linuximage');
+    unless ($litab) {
+        xCAT::MsgUtils->message("E", { error => ["Error: Cannot open table linuximage."], errorcode => ["1"] }, $callback);
+        return 1;
+    }
+
+    my $pkgdir = "$defaultpath/$filename";
+    $litab->setAttribs({ 'imagename' => $imagename }, { 'pkgdir' => $pkgdir });
+
+    xCAT::MsgUtils->message("I", { data => ["The image $imagename is created."] }, $callback);
+
+}
+
+
+# run the nodeset to updatenode provmethod 
+sub nodeset {
+    my $request  = shift;
+    my $callback = shift;
+    my $subreq   = shift;
+
+    xCAT::MsgUtils->message("E", { error => ["DIDN't support nodeset yet"], errorcode => ["1"] }, $callback);
+    return;
+
+    my $usage_string = "nodeset noderange osimage[=imagename]";
+
+    my $nodes = $request->{'node'};
+    my $args  = $request->{arg};
+    my $setosimg;
+    foreach (@$args) {
+        if (/osimage=(.*)/) {
+            $setosimg = $1;
+        }
+    }
+
+    # get the provision method for all the nodes
+    my $nttab = xCAT::Table->new("nodetype");
+    unless ($nttab) {
+        xCAT::MsgUtils->message("E", { error => ["Cannot open the nodetype table."], errorcode => ["1"] }, $callback);
+        return;
+    }
+
+    # if the osimage=xxx has been specified, then set it to the provmethod attr .
+    if ($setosimg) {
+        my %setpmethod;
+        foreach (@$nodes) {
+            $setpmethod{$_}{'provmethod'} = $setosimg;
+        }
+        $nttab->setNodesAttribs(\%setpmethod);
+    }
+
+}
+1;


### PR DESCRIPTION
for issue #5117 .

created new plug in for cumulus OS, will handler copycd and nodeset for now.

````
# copycds ./cumulus-linux-3.5.2-bcm-armel.bin
run copycds for cumulus OS file = /install/custom/sw_os/cumulus/./cumulus-linux-3.5.2-bcm-armel.bin, distname=cumulus
Copying media to /install/cumulus3.5.2/cumulus-3.5.2-armel
The image cumulus-3.5.2-armel is created.

# lsdef -t osimage cumulus-3.5.2-armel
Object name: cumulus-3.5.2-armel
    description=Cumulus Linux
    imagetype=linux
    osarch=armel
    osname=cumulus
    osvers=cumulus3.5.2
    pkgdir=/install/cumulus3.5.2/cumulus-3.5.2-armel/cumulus-linux-3.5.2-bcm-armel.bin
    provmethod=onie
````