### PR TITLE
add a case for bug 1641 go-xcat update will continue even if required repoquery command is not installed

### DIFF
--- a/xCAT-test/autotest/testcase/go-xcat/case5
+++ b/xCAT-test/autotest/testcase/go-xcat/case5
@@ -1,9 +1,9 @@
 start:go_xcat_without_repoquery
 description:test go_xcat when command repoquery is not found. This case is for bug 1641.
 os:rhels
-label:cn_os_ready
+label:others,go_xcat
 cmd:if xdsh $$CN "yum -h";then xdsh $$CN  "yum remove -y *xCAT*";fi
-cmd:xdsh $$CN "cp -f /usr/bin/repoquery /usr/bin/repoquery.bak"
+cmd:xdsh $$CN "mv -f /usr/bin/repoquery /usr/bin/repoquery.bak"
 cmd:xdsh $$CN "cd /; rm -rf /go-xcat"
 check:rc==0
 cmd:xdsh $$CN "cd /; scp -r $$MN:/opt/xcat/share/xcat/tools/go-xcat ./"
@@ -13,6 +13,6 @@ check:rc!=0
 check:output=~Command "repoquery" not found
 check:output=~go-xcat: Install the `yum-utils' package and rerun
 check:output=~go-xcat: Failed to get package list from repository `xcat-core'
-cmd:xdsh $$CN "cp -f /usr/bin/repoquery.bak /usr/bin/repoquery"
+cmd:xdsh $$CN "mv -f /usr/bin/repoquery.bak /usr/bin/repoquery"
 end
 

--- a/xCAT-test/autotest/testcase/go-xcat/case5
+++ b/xCAT-test/autotest/testcase/go-xcat/case5
@@ -1,0 +1,18 @@
+start:go_xcat_without_repoquery
+description:test go_xcat when command repoquery is not found. This case is for bug 1641.
+os:rhels
+label:cn_os_ready
+cmd:if xdsh $$CN "yum -h";then xdsh $$CN  "yum remove -y *xCAT*";fi
+cmd:xdsh $$CN "cp -f /usr/bin/repoquery /usr/bin/repoquery.bak"
+cmd:xdsh $$CN "cd /; rm -rf /go-xcat"
+check:rc==0
+cmd:xdsh $$CN "cd /; scp -r $$MN:/opt/xcat/share/xcat/tools/go-xcat ./"
+check:rc==0
+cmd:xdsh $$CN "cd /; ./go-xcat --xcat-version=devel update -y"
+check:rc!=0
+check:output=~Command "repoquery" not found
+check:output=~go-xcat: Install the `yum-utils' package and rerun
+check:output=~go-xcat: Failed to get package list from repository `xcat-core'
+cmd:xdsh $$CN "cp -f /usr/bin/repoquery.bak /usr/bin/repoquery"
+end
+


### PR DESCRIPTION
### The PR is to add case for bug #1641

