### PR TITLE
Make xcattest can supprot multiple values for key words hcp and arch

### DIFF
--- a/xCAT-test/autotest/testcase/rpower/cases0
+++ b/xCAT-test/autotest/testcase/rpower/cases0
@@ -173,27 +173,27 @@ check:rc==0
 end
 
 start:rpower_suspend_OpenpowerBmc
-hcp:openbmc
+hcp:openbmc,ipmi
 label:cn_bmc_ready,hctrl_openpower_ipmi,hctrl_openbmc
 cmd:rpower $$CN suspend
-check:output=~Error: (\[.*?\]: )?Unsupported command: rpower suspend
+check:output=~Error: (\[.*?\]: )?[Uu]nsupported command[:]* rpower suspend
 check:rc==1
 end
 
 
 start:rpower_wake_OpenpowerBmc
-hcp:openbmc
+hcp:openbmc,ipmi
 label:cn_bmc_ready,hctrl_openpower_ipmi,hctrl_openbmc
 cmd:rpower $$CN wake
-check:output=~Error: (\[.*?\]: )?Unsupported command: rpower wake
+check:output=~Error: (\[.*?\]: )?[Uu]nsupported command[:]* rpower wake
 check:rc==1
 end
 
 start:rpower_errorcommand_OpenpowerBmc
-hcp:openbmc
+hcp:openbmc,ipmi
 label:cn_bmc_ready,hctrl_openpower_ipmi,hctrl_openbmc
 cmd:rpower $$CN ddd
-check:output=~Error: (\[.*?\]: )?Unsupported command: rpower ddd 
+check:output=~Error: (\[.*?\]: )?[Uu]nsupported command[:]* rpower ddd
 check:rc==1
 end
 

--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -1052,15 +1052,21 @@ sub load_case {
                 $case_ref->[$i]->{arch} = $1;
 
                 if ($run_case_flag) {
-
+                    
                     #To judge whether need to skip the current case
-                    my $case_arch = $case_ref->[$i]->{arch};
-                    if ($case_arch =~ /ppc/i && $case_arch !~ /le|el/i) {
-                        $case_arch = "ppc";
-                    } elsif ($case_arch =~ /ppc/i && $case_arch =~ /le|el/i) {
-                        $case_arch = "ppc64le";
-                    } elsif ($case_arch =~ /x86/i) {
-                        $case_arch = "x86";
+
+                    my @vaild_archs_tmp = split(",", $case_ref->[$i]->{arch});
+                    my @vaild_archs=();
+                    foreach my $arch (@vaild_archs_tmp){                    
+                        my $tmp_str="";
+                        if ($arch =~ /ppc/i && $arch !~ /le|el/i) {
+                            $tmp_str = "ppc";
+                        } elsif ($arch =~ /ppc/i && $arch =~ /le|el/i) {
+                            $tmp_str = "ppc64le";
+                        } elsif ($arch =~ /x86/i) {
+                            $tmp_str = "x86";
+                        }
+                        push @vaild_archs, $tmp_str; 
                     }
 
                     my $env_arch = "";
@@ -1079,10 +1085,13 @@ sub load_case {
                     }
 
                     my $valid = 0;
-                    if ($case_arch eq $env_arch) {
-                        $valid = 1;
-                        if (grep (/$case_ref->[$i]->{name}/, @{ $invalidcases{"noruncases"} })) {
-                            delete_item_from_array($case_ref->[$i]->{name}, $invalidcases{"noruncases"});
+                    foreach my $arch (@vaild_archs){
+                        if ($arch eq $env_arch) {
+                            $valid = 1;
+                            if (grep (/$case_ref->[$i]->{name}/, @{ $invalidcases{"noruncases"} })) {
+                                delete_item_from_array($case_ref->[$i]->{name}, $invalidcases{"noruncases"});
+                            }
+                            last;
                         }
                     }
                     unless ($valid) {
@@ -1104,12 +1113,18 @@ sub load_case {
 
                     #To judge whether need to skip the current case
                     my $valid = 0;
-                    if (exists($config{var}{HCP}) && ($case_ref->[$i]->{hcp} =~ /$config{var}{HCP}/i)) {
-                        $valid = 1;
-                        if (grep (/$case_ref->[$i]->{name}/, @{ $invalidcases{"noruncases"} })) {
-                            delete_item_from_array($case_ref->[$i]->{name}, $invalidcases{"noruncases"});
+                    my @valid_hcps = split(",", $case_ref->[$i]->{hcp});
+
+                    foreach my $hcp (@valid_hcps){
+                        $hcp =~  s/^\s+|\s+$//g;
+                        if (exists($config{var}{HCP}) && ($hcp =~ /^$config{var}{HCP}$/i)) {
+                            $valid = 1;
+                            if (grep (/$case_ref->[$i]->{name}/, @{ $invalidcases{"noruncases"} })) {
+                                delete_item_from_array($case_ref->[$i]->{name}, $invalidcases{"noruncases"});
+                            }
+                            last;
                         }
-                    }
+                    } 
                     unless ($valid) {
                         if (exists($case_name_index_map_bak{ $case_ref->[$i]->{name} })) {
                             $$case_name_index_map_ref{ $case_ref->[$i]->{name} } = $case_name_index_map_bak{ $case_ref->[$i]->{name} };


### PR DESCRIPTION
what to do in this PR:
* Make xcattest can supprot multiple values for key words hcp and arch
* fix bugs of some test cases

The ut like below:

Add more values of hcp for ``rpower_suspend_OpenpowerBmc``
```
start:rpower_suspend_OpenpowerBmc
hcp:openbmc , ipmi
label:cn_bmc_ready,hctrl_openpower_ipmi,hctrl_openbmc
cmd:rpower $$CN suspend
check:output=~Error: (\[.*?\]: )?[Uu]nsupported command[:]* rpower suspend
check:rc==1
end
```
Before change:
```
[root@c910f03c05k25 autotest]# XCATTEST_CN=fs3 xcattest -t rpower_suspend_OpenpowerBmc
xCAT automated test started at Fri Jul  6 03:39:33 2018
******************************
To detect current test environment
******************************
Detecting: OS = linux
Detecting: ARCH = ppc64le
Detecting: HCP = ipmi
******************************
loading test cases
******************************
Unsuitable current environment:
rpower_suspend_OpenpowerBmc
To run:
There is no valid case to run
```
After change:
```
[root@c910f03c05k25 rpower]#  XCATTEST_CN=fs3 xcattest -t rpower_suspend_OpenpowerBmc
xCAT automated test started at Fri Jul  6 05:13:15 2018
******************************
To detect current test environment
******************************
Detecting: OS = linux
Detecting: ARCH = ppc64le
Detecting: HCP = ipmi
******************************
loading test cases
******************************
To run:
rpower_suspend_OpenpowerBmc
******************************
Start to run test cases
******************************
------START::rpower_suspend_OpenpowerBmc::Time:Fri Jul  6 05:13:17 2018------

RUN:rpower fs3 suspend [Fri Jul  6 05:13:17 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
fs3: [c910f03c05k25]: Error: unsupported command rpower suspend for OpenPOWER
CHECK:output =~ Error: (\[.*?\]: )?[Uu]nsupported command[:]* rpower suspend	[Pass]
CHECK:rc == 1	[Pass]

------END::rpower_suspend_OpenpowerBmc::Passed::Time:Fri Jul  6 05:13:17 2018 ::Duration::0 sec------
------Total: 1 , Failed: 0------
```