### PR TITLE
Modify xcattest for bug 5382

### DIFF
--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -1404,12 +1404,20 @@ sub run_case {
                     my $rvalue = $2;
 
                     $rvalue = getfunc($rvalue);
+                     
+                    #modify for issue5382
+                    $rvalue =~ s/{/\\{/g;
+
                     if ((($op eq '=~') && ($lvalue !~ /$rvalue/))
                         || (($op eq '!~') && ($lvalue =~ /$rvalue/))
                         || (($op eq '==') && ($lvalue ne $rvalue))
                         || (($op eq '!=') && ($lvalue eq $rvalue))) {
                         $failflag = 1;
                     }
+
+                    #modify for issue5382
+                    $rvalue =~ s/\\\{/{/g;
+
                     if ($failflag) {
                         log_this($running_log_fd, "CHECK:output $op $rvalue\t[Failed]");
                         push(@caselog, "CHECK:output $op $rvalue\t[Failed]");


### PR DESCRIPTION
Modify ``xcattest`` for bug #5382 

The test case ``makeconservercf_null`` is
```
start:makeconservercf_null
cmd:chdef -t node -o testnodetmp cons=hmc groups=all
cmd:makeconservercf testnodetmp
check:rc==0
cmd:cat /etc/conserver.cf
check:output=~console testnodetmp {
check:output=~  /opt/xcat/share/xcat/cons/hmc testnodetmp;
check:output=~}
cmd:rmdef -t node testnodetmp
end
```
After fixing, in ubuntu 18.04, the output are:
```
------START::makeconservercf_null::Time:Wed Jul 11 03:24:22 2018------

RUN:chdef -t node -o testnodetmp cons=hmc groups=all [Wed Jul 11 03:24:22 2018]

ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
New object definitions 'testnodetmp' have been created.

RUN:makeconservercf testnodetmp [Wed Jul 11 03:24:22 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:cat /etc/conserver.cf [Wed Jul 11 03:24:23 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
access * {
  trusted 127.0.0.1;
  trusted 10.3.9.3;
  trusted localhost,c910f03c09k03;
}
default * {
  logfile /var/log/consoles/&;
  timestamp 1lab;
  rw *;
  master localhost;
}
config * {
  sslrequired yes;
  sslcacertificatefile /etc/xcat/cert/ca.pem;
  sslcredentials /etc/xcat/cert/server-cred.pem;
}
default cyclades { type host; portbase 7000; portinc 1; }
default mrv { type host; portbase 2000; portinc 100; }
##
## Sample conserver.cf file, to give you ideas of what you can do with
## the various configuration items.
##
#
#### set up global access
#default full	{ rw *; }
#
#### define some terminal server specifics
## we set portbase and portinc so we can reference the ports in a
## physical representation and let conserver do the math to figure
## out the actual socket address
#default cisco	{ type host; portbase 2000; portinc 1; }
#default xyplex	{ type host; portbase 2000; portinc 100; }
#default iolan	{ type host; portbase 10000; portinc 1; }
#
#### set up some custom break sequences
#break 4 { string "+\d+\d+"; delay 300; }
#break 5 { string "\033c"; }
#
#### set the defaults for all the consoles
## these get applied before anything else
#default * {
#	# The '&' character is substituted with the console name
#	logfile /var/consoles/&;
#	# timestamps every hour with activity and break logging
#	timestamp 1hab;
#	# include the 'full' default
#	include full;
#	# master server is localhost
#	master localhost;
#}
#
#### define the first terminal server
#default ts1.conserver.com {
#	# use the xyplex defaults
#	include xyplex;
#	# host to connect to is ts1.conserver.com
#	host ts1.conserver.com;
#	# run login-xyplex when connecting to the term server
#	initcmd /usr/local/sbin/login-xyplex;
#}
#
## now define the consoles on ts1.conserver.com
## bryan isn't allowed on web1.conserver.com
#console web1.conserver.com { include ts1.conserver.com; port 2; rw !bryan; }
#console ns1.conserver.com { include ts1.conserver.com; port 10; }
#console ns2.conserver.com { include ts1.conserver.com; port 8; }
#
#### define the second terminal server
## this one is a cisco, with simple socket connections
#default ts2.conserver.com { include cisco; host ts2.conserver.com; }
#
## and the consoles on ts2.conserver.com
#console ldap1.conserver.com { include ts2.conserver.com; port 7; }
#
#### and now some one-off consoles
## we still inherit the '*' default set
## a simple ssh invocation
#console ssh {
#	type exec;
#	exec ssh localhost;
#	# provide a 'message-of-the-day'
#	motd "just a simple ssh to localhost";
#}
#
## connect to /dev/ttya
#console ttya {
#	type device;
#	device /dev/ttya; parity none; baud 9600;
#	idlestring "#";
#	idletimeout 5m;		# send a '#' every 5 minutes of idle
#	timestamp "";		# no timestamps on this console
#}
#
#### define a group of users
#group sysadmin {
#    users bryan, todd;
#    users dave;
#}
#
#### reset the defaults for the next set of consoles
## again, these get applied before anything else
#default * {
#	# The '&' character is substituted with the console name
#	logfile /var/consoles/&;
#	timestamp 5m;
#	rw sysadmin;  # use the group defined above
#	master localhost;
#}
#
#default cyclades {
#	# sets up /dev/ttyC0 through /dev/ttyC31, for a 32 port card
#	# referenced as ports 1 through 32
#	type device;
#	device /dev/ttyC.;
#	devicesubst .=Pd;
#	portbase -1;
#	portinc 1;
#	host none; # not really used, since devicesubst doesn't use it
#	baud 9600;
#	parity none;
#}
#
#console modem1.conserver.com { include cyclades; port 2; break 4; }
## todd isn't allowed on modem2.conserver.com
#console modem2.conserver.com { include cyclades; port 6; rw !todd; }
#
#### list of clients we allow
#access * {
#	allowed 10.0.0.0/8 192.168.0.0/16;
#	allowed cs1.conserver.com cs2.conserver.com cs3.conserver.com;
#	trusted 127.0.0.1;
#}
#xCAT BEGIN testnodetmp CONS
console testnodetmp {
  type exec;
  exec /opt/xcat/share/xcat/cons/hmc testnodetmp;
}
#xCAT END testnodetmp CONS
CHECK:output =~ console testnodetmp {	[Pass]
CHECK:output =~ /opt/xcat/share/xcat/cons/hmc testnodetmp;	[Pass]
CHECK:output =~ }	[Pass]

RUN:rmdef -t node testnodetmp [Wed Jul 11 03:24:23 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.

------END::makeconservercf_null::Passed::Time:Wed Jul 11 03:24:23 2018 ::Duration::1 sec------
------Total: 1 , Failed: 0------
```

Also UT in rhels7.5 and sles11.4, this fix can work on both platform too. 