### PR TITLE
using --nosyncfiles to ignore sync files to root image when packimage

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/packimage.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/packimage.1.rst
@@ -23,7 +23,7 @@ SYNOPSIS
 
 \ **packimage  [-v| -**\ **-version]**\ 
 
-\ **packimage**\  [\ **-m | -**\ **-method**\  \ *cpio|tar*\ ] [\ **-c | -**\ **-compress**\  \ *gzip|pigz|xz*\ ]  \ *imagename*\ 
+\ **packimage**\  [\ **-m | -**\ **-method**\  \ *cpio|tar*\ ] [\ **-c | -**\ **-compress**\  \ *gzip|pigz|xz*\ ] [\ **--nosyncfiles**\ ] \ *imagename*\
 
 
 ***********
@@ -57,6 +57,8 @@ OPTIONS
 
 \ **-c| -**\ **-compress**\           Compress Method (pigz,gzip,xz, default is pigz/gzip)
 
+\ **--nosyncfiles**\           Bypass of syncfiles requested, will not sync files to root image directory
+
 
 ************
 RETURN VALUE
@@ -87,6 +89,14 @@ EXAMPLES
 .. code-block:: perl
 
   packimage -m tar -c pigz rhels7.1-x86_64-netboot-compute
+
+
+3. To pack the osimage 'rhels7.1-x86_64-netboot-compute' without syncing files:
+
+
+.. code-block:: perl
+
+  packimage --nosyncfiles rhels7.1-x86_64-netboot-compute
 
 
 

--- a/xCAT-client/pods/man1/packimage.1.pod
+++ b/xCAT-client/pods/man1/packimage.1.pod
@@ -8,7 +8,7 @@ B<packimage [-h| --help]>
 
 B<packimage  [-v| --version]>
 
-B<packimage> [B<-m>|B<--method> I<cpio|tar>] [B<-c>|B<--compress> I<gzip|pigz|xz>]  I<imagename>
+B<packimage> [B<-m>|B<--method> I<cpio|tar>] [B<-c>|B<--compress> I<gzip|pigz|xz>] [B<--nosyncfiles>] I<imagename>
 
 =head1 DESCRIPTION
 
@@ -31,6 +31,8 @@ B<-m| --method>          Archive Method (cpio,tar,squashfs, default is cpio)
 
 B<-c| --compress>          Compress Method (pigz,gzip,xz, default is pigz/gzip)
 
+B<--nosyncfiles>          Bypass of syncfiles requested, will not sync files to root image directory
+
 
 =head1 RETURN VALUE
 
@@ -47,6 +49,10 @@ B<-c| --compress>          Compress Method (pigz,gzip,xz, default is pigz/gzip)
 2. To pack the osimage 'rhels7.1-x86_64-netboot-compute' with "tar" to archive and "pigz" to compress:
 
  packimage -m tar -c pigz rhels7.1-x86_64-netboot-compute
+
+3. To pack the osimage 'rhels7.1-x86_64-netboot-compute' without syncing files:
+
+ packimage --nosyncfiles rhels7.1-x86_64-netboot-compute
 
 =head1 FILES
 

--- a/xCAT-server/lib/xcat/plugins/packimage.pm
+++ b/xCAT-server/lib/xcat/plugins/packimage.pm
@@ -82,7 +82,7 @@ sub process_request {
         @ARGV = @{$args};
     }
     if (scalar(@ARGV) == 0) {
-        $callback->({ info => ["Usage:\n   packimage [-m| --method=cpio|tar] [-c| --compress=gzip|pigz|xz] <imagename>\n   packimage [-h| --help]\n   packimage [-v| --version]"] });
+        $callback->({ info => ["Usage:\n   packimage [-m| --method=cpio|tar] [-c| --compress=gzip|pigz|xz] [--nosyncfiles] <imagename>\n   packimage [-h| --help]\n   packimage [-v| --version]"] });
         return 0;
     }
 
