### PR TITLE
modify testcase of xcat-inventory environement based on code modify

### DIFF
--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.environment
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.environment
@@ -21,7 +21,7 @@ check:rc==0
 
 cmd:rootimgdir=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir ]; then mv $rootimgdir $rootimgdir.regbak -f;fi
 check:rc==0
-cmd:export GITREPO="/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo";export SWDIR="/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir";xcat-inventory import -f /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.yaml
+cmd:xcat-inventory import -f /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.yaml -e GITREPO=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo -e SWDIR=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir
 check:output=~Importing object: test.environments.osimage
 check:output=~Inventory import successfully!
 check:rc==0
@@ -31,7 +31,6 @@ cmd:genimage test.environments.osimage
 check:rc==0
 cmd:packimage test.environments.osimage 
 check:rc==0
-
 cmd:rinstall $$CN osimage=test.environments.osimage
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
@@ -86,7 +85,7 @@ label:others,xcat_inventory
 cmd:lsdef -t osimage -o test.environments.osimage >/dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t osimage -o test.environments.osimage -z >/tmp/test.environments.osimage_image.stanza ;rmdef -t osimage -o test.environments.osimage;fi
 check:rc==0
 cmd:dir="/tmp/export";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi; mkdir -p $dir
-cmd:export GITREPO="/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo";export SWDIR="/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir";xcat-inventory import -f /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.yaml
+cmd:xcat-inventory import -f /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.yaml -e GITREPO=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo -e SWDIR=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir
 check:output=~Importing object: test.environments.osimage
 check:output=~Inventory import successfully!
 check:rc==0
@@ -101,7 +100,7 @@ cmd:diff -y  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templat
 check:rc==0
 cmd:rmdef -t osimage -o test.environments.osimage
 check:rc==0
-cmd:export GITREPO="/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo";export SWDIR="/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir";xcat-inventory import -f /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json
+cmd:xcat-inventory import -f /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json -e GITREPO=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo -e SWDIR=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir
 check:output=~Importing object: test.environments.osimage
 check:output=~Inventory import successfully!
 check:rc==0

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/environment/gitrepo/postinstall/test1.postinstall
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/environment/gitrepo/postinstall/test1.postinstall
@@ -48,5 +48,5 @@ fi
 #  [ -r $workdir/$profile.$ext ] && cat $workdir/$profile.$ext | grep -E '^[[:space:]]*#.*[[:space:]]\$Id' >> $installroot/etc/IMGVERSION
 #done
 echo "test postisntall" >> $installroot/tmp/test1.postinstall
-${GITREPO}/postinstall/test2.postinstall
+${GITREPO}/postinstall/test2.postinstall $installroot
 

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.yaml
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.yaml
@@ -2,8 +2,8 @@ osimage:
   test.environments.osimage:
     basic_attributes:
       arch: ppc64le
-      distribution: rhels7.5-alternate 
-      osdistro: rhels7.5-alternate-ppc64le 
+      distribution: rhels7.5 
+      osdistro: rhels7.5-ppc64le 
       osname: Linux
     filestosync: {{GITREPO}}/syncfiles/synclist
     deprecated:
@@ -16,7 +16,7 @@ osimage:
     package_selection:
       otherpkgdir: {{SWDIR}}/otherpkgdir/
       otherpkglist: {{GITREPO}}/otherpkglist/test1.otherpkglist,{{GITREPO}}/otherpkglist/test2.otherpkglist,
-      pkgdir: /install/rhels7.5-alternate/ppc64le,{{SWDIR}}/pkgdir/
+      pkgdir: /install/rhels7.5/ppc64le,{{SWDIR}}/pkgdir/
       pkglist: /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist,{{GITREPO}}/pkglist/test1.pkglist,{{GITREPO}}/pkglist/test2.pkglist
     provision_mode: netboot
     role: compute


