### PR TITLE
routeop: inconditionally replace the default gateway

### DIFF
--- a/xCAT/postscripts/routeop
+++ b/xCAT/postscripts/routeop
@@ -258,7 +258,7 @@ replace_persistent_route()
                     echo "Persistent route \"$route\" has been added in $filename."
                 else 
                     # replace it
-                    sed -i -e "s/$routedest1.*/$route1/g" $filename
+                    sed -i -e "s/${routedest1}.*/$route1/g" $filename
                     echo "Persistent route \"$route\" has been replaced in $filename."
                 fi
             else
@@ -300,7 +300,9 @@ replace_persistent_route()
             if [ "$net" = "default" ]; then
                 filename="/etc/sysconfig/network"
                 route="GATEWAY=$gw"
+                route1=$route
                 routedest="GATEWAY="
+                routedest1=$routedest
             fi
             if [ -f $filename ]; then
                 egrep "^$routedest" $filename 2>&1 1>/dev/null
@@ -309,7 +311,7 @@ replace_persistent_route()
                     echo "Persistent route \"$route\" has been added in $filename."
                 else 
                     # replace it
-                    sed -i -e "s/$routedest1.*/$route1/g" $filename
+                    sed -i -e "s/${routedest1}.*/$route1/g" $filename
                     echo "Persistent route \"$route\" has been replaced in $filename."
                 fi
             else

--- a/xCAT/postscripts/routeop
+++ b/xCAT/postscripts/routeop
@@ -300,7 +300,7 @@ replace_persistent_route()
             if [ "$net" = "default" ]; then
                 filename="/etc/sysconfig/network"
                 route="GATEWAY=$gw"
-                routedest="$route"
+                routedest="GATEWAY="
             fi
             if [ -f $filename ]; then
                 egrep "^$routedest" $filename 2>&1 1>/dev/null


### PR DESCRIPTION
When `/etc/sysconfig/network` already contains a `GATEWAY=` line set with a specific destination, the `routeop replace ` command will *only* replace it if the new default gateway is exactly the same, and will end up adding an extra `GATEWAY=` line if it's different.

That's because the `egrep` command on line 306 matches the full gateway line (`GATEWAY=$gw`), instead of just the part that indicates that it's the default route (`GATEWAY=`)
https://github.com/xcat2/xcat-core/blob/738e5c8814398225949760471bb28982cf2627a5/xCAT/postscripts/routeop#L300-L309

This patch makes sure to:
1. _replace_ whatever default gateway is set, and to only _add_ a new entry if non exists in `/etc/sysconfig/network`.
2. replace an existing default route with the actual new value. `$route1` and `$routedest1` are not defined in the default-route case for Redhat.
3. fix a broken `sed` regex where the bash `$routedest1` was fixed up with the following `.*`

It's only been tested on Redhat and doesn't address the SuSE or Debian cases by lack of testing platforms on my end.