### PR TITLE
Fix ERR message when running ondiscover in the chain table

### DIFF
--- a/xCAT-server/lib/xcat/plugins/destiny.pm
+++ b/xCAT-server/lib/xcat/plugins/destiny.pm
@@ -185,6 +185,11 @@ sub setdestiny {
                 $state = $stents{$_}->[0]->{currstate};
                 $state =~ s/ .*//;
 
+                #skip the node if state=ondiscover
+                if ($state eq 'ondiscover') {
+                    next;
+                }
+
                 #get the osimagename if nodetype.provmethod has osimage specified
                 #use it for both sninit and genesis operating
                 if (($state eq 'install') || ($state eq 'netboot') || ($state eq 'statelite')) {


### PR DESCRIPTION
For issue #5098 ,  
do not running setdestiny() again if state in the "enact" and currstate is `ondiscover`
following are logs from /var/log/xcat/cluster.log:
````
ay 14 22:42:06 boston02 xcat[107251]: INFO xcatd: install monitor received a connection request from 172.20.226.10
May 14 22:42:06 boston02 xcat[107251]: INFO xcatd: 172.20.226.10 is matched with node mid08tor03cn10
May 14 22:42:06 boston02 xcat[107251]: INFO xcatd: triggering 'updatenodestat mid08tor03cn10 bmcready'...
May 14 22:42:06 boston02 xcat[107251]: mid08tor03cn10 status: bmcready statustime: 05-14-2018 22:42:06
May 14 22:42:06 boston02 xcat[107251]: INFO xcatd: finish a connection request for mid08tor03cn10 from 172.20.226.10
May 14 22:42:06 mid08tor03cn10 xcat:  ready
May 14 22:42:06 mid08tor03cn10 xcat:  done
May 14 22:42:06 mid08tor03cn10 xcat.genesis.doxcat:  Running nextdestiny 172.20.253.31:3001...
May 14 22:42:06 boston02 xcat[9202]: xCAT: Allowing nextdestiny for mid08tor03cn10 from mid08tor03cn10
May 14 22:42:07 boston02 xcat[9218]: xCAT: Allowing rspconfig to mid08tor03cn10 sshcfg for root from localhost
May 14 22:42:07 sn02 xcat[21763]:  xCAT: Allowing rspconfig to mid08tor03cn10 sshcfg for root from boston02
May 14 22:42:19 sn02 xcat[21785]:  xCAT: Allowing makedhcp to mid08tor03cn10 for boston02.pok.stglabs.ibm.com from boston02
May 14 22:42:19 mid08tor03cn10 xcat.genesis.doxcat:  nextdestiny - Complete.
May 14 22:42:19 mid08tor03cn10 xcat.genesis.doxcat:  The destiny=ondiscover, destiny parameters=ondiscover
May 14 22:42:19 mid08tor03cn10 xcat.genesis.doxcat:  Running nextdestiny (ondiscover) 172.20.253.31:3001...
May 14 22:42:19 boston02 xcat[9270]: xCAT: Allowing nextdestiny for mid08tor03cn10 from mid08tor03cn10
May 14 22:42:20 mid08tor03cn10 xcat.genesis.doxcat:  nextdestiny (ondiscover) - Complete.
````