### PR TITLE
REST API for OpenBMC nodes

### DIFF
--- a/xCAT-server/xCAT-wsapi/xcatws.cgi
+++ b/xCAT-server/xCAT-wsapi/xcatws.cgi
@@ -1943,6 +1943,20 @@ sub actionout {
 
     my $jsonnode;
     foreach my $d (@$data) {
+        if (defined($d->{info})) {
+            # OpenBMC format
+            if ($param->{'resourcename'} eq "eventlog") {
+                my ($node, $logentry) = split(/:/, $d->{info}->[0], 2);
+                $logentry =~ s/^\s+|\s+$//g; # trim whitespace from log entry
+                push @{ $jsonnode->{$node}->{ $param->{'resourcename'} } }, $logentry;
+            } else {
+                my ($node, $resourcename, $value) = split(/:/, $d->{info}->[0]);
+                $resourcename =~ s/^\s+|\s+$//g; # trim whitespace from resourcename
+                $value =~ s/^\s+|\s+$//g; # trim whitespace from value
+                $jsonnode->{ $node }->{ $resourcename } = $value;
+            }
+            next;
+        }
         unless (defined($d->{node}->[0]->{name})) {
             next;
         }

--- a/xCAT-test/autotest/restapi.template
+++ b/xCAT-test/autotest/restapi.template
@@ -1,0 +1,7 @@
+# The test for the REST API needs to specify
+# the specific node and userid/password for REST API access
+
+[System]
+username=
+password=
+CN=

--- a/xCAT-test/autotest/testcase/restapi/node/cases0
+++ b/xCAT-test/autotest/testcase/restapi/node/cases0
@@ -1,104 +1,111 @@
 start:create_node_rest
 description: create a node with REST API
-cmd:restapitest -m POST -r /nodes/restnode -d '{"groups":"all","mgt":"dfm","netboot":"yaboot"}'
+cmd:restapitest -m POST -r /nodes/restnode -d '{"groups":"all","mgt":"dfm","netboot":"yaboot"}' -u $$username -p $$password
 check:rc==201
 end
 
 start:create_node_rest2
 description: create a node with REST API failure
-cmd:restapitest -m POST -r /nodes/restnode -d '{"groups":"all","mgt":"dfm","netboot":"yaboot"}'
+cmd:restapitest -m POST -r /nodes/restnode -d '{"groups":"all","mgt":"dfm","netboot":"yaboot"}' -u $$username -p $$password
 check:rc==147
-check:output=~'errorcode' => '1'
+check:output=~"errorcode":"1"
 end
 
 start:get_nodes_rest
 description: get all nodes with REST API
-cmd:restapitest -m GET -r /nodes
+cmd:restapitest -m GET -r /nodes -u $$username -p $$password
 check:rc==200
-check:output=~'restnode'
+check:output=~"restnode"
 end
 
 start:get_node_rest
 description: get single node with REST API
-cmd:restapitest -m GET -r /nodes/restnode
+cmd:restapitest -m GET -r /nodes/restnode -u $$username -p $$password
 check:rc==200
-check:output=~'restnode'
+check:output=~"restnode"
 end
 
 start:node_delete_rest
 description: delete node with REST API
-cmd:restapitest -m DELETE -r /nodes/restnode
+cmd:restapitest -m DELETE -r /nodes/restnode -u $$username -p $$password
 check:rc==200
 end
 
 start:get_nodes_rest2
 description: get all nodes with REST API
-cmd:restapitest -m GET -r /nodes
+cmd:restapitest -m GET -r /nodes -u $$username -p $$password
 check:rc==200
-check:output!~'restnode'
+check:output!~"restnode"
 end
 
 start:get_node_rest2
 description: get single node with REST API
-cmd:restapitest -m GET -r /nodes/restnode
+cmd:restapitest -m GET -r /nodes/restnode -u $$username -p $$password
 check:rc==147
-check:output=~'errorcode' => '1'
+check:output=~"errorcode":"1"
 end
 
 start:create_node_token_rest
 description: create a node with REST API using authentication token
-cmd:restapitest -m POST -r /nodes/restnode -d '{"groups":"all","mgt":"dfm","netboot":"yaboot"}' -t
+cmd:restapitest -m POST -r /nodes/restnode -d '{"groups":"all","mgt":"dfm","netboot":"yaboot"}' -u $$username -p $$password -t
 check:rc==201
 end
 
 start:node_makehosts_rest
 description: makehosts for node with REST API
-cmd:restapitest -m POST -r /nodes/restnode/host
+cmd:restapitest -m POST -r /nodes/restnode/host -u $$username -p $$password
 check:rc==201
 end
 
 start:node_makedns_rest
 description: makehosts for node with REST API
-cmd:restapitest -m POST -r /nodes/restnode/dns
+cmd:restapitest -m POST -r /nodes/restnode/dns -u $$username -p $$password
 check:rc==201
 end
 
 start:node_delete_dns_rest
 description: delete dns for node with REST API
-cmd:restapitest -m DELETE -r /nodes/restnode/dns
+cmd:restapitest -m DELETE -r /nodes/restnode/dns -u $$username -p $$password
 check:rc==200
 end
 
 start:node_change_attr_rest
 description: change node attribute with REST API
-cmd:restapitest -m PUT -r /nodes/restnode -d '{"mac":"00:1a:64:54:14:80"}'
+cmd:restapitest -m PUT -r /nodes/restnode -d '{"mac":"00:1a:64:54:14:80"}' -u $$username -p $$password
 check:rc==200
 end
 
 start:node_makedhcp_rest
 description: makedhcp for node with REST API
-cmd:restapitest -m POST -r /nodes/node1/dhcp
+cmd:restapitest -m POST -r /nodes/restnode/dhcp -u $$username -p $$password
 check:rc==201
 end
 
-start:node_delete_dhcp
+start:node_delete_dhcp_rest
 description: node_delete_dhcp
-cmd:restapitest -m DELETE -r /nodes/node1/dhcp
+cmd:restapitest -m DELETE -r /nodes/restnode/dhcp -u $$username -p $$password
 check:rc==200
 end
 
 start:node_state_rest
 description: get node state with REST API
-cmd:restapitest -m GET -r /nodes/restnode/nodestat
+cmd:restapitest -m GET -r /nodes/$$CN/nodestat -u $$username -p $$password
 check:rc==200
-check:output=~'restnode'
-check:output=~'nodestat'
+check:output=~"$$CN"
+check:output=~"nodestat"
 end
 
 start:node_state_token_rest
 description: get node state with REST API using authentication token
-cmd:restapitest -m GET -r /nodes/restnode/nodestat -t
+cmd:restapitest -m GET -r /nodes/$$CN/nodestat -u $$username -p $$password -t
 check:rc==200
-check:output=~'restnode'
-check:output=~'nodestat'
+check:output=~"$$CN"
+check:output=~"nodestat"
+end
+
+start:get_node_rest_error
+description: get single node with REST API with invalid user or password
+cmd:restapitest -m GET -r /nodes/restnode -u abc -p xyz
+check:rc==145
+check:output=~"error":"Authentication failure"
 end

--- a/xCAT-test/autotest/testcase/restapi/node/cases1
+++ b/xCAT-test/autotest/testcase/restapi/node/cases1
@@ -1,0 +1,47 @@
+start:inventory_node_rest
+description: get OpenBMC node inventory with REST API
+hcp:openbmc
+cmd:restapitest -m GET -r /nodes/$$CN/inventory -u $$username -p $$password
+check:rc==200
+check:output =~ "CPU0 PrettyName":"PROCESSOR MODULE"
+end
+
+start:inventory_node_rest2
+description: get IPMI node inventory with REST API
+hcp:ipmi
+cmd:restapitest -m GET -r /nodes/$$CN/inventory -u $$username -p $$password
+check:rc==200
+check:output=~Board Serial Number
+end
+
+start:vitals_node_rest
+description: get OpenBMC node vitals with REST API
+hcp:openbmc
+cmd:restapitest -m GET -r /nodes/$$CN/vitals -u $$username -p $$password
+check:rc==200
+check:output =~"LEDs Front Fault"
+end
+
+start:vitals_node_rest2
+description: get IPMI node vitals with REST API
+hcp:ipmi
+cmd:restapitest -m GET -r /nodes/$$CN/vitals -u $$username -p $$password
+check:rc==200
+check:output=~CPU Core Temp
+end
+
+start:eventlog_node_rest
+description: get OpenBMC node inventory with REST API
+hcp:openbmc
+cmd:restapitest -m GET -r /nodes/$$CN/eventlog -u $$username -p $$password
+check:rc==200
+check:output=~"eventlog"
+end
+
+start:eventlog_node_rest2
+description: get IPMI node eventlog with REST API
+hcp:ipmi
+cmd:restapitest -m GET -r /nodes/$$CN/eventlog -u $$username -p $$password
+check:rc==200
+check:output=~eventlog
+end

--- a/xCAT-test/restapitest
+++ b/xCAT-test/restapitest
@@ -97,51 +97,25 @@ if ($resource) {
     }
 }
 
-
-##############################################################
-# ONLY check result,exit immediately
-##############################################################
-if ($output and !defined($method)) {
-    my $res = check_result($output, $loperator, $outputfile);
-    log_debug(2, "check result runs with $output and $loperator, result is $res\n");
-    exit $res;
-}
-
 ##############################################################
 # Give default values for optional vars.
 ###############################################################
 my $rootdir   = "$::XCATROOT/share/xcat/tools/autotest";
 my $resultdir = "$rootdir/result";
 my $logfile   = "$rootdir/result/restapitest.log";
+#logfile: /opt/xcat/share/xcat/tools/autotest/result/restapitest.log
 
-#/opt/xcat/share/xcat/tools/autotest/result/restapitest.log
-my $confile = "$rootdir/default.conf";
+unless (($user) && ($passwd)) {
 
-
-# read configuration file
-if (!open(CONF, "<$confile")) {
-    log_debug(1, "can't open configuration file $confile");
+    # No user or passwd passed in, read configuration file, they might be there
+    print "Userid and password must be supplied\n";
     exit 1;
-}
-my %confhash;
-while (<CONF>) {
-    if (/restapi-(\w+)=(\S+)/) {
-        $confhash{$1} = $2;
-    }
 }
 
 # get hostname or default to local host if not specified
 unless ($host) {
     $host = "127.0.0.1";
 }
-
-unless ($user) {
-    $user = $confhash{DefaultUser1};
-}
-unless ($passwd) {
-    $passwd = $confhash{DefaultPasswd1};
-}
-my $DefaultPasswd = $confhash{DefaultPasswd1};
 
 if ($usetoken) {
 # get token
@@ -155,64 +129,11 @@ log_debug(3, "User $user. \n");
 log_debug(3, "Password $passwd. \n");
 log_debug(3, "Host $host. \n");
 log_debug(3, "Got token $token. \n");
-log_debug(3, "get path of ca $confhash{Cert} \n");
 
 my $res = run_restapi($method, $resource, $data, "", $port, "$host", "$user", "$passwd", "$token");
-$defaulthash       = parse_json($res);
 $defaulthttpresult = check_errcode();
 
-print Dumper $defaulthash;
-exit $defaulthttpresult;
-
-####################################################
-# Begin to run test cases
-####################################################
-my @users   = ($confhash{DefaultUser1},   $confhash{DefaultUser2},   $user);
-my @passwds = ($confhash{DefaultPasswd1}, $confhash{DefaultPasswd2}, $passwd);
-my @tokens = ("", $token, $token);
-my @certs = ("", $confhash{Cert}, $cert);
-my $i = 0;
-unless ($method eq "POST") {    # Should not post sevral times
-    for my $u (@users) {
-        next unless ($u);
-        my $p = $passwds[$i];
-        $i++;
-        for my $t (@tokens) {
-            for my $c (@certs) {
-
-                #if ($method eq "POST" and ($resource =~ /^\/nodes\/(\w+)$/)) {
-                #     `/opt/xcat/bin/rmdef $1`;
-                #     log_debug(2,"restapi test rmdef $1\n");
-                #}
-                my $res = run_restapi($method, $resource, $data, $c, $port, $host, $u, $p, $t);
-                if ($res) {
-                    my $reshash = parse_json($res);
-                    log_debug(2, "parse curl result and got:\n");
-                    log_debug(2, $reshash);
-                    if (%$reshash != %$defaulthash) {
-                        log_debug(3, "restapi test cases run different result with $method, $resource, $data, $c, $port, $host, $u, $p, $t\n");
-                        exit 1;
-                    }
-                }
-                my $errcode = check_errcode();
-                log_debug(2, "get curl error code: $errcode\n");
-                if ($errcode != $defaulthttpresult) {
-                    log_debug(3, "restapi test cases run different error code with $method, $resource, $data, $c, $port, $host, $u, $p, $t\n");
-                    exit 1;
-                }
-            }
-        }
-    }
-}
-##############################################################
-# check result
-##############################################################
-if ($output) {
-    my $res = check_result($output, $loperator, $res);
-    log_debug(2, "check result runs with $output and $loperator, result is $res\n");
-    exit $res;
-}
-
+print Dumper $res;
 exit $defaulthttpresult;
 
 ################################################
@@ -287,10 +208,9 @@ sub run_restapi
     $cmd .= "/xcatws";
     $cmd .= "$r?";
     unless ($t) {
-        $cmd .= "userName=$u&userPW=$a'";
-    } else {
-        $cmd .= "'";
+        $cmd .= "userName=$u&userPW=$a";
     }
+    $cmd .= "&pretty=1'";
     if ($d) {
         $cmd .= " -H Content-Type:application/json --data '$d'";
     }


### PR DESCRIPTION
#5127 

This PR:
1. Fixes problem with REST API commands for OpenBMC nodes. The data needs to be parsed differently from IPMI controlled nodes.
2. Adds automated UT cases for REST API

Before fix:

```
[root@stratton01 ~]# curl -X GET -k  'https://127.0.0.1/xcatws/nodes/f6u13/inventory?userName=root&userPW=cluster'

[root@stratton01 ~]# curl -X GET -k  'https://127.0.0.1/xcatws/nodes/f6u13/vitals?userName=root&userPW=cluster'

[root@stratton01 ~]# curl -X GET -k  'https://127.0.0.1/xcatws/nodes/f6u13/eventlog?userName=root&userPW=cluster'
```

After fix:

```
[root@stratton01 autotest]# curl -X GET -k  'https://127.0.0.1/xcatws/nodes/f6u13/inventory?userName=root&userPW=cluster'
{"f6u13":{"DIMM5 PartNumber":"","GV100CARD4 Functional":"0","DIMM8 PartNumber":"","DIMM10 Functional":"1","CPU1 CORE11 Present":"1","BMC PrettyName":"BMC PLANAR","CPU1 CORE16 Present":"1","DIMM12 BuildDate":"","DIMM7 Manufacturer":"0x2c80","CPU0 CO

[root@stratton01 autotest]# curl -X GET -k  'https://127.0.0.1/xcatws/nodes/f6u13/vitals?userName=root&userPW=cluster'
{"f6u13":{"Dimm15 Temp":"35 C","Fan1 1":"3647 RPMS","P0 Core21 Temp":"44 C","P0 Vdd Temp":"34 C","P0 Gpu2 Power":"4 Watts","Fan1 0":"3330 RPMS","P1 Io Power":"57 Watts","Ps0 Output Current":"14.25 Amps","LEDs Fan0":"Off","Dimm12 Temp":"34 C","LEDs Fan2":"Off",

[root@stratton01 autotest]# curl -X GET -k  'https://127.0.0.1/xcatws/nodes/f6u13/eventlog?userName=root&userPW=cluster'
{"f6u13":{"eventlog":["11/28/2017 22:04:59 [1]: xyz.openbmc_project.Common.Error.InternalFailure (PID: 1353), Resolved: 1","11/28/2017 22:05:02 [2]: xyz.openbmc_project.Common.Error.InternalFailure (PID: 1353), Resolved: 1","12/01/2017 01:17:39 [3]: xyz.openbmc_project.Software.Version.Error.ManifestFileFailure (PID: 1245), Resolved: 1","12/01/2017 05:12:17 [4]: xyz.openbmc_project.Software.Version.Error.ManifestFileFailure (PID: 1468), Resolved: 1","12/01/2017 05:17:23 [5]: 
```

Automatest testcase execution:
```
[root@stratton01 autotest]# xcattest -f restapi.template -c restapi/node
:
:
:
------END::get_node_rest_error::Passed::Time:Thu Apr 26 15:19:02 2018 ::Duration::1 sec------
------Total: 20 , Failed: 0------

xCAT automated test finished at Thu Apr 26 15:19:02 2018
```