### PR TITLE
Two changes on xcatperftest

### DIFF
--- a/xCAT-test/autotest/perfcmds.lst
+++ b/xCAT-test/autotest/perfcmds.lst
@@ -1,5 +1,5 @@
-#SERIES# 1,50,100,250,500,1000,2500,5000,10000
-lsdef #NODES#
+#SERIES# 1,50,100,250,500,1000,2500,5000,10000,20000
+lsdef #NODES# -i ip,mac
 makehosts #NODES#
 makedns -n #NODES#
 makedhcp #NODES#
@@ -10,4 +10,6 @@ nodeset #NODES# osimage=#OSIMAGE#
 chdef -t node -o #NODES# postscripts="fake" profile="install" netboot="grub2"
 rmdef -t node #PERFGRP#
 cat #STANZ#|mkdef -z -f
+lsdef -w 'serial=12345678'
+chdef #NODES# -p groups=group1
 noderm #PERFGRP#

--- a/xCAT-test/bin/xcatperftest
+++ b/xCAT-test/bin/xcatperftest
@@ -347,7 +347,12 @@ execCmd()
   fi
 
   start=`date +%s%3N`
-  eval "$1" > /dev/null 2>&1
+
+  #using timeout to avoid some commands hang
+  timeout 3600 bash <<EOT
+$1 > /dev/null 2>&1
+EOT
+
   retval=$?
   end=`date +%s%3N`
   delta=$(printf "%.2f" `echo "scale=2;$(($end-$start))/1000"|bc`)


### PR DESCRIPTION
### The PR is to fix issue https://github.com/xcat2/xcat2-task-management/issues/306

### The modification include
- add timeout when executing the test commands
- add `lsdef -w` and `chdef -p` into default commands list

### The UT result
```
xcatperftest 10 ./share/xcat/tools/autotest/perfcmds.lst
==================================================
..........
==================================================
Continue the performance testing for commands in ./share/xcat/tools/autotest/perfcmds.lst
==================================================
[Testing for command]: cat /opt/xcat/share/xcat/tools/autotest/result/perfstanz-10.20180921060205 | mkdef -z -f ...
=====> SUCCESS, mkdef, 5.90, 10, 1.69, "cat /opt/xcat/share/xcat/tools/autotest/result/perfstanz-10.20180921060205 | mkdef -z -f"
[Testing for command]: lsdef fake[1-1] -i ip,mac ...
=====> SUCCESS, lsdef, 2.94, 1, 0.34, "lsdef fake[1-1] -i ip,mac"
[Testing for command]: makehosts fake[1-1] ...
=====> SUCCESS, makehosts, 0.48, 1, 2.08, "makehosts fake[1-1]"
[Testing for command]: makedns -n fake[1-1] ...
=====> FAIL, makedns, 5.67, 1, 0.17, "makedns -n fake[1-1]"
[Testing for command]: makedhcp fake[1-1] ...
=====> FAIL, makedhcp, 0.99, 1, 1.01, "makedhcp fake[1-1]"
[Testing for command]: makeknownhosts fake[1-1] ...
=====> SUCCESS, makeknownhosts, 0.42, 1, 2.38, "makeknownhosts fake[1-1]"
[Testing for command]: nodech fake[1-1] groups,=group1 ...
=====> SUCCESS, nodech, 0.38, 1, 2.63, "nodech fake[1-1] groups,=group1"
[Testing for command]: nodels fake[1-1] noderes ...
=====> SUCCESS, nodels, 0.43, 1, 2.32, "nodels fake[1-1] noderes"
[Testing for command]: nodeset fake[1-1] osimage=rhels7.4-alternate-ppc64le-install-compute ...
=====> FAIL, nodeset, 2.56, 1, 0.39, "nodeset fake[1-1] osimage=rhels7.4-alternate-ppc64le-install-compute"
[Testing for command]: chdef -t node -o fake[1-1] postscripts="fake" profile="install" netboot="grub2" ...
=====> SUCCESS, chdef, 4.36, 1, 0.22, "chdef -t node -o fake[1-1] postscripts="fake" profile="install" netboot="grub2""
[Testing for command]: rmdef -t node perftest ...
=====> SUCCESS, rmdef, 1.35, 10, 7.40, "rmdef -t node perftest"
[Testing for command]: cat /opt/xcat/share/xcat/tools/autotest/result/perfstanz-10.20180921060205|mkdef -z -f ...
=====> SUCCESS, mkdef, 9.07, 10, 1.10, "cat /opt/xcat/share/xcat/tools/autotest/result/perfstanz-10.20180921060205|mkdef -z -f"
[Testing for command]: lsdef -w 'serial=12345678' ...
=====> SUCCESS, lsdef, 30.43, -, -, "lsdef -w 'serial=12345678'"
[Testing for command]: chdef fake[1-1] -p groups=group1 ...
=====> SUCCESS, chdef, 3.43, 1, 0.29, "chdef fake[1-1] -p groups=group1"
[Testing for command]: noderm perftest ...
=====> SUCCESS, noderm, 1.76, 10, 5.68, "noderm perftest"

Done. Check the performance result in /opt/xcat/share/xcat/tools/autotest/result/perfreport-10.log.20180921060205
```
