### PR TITLE
fix when xcatdebugmode=1, non shell (/bin/sh) postscripts will not show output back on MN #5510

### DIFF
--- a/xCAT/postscripts/xcatdsklspost
+++ b/xCAT/postscripts/xcatdsklspost
@@ -896,7 +896,7 @@ run_ps () {
         bash -x ./\$@ 2>&1 | tee -a \$logfile | tee >(logger -t xcat.mypostscript -p debug)
         ret_local=\${PIPESTATUS[0]}
      else
-        ./\$@ 2>&1 | tee -a \$logfile | logger -t xcat.mypostscript -p debug
+        ./\$@ 2>&1 | tee -a \$logfile | tee >(logger -t xcat.mypostscript -p debug)
         ret_local=\${PIPESTATUS[0]}
      fi
   else


### PR DESCRIPTION
UT:
```
[root@briggs01 xcatpost]# chdef -t site clustersite xcatdebugmode=1
1 object definitions have been created or modified.
[root@briggs01 xcatpost]# updatenode mid05tor12cn03 -P custom.ps/list_software
mid05tor12cn03: trying to download postscripts...
mid05tor12cn03: postscripts downloaded successfully
mid05tor12cn03: trying to get mypostscript from 172.12.253.27...
mid05tor12cn03: Running postscript: custom.ps/list_software
mid05tor12cn03:
mid05tor12cn03: INFO: Listing xCAT information...
mid05tor12cn03:    IMAGENAME=ist.redhat-alt.install.DF
mid05tor12cn03:
mid05tor12cn03: INFO: Listing kernel information...
mid05tor12cn03:    KERNEL: 4.14.0-49.11.1.el7a.ppc64le
mid05tor12cn03:    INSTALLED KERNEL MODULES in /lib/modules
mid05tor12cn03:    --> 4.14.0-49.10.1.el7a.ibmnvidia.7.ppc64le
mid05tor12cn03:    --> 4.14.0-49.11.1.el7a.ppc64le
mid05tor12cn03:
mid05tor12cn03: INFO: Listing HPC Stack Software Levels...
mid05tor12cn03:    MELLANOX_OFED: MLNX_OFED_LINUX-4.3-4.0.5.1 (OFED-4.3-4.0.5):
mid05tor12cn03:    NVIDIA_CUDA_VERSION: cuda-9.2.148-1.ppc64le
mid05tor12cn03:    NVIDIA_DRIVER_VERSIONS: VBIOS Version                   : 88.00.13.00.02
mid05tor12cn03:    NVIDIA_DRIVER_VERSIONS: Driver Version                      : 396.47
mid05tor12cn03:    CSM_CORE_VERSION: (no version installed)
mid05tor12cn03:    ESSL_VERSION: essl.common-6.1.0-0.ppc64le
mid05tor12cn03:    GPFS_GPLBIN_VERSION: gpfs.gplbin-4.14.0-49.10.1.el7a.ibmnvidia.7.ppc64le-5.0.1-0.ppc64le
mid05tor12cn03: gpfs.gplbin-4.14.0-49.11.1.el7a.ppc64le-5.0.1-0.ppc64le
mid05tor12cn03:    GPFS_VERSION: gpfs.base-5.0.1-0.ppc64le
mid05tor12cn03:    PESSL_VERSION: pessl.common-5.4.0-0.ppc64le
mid05tor12cn03:    PPT_VERSION: ppt_runtime-2.4.0-0.ppc64le
mid05tor12cn03:    SMPI_VERSION: ibm_smpi-10.02.00.06rtm1-rh7_20180811.ppc64le
mid05tor12cn03:    SMPI_VERSION_nv_rsync_mem: nv_rsync_mem-1.0-2.ppc64le
mid05tor12cn03:    SMPI_VERSION_nvidia_peer_memory: nvidia_peer_memory-1.0-4.2.ppc64le
mid05tor12cn03:    XLC_VERSION: xlc.16.1.0-16.1.0.0-180413g.ppc64le
mid05tor12cn03:    XLF_VERSION: xlf.16.1.0-16.1.0.0-180413g.ppc64le
mid05tor12cn03: postscript: custom.ps/list_software exited with code 0
mid05tor12cn03: Running of postscripts has completed.
```