### PR TITLE
[Docu] IB switch configuration: fix passwd entry

### DIFF
--- a/docs/source/advanced/networks/infiniband/switch_configuration.rst
+++ b/docs/source/advanced/networks/infiniband/switch_configuration.rst
@@ -23,12 +23,12 @@ The switches table will look like this: ::
 
 If there is only one admin and one password for all the switches then put the entry in the xCAT passwd table for the admin id and password to use to login. ::
 
-	tabch key=mswitch  passwd.username=admin passwd.password=admin
+	tabch key=switch  passwd.username=admin passwd.password=admin
 
 The passwd table will look like this: ::
 
 	#key,username,password,cryptmethod,comments,disable
-	"mswitch","admin","admin",,,
+	"switch","admin","admin",,,
 
 Setup ssh connection to the Mellanox Switch
 -------------------------------------------


### PR DESCRIPTION
The entry in the passwd table has to use the key `switch`, otherwise the SSH username and password is not detected properly.

I tested it with `mswitch` and it didn't work.
You get the following error:
```
Error: [xcat]: Unable to get the username and the password for node XXXX. Please fill the switches table or the password table.
```

Documentation also says the key has to be `switch`:
See `man switches` page:
```
       sshusername
                 The remote login user name. It can be for ssh or telnet. If it is for telnet,
                 set protocol to "telnet". If the sshusername is blank, the username, password
                 and protocol will be retrieved from the passwd table with "switch" as the key.

       sshpassword
                 The remote login password. It can be for ssh or telnet. If it is for telnet, set
                 protocol to "telnet". If the sshusername is blank, the username, password and
                 protocol will be retrieved from the passwd table with "switch" as the key.
```
See `man passwd` page:
```
       key
              The type of component this user/pw is for. Valid values: blade (management module), 
              ipmi (BMC), system (nodes), omapi (DHCP), hmc, ivm, cec, frame, switch.
```