### PR TITLE
Change options from V|Verbose to V|verbose

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/chzone.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/chzone.1.rst
@@ -7,7 +7,7 @@ chzone.1
 
 
 ************
-\ **NAME**\
+\ **NAME**\ 
 ************
 
 
@@ -15,7 +15,7 @@ chzone.1
 
 
 ****************
-\ **SYNOPSIS**\
+\ **SYNOPSIS**\ 
 ****************
 
 
@@ -25,7 +25,7 @@ chzone.1
 
 
 *******************
-\ **DESCRIPTION**\
+\ **DESCRIPTION**\ 
 *******************
 
 
@@ -36,165 +36,165 @@ Note: if any zones in the zone table, there must be one and only one defaultzone
 
 
 ***************
-\ **OPTIONS**\
+\ **OPTIONS**\ 
 ***************
 
 
 
-\ **-h | -**\ **-help**\
-
+\ **-h | -**\ **-help**\ 
+ 
  Displays usage information.
+ 
 
 
-
-\ **-v | -**\ **-version**\
-
+\ **-v | -**\ **-version**\ 
+ 
  Displays command version and build date.
+ 
 
 
-
-\ **-k | -**\ **-sshkeypath**\  \ *full path to the ssh RSA private key*\
-
+\ **-k | -**\ **-sshkeypath**\  \ *full path to the ssh RSA private key*\ 
+ 
  This is the path to the id_rsa key that will be used to build new root's ssh keys for the zone. If -k is used, it will generate the ssh public key from the input ssh RSA private key, and store both in /etc/xcat/sshkeys/<zonename>/.ssh directory.
+ 
 
 
-
-\ **-K | -**\ **-genkeys**\
-
+\ **-K | -**\ **-genkeys**\ 
+ 
  Using this flag, will  generate new ssh RSA private and public keys for the zone into the /etc/xcat/sshkeys/<zonename>/.ssh directory.
  The nodes are not automatically updated with the new root ssh keys by chzone. You must run updatenode -k  or xdsh -K to the nodes to update the root ssh keys to the new generated zone keys. This will also sync any service nodes with the zone keys, if you have a hierarchical cluster.
+ 
 
 
-
-\ **-**\ **-defaultzone**\
-
+\ **-**\ **-defaultzone**\ 
+ 
  if \ **-**\ **-defaultzone**\  is input, then it will set the zone defaultzone attribute to yes.
  if \ **-**\ **-defaultzone**\  is input and another zone is currently the default,
  then the \ **-f**\  flag must be used to force a change to the new defaultzone.
  If \ **-f**\  flag is not use an error will be returned and no change made.
  Note: if any zones in the zone table, there must be one and only one defaultzone. Otherwise, errors will occur.
+ 
 
 
-
-\ **-a | -**\ **-addnoderange**\  \ *noderange*\
-
+\ **-a | -**\ **-addnoderange**\  \ *noderange*\ 
+ 
  For each node in the noderange, it will set the zonename attribute for that node to the input zonename.
  If the -g flag is also on the command, then
  it will add the group name "zonename" to each node in the noderange.
+ 
 
 
-
-\ **-r | -**\ **-rmnoderange**\  \ *noderange*\
-
+\ **-r | -**\ **-rmnoderange**\  \ *noderange*\ 
+ 
  For each node in the noderange, if the node is a member of the input zone, it will remove the zonename attribute for that node.
  If any of the nodes in the noderange is not a member of the zone, you will get an error and nothing will be changed.
  If the -g flag is also on the command, then
  it will remove the group name "zonename" from each node in the noderange.
+ 
 
 
-
-\ **-s| -**\ **-sshbetweennodes**\  \ **yes|no**\
-
+\ **-s| -**\ **-sshbetweennodes**\  \ **yes|no**\ 
+ 
  If -s entered, the zone sshbetweennodes attribute will be set to yes or no based on the input. When this is set to yes, then ssh will be setup to allow passwordless root access between nodes.  If no, then root will be prompted for a password when running ssh between the nodes in the zone.
+ 
 
 
-
-\ **-f | -**\ **-force**\
-
+\ **-f | -**\ **-force**\ 
+ 
  Used with the \ **-**\ **-defaultzone**\  flag to override the current default zone.
+ 
 
 
-
-\ **-g | -**\ **-assigngroup**\
-
+\ **-g | -**\ **-assigngroup**\ 
+ 
  Used with the \ **-a**\  or \ **-r**\  flag to add or remove the group zonename for all nodes in the input noderange.
