### PR TITLE
delete all switchdiscover test cases

### DIFF
--- a/xCAT-test/autotest/bundle/pegas_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/pegas_ppc64le.bundle
@@ -265,14 +265,6 @@ prsync_h
 prsync_v
 prsync_dir_node
 prsync_file_node
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 makentp_v
 makentp_h
 nodeset_check_warninginfo

--- a/xCAT-test/autotest/bundle/rhels6.7_ppc64.bundle
+++ b/xCAT-test/autotest/bundle/rhels6.7_ppc64.bundle
@@ -252,14 +252,6 @@ xdsh_t
 xdsh_q
 xdsh_T
 xdsh_o
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 makentp_v
 makentp_h
 nodeset_check_warninginfo

--- a/xCAT-test/autotest/bundle/rhels6.7_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/rhels6.7_x86_64.bundle
@@ -187,14 +187,6 @@ xdsh_t
 xdsh_q
 xdsh_T
 xdsh_o
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 nodeset_check_warninginfo
 reg_linux_diskless_installation_flat
 reg_linux_statelite_installation_flat

--- a/xCAT-test/autotest/bundle/rhels6.8_ppc64.bundle
+++ b/xCAT-test/autotest/bundle/rhels6.8_ppc64.bundle
@@ -261,14 +261,6 @@ prsync_h
 prsync_v
 prsync_dir_node
 prsync_file_node
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 makentp_v
 makentp_h
 nodeset_check_warninginfo

--- a/xCAT-test/autotest/bundle/rhels6.8_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/rhels6.8_x86_64.bundle
@@ -196,14 +196,6 @@ prsync_h
 prsync_v
 prsync_dir_node
 prsync_file_node
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 nodeset_shell
 nodeset_cmdline
 nodeset_runimg

--- a/xCAT-test/autotest/bundle/rhels6.9_ppc64.bundle
+++ b/xCAT-test/autotest/bundle/rhels6.9_ppc64.bundle
@@ -268,14 +268,6 @@ prsync_h
 prsync_v
 prsync_dir_node
 prsync_file_node
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 makentp_v
 makentp_h
 nodeset_check_warninginfo

--- a/xCAT-test/autotest/bundle/rhels6.9_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/rhels6.9_x86_64.bundle
@@ -199,14 +199,6 @@ prsync_h
 prsync_v
 prsync_dir_node
 prsync_file_node
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 nodeset_check_warninginfo
 xcatconfig_u_check_xcatsslversion_rhels_sles
 xcatconfig_c

--- a/xCAT-test/autotest/bundle/rhels7.2_ppc64.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.2_ppc64.bundle
@@ -262,14 +262,6 @@ prsync_h
 prsync_v
 prsync_dir_node
 prsync_file_node
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 nodeset_shell
 nodeset_cmdline
 nodeset_runimg

--- a/xCAT-test/autotest/bundle/rhels7.2_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.2_ppc64le.bundle
@@ -255,14 +255,6 @@ prsync_h
 prsync_v
 prsync_dir_node
 prsync_file_node
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 nodeset_shell
 nodeset_cmdline
 nodeset_runimg

--- a/xCAT-test/autotest/bundle/rhels7.2_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.2_x86_64.bundle
@@ -196,14 +196,6 @@ prsync_h
 prsync_v
 prsync_dir_node
 prsync_file_node
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 nodeset_check_warninginfo
 nodeset_shell
 nodeset_cmdline

--- a/xCAT-test/autotest/bundle/rhels7.3_ppc64.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.3_ppc64.bundle
@@ -267,14 +267,6 @@ prsync_h
 prsync_v
 prsync_dir_node
 prsync_file_node
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 makentp_v
 makentp_h
 nodeset_check_warninginfo

--- a/xCAT-test/autotest/bundle/rhels7.3_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.3_ppc64le.bundle
@@ -261,14 +261,6 @@ prsync_h
 prsync_v
 prsync_dir_node
 prsync_file_node
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 nodeset_shell
 nodeset_cmdline
 nodeset_runimg

--- a/xCAT-test/autotest/bundle/rhels7.3_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.3_x86_64.bundle
@@ -215,14 +215,6 @@ prsync_h
 prsync_v
 prsync_dir_node
 prsync_file_node
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 nodeset_check_warninginfo
 nodeset_shell
 nodeset_cmdline

--- a/xCAT-test/autotest/bundle/rhels7.4_ppc64.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.4_ppc64.bundle
@@ -311,14 +311,6 @@ prsync_h
 prsync_v
 prsync_dir_node
 prsync_file_node
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 makentp_v
 makentp_h
 nodeset_check_warninginfo

--- a/xCAT-test/autotest/bundle/rhels7.4_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.4_ppc64le.bundle
@@ -306,14 +306,6 @@ prsync_h
 prsync_v
 prsync_dir_node
 prsync_file_node
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 makentp_v
 makentp_h
 nodeset_check_warninginfo

--- a/xCAT-test/autotest/bundle/rhels7.4_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.4_x86_64.bundle
@@ -267,14 +267,6 @@ prsync_h
 prsync_v
 prsync_dir_node
 prsync_file_node
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 nodeset_check_warninginfo
 xcatconfig_u_check_xcatsslversion_rhels_sles
 xcatconfig_c

