### PR TITLE
Add labels for test cases which test DB operation command

### DIFF
--- a/xCAT-test/autotest/testcase/chdef/cases0
+++ b/xCAT-test/autotest/testcase/chdef/cases0
@@ -1,11 +1,13 @@
 start:chdef_null
 description:chdef without any flag
+label:mn_only,db
 cmd:chdef
 check:output=~Usage
 end
 
 start:chdef_t_node
 description:chdef -t node
+label:mn_only,db
 cmd:mkdef -t node -o testnode groups=all
 check:rc==0
 cmd:chdef -t node -o testnode groups=aix
@@ -34,6 +36,7 @@ end
 
 start:chdef_t_network
 description:chdef -t network
+label:mn_only,db
 cmd:chdef -t network -o testnetwork net=111.222.33.0 mask=255.255.255.254
 check:rc==0
 cmd:lsdef -t network -l testnetwork
@@ -52,6 +55,7 @@ end
 
 start:chdef_p
 description:chdef -p -t node
+label:mn_only,db
 cmd:mkdef -t node -o testnode groups=all
 check:rc==0
 cmd:chdef -p -t node -o testnode groups=aix
@@ -63,6 +67,7 @@ end
 
 start:chdef_m
 description:chdef -m -t node
+label:mn_only,db
 cmd:mkdef -t node -o testnode groups=all,testgroup
 check:rc==0
 cmd:chdef -m -t node -o testnode groups=testgroup
@@ -74,6 +79,7 @@ end
 
 start:chdef_z
 description:chdef -z
+label:mn_only,db
 cmd:mkdef -t node -o testnode groups=all
 check:rc==0
 cmd:lsdef testnode -z > /tmp/testnode.stanza
@@ -91,6 +97,7 @@ end
 
 start:chdef_group
 description:chdef with node group
+label:mn_only,db
 cmd:mkdef -t node -o testnode1-testnode2 mgt=hmc cons=hmc groups=all,systemp
 check:rc==0
 cmd:mkdef -t node -o testnode3-testnode4 mgt=ipmi cons=ipmi groups=all,systemx
@@ -127,6 +134,7 @@ end
 
 
 start:chdef_group_p
+label:mn_only,db
 cmd:chdef abcnode1 -p groups=abc
 check:rc==0
 cmd:chdef abcnode2 -p groups=abcabc
@@ -144,6 +152,7 @@ end
 
 start:chdef_dynamic_group
 description:chdef with dynamic node group
+label:mn_only,db
 cmd:mkdef -t node -o testnode1-testnode2 mgt=hmc cons=hmc groups=all,systemp
 check:rc==0
 cmd:mkdef -t node -o testnode3-testnode4 mgt=hmc cons=ipmi groups=all,systemx
@@ -190,6 +199,7 @@ end
 
 start:chdef_multiple_keys
 description:mkdef support for multiple keys in a table, such as ppcdirect
+label:mn_only,db
 cmd: mkdef -t node -o testfsp mgt=fsp cons=fsp groups=all,fsp nodetype=fsp passwd.HMC=abc123 passwd.general=abc123 passwd.admin=abc123
 check:rc==0
 cmd:lsdef testfsp
@@ -210,6 +220,7 @@ end
 
 start:chdef_n
 description:chdef -n
+label:mn_only,db
 cmd:mkdef -t node -o testnode1 mgt=hmc cons=hmc groups=all,systemp
 check:rc==0
 cmd:chdef testnode1 -n testnode2
@@ -228,6 +239,7 @@ end
 
 start:chdef_t_o_error
 description:chdef -t wrongtype
+label:mn_only,db
 cmd:chdef -t wrongtype -o testnode groups=all,aix
 check:rc!=0
 check:output=~not a valid
@@ -235,8 +247,8 @@ end
 
 
 start:chdef_template
-os:linux
 description:try to change a template, a new node is created according to chdef. 
+label:mn_only,db
 cmd:result=`lsdef | grep  switch-template`; if [[ $result =~ "switch-template" ]]; then echo $result; noderm switch-template; fi
 cmd:chdef -t node -o switch-template groups=test
 check:output=~1 object definitions have been created or modified
@@ -249,8 +261,10 @@ check:rc==0
 cmd:noderm switch-template
 check:rc==0
 end
+
 start:chdef_site_check
 description:This case is use to check site table could be changed successfully
+label:mn_only,db
 cmd:var=`lsdef -t site clustersite -i dhcplease|grep 'dhcplease=' |awk -F= '{print $2}'`;echo $var>/tmp/sitevalue;chdef -t site clustersite dhcplease=300
 check:rc==0
 check:output=~1 object definitions have been created or modified.

--- a/xCAT-test/autotest/testcase/chtab/cases0
+++ b/xCAT-test/autotest/testcase/chtab/cases0
@@ -1,5 +1,6 @@
 start:chtab_null
 description:Check chtab with no attr
+label:mn_only,db
 cmd:chtab
 check:rc!=0
 check:output=~Usage
@@ -8,6 +9,7 @@ end
 
 start:chtab_d
 description:check chtab -d 
+label:mn_only,db
 cmd:chtab key=rsh_test site.value=/opt/xcat/bin/rcp site.comments="the rcp command" site.disable=no
 check:rc==0
 cmd:tabdump site | grep rsh_test
@@ -21,6 +23,7 @@ end
 
 start:chtab_modify_node
 description:test chtab with node=XXX
+label:mn_only,db
 cmd:chdef -t node -o testnode groups=rhels5.5
 check:rc==0
 cmd:chtab node=testnode nodelist.groups=all
@@ -33,6 +36,7 @@ end
 
 start:chtab_modify_key
 description:check chtab with key=xxx
+label:mn_only,db
 cmd:chtab key=rsh_test site.value=/opt/xcat/bin/rcp site.comments="the rcp command" 
 check:rc==0
 cmd:tabdump site | grep rsh_test
@@ -52,6 +56,7 @@ end
 
 start:chtab_err_symble
 description: check chtab  with error attr
+label:mn_only,db
 cmd:chtab -t
 check:output=~Usage
 end
@@ -59,6 +64,7 @@ end
 
 start:chtab_err_table
 description:chtab with error table
+label:mn_only,db
 cmd:chtab error=error site.comment=error
 check:rc!=0
 check:output=~no such column|column \"error\" does not exist
@@ -67,6 +73,7 @@ end
 
 start:chtab_h
 description:chtab -h and --help
+label:mn_only,db
 cmd:chtab -h
 check:output=~Usage
 cmd:chtab --help
@@ -76,6 +83,7 @@ end
 
 start:chtab_v
 description:chtab -v and -version
+label:mn_only,db
 cmd:chtab -v
 check:output=~Version
 cmd:chtab -version

--- a/xCAT-test/autotest/testcase/dumpxCATdb/cases0
+++ b/xCAT-test/autotest/testcase/dumpxCATdb/cases0
@@ -1,5 +1,6 @@
 start:dumpxCATdb_h
 description:dumpxCATdb -h
+label:mn_only,db
 cmd:dumpxCATdb -h
 check:rc==0
 check:output=~dumpxCATdb
@@ -7,6 +8,7 @@ end
 
 start:dumpxCATdb_v
 description:Command Version
+label:mn_only,db
 cmd:dumpxCATdb -v
 check:rc==0
 check:output=~Version
@@ -14,6 +16,7 @@ end
 
 start:dumpxCATdb_p_nullskiptables
 description:dumpxCATdb -p path,not skiptables
+label:mn_only,db
 cmd:chtab key=skiptables site.value=""
 check:rc==0
 cmd:dumpxCATdb -p /tmp/db
@@ -29,6 +32,7 @@ end
 
 start:dumpxCATdb_a_p_nullskiptables
 description:dump all,without this flag the eventlog and auditlog will be skipped
+label:mn_only,db
 cmd:chtab key=skiptables site.value=""
 check:rc==0
 cmd:dumpxCATdb -a -p /tmp/db.all
@@ -43,6 +47,7 @@ end
 
 start:dumpxCATdb_p_skiptables
 description:To have dumpxCATdb not backup the hosts or passwd table
+label:mn_only,db
 cmd:chtab key=skiptables site.value="hosts,passwd"
 check:rc==0
 cmd:dumpxCATdb -p /tmp/db.skiptables
@@ -56,6 +61,7 @@ end
 
 start:dumpxCATdb_a_p_skiptables
 description:To have dumpxCATdb all but not backup the hosts or passwd table
+label:mn_only,db
 cmd:chtab key=skiptables site.value="hosts,passwd"
 check:rc==0
 cmd:dumpxCATdb -a -p /tmp/db.skiptables
@@ -70,6 +76,7 @@ end
 
 start:dumpxCATdb_p_nullskiptables_V
 description:test verbose and -p
