### PR TITLE
refine test case xdsh_regular_command

### DIFF
--- a/xCAT-test/autotest/testcase/xdsh/cases0
+++ b/xCAT-test/autotest/testcase/xdsh/cases0
@@ -15,7 +15,7 @@ start:xdsh_regular_command
 label:cn_os_ready,parallel_cmds
 cmd:XCATBYPASS=1 xdsh $$CN "ps -ef"
 check:rc==0
-check:output=~$$CN: UID        PID  PPID  C STIME TTY          TIME CMD
+check:output=~$$CN:\s+UID\s+PID\s+PPID\s+C\s+STIME\s+TTY\s+TIME\s+CMD
 end
 
 start:xdsh_Q_command


### PR DESCRIPTION
### The PR is to refine test case

### The modification include

* refine  ``xdsh_regular_command``. 

In some OSs , the output of ``ps -ef `` are 
```
UID         PID   PPID  C STIME TTY          TIME CMD
...
```
In some OSs, the output of ``ps -ef`` are
```
UID        PID  PPID  C STIME TTY          TIME CMD
```
Refine the regular expression of test case ``xdsh_regular_command``

### The UT result
```
------START::xdsh_regular_command::Time:Tue Sep  4 01:45:18 2018------

RUN:XCATBYPASS=1 xdsh c910f02c01p27 "ps -ef" [Tue Sep  4 01:45:18 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
/usr/bin/locale: Cannot set LC_CTYPE to default locale: No such file or directory
/usr/bin/locale: Cannot set LC_ALL to default locale: No such file or directory
c910f02c01p27: UID        PID  PPID  C STIME TTY          TIME CMD
c910f02c01p27: root         1     0  0 Sep03 ?        00:00:02 /usr/lib/systemd/systemd --switched-root --system --deserialize 22
c910f02c01p27: root         2     0  0 Sep03 ?        00:00:00 [kthreadd]
.......
c910f02c01p27: root     22393 22390  0 01:45 ?        00:00:00 ps -ef
c910f02c01p27: bash: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
c910f02c01p27: bash: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
CHECK:rc == 0	[Pass]
CHECK:output =~ c910f02c01p27:\s+UID\s+PID\s+PPID\s+C\s+STIME\s+TTY\s+TIME\s+CMD	[Pass]

------END::xdsh_regular_command::Passed::Time:Tue Sep  4 01:45:21 2018 ::Duration::3 sec------
------Total: 1 , Failed: 0------
```
