### PR TITLE
enhance lsdef Noderange format error

### DIFF
--- a/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
+++ b/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
@@ -768,7 +768,6 @@ sub processArgs
                     eval { /$a/ };
                     if ($@)
                     {
-                        print Dumper($@);
                         my $rsp = {};
                         $rsp->{data}->[0] = "Invalid regular expression $a, check the noderange syntax.";
                         xCAT::MsgUtils->message("E", $rsp, $::callback);

--- a/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
+++ b/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
@@ -765,6 +765,15 @@ sub processArgs
                 #    then set noderange
                 if (($::command ne 'mkdef') && ($a =~ m/^\//))
                 {
+                    eval { /$a/ };
+                    if ($@)
+                    {
+                        print Dumper($@);
+                        my $rsp = {};
+                        $rsp->{data}->[0] = "Invalid regular expression $a, check the noderange syntax.";
+                        xCAT::MsgUtils->message("E", $rsp, $::callback);
+                        return 3;
+                    }
                     @::noderange = &noderange($a, 1); # Use the "verify" option to support regular expression
                 }
                 else


### PR DESCRIPTION
fix https://github.com/xcat2/xcat-core/issues/2707

"/a01n[01-09].*" is not right regular expression since it contains ``1-0``.
The error displayed looks very confusing, catch invalid Perl regular expression like that and display a better error message.

UT:
1. commands UT:
```
[root@bybc0602 xCAT_plugin]# lsdef /a01n[01-09].* -i ip -c
Error: [bybc0602]: Invalid regular expression /a01n[01-09].*, check the noderange syntax.

[root@bybc0602 xCAT_plugin]# lsdef /a01n[01-9].* -i ip -c
a01n01: ip=50.1.1.01
a01n02: ip=50.1.1.02
a01n03: ip=50.1.1.03
a01n04: ip=50.1.1.04
a01n05: ip=50.1.1.05
a01n06: ip=50.1.1.06
a01n07: ip=50.1.1.07
a01n08: ip=50.1.1.08
a01n09: ip=50.1.1.09
a01n10: ip=50.1.1.10

[root@bybc0602 xCAT_plugin]# lsdef a01n[01-10] -i ip -c
a01n01: ip=50.1.1.01
a01n02: ip=50.1.1.02
a01n03: ip=50.1.1.03
a01n04: ip=50.1.1.04
a01n05: ip=50.1.1.05
a01n06: ip=50.1.1.06
a01n07: ip=50.1.1.07
a01n08: ip=50.1.1.08
a01n09: ip=50.1.1.09
a01n10: ip=50.1.1.10

[root@bybc0602 xCAT_plugin]# lsdef a01n[01-09] -i ip -c
a01n01: ip=50.1.1.01
a01n02: ip=50.1.1.02
a01n03: ip=50.1.1.03
a01n04: ip=50.1.1.04
a01n05: ip=50.1.1.05
a01n06: ip=50.1.1.06
a01n07: ip=50.1.1.07
a01n08: ip=50.1.1.08
a01n09: ip=50.1.1.09
```

2. ``lsdef`` autotest UT:
 ```
[root@bybc0602 autotest]# grep END /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20180727043339
END::lsdef_null::Passed::Time:Fri Jul 27 04:33:42 2018 ::Duration::1 sec
END::lsdef_a::Passed::Time:Fri Jul 27 04:33:46 2018 ::Duration::4 sec
END::lsdef_t_o_l::Passed::Time:Fri Jul 27 04:33:49 2018 ::Duration::3 sec
END::lsdef_t_o_l_z::Passed::Time:Fri Jul 27 04:33:52 2018 ::Duration::3 sec
END::lsdef_t::Passed::Time:Fri Jul 27 04:33:54 2018 ::Duration::2 sec
END::lsdef_t_i_o::Passed::Time:Fri Jul 27 04:33:57 2018 ::Duration::3 sec
END::lsdef_t_w::Passed::Time:Fri Jul 27 04:34:02 2018 ::Duration::5 sec
END::lsdef_s::Passed::Time:Fri Jul 27 04:34:03 2018 ::Duration::1 sec
END::lsdef_t_auditlog::Passed::Time:Fri Jul 27 04:34:04 2018 ::Duration::1 sec
END::lsdef_t_eventlog::Passed::Time:Fri Jul 27 04:34:05 2018 ::Duration::1 sec
END::lsdef_t_policy::Passed::Time:Fri Jul 27 04:34:05 2018 ::Duration::0 sec
END::lsdef_t_site::Passed::Time:Fri Jul 27 04:34:06 2018 ::Duration::1 sec
END::lsdef_t_err::Passed::Time:Fri Jul 27 04:34:07 2018 ::Duration::1 sec
END::lsdef_t_h_i::Passed::Time:Fri Jul 27 04:34:07 2018 ::Duration::0 sec
END::lsdef_nics::Passed::Time:Fri Jul 27 04:34:09 2018 ::Duration::2 sec
END::lsdef_template::Passed::Time:Fri Jul 27 04:34:10 2018 ::Duration::1 sec
END::lsdef_template_switch_template::Passed::Time:Fri Jul 27 04:34:10 2018 ::Duration::0 sec
END::lsdef_template_with_invalid_name::Passed::Time:Fri Jul 27 04:34:11 2018 ::Duration::1 sec
```

3. ``chdef`` autotest UT:
```
[root@bybc0602 autotest]# grep END /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20180727043517
END::chdef_null::Passed::Time:Fri Jul 27 04:35:19 2018 ::Duration::0 sec
END::chdef_t_node::Passed::Time:Fri Jul 27 04:35:23 2018 ::Duration::4 sec
END::chdef_t_network::Passed::Time:Fri Jul 27 04:35:26 2018 ::Duration::3 sec
END::chdef_p::Passed::Time:Fri Jul 27 04:35:28 2018 ::Duration::2 sec
END::chdef_m::Passed::Time:Fri Jul 27 04:35:30 2018 ::Duration::2 sec
END::chdef_z::Passed::Time:Fri Jul 27 04:35:32 2018 ::Duration::2 sec
END::chdef_group::Passed::Time:Fri Jul 27 04:35:38 2018 ::Duration::6 sec
END::chdef_group_p::Passed::Time:Fri Jul 27 04:35:40 2018 ::Duration::2 sec sec
END::chdef_multiple_keys::Passed::Time:Fri Jul 27 04:35:50 2018 ::Duration::3 sec
END::chdef_n::Passed::Time:Fri Jul 27 04:35:53 2018 ::Duration::3 sec
END::chdef_t_o_error::Passed::Time:Fri Jul 27 04:35:53 2018 ::Duration::0 sec
END::chdef_template::Passed::Time:Fri Jul 27 04:35:55 2018 ::Duration::2 sec
END::chdef_site_check::Passed::Time:Fri Jul 27 04:35:57 2018 ::Duration::2 sec
```

4. ``rmdef`` autotest UT:
```
[root@bybc0602 autotest]# grep END /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20180727043642
END::rmdef_null::Passed::Time:Fri Jul 27 04:36:44 2018 ::Duration::0 sec
END::rmdef_t_o_node::Passed::Time:Fri Jul 27 04:36:46 2018 ::Duration::2 sec
END::rmdef_t_node::Passed::Time:Fri Jul 27 04:36:48 2018 ::Duration::2 sec
END::rmdef_node::Passed::Time:Fri Jul 27 04:36:51 2018 ::Duration::3 sec
END::rmdef_t_o_network::Passed::Time:Fri Jul 27 04:36:52 2018 ::Duration::1 sec
END::rmdef_group::Passed::Time:Fri Jul 27 04:36:56 2018 ::Duration::4 sec
END::rmdef_dynamic_group::Passed::Time:Fri Jul 27 04:36:59 2018 ::Duration::3 sec
END::rmdef_t_err::Passed::Time:Fri Jul 27 04:37:00 2018 ::Duration::1 sec
END::rmdef_template::Passed::Time:Fri Jul 27 04:37:01 2018 ::Duration::1 sec
```