+label:mn_only,db
 cmd:chtab key=skiptables site.value=""
 check:rc==0
 cmd:dumpxCATdb -p /tmp/db -V
@@ -83,6 +90,7 @@ end
 
 start:dumpxCATdb_a_p_nullskiptables_V
 description:test -V and -a
+label:mn_only,db
 cmd:chtab key=skiptables site.value=""
 check:rc==0
 cmd:dumpxCATdb -a -p /tmp/db -V
@@ -95,6 +103,7 @@ end
 
 start:dumpxCATdb_p_V
 description:test -p -V
+label:mn_only,db
 cmd:chtab key=skiptables site.value="passwd"
 check:rc==0
 cmd:dumpxCATdb -p /tmp/db -V

--- a/xCAT-test/autotest/testcase/gettab/cases0
+++ b/xCAT-test/autotest/testcase/gettab/cases0
@@ -1,4 +1,5 @@
 start:gettab_key_table
+label:mn_only,db
 cmd:gettab key=xcatdport site.value
 check:rc==0
 check:output==3001
@@ -7,6 +8,7 @@ end
 
 start:gettab_H
 description:gettab -H and --with-fieldname
+label:mn_only,db
 cmd:gettab -H key=master site.value
 check:rc==0
 check:output=~site.value:
@@ -17,6 +19,7 @@ end
 
 start:gettab_err
 description:gettab with error symble ,error key ,error attr.
+label:mn_only,db
 cmd:gettab -c
 check:rc!=0
 check:output=~Usage
@@ -30,6 +33,7 @@ end
 
 start:gettab_h
 description:gettab -h and -? and --help
+label:mn_only,db
 cmd:gettab -h
 check:output=~Usage
 cmd:gettab -?

--- a/xCAT-test/autotest/testcase/lsdef/cases0
+++ b/xCAT-test/autotest/testcase/lsdef/cases0
@@ -1,5 +1,6 @@
 start:lsdef_null
 description: lsdef without any flag
+label:mn_only,db
 cmd:mkdef -t node -o testnodell groups=all
 check:rc==0
 cmd:lsdef
@@ -11,6 +12,7 @@ end
 
 start:lsdef_a
 description: lsdef -a and lsdef --all
+label:mn_only,db
 cmd:mkdef -t node -o testnode groups=all
 check:rc==0
 cmd:mkdef -t network -o testnetwork net=1.2.3.0 mask=255.255.255.0
@@ -35,6 +37,7 @@ end
 
 start:lsdef_t_o_l
 description: lsdef -o -l
+label:mn_only,db
 cmd:mkdef -t node -o testnode groups=all
 check:rc==0
 cmd:mkdef -t network -o testnetwork net=1.2.3.0 mask=255.255.255.0
@@ -56,6 +59,7 @@ end
 
 start:lsdef_t_o_l_z
 description: lsdef -l -z
+label:mn_only,db
 cmd:mkdef -t node -o testnode groups=all
 check:rc==0
 cmd:mkdef -t network -o testnetwork net=1.2.3.0 mask=255.255.255.0
@@ -76,6 +80,7 @@ end
 
 start:lsdef_t
 description: lsdef -t
+label:mn_only,db
 cmd:mkdef -t node -o testnode groups=all
 check:rc==0
 cmd:mkdef -t network -o testnetwork net=1.2.3.0 mask=255.255.255.0
@@ -90,6 +95,7 @@ end
 
 start:lsdef_t_i_o
 description: lsdef -i
+label:mn_only,db
 cmd:mkdef -t node -o testnode groups=all
 check:rc==0
 cmd:lsdef -t node -o testnode -i groups
@@ -107,6 +113,7 @@ cmd:rmdef -t network testnetwork
 end
 
 start:lsdef_t_w
+label:mn_only,db
 cmd:mkdef -t node -o testnode11,testnode21 cons=hmc groups=all
 check:rc==0
 cmd:mkdef -t node -o testnode31,testnode41 cons=ipmi groups=linux
@@ -137,6 +144,7 @@ end
 
 start:lsdef_s
 description: lsdef -s
+label:mn_only,db
 cmd:mkdef -t node -o testnode groups=all
 check:rc==0
 cmd:lsdef -s testnode
@@ -147,6 +155,7 @@ end
 
 start:lsdef_t_auditlog
 description:lsdef -t auditlog
+label:mn_only,db
 cmd:tabprune auditlog -a
 check:rc==0
 cmd:lsdef -t auditlog
@@ -156,6 +165,7 @@ end
 
 start:lsdef_t_eventlog
 description:lsdef -t eventlog
+label:mn_only,db
 cmd:tabprune eventlog -a
 check:rc==0
 cmd:lsdef -t eventlog
@@ -165,6 +175,7 @@ end
 
 start:lsdef_t_policy
 description:lsdef -t policy
+label:mn_only,db
 cmd:lsdef -t policy
 check:rc==0
 check:output=~1\s+\(policy\)
@@ -175,6 +186,7 @@ end
 
 start:lsdef_t_site
 description:lsdef -t site
+label:mn_only,db
 cmd:lsdef -t site
 check:rc==0
 check:output=~clustersite
@@ -185,6 +197,7 @@ end
 
 start:lsdef_t_err
 description:lsdef -t wrongtype -o
+label:mn_only,db
 cmd:lsdef -t wrongtype -o test
 check:rc!=0
 check:output=~Error
@@ -192,6 +205,7 @@ end
 
 start:lsdef_t_h_i
 description:lsdef -t node -h -i status
+label:mn_only,db
 cmd:lsdef -t node -h -i status
 check:rc==0
 check:output=~status
@@ -199,6 +213,7 @@ end
 
 start:lsdef_nics
 description:lsdef --nics
+label:mn_only,db
 cmd:mkdef -t node -o testnode1 groups=all mgt=ipmi nicips.eth0=1.1.1.1
 check:rc==0
 cmd:lsdef testnode1 --nics
@@ -211,8 +226,8 @@ check:output=~Could not find
 end
 
 start:lsdef_template
-os:linux
 description:check xCAT supported template
+label:mn_only,db
 cmd:lsdef --template
 check:rc==0
 check:output=~hmc\-template  \(node\)
@@ -224,8 +239,8 @@ check:output=~x86_64kvmguest\-template  \(node\)
 end
 
 start:lsdef_template_switch_template
-os:linux
 description:check xCAT supported template for switch template
+label:mn_only,db
 cmd:lsdef --template switch-template
 check:rc==0
 check:output=~Object name\: switch-template
@@ -241,7 +256,7 @@ check:output=~switchtype\=OPTIONAL\:The type of switch
 end
 
 start:lsdef_template_with_invalid_name
-os:linux
+label:mn_only,db
 description:lsdef --template with invalid template name
 cmd:result=`lsdef | grep  test_with_invalid_name`; if [[ $result =~ "test_with_invalid_name" ]]; then noderm test_with_invalid_name; fi
 cmd:lsdef --template "test_with_invalid_name"

--- a/xCAT-test/autotest/testcase/mkdef/cases0
+++ b/xCAT-test/autotest/testcase/mkdef/cases0
@@ -1,11 +1,13 @@
 start:mkdef_null
 description:mkdef without any flag
+label:mn_only,db
 cmd:mkdef
 check:output=~Usage
 end
 
 start:mkdef_node
 description:mkdef -t node
+label:mn_only,db
 cmd:mkdef -t node -o testnode,testnode1 groups=all,aix
 check:rc==0
 cmd:lsdef -i groups testnode
@@ -19,6 +21,7 @@ end
 
 start:mkdef_f
 description:mkdef -f
+label:mn_only,db
 cmd:mkdef -t node -o testnode groups=all,aix
 check:rc==0
 cmd:mkdef -f -t node -o testnode nodetype=lpar,osi groups=all
@@ -32,6 +35,7 @@ end
 
 start:mkdef_z
 description:mkdef -z
+label:mn_only,db
 cmd:mkdef -t node -o orignode mgt=fsp cons=hmc pprofile=orignode groups=lpar,all
 check:rc==0
 cmd:lsdef -l orignode -z > /tmp/orignode.stanza
@@ -51,6 +55,7 @@ end
 
 start:mkdef_group
 description: mkdef static node group
+label:mn_only,db
 cmd:mkdef -t node -o testnode1-testnode2 mgt=hmc cons=hmc groups=all,systemp
 check:rc==0
 cmd:mkdef -t node -o testnode3-testnode4 mgt=ipmi cons=ipmi groups=all,systemx
@@ -89,6 +94,7 @@ end
 
 start:mkdef_dynamic_group
 description:mkdef with dynamic node group
