### PR TITLE
check ip whether static for networkmanager config

### DIFF
--- a/xCAT-probe/lib/perl/probe_utils.pm
+++ b/xCAT-probe/lib/perl/probe_utils.pm
@@ -179,6 +179,14 @@ sub is_static_ip {
     my $os  = get_os();
     my $rst = 0;
 
+    my $ipv4_method = `nmcli con show $nic 2>&1 | grep -E 'ipv4.method'`;
+    unless ($?) {
+        if ($ipv4_method =~ /manual/) {
+            $rst = 1;
+        }
+        return $rst;
+    }
+
     if ($os =~ /redhat/) {
         my $output1 = `cat /etc/sysconfig/network-scripts/ifcfg-$nic 2>&1 |grep -i IPADDR`;
         my $output2 = `cat /etc/sysconfig/network-scripts/ifcfg-$nic 2>&1 |grep -i BOOTPROTO`;


### PR DESCRIPTION
https://github.com/xcat2/xcat2-task-management/issues/154

If ipv4.method is 'manual' by `nmcli con show $nic 2>&1 | grep -E 'ipv4.method'`, it is static ip.
If not, it is dhcp.
If run cmd failed, check ip config file.