### PR TITLE
REST API handle no key match for tables

### DIFF
--- a/xCAT-server/xCAT-wsapi/xcatws.cgi
+++ b/xCAT-server/xCAT-wsapi/xcatws.cgi
@@ -2871,6 +2871,12 @@ sub tablerowhdl {
         # Error returned, most likely invalid table, substitute a better error msg
         @$responses[0]->{error} = "No such table: @tables";
     }
+    # Check if there is any real data in response
+    # One key ('xcatdsource' => '<node>') is always returned.
+    # If no other keys in response - no matches on key or attribute were returned from xcatd
+    if (keys @$responses[0] <= 1) {
+        @$responses[0]->{error} = "No table rows matched specified keys or attributes";
+    }
     return $responses;
 }
 

--- a/xCAT-test/autotest/testcase/restapi/table/cases0
+++ b/xCAT-test/autotest/testcase/restapi/table/cases0
@@ -19,6 +19,20 @@ check:rc==200
 check:output=~"mask":"255.0.0.0"
 end
 
+start:get_network_table_with_attr_selection_error_rest
+description: get all attribute matching networks table entries with REST API, invalid attribute name
+cmd:restapitest -m GET -r /tables/networks/rows/abc=255.0.0.0 -u $$username -p $$password
+check:rc==147
+check:output=~No table rows
+end
+
+start:get_network_table_with_attr_selection_error_rest2
+description: get all attribute matching networks table entries with REST API, no match
+cmd:restapitest -m GET -r /tables/networks/rows/mask=a.b.c.d -u $$username -p $$password
+check:rc==147
+check:output=~No table rows
+end
+
 start:get_network_table_with_attr_selection_rest2
 description: get attribute matching networks table attributes with REST API
 cmd:restapitest -m GET -r /tables/networks/rows/mask=255.0.0.0/gateway -u $$username -p $$password


### PR DESCRIPTION
#5148 
This pull request:
1. Handles cases when key is invalid or key does not match anything from the table
2. Adds automated testcases 

Before this PR:
```
[root@stratton01 xcat]# curl -X GET -k  'https://127.0.0.1/xcatws/tables/networks/rows/masks=255.0.0.0?userName=root&userPW=xxxxxxxx&pretty=1'
{
   "networks":[
      {
         "xcatdsource":"stratton01"
      }
   ]
}

[root@stratton01 xcat]#
```

After this PR:
```
[root@stratton01 xcat]# curl -X GET -k  'https://127.0.0.1/xcatws/tables/networks/rows/masks=255.0.0.0?userName=root&userPW=xxxxx&pretty=1'
{
   "errorcode":"1",
   "error":[
      "No table rows matched specified keys or attributes"
   ]
}

[root@stratton01 xcat]# curl -X GET -k  'https://127.0.0.1/xcatws/tables/networks/rows/mask=a.b.c.d?userName=root&userPW=xxxxx&pretty=1'
{
   "errorcode":"1",
   "error":[
      "No table rows matched specified keys or attributes"
   ]
}

[root@stratton01 xcat]#
```