### PR TITLE
make store_fd does not thow exception and the client could be closed.

### DIFF
--- a/perl-xCAT/xCAT/Table.pm
+++ b/perl-xCAT/xCAT/Table.pm
@@ -351,7 +351,7 @@ sub init_dbworker {
                             xCAT::MsgUtils->message("S", "xcatd: possible BUG encountered by xCAT DB worker " . $err);
                             if ($currcon) {
                                 eval {  #avoid hang by allowin client to die too
-                                    store_fd("*XCATBUGDETECTED*:$err:*XCATBUGDETECTED*\n", $currcon);
+                                    store_fd(["*XCATBUGDETECTED*:$err:*XCATBUGDETECTED*\n"], $currcon);
                                     $clientset->remove($currcon);
                                     close($currcon);
                                 };


### PR DESCRIPTION
Partial fix #5150 
when run some wrong code, the DB operation will failed. And by design, it could close the socket with DB process, just for a code error(store_fd), now it won't close the socket correctly.

So the plugin which cause DB exception will not quit. And after fix, the plugin could be quit with error.

```
curl -X DELETE -k  'https://127.0.0.1/xcatws/tables/networks/rows/masks=255.0.0.0?userName=root&userPW=cluster&pretty=1'

ps -ef|grep xcatd
root     127847      1  0 05:38 ?        00:00:00 xcatd: SSL listener
root     127848 127847  3 05:38 ?        00:00:01 xcatd: DB Access
root     127849 127847  0 05:38 ?        00:00:00 xcatd: UDP listener
root     127850 127847  0 05:38 ?        00:00:00 xcatd: install monitor
root     127851 127849  0 05:38 ?        00:00:00 xcatd: Discovery worker
root     127852 127847  0 05:38 ?        00:00:00 xcatd: Command log writer
root     128105 127847  3 05:39 ?        00:00:00 xcatd SSL: getipmicons to fs2 for root@localhost
root     128106 128105  0 05:39 ?        00:00:00 xcatd SSL: getipmicons to fs2 for root@localhost: ipmi instance
root     128135  79727  0 05:39 pts/37   00:00:00 grep --color=auto xcatd
```