### PR TITLE
Modify test case buildkit_v to support rhels

### DIFF
--- a/xCAT-test/autotest/testcase/buildkit/cases0
+++ b/xCAT-test/autotest/testcase/buildkit/cases0
@@ -2,12 +2,12 @@ start:buildkit_v
 os:Linux
 cmd:buildkit -v
 check:rc==0
-check:output=~xcat-buildkit
+check:output=~x[cC][aA][tT]-buildkit
 check:output=~kitframework
 check:output=~compatible_frameworks
 cmd:buildkit --version
 check:rc==0
-check:output=~xcat-buildkit
+check:output=~x[cC][aA][tT]-buildkit
 check:output=~kitframework
 check:output=~compatible_frameworks
 end


### PR DESCRIPTION
### Modify test case `buildkit_v` to support rhels

The modification is to match xcat name in both upper-case and lower-case. 

### The UT result in rhels7.6
```
------START::buildkit_v::Time:Mon Sep  3 22:15:03 2018------

RUN:buildkit -v [Mon Sep  3 22:15:03 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
xCAT-buildkit:  2.14.4-snap201809031026
	kitframework = 2
	compatible_frameworks = 0,1,2
CHECK:rc == 0	[Pass]
CHECK:output =~ x[cC][aA][tT]-buildkit	[Pass]
CHECK:output =~ kitframework	[Pass]
CHECK:output =~ compatible_frameworks	[Pass]

RUN:buildkit --version [Mon Sep  3 22:15:03 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
xCAT-buildkit:  2.14.4-snap201809031026
	kitframework = 2
	compatible_frameworks = 0,1,2
CHECK:rc == 0	[Pass]
CHECK:output =~ x[cC][aA][tT]-buildkit	[Pass]
CHECK:output =~ kitframework	[Pass]
CHECK:output =~ compatible_frameworks	[Pass]

------END::buildkit_v::Passed::Time:Mon Sep  3 22:15:03 2018 ::Duration::0 sec------
------Total: 1 , Failed: 0------
```

