### PR TITLE
UT testcase for secureroot

### DIFF
--- a/xCAT-test/autotest/testcase/nodeset/cases0
+++ b/xCAT-test/autotest/testcase/nodeset/cases0
@@ -479,9 +479,15 @@ os: rhels
 description: Test nodeset could generate right installation files when site.secureroot=1
 label: others,security
 cmd: chdef -t site secureroot=1
-cmd: nodeset $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+cmd: myimage=__GETNODEATTR($$CN,provmethod)__; osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute; cn=$$CN
+test -f /install/autoinst/$cn && mv -f /install/autoinst/$cn /install/autoinst/$cn.secureroot
+nodeset $cn osimage=$osimage
+myresult=$?
+chdef $cn provmethod=$myimage
+test $myresult -eq 0
 check:rc==0
 cmd: cat /install/autoinst/$$CN | grep '^rootpw --iscrypted \*' > /dev/null
 check:rc==0
 cmd: chdef -t site secureroot=
+cmd: test -f /install/autoinst/$$CN.secureroot && mv -f /install/autoinst/$$CN.secureroot /install/autoinst/$$CN
 end

--- a/xCAT-test/autotest/testcase/nodeset/cases0
+++ b/xCAT-test/autotest/testcase/nodeset/cases0
@@ -473,3 +473,15 @@ check:output=~$$CN:\s*install
 cmd:imagename=`cat /tmp/imagename`;osversion=`lsdef -t osimage -o $imagename |grep osvers|awk -F= '{print $2}'`;versionnum=`echo $osversion |sed 's:[a-zA-Z]::g'`;grep -w -A10 "$$CN" /var/lib/dhcpd/dhcpd.leases | grep "/install/$osversion/armel/cumulus-linux-$versionnum-bcm-armel.bin"
 check:rc==0
 end
+
+start:nodeset_secureroot
+os: rhels
+description: Test nodeset could generate right installation files when site.secureroot=1
+label: others,security
+cmd: chdef -t site secureroot=1
+cmd: nodeset $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+check:rc==0
+cmd: cat /install/autoinst/$$CN | grep '^rootpw --iscrypted \*' > /dev/null
+check:rc==0
+cmd: chdef -t site secureroot=
+end

--- a/xCAT-test/autotest/testcase/packimg/cases_secure_protect
+++ b/xCAT-test/autotest/testcase/packimg/cases_secure_protect
@@ -1,0 +1,42 @@
+start:packimage_nosyncfiles
+os:Linux
+description: Test packimage with --nosyncfiles
+label: others,security
+cmd: myimage=$$OSIMAGE
+lsdef -t osimage -o $myimage -z > /tmp/packimage_nosyncfiles.osimage && \
+chdef -t osimage -o "$myimage" rootimgdir=/tmp/packimage_nosyncfiles/rootimgdir && \
+chdef -t osimage -o "$myimage" synclists=/tmp/packimage_nosyncfiles.sensitive.$$ && \
+touch /tmp/packimage_nosyncfiles.sensitive && \
+echo "/tmp/packimage_nosyncfiles.sensitive -> /etc/sensitive.xcattesting" > /tmp/packimage_nosyncfiles.sensitive.$$ && \
+genimage "$myimage" && \
+packimage "$myimage" --nosyncfiles
+if [ $? = 0 ]; then
+  test ! -e /tmp/packimage_nosyncfiles/rootimgdir/rootimg/etc/sensitive.xcattesting
+else
+  false
+fi
+check:rc==0
+cmd: test -e /tmp/packimage_nosyncfiles.osimage && cat /tmp/packimage_nosyncfiles.osimage | mkdef -t osimage $$OSIMAGE -f
+cmd: rm -rf /tmp/packimage_nosyncfiles*
+end
+
+start:packimage_secureroot
+os:Linux
+description: Test packimage with site.secureroot=1
+label: others,security
+cmd: chdef -t site secureroot=1
+cmd: myimage=$$OSIMAGE
+lsdef -t osimage $myimage -z > /tmp/packimage_secureroot.osimage && \
+chdef -t osimage -o "$myimage" rootimgdir=/tmp/packimage_secureroot/rootimgdir && \
+genimage "$myimage" && \
+packimage "$myimage" --nosyncfiles
+if [ $? = 0 ]; then
+  grep '^root\:\*\:' /tmp/packimage_secureroot/rootimgdir/rootimg/etc/shadow
+else
+  false
+fi
+check:rc==0
+cmd: test -e /tmp/packimage_secureroot.osimage && cat /tmp/packimage_secureroot.osimage | mkdef -t osimage $$OSIMAGE -f
+cmd: rm -rf /tmp/packimage_secureroot*
+cmd: chdef -t site secureroot=
+end


