### PR TITLE
Add /etc/gshadow for the syncfile MERGE clause

### DIFF
--- a/perl-xCAT/xCAT/CFMUtils.pm
+++ b/perl-xCAT/xCAT/CFMUtils.pm
@@ -59,7 +59,7 @@ sub initCFMdir
     my @sysfiles = ("/etc/hosts");
 
     # the /etc/passwd, shadow, group files will be merged
-    my @userfiles = ("/etc/passwd", "/etc/shadow", "/etc/group");
+    my @userfiles = ("/etc/passwd", "/etc/shadow", "/etc/gshadow", "/etc/group");
 
     # create the cfmdir
     if (!-d $cfmdir)
@@ -113,7 +113,7 @@ sub initCFMdir
 #-----------------------------------------------------------------------------
 
 =head3 updateUserInfo
-    Update the /etc/passwd, shadow, group merge files under specified CFM directory
+    Update the /etc/passwd, shadow, gshadow, group merge files under specified CFM directory
 
     Arguments:
       $cfmdir - CFM directory for osimage
@@ -133,7 +133,7 @@ sub initCFMdir
 sub updateUserInfo {
     my ($class, $cfmdir) = @_;
 
-    my @userfiles = ("/etc/passwd", "/etc/shadow", "/etc/group");
+    my @userfiles = ("/etc/passwd", "/etc/shadow", "/etc/gshadow", "/etc/group");
 
     my @osfiles = glob("$cfmdir/*.OS");
     if (!@osfiles)
@@ -141,7 +141,7 @@ sub updateUserInfo {
         if ($::VERBOSE)
         {
             my $rsp = {};
-            $rsp->{data}->[0] = "Skiping the update of the /etc/passwd, shadow, group merge files under the CFM directory.";
+            $rsp->{data}->[0] = "Skiping the update of the /etc/passwd, shadow, gshadow, group merge files under the CFM directory.";
             xCAT::MsgUtils->message("I", $rsp, $::CALLBACK);
         }
         return 0;
@@ -153,7 +153,7 @@ sub updateUserInfo {
         my @newrecords = ();
         my $backup     = basename($file) . ".OS";
 
-        # get the records from /etc/passwd, shadow, group file and backup files(.OS files)
+        # get the records from /etc/passwd, shadow, gshadow, group file and backup files(.OS files)
         # and all the files from /install/osimages/$imgname/cfmdir directory
         foreach my $userinfo ($file, "$cfmdir/$backup")
         {
@@ -173,7 +173,7 @@ sub updateUserInfo {
             }
             close($fp);
 
-            # check the records from /etc/passwd, shadow, group file or backup
+            # check the records from /etc/passwd, shadow, gshadow, group file or backup
             if ($userinfo =~ /^\/etc/)
             {
                 @newrecords = @records;
@@ -309,6 +309,7 @@ sub setCFMSynclistFile {
 	MERGE:
 	<cfmdir>/etc/group.merge -> /etc/group
 	<cfmdir>/etc/shadow.merge -> /etc/shadow
+	<cfmdir>/etc/gshadow.merge -> /etc/gshadow
 	<cfmdir>/etc/passwd.merge -> /etc/passwd
 
     Arguments:
@@ -358,13 +359,13 @@ sub updateCFMSynclistFile {
                 mkpath dirname($cfmsynclist);
             }
 
-            # update /etc/passwd, shadow, group merge files
+            # update /etc/passwd, shadow, gshadow, group merge files
             my $ret = xCAT::CFMUtils->updateUserInfo($cfmdir);
             if ($ret != 0)
             {
                 my $rsp = {};
                 $rsp->{error}->[0] =
-                  "Update /etc/passwd, shadow, group merge files failed.";
+                  "Update /etc/passwd, shadow, gshadow, group merge files failed.";
                 xCAT::MsgUtils->message("E", $rsp, $::CALLBACK);
                 return 1;
             }
@@ -418,10 +419,10 @@ sub updateCFMSynclistFile {
             }
             foreach my $file (@mergefiles)
             {
-                my @userfiles = ("/etc/passwd", "/etc/shadow", "/etc/group");
+                my @userfiles = ("/etc/passwd", "/etc/shadow", "/etc/gshadow", "/etc/group");
                 my $dest = substr($file, length($cfmdir), length($file) - length(".merge") - length($cfmdir));
 
-                # only /etc/passwd, /etc/shadow, /etc/groups merging is supported
+                # only /etc/passwd, /etc/shadow, /etc/gshadow, /etc/groups merging is supported
                 if (grep(/$dest/, @userfiles)) {
                     print $fp "$file -> $dest\n";
                 }

--- a/perl-xCAT/xCAT/DSHCLI.pm
+++ b/perl-xCAT/xCAT/DSHCLI.pm
@@ -5502,9 +5502,10 @@ sub build_append_rsync
            /tmp/mypasswd -> /etc/passwd
            /tmp/mygroup -> /etc/group
            /tmp/myshadow -> /etc/shadow
+           /tmp/mygshadow -> /etc/gshadow
 
-          Merges the information from the files in mypasswd, mygroup,
-          myshadow into /etc/passwd, /etc/group , /etc/shadow on the nodes.
+          Merges the information from the files in mypasswd, mygroup,mygshadow,
+          myshadow into /etc/passwd, /etc/group , /etc/gshadow, /etc/shadow on the nodes.
           These are the only files supported from MERGE and only on Linux
         Returns:
           Files do not exist, rsync errors.
@@ -6155,8 +6156,9 @@ sub bld_and_run_append
 
         Runs xdsh with input to call /opt/xcat/share/xcat/scripts/xdcpmerge.sh
         which will perform the merge function on the node.
-        Input is the nodesyncfiledir mergefile1:orgfile mergefile2:orgfile2....]        Note: MERGE is only support on Linux and for /etc/passwd,/etc/shadow,
-              and /etc/group
+        Input is the nodesyncfiledir mergefile1:orgfile mergefile2:orgfile2....]        
+        Note: MERGE is only support on Linux and for /etc/passwd,/etc/shadow,
+              /etc/gshadow, and /etc/group
 =cut
 
 #-------------------------------------------------------------------------------
@@ -6189,9 +6191,10 @@ sub bld_and_run_merge
             my $filetomerge = $2;    # file to merge right of arrow
             if (($filetomerge ne "/etc/passwd")
                 && ($filetomerge ne "/etc/group")
+                && ($filetomerge ne "/etc/gshadow")
                 && ($filetomerge ne "/etc/shadow")) {
                 my $rsp = {};
-                $rsp->{error}->[0] = "$filetomerge is not either /etc/passwd, /etc/group or /etc/shadow. Those are the only supported files for MERGE";
+                $rsp->{error}->[0] = "$filetomerge is not either /etc/passwd, /etc/group, /etc/gshadow or /etc/shadow. Those are the only supported files for MERGE";
                 xCAT::MsgUtils->message("E", $rsp, $::CALLBACK, 1);
                 return 1;
 


### PR DESCRIPTION
For issue #5448 ,

````
# lsdef mid08tor03cn01 -i provmethod
Object name: mid08tor03cn01
    provmethod=xcat.redhat-alt.full.netboot
# lsdef -t osimage xcat.redhat-alt.full.netboot -i synclists
Object name: xcat.redhat-alt.full.netboot
    synclists=/tmp/compute.synclist
# cat /tmp/compute.synclist
MERGE:
/tmp/mergeshadow -> /etc/shadow
/tmp/mergeshadow -> /etc/gshadow
# cat /tmp/mergeshadow
ntp:*:17492:0:99999:7:::
ntpxxx:*:17492:0:99999:7:::
# cat mergegshadow
ntp:::
ntpxx:::
````
on the compute node: 
````
# grep ntp /etc/shadow
ntp:!!:17771::::::
# grep ntp /etc/gshadow
ntp:!::
````
Before fix will get error message:
```
# updatenode mid08tor03cn01 -F
/etc/gshadow is not either /etc/passwd, /etc/group or /etc/shadow. Those are the only supported files for MERGE
1
1
File synchronization failed for nodes: "mid08tor03cn01"
````
After fix:
````
# updatenode mid08tor03cn01 -F
File synchronization has completed for nodes: "mid08tor03cn01"
````
on the compute node:
````
# grep ntp /etc/gshadow
ntp:::
ntpxx:::
# grep ntp /etc/shadow
ntp:*:17492:0:99999:7:::
ntpxx:*:17492:0:99999:7:::
````