+ 
 
 
-
-\ **-V | -**\ **-Verbose**\
-
+\ **-V | -**\ **-verbose**\ 
+ 
  Verbose mode.
-
+ 
 
 
 
 ****************
-\ **EXAMPLES**\
+\ **EXAMPLES**\ 
 ****************
 
 
 
 1. To chzone zone1 to the default zone, enter:
-
-
+ 
+ 
  .. code-block:: perl
-
+ 
    chzone> zone1 --default -f
-
-
+ 
+ 
 
 
 2. To generate new root ssh keys for zone2A using the ssh id_rsa private key in /root/.ssh:
-
-
+ 
+ 
  .. code-block:: perl
-
+ 
    chzone zone2A -k /root/.ssh
-
-
+ 
+ 
  Note: you must use xdsh -K or updatenode -k to update the nodes with the new keys
-
+ 
 
 
 3. To generate new root ssh keys for zone2A, enter :
-
-
+ 
+ 
  .. code-block:: perl
-
+ 
    chzone zone2A -K
-
-
+ 
+ 
  Note: you must use xdsh -K or updatenode -k to update the nodes with the new keys
-
+ 
 
 
 4. To add a new group of nodes (compute3) to zone3 and add zone3 group to the nodes,  enter:
-
-
+ 
+ 
  .. code-block:: perl
-
+ 
    chzone zone3 -a compute3 -g
-
-
+ 
+ 
 
 
 5.
-
+ 
  To remove a group of nodes (compute4) from zone4 and remove zone4 group from the nodes,  enter:
-
-
+ 
+ 
  .. code-block:: perl
-
+ 
    chzone> zone4 -r compute4 -g
-
-
+ 
+ 
 
 
 6. To change the sshbetweennodes setting on the zone to not allow passwordless ssh between nodes,  enter:
-
-
+ 
+ 
  .. code-block:: perl
-
+ 
    chzone zone5 -s no
-
-
+ 
+ 
  Note: you must use \ **xdsh -K**\  or \ **updatenode -k**\  to update the nodes with this new setting.
-
+ 
 
 
 
 *************
-\ **FILES**\
+\ **FILES**\ 
 *************
 
 
@@ -204,7 +204,7 @@ Location of the chzone command.
 
 
 ****************
-\ **SEE ALSO**\
+\ **SEE ALSO**\ 
 ****************
 
 

--- a/docs/source/guides/admin-guides/references/man1/mkzone.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/mkzone.1.rst
@@ -7,7 +7,7 @@ mkzone.1
 
 
 ************
-\ **NAME**\
+\ **NAME**\ 
 ************
 
 
@@ -15,7 +15,7 @@ mkzone.1
 
 
 ****************
-\ **SYNOPSIS**\
+\ **SYNOPSIS**\ 
 ****************
 
 
@@ -25,7 +25,7 @@ mkzone.1
 
 
 *******************
-\ **DESCRIPTION**\
+\ **DESCRIPTION**\ 
 *******************
 
 
@@ -36,151 +36,151 @@ Note: if any zones in the zone table, there must be one and only one defaultzone
 
 
 ***************
-\ **OPTIONS**\
+\ **OPTIONS**\ 
 ***************
 
 
 
-\ **-h | -**\ **-help**\
-
+\ **-h | -**\ **-help**\ 
+ 
  Displays usage information.
+ 
 
 
-
-\ **-v | -**\ **-version**\
-
+\ **-v | -**\ **-version**\ 
+ 
  Displays command version and build date.
+ 
 
 
-
-\ **-k | -**\ **-sshkeypath**\  \ *full path to the ssh RSA private key*\
-
+\ **-k | -**\ **-sshkeypath**\  \ *full path to the ssh RSA private key*\ 
+ 
  This is the path to the id_rsa key that will be used to build root's ssh keys for the zone. If -k is used, it will generate the ssh public key from the input ssh RSA private key and store both in /etc/xcat/sshkeys/<zonename>/.ssh directory.
  If -f is not used,  then it will generate a set of root ssh keys for the zone and store them in /etc/xcat/sshkeys/<zonename>/.ssh.
+ 
 
 
-
-\ **-**\ **-default**\
-
+\ **-**\ **-default**\ 
+ 
  if --defaultzone is input, then it will set the zone defaultzone attribute to yes; otherwise it will set to no.
  if --defaultzone is input and another zone is currently the default,
  then the -f flag must be used to force a change to the new defaultzone.
  If -f flag is not use an error will be returned and no change made.
  Note: if any zones in the zone table, there must be one and only one defaultzone. Otherwise, errors will occur.
