### PR TITLE
Enhance xcattest to support label search

### DIFF
--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -16,8 +16,9 @@ BEGIN
 use lib "$::XCATROOT/lib/perl";
 
 #--------------global attributes----------------
-my $prpgram_path             = dirname(File::Spec->rel2abs(__FILE__));
-my $program_name             = basename($0);
+my $prpgram_path = dirname(File::Spec->rel2abs(__FILE__));
+my $program_name = basename($0);
+
 my $rootdir                  = "$prpgram_path/../share/xcat/tools/autotest";
 my $casedir                  = "$rootdir/testcase/";
 my $bundledir                = "$rootdir/bundle/";
@@ -52,19 +53,29 @@ my $RUN   = 1;
 
 #----------global logs attributes---------------
 my $running_log_fd     = undef
-my $running_log_name = undef;
+  my $running_log_name = undef;
 my $failed_log_name      = undef;
 my $performance_log_name = undef;
 
 #--------------command line attrbutes--------------
-my $needhelp   = 0;
-my $configfile = undef;
-my $bundlelist = undef;
-my $caselist   = undef;
-my $cmdlist    = undef;
-my $list       = undef;
-my $restore    = 0;
-my $quiet      = 0;
+my $needhelp          = 0;
+my $configfile        = undef;
+my $bundlelist        = undef;
+my $caselist          = undef;
+my $cmdlist           = undef;
+my $list              = undef;
+my $restore           = 0;
+my $quiet             = 0;
+my $search_expression = undef;
+
+my %label_map;
+my $label_value = 1;
+my @label_order = (["xcat_install"],
+    ["mn_only"],
+    [ "sn_diskful", "sn_diskless" ],
+    [ "flat_cn_diskful", "flat_cn_diskless", "hierarchy_cn_diskful", "hierarchy_cn_diskless" ],
+    [ "cn_bmc_ready", "cn_os_ready" ],
+    ["others"]);
 
 #-------------usage--------------------
 $::USAGE = "Usage:
@@ -117,6 +128,7 @@ if (
         "c=s" => \$cmdlist,
         "l=s" => \$list,
         "q"   => \$quiet,
+        "s=s" => \$search_expression,
         "r"   => \$restore)
   )
 {
@@ -140,6 +152,10 @@ $rst = calculate_cases_to_be_run(\@cases_to_be_run, \$error);
 if ($rst) {
     log_this($running_log_fd, "$error");
     to_exit(1);
+}
+
+if ($search_expression) {
+    to_exit(0);
 }
 
 #print "----case to be run-----------------\n";
@@ -220,11 +236,12 @@ if (defined($configfile)) {
     }
 } else {
     $setup_env_by_config_file = 0;
+
     # Leverage environment variable to used in test case
     foreach (keys %ENV) {
         if (/^XCATTEST_/) {
-            my @envname=split("_",$_,2);
-            $config{var}{$envname[-1]} = $ENV{$_};
+            my @envname = split("_", $_, 2);
+            $config{var}{ $envname[-1] } = $ENV{$_};
         }
     }
 }
@@ -264,7 +281,7 @@ log_this($running_log_fd, "******************************");
 log_this($running_log_fd, "loading test cases");
 log_this($running_log_fd, "******************************");
 $rst = load_case(\@cases_to_be_run, \@cases, \%case_name_index_map, \$error, $RUN);
-if ($rst && $rst < 2 ) {
+if ($rst && $rst < 2) {
     log_this($running_log_fd, "$error");
     to_exit(1);
 }
@@ -276,7 +293,7 @@ if ($rst && $rst < 2 ) {
 #print "=====Dumper cases to be run=====\n";
 #print Dumper \@cases_to_be_run;
 
-unless(@cases_to_be_run){
+unless (@cases_to_be_run) {
     to_exit(1);
 }
 
@@ -466,6 +483,66 @@ sub calculate_cases_to_be_run {
                 }
             }
             close($fd);
+        }
+    } elsif ($search_expression) {
+        my $rst = load_case(\@cases_to_be_run, \@cases, \%case_name_index_map, \$error, $NORUN);
+        if ($rst) {
+            log_this($running_log_fd, "$error");
+            return 1;
+        }
+
+        #        print "-----------------------------------\n";
+        #        print Dumper \@cases;
+        #        print "-----------------------------------\n";
+        #        print Dumper \%label_map;
+        #        print "===>exp = $search_expression\n";
+
+        my @filters = ();
+        my $index   = 0;
+        my @exps    = split('\|', $search_expression);
+        foreach my $e (@exps) {
+            $e =~ s/\+/ /g;
+            $e =~ s/\-/ -/g;
+            my @tags = split(' ', $e);
+            foreach my $t (@tags) {
+                if ($t =~ /^-(.+)/) {
+                    push @{ $filters[$index] }, ($label_map{$1} * -1);
+                } else {
+                    push @{ $filters[$index] }, $label_map{$t};
+                }
+            }
+            $index += 1;
+        }
+
+        #print Dumper \@filters;
+
+        my @targetcases = ();
+        foreach my $case (@cases) {
+            foreach my $f (@filters) {
+                my $hit = 1;
+                foreach my $c (@$f) {
+                    if (($c > 0) and (($case->{label} & $c) == 0)) {
+                        $hit = 0;
+                        last;
+                    } elsif (($c < 0) and (($case->{label} & ($c * -1)) != 0)) {
+                        $hit = 0;
+                        last;
+                    }
+                }
+                push @targetcases, $case->{name} if ($hit and !(grep { /^$case->{name}$/ } @targetcases));
+            }
+        }
+
+        #print Dumper \@targetcases;
+
+        for (my $i = 0 ; $i <= $#label_order ; $i++) {
+            foreach my $l (@{ $label_order[$i] }) {
+                foreach my $c (@targetcases) {
+
+                    #print "$c\t$cases[$case_name_index_map{$c}]->{label_str}\n"  unless(($cases[$case_name_index_map{$c}]->{label} & $label_map{$l}) == 0);
+                    print "$c\n" unless (($cases[ $case_name_index_map{$c} ]->{label} & $label_map{$l}) == 0);
+                }
+            }
         }
     }
     return 0;
