### PR TITLE
`Accepted` status would be returned if etcd storage is used

### DIFF
--- a/xCAT-server/lib/perl/xCAT/Goconserver.pm
+++ b/xCAT-server/lib/perl/xCAT/Goconserver.pm
@@ -264,7 +264,7 @@ sub delete_nodes {
         return 1;
     } elsif ($delmode) {
         while (my ($k, $v) = each %{$response}) {
-            if ($v ne "Deleted") {
+            if ($v ne "Deleted" && $v ne "Accepted") {
                 xCAT::MsgUtils->error_message("$k: Failed to delete entry in goconserver: $v", $callback);
                 $ret = 1;
             } else {
@@ -299,7 +299,7 @@ sub create_nodes {
         return 1;
     } elsif ($response) {
         while (my ($k, $v) = each %{$response}) {
-            if ($v ne "Created") {
+            if ($v ne "Created" && $v ne "Accepted") {
                 xCAT::MsgUtils->error_message("$k: Failed to create console entry in goconserver: $v", $callback);
                 $ret = 1;
             } else {


### PR DESCRIPTION
goconserver leverage the `watch` feature from etcd which make the
request asynchronous. As the result could not be determined until
the logic in watch thread completed, goconserver just return `Accepted`
status instead of the final status( Created or Deleted).

```
[root@boston02 goconserver]# congo list
Could not find any record.
[root@boston02 goconserver]# makegocons
coral-pdu: ignore, cons attribute or serialport attribute is not specified.
f6pdu15: ignore, cons attribute or serialport attribute is not specified.
f6pdu16: ignore, cons attribute or serialport attribute is not specified.
mid08: ignore, cons attribute or serialport attribute is not specified.
core01: ignore, cons attribute or serialport attribute is not specified.
mid08tor03: ignore, cons attribute or serialport attribute is not specified.
mgmtsw01: ignore, cons attribute or serialport attribute is not specified.
Error: Failed to send delete request.
sn02: Accepted
mid08tor03cn10: Accepted
mid08tor03cn26: Accepted
mid08tor03cn01: Accepted
[root@boston02 goconserver]# congo list
mid08tor03cn01 (host: sn02.pok.stglabs.ibm.com, state: error)
mid08tor03cn10 (host: boston02.pok.stglabs.ibm.com, state: connected)
mid08tor03cn26 (host: sn02.pok.stglabs.ibm.com, state: connected)
sn02 (host: boston02.pok.stglabs.ibm.com, state: connected)
```