### PR TITLE
rinstall flag and option

### DIFF
--- a/docs/source/guides/admin-guides/references/man8/rinstall.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/rinstall.8.rst
@@ -19,9 +19,11 @@ Name
 ****************
 
 
-\ **rinstall**\  \ *noderange*\  [\ **boot**\  | \ **shell**\  | \ **runcmd=bmcsetup**\ ] [\ **runimage=**\ \ *task*\ ] [\ **-c | -**\ **-console**\ ] [\ **-V | -**\ **-verbose**\ ]
+\ **rinstall**\  \ *noderange*\  [\ **boot**\  | \ **shell**\  | \ **runcmd=bmcsetup**\ ] [\ **-c | -**\ **-console**\ ] [\ **-V | -**\ **-verbose**\ ]
 
-\ **rinstall**\  \ *noderange*\  [\ **osimage**\ =\ *imagename*\  | \ *imagename*\ ] [\ **-**\ **-ignorekernelchk**\ ] [\ **-c | -**\ **-console**\ ] [\ **-u | -**\ **-uefimode**\ ] [\ **-V | -**\ **-verbose**\ ]
+\ **rinstall**\  \ *noderange*\  \ **osimage**\ [=\ *imagename*\ ] [\ **-**\ **-ignorekernelchk**\ ] [\ **-c | -**\ **-console**\ ] [\ **-u | -**\ **-uefimode**\ ] [\ **-V | -**\ **-verbose**\ ]
+
+\ **rinstall**\  \ *noderange*\  \ **runimage=**\ \ *task*\ 
 
 \ **rinstall**\  [\ **-h | -**\ **-help | -v | -**\ **-version**\ ]
 
@@ -33,9 +35,9 @@ Name
 
 \ **rinstall**\  is a convenience command to begin OS provision on a noderange.
 
-If \ **osimage**\ =\ *imagename*\  | \ *imagename*\  is specified or nodetype.provmethod=\ **osimage**\  is set, provision the noderange with the osimage specified/configured.
+If \ **osimage**\ =\ *imagename*\  is specified or \ **osimage**\  is specified and nodetype.provmethod=\ **osimage**\  is set, provision the noderange with the osimage specified/configured.
 
-If \ **-c**\  is specified, it will then run rcons on the node. This is allowed only if one node in the noderange. If need consoles on multiple nodes, see winstall(8)|winstall.8.
+If \ **-c**\  is specified, it will then run \ **rcons**\  on the node. This is allowed only if one node is in the noderange. If consoles are needed on multiple nodes, see winstall(8)|winstall.8.
 
 
 ***************
@@ -50,9 +52,9 @@ If \ **-c**\  is specified, it will then run rcons on the node. This is allowed 
  
 
 
-\ *imagename*\  | \ **osimage=**\ \ *imagename*\ 
+\ **osimage**\ [=\ *imagename*\ ]
  
- Prepare server for installing a node using the specified os image. The os image is defined in the \ *osimage*\  table and \ *linuximage*\  table. If the \ *imagename*\  is omitted, the os image name will be obtained from \ *nodetype.provmethod*\  for the node.
+ Prepare server for installing a node using the specified OS image. The OS image is defined in the \ *osimage*\  table and \ *linuximage*\  table. If the \ *imagename*\  is omitted, the OS image name will be obtained from \ *nodetype.provmethod*\  for the node.
  
 
 
@@ -107,7 +109,7 @@ If \ **-c**\  is specified, it will then run rcons on the node. This is allowed 
 
 \ **-c | -**\ **-console**\ 
  
- Requests that rinstall runs rcons once the provision starts.  This will only work if there is only one node in the noderange. See winstall(8)|winstall.8 for starting consoles on multiple nodes.
+ Requests that \ **rinstall**\  runs \ **rcons**\  once the provision starts.  This will only work if there is only one node in the noderange. See winstall(8)|winstall.8 for starting consoles on multiple nodes.
  
 
 

