### PR TITLE
fix issue Non-root user can not run ping on ubuntu 14.4.4 diskless #5227

### DIFF
--- a/xCAT-server/lib/xcat/plugins/packimage.pm
+++ b/xCAT-server/lib/xcat/plugins/packimage.pm
@@ -500,7 +500,7 @@ sub process_request {
         my $checkoption2 = `tar --selinux 2>&1`;
         my $option;
         if ($checkoption1 !~ /unrecognized/) {
-            $option .= "--xattrs-include='*' ";
+            $option .= " --xattrs --xattrs-include='*' ";
         }
         if ($checkoption2 !~ /unrecognized/) {
             $option .= "--selinux ";

--- a/xCAT-server/share/xcat/netboot/ubuntu/genimage
+++ b/xCAT-server/share/xcat/netboot/ubuntu/genimage
@@ -1501,9 +1501,9 @@ EOMS
     print $inifile "    ([ \"\$xcatdebugmode\" = \"1\" ] || [ \"\$xcatdebugmode\" = \"2\" ]) && logger -t xcat -p debug \"Extracting root filesystem:\"\n";
     print $inifile "    echo -n \"Extracting root filesystem:\"\n";
     print $inifile "    if [ -r /rootimg.tar.gz ]; then\n";
-    print $inifile "        /bin/tar --selinux --xattrs-include='*' -zxf /rootimg.tar.gz\n";
+    print $inifile "        /bin/tar --selinux --xattrs --xattrs-include='*' -zxf /rootimg.tar.gz\n";
     print $inifile "    elif [ -r /rootimg.tar.xz ]; then\n";
-    print $inifile "        /bin/tar --selinux --xattrs-include='*' -Jxf /rootimg.tar.xz\n";
+    print $inifile "        /bin/tar --selinux --xattrs --xattrs-include='*' -Jxf /rootimg.tar.xz\n";
     print $inifile "    fi\n";
     print $inifile "    ([ \"\$xcatdebugmode\" = \"1\" ] || [ \"\$xcatdebugmode\" = \"2\" ]) && logger -t xcat -p debug \"Done...\"\n";
     print $inifile "    echo Done\n";


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-core/issues/5227:

add  `tar` option `--xattrs` in packimage and ubuntu/genimage  


UT: 
```
root@c910f04x35v02:~# genimage ubuntu14.04.4-x86_64-netboot-compute
root@c910f04x35v02:~# packimage ubuntu14.04.4-x86_64-netboot-compute -m tar
root@c910f04x35v02:~# rinstall c910f04x35v04
root@c910f04x35v04:~# su immarvin
immarvin@c910f04x35v04:/root$ ping 127.0.0.1
PING 127.0.0.1 (127.0.0.1) 56(84) bytes of data.
64 bytes from 127.0.0.1: icmp_seq=1 ttl=64 time=0.028 ms
64 bytes from 127.0.0.1: icmp_seq=2 ttl=64 time=0.011 ms
^C
--- 127.0.0.1 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 999ms
rtt min/avg/max/mdev = 0.011/0.019/0.028/0.009 ms
immarvin@c910f04x35v04:/root$
```