### PR TITLE
Formatting and spelling fixes for some man pages

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/common/deployment/use_kernel_patch.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/deployment/use_kernel_patch.rst
@@ -21,4 +21,4 @@ The RPM names below are only examples, substitute your specific level and archit
         genitrd rhels7.3-ppc64le-install-compute --ignorekernelchk
         nodeset <CN> osimage=rhels7.3-ppc64le-install-compute --noupdateinitrd
 
-#. Boot CN from net normallly.
+#. Boot CN from net normally.

--- a/docs/source/guides/admin-guides/references/man1/chzone.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/chzone.1.rst
@@ -30,8 +30,8 @@ chzone.1
 
 
 The \ **chzone**\  command is designed to change the definition of a zone previous defined in the cluster.
-The chzone command is only supported on Linux ( No AIX support).
-The nodes are not updated with the new root ssh keys by chzone. You must run updatenode -k  or xdsh -K to the nodes to update the root ssh keys to the new generated zone keys. This will also sync any service nodes with the zone keys, if you have a hierarchical cluster.
+The \ **chzone**\  command is only supported on Linux ( No AIX support).
+The nodes are not updated with the new root ssh keys by \ **chzone**\ . You must run \ **updatenode -k**\   or \ **xdsh -K**\  to the nodes to update the root ssh keys to the new generated zone keys. This will also sync any service nodes with the zone keys, if you have a hierarchical cluster.
 Note: if any zones in the zone table, there must be one and only one defaultzone. Otherwise, errors will occur.
 
 
@@ -55,14 +55,14 @@ Note: if any zones in the zone table, there must be one and only one defaultzone
 
 \ **-k | -**\ **-sshkeypath**\  \ *full path to the ssh RSA private key*\ 
  
- This is the path to the id_rsa key that will be used to build new root's ssh keys for the zone. If -k is used, it will generate the ssh public key from the input ssh RSA private key, and store both in /etc/xcat/sshkeys/<zonename>/.ssh directory.
+ This is the path to the id_rsa key that will be used to build new root's ssh keys for the zone. If \ **-k**\  is used, it will generate the ssh public key from the input ssh RSA private key, and store both in /etc/xcat/sshkeys/<zonename>/.ssh directory.
  
 
 
 \ **-K | -**\ **-genkeys**\ 
  
  Using this flag, will  generate new ssh RSA private and public keys for the zone into the /etc/xcat/sshkeys/<zonename>/.ssh directory.
- The nodes are not automatically updated with the new root ssh keys by chzone. You must run updatenode -k  or xdsh -K to the nodes to update the root ssh keys to the new generated zone keys. This will also sync any service nodes with the zone keys, if you have a hierarchical cluster.
+ The nodes are not automatically updated with the new root ssh keys by chzone. You must run \ **updatenode -k**\   or \ **xdsh -K**\  to the nodes to update the root ssh keys to the new generated zone keys. This will also sync any service nodes with the zone keys, if you have a hierarchical cluster.
  
 
 
@@ -79,7 +79,7 @@ Note: if any zones in the zone table, there must be one and only one defaultzone
 \ **-a | -**\ **-addnoderange**\  \ *noderange*\ 
  
  For each node in the noderange, it will set the zonename attribute for that node to the input zonename.
- If the -g flag is also on the command, then
+ If the \ **-g**\  flag is also on the command, then
  it will add the group name "zonename" to each node in the noderange.
  
 
@@ -88,14 +88,14 @@ Note: if any zones in the zone table, there must be one and only one defaultzone
  
  For each node in the noderange, if the node is a member of the input zone, it will remove the zonename attribute for that node.
  If any of the nodes in the noderange is not a member of the zone, you will get an error and nothing will be changed.
- If the -g flag is also on the command, then
+ If the \ **-g**\  flag is also on the command, then
  it will remove the group name "zonename" from each node in the noderange.
  
 
 
 \ **-s| -**\ **-sshbetweennodes**\  \ **yes|no**\ 
  
- If -s entered, the zone sshbetweennodes attribute will be set to yes or no based on the input. When this is set to yes, then ssh will be setup to allow passwordless root access between nodes.  If no, then root will be prompted for a password when running ssh between the nodes in the zone.
+ If \ **-s**\  entered, the zone sshbetweennodes attribute will be set to yes or no based on the input. When this is set to yes, then ssh will be setup to allow passwordless root access between nodes.  If no, then root will be prompted for a password when running ssh between the nodes in the zone.
  
 
 
@@ -168,9 +168,7 @@ Note: if any zones in the zone table, there must be one and only one defaultzone
  
 
 
-5.
- 
- To remove a group of nodes (compute4) from zone4 and remove zone4 group from the nodes,  enter:
+5. To remove a group of nodes (compute4) from zone4 and remove zone4 group from the nodes,  enter:
  
  
  .. code-block:: perl
@@ -208,5 +206,5 @@ Location of the chzone command.
 ****************
 
 
-L <mkzone(1)|mkzone.1>,L <rmzone(1)|rmzone.1>,L <xdsh(1)|xdsh.1>, updatenode(1)|updatenode.1
+mkzone(1)|mkzone.1, rmzone(1)|rmzone.1, xdsh(1)|xdsh.1, updatenode(1)|updatenode.1
 

