### PR TITLE
Avoid use command route in configeth, since it is obsoleted

### DIFF
--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -451,9 +451,9 @@ elif [ "$1" = "-s" ];then
                 if [ ! -z "${inst_nic}" ];then
                     str_inst_ip=`ip -4 -o addr|grep -i ${inst_nic} |awk '{print $4}'|awk -F/ '{print $1}'`
                     if [ ! -z "$str_inst_ip" ];then
-                        inst_ip_pre=`ip ro ls|grep -i ${str_inst_ip}|awk '{print $1}'|awk -F/ '{print $1}'`
-                        if [ ! -z "$inst_ip_pre" ];then
-                            str_inst_mask=`route |grep ^${inst_ip_pre}|awk '{print $3}'|head -1`
+                        inst_prefix=`ip ro ls|grep -i ${str_inst_ip}|awk '{print $1}'|awk -F/ '{print $2}'`
+                        if [ ! -z "$inst_prefix" ];then
+                            str_inst_mask=`v4prefix2mask $inst_prefix`
                         fi
                     fi
                 fi
@@ -473,9 +473,9 @@ elif [ "$1" = "-s" ];then
                 if [ ! -z "${inst_nic}" ];then
                     str_inst_ip=`ip -4 -o addr|grep -i ${inst_nic} |awk '{print $4}'|awk -F/ '{print $1}'`
                     if [ ! -z "$str_inst_ip" ];then
-                        inst_ip_pre=`ip ro ls|grep -i ${str_inst_ip}|awk '{print $1}'|awk -F/ '{print $1}'`
-                        if [ ! -z "$inst_ip_pre" ];then
-                            str_inst_mask=`route |grep ^${inst_ip_pre}|awk '{print $3}'|head -1`
+                        inst_prefix=`ip ro ls|grep -i ${str_inst_ip}|awk '{print $1}'|awk -F/ '{print $2}'`
+                        if [ ! -z "$inst_prefix" ];then
+                            str_inst_mask=`v4prefix2mask $inst_prefix`
                         fi
                     fi
                 fi


### PR DESCRIPTION
This solve some `confignetwork` problems on Ubuntu 18.04. Since `confignetwork` calls `configeth`. And in Ubuntu 18.04, command `route` does not exist by default.