### PR TITLE
Add compute.ubuntu18.04.x86_64.pkglist for Ubuntu 18.04 x86-64 support

### DIFF
--- a/xCAT-server/share/xcat/install/ubuntu/compute.ubuntu18.04.x86_64.pkglist
+++ b/xCAT-server/share/xcat/install/ubuntu/compute.ubuntu18.04.x86_64.pkglist
@@ -1,0 +1,14 @@
+bash
+ifupdown
+nfs-common
+openssl
+isc-dhcp-client
+libc-bin
+openssh-server
+openssh-client
+wget
+vim
+rsync
+busybox-static
+gawk
+dnsutils


### PR DESCRIPTION
For task https://github.com/xcat2/xcat2-task-management/issues/212