### PR TITLE
capture retrieve_fd fatal error, log the underlie message

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -8239,7 +8239,13 @@ sub loadsdrcache {
     if (!open($fh, "<$file")) {
         return (1);
     }
-    $r = retrieve_fd($fh);
+    eval {
+        $r = retrieve_fd($fh);
+    }
+    if($@){
+        xCAT::MsgUtils->message("S", "loadsdrcache: Fatal error while retrieving data from $file, $@");
+        return 1;
+    }
     unless ($r) { close($fh); return 1; }
     unless ($r->{xcat_sdrcacheversion} and $r->{xcat_sdrcacheversion} == $cache_version) { close($fh); return 1; } #version mismatch
 


### PR DESCRIPTION
fix https://github.com/xcat2/xcat-core/issues/5556:
```
[root@mgmt1][~]# rinv node-xxx firm
Error: ipmi plugin bug, pid 100016, process description: 'xcatd SSL: rinv to node-xxx for root@localhost.localdomain: ipmi instance' with error 'Magic number checking on storable file failed at /usr/lib64/perl5/vendor_perl/Storable.pm line 399, at /opt/xcat/lib/perl/xCAT_plugin/ipmi.pm line 8216.
' while trying to fulfill request for the following nodes: node-xxx
```

