### PR TITLE
Allow any command for runcmd= option

### DIFF
--- a/docs/source/guides/admin-guides/references/man8/nodeset.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/nodeset.8.rst
@@ -115,7 +115,7 @@ A user can supply their own scripts to be run on the mn or on the service node (
 
 \ **runcmd=**\ \ *command*\ 
  
- This instructs the node to boot to the xCAT genesis environment and specified command to be executed.  This causes the IP, netmask, gateway, username, and password to be programmed according to the configuration in node object definition.
+ This instructs the node to boot to the xCAT genesis environment and specified command to be executed.
  
 
 
@@ -198,7 +198,7 @@ root directory and the TFTP xCAT  subdirectory.   /tftpboot  and
  
 
 
-3. Boot node1 into genesis environment and execute bmcsetup script.
+3. Boot node1 into xCAT genesis environment and execute bmcsetup script. This causes the IP, netmask, gateway, username, and password to be programmed according to the configuration in node object definition.
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man8/nodeset.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/nodeset.8.rst
@@ -19,7 +19,7 @@ Name
 ****************
 
 
-\ **nodeset**\  \ *noderange*\  [\ **boot**\  | \ **stat**\  [\ **-a**\ ]| \ **offline**\  | \ **runcmd=bmcsetup**\  | \ **osimage**\ [=\ *imagename*\ ] | \ **shell**\  | \ **shutdown**\ ] [\ **-V | -**\ **-verbose**\ ]
+\ **nodeset**\  \ *noderange*\  [\ **boot**\  | \ **stat**\  [\ **-a**\ ]| \ **offline**\  | \ **runcmd=**\ \ *command*\  | \ **osimage**\ [=\ *imagename*\ ] | \ **shell**\  | \ **shutdown**\ ] [\ **-V | -**\ **-verbose**\ ]
 
 \ **nodeset**\  \ *noderange*\  \ **osimage**\ [=\ *imagename*\ ] [\ **-**\ **-noupdateinitrd**\ ] [\ **-**\ **-ignorekernelchk**\ ]
 
@@ -113,10 +113,9 @@ A user can supply their own scripts to be run on the mn or on the service node (
  
 
 
-\ **runcmd=bmcsetup**\ 
+\ **runcmd=**\ \ *command*\ 
  
- This instructs the node to boot to the xCAT nbfs environment and proceed to configure BMC
- for basic remote access.  This causes the IP, netmask, gateway, username, and password to be programmed according to the configuration table.
+ This instructs the node to boot to the xCAT genesis environment and specified command to be executed.  This causes the IP, netmask, gateway, username, and password to be programmed according to the configuration in node object definition.
  
 
 
@@ -195,6 +194,16 @@ root directory and the TFTP xCAT  subdirectory.   /tftpboot  and
  .. code-block:: perl
  
    nodeset $node runimage=http://$MASTER/image.tgz
+ 
+ 
+
+
+3. Boot node1 into genesis environment and execute bmcsetup script.
+ 
+ 
+ .. code-block:: perl
+ 
+   rinstall node1 runcmd=bmcsetup
  
  
 

--- a/docs/source/guides/admin-guides/references/man8/rinstall.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/rinstall.8.rst
@@ -72,7 +72,7 @@ If \ **-c**\  is specified, it will then run \ **rcons**\  on the node. This is 
 
 \ **runcmd=**\ \ *command*\ 
  
- This instructs the node to boot to the xCAT genesis environment and specified command to be executed.  This causes the IP, netmask, gateway, username, and password to be programmed according to the configuration in node object definition.
+ This instructs the node to boot to the xCAT genesis environment and specified command to be executed.
  
 
 
@@ -150,7 +150,7 @@ If \ **-c**\  is specified, it will then run \ **rcons**\  on the node. This is 
  
 
 
-4. Boot node1 into genesis environment and execute bmcsetup script.
+4. Boot node1 into xCAT genesis environment and execute bmcsetup script. This causes the IP, netmask, gateway, username, and password to be programmed according to the configuration in node object definition.
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man8/rinstall.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/rinstall.8.rst
@@ -19,7 +19,7 @@ Name
 ****************
 
 
-\ **rinstall**\  \ *noderange*\  [\ **boot**\  | \ **shell**\  | \ **runcmd=bmcsetup**\ ] [\ **-c | -**\ **-console**\ ] [\ **-V | -**\ **-verbose**\ ]
+\ **rinstall**\  \ *noderange*\  [\ **boot**\  | \ **shell**\  | \ **runcmd=**\ \ *command*\ ] [\ **-c | -**\ **-console**\ ] [\ **-V | -**\ **-verbose**\ ]
 
 \ **rinstall**\  \ *noderange*\  \ **osimage**\ [=\ *imagename*\ ] [\ **-**\ **-ignorekernelchk**\ ] [\ **-c | -**\ **-console**\ ] [\ **-u | -**\ **-uefimode**\ ] [\ **-V | -**\ **-verbose**\ ]
 
@@ -70,9 +70,9 @@ If \ **-c**\  is specified, it will then run \ **rcons**\  on the node. This is 
  
 
 
-\ **runcmd=bmcsetup**\ 
+\ **runcmd=**\ \ *command*\ 
  
- This instructs the node to boot to the xCAT nbfs environment and proceed to configure BMC for basic remote access.  This causes the IP, netmask, gateway, username, and password to be programmed according to the configuration table.
+ This instructs the node to boot to the xCAT genesis environment and specified command to be executed.  This causes the IP, netmask, gateway, username, and password to be programmed according to the configuration in node object definition.
  
 
 
@@ -146,6 +146,16 @@ If \ **-c**\  is specified, it will then run \ **rcons**\  on the node. This is 
  .. code-block:: perl
  
    rinstall node1 -c
+ 
+ 
+
+
+4. Boot node1 into genesis environment and execute bmcsetup script.
+ 
+ 
+ .. code-block:: perl
+ 
+   rinstall node1 runcmd=bmcsetup
  
  
 

--- a/xCAT-client/pods/man8/nodeset.8.pod
+++ b/xCAT-client/pods/man8/nodeset.8.pod
@@ -80,7 +80,7 @@ Display the current boot loader config file description for the nodes requested.
 
 =item B<runcmd=>I<command>
 
-This instructs the node to boot to the xCAT genesis environment and specified command to be executed.  This causes the IP, netmask, gateway, username, and password to be programmed according to the configuration in node object definition.
+This instructs the node to boot to the xCAT genesis environment and specified command to be executed.
 
 =item B<shell>
 
@@ -138,7 +138,7 @@ To run http://$master/image.tgz  after deployment:
  nodeset $node runimage=http://$MASTER/image.tgz
 
 =item 3.
-Boot node1 into genesis environment and execute bmcsetup script.
+Boot node1 into xCAT genesis environment and execute bmcsetup script. This causes the IP, netmask, gateway, username, and password to be programmed according to the configuration in node object definition.
 
  rinstall node1 runcmd=bmcsetup
 

--- a/xCAT-client/pods/man8/nodeset.8.pod
+++ b/xCAT-client/pods/man8/nodeset.8.pod
@@ -4,7 +4,7 @@ B<nodeset> - set the boot state for a noderange
 
 =head1 B<Synopsis>
 
-B<nodeset> I<noderange> [B<boot> | B<stat> [B<-a>]| B<offline> | B<runcmd=bmcsetup> | B<osimage>[=I<imagename>] | B<shell> | B<shutdown>] [B<-V>|B<--verbose>]
+B<nodeset> I<noderange> [B<boot> | B<stat> [B<-a>]| B<offline> | B<runcmd=>I<command> | B<osimage>[=I<imagename>] | B<shell> | B<shutdown>] [B<-V>|B<--verbose>]
 
 B<nodeset> I<noderange> B<osimage>[=I<imagename>] [B<--noupdateinitrd>] [B<--ignorekernelchk>]
 
@@ -78,10 +78,9 @@ If you would like to run a task after deployment, you can define that task with 
 
 Display the current boot loader config file description for the nodes requested. When B<disjointdhcps> is set, using B<-a> to display them on all available service nodes.
 
-=item B<runcmd=bmcsetup>
+=item B<runcmd=>I<command>
 
-This instructs the node to boot to the xCAT nbfs environment and proceed to configure BMC
-for basic remote access.  This causes the IP, netmask, gateway, username, and password to be programmed according to the configuration table.
+This instructs the node to boot to the xCAT genesis environment and specified command to be executed.  This causes the IP, netmask, gateway, username, and password to be programmed according to the configuration in node object definition.
 
 =item B<shell>
 
@@ -137,6 +136,11 @@ To setup to install mycomputeimage on the compute node group.
 To run http://$master/image.tgz  after deployment:
 
  nodeset $node runimage=http://$MASTER/image.tgz
+
+=item 3.
+Boot node1 into genesis environment and execute bmcsetup script.
+
+ rinstall node1 runcmd=bmcsetup
 
 =back
 

--- a/xCAT-client/pods/man8/rinstall.8.pod
+++ b/xCAT-client/pods/man8/rinstall.8.pod
@@ -4,7 +4,7 @@ B<rinstall> - Begin OS provision on a noderange
 
 =head1 B<Synopsis>
 
-B<rinstall> I<noderange> [B<boot> | B<shell> | B<runcmd=bmcsetup>] [B<-c>|B<--console>] [B<-V>|B<--verbose>]
+B<rinstall> I<noderange> [B<boot> | B<shell> | B<runcmd=>I<command>] [B<-c>|B<--console>] [B<-V>|B<--verbose>]
 
 B<rinstall> I<noderange> B<osimage>[=I<imagename>] [B<--ignorekernelchk>] [B<-c>|B<--console>] [B<-u>|B<--uefimode>] [B<-V>|B<--verbose>]
 
@@ -40,9 +40,9 @@ Skip the kernel version checking when injecting drivers from osimage.driverupdat
 
 If you would like to run a task after deployment, you can define that task with this attribute.    
 
-=item B<runcmd=bmcsetup>
+=item B<runcmd=>I<command>
 
-This instructs the node to boot to the xCAT nbfs environment and proceed to configure BMC for basic remote access.  This causes the IP, netmask, gateway, username, and password to be programmed according to the configuration table.
+This instructs the node to boot to the xCAT genesis environment and specified command to be executed.  This causes the IP, netmask, gateway, username, and password to be programmed according to the configuration in node object definition.
 
 =item B<shell>
 
@@ -90,6 +90,11 @@ Provision nodes 1 through 20 with the osimage rhels6.4-ppc64-netboot-compute.
 Provision node1 and start a console to monitor the process.
 
  rinstall node1 -c
+
+=item 4.
+Boot node1 into genesis environment and execute bmcsetup script.
+
+ rinstall node1 runcmd=bmcsetup
 
 =back 
 

--- a/xCAT-client/pods/man8/rinstall.8.pod
+++ b/xCAT-client/pods/man8/rinstall.8.pod
@@ -42,7 +42,7 @@ If you would like to run a task after deployment, you can define that task with 
 
 =item B<runcmd=>I<command>
 
-This instructs the node to boot to the xCAT genesis environment and specified command to be executed.  This causes the IP, netmask, gateway, username, and password to be programmed according to the configuration in node object definition.
+This instructs the node to boot to the xCAT genesis environment and specified command to be executed.
 
 =item B<shell>
 
@@ -92,7 +92,7 @@ Provision node1 and start a console to monitor the process.
  rinstall node1 -c
 
 =item 4.
-Boot node1 into genesis environment and execute bmcsetup script.
+Boot node1 into xCAT genesis environment and execute bmcsetup script. This causes the IP, netmask, gateway, username, and password to be programmed according to the configuration in node object definition.
 
  rinstall node1 runcmd=bmcsetup
 

--- a/xCAT-server/lib/xcat/plugins/rinstall.pm
+++ b/xCAT-server/lib/xcat/plugins/rinstall.pm
@@ -113,7 +113,7 @@ sub rinstall {
            $OSIMAGE = $1; # osimage was specified
            xCAT::MsgUtils->message("I", $rsp, $callback);
         }
-        elsif ($state =~ /^boot$|^shell$|^osimage$|^runcmd=bmcsetup$|^runimage=/) {
+        elsif ($state =~ /^boot$|^shell$|^osimage$|^runcmd=|^runimage=/) {
            # the rest are valid actions, just pass to nodeset
            $STATES=$state;
         }
@@ -584,7 +584,7 @@ sub usage {
     my $callback = shift;
     my $rsp      = {};
     $rsp->{data}->[0] = "Usage:";
-    $rsp->{data}->[1] = "   $command <noderange> [boot | shell | runcmd=bmcsetup] [-c|--console] [-u|--uefimode] [-V|--verbose]";
+    $rsp->{data}->[1] = "   $command <noderange> [boot | shell | runcmd=<command>] [-c|--console] [-u|--uefimode] [-V|--verbose]";
     $rsp->{data}->[2] = "   $command <noderange> osimage[=<imagename>] [--ignorekernelchk] [-c|--console] [-u|--uefimode] [-V|--verbose]";
     $rsp->{data}->[3] = "   $command <noderange> runimage=<task>";
     $rsp->{data}->[4] = "   $command [-h|--help|-v|--version]";


### PR DESCRIPTION
#5446 

Allow any command specification for `runcmd=` option.
Also, modify usage and man page to show any command can be used.