### PR TITLE
add a case to support regex for makehosts

### DIFF
--- a/xCAT-test/autotest/testcase/makehosts/cases0
+++ b/xCAT-test/autotest/testcase/makehosts/cases0
@@ -171,3 +171,27 @@ cmd:if [ -e /tmp/s01r1b01.standa ]; then rmdef s01r1b01; cat /tmp/s01r1b01.stand
 check:rc==0
 cmd:mv -f /etc/hosts.xcatbakautotest /etc/hosts
 end
+
+start:makehosts_regex
+description:this case is to test if makehosts support regex. This case is for bug 2578.
+cmd:cp /etc/hosts /etc/hosts.bak
+cmd:if lsdef -z sn4b;then lsdef -z sn4b|tee /tmp/sn4bdef;noderm sn4b;fi
+cmd:if lsdef -t group -z regextest;then lsdef -t group -z regextest |tee /tmp/regextestdef;rmdef -t group -o regextest;fi
+cmd:if grep sn4b /etc/hosts;then sed -i '/sn4b/d' /etc/hosts;fi
+check:rc==0
+cmd:mkdef -t node sn4b groups=compute
+check:rc==0
+cmd:mkdef -t group regextest ip="|\D+(\d+)\D+|20.80.1.($1*2+103)|" members=sn4b nichostnamesuffixes.eth0=-eth0 nicips.eth0="|\D+(\d+)\D+|10.80.1.($1*2+103)|" nicnetworks.eth0=10_0_0_0-255_0_0_0
+check:rc==0
+cmd:lsdef -t group regex
+check:rc==0
+cmd:makehosts sn4b
+check:rc==0
+cmd:sn4bip=`lsdef sn4b |grep -w ip|awk -F= '{print $2}'`;grep $sn4bip /etc/hosts
+check:rc==0
+cmd:sn4beth0ip=`lsdef sn4b |grep -w nicips.eth0|awk -F= '{print $2}'`;grep $sn4beth0ip /etc/hosts
+check:rc==0
+cmd:cp -f /etc/hosts.bak /etc/hosts
+cmd:noderm sn4b;if [ -e /tmp/sn4bdef ]; then cat /tmp/sn4bdef |mkdef -z;fi
+cmd:rmdef -t group -o regextest;if [ -e /tmp/regextestdef ]; then cat /tmp/regextestdef |mkdef -z;fi
+end

--- a/xCAT-test/autotest/testcase/makehosts/cases0
+++ b/xCAT-test/autotest/testcase/makehosts/cases0
@@ -183,7 +183,7 @@ cmd:mkdef -t node sn4b groups=compute
 check:rc==0
 cmd:mkdef -t group regextest ip="|\D+(\d+)\D+|20.80.1.($1*2+103)|" members=sn4b nichostnamesuffixes.eth0=-eth0 nicips.eth0="|\D+(\d+)\D+|10.80.1.($1*2+103)|" nicnetworks.eth0=10_0_0_0-255_0_0_0
 check:rc==0
-cmd:lsdef -t group regex
+cmd:lsdef -t group regextest
 check:rc==0
 cmd:makehosts sn4b
 check:rc==0


### PR DESCRIPTION
Case Name: makehosts_regex
description:this case is to test if makehosts support regex. This case is for bug #2578.

