### PR TITLE
fix issue genimage failure might cause /proc umounted #5640

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -117,7 +117,9 @@ sub mount_chroot {
 sub umount_chroot {
     my $rootimage_dir = shift;
 
-    $rootimage_dir=realpath($rootimage_dir);
+    if(-e "$rootimage_dir"){
+        $rootimage_dir=realpath($rootimage_dir);
+    }
     if ($rootimage_dir eq "/") {
         print "\n\n\n\nWARNING: /proc and /sys may still be mounted in the rootimgdir\n\n\n\n";
         return 1;
@@ -134,7 +136,7 @@ sub umount_chroot {
     }
     close($FILEHD);
     foreach my $mntpt (@mntptlist){
-        system("umount -l $mntpt >/dev/null 2>&1")
+        system("umount -l $mntpt >/dev/null 2>&1");
     }
 
     if (majversion($osver) > 6) {
@@ -287,7 +289,13 @@ foreach (@ndrivers) {
     }
 }
 
-unless ($onlyinitrd) {
+if($onlyinitrd){
+    unless(-e "$rootimg_dir"){
+        print("the root image directory \"$rootimg_dir\"does not exist, please run \"genimage $imagename\" to generate the root image directory first!\n");
+        exit 1;
+    }
+}else
+{
     @yumdirs = ();
 
     my @pkgdirs = split(",", $srcdir);


### PR DESCRIPTION
The PR is to fix issue https://github.com/xcat2/xcat-core/issues/5640

The modification include:
1. check whether the `$rootimg_dir` exist at the beginning of `genimage --onlyinitrd`
2. `realpath($path)` will return `` if $path does not exist

### The UT result
```
[root@c910f03c05k20 ~]# genimage --onlyinitrd rhels7.3-x86_64-netboot-compute
Generating image:
cd /opt/xcat/share/xcat/netboot/rh; ./genimage -a x86_64 -o rhels7.3 -p compute --onlyinitrd --srcdir "/install/rhels7.3/x86_64" --pkglist /opt/xcat/share/xcat/netboot/rh/compute.rhels7.x86_64.pkglist --otherpkgdir "/install/post/otherpkgs/rhels7.3/x86_64" --postinstall "/opt/xcat/share/xcat/netboot/rh/compute.rhels7.x86_64.postinstall" --rootimgdir /install/netboot/rhels7.3/x86_64/compute --tempfile /tmp/xcat_genimage.14830 rhels7.3-x86_64-netboot-compute
the root image directory "/install/netboot/rhels7.3/x86_64/compute/rootimg"does not exist, please run "genimage rhels7.3-x86_64-netboot-compute" to generate the root image directory first!
Error: [c910f03c05k20]: Command failed: cd /opt/xcat/share/xcat/netboot/rh; ./genimage -a x86_64 -o rhels7.3 -p compute --onlyinitrd --srcdir "/install/rhels7.3/x86_64" --pkglist /opt/xcat/share/xcat/netboot/rh/compute.rhels7.x86_64.pkglist --otherpkgdir "/install/post/otherpkgs/rhels7.3/x86_64" --postinstall "/opt/xcat/share/xcat/netboot/rh/compute.rhels7.x86_64.postinstall" --rootimgdir /install/netboot/rhels7.3/x86_64/compute --tempfile /tmp/xcat_genimage.14830 rhels7.3-x86_64-netboot-compute 2>&1. Error message: the root image directory "/install/netboot/rhels7.3/x86_64/compute/rootimg"does not exist, please run "genimage rhels7.3-x86_64-netboot-compute" to generate the root image directory first!.

[root@c910f03c05k20 ~]# ls /proc
1     1123   14783  15008  15055  2     2269  27    2984  399  47    58    9            fs          modules       sysrq-trigger
10    114    14908  15011  15056  20    2271  2780  299   4    479   59    9310         interrupts  mounts        sysvipc
1028  1145   14959  15022  15057  2022  2273  28    3     40   48    60    buddyinfo    iomem       net           timer_list
1054  1162   14971  15026  1510   2066  2291  284   30    400  49    603   bus          ioports     pagetypeinfo  timer_stats
1055  1167   14972  15027  1517   21    23    2841  3022  401  5     61    cgroups      irq         partitions    tty
1056  1171   14974  15028  1579   2185  2371  2842  31    402  50    6670  cmdline      kallsyms    powerpc       uptime
1057  12     14975  15029  16     22    2372  285   32    403  507   69    consoles     kcore       ppc64         version
1058  1205   14976  1503   1698   2222  2373  286   33    404  51    7     cpuinfo      keys        rtas          vmallocinfo
1059  121    14983  15030  17     2224  2374  2941  34    405  510   70    crypto       key-users   sched_debug   vmstat
1060  1210   14984  15031  1716   2243  2375  2942  35    406  511   71    devices      kmsg        schedstat     zoneinfo
1061  1216   14985  15039  1734   2246  2393  2943  36    407  52    72    device-tree  kpagecount  scsi
1094  1217   1499   15045  1798   225   2394  2944  37    41   53    73    diskstats    kpageflags  self
11    12374  14998  15046  18     2253  2395  2946  38    42   5384  74    dma          loadavg     slabinfo
1102  13     14999  15049  1834   2254  2396  2947  381   43   54    75    driver       locks       softirqs
1116  1379   15     15050  1947   2257  2397  2948  382   44   55    77    execdomains  mdstat      stat
1117  1380   15000  15052  198    2260  25    2949  39    45   56    78    fb           meminfo     swaps
1119  14765  15007  15054  1984   2266  26    298   398   46   57    8     filesystems  misc        sys
[root@c910f03c05k20 ~]#
```



