### PR TITLE
update onie doc to add rspconfig sshcfg command

### DIFF
--- a/docs/source/advanced/networks/onie_switches/os_cumulus/install.rst
+++ b/docs/source/advanced/networks/onie_switches/os_cumulus/install.rst
@@ -86,7 +86,7 @@ To ease in the management of the switch, xCAT provides a script to help configur
 
 Execute the following to sync the xCAT keys to the switch: ::
 
-    /opt/xcat/share/xcat/scripts/configonie --switches frame01sw1 --ssh
+    rspconfig frame01sw1 sshcfg 
 
 Validate the ssh keys are correctly configured by running a ``xdsh`` command: ::
 

--- a/xCAT-server/lib/xcat/plugins/onie.pm
+++ b/xCAT-server/lib/xcat/plugins/onie.pm
@@ -107,6 +107,8 @@ sub process_request {
         my $subcmd = $exargs[0];
         if ($subcmd eq 'sshcfg') {
             process_sshcfg($nodes, $callback);
+        } else {
+            xCAT::MsgUtils->message("I", { data => ["The rspconfig command $subcmd is not supported"] }, $callback);
         }
     }
 

--- a/xCAT-server/lib/xcat/plugins/switch.pm
+++ b/xCAT-server/lib/xcat/plugins/switch.pm
@@ -420,9 +420,12 @@ sub process_switch_config {
                     xCAT::MellanoxIB::setConfig($nodes, $callback, $subreq, $subcommand, $argument);
                 }
             } else {
-                my $rsp = {};
-                $rsp->{error}->[0] = "The following '$t' switches are unsuppored:\n@$nodes";
-                $callback->($rsp);
+                #onie switch will processed in the onie plug in
+                unless ($t =~ /onie/i) {
+                    my $rsp = {};
+                    $rsp->{error}->[0] = "The following '$t' switches are not supported:\n@$nodes";
+                    $callback->($rsp);
+                }
             }
         }
     }


### PR DESCRIPTION
update onie xcat doc to use `rscpconfig sshcfg` command instead of `configonie --ssh`.
Handle Error case if subcommand other than `sshcfg`