### PR TITLE
fix issue 5245, return 0 when pscp -h

### DIFF
--- a/xCAT-client/bin/pscp
+++ b/xCAT-client/bin/pscp
@@ -20,7 +20,7 @@ my $interface;
 GetOptions(
     "interface=s" => \$interface,
     "f|fanout=s"  => \$fanout,
-    "h|help"      => \$usage,
+    "h|help"      => \&usage,
     "v|version"   => \$::VERSION,
 );
 my %nodehdl;
@@ -32,9 +32,17 @@ if ($ENV{XCATHOST}) {
 
 sub usage
 {
-    print $_[0];
+    my $rc = 1;
+    my @info = @_;
+    if (@info) {
+        if ($info[0] eq "h") {
+            $rc = 0;
+        } else {
+            print $info[0];
+        } 
+    }
     print "Usage: pscp [ -f fanout] [-i <SUFFIX>] [SCP OPTIONS...] FILE... <NODERANGE>:<DESTINATION>\n";
-    exit 1;
+    exit $rc;
 }
 
 my $pshmaxp = 64;


### PR DESCRIPTION
### The PR is to fix issue _#5245_

### The modification include

Check function "usage" parameter, if "h", exit code is 0;

### The UT result
```
[root@c910f03c17k21 xcat-core]# pscp -h
Usage: pscp [ -f fanout] [-i <SUFFIX>] [SCP OPTIONS...] FILE... <NODERANGE>:<DESTINATION>
[root@c910f03c17k21 xcat-core]# echo $?
0
[root@c910f03c17k21 xcat-core]# pscp
Usage: pscp [ -f fanout] [-i <SUFFIX>] [SCP OPTIONS...] FILE... <NODERANGE>:<DESTINATION>
[root@c910f03c17k21 xcat-core]# echo $?
1
[root@c910f03c17k21 xcat-core]# pscp -r /tmp/cluster.json
No node range specified

Usage: pscp [ -f fanout] [-i <SUFFIX>] [SCP OPTIONS...] FILE... <NODERANGE>:<DESTINATION>
```