### PR TITLE
fix issue 5633, use noempty file to check tftp service

### DIFF
--- a/xCAT-probe/lib/perl/probe_utils.pm
+++ b/xCAT-probe/lib/perl/probe_utils.pm
@@ -375,16 +375,18 @@ sub is_tftp_ready {
     rename("/$test_dir/tftptestt.tmp", "/$test_dir/tftptestt.tmp.old") if (-e "/$test_dir/tftptestt.tmp");
     rename("./tftptestt.tmp", "./tftptestt.tmp.old") if (-e "./tftptestt.tmp");
 
-    system("touch /$test_dir/tftptestt.tmp");
+    system("date > /$test_dir/tftptestt.tmp");
     my $output = `tftp -4 -v $mnip -c get /tftptest/tftptestt.tmp 2>&1`;
-    if ((!$?) && (-e "./tftptestt.tmp")) {
+    if ((!$?) && (-s "./tftptestt.tmp")) {
         unlink("./tftptestt.tmp");
         rename("./tftptestt.tmp.old", "./tftptestt.tmp") if (-e "./tftptestt.tmp.old");
         rename("/$test_dir/tftptestt.tmp.old", "/$test_dir/tftptestt.tmp") if (-e "/$test_dir/tftptestt.tmp.old");
+        system("rm -rf $test_dir");
         return 1;
     } else {
         rename("./tftptestt.tmp.old", "./tftptestt.tmp") if (-e "./tftptestt.tmp.old");
         rename("/$test_dir/tftptestt.tmp.old", "/$test_dir/tftptestt.tmp") if (-e "/$test_dir/tftptestt.tmp.old");
+        system("rm -rf $test_dir");
         return 0;
     }
 }


### PR DESCRIPTION
### The PR is to fix issue _#5633_

### The modification include

_##item1_
Use noempty file to check

### The UT result
```
=================================== SUMMARY ====================================
[MN]: Checking on MN...                                                                                           [ OK ]
    No interface provided by '-i' option, detected site table IP attribute 10.3.17.21, checking xCAT configurat...[WARN]
    If this is incorrect, rerun with -i <ifname> option                                                           [WARN]
[root@c910f03c17k21 ~]# find / -name tftptestt.tmp
[root@c910f03c17k21 ~]# systemctl stop xcatd
[root@c910f03c17k21 ~]# systemctl start tftp
[root@c910f03c17k21 ~]# systemctl start xcatd
[root@c910f03c17k21 ~]# xcatprobe xcatmn
...
[mn]: Checking TFTP service is configured...                                                                      [FAIL]
[mn]: TFTP service based on xCAT is not running
[mn]: TFTP service isn't ready on 10.3.17.21, stop tftp service and start it by restarting xcatd
[mn]: Checking DNS service is configured...                                                                       [ OK ]
[mn]: Checking DHCP service is configured...                                                                      [ OK ]
```