### PR TITLE
add case for task 164,exporting the files referred in #INCLUDE:# in pkglist, otherpkglist, etc.. for xcat-inventory

### DIFF
--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.include
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.include
@@ -10,16 +10,17 @@ cmd:lsdef -t osimage -o test_osimage >/dev/null 2>&1;if [[ $? -eq 0 ]]; then lsd
 check:rc==0
 cmd:cat /tmp/imagedata/test_osimage/test_osimage.stanza |mkdef -z
 check:rc==0
+cmd:rm -rf /tmp/imagedata/test_osimage/test_osimage.stanza
 cmd:lsdef -t osimage -o test_osimage
 check:rc==0
 cmd:xcat-inventory export -t osimage -o test_osimage -d /tmp/imagedata/export 
 check:output=~The osimage objects has been exported to directory /tmp/imagedata/export 
 cmd:ls -lFR /tmp/imagedata/export
-cmd:diff -r /tmp/imagedata/test_osimage /tmp/imagedata/export/osimage/tmp/imagedata/test_osimage/
+cmd:diff -r /tmp/imagedata/test_osimage /tmp/imagedata/export/test_osimage/tmp/imagedata/test_osimage/
+check:output=~Only in /tmp/imagedata/test_osimage: file7
+cmd:diff -y /etc/hosts /tmp/imagedata/export/test_osimage/etc/hosts 
 check:rc==0
-cmd:diff -y /etc/hosts /tmp/imagedata/export/osimage/tmp/imagedata/test_osimage/etc/hosts
-check:rc==0
-cmd:ls -l /tmp/imagedata/export/osimage/tmp/imagedata/test_osimage/file7
+cmd:ls -l /tmp/imagedata/export/test_osimage/tmp/imagedata/test_osimage/file7
 check:rc!=0 
 cmd: rmdef -t osimage -o  test_osimage
 check:rc==0
@@ -31,7 +32,7 @@ check:output=~Inventory import successfully!
 check:output=~The object test_osimage has been imported
 cmd:lsdef -t osimage -o test_osimage
 check:rc==0
-cmd:diff -r /tmp/imagedata/export /tmp/imagedata/test_osimage 
+cmd:diff -r /tmp/imagedata/export/test_osimage/tmp/imagedata/test_osimage/ /tmp/imagedata/test_osimage 
 check:rc==0
 cmd: rmdef -t osimage -o  test_osimage
 check:rc==0

--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.include
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.include
@@ -1,5 +1,6 @@
 start:export_import_osimage_with_INCLUDE_in_file
 description:This case is used to test xcat-inventory export and import one linux osimage definition which has INCLUDE in the attribute's specified files. The attributes are pkglist, otherpkglist,exlist,synclists,template,postinstall and partitionfile.
+label:xcat-inventory
 cmd:dir="/tmp/imagedata/";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi; mkdir -p $dir
 check:rc==0
 cmd:dir="/tmp/imagedata/export";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi; mkdir -p $dir

--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.include
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.include
@@ -2,60 +2,39 @@ start:export_import_osimage_with_INCLUDE_in_file
 description:This case is used to test xcat-inventory export and import one linux osimage definition which has INCLUDE in the attribute's specified files. The attributes are pkglist, otherpkglist,exlist,synclists,template,postinstall and partitionfile.
 cmd:dir="/tmp/imagedata/";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi; mkdir -p $dir
 check:rc==0
-cmd:dir="/opt/inventory/site";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi; mkdir -p $dir
+cmd:dir="/tmp/imagedata/export";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi; mkdir -p $dir
 check:rc==0
 cmd:cp -rf /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage /tmp/imagedata
 check:rc==0
-cmd:lsdef -t osimage -o test_osimage >/dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t osimage -o test_osimage -z >/tmp/test_osimage.stanza ;rmdef -t osimage -o test_osimage;fi
+cmd:lsdef -t osimage -o test_osimage >/dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t osimage -o test_osimage -z >/tmp/imagedata/test_osimage.org.stanza ;rmdef -t osimage -o test_osimage;fi
 check:rc==0
 cmd:cat /tmp/imagedata/test_osimage/test_osimage.stanza |mkdef -z
 check:rc==0
 cmd:lsdef -t osimage -o test_osimage
 check:rc==0
