### PR TITLE
support sles12sp3 servicenode installation

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/post.xcat
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat
@@ -274,7 +274,7 @@ if [ $hassystemd -eq 1 ] ; then
         cat >/etc/systemd/system/xcatpostinit1.service <<'EOF'
 #INCLUDE:/install/postscripts/xcatpostinit1.service.yast2#
 EOF
-        cat >/opt/xcat/xcatpostinit1.service.yast2 <<'EOF'
+        cat >/opt/xcat/xcatpostinit1.service.sles <<'EOF'
 #INCLUDE:/install/postscripts/xcatpostinit1.service#
 EOF
     else

--- a/xCAT-server/share/xcat/install/scripts/post.xcat
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat
@@ -270,9 +270,18 @@ if [ $? -eq 0 ]; then
 fi
 
 if [ $hassystemd -eq 1 ] ; then
-    cat >/etc/systemd/system/xcatpostinit1.service <<'EOF'
+    if [[ $OSVER == sles12* ]]; then
+        cat >/etc/systemd/system/xcatpostinit1.service <<'EOF'
+#INCLUDE:/install/postscripts/xcatpostinit1.service.yast2#
+EOF
+        cat >/opt/xcat/xcatpostinit1.service.yast2 <<'EOF'
 #INCLUDE:/install/postscripts/xcatpostinit1.service#
 EOF
+    else
+        cat >/etc/systemd/system/xcatpostinit1.service <<'EOF'
+#INCLUDE:/install/postscripts/xcatpostinit1.service#
+EOF
+    fi
     if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
         msgutil_r "$MASTER_IP" "debug" "/etc/systemd/system/xcatpostinit1.service generated" "/var/log/xcat/xcat.log" "$log_label"
     fi

--- a/xCAT/postscripts/xcatpostinit1.install
+++ b/xCAT/postscripts/xcatpostinit1.install
@@ -48,11 +48,9 @@ start)
     if [ -r /opt/xcat/xcatinstallpost ]; then
       /opt/xcat/xcatinstallpost
     fi
-    if [ -f /opt/xcat/xcatpostinit1.service.yast2 ]; then
-        mv /etc/systemd/system/xcatpostinit1.service /etc/systemd/system/xcatpostinit1.service.xcatbak
-        if [ $? -eq 0 ]; then
-            mv /opt/xcat/xcatpostinit1.service.yast2 /etc/systemd/system/xcatpostinit1.service
-        fi
+    if [ -f /opt/xcat/xcatpostinit1.service.sles ]; then
+        rm -rf /etc/systemd/system/xcatpostinit1.service
+        mv /opt/xcat/xcatpostinit1.service.sles /etc/systemd/system/xcatpostinit1.service
     fi
   fi
 

--- a/xCAT/postscripts/xcatpostinit1.install
+++ b/xCAT/postscripts/xcatpostinit1.install
@@ -48,6 +48,12 @@ start)
     if [ -r /opt/xcat/xcatinstallpost ]; then
       /opt/xcat/xcatinstallpost
     fi
+    if [ -f /opt/xcat/xcatpostinit1.service.yast2 ]; then
+        mv /etc/systemd/system/xcatpostinit1.service /etc/systemd/system/xcatpostinit1.service.xcatbak
+        if [ $? -eq 0 ]; then
+            mv /opt/xcat/xcatpostinit1.service.yast2 /etc/systemd/system/xcatpostinit1.service
+        fi
+    fi
   fi
 
   ;;

--- a/xCAT/postscripts/xcatpostinit1.service.yast2
+++ b/xCAT/postscripts/xcatpostinit1.service.yast2
@@ -1,0 +1,12 @@
+[Unit]
+Description=xcat service on compute node, the framework to run postbootscript and update node status 
+After=network.target rsyslog.service YaST2-Firstboot.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/xcat/xcatpostinit1 start
+ExecStop=/opt/xcat/xcatpostinit1 stop
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/xCAT/postscripts/xcatpostinit1.service.yast2
+++ b/xCAT/postscripts/xcatpostinit1.service.yast2
@@ -1,5 +1,5 @@
 [Unit]
-Description=xcat service on compute node, the framework to run postbootscript and update node status 
+Description=xcat service on compute node, the framework to run postbootscript during OS provision 
 After=network.target rsyslog.service YaST2-Firstboot.service
 
 [Service]


### PR DESCRIPTION
For https://github.com/xcat2/xcat-core/issues/5417:
Before this fix, the xcatpostinit1.service will run with YaST2 Second Stage in parallel:
```
[  OK  ] Stopped wicked managed network interfaces.
         Starting wicked managed network interfaces...
[  OK  ] Started xcat service on compute nod...otscript and update node status.
[  OK  ] Started wicked managed network interfaces.
stty: 'standard input': unable to perform all requested operations
[  OK  ] Stopped Setup Virtual Console.
         Stopping Setup Virtual Console...
         Starting Setup Virtual Console...
[  OK  ] Started Setup Virtual Console.
[  OK  ] Started YaST2 Second Stage.
         Starting Autoyast2 Init Scripts...
         Starting Load kdump kernel and initrd...
[  OK  ] Started Autoyast2 Init Scripts.
         Starting Permit User Sessions...
[  OK  ] Started Permit User Sessions.
         Starting Hold until boot process finishes up...
         Starting Terminate Plymouth Boot Screen...
```
After code fix, the process is following,xcatpostinit1.service will run after Starting Autoyast2 Init Scripts, based on https://www.suse.com/documentation/sles-12/singlehtml/book_autoyast/book_autoyast.html#CreateProfile.Firstboot,
```
         Stopping wicked managed network interfaces...
[  OK  ] Stopped wicked managed network interfaces.
         Starting wicked managed network interfaces...
[  OK  ] Started wicked managed network interfaces.
stty: 'standard input': unable to perform all requested operations
[  OK  ] Stopped Setup Virtual Console.
         Stopping Setup Virtual Console...
         Starting Setup Virtual Console...
[  OK  ] Started Setup Virtual Console.
[  OK  ] Started YaST2 Second Stage.
         Starting Autoyast2 Init Scripts...
         Starting xcat service on compute no...script and update node status...
[  OK  ] Started Autoyast2 Init Scripts.
         Starting Permit User Sessions...
[  OK  ] Started Permit User Sessions.
         Starting Hold until boot process finishes up...
         Starting Terminate Plymouth Boot Screen...

Welcome to SUSE Linux Enterprise Server 12 SP3  (ppc64le) - Kernel 4.4.73-5-default (hvc0).
c910f03c09k13 login:

c910f03c09k13:~ # tail -f /var/log/xcat/xcat.log
+ [[ sles12.3 != sles11* ]]
+ service network stop
+ '[' 1 = 1 ']'
+ set +x
Tue Jul 24 07:19:23 EDT 2018 [info]: xcat.xcatinstallpost: Running /xcatpost/mypostscript.post
Tue Jul 24 07:19:23 EDT 2018 [info]: xcat.mypostscript: Running postbootscript: otherpkgs
Tue Jul 24 07:20:21 EDT 2018 [info]: xcat.mypostscript: postbootscript otherpkgs return with 0
Tue Jul 24 07:20:21 EDT 2018 [debug]: xcat.mypostscript: node booted, reporting status...
Tue Jul 24 07:20:21 EDT 2018 [info]: xcat.mypostscript: provision completed.(c910f03c09k13)
Tue Jul 24 07:20:21 EDT 2018 [info]: xcat.xcatinstallpost: /xcatpost/mypostscript.post return
```

