### PR TITLE
enhance ifdown/ifup for confignetwork and confignics

### DIFF
--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -404,9 +404,9 @@ if [ "$1" = "-r" ];then
         ip link show $str_nic_name | grep -i ',up'
         if [ $? -eq 0 ];then
             if [ "$str_os_type" = "debian" ];then
-                ifdown --force $str_nic_name
+                ip link set $str_nic_name down
             else
-                ifdown $str_nic_name
+                ip link set $str_nic_name down
             fi
         fi
 
@@ -641,7 +641,7 @@ elif [ "$1" = "-s" ];then
     fi
 
     if [ "$UPDATENODE" = "1" ] || grep "REBOOT=TRUE" /opt/xcat/xcatinfo >/dev/null 2>&1; then
-        ifdown $str_inst_nic;ifup $str_inst_nic
+        ip link set $str_inst_nic down;ip link set $str_inst_nic up
     fi 
     if [ $? -ne 0 ]; then
         log_error "ifup $str_inst_nic failed."
@@ -976,9 +976,9 @@ else
         if [ $bool_restart_flag -eq 1 ];then
             if [ "$str_nic_status" = "up" ];then
                 if [ "$str_os_type" = "debian" ];then
-                    ifdown --force $str_nic_name > /dev/null
+                    ip link set $str_nic_name down > /dev/null
                 else
-                    ifdown $str_nic_name > /dev/null
+                    ip link set $str_nic_name down > /dev/null
                 fi
             fi
             #delete all old ip address

--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -987,7 +987,7 @@ else
                 if [ "$str_os_type" = "debian" ];then
                     ifdown --force $str_nic_name > /dev/null
                 else
-                    if [ $reboot_nic_bool ]; then
+                    if [ $reboot_nic_bool -eq 1 ]; then
                         ifdown $str_nic_name > /dev/null
                     fi
                 fi
@@ -1068,7 +1068,7 @@ else
                 error_code=1
             fi
         else
-            if [ $reboot_nic_bool ]; then
+            if [ $reboot_nic_bool -eq 1 ]; then
                 echo "bring up ip"
                 ifup $str_nic_name
                 if [ $? -ne 0 ]; then

--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -9,6 +9,15 @@ if [ "$(uname -s|tr 'A-Z' 'a-z')" = "linux" ];then
    . $str_dir_name/nicutils.sh
 fi
 error_code=0
