### PR TITLE
fix issue 5548, if ip source is dhcp will remind that could not set ntpservers

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
@@ -334,6 +334,9 @@ rmdir \"/tmp/$userid\" \n")
         if not nic:
             return self.callback.error('Can not get facing NIC for %s' % bmcip, node)
 
+        if (netinfo[nic]['ipsrc'] == 'DHCP'):
+            return self.callback.error('BMC IP source is DHCP, could not set NTPServers', node)
+
         try:
             obmc.set_ntp_servers(nic, servers)
             self.callback.info('%s: BMC Setting NTPServers...' % node)

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -3532,6 +3532,11 @@ sub rspconfig_response {
                 if (defined($content{Address}) and $content{Address}) {
                     if ($content{Address} eq $node_info{$node}{bmcip} and $node_info{$node}{cur_status} eq "RSPCONFIG_GET_NIC_RESPONSE") {
                         $status_info{RSPCONFIG_SET_NTPSERVERS_REQUEST}{init_url} =~ s/#NIC#/$nic/g;
+                        if (defined($content{Origin}) and $content{Origin} =~ /DHCP$/) {
+                            xCAT::SvrUtils::sendmsg([1, "BMC IP source is DHCP, could not set NTPServers"], $callback, $node);
+                            $wait_node_num--;
+                            return;
+                        }
                         if ($next_status{"RSPCONFIG_GET_NIC_RESPONSE"}) {
                             $node_info{$node}{cur_status} = $next_status{"RSPCONFIG_GET_NIC_RESPONSE"};
                             gen_send_request($node);


### PR DESCRIPTION
#5548 

If target BMC with DHCP IP, print out msg ``BMC IP source is DHCP, could not set NTPServers``

Python:
```
# rspconfig f6u13 ntpservers=
Mon Aug 27 03:37:49 2018 f6u13: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.6.13.100/login -d '{"data": ["root", "xxxxxx"]}'
Mon Aug 27 03:37:49 2018 f6u13: [openbmc_debug] login 200 OK
Mon Aug 27 03:37:49 2018 f6u13: [openbmc_debug] get_netinfo curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://10.6.13.100/xyz/openbmc_project/network/enumerate
Mon Aug 27 03:37:50 2018 f6u13: [openbmc_debug] get_netinfo 200 OK
Mon Aug 27 03:37:50 2018 f6u13: [openbmc_debug] get_netinfo Found LinkLocal address 169.254.176.157 for interface /xyz/openbmc_project/network/eth0, Ignoring...
f6u13: [c910f03c17k21]: Error: BMC IP source is DHCP, could not set NTPServers
```
Perl:
```
# rspconfig f6u13 ntpservers=
Mon Aug 27 03:34:24 2018 OpenBMC: [openbmc_debug_perl]
Mon Aug 27 03:34:24 2018 f6u13: [openbmc_debug_perl] curl -k -c cjar -H "Content-Type: application/json" -d '{ "data": ["root", "xxxxxx"] }' https://10.6.13.100/login
Mon Aug 27 03:34:24 2018 f6u13: [openbmc_debug_perl] login_response 200 OK
Mon Aug 27 03:34:24 2018 f6u13: [openbmc_debug_perl] curl -k -b cjar -X GET -H "Content-Type: application/json" https://10.6.13.100/xyz/openbmc_project/network/enumerate
Mon Aug 27 03:34:25 2018 f6u13: [openbmc_debug_perl] rspconfig_get_nic_response 200 OK
f6u13: [c910f03c17k21]: Error: BMC IP source is DHCP, could not set NTPServers
```