### PR TITLE
update case for task 189,xcat-inventory osimage support environment variables(export part)

### DIFF
--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.environment
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.environment
@@ -97,6 +97,18 @@ check:rc==0
 check:output=~The inventory data has been dumped to /tmp/export/test.environments.osimage.yaml
 cmd:diff -y  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.yaml /tmp/export/test.environments.osimage.yaml --ignore-blank-lines  -I "^#"
 check:rc==0
+cmd:rmdef -t osimage -o test.environments.osimage
+check:rc==0
+cmd:export GITREPO="/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo";export SWDIR="/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir";xcat-inventory import -f /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json
+check:output=~Importing object: test.environments.osimage
+check:output=~Inventory import successfully!
+check:rc==0
+cmd:lsdef -t osimage -o test.environments.osimage
+check:rc==0
+cmd:xcat-inventory export  -t osimage -o test.environments.osimage -f /tmp/export/test.environments.osimage.json
+check:rc==0
+cmd:diff -y  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json /tmp/export/test.environments.osimage.json --ignore-blank-lines  -I "^#"
+check:rc==0
 cmd:dir="/tmp/export"; rm -rf $dir; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi
 cmd: rmdef -t osimage -o test.environments.osimage
 check:rc==0

--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.environment
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.environment
@@ -1,7 +1,7 @@
 start:import_osimage_with_environments_in_yaml
 description:this case is to verify if osimage import could support environment variables.
 os:Linux
-label:xcat_install,xcat_inventory,provision
+label:others,xcat_inventory,invoke_provison
 cmd:chdef -t node -o $$CN servicenode= monserver=$$MN nfsserver=$$MN tftpserver=$$MN  xcatmaster=$$MN
 check:rc==0
 
@@ -85,13 +85,15 @@ os:Linux
 label:others,xcat_inventory
 cmd:lsdef -t osimage -o test.environments.osimage >/dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t osimage -o test.environments.osimage -z >/tmp/test.environments.osimage_image.stanza ;rmdef -t osimage -o test.environments.osimage;fi
 check:rc==0
+cmd:dir="/tmp/export";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi; mkdir -p $dir
 cmd:export GITREPO="/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo";export SWDIR="/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir";xcat-inventory import -f /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.yaml
 check:output=~Importing object: test.environments.osimage
 check:output=~Inventory import successfully!
 check:rc==0
-cmd:lsdef -t osimage -o test.environments.osimage
+cmd:lsdef -t osimage -o test.environments.osimage -z >> /tmp/export/test.environments.osimage.yaml.stanza
 check:rc==0
-cmd:dir="/tmp/export";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi; mkdir -p $dir
+cmd:diff -y /tmp/export/test.environments.osimage.yaml.stanza /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.stanza
+check:rc==0
 cmd:xcat-inventory export  -t osimage -o test.environments.osimage -f /tmp/export/test.environments.osimage.yaml --format yaml
 check:rc==0
 check:output=~The inventory data has been dumped to /tmp/export/test.environments.osimage.yaml
@@ -103,7 +105,9 @@ cmd:export GITREPO="/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/
 check:output=~Importing object: test.environments.osimage
 check:output=~Inventory import successfully!
 check:rc==0
-cmd:lsdef -t osimage -o test.environments.osimage
+cmd:lsdef -t osimage -o test.environments.osimage -z >> /tmp/export/test.environments.osimage.json.stanza
+check:rc==0
+cmd:diff -y /tmp/export/test.environments.osimage.json.stanza /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.stanza
 check:rc==0
 cmd:xcat-inventory export  -t osimage -o test.environments.osimage -f /tmp/export/test.environments.osimage.json
 check:rc==0

--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.environment
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.environment
@@ -78,3 +78,61 @@ check:rc==0
 cmd:xdsh $$CN "rpm -qa |grep -w dhcp"
 check:rc==0
 end
