### PR TITLE
update test case 'xcatd_start' for issue 5152

### DIFF
--- a/xCAT-test/autotest/testcase/xcatd/case0
+++ b/xCAT-test/autotest/testcase/xcatd/case0
@@ -1,31 +1,46 @@
 start:xcatd_start
 description:stop then start xcatd daemon, and check all the 6 processes are running
 os:linux
+cmd:if [ -d "/tmp/xcatd_start" ]; then mv /tmp/xcatd_start /tmp/xcatd_start.org; fi; mkdir -p /tmp/xcatd_start
+check:rc==0
 cmd:service xcatd status
 check:rc==0
-check:output=~xcatd service is running
+check:output=~Active: active \(running\)|xcatd service is running
+cmd:ps axjf |grep -v grep |grep "xcatd:" | tee /tmp/xcatd_start/original_xcatd_processes_status
+check:rc==0
+cmd:cat /tmp/xcatd_start/original_xcatd_processes_status |wc -l
+check:output=~6
 cmd:service xcatd stop
 check:rc==0
 cmd:sleep 3
+cmd:ps axjf |grep -v grep |grep "xcatd:" | tee /tmp/xcatd_start/after_stop_xcatd_processes_status
+check:rc==0
+cmd:cat /tmp/xcatd_start/after_stop_xcatd_processes_status|wc -l
+check:output=~0
 cmd:service xcatd start
 check:rc==0
-check:output=~Starting xcatd
-check:output=~[  OK  ]
+cmd:sleep 3
 cmd:service xcatd status
 check:rc==0
-check:output=~xcatd service is running
-cmd:result=`ps -ef | grep "xcatd: SSL listener" | grep -v grep | wc -l`; if [ $result -eq 1 ]; then echo "only one process"; fi
-check:output=~only one process
-cmd:result=`ps -ef | grep "xcatd: DB Access" | grep -v grep | wc -l`; if [ $result -eq 1 ]; then echo "only one process"; fi
-check:output=~only one process
-cmd:result=`ps -ef | grep "xcatd: UDP listener" | grep -v grep | wc -l`; if [ $result -eq 1 ]; then echo "only one process"; fi
-check:output=~only one process
-cmd:result=`ps -ef | grep "xcatd: install monitor" | grep -v grep | wc -l`; if [ $result -eq 1 ]; then echo "only one process"; fi
-check:output=~only one process
-cmd:result=`ps -ef | grep "xcatd: Discovery worke" | grep -v grep | wc -l`; if [ $result -eq 1 ]; then echo "only one process"; fi
-check:output=~only one process
-cmd:result=`ps -ef | grep "xcatd: Command log writer" | grep -v grep | wc -l`; if [ $result -eq 1 ]; then echo "only one process"; fi
-check:output=~only one process
+check:output=~Active: active \(running\)|xcatd service is running
+cmd:ps axjf |grep -v grep |grep "xcatd:" | tee /tmp/xcatd_start/after_start_xcatd_processes_status
+check:rc==0
+cmd:cat  /tmp/xcatd_start/after_start_xcatd_processes_status|wc -l
+check:output=~6
+cmd:grep "xcatd: SSL listener" /tmp/xcatd_start/after_start_xcatd_processes_status|wc -l
+check:output=~1
+cmd:grep "xcatd: DB Access" /tmp/xcatd_start/after_start_xcatd_processes_status|wc -l
+check:output=~1
+cmd:grep "xcatd: UDP listener" /tmp/xcatd_start/after_start_xcatd_processes_status|wc -l
+check:output=~1
+cmd:grep "xcatd: Discovery worker" /tmp/xcatd_start/after_start_xcatd_processes_status|wc -l
+check:output=~1
+cmd:grep "xcatd: install monitor" /tmp/xcatd_start/after_start_xcatd_processes_status|wc -l
+check:output=~1
+cmd:grep "xcatd: Command log writer" /tmp/xcatd_start/after_start_xcatd_processes_status|wc -l
+check:output=~1
+cmd: rm -rf /tmp/xcatd_start; if [ -d "/tmp/xcatd_start.org" ]; then mv /tmp/xcatd_start.org /tmp/xcatd_start; fi
+check:rc==0
 end
 
 start:xcatd_start_systemd


### PR DESCRIPTION
Update test case xcatd_start for issue #5152. 
related task xcat2/xcat2-task-management#118

The UT output is:

