### PR TITLE
Add test case for xcatprobe detect_dhcpd command 

### DIFF
--- a/xCAT-test/autotest/testcase/probe/detect_dhcpd
+++ b/xCAT-test/autotest/testcase/probe/detect_dhcpd
@@ -19,7 +19,7 @@ elif [ -e "/etc/SuSE-release" ]; then
 elif [ -e "/etc/lsb-release" ]; then
     dpkg -l|grep tcpdump
     if [ "$?" != "0" ] ;then
-        apt-get install -y
+        apt-get install -y tcpdump
     fi
 fi
 cmd:echo "$$CN" |tee /tmp/detect_dhcpd_work/cn

--- a/xCAT-test/autotest/testcase/probe/detect_dhcpd
+++ b/xCAT-test/autotest/testcase/probe/detect_dhcpd
@@ -1,0 +1,30 @@
+start:detect_dhcpd_work
+description:To test if xcatprobe detect_dhcpd works. This case must run in xcat mn
+cmd:if [ -d "/tmp/detect_dhcpd_work" ]; then mv /tmp/detect_dhcpd_work /tmp/detect_dhcpd_work.bak; fi; mkdir -p  /tmp/detect_dhcpd_work
+#cmd:makedhcp -n
+#check:rc == 0
+#cmd:makedhcp $$CN
+#check:rc == 0
+#cmd:#!/bin/bash
+#if [ -e "/etc/redhat-release" ]; then
+#   rpm -qa |grep tcpdump
+#   if [ "$?" != "0" ] ;then
+#       yum install -y tcpdump
+#   fi
+#elif [ -e "/etc/SuSE-release" ]; then
+#    rpm -qa |grep tcpdump
+#    if [ "$?" != "0" ] ;then
+#       zypper -n install tcpdump
+#    fi
+#elif [ -e "/etc/lsb-release" ]; then
+#    dpkg -l|grep tcpdump
+#    if [ "$?" != "0" ] ;then
+#        apt-get install -y
+#    fi
+#fi
+cmd:declare -a array=(`lsdef $$CN -i mac -c|awk -F"=" '{print $2}'|sed 's/|/ /g'`);for i in "${array[@]}"; do if ! echo $i|grep -q  NOIP;then echo "$i" > /tmp/detect_dhcpd_work/mac;break;fi;done;
+cmd:mac=`cat /tmp/detect_dhcpd_work/mac`; mn=`lsdef -t site -i master -c|awk -F"=" '{print $2}'`;nic=`ip -4 -o a|grep $mn|awk -F" " '{print $2}'`;xcatprobe detect_dhcpd -i $nic -m $mac
+check:output !~ There are 0 servers replied to dhcp discover
+check:output =~ The next server is
+#cmd:rm -rf /tmp/detect_dhcpd_work; if [ -d "/tmp/detect_dhcpd_work.bak" ]; then mv /tmp/detect_dhcpd_work.bak /tmp/detect_dhcpd_work;fi
+end

--- a/xCAT-test/autotest/testcase/probe/detect_dhcpd
+++ b/xCAT-test/autotest/testcase/probe/detect_dhcpd
@@ -1,30 +1,45 @@
 start:detect_dhcpd_work
 description:To test if xcatprobe detect_dhcpd works. This case must run in xcat mn
 cmd:if [ -d "/tmp/detect_dhcpd_work" ]; then mv /tmp/detect_dhcpd_work /tmp/detect_dhcpd_work.bak; fi; mkdir -p  /tmp/detect_dhcpd_work
-#cmd:makedhcp -n
-#check:rc == 0
-#cmd:makedhcp $$CN
-#check:rc == 0
-#cmd:#!/bin/bash
-#if [ -e "/etc/redhat-release" ]; then
-#   rpm -qa |grep tcpdump
-#   if [ "$?" != "0" ] ;then
-#       yum install -y tcpdump
-#   fi
-#elif [ -e "/etc/SuSE-release" ]; then
-#    rpm -qa |grep tcpdump
-#    if [ "$?" != "0" ] ;then
-#       zypper -n install tcpdump
-#    fi
-#elif [ -e "/etc/lsb-release" ]; then
-#    dpkg -l|grep tcpdump
-#    if [ "$?" != "0" ] ;then
-#        apt-get install -y
-#    fi
-#fi
-cmd:declare -a array=(`lsdef $$CN -i mac -c|awk -F"=" '{print $2}'|sed 's/|/ /g'`);for i in "${array[@]}"; do if ! echo $i|grep -q  NOIP;then echo "$i" > /tmp/detect_dhcpd_work/mac;break;fi;done;
-cmd:mac=`cat /tmp/detect_dhcpd_work/mac`; mn=`lsdef -t site -i master -c|awk -F"=" '{print $2}'`;nic=`ip -4 -o a|grep $mn|awk -F" " '{print $2}'`;xcatprobe detect_dhcpd -i $nic -m $mac
+cmd:makedhcp -n
+check:rc == 0
+cmd:makedhcp $$CN
+check:rc == 0
+cmd:#!/bin/bash
+if [ -e "/etc/redhat-release" ]; then
+   rpm -qa |grep tcpdump
+   if [ "$?" != "0" ] ;then
+       yum install -y tcpdump
+   fi
+elif [ -e "/etc/SuSE-release" ]; then
+    rpm -qa |grep tcpdump
+    if [ "$?" != "0" ] ;then
+       zypper -n install tcpdump
+    fi
+elif [ -e "/etc/lsb-release" ]; then
+    dpkg -l|grep tcpdump
+    if [ "$?" != "0" ] ;then
+        apt-get install -y
+    fi
+fi
+cmd:echo "$$CN" |tee /tmp/detect_dhcpd_work/cn
+cmd: #!/bin/bash
+cn=`cat /tmp/detect_dhcpd_work/cn`
+mac=""
+nic=""
+declare -a array=(`lsdef $cn -i mac -c|awk -F"=" '{print $2}'|sed 's/|/ /g'`)
+for i in "${array[@]}"
+do 
+    if ! echo $i|grep -q  NOIP
+    then 
+       mac=$i
+       break
+    fi
+done
+mn=`lsdef -t site -i master -c|awk -F"=" '{print $2}'`
+nic=`ip -4 -o a|grep $mn|awk -F" " '{print $2}'`
+xcatprobe -w detect_dhcpd -i $nic -m $mac
 check:output !~ There are 0 servers replied to dhcp discover
