### PR TITLE
Catch rflash firmware upload error

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -62,6 +62,7 @@ $::UPLOAD_ACTIVATE_STREAM   = 0;
 $::RFLASH_STREAM_NO_HOST_REBOOT = 0;
 $::NO_ATTRIBUTES_RETURNED   = "No attributes returned from the BMC.";
 $::FAILED_UPLOAD_MSG        = "Failed to upload update file";
+$::FAILED_LOGIN_MSG         = "BMC did not respond. Validate BMC configuration and retry the command.";
 
 $::UPLOAD_WAIT_ATTEMPT      = 6;
 $::UPLOAD_WAIT_INTERVAL     = 10;
@@ -990,7 +991,8 @@ sub process_request {
 
     foreach my $node (keys %node_info) {
         if (!$valid_nodes{$node}) {
-            xCAT::SvrUtils::sendmsg([1, "BMC did not respond. Validate BMC configuration and retry the command."], $callback, $node);
+            xCAT::SvrUtils::sendmsg([1, $::FAILED_LOGIN_MSG], $callback, $node);
+            $node_info{$node}{rst} = $::FAILED_LOGIN_MSG;
             $wait_node_num--;
             next;
         }

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1066,11 +1066,12 @@ rmdir \"/tmp/\$userid\" \n";
                         # In that case check the rflash log file for this node and extract error from there
                         unless ($node_info{$node}{rst}) {
                             my $rflash_log_file = xCAT::Utils->full_path($node.".log", $::XCAT_LOG_RFLASH_DIR);
-                            $node_info{$node}{rst} = "Firmware upload error"; # Generic default message
                             # Extract the upload error from last line in log file 
                             my $upload_error = `tail $rflash_log_file -n1 | grep "$::FAILED_UPLOAD_MSG"`;
                             if ($upload_error) {
                                 $node_info{$node}{rst} = $upload_error;
+                            } else {
+                                $node_info{$node}{rst} = "BMC is not ready";
                             }
                         }
                         push @{ $rflash_result{fail} }, "$node: $node_info{$node}{rst}";


### PR DESCRIPTION
#5312 

Since firmware upload is done in a forked process, the upload errors can not be saved in the $node_info structure. Instead if error occurred, check the rflash log file for the node. If we find an error there, report it in the main process summary section.

```
[root@briggs01 xcat]# rflash mid05tor12cn15 -a /tmp/gurevich/fw.tar
Attempting to upload /tmp/gurevich/fw.tar, please wait...
mid05tor12cn15: Failed to upload update file /tmp/gurevich/fw.tar : 400 Bad Request - Version already exists or failed to be extracted
-------------------------------------------------------
Firmware update complete: Total=1 Success=0 Failed=1
mid05tor12cn15: Failed to upload update file /tmp/gurevich/fw.tar :400 Bad Request - Version already exists or failed to be extracted
-------------------------------------------------------
[root@briggs01 xcat]#
```