### PR TITLE
the error message of *def command is disordered when running internally

### DIFF
--- a/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
+++ b/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
@@ -4555,17 +4555,19 @@ sub defmk_usage
     $rsp->{data}->[3] = "      [-o object-names] [-z|--stanza ]";
     $rsp->{data}->[4] = "      [-d | --dynamic] [-w attr==val [-w attr=~val] ...]";
     $rsp->{data}->[5] = "      [-f | --force] [noderange] [attr=val [attr=val...]]";
-    $rsp->{data}->[6] = "\nThe following data object types are supported by xCAT.\n";
-    my $n = 6;
+    $rsp->{data}->[6] = "\nThe following data object types are supported by xCAT:\n";
+    my $n = 7;
+    my $dataobj;
 
     foreach my $t (sort(keys %{xCAT::Schema::defspec}))
     {
-        $rsp->{data}->[$n] = "$t";
-        $n++;
+        $dataobj = $dataobj . ' ' . $t;
     }
+    $rsp->{data}->[$n] = "$dataobj\n";
+    $n++;
     $rsp->{data}->[$n] = "\nUse the \'-h\' option together with the \'-t\' option to";
     $n++;
-    $rsp->{data}->[$n] = "get a list of valid attribute names for each object type.\n";
+    $rsp->{data}->[$n] = " get a list of valid attribute names for each object type.\n";
     xCAT::MsgUtils->message("I", $rsp, $::callback);
     return 0;
 }
@@ -4596,17 +4598,19 @@ sub defch_usage
     $rsp->{data}->[3] = "  chdef [-V | --verbose] [-t object-types] [-o object-names] [-d | --dynamic]";
     $rsp->{data}->[4] = "    [-z | --stanza] [-m | --minus] [-p | --plus]";
     $rsp->{data}->[5] = "    [-w attr==val [-w attr=~val] ... ] [noderange] [attr=val [attr=val...]]\n";
-    $rsp->{data}->[6] = "\nThe following data object types are supported by xCAT.\n";
+    $rsp->{data}->[6] = "\nThe following data object types are supported by xCAT:\n";
     my $n = 7;
+    my $dataobj;
 
     foreach my $t (sort(keys %{xCAT::Schema::defspec}))
     {
-        $rsp->{data}->[$n] = "$t";
-        $n++;
+        $dataobj = $dataobj . ' ' . $t;
     }
+    $rsp->{data}->[$n] = "$dataobj\n";
+    $n++;
     $rsp->{data}->[$n] = "\nUse the \'-h\' option together with the \'-t\' option to";
     $n++;
-    $rsp->{data}->[$n] = "get a list of valid attribute names for each object type.\n";
+    $rsp->{data}->[$n] = " get a list of valid attribute names for each object type.\n";
     xCAT::MsgUtils->message("I", $rsp, $::callback);
     return 0;
 }
@@ -4638,17 +4642,19 @@ sub defls_usage
     $rsp->{data}->[4] = "  lsdef [-V | --verbose] [-t object-types] [-o object-names]";
     $rsp->{data}->[5] = "        [ -l | --long] [-s | --short] [-a | --all] [-z | --stanza ] [-S]";
     $rsp->{data}->[6] = "        [-i attr-list] [-w attr==val [-w attr=~val] ...] [noderange]\n";
-    $rsp->{data}->[7] = "\nThe following data object types are supported by xCAT.\n";
-    my $n = 6;
+    $rsp->{data}->[7] = "\nThe following data object types are supported by xCAT:\n";
+    my $n = 8;
+    my $dataobj;
 
     foreach my $t (sort(keys %{xCAT::Schema::defspec}))
     {
-        $rsp->{data}->[$n] = "$t";
-        $n++;
+        $dataobj = $dataobj . ' ' . $t;
     }
+    $rsp->{data}->[$n] = "$dataobj\n";
+    $n++;
     $rsp->{data}->[$n] = "\nUse the \'-h\' option together with the \'-t\' option to";
     $n++;
