### PR TITLE
Update cuda_power9_setup for CUDA 10.0

### DIFF
--- a/xCAT/postscripts/cuda_power9_setup
+++ b/xCAT/postscripts/cuda_power9_setup
@@ -27,7 +27,7 @@ then
 	sed -i /SUBSYSTEM==\"memory\"/d ${IMG_ROOTIMGDIR}/lib/udev/rules.d/40-redhat.rules
 fi
 
-echo 'options nvidia NVreg_EnableStreamMemOPs=1 NVreg_RegistryDwords="PeerMappingOverride=1"' >${IMG_ROOTIMGDIR}/usr/lib/modprobe.d/nvidia.conf
+echo 'options nvidia NVreg_EnableStreamMemOPs=1 NVreg_RegistryDwords="PeerMappingOverride=1"' >>${IMG_ROOTIMGDIR}/usr/lib/modprobe.d/nvidia.conf
 
 if [ -z "${IMG_ROOTIMGDIR}" ]
 then

--- a/xCAT/postscripts/cuda_power9_setup
+++ b/xCAT/postscripts/cuda_power9_setup
@@ -27,7 +27,7 @@ then
 	sed -i /SUBSYSTEM==\"memory\"/d ${IMG_ROOTIMGDIR}/lib/udev/rules.d/40-redhat.rules
 fi
 
-echo 'options nvidia NVreg_EnableStreamMemOPs=1 NVreg_RegistryDwords="PeerMappingOverride=1"' >>${IMG_ROOTIMGDIR}/usr/lib/modprobe.d/nvidia.conf
+echo 'options nvidia NVreg_EnableStreamMemOPs=1 NVreg_RegistryDwords="PeerMappingOverride=1"' >${IMG_ROOTIMGDIR}/usr/lib/modprobe.d/nvidia_options.conf
 
 if [ -z "${IMG_ROOTIMGDIR}" ]
 then


### PR DESCRIPTION
CUDA 10.0 ships with the following file:
```
# cat /usr/lib/modprobe.d/nvidia.conf
blacklist nouveau

# Uncomment the following line to enable kernel modesetting support.
# There is NO graphical framebuffer (like OSS drivers) at the moment; this is
# only for Wayland. For Gnome, you also require an EGLStream build of Mutter.
#options nvidia-drm modeset=1
```
Previously (CUDA 9) this file was called: `/usr/lib/modprobe.d/blacklist-nouveau.conf`

We don't want to overwrite `blacklist nouveau`, so use another file for our custom module options.