### PR TITLE
enhance chdef testcase for postscripts

### DIFF
--- a/xCAT-test/autotest/testcase/chdef/cases0
+++ b/xCAT-test/autotest/testcase/chdef/cases0
@@ -18,6 +18,16 @@ check:rc==0
 cmd:lsdef -t node -l testnode 
 check:rc==0
 check:output=~groups=linux
+cmd:chdef -t node -o testnode postscripts="syslog,remoteshell,syncfiles"
+check:rc==0
+check:output!~Error
+check:output=~Warning: testnode: postscripts 'syslog' is already included
+check:output=~Warning: testnode: postscripts 'remoteshell' is already included
+check:output=~Warning: testnode: postscripts 'syncfiles' is already included
+cmd:chdef -t node -o testnode postbootscripts=otherpkgs
+check:rc==0
+check:output!~Error
+check:output=~Warning: testnode: postbootscripts 'otherpkgs' is already included
 cmd:rmdef -t node testnode
 check:rc==0
 end


### PR DESCRIPTION
for #4073 

UT:
```
... ...
RUN:chdef -t node -o testnode postscripts="syslog,remoteshell,syncfiles" [Wed May  2 01:52:41 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Warning: testnode: postscripts 'syslog' is already included in the 'xcatdefaults'.
Warning: testnode: postscripts 'remoteshell' is already included in the 'xcatdefaults'.
Warning: testnode: postscripts 'syncfiles' is already included in the 'xcatdefaults'.
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]
CHECK:output !~ Error	[Pass]
CHECK:output =~ Warning: testnode: postscripts 'syslog' is already included	[Pass]
CHECK:output =~ Warning: testnode: postscripts 'remoteshell' is already included	[Pass]
CHECK:output =~ Warning: testnode: postscripts 'syncfiles' is already included	[Pass]

RUN:chdef -t node -o testnode postbootscripts=otherpkgs [Wed May  2 01:52:42 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Warning: testnode: postbootscripts 'otherpkgs' is already included in the 'xcatdefaults'.
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]
CHECK:output !~ Error	[Pass]
CHECK:output =~ Warning: testnode: postbootscripts 'otherpkgs' is already included	[Pass]

RUN:rmdef -t node testnode [Wed May  2 01:52:43 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

------END::chdef_t_node::Passed::Time:Wed May  2 01:52:44 2018 ::Duration::6 sec------
```