-    $rsp->{data}->[$n] = "get a list of valid attribute names for each object type.\n";
+    $rsp->{data}->[$n] = " get a list of valid attribute names for each object type.\n";
     xCAT::MsgUtils->message("I", $rsp, $::callback);
     return 0;
 }
@@ -4677,17 +4683,19 @@ sub defrm_usage
     $rsp->{data}->[1] = "  rmdef [-h | --help ] [-t object-types]\n";
     $rsp->{data}->[2] = "  rmdef [-V | --verbose] [-t object-types] [-a | --all] [-f | --force]";
     $rsp->{data}->[3] = "    [-o object-names] [-C | --cleanup] [noderange]\n";
-    $rsp->{data}->[4] = "\nThe following data object types are supported by xCAT.\n";
+    $rsp->{data}->[4] = "\nThe following data object types are supported by xCAT:\n";
     my $n = 5;
+    my $dataobj;
 
     foreach my $t (sort(keys %{xCAT::Schema::defspec}))
     {
-        $rsp->{data}->[$n] = "$t";
-        $n++;
+        $dataobj = $dataobj . ' ' . $t;
     }
+    $rsp->{data}->[$n] = "$dataobj\n";
+    $n++;
     $rsp->{data}->[$n] = "\nUse the \'-h\' option together with the \'-t\' option to";
     $n++;
-    $rsp->{data}->[$n] = "get a list of valid attribute names for each object type.\n";
+    $rsp->{data}->[$n] = " get a list of valid attribute names for each object type.\n";
     xCAT::MsgUtils->message("I", $rsp, $::callback);
     return 0;
 }

--- a/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
+++ b/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
@@ -4604,7 +4604,11 @@ sub defch_usage
 
     foreach my $t (sort(keys %{xCAT::Schema::defspec}))
     {
-        $dataobj = $dataobj . ' ' . $t;
+        if ($dataobj) {
+            $dataobj = $dataobj . ',' . $t;
+        } else {
+            $dataobj = $t;
+        }
     }
     $rsp->{data}->[$n] = "$dataobj\n";
     $n++;

--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -819,10 +819,10 @@ sub write_to_xcatdb {
                                            "bmcusername=$bmcuser", "bmcpassword=$bmcpass", "nodetype=$nodetype", 
                                            "servicenode=$sn", "conserver=$conserver",
                                            "hwtype=$hwtype", "groups=all" ] },
-                                  $request_command, 0, 1);
+                                  $request_command, -1, 1);
     if ($::RUNCMD_RC != 0) {
         my $rsp = {};
-        push @{ $rsp->{data} }, "create or modify node is failed.\n";
+        push @{ $rsp->{data} }, "Failed to run chdef command for node=$node\n";
         xCAT::MsgUtils->message("E", $rsp, $::CALLBACK);
         return 2;
     }


### PR DESCRIPTION
for issue #4989 

1) in the bmcdiscover plugin, if hit chdef error, it will return error code but not error message
```
# bmcdiscover --range 172.20.253.104 -w
Error: Failed to run chdef command for node=
````

2)for all the def usage subroutine in the DBobjectdefs.pm, i will add space between each datatype instead put each datatype to ARRAY.
````
]# chdef -t node -o '' bmc=10.4.30.254 groups=all
Error: No object names were provided.

Usage: chdef - Change xCAT data object definitions.

  chdef [-h | --help ] [-t object-types]

  chdef [-t object-types] [-o object-names] [-n new-name] [node]

  chdef [-V | --verbose] [-t object-types] [-o object-names] [-d | --dynamic]
    [-z | --stanza] [-m | --minus] [-p | --plus]
    [-w attr==val [-w attr=~val] ... ] [noderange] [attr=val [attr=val...]]


The following data object types are supported by xCAT:

 auditlog boottarget eventlog firmware group kit kitcomponent kitrepo monitoring network node notification osdistro osdistroupdate osimage pdu policy rack route site taskstate zone zvmivp


Use the '-h' option together with the '-t' option to
 get a list of valid attribute names for each object type.
````