### PR TITLE
Display only OpenBMC usage

### DIFF
--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -618,7 +618,6 @@ $usage{"rspconfig.openbmc"} = $usage{"rspconfig.common"} .
 $usage{"rinv"} = $usage{"rinv.common"} . 
                       $usage{"rinv.begin"} .
                       $usage{"rinv.openbmc"} .
-                      "   " .
                       $usage{"rinv.end"};
 
 $usage{"rinv.openbmc"} = $usage{"rinv.common"} .
@@ -634,7 +633,6 @@ $usage{"rbeacon.openbmc"} = $usage{"rbeacon.common"} .
 $usage{"rvitals"} = $usage{"rvitals.common"} . 
                       $usage{"rvitals.begin"} .
                       $usage{"rvitals.openbmc"} .
-                      "   " .
                       $usage{"rvitals.end"};
 
 $usage{"rvitals.openbmc"} = $usage{"rvitals.common"} .
@@ -652,7 +650,6 @@ $usage{"rflash.openbmc"} = $usage{"rflash.common"} .
 $usage{"rpower"} = $usage{"rpower.common"} . 
                       $usage{"rpower.begin"} .
                       $usage{"rpower.openbmc"} .
-                      "   " .
                       $usage{"rpower.end"};
 
 $usage{"rpower.openbmc"} = $usage{"rpower.common"} .

