### PR TITLE
Using port 22 for unprivileged node ping 

### DIFF
--- a/xCAT-client/bin/pping
+++ b/xCAT-client/bin/pping
@@ -199,9 +199,10 @@ sub nmap_pping {
         @nmap_options = xCAT::TableUtils->get_site_attribute("nmapoptions");
         $more_options = $nmap_options[0];
     }
-    open(FPING, "nmap -PE --system-dns --unprivileged --send-ip -sP $more_options " . join(' ', @$nodes) . " 2> /dev/null|") or die("Cannot open nmap pipe: $!");
+    # Added port 22 for unprivileged case (#4324)
+    open(NMAP, "nmap -PE --system-dns --send-ip -sP --unprivileged -PA80,443,22 $more_options " . join(' ', @$nodes) . " 2> /dev/null|") or die("Cannot open nmap pipe: $!");
     my $node;
-    while (<FPING>) {
+    while (<NMAP>) {
         if (/Host (.*) \(.*\) appears to be up/) {
             $node = $1;
             unless ($deadnodes{$node}) {

--- a/xCAT-server/lib/xcat/plugins/nodestat.pm
+++ b/xCAT-server/lib/xcat/plugins/nodestat.pm
@@ -658,7 +658,7 @@ sub process_request_nmap {
         if ($ip6 and scalar(@ip6s)) {
             open($fping, "nmap --unprivileged -6 -PS$ports,3001 -n --send-ip -p $ports,3001 $more_options " . join(' ', @ip6s) . " 2> /dev/null|") or die("Can't start nmap: $!");
         } elsif (not $ip6 and scalar(@ips)) {
-            open($fping, "nmap --unprivileged -PE -n --send-ip -p $ports,3001 $more_options " . join(' ', @ips) . " 2> /dev/null|") or die("Can't start nmap: $!");
+            open($fping, "nmap --unprivileged -PA80,443,22 -PE -n --send-ip -p $ports,3001 $more_options " . join(' ', @ips) . " 2> /dev/null|") or die("Can't start nmap: $!");
         } else { next; }
         while (<$fping>) {
             if (/Interesting ports on ([^ ]*)[: ]/ or /Nmap scan report for ([^ ]*)/) {


### PR DESCRIPTION
### The PR is to fix issue #4324

### The modification include

when doing pping,  we will force to use port 22 for unprivileged node ping (TCP only), it could work when the node is under firewall as 22 is normally opened by firewall.

Note:  default is 80/443


### The UT result
1, start firewalld on sn02
`xdsh sn02 systemctl start firewalld`

Before apply the patch:
```
[root@boston02 ~]# pping sn02
sn02: noping
```
After apply the patch:
```
[root@boston02 xcat]# pping sn02
sn02: ping
[root@boston02 xcat]#nodestat sn02
sn02: sshd
```

