### PR TITLE
Failed to parse the prescripts without action defined

### DIFF
--- a/xCAT-server/lib/xcat/plugins/prescripts.pm
+++ b/xCAT-server/lib/xcat/plugins/prescripts.pm
@@ -426,21 +426,19 @@ sub parseprescripts
     my $scripts = shift;
     my $action  = shift;
     my $ret;
-    if ($scripts) {
-        if ($scripts =~ /:/) {
-            my @a = split(/\|/, $scripts);
-            foreach my $token (@a) {
 
-                #print "token=$token, action=$action\n";
+    if ($scripts) {
+        foreach my $token (split(/\|/, $scripts)) {
+            if ($token =~ /:/) {
                 if ($token =~ /^$action:(.*)/) {
-                    $ret = $1;
-                    last;
+                    $ret .= "$1,";
                 }
+            } else {
+                $ret .= "$token,";
             }
-        } else {
-            $ret = $scripts;
         }
     }
+
     return $ret;
 }
 


### PR DESCRIPTION
### The PR is to fix issue 
#5676

### The UT result

````
[root@boston02 xCAT_plugin]# lsdef mid08tor03cn01 -i prescripts-begin
Object name: mid08tor03cn01
    prescripts-begin=all.sh|boot:boot.sh|osimage:osimage.sh,osimage1.sh
[root@boston02 xCAT_plugin]# nodeset mid08tor03cn01 boot
boston02.pok.stglabs.ibm.com: Running begin script all.sh for nodes mid08tor03cn01.
boston02.pok.stglabs.ibm.com: all.sh: running all.sh

boston02.pok.stglabs.ibm.com: Running begin script boot.sh for nodes mid08tor03cn01.
boston02.pok.stglabs.ibm.com: boot.sh: running boot.sh

mid08tor03cn01: boot
[root@boston02 xCAT_plugin]# nodeset mid08tor03cn01 install
boston02.pok.stglabs.ibm.com: Running begin script all.sh for nodes mid08tor03cn01.
boston02.pok.stglabs.ibm.com: all.sh: running all.sh

Error: [boston02]: The options "install", "netboot", and "statelite" have been deprecated, use "osimage=<osimage_name>" instead.
[root@boston02 xCAT_plugin]# nodeset mid08tor03cn01 osimage=rhels7.5-alternate-ppc64le-netboot-compute
boston02.pok.stglabs.ibm.com: Running begin script all.sh for nodes mid08tor03cn01.
boston02.pok.stglabs.ibm.com: all.sh: running all.sh

boston02.pok.stglabs.ibm.com: Running begin script osimage.sh for nodes mid08tor03cn01.
boston02.pok.stglabs.ibm.com: osimage.sh: running osimage.sh

boston02.pok.stglabs.ibm.com: Running begin script osimage1.sh for nodes mid08tor03cn01.
boston02.pok.stglabs.ibm.com: osimage1.sh: running osimage1.sh

mid08tor03cn01: netboot rhels7.5-alternate-ppc64le-compute
````