--- a/docs/source/guides/admin-guides/references/man1/db2sqlsetup.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/db2sqlsetup.1.rst
@@ -175,9 +175,7 @@ EXAMPLES
  
 
 
-5.
- 
- To setup the DB2 database but not start xcat running with it:
+5. To setup the DB2 database but not start xcat running with it:
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man1/lstree.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/lstree.1.rst
@@ -112,9 +112,7 @@ EXAMPLES
  
 
 
-2.
- 
- To display the tree of service node hierarchy for service node "mysn01".
+2. To display the tree of service node hierarchy for service node "mysn01".
  
  
  .. code-block:: perl
@@ -135,9 +133,7 @@ EXAMPLES
  
 
 
-3.
- 
- To display the tree of hardware hierarchy for all the nodes.
+3. To display the tree of hardware hierarchy for all the nodes.
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man1/mkdsklsnode.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/mkdsklsnode.1.rst
@@ -247,9 +247,7 @@ EXAMPLES
  
 
 
-4.
- 
- Initialize an xCAT node called "node02" as an AIX diskless node.  Create a new NIM machine definition name with the osimage as an extension to the xCAT node name.
+4. Initialize an xCAT node called "node02" as an AIX diskless node.  Create a new NIM machine definition name with the osimage as an extension to the xCAT node name.
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man1/mkzone.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/mkzone.1.rst
@@ -132,9 +132,7 @@ Note: if any zones in the zone table, there must be one and only one defaultzone
  
 
 
-3.
- 
- To make a new zone2A using the ssh id_rsa private key in /root/.ssh:
+3. To make a new zone2A using the ssh id_rsa private key in /root/.ssh:
  
  
  .. code-block:: perl
@@ -144,9 +142,7 @@ Note: if any zones in the zone table, there must be one and only one defaultzone
  
 
 
-4.
- 
- To make a new zone3 and assign the noderange compute3 to the zone  enter:
+4. To make a new zone3 and assign the noderange compute3 to the zone  enter:
  
  
  .. code-block:: perl
@@ -166,9 +162,7 @@ Note: if any zones in the zone table, there must be one and only one defaultzone
  
 
 
-6.
- 
- To make a new zone5 and assign the noderange compute5 to the zone and add zone5 as a group to each node but not allow passwordless ssh between the nodes  enter:
+6. To make a new zone5 and assign the noderange compute5 to the zone and add zone5 as a group to each node but not allow passwordless ssh between the nodes  enter:
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man1/nodechmac.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/nodechmac.1.rst
@@ -29,7 +29,7 @@ DESCRIPTION
 ***********
 
 
-The \ **nodechmac**\  command changes the MAC address for provisioned node’s network interface.
+The \ **nodechmac**\  command changes the MAC address for provisioned node's network interface.
 
 You can use this command to keep an existing node configuration. For example, if an existing node has hardware problems, the replacement node can use the old configurations. By using the nodechmac command, the node name and network settings of the old node can be used by the new node.
 

--- a/docs/source/guides/admin-guides/references/man1/renergy.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/renergy.1.rst
@@ -832,9 +832,7 @@ so no additional plugins are needed for BladeCenter.)
  
 
 
-4
- 
- Query all the attirbutes for management module node MM1. (For chassis)
+4 Query all the attributes for management module node MM1. (For chassis)
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man1/rinv.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rinv.1.rst
@@ -384,9 +384,7 @@ Calling \ **rinv**\  for VMware will display the UUID/GUID, number of CPUs, amou
  
 
 
-3.
- 
- To retrieve 'config' information from the HMC-managed LPAR node3, enter:
+3. To retrieve 'config' information from the HMC-managed LPAR node3, enter:
  
  
  .. code-block:: perl
@@ -406,9 +404,7 @@ Calling \ **rinv**\  for VMware will display the UUID/GUID, number of CPUs, amou
  
 
 
-4.
- 
- To retrieve information about a VMware node vm1, enter:
+4. To retrieve information about a VMware node vm1, enter:
  
  
  .. code-block:: perl
@@ -433,9 +429,7 @@ Calling \ **rinv**\  for VMware will display the UUID/GUID, number of CPUs, amou
  
 
 
-5.
- 
- To list the defined network names available for a given node:
+5. To list the defined network names available for a given node:
  
  
  .. code-block:: perl
@@ -460,9 +454,7 @@ Calling \ **rinv**\  for VMware will display the UUID/GUID, number of CPUs, amou
  
 
 
-6.
- 
- To list the configuration for a given network:
+6. To list the configuration for a given network:
  
  
  .. code-block:: perl
@@ -483,9 +475,7 @@ Calling \ **rinv**\  for VMware will display the UUID/GUID, number of CPUs, amou
  
 
 
-7.
- 
- To list the disk pool names available:
+7. To list the disk pool names available:
  
  
  .. code-block:: perl
@@ -505,9 +495,7 @@ Calling \ **rinv**\  for VMware will display the UUID/GUID, number of CPUs, amou
  
 
 
-8.
- 
- List the configuration for a given disk pool:
+8. List the configuration for a given disk pool:
  
  
  .. code-block:: perl
@@ -527,9 +515,7 @@ Calling \ **rinv**\  for VMware will display the UUID/GUID, number of CPUs, amou
  
 
 
