### PR TITLE
enhance xcattest 

### DIFF
--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -21,6 +21,7 @@ my $program_name = basename($0);
 
 my $rootdir                  = "$prpgram_path/../share/xcat/tools/autotest";
 my $casedir                  = "$rootdir/testcase/";
+$casedir = $ENV{'XCATTEST_CASEDIR'} if exists $ENV{'XCATTEST_CASEDIR'};
 my $bundledir                = "$rootdir/bundle/";
 my $resultdir                = "$rootdir/result/";
 my $rst                      = 0;
@@ -56,6 +57,8 @@ my $running_log_fd     = undef
 my $running_log_name   = undef;
 my $failed_log_name      = undef;
 my $performance_log_name = undef;
+my $xcatdebug = 0;
+$xcatdebug = 1 if exists $ENV{'XCATTEST_DEBUG'};
 
 #--------------command line attrbutes--------------
 my $needhelp          = 0;
@@ -177,8 +180,11 @@ if ($rst) {
     to_exit(1);
 }
 
-#print "----case to be run-----------------\n";
-#print Dumper \@cases_to_be_run;
+
+if ($xcatdebug) {
+    print "----case to be run-----------------\n";
+    print Dumper \@cases_to_be_run;
+}
 
 if ($list) {
     if ($list eq "caselist") {
@@ -340,12 +346,14 @@ if ($rst && $rst < 2) {
     to_exit(1);
 }
 
-#print "=====Dumper loaded cases=======\n";
-#print Dumper \@cases;
-#print "=====Dumper case_name_index_map=======================\n";
-#print Dumper \%case_name_index_map;
-#print "=====Dumper cases to be run=====\n";
-#print Dumper \@cases_to_be_run;
+if ($xcatdebug) {
+    print "=====Dumper loaded cases=======\n";
+    print Dumper \@cases;
+    print "=====Dumper case_name_index_map=======================\n";
+    print Dumper \%case_name_index_map;
+    print "=====Dumper cases to be run=====\n";
+    print Dumper \@cases_to_be_run;
+}
 
 unless (@cases_to_be_run) {
     to_exit(1);
@@ -1647,7 +1655,7 @@ sub runscript {
 
 #--------------------------------------------------------
 # Fuction name: getnodeattr
-# Description: get the value of node attribute form current environment
+# Description: get the value of node attribute from current environment
 # Atrributes:
 # Retrun code:
 #--------------------------------------------------------
@@ -1655,11 +1663,26 @@ sub getnodeattr {
     my $node   = shift;
     my $attr   = shift;
     my $maxtry = 40;
+    return getobjectattr('node', $node, $attr, $maxtry);
+}
+
+#--------------------------------------------------------
+# Fuction name: getobjectattr
+# Description: get the value of object attribute from current DB
+# Atrributes:
+# Retrun code:
+#--------------------------------------------------------
+sub getobjectattr {
+    my $objtype   = shift;
+    my $objname   = shift;
+    my $attr      = shift;
+    my $maxtry    = shift;
+    $maxtry = 1 unless defined($maxtry) and $maxtry > 0;
     foreach my $try (0 .. $maxtry) {
-        my @output = runcmd("lsdef -t node -o $node -i $attr");
+        my @output = runcmd("lsdef -t $objtype -o $objname -i $attr");
         if ($::RUNCMD_RC == 0) {
             foreach my $line (@output) {
-                if ($line =~ /$attr=(\w.+)/) {
+                if ($line =~ /$attr=(\S.+)/) {
                     return $1;
                 }
             }
@@ -1813,7 +1836,7 @@ sub getfunc
 {
     my $str = shift;
 
-    while ($str =~ /__(\w+)\(([\s\,\w\$]*)\)__/) {
+    while ($str =~ /__(\w+)\(([\s\,\w\$\-\.]*)\)__/) {
         my $func      = $1;
         my $parameter = $2;
         my $value     = undef;
@@ -1824,6 +1847,11 @@ sub getfunc
         @para = split /\s*,\s*/, $parameter;
         if ($func eq "GETNODEATTR") {
             $value = getnodeattr($para[0], $para[1]);
+            if ($value eq "Unknown") {
+                $value = '';
+            }
+        } elsif ($func eq "GETOBJECTATTR") {
+            $value = getobjectattr(@para);
             if ($value eq "Unknown") {
                 $value = '';
             }


### PR DESCRIPTION
enhance `xcattest` for better debug new case and acquire attribute not only for node:

 - to support customize the testcase dir with environment variable XCATTEST_CASEDIR
 - to allow to print more debug info with environment variable XCATTEST_DEBUG
 - to add a new func to get general object attribute (\_\_GETOBJECTATTR(...)\_\_)

UT:
```
chdef -t osimage -o rhels7.3-ppc64le-install-compute rootimgdir=/tmp/testing
1 object definitions have been created or modified.

XCATTEST_CASEDIR=`pwd` XCATTEST_CN=fake1 XCATTEST_DEBUG=1 /opt/xcat/bin/xcattest -t test
----case to be run-----------------
$VAR1 = [
          'test'
        ];
xCAT automated test started at Tue Jun 19 21:24:02 2018
******************************
To detect current test environment
******************************
Detecting: OS = linux
Detecting: ARCH = ppc64le
Detecting: HCP = openbmc
******************************
loading test cases
******************************
To run:
test
=====Dumper loaded cases=======
$VAR1 = [
          {
            'cmd' => [
                       [
                         'echo __GETOBJECTATTR(osimage,__GETNODEATTR(fake1,provmethod)__,rootimgdir)__'
                       ]
                     ],
            'name' => 'test',
            'description' => 'this is just a test',
            'os' => 'Linux',
            'label_str' => '',
            'filename' => '/opt/xcat/share/xcat/tools/autotest/testcase/packimg/secure_protect_cases',
            'check' => [
                         [
                           'rc==0'
                         ]
                       ],
            'label' => 0
          }
        ];
=====Dumper case_name_index_map=======================
$VAR1 = {
          'test' => 0
        };
=====Dumper cases to be run=====
$VAR1 = [
          'test'
        ];
******************************
Start to run test cases
******************************
------START::test::Time:Tue Jun 19 21:24:03 2018------

RUN:echo __GETOBJECTATTR(osimage,__GETNODEATTR(fake1,provmethod)__,rootimgdir)__ [Tue Jun 19 21:24:03 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
/tmp/testing         <======== .  get the right value
CHECK:rc == 0	[Pass]

------END::test::Passed::Time:Tue Jun 19 21:24:04 2018 ::Duration::1 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished at Tue Jun 19 21:24:04 2018
```