### PR TITLE
Specify the new GPG key 5619700D used for signing

### DIFF
--- a/build-ubunturepo
+++ b/build-ubunturepo
@@ -335,7 +335,7 @@ __EOF__
            echo "GPGSIGN=$GPGSIGN specified, the repo will not be signed"
            echo "" >> conf/distributions
        else 
-           echo "SignWith: yes" >> conf/distributions
+           echo "SignWith: 5619700D" >> conf/distributions
            echo "" >> conf/distributions
        fi
     done
@@ -462,7 +462,7 @@ __EOF__
             echo "GPGSIGN=$GPGSIGN specified, the repo will not be signed"
             echo "" >> conf/distributions
         else
-            echo "SignWith: yes" >> conf/distributions
+            echo "SignWith: 5619700D" >> conf/distributions
             echo "" >> conf/distributions
         fi
 


### PR DESCRIPTION
This patch is for solving issue #5306. A new 4096-bit-long DSA key was created for package signing.

```
# gpg --list-sigs
/root/.gnupg/pubring.gpg
------------------------
pub   1024D/C6565BC9 2015-01-07
uid                  xCAT Security Key <xcat@cn.ibm.com>
sig 3        C6565BC9 2018-06-22  xCAT Security Key <xcat@cn.ibm.com>
sub   2048g/6EFCDE35 2015-01-07
sig          C6565BC9 2015-01-07  xCAT Security Key <xcat@cn.ibm.com>

pub   4096R/CA548A47 2018-06-22 [expires: 2037-08-20]
uid                  xCAT Automatic Signing Key <xcat@cn.ibm.com>
sig 3        CA548A47 2018-06-22  xCAT Automatic Signing Key <xcat@cn.ibm.com>
sig          C6565BC9 2018-06-22  xCAT Security Key <xcat@cn.ibm.com>
sub   4096R/5619700D 2018-06-22 [expires: 2037-08-20]
sig          CA548A47 2018-06-22  xCAT Automatic Signing Key <xcat@cn.ibm.com>
```