### PR TITLE
fix issue 5633, enhance check tftp service

### DIFF
--- a/xCAT-probe/lib/perl/probe_utils.pm
+++ b/xCAT-probe/lib/perl/probe_utils.pm
@@ -376,7 +376,7 @@ sub is_tftp_ready {
     rename("./tftptestt.tmp", "./tftptestt.tmp.old") if (-e "./tftptestt.tmp");
 
     system("touch /$test_dir/tftptestt.tmp");
-    my $output = `tftp $mnip  -c get /tftptest/tftptestt.tmp 2>&1`;
+    my $output = `tftp -4 -v $mnip -c get /tftptest/tftptestt.tmp 2>&1`;
     if ((!$?) && (-e "./tftptestt.tmp")) {
         unlink("./tftptestt.tmp");
         rename("./tftptestt.tmp.old", "./tftptestt.tmp") if (-e "./tftptestt.tmp.old");

--- a/xCAT-probe/lib/perl/probe_utils.pm
+++ b/xCAT-probe/lib/perl/probe_utils.pm
@@ -369,20 +369,22 @@ sub is_tftp_ready {
     my $mnip = shift;
     $mnip = shift if (($mnip) && ($mnip =~ /probe_utils/));
     my $tftpdir = shift;
+    my $test_dir = $tftpdir . "/tftptest/";
+    system("mkdir -p $test_dir");
 
-    rename("/$tftpdir/tftptestt.tmp", "/$tftpdir/tftptestt.tmp.old") if (-e "/$tftpdir/tftptestt.tmp");
+    rename("/$test_dir/tftptestt.tmp", "/$test_dir/tftptestt.tmp.old") if (-e "/$test_dir/tftptestt.tmp");
     rename("./tftptestt.tmp", "./tftptestt.tmp.old") if (-e "./tftptestt.tmp");
 
-    system("touch /$tftpdir/tftptestt.tmp");
-    my $output = `tftp -4 -v $mnip  -c get tftptestt.tmp`;
+    system("touch /$test_dir/tftptestt.tmp");
+    my $output = `tftp $mnip  -c get /tftptest/tftptestt.tmp 2>&1`;
     if ((!$?) && (-e "./tftptestt.tmp")) {
         unlink("./tftptestt.tmp");
         rename("./tftptestt.tmp.old", "./tftptestt.tmp") if (-e "./tftptestt.tmp.old");
-        rename("/$tftpdir/tftptestt.tmp.old", "/$tftpdir/tftptestt.tmp") if (-e "/$tftpdir/tftptestt.tmp.old");
+        rename("/$test_dir/tftptestt.tmp.old", "/$test_dir/tftptestt.tmp") if (-e "/$test_dir/tftptestt.tmp.old");
         return 1;
     } else {
         rename("./tftptestt.tmp.old", "./tftptestt.tmp") if (-e "./tftptestt.tmp.old");
-        rename("/$tftpdir/tftptestt.tmp.old", "/$tftpdir/tftptestt.tmp") if (-e "/$tftpdir/tftptestt.tmp.old");
+        rename("/$test_dir/tftptestt.tmp.old", "/$test_dir/tftptestt.tmp") if (-e "/$test_dir/tftptestt.tmp.old");
         return 0;
     }
 }

--- a/xCAT-probe/subcmds/xcatmn
+++ b/xCAT-probe/subcmds/xcatmn
@@ -102,8 +102,9 @@ sub do_main_job {
     $rc |= $rst;
 
     #check tftp service
-    $rst = check_tftp_service($installnicip, \$checkpoint, \@error);
-    print_check_result($checkpoint, "f", $rst, \@error);
+    ($rst, $flag) = check_tftp_service($installnicip, \$checkpoint, \@error);
+    print_check_result($checkpoint, $flag, $rst, \@error);
+    $rst = 0 if ($flag == "w");
     $rc |= $rst;
 
     #check DNS service
@@ -696,6 +697,7 @@ sub check_tftp_service {
     my $checkpoint_ref =  shift;
     my $error_ref = shift;
     my $rst       = 1;
+    my $flag      = 'f';
 
     $$checkpoint_ref = "Checking TFTP service is configured...";
     @$error_ref = ();
@@ -727,17 +729,24 @@ sub check_tftp_service {
                     last;
                 }
                 unless(probe_utils->is_tftp_ready("$serverip", $tftpdir)) {
-                    push @$error_ref, "TFTP service isn't ready on $serverip";
+                    push @$error_ref, "TFTP service isn't ready on $serverip, stop tftp service and start it by restarting xcatd";
                     last;
                 }
                 $rst = 0;
+            }
+            if ($rst == 0) {
+                my $tftp_ps = `ps aux 2>&1| grep tftp | grep xcat |grep -v grep`;
+                if (!$tftp_ps) {
+                    push @$error_ref, "TFTP service based on xCAT is not running";
+                    $flag = 'w';
+                }
             }
         }
     } else {
         $rst = 2;
     }
 
-    return $rst;
+    return ($rst, $flag);
 }
 
 sub check_rsyslog_service {

--- a/xCAT-probe/subcmds/xcatmn
+++ b/xCAT-probe/subcmds/xcatmn
@@ -728,18 +728,18 @@ sub check_tftp_service {
                     push @$error_ref, "There isn't '$tftpdir' directory on current server";
                     last;
                 }
-                unless(probe_utils->is_tftp_ready("$serverip", $tftpdir)) {
-                    push @$error_ref, "TFTP service isn't ready on $serverip, stop tftp service and start it by restarting xcatd";
-                    last;
-                }
-                $rst = 0;
-            }
-            if ($rst == 0) {
                 my $tftp_ps = `ps aux 2>&1| grep tftp | grep xcat |grep -v grep`;
                 if (!$tftp_ps) {
                     push @$error_ref, "TFTP service based on xCAT is not running";
                     $flag = 'w';
                 }
+                unless(probe_utils->is_tftp_ready("$serverip", $tftpdir)) {
+                    push @$error_ref, "TFTP service isn't ready on $serverip, stop tftp service and start it by restarting xcatd";
+                    $flag = 'f';
+                    last;
+                }
+                last if ($flag eq 'w');
+                $rst = 0;
             }
         }
     } else {


### PR DESCRIPTION
### The PR is to fix issue _#5633_

### The modification include

1. Use ``tftp $mnip  -c get /tftptest/tftptestt.tmp`` check tftp service
2. ``ps`` check whether has tftp process by xcat, it not, add to warning msg.

### The UT result
```
# xcatprobe xcatmn
[mn]: Checking all xCAT daemons are running...                                                                    [ OK ]
[mn]: Checking xcatd can receive command request...                                                               [ OK ]
[mn]: Checking 'site' table is configured...                                                                      [ OK ]
[mn]: No interface provided by '-i' option, detected site table IP attribute 10.3.17.21, checking xCAT configur...[WARN]
[mn]: If this is incorrect, rerun with -i <ifname> option                                                         [WARN]
[mn]: Checking provision network is configured...                                                                 [ OK ]
[mn]: Checking 'passwd' table is configured...                                                                    [ OK ]
[mn]: Checking important directories(installdir,tftpdir) are configured...                                        [ OK ]
[mn]: Checking SELinux is disabled...                                                                             [ OK ]
[mn]: Checking HTTP service is configured...                                                                      [ OK ]
[mn]: Checking TFTP service is configured...                                                                      [FAIL]
[mn]: TFTP service based on xCAT is not running
[mn]: TFTP service isn't ready on 10.3.17.21, stop tftp service and start it by restarting xcatd
[mn]: Checking DNS service is configured...                                                                       [ OK ]
.....
=================================== SUMMARY ====================================
[MN]: Checking on MN...                                                                                           [FAIL]
    No interface provided by '-i' option, detected site table IP attribute 10.3.17.21, checking xCAT configurat...[WARN]
    If this is incorrect, rerun with -i <ifname> option                                                           [WARN]
    Checking TFTP service is configured...                                                                        [FAIL]
        TFTP service based on xCAT is not running
        TFTP service isn't ready on 10.3.17.21, stop tftp service and start it by restarting xcatd
```
