### PR TITLE
bash [[ notation requires bash

### DIFF
--- a/xCAT/postscripts/mkresolvconf
+++ b/xCAT/postscripts/mkresolvconf
@@ -25,7 +25,7 @@ if [ -n "$master" ] && [ -n "$domain" ]; then
 	#logger -t xcat "Created /etc/resolv.conf file on $node."
 	cp $conf_file $conf_file_bak > /dev/null 2>&1
 	echo "search $domain" >$conf_file
-    if [[ "$nameservers" != "" ]]; then
+    if [ "$nameservers" != "" ]; then
         for ns in ${nameservers//,/ }; do
     	    grep -q $ns $conf_file || \
                 echo "nameserver ${ns/<xcatmaster>/$master}" >>$conf_file

--- a/xCAT/postscripts/mkresolvconf
+++ b/xCAT/postscripts/mkresolvconf
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # IBM(c) 2007 EPL license http://www.eclipse.org/legal/epl-v10.html
 #
 #---------------------------------------------------------------------------
@@ -25,7 +25,7 @@ if [ -n "$master" ] && [ -n "$domain" ]; then
 	#logger -t xcat "Created /etc/resolv.conf file on $node."
 	cp $conf_file $conf_file_bak > /dev/null 2>&1
 	echo "search $domain" >$conf_file
-    if [ "$nameservers" != "" ]; then
+    if [[ "$nameservers" != "" ]]; then
         for ns in ${nameservers//,/ }; do
     	    grep -q $ns $conf_file || \
                 echo "nameserver ${ns/<xcatmaster>/$master}" >>$conf_file


### PR DESCRIPTION
When running ubuntu, and using the xCAT postscript `mkresolvconf`, one receives the error message:

```
Fri Aug 10 15:53:44 CEST 2018 [info]: xcat.mypostscript: Running postscript: mkresolvconf
./mkresolvconf: 28: ./mkresolvconf: [[: not found
Fri Aug 10 15:53:44 CEST 2018 [info]: xcat.mypostscript: postscript mkresolvconf return with 0
```

This is because in ubuntu `#!/bin/sh` links to `dash`
```
root@node1:/xcatpost# ll /bin/sh
lrwxrwxrwx 1 root root 4 Aug 10 15:47 /bin/sh -> dash*
```
which does not support the `[[ ... ]]` notation, since this is a bash notation. See https://stackoverflow.com/questions/3427872/whats-the-difference-between-and-in-bash

(On other distros where `sh -> bash` this is not an issue.)

This PR replaces bash brackets by sh brackets, (and leaves the now necessary quotes).

Unfortunately the return code stayed at 0 even with this error, which explains (somewhat) why it has not been discovered yet.

PS: I wonder how many xCAT deployments will break once this is merged. Nevertheless: it is a bug.
