### PR TITLE
Handle invalid tables in REST API

### DIFF
--- a/docs/source/advanced/restapi/restapi_resource/restapi_reference.rst
+++ b/docs/source/advanced/restapi/restapi_resource/restapi_reference.rst
@@ -2107,7 +2107,7 @@ Get OS and ARCH attributes from nodetype table for node1 and node2. ::
 [URI:/tables/{tablelist}/rows] - The non-node table resource
 ------------------------------------------------------------
 
-Use this for tables that don't have node name as the key of the table, for example: passwd, site, networks, polciy, etc.
+Use this for tables that don't have node name as the key of the table, for example: passwd, site, networks, policy, etc.
 
 GET - Get all rows from non-node tables.
 ````````````````````````````````````````
@@ -2144,7 +2144,7 @@ Get all rows from networks table. ::
 [URI:/tables/{tablelist}/rows/{keys}] - The non-node table rows resource
 ------------------------------------------------------------------------
 
-Use this for tables that don't have node name as the key of the table, for example: passwd, site, networks, polciy, etc.
+Use this for tables that don't have node name as the key of the table, for example: passwd, site, networks, policy, etc.
 
 {keys} should be the name=value pairs which are used to search table. e.g. {keys} should be [net=192.168.1.0,mask=255.255.255.0] for networks table query since the net and mask are the keys of networks table.
 
@@ -2157,7 +2157,7 @@ GET - Get attributes for rows from non-node tables.
 
 **Example:** 
 
-Get row which net=192.168.1.0,mask=255.255.255.0 from networks table. :: 
+Get rows from networks table where net=192.168.1.0,mask=255.255.255.0. :: 
 
 
     curl -X GET -k 'https://127.0.0.1/xcatws/tables/networks/rows/net=192.168.1.0,mask=255.255.255.0?userName=root&userPW=cluster&pretty=1'
@@ -2201,14 +2201,14 @@ DELETE - Delete rows from a non-node table that have the attribute values specif
 
 **Example:** 
 
-Delete a route row which routename=privnet in the routes table. :: 
+Delete rows from routes table where routename=privnet. :: 
 
 
     curl -X DELETE -k 'https://127.0.0.1/xcatws/tables/routes/rows/routename=privnet?userName=root&userPW=cluster&pretty=1'
 [URI:/tables/{tablelist}/rows/{keys}/{attrlist}] - The non-node table attributes resource
 -----------------------------------------------------------------------------------------
 
-Use this for tables that don't have node name as the key of the table, for example: passwd, site, networks, polciy, etc.
+Use this for tables that don't have node name as the key of the table, for example: passwd, site, networks, policy, etc.
 
 GET - Get specific attributes for rows from non-node tables.
 ````````````````````````````````````````````````````````````
@@ -2219,7 +2219,7 @@ GET - Get specific attributes for rows from non-node tables.
 
 **Example:** 
 
-Get attributes mgtifname and tftpserver which net=192.168.1.0,mask=255.255.255.0 from networks table. :: 
+Get attributes mgtifname and tftpserver from networks table for each row where net=192.168.1.0,mask=255.255.255.0. :: 
 
 
     curl -X GET -k 'https://127.0.0.1/xcatws/tables/networks/rows/net=192.168.1.0,mask=255.255.255.0/mgtifname,tftpserver?userName=root&userPW=cluster&pretty=1'