+
+start:export_osimage_with_environments
+description:this case is to verify if osimage export could support environment variables.
+os:Linux
+label:xcat_install,xcat_inventory
+cmd:lsdef -t osimage -o test.environments.osimage >/dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t osimage -o test.environments.osimage -z >/tmp/test.environments.osimage_image.stanza ;rmdef -t osimage -o test.environments.osimage;fi
+check:rc==0
+cmd:export GITREPO="/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo";export SWDIR="/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir";xcat-inventory import -f /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.yaml
+check:output=~Importing object: test.environments.osimage
+check:output=~Inventory import successfully!
+check:rc==0
+cmd:lsdef -t osimage -o test.environments.osimage
+check:rc==0
+cmd:dir="/tmp/export";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi; mkdir -p $dir
+cmd:xcat-inventory export  -t osimage -o test.environments.osimage -d /tmp/export
+check:rc==0
+check:output=~The osimage objects has been exported to directory /tmp/export
+cmd:ls -lFR /tmp/export
+cmd:grep "environvars" /tmp/export/test.environments.osimage/definition.json
+check:rc!=0
+cmd:grep "filestosync: {{GITREPO}}/syncfiles/synclist" /tmp/export/test.environments.osimage/definition.json
+check:rc==0
+cmd:grep "postinstall: /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.postinstall,{{GITREPO}}/postinstall/test1.postinstall" /tmp/export/test.environments.osimage/definition.json
+check:rc==0
+cmd:grep "otherpkgdir: {{SWDIR}}/otherpkgdir/" /tmp/export/test.environments.osimage/definition.json
+check:rc==0
+cmd:grep "otherpkglist: {{GITREPO}}/otherpkglist/test1.otherpkglist,{{GITREPO}}/otherpkglist/test2.otherpkglist" /tmp/export/test.environments.osimage/definition.json
+check:rc==0
+cmd:grep "pkgdir: /install/rhels7.5-alternate/ppc64le,{{SWDIR}}/pkgdir/" /tmp/export/test.environments.osimage/definition.json
+check:rc==0
+cmd:grep "pkglist: /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist,{{GITREPO}}/pkglist/test1.pkglist,{{GITREPO}}/pkglist/test2.pkglist" /tmp/export/test.environments.osimage/definition.json
+check:rc==0
+cmd:rm -rf /tmp/export/test.environments.osimage
+cmd:xcat-inventory export  -t osimage -o test.environments.osimage -d /tmp/export --format yaml
+check:rc==0
+check:output=~The osimage objects has been exported to directory /tmp/export
+cmd:ls -lFR /tmp/export
+cmd:grep "environvars" /tmp/export/test.environments.osimage/definition.yaml
+check:rc!=0
+cmd:grep "filestosync: {{GITREPO}}/syncfiles/synclist" /tmp/export/test.environments.osimage/definition.yaml
+check:rc==0
+cmd:grep "postinstall: /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.postinstall,{{GITREPO}}/postinstall/test1.postinstall" /tmp/export/test.environments.osimage/definition.yaml
+check:rc==0
+cmd:grep "otherpkgdir: {{SWDIR}}/otherpkgdir/" /tmp/export/test.environments.osimage/definition.yaml
+check:rc==0
+cmd:grep "otherpkglist: {{GITREPO}}/otherpkglist/test1.otherpkglist,{{GITREPO}}/otherpkglist/test2.otherpkglist" /tmp/export/test.environments.osimage/definition.yaml
+check:rc==0
+cmd:grep "pkgdir: /install/rhels7.5-alternate/ppc64le,{{SWDIR}}/pkgdir/" /tmp/export/test.environments.osimage/definition.yaml
+check:rc==0
+cmd:grep "pkglist: /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist,{{GITREPO}}/pkglist/test1.pkglist,{{GITREPO}}/pkglist/test2.pkglist" /tmp/export/test.environments.osimage/definition.yaml
+check:rc==0
+cmd:dir="/tmp/export"; rm -rf $dir; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi
+cmd: rmdef -t osimage -o test.environments.osimage
+check:rc==0
+cmd: if [ -e /tmp/test.environments.osimage.stanza ]; then cat /tmp/test.environments.osimage.stanza |mkdef -z;fi
+end
+
+

--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.environment
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.environment
@@ -82,52 +82,20 @@ end
 start:export_osimage_with_environments
 description:this case is to verify if osimage export could support environment variables.
 os:Linux
