### PR TITLE
nodediscover.pm: print error message when failed to open socket to 3001 port of the node under discovery

### DIFF
--- a/xCAT-server/lib/xcat/plugins/nodediscover.pm
+++ b/xCAT-server/lib/xcat/plugins/nodediscover.pm
@@ -510,7 +510,7 @@ sub process_request {
         Timeout  => '1',
         Proto    => 'tcp'
     );
-    unless ($sock) { xCAT::MsgUtils->message("S", "xcat.discovery.nodediscover: Failed to notify $clientip that it's actually $node. $node has not been discovered."); return; }
+    unless ($sock) { xCAT::MsgUtils->message("S", "xcat.discovery.nodediscover: Failed to notify $clientip that it's actually $node. $node has not been discovered: $!"); return; }
     print $sock $restartstring;
     close($sock);
 


### PR DESCRIPTION
nodediscover.pm: print error message when failed to open socket to 3001 port of the node under discovery