### PR TITLE
remove date in updatenode message, for ticket Request removal of datefrom  line in xCAT framework, idea? #5348

### DIFF
--- a/xCAT/postscripts/xcatdsklspost
+++ b/xCAT/postscripts/xcatdsklspost
@@ -887,7 +887,7 @@ run_ps () {
  fi
 
  if [ -f \$1 ]; then 
-  echo \"\`date\` Running \$scriptype: \$1\"
+  echo \"Running \$scriptype: \$1\"
   msgutil_r \"\$MASTER_IP\" \"info\" "\"Running \$scriptype: \$1\"" \"\$logfile\" \"xcat.mypostscript\"
   if [ \"\$XCATDEBUGMODE\" = \"1\" ] || [ \"\$XCATDEBUGMODE\" = \"2\" ]; then
      local compt=\$(file \$1)


### PR DESCRIPTION
UT:
```
[root@briggs01 ~]# updatenode mid05tor12cn15 -Psyslog
mid05tor12cn15: trying to download postscripts...
mid05tor12cn15: postscripts downloaded successfully
mid05tor12cn15: trying to get mypostscript from 172.12.253.27...
mid05tor12cn15: Running postscript: syslog
mid05tor12cn15: postscript: syslog exited with code 0
mid05tor12cn15: Running of postscripts has completed.
```