### PR TITLE
Using physical entity description OID to get Vendor information

### DIFF
--- a/xCAT-server/lib/xcat/plugins/switchdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/switchdiscover.pm
@@ -982,7 +982,7 @@ sub get_snmpvendorinfo {
 
     foreach $comms(@comm_list) {
         #get sysDescr.0";
-        my $ccmd = "snmpwalk -Os -v1 -c $comms $ip 1.3.6.1.2.1.1.1";
+        my $ccmd = "snmpwalk -Os -v1 -c $comms $ip 1.3.6.1.2.1.47.1.1.1.1.2.1";
         if (exists($globalopt{verbose}))    {
            send_msg($request, 0, "Process command: $ccmd\n");
         }


### PR DESCRIPTION
xCAT couldn't recognize sn2410/sn2700 mellanox Ethernet switch as `Mellanox` switch type via system.sysDescr OID
````
# snmpwalk -Os -v1 -c public 8331-25M-switch 1.3.6.1.2.1.1.1
sysDescr.0 = STRING: Onyx,MSN2410,SWv3.6.6107
````
The match string has to be one of following:
````
Mellanox => "Mellanox",
    mellanox => "Mellanox",
    MLNX => "Mellanox",
    MELLAN => "Mellanox",
````
Changing this to use the `physical entity MIB` ,  verified the supported switches on the lab
````
# snmpwalk -Os -v1 -c public mid08tor03 1.3.6.1.2.1.47.1.1.1.1.2.1
mib-2.47.1.1.1.1.2.1 = STRING: "Edgecore arm-accton_as4610_54-r0 4610-54T-O-AC-B Chassis"

# snmpwalk -Os -v1 -c public mid08 1.3.6.1.2.1.47.1.1.1.1.2.1
mib-2.47.1.1.1.1.2.1 = STRING: "Mellanox MSX1410, 48 port 10GbE + 12 port 40GbE Switch System"

# snmpwalk -Os -v1 -c public core01 1.3.6.1.2.1.47.1.1.1.1.2.1
mib-2.47.1.1.1.1.2.1 = STRING: "Mellanox MSX1410, 48 port 10GbE + 12 port 40GbE Switch System"

# snmpwalk -Os -v1 -c public mgmtsw01 1.3.6.1.2.1.47.1.1.1.1.2.1
mib-2.47.1.1.1.1.2.1 = STRING: "IBM Networking Operating System RackSwitch G8052"

# snmpwalk -Os -v1 -c public 8331-25M-switch 1.3.6.1.2.1.47.1.1.1.1.2.1
mib-2.47.1.1.1.1.2.1 = STRING: "Mellanox MSN2410, 48 port 25GbE + 8 port 100GbE Switch System"
````