### PR TITLE
getAllNodeAttribs will query site table too much (#5505)

### DIFF
--- a/perl-xCAT/xCAT/Table.pm
+++ b/perl-xCAT/xCAT/Table.pm
@@ -3417,6 +3417,12 @@ sub getAllNodeAttribs
     $self->{nodelist}->_build_cache([ 'node', 'groups' ]);
     $self->{_use_cache} = 1;
     $self->{nodelist}->{_use_cache} = 1;
+
+    my @hierarchy_attrs = ();
+    my $hierarchy_field = xCAT::TableUtils->get_site_attribute("hierarchicalattrs");
+    if ($hierarchy_field) {
+        @hierarchy_attrs = split(/,/, $hierarchy_field);
+    }
     while (my $data = $query->fetchrow_hashref())
     {
 
@@ -3437,12 +3443,13 @@ sub getAllNodeAttribs
             #}  end SF 3580
 
             #my $localhash = $self->getNodesAttribs(\@nodes,$attribq); #NOTE:  This is stupid, rebuilds the cache for every entry, FIXME
-            my %options;
-            my @hierarchy_attrs = ();
-            my $hierarchy_field = xCAT::TableUtils->get_site_attribute("hierarchicalattrs");
-            if ($hierarchy_field) {
-                @hierarchy_attrs = split(/,/, $hierarchy_field);
-            }
+
+            #my @hierarchy_attrs = ();
+            #my $hierarchy_field = xCAT::TableUtils->get_site_attribute("hierarchicalattrs");
+            #if ($hierarchy_field) {
+            #    @hierarchy_attrs = split(/,/, $hierarchy_field);
+            #}
+            my %options = ();
             $options{hierarchy_attrs} = \@hierarchy_attrs;
             foreach (@nodes)
             {


### PR DESCRIPTION
To fix #5505 
 - move `get_site_attribute` out from loop

UT:  
1, make postgresql could log statement, and clean the log file
2, remove /etc/conserver.cf,  and Restart xcatd on SN
3, /etc/conserver.cf could be generated successfully.
4, observer the postgreql daemon on MN, and no CPU high again.
And made the comparison for the query logs:
```
[root@c910f03c05k20 pg_log]# grep execute postgresql-Thu.log.good|wc
    122    1626   13884
[root@c910f03c05k20 pg_log]# grep execute postgresql-Thu.log.bad|wc
  28033  346027 3037395
```
Most of them are query site table.
```
[root@c910f03c05k20 pg_log]# grep execute postgresql-Thu.log.bad|grep site|wc
   9326  214490 1637637
```