### PR TITLE
Use File::Temp::tmpnam() instead of POSIX::tmpnam()

### DIFF
--- a/perl-xCAT/xCAT/PPCrflash.pm
+++ b/perl-xCAT/xCAT/PPCrflash.pm
@@ -12,7 +12,7 @@ use xCAT::Utils;
 use xCAT::TableUtils;
 use Getopt::Long;
 use File::Spec;
-use POSIX qw(tmpnam);
+use File::Temp;
 
 my $packages_dir = ();
 my $activate     = ();
@@ -662,7 +662,7 @@ sub rflash {
     ########################
     # Now build a temporary file containing the stanzas to be run on the HMC
     ###################
-    my $tmp_file = tmpnam();    # the file handle of the stanza
+    my $tmp_file = File::Temp::tmpnam();    # the file handle of the stanza
     ##############################
     # Open the temp file
     ##########################

--- a/xCAT-server/lib/xcat/plugins/xdsh.pm
+++ b/xCAT-server/lib/xcat/plugins/xdsh.pm
@@ -15,6 +15,7 @@ use strict;
 use Storable qw(dclone);
 use File::Basename;
 use File::Path;
+use File::Temp;
 use POSIX;
 require xCAT::Table;
 use Data::Dumper;
@@ -882,7 +883,7 @@ sub process_servicenodes_xdsh
         # build a tmp syncfile with
         # $::dshexecute -> $synfiledir . $::dshexecute
         # $::dshenvfile -> $synfiledir . $::dshenvfile
-        my $tmpsyncfile = POSIX::tmpnam . ".dsh";
+        my $tmpsyncfile = File::Temp::tmpnam . ".dsh";
 
         # if -E option
         my $envfile;


### PR DESCRIPTION
This pull request fix similar issue as github issue #5381. Part of this problem was fixed in pull request #5440.

Based on POSIX.1-2008 [1], `POSIX::tmpnam` was obsoleted. And in Perl 5.26, it was removed [2].

* [1] http://pubs.opengroup.org/onlinepubs/9699919799/
> Applications should use the `tmpfile()`, `mkstemp()`, or `mkdtemp()` functions instead of the obsolescent `tmpnam()` function.
* [2] https://perldoc.perl.org/perl5260delta.html#POSIX%3a%3atmpnam()-has-been-removed
> The fundamentally unsafe `tmpnam()` interface was deprecated in Perl 5.22 and has now been removed. In its place, you can use, for example, the `File::Temp` interfaces.