### PR DESCRIPTION
UT:
```
xCAT automated test started at Thu Jul 12 03:52:57 2018
******************************
To detect current test environment
******************************
Detecting: OS = linux
Detecting: ARCH = ppc64le
Detecting: HCP = kvm
******************************
loading test cases
******************************
To run:
export_osimage_with_environments
******************************
Start to run test cases
******************************
------START::export_osimage_with_environments::Time:Thu Jul 12 03:52:59 2018------

RUN:lsdef -t osimage -o test.environments.osimage >/dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t osimage -o test.environments.osimage -z >/tmp/test.environments.osimage_image.stanza ;rmdef -t osimage -o test.environments.osimage;fi [Thu Jul 12 03:52:59 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:dir="/tmp/export";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi; mkdir -p $dir [Thu Jul 12 03:52:59 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:xcat-inventory import -f /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.yaml -e GITREPO=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo -e SWDIR=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir [Thu Jul 12 03:52:59 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Importing object: test.environments.osimage
Inventory import successfully!
CHECK:output =~ Importing object: test.environments.osimage	[Pass]
CHECK:output =~ Inventory import successfully!	[Pass]
CHECK:rc == 0	[Pass]

RUN:lsdef -t osimage -o test.environments.osimage -z >> /tmp/export/test.environments.osimage.yaml.stanza [Thu Jul 12 03:53:00 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:diff -y /tmp/export/test.environments.osimage.yaml.stanza /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.stanza [Thu Jul 12 03:53:01 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
# <xCAT data object stanza file>				# <xCAT data object stanza file>

test.environments.osimage:					test.environments.osimage:
    objtype=osimage						    objtype=osimage
    environvar=GITREPO=/opt/xcat/share/xcat/tools/autotest/te	    environvar=GITREPO=/opt/xcat/share/xcat/tools/autotest/te
    imagetype=linux						    imagetype=linux
    osarch=ppc64le						    osarch=ppc64le
    osdistroname=rhels7.5-alternate-ppc64le			    osdistroname=rhels7.5-alternate-ppc64le
    osname=Linux						    osname=Linux
    osvers=rhels7.5-alternate					    osvers=rhels7.5-alternate
    otherpkgdir=/opt/xcat/share/xcat/tools/autotest/testcase/	    otherpkgdir=/opt/xcat/share/xcat/tools/autotest/testcase/
    otherpkglist=/opt/xcat/share/xcat/tools/autotest/testcase	    otherpkglist=/opt/xcat/share/xcat/tools/autotest/testcase
    permission=755						    permission=755
    pkgdir=/install/rhels7.5-alternate/ppc64le,/opt/xcat/shar	    pkgdir=/install/rhels7.5-alternate/ppc64le,/opt/xcat/shar
    pkglist=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.pp	    pkglist=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.pp
    postinstall=/opt/xcat/share/xcat/netboot/rh/compute.rhels	    postinstall=/opt/xcat/share/xcat/netboot/rh/compute.rhels
    profile=compute						    profile=compute
    provmethod=netboot						    provmethod=netboot
    rootimgdir=/install/custom/test.environments.osimage	    rootimgdir=/install/custom/test.environments.osimage
    synclists=/opt/xcat/share/xcat/tools/autotest/testcase/xc	    synclists=/opt/xcat/share/xcat/tools/autotest/testcase/xc
    usercomment=rhels7.5,test_environment_variables		    usercomment=rhels7.5,test_environment_variables
CHECK:rc == 0	[Pass]

RUN:xcat-inventory export  -t osimage -o test.environments.osimage -f /tmp/export/test.environments.osimage.yaml --format yaml [Thu Jul 12 03:53:01 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
The inventory data has been dumped to /tmp/export/test.environments.osimage.yaml
CHECK:rc == 0	[Pass]
CHECK:output =~ The inventory data has been dumped to /tmp/export/test.environments.osimage.yaml	[Pass]

RUN:diff -y  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.yaml /tmp/export/test.environments.osimage.yaml --ignore-blank-lines  -I "^#" [Thu Jul 12 03:53:02 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
osimage:							osimage:
  test.environments.osimage:					  test.environments.osimage:
    basic_attributes:						    basic_attributes:
      arch: ppc64le						      arch: ppc64le
      distribution: rhels7.5-alternate				      distribution: rhels7.5-alternate
      osdistro: rhels7.5-alternate-ppc64le			      osdistro: rhels7.5-alternate-ppc64le
      osname: Linux						      osname: Linux
    deprecated:							    deprecated:
      comments: rhels7.5,test_environment_variables		      comments: rhels7.5,test_environment_variables
    filestosync:						    filestosync:
    - '{{GITREPO}}/syncfiles/synclist'				    - '{{GITREPO}}/syncfiles/synclist'
    genimgoptions:						    genimgoptions:
      permission: '755'						      permission: '755'
      postinstall:						      postinstall:
      - /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64l	      - /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64l
      - '{{GITREPO}}/postinstall/test1.postinstall'		      - '{{GITREPO}}/postinstall/test1.postinstall'
      rootimgdir: /install/custom/test.environments.osimage	      rootimgdir: /install/custom/test.environments.osimage
    imagetype: linux						    imagetype: linux
    package_selection:						    package_selection:
      otherpkgdir:						      otherpkgdir:
      - '{{SWDIR}}/otherpkgdir/'				      - '{{SWDIR}}/otherpkgdir/'
      otherpkglist:						      otherpkglist:
      - '{{GITREPO}}/otherpkglist/test1.otherpkglist'		      - '{{GITREPO}}/otherpkglist/test1.otherpkglist'
      - '{{GITREPO}}/otherpkglist/test2.otherpkglist'		      - '{{GITREPO}}/otherpkglist/test2.otherpkglist'
      - ''							      - ''
      pkgdir:							      pkgdir:
      - /install/rhels7.5-alternate/ppc64le			      - /install/rhels7.5-alternate/ppc64le
      - '{{SWDIR}}/pkgdir/'					      - '{{SWDIR}}/pkgdir/'
      pkglist:							      pkglist:
      - /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64l	      - /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64l
      - '{{GITREPO}}/pkglist/test1.pkglist'			      - '{{GITREPO}}/pkglist/test1.pkglist'
      - '{{GITREPO}}/pkglist/test2.pkglist'			      - '{{GITREPO}}/pkglist/test2.pkglist'
    provision_mode: netboot					    provision_mode: netboot
    role: compute						    role: compute
schema_version: '1.0'						schema_version: '1.0'
							      )
							      )	#Version 2.14.2 (git commit f2090565b1d1b8efa7558d034de047845
CHECK:rc == 0	[Pass]

RUN:rmdef -t osimage -o test.environments.osimage [Thu Jul 12 03:53:02 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:xcat-inventory import -f /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json -e GITREPO=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo -e SWDIR=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir [Thu Jul 12 03:53:02 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Importing object: test.environments.osimage
Inventory import successfully!
CHECK:output =~ Importing object: test.environments.osimage	[Pass]
CHECK:output =~ Inventory import successfully!	[Pass]
CHECK:rc == 0	[Pass]

RUN:lsdef -t osimage -o test.environments.osimage -z >> /tmp/export/test.environments.osimage.json.stanza [Thu Jul 12 03:53:03 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:diff -y /tmp/export/test.environments.osimage.json.stanza /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.stanza [Thu Jul 12 03:53:04 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
# <xCAT data object stanza file>				# <xCAT data object stanza file>

test.environments.osimage:					test.environments.osimage:
    objtype=osimage						    objtype=osimage
    environvar=GITREPO=/opt/xcat/share/xcat/tools/autotest/te	    environvar=GITREPO=/opt/xcat/share/xcat/tools/autotest/te
    imagetype=linux						    imagetype=linux
    osarch=ppc64le						    osarch=ppc64le
    osdistroname=rhels7.5-alternate-ppc64le			    osdistroname=rhels7.5-alternate-ppc64le
    osname=Linux						    osname=Linux
    osvers=rhels7.5-alternate					    osvers=rhels7.5-alternate
    otherpkgdir=/opt/xcat/share/xcat/tools/autotest/testcase/	    otherpkgdir=/opt/xcat/share/xcat/tools/autotest/testcase/
    otherpkglist=/opt/xcat/share/xcat/tools/autotest/testcase	    otherpkglist=/opt/xcat/share/xcat/tools/autotest/testcase
    permission=755						    permission=755
    pkgdir=/install/rhels7.5-alternate/ppc64le,/opt/xcat/shar	    pkgdir=/install/rhels7.5-alternate/ppc64le,/opt/xcat/shar
    pkglist=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.pp	    pkglist=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.pp
    postinstall=/opt/xcat/share/xcat/netboot/rh/compute.rhels	    postinstall=/opt/xcat/share/xcat/netboot/rh/compute.rhels
    profile=compute						    profile=compute
    provmethod=netboot						    provmethod=netboot
    rootimgdir=/install/custom/test.environments.osimage	    rootimgdir=/install/custom/test.environments.osimage
    synclists=/opt/xcat/share/xcat/tools/autotest/testcase/xc	    synclists=/opt/xcat/share/xcat/tools/autotest/testcase/xc
    usercomment=rhels7.5,test_environment_variables		    usercomment=rhels7.5,test_environment_variables
CHECK:rc == 0	[Pass]

RUN:xcat-inventory export  -t osimage -o test.environments.osimage -f /tmp/export/test.environments.osimage.json [Thu Jul 12 03:53:04 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
The inventory data has been dumped to /tmp/export/test.environments.osimage.json
CHECK:rc == 0	[Pass]

RUN:diff -y  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json /tmp/export/test.environments.osimage.json --ignore-blank-lines  -I "^#" [Thu Jul 12 03:53:05 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
{								{
    "osimage": {						    "osimage": {
        "test.environments.osimage": {				        "test.environments.osimage": {
            "basic_attributes": {				            "basic_attributes": {
                "arch": "ppc64le",				                "arch": "ppc64le",
                "distribution": "rhels7.5-alternate",		                "distribution": "rhels7.5-alternate",
                "osdistro": "rhels7.5-alternate-ppc64le",	                "osdistro": "rhels7.5-alternate-ppc64le",
                "osname": "Linux"				                "osname": "Linux"
            },							            },
            "deprecated": {					            "deprecated": {
                "comments": "rhels7.5,test_environment_variab	                "comments": "rhels7.5,test_environment_variab
            },							            },
            "filestosync": [					            "filestosync": [
                "{{GITREPO}}/syncfiles/synclist"		                "{{GITREPO}}/syncfiles/synclist"
            ],							            ],
            "genimgoptions": {					            "genimgoptions": {
                "permission": "755",				                "permission": "755",
                "postinstall": [				                "postinstall": [
                    "/opt/xcat/share/xcat/netboot/rh/compute.	                    "/opt/xcat/share/xcat/netboot/rh/compute.
                    "{{GITREPO}}/postinstall/test1.postinstal	                    "{{GITREPO}}/postinstall/test1.postinstal
                ],						                ],
                "rootimgdir": "/install/custom/test.environme	                "rootimgdir": "/install/custom/test.environme
            },							            },
            "imagetype": "linux",				            "imagetype": "linux",
            "package_selection": {				            "package_selection": {
                "otherpkgdir": [				                "otherpkgdir": [
                    "{{SWDIR}}/otherpkgdir/"			                    "{{SWDIR}}/otherpkgdir/"
                ],						                ],
                "otherpkglist": [				                "otherpkglist": [
                    "{{GITREPO}}/otherpkglist/test1.otherpkgl	                    "{{GITREPO}}/otherpkglist/test1.otherpkgl
                    "{{GITREPO}}/otherpkglist/test2.otherpkgl	                    "{{GITREPO}}/otherpkglist/test2.otherpkgl
                    ""						                    ""
                ],						                ],
                "pkgdir": [					                "pkgdir": [
                    "/install/rhels7.5-alternate/ppc64le",	                    "/install/rhels7.5-alternate/ppc64le",
                    "{{SWDIR}}/pkgdir/"				                    "{{SWDIR}}/pkgdir/"
                ],						                ],
                "pkglist": [					                "pkglist": [
                    "/opt/xcat/share/xcat/netboot/rh/compute.	                    "/opt/xcat/share/xcat/netboot/rh/compute.
                    "{{GITREPO}}/pkglist/test1.pkglist",	                    "{{GITREPO}}/pkglist/test1.pkglist",
                    "{{GITREPO}}/pkglist/test2.pkglist"		                    "{{GITREPO}}/pkglist/test2.pkglist"
                ]						                ]
            },							            },
            "provision_mode": "netboot",			            "provision_mode": "netboot",
            "role": "compute"					            "role": "compute"
        }							        }
    },								    },
    "schema_version": "1.0"					    "schema_version": "1.0"
}								}
#Version 2.14.2 (git commit 09f0772835afdc0f962c9e7fe8cef862e	#Version 2.14.2 (git commit f2090565b1d1b8efa7558d034de047845
CHECK:rc == 0	[Pass]

RUN:dir="/tmp/export"; rm -rf $dir; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi [Thu Jul 12 03:53:05 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:rmdef -t osimage -o test.environments.osimage [Thu Jul 12 03:53:05 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:if [ -e /tmp/test.environments.osimage.stanza ]; then cat /tmp/test.environments.osimage.stanza |mkdef -z;fi [Thu Jul 12 03:53:06 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::export_osimage_with_environments::Passed::Time:Thu Jul 12 03:53:06 2018 ::Duration::7 sec------
------Total: 1 , Failed: 0------
```


