### PR TITLE
Fix bug #5612 of xcattest

### DIFF
--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -1741,7 +1741,9 @@ sub get_files_recursive
         next if ($direntry eq '..');
         my $target = "$dir/$direntry";
         if (-d $target) {
-            get_files_recursive($target, $files_path_ref);
+            unless ($target =~ /xcat-inventory\/templates/){
+                get_files_recursive($target, $files_path_ref);
+            }
         } else {
             push(@{$files_path_ref}, glob("$target\n"));
         }


### PR DESCRIPTION
### The PR is to fix issue #5612 

### The modification include

Filter out `xcat-inventory/template` directory when load test cases.


### The UT result
```
[root@f6u13k10 xcat-inventory]#  xcattest -c xcat-inventory
xCAT automated test started at Thu Sep  6 22:40:18 2018
******************************
To detect current test environment
******************************
Detecting: OS = linux
Warning: No compute node defined, can't get ARCH of compute node
Warning: No compute node defined, can't get HCP TYPE of compute node
******************************
loading test cases
******************************
Miss attribute:
export_import_single_ppc_by_json miss attribute DSTMN
export_import_single_ppc_by_yaml miss attribute DSTMN
export_import_single_kvm_by_json miss attribute DSTMN
export_import_single_kvm_by_yaml miss attribute DSTMN
export_import_single_pdu_by_json miss attribute DSTMN
export_import_single_pdu_by_yaml miss attribute DSTMN
export_import_single_boston_by_yaml miss attribute DSTMN
export_import_single_boston_by_json miss attribute DSTMN
export_import_single_witherspoon_by_yaml miss attribute DSTMN
export_import_single_witherspoon_by_json miss attribute DSTMN
export_import_single_switch_by_json miss attribute DSTMN
export_import_single_switch_by_yaml miss attribute DSTMN
export_import_nodes_delimited_with_comma_by_yaml miss attribute DSTMN
export_import_nodes_delimited_with_comma_by_json miss attribute DSTMN
export_single_node_then_modify_yaml_then_import miss attribute DSTMN
export_single_node_then_modify_json_then_import miss attribute DSTMN
export_import_single_group_json miss attribute DSTMN
export_import_single_group_yaml miss attribute DSTMN
```