-9.
- 
- List the known zFCP pool names.
+9. List the known zFCP pool names.
  
  
  .. code-block:: perl
@@ -549,9 +535,7 @@ Calling \ **rinv**\  for VMware will display the UUID/GUID, number of CPUs, amou
  
 
 
-10.
- 
- List the SCSI/FCP devices contained in a given zFCP pool:
+10. List the SCSI/FCP devices contained in a given zFCP pool:
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man1/rmzone.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rmzone.1.rst
@@ -91,9 +91,7 @@ Note: if any zones in the zone table, there must be one and only one defaultzone
  
 
 
-2.
- 
- To remove zone2 from the zone table, the zone2 zonename attribute, and the zone2 group assigned to all nodes that were in zone2, enter:
+2. To remove zone2 from the zone table, the zone2 zonename attribute, and the zone2 group assigned to all nodes that were in zone2, enter:
  
  
  .. code-block:: perl
@@ -103,9 +101,7 @@ Note: if any zones in the zone table, there must be one and only one defaultzone
  
 
 
-3.
- 
- To remove zone3 from the zone table, all the node zone attributes and  override the fact it is the defaultzone,  enter:
+3. To remove zone3 from the zone table, all the node zone attributes and  override the fact it is the defaultzone,  enter:
  
  
  .. code-block:: perl
@@ -127,5 +123,5 @@ Location of the rmzone command.
 ****************
 
 
-L <mkzone(1)|mkzone.1>,L <chzone(1)|chzone.1>,L <xdsh(1)|xdsh.1>, updatenode(1)|updatenode.1
+mkzone(1)|mkzone.1, chzone(1)|chzone.1, xdsh(1)|xdsh.1, updatenode(1)|updatenode.1
 

--- a/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
@@ -320,7 +320,7 @@ OPTIONS
 
 \ **community**\ ={\ **public**\  | \ *string*\ }
  
- Get or set the SNMP commmunity value. The default is \ **public**\ .
+ Get or set the SNMP community value. The default is \ **public**\ .
  
 
 
@@ -446,7 +446,7 @@ OPTIONS
 
 \ **vlan**\ 
  
- Get or set vlan ID. For get vlan ID, if vlan is not enabled, 'BMC VLAN disabled' will be outputed. For set vlan ID, the valid value are [1-4096].
+ Get or set vlan ID. For get vlan ID, if vlan is not enabled, 'BMC VLAN disabled' will be displayed. For set vlan ID, the valid value are [1-4096].
  
 
 
@@ -1250,9 +1250,7 @@ EXAMPLES
  
 
 
-27.
- 
- To deconfigure memory bank 9 and 10 of Processing Unit 0 on mm01:
+27. To deconfigure memory bank 9 and 10 of Processing Unit 0 on mm01:
  
  
  .. code-block:: perl
@@ -1270,9 +1268,7 @@ EXAMPLES
  
 
 
-28.
- 
- To reset the network interface of the specified nodes:
+28. To reset the network interface of the specified nodes:
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man1/sinv.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/sinv.1.rst
@@ -163,7 +163,7 @@ Command Protocol can be used. See man \ **xdsh**\  for more details.
  for Ethernet switches and IB switches under
  \ */opt/xcat/share/xcat/devicetype*\  directory. If you want to overwrite
  any of the configuration files, copy them to \ */var/opt/xcat/*\ 
- directory and cutomize.
+ directory and customize.
  For example, \ *base/IBSwitch/Qlogic/config*\  is the configuration
  file location if devicetype is specified as IBSwitch::Qlogic.
  xCAT will first search config file using \ */var/opt/xcat/*\  as the base.
@@ -329,9 +329,7 @@ using the exact match option, generating no additional templates, enter:
  
 
 
-8.
- 
- To execute \ **sinv**\  on the AIX NIM 611dskls spot and compare /etc/hosts to compute1 node, run the following:
+8. To execute \ **sinv**\  on the AIX NIM 611dskls spot and compare /etc/hosts to compute1 node, run the following:
  
  
  .. code-block:: perl
@@ -343,9 +341,7 @@ using the exact match option, generating no additional templates, enter:
  
 
 
-9.
- 
- To execute \ **sinv**\  on the device mswitch2 and compare to mswitch1
+9. To execute \ **sinv**\  on the device mswitch2 and compare to mswitch1
  
  
  .. code-block:: perl
@@ -367,5 +363,5 @@ Location of the sinv command.
 ****************
 
 
-L <xdsh(1)|xdsh.1>, noderange(3)|noderange.3
+xdsh(1)|xdsh.1, noderange(3)|noderange.3
 

--- a/docs/source/guides/admin-guides/references/man1/xdcp.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/xdcp.1.rst
@@ -47,7 +47,7 @@ If the Management Node is target node, it must be defined in the xCAT database w
 \ **REMOTE**\  \ **USER**\ :
 
 A  user_ID  can  be specified for the remote copy command.  Remote user
-specification is identical for the xdcp and xdsh commands.  See  the  xdsh
+specification is identical for the \ **xdcp**\  and \ **xdsh**\  commands.  See  the  \ **xdsh**\ 
 command for more information.
 
 \ **REMOTE**\  \ **COMMAND**\  \ **COPY**\ :
@@ -234,7 +234,7 @@ standard output or standard error is displayed.
  
  When you use the append script,  the file  (left) of the arrow is appended to the file right of the arrow.  In this example, /etc/myappenddir/appendfile is appended to /etc/mysetup/setup file, which must already exist on the node. The /opt/xcat/share/xcat/scripts/xdcpappend.sh is used to accomplish this.
  
- Another option is the \ **MERGE:**\  clause in the synclist file. The \ **MERGE:**\  clause is used to append the contents of the input file to /etc/passwd, /etc/group, or /etc/shadow on a Linux node.  It is only supported for those files and only on Linux. You must not use both the APPEND and MERGE funcion for these three files. The processing could end up not creating the file you desire. The MERGE function is the preferred method, becuase APPEND only adds to the file.  MERGE will add to the file but also insure there are no duplicate entries.
+ Another option is the \ **MERGE:**\  clause in the synclist file. The \ **MERGE:**\  clause is used to append the contents of the input file to /etc/passwd, /etc/group, or /etc/shadow on a Linux node.  It is only supported for those files and only on Linux. You must not use both the APPEND and MERGE funcion for these three files. The processing could end up not creating the file you desire. The MERGE function is the preferred method, because APPEND only adds to the file.  MERGE will add to the file but also insure there are no duplicate entries.
  
  For example, your rsynclist file may look like this:
   /tmp/share/file2  ->  /tmp/file2
@@ -605,9 +605,7 @@ from the local host to node1 in the cluster, enter:
  
 
 
-9.
- 
- To rsync all the files in /home/mikev to the  compute nodes:
+9. To rsync all the files in /home/mikev to the  compute nodes:
  
  Create a rsync file /tmp/myrsync, with this line:
  

--- a/docs/source/guides/admin-guides/references/man1/xdsh.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/xdsh.1.rst
@@ -87,8 +87,7 @@ The remote shell is determined as follows, in order of precedence:
 
 4. The \ **/usr/bin/ssh**\  command.
 
