### PR TITLE
Replace 5623: Correct typo in xCAT-vlan spec file comment

### DIFF
--- a/xCAT-vlan/xCAT-vlan.spec
+++ b/xCAT-vlan/xCAT-vlan.spec
@@ -19,7 +19,7 @@ BuildArch: noarch
 Requires: xCAT-client = 4:%{version}-%{release}
 
 %description
-xCAT-vlan provides the xCAT vlan confiuration.
+xCAT-vlan provides the xCAT vlan configuration.
 
 %prep
 %setup -q -n xCAT-vlan


### PR DESCRIPTION
### The PR is to replace #5623 

### The modification include

xCAT-vlan spec file

### The UT result
`##The UT output##`