### PR TITLE
Update the testcase to cover the changes in #5119

### DIFF
--- a/xCAT-test/autotest/testcase/UT_openbmc/reventlog_resolved_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/reventlog_resolved_cases0
@@ -4,7 +4,7 @@ os:Linux
 hcp:openbmc
 cmd:reventlog $$CN resolved
 check:rc==1
-check:output=~Error: Usage error. Provide a comma separated
+check:output=~Error: (\[.*?\]: )?Usage error. Provide a comma separated
 end
 
 start:reventlog_resolved_parse_error2
@@ -13,7 +13,7 @@ os:Linux
 hcp:openbmc
 cmd:reventlog $$CN resolved=
 check:rc==1
-check:output=~Error: Usage error. Provide a comma separated
+check:output=~Error: (\[.*?\]: )?Usage error. Provide a comma separated
 end
 
 start:reventlog_resolved_parse_error3
@@ -22,7 +22,7 @@ os:Linux
 hcp:openbmc
 cmd:reventlog $$CN resolved 1,2,3
 check:rc==1
-check:output=~Error: Usage error. Provide a comma separated
+check:output=~Error: (\[.*?\]: )?Usage error. Provide a comma separated
 end
 
 start:reventlog_resolved_parse_error4
@@ -31,7 +31,7 @@ os:Linux
 hcp:openbmc
 cmd:reventlog $$CN resolved=-1
 check:rc==1
-check:output=~Error: Invalid ID=
+check:output=~Error: (\[.*?\]: )?Invalid ID=
 end
 
 start:reventlog_resolved_parse_error5
@@ -40,7 +40,7 @@ os:Linux
 hcp:openbmc
 cmd:reventlog $$CN resolved=abc
 check:rc==1
-check:output=~Error: Invalid ID=
+check:output=~Error: (\[.*?\]: )?Invalid ID=
 end
 
 start:reventlog_resolved_list

--- a/xCAT-test/autotest/testcase/UT_openbmc/rflash_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rflash_cases0
@@ -14,7 +14,7 @@ os:Linux
 hcp:openbmc
 cmd: rflash $$CN -a /tmp/abc123.tz
 check:rc==1
-check:output=~Error: Invalid firmware specified with -a
+check:output=~Error: (\[.*?\]: )?Invalid firmware specified with -a
 end 
 
 start:rflash_invalid_activate_and_delete
@@ -23,7 +23,7 @@ os:Linux
 hcp:openbmc
 cmd: rflash $$CN -a 123 --delete 123
 check:rc==1
-check:output=~Error: Multiple options are not supported
+check:output=~Error: (\[.*?\]: )?Multiple options are not supported
 end 
 
 start:rflash_invalid_id 
@@ -32,7 +32,7 @@ os:Linux
 hcp:openbmc
 cmd: rflash $$CN -a 123
 check:rc==1
-check:output=~Error: Invalid ID provided to activate
+check:output=~Error: (\[.*?\]: )?Invalid ID provided to activate
 end 
 
 start:rflash_invalid_multiple_id_3
@@ -41,7 +41,7 @@ os:Linux
 hcp:openbmc
 cmd: rflash $$CN -a 123 abc asdbas 
 check:rc==1
-check:output=~Error: More than one firmware specified is not supported
+check:output=~Error: (\[.*?\]: )?More than one firmware specified is not supported
 end 
 
 start:rflash_invalid_multiple_id_2
@@ -50,7 +50,7 @@ os:Linux
 hcp:openbmc
 cmd: rflash $$CN -a asdbas 123
 check:rc==1
-check:output=~Error: More than one firmware specified is not supported
+check:output=~Error: (\[.*?\]: )?More than one firmware specified is not supported
 end 
 
 start:rflash_invalid_node
@@ -59,7 +59,7 @@ os:Linux
 hcp:openbmc
 cmd: rflash -a 221d9020
 check:rc==1 
-check:output=~Error: Invalid nodes and/or groups in noderange: 221d9020
+check:output=~Error: (\[.*?\]: )?Invalid nodes and/or groups in noderange: 221d9020
 end
 
 start:rflash_invalid_delete_2
@@ -68,7 +68,7 @@ os:Linux
 hcp:openbmc
 cmd: rflash $$CN --delete 221d9020 221d9020
 check:rc==1 
-check:output=~Error: More than one firmware specified is not supported
+check:output=~Error: (\[.*?\]: )?More than one firmware specified is not supported
 end
 
 start:rflash_delete_active_bmc
@@ -77,5 +77,5 @@ os:Linux
 hcp:openbmc
 cmd: rflash $$CN -l | grep \* | grep BMC | awk '{print $2}' | xargs -i{} rflash $$CN --delete {}
 check:rc==1
-check:output=~$$CN: Error: Deleting currently active BMC firmware is not supported
+check:output=~$$CN: (\[.*?\]: )?Error: Deleting currently active BMC firmware is not supported
 end

--- a/xCAT-test/autotest/testcase/UT_openbmc/rspconfig_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rspconfig_cases0
@@ -23,7 +23,7 @@ description: Check the parsing code for rspconfig (error cases)
 hcp: openbmc
 cmd: rspconfig $$CN ip,netmask,gateway,hostname,vlan
 check:rc==1
-check:output=~Error: Unsupported command
+check:output=~Error: (\[.*?\]: )?Unsupported command
 end 
 
 start:rspconfig_get_set_error
@@ -31,7 +31,7 @@ description: Check the parsing code for rspconfig (error cases) - Cannot get/set
 hcp: openbmc
 cmd: rspconfig $$CN ip netmask=255.0.0.0
 check:rc==1
-check:output=~Error: Can not set and query OpenBMC information at the same time
+check:output=~Error: (\[.*?\]: )?Can not set and query OpenBMC information at the same time
 end
 
 start:rspconfig_get_and_set_hostname

--- a/xCAT-test/autotest/testcase/addkitcomp/case0
+++ b/xCAT-test/autotest/testcase/addkitcomp/case0
@@ -110,7 +110,7 @@ check:output=~KIT_DEPLOY_PARAMS
 check:output=~KIT_COMPONENTS
 cmd:rmkitcomp -i testimage ubuntukit-compute-1-1.0-1-ubuntu-14.04-ppc64el 
 check:rc==1
-check:output=~Error: Failed to remove kitcomponent
+check:output=~Error: (\[.*?\]: )?Failed to remove kitcomponent
 cmd:rmkitcomp -i testimage -f ubuntukit-compute-1-1.0-1-ubuntu-14.04-ppc64el
 check:rc==0
 check:output=~Removing kitcomponent ubuntukit-compute-1-1.0-1-ubuntu-14.04-ppc64el from osimage testimage

--- a/xCAT-test/autotest/testcase/chdef/cases0
+++ b/xCAT-test/autotest/testcase/chdef/cases0
@@ -21,13 +21,13 @@ check:output=~groups=linux
 cmd:chdef -t node -o testnode postscripts="syslog,remoteshell,syncfiles"
 check:rc==0
 check:output!~Error
-check:output=~Warning: testnode: postscripts 'syslog' is already included
-check:output=~Warning: testnode: postscripts 'remoteshell' is already included
-check:output=~Warning: testnode: postscripts 'syncfiles' is already included
+check:output=~Warning: (\[.*?\]: )?testnode: postscripts 'syslog' is already included
+check:output=~Warning: (\[.*?\]: )?testnode: postscripts 'remoteshell' is already included
+check:output=~Warning: (\[.*?\]: )?testnode: postscripts 'syncfiles' is already included
 cmd:chdef -t node -o testnode postbootscripts=otherpkgs
 check:rc==0
 check:output!~Error
-check:output=~Warning: testnode: postbootscripts 'otherpkgs' is already included
+check:output=~Warning: (\[.*?\]: )?testnode: postbootscripts 'otherpkgs' is already included
 cmd:rmdef -t node testnode
 check:rc==0
 end

