### PR TITLE
Simplify cuda_power9_setup

### DIFF
--- a/xCAT/postscripts/cuda_power9_setup
+++ b/xCAT/postscripts/cuda_power9_setup
@@ -5,6 +5,7 @@
 #     <http://www.eclipse.org/legal/epl-v10.html>
 #
 # 2018-03-21 GONG Jie <gongjie@linux.vnet.ibm.com>
+# 2018-04-24 Matt Ezell <ezellma@ornl.gov>
 #
 # This script is used for doing extra setup steps for NVIDIA POWER9 CUDA driver
 # on RHEL 7. Please refer document below for details.
@@ -14,66 +15,13 @@
 
 umask 0022
 
-grep '^#' /usr/lib/systemd/system/nvidia-persistenced.service >/tmp/nvidia-persistenced.service
-cat >>/tmp/nvidia-persistenced.service <<-EOF
+mkdir ${IMG_ROOTIMGDIR}/etc/systemd/system/nvidia-persistenced.service.d
+printf '[Service]\nPIDFile=/var/run/nvidia-persistenced/nvidia-persistenced.pid\n' > ${IMG_ROOTIMGDIR}/etc/systemd/system/nvidia-persistenced.service.d/pidfile.conf
+printf '[Service]\nRestart=always\n' > ${IMG_ROOTIMGDIR}/etc/systemd/system/nvidia-persistenced.service.d/restartalways.conf
 
-[Unit]
-Description=NVIDIA Persistence Daemon
-Wants=syslog.target
+[ ! -z "${IMG_ROOTIMGDIR}" ] && CHROOTCMD="chroot ${IMG_ROOTIMGDIR}"
+$CHROOTCMD /bin/bash -c "systemctl enable nvidia-persistenced"
 
-[Service]
-Type=forking
-PIDFile=/var/run/nvidia-persistenced/nvidia-persistenced.pid
-Restart=always
-ExecStart=/usr/bin/nvidia-persistenced --user root --verbose
-ExecStopPost=/bin/rm -rf /var/run/nvidia-persistenced
+rm -f ${IMG_ROOTIMGDIR}/lib/udev/rules.d/40-redhat.rules
 
-[Install]
-WantedBy=multi-user.target
-EOF
-
-mv /tmp/nvidia-persistenced.service /usr/lib/systemd/system/nvidia-persistenced.service
-
-chown root.root /usr/lib/systemd/system/nvidia-persistenced.service
-chmod 0644 /usr/lib/systemd/system/nvidia-persistenced.service
-
-systemctl enable nvidia-persistenced
-
-rm -f /lib/udev/rules.d/40-redhat.rules
-
-#
-# Extra steps for passing parameters to kernel module nvidia
-#
-mkdir -p /usr/lib/dracut/modules.d/95nvidia
-cat >/usr/lib/dracut/modules.d/95nvidia/module-setup.sh <<EOF
-#!/bin/bash
-# module setup file for dracut
-# nvidia patch described in:
-
-check() {
-    return 0
-}
-
-depends() {
-    return 0
-}
-
-installkernel() {
-    return 0
-}
-
-install() {
-    [ -d \$initdir/etc/modprobe.d/ ] || mkdir \$initdir/etc/modprobe.d
-    echo 'options nvidia NVreg_EnableStreamMemOPs=1 NVreg_RegistryDwords="PeerMappingOverride=1"' >\$initdir/etc/modprobe.d/nvidia.conf
-}
-EOF
-
-chmod 0755 /usr/lib/dracut/modules.d/95nvidia/module-setup.sh
-echo 'add_dracutmodules+=" nvidia "' >/etc/dracut.conf.d/nvidia_patch.conf
-
-# Patch for the diskfull environment, or in case kernel module nvidia need to be reloaded
-echo 'options nvidia NVreg_EnableStreamMemOPs=1 NVreg_RegistryDwords="PeerMappingOverride=1"' >/etc/modprobe.d/nvidia.conf
-
-# Redo the initrd image
-kernel_version="$(for d in $(ls /lib/modules | sort -V) ; do : ; done && echo $d)"
-mkinitrd -v -f "/boot/initramfs-${kernel_version}.img" "${kernel_version}"
+echo 'options nvidia NVreg_EnableStreamMemOPs=1 NVreg_RegistryDwords="PeerMappingOverride=1"' >${IMG_ROOTIMGDIR}/usr/lib/modprobe.d/nvidia.conf


### PR DESCRIPTION
- Detect if running as a posinstall or postscript, remove requirement for explict chroot
- It is generally frowned upon to modify files packaged by RPMs. For the unit file, instead extend it
- No need to create a dracut module, it will pull in any files in `/usr/lib/modprobe.d`