### PR TITLE
Add wget package to rhels8 pkglist

### DIFF
--- a/xCAT-server/share/xcat/install/rh/compute.rhels8.pkglist
+++ b/xCAT-server/share/xcat/install/rh/compute.rhels8.pkglist
@@ -5,3 +5,4 @@ nfs-utils
 openssh-server
 rsync
 util-linux
+wget

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels8.ppc64le.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels8.ppc64le.pkglist
@@ -31,3 +31,4 @@ tar
 util-linux
 vim-minimal
 xz
+wget

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels8.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels8.x86_64.pkglist
@@ -29,3 +29,4 @@ tar
 util-linux
 vim-minimal
 xz
+wget


### PR DESCRIPTION
For issue #5707 

The rhels8 base iso ` RHEL-8.0-20180531.2-BaseOS-ppc64le-dvd1.iso` doesn't contain the `wget`  package,  diskfull installation will failed and diskless node can provision but failed to download the postscripts.

For rhels8 `RHEL-8.0-20180920.2-ppc64le-dvd1.iso`, it contains `wget` package,  adding `wget` to rhels8 pkglist:
diskfull:  The node able to provision, but network is not started (another issue, debug later)
````
[root@localhost ~]# ifconfig
lo: flags=73<UP,LOOPBACK,RUNNING>  mtu 65536
        inet 127.0.0.1  netmask 255.0.0.0
        inet6 ::1  prefixlen 128  scopeid 0x10<host>
        loop  txqueuelen 1000  (Local Loopback)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
````

diskless:  node provisioned,   ip address signed,  postscripts download, but mypostscripts didn't get run
````
]# cat /var/log/xcat/xcat.log
Mon Oct 15 13:21:49 EDT 2018 [debug]: xcat.xcatdsklspost: Running /opt/xcat/xcatdsklspost
Mon Oct 15 13:21:49 EDT 2018 [info]: xcat.xcatdsklspost: trying to download postscripts...
Mon Oct 15 13:21:49 EDT 2018 [debug]: xcat.xcatdsklspost: trying to download postscripts from http://172.20.253.31/install/postscripts/
Mon Oct 15 13:21:49 EDT 2018 [debug]: xcat.xcatdsklspost: postscripts are downloaded from 172.20.253.31 successfully.
Mon Oct 15 13:21:49 EDT 2018 [info]: xcat.xcatdsklspost: postscripts downloaded successfully
Mon Oct 15 13:21:49 EDT 2018 [info]: xcat.xcatdsklspost: trying to get mypostscript from 172.20.253.31...
````

we have other issues for rhels8 image, but adding `wget` package will help provision the nodes.

