### PR TITLE
Enhancement for using site cache in plugin

### DIFF
--- a/perl-xCAT/xCAT/Client.pm
+++ b/perl-xCAT/xCAT/Client.pm
@@ -174,6 +174,7 @@ sub submit_request {
 
         # Load plugins from either specified or default dir
         require xCAT::Table;
+        populate_site_hash();
         my %cmd_handlers;
         my @plugins_dirs = split('\:', $ENV{XCATBYPASS});
         if (-d $plugins_dirs[0]) {
@@ -191,8 +192,6 @@ sub submit_request {
             $plugins_dir = $::XCATROOT . '/lib/perl/xCAT_plugin';
             scan_plugins();
         }
-
-        populate_site_hash();
 
         #  don't do XML transformation -- assume request is well-formed
         #  my $xmlreq=XMLout($request,RootName=>xcatrequest,NoAttr=>1,KeyAttr=>[]);

--- a/perl-xCAT/xCAT/Table.pm
+++ b/perl-xCAT/xCAT/Table.pm
@@ -2359,12 +2359,12 @@ sub getNodesAttribs {
         $self->{nodelist}->{_use_cache} = 1;
     }
     my $rethash;
-    my @hierarchy_attrs = ();
-    my $hierarchy_field = xCAT::TableUtils->get_site_attribute("hierarchicalattrs");
-    if ($hierarchy_field) {
-        @hierarchy_attrs = split(/,/, $hierarchy_field);
-    }
-    $options{hierarchy_attrs} = \@hierarchy_attrs;
+    #my @hierarchy_attrs = ();
+    #my $hierarchy_field = xCAT::TableUtils->get_site_attribute("hierarchicalattrs");
+    #if ($hierarchy_field) {
+    #    @hierarchy_attrs = split(/,/, $hierarchy_field);
+    #}
+    #$options{hierarchy_attrs} = \@hierarchy_attrs;
     foreach (@$nodelist) {
         my @nodeentries = $self->getNodeAttribs($_, \@realattribs, %options);
         $rethash->{$_} = \@nodeentries;    #$self->getNodeAttribs($_,\@attribs);

--- a/perl-xCAT/xCAT/TableUtils.pm
+++ b/perl-xCAT/xCAT/TableUtils.pm
@@ -1261,27 +1261,28 @@ sub getAppStatus
   get_site_attribute
 
 	Arguments:
-
+                $attribute -- the attribute you want to get
+                $dvalue    -- Optional, the default string value if the attribute does not exist
 	Returns:
 	    The value of the attribute requested from the site table
-	Globals:
-		none
-	Error:
-		undef
-	Example:
-	   @attr=xCAT::TableUtils->get_site_attribute($attribute);
-	Comments:
-		none
+        Globals:
+                %::XCATSITEVALS
+        Error:
+                undef
+        Example:
+           @attr=xCAT::TableUtils->get_site_attribute($attribute);
+        Comments:
+                none
 
 =cut
 
 #------------------------------------------------------------------------
 sub get_site_attribute
 {
-    my ($class, $attr) = @_;
+    my ($class, $attr, $dvalue) = @_;
 
     my $values;
-    if (defined($::XCATSITEVALS{$attr})) {
+    if (%::XCATSITEVALS) {
         $values = ($::XCATSITEVALS{$attr});
     } else {
         my $sitetab = xCAT::Table->new('site');
@@ -1300,7 +1301,8 @@ sub get_site_attribute
 
         }
     }
-    return $values;
+    return $values if ( defined $values);
+    return $dvalue;
 }
 
 

--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -970,6 +970,10 @@ if (defined $pid_init) {
         %cmd_handlers = %{ fd_retrieve($readpipe) };
     } else {
         $$progname = "xcatd: plugin initialization";
+        if (xCAT::Utils->isServiceNode()) {
+            # Cache the site hash to accelerate the speed of init_plugins on SN
+            populate_site_hash();
+        }
         scan_plugins($writepipe);
         exit(0);
     }


### PR DESCRIPTION
To fix the issue #5534 
- using cache from plugin when getNodesAttribs/getNodeAttribs (pass it into DB process from plugin process)
- Site cache is a whole hash, so to use cache when by the hash is there, instead of the specified key is there. So that if no key defined in `site` table, with the cache,  it does not query DB again.
-  When xcatd restarted on service node,  cache site hash before init plugins.
-  For XCATBYPASS mode,  cache site hash before init plugins.