+ 
 
 
-
-\ **-a | -**\ **-addnoderange**\  \ *noderange*\
-
+\ **-a | -**\ **-addnoderange**\  \ *noderange*\ 
+ 
  For each node in the noderange, it will set the zonename attribute for that node to the input zonename.
  If the -g flag is also on the command, then
  it will add the group name "zonename" to each node in the noderange.
+ 
 
 
-
-\ **-s| -**\ **-sshbetweennodes**\  \ **yes|no**\
-
+\ **-s| -**\ **-sshbetweennodes**\  \ **yes|no**\ 
+ 
  If -s entered, the zone sshbetweennodes attribute will be set to yes or no. It defaults to yes. When this is set to yes, then ssh will be setup
  to allow passwordless root access between nodes.  If no, then root will be prompted for a password when running ssh between the nodes in the zone.
+ 
 
 
-
-\ **-f | -**\ **-force**\
-
+\ **-f | -**\ **-force**\ 
+ 
  Used with the (--defaultzone) flag to override the current default zone.
+ 
 
 
-
-\ **-g | -**\ **-assigngroup**\
-
+\ **-g | -**\ **-assigngroup**\ 
+ 
  Used with the (-a) flag to create the group zonename for all nodes in the input noderange.
+ 
 
 
-
-\ **-V | -**\ **-Verbose**\
-
+\ **-V | -**\ **-verbose**\ 
+ 
  Verbose mode.
-
+ 
 
 
 
 ****************
-\ **EXAMPLES**\
+\ **EXAMPLES**\ 
 ****************
 
 
 
 1. To make a new zone1 using defaults, enter:
-
-
+ 
+ 
  .. code-block:: perl
-
+ 
    mkzone zone1
-
-
+ 
+ 
  Note: with the first \ **mkzone**\ , you will automatically get the xcatdefault zone created as the default zone.  This zone uses ssh keys from <roothome>/.ssh directory.
-
+ 
 
 
 2. To make a new zone2 using defaults and make it the default zone enter:
-
-
+ 
+ 
  .. code-block:: perl
-
+ 
    mkzone> zone2 --defaultzone -f
-
-
+ 
+ 
 
 
 3.
-
+ 
  To make a new zone2A using the ssh id_rsa private key in /root/.ssh:
-
-
+ 
+ 
  .. code-block:: perl
-
+ 
    mkzone zone2A -k /root/.ssh
-
-
+ 
+ 
 
 
 4.
-
+ 
  To make a new zone3 and assign the noderange compute3 to the zone  enter:
-
-
+ 
+ 
  .. code-block:: perl
-
+ 
    mkzone zone3 -a compute3
-
-
+ 
+ 
 
 
 5. To make a new zone4 and assign the noderange compute4 to the zone and add zone4 as a group to each node  enter:
-
-
+ 
+ 
  .. code-block:: perl
-
+ 
    mkzone zone4 -a compute4 -g
-
-
+ 
+ 
 
 
 6.
-
+ 
  To make a new zone5 and assign the noderange compute5 to the zone and add zone5 as a group to each node but not allow passwordless ssh between the nodes  enter:
-
-
+ 
+ 
  .. code-block:: perl
-
+ 
    mkzone zone5 -a compute5 -g -s no
-
-
+ 
+ 
 
 
 
 *************
-\ **Files**\
+\ **Files**\ 
 *************
 
 
@@ -190,7 +190,7 @@ Location of the mkzone command.
 
 
 ****************
-\ **SEE ALSO**\
+\ **SEE ALSO**\ 
 ****************
 
 

--- a/docs/source/guides/admin-guides/references/man1/rmzone.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rmzone.1.rst
@@ -7,7 +7,7 @@ rmzone.1
 
 
 ************
-\ **NAME**\
+\ **NAME**\ 
 ************
 
 
@@ -15,7 +15,7 @@ rmzone.1
 
 
 ****************
-\ **SYNOPSIS**\
+\ **SYNOPSIS**\ 
 ****************
 
 
@@ -25,7 +25,7 @@ rmzone.1
 
 
 *******************
-\ **DESCRIPTION**\
+\ **DESCRIPTION**\ 
 *******************
 
 
@@ -38,92 +38,92 @@ Note: if any zones in the zone table, there must be one and only one defaultzone
 
 
 ***************
