### PR TITLE
Add test for issue 922

### DIFF
--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_flat
@@ -71,6 +71,16 @@ check:output=~64 bytes from $$CN
 cmd:xdsh $$CN  "cat /var/log/xcat/xcat.log"
 cmd:xdsh $$CN "cat /test.synclist"
 check:rc==0
+#add test for issue922
+cmd:xdsh $$CN  "ls -l /bin/ping"
+cmd:xdsh $$CN "ping -c 1 127.0.0.1"
+check:rc==0
+cmd:xdsh $$CN "useradd -m xcatuser"
+check:rc==0
+cmd:xdsh $$CN "su - xcatuser sh  -c \"ping -c 1 127.0.0.1\""
+check:rc==0
+cmd:xdsh $$CN "userdel xcatuser"
+check:rc==0
 cmd:if [[ -f /test.synclist.bak ]] ;then mv -f /test.synclist.bak /tmp/test.synclist;else rm -rf /test.synclist;fi
 cmd:chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute synclists=
 end

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_hierarchy
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_hierarchy
@@ -68,6 +68,16 @@ check:rc==0
 cmd:xdsh $$CN  "cat /var/log/xcat/xcat.log"
 cmd:xdsh $$CN "cat /test.synclist"
 check:rc==0
+#add test for issue922
+cmd:xdsh $$CN  "ls -l /bin/ping"
+cmd:xdsh $$CN "ping -c 1 127.0.0.1"
+check:rc==0
+cmd:xdsh $$CN "useradd -m xcatuser"
+check:rc==0
+cmd:xdsh $$CN "su - xcatuser sh  -c \"ping -c 1 127.0.0.1\""
+check:rc==0
+cmd:xdsh $$CN "userdel xcatuser"
+check:rc==0
 cmd:if [[ -f /test.synclist.bak ]] ;then mv -f /test.synclist.bak /test.synclist;else rm -rf /test.synclist;fi
 cmd:chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute synclists=
 end

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat
@@ -72,6 +72,16 @@ check:rc==0
 cmd:xdsh $$CN  "cat /var/log/xcat/xcat.log"
 cmd:xdsh $$CN  "cat /test.synclist"
 check:rc==0
