### PR TITLE
Fixes xcat2/xcat-core issue 5476

### DIFF
--- a/xCAT-server/lib/xcat/plugins/geninitrd.pm
+++ b/xCAT-server/lib/xcat/plugins/geninitrd.pm
@@ -180,7 +180,7 @@ sub geninitrd {
     my $initrdpath;
     my $kernelpath;
     my $tftpdir = "/tftpboot";
-    my @entries = xCAT::TableUtils->get_site_attribute("$tftpdir");
+    my @entries = xCAT::TableUtils->get_site_attribute("tftpdir");
     my $t_entry = $entries[0];
     if (defined($t_entry)) {
         $tftpdir = $t_entry;


### PR DESCRIPTION
    get_site_attribute() call uses variable where it should
     use the bare string name of the variable