### PR TITLE
add HA test cases for redhat

### DIFF
--- a/xCAT-test/autotest/linux.conf.template
+++ b/xCAT-test/autotest/linux.conf.template
@@ -58,7 +58,7 @@ os=rhels5.4
 
 #system varible for autotest
 [System]
-MN=rhmn
+MN=rhmn      
 SN=rhsn
 CN=lpar5            #It can be used in flat environment
 CNWITHSN=lpar6      #It can be used in hierarchy environment for cn
@@ -146,3 +146,11 @@ NODEIP=10.4.27.10
 #genesis testcase
 imgip=10.4.27.10
 #imgip should be same with MN's ip genesis case only for ppc64le and x86_64
+#For HA
+VIP=10.3.17.233
+PRIMARYMN=lpar5
+PMNSECONDNIC=eth1
+STANDBYMN=lpar6
+SMNSECONDNIC=eth1
+HACN=lpar7
+HASCIPRTURL=https://raw.githubusercontent.com/xcat2/xcat-extensions/master/HA/xcatha.py

--- a/xCAT-test/autotest/testcase/HA/case0
+++ b/xCAT-test/autotest/testcase/HA/case0
@@ -1,0 +1,350 @@
+#only support redhat and postgresql
+start:setup_2_new_HA_MN
+os:Linux
+#back up
+cmd:lsdef -z $$PRIMARYMN > /tmp/node.stanza
+cmd:lsdef -z $$STANDBYMN >> /tmp/node.stanza
+cmd:lsdef -z $$HACN >> /tmp/node.stanza
+cmd:lsdef -t osimage -z __GETNODEATTR($$PRIMARYMN,os)__-__GETNODEATTR($$PRIMARYMN,arch)__-install-compute > /tmp/osimage.stanza
+cmd:chdef -t node -o $$PRIMARYMN,$$STANDBYMN,$$HACN servicenode= monserver= nfsserver= tftpserver= xcatmaster=
+check:rc==0
+cmd:lsdef -z $$HACN > /tmp/HACN.stanza
+check:rc==0
+
+#prepare
+cmd:makedns -n
+check:rc==0
+cmd:if [[ "__GETNODEATTR($$PRIMARYMN,arch)__" = "ppc64" ]] && [[ "__GETNODEATTR($$PRIMARYMN,mgt)__" != "ipmi" ]]; then getmacs -D $$PRIMARYMN; fi
+check:rc==0
+cmd:makedhcp -n
+check:rc==0
+cmd:makedhcp -a
+check:rc==0
+cmd:a=0;while true; do [ $a -eq 100 ] && exit 1;output=$(makedhcp -q $$PRIMARYMN);[ $? -ne 0 ] && exit 1;echo $output|grep $$PRIMARYMN 2>/dev/null && exit 0;a=$[$a+1];sleep 1;done
+check:rc==0
+cmd:copycds $$ISO
+check:rc==0
+cmd:if [[ -f /install/postscripts/cfghamn ]] ;then mv -f /install/postscripts/cfghamn /install/postscripts/cfghamn.bak;fi;
+cmd:if [[ -f /install/postscripts/check_node_state ]] ;then mv -f /install/postscripts/check_node_state /install/postscripts/check_node_state.bak;fi;
+cmd:cp -f /opt/xcat/share/xcat/tools/autotest/testcase/HA/cfghamn /install/postscripts/
+cmd:cp -f /opt/xcat/share/xcat/tools/autotest/testcase/HA/check_node_state /install/postscripts/
+cmd:if [[ -f /install/postscripts/xcatha.py ]] ;then mv -f /install/postscripts/xcatha.py /install/postscripts/xcatha.py.bak;fi;
+cmd:if [[ ! -f /install/postscripts/xcatha.py ]] ;then wget $$HASCIPRTURL -P /install/postscripts/; fi;
+cmd:ls /install/postscripts/xcatha.py
+check:rc==0
+cmd:genimage __GETNODEATTR($$PRIMARYMN,os)__-__GETNODEATTR($$PRIMARYMN,arch)__-netboot-compute
+check:rc==0
+cmd:packimage __GETNODEATTR($$PRIMARYMN,os)__-__GETNODEATTR($$PRIMARYMN,arch)__-netboot-compute
+check:rc==0
+cmd:imgexport __GETNODEATTR($$PRIMARYMN,os)__-__GETNODEATTR($$PRIMARYMN,arch)__-netboot-compute
+check:rc==0
+
+#create hosts file for 2 HA nodes
+cmd:echo "127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4" > /opt/xcat/share/xcat/tools/autotest/testcase/HA/hosts
+cmd:echo "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6" >> /opt/xcat/share/xcat/tools/autotest/testcase/HA/hosts
+cmd:echo "__GETNODEATTR($$PRIMARYMN,ip)__ $$PRIMARYMN $$PRIMARYMN.pok.stglabs.ibm.com" >> /opt/xcat/share/xcat/tools/autotest/testcase/HA/hosts
+cmd:echo "__GETNODEATTR($$STANDBYMN,ip)__ $$STANDBYMN $$STANDBYMN.pok.stglabs.ibm.com" >> /opt/xcat/share/xcat/tools/autotest/testcase/HA/hosts
+cmd:echo "$$VIP autotesthamn autotesthamn.pok.stglabs.ibm.com" >> /opt/xcat/share/xcat/tools/autotest/testcase/HA/hosts
+cmd:echo "__GETNODEATTR($$HACN,ip)__ $$HACN $$HACN.pok.stglabs.ibm.com" >> /opt/xcat/share/xcat/tools/autotest/testcase/HA/hosts
+
+#configure syclists
+cmd:if [[ -f /test.synclist ]] ;then mv -f /test.synclist /test.synclist.bak;fi;
+cmd:echo "/opt/xcat/share/xcat/tools/autotest/testcase/HA/hosts -> /etc/hosts" > /test.synclist
+cmd:echo "/tmp/HACN.stanza -> /tmp/HACN.stanza" >> /test.synclist
+cmd:chdef -t osimage -o __GETNODEATTR($$PRIMARYMN,os)__-__GETNODEATTR($$PRIMARYMN,arch)__-install-compute synclists=/test.synclist
+check:rc==0 
+
+#modify postbootscripts
+cmd:if [[ -d /install/autotestHA ]] ;then mv -f /install/autotestHA /install/autotestHA.bak;fi
+cmd:mkdir -p /install/autotestHA
+cmd:chdef $$PRIMARYMN,$$STANDBYMN -p postbootscripts="confignetwork -s,cfghamn -l $$MN:/install/autotestHA -i $$VIP -x s"
+check:rc==0
+
+#provision first HA node
+cmd:rinstall $$PRIMARYMN osimage=__GETNODEATTR($$PRIMARYMN,os)__-__GETNODEATTR($$PRIMARYMN,arch)__-install-compute
+check:rc==0
+cmd:sleep 300
+cmd:a=0;while ! `lsdef -l $$PRIMARYMN|grep status|grep booted >/dev/null`; do sleep 20;((a++));if [ $a -gt 300 ];then break;fi done
+cmd:ping $$PRIMARYMN -c 3
+check:rc==0
+check:output=~64 bytes from $$PRIMARYMN
+cmd:xdsh $$PRIMARYMN date
+check:rc==0
+check:output=~\d\d:\d\d:\d\d
+
+#provision second HA node
+cmd:rinstall $$STANDBYMN osimage=__GETNODEATTR($$PRIMARYMN,os)__-__GETNODEATTR($$PRIMARYMN,arch)__-install-compute
+check:rc==0
+cmd:sleep 300
+cmd:a=0;while ! `lsdef -l $$STANDBYMN|grep status|grep booted >/dev/null`; do sleep 20;((a++));if [ $a -gt 300 ];then break;fi done
+cmd:ping $$STANDBYMN -c 3
+check:rc==0
+check:output=~64 bytes from $$STANDBYMN
+cmd:xdsh $$STANDBYMN date
+check:rc==0
+check:output=~\d\d:\d\d:\d\d
+
+#activate the first HA node
+cmd:updatenode $$PRIMARYMN -P "cfghamn -l $$MN:/install/autotestHA -i $$VIP -x a"
+check:rc==0
+cmd:xdsh $$PRIMARYMN "chdef -t site domain=pok.stglabs.ibm.com"
+cmd:makedhcp -d $$HACN
+check:rc==0
+
+#provision HACN on primary MN
+cmd:rsync /opt/xcat/share/xcat/tools/autotest/__GETNODEATTR($$PRIMARYMN,os)__-__GETNODEATTR($$PRIMARYMN,arch)__-netboot-compute.tgz $$PRIMARYMN:/root/ 
+check:rc==0
+cmd:xdsh $$PRIMARYMN "imgimport /root/__GETNODEATTR($$PRIMARYMN,os)__-__GETNODEATTR($$PRIMARYMN,arch)__-netboot-compute.tgz"
+check:rc==0
+cmd:xdsh $$PRIMARYMN "cat /tmp/HACN.stanza|chdef -z"
+check:rc==0
+cmd:xdsh $$PRIMARYMN "makedns -n"
+check:rc==0
+cmd:xdsh $$PRIMARYMN "makedhcp -n"
+check:rc==0
+cmd:xdsh $$PRIMARYMN "makedhcp -a"
+check:rc==0
+cmd:xdsh $$PRIMARYMN "rinstall $$HACN osimage=__GETNODEATTR($$PRIMARYMN,os)__-__GETNODEATTR($$PRIMARYMN,arch)__-netboot-compute"
+check:rc==0
+cmd:sleep 150
+cmd:xdsh $$PRIMARYMN "chmod 755 /xcatpost/check_node_state"
+cmd:xdsh $$PRIMARYMN "/xcatpost/check_node_state $$HACN"
+cmd:xdsh $$PRIMARYMN "lsdef $$HACN -i status"
+check:output=~booted
+check:rc==0
+
+#deactivate the first HA node
+cmd:updatenode $$PRIMARYMN -P "cfghamn -l $$MN:/install/autotestHA -i $$VIP -x d"
+check:rc==0
+
+#activate the second HA node
+cmd:updatenode $$STANDBYMN -P "cfghamn -l $$MN:/install/autotestHA -i $$VIP -x a"
+check:rc==0
+
+#provision HACN on standby MN
+cmd:xdsh $$STANDBYMN "rinstall $$HACN osimage=__GETNODEATTR($$PRIMARYMN,os)__-__GETNODEATTR($$PRIMARYMN,arch)__-netboot-compute"
+check:rc==0
+cmd:sleep 150
+cmd:xdsh $$STANDBYMN "chmod 755 /xcatpost/check_node_state"
+cmd:xdsh $$STANDBYMN "/xcatpost/check_node_state $$HACN"
+cmd:xdsh $$STANDBYMN "lsdef $$HACN -i status"
+check:output=~booted
+
+#deactivate the second HA node
+cmd:updatenode $$STANDBYMN -P "cfghamn -l $$MN:/install/autotestHA -i $$VIP -x d"
+check:rc==0
+
+#restore data
+cmd:cat /tmp/node.stanza | chdef -z;rm -rf /tmp/node.stanza
+cmd:cat /tmp/osimage.stanza | chdef -z;rm -rf /tmp/osimage.stanza
+cmd:rm -rf /opt/xcat/share/xcat/tools/autotest/testcase/HA/hosts
+cmd:rm -rf /opt/xcat/share/xcat/tools/autotest/__GETNODEATTR($$PRIMARYMN,os)__-__GETNODEATTR($$PRIMARYMN,arch)__-netboot-compute.tgz
+cmd:if [[ -d /install/autotestHA.bak ]] ;then mv -f /install/autotestHA.bak /install/autotestHA;fi
+cmd:if [[ -f /test.synclist.bak ]] ;then mv -f /test.synclist.bak /tmp/test.synclist;else rm -rf /test.synclist;fi
+cmd:if [[ -f /install/postscripts/cfghamn.bak ]] ;then mv -f /install/postscripts/cfghamn.bak /install/postscripts/cfghamn;fi;
+cmd:if [[ -f /install/postscripts/xcatha.py.bak ]] ;then mv -f /install/postscripts/xcatha.py.bak /install/postscripts/xcatha.py;fi;
+cmd:if [[ -f /install/postscripts/check_node_state.bak ]] ;then mv -f /install/postscripts/check_node_state.bak /install/postscripts/check_node_state;fi;
+end
+
+start:configure_exist_xCAT_MN_to_HA_MN
+os:Linux
+#back up
+cmd:lsdef -z $$PRIMARYMN > /tmp/node.stanza
+cmd:lsdef -z $$STANDBYMN >> /tmp/node.stanza
+cmd:lsdef -z $$HACN >> /tmp/node.stanza
+cmd:lsdef -t osimage -z __GETNODEATTR($$PRIMARYMN,os)__-__GETNODEATTR($$PRIMARYMN,arch)__-install-compute > /tmp/osimage.stanza
+cmd:chdef -t node -o $$PRIMARYMN,$$STANDBYMN,$$HACN servicenode= monserver= nfsserver= tftpserver= xcatmaster=
+check:rc==0
+cmd:lsdef -z $$HACN > /tmp/HACN.stanza
+check:rc==0
+
+#prepare
+cmd:makedns -n
+check:rc==0
+cmd:if [[ "__GETNODEATTR($$PRIMARYMN,arch)__" = "ppc64" ]] && [[ "__GETNODEATTR($$PRIMARYMN,mgt)__" != "ipmi" ]]; then getmacs -D $$PRIMARYMN; fi
+check:rc==0
+cmd:makedhcp -n
+check:rc==0
+cmd:makedhcp -a
+check:rc==0
+cmd:a=0;while true; do [ $a -eq 100 ] && exit 1;output=$(makedhcp -q $$PRIMARYMN);[ $? -ne 0 ] && exit 1;echo $output|grep $$PRIMARYMN 2>/dev/null && exit 0;a=$[$a+1];sleep 1;done
+check:rc==0
+cmd:copycds $$ISO
+check:rc==0
+cmd:if [[ -f /install/postscripts/cfghamn ]] ;then mv -f /install/postscripts/cfghamn /install/postscripts/cfghamn.bak;fi;
+cmd:if [[ -f /install/postscripts/check_node_state ]] ;then mv -f /install/postscripts/check_node_state /install/postscripts/check_node_state.bak;fi;
+cmd:cp -f /opt/xcat/share/xcat/tools/autotest/testcase/HA/cfghamn /install/postscripts/
+cmd:cp -f /opt/xcat/share/xcat/tools/autotest/testcase/HA/check_node_state /install/postscripts/
+cmd:if [[ -f /install/postscripts/xcatha.py ]] ;then mv -f /install/postscripts/xcatha.py /install/postscripts/xcatha.py.bak;fi;
+cmd:if [[ ! -f /install/postscripts/xcatha.py ]] ;then wget $$HASCIPRTURL -P /install/postscripts/; fi;
+cmd:ls /install/postscripts/xcatha.py
+check:rc==0
+cmd:genimage __GETNODEATTR($$PRIMARYMN,os)__-__GETNODEATTR($$PRIMARYMN,arch)__-netboot-compute
+check:rc==0
+cmd:packimage __GETNODEATTR($$PRIMARYMN,os)__-__GETNODEATTR($$PRIMARYMN,arch)__-netboot-compute
+check:rc==0
+cmd:imgexport __GETNODEATTR($$PRIMARYMN,os)__-__GETNODEATTR($$PRIMARYMN,arch)__-netboot-compute
+check:rc==0
+
+#prepare /etc/hosts 
+cmd:echo "127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4" > /opt/xcat/share/xcat/tools/autotest/testcase/HA/hosts
+cmd:echo "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6" >> /opt/xcat/share/xcat/tools/autotest/testcase/HA/hosts
+cmd:echo "100.1.0.100 $$PRIMARYMN-1 $$PRIMARYMN-1.pok.stglabs.ibm.com" >> /opt/xcat/share/xcat/tools/autotest/testcase/HA/hosts
+cmd:echo "100.1.0.101 $$STANDBYMN-1 $$STANDBYMN-1.pok.stglabs.ibm.com" >> /opt/xcat/share/xcat/tools/autotest/testcase/HA/hosts
+cmd:echo "100.1.0.233 autotesthamn autotesthamn.pok.stglabs.ibm.com" >> /opt/xcat/share/xcat/tools/autotest/testcase/HA/hosts
+cmd:echo "100.1.0.103 $$HACN $$HACN.pok.stglabs.ibm.com" >> /opt/xcat/share/xcat/tools/autotest/testcase/HA/hosts
+
+#configure syclists
+cmd:if [[ -f /test.synclist ]] ;then mv -f /test.synclist /test.synclist.bak;fi;
+cmd:echo "/opt/xcat/share/xcat/tools/autotest/testcase/HA/hosts -> /etc/hosts" > /test.synclist
+cmd:echo "/tmp/HACN.stanza -> /tmp/HACN.stanza" >> /test.synclist
+cmd:chdef -t osimage -o __GETNODEATTR($$PRIMARYMN,os)__-__GETNODEATTR($$PRIMARYMN,arch)__-install-compute synclists=/test.synclist
+check:rc==0
+
+#create HA network
+cmd:mkdef -t network -o 100_1_0_0-255_255_0_0 net=100.1.0.0 mask=255.255.0.0 
+check:rc==0
+cmd:chdef $$PRIMARYMN nicips.$$PMNSECONDNIC=100.1.0.233 nictypes.$$PMNSECONDNIC=Ethernet nicnetworks.$$PMNSECONDNIC=100_1_0_0-255_255_0_0
+check:rc==0
+cmd:chdef $$STANDBYMN nicips.$$SMNSECONDNIC=100.1.0.101 nictypes.$$SMNSECONDNIC=Ethernet nicnetworks.$$SMNSECONDNIC=100_1_0_0-255_255_0_0
+check:rc==0
+
+#configure postbootscripts
+cmd:if [[ -d /install/autotestHA ]] ;then mv -f /install/autotestHA /install/autotestHA.bak;fi
+cmd:mkdir -p /install/autotestHA
+cmd:chdef $$PRIMARYMN,$$STANDBYMN -p postbootscripts="confignetwork -s"
+check:rc==0
+
+#provison first node
+cmd:rinstall $$PRIMARYMN,$$STANDBYMN osimage=__GETNODEATTR($$PRIMARYMN,os)__-__GETNODEATTR($$PRIMARYMN,arch)__-install-compute
+check:rc==0
+cmd:sleep 300
+cmd:a=0;while ! `lsdef -l $$PRIMARYMN|grep status|grep booted >/dev/null`; do sleep 20;((a++));if [ $a -gt 300 ];then break;fi done
+cmd:ping $$PRIMARYMN -c 3
+check:rc==0
+check:output=~64 bytes from $$PRIMARYMN
+cmd:xdsh $$PRIMARYMN date
+check:rc==0
+check:output=~\d\d:\d\d:\d\d
+cmd:a=0;while ! `lsdef -l $$STANDBYMN|grep status|grep booted >/dev/null`; do sleep 20;((a++));if [ $a -gt 300 ];then break;fi done
+cmd:ping $$STANDBYMN -c 3
+check:rc==0
+check:output=~64 bytes from $$STANDBYMN
+cmd:xdsh $$STANDBYMN date
+check:rc==0
+check:output=~\d\d:\d\d:\d\d
+
+#update resolv.conf and hostname
+cmd:xdsh $$PRIMARYMN 'echo "nameserver 100.1.0.233">> /etc/resolv.conf'
+check:rc==0
+cmd:xdsh $$PRIMARYMN "hostname autotesthamn"
+check:rc==0
+
+#install xCAT
+cmd:mkdir -p /install/post/otherpkgs/__GETNODEATTR($$PRIMARYMN,os)__/__GETNODEATTR($$PRIMARYMN,arch)__/xcat
+check:rc==0
+cmd:cp -r /xcat-core /install/post/otherpkgs/__GETNODEATTR($$PRIMARYMN,os)__/__GETNODEATTR($$PRIMARYMN,arch)__/xcat/
+cmd:cp -r /xcat-dep /install/post/otherpkgs/__GETNODEATTR($$PRIMARYMN,os)__/__GETNODEATTR($$PRIMARYMN,arch)__/xcat/
+cmd:cd /install/post/otherpkgs/__GETNODEATTR($$SN,os)__/__GETNODEATTR($$SN,arch)__/xcat/xcat-core && createrepo .
+check:rc==0
+cmd:if [[ "__GETNODEATTR($$PRIMARYMN,os)__" =~ "rh" ]];then path="rh";elif [[ "__GETNODEATTR($$PRIMARYMN,os)__" =~ "sles" ]];then path="sles";fi; ver="__GETNODEATTR($$PRIMARYMN,os)__"; tmp=${ver%.*};ver=`echo "$tmp"|sed 's:[a-zA-Z]::g'`;cd /install/post/otherpkgs/__GETNODEATTR($$SN,os)__/__GETNODEATTR($$SN,arch)__/xcat/xcat-dep/$path$ver/__GETNODEATTR($$SN,arch)__ && createrepo .;
+check:rc==0
+cmd:chdef -t osimage __GETNODEATTR($$PRIMARYMN,os)__-__GETNODEATTR($$PRIMARYMN,arch)__-install-compute otherpkgdir="/install/post/otherpkgs/__GETNODEATTR($$PRIMARYMN,os)__/__GETNODEATTR($$PRIMARYMN,arch)__"
+check:rc==0
+cmd:cmd:if [[ -f /opt/xcat/share/xcat/install/rh/autotest.otherpkgs.pkglist ]]; then mv -f /opt/xcat/share/xcat/install/rh/autotest.otherpkgs.pkglist /opt/xcat/share/xcat/install/rh/autotest.otherpkgs.pkglist.bak;fi
+cmd:echo "xcat/xcat-core/xCAT" > /opt/xcat/share/xcat/install/rh/autotest.otherpkgs.pkglist
+cmd:echo "xcat/xcat-dep/rh7/ppc64le/conserver-xcat" >> /opt/xcat/share/xcat/install/rh/autotest.otherpkgs.pkglist
+cmd:echo "xcat/xcat-dep/rh7/ppc64le/perl-Net-Telnet" >> /opt/xcat/share/xcat/install/rh/autotest.otherpkgs.pkglist
+cmd:echo "xcat/xcat-dep/rh7/ppc64le/perl-Expect" >> /opt/xcat/share/xcat/install/rh/autotest.otherpkgs.pkglist
+cmd:chdef -t osimage __GETNODEATTR($$PRIMARYMN,os)__-__GETNODEATTR($$PRIMARYMN,arch)__-install-compute otherpkglist="/opt/xcat/share/xcat/install/rh/autotest.otherpkgs.pkglist"
+cmd:updatenode $$PRIMARYMN -P otherpkgs
+check:rc==0
+cmd:updatenode $$STANDBYMN -P otherpkgs
+check:rc==0
+cmd:xdsh $$PRIMARYMN,$$STANDBYMN "yum -y install postgresql* perl-DBD-Pg"
+check:rc==0
+
+
+#configure first MN as standby HA MN
+cmd:xdsh $$PRIMARYMN "service xcatd stop" 
+check:rc==0
+cmd:xdsh $$PRIMARYMN "sed -i 's/IPADDR=100.1.0.233/IPADDR=100.1.0.100/g' /etc/sysconfig/network-scripts/ifcfg-$$PMNSECONDNIC"
+check:rc==0
+cmd:xdsh $$PRIMARYMN "ifdown $$PMNSECONDNIC;ifup $$PMNSECONDNIC"
+check:rc==0
+cmd:xdsh $$PRIMARYMN "hostname $$PRIMARYMN-1"
+check:rc==0
+cmd:updatenode $$PRIMARYMN -P "cfghamn -l $$MN:/install/autotestHA -i 100.1.0.233 -n $$PMNSECONDNIC:0 -x s"
+check:rc==0
+
+#configure second MN as standby HA MN
+cmd:xdsh $$STANDBYMN "hostname $$STANDBYMN-1"
+check:rc==0
+cmd:updatenode $$STANDBYMN -P "cfghamn -l $$MN:/install/autotestHA -i 100.1.0.233 -n $$SMNSECONDNIC:0 -x s"
+check:rc==0
+
+#activate the first HA node
+cmd:updatenode $$PRIMARYMN -P "cfghamn -l $$MN:/install/autotestHA -i 100.1.0.233 -n $$PMNSECONDNIC:0 -x a"
+check:rc==0
+cmd:xdsh $$PRIMARYMN "chdef -t site domain=pok.stglabs.ibm.com"
+cmd:makedhcp -d $$HACN
+check:rc==0
+
+#provision HACN on primary MN
+cmd:rsync /opt/xcat/share/xcat/tools/autotest/__GETNODEATTR($$PRIMARYMN,os)__-__GETNODEATTR($$PRIMARYMN,arch)__-netboot-compute.tgz $$PRIMARYMN:/root/
+check:rc==0
+cmd:xdsh $$PRIMARYMN "imgimport /root/__GETNODEATTR($$PRIMARYMN,os)__-__GETNODEATTR($$PRIMARYMN,arch)__-netboot-compute.tgz"
+check:rc==0
+cmd:xdsh $$PRIMARYMN "cat /tmp/HACN.stanza|chdef -z"
+check:rc==0
+cmd:xdsh $$PRIMARYMN "chdef $$HACN ip=100.10.0.103"
+cmd:xdsh $$PRIMARYMN "makedns -n"
+check:rc==0
+cmd:xdsh $$PRIMARYMN "makedhcp -n"
+check:rc==0
+cmd:xdsh $$PRIMARYMN "makedhcp -a"
+check:rc==0
+cmd:xdsh $$PRIMARYMN "rinstall $$HACN osimage=__GETNODEATTR($$PRIMARYMN,os)__-__GETNODEATTR($$PRIMARYMN,arch)__-netboot-compute"
+check:rc==0
+cmd:sleep 150
+cmd:xdsh $$PRIMARYMN "chmod 755 /xcatpost/check_node_state"
+cmd:xdsh $$PRIMARYMN "/xcatpost/check_node_state $$HACN"
+cmd:xdsh $$PRIMARYMN "lsdef $$HACN -i status"
+check:output=~booted
+check:rc==0
+
+#deactivate the first HA node
+cmd:updatenode $$PRIMARYMN -P "cfghamn -l $$MN:/install/autotestHA -i 100.1.0.233 -n $$SMNSECONDNIC:0 -x d"
+check:rc==0
+
+#activate the second HA node
+cmd:updatenode $$STANDBYMN -P "cfghamn -l $$MN:/install/autotestHA -i 100.1.0.233 -n $$SMNSECONDNIC:0 -x a"
+check:rc==0
+
+#provision HACN on standby MN
+cmd:xdsh $$STANDBYMN "rinstall $$HACN osimage=__GETNODEATTR($$PRIMARYMN,os)__-__GETNODEATTR($$PRIMARYMN,arch)__-netboot-compute"
+check:rc==0
+cmd:sleep 150
+cmd:xdsh $$STANDBYMN "chmod 755 /xcatpost/check_node_state"
+cmd:xdsh $$STANDBYMN "/xcatpost/check_node_state $$HACN"
+cmd:xdsh $$STANDBYMN "lsdef $$HACN -i status"
+check:output=~booted
+
+#deactivate the second HA node
+cmd:updatenode $$STANDBYMN -P "cfghamn -l $$MN:/install/autotestHA -i 100.1.0.233 -x d"
+check:rc==0
+
+#restore data
+cmd:cat /tmp/node.stanza | chdef -z;rm -rf /tmp/node.stanza
+cmd:cat /tmp/osimage.stanza | chdef -z;rm -rf /tmp/osimage.stanza
+cmd:rm -rf /opt/xcat/share/xcat/tools/autotest/testcase/HA/hosts
+cmd:rmdef -t network -o 100_1_0_0-255_255_0_0
+cmd:rm -rf /install/post/otherpkgs/__GETNODEATTR($$PRIMARYMN,os)__/__GETNODEATTR($$PRIMARYMN,arch)__ 
+cmd:rm -rf /opt/xcat/share/xcat/tools/autotest/__GETNODEATTR($$PRIMARYMN,os)__-__GETNODEATTR($$PRIMARYMN,arch)__-netboot-compute.tgz
+cmd:if [[ -d /install/autotestHA.bak ]] ;then mv -f /install/autotestHA.bak /install/autotestHA;fi
+cmd:if [[ -f /test.synclist.bak ]] ;then mv -f /test.synclist.bak /tmp/test.synclist;else rm -rf /test.synclist;fi
+cmd:if [[ -f /install/postscripts/cfghamn.bak ]] ;then mv -f /install/postscripts/cfghamn.bak /install/postscripts/cfghamn;fi;
+cmd:if [[ -f /install/postscripts/xcatha.py.bak ]] ;then mv -f /install/postscripts/xcatha.py.bak /install/postscripts/xcatha.py;fi;
+cmd:if [[ -f /install/postscripts/check_node_state.bak ]] ;then mv -f /install/postscripts/check_node_state.bak /install/postscripts/check_node_state;fi;
+cmd:if [[ -f /opt/xcat/share/xcat/install/rh/autotest.otherpkgs.pkglist.bak ]] ;then mv -f /opt/xcat/share/xcat/install/rh/autotest.otherpkgs.pkglist.bak /opt/xcat/share/xcat/install/rh/autotest.otherpkgs.pkglist;fi
+end