@@ -847,11 +924,11 @@ sub load_case {
             return 1;
         }
         while ($line = <$fd>) {
-            if($newcmdstart){
-                $line =~ s/\s+$//g ;
-             }else{
-                $line =~ s/^\s+|#[^!].+|\s+$//g ;
-             }
+            if ($newcmdstart) {
+                $line =~ s/\s+$//g;
+            } else {
+                $line =~ s/^\s+|#[^!].+|\s+$//g;
+            }
 
             #skip blank and comment lines
             next if (length($line) == 0 || ($line =~ /^\s*#/));
@@ -860,16 +937,18 @@ sub load_case {
                 my $name = $1;
                 if ($load_all_case_flag) {
                     if (is_valid_case_name($name)) {
-                        $skip                              = 0;
-                        $j                                 = -1;
-                        $case_ref->[$i]                    = {};
-                        $case_ref->[$i]->{name}            = $name;
-                        $case_ref->[$i]->{filename}        = $file;
-                        if(exists($$case_name_index_map_ref{"$name"})){
-                            $case_name_index_map_bak{"$name"}=$$case_name_index_map_ref{"$name"};
+                        $skip                        = 0;
+                        $j                           = -1;
+                        $case_ref->[$i]              = {};
+                        $case_ref->[$i]->{name}      = $name;
+                        $case_ref->[$i]->{filename}  = $file;
+                        $case_ref->[$i]->{label}     = 0;
+                        $case_ref->[$i]->{label_str} = "";
+                        if (exists($$case_name_index_map_ref{"$name"})) {
+                            $case_name_index_map_bak{"$name"} = $$case_name_index_map_ref{"$name"};
                         }
                         $$case_name_index_map_ref{"$name"} = $i;
-                        $newcmdstart                       = 0;
+                        $newcmdstart = 0;
                     } else {
                         $skip = 1;
                         push @{ $invalidcases{"invalidcasename"} }, $name;
@@ -880,17 +959,19 @@ sub load_case {
                         next;
                     } else {
                         if (is_valid_case_name($name)) {
-                            $skip                              = 0;
-                            $j                                 = -1;
-                            $case_ref->[$i]                    = {};
-                            $case_ref->[$i]->{name}            = $name;
-                            $case_ref->[$i]->{filename}        = $file;
-                            if(exists($$case_name_index_map_ref{"$name"})){
-                                $case_name_index_map_bak{"$name"}=$$case_name_index_map_ref{"$name"};
+                            $skip                        = 0;
+                            $j                           = -1;
+                            $case_ref->[$i]              = {};
+                            $case_ref->[$i]->{name}      = $name;
+                            $case_ref->[$i]->{filename}  = $file;
+                            $case_ref->[$i]->{label}     = 0;
+                            $case_ref->[$i]->{label_str} = "";
+                            if (exists($$case_name_index_map_ref{"$name"})) {
+                                $case_name_index_map_bak{"$name"} = $$case_name_index_map_ref{"$name"};
                             }
                             $$case_name_index_map_ref{"$name"} = $i;
-                            $newcmdstart                       = 0;
-                            if(grep (/$case_ref->[$i]->{name}/,@{ $invalidcases{"noruncases"} })){
+                            $newcmdstart = 0;
+                            if (grep (/$case_ref->[$i]->{name}/, @{ $invalidcases{"noruncases"} })) {
                                 delete_item_from_array($case_ref->[$i]->{name}, $invalidcases{"noruncases"});
                             }
                         } else {
@@ -921,98 +1002,124 @@ sub load_case {
                     foreach my $os (@newvalidoslist) {
                         if ($currentos =~ /$os/i) {
                             $valid = 1;
-                            if(grep (/$case_ref->[$i]->{name}/,@{ $invalidcases{"noruncases"} })){
+                            if (grep (/$case_ref->[$i]->{name}/, @{ $invalidcases{"noruncases"} })) {
                                 delete_item_from_array($case_ref->[$i]->{name}, $invalidcases{"noruncases"});
                             }
                             last;
                         }
                     }
                     unless ($valid) {
+
                         #$skip = 1;
-                        if(exists($case_name_index_map_bak{$case_ref->[$i]->{name}})){
-                            $$case_name_index_map_ref{$case_ref->[$i]->{name}}=$case_name_index_map_bak{$case_ref->[$i]->{name}};
-                        }else{
-                            delete $$case_name_index_map_ref{$case_ref->[$i]->{name}};
-                            if(! grep (/$case_ref->[$i]->{name}/,@{ $invalidcases{"noruncases"} })){
+                        if (exists($case_name_index_map_bak{ $case_ref->[$i]->{name} })) {
+                            $$case_name_index_map_ref{ $case_ref->[$i]->{name} } = $case_name_index_map_bak{ $case_ref->[$i]->{name} };
+                        } else {
+                            delete $$case_name_index_map_ref{ $case_ref->[$i]->{name} };
+                            if (!grep (/$case_ref->[$i]->{name}/, @{ $invalidcases{"noruncases"} })) {
                                 push @{ $invalidcases{"noruncases"} }, $case_ref->[$i]->{name};
                             }
                         }
                     }
                 }
                 $newcmdstart = 0;
+                $newcmdstart = 0;
+                my $str = "os=$case_ref->[$i]->{os}";
+                unless (exists $label_map{"$str"}) {
+                    $label_map{"$str"} = $label_value;
+                    $label_value *= 2;
+                }
+                $case_ref->[$i]->{label} |= $label_map{$str};
+                $case_ref->[$i]->{label_str} .= "$str,";
             } elsif ($line =~ /^arch\s*:\s*(\w[\w\,]+)/) {
                 next if $skip;
                 $case_ref->[$i]->{arch} = $1;
 
                 if ($run_case_flag) {
+
                     #To judge whether need to skip the current case
                     my $case_arch = $case_ref->[$i]->{arch};
-                    if($case_arch =~ /ppc/i && $case_arch !~ /le|el/i){
-                        $case_arch="ppc";
-                    }elsif($case_arch =~ /ppc/i && $case_arch =~ /le|el/i){
-                        $case_arch="ppc64le";
-                    }elsif($case_arch =~ /x86/i){
-                        $case_arch="x86";
+                    if ($case_arch =~ /ppc/i && $case_arch !~ /le|el/i) {
+                        $case_arch = "ppc";
+                    } elsif ($case_arch =~ /ppc/i && $case_arch =~ /le|el/i) {
+                        $case_arch = "ppc64le";
+                    } elsif ($case_arch =~ /x86/i) {
+                        $case_arch = "x86";
                     }
 
                     my $env_arch = "";
-                    if(exists($config{var}{ARCH})){
+                    if (exists($config{var}{ARCH})) {
                         $env_arch = $config{var}{ARCH};
-                    }else{
-                        $env_arch =`uname -m`;
+                    } else {
+                        $env_arch = `uname -m`;
                         chomp($env_arch);
                     }
-                    if($env_arch =~ /ppc/i && $env_arch !~ /le|el/i){
-                        $env_arch="ppc";
-                    }elsif($env_arch =~ /ppc/i && $env_arch =~ /le|el/i){
-                        $env_arch="ppc64le";
-                    }elsif($env_arch =~ /x86/i){
-                        $env_arch="x86";
+                    if ($env_arch =~ /ppc/i && $env_arch !~ /le|el/i) {
+                        $env_arch = "ppc";
+                    } elsif ($env_arch =~ /ppc/i && $env_arch =~ /le|el/i) {
+                        $env_arch = "ppc64le";
+                    } elsif ($env_arch =~ /x86/i) {
+                        $env_arch = "x86";
                     }
-                
-                    my $valid     = 0;
+
+                    my $valid = 0;
                     if ($case_arch eq $env_arch) {
                         $valid = 1;
-                        if(grep (/$case_ref->[$i]->{name}/,@{ $invalidcases{"noruncases"} })){
+                        if (grep (/$case_ref->[$i]->{name}/, @{ $invalidcases{"noruncases"} })) {
                             delete_item_from_array($case_ref->[$i]->{name}, $invalidcases{"noruncases"});
                         }
                     }
                     unless ($valid) {
-                        if(exists($case_name_index_map_bak{$case_ref->[$i]->{name}})){
-                            $$case_name_index_map_ref{$case_ref->[$i]->{name}}=$case_name_index_map_bak{$case_ref->[$i]->{name}};
-                        }else{
-                            delete $$case_name_index_map_ref{$case_ref->[$i]->{name}};
-                            if(! grep (/$case_ref->[$i]->{name}/,@{ $invalidcases{"noruncases"} })){
+                        if (exists($case_name_index_map_bak{ $case_ref->[$i]->{name} })) {
+                            $$case_name_index_map_ref{ $case_ref->[$i]->{name} } = $case_name_index_map_bak{ $case_ref->[$i]->{name} };
+                        } else {
+                            delete $$case_name_index_map_ref{ $case_ref->[$i]->{name} };
+                            if (!grep (/$case_ref->[$i]->{name}/, @{ $invalidcases{"noruncases"} })) {
                                 push @{ $invalidcases{"noruncases"} }, $case_ref->[$i]->{name};
                             }
                         }
                     }
                 }
                 $newcmdstart = 0;
+                my $str = "arch=$case_ref->[$i]->{arch}";
+                unless (exists $label_map{"$str"}) {
+                    $label_map{"$str"} = $label_value;
+                    $label_value *= 2;
+                }
+                $case_ref->[$i]->{label} |= $label_map{$str};
+                $case_ref->[$i]->{label_str} .= "$str,";
             } elsif ($line =~ /^hcp\s*:\s*(\w[\w\,]+)/) {
                 next if $skip;
                 $case_ref->[$i]->{hcp} = $1;
                 if ($run_case_flag) {
+
                     #To judge whether need to skip the current case
-                    my $valid     = 0;
-                    if (exists ($config{var}{HCP}) && ($case_ref->[$i]->{hcp} =~ /$config{var}{HCP}/i)) {
+                    my $valid = 0;
+                    if (exists($config{var}{HCP}) && ($case_ref->[$i]->{hcp} =~ /$config{var}{HCP}/i)) {
                         $valid = 1;
-                        if(grep (/$case_ref->[$i]->{name}/,@{ $invalidcases{"noruncases"} })){
+                        if (grep (/$case_ref->[$i]->{name}/, @{ $invalidcases{"noruncases"} })) {
                             delete_item_from_array($case_ref->[$i]->{name}, $invalidcases{"noruncases"});
                         }
                     }
                     unless ($valid) {
-                        if(exists($case_name_index_map_bak{$case_ref->[$i]->{name}})){
-                            $$case_name_index_map_ref{$case_ref->[$i]->{name}}=$case_name_index_map_bak{$case_ref->[$i]->{name}};
-                        }else{
-                            delete $$case_name_index_map_ref{$case_ref->[$i]->{name}};
-                            if(! grep (/$case_ref->[$i]->{name}/,@{ $invalidcases{"noruncases"} })){
+                        if (exists($case_name_index_map_bak{ $case_ref->[$i]->{name} })) {
+                            $$case_name_index_map_ref{ $case_ref->[$i]->{name} } = $case_name_index_map_bak{ $case_ref->[$i]->{name} };
+                        } else {
+                            delete $$case_name_index_map_ref{ $case_ref->[$i]->{name} };
+                            if (!grep (/$case_ref->[$i]->{name}/, @{ $invalidcases{"noruncases"} })) {
                                 push @{ $invalidcases{"noruncases"} }, $case_ref->[$i]->{name};
                             }
                         }
                     }
                 }
                 $newcmdstart = 0;
+
+                my $str = "hcp=$case_ref->[$i]->{hcp}";
+                unless (exists $label_map{"$str"}) {
+                    $label_map{"$str"} = $label_value;
+                    $label_value *= 2;
+                }
+                $case_ref->[$i]->{label} |= $label_map{$str};
+                $case_ref->[$i]->{label_str} .= "$str,";
             } elsif ($line =~ /^type\s*:\s*(\w[\w\,-]+)/) {
                 next if $skip;
                 $case_ref->[$i]->{type} = $1;
@@ -1029,6 +1136,18 @@ sub load_case {
                 next if $skip;
                 $case_ref->[$i]->{attribute} = $1;
                 $newcmdstart = 0;
+            } elsif ($line =~ /^label\s*:\s*(.+)/) {
+                next if $skip;
+                my @labels = split(",", $1);
+
+                foreach my $t (@labels) {
+                    unless (exists $label_map{$t}) {
+                        $label_map{$t} = $label_value;
+                        $label_value *= 2;
+                    }
+                    $case_ref->[$i]->{label} |= $label_map{$t};
+                    $case_ref->[$i]->{label_str} .= "$t,";
+                }
             } elsif ($line =~ /^cmd\s*:\s*([\#\/\$\w].+)/) {
                 next if $skip;
                 $newcmdstart = 0;
@@ -1038,7 +1157,7 @@ sub load_case {
                 if ($run_case_flag) {
                     $case_ref->[$i]->{cmd}->[$j][$m] = getvar($1, \%config);
                     if ($case_ref->[$i]->{cmd}->[$j][$m] =~ /miss attribute (.+)/) {
-                        update_miss_attr($case_ref->[$i]->{cmd}->[$j][$m], $case_ref->[$i]->{name}, \@{$invalidcases{"missattr"}});
+                        update_miss_attr($case_ref->[$i]->{cmd}->[$j][$m], $case_ref->[$i]->{name}, \@{ $invalidcases{"missattr"} });
                     }
                 } else {
                     $case_ref->[$i]->{cmd}->[$j][$m] = $1;
@@ -1049,7 +1168,7 @@ sub load_case {
                 if ($run_case_flag) {
                     $case_ref->[$i]->{check}->[$j][$z] = getvar($1, \%config);
                     if ($case_ref->[$i]->{check}->[$j][$z] =~ /miss attribute/) {
-                        update_miss_attr($case_ref->[$i]->{check}->[$j][$z], $case_ref->[$i]->{name}, \@{$invalidcases{"missattr"}});
+                        update_miss_attr($case_ref->[$i]->{check}->[$j][$z], $case_ref->[$i]->{name}, \@{ $invalidcases{"missattr"} });
                     }
                 } else {
                     $case_ref->[$i]->{check}->[$j][$z] = $1;
@@ -1061,7 +1180,7 @@ sub load_case {
                 if ($run_case_flag) {
                     $case_ref->[$i]->{cmdcheck}->[$j][$z] = getvar($1, \%config);
                     if ($case_ref->[$i]->{cmdcheck}->[$j][$z] =~ /miss attribute/) {
-                         update_miss_attr($case_ref->[$i]->{cmdcheck}->[$j][$z],$case_ref->[$i]->{name}, \@{$invalidcases{"missattr"}});
+                        update_miss_attr($case_ref->[$i]->{cmdcheck}->[$j][$z], $case_ref->[$i]->{name}, \@{ $invalidcases{"missattr"} });
                     }
                 } else {
                     $case_ref->[$i]->{cmdcheck}->[$j][$z] = $1;
@@ -1092,7 +1211,8 @@ sub load_case {
 
     if ($run_case_flag) {
         if ($invalidcases{"missattr"}) {
-            log_this($running_log_fd, "Miss attribute:", @{$invalidcases{"missattr"}});
+            log_this($running_log_fd, "Miss attribute:", @{ $invalidcases{"missattr"} });
+
             #$$error_ref = "Miss attribute: " . join(",", @{ $invalidcases{"missattr"} });
             foreach my $line (@{ $invalidcases{"missattr"} }) {
                 my @name = split(" ", $line);
@@ -1103,7 +1223,7 @@ sub load_case {
             $caseerror = 2;
         }
 
-        if ($invalidcases{"noruncases"} && @{$invalidcases{"noruncases"}}) {
+        if ($invalidcases{"noruncases"} && @{ $invalidcases{"noruncases"} }) {
             log_this($running_log_fd, "Unsuitable current environment:", @{ $invalidcases{"noruncases"} });
             push @wrong_cases, @{ $invalidcases{"noruncases"} };
             $caseerror = 2;
@@ -1111,18 +1231,18 @@ sub load_case {
 
         # To filter unexisted cases
         my @unexisted_cases;
-        foreach my $case (@{$cases_to_be_run_ref}){
-            if(!(grep { /^$case$/ } @wrong_cases) && !defined ($$case_name_index_map_ref{$case})){
+        foreach my $case (@{$cases_to_be_run_ref}) {
+            if (!(grep { /^$case$/ } @wrong_cases) && !defined($$case_name_index_map_ref{$case})) {
                 push @unexisted_cases, $case;
             }
         }
-        if(@unexisted_cases){
+        if (@unexisted_cases) {
             log_this($running_log_fd, "Not existed:", @unexisted_cases);
-            push @wrong_cases, @unexisted_cases;                 
+            push @wrong_cases, @unexisted_cases;
             $caseerror = 2;
         }
 
-        if($caseerror) {
+        if ($caseerror) {
             my @new_cases_to_be_run = ();
             foreach my $c (@{$cases_to_be_run_ref}) {
                 if (!(grep { /^$c$/ } @wrong_cases)) {
@@ -1131,10 +1251,10 @@ sub load_case {
             }
             @{$cases_to_be_run_ref} = @new_cases_to_be_run;
         }
-        
-        if (@{$cases_to_be_run_ref}){
+
+        if (@{$cases_to_be_run_ref}) {
             log_this($running_log_fd, "To run:", @{$cases_to_be_run_ref});
-        }else{
+        } else {
             log_this($running_log_fd, "To run:", "There is no valid case to run");
         }
     }
@@ -1234,9 +1354,9 @@ sub run_case {
                 #to run single line command
 
                 log_this($running_log_fd, "RUN:$cmd->[0] [$runstartstr]");
-                $cmd->[0]    = getfunc($cmd->[0]);
-                @output = &runcmd($cmd->[0]);
-                $rc     = $::RUNCMD_RC;
+                $cmd->[0] = getfunc($cmd->[0]);
+                @output   = &runcmd($cmd->[0]);
+                $rc       = $::RUNCMD_RC;
                 push(@caselog, "RUN:$cmd->[0] [$runstartstr]");
             } else {
 
@@ -1333,7 +1453,7 @@ sub run_case {
                 if ($cmdcheck) {
                     &runcmd($cmdcheck);
                     $rc = $::RUNCMD_RC;
-                    if ($rc != 0 ) {
+                    if ($rc != 0) {
                         $failflag = 1;
                         log_this($running_log_fd, "CHECK:output $cmdcheck\t[Failed]");
                         push(@caselog, "CHECK:output $cmdcheck\t[Failed]");
@@ -1439,8 +1559,8 @@ sub setup_env_by_configure_file {
 }
 
 #--------------------------------------------------------
-# Fuction name: detect_current_env 
-# Description: detect some important attribute in current environment, such as os, arch, hcp... 
+# Fuction name: detect_current_env
+# Description: detect some important attribute in current environment, such as os, arch, hcp...
 # Atrributes:
 #          $config_ref (input attribute)
 #            The reference of global hash %config.
@@ -1449,7 +1569,7 @@ sub setup_env_by_configure_file {
 #               The reference of scalar to save the error message generated during running current function
 # Retrun code:  0 Success  1 Failed
 #--------------------------------------------------------
-sub detect_current_env{
+sub detect_current_env {
     my $config_ref = shift;
     my $error_ref  = shift;
 
@@ -1807,36 +1927,37 @@ sub print_table {
 }
 
 sub update_miss_attr {
-    my $org_str = shift;
-    my $case_name = shift;
-    my $miss_attr_arr_ref = shift;  
+    my $org_str           = shift;
+    my $case_name         = shift;
+    my $miss_attr_arr_ref = shift;
 
     my $insert_flag = 0;
-    my $index = 0;
-    foreach my $str (@{$miss_attr_arr_ref}){
-        my @words = split(" ", $str);
+    my $index       = 0;
+    foreach my $str (@{$miss_attr_arr_ref}) {
+        my @words     = split(" ", $str);
         my @org_words = split(" ", $org_str);
-        if($case_name eq "$words[0]"){
-           if(!(grep { /^$org_words[2]$/} @words)){
-               $miss_attr_arr_ref->[$index] .= " $org_words[2]"; 
-           }
-           $insert_flag = 1;
-           last;
+        if ($case_name eq "$words[0]") {
+            if (!(grep { /^$org_words[2]$/ } @words)) {
+                $miss_attr_arr_ref->[$index] .= " $org_words[2]";
+            }
+            $insert_flag = 1;
+            last;
         }
         ++$index;
     }
 
-    unless($insert_flag){
+    unless ($insert_flag) {
         push @{$miss_attr_arr_ref}, "$case_name $org_str";
     }
 }
-sub delete_item_from_array{
-    my $item = shift;
-    my $array_ref = shift; 
-      
-    my @tmp_arr=();
-    foreach (@$array_ref){
-        push @tmp_arr, $_ unless($_ eq $item);
+
+sub delete_item_from_array {
+    my $item      = shift;
+    my $array_ref = shift;
+
+    my @tmp_arr = ();
+    foreach (@$array_ref) {
+        push @tmp_arr, $_ unless ($_ eq $item);
     }
     @$array_ref = @tmp_arr;
 }

--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -53,7 +53,7 @@ my $RUN   = 1;
 
 #----------global logs attributes---------------
 my $running_log_fd     = undef
-  my $running_log_name = undef;
+my $running_log_name   = undef;
 my $failed_log_name      = undef;
 my $performance_log_name = undef;
 
@@ -86,6 +86,8 @@ To list the information about all cases shipped by xcat test package
     $program_name -l {caselist|caseinfo|casenum}
 To list the information about all bunldes shipped by xcat test package
     $program_name -l bundleinfo 
+To list the information about label
+    $program_name -l labelinfo
 To list the information about cases in specific bundles
     $program_name -l {caselist|caseinfo|casenum} -b <bundle_list>
 To list the information about cases related to specific commands
@@ -109,6 +111,10 @@ Options:
     -b : Comma separated list of bundle names to test. If a bundle name is specified without an absolute path, such like /<path/xxx.bundle, or ./xxx.bundle, bundles under $bundledir will be searched by default.
     -r : Back up the original environment settings before running test, and restore them after running test.
     -q : Just record all the output of $program_name into log file under $resultdir, not print to STDOUT. Print to STDOUT by default. 
+    -s : Filter case by label. The acceptable value looks like 'label1+label2-label3\|label4\|label5', 'label1+label2-label3' works as sub expression. 
+         '|' means union filter, it has higher priority, expression1|expression2 means the case either satisfies expression1 or satisfies expression2. 
+         '+' means the case need have specific label. low priority.
+         '-' means the case does not have specific label. low priority. 
 ";
 
 #==============================================================================================
@@ -154,9 +160,6 @@ if ($rst) {
     to_exit(1);
 }
 
-if ($search_expression) {
-    to_exit(0);
-}
 
 #print "----case to be run-----------------\n";
 #print Dumper \@cases_to_be_run;
@@ -198,6 +201,7 @@ if ($list) {
             $rst = load_case(\@cases_to_be_run, \@cases, \%case_name_index_map, \$error, $NORUN);
             if ($rst) {
                 log_this($running_log_fd, "$error");
+                to_exit(1);
             }
             my $casenum = @cases;
             log_this($running_log_fd, "$casenum");
@@ -210,8 +214,56 @@ if ($list) {
             log_this($running_log_fd, "$error");
             to_exit(1);
         }
+    } elsif ($list eq "labelinfo"){
+        $rst = load_case(\@cases_to_be_run, \@cases, \%case_name_index_map, \$error, $NORUN);
+        if ($rst) {
+            log_this($running_log_fd, "$error");
+            to_exit(1);
+        }
+        
+        my %case_label_table;
+        my %label_conut;
+        for(my $i=0; $i <= $#cases; $i++){
+            if(exists $cases[$i]{label_str}){
+                $case_label_table{$cases[$i]{name}} = $cases[$i]{label_str} if(length($cases[$i]{label_str}));
+                my @labels = split(",", $cases[$i]{label_str});
+                foreach my $label (@labels){
+                    if(!exists $label_conut{$label}){
+                        $label_conut{$label}=1;
+                    }else{
+                        $label_conut{$label}+=1;
+                    }
+                }
+            }
+        }  
+
+        #my $exist_label = join(" ", keys(%label_conut));
+        #log_this($running_log_fd, "Existed labels are: $exist_label");
+        log_this($running_log_fd, "-------------------------------");
+        log_this($running_log_fd, "The labels of cases:");
+        log_this($running_log_fd, "-------------------------------");
+        print_table(\%case_label_table);
+        log_this($running_log_fd, "\n-------------------------------");
+        log_this($running_log_fd, "The number of cases of each label:");
+        log_this($running_log_fd, "-------------------------------");
+        print_table(\%label_conut);
+        log_this($running_log_fd, "-------------------------------");
+        my $total_case = @cases;
+        my $case_with_label_num = keys %case_label_table;
+        log_this($running_log_fd, "There are $total_case cases totaly, there are $case_with_label_num cases with label.");
+        
     }
+
     to_exit(0);
+}
+
+
+if ($search_expression) {
+    $rst = filter_case_by_label(\$error);
+    if($rst){
+          log_this($running_log_fd, "$error");
+    }
+    to_exit($rst);
 }
 
 unless (@cases_to_be_run) {
@@ -484,66 +536,6 @@ sub calculate_cases_to_be_run {
             }
             close($fd);
         }
-    } elsif ($search_expression) {
-        my $rst = load_case(\@cases_to_be_run, \@cases, \%case_name_index_map, \$error, $NORUN);
-        if ($rst) {
-            log_this($running_log_fd, "$error");
-            return 1;
-        }
-
-        #        print "-----------------------------------\n";
-        #        print Dumper \@cases;
-        #        print "-----------------------------------\n";
-        #        print Dumper \%label_map;
-        #        print "===>exp = $search_expression\n";
-
-        my @filters = ();
-        my $index   = 0;
-        my @exps    = split('\|', $search_expression);
-        foreach my $e (@exps) {
-            $e =~ s/\+/ /g;
-            $e =~ s/\-/ -/g;
-            my @tags = split(' ', $e);
-            foreach my $t (@tags) {
-                if ($t =~ /^-(.+)/) {
-                    push @{ $filters[$index] }, ($label_map{$1} * -1);
-                } else {
-                    push @{ $filters[$index] }, $label_map{$t};
-                }
-            }
-            $index += 1;
-        }
-
-        #print Dumper \@filters;
-
-        my @targetcases = ();
-        foreach my $case (@cases) {
-            foreach my $f (@filters) {
-                my $hit = 1;
-                foreach my $c (@$f) {
-                    if (($c > 0) and (($case->{label} & $c) == 0)) {
-                        $hit = 0;
-                        last;
-                    } elsif (($c < 0) and (($case->{label} & ($c * -1)) != 0)) {
-                        $hit = 0;
-                        last;
-                    }
-                }
-                push @targetcases, $case->{name} if ($hit and !(grep { /^$case->{name}$/ } @targetcases));
-            }
-        }
-
-        #print Dumper \@targetcases;
-
-        for (my $i = 0 ; $i <= $#label_order ; $i++) {
-            foreach my $l (@{ $label_order[$i] }) {
-                foreach my $c (@targetcases) {
-
-                    #print "$c\t$cases[$case_name_index_map{$c}]->{label_str}\n"  unless(($cases[$case_name_index_map{$c}]->{label} & $label_map{$l}) == 0);
-                    print "$c\n" unless (($cases[ $case_name_index_map{$c} ]->{label} & $label_map{$l}) == 0);
-                }
-            }
-        }
     }
     return 0;
 }
@@ -612,7 +604,7 @@ sub check_option_validity {
         if ($bundlelist || $caselist || $cmdlist) {
             @vaild_list_method = ("caselist", "caseinfo", "casenum");
         } else {
-            @vaild_list_method = ("caselist", "caseinfo", "casenum", "bundleinfo");
+            @vaild_list_method = ("caselist", "caseinfo", "casenum", "bundleinfo", "labelinfo");
         }
         if (!(grep { /^$list$/ } @vaild_list_method)) {
             $$error_ref = "Unsupport list method for option l";
@@ -1960,4 +1952,84 @@ sub delete_item_from_array {
         push @tmp_arr, $_ unless ($_ eq $item);
     }
     @$array_ref = @tmp_arr;
+}
+
+
+sub filter_case_by_label{
+      my $error_ref=shift;
+        my $rst = load_case(\@cases_to_be_run, \@cases, \%case_name_index_map, $error_ref, $NORUN);
+        if ($rst) {
+            log_this($running_log_fd, "$$error_ref");
+            return 1;
+        }
+
+        #        print "-----------------------------------\n";
+        #        print Dumper \@cases;
+        #        print "-----------------------------------\n";
+        #        print Dumper \%label_map;
+        #        print "===>exp = $search_expression\n";
+
+        my @filters = ();
+        my $index   = 0;
+        my @undefined_labels;
+        my @exps    = split('\|', $search_expression);
+        foreach my $e (@exps) {
+            $e =~ s/\+/ /g;
+            $e =~ s/\-/ -/g;
+            my @tags = split(' ', $e);
+            foreach my $t (@tags) {
+                if ($t =~ /^-(.+)/) {
+                    my $tmpt=$1;
+                    unless(grep { /^$tmpt$/ } keys(%label_map)){
+                        push @undefined_labels, $tmpt; 
+                        next;
+                    }
+                    push @{ $filters[$index] }, ($label_map{$tmpt} * -1);
+                } else {
+                    unless(grep { /^$t$/ } keys(%label_map)){
+                        push  @undefined_labels, $t;
+                        next;
+                    }
+                    push @{ $filters[$index] }, $label_map{$t};
+                }
+            }
+            $index += 1;
+        }
+     
+        if(@undefined_labels){
+            $$error_ref = "Label \"".join(",", @undefined_labels)."\" are not exist. Existed labels are: ".join(" ", keys(%label_map));
+            return 1;
+        }
+
+        #print Dumper \@filters;
+
+        my @targetcases = ();
+        foreach my $case (@cases) {
+            foreach my $f (@filters) {
+                my $hit = 1;
+                foreach my $c (@$f) {
+                    if (($c > 0) and (($case->{label} & $c) == 0)) {
+                        $hit = 0;
+                        last;
+                    } elsif (($c < 0) and (($case->{label} & ($c * -1)) != 0)) {
+                        $hit = 0;
+                        last;
+                    }
+                }
+                push @targetcases, $case->{name} if ($hit and !(grep { /^$case->{name}$/ } @targetcases));
+            }
+        }
+
+        #print Dumper \@targetcases;
+
+        for (my $i = 0 ; $i <= $#label_order ; $i++) {
+            foreach my $l (@{ $label_order[$i] }) {
+                foreach my $c (@targetcases) {
+
+                    #print "$c\t$cases[$case_name_index_map{$c}]->{label_str}\n"  unless(($cases[$case_name_index_map{$c}]->{label} & $label_map{$l}) == 0);
+                    print "$c\n" unless (($cases[ $case_name_index_map{$c} ]->{label} & $label_map{$l}) == 0);
+                }
+            }
+        }
+        return 0;
 }

--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -69,7 +69,6 @@ my $quiet             = 0;
 my $search_expression = undef;
 
 my %label_map;
-my $label_value = 1;
 my @label_order = (["xcat_install"],
     ["mn_only"],
     [ "sn_diskful", "sn_diskless" ],
@@ -95,12 +94,19 @@ To list the information about cases related to specific commands
 To list the information about specific cases  
     $program_name -l {caselist|caseinfo|casenum} -t <case_list>
 
+To list cases information that satisfy specific filter expression
+    $program_name -l {caselist|caseinfo|casenum} -s \"filter_expression\"    
+To list information about cases in specific bundles and satisfy specific filter expression at same time
+    $program_name -l {caselist|caseinfo|casenum} -b <bundle_list> -s \"filter_expression\"
+
 To run test cases in specific bundles 
     $program_name [-f {configure_file|configure_file:System}] -b <bundle_list>  [-r] [-q]
 To run specific test cases 
     $program_name [-f {configure_file|configure_file:System}] -t <case_list>  [-r] [-q]
 To run all cases related to specific commands 
     $program_name [-f {configure_file|configure_file:System}] -c <command_list> [-r] [-q]
+To run test cases that satisfy specific filter expression
+    $program_name -s \"filter_expression\"
 
 Options:
     -h : Get $program_name usage information. 
@@ -154,6 +160,12 @@ if ($rst) {
     to_exit(1);
 }
 
+$rst = scan_existed_labels(\%label_map, \$error);
+if($rst) {
+    log_this($running_log_fd, "$error");
+    to_exit(1);
+}
+
 $rst = calculate_cases_to_be_run(\@cases_to_be_run, \$error);
 if ($rst) {
     log_this($running_log_fd, "$error");
@@ -168,7 +180,7 @@ if ($list) {
     if ($list eq "caselist") {
         if (@cases_to_be_run) {
 
-            #list the cases indicated by option -b,-c,-t
+            #list the cases indicated by option -b,-c,-t, -s
             foreach (@cases_to_be_run) {
                 log_this($running_log_fd, "$_");
             }
@@ -255,15 +267,6 @@ if ($list) {
     }
 
     to_exit(0);
-}
-
-
-if ($search_expression) {
-    $rst = filter_case_by_label(\$error);
-    if($rst){
-          log_this($running_log_fd, "$error");
-    }
-    to_exit($rst);
 }
 
 unless (@cases_to_be_run) {
@@ -536,6 +539,25 @@ sub calculate_cases_to_be_run {
             }
             close($fd);
         }
+    }
+
+
+    if($search_expression){
+        my @tmp_cases=();
+        my %tmp_case_name_index_map;
+        my @rest_cases_to_be_run=();
+
+        my $rst = load_case($cases_to_be_run_ref, \@tmp_cases, \%tmp_case_name_index_map, $error_ref, $NORUN);
+        if ($rst) {
+            return 1;
+        }
+     
+        $rst = filter_case_by_label(\@tmp_cases, \%tmp_case_name_index_map, \@rest_cases_to_be_run, $error_ref);
+        if ($rst) {
+            return 1;
+        }
+
+        @$cases_to_be_run_ref=@rest_cases_to_be_run;        
     }
     return 0;
 }
@@ -896,6 +918,8 @@ sub load_case {
     my $case_num           = @{$cases_to_be_run_ref};
     $load_all_case_flag = 1 if ($case_num == 0);
 
+    @$case_ref = ();
+    %$case_name_index_map_ref=();
     my @files = ();
     get_files_recursive("$casedir", \@files);
 
@@ -972,7 +996,7 @@ sub load_case {
                         }
                     }
                 }
-            } elsif ($line =~ /^os\s*:\s*(\w[\w\,]+)/) {
+            } elsif ($line =~ /^os\s*:\s*(\w[\w\, ]+)/) {
                 next if $skip;
                 $case_ref->[$i]->{os} = $1;
 
@@ -1014,15 +1038,14 @@ sub load_case {
                     }
                 }
                 $newcmdstart = 0;
-                $newcmdstart = 0;
-                my $str = "os=$case_ref->[$i]->{os}";
-                unless (exists $label_map{"$str"}) {
-                    $label_map{"$str"} = $label_value;
-                    $label_value *= 2;
+                my @oss = split(",", $case_ref->[$i]->{os});
+                foreach my $os (@oss){ 
+                   $os =~ s/^\s+|\s+$//g;
+                   my $str = "os=$os";
+                   $case_ref->[$i]->{label} |= $label_map{$str};
+                   $case_ref->[$i]->{label_str} .= "$str,";
                 }
-                $case_ref->[$i]->{label} |= $label_map{$str};
-                $case_ref->[$i]->{label_str} .= "$str,";
-            } elsif ($line =~ /^arch\s*:\s*(\w[\w\,]+)/) {
+            } elsif ($line =~ /^arch\s*:\s*(\w[\w\, ]+)/) {
                 next if $skip;
                 $case_ref->[$i]->{arch} = $1;
 
@@ -1072,14 +1095,15 @@ sub load_case {
                     }
                 }
                 $newcmdstart = 0;
-                my $str = "arch=$case_ref->[$i]->{arch}";
-                unless (exists $label_map{"$str"}) {
-                    $label_map{"$str"} = $label_value;
-                    $label_value *= 2;
+
+                my @archs = split(",", $case_ref->[$i]->{arch});
+                foreach my $arch (@archs){
+                   $arch =~ s/^\s+|\s+$//g;
+                   my $str = "arch=$arch";
+                   $case_ref->[$i]->{label} |= $label_map{$str};
+                   $case_ref->[$i]->{label_str} .= "$str,";
                 }
-                $case_ref->[$i]->{label} |= $label_map{$str};
-                $case_ref->[$i]->{label_str} .= "$str,";
-            } elsif ($line =~ /^hcp\s*:\s*(\w[\w\,]+)/) {
+            } elsif ($line =~ /^hcp\s*:\s*(\w[\w\, ]+)/) {
                 next if $skip;
                 $case_ref->[$i]->{hcp} = $1;
                 if ($run_case_flag) {
@@ -1105,13 +1129,13 @@ sub load_case {
                 }
                 $newcmdstart = 0;
 
-                my $str = "hcp=$case_ref->[$i]->{hcp}";
-                unless (exists $label_map{"$str"}) {
-                    $label_map{"$str"} = $label_value;
-                    $label_value *= 2;
+                my @hcps = split(",", $case_ref->[$i]->{hcp});
+                foreach my $hcp (@hcps){
+                   $hcp =~ s/^\s+|\s+$//g;
+                   my $str = "hcp=$hcp";
+                   $case_ref->[$i]->{label} |= $label_map{$str};
+                   $case_ref->[$i]->{label_str} .= "$str,";
                 }
-                $case_ref->[$i]->{label} |= $label_map{$str};
-                $case_ref->[$i]->{label_str} .= "$str,";
             } elsif ($line =~ /^type\s*:\s*(\w[\w\,-]+)/) {
                 next if $skip;
                 $case_ref->[$i]->{type} = $1;
@@ -1131,12 +1155,8 @@ sub load_case {
             } elsif ($line =~ /^label\s*:\s*(.+)/) {
                 next if $skip;
                 my @labels = split(",", $1);
-
                 foreach my $t (@labels) {
-                    unless (exists $label_map{$t}) {
-                        $label_map{$t} = $label_value;
-                        $label_value *= 2;
-                    }
+                    $t=~s/^\s+|\s+$//g;
                     $case_ref->[$i]->{label} |= $label_map{$t};
                     $case_ref->[$i]->{label_str} .= "$t,";
                 }
@@ -1954,82 +1974,139 @@ sub delete_item_from_array {
     @$array_ref = @tmp_arr;
 }
 
+sub filter_case_by_label {
+    my $cases_ref                = shift;
+    my $case_name_index_map_ref  = shift;
+    my $rest_cases_to_be_run_ref = shift;
+    my $error_ref                = shift;
 
-sub filter_case_by_label{
-      my $error_ref=shift;
-        my $rst = load_case(\@cases_to_be_run, \@cases, \%case_name_index_map, $error_ref, $NORUN);
-        if ($rst) {
-            log_this($running_log_fd, "$$error_ref");
+    my @filters = ();
+    my $rst = parse_filters(\@filters, $error_ref);
+    if($rst){
+        return 1;
+    }
+    #print Dumper \@filters;
+
+    my @targetcases = ();
+    foreach my $case (@{$cases_ref}) {
+        foreach my $f (@filters) {
+            my $hit = 1;
+            foreach my $c (@$f) {
+                if (($c > 0) and (($case->{label} & $c) == 0)) {
+                    $hit = 0;
+                    last;
+                } elsif (($c < 0) and (($case->{label} & ($c * -1)) != 0)) {
+                    $hit = 0;
+                    last;
+                }
+            }
+            push @targetcases, $case->{name} if ($hit and !(grep { /^$case->{name}$/ } @targetcases));
+        }
+    }
+
+    #print Dumper \@targetcases;
+
+    for (my $i = 0 ; $i <= $#label_order ; $i++) {
+        foreach my $l (@{ $label_order[$i] }) {
+            foreach my $c (@targetcases) {
+                push @{$rest_cases_to_be_run_ref}, $c unless (($cases_ref->[ $case_name_index_map_ref->{$c} ]->{label} & $label_map{$l}) == 0);
+            }
+        }
+    }
+    return 0;
+}
+
+sub parse_filters{
+    my $filters_ref=shift;
+    my $error_ref=shift;
+
+    my $index   = 0;
+    my @undefined_labels;
+    my @exps = split('\|', $search_expression);
+    foreach my $e (@exps) {
+        $e =~ s/\+/ /g;
+        $e =~ s/\-/ -/g;
+        my @tags = split(' ', $e);
+        foreach my $t (@tags) {
+            if ($t =~ /^-(.+)/) {
+                my $tmpt = $1;
+                unless (grep { /^$tmpt$/ } keys(%label_map)) {
+                    push @undefined_labels, $tmpt;
+                    next;
+                }
+                push @{ $filters_ref->[$index] }, ($label_map{$tmpt} * -1);
+            } else {
+                unless (grep { /^$t$/ } keys(%label_map)) {
+                    push @undefined_labels, $t;
+                    next;
+                }
+                push @{ $filters_ref->[$index] }, $label_map{$t};
+            }
+        }
+        $index += 1;
+    }
+
+    if (@undefined_labels) {
+        $$error_ref = "Label \"" . join(",", @undefined_labels) . "\" are not exist. Existed labels are: " . join(" ", keys(%label_map));
+        return 1;
+    }
+    return 0;
+}
+
+sub scan_existed_labels {
+    my $label_map_ref = shift;
+    my $error_ref     = shift;
+
+    my $label_value = 1;
+    my @files       = ();
+    my @cmdfiles    = ();
+    get_files_recursive("$casedir", \@files);
+
+    my $fd = undef;
+    foreach my $file (@files) {
+        if (!open($fd, "<$file")) {
+            $$error_ref = "can't open $file:$!";
             return 1;
         }
+        while (my $line = <$fd>) {
+            $line =~ s/^\s+|#[^!].+|\s+$//g;
 
-        #        print "-----------------------------------\n";
-        #        print Dumper \@cases;
-        #        print "-----------------------------------\n";
-        #        print Dumper \%label_map;
-        #        print "===>exp = $search_expression\n";
+            #skip blank and comment lines
+            next if (length($line) == 0 || ($line =~ /^\s*#/));
 
-        my @filters = ();
-        my $index   = 0;
-        my @undefined_labels;
-        my @exps    = split('\|', $search_expression);
-        foreach my $e (@exps) {
-            $e =~ s/\+/ /g;
-            $e =~ s/\-/ -/g;
-            my @tags = split(' ', $e);
-            foreach my $t (@tags) {
-                if ($t =~ /^-(.+)/) {
-                    my $tmpt=$1;
-                    unless(grep { /^$tmpt$/ } keys(%label_map)){
-                        push @undefined_labels, $tmpt; 
-                        next;
-                    }
-                    push @{ $filters[$index] }, ($label_map{$tmpt} * -1);
-                } else {
-                    unless(grep { /^$t$/ } keys(%label_map)){
-                        push  @undefined_labels, $t;
-                        next;
-                    }
-                    push @{ $filters[$index] }, $label_map{$t};
+            my @labels = ();
+            if ($line =~ /^os\s*:\s*(\w[\w\, ]+)/) {
+                my @oss = split(",", $1);
+                foreach my $os (@oss){
+                    $os =~ s/^\s+|\s+$//g;
+                      push @labels, "os=$os";
+                  }
+            } elsif ($line =~ /^arch\s*:\s*(\w[\w\, ]+)/) {
+                my @archs = split(",", $1);
+                foreach my $arch (@archs) {
+                    $arch =~ s/^\s+|\s+$//g;
+                    push @labels, "arch=$arch";
+                }
+            } elsif ($line =~ /^hcp\s*:\s*(\w[\w\, ]+)/) {
+                my @hcps = split(",", $1);
+                foreach my $hcp (@hcps) {
+                    $hcp =~ s/^\s+|\s+$//g;
+                    push @labels, "hcp=$hcp";
+                }
+            } elsif ($line =~ /^label\s*:\s*(.+)/) {
+                push @labels, split(",", $1);
+            }
+
+            foreach my $t (@labels) {
+                unless (exists $label_map_ref->{$t}) {
+                    $label_map_ref->{$t} = $label_value;
+                    $label_value *= 2;
                 }
             }
-            $index += 1;
-        }
-     
-        if(@undefined_labels){
-            $$error_ref = "Label \"".join(",", @undefined_labels)."\" are not exist. Existed labels are: ".join(" ", keys(%label_map));
-            return 1;
+
         }
 
-        #print Dumper \@filters;
-
-        my @targetcases = ();
-        foreach my $case (@cases) {
-            foreach my $f (@filters) {
-                my $hit = 1;
-                foreach my $c (@$f) {
-                    if (($c > 0) and (($case->{label} & $c) == 0)) {
-                        $hit = 0;
-                        last;
-                    } elsif (($c < 0) and (($case->{label} & ($c * -1)) != 0)) {
-                        $hit = 0;
-                        last;
-                    }
-                }
-                push @targetcases, $case->{name} if ($hit and !(grep { /^$case->{name}$/ } @targetcases));
-            }
-        }
-
-        #print Dumper \@targetcases;
-
-        for (my $i = 0 ; $i <= $#label_order ; $i++) {
-            foreach my $l (@{ $label_order[$i] }) {
-                foreach my $c (@targetcases) {
-
-                    #print "$c\t$cases[$case_name_index_map{$c}]->{label_str}\n"  unless(($cases[$case_name_index_map{$c}]->{label} & $label_map{$l}) == 0);
-                    print "$c\n" unless (($cases[ $case_name_index_map{$c} ]->{label} & $label_map{$l}) == 0);
-                }
-            }
-        }
-        return 0;
+        close($fd);
+    }
+    return 0;
 }

--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -69,6 +69,7 @@ my $quiet             = 0;
 my $search_expression = undef;
 
 my %label_map;
+my %case_label_map;
 my @label_order = (["xcat_install"],
     ["mn_only"],
     [ "sn_diskful", "sn_diskless" ],
@@ -110,7 +111,7 @@ To run test cases that satisfy specific filter expression
 
 Options:
     -h : Get $program_name usage information. 
-    -l : list specific information. The valid options are caselist,caseinfo,casenum,bundleinfo
+    -l : list specific information. The valid options are caselist,caseinfo,casenum,bundleinfo.
     -f : specify the configuration file. If 'System' tag is used, only [System] section in the configuration file will be used. If 'System' is not used all other sections of the configuration file will be used, like [Table], [Object], etc.
     -c : Comma separated list of command names to test. 
     -t : Comma separated list of test case names to test.
@@ -148,6 +149,8 @@ if (
     to_exit(1);
 }
 
+#$list="caselist" unless($list);
+
 if ($needhelp) {
     log_this($running_log_fd, "$::USAGE");
     to_exit(0);
@@ -160,10 +163,12 @@ if ($rst) {
     to_exit(1);
 }
 
-$rst = scan_existed_labels(\%label_map, \$error);
-if($rst) {
-    log_this($running_log_fd, "$error");
-    to_exit(1);
+if($search_expression){
+    $rst = scan_existed_labels(\%case_label_map, \%label_map, \$error);
+    if($rst) {
+        log_this($running_log_fd, "$error");
+        to_exit(1);
+    }
 }
 
 $rst = calculate_cases_to_be_run(\@cases_to_be_run, \$error);
@@ -171,7 +176,6 @@ if ($rst) {
     log_this($running_log_fd, "$error");
     to_exit(1);
 }
-
 
 #print "----case to be run-----------------\n";
 #print Dumper \@cases_to_be_run;
@@ -227,18 +231,13 @@ if ($list) {
             to_exit(1);
         }
     } elsif ($list eq "labelinfo"){
-        $rst = load_case(\@cases_to_be_run, \@cases, \%case_name_index_map, \$error, $NORUN);
-        if ($rst) {
-            log_this($running_log_fd, "$error");
-            to_exit(1);
-        }
-        
-        my %case_label_table;
+        $rst = scan_existed_labels(\%case_label_map, \%label_map, \$error);
         my %label_conut;
-        for(my $i=0; $i <= $#cases; $i++){
-            if(exists $cases[$i]{label_str}){
-                $case_label_table{$cases[$i]{name}} = $cases[$i]{label_str} if(length($cases[$i]{label_str}));
-                my @labels = split(",", $cases[$i]{label_str});
+        my %case_label_str_map;
+        foreach my $case (keys %case_label_map){
+            if($case_label_map{$case}{label_str}){ 
+                $case_label_str_map{$case} = $case_label_map{$case}{label_str};
+                my @labels = split(",", $case_label_map{$case}{label_str});
                 foreach my $label (@labels){
                     if(!exists $label_conut{$label}){
                         $label_conut{$label}=1;
@@ -249,19 +248,19 @@ if ($list) {
             }
         }  
 
-        #my $exist_label = join(" ", keys(%label_conut));
-        #log_this($running_log_fd, "Existed labels are: $exist_label");
         log_this($running_log_fd, "-------------------------------");
         log_this($running_log_fd, "The labels of cases:");
         log_this($running_log_fd, "-------------------------------");
-        print_table(\%case_label_table);
+        print_table(\%case_label_str_map);
+        my $label_total_num=keys %label_conut;
         log_this($running_log_fd, "\n-------------------------------");
+        log_this($running_log_fd, "There are $label_total_num different labels"); 
         log_this($running_log_fd, "The number of cases of each label:");
         log_this($running_log_fd, "-------------------------------");
         print_table(\%label_conut);
         log_this($running_log_fd, "-------------------------------");
-        my $total_case = @cases;
-        my $case_with_label_num = keys %case_label_table;
+        my $total_case = keys %case_label_map;
+        my $case_with_label_num = keys %case_label_str_map;
         log_this($running_log_fd, "There are $total_case cases totaly, there are $case_with_label_num cases with label.");
         
     }
@@ -270,7 +269,7 @@ if ($list) {
 }
 
 unless (@cases_to_be_run) {
-    log_this($running_log_fd, "Please indicate the cases to run by option -b,-c,-t");
+    log_this($running_log_fd, "There is no case to run, Please indicate case by option -b,-c,-t,-s");
     to_exit(1);
 }
 
@@ -543,16 +542,8 @@ sub calculate_cases_to_be_run {
 
 
     if($search_expression){
-        my @tmp_cases=();
-        my %tmp_case_name_index_map;
         my @rest_cases_to_be_run=();
-
-        my $rst = load_case($cases_to_be_run_ref, \@tmp_cases, \%tmp_case_name_index_map, $error_ref, $NORUN);
-        if ($rst) {
-            return 1;
-        }
-     
-        $rst = filter_case_by_label(\@tmp_cases, \%tmp_case_name_index_map, \@rest_cases_to_be_run, $error_ref);
+        $rst = filter_case_by_label($cases_to_be_run_ref,\%case_label_map,\@rest_cases_to_be_run, $error_ref);
         if ($rst) {
             return 1;
         }
@@ -1975,8 +1966,8 @@ sub delete_item_from_array {
 }
 
 sub filter_case_by_label {
-    my $cases_ref                = shift;
-    my $case_name_index_map_ref  = shift;
+    my $cases_to_be_run_ref      = shift;
+    my $case_label_map_ref       = shift;
     my $rest_cases_to_be_run_ref = shift;
     my $error_ref                = shift;
 
@@ -1988,19 +1979,22 @@ sub filter_case_by_label {
     #print Dumper \@filters;
 
     my @targetcases = ();
-    foreach my $case (@{$cases_ref}) {
+    foreach my $case (keys %{$case_label_map_ref}) {
+        if(@$cases_to_be_run_ref){
+            next unless(grep { /^$case$/ } @$cases_to_be_run_ref);
+        }
         foreach my $f (@filters) {
             my $hit = 1;
             foreach my $c (@$f) {
-                if (($c > 0) and (($case->{label} & $c) == 0)) {
+                if (($c > 0) and (($case_label_map_ref->{$case}->{label} & $c) == 0)) {
                     $hit = 0;
                     last;
-                } elsif (($c < 0) and (($case->{label} & ($c * -1)) != 0)) {
+                } elsif (($c < 0) and (($case_label_map_ref->{$case}->{label} & ($c * -1)) != 0)) {
                     $hit = 0;
                     last;
                 }
             }
-            push @targetcases, $case->{name} if ($hit and !(grep { /^$case->{name}$/ } @targetcases));
+            push @targetcases, $case if ($hit and !(grep { /^$case$/ } @targetcases));
         }
     }
 
@@ -2009,7 +2003,7 @@ sub filter_case_by_label {
     for (my $i = 0 ; $i <= $#label_order ; $i++) {
         foreach my $l (@{ $label_order[$i] }) {
             foreach my $c (@targetcases) {
-                push @{$rest_cases_to_be_run_ref}, $c unless (($cases_ref->[ $case_name_index_map_ref->{$c} ]->{label} & $label_map{$l}) == 0);
+                push @{$rest_cases_to_be_run_ref}, $c unless (($case_label_map_ref->{$c}->{label} & $label_map{$l}) == 0);
             }
         }
     }
@@ -2046,41 +2040,43 @@ sub parse_filters{
         $index += 1;
     }
 
-    if (@undefined_labels) {
-        $$error_ref = "Label \"" . join(",", @undefined_labels) . "\" are not exist. Existed labels are: " . join(" ", keys(%label_map));
-        return 1;
-    }
+#    if (@undefined_labels) {
+#        $$error_ref = "Label \"" . join(",", @undefined_labels) . "\" are not exist. Existed labels are: " . join(" ", keys(%label_map));
+#        return 1;
+#    }
     return 0;
 }
 
 sub scan_existed_labels {
-    my $label_map_ref = shift;
-    my $error_ref     = shift;
+    my $case_label_map_ref = shift;
+    my $label_map_ref      = shift;
+    my $error_ref          = shift;
 
     my $label_value = 1;
     my @files       = ();
     my @cmdfiles    = ();
     get_files_recursive("$casedir", \@files);
 
-    my $fd = undef;
     foreach my $file (@files) {
-        if (!open($fd, "<$file")) {
-            $$error_ref = "can't open $file:$!";
-            return 1;
-        }
-        while (my $line = <$fd>) {
+        my @output = runcmd("grep -E \"start:|hcp:|os:|arch:|label:\" $file");
+        my $current_case_name = "";
+        foreach my $line (@output) {
             $line =~ s/^\s+|#[^!].+|\s+$//g;
 
             #skip blank and comment lines
             next if (length($line) == 0 || ($line =~ /^\s*#/));
 
             my @labels = ();
-            if ($line =~ /^os\s*:\s*(\w[\w\, ]+)/) {
+            if ($line =~ /^start\s*:\s*(.*)/) {
+                $current_case_name                                     = $1;
+                $case_label_map_ref->{$current_case_name}->{label}     = 0;
+                $case_label_map_ref->{$current_case_name}->{label_str} = "";
+            } elsif ($line =~ /^os\s*:\s*(\w[\w\, ]+)/) {
                 my @oss = split(",", $1);
-                foreach my $os (@oss){
+                foreach my $os (@oss) {
                     $os =~ s/^\s+|\s+$//g;
-                      push @labels, "os=$os";
-                  }
+                    push @labels, "os=$os";
+                }
             } elsif ($line =~ /^arch\s*:\s*(\w[\w\, ]+)/) {
                 my @archs = split(",", $1);
                 foreach my $arch (@archs) {
@@ -2094,19 +2090,24 @@ sub scan_existed_labels {
                     push @labels, "hcp=$hcp";
                 }
             } elsif ($line =~ /^label\s*:\s*(.+)/) {
-                push @labels, split(",", $1);
-            }
-
-            foreach my $t (@labels) {
-                unless (exists $label_map_ref->{$t}) {
-                    $label_map_ref->{$t} = $label_value;
-                    $label_value *= 2;
+                my @tmp = split(",", $1);
+                foreach my $l (@tmp){
+                   $l =~ s/^\s+|\s+$//g;
+                   push @labels, $l;
                 }
             }
 
+            if($current_case_name){
+                foreach my $t (@labels) {
+                    unless (exists $label_map_ref->{$t}) {
+                        $label_map_ref->{$t} = $label_value;
+                        $label_value *= 2;
+                    }
+                    $case_label_map_ref->{$current_case_name}->{label} |= $label_map_ref->{$t};
+                    $case_label_map_ref->{$current_case_name}->{label_str} .= "$t,";
+                }
+            }
         }
-
-        close($fd);
     }
     return 0;
 }

--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -2027,7 +2027,7 @@ sub scan_existed_labels {
     get_files_recursive("$casedir", \@files);
 
     foreach my $file (@files) {
-        my @output = runcmd("grep -E \"start:|hcp:|os:|arch:|label:\" $file");
+        my @output = runcmd("grep -E \"^start:|^hcp:|^os:|^arch:|^label:\" $file");
         my $current_case_name = "";
         foreach my $line (@output) {
             $line =~ s/^\s+|#[^!].+|\s+$//g;

--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -1029,13 +1029,6 @@ sub load_case {
                     }
                 }
                 $newcmdstart = 0;
-                my @oss = split(",", $case_ref->[$i]->{os});
-                foreach my $os (@oss){ 
-                   $os =~ s/^\s+|\s+$//g;
-                   my $str = "os=$os";
-                   $case_ref->[$i]->{label} |= $label_map{$str};
-                   $case_ref->[$i]->{label_str} .= "$str,";
-                }
             } elsif ($line =~ /^arch\s*:\s*(\w[\w\, ]+)/) {
                 next if $skip;
                 $case_ref->[$i]->{arch} = $1;
@@ -1086,14 +1079,6 @@ sub load_case {
                     }
                 }
                 $newcmdstart = 0;
-
-                my @archs = split(",", $case_ref->[$i]->{arch});
-                foreach my $arch (@archs){
-                   $arch =~ s/^\s+|\s+$//g;
-                   my $str = "arch=$arch";
-                   $case_ref->[$i]->{label} |= $label_map{$str};
-                   $case_ref->[$i]->{label_str} .= "$str,";
-                }
             } elsif ($line =~ /^hcp\s*:\s*(\w[\w\, ]+)/) {
                 next if $skip;
                 $case_ref->[$i]->{hcp} = $1;
@@ -1119,14 +1104,6 @@ sub load_case {
                     }
                 }
                 $newcmdstart = 0;
-
-                my @hcps = split(",", $case_ref->[$i]->{hcp});
-                foreach my $hcp (@hcps){
-                   $hcp =~ s/^\s+|\s+$//g;
-                   my $str = "hcp=$hcp";
-                   $case_ref->[$i]->{label} |= $label_map{$str};
-                   $case_ref->[$i]->{label_str} .= "$str,";
-                }
             } elsif ($line =~ /^type\s*:\s*(\w[\w\,-]+)/) {
                 next if $skip;
                 $case_ref->[$i]->{type} = $1;
@@ -1143,14 +1120,6 @@ sub load_case {
                 next if $skip;
                 $case_ref->[$i]->{attribute} = $1;
                 $newcmdstart = 0;
-            } elsif ($line =~ /^label\s*:\s*(.+)/) {
-                next if $skip;
-                my @labels = split(",", $1);
-                foreach my $t (@labels) {
-                    $t=~s/^\s+|\s+$//g;
-                    $case_ref->[$i]->{label} |= $label_map{$t};
-                    $case_ref->[$i]->{label_str} .= "$t,";
-                }
             } elsif ($line =~ /^cmd\s*:\s*([\#\/\$\w].+)/) {
                 next if $skip;
                 $newcmdstart = 0;


### PR DESCRIPTION
Enhance ``xcattest`` to support label search.

The design document is https://github.com/xcat2/xcat-core/wiki/Test-Design-of-TestCase-Label

**Note**, Due to use ``perltidy`` to reformat script, so some code change just are about the format change, please ignore. 

UT:

```
[root@c910f03c17k25 xcattest_investigation]# ./xcattest -h
Usage:
......
To list the information about label
    xcattest -l labelinfo
......
To list cases information that satisfy specific filter expression
    xcattest -l {caselist|caseinfo|casenum} -s "filter_expression"
To list information about cases in specific bundles and satisfy specific filter expression at same time
    xcattest -l {caselist|caseinfo|casenum} -b <bundle_list> -s "filter_expression"
......
To run test cases that satisfy specific filter expression
    xcattest -s "filter_expression"
....
Options:
....
    -s : Filter case by label. The acceptable value looks like 'label1+label2-label3|label4|label5', 'label1+label2-label3' works as sub expression.
         '|' means union filter, it has higher priority, expression1|expression2 means the case either satisfies expression1 or satisfies expression2.
         '+' means the case need have specific label. low priority.
         '-' means the case does not have specific label. low priority.
```

**Note**, if a case has had key word ``hcp``,``os``,``arch`` already, the label system will switch them to a label automatically.  Take below case for example:
```
start:install_xCAT_on_rhels_sles
os:redhat,  sles
label:xcat_install
cmd:date
end
```
Even without key word ``label``, this case will have label ``os=redhat``and  ``os=sles`` automatically. This design is for compatible with existed cases. 

Below bogus cases are used to test new ``xcattest``, if need to verify new code in your own environment, rename ``/opt/xcat/share/xcat/tools/autotest/testcase`` directory and copy below bogus cases to ``/opt/xcat/share/xcat/tools/autotest/testcase/boguscase``.
```
start:install_xCAT_on_rhels_sles
os:redhat, sles
label:xcat_install
cmd:date
end

start:install_xCAT_on_ubuntu
os:ubuntu
label:xcat_install
cmd:date
end

start:SN_setup_case
label:sn_diskful,provision
cmd:date
end

start:SN_diskless_setup_case
label: sn_diskless,provision
cmd:date
end

start:xcatd_start
label:mn_only, xcatd
cmd:date
end

start:xcatd_stop
label:mn_only,xcatd
cmd:date
end

start:lsdef_n
label:mn_only,db
cmd:date
end

start:mkdef_n
label:mn_only,db
cmd:date
end

start:reg_linux_diskfull_installation_flat
label:flat_cn_diskful,provision
os:linux
cmd:date
end

start:reg_linux_diskless_installation_flat
label:flat_cn_diskless,provision
os:linux
cmd:date
end

start:reg_linux_diskfull_installation_hierarchy
label:hierarchy_cn_diskful,provision
cmd:date
end

start:reg_linux_diskless_installation_hierarchy
label:hierarchy_cn_diskless, provision
cmd:date
end


start:xdcp_src_dst
label:cn_os_ready,dhcp
cmd:date
end

start:makedns_environment_check_forworder_mode
label:cn_os_ready,dns
cmd:date
end

start:rpower_status
hcp:openbmc, impi
label:cn_bmc_ready,hctrl_gen
cmd:date
end

start:rpower_suspend_OpenpowerBmc
hcp:openbmc
label:cn_bmc_ready,hctrl_openbmc
cmd:date
end

start:rpower_onstandby
arch:ppc64
label:cn_bmc_ready,hctrl_fsp
cmd:date
end

start:ib_invoke_provison
label:others,ib,invoke_provison
cmd:date
end

start:ib
label:others,ib
cmd:date
end

start:case_without_label
cmd:date
end
```

The test results are:
```
#For list all label information
[root@c910f03c17k25 xcattest_investigation]# ./xcattest -l labelinfo
-------------------------------
The labels of cases:
-------------------------------
SN_diskless_setup_case                       sn_diskless,provision,
SN_setup_case                                sn_diskful,provision,
ib                                           others,ib,
ib_invoke_provison                           others,ib,invoke_provison,
install_xCAT_on_rhels_sles                   os=redhat,os=sles,xcat_install,
install_xCAT_on_ubuntu                       os=ubuntu,xcat_install,
lsdef_n                                      mn_only,db,
makedns_environment_check_forworder_mode     cn_os_ready,dns,
mkdef_n                                      mn_only,db,
reg_linux_diskfull_installation_flat         flat_cn_diskful,provision,os=linux,
reg_linux_diskfull_installation_hierarchy    hierarchy_cn_diskful,provision,
reg_linux_diskless_installation_flat         flat_cn_diskless,provision,os=linux,
reg_linux_diskless_installation_hierarchy    hierarchy_cn_diskless,provision,
rpower_onstandby                             arch=ppc64,cn_bmc_ready,hctrl_fsp,
rpower_status                                hcp=openbmc,hcp=impi,cn_bmc_ready,hctrl_gen,
rpower_suspend_OpenpowerBmc                  hcp=openbmc,cn_bmc_ready,hctrl_openbmc,
xcatd_start                                  mn_only,xcatd,
xcatd_stop                                   mn_only,xcatd,
xdcp_src_dst                                 cn_os_ready,dhcp,

-------------------------------
There are 28 different labels
The number of cases of each label:
-------------------------------
arch=ppc64               1
cn_bmc_ready             3
cn_os_ready              2
db                       2
dhcp                     1
dns                      1
flat_cn_diskful          1
flat_cn_diskless         1
hcp=impi                 1
hcp=openbmc              2
hctrl_fsp                1
hctrl_gen                1
hctrl_openbmc            1
hierarchy_cn_diskful     1
hierarchy_cn_diskless    1
ib                       2
invoke_provison          1
mn_only                  4
os=linux                 2
os=redhat                1
os=sles                  1
os=ubuntu                1
others                   2
provision                6
sn_diskful               1
sn_diskless              1
xcat_install             2
xcatd                    2
-------------------------------
There are 20 cases totaly, there are 19 cases with label.

#For generating a daily regression bundle
[root@c910f03c17k25 xcattest_investigation]# ./xcattest -s "xcat_install+os=ubuntu|xcatd|flat_cn_diskful|cn_os_ready|ib-invoke_provison" -l caselist
install_xCAT_on_ubuntu
xcatd_start
xcatd_stop
reg_linux_diskfull_installation_flat
xdcp_src_dst
makedns_environment_check_forworder_mode
ib

#For generating a smoking test bundle
[root@c910f03c17k25 xcattest_investigation]# ./xcattest -s "mn_only" -l caselist
xcatd_start
lsdef_n
xcatd_stop
mkdef_n

#Filter out all provision test cases 
[root@c910f03c17k25 xcattest_investigation]# ./xcattest -s "provision" -l caselist
SN_setup_case
SN_diskless_setup_case
reg_linux_diskfull_installation_flat
reg_linux_diskless_installation_flat
reg_linux_diskfull_installation_hierarchy
reg_linux_diskless_installation_hierarchy

#Filter out all  test cases need to install CN/SN
[root@c910f03c17k25 xcattest_investigation]# ./xcattest -s "provision|invoke_provison" -l caselist
SN_setup_case
SN_diskless_setup_case
reg_linux_diskfull_installation_flat
reg_linux_diskless_installation_flat
reg_linux_diskfull_installation_hierarchy
reg_linux_diskless_installation_hierarchy
ib_invoke_provison

#Filter out all cases against one component, take bogus IB for example
[root@c910f03c17k25 xcattest_investigation]# ./xcattest -s "ib" -l caselist
ib
ib_invoke_provison

#Filter out all cases against one component but without provision CN
[root@c910f03c17k25 xcattest_investigation]# ./xcattest -s "ib-invoke_provison" -l caselist
ib
```
All the test case filtered out are ordered by prerequisite order if they do not belong to the same level.

To run cases that satisfy specific filter expression
```
[root@c910f03c17k25 xcattest_investigation]# ./xcattest -s "mn_only"
xCAT automated test started at Wed Jun 13 03:51:37 2018
******************************
To detect current test environment
******************************
Detecting: OS = linux
Warning: No compute node defined, can't get ARCH of compute node
Warning: No compute node defined, can't get HCP TYPE of compute node
******************************
loading test cases
******************************
To run:
xcatd_start
lsdef_n
xcatd_stop
mkdef_n
******************************
Start to run test cases
******************************
------START::xcatd_start::Time:Wed Jun 13 03:51:37 2018------

RUN:date [Wed Jun 13 03:51:37 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Wed Jun 13 03:51:37 EDT 2018

------END::xcatd_start::Passed::Time:Wed Jun 13 03:51:37 2018 ::Duration::0 sec------
------START::lsdef_n::Time:Wed Jun 13 03:51:37 2018------

RUN:date [Wed Jun 13 03:51:37 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Wed Jun 13 03:51:37 EDT 2018

------END::lsdef_n::Passed::Time:Wed Jun 13 03:51:37 2018 ::Duration::0 sec------
------START::xcatd_stop::Time:Wed Jun 13 03:51:37 2018------

RUN:date [Wed Jun 13 03:51:37 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Wed Jun 13 03:51:37 EDT 2018

------END::xcatd_stop::Passed::Time:Wed Jun 13 03:51:37 2018 ::Duration::0 sec------
------START::mkdef_n::Time:Wed Jun 13 03:51:37 2018------

RUN:date [Wed Jun 13 03:51:37 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Wed Jun 13 03:51:37 EDT 2018

------END::mkdef_n::Passed::Time:Wed Jun 13 03:51:37 2018 ::Duration::0 sec------
------Total: 4 , Failed: 0------

xCAT automated test finished at Wed Jun 13 03:51:37 2018
Please check results in the /home/xcattest_investigation//result/,
and see /home/xcattest_investigation//result//failedcases.20180613035137 file for failed cases.
see /home/xcattest_investigation//result//performance.report.20180613035137 file for time consumption
```

For error handling:
```
[root@c910f03c17k25 xcattest_investigation]# ./xcattest -s errorlabel
There is no case to run, Please indicate case by option -b,-c,-t,-s
```

Complex filter
```
[root@c910f03c17k25 xcattest_investigation]# ./xcattest -s "mn_only"  -t mkdef_n,lsdef_n,ib  -l caselist
lsdef_n
mkdef_n
```