-label:xcat_install,xcat_inventory
+label:others,xcat_inventory
 cmd:lsdef -t osimage -o test.environments.osimage >/dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t osimage -o test.environments.osimage -z >/tmp/test.environments.osimage_image.stanza ;rmdef -t osimage -o test.environments.osimage;fi
 check:rc==0
-cmd:export GITREPO="/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo";export SWDIR="/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir";xcat-inventory import -f /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.yaml
+cmd:export GITREPO="/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo";export SWDIR="/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir";xcat-inventory import -f /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.yaml
 check:output=~Importing object: test.environments.osimage
 check:output=~Inventory import successfully!
 check:rc==0
 cmd:lsdef -t osimage -o test.environments.osimage
 check:rc==0
 cmd:dir="/tmp/export";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi; mkdir -p $dir
-cmd:xcat-inventory export  -t osimage -o test.environments.osimage -d /tmp/export
+cmd:xcat-inventory export  -t osimage -o test.environments.osimage -f /tmp/export/test.environments.osimage.yaml --format yaml
 check:rc==0
-check:output=~The osimage objects has been exported to directory /tmp/export
-cmd:ls -lFR /tmp/export
-cmd:grep "environvars" /tmp/export/test.environments.osimage/definition.json
-check:rc!=0
-cmd:grep "filestosync: {{GITREPO}}/syncfiles/synclist" /tmp/export/test.environments.osimage/definition.json
-check:rc==0
-cmd:grep "postinstall: /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.postinstall,{{GITREPO}}/postinstall/test1.postinstall" /tmp/export/test.environments.osimage/definition.json
-check:rc==0
-cmd:grep "otherpkgdir: {{SWDIR}}/otherpkgdir/" /tmp/export/test.environments.osimage/definition.json
-check:rc==0
-cmd:grep "otherpkglist: {{GITREPO}}/otherpkglist/test1.otherpkglist,{{GITREPO}}/otherpkglist/test2.otherpkglist" /tmp/export/test.environments.osimage/definition.json
-check:rc==0
-cmd:grep "pkgdir: /install/rhels7.5-alternate/ppc64le,{{SWDIR}}/pkgdir/" /tmp/export/test.environments.osimage/definition.json
-check:rc==0
-cmd:grep "pkglist: /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist,{{GITREPO}}/pkglist/test1.pkglist,{{GITREPO}}/pkglist/test2.pkglist" /tmp/export/test.environments.osimage/definition.json
-check:rc==0
-cmd:rm -rf /tmp/export/test.environments.osimage
-cmd:xcat-inventory export  -t osimage -o test.environments.osimage -d /tmp/export --format yaml
-check:rc==0
-check:output=~The osimage objects has been exported to directory /tmp/export
-cmd:ls -lFR /tmp/export
-cmd:grep "environvars" /tmp/export/test.environments.osimage/definition.yaml
-check:rc!=0
-cmd:grep "filestosync: {{GITREPO}}/syncfiles/synclist" /tmp/export/test.environments.osimage/definition.yaml
-check:rc==0
-cmd:grep "postinstall: /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.postinstall,{{GITREPO}}/postinstall/test1.postinstall" /tmp/export/test.environments.osimage/definition.yaml
-check:rc==0
-cmd:grep "otherpkgdir: {{SWDIR}}/otherpkgdir/" /tmp/export/test.environments.osimage/definition.yaml
-check:rc==0
-cmd:grep "otherpkglist: {{GITREPO}}/otherpkglist/test1.otherpkglist,{{GITREPO}}/otherpkglist/test2.otherpkglist" /tmp/export/test.environments.osimage/definition.yaml
-check:rc==0
-cmd:grep "pkgdir: /install/rhels7.5-alternate/ppc64le,{{SWDIR}}/pkgdir/" /tmp/export/test.environments.osimage/definition.yaml
-check:rc==0
-cmd:grep "pkglist: /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist,{{GITREPO}}/pkglist/test1.pkglist,{{GITREPO}}/pkglist/test2.pkglist" /tmp/export/test.environments.osimage/definition.yaml
+check:output=~The inventory data has been dumped to /tmp/export/test.environments.osimage.yaml
+cmd:diff -y  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.yaml /tmp/export/test.environments.osimage.yaml --ignore-blank-lines  -I "^#"
 check:rc==0
 cmd:dir="/tmp/export"; rm -rf $dir; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi
 cmd: rmdef -t osimage -o test.environments.osimage

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.stanza
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.stanza
@@ -1,0 +1,21 @@
+# <xCAT data object stanza file>
+
+test.environments.osimage:
+    objtype=osimage
+    environvar=GITREPO=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo,SWDIR=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir
+    imagetype=linux
+    osarch=ppc64le
+    osdistroname=rhels7.5-alternate-ppc64le
+    osname=Linux
+    osvers=rhels7.5-alternate
+    otherpkgdir=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir/otherpkgdir/
+    otherpkglist=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/otherpkglist/test1.otherpkglist,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/otherpkglist/test2.otherpkglist,
+    permission=755
+    pkgdir=/install/rhels7.5-alternate/ppc64le,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir/pkgdir/
+    pkglist=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/pkglist/test1.pkglist,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/pkglist/test2.pkglist
+    postinstall=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.postinstall,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/postinstall/test1.postinstall
+    profile=compute
+    provmethod=netboot
+    rootimgdir=/install/custom/test.environments.osimage
+    synclists=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/syncfiles/synclist
+    usercomment=rhels7.5,test_environment_variables

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json
@@ -1,0 +1,50 @@
+{
+    "osimage": {
+        "test.environments.osimage": {
+            "basic_attributes": {
+                "arch": "ppc64le",
+                "distribution": "rhels7.5-alternate",
+                "osdistro": "rhels7.5-alternate-ppc64le",
+                "osname": "Linux"
+            },
+            "deprecated": {
+                "comments": "rhels7.5,test_environment_variables"
+            },
+            "filestosync": [
+                "{{GITREPO}}/syncfiles/synclist"
+            ],
+            "genimgoptions": {
+                "permission": "755",
+                "postinstall": [
+                    "/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.postinstall",
+                    "{{GITREPO}}/postinstall/test1.postinstall"
+                ],
+                "rootimgdir": "/install/custom/test.environments.osimage"
+            },
+            "imagetype": "linux",
+            "package_selection": {
+                "otherpkgdir": [
+                    "{{SWDIR}}/otherpkgdir/"
+                ],
+                "otherpkglist": [
+                    "{{GITREPO}}/otherpkglist/test1.otherpkglist",
+                    "{{GITREPO}}/otherpkglist/test2.otherpkglist",
+                    ""
+                ],
+                "pkgdir": [
+                    "/install/rhels7.5-alternate/ppc64le",
+                    "{{SWDIR}}/pkgdir/"
+                ],
+                "pkglist": [
+                    "/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist",
+                    "{{GITREPO}}/pkglist/test1.pkglist",
+                    "{{GITREPO}}/pkglist/test2.pkglist"
+                ]
+            },
+            "provision_mode": "netboot",
+            "role": "compute"
+        }
+    },
+    "schema_version": "1.0"
+}
+#Version 2.14.2 (git commit 09f0772835afdc0f962c9e7fe8cef862e9505ad7, built Tue Jun 19 01:58:56 EDT 2018)

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.yaml
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.yaml
@@ -1,0 +1,35 @@
+osimage:
+  test.environments.osimage:
+    basic_attributes:
+      arch: ppc64le
+      distribution: rhels7.5-alternate
+      osdistro: rhels7.5-alternate-ppc64le
+      osname: Linux
+    deprecated:
+      comments: rhels7.5,test_environment_variables
+    filestosync:
+    - '{{GITREPO}}/syncfiles/synclist'
+    genimgoptions:
+      permission: '755'
+      postinstall:
+      - /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.postinstall
+      - '{{GITREPO}}/postinstall/test1.postinstall'
+      rootimgdir: /install/custom/test.environments.osimage
+    imagetype: linux
+    package_selection:
+      otherpkgdir:
+      - '{{SWDIR}}/otherpkgdir/'
+      otherpkglist:
+      - '{{GITREPO}}/otherpkglist/test1.otherpkglist'
+      - '{{GITREPO}}/otherpkglist/test2.otherpkglist'
+      - ''
+      pkgdir:
+      - /install/rhels7.5-alternate/ppc64le
+      - '{{SWDIR}}/pkgdir/'
+      pkglist:
+      - /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist
+      - '{{GITREPO}}/pkglist/test1.pkglist'
+      - '{{GITREPO}}/pkglist/test2.pkglist'
+    provision_mode: netboot
+    role: compute
+schema_version: '1.0'


