### PR TITLE
Modify the output message if failed pping_hostname() 

### DIFF
--- a/perl-xCAT/xCAT/DSHCLI.pm
+++ b/perl-xCAT/xCAT/DSHCLI.pm
@@ -3420,6 +3420,8 @@ sub verify_targets
     {
 
         my $hostname = $$resolved_targets{$user_target}{'hostname'};
+        #use hostname in case the host is ip address
+        my $hostname = xCAT::NetworkUtils->gethostname($host);
         push @ping_list, $hostname;
     }
 

--- a/perl-xCAT/xCAT/DSHCLI.pm
+++ b/perl-xCAT/xCAT/DSHCLI.pm
@@ -3419,9 +3419,7 @@ sub verify_targets
     foreach my $user_target (keys(%$resolved_targets))
     {
 
-        my $host = $$resolved_targets{$user_target}{'hostname'};
-        #use hostname in case the host is ip address
-        my $hostname = xCAT::NetworkUtils->gethostname($host);
+        my $hostname = $$resolved_targets{$user_target}{'hostname'};
         push @ping_list, $hostname;
     }
 
@@ -3443,7 +3441,7 @@ sub verify_targets
             {
                 my $rsp = {};
                 $rsp->{error}->[0] =
-"$user_target is not responding. No command will be issued to this host.";
+"$user_target is not responding, make sure it is a node object and is defined in xCATdb. No command will be issued to this host.";
                 xCAT::MsgUtils->message("E", $rsp, $::CALLBACK);
 
                 # report error status  --nodestatus

--- a/perl-xCAT/xCAT/DSHCLI.pm
+++ b/perl-xCAT/xCAT/DSHCLI.pm
@@ -3419,7 +3419,7 @@ sub verify_targets
     foreach my $user_target (keys(%$resolved_targets))
     {
 
-        my $hostname = $$resolved_targets{$user_target}{'hostname'};
+        my $host = $$resolved_targets{$user_target}{'hostname'};
         #use hostname in case the host is ip address
         my $hostname = xCAT::NetworkUtils->gethostname($host);
         push @ping_list, $hostname;


### PR DESCRIPTION
on issue #5661, if servicenode attribute is ip address, `updatenode -f` will not sync files to service node. That will cause syncfile list failed during the node deployment.  
`updatenode -f` will call `pping_hostname()` sub routine and this routine only takes hostname,  so always convert host to the hostname before call pping_hostname(). 

unit test:
```
[root@boston02 xCAT]# lsdef mid08tor03cn01 -i groups,servicenode
Object name: mid08tor03cn01
    groups=all,p9,cn_regex,p9up,witherspoon,dd20
    servicenode=172.20.254.2
[root@boston02 xCAT]# updatenode dd20 -f
File synchronization has completed for service nodes: "172.20.254.2"
````