--- a/xCAT-server/lib/xcat/plugins/openbmc2.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc2.pm
@@ -73,8 +73,14 @@ sub preprocess_request {
     if (ref($extrargs)) {
         @exargs = @$extrargs;
     }
-    my $usage_string = xCAT::Usage->parseCommand($command, @exargs);
+    # Request usage for openbmc sections only
+    my $usage_string = xCAT::Usage->parseCommand($command . ".openbmc", @exargs);
+ 
     if ($usage_string) {
+        if ($usage_string =~ /cannot be found/) {
+            # Could not find usage for openbmc section, try getting usage for all sections
+            $usage_string = xCAT::Usage->parseCommand($command, @exargs);
+        }
         $callback->({ data => [$usage_string] });
         $request = {};
         return;


### PR DESCRIPTION
#4938 

Filter out usage not related to the type of the node if node is specified.

```
[root@stratton01 xcat]# rspconfig f6u03 -h
Usage:
   Common:
       rspconfig [-h|--help|-v|--version|-V|--verbose]
   OpenBMC specific:
       rspconfig <noderange> [ipsrc|ip|netmask|gateway|vlan]
       rspconfig <noderange> admin_passwd=<currentpasswd,newpasswd>
       rspconfig <noderange> dump [-l|--list] [-g|--generate] [-c|--clear {<id>|all}] [-d|--download {<id>|all}]
       rspconfig <noderange> gard -c|--clear
       rspconfig <noderange> [hostname|ntpservers]
       rspconfig <noderange> [hostname=<*|hostname>|ntpservers=<ntpservers>]
       rspconfig <noderange> sshcfg
       rspconfig <noderange> powerrestorepolicy
       rspconfig <noderange> powerrestorepolicy={always_on|restore|always_off}
       rspconfig <noderange> powersupplyredundancy
       rspconfig <noderange> powersupplyredundancy={disabled|enabled}
       rspconfig <noderange> timesyncmethod
       rspconfig <noderange> timesyncmethod={ntp|manual}
       rspconfig <noderange> bootmode
       rspconfig <noderange> bootmode={safe|regular|setup}
       rspconfig <noderange> autoreboot
       rspconfig <noderange> autoreboot={0|1}

[root@stratton01 xcat]#
```
```
[root@stratton01 xcat]# rspconfig -h
Usage:
   Common:
       rspconfig [-h|--help|-v|--version|-V|--verbose]
   BMC/MPA Common:
       rspconfig <noderange> [snmpdest|alert|community] [-V|--verbose]
       rspconfig <noderange> [snmpdest=<dest ip address>|alert=<on|off|en|dis|enable|disable>|community=<string>]
   BMC specific:
       rspconfig <noderange> [ip|netmask|gateway|backupgateway|garp|vlan]
       rspconfig <noderange> [garp=<number of 1/2 second>]
       rspconfig <noderange> [userid=<userid> username=<username> password=<password>]
   OpenBMC specific:
       rspconfig <noderange> [ipsrc|ip|netmask|gateway|vlan]
       rspconfig <noderange> admin_passwd=<currentpasswd,newpasswd>
       rspconfig <noderange> dump [-l|--list] [-g|--generate] [-c|--clear {<id>|all}] [-d|--download {<id>|all}]
       rspconfig <noderange> gard -c|--clear
       rspconfig <noderange> [hostname|ntpservers]
       rspconfig <noderange> [hostname=<*|hostname>|ntpservers=<ntpservers>]
       rspconfig <noderange> sshcfg
       rspconfig <noderange> powerrestorepolicy
       rspconfig <noderange> powerrestorepolicy={always_on|restore|always_off}
       rspconfig <noderange> powersupplyredundancy
       rspconfig <noderange> powersupplyredundancy={disabled|enabled}
       rspconfig <noderange> timesyncmethod
       rspconfig <noderange> timesyncmethod={ntp|manual}
       rspconfig <noderange> bootmode
       rspconfig <noderange> bootmode={safe|regular|setup}
       rspconfig <noderange> autoreboot
       rspconfig <noderange> autoreboot={0|1}
   iDataplex specific:
       rspconfig <noderange> [thermprofile]
       rspconfig <noderange> [thermprofile=<two digit number from chassis>]
   MPA specific:
       rspconfig <noderange>  [sshcfg|snmpcfg|pd1|pd2|network|swnet|ntp|textid|frame]
       rspconfig <singlenode> [textid=name]
       rspconfig <singlenode> [frame=number]
       rspconfig <singlenode> [USERID=passwd] [updateBMC=<y|n>]
       rspconfig <noderange>  [sshcfg=<enable|disable>|
           snmpcfg=<enable|disable>|
           pd1=<nonred|redwoperf|redwperf>|
           pd2=<nonred|redwoperf|redwperf>|
           network=<*|[ip],[host],[gateway],[netmask]>|
           swnet=<[ip],[gateway],[netmask]>|
           textid=<*>|
           frame=<*>|
           ntp=<[ntp],[ip],[frequency],[v3]>
   FSP/CEC (using ASM Interface) Specific:
       rspconfig <noderange> [autopower|iocap|decfg|memdecfg|procdecfg|time|date|spdump|sysdump|network|hostname]
       rspconfig <noderange> autopower=<enable|disable>|
           iocap=<enable|disable>|
           decfg=<enable|disable>:<policy name>,...|
           memdecfg=<configure|deconfigure>:<processing unit>:<bank|unit>:<bank/unit number>:id,...|
           procdecfg=<configure|deconfigure>:<processing unit>:id,...|
           date=<mm-dd-yyyy>|
           time=<hh:mm:ss>|
           network=<*|[ip],[host],[gateway],[netmask]>|
           HMC_passwd=<currentpasswd,newpasswd>|
           admin_passwd=<currentpasswd,newpasswd>|
           general_passwd=<currentpasswd,newpasswd>|
           *_passwd=<currentpasswd,newpasswd>|
           hostname=<*|hostname>
   FSP/CEC (using Direct FSP Management) Specific:
       rspconfig <noderange> HMC_passwd=<currentpasswd,newpasswd>
       rspconfig <noderange> admin_passwd=<currentpasswd,newpasswd>
       rspconfig <noderange> general_passwd=<currentpasswd,newpasswd>
       rspconfig <noderange> *_passwd=<currentpasswd,newpasswd>
       rspconfig <noderange> [sysname]
       rspconfig <noderange> [sysname=<*|name>]
       rspconfig <noderange> [pending_power_on_side]
       rspconfig <noderange> [pending_power_on_side=<temp|perm>]
       rspconfig <noderange> [cec_off_policy]
       rspconfig <noderange> [cec_off_policy=<poweroff|stayon>]
       rspconfig <noderange> [huge_page]
       rspconfig <noderange> [huge_page=<NUM>]
       rspconfig <noderange> [BSR]
       rspconfig <noderange> [setup_failover]
       rspconfig <noderange> [setup_failover=<enable|disable>]
       rspconfig <noderange> [force_failover]
       rspconfig <noderange> --resetnet
   BPA/Frame (using Direct FSP Management)specific:
       rspconfig <noderange> HMC_passwd=<currentpasswd,newpasswd>
       rspconfig <noderange> admin_passwd=<currentpasswd,newpasswd>
       rspconfig <noderange> general_passwd=<currentpasswd,newpasswd>
       rspconfig <noderange> *_passwd=<currentpasswd,newpasswd>
       rspconfig <noderange> [frame]
       rspconfig <noderange> frame=<*|frame>
       rspconfig <noderange> [sysname]
       rspconfig <noderange> [sysname=<*|name>]
       rspconfig <noderange> [pending_power_on_side]
       rspconfig <noderange> [pending_power_on_side=<temp|perm>]
       rspconfig <noderange> --resetnet
   HMC specific:
       rspconfig <noderange>  [sshcfg]
       rspconfig <noderange>  [sshcfg=<enable|disable>]

[root@stratton01 xcat]#
```