+label:mn_only,db
 cmd:mkdef -t node -o testnode1-testnode2 mgt=hmc cons=hmc groups=all,systemp
 check:rc==0
 cmd:mkdef -t node -o testnode3-testnode4 mgt=ipmi cons=ipmi groups=all,systemx
@@ -125,6 +131,7 @@ end
 
 start:mkdef_multiple_keys
 description:mkdef support for multiple keys in a table, such as ppcdirect
+label:mn_only,db
 cmd: mkdef -t node -o testfsp mgt=fsp cons=fsp groups=all,fsp nodetype=fsp passwd.HMC=abc123 passwd.general=abc123 passwd.admin=abc123
 check:rc==0
 cmd:lsdef testfsp
@@ -138,6 +145,7 @@ end
 
 start:mkdef_t_network
 description: mkdef -t network
+label:mn_only,db
 cmd:mkdef -t network -o testnetwork net=1.2.3.0 mask=255.255.255.0 gateway=1.2.3.1
 check:rc==0
 cmd:lsdef -t network
@@ -153,6 +161,7 @@ end
 
 start:mkdef_t_o_error
 description:mkdef -t wrongtype
+label:mn_only,db
 cmd:mkdef -t wrongtype -o testnode groups=all,aix
 check:rc!=0
 check:output=~not a valid
@@ -160,8 +169,8 @@ end
 
 
 start:mkdef_template_switch_template_without_attribute
-os:linux
 description:create a node with swtich template without any attributes
+label:mn_only,db
 cmd:result=`lsdef | grep  auto_test_node_1`; if [[ $result =~ "auto_test_node_1" ]]; then echo $result; noderm auto_test_node_1; fi
 cmd:mkdef -t node -o auto_test_node_1 --template switch-template
 check:rc==0
@@ -183,8 +192,8 @@ check:rc==0
 end
 
 start:mkdef_template_cec_template_without_remainder
-os:linux
 description:create a node with cec template once
+label:mn_only,db
 cmd:result=`lsdef | grep  auto_test_cec_node_1`; if [[ $result =~ "auto_test_cec_node_1" ]]; then echo $result; noderm auto_test_cec_node_1; fi
 cmd:mkdef -t node -o auto_test_cec_node_1 --template cec-template serial=test mtm=test hcp=test
 check:rc==0
@@ -206,8 +215,8 @@ check:rc==0
 end
 
 start:mkdef_template_invalid_template
-os:linux
 description:create a node with invalid template 
+label:mn_only,db
 cmd:result=`lsdef | grep  auto_test_node`; if [[ $result =~ "auto_test_node" ]]; then echo $result; noderm auto_test_node; fi
 cmd:result=`lsdef | grep  auto_test_invalid_template`; if [[ $result =~ "auto_test_invalid_template" ]]; then echo $result; noderm auto_test_invalid_template; fi
 cmd:lsdef --template auto_test_invalid_template
@@ -219,8 +228,8 @@ check:output=~Error\: (\[.*?\]: )?Could not find the template object named \'aut
 end
 
 start:mkdef_node_with_a_node_template
-os:linux
 description:create a node with a node template, using cec template to create node at beginning
+label:mn_only,db
 cmd:result=`lsdef | grep  auto_test_cec_node_1`; if [[ $result =~ "auto_test_cec_node_1" ]]; then echo $result; noderm auto_test_cec_node_1; fi
 cmd:result=`lsdef | grep  auto_test_cec_node_2`; if [[ $result =~ "auto_test_cec_node_2" ]]; then echo $result; noderm auto_test_cec_node_2; fi
 cmd:mkdef -t node -o auto_test_cec_node_1 --template cec-template serial=test mtm=test hcp=test groups=test_template
@@ -250,8 +259,8 @@ check:rc==0
 end
 
 start:mkdef_template_cec_template_step_by_step
-os:linux
 description:create a node with cec template step by step
+label:mn_only,db
 cmd:result=`lsdef | grep  auto_test_cec_node_1`; if [[ $result =~ "auto_test_cec_node_1" ]]; then echo $result; noderm auto_test_cec_node_1; fi
 cmd:mkdef -t node -o auto_test_cec_node_1 --template cec-template
 check:rc==1
@@ -282,8 +291,8 @@ check:rc==0
 end
 
 start:check_mkdef_node_with_template_priority
-os:linux
 description:create node named cec-template with cec template at beginning, the node is priority high than tempalate to create a new node
+label:mn_only,db
 cmd:result=`lsdef | grep  cec-template`; if [[ $result =~ "cec-template" ]]; then echo $result; noderm cec-template; fi
 cmd:result=`lsdef | grep  auto_test_cec_node`; if [[ $result =~ "auto_test_cec_node" ]]; then echo $result; noderm auto_test_cec_node; fi
 cmd:mkdef -t node -o cec-template --template cec-template serial=test mtm=test hcp=test groups=test_template_priority
@@ -312,8 +321,8 @@ check:rc==0
 end
 
 start:mkdef_template_diskless_osimage_rootimgdir
-os:linux
 description:check rootimgdir warning message after make new osimage with mkdef --template
+label:cn_os_ready,db
 cmd:mkdef -t osimage -o test-osimage_with_template --template  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 output=~1 object definitions have been created or modified
@@ -324,9 +333,10 @@ check:output=~__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-comput
 cmd:rmdef -t osimage -o test-osimage_with_template
 check:rc==0
 end
+
 start:mkdef_rhels73
-os:linux
 description:create rhels7.3 osimage
+label:mn_only,db
 cmd:mkdef -t osimage -o rhels7.3-test-osimage --template  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 output=~1 object definitions have been created or modified

--- a/xCAT-test/autotest/testcase/mkdef/cases1
+++ b/xCAT-test/autotest/testcase/mkdef/cases1
@@ -1,5 +1,6 @@
 start:mkdef_github_issue2582
 description:Verify github issue 2582
+label:mn_only,db
 cmd:mkdef -t group -o doubletrouble bmc='|\z|-imm|' mgt=ipmi
 check:rc==0
 cmd:mkdef mgt02 groups=doubletrouble
@@ -12,6 +13,7 @@ end
 
 start:mkdef_regex_bmc
 description:The second example in xCAT document Using Regular Expressions in the xCAT Tables
+label:mn_only,db
 cmd:chtab node=compute 'ipmi.bmc=/\z/-bmc/'
 check:rc==0
 cmd:mkdef com02 groups=compute mgt=ipmi
@@ -26,6 +28,7 @@ end
 
 start:mkdef_regex_ip
 description:The third example in xCAT document Using Regular Expressions in the xCAT Tables
+label:mn_only,db
 cmd:chtab node=compute 'hosts.ip=|node(\d+)|10.0.0.($1+0)|'
 check:rc==0
 cmd:mkdef node254 groups=compute
@@ -40,6 +43,7 @@ end
 
 start:mkdef_regex_kvm
 description:The fourth example in xCAT document Using Regular Expressions in the xCAT Tables
+label:mn_only,db
 cmd:chtab node=kvms 'vm.host=|\D+(\d+)\D+(\d+)\D+(\d+)\D+(\d+)|c($1)f($2)x($3)|' 'vm.storage=|\D+(\d+)\D+(\d+)\D+(\d+)\D+(\d+)|dir:///install/vms/vm($4+0)|' vm.memory=3072 vm.cpus=2 vm.nics=virbr2 vm.nicmodel=virtio
 check:rc==0
 cmd:mkdef -t node -o c01f02x03v04 groups=kvms mgt=kvm
@@ -64,6 +68,7 @@ end
 
 start:mkdef_regex_nicsip
 description:Verify the GitHub issue #3047.
+label:mn_only,db
 cmd:rmdef xcattest_tmp_node_sn[01-16]
 cmd:rmdef -t group -o xcattest_tmp_group_regex
 cmd:mkdef -t group -o xcattest_tmp_group_regex

--- a/xCAT-test/autotest/testcase/nodeadd/cases0
+++ b/xCAT-test/autotest/testcase/nodeadd/cases0
@@ -1,10 +1,12 @@
 start:nodeadd_null
 description:nodeadd without any flag
+label:mn_only,db
 cmd:nodeadd
 check:output=~Usage
 end
 
 start:nodeadd_noderange
+label:mn_only,db
 cmd:nodeadd testnode1-testnode2 groups="lpar,all" nodetype.nodetype="lpar,osi"
 check:rc==0
 cmd:lsdef -i groups,nodetype testnode1
@@ -21,6 +23,7 @@ cmd:rmdef -t node -o testnode1-testnode2
 end
 
 start:nodeadd_noderange_nodetype
+label:mn_only,db
 cmd:nodeadd testnode1-testnode2 groups=all,rhel5 nodetype.os=rhel5
 check:rc=0
 cmd:lsdef -i groups,os testnode1
