### PR TITLE
fix issue 2306: Need to clean up the temporary xCAT node during discovery regarding rcons

### DIFF
--- a/xCAT-server/lib/xcat/plugins/nodediscover.pm
+++ b/xCAT-server/lib/xcat/plugins/nodediscover.pm
@@ -481,6 +481,15 @@ sub process_request {
             }
         }
     }
+    if (-x "/usr/bin/goconserver") {
+        xCAT::MsgUtils->message("S", "xcat.discovery.nodediscover: clean up undefined nodes from goconserver");
+        require xCAT::Goconserver;
+        if (xCAT::Goconserver::is_goconserver_running()) {
+            xCAT::Goconserver::cleanup_nodes(undef);
+        }
+    } else {
+        xCAT::MsgUtils->message("S", "xcat.discovery.nodediscover: After discovery done, please use 'makeconservercf -C' to clean up undefined nodes from conserver");
+    }
 
 
     my $restartstring = "restart";

--- a/xCAT-server/lib/xcat/plugins/nodediscover.pm
+++ b/xCAT-server/lib/xcat/plugins/nodediscover.pm
@@ -456,9 +456,25 @@ sub process_request {
         $callback->({ error => ["The node [$node] should have a correct IP address which belongs to the management network."], errorcode => ["1"] });
         return;
     }
+
+    my $bmc_node = undef;
+    if (defined($request->{bmc_node}) and defined($request->{bmc_node}->[0])) {
+        $bmc_node = $request->{bmc_node}->[0];
+    }
+    
+    if (-x "/usr/bin/goconserver") {
+        xCAT::MsgUtils->message("S", "xcat.discovery.nodediscover: remove gocons session for $bmc_node");
+        require xCAT::Goconserver;
+        if (xCAT::Goconserver::is_goconserver_running()) {
+            my $api_url = "https://localhost:". xCAT::Goconserver::get_api_port();
+            xCAT::Goconserver::delete_nodes($api_url, {"$bmc_node" => 1}, 1, $callback);
+        }
+    } else {
+        xCAT::MsgUtils->message("S", "xcat.discovery.nodediscover: After discovery done, please use 'makeconservercf -C' to clean up undefined nodes from conserver");
+    }
+
     if (defined($request->{bmcinband})) {
-        if (defined($request->{bmc_node}) and defined($request->{bmc_node}->[0])) {
-            my $bmc_node = $request->{bmc_node}->[0];
+        if (defined($bmc_node)) {
             xCAT::MsgUtils->message("S", "xcat.discovery.nodediscover: Removing discovered BMC nodes definition: $bmc_node...");
             my $rmcmd = "rmdef $bmc_node";
             xCAT::Utils->runcmd($rmcmd, 0);
@@ -470,8 +486,7 @@ sub process_request {
             }
         }
     } else {
-        if (defined($request->{bmc_node}) and defined($request->{bmc_node}->[0])) {
-            my $bmc_node = $request->{bmc_node}->[0];
+        if (defined($bmc_node)) {
             if ($bmc_node =~ /\,/) {
                 xCAT::MsgUtils->message("W", "Multiple BMC nodes matched with no bmcinband specified, please remove manually");
             } else {
@@ -481,16 +496,7 @@ sub process_request {
             }
         }
     }
-    if (-x "/usr/bin/goconserver") {
-        xCAT::MsgUtils->message("S", "xcat.discovery.nodediscover: clean up undefined nodes from goconserver");
-        require xCAT::Goconserver;
-        if (xCAT::Goconserver::is_goconserver_running()) {
-            xCAT::Goconserver::cleanup_nodes(undef);
-        }
-    } else {
-        xCAT::MsgUtils->message("S", "xcat.discovery.nodediscover: After discovery done, please use 'makeconservercf -C' to clean up undefined nodes from conserver");
-    }
-
+    
 
     my $restartstring = "restart";
     if (scalar @forcenics > 0) {


### PR DESCRIPTION
add "makegocons -C" to cleanup all undefined node
Fix issue #2306 

The log in cluster.log:
```
# tail -f /var/log/xcat/cluster.log |grep xcat.discovery.nodediscover
Jul  5 03:22:38 briggs01 xcat[125707]: xcat.discovery.nodediscover: remove gocons session for node-8335-gtc-785260a
Jul  5 03:22:39 briggs01 xcat[125707]: xcat.discovery.nodediscover: Removing discovered BMC nodes definition: node-8335-gtc-785260a...
Jul  5 03:22:39 briggs01 xcat[125707]: xcat.discovery.nodediscover: node-8335-gtc-785260a definition removed from xCAT
Jul  5 03:22:39 briggs01 xcat[125707]: xcat.discovery.nodediscover: mid05tor12cn16 has been discovered
```
The console output:
```# rcons node-8335-gtc-785260a
[Enter `^Ec?' for help]
goconserver(2018-07-05T03:22:21-04:00): Hello 10.6.27.1:54540, welcome to the session of node-8335-gtc-785260a

[xCAT Genesis running on mid05tor12cn16 /]#
[xCAT Genesis running on mid05tor12cn16 /]#
[xCAT Genesis running on mid05tor12cn16 /]# /bin/dodiscovery
<166>Jul  5 03:19:09 xcat.genesis.dodiscovery: Beginning node discovery process...
<166>Jul  5 03:19:09 xcat.genesis.dodiscovery: Waiting for nics to get addresses
enP5p1s0f0|172.12.139.16
<166>Jul  5 03:19:09 xcat.genesis.dodiscovery: Network configuration complete, commencing transmit of discovery packets
<166>Jul  5 03:19:09 xcat.genesis.dodiscovery: Beginning echo information to discovery packet file...
<166>Jul  5 03:19:12 xcat.genesis.dodiscovery: Discovery packet file is ready.
<166>Jul  5 03:19:12 xcat.genesis.dodiscovery: Sending the discovery packet to xCAT (172.12.253.27:3001)...
<166>Jul  5 03:19:12 xcat.genesis.dodiscovery: Sleeping 5 seconds...
<166>Jul  5 03:19:12 xcat.genesis.minixcatd: The request is processing by xCAT master...
Could not receive message, error: EOF.
[Enter `^Ec.' to exit]
Session is teminated unexpectedly, retrying....
Could not connect to node-8335-gtc-785260a, error: Node not exist
```

