### PR TITLE
fix issue 5604, delete extra / of rootimgdir

### DIFF
--- a/xCAT-server/share/xcat/ib/scripts/Mellanox/mlnxofed_ib_install.v2
+++ b/xCAT-server/share/xcat/ib/scripts/Mellanox/mlnxofed_ib_install.v2
@@ -204,7 +204,12 @@ function cleanup()
         fi
 
         # Clean up the ofed iso
-        if mount | grep -q "$IMGROOTPATH/tmp/ofed/mountpoint"; then
+        tmp_imgpath=$IMGROOTPATH
+        while (echo $tmp_imgpath | grep "/$")
+        do
+            tmp_imgpath=${tmp_imgpath%/*}
+        done
+        if mount | grep -q "$tmp_imgpath/tmp/ofed/mountpoint"; then
             while ! umount "$IMGROOTPATH/tmp/ofed/mountpoint"
             do
                 (( ++i > max_retry )) && echo "Umount $IMGROOTPATH/tmp/ofed/mountpoint failed" >&2 && break


### PR DESCRIPTION
### The PR is to fix issue _#5604_

### The modification include

delete extra '/' in rootimgdir.

### The UT result
```
# cat test.sh
rootimg="/aaa/bbb/cccc//"
while (echo $rootimg | grep "/$")
do
    rootimg=${rootimg%/*}
done
echo $rootimg

# sh test.sh
/aaa/bbb/cccc
```