### PR TITLE
update a case for cumulus switch osimage support

### DIFF
--- a/xCAT-test/autotest/testcase/nodeset/cases0
+++ b/xCAT-test/autotest/testcase/nodeset/cases0
@@ -463,7 +463,7 @@ check:rc==0
 check:output=~description=Cumulus Linux
 check:output=~osarch=armel
 check:output=~osname=cumulus
-cmd:pkgfile=`lsdef -t osimage -o $imagename |grep pkgdir|awk -F= '{print $2}'`;ls -l $pkgfile
+cmd:imagename=`cat /tmp/imagename`;pkgfile=`lsdef -t osimage -o $imagename |grep pkgdir|awk -F= '{print $2}'`;ls -l $pkgfile
 check:rc==0
 cmd:echo "/etc/resolv.conf /etc/nsswitch.conf -> ($$CN) /tmp/\n /etc/rsyslog.conf  ->  /tmp/aa\n /etc/rsyslog.d/ -> /tmp/bb/\n /tmp/post1 -> /tmp/\n\n EXECUTEALWAYS:\n/tmp/post1\n" >> /tmp/synclists;echo "#!/bin/sh\n\nmv /tmp/aa /tmp/mm" >> /tmp/posts1;imagename=`cat /tmp/imagename`; chdef -t osimage -o $imagename synclists=/tmp/synclists
 check:rc==0

--- a/xCAT-test/autotest/testcase/nodeset/cases0
+++ b/xCAT-test/autotest/testcase/nodeset/cases0
@@ -450,3 +450,26 @@ cmd:rmdef -t osimage -o "rhels7.99-ppc64le-install-compute"
 cmd:rm -rf /install/rhels7.99
 cmd:xdsh $$SN 'rm -rf /install/rhels7.99'
 end
+
+start:nodeset_switch_osimage
+description: This case is to verify if xcat supports nodeset <switch> osimage command for cumulus switch. This case is for bug 5126.
+os:Linux
+cmd:copycds $$CUMULUSOS |tee /tmp/cumulusimage
+check:rc==0
+cmd:grep "The image" /tmp/cumulusimage |sed -r 's/.*\image(.*)\is.*/\1/' |tee /tmp/imagename
+check:rc==0
+cmd:imagename=`cat /tmp/imagename`;lsdef -t osimage -o $imagename
+check:rc==0
+check:output=~description=Cumulus Linux
+check:output=~osarch=armel
+check:output=~osname=cumulus
+cmd:imagename=`cat /tmp/imagename`;osversion=`lsdef -t osimage -o $imagename |grep osvers|awk -F= '{print $2}'`;versionnum=`echo $osversion |sed 's:[a-zA-Z]::g'`;ls -l /install/$osversion/armel/cumulus-linux-$versionnum-bcm-armel.bin
+check:rc==0
+cmd:echo "/etc/resolv.conf /etc/nsswitch.conf -> ($$CN) /tmp/\n /etc/rsyslog.conf  ->  /tmp/aa\n /etc/rsyslog.d/ -> /tmp/bb/\n /tmp/post1 -> /tmp/\n\n EXECUTEALWAYS:\n/tmp/post1\n" >> /tmp/synclists;echo "#!/bin/sh\n\nmv /tmp/aa /tmp/mm" >> /tmp/posts1;imagename=`cat /tmp/imagename`; chdef -t osimage -o $imagename synclists=/tmp/synclists
+check:rc==0
+cmd:imagename=`cat /tmp/imagename`;nodeset $$CN osimage=$imagename
+check:rc==0
+check:output=~$$CN:\s*install
+cmd:imagename=`cat /tmp/imagename`;osversion=`lsdef -t osimage -o $imagename |grep osvers|awk -F= '{print $2}'`;versionnum=`echo $osversion |sed 's:[a-zA-Z]::g'`;grep -w -A10 "$$CN" /var/lib/dhcpd/dhcpd.leases | grep "/install/$osversion/armel/cumulus-linux-$versionnum-bcm-armel.bin"
+check:rc==0
+end

--- a/xCAT-test/autotest/testcase/nodeset/cases0
+++ b/xCAT-test/autotest/testcase/nodeset/cases0
@@ -463,7 +463,7 @@ check:rc==0
 check:output=~description=Cumulus Linux
 check:output=~osarch=armel
 check:output=~osname=cumulus