### PR DESCRIPTION
https://github.com/xcat2/xcat2-task-management/issues/173

1, nodeset_secureroot
```
XCATTEST_CASEDIR=`pwd` XCATTEST_CN=fake1 /opt/xcat/bin/xcattest -t nodeset_secureroot
xCAT automated test started at Fri Jun 22 03:11:22 2018
******************************
To detect current test environment
******************************
Detecting: OS = linux
Detecting: ARCH = ppc64le
Detecting: HCP = openbmc
******************************
loading test cases
******************************
To run:
nodeset_secureroot
******************************
Start to run test cases
******************************
------START::nodeset_secureroot::Time:Fri Jun 22 03:11:23 2018------

RUN:chdef -t site secureroot=1 [Mon Jun 25 10:07:55 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.

RUN: [Mon Jun 25 10:07:56 2018]
myimage=__GETNODEATTR(fake1,provmethod)__; osimage=__GETNODEATTR(fake1,os)__-__GETNODEATTR(fake1,arch)__-install-compute; cn=fake1
test -f /install/autoinst/$cn && mv -f /install/autoinst/$cn /install/autoinst/$cn.secureroot
nodeset $cn osimage=$osimage
myresult=$?
chdef $cn provmethod=$myimage
test $myresult -eq 0
ElapsedTime:25 sec
RETURN rc = 0
OUTPUT:
fake1: install rhels7.3-ppc64le-compute
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:cat /install/autoinst/fake1 | grep '^rootpw --iscrypted \*' > /dev/null [Mon Jun 25 10:08:21 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:chdef -t site secureroot= [Mon Jun 25 10:08:21 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.

RUN:test -f /install/autoinst/fake1.secureroot && mv -f /install/autoinst/fake1.secureroot /install/autoinst/fake1 [Mon Jun 25 10:08:22 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::nodeset_secureroot::Passed::Time:Fri Jun 22 03:11:29 2018 ::Duration::6 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished at Fri Jun 22 03:11:29 2018
```
2, packimage_secureroot
`XCATTEST_CASEDIR=`pwd` XCATTEST_OSIMAGE=rhels7.3-ppc64le-netboot-compute /opt/xcat/bin/xcattest -t packimage_secureroot`
```
xCAT automated test started at Thu Jun 21 23:06:13 2018
******************************
To detect current test environment
******************************
Detecting: OS = linux
Warning: No compute node defined, can't get ARCH of compute node
Warning: No compute node defined, can't get HCP TYPE of compute node
******************************
loading test cases
******************************
To run:
packimage_secureroot
******************************
Start to run test cases
******************************
------START::packimage_secureroot::Time:Thu Jun 21 23:06:13 2018------

RUN:chdef -t site secureroot=1 [Thu Jun 21 23:06:13 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.

RUN: [Thu Jun 21 23:06:14 2018]
myimage=rhels7.3-ppc64le-netboot-compute
lsdef -t osimage -o $myimage | grep 'provmethod=netboot' > /dev/null && ( echo 'Not statelesss osimage'; exit 1 )
lsdef -t osimage $myimage -z > /tmp/packimage_secureroot.osimage && \
chdef -t osimage -o "$myimage" rootimgdir=/tmp/packimage_secureroot/rootimgdir && \
genimage "$myimage" && \
packimage "$myimage" --nosyncfiles
if [ $? = 0 ]; then
  grep '^root\:\*\:' /tmp/packimage_secureroot/rootimgdir/rootimg/etc/shadow
else
  false
fi
ElapsedTime:300 sec
RETURN rc = 0
OUTPUT:
Not statelesss osimage
1 object definitions have been created or modified.
Generating image:
...
Packing contents of /tmp/packimage_secureroot/rootimgdir/rootimg
archive method:cpio
compress method:gzip

root:*:13880:0:99999:7:::
CHECK:rc == 0   [Pass]

RUN:test -e /tmp/packimage_secureroot.osimage && cat /tmp/packimage_secureroot.osimage | mkdef -t osimage rhels7.3-ppc64le-netboot-compute -f [Thu Jun 21 23:11:14 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.

RUN:rm -rf /tmp/packimage_secureroot* [Thu Jun 21 23:11:15 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:chdef -t site secureroot= [Thu Jun 21 23:11:15 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.

------END::packimage_secureroot::Passed::Time:Thu Jun 21 23:11:16 2018 ::Duration::303 sec------
------Total: 1 , Failed: 0------
```

