### PR TITLE
Enhance osdeploy for issue 5488

### DIFF
--- a/xCAT-probe/lib/perl/LogParse.pm
+++ b/xCAT-probe/lib/perl/LogParse.pm
@@ -126,10 +126,15 @@ sub obtain_log_file_list {
     my $self = shift;
     my %candidate_log;
 
+    my @loglist = ("/var/log/messages",
+                   "/var/log/xcat/cluster.log",
+                   "/var/log/xcat/computes.log",
+                   "/var/log/syslog");
+
     my @candidate_log_set;
-    push @candidate_log_set, "/var/log/messages" if (-e "/var/log/messages");
-    push @candidate_log_set, "/var/log/xcat/cluster.log" if (-e "/var/log/xcat/cluster.log");
-    push @candidate_log_set, "/var/log/xcat/computes.log" if (-e "/var/log/xcat/computes.log");
+    foreach my $log (@loglist){
+        push @candidate_log_set, $log if (-e "$log");
+    }
 
     my $filename;
     foreach my $log (@candidate_log_set) {


### PR DESCRIPTION
### The PR is to fix issue #5488

### The modification include

* Add ``/var/log/syslog`` into the filter scope of ``osdeploy``.

### The UT result

* under ubuntu 18.04.1

```
root@f6u13k14:# xcatprobe  osdeploy -n f6u13k14
The install NIC in current server is enp0s1                                                                       [INFO]
All nodes to be deployed are valid                                                                                [ OK ]
-------------------------------------------------------------
Start capturing every message during OS provision process....
-------------------------------------------------------------

[f6u13k14] 00:26:59 Use command rinstall to reboot node f6u13k14
[f6u13k14] 00:27:00 Node status is changed to powering-on
[f6u13k14] 00:27:00 Node status is changed to powering-on
[f6u13k14] 00:27:03 Receive DHCPDISCOVER via enp0s1
[f6u13k14] 00:27:03 Send DHCPOFFER on 10.6.13.14 back to 42:37:0a:06:0d:0e via enp0s1
[f6u13k14] 00:27:03 DHCPREQUEST for 10.6.13.14 (10.6.13.13) from 42:37:0a:06:0d:0e via enp0s1
.....
[f6u13k14] 00:31:35 provision completed                                                                           [ OK ]
All nodes specified to monitor, have finished OS provision process                                                [ OK ]
======================  Summary  =====================
All nodes provisioned successfully                                                                                [ OK ]
```

* under rhels7.6
```
[root@c910f03c17k25 subcmds]# ./osdeploy -n c910f03c17k08
[info]   :The install NIC in current server is eth1
[ok]     :All nodes to be deployed are valid
-------------------------------------------------------------
Start capturing every message during OS provision process....
-------------------------------------------------------------

[debug]  :[c910f03c17k08] 00:23:47 Use command rinstall to reboot node c910f03c17k08
[debug]  :[c910f03c17k08] 00:24:14 Use command rinstall to reboot node c910f03c17k08
[debug]  :[c910f03c17k08] 00:24:19 Node status is changed to powering-on
[debug]  :[c910f03c17k08] 00:24:19 Node status is changed to powering-on
[debug]  :[c910f03c17k08] 00:24:24 Receive DHCPDISCOVER via eth1
[debug]  :[c910f03c17k08] 00:24:24 Send DHCPOFFER on 10.3.17.8 back to 42:29:0a:03:11:08 via eth1
[debug]  :[c910f03c17k08] 00:24:24 DHCPREQUEST for 10.3.17.8 (10.3.17.25) from 42:29:0a:03:11:08 via eth1
[debug]  :[c910f03c17k08] 00:24:24 Send DHCPACK on 10.3.17.8 back to 42:29:0a:03:11:08 via eth1
.........
[ok]     :All nodes specified to monitor, have finished OS provision process
======================  Summary  =====================
[ok]     :All nodes provisioned successfully
```