### PR TITLE
Fix broken xcat-probing for static IP on ubuntu

### DIFF
--- a/xCAT-probe/lib/perl/probe_utils.pm
+++ b/xCAT-probe/lib/perl/probe_utils.pm
@@ -206,7 +206,7 @@ sub is_static_ip {
         my $output2 = `cat /etc/sysconfig/network/ifcfg-$nic 2>&1 |grep -i BOOTPROTO`;
         $rst = 1 if (($output1 =~ /$ip/) && ($output2 =~ /static/i));
     } elsif ($os =~ /ubuntu/) {
-        my $output = `cat /etc/network/interfaces 2>&1|grep -E "iface\s+$nic"`;
+        my $output = `cat /etc/network/interfaces 2>&1|grep -E "iface\\s+$nic"`;
         $rst = 1 if ($output =~ /static/i);
     }
     return $rst;


### PR DESCRIPTION
When running ubuntu and using `xcatprobe xcatmn -i <if>`, it is checked, among other things, that the management node IP address is defined to be static in the file `/etc/network/interfaces`.

This PR fixes a critical typo, that results in a wrong result for this check.