### PR TITLE
modify ipmi rsp check to support openbmc ipmi interface

### DIFF
--- a/xCAT-server/lib/perl/xCAT/IPMI.pm
+++ b/xCAT-server/lib/perl/xCAT/IPMI.pm
@@ -679,9 +679,14 @@ sub handle_ipmi_packet {
             if ($rsp[5] & 0b10000000) {
                 $encrypted = 1;
             }
+
+#------------------------modified to support openbmc ipmi command----------------
             unless ($rsp[5] & 0b01000000) {
-                return 3; #we refuse to examine unauthenticated packets in this context
+                if ($self->{max_privilege} != 0) {
+                    return 3; #we refuse to examine unauthenticated packets in this context
+                }
             }
+
             splice(@rsp, 0, 4);    #ditch the rmcp header
             my @authcode = splice(@rsp, -12); #strip away authcode and remember it
             my @expectedcode = unpack("C*", hmac_sha1(pack("C*", @rsp), $self->{k1}));
@@ -763,10 +768,13 @@ sub got_rmcp_response {
         return 9;
     }
     $byte = shift @data;
-    unless ($byte >= 4) {
+
+    # add $byte == 0 to support openbmc ipmi command
+    unless ($byte >= 4 or $byte == 0) {
         $self->{onlogon}->("ERROR: Cannot acquire sufficient privilege", $self->{onlogon_args});
         return 9;
     }
+    $self->{max_privilege} = $byte if ($byte == 0);
     splice @data, 0, 5;
     $self->{pendingsessionid} = [ splice @data, 0, 4 ];
 


### PR DESCRIPTION
https://github.ibm.com/vhu/c910env/issues/266

UT of output:
```
mid05tor12cn15-ipmi: [ipmi_debug] rpower: stat(stat), raw_cmd: netfn(0x06=>App), cmd(0x38=>Get Channel Authentication Capabilities), data=[142, 4]
mid05tor12cn15-ipmi: [ipmi_debug] rpower: stat(stat), raw_cmd: netfn(0x06=>App), cmd(0x3b=>Set session privilege level), data=[4]
mid05tor12cn15-ipmi: [ipmi_debug] rpower: stat(stat), raw_cmd: netfn(0x06=>App), cmd(0x01=>Get Device ID), data=[]
mid05tor12cn15-ipmi: [ipmi_debug] rpower: stat(stat), raw_cmd: netfn(0x00=>Chassis), cmd(0x01=>Get Chassis Status), data=[]
mid05tor12cn15-ipmi: on
mid05tor12cn15-ipmi: [ipmi_debug] rpower: stat(stat), raw_cmd: netfn(0x06=>App), cmd(0x3c=>Close Session), data=[63, 190, 25, 0]
```
1. For step 1, received level is 0, make it continue.
``Maximum privilege level            : Unknown (0x00)``

2. For step 2, received unauthenticated msg( ``$rsp[5]`` is 128), make it continue.