### PR TITLE
Tweak for setupntp. Ubuntu use chrony.service instead of chronyd.service

### DIFF
--- a/xCAT/postscripts/setupntp
+++ b/xCAT/postscripts/setupntp
@@ -151,7 +151,10 @@ systemctl disable ntpd.service 2>/dev/null
 systemctl disable ntp-wait.service 2>/dev/null
 systemctl disable ntpdate.service 2>/dev/null
 
-systemctl stop chronyd.service
+# On Ubuntu 18.04
+systemctl stop chrony.service 2>/dev/null
+# On RHEL 7, 8
+systemctl stop chronyd.service 2>/dev/null
 
 # The system is configured to maintain the RTC in universal time.
 timedatectl set-local-rtc 0
@@ -291,11 +294,13 @@ log measurements statistics tracking
 EOF
 exit_if_bad "$?" "Failed to create configuration file for chrony"
 
-systemctl reenable chronyd.service
-exit_if_bad "$?" "Failed to enable chronyd.service"
+systemctl reenable chrony.service 2>/dev/null ||
+	systemctl reenable chronyd.service 2>/dev/null
+exit_if_bad "$?" "Failed to enable chrony service"
 
-systemctl reload-or-restart chronyd.service
-exit_if_bad "$?" "Failed to start chronyd.service"
+systemctl reload-or-restart chrony.service 2>/dev/null ||
+	systemctl reload-or-restart chronyd.service 2>/dev/null
+exit_if_bad "$?" "Failed to start chrony service"
 
 logger -t xcat -p local4.info "NTP setup accomplished!"
 


### PR DESCRIPTION
Below are the unit test result on Ubuntu 18.04
```
# makentp
configuring management node: c910f03c17k03.
Will configure chronyd instead.
Calling ... /install/postscripts/setupntp
Daemon chronyd configured.
# systemctl list-unit-files | grep chrony
chrony-dnssrv@.service                                           static
chrony.service                                                   enabled
chronyd.service                                                  enabled
chrony-dnssrv@.timer                                             disabled
# systemctl status chrony
* chrony.service - chrony, an NTP client/server
   Loaded: loaded (/lib/systemd/system/chrony.service; enabled; vendor preset: enabled)
   Active: active (running) since Tue 2018-07-24 05:04:40 EDT; 23s ago
     Docs: man:chronyd(8)
           man:chronyc(1)
           man:chrony.conf(5)
  Process: 6871 ExecStartPost=/usr/lib/chrony/chrony-helper update-daemon (code=exited, status=0/SUCCESS)
  Process: 6863 ExecStart=/usr/lib/systemd/scripts/chronyd-starter.sh $DAEMON_OPTS (code=exited, status=0/SUCCESS)
 Main PID: 6869 (chronyd)
    Tasks: 1 (limit: 4915)
   CGroup: /system.slice/chrony.service
           `-6869 /usr/sbin/chronyd

Jul 24 05:04:40 c910f03c17k03 systemd[1]: Starting chrony, an NTP client/server...
Jul 24 05:04:40 c910f03c17k03 chronyd[6869]: chronyd version 3.2 starting (+CMDMON +NTP +REFCLOCK +RTC +PRIVDROP +SCFILTER +SECHASH +SIGND +
Jul 24 05:04:40 c910f03c17k03 chronyd[6869]: Frequency -25.740 +/- 0.229 ppm read from /var/lib/chrony/chrony.drift
Jul 24 05:04:40 c910f03c17k03 chronyd[6869]: Using right/UTC timezone to obtain leap second data
Jul 24 05:04:40 c910f03c17k03 systemd[1]: Started chrony, an NTP client/server.
Jul 24 05:04:53 c910f03c17k03 chronyd[6869]: Selected source 129.6.15.28
Jul 24 05:04:53 c910f03c17k03 chronyd[6869]: System clock TAI offset set to 37 seconds
```