```
------START::import_osimage_with_environments_in_yaml::Time:Wed Jul 11 21:32:49 2018------
.....

RUN:xcat-inventory import -f /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.yaml -e GITREPO=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo -e SWDIR=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir [Thu Jul 12 03:56:38 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
Importing object: test.environments.osimage
Inventory import successfully!
CHECK:output =~ Importing object: test.environments.osimage	[Pass]
CHECK:output =~ Inventory import successfully!	[Pass]
CHECK:rc == 0	[Pass]

RUN:lsdef -t osimage -o test.environments.osimage [Thu Jul 12 03:56:40 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Object name: test.environments.osimage
    environvar=GITREPO=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo,SWDIR=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir
    imagetype=linux
    osarch=ppc64le
    osdistroname=rhels7.5-ppc64le
    osname=Linux
    osvers=rhels7.5
    otherpkgdir=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir/otherpkgdir/
    otherpkglist=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/otherpkglist/test1.otherpkglist,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/otherpkglist/test2.otherpkglist,
    permission=755
    pkgdir=/install/rhels7.5/ppc64le,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir/pkgdir/
    pkglist=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/pkglist/test1.pkglist,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/pkglist/test2.pkglist
    postinstall=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.postinstall,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/postinstall/test1.postinstall
    profile=compute
    provmethod=netboot
    rootimgdir=/install/custom/test.environments.osimage
    synclists=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/syncfiles/synclist
    usercomment=rhels7.5,test_environment_variables
CHECK:rc == 0	[Pass]

.......

RUN:xdsh c910f03c17k20 "rpm -qa |grep -w dhcp" [Thu Jul 12 04:06:28 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f03c17k20: dhcp-4.2.5-68.el7.ppc64le
c910f03c17k20: dhcp-libs-4.2.5-68.el7.ppc64le
c910f03c17k20: dhcp-common-4.2.5-68.el7.ppc64le
CHECK:rc == 0	[Pass]

------END::import_osimage_with_environments_in_yaml::Passed::Time:Thu Jul 12 04:06:29 2018 ::Duration::646 sec------
------Total: 1 , Failed: 0------
```