### PR TITLE
Failed to discover PDU

### DIFF
--- a/xCAT-server/lib/xcat/plugins/switchdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/switchdiscover.pm
@@ -981,8 +981,8 @@ sub get_snmpvendorinfo {
     push @comm_list, 'public';
 
     foreach $comms(@comm_list) {
-        #for pdu: get vendor info from sysDescr.0
-        #for switches: get vendor info from product OID 
+        #for pdu: get vendor info from sysDescr
+        #for switches: get vendor info from entPhysicalDescr 
         my $ccmd;
         if (exists($globalopt{pdu})) {
             $ccmd = "snmpwalk -Os -v1 -c $comms $ip 1.3.6.1.2.1.1.1";

--- a/xCAT-server/lib/xcat/plugins/switchdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/switchdiscover.pm
@@ -981,8 +981,14 @@ sub get_snmpvendorinfo {
     push @comm_list, 'public';
 
     foreach $comms(@comm_list) {
-        #get sysDescr.0";
-        my $ccmd = "snmpwalk -Os -v1 -c $comms $ip 1.3.6.1.2.1.47.1.1.1.1.2.1";
+        #for pdu: get vendor info from sysDescr.0
+        #for switches: get vendor info from product OID 
+        my $ccmd;
+        if (exists($globalopt{pdu})) {
+            $ccmd = "snmpwalk -Os -v1 -c $comms $ip 1.3.6.1.2.1.1.1";
+        } else {
+            $ccmd = "snmpwalk -Os -v1 -c $comms $ip 1.3.6.1.2.1.47.1.1.1.1.2.1";
+        }
         if (exists($globalopt{verbose}))    {
            send_msg($request, 0, "Process command: $ccmd\n");
         }


### PR DESCRIPTION
After PR #5283 , the `pdudiscover` failed to find available PDUs.

```
[root@boston02 ~]# snmpwalk -Os -v1 -c public 172.21.253.104 1.3.6.1.2.1.47.1.1.1.1.2.1
[root@boston02 ~]# snmpwalk -Os -v1 -c public 172.21.253.104 1.3.6.1.2.1
sysDescr.0 = STRING: IBM PDU 46W1608(46M4003) OPDP_sIBM_v01.3_8 FreeRTOS_4.2.1 Lwip_1.2.0
````
modify code to still use sysDescr OID to find pdu

````
[root@boston02 xCAT_plugin]# pdudiscover --range 172.21.253.104
Discovering pdu using snmpwalk for 172.21.253.104 .....
ip              name                    vendor                                                  mac
------------    ------------            ------------                                            ------------
172.21.253.104  f6pdu15                 IBM PDU 46W1608(46M4003) OPDP_sIBM_v01.3_8 FreeRTOS_4.2.1 Lwip_1.2.0    00:18:23:05:84:0e
pdu discovered and matched: f6pdu15 to f6pdu15
````


