### PR TITLE
support encode hyphens in xcatlib.sh

### DIFF
--- a/xCAT/postscripts/xcatlib.sh
+++ b/xCAT/postscripts/xcatlib.sh
@@ -1,6 +1,6 @@
 function hashencode(){
-        local str_map="$1"
-         echo `echo $str_map | sed 's/\./xDOTx/g' | sed 's/:/xCOLONx/g' | sed 's/,/:xCOMMAx/g'`
+    local str_map="$1"
+    echo `echo $str_map | sed 's/\./xDOTx/g' | sed 's/:/xCOLONx/g' | sed 's/,/:xCOMMAx/g' | sed 's/-/xHYPHENx/g'`
 }
 
 function hashset(){


### PR DESCRIPTION
for #5511 
Before this fix, nics name with "-" is not support in `confignetwork` well. `function hashencode` is used by `hashset` and `hashget`. `hashset` and `hashget` are only used by `confignetwork` related scripts.
`confignetwork` UT:
```
[root@bybc0602 /]# updatenode bybc0609 "confignetwork"
bybc0609: trying to download postscripts...
bybc0609: postscripts downloaded successfully
bybc0609: trying to get mypostscript from 10.5.106.2...
bybc0609: Running postscript: confignetwork
bybc0609: [I]: All valid nics and device list:
bybc0609: [I]: br-mgt eth1
bybc0609: [I]: NetworkManager is inactive.
bybc0609: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bybc0609: configure nic and its device : br-mgt eth1
bybc0609: [I]: create_bridge_interface ifname=br-mgt _brtype=bridge _port=eth1 _pretype=ethernet
bybc0609: [I]: Pickup xcatnet, "20net", from NICNETWORKS for interface "br-mgt".
bybc0609: [I]: create_raw_eth_interface_for_br ifname=eth1 _bridge=br-mgt _mtu=1500
bybc0609: [I]: create_persistent_ifcfg ifname=eth1 inattrs=ONBOOT=yes,TYPE=Ethernet,BRIDGE=br-mgt,BOOTPROTO=none,MTU=1500
bybc0609: ['ifcfg-eth1']
bybc0609: [I]: >> DEVICE="eth1"
bybc0609: [I]: >> BOOTPROTO="none"
bybc0609: [I]: >> NAME="eth1"
bybc0609: [I]: >> HWADDR="42:74:0a:05:6a:09"
bybc0609: [I]: >> ONBOOT="yes"
bybc0609: [I]: >> TYPE="Ethernet"
bybc0609: [I]: >> BRIDGE="br-mgt"
bybc0609: [I]: >> MTU="1500"
bybc0609: [I]: brctl addbr br-mgt
bybc0609: [I]: brctl stp br-mgt on
bybc0609: [I]: brctl addif br-mgt eth1
bybc0609: [I]: migrate_ip ifname=br-mgt sports=eth1
bybc0609: [I]: create_persistent_ifcfg ifname=br-mgt xcatnet=20net inattrs=ONBOOT=yes,STP=on,TYPE=Bridge,MTU=1500
bybc0609: ['ifcfg-br-mgt']
bybc0609: [I]: >> DEVICE="br-mgt"
bybc0609: [I]: >> BOOTPROTO="static"
bybc0609: [I]: >> IPADDR="20.0.0.9"
bybc0609: [I]: >> NETMASK="255.0.0.0"
bybc0609: [I]: >> MTU="1500"
bybc0609: [I]: >> NAME="br-mgt"
bybc0609: [I]: >> ONBOOT="yes"
bybc0609: [I]: >> STP="on"
bybc0609: [I]: >> TYPE="Bridge"
bybc0609: postscript: confignetwork exited with code 0
bybc0609: Running of postscripts has completed.

[root@bybc0602 postscripts]# updatenode bybc0609 "confignetwork -s"
bybc0609: trying to download postscripts...
bybc0609: postscripts downloaded successfully
bybc0609: trying to get mypostscript from 10.5.106.2...
bybc0609: Running postscript: confignetwork
bybc0609: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bybc0609: [I]: configure the install nic eth0.
bybc0609: [I]: configeth on bybc0609: os type: redhat
bybc0609: ['/etc/sysconfig/network-scripts/ifcfg-eth0']
bybc0609: [I]: >> DEVICE=eth0
bybc0609: [I]: >> IPADDR=10.5.106.9
bybc0609: [I]: >> NETMASK=255.0.0.0
bybc0609: [I]: >> BOOTPROTO=static
bybc0609: [I]: >> ONBOOT=yes
bybc0609: [I]: >> HWADDR=42:f5:0a:05:6a:09
bybc0609: [I]: >> MTU=1500
bybc0609: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bybc0609: [I]: All valid nics and device list:
bybc0609: [I]: br-mgt eth1
bybc0609: [I]: NetworkManager is inactive.
bybc0609: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bybc0609: configure nic and its device : br-mgt eth1
bybc0609: [I]: create_bridge_interface ifname=br-mgt _brtype=bridge _port=eth1 _pretype=ethernet
bybc0609: [I]: Pickup xcatnet, "20net", from NICNETWORKS for interface "br-mgt".
bybc0609: [I]: create_raw_eth_interface_for_br ifname=eth1 _bridge=br-mgt _mtu=1500
bybc0609: [I]: create_persistent_ifcfg ifname=eth1 inattrs=ONBOOT=yes,TYPE=Ethernet,BRIDGE=br-mgt,BOOTPROTO=none,MTU=1500
bybc0609: grep: /proc/net/bonding/br-mgt: No such file or directory
bybc0609: ['ifcfg-eth1']
bybc0609: [I]: >> DEVICE="eth1"
bybc0609: [I]: >> BOOTPROTO="none"
bybc0609: [I]: >> NAME="eth1"
bybc0609: [I]: >> ONBOOT="yes"
bybc0609: [I]: >> TYPE="Ethernet"
bybc0609: [I]: >> BRIDGE="br-mgt"
bybc0609: [I]: >> MTU="1500"
bybc0609: [I]: brctl addbr br-mgt
bybc0609: device br-mgt already exists; can't create bridge with the same name
bybc0609: [I]: brctl stp br-mgt on
bybc0609: [I]: brctl addif br-mgt eth1
bybc0609: device eth1 is already a member of a bridge; can't enslave it to bridge br-mgt.
bybc0609: [I]: migrate_ip ifname=br-mgt sports=eth1
bybc0609: [I]: create_persistent_ifcfg ifname=br-mgt xcatnet=20net inattrs=ONBOOT=yes,STP=on,TYPE=Bridge,MTU=1500
bybc0609: ['ifcfg-br-mgt']
bybc0609: [I]: >> DEVICE="br-mgt"
bybc0609: [I]: >> BOOTPROTO="static"
bybc0609: [I]: >> IPADDR="20.0.0.9"
bybc0609: [I]: >> NETMASK="255.0.0.0"
bybc0609: [I]: >> MTU="1500"
bybc0609: [I]: >> NAME="br-mgt"
bybc0609: [I]: >> ONBOOT="yes"
bybc0609: [I]: >> STP="on"
bybc0609: [I]: >> TYPE="Bridge"
bybc0609: postscript: confignetwork exited with code 0
bybc0609: Running of postscripts has completed.
```

