### PR TITLE
remind incorrect syntax in object name regular expression

### DIFF
--- a/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
+++ b/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
@@ -3922,6 +3922,17 @@ sub defls
             # the object names are passed in through command line
             if ($::objectsfrom_args || $::opt_o || (($type eq 'node') && ($::opt_o || @::noderange)))
             {
+
+                eval { /$obj/ };
+                if ($@)
+                {
+                    print Dumper($@);
+                    my $rsp = {};
+                    $rsp->{data}->[0] = "Invalid \'$obj\' name, check the object named \'$obj\' of type \'$type\' syntax.";
+                    xCAT::MsgUtils->message("E", $rsp, $::callback);
+                    return 3;
+                }
+
                 if (!grep(/^$obj$/, @allobjoftype))
                 {
                     my $rsp;


### PR DESCRIPTION
fix https://github.com/xcat2/xcat-core/issues/5453
If object name contain incorrect syntax regular expression, ``lsdef`` print error and exit
UT:
1. if object name contains incorrect syntax regular expression, ``lsdef`` print error and exit
```
[root@bybc0602 xCAT]# lsdef -t network mgt[[[[
Error: [bybc0602]: Invalid 'mgt[[[[' name, check the object named 'mgt[[[[' of type 'network' syntax.

[root@bybc0602 xCAT]# lsdef -t osimage sles------[
Error: [bybc0602]: Invalid 'sles------[' name, check the object named 'sles------[' of type 'osimage' syntax.

[root@bybc0602 xCAT]# lsdef node[01-;
Error: [bybc0602]: Invalid 'node[01-' name, check the object named 'node[01-' of type 'node' syntax.
```
2. if the object format is correct, but it does not exist, the code logic is the same with that before:
```
[root@bybc0602 xCAT]# lsdef node[1-9]
Error: [bybc0602]: Could not find an object named 'node4' of type 'node'.
Error: [bybc0602]: Could not find an object named 'node5' of type 'node'.
Error: [bybc0602]: Could not find an object named 'node6' of type 'node'.
Error: [bybc0602]: Could not find an object named 'node7' of type 'node'.
Error: [bybc0602]: Could not find an object named 'node8' of type 'node'.
Error: [bybc0602]: Could not find an object named 'node9' of type 'node'.
Object name: node1
    groups=all
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
Object name: node2
    groups=all
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
Object name: node3
    groups=all
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
```
3. correct expression:
```
[root@bybc0602 xCAT]# lsdef -t network mgtnetwork
Object name: mgtnetwork
    gateway=10.0.0.103
    mask=255.0.0.0
    mgtifname=eth0
    mtu=1500
    net=10.0.0.0
[root@bybc0602 xCAT]# lsdef node1-node3
Object name: node1
    groups=all
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
Object name: node2
    groups=all
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
Object name: node3
    groups=all
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
[root@bybc0602 xCAT]#
```