### PR TITLE
add a case for issue 4770 Should --delete option be used for the firmware in active(*) state

### DIFF
--- a/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
+++ b/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
@@ -479,3 +479,15 @@ check:output =~ image_id.+--delete
 check:rc == 0
 end
 
+start:rflash_delete_no_active
+description:this case is to check if --delete is not allowed to be used for the active state firmware. This case is for issue 4770.
+os:Linux
+hcp:openbmc
+cmd:activenum=`rflash $$CN -l |grep -w "Host\s*Active(\*)" |awk '{print $2}'`;rflash $$CN $activenum --delete
+check:rc != 0
+check:output =~$$CN\s*:\s*Error: Deleting currently active firmware on powered on host is not supported 
+cmd:activenum=`rflash $$CN -l |grep -w "BMC\s*Active(\*)" |awk '{print $2}'`;rflash $$CN $activenum --delete
+check:rc != 0
+check:output =~~$$CN\s*:\s*Error: Deleting currently active BMC firmware is not supported
+end
+


### PR DESCRIPTION
Case Name: rflash_delete_no_active
description:this case is to check if --delete is not allowed to be used for the active state firmware. This case is for issue 4770.

UT result
```
xCAT automated test started at Wed May  2 23:17:06 2018
******************************
To detect current test environment
******************************
Detecting: OS = linux
Detecting: ARCH = ppc64le
Detecting: HCP = openbmc
******************************
loading test cases
******************************
To run:
rflash_delete_no_active
******************************
Start to run test cases
******************************
------START::rflash_delete_no_active::Time:Wed May  2 23:17:07 2018------

RUN:activenum=`rflash mid08tor03cn10 -l |grep -w "Host\s*Active(\*)" |awk '{print $2}'`;rflash mid08tor03cn10 $activenum --delete [Wed May  2 23:17:07 2018]
ElapsedTime:7 sec
RETURN rc = 1
OUTPUT:
mid08tor03cn10: Error: Deleting currently active firmware on powered on host is not supported
Attempting to delete ID=7379838a, please wait...
CHECK:rc != 0	[Pass]
CHECK:output =~ mid08tor03cn10\s*:\s*Error: Deleting currently active firmware on powered on host is not supported	[Pass]
RUN:activenum=`rflash mid08tor03cn10 -l |grep -w "BMC\s*Active(\*)" |awk '{print $2}'`;rflash mid08tor03cn10 $activenum --delete [Wed May  2 23:17:14 2018]
ElapsedTime:4 sec
RETURN rc = 1
OUTPUT:
mid08tor03cn10: Error: Deleting currently active BMC firmware is not supported
Attempting to delete ID=f57b7b1b, please wait...
CHECK:rc != 0	[Pass]
CHECK:output =~~ mid08tor03cn10\s*:\s*Error: Deleting currently active BMC firmware is not supported	[Pass]

------END::rflash_delete_no_active::Passed::Time:Wed May  2 23:17:18 2018 ::Duration::11 sec------
------Total: 1 , Failed: 0------
```