### PR TITLE
Revise go_xcat_noinput test case, by install package gpg on Ubuntu compute node

### DIFF
--- a/xCAT-test/autotest/testcase/go-xcat/case1
+++ b/xCAT-test/autotest/testcase/go-xcat/case1
@@ -6,6 +6,8 @@ cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "dpkg -l |grep -i perl-xcat";els
 check:rc!=0
 cmd:if xdsh $$CN "grep \"Red Hat\" /etc/*release >/dev/null"; then xdsh $$CN "yum install -y yum-utils bzip2"; fi
 check:rc==0
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get install -y gpg"; fi
+check:rc==0
 cmd:xdsh $$CN "cd /; rm -rf /go-xcat"
 check:rc==0
 cmd:xdsh $$CN "cd /; scp -r $$MN:/opt/xcat/share/xcat/tools/go-xcat ./"


### PR DESCRIPTION
This pull request fix the go_xcat_noinput test case problem on Ubuntu 18.04.