### PR TITLE
fix Statelite provision hung at ``netbooting`` for rhels 6.10 in PPC64

### DIFF
--- a/xCAT-server/lib/xcat/plugins/statelite.pm
+++ b/xCAT-server/lib/xcat/plugins/statelite.pm
@@ -469,7 +469,7 @@ sub process_request {
     $verbose && $callback->({ info => ["put the statelite rc file to $rootimg_dir/etc/init.d/"] });
 
     # rh5,rh6.1 to rh6.4 use rc.statelite.ppc.redhat, otherwise use rc.statelite
-    if (($osver =~ m/^rh[a-zA-Z]*5/) or ($osver =~ m/^rh[a-zA-Z]*6(\.)?[1-4]/) and $arch eq "ppc64") { # special case for redhat5/6.x on PPC64
+    if (($osver =~ m/^rh[a-zA-Z]*5/) or ($osver =~ m/^rh[a-zA-Z]*6(\.)?[1-4]$/) and $arch eq "ppc64") { # special case for redhat5/6.x on PPC64
         system("cp -a $::XCATROOT/share/xcat/netboot/add-on/statelite/rc.statelite.ppc.redhat $rootimg_dir/etc/init.d/statelite");
     } else {
         system("cp -a $::XCATROOT/share/xcat/netboot/add-on/statelite/rc.statelite $rootimg_dir/etc/init.d/statelite");


### PR DESCRIPTION
For https://github.com/xcat2/xcat-core/issues/5294

statelite.pm select wrong rc.statelite.ppc.redhat