### PR TITLE
fix no space left on sles12.3 servicenode

### DIFF
--- a/xCAT-server/share/xcat/install/sles/service.sles12.tmpl
+++ b/xCAT-server/share/xcat/install/sles/service.sles12.tmpl
@@ -40,42 +40,6 @@
         <device>XCATPARTITIONHOOK</device>
         <initialize config:type="boolean">true</initialize>
         <use>all</use>
-        <partitions config:type="list">
-          <partition>
-            <create config:type="boolean">true</create>
-            <loop_fs config:type="boolean">false</loop_fs>
-            <mountby config:type="symbol">device</mountby>
-            <partition_id config:type="integer">65</partition_id>
-            <partition_nr config:type="integer">1</partition_nr>
-            <resize config:type="boolean">false</resize>
-            <size>8225280</size>
-          </partition>
-          <partition>
-            <create config:type="boolean">true</create>
-            <crypt_fs config:type="boolean">false</crypt_fs>
-            <filesystem config:type="symbol">swap</filesystem>
-            <format config:type="boolean">true</format>
-            <loop_fs config:type="boolean">false</loop_fs>
-            <mount>swap</mount>
-            <mountby config:type="symbol">uuid</mountby>
-            <partition_id config:type="integer">130</partition_id>
-            <partition_nr config:type="integer">2</partition_nr>
-            <resize config:type="boolean">false</resize>
-            <size>auto</size>
-          </partition>
-          <partition>
-            <create config:type="boolean">true</create>
-            <crypt_fs config:type="boolean">false</crypt_fs>
-            <filesystem config:type="symbol">btrfs</filesystem>
-            <format config:type="boolean">true</format>
-            <loop_fs config:type="boolean">false</loop_fs>
-            <mount>/</mount>
-            <mountby config:type="symbol">uuid</mountby>
-            <partition_id config:type="integer">131</partition_id>
-            <partition_nr config:type="integer">3</partition_nr>
-            <size>100%</size>
-          </partition>
-        </partitions>
       </drive>
       <!-- XCAT-PARTITION-END -->
     </partitioning>


### PR DESCRIPTION
### The PR is to fix issue https://github.com/xcat2/xcat-core/issues/5635

### The modification include
service.sles12.tmpl

### The UT result
```
sles # lsdef c910f04x35v06 -i status
Object name: c910f04x35v06
    status=booted
c910f04x35v06:~ # cat /var/log/xcat/xcat.log|grep -E "xcat.mypostscript|xcat.xcatinstallpost"
Mon Sep 17 08:36:01 EDT 2018 [info]: xcat.mypostscript: Running postscript: syslog
Mon Sep 17 08:36:01 EDT 2018 [info]: xcat.mypostscript: postscript syslog return with 0
Mon Sep 17 08:36:01 EDT 2018 [info]: xcat.mypostscript: Running postscript: remoteshell
Mon Sep 17 08:36:03 EDT 2018 [info]: xcat.mypostscript: postscript remoteshell return with 0
Mon Sep 17 08:36:03 EDT 2018 [info]: xcat.mypostscript: Running postscript: syncfiles
Mon Sep 17 08:36:03 EDT 2018 [info]: xcat.mypostscript: postscript syncfiles return with 0
Mon Sep 17 08:36:03 EDT 2018 [info]: xcat.mypostscript: Running postscript: servicenode
Mon Sep 17 08:36:06 EDT 2018 [info]: xcat.mypostscript: postscript servicenode return with 0
Mon Sep 17 08:37:02 EDT 2018 [info]: xcat.xcatinstallpost: Running /xcatpost/mypostscript.post
Mon Sep 17 08:37:02 EDT 2018 [info]: xcat.mypostscript: Running postbootscript: otherpkgs
Mon Sep 17 04:38:09 EDT 2018 [info]: xcat.mypostscript: postbootscript otherpkgs return with 0
Mon Sep 17 04:38:09 EDT 2018 [info]: xcat.mypostscript: provision completed.(c910f04x35v06)
Mon Sep 17 04:38:09 EDT 2018 [info]: xcat.xcatinstallpost: /xcatpost/mypostscript.post return
```