--- a/xCAT-test/autotest/testcase/HA/case0
+++ b/xCAT-test/autotest/testcase/HA/case0
@@ -29,7 +29,8 @@ cmd:if [[ -f /install/postscripts/check_node_state ]] ;then mv -f /install/posts
 cmd:cp -f /opt/xcat/share/xcat/tools/autotest/testcase/HA/cfghamn /install/postscripts/
 cmd:cp -f /opt/xcat/share/xcat/tools/autotest/testcase/HA/check_node_state /install/postscripts/
 cmd:if [[ -f /install/postscripts/xcatha.py ]] ;then mv -f /install/postscripts/xcatha.py /install/postscripts/xcatha.py.bak;fi;
-cmd:if [[ ! -f /install/postscripts/xcatha.py ]] ;then wget $$HASCIPRTURL -P /install/postscripts/; fi;
+cmd:wget -O - $$HASCIPRTURL > /install/postscripts/xcatha.py
+check:rc==0
 cmd:ls /install/postscripts/xcatha.py
 check:rc==0
 cmd:genimage __GETNODEATTR($$PRIMARYMN,os)__-__GETNODEATTR($$PRIMARYMN,arch)__-netboot-compute
@@ -111,8 +112,9 @@ cmd:xdsh $$PRIMARYMN "chmod 755 /xcatpost/check_node_state"
 cmd:xdsh $$PRIMARYMN "/xcatpost/check_node_state $$HACN"
 cmd:xdsh $$PRIMARYMN "lsdef $$HACN -i status"
 check:output=~booted
