### PR TITLE
hardeths: avoid duplicate GATEWAY entries in /etc/sysconfig/network

### DIFF
--- a/xCAT/postscripts/hardeths
+++ b/xCAT/postscripts/hardeths
@@ -73,7 +73,9 @@ else
         sed -i "s/HOSTNAME.*/HOSTNAME=`hostname`/" /etc/sysconfig/network
     fi
     if [ ! -z "$defgw" ]; then
-        echo "GATEWAY=$defgw" >> /etc/sysconfig/network
+        grep -qw GATEWAY /etc/sysconfig/network && \
+            sed -i "s/^GATEWAY.*/GATEWAY=$defgw/" /etc/sysconfig/network || \
+            echo "GATEWAY=$defgw" >> /etc/sysconfig/network
     fi
 fi
 

--- a/xCAT/postscripts/hardeths
+++ b/xCAT/postscripts/hardeths
@@ -50,7 +50,7 @@ if [ -f /etc/os-release ] && (cat /etc/os-release |grep -i  '^NAME=[ "]*Cumulus 
     OSVER="cumulus"
 fi
 
-defgw=`ip route | grep default | awk '{print $3}'`
+defgw=`ip route | grep default | awk '{print $3}' | head -n1`
 if ( pmatch $OSVER "ubuntu*" ) || (pmatch $OSVER "cumulus")
 then
     echo `hostname` >/etc/hostname


### PR DESCRIPTION
When `/etc/sysconfig/network` already contains a `GATEWAY=` line, the `hardeths` postscript will add a second `GATEWAY` entry, which could lead to issues.

This patch avoid this, by replacing the `GATEWAY=` line if it already exists in `/etc/sysconfig/network`, or adding it if it doesn't.