### PR TITLE
Further modification for adding test case for 922

### DIFF
--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_flat
@@ -51,6 +51,8 @@ check:rc==0
 
 cmd:genimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
 check:rc==0
+cmd:rootimagedir=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute  -i  rootimgdir -c|awk -F"=" '{print $2}'`; chroot $rootimagedir/rootimg useradd xcatuser
+check:rc==0
 cmd:liteimg  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
 check:rc==0
 
@@ -85,11 +87,7 @@ check:rc!=0
 cmd:xdsh $$CN  "ls -l /bin/ping"
 cmd:xdsh $$CN "ping -c 1 127.0.0.1"
 check:rc==0
-cmd:xdsh $$CN "useradd -m xcatuser"
-check:rc==0
 cmd:xdsh $$CN "su - xcatuser sh  -c \"ping -c 1 127.0.0.1\""
-check:rc==0
-cmd:xdsh $$CN "userdel xcatuser"
 check:rc==0
 cmd:output=$(xdsh $$CN ls -al / |grep test.statelite);if [[ $? -eq 0 ]];then  xdsh $$CN rm -rf /test.tatelite;fi
 cmd:rootimgdir=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir ]; then rm -rf $rootimgdir;fi

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_nfs
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_nfs
@@ -69,6 +69,8 @@ check:rc==0
 
 cmd:genimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
 check:rc==0
+cmd:rootimagedir=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute  -i  rootimgdir -c|awk -F"=" '{print $2}'`; chroot $rootimagedir/rootimg useradd xcatuser
+check:rc==0
 cmd:liteimg __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
 check:rc==0
 cmd:prsync /install $$SN:/
@@ -105,11 +107,7 @@ check:rc!=0
 cmd:xdsh $$CN  "ls -l /bin/ping"
 cmd:xdsh $$CN "ping -c 1 127.0.0.1"
 check:rc==0
-cmd:xdsh $$CN "useradd -m xcatuser"
-check:rc==0
 cmd:xdsh $$CN "su - xcatuser sh  -c \"ping -c 1 127.0.0.1\""
-check:rc==0
-cmd:xdsh $$CN "userdel xcatuser"
 check:rc==0
 cmd:output=$(xdsh $$CN ls -al / |grep test.statelite);if [[ $? -eq 0 ]];then  xdsh $$CN rm -rf /test.tatelite;fi
 cmd:rootimgdir=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir ]; then rm -rf $rootimgdir;fi


### PR DESCRIPTION
Related issue #922
Related task xcat2/xcat2-task-management#112

Due to the disk of nfs based statelite cn can not be written, so can not add user directly after provision, so add non-root user into image after genimage. 

The output before fixing:
```
RUN:xdsh f6u13k15 "useradd -m xcatuser" [Wed May  9 11:32:10 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
f6u13k15: useradd: cannot lock /etc/passwd; try again later.
CHECK:rc == 0   [Failed]

RUN:xdsh f6u13k15 "su - xcatuser sh  -c \"ping -c 1 127.0.0.1\"" [Wed May  9 11:32:11 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f6u13k15: su: user xcatuser does not exist
```
After fixing :
```
....
RUN:rootimagedir=`lsdef -t osimage __GETNODEATTR(f6u13k15,os)__-__GETNODEATTR(f6u13k15,arch)__-statelite-compute  -i  rootimgdir -c|awk -F"=" '{print $2}'`; chroot $rootimagedir/rootimg useradd xcatuser [Thu May 10 04:24:27 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]
....
RUN:xdsh f6u13k15  "ls -l /bin/ping" [Thu May 10 04:32:56 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
f6u13k15: -rwxr-xr-x 1 root root 135976 May 22  2017 /bin/ping

RUN:xdsh f6u13k15 "ping -c 1 127.0.0.1" [Thu May 10 04:32:56 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u13k15: PING 127.0.0.1 (127.0.0.1) 56(84) bytes of data.
f6u13k15: 64 bytes from 127.0.0.1: icmp_seq=1 ttl=64 time=0.014 ms
f6u13k15:
f6u13k15: --- 127.0.0.1 ping statistics ---
f6u13k15: 1 packets transmitted, 1 received, 0% packet loss, time 0ms
f6u13k15: rtt min/avg/max/mdev = 0.014/0.014/0.014/0.000 ms

RUN:xdsh f6u13k15 "su - xcatuser sh  -c \"ping -c 1 127.0.0.1\"" [Thu May 10 04:32:57 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
f6u13k15: ping: socket: Operation not permitted
.....
```
