### PR TITLE
Fix minor configeth problem on Ubuntu 18.04

### DIFF
--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -650,7 +650,12 @@ elif [ "$1" = "-s" ];then
     fi
 
     if [ "$UPDATENODE" = "1" ] || grep "REBOOT=TRUE" /opt/xcat/xcatinfo >/dev/null 2>&1; then
-        ifdown $str_inst_nic;ifup $str_inst_nic
+        if [ "$str_os_type" = "debian" ];then
+            ifdown --force $str_inst_nic
+        else
+            ifdown $str_inst_nic
+        fi
+        ifup $str_inst_nic
     fi 
     if [ $? -ne 0 ]; then
         log_error "ifup $str_inst_nic failed."


### PR DESCRIPTION
This pull request fix a minor glitch of `configeth` on Ubuntu 18.04

**Before**
```
# updatenode c910f03c17k04 'configeth -s enp0s1'
c910f03c17k04: vpdupdate is not supported on the pSeries KVM Guest platform
c910f03c17k04: updating VPD database
c910f03c17k04: trying to download postscripts...
c910f03c17k04: postscripts downloaded successfully
c910f03c17k04: trying to get mypostscript from 10.3.17.3...
c910f03c17k04: Running postscript: configeth
c910f03c17k04: #XCAT_CONFIG
c910f03c17k04: [I]: configeth on c910f03c17k04: os type: debian
c910f03c17k04: ifdown: interface enp0s1 not configured
c910f03c17k04: RTNETLINK answers: File exists
c910f03c17k04: Failed to bring up enp0s1.
c910f03c17k04: [E]:Error: ifup enp0s1 failed.
c910f03c17k04: postscript: configeth exited with code 1
c910f03c17k04: Running of postscripts has completed.
```
**After**
```
# updatenode c910f03c17k04 'configeth -s enp0s1'
c910f03c17k04: vpdupdate is not supported on the pSeries KVM Guest platform
c910f03c17k04: updating VPD database
c910f03c17k04: trying to download postscripts...
c910f03c17k04: postscripts downloaded successfully
c910f03c17k04: trying to get mypostscript from 10.3.17.3...
c910f03c17k04: Running postscript: configeth
c910f03c17k04: [I]: configeth on c910f03c17k04: os type: debian
c910f03c17k04: postscript: configeth exited with code 0
c910f03c17k04: Running of postscripts has completed.
```