@@ -36,16 +39,19 @@ cmd:rmdef -t node -o testnode1-testnode2
 end
 
 start:nodeadd_v
+label:mn_only,db
 cmd:nodeadd -v
 check:output=~Version
 end
 
 start:nodeadd_h
+label:mn_only,db
 cmd:nodeadd -h
 check:output=~Usage
 end
 
 start:nodeadd_err_symbol
+label:mn_only,db
 cmd:nodeadd testnode magt=unknown
 check:rc!=0
 check:output=~Error

--- a/xCAT-test/autotest/testcase/nodech/cases0
+++ b/xCAT-test/autotest/testcase/nodech/cases0
@@ -1,5 +1,6 @@
 start:nodech_noderange_table
 description:nodech testnode groups=all,rhels5.5 nodetype.os=rhels5.5 nodehm.mgt=hmc
+label:mn_only,db
 cmd:chdef -t node -o testnode groups=all,rhels5.4
 check:rc==0
 cmd:nodech testnode groups=all,rhels5.5 nodetype.os=rhels5.5 nodehm.mgt=hmc
@@ -14,6 +15,7 @@ end
 
 start:nodech_noderange_table_comma
 description:nodech testnode groups,=rhels5.5.Check nodech command with ,=.
+label:mn_only,db
 cmd:chdef -t node -o testnode groups=all
 check:rc==0
 cmd:nodech testnode groups,=rhels5.5
@@ -25,6 +27,7 @@ end
 
 
 start:nodech_noderange_table_arrow
+label:mn_only,db
 cmd:chdef -t node -o testnode groups=all,rhels5.5
 check:rc==0
 cmd:nodech testnode groups^=rhels5.5
@@ -37,6 +40,7 @@ end
 
 start:nodech_noderange_table_comma_arrow
 description:nodech testnode groups^=rhels5.5 groups,=rhels5.4 . Check nodech command with both ^= and ,=.
+label:mn_only,db
 cmd:chdef -t node -o testnode groups=all,rhels5.5
 check:rc==0
 cmd:nodech testnode groups^=rhels5.5 groups,=rhels5.4
@@ -48,6 +52,7 @@ end
 
 start:nodech_noderanage_table_at
 description:nodech testnode nodetype.os=@=helloworld.Check nodech command with =@=.
+label:mn_only,db
 cmd:chdef -t node -o testnode os=hello groups=all
 check:rc==0
 cmd:nodech testnode nodetype.os=@=helloworld
@@ -60,6 +65,7 @@ end
 
 start:nodech_noderange_table_include
 description:nodech groups=~rh4.123456789 groups=rhels5.5.The command nodech with =~.
+label:mn_only,db
 cmd:chdef -t node -o testnode groups=rh4.123456789
 check:rc==0
 cmd:nodech groups=~rh4.123456789 groups=rhels5.5
@@ -71,6 +77,7 @@ end
 
 start:nodech_noderange_table_uninclude
 description:nodech testnode1-testnode2 nodelist.groups\!~rhels5.5 nodelist.groups=rhels5.5,all.The command nodech with !~.
+label:mn_only,db
 cmd:chdef -t node -o testnode1 groups=rhels5.5,all
 check:rc==0
 cmd:chdef -t node -o testnode2 groups=rhels5.4,all
@@ -85,6 +92,7 @@ end
 
 start:nodech_noderange_table_equal
 description:nodech groups==rh4.123456789 groups=rhels5.5.The command nodech with ==.
+label:mn_only,db
 cmd:chdef -t node -o testnode groups=rh4.123456789
 check:rc==0
 cmd:nodech groups==rh4.123456789 groups=rhels5.5
@@ -97,6 +105,7 @@ end
 
 start:nodech_noderange_table_unequal
 description::nodech testnode1-testnode2 groups!=rhels5.5 groups=rhels5.5.The command nodech with !=.
+label:mn_only,db
 cmd:chdef -t node -o testnode1 groups=rhels5.5
 check:rc==0
 cmd:chdef -t node -o testnode2 groups=rhels5.4
@@ -110,6 +119,7 @@ end
 
 start:nodech_noderange_shortname_groups
 description:nodech testnode groups=rhels5.4.The nodech use shortname groups
+label:mn_only,db
 cmd:chdef -t node -o testnode groups=rhels5.5
 check:rc==0
 cmd:nodech testnode groups=rhels5.4
@@ -122,6 +132,7 @@ end
 
 start:nodech_noderange_shortname_tags
 description:nodech testnode tags=rhels5.4.The nodech use shortname tags
+label:mn_only,db
 cmd:chdef -t node -o testnode groups=rhels5.5
 check:rc==0
 cmd:nodech testnode tags=rhels5.4
@@ -134,6 +145,7 @@ end
 
 start:nodech_noderange_shortname_mgt
 description:nodech testnode mgt=hmc.The nodech use shortname mgt
+label:mn_only,db
 cmd:chdef -t node -o testnode mgt=blade  groups=all
 check:rc==0
 cmd:nodech testnode mgt=hmc
@@ -145,6 +157,7 @@ end
 
 start:nodech_delete
 description:nodech -d 
+label:mn_only,db
 cmd:chdef -t node -o testnode os=hello groups=all
 check:rc==0
 cmd:nodech -d testnode nodetype
@@ -156,6 +169,7 @@ end
 
 start:nodech_h
 description:nodech -h
+label:mn_only,db
 cmd:nodech -h
 check:output=~Usage
 cmd:nodech -?
@@ -166,6 +180,7 @@ end
 
 start:nodech_v
 description:nodech -v
+label:mn_only,db
 cmd:nodech -v
 check:output=~Version
 end
@@ -173,6 +188,7 @@ end
 
 start:nodech_d_error
 description:nodech --delete
+label:mn_only,db
 cmd:chdef -t node -o testnode os=hello groups=test
 check:rc==0
 cmd:nodech --delete
@@ -187,6 +203,7 @@ end
 
 start:nodech_error_node
 description: nodech error noderange,nodech testnode1 groups=all,rhels5.5 nodetype.os=rhels5.5 nodehm.mgt=hmc
+label:mn_only,db
 cmd:chdef -t node -o testnode groups=all,rhels5.4
 check:rc==0
 cmd:nodech testnode1 groups=all,rhels5.5 nodetype.os=rhels5.5 nodehm.mgt=hmc
@@ -198,6 +215,7 @@ end
 
 start:nodech_error_table
 description: nodech error table.
+label:mn_only,db
 cmd:chdef -t node -o testnode groups=all,rhels5.4
 check:rc==0
 cmd:nodech testnode groups=all,rhels5.5 nodetypes.os=rhels5.5 nodehm.mgt=hmc

--- a/xCAT-test/autotest/testcase/nodegrpch/cases0
+++ b/xCAT-test/autotest/testcase/nodegrpch/cases0
@@ -1,5 +1,6 @@
 start:nodegrpch_v
 description:nodegrpch -v and --version
+label:mn_only,db
 cmd:nodegrpch -v 
 check:output=~Version
 cmd:nodegrpch --version
@@ -8,6 +9,7 @@ end
 
 start:nodegrpch_h
 description:nodegrpch -? and -h --help
+label:mn_only,db
 cmd:nodegrpch -h
 check:output=~Usage
 cmd:nodegrpch -?
@@ -19,6 +21,7 @@ end
 
 start:nodegrpch_groups
 description:nodegrpch rh4.1234567890 mgt=hmc
+label:mn_only,db
 cmd:chdef -t node -o testnode groups=rh4.1234567890 mgt=blade
 check:rc==0
 cmd:nodegrpch rh4.1234567890 mgt=hmc
@@ -32,6 +35,7 @@ end
 
 start:nodegrpch_err
 description:
+label:mn_only,db
 cmd:nodegrpch -c 
 check:rc!=0
 check:output=~Usage

--- a/xCAT-test/autotest/testcase/nodels/cases0
+++ b/xCAT-test/autotest/testcase/nodels/cases0
@@ -1,5 +1,6 @@
 start:nodels_null
 description:nodels | grep testnode
+label:mn_only,db
 cmd:chdef -t node -o testnode groups="all,aix"
 check:rc==0
 cmd:nodels | grep testnode
@@ -11,6 +12,7 @@ end
 
 start:nodels_noderange_shortname_groups
 description:The nodels use shortname groups
+label:mn_only,db
 cmd:chdef -t node -o testnode groups=rhels5.5
 check:rc==0
 cmd:nodels testnode groups
@@ -22,6 +24,7 @@ end
 
 start:nodels_noderange_shortname_tags
 description:The nodels use shortname tags
+label:mn_only,db
 cmd:chdef -t node -o testnode groups=rhels5.5
 check:rc==0
 cmd:nodels testnode tags
