### PR TITLE
Add WARNING message if non-root user runs chtab command

### DIFF
--- a/xCAT-server/sbin/chtab
+++ b/xCAT-server/sbin/chtab
@@ -66,7 +66,7 @@ unless ($target) {
 my $current_userid = getpwuid($>);
 if ($current_userid ne "root")
 {
-    print "WARNING: chtab bypasses xcatd and does not enforce xCAT policy tables. Using tabch instead.\n";
+    print "WARNING: chtab bypasses xcatd and does not enforce xCAT policy tables. Consider using tabch instead.\n";
 }
 
 my %keyhash = ();

--- a/xCAT-server/sbin/chtab
+++ b/xCAT-server/sbin/chtab
@@ -66,7 +66,7 @@ unless ($target) {
 my $current_userid = getpwuid($>);
 if ($current_userid ne "root")
 {
-    print "WARNING: chtab worked without passing xcatd, using tabch command instead if user is controled by policy mechanism\n";
+    print "WARNING: chtab bypasses xcatd and does not enforce xCAT policy tables. Using tabch instead.\n";
 }
 
 my %keyhash = ();

--- a/xCAT-server/sbin/chtab
+++ b/xCAT-server/sbin/chtab
@@ -63,6 +63,12 @@ unless ($target) {
     exit(1);
 }
 
+my $current_userid = getpwuid($>);
+if ($current_userid ne "root")
+{
+    print "WARNING: chtab worked without passing xcatd, using tabch command instead if user is controled by policy mechanism\n";
+}
+
 my %keyhash = ();
 my @keypairs = split(/,/, $target);
 if ($keypairs[0] !~ /([^\.\=]+)\.([^\.\=]+)\=(.+)/) {


### PR DESCRIPTION
For issue #5260

If user is not root,  running `chtab` command will log a warning message.
````
[cxhong@boston02 home]$ chtab
WARNING: chtab worked without passing xcatd, using tabch command instead if user is controled by policy mechanism
````