### PR TITLE
Revert commit 2bf5dc57f9da2b72e80106026dd13f71774ff476 "use tar as the default archive method instead of cpio (#5187)"

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/packimage.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/packimage.1.rst
@@ -53,7 +53,7 @@ OPTIONS
 
 \ **-v**\           Command Version.
 
-\ **-m| -**\ **-method**\           Archive Method (cpio,tar,squashfs, default is tar)
+\ **-m| -**\ **-method**\           Archive Method (cpio,tar,squashfs, default is cpio)
 
 \ **-c| -**\ **-compress**\           Compress Method (pigz,gzip,xz, default is pigz/gzip)
 

--- a/xCAT-client/pods/man1/packimage.1.pod
+++ b/xCAT-client/pods/man1/packimage.1.pod
@@ -27,7 +27,7 @@ B<-h>          Display usage message.
 
 B<-v>          Command Version.
 
-B<-m| --method>          Archive Method (cpio,tar,squashfs, default is tar)
+B<-m| --method>          Archive Method (cpio,tar,squashfs, default is cpio)
 
 B<-c| --compress>          Compress Method (pigz,gzip,xz, default is pigz/gzip)
 

--- a/xCAT-server/lib/xcat/plugins/packimage.pm
+++ b/xCAT-server/lib/xcat/plugins/packimage.pm
@@ -89,7 +89,7 @@ sub process_request {
     my $osver;
     my $arch;
     my $profile;
-    my $method = 'tar';
+    my $method = 'cpio';
     my $compress;
     my $exlistloc;
     my $syncfile;


### PR DESCRIPTION
 "[CUSTOMER] Ping not working for non root users on Diskless PowerKVM guests (rhels7.2) #922: use tar as the default archive method instead of cpio (#5187)"

This reverts commit 2bf5dc57f9da2b72e80106026dd13f71774ff476.