### PR TITLE
update node status when enter shell/standby

### DIFF
--- a/xCAT-genesis-scripts/usr/bin/doxcat
+++ b/xCAT-genesis-scripts/usr/bin/doxcat
@@ -319,6 +319,11 @@ if [ "$destiny" != "discover" ]; then #we aren't discoverying, we probably can a
 	logger -s -t $log_label -p local4.info "Getting initial certificate --> $XCATMASTER:$XCATPORT"
 	/bin/getcert $XCATMASTER:$XCATPORT
 fi
+if [ "$destiny" ]; then
+	# run getdestiny to update node status
+	/bin/getdestiny $XCATMASTER:$XCATPORT >/dev/null 2>&1
+fi
+
 while :; do
 
         grepconfigraid=`echo $destiny|grep "configraid"`
@@ -389,7 +394,7 @@ while :; do
 		tar xvf `basename $destparameter`
 		./runme.sh
 		cd -
-                logger -s -t $log_label -p local4.info "Running nextdestiny $XCATMASTER:$XCATPORT..."
+		logger -s -t $log_label -p local4.info "Running nextdestiny $XCATMASTER:$XCATPORT..."
 		destiny=`/bin/nextdestiny $XCATMASTER:$XCATPORT`
 		dest=`echo $destiny|awk -F= '{print $1}'`
 		logger -s -t $log_label -p local4.info "nextdestiny - Complete."

--- a/xCAT-server/lib/xcat/plugins/destiny.pm
+++ b/xCAT-server/lib/xcat/plugins/destiny.pm
@@ -915,6 +915,16 @@ sub getdestiny {
     my %node_status = ();
     foreach $node (@$nodes) {
         unless ($chaintab) { #Without destiny, have the node wait with ssh hopefully open at least
+            my $stat = xCAT_monitoring::monitorctrl->getNodeStatusFromNodesetState("standby", "getdestiny");
+            if ($stat) {
+                if (exists($node_status{$stat})) {
+                    push @{ $node_status{$stat} }, $node;
+                } else { 
+                    $node_status{$stat} = [$node];
+                }
+                xCAT_monitoring::monitorctrl::setNodeStatusAttributes(\%node_status, 1);
+            }
+            
             $callback->({ node => [ { name => [$node], data => ['standby'], destiny => ['standby'] } ] });
             return;
         }
@@ -928,10 +938,10 @@ sub getdestiny {
                 #print "node=$node, stat=$stat\n";
                 if ($stat) {
                     if (exists($node_status{$stat})) {
-                        my $pa = $node_status{$stat};
-                        push(@$pa, $node);
+                        push @{ $node_status{$stat} }, $node;
+                    } else {
+                        $node_status{$stat} = [$node];
                     }
-                    else { $node_status{$stat} = [$node]; }
                 }
             }
 
@@ -979,10 +989,10 @@ sub getdestiny {
             #print  "node=$node, stat=$stat\n";
             if ($stat) {
                 if (exists($node_status{$stat})) {
-                    my $pa = $node_status{$stat};
-                    push(@$pa, $node);
+                    push @{ $node_status{$stat} }, $node;
+                } else {
+                    $node_status{$stat} = [$node];
                 }
-                else { $node_status{$stat} = [$node]; }
             }
         }
 


### PR DESCRIPTION
#4248 #3902 

When CN enter "shell/standby", run "getdestiny" to update node's status in getdestiny function destiny.pm.

UT steps:

1. ``nodeset shell,standby``
2. ``lsdef`` get that  status is "shell"
3. ``rpower boot``, check status is "powering-on"
4. When CN enter genesis, check status is "shell"
5. exit shell, check status is "standingby"

The reason that modify like this:

After run "nodeset", will create petitboot file for node including "destiny=*".
When node boot, will load petitboot file, get destiny and then enter corresponding status.

To update status after step 3, need to send status back to MN to update status. If add new command to update, we need to modify several parts code and modify policy table. But if we run "getdestiny" again, we do not need modify other code, and have tested have no other influence.