### PR TITLE
fix issue 5627, find verbose option and delete it for openbmc perl

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1224,12 +1224,6 @@ sub parse_args {
         return ([ 1, "Error parsing arguments." ]);
     }
 
-    # If command includes '-V', it must be the last one prarmeter. Or print error message.
-    if ($verbose) {
-        my $option = $$extrargs[-1];
-        return ([ 1, "Error parsing arguments." ]) if ($option !~ /V|verbose/);
-    }
-
     if (scalar(@ARGV) >= 2 and ($command =~ /rpower|rinv|rvitals/)) {
         return ([ 1, "Only one option is supported at the same time for $command" ]);
     } elsif (scalar(@ARGV) >= 2 and $command eq "reventlog") {
@@ -1514,9 +1508,11 @@ sub parse_command_status {
 
     return if ($command eq "getopenbmccons");
 
-    if ($$subcommands[-1] and $$subcommands[-1] =~ /V|verbose/) {
-        $::VERBOSE = 1;
-        pop(@$subcommands);
+    for (my $i = $#{ $subcommands }; $i >= 0; $i--) {
+        if (${ $subcommands }[$i] =~ /^-V$|^--verbose$/) {
+            $::VERBOSE = 1;
+            splice(@{ $subcommands }, $i, 1);
+        }
     }
 
     $next_status{LOGIN_REQUEST} = "LOGIN_RESPONSE";


### PR DESCRIPTION
### The PR is to fix issue _#5627_

### The modification include

Check whether has verbose option(``-V|--verbose``), if has delete it from array.

### The UT result
```
# rinv f6u13 -V serial
Wed Sep 12 03:52:49 2018 OpenBMC: [c910f03c17k21]: [openbmc_debug_perl]
[c910f03c17k21]: Running command in Perl
Wed Sep 12 03:52:49 2018 f6u13: [c910f03c17k21]: [openbmc_debug_perl] curl -k -c cjar -H "Content-Type: application/json" -d '{ "data": ["root", "xxxxxx"] }' https://10.6.13.100/login
Wed Sep 12 03:52:49 2018 f6u13: [c910f03c17k21]: [openbmc_debug_perl] login_response 200 OK
Wed Sep 12 03:52:49 2018 f6u13: [c910f03c17k21]: [openbmc_debug_perl] curl -k -b cjar -X GET -H "Content-Type: application/json" https://10.6.13.100/xyz/openbmc_project/inventory/enumerate
Wed Sep 12 03:52:53 2018 f6u13: [c910f03c17k21]: [openbmc_debug_perl] rinv_response 200 OK
[c910f03c17k21]: f6u13: SYSTEM SerialNumber : 1318DAA.........
```