### PR TITLE
update xcat-inventory test cases according to the modification in xcat-inventory 0.1.2

### DIFF
--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.common
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.common
@@ -32,7 +32,7 @@ end
 start:xcat_inventory_invalid_subcmd
 description:This case is used to test xcat-inventory export subcommand to handle invalid subcommand. The vaild subcommand are export and import.
 cmd:xcat-inventory aaa
-check:output=~ xcat-inventory: error: argument <subcommand>: invalid choice:
+check:output=~ Error: not a valid subcommand to run
 check:output=~ usage:
 check:rc!=0
 end
@@ -67,7 +67,7 @@ cmd:mkdir -p /tmp/xcat_inventory_import_option_f_invalid_file
 check:rc==0
 #to handle a non-existed file
 cmd:xcat-inventory import -f aaa
-check:output=~The specified path does not exist
+check:output=~The specified inventory file does not exist
 check:output !~Traceback
 check:rc!=0
 #To handle a invalid json file

--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.node
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.node
@@ -730,7 +730,7 @@ check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/xcat_inventory_try_to_export_nonexisted_node/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd: xcat-inventory export --format=json -t node -o bogusnode
-check:output=~Error: cannot find objects: bogusnode!
+check:output=~Error: cannot find node objects: bogusnode!
 check:rc!=0
 cmd: xcat-inventory export --format=yaml -t node -o bogusnode
 check:output=~Error: cannot find objects: bogusnode!

--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.node
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.node
@@ -733,7 +733,7 @@ cmd: xcat-inventory export --format=json -t node -o bogusnode
 check:output=~Error: cannot find node objects: bogusnode!
 check:rc!=0
 cmd: xcat-inventory export --format=yaml -t node -o bogusnode
-check:output=~Error: cannot find objects: bogusnode!
+check:output=~Error: cannot find node objects: bogusnode!
 check:rc!=0
 cmd:if [[ -e /tmp/xcat_inventory_try_to_export_nonexisted_node/bogusnode.stanza ]]; then cat /tmp/xcat_inventory_try_to_export_nonexisted_node/bogusnode.stanza | mkdef -z;fi
 check:rc==0
@@ -752,12 +752,12 @@ check:rc==0
 cmd:xcat-inventory export --format=json  -t node -o bogusnode |tee  /tmp/xcat_inventory_try_to_import_nonexisted_node/json
 check:rc==0
 cmd:xcat-inventory import -f /tmp/xcat_inventory_try_to_import_nonexisted_node/json  -t node -o bogusnode1
-check:output=~Error: cannot find objects: bogusnode1!
+check:output=~Error: cannot find node objects: bogusnode1!
 check:rc!=0
 cmd:xcat-inventory export --format=yaml -t node -o bogusnode |tee  /tmp/xcat_inventory_try_to_import_nonexisted_node/yaml
 check:rc==0
 cmd:xcat-inventory import -f /tmp/xcat_inventory_try_to_import_nonexisted_node/yaml  -t node -o bogusnode1
-check:output=~Error: cannot find objects: bogusnode1!
+check:output=~Error: cannot find node objects: bogusnode1!
 check:rc!=0
 cmd:rmdef bogusnode
 check:rc==0

--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.osimage.validation
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.osimage.validation
@@ -14,7 +14,7 @@ check: rc==0
 cmd: /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "osimage" "testosimage1" "role" "invalid" "/tmp/xcat_inventory_import_validation_osimage/trash/"
 check: rc!=0
 cmd: /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "osimage" "testosimage1" "role" "" "/tmp/xcat_inventory_import_validation_osimage/trash/"
-check: rc!=0
+check: rc==0
 
 cmd: /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/validatehelper "osimage" "testosimage1" "imagetype" "windows" "/tmp/xcat_inventory_import_validation_osimage/trash/"
 check: rc==0


### PR DESCRIPTION
* update the error message check

* the `role` attribute of osimage is allowed, since for cumulus os image, there is no `role` info

UT:

```
[root@c910f03c05k08 ~]# XCATTEST_DSTMN=10.3.5.8 xcattest -t xcat_inventory_invalid_subcmd,xcat_inventory_import_option_f_invalid_file,xcat_inventory_try_to_export_nonexisted_node,xcat_inventory_import_validation_osimage
...
------END::xcat_inventory_import_validation_osimage::Passed::Time:Tue May 22 03:16:07 2018 ::Duration::50 sec------
------Total: 4 , Failed: 0------

xCAT automated test finished at Tue May 22 03:16:07 2018
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20180522031513 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20180522031513 file for time consumption

```
