### PR TITLE
update hwinv table by updatenode -P geinv

### DIFF
--- a/xCAT-server/lib/xcat/plugins/updatehwinv.pm
+++ b/xCAT-server/lib/xcat/plugins/updatehwinv.pm
@@ -1,0 +1,68 @@
+#!/usr/bin/perl
+# IBM(c) 2018 EPL license http://www.eclipse.org/legal/epl-v10.html
+
+package xCAT_plugin::updatehwinv;
+
+BEGIN
+{
+    $::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : '/opt/xcat';
+}
+use lib "$::XCATROOT/lib/perl";
+use strict;
+use warnings "all";
+use xCAT::Table;
+use xCAT::Utils;
+
+#-------------------------------------------------------
+
+=head3  handled_commands
+
+  Return list of commands handled by this plugin
+
+=cut
+
+#-------------------------------------------------------
+sub handled_commands {
+    return {
+        updatehwinv => 'updatehwinv',
+    };
+}
+
+sub process_request {
+    my $req      = shift;
+    my $callback = shift;
+
+    if ($req->{command}->[0] eq "updatehwinv") {
+        update_hw_inv($req);
+    }
+}
+
+sub update_hw_inv {
+    my $request = shift;
+    my $node     = $request->{'_xcat_clienthost'}->[0];
+
+    my @nodefs;
+    my $basicdata;
+
+    my @hwinv_info = ("cpucount", "cputype", "memory", "disksize");
+
+    foreach my $hwinv_type (@hwinv_info) {
+        if (defined($request->{$hwinv_type}) and $request->{$hwinv_type}->[0]) {
+            $basicdata->{$hwinv_type} = $request->{$hwinv_type}->[0];
+        } else {
+            push @nodefs, $hwinv_type;
+        }
+    }
+
+    if ($basicdata) {
+        my $hwinv_tab = xCAT::Table->new("hwinv", -create => 1);
+        xCAT::MsgUtils->message("S", "xcat.hwinv: Update hwinv for $node"); 
+        $hwinv_tab->setNodeAttribs($node, $basicdata);
+    }
+    if (@nodefs) {
+        my $nodef = join(",", @nodefs);
+        xCAT::MsgUtils->message("E", "xcat.hwinv: No valid hwinv info $nodef received from $node");
+    }
+}
+
+1;

--- a/xCAT-server/sbin/xcatconfig
+++ b/xCAT-server/sbin/xcatconfig
@@ -1360,6 +1360,8 @@ sub initDB
 "$::XCATROOT/sbin/chtab priority=4.8 policy.commands=litetree policy.rule=allow;";
             $chtabcmds .=
 "$::XCATROOT/sbin/chtab priority=4.9 policy.commands=getadapter policy.rule=allow;";
+            $chtabcmds .=
+"$::XCATROOT/sbin/chtab priority=4.10 policy.commands=updatehwinv policy.rule=allow;";
         }
         my $outref = xCAT::Utils->runcmd("$chtabcmds", 0);
         if ($::RUNCMD_RC != 0)

--- a/xCAT/postscripts/getinv
+++ b/xCAT/postscripts/getinv
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+if [ -z "$XCATDEST" ]; then
+    XCATDEST=$1
+fi
+
+if [ -z "$XCATDEST" ]; then
+    XCATDEST=$MASTER_IP:$XCATDPORT
+fi
+
+tmp_file=/tmp/invinfo.xml
+
+CPUCOUNT=`lscpu | grep "^CPU(s)" | awk -F':' '{print $2}' | sed 's/^[ \t]*//g'`
+CPUTYPE=`lscpu | grep "Model name" | awk -F':' '{print $2}' | sed 's/^[ \t]*//g'`
+MEMORY=`cat /proc/meminfo |grep MemTotal|awk '{printf "%.0fMB\n", $2/1024}'`
+DISKSIZE="$(grep -v name /proc/partitions |sort -g -k 1,2 |awk 'BEGIN{sep=""} /[^0-9]$/{printf("%s%s:%.0fGB", sep, $4, $3/1024^2) ; sep=","}')"
+
+echo "<xcatrequest>" > $tmp_file
+echo "<command>updatehwinv</command>" >> $tmp_file
+echo "<cpucount>$CPUCOUNT</cpucount>" >> $tmp_file
+echo "<cputype>$CPUTYPE</cputype>" >> $tmp_file
+echo "<memory>$MEMORY</memory>" >> $tmp_file
+echo "<disksize>$DISKSIZE</disksize>" >> $tmp_file
+echo "</xcatrequest>" >> $tmp_file
+
+xml_file=/tmp/hwinv.xml
+rm -f $xml_file
+
+while [ ! -f $xml_file ] || grep error $xml_file; do
+    if [ -f $xml_file ]; then
+        timer=60
+        while [ $timer -gt 0 ]; do
+            sleep 1
+            echo -en  "Retrying in $timer seconds  \r"
+            timer=$(($timer-1));
+        done
+    fi
+ 
+    if [ -f /etc/xcat/cert.pem -a -f /etc/xcat/certkey.pem ]; then
+        cat $tmp_file | openssl s_client -key /etc/xcat/certkey.pem -cert /etc/xcat/cert.pem -connect $XCATDEST -quiet 2> /dev/null > $xml_file
+    else
+        cat $tmp_file | openssl s_client -connect $XCATDEST -quiet 2> /dev/null > $xml_file
+    fi
+done
+
+rm $tmp_file


