### PR TITLE
Improve getopenbmccons performance (#5507)

### DIFF
--- a/xCAT-server/share/xcat/cons/openbmc
+++ b/xCAT-server/share/xcat/cons/openbmc
@@ -64,7 +64,7 @@ sub getans {
 my $cmdref = {
     command   => ["getopenbmccons"],
     arg       => ["text"],
-    noderange => [ $ARGV[0] ]
+    node => [ $ARGV[0] ]
 };
 acquire_lock();
 # avoid of congestion


### PR DESCRIPTION
Made below changes to improve the performance (#5507 ):
 - as it is only DB operation, do all things in preprocess_handler
 - pass 'node' instead of 'noderange' to avoid accessing whole `nodelist`
 - comments to send debug message to client for `getopenbmccons`

UT:  
Fuction pass: It can still get the right bmcip/user/password for a node.

Performance:
1, Compare the total time of run `getopenbmccons`,  the time is shorten from 0.7 s to 0.4 s for a 4k+ nodes cluster.

2, Check the Pgsl DB query log,  and not fetching whole `nodelist` table anymore.
```
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  duration: 0.290 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.110 ms
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  duration: 0.078 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.076 ms
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  duration: 0.076 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.126 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.115 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.184 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  execute dbdpg_p7522_402: SELECT * FROM site WHERE "disable" is NULL or "disable" in ('0','no','NO','No','nO')
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.160 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: DEALLOCATE dbdpg_p7522_402
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.055 ms
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  duration: 0.137 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.088 ms
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  duration: 0.078 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.075 ms
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  duration: 0.076 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.130 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.100 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.191 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  execute dbdpg_p7522_403: SELECT * FROM networks WHERE "disable" is NULL or "disable" in ('0','no','NO','No','nO')
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.179 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: DEALLOCATE dbdpg_p7522_403
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.051 ms
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  duration: 0.084 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.076 ms
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  duration: 0.077 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.136 ms
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  duration: 0.074 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.071 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.128 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.150 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  execute dbdpg_p7522_404: SELECT * FROM policy WHERE "disable" is NULL or "disable" in ('0','no','NO','No','nO')
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.236 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: DEALLOCATE dbdpg_p7522_404
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.048 ms
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  duration: 0.107 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.135 ms
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  duration: 0.074 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.073 ms
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  duration: 0.074 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.073 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.079 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.166 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  execute dbdpg_p7522_405: SELECT * FROM site WHERE "key" = $1 and ("disable" is NULL or "disable" in ('0','no','NO','No','nO'))
10.3.5.24-17740 2018-08-15 04:33:38 EDT DETAIL:  parameters: $1 = 'hierarchicalattrs'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.163 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: DEALLOCATE dbdpg_p7522_405
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.046 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.087 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.192 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  execute dbdpg_p7522_406: SELECT * FROM nodehm WHERE "node" = $1 and ("disable" is NULL or "disable" in ('0','no','NO','No','nO'))
10.3.5.24-17740 2018-08-15 04:33:38 EDT DETAIL:  parameters: $1 = 'sierra1'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.263 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: DEALLOCATE dbdpg_p7522_406
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.102 ms
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  duration: 0.082 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.077 ms
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  duration: 0.076 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.116 ms
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  duration: 0.075 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.132 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.076 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.163 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  execute dbdpg_p7522_407: SELECT * FROM passwd WHERE "key" = $1 and ("disable" is NULL or "disable" in ('0','no','NO','No','nO'))
10.3.5.24-17740 2018-08-15 04:33:38 EDT DETAIL:  parameters: $1 = 'openbmc'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.138 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: DEALLOCATE dbdpg_p7522_407
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.101 ms
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  duration: 0.076 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.074 ms
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  duration: 0.074 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.128 ms
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17768 2018-08-15 04:33:38 EDT LOG:  duration: 0.074 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: SELECT 'DBD::Pg ping test'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.127 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.127 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.146 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  execute dbdpg_p7522_408: SELECT * FROM site WHERE "key" = $1 and ("disable" is NULL or "disable" in ('0','no','NO','No','nO'))
10.3.5.24-17740 2018-08-15 04:33:38 EDT DETAIL:  parameters: $1 = 'hierarchicalattrs'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.155 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: DEALLOCATE dbdpg_p7522_408
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.105 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.076 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.163 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  execute dbdpg_p7522_409: SELECT * FROM openbmc WHERE "node" = $1 and ("disable" is NULL or "disable" in ('0','no','NO','No','nO'))
10.3.5.24-17740 2018-08-15 04:33:38 EDT DETAIL:  parameters: $1 = 'sierra1'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.197 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: DEALLOCATE dbdpg_p7522_409
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.046 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.082 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.174 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  execute dbdpg_p7522_410: SELECT * FROM nodelist WHERE "node" = $1 and ("disable" is NULL or "disable" in ('0','no','NO','No','nO'))
10.3.5.24-17740 2018-08-15 04:33:38 EDT DETAIL:  parameters: $1 = 'sierra1'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.196 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: DEALLOCATE dbdpg_p7522_410
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.103 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.075 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.160 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  execute dbdpg_p7522_411: SELECT * FROM openbmc WHERE "node" = $1 and ("disable" is NULL or "disable" in ('0','no','NO','No','nO'))
10.3.5.24-17740 2018-08-15 04:33:38 EDT DETAIL:  parameters: $1 = 'compute'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.123 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: DEALLOCATE dbdpg_p7522_411
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.101 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.075 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.098 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  execute dbdpg_p7522_412: SELECT * FROM openbmc WHERE "node" = $1 and ("disable" is NULL or "disable" in ('0','no','NO','No','nO'))
10.3.5.24-17740 2018-08-15 04:33:38 EDT DETAIL:  parameters: $1 = 'aw20'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.120 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: DEALLOCATE dbdpg_p7522_412
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.045 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.074 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.159 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  execute dbdpg_p7522_413: SELECT * FROM openbmc WHERE "node" = $1 and ("disable" is NULL or "disable" in ('0','no','NO','No','nO'))
10.3.5.24-17740 2018-08-15 04:33:38 EDT DETAIL:  parameters: $1 = 'service1'
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.123 ms
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  statement: DEALLOCATE dbdpg_p7522_413
10.3.5.24-17740 2018-08-15 04:33:38 EDT LOG:  duration: 0.103 ms
```

3, check the `/var/log/xcat/cluster.log`,  not run `process_handler` anymore.
```
Aug 15 04:33:38 c910f03c05k24 xcat[8745]: DEBUG  xcatd: connection from root@localhost
Aug 15 04:33:38 c910f03c05k24 xcat[8745]: DEBUG  xcatd: open new process : xcatd SSL: getopenbmccons for root@localhost
Aug 15 04:33:38 c910f03c05k24 xcat[8746]: DEBUG  xcatd: dispatch request 'getopenbmccons text' to plugin 'openbmc'
Aug 15 04:33:38 c910f03c05k24 xcat[8746]: DEBUG  xcatd: handle request 'getopenbmccons' by plugin 'openbmc''s preprocess_request
Aug 15 04:33:39 c910f03c05k24 xcat[8745]: DEBUG  xcatd: close connection with root@localhost
```