### PR TITLE
update case for task 246,xcat-inventory support regular expression

### DIFF
--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.nics
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.nics
@@ -1,0 +1,45 @@
+start:export_import_nics_with_regex
+description:This case is used to test xcat-inventory export and import could support  regex for xcat attributes.
+label:others,xcat_inventory
+cmd:dir="/tmp/export";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi; mkdir -p $dir
+cmd:tabdump nics |tee /tmp/export/nics.cvs
+check:rc==0
+cmd:tabrestore  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/nics.csv
+check:rc==0
+cmd:xcat-inventory export  -t node -o testnodes -f /tmp/export/nics.yaml --format yaml
+check:rc==0
+check:output=~The inventory data has been dumped to /tmp/export/nics.yaml 
+cmd:diff -y  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/nics.yaml /tmp/export/nics.yaml --ignore-blank-lines  -I "^#"
+check:rc==0
+cmd:xcat-inventory export  -t node -o testnodes -f /tmp/export/nics.json --format json 
+check:rc==0
+cmd:diff -y  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/nics.json /tmp/export/nics.json --ignore-blank-lines  -I "^#"
+check:rc==0
+cmd:tabch -d node="testnodes" nics
+check:rc==0
+cmd:xcat-inventory import  -t node -o testnodes -f /tmp/export/nics.yaml
+check:rc==0
+check:output=~loading inventory date in "/tmp/export/nics.yaml"
+check:output=~start to import "node" type objects
+check:output=~ preprocessing "node" type objects
+check:output=~ writting "node" type objects
+check:output=~Inventory import successfully!
+cmd:tabdump nics |tee /tmp/export/nics.yaml.cvs;diff -y /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/nics.csv /tmp/export/nics.yaml.cvs
+check:rc==0
+cmd:tabch -d node="testnodes" nics
+check:rc==0
+cmd:xcat-inventory import  -t node -o testnodes -f /tmp/export/nics.json
+check:rc==0
+check:output=~loading inventory date in "/tmp/export/nics.json"
+check:output=~start to import "node" type objects
+check:output=~ preprocessing "node" type objects
+check:output=~ writting "node" type objects
+check:output=~Inventory import successfully!
+cmd:tabdump nics |tee /tmp/export/nics.json.cvs;diff -y /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/nics.csv /tmp/export/nics.json.cvs
+check:rc==0
+cmd:tabch -d node="testnodes" nics
+check:rc==0
+cmd:tabrestore /tmp/export/nics.cvs
+check:rc==0
+cmd:dir="/tmp/export"; rm -rf $dir; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi
+end

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/nics.csv
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/nics.csv
@@ -1,0 +1,2 @@
+#node,nicips,nichostnamesuffixes,nichostnameprefixes,nictypes,niccustomscripts,nicnetworks,nicaliases,nicextraparams,nicdevices,nicsadapter,comments,disable
+"testnodes","|(.)(..)n(..)|ib0!(ipadd(10,41,0,100,dim2idx(a2idx($1),36,$2,18,$3),2,1))|","ib0!ib",,"ib0!Infiniband",,"ib0!ipoib",,,,,,

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/nics.json
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/nics.json
@@ -1,0 +1,26 @@
+{
+    "node": {
+        "testnodes": {
+            "device_type": "server",
+            "network_info": {
+                "nics": {
+                    "ib0": {
+                        "hostnamesuffixes": [
+                            "ib"
+                        ],
+                        "ips": "|(.)(..)n(..)|ib0!(ipadd(10,41,0,100,dim2idx(a2idx($1),36,$2,18,$3),2,1))|",
+                        "networks": [
+                            "ipoib"
+                        ],
+                        "type": [
+                            "Infiniband"
+                        ]
+                    }
+                }
+            },
+            "obj_type": "group",
+            "role": "compute"
+        }
+    },
+    "schema_version": "1.0"
+}

--- a/xCAT-test/autotest/testcase/xcat-inventory/templates/nics.yaml
+++ b/xCAT-test/autotest/testcase/xcat-inventory/templates/nics.yaml
@@ -1,0 +1,16 @@
+node:
+  testnodes:
+    device_type: server
+    network_info:
+      nics:
+        ib0:
+          hostnamesuffixes:
+          - ib
+          ips: '|(.)(..)n(..)|ib0!(ipadd(10,41,0,100,dim2idx(a2idx($1),36,$2,18,$3),2,1))|'
+          networks:
+          - ipoib
+          type:
+          - Infiniband
+    obj_type: group
+    role: compute
+schema_version: '1.0'


### PR DESCRIPTION
### The PR is to fix task 246