-\ **OPTIONS**\
+\ **OPTIONS**\ 
 ***************
 
 
 
-\ **-h | -**\ **-help**\
-
+\ **-h | -**\ **-help**\ 
+ 
  Displays usage information.
+ 
 
 
-
-\ **-v | -**\ **-version**\
-
+\ **-v | -**\ **-version**\ 
+ 
  Displays command version and build date.
+ 
 
 
-
-\ **-f | -**\ **-force**\
-
+\ **-f | -**\ **-force**\ 
+ 
  Used to remove a zone that is defined as current default zone.  This should only be done if you are removing all zones, or you will
  adding a new zone or changing an existing zone to be the default zone.
+ 
 
 
-
-\ **-g | -**\ **-assigngroup**\
-
+\ **-g | -**\ **-assigngroup**\ 
+ 
  Remove the assigned group named \ **zonename**\  from all nodes assigned to the zone being removed.
+ 
 
 
-
-\ **-V | -**\ **-Verbose**\
-
+\ **-V | -**\ **-verbose**\ 
+ 
  Verbose mode.
-
+ 
 
 
 
 ****************
-\ **Examples**\
+\ **Examples**\ 
 ****************
 
 
 
 1. To remove zone1 from the zone table and the zonename attribute on all it's assigned nodes , enter:
-
-
+ 
+ 
  .. code-block:: perl
-
+ 
    rmzone zone1
-
-
+ 
+ 
 
 
 2.
-
+ 
  To remove zone2 from the zone table, the zone2 zonename attribute, and the zone2 group assigned to all nodes that were in zone2, enter:
-
-
+ 
+ 
  .. code-block:: perl
-
+ 
    rmzone zone2 -g
-
-
+ 
+ 
 
 
 3.
-
+ 
  To remove zone3 from the zone table, all the node zone attributes and  override the fact it is the defaultzone,  enter:
-
-
+ 
+ 
  .. code-block:: perl
-
+ 
    rmzone zone3 -g -f
+ 
+ 
 
 
+\ **Files**\ 
 
