### PR TITLE
retry in rpower reset when get 'Connection aborted' [ DO NOT MERGE ]

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -345,7 +345,7 @@ class OpenBMCRest(object):
                 e.message = "Login to BMC failed: Can't connect to {0} {1}.".format(e.host_and_port, e.detail_msg)
             else:
                 e.message = 'BMC did not respond. ' \
-                            'Validate BMC configuration and retry the command.'
+                            'Validate BMC configuration and retry the command. ' + e.detail_msg
             self._print_error_log(e.message, cmd)
             raise
         except ValueError:


### PR DESCRIPTION
https://github.ibm.com/vhu/c910env/issues/346

During ``rpower reset``, if got "SelfServerException" when list state or power on, retry.

UT:
```
Thu Aug 30 20:59:02 2018 mid05tor12cn03: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://172.11.139.3/login -d '{"data": ["root", "xxxxxx"]}'
Thu Aug 30 20:59:02 2018 mid05tor12cn05: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://172.11.139.5/login -d '{"data": ["root", "xxxxxx"]}'
Thu Aug 30 20:59:02 2018 mid05tor12cn03: [openbmc_debug] login 200 OK
Thu Aug 30 20:59:02 2018 mid05tor12cn03: [openbmc_debug] list_power_states curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.3/xyz/openbmc_project/state/enumerate
Thu Aug 30 20:59:02 2018 mid05tor12cn05: [openbmc_debug] login 200 OK
Thu Aug 30 20:59:02 2018 mid05tor12cn05: [openbmc_debug] list_power_states curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.5/xyz/openbmc_project/state/enumerate
Thu Aug 30 20:59:02 2018 mid05tor12cn03: [openbmc_debug] list_power_states 200 OK
Thu Aug 30 20:59:02 2018 mid05tor12cn03: [openbmc_debug] set_power_state curl -k -c cjar -b cjar -X PUT -H "Content-Type: application/json" https://172.11.139.3/xyz/openbmc_project/state/chassis0/attr/RequestedPowerTransition -d '{"data": "xyz.openbmc_project.State.Chassis.Transition.Off"}'
Thu Aug 30 20:59:02 2018 mid05tor12cn05: [openbmc_debug] list_power_states 200 OK
Thu Aug 30 20:59:02 2018 mid05tor12cn05: [openbmc_debug] set_power_state curl -k -c cjar -b cjar -X PUT -H "Content-Type: application/json" https://172.11.139.5/xyz/openbmc_project/state/chassis0/attr/RequestedPowerTransition -d '{"data": "xyz.openbmc_project.State.Chassis.Transition.Off"}'
Thu Aug 30 20:59:03 2018 mid05tor12cn03: [openbmc_debug] set_power_state 200 OK
Thu Aug 30 20:59:03 2018 mid05tor12cn03: [openbmc_debug] list_power_states curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.3/xyz/openbmc_project/state/enumerate
Thu Aug 30 20:59:03 2018 mid05tor12cn05: [openbmc_debug] set_power_state 200 OK
Thu Aug 30 20:59:03 2018 mid05tor12cn05: [openbmc_debug] list_power_states curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.5/xyz/openbmc_project/state/enumerate
Thu Aug 30 20:59:13 2018 mid05tor12cn03: [openbmc_debug] list_power_states 200 OK
Thu Aug 30 20:59:13 2018 mid05tor12cn03: [openbmc_debug] list_power_states curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.3/xyz/openbmc_project/state/enumerate
Thu Aug 30 20:59:14 2018 mid05tor12cn03: [openbmc_debug] list_power_states 200 OK
Thu Aug 30 20:59:14 2018 mid05tor12cn03: [openbmc_debug] set_power_state curl -k -c cjar -b cjar -X PUT -H "Content-Type: application/json" https://172.11.139.3/xyz/openbmc_project/state/host0/attr/RequestedHostTransition -d '{"data": "xyz.openbmc_project.State.Host.Transition.On"}'
Thu Aug 30 20:59:14 2018 mid05tor12cn03: [openbmc_debug] set_power_state 200 OK
mid05tor12cn03: reset
Thu Aug 30 20:59:20 2018 mid05tor12cn05: [openbmc_debug] list_power_states 200 OK
Thu Aug 30 20:59:20 2018 mid05tor12cn05: [openbmc_debug] list_power_states curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.5/xyz/openbmc_project/state/enumerate
Thu Aug 30 20:59:20 2018 mid05tor12cn05: [openbmc_debug] list_power_states BMC did not respond. Validate BMC configuration and retry the command. (Connection reset by peer)
Thu Aug 30 20:59:20 2018 mid05tor12cn05: [openbmc_debug] list_power_states curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://172.11.139.5/xyz/openbmc_project/state/enumerate
Thu Aug 30 20:59:21 2018 mid05tor12cn05: [openbmc_debug] list_power_states 200 OK
Thu Aug 30 20:59:21 2018 mid05tor12cn05: [openbmc_debug] set_power_state curl -k -c cjar -b cjar -X PUT -H "Content-Type: application/json" https://172.11.139.5/xyz/openbmc_project/state/host0/attr/RequestedHostTransition -d '{"data": "xyz.openbmc_project.State.Host.Transition.On"}'
Thu Aug 30 20:59:21 2018 mid05tor12cn05: [openbmc_debug] set_power_state 200 OK
mid05tor12cn05: reset
```