### PR TITLE
fix ramdisk based statelite failed in rhels7.6-alternate-ppc64le beta

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
@@ -201,7 +201,7 @@ elif [ -r /rootimg-statelite.gz ]; then
         MAXTRIES=5
         ITER=0
         if [ -z $MNTOPTS ]; then
-            MNT_OPTIONS="nolock,rsize=32768,tcp,nfsvers=3,timeo=14"
+            MNT_OPTIONS="nolock,rsize=32768,tcp,timeo=14"
         else
             MNT_OPTIONS=$MNTOPTS
         fi

--- a/xCAT-server/share/xcat/netboot/rh/dracut_047/xcat-prepivot.sh
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_047/xcat-prepivot.sh
@@ -53,7 +53,7 @@ if [ ! -z $SNAPSHOTSERVER ]; then
     MAXTRIES=5
     ITER=0
     if [ -z $MNTOPTS ]; then
-        MNT_OPTIONS="nolock,rsize=32768,tcp,nfsvers=3,timeo=14"
+        MNT_OPTIONS="nolock,rsize=32768,tcp,timeo=14"
     else
         MNT_OPTIONS=$MNTOPTS
     fi

--- a/xCAT-server/share/xcat/netboot/rh/dracut_047/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_047/xcatroot
@@ -202,7 +202,7 @@ elif [ -r /rootimg-statelite.gz ]; then
         MAXTRIES=5
         ITER=0
         if [ -z $MNTOPTS ]; then
-            MNT_OPTIONS="nolock,rsize=32768,tcp,nfsvers=3,timeo=14"
+            MNT_OPTIONS="nolock,rsize=32768,tcp,timeo=14"
         else
             MNT_OPTIONS=$MNTOPTS
         fi


### PR DESCRIPTION
### The PR is to fix issue _#xxx_
fix #5581 
### The modification include
delete nfsvers=3 for rh statelite

### The UT result
Provision statelite rh7.6-alternate-ppc64le
```
 ~]# rcons f6u13k18
 ~]# df -h
Filesystem                   Size  Used Avail Use% Mounted on
tmpfs                        2.0G   22M  2.0G   2% /run
rootfs                       2.0G  1.4G  625M  70% /
rw                           2.0G   94M  1.9G   5% /var
f6u13k16:/nodedata/f6u13k18   35G   14G   20G  40% /.statelite/persistent
rw                           2.0G   64K  2.0G   1% /.sllocal/log
devtmpfs                     2.0G     0  2.0G   0% /dev
tmpfs                        2.0G     0  2.0G   0% /dev/shm
tmpfs                        2.0G     0  2.0G   0% /sys/fs/cgroup
tmpfs                        407M     0  407M   0% /run/user/0

... ...

]# lsdef f6u13k18 -i status
Object name: f6u13k18
    status=booted
```
