### PR TITLE
enhance rspconfig ntpservers case

### DIFF
--- a/xCAT-test/autotest/testcase/rspconfig/rspconfig_ntp.sh
+++ b/xCAT-test/autotest/testcase/rspconfig/rspconfig_ntp.sh
@@ -3,7 +3,15 @@
 cn=$1
 mn=$2
 
-ntpservers=`rspconfig $cn ntpservers | awk -F":" '{print $3}' | sed 's/^ //;s/ $//'`
+ipsrc=`rspconfig $cn ipsrc | grep "BMC IP Source" | awk -F":" '{print $3}' | sed 's/^ //;s/ $//'`
+if [ $? -ne 0 ]; then
+    echo "rspconfig $cn ipsrc failed"
+    exit 1
+fi
+
+echo "BMC IP Source is $ipsrc"
+
+ntpservers=`rspconfig $cn ntpservers | grep "BMC NTP Servers" | awk -F":" '{print $3}' | sed 's/^ //;s/ $//'`
 if [ $? -ne 0 ]; then
     echo "rspconfig $cn ntpservers failed"
     exit 1
@@ -17,7 +25,23 @@ else
    new_ntpservers=$mn
 fi
 
-output=`rspconfig $cn ntpservers=$new_ntpservers`
+output=`rspconfig $cn ntpservers=$new_ntpservers 2>&1`
+echo "$output"
+if [ $ipsrc == "DHCP" ]; then
+    if [ $? -ne 1 ]; then
+        if [[ "$output" =~ "Error: BMC IP source is DHCP, could not set NTPServers" ]]; then
+            echo "Get correct output for BMC IP source is DHCP"
+            exit 0
+        else
+            echo "Get output '$output' when want to set NTPServers for BMC IP source is DHCP"
+            exit 1
+        fi
+    else
+        echo "Get wrong exit code $? when want to set NTPServers for BMC IP source is DHCP" 
+        exit 1
+    fi
+fi
+
 if [ $? -ne 0 ]; then
     echo "rspconfig $cn ntpservers=$new_ntpservers failed"
     exit 1
@@ -30,6 +54,30 @@ else
     exit 1
 fi
 
+output=`rspconfig $cn ntpservers 2>&1`
+if [[ $output =~ "$cn: BMC NTP Servers" ]]  && [[ $output =~ "$new_ntpservers" ]]; then
+    echo "Checked NTPServers as $new_ntpservers success"
+else
+    echo "Checked NTPServers as $new_ntpservers failed, the output is $output"
+    exit 1
+fi
+
+echo "rpower $cn bmcreboot to check ntpservers setting..."
+rpower $cn bmcreboot
+if [ $? -ne 0 ]; then
+    echo "run rpower $cn bmcreboot failed"
+else
+    sleep 300
+fi
+
+output=`rspconfig $cn ntpservers 2>&1`
+if [[ $output =~ "$cn: BMC NTP Servers" ]]  && [[ $output =~ "$new_ntpservers" ]]; then
+    echo "Verified NTPServers $new_ntpservers after BMC reboot"
+else
+    echo "Verified NTPServers as $ntpservers failed after BMC reboot, output is $output"
+    exit 1
+fi
+
 echo "To clear environment"
 
 if [ $ntpservers != "None" ]; then
@@ -38,16 +86,37 @@ else
     original_ntpservers=""
 fi
 
-output=`rspconfig $cn ntpservers=$original_ntpservers`
+output=`rspconfig $cn ntpservers=$original_ntpservers 2>&1`
 if [ $? -ne 0 ]; then
     echo "rspconfig $cn ntpservers=$ntpservers failed when clearing environment"
     exit 1
 fi
-
 if [[ "$output" =~ "$cn: BMC NTP Servers" ]] && [[ $output =~ "$ntpservers" ]]; then
     echo "Setting NTPServers as $ntpservers success when clearing environment"
