### PR TITLE
Fix issue 5518: perl-xCAT/xCAT/MacMap.pm on ubuntu18.4 and rhels6.10

### DIFF
--- a/perl-xCAT/xCAT/MacMap.pm
+++ b/perl-xCAT/xCAT/MacMap.pm
@@ -533,7 +533,7 @@ sub refresh_table {
     my $children = 0;
     my $inputs   = new IO::Select;
     $SIG{CHLD} = sub { while (waitpid(-1, WNOHANG) > 0) { $children-- } };
-    foreach my $entry (keys $self->{switches}) {
+    foreach my $entry (keys %{$self->{switches}}) {
         while ($children > 64) {
             $self->handle_output($inputs);
         }


### PR DESCRIPTION
Fix issue #5518 

Syntax error for Macmap.pm:
```
# perl -c /opt/xcat/lib/perl/xCAT/MacMap.pm
Experimental keys on scalar is now forbidden at /opt/xcat/lib/perl/xCAT/MacMap.pm line 536.
Type of arg 1 to keys must be hash or array (not hash element) at /opt/xcat/lib/perl/xCAT/MacMap.pm line 536, near "}) "
/opt/xcat/lib/perl/xCAT/MacMap.pm had compilation errors.
```