### PR TITLE
put a delay of 3 seconds to untar the firmware file for rflash -d

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -4773,7 +4773,7 @@ sub rflash_upload {
                     unless ($::UPLOAD_AND_ACTIVATE or $::UPLOAD_ACTIVATE_STREAM) {
                         xCAT::SvrUtils::sendmsg("$upload_success_msg", $callback, $node);
                     }
-                    #put a delay of 3 seconds to untar the file
+                    #Put a delay of 3 seconds to allow time for the BMC to untar the file we just uploaded
                     if (defined($::UPLOAD_ACTIVATE_STREAM)){
                         sleep 3;
                     }

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -4773,6 +4773,10 @@ sub rflash_upload {
                     unless ($::UPLOAD_AND_ACTIVATE or $::UPLOAD_ACTIVATE_STREAM) {
                         xCAT::SvrUtils::sendmsg("$upload_success_msg", $callback, $node);
                     }
+                    #put a delay of 3 seconds to untar the file
+                    if (defined($::UPLOAD_ACTIVATE_STREAM)){
+                        sleep 3;
+                    }
                     print RFLASH_LOG_FILE_HANDLE "$upload_success_msg\n";
                     # Try to logoff, no need to check result, as there is nothing else to do if failure
                 } else {


### PR DESCRIPTION
for #5399 
after rflash -d, I do not find "Unable to read the manifest file" from reventlog
The positive function works well:
```
]# rflash mid05tor12cn15 -d /mnt/xcat/iso/firmware/op910/910.1827.20180712b_1742Fx-r10
Fri Jul 20 01:17:23 2018 OpenBMC: [openbmc_debug_perl]
Attempting to upload /mnt/xcat/iso/firmware/op910/910.1827.20180712b_1742Fx-r10/obmc-witherspoon-ibm-v2.0.ubi.mtd.tar and /mnt/xcat/iso/firmware/op910/910.1827.20180712b_1742Fx-r10/witherspoon.pnor.squashfs.tar, please wait...
Fri Jul 20 01:17:24 2018 mid05tor12cn15: [openbmc_debug_perl] curl -k -c cjar -H "Content-Type: application/json" -d '{ "data": ["root", "xxxxxx"] }' https://172.11.139.15/login
Fri Jul 20 01:17:25 2018 mid05tor12cn15: [openbmc_debug_perl] login_response 200 OK
mid05tor12cn15: LATER Exited from upload with RC=0
Fri Jul 20 01:17:25 2018 mid05tor12cn15: [openbmc_debug_perl] RFLASH_FILE_UPLOAD_RESPONSE: CMD: curl -b /tmp/_xcat_cjar.mid05tor12cn15 -k -H 'Content-Type: application/octet-stream' -X PUT -T /mnt/xcat/iso/firmware/op910/910.1827.20180712b_1742Fx-r10/obmc-witherspoon-ibm-v2.0.ubi.mtd.tar https://172.11.139.15/upload/image/
Fri Jul 20 01:17:41 2018 mid05tor12cn15: [openbmc_debug_perl] RFLASH_FILE_UPLOAD_RESPONSE: CMD: curl -b /tmp/_xcat_cjar.mid05tor12cn15 -k -H 'Content-Type: application/octet-stream' -X PUT -T /mnt/xcat/iso/firmware/op910/910.1827.20180712b_1742Fx-r10/witherspoon.pnor.squashfs.tar https://172.11.139.15/upload/image/
mid05tor12cn15: Exited from upload with RC=0
Fri Jul 20 01:18:01 2018 mid05tor12cn15: [openbmc_debug_perl] curl -k -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.15/xyz/openbmc_project/software/enumerate
Fri Jul 20 01:18:03 2018 mid05tor12cn15: [openbmc_debug_perl] rflash_update_check_id_response 200 OK
Fri Jul 20 01:18:03 2018 mid05tor12cn15: [openbmc_debug_perl] CHECK_ID_RESPONSE: Looking for software ID: ibm-v2.0-0-r46-0-gbed584c IBM-witherspoon-ibm-OP9_v1.19_1.179...
Fri Jul 20 01:18:03 2018 mid05tor12cn15: [openbmc_debug_perl] CHECK_ID_RESPONSE: key_url=/xyz/openbmc_project/software/d8368f51 version=IBM-witherspoon-ibm-OP9_v1.19_1.172
Fri Jul 20 01:18:03 2018 mid05tor12cn15: [openbmc_debug_perl] CHECK_ID_RESPONSE: key_url=/xyz/openbmc_project/software/4255b1b5 version=IBM-witherspoon-ibm-OP9_v1.19_1.179
mid05tor12cn15: Firmware upload successful. Attempting to activate firmware: IBM-witherspoon-ibm-OP9_v1.19_1.179 (ID: 4255b1b5)
Fri Jul 20 01:18:03 2018 mid05tor12cn15: [openbmc_debug_perl] CHECK_ID_RESPONSE: key_url=/xyz/openbmc_project/software/376af621 version=ibm-v2.1-438-g0030304-r15-0-g19832d3
Fri Jul 20 01:18:03 2018 mid05tor12cn15: [openbmc_debug_perl] CHECK_ID_RESPONSE: key_url=/xyz/openbmc_project/software/b04fff27 version=ibm-v2.0-0-r46-0-gbed584c
mid05tor12cn15: Firmware upload successful. Attempting to activate firmware: ibm-v2.0-0-r46-0-gbed584c (ID: b04fff27)
Fri Jul 20 01:18:03 2018 mid05tor12cn15: [openbmc_debug_perl] curl -k -b cjar -X PUT -H "Content-Type: application/json" -d '{"data":"xyz.openbmc_project.Software.Activation.RequestedActivations.Active"}' https://172.11.139.15/xyz/openbmc_project/software/b04fff27/attr/RequestedActivation
Fri Jul 20 01:18:05 2018 mid05tor12cn15: [openbmc_debug_perl] rflash_update_activate_response 200 OK
Fri Jul 20 01:18:05 2018 mid05tor12cn15: [openbmc_debug_perl] curl -k -b cjar -X PUT -H "Content-Type: application/json" -d '{"data":"xyz.openbmc_project.Software.Activation.RequestedActivations.Active"}' https://172.11.139.15/xyz/openbmc_project/software/4255b1b5/attr/RequestedActivation
Fri Jul 20 01:18:06 2018 mid05tor12cn15: [openbmc_debug_perl] rflash_update_host_activate_response 200 OK
Fri Jul 20 01:18:06 2018 mid05tor12cn15: [openbmc_debug_perl] curl -k -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.15/xyz/openbmc_project/software/enumerate
Fri Jul 20 01:18:07 2018 mid05tor12cn15: [openbmc_debug_perl] rflash_update_check_state_response 200 OK
mid05tor12cn15: Firmware IBM-witherspoon-ibm-OP9_v1.19_1.179 activation successful.
mid05tor12cn15: Firmware ibm-v2.0-0-r46-0-gbed584c activation successful.
Fri Jul 20 01:18:08 2018 mid05tor12cn15: [openbmc_debug_perl] curl -k -b cjar -X PUT -H "Content-Type: application/json" -d '{"data":"xyz.openbmc_project.State.BMC.Transition.Reboot"}' https://172.11.139.15/xyz/openbmc_project/state/bmc0/attr/RequestedBMCTransition
Fri Jul 20 01:18:09 2018 mid05tor12cn15: [openbmc_debug_perl] rpower_reset_response 200 OK
mid05tor12cn15: BMC reboot
Fri Jul 20 01:18:24 2018 mid05tor12cn15: [openbmc_debug_perl] curl -k -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.15/xyz/openbmc_project/state/enumerate
Fri Jul 20 01:18:26 2018 mid05tor12cn15: [openbmc_debug_perl] rpower_bmc_status_response 503 Service Unavailable
mid05tor12cn15: Retry BMC state, wait for 15 seconds ...
Fri Jul 20 01:18:41 2018 mid05tor12cn15: [openbmc_debug_perl] curl -k -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.15/xyz/openbmc_project/state/enumerate
Fri Jul 20 01:20:13 2018 mid05tor12cn15: [openbmc_debug_perl] rpower_bmc_status_response 503 Service Unavailable
mid05tor12cn15: Retry BMC state, wait for 15 seconds ...
Fri Jul 20 01:20:28 2018 mid05tor12cn15: [openbmc_debug_perl] curl -k -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.15/xyz/openbmc_project/state/enumerate
Fri Jul 20 01:21:01 2018 mid05tor12cn15: [openbmc_debug_perl] rpower_bmc_status_response 404 Not Found
mid05tor12cn15: Retry BMC state, wait for 15 seconds ...
Fri Jul 20 01:21:16 2018 mid05tor12cn15: [openbmc_debug_perl] curl -k -c cjar -H "Content-Type: application/json" -d '{ "data": ["root", "xxxxxx"] }' https://172.11.139.15/login
Fri Jul 20 01:21:17 2018 mid05tor12cn15: [openbmc_debug_perl] login_response_general 200 OK
Fri Jul 20 01:21:17 2018 mid05tor12cn15: [openbmc_debug_perl] curl -k -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.15/xyz/openbmc_project/state/enumerate
Fri Jul 20 01:21:17 2018 mid05tor12cn15: [openbmc_debug_perl] rpower_bmc_status_response 200 OK
Fri Jul 20 01:21:32 2018 mid05tor12cn15: [openbmc_debug_perl] curl -k -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.15/xyz/openbmc_project/state/enumerate
Fri Jul 20 01:21:39 2018 mid05tor12cn15: [openbmc_debug_perl] rpower_bmc_status_response 200 OK
Fri Jul 20 01:21:54 2018 mid05tor12cn15: [openbmc_debug_perl] curl -k -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.15/xyz/openbmc_project/state/enumerate
Fri Jul 20 01:21:59 2018 mid05tor12cn15: [openbmc_debug_perl] rpower_bmc_status_response 200 OK
mid05tor12cn15: BMC Ready
Fri Jul 20 01:21:59 2018 mid05tor12cn15: [openbmc_debug_perl] curl -k -b cjar -X PUT -H "Content-Type: application/json" -d '{"data":"xyz.openbmc_project.State.Chassis.Transition.Off"}' https://172.11.139.15/xyz/openbmc_project/state/chassis0/attr/RequestedPowerTransition
Fri Jul 20 01:22:03 2018 mid05tor12cn15: [openbmc_debug_perl] rpower_off_response 200 OK
Fri Jul 20 01:22:03 2018 mid05tor12cn15: [openbmc_debug_perl] curl -k -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.15/xyz/openbmc_project/state/enumerate
Fri Jul 20 01:22:11 2018 mid05tor12cn15: [openbmc_debug_perl] rpower_check_response 200 OK
Fri Jul 20 01:22:11 2018 mid05tor12cn15: [openbmc_debug_perl] curl -k -b cjar -X PUT -H "Content-Type: application/json" -d '{"data":"xyz.openbmc_project.State.Host.Transition.On"}' https://172.11.139.15/xyz/openbmc_project/state/host0/attr/RequestedHostTransition
Fri Jul 20 01:22:13 2018 mid05tor12cn15: [openbmc_debug_perl] rpower_on_response 200 OK
mid05tor12cn15: reset
```