### PR TITLE
modify bmcdiscover manpage for IP range

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/bmcdiscover.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/bmcdiscover.1.rst
@@ -48,7 +48,7 @@ OPTIONS
 
 \ **-**\ **-range**\ 
  
- Specify one or more IP ranges acceptable to nmap.  IP range can be hostnames, IP addresses, networks, etc.  A single IP address (10.1.2.3) or an IP range (10.1.2.0/24) can be specified.  If the range is very large, the \ **bmcdiscover**\  command may take a long time to return.
+ Specify one or more IP ranges acceptable to nmap.  IP range can be hostnames, IP addresses, networks, etc.  A single IP address (10.1.2.3), several IPs with commas (10.1.2.3,10.1.2.10), Ip range with "-" (10.1.2.0-100) or an IP range (10.1.2.0/24) can be specified.  If the range is very large, the \ **bmcdiscover**\  command may take a long time to return.
  
 
 

--- a/xCAT-client/pods/man1/bmcdiscover.1.pod
+++ b/xCAT-client/pods/man1/bmcdiscover.1.pod
@@ -27,7 +27,7 @@ Note: The scan method currently support is B<nmap>.
 
 =item B<--range>       
 
-Specify one or more IP ranges acceptable to nmap.  IP range can be hostnames, IP addresses, networks, etc.  A single IP address (10.1.2.3) or an IP range (10.1.2.0/24) can be specified.  If the range is very large, the B<bmcdiscover> command may take a long time to return. 
+Specify one or more IP ranges acceptable to nmap.  IP range can be hostnames, IP addresses, networks, etc.  A single IP address (10.1.2.3), several IPs with commas (10.1.2.3,10.1.2.10), Ip range with "-" (10.1.2.0-100) or an IP range (10.1.2.0/24) can be specified.  If the range is very large, the B<bmcdiscover> command may take a long time to return. 
 
 =item B<--sn>
 


### PR DESCRIPTION
#3887
The types allowed:
10.2.3.1
10.2.3.1,10.2.3.5 (2 IPs)
10.2.3.1-5(5 IPs)
10.1.2.0/24

After modified:
http://10.3.5.4/install/build/html/guides/admin-guides/references/man1/bmcdiscover.1.html?highlight=bmcdiscover