### PR TITLE
Recording the Severity of log message into xCAT logs

### DIFF
--- a/perl-xCAT/xCAT/MsgUtils.pm
+++ b/perl-xCAT/xCAT/MsgUtils.pm
@@ -897,42 +897,24 @@ sub trace() {
     if (($level eq "I") || ($level eq "i")) { $prefix = "INFO"; }
     if (($level eq "D") || ($level eq "d")) { $prefix = "DEBUG"; }
 
-    if (($level eq "E")
-        || ($level eq "e")
-        || ($level eq "I")
-        || ($level eq "i")
-        || ($level eq "W")
-        || ($level eq "w")) {
-        my $msg = $prefix . " " . $logcontent;
-        eval {
-            openlog("xcat", "nofatal,pid", "local4");
-            syslog("$prefix", $msg);
-            closelog();
-        };
-        if ($@) {
-            print "Error: Unable to log to syslog: $@\n";
-            print "$msg\n";
-        }
-        return;
+    return unless ($prefix); #unknown level, do nothing.
+
+    if (($verbose == 0) && ($prefix eq "DEBUG")) {
+        my @tmp = xCAT::TableUtils->get_site_attribute("xcatdebugmode");
+        my $xcatdebugmode = $tmp[0];
+        return unless (($xcatdebugmode == 1) || ($xcatdebugmode == 2));
     }
 
-    my @tmp           = xCAT::TableUtils->get_site_attribute("xcatdebugmode");
-    my $xcatdebugmode = $tmp[0];
-    if (($level eq "D")
-        || ($level eq "d")) {
-        if (($verbose == 1) || ($xcatdebugmode eq "1") || ($xcatdebugmode eq "2")) {
-            my $msg = $prefix . " " . $logcontent;
-            eval {
-                openlog("xcat", "nofatal,pid", "local4");
-                syslog("$prefix", $msg);
-                closelog();
-            };
-            if ($@) {
-                print "Error: Unable to log to syslog: $@\n";
-                print "$msg\n";
-            }
-        }
+    eval {
+        openlog("xcat", "nofatal,pid", "local4");
+        syslog("$prefix", $logcontent);
+        closelog();
+    };
+    if ($@) {
+        print "Error: Unable to log to syslog: $@\n";
+        print "$prefix . $logcontent\n";
     }
+
 }
 
 #------------------------------------------------------------------

--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -844,14 +844,14 @@ sub do_udp_service {    # This function opens up a UDP port
                         #notify the client that its request is been processing
                         my $ret=xCAT::NetworkUtils->send_tcp_msg($clientip,3001,"processing");
                         if($ret){
-                            xCAT::MsgUtils->message("S", "INFO xcatd: fail to notify $clientip that its 'findme' request is been processing");
+                            xCAT::MsgUtils->message("S", "xcatd: fail to notify $clientip that its 'findme' request is been processing");
                         }
                     } elsif ($data =~ /^<xcat/) {    # xml format
                         store_fd({ data => $data, sockaddr => $clientip, sport => $sport }, $discoctl);
                         #notify the client that its request is been processing
                         my $ret=xCAT::NetworkUtils->send_tcp_msg($clientip,3001,"processing");
                         if($ret){
-                            xCAT::MsgUtils->message("S", "INFO xcatd: fail to notify $clientip that its 'findme' request is been processing");
+                            xCAT::MsgUtils->message("S", "xcatd: fail to notify $clientip that its 'findme' request is been processing");
                         }
 
                     } else {    # for *now*, we'll do a tiny YAML subset
@@ -1212,7 +1212,7 @@ unless ($cmdlog_svrpid) {
         if ($clientsock)           { close($clientsock); }
         if (-e $cmdlogservicefile) { unlink("$cmdlogservicefile"); }
         if ($cmdlogsvrlistener)    { close($cmdlogsvrlistener); }
-        xCAT::MsgUtils->message("S", "INFO xcatd: 'Command log writer' process $$ is terminated by USR2 signal");
+        xCAT::MsgUtils->message("S", "xcatd: 'Command log writer' process $$ is terminated by USR2 signal");
         exit(0);
     };
 
@@ -1222,7 +1222,7 @@ unless ($cmdlog_svrpid) {
         if ($clientsock)           { close($clientsock); }
         if (-e $cmdlogservicefile) { unlink("$cmdlogservicefile"); }
         if ($cmdlogsvrlistener)    { close($cmdlogsvrlistener); }
-        xCAT::MsgUtils->message("S", "INFO xcatd: 'Command log writer' process $$ is terminated by TERM or INT signal");
+        xCAT::MsgUtils->message("S", "xcatd: 'Command log writer' process $$ is terminated by TERM or INT signal");
         exit(0);
     };
 
@@ -1246,10 +1246,10 @@ unless ($cmdlog_svrpid) {
             $cmdlogfileswitch = 1;
         }
         if (!$trytime) {
-            xCAT::MsgUtils->message("S", "INFO xcatd: 'Command log writer' process $$ get HUP signal, reopen commands.log file failed, send TERM signal to kill itself");
+            xCAT::MsgUtils->message("S", "xcatd: 'Command log writer' process $$ get HUP signal, reopen commands.log file failed, send TERM signal to kill itself");
             kill 'INT', $$;
         } else {
-            xCAT::MsgUtils->message("S", "INFO xcatd: 'Command log writer' process $$ get HUP signal, reopen commands.log file");
+            xCAT::MsgUtils->message("S", "xcatd: 'Command log writer' process $$ get HUP signal, reopen commands.log file");
         }
     };
 
@@ -1260,7 +1260,7 @@ unless ($cmdlog_svrpid) {
         Listen    => 8192);
 
     if (not $cmdlogsvrlistener and open($cmdlogpidfile, "<", "$cmdlogservicefile")) {
-        xCAT::MsgUtils->message("S", "INFO xcatd: 'Command log writer' process $$ is trying to get port $cmdlog_port");
+        xCAT::MsgUtils->message("S", "xcatd: 'Command log writer' process $$ is trying to get port $cmdlog_port");
         my $pid = <$cmdlogpidfile>;
         if ($pid) {
             kill 'USR2', $pid;
@@ -1319,7 +1319,7 @@ unless ($cmdlog_svrpid) {
 
     if ($cmdlogfile)        { close($cmdlogfile); }
     if ($cmdlogsvrlistener) { close($cmdlogsvrlistener); }
-    xCAT::MsgUtils->message("S", "INFO xcatd: 'Command log writer' process $$ stop");
+    xCAT::MsgUtils->message("S", "xcatd: 'Command log writer' process $$ stop");
 }
 
 # ----used for command log end---------

--- a/xCAT/etc/rsyslog.d/xcat-cluster.conf
+++ b/xCAT/etc/rsyslog.d/xcat-cluster.conf
@@ -1,3 +1,3 @@
-$template xCATTraditionalFormat0,"%timegenerated% %HOSTNAME% %syslogtag% %msg:::drop-last-lf%\n"
+$template xCATTraditionalFormat0,"%timegenerated% %HOSTNAME% %syslogtag% %syslogseverity-text:::uppercase% %msg:::drop-last-lf%\n"
 :programname, isequal, "xcat" /var/log/xcat/cluster.log;xCATTraditionalFormat0
 :programname, startswith, "xcat." /var/log/xcat/cluster.log;xCATTraditionalFormat0

--- a/xCAT/etc/rsyslog.d/xcat-compute.conf
+++ b/xCAT/etc/rsyslog.d/xcat-compute.conf
@@ -1,3 +1,3 @@
-$template xCATTraditionalFormat9,"%timegenerated% %HOSTNAME% %syslogtag% %msg:::drop-last-lf%\n"
+$template xCATTraditionalFormat9,"%timegenerated% %HOSTNAME% %syslogtag% %syslogseverity-text:::uppercase% %msg:::drop-last-lf%\n"
 :fromhost-ip, !isequal, "127.0.0.1" /var/log/xcat/computes.log;xCATTraditionalFormat9
 & ~


### PR DESCRIPTION
This is for #5263  
- modify rsyslog conf and add "%syslogseverity-text:::uppercase%" to input the text Severity
 - remove duplicate Severity in log message
 - modify MsgUtils::trace for better performance and code structure

UT: after applied the changes:
```
tail /var/log/xcat/cluster.log
May 30 19:44:45 c910f03c05k20 xcat[14561]: DEBUG  xcatd: dispatch request 'tabdump site' to plugin 'tabutils'
May 30 19:44:45 c910f03c05k20 xcat[14561]: DEBUG  xcatd: handle request 'tabdump' by plugin 'tabutils''s process_request
May 30 19:44:45 c910f03c05k20 xcat[14560]: DEBUG  xcatd: close connection with root@localhost
May 30 19:44:56 c910f03c05k20 xcat[14571]: DEBUG  xcatd: connection from root@localhost
May 30 19:44:56 c910f03c05k20 xcat[14571]: DEBUG  xcatd: open new process : xcatd SSL: tabrestore for root@localhost
May 30 19:44:56 c910f03c05k20 xcat[14571]: INFO  xCAT: Allowing tabrestore for root from localhost
May 30 19:44:56 c910f03c05k20 xcat[14572]: DEBUG  xcatd: dispatch request 'tabrestore ' to plugin 'tabutils'
May 30 19:44:56 c910f03c05k20 xcat[14572]: DEBUG  xcatd: handle request 'tabrestore' by plugin 'tabutils''s process_request
May 30 19:44:56 c910f03c05k20 xcat[14571]: DEBUG  xcatd: close connection with root@localhost
May 30 19:45:10 c910f03c05k20 xcat[14579]: INFO  xCAT: Allowing nodels for root from localhost
```

Note: xCAT still have many log message, it starts with `Error: ...`, for such case, there might be still duplicate info for the severity, so it is expected the severity is appended by xcat provided method, but not in the log message.

If we hit more, we can fix them case by case.


For xcat-compute.log,  all logs from SN and CN, could show the Severity in log file too.
```
May 30 20:21:25 c910f03c05k24 dhcpd:  DHCPDISCOVER from 42:88:0a:04:0e:29 via eth0: network eth0: no free leases
May 30 20:21:25 c910f03c05k24 dhcpd:  DHCPDISCOVER from 16:3f:47:ad:52:03 via eth0: network eth0: no free leases
May 30 20:21:26 c910f03c05k24 dhcpd:  DHCPDISCOVER from 7a:14:e3:86:5c:03 via eth0: network eth0: no free leases
May 30 20:21:26 c910f03c05k24 dhcpd:  DHCPDISCOVER from 42:d3:0a:05:68:04 via eth0: network eth0: no free leases
May 30 20:21:26 c910f03c05k24 dhcpd:  DHCPDISCOVER from 4a:c8:f3:d0:71:03 via eth0: network eth0: no free leases

after applied the rsysyslog changes:

May 30 20:21:28 c910f03c05k24 dhcpd: ERR  DHCPDISCOVER from 42:88:0a:04:0e:29 via eth0: network eth0: no free leases
May 30 20:21:28 c910f03c05k24 dhcpd: ERR  DHCPDISCOVER from e6:d4:d3:4f:08:03 via eth0: network eth0: no free leases
May 30 20:21:28 c910f03c05k24 dhcpd: ERR  DHCPDISCOVER from 16:3f:48:47:a3:03 via eth0: network eth0: no free leases
May 30 20:21:29 c910f03c05k24 dhcpd: ERR  DHCPDISCOVER from 7a:14:e3:86:5c:03 via eth0: network eth0: no free leases
May 30 20:21:29 c910f03c05k24 dhcpd: ERR  DHCPDISCOVER from 4a:c8:f3:d0:71:03 via eth0: network eth0: no free leases
```