@@ -95,6 +95,7 @@ sub process_request {
     my $syncfile;
     my $rootimg_dir;
     my $destdir;
+    my $nosyncfiles;
     my $imagename;
     my $dotorrent;
     my $provmethod;
@@ -109,6 +110,7 @@ sub process_request {
         "method|m=s"  => \$method,
         "compress|c=s"  => \$compress,
         "tracker=s"   => \$dotorrent,
+        'nosyncfiles'      => \$nosyncfiles,
         "help|h"      => \$help,
         "version|v"   => \$version
     );
@@ -122,7 +124,7 @@ sub process_request {
         return 0;
     }
     if ($help) {
-        $callback->({ info => ["Usage:\n   packimage [-m| --method=cpio|tar] [-c| --compress=gzip|pigz|xz] <imagename>\n   packimage [-h| --help]\n   packimage [-v| --version]"] });
+        $callback->({ info => ["Usage:\n   packimage [-m| --method=cpio|tar] [-c| --compress=gzip|pigz|xz] [--nosyncfiles] <imagename>\n   packimage [-h| --help]\n   packimage [-v| --version]"] });
         return 0;
     }
 
@@ -412,12 +414,15 @@ sub process_request {
     close($shadow);
     umask($oldmask);
 
-    # sync fils configured in the synclist to the rootimage
-    $syncfile = xCAT::SvrUtils->getsynclistfile(undef, $osver, $arch, $profile, "netboot", $imagename);
-    if (defined($syncfile) && -f $syncfile
-        && -d $rootimg_dir) {
-        print "sync files from $syncfile to the $rootimg_dir\n";
-        system("$::XCATROOT/bin/xdcp -i $rootimg_dir -F $syncfile");
+    if (not $nosyncfiles) {
+        # sync fils configured in the synclist to the rootimage
+        $syncfile = xCAT::SvrUtils->getsynclistfile(undef, $osver, $arch, $profile, "netboot", $imagename);
+        if ( defined($syncfile) && -f $syncfile && -d $rootimg_dir) {
+            print "Syncing files from $syncfile to root image dir: $rootimg_dir\n";
+            system("$::XCATROOT/bin/xdcp -i $rootimg_dir -F $syncfile");
+        }
+    } else {
+        print "Bypass of syncfiles requested, will not sync files to root image directory.\n";
     }
 
     my $temppath;


### PR DESCRIPTION
In existing code, `packimage` will always sync files in synclist to root image directory, and then pack into archive. Here, we provide an option to allow packimage to ignore syncing files in the synclist
```
packimage -h
Usage:
   packimage [-m| --method=cpio|tar] [-c| --compress=gzip|pigz|xz] [--nosyncfiles] <imagename>
   packimage [-h| --help]
   packimage [-v| --version]
```
synclist is defined for osimage
```
#lsdef -t osimage rhels7.5-alt-rc2-ppc64le-ANSIBLE-netboot-compute
Object name: rhels7.5-alt-rc2-ppc64le-ANSIBLE-netboot-compute
    exlist=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.exlist
    imagetype=linux
    osarch=ppc64le
    osdistroname=rhels7.5-alt-rc2-ppc64le
    osname=Linux
    osvers=rhels7.5-alt-rc2
    otherpkgdir=/install/ansible/custom/rhels7.5-alt-rc2-ppc64le-ANSIBLE-netboot-compute/otherpkgdir
    otherpkglist=/install/ansible/custom/rhels7.5-alt-rc2-ppc64le-ANSIBLE-netboot-compute/custom-rhels7.5-alt-rc2.otherpkglist.pkglist
    permission=755
    pkgdir=/install/rhels7.5-alt-rc2/ppc64le
    pkglist=/install/ansible/custom/rhels7.5-alt-rc2-ppc64le-ANSIBLE-netboot-compute/custom-rhels7.5-alt-rc2.pkglist
    postinstall=/install/ansible/custom/rhels7.5-alt-rc2-ppc64le-ANSIBLE-netboot-compute/custom-rhels7.5-alt-rc2.postinstall
    profile=compute
    provmethod=netboot
    rootimgdir=/install/ansible/custom/rhels7.5-alt-rc2-ppc64le-ANSIBLE-netboot-compute/rootimgdir
    synclists=/tmp/sensitive.lst
    usercomment=cudafull,mellanox

#cat /tmp/sensitive.lst
/etc/sensitive -> /etc/sensitive
/install/ansible/custom/rhels7.5-alt-rc2-ppc64le-ANSIBLE-netboot-compute/etc/shadow -> /etc/shadow
/install/ansible/custom/rhels7.5-alt-rc2-ppc64le-ANSIBLE-netboot-compute/etc/passwd -> /etc/passwd
#/etc/shadow -> /etc/shadow
#/etc/passwd -> /etc/passwd
```
```
#rm -f $ROOTIMGDIR
#genimage rhels7.5-alt-rc2-ppc64le-ANSIBLE-netboot-compute
XCATBYPASS=1 packimage --nosyncfiles rhels7.5-alt-rc2-ppc64le-ANSIBLE-netboot-compute > /tmp/packimg.log
#cat /tmp/packimg.log
excludestr=find . -xdev '!' -path './boot*' -a '!' -path './usr/share/wallpapers/RHEL6/contents/images*' -a '!' -path './usr/include*' -a '!' -path './usr/lib/locale*' -a '!' -path './usr/lib64/perl5/Encode/CN*' -a '!' -path './usr/lib64/perl5/Encode/JP*' -a '!' -path './usr/lib64/perl5/Encode/TW*' -a '!' -path './usr/lib64/perl5/Encode/KR*' -a '!' -path './lib/kbd/keymaps/i386*' -a '!' -path './lib/kbd/keymaps/mac*' -a '!' -path './lib/kbd/keymaps/include*' -a '!' -path './usr/local/include*' -a '!' -path './usr/local/share/man*' -a '!' -path './usr/share/man*' -a '!' -path './usr/share/cracklib*' -a '!' -path './usr/share/doc*' -a '!' -path './usr/share/gnome*' -a '!' -path './usr/share/i18n*' -a '!' -path './usr/share/info*' -a '!' -path './usr/share/locale/*' -a '!' -path './usr/share/omf*' -a '!' -path './usr/share/vim/site/doc*' -a '!' -path './usr/share/vim/vim74/doc*' -a '!' -path './usr/share/zoneinfo*' -a '!' -path './var/cache/man*' -a '!' -path './var/lib/yum*' -a '!' -path './tmp*' -a '!' -path './etc/init.d/statelite' -a '!' -path './etc/rc.sysinit.backup' -a '!' -path './.statelite*' -a '!' -path './.default*' -a '!' -path './.statebackup*'

 includestr=find . -xdev -path './usr/share/i18n/en_US*' -o -path './usr/share/locale/en_US*' -o -path './usr/share/locale/C*' -o -path './usr/share/locale/locale.alias' -o -path './usr/lib/locale/locale-archive' -o -path './usr/lib/locale/en*'

Bypass of syncfiles requested, will not sync files to root image directory.
Packing contents of /install/ansible/custom/rhels7.5-alt-rc2-ppc64le-ANSIBLE-netboot-compute/rootimgdir/rootimg
archive method:cpio
compress method:gzip
```

Check the root image directory, there are only the default shadow files created during `genimage` and the root password is updated based on DB table `passwd`.
```
cd $ROOTIMGDIR
cat etc/shadow
root:$5$0Bmm2XzV$FRnC1V8diewStQKtmFZ0IniUjw9nXcTnES/rifSZjR0:13880:0:99999:7:::
bin:*:17492:0:99999:7:::
daemon:*:17492:0:99999:7:::
adm:*:17492:0:99999:7:::
lp:*:17492:0:99999:7:::
sync:*:17492:0:99999:7:::
shutdown:*:17492:0:99999:7:::
halt:*:17492:0:99999:7:::
mail:*:17492:0:99999:7:::
operator:*:17492:0:99999:7:::
games:*:17492:0:99999:7:::
ftp:*:17492:0:99999:7:::
nobody:*:17492:0:99999:7:::
systemd-network:!!:17672::::::
dbus:!!:17672::::::
ntp:!!:17672::::::
rpc:!!:17672:0:99999:7:::
rpcuser:!!:17672::::::
nfsnobody:!!:17672::::::
sshd:!!:17672::::::
```
provision the CN with the osimage
```
rinstall mid05tor12cn16 osimage=rhels7.5-alt-rc2-ppc64le-ANSIBLE-netboot-compute
Provision node(s): mid05tor12cn16

ssh testme@mid05tor12cn16
testme@mid05tor12cn16's password:
Last login: Mon May 21 08:32:06 2018 from gateway
Could not chdir to home directory /home/testme: No such file or directory
/usr/bin/id: cannot find name for group ID 1001
```