-cmd:xcat-inventory export -t osimage -o test_osimage -d /opt/inventory/site/ 
-check:output=~The osimage objects has been exported to directory /opt/inventory/site/
-cmd:ls -lFR /opt/inventory/site/
-cmd:diff -y /tmp/imagedata/test_osimage/file1.1 /opt/inventory/site/test_osimage/tmp/imagedata/test_osimage/file1.1
+cmd:xcat-inventory export -t osimage -o test_osimage -d /tmp/imagedata/export 
+check:output=~The osimage objects has been exported to directory /tmp/imagedata/export 
+cmd:ls -lFR /tmp/imagedata/export
+cmd:diff -r /tmp/imagedata/test_osimage /tmp/imagedata/export/osimage/tmp/imagedata/test_osimage/
 check:rc==0
-cmd:diff -y /tmp/imagedata/test_osimage/file2.1 /opt/inventory/site/test_osimage/tmp/imagedata/test_osimage/file2.1
+cmd:diff -y /etc/hosts /tmp/imagedata/export/osimage/tmp/imagedata/test_osimage/etc/hosts
 check:rc==0
-cmd:diff -y /tmp/imagedata/test_osimage/file2.2 /opt/inventory/site/test_osimage/tmp/imagedata/test_osimage/file2.2
-check:rc==0
-cmd:diff -y /tmp/imagedata/test_osimage/file2.3 /opt/inventory/site/test_osimage/tmp/imagedata/test_osimage/file2.3
-check:rc==0
-cmd:diff -y /tmp/imagedata/test_osimage/file3.1 /opt/inventory/site/test_osimage/tmp/imagedata/test_osimage/file3.1
-check:rc==0
-cmd:diff -y /tmp/imagedata/test_osimage/file3.2 /opt/inventory/site/test_osimage/tmp/imagedata/test_osimage/file3.2
-check:rc==0
-cmd:diff -y /tmp/imagedata/test_osimage/file3.3 /opt/inventory/site/test_osimage/tmp/imagedata/test_osimage/file3.3
-check:rc==0
-cmd:diff -y /tmp/imagedata/test_osimage/file4.1 /opt/inventory/site/test_osimage/tmp/imagedata/test_osimage/file4.1
-check:rc==0
-cmd:diff -y /tmp/imagedata/test_osimage/file4.2 /opt/inventory/site/test_osimage/tmp/imagedata/test_osimage/file4.2
-check:rc==0
-cmd:diff -y /tmp/imagedata/test_osimage/file4.3 /opt/inventory/site/test_osimage/tmp/imagedata/test_osimage/file4.3
-check:rc==0
-cmd:diff -y /etc/hosts /opt/inventory/site/osimages/test_osimage/etc/hosts
-check:rc==0
-cmd:diff -y /tmp/imagedata/test_osimage/file6 /opt/inventory/site/test_osimage/tmp/imagedata/test_osimage/file6
-check:rc==0
-cmd:ls -l /opt/inventory/site/osimages/test_osimage/file7
+cmd:ls -l /tmp/imagedata/export/osimage/tmp/imagedata/test_osimage/file7
 check:rc!=0 
 cmd: rmdef -t osimage -o  test_osimage
 check:rc==0
 cmd:rm -rf /tmp/imagedata/test_osimage
-cmd:xcat-inventory import -t osimage -d /opt/inventory/site
+cmd:xcat-inventory import -t osimage -d /tmp/imagedata/export
 check:rc==0
 check:output=~Importing object: test_osimage
 check:output=~Inventory import successfully!
 check:output=~The object test_osimage has been imported
 cmd:lsdef -t osimage -o test_osimage
 check:rc==0
-cmd:diff -r /opt/inventory/site/osimages/test_osimage /tmp/imagedata/test_osimage
+cmd:diff -r /tmp/imagedata/export /tmp/imagedata/test_osimage 
 check:rc==0
 cmd: rmdef -t osimage -o  test_osimage
 check:rc==0
-#cmd:dir="/opt/inventory/site/osimage"; rm -rf $dir; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi
-#cmd:dir="/tmp/imagedata"; rm -rf $dir; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi
-cmd: if [ -e /tmp/test_osimage.stanza ]; then cat /tmp/test_osimage.stanza |mkdef -z;fi
+cmd:dir="/tmp/imagedata"; rm -rf $dir; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi
+cmd: if [ -e /tmp/imagedata/test_osimage.org.stanza ]; then cat /tmp/imagedata/test_osimage.org.stanza |mkdef -z;fi
 end

