### PR TITLE
Create switchprobe link during xCAT-probe installation

### DIFF
--- a/makerpm
+++ b/makerpm
@@ -13,7 +13,6 @@ function xcat_probe_copy {
     # xCAT-probe uses some functions shipped with xCAT,  copying for the following reasons:
     #     1. make xCAT-probe code be self-contained
     #     2. do not maintain two files for each script
-    #     3. symbolic link can't work during packaging
     RPMNAME=${1}
     if [ $RPMNAME = "xCAT-probe" ]; then
         mkdir -p ${RPMNAME}/lib/perl/xCAT/

--- a/xCAT-probe/subcmds/switch_macmap
+++ b/xCAT-probe/subcmds/switch_macmap
@@ -53,13 +53,6 @@ if ($help) {
     exit 0;
 }
 
-if (!-d "$currdir/bin") {
-    mkpath("$currdir/bin/");
-}
-if (!-e "$currdir/bin/switchprobe") {
-    link("$::XCATROOT/bin/xcatclient", "$currdir/bin/switchprobe");
-}
-
 if ($test) {
     `$currdir/bin/switchprobe -h`;
     if ($?) {

--- a/xCAT-probe/xCAT-probe.spec
+++ b/xCAT-probe/xCAT-probe.spec
@@ -61,16 +61,13 @@ rm -rf $RPM_BUILD_ROOT
 - "Create xCAT probe package"
 
 %post
-echo "In RPM post section..."
-echo "Create %{prefix}/probe/subcmds/bin/switchprobe link to xcatclient..."
 if [ -e %{prefix}/probe/subcmds/bin/switchprobe ]; then
     rm -rf %{prefix}/probe/subcmds/bin/switchprobe
+else
+    mkdir -p %{prefix}/probe/subcmds/bin/
 fi
-mkdir -p %{prefix}/probe/subcmds/bin/
 cd %{prefix}/probe/subcmds/bin/ 
 ln %{prefix}/bin/xcatclient switchprobe
 
 %preun
-echo "In RPM preun section..."
-echo "Remove %{prefix}/probe/subcmds/bin/switchprobe ..."
 rm -rf %{prefix}/probe/subcmds/bin/

--- a/xCAT-probe/xCAT-probe.spec
+++ b/xCAT-probe/xCAT-probe.spec
@@ -67,9 +67,12 @@ else
     mkdir -p %{prefix}/probe/subcmds/bin/
 fi
 cd %{prefix}/probe/subcmds/bin/ 
-ln %{prefix}/bin/xcatclient switchprobe
+if [ -e %{prefix}/bin/xcatclient ]; then
+    ln -s %{prefix}/bin/xcatclient switchprobe
+fi
 
 %preun
+#remove the bin directory if not on upgrade
 if [ "$1" != "1" ]; then
     rm -rf %{prefix}/probe/subcmds/bin/
 fi

--- a/xCAT-probe/xCAT-probe.spec
+++ b/xCAT-probe/xCAT-probe.spec
@@ -61,5 +61,16 @@ rm -rf $RPM_BUILD_ROOT
 - "Create xCAT probe package"
 
 %post
+echo "In RPM post section..."
+echo "Create %{prefix}/probe/subcmds/bin/switchprobe link to xcatclient..."
+if [ -e %{prefix}/probe/subcmds/bin/switchprobe ]; then
+    rm -rf %{prefix}/probe/subcmds/bin/switchprobe
+fi
+mkdir -p %{prefix}/probe/subcmds/bin/
+cd %{prefix}/probe/subcmds/bin/ 
+ln %{prefix}/bin/xcatclient switchprobe
 
 %preun
+echo "In RPM preun section..."
+echo "Remove %{prefix}/probe/subcmds/bin/switchprobe ..."
+rm -rf %{prefix}/probe/subcmds/bin/

--- a/xCAT-probe/xCAT-probe.spec
+++ b/xCAT-probe/xCAT-probe.spec
@@ -70,4 +70,6 @@ cd %{prefix}/probe/subcmds/bin/
 ln %{prefix}/bin/xcatclient switchprobe
 
 %preun
-rm -rf %{prefix}/probe/subcmds/bin/
+if [ "$1" != "1" ]; then
+    rm -rf %{prefix}/probe/subcmds/bin/
+fi


### PR DESCRIPTION
for issue #5266 

currently, switchprobe to switch plugin is created from `probe/subcmds/switch_macmap`,  the non-root user will not able to run `xcatprobe switch_macmap` if `probe/subcmds/bin/switchprobe` is not created by root first.  To fix this, will create `switchprobe` in the %post durling xCAT-probe installation.

````
# rpm -ivh /root/xCAT-probe-2.14.1-snap000000000000.noarch.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:xCAT-probe-4:2.14.1-snap000000000################################# [100%]
In RPM post section...
Create /opt/xcat/probe/subcmds/bin/switchprobe link to xcatclient...
# ls -ltr /opt/xcat/probe/subcmds/bin
total 4
-rwxr-xr-x 2 root root 3281 May 30 07:16 switchprobe

# rpm -ef --nodeps xCAT-probe
In RPM preun section...
Remove /opt/xcat/probe/subcmds/bin/switchprobe ...
# ls -ltr /opt/xcat/probe/subcmds/bin
ls: cannot access /opt/xcat/probe/subcmds/bin: No such file or directory

````
