### PR TITLE
syncfiles: fix for sync lists generated with the wrong username

### DIFF
--- a/perl-xCAT/xCAT/RSYNC.pm
+++ b/perl-xCAT/xCAT/RSYNC.pm
@@ -151,7 +151,7 @@ sub remote_copy_command
           or die "Can not open file $rsyncfile";
         my $dest_dir_list = join ' ', keys %{ $$config{'destDir_srcFile'} };
         my $dest_user_host = $$config{'dest-host'};
-        if ($$config{'dest-user'})
+        if (getpwnam($$config{'dest-user'}))
         {
             $dest_user_host =
               "$$config{'dest-user'}@" . "$$config{'dest-host'}";

--- a/perl-xCAT/xCAT/SSH.pm
+++ b/perl-xCAT/xCAT/SSH.pm
@@ -150,7 +150,7 @@ sub remote_copy_command {
 
         open SCPCMDFILE, "> $scpfile"
           or die "Can not open file $scpfile";
-        if ($$config{'dest-user'})
+        if (getpwnam($$config{'dest-user'}))
         {
             $dest_user_host =
               "$$config{'dest-user'}@" . "$$config{'dest-host'}";


### PR DESCRIPTION
### The PR is to fix issue _#5252_

### The modification include

_##Check `dest-user` existence_

Since user accounts used to synchronize files or to run xCAT commands need to exist on both the MN and the SNs, this PR just adds a check to make sure that the username passed as `$$config{'dest-user'}` is actually a valid username, and not the MN's hostname, as described in #4455 and #5252.

### The UT result
`syncfiles` works 


