### PR TITLE
Add one test case for xcat-inventory export option -f

### DIFF
--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.common
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.common
@@ -53,13 +53,47 @@ check:output!~Traceback (most recent call last):
 check:rc!=0
 end
 
-#start:xcat_inventory_export_option_f_invalid_file
-#description:This case is used to test xcat-inventory export subcommand to handle invalid file for option f
-#cmd:xcat-inventory export -f aaa
-#check:output=~The specified path does not exist
-#check:output !~Traceback
-#check:rc!=0
-#end
+start:xcat_inventory_export_option_f
+description:This case is used to test xcat-inventory export subcommand to handle option f
+cmd:dir="/tmp/xcat_inventory_export_option_f";echo ${dir}".old";if [ -d "${dir}" ];then mv ${dir} ${dir}".old"; fi; mkdir -p $dir
+check:rc==0
+cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/xcat_inventory_export_option_f/bogusnode.stanza ;rmdef bogusnode;fi
+check:rc==0
+cmd:mkdef -t node -o bogusnode groups=bogusgroup
+check:rc==0
+cmd:xcat-inventory export --format=yaml -t node -o bogusnode | tee /tmp/xcat_inventory_export_option_f/export_yaml_without_f
+check:rc==0
+cmd:xcat-inventory export --format=yaml -t node -o bogusnode -f /tmp/xcat_inventory_export_option_f/export_yaml_with_f
+check:rc==0
+check:output !~Traceback
+cmd:diff  /tmp/xcat_inventory_export_option_f/export_yaml_without_f /tmp/xcat_inventory_export_option_f/export_yaml_with_f
+check:rc==0
+cmd:xcat-inventory export -t node -o bogusnode | tee /tmp/xcat_inventory_export_option_f/export_json_without_f
+check:rc==0
+cmd:xcat-inventory export -t node -o bogusnode --path /tmp/xcat_inventory_export_option_f/export_json_with_f
+check:rc==0
+cmd:diff /tmp/xcat_inventory_export_option_f/export_json_without_f  /tmp/xcat_inventory_export_option_f/export_json_with_f
+check:rc==0
+cmd:xcat-inventory export -t node -o bogusnode -f
+check:rc!=0
+check:output ~=usage
+check:output ~= error: argument -f/--path: expected one argument
+cmd:xcat-inventory export -t node -o bogusnode --path
+check:rc!=0
+eck:output ~=usage
+check:output ~= error: argument -f/--path: expected one argument
+cmd:mkdir /tmp/xcat_inventory_export_option_f/testdir
+check:rc==0
+cmd:xcat-inventory export -t node -o bogusnode -f /tmp/xcat_inventory_export_option_f/testdir
+check:rc!=0
+check:output ~= Error: the specified file /tmp/xcat_inventory_export_option_f/testdir already exists, is not a file!
+cmd:rmdef bogusnode
+check:rc==0
+cmd:if [[ -e /tmp/xcat_inventory_export_option_f/bogusnode.stanza ]]; then cat /tmp/xcat_inventory_export_option_f/bogusnode.stanza | mkdef -z;fi
+check:rc==0
+cmd:dir="/tmp/xcat_inventory_export_option_f"; rm -rf $dir; if [ -d ${dir}".old" ];then mv ${dir}".old" $dir; fi
+check:rc==0
+end
 
 start:xcat_inventory_import_option_f_invalid_file
 description:This case is used to test xcat-inventory import subcommand to handle invalid file for option f


### PR DESCRIPTION
Add one test case for xcat-inventory export option ``-f``.

