### PR TITLE
Only update switch/port information for mtms based discovery

### DIFF
--- a/xCAT-server/lib/xcat/plugins/nodediscover.pm
+++ b/xCAT-server/lib/xcat/plugins/nodediscover.pm
@@ -414,6 +414,17 @@ sub process_request {
         # search the management nic and record the switch informaiton
         foreach my $nic (@{ $request->{nic} }) {
             if (defined($nic->{'hwaddr'}) && $nic->{'hwaddr'}->[0] =~ /$firstmac/i) {
+                if (defined($nic->{'switchname'}) && defined($nic->{'switchport'})) {
+                    # update the switch table
+                    my $switchtab = xCAT::Table->new('switch');
+                    if ($switchtab) {
+                        $switchtab->setNodeAttribs($node, { switch => $nic->{'switchname'}->[0], port => $nic->{'switchport'}->[0] });
+                        $switchtab->close();
+                    }
+
+                }
+                next;
+                # Don't create switch definition in nodelist, hosts, switches table
                 if (defined($nic->{'switchname'}) && defined($nic->{'switchaddr'})) {
 
                     # update the switch to switches table


### PR DESCRIPTION
When doing mtms based nodediscovery, the data will be like this before fix:
```
# for TAB in `echo "nodelist hosts switches switch"`; do echo "Checking table:$TAB for switch: mid01tor01"; tabdump $TAB |grep mid01tor01; done
Checking table:nodelist for switch: mid01tor01
"mid01tor01cn01","all,firestone,p8le","shell","08-30-2018 01:29:44",,,,,,,,,
"mid01tor01.mycluster.com","all,switch",,,,,,,,,,,
Checking table:hosts for switch: mid21tor01
"mid01tor01.mycluster.com","192.168.1.1",,,,
Checking table:switches for switch: mid01tor01
"mid01tor01.mycluster.com",,,,,,,,,,,"Cumulus Linux version 3.4.1 running on accton as4610_54",
Checking table:switch for switch: mid01tor01
"mid01tor01cn01","mid01tor01.mycluster.com","swp1",,,,
```

With fix, only switch table is updated:
```
# for TAB in `echo "nodelist hosts switches switch"`; do echo "Checking table:$TAB for switch: mid01tor01"; tabdump $TAB |grep mid01tor01; done
Checking table:nodelist for switch: mid01tor01
"mid01tor01cn01","all,firestone,p8le","shell","08-30-2018 01:29:44",,,,,,,,,
Checking table:hosts for switch: mid21tor01
Checking table:switches for switch: mid01tor01
Checking table:switch for switch: mid01tor01
"mid01tor01cn01","mid01tor01.mycluster.com","swp1",,,,
```