### PR TITLE
support secure root method

### DIFF
--- a/perl-xCAT/xCAT/Schema.pm
+++ b/perl-xCAT/xCAT/Schema.pm
@@ -1178,6 +1178,8 @@ passed as argument rather than by table value',
 "              all of the nodes passed into the cmd and create the mypostscript file\n" .
 "              for each node, and put them in a directory of tftpdir(such as: /tftpboot)\n" .
 "              If no, it will not generate the mypostscript file in the tftpdir.\n\n" .
+" secureroot:  If set to 1, xCAT will use secure mode to transfer root password hash\n" .
+"              during the installation.  Default is 0.\n\n" .
 " setinstallnic:  Set the network configuration for installnic to be static.\n\n" .
 " sharedtftp:  Set to 0 or no, xCAT should not assume the directory\n" .
 "              in tftpdir is mounted on all on Service Nodes. Default is 1/yes.\n" .

--- a/xCAT-server/lib/perl/xCAT/Template.pm
+++ b/xCAT-server/lib/perl/xCAT/Template.pm
@@ -1598,6 +1598,7 @@ sub crydb
     };
     $kp = $get_query_map->($key);
     return undef if (!defined($kp));
+    return '*' if ($::XCATSITEVALS{secureroot} eq "1");
     return xCAT::PasswordUtils::crypt_system_password($table, $kp, \@fields);
 }
 

--- a/xCAT-server/lib/xcat/plugins/credentials.pm
+++ b/xCAT-server/lib/xcat/plugins/credentials.pm
@@ -33,6 +33,7 @@ use IO::Socket::INET;
 use Time::HiRes qw(sleep);
 
 use xCAT::Utils;
+use xCAT::PasswordUtils;
 
 use xCAT::MsgUtils;
 use Getopt::Long;
@@ -316,6 +317,16 @@ sub process_request
             }
             $tfilename = "/etc/xcatdockerca/cert/dockerhost-cert.pem";
 
