### PR TITLE
put the tarball directly under DEST directory when building xcat-core

### DIFF
--- a/build-ubunturepo
+++ b/build-ubunturepo
@@ -28,7 +28,6 @@
 #
 #               DEST=<directory> - provide a directory to contains the build result
 #
-#               BUILDDESTDIR=<build_tarball_dir> - Copy build core tarball to BUILDDESTDIR if defined
 # For the dependency packages 1. All the xcat dependency deb packages should be uploaded to
 #                                "pokgsa/projects/x/xcat/build/ubuntu/xcat-dep/debs/" on GSA
 #                             2. run ./build-ubunturepo -d
@@ -399,14 +398,10 @@ __EOF__
     chgrp root $tar_name
     chmod g+w $tar_name
 
-    if [ "$BUILDDESTDIR" ]; then
-        rm -rf $BUILDDESTDIR
-        mkdir -p $BUILDDESTDIR
-        cp $tar_name $BUILDDESTDIR
+    if [ -n "$DEST" ]; then
+        ln -sf $(basename `pwd`)/$tar_name ../$tar_name
         if [ $? != 0 ]; then
-            echo "Failed to copy $tar_name to $BUILDDESTDIR"
-        else
-            echo "Copied $tar_name to $BUILDDESTDIR"
+            echo "ERROR: Failed to make symbol link $DEST/$tar_name"
         fi
     fi
 

--- a/buildcore.sh
+++ b/buildcore.sh
@@ -32,8 +32,6 @@
 #        GPGSIGN/RPMSIGN=0 or GPGSIGN/RPMSIGN=1 - Sign the RPMs using the keys on GSA, the default is to sign the rpms without GPGSIGN/RPMSIGN specified
 #        DEST=<directory> - provide a directory to contains the build result
 #
-#        BUILDDESTDIR=<build_tarball_dir> - Copy build core tarball to BUILDDESTDIR if defined
-#
 # The following environment variables can be modified if you need
 #
 
@@ -585,14 +583,10 @@ fi
 chgrp $SYSGRP $TARNAME
 chmod g+w $TARNAME
 
-if [ "$BUILDDESTDIR" ]; then
-    rm -rf $BUILDDESTDIR
-    mkdir -p $BUILDDESTDIR
-    cp $TARNAME $BUILDDESTDIR
+if [ -n "$DEST" ]; then
+    ln -sf $(basename `pwd`)/$TARNAME ../$TARNAME
     if [ $? != 0 ]; then
-        echo "Failed to copy $TARNAME to $BUILDDESTDIR"
-    else
-        echo "Copied $TARNAME to $BUILDDESTDIR"
+        echo "ERROR: Failed to make symbol link $DEST/$TARNAME"
     fi
 fi
 


