### PR TITLE
Slight tweak the hack_uname() hack

### DIFF
--- a/xCAT-server/share/xcat/ib/scripts/Mellanox/mlnxofed_ib_install.v2
+++ b/xCAT-server/share/xcat/ib/scripts/Mellanox/mlnxofed_ib_install.v2
@@ -160,7 +160,7 @@ function hack_uname()
                         if [ -n "\$KERNELVERSION" ]; then
                             echo \$KERNELVERSION
                         else
-                            for d in \$(ls /lib/modules | sort -V) ; do : ; done && echo \$d
+                            for d in \$(cd /lib/modules && echo [0-9]* 2>/dev/null | sort -V) ; do : ; done && echo \$d
                         fi
 			;;
 		"-s"|"")


### PR DESCRIPTION
This patch update the `hack_uname()` function to only check directories whose name begin with a number.