### PR TITLE
diskless support root options in addkcmdline 

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
@@ -78,13 +78,13 @@ elif [ -r /rootimg.cpio.gz ] || [ -r /rootimg.cpio.xz ]; then
     logger $SYSLOGHOST -t $log_label -p local4.info "Setting up RAM-root tmpfs on downloaded rootimg.cpio.[gz/xz]..."
     echo Setting up RAM-root tmpfs.
     rootopts="mode=755"
-    if [ -n $rflags ]; then
-        rootopts="$rootopts"",""$rflags"
+    if [ -n "$rflags" ]; then
+        rootopts="$rootopts","$rflags"
     fi
-    if [ -z $rootlimit ];then
+    if [ -z "$rootlimit" ];then
         mount -t tmpfs -o $rootopts rootfs $NEWROOT
     else
-        mount -t tmpfs -o "$rootopts"size=$rootlimit rootfs $NEWROOT
+        mount -t tmpfs -o "$rootopts",size=$rootlimit rootfs $NEWROOT
     fi
 
     cd $NEWROOT

--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
@@ -84,7 +84,7 @@ elif [ -r /rootimg.cpio.gz ] || [ -r /rootimg.cpio.xz ]; then
     if [ -z $rootlimit ];then
         mount -t tmpfs -o $rootopts rootfs $NEWROOT
     else
-        mount -t tmpfs -o mode=755,size=$rootlimit rootfs $NEWROOT
+        mount -t tmpfs -o "$rootopts"size=$rootlimit rootfs $NEWROOT
     fi
 
     cd $NEWROOT

--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
@@ -10,7 +10,7 @@ XCATMASTER=$XCAT
 STATEMNT="$(getarg STATEMNT=)"
 rootlimit="$(getarg rootlimit=)"
 xcatdebugmode="$(getarg xcatdebugmode=)"
-
+rflags="$(getarg rootflags=)"
 getarg nonodestatus
 NODESTATUS=$?
 
@@ -77,8 +77,12 @@ if [ -r /rootimg.sfs ]; then
 elif [ -r /rootimg.cpio.gz ] || [ -r /rootimg.cpio.xz ]; then
     logger $SYSLOGHOST -t $log_label -p local4.info "Setting up RAM-root tmpfs on downloaded rootimg.cpio.[gz/xz]..."
     echo Setting up RAM-root tmpfs.
+    rootopts="mode=755"
+    if [ -n $rflags ]; then
+        rootopts="$rootopts"",""$rflags"
+    fi
     if [ -z $rootlimit ];then
-        mount -t tmpfs -o mode=755 rootfs $NEWROOT
+        mount -t tmpfs -o $rootopts rootfs $NEWROOT
     else
         mount -t tmpfs -o mode=755,size=$rootlimit rootfs $NEWROOT
     fi


### PR DESCRIPTION
for https://github.ibm.com/DCS-research/WSC-coral/issues/1385#issuecomment-6770314 and https://github.com/xcat2/xcat-core/issues/2470

UT:
1, add addkcmdline for node definition:
```
chdef mid05tor12cn15 addkcmdline='rootflags=rw,mode=755,mpol=interleave:0,8'
```

2,
In debug mode , dracut switch_root:
```
switch_root:/# mount |grep rootfs
rootfs on / type rootfs (rw,size=127184768k,nr_inodes=1987262)
rootfs on /sysroot type tmpfs (rw,relatime,mode=755,mpol=interleave:0,8)
switch_root:/# egrep FilePages /sys/devices/system/node/node{0,8}/meminfo
/sys/devices/system/node/node0/meminfo:Node 0 FilePages:       1049792 kB
/sys/devices/system/node/node8/meminfo:Node 8 FilePages:        778752 kB
--
```
3.
In diskless node:
```
[root@mid05tor12cn15 ~]# mount|grep rootfs
rootfs on / type tmpfs (rw,relatime,mode=755,mpol=interleave:0,8)
[root@mid05tor12cn15 ~]#  egrep FilePages /sys/devices/system/node/node{0,8}/meminfo
/sys/devices/system/node/node0/meminfo:Node 0 FilePages:        727296 kB
/sys/devices/system/node/node8/meminfo:Node 8 FilePages:        703232 kB
```


