### PR TITLE
modify man page of rcons about exit code

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rcons.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rcons.1.rst
@@ -35,7 +35,7 @@ multiple read-only instances of the console, plus console logging.
 
 If \ *conserver-host*\  is specified, the conserver daemon on that host will be contacted, instead of on the local host.
 
-To exit the console session, enter:  <ctrl>e c .
+To exit the console session, enter: 'ctrl-e c .' (3 characters: ctrl-e, 'c' and '.').
 
 
 ***************

--- a/xCAT-client/pods/man1/rcons.1.pod
+++ b/xCAT-client/pods/man1/rcons.1.pod
@@ -16,7 +16,7 @@ multiple read-only instances of the console, plus console logging.
 
 If I<conserver-host> is specified, the conserver daemon on that host will be contacted, instead of on the local host.
 
-To exit the console session, enter:  <ctrl>e c .
+To exit the console session, enter: 'ctrl-e c .' (3 characters: ctrl-e, 'c' and '.').
 
 =head1 B<Options>
 


### PR DESCRIPTION
#5327 

``To exit the console session, enter: 'ctrl-e c .' (3 characters: ctrl-e, 'c' and '.').``