### PR TITLE
Add virtio_net to default network driver list for Ubuntu on ppc64el

### DIFF
--- a/xCAT-server/share/xcat/netboot/ubuntu/genimage
+++ b/xCAT-server/share/xcat/netboot/ubuntu/genimage
@@ -201,7 +201,7 @@ if ($netdriver) {
     if ($arch eq 'x86' or $arch eq 'x86_64') {
         @ndrivers = qw/tg3 bnx2 bnx2x e1000 e1000e igb mlx_en virtio_net/;
     } elsif ($arch eq 'ppc64el') {
-        @ndrivers = qw/bnx2 bnx2x e1000 e1000e igb mlx_en mlx4_en/;
+        @ndrivers = qw/bnx2 bnx2x e1000 e1000e igb mlx_en mlx4_en virtio_net/;
     } elsif ($arch eq 'ppc64') {
         @ndrivers = qw/e1000 e1000e igb ibmveth ehea/;
     } elsif ($arch eq 's390x') {


### PR DESCRIPTION
This will make the default diskless osimage work on KVM environment.