### PR TITLE
Add REST API beacon status function

### DIFF
--- a/docs/source/advanced/restapi/restapi_resource/restapi_reference.rst
+++ b/docs/source/advanced/restapi/restapi_resource/restapi_reference.rst
@@ -755,6 +755,29 @@ Delete all the event log for node1. ::
 [URI:/nodes/{noderange}/beacon] - The beacon resource for the node {noderange}
 ------------------------------------------------------------------------------
 
+GET - Get the beacon status for the node {noderange}.
+`````````````````````````````````````````````````````
+
+Refer to the man page: :doc:`rbeacon </guides/admin-guides/references/man1/rbeacon.1>`
+
+**Returns:**
+
+* Json format: An object which includes multiple '<name> : {att:value, attr:value ...}' pairs.
+
+**Example:** 
+
+Get beacon for node1. :: 
+
+
+    curl -X GET -k 'https://127.0.0.1/xcatws/nodes/node1/beacon?userName=root&userPW=cluster&pretty=1'
+    {
+       "node1":{
+          "beacon":[
+             "Front:Blink Rear:Blink"
+          ]
+       }
+    }
+
 PUT - Change the beacon status for the node {noderange}.
 ````````````````````````````````````````````````````````
 
@@ -774,13 +797,6 @@ Turn on the beacon. ::
 
 
     curl -X PUT -k 'https://127.0.0.1/xcatws/nodes/node1/beacon?userName=root&userPW=cluster&pretty=1' -H Content-Type:application/json --data '{"action":"on"}'
-    [
-       {
-          "name":"node1",
-          "beacon":"on"
-       }
-    ]
-
 [URI:/nodes/{noderange}/updating] - The updating resource for the node {noderange}
 ----------------------------------------------------------------------------------
 

--- a/xCAT-test/autotest/testcase/restapi/node/cases1
+++ b/xCAT-test/autotest/testcase/restapi/node/cases1
@@ -45,3 +45,27 @@ cmd:restapitest -m GET -r /nodes/$$CN/eventlog -u $$username -p $$password
 check:rc==200
 check:output=~eventlog
 end
+
+start:beacon_node_rest
+description: get OpenBMC node beacon with REST API
+hcp:openbmc
+cmd:restapitest -m GET -r /nodes/$$CN/beacon -u $$username -p $$password
+check:rc==200
+check:output=~Front
+check:output=~Rear
+end
+
+start:beacon_set_node_rest
+description: set OpenBMC node beacon with REST API
+hcp:openbmc
+cmd:restapitest -m PUT -r /nodes/$$CN/beacon -d '{"action":"on"}' -u $$username -p $$password
+check:rc==200
+end
+
+start:beacon_set_node_rest2
+description: set IPMI node beacon with REST API
+hcp:ipmi
+cmd:restapitest -m PUT -r /nodes/$$CN/beacon -d '{"action":"on"}' -u $$username -p $$password
+check:rc==200
+end
+


### PR DESCRIPTION
#5145 
This PR:
1. Adds beacon GET to xCAT REST API
2. Add beacon REST API automated testcases
3. Modify REST API documentation to show GET function and to show PUT function has no output.

After PR:

* OpenBMC
```
[root@stratton01 xcat]#  curl -X GET -k  'https://127.0.0.1/xcatws/nodes/f6u13/beacon?userName=root&userPW=xxxxx&pretty=1'
{
   "f6u13":{
      "beacon":[
         "Front:Blink Rear:Blink"
      ]
   }
}

[root@stratton01 xcat]#
```

* IPMI
```
[root@stratton01 xcat]#  curl -X GET -k  'https://127.0.0.1/xcatws/nodes/frame5u39/beacon?userName=root&userPW=xxxx&pretty=1'
{
   "errorcode":"1",
   "error":[
      "frame5u39: Only 'on' or 'off' is supported for IPMI managed nodes."
   ]
}

[root@stratton01 xcat]#
```
```
XCATTEST_CN=f6u13 XCATTEST_username=wsuser XCATTEST_password=xxxxxx xcattest -c restapi/node
::
:: 
------END::get_node_rest_error::Passed::Time:Mon May  7 11:38:10 2018 ::Duration::0 sec------
------Total: 22 , Failed: 0------
```