### PR TITLE
modify nodestat usage and manpage for `-f|--useping`

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/nodestat.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/nodestat.1.rst
@@ -19,7 +19,7 @@ Name
 ****************
 
 
-\ **nodestat**\  [\ *noderange*\ ] [\ **-m | -**\ **-usemon**\ ] [\ **-p | -**\ **-powerstat**\ ] [\ **-f**\ ] [\ **-u | -**\ **-updatedb**\ ]
+\ **nodestat**\  [\ *noderange*\ ] [\ **-m | -**\ **-usemon**\ ] [\ **-p | -**\ **-powerstat**\ ] [\ **-f | -**\ **-usefping**\ ] [\ **-u | -**\ **-updatedb**\ ]
 
 \ **nodestat**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
@@ -86,7 +86,7 @@ For the command specified by 'dcmd', no input is needed, the output can be a str
 
 
 
-\ **-f**\ 
+\ **-f | -**\ **-usefping**\
  
  Uses fping instead of nmap even if nmap is available.  If you seem to be having a problem with false negatives, fping can be more forgiving, but slower.
  

--- a/xCAT-client/pods/man1/nodestat.1.pod
+++ b/xCAT-client/pods/man1/nodestat.1.pod
@@ -4,7 +4,7 @@ B<nodestat> - display the running status of each node in a noderange
 
 =head1 B<Synopsis>
 
-B<nodestat> [I<noderange>] [B<-m>|B<--usemon>] [B<-p>|B<--powerstat>] [B<-f>] [B<-u>|B<--updatedb>]
+B<nodestat> [I<noderange>] [B<-m>|B<--usemon>] [B<-p>|B<--powerstat>] [B<-f>|B<--usefping>] [B<-u>|B<--updatedb>]
 
 B<nodestat> [B<-h>|B<--help>|B<-v>|B<--version>]
 
@@ -57,7 +57,7 @@ For the command specified by 'dcmd', no input is needed, the output can be a str
 
 =over 10
 
-=item B<-f>
+=item B<-f>|B<--usefping>
 
 Uses fping instead of nmap even if nmap is available.  If you seem to be having a problem with false negatives, fping can be more forgiving, but slower.
 

--- a/xCAT-server/lib/xcat/plugins/nodestat.pm
+++ b/xCAT-server/lib/xcat/plugins/nodestat.pm
@@ -912,7 +912,7 @@ sub process_request {
     if (ref $request->{arg}) {
         @ARGV = @{ $request->{arg} };
         GetOptions(
-            'f' => \$usefping
+            'f|useping' => \$usefping
         );
     }
 
@@ -1217,7 +1217,7 @@ sub usage
     my $retcode=shift;
     my $rsp = {};
     $rsp->{data}->[0] = "Usage:";
-    $rsp->{data}->[1] = "  nodestat [noderange] [-m|--usemon] [-p|powerstat] [-u|--updatedb]";
+    $rsp->{data}->[1] = "  nodestat [noderange] [-m|--usemon] [-p|powerstat] [-f|--usefping] [-u|--updatedb]";
     $rsp->{data}->[2] = "  nodestat [-h|--help|-v|--version]";
     if($retcode){
        $rsp->{errorcode}->[0]=$retcode;


### PR DESCRIPTION
The change is straightforward, as `-f` is already supported, need to cover `--usefping`
This PR is to replace https://github.com/xcat2/xcat-core/pull/4849

UT:
```
nodestat -h
Usage:
  nodestat [noderange] [-m|--usemon] [-p|powerstat] [-f|--usefping] [-u|--updatedb]
  nodestat [-h|--help|-v|--version]
```

Note the print message is added for temporary
```
# XCATBYPASS=1 nodestat -f c910f03c05k24
here is using fping...
c910f03c05k24: sshd
# XCATBYPASS=1 nodestat --usefping c910f03c05k24
here is using fping...
c910f03c05k24: sshd
# XCATBYPASS=1 nodestat c910f03c05k24
c910f03c05k24: sshd
# mv /usr/bin/nmap /usr/bin/nmap.bak
# XCATBYPASS=1 nodestat c910f03c05k24
here is using fping...
c910f03c05k24: sshd
```