### PR TITLE
refine xdsh_t case to fix issue #5687

### DIFF
--- a/xCAT-test/autotest/testcase/xdsh/cases0
+++ b/xCAT-test/autotest/testcase/xdsh/cases0
@@ -96,7 +96,7 @@ start:xdsh_t
 label:cn_os_ready,parallel_cmds
 cmd:date +%s > /tmp/start.txt
 check:rc==0
-cmd:xdsh $$CN -t 5 "ssh 1.1.1.1"
+cmd:xdsh $$CN -t 5 "sleep 10"
 check:rc!=0
 check:output=~Error: (\[.*?\]: )?Caught SIGINT - terminating the child processes.
 cmd:date +%s > /tmp/end.txt


### PR DESCRIPTION
### The PR is to fix issue #5687

### The modification include

*  refine test case xdsh_t to avoid ``ssh 1.1.1.1``

### The UT result

```
------START::xdsh_t::Time:Wed Oct 10 03:26:10 2018------

RUN:date +%s > /tmp/start.txt [Wed Oct 10 03:26:10 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xdsh f6u13k15 -t 5 "sleep 10" [Wed Oct 10 03:26:10 2018]
ElapsedTime:6 sec
RETURN rc = 3
OUTPUT:
Error: [f6u13k13]: Caught SIGINT - terminating the child processes.
[f6u13k13]: f6u13k15: Warning: Permanently added 'f6u13k15,10.6.13.15' (ECDSA) to the list of known hosts.

Error: [f6u13k13]:  A return code for the command run on the host f6u13k15 was not received.
CHECK:rc != 0	[Pass]
CHECK:output =~ Error: (\[.*?\]: )?Caught SIGINT - terminating the child processes.	[Pass]

RUN:date +%s > /tmp/end.txt [Wed Oct 10 03:26:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:a=`cat /tmp/start.txt`;b=`cat /tmp/end.txt`;c=$[$b-$a];echo $c [Wed Oct 10 03:26:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
6
CHECK:rc == 0	[Pass]

RUN:rm -f /tmp/start.txt /tmp/end.txt [Wed Oct 10 03:26:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::xdsh_t::Passed::Time:Wed Oct 10 03:26:16 2018 ::Duration::6 sec------
------Total: 1 , Failed: 0------
```