--- a/xCAT-test/autotest/testcase/chvm/cases0
+++ b/xCAT-test/autotest/testcase/chvm/cases0
@@ -50,7 +50,7 @@ cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z 
 check:rc==0
 cmd:chvm bogusnode 
 check:rc!=0
-check:output=~Error: Invalid nodes and/or groups in noderange
+check:output=~Error: (\[.*?\]: )?Invalid nodes and/or groups in noderange
 cmd:if [[ -e /tmp/chvm_err_node/bogusnode.stanza ]]; then cat /tmp/chvm_err_node/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:dir="/tmp/chvm_err_node"; rm -rf $dir; if [ -d ${dir}".old" ];then mv ${dir}".old" $dir; fi

--- a/xCAT-test/autotest/testcase/lsdef/cases0
+++ b/xCAT-test/autotest/testcase/lsdef/cases0
@@ -246,5 +246,5 @@ description:lsdef --template with invalid template name
 cmd:result=`lsdef | grep  test_with_invalid_name`; if [[ $result =~ "test_with_invalid_name" ]]; then noderm test_with_invalid_name; fi
 cmd:lsdef --template "test_with_invalid_name"
 check:rc==1
-check:output=~Error: Could not find test_with_invalid_name in xCAT templates.
+check:output=~Error: (\[.*?\]: )?Could not find test_with_invalid_name in xCAT templates.
 end 