3, packimage_nosyncfile
`XCATTEST_CASEDIR=`pwd` XCATTEST_OSIMAGE=rhels7.3-ppc64le-netboot-compute /opt/xcat/bin/xcattest -t packimage_nosyncfiles`

```
xCAT automated test started at Fri Jun 22 03:25:34 2018
******************************
To detect current test environment
******************************
Detecting: OS = linux
Warning: No compute node defined, can't get ARCH of compute node
Warning: No compute node defined, can't get HCP TYPE of compute node
******************************
loading test cases
******************************
To run:
packimage_nosyncfiles
******************************
Start to run test cases
******************************
------START::packimage_nosyncfiles::Time:Fri Jun 22 03:25:34 2018------

RUN: [Fri Jun 22 03:25:34 2018]
myimage=rhels7.3-ppc64le-netboot-compute
lsdef -t osimage -o $myimage | grep 'provmethod=netboot' > /dev/null && ( echo 'Not statelesss osimage'; exit 1 )
lsdef -t osimage -o $myimage -z > /tmp/packimage_nosyncfiles.osimage && \
chdef -t osimage -o "$myimage" rootimgdir=/tmp/packimage_nosyncfiles/rootimgdir && \
chdef -t osimage -o "$myimage" synclists=/tmp/packimage_nosyncfiles.sensitive.$$ && \
touch /tmp/packimage_nosyncfiles.sensitive && \
echo "/tmp/packimage_nosyncfiles.sensitive -> /etc/sensitive.xcattesting" > /tmp/packimage_nosyncfiles.sensitive.$$ && \
genimage "$myimage" && \
packimage "$myimage" --nosyncfiles
if [ $? = 0 ]; then
  test ! -e /tmp/packimage_nosyncfiles/rootimgdir/rootimg/etc/sensitive.xcattesting
else
  false
fi
ElapsedTime:286 sec
RETURN rc = 0
OUTPUT:
Not statelesss osimage
1 object definitions have been created or modified.
1 object definitions have been created or modified.
Generating image:
...

Packing contents of /tmp/packimage_nosyncfiles/rootimgdir/rootimg
archive method:cpio
compress method:gzip

CHECK:rc == 0	[Pass]

RUN:test -e /tmp/packimage_nosyncfiles.osimage && cat /tmp/packimage_nosyncfiles.osimage | mkdef -t osimage rhels7.3-ppc64le-netboot-compute -f [Fri Jun 22 03:30:20 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.

RUN:rm -rf /tmp/packimage_nosyncfiles* [Fri Jun 22 03:30:21 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::packimage_nosyncfiles::Passed::Time:Fri Jun 22 03:30:21 2018 ::Duration::287 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished at Fri Jun 22 03:30:21 2018
```