--- a/xCAT-test/autotest/bundle/sles11.4_ppc64.bundle
+++ b/xCAT-test/autotest/bundle/sles11.4_ppc64.bundle
@@ -250,14 +250,6 @@ prsync_h
 prsync_v
 prsync_dir_node
 prsync_file_node
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 makentp_v
 makentp_h
 nodeset_check_warninginfo

--- a/xCAT-test/autotest/bundle/sles11.4_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/sles11.4_x86_64.bundle
@@ -204,14 +204,6 @@ prsync_h
 prsync_v
 prsync_dir_node
 prsync_file_node
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 nodeset_check_warninginfo
 xcatd_start
 xcatd_stop

--- a/xCAT-test/autotest/bundle/sles12.1_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/sles12.1_ppc64le.bundle
@@ -204,14 +204,6 @@ prsync_h
 prsync_v
 prsync_dir_node
 prsync_file_node
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 nodeset_shell
 nodeset_cmdline
 nodeset_runimg

--- a/xCAT-test/autotest/bundle/sles12.1_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/sles12.1_x86_64.bundle
@@ -200,14 +200,6 @@ prsync_h
 prsync_v
 prsync_dir_node
 prsync_file_node
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 nodeset_shell
 nodeset_cmdline
 nodeset_runimg

--- a/xCAT-test/autotest/bundle/sles12.2_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/sles12.2_ppc64le.bundle
@@ -219,14 +219,6 @@ prsync_h
 prsync_v
 prsync_dir_node
 prsync_file_node
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 xcatd_start
 xcatd_stop
 xcatd_restart

--- a/xCAT-test/autotest/bundle/sles12.2_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/sles12.2_x86_64.bundle
@@ -216,14 +216,6 @@ prsync_h
 prsync_v
 prsync_dir_node
 prsync_file_node
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 nodeset_check_warninginfo
 xcatd_start
 xcatd_stop

--- a/xCAT-test/autotest/bundle/sles12_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/sles12_ppc64le.bundle
@@ -187,14 +187,6 @@ xdsh_t
 xdsh_q
 xdsh_T
 xdsh_o
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 nodeset_shell
 nodeset_cmdline
 nodeset_runimg

--- a/xCAT-test/autotest/bundle/sles12_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/sles12_x86_64.bundle
@@ -191,14 +191,6 @@ xdsh_t
 xdsh_q
 xdsh_T
 xdsh_o
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 nodeset_shell
 nodeset_cmdline
 nodeset_runimg

--- a/xCAT-test/autotest/bundle/ubuntu14.04.3_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu14.04.3_ppc64le.bundle
@@ -182,14 +182,6 @@ xdsh_t
 xdsh_q
 xdsh_T
 xdsh_o
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 nodeset_shell
 nodeset_cmdline
 nodeset_runimg

--- a/xCAT-test/autotest/bundle/ubuntu14.04.3_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu14.04.3_x86_64.bundle
@@ -183,14 +183,6 @@ xdsh_t
 xdsh_q
 xdsh_T
 xdsh_o
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 nodeset_shell
 nodeset_cmdline
 nodeset_runimg

--- a/xCAT-test/autotest/bundle/ubuntu14.04.4_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu14.04.4_ppc64le.bundle
@@ -207,14 +207,6 @@ prsync_h
 prsync_v
 prsync_dir_node
 prsync_file_node
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 xcatd_start
 xcatd_stop
 xcatd_restart

--- a/xCAT-test/autotest/bundle/ubuntu14.04.4_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu14.04.4_x86_64.bundle
@@ -205,14 +205,6 @@ prsync_h
 prsync_v
 prsync_dir_node
 prsync_file_node
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 nodeset_check_warninginfo
 Full_installation_flat_docker
 rpower_stop_docker

--- a/xCAT-test/autotest/bundle/ubuntu16.04.1_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu16.04.1_ppc64le.bundle
@@ -208,14 +208,6 @@ prsync_h
 prsync_v
 prsync_dir_node
 prsync_file_node
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 xcatd_start
 xcatd_stop
 xcatd_restart

--- a/xCAT-test/autotest/bundle/ubuntu16.04.1_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu16.04.1_x86_64.bundle
@@ -205,14 +205,6 @@ prsync_h
 prsync_v
 prsync_dir_node
 prsync_file_node
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 xcatd_start
 xcatd_stop
 xcatd_restart

--- a/xCAT-test/autotest/bundle/ubuntu16.04_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu16.04_ppc64le.bundle
@@ -183,14 +183,6 @@ xdsh_t
 xdsh_q
 xdsh_T
 xdsh_o
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 xcatd_start
 xcatd_stop
 xcatd_restart

--- a/xCAT-test/autotest/bundle/ubuntu16.04_x86_64.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu16.04_x86_64.bundle
@@ -183,14 +183,6 @@ xdsh_t
 xdsh_q
 xdsh_T
 xdsh_o
-switchdiscover_range_default
-switchdiscover_h
-switchdiscover_range_s
-switchdiscover_range_default_w
-switchdiscover_range_r
-switchdiscover_range_x
-switchdiscover_range_z
-switchdiscover_range_z_V
 nodeset_shell
 nodeset_cmdline
 nodeset_runimg


### PR DESCRIPTION
The PR is to delete all ``switchdiscover`` test cases to resolve switch access attempts  in lab. 