```
------START::xcatd_start::Time:Tue May  1 23:42:15 2018------

RUN:if [ -d "/tmp/xcatd_start" ]; then mv /tmp/xcatd_start /tmp/xcatd_start.org; fi; mkdir -p /tmp/xcatd_start [Tue May  1 23:42:15 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:service xcatd status [Tue May  1 23:42:15 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
xcatd service is running
CHECK:rc == 0	[Pass]
CHECK:output =~ Active: active \(running\)|xcatd service is running	[Pass]

RUN:ps axjf |grep -v grep |grep "xcatd:" | tee /tmp/xcatd_start/original_xcatd_processes_status [Tue May  1 23:42:15 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
    1 29554 29554 29554 ?           -1 Ss       0   0:00 xcatd: SSL listener
29554 29555 29554 29554 ?           -1 S        0   0:00  \_ xcatd: DB Access
29554 29557 29554 29554 ?           -1 S        0   0:00  \_ xcatd: UDP listener
29557 29561 29554 29554 ?           -1 S        0   0:00  |   \_ xcatd: Discovery worker
29554 29558 29554 29554 ?           -1 S        0   0:00  \_ xcatd: install monitor
29554 29559 29554 29554 ?           -1 S        0   0:00  \_ xcatd: Command log writer
CHECK:rc == 0	[Pass]

RUN:cat /tmp/xcatd_start/original_xcatd_processes_status |wc -l [Tue May  1 23:42:15 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
6
CHECK:output =~ 6	[Pass]

RUN:service xcatd stop [Tue May  1 23:42:15 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Stopping xcatd (via systemctl):  [  OK  ]
CHECK:rc == 0	[Pass]

RUN:sleep 3 [Tue May  1 23:42:16 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:

RUN:ps axjf |grep -v grep |grep "xcatd:" | tee /tmp/xcatd_start/after_stop_xcatd_processes_status [Tue May  1 23:42:19 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:cat /tmp/xcatd_start/after_stop_xcatd_processes_status|wc -l [Tue May  1 23:42:19 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
0
CHECK:output =~ 0	[Pass]

RUN:service xcatd start [Tue May  1 23:42:19 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
Starting xcatd (via systemctl):  [  OK  ]
CHECK:rc == 0	[Pass]

RUN:sleep 3 [Tue May  1 23:42:22 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:

RUN:service xcatd status [Tue May  1 23:42:25 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
xcatd service is running
CHECK:rc == 0	[Pass]
CHECK:output =~ Active: active \(running\)|xcatd service is running	[Pass]

RUN:ps axjf |grep -v grep |grep "xcatd:" | tee /tmp/xcatd_start/after_start_xcatd_processes_status [Tue May  1 23:42:25 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
    1 29776 29776 29776 ?           -1 Ss       0   0:00 xcatd: SSL listener
29776 29777 29776 29776 ?           -1 S        0   0:00  \_ xcatd: DB Access
29776 29779 29776 29776 ?           -1 S        0   0:00  \_ xcatd: UDP listener
29779 29782 29776 29776 ?           -1 S        0   0:00  |   \_ xcatd: Discovery worker
29776 29780 29776 29776 ?           -1 S        0   0:00  \_ xcatd: install monitor
29776 29781 29776 29776 ?           -1 S        0   0:00  \_ xcatd: Command log writer
CHECK:rc == 0	[Pass]

RUN:cat  /tmp/xcatd_start/after_start_xcatd_processes_status|wc -l [Tue May  1 23:42:25 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
6
CHECK:output =~ 6	[Pass]

RUN:grep "xcatd: SSL listener" /tmp/xcatd_start/after_start_xcatd_processes_status|wc -l [Tue May  1 23:42:25 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1
CHECK:output =~ 1	[Pass]

RUN:grep "xcatd: DB Access" /tmp/xcatd_start/after_start_xcatd_processes_status|wc -l [Tue May  1 23:42:25 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1
CHECK:output =~ 1	[Pass]

RUN:grep "xcatd: UDP listener" /tmp/xcatd_start/after_start_xcatd_processes_status|wc -l [Tue May  1 23:42:25 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1
CHECK:output =~ 1	[Pass]

RUN:grep "xcatd: Discovery worker" /tmp/xcatd_start/after_start_xcatd_processes_status|wc -l [Tue May  1 23:42:25 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1
CHECK:output =~ 1	[Pass]

RUN:grep "xcatd: install monitor" /tmp/xcatd_start/after_start_xcatd_processes_status|wc -l [Tue May  1 23:42:25 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1
CHECK:output =~ 1	[Pass]

RUN:grep "xcatd: Command log writer" /tmp/xcatd_start/after_start_xcatd_processes_status|wc -l [Tue May  1 23:42:25 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1
CHECK:output =~ 1	[Pass]

RUN:rm -rf /tmp/xcatd_start; if [ -d "/tmp/xcatd_start.org" ]; then mv /tmp/xcatd_start.org /tmp/xcatd_start; fi [Tue May  1 23:42:25 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::xcatd_start::Passed::Time:Tue May  1 23:42:25 2018 ::Duration::10 sec------
```