### PR TITLE
check BMC state after BMCreboot in rflash -d

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2447,8 +2447,13 @@ sub deal_with_response {
             if ($node_info{$node}{cur_status} eq "RPOWER_RESET_RESPONSE" and defined $status_info{RPOWER_RESET_RESPONSE}{argv} and $status_info{RPOWER_RESET_RESPONSE}{argv} =~ /bmcreboot$/) { 
                 my $infomsg = "BMC $::POWER_STATE_REBOOT";
                 xCAT::SvrUtils::sendmsg($infomsg, $callback, $node);
-                $wait_node_num--;
-                return;    
+                if ($::UPLOAD_ACTIVATE_STREAM) {
+                    retry_after($node, "RPOWER_BMC_CHECK_REQUEST", 15);
+                    return;
+                }else{
+                    $wait_node_num--;
+                    return;
+                }    
             }
             $error = $::RESPONSE_SERVICE_TIMEOUT;
         } else {


### PR DESCRIPTION
for https://github.com/xcat2/xcat-core/issues/5454:
After reboot BMC, BMC need time to be ready.
So after BMC reboots in ``rflash -d``, when current response gets RESPONSE_SERVICE_TIMEOUT, it should waits 15 seconds to retry to check if BMC is ready or not. Using ``f6u13`` to flash ``/mnt/xcat/iso/firmware/op910/910.1746.20171219c_1742Ei `` to do the UT as following:

```
[root@stratton01 xCAT_plugin]# rflash f6u13 -d /mnt/xcat/iso/firmware/op910/910.1746.20171219c_1742Ei -V
Fri Aug  3 02:11:45 2018 OpenBMC: [stratton01]: [openbmc_debug_perl]
[stratton01]: Attempting to upload /mnt/xcat/iso/firmware/op910/910.1746.20171219c_1742Ei/obmc-phosphor-image-witherspoon.ubi.mtd.tar and /mnt/xcat/iso/firmware/op910/910.1746.20171219c_1742Ei/witherspoon.pnor.squashfs.tar, please wait...
[stratton01]: Running command in Perl
Fri Aug  3 02:11:45 2018 f6u13: [stratton01]: [openbmc_debug_perl] curl -k -c cjar -H "Content-Type: application/json" -d '{ "data": ["root", "xxxxxx"] }' https://f6u13-bmc/login
Fri Aug  3 02:11:45 2018 f6u13: [stratton01]: [openbmc_debug_perl] login_response 200 OK
f6u13: [stratton01]: Warning: DD 2.0 processor detected on this node, should not have firmware > ibm-v2.0-0-r13.6 (BMC) and > v1.19_1.94 (Host).
f6u13: [stratton01]: Uploading /mnt/xcat/iso/firmware/op910/910.1746.20171219c_1742Ei/witherspoon.pnor.squashfs.tar ...
Fri Aug  3 02:11:46 2018 f6u13: [stratton01]: [openbmc_debug_perl] RFLASH_FILE_UPLOAD_RESPONSE: CMD: curl -b /tmp/_xcat_cjar.f6u13 -k -H 'Content-Type: application/octet-stream' -X PUT -T /mnt/xcat/iso/firmware/op910/910.1746.20171219c_1742Ei/witherspoon.pnor.squashfs.tar https://f6u13-bmc/upload/image/
f6u13: [stratton01]: Uploading /mnt/xcat/iso/firmware/op910/910.1746.20171219c_1742Ei/obmc-phosphor-image-witherspoon.ubi.mtd.tar ...
Fri Aug  3 02:12:01 2018 f6u13: [stratton01]: [openbmc_debug_perl] RFLASH_FILE_UPLOAD_RESPONSE: CMD: curl -b /tmp/_xcat_cjar.f6u13 -k -H 'Content-Type: application/octet-stream' -X PUT -T /mnt/xcat/iso/firmware/op910/910.1746.20171219c_1742Ei/obmc-phosphor-image-witherspoon.ubi.mtd.tar https://f6u13-bmc/upload/image/
Fri Aug  3 02:12:17 2018 f6u13: [stratton01]: [openbmc_debug_perl] curl -k -b cjar -X GET -H "Content-Type: application/json" https://f6u13-bmc/xyz/openbmc_project/software/enumerate
Fri Aug  3 02:12:18 2018 f6u13: [stratton01]: [openbmc_debug_perl] rflash_update_check_id_response 200 OK
Fri Aug  3 02:12:18 2018 f6u13: [stratton01]: [openbmc_debug_perl] CHECK_ID_RESPONSE: Looking for software ID: ibm-v2.0-0-r13.6-0-g76c2c96 IBM-witherspoon-ibm-OP9_v1.19_1.94...
Fri Aug  3 02:12:18 2018 f6u13: [stratton01]: [openbmc_debug_perl] CHECK_ID_RESPONSE: key_url=/xyz/openbmc_project/software/442e6ec8 version=ibm-v2.0-0-r13.6-0-g76c2c96
f6u13: [stratton01]: Firmware upload successful. Attempting to activate firmware: ibm-v2.0-0-r13.6-0-g76c2c96 (ID: 442e6ec8)
Fri Aug  3 02:12:18 2018 f6u13: [stratton01]: [openbmc_debug_perl] CHECK_ID_RESPONSE: key_url=/xyz/openbmc_project/software/b04fff27 version=ibm-v2.0-0-r46-0-gbed584c
Fri Aug  3 02:12:18 2018 f6u13: [stratton01]: [openbmc_debug_perl] CHECK_ID_RESPONSE: key_url=/xyz/openbmc_project/software/e339c76d version=IBM-witherspoon-ibm-OP9_v1.19_1.189
Fri Aug  3 02:12:18 2018 f6u13: [stratton01]: [openbmc_debug_perl] CHECK_ID_RESPONSE: key_url=/xyz/openbmc_project/software/498bd90d version=IBM-witherspoon-ibm-OP9_v1.19_1.94
f6u13: [stratton01]: Firmware upload successful. Attempting to activate firmware: IBM-witherspoon-ibm-OP9_v1.19_1.94 (ID: 498bd90d)
Fri Aug  3 02:12:18 2018 f6u13: [stratton01]: [openbmc_debug_perl] curl -k -b cjar -X PUT -H "Content-Type: application/json" -d '{"data":"xyz.openbmc_project.Software.Activation.RequestedActivations.Active"}' https://f6u13-bmc/xyz/openbmc_project/software/442e6ec8/attr/RequestedActivation
Fri Aug  3 02:12:19 2018 f6u13: [stratton01]: [openbmc_debug_perl] rflash_update_activate_response 200 OK
f6u13: [stratton01]: rflash ibm-v2.0-0-r13.6-0-g76c2c96 started, please wait...
Fri Aug  3 02:12:19 2018 f6u13: [stratton01]: [openbmc_debug_perl] curl -k -b cjar -X PUT -H "Content-Type: application/json" -d '{"data":"xyz.openbmc_project.Software.Activation.RequestedActivations.Active"}' https://f6u13-bmc/xyz/openbmc_project/software/498bd90d/attr/RequestedActivation
Fri Aug  3 02:12:19 2018 f6u13: [stratton01]: [openbmc_debug_perl] rflash_update_host_activate_response 200 OK
f6u13: [stratton01]: rflash IBM-witherspoon-ibm-OP9_v1.19_1.94 started, please wait...
Fri Aug  3 02:12:19 2018 f6u13: [stratton01]: [openbmc_debug_perl] curl -k -b cjar -X GET -H "Content-Type: application/json" https://f6u13-bmc/xyz/openbmc_project/software/enumerate
Fri Aug  3 02:12:20 2018 f6u13: [stratton01]: [openbmc_debug_perl] rflash_update_check_state_response 200 OK
[stratton01]: f6u13: Firmware IBM-witherspoon-ibm-OP9_v1.19_1.94 activation successful.
[stratton01]: f6u13: Firmware ibm-v2.0-0-r13.6-0-g76c2c96 activation successful.
Fri Aug  3 02:12:20 2018 f6u13: [stratton01]: [openbmc_debug_perl] curl -k -b cjar -X PUT -H "Content-Type: application/json" -d '{"data":"xyz.openbmc_project.State.BMC.Transition.Reboot"}' https://f6u13-bmc/xyz/openbmc_project/state/bmc0/attr/RequestedBMCTransition
Fri Aug  3 02:12:25 2018 f6u13: [stratton01]: [openbmc_debug_perl] rpower_reset_response 200 OK

f6u13: [stratton01]: BMC reboot
Fri Aug  3 02:12:40 2018 f6u13: [stratton01]: [openbmc_debug_perl] curl -k -b cjar -X GET -H "Content-Type: application/json" https://f6u13-bmc/xyz/openbmc_project/state/enumerate
Fri Aug  3 02:12:41 2018 f6u13: [stratton01]: [openbmc_debug_perl] rpower_bmc_status_response 503 Service Unavailable
[stratton01]: f6u13: Retry BMC state, wait for 15 seconds ...
Fri Aug  3 02:12:56 2018 f6u13: [stratton01]: [openbmc_debug_perl] curl -k -b cjar -X GET -H "Content-Type: application/json" https://f6u13-bmc/xyz/openbmc_project/state/enumerate
Fri Aug  3 02:13:56 2018 f6u13: [stratton01]: [openbmc_debug_perl] rpower_bmc_status_response 503 Service Unavailable
[stratton01]: f6u13: Retry BMC state, wait for 15 seconds ...
Fri Aug  3 02:14:11 2018 f6u13: [stratton01]: [openbmc_debug_perl] curl -k -b cjar -X GET -H "Content-Type: application/json" https://f6u13-bmc/xyz/openbmc_project/state/enumerate
Fri Aug  3 02:15:11 2018 f6u13: [stratton01]: [openbmc_debug_perl] rpower_bmc_status_response 503 Service Unavailable
[stratton01]: f6u13: Retry BMC state, wait for 15 seconds ...
Fri Aug  3 02:15:26 2018 f6u13: [stratton01]: [openbmc_debug_perl] curl -k -b cjar -X GET -H "Content-Type: application/json" https://f6u13-bmc/xyz/openbmc_project/state/enumerate
Fri Aug  3 02:15:39 2018 f6u13: [stratton01]: [openbmc_debug_perl] rpower_bmc_status_response 404 Not Found
[stratton01]: f6u13: Retry BMC state, wait for 15 seconds ...
Fri Aug  3 02:15:54 2018 f6u13: [stratton01]: [openbmc_debug_perl] curl -k -c cjar -H "Content-Type: application/json" -d '{ "data": ["root", "xxxxxx"] }' https://f6u13-bmc/login
Fri Aug  3 02:15:56 2018 f6u13: [stratton01]: [openbmc_debug_perl] login_response_general 200 OK
Fri Aug  3 02:15:56 2018 f6u13: [stratton01]: [openbmc_debug_perl] curl -k -b cjar -X GET -H "Content-Type: application/json" https://f6u13-bmc/xyz/openbmc_project/state/enumerate
Fri Aug  3 02:16:01 2018 f6u13: [stratton01]: [openbmc_debug_perl] rpower_bmc_status_response 200 OK
Fri Aug  3 02:16:16 2018 f6u13: [stratton01]: [openbmc_debug_perl] curl -k -b cjar -X GET -H "Content-Type: application/json" https://f6u13-bmc/xyz/openbmc_project/state/enumerate
Fri Aug  3 02:16:26 2018 f6u13: [stratton01]: [openbmc_debug_perl] rpower_bmc_status_response 200 OK
f6u13: [stratton01]: BMC Ready

Fri Aug  3 02:16:26 2018 f6u13: [stratton01]: [openbmc_debug_perl] curl -k -b cjar -X PUT -H "Content-Type: application/json" -d '{"data":"xyz.openbmc_project.State.Chassis.Transition.Off"}' https://f6u13-bmc/xyz/openbmc_project/state/chassis0/attr/RequestedPowerTransition
Fri Aug  3 02:16:30 2018 f6u13: [stratton01]: [openbmc_debug_perl] rpower_off_response 200 OK
Fri Aug  3 02:16:30 2018 f6u13: [stratton01]: [openbmc_debug_perl] curl -k -b cjar -X GET -H "Content-Type: application/json" https://f6u13-bmc/xyz/openbmc_project/state/enumerate
Fri Aug  3 02:16:51 2018 f6u13: [stratton01]: [openbmc_debug_perl] rpower_check_response 200 OK
Fri Aug  3 02:16:53 2018 f6u13: [stratton01]: [openbmc_debug_perl] curl -k -b cjar -X GET -H "Content-Type: application/json" https://f6u13-bmc/xyz/openbmc_project/state/enumerate
Fri Aug  3 02:16:56 2018 f6u13: [stratton01]: [openbmc_debug_perl] rpower_check_response 200 OK
Fri Aug  3 02:16:56 2018 f6u13: [stratton01]: [openbmc_debug_perl] curl -k -b cjar -X PUT -H "Content-Type: application/json" -d '{"data":"xyz.openbmc_project.State.Host.Transition.On"}' https://f6u13-bmc/xyz/openbmc_project/state/host0/attr/RequestedHostTransition
Fri Aug  3 02:16:58 2018 f6u13: [stratton01]: [openbmc_debug_perl] rpower_on_response 200 OK
f6u13: [stratton01]: reset
Fri Aug  3 02:16:58 2018 f6u13: [stratton01]: [openbmc_debug_perl] curl -k -b cjar -X GET -H "Content-Type: application/json" https://f6u13-bmc/xyz/openbmc_project/state/enumerate
Fri Aug  3 02:17:13 2018 f6u13: [stratton01]: [openbmc_debug_perl] rpower_check_on_response 200 OK
Fri Aug  3 02:17:25 2018 f6u13: [stratton01]: [openbmc_debug_perl] curl -k -b cjar -X PUT -H "Content-Type: application/json" -d '{"data":"xyz.openbmc_project.State.Host.Transition.On"}' https://f6u13-bmc/xyz/openbmc_project/state/host0/attr/RequestedHostTransition
Fri Aug  3 02:17:25 2018 f6u13: [stratton01]: [openbmc_debug_perl] rpower_on_response 200 OK
f6u13: [stratton01]: on
Fri Aug  3 02:17:25 2018 f6u13: [stratton01]: [openbmc_debug_perl] curl -k -b cjar -X GET -H "Content-Type: application/json" https://f6u13-bmc/xyz/openbmc_project/state/enumerate
Fri Aug  3 02:17:26 2018 f6u13: [stratton01]: [openbmc_debug_perl] rpower_check_on_response 200 OK


[root@stratton01 xCAT_plugin]# rflash f6u13 -l
Fri Aug  3 02:18:01 2018 OpenBMC: [openbmc_debug_perl]
Fri Aug  3 02:18:01 2018 f6u13: [openbmc_debug_perl] curl -k -c cjar -H "Content-Type: application/json" -d '{ "data": ["root", "xxxxxx"] }' https://f6u13-bmc/login
Fri Aug  3 02:18:02 2018 f6u13: [openbmc_debug_perl] login_response 200 OK
Fri Aug  3 02:18:02 2018 f6u13: [openbmc_debug_perl] curl -k -b cjar -X GET -H "Content-Type: application/json" https://f6u13-bmc/xyz/openbmc_project/software/enumerate
Fri Aug  3 02:18:03 2018 f6u13: [openbmc_debug_perl] rflash_list_response 200 OK
f6u13: ID       Purpose State      Version
f6u13: -------------------------------------------------------
f6u13: 442e6ec8 BMC     Active(*)  ibm-v2.0-0-r13.6-0-g76c2c96
f6u13: b04fff27 BMC     Active     ibm-v2.0-0-r46-0-gbed584c
f6u13: e339c76d Host    Active     IBM-witherspoon-ibm-OP9_v1.19_1.189
f6u13: 498bd90d Host    Active(*)  IBM-witherspoon-ibm-OP9_v1.19_1.94
f6u13:
```