### PR DESCRIPTION
UT:
For RPM, (using branch `master`)
```
docker run -it -e BUILDALL=1 -v `pwd`:/xcatsrc -v ~/xcatbuild:/xcatbuild xcatbuild:rpm
ls ~/xcatbuild/
build.log		core-rpms-snap.tar.bz2	devel
tar tvf ~/xcatbuild/core-rpms-snap.tar.bz2
drwxrwxr-x  0 root   root        0 Aug  7 13:34 xcat-core/
-rw-rw-r--  0 root   root    29652 Aug  7 13:35 xcat-core/xCATsn-2.14.3-snap201808070534.ppc64.rpm
-rw-rw-r--  0 root   root   456632 Aug  7 13:34 xcat-core/xCAT-client-2.14.3-snap201808070534.noarch.rpm
-rw-rw-r--  0 root   root   621784 Aug  7 13:34 xcat-core/perl-xCAT-2.14.3-snap201808070534.noarch.rpm
-rw-rw-r--  0 root   root    90720 Aug  7 13:35 xcat-core/xCAT-probe-2.14.3-snap201808070534.noarch.rpm
-rw-rw-r--  0 root   root    29652 Aug  7 13:35 xcat-core/xCATsn-2.14.3-snap201808070534.ppc64le.rpm
-rw-rw-r--  0 root   root    59576 Aug  7 13:35 xcat-core/xCAT-genesis-scripts-ppc64-2.14.3-snap201808070534.noarch.rpm
drwxrwxr-x  0 root   root        0 Aug  7 13:34 xcat-core/repodata/
-rw-rw-r--  0 root   root    29492 Aug  7 13:34 xcat-core/repodata/2076b256e028b444287799dd72a08bfe0301bc5b-primary.sqlite.bz2
-rw-rw-r--  0 root   root    19819 Aug  7 13:34 xcat-core/repodata/fe0f56fedccbe059cdba8187c6b3615e3ae8653b-filelists.xml.gz
-rw-rw-r--  0 root   root     8813 Aug  7 13:34 xcat-core/repodata/e289503ba301436e14862294028cc782e5f00d68-primary.xml.gz
-rw-rw-r--  0 root   root     2511 Aug  7 13:34 xcat-core/repodata/repomd.xml
-rw-rw-r--  0 root   root     1443 Aug  7 13:34 xcat-core/repodata/946795d4e2364ba3a2299bc788bc55eeff62e207-other.xml.gz
-rw-rw-r--  0 root   root    30040 Aug  7 13:34 xcat-core/repodata/f3de2c7c2fdfd62acd8f306f0e39d78475c5f5f3-filelists.sqlite.bz2
-rw-rw-r--  0 root   root     2281 Aug  7 13:34 xcat-core/repodata/a5f023da1a5e68837764c5e5be8032e65f0d1cff-other.sqlite.bz2
-rw-rw-r--  0 root   root   992840 Aug  7 13:35 xcat-core/xCAT-test-2.14.3-snap201808070534.noarch.rpm
-rw-rw-r--  0 root   root  1840248 Aug  7 13:35 xcat-core/xCAT-server-2.14.3-snap201808070534.noarch.rpm
-rw-rw-r--  0 root   root    84320 Aug  7 13:35 xcat-core/xCAT-openbmc-py-2.14.3-snap201808070535.noarch.rpm
-rwxrwxr-x  0 root   root      632 Aug  7 13:34 xcat-core/mklocalrepo.sh
-rw-rw-r--  0 root   root    67644 Aug  7 13:35 xcat-core/xCAT-buildkit-2.14.3-snap201808070534.noarch.rpm
-rw-rw-r--  0 root   root    38324 Aug  7 13:35 xcat-core/xCAT-SoftLayer-2.14.3-snap201808070534.noarch.rpm
-rw-rw-r--  0 root   root    29528 Aug  7 13:35 xcat-core/xCATsn-2.14.3-snap201808070534.s390x.rpm
-rw-rw-r--  0 root   root    38536 Aug  7 13:35 xcat-core/xCAT-vlan-2.14.3-snap201808070534.noarch.rpm
-rw-rw-r--  0 root   root   247200 Aug  7 13:35 xcat-core/xCAT-2.14.3-snap201808070534.ppc64.rpm
-rw-rw-r--  0 root   root   247196 Aug  7 13:35 xcat-core/xCAT-2.14.3-snap201808070534.ppc64le.rpm
-rw-rw-r--  0 root   root     6532 Aug  7 13:35 xcat-core/xCAT-csm-2.14.3-snap201808070534.noarch.rpm
-rw-rw-r--  0 root   root   247196 Aug  7 13:35 xcat-core/xCAT-2.14.3-snap201808070534.x86_64.rpm
-rw-rw-r--  0 root   root    59572 Aug  7 13:35 xcat-core/xCAT-genesis-scripts-x86_64-2.14.3-snap201808070534.noarch.rpm
-rw-rw-r--  0 root   root     3596 Aug  7 13:35 xcat-core/xCAT-confluent-2.14.3-snap201808070534.noarch.rpm
-rw-rw-r--  0 root   root    29652 Aug  7 13:35 xcat-core/xCATsn-2.14.3-snap201808070534.x86_64.rpm
-rw-r--r--  0 root   root      204 Aug  7 13:34 xcat-core/xcat-core.repo
-rw-rw-r--  0 root   root   247180 Aug  7 13:35 xcat-core/xCAT-2.14.3-snap201808070534.s390x.rpm
-rw-r--r--  0 root   root      181 Aug  7 13:34 xcat-core/buildinfo
```

