### PR TITLE
Modify some error or typo in some old cases

### DIFF
--- a/xCAT-test/autotest/testcase/chtab/cases0
+++ b/xCAT-test/autotest/testcase/chtab/cases0
@@ -61,7 +61,7 @@ start:chtab_err_table
 description:chtab with error table
 cmd:chtab error=error site.comment=error
 check:rc!=0
-check:output=~no such column
+check:output=~no such column|column \"error\" does not exist
 end
 
 

--- a/xCAT-test/autotest/testcase/chvm/cases0
+++ b/xCAT-test/autotest/testcase/chvm/cases0
@@ -44,7 +44,15 @@ check:rc!=0
 check:output=~Usage
 end
 start:chvm_err_node
-cmd:chvm testnode
+cmd:dir="/tmp/chvm_err_node";echo ${dir}".old";if [ -d "${dir}" ];then mv ${dir} ${dir}".old"; fi; mkdir -p $dir
+check:rc==0
+cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/chvm_err_node/bogusnode.stanza ;rmdef bogusnode;fi
+check:rc==0
+cmd:chvm bogusnode 
 check:rc!=0
-check:output=~Usage
+check:output=~Error: Invalid nodes and/or groups in noderange
+cmd:if [[ -e /tmp/chvm_err_node/bogusnode.stanza ]]; then cat /tmp/chvm_err_node/bogusnode.stanza | mkdef -z;fi
+check:rc==0
+cmd:dir="/tmp/chvm_err_node"; rm -rf $dir; if [ -d ${dir}".old" ];then mv ${dir}".old" $dir; fi
+check:rc==0
 end

--- a/xCAT-test/autotest/testcase/mkdef/cases0
+++ b/xCAT-test/autotest/testcase/mkdef/cases0
@@ -294,8 +294,8 @@ check:rc==0
 check:output=~1 object definitions have been created or modified
 cmd:lsdef auto_test_cec_node
 check:output=~Object name\: auto\_test\_cec\_node
-check:output=~groups\=test\_template\_priority
-check:output!=groups\=cec\,all
+check:output!=groups\=test\_template\_priority
+check:output=~groups\=cec\,all
 check:output=~hwtype\=cec
 check:output=~mgt\=hmc
 check:output=~nodetype\=ppc

--- a/xCAT-test/autotest/testcase/nodech/cases0
+++ b/xCAT-test/autotest/testcase/nodech/cases0
@@ -173,7 +173,7 @@ end
 
 start:nodech_d_error
 description:nodech --delete
-cmd:chdef -t node -o testnode os=hello
+cmd:chdef -t node -o testnode os=hello groups=test
 check:rc==0
 cmd:nodech --delete
 check:rc!=0

--- a/xCAT-test/autotest/testcase/xcatsnap/cases0
+++ b/xCAT-test/autotest/testcase/xcatsnap/cases0
@@ -29,7 +29,7 @@ start:xcatsnap_v
 description:xcatsnap -v and --version
 cmd:xcatsnap -v
 check:output=~version|Version
-cmd:xcatsnamp --version
+cmd:xcatsnap --version
 check:output=~version|Version
 end
 


### PR DESCRIPTION
There are some error or typo in some old test cases, modify them in the pull request.