--- a/xCAT-client/pods/man8/rinstall.8.pod
+++ b/xCAT-client/pods/man8/rinstall.8.pod
@@ -4,9 +4,11 @@ B<rinstall> - Begin OS provision on a noderange
 
 =head1 B<Synopsis>
 
-B<rinstall> I<noderange> [B<boot> | B<shell> | B<runcmd=bmcsetup>] [B<runimage=>I<task>] [B<-c>|B<--console>] [B<-V>|B<--verbose>]
+B<rinstall> I<noderange> [B<boot> | B<shell> | B<runcmd=bmcsetup>] [B<-c>|B<--console>] [B<-V>|B<--verbose>]
 
-B<rinstall> I<noderange> [B<osimage>=I<imagename> | I<imagename>] [B<--ignorekernelchk>] [B<-c>|B<--console>] [B<-u>|B<--uefimode>] [B<-V>|B<--verbose>]
+B<rinstall> I<noderange> B<osimage>[=I<imagename>] [B<--ignorekernelchk>] [B<-c>|B<--console>] [B<-u>|B<--uefimode>] [B<-V>|B<--verbose>]
+
+B<rinstall> I<noderange> B<runimage=>I<task>
 
 B<rinstall> [B<-h>|B<--help>|B<-v>|B<--version>]
 
@@ -14,9 +16,9 @@ B<rinstall> [B<-h>|B<--help>|B<-v>|B<--version>]
 
 B<rinstall> is a convenience command to begin OS provision on a noderange.
 
-If B<osimage>=I<imagename> | I<imagename> is specified or nodetype.provmethod=B<osimage> is set, provision the noderange with the osimage specified/configured.
+If B<osimage>=I<imagename> is specified or B<osimage> is specified and nodetype.provmethod=B<osimage> is set, provision the noderange with the osimage specified/configured.
 
-If B<-c> is specified, it will then run rcons on the node. This is allowed only if one node in the noderange. If need consoles on multiple nodes, see L<winstall(8)|winstall.8>.
+If B<-c> is specified, it will then run B<rcons> on the node. This is allowed only if one node is in the noderange. If consoles are needed on multiple nodes, see L<winstall(8)|winstall.8>.
 
 =head1 B<Options>
 
@@ -26,9 +28,9 @@ If B<-c> is specified, it will then run rcons on the node. This is allowed only 
 
 Instruct network boot loader to be skipped, generally meaning boot to hard disk
 
-=item I<imagename> | B<osimage=>I<imagename>
+=item B<osimage>[=I<imagename>]
 
-Prepare server for installing a node using the specified os image. The os image is defined in the I<osimage> table and I<linuximage> table. If the I<imagename> is omitted, the os image name will be obtained from I<nodetype.provmethod> for the node.  
+Prepare server for installing a node using the specified OS image. The OS image is defined in the I<osimage> table and I<linuximage> table. If the I<imagename> is omitted, the OS image name will be obtained from I<nodetype.provmethod> for the node.  
 
 =item B<--ignorekernelchk>
 
@@ -65,7 +67,7 @@ Verbose output.
 
 =item B<-c>|B<--console>
 
-Requests that rinstall runs rcons once the provision starts.  This will only work if there is only one node in the noderange. See L<winstall(8)|winstall.8> for starting consoles on multiple nodes.
+Requests that B<rinstall> runs B<rcons> once the provision starts.  This will only work if there is only one node in the noderange. See L<winstall(8)|winstall.8> for starting consoles on multiple nodes.
 
 =back
 

--- a/xCAT-server/lib/xcat/plugins/destiny.pm
+++ b/xCAT-server/lib/xcat/plugins/destiny.pm
@@ -335,7 +335,7 @@ sub setdestiny {
                         return;
                     }
                 } else {
-                    $callback->({ errorcode => [1], error => "Cannot find the OS image $target on the osimage table.", errorabort => [1] });
+                    $callback->({ errorcode => [1], error => "Cannot find the OS image $target in the osimage table.", errorabort => [1] });
                     return;
                 }
 
