### PR TITLE
redirect wget output to /tmp/wget.log

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/post.xcat
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat
@@ -88,7 +88,7 @@ if [ ! -x /usr/bin/wget ]; then
     sleep 36500d
 fi
 
-wget -l inf -N -r --waitretry=10 --random-wait --retry-connrefused  -e robots=off -nH --cut-dirs=2 --reject "index.html*" --no-parent -t 20 -T 60 http://$MASTER_IP$INSTALLDIR/postscripts/ -P /xcatpost
+wget -l inf -N -r --waitretry=10 --random-wait --retry-connrefused  -e robots=off -nH --cut-dirs=2 --reject "index.html*" --no-parent -t 20 -T 60 http://$MASTER_IP$INSTALLDIR/postscripts/ -P /xcatpost 2> /tmp/wget.log
 if [ "$?" != "0" ]; then
     msgutil_r "$MASTER_IP" "error" "failed to download postscripts from http://$MASTER_IP$INSTALLDIR/postscripts/, halt ..." "/var/log/xcat/xcat.log" "$log_label"
     /tmp/updateflag $MASTER $XCATIPORT "installstatus failed"

--- a/xCAT-server/share/xcat/install/scripts/post.xcat
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat
@@ -90,7 +90,7 @@ fi
 
 wget -l inf -N -r --waitretry=10 --random-wait --retry-connrefused  -e robots=off -nH --cut-dirs=2 --reject "index.html*" --no-parent -t 20 -T 60 http://$MASTER_IP$INSTALLDIR/postscripts/ -P /xcatpost 2> /tmp/wget.log
 if [ "$?" != "0" ]; then
-    msgutil_r "$MASTER_IP" "error" "failed to download postscripts from http://$MASTER_IP$INSTALLDIR/postscripts/, halt ..." "/var/log/xcat/xcat.log" "$log_label"
+    msgutil_r "$MASTER_IP" "error" "failed to download postscripts from http://$MASTER_IP$INSTALLDIR/postscripts/,check /tmp/wget.log on the node,  halt ..." "/var/log/xcat/xcat.log" "$log_label"
     /tmp/updateflag $MASTER $XCATIPORT "installstatus failed"
     sleep 36500d
 fi


### PR DESCRIPTION
For issue #5248 .

For diskfull installation,   the message of downloading each postscripts from wget() still showed at `/var/log/xcat/xcat.log`.   redirect wget stderr to /tmp/wget.log for this PR.
````
Running Kickstart Post-Installation script...
Fri May 25 10:39:59 EDT 2018 [info]: xcat.deployment: Executing post.xcat to prepare for firstbooting ...
Fri May 25 10:40:42 EDT 2018 [info]: xcat.deployment: trying to download postscripts from 172.20.254.2...
Fri May 25 10:40:43 EDT 2018 [info]: xcat.deployment: postscripts downloaded successfully
````