The UT are:
```
------START::check_mkdef_node_with_template_priority::Time:Thu May 24 02:00:22 2018------

RUN:result=`lsdef | grep  cec-template`; if [[ $result =~ "cec-template" ]]; then echo $result; noderm cec-template; fi [Thu May 24 02:00:22 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:result=`lsdef | grep  auto_test_cec_node`; if [[ $result =~ "auto_test_cec_node" ]]; then echo $result; noderm auto_test_cec_node; fi [Thu May 24 02:00:23 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:mkdef -t node -o cec-template --template cec-template serial=test mtm=test hcp=test groups=test_template_priority [Thu May 24 02:00:23 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]
CHECK:output =~ 1 object definitions have been created or modified	[Pass]

RUN:mkdef -t node -o auto_test_cec_node --template cec-template serial=test2 mtm=test2 hcp=test2 [Thu May 24 02:00:24 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]
CHECK:output =~ 1 object definitions have been created or modified	[Pass]

RUN:lsdef auto_test_cec_node [Thu May 24 02:00:24 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Object name: auto_test_cec_node
    groups=cec,all
    hcp=test2
    hwtype=cec
    mgt=hmc
    mtm=test2
    nodetype=ppc
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
    serial=test2
    usercomment=the cec definition template
CHECK:output =~ Object name\: auto\_test\_cec\_node	[Pass]
CHECK:output != groups\=test\_template\_priority	[Pass]
CHECK:output =~ groups\=cec\,all	[Pass]
CHECK:output =~ hwtype\=cec	[Pass]
CHECK:output =~ mgt\=hmc	[Pass]
CHECK:output =~ nodetype\=ppc	[Pass]
CHECK:output =~ postbootscripts\=otherpkgs	[Pass]
CHECK:output =~ postscripts\=syslog\,remoteshell\,syncfiles	[Pass]
CHECK:output =~ usercomment\=the cec definition template	[Pass]
CHECK:output =~ hcp\=test2	[Pass]
CHECK:output =~ mtm\=test2	[Pass]
CHECK:output =~ serial\=test2	[Pass]

RUN:noderm cec-template [Thu May 24 02:00:25 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:noderm auto_test_cec_node [Thu May 24 02:00:25 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::check_mkdef_node_with_template_priority::Passed::Time:Thu May 24 02:00:25 2018 ::Duration::3 sec------

------START::nodech_d_error::Time:Thu May 24 02:04:06 2018------

RUN:chdef -t node -o testnode os=hello groups=test [Thu May 24 02:04:06 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
New object definitions 'testnode' have been created.
CHECK:rc == 0	[Pass]

RUN:nodech --delete [Thu May 24 02:04:07 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Usage: nodech <noderange> table.column=value [...]
       nodech {-d | --delete} <noderange> <table> [...]
       nodech {-v | --version}
       nodech [-? | -h | --help]
CHECK:rc != 0	[Pass]
CHECK:output =~ Usage	[Pass]

RUN:nodech -d [Thu May 24 02:04:07 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Usage: nodech <noderange> table.column=value [...]
       nodech {-d | --delete} <noderange> <table> [...]
       nodech {-v | --version}
       nodech [-? | -h | --help]
CHECK:rc != 0	[Pass]
CHECK:output =~ Usage	[Pass]

RUN:rmdef -t node testnode [Thu May 24 02:04:07 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.

------END::nodech_d_error::Passed::Time:Thu May 24 02:04:08 2018 ::Duration::2 sec------

------START::chtab_err_table::Time:Thu May 24 02:06:57 2018------

RUN:chtab error=error site.comment=error [Thu May 24 02:06:57 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
DBD::Pg::st execute failed: ERROR:  column "error" does not exist
LINE 1: SELECT * FROM site WHERE "error" = $1
                                 ^ at /opt/xcat/lib/perl/xCAT/Table.pm line 1770.
DBD::Pg::st fetchrow_arrayref failed: no statement executing at /opt/xcat/lib/perl/xCAT/Table.pm line 1774.
DBD::Pg::st execute failed: ERROR:  current transaction is aborted, commands ignored until end of transaction block at /opt/xcat/lib/perl/xCAT/Table.pm line 1911.
CHECK:rc != 0	[Pass]
CHECK:output =~ no such column|column \"error\" does not exist	[Pass]

------END::chtab_err_table::Passed::Time:Thu May 24 02:06:57 2018 ::Duration::0 sec------

------START::xcatsnap_v::Time:Thu May 24 02:13:12 2018------

RUN:xcatsnap -v [Thu May 24 02:13:12 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Version 2.14.1 (git commit bed114d6b9779d48ba37447deb7842ec954e808e, built Tue May 22 06:15:46 EDT 2018)

CHECK:output =~ version|Version	[Pass]

RUN:xcatsnap --version [Thu May 24 02:13:12 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Version 2.14.1 (git commit bed114d6b9779d48ba37447deb7842ec954e808e, built Tue May 22 06:15:46 EDT 2018)

CHECK:output =~ version|Version	[Pass]

------END::xcatsnap_v::Passed::Time:Thu May 24 02:13:12 2018 ::Duration::0 sec------

------START::chvm_err_node::Time:Thu May 24 02:33:48 2018------

RUN:dir="/tmp/chvm_err_node";echo ${dir}".old";if [ -d "${dir}" ];then mv ${dir} ${dir}".old"; fi; mkdir -p $dir [Thu May 24 02:33:48 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
/tmp/chvm_err_node.old
CHECK:rc == 0	[Pass]

RUN:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/chvm_err_node/bogusnode.stanza ;rmdef bogusnode;fi [Thu May 24 02:33:48 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:chvm bogusnode [Thu May 24 02:33:49 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Error: Invalid nodes and/or groups in noderange: bogusnode
CHECK:rc != 0	[Pass]
CHECK:output =~ Error: Invalid nodes and/or groups in noderange	[Pass]

RUN:if [[ -e /tmp/chvm_err_node/bogusnode.stanza ]]; then cat /tmp/chvm_err_node/bogusnode.stanza | mkdef -z;fi [Thu May 24 02:33:49 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:dir="/tmp/chvm_err_node"; rm -rf $dir; if [ -d ${dir}".old" ];then mv ${dir}".old" $dir; fi [Thu May 24 02:33:49 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::chvm_err_node::Passed::Time:Thu May 24 02:33:49 2018 ::Duration::1 sec------
```