-
-\ **Files**\
-
-\ **/opt/xcat/bin/rmzone/**\
+\ **/opt/xcat/bin/rmzone/**\ 
 
 Location of the rmzone command.
 
 
 ****************
-\ **SEE ALSO**\
+\ **SEE ALSO**\ 
 ****************
 
 

--- a/docs/source/guides/admin-guides/references/man1/sinv.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/sinv.1.rst
@@ -7,7 +7,7 @@ sinv.1
 
 
 ************
-\ **NAME**\
+\ **NAME**\ 
 ************
 
 
@@ -15,7 +15,7 @@ sinv.1
 
 
 ****************
-\ **SYNOPSIS**\
+\ **SYNOPSIS**\ 
 ****************
 
 
@@ -25,7 +25,7 @@ sinv.1
 
 
 *******************
-\ **DESCRIPTION**\
+\ **DESCRIPTION**\ 
 *******************
 
 
@@ -67,45 +67,45 @@ Command Protocol can be used. See man \ **xdsh**\  for more details.
 
 
 ***************
-\ **OPTIONS**\
+\ **OPTIONS**\ 
 ***************
 
 
 
-\ **-o | -**\ **-output**\  \ *report output file*\
-
+\ **-o | -**\ **-output**\  \ *report output file*\ 
+ 
  Optional output file. This is the location of the file that will contain the report of the nodes that match, and do not match, the input templates. If the flag is not used, the output will go to stdout.
+ 
 
 
-
-\ **-p | -**\ **-tp**\  \ *template path*\
-
+\ **-p | -**\ **-tp**\  \ *template path*\ 
+ 
  This is the path to the template file. The template contains the output
  of \ **xdsh**\  or \ **rinv**\  command, that has been run against a "seed" node, a node
  that contains the configuration that you would like all nodes in your noderange to match.
-
+ 
  The admin can create the template by running the \ **xdsh**\  or \ **rinv**\  command on
  the seed node, pipe to \ **xdshcoll**\  (required) and store the output
  in the template path. See examples.
-
+ 
  \ **Note:**\  The admin can also edit the template to remove any lines that they do not want checked.
-
+ 
  An alternative method is to use the [\ **-s**\  \ *seed node*\ ] parameter,
  which will automatically build the template for you from the
  seed node named.
-
+ 
  If a a seed node is not provided, then command will automatically use the first node in the noderange as
  the seed node.
+ 
 
 
-
-\ **-t | -**\ **-tc**\  \ *template count*\
-
+\ **-t | -**\ **-tc**\  \ *template count*\ 
+ 
  This count is the number of templates that the command will use
  to check for nodes matches.  If the template in the template path does not
  match a node, the \ **sinv**\  will check additional templates up
  to the template count.
-
+ 
  For each node, it will compare the node against each template to see if
  there is a match.
  If there is no match, and we are not over the template count,
@@ -114,256 +114,256 @@ Command Protocol can be used. See man \ **xdsh**\  for more details.
  their group at the end of the run in the output file.
  If no template count is specified, 0 is the default, and all nodes will
  be compared against the first template.
+ 
 
 
-
-\ **-s | -**\ **-seed**\  \ *seed node*\
-
+\ **-s | -**\ **-seed**\  \ *seed node*\ 
+ 
  This is the node that will be used to build the first template
  that is stored in template path.  You can use this parameter instead of running
  the command yourself to build the template.
-
+ 
  \ **Note:**\  If no seed node is supplied, the first node in the noderange is automatically
  selected as a seed node.
+ 
 
 
-
-\ **-i | -**\ **-ignorefirst**\
-
+\ **-i | -**\ **-ignorefirst**\ 
+ 
  This flag suppresses the reporting of the nodes matching the first
  template. In very large systems, you may not want to show the nodes that
  have the correct configuration, since the list could contain thousands of nodes.
  This allows you to only report the nodes that do not match the required
  configuration.
+ 
 
 
-
-\ **-e | -**\ **-exactmatch**\
-
+\ **-e | -**\ **-exactmatch**\ 
+ 
  This requires the check of node output against template to be an exact match.
  If this flag is not set, \ **sinv**\  checks to see if the return from the
  \ **xdsh**\  or \ **rinv**\  command to the nodes contain a match for each line in the input
  template (except for xdshcoll header and comments). If not in exactmatch mode,
  there can be more lines in the \ **xdsh**\  or \ **rinv**\  return from the nodes.
-
+ 
  For example, if running a "rpm -qa | grep xCAT" command, without exactmatch
  set, if the node contains more xCAT rpms that listed in the template,
  it would be considered a match, as long as all rpms listed in the template
  were on the node. With exactmatch set, the output must be identical
  to the template.
+ 
 
 
-
-\ **-**\ **-devicetype**\  \ *type_of_device*\
-
+\ **-**\ **-devicetype**\  \ *type_of_device*\ 
+ 
  Specify a user-defined device type that references the location
  of relevant device configuration file. The devicetype value must
  correspond to a valid device configuration file.
  xCAT ships some default configuration files
  for Ethernet switches and IB switches under
  \ */opt/xcat/share/xcat/devicetype*\  directory. If you want to overwrite
