### PR TITLE
Add chrony to default Ubuntu 18.04 package lists

### DIFF
--- a/xCAT-server/share/xcat/install/ubuntu/compute.ubuntu18.04.ppc64el.pkglist
+++ b/xCAT-server/share/xcat/install/ubuntu/compute.ubuntu18.04.ppc64el.pkglist
@@ -12,3 +12,4 @@ rsync
 busybox-static
 gawk
 dnsutils
+chrony

--- a/xCAT-server/share/xcat/install/ubuntu/compute.ubuntu18.04.x86_64.pkglist
+++ b/xCAT-server/share/xcat/install/ubuntu/compute.ubuntu18.04.x86_64.pkglist
@@ -12,3 +12,4 @@ rsync
 busybox-static
 gawk
 dnsutils
+chrony

--- a/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu18.04.ppc64el.pkglist
+++ b/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu18.04.ppc64el.pkglist
@@ -17,3 +17,4 @@ tar
 gzip
 xz-utils
 cpio
+chrony

--- a/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu18.04.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu18.04.x86_64.pkglist
@@ -17,3 +17,4 @@ tar
 gzip
 xz-utils
 cpio
+chrony


### PR DESCRIPTION
I think it is better to add `chrony` to the package list explicitly.