The UT is:
```
------START::xcat_inventory_export_option_f::Time:Thu May 24 02:59:51 2018------

RUN:dir="/tmp/xcat_inventory_export_option_f";echo ${dir}".old";if [ -d "${dir}" ];then mv ${dir} ${dir}".old"; fi; mkdir -p $dir [Thu May 24 02:59:51 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
/tmp/xcat_inventory_export_option_f.old
CHECK:rc == 0	[Pass]

RUN:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/xcat_inventory_export_option_f/bogusnode.stanza ;rmdef bogusnode;fi [Thu May 24 02:59:51 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:mkdef -t node -o bogusnode groups=bogusgroup [Thu May 24 02:59:51 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:xcat-inventory export --format=yaml -t node -o bogusnode | tee /tmp/xcat_inventory_export_option_f/export_yaml_without_f [Thu May 24 02:59:52 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
node:
  bogusnode:
    device_type: server
    obj_info:
      groups: bogusgroup
    obj_type: node
    role: compute
schema_version: '1.0'

CHECK:rc == 0	[Pass]

RUN:xcat-inventory export --format=yaml -t node -o bogusnode -f /tmp/xcat_inventory_export_option_f/export_yaml_with_f [Thu May 24 02:59:52 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
The inventory data has been dumped to /tmp/xcat_inventory_export_option_f/export_yaml_with_f
CHECK:rc == 0	[Pass]
CHECK:output !~ Traceback	[Pass]

RUN:diff  /tmp/xcat_inventory_export_option_f/export_yaml_without_f /tmp/xcat_inventory_export_option_f/export_yaml_with_f [Thu May 24 02:59:53 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xcat-inventory export -t node -o bogusnode | tee /tmp/xcat_inventory_export_option_f/export_json_without_f [Thu May 24 02:59:53 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
{
    "node": {
        "bogusnode": {
            "device_type": "server",
            "obj_info": {
                "groups": "bogusgroup"
            },
            "obj_type": "node",
            "role": "compute"
        }
    },
    "schema_version": "1.0"
}
CHECK:rc == 0	[Pass]

RUN:xcat-inventory export -t node -o bogusnode --path /tmp/xcat_inventory_export_option_f/export_json_with_f [Thu May 24 02:59:54 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
The inventory data has been dumped to /tmp/xcat_inventory_export_option_f/export_json_with_f
CHECK:rc == 0	[Pass]

RUN:diff /tmp/xcat_inventory_export_option_f/export_json_without_f  /tmp/xcat_inventory_export_option_f/export_json_with_f [Thu May 24 02:59:55 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xcat-inventory export -t node -o bogusnode -f [Thu May 24 02:59:55 2018]
ElapsedTime:0 sec
RETURN rc = 2
OUTPUT:
usage: xcat-inventory export [-t <type>] [-x EXCLUDE] [-o <name>] [-f <path>]
                             [-d <directory>] [-s <version>]
                             [--format <format>]
xcat-inventory export: error: argument -f/--path: expected one argument
CHECK:rc != 0	[Pass]
CHECK:output ~= usage	[Pass]
CHECK:output ~= error: argument -f/--path: expected one argument	[Pass]

RUN:xcat-inventory export -t node -o bogusnode --path [Thu May 24 02:59:55 2018]
ElapsedTime:0 sec
RETURN rc = 2
OUTPUT:
usage: xcat-inventory export [-t <type>] [-x EXCLUDE] [-o <name>] [-f <path>]
                             [-d <directory>] [-s <version>]
                             [--format <format>]
xcat-inventory export: error: argument -f/--path: expected one argument
CHECK:rc != 0	[Pass]
CHECK:output ~= error: argument -f/--path: expected one argument	[Pass]

RUN:mkdir /tmp/xcat_inventory_export_option_f/testdir [Thu May 24 02:59:55 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xcat-inventory export -t node -o bogusnode -f /tmp/xcat_inventory_export_option_f/testdir [Thu May 24 02:59:55 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: the specified file /tmp/xcat_inventory_export_option_f/testdir already exists, is not a file!
CHECK:rc != 0	[Pass]
CHECK:output ~= Error: the specified file /tmp/xcat_inventory_export_option_f/testdir already exists, is not a file!	[Pass]

RUN:rmdef bogusnode [Thu May 24 02:59:56 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:if [[ -e /tmp/xcat_inventory_export_option_f/bogusnode.stanza ]]; then cat /tmp/xcat_inventory_export_option_f/bogusnode.stanza | mkdef -z;fi [Thu May 24 02:59:57 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:dir="/tmp/xcat_inventory_export_option_f"; rm -rf $dir; if [ -d ${dir}".old" ];then mv ${dir}".old" $dir; fi [Thu May 24 02:59:57 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::xcat_inventory_export_option_f::Passed::Time:Thu May 24 02:59:57 2018 ::Duration::6 sec------
```