### PR TITLE
Modify output message for PDU outlet state

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -803,6 +803,14 @@ sub preprocess_request {
         return;
     }
 
+    #pdu commands will be handled in the pdu plugin
+    if ($command eq "rpower") {
+        my $subcmd = $exargs[0];
+        if(($subcmd eq 'pduoff') || ($subcmd eq 'pduon') || ($subcmd eq 'pdustat') || ($subcmd eq 'pdureset')){
+            return;
+        }
+    }
+
     my $parse_result = parse_args($command, $extrargs, $noderange);
     if (ref($parse_result) eq 'ARRAY') {
         my $error_data;

--- a/xCAT-server/lib/xcat/plugins/openbmc2.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc2.pm
@@ -86,6 +86,14 @@ sub preprocess_request {
         return;
     }
 
+    #pdu commands will be handled in the pdu plugin
+    if ($command eq "rpower") {
+        my $subcmd = $exargs[0];
+        if(($subcmd eq 'pduoff') || ($subcmd eq 'pduon') || ($subcmd eq 'pdustat') || ($subcmd eq 'pdureset')){
+             return;
+        }
+    }
+
     my $parse_result = parse_args($command, $extrargs, $noderange);
     if (ref($parse_result) eq 'ARRAY') {
         my $error_data;

--- a/xCAT-server/lib/xcat/plugins/pdu.pm
+++ b/xCAT-server/lib/xcat/plugins/pdu.pm
@@ -404,7 +404,7 @@ sub powerpduoutlet {
             if ($session->{ErrorStr}) { 
                 $callback->({ errorcode => [1],error => "$node: $pdu outlet $outlet has error = $session->{ErrorStr}"});
             } else {
-                $output = "$pdu outlet $outlet is $statstr"; 
+                $output = "$pdu operational state for outlet $outlet is $statstr"; 
                 xCAT::SvrUtils::sendmsg($output, $callback, $node, %allerrornodes);
             }
         }
@@ -508,7 +508,7 @@ sub powerstat {
         for (my $outlet =1; $outlet <= $count; $outlet++)
         {
             my $statstr = outletstat($session, $outlet);
-            my $msg = " outlet $outlet is $statstr";
+            my $msg = " operational state for the outlet $outlet is $statstr";
             xCAT::SvrUtils::sendmsg($msg, $callback, $pdu, %allerrornodes);
         }
     }
@@ -519,6 +519,13 @@ sub powerstat {
 =head3  outletstat 
 
     Process command to query status of one pdu outlet
+    ibmPduOutletState defined from mib file
+         off(0) 
+         on(1)
+         cycling(2)
+         delaySwitch10(3)
+         delaySwitch30(4)
+         delaySwitch60(5)
 
 =cut
 
@@ -535,12 +542,20 @@ sub outletstat {
     }
 
     $output = $session->get("$oid.$outlet");
-    if ($output eq 1) {
-        $statstr = "on";
-    } elsif ($output eq 0) {
+    if ($output eq 0) {
         $statstr = "off";
+    } elsif ($output eq 1) {
+        $statstr = "on";
+    } elsif ($output eq 2) {
+        $statstr = "cycling";
+    } elsif ($output eq 3) {
+        $statstr = "delaySwitch10";
+    } elsif ($output eq 4) {
+        $statstr = "delaySwitch30";
+    } elsif ($output eq 5) {
+        $statstr = "delaySwitch60";
     } else {
-        return;
+        $statstr = "$output(unknown state)" ;
     }
     return $statstr;
 }


### PR DESCRIPTION
Enhance output message for PDU outlet state.  relate to issue #5213 
1) filter out rpower pduxxx command to the openbmc plugin
````
# chdef mid08tor03cn10 pdu=f6pdu16:2
1 object definitions have been created or modified.
# rpower mid08tor03cn10 pdustat
mid08tor03cn10: f6pdu16 operational state for outlet 2 is on
````
2) based on pdu mib file, add more outlet state instead of only off/on.
        off(0)
         on(1)
         cycling(2)
         delaySwitch10(3)
         delaySwitch30(4)
         delaySwitch60(5)
````
]# rpower f6pdu15 stat
f6pdu15: operational state for the outlet 1 is 7(unknown state)
f6pdu15: operational state for the outlet 2 is 7(unknown state)
f6pdu15: operational state for the outlet 3 is 7(unknown state)
f6pdu15: operational state for the outlet 4 is 7(unknown state)
f6pdu15: operational state for the outlet 5 is 7(unknown state)
f6pdu15: operational state for the outlet 6 is 7(unknown state)
f6pdu15: operational state for the outlet 7 is 7(unknown state)
f6pdu15: operational state for the outlet 8 is 7(unknown state)
f6pdu15: operational state for the outlet 9 is 7(unknown state)
````
