### PR TITLE
Add labels for all hardware control test case

### DIFF
--- a/xCAT-test/autotest/testcase/UT_openbmc/reventlog_resolved_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/reventlog_resolved_cases0
@@ -2,6 +2,7 @@ start:reventlog_resolved_parse_error1
 description: Do not pass in any logs to clear
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:reventlog $$CN resolved
 check:rc==1
 check:output=~Error: (\[.*?\]: )?Usage error. Provide a comma separated
@@ -11,6 +12,7 @@ start:reventlog_resolved_parse_error2
 description: Do not pass in any logs to clear, include = sign
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:reventlog $$CN resolved=
 check:rc==1
 check:output=~Error: (\[.*?\]: )?Usage error. Provide a comma separated
@@ -20,6 +22,7 @@ start:reventlog_resolved_parse_error3
 description: forgot the = sign
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:reventlog $$CN resolved 1,2,3
 check:rc==1
 check:output=~Error: (\[.*?\]: )?Usage error. Provide a comma separated
@@ -29,6 +32,7 @@ start:reventlog_resolved_parse_error4
 description: Pass in a negative number
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:reventlog $$CN resolved=-1
 check:rc==1
 check:output=~Error: (\[.*?\]: )?Invalid ID=
@@ -38,6 +42,7 @@ start:reventlog_resolved_parse_error5
 description: Pass in a string
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:reventlog $$CN resolved=abc
 check:rc==1
 check:output=~Error: (\[.*?\]: )?Invalid ID=
@@ -47,6 +52,7 @@ start:reventlog_resolved_list
 description: Pass in a list of ids
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:reventlog $$CN resolved=100,101
 check:rc==0
 check:output=~Attempting to resolve the following log entries: 100,101...
@@ -56,6 +62,7 @@ start:reventlog_resolved_LED
 description: Pass in a LED keyword
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:reventlog $$CN resolved=Led
 check:rc==0
 check:output=~Attempting to resolve the following log entries: Led...

--- a/xCAT-test/autotest/testcase/UT_openbmc/rflash_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rflash_cases0
@@ -2,6 +2,7 @@ start:rflash_check
 description: Make sure the --check option works
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN --check
 check:rc==0
 check:output=~$$CN: BMC Firmware Product
@@ -12,6 +13,7 @@ start:rflash_invalid_activate
 description: Provide an invalid option for activte, file does not end in .tar
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd: rflash $$CN -a /tmp/abc123.tz
 check:rc==1
 check:output=~Error: (\[.*?\]: )?Invalid firmware specified with -a
@@ -21,6 +23,7 @@ start:rflash_invalid_activate_and_delete
 description: Cannot specify -a and --delete at the same time
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd: rflash $$CN -a 123 --delete 123
 check:rc==1
 check:output=~Error: (\[.*?\]: )?Multiple options are not supported
@@ -30,6 +33,7 @@ start:rflash_invalid_id
 description: Passing an invalid ID to activate
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd: rflash $$CN -a 123
 check:rc==1
 check:output=~Error: (\[.*?\]: )?Invalid ID provided to activate
@@ -39,6 +43,7 @@ start:rflash_invalid_multiple_id_3
 description: Code does not currently support multiple IDs to activate
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd: rflash $$CN -a 123 abc asdbas 
 check:rc==1
 check:output=~Error: (\[.*?\]: )?More than one firmware specified is not supported
@@ -48,6 +53,7 @@ start:rflash_invalid_multiple_id_2
 description: Code does not currently support multiple IDs to activate
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd: rflash $$CN -a asdbas 123
 check:rc==1
 check:output=~Error: (\[.*?\]: )?More than one firmware specified is not supported
@@ -57,6 +63,7 @@ start:rflash_invalid_node
 description: Activate a valid ID hash but forget to put in a node range 
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd: rflash -a 221d9020
 check:rc==1 
 check:output=~Error: (\[.*?\]: )?Invalid nodes and/or groups in noderange: 221d9020
@@ -66,6 +73,7 @@ start:rflash_invalid_delete_2
 description: Attempt to delete more than 1 ID from the FW
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd: rflash $$CN --delete 221d9020 221d9020
 check:rc==1 
 check:output=~Error: (\[.*?\]: )?More than one firmware specified is not supported
@@ -75,6 +83,7 @@ start:rflash_delete_active_bmc
 description: Attempt to delete the active BMC firmware
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd: rflash $$CN -l | grep \* | grep BMC | awk '{print $2}' | xargs -i{} rflash $$CN --delete {}
 check:rc==1
 check:output=~$$CN: (\[.*?\]: )?Error: Deleting currently active BMC firmware is not supported

--- a/xCAT-test/autotest/testcase/UT_openbmc/rinv_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rinv_cases0
@@ -1,6 +1,7 @@
 start:rinv_record_firmware_level
 description: Record the firmware level for the start of each testcase
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd: rinv $$CN firm
 check:rc==0
 end
@@ -8,6 +9,7 @@ end
 start:rinv_check_active_fw_count
 description: Ensure that there is only 2 active firmware, one for bmc and one for pnor
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd: rinv $$CN firm | tee /tmp/xcattest.rinv_check_active_fw_count.output
 check:rc==0
 cmd: grep -i ibm /tmp/xcattest.rinv_check_active_fw_count.output | grep -i 'HOST Firmware Product' | grep -i 'Active)\*' | wc -l
