### PR TITLE
Add non-root user check for diskless provision

### DIFF
--- a/xCAT-test/autotest/testcase/packimg/cases0
+++ b/xCAT-test/autotest/testcase/packimg/cases0
@@ -214,6 +214,16 @@ check:output=~\d\d:\d\d:\d\d
 cmd:xdsh $$CN mount
 check:rc==0
 check:output=~on / type tmpfs
+#add test for issue922
+cmd:xdsh $$CN  "ls -l /bin/ping"
+cmd:xdsh $$CN "ping -c 1 127.0.0.1"
+check:rc==0
+cmd:xdsh $$CN "useradd -m xcatuser"
+check:rc==0
+cmd:xdsh $$CN "su - xcatuser sh  -c \"ping -c 1 127.0.0.1\""
+check:rc==0
+cmd:xdsh $$CN "userdel xcatuser"
+check:rc==0
 cmd:rootimgdir=`lsdef -t osimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir.regbak ]; then rm -rf $rootimgdir; mv $rootimgdir.regbak $rootimgdir; fi
 check:rc==0
 cmd:rm -rf  /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.tar.gz
@@ -254,6 +264,16 @@ check:output=~\d\d:\d\d:\d\d
 cmd:xdsh $$CN mount
 check:rc==0
 check:output=~on / type tmpfs
+#add test for issue922
+cmd:xdsh $$CN  "ls -l /bin/ping"
+cmd:xdsh $$CN "ping -c 1 127.0.0.1"
+check:rc==0
+cmd:xdsh $$CN "useradd -m xcatuser"
+check:rc==0
+cmd:xdsh $$CN "su - xcatuser sh  -c \"ping -c 1 127.0.0.1\""
+check:rc==0
+cmd:xdsh $$CN "userdel xcatuser"
+check:rc==0
 cmd:rootimgdir=`lsdef -t osimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir.regbak ]; then rm -rf $rootimgdir; mv $rootimgdir.regbak $rootimgdir; fi
 check:rc==0
 cmd:rm -rf  /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.tar.gz
@@ -294,6 +314,16 @@ check:output=~\d\d:\d\d:\d\d
 cmd:xdsh $$CN mount
 check:rc==0
 check:output=~on / type tmpfs
+#add test for issue922
+cmd:xdsh $$CN  "ls -l /bin/ping"
+cmd:xdsh $$CN "ping -c 1 127.0.0.1"
+check:rc==0
+cmd:xdsh $$CN "useradd -m xcatuser"
+check:rc==0
+cmd:xdsh $$CN "su - xcatuser sh  -c \"ping -c 1 127.0.0.1\""
+check:rc==0
+cmd:xdsh $$CN "userdel xcatuser"
+check:rc==0
 cmd:rootimgdir=`lsdef -t osimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir.regbak ]; then rm -rf $rootimgdir; mv $rootimgdir.regbak $rootimgdir; fi
 check:rc==0
 cmd:rm -rf  /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.tar.xz


### PR DESCRIPTION
Related task xcat2/xcat2-task-management#112

Related issue #922

The related UT:
```
........
RUN:xdsh f6u13k15  "ls -l /bin/ping" [Tue May  8 03:08:05 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u13k15: -rwxr-xr-x. 1 root root 135976 May 22  2017 /bin/ping

RUN:xdsh f6u13k15 "ping -c 1 127.0.0.1" [Tue May  8 03:08:06 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u13k15: PING 127.0.0.1 (127.0.0.1) 56(84) bytes of data.
f6u13k15: 64 bytes from 127.0.0.1: icmp_seq=1 ttl=64 time=0.021 ms
f6u13k15:
f6u13k15: --- 127.0.0.1 ping statistics ---
f6u13k15: 1 packets transmitted, 1 received, 0% packet loss, time 0ms
f6u13k15: rtt min/avg/max/mdev = 0.021/0.021/0.021/0.000 ms
CHECK:rc == 0	[Pass]

RUN:xdsh f6u13k15 "useradd -m xcatuser" [Tue May  8 03:08:07 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xdsh f6u13k15 "su - xcatuser sh  -c \"ping -c 1 127.0.0.1\"" [Tue May  8 03:08:07 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u13k15: PING 127.0.0.1 (127.0.0.1) 56(84) bytes of data.
f6u13k15: 64 bytes from 127.0.0.1: icmp_seq=1 ttl=64 time=0.036 ms
f6u13k15:
f6u13k15: --- 127.0.0.1 ping statistics ---
f6u13k15: 1 packets transmitted, 1 received, 0% packet loss, time 0ms
f6u13k15: rtt min/avg/max/mdev = 0.036/0.036/0.036/0.000 ms
CHECK:rc == 0	[Pass]

RUN:xdsh f6u13k15 "userdel xcatuser" [Tue May  8 03:08:08 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]
........
```