--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.include
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.include
@@ -1,0 +1,61 @@
+start:export_import_osimage_with_INCLUDE_in_file
+description:This case is used to test xcat-inventory export and import one linux osimage definition which has INCLUDE in the attribute's specified files. The attributes are pkglist, otherpkglist,exlist,synclists,template,postinstall and partitionfile.
+cmd:dir="/tmp/imagedata/";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi; mkdir -p $dir
+check:rc==0
+cmd:dir="/opt/inventory/site";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi; mkdir -p $dir
+check:rc==0
+cmd:cp -rf /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage /tmp/imagedata
+check:rc==0
+cmd:lsdef -t osimage -o test_osimage >/dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t osimage -o test_osimage -z >/tmp/test_osimage.stanza ;rmdef -t osimage -o test_osimage;fi
+check:rc==0
+cmd:cat /tmp/imagedata/test_osimage/test_osimage.stanza |mkdef -z
+check:rc==0
+cmd:lsdef -t osimage -o test_osimage
+check:rc==0
+cmd:xcat-inventory export -t osimage -o test_osimage -d /opt/inventory/site/ 
+check:output=~The osimage objects has been exported to directory /opt/inventory/site/
+cmd:ls -lFR /opt/inventory/site/
+cmd:diff -y /tmp/imagedata/test_osimage/file1.1 /opt/inventory/site/test_osimage/tmp/imagedata/test_osimage/file1.1
+check:rc==0
+cmd:diff -y /tmp/imagedata/test_osimage/file2.1 /opt/inventory/site/test_osimage/tmp/imagedata/test_osimage/file2.1
+check:rc==0
+cmd:diff -y /tmp/imagedata/test_osimage/file2.2 /opt/inventory/site/test_osimage/tmp/imagedata/test_osimage/file2.2
+check:rc==0
+cmd:diff -y /tmp/imagedata/test_osimage/file2.3 /opt/inventory/site/test_osimage/tmp/imagedata/test_osimage/file2.3
+check:rc==0
+cmd:diff -y /tmp/imagedata/test_osimage/file3.1 /opt/inventory/site/test_osimage/tmp/imagedata/test_osimage/file3.1
+check:rc==0
+cmd:diff -y /tmp/imagedata/test_osimage/file3.2 /opt/inventory/site/test_osimage/tmp/imagedata/test_osimage/file3.2
+check:rc==0
+cmd:diff -y /tmp/imagedata/test_osimage/file3.3 /opt/inventory/site/test_osimage/tmp/imagedata/test_osimage/file3.3
+check:rc==0
+cmd:diff -y /tmp/imagedata/test_osimage/file4.1 /opt/inventory/site/test_osimage/tmp/imagedata/test_osimage/file4.1
+check:rc==0
+cmd:diff -y /tmp/imagedata/test_osimage/file4.2 /opt/inventory/site/test_osimage/tmp/imagedata/test_osimage/file4.2
+check:rc==0
+cmd:diff -y /tmp/imagedata/test_osimage/file4.3 /opt/inventory/site/test_osimage/tmp/imagedata/test_osimage/file4.3
+check:rc==0
+cmd:diff -y /etc/hosts /opt/inventory/site/osimages/test_osimage/etc/hosts
+check:rc==0
+cmd:diff -y /tmp/imagedata/test_osimage/file6 /opt/inventory/site/test_osimage/tmp/imagedata/test_osimage/file6
+check:rc==0
+cmd:ls -l /opt/inventory/site/osimages/test_osimage/file7
+check:rc!=0 
+cmd: rmdef -t osimage -o  test_osimage
+check:rc==0
+cmd:rm -rf /tmp/imagedata/test_osimage
+cmd:xcat-inventory import -t osimage -d /opt/inventory/site
+check:rc==0
+check:output=~Importing object: test_osimage
+check:output=~Inventory import successfully!
+check:output=~The object test_osimage has been imported
+cmd:lsdef -t osimage -o test_osimage
+check:rc==0
+cmd:diff -r /opt/inventory/site/osimages/test_osimage /tmp/imagedata/test_osimage
+check:rc==0
+cmd: rmdef -t osimage -o  test_osimage
+check:rc==0
+#cmd:dir="/opt/inventory/site/osimage"; rm -rf $dir; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi
+#cmd:dir="/tmp/imagedata"; rm -rf $dir; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi
+cmd: if [ -e /tmp/test_osimage.stanza ]; then cat /tmp/test_osimage.stanza |mkdef -z;fi
+end

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/exlist
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/exlist
@@ -1,0 +1,2 @@
+#Test file for exlist
+#INCLUDE: /tmp/imagedata/test_osimage/file1.1# 

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file1.1
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file1.1
@@ -1,0 +1,2 @@
+###Test file without INCLUDE
+AAA

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file2.1
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file2.1
@@ -1,0 +1,2 @@
+###Test file with one INCLUDE in the file
+AAA

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file2.2
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file2.2
@@ -1,0 +1,2 @@
+###Test file with one INCLUDE in the file
+BBB

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file2.3
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file2.3
@@ -1,0 +1,2 @@
+###Test file with one INCLUDE in the file
+CCC

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file3.1
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file3.1
@@ -1,0 +1,2 @@
+###Test file with serverl INCLUDE in the file
+#INCLUDE:/tmp/imagedata/test_osimage/file3.2#

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file3.2
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file3.2
@@ -1,0 +1,2 @@
+###Test file with serverl INCLUDE in the file
+#INCLUDE:/tmp/imagedata/test_osimage/file3.3#

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file3.3
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file3.3
@@ -1,0 +1,2 @@
+###Test file with serverl INCLUDE in the file
+AAA

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file4.1
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file4.1
@@ -1,0 +1,2 @@
+#Test file for INCLUDE nesting file
+#INCLUDE:/tmp/imagedata/test_osimage/file4.2#

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file4.2
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file4.2
@@ -1,0 +1,2 @@
+#Test file for INCLUDE nesting file
+#INCLUDE:/tmp/imagedata/test_osimage/file4.3#

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file4.3
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file4.3
@@ -1,0 +1,2 @@
+#Test file for INCLUDE nesting file
+#INCLUDE:/tmp/imagedata/test_osimage/file4.1#

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file5
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file5
@@ -1,0 +1,2 @@
+#Test file for INCLUDE nesting file
+#INCLUDE:/etc/hosts#

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file6
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file6
@@ -1,0 +1,2 @@
+#Test file for INCLUDE nesting file
+AAA

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file7
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file7
@@ -1,0 +1,2 @@
+#Test file for INCLUDE nesting file
+AAA

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/otherpkglist
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/otherpkglist
@@ -1,0 +1,4 @@
+#Test file for otherpkglist
+#INCLUDE: /tmp/imagedata/test_osimage/file2.1#
+#INCLUDE: /tmp/imagedata/test_osimage/file2.2#
+#INCLUDE: /tmp/imagedata/test_osimage/file2.3#

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/partitionfile
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/partitionfile
@@ -1,0 +1,2 @@
+#Test file for otherpkglist
+#INCLUDE: /tmp/imagedata/test_osimage/file3.1#

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/pkglist
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/pkglist
@@ -1,0 +1,2 @@
+#Test file for otherpkglist
+#INCLUDE: /tmp/imagedata/test_osimage/file4.1#

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/postinstall
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/postinstall
@@ -1,0 +1,2 @@
+#Test file for otherpkglist
+#INCLUDE: /tmp/imagedata/test_osimage/file5#

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/synclists
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/synclists
@@ -1,0 +1,2 @@
+#Test file for synclists
+#INCLUDE: ./file6#

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/template.tmpl
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/template.tmpl
@@ -1,0 +1,2 @@
+#Test file for template
+#INCLUDE: /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/file7#

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/test_osimage.stanza
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage/test_osimage.stanza
@@ -1,0 +1,13 @@
+# <xCAT data object stanza file>
+
+test_osimage:
+    objtype=osimage
+    exlist=/tmp/imagedata/test_osimage/exlist
+    imagetype=linux
+    otherpkglist=/tmp/imagedata/test_osimage/otherpkglist
+    partitionfile=/tmp/imagedata/test_osimage/partitionfile
+    pkglist=/tmp/imagedata/test_osimage/pkglist
+    postinstall=/tmp/imagedata/test_osimage/postinstall
+    provmethod=install
+    synclists=/tmp/imagedata/test_osimage/synclists
+    template=/tmp/imagedata/test_osimage/template.tmpl


### PR DESCRIPTION
Case Name: export_import_osimage_with_INCLUDE_in_file
description:This case is used to test xcat-inventory export and import one linux osimage definition which has INCLUDE in the attribute's specified files. The attributes are pkglist, otherpkglist,exlist,synclists,template,postinstall and partitionfile.