+#add test for issue922
+cmd:xdsh $$CN  "ls -l /bin/ping"
+cmd:xdsh $$CN "ping -c 1 127.0.0.1"
+check:rc==0
+cmd:xdsh $$CN "useradd -m xcatuser"
+check:rc==0
+cmd:xdsh $$CN "su - xcatuser sh  -c \"ping -c 1 127.0.0.1\""
+check:rc==0
+cmd:xdsh $$CN "userdel xcatuser"
+check:rc==0
 cmd:if [[ -f /test.synclist.bak ]] ;then mv -f /test.synclist.bak /test.synclist;else rm -rf /test.synclist;fi
 cmd:chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute synclists=
 check:rc==0

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_hierarchy
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_hierarchy
@@ -73,6 +73,16 @@ cmd:rootimgdir=`lsdef -t osimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,ar
 check:rc==0
 cmd:xdsh $$CN  "cat /test.synclist"
 check:rc==0
+#add test for issue922
+cmd:xdsh $$CN  "ls -l /bin/ping"
+cmd:xdsh $$CN "ping -c 1 127.0.0.1"
+check:rc==0
+cmd:xdsh $$CN "useradd -m xcatuser"
+check:rc==0
+cmd:xdsh $$CN "su - xcatuser sh  -c \"ping -c 1 127.0.0.1\""
+check:rc==0
+cmd:xdsh $$CN "userdel xcatuser"
+check:rc==0
 cmd:if [[ -f /test.synclist.bak ]] ;then mv -f /test.synclist.bak /test.synclist;else rm -rf /test.synclist;fi
 cmd:chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute synclists=
 check:rc==0

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_flat
@@ -81,6 +81,16 @@ check:output=~$$CN: $$CN
 cmd:xdsh $$CN  "cat /var/log/xcat/xcat.log"
 cmd:xdsh $$CN "echo "test"> /test.statelite"
 check:rc!=0
+#add test for issue922
+cmd:xdsh $$CN  "ls -l /bin/ping"
+cmd:xdsh $$CN "ping -c 1 127.0.0.1"
+check:rc==0
+cmd:xdsh $$CN "useradd -m xcatuser"
+check:rc==0
+cmd:xdsh $$CN "su - xcatuser sh  -c \"ping -c 1 127.0.0.1\""
+check:rc==0
+cmd:xdsh $$CN "userdel xcatuser"
+check:rc==0
 cmd:output=$(xdsh $$CN ls -al / |grep test.statelite);if [[ $? -eq 0 ]];then  xdsh $$CN rm -rf /test.tatelite;fi
 cmd:rootimgdir=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir ]; then rm -rf $rootimgdir;fi
 check:rc==0
@@ -121,6 +131,16 @@ cmd:ping $$CN -c 3
 check:rc==0
 check:output=~64 bytes from $$CN
 cmd:xdsh $$CN  "cat /var/log/xcat/xcat.log"
+#add test for issue922
+cmd:xdsh $$CN  "ls -l /bin/ping"
+cmd:xdsh $$CN "ping -c 1 127.0.0.1"
+check:rc==0
+cmd:xdsh $$CN "useradd -m xcatuser"
+check:rc==0
+cmd:xdsh $$CN "su - xcatuser sh  -c \"ping -c 1 127.0.0.1\""
+check:rc==0
+cmd:xdsh $$CN "userdel xcatuser"
+check:rc==0
 cmd:rm -rf /tmp/image;mkdir /tmp/image
 check:rc==0
 cmd:imgexport __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute /tmp/image/image.tgz

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_nfs
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_nfs
@@ -101,6 +101,16 @@ check:output=~$$CN: $$CN
 cmd:xdsh $$CN  "cat /var/log/xcat/xcat.log"
 cmd:xdsh $$CN "echo "test"> /test.statelite"
 check:rc!=0
+#add test for issue922
+cmd:xdsh $$CN  "ls -l /bin/ping"
+cmd:xdsh $$CN "ping -c 1 127.0.0.1"
+check:rc==0
+cmd:xdsh $$CN "useradd -m xcatuser"
+check:rc==0
+cmd:xdsh $$CN "su - xcatuser sh  -c \"ping -c 1 127.0.0.1\""
+check:rc==0
+cmd:xdsh $$CN "userdel xcatuser"
+check:rc==0
 cmd:output=$(xdsh $$CN ls -al / |grep test.statelite);if [[ $? -eq 0 ]];then  xdsh $$CN rm -rf /test.tatelite;fi
 cmd:rootimgdir=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir ]; then rm -rf $rootimgdir;fi
 check:rc==0

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_ramdisk
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_ramdisk
@@ -93,6 +93,16 @@ cmd:xdsh $$CN hostname
 check:rc==0
 check:output=~$$CN: $$CN
 cmd:xdsh $$CN  "cat /var/log/xcat/xcat.log"
+#add test for issue922
+cmd:xdsh $$CN  "ls -l /bin/ping"
+cmd:xdsh $$CN "ping -c 1 127.0.0.1"
+check:rc==0
+cmd:xdsh $$CN "useradd -m xcatuser"
+check:rc==0
+cmd:xdsh $$CN "su - xcatuser sh  -c \"ping -c 1 127.0.0.1\""
+check:rc==0
+cmd:xdsh $$CN "userdel xcatuser"
+check:rc==0
 cmd:rootimgdir=`lsdef -t osimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir.regbak ]; then rm -rf $rootimgdir; mv $rootimgdir.regbak $rootimgdir; fi
 check:rc==0
 end


### PR DESCRIPTION
Add test for issue #922.
Related task is xcat2/xcat2-task-management#112

The related UT against ``reg_linux_diskfull_installation_flat`` on rhels7.5 are
```
.......
RUN:xdsh f6u13k15 "cat /test.synclist" [Tue May  8 03:08:05 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
f6u13k15: /test.synclist -> /test.synclist
CHECK:rc == 0	[Pass]

RUN:xdsh f6u13k15  "ls -l /bin/ping" [Tue May  8 03:08:05 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u13k15: -rwxr-xr-x. 1 root root 135976 May 22  2017 /bin/ping

RUN:xdsh f6u13k15 "ping -c 1 127.0.0.1" [Tue May  8 03:08:06 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u13k15: PING 127.0.0.1 (127.0.0.1) 56(84) bytes of data.
f6u13k15: 64 bytes from 127.0.0.1: icmp_seq=1 ttl=64 time=0.021 ms
f6u13k15:
f6u13k15: --- 127.0.0.1 ping statistics ---
f6u13k15: 1 packets transmitted, 1 received, 0% packet loss, time 0ms
f6u13k15: rtt min/avg/max/mdev = 0.021/0.021/0.021/0.000 ms
CHECK:rc == 0	[Pass]

RUN:xdsh f6u13k15 "useradd -m xcatuser" [Tue May  8 03:08:07 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xdsh f6u13k15 "su - xcatuser sh  -c \"ping -c 1 127.0.0.1\"" [Tue May  8 03:08:07 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u13k15: PING 127.0.0.1 (127.0.0.1) 56(84) bytes of data.
f6u13k15: 64 bytes from 127.0.0.1: icmp_seq=1 ttl=64 time=0.036 ms
f6u13k15:
f6u13k15: --- 127.0.0.1 ping statistics ---
f6u13k15: 1 packets transmitted, 1 received, 0% packet loss, time 0ms
f6u13k15: rtt min/avg/max/mdev = 0.036/0.036/0.036/0.000 ms
CHECK:rc == 0	[Pass]

RUN:xdsh f6u13k15 "userdel xcatuser" [Tue May  8 03:08:08 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]
........
```