### PR TITLE
there are several xcatd SSL process remaining

### DIFF
--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -1003,11 +1003,16 @@ my %immediatechildren;
 
 sub generic_reaper {
     local ($!);
+    #print "generic_reaper in $$...";
     while (($CHILDPID = waitpid(-1, WNOHANG)) > 0) {
-        if (($CHILDPID == $pid_UDP) && ($udpctl)) {
-
-            # got here because UDP child is gone
-            close($udpctl); $udpctl = 0;
+        #print "reaper for $CHILDPID...\n";
+        if ($CHILDPID == $pid_UDP) {
+            if ($udpctl) {
+                # got here because UDP child is gone
+                close($udpctl);
+                $udpctl = 0;
+            }
+            $pid_UDP = 0;
         }
         yield;
     }
@@ -1017,16 +1022,20 @@ sub generic_reaper {
 sub ssl_reaper {
     local ($!);
     my $numdone = 0;
+    #print "ssl_reaper in $$...";
     while (($CHILDPID = waitpid(-1, WNOHANG)) > 0) {
+        #print "reaper for $CHILDPID...\n";
         if ($immediatechildren{$CHILDPID}) {
             delete $immediatechildren{$CHILDPID};
             $sslclients--;
             $numdone--;
         }
-        if (($CHILDPID == $pid_UDP) && ($udpctl)) {
-
-            # got here because UDP child is gone
-            close($udpctl); $udpctl = 0;
+        if ($CHILDPID == $pid_UDP) {
+            if ($udpctl) {
+                # got here because UDP child is gone
+                close($udpctl);
+                $udpctl = 0;
+            }
             $pid_UDP = 0;
         }
         if ($CHILDPID == $cmdlog_svrpid) {
@@ -1041,32 +1050,36 @@ sub ssl_reaper {
 
 sub dispatch_reaper {
     local ($!);
+    #print "dispatch_reaper in $$...";
     while (($CHILDPID = waitpid(-1, WNOHANG)) > 0) {
+        #print "reaper for $CHILDPID...\n";
         if ($dispatched_children{$CHILDPID}) {
             delete $dispatched_children{$CHILDPID};
             $dispatch_children--;
         }
-        if (($CHILDPID == $pid_UDP) && ($udpctl)) {
-
-            # got here because UDP child is gone
-            close($udpctl); $udpctl = 0;
-        }
+        #if (($CHILDPID == $pid_UDP) && ($udpctl)) {
+        #
+        #    # got here because UDP child is gone
+        #    close($udpctl); $udpctl = 0;
+        #}
     }
     $SIG{CHLD} = \&dispatch_reaper;
 }
 
 sub plugin_reaper {
     local ($!);
+    #print "plugin_reaper in $$...";
     while (($CHILDPID = waitpid(-1, WNOHANG)) > 0) {
+        #print "reaper for $CHILDPID...\n";
         if ($plugin_children{$CHILDPID}) {
             delete $plugin_children{$CHILDPID};
             $plugin_numchildren--;
         }
-        if (($CHILDPID == $pid_UDP) && ($udpctl)) {
-
-            # got here because UDP child is gone
-            close($udpctl); $udpctl = 0;
-        }
+        #if (($CHILDPID == $pid_UDP) && ($udpctl)) {
+        #
+        #    # got here because UDP child is gone
+        #    close($udpctl); $udpctl = 0;
+        #}
     }
     $SIG{CHLD} = \&plugin_reaper;
 }
@@ -1162,6 +1175,7 @@ if (!defined $pid_MON) {
 }
 unless ($pid_MON) {
     $$progname = "xcatd: install monitor";
+    $pid_UDP = 0;
     close($udpctl); $udpctl = 0;
     do_installm_service;
     xexit(0);
@@ -1510,7 +1524,7 @@ until ($quit) {
     }
 
     if ($child == 0) {
-        close($udpctl); $udpctl = 0;
+        close($udpctl); $udpctl = 0; $pid_UDP=0;
         $SIG{TERM} = $SIG{INT} = 'DEFAULT';
         $SIG{CHLD} = \&generic_reaper;    # THROTTLE
         $listener->close;
@@ -1614,16 +1628,27 @@ if (open($mainpidfile, "<", "/var/run/xcat/mainservice.pid")) {
     close($mainpidfile);
 }
 if ($listener) { $listener->close; }
-my $lastpid;
-while (keys %immediatechildren || $pid_UDP || $cmdlog_svrpid || $pid_MON) {
-    $lastpid = wait();
+
+$SIG{CHLD} = "DEFAULT"; # Disable the signal handler and let wait to cover the children quit
+
+my $remains = keys %immediatechildren;
+xCAT::MsgUtils->trace(0, 'I', "xcatd is going to stop, waiting for $remains plugins to quit...");
+while ($remains || $pid_UDP || $cmdlog_svrpid || $pid_MON) {
+    my $lastpid = wait();
+    last if ($lastpid < 0);
+
+    # Found an valid child process
     if ($immediatechildren{$lastpid}) {
         delete $immediatechildren{$lastpid};
-    } elsif ($lastpid == $pid_UDP) {
+        $remains = keys %immediatechildren;
+    }
+    elsif ($lastpid == $pid_UDP) {
         $pid_UDP = 0;
-    } elsif ($lastpid == $cmdlog_svrpid) {
+    }
+    elsif ($lastpid == $cmdlog_svrpid) {
         $cmdlog_svrpid = 0;
-    } elsif ($lastpid == $pid_MON) {
+    }
+    elsif ($lastpid == $pid_MON) {
         $pid_MON = 0;
     }
 }


### PR DESCRIPTION
Fix the issue #5153, to reduce the possibility that  the SSL process cannot quit successfully.
    ~~- using non-block waitpid when SSL quit, and add a bit more logs~~
    - Disable the signal handler after the SSL will quit.
    - refine the `generic_reaper` and `ssl_reaper` to better cover $pid_UDP
    - clean the $pid_UDP for child process, so that they don't need to consider UPD process and remove the code from  `plugin_reaper` and `dispatch_reaper`

UT: 
1, run xcattest for the regression.
```
xcattest -t xcatd_start
xCAT automated test started at Wed May 16 02:14:21 2018
******************************
To detect current test environment
******************************
Detecting: OS = linux
Warning: No compute node defined, can't get ARCH of compute node
Warning: No compute node defined, can't get HCP TYPE of compute node
******************************
loading test cases
******************************
To run:
xcatd_start
******************************
Start to run test cases
******************************
------START::xcatd_start::Time:Wed May 16 02:14:21 2018------

RUN:service xcatd status [Wed May 16 02:14:21 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
xcatd service is running
CHECK:rc == 0	[Pass]
CHECK:output =~ xcatd service is running	[Pass]

RUN:service xcatd stop [Wed May 16 02:14:21 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Stopping xcatd (via systemctl):  [  OK  ]
CHECK:rc == 0	[Pass]

RUN:sleep 3 [Wed May 16 02:14:21 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:

RUN:service xcatd start [Wed May 16 02:14:24 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
Starting xcatd (via systemctl):  [  OK  ]
CHECK:rc == 0	[Pass]
CHECK:output =~ Starting xcatd	[Pass]
CHECK:output =~ [  OK  ]	[Pass]

RUN:service xcatd status [Wed May 16 02:14:27 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
xcatd service is running
CHECK:rc == 0	[Pass]
CHECK:output =~ xcatd service is running	[Pass]

RUN:result=`ps -ef | grep "xcatd: SSL listener" | grep -v grep | wc -l`; if [ $result -eq 1 ]; then echo "only one process"; fi [Wed May 16 02:14:27 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
only one process
CHECK:output =~ only one process	[Pass]

RUN:result=`ps -ef | grep "xcatd: DB Access" | grep -v grep | wc -l`; if [ $result -eq 1 ]; then echo "only one process"; fi [Wed May 16 02:14:27 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
only one process
CHECK:output =~ only one process	[Pass]

RUN:result=`ps -ef | grep "xcatd: UDP listener" | grep -v grep | wc -l`; if [ $result -eq 1 ]; then echo "only one process"; fi [Wed May 16 02:14:27 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
only one process
CHECK:output =~ only one process	[Pass]

RUN:result=`ps -ef | grep "xcatd: install monitor" | grep -v grep | wc -l`; if [ $result -eq 1 ]; then echo "only one process"; fi [Wed May 16 02:14:27 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
only one process
CHECK:output =~ only one process	[Pass]

RUN:result=`ps -ef | grep "xcatd: Discovery worke" | grep -v grep | wc -l`; if [ $result -eq 1 ]; then echo "only one process"; fi [Wed May 16 02:14:27 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
only one process
CHECK:output =~ only one process	[Pass]

RUN:result=`ps -ef | grep "xcatd: Command log writer" | grep -v grep | wc -l`; if [ $result -eq 1 ]; then echo "only one process"; fi [Wed May 16 02:14:27 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
only one process
CHECK:output =~ only one process	[Pass]

------END::xcatd_start::Passed::Time:Wed May 16 02:14:27 2018 ::Duration::6 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished at Wed May 16 02:14:27 2018
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20180516021421 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20180516021421 file for time consumption
```
2, test the `restartxcatd`. 
on Terminal 1, run `xdsh <> "sleep 60"`
on terminal 2, run `restartxcatd`

```
restartxcatd
restartxcatd invoked by root.

Restarting xCATd                                           [  OK  ]
# ps -ef|grep xcatd
root     13796     1  0 02:17 ?        00:00:00 xcatd: SSL listener
root     13797 13796  0 02:17 ?        00:00:00 xcatd: DB Access
postgres 13798  7072  0 02:17 ?        00:00:00 postgres: xcatadm xcatdb 10.3.5.20(33870) idle
root     13818 13796  0 02:18 ?        00:00:00 xcatd SSL: xdsh to c910f03c05k24 for root@localhost
root     13819 13818  0 02:18 ?        00:00:00 xcatd SSL: xdsh to c910f03c05k24 for root@localhost: xdsh instance
root     13866     1  1 02:18 ?        00:00:00 xcatd: SSL listener
root     13867 13866  1 02:18 ?        00:00:00 xcatd: DB Access
postgres 13868  7072  1 02:18 ?        00:00:00 postgres: xcatadm xcatdb 10.3.5.20(33886) idle
root     13869 13866  0 02:18 ?        00:00:00 xcatd: UDP listener
root     13870 13869  0 02:18 ?        00:00:00 xcatd: Discovery worker
root     13871 13866  0 02:18 ?        00:00:00 xcatd: install monitor
root     13872 13866  0 02:18 ?        00:00:00 xcatd: Command log writer
postgres 13877  7072  0 02:18 ?        00:00:00 postgres: xcatadm xcatdb 10.3.5.20(33888) idle
```
OK, fastreboot is still working, and we can see the new logs
```
May 16 02:18:14 c910f03c05k20 xcat[13796]:  xcatd main service 13796 quiescing
May 16 02:18:14 c910f03c05k20 xcat[13796]:  INFO xcatd is going to stop, waiting for 1 plugins to quit...
```