### PR TITLE
fix issue 5596, recover env for case rinv_wrongbmcpasswd

### DIFF
--- a/xCAT-test/autotest/testcase/rinv/cases0
+++ b/xCAT-test/autotest/testcase/rinv/cases0
@@ -154,6 +154,7 @@ check:rc==0
 cmd:rinv $$CN all
 check:rc==1
 check:output=~$$CN: (\[.*?\]: )?Error:.+Invalid username or password|Error: (\[.*?\]: )?ERROR: Incorrect password provided
+cmd:chdef $$CN bmcpassword=
 cmd:cat /tmp/testnode.stanza | chdef -z;rm -rf /tmp/testnode.stanza
 check:rc==0
 end


### PR DESCRIPTION
### The PR is to fix issue _#5596_

### The modification include

_##recover env_
If the ``bmcpassword`` isn't defined in node attribute before the case run, only ``chdef`` the whole node's definition the wrong password will not be changed.
So clear it before ``chdef``.

### The UT result
```
# XCATTEST_CN=f6u13 xcattest -t rinv_wrongbmcpasswd
xCAT automated test started at Wed Oct 10 04:19:55 2018
******************************
To detect current test environment
******************************
Detecting: OS = linux
Detecting: ARCH = Unknown
Detecting: HCP = openbmc
******************************
loading test cases
******************************
To run:
rinv_wrongbmcpasswd
******************************
Start to run test cases
******************************
------START::rinv_wrongbmcpasswd::Time:Wed Oct 10 04:20:13 2018------

RUN:lsdef -l f6u13 -z >/tmp/testnode.stanza [Wed Oct 10 04:20:13 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:chdef f6u13 bmcpassword=test [Wed Oct 10 04:20:13 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:rinv f6u13 all [Wed Oct 10 04:20:14 2018]
ElapsedTime:3 sec
RETURN rc = 1
OUTPUT:
f6u13: [c910f03c17k21]: Error: [401] Invalid username or password
CHECK:rc == 1	[Pass]
CHECK:output =~ f6u13: (\[.*?\]: )?Error:.+Invalid username or password|Error: (\[.*?\]: )?ERROR: Incorrect password provided	[Pass]

RUN:chdef f6u13 bmcpassword= [Wed Oct 10 04:20:17 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.

RUN:cat /tmp/testnode.stanza | chdef -z;rm -rf /tmp/testnode.stanza [Wed Oct 10 04:20:17 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

------END::rinv_wrongbmcpasswd::Passed::Time:Wed Oct 10 04:20:18 2018 ::Duration::5 sec------
------Total: 1 , Failed: 0------
```