For Ubuntu: (using branch `build-tar`)
```
docker run -it -e BUILDALL=1 -v `pwd`:/xcatsrc -v ~/xcatbuild:/xcatbuild xcatbuild:deb
ls -l ~/xcatbuild/
total 0
lrwxrwxrwx  1 binxu  staff   36 Aug  7 13:51 core-debs-snap.tar.bz2 -> debsbuild-tar/core-debs-snap.tar.bz2
drwxr-xr-x  6 binxu  staff  192 Aug  7 13:51 debsbuild-tar
bindembp:xcat-core binxu$ tar tjf ~/xcatbuild/core-debs-snap.tar.bz2
xcat-core/
xcat-core/mklocalrepo.sh
xcat-core/db/
xcat-core/db/checksums.db
xcat-core/db/contents.cache.db
xcat-core/db/release.caches.db
xcat-core/db/references.db
xcat-core/db/version
xcat-core/db/packages.db
xcat-core/conf/
xcat-core/conf/options
xcat-core/conf/distributions
xcat-core/pool/
xcat-core/pool/main/
xcat-core/pool/main/x/
xcat-core/pool/main/x/xcat-probe/
xcat-core/pool/main/x/xcat-probe/xcat-probe_2.14.3-snap201808070549_all.deb
xcat-core/pool/main/x/xcat/
xcat-core/pool/main/x/xcat/xcat_2.14.3-snap201808070549_amd64.deb
xcat-core/pool/main/x/xcat/xcat_2.14.3-snap201808070549_ppc64el.deb
xcat-core/pool/main/x/xcat-confluent/
xcat-core/pool/main/x/xcat-confluent/xcat-confluent_2.14.3-snap201808070549_all.deb
xcat-core/pool/main/x/xcat-vlan/
xcat-core/pool/main/x/xcat-vlan/xcat-vlan_2.14.3-snap201808070549_all.deb
xcat-core/pool/main/x/xcatsn/
xcat-core/pool/main/x/xcatsn/xcatsn_2.14.3-snap201808070549_amd64.deb
xcat-core/pool/main/x/xcatsn/xcatsn_2.14.3-snap201808070549_ppc64el.deb
xcat-core/pool/main/x/xcat-buildkit/
xcat-core/pool/main/x/xcat-buildkit/xcat-buildkit_2.14.3-snap201808070549_all.deb
xcat-core/pool/main/x/xcat-client/
xcat-core/pool/main/x/xcat-client/xcat-client_2.14.3-snap201808070549_all.deb
xcat-core/pool/main/x/xcat-genesis-scripts/
xcat-core/pool/main/x/xcat-genesis-scripts/xcat-genesis-scripts-ppc64_2.14.3-snap201808070549_all.deb
xcat-core/pool/main/x/xcat-genesis-scripts/xcat-genesis-scripts-amd64_2.14.3-snap201808070549_all.deb
xcat-core/pool/main/x/xcat-test/
xcat-core/pool/main/x/xcat-test/xcat-test_2.14.3-snap201808070549_all.deb
xcat-core/pool/main/p/
xcat-core/pool/main/p/perl-xcat/
xcat-core/pool/main/p/perl-xcat/perl-xcat_2.14.3-snap201808070549_all.deb
xcat-core/buildinfo
xcat-core/dists/
xcat-core/dists/bionic/
xcat-core/dists/bionic/Release
xcat-core/dists/bionic/main/
xcat-core/dists/bionic/main/binary-ppc64el/
xcat-core/dists/bionic/main/binary-ppc64el/Packages.gz
xcat-core/dists/bionic/main/binary-ppc64el/Release
xcat-core/dists/bionic/main/binary-ppc64el/Packages
xcat-core/dists/bionic/main/binary-amd64/
xcat-core/dists/bionic/main/binary-amd64/Packages.gz
xcat-core/dists/bionic/main/binary-amd64/Release
xcat-core/dists/bionic/main/binary-amd64/Packages
xcat-core/dists/xenial/
xcat-core/dists/xenial/Release
xcat-core/dists/xenial/main/
xcat-core/dists/xenial/main/binary-ppc64el/
xcat-core/dists/xenial/main/binary-ppc64el/Packages.gz
xcat-core/dists/xenial/main/binary-ppc64el/Release
xcat-core/dists/xenial/main/binary-ppc64el/Packages
xcat-core/dists/xenial/main/binary-amd64/
xcat-core/dists/xenial/main/binary-amd64/Packages.gz
xcat-core/dists/xenial/main/binary-amd64/Release
xcat-core/dists/xenial/main/binary-amd64/Packages
xcat-core/dists/trusty/
xcat-core/dists/trusty/Release
xcat-core/dists/trusty/main/
xcat-core/dists/trusty/main/binary-ppc64el/
xcat-core/dists/trusty/main/binary-ppc64el/Packages.gz
xcat-core/dists/trusty/main/binary-ppc64el/Release
xcat-core/dists/trusty/main/binary-ppc64el/Packages
xcat-core/dists/trusty/main/binary-amd64/
xcat-core/dists/trusty/main/binary-amd64/Packages.gz
xcat-core/dists/trusty/main/binary-amd64/Release
xcat-core/dists/trusty/main/binary-amd64/Packages
xcat-core/dists/utopic/
xcat-core/dists/utopic/Release
xcat-core/dists/utopic/main/
xcat-core/dists/utopic/main/binary-ppc64el/
xcat-core/dists/utopic/main/binary-ppc64el/Packages.gz
xcat-core/dists/utopic/main/binary-ppc64el/Release
xcat-core/dists/utopic/main/binary-ppc64el/Packages
xcat-core/dists/utopic/main/binary-amd64/
xcat-core/dists/utopic/main/binary-amd64/Packages.gz
xcat-core/dists/utopic/main/binary-amd64/Release
xcat-core/dists/utopic/main/binary-amd64/Packages
xcat-core/dists/saucy/
xcat-core/dists/saucy/Release
xcat-core/dists/saucy/main/
xcat-core/dists/saucy/main/binary-amd64/
xcat-core/dists/saucy/main/binary-amd64/Packages.gz
xcat-core/dists/saucy/main/binary-amd64/Release
xcat-core/dists/saucy/main/binary-amd64/Packages
```