### PR TITLE
using execute binary of systemd to determine if systemd is enabled on the distro

### DIFF
--- a/xCAT-server/sbin/xcatconfig
+++ b/xCAT-server/sbin/xcatconfig
@@ -425,7 +425,7 @@ if ($::INITIALINSTALL || $::FORCE || $::UPDATEINSTALL)
 # The systemd only has LANG and PATH as default environmental variables,
 # TERM is needed for KVM consoles(actually screen command needs TERM)
 # import the TERM into systemd
-if (-d "/usr/lib/systemd/system") {
+if (-x "/usr/lib/systemd/systemd" || -x "/lib/systemd/systemd") {
     my $term = $ENV{'TERM'};
     if (!$term) {
         $term = "vt100";


### PR DESCRIPTION
To fix #5433 
The root cause is now xCAT-server will ship `/usr/lib/systemd/system/xcatd.service` in RPM, but xcatconfig will use `/usr/lib/systemd/system` to see if it is systemd enabled distro. Then it cause the problem, now we use the systemd binary to check if systemd enabled.

UT: 
```
c910f02c08p05:~ #xcatconfig  -c 2>&1 | tee /tmp/xcatconfig.test
...
c910f02c08p05:~ #cat /tmp/xcatconfig.test|grep "Command failed"
c910f02c08p05:~ #
```
And On RH6.10,  same no the systemd binary
```
[root@c910f02c01p13 ~]# ls /usr/lib/systemd/systemd
ls: cannot access /usr/lib/systemd/systemd: No such file or directory
[root@c910f02c01p13 ~]# ls /lib/systemd/systemd
ls: cannot access /lib/systemd/systemd: No such file or directory
[root@c910f02c01p13 ~]#
```