+cmd:xdsh $$PRIMARYMN "xdsh $$HACN date"
 check:rc==0
-
+ 
 #deactivate the first HA node
 cmd:updatenode $$PRIMARYMN -P "cfghamn -l $$MN:/install/autotestHA -i $$VIP -x d"
 check:rc==0

--- a/xCAT-test/autotest/testcase/HA/cfghamn
+++ b/xCAT-test/autotest/testcase/HA/cfghamn
@@ -1,0 +1,171 @@
+#!/bin/bash
+#USAGE:cfghamn -l shared_data_path -i VIP [-g git_repo_for_xcat_inventory_data] [-x s|d|a]
+
+str_os_type=`uname -s`
+if [ x"$str_os_type" = "xLinux" ];then
+    str_dir_name="${0%/*}"
+    . $str_dir_name/xcatlib.sh
+else
+    log_error "Does NOT support non-Linux Operating System."
+    exit 1
+fi
+
+# get specific NIC for VIP
+function get_nic(){
+    pysical_ip=$1
+    primary_nic=`ip route | grep $pysical_ip | awk -F '[ \t*]' '{print $3}'|head -1`
+    if [ -n $primary_nic ]; then
+        echo $primary_nic:0
+    fi
+}
+
+function get_mask(){
+   pysical_ip=$1
+   prefix=$(ip route |grep $pysical_ip|awk '{print $1}'|cut -f 2 -d'/')
+   netmask=$(v4prefix2mask $prefix)
+   if [ -n $netmask ]; then
+       echo $netmask
+   else
+       echo "255.255.255.0"
+   fi
+}
+
+pysical_hostname=$(hostname -s)
+pysical_ip=$(hostname -i)
+#create vip hostname
+function get_vip_hostname(){
+    vip=$1
+    vip_hostname=$(getent hosts $vip | awk -F ' ' '{print $2}' | awk -F'.' '{print $1}'| uniq)
+    if [ -z $vip_hostname ]; then
+        vip_hostname=${pysical_hostname}-ha
+    fi
+    echo $vip_hostname
+}
+
+return_code=0
+if [ $# -lt 4 ]; then
+    echo "USAGE:`basename $0` -l shared_data_path -i VIP"
+    exit 1
+fi
+while getopts "l:i:g:x:n:" opt; do
+  case $opt in
+    l)
+      SHARE_DATA=$OPTARG
+      echo "The shared data directory is $SHARE_DATA" 
+      ;;
+    i)
+      VIP=$OPTARG
+      echo "The VIP is $VIP"
+      ;; 
+    g)
+      URL=$OPTARG
+      echo "xcat-inventory git URL is $URL"
+      ;;
+    x)
+      #options can be s|d|a
+      # s means setup, d means deactivate, a means activate
+      XCMD=$OPTARG
+      ;;
+    n)
+      #VIP physical nic
+      PHYSICALNIC=$OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG"
+      return_code=1 
+      ;;
+  esac
+done
+if [ -z $PHYSICALNIC ]; then
+    VIP_NIC=$(get_nic $pysical_ip)
+else
+    VIP_NIC=$PHYSICALNIC
+fi
+if [ -n $VIP_NIC ]; then
+    echo "VIP NIC is :" $VIP_NIC
+else
+    echo "Error: cannot get VIP NIC"
+    return_code=1
+fi
+
+yum -y install yum-utils
+
+cmdlable=""
+if [ -n $XCMD ]; then
+    if [[ "${XCMD}" == "s" || "${XCMD}" == "a" || "${XCMD}" == "d" ]]; then
+        cmdlable=$XCMD
+    else
+        echo "Error: xcatha.py does not support $XCMD option"
+        return_code=1
+    fi
+fi
+
+NETMASK=$(get_mask $pysical_ip) 
+if [[ -n $NETMASK ]]; then
+    echo "NETMASK is :" $NETMASK
+fi
+VIP_hostname=$(get_vip_hostname $VIP)
+if [ -n $VIP_hostname ]; then
+    echo "VIP hostname is :" $VIP_hostname
+else
+    echo "Error: cannot define VIP hostname"
+    return_code=1
+fi
+SHARE_DATA_DES=/xcat/HA/$pysical_hostname
+if [[ "$cmdlable" == "s" ]]; then
+    mkdir -p $SHARE_DATA_DES
+    mount|grep -w $SHARE_DATA_DES
+    if [ $? -ne 0 ]; then 
+        mount $SHARE_DATA $SHARE_DATA_DES
+        if [ $? -ne 0 ]; then
+            echo "mount $SHARE_DATA $SHARE_DATA_DES [failed]"
+            return_code=1
+        fi
+    else
+        echo "$SHARE_DATA_DES is already mounted"
+    fi
+fi
+if [ -n "$URL" ]; then
+    rm -rf /root/xcat-mn-data
+    git clone $URL /root/xcat-mn-data
+else
+    echo "There is no xcat-inventory data"
+fi
+
+if [ $return_code -eq 1 ]; then
+    echo "Process exit with above error"
+    exit $return_code
+else
+    if [[ "$cmdlable" == "s" ]]; then
+        echo "Start to configure HA NODE $VIP_hostname"
+        msg="python /xcatpost/xcatha.py -s -p /$SHARE_DATA_DES -v $VIP -i $VIP_NIC -n $VIP_hostname -m $NETMASK"
+        echo $msg
+        python /xcatpost/xcatha.py -s -p /$SHARE_DATA_DES -v $VIP -i $VIP_NIC -n $VIP_hostname -m $NETMASK
+        if [ $? -ne 0 ]; then
+            return_code=1
+        fi
+    elif [[ "$cmdlable" == "a" ]]; then
+        echo "Start to activate $VIP_hostname"
+        python /xcatpost/xcatha.py -a -p /$SHARE_DATA_DES -v $VIP -i $VIP_NIC -n $VIP_hostname -m $NETMASK
+        if [ $? -eq 0 ]; then
+             if [ -d /root/xcat-mn-data ]; then
+                 echo "use xcat-inventory to import Cluster data"
+                 xcat-inventory import -f /root/xcat-mn-data/cluster.json
+                 if [ $? -ne 0 ]; then
+                     return_code=1
+                 fi
+             fi
+        else
+            return_code=1
+        fi
+    elif [[ "$cmdlable" == "d" ]]; then
+        echo "Start to deactivate $VIP_hostname"
+        python /xcatpost/xcatha.py -d -v $VIP -i $VIP_NIC
+        if [ $? -ne 0 ]; then
+            return_code=1
+        fi
+    else
+        return_code=1
+    fi
+fi
+exit $return_code

