### PR TITLE
Support multiple syncfile list for packimage 

### DIFF
--- a/xCAT-server/lib/xcat/plugins/packimage.pm
+++ b/xCAT-server/lib/xcat/plugins/packimage.pm
@@ -423,13 +423,19 @@ sub process_request {
     if (not $nosyncfiles) {
         # sync fils configured in the synclist to the rootimage
         $syncfile = xCAT::SvrUtils->getsynclistfile(undef, $osver, $arch, $profile, "netboot", $imagename);
-        if ( defined($syncfile) && -f $syncfile && -d $rootimg_dir) {
+        if ( defined($syncfile) && -d $rootimg_dir) {
             my $myenv='';
             if($envars){
                 $myenv.=" XCAT_OSIMAGE_ENV=$envars";
             }
-            print "Syncing files from $syncfile to root image dir: $rootimg_dir\n";
-            system("$myenv $::XCATROOT/bin/xdcp -i $rootimg_dir -F $syncfile");
+            my @filelist = split ',', $syncfile;
+            foreach my $synclistfile (@filelist) {
+                if ( -f $synclistfile) {
+                    print "Syncing files from $synclistfile to root image dir: $rootimg_dir\n";
+                    my $cmd = "$myenv $::XCATROOT/bin/xdcp -i $rootimg_dir -F $synclistfile";
+                    xCAT::Utils->runcmd($cmd, 0, 1);
+                }
+            }
         }
     } else {
         print "Bypass of syncfiles requested, will not sync files to root image directory.\n";

--- a/xCAT-server/lib/xcat/plugins/statelite.pm
+++ b/xCAT-server/lib/xcat/plugins/statelite.pm
@@ -233,10 +233,14 @@ sub process_request {
 
     #sync fils configured in the synclist to the rootimage
     $syncfile = xCAT::SvrUtils->getsynclistfile(undef, $osver, $arch, $profile, "netboot", $imagename);
-    if (defined($syncfile) && -f $syncfile
-        && -d $rootimg_dir) {
-        print "sync files from $syncfile to the $rootimg_dir\n";
-        `$::XCATROOT/bin/xdcp -i $rootimg_dir -F $syncfile`;
+    if (defined($syncfile) && -d $rootimg_dir) {
+        my @filelist = split ',', $syncfile;
+        foreach my $synclistfile (@filelist) {
+            if ( -f $synclistfile) {
+                print "sync files from $synclistfile to the $rootimg_dir\n";
+                `$::XCATROOT/bin/xdcp -i $rootimg_dir -F $synclistfile`;
+            }
+        }
     }
 
     # check if the file "litefile.save" exists or not


### PR DESCRIPTION
for issue #5517 
multiple syncfile list worked fine for updatenode and syncfiles postscripts, but failed during packimage process.  

````
# lsdef -t osimage rhels7.5-alternate-ppc64le-netboot-compute -i synclists
Object name: rhels7.5-alternate-ppc64le-netboot-compute
    synclists=/tmp/sysfile1,/tmp/sysfile2
# cat /tmp/sysfile1
/etc/hosts -> /etc/hosts
/etc/hosts -> /tmp/hosts

# cat /tmp/sysfile2
/tmp/sysfile1 -> /tmp/syncfile

# ls -ltr /install/netboot/rhels7.5-alternate/ppc64le/compute/rootimg/tmp
total 8
-rw-r--r-- 1 root root 918 Aug 13 11:15 hosts
-rw-r--r-- 1 root root  51 Aug 16 11:57 syncfile
````