### The UT result with repoquery
```
------START::go_xcat_without_repoquery::Time:Fri Sep 21 02:39:33 2018------

RUN:if xdsh c910f02c01p10 "yum -h";then xdsh c910f02c01p10  "yum remove -y *xCAT*";fi [Fri Sep 21 02:39:33 2018]
ElapsedTime:13 sec
RETURN rc = 0
OUTPUT:
c910f02c01p10: Loaded plugins: product-id, search-disabled-repos, subscription-manager
c910f02c01p10: This system is not registered with an entitlement server. You can use subscription-manager to register.
c910f02c01p10: Usage: yum [options] COMMAND
c910f02c01p10:
c910f02c01p10: List of Commands:
c910f02c01p10:
c910f02c01p10: check          Check for problems in the rpmdb
c910f02c01p10: check-update   Check for available package updates
c910f02c01p10: clean          Remove cached data
c910f02c01p10: deplist        List a package's dependencies
c910f02c01p10: distribution-synchronization Synchronize installed packages to the latest available versions
c910f02c01p10: downgrade      downgrade a package
c910f02c01p10: erase          Remove a package or packages from your system
c910f02c01p10: fs             Acts on the filesystem data of the host, mainly for removing docs/lanuages for minimal hosts.
c910f02c01p10: fssnapshot     Creates filesystem snapshots, or lists/deletes current snapshots.
c910f02c01p10: groups         Display, or use, the groups information
c910f02c01p10: help           Display a helpful usage message
c910f02c01p10: history        Display, or use, the transaction history
c910f02c01p10: info           Display details about a package or group of packages
c910f02c01p10: install        Install a package or packages on your system
c910f02c01p10: list           List a package or groups of packages
c910f02c01p10: load-transaction load a saved transaction from filename
c910f02c01p10: makecache      Generate the metadata cache
c910f02c01p10: provides       Find what package provides the given value
c910f02c01p10: reinstall      reinstall a package
c910f02c01p10: repo-pkgs      Treat a repo. as a group of packages, so we can install/remove all of them
c910f02c01p10: repolist       Display the configured software repositories
c910f02c01p10: search         Search package details for the given string

c910f02c01p10: repolist       Display the configured software repositories
c910f02c01p10: search         Search package details for the given string
c910f02c01p10: shell          Run an interactive yum shell
c910f02c01p10: swap           Simple way to swap packages, instead of using shell
c910f02c01p10: update         Update a package or packages on your system
c910f02c01p10: update-minimal Works like upgrade, but goes to the 'newest' package match which fixes a problem that affects your system
c910f02c01p10: updateinfo     Acts on repository update information
c910f02c01p10: upgrade        Update packages taking obsoletes into account
c910f02c01p10: version        Display a version for the machine and/or available repos.
c910f02c01p10:
c910f02c01p10:
c910f02c01p10: Options:
c910f02c01p10:   -h, --help            show this help message and exit
c910f02c01p10:   -t, --tolerant        be tolerant of errors
c910f02c01p10:   -C, --cacheonly       run entirely from system cache, don't update cache
c910f02c01p10:   -c [config file], --config=[config file]
c910f02c01p10:                         config file location
c910f02c01p10:   -R [minutes], --randomwait=[minutes]
c910f02c01p10:                         maximum command wait time
c910f02c01p10:   -d [debug level], --debuglevel=[debug level]
c910f02c01p10:                         debugging output level
c910f02c01p10:   --showduplicates      show duplicates, in repos, in list/search commands
c910f02c01p10:   -e [error level], --errorlevel=[error level]
c910f02c01p10:                         error output level
c910f02c01p10:   --rpmverbosity=[debug level name]
c910f02c01p10:                         debugging output level for rpm
c910f02c01p10:   -q, --quiet           quiet operation
c910f02c01p10:   -v, --verbose         verbose operation
c910f02c01p10:   -y, --assumeyes       answer yes for all questions
c910f02c01p10:   --assumeno            answer no for all questions
c910f02c01p10:   --version             show Yum version and exit
c910f02c01p10:   --installroot=[path]  set install root
c910f02c01p10:   --enablerepo=[repo]   enable one or more repositories (wildcards allowed)

c910f02c01p10:                         updates
c910f02c01p10:   --sec-severity=SEVS, --secseverity=SEVS
c910f02c01p10:                         Include security relevant packages matching the
c910f02c01p10:                         severity, in updates
c910f02c01p10:
c910f02c01p10:   Plugin Options:
c910f02c01p10: Loaded plugins: product-id, search-disabled-repos, subscription-manager
c910f02c01p10: This system is not registered with an entitlement server. You can use subscription-manager to register.
c910f02c01p10: Resolving Dependencies
c910f02c01p10: --> Running transaction check
c910f02c01p10: ---> Package perl-xCAT.noarch 4:2.14.4-snap201809200617 will be erased
c910f02c01p10: ---> Package xCAT-client.noarch 4:2.14.4-snap201809200617 will be erased
c910f02c01p10: ---> Package xCAT-genesis-base-ppc64.noarch 2:2.14-snap201804041553 will be erased
c910f02c01p10: ---> Package xCAT-genesis-base-x86_64.noarch 2:2.14-snap201803282249 will be erased
c910f02c01p10: ---> Package xCAT-genesis-scripts-ppc64.noarch 1:2.14.4-snap201809200617 will be erased
c910f02c01p10: ---> Package xCAT-genesis-scripts-x86_64.noarch 1:2.14.4-snap201809200617 will be erased
c910f02c01p10: ---> Package xCAT-probe.noarch 4:2.14.4-snap201809200617 will be erased
c910f02c01p10: ---> Package xCAT-server.noarch 4:2.14.4-snap201809200617 will be erased
c910f02c01p10: ---> Package xCATsn.ppc64 4:2.14.4-snap201809200617 will be erased
c910f02c01p10: --> Finished Dependency Resolution
c910f02c01p10:
c910f02c01p10: Dependencies Resolved
c910f02c01p10:
c910f02c01p10: ================================================================================
c910f02c01p10:  Package                Arch   Version                   Repository        Size
c910f02c01p10: ================================================================================
c910f02c01p10: Removing:
c910f02c01p10:  perl-xCAT              noarch 4:2.14.4-snap201809200617 @xcat-otherpkgs0 4.0 M
c910f02c01p10:  xCAT-client            noarch 4:2.14.4-snap201809200617 @xcat-otherpkgs0 2.9 M
c910f02c01p10:  xCAT-genesis-base-ppc64
c910f02c01p10:                         noarch 2:2.14-snap201804041553   @xcat-otherpkgs1 400 M
c910f02c01p10:  xCAT-genesis-base-x86_64
c910f02c01p10:                         noarch 2:2.14-snap201803282249   @xcat-otherpkgs1 224 M
c910f02c01p10:  xCAT-genesis-scripts-ppc64
c910f02c01p10:   Verifying  : 2:xCAT-genesis-base-ppc64-2.14-snap201804041553.noarch       4/9
c910f02c01p10:   Verifying  : 1:xCAT-genesis-scripts-ppc64-2.14.4-snap201809200617.noarc   5/9
c910f02c01p10:   Verifying  : 2:xCAT-genesis-base-x86_64-2.14-snap201803282249.noarch      6/9
c910f02c01p10:   Verifying  : 4:xCAT-client-2.14.4-snap201809200617.noarch                 7/9
c910f02c01p10:   Verifying  : 1:xCAT-genesis-scripts-x86_64-2.14.4-snap201809200617.noar   8/9
c910f02c01p10:   Verifying  : 4:xCAT-server-2.14.4-snap201809200617.noarch                 9/9
c910f02c01p10:
c910f02c01p10: Removed:
c910f02c01p10:   perl-xCAT.noarch 4:2.14.4-snap201809200617
c910f02c01p10:   xCAT-client.noarch 4:2.14.4-snap201809200617
c910f02c01p10:   xCAT-genesis-base-ppc64.noarch 2:2.14-snap201804041553
c910f02c01p10:   xCAT-genesis-base-x86_64.noarch 2:2.14-snap201803282249
c910f02c01p10:   xCAT-genesis-scripts-ppc64.noarch 1:2.14.4-snap201809200617
c910f02c01p10:   xCAT-genesis-scripts-x86_64.noarch 1:2.14.4-snap201809200617
c910f02c01p10:   xCAT-probe.noarch 4:2.14.4-snap201809200617
c910f02c01p10:   xCAT-server.noarch 4:2.14.4-snap201809200617
c910f02c01p10:   xCATsn.ppc64 4:2.14.4-snap201809200617
c910f02c01p10:
c910f02c01p10: Complete!

RUN:xdsh c910f02c01p10 "mv -f /usr/bin/repoquery /usr/bin/repoquery.bak" [Fri Sep 21 02:39:46 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:xdsh c910f02c01p10 "cd /; rm -rf /go-xcat" [Fri Sep 21 02:39:47 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0   [Pass]

RUN:xdsh c910f02c01p10 "cd /; scp -r c910f02c01p09:/opt/xcat/share/xcat/tools/go-xcat ./" [Fri Sep 21 02:39:48 2018]
ElapsedTime:1 sec
RETURN rc = 0
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
[c910f02c01p09]: c910f02c01p10: Warning: Permanently added 'c910f02c01p09,10.2.1.9' (ECDSA) to the list of known hosts.

CHECK:rc == 0   [Pass]

RUN:xdsh c910f02c01p10 "cd /; ./go-xcat --xcat-version=devel update -y" [Fri Sep 21 02:39:49 2018]
ElapsedTime:9 sec
RETURN rc = 1
OUTPUT:
c910f02c01p10: Operating system:   linux
c910f02c01p10: Architecture:       ppc64
c910f02c01p10: Linux Distribution: rhel
c910f02c01p10: Version:            7.6
c910f02c01p10:
c910f02c01p10: Reading repositories ...... done
[c910f02c01p09]: c910f02c01p10: tee: /tmp/go-xcat.TkOOXmTN/update_xcat.stderrtee: /tmp/go-xcat.TkOOXmTN/update_xcat.stdout: No such file or directory
c910f02c01p10: : No such file or directoryCommand "repoquery" not found.
c910f02c01p10: go-xcat: Install the `yum-utils' package and rerun.
c910f02c01p10: go-xcat: Failed to get package list from repository `xcat-core'.
CHECK:rc != 0   [Pass]
CHECK:output =~ Command "repoquery" not found   [Pass]
CHECK:output =~ go-xcat: Install the `yum-utils' package and rerun      [Pass]
CHECK:output =~ go-xcat: Failed to get package list from repository `xcat-core' [Pass]

RUN:xdsh c910f02c01p10 "mv -f /usr/bin/repoquery.bak /usr/bin/repoquery" [Fri Sep 21 02:39:58 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

------END::go_xcat_without_repoquery::Passed::Time:Fri Sep 21 02:39:59 2018 ::Duration::26 sec------
------Total: 1 , Failed: 0------
```