+        } elsif ($parm =~ /xcat_secure_pw:/) {
+            xCAT::MsgUtils->trace(0, 'I', "credentials: sending $parm to $client");
+            my @users=split(/:/,$parm);
+            if (defined($users[1]) and $users[1] eq 'root') {
+                my $pass = xCAT::PasswordUtils::crypt_system_password();
+                if ($pass) {
+                    push @{$rsp->{'data'}}, { content => [ $pass ], desc => [ $parm ] };
+                }
+            }
+            next;
         } else {
             xCAT::MsgUtils->trace(0, 'W', "credentials: Not supported type: $parm");
             next;

--- a/xCAT-server/lib/xcat/plugins/packimage.pm
+++ b/xCAT-server/lib/xcat/plugins/packimage.pm
@@ -394,11 +394,15 @@ sub process_request {
     system("umount $rootimg_dir/proc");
     copybootscript($installroot, $rootimg_dir, $osver, $arch, $profile, $callback);
 
+
     my $pass = xCAT::PasswordUtils::crypt_system_password();
     if (!defined($pass)) {
         $pass = 'cluster';
     }
-
+    my @secure_root    = xCAT::TableUtils->get_site_attribute("secureroot");
+    if ($secure_root[0] == 1) {
+        $pass = '*';
+    }
     my $oldmask = umask(0077);
     my $shadow;
     open($shadow, "<", "$rootimg_dir/etc/shadow");

--- a/xCAT/postscripts/remoteshell
+++ b/xCAT/postscripts/remoteshell
@@ -462,6 +462,73 @@ then
   fi
 fi
 
+# if secureroot is enabled then we get root password hash, not for updatenode
+if [ "x$SECUREROOT" = "x1" ] && [ "x$UPDATENODE" != "x1" ]; then
+  logger -t xcat -p local4.info "remoteshell: secure root is enabled"
+  if [ $useflowcontrol = "1" ]; then
+    logger -t xcat -p local4.info "remoteshell: sending xcatflowrequest $master 3001"
+    /$xcatpost/xcatflowrequest $master 3001
+    rc=$?
+    if [ $rc -ne 0 ]; then
+      logger -t xcat -p local4.info "remoteshell: error from xcatflowrequest (rc=$rc), will not use flow control"
+      useflowcontrol=0
+    fi
+  fi
+  getcredentials.awk xcat_secure_pw:root | grep -E -v '</{0,1}xcatresponse>|</{0,1}serverdone>'|sed -e 's/&lt;/</' -e 's/&gt;/>/' -e 's/&amp;/&/' -e 's/&quot/"/' -e "s/&apos;/'/" > /tmp/secure_root_hash
+
+  logger -t xcat -p local4.info "remoteshell: gathering password hash for root"
+  #check whether the message is an error or not
+  grep -E '<error>' /tmp/secure_root_hash > /dev/null
+  if [ $? -ne 0 ]; then
+	#The message contains the data we request
+    rootpwhash=`cat /tmp/secure_root_hash | grep -E '</{0,1}content>' | sed -n 's%.*<content>\(.*\)</content>.*%\1%p'`
+
+    MAX_RETRIES=10
+    RETRY=0
+    while [ -z "$rootpwhash" ]; do
+      if [ $useflowcontrol = "0" ]; then
+        let SLI=$RANDOM%10
+        let SLI=SLI+10
+        sleep $SLI
+      fi
+      RETRY=$(($RETRY+1))
+      if [ $RETRY -eq $MAX_RETRIES ]; then
+        ERR_MSG="Too many retries"
+        break
+      fi
+      if [ $useflowcontrol = "1" ]; then
+        #first contact daemon  xcatflowrequest <server> 3001
+        logger -t xcat -p local4.info "remoteshell: sending xcatflowrequest $master 3001"
+        /$xcatpost/xcatflowrequest $master 3001
+        rc=$?
+        if [ $rc -ne 0 ]; then
+          logger -t xcat -p local4.info "remoteshell: error from xcatflowrequest (rc=$rc), will not use flow control"
+          useflowcontrol=0
+        fi
+      fi
+      getcredentials.awk xcat_secure_pw:root | grep -E -v '</{0,1}xcatresponse>|</{0,1}serverdone>'|sed -e 's/&lt;/</' -e 's/&gt;/>/' -e 's/&amp;/&/' -e 's/&quot/"/' -e "s/&apos;/'/" > /tmp/secure_root_hash
+      grep -E '<error>' /tmp/secure_root_hash > /dev/null
+      if [ $? -ne 0 ]; then
+        rootpwhash=`cat /tmp/secure_root_hash | grep -E '</{0,1}content>' | sed -n 's%.*<content>\(.*\)</content>.*%\1%p'`
+      else
+        ERR_MSG=`sed -n 's%.*<error>\(.*\)</error>.*%\1%p' /tmp/secure_root_hash`
+        break
+      fi
+	done
+    if [ -n "$rootpwhash" ]; then
+      #updat shadow
+      usermod -p "$rootpwhash" root
+    fi
+  else
+	#This is an error message
+	ERR_MSG=`sed -n 's%.*<error>\(.*\)</error>.*%\1%p' /tmp/secure_root_hash`
+  fi
+  rm /tmp/secure_root_hash
+  if [ "x" != "x$ERR_MSG" ]; then
+    logger -t xcat -p local4.err "Failed to acquire secure root password: $ERR_MSG"
+  fi
+fi
+
 # start up the sshd for syncfiles postscript to do the sync work
 logger -t xcat -p local4.info "start up sshd"
 if [[ $OSVER == ubuntu* || $OSVER == debian* ]]


### PR DESCRIPTION
 - support xcat_secure_pw:<user> API in credential plugin
 - for diskless, if enabled secure root, packimage will not write root password into image
 - for stateful, if enabled secure root, nodeset will not write root password into config file
 - and 'remoteshell' will update shadow file accordingly during the provisining

UT:
```
# packimage rhels7.5-alt-rc2-ppc64le-ANSIBLE-netboot-compute
Packing contents of /install/ansible/custom/rhels7.5-alt-rc2-ppc64le-ANSIBLE-netboot-compute/rootimgdir/rootimg
archive method:cpio
compress method:gzip

#head -1 /install/ansible/custom/rhels7.5-alt-rc2-ppc64le-ANSIBLE-netboot-compute/rootimgdir/rootimg/etc/shadow
root:*:13880:0:99999:7:::

# rinstall mid05tor12cn16
Provision node(s): mid05tor12cn16

# xdsh mid05tor12cn16 head -1 /etc/shadow
mid05tor12cn16: root:$5$VWtqsxei$AoPeAIZrm68SANNtv3NW1.0PkdEuo7WGaI8WOZ20uv7:17689:0:99999:7:::
```
Try with `ssh mid05tor12cn16 -o PreferredAuthentications=password`, password is okay.


For stateful:
```
#chdef -t site secureroot=1
#nodeset c910f03c05k29 osimage

#cat /install/autoinst/c910f03c05k29|grep ^rootpw
rootpw --iscrypted *
```
And provision the node, it could be provisioned, after it is up, using password to ssh it.
`ssh c910f03c05k29 -o PreferredAuthentications=password`
It will prompt to input password, and login with the right password.  Testing is passed.

If not enabled,  the same as previous
```
#chdef -t site secureroot=0    Or #chdef -t site secureroot=
#nodeset c910f03c05k29 osimage

cat /install/autoinst/c910f03c05k29|grep ^rootpw
rootpw --iscrypted $5$PuPt61Ux$ruYaBA2bd8hSbNoT8emaxkv3M3iAJKB6nCt3xB7ri73

```

For updatenode:
```
modify root hash in /etc/shadow on mid05tor12cn16
updatenode mid05tor12cn16 remoteshell
# xdsh mid05tor12cn16 head -1 /etc/shadow
mid05tor12cn16: root:*:17689:0:99999:7:::
```