-cmd:imagename=`cat /tmp/imagename`;osversion=`lsdef -t osimage -o $imagename |grep osvers|awk -F= '{print $2}'`;versionnum=`echo $osversion |sed 's:[a-zA-Z]::g'`;ls -l /install/$osversion/armel/cumulus-linux-$versionnum-bcm-armel.bin
+cmd:pkgfile=`lsdef -t osimage -o $imagename |grep pkgdir|awk -F= '{print $2}'`;ls -l $pkgfile
 check:rc==0
 cmd:echo "/etc/resolv.conf /etc/nsswitch.conf -> ($$CN) /tmp/\n /etc/rsyslog.conf  ->  /tmp/aa\n /etc/rsyslog.d/ -> /tmp/bb/\n /tmp/post1 -> /tmp/\n\n EXECUTEALWAYS:\n/tmp/post1\n" >> /tmp/synclists;echo "#!/bin/sh\n\nmv /tmp/aa /tmp/mm" >> /tmp/posts1;imagename=`cat /tmp/imagename`; chdef -t osimage -o $imagename synclists=/tmp/synclists
 check:rc==0


### PR DESCRIPTION
Add 1 case in this pull request

[case 1]
Case Name:nodeset_switch_osimage
description: This case is to verify if xcat supports nodeset <switch> osimage command for cumulus switch. This case is for bug 5126.

test result
```
------START::nodeset_switch_osimage::Time:Tue May  8 04:16:17 2018------

RUN:copycds /cumulus-linux-3.5.2-bcm-armel.bin |tee /tmp/cumulusimage [Tue May  8 04:16:17 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
Copying media to /install/cumulus3.5.2/armel
Media copy operation successful
The image cumulus3.5.2-armel is created.
CHECK:rc == 0   [Pass]

RUN:grep "The image" /tmp/cumulusimage |sed -r 's/.*\image(.*)\is.*/\1/' |tee /tmp/imagename [Tue May  8 04:16:20 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
 cumulus3.5.2-armel
CHECK:rc == 0   [Pass]

RUN:imagename=`cat /tmp/imagename`;lsdef -t osimage -o $imagename [Tue May  8 04:16:20 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Object name: cumulus3.5.2-armel
    description=Cumulus Linux
    imagetype=linux
    osarch=armel
    osname=cumulus
    osvers=cumulus3.5.2
    pkgdir=/install/cumulus3.5.2/armel/cumulus-linux-3.5.2-bcm-armel.bin
    provmethod=install
    synclists=/tmp/synclists
CHECK:rc == 0   [Pass]
CHECK:output =~ description=Cumulus Linux       [Pass]
CHECK:output =~ osarch=armel    [Pass]
CHECK:output =~ osname=cumulus  [Pass]

RUN:imagename=`cat /tmp/imagename`;pkgfile=`lsdef -t osimage -o $imagename |grep pkgdir|awk -F= '{print $2}'`;ls -l $pkgfile [Tue May  8 04:23:56 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
-rwxr-xr-x 1 root root 180570582 May  8 04:23 /install/cumulus3.5.2/armel/cumulus-linux-3.5.2-bcm-armel.bin
CHECK:rc == 0	[Pass]

RUN:echo "/etc/resolv.conf /etc/nsswitch.conf -> (mid05tor26) /tmp/\n /etc/rsyslog.conf  ->  /tmp/aa\n /etc/rsyslog.d/ -> /tmp/bb/\n /tmp/post1 -> /tmp/\n\n EXECUTEALWAYS:\n/tmp/post1\n" >> /tmp/synclists;echo "#!/bin/sh\n\nmv /tmp/aa /tmp/mm" >> /tmp/posts1;imagename=`cat /tmp/imagename`; chdef -t osimage -o $imagename synclists=/tmp/synclists [Tue May  8 04:23:56 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:imagename=`cat /tmp/imagename`;nodeset mid05tor26 osimage=$imagename [Tue May  8 04:23:57 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
mid05tor26: install cumulus3.5.2-armel
CHECK:rc == 0	[Pass]
CHECK:output =~ mid05tor26:\s*install	[Pass]

RUN:imagename=`cat /tmp/imagename`;osversion=`lsdef -t osimage -o $imagename |grep osvers|awk -F= '{print $2}'`;versionnum=`echo $osversion |sed 's:[a-zA-Z]::g'`;grep -w -A10 "mid05tor26" /var/lib/dhcpd/dhcpd.leases | grep "/install/$osversion/armel/cumulus-linux-$versionnum-bcm-armel.bin" [Tue May  8 04:23:57 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::nodeset_switch_osimage::Passed::Time:Tue May  8 04:23:57 2018 ::Duration::4 sec------
------Total: 1 , Failed: 0------
```