### PR TITLE
code error cause rpm package is not signed

### DIFF
--- a/buildcore.sh
+++ b/buildcore.sh
@@ -92,7 +92,7 @@ if [ -z "$RPMSIGN" ] && [ -z "$GPGSIGN" ]; then
 elif [ -n "$GPGSIGN" ]; then # use GPGSIGN in first
     RPMSIGN=$GPGSIGN
 fi
-if [ -z "$RPMSIGN" -o "$RPMSIGN" != "0" ]; then
+if [ -z "$RPMSIGN" -o "$RPMSIGN" != "1" ]; then
     RPMSIGN=0
 fi
 if [ -z "$BUILDALL" ]; then


### PR DESCRIPTION
UT:   Using temp print code
```
[root@e5bc7f23cdb9 xcatsrc]# ./buildcore.sh RPMSIGN=2
RPMSIGN=0
[root@e5bc7f23cdb9 xcatsrc]# ./buildcore.sh RPMSIGN=1
RPMSIGN=1
[root@e5bc7f23cdb9 xcatsrc]# ./buildcore.sh
RPMSIGN=0
[root@e5bc7f23cdb9 xcatsrc]# ./buildcore.sh RPMSIGN=0
RPMSIGN=0
```