@@ -33,6 +36,7 @@ end
 
 start:nodels_noderange_shortname_mgt
 description:The nodels use shortname mgt
+label:mn_only,db
 cmd:chdef -t node -o testnode mgt=blade groups=all
 check:rc==0
 cmd:nodels testnode mgt
@@ -43,6 +47,7 @@ end
 
 start:nodels_table_include
 description:Check the command nodels with =~.
+label:mn_only,db
 cmd:chdef -t node -o testnode groups=rh4.123456789
 check:rc==0
 cmd:nodels groups=~rh4.123456789 
@@ -54,6 +59,7 @@ end
 
 start:nodels_noderange_table_uninclude
 description:Check the command nodels with !~.
+label:mn_only,db
 cmd:chdef -t node -o testnode1 groups=rhels5.5,all
 check:rc==0
 cmd:chdef -t node -o testnode2 groups=rhels5.4,all
@@ -67,6 +73,7 @@ end
 
 start:nodels_noderange_table_equal
 description:Check the command nodels with ==.
+label:mn_only,db
 cmd:chdef -t node -o testnode groups=rh4.123456789
 check:rc==0
 cmd:nodels groups==rh4.123456789
@@ -78,6 +85,7 @@ end
 
 start:nodels_noderange_table_unequal
 description:Check the command nodels with !=.
+label:mn_only,db
 cmd:chdef -t node -o testnode1 groups=rhels5.5
 check:rc==0
 cmd:chdef -t node -o testnode2 groups=rhels5.4
@@ -90,6 +98,7 @@ end
 
 start:nodels_b
 description:nodels -b and nodels --blame
+label:mn_only,db
 cmd:chdef -t node -o testnode groups=rhels5.5
 check:rc==0
 cmd:nodels testnode -b groups
@@ -103,6 +112,7 @@ end
 
 start:nodels_S
 description:nodels -S
+label:mn_only,db
 cmd:chdef -t node -o testnode hidden=1 groups=rhels5.5  
 check:rc==0
 cmd:nodels -S
@@ -114,6 +124,7 @@ end
 
 start:nodels_H
 description:nodels -H all groups mgt | grep testnode
+label:mn_only,db
 cmd:chdef -t node -o testnode groups="all,aix" mgt="hmc"
 check:rc==0
 cmd:nodels -H all groups mgt | grep testnode
@@ -125,6 +136,7 @@ end
 
 start:nodels_noderange
 description:nodels testnode
+label:mn_only,db
 cmd:chdef -t node -o testnode groups="all,aix"
 check:rc==0
 cmd:nodels testnode
@@ -136,6 +148,7 @@ end
 
 start:nodels_noderange_table
 description:nodels testnode nodelist
+label:mn_only,db
 cmd:chdef -t node -o testnode groups=all
 check:rc==0
 cmd:nodels testnode nodelist
@@ -147,6 +160,7 @@ end
 
 start:nodels_tablevalue
 description:nodels rh4.1234567890
+label:mn_only,db
 cmd:chdef -t node -o testnode groups=rh4.1234567890
 check:rc==0
 cmd:nodels rh4.1234567890
@@ -158,28 +172,13 @@ end
 
 start:nodels_tablevalue_tablecolumn
 description:nodels rh4.1234567890 mgt
+label:mn_only,db
 cmd:chdef -t node -o testnode groups=rh4.1234567890 mgt=hmc
 check:rc==0
 cmd:nodels rh4.1234567890 mgt
 check:rc==0
 check:output=~testnode:\s*hmc
 cmd:rmdef -t node testnode
-end
-
-
-start:nodels_noderange_tablecolumn
-description:nodels testnode nodehm.mgt
-cmd:chdef -t node -o testnode mgt=hmc groups=all
-check:rc==0
-cmd:nodels testnode nodehm.mgt
-check:rc==0
-check:output=~testnode:\s*hmc
-cmd:rmdef -t node testnode
-end
-
-
-start:nodels_tablevalue_tablecolumn
-description:nodels  groups==rh4.1234567890 mgt
 cmd:chdef -t node -o testnode1-testnode4 groups=rh4.1234567890 mgt=hmc
 check:rc==0
 cmd:nodels  groups==rh4.1234567890 mgt
@@ -192,8 +191,23 @@ cmd:rmdef -t node testnode1-testnode4
 end
 
 
+start:nodels_noderange_tablecolumn
+description:nodels testnode nodehm.mgt
+label:mn_only,db
+cmd:chdef -t node -o testnode mgt=hmc groups=all
+check:rc==0
+cmd:nodels testnode nodehm.mgt
+check:rc==0
+check:output=~testnode:\s*hmc
+cmd:rmdef -t node testnode
+end
+
+
+
+
 start:nodels_h
 description:nodels -h and nodels -? and nodels --help
+label:mn_only,db
 cmd:nodels -h
 check:output=~Usage
 cmd:nodels -?
@@ -204,6 +218,7 @@ end
 
 
 start:nodels_v
+label:mn_only,db
 cmd:nodels -v
 check:output=~Version
 cmd:nodels --version
@@ -212,12 +227,14 @@ end
 
 
 start:nodels_err_symbol
+label:mn_only,db
 cmd:nodels -H all unknown
 check:rc!=0
 check:output=~Error
 end
 
 start:nodels_err_noderange
+label:mn_only,db
 cmd:nodels douniwan
 check:rc!=0
 check:output=~Error

--- a/xCAT-test/autotest/testcase/noderange/cases0
+++ b/xCAT-test/autotest/testcase/noderange/cases0
@@ -1,5 +1,6 @@
 start:noderange_individual_node
 description: noderange individual node
+label:mn_only,db
 cmd:mkdef -t node -o testnode01 -f groups=all
 cmd:nodels testnode01
 check:rc==0
@@ -9,6 +10,7 @@ end
 
 start:noderange_individual_grp
 description: noderange individual group
+label:mn_only,db
 cmd:mkdef -t node -o testnode01,testnode02 groups=nrtestgrp
 cmd:nodels nrtestgrp
 check:rc==0
@@ -20,6 +22,7 @@ end
 
 start:noderange_node01-node10
 description: noderange node01-node10
+label:mn_only,db
 cmd:mkdef -t node -o nrtestnode01-nrtestnode10 groups=all
 check:rc==0
 cmd:nodels nrtestnode01-nrtestnode10
@@ -33,6 +36,7 @@ end
 
 start:noderange_node_01-10
 description: noderange node[01-10]
+label:mn_only,db
 cmd:mkdef -t node -o nrtestnode[01-10] groups=all
 check:rc==0
 cmd:nodels nrtestnode[01-10]
@@ -46,6 +50,7 @@ end
 
 start:noderange_node01_10
 description: noderange node[01:10]
+label:mn_only,db
 cmd:mkdef -t node -o nrtestnode[01:10] groups=all
 check:rc==0
 cmd:nodels nrtestnode[01:10]
@@ -59,6 +64,7 @@ end
 
 start:noderange_f1-f2_n1-n3
 description: noderange f[1-2]n[1-3]
+label:mn_only,db
 cmd:mkdef -t node -o f[1-2]n[1-3] groups=all
 check:rc==0
 cmd:nodels f[1-2]n[1-3]
@@ -75,6 +81,7 @@ end
 
 start:noderange_group1-group3
 description: noderange group1-group3
+label:mn_only,db
 cmd:mkdef -t node -o testnode01 groups=nrtestgrp1
 cmd:mkdef -t node -o testnode02 groups=nrtestgrp2
 cmd:mkdef -t node -o testnode03 groups=nrtestgrp3
@@ -89,6 +96,7 @@ end
 
 #start:noderange_node001-node200
 #description: noderange node001-node200
+#label:mn_only,db
 #cmd:mkdef -t node -o nrtestnode001-nrtestnode200 groups=all
 #check:rc==0
 #cmd:nodels nrtestnode001-nrtestnode200
@@ -103,6 +111,7 @@ end
 
 start:noderange_node10_plus_3
 description: noderange node10+3
+label:mn_only,db
 cmd:mkdef -t node -o nrtestnode10+3 groups=all
 check:rc==0
 cmd:nodels nrtestnode10+3
@@ -117,6 +126,7 @@ end
 
 start:noderange_10-20
 description: noderange 10-20
+label:mn_only,db
 cmd:mkdef -t node -o 10-20 groups=all
 check:rc==0
 cmd:nodels 10-20
@@ -132,18 +142,21 @@ end
 
 start:noderange_XCAT_NODE_PREFIX
 description: noderange XCAT_NODE_PREFIX
