### PR TITLE
Move 2 dns cases from CI test scope

### DIFF
--- a/xCAT-test/autotest/testcase/makedns/cases0
+++ b/xCAT-test/autotest/testcase/makedns/cases0
@@ -74,7 +74,7 @@ end
 start:makedns_ubuntu_n
 description:makedns -n
 os:ubuntu
-label:mn_only,dns
+label:mn_only,dns,wait_fix
 cmd:chtab netname=testnetwork networks.net=100.100.100.0 networks.mask=255.255.255.0 networks.mgtifname=eth0 networks.gateway=100.100.100.254
 check:rc==0
 cmd:cp /etc/hosts  /etc/hosts.testbak
@@ -141,7 +141,7 @@ end
 
 start:makedns
 description:makedns
-label:mn_only,dns
+label:mn_only,dns,wait_fix
 cmd:chtab netname=testnetwork networks.net=100.100.100.0 networks.mask=255.255.255.0 networks.mgtifname=eth0 networks.gateway=100.100.100.254
 check:rc==0
 cmd:makedns -n


### PR DESCRIPTION
Move 2 dns cases from CI test scope,

These 2 cases are not stable in CI test environment. sometime are successful and sometime are failed. so move these 2 cases out first. 