### PR TITLE
Return and log error message  if run by non-root users for config switch commands

### DIFF
--- a/xCAT-server/share/xcat/scripts/configBNT
+++ b/xCAT-server/share/xcat/scripts/configBNT
@@ -67,6 +67,13 @@ if ($::HELP)
     exit(0);
 }
 
+my $current_usr = getpwuid($>);
+if ($current_usr ne "root")
+{
+    print "Can't run this command for non-root user\n";
+    exit(1);
+}
+
 my $switchestab;
 my $switchhash;
 my $passwdtab;

--- a/xCAT-server/share/xcat/scripts/configMellanox
+++ b/xCAT-server/share/xcat/scripts/configMellanox
@@ -62,6 +62,13 @@ if ($::HELP)
     exit(0);
 }
 
+my $current_usr = getpwuid($>);
+if ($current_usr ne "root")
+{
+    print "Can't run this command for non-root user\n";
+    exit(1);
+}
+
 if ($::SWITCH)
 {
     my @filternodes = xCAT::NodeRange::noderange( $::SWITCH );

--- a/xCAT-server/share/xcat/scripts/configonie
+++ b/xCAT-server/share/xcat/scripts/configonie
@@ -61,6 +61,13 @@ if ($::HELP)
     exit(0);
 }
 
+my $current_usr = getpwuid($>);
+if ($current_usr ne "root")
+{
+    print "Can't run this command for non-root user\n";
+    exit(1);
+}
+
 if ($::SWITCH) {
     my @filternodes = xCAT::NodeRange::noderange( $::SWITCH );
     if (nodesmissed) {


### PR DESCRIPTION
for issue #5411
the three config switch command : configonie, configBNT and configMellanox , needs to access xCAT DB to get valid information.  non-root user will hit DB error:
````
[cxhong@briggs01 ~]$ /opt/xcat/share/xcat/scripts/configBNT --switches mid05tor26 --all
Failed to connect to site table after retrying 3 times: DBI connect('/etc/xcat/site.sqlite','',...) failed: unable to open database file at /opt/xcat/lib/perl/xCAT/Table.pm line 972.

Can't call method "prepare" on an undefined value at /opt/xcat/lib/perl/xCAT/Table.pm line 998.
````
For this PR, we will log the error message and exit the command if ran by non-root users:
````
]$ /opt/xcat/share/xcat/scripts/configonie --switches mid05tor26 --ntp
Can't run this command for non-root user
`````