+label:mn_only,db
 cmd: XCAT_NODE_PREFIX=abc XCATBYPASS=1 nodels 10-20
 check:output=~abc10,abc11,abc12,abc13,abc14,abc15,abc16,abc17,abc18,abc19,abc20
 end
 
 start:noderange_XCAT_NODE_SUFFIX
 description: noderange XCAT_NODE_SUFFIX
+label:mn_only,db
 cmd: XCAT_NODE_PREFIX=abc XCAT_NODE_SUFFIX=def XCATBYPASS=1 nodels 10-20
 check:output=~abc10def,abc11def,abc12def,abc13def,abc14def,abc15def,abc16def,abc17def,abc18def,abc19def,abc20def
 end
 
 start:noderange_slash_urtestnode_dot_star
 description: noderange /nrtestnode.*
+label:mn_only,db
 cmd:mkdef -t node -o nrtestnode1-nrtestnode3 groups=all
 check:rc==0
 cmd:nodels /nrtestnode.*
@@ -157,6 +170,7 @@ end
 
 start:noderange_dir_tmp-nodelistfile
 description: noderange ^/tmp/nodelistfile
+label:mn_only,db
 #cmd:echo #testnode1 > /tmp/nodelist
 cmd:mkdef -t node -o nrnode1,nrnode2 groups=all
 cmd:echo nrnode1 > /tmp/nodelist
@@ -171,6 +185,7 @@ end
 
 start:noderange_exclusion
 description: noderange exnode1-exnode5,-exnode3,-exnode4
+label:mn_only,db
 cmd:mkdef -t node -o exnode1-exnode5 groups=all
 check:rc==0
 cmd:nodels exnode1-exnode5,-exnode3,-exnode4
@@ -186,6 +201,7 @@ end
 
 start:noderange_group_intersection
 description: noderange group1@group2
+label:mn_only,db
 cmd:mkdef -t node -o nrtestnode1-nrtestnode3 groups=group1
 check:rc==0
 cmd:chdef -t node -o nrtestnode1 -p groups=group2

--- a/xCAT-test/autotest/testcase/noderm/cases0
+++ b/xCAT-test/autotest/testcase/noderm/cases0
@@ -1,5 +1,6 @@
 start:noderm_noderange
 description:noderm testnode1,testnode2
+label:mn_only,db
 cmd:nodeadd testnode1,testnode2 groups=all
 check:rc==0
 cmd:lsdef -t node testnode1,testnode2
@@ -14,6 +15,7 @@ end
 
 start:noderm_h
 description:noderm -h
+label:mn_only,db
 cmd:noderm -h
 check:output=~Usage
 cmd:noderm --help
@@ -22,12 +24,14 @@ end
 
 start:noderm_null
 description:noderm
+label:mn_only,db
 cmd:noderm
 check:output=~Usage
 end
 
 start:noderm_err_node
 description:noderm err
+label:mn_only,db
 cmd:rmdef -t node testnode
 cmd:noderm testnode
 check:rc!=0

--- a/xCAT-test/autotest/testcase/regnotif/case0
+++ b/xCAT-test/autotest/testcase/regnotif/case0
@@ -1,5 +1,6 @@
 start:regnotif_null
 description:regnotif with no argument
+label:mn_only,db
 cmd:regnotif
 check:rc==0
 check:output=~Usage
@@ -7,6 +8,7 @@ end
 
 start:regnotif_o
 description:regnotif with normal argument
+label:mn_only,db
 cmd:echo "hello,world" > test.pm
 check:rc==0
 cmd:regnotif test.pm nodelist -o a,d
@@ -18,9 +20,9 @@ cmd:unregnotif test.pm
 cmd:rm -f test.pm
 end
 
-
 start:regnotif_err
 description:regnotif with error arguments
+label:mn_only,db
 cmd:echo "hello,world" > test.pm
 check:rc==0
 cmd:regnotif test.pm  -o a,d
@@ -32,10 +34,9 @@ check:output=~Usage
 cmd:rm -f test.pm
 end
 
-
-
 start:regnotif_h
 description:regnotif -h and --help
+label:mn_only,db
 cmd:regnotif -h 
 check:rc==0
 check:output=~Usage
@@ -47,6 +48,7 @@ end
 
 start:regnotif_v
 description:regnotif -v and --version
+label:mn_only,db
 cmd:regnotif -v
 check:rc==0
 check:output=~Version|version

--- a/xCAT-test/autotest/testcase/restorexCATdb/cases0
+++ b/xCAT-test/autotest/testcase/restorexCATdb/cases0
@@ -1,10 +1,12 @@
 start:restorexCAT_h
+label:mn_only,db
 cmd:restorexCATdb -h
 check:rc==0
 check:output=~restorexCATdb
 end
 
 start:restorexCATdb_v
+label:mn_only,db
 cmd:restorexCATdb -v
 check:rc==0
 check:output=~Version
@@ -12,6 +14,7 @@ end
 
 start:restorexcatdb_p
 description:restore the xcat database from the /tmp/db
+label:mn_only,db
 cmd:chtab key=skiptables site.value=""
 check:rc==0
 cmd:dumpxCATdb -p /tmp/db1
@@ -33,6 +36,7 @@ cmd:rm -rf /tmp/db1 /tmp/db2 /tmp/db.1 /tmp/db.2
 end
 
 start:restorexCATdb_p_V
+label:mn_only,db
 cmd:chtab key=skiptables site.value=""
 check:rc==0
 cmd:dumpxCATdb -a -p /tmp/db
@@ -47,6 +51,7 @@ cmd:rm -rf /tmp/db
 end
 
 start:restorexCATdb_a_p_V
+label:mn_only,db
 cmd:chtab key=skiptables site.value=""
 check:rc==0
 cmd:dumpxCATdb -a -p /tmp/db
@@ -60,6 +65,7 @@ cmd:rm -rf /tmp/db
 end
 
 start:restorexCATdb_wrongpath
+label:mn_only,db
 cmd:restorexCATdb -p /tmp/testpath
 check:rc!=0
 end

--- a/xCAT-test/autotest/testcase/rmdef/cases0
+++ b/xCAT-test/autotest/testcase/rmdef/cases0
@@ -1,11 +1,13 @@
 start:rmdef_null
 description:rmdef without any flag
+label:mn_only,db
 cmd:rmdef
 check:output=~Usage
 end
 
 start:rmdef_t_o_node
 description:rmdef -t node -o
+label:mn_only,db
 cmd:mkdef -t node -o testnode,testnode1 groups=all,aix
 check:rc==0
 cmd:lsdef -t node testnode,testnode1
@@ -20,6 +22,7 @@ end
 
 start:rmdef_t_node
 description:rmdef -t node
+label:mn_only,db
 cmd:mkdef -t node -o testnode,testnode1 groups=all,aix
 check:rc==0
 cmd:lsdef -t node testnode,testnode1
@@ -34,6 +37,7 @@ end
 
 start:rmdef_node
 description:rmdef nodename
+label:mn_only,db
 cmd:mkdef -t node -o testnode,testnode1 groups=all,aix
 check:rc==0
 cmd:lsdef -t node testnode,testnode1
@@ -48,6 +52,7 @@ end
 
 start:rmdef_t_o_network
 description:rmdef -t network
+label:mn_only,db
 cmd:mkdef -t network -o testnet net=1.2.3.0 mask=255.0.0.0 gateway=1.2.3.1 
 check:rc==0
 cmd:lsdef -t network
@@ -60,6 +65,7 @@ end
 
 start:rmdef_group
 description:rmdef to remove static node group
+label:mn_only,db
 cmd:mkdef -t node -o testnode1-testnode2 mgt=hmc cons=hmc groups=all,systemp
 check:rc==0
 cmd:mkdef -t group -o testgrp members=testnode1,testnode2
@@ -81,6 +87,7 @@ end
 
 start:rmdef_dynamic_group
 description:rmdef to remove dynamic node group
+label:mn_only,db
 cmd:mkdef -t node -o testnode1-testnode2 mgt=hmc cons=hmc groups=all,systemp
 check:rc==0
 cmd:mkdef -t group -o dyngrp -d -w mgt==hmc -w cons==hmc -w groups==all,systemp
@@ -124,14 +131,15 @@ end
 
 start:rmdef_t_err
 description:rmdef -t wrongtype
+label:mn_only,db
 cmd:rmdef -t wrongtype -o testnode
 check:rc!=0
 check:output=~not a valid
 end
 
 start:rmdef_template
-os:linux
 description:try to delete a template, then error messages appear 
+label:mn_only,db
 cmd:result=`lsdef | grep  switch-template`; if [[ $result =~ "switch-template" ]]; then echo $result; noderm switch-template; fi
 cmd:rmdef switch-template
 check:rc==1

