### PR TITLE
fix typo in informational message

### DIFF
--- a/xCAT-probe/subcmds/discovery
+++ b/xCAT-probe/subcmds/discovery
@@ -520,7 +520,7 @@ sub do_pre_check {
 
 #------------------------------------------
 sub check_genesis_file {
-    my $msg = "Genesis files are avaliable";
+    my $msg = "Genesis files are available";
     my $rst = 0;
     my @warn_msg;
 

--- a/xCAT-server/lib/xcat/plugins/nodediscover.pm
+++ b/xCAT-server/lib/xcat/plugins/nodediscover.pm
@@ -319,7 +319,7 @@ sub process_request {
                     my $hosttag = gethosttag($node, $netn, @ifinfo[1], \%usednames);
                     unless ($hosttag) {
                         my $nettagname = $usednames_for_net{$netn};
-                        # For nics not in the install network, don't deal with them if not an avaliable hostname get 
+                        # For nics not in the install network, don't deal with them if not an available hostname get 
                         # In case another nic in install network get a hosttag other than nodename, need to compare the IP address they can convert to
                         if ($nettagname and (inet_aton($nettagname) eq inet_aton($node))) {
                             $hosttag = "$node-$ifinfo[1]";


### PR DESCRIPTION
Fix a simple typo in an informational message. No functional changes.