- any of the configuration files, copy them to \ */var/opt/xcat/*\
+ any of the configuration files, copy them to \ */var/opt/xcat/*\ 
  directory and cutomize.
  For example, \ *base/IBSwitch/Qlogic/config*\  is the configuration
  file location if devicetype is specified as IBSwitch::Qlogic.
  xCAT will first search config file using \ */var/opt/xcat/*\  as the base.
  If not found, it will search for it using
  \ */opt/xcat/share/xcat/devicetype/*\  as the base.
+ 
 
 
-
-\ **-l | -**\ **-user**\  \ *user_ID*\
-
+\ **-l | -**\ **-user**\  \ *user_ID*\ 
+ 
  Specifies a remote user name to use for remote command execution.
+ 
 
 
-
-\ **-c | -**\ **-command**\
-
+\ **-c | -**\ **-command**\ 
+ 
  The \ **xdsh**\  or \ **rinv**\  command that will be run. The command should be enclosed in
  double quotes to insure correct shell interpretation. This parameter must only contain, the node range or the image path (Linux) or spot name for AIX. It cannot be used to set additional input flags to \ **xdsh**\  or \ **rinv**\  (for example \ **-s**\ ,\ **-T**\ ,\ **-e**\ ).  See examples below.
-
+ 
  \ **Note:**\  do not add the \ **| xdshcoll**\  to the command,
  it is automatically added by \ **sinv**\ .  \ **sinv**\  also automatically sets the \ **-v**\  flag for \ **xdsh**\ .
+ 
 
 
-
-\ **-f | -**\ **-file**\
-
+\ **-f | -**\ **-file**\ 
+ 
  The file containing the \ **xdsh**\  or \ **rinv**\  command that will be run.
  This should be the fully qualified name of the file.
-
+ 
  \ **Note:**\  do not add the \ **| xdshcoll**\  to the command in the file,
  it is automatically added by \ **sinv**\ .
+ 
 
 
-
-\ **-r | -**\ **-remove**\
-
+\ **-r | -**\ **-remove**\ 
+ 
  This flag indicates that generated templates should be removed at the
  at the end of the \ **sinv**\  command execution.
-
- If the flag is specified, then all templates that are generated by the \ **sinv**\
+ 
+ If the flag is specified, then all templates that are generated by the \ **sinv**\ 
  command, will be removed. If the first template is created by the admin,
  it will not be removed.
-
+ 
  If the flag is not specified, no
  templates will be removed. It is up to the admin to cleanup templates.
+ 
 
 
-
-\ **-h | -**\ **-help**\
-
+\ **-h | -**\ **-help**\ 
+ 
  Displays usage information.
+ 
 
 
-
-\ **-v | -**\ **-version**\
-
+\ **-v | -**\ **-version**\ 
+ 
  Displays xCAT release version.
+ 
 
 
-
-\ **-V | -**\ **-Verbose**\
-
+\ **-V | -**\ **-verbose**\ 
+ 
  Verbose mode.
-
+ 
 
 
 
 ****************
-\ **Examples**\
+\ **Examples**\ 
 ****************
 
 
 
 1. To setup sinv.template (name optional) for input to the \ **sinv**\  command, enter:
-
-
+ 
+ 
  .. code-block:: perl
-
+ 
    xdsh node1,node2 "rpm -qa | grep ssh " | xdshcoll  > /tmp/sinv.template
-
-
+ 
+ 
  Note: when setting up the template the output of \ **xdsh**\  must be piped to \ **xdshcoll**\ , \ **sinv**\  processing depends on it.
-
+ 
 
 
 2. To setup rinv.template for input to the \ **sinv**\  command , enter:
-
-
+ 
+ 
  .. code-block:: perl
-
+ 
    rinv node1-node2 serial | xdshcoll  > /tmp/rinv.template
-
-
+ 
+ 
  Note: when setting up the template the output of \ **rinv**\  must be piped to \ **xdshcoll**\ , \ **sinv**\  processing depends on it.
-
+ 
 
 
 3. To execute \ **sinv**\  using the sinv.template generated above
 on the nodegroup, \ *testnodes*\  ,possibly generating up to two
 new templates, and removing all generated templates in the end, and writing
 output report to /tmp/sinv.output, enter:
-
-
+ 
+ 
  .. code-block:: perl
-
+ 
    sinv -c "xdsh testnodes rpm -qa | grep ssh" -p /tmp/sinv.template -t 2 -r -o /tmp/sinv.output
-
-
+ 
+ 
  Note: do not add the pipe to \ **xdshcoll**\  on the \ **-c**\  flag, it is automatically added by the \ **sinv**\ .
-
+ 
 
 
 4. To execute \ **sinv**\  on noderange, \ *node1-node4*\ , using the seed node, \ *node8*\ ,
 to generate the first template, using the \ **xdsh**\  command (\ **-c**\ ),
 possibly generating up to two additional
 templates and not removing any templates at the end, enter:
-
-
+ 
+ 
  .. code-block:: perl
-
+ 
    sinv -c "xdsh node1-node4 lslpp -l | grep bos.adt" -s node8 -p /tmp/sinv.template -t 2 -o /tmp/sinv.output
-
-
+ 
+ 
 
 
 5. To execute \ **sinv**\  on noderange, \ *node1-node4*\ , using the seed node, \ *node8*\ ,
 to generate the first template, using the \ **rinv**\  command (\ **-c**\ ),
 possibly generating up to two additional
 templates and removing any generated templates at the end, enter:
-
-
+ 
+ 
  .. code-block:: perl
-
+ 
    sinv -c "rinv node1-node4 serial" -s node8 -p /tmp/sinv.template -t 2 -r -o /tmp/rinv.output
-
-
+ 
+ 
 
 
 6. To execute \ **sinv**\  on noderange, \ *node1-node4*\ , using \ *node1*\  as
 the seed node, to generate the sinv.template from the \ **xdsh**\  command (\ **-c**\ ),
 using the exact match option, generating no additional templates, enter:
-
-
+ 
+ 
  .. code-block:: perl
-
+ 
    sinv -c "xdsh node1-node4 lslpp -l | grep bos.adt" -s node1 -e -p /tmp/sinv.template  -o /tmp/sinv.output
-
-
+ 
+ 
  Note: the /tmp/sinv.template file must be empty, otherwise it will be used
  as an admin generated template.
-
+ 
 
 
 7. To execute \ **sinv**\  on the Linux osimage defined for cn1.  First build a template from the /etc/hosts on the node. Then run \ **sinv**\  to compare.
-
-
+ 
+ 
  .. code-block:: perl
-
+ 
    xdsh cn1 "cat /etc/hosts" | xdshcoll > /tmp/sinv2/template"
-
+  
    sinv -c "xdsh -i /install/netboot/rhels6/ppc64/test_ramdisk_statelite/rootimg cat /etc/hosts" -e -t 1 -p /tmp/sinv.template -o /tmp/sinv.output
-
-
+ 
+ 
 
 
 8.
-
+ 
  To execute \ **sinv**\  on the AIX NIM 611dskls spot and compare /etc/hosts to compute1 node, run the following:
-
-
+ 
+ 
  .. code-block:: perl
-
+ 
    xdsh compute1 "cat /etc/hosts" | xdshcoll > /tmp/sinv2/template"
-
+  
    sinv -c "xdsh -i 611dskls cat /etc/hosts" -e -t1 -p /tmp/sinv.template -o /tmp/sinv.output
-
-
+ 
+ 
 
 
 9.
-
+ 
  To execute \ **sinv**\  on the device mswitch2 and compare to mswitch1
-
-
+ 
+ 
  .. code-block:: perl
-
+ 
    sinv -c "xdsh mswitch  enable;show version" -s mswitch1 -p /tmp/sinv/template --devicetype IBSwitch::Mellanox -l admin -t 2
+ 
+ 
 
 
+\ **Files**\ 
 
-
-\ **Files**\
-
-\ **/opt/xcat/bin/sinv/**\
+\ **/opt/xcat/bin/sinv/**\ 
 
 Location of the sinv command.
 
 
 ****************
-\ **SEE ALSO**\
+\ **SEE ALSO**\ 
 ****************
 
 

--- a/perl-xCAT/xCAT/PPClog.pm
+++ b/perl-xCAT/xCAT/PPClog.pm
@@ -40,7 +40,7 @@ sub parse_args {
     $Getopt::Long::ignorecase = 0;
     Getopt::Long::Configure("bundling");
 
-    if (!GetOptions(\%opt, qw(V|Verbose))) {
+    if (!GetOptions(\%opt, qw(V|verbose))) {
         return (usage());
     }
     ####################################

--- a/perl-xCAT/xCAT/SINV.pm
+++ b/perl-xCAT/xCAT/SINV.pm
@@ -118,7 +118,7 @@ sub parse_and_run_sinv
             'c|cmd=s'                 => \$options{'sinv_cmd'},
             'f|file=s'                => \$options{'sinv_cmd_file'},
             'v|version'               => \$options{'version'},
-            'V|Verbose'               => \$options{'verbose'},
+            'V|verbose'               => \$options{'verbose'},
         )
       )
     {

--- a/xCAT-client/pods/man1/chzone.1.pod
+++ b/xCAT-client/pods/man1/chzone.1.pod
@@ -71,7 +71,7 @@ Used with the B<--defaultzone> flag to override the current default zone.
 
 Used with the B<-a> or B<-r> flag to add or remove the group zonename for all nodes in the input noderange.
 
-=item B<-V>|B<--Verbose>
+=item B<-V>|B<--verbose>
 
 Verbose mode.
 

--- a/xCAT-client/pods/man1/mkzone.1.pod
+++ b/xCAT-client/pods/man1/mkzone.1.pod
@@ -59,7 +59,7 @@ Used with the (--defaultzone) flag to override the current default zone.
 
 Used with the (-a) flag to create the group zonename for all nodes in the input noderange.
 
-=item B<-V>|B<--Verbose>
+=item B<-V>|B<--verbose>
 
 Verbose mode.
 

--- a/xCAT-client/pods/man1/rmzone.1.pod
+++ b/xCAT-client/pods/man1/rmzone.1.pod
@@ -40,7 +40,7 @@ adding a new zone or changing an existing zone to be the default zone.
 
 Remove the assigned group named B<zonename> from all nodes assigned to the zone being removed.
 
-=item B<-V>|B<--Verbose>
+=item B<-V>|B<--verbose>
 
 Verbose mode.
 

--- a/xCAT-client/pods/man1/sinv.1.pod
+++ b/xCAT-client/pods/man1/sinv.1.pod
@@ -182,7 +182,7 @@ Displays usage information.
 
 Displays xCAT release version.
 
-=item B<-V>|B<--Verbose>
+=item B<-V>|B<--verbose>
 
 Verbose mode.
 

--- a/xCAT-server/lib/xcat/plugins/docker.pm
+++ b/xCAT-server/lib/xcat/plugins/docker.pm
@@ -647,7 +647,7 @@ sub parse_args {
     # Process command-line flags
     #############################################
     if (!GetOptions(\%opt,
-            qw(h|help V|Verbose v|version))) {
+            qw(h|help V|verbose v|version))) {
         return (usage());
     }
 

--- a/xCAT-server/lib/xcat/plugins/hpblade.pm
+++ b/xCAT-server/lib/xcat/plugins/hpblade.pm
@@ -1468,7 +1468,7 @@ sub rscan {
         return (join('', ($_[0], $usage_string)));
     };
 
-    if (!GetOptions(\%opt, qw(V|Verbose w x z))) {
+    if (!GetOptions(\%opt, qw(V|verbose w x z))) {
         return (1, usage());
     }
     if (defined($ARGV[0])) {

--- a/xCAT-server/lib/xcat/plugins/lsslp.pm
+++ b/xCAT-server/lib/xcat/plugins/lsslp.pm
@@ -283,7 +283,7 @@ sub parse_args {
     # Process command-line flags
     #############################################
     if (!GetOptions(\%opt,
-            qw(h|help V|Verbose v|version i=s x z w r s=s e=s t=s m c n C=s T=s I u range=s flexdiscover updatehosts vpdtable))) {
+            qw(h|help V|verbose v|version i=s x z w r s=s e=s t=s m c n C=s T=s I u range=s flexdiscover updatehosts vpdtable))) {
         return (usage());
     }
 

--- a/xCAT-server/lib/xcat/plugins/makentp.pm
+++ b/xCAT-server/lib/xcat/plugins/makentp.pm
@@ -129,7 +129,7 @@ sub parse_args {
 
     # Process command-line flags
     if (!GetOptions(\%opt,
-            qw(h|help V|Verbose v|version a|all))) {
+            qw(h|help V|verbose v|version a|all))) {
         return (usage());
     }
 

--- a/xCAT-server/lib/xcat/plugins/rescanplugins.pm
+++ b/xCAT-server/lib/xcat/plugins/rescanplugins.pm
@@ -76,7 +76,7 @@ sub preprocess_request
             'h|help'         => \$options{'help'},
             's|servicenodes' => \$options{'servicenodes'},
             'v|version'      => \$options{'version'},
-            'V|Verbose'      => \$options{'verbose'}
+            'V|verbose'      => \$options{'verbose'}
         )
       )
     {

--- a/xCAT-server/lib/xcat/plugins/xCATWorld.pm
+++ b/xCAT-server/lib/xcat/plugins/xCATWorld.pm
@@ -120,7 +120,7 @@ sub process_request
         !GetOptions(
             'h|help'    => \$options{'help'},
             'v|version' => \$options{'version'},
-            'V|Verbose' => \$options{'verbose'}
+            'V|verbose' => \$options{'verbose'}
         )
       )
     {

--- a/xCAT-server/lib/xcat/plugins/zone.pm
+++ b/xCAT-server/lib/xcat/plugins/zone.pm
@@ -127,7 +127,7 @@ sub process_request
             'K|genkeys'               => \$options{'gensshkeys'},
             's|sshbetweennodes=s'     => \$options{'sshbetweennodes'},
             'v|version'               => \$options{'version'},
-            'V|Verbose'               => \$options{'verbose'},
+            'V|verbose'               => \$options{'verbose'},
         )
       )
     {


### PR DESCRIPTION
for issue #5407 

````
[root@boston02 ~]# makentp --Verbose
 Usage: makentp [-h|--help|-v|--version]
       makentp [-a|--all] [-V|--verbose]
[root@boston02 ~]# makentp --verbose
[boston02]: configuring management node: boston02.pok.stglabs.ibm.com.
[boston02]: Will configure chronyd instead.
[boston02]: Calling ... /install/postscripts/setupntp 10.0.0.101
[boston02]: Daemon chronyd configured.
````