### PR TITLE
Suppress the `index.attr, No such file or directory' error message from openssl

### DIFF
--- a/xCAT-server/share/xcat/scripts/setup-dockerhost-cert.sh
+++ b/xCAT-server/share/xcat/scripts/setup-dockerhost-cert.sh
@@ -49,6 +49,7 @@ if [  -e $XCATDOCKERCADIR/index ]; then
   rm -f $XCATDOCKERCADIR/index*
 fi
 touch $XCATDOCKERCADIR/index
+touch $XCATDOCKERCADIR/index.attr
 
 echo "00" > $XCATDOCKERCADIR/serial
 

--- a/xCAT-server/share/xcat/scripts/setup-xcat-ca.sh
+++ b/xCAT-server/share/xcat/scripts/setup-xcat-ca.sh
@@ -28,6 +28,7 @@ else
 fi
 sed -e "s@##XCATCADIR##@$XCATCADIR@" $XCATROOT/share/xcat/ca/openssl.cnf.tmpl > $XCATCADIR/openssl.cnf
 cp $XCATROOT/share/xcat/ca/Makefile $XCATCADIR/
+touch $XCATCADIR/index.attr
 cd $XCATCADIR
 make init
 #openssl req -nodes -config openssl.cnf -days 7300 -x509 -newkey rsa:2048 -out ca-cert.pem -extensions v3_ca -outform PEM -subj /CN="$CNA"


### PR DESCRIPTION
This pull request solve issue #5386.

Simple create the `index.attr` file, in order to suppress the error message.