### PR TITLE
Add model type for 'stratton' boxes, 8001-12C model type in firmware flashing

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -1978,7 +1978,7 @@ sub do_firmware_update {
     # P9 Boston (9006-22C, 9006-12C, 5104-22C) or P8 Briggs (8001-22C) 
     # firmware update is done using pUpdate utility expected to be in the 
     # specified data directory along with the update files .bin for BMC or .pnor for Host
-    if ($output =~ /8001-22C|9006-22C|5104-22C|9006-12C/) {
+    if ($output =~ /8001-22C|9006-22C|5104-22C|8001-12C|9006-12C/) {
         # Verify valid data directory was specified
         if (defined $directory_name) {
             unless (File::Spec->file_name_is_absolute($directory_name)) {


### PR DESCRIPTION
Fixes #5336 

After  code change:
```
[root@fs2vm112 OP825]# rflash stratton01 -d v2.20_BMC1.27
stratton01: rflash started, Please wait...
stratton01: Firmware updated, powering chassis on to populate FRU information...
```
Then looking at the rflash logs: 

```
...
*   we like to restore/backup IPMI config through LAN channel with          *
*   - BMC IP address 10.11.12.13 port 623                                   *
*   - IPMI username is usr                                                  *
*   - Password for usr is pwd                                               *
*   - Preserve Configuration                                                *
*   pUpdate -c -f fw.bin -i lan -h 10.11.12.13 623 -u usr -p pwd            *
*   pUpdate -c -d fwdump.bin -i lan -h 10.11.12.13 623 -u usr -p pwd        *
*****************************************************************************

/mnt/xcat/iso/supermicro_firmware/p8/OP825/v2.20_BMC1.27/pUpdate -f /mnt/xcat/iso/supermicro_firmware/p8/OP825/v2.20_BMC1.27/SMT_P8_127.bin -i lan -h 50.6.29.1 -u ADMIN -p ADMIN
Check if this file is valid................
```
