### PR TITLE
specify build pkg dir when build rpm/deb

### DIFF
--- a/build-ubunturepo
+++ b/build-ubunturepo
@@ -26,7 +26,7 @@
 #                            
 #               LOG=<filename> - provide an LOG file option to redirect some output into log file
 #
-#               PKGDIR=<build_pkg_dir> - Copy build core tarball to PKGDIR if defined
+#               BUILDDESTDIR=<build_tarball_dir> - Copy build core tarball to BUILDDESTDIR if defined
 # For the dependency packages 1. All the xcat dependency deb packages should be uploaded to
 #                                "pokgsa/projects/x/xcat/build/ubuntu/xcat-dep/debs/" on GSA
 #                             2. run ./build-ubunturepo -d
@@ -401,13 +401,14 @@ __EOF__
     chgrp root $tar_name
     chmod g+w $tar_name
 
-    if [ "$PKGDIR" ]; then
-        mkdir -p $PKGDIR
-        cp $tar_name $PKGDIR
+    if [ "$BUILDDESTDIR" ]; then
+        rm -rf $BUILDDESTDIR
+        mkdir -p $BUILDDESTDIR
+        cp $tar_name $BUILDDESTDIR
         if [ $? != 0 ]; then
-            echo "Failed to copy $tar_name to $PKGDIR"
+            echo "Failed to copy $tar_name to $BUILDDESTDIR"
         else
-            echo "Copied $tar_name to $PKGDIR"
+            echo "Copied $tar_name to $BUILDDESTDIR"
         fi
     fi
 

--- a/build-ubunturepo
+++ b/build-ubunturepo
@@ -26,6 +26,7 @@
 #                            
 #               LOG=<filename> - provide an LOG file option to redirect some output into log file
 #
+#               PKGDIR=<build_pkg_dir> - Copy build core tarball to PKGDIR if defined
 # For the dependency packages 1. All the xcat dependency deb packages should be uploaded to
 #                                "pokgsa/projects/x/xcat/build/ubuntu/xcat-dep/debs/" on GSA
 #                             2. run ./build-ubunturepo -d
@@ -399,6 +400,16 @@ __EOF__
     tar -hjcf $tar_name xcat-core
     chgrp root $tar_name
     chmod g+w $tar_name
+
+    if [ "$PKGDIR" ]; then
+        mkdir -p $PKGDIR
+        cp $tar_name $PKGDIR
+        if [ $? != 0 ]; then
+            echo "Failed to copy $tar_name to $PKGDIR"
+        else
+            echo "Copied $tar_name to $PKGDIR"
+        fi
+    fi
 
     if [ ! -e core-snap ]; then
         ln -s xcat-core core-snap

--- a/buildcore.sh
+++ b/buildcore.sh
@@ -30,7 +30,7 @@
 #        VERBOSE=1 - to see lots of verbose output
 #        LOG=<filename> - provide an LOG file option to redirect some output into log file
 #        RPMSIGN=0 or RPMSIGN=1 - Sign the RPMs using the keys on GSA, the default is to sign the rpms without RPMSIGN specified
-
+#        PKGDIR=<build_pkg_dir> - Copy build core tarball to PKGDIR if defined
 #
 # The following environment variables can be modified if you need
 #
@@ -568,6 +568,16 @@ else
 fi
 chgrp $SYSGRP $TARNAME
 chmod g+w $TARNAME
+
+if [ "$PKGDIR" ]; then
+    mkdir -p $PKGDIR
+    cp $TARNAME $PKGDIR
+    if [ $? != 0 ]; then
+        echo "Failed to copy $TARNAME to $PKGDIR"
+    else
+        echo "Copied $TARNAME to $PKGDIR"
+    fi
+fi
 
 # Decide whether to upload or not
 if [ -n "$UP" ] && [ "$UP" == 0 ]; then

--- a/buildcore.sh
+++ b/buildcore.sh
@@ -30,7 +30,7 @@
 #        VERBOSE=1 - to see lots of verbose output
 #        LOG=<filename> - provide an LOG file option to redirect some output into log file
 #        RPMSIGN=0 or RPMSIGN=1 - Sign the RPMs using the keys on GSA, the default is to sign the rpms without RPMSIGN specified
-#        PKGDIR=<build_pkg_dir> - Copy build core tarball to PKGDIR if defined
+#        BUILDDESTDIR=<build_tarball_dir> - Copy build core tarball to BUILDDESTDIR if defined
 #
 # The following environment variables can be modified if you need
 #
@@ -569,13 +569,14 @@ fi
 chgrp $SYSGRP $TARNAME
 chmod g+w $TARNAME
 
-if [ "$PKGDIR" ]; then
-    mkdir -p $PKGDIR
-    cp $TARNAME $PKGDIR
+if [ "$BUILDDESTDIR" ]; then
+    rm -rf $BUILDDESTDIR
+    mkdir -p $BUILDDESTDIR
+    cp $TARNAME $BUILDDESTDIR
     if [ $? != 0 ]; then
-        echo "Failed to copy $TARNAME to $PKGDIR"
+        echo "Failed to copy $TARNAME to $BUILDDESTDIR"
     else
-        echo "Copied $TARNAME to $PKGDIR"
+        echo "Copied $TARNAME to $BUILDDESTDIR"
     fi
 fi
 


### PR DESCRIPTION
Add env "BUILDDESTDIR", if not null, will copy core tarball to this folder.