### PR TITLE
update case for issue 4855,  to compare the output of perl vs python for bmcstate when bmc reboots

### DIFF
--- a/xCAT-test/autotest/testcase/UT_openbmc/scripts/bmcreboot.sh
+++ b/xCAT-test/autotest/testcase/UT_openbmc/scripts/bmcreboot.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+if [[ -z ${1} ]]; then
+    echo "Provide the name of the node as the first argument of this script"
+    exit 1
+fi
+NODE=${1}
+
+if [[ -z ${2} ]]; then
+    echo "Provide the name of the log file as the second argument of this script"
+    exit 1
+fi
+LOGFILE=$2
+
+if [[ -z ${3} ]]; then
+    echo "Provide either PERL or PYTHON as the third argument of this script"
+    exit 1
+fi
+
+if [[ ${3} == "PERL" ]]; then
+   echo "Running the test in PERL"
+   unset XCAT_OPENBMC_PYTHON
+elif [[ ${3} == "PYTHON" ]]; then
+   echo "Running the test in PYTHON"
+   export XCAT_OPENBMC_PYTHON=YES
+else
+   echo "UNKNOWN SELECTED!"
+   exit 1
+fi
+
+ITERATIONS=20
+SLEEP_TIME=2
+
+# Turn off debug mode....
+#
+chdef -t site clustersite xcatdebugmode=
+
+# Create a new log file
+date > $LOGFILE
+
+rpower $NODE bmcstate
+
+# Reboot the bmc
+rpower $NODE bmcreboot | tee -a $LOGFILE 2>&1
+
+counter=1
+ready_cnt=0
+while [[ $counter -le $ITERATIONS ]]; do
+   sleep $SLEEP_TIME
+   RC=`rpower $NODE bmcstate >> $LOGFILE 2>&1 ; echo $?`
+   echo "Count: $counter, RC: $RC"
+    ((counter++))
+   if [[ $RC == 0 ]]; then
+       ((ready_cnt++))
+       if [[ $ready_cnd > 2 ]]; then
+           echo "Leaving loop...."
+           break
+       fi 
+   fi
+done
+
+echo "All done!"

--- a/xCAT-test/autotest/testcase/rpower/cases0
+++ b/xCAT-test/autotest/testcase/rpower/cases0
@@ -180,3 +180,35 @@ cmd:rpower $$CN ddd
 check:output=~Error: Unsupported command: rpower ddd 
 check:rc==1
 end
+
+start:rpower_bmcreboot_perl_python_output
+description:record the output for rpower bmcreboot and compare the output for perl and python version. 
+hcp:openbmc
+cmd: /opt/xcat/share/xcat/tools/autotest/testcase/UT_openbmc/scripts/bmcreboot.sh $$CN /tmp/xcattest.rpower.bmcstate.perl.out PERL
+check:rc==0
+cmd: grep "Login to BMC failed: 500" /tmp/xcattest.rpower.bmcstate.perl.out | sort | uniq | wc -l
+check:output=~3
+cmd: grep "timeout" /tmp/xcattest.rpower.bmcstate.perl.out | sort | uniq | wc -l
+check:output=~1
+cmd: grep "No route to host" /tmp/xcattest.rpower.bmcstate.perl.out | sort | uniq | wc -l
+check:output=~1
+cmd: grep "BMC NotReady" /tmp/xcattest.rpower.bmcstate.perl.out | sort | uniq | wc -l
+check:output=~1
+cmd: grep "BMC Ready" /tmp/xcattest.rpower.bmcstate.perl.out | sort | uniq | wc -l
+check:output=~1
+cmd: cat /tmp/xcattest.rpower.bmcstate.perl.out
+cmd: /opt/xcat/share/xcat/tools/autotest/testcase/UT_openbmc/scripts/bmcreboot.sh $$CN /tmp/xcattest.rpower.bmcstate.python.out PYTHON
+check:rc==0
+cmd: grep "Login to BMC failed: 500" /tmp/xcattest.rpower.bmcstate.python.out | sort | uniq | wc -l
+check:output=~3
+cmd: grep "timeout" /tmp/xcattest.rpower.bmcstate.python.out | sort | uniq | wc -l
+check:output=~1
+cmd: grep "No route to host" /tmp/xcattest.rpower.bmcstate.python.out | sort | uniq | wc -l
+check:output=~1
+cmd: grep "BMC NotReady" /tmp/xcattest.rpower.bmcstate.python.out | sort | uniq | wc -l
+check:output=~1
+cmd: grep "BMC Ready" /tmp/xcattest.rpower.bmcstate.python.out | sort | uniq | wc -l
+check:output=~1
+cmd: cat /tmp/xcattest.rpower.bmcstate.python.out
+cmd:rm -rf /tmp/xcattest.rpower.bmcstate.perl.out /tmp/xcattest.rpower.bmcstate.python.out
+end


### PR DESCRIPTION
Case Name: rpower_bmcreboot_perl_python_output
description:record the output for rpower bmcreboot and compare the output for perl and python version.