### PR TITLE
Add back ntp-wait for building genesis-base on pegas

### DIFF
--- a/xCAT-genesis-builder/buildrpm
+++ b/xCAT-genesis-builder/buildrpm
@@ -144,6 +144,20 @@ libnss_pkgname=`find /usr/lib64/ -name libnss_dns-2*.so | xargs basename`
 sed -i "s/\/lib64\/libnss_dns-2.12.so/\/usr\/lib64\/$libnss_pkgname/g" $DRACUTMODDIR/install
 sed -i 's/\/lib64\/libnss_dns.so.2/\/usr\/lib64\/libnss_dns.so.2/' $DRACUTMODDIR/install
 
+# Based on cmdlist_check, makesure the commands are included in $DRACUTMODDIR/install
+if [ -e "${DRACUTMODDIR}/cmdlist_check" ]; then
+    miss_cmd=0
+    for cmd in `cat ${DRACUTMODDIR}/cmdlist_check`; do
+        if ! grep $cmd $DRACUTMODDIR/install; then
+            echo "The $cmd is missed in install file"
+            miss_cmd=1
+        fi
+    done
+    if [ "$miss_cmd" = 1 ]; then
+        exit 1
+    fi
+fi
+
 mkdir -p /tmp/xcatgenesis.$$/opt/xcat/share/xcat/netboot/genesis/$BUILDARCH/fs 
 
 # run dracut

--- a/xCAT-genesis-builder/buildrpm
+++ b/xCAT-genesis-builder/buildrpm
@@ -133,7 +133,6 @@ elif [ $BUILDARCH = "ppc64" ]; then
            sed -i 's/ mkreiserfs//' $DRACUTMODDIR/install
            sed -i 's/ reiserfstune//' $DRACUTMODDIR/install
            sed -i 's/ vconfig//' $DRACUTMODDIR/install
-           sed -i 's/ ntp-wait//' $DRACUTMODDIR/install
         fi
         sed -i 's/ efibootmgr//' $DRACUTMODDIR/install
         sed -i 's/ dmidecode//' $DRACUTMODDIR/install

--- a/xCAT-genesis-builder/buildrpm
+++ b/xCAT-genesis-builder/buildrpm
@@ -149,7 +149,7 @@ if [ -e "${DRACUTMODDIR}/cmdlist_check" ]; then
     miss_cmd=0
     for cmd in `cat ${DRACUTMODDIR}/cmdlist_check`; do
         if ! grep $cmd $DRACUTMODDIR/install; then
-            echo "The $cmd is missed in install file"
+            echo "ERROR: The required $cmd is not included in the install file to build the Genesis base package"
             miss_cmd=1
         fi
     done

--- a/xCAT-genesis-builder/cmdlist_check
+++ b/xCAT-genesis-builder/cmdlist_check
@@ -1,0 +1,1 @@
+ntp-wait

--- a/xCAT-test/autotest/testcase/install_xCAT/case0
+++ b/xCAT-test/autotest/testcase/install_xCAT/case0
@@ -18,10 +18,6 @@ check:output=~Version
 cmd:service xcatd status
 check:rc==0
 check:output=~running
-cmd:rpm -ql xCAT-genesis-base-x86_64 |grep ntp-wait
-check:rc==0
-cmd:rpm -ql xCAT-genesis-base-ppc64 |grep ntp-wait
-check:rc==0
 cmd:rm -rf /install_xCAT_xcat-core.tar.bz2 /install_xCAT_xcat-dep.tar.bz2
 end
 
@@ -47,10 +43,6 @@ check:output=~Version
 cmd:service xcatd status
 check:rc==0
 check:output=~running
-cmd:dpkg -L xcat-genesis-base-ppc64 |grep ntp-wait
-check:rc==0
-cmd:dpkg -L xcat-genesis-base-amd64 |grep ntp-wait
-check:rc==0
 cmd:rm -rf /install_xCAT_xcat-core.tar.bz2 /install_xCAT_xcat-dep.tar.bz2
 end
 

--- a/xCAT-test/autotest/testcase/install_xCAT/case0
+++ b/xCAT-test/autotest/testcase/install_xCAT/case0
@@ -18,6 +18,10 @@ check:output=~Version
 cmd:service xcatd status
 check:rc==0
 check:output=~running
+cmd:rpm -ql xCAT-genesis-base-x86_64 |grep ntp-wait
+check:rc==0
+cmd:rpm -ql xCAT-genesis-base-ppc64 |grep ntp-wait
+check:rc==0
 cmd:rm -rf /install_xCAT_xcat-core.tar.bz2 /install_xCAT_xcat-dep.tar.bz2
 end
 
@@ -43,6 +47,10 @@ check:output=~Version
 cmd:service xcatd status
 check:rc==0
 check:output=~running
+cmd:dpkg -L xcat-genesis-base-ppc64 |grep ntp-wait
+check:rc==0
+cmd:dpkg -L xcat-genesis-base-amd64 |grep ntp-wait
+check:rc==0
 cmd:rm -rf /install_xCAT_xcat-core.tar.bz2 /install_xCAT_xcat-dep.tar.bz2
 end
 


### PR DESCRIPTION
To fix issue #5160
Add back ntp-wait for building genesis-base for Pegas
```
[root@fs2vm111 builder]# rpm -qpl /root/rpmbuild/RPMS/noarch/xCAT-genesis-base-ppc64-2.14-snap201805110448.noarch.rpm | grep ntp-wait
/opt/xcat/share/xcat/netboot/genesis/ppc64/fs/usr/sbin/ntp-wait
```