### PR TITLE
Enlarge the size of /boot partition for Ubuntu

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/pre.ubuntu
+++ b/xCAT-server/share/xcat/install/scripts/pre.ubuntu
@@ -195,7 +195,7 @@ if [ -d /sys/firmware/efi ]; then
     echo "    ." >> /tmp/partitionfile
 else
     echo "ubuntu-boot ::" > /tmp/partitionfile
-    echo "100 50 100 ext3" >> /tmp/partitionfile
+    echo "256 256 512 ext3" >> /tmp/partitionfile
     echo '    $primary{ } $bootable{ } method{ format } format{ } use_filesystem{ } filesystem{ ext3 } mountpoint{ /boot }' >> /tmp/partitionfile
     echo "    ." >> /tmp/partitionfile
 fi

--- a/xCAT-server/share/xcat/install/scripts/pre.ubuntu.ppc64
+++ b/xCAT-server/share/xcat/install/scripts/pre.ubuntu.ppc64
@@ -214,7 +214,7 @@ else
     echo '    $primary{ } $bootable{ } method{ prep }' >> /tmp/partitionfile
     echo "    ." >> /tmp/partitionfile
 
-    #echo "100 50 100 ext4" >> /tmp/partitionfile
+    #echo "256 256 512 ext4" >> /tmp/partitionfile
     #echo '    $primary{ } $bootable{ } method{ format } format{ } use_filesystem{ } filesystem{ ext4 } mountpoint{ /boot }' >> /tmp/partitionfile
     #echo "    ." >> /tmp/partitionfile
 fi


### PR DESCRIPTION
The original minimal size is 100, which means 100MB. But it is rounded to cylinder size. In recent Jenkins daily run. One of our testing machine get only 88MB for its /boot partition. It is not big enough for even one kernel and its initrd image.

Thus, I enlarge it to 256MB minimal