### PR TITLE
makedhcp check if mac format is valid

### DIFF
--- a/xCAT-server/lib/xcat/plugins/dhcp.pm
+++ b/xCAT-server/lib/xcat/plugins/dhcp.pm
@@ -587,6 +587,7 @@ sub addnode
         );
         return;
     }
+    
     my @macs = split(/\|/, $ent->{mac});
     my $mace;
     my $deflstaments = $lstatements;
@@ -603,6 +604,16 @@ sub addnode
             $hname = $node;
         }                                #Default to hostname equal to nodename
         unless ($mac) { next; }          #Skip corrupt format
+        if ($mac !~ /^[0-9a-fA-F]{2}(-[0-9a-fA-F]{2}){5}$|^[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}$/)
+        {
+            $callback->(
+                {
+                    error => ["Invalid mac address $mac for $node"],
+                    errorcode => [1]
+                }
+            );
+            next;
+        }
         my $ip = getipaddr($hname, OnlyV4 => 1);
         if ($hname eq '*NOIP*') {
             $hname = $node . "-noip" . $mac;

--- a/xCAT-test/autotest/testcase/makedhcp/cases0
+++ b/xCAT-test/autotest/testcase/makedhcp/cases0
@@ -66,6 +66,19 @@ cmd:rmdef testnode1
 cmd:if [ -f "/etc/dhcp/dhcpd.conf" ];then mv -f /etc/dhcp/dhcpd.conf /etc/dhcp/dhcpd.conf.bak ; elif [ -f "/etc/dhcpd.conf" ]; then mv -f /etc/dhcpd.conf /etc/dhcpd.conf.bak; fi
 end
 
+start:makedhcp_a_linux_check_invalid_mac
+description:Define all nodes to the DHCP server. If mac format is invalid, makedhcp -a print error and return 1
+os:Linux
+label:mn_only,dhcp
+cmd:lsdef -l $$CN -z > /tmp/$$CN.stanza
+cmd:chdef -t node -o $$CN mac=11:22:33
+cmd:makedhcp $$CN
+check:rc!=0
+check:output!~ ^11:22:33$
+cmd:chdef -t node -o $$CN mac=
+cmd:cat /tmp/$$CN.stanza | chdef -z
+end
+
 start:makedhcp_a_d_linux
 os:Linux
 label:mn_only,dhcp


### PR DESCRIPTION
For https://github.com/xcat2/xcat-core/issues/4014

Fix issue and add one testcase

All autotest DHCP testcases are passed, UT:
```
[root@bybc0602 xCAT_plugin]# chdef tz998 arch=ppc64le cons=bmc groups=all ip=10.252.9.98 mac=fo:ba:ba:qu:xy mgt=ipmi netboot=petitboot
1 object definitions have been created or modified.
New object definitions 'tz998' have been created.
[root@bybc0602 xCAT_plugin]# makehosts tz998
[root@bybc0602 xCAT_plugin]# makedhcp tz998
Error: [bybc0602]: Invalid mac address fo:ba:ba:qu:xy for tz998
[root@bybc0602 xCAT_plugin]# echo $?
1
[root@bybc0602 xCAT_plugin]# makedhcp -a
Warning: [bybc0602]: The hostname node000111 of node node000111 could not be resolved.
Warning: [bybc0602]: The hostname node000111 of node node000111 could not be resolved.
Error: [bybc0602]: Invalid mac address fo:ba:ba:qu:xy for tz998
[root@bybc0602 xCAT_plugin]# echo $?
1
[root@bybc0602 xCAT_plugin]# grep "fo:ba:ba:qu:xy" /var/lib/dhcpd/dhcpd.leases
[root@bybc0602 xCAT_plugin]# echo $?
1

[root@bybc0602 autotest]# grep END /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20180727005234
END::makedhcp_n::Passed::Time:Fri Jul 27 00:52:56 2018 ::Duration::20 sec
END::makedhcp_h::Passed::Time:Fri Jul 27 00:52:56 2018 ::Duration::0 sec
END::makedhcp_help::Passed::Time:Fri Jul 27 00:52:57 2018 ::Duration::1 sec
END::makedhcp_n_linux::Passed::Time:Fri Jul 27 00:52:57 2018 ::Duration::0 sec
END::makedhcp_a_linux::Passed::Time:Fri Jul 27 00:53:02 2018 ::Duration::5 sec
END::makedhcp_a_linux_check_invalid_mac::Passed::Time:Fri Jul 27 00:53:05 2018 ::Duration::3 sec
END::makedhcp_a_d_linux::Passed::Time:Fri Jul 27 00:53:14 2018 ::Duration::9 sec
END::makedhcp_d_linux::Passed::Time:Fri Jul 27 00:53:19 2018 ::Duration::5 sec
END::makedhcp_a::Passed::Time:Fri Jul 27 00:53:22 2018 ::Duration::3 sec
END::makedhcp_a_d::Passed::Time:Fri Jul 27 00:53:26 2018 ::Duration::4 sec
END::makedhcp_d::Passed::Time:Fri Jul 27 00:53:29 2018 ::Duration::3 sec
END::makedhcp_remote_network::Passed::Time:Fri Jul 27 00:53:33 2018 ::Duration::4 sec
```