### PR TITLE
let mysqlsetup work when using alias IP as MN IP

### DIFF
--- a/xCAT-client/bin/mysqlsetup
+++ b/xCAT-client/bin/mysqlsetup
@@ -338,6 +338,7 @@ if ((($odbconly == 0) && ($::xcatrunningmysql == 0)) || $::UPDATE || $::SETUPLL)
 }
 
 # initial setup request, if not already running mysql
+my $hostfile_configured=1;
 if (($::INIT) && ($::xcatrunningmysql == 0))
 {
     # MySQL not running, then initialize the database
@@ -443,6 +444,12 @@ if (($::INIT) && ($::xcatrunningmysql == 0))
         #
         &createcfgloc;
 
+        if ($::HOSTFILE)
+        {
+           &addhosts;
+           $hostfile_configured=0
+        }
+
         #
         # Restore backed up database into MySQL
         #
@@ -481,7 +488,7 @@ if ($::SETUPLL)
 
 
 # if input a list of hosts to add to the database, to give access to MySQL
-if ($::HOSTFILE)
+if (($::HOSTFILE) && ($hostfile_configured == 1))
 {
     &addhosts;
 


### PR DESCRIPTION
For #5278 

`mysqlsetup -i -f /tmp/physical_IP -V` UT：
```
... ...
Running command on bymn: rpm -qa | grep -i mariadb 2>&1

Running command on bymn: rpm -qa | grep -i perl-DBD-mysql 2>&1

Running command on bymn: ps -ef | grep mysqld 2>&1

Running command on bymn: pidof mysqld 2>&1

Running command on bymn: /usr/bin/mysql_install_db --user=mysql 2>&1

Running command on bymn: ps -ef | grep mysqld | grep -v grep 2>&1

Running command on bymn: chkconfig mariadb on 2>&1

Backing up xCAT Database to /root/xcat-dbback.
This could take several minutes.
Running command on bymn: mkdir -p /root/xcat-dbback 2>&1

Running command on bymn: dumpxCATdb -p /root/xcat-dbback 2>&1

Shutting down the xcatd daemon during database migration.
Stopping xcatd (via systemctl):                            [  OK  ]
Running command on bymn: grep master /root/xcat-dbback/site.csv 2>&1

Running command on bymn: cp /etc/xcat/cfgloc.mysql /etc/xcat/cfgloc 2>&1

Restoring the xCAT Database with /root/xcat-dbback to MySQL database.
This could take several minutes.
Restarting xcatd (via systemctl):                          [  OK  ]
xCAT is now running on the MySQL database.
```