### PR TITLE
Increase packet size of recv()

### DIFF
--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -809,7 +809,7 @@ sub do_udp_service {    # This function opens up a UDP port
                     my $hdl;
                     foreach $hdl (@hdls) {
                         if ($hdl == $socket) {
-                            $part = $socket->recv($data, 2000);
+                            $part = $socket->recv($data, 3000);
                             $packets{$part} = [ $part, $data ];
                         } elsif ($hdl == $sslctl) {
                             next;
@@ -861,7 +861,7 @@ sub do_udp_service {    # This function opens up a UDP port
                     while (@hdls = $select->can_read(0)) { # grab any incoming requests during run
                         foreach my $hdl (@hdls) {
                             if ($hdl == $socket) {
-                                $part = $socket->recv($data, 1500);
+                                $part = $socket->recv($data,3000);
                                 $packets{$part} = [ $part, $data ];
 
                                 #} elsif ($hdl == $sslctl) {


### PR DESCRIPTION
this is for issue #5177

If `findme` discovery packet size is more than 2000B,  the xcatd will not be able to receive this request.  Increase recv() packet size to 3000B. 

```
 -rw-r--r-- 1 root root 2038 May 24 09:24 discopacket.gz
````
the `/var/log/xcat/cluster.log` will show the log message as following:
```
May 21 11:57:29 boston02 xcat[73619]: DEBUG dhcp: load dhcp config file /etc/dhcp/dhcpd.conf
May 21 11:57:29 boston02 xcat[73619]: xcat.discovery.nodediscover: mid08tor03cn10 has been discovered
May 21 11:57:29 boston02 xcat[73619]: DEBUG xcatd: call plugin <typemtms> to handle command <findme>
May 21 11:57:29 boston02 xcat[73619]: DEBUG xcatd: call plugin <zzzdiscovery> to handle command <findme>
May 21 11:57:29 boston02 xcat[73619]: xcat.discovery.zzzdiscovery: (8335-GTC*785261A) Successfully discovered the node using switch discovery method.
````
hwinv table stored disks for each node, so we can't throw out the `disksize` in the discopacket
```
# tabdump hwinv
#node,cputype,cpucount,memory,disksize,comments,disable
"mid08tor03cn10","POWER9 (raw), altivec supported","160","261597MB","sda:932GB,sdb:932GB",,
"sn02","POWER9 (raw), altivec supported","176","523462MB","sda:932GB,sdb:932GB",,
"mid08tor03cn26","POWER9, altivec supported","128","114331MB",,,
"mid08tor03cn01","POWER9 (raw), altivec supported","132","523488MB","sda:932GB,sdb:932GB",,
```

 