### The UT result
```
------START::export_import_nics_with_regex::Time:Thu Sep 20 03:03:29 2018------

RUN:dir="/tmp/export";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi; mkdir -p $dir [Thu Sep 20 03:03:29 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:tabdump nics |tee /tmp/export/nics.cvs [Thu Sep 20 03:03:29 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
#node,nicips,nichostnamesuffixes,nichostnameprefixes,nictypes,niccustomscripts,nicnetworks,nicaliases,nicextraparams,nicdevices,nicsadapter,comments,disable
CHECK:rc == 0   [Pass]

RUN:tabrestore  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/nics.csv [Thu Sep 20 03:03:29 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0   [Pass]

RUN:xcat-inventory export  -t node -o testnodes -f /tmp/export/nics.yaml --format yaml [Thu Sep 20 03:03:29 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
The inventory data has been dumped to /tmp/export/nics.yaml
CHECK:rc == 0   [Pass]
CHECK:output =~ The inventory data has been dumped to /tmp/export/nics.yaml     [Pass]

RUN:diff -y  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/nics.yaml /tmp/export/nics.yaml --ignore-blank-lines  -I "^#" [Thu Sep 20 03:03:30 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
RETURN rc = 0
OUTPUT:
node:                                                           node:
  testnodes:                                                      testnodes:
    device_type: server                                             device_type: server
    network_info:                                                   network_info:
      nics:                                                           nics:
        ib0:                                                            ib0:
          hostnamesuffixes:                                               hostnamesuffixes:
          - ib                                                            - ib
          ips: '|(.)(..)n(..)|ib0!(ipadd(10,41,0,100,dim2idx(             ips: '|(.)(..)n(..)|ib0!(ipadd(10,41,0,100,dim2idx(
          networks:                                                       networks:
          - ipoib                                                         - ipoib
          type:                                                           type:
          - Infiniband                                                    - Infiniband
    obj_type: group                                                 obj_type: group
    role: compute                                                   role: compute
schema_version: '1.0'                                           schema_version: '1.0'
                                                              )
                                                              ) #Version 2.14.3 (git commit 7b7d9ab67589afec1ba58cd5138154290
CHECK:rc == 0   [Pass]

RUN:xcat-inventory export  -t node -o testnodes -f /tmp/export/nics.json --format json [Thu Sep 20 03:03:30 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
The inventory data has been dumped to /tmp/export/nics.json
CHECK:rc == 0   [Pass]

RUN:diff -y  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/nics.json /tmp/export/nics.json --ignore-blank-lines  -I "^#" [Thu Sep 20 03:03:31 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
RETURN rc = 0
OUTPUT:
node:                                                           node:
  testnodes:                                                      testnodes:
    device_type: server                                             device_type: server
    network_info:                                                   network_info:
      nics:                                                           nics:
        ib0:                                                            ib0:
          hostnamesuffixes:                                               hostnamesuffixes:
          - ib                                                            - ib
          ips: '|(.)(..)n(..)|ib0!(ipadd(10,41,0,100,dim2idx(             ips: '|(.)(..)n(..)|ib0!(ipadd(10,41,0,100,dim2idx(
          networks:                                                       networks:
          - ipoib                                                         - ipoib
          type:                                                           type:
          - Infiniband                                                    - Infiniband
    obj_type: group                                                 obj_type: group
    role: compute                                                   role: compute
schema_version: '1.0'                                           schema_version: '1.0'
                                                              )
                                                              ) #Version 2.14.3 (git commit 7b7d9ab67589afec1ba58cd5138154290
CHECK:rc == 0   [Pass]

RUN:xcat-inventory export  -t node -o testnodes -f /tmp/export/nics.json --format json [Thu Sep 20 03:03:30 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
The inventory data has been dumped to /tmp/export/nics.json
CHECK:rc == 0   [Pass]

RUN:diff -y  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/nics.json /tmp/export/nics.json --ignore-blank-lines  -I "^#" [Thu Sep 20 03:03:31 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
RETURN rc = 0
OUTPUT:
{                                                               {
    "node": {                                                       "node": {
        "testnodes": {                                                  "testnodes": {
            "device_type": "server",                                        "device_type": "server",
            "network_info": {                                               "network_info": {
                "nics": {                                                       "nics": {
                    "ib0": {                                                        "ib0": {
                        "hostnamesuffixes": [                                           "hostnamesuffixes": [
                            "ib"                                                            "ib"
                        ],                                                              ],
                        "ips": "|(.)(..)n(..)|ib0!(ipadd(10,4                           "ips": "|(.)(..)n(..)|ib0!(ipadd(10,4
                        "networks": [                                                   "networks": [
                            "ipoib"                                                         "ipoib"
                        ],                                                              ],
                        "type": [                                                       "type": [
                            "Infiniband"                                                    "Infiniband"
                        ]                                                               ]
                    }                                                               }
                }                                                               }
            },                                                              },
            "obj_type": "group",                                            "obj_type": "group",
            "role": "compute"                                               "role": "compute"
        }                                                               }
    },                                                              },
    "schema_version": "1.0"                                         "schema_version": "1.0"
}                                                               }
                                                              ) #Version 2.14.3 (git commit 7b7d9ab67589afec1ba58cd5138154290
CHECK:rc == 0   [Pass]

RUN:tabch -d node="testnodes" nics [Thu Sep 20 03:03:31 2018]
ElapsedTime:1 sec
RETURN rc = 0
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0   [Pass]

RUN:xcat-inventory import  -t node -o testnodes -f /tmp/export/nics.yaml [Thu Sep 20 03:03:32 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
loading inventory date in "/tmp/export/nics.yaml"
start to import "node" type objects
 preprocessing "node" type objects
 writting "node" type objects
Inventory import successfully!
CHECK:rc == 0   [Pass]
CHECK:output =~ loading inventory date in "/tmp/export/nics.yaml"       [Pass]
CHECK:output =~ start to import "node" type objects     [Pass]
CHECK:output =~ preprocessing "node" type objects       [Pass]
CHECK:output =~ writting "node" type objects    [Pass]
CHECK:output =~ Inventory import successfully!  [Pass]

RUN:tabdump nics |tee /tmp/export/nics.yaml.cvs;diff -y /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/nics.csv /tmp/export/nics.yaml.cvs [Thu Sep 20 03:03:32 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
#node,nicips,nichostnamesuffixes,nichostnameprefixes,nictypes,niccustomscripts,nicnetworks,nicaliases,nicextraparams,nicdevices,nicsadapter,comments,disable
"testnodes","|(.)(..)n(..)|ib0!(ipadd(10,41,0,100,dim2idx(a2idx($1),36,$2,18,$3),2,1))|","ib0!ib",,"ib0!Infiniband",,"ib0!ipoib",,,,,,
#node,nicips,nichostnamesuffixes,nichostnameprefixes,nictypes   #node,nicips,nichostnamesuffixes,nichostnameprefixes,nictypes
"testnodes","|(.)(..)n(..)|ib0!(ipadd(10,41,0,100,dim2idx(a2i   "testnodes","|(.)(..)n(..)|ib0!(ipadd(10,41,0,100,dim2idx(a2i
CHECK:rc == 0   [Pass]

RUN:tabch -d node="testnodes" nics [Thu Sep 20 03:03:33 2018]
RUN:tabch -d node="testnodes" nics [Thu Sep 20 03:03:33 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0   [Pass]

RUN:xcat-inventory import  -t node -o testnodes -f /tmp/export/nics.json [Thu Sep 20 03:03:33 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
loading inventory date in "/tmp/export/nics.json"
start to import "node" type objects
 preprocessing "node" type objects
 writting "node" type objects
Inventory import successfully!
CHECK:rc == 0   [Pass]
CHECK:output =~ loading inventory date in "/tmp/export/nics.json"       [Pass]
CHECK:output =~ start to import "node" type objects     [Pass]
CHECK:output =~ preprocessing "node" type objects       [Pass]
CHECK:output =~ writting "node" type objects    [Pass]
CHECK:output =~ Inventory import successfully!  [Pass]

RUN:tabdump nics |tee /tmp/export/nics.json.cvs;diff -y /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/nics.csv /tmp/export/nics.json.cvs [Thu Sep 20 03:03:34 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
#node,nicips,nichostnamesuffixes,nichostnameprefixes,nictypes,niccustomscripts,nicnetworks,nicaliases,nicextraparams,nicdevices,nicsadapter,comments,disable
"testnodes","|(.)(..)n(..)|ib0!(ipadd(10,41,0,100,dim2idx(a2idx($1),36,$2,18,$3),2,1))|","ib0!ib",,"ib0!Infiniband",,"ib0!ipoib",,,,,,
#node,nicips,nichostnamesuffixes,nichostnameprefixes,nictypes   #node,nicips,nichostnamesuffixes,nichostnameprefixes,nictypes
"testnodes","|(.)(..)n(..)|ib0!(ipadd(10,41,0,100,dim2idx(a2i   "testnodes","|(.)(..)n(..)|ib0!(ipadd(10,41,0,100,dim2idx(a2i
CHECK:rc == 0   [Pass]
"testnodes","|(.)(..)n(..)|ib0!(ipadd(10,41,0,100,dim2idx(a2i   "testnodes","|(.)(..)n(..)|ib0!(ipadd(10,41,0,100,dim2idx(a2i
CHECK:rc == 0   [Pass]

RUN:tabch -d node="testnodes" nics [Thu Sep 20 03:03:34 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0   [Pass]

RUN:tabrestore /tmp/export/nics.cvs [Thu Sep 20 03:03:34 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0   [Pass]

RUN:dir="/tmp/export"; rm -rf $dir; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi [Thu Sep 20 03:03:34 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::export_import_nics_with_regex::Passed::Time:Thu Sep 20 03:03:34 2018 ::Duration::5 sec------
------Total: 1 , Failed: 0------

```