### PR TITLE
Stop rinstall processing if runimage is invalid

### DIFF
--- a/xCAT-server/lib/xcat/plugins/destiny.pm
+++ b/xCAT-server/lib/xcat/plugins/destiny.pm
@@ -603,7 +603,7 @@ sub setdestiny {
                     my $cmd = "wget --spider --timeout 3 --tries=1 $path";
                     my @output = xCAT::Utils->runcmd("$cmd", -1);
                     unless (grep /^Remote file exists/, @output) {
-                        $callback->({ error => ["Cannot get $path with wget. Could you confirm it's downloadable by wget?"], errorcode => [1], errorabort => [1]});
+                        $callback->({ error => ["Cannot wget $path. Verify it's downloadable."], errorcode => [1], errorabort => [1]});
                         return;
                     }
                 } else {

--- a/xCAT-server/lib/xcat/plugins/rinstall.pm
+++ b/xCAT-server/lib/xcat/plugins/rinstall.pm
@@ -365,6 +365,14 @@ sub rinstall {
                 xCAT::MsgUtils->message("E", $rsp, $callback);
                 return 1;
             }
+            if ($line =~ /Cannot wget/) {
+                # If nodeset returns error that runimage can not be downloaded by wget, 
+                # display the error from nodeset (if not alredy displayed by VERBOSE above), stop processing and return.
+                unless ($VERBOSE) {
+                    xCAT::MsgUtils->message("I", $rsp, $callback);
+                }
+                return 1;
+            }
             xCAT::MsgUtils->message("I", $rsp, $callback);
         }
 


### PR DESCRIPTION
Currently `rinstall` continues processing if `runimage=xxxx` points to an invalid file.

This PR 
1. Catches the error and stops `rinstall` processing. 
2. Changes the error message to be more compact.
3. Eliminates duplicate messages when `-V` is used

Before PR:
```
[root@boston01 xcat]# rinstall mid21tor24cn07 runimage=abc
Provision node(s): mid21tor24cn07
Cannot get abc with wget. Could you confirm it's downloadable by wget?
mid21tor24cn07: ERROR: timeout
Error: [boston01]: Failed to run 'rsetboot' against the following nodes: mid21tor24cn07
[root@boston01 xcat]#
```

```
[root@boston01 xcat]# rinstall mid21tor24cn07 runimage=abc -V
[boston01]: Provision node(s): mid21tor24cn07
[boston01]: Run command: nodeset mid21tor24cn07 runimage=abc
[boston01]: Cannot get abc with wget. Could you confirm it's downloadable by wget?
[boston01]: Cannot get abc with wget. Could you confirm it's downloadable by wget?
[boston01]: Run command: rsetboot mid21tor24cn07 net
[boston01]: mid21tor24cn07: ERROR: timeout
[boston01]: mid21tor24cn07: ERROR: timeout
Error: [boston01]: Failed to run 'rsetboot' against the following nodes: mid21tor24cn07
[boston01]: Run command: rpower  boot
[root@boston01 xcat]#
```

After:
```
[root@boston01 xcat]# rinstall mid21tor24cn07 runimage=abc
Provision node(s): mid21tor24cn07
Cannot wget abc. Verify it's downloadable.
[root@boston01 xcat]#
```

```
[root@boston01 xcat]# rinstall mid21tor24cn07 runimage=abc -V
[boston01]: Provision node(s): mid21tor24cn07
[boston01]: Run command: nodeset mid21tor24cn07 runimage=abc
[boston01]: Cannot wget abc. Verify it's downloadable.
[root@boston01 xcat]#
```