-The  remote shell options are determined as follows, in order of prece-
-dence:
+The  remote shell options are determined as follows, in order of precedence:
 
 1. The \ **-o**\  flag.
 
@@ -664,11 +663,9 @@ on the service node fedora9 diskless image, enter:
  
 
 
-9.
- 
- To define the QLogic IB switch as a node and to set up the SSH keys for IB switch
- \ **qswitch**\  with device configuration file
- \ **/var/opt/xcat/IBSwitch/Qlogic/config**\  and user name \ **username**\ , enter
+9. To define the QLogic IB switch as a node and to set up the SSH keys for IB switch
+\ **qswitch**\  with device configuration file
+\ **/var/opt/xcat/IBSwitch/Qlogic/config**\  and user name \ **username**\ , enter
  
  
  .. code-block:: perl
@@ -703,9 +700,7 @@ on the service node fedora9 diskless image, enter:
  
 
 
-12.
- 
- To define a BNT Ethernet switch as a node and run a command to create a new vlan with vlan id 3 on the switch.
+12. To define a BNT Ethernet switch as a node and run a command to create a new vlan with vlan id 3 on the switch.
  
  
  .. code-block:: perl
@@ -727,9 +722,7 @@ on the service node fedora9 diskless image, enter:
  
 
 
-13.
- 
- To run \ **xdsh**\  with the non-root userid "user1" that has been setup as an xCAT userid and with sudo on node1 and node2 to run as root, do the following, see xCAT doc on Granting_Users_xCAT_privileges:
+13. To run \ **xdsh**\  with the non-root userid "user1" that has been setup as an xCAT userid and with sudo on node1 and node2 to run as root, do the following, see xCAT doc on Granting_Users_xCAT_privileges:
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man1/xdshbak.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/xdshbak.1.rst
@@ -166,10 +166,8 @@ the format used in the Description, enter:
  
 
 
-2.
- 
- To display the results of a command issued on several nodes with
- identical output displayed only once, enter:
+2. To display the results of a command issued on several nodes with
+identical output displayed only once, enter:
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man5/nodegroup.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/nodegroup.5.rst
@@ -44,7 +44,7 @@ nodegroup Attributes:
 
 \ **grouptype**\ 
  
- The only current valid value is dynamic.  We will be looking at having the object def commands working with static group definitions in the nodelist table.
+ Static or Dynamic. A static group is defined to contain a specific set of cluster nodes. A dynamic node group is one that has its members determined by specifying a selection criteria for node attributes.
  
 
 

--- a/docs/source/guides/admin-guides/references/man5/site.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/site.5.rst
@@ -457,7 +457,7 @@ site Attributes:
   
    xcatlport:  The port used by xcatd command log writer process to collect command output.
   
-   xcatsslversion:  The ssl version by xcatd. Default is SSLv3.
+   xcatsslversion:  The ssl version by xcatd. Default is TLSv1.
   
    xcatsslciphers:  The ssl cipher by xcatd. Default is 3DES.
  

--- a/docs/source/guides/admin-guides/references/man7/group.7.rst
+++ b/docs/source/guides/admin-guides/references/man7/group.7.rst
@@ -331,7 +331,7 @@ group Attributes:
 
 \ **grouptype**\  (nodegroup.grouptype)
  
