### PR TITLE
Modify xcatd_stop test case to satisfy all rhels, sles and ubuntu os

### DIFF
--- a/xCAT-test/autotest/testcase/xcatd/case0
+++ b/xCAT-test/autotest/testcase/xcatd/case0
@@ -55,8 +55,6 @@ check:output=~xcatd service|xcatd.service
 check:output=~xcatd service is running|active \(running\)
 cmd:service xcatd stop
 check:rc==0
-check:output=~Stopping x(cat|CAT)d
-check:output=~[  OK  ]
 cmd:sleep 3
 cmd:service xcatd status
 check:output=~xcatd service|xcatd.service


### PR DESCRIPTION
Due to in sles and ubuntn, there is no output of ``service xcatd stop`` command, so update test case ``xcatd_stop`` to make it run all os(rhels,  sles, ubuntu).

before updating, in sles and ubuntu, the error like below:
```
RUN:service xcatd stop [Thu Jul  5 15:22:15 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0   [Pass]
CHECK:output =~ Stopping x(cat|CAT)d    [Failed]
```

After updating
```
RUN:service xcatd stop [Thu Jul  5 15:22:15 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0   [Pass]
```