### PR TITLE
Support REST boolean for reventlog resolved=

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_eventlog.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_eventlog.py
@@ -87,7 +87,7 @@ class OpenBMCEventlogTask(ParallelNodesCommand):
                 # loop through eventlog_info_dict and collect LED ids to be resolved into a eventlog_ids_to_resolve array
                 for key in list(keys):
                     if "[LED]" in eventlog_info_dict[key]:
-                        if "Resolved: 0" in eventlog_info_dict[key]:
+                        if "Resolved: 0" or "Resolved: false" in eventlog_info_dict[key]:
                             eventlog_ids_to_resolve.append(key)
                         else:
                             if self.verbose:
@@ -96,7 +96,7 @@ class OpenBMCEventlogTask(ParallelNodesCommand):
                 # loop through list of ids and collect ids to resolve into a eventlog_ids_to_resolve array
                 for id_to_resolve in ids.split(','):
                     if id_to_resolve in eventlog_info_dict:
-                        if "Resolved: 0" in eventlog_info_dict[id_to_resolve]:
+                        if "Resolved: 0" or "Resolved: false" in eventlog_info_dict[id_to_resolve]:
                             eventlog_ids_to_resolve.append(id_to_resolve)
                         else:
                             if self.verbose:


### PR DESCRIPTION
A new BMC fw level will soon start returning boolean `true/false` instead of `0/1`.
This PR adds support for that change in `rspconfig <node> resolved=<ID>`

```
[root@briggs01 ~]# reventlog mid05tor12cn13 3
Wed Jul 18 15:47:01 2018 mid05tor12cn13: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://172.11.139.13/login -d '{"data": ["root", "xxxxxx"]}'
Wed Jul 18 15:47:01 2018 mid05tor12cn13: [openbmc_debug] login 200 OK
Wed Jul 18 15:47:01 2018 mid05tor12cn13: [openbmc_debug] get_eventlog_info curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.13/xyz/openbmc_project/logging/enumerate
Wed Jul 18 15:47:08 2018 mid05tor12cn13: [openbmc_debug] get_eventlog_info 200 OK
mid05tor12cn13: 07/18/2018 13:27:08 [127]: Firmware/Software Failure, (Warning) An internal failure has occurred while performing an operation. (AffectedSubsystem: Systems Management - Core / Virtual Appliance,  Resolved: False
mid05tor12cn13: 07/18/2018 15:05:38 [128]: Firmware/Software Failure, (Warning) An internal failure has occurred while performing an operation. (AffectedSubsystem: Systems Management - Core / Virtual Appliance,  Resolved: False
mid05tor12cn13: 07/18/2018 15:05:50 [129]: Firmware/Software Failure, (Warning) An internal failure has occurred while performing an operation. (AffectedSubsystem: Systems Management - Core / Virtual Appliance,  Resolved: False
[root@briggs01 ~]#
```

```
[root@briggs01 ~]# reventlog mid05tor12cn13 resolved=129
Attempting to resolve the following log entries: 129...
Wed Jul 18 15:46:32 2018 mid05tor12cn13: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://172.11.139.13/login -d '{"data": ["root", "xxxxxx"]}'
Wed Jul 18 15:46:32 2018 mid05tor12cn13: [openbmc_debug] login 200 OK
Wed Jul 18 15:46:32 2018 mid05tor12cn13: [openbmc_debug] get_eventlog_info curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.13/xyz/openbmc_project/logging/enumerate
Wed Jul 18 15:46:39 2018 mid05tor12cn13: [openbmc_debug] get_eventlog_info 200 OK
Wed Jul 18 15:46:39 2018 mid05tor12cn13: [openbmc_debug] resolve_event_log_entries curl -k -c cjar -b cjar -X PUT -H "Content-Type: application/json" https://172.11.139.13/xyz/openbmc_project/logging/entry/129/attr/Resolved -d '{"data": "1"}'
Wed Jul 18 15:46:40 2018 mid05tor12cn13: [openbmc_debug] resolve_event_log_entries 200 OK
mid05tor12cn13: Resolved 129
```

```
[root@briggs01 ~]# reventlog mid05tor12cn13 3
Wed Jul 18 15:47:01 2018 mid05tor12cn13: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://172.11.139.13/login -d '{"data": ["root", "xxxxxx"]}'
Wed Jul 18 15:47:01 2018 mid05tor12cn13: [openbmc_debug] login 200 OK
Wed Jul 18 15:47:01 2018 mid05tor12cn13: [openbmc_debug] get_eventlog_info curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.13/xyz/openbmc_project/logging/enumerate
Wed Jul 18 15:47:08 2018 mid05tor12cn13: [openbmc_debug] get_eventlog_info 200 OK
mid05tor12cn13: 07/18/2018 13:27:08 [127]: Firmware/Software Failure, (Warning) An internal failure has occurred while performing an operation. (AffectedSubsystem: Systems Management - Core / Virtual Appliance,  Resolved: False
mid05tor12cn13: 07/18/2018 15:05:38 [128]: Firmware/Software Failure, (Warning) An internal failure has occurred while performing an operation. (AffectedSubsystem: Systems Management - Core / Virtual Appliance,  Resolved: False
mid05tor12cn13: 07/18/2018 15:05:50 [129]: Firmware/Software Failure, (Warning) An internal failure has occurred while performing an operation. (AffectedSubsystem: Systems Management - Core / Virtual Appliance,  Resolved: True
[root@briggs01 ~]#
```