@@ -416,7 +416,7 @@ sub setdestiny {
                                 }
                             } else {
                                 push(@{ $invalidosimghash->{$osimage}->{nodes} }, $tmpnode);
-                                $invalidosimghash->{$osimage}->{error}->[0] = "Cannot find the OS image $osimage on the osimage table";
+                                $invalidosimghash->{$osimage}->{error}->[0] = "Cannot find the OS image $osimage in the osimage table";
                                 next;
                             }
                         }

--- a/xCAT-server/lib/xcat/plugins/rinstall.pm
+++ b/xCAT-server/lib/xcat/plugins/rinstall.pm
@@ -69,7 +69,6 @@ sub rinstall {
     my $CONSOLE;
     my $OSIMAGE;
     my $STATES;
-    my $RESTSTATES;
     my $ignorekernelchk;
     my $VERBOSE;
     my $HELP;
@@ -82,6 +81,7 @@ sub rinstall {
     my $nodes;
     my @nodes;
     my %nodes;
+    my $rsp = {};
 
     # There are nodes
     if (defined($req->{node})) {
@@ -100,7 +100,6 @@ sub rinstall {
     if (($command =~ /rinstall/) or ($command =~ /winstall/)) {
         my $ret=xCAT::Usage->validateArgs($command,@ARGV);
         if ($ret->[0]!=0) {
-             my $rsp={};
              $rsp->{error}->[0] = $ret->[1];
              $rsp->{errorcode}->[0] = $ret->[0];
              xCAT::MsgUtils->message("E", $rsp, $callback);
@@ -109,36 +108,32 @@ sub rinstall {
         }
 
         my $state = $ARGV[0];
-        ($state, $RESTSTATES) = split(/,/, $state, 2);
         chomp($state);
-        if ($state eq "image" or $state eq "winshell" or $state =~ /^osimage/) {
-            my $target;
-            my $action;
-            if ($state =~ /=/) {
-                ($state, $target) = split '=', $state, 2;
-                if ($target =~ /:/) {
-                    ($target, $action) = split ':', $target, 2;
-                }
-            }
-            else {
-                if ($state =~ /:/) {
-                    ($state, $action) = split ':', $state, 2;
-                }
-            }
-            if ($state eq 'osimage') {
-                $OSIMAGE = $target;
-            }
+        if ($state =~ /^osimage=(\S+)/) {
+           $OSIMAGE = $1; # osimage was specified
+           xCAT::MsgUtils->message("I", $rsp, $callback);
+        }
+        elsif ($state =~ /^boot$|^shell$|^osimage$|^runcmd=bmcsetup$|^runimage=/) {
+           # the rest are valid actions, just pass to nodeset
+           $STATES=$state;
+        }
+        elsif ($state =~ /^-/) {
+           # if starts with dash, let GetOptions below to process
         }
         else {
-            unless ($state =~ /-/) {
-                $STATES = $state;
-            }
+           if ($state) {
+               $rsp->{errorcode}->[0]=1;
+               $rsp->{error}->[0]="Invalid option $state";
+               xCAT::MsgUtils->message("E",$rsp,$callback);
+               &usage($command, $callback);
+               return 1;
+           }
         }
 
         Getopt::Long::Configure("bundling");
         Getopt::Long::Configure("no_pass_through");
         unless (
-            GetOptions('O|osimage=s' => \$OSIMAGE,
+            GetOptions(
                 'ignorekernelchk' => \$ignorekernelchk,
                 'V|verbose'       => \$VERBOSE,
                 'h|help'          => \$HELP,
@@ -156,7 +151,6 @@ sub rinstall {
     }
     if ($VERSION) {
         my $version = xCAT::Utils->Version();
-        my $rsp     = {};
         $rsp->{data}->[0] = "$version";
         xCAT::MsgUtils->message("I", $rsp, $callback);
         return 0;
@@ -167,7 +161,6 @@ sub rinstall {
     }
 
     if($command eq "rinstall" and scalar(@nodes) > 1 and $CONSOLE){
-       my $rsp;
        $rsp->{errorcode}->[0]=1;
        $rsp->{error}->[0]="rinstall -c/--console can only be run against one node! Please use winstall -c/--console for multiple nodes.";
        xCAT::MsgUtils->message("E",$rsp,$callback);
@@ -183,7 +176,7 @@ sub rinstall {
 
     if ($OSIMAGE) {
 
-        # if -O|--osimage or osimage=<imagename> is specified,
+        # if osimage=<imagename> is specified,
         # call "nodeset ... osimage= ..." to set the boot state of the noderange to the specified osimage,
         # "nodeset" will handle the updating of node attributes such as os,arch,profile,provmethod.
 
@@ -197,8 +190,13 @@ sub rinstall {
         (my $ref) = $osimagetable->getAttribs({ imagename => $OSIMAGE }, 'osvers', 'osarch', 'imagetype');
         $osimagetable->close();
 
+        unless ($ref) {
+            # Nothing was returned from getAttrbs for the specified image
+            $rsp->{data}->[0] = "Cannot find the OS image $OSIMAGE in the osimage table.";
+            xCAT::MsgUtils->message("E", $rsp, $callback);
+            return 1;
+        }
         unless (defined($ref->{osarch})) {
-            my $rsp = {};
             $rsp->{error}->[0] = "$OSIMAGE 'osarch' attribute not defined in 'osimage' table.";
             $rsp->{errorcode}->[0] = 1;
             xCAT::MsgUtils->message("E", $rsp, $callback);
@@ -215,7 +213,6 @@ sub rinstall {
             my $nodetypeattribs = $nodetypecache->{$node}->[0];
             my $nodehmattribs   = $nodehmcache->{$node}->[0];
             unless (defined($noderesattribs) and defined($noderesattribs->{'netboot'})) {
-                my $rsp = {};
                 $rsp->{error}->[0] = "$node: Missing the 'netboot' attribute.";
                 $rsp->{errorcode}->[0] = 1;
                 xCAT::MsgUtils->message("E", $rsp, $callback);
@@ -229,7 +226,6 @@ sub rinstall {
             }
 
             unless (defined($nodetypeattribs) and defined($nodetypeattribs->{'arch'})) {
-                my $rsp = {};
                 $rsp->{error}->[0] = "$node: 'arch' attribute not defined in 'nodetype' table.";
                 $rsp->{errorcode}->[0] = 1;
                 xCAT::MsgUtils->message("E", $rsp, $callback);
@@ -238,7 +234,6 @@ sub rinstall {
             my $nodetypearch = $nodetypeattribs->{'arch'};
             if ($nodetypearch ne $osimagearch) {
 	        unless(($nodetypearch =~ /^ppc64(le|el)?$/i) and ($osimagearch =~ /^ppc64(le|el)?$/i)){
-                    my $rsp = {};
                     $rsp->{error}->[0] = "$node: The value of 'arch' attribute of node does not match the 'osarch' attribute of osimage.";
                     $rsp->{errorcode}->[0] = 1;
                     xCAT::MsgUtils->message("E", $rsp, $callback);
@@ -247,7 +242,6 @@ sub rinstall {
             }
 
             unless (defined($nodehmattribs) and defined($nodehmattribs->{'mgt'})) {
-                my $rsp = {};
                 $rsp->{error}->[0] = "$node: 'mgt' attribute not defined in 'nodehm' table.";
                 $rsp->{errorcode}->[0] = 1;
                 xCAT::MsgUtils->message("E", $rsp, $callback);
@@ -259,20 +253,14 @@ sub rinstall {
         #only provision the normal nodes
         @nodes = @validnodes;
 
-        if ($RESTSTATES) {
-            push @parameter, "osimage=$OSIMAGE,$RESTSTATES";
-        } else {
-            push @parameter, "osimage=$OSIMAGE";
-        }
+        push @parameter, "osimage=$OSIMAGE";
+
         if ($ignorekernelchk) {
             push @parameter, " --ignorekernelchk";
         }
     }
     elsif ($STATES) {
         push @parameter, "$STATES";
-        if ($RESTSTATES) {
-            $parameter[-1] .= ",$RESTSTATES";
-        }
     }
     else {
 
@@ -291,7 +279,6 @@ sub rinstall {
             unless ($nodetypecache) { next; }
             my $nodetypeattribs = $nodetypecache->{$node}->[0];
             unless (defined($nodetypeattribs) and defined($nodetypeattribs->{'provmethod'})) {
-                my $rsp = {};
                 $rsp->{error}->[0] = "$node: 'provmethod' attribute not defined in 'nodetype' table.";
                 $rsp->{errorcode}->[0] = 1;
                 xCAT::MsgUtils->message("E", $rsp, $callback);
@@ -326,20 +313,15 @@ sub rinstall {
         #only provision the normal nodes
         @nodes = @validnodes;
         push @parameter, "osimage";
-        if ($RESTSTATES) {
-            $parameter[-1] .= ",$RESTSTATES";
-        }
     }
 
     if (scalar(@nodes) == 0) {
-        my $rsp = {};
         $rsp->{error}->[0]     = "No available nodes for provision.";
         $rsp->{errorcode}->[0] = 1;
         xCAT::MsgUtils->message("E", $rsp, $callback);
         return 1;
     }
     else {
-        my $rsp = {};
         $rsp->{data}->[0] = "Provision node(s): @nodes";
         xCAT::MsgUtils->message("I", $rsp, $callback);
     }
@@ -390,7 +372,6 @@ sub rinstall {
             delete $nodes{$node};
         }
 
-        my $rsp = {};
         if (0+@failurenodes > 0) { 
             $rsp->{error}->[0] = "Failed to run 'nodeset' against the following nodes: @failurenodes";
             $rsp->{errorcode}->[0] = 1;
@@ -412,7 +393,6 @@ sub rinstall {
         $::RUNCMD_RC = 0;
         my @nodes = @{ $hmhash{$hmkey} };
         unless ($hmkey =~ /^(ipmi|blade|hmc|ivm|fsp|kvm|esx|rhevm|openbmc)$/)  {
-            my $rsp = {};
             $rsp->{error}->[0] = "@nodes: rinstall only support nodehm.mgt type 'ipmi', 'blade', 'hmc', 'ivm', 'fsp', 'kvm', 'esx', 'rhevm'.";
             $rsp->{errorcode}->[0] = 1;
             xCAT::MsgUtils->message("E", $rsp, $callback);
@@ -431,7 +411,6 @@ sub rinstall {
                 $subreq, -1, 1);
 
             $rc = $::RUNCMD_RC;
-            my $rsp = {};
             if ($VERBOSE) {
                 my @cmd = "Run command: rnetboot @nodes";
                 push @{ $rsp->{data} }, @cmd;
@@ -459,7 +438,6 @@ sub rinstall {
                         push @failurenodes, $node;
                     }
                 }
-                my $rsp = {};
                 if (0+@failurenodes > 0) { 
                     $rsp->{error}->[0] = "Failed to run 'rnetboot' against the following nodes: @failurenodes";
                     $rsp->{errorcode}->[0] = 1;
@@ -554,7 +532,6 @@ sub rinstall {
                 $subreq, -1, 1);
 
             $rc = $::RUNCMD_RC;
-            my $rsp = {};
             if ($VERBOSE) {
                 my @cmd = "Run command: rpower @nodes @rpowerarg";
                 push @{ $rsp->{data} }, @cmd;
@@ -607,9 +584,10 @@ sub usage {
     my $callback = shift;
     my $rsp      = {};
     $rsp->{data}->[0] = "Usage:";
-    $rsp->{data}->[1] = "   $command <noderange> [boot | shell | runcmd=bmcsetup] [runimage=<task>] [-c|--console] [-u|--uefimode] [-V|--verbose]";
-    $rsp->{data}->[2] = "   $command <noderange> [osimage=<imagename> | <imagename>] [--ignorekernelchk] [-c|--console] [-u|--uefimode] [-V|--verbose]";
-    $rsp->{data}->[3] = "   $command [-h|--help|-v|--version]";
+    $rsp->{data}->[1] = "   $command <noderange> [boot | shell | runcmd=bmcsetup] [-c|--console] [-u|--uefimode] [-V|--verbose]";
+    $rsp->{data}->[2] = "   $command <noderange> osimage[=<imagename>] [--ignorekernelchk] [-c|--console] [-u|--uefimode] [-V|--verbose]";
+    $rsp->{data}->[3] = "   $command <noderange> runimage=<task>";
+    $rsp->{data}->[4] = "   $command [-h|--help|-v|--version]";
     xCAT::MsgUtils->message("I", $rsp, $callback);
 }
 


### PR DESCRIPTION
#5427 

Fixing usage, manpage, and options/flags processing for `rinstall` command.

```
[root@boston01 xcat]# rinstall mid21tor24cn07 abc
Error: [boston01]: Invalid option abc
Usage:
   rinstall <noderange> [boot | shell | runcmd=bmcsetup] [-c|--console] [-u|--uefimode] [-V|--verbose]
   rinstall <noderange> osimage[=<imagename>] [--ignorekernelchk] [-c|--console] [-u|--uefimode] [-V|--verbose]
   rinstall <noderange> runimage=<task>
   rinstall [-h|--help|-v|--version]
[root@boston01 xcat]#
```

```
[root@boston01 xcat]# rinstall mid21tor24cn07 osimage=abc
Error: [boston01]: Cannot find the OS image abc in the osimage table.
[root@boston01 xcat]#
```

```
[root@boston01 xcat]# rinstall mid21tor24cn07 osimage=xcat.redhat-alt.full.install -V
[boston01]: Provision node(s): mid21tor24cn07
[boston01]: Run command: nodeset mid21tor24cn07 osimage=xcat.redhat-alt.full.install
:
:
```

```
[root@boston01 xcat]# rinstall mid21tor24cn07 osimage -V
[boston01]: Provision node(s): mid21tor24cn07
[boston01]: Run command: nodeset mid21tor24cn07 osimage
:
:
```

```
[root@boston01 xcat]# rinstall mid21tor24cn07 -V
[boston01]: Provision node(s): mid21tor24cn07
[boston01]: Run command: nodeset mid21tor24cn07 osimage
:
:
```

```
[root@boston01 xcat]# rinstall mid21tor24cn07 xyz=abc
Error: [boston01]: Invalid option xyz=abc
Usage:
   rinstall <noderange> [boot | shell | runcmd=bmcsetup] [-c|--console] [-u|--uefimode] [-V|--verbose]
   rinstall <noderange> osimage[=<imagename>] [--ignorekernelchk] [-c|--console] [-u|--uefimode] [-V|--verbose]
   rinstall <noderange> runimage=<task>
   rinstall [-h|--help|-v|--version]
[root@boston01 xcat]#
```

```
[root@boston01 xcat]# rinstall mid21tor24cn07 runcmd=abc
Error: [boston01]: Invalid option runcmd=abc
Usage:
   rinstall <noderange> [boot | shell | runcmd=bmcsetup] [-c|--console] [-u|--uefimode] [-V|--verbose]
   rinstall <noderange> osimage[=<imagename>] [--ignorekernelchk] [-c|--console] [-u|--uefimode] [-V|--verbose]
   rinstall <noderange> runimage=<task>
   rinstall [-h|--help|-v|--version]
[root@boston01 xcat]#
```

```
[root@boston01 xcat]# rinstall mid21tor24cn07 runcmd=bmcsetup -V
[boston01]: Provision node(s): mid21tor24cn07
[boston01]: Run command: nodeset mid21tor24cn07 runcmd=bmcsetup
:
:
```