### PR TITLE
Add --noupdateinitrd option to rinstall

### DIFF
--- a/docs/source/guides/admin-guides/references/man8/nodeset.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/nodeset.8.rst
@@ -90,7 +90,7 @@ A user can supply their own scripts to be run on the mn or on the service node (
 
 \ **-**\ **-noupdateinitrd**\ 
  
- Skip the rebuilding of initrd when the 'netdrivers', 'drvierupdatesrc' or 'osupdatename' were set for injecting new drivers to initrd. But, the \ **geninitrd**\  command
+ Skip the rebuilding of initrd when the 'netdrivers', 'driverupdatesrc' or 'osupdatename' were set for injecting new drivers to initrd. But, the \ **geninitrd**\  command
  should be run to rebuild the initrd for new drivers injecting. This is used to improve the performance of \ **nodeset**\  command.
  
 

--- a/docs/source/guides/admin-guides/references/man8/rinstall.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/rinstall.8.rst
@@ -21,7 +21,7 @@ Name
 
 \ **rinstall**\  \ *noderange*\  [\ **boot**\  | \ **shell**\  | \ **runcmd=**\ \ *command*\ ] [\ **-c | -**\ **-console**\ ] [\ **-V | -**\ **-verbose**\ ]
 
-\ **rinstall**\  \ *noderange*\  \ **osimage**\ [=\ *imagename*\ ] [\ **-**\ **-ignorekernelchk**\ ] [\ **-c | -**\ **-console**\ ] [\ **-u | -**\ **-uefimode**\ ] [\ **-V | -**\ **-verbose**\ ]
+\ **rinstall**\  \ *noderange*\  \ **osimage**\ [=\ *imagename*\ ] [\ **-**\ **-noupdateinitrd**\ ][\ **-**\ **-ignorekernelchk**\ ] [\ **-c | -**\ **-console**\ ] [\ **-u | -**\ **-uefimode**\ ] [\ **-V | -**\ **-verbose**\ ]
 
 \ **rinstall**\  \ *noderange*\  \ **runimage=**\ \ *task*\ 
 
@@ -56,6 +56,10 @@ If \ **-c**\  is specified, it will then run \ **rcons**\  on the node. This is 
  
  Prepare server for installing a node using the specified OS image. The OS image is defined in the \ *osimage*\  table and \ *linuximage*\  table. If the \ *imagename*\  is omitted, the OS image name will be obtained from \ *nodetype.provmethod*\  for the node.
  
+
+
+\ **-**\ **-noupdateinitrd**\  Skip the rebuilding of initrd when the 'netdrivers', 'driverupdatesrc' or 'osupdatename' were set for injecting new drivers to initrd. But, the \ **geninitrd**\  command should be run to rebuild the initrd for new drivers injecting. This is used to improve the performance of \ **rinstall**\  command.
+
 
 
 \ **-**\ **-ignorekernelchk**\ 

--- a/xCAT-client/pods/man8/nodeset.8.pod
+++ b/xCAT-client/pods/man8/nodeset.8.pod
@@ -63,7 +63,7 @@ Prepare server for installing a node using the specified os image. The os image 
 
 =item B<--noupdateinitrd>
 
-Skip the rebuilding of initrd when the 'netdrivers', 'drvierupdatesrc' or 'osupdatename' were set for injecting new drivers to initrd. But, the B<geninitrd> command
+Skip the rebuilding of initrd when the 'netdrivers', 'driverupdatesrc' or 'osupdatename' were set for injecting new drivers to initrd. But, the B<geninitrd> command
 should be run to rebuild the initrd for new drivers injecting. This is used to improve the performance of B<nodeset> command.
 
 =item B<--ignorekernelchk>

--- a/xCAT-client/pods/man8/rinstall.8.pod
+++ b/xCAT-client/pods/man8/rinstall.8.pod
@@ -6,7 +6,7 @@ B<rinstall> - Begin OS provision on a noderange
 
 B<rinstall> I<noderange> [B<boot> | B<shell> | B<runcmd=>I<command>] [B<-c>|B<--console>] [B<-V>|B<--verbose>]
 
-B<rinstall> I<noderange> B<osimage>[=I<imagename>] [B<--ignorekernelchk>] [B<-c>|B<--console>] [B<-u>|B<--uefimode>] [B<-V>|B<--verbose>]
+B<rinstall> I<noderange> B<osimage>[=I<imagename>] [B<--noupdateinitrd>][B<--ignorekernelchk>] [B<-c>|B<--console>] [B<-u>|B<--uefimode>] [B<-V>|B<--verbose>]
 
 B<rinstall> I<noderange> B<runimage=>I<task>
 
@@ -31,6 +31,9 @@ Instruct network boot loader to be skipped, generally meaning boot to hard disk
 =item B<osimage>[=I<imagename>]
 
 Prepare server for installing a node using the specified OS image. The OS image is defined in the I<osimage> table and I<linuximage> table. If the I<imagename> is omitted, the OS image name will be obtained from I<nodetype.provmethod> for the node.  
+
+=item B<--noupdateinitrd>
+Skip the rebuilding of initrd when the 'netdrivers', 'driverupdatesrc' or 'osupdatename' were set for injecting new drivers to initrd. But, the B<geninitrd> command should be run to rebuild the initrd for new drivers injecting. This is used to improve the performance of B<rinstall> command.
 
 =item B<--ignorekernelchk>
 

--- a/xCAT-server/lib/xcat/plugins/rinstall.pm
+++ b/xCAT-server/lib/xcat/plugins/rinstall.pm
@@ -70,6 +70,7 @@ sub rinstall {
     my $OSIMAGE;
     my $STATES;
     my $ignorekernelchk;
+    my $noupdateinitrd;
     my $VERBOSE;
     my $HELP;
     my $VERSION;
@@ -135,6 +136,7 @@ sub rinstall {
         unless (
             GetOptions(
                 'ignorekernelchk' => \$ignorekernelchk,
+                'noupdateinitrd'  => \$noupdateinitrd,
                 'V|verbose'       => \$VERBOSE,
                 'h|help'          => \$HELP,
                 'v|version'       => \$VERSION,
@@ -256,7 +258,10 @@ sub rinstall {
         push @parameter, "osimage=$OSIMAGE";
 
         if ($ignorekernelchk) {
-            push @parameter, " --ignorekernelchk";
+            push @parameter, "--ignorekernelchk";
+        }
+        if ($noupdateinitrd) {
+            push @parameter, "--noupdateinitrd";
         }
     }
     elsif ($STATES) {
@@ -593,7 +598,7 @@ sub usage {
     my $rsp      = {};
     $rsp->{data}->[0] = "Usage:";
     $rsp->{data}->[1] = "   $command <noderange> [boot | shell | runcmd=<command>] [-c|--console] [-u|--uefimode] [-V|--verbose]";
-    $rsp->{data}->[2] = "   $command <noderange> osimage[=<imagename>] [--ignorekernelchk] [-c|--console] [-u|--uefimode] [-V|--verbose]";
+    $rsp->{data}->[2] = "   $command <noderange> osimage[=<imagename>] [--noupdateinitrd] [--ignorekernelchk] [-c|--console] [-u|--uefimode] [-V|--verbose]";
     $rsp->{data}->[3] = "   $command <noderange> runimage=<task>";
     $rsp->{data}->[4] = "   $command [-h|--help|-v|--version]";
     xCAT::MsgUtils->message("I", $rsp, $callback);


### PR DESCRIPTION
#5497 

`rinstall` will pass `--noupdateinitrd` option, if specified, to `nodeset`

UT:

```
[root@boston01 xcat]# ls -l /tftpboot/xcat/osimage/rhels7.5-ga-ppc64le-install-compute
total 62332
-rw-r--r-- 1 root root 44030164 Aug 16 11:23 initrd.img
-rw-r--r-- 1 root root 19793184 Aug 16 11:23 vmlinuz

[root@boston01 xcat]# date
Thu Aug 16 11:55:26 EDT 2018

[root@boston01 xcat]# rinstall mid21tor24cn07 osimage=rhels7.5-ga-ppc64le-install-compute --noupdateinitrd -V        [boston01]: Provision node(s): mid21tor24cn07
[boston01]: Run command: nodeset mid21tor24cn07 osimage=rhels7.5-ga-ppc64le-install-compute --noupdateinitrd
[boston01]: mid21tor24cn07: install rhels7.5-ga-ppc64le-compute

[root@boston01 xcat]# ls -l /tftpboot/xcat/osimage/rhels7.5-ga-ppc64le-install-compute
total 62332
-rw-r--r-- 1 root root 44030164 Aug 16 11:23 initrd.img
-rw-r--r-- 1 root root 19793184 Aug 16 11:23 vmlinuz
[root@boston01 xcat]#
```