### PR TITLE
fix issue #105 in xcat-inventory, 

### DIFF
--- a/xCAT-server/lib/perl/xCAT/Postage.pm
+++ b/xCAT-server/lib/perl/xCAT/Postage.pm
@@ -1204,7 +1204,9 @@ sub getImageitems_for_node
             }
             if ($ref1->{'environvar'}){
                 foreach my $myenvar(split(',',$ref1->{'environvar'})){
-                    $result .='export '.$myenvar."\n";
+                    $result .=$myenvar."\n";
+                    my ($varname,$value)=split('=',$myenvar);
+                    $result .='export '.$varname."\n";
                 }
             }
         }


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-inventory/issues/105: correct the format of export entries in osimage.environvar

for osimage:
```
# lsdef -t osimage -o xcat.redhat-alt.full.install -i environvar
Object name: xcat.redhat-alt.full.install
    environvar=GITBRANCH=xcat_sp_updates,OBJNAME=xcat.redhat-alt.full.install,GITCOMMIT=4b2f,GITROOT=/install/xcat_clusters
```

Before fix:
```
#cat /xcatpost/mypostscript
...
export GITBRANCH=xcat_sp_updates
export OBJNAME=xcat.redhat-alt.full.install
export GITCOMMIT=4b2f
export GITROOT=/install/xcat_clusters
...
```
after fix:
```
#cat /xcatpost/mypostscript
...
GITBRANCH=xcat_sp_updates
export GITBRANCH
OBJNAME=xcat.redhat-alt.full.install
export OBJNAME
GITCOMMIT=4b2f
export GITCOMMIT
GITROOT=/install/xcat_clusters
export GITROOT
...
```



UT:
```

# updatenode node1 -P custom.ps/list_software
mid21tor24cn02: trying to download postscripts...
mid21tor24cn02: postscripts downloaded successfully
mid21tor24cn02: trying to get mypostscript from 1.1.1.1...
mid21tor24cn02: Running postscript: custom.ps/list_software
mid21tor24cn02:
mid21tor24cn02: INFO: Listing xCAT information...
mid21tor24cn02:    IMAGENAME=xcat.redhat-alt.full.install
mid21tor24cn02:
mid21tor24cn02: INFO: Listing kernel information...
mid21tor24cn02:    KERNEL: 4.14.0-49.el7a.ppc64le
mid21tor24cn02:    INSTALLED KERNEL MODULES in /lib/modules
mid21tor24cn02:    --> 4.14.0-49.el7a.ppc64le
mid21tor24cn02:
mid21tor24cn02: INFO: Listing HPC Stack Software Levels...
mid21tor24cn02:    MELLANOX_OFED: MLNX_OFED_LINUX-4.3-4.0.5.2 (OFED-4.3-4.0.5):
mid21tor24cn02:    NVIDIA_CUDA_VERSION: cuda-9.2.148-1.ppc64le
mid21tor24cn02:    NVIDIA_DRIVER_VERSIONS:
mid21tor24cn02:    CSM_CORE_VERSION: (no version installed)
mid21tor24cn02:    ESSL_VERSION: (no version installed)
mid21tor24cn02:    GPFS_GPLBIN_VERSION: (no version installed)
mid21tor24cn02:    GPFS_VERSION: (no version installed)
mid21tor24cn02:    PESSL_VERSION: (no version installed)
mid21tor24cn02:    PPT_VERSION: (no version installed)
mid21tor24cn02:    SMPI_VERSION: (no version installed)
mid21tor24cn02:    SMPI_VERSION_nv_rsync_mem: (no version installed)
mid21tor24cn02:    SMPI_VERSION_nvidia_peer_memory: (no version installed)
mid21tor24cn02:    XLC_VERSION: (no version installed)
mid21tor24cn02:    XLF_VERSION: (no version installed)
mid21tor24cn02: postscript: custom.ps/list_software exited with code 0
mid21tor24cn02: Running of postscripts has completed.
```