--- a/xCAT-test/autotest/testcase/nodeset/cases0
+++ b/xCAT-test/autotest/testcase/nodeset/cases0
@@ -173,7 +173,7 @@ cmd:if [[ "__GETNODEATTR($$CN,arch)__" =~ "el" || "__GETNODEATTR($$CN,arch)__" =
 check:rc==0
 cmd:lsdef testnode1
 cmd:nodeset testnode1 osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
-check:output=~Warning: testnode1:.+might be invalid
+check:output=~Warning: (\[.*?\]: )?testnode1:.+might be invalid
 cmd:noderm testnode1
 end
 
@@ -349,7 +349,7 @@ description:This testcase is to very nodeset osimage errorcommand could give rig
 Attribute: $$CN-The operation object of nodeset command
 cmd:nodeset $$CN osimage= __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==1
-check:output=~Error: Invalid argument:
+check:output=~Error: (\[.*?\]: )?Invalid argument:
 check:output=~Usage: nodeset <noderange>
 end
 

--- a/xCAT-test/autotest/testcase/packimg/cases0
+++ b/xCAT-test/autotest/testcase/packimg/cases0
@@ -343,7 +343,7 @@ cmd:ls -l /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/c
 check:rc==0
 cmd:packimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute -m invalid 
 check:rc!=0
-check:output=~Error: Invalid archive method 'invalid' requested
+check:output=~Error: (\[.*?\]: )?Invalid archive method 'invalid' requested
 cmd:rm -rf /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg
 cmd:mv -f /rootimg.bak /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg
 end
@@ -359,7 +359,7 @@ cmd:ls -l /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/c
 check:rc==0
 cmd:packimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute -c invalid
 check:rc!=0
-check:output=~Error: Invalid compress method 'invalid' requested
+check:output=~Error: (\[.*?\]: )?Invalid compress method 'invalid' requested
 cmd:rm -rf /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg
 cmd:mv -f /rootimg.bak /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg
 end

--- a/xCAT-test/autotest/testcase/pdu/case0
+++ b/xCAT-test/autotest/testcase/pdu/case0
@@ -27,7 +27,7 @@ cmd:rmdef $$PDU
 check:rc==0
 cmd:lsdef $$PDU
 check:rc!=0
-check:output=~Error: Could not find an object named '$$PDU'
+check:output=~Error: (\[.*?\]: )?Could not find an object named '$$PDU'
 cmd:mkdef $$PDU groups=pdu ip=$$PDUIP mgt=pdu nodetype=pdu
 check:rc==0
 cmd:chdef $$PDU machinetype=1u

--- a/xCAT-test/autotest/testcase/pping/cases0
+++ b/xCAT-test/autotest/testcase/pping/cases0
@@ -24,5 +24,5 @@ end
 start:pping_invalidnode
 cmd:pping test
 check:rc!=0
-check:output=~Warning: Invalid nodes in noderange:test
+check:output=~Warning: (\[.*?\]: )?Invalid nodes in noderange:test
 end

--- a/xCAT-test/autotest/testcase/restapi/table/cases0
+++ b/xCAT-test/autotest/testcase/restapi/table/cases0
@@ -54,5 +54,5 @@ cmd: restapitest -m POST -r /networks/network_rest -d '{"gateway":"10.1.0.1","ma
 cmd: restapitest -m DELETE -r /tables/networks/rows/net=199.168.0.0 -u $$username -p $$password
 check:rc==200
 cmd: lsdef -t network network_rest
-check:output=~Error: Could not find an object named 'network_rest' of type 'network'.
+check:output=~Error: (\[.*?\]: )?Could not find an object named 'network_rest' of type 'network'.
 end

--- a/xCAT-test/autotest/testcase/reventlog/cases0
+++ b/xCAT-test/autotest/testcase/reventlog/cases0
@@ -36,9 +36,9 @@ cmd:reventlog $$CN -s all
 check:output=~The -s option is not supported for OpenBMC|Only one option is supported at the same time for reventlog
 check:rc!=0
 cmd:reventlog $$CN -s
-check:output=~Error: Unsupported command
+check:output=~Error: (\[.*?\]: )?Unsupported command
 check:rc!=0
 cmd:reventlog $$CN all aaa
-check:output=~Error: Only one option is supported at the same time
+check:output=~Error: (\[.*?\]: )?Only one option is supported at the same time
 check:rc!=0
 end

--- a/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
+++ b/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
@@ -6,7 +6,7 @@ cmd:rflash -c
 check:output=~Usage:
 cmd:rflash -c 1.tar
 check:rc != 0
-check:output=~Error: Invalid nodes and/or groups in noderange
+check:output=~Error: (\[.*?\]: )?Invalid nodes and/or groups in noderange
 end
 
 start:rflash_option_l_without_specify_noderange
@@ -25,10 +25,10 @@ cmd:rflash -a
 check:output=~Usage:
 cmd:rflash -a 1.tar
 check:rc != 0
-check:output=~Error: Invalid nodes and/or groups in noderange
+check:output=~Error: (\[.*?\]: )?Invalid nodes and/or groups in noderange
 cmd:rflash -a 123abc
 check:rc != 0
-check:output=~Error: Invalid nodes and/or groups in noderange
+check:output=~Error: (\[.*?\]: )?Invalid nodes and/or groups in noderange
 end
 
 start:rflash_option_u_without_specify_noderange
@@ -39,7 +39,7 @@ cmd:rflash -u
 check:output=~Usage:
 cmd:rflash -u  1.tar
 check:rc != 0
-check:output=~Error: Invalid nodes and/or groups in noderange
+check:output=~Error: (\[.*?\]: )?Invalid nodes and/or groups in noderange
 end
 
 start:rflash_option_d_without_specify_noderange
@@ -52,7 +52,7 @@ cmd:rflash -d /1234
 check:Usage:
 cmd:rflash --delete 1234abc
 check:rc != 0
-check:output=~Error: Invalid nodes and/or groups in noderange
+check:output=~Error: (\[.*?\]: )?Invalid nodes and/or groups in noderange
 end
 
 start:rflash_without_option
@@ -61,7 +61,7 @@ os:Linux
 hcp:openbmc
 cmd:rflash $$CN 1.tar
 check:rc != 0
-check:output=~Error: Invalid option specified when a file is provided:
+check:output=~Error: (\[.*?\]: )?Invalid option specified when a file is provided:
 end
 
 start:rflash_unsupport_multiple_option_a_u
@@ -69,7 +69,7 @@ description: basic usage check. If specify multiple options a+u, should throw ou
 os:Linux
 hcp:openbmc
 cmd:rflash $$CN -a 1.tz -u
-check:output=~Error: Multiple options are not supported
+check:output=~Error: (\[.*?\]: )?Multiple options are not supported
 check:rc != 0
 end
 
@@ -78,7 +78,7 @@ description: basic usage check. If specify multiple options a+c, should throw ou
 os:Linux
 hcp:openbmc
 cmd:rflash $$CN -a 1.tz -c
-check:output=~Error: Multiple options are not supported
+check:output=~Error: (\[.*?\]: )?Multiple options are not supported
 check:rc != 0
 end
 
@@ -87,7 +87,7 @@ description: basic usage check. If specify multiple options a+l, should throw ou
 os:Linux
 hcp:openbmc
 cmd:rflash $$CN -a 1.tz -l
-check:output=~Error: Multiple options are not supported
+check:output=~Error: (\[.*?\]: )?Multiple options are not supported
 check:rc != 0
 end
 
@@ -96,7 +96,7 @@ description: basic usage check. If specify multiple options a+d, should throw ou
 os:Linux
 hcp:openbmc
 cmd:rflash $$CN -a 1.tz -d
-check:output=~Error: Multiple options are not supported
+check:output=~Error: (\[.*?\]: )?Multiple options are not supported
 check:rc != 0
 end
 
@@ -105,7 +105,7 @@ description: basic usage check. If specify multiple options c+l, should throw ou
 os:Linux
 hcp:openbmc
 cmd:rflash $$CN -c 1.tz -l
-check:output=~Error: Multiple options are not supported
+check:output=~Error: (\[.*?\]: )?Multiple options are not supported
 check:rc != 0
 end
 
@@ -114,7 +114,7 @@ description: basic usage check. If specify multiple options c+u, should throw ou
 os:Linux
 hcp:openbmc
 cmd:rflash $$CN -c 1.tz -u
-check:output=~Error: Multiple options are not supported
+check:output=~Error: (\[.*?\]: )?Multiple options are not supported
 check:rc != 0
 end
 
@@ -123,7 +123,7 @@ description: basic usage check. If specify multiple options c+d, should throw ou
 os:Linux
 hcp:openbmc
 cmd:rflash $$CN -c 1.tz -d
-check:output=~Error: Multiple options are not supported
+check:output=~Error: (\[.*?\]: )?Multiple options are not supported
 check:rc != 0
 end
 
@@ -132,7 +132,7 @@ description: basic usage check. If specify multiple options l+d, should throw ou
 os:Linux
 hcp:openbmc
 cmd:rflash $$CN -l -d
-check:output=~Error: Multiple options are not supported
+check:output=~Error: (\[.*?\]: )?Multiple options are not supported
 check:rc != 0
 end
 
@@ -141,7 +141,7 @@ description: basic usage check. If specify multiple options l+u, should throw ou
 os:Linux
 hcp:openbmc
 cmd:rflash $$CN -l -u
-check:output=~Error: Multiple options are not supported
+check:output=~Error: (\[.*?\]: )?Multiple options are not supported
 check:rc != 0
 end
 
@@ -150,7 +150,7 @@ description: basic usage check. If specify multiple options u+d, should throw ou
 os:Linux
 hcp:openbmc
 cmd:rflash $$CN -u -d
-check:output=~Error: Multiple options are not supported
+check:output=~Error: (\[.*?\]: )?Multiple options are not supported
 check:rc != 0
 end
 
@@ -159,22 +159,22 @@ description: basic usage check for option c. if the file does not exist, should 
 os:Linux
 hcp:openbmc
 cmd:rflash $$CN -c /tmp/abc123.tz
-check:output=~Error: Invalid firmware specified with
+check:output=~Error: (\[.*?\]: )?Invalid firmware specified with
 check:rc != 0
 cmd:rflash $$CN -c /tmp/
-check:output=~Error: Invalid firmware specified with
+check:output=~Error: (\[.*?\]: )?Invalid firmware specified with
 check:rc != 0
 cmd:rflash $$CN /tmp/abc123.tz -c
-check:output=~Error: Invalid firmware specified with
+check:output=~Error: (\[.*?\]: )?Invalid firmware specified with
 check:rc != 0
 cmd:rflash $$CN /tmp/ -c
-check:output=~Error: Invalid firmware specified with
+check:output=~Error: (\[.*?\]: )?Invalid firmware specified with
 check:rc != 0
 cmd:rflash $$CN  1.tar -c
-check:output=~Error: Cannot access
+check:output=~Error: (\[.*?\]: )?Cannot access
 check:rc != 0
 cmd:rflash $$CN -c /tmp/1.tar
-check:output=~Error: Cannot access
+check:output=~Error: (\[.*?\]: )?Cannot access
 check:rc != 0
 end
 
@@ -183,16 +183,16 @@ description: basic usage check for option c. if there are multiple value assigne
 os:Linux
 hcp:openbmc
 cmd:rflash $$CN -c /tmp/abc123.tz /tmp/abc124.tz
-check:output=~Error: Invalid firmware specified with
+check:output=~Error: (\[.*?\]: )?Invalid firmware specified with
 check:rc != 0
 cmd:rflash $$CN -c  1.tz 2.tz 3.tz 
-check:output=~Error: Invalid firmware specified with
+check:output=~Error: (\[.*?\]: )?Invalid firmware specified with
 check:rc != 0
 cmd:rflash $$CN 1.tz 2.tz 3.tz -c
-check:output=~Error: Invalid firmware specified with
+check:output=~Error: (\[.*?\]: )?Invalid firmware specified with
 check:rc != 0
 cmd:rflash $$CN 1.tz -c 2.tz
-check:output=~Error: Invalid firmware specified with
+check:output=~Error: (\[.*?\]: )?Invalid firmware specified with
 check:rc != 0
 end
 
@@ -234,10 +234,10 @@ description: basic usage check for option l. if there is value for l option,  sh
 os:Linux
 hcp:openbmc
 cmd:rflash $$CN -l /tmp/abc123.tz
-check:output=~Error: Invalid option
+check:output=~Error: (\[.*?\]: )?Invalid option
 check:rc != 0
 cmd: rflash $$CN /tmp/abc123.tz -l
-check:output=~Error: Invalid option
+check:output=~Error: (\[.*?\]: )?Invalid option
 check:rc != 0
 end
 
@@ -263,27 +263,27 @@ description: basic usage check for option u. if the file does not exist, should 
 os:Linux
 hcp:openbmc
 cmd:rflash $$CN -u /tmp/abc123.tz
-check:output=~Error: Invalid firmware specified with
+check:output=~Error: (\[.*?\]: )?Invalid firmware specified with
 check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN -u /tmp/
-check:output=~Error: Invalid firmware specified with
+check:output=~Error: (\[.*?\]: )?Invalid firmware specified with
 check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN /tmp/abc123.tz -u
-check:output=~Error: Invalid firmware specified with
+check:output=~Error: (\[.*?\]: )?Invalid firmware specified with
 check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN /tmp/ -u
-check:output=~Error: Invalid firmware specified with
+check:output=~Error: (\[.*?\]: )?Invalid firmware specified with
 check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN 1.tar -u
-check:output=~Error: Cannot access
+check:output=~Error: (\[.*?\]: )?Cannot access
 check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN -u /tmp/1.tar
-check:output=~Error: Cannot access
+check:output=~Error: (\[.*?\]: )?Cannot access
 check:output!~Attempting to
 check:rc != 0
 end
@@ -293,19 +293,19 @@ description: basic usage check for option u. if there are multiple value assigne
 os:Linux
 hcp:openbmc
 cmd:rflash $$CN -u /tmp/abc123.tz /tmp/abc124.tz
-check:output=~Error: Invalid firmware specified with
+check:output=~Error: (\[.*?\]: )?Invalid firmware specified with
 check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN -u 1.tz 2.tz 3.tz 
-check:output=~Error: Invalid firmware specified with
+check:output=~Error: (\[.*?\]: )?Invalid firmware specified with
 check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN 1.tz 2.tz 3.tz -u
-check:output=~Error: Invalid firmware specified with
+check:output=~Error: (\[.*?\]: )?Invalid firmware specified with
 check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN 1.tz -u 2.tz
-check:output=~Error: Invalid firmware specified with
+check:output=~Error: (\[.*?\]: )?Invalid firmware specified with
 check:output!~Attempting to
 check:rc != 0
 end
@@ -331,11 +331,11 @@ check:output=~rror: Invalid firmware specified with
 check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN 1.tar -a
-check:output=~Error: Cannot access
+check:output=~Error: (\[.*?\]: )?Cannot access
 check:output!~Attempting to 
 check:rc != 0
 cmd:rflash $$CN -a /tmp/1.tar
-check:output=~Error: Cannot access
+check:output=~Error: (\[.*?\]: )?Cannot access
 check:output!~Attempting to
 check:rc != 0
 end
@@ -345,27 +345,27 @@ description: basic usage check for option a. if there are multiple value assigne
 os:Linux
 hcp:openbmc
 cmd:rflash $$CN -a /tmp/abc123.tz /tmp/abc124.tz
-check:output=~Error: Invalid firmware specified with
+check:output=~Error: (\[.*?\]: )?Invalid firmware specified with
 check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN -a 1.tz 2.tz 3.tz
-check:output=~Error: More than one firmware specified is not supported
+check:output=~Error: (\[.*?\]: )?More than one firmware specified is not supported
 check:output!~Attempting to 
 check:rc != 0
 cmd:rflash $$CN 1.tz 2.tz 3.tz -a
-check:output=~Error: More than one firmware specified is not supported
+check:output=~Error: (\[.*?\]: )?More than one firmware specified is not supported
 check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN 1.tz -a 2.tz
-check:output=~Error: More than one firmware specified is not supported
+check:output=~Error: (\[.*?\]: )?More than one firmware specified is not supported
 check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN 1234567 -a 2345678
-check:output=~Error: More than one firmware specified is not supported
+check:output=~Error: (\[.*?\]: )?More than one firmware specified is not supported
 check:output!~Attempting to 
 check:rc != 0
 cmd:rflash $$CN -a 123 abc asdbas 
-check:output=~Error: More than one firmware specified is not supported
+check:output=~Error: (\[.*?\]: )?More than one firmware specified is not supported
 check:output!~Attempting to
 check:rc != 0
 end
@@ -376,10 +376,10 @@ description: basic usage check for option a. if active a non-existent firmware I
 os:Linux
 hcp:openbmc
 cmd:rflash $$CN -a 1234567
-check:output=~Error: Invalid ID provided to activate
+check:output=~Error: (\[.*?\]: )?Invalid ID provided to activate
 check:rc != 0
 cmd:rflash $$CN -a d123abc
-check:output=~Error: Invalid ID provided to activate
+check:output=~Error: (\[.*?\]: )?Invalid ID provided to activate
 check:rc != 0
 end
 
@@ -388,15 +388,15 @@ description: basic usage check for option delete. if there are multiple value as
 os:Linux
 hcp:openbmc
 cmd:rflash $$CN --delete 1234567 2345678 
-check:output=~Error: More than one firmware specified is not supported
+check:output=~Error: (\[.*?\]: )?More than one firmware specified is not supported
 check:output!~Attempting to delete
 check:rc != 0
 cmd:rflash $$CN 1234567 2345678 --delete
-check:output=~Error: More than one firmware specified is not supported
+check:output=~Error: (\[.*?\]: )?More than one firmware specified is not supported
 check:output!~Attempting to delete
 check:rc != 0
 cmd:rflash $$CN 1234567 --delete 2345678
-check:output=~Error: More than one firmware specified is not supported
+check:output=~Error: (\[.*?\]: )?More than one firmware specified is not supported
 check:output!~Attempting to delete
 check:rc != 0
 end
@@ -406,10 +406,10 @@ description: basic usage check for option --delete. if delete a non-existent fir
 os:Linux
 hcp:openbmc
 cmd:rflash $$CN --delete 1234567
-check:output=~Error: Invalid ID provided to delete
+check:output=~Error: (\[.*?\]: )?Invalid ID provided to delete
 check:rc != 0
 cmd:rflash $$CN --delete d123abc
-check:output=~Error: Invalid ID provided to delete
+check:output=~Error: (\[.*?\]: )?Invalid ID provided to delete
 check:rc != 0
 end
 
@@ -418,15 +418,15 @@ description: basic usage check for option d. if there are multiple value assigne
 os:Linux
 hcp:openbmc
 cmd:rflash $$CN -d /123/   /234/
-check:output=~Error: More than one
+check:output=~Error: (\[.*?\]: )?More than one
 check:output!~Attempting to 
 check:rc != 0
 cmd:rflash $$CN /123/   /234/  -d
-check:output=~Error: More than one 
+check:output=~Error: (\[.*?\]: )?More than one 
 check:output!~Attempting to
 check:rc != 0
 cmd:rflash $$CN /123/ -d /234/
-check:output=~Error: More than one 
+check:output=~Error: (\[.*?\]: )?More than one 
 check:output!~Attempting to 
 check:rc != 0
 end
@@ -439,28 +439,28 @@ hcp:openbmc
 cmd:rm -rf /tmp/bogus123
 check:rc == 0
 cmd:rflash $$CN -d /tmp/bogus123 
-check:output=~Error: Can't open directory
+check:output=~Error: (\[.*?\]: )?Can't open directory
 check:output!~Attempting to 
 check:rc != 0
 cmd:rflash $$CN /tmp/bogus123
-check:output=~Error: Invalid option specified
+check:output=~Error: (\[.*?\]: )?Invalid option specified
 check:rc != 0
 cmd:mkdir -p /tmp/bogus123
 check:rc == 0
 cmd:rflash $$CN /tmp/bogus123 -d
-check:output =~Error: No BMC tar file found|Can't open directory
+check:output =~Error: (\[.*?\]: )?No BMC tar file found|Can't open directory
 check:output!~Attempting to
 check:rc != 0
 cmd:touch /tmp/bogus123/obmc-phosphor-image-witherspoon.ubi.mtd.tar 
 check:rc == 0
 cmd:rflash $$CN -d /tmp/bogus123
-check:output =~Error: No BMC tar file found|Can't open directory
+check:output =~Error: (\[.*?\]: )?No BMC tar file found|Can't open directory
 check:output!~Attempting to
 check:rc != 0
 cmd:touch /tmp/bogus123/witherspoon.pnor.squashfs.tar 
 check:rc == 0
 cmd:rflash $$CN -d /tmp/bogus123
-check:output =~Error: No BMC tar file found|Can't open directory
+check:output =~Error: (\[.*?\]: )?No BMC tar file found|Can't open directory
 check:output!~Attempting to
 check:rc != 0
 cmd:rm -rf /tmp/bogus123
@@ -485,9 +485,9 @@ os:Linux
 hcp:openbmc
 cmd:activenum=`rflash $$CN -l |grep -w "Host\s*Active(\*)" |awk '{print $2}'`;rflash $$CN $activenum --delete
 check:rc != 0
-check:output =~$$CN\s*:\s*Error: Deleting currently active firmware on powered on host is not supported 
+check:output =~$$CN\s*:\s*(\[.*?\]: )?Error: Deleting currently active firmware on powered on host is not supported 
 cmd:activenum=`rflash $$CN -l |grep -w "BMC\s*Active(\*)" |awk '{print $2}'`;rflash $$CN $activenum --delete
 check:rc != 0
-check:output =~~$$CN\s*:\s*Error: Deleting currently active BMC firmware is not supported
+check:output =~~$$CN\s*:\s*(\[.*?\]: )?Error: Deleting currently active BMC firmware is not supported
 end
 

--- a/xCAT-test/autotest/testcase/rinv/cases0
+++ b/xCAT-test/autotest/testcase/rinv/cases0
@@ -121,7 +121,7 @@ cmd:chdef $$CN bmcpassword=test
 check:rc==0
 cmd:rinv $$CN all
 check:rc==1
-check:output=~$$CN: Error:.+Invalid username or password|Error: ERROR: Incorrect password provided
+check:output=~$$CN: (\[.*?\]: )?Error:.+Invalid username or password|Error: (\[.*?\]: )?ERROR: Incorrect password provided
 cmd:cat /tmp/testnode.stanza | chdef -z;rm -rf /tmp/testnode.stanza 
 check:rc==0
 end
@@ -129,5 +129,5 @@ start:rinv_errorcommand
 description:get right return if input error command
 cmd:rinv $$CN dafds
 check:rc==1
-check:output=~Unsupported command|Error: Usage:
+check:output=~Unsupported command|Error: (\[.*?\]: )?Usage:
 end

--- a/xCAT-test/autotest/testcase/rmkitcomp/case0
+++ b/xCAT-test/autotest/testcase/rmkitcomp/case0
@@ -81,7 +81,7 @@ check:output=~ubuntukit-compute-1
 check:output=~ubuntukit-compute-2
 cmd:rmkitcomp -i testimage ubuntukit-compute-1-1.0-1-ubuntu-14.04-ppc64el
 check:rc==1
-check:output=~Error: Failed to remove kitcomponent
+check:output=~Error: (\[.*?\]: )?Failed to remove kitcomponent
 cmd:rmkitcomp -i testimage -f ubuntukit-compute-1-1.0-1-ubuntu-14.04-ppc64el
 check:rc==0
 check:output=~Removing kitcomponent ubuntukit-compute-1-1.0-1-ubuntu-14.04-ppc64el from osimage testimage

--- a/xCAT-test/autotest/testcase/rpower/cases0
+++ b/xCAT-test/autotest/testcase/rpower/cases0
@@ -162,7 +162,7 @@ end
 start:rpower_suspend_OpenpowerBmc
 hcp:openbmc
 cmd:rpower $$CN suspend
-check:output=~Error: Unsupported command: rpower suspend
+check:output=~Error: (\[.*?\]: )?Unsupported command: rpower suspend
 check:rc==1
 end
 
@@ -170,14 +170,14 @@ end
 start:rpower_wake_OpenpowerBmc
 hcp:openbmc
 cmd:rpower $$CN wake
-check:output=~Error: Unsupported command: rpower wake
+check:output=~Error: (\[.*?\]: )?Unsupported command: rpower wake
 check:rc==1
 end
 
 start:rpower_errorcommand_OpenpowerBmc
 hcp:openbmc
 cmd:rpower $$CN ddd
-check:output=~Error: Unsupported command: rpower ddd 
+check:output=~Error: (\[.*?\]: )?Unsupported command: rpower ddd 
 check:rc==1
 end
 

--- a/xCAT-test/autotest/testcase/rsetboot/cases0
+++ b/xCAT-test/autotest/testcase/rsetboot/cases0
@@ -120,7 +120,7 @@ description:rsetboot node using invalidaction
 Attribute: $$CN-The operation object of rsetboot command.
 cmd:rsetboot $$CN dsdf
 check:rc!=0
-check:output=~Error: unsupported command|Unsupported command
+check:output=~Error: (\[.*?\]: )?unsupported command|Unsupported command
 end
 
 start:rsetboot_group_net

--- a/xCAT-test/autotest/testcase/rspconfig/cases0
+++ b/xCAT-test/autotest/testcase/rspconfig/cases0
@@ -62,7 +62,7 @@ Attribute: $$CN-The operation object of rspconfig command
 os:Linux
 hcp:openbmc
 cmd:rspconfig $$CN ip=__GETNODEATTR($$CN,bmc)__
-check:output=~Error: IP, netmask and gateway must be configured together.
+check:output=~Error: (\[.*?\]: )?IP, netmask and gateway must be configured together.
 check:rc!=0
 end
 
@@ -72,7 +72,7 @@ Attribute: $$CN-The operation object of rspconfig command
 os:Linux
 hcp:openbmc
 cmd:rspconfig $$CN ip=ddd gateway=0.0.0.0  netmask=255.255.0.0
-check:output=~Error: Invalid parameter for option ip
+check:output=~Error: (\[.*?\]: )?Invalid parameter for option ip
 check:rc!=0
 end
 
@@ -95,7 +95,7 @@ Attribute: $$CN-The operation object of rspconfig command
 os:Linux
 hcp:openbmc
 cmd:rspconfig $$CN netmask=255.255.0.0
-check:output=~Error: IP, netmask and gateway must be configured together.
+check:output=~Error: (\[.*?\]: )?IP, netmask and gateway must be configured together.
 check:rc!=0
 end
 
@@ -103,13 +103,13 @@ start:rspconfig_netmask_invalid
 despcription:rspconfig could not change openbmc netmask using invalid netmask
 Attribute: $$CN-The operation object of rspconfig command
 cmd:rspconfig $$CN netmask=ddd
-check:output=~Error: Invalid parameter for option netmask
+check:output=~Error: (\[.*?\]: )?Invalid parameter for option netmask
 check:rc!=0
 cmd:rspconfig $$CN netmask=ddd ip=__GETNODEATTR($$CN,bmc)__ gateway=0.0.0.0
-check:output=~Error: Invalid parameter for option netmask
+check:output=~Error: (\[.*?\]: )?Invalid parameter for option netmask
 check:rc!=0
 cmd:rspconfig $$CN netmask= ip=__GETNODEATTR($$CN,bmc)__ gateway=0.0.0.0
-check:output=~Error: Invalid parameter for option netmask
+check:output=~Error: (\[.*?\]: )?Invalid parameter for option netmask
 check:rc!=0
 end
  
@@ -119,7 +119,7 @@ Attribute: $$CN-The operation object of rspconfig command
 os:Linux
 hcp:openbmc
 cmd:rspconfig $$CN gateway=0.0.0.0
-check:output=~Error: IP, netmask and gateway must be configured together.
+check:output=~Error: (\[.*?\]: )?IP, netmask and gateway must be configured together.
 check:rc!=0
 end
 
@@ -127,10 +127,10 @@ start:rspconfig_set_vlan
 description:rspconfig change openbmc gateway
 Attribute: $$CN-The operation object of rspconfig command
 cmd:rspconfig $$CN vlan=0
-check:output=~Error: Invalid parameter for option vlan|Error: VLAN must be configured with IP, netmask and gateway
+check:output=~Error: (\[.*?\]: )?Invalid parameter for option vlan|Error: (\[.*?\]: )?VLAN must be configured with IP, netmask and gateway
 check:rc!=0
 cmd:rspconfig $$CN vlan=111
-check:output=~Error: VLAN must be configured with IP, netmask and gateway
+check:output=~Error: (\[.*?\]: )?VLAN must be configured with IP, netmask and gateway
 check:rc!=0
 end
 
@@ -147,13 +147,13 @@ Attribute: $$CN-The operation object of rspconfig command
 os:Linux
 hcp:openbmc
 cmd:rspconfig $$CN gateway=ddd
-check:output=~Error: Invalid parameter for option gateway
+check:output=~Error: (\[.*?\]: )?Invalid parameter for option gateway
 check:rc!=0
 cmd:rspconfig $$CN gateway= ip=__GETNODEATTR($$CN,bmc)__ netmask=255.0.0.0
-check:output=~Error: Invalid parameter for option gateway
+check:output=~Error: (\[.*?\]: )?Invalid parameter for option gateway
 check:rc!=0
 cmd:rspconfig $$CN gateway=
-check:output=~Error: Invalid parameter for option gateway
+check:output=~Error: (\[.*?\]: )?Invalid parameter for option gateway
 check:rc!=0
 end
 
@@ -163,7 +163,7 @@ Attribute: $$CN-The operation object of rspconfig command
 os:Linux
 hcp:openbmc
 cmd:rspconfig $$CN vlan=dddsdsdfs
-check:output=~Error: VLAN must be configured with IP, netmask and gateway
+check:output=~Error: (\[.*?\]: )?VLAN must be configured with IP, netmask and gateway
 check:rc!=0
 end
 
@@ -173,7 +173,7 @@ Attribute: $$CN-The operation object of rspconfig command
 os:Linux
 hcp:openbmc
 cmd:rspconfig $$CN ip=dsd gateway=ooo netmask=asfsf vlan=dddsdsdfs
-check:output=~Error: Invalid parameter
+check:output=~Error: (\[.*?\]: )?Invalid parameter
 check:rc!=0
 end
 
@@ -184,7 +184,7 @@ hcp:openbmc
 cmd:test=$(lsdef testnode);if [[ $? -eq 0 ]]; then lsdef -l testnode -z >/tmp/testnode.stanza ;rmdef testnode;fi
 check:rc==0
 cmd:rspconfig testnode ip
-check:output=~Error: Invalid nodes and/or groups in noderange
+check:output=~Error: (\[.*?\]: )?Invalid nodes and/or groups in noderange
 check:rc!=0
 cmd:if [[ -e /tmp/testnode.stanza ]]; then cat /tmp/testnode.stanza | chdef -z;rm -rf /tmp/testnode.stanza;fi
 check:rc==0
@@ -197,7 +197,7 @@ hcp:openbmc
 cmd:test=$(lsdef testnode);if [[ $? -eq 0 ]]; then lsdef -l testnode -z >/tmp/testnode.stanza ;rmdef testnode;fi
 check:rc==0
 cmd:rspconfig testnode,$$CN ip
-check:output=~Error: Invalid nodes
+check:output=~Error: (\[.*?\]: )?Invalid nodes
 check:rc!=0
 cmd:if [[ -e /tmp/testnode.stanza ]]; then cat /tmp/testnode.stanza | chdef -z;rm -rf /tmp/testnode.stanza;fi
 check:rc==0
@@ -323,13 +323,13 @@ description: To test <get node hostname> with error input, should throw out erro
 os:Linux
 hcp:openbmc
 cmd:rspconfig $$CN hostname bogus
-check:output =~Error: Unsupported command
+check:output =~Error: (\[.*?\]: )?Unsupported command
 check:rc != 0
 cmd:rspconfig $$CN bogus hostname
-check:output =~Error: Unsupported command
+check:output =~Error: (\[.*?\]: )?Unsupported command
 check:rc != 0
 cmd:rspconfig $$CN hostname=
-check:output =~Error: Invalid parameter for option hostname
+check:output =~Error: (\[.*?\]: )?Invalid parameter for option hostname
 check:rc != 0
 end
 
@@ -364,19 +364,19 @@ description: To test "rspconfig <node> admin_passwd=xxx,yyy". If the format of "
 os:Linux
 hcp:openbmc
 cmd:rspconfig $$CN admin_passwd=cluster,
-check:output =~Error: Invalid parameter for option admin_passwd
+check:output =~Error: (\[.*?\]: )?Invalid parameter for option admin_passwd
 check:rc != 0
 cmd:rspconfig $$CN admin_passwd=,cluster
-check:output =~Error: Invalid parameter for option admin_passwd
+check:output =~Error: (\[.*?\]: )?Invalid parameter for option admin_passwd
 check:rc != 0
 cmd:rspconfig $$CN admin_passwd=,
-check:output =~Error: Invalid parameter for option admin_passwd
+check:output =~Error: (\[.*?\]: )?Invalid parameter for option admin_passwd
 check:rc != 0
 cmd:rspconfig $$CN admin_passwd=
-check:output =~Error: Invalid parameter for option admin_passwd
+check:output =~Error: (\[.*?\]: )?Invalid parameter for option admin_passwd
 check:rc != 0
 cmd:rspconfig $$CN admin_passwd=;
-check:output =~Error: Invalid parameter for option admin_passwd
+check:output =~Error: (\[.*?\]: )?Invalid parameter for option admin_passwd
 end
 
 start:rspconfig_set_admin_passwd_with_error_origin_password
@@ -393,10 +393,10 @@ description: To test "rspconfig <node> sshcfg" with error input, should throw ou
 os:Linux
 hcp:openbmc
 cmd:rspconfig $$CN sshcfg aaa
-check:output =~Error: Configure sshcfg must be issued without other options.
+check:output =~Error: (\[.*?\]: )?Configure sshcfg must be issued without other options.
 check:rc != 0
 cmd:rspconfig $$CN  hostname sshcfg
-check:output =~Error: Configure sshcfg must be issued without other options.
+check:output =~Error: (\[.*?\]: )?Configure sshcfg must be issued without other options.
 check:rc != 0
 end
 

--- a/xCAT-test/autotest/testcase/rspconfig/cases1
+++ b/xCAT-test/autotest/testcase/rspconfig/cases1
@@ -6,7 +6,7 @@ cmd:rspconfig $$CN ipsrc
 check:output=~$$CN\s*:\s*BMC IP Source: Static|BMC IP Source: Dynamic 
 check:rc == 0
 cmd:rspconfig $$CN  hostname sshcfg
-check:output =~Error: Configure sshcfg must be issued without other options.
+check:output =~Error: (\[.*?\]: )?Configure sshcfg must be issued without other options.
 check:rc != 0
 end
 
@@ -188,7 +188,7 @@ cmd:rspconfig $$CN powerrestorepolicy=restore
 check:output =~$$CN:\s*BMC Setting BMC PowerRestorePolicy...
 check:rc == 0
 cmd:rspconfig $$CN powerrestorepolicy=abc
-check:output =~$$CN:\s*Error: Invalid value '\S*' for 'powerrestorepolicy', Valid values: restore,always_on,always_off 
+check:output =~$$CN:\s*(\[.*?\]: )?Error: Invalid value '\S*' for 'powerrestorepolicy', Valid values: restore,always_on,always_off
 check:rc != 0
 cmd:rspconfig $$CN powerrestorepolicy
 check:rc == 0
@@ -218,7 +218,7 @@ cmd:rspconfig $$CN powersupplyredundancy
 check:rc == 0
 check:output =~$$CN:\s*BMC PowerSupplyRedundancy:\s*Disabled 
 cmd:rspconfig $$CN powersupplyredundancy=abc
-check:output =~$$CN:\s*Error: Invalid value \S* for 'powersupplyredundancy', Valid values: disabled,enabled 
+check:output =~$$CN:\s*(\[.*?\]: )?Error: Invalid value \S* for 'powersupplyredundancy', Valid values: disabled,enabled
 check:rc != 0
 cmd:redundancy=`cat /tmp/powersupplyredundancy | awk -F ":" '{print $3}'`;newredundancy=`echo $redundancy |tr 'A-Z' 'a-z'`;rspconfig $$CN powersupplyredundancy=$newredundancy
 check:rc == 0
@@ -245,7 +245,7 @@ cmd:rspconfig $$CN timesyncmethod
 check:rc == 0
 check:output =~$$CN:\s*BMC TimeSyncMethod:\s*Manual
 cmd:rspconfig $$CN  timesyncmethod=abc
-check:output =~$$CN:\s*Error: Invalid value \S* for 'timesyncmethod', Valid values: ntp,manual
+check:output =~$$CN:\s*(\[.*?\]: )?Error: Invalid value \S* for 'timesyncmethod', Valid values: ntp,manual
 check:rc != 0
 cmd:syncmethod=`cat /tmp/timesyncmethod | awk -F ":" '{print $3}'`;newsyncmethod=`echo $syncmethod |tr 'A-Z' 'a-z'`;rspconfig $$CN timesyncmethod=$newsyncmethod
 check:rc == 0
@@ -278,7 +278,7 @@ cmd:rspconfig $$CN bootmode
 check:rc == 0
 check:output =~$$CN:\s*BMC BootMode:\s*Setup
 cmd:rspconfig $$CN bootmode=abc
-check:output =~$$CN:\s*Error: Invalid value \S* for 'bootmode', Valid values: regular,safe,setup
+check:output =~$$CN:\s*(\[.*?\]: )?Error: Invalid value \S* for 'bootmode', Valid values: regular,safe,setup
 check:rc != 0
 cmd:mode=`cat /tmp/bootmode |awk -F ":" '{print $3}'`;newmode=`echo $mode |tr 'A-Z' 'a-z'`;rspconfig $$CN bootmode=$newmode
 check:rc == 0
@@ -305,7 +305,7 @@ cmd:rspconfig $$CN autoreboot
 check:rc == 0
 check:output =~$$CN:\s*BMC AutoReboot:\s*0
 cmd:rspconfig $$CN autoreboot=2
-check:output =~$$CN:\s*Error: Invalid value \S* for 'autoreboot', Valid values: 0,1
+check:output =~$$CN:\s*(\[.*?\]: )?Error: Invalid value \S* for 'autoreboot', Valid values: 0,1
 check:rc != 0
 cmd:autoreboot=`cat /tmp/autoreboot |awk -F ":" '{print $3}'`;newautoreboot=`echo $autoreboot |tr 'A-Z' 'a-z'`;rspconfig $$CN autoreboot=$newautoreboot
 check:rc == 0
@@ -317,7 +317,7 @@ description: To test "rspconfig <node> invalid_value"  should throw out error me
 os:Linux
 hcp:openbmc
 cmd:rspconfig $$CN aaa
-check:output =~Error: Unsupported command: rspconfig aaa 
+check:output =~Error: (\[.*?\]: )?Unsupported command: rspconfig aaa
 check:rc != 0
 end
 

--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.node
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.node
@@ -730,10 +730,10 @@ check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/xcat_inventory_try_to_export_nonexisted_node/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd: xcat-inventory export --format=json -t node -o bogusnode
-check:output=~Error: cannot find node objects: bogusnode!
+check:output=~Error: (\[.*?\]: )?cannot find node objects: bogusnode!
 check:rc!=0
 cmd: xcat-inventory export --format=yaml -t node -o bogusnode
-check:output=~Error: cannot find node objects: bogusnode!
+check:output=~Error: (\[.*?\]: )?cannot find node objects: bogusnode!
 check:rc!=0
 cmd:if [[ -e /tmp/xcat_inventory_try_to_export_nonexisted_node/bogusnode.stanza ]]; then cat /tmp/xcat_inventory_try_to_export_nonexisted_node/bogusnode.stanza | mkdef -z;fi
 check:rc==0
@@ -752,12 +752,12 @@ check:rc==0
 cmd:xcat-inventory export --format=json  -t node -o bogusnode |tee  /tmp/xcat_inventory_try_to_import_nonexisted_node/json
 check:rc==0
 cmd:xcat-inventory import -f /tmp/xcat_inventory_try_to_import_nonexisted_node/json  -t node -o bogusnode1
-check:output=~Error: cannot find node objects: bogusnode1!
+check:output=~Error: (\[.*?\]: )?cannot find node objects: bogusnode1!
 check:rc!=0
 cmd:xcat-inventory export --format=yaml -t node -o bogusnode |tee  /tmp/xcat_inventory_try_to_import_nonexisted_node/yaml
 check:rc==0
 cmd:xcat-inventory import -f /tmp/xcat_inventory_try_to_import_nonexisted_node/yaml  -t node -o bogusnode1
-check:output=~Error: cannot find node objects: bogusnode1!
+check:output=~Error: (\[.*?\]: )?cannot find node objects: bogusnode1!
 check:rc!=0
 cmd:rmdef bogusnode
 check:rc==0
@@ -1647,7 +1647,7 @@ check:rc==0
 cmd:diff -y /tmp/export_more_nodes_import_part_nodes_json/nodes.bogus /tmp/export_more_nodes_import_part_nodes_json/nodes.import
 check:rc==0
 cmd:lsdef -t node bogusnode3
-check:output=~Error: Could not find an object 
+check:output=~Error: (\[.*?\]: )?Could not find an object
 check:rc!=0
 cmd:rmdef bogusnode[1-2]
 check:rc==0
@@ -1689,7 +1689,7 @@ check:rc==0
 cmd:diff -y /tmp/export_more_nodes_import_part_nodes_yaml/nodes.bogus /tmp/export_more_nodes_import_part_nodes_yaml/nodes.import
 check:rc==0
 cmd:lsdef -t node bogusnode3
-check:output=~Error: Could not find an object 
+check:output=~Error: (\[.*?\]: )?Could not find an object
 check:rc!=0
 cmd:rmdef bogusnode[1-2]
 check:rc==0

--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.site
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.site
@@ -845,13 +845,13 @@ cmd:#!/bin/bash
 diff -y --ignore-blank-lines  --ignore-matching-lines="^#"  /tmp/xcat_inventory_try_to_import_all_type_is_site_json_format/site.org  /tmp/xcat_inventory_try_to_import_all_type_is_site_json_format/site.import
 check:rc==0
 cmd:lsdef bogusgroup1
-check:output=~Error: Could not find an object
+check:output=~Error: (\[.*?\]: )?Could not find an object
 check:rc!=0
 cmd:lsdef bogusgroup2
-check:output=~Error: Could not find an object
+check:output=~Error: (\[.*?\]: )?Could not find an object
 check:rc!=0
 cmd:lsdef bogusgroup3
-check:output=~Error: Could not find an object
+check:output=~Error: (\[.*?\]: )?Could not find an object
 check:rc!=0
 cmd:tabdump networks|grep 100_0_0_0-255_0_0_0
 check:rc!=0
@@ -1211,13 +1211,13 @@ cmd:#!/bin/bash
 diff -y --ignore-blank-lines  --ignore-matching-lines="^#"  /tmp/xcat_inventory_try_to_import_all_type_is_site_yaml_format/site.org  /tmp/xcat_inventory_try_to_import_all_type_is_site_yaml_format/site.import
 check:rc==0
 cmd:lsdef bogusgroup1
-check:output=~Error: Could not find an object
+check:output=~Error: (\[.*?\]: )?Could not find an object
 check:rc!=0
 cmd:lsdef bogusgroup2
-check:output=~Error: Could not find an object
+check:output=~Error: (\[.*?\]: )?Could not find an object
 check:rc!=0
 cmd:lsdef bogusgroup3
-check:output=~Error: Could not find an object
+check:output=~Error: (\[.*?\]: )?Could not find an object
 check:rc!=0
 cmd:tabdump networks|grep 100_0_0_0-255_0_0_0
 check:rc!=0

--- a/xCAT-test/autotest/testcase/xcat-inventory/validatehelper
+++ b/xCAT-test/autotest/testcase/xcat-inventory/validatehelper
@@ -59,7 +59,7 @@ def GetAttrInFile(fpath,objtype,objname,attrpath):
         try:
             objdict=yaml.load(f)
         except Exception,e:
-            raise Exception("Error: cannot open file "+fpath+"! "+str(e))
+            raise Exception("Error: (\[.*?\]: )?cannot open file "+fpath+"! "+str(e))
 
     f.close()
     myattrpath=objtype+"."+objname+"."+attrpath
@@ -109,7 +109,7 @@ def UpdateAttrInFile(fpath,fformat,objtype,objname,attrpath,value):
         try:
             objdict=yaml.load(f)
         except Exception,e:
-            raise Exception("Error: cannot open file "+fpath+"! "+str(e))
+            raise Exception("Error: (\[.*?\]: )?cannot open file "+fpath+"! "+str(e))
 
     f.close()
     myattrpath=objtype+"."+objname+"."+attrpath

--- a/xCAT-test/autotest/testcase/xcatd/case0
+++ b/xCAT-test/autotest/testcase/xcatd/case0
@@ -242,7 +242,7 @@ check:output=~xcatd service is running
 cmd:chtab name=root policy.rule=disable
 check:rc==0
 cmd:lsdef
-check:output=~Error: Permission denied for request
+check:output=~Error: (\[.*?\]: )?Permission denied for request
 cmd:XCATBYPASS=YES lsdef
 check:rc==0
 cmd:XCATBYPASS=YES chtab name=root policy.rule=allow
@@ -261,7 +261,7 @@ check:output=~active \(running\)
 cmd:chtab name=root policy.rule=disable
 check:rc==0
 cmd:lsdef
-check:output=~Error: Permission denied for request
+check:output=~Error: (\[.*?\]: )?Permission denied for request
 cmd:XCATBYPASS=YES lsdef
 check:rc==0
 cmd:XCATBYPASS=YES chtab name=root policy.rule=allow
@@ -285,7 +285,7 @@ check:rc==0
 cmd:lsdef
 check:rc==0 
 cmd:tabdump policy
-check:output=~Error: Permission denied for request
+check:output=~Error: (\[.*?\]: )?Permission denied for request
 cmd:chtab name=root policy.commands= policy.rule=allow
 check:rc==0
 end
@@ -306,7 +306,7 @@ check:rc==0
 cmd:lsdef
 check:rc==0
 cmd:tabdump policy
-check:output=~Error: Permission denied for request
+check:output=~Error: (\[.*?\]: )?Permission denied for request
 cmd:chtab name=root policy.commands= policy.rule=allow
 check:rc==0
 end

--- a/xCAT-test/autotest/testcase/xdsh/cases0
+++ b/xCAT-test/autotest/testcase/xdsh/cases0
@@ -88,7 +88,7 @@ cmd:date +%s > /tmp/start.txt
 check:rc==0
 cmd:xdsh $$CN -t 5 "ssh 1.1.1.1"
 check:rc!=0
-check:output=~Error: Caught SIGINT - terminating the child processes.
+check:output=~Error: (\[.*?\]: )?Caught SIGINT - terminating the child processes.
 cmd:date +%s > /tmp/end.txt
 check:rc==0
 cmd:a=`cat /tmp/start.txt`;b=`cat /tmp/end.txt`;c=$[$b-$a];echo $c


### PR DESCRIPTION
Update the test cases to cover the changes in https://github.com/xcat2/xcat-core/pull/5119
using regular expression to cover the error/warn message which contains the server name

Here just use `(\[.*?\]: )?` to math the both output case for:
`Error: this is an example error message` and `Error: [sn01]: this is an example error message`

As this is general, just use one case for UT
UT:
```
XCATTEST_CN=c910f03c05k30 xcattest -t nodeset_check_warninginfo
xCAT automated test started at Fri May 25 23:47:56 2018
******************************
To detect current test environment
******************************
Detecting: OS = linux
Detecting: ARCH = ppc64le
Detecting: HCP = kvm
******************************
loading test cases
******************************
To run:
nodeset_check_warninginfo
******************************
Start to run test cases
******************************
------START::nodeset_check_warninginfo::Time:Fri May 25 23:47:58 2018------

RUN:if [[ "__GETNODEATTR(c910f03c05k30,arch)__" =~ "el" || "__GETNODEATTR(c910f03c05k30,arch)__" =~ "le" ]]; then bootloader=xnba; else bootloader=petitboot; fi; mkdef -t node -o testnode1 arch=ppc64el cons=ipmi groups=pbmc mgt=ipmi ip=10.1.1.200 mac=e6:d4:d2:3a:ad:06  monserver=10.1.1.1 nameservers=10.1.1.1 nodetype=ppc,osi profile=compute tftpserver=10.1.1.1 xcatmaster=10.1.1.1 netboot=$bootloader [Fri May 25 23:47:58 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:lsdef testnode1 [Fri May 25 23:47:59 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Object name: testnode1
    arch=ppc64el
    cons=ipmi
    groups=pbmc
    ip=10.1.1.200
    mac=e6:d4:d2:3a:ad:06
    mgt=ipmi
    monserver=10.1.1.1
    nameservers=10.1.1.1
    netboot=xnba
    nodetype=ppc,osi
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
    profile=compute
    tftpserver=10.1.1.1
    xcatmaster=10.1.1.1

RUN:nodeset testnode1 osimage=__GETNODEATTR(c910f03c05k30,os)__-__GETNODEATTR(c910f03c05k30,arch)__-install-compute [Fri May 25 23:47:59 2018]
ElapsedTime:5 sec
RETURN rc = 1
OUTPUT:
Warning: [c910f03c05k20]: testnode1: xnba might be invalid when provisioning rhels7.3-ppc64le-install-compute,valid options: "petitboot,grub2,grub2-tftp,grub2-http".
For more details see the 'netboot' description in the output of "tabdump -d noderes".
Error: [c910f03c05k20]: dhcp server is not running.  please start the dhcp server.
testnode1: install rhels7.3-ppc64le-compute
CHECK:output =~ Warning: (\[.*?\]: )?testnode1:.+might be invalid	[Pass]

RUN:noderm testnode1 [Fri May 25 23:48:04 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::nodeset_check_warninginfo::Passed::Time:Fri May 25 23:48:04 2018 ::Duration::6 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished at Fri May 25 23:48:04 2018
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20180525234756 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20180525234756 file for time consumption
```
For compatilbe:
```
XCATTEST_CN=c910f03c05k30 xcattest -t nodeset_check_warninginfo
xCAT automated test started at Fri May 25 23:49:22 2018
******************************
To detect current test environment
******************************
Detecting: OS = linux
Detecting: ARCH = ppc64le
Detecting: HCP = kvm
******************************
loading test cases
******************************
To run:
nodeset_check_warninginfo
******************************
Start to run test cases
******************************
------START::nodeset_check_warninginfo::Time:Fri May 25 23:49:23 2018------

RUN:if [[ "__GETNODEATTR(c910f03c05k30,arch)__" =~ "el" || "__GETNODEATTR(c910f03c05k30,arch)__" =~ "le" ]]; then bootloader=xnba; else bootloader=petitboot; fi; mkdef -t node -o testnode1 arch=ppc64el cons=ipmi groups=pbmc mgt=ipmi ip=10.1.1.200 mac=e6:d4:d2:3a:ad:06  monserver=10.1.1.1 nameservers=10.1.1.1 nodetype=ppc,osi profile=compute tftpserver=10.1.1.1 xcatmaster=10.1.1.1 netboot=$bootloader [Fri May 25 23:49:23 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:lsdef testnode1 [Fri May 25 23:49:24 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Object name: testnode1
    arch=ppc64el
    cons=ipmi
    groups=pbmc
    ip=10.1.1.200
    mac=e6:d4:d2:3a:ad:06
    mgt=ipmi
    monserver=10.1.1.1
    nameservers=10.1.1.1
    netboot=xnba
    nodetype=ppc,osi
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
    profile=compute
    tftpserver=10.1.1.1
    xcatmaster=10.1.1.1

RUN:nodeset testnode1 osimage=__GETNODEATTR(c910f03c05k30,os)__-__GETNODEATTR(c910f03c05k30,arch)__-install-compute [Fri May 25 23:49:25 2018]
ElapsedTime:4 sec
RETURN rc = 1
OUTPUT:
Warning: testnode1: xnba might be invalid when provisioning rhels7.3-ppc64le-install-compute,valid options: "petitboot,grub2,grub2-tftp,grub2-http".
For more details see the 'netboot' description in the output of "tabdump -d noderes".
Error: dhcp server is not running.  please start the dhcp server.
testnode1: install rhels7.3-ppc64le-compute
CHECK:output =~ Warning: (\[.*?\]: )?testnode1:.+might be invalid	[Pass]

RUN:noderm testnode1 [Fri May 25 23:49:29 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

------END::nodeset_check_warninginfo::Passed::Time:Fri May 25 23:49:30 2018 ::Duration::7 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished at Fri May 25 23:49:30 2018
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20180525234922 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20180525234922 file for time consumption
```