### PR TITLE
OpenBMC rinv more specific REST calls

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_flash.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_flash.py
@@ -528,7 +528,7 @@ class OpenBMCFlashTask(ParallelNodesCommand):
         try:
             obmc.login()
             # Before uploading file, check CPU DD version
-            inventory_info_dict = obmc.get_inventory_info()
+            inventory_info_dict = obmc.get_inventory_info('cpu')
             cpu_info = inventory_info_dict["CPU"]
             for info in cpu_info:
                 if info.startswith("CPU0 Version : 20"):

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_inventory.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_inventory.py
@@ -83,7 +83,7 @@ class OpenBMCInventoryTask(ParallelNodesCommand):
         inventory_info = []
         try:
             obmc.login()
-            inventory_info_dict = obmc.get_inventory_info()
+            inventory_info_dict = obmc.get_inventory_info(inventory_type)
 
             if inventory_type == 'all' or not inventory_type:
                 keys = inventory_info_dict.keys()


### PR DESCRIPTION
#5158 
Depending on a `rinv` option specified, call the specific REST API to get just that data, instead of getting all inventory data and filtering our output later.
No external input or output changes.