### PR TITLE
Avoid use command ifconfig in test case psh_i

### DIFF
--- a/xCAT-test/autotest/testcase/psh/cases0
+++ b/xCAT-test/autotest/testcase/psh/cases0
@@ -49,7 +49,7 @@ description: psh -i interface CN 'uptime' in linux
 os:Linux
 cmd:cp /etc/hosts /etc/hostsBK
 check:rc==0
-cmd:interface=`xdsh $$CN  'ifconfig' | sed -n 1p | awk -F : '{print $2}' | awk -F ' ' '{print $1}'`;sed -i "/$$CN/s/$/ $$CN-$interface/g" '/etc/hosts';psh -i $interface $$CN 'uptime'
+cmd:interface=`xdsh $$CN 'ip route' | awk '/default/ { print $NF }'`;sed -i "/$$CN/s/$/ $$CN-$interface/g" '/etc/hosts';psh -i $interface $$CN 'uptime'
 check:output=~$$CN
 check:rc==0
 cmd:rm -rf /etc/hosts


### PR DESCRIPTION
This patch fix the test case `psh_i` problem on Ubuntu 18.04. Since on Ubuntu 18.04, command `ifconfig` is not installed by default.