### PR TITLE
fix issue 5288, print out management node when summary for rflash

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_flash.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_flash.py
@@ -560,13 +560,13 @@ class OpenBMCFlashTask(ParallelNodesCommand):
                 failed_num += 1
                 failed_list.append('%s: %s' % (key, value))
 
-        self.callback.info('-' * 55)
-        self.callback.info('%s complete: Total=%d Success=%d Failed=%d' % \
+        self.callback.info_with_host('-' * 55)
+        self.callback.info_with_host('%s complete: Total=%d Success=%d Failed=%d' % \
                            ('Firmware update', self.nodes_num, success_num, failed_num))
 
         for i in failed_list:
-            self.callback.info(i)
-        self.callback.info('-' * 55)
+            self.callback.info_with_host(i)
+        self.callback.info_with_host('-' * 55)
 
     def post_activate_firm(self, task, activate_arg, **kw):
 

--- a/xCAT-openbmc-py/lib/python/agent/xcatagent/server.py
+++ b/xCAT-openbmc-py/lib/python/agent/xcatagent/server.py
@@ -44,6 +44,10 @@ class XCATMessager(utils.Messager):
         d = {'type': MSG_TYPE, 'msg': {'type': 'syslog', 'data': msg}}
         self._send(d)
 
+    def info_with_host(self, msg):
+        d = {'type': MSG_TYPE, 'msg': {'type': 'info_with_host', 'data': msg}}
+        self._send(d)
+
     def update_node_attributes(self, attribute, node, data):
         d = {'type': DB_TYPE, 'attribute': {'name': attribute, 'method': 'set', 'type': 'node', 'node': node, 'value': data}}
         self._send(d)

--- a/xCAT-server/lib/perl/xCAT/AGENT.pm
+++ b/xCAT-server/lib/perl/xCAT/AGENT.pm
@@ -108,6 +108,8 @@ sub handle_message {
             xCAT::SvrUtils::sendmsg([ 1, $msg->{data} ], $callback, $msg->{node});
         } elsif ($msg->{type} eq 'syslog'){
             xCAT::MsgUtils->message("S", $msg->{data});
+        } elsif ($msg->{type} eq 'info_with_host') {
+            xCAT::MsgUtils->message("I", { data => [$msg->{data}], host => [1] }, $callback);
         }
     } elsif ($data->{type} eq $DB_TYPE) {
         my $attribute = $data->{attribute};

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1064,7 +1064,7 @@ rmdir \"/tmp/\$userid\" \n";
                         push @{ $rflash_result{fail} }, "$node: $node_info{$node}{rst}";
                     }
                 }
-                xCAT::MsgUtils->message("I", { data => ["-------------------------------------------------------"] }, $callback);
+                xCAT::MsgUtils->message("I", { data => ["-------------------------------------------------------"], host => [1] }, $callback);
                 my $summary = "Firmware update complete: ";
                 my $total = keys %node_info;
                 my $success = 0;
@@ -1072,14 +1072,14 @@ rmdir \"/tmp/\$userid\" \n";
                 $success = @{ $rflash_result{success} } if (defined $rflash_result{success} and @{ $rflash_result{success} });
                 $fail = @{ $rflash_result{fail} } if (defined $rflash_result{fail} and @{ $rflash_result{fail} });
                 $summary .= "Total=$total Success=$success Failed=$fail";
-                xCAT::MsgUtils->message("I", { data => ["$summary"] }, $callback);
+                xCAT::MsgUtils->message("I", { data => ["$summary"], host => [1] }, $callback);
 
                 if ($rflash_result{fail}) {
                     foreach (@{ $rflash_result{fail} }) {
-                        xCAT::MsgUtils->message("I", { data => ["$_"] }, $callback);
+                        xCAT::MsgUtils->message("I", { data => ["$_"], host => [1] }, $callback);
                     }
                 }
-                xCAT::MsgUtils->message("I", { data => ["-------------------------------------------------------"] }, $callback);
+                xCAT::MsgUtils->message("I", { data => ["-------------------------------------------------------"], host => [1] }, $callback);
             }
             last;
         }


### PR DESCRIPTION
#5288 

before modified:
```
# rflash mid05tor12cn16 -a 7c6bacc0
Attempting to activate ID=7c6bacc0, please wait...
mid05tor12cn16: Firmware activation successful.
-------------------------------------------------------
Firmware update complete: Total=1 Success=1 Failed=0
-------------------------------------------------------
```

UT: perl version
```
# rflash mid05tor12cn16 -a 7c6bacc0
Attempting to activate ID=7c6bacc0, please wait...
mid05tor12cn16: Firmware activation successful.
[briggs01]: -------------------------------------------------------
[briggs01]: Firmware update complete: Total=1 Success=1 Failed=0
[briggs01]: -------------------------------------------------------
```

UT: python version
```
# rflash mid05tor12cn16 -a d8368f51
Attempting to activate ID=d8368f51, please wait..
mid05tor12cn16: Firmware IBM-witherspoon-ibm-OP9_v1.19_1.172 activation successful.
[briggs01]: -------------------------------------------------------
[briggs01]: Firmware update complete: Total=1 Success=1 Failed=0
[briggs01]: -------------------------------------------------------
```