### PR TITLE
Fix issue 5649: makedhcp misleading error message

### DIFF
--- a/xCAT-server/lib/xcat/plugins/dhcp.pm
+++ b/xCAT-server/lib/xcat/plugins/dhcp.pm
@@ -538,19 +538,19 @@ sub addnode
                     unless ($nxtsrvd[0]) { $nxtsrv = $nxtsrvd[1]; }
                     elsif ($nxtsrvd[0] == 1) { $callback->({ error => [ $nxtsrvd[1] ] }); }
                     else {
-                        $callback->({ error => ["Unable to determine the tftpserver for $node, please makesure \"xcatmaster\" is set correctly"], errorcode => [1] });
+                        $callback->({ error => ["Unable to determine the tftpserver for $node, verify \"xcatmaster\" is set correctly"], errorcode => [1] });
                         return;
                     }
                 } else {
                     my $tmp_server = inet_aton($node_server);
                     unless ($tmp_server) {
-                        $callback->({ error => ["Unable to determine the tftpserver for $node, please makesure \"xcatmaster\" is set correctly"], errorcode => [1] });
+                        $callback->({ error => ["Unable to resolve the tftpserver for $node, verify \"xcatmaster\" is set correctly"], errorcode => [1] });
                         return;
                     }
                     $nxtsrv = inet_ntoa($tmp_server);
                 }
                 unless ($nxtsrv) {
-                    $callback->({ error => ["Unable to determine the tftpserver for $node, please makesure \"xcatmaster\" is set correctly"], errorcode => [1] });
+                    $callback->({ error => ["Unable to determine the tftpserver for $node, verify \"xcatmaster\" is set correctly"], errorcode => [1] });
                     return;
                 }
                 $guess_next_server = 0;

--- a/xCAT-server/lib/xcat/plugins/dhcp.pm
+++ b/xCAT-server/lib/xcat/plugins/dhcp.pm
@@ -538,19 +538,19 @@ sub addnode
                     unless ($nxtsrvd[0]) { $nxtsrv = $nxtsrvd[1]; }
                     elsif ($nxtsrvd[0] == 1) { $callback->({ error => [ $nxtsrvd[1] ] }); }
                     else {
-                        $callback->({ error => ["Unable to determine the tftpserver for $node"], errorcode => [1] });
+                        $callback->({ error => ["Unable to determine the tftpserver for $node, please makesure \"xcatmaster\" is set correctly"], errorcode => [1] });
                         return;
                     }
                 } else {
                     my $tmp_server = inet_aton($node_server);
                     unless ($tmp_server) {
-                        $callback->({ error => ["Unable to resolve the tftpserver for $node"], errorcode => [1] });
+                        $callback->({ error => ["Unable to determine the tftpserver for $node, please makesure \"xcatmaster\" is set correctly"], errorcode => [1] });
                         return;
                     }
                     $nxtsrv = inet_ntoa($tmp_server);
                 }
                 unless ($nxtsrv) {
-                    $callback->({ error => ["Unable to determine the tftpserver for $node"], errorcode => [1] });
+                    $callback->({ error => ["Unable to determine the tftpserver for $node, please makesure \"xcatmaster\" is set correctly"], errorcode => [1] });
                     return;
                 }
                 $guess_next_server = 0;


### PR DESCRIPTION
### The PR is to fix issue #5649 

### The modification include

Modify the warning message if failed to get/resolve `xcatmaster`

### The UT result
```
# makedhcp <mynode>
Error: [xcatmn]: Unable to determine the tftpserver for <mynode>, please makesure "xcatmaster" is set correctly
```