--- a/xCAT-test/autotest/testcase/tabdump/cases0
+++ b/xCAT-test/autotest/testcase/tabdump/cases0
@@ -1,11 +1,13 @@
 start:tabdump_null
 description:display table list
+label:mn_only,db
 cmd:tabdump
 check:rc==0
 check:output=~site
 end
 
 start:tabdump_table
+label:mn_only,db
 cmd:tabdump site | grep xcatiport
 check:rc==0
 check:output=="xcatiport","3002",,
@@ -13,6 +15,7 @@ end
 
 start:tabdump_v
 description:version
+label:mn_only,db
 cmd:tabdump -v
 check:rc==0
 check:output=~Version
@@ -20,6 +23,7 @@ end
 
 start:tabdump_h
 description:usage
+label:mn_only,db
 cmd:tabdump -h
 check:rc==0
 check:output=~Usage
@@ -27,6 +31,7 @@ end
 
 start:tabdump_help
 description:usage
+label:mn_only,db
 cmd:tabdump -?
 check:rc==0
 check:output=~Usage
@@ -36,6 +41,7 @@ end
 
 start:tabdump_w_match
 description:-w flags to specify the selection string,Select nodes where the attribute value matches the SQL LIKE value.
+label:mn_only,db
 cmd:mkdef -t node -o testnode01 groups="all,aix"
 check:rc==0
 cmd:mkdef -t node -o testnode02 groups="aix"
@@ -50,6 +56,7 @@ end
 
 start:tabdump_w_equal
 description:-w flags to specify the selection string,Select nodes where the attribute value is exactly this value
+label:mn_only,db
 cmd:mkdef -t node -o testnode01 groups="all,aix"
 check:rc==0
 cmd:mkdef -t node -o testnode02 groups="aix"
@@ -63,6 +70,7 @@ cmd:rmdef testnode02
 end
 
 start:tabdump_w_ne
+label:mn_only,db
 cmd:mkdef -t node -o testnode01,testnode02,testnode03 groups="aix"
 check:rc==0
 cmd:mkdef -t node -o testnode04 groups="linux"
@@ -80,6 +88,7 @@ cmd:rmdef testnode04
 end
 
 start:tabdump_w_notmatch
+label:mn_only,db
 cmd:mkdef -t node -o testnode01 groups="all"
 check:rc==0
 cmd:mkdef -t node -o testnode02 groups="aix"
@@ -94,6 +103,7 @@ end
 
 start:tabdump_w_gt
 description:Select nodes where the attribute value is greater than this  specific value
+label:mn_only,db
 cmd:mkdef -t node -o testnode01 groups="aix" statustime=2011-04-19
 check:rc==0
 cmd:mkdef -t node -o testnode02 groups="aix" statustime=2011-04-18
@@ -106,6 +116,7 @@ end
 
 start:tabdump_w_ge
 description:Select nodes where the attribute value is greater than this  specific value
+label:mn_only,db
 cmd:mkdef -t node -o testnode01 groups="aix" statustime=2011-04-19
 check:rc==0
 cmd:mkdef -t node -o testnode02 groups="aix" statustime=2011-04-18
@@ -119,6 +130,7 @@ end
 
 start:tabdump_w_lt
 description:Select nodes where the attribute value is greater than this  specific value
+label:mn_only,db
 cmd:mkdef -t node -o testnode01 groups="aix" statustime=2011-04-19
 check:rc==0
 cmd:mkdef -t node -o testnode02 groups="aix" statustime=2011-04-18
@@ -130,8 +142,8 @@ cmd:rmdef -t node testnode01-testnode02
 end
 
 start:tabdump_w_le
-description:Select nodes where the attribute value is greater than this  specifi
-c value
+description:Select nodes where the attribute value is greater than this  specific value
+label:mn_only,db
 cmd:mkdef -t node -o testnode01 groups="aix" statustime=2011-04-19
 check:rc==0
 cmd:mkdef -t node -o testnode02 groups="aix" statustime=2011-04-18
@@ -145,12 +157,14 @@ end
 
 
 start:tabdump_d
+label:mn_only,db
 cmd:tabdump -d |grep site
 check:rc==0
 check:output=~site:
 end
 
 start:tabdump_f_d
+label:mn_only,db
 cmd:tabdump -f /tmp/table -d site|grep site
 check:rc==0
 check:output=~site
@@ -158,6 +172,7 @@ cmd:rm -f /tmp/table
 end
 
 start:tabdump_d_nodehm
+label:mn_only,db
 cmd:tabdump -d site | grep xcatiport
 check:rc==0
 check:output=~xcatiport

--- a/xCAT-test/autotest/testcase/tabgrep/cases0
+++ b/xCAT-test/autotest/testcase/tabgrep/cases0
@@ -1,5 +1,6 @@
 start:tabgrep_null
 description: tabgrep with no argument
+label:mn_only,db
 cmd:tabgrep
 check:output=~Usage
 end
@@ -8,6 +9,7 @@ end
 
 start:tabgrep_h
 description:tabgrep -h an d -? and --help
+label:mn_only,db
 cmd:tabgrep -h
 check:output=~Usage
 cmd:tabgrep -?
@@ -18,6 +20,7 @@ end
 
 
 start:tabgrep_node
+label:mn_only,db
 cmd:mkdef -t node testnode groups=all
 check:rc==0
 cmd:tabgrep testnode
@@ -29,6 +32,7 @@ end
 
 start:tabgrep_err
 description:tabgrep with error noderange
+label:mn_only,db
 cmd:rmdef -t node testnode
 cmd:tabgrep testnode
 check:rc!=0

--- a/xCAT-test/autotest/testcase/tabprune/cases0
+++ b/xCAT-test/autotest/testcase/tabprune/cases0
@@ -1,5 +1,6 @@
 start:tabprune_h
 description:tabprune -h
+label:mn_only,db
 cmd:tabprune -h
 check:rc==0
 check:output=~Usage
@@ -7,6 +8,7 @@ end
 
 start:tabprune_v
 description:tabprune -v
+label:mn_only,db
 cmd:tabprune -v
 check:rc==0
 check:output=~Version
@@ -14,6 +16,7 @@ end
 
 start:tabprune_a_eventlog
 description:tabprune eventlog -a 
+label:mn_only,db
 cmd:tabprune eventlog -a
 check:rc==0
 check:output!~not a valid xCAT object type
@@ -21,6 +24,7 @@ end
 
 start:tabprune_V_a_eventlog
 description:tabprune eventlog -V -a > /tmp/eventlog.csv
+label:mn_only,db
 cmd:tabprune eventlog -V -a > /tmp/eventlog.csv
 check:rc==0
 cmd:ls /tmp/eventlog.csv
@@ -31,6 +35,7 @@ end
 
 start:tabprune_p_auditlog
 description:to remove 50% of the auditlog table,if the original number is odd number,the final result is 1;or else the final number is 0;
+label:mn_only,db
 #cmd:n1=`lsdef -t auditlog|wc -l`;tabprune auditlog -p 50;n2=`lsdef -t auditlog|wc -l`;echo $((n1-($n2-2)*2))
 cmd:n1=`lsdef -t auditlog|wc -l`;tabprune auditlog -p 50;n2=`lsdef -t auditlog|wc -l`;echo $($n2<n1)
 check:rc=0
@@ -39,6 +44,7 @@ end
 
 start:tabprune_i_auditlog
 description:remove the records whose recid is less than the input recid number
+label:mn_only,db
 cmd:chtab key=auditskipcmds site.value=
 check:rc=0
 cmd:lsdef -t site
@@ -55,7 +61,7 @@ end
 
 start:tabprune_V_n_auditlog
 description:remove 3 records from the auditlog table and display the remove records
-description:tabprune auditlog -V -n 3
+label:mn_only,db
 cmd:chtab key=auditskipcmds site.value=
 check:rc=0
 cmd:lsdef -t site

--- a/xCAT-test/autotest/testcase/tabrestore/cases0
+++ b/xCAT-test/autotest/testcase/tabrestore/cases0
@@ -1,11 +1,13 @@
 start:tabrestore_null
 description:tabrestore without any flag
+label:mn_only,db
 cmd:tabrestore
 check:rc!=0
 check:output=~Usage
 end
 
 start:tabrestore_table
+label:mn_only,db
 cmd:tabdump site > /tmp/site.csv
 check:rc==0
 cmd:chtab key=db2installloc site.value=/test
@@ -20,12 +22,14 @@ cmd:rm -f /tmp/site.csv /tmp/site1.csv
 end
 
 start:tabrestore_h
+label:mn_only,db
 cmd:tabrestore -h
 check:output=~Usage
 end
 
 start:tabrestore_err
 description:tabrestore wrong.csv
+label:mn_only,db
 cmd:tabrestore wrong.csv
 check:rc!=0
 check:output=~Error

