### PR TITLE
Handle the wrong table name when using tabch

### DIFF
--- a/xCAT-server/lib/xcat/plugins/tabutils.pm
+++ b/xCAT-server/lib/xcat/plugins/tabutils.pm
@@ -2297,6 +2297,7 @@ sub tabch {
                 my %rsp;
                 $rsp{data}->[0] = "Incorrect argument \"$_\".\n";
                 $rsp{data}->[1] = "Check man tabch or tabch -h\n";
+                $rsp{errorcode}->[0] = 1;
                 $callback->(\%rsp);
                 return 1;
             }
@@ -2318,14 +2319,23 @@ sub tabch {
             my %rsp;
             $rsp{data}->[0] = "Missing table name.\n";
             $rsp{data}->[1] = "Check man tabch or tabch -h\n";
+            $rsp{errorcode}->[0] = 1;
             $callback->(\%rsp);
             return 1;
         }
+
         for (@tables_to_del)
         {
-            $tables{$_} = xCAT::Table->new($_, -create => 1, -autocommit => 0);
-            $tables{$_}->delEntries(\%keyhash);
-            $tables{$_}->commit;
+            my $tab = xCAT::Table->new($_, -create => 1, -autocommit => 0);
+            unless ($tab) {
+            my %rsp;
+                $rsp{data}->[0] = "Table $_ does not exist.";
+                $rsp{errorcode}->[0] = 1;
+                $callback->(\%rsp);
+                next;
+            }
+            $tab->delEntries(\%keyhash);
+            $tab->commit;
         }
     }
     else {
@@ -2347,6 +2357,7 @@ sub tabch {
                 } else {
                     my %rsp;
                     $rsp{data}->[0] = "Table $table does not exist.\n";
+                    $rsp{errorcode}->[0] = 1;
                     $callback->(\%rsp);
                     return 1;
 
@@ -2386,7 +2397,7 @@ sub tabch {
             }
             unless (grep /$column/, @{ $xCAT::Schema::tabspec{$table}->{cols} }) {
                 $callback->({ error => "$table.$column not a valid table.column description", errorcode => [1] });
-                return;
+                return 1;
             }
             $tableupdates{$table}{$column} = $value;
         }

--- a/xCAT-test/autotest/testcase/chtab/cases0
+++ b/xCAT-test/autotest/testcase/chtab/cases0
@@ -62,6 +62,18 @@ check:output=~Usage
 end
 
 
+start:chtab_nonexist_table
+description:chtab with nonexisting table name
+label:mn_only,db
+cmd:tabch -d key=abc123 nonexist_table1 nonexist_table2
+check:rc!=0
+check:output=~Table nonexist_table1 does not exist
+check:output=~Table nonexist_table2 does not exist
+cmd:tabch key=abc123 nonexist_table1.comments="mg"
+check:rc!=0
+check:output=~Table nonexist_table1 does not exist
+end
+
 start:chtab_err_table
 description:chtab with error table
 label:mn_only,db


### PR DESCRIPTION
### The PR is to fix issue #5151 

### The modification include
- when user input wrong table name, report the error message. As a compatible, still using data to report the error message
- but set exit code as non-zero

### The UT result
```
tabch -d key=abc123 abc dfd
Table abc does not exist.
Table dfd does not exist.
[root@c910f03c05k30 xcat]# echo $?
1
```
```
tabch key=abc123 sites.comments="mg"
Table sites does not exist.

[root@c910f03c05k30 xcat]# echo $?
1
```
