### PR TITLE
Get group name from lsdef command

### DIFF
--- a/xCAT-client/share/xcat/tools/groupfiles4dsh
+++ b/xCAT-client/share/xcat/tools/groupfiles4dsh
@@ -45,7 +45,7 @@ use xCAT::Utils;
 # Main
 my $rc = 0;
 &parse_args;
-my $cmd = "lsdef -t group";
+my $cmd = "lsdef -t group | awk '{print \$1}'";
 my @grpoutput = xCAT::Utils->runcmd($cmd, 0);
 if ($::RUNCMD_RC != 0)
 {    # error


### PR DESCRIPTION
### The PR is to fix issue _ #5655 

### The modification include
`lsdef -t group` will get groupname with `(group)` string at the end of each line
```
[root@boston02 tools]# lsdef -t group
10.6.25.1  (group)
172.21.208.100  (group)
172.21.208.3  (group)
172.21.253.104  (group)
172.21.253.105  (group)
172.21.253.115  (group)
all  (group)
boston  (group)
cn_regex  (group)
compute_group  (group)
````
the group name will be `10.6.25.1  (group)` instead of `10.6.25.1` from above command.

### The UT result
```
[root@boston02 ~]# groupfiles4dsh -p /tmp/nodegroupfiles
[root@boston02 ~]# ls -ltr /tmp/nodegroupfiles/
total 60
-rw-r--r-- 1 root root  0 Sep 26 16:19 10.6.25.1
-rw-r--r-- 1 root root  0 Sep 26 16:19 172.21.208.100
-rw-r--r-- 1 root root  0 Sep 26 16:19 172.21.208.3
-rw-r--r-- 1 root root  0 Sep 26 16:19 172.21.253.104
-rw-r--r-- 1 root root  0 Sep 26 16:19 172.21.253.105
-rw-r--r-- 1 root root  0 Sep 26 16:19 172.21.253.115
-rw-r--r-- 1 root root 39 Sep 26 16:19 all
-rw-r--r-- 1 root root 15 Sep 26 16:19 boston
-rw-r--r-- 1 root root 15 Sep 26 16:19 cn_regex
-rw-r--r-- 1 root root  0 Sep 26 16:19 compute_group


