### PR TITLE
fix issue 5617, show existed node info when bmcdiscover -z

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -1175,6 +1175,10 @@ sub bmcdiscovery_ipmi {
                 if (exists($::VPDHASH{$mtmsip})) {
                     my $pre_node = $::VPDHASH{$mtmsip};
                     xCAT::MsgUtils->message("I", { data => ["Found match node $pre_node with bmc ip address: $ip, rsetboot/rpower $pre_node to continue hardware discovery."] }, $::CALLBACK);
+                    if ($opz) {
+                        $node_data .= ",";
+                        display_output($opz,undef,$pre_node,$mac_node,$node_data,"ipmi",$request_command);
+                    }
                     return;
                 }
                 $mtms_node = "node-$mtm-$serial";
@@ -1304,6 +1308,10 @@ sub bmcdiscovery_openbmc{
             if (exists($::VPDHASH{$mtmsip})) {
                 my $pre_node = $::VPDHASH{$mtmsip};
                 xCAT::MsgUtils->message("I", { data => ["Found match node $pre_node with bmc ip address: $ip, rsetboot/rpower $pre_node to continue hardware discovery."] }, $::CALLBACK);
+                if ($opz) {
+                    $node_data .= ",";
+                    display_output($opz,undef,$pre_node,$mac_node,$node_data,"openbmc",$request_command);
+                }
                 return;
             }
             $mtms_node = "node-$mtm-$serial";


### PR DESCRIPTION
### The PR is to fix issue _#5617_

### The modification include

When ``bmcdiscover -z``, if found match node, even show info as before.

### The UT result
```
# bmcdiscover --range 10.6.13.100 -z
Found match node node-8335-gtc-1318daa with bmc ip address: 10.6.13.100, rsetboot/rpower node-8335-gtc-1318daa to continue hardware discovery.
node-8335-gtc-1318daa:
	objtype=node
	groups=all
	bmc=10.6.13.100
	cons=openbmc
	mgt=openbmc
	mtm=8335-GTC
	serial=1318DAA

# bmcdiscover --range 10.6.13.100
Found match node node-8335-gtc-1318daa with bmc ip address: 10.6.13.100, rsetboot/rpower node-8335-gtc-1318daa to continue hardware discovery.
```