### PR TITLE
Use File::Temp::tmpnam() instead of POSIX::tmpnam()

### DIFF
--- a/perl-xCAT/xCAT/DSHCLI.pm
+++ b/perl-xCAT/xCAT/DSHCLI.pm
@@ -14,6 +14,7 @@ use File::Basename;
 use locale;
 use strict;
 use File::Path;
+use File::Temp;
 use POSIX;
 use Socket;
 use Getopt::Long;
@@ -1229,7 +1230,7 @@ sub fork_fanout_dsh
                 $rsp->{data}->[0] = "TRACE: Environment option specified";
                 $dsh_trace && (xCAT::MsgUtils->message("I", $rsp, $::CALLBACK));
                 my %env_rcp_config = ();
-                $tmp_env_file = POSIX::tmpnam . '.dsh';
+                $tmp_env_file = File::Temp::tmpnam . '.dsh';
                 $rsh_config{'command'} .= ". $tmp_env_file ; ";
 
                 $env_rcp_config{'src-file'}  = $$options{'environment'};
@@ -1280,7 +1281,7 @@ sub fork_fanout_dsh
                 $dsh_trace && (xCAT::MsgUtils->message("I", $rsp, $::CALLBACK));
 
                 my %exe_rcp_config = ();
-                $tmp_cmd_file = POSIX::tmpnam . ".dsh";
+                $tmp_cmd_file = File::Temp::tmpnam . ".dsh";
 
                 my ($exe_cmd, @args) = @{ $$options{'execute'} };
                 my $chmod_cmd = "";


### PR DESCRIPTION
Fix github issue #5381.

Based on POSIX.1-2008 [1], `POSIX::tmpnam` was obsoleted. And in Perl 5.26, it was removed [2].

* [1] http://pubs.opengroup.org/onlinepubs/9699919799/
> Applications should use the `tmpfile()`, `mkstemp()`, or `mkdtemp()` functions instead of the obsolescent `tmpnam()` function.
* [2] https://perldoc.perl.org/perl5260delta.html#POSIX%3a%3atmpnam()-has-been-removed
> The fundamentally unsafe `tmpnam()` interface was deprecated in Perl 5.22 and has now been removed. In its place, you can use, for example, the `File::Temp` interfaces.