### PR DESCRIPTION
#5345 
Run ``updatenode`` with xcatdebugmode is 1
```
# updatenode c910f03c17k20 -P getinv
c910f03c17k20: vpdupdate is not supported on the pSeries KVM Guest platform
c910f03c17k20: updating VPD database
c910f03c17k20: trying to download postscripts...
c910f03c17k20: postscripts downloaded successfully
c910f03c17k20: trying to get mypostscript from 10.3.17.21...
c910f03c17k20: Wed Jul  4 02:38:48 EDT 2018 Running postscript: getinv
c910f03c17k20: + '[' -z '' ']'
c910f03c17k20: + XCATDEST=
c910f03c17k20: + '[' -z '' ']'
c910f03c17k20: + XCATDEST=10.3.17.21:3001
c910f03c17k20: + tmp_file=/tmp/invinfo.xml
c910f03c17k20: + '[' -r /sys/devices/virtual/dmi/id/product_name ']'
c910f03c17k20: + '[' -r /proc/device-tree/model ']'
c910f03c17k20: + grep -e '^cpu\s*:' /proc/cpuinfo
c910f03c17k20: + read line
c910f03c17k20: + echo cpu : POWER8E '(raw),' altivec supported
c910f03c17k20: + read line
c910f03c17k20: + echo cpu : POWER8E '(raw),' altivec supported
c910f03c17k20: + read line
c910f03c17k20: + echo cpu : POWER8E '(raw),' altivec supported
c910f03c17k20: + read line
c910f03c17k20: + echo cpu : POWER8E '(raw),' altivec supported
c910f03c17k20: + read line
c910f03c17k20: ++ cat /proc/cpuinfo
c910f03c17k20: ++ grep -e '^cpu\s*:'
c910f03c17k20: ++ wc -l
c910f03c17k20: + CPUCOUNT=4
c910f03c17k20: ++ cat /tmp/cpumod
c910f03c17k20: ++ awk -F: '{print $2}'
c910f03c17k20: ++ sed -e 's/^ //'
c910f03c17k20: + CPUTYPE='POWER8E (raw), altivec supported'
c910f03c17k20: ++ cat /proc/meminfo
c910f03c17k20: ++ awk '{printf "%.0fMB\n", $2/1024}'
c910f03c17k20: ++ grep MemTotal
c910f03c17k20: + MEMORY=6119MB
c910f03c17k20: ++ grep -v name /proc/partitions
c910f03c17k20: ++ awk 'BEGIN{sep=""} /[^0-9]$/{printf("%s%s:%.0fGB", sep, $4, $3/1024^2) ; sep=","}'
c910f03c17k20: ++ sort -g -k 1,2
c910f03c17k20: + DISKSIZE=sda:40GB
c910f03c17k20: + echo '<xcatrequest>'
c910f03c17k20: + echo '<command>updatehwinv</command>'
c910f03c17k20: + echo '<cpucount>4</cpucount>'
c910f03c17k20: + echo '<cputype>POWER8E (raw), altivec supported</cputype>'
c910f03c17k20: + echo '<memory>6119MB</memory>'
c910f03c17k20: + echo '<disksize>sda:40GB</disksize>'
c910f03c17k20: + echo '</xcatrequest>'
c910f03c17k20: + xml_file=/tmp/hwinv.xml
c910f03c17k20: + rm -f /tmp/hwinv.xml
c910f03c17k20: + '[' '!' -f /tmp/hwinv.xml ']'
c910f03c17k20: + '[' -f /tmp/hwinv.xml ']'
c910f03c17k20: + '[' -f /etc/xcat/cert.pem -a -f /etc/xcat/certkey.pem ']'
c910f03c17k20: + cat /tmp/invinfo.xml
c910f03c17k20: + openssl s_client -connect 10.3.17.21:3001 -quiet
c910f03c17k20: + '[' '!' -f /tmp/hwinv.xml ']'
c910f03c17k20: + grep error /tmp/hwinv.xml
c910f03c17k20: + rm /tmp/cpumod
c910f03c17k20: + rm /tmp/invinfo.xml
c910f03c17k20: postscript: getinv exited with code 0
c910f03c17k20: Running of postscripts has completed.
```
result:
```
# tabdump hwinv
#node,cputype,cpucount,memory,disksize,comments,disable
"c910f03c17k20","POWER8E (raw), altivec supported","4","6119MB","sda:40GB",,
```