### PR TITLE
xcat-inventory diff cases

### DIFF
--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.diff
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.diff
@@ -65,7 +65,21 @@ description:This case is used to test xcat-inventory diff files
 label:others,xcat_inventory
 cmd:xcat-inventory diff --files /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file1.json /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file2.json > /tmp/xcat_inventory_diff_files.result
 check:rc==0
-cmd:diff /tmp/xcat_inventory_diff_files.result /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/diff_files.result
+cmd:sh /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/change_name.sh /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file1.json /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file2.json /tmp/tmp_diff.result
+check:rc==0
+cmd:diff /tmp/xcat_inventory_diff_files.result /tmp/tmp_diff.result
+check:output=
+check:rc==0
+end
+
+start:xcat_inventory_diff_files_filename
+description:This case is used to test xcat-inventory diff files filename
+label:others,xcat_inventory
+cmd:xcat-inventory diff --files /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file1.json /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file2.json --filename xcat_inventory_diff_files_filename.test > /tmp/xcat_inventory_diff_files_filename.result
+check:rc==0
+cmd:sh /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/change_name.sh xcat_inventory_diff_files_filename.test xcat_inventory_diff_files_filename.test /tmp/tmp_diff.result
+check:rc==0
+cmd:diff /tmp/xcat_inventory_diff_files_filename.result /tmp/tmp_diff.result
 check:output=
 check:rc==0
 end

--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.diff
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.diff
@@ -1,0 +1,90 @@
+start:xcat_inventory_diff_h
+description:This case is used to test xcat-inventory diff usage information
+label:others,xcat_inventory
+cmd:xcat-inventory diff -h
+check:output=~usage: xcat-inventory diff
+check:rc==0
+cmd:xcat-inventory help diff
+check:output=~usage: xcat-inventory diff
+check:rc==0
+end
+
+start:xcat_inventory_diff_without_option
+description:This case is used to test xcat-inventory diff without option, should be error
+label:others,xcat_inventory
+cmd:xcat-inventory diff
+check:output=~Error: No valid source type!
+check:rc!=0
+end
+
+start:xcat_inventory_diff_files_all
+description:This case is used to test xcat-inventory diff files all, should be error
+label:others,xcat_inventory
+cmd:xcat-inventory diff --files /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file1.json /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file2.json --all
+check:output=~Error: '--all' must be used with '--source'!
+check:rc!=0
+end
+
+start:xcat_inventory_diff_source_filename
+description:This case is used to test xcat-inventory diff source filename, should be error
+label:others,xcat_inventory
+cmd:xcat-inventory diff --source /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file1.json --filename test_filename
+check:output=~Error: '--filename' must be used with '--files'!
+check:rc!=0
+end
+
+start:xcat_inventory_diff_files_source
+description:This case is used to test xcat-inventory diff files source, should be error
+label:others,xcat_inventory
+cmd:xcat-inventory diff --files /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file1.json /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file2.json --source /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file2.json
+check:output=~Error: '--files' and '--source' cannot be used together!
+check:rc!=0
+end
+
+start:xcat_inventory_diff_filename
+description:This case is used to test xcat-inventory diff filename, should be error
+label:others,xcat_inventory
+cmd:xcat-inventory diff --filename test_filename
+check:output=~Error: No valid source type!
+check:rc!=0
+end
+
+start:xcat_inventory_diff_no_exist_file
+description:This case is used to test xcat-inventory diff files, if the given file not exist, show error message
+label:others,xcat_inventory
+cmd:xcat-inventory diff --files /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/noexist.file /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file2.json
+check:output=~Error: File '/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/noexist.file' does not exist, please check...
+check:rc!=0
+cmd:xcat-inventory diff --source /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/noexist.file
+check:output=~Error: File '/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/noexist.file' does not exist, please check...
+check:rc!=0
+end
+
+start:xcat_inventory_diff_files
+description:This case is used to test xcat-inventory diff files
+label:others,xcat_inventory
+cmd:xcat-inventory diff --files /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file1.json /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file2.json > /tmp/xcat_inventory_diff_files.result
+check:rc==0
+cmd:diff /tmp/xcat_inventory_diff_files.result /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/diff_files.result
+check:output=
+check:rc==0
+end
+
+start:xcat_inventory_diff_source
+description:This case is used to test xcat-inventory diff source
+label:others,xcat_inventory
+cmd:rm -rf /tmp/xcat-inventory_diff_case.json
+cmd:xcat-inventory export --format json -f /tmp/xcat-inventory_diff_case.json
+check:rc==0
+cmd:xcat-inventory import -f /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file1.json
+check:rc==0
+cmd:xcat-inventory diff --source /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file2.json > /tmp/xcat_inventory_diff_source.result
+check:rc==0
+cmd:diff /tmp/xcat_inventory_diff_source.result /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/diff_source.result
+check:output=
+check:rc==0
+cmd:xcat-inventory import -c -f /tmp/xcat-inventory_diff_case.json
+check:rc==0
+cmd:rm -rf /tmp/xcat-inventory_diff_case.json
+end
+

