### PR TITLE
fix osarch missing from copycds

### DIFF
--- a/xCAT-server/lib/xcat/plugins/sles.pm
+++ b/xCAT-server/lib/xcat/plugins/sles.pm
@@ -1632,7 +1632,6 @@ sub copycd
     {
         my $dinfo;
         open($dinfo, $mntpath . "/content");
-        my $darch;
         while (<$dinfo>)
         {
             if (m/^DEFAULTBASE\s+(\S+)/)


### PR DESCRIPTION
for https://github.com/xcat2/xcat-core/issues/5541

UT: the following autotest cases are passed:
```
END::reg_linux_diskfull_installation_flat::Passed::Time:Mon Aug 20 23:33:22 2018 ::Duration::1359 sec
END::copycds_iso::Passed::Time:Tue Aug 21 01:45:27 2018 ::Duration::129 sec
END::copycds_n::Passed::Time:Tue Aug 21 01:48:28 2018 ::Duration::142 sec
END::copycds_a::Passed::Time:Tue Aug 21 01:50:53 2018 ::Duration::145 sec
END::copycds_n_a::Passed::Time:Tue Aug 21 01:53:04 2018 ::Duration::131 sec
END::copycds_a_err::Passed::Time:Tue Aug 21 01:53:05 2018 ::Duration::1 sec
END::copycds_n_err::Passed::Time:Tue Aug 21 01:53:06 2018 ::Duration::1 sec
END::copycds_p::Passed::Time:Tue Aug 21 01:55:46 2018 ::Duration::160 sec
END::copycds_path::Passed::Time:Tue Aug 21 01:57:51 2018 ::Duration::125 sec
END::copycds_i::Passed::Time:Tue Aug 21 01:57:53 2018 ::Duration::2 sec
END::copycds_inspection::Passed::Time:Tue Aug 21 01:57:55 2018 ::Duration::2 sec
END::copycds_o::Passed::Time:Tue Aug 21 02:00:05 2018 ::Duration::130 sec
END::copycds_noosimage::Passed::Time:Tue Aug 21 02:02:30 2018 ::Duration::145 sec
END::copycds_w::Passed::Time:Tue Aug 21 02:04:40 2018 ::Duration::130 sec
END::copycds_w2::Passed::Time:Tue Aug 21 02:07:03 2018 ::Duration::143 sec
END::copycds_nonoverwrite::Passed::Time:Tue Aug 21 02:09:19 2018 ::Duration::136 sec
END::copycds_nonoverwrite2::Passed::Time:Tue Aug 21 02:11:45 2018 ::Duration::146 sec
END::copycds_bogus_disc::Passed::Time:Tue Aug 21 02:16:32 2018 ::Duration::4 sec
```
copycds results:
```
/ # lsdef -t osimage
sles12.3-x86_64-install-compute  (osimage)
sles12.3-x86_64-install-service  (osimage)
sles12.3-x86_64-netboot-compute  (osimage)
sles12.3-x86_64-statelite-compute  (osimage)
```