--- a/xCAT-test/autotest/testcase/unregnotif/case0
+++ b/xCAT-test/autotest/testcase/unregnotif/case0
@@ -1,5 +1,6 @@
 start:unregnotif_null
 description:unregnotif with no argument
+label:mn_only,db
 cmd:unregnotif
 check:output=~Usage
 end
@@ -7,6 +8,7 @@ end
 
 start:unregnotif_f
 description:unregnotif with a argument filename
+label:mn_only,db
 cmd:echo "hello" > test.pm
 check:rc==0
 cmd:regnotif test.pm nodelist -o a,d
@@ -24,6 +26,7 @@ end
 
 start:unregnotif_h
 description:unregnotif -h and -help
+label:mn_only,db
 cmd:unregnotif -h
 check:output=~Usage
 cmd:unregnotif -help
@@ -32,6 +35,7 @@ end
 
 start:unregnotif_v
 description:unregnotif -v and -version
+label:mn_only,db
 cmd:unregnotif -v
 check:output=~version|Version
 cmd:unregnotif -version

--- a/xCAT-test/autotest/testcase/xcatstanzafile/cases0
+++ b/xCAT-test/autotest/testcase/xcatstanzafile/cases0
@@ -1,6 +1,6 @@
 start:xcatstanzafile_normal
-os:Linux
 description:xcatstanzafile in normal format
+label:mn_only,db
 cmd:echo -e "default-node:\n	groups=all,compute\ntestnode:\n    objtype=node\n    xcatmaster=MS02.ppd.pok.com\n    nfsserver=IS227.ppd.pok.com" > testfile
 check:rc==0
 cmd:cat testfile|chdef -z
@@ -13,24 +13,10 @@ cmd:rmdef -t node testnode
 cmd:rm -f testfile
 end
 
-start:xcatstanzafile_normal
-os:Aix
-description:xcatstanzafile in normal format
-cmd:echo "default-node:\n       groups=all,compute\n testnode:\n    objtype=node\n    xcatmaster=MS02.ppd.pok.com\n    nfsserver=IS227.ppd.pok.com" > testfile
-check:rc==0
-cmd:cat testfile|chdef -z
-check:rc==0
-cmd:lsdef testnode
-check:output=~(groups=all,compute)
-check:output=~xcatmaster=MS02.ppd.pok.com
-check:output=~nfsserver=IS227.ppd.pok.com
-cmd:rmdef -t node testnode
-cmd:rm -f testfile
-end
-
 
 start:xcatstanzafile_colon
 description:xcatstanzafile's header without colon
+label:mn_only,db
 cmd:echo -e "default-node:\n    groups=all,compute\ntestnode\n    objtype=node\n    xcatmaster=MS02.ppd.pok.com\n    nfsserver=IS227.ppd.pok.com" > testfile
 check:rc==0
 cmd:cat testfile|chdef -z
@@ -44,6 +30,7 @@ end
 
 start:xcatstanzafile_attribute
 description:xcatstanzafile with error attribute line
+label:mn_only,db
 cmd:echo -e "default-node:\n    groups=all,compute\ntestnode:\n    objtype=node\n    xcatmasterMS02.ppd.pok.com\n    nfsserver=IS227.ppd.pok.com" > testfile
 check:rc==0
 cmd:cat testfile|chdef -z
@@ -69,6 +56,7 @@ end
 
 start:xcatstanzafile_objtype
 description:xcatstanzafile,a stanza without objtype definition
+label:mn_only,db
 cmd:echo -e "default-node:\n    groups=all,compute\ntestnode:\n    xcatmaster=MS02.ppd.pok.com\n    nfsserver=IS227.ppd.pok.com" > testfile
 check:rc==0
 cmd:cat testfile|mkdef -z
@@ -80,6 +68,7 @@ end
 
 #start:xcatstanzafile_comment
 #description:xcatstanzafile,a stanza without objtype definition
+#label:mn_only,db
 #cmd:echo -ne "default-node:\n    groups=all,compute\ntestnode:\n    objtype=node\n    xcatmaster=MS02.ppd.pok.com\n    nfsserver=IS227.ppd.pok.com" > testfile
 #check:rc==0
 #cmd:echo '#abc' >> testfile
@@ -91,8 +80,8 @@ end
 
 
 start:xcatstanzafile_tab
-os:Linux
 description:xcatstanzafile,line with tab and space
+label:mn_only,db
 cmd:echo -e "default-node:\n    groups=all,compute\ntestnode:\n    objtype=node\n    xcatmaster	=	MS02.ppd.pok.com\n    nfsserver=IS227.ppd.pok.com" > testfile
 check:rc==0
 cmd:cat testfile|mkdef -z
@@ -101,21 +90,9 @@ cmd:rmdef -t node testnode
 cmd:rm -f testfile
 end
 
-start:xcatstanzafile_tab
-os:Aix
-description:xcatstanzafile,line with tab and space
-cmd:echo "default-node:\n    groups=all,compute\n testnode:\n    objtype=node\n    xcatmaster   =       MS02.ppd.pok.com\n    nfsserver=IS227.ppd.pok.com" > testfile
-check:rc==0
-cmd:cat testfile|mkdef -z
-check:rc==0
-cmd:rmdef -t node testnode
-cmd:rm -f testfile
-end
-
-
 start:xcatstanzafile_multattr
-os:Linux
 description:xcatstanzafile,line with multiple attribute
+label:mn_only,db
 cmd:echo -e "default-node:\n    groups=all,compute\ntestnode:\n    objtype=node\n    xcatmaster= MS02.ppd.pok.com	nfsserver=IS227.ppd.pok.com" > testfile
 check:rc==0
 cmd:cat testfile|mkdef -z
@@ -126,24 +103,10 @@ cmd:rmdef -t node testnode
 cmd:rm -f testfile
 end
 
-start:xcatstanzafile_multattr
-os:Aix
-description:xcatstanzafile,line with multiple attribute
-cmd:echo "default-node:\n    groups=all,compute\n testnode:\n    objtype=node\n    xcatmaster= MS02.ppd.pok.com nfsserver=IS227.ppd.pok.com" > testfile
-check:rc==0
-cmd:cat testfile|mkdef -z
-check:rc==0
-cmd:lsdef testnode
-check:output=~\s*xcatmaster=MS02.ppd.pok.com\s*nfsserver=IS227.ppd.pok.com
-cmd:rmdef -t node testnode
-cmd:rm -f testfile
-end
-
-
 
 start:xcatstanzafile_defaultvalue
-os:Linux
 description:xcatstanzafile,If the header name is ``default-<object type>:'' the attribute values in the stanza are considered default values for subsequent definitions in the file that are the same object type.
+label:mn_only,db
 cmd:echo -e "default-node:\n    groups=all,compute\ntestnode:\n    objtype=node\n    xcatmaster= MS02.ppd.pok.com\n       nfsserver=IS227.ppd.pok.com" > testfile
 check:rc==0
 cmd:cat testfile|mkdef -z
@@ -154,23 +117,9 @@ cmd:rmdef -t node testnode
 cmd:rm -f testfile
 end
 
-start:xcatstanzafile_defaultvalue
-os:Aix
-description:xcatstanzafile,If the header name is ``default-<object type>:'' the attribute values in the stanza are considered default va
-lues for subsequent definitions in the file that are the same object type.
-cmd:echo "default-node:\n    groups=all,compute\n testnode:\n    objtype=node\n    xcatmaster= MS02.ppd.pok.com\n       nfsserver=IS227.ppd.pok.com" > testfile
-check:rc==0
-cmd:cat testfile|mkdef -z
-check:rc==0
-cmd:lsdef testnode
-check:output=~(groups=all,compute)
-cmd:rmdef -t node testnode
-cmd:rm -f testfile
-end
-
-
 start:xcatstanzafile_specificvalue
 description:When a specific value for an attribute is provided in the stanza, it takes priority over any default value that had been set.
+label:mn_only,db
 cmd:bash -c 'echo -e "default-node:\n    groups=all,compute\ntestnode:\n    objtype=node\n    groups=all,rhels5.5\n	xcatmaster= MS02.ppd.pok.com\n       nfsserver=IS227.ppd.pok.com" > testfile'
 check:rc==0
 cmd:cat testfile|mkdef -z
@@ -180,10 +129,5 @@ check:output=~groups=all,rhels5.5
 cmd:rmdef -t node testnode
 cmd:rm -f testfile
 end
-
-
-
-
-
 
 


### PR DESCRIPTION
Add labels for ``mn_only`` test cases.

* Add labels for test cases which test DB operation command
* Deleted some ``AIX`` test case at same time
* combine few test case which have same case name at same time

Related task xcat2/xcat2-task-management#208
