### PR TITLE
delete policy table change by xcat in pr 5371

### DIFF
--- a/xCAT-server/lib/xcat/plugins/updatehwinv.pm
+++ b/xCAT-server/lib/xcat/plugins/updatehwinv.pm
@@ -12,6 +12,7 @@ use strict;
 use warnings "all";
 use xCAT::Table;
 use xCAT::Utils;
+use xCAT::NodeRange;
 
 #-------------------------------------------------------
 
@@ -38,8 +39,16 @@ sub process_request {
 }
 
 sub update_hw_inv {
-    my $request = shift;
-    my $node     = $request->{'_xcat_clienthost'}->[0];
+    my $request    = shift;
+    my $tmp_node   = $request->{'_xcat_clienthost'}->[0];
+    my @valid_node = xCAT::NodeRange::noderange($tmp_node);
+
+    unless (@valid_node) {
+        xCAT::MsgUtils->message("S", "xcat.hwinv: Received invalid node $tmp_node hwinv info, ignore...");
+        return;
+    }
+
+    my $node = $valid_node[0];
 
     my @nodefs;
     my $basicdata;

--- a/xCAT-server/sbin/xcatconfig
+++ b/xCAT-server/sbin/xcatconfig
@@ -1360,8 +1360,6 @@ sub initDB
 "$::XCATROOT/sbin/chtab priority=4.8 policy.commands=litetree policy.rule=allow;";
             $chtabcmds .=
 "$::XCATROOT/sbin/chtab priority=4.9 policy.commands=getadapter policy.rule=allow;";
-            $chtabcmds .=
-"$::XCATROOT/sbin/chtab priority=4.10 policy.commands=updatehwinv policy.rule=allow;";
         }
         my $outref = xCAT::Utils->runcmd("$chtabcmds", 0);
         if ($::RUNCMD_RC != 0)

--- a/xCAT/postscripts/getinv
+++ b/xCAT/postscripts/getinv
@@ -28,6 +28,11 @@ rm -f $xml_file
 
 while [ ! -f $xml_file ] || grep error $xml_file; do
     if [ -f $xml_file ]; then
+        if grep "Permission denied for request" $xml_file; then
+            echo -en "Please run 'chtab priority=4.10 policy.commands=updatehwinv policy.rule=allow' to allow 'updatehwinv' command \r";
+            rm $tmp_file
+            exit 1
+        fi
         timer=60
         while [ $timer -gt 0 ]; do
             sleep 1


### PR DESCRIPTION
For #5345, will not change policy table as default.
User needs to modify it by themselves.

Add node check when receive ``updatehwinv`` command.

```
# updatenode c910f03c17k20 -P getinv
c910f03c17k20: vpdupdate is not supported on the pSeries KVM Guest platform
c910f03c17k20: updating VPD database
c910f03c17k20: trying to download postscripts...
c910f03c17k20: postscripts downloaded successfully
c910f03c17k20: trying to get mypostscript from 10.3.17.21...
c910f03c17k20: Fri Jul  6 04:45:12 EDT 2018 Running postscript: getinv
c910f03c17k20:   <error>Permission denied for request</error>
c910f03c17k20:   <errorcode>1</errorcode>
c910f03c17k20:   <error>Permission denied for request</error>
c910f03c17k20: Please run 'chtab priority=4.10 policy.commands=updatehwinv policy.rule=allow' to allow 'updatehwinv' command
postscript: getinv exited with code 1
c910f03c17k20: Running of postscripts has completed.
```