### PR TITLE
Add more debug information to test case psh_i for issue 5466

### DIFF
--- a/xCAT-test/autotest/testcase/psh/cases0
+++ b/xCAT-test/autotest/testcase/psh/cases0
@@ -49,9 +49,11 @@ description: psh -i interface CN 'uptime' in linux
 os:Linux
 cmd:cp /etc/hosts /etc/hostsBK
 check:rc==0
-cmd:interface=`xdsh $$CN 'ip route' | awk '/default/ { for (i = 1; i <= NF; ++i) if ("dev" == $i) { print $(i + 1) ; exit } }'`;sed -i "/$$CN/s/$/ $$CN-$interface/g" '/etc/hosts';psh -i $interface $$CN 'uptime'
+cmd:grep $$CN /etc/hosts
+cmd:interface=`xdsh $$CN 'ip route' | awk '/default/ { for (i = 1; i <= NF; ++i) if ("dev" == $i) { print $(i + 1) ; exit } }'`; echo "interface=$interface"; sed -i "/$$CN/s/$/ $$CN-$interface/g" '/etc/hosts';psh -i $interface $$CN 'uptime'
 check:output=~$$CN
 check:rc==0
+cmd:grep $$CN /etc/hosts
 cmd:rm -rf /etc/hosts
 cmd:cp /etc/hostsBK /etc/hosts
 check:rc==0


### PR DESCRIPTION
Due to there is strange thing in issue #5466,  add more debug information to test cases ``psh_i``.

The UT are:

```
------START::psh_i::Time:Mon Aug  6 04:14:46 2018------

RUN:cp /etc/hosts /etc/hostsBK [Mon Aug  6 04:14:46 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:grep f6u13k18 /etc/hosts [Mon Aug  6 04:14:46 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
10.6.13.18 f6u13k18 f6u13k18.pok.stglabs.ibm.com

RUN:interface=`xdsh f6u13k18 'ip route' | awk '/default/ { for (i = 1; i <= NF; ++i) if ("dev" == $i) { print $(i + 1) ; exit } }'`; echo "interface=$interface"; sed -i "/f6u13k18/s/$/ f6u13k18-$interface/g" '/etc/hosts';psh -i $interface f6u13k18 'uptime' [Mon Aug  6 04:14:46 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
interface=enp0s1
f6u13k18-enp0s1:  04:14:48 up 15:57,  0 users,  load average: 0.00, 0.00, 0.00
CHECK:output =~ f6u13k18	[Pass]
CHECK:rc == 0	[Pass]

RUN:grep f6u13k18 /etc/hosts [Mon Aug  6 04:14:48 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
10.6.13.18 f6u13k18 f6u13k18.pok.stglabs.ibm.com f6u13k18-enp0s1

RUN:rm -rf /etc/hosts [Mon Aug  6 04:14:48 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:cp /etc/hostsBK /etc/hosts [Mon Aug  6 04:14:48 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::psh_i::Passed::Time:Mon Aug  6 04:14:48 2018 ::Duration::2 sec------
```