@@ -23,6 +25,7 @@ end
 start:rinv_check_active_fw_count_verbose
 description: Ensure that there is only 2 active firmware, one for bmc and one for pnor (in verbose mode) (Issue #4236)
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd: rinv $$CN firm -V | tee /tmp/xcattest.rinv_check_active_fw_count_verbose.output
 check:rc==0
 cmd: grep -i ibm /tmp/xcattest.rinv_check_active_fw_count_verbose.output| grep -i 'HOST Firmware Product' | grep -i 'Active)\*' | wc -l

--- a/xCAT-test/autotest/testcase/UT_openbmc/rspconfig_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rspconfig_cases0
@@ -1,6 +1,7 @@
 start:rspconfig_record_firmware_level
 description: Record the firmware level for the start of each testcase
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd: rinv $$CN firm
 check:rc==0
 end
@@ -9,6 +10,7 @@ start:rspconfig_get_all
 description: Check that we can get all the attributes from the BMC 
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN ip netmask gateway hostname vlan
 check:rc==0
 check:output=~$$CN: BMC IP:
@@ -21,6 +23,7 @@ end
 start:rspconfig_get_all_error
 description: Check the parsing code for rspconfig (error cases) 
 hcp: openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd: rspconfig $$CN ip,netmask,gateway,hostname,vlan
 check:rc==1
 check:output=~Error: (\[.*?\]: )?Unsupported command
@@ -29,6 +32,7 @@ end
 start:rspconfig_get_set_error
 description: Check the parsing code for rspconfig (error cases) - Cannot get/set in same line
 hcp: openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd: rspconfig $$CN ip netmask=255.0.0.0
 check:rc==1
 check:output=~Error: (\[.*?\]: )?Can not set and query OpenBMC information at the same time
@@ -38,6 +42,7 @@ start:rspconfig_get_and_set_hostname
 description: Test setting and getting hostname on the BMC 
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 # Save the hostname to a file.... 
 cmd:rspconfig $$CN hostname | tee /tmp/xcattest.rspconfig.hostname
 check:rc==0

--- a/xCAT-test/autotest/testcase/UT_openbmc/supported_commands_case0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/supported_commands_case0
@@ -2,6 +2,7 @@ start:supported_cmds_rpower
 description: Make sure the rpower command works ...
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rpower $$CN state
 check:rc==0
 check:output=~$$CN: 
@@ -14,6 +15,7 @@ start:supported_cmds_rinv
 description: Make sure that the rinv command works...
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd: rinv $$CN
 check:rc==0
 check:output=~$$CN:
@@ -39,6 +41,7 @@ start:supported_cmds_rvitals
 description: Make sure that the rvitals command works...
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd: rvitals $$CN
 check:rc==0
 check:output=~$$CN:
@@ -71,6 +74,7 @@ start:supported_cmds_rbeacon
 description: Make sure the rbeacon command works ...
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rbeacon $$CN on
 check:rc==0
 check:output=~$$CN: on 
@@ -83,6 +87,7 @@ start:supported_cmds_reventlog
 description: Make sure the reventlog command works ...
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:reventlog $$CN
 check:rc==0
 check:output=~$$CN:
@@ -98,6 +103,7 @@ start:supported_cmds_rflash
 description: Make sure the rflash command works ...
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN -c
 check:rc==0
 check:output=~$$CN: BMC Firmware Product:
@@ -111,6 +117,7 @@ start:supported_cmds_rsetboot
 description: Make sure the rsetboot command works ...
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rsetboot $$CN stat
 check:rc==0
 check:output=~$$CN:
@@ -120,6 +127,7 @@ start:supported_cmds_rspconfig
 description: Make sure the rspconfig command works ...
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN ipsrc
 check:rc==0
 check:output=~$$CN: BMC IP Source:

--- a/xCAT-test/autotest/testcase/rbeacon/cases0
+++ b/xCAT-test/autotest/testcase/rbeacon/cases0
@@ -2,6 +2,7 @@ start:rbeacon_null
 description: this case is to test rbeacon usage
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rbeacon
 check:rc==0
 check:output=~Usage
@@ -11,6 +12,7 @@ start:rbeacon_stat
 description: this case is to test rbeacon CN stat
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rbeacon $$CN stat
 check:rc==0
 check:output=~$$CN\s*:\s*Front:Off Rear:Off|Front:On Rear:On|Front:Off Rear:On|Front:On Rear:Off|Front:Blink Rear:Blink 
@@ -20,6 +22,7 @@ start:rbeacon_help
 description: this case is to test rbeacon -h and --help output 
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rbeacon -h
 check:rc==0
 check:output=~Usage
@@ -34,6 +37,7 @@ start:rbeacon_version
 description: this case is to test rbeacon -v and --version output
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rbeacon -v
 check:rc==0
 check:output=~Version
@@ -48,6 +52,7 @@ start:rbeacon_false
 description: this case is to test rbeacon could process false input 
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rbeacon $$CN abc
 check:rc!=0
 check:output=~$$CN\s*:\s*Error:\s*Only \'on\', \'off\' or \'stat\' is supported

--- a/xCAT-test/autotest/testcase/rbeacon/cases0
+++ b/xCAT-test/autotest/testcase/rbeacon/cases0
@@ -2,7 +2,7 @@ start:rbeacon_null
 description: this case is to test rbeacon usage
 os:Linux
 hcp:openbmc
-label:cn_bmc_ready,hctrl_openbmc
+label:mn_only,hctrl_openbmc
 cmd:rbeacon
 check:rc==0
 check:output=~Usage
@@ -22,7 +22,7 @@ start:rbeacon_help
 description: this case is to test rbeacon -h and --help output 
 os:Linux
 hcp:openbmc
-label:cn_bmc_ready,hctrl_openbmc
+label:mn_only,hctrl_openbmc
 cmd:rbeacon -h
 check:rc==0
 check:output=~Usage
@@ -37,7 +37,7 @@ start:rbeacon_version
 description: this case is to test rbeacon -v and --version output
 os:Linux
 hcp:openbmc
-label:cn_bmc_ready,hctrl_openbmc
+label:mn_only,hctrl_openbmc
 cmd:rbeacon -v
 check:rc==0
 check:output=~Version

--- a/xCAT-test/autotest/testcase/reventlog/cases0
+++ b/xCAT-test/autotest/testcase/reventlog/cases0
@@ -1,22 +1,26 @@
 start:reventlog_null
+label:cn_bmc_ready,hctrl_gen
 cmd:reventlog
 check:rc==0
 check:output=~Usage
 end
 
 start:reventlog_all
+label:cn_bmc_ready,hctrl_gen
 cmd:reventlog $$CN all
 check:rc==0
 check:output=~$$CN\s*:\s*.*\d\d/\d\d/\d\d\s*\S+|No attributes returned from the BMC
 end
 
 start:reventlog_clear
+label:cn_bmc_ready,hctrl_gen
 cmd:reventlog $$CN clear
 check:rc==0
 check:output=~$$CN\s*:\s*Logs cleared|SEL cleared
 end
 
 start:reventlog_numofentries
+label:cn_bmc_ready,hctrl_gen
 cmd:reventlog $$CN 5
 check:rc==0
 check:output=~$$CN\s*:\s*.*\d\d/\d\d/\d\d\s*\S+|$$CN: no SEL entries|Entry|No attributes returned from the BMC 
@@ -26,6 +30,7 @@ start:reventlog_s_openbmc
 description: For openbmc, reventlog has dropped option s
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:reventlog $$CN 10 -s
 check:output=~The -s option is not supported for OpenBMC
 check:rc!=0

--- a/xCAT-test/autotest/testcase/reventlog/cases0
+++ b/xCAT-test/autotest/testcase/reventlog/cases0
@@ -1,26 +1,26 @@
 start:reventlog_null
-label:cn_bmc_ready,hctrl_gen
+label:mn_only,hctrl_general
 cmd:reventlog
 check:rc==0
 check:output=~Usage
 end
 
 start:reventlog_all
-label:cn_bmc_ready,hctrl_gen
+label:cn_bmc_ready,hctrl_general
 cmd:reventlog $$CN all
 check:rc==0
 check:output=~$$CN\s*:\s*.*\d\d/\d\d/\d\d\s*\S+|No attributes returned from the BMC
 end
 
 start:reventlog_clear
-label:cn_bmc_ready,hctrl_gen
+label:cn_bmc_ready,hctrl_general
 cmd:reventlog $$CN clear
 check:rc==0
 check:output=~$$CN\s*:\s*Logs cleared|SEL cleared
 end
 
 start:reventlog_numofentries
-label:cn_bmc_ready,hctrl_gen
+label:cn_bmc_ready,hctrl_general
 cmd:reventlog $$CN 5
 check:rc==0
 check:output=~$$CN\s*:\s*.*\d\d/\d\d/\d\d\s*\S+|$$CN: no SEL entries|Entry|No attributes returned from the BMC 

--- a/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
+++ b/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
@@ -2,6 +2,7 @@ start:rflash_option_c_without_specify_noderange
 description: basic usage check for option c. if without specify noderange for rflash command, should offer usage message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash -c
 check:output=~Usage:
 cmd:rflash -c 1.tar
@@ -13,6 +14,7 @@ start:rflash_option_l_without_specify_noderange
 description: basic usage check for option l. if without specify noderange for rflash command, should offer usage message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash -l
 check:output=~Usage:
 end
@@ -21,6 +23,7 @@ start:rflash_option_a_without_specify_noderange
 description: basic usage check for option a. if without specify noderange for rflash command, should offer usage message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash -a
 check:output=~Usage:
 cmd:rflash -a 1.tar
@@ -35,6 +38,7 @@ start:rflash_option_u_without_specify_noderange
 description: basic usage check for option u. if without specify noderange for rflash command, should offer usage message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash -u
 check:output=~Usage:
 cmd:rflash -u  1.tar
@@ -46,6 +50,7 @@ start:rflash_option_d_without_specify_noderange
 description: basic usage check for option d. if without specify noderange for rflash command, should offer usage message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash -d
 check:output=~Usage:
 cmd:rflash -d /1234
@@ -59,6 +64,7 @@ start:rflash_without_option
 description: basic usage check, if without option, should throw out a error
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN 1.tar
 check:rc != 0
 check:output=~Error: (\[.*?\]: )?Invalid option specified when a file is provided:
@@ -68,6 +74,7 @@ start:rflash_unsupport_multiple_option_a_u
 description: basic usage check. If specify multiple options a+u, should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN -a 1.tz -u
 check:output=~Error: (\[.*?\]: )?Multiple options are not supported
 check:rc != 0
@@ -77,6 +84,7 @@ start:rflash_unsupport_multiple_option_a_c
 description: basic usage check. If specify multiple options a+c, should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN -a 1.tz -c
 check:output=~Error: (\[.*?\]: )?Multiple options are not supported
 check:rc != 0
@@ -86,6 +94,7 @@ start:rflash_unsupport_multiple_option_a_l
 description: basic usage check. If specify multiple options a+l, should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN -a 1.tz -l
 check:output=~Error: (\[.*?\]: )?Multiple options are not supported
 check:rc != 0
@@ -95,6 +104,7 @@ start:rflash_unsupport_multiple_option_a_d
 description: basic usage check. If specify multiple options a+d, should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN -a 1.tz -d
 check:output=~Error: (\[.*?\]: )?Multiple options are not supported
 check:rc != 0
@@ -104,6 +114,7 @@ start:rflash_unsupport_multiple_option_c_l
 description: basic usage check. If specify multiple options c+l, should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN -c 1.tz -l
 check:output=~Error: (\[.*?\]: )?Multiple options are not supported
 check:rc != 0
@@ -113,6 +124,7 @@ start:rflash_unsupport_multiple_option_c_u
 description: basic usage check. If specify multiple options c+u, should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN -c 1.tz -u
 check:output=~Error: (\[.*?\]: )?Multiple options are not supported
 check:rc != 0
@@ -122,6 +134,7 @@ start:rflash_unsupport_multiple_option_c_d
 description: basic usage check. If specify multiple options c+d, should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN -c 1.tz -d
 check:output=~Error: (\[.*?\]: )?Multiple options are not supported
 check:rc != 0
@@ -131,6 +144,7 @@ start:rflash_unsupport_multiple_option_l_d
 description: basic usage check. If specify multiple options l+d, should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN -l -d
 check:output=~Error: (\[.*?\]: )?Multiple options are not supported
 check:rc != 0
@@ -140,6 +154,7 @@ start:rflash_unsupport_multiple_option_l_u
 description: basic usage check. If specify multiple options l+u, should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN -l -u
 check:output=~Error: (\[.*?\]: )?Multiple options are not supported
 check:rc != 0
@@ -149,6 +164,7 @@ start:rflash_unsupport_multiple_option_u_d
 description: basic usage check. If specify multiple options u+d, should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN -u -d
 check:output=~Error: (\[.*?\]: )?Multiple options are not supported
 check:rc != 0
@@ -158,6 +174,7 @@ start:rflash_option_c_file_not_exist
 description: basic usage check for option c. if the file does not exist, should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN -c /tmp/abc123.tz
 check:output=~Error: (\[.*?\]: )?Invalid firmware specified with
 check:rc != 0
@@ -182,6 +199,7 @@ start:rflash_option_c_with_multiple_values
 description: basic usage check for option c. if there are multiple value assigned to c option,  should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN -c /tmp/abc123.tz /tmp/abc124.tz
 check:output=~Error: (\[.*?\]: )?Invalid firmware specified with
 check:rc != 0
@@ -200,6 +218,7 @@ start:rflash_option_c_against_node
 description:  Make sure the -c option against node works
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN -c |tee /tmp/rflash_option_c.output
 check:rc == 0
 cmd:grep -i ibm /tmp/rflash_option_c.output |grep -i 'HOST Firmware Product' | grep -i 'Active)\*' | wc -l
@@ -216,6 +235,7 @@ start:rflash_option_check_with_V_against_node
 description:  Make sure the --check option with V works
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN --check -V |tee /tmp/rflash_option_check_with_V.output
 check:rc == 0
 cmd:grep -i ibm /tmp/rflash_option_check_with_V.output |grep -i 'HOST Firmware Product' | grep -i 'Active)\*' | wc -l
@@ -233,6 +253,7 @@ start:rflash_option_l_with_value
 description: basic usage check for option l. if there is value for l option,  should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN -l /tmp/abc123.tz
 check:output=~Error: (\[.*?\]: )?Invalid option
 check:rc != 0
@@ -245,6 +266,7 @@ start:rflash_option_l
 description:  Make sure the -l option works
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN -l |tee /tmp/rflash_option_l.output
 check:rc == 0
 cmd:grep -i ' bmc ' /tmp/rflash_option_l.output | grep -i 'Active(\*)' | wc -l
@@ -262,6 +284,7 @@ start:rflash_option_u_file_not_exist
 description: basic usage check for option u. if the file does not exist, should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN -u /tmp/abc123.tz
 check:output=~Error: (\[.*?\]: )?Invalid firmware specified with
 check:output!~Attempting to
@@ -292,6 +315,7 @@ start:rflash_option_u_with_multiple_values
 description: basic usage check for option u. if there are multiple value assigned to u option,  should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN -u /tmp/abc123.tz /tmp/abc124.tz
 check:output=~Error: (\[.*?\]: )?Invalid firmware specified with
 check:output!~Attempting to
@@ -314,6 +338,7 @@ start:rflash_option_a_file_not_exist
 description: basic usage check for option a. if the file does not exist, should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN -a /tmp/abc123.tz
 check:output=~rror: Invalid firmware specified with
 check:output!~Attempting to 
@@ -344,6 +369,7 @@ start:rflash_option_a_with_multiple_values
 description: basic usage check for option a. if there are multiple value assigned to a option, should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN -a /tmp/abc123.tz /tmp/abc124.tz
 check:output=~Error: (\[.*?\]: )?Invalid firmware specified with
 check:output!~Attempting to
@@ -375,6 +401,7 @@ start:rflash_option_a_with_non_existent_id
 description: basic usage check for option a. if active a non-existent firmware ID, should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN -a 1234567
 check:output=~Error: (\[.*?\]: )?Invalid ID provided to activate
 check:rc != 0
@@ -387,6 +414,7 @@ start:rflash_option_delete_with_multiple_values
 description: basic usage check for option delete. if there are multiple value assigned to delete option, should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN --delete 1234567 2345678 
 check:output=~Error: (\[.*?\]: )?More than one firmware specified is not supported
 check:output!~Attempting to delete
@@ -405,6 +433,7 @@ start:rflash_option_delete_with_non_existent_id
 description: basic usage check for option --delete. if delete a non-existent firmware ID, should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN --delete 1234567
 check:output=~Error: (\[.*?\]: )?Invalid ID provided to delete
 check:rc != 0
@@ -417,6 +446,7 @@ start:rflash_option_d_with_multiple_values
 description: basic usage check for option d. if there are multiple value assigned to d option, should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash $$CN -d /123/   /234/
 check:output=~Error: (\[.*?\]: )?More than one
 check:output!~Attempting to 
@@ -436,6 +466,7 @@ start:rflash_option_d_with_non_existent_dir
 description: basic usage check for option -d. if try to oprate non-existent dir by d option, should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rm -rf /tmp/bogus123
 check:rc == 0
 cmd:rflash $$CN -d /tmp/bogus123 
@@ -471,6 +502,7 @@ start:rflash_usage
 description:checke the usage of rflash for openbmc
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rflash -h
 check:output =~Usage:
 check:output =~OpenPOWER OpenBMC specific:
@@ -483,6 +515,7 @@ start:rflash_delete_no_active
 description:this case is to check if --delete is not allowed to be used for the active state firmware. This case is for issue 4770.
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:activenum=`rflash $$CN -l |grep -w "Host\s*Active(\*)" |awk '{print $2}'`;rflash $$CN $activenum --delete
 check:rc != 0
 check:output =~$$CN\s*:\s*(\[.*?\]: )?Error: Deleting currently active firmware on powered on host is not supported 

--- a/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
+++ b/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
@@ -2,7 +2,7 @@ start:rflash_option_c_without_specify_noderange
 description: basic usage check for option c. if without specify noderange for rflash command, should offer usage message
 os:Linux
 hcp:openbmc
-label:cn_bmc_ready,hctrl_openbmc
+label:mn_only,hctrl_openbmc
 cmd:rflash -c
 check:output=~Usage:
 cmd:rflash -c 1.tar
@@ -14,7 +14,7 @@ start:rflash_option_l_without_specify_noderange
 description: basic usage check for option l. if without specify noderange for rflash command, should offer usage message
 os:Linux
 hcp:openbmc
-label:cn_bmc_ready,hctrl_openbmc
+label:mn_only,hctrl_openbmc
 cmd:rflash -l
 check:output=~Usage:
 end
@@ -23,7 +23,7 @@ start:rflash_option_a_without_specify_noderange
 description: basic usage check for option a. if without specify noderange for rflash command, should offer usage message
 os:Linux
 hcp:openbmc
-label:cn_bmc_ready,hctrl_openbmc
+label:mn_only,hctrl_openbmc
 cmd:rflash -a
 check:output=~Usage:
 cmd:rflash -a 1.tar
@@ -38,7 +38,7 @@ start:rflash_option_u_without_specify_noderange
 description: basic usage check for option u. if without specify noderange for rflash command, should offer usage message
 os:Linux
 hcp:openbmc
-label:cn_bmc_ready,hctrl_openbmc
+label:mn_only,hctrl_openbmc
 cmd:rflash -u
 check:output=~Usage:
 cmd:rflash -u  1.tar
@@ -50,11 +50,11 @@ start:rflash_option_d_without_specify_noderange
 description: basic usage check for option d. if without specify noderange for rflash command, should offer usage message
 os:Linux
 hcp:openbmc
-label:cn_bmc_ready,hctrl_openbmc
+label:mn_only,hctrl_openbmc
 cmd:rflash -d
 check:output=~Usage:
 cmd:rflash -d /1234
-check:Usage:
+check:output=~Usage:
 cmd:rflash --delete 1234abc
 check:rc != 0
 check:output=~Error: (\[.*?\]: )?Invalid nodes and/or groups in noderange
@@ -502,7 +502,7 @@ start:rflash_usage
 description:checke the usage of rflash for openbmc
 os:Linux
 hcp:openbmc
-label:cn_bmc_ready,hctrl_openbmc
+label:mn_only,hctrl_openbmc
 cmd:rflash -h
 check:output =~Usage:
 check:output =~OpenPOWER OpenBMC specific:

--- a/xCAT-test/autotest/testcase/rinv/cases0
+++ b/xCAT-test/autotest/testcase/rinv/cases0
@@ -7,7 +7,7 @@
 
 start:rinv_h
 description:show help information for rinv
-label:cn_bmc_ready,hctrl_gen
+label:mn_only,hctrl_general
 cmd:rinv -h
 check:rc==0
 check:output=~Usage
@@ -16,7 +16,7 @@ end
 
 start:rinv_help
 description:show help information for rinv
-label:cn_bmc_ready,hctrl_gen
+label:mn_only,hctrl_general
 cmd:rinv --help
 check:rc==0
 check:output=~Usage
@@ -25,7 +25,7 @@ end
 
 start:rinv_v
 description:show version for Version
-label:cn_bmc_ready,hctrl_gen
+label:mn_only,hctrl_general
 cmd:rinv -v
 check:rc==0
 check:output=~Version
@@ -54,7 +54,7 @@ end
 start:rinv_serial
 description:Retrieves serial number.
 Attribute: $$CN-The operation object of rinv command
-label:cn_bmc_ready,hctrl_gen
+label:cn_bmc_ready,hctrl_general
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rinv $$CN serial
 check:rc==0
 end
@@ -62,7 +62,7 @@ end
 start:rinv_model
 description:Retrieves serial number.
 Attribute: $$CN-The operation object of rinv command
-label:cn_bmc_ready,hctrl_gen
+label:cn_bmc_ready,hctrl_general
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rinv $$CN model
 check:rc==0
 end
@@ -70,7 +70,7 @@ end
 start:rinv_firm
 description:Retrieves firmware versions.
 Attribute: $$CN-The operation object of rinv command
-label:cn_bmc_ready,hctrl_gen
+label:cn_bmc_ready,hctrl_general
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rinv $$CN firm
 check:rc==0
 end
@@ -78,7 +78,7 @@ end
 start:rinv_all
 description:get serial,model
 Attribute: $$CN-The operation object of rinv command
-label:cn_bmc_ready,hctrl_gen
+label:cn_bmc_ready,hctrl_general
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rinv $$CN all
 check:rc==0
 end
@@ -118,7 +118,7 @@ check:rc==0
 end
 
 start:rinv_noderange_err
-label:cn_bmc_ready,hctrl_gen
+label:mn_only,hctrl_general
 cmd:rinv testnode
 check:rc!=0
 check:output=~Error
@@ -127,7 +127,7 @@ end
 start:rinv_mixnode
 description:get mixnode information,one is invalid node
 Attribute: $$CN-The operation object of rinv command
-label:cn_bmc_ready,hctrl_gen
+label:cn_bmc_ready,hctrl_general
 cmd:test=$(lsdef testnode);if [[ $? -eq 0 ]]; then lsdef -l testnode -z >/tmp/testnode.stanza ;rmdef testnode;fi
 check:rc==0
 cmd:chdef testnode groups=test mgt=__GETNODEATTR($$CN,mgt)__
@@ -160,7 +160,7 @@ end
 
 start:rinv_errorcommand
 description:get right return if input error command
-label:cn_bmc_ready,hctrl_gen
+label:cn_bmc_ready,hctrl_general
 cmd:rinv $$CN dafds
 check:rc==1
 check:output=~Unsupported command|Error: (\[.*?\]: )?Usage:

--- a/xCAT-test/autotest/testcase/rinv/cases0
+++ b/xCAT-test/autotest/testcase/rinv/cases0
@@ -4,22 +4,28 @@
 #check:rc!=0
 #check:output=~Usage
 #end
+
 start:rinv_h
 description:show help information for rinv
+label:cn_bmc_ready,hctrl_gen
 cmd:rinv -h
 check:rc==0
 check:output=~Usage
 check:output=~rinv
 end
+
 start:rinv_help
 description:show help information for rinv
+label:cn_bmc_ready,hctrl_gen
 cmd:rinv --help
 check:rc==0
 check:output=~Usage
 check:output=~rinv
 end
+
 start:rinv_v
 description:show version for Version
+label:cn_bmc_ready,hctrl_gen
 cmd:rinv -v
 check:rc==0
 check:output=~Version
@@ -28,76 +34,100 @@ end
 start:rinv_bus
 description:rinv list all buses for each I/O slot 
 Attribute: $$CN-The operation object of rinv command
+label:cn_bmc_ready,hctrl_fsp
 cmd:rinv $$CN bus
 check:rc==0
 check:output=~I/O Bus Information
 end
+
 start:rinv_config
 description:Retrieves number of processors, speed, total memory, and DIMM locations. 
 Attribute: $$CN-The operation object of rinv command
+label:cn_bmc_ready,hctrl_fsp
 cmd:rinv $$CN config
 check:rc==0
 check:output=~Machine Configuration Info
 check:output=~Number of Processors:\s*\d+
 check:output=~Total Memory \(\w+\):\s*\d+
 end
+
 start:rinv_serial
 description:Retrieves serial number.
 Attribute: $$CN-The operation object of rinv command
+label:cn_bmc_ready,hctrl_gen
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rinv $$CN serial
 check:rc==0
 end
+
 start:rinv_model
 description:Retrieves serial number.
 Attribute: $$CN-The operation object of rinv command
+label:cn_bmc_ready,hctrl_gen
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rinv $$CN model
 check:rc==0
 end
+
 start:rinv_firm
 description:Retrieves firmware versions.
 Attribute: $$CN-The operation object of rinv command
+label:cn_bmc_ready,hctrl_gen
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rinv $$CN firm
 check:rc==0
 end
+
 start:rinv_all
 description:get serial,model
 Attribute: $$CN-The operation object of rinv command
+label:cn_bmc_ready,hctrl_gen
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rinv $$CN all
 check:rc==0
 end
+
 start:rinv_cpu
 description:get cpu information
 Attribute: $$CN-The operation object of rinv command
+label:cn_bmc_ready,hctrl_openbmc
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rinv $$CN cpu
 check:rc==0
 end
+
 start:rinv_dimm
 description:get dimm information
 Attribute: $$CN-The operation object of rinv command
+hcp:openbmc
+arch:ppc64le
+label:cn_bmc_ready,hctrl_openbmc
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rinv $$CN dimm
 check:rc==0
 end
+
 start:rinv_uuid
 description:get uuid information
 Attribute: $$CN-The operation object of rinv command
+label:cn_bmc_ready,hctrl_openpower_ipmi
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rinv $$CN uuid
 check:rc==0
 end
+
 start:rinv_vpd
 description:get vpd information
 Attribute: $$CN-The operation object of rinv command
+label:cn_bmc_ready,hctrl_openpower_ipmi
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rinv $$CN vpd
 check:rc==0
 end
 
 start:rinv_noderange_err
+label:cn_bmc_ready,hctrl_gen
 cmd:rinv testnode
 check:rc!=0
 check:output=~Error
 end
+
 start:rinv_mixnode
 description:get mixnode information,one is invalid node
 Attribute: $$CN-The operation object of rinv command
+label:cn_bmc_ready,hctrl_gen
 cmd:test=$(lsdef testnode);if [[ $? -eq 0 ]]; then lsdef -l testnode -z >/tmp/testnode.stanza ;rmdef testnode;fi
 check:rc==0
 cmd:chdef testnode groups=test mgt=__GETNODEATTR($$CN,mgt)__
@@ -112,9 +142,11 @@ check:rc==0
 cmd:rmdef testnode;if [[ -e /tmp/testnode.stanza ]]; then cat /tmp/testnode.stanza | chdef -z;rm -rf /tmp/testnode.stanza;fi
 check:rc==0
 end
+
 start:rinv_wrongbmcpasswd
 description:get right return if bmc's passwd wrong
 Attribute: $$CN-The operation object of rinv command
+label:cn_bmc_ready,hctrl_openpower_ipmi,hctrl_fsp,hctrl_openbmc
 cmd:lsdef -l $$CN -z >/tmp/testnode.stanza
 check:rc==0
 cmd:chdef $$CN bmcpassword=test
@@ -125,8 +157,10 @@ check:output=~$$CN: (\[.*?\]: )?Error:.+Invalid username or password|Error: (\[.
 cmd:cat /tmp/testnode.stanza | chdef -z;rm -rf /tmp/testnode.stanza 
 check:rc==0
 end
+
 start:rinv_errorcommand
 description:get right return if input error command
+label:cn_bmc_ready,hctrl_gen
 cmd:rinv $$CN dafds
 check:rc==1
 check:output=~Unsupported command|Error: (\[.*?\]: )?Usage:

--- a/xCAT-test/autotest/testcase/rinv/cases2
+++ b/xCAT-test/autotest/testcase/rinv/cases2
@@ -2,6 +2,7 @@ start:rinv_mprom
 description:this case is to test mprom option for rinv on x86_64 servers.
 hcp:ipmi
 arch:x86_64
+label:cn_bmc_ready,hctrl_bmc_ipmi
 cmd:rinv $$CN mprom 
 check:rc==0
 check:output=~BMC Firmware:\s*\w+.\w+
@@ -11,6 +12,7 @@ start:rinv_guid
 description:this case is to test guid option for rinv on x86_64 servers.
 hcp:ipmi
 arch:x86_64
+label:cn_bmc_ready,hctrl_bmc_ipmi
 cmd:rinv $$CN guid 
 check:rc==0
 check:output=~UUID/GUID:\s*\w+-\w+-\w+-\w+-\w+
@@ -20,6 +22,7 @@ start:rinv_dimm
 description:this case is to test dimm option for rinv on x86_64 servers.
 hcp:ipmi
 arch:x86_64
+label:cn_bmc_ready,hctrl_bmc_ipmi
 cmd:rinv $$CN dimm
 check:rc==0
 check:output=~DIMM 1 :\s*\w+

--- a/xCAT-test/autotest/testcase/rpower/cases0
+++ b/xCAT-test/autotest/testcase/rpower/cases0
@@ -1,6 +1,7 @@
 start:rpower_off
 description:This case is to test off option could remote power off nodes 
 Attribute: $$CN-The operation object of rpower command
+label:cn_bmc_ready,hctrl_gen
 cmd:rpower $$CN on
 cmd:a=0;while ! `rpower $$CN stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 check:ouptut=~Running|on
@@ -14,6 +15,7 @@ end
 start:rpower_stat
 description:This case is to test stat option could show the power status of nodes
 Attribute: $$CN-The operation object of rpower command
+label:cn_bmc_ready,hctrl_gen
 cmd:rpower $$CN on
 cmd:a=0;while ! `rpower $$CN stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 5 ];then break;fi done
 cmd:rpower $$CN stat
@@ -35,6 +37,7 @@ end
 start:rpower_boot
 description:This case is to test boot option could power on the nodes if nodes in off state.  Or could  hard reset the nodes if they are on. 
 Attribute: $$CN-The operation object of rpower command
+label:cn_bmc_ready,hctrl_gen
 cmd:rpower $$CN off
 cmd:a=0;while ! `rpower $$CN stat|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$CN stat
@@ -49,6 +52,7 @@ end
 start:rpower_status
 description:This case is to test status option could show the power status of nodes
 Attribute: $$CN-The operation object of rpower command
+label:cn_bmc_ready,hctrl_gen
 cmd:rpower $$CN off
 cmd:a=0;while ! `rpower $$CN status|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$CN status
@@ -63,6 +67,7 @@ end
 start:rpower_state
 description:This case is to test state option could show the power status of nodes
 Attribute: $$CN-The operation object of rpower command
+label:cn_bmc_ready,hctrl_gen
 cmd:rpower $$CN off
 cmd:a=0;while ! `rpower $$CN state|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$CN state
@@ -77,6 +82,7 @@ end
 start:rpower_on
 description:This case is to test on option could remote power on nodes
 Attribute: $$CN-The operation object of rpower command
+label:cn_bmc_ready,hctrl_gen
 cmd:rpower $$CN off
 cmd:a=0;while ! `rpower $$CN stat|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$CN stat
@@ -91,6 +97,7 @@ end
 start:rpower_reset
 description:This case is to test reset option could hard reset nodes when nodes are in on state.
 Attribute: $$CN-The operation object of rpower command
+label:cn_bmc_ready,hctrl_gen
 cmd:stat=`rpower $$CN stat`;if ([[ $stat =~ on ]] || [[ $stat =~ Running ]]) ;then rpower $$CN reset;sleep 300;stat1=`rpower $$CN stat`;if ([[ $stat1 =~ on ]] || [[ $stat1 =~ Running ]]);then exit 0;else exit 1;fi;else rpower $$CN reset;sleep 300;stat1=`rpower $$CN stat`;if ([[ $stat1 =~ off ]] || [[ $stat1 =~ "Not Activated" ]]);then exit 0;else exit 1;fi;fi
 check:rc==0
 end
@@ -98,6 +105,7 @@ end
 start:rpower_noderange
 description:This case is to test rpower could process error usage and return help information.
 Attribute: $$CN-The operation object of rpower command
+label:cn_bmc_ready,hctrl_gen
 cmd:rpower $$CN
 check:rc!=0
 check:output=~Unsupported|Usage|Please enter an action
@@ -106,6 +114,7 @@ end
 start:rpower_noderange_nodeps
 description:This case is to test rpower could process error usage and return help information.
 Attribute: $$CN-The operation object of rpower command
+label:cn_bmc_ready,hctrl_gen
 cmd:rpower $$CN --nodeps
 check:rc!=0
 check:output=~Unsupported|Usage
@@ -114,6 +123,7 @@ end
 start:rpower_err_noderange
 description:This case is to test rpower could process error usage and return help information.
 Attribute:N/A 
+label:cn_bmc_ready,hctrl_gen
 cmd:rpower testnode stat
 check:rc!=0
 check:output=~Error
@@ -122,6 +132,7 @@ end
 start:rpower_softoff
 description:This case is to test softoff option could remote shutdown nodes 
 Attribute: $$CN-The operation object of rpower command
+label:cn_bmc_ready,hctrl_fsp,hctrl_openbmc
 cmd:rpower $$CN on
 cmd:a=0;while ! `rpower $$CN stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 check:ouptut=~Running|on
@@ -135,6 +146,7 @@ end
 start:rpower_onstandby
 description:This case is to test onstandby option could bring server to standby state 
 Attribute: $$CN-The operation object of rpower command
+label:cn_bmc_ready,hctrl_fsp
 arch:ppc64
 cmd:rpower $$CN off
 check:rc==0
@@ -149,6 +161,7 @@ end
 start:rpower_wrongpasswd
 description:rpower ipmi and openbmc using wrong passwd  
 Attribute: $$CN-The operation object of rpower command
+label:cn_bmc_ready,hctrl_openpower_ipmi
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rpower/rpower_wrongpasswd_test.sh  -pt $$CN  $$bmcpasswd $$bmcusername
 check:rc==0
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rpower/rpower_wrongpasswd_test.sh  -c $$CN 
@@ -161,6 +174,7 @@ end
 
 start:rpower_suspend_OpenpowerBmc
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openpower_ipmi,hctrl_openbmc
 cmd:rpower $$CN suspend
 check:output=~Error: (\[.*?\]: )?Unsupported command: rpower suspend
 check:rc==1
@@ -169,6 +183,7 @@ end
 
 start:rpower_wake_OpenpowerBmc
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openpower_ipmi,hctrl_openbmc
 cmd:rpower $$CN wake
 check:output=~Error: (\[.*?\]: )?Unsupported command: rpower wake
 check:rc==1
@@ -176,6 +191,7 @@ end
 
 start:rpower_errorcommand_OpenpowerBmc
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openpower_ipmi,hctrl_openbmc
 cmd:rpower $$CN ddd
 check:output=~Error: (\[.*?\]: )?Unsupported command: rpower ddd 
 check:rc==1
@@ -184,6 +200,7 @@ end
 start:rpower_bmcreboot_perl_python_output
 description:record the output for rpower bmcreboot and compare the output for perl and python version. 
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd: /opt/xcat/share/xcat/tools/autotest/testcase/UT_openbmc/scripts/bmcreboot.sh $$CN /tmp/xcattest.rpower.bmcstate.perl.out PERL
 check:rc==0
 cmd: grep "Login to BMC failed: 500" /tmp/xcattest.rpower.bmcstate.perl.out | sort | uniq | wc -l

--- a/xCAT-test/autotest/testcase/rpower/cases0
+++ b/xCAT-test/autotest/testcase/rpower/cases0
@@ -1,7 +1,7 @@
 start:rpower_off
 description:This case is to test off option could remote power off nodes 
 Attribute: $$CN-The operation object of rpower command
-label:cn_bmc_ready,hctrl_gen
+label:cn_bmc_ready,hctrl_general
 cmd:rpower $$CN on
 cmd:a=0;while ! `rpower $$CN stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 check:ouptut=~Running|on
@@ -15,7 +15,7 @@ end
 start:rpower_stat
 description:This case is to test stat option could show the power status of nodes
 Attribute: $$CN-The operation object of rpower command
-label:cn_bmc_ready,hctrl_gen
+label:cn_bmc_ready,hctrl_general
 cmd:rpower $$CN on
 cmd:a=0;while ! `rpower $$CN stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 5 ];then break;fi done
 cmd:rpower $$CN stat
@@ -37,7 +37,7 @@ end
 start:rpower_boot
 description:This case is to test boot option could power on the nodes if nodes in off state.  Or could  hard reset the nodes if they are on. 
 Attribute: $$CN-The operation object of rpower command
-label:cn_bmc_ready,hctrl_gen
+label:cn_bmc_ready,hctrl_general
 cmd:rpower $$CN off
 cmd:a=0;while ! `rpower $$CN stat|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$CN stat
@@ -52,7 +52,7 @@ end
 start:rpower_status
 description:This case is to test status option could show the power status of nodes
 Attribute: $$CN-The operation object of rpower command
-label:cn_bmc_ready,hctrl_gen
+label:cn_bmc_ready,hctrl_general
 cmd:rpower $$CN off
 cmd:a=0;while ! `rpower $$CN status|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$CN status
@@ -67,7 +67,7 @@ end
 start:rpower_state
 description:This case is to test state option could show the power status of nodes
 Attribute: $$CN-The operation object of rpower command
-label:cn_bmc_ready,hctrl_gen
+label:cn_bmc_ready,hctrl_general
 cmd:rpower $$CN off
 cmd:a=0;while ! `rpower $$CN state|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$CN state
@@ -82,7 +82,7 @@ end
 start:rpower_on
 description:This case is to test on option could remote power on nodes
 Attribute: $$CN-The operation object of rpower command
-label:cn_bmc_ready,hctrl_gen
+label:cn_bmc_ready,hctrl_general
 cmd:rpower $$CN off
 cmd:a=0;while ! `rpower $$CN stat|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$CN stat
@@ -97,7 +97,7 @@ end
 start:rpower_reset
 description:This case is to test reset option could hard reset nodes when nodes are in on state.
 Attribute: $$CN-The operation object of rpower command
-label:cn_bmc_ready,hctrl_gen
+label:cn_bmc_ready,hctrl_general
 cmd:stat=`rpower $$CN stat`;if ([[ $stat =~ on ]] || [[ $stat =~ Running ]]) ;then rpower $$CN reset;sleep 300;stat1=`rpower $$CN stat`;if ([[ $stat1 =~ on ]] || [[ $stat1 =~ Running ]]);then exit 0;else exit 1;fi;else rpower $$CN reset;sleep 300;stat1=`rpower $$CN stat`;if ([[ $stat1 =~ off ]] || [[ $stat1 =~ "Not Activated" ]]);then exit 0;else exit 1;fi;fi
 check:rc==0
 end
@@ -105,7 +105,7 @@ end
 start:rpower_noderange
 description:This case is to test rpower could process error usage and return help information.
 Attribute: $$CN-The operation object of rpower command
-label:cn_bmc_ready,hctrl_gen
+label:cn_bmc_ready,hctrl_general
 cmd:rpower $$CN
 check:rc!=0
 check:output=~Unsupported|Usage|Please enter an action
@@ -114,7 +114,7 @@ end
 start:rpower_noderange_nodeps
 description:This case is to test rpower could process error usage and return help information.
 Attribute: $$CN-The operation object of rpower command
-label:cn_bmc_ready,hctrl_gen
+label:cn_bmc_ready,hctrl_general
 cmd:rpower $$CN --nodeps
 check:rc!=0
 check:output=~Unsupported|Usage
@@ -123,7 +123,7 @@ end
 start:rpower_err_noderange
 description:This case is to test rpower could process error usage and return help information.
 Attribute:N/A 
-label:cn_bmc_ready,hctrl_gen
+label:mn_only,hctrl_general
 cmd:rpower testnode stat
 check:rc!=0
 check:output=~Error

--- a/xCAT-test/autotest/testcase/rsetboot/cases0
+++ b/xCAT-test/autotest/testcase/rsetboot/cases0
@@ -72,7 +72,7 @@ end
 
 start:rsetboot_h
 description:get rsetboot help information
-label:cn_bmc_ready,hctrl_gen
+label:mn_only,hctrl_general
 cmd:rsetboot -h
 check:rc==0
 check:output=~Usage: rsetboot
@@ -80,7 +80,7 @@ end
 
 start:rsetboot_help
 description:get rsetboot help information using rsetboot help
-label:cn_bmc_ready,hctrl_gen
+label:mn_only,hctrl_general
 cmd:rsetboot -help
 check:rc==0
 check:output=~Usage: rsetboot
@@ -88,7 +88,7 @@ end
 
 start:rsetboot_v
 desription:get rsetboot version
-label:cn_bmc_ready,hctrl_gen
+label:mn_only,hctrl_general
 cmd:rsetboot -v
 check:rc==0
 check:output=~Version
@@ -96,7 +96,7 @@ end
 
 start:rsetboot_node_invalidnode
 desription:rsetboot using invalidenode
-label:cn_bmc_ready,hctrl_gen
+label:mn_only,hctrl_general
 cmd:rsetboot testnode boot
 check:rc!=0
 end

--- a/xCAT-test/autotest/testcase/rsetboot/cases0
+++ b/xCAT-test/autotest/testcase/rsetboot/cases0
@@ -1,6 +1,7 @@
 start:rsetboot_hd_statcheck
 description:set the boot device from hd
 Attribute: $$CN-The operation object of rsetboot command.
+label:cn_bmc_ready,hctrl_openbmc
 cmd:if [[ -f /tmp/rsetboot.stat ]];then mv -f /tmp/rsetboot.stat /tmp/rsetboot.stat.bak;fi; rsetboot $$CN state > /tmp/rsetboot.stat;
 check:rc==0
 cmd:rsetboot $$CN hd
@@ -18,6 +19,7 @@ end
 start:rsetboot_net_statcheck
 description:set the boot device from net
 Attribute: $$CN-The operation object of rsetboot command.
+label:cn_bmc_ready,hctrl_openbmc,hctrl_bmc_ipmi
 cmd:if [[ -f /tmp/rsetboot.stat ]];then mv -f /tmp/rsetboot.stat /tmp/rsetboot.stat.bak;fi; rsetboot $$CN state > /tmp/rsetboot.stat;
 check:rc==0
 cmd:rsetboot $$CN net
@@ -35,6 +37,7 @@ end
 start:rsetboot_cd_statcheck
 description:set the boot device from CD/DVD
 Attribute: $$CN-The operation object of rsetboot command.
+label:cn_bmc_ready,hctrl_openbmc,hctrl_bmc_ipmi
 cmd:if [[ -f /tmp/rsetboot.stat ]];then mv -f /tmp/rsetboot.stat /tmp/rsetboot.stat.bak;fi; rsetboot $$CN state > /tmp/rsetboot.stat;
 check:rc==0
 cmd:rsetboot $$CN cd
@@ -52,6 +55,7 @@ end
 start:rsetboot_default_statcheck
 description:set the boot device default
 Attribute: $$CN-The operation object of rsetboot command.
+label:cn_bmc_ready,hctrl_openbmc,hctrl_bmc_ipmi
 cmd:if [[ -f /tmp/rsetboot.stat ]];then mv -f /tmp/rsetboot.stat /tmp/rsetboot.stat.bak;fi; rsetboot $$CN state > /tmp/rsetboot.stat;
 check:rc==0
 cmd:rsetboot $$CN default
@@ -68,6 +72,7 @@ end
 
 start:rsetboot_h
 description:get rsetboot help information
+label:cn_bmc_ready,hctrl_gen
 cmd:rsetboot -h
 check:rc==0
 check:output=~Usage: rsetboot
@@ -75,6 +80,7 @@ end
 
 start:rsetboot_help
 description:get rsetboot help information using rsetboot help
+label:cn_bmc_ready,hctrl_gen
 cmd:rsetboot -help
 check:rc==0
 check:output=~Usage: rsetboot
@@ -82,12 +88,15 @@ end
 
 start:rsetboot_v
 desription:get rsetboot version
+label:cn_bmc_ready,hctrl_gen
 cmd:rsetboot -v
 check:rc==0
 check:output=~Version
 end
+
 start:rsetboot_node_invalidnode
 desription:rsetboot using invalidenode
+label:cn_bmc_ready,hctrl_gen
 cmd:rsetboot testnode boot
 check:rc!=0
 end
@@ -95,6 +104,7 @@ end
 start:rsetboot_noderange_net
 description:rsetboot noderange net
 Attribute: $$CN-The operation object of rsetboot command.
+label:cn_bmc_ready,hctrl_openbmc,hctrl_bmc_ipmi
 cmd:test=$(lsdef testnode);if [[ $? -eq 0 ]]; then lsdef -l testnode -z >/tmp/testnode.stanza ;rmdef testnode;fi
 check:rc==0
 cmd:chdef testnode groups=test mgt=__GETNODEATTR($$CN,mgt)__
@@ -118,6 +128,7 @@ end
 start:rsetboot_node_invalidaction
 description:rsetboot node using invalidaction
 Attribute: $$CN-The operation object of rsetboot command.
+label:cn_bmc_ready,hctrl_openbmc,hctrl_bmc_ipmi
 cmd:rsetboot $$CN dsdf
 check:rc!=0
 check:output=~Error: (\[.*?\]: )?unsupported command|Unsupported command
@@ -126,6 +137,7 @@ end
 start:rsetboot_group_net
 description:rsetboot group node 
 Attribute: $$CN-The operation object of rsetboot command.
+label:cn_bmc_ready,hctrl_openbmc,hctrl_bmc_ipmi
 cmd:test=$(lsdef testnode);if [[ $? -eq 0 ]]; then lsdef -l testnode -z >/tmp/testnode.stanza ;rmdef testnode;fi
 check:rc==0
 cmd:if [[ -f /tmp/rsetboot.stat ]];then mv -f /tmp/rsetboot.stat /tmp/rsetboot.stat.bak;fi; rsetboot $$CN state > /tmp/rsetboot.stat;

--- a/xCAT-test/autotest/testcase/rspconfig/cases0
+++ b/xCAT-test/autotest/testcase/rspconfig/cases0
@@ -1,12 +1,15 @@
 #Need to test later
 start:rspconfig_autopower
 hcp:fsp
+label:cn_bmc_ready,hctrl_fsp
 cmd:rspconfig $$CEC autopower
 check:rc==0
 check:output=~$$CEC: autopower: \w+
 end
+
 start:rspconfig_iocap
 hcp:fsp
+label:cn_bmc_ready,hctrl_fsp
 cmd:rspconfig $$CEC iocap
 check:rc==0
 check:output=~$$CEC: iocap: \w+
@@ -14,18 +17,23 @@ end
 
 start:rspconfig_time
 hcp:fsp
+label:cn_bmc_ready,hctrl_fsp
 cmd:rspconfig $$CEC time
 check:rc==0
 check:output=~$$CEC: Time: \d\d:\d\d:\d\d
 end
+
 start:rspconfig_date
 hcp:fsp
+label:cn_bmc_ready,hctrl_fsp
 cmd:rspconfig $$CEC date
 check:rc==0
 check:output=~$$CEC: Date: \d\d-\d\d-\d\d\d\d
 end
+
 start:rspconfig_decfg
 hcp:fsp
+label:cn_bmc_ready,hctrl_fsp
 cmd:rspconfig $$CEC decfg
 check:rc==0
 check:output=~$$CEC
@@ -34,8 +42,10 @@ check:output=~predictive
 check:output=~system bus
 check:output=~functional
 end
+
 start:rspconfig_sshcfg
 hcp:hmc
+label:cn_bmc_ready,hctrl_hmc,hctrl_openbmc
 cmd:rspconfig __GETNODEATTR($$CN,hcp)__ sshcfg
 check:rc==0
 check:output=~__GETNODEATTR($$CN,hcp)__: \w+
@@ -44,6 +54,7 @@ end
 start:rspconfig_list_ntpservers
 description: rspconfig list ntpservers info
 Attribute: $$CN-The operation object of rspconfig command
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN ntpservers
 check:rc==0
 check:output=~$$CN: BMC NTP Servers
@@ -52,6 +63,7 @@ end
 start:rspconfig_set_ntpservers
 description: rspconfig set ntpservers
 Attribute: $$CN-The operation object of rspconfig command
+label:cn_bmc_ready,hctrl_openbmc
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig_ntp.sh $$CN $$MN
 check:rc==0
 end
@@ -61,6 +73,7 @@ description:To test change openbmc ip separately by rspconfig. should not suppor
 Attribute: $$CN-The operation object of rspconfig command
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN ip=__GETNODEATTR($$CN,bmc)__
 check:output=~Error: (\[.*?\]: )?IP, netmask and gateway must be configured together.
 check:rc!=0
@@ -71,6 +84,7 @@ description:rspconfig could not change openbmc ip using invalid ip
 Attribute: $$CN-The operation object of rspconfig command
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN ip=ddd gateway=0.0.0.0  netmask=255.255.0.0
 check:output=~Error: (\[.*?\]: )?Invalid parameter for option ip
 check:rc!=0
@@ -81,6 +95,7 @@ description:rspconfig could not set ip to null
 Attribute: $$CN-The operation object of rspconfig command
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN ip=
 check:output=~Invalid parameter for option ip
 check:rc!=0
@@ -94,6 +109,7 @@ description:To test change openbmc netmask separately by rspconfig. should not s
 Attribute: $$CN-The operation object of rspconfig command
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN netmask=255.255.0.0
 check:output=~Error: (\[.*?\]: )?IP, netmask and gateway must be configured together.
 check:rc!=0
@@ -102,6 +118,7 @@ end
 start:rspconfig_netmask_invalid
 despcription:rspconfig could not change openbmc netmask using invalid netmask
 Attribute: $$CN-The operation object of rspconfig command
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN netmask=ddd
 check:output=~Error: (\[.*?\]: )?Invalid parameter for option netmask
 check:rc!=0
@@ -118,6 +135,7 @@ description:To test change openbmc gateway by rspconfig. should not support and 
 Attribute: $$CN-The operation object of rspconfig command
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN gateway=0.0.0.0
 check:output=~Error: (\[.*?\]: )?IP, netmask and gateway must be configured together.
 check:rc!=0
@@ -126,6 +144,7 @@ end
 start:rspconfig_set_vlan
 description:rspconfig change openbmc gateway
 Attribute: $$CN-The operation object of rspconfig command
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN vlan=0
 check:output=~Error: (\[.*?\]: )?Invalid parameter for option vlan|Error: (\[.*?\]: )?VLAN must be configured with IP, netmask and gateway
 check:rc!=0
@@ -137,6 +156,7 @@ end
 start:rspconfig_set_all
 description:rspconfig change openbmc ip/netmask/gateway/vlan
 Attribute: $$CN-The operation object of rspconfig command
+label:cn_bmc_ready,hctrl_openbmc
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig.sh -a  $$CN 
 check:rc==0
 end
@@ -146,6 +166,7 @@ despcription:rspconfig could not change openbmc gatway using invalid gateway
 Attribute: $$CN-The operation object of rspconfig command
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN gateway=ddd
 check:output=~Error: (\[.*?\]: )?Invalid parameter for option gateway
 check:rc!=0
@@ -162,6 +183,7 @@ despcription:rspconfig could not change openbmc gatway using invalid vlan
 Attribute: $$CN-The operation object of rspconfig command
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN vlan=dddsdsdfs
 check:output=~Error: (\[.*?\]: )?VLAN must be configured with IP, netmask and gateway
 check:rc!=0
@@ -172,6 +194,7 @@ despcription:rspconfig could not change openbmc gatway using invalid vlan
 Attribute: $$CN-The operation object of rspconfig command
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN ip=dsd gateway=ooo netmask=asfsf vlan=dddsdsdfs
 check:output=~Error: (\[.*?\]: )?Invalid parameter
 check:rc!=0
@@ -181,6 +204,7 @@ start:rspconfig_node_invalid
 despcription:rspconfig could not do any action  using invalid node
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:test=$(lsdef testnode);if [[ $? -eq 0 ]]; then lsdef -l testnode -z >/tmp/testnode.stanza ;rmdef testnode;fi
 check:rc==0
 cmd:rspconfig testnode ip
@@ -194,6 +218,7 @@ start:rspconfig_noderange_invalid
 despcription:rspconfig could not do any action  using invalid node
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:test=$(lsdef testnode);if [[ $? -eq 0 ]]; then lsdef -l testnode -z >/tmp/testnode.stanza ;rmdef testnode;fi
 check:rc==0
 cmd:rspconfig testnode,$$CN ip
@@ -205,6 +230,7 @@ end
 
 start:rspconfig_list_ip
 despcription:rspconfig list bmc ip
+label:cn_bmc_ready,hctrl_bmc_ipmi,hctrl_openbmc
 cmd:rspconfig $$CN ip 
 check:rc==0
 check:output=~__GETNODEATTR($$CN,bmc)__
@@ -214,6 +240,7 @@ start:rspconfig_list_gateway
 hcp:openbmc
 description:rspconfig list openbmc gateway
 Attribute: $$CN-The operation object of rspconfig command
+label:cn_bmc_ready,hctrl_bmc_ipmi,hctrl_openbmc
 cmd:rspconfig $$CN gateway
 check:output=~$$CN: BMC Gateway:
 check:rc==0
@@ -223,6 +250,7 @@ start:rspconfig_list_netmask
 hcp:openbmc
 description:rspconfig list openbmc netmask
 Attribute: $$CN-The operation object of rspconfig command
+label:cn_bmc_ready,hctrl_bmc_ipmi,hctrl_openbmc
 cmd:rspconfig $$CN netmask 
 check:rc==0
 check:output=~$$CN: BMC Netmask:
@@ -231,6 +259,7 @@ end
 start:rspconfig_list_vlan
 description:rspconfig list openbmc vlan
 Attribute: $$CN-The operation object of rspconfig command
+label:cn_bmc_ready,hctrl_bmc_ipmi,hctrl_openbmc
 cmd: rspconfig $$CN vlan
 check:rc==0
 check:output=~$$CN: BMC VLAN ID:
@@ -239,6 +268,7 @@ end
 start:rspconfig_list_all
 description:rspconfig list openbmc ip gateway netmask vlan 
 Attribute: $$CN-The operation object of rspconfig command
+label:cn_bmc_ready,hctrl_bmc_ipmi,hctrl_openbmc
 cmd: rspconfig $$CN ip gateway netmask vlan
 check:rc==0
 check:output=~$$CN: BMC VLAN ID:
@@ -252,6 +282,7 @@ start:rspconfig_set_hostname_equal_star_with_bmc_is_ip
 description:when bmc=<ip>, rspconfig <node> hostname=* should throw out error
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 #in automation environment, bmc is ip by default. 
 cmd:lsdef $$CN -i bmc -c
 check:rc == 0
@@ -266,6 +297,7 @@ start:rspconfig_set_hostname_equal_star_with_bmc_is_hostname
 description:when bmc=<bmc_hostname>, rspconfig <node> hostname=* should set bmc_hostname into bmc 
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:mkdir -p /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname
 check:rc == 0
 cmd:lsdef $$CN -z > /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname/$$CN.stanza
@@ -299,6 +331,7 @@ start:rspconfig_get_hostname
 description:To test get bmc hostname by rspconfig. 
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:mkdir -p /tmp/rspconfig_get_hostname
 check:rc == 0
 cmd:rspconfig $$CN sshcfg
@@ -322,6 +355,7 @@ start:rspconfig_hostname_with_error_input
 description: To test <get node hostname> with error input, should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN hostname bogus
 check:output =~Error: (\[.*?\]: )?Unsupported command
 check:rc != 0
@@ -337,6 +371,7 @@ start:rspconfig_set_hostname
 description:To test set bmc hostname by rspconfig
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:mkdir -p /tmp/rspconfig_set_hostname
 check:rc == 0
 cmd:rspconfig $$CN sshcfg
@@ -363,6 +398,7 @@ start:rspconfig_set_admin_passwd_with_error_input
 description: To test "rspconfig <node> admin_passwd=xxx,yyy". If the format of "xxx,yyy" is wrong, should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN admin_passwd=cluster,
 check:output =~Error: (\[.*?\]: )?Invalid parameter for option admin_passwd
 check:rc != 0
@@ -383,6 +419,7 @@ start:rspconfig_set_admin_passwd_with_error_origin_password
 description: To test "rspconfig <node> admin_passwd=xxx,yyy". If the original password is wrong, should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN admin_passwd=bogus__GETNODEATTR($$CN,bmcpassword)__,cluster
 check:output =~Current BMC password is incorrect
 #check:rc != 0
@@ -392,6 +429,7 @@ start:rspconfig_sshcfg_with_error_input
 description: To test "rspconfig <node> sshcfg" with error input, should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN sshcfg aaa
 check:output =~Error: (\[.*?\]: )?Configure sshcfg must be issued without other options.
 check:rc != 0

--- a/xCAT-test/autotest/testcase/rspconfig/cases1
+++ b/xCAT-test/autotest/testcase/rspconfig/cases1
@@ -2,6 +2,7 @@ start:rspconfig_ipsrc
 description: To test "rspconfig <node> ipsrc",to get the IP source for OpenBMC 
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN ipsrc 
 check:output=~$$CN\s*:\s*BMC IP Source: Static|BMC IP Source: Dynamic 
 check:rc == 0
@@ -14,6 +15,7 @@ start:rspconfig_dump_list
 description: To test "rspconfig <node> dump -l" and "rspconfig <node> dump --list" 
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN dump -l  
 check:output =~$$CN:\s*No attributes returned from the BMC.|\s*\[\d+\]\s* Generated:
 check:rc == 0
@@ -26,6 +28,7 @@ start:rspconfig_dump_generate
 description: To test "rspconfig <node> dump -g" and "rspconfig <node> dump --generate" 
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN dump -l|tee /tmp/dumplistold
 check:output =~$$CN:\s*No attributes returned from the BMC.|\s*\[\d+\]\s* Generated:
 check:rc == 0 
@@ -60,6 +63,7 @@ start:rspconfig_dump_clear
 description: To test "rspconfig <node> dump -c" and "rspconfig <node> dump --clear" 
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN dump -g |tee /tmp/dumpgenerate
 check:rc == 0
 check:output =~$$CN:\s*\[\d+\]\s* success
@@ -100,6 +104,7 @@ start:rspconfig_dump_download
 description: To test rspconfig <node> dump -d" and "rspconfig <node> dump --download"
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN dump -g |tee /tmp/dumpgenerate
 check:rc == 0
 check:output =~$$CN:\s*\[\d+\]\s* success
@@ -133,6 +138,7 @@ start:rspconfig_dump_no_option
 description: To test "rspconfig <node> dump"
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN dump  
 check:rc == 0
 check:output =~$$CN:\s*Dump requested
@@ -148,6 +154,7 @@ start:rspconfig_gard
 description: To test "rspconfig <node> gard -c" 
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN gard -c 
 check:output =~$$CN:\s*GARD cleared
 check:rc == 0
@@ -160,6 +167,7 @@ start:rspconfig_ntpserver
 description: To test "rspconfig <node> ntpservers" to show the ntp server of the node 
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN ntpservers 
 check:output =~$$CN:\s*BMC NTP Servers:\s*None|\s*\d+.\d+.\d+.\d+
 check:rc == 0
@@ -169,6 +177,7 @@ start:rspconfig_powerrestorepolicy
 description: To test "rspconfig <node> powerrestorepolicy" to show the policy 
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN powerrestorepolicy |tee /tmp/powerrestorepolicy 
 check:output =~$$CN:\s*BMC PowerRestorePolicy:\s*AlwaysOff|AlwaysOn|Restore
 check:rc == 0
@@ -202,6 +211,7 @@ start:rspconfig_powersupplyredundancy
 description: To test "rspconfig <node> powersupplyredundancy" to show the powersupplyredundancy state 
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN powersupplyredundancy |tee /tmp/powersupplyredundancy 
 check:output =~$$CN:\s*BMC PowerSupplyRedundancy:\s*Enabled|Disabled
 check:rc == 0
@@ -229,6 +239,7 @@ start:rspconfig_timesyncmethod
 description: To test "rspconfig <node> timesyncmethod" to show the timesyncmethod 
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN timesyncmethod |tee /tmp/timesyncmethod
 check:output =~$$CN:\s*BMC TimeSyncMethod:\s*NTP|Manual
 check:rc == 0
@@ -256,6 +267,7 @@ start:rspconfig_bootmode
 description: To test "rspconfig <node> bootmode" to show and change bootmode 
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN bootmode|tee /tmp/bootmode
 check:output =~$$CN:\s*BMC BootMode:\s*Regular|Safe|Setup
 check:rc == 0
@@ -289,6 +301,7 @@ start:rspconfig_autoreboot
 description: To test "rspconfig <node> autoreboot" to show and change autoreboot 
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN autoreboot|tee /tmp/autoreboot
 check:output =~$$CN:\s*BMC AutoReboot:\s*1|0
 check:rc == 0
@@ -316,6 +329,7 @@ start:rspconfig_invalid
 description: To test "rspconfig <node> invalid_value"  should throw out error message
 os:Linux
 hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN aaa
 check:output =~Error: (\[.*?\]: )?Unsupported command: rspconfig aaa
 check:rc != 0

--- a/xCAT-test/autotest/testcase/rvitals/cases0
+++ b/xCAT-test/autotest/testcase/rvitals/cases0
@@ -1,7 +1,6 @@
 start:rvitals_h
 description:get rvitals's usage
-Attribute: $$CN-The operation object of rvitals command
-label:cn_bmc_ready,hctrl_gen
+label:mn_only,hctrl_general
 cmd:rvitals -h 
 check:rc==0
 check:output=~Usage:
@@ -10,8 +9,7 @@ end
 
 start:rvitals_v
 description:get rvitals's version
-Attribute: $$CN-The operation object of rvitals command
-label:cn_bmc_ready,hctrl_gen
+label:mn_only,hctrl_general
 cmd:rvitals -v
 check:rc==0
 check:output=~Version
@@ -20,7 +18,7 @@ end
 start:rvitals_temp
 description:Retrieves temperatures
 Attribute: $$CN-The operation object of rvitals command
-label:cn_bmc_ready,hctrl_gen
+label:cn_bmc_ready,hctrl_general
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rvitals $$CN temp
 check:rc==0
 end
@@ -50,7 +48,7 @@ end
 start:rvitals_voltage
 description:Retrieves power supply and VRM voltage readings
 Attribute: $$CN-The operation object of rvitals command
-label:cn_bmc_ready,hctrl_gen
+label:cn_bmc_ready,hctrl_general
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rvitals $$CN voltage
 check:rc==0
 end
@@ -85,7 +83,7 @@ end
 start:rvitals_all
 description:Retrieves all status
 Attribute: $$CN-The operation object of rvitals command
-label:cn_bmc_ready,hctrl_gen
+label:cn_bmc_ready,hctrl_general
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rvitals $$CN all
 check:rc==0
 end
@@ -125,14 +123,14 @@ end
 
 start:rvitals_noderange_err
 description:using not defined node
-label:cn_bmc_ready,hctrl_gen
+label:mn_only,hctrl_general
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rvitals testnode 
 check:rc!=0
 end
 
 start:rvitals_errorcommand
 description:using wrong command
-label:cn_bmc_ready,hctrl_gen
+label:cn_bmc_ready,hctrl_general
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rvitals $$CN errorcommand
 check:rc!=0
 end

--- a/xCAT-test/autotest/testcase/rvitals/cases0
+++ b/xCAT-test/autotest/testcase/rvitals/cases0
@@ -1,6 +1,7 @@
 start:rvitals_h
 description:get rvitals's usage
 Attribute: $$CN-The operation object of rvitals command
+label:cn_bmc_ready,hctrl_gen
 cmd:rvitals -h 
 check:rc==0
 check:output=~Usage:
@@ -10,6 +11,7 @@ end
 start:rvitals_v
 description:get rvitals's version
 Attribute: $$CN-The operation object of rvitals command
+label:cn_bmc_ready,hctrl_gen
 cmd:rvitals -v
 check:rc==0
 check:output=~Version
@@ -18,6 +20,7 @@ end
 start:rvitals_temp
 description:Retrieves temperatures
 Attribute: $$CN-The operation object of rvitals command
+label:cn_bmc_ready,hctrl_gen
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rvitals $$CN temp
 check:rc==0
 end
@@ -27,6 +30,7 @@ description:Retrieves disk temperatures
 Attribute: $$CN-The operation object of rvitals command
 arch:ppc64le
 hcp:ipmi
+label:cn_bmc_ready,hctrl_openpower_ipmi
 cmd:rvitals $$CN disktemp
 check:rc==0
 check:output=~Ambient Temp
@@ -37,6 +41,7 @@ description:Retrieves cpu  temperatures
 Attribute: $$CN-The operation object of rvitals command
 arch:ppc64le
 hcp:ipmi
+label:cn_bmc_ready,hctrl_openpower_ipmi
 cmd:rvitals $$CN cputemp
 check:rc==0
 check:output=~Ambient Temp
@@ -45,6 +50,7 @@ end
 start:rvitals_voltage
 description:Retrieves power supply and VRM voltage readings
 Attribute: $$CN-The operation object of rvitals command
+label:cn_bmc_ready,hctrl_gen
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rvitals $$CN voltage
 check:rc==0
 end
@@ -52,6 +58,7 @@ end
 start:rvitals_power
 description:Retrieves power status
 Attribute: $$CN-The operation object of rvitals command
+label:cn_bmc_ready,hctrl_bmc_ipmi,hctrl_openpower_ipmi,hctrl_openbmc
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rvitals $$CN power
 check:rc==0
 end
@@ -59,6 +66,7 @@ end
 start:rvitals_state
 description:Retrieves the system state.
 Attribute: $$CN-The operation object of rvitals command
+label:cn_bmc_ready
 cmd:rvitals $$CN state
 check:rc==0
 check:output=~System State:
@@ -68,6 +76,7 @@ start:rvitals_lcds
 description:Retrieves LCDs status
 Attribute: $$CN-The operation object of rvitals command
 hcp:hmc,ivm,fsp,ipmi
+label:cn_bmc_ready,hctrl_fsp
 cmd:rvitals $$CN lcds
 check:rc==0
 check:output=~Current LCD
@@ -76,6 +85,7 @@ end
 start:rvitals_all
 description:Retrieves all status
 Attribute: $$CN-The operation object of rvitals command
+label:cn_bmc_ready,hctrl_gen
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rvitals $$CN all
 check:rc==0
 end
@@ -83,6 +93,7 @@ end
 start:rvitals_leds
 description:Retrieves leds status
 Attribute: $$CN-The operation object of rvitals command
+label:cn_bmc_ready,hctrl_bmc_ipmi,hctrl_openpower_ipmi,hctrl_openbmc
 cmd:rvitals $$CN  leds
 check:rc==0
 check:output=~LED
@@ -91,28 +102,37 @@ end
 start:rvitals_fanspeed
 description:Retrieves fan speeds.
 Attribute: $$CN-The operation object of rvitals command
+label:cn_bmc_ready,hctrl_bmc_ipmi,hctrl_openpower_ipmi,hctrl_openbmc
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rvitals $$CN fanspeed
 check:rc==0
 end
+
 start:rvitals_wattage
 description:Retrieves wattage readings.
 Attribute: $$CN-The operation object of rvitals command
+label:cn_bmc_ready,hctrl_bmc_ipmi,hctrl_openpower_ipmi,hctrl_openbmc
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rvitals $$CN wattage
 check:rc==0
 end
+
 start:rvitals_altitude
 description:Retrieves altitude readings.
 Attribute: $$CN-The operation object of rvitals command
+label:cn_bmc_ready,hctrl_openbmc
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rvitals $$CN altitude
 check:rc==0
 end
+
 start:rvitals_noderange_err
 description:using not defined node
+label:cn_bmc_ready,hctrl_gen
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rvitals testnode 
 check:rc!=0
 end
+
 start:rvitals_errorcommand
 description:using wrong command
+label:cn_bmc_ready,hctrl_gen
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rvitals/openbmctest.sh rvitals $$CN errorcommand
 check:rc!=0
 end

--- a/xCAT-test/autotest/testcase/rvitals/cases1
+++ b/xCAT-test/autotest/testcase/rvitals/cases1
@@ -1,6 +1,6 @@
 start:rvitals_outputs_format_checking
 description: Check the output formats of rvitals
-label:cn_bmc_ready,hctrl_gen
+label:cn_bmc_ready,hctrl_general
 cmd:rvitals $$CN | grep -v -E '^[^:]+:[^:]+:[^:]+$'
 check:rc==1
 end

--- a/xCAT-test/autotest/testcase/rvitals/cases1
+++ b/xCAT-test/autotest/testcase/rvitals/cases1
@@ -1,5 +1,6 @@
 start:rvitals_outputs_format_checking
 description: Check the output formats of rvitals
+label:cn_bmc_ready,hctrl_gen
 cmd:rvitals $$CN | grep -v -E '^[^:]+:[^:]+:[^:]+$'
 check:rc==1
 end


### PR DESCRIPTION
Add labels for all hardware control test case.

Related commands are ``rflash``, ``rpower``, ``rinv``, ``rvitals``, ``rspconfig``, ``rsetboot``,``rbeacon``, and ``reventlog``.

Also including test cases from ``UT_openbmc``.

Related task xcat2/xcat2-task-management#200 