+fi
+
+output=`rspconfig $cn ntpservers 2>&1`
+if [[ "$output" =~ "$cn: BMC NTP Servers" ]] && [[ $output =~ "$ntpservers" ]]; then
+    echo "Checked NTPServers as $ntpservers success when clearing environment" 
+else
+    echo "Checked NTPServers as $ntpservers failed when clearing environment output is $output"
+    exit 1
+fi
+
+echo "rpower $cn bmcreboot to recover environment"
+rpower $cn bmcreboot
+if [ $? -ne 0 ]; then
+    echo "run rpower $cn bmcreboot failed when recover environment"
+    exit 1
+else
+    sleep 300
+fi
+
+output=`rspconfig $cn ntpservers 2>&1`
+if [[ "$output" =~ "$cn: BMC NTP Servers" ]] && [[ $output =~ "$ntpservers" ]]; then
+    echo "Verified NTPServers as $ntpservers success when clearing environment after BMC reboot"
     exit 0
 fi
 
-echo "Setting NTPServers as $ntpservers failed when clearing environment"
+echo "Verified NTPServers as $ntpservers failed when clearing environment after BMC reboot, output is $output"
 exit 1


### PR DESCRIPTION
### The PR is to fix issue _#5540_

### The modification include

_##Enhance rspconfig set ntpservers case_

The script is called in ``../autotest/testcase/rspconfig/cases0``.

```
start:rspconfig_set_ntpservers
description: rspconfig set ntpservers
Attribute: $$CN-The operation object of rspconfig command
label:cn_bmc_ready,hctrl_openbmc
cmd:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig_ntp.sh $$CN $$MN
check:rc==0
end
```

### The UT result
* IP source is static
```
# XCATTEST_MN=briggs01 XCATTEST_CN=mid05tor12cn05 xcattest -t rspconfig_set_ntpservers
xCAT automated test started at Wed Oct 10 03:35:21 2018
******************************
To detect current test environment
******************************
Detecting: OS = linux
Detecting: ARCH = ppc64le
Detecting: HCP = openbmc
******************************
loading test cases
******************************
To run:
rspconfig_set_ntpservers
******************************
Start to run test cases
******************************
------START::rspconfig_set_ntpservers::Time:Wed Oct 10 03:35:23 2018------

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig_ntp.sh mid05tor12cn05 briggs01 [Wed Oct 10 03:35:23 2018]
ElapsedTime:649 sec
RETURN rc = 0
OUTPUT:
BMC IP Source is Static
The original BMC NTP Servers is None
mid05tor12cn05: BMC NTP Servers: briggs01
mid05tor12cn05: Warning: time will not be synchronized until the host is powered off.
Setting NTPServers as briggs01 success
rpower mid05tor12cn05 bmcreboot to check ntpservers setting...
mid05tor12cn05: BMC reboot
Setting NTPServers as briggs01 success
To clear environment
Setting NTPServers as None success when clearing environment
rpower mid05tor12cn05 bmcreboot to recover environment
mid05tor12cn05: BMC reboot
Setting NTPServers as None success when clearing environment after bmc reboot
CHECK:rc == 0	[Pass]

------END::rspconfig_set_ntpservers::Passed::Time:Wed Oct 10 03:46:12 2018 ::Duration::649 sec------
------Total: 1 , Failed: 0------
```

* IP source is DHCP
```
# XCATTEST_MN=c910f03c17k21 XCATTEST_CN=f6u13 xcattest -t rspconfig_set_ntpservers
xCAT automated test started at Wed Oct 10 04:50:02 2018
******************************
To detect current test environment
******************************
Detecting: OS = linux
Detecting: ARCH = Unknown
Detecting: HCP = openbmc
******************************
loading test cases
******************************
To run:
rspconfig_set_ntpservers
******************************
Start to run test cases
******************************
------START::rspconfig_set_ntpservers::Time:Wed Oct 10 04:50:19 2018------

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/rspconfig/rspconfig_ntp.sh f6u13 c910f03c17k21 [Wed Oct 10 04:50:19 2018]
ElapsedTime:4 sec
RETURN rc = 0
OUTPUT:
BMC IP Source is DHCP
The original BMC NTP Servers is None
f6u13: [c910f03c17k21]: Error: BMC IP source is DHCP, could not set NTPServers
Get correct output for BMC IP source is DHCP
CHECK:rc == 0	[Pass]

------END::rspconfig_set_ntpservers::Passed::Time:Wed Oct 10 04:50:23 2018 ::Duration::4 sec------
------Total: 1 , Failed: 0------
```