+#########################################################################
+# ifdown/ifup will not be executed in diskful provision postscripts stage
+#########################################################################
+reboot_nic_bool=1
+if [ -z "$UPDATENODE" ] || [ $UPDATENODE -ne 1 ] ; then
+    if [ "$NODESETSTATE" = "install" ] && ! grep "REBOOT=TRUE" /opt/xcat/xcatinfo >/dev/null 2>&1; then
+        reboot_nic_bool=0
+    fi
+fi
 function configipv4(){
     str_if_name=$1
     str_v4ip=$2
@@ -404,9 +413,9 @@ if [ "$1" = "-r" ];then
         ip link show $str_nic_name | grep -i ',up'
         if [ $? -eq 0 ];then
             if [ "$str_os_type" = "debian" ];then
-                ip link set $str_nic_name down
+                ifdown --force $str_nic_name
             else
-                ip link set $str_nic_name down
+                ifdown $str_nic_name
             fi
         fi
 
@@ -641,7 +650,7 @@ elif [ "$1" = "-s" ];then
     fi
 
     if [ "$UPDATENODE" = "1" ] || grep "REBOOT=TRUE" /opt/xcat/xcatinfo >/dev/null 2>&1; then
-        ip link set $str_inst_nic down;ip link set $str_inst_nic up
+        ifdown $str_inst_nic;ifup $str_inst_nic
     fi 
     if [ $? -ne 0 ]; then
         log_error "ifup $str_inst_nic failed."
@@ -976,9 +985,11 @@ else
         if [ $bool_restart_flag -eq 1 ];then
             if [ "$str_nic_status" = "up" ];then
                 if [ "$str_os_type" = "debian" ];then
-                    ip link set $str_nic_name down > /dev/null
+                    ifdown --force $str_nic_name > /dev/null
                 else
-                    ip link set $str_nic_name down > /dev/null
+                    if [ $reboot_nic_bool ]; then
+                        ifdown $str_nic_name > /dev/null
+                    fi
                 fi
             fi
             #delete all old ip address
@@ -1057,11 +1068,13 @@ else
                 error_code=1
             fi
         else
-            echo "bring up ip"
-            ifup $str_nic_name
-            if [ $? -ne 0 ]; then
-                log_error "ifup $str_nic_name failed."
-                error_code=1
+            if [ $reboot_nic_bool ]; then
+                echo "bring up ip"
+                ifup $str_nic_name
+                if [ $? -ne 0 ]; then
+                    log_error "ifup $str_nic_name failed."
+                    error_code=1
+                fi
             fi
         fi
     fi

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -17,8 +17,7 @@ tail="tail"
 dmesg="dmesg"
 grep="grep"
 lspci="lspci"
-ifup="ifup"
-ifdown="ifdown"
+ip_link_set="ip link set"
 nmcli="nmcli"
 dirname="dirname"
 ip="ip"
@@ -970,10 +969,10 @@ function create_bridge_interface {
          inattrs="$cfg"
 
     # bring up interface formally
-    lines=`$ifdown $ifname; $ifup $ifname`
+    lines=`$ip_link_set $ifname down; $ip_link_set $ifname up`
     rc=$?
     if [ $rc -ne 0 ]; then
-        log_warn "ifup $ifname failed with return code equals to $rc"
+        log_warn "$ip_link_set $ifname up failed with return code equals to $rc"
         echo "$lines" \
         | $sed -e 's/^/>> /g' \
         | log_lines info
@@ -1062,10 +1061,10 @@ function create_ethernet_interface {
         inattrs="$cfg"
 
     # bring up interface formally
-    true || lines=`$ifdown $ifname; $ifup $ifname`
+    true || lines=`$ip_link_set $ifname down; $ip_link_set $ifname down`
     rc=$?
     if [ $rc -ne 0 ]; then
-        log_warn "ifup $ifname failed with return code equals to $rc"
+        log_warn "$ip_link_set $ifname up failed with return code equals to $rc"
         echo "$lines" \
         | $sed -e 's/^/>> /g' \
         | log_lines info
@@ -1188,7 +1187,7 @@ function create_vlan_interface {
         inattrs="$cfg"
     if [ x$xcatnet != x ]; then
         # bring up interface formally
-        lines=`$ifdown $ifname.$vlanid; $ifup $ifname.$vlanid`
+        lines=`$ip_link_set $ifname.$vlanid down; $ip_link_set $ifname.$vlanid up`
         rc=$?
         if [ $rc -ne 0 ]; then
             log_warn "ifup $ifname.$vlanid failed with return code equals to $rc"
@@ -1486,10 +1485,10 @@ function create_bond_interface {
         xcatnet=$xcatnet \
         inattrs="$cfg"
     if [ x$xcatnet != x ]; then
-        lines=`$ifdown $ifname; $ifup $ifname 2>&1`
+        lines=`$ip_link_set $ifname down; $ip_link_set $ifname up 2>&1`
         rc=$?
         if [ $rc -ne 0 ]; then
-            log_warn "ifup $ifname failed with return code equals to $rc"
+            log_warn "$ip_link_set failed up with return code equals to $rc"
             echo "$lines" \
             | $sed -e 's/^/'$ifname' ifup out >> /g' \
             | log_lines info

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -980,7 +980,7 @@ function create_bridge_interface {
          inattrs="$cfg"
 
     # bring up interface formally
-    if [ $reboot_nic_bool ]; then
+    if [ $reboot_nic_bool -eq 1 ]; then
         lines=`$ifdown $ifname; $ifup $ifname`
         rc=$?
     fi
@@ -1074,7 +1074,7 @@ function create_ethernet_interface {
         inattrs="$cfg"
 
     # bring up interface formally
-    if [ $reboot_nic_bool ]; then
+    if [ $reboot_nic_bool -eq 1 ]; then
         lines=`$ifdown $ifname; $ifup $ifname`
         rc=$?
     fi
@@ -1202,7 +1202,7 @@ function create_vlan_interface {
         inattrs="$cfg"
     if [ x$xcatnet != x ]; then
         # bring up interface formally
-        if [ $reboot_nic_bool ]; then
+        if [ $reboot_nic_bool -eq 1 ]; then
             lines=`$ifdown $ifname.$vlanid; $ifup $ifname.$vlanid`
             rc=$?
         fi
@@ -1502,7 +1502,7 @@ function create_bond_interface {
         xcatnet=$xcatnet \
         inattrs="$cfg"
     if [ x$xcatnet != x ]; then
-        if [ $reboot_nic_bool ]; then
+        if [ $reboot_nic_bool -eq 1 ]; then
             lines=`$ifdown $ifname; $ifup $ifname 2>&1`
             rc=$?
         fi


### PR DESCRIPTION
for https://github.com/xcat2/xcat-core/issues/5420
``nmcli`` doesn't exist in the chroot'ed deployment environment that cause ``ifdown/ifup`` failure. If it's in a pre-installation context (such as anaconda when run as a postscript), as it just needs to set the configuration files for the next boot, and the status of the interface doesn't really matter, so for diskful provison postscript stage, will not execute ``ifdown/ifup`` to take the configure file effect.

Did UT in redhat7.4 environment using autotest ``confignetwork`` testcase:
```
[root@bybc0602 postscripts]# grep "END" /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20180725024644
END::confignetwork_s_installnic_secondarynic_updatenode::Passed::Time:Thu Jul 26 04:15:25 2018 ::Duration::21 sec
END::confignetwork_secondarynic_updatenode::Passed::Time:Thu Jul 26 04:15:36 2018 ::Duration::11 sec
END::confignetwork_secondarynic_nicaliases_updatenode::Passed::Time:Thu Jul 26 04:15:49 2018 ::Duration::13 sec
END::confignetwork_secondarynic_nicextraparams_updatenode::Passed::Time:Thu Jul 26 04:16:10 2018 ::Duration::21 sec
END::confignetwork_secondarynic_nicnetworks_updatenode_false::Passed::Time:Thu Jul 26 04:16:15 2018 ::Duration::5 sec
END::confignetwork_secondarynic_nicips_updatenode_false::Passed::Time:Thu Jul 26 04:16:21 2018 ::Duration::6 sec
END::confignetwork_secondarynic_nictype_updatenode_false::Passed::Time:Thu Jul 26 04:16:26 2018 ::Duration::5 sec
END::confignetwork_disable_set_to_yes::Passed::Time:Thu Jul 26 04:16:32 2018 ::Duration::6 sec
END::confignetwork_disable_set_to_1::Passed::Time:Thu Jul 26 04:16:38 2018 ::Duration::6 sec
END::confignetwork_niccustomscripts::Passed::Time:Thu Jul 26 04:16:44 2018 ::Duration::6 sec
END::confignetwork_secondarynic_thirdnic_multiplevalue_updatenode::Passed::Time:Thu Jul 26 04:17:11 2018 ::Duration::27 sec
END::confignetwork_vlan_eth0::Passed::Time:Thu Jul 26 04:17:41 2018 ::Duration::30 sec
END::confignetwork_vlan_false::Passed::Time:Thu Jul 26 04:17:59 2018 ::Duration::18 sec
END::confignetwork_bond_eth2_eth3::Passed::Time:Thu Jul 26 04:18:08 2018 ::Duration::9 sec
END::confignetwork_vlan_bond::Passed::Time:Thu Jul 26 04:19:18 2018 ::Duration::46 sec
END::confignetwork_2eth_bridge_br0::Passed::Time:Thu Jul 26 04:20:02 2018 ::Duration::44 sec
END::confignetwork_static_installnic::Passed::Time:Thu Jul 26 04:24:10 2018 ::Duration::68 sec
END::confignetwork_bond_false::Passed::Time:Thu Jul 26 04:33:19 2018 ::Duration::25 sec
END::confignetwork_bond_false::Passed::Time:Thu Jul 26 04:33:19 2018 ::Duration::25 sec
END::confignetwork_2eth_bridge_br22_br33::Failed::Time:Thu Jul 26 04:34:20 2018 ::Duration::61 sec
END::confignetwork_installnic_2eth_bridge_br22_br33::Failed::Time:Thu Jul 26 04:35:28 2018 ::Duration::68 sec
END::confignetwork__bridge_false::Failed::Time:Thu Jul 26 04:36:18 2018 ::Duration::50 sec

[root@bybc0602 postscripts]# xdsh bybc0609 "more /etc/*release"
bybc0609: ::::::::::::::
bybc0609: /etc/os-release
bybc0609: ::::::::::::::
bybc0609: NAME="Red Hat Enterprise Linux Server"
bybc0609: VERSION="7.4 (Maipo)"
bybc0609: ID="rhel"
bybc0609: ID_LIKE="fedora"
bybc0609: VARIANT="Server"
bybc0609: VARIANT_ID="server"
bybc0609: VERSION_ID="7.4"
bybc0609: PRETTY_NAME="Red Hat Enterprise Linux Server 7.4 (Maipo)"
...
```