### PR TITLE
use tar as the default archive method instead of cpio

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/packimage.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/packimage.1.rst
@@ -53,7 +53,7 @@ OPTIONS
 
 \ **-v**\           Command Version.
 
-\ **-m| -**\ **-method**\           Archive Method (cpio,tar,squashfs, default is cpio)
+\ **-m| -**\ **-method**\           Archive Method (cpio,tar,squashfs, default is tar)
 
 \ **-c| -**\ **-compress**\           Compress Method (pigz,gzip,xz, default is pigz/gzip)
 

--- a/xCAT-client/pods/man1/packimage.1.pod
+++ b/xCAT-client/pods/man1/packimage.1.pod
@@ -27,7 +27,7 @@ B<-h>          Display usage message.
 
 B<-v>          Command Version.
 
-B<-m| --method>          Archive Method (cpio,tar,squashfs, default is cpio)
+B<-m| --method>          Archive Method (cpio,tar,squashfs, default is tar)
 
 B<-c| --compress>          Compress Method (pigz,gzip,xz, default is pigz/gzip)
 

--- a/xCAT-server/lib/xcat/plugins/packimage.pm
+++ b/xCAT-server/lib/xcat/plugins/packimage.pm
@@ -89,7 +89,7 @@ sub process_request {
     my $osver;
     my $arch;
     my $profile;
-    my $method = 'cpio';
+    my $method = 'tar';
     my $compress;
     my $exlistloc;
     my $syncfile;


### PR DESCRIPTION
for issue https://github.com/xcat2/xcat-core/issues/922:

use tar as the default archive method instead of cpio 

UT:

```
[root@boston02 xCAT_plugin]# packimage rhels7.5-alt-rc2-ppc64le-netboot-compute
Packing contents of /install/netboot/rhels7.5-alternate/ppc64le/service/rootimg
archive method:tar
compress method:gzip

```