UT result
```
xCAT automated test started at Thu May 10 01:09:16 2018
******************************
loading Configure file
******************************
Varible:
    CN = mid05tor26
    CUMULUSOS = /cumulus-linux-3.5.2-bcm-armel.bin
    MN = mid05tor12cn05
******************************
Initialize xCAT test environment by definition in configure file
******************************
******************************
To detect current test environment
******************************
Detecting: OS = linux
Detecting: ARCH = ppc64le
Detecting: HCP = switch
******************************
loading test cases
******************************
To run:
makehosts_regex
******************************
Start to run test cases
******************************
------START::makehosts_regex::Time:Thu May 10 01:09:17 2018------

RUN:cp /etc/hosts /etc/hosts.bak [Thu May 10 01:09:17 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:if lsdef -z sn4b;then lsdef -z sn4b|tee /tmp/sn4bdef;noderm sn4b;fi [Thu May 10 01:09:17 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
# <xCAT data object stanza file>

sn4b:
    objtype=node
    groups=compute
# <xCAT data object stanza file>

sn4b:
    objtype=node
    groups=compute

RUN:if lsdef -t group -z regextest;then lsdef -t group -z regextest |tee /tmp/regextestdef;rmdef -t group -o regextest;fi [Thu May 10 01:09:18 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
# <xCAT data object stanza file>

regextest:
    objtype=group
    grouptype=static
    ip=|\D+(\d+)\D+|20.80.1.(*2+103)|
    members=
    nichostnamesuffixes.eth0=-eth0
    nicips.eth0=|\D+(\d+)\D+|10.80.1.(*2+103)|
    nicnetworks.eth0=10_0_0_0-255_0_0_0
# <xCAT data object stanza file>

regextest:
    objtype=group
    grouptype=static
    ip=|\D+(\d+)\D+|20.80.1.(*2+103)|
    members=
    nichostnamesuffixes.eth0=-eth0
    nicips.eth0=|\D+(\d+)\D+|10.80.1.(*2+103)|
    nicnetworks.eth0=10_0_0_0-255_0_0_0
1 object definitions have been removed.

RUN:if grep sn4b /etc/hosts;then sed -i '/sn4b/d' /etc/hosts;fi [Thu May 10 01:09:19 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:mkdef -t node sn4b groups=compute [Thu May 10 01:09:19 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:mkdef -t group regextest ip="|\D+(\d+)\D+|20.80.1.($1*2+103)|" members=sn4b nichostnamesuffixes.eth0=-eth0 nicips.eth0="|\D+(\d+)\D+|10.80.1.($1*2+103)|" nicnetworks.eth0=10_0_0_0-255_0_0_0 [Thu May 10 01:09:20 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:lsdef -t group regex [Thu May 10 01:09:21 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Object name: regex
    grouptype=static
    ip=|\D+(\d+)\D+|20.80.1.(*2+103)|
    members=
    nichostnamesuffixes.eth0=-eth0
    nicips.eth0=|\D+(\d+)\D+|10.80.1.(*2+103)|
    nicnetworks.eth0=10_0_0_0-255_0_0_0
CHECK:rc == 0	[Pass]

RUN:makehosts sn4b [Thu May 10 01:09:21 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:sn4bip=`lsdef sn4b |grep -w ip|awk -F= '{print $2}'`;grep $sn4bip /etc/hosts [Thu May 10 01:09:21 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
20.80.1.103 sn4b sn4b.pok.stglabs.ibm.com
CHECK:rc == 0	[Pass]

RUN:sn4beth0ip=`lsdef sn4b |grep -w nicips.eth0|awk -F= '{print $2}'`;grep $sn4beth0ip /etc/hosts [Thu May 10 01:09:22 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
10.80.1.103 sn4b-eth0 sn4b-eth0.pok.stglabs.ibm.com
CHECK:rc == 0	[Pass]

RUN:cp -f /etc/hosts.bak /etc/hosts [Thu May 10 01:09:22 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:noderm sn4b;if [ -e /tmp/sn4bdef ]; then cat /tmp/sn4bdef |mkdef -z;fi [Thu May 10 01:09:22 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.

RUN:rmdef -t group -o regextest;if [ -e /tmp/regextestdef ]; then cat /tmp/regextestdef |mkdef -z;fi [Thu May 10 01:09:23 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
Warning: Cannot determine a member list for group 'regextest'.
1 object definitions have been created or modified.

------END::makehosts_regex::Passed::Time:Thu May 10 01:09:24 2018 ::Duration::7 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished at Thu May 10 01:09:24 2018
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20180510010916 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20180510010916 file for time consumption
```