### PR TITLE
Fix issue 5111: REST API does not respect the "host" setting in "policy" table

### DIFF
--- a/xCAT-server/xCAT-wsapi/xcatws.cgi
+++ b/xCAT-server/xCAT-wsapi/xcatws.cgi
@@ -1373,6 +1373,10 @@ my @path        = split(/\//, $pathInfo);   # The uri path like /nodes/node1/...
 my $pageContent = ''; # Global var containing the ouptut back to the rest client
 my %header_info;      #Global var containing the extra info to the http header
 my $request = { clienttype => 'ws' }; # Global var that holds the request to send to xcatd
+my $remote_host = $q->remote_host();
+my ($client_name, $client_aliases) = gethostbyaddr(inet_aton($remote_host), AF_INET);
+$request->{remote_client}->[0]= $client_name.','.$client_aliases;
+
 my $format = 'json';                  # The output format for a request invoke
 my $xmlinstalled; # Global var to speicfy whether the xml modules have been loaded
 


### PR DESCRIPTION
Fix issue #5111 

In the original logic, the ip/hostname of client won't be passed to xCATd side after xcatws.cgi get a RESTful request. 
With the policy setting:
```
[root@briggs01 ~]# tabdump policy |grep wsuser
"6","wsuser","c910loginx03",,,,,"allow",,
```
Before fix:
```
$ curl -X GET -k 'https://briggs01/xcatws/nodes/p9up/nodestat?userName=wsuser&userPW=cluster_junk2&pretty=1'
{
   "errorcode":"2",
   "error":"Authentication failure: Permission denied for request"
}
```
After fix:
```
$ curl -X GET -k 'https://briggs01/xcatws/nodes/p9up/nodestat?userName=wsuser&userPW=cluster_junk2&pretty=1'
{
   "mid05tor12cn13":{
      "nodestat":"sshd"
   },
   "mid05tor12cn16":{
      "nodestat":"sshd"
   },
   "mid05tor12cn15":{
      "nodestat":"sshd"
   }
}
```