### PR TITLE
Modify case bmcdiscover_range_w to cover boston server

### DIFF
--- a/xCAT-test/autotest/testcase/bmcdiscover/cases0
+++ b/xCAT-test/autotest/testcase/bmcdiscover/cases0
@@ -67,6 +67,7 @@ check:output=~Writing node
 check:output=~$$bmcrange,.+,.+,$$bmcusername,$$bmcpasswd 
 end
 
+
 start:bmcdiscover_range_z
 cmd:bmcdiscover --range  $$bmcrange -u $$bmcusername -p $$bmcpasswd -z
 check:rc==0

--- a/xCAT-test/autotest/testcase/bmcdiscover/cases0
+++ b/xCAT-test/autotest/testcase/bmcdiscover/cases0
@@ -64,7 +64,7 @@ start:bmcdiscover_range_w
 cmd:bmcdiscover --range  $$bmcrange -u $$bmcusername -p $$bmcpasswd -w
 check:rc==0
 check:output=~Writing node
-check:output=~$$bmcrange,\w*,\w*,$$bmcusername,$$bmcpasswd 
+check:output=~$$bmcrange,.+,.+,$$bmcusername,$$bmcpasswd 
 end
 
 start:bmcdiscover_range_z


### PR DESCRIPTION
The MTM of BOSTON server has character which was not covered by ``bmcdiscover_range_w``, in order to test BOSTON server, modify test case ``bmcdiscover_range_w ``.

Before fixing, the output like:
```
------START::bmcdiscover_range_w::Time:Mon May 14 15:34:47 2018------

FILENAME:/opt/xcat/bin/../share/xcat/tools/autotest/testcase//bmcdiscover/cases0

RUN:bmcdiscover --range  50.6.36.1 -u xxxxx -p xxxxx -w [Mon May 14 15:34:47 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Writing node-9006-22c-1309ala (50.6.36.1,9006-22C,1309ALA,xxxxx,xxxxx,mp,bmc,,,) to database...
CHECK:rc == 0   [Pass]
CHECK:output =~ Writing node    [Pass]
CHECK:output =~ 50.6.36.1,\w*,\w*,xxxxx,xxxxx   [Failed]

------END::bmcdiscover_range_w::Failed::Time:Mon May 14 15:34:48 2018 ::Duration::1 sec------

```

After fixing, the output like:
```
------START::bmcdiscover_range_w::Time:Mon May 14 21:39:50 2018------

RUN:bmcdiscover --range  50.6.36.1 -u xxxxx -p xxxxx -w [Mon May 14 21:39:50 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
Writing node-9006-22c-1309ala (50.6.36.1,9006-22C,1309ALA,xxxxx,xxxxx,mp,bmc,,,) to database...
CHECK:rc == 0	[Pass]
CHECK:output =~ Writing node	[Pass]
CHECK:output =~ 50.6.36.1,.+,.+,xxxxx,xxxxx	[Pass]

------END::bmcdiscover_range_w::Passed::Time:Mon May 14 21:39:52 2018 ::Duration::2 sec------
------Total: 1 , Failed: 0------
```

The regression for x86:
```
------START::bmcdiscover_range_w::Time:Mon May 14 21:45:44 2018------

RUN:bmcdiscover --range  10.4.29.2 -u xxxxx -p xxxxx -w [Mon May 14 21:45:44 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
Writing node-7912ac1-06vag33 (10.4.29.2,7912AC1,06VAG33,xxxxx,xxxxx,mp,bmc,,,) to database...
CHECK:rc == 0	[Pass]
CHECK:output =~ Writing node	[Pass]
CHECK:output =~ 10.4.29.2,.+,.+,xxxxx,xxxxx	[Pass]

------END::bmcdiscover_range_w::Passed::Time:Mon May 14 21:45:46 2018 ::Duration::2 sec------
------Total: 1 , Failed: 0------
```