### PR TITLE
fix issue 5598, return 1 when invalid id for reventlog resolved

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_eventlog.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_eventlog.py
@@ -102,11 +102,11 @@ class OpenBMCEventlogTask(ParallelNodesCommand):
                             if self.verbose:
                                 self.callback.info('%s: Not resolving already resolved eventlog ID %s'  % (node, id_to_resolve))
                     else:
-                        self.callback.info('%s: Invalid ID: %s'  % (node, id_to_resolve))
+                        self.callback.error('Invalid ID: %s'  % (id_to_resolve), node)
 
             if len(eventlog_ids_to_resolve) == 0:
                 # At the end and there are no entries to resolve
-                self.callback.info('%s: No event log entries needed to be resolved'  % node)
+                self.callback.error('No event log entries needed to be resolved', node)
             else:
                 # Resolve entries that were collected into the eventlog_ids_to_resolve array
                 obmc.resolve_event_log_entries(eventlog_ids_to_resolve)


### PR DESCRIPTION
### The PR is to fix issue _#5598_

### The modification include

If id_to_resolve is invalid, return code will be "1".

### The UT result
```
# reventlog mid05tor12cn03 resolved=-1
Attempting to resolve the following log entries: -1...
Install the OpenBMC RAS package to obtain more details logging messages.
mid05tor12cn03: [briggs01]: Error: Invalid ID: -1
mid05tor12cn03: [briggs01]: Error: No event log entries needed to be resolved
# echo $?
1
```

Checked perl code, do not need to modify, return code is 1.