### PR TITLE
fix 5200 do not restart_ib_driver_service by default

### DIFF
--- a/xCAT/postscripts/configib
+++ b/xCAT/postscripts/configib
@@ -94,17 +94,28 @@ else
     ib_driver="openibd"
 fi
 
+restart_ib_driver=0
 #make changes to the confiuration file
 if [ $PLTFRM == "Linux" ]
 then
     if [ -f "/etc/rdma/rdma.conf" ]
     then
+        md5f1=$(md5sum /etc/rdma/rdma.conf |cut -d' ' -f1)
         TMP1=`sed "s/SDP_LOAD=yes/SDP_LOAD=no/g" /etc/rdma/rdma.conf`
 	echo "$TMP1" > /etc/rdma/rdma.conf 
+        md5f2=$(md5sum /etc/rdma/rdma.conf |cut -d' ' -f1)
+        if [ "$md5f2" != "$md5f1" ]; then
+            restart_ib_driver=1
+        fi
     elif [ -f "/etc/infiniband/openib.conf" ]
     then
+        md5f1=$(md5sum /etc/infiniband/openib.conf |cut -d' ' -f1)
         TMP1=`sed "s/SDP_LOAD=yes/SDP_LOAD=no/g" /etc/infiniband/openib.conf`
 	echo "$TMP1" > /etc/infiniband/openib.conf
+        md5f2=$(md5sum /etc/infiniband/openib.conf |cut -d' ' -f1)
+        if [ "$md5f2" != "$md5f1" ]; then
+            restart_ib_driver=1
+        fi
     fi
 
     if [ -f "/etc/modprobe.conf" ]
@@ -667,7 +678,11 @@ done # end for nic
 if [ $PLTFRM == "Linux" ]
 then
     #/sbin/service $ib_driver restart
-    restartservice $ib_driver
+    if [ $restart_ib_driver = "1" ]; then
+            echo "restart $ib_driver service"
+            logger -p local4.info -t xcat "restart $ib_driver service"
+            restartservice $ib_driver
+    fi
     for nic in `echo "$goodnics" | tr "," "\n"|sort -u`
     do     
         sleep 5

--- a/xCAT/postscripts/configib
+++ b/xCAT/postscripts/configib
@@ -678,7 +678,7 @@ done # end for nic
 if [ $PLTFRM == "Linux" ]
 then
     #/sbin/service $ib_driver restart
-    if [ $restart_ib_driver = "1" ]; then
+    if [ "$restart_ib_driver" = "1" ]; then
             echo "restart $ib_driver service"
             logger -p local4.info -t xcat "restart $ib_driver service"
             restartservice $ib_driver


### PR DESCRIPTION
https://github.com/xcat2/xcat-core/issues/5200

UT in fake IB env:
1, can restart scenario:
```
[root@bybc0602 postscripts]# updatenode bybc0605 -P "confignetwork --ibaports=2" -V |tee log
Running command on bybc0602: ip -4 --oneline addr show |awk -F ' ' '{print $4}'|awk -F '/' '{print $1}' 2>&1

Running command on bybc0602: chmod -R a+r /install/postscripts 2>&1

  bybc0602: Internal call command: xdsh bybc0605 --nodestatus -s -v -e /install/postscripts/xcatdsklspost 1 -m 10.5.106.2 'confignetwork --ibaports=2' --tftp /tftpboot --installdir /install --nfsv4 no -c -V
Running command on bybc0602: ip -4 --oneline addr show |awk -F ' ' '{print $4}'|awk -F '/' '{print $1}' 2>&1
Running command on bybc0602: hostname 2>&1
Running command on bybc0602: /opt/xcat/bin/pping bybc0605 2>&1
bybc0605: Warning: the ECDSA host key for 'bybc0605' differs from the key for the IP address '10.5.106.5'
bybc0605: Offending key for IP in /root/.ssh/known_hosts:21
bybc0605: Matching host key in /root/.ssh/known_hosts:32

bybc0605: Running /tmp/file9HuzTn.dsh 1 -m 10.5.106.2 confignetwork --ibaports=2 --tftp /tftpboot --installdir /install --nfsv4 no -c -V
bybc0605: trying to download postscripts...
bybc0605: trying to download postscripts from http://10.5.106.2/install/postscripts/
bybc0605: postscripts are downloaded from 10.5.106.2 successfully.
bybc0605: postscripts downloaded successfully
bybc0605: trying to get mypostscript from 10.5.106.2...
bybc0605: trying to download http://10.5.106.2/tftpboot/mypostscripts/mypostscript.bybc0605...
bybc0605: mypostscript.bybc0605 is downloaded successfully.
bybc0605: Running //xcatpost/mypostscript
bybc0605: Wed May 16 04:59:12 EDT 2018 Running postscript: confignetwork
bybc0605: [I]: All valid nics and device list:
bybc0605: [I]: ib0,ib1
bybc0605: [I]: NetworkManager is inactive.
bybc0605: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bybc0605: configure nic and its device : ib0,ib1
bybc0605: [I]: Call configib for IB nics: ib0,ib1, ports: 2
bybc0605: [I]: NIC_IBNICS=ib0,ib1 NIC_IBAPORTS=2 configib
bybc0605: restart openibd service
bybc0605: [E]:Error: configib failed.
bybc0605: postscript: confignetwork exited with code 1
bybc0605: //xcatpost/mypostscript return with 1
bybc0605: Running of postscripts has completed.
```
2. do not restart openibd 
```
ybc0605: Wed May 16 04:58:21 EDT 2018 Running postscript: confignetwork
bybc0605: [I]: All valid nics and device list:
bybc0605: [I]: ib0,ib1
bybc0605: [I]: NetworkManager is inactive.
bybc0605: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bybc0605: configure nic and its device : ib0,ib1
bybc0605: [I]: Call configib for IB nics: ib0,ib1, ports: 2
bybc0605: [I]: NIC_IBNICS=ib0,ib1 NIC_IBAPORTS=2 configib
bybc0605: [E]:Error: configib failed.
bybc0605: postscript: confignetwork exited with code 1
bybc0605: //xcatpost/mypostscript return with 1
bybc0605: Running of postscripts has completed.
```