-check:output =~ The next server is
-#cmd:rm -rf /tmp/detect_dhcpd_work; if [ -d "/tmp/detect_dhcpd_work.bak" ]; then mv /tmp/detect_dhcpd_work.bak /tmp/detect_dhcpd_work;fi
+check:output =~ Server:__GETTABLEVALUE(key,master,value,site)__ assign IP .+__GETNODEATTR($$CN,ip)__ 
+cmd:rm -rf /tmp/detect_dhcpd_work; if [ -d "/tmp/detect_dhcpd_work.bak" ]; then mv /tmp/detect_dhcpd_work.bak /tmp/detect_dhcpd_work;fi
 end


### PR DESCRIPTION
Add test for issue #4028.
Related task is xcat2/xcat2-task-management#85

The UT result:

```
------START::detect_dhcpd_work::Time:Tue May  8 23:28:58 2018------

RUN:if [ -d "/tmp/detect_dhcpd_work" ]; then mv /tmp/detect_dhcpd_work /tmp/detect_dhcpd_work.bak; fi; mkdir -p  /tmp/detect_dhcpd_work [Tue May  8 23:28:58 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:makedhcp -n [Tue May  8 23:28:58 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Warning: No dynamic range specified for 10.0.0.0. If hardware discovery is being used, a dynamic range is required.
Renamed existing dhcp configuration file to  /etc/dhcp/dhcpd.conf.xcatbak

CHECK:rc == 0	[Pass]

RUN:makedhcp c910f04x35v04 [Tue May  8 23:28:58 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN: [Tue May  8 23:28:59 2018]
#!/bin/bash
if [ -e "/etc/redhat-release" ]; then
   rpm -qa |grep tcpdump
   if [ "$?" != "0" ] ;then
       yum install -y tcpdump
   fi
elif [ -e "/etc/SuSE-release" ]; then
    rpm -qa |grep tcpdump
    if [ "$?" != "0" ] ;then
       zypper -n install tcpdump
    fi
elif [ -e "/etc/lsb-release" ]; then
    dpkg -l|grep tcpdump
    if [ "$?" != "0" ] ;then
        apt-get install -y
    fi
fi
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
tcpdump-4.0.0-11.20090921gitdf3cb4.2.el6.x86_64

RUN:echo "c910f04x35v04" |tee /tmp/detect_dhcpd_work/cn [Tue May  8 23:29:00 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
c910f04x35v04

RUN: [Tue May  8 23:29:00 2018]
#!/bin/bash
cn=`cat /tmp/detect_dhcpd_work/cn`
mac=""
nic=""
declare -a array=(`lsdef $cn -i mac -c|awk -F"=" '{print $2}'|sed 's/|/ /g'`)
for i in "${array[@]}"
do
    if ! echo $i|grep -q  NOIP
    then
       mac=$i
       break
    fi
done
mn=`lsdef -t site -i master -c|awk -F"=" '{print $2}'`
nic=`ip -4 -o a|grep $mn|awk -F" " '{print $2}'`
xcatprobe -w detect_dhcpd -i $nic -m $mac
ElapsedTime:15 sec
RETURN rc = 0
OUTPUT:
Start to detect DHCP, please wait 10 seconds                              [INFO]
++++++++++++++++++++++++++++++++++                                        [INFO]
There are 1 servers replied to dhcp discover.                             [INFO]
    Server:10.4.35.2 assign IP [10.4.35.4]. The next server is [10.4.35.3]!                                                                               [INFO]
++++++++++++++++++++++++++++++++++                                        [INFO]
CHECK:output !~ There are 0 servers replied to dhcp discover	[Pass]
CHECK:output =~ Server:10.4.35.2 assign IP .+10.4.35.4	[Pass]

RUN:rm -rf /tmp/detect_dhcpd_work; if [ -d "/tmp/detect_dhcpd_work.bak" ]; then mv /tmp/detect_dhcpd_work.bak /tmp/detect_dhcpd_work;fi [Tue May  8 23:29:15 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::detect_dhcpd_work::Passed::Time:Tue May  8 23:29:15 2018 ::Duration::17 sec------
```