### PR TITLE
Fix code error to generate the right socket file name based on the caller PID

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc2.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc2.pm
@@ -149,7 +149,7 @@ sub process_request {
     return unless(%node_info);
 
     # If we can't start the python agent, exit immediately
-    my $pid = xCAT::OPENBMC::start_python_agent();
+    my $pid = xCAT::OPENBMC::start_python_agent($$);
     if (!defined($pid)) {
         xCAT::MsgUtils->message("E", { data => ["Failed to start the xCAT Python agent. Check /var/log/xcat/cluster.log for more information."] }, $callback);
         return;


### PR DESCRIPTION
To fix #5257 

As we cannot use `$$` directly, so in plugin, it will pass the plugin process PID to set the right name for lockfile and socket file.

UT:
```
chdef f6u17 servicenode=c910f03c05k04,c910f03c17k17
rpower f6u03,f6u13,f6u17 stat -V
[c910f03c05k04]: Running command in Python
[c910f03c05k04]: f6u03: on
[c910f03c05k04]: f6u13: on
f6u17: [c910f03c05k04]: Error: Login to BMC failed: Can't connect to 10.6.17.100:443 (No route to host).
Error: [c910f03c05k04]: Failed to dispatch command to any of the following service nodes: c910f03c05k04,c910f03c17k17
```  

Before fix, the output as below:
```
rpower f6u03,f6u13,f6u17 stat -V
[c910f03c05k04]: Running command in Python
[c910f03c05k04]: f6u03: on
[c910f03c05k04]: f6u13: on
Error: [c910f03c05k04]: Agent exited unexpectedly.  See /var/log/xcat/agent.log for details.
[c910f03c05k04]: To revert to Perl framework: chdef -t site clustersite openbmcperl=ALL
Error: [c910f03c05k04]: Failed to dispatch command to any of the following service nodes: c910f03c05k04,c910f03c17k17
```