### PR TITLE
enhance statelite persistent dir mount options for rh7.6

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/xcat-prepivot.sh
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/xcat-prepivot.sh
@@ -52,7 +52,7 @@ if [ ! -z $SNAPSHOTSERVER ]; then
     MAXTRIES=5
     ITER=0
     if [ -z $MNTOPTS ]; then
-        MNT_OPTIONS="nolock,rsize=32768,tcp,nfsvers=3,timeo=14"
+        MNT_OPTIONS="nolock,rsize=32768,tcp,timeo=14"
     else
         MNT_OPTIONS=$MNTOPTS
     fi


### PR DESCRIPTION
Fix https://github.com/xcat2/xcat-core/issues/5558

After this fix:
This nfsvers options is for  statelite persistent files in `statelite` table.
1. If there are no mount options in `statelite` table, the persistent files default mount options are "nolock,rsize=32768,tcp,timeo=14";
2. If there are mount options in `statelite` table, use the specific value.
3. If there is no mount option in `statelite` table, the nfserver version is different with the nfsclient version, we recommend add correct nfserver nfsvers for `mntopts` in `statelite` table.