--- a/xCAT-test/autotest/testcase/xcat-inventory/diff/change_name.sh
+++ b/xCAT-test/autotest/testcase/xcat-inventory/diff/change_name.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+file1=$1
+file2=$2
+tmp_diff_file=$3
+rm -rf $tmp_diff_file
+echo "copy /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/diff.result to $tmp_diff_file and modify compare file name in $tmp_diff_file"
+cp /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/diff.result $tmp_diff_file
+echo "copy command exit code $?"
+sed -i "s|#FILE1#|$file1|g" $tmp_diff_file
+echo "sed command exit code $?"
+sed -i "s|#FILE2#|$file2|g" $tmp_diff_file
+echo "sed command exit code $?"

--- a/xCAT-test/autotest/testcase/xcat-inventory/diff/diff_files.result
+++ b/xCAT-test/autotest/testcase/xcat-inventory/diff/diff_files.result
@@ -2,8 +2,8 @@
 ====================BEGIN=====================
 
 
---- /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file1.json
-+++ /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file2.json
+--- #FILE1#
++++ #FILE2#
 {
     "node": {
         "node1": {

--- a/xCAT-test/autotest/testcase/xcat-inventory/diff/diff_files.result
+++ b/xCAT-test/autotest/testcase/xcat-inventory/diff/diff_files.result
@@ -1,0 +1,87 @@
+
+====================BEGIN=====================
+
+
+--- /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file1.json
++++ /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file2.json
+{
+    "node": {
+        "node1": {
+            "obj_info": {
+-                "groups": "ipmi"
++                "groups": "all"
+            },
+            "engines": {
+                "hardware_mgt_engine": {
+-                    "engine_type": "ipmi"
+                    "engine_info": {
+-                        "bmcusername": "ADMIN"
+                    },
++                    "engine_type": "openbmc"
+                }
+            }
+        },
+-        "node3": {
+-            "obj_info": {
+-                "groups": "openbmc"
+-            },
+-            "role": "compute",
+-            "device_type": "server",
+-            "engines": {
+-                "hardware_mgt_engine": {
+-                    "engine_info": {
+-                        "bmc": "10.1.1.2",
+-                        "bmcusername": "ADMIN"
+-                    },
+-                    "engine_type": "openbmc"
+-                }
+-            },
+-            "obj_type": "node"
+-        }
+        "node2": {
+            "network_info": {
+                "primarynic": {
+                    "mac": [
+-                        "42:73:0a:03:11:0a!*NOIP*",
++                        "42:6e:0a:03:11:0b"
+                    ]
+                }
+            }
+        }
+    },
+    "osimage": {
+        "rhels7.5-alternate-ppc64le-install-compute": {
+            "package_selection": {
+                "pkgdir": [
++                    "/install/rhels7.5-alternate/ppc64le/test"
+                ],
+                "otherpkgdir": [
+-                    "/install/post/otherpkgs/rhels7.5-alternate/ppc64le",
++                    "/install/post/otherpkgs/rhels7.5-alternate/ppc64"
+                ]
+            }
+        }
+    },
+    "site": {
+        "clustersite": {
+-            "xcatdebugmode": "1",
+-            "domain": "test.com",
+-            "master": "10.1.1.2",
+-            "forwarders": "10.0.0.1"
++            "xcatdebugmode": "0",
++            "domain": "cluster.com",
++            "master": "10.1.1.1"
+        }
+    },
+    "network": {
+        "10_0_0_0-255_0_0_0": {
+            "basic_attr": {
+-                "mgtifname": "eth1"
++                "mgtifname": "eth0"
+            }
+        }
+    }
+}
+
+====================END=====================
+

--- a/xCAT-test/autotest/testcase/xcat-inventory/diff/diff_source.result
+++ b/xCAT-test/autotest/testcase/xcat-inventory/diff/diff_source.result
@@ -1,0 +1,70 @@
+
+====================BEGIN=====================
+
+
+--- xCAT DB
++++ /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file2.json
+{
+    "node": {
+        "node1": {
+            "obj_info": {
+-                "groups": "ipmi"
++                "groups": "all"
+            },
+            "engines": {
+                "hardware_mgt_engine": {
+-                    "engine_type": "ipmi"
+                    "engine_info": {
+-                        "bmcusername": "ADMIN"
+                    },
++                    "engine_type": "openbmc"
+                }
+            }
+        },
+        "node2": {
+            "network_info": {
+                "primarynic": {
+                    "mac": [
+-                        "42:73:0a:03:11:0a!*NOIP*",
++                        "42:6e:0a:03:11:0b"
+                    ]
+                }
+            }
+        }
+    },
+    "osimage": {
+        "rhels7.5-alternate-ppc64le-install-compute": {
+            "package_selection": {
+                "pkgdir": [
++                    "/install/rhels7.5-alternate/ppc64le/test"
+                ],
+                "otherpkgdir": [
+-                    "/install/post/otherpkgs/rhels7.5-alternate/ppc64le",
++                    "/install/post/otherpkgs/rhels7.5-alternate/ppc64"
+                ]
+            }
+        }
+    },
+    "site": {
+        "clustersite": {
+-            "xcatdebugmode": "1",
+-            "domain": "test.com",
+-            "master": "10.1.1.2",
+-            "forwarders": "10.0.0.1"
++            "xcatdebugmode": "0",
++            "domain": "cluster.com",
++            "master": "10.1.1.1"
+        }
+    },
+    "network": {
+        "10_0_0_0-255_0_0_0": {
+            "basic_attr": {
+-                "mgtifname": "eth1"
++                "mgtifname": "eth0"
+            }
+        }
+    }
+}
+
+====================END=====================
+

--- a/xCAT-test/autotest/testcase/xcat-inventory/diff/xcat-inventory_diff_file1.json
+++ b/xCAT-test/autotest/testcase/xcat-inventory/diff/xcat-inventory_diff_file1.json
@@ -1,0 +1,191 @@
+{
+    "network": {
+        "10_0_0_0-255_0_0_0": {
+            "basic_attr": {
+                "gateway": "<xcatmaster>",
+                "mask": "255.0.0.0",
+                "mgtifname": "eth1",
+                "mtu": "1500",
+                "net": "10.0.0.0"
+            },
+            "service": {
+                "tftpserver": "<xcatmaster>"
+            }
+        }
+    },
+    "node": {
+        "node1": {
+            "device_type": "server",
+            "engines": {
+                "hardware_mgt_engine": {
+                    "engine_info": {
+                        "bmc": "10.1.1.1",
+                        "bmcusername": "ADMIN",
+                    },
+                    "engine_type": "ipmi"
+                }
+            },
+            "obj_info": {
+                "groups": "ipmi"
+            },
+            "obj_type": "node",
+            "role": "compute"
+        },
+        "node2": {
+            "device_info": {
+                "arch": "ppc64le",
+                "uuid": "7d6ca5da-9485-11e8-821f-426e0a03110a"
+            },
+            "device_type": "server",
+            "engines": {
+                "console_engine": {
+                    "engine_info": {
+                        "consoleenabled": "1",
+                        "serialport": "0",
+                        "serialspeed": "115200"
+                    }
+                },
+                "hardware_mgt_engine": {
+                    "engine_info": {
+                        "id": "10",
+                        "vmcpus": "2",
+                        "vmhost": "node_host",
+                        "vmmemory": "6144",
+                        "vmnics": "brenP3p9s0f0,brenP3p9s0f1",
+                        "vmstorage": "phy:/dev/mapper/vdiskvg01-vdisk01n10"
+                    },
+                    "engine_type": "kvm"
+                },
+                "netboot_engine": {
+                    "engine_info": {
+                        "osimage": "rhels7.5-ppc64le-install-compute"
+                    },
+                    "engine_type": "grub2"
+                }
+            },
+            "network_info": {
+                "primarynic": {
+                    "mac": [
+                        "42:6e:0a:03:11:0a",
+                        "42:73:0a:03:11:0a!*NOIP*"
+                    ]
+                }
+            },
+            "obj_info": {
+                "groups": "all"
+            },
+            "obj_type": "node",
+            "role": "compute"
+        },
+        "node3": {
+            "device_type": "server",
+            "engines": {
+                "hardware_mgt_engine": {
+                    "engine_info": {
+                        "bmc": "10.1.1.2",
+                        "bmcusername": "ADMIN",
+                    },
+                    "engine_type": "openbmc"
+                }
+            },
+            "obj_info": {
+                "groups": "openbmc"
+            },
+            "obj_type": "node",
+            "role": "compute"
+        },
+        "service": {
+            "device_type": "server",
+            "engines": {
+                "netboot_engine": {
+                    "engine_info": {
+                        "postscripts": "servicenode"
+                    }
+                }
+            },
+            "obj_type": "group",
+            "role": "compute"
+        },
+        "xcatdefaults": {
+            "device_type": "server",
+            "engines": {
+                "netboot_engine": {
+                    "engine_info": {
+                        "postbootscripts": "otherpkgs",
+                        "postscripts": "syslog,remoteshell,syncfiles"
+                    }
+                }
+            },
+            "obj_type": "group",
+            "role": "compute"
+        }
+    },
+    "osimage": {
+        "rhels7.5-alternate-ppc64le-install-compute": {
+            "basic_attributes": {
+                "arch": "ppc64le",
+                "distribution": "rhels7.5-alternate",
+                "osdistro": "rhels7.5-alternate-ppc64le",
+                "osname": "Linux"
+            },
+            "imagetype": "linux",
+            "package_selection": {
+                "otherpkgdir": [
+                    "/install/post/otherpkgs/rhels7.5-alternate/ppc64le"
+                ],
+                "pkgdir": [
+                    "/install/rhels7.5-alternate/ppc64le"
+                ],
+                "pkglist": [
+                    "/opt/xcat/share/xcat/install/rh/compute.rhels7.pkglist"
+                ]
+            },
+            "provision_mode": "install",
+            "role": "compute",
+            "template": "/opt/xcat/share/xcat/install/rh/compute.rhels7.tmpl"
+        },
+    },
+    "schema_version": "latest",
+    "site": {
+        "clustersite": {
+            "SNsyncfiledir": "/var/xcat/syncfiles",
+            "auditnosyslog": "0",
+            "auditskipcmds": "ALL",
+            "blademaxp": "64",
+            "cleanupxcatpost": "no",
+            "consoleondemand": "no",
+            "databaseloc": "/var/lib",
+            "db2installloc": "/mntdb2",
+            "dhcplease": "43200",
+            "dnshandler": "ddns",
+            "domain": "test.com",
+            "enableASMI": "no",
+            "forwarders": "10.0.0.1",
+            "fsptimeout": "0",
+            "installdir": "/install",
+            "ipmimaxp": "64",
+            "ipmiretries": "3",
+            "ipmitimeout": "2",
+            "master": "10.1.1.2",
+            "maxssh": "8",
+            "nameservers": "10.1.1.1",
+            "nodesyncfiledir": "/var/xcat/node/syncfiles",
+            "powerinterval": "0",
+            "ppcmaxp": "64",
+            "ppcretry": "3",
+            "ppctimeout": "0",
+            "sharedtftp": "1",
+            "sshbetweennodes": "ALLGROUPS",
+            "syspowerinterval": "0",
+            "tftpdir": "/tftpboot",
+            "timezone": "US/Eastern",
+            "useNmapfromMN": "no",
+            "vsftp": "n",
+            "xcatconfdir": "/etc/xcat",
+            "xcatdebugmode": "1",
+            "xcatdport": "3001",
+            "xcatiport": "3002",
+            "xcatsslversion": "TLSv1"
+        }
+    }
+}

--- a/xCAT-test/autotest/testcase/xcat-inventory/diff/xcat-inventory_diff_file2.json
+++ b/xCAT-test/autotest/testcase/xcat-inventory/diff/xcat-inventory_diff_file2.json
@@ -1,0 +1,173 @@
+{
+    "network": {
+        "10_0_0_0-255_0_0_0": {
+            "basic_attr": {
+                "gateway": "<xcatmaster>",
+                "mask": "255.0.0.0",
+                "mgtifname": "eth0",
+                "mtu": "1500",
+                "net": "10.0.0.0"
+            },
+            "service": {
+                "tftpserver": "<xcatmaster>"
+            }
+        }
+    },
+    "node": {
+        "node1": {
+            "device_type": "server",
+            "engines": {
+                "hardware_mgt_engine": {
+                    "engine_info": {
+                        "bmc": "10.1.1.1",
+                    },
+                    "engine_type": "openbmc"
+                }
+            },
+            "obj_info": {
+                "groups": "all"
+            },
+            "obj_type": "node",
+            "role": "compute"
+        },
+        "node2": {
+            "device_info": {
+                "arch": "ppc64le",
+                "uuid": "7d6ca5da-9485-11e8-821f-426e0a03110a"
+            },
+            "device_type": "server",
+            "engines": {
+                "console_engine": {
+                    "engine_info": {
+                        "consoleenabled": "1",
+                        "serialport": "0",
+                        "serialspeed": "115200"
+                    }
+                },
+                "hardware_mgt_engine": {
+                    "engine_info": {
+                        "id": "10",
+                        "vmcpus": "2",
+                        "vmhost": "node_host",
+                        "vmmemory": "6144",
+                        "vmnics": "brenP3p9s0f0,brenP3p9s0f1",
+                        "vmstorage": "phy:/dev/mapper/vdiskvg01-vdisk01n10"
+                    },
+                    "engine_type": "kvm"
+                },
+                "netboot_engine": {
+                    "engine_info": {
+                        "osimage": "rhels7.5-ppc64le-install-compute"
+                    },
+                    "engine_type": "grub2"
+                }
+            },
+            "network_info": {
+                "primarynic": {
+                    "mac": [
+                        "42:6e:0a:03:11:0a",
+                        "42:6e:0a:03:11:0b"
+                    ]
+                }
+            },
+            "obj_info": {
+                "groups": "all"
+            },
+            "obj_type": "node",
+            "role": "compute"
+        },
+        "service": {
+            "device_type": "server",
+            "engines": {
+                "netboot_engine": {
+                    "engine_info": {
+                        "postscripts": "servicenode"
+                    }
+                }
+            },
+            "obj_type": "group",
+            "role": "compute"
+        },
+        "xcatdefaults": {
+            "device_type": "server",
+            "engines": {
+                "netboot_engine": {
+                    "engine_info": {
+                        "postbootscripts": "otherpkgs",
+                        "postscripts": "syslog,remoteshell,syncfiles"
+                    }
+                }
+            },
+            "obj_type": "group",
+            "role": "compute"
+        }
+    },
+    "osimage": {
+        "rhels7.5-alternate-ppc64le-install-compute": {
+            "basic_attributes": {
+                "arch": "ppc64le",
+                "distribution": "rhels7.5-alternate",
+                "osdistro": "rhels7.5-alternate-ppc64le",
+                "osname": "Linux"
+            },
+            "imagetype": "linux",
+            "package_selection": {
+                "otherpkgdir": [
+                    "/install/post/otherpkgs/rhels7.5-alternate/ppc64"
+                ],
+                "pkgdir": [
+                    "/install/rhels7.5-alternate/ppc64le",
+                    "/install/rhels7.5-alternate/ppc64le/test"
+                ],
+                "pkglist": [
+                    "/opt/xcat/share/xcat/install/rh/compute.rhels7.pkglist"
+                ]
+            },
+            "provision_mode": "install",
+            "role": "compute",
+            "template": "/opt/xcat/share/xcat/install/rh/compute.rhels7.tmpl"
+        },
+    },
+    "schema_version": "latest",
+    "site": {
+        "clustersite": {
+            "SNsyncfiledir": "/var/xcat/syncfiles",
+            "auditnosyslog": "0",
+            "auditskipcmds": "ALL",
+            "blademaxp": "64",
+            "cleanupxcatpost": "no",
+            "consoleondemand": "no",
+            "databaseloc": "/var/lib",
+            "db2installloc": "/mntdb2",
+            "dhcplease": "43200",
+            "dnshandler": "ddns",
+            "domain": "cluster.com",
+            "enableASMI": "no",
+            "fsptimeout": "0",
+            "installdir": "/install",
+            "ipmimaxp": "64",
+            "ipmiretries": "3",
+            "ipmitimeout": "2",
+            "master": "10.1.1.1",
+            "maxssh": "8",
+            "nameservers": "10.1.1.1",
+            "nodesyncfiledir": "/var/xcat/node/syncfiles",
+            "powerinterval": "0",
+            "ppcmaxp": "64",
+            "ppcretry": "3",
+            "ppctimeout": "0",
+            "sharedtftp": "1",
+            "sshbetweennodes": "ALLGROUPS",
+            "syspowerinterval": "0",
+            "tftpdir": "/tftpboot",
+            "timezone": "US/Eastern",
+            "useNmapfromMN": "no",
+            "vsftp": "n",
+            "xcatconfdir": "/etc/xcat",
+            "xcatdebugmode": "0",
+            "xcatdport": "3001",
+            "xcatiport": "3002",
+            "xcatsslversion": "TLSv1"
+        }
+    }
+}


### PR DESCRIPTION
### The PR is for task _https://github.com/xcat2/xcat-inventory/issues/116_ 

_##Feature description##_

cases design: 
https://github.com/xcat2/xcat-core/wiki/Test-Design-of-xcat-inventory-diff

### The UT result
```
# xcattest -b /tmp/diff.bundle
xCAT automated test started at Sun Sep 16 22:56:08 2018
******************************
To detect current test environment
******************************
Detecting: OS = linux
Warning: No compute node defined, can't get ARCH of compute node
Warning: No compute node defined, can't get HCP TYPE of compute node
******************************
loading test cases
******************************
To run:
xcat_inventory_diff_h
xcat_inventory_diff_without_option
xcat_inventory_diff_files_all
xcat_inventory_diff_source_filename
xcat_inventory_diff_files_source
xcat_inventory_diff_filename
xcat_inventory_diff_no_exist_file
xcat_inventory_diff_files
xcat_inventory_diff_files_filename
xcat_inventory_diff_source
******************************
Start to run test cases
******************************
------START::xcat_inventory_diff_h::Time:Sun Sep 16 22:56:09 2018------

RUN:xcat-inventory diff -h [Sun Sep 16 22:56:09 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
usage: xcat-inventory diff [--files FILE FILE] [--filename FILENAME]
                           [--source FILE] [--all]

show inventory diff between files or file vs xCAT DB

Arguments:
  --files FILE FILE    compare the given 2 inventory files
  --filename FILENAME  the filename want to show, be used with "--files"
  --source FILE        compare the given inventory file with xCAT DB
  --all                compare the given inventory file with the whole xCAT
                       DB, be used with "--source". If not specified, will
                       only compare the objects in given inventory file by
                       default.
CHECK:output =~ usage: xcat-inventory diff	[Pass]
CHECK:rc == 0	[Pass]

RUN:xcat-inventory help diff [Sun Sep 16 22:56:09 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
usage: xcat-inventory diff [--files FILE FILE] [--filename FILENAME]
                           [--source FILE] [--all]

show inventory diff between files or file vs xCAT DB

Arguments:
  --files FILE FILE    compare the given 2 inventory files
  --filename FILENAME  the filename want to show, be used with "--files"
  --source FILE        compare the given inventory file with xCAT DB
  --all                compare the given inventory file with the whole xCAT
                       DB, be used with "--source". If not specified, will
                       only compare the objects in given inventory file by
                       default.
CHECK:output =~ usage: xcat-inventory diff	[Pass]
CHECK:rc == 0	[Pass]

------END::xcat_inventory_diff_h::Passed::Time:Sun Sep 16 22:56:10 2018 ::Duration::1 sec------
------START::xcat_inventory_diff_without_option::Time:Sun Sep 16 22:56:10 2018------

RUN:xcat-inventory diff [Sun Sep 16 22:56:10 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: No valid source type!
CHECK:output =~ Error: No valid source type!	[Pass]
CHECK:rc != 0	[Pass]

------END::xcat_inventory_diff_without_option::Passed::Time:Sun Sep 16 22:56:11 2018 ::Duration::1 sec------
------START::xcat_inventory_diff_files_all::Time:Sun Sep 16 22:56:11 2018------

RUN:xcat-inventory diff --files /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file1.json /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file2.json --all [Sun Sep 16 22:56:11 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: '--all' must be used with '--source'!
CHECK:output =~ Error: '--all' must be used with '--source'!	[Pass]
CHECK:rc != 0	[Pass]

------END::xcat_inventory_diff_files_all::Passed::Time:Sun Sep 16 22:56:12 2018 ::Duration::1 sec------
------START::xcat_inventory_diff_source_filename::Time:Sun Sep 16 22:56:12 2018------

RUN:xcat-inventory diff --source /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file1.json --filename test_filename [Sun Sep 16 22:56:12 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: '--filename' must be used with '--files'!
CHECK:output =~ Error: '--filename' must be used with '--files'!	[Pass]
CHECK:rc != 0	[Pass]

------END::xcat_inventory_diff_source_filename::Passed::Time:Sun Sep 16 22:56:13 2018 ::Duration::1 sec------
------START::xcat_inventory_diff_files_source::Time:Sun Sep 16 22:56:13 2018------

RUN:xcat-inventory diff --files /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file1.json /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file2.json --source /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file2.json [Sun Sep 16 22:56:13 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: '--files' and '--source' cannot be used together!
CHECK:output =~ Error: '--files' and '--source' cannot be used together!	[Pass]
CHECK:rc != 0	[Pass]

------END::xcat_inventory_diff_files_source::Passed::Time:Sun Sep 16 22:56:14 2018 ::Duration::1 sec------
------START::xcat_inventory_diff_filename::Time:Sun Sep 16 22:56:14 2018------

RUN:xcat-inventory diff --filename test_filename [Sun Sep 16 22:56:14 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: No valid source type!
CHECK:output =~ Error: No valid source type!	[Pass]
CHECK:rc != 0	[Pass]

------END::xcat_inventory_diff_filename::Passed::Time:Sun Sep 16 22:56:15 2018 ::Duration::1 sec------
------START::xcat_inventory_diff_no_exist_file::Time:Sun Sep 16 22:56:15 2018------

RUN:xcat-inventory diff --files /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/noexist.file /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file2.json [Sun Sep 16 22:56:15 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: File '/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/noexist.file' does not exist, please check...
CHECK:output =~ Error: File '/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/noexist.file' does not exist, please check...	[Pass]
CHECK:rc != 0	[Pass]

RUN:xcat-inventory diff --source /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/noexist.file [Sun Sep 16 22:56:16 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: File '/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/noexist.file' does not exist, please check...
CHECK:output =~ Error: File '/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/noexist.file' does not exist, please check...	[Pass]
CHECK:rc != 0	[Pass]

------END::xcat_inventory_diff_no_exist_file::Passed::Time:Sun Sep 16 22:56:17 2018 ::Duration::2 sec------
------START::xcat_inventory_diff_files::Time:Sun Sep 16 22:56:17 2018------

RUN:xcat-inventory diff --files /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file1.json /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file2.json > /tmp/xcat_inventory_diff_files.result [Sun Sep 16 22:56:17 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:sh /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/change_name.sh /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file1.json /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file2.json /tmp/tmp_diff.result [Sun Sep 16 22:56:18 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
copy /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/diff.result to /tmp/tmp_diff.result and modify compare file name in /tmp/tmp_diff.result
copy command exit code 0
sed command exit code 0
sed command exit code 0
CHECK:rc == 0	[Pass]

RUN:diff /tmp/xcat_inventory_diff_files.result /tmp/tmp_diff.result [Sun Sep 16 22:56:18 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::xcat_inventory_diff_files::Passed::Time:Sun Sep 16 22:56:18 2018 ::Duration::1 sec------
------START::xcat_inventory_diff_files_filename::Time:Sun Sep 16 22:56:18 2018------

RUN:xcat-inventory diff --files /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file1.json /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file2.json --filename xcat_inventory_diff_files_filename.test > /tmp/xcat_inventory_diff_files_filename.result [Sun Sep 16 22:56:18 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:sh /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/change_name.sh xcat_inventory_diff_files_filename.test xcat_inventory_diff_files_filename.test /tmp/tmp_diff.result [Sun Sep 16 22:56:20 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
copy /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/diff.result to /tmp/tmp_diff.result and modify compare file name in /tmp/tmp_diff.result
copy command exit code 0
sed command exit code 0
sed command exit code 0
CHECK:rc == 0	[Pass]

RUN:diff /tmp/xcat_inventory_diff_files_filename.result /tmp/tmp_diff.result [Sun Sep 16 22:56:20 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::xcat_inventory_diff_files_filename::Passed::Time:Sun Sep 16 22:56:20 2018 ::Duration::2 sec------
------START::xcat_inventory_diff_source::Time:Sun Sep 16 22:56:20 2018------

RUN:rm -rf /tmp/xcat-inventory_diff_case.json [Sun Sep 16 22:56:20 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:xcat-inventory export --format json -f /tmp/xcat-inventory_diff_case.json [Sun Sep 16 22:56:20 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
The inventory data has been dumped to /tmp/xcat-inventory_diff_case.json
CHECK:rc == 0	[Pass]

RUN:xcat-inventory import -f /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file1.json [Sun Sep 16 22:56:21 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
Importing object: node1
Importing object: node3
Importing object: node2
Importing object: service
Importing object: xcatdefaults
Importing object: rhels7.5-alternate-ppc64le-install-compute
Importing object: 10_0_0_0-255_0_0_0
Inventory import successfully!
CHECK:rc == 0	[Pass]

RUN:xcat-inventory diff --source /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/xcat-inventory_diff_file2.json > /tmp/xcat_inventory_diff_source.result [Sun Sep 16 22:56:23 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:diff /tmp/xcat_inventory_diff_source.result /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/diff/diff_source.result [Sun Sep 16 22:56:25 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xcat-inventory import -c -f /tmp/xcat-inventory_diff_case.json [Sun Sep 16 22:56:25 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
...
Inventory import successfully!
CHECK:rc == 0	[Pass]

RUN:rm -rf /tmp/xcat-inventory_diff_case.json [Sun Sep 16 22:56:27 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::xcat_inventory_diff_source::Passed::Time:Sun Sep 16 22:56:27 2018 ::Duration::7 sec------
------Total: 10 , Failed: 0------
```