### PR TITLE
[go-xcat] Fix package version checking on Ubuntu 18.04

### DIFF
--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -2,7 +2,7 @@
 #
 # go-xcat - Install xCAT automatically.
 #
-# Version 1.0.27
+# Version 1.0.28
 #
 # Copyright (C) 2016, 2017, 2018 International Business Machines
 # Eclipse Public License, Version 1.0 (EPL-1.0)
@@ -438,7 +438,12 @@ function check_package_version_deb()
 		do
 			if [[ "$1" = "${name[i]}" ]]
 			then
-				echo "${ver[i]}"
+				if [[ -n "${ver[i]}" ]]
+				then
+					echo "${ver[i]}"
+				else
+					echo "(not installed)"
+				fi
 				unset "name[${i}]" "ver[${i}]"
 				shift && continue 2
 			fi


### PR DESCRIPTION
This patch fixed a phenomena, that on Ubuntu 18.04, a couple of packages are failed to show as `(not installed)`.

```
# go-xcat -x devel check
Operating system:   linux
Architecture:       ppc64le
Linux Distribution: ubuntu
Version:            18.04

Reading repositories ...... done

xCAT Core Packages
==================

Package Name                Installed                      In Repository
------------                ---------                      -------------
perl-xcat                   2.14.2-snap201806220616        2.14.2-snap201806220616
xcat                        2.14.2-snap201806220616        2.14.2-snap201806220616
xcat-buildkit                                              2.14.2-snap201806220616
xcat-client                 2.14.2-snap201806220616        2.14.2-snap201806220616
xcat-confluent              (not installed)                2.14.2-snap201806220616
xcat-genesis-scripts-amd64  2.14.2-snap201806220616        2.14.2-snap201806220616
xcat-genesis-scripts-ppc64  2.14.2-snap201806220616        2.14.2-snap201806220616
xcat-probe                                                 2.14.2-snap201806220616
xcat-server                 2.14.2-snap201806220616        2.14.2-snap201806220616
xcat-test                   (not installed)                2.14.2-snap201806220616
xcat-vlan                   (not installed)                2.14.2-snap201806220616
xcatsn                      (not installed)                2.14.2-snap201806220616

xCAT Dependency Packages
========================

Package Name                Installed                      In Repository
------------                ---------                      -------------
conserver-xcat              8.2.1-1                        8.2.1-1
elilo-xcat                  3.14-4                         3.14-4
goconserver                 0.2.2-snap201803292224         0.2.2-snap201803292224
grub2-xcat                  2.02-0.16.el7.snap201506090204 2.02-0.16.el7.snap201506090204
ipmitool-xcat               1.8.18                         1.8.18
syslinux-xcat               3.86-2                         3.86-2
xcat-genesis-base-amd64     2.14-snap201803282249          2.14-snap201803282249
xcat-genesis-base-ppc64     2.14-snap201803282253          2.14-snap201803282253
xnba-undi                   1.0.3-7                        1.0.3-7
```