### PR TITLE
fix /etc/hosts empty in sles12sp3 diskful installation 

### DIFF
--- a/xCAT-server/share/xcat/install/sles/compute.sles12.tmpl
+++ b/xCAT-server/share/xcat/install/sles/compute.sles12.tmpl
@@ -76,6 +76,7 @@
           <startmode>onboot</startmode>
         </interface>
       </interfaces>
+      <keep_install_network config:type="boolean">true</keep_install_network> 
       <routing>
         <ip_forward config:type="boolean">false</ip_forward>
         <routes config:type="list"/>

--- a/xCAT-server/share/xcat/install/sles/service.sles12.tmpl
+++ b/xCAT-server/share/xcat/install/sles/service.sles12.tmpl
@@ -112,6 +112,7 @@
           <startmode>onboot</startmode>
         </interface>
       </interfaces>
+      <keep_install_network config:type="boolean">true</keep_install_network>
       <routing>
         <ip_forward config:type="boolean">false</ip_forward>
         <routes config:type="list"/>


### PR DESCRIPTION
for https://github.com/xcat2/xcat2-task-management/issues/251
I got this information from https://www.suse.com/documentation/sles-12/book_autoyast/data/createprofile_network.html
:
 If the following setting is set to true, YaST will keep network settings created during the installation (via Linuxrc) and/or merge it with network settings from the AutoYaST control file (if defined). AutoYaST settings have higher priority than already present configuration files. YaST will write ifcfg-* files based on the entries in the control file without removing old ones. If there is an empty or no dns and routing section, YaST will keep already existing values. Otherwise settings from the control file will be applied.
```
<keep_install_network
config:type="boolean">true</keep_install_network>
```
During the second stage, installation of additional packages will take place before the network, as described in the profile, is configured. keep_install_network is set by default to true to ensure that a network is available in case it is needed to install those packages. If all packages are installed during the first stage and the network is not needed early during the second one, setting keep_install_network to false will avoid copying the configuration. 

The doc said: **keep_install_network is set by default to true to ensure that a network is available in case it is needed to install those packages**, but I found **keep_install_network is set by default to true** did not work in sles12sp3, because when there is no ``hosts`` entry configuration in auto yast installation configuration state, it should do nothing for ``/etc/hosts``, but it delete the file. So **keep_install_network is set by default to true** should be wrote into ``networking`` section in auto yast installation process.