--- a/xCAT-server/xCAT-wsapi/xcatws.cgi
+++ b/xCAT-server/xCAT-wsapi/xcatws.cgi
@@ -1192,7 +1192,7 @@ my %URIdef = (
         },
         table_all_rows => {
             desc => "[URI:/tables/{tablelist}/rows] - The non-node table resource",
-            desc1 => "Use this for tables that don't have node name as the key of the table, for example: passwd, site, networks, polciy, etc.",
+            desc1 => "Use this for tables that don't have node name as the key of the table, for example: passwd, site, networks, policy, etc.",
             matcher => '^/tables/[^/]+/rows$',
             GET     => {
                 desc => "Get all rows from non-node tables.",
@@ -1204,13 +1204,13 @@ my %URIdef = (
         },
         table_rows => {
             desc => "[URI:/tables/{tablelist}/rows/{keys}] - The non-node table rows resource",
-            desc1 => "Use this for tables that don't have node name as the key of the table, for example: passwd, site, networks, polciy, etc.",
+            desc1 => "Use this for tables that don't have node name as the key of the table, for example: passwd, site, networks, policy, etc.",
             desc2 => "{keys} should be the name=value pairs which are used to search table. e.g. {keys} should be [net=192.168.1.0,mask=255.255.255.0] for networks table query since the net and mask are the keys of networks table.",
             matcher => '^/tables/[^/]+/rows/[^/]+$',
             GET     => {
                 desc => "Get attributes for rows from non-node tables.",
                 usage => "||An object containing each table.  Within each table object is an array of row objects containing the attributes.|",
-                example => qq(|Get row which net=192.168.1.0,mask=255.255.255.0 from networks table.|GET|/tables/networks/rows/net=192.168.1.0,mask=255.255.255.0|{\n   \"networks\":[\n      {\n         \"mgtifname\":\"eth0\",\n         \"netname\":\"192_168_1_0-255_255_255_0\",\n         \"tftpserver\":\"192.168.1.15\",\n         \"gateway\":\"192.168.1.100\",\n         \"staticrangeincrement\":\"1\",\n         \"net\":\"192.168.1.0\",\n         \"mask\":\"255.255.255.0\"\n      }\n   ]\n}|),
+                example => qq(|Get rows from networks table where net=192.168.1.0,mask=255.255.255.0.|GET|/tables/networks/rows/net=192.168.1.0,mask=255.255.255.0|{\n   \"networks\":[\n      {\n         \"mgtifname\":\"eth0\",\n         \"netname\":\"192_168_1_0-255_255_255_0\",\n         \"tftpserver\":\"192.168.1.15\",\n         \"gateway\":\"192.168.1.100\",\n         \"staticrangeincrement\":\"1\",\n         \"net\":\"192.168.1.0\",\n         \"mask\":\"255.255.255.0\"\n      }\n   ]\n}|),
                 fhandler => \&tablerowhdl,
                 outhdler => \&tableout,
             },
@@ -1224,19 +1224,19 @@ my %URIdef = (
             DELETE => {
                 desc => "Delete rows from a non-node table that have the attribute values specified in {keys}.",
                 usage => "||$usagemsg{non_getreturn}|",
-                example => '|Delete a route row which routename=privnet in the routes table.|DELETE|/tables/routes/rows/routename=privnet||',
+                example => '|Delete rows from routes table where routename=privnet.|DELETE|/tables/routes/rows/routename=privnet||',
                 fhandler => \&tablerowdelhdl,
                 outhdler => \&noout,
             },
         },
         table_rows_attrs => {
             desc => "[URI:/tables/{tablelist}/rows/{keys}/{attrlist}] - The non-node table attributes resource",
-            desc1 => "Use this for tables that don't have node name as the key of the table, for example: passwd, site, networks, polciy, etc.",
+            desc1 => "Use this for tables that don't have node name as the key of the table, for example: passwd, site, networks, policy, etc.",
             matcher => '^/tables/[^/]+/rows/[^/]+/[^/]+$',
             GET     => {
                 desc => "Get specific attributes for rows from non-node tables.",
                 usage => "||An object containing each table.  Within each table object is an array of row objects containing the attributes.|",
-                example => qq(|Get attributes mgtifname and tftpserver which net=192.168.1.0,mask=255.255.255.0 from networks table.|GET|/tables/networks/rows/net=192.168.1.0,mask=255.255.255.0/mgtifname,tftpserver|{\n   \"networks\":[\n      {\n         \"mgtifname\":\"eth0\",\n         \"tftpserver\":\"192.168.1.15\"\n      }\n   ]\n}|),
+                example => qq(|Get attributes mgtifname and tftpserver from networks table for each row where net=192.168.1.0,mask=255.255.255.0.|GET|/tables/networks/rows/net=192.168.1.0,mask=255.255.255.0/mgtifname,tftpserver|{\n   \"networks\":[\n      {\n         \"mgtifname\":\"eth0\",\n         \"tftpserver\":\"192.168.1.15\"\n      }\n   ]\n}|),
                 fhandler => \&tablerowhdl,
                 outhdler => \&tableout,
             },
@@ -2853,6 +2853,10 @@ sub tablerowhdl {
     # out of the node hash and make it the key
     my $responses = sendRequest($req, { SuppressEmpty => undef, ForceArray => 0, KeyAttr => [] });
 
+    if (@$responses[0]->{error}) {
+        # Error returned, most likely invalid table, substitute a better error msg
+        @$responses[0]->{error} = "No such table: @tables";
+    }
     return $responses;
 }
 

--- a/xCAT-test/autotest/testcase/restapi/table/cases0
+++ b/xCAT-test/autotest/testcase/restapi/table/cases0
@@ -1,101 +1,44 @@
-start:node_post_for_table_get
-description: node_for_table_get
-cmd:restapitest -m POST -r /nodes/tnode1 -d '{"groups":"all","mgt":"dfm","netboot":"xnba","provmethod":"rhels6.4-x86_64-install-compute","profile":"compute","arch":"x86_64","os":"rhels6.4"}'
-check:rc==201
-end
-
-start:node_post_for_table_get
-description: node_for_table_get
-cmd:restapitest -m POST -r /nodes/tnode2 -d '{"groups":"all","mgt":"dfm","netboot":"yaboot","provmethod":"rhels6.4-ppc64-install-compute","profile":"compute","arch":"ppc64","os":"rhels6.4"}'
-check:rc==201
-end
-
-start:table_get
-description: table_get
-cmd:restapitest -m GET -r /tables/nodetype/nodes/tnode1,tnode2 
+start:get_networks_table_rest
+description: get all networks table entries with REST API
+cmd:restapitest -m GET -r /tables/networks/rows -u $$username -p $$password
 check:rc==200
-cmdcheck:restapitest -o '{"nodetype":[{"arch":"ppc64"}]}' -O ==
+check:output=~netname
 end
 
-start:table_get2
-description: table_get2
-cmd:restapitest -m GET -r /tables/nodetype,noderes/nodes/tnode1,tnode2 
+start:get_network_table_rest
+description: get all entries from invalid table name with REST API
+cmd:restapitest -m GET -r /tables/network/rows -u $$username -p $$password
+check:rc==147
+check:output=~No such table
+end
+
+start:get_network_table_with_attr_selection_rest
+description: get all attribute matching networks table entries with REST API
+cmd:restapitest -m GET -r /tables/networks/rows/mask=255.0.0.0 -u $$username -p $$password
 check:rc==200
-cmdcheck:restapitest -o '{"nodetype":[{"arch":"ppc64"}]}' -O ==
+check:output=~"mask":"255.0.0.0"
 end
 
-start:table_put
-description: table_put 
-cmd:restapitest -m PUT -r /tables/nodetype,noderes/nodes/tnode1,tnode2 -d '{"nodetype":{"arch":"x86_64"},"noderes":{"netboot":"xnba"}}' 
+start:get_network_table_with_attr_selection_rest2
+description: get attribute matching networks table attributes with REST API
+cmd:restapitest -m GET -r /tables/networks/rows/mask=255.0.0.0/gateway -u $$username -p $$password
 check:rc==200
+check:output=~"gateway":"
 end
 
-start:table_get3
-description: table_get3
-cmd:restapitest -m GET -r /tables/nodetype,noderes/nodes/tnode1,tnode2 
+start:set_network_table_attr_with_attr_selection_rest2
+description: set attribute for network table for attr seleection with REST API
+cmd:restapitest -m PUT -r /tables/networks/rows/mask=255.0.0.0 -d '{"comments":"REST API TEST"}' -u $$username -p $$password
 check:rc==200
-cmdcheck:restapitest -o '{"nodetype":[{"arch":"x86_64"}]}' -O ==
+cmd:lsdef -l -t network
+check:output=~REST API TEST
 end
 
-start:table_get_attr
-description: table_get_attr
-cmd:restapitest -m GET -r /tables/nodetype,noderes/nodes/tnode1,tnode2 
+start:delete_network_rest
+description: create a network and delele network with REST API
+cmd: restapitest -m POST -r /networks/network_rest -d '{"gateway":"10.1.0.1","mask":"255.255.0.0","net":"199.168.0.0"}' -u $$username -p $$password
+cmd: restapitest -m DELETE -r /tables/networks/rows/net=199.168.0.0 -u $$username -p $$password
 check:rc==200
-cmdcheck:restapitest -o '{"nodetype":[{"arch":"x86_64"}]}' -O ==
+cmd: lsdef -t network network_rest
+check:output=~Error: Could not find an object named 'network_rest' of type 'network'.
 end
-
-start:table_get_row
-description: table_get_row
-cmd:restapitest -m GET -r /tables/networks/rows
-check:rc==200
-cmdcheck:restapitest -o '{"networks":[{"netname":"ANY"}]}' -O ==
-end
-
-start:table_get_row_key
-description: table_get_row_key
-cmd:restapitest -m GET -r /tables/networks/rows/net=9.114.154.64,mask=255.255.255.192
-check:rc==200
-cmdcheck:restapitest -o '{"networks":[{"mask":"255.255.255.192"}]}' -O ==
-end
-
-start:table_put
-description: table_put
-cmd:restapitest -m PUT -r /tables/routes/rows/routename=privnet -d '{"net":"10.0.1.0","mask":"255.255.255.0","gateway":"10.0.1.254","ifname":"eth1"}'
-check:rc==200
-end
-
-start:table_get_row1
-description: table_get_row1
-cmd:restapitest -m GET -r /tables/routes/privnet
-check:rc==200
-cmdcheck:restapitest -o '{"routes":[{"gateway":"10.0.1.254"}]}' -O ==
-end
-
-start:table_get_row_key1
-description: table_get_row_key1
-cmd:restapitest -m GET -r /tables/routes/rows/routename=privnet
-check:rc==200
-cmdcheck:restapitest -o '{"networks":[{"ifname":"eth1"}]}' -O ==
-end
-
-start:table_delete_row
-description: table_delete_row
-cmd:restapitest -m DELETE -r /tables/routes/rows/routename=privnet
-check:rc==200
-cmdcheck:restapitest -o '{"networks":[{"ifname":"eth1"}]}' -O ==
-end
-
-start:table_get_row_for_delete
-description: table_get_row_for_delete
-cmd:restapitest -m GET -r /tables/routes/privnet
-check:rc==200
-cmdcheck:restapitest -o '{"routes":[{"gateway":"10.0.1.254"}]}' -O !==
-end
-
-start:table_get_special_key
-description: table_get_special_key
-cmd:restapitest -m GET -r /tables/networks/rows/net=192.168.1.0,mask=255.255.255.0/mgtifname,tftpserver
-check:rc==200
-cmdcheck:restapitest -o '{"networks":[{"mgtifname":"eth0"}]}' -O !==
-end
-


### PR DESCRIPTION
#5147 

This pull request fixes the problem when invalid table name is passed into REST API. It also fixes spelling and wording problems in REST API doc.

After fix:
```
[root@stratton01 xcat]# curl -X GET -k  'https://127.0.0.1/xcatws/tables/network/rows?userName=root&userPW=xxxxxx&pretty=1'
{
   "errorcode":"1",
   "error":[
      "No such table: network"
   ]
}
[root@stratton01 xcat]#
```
```
[root@stratton01 xcat]# curl -X GET -k  'https://127.0.0.1/xcatws/tables/networks/rows?userName=root&userPW=cluster&pretty=1'
{
   "networks":[
      {
         "mgtifname":"enP2p1s0f0",
         "netname":"10_0_0_0-255_0_0_0",
         "tftpserver":"10.6.29.1",
         "gateway":"10.0.0.101",
         "net":"10.0.0.0",
         "mask":"255.0.0.0"
      },
      {
         "mgtifname":"enP2p1s0f2",
         "netname":"50_0_0_0-255_0_0_0",
         "tftpserver":"50.6.29.2",
         "gateway":"<xcatmaster>",
         "net":"50.0.0.0",
         "mask":"255.0.0.0"
      },
      {
         "mgtifname":"enP34p1s0f0",
         "netname":"172_10_0_0-255_255_0_0",
         "net":"172.10.0.0",
         "mask":"255.255.0.0"
      },
      {
         "mgtifname":"enP34p1s0f1",
         "netname":"172_11_0_0-255_255_0_0",
         "net":"172.11.0.0",
         "mask":"255.255.0.0"
      },
      {
         "netname":"private_192",
         "net":"192.168.0.0",
         "mask":"255.255.0.0"
      },
      {
         "netname":"autotest_ent",
         "gateway":"192.168.10.3",
         "net":"192.168.10.0",
         "mask":"255.255.255.0"
      }
   ]
}
[root@stratton01 xcat]#
```