- The only current valid value is dynamic.  We will be looking at having the object def commands working with static group definitions in the nodelist table.
+ Static or Dynamic. A static group is defined to contain a specific set of cluster nodes. A dynamic node group is one that has its members determined by specifying a selection criteria for node attributes.
  
 
 

--- a/perl-xCAT/xCAT/Schema.pm
+++ b/perl-xCAT/xCAT/Schema.pm
@@ -585,7 +585,7 @@ passed as argument rather than by table value',
         table_desc => 'Contains group definitions, whose membership is dynamic depending on characteristics of the node.',
         descriptions => {
             groupname => 'Name of the group.',
-            grouptype => 'The only current valid value is dynamic.  We will be looking at having the object def commands working with static group definitions in the nodelist table.',
+            grouptype => 'Static or Dynamic. A static group is defined to contain a specific set of cluster nodes. A dynamic node group is one that has its members determined by specifying a selection criteria for node attributes.',
             members => 'The value of the attribute is not used, but the attribute is necessary as a place holder for the object def commands.  (The membership for static groups is stored in the nodelist table.)',
             membergroups => 'This attribute stores a comma-separated list of nodegroups that this nodegroup refers to. This attribute is only used by PCM.',
             wherevals => 'A list of "attr*val" pairs that can be used to determine the members of a dynamic group, the delimiter is "::" and the operator * can be ==, =~, != or !~.',

--- a/xCAT-client/pods/man1/chzone.1.pod
+++ b/xCAT-client/pods/man1/chzone.1.pod
@@ -12,8 +12,8 @@ B<chzone> [B<-h> | B<-v>]
 =head1 B<DESCRIPTION>
 
 The B<chzone> command is designed to change the definition of a zone previous defined in the cluster.
-The chzone command is only supported on Linux ( No AIX support).
-The nodes are not updated with the new root ssh keys by chzone. You must run updatenode -k  or xdsh -K to the nodes to update the root ssh keys to the new generated zone keys. This will also sync any service nodes with the zone keys, if you have a hierarchical cluster.
+The B<chzone> command is only supported on Linux ( No AIX support).
+The nodes are not updated with the new root ssh keys by B<chzone>. You must run B<updatenode -k>  or B<xdsh -K> to the nodes to update the root ssh keys to the new generated zone keys. This will also sync any service nodes with the zone keys, if you have a hierarchical cluster.
 Note: if any zones in the zone table, there must be one and only one defaultzone. Otherwise, errors will occur.
 
 =head1 B<OPTIONS>
@@ -30,12 +30,12 @@ Displays command version and build date.
 
 =item B<-k | --sshkeypath> I<full path to the ssh RSA private key>
 
-This is the path to the id_rsa key that will be used to build new root's ssh keys for the zone. If -k is used, it will generate the ssh public key from the input ssh RSA private key, and store both in /etc/xcat/sshkeys/<zonename>/.ssh directory.
+This is the path to the id_rsa key that will be used to build new root's ssh keys for the zone. If B<-k> is used, it will generate the ssh public key from the input ssh RSA private key, and store both in /etc/xcat/sshkeys/<zonename>/.ssh directory.
 
 =item B<-K | --genkeys>
 
 Using this flag, will  generate new ssh RSA private and public keys for the zone into the /etc/xcat/sshkeys/<zonename>/.ssh directory.
-The nodes are not automatically updated with the new root ssh keys by chzone. You must run updatenode -k  or xdsh -K to the nodes to update the root ssh keys to the new generated zone keys. This will also sync any service nodes with the zone keys, if you have a hierarchical cluster.
+The nodes are not automatically updated with the new root ssh keys by chzone. You must run B<updatenode -k>  or B<xdsh -K> to the nodes to update the root ssh keys to the new generated zone keys. This will also sync any service nodes with the zone keys, if you have a hierarchical cluster.
 
 =item B<--defaultzone>
 
@@ -48,20 +48,20 @@ Note: if any zones in the zone table, there must be one and only one defaultzone
 =item B<-a | --addnoderange> I<noderange>
 
 For each node in the noderange, it will set the zonename attribute for that node to the input zonename.
-If the -g flag is also on the command, then
+If the B<-g> flag is also on the command, then
 it will add the group name "zonename" to each node in the noderange.
 
 =item B<-r | --rmnoderange> I<noderange>
 
 For each node in the noderange, if the node is a member of the input zone, it will remove the zonename attribute for that node.
 If any of the nodes in the noderange is not a member of the zone, you will get an error and nothing will be changed.
-If the -g flag is also on the command, then
+If the B<-g> flag is also on the command, then
 it will remove the group name "zonename" from each node in the noderange.
 
 
 =item B<-s| --sshbetweennodes> B<yes|no>
 
-If -s entered, the zone sshbetweennodes attribute will be set to yes or no based on the input. When this is set to yes, then ssh will be setup to allow passwordless root access between nodes.  If no, then root will be prompted for a password when running ssh between the nodes in the zone.
+If B<-s> entered, the zone sshbetweennodes attribute will be set to yes or no based on the input. When this is set to yes, then ssh will be setup to allow passwordless root access between nodes.  If no, then root will be prompted for a password when running ssh between the nodes in the zone.
 
 =item B<-f | --force>
 
@@ -108,7 +108,6 @@ To add a new group of nodes (compute3) to zone3 and add zone3 group to the nodes
  chzone zone3 -a compute3 -g
 
 =item 5.
-
 To remove a group of nodes (compute4) from zone4 and remove zone4 group from the nodes,  enter:
 
  chzone> zone4 -r compute4 -g
@@ -130,4 +129,4 @@ Location of the chzone command.
 
 =head1 B<SEE ALSO>
 
-L <mkzone(1)|mkzone.1>,L <rmzone(1)|rmzone.1>,L <xdsh(1)|xdsh.1>, L<updatenode(1)|updatenode.1>
+L<mkzone(1)|mkzone.1>, L<rmzone(1)|rmzone.1>, L<xdsh(1)|xdsh.1>, L<updatenode(1)|updatenode.1>

--- a/xCAT-client/pods/man1/db2sqlsetup.1.pod
+++ b/xCAT-client/pods/man1/db2sqlsetup.1.pod
@@ -116,7 +116,6 @@ To setup the ODBC for  DB2 xcatdb database access, on the SN :
  db2sqlsetup -o -C
 
 =item 5.
-
 To setup the DB2 database but not start xcat running with it:
 
  db2sqlsetup -i -S -N

--- a/xCAT-client/pods/man1/lstree.1.pod
+++ b/xCAT-client/pods/man1/lstree.1.pod
@@ -67,7 +67,6 @@ Output is similar to:
  ......
 
 =item 2.
-
 To display the tree of service node hierarchy for service node "mysn01".
 
  lstree -s mysn01
@@ -80,7 +79,6 @@ Output is similar to:
  |__mycn03
 
 =item 3.
-
 To display the tree of hardware hierarchy for all the nodes.
 
  lstree -H

--- a/xCAT-client/pods/man1/mkdsklsnode.1.pod
+++ b/xCAT-client/pods/man1/mkdsklsnode.1.pod
@@ -176,7 +176,6 @@ Initialize diskless node "clstrn29" using the xCAT osimage called "61dskls".  Al
  mkdsklsnode -i 61dskls clstrn29 psize=128 sparse_paging=yes
 
 =item 4.
-
 Initialize an xCAT node called "node02" as an AIX diskless node.  Create a new NIM machine definition name with the osimage as an extension to the xCAT node name.
 
  mkdsklsnode -n -i 61spot node02

--- a/xCAT-client/pods/man1/mkzone.1.pod
+++ b/xCAT-client/pods/man1/mkzone.1.pod
@@ -82,13 +82,11 @@ To make a new zone2 using defaults and make it the default zone enter:
  mkzone> zone2 --defaultzone -f
 
 =item 3.
-
 To make a new zone2A using the ssh id_rsa private key in /root/.ssh:
 
  mkzone zone2A -k /root/.ssh
 
 =item 4.
-
 To make a new zone3 and assign the noderange compute3 to the zone  enter:
 
  mkzone zone3 -a compute3
@@ -99,7 +97,6 @@ To make a new zone4 and assign the noderange compute4 to the zone and add zone4 
  mkzone zone4 -a compute4 -g
 
 =item 6.
-
 To make a new zone5 and assign the noderange compute5 to the zone and add zone5 as a group to each node but not allow passwordless ssh between the nodes  enter:
 
  mkzone zone5 -a compute5 -g -s no

--- a/xCAT-client/pods/man1/nodechmac.1.pod
+++ b/xCAT-client/pods/man1/nodechmac.1.pod
@@ -10,7 +10,7 @@ B<nodechmac> I<node-name> B<mac=>I<mac-address>
 
 =head1 DESCRIPTION
 
-The B<nodechmac> command changes the MAC address for provisioned node’s network interface.
+The B<nodechmac> command changes the MAC address for provisioned node's network interface.
 
 You can use this command to keep an existing node configuration. For example, if an existing node has hardware problems, the replacement node can use the old configurations. By using the nodechmac command, the node name and network settings of the old node can be used by the new node.
 

--- a/xCAT-client/pods/man1/renergy.1.pod
+++ b/xCAT-client/pods/man1/renergy.1.pod
@@ -699,8 +699,7 @@ The output of the query operation:
     ...
 
 =item 4
-
-Query all the attirbutes for management module node MM1. (For chassis)
+Query all the attributes for management module node MM1. (For chassis)
 
  renergy MM1 all
 

--- a/xCAT-client/pods/man1/rinv.1.pod
+++ b/xCAT-client/pods/man1/rinv.1.pod
@@ -258,7 +258,6 @@ Output is similar to:
  </SYSTEM>
 
 =item 3.
-
 To retrieve 'config' information from the HMC-managed LPAR node3, enter:
 
  rinv node3 config
@@ -270,7 +269,6 @@ Output is similar to:
  node5: Total Memory (MB): 1024
 
 =item 4.
-
 To retrieve information about a VMware node vm1, enter:
 
  rinv vm1
@@ -287,7 +285,6 @@ Output is similar to:
 B<zVM specific :>
 
 =item 5.
-
 To list the defined network names available for a given node:
 
  rinv pokdev61 --getnetworknames
@@ -304,7 +301,6 @@ Output is similar to:
  pokdev61: VSWITCH SYSTEM VSW3
 
 =item 6.
-
 To list the configuration for a given network:
 
  rinv pokdev61 --getnetwork GLAN1
@@ -317,7 +313,6 @@ Output is similar to:
  pokdev61:   Isolation Status: OFF
 
 =item 7.
-
 To list the disk pool names available:
 
  rinv pokdev61 --diskpoolnames
@@ -329,7 +324,6 @@ Output is similar to:
  pokdev61: POOL3
 
 =item 8.
-
 List the configuration for a given disk pool:
 
  rinv pokdev61 --diskpool POOL1 free
@@ -342,7 +336,6 @@ Output is similar to:
 
 
 =item 9.
-
 List the known zFCP pool names.
 
  rinv pokdev61 --zfcppoolnames
@@ -354,7 +347,6 @@ Output is similar to:
  pokdev61: zfcp3
 
 =item 10.
-
 List the SCSI/FCP devices contained in a given zFCP pool:
 
  rinv pokdev61 --zfcppool zfcp1

--- a/xCAT-client/pods/man1/rmzone.1.pod
+++ b/xCAT-client/pods/man1/rmzone.1.pod
@@ -58,13 +58,11 @@ To remove zone1 from the zone table and the zonename attribute on all it's assig
  rmzone zone1
 
 =item 2.
-
 To remove zone2 from the zone table, the zone2 zonename attribute, and the zone2 group assigned to all nodes that were in zone2, enter:
 
  rmzone zone2 -g
 
 =item 3.
-
 To remove zone3 from the zone table, all the node zone attributes and  override the fact it is the defaultzone,  enter:
 
  rmzone zone3 -g -f
@@ -79,4 +77,4 @@ Location of the rmzone command.
 
 =head1 B<SEE ALSO>
 
-L <mkzone(1)|mkzone.1>,L <chzone(1)|chzone.1>,L <xdsh(1)|xdsh.1>, L<updatenode(1)|updatenode.1>
+L<mkzone(1)|mkzone.1>, L<chzone(1)|chzone.1>, L<xdsh(1)|xdsh.1>, L<updatenode(1)|updatenode.1>

--- a/xCAT-client/pods/man1/rspconfig.1.pod
+++ b/xCAT-client/pods/man1/rspconfig.1.pod
@@ -264,7 +264,7 @@ Get the BMC backup gateway ip address.
 
 =item B<community>={B<public> | I<string>}
 
-Get or set the SNMP commmunity value. The default is B<public>.
+Get or set the SNMP community value. The default is B<public>.
 
 =item B<date>=I<mm:dd:yyy>
 
@@ -348,7 +348,7 @@ Get or set hostname on the service processor.
 
 =item B<vlan>
 
-Get or set vlan ID. For get vlan ID, if vlan is not enabled, 'BMC VLAN disabled' will be outputed. For set vlan ID, the valid value are [1-4096].
+Get or set vlan ID. For get vlan ID, if vlan is not enabled, 'BMC VLAN disabled' will be displayed. For set vlan ID, the valid value are [1-4096].
 
 =item B<ipsrc>
 
@@ -855,7 +855,6 @@ To force service processor failover for cec01:
  cec01: 192.168.2.2: sp=primary,ipadd=192.168.2.2,alt_ipadd=unavailable,state=LINE UP
 
 =item 27.
-
 To deconfigure memory bank 9 and 10 of Processing Unit 0 on mm01:
 
  rspconfig mm01 memdecfg=deconfigure:bank:0:9,10
@@ -865,7 +864,6 @@ Output is similar to:
  mm01: Success
 
 =item 28.
-
 To reset the network interface of the specified nodes:
 
  rspconfig --resetnet

--- a/xCAT-client/pods/man1/sinv.1.pod
+++ b/xCAT-client/pods/man1/sinv.1.pod
@@ -135,7 +135,7 @@ xCAT ships some default configuration files
 for Ethernet switches and IB switches under
 I</opt/xcat/share/xcat/devicetype> directory. If you want to overwrite
 any of the configuration files, copy them to I</var/opt/xcat/>
-directory and cutomize.
+directory and customize.
 For example, I<base/IBSwitch/Qlogic/config> is the configuration
 file location if devicetype is specified as IBSwitch::Qlogic.
 xCAT will first search config file using I</var/opt/xcat/> as the base.
@@ -252,7 +252,6 @@ To execute B<sinv> on the Linux osimage defined for cn1.  First build a template
  sinv -c "xdsh -i /install/netboot/rhels6/ppc64/test_ramdisk_statelite/rootimg cat /etc/hosts" -e -t 1 -p /tmp/sinv.template -o /tmp/sinv.output
 
 =item 8.
-
 To execute B<sinv> on the AIX NIM 611dskls spot and compare /etc/hosts to compute1 node, run the following:
 
  xdsh compute1 "cat /etc/hosts" | xdshcoll > /tmp/sinv2/template"
@@ -260,7 +259,6 @@ To execute B<sinv> on the AIX NIM 611dskls spot and compare /etc/hosts to comput
  sinv -c "xdsh -i 611dskls cat /etc/hosts" -e -t1 -p /tmp/sinv.template -o /tmp/sinv.output
 
 =item 9.
-
 To execute B<sinv> on the device mswitch2 and compare to mswitch1
 
  sinv -c "xdsh mswitch  enable;show version" -s mswitch1 -p /tmp/sinv/template --devicetype IBSwitch::Mellanox -l admin -t 2
@@ -275,4 +273,4 @@ Location of the sinv command.
 
 =head1 B<SEE ALSO>
 
-L <xdsh(1)|xdsh.1>, L<noderange(3)|noderange.3>
+L<xdsh(1)|xdsh.1>, L<noderange(3)|noderange.3>

--- a/xCAT-client/pods/man1/xdcp.1.pod
+++ b/xCAT-client/pods/man1/xdcp.1.pod
@@ -31,7 +31,7 @@ If the Management Node is target node, it must be defined in the xCAT database w
 B<REMOTE> B<USER>:
 
 A  user_ID  can  be specified for the remote copy command.  Remote user
-specification is identical for the xdcp and xdsh commands.  See  the  xdsh
+specification is identical for the B<xdcp> and B<xdsh> commands.  See  the  B<xdsh>
 command for more information.
 
 B<REMOTE> B<COMMAND> B<COPY>:
@@ -185,7 +185,7 @@ For example, your rsynclist file may look like this:
 
 When you use the append script,  the file  (left) of the arrow is appended to the file right of the arrow.  In this example, /etc/myappenddir/appendfile is appended to /etc/mysetup/setup file, which must already exist on the node. The /opt/xcat/share/xcat/scripts/xdcpappend.sh is used to accomplish this.
 
-Another option is the B<MERGE:> clause in the synclist file. The B<MERGE:> clause is used to append the contents of the input file to /etc/passwd, /etc/group, or /etc/shadow on a Linux node.  It is only supported for those files and only on Linux. You must not use both the APPEND and MERGE funcion for these three files. The processing could end up not creating the file you desire. The MERGE function is the preferred method, becuase APPEND only adds to the file.  MERGE will add to the file but also insure there are no duplicate entries.
+Another option is the B<MERGE:> clause in the synclist file. The B<MERGE:> clause is used to append the contents of the input file to /etc/passwd, /etc/group, or /etc/shadow on a Linux node.  It is only supported for those files and only on Linux. You must not use both the APPEND and MERGE funcion for these three files. The processing could end up not creating the file you desire. The MERGE function is the preferred method, because APPEND only adds to the file.  MERGE will add to the file but also insure there are no duplicate entries.
 
 For example, your rsynclist file may look like this:
  /tmp/share/file2  ->  /tmp/file2
@@ -469,7 +469,6 @@ Run:
  xdcp compute -F /tmp/myrsync
 
 =item 9.
-
 To rsync all the files in /home/mikev to the  compute nodes:
 
 Create a rsync file /tmp/myrsync, with this line:

--- a/xCAT-client/pods/man1/xdsh.1.pod
+++ b/xCAT-client/pods/man1/xdsh.1.pod
@@ -70,8 +70,7 @@ The remote shell is determined as follows, in order of precedence:
 
 4. The B</usr/bin/ssh> command.
 
-The  remote shell options are determined as follows, in order of prece-
-dence:
+The  remote shell options are determined as follows, in order of precedence:
 
 1. The B<-o> flag.
 
@@ -525,7 +524,6 @@ To cleanup the servicenode directory that stages the copy of files to the nodes,
  xdsh servicenoderange -c
 
 =item 9.
-
 To define the QLogic IB switch as a node and to set up the SSH keys for IB switch
 B<qswitch> with device configuration file
 B</var/opt/xcat/IBSwitch/Qlogic/config> and user name B<username>, enter
@@ -548,7 +546,6 @@ B<mswitch> with and user name B<username>, enter
  xdsh mswitch -l admin --devicetype IBSwitch::Mellanox  'enable;configure terminal;show ssh server host-keys'
 
 =item 12.
-
 To define a BNT Ethernet switch as a node and run a command to create a new vlan with vlan id 3 on the switch.
 
  chdef myswitch groups=all
@@ -562,7 +559,6 @@ If it is for Telnet, add I<tn:> in front of the user name: I<tn:admin>.
  dsh myswitch --devicetype EthSwitch::BNT 'enable;configure terminal;vlan 3;end;show vlan'
 
 =item 13.
-
 To run B<xdsh> with the non-root userid "user1" that has been setup as an xCAT userid and with sudo on node1 and node2 to run as root, do the following, see xCAT doc on Granting_Users_xCAT_privileges:
 
  xdsh node1,node2 --sudo -l user1 "cat /etc/passwd"

--- a/xCAT-client/pods/man1/xdshbak.1.pod
+++ b/xCAT-client/pods/man1/xdshbak.1.pod
@@ -114,7 +114,6 @@ the format used in the Description, enter:
  xdsh node1,node2,node3 cat /etc/passwd | xdshbak
 
 =item 2.
-
 To display the results of a command issued on several nodes with
 identical output displayed only once, enter:
 


### PR DESCRIPTION
Some man pages have these errors at the end:
```
man xdsh
:
:
POD ERRORS
       Hey! The above document had some coding errors, which are explained below:

       Around line 527:
           Expected text after =item, not a number

       Around line 550:
           Expected text after =item, not a number

       Around line 564:
           Expected text after =item, not a number
```

Cause is a line separating `=item xx.` and the text in `.pod` file

Also fixed multiple spelling and formatting errors.