### PR DESCRIPTION
Case Name:export_osimage_with_environments
description:this case is to verify if osimage export could support environment variables.

UT result
```
xCAT automated test started at Tue Jul  3 05:42:50 2018
******************************
loading Configure file
******************************
Varible:
    CN = mid08tor03cn01
    ISO = /mnt/xcat/iso/redhat/7.5/GA/RHEL-7.5-20180322.0-Server-ppc64le-dvd1.iso
    MN = boston02
******************************
Initialize xCAT test environment by definition in configure file
******************************
******************************
To detect current test environment
******************************
Detecting: OS = linux
Detecting: ARCH = ppc64le
Detecting: HCP = openbmc
******************************
loading test cases
******************************
To run:
export_osimage_with_environments
******************************
Start to run test cases
******************************
------START::export_osimage_with_environments::Time:Tue Jul  3 05:42:52 2018------

RUN:lsdef -t osimage -o test.environments.osimage >/dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t osimage -o test.environments.osimage -z >/tmp/test.environments.osimage_image.stanza ;rmdef -t osimage -o test.environments.osimage;fi [Tue Jul  3 05:42:52 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:export GITREPO="/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo";export SWDIR="/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir";xcat-inventory import -f /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.yaml [Tue Jul  3 05:42:53 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
set(['GITREPO', 'SWDIR'])
Importing object: test.environments.osimage
Inventory import successfully!
CHECK:output =~ Importing object: test.environments.osimage	[Pass]
CHECK:output =~ Inventory import successfully!	[Pass]
CHECK:rc == 0	[Pass]

RUN:lsdef -t osimage -o test.environments.osimage [Tue Jul  3 05:42:54 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Object name: test.environments.osimage
    environvar=GITREPO=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo,SWDIR=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir
    imagetype=linux
    osarch=ppc64le
    osdistroname=rhels7.5-alternate-ppc64le
    osname=Linux
    osvers=rhels7.5-alternate
    otherpkgdir=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir/otherpkgdir/
    otherpkglist=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/otherpkglist/test1.otherpkglist,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/otherpkglist/test2.otherpkglist,
    permission=755
    pkgdir=/install/rhels7.5-alternate/ppc64le,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir/pkgdir/
    pkglist=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/pkglist/test1.pkglist,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/pkglist/test2.pkglist
    postinstall=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.postinstall,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/postinstall/test1.postinstall
    profile=compute
    provmethod=netboot
    rootimgdir=/install/custom/test.environments.osimage
    synclists=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/syncfiles/synclist
    usercomment=rhels7.5,test_environment_variables
CHECK:rc == 0	[Pass]

RUN:dir="/tmp/export";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi; mkdir -p $dir [Tue Jul  3 05:42:55 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:xcat-inventory export  -t osimage -o test.environments.osimage -f /tmp/export/test.environments.osimage.yaml --format yaml [Tue Jul  3 05:42:55 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
The inventory data has been dumped to /tmp/export/test.environments.osimage.yaml
CHECK:rc == 0	[Pass]
CHECK:output =~ The inventory data has been dumped to /tmp/export/test.environments.osimage.yaml	[Pass]

RUN:diff -y  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.yaml /tmp/export/test.environments.osimage.yaml --ignore-blank-lines  -I "^#" [Tue Jul  3 05:42:56 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
osimage:							osimage:
  test.environments.osimage:					  test.environments.osimage:
    basic_attributes:						    basic_attributes:
      arch: ppc64le						      arch: ppc64le
      distribution: rhels7.5-alternate				      distribution: rhels7.5-alternate
      osdistro: rhels7.5-alternate-ppc64le			      osdistro: rhels7.5-alternate-ppc64le
      osname: Linux						      osname: Linux
    deprecated:							    deprecated:
      comments: rhels7.5,test_environment_variables		      comments: rhels7.5,test_environment_variables
    filestosync:						    filestosync:
    - '{{GITREPO}}/syncfiles/synclist'				    - '{{GITREPO}}/syncfiles/synclist'
    genimgoptions:						    genimgoptions:
      permission: '755'						      permission: '755'
      postinstall:						      postinstall:
      - /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64l	      - /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64l
      - '{{GITREPO}}/postinstall/test1.postinstall'		      - '{{GITREPO}}/postinstall/test1.postinstall'
      rootimgdir: /install/custom/test.environments.osimage	      rootimgdir: /install/custom/test.environments.osimage
    imagetype: linux						    imagetype: linux
    package_selection:						    package_selection:
      otherpkgdir:						      otherpkgdir:
      - '{{SWDIR}}/otherpkgdir/'				      - '{{SWDIR}}/otherpkgdir/'
      otherpkglist:						      otherpkglist:
      - '{{GITREPO}}/otherpkglist/test1.otherpkglist'		      - '{{GITREPO}}/otherpkglist/test1.otherpkglist'
      - '{{GITREPO}}/otherpkglist/test2.otherpkglist'		      - '{{GITREPO}}/otherpkglist/test2.otherpkglist'
      - ''							      - ''
      pkgdir:							      pkgdir:
      - /install/rhels7.5-alternate/ppc64le			      - /install/rhels7.5-alternate/ppc64le
      - '{{SWDIR}}/pkgdir/'					      - '{{SWDIR}}/pkgdir/'
      pkglist:							      pkglist:
      - /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64l	      - /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64l
      - '{{GITREPO}}/pkglist/test1.pkglist'			      - '{{GITREPO}}/pkglist/test1.pkglist'
      - '{{GITREPO}}/pkglist/test2.pkglist'			      - '{{GITREPO}}/pkglist/test2.pkglist'
    provision_mode: netboot					    provision_mode: netboot
    role: compute						    role: compute
schema_version: '1.0'						schema_version: '1.0'
							      )
							      )	#Version 2.14.2 (git commit 09f0772835afdc0f962c9e7fe8cef862e
CHECK:rc == 0	[Pass]

RUN:rmdef -t osimage -o test.environments.osimage [Tue Jul  3 05:42:56 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:export GITREPO="/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo";export SWDIR="/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir";xcat-inventory import -f /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json [Tue Jul  3 05:42:57 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
set(['GITREPO', 'SWDIR'])
Importing object: test.environments.osimage
Inventory import successfully!
CHECK:output =~ Importing object: test.environments.osimage	[Pass]
CHECK:output =~ Inventory import successfully!	[Pass]
CHECK:rc == 0	[Pass]

RUN:lsdef -t osimage -o test.environments.osimage [Tue Jul  3 05:42:58 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Object name: test.environments.osimage
    environvar=GITREPO=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo,SWDIR=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir
    imagetype=linux
    osarch=ppc64le
    osdistroname=rhels7.5-alternate-ppc64le
    osname=Linux
    osvers=rhels7.5-alternate
    otherpkgdir=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir/otherpkgdir/
    otherpkglist=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/otherpkglist/test1.otherpkglist,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/otherpkglist/test2.otherpkglist,
    permission=755
    pkgdir=/install/rhels7.5-alternate/ppc64le,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir/pkgdir/
    pkglist=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/pkglist/test1.pkglist,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/pkglist/test2.pkglist
    postinstall=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.postinstall,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/postinstall/test1.postinstall
    profile=compute
    provmethod=netboot
    rootimgdir=/install/custom/test.environments.osimage
    synclists=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/syncfiles/synclist
    usercomment=rhels7.5,test_environment_variables
CHECK:rc == 0	[Pass]

RUN:xcat-inventory export  -t osimage -o test.environments.osimage -f /tmp/export/test.environments.osimage.json [Tue Jul  3 05:42:58 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
The inventory data has been dumped to /tmp/export/test.environments.osimage.json
CHECK:rc == 0	[Pass]

RUN:diff -y  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json /tmp/export/test.environments.osimage.json --ignore-blank-lines  -I "^#" [Tue Jul  3 05:43:00 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
{								{
    "osimage": {						    "osimage": {
        "test.environments.osimage": {				        "test.environments.osimage": {
            "basic_attributes": {				            "basic_attributes": {
                "arch": "ppc64le",				                "arch": "ppc64le",
                "distribution": "rhels7.5-alternate",		                "distribution": "rhels7.5-alternate",
                "osdistro": "rhels7.5-alternate-ppc64le",	                "osdistro": "rhels7.5-alternate-ppc64le",
                "osname": "Linux"				                "osname": "Linux"
            },							            },
            "deprecated": {					            "deprecated": {
                "comments": "rhels7.5,test_environment_variab	                "comments": "rhels7.5,test_environment_variab
            },							            },
            "filestosync": [					            "filestosync": [
                "{{GITREPO}}/syncfiles/synclist"		                "{{GITREPO}}/syncfiles/synclist"
            ],							            ],
            "genimgoptions": {					            "genimgoptions": {
                "permission": "755",				                "permission": "755",
                "postinstall": [				                "postinstall": [
                    "/opt/xcat/share/xcat/netboot/rh/compute.	                    "/opt/xcat/share/xcat/netboot/rh/compute.
                    "{{GITREPO}}/postinstall/test1.postinstal	                    "{{GITREPO}}/postinstall/test1.postinstal
                ],						                ],
                "rootimgdir": "/install/custom/test.environme	                "rootimgdir": "/install/custom/test.environme
            },							            },
            "imagetype": "linux",				            "imagetype": "linux",
            "package_selection": {				            "package_selection": {
                "otherpkgdir": [				                "otherpkgdir": [
                    "{{SWDIR}}/otherpkgdir/"			                    "{{SWDIR}}/otherpkgdir/"
                ],						                ],
                "otherpkglist": [				                "otherpkglist": [
                    "{{GITREPO}}/otherpkglist/test1.otherpkgl	                    "{{GITREPO}}/otherpkglist/test1.otherpkgl
                    "{{GITREPO}}/otherpkglist/test2.otherpkgl	                    "{{GITREPO}}/otherpkglist/test2.otherpkgl
                    ""						                    ""
                ],						                ],
                "pkgdir": [					                "pkgdir": [
                    "/install/rhels7.5-alternate/ppc64le",	                    "/install/rhels7.5-alternate/ppc64le",
                    "{{SWDIR}}/pkgdir/"				                    "{{SWDIR}}/pkgdir/"
                ],						                ],
                "pkglist": [					                "pkglist": [
                    "/opt/xcat/share/xcat/netboot/rh/compute.	                    "/opt/xcat/share/xcat/netboot/rh/compute.
                    "{{GITREPO}}/pkglist/test1.pkglist",	                    "{{GITREPO}}/pkglist/test1.pkglist",
                    "{{GITREPO}}/pkglist/test2.pkglist"		                    "{{GITREPO}}/pkglist/test2.pkglist"
                ]						                ]
            },							            },
            "provision_mode": "netboot",			            "provision_mode": "netboot",
            "role": "compute"					            "role": "compute"
        }							        }
    },								    },
    "schema_version": "1.0"					    "schema_version": "1.0"
}								}
#Version 2.14.2 (git commit 09f0772835afdc0f962c9e7fe8cef862e	#Version 2.14.2 (git commit 09f0772835afdc0f962c9e7fe8cef862e
CHECK:rc == 0	[Pass]

RUN:dir="/tmp/export"; rm -rf $dir; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi [Tue Jul  3 05:43:00 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:rmdef -t osimage -o test.environments.osimage [Tue Jul  3 05:43:00 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:if [ -e /tmp/test.environments.osimage.stanza ]; then cat /tmp/test.environments.osimage.stanza |mkdef -z;fi [Tue Jul  3 05:43:00 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::export_osimage_with_environments::Passed::Time:Tue Jul  3 05:43:00 2018 ::Duration::8 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished at Tue Jul  3 05:43:00 2018
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20180703054250 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20180703054250 file for time consumption
```