The UT result withouth repoquery
```
------START::go_xcat_without_repoquery::Time:Fri Sep 21 03:21:13 2018------

RUN:if xdsh c910f02c01p10 "yum -h";then xdsh c910f02c01p10  "yum remove -y *xCAT*";fi [Fri Sep 21 03:21:13 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
c910f02c01p10: Loaded plugins: product-id, search-disabled-repos, subscription-manager
c910f02c01p10: This system is not registered with an entitlement server. You can use subscription-manager to register.
c910f02c01p10: Usage: yum [options] COMMAND
c910f02c01p10:
c910f02c01p10: List of Commands:
c910f02c01p10:
c910f02c01p10: check          Check for problems in the rpmdb
c910f02c01p10: check-update   Check for available package updates
c910f02c01p10: clean          Remove cached data
c910f02c01p10: deplist        List a package's dependencies
c910f02c01p10: distribution-synchronization Synchronize installed packages to the latest available versions
c910f02c01p10: downgrade      downgrade a package
c910f02c01p10: erase          Remove a package or packages from your system
c910f02c01p10: fs             Acts on the filesystem data of the host, mainly for removing docs/lanuages for minimal hosts.
c910f02c01p10: fssnapshot     Creates filesystem snapshots, or lists/deletes current snapshots.
c910f02c01p10: groups         Display, or use, the groups information
c910f02c01p10: help           Display a helpful usage message
c910f02c01p10: history        Display, or use, the transaction history
c910f02c01p10: info           Display details about a package or group of packages
c910f02c01p10: install        Install a package or packages on your system
c910f02c01p10: list           List a package or groups of packages
c910f02c01p10: load-transaction load a saved transaction from filename
c910f02c01p10: makecache      Generate the metadata cache
c910f02c01p10: provides       Find what package provides the given value
c910f02c01p10: reinstall      reinstall a package
c910f02c01p10: repo-pkgs      Treat a repo. as a group of packages, so we can install/remove all of them
c910f02c01p10: repolist       Display the configured software repositories
c910f02c01p10: search         Search package details for the given string
c910f02c01p10: shell          Run an interactive yum shell
c910f02c01p10: swap           Simple way to swap packages, instead of using shell
c910f02c01p10: update         Update a package or packages on your system
c910f02c01p10: update-minimal Works like upgrade, but goes to the 'newest' package match which fixes a problem that affects your system
c910f02c01p10: updateinfo     Acts on repository update information
c910f02c01p10: upgrade        Update packages taking obsoletes into account
c910f02c01p10: version        Display a version for the machine and/or available repos.
c910f02c01p10:
c910f02c01p10:
c910f02c01p10: Options:
c910f02c01p10:   -h, --help            show this help message and exit
c910f02c01p10:   -t, --tolerant        be tolerant of errors
c910f02c01p10:   -C, --cacheonly       run entirely from system cache, don't update cache
c910f02c01p10:   -c [config file], --config=[config file]
c910f02c01p10:                         config file location
c910f02c01p10:   -R [minutes], --randomwait=[minutes]
c910f02c01p10:                         maximum command wait time
c910f02c01p10:   -d [debug level], --debuglevel=[debug level]
c910f02c01p10:                         debugging output level
c910f02c01p10:   --showduplicates      show duplicates, in repos, in list/search commands
c910f02c01p10:   -e [error level], --errorlevel=[error level]
c910f02c01p10:                         error output level
c910f02c01p10:   --rpmverbosity=[debug level name]
c910f02c01p10:                         debugging output level for rpm
c910f02c01p10:   -q, --quiet           quiet operation
c910f02c01p10:   -v, --verbose         verbose operation
c910f02c01p10:   -y, --assumeyes       answer yes for all questions
c910f02c01p10:   --assumeno            answer no for all questions
c910f02c01p10:   --version             show Yum version and exit
c910f02c01p10:   --installroot=[path]  set install root
c910f02c01p10:   --enablerepo=[repo]   enable one or more repositories (wildcards allowed)
c910f02c01p10:   --disablerepo=[repo]  disable one or more repositories (wildcards allowed)
c910f02c01p10:   -x [package], --exclude=[package]
c910f02c01p10:                         exclude package(s) by name or glob
c910f02c01p10:   --disableexcludes=[repo]
c910f02c01p10:                         disable exclude from main, for a repo or for
c910f02c01p10:                         everything
c910f02c01p10:   --disableincludes=[repo]
c910f02c01p10:                         disable includepkgs for a repo or for everything
c910f02c01p10:   --obsoletes           enable obsoletes processing during updates
c910f02c01p10:   --noplugins           disable Yum plugins
c910f02c01p10:   --nogpgcheck          disable gpg signature checking
c910f02c01p10:   --disableplugin=[plugin]
c910f02c01p10:                         disable plugins by name
c910f02c01p10:   --enableplugin=[plugin]
c910f02c01p10:                         enable plugins by name
c910f02c01p10:   --skip-broken         skip packages with depsolving problems
c910f02c01p10:   --color=COLOR         control whether color is used
c910f02c01p10:   --releasever=RELEASEVER
c910f02c01p10:                         set value of $releasever in yum config and repo files
c910f02c01p10:   --downloadonly        don't update, just download
c910f02c01p10:   --downloaddir=DLDIR   specifies an alternate directory to store packages
c910f02c01p10:   --setopt=SETOPTS      set arbitrary config and repo options
c910f02c01p10:   --bugfix              Include bugfix relevant packages, in updates
c910f02c01p10:   --security            Include security relevant packages, in updates
c910f02c01p10:   --advisory=ADVS, --advisories=ADVS
c910f02c01p10:                         Include packages needed to fix the given advisory, in
c910f02c01p10:                         updates
c910f02c01p10:   --bzs=BZS             Include packages needed to fix the given BZ, in
c910f02c01p10:                         updates
c910f02c01p10:   --cves=CVES           Include packages needed to fix the given CVE, in
c910f02c01p10:                         updates
c910f02c01p10:   --sec-severity=SEVS, --secseverity=SEVS
c910f02c01p10:                         Include security relevant packages matching the
c910f02c01p10:                         severity, in updates
c910f02c01p10:
c910f02c01p10:   Plugin Options:
c910f02c01p10: Loaded plugins: product-id, search-disabled-repos, subscription-manager
c910f02c01p10: This system is not registered with an entitlement server. You can use subscription-manager to register.
c910f02c01p10: No package *xCAT* available.
c910f02c01p10:   * Maybe you meant: elilo-xcat, grub2-xcat, conserver-xcat, syslinux-xcat,
c910f02c01p10:                    : ipmitool-xcat
c910f02c01p10: No Packages marked for removal
[c910f02c01p09]: c910f02c01p10: No Match for argument: *xCAT*

RUN:xdsh c910f02c01p10 "mv -f /usr/bin/repoquery /usr/bin/repoquery.bak" [Fri Sep 21 03:21:16 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
[c910f02c01p09]: c910f02c01p10: mv: cannot stat '/usr/bin/repoquery': No such file or directory

RUN:xdsh c910f02c01p10 "cd /; rm -rf /go-xcat" [Fri Sep 21 03:21:16 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0   [Pass]

RUN:xdsh c910f02c01p10 "cd /; scp -r c910f02c01p09:/opt/xcat/share/xcat/tools/go-xcat ./" [Fri Sep 21 03:21:17 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0   [Pass]

RUN:xdsh c910f02c01p10 "cd /; ./go-xcat --xcat-version=devel update -y" [Fri Sep 21 03:21:18 2018]
ElapsedTime:6 sec
RETURN rc = 1
OUTPUT:
c910f02c01p10: Operating system:   linux
c910f02c01p10: Architecture:       ppc64
c910f02c01p10: Linux Distribution: rhel
c910f02c01p10: Version:            7.6
c910f02c01p10:
c910f02c01p10: Reading repositories ...... done
[c910f02c01p09]: c910f02c01p10: Command "repoquery" not found.
[c910f02c01p09]: c910f02c01p10: go-xcat: Install the `yum-utils' package and rerun.
[c910f02c01p09]: c910f02c01p10: go-xcat: Failed to get package list from repository `xcat-core'.
CHECK:rc != 0   [Pass]
CHECK:output =~ Command "repoquery" not found   [Pass]
CHECK:output =~ go-xcat: Install the `yum-utils' package and rerun      [Pass]
CHECK:output =~ go-xcat: Failed to get package list from repository `xcat-core' [Pass]

RUN:xdsh c910f02c01p10 "mv -f /usr/bin/repoquery.bak /usr/bin/repoquery" [Fri Sep 21 03:21:24 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::go_xcat_without_repoquery::Passed::Time:Fri Sep 21 03:21:24 2018 ::Duration::11 sec------
------Total: 1 , Failed: 0------


```
