### PR TITLE
fix enablekdump for redhat7.6 and 7.6-alt nfs vers 4 support

### DIFF
--- a/xCAT/postscripts/enablekdump
+++ b/xCAT/postscripts/enablekdump
@@ -229,11 +229,13 @@ EOF
                            break
                        fi
                    done
-               fi
-               if [ $nfsver -ne 0 ]; then
-                   /bin/mount -o vers=$nfsver $KDIP:$KDPATH $MOUNTPATH
+                   if [ $nfsver -ne 0 ]; then
+                       /bin/mount -o vers=$nfsver $KDIP:$KDPATH $MOUNTPATH
+                   else
+                       /bin/mount -o nolock $KDIP:$KDPATH $MOUNTPATH
+                   fi
                else
-                   /bin/mount -o nolock $KDIP:$KDPATH $MOUNTPATH
+                   /bin/echo "nfs server is not available"
                fi
                [ -d $MOUNTPATH/var/crash ] || mkdir -p $MOUNTPATH/var/crash
 

--- a/xCAT/postscripts/enablekdump
+++ b/xCAT/postscripts/enablekdump
@@ -216,8 +216,12 @@ EOF
             fi
 	else
             if (pmatch $OSVER "rhel7*") || (pmatch $OSVER "rhels7*");then
-               /bin/mount -o vers=3 $KDIP:$KDPATH $MOUNTPATH
-               #/bin/mount -o nolock $KDIP:$KDPATH $MOUNTPATH
+               nfsvers=$(/usr/sbin/rpcinfo -p $KDIP|grep -w nfs|awk '{print $2}'|head -1)
+               if [ -n "$nfsvers" ]; then
+                   /bin/mount -o vers=$nfsvers $KDIP:$KDPATH $MOUNTPATH
+               else
+                   /bin/mount -o nolock $KDIP:$KDPATH $MOUNTPATH
+               fi
                [ -d $MOUNTPATH/var/crash ] || mkdir -p $MOUNTPATH/var/crash
 
                #The initramfs used in kdump does not need "root", however, the initramfs refused to continue

--- a/xCAT/postscripts/enablekdump
+++ b/xCAT/postscripts/enablekdump
@@ -216,9 +216,22 @@ EOF
             fi
 	else
             if (pmatch $OSVER "rhel7*") || (pmatch $OSVER "rhels7*");then
-               nfsvers=$(/usr/sbin/rpcinfo -p $KDIP|grep -w nfs|awk '{print $2}'|head -1)
+               nfsvers=$(/usr/sbin/rpcinfo -p $KDIP|grep -w nfs|awk /tcp/'{print $2}'|sort)
+               nfsver=0
                if [ -n "$nfsvers" ]; then
-                   /bin/mount -o vers=$nfsvers $KDIP:$KDPATH $MOUNTPATH
+                   for i in $nfsvers
+                   do
+                       if [ $i -eq 3 ] && ! [ grep -w nfs /proc/filesystems >/dev/null 2>&1 ]; then
+                           nfsver=3
+                           break
+                       elif [ $i -eq 4 ] && ! [ grep -w nfs4 /proc/filesystems >/dev/null 2>&1 ]; then
+                           nfsver=4
+                           break
+                       fi
+                   done
+               fi
+               if [ $nfsver -ne 0 ]; then
+                   /bin/mount -o vers=$nfsver $KDIP:$KDPATH $MOUNTPATH
                else
                    /bin/mount -o nolock $KDIP:$KDPATH $MOUNTPATH
                fi


### PR DESCRIPTION
### The PR is to fix issue 

https://github.com/xcat2/xcat-core/issues/5712

### The modification include

nfs vers in redhat7.6 and 7.6-alt is 4, enablekdump hard code `mount -o vers=3 ...`, this cause error like:
```
[root@f5u14 ~]# /bin/mount -o vers=3 10.6.13.10:/kdumpdir /root/bai
mount.nfs: requested NFS version or transport protocol is not supported
```

### The UT result
After this fix, UT:
```
[root@f6u13k10 postscripts]# updatenode f5u14 -P enablekdump
f5u14: trying to download postscripts...
f5u14: postscripts downloaded successfully
f5u14: trying to get mypostscript from 10.6.13.10...
f5u14: Running postscript: enablekdump
f5u14: ++ /usr/sbin/rpcinfo -p f6u13k10
f5u14: ++ grep -w nfs
f5u14: ++ awk '/tcp/{print $2}'
f5u14: ++ sort
f5u14: + nfsvers=4
f5u14: + nfsver=0
f5u14: + '[' -n 4 ']'
f5u14: + for i in '$nfsvers'
f5u14: + '[' 4 -eq 3 ']'
f5u14: + '[' 4 -eq 4 ']'
f5u14: + '[' grep -w nfs4 /proc/filesystems ']'
f5u14: + nfsver=4
f5u14: + break
f5u14: + '[' 4 -ne 0 ']'
f5u14: + /bin/mount -o vers=4 f6u13k10:/kdumpdir /mnt
f5u14: + set +x
f5u14: postscript: enablekdump exited with code 0
f5u14: Running of postscripts has completed.

```