### PR TITLE
update case for task195 , add cases for bug #50, xcat-inventory import -d <> -c  can only see the last one after imported

### DIFF
--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.osimage
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.osimage
@@ -1255,3 +1255,34 @@ cmd:file="/opt/xcat/share/xcat/install/rh/template"; rm -rf $file; if [ -d ${fil
 cmd:for file in /tmp/osimages/*.stanza; do cat $file|mkdef -z; done
 cmd:if [ -e /tmp/osimages.bak ]; then mv -f /tmp/osimages.bak /tmp/osimages; fi
 end
+
+start:export_import_osimages_by_dir_with_c
+description:This case is used to test xcat-inventory export and import  linux osimage definition witch -c option.
+label:others,xcat_inventory
+cmd:dir="/tmp/export";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi; mkdir -p $dir
+cmd:imgdir='/tmp/export';for img in $(lsdef -t osimage -s|awk -F' ' '{print $1}'); do lsdef -t osimage -o $img -z > $imgdir/${img}.stanza;done
+check:rc==0
+cmd:for img in $(lsdef -t osimage -s|awk -F' ' '{print $1}');do rmdef -t osimage -o $img;done
+check:rc==0
+cmd:chdef -t osimage -o test_myimage1,test_myimage2,test_myimage3 imagetype=linux provmethod=install
+check:rc==0
+cmd:xcat-inventory export -t osimage -o test_myimage1,test_myimage2 -d /tmp/export
+check:rc==0
+check:output=~The osimage objects has been exported to directory /tmp/export
+cmd:ls -lFR /tmp/export
+cmd: xcat-inventory import -t osimage -d /tmp/export -c
+check:rc==0
+check:output=~Importing object: test_myimage1
+check:output=~Inventory import successfully!
+check:output=~The object test_myimage1 has been imported
+check:output=~Importing object: test_myimage2
+check:output=~Inventory import successfully!
+check:output=~The object test_myimage2 has been imported
+cmd:lsdef -t osimage -o test_myimage1,test_myimage2
+check:rc==0
+cmd:lsdef -t osimage -o test_myimage3
+check:rc!=0
+cmd:rmdef -t osimage -o test_myimage1,test_myimage2
+cmd:for file in /tmp/export/*.stanza; do cat $file|mkdef -z; done
+cmd:dir="/tmp/export"; rm -rf $dir; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi
+end


### PR DESCRIPTION
Case Name: export_import_osimages_by_dir_with_c
description:This case is used to test xcat-inventory export and import  linux osimage definition witch -c option.

The UT result
```
[root@boston02 autotest]# xcattest -f test.conf -t export_import_osimages_by_dir_with_c
xCAT automated test started at Tue Jul  3 01:55:41 2018
******************************
loading Configure file
******************************
Varible:
    CN = mid08tor03cn01
    ISO = /mnt/xcat/iso/redhat/7.5/GA/RHEL-7.5-20180322.0-Server-ppc64le-dvd1.iso
    MN = boston02
******************************
Initialize xCAT test environment by definition in configure file
******************************
******************************
To detect current test environment
******************************
Detecting: OS = linux
Detecting: ARCH = ppc64le
Detecting: HCP = openbmc
******************************
loading test cases
******************************

To run:
export_import_osimages_by_dir_with_c
******************************
Start to run test cases
******************************
------START::export_import_osimages_by_dir_with_c::Time:Tue Jul  3 01:55:42 2018------

RUN:dir="/tmp/export";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi; mkdir -p $dir [Tue Jul  3 01:55:42 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:imgdir='/tmp/export';for img in $(lsdef -t osimage -s|awk -F' ' '{print $1}'); do lsdef -t osimage -o $img -z > $imgdir/${img}.stanza;done [Tue Jul  3 01:55:42 2018]
ElapsedTime:7 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:for img in $(lsdef -t osimage -s|awk -F' ' '{print $1}');do rmdef -t osimage -o $img;done [Tue Jul  3 01:55:49 2018]
ElapsedTime:6 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
1 object definitions have been removed.
1 object definitions have been removed.
1 object definitions have been removed.
1 object definitions have been removed.
1 object definitions have been removed.
1 object definitions have been removed.
1 object definitions have been removed.
1 object definitions have been removed.
1 object definitions have been removed.
1 object definitions have been removed.
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:chdef -t osimage -o test_myimage1,test_myimage2,test_myimage3 imagetype=linux provmethod=install [Tue Jul  3 01:55:55 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
3 object definitions have been created or modified.
New object definitions 'test_myimage3,test_myimage2,test_myimage1' have been created.
CHECK:rc == 0	[Pass]

RUN:xcat-inventory export -t osimage -o test_myimage1,test_myimage2 -d /tmp/export [Tue Jul  3 01:55:56 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
The osimage objects has been exported to directory /tmp/export
CHECK:rc == 0	[Pass]
CHECK:output =~ The osimage objects has been exported to directory /tmp/export	[Pass]

RUN:ls -lFR /tmp/export [Tue Jul  3 01:55:57 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
/tmp/export:
total 56
-rw-r--r-- 1 root root  517 Jul  3 01:55 rhels7.5-alternate-ppc64le-install-compute.stanza
-rw-r--r-- 1 root root  643 Jul  3 01:55 rhels7.5-alternate-ppc64le-install-service.stanza
-rw-r--r-- 1 root root  702 Jul  3 01:55 rhels7.5-alternate-ppc64le-netboot-compute.stanza
-rw-r--r-- 1 root root  687 Jul  3 01:55 rhels7.5-alternate-ppc64le-statelite-compute.stanza
-rw-r--r-- 1 root root  467 Jul  3 01:55 rhels7.5-ppc64le-install-compute.stanza
-rw-r--r-- 1 root root  593 Jul  3 01:55 rhels7.5-ppc64le-install-service.stanza
-rw-r--r-- 1 root root  642 Jul  3 01:55 rhels7.5-ppc64le-netboot-compute.stanza
-rw-r--r-- 1 root root  627 Jul  3 01:55 rhels7.5-ppc64le-statelite-compute.stanza
-rw-r--r-- 1 root root 1736 Jul  3 01:55 test.environments.osimage.stanza
drwxr-xr-x 2 root root 4096 Jul  3 01:55 test_myimage1/
-rw-r--r-- 1 root root  112 Jul  3 01:55 test_myimage1.stanza
drwxr-xr-x 2 root root 4096 Jul  3 01:55 test_myimage2/
-rw-r--r-- 1 root root  112 Jul  3 01:55 test_myimage2.stanza
-rw-r--r-- 1 root root  486 Jul  3 01:55 test_osimage.stanza

/tmp/export/test_myimage1:
total 4
-rw-r--r-- 1 root root 273 Jul  3 01:55 definition.json

/tmp/export/test_myimage2:
total 4
-rw-r--r-- 1 root root 273 Jul  3 01:55 definition.json

RUN:xcat-inventory import -t osimage -d /tmp/export -c [Tue Jul  3 01:55:57 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
Importing object: test_myimage1
Inventory import successfully!
The object test_myimage1 has been imported
Importing object: test_myimage2
Inventory import successfully!
The object test_myimage2 has been imported
CHECK:rc == 0	[Pass]
CHECK:output =~ Importing object: test_myimage1	[Pass]
CHECK:output =~ Inventory import successfully!	[Pass]
CHECK:output =~ The object test_myimage1 has been imported	[Pass]
CHECK:output =~ Importing object: test_myimage2	[Pass]
CHECK:output =~ Inventory import successfully!	[Pass]
CHECK:output =~ The object test_myimage2 has been imported	[Pass]

RUN:lsdef -t osimage -o test_myimage1,test_myimage2 [Tue Jul  3 01:55:59 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Object name: test_myimage1
    imagetype=linux
    provmethod=install
Object name: test_myimage2
    imagetype=linux
    provmethod=install
CHECK:rc == 0	[Pass]

RUN:lsdef -t osimage -o test_myimage3 [Tue Jul  3 01:55:59 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: [boston02]: Could not find an object named 'test_myimage3' of type 'osimage'.
CHECK:rc != 0	[Pass]

RUN:rmdef -t osimage -o test_myimage1,test_myimage2 [Tue Jul  3 01:56:00 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
2 object definitions have been removed.

RUN:for file in /tmp/export/*.stanza; do cat $file|mkdef -z; done [Tue Jul  3 01:56:00 2018]
ElapsedTime:6 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
1 object definitions have been created or modified.
1 object definitions have been created or modified.
1 object definitions have been created or modified.
1 object definitions have been created or modified.
1 object definitions have been created or modified.
1 object definitions have been created or modified.
1 object definitions have been created or modified.
1 object definitions have been created or modified.
1 object definitions have been created or modified.
1 object definitions have been created or modified.
1 object definitions have been created or modified.

RUN:dir="/tmp/export"; rm -rf $dir; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi [Tue Jul  3 01:56:06 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::export_import_osimages_by_dir_with_c::Passed::Time:Tue Jul  3 01:56:06 2018 ::Duration::24 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished at Tue Jul  3 01:56:06 2018
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20180703015541 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20180703015541 file for time consumption
```