--- a/xCAT-test/autotest/testcase/HA/check_node_state
+++ b/xCAT-test/autotest/testcase/HA/check_node_state
@@ -1,0 +1,12 @@
+#!/bin/bash
+a=0;
+HAMN=$1
+while ! $(lsdef -l $HAMN|grep status|grep booted >/dev/null)
+do 
+    sleep 20
+    ((a++))
+    echo "Retry ..."
+    if [ $a -gt 300 ];then 
+        break
+    fi 
+done


### PR DESCRIPTION
for https://github.com/xcat2/xcat2-task-management/issues/249

Add 2 testcase:
setup_2_new_HA_MN
configure_exist_xCAT_MN_to_HA_MN

I ran UT in autotest ENV, the log was too long, so I only paste the results  here:
```
xcattest.log.20180828224841:------END::setup_2_new_HA_MN::Passed::Time:Tue Aug 28 23:37:23 2018 ::Duration::2917 sec------
xcattest.log.20180830223154:------END::configure_exist_xCAT_MN_to_HA_MN::Passed::Time:Thu Aug 30 23:00:43 2018 ::Duration::1724 sec------
```
Key process:
```
RUN:updatenode c910f03c11k16 -P "cfghamn -l $mnip:/install/HA -i 10.3.17.233 -x a" [Tue Aug 28 23:26:10 2018]
ElapsedTime:9 sec
RETURN rc = 0
OUTPUT:
c910f03c11k16: vpdupdate is not supported on the pSeries KVM Guest platform
c910f03c11k16: updating VPD database
c910f03c11k16: trying to download postscripts...
c910f03c11k16: postscripts downloaded successfully
c910f03c11k16: trying to get mypostscript from 10.3.11.15...
c910f03c11k16: Running postscript: cfghamn
c910f03c11k16: The shared data directory is :/install/HA
c910f03c11k16: The VIP is 10.3.17.233
c910f03c11k16: VIP NIC is : eth2:0
c910f03c11k16: Loaded plugins: product-id, search-disabled-repos, subscription-manager
c910f03c11k16: This system is not registered with an entitlement server. You can use subscription-manager to register.
c910f03c11k16: Package yum-utils-1.1.31-45.el7.noarch already installed and latest version
c910f03c11k16: Nothing to do
c910f03c11k16: NETMASK is : 255.0.0.0
c910f03c11k16: VIP hostname is : autotesthamn
c910f03c11k16: There is no xcat-inventory data
c910f03c11k16: Start to activate autotesthamn
c910f03c11k16: 2018-08-28 23:26:12,506 - INFO - Activating this node as xCAT primary MN
c910f03c11k16: 2018-08-28 23:26:12,510 - INFO - ########## Activate stage ##########
c910f03c11k16: 2018-08-28 23:26:12,510 - INFO - ===> Check virtual ip stage <===
c910f03c11k16: 2018-08-28 23:26:12,510 - DEBUG - ping -c 1 -w 10 10.3.17.233
c910f03c11k16: PING 10.3.17.233 (10.3.17.233) 56(84) bytes of data.
c910f03c11k16: --- 10.3.17.233 ping statistics ---
c910f03c11k16: 3 packets transmitted, 0 received, +3 errors, 100% packet loss, time 2101ms
c910f03c11k16: pipe 3
c910f03c11k16: 2018-08-28 23:26:15,656 - INFO - virtual ip can be used.
c910f03c11k16: 2018-08-28 23:26:15,656 - INFO - ===> Configure virtual ip as alias ip stage <===
c910f03c11k16: 2018-08-28 23:26:15,659 - DEBUG - ifconfig eth2:0 10.3.17.233  netmask 255.0.0.0 [Passed]
c910f03c11k16: 2018-08-28 23:26:15,666 - INFO - ===> Configure hostname stage <===
c910f03c11k16: 2018-08-28 23:26:15,668 - DEBUG - hostname autotesthamn [Passed]
c910f03c11k16: 2018-08-28 23:26:15,668 - INFO - Check if xCAT data is in shared data directory
c910f03c11k16: 2018-08-28 23:26:15,669 - DEBUG - There is xCAT data //xcat/HA/c910f03c11k16/install in shared data //xcat/HA/c910f03c11k16
c910f03c11k16: 2018-08-28 23:26:15,669 - INFO - ===> Start all services stage <===
c910f03c11k16: 2018-08-28 23:26:16,746 - DEBUG - systemctl start postgresql [Passed]
c910f03c11k16: 2018-08-28 23:26:19,363 - DEBUG - systemctl start xcatd [Passed]
c910f03c11k16: 2018-08-28 23:26:19,769 - ERROR - lsdef -t site -i domain|grep domain [Failed]
c910f03c11k16: 2018-08-28 23:26:19,769 - WARNING - "domain" entry is not in "site" table. "named" service will not be started
c910f03c11k16: 2018-08-28 23:26:19,769 - WARNING - "domain" entry is not in "site" table. "dhcpd" service will not be started
c910f03c11k16: 2018-08-28 23:26:19,830 - DEBUG - systemctl start ntpd [Passed]
c910f03c11k16: 2018-08-28 23:26:19,831 - INFO - This machine is set to primary management node successfully...
c910f03c11k16: postscript: cfghamn exited with code 0
c910f03c11k16: Running of postscripts has completed.
CHECK:rc == 0   [Pass]

... ...

RUN:xdsh c910f03c11k16 "rinstall c910f03c11k18 osimage=__GETNODEATTR(c910f03c11k16,os)__-__GETNODEATTR(c910f03c11k16,arch)__-netboot-compute" [Tue Aug 28 23:26:42 2018]
ElapsedTime:5 sec
RETURN rc = 0
OUTPUT:
c910f03c11k16: Provision node(s): c910f03c11k18
CHECK:rc == 0   [Pass]

RUN:sleep 300 [Tue Aug 28 23:26:47 2018]
ElapsedTime:300 sec
RETURN rc = 0
OUTPUT:

RUN:xdsh c910f03c11k16 "chmod 755 /xcatpost/check_node_state" [Tue Aug 28 23:31:47 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:xdsh c910f03c11k16 "/xcatpost/check_node_state c910f03c11k18" [Tue Aug 28 23:31:48 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
... ...

RUN:xdsh c910f03c11k16 "lsdef c910f03c11k18 -i status" [Tue Aug 28 23:31:49 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f03c11k16: Object name: c910f03c11k18
c910f03c11k16:     status=booted
CHECK:output =~ booted  [Pass]
CHECK:rc == 0   [Pass]

RUN:updatenode c910f03c11k16 -P "cfghamn -l $mnip:/install/HA -i 10.3.17.233 -x d" [Tue Aug 28 23:31:50 2018]
ElapsedTime:5 sec
RETURN rc = 0
OUTPUT:
c910f03c11k16: vpdupdate is not supported on the pSeries KVM Guest platform
c910f03c11k16: updating VPD database
... ...
c910f03c11k16: 2018-08-28 23:31:55,214 - INFO - This machine is set to standby management node successfully...
c910f03c11k16: postscript: cfghamn exited with code 0
c910f03c11k16: Running of postscripts has completed.
CHECK:rc == 0   [Pass]

RUN:updatenode c910f03c11k17 -P "cfghamn -l $mnip:/install/HA -i 10.3.17.233 -x a" [Tue Aug 28 23:31:55 2018]
ElapsedTime:13 sec
RETURN rc = 0
OUTPUT:
c910f03c11k17: vpdupdate is not supported on the pSeries KVM Guest platform
c910f03c11k17: updating VPD database
... ...
c910f03c11k17: postscripts downloaded successfully
c910f03c11k17: trying to get mypostscript from 10.3.11.15...
c910f03c11k17: Running postscript: cfghamn
c910f03c11k17: The shared data directory is :/install/HA
c910f03c11k17: The VIP is 10.3.17.233
c910f03c11k17: VIP NIC is : eth2:0
c910f03c11k17: Loaded plugins: product-id, search-disabled-repos, subscription-manager
c910f03c11k17: This system is not registered with an entitlement server. You can use subscription-manager to register.
c910f03c11k17: Package yum-utils-1.1.31-45.el7.noarch already installed and latest version
c910f03c11k17: Nothing to do
c910f03c11k17: NETMASK is : 255.0.0.0
c910f03c11k17: VIP hostname is : autotesthamn
c910f03c11k17: There is no xcat-inventory data
c910f03c11k17: Start to activate autotesthamn
c910f03c11k17: 2018-08-28 23:31:57,167 - INFO - Activating this node as xCAT primary MN
c910f03c11k17: 2018-08-28 23:31:57,169 - INFO - ########## Activate stage ##########
c910f03c11k17: 2018-08-28 23:31:57,169 - INFO - ===> Check virtual ip stage <===
... ...
c910f03c11k17: 2018-08-28 23:32:08,751 - INFO - This machine is set to primary management node successfully...
c910f03c11k17: postscript: cfghamn exited with code 0
c910f03c11k17: Running of postscripts has completed.
CHECK:rc == 0   [Pass]

RUN:xdsh c910f03c11k17 "rinstall c910f03c11k18 osimage=__GETNODEATTR(c910f03c11k16,os)__-__GETNODEATTR(c910f03c11k16,arch)__-netboot-compute" [Tue Aug 28 23:32:08 2018]
ElapsedTime:6 sec
RETURN rc = 0
OUTPUT:
c910f03c11k17: Provision node(s): c910f03c11k18
CHECK:rc == 0   [Pass]
... ...
RUN:xdsh c910f03c11k17 "lsdef c910f03c11k18 -i status" [Tue Aug 28 23:37:15 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f03c11k17: Object name: c910f03c11k18
c910f03c11k17:     status=booted
CHECK:output =~ booted  [Pass]

RUN:updatenode c910f03c11k17 -P "cfghamn -l $mnip:/install/HA -i 10.3.17.233 -x d" [Tue Aug 28 23:37:16 2018]
ElapsedTime:5 sec
RETURN rc = 0
OUTPUT:
... ...
------END::setup_2_new_HA_MN::Passed::Time:Tue Aug 28 23:37:23 2018 ::Duration::2917 sec------
```

