### PR TITLE
not generate debuginfo for xCAT-server package

### DIFF
--- a/xCAT-server/xCAT-server.spec
+++ b/xCAT-server/xCAT-server.spec
@@ -15,6 +15,7 @@ BuildRoot: /var/tmp/%{name}-%{version}-%{release}-root
 %ifnos linux
 AutoReqProv: no
 %endif
+%define debug_package %{nil}
 
 %define fsm %(if [ "$fsm" = "1" ];then echo 1; else echo 0; fi)
 


### PR DESCRIPTION
UT:
```
[root@0936df1ed2d1 xcat-core]# ./makerpm xCAT-server
Building /root/rpmbuild/RPMS/noarch/xCAT-server-2.14.3-snap*.noarch.rpm ...
[root@0936df1ed2d1 xcat-core]#
```

Before the fix:
```
./makerpm xCAT-server ''
Building /root/rpmbuild/RPMS/noarch/xCAT-server-2.14.3-snap*.noarch.rpm ...
find: 'debug': No such file or directory 
```