### PR TITLE
Force chain to be standby if only runcmd/ondiscover is specified for chain attribute

### DIFF
--- a/xCAT-server/lib/xcat/plugins/destiny.pm
+++ b/xCAT-server/lib/xcat/plugins/destiny.pm
@@ -848,6 +848,10 @@ sub nextdestiny {
         }
         unless ($ref->{currchain}) {    #If no current chain, copy the default
             $ref->{currchain} = $ref->{chain};
+        } else {
+            if ($ref->{currstate} and ($ref->{currstate} eq $ref->{currchain})) {
+                $ref->{currchain} = 'standby';
+            }
         }
         my @chain = split /[,;]/, $ref->{currchain};
 

--- a/xCAT-server/lib/xcat/plugins/destiny.pm
+++ b/xCAT-server/lib/xcat/plugins/destiny.pm
@@ -848,9 +848,10 @@ sub nextdestiny {
         }
         unless ($ref->{currchain}) {    #If no current chain, copy the default
             $ref->{currchain} = $ref->{chain};
-        } else {
-            if ($ref->{currstate} and ($ref->{currstate} eq $ref->{currchain})) {
+        } elsif ($ref->{currchain} !~ /[,;]/){
+            if ($ref->{currstate} and ($ref->{currchain} =~ /$ref->{currstate}/)) {
                 $ref->{currchain} = 'standby';
+                $callnodeset = 0;
             }
         }
         my @chain = split /[,;]/, $ref->{currchain};


### PR DESCRIPTION
Just partly fix the issue #5098, ondiscover/runcmd won't loop when using `nextdistiny`.
For current code login in destiny.pm, the nextdestiny will cause loop if set ondiscover=xxx or runcmd=xxx at the end of `chain` attribute.
In this PR, if it check the `currchain` equal `currstate`, `nextdestiny` will return `standby` instead of `currchain`which will cause `ondiscover` or `runcmd` run once and once again.

Before fix (from console log):
```
[2018-05-10T03:12:58-04:00] <166>May  7 03:19:20 xcat.genesis.bmcsetup: Set the cipher_privileges for the channel
[2018-05-10T03:12:59-04:00] <166>May  7 03:19:20 xcat.genesis.bmcsetup: Set the cipher_privileges for the channel: OK
[2018-05-10T03:12:59-04:00] <166>May  7 03:19:20 xcat.genesis.bmcsetup: Enabling SOL for channel 1
[2018-05-10T03:12:59-04:00] <166>May  7 03:19:20 xcat.genesis.bmcsetup: Enabling SOL for channel 1: OK
[2018-05-10T03:12:59-04:00] <166>May  7 03:19:20 xcat.genesis.bmcsetup: Enabling SOL for ADMIN
[2018-05-10T03:12:59-04:00] <166>May  7 03:19:20 xcat.genesis.bmcsetup: Enabling SOL for ADMIN: OK
[2018-05-10T03:12:59-04:00] <166>May  7 03:19:20 xcat.genesis.bmcsetup: Lighting Identify Light
[2018-05-10T03:12:59-04:00] Chassis identify interval: 250 seconds
[2018-05-10T03:12:59-04:00] <166>May  7 03:19:20 xcat.genesis.doxcat: Running nextdestiny 10.6.29.1:3001...
[2018-05-10T03:12:59-04:00]                                                     
[2018-05-10T03:12:59-04:00] <166>May  7 03:19:21 xcat.genesis.doxcat: nextdestiny - Complete.
[2018-05-10T03:12:59-04:00] <166>May  7 03:19:21 xcat.genesis.doxcat: The destiny=runcmd, destiny parameters=bmcsetup                   ==> next destiny is runcmd again after the above bmcsetup
```
After fix:
```
[2018-05-10T04:29:52-04:00] <166>May  7 04:36:13 xcat.genesis.bmcsetup: Enabling SOL for channel 1: OK
[2018-05-10T04:29:52-04:00] <166>May  7 04:36:13 xcat.genesis.bmcsetup: Enabling SOL for ADMIN
[2018-05-10T04:29:52-04:00] <166>May  7 04:36:13 xcat.genesis.bmcsetup: Enabling SOL for ADMIN: OK
[2018-05-10T04:29:52-04:00] <166>May  7 04:36:13 xcat.genesis.bmcsetup: Lighting Identify Light
[2018-05-10T04:29:52-04:00] Chassis identify interval: 250 seconds
[2018-05-10T04:29:52-04:00] <166>May  7 04:36:13 xcat.genesis.doxcat: Running nextdestiny 10.6.29.1:3001...
[2018-05-10T04:29:52-04:00]                                                          
[2018-05-10T04:29:52-04:00] <166>May  7 04:36:14 xcat.genesis.doxcat: nextdestiny - Complete.
[2018-05-10T04:29:52-04:00] <166>May  7 04:36:14 xcat.genesis.doxcat: The destiny=standby, destiny parameters=standby
```