### PR TITLE
rflash for ipmi machines enhancements

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -2040,6 +2040,7 @@ sub do_firmware_update {
             $exit_with_error_func->($sessdata->{node}, $callback,
                 "At least one update file (.bin or .pnor) needs to be in data directory $pUpdate_directory.");
         }
+
         # All checks are done, run pUpdate utility on each of the update files found in 
         # the specified data directory
         xCAT::SvrUtils::sendmsg("rflash started, Please wait...", $callback, $sessdata->{node});
@@ -2107,11 +2108,16 @@ sub do_firmware_update {
         $exit_with_success_func->($sessdata->{node}, $callback, "Firmware updated, powering chassis on to populate FRU information...");
     }
 
+    # If we get here, the target machine is *NOT* IBM Power S822LC for Big Data (Supermicro)
+    # Only .hpm files is supported for such machine, no directory option is supported
+    if (defined $directory_name) {
+        $exit_with_error_func->($sessdata->{node}, $callback, "Directory option is not supported for target machine: \n$output");
+    }
     if (($hpm_data_hash{deviceID} ne $sessdata->{device_id}) ||
         ($hpm_data_hash{productID} ne $sessdata->{prod_id}) ||
         ($hpm_data_hash{manufactureID} ne $sessdata->{mfg_id})) {
         $exit_with_error_func->($sessdata->{node}, $callback,
-            "The image file doesn't match this machine");
+            "The image file doesn't match target machine: \n$output");
     }
 
     # check for 8335-GTB Firmware above 1610A release.  If below, exit


### PR DESCRIPTION
#5344 

Some `rflash` ipmi enhancements:

1. When displaying message The image file doesn't match this machine also display machine's info
2. If `-d` option is specified return an error if target machine is not "IBM Power S822LC for Big Data"

```
[root@c910f02c05p03 xcat]# rflash fs1 -d /mnt/xcat/iso/supermicro_firmware/p8/OP825/v2.20_BMC1.27
Error: [c910f02c05p03]: fs1: Directory option is not supported for target machine:
 Chassis Type          : Unknown
 Chassis Part Number   : 8335-GTA
 Chassis Serial        : 0000000000000000
 Board Mfg Date        : Sun Dec 31 19:00:00 1995
 Board Mfg             : IBM
 Board Product         : SYSTEM PLANAR
 Board Serial          : 0000000000000000
 Board Part Number     : 0000000000000000
[root@c910f02c05p03 xcat]#
```

```
[root@c910f02c05p03 xcat]# rflash stratton01 -d /mnt/xcat/iso/supermicro_firmware/p8/OP825/v2.20_BMC1.27
Error: [c910f02c05p03]: stratton01: The image file doesn't match target machine:
 Chassis Type          : Unknown
 Chassis Part Number   : 8001-12ABC
 Chassis Serial        : 130124A
 Board Mfg Date        : Sun Dec 31 19:00:00 1995
 Board Mfg             : IBM
 Board Product         : SYSTEM PLANAR
 Board Serial          : OM168S010286
 Board Part Number     : P8DTU
[root@c910f02c05p03 xcat]#
```