### PR TITLE
Update some outdated test cases

### DIFF
--- a/xCAT-test/autotest/testcase/UT_openbmc/reventlog_resolved_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/reventlog_resolved_cases0
@@ -25,7 +25,7 @@ hcp:openbmc
 label:cn_bmc_ready,hctrl_openbmc
 cmd:reventlog $$CN resolved 1,2,3
 check:rc==1
-check:output=~Error: (\[.*?\]: )?Usage error. Provide a comma separated
+check:output=~Error: (\[.*?\]: )?Only one option is supported at the same time for reventlog
 end
 
 start:reventlog_resolved_parse_error4
@@ -35,7 +35,7 @@ hcp:openbmc
 label:cn_bmc_ready,hctrl_openbmc
 cmd:reventlog $$CN resolved=-1
 check:rc==1
-check:output=~Error: (\[.*?\]: )?Invalid ID=
+check:output=~Error: (\[.*?\]: )?Invalid ID:
 end
 
 start:reventlog_resolved_parse_error5
@@ -45,7 +45,7 @@ hcp:openbmc
 label:cn_bmc_ready,hctrl_openbmc
 cmd:reventlog $$CN resolved=abc
 check:rc==1
-check:output=~Error: (\[.*?\]: )?Invalid ID=
+check:output=~Error: (\[.*?\]: )?Invalid ID:
 end
 
 start:reventlog_resolved_list
@@ -54,7 +54,7 @@ os:Linux
 hcp:openbmc
 label:cn_bmc_ready,hctrl_openbmc
 cmd:reventlog $$CN resolved=100,101
-check:rc==0
+check:rc==1
 check:output=~Attempting to resolve the following log entries: 100,101...
 end
 
@@ -64,6 +64,6 @@ os:Linux
 hcp:openbmc
 label:cn_bmc_ready,hctrl_openbmc
 cmd:reventlog $$CN resolved=Led
-check:rc==0
+check:rc==1
 check:output=~Attempting to resolve the following log entries: Led...
 end

--- a/xCAT-test/autotest/testcase/UT_openbmc/rspconfig_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rspconfig_cases0
@@ -50,7 +50,7 @@ check:output=~$$CN: BMC Hostname:
 # Set to witherspoon first
 cmd:rspconfig $$CN hostname=witherspoon
 check:rc==0
-check:output=~$$CN: BMC Setting Hostname...
+check:output=~$$CN: BMC Setting BMC Hostname...
 # Check that it's set to witherspoon
 cmd:rspconfig $$CN hostname
 check:rc==0
@@ -58,7 +58,7 @@ check:output=~$$CN: BMC Hostname: witherspoon
 # Set to <host>-UTset
 cmd:rspconfig $$CN hostname=$$CN-UTset
 check:rc==0
-check:output=~$$CN: BMC Setting Hostname...
+check:output=~$$CN: BMC Setting BMC Hostname...
 # Check that it's set
 cmd:rspconfig $$CN hostname
 check:rc==0
@@ -66,7 +66,7 @@ check:output=~$$CN: BMC Hostname: $$CN-UTset
 # Restore to saved version
 cmd:grep BMC /tmp/xcattest.rspconfig.hostname  | cut -d' ' -f4 | xargs -i{} rspconfig $$CN hostname={}
 check:rc==0
-check:output=~$$CN: BMC Setting Hostname...
+check:output=~$$CN: BMC Setting BMC Hostname...
 cmd:rspconfig $$CN hostname
 check:rc==0
 check:output=~$$CN: BMC Hostname:

--- a/xCAT-test/autotest/testcase/installation/setup_vm
+++ b/xCAT-test/autotest/testcase/installation/setup_vm
@@ -1,20 +1,29 @@
 start:setup_vm
-description:set up vm environment
-cmd:var=`expr substr "__GETNODEATTR($$CN,vmstorage)__" 1 3`;echo $var;if [ "__GETNODEATTR($$CN,arch)__" != "ppc64"  -a  "__GETNODEATTR($$CN,mgt)__" != "ipmi" -a "__GETNODEATTR($$CN,mgt)__" != "openbmc" ];then rmvm $$CN -f -p;if [[ "$var" = "phy" ]]; then mkvm $$CN;exit $? ; elif  [[ "$var" = "dir" ]];then mkvm $$CN ; rmvm $$CN -f -p ; mkvm $$CN -s 20G ;exit $? ;elif [ "$var" = "nfs" -o "$var" = "lvm" ];then echo  "Need to fix me. ";exit 2;else echo "Could not surpport vmstorage.";exit 3;fi;fi
+description:reset up vm environment if need 
+label:others
+cmd:if [ "__GETNODEATTR($$CN,arch)__" != "ppc64"  -a  "__GETNODEATTR($$CN,mgt)__" != "ipmi" -a "__GETNODEATTR($$CN,mgt)__" != "openbmc" ];then echo "CN node $$CN is a vm which mgt is __GETNODEATTR($$CN,mgt)__, start to recreate the vm now"; echo "rmvm $$CN -f -p";rpower $$CN off; sleep 3; rmvm $$CN -f -p; var=`expr substr "__GETNODEATTR($$CN,vmstorage)__" 1 3`; echo "The disk create way of $$CN is $var"; if [ "$var" = "phy" ]; then echo "mkvm $$CN"; mkvm $$CN; exit $?; elif [ "$var" = "dir" ]; then echo "mkvm $$CN -s 20G"; mkvm $$CN -s 20G; exit $?; elif ["$var" = "nfs" -o "$var" = "lvm" ];then echo  "Need to fix me"; exit 2; else echo "unsupported disk creation way"; exit 3;fi;else echo "CN node $$CN is a non-VM; do not need to recreate it";fi 
 check:rc==0
-cmd:rpower $$CN on
+
+cmd:if [ "__GETNODEATTR($$CN,arch)__" != "ppc64"  -a  "__GETNODEATTR($$CN,mgt)__" != "ipmi" -a  "__GETNODEATTR($$CN,mgt)__" != "openbmc" ]; then echo "CN node is a vm, need to repower it on"; echo "rpower $$CN on"; rpower $$CN on; else echo "CN node $$CN is a non-VM; do not need to repower on it"; fi
 check:rc==0
+
 cmd:rpower $$CN stat
 check:output=~on
-cmd:var=`expr substr "__GETNODEATTR($$SN,vmstorage)__" 1 3`;echo $var;if [ "__GETNODEATTR($$SN,arch)__" != "ppc64"  -a  "__GETNODEATTR($$SN,mgt)__" != "ipmi" -a  "__GETNODEATTR($$CN,mgt)__" != "openbmc" ];then rmvm $$SN -f -p;if [[ "$var" = "phy" ]]; then mkvm $$SN;exit $? ; elif  [[ "$var" = "dir" ]];then mkvm $$SN ; rmvm $$SN -f -p ; mkvm $$SN -s 20G ;exit $? ;elif [ "$var" = "nfs" -o "$var" = "lvm" ];then echo  "Need to fix me. ";exit 2;else echo "Could not surpport vmstorage.";exit 3;fi;fi
+
+cmd:if [ "__GETNODEATTR($$CN,arch)__" != "ppc64" -a  "__GETNODEATTR($$CN,mgt)__" != "ipmi" -a "__GETNODEATTR($$CN,mgt)__" != "openbmc" ]; then tabdump -w node==$$CN kvm_nodedata; fi
 check:rc==0
-cmd:rpower $$SN on
+
+cmd:if [ "__GETNODEATTR($$SN,arch)__" != "ppc64"  -a  "__GETNODEATTR($$SN,mgt)__" != "ipmi" -a "__GETNODEATTR($$SN,mgt)__" != "openbmc" ];then echo "SN node $$SN is a vm which mgt is __GETNODEATTR($$SN,mgt)__, start to recreate the vm now"; echo "rmvm $$SN -f -p"; rpower $$SN off; sleep 3; rmvm $$SN -f -p; var=`expr substr "__GETNODEATTR($$SN,vmstorage)__" 1 3`; echo "The disk create way of $$SN is $var"; if [ "$var" = "phy" ]; then echo "mkvm $$SN"; mkvm $$SN; exit $?; elif [ "$var" = "dir" ]; then echo "mkvm $$SN -s 20G"; mkvm $$SN -s 20G; exit $?; elif ["$var" = "nfs" -o "$var" = "lvm" ];then echo  "Need to fix me"; exit 2; else echo "unsupported disk creation way"; exit 3;fi;else echo "SN node $$SN is a non-VM; do not need to recreate it";fi 
 check:rc==0
+
+
+cmd:if [ "__GETNODEATTR($$SN,arch)__" != "ppc64"  -a  "__GETNODEATTR($$SN,mgt)__" != "ipmi" -a  "__GETNODEATTR($$SN,mgt)__" != "openbmc" ];then echo "SN node $$SN is a VM, need to rpower it on"; echo "rpower $$SN on"; rpower $$SN on; fi
+check:rc==0
+
 cmd:rpower $$SN stat
 check:output=~on
-#Add for debug rmvm issue
-cmd:if [ "__GETNODEATTR($$CN,arch)__" != "ppc64" -a  "__GETNODEATTR($$CN,mgt)__" != "ipmi" ]; then tabdump -w node==$$CN kvm_nodedata; fi
+
 check:rc==0
-cmd:if [ "__GETNODEATTR($$SN,arch)__" != "ppc64" -a  "__GETNODEATTR($$SN,mgt)__" != "ipmi" ]; then tabdump -w node==$$SN kvm_nodedata; fi
+cmd:if [ "__GETNODEATTR($$SN,arch)__" != "ppc64" -a  "__GETNODEATTR($$SN,mgt)__" != "ipmi" -a "__GETNODEATTR($$SN,mgt)__" != "openbmc" ]; then tabdump -w node==$$SN kvm_nodedata; fi
 check:rc==0
 end

--- a/xCAT-test/autotest/testcase/rspconfig/cases1
+++ b/xCAT-test/autotest/testcase/rspconfig/cases1
@@ -4,7 +4,7 @@ os:Linux
 hcp:openbmc
 label:cn_bmc_ready,hctrl_openbmc
 cmd:rspconfig $$CN ipsrc
-check:output=~$$CN\s*:\s*BMC IP Source: Static|BMC IP Source: Dynamic
+check:output=~$$CN\s*:\s*BMC IP Source: Static|BMC IP Source: DHCP 
 check:rc == 0
 cmd:rspconfig $$CN  hostname sshcfg
 check:output =~Error: (\[.*?\]: )?Configure sshcfg must be issued without other options.


### PR DESCRIPTION
### The PR is to update some outdated test cases and refine setup_vm cases

* The output of some command have been changed, so need to update the test case at same time. 
```
reventlog_resolved_LED
reventlog_resolved_list
reventlog_resolved_parse_error3
reventlog_resolved_parse_error4
reventlog_resolved_parse_error5
rspconfig_get_and_set_hostname
rspconfig_ipsrc
```
The UT are:

```
------START::reventlog_resolved_LED::Time:Wed Oct 17 23:27:49 2018------

RUN:reventlog f5u14 resolved=Led [Wed Oct 17 23:27:49 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
f5u14: [f6u13k10]: Error: No event log entries needed to be resolved
Attempting to resolve the following log entries: Led...
Install the OpenBMC RAS package to obtain more details logging messages.
CHECK:rc == 1	[Pass]
CHECK:output =~ Attempting to resolve the following log entries: Led...	[Pass]

------END::reventlog_resolved_LED::Passed::Time:Wed Oct 17 23:27:50 2018 ::Duration::1 sec------
------START::reventlog_resolved_list::Time:Wed Oct 17 23:27:50 2018------

RUN:reventlog f5u14 resolved=100,101 [Wed Oct 17 23:27:50 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
f5u14: [f6u13k10]: Error: Invalid ID: 100
f5u14: [f6u13k10]: Error: Invalid ID: 101
f5u14: [f6u13k10]: Error: No event log entries needed to be resolved
Attempting to resolve the following log entries: 100,101...
Install the OpenBMC RAS package to obtain more details logging messages.
CHECK:rc == 1	[Pass]
CHECK:output =~ Attempting to resolve the following log entries: 100,101...	[Pass]

------END::reventlog_resolved_list::Passed::Time:Wed Oct 17 23:27:51 2018 ::Duration::1 sec------
------START::reventlog_resolved_parse_error3::Time:Wed Oct 17 23:27:51 2018------

RUN:reventlog f5u14 resolved 1,2,3 [Wed Oct 17 23:27:51 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
f5u14: Error: Only one option is supported at the same time for reventlog
CHECK:rc == 1	[Pass]
CHECK:output =~ Error: (\[.*?\]: )?Only one option is supported at the same time for reventlog	[Pass]

------END::reventlog_resolved_parse_error3::Passed::Time:Wed Oct 17 23:27:52 2018 ::Duration::1 sec------
------START::reventlog_resolved_parse_error4::Time:Wed Oct 17 23:27:52 2018------

RUN:reventlog f5u14 resolved=-1 [Wed Oct 17 23:27:52 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
f5u14: [f6u13k10]: Error: Invalid ID: -1
f5u14: [f6u13k10]: Error: No event log entries needed to be resolved
Attempting to resolve the following log entries: -1...
Install the OpenBMC RAS package to obtain more details logging messages.
CHECK:rc == 1	[Pass]
CHECK:output =~ Error: (\[.*?\]: )?Invalid ID:	[Pass]

------END::reventlog_resolved_parse_error4::Passed::Time:Wed Oct 17 23:27:53 2018 ::Duration::1 sec------
------START::reventlog_resolved_parse_error5::Time:Wed Oct 17 23:27:53 2018------

RUN:reventlog f5u14 resolved=abc [Wed Oct 17 23:27:53 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
f5u14: [f6u13k10]: Error: Invalid ID: abc
f5u14: [f6u13k10]: Error: No event log entries needed to be resolved
Attempting to resolve the following log entries: abc...
Install the OpenBMC RAS package to obtain more details logging messages.
CHECK:rc == 1	[Pass]
CHECK:output =~ Error: (\[.*?\]: )?Invalid ID:	[Pass]

------END::reventlog_resolved_parse_error5::Passed::Time:Wed Oct 17 23:27:54 2018 ::Duration::1 sec------
------START::rspconfig_get_and_set_hostname::Time:Wed Oct 17 23:27:54 2018------

RUN:rspconfig f5u14 hostname | tee /tmp/xcattest.rspconfig.hostname [Wed Oct 17 23:27:54 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
f5u14: BMC Hostname: bogus_bmc_hostname
CHECK:rc == 0	[Pass]
CHECK:output =~ f5u14: BMC Hostname:	[Pass]

RUN:rspconfig f5u14 hostname=witherspoon [Wed Oct 17 23:27:57 2018]
ElapsedTime:4 sec
RETURN rc = 0
OUTPUT:
f5u14: BMC Setting BMC Hostname...
f5u14: BMC Hostname: witherspoon
CHECK:rc == 0	[Pass]
CHECK:output =~ f5u14: BMC Setting BMC Hostname...	[Pass]

RUN:rspconfig f5u14 hostname [Wed Oct 17 23:28:01 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f5u14: BMC Hostname: witherspoon
CHECK:rc == 0	[Pass]
CHECK:output =~ f5u14: BMC Hostname: witherspoon	[Pass]

RUN:rspconfig f5u14 hostname=f5u14-UTset [Wed Oct 17 23:28:02 2018]
ElapsedTime:4 sec
RETURN rc = 0
OUTPUT:
f5u14: BMC Setting BMC Hostname...
f5u14: BMC Hostname: f5u14-UTset
CHECK:rc == 0	[Pass]
CHECK:output =~ f5u14: BMC Setting BMC Hostname...	[Pass]

RUN:rspconfig f5u14 hostname [Wed Oct 17 23:28:06 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f5u14: BMC Hostname: f5u14-UTset
CHECK:rc == 0	[Pass]
CHECK:output =~ f5u14: BMC Hostname: f5u14-UTset	[Pass]

RUN:grep BMC /tmp/xcattest.rspconfig.hostname  | cut -d' ' -f4 | xargs -i{} rspconfig f5u14 hostname={} [Wed Oct 17 23:28:07 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
f5u14: BMC Setting BMC Hostname...
f5u14: BMC Hostname: bogus_bmc_hostname
CHECK:rc == 0	[Pass]
CHECK:output =~ f5u14: BMC Setting BMC Hostname...	[Pass]

RUN:rspconfig f5u14 hostname [Wed Oct 17 23:28:09 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
f5u14: BMC Hostname: bogus_bmc_hostname
CHECK:rc == 0	[Pass]
CHECK:output =~ f5u14: BMC Hostname:	[Pass]

RUN:rm /tmp/xcattest.rspconfig.hostname [Wed Oct 17 23:28:11 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::rspconfig_get_and_set_hostname::Passed::Time:Wed Oct 17 23:28:11 2018 ::Duration::17 sec------
------START::rspconfig_ipsrc::Time:Wed Oct 17 23:28:11 2018------

RUN:rspconfig f5u14 ipsrc [Wed Oct 17 23:28:11 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
f5u14: BMC IP Source: DHCP
CHECK:output =~ f5u14\s*:\s*BMC IP Source: Static|BMC IP Source: DHCP	[Pass]
CHECK:rc == 0	[Pass]

RUN:rspconfig f5u14  hostname sshcfg [Wed Oct 17 23:28:13 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f5u14: Error: Configure sshcfg must be issued without other options.
CHECK:output =~ Error: (\[.*?\]: )?Configure sshcfg must be issued without other options.	[Pass]
CHECK:rc != 0	[Pass]

------END::rspconfig_ipsrc::Passed::Time:Wed Oct 17 23:28:13 2018 ::Duration::2 sec------

```

* Refine ``setup_vm`` case add more debug information

The UT are 
  * on VM+physical node cluster:
```
------START::setup_vm::Time:Wed Oct 17 23:33:28 2018------

RUN:if [ "__GETNODEATTR(f5u14,arch)__" != "ppc64"  -a  "__GETNODEATTR(f5u14,mgt)__" != "ipmi" -a "__GETNODEATTR(f5u14,mgt)__" != "openbmc" ];then echo "CN node f5u14 is a vm which mgt is __GETNODEATTR(f5u14,mgt)__, start to recreate the vm now"; echo "rmvm f5u14 -f -p";rpower f5u14 off; sleep 3; rmvm f5u14 -f -p; var=`expr substr "__GETNODEATTR(f5u14,vmstorage)__" 1 3`; echo "The disk create way of f5u14 is $var"; if [ "$var" = "phy" ]; then echo "mkvm f5u14"; mkvm f5u14; exit $?; elif [ "$var" = "dir" ]; then echo "mkvm f5u14 -s 20G"; mkvm f5u14 -s 20G; exit $?; elif ["$var" = "nfs" -o "$var" = "lvm" ];then echo  "Need to fix me"; exit 2; else echo "unsupported disk creation way"; exit 3;fi;else echo "CN node f5u14 is a non-VM; do not need to recreate it";fi [Wed Oct 17 23:33:28 2018]
ElapsedTime:18 sec
RETURN rc = 0
OUTPUT:
CN node f5u14 is a non-VM; do not need to recreate it
CHECK:rc == 0	[Pass]

RUN:if [ "__GETNODEATTR(f5u14,arch)__" != "ppc64"  -a  "__GETNODEATTR(f5u14,mgt)__" != "ipmi" -a  "__GETNODEATTR(f5u14,mgt)__" != "openbmc" ]; then echo "CN node is a vm, need to repower it on"; echo "rpower f5u14 on"; rpower f5u14 on; else echo "CN node f5u14 is a non-VM; do not need to repower on it"; fi [Wed Oct 17 23:33:46 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CN node f5u14 is a non-VM; do not need to repower on it
CHECK:rc == 0	[Pass]

RUN:rpower f5u14 stat [Wed Oct 17 23:33:47 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
f5u14: on
CHECK:output =~ on	[Pass]

RUN:if [ "__GETNODEATTR(f5u14,arch)__" != "ppc64" -a  "__GETNODEATTR(f5u14,mgt)__" != "ipmi" -a "__GETNODEATTR(f5u14,mgt)__" != "openbmc" ]; then tabdump -w node==f5u14 kvm_nodedata; fi [Wed Oct 17 23:33:49 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:if [ "__GETNODEATTR(f6u13k11,arch)__" != "ppc64"  -a  "__GETNODEATTR(f6u13k11,mgt)__" != "ipmi" -a "__GETNODEATTR(f6u13k11,mgt)__" != "openbmc" ];then echo "SN node f6u13k11 is a vm which mgt is __GETNODEATTR(f6u13k11,mgt)__, start to recreate the vm now"; echo "rmvm f6u13k11 -f -p"; rpower f6u13k11 off; sleep 3; rmvm f6u13k11 -f -p; var=`expr substr "__GETNODEATTR(f6u13k11,vmstorage)__" 1 3`; echo "The disk create way of f6u13k11 is $var"; if [ "$var" = "phy" ]; then echo "mkvm f6u13k11"; mkvm f6u13k11; exit $?; elif [ "$var" = "dir" ]; then echo "mkvm f6u13k11 -s 20G"; mkvm f6u13k11 -s 20G; exit $?; elif ["$var" = "nfs" -o "$var" = "lvm" ];then echo  "Need to fix me"; exit 2; else echo "unsupported disk creation way"; exit 3;fi;else echo "SN node f6u13k11 is a non-VM; do not need to recreate it";fi [Wed Oct 17 23:33:50 2018]
ElapsedTime:6 sec
RETURN rc = 0
OUTPUT:
SN node f6u13k11 is a vm which mgt is kvm, start to recreate the vm now
rmvm f6u13k11 -f -p
f6u13k11: off
The disk create way of f6u13k11 is phy
mkvm f6u13k11
CHECK:rc == 0	[Pass]

RUN:if [ "__GETNODEATTR(f6u13k11,arch)__" != "ppc64"  -a  "__GETNODEATTR(f6u13k11,mgt)__" != "ipmi" -a  "__GETNODEATTR(f6u13k11,mgt)__" != "openbmc" ];then echo "SN node f6u13k11 is a VM, need to rpower it on"; echo "rpower f6u13k11 on"; rpower f6u13k11 on; fi [Wed Oct 17 23:33:56 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
SN node f6u13k11 is a VM, need to rpower it on
rpower f6u13k11 on
f6u13k11: on
CHECK:rc == 0	[Pass]

RUN:rpower f6u13k11 stat [Wed Oct 17 23:33:58 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
f6u13k11: on
CHECK:output =~ on	[Pass]
CHECK:rc == 0	[Pass]

RUN:if [ "__GETNODEATTR(f6u13k11,arch)__" != "ppc64" -a  "__GETNODEATTR(f6u13k11,mgt)__" != "ipmi" -a "__GETNODEATTR(f6u13k11,mgt)__" != "openbmc" ]; then tabdump -w node==f6u13k11 kvm_nodedata; fi [Wed Oct 17 23:33:58 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
#node,xml,comments,disable
"f6u13k11","<domain type='kvm' id='540'>
  <name>f6u13k11</name>
  <uuid>4a9efba4-42d1-e811-9c7d-42340a060d0b</uuid>
  <memory unit='KiB'>8388608</memory>
  <currentMemory unit='KiB'>8388608</currentMemory>
  <vcpu placement='static'>2</vcpu>
  <resource>
    <partition>/machine</partition>
  </resource>
  <os>
    <type arch='ppc64le' machine='pseries-rhel7.4.0'>hvm</type>
    <boot dev='network'/>
    <boot dev='hd'/>
  </os>
  <features>
    <acpi/>
    <apic/>
    <pae/>
  </features>
  <clock offset='utc'/>
  <on_poweroff>destroy</on_poweroff>
  <on_reboot>restart</on_reboot>
  <on_crash>destroy</on_crash>
  <devices>
    <emulator>/usr/libexec/qemu-kvm</emulator>
    <disk type='block' device='disk'>
      <driver name='qemu' type='raw'/>
      <source dev='/dev/mapper/vdiskvg00-vdisk00n11'/>
      <backingStore/>
      <target dev='sda' bus='scsi'/>
      <alias name='scsi0-0-0-0'/>
      <address type='drive' controller='0' bus='0' target='0' unit='0'/>
    </disk>
    <disk type='file' device='cdrom'>
      <driver name='qemu' type='raw'/>
      <backingStore/>
      <target dev='sdd' bus='scsi'/>
      <readonly/>
      <alias name='scsi0-0-0-3'/>
      <address type='drive' controller='0' bus='0' target='0' unit='3'/>
    </disk>
    <controller type='usb' index='0' model='qemu-xhci'>
      <alias name='usb'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
    </controller>
    <controller type='pci' index='0' model='pci-root'>
      <model name='spapr-pci-host-bridge'/>
      <target index='0'/>
      <alias name='pci.0'/>
    </controller>
    <controller type='scsi' index='0'>
      <alias name='scsi0'/>
      <address type='spapr-vio' reg='0x2000'/>
    </controller>
    <interface type='bridge'>
      <mac address='42:33:0a:06:0d:0b'/>
      <source bridge='br0'/>
      <target dev='vnet9'/>
      <model type='virtio-net-pci'/>
      <alias name='net0'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x0'/>
    </interface>
    <interface type='bridge'>
      <mac address='42:c0:0a:06:0d:0b'/>
      <source bridge='private_br0'/>
      <target dev='vnet10'/>
      <model type='virtio-net-pci'/>
      <alias name='net1'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
    </interface>
    <interface type='bridge'>
      <mac address='42:26:0a:06:0d:0b'/>
      <source bridge='private_br1'/>
      <target dev='vnet11'/>
      <model type='virtio-net-pci'/>
      <alias name='net2'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
    </interface>
    <serial type='pty'>
      <source path='/dev/pts/4'/>
      <target port='0'/>
      <alias name='serial0'/>
      <address type='spapr-vio' reg='0x30000000'/>
    </serial>
    <console type='pty' tty='/dev/pts/4'>
      <source path='/dev/pts/4'/>
      <target type='serial' port='0'/>
      <alias name='serial0'/>
      <address type='spapr-vio' reg='0x30000000'/>
    </console>
    <input type='tablet' bus='usb'>
      <alias name='input0'/>
      <address type='usb' bus='0' port='1'/>
    </input>
    <input type='keyboard' bus='usb'>
      <alias name='input1'/>
      <address type='usb' bus='0' port='2'/>
    </input>
    <input type='mouse' bus='usb'>
      <alias name='input2'/>
      <address type='usb' bus='0' port='3'/>
    </input>
    <graphics type='vnc' port='5903' autoport='yes' listen='0.0.0.0'>
      <listen type='address' address='0.0.0.0'/>
    </graphics>
    <video>
      <model type='vga' vram='8192' heads='1' primary='yes'/>
      <alias name='video0'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
    </video>
    <memballoon model='virtio'>
      <alias name='balloon0'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0'/>
    </memballoon>
    <panic model='pseries'/>
  </devices>
  <seclabel type='none' model='none'/>
  <seclabel type='dynamic' model='dac' relabel='yes'>
    <label>+107:+107</label>
    <imagelabel>+107:+107</imagelabel>
  </seclabel>
</domain>
",,
CHECK:rc == 0	[Pass]

------END::setup_vm::Passed::Time:Wed Oct 17 23:33:59 2018 ::Duration::31 sec------
```

  * on all VM cluster:
```
------START::setup_vm::Time:Wed Oct 17 23:13:37 2018------

RUN:if [ "__GETNODEATTR(f6u13k15,arch)__" != "ppc64"  -a  "__GETNODEATTR(f6u13k15,mgt)__" != "ipmi" -a "__GETNODEATTR(f6u13k15,mgt)__" != "openbmc" ];then echo "CN node f6u13k15 is a vm which mgt is __GETNODEATTR(f6u13k15,mgt)__, start to recreate the vm now"; echo "rmvm f6u13k15 -f -p";rpower f6u13k15 off; sleep 3; rmvm f6u13k15 -f -p; var=`expr substr "__GETNODEATTR(f6u13k15,vmstorage)__" 1 3`; echo "The disk create way of f6u13k15 is $var"; if [ "$var" = "phy" ]; then echo "mkvm f6u13k15"; mkvm f6u13k15; exit $?; elif [ "$var" = "dir" ]; then echo "mkvm f6u13k15 -s 20G"; mkvm f6u13k15 -s 20G; exit $?; elif ["$var" = "nfs" -o "$var" = "lvm" ];then echo  "Need to fix me"; exit 2; else echo "unsupported disk creation way"; exit 3;fi;else echo "CN node f6u13k15 is a non-VM; do not need to recreate it";fi [Wed Oct 17 23:13:37 2018]
ElapsedTime:5 sec
RETURN rc = 0
OUTPUT:
CN node f6u13k15 is a vm which mgt is kvm, start to recreate the vm now
rmvm f6u13k15 -f -p
f6u13k15: off
The disk create way of f6u13k15 is phy
mkvm f6u13k15
CHECK:rc == 0	[Pass]

RUN:if [ "__GETNODEATTR(f6u13k15,arch)__" != "ppc64"  -a  "__GETNODEATTR(f6u13k15,mgt)__" != "ipmi" -a  "__GETNODEATTR(f6u13k15,mgt)__" != "openbmc" ]; then echo "CN node is a vm, need to repower it on"; echo "rpower f6u13k15 on"; rpower f6u13k15 on; else echo "CN node f6u13k15 is a non-VM; do not need to repower on it"; fi [Wed Oct 17 23:13:42 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
CN node is a vm, need to repower it on
rpower f6u13k15 on
f6u13k15: on
CHECK:rc == 0	[Pass]

RUN:rpower f6u13k15 stat [Wed Oct 17 23:13:44 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u13k15: on
CHECK:output =~ on	[Pass]

RUN:if [ "__GETNODEATTR(f6u13k15,arch)__" != "ppc64" -a  "__GETNODEATTR(f6u13k15,mgt)__" != "ipmi" -a "__GETNODEATTR(f6u13k15,mgt)__" != "openbmc" ]; then tabdump -w node==f6u13k15 kvm_nodedata; fi [Wed Oct 17 23:13:45 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
#node,xml,comments,disable
"f6u13k15","<domain type='kvm' id='538'>
  <name>f6u13k15</name>
  <uuid>d2b1802d-20d2-e811-9d0e-429c0a060d0f</uuid>
  <memory unit='KiB'>4194304</memory>
  <currentMemory unit='KiB'>4194304</currentMemory>
  <vcpu placement='static'>2</vcpu>
  <resource>
    <partition>/machine</partition>
  </resource>
  <os>
    <type arch='ppc64le' machine='pseries-rhel7.4.0'>hvm</type>
    <boot dev='network'/>
    <boot dev='hd'/>
  </os>
  <features>
    <acpi/>
    <apic/>
    <pae/>
  </features>
  <clock offset='utc'/>
  <on_poweroff>destroy</on_poweroff>
  <on_reboot>restart</on_reboot>
  <on_crash>destroy</on_crash>
  <devices>
    <emulator>/usr/libexec/qemu-kvm</emulator>
    <disk type='block' device='disk'>
      <driver name='qemu' type='raw'/>
      <source dev='/dev/mapper/vdiskvg00-vdisk00n15'/>
      <backingStore/>
      <target dev='sda' bus='scsi'/>
      <alias name='scsi0-0-0-0'/>
      <address type='drive' controller='0' bus='0' target='0' unit='0'/>
    </disk>
    <disk type='file' device='cdrom'>
      <driver name='qemu' type='raw'/>
      <backingStore/>
      <target dev='sdd' bus='scsi'/>
      <readonly/>
      <alias name='scsi0-0-0-3'/>
      <address type='drive' controller='0' bus='0' target='0' unit='3'/>
    </disk>
    <controller type='usb' index='0' model='qemu-xhci'>
      <alias name='usb'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
    </controller>
    <controller type='pci' index='0' model='pci-root'>
      <model name='spapr-pci-host-bridge'/>
      <target index='0'/>
      <alias name='pci.0'/>
    </controller>
    <controller type='scsi' index='0'>
      <alias name='scsi0'/>
      <address type='spapr-vio' reg='0x2000'/>
    </controller>
    <interface type='bridge'>
      <mac address='42:9c:0a:06:0d:0f'/>
      <source bridge='br0'/>
      <target dev='vnet15'/>
      <model type='virtio-net-pci'/>
      <alias name='net0'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x0'/>
    </interface>
    <interface type='bridge'>
      <mac address='42:f0:0a:06:0d:0f'/>
      <source bridge='private_br0'/>
      <target dev='vnet16'/>
      <model type='virtio-net-pci'/>
      <alias name='net1'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
    </interface>
    <interface type='bridge'>
      <mac address='42:91:0a:06:0d:0f'/>
      <source bridge='private_br1'/>
      <target dev='vnet17'/>
      <model type='virtio-net-pci'/>
      <alias name='net2'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
    </interface>
    <serial type='pty'>
      <source path='/dev/pts/7'/>
      <target port='0'/>
      <alias name='serial0'/>
      <address type='spapr-vio' reg='0x30000000'/>
    </serial>
    <console type='pty' tty='/dev/pts/7'>
      <source path='/dev/pts/7'/>
      <target type='serial' port='0'/>
      <alias name='serial0'/>
      <address type='spapr-vio' reg='0x30000000'/>
    </console>
    <input type='tablet' bus='usb'>
      <alias name='input0'/>
      <address type='usb' bus='0' port='1'/>
    </input>
    <input type='keyboard' bus='usb'>
      <alias name='input1'/>
      <address type='usb' bus='0' port='2'/>
    </input>
    <input type='mouse' bus='usb'>
      <alias name='input2'/>
      <address type='usb' bus='0' port='3'/>
    </input>
    <graphics type='vnc' port='5905' autoport='yes' listen='0.0.0.0'>
      <listen type='address' address='0.0.0.0'/>
    </graphics>
    <video>
      <model type='vga' vram='8192' heads='1' primary='yes'/>
      <alias name='video0'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
    </video>
    <memballoon model='virtio'>
      <alias name='balloon0'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0'/>
    </memballoon>
    <panic model='pseries'/>
  </devices>
  <seclabel type='none' model='none'/>
  <seclabel type='dynamic' model='dac' relabel='yes'>
    <label>+107:+107</label>
    <imagelabel>+107:+107</imagelabel>
  </seclabel>
</domain>
",,
CHECK:rc == 0	[Pass]

RUN:if [ "__GETNODEATTR(f6u13k14,arch)__" != "ppc64"  -a  "__GETNODEATTR(f6u13k14,mgt)__" != "ipmi" -a "__GETNODEATTR(f6u13k14,mgt)__" != "openbmc" ];then echo "SN node f6u13k14 is a vm which mgt is __GETNODEATTR(f6u13k14,mgt)__, start to recreate the vm now"; echo "rmvm f6u13k14 -f -p"; rpower f6u13k14 off; sleep 3; rmvm f6u13k14 -f -p; var=`expr substr "__GETNODEATTR(f6u13k14,vmstorage)__" 1 3`; echo "The disk create way of f6u13k14 is $var"; if [ "$var" = "phy" ]; then echo "mkvm f6u13k14"; mkvm f6u13k14; exit $?; elif [ "$var" = "dir" ]; then echo "mkvm f6u13k14 -s 20G"; mkvm f6u13k14 -s 20G; exit $?; elif ["$var" = "nfs" -o "$var" = "lvm" ];then echo  "Need to fix me"; exit 2; else echo "unsupported disk creation way"; exit 3;fi;else echo "SN node f6u13k14 is a non-VM; do not need to recreate it";fi [Wed Oct 17 23:13:46 2018]
ElapsedTime:6 sec
RETURN rc = 0
OUTPUT:
SN node f6u13k14 is a vm which mgt is kvm, start to recreate the vm now
rmvm f6u13k14 -f -p
f6u13k14: off
The disk create way of f6u13k14 is phy
mkvm f6u13k14
CHECK:rc == 0	[Pass]

RUN:if [ "__GETNODEATTR(f6u13k14,arch)__" != "ppc64"  -a  "__GETNODEATTR(f6u13k14,mgt)__" != "ipmi" -a  "__GETNODEATTR(f6u13k14,mgt)__" != "openbmc" ];then echo "SN node f6u13k14 is a VM, need to rpower it on"; echo "rpower f6u13k14 on"; rpower f6u13k14 on; fi [Wed Oct 17 23:13:52 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
SN node f6u13k14 is a VM, need to rpower it on
rpower f6u13k14 on
f6u13k14: on
CHECK:rc == 0	[Pass]

RUN:rpower f6u13k14 stat [Wed Oct 17 23:13:53 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u13k14: on
CHECK:output =~ on	[Pass]
CHECK:rc == 0	[Pass]

RUN:if [ "__GETNODEATTR(f6u13k14,arch)__" != "ppc64" -a  "__GETNODEATTR(f6u13k14,mgt)__" != "ipmi" -a "__GETNODEATTR(f6u13k14,mgt)__" != "openbmc" ]; then tabdump -w node==f6u13k14 kvm_nodedata; fi [Wed Oct 17 23:13:54 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
#node,xml,comments,disable
"f6u13k14","<domain type='kvm' id='539'>
  <name>f6u13k14</name>
  <uuid>5efbde01-0ed2-e811-81a0-424b0a060d0e</uuid>
  <memory unit='KiB'>4194304</memory>
  <currentMemory unit='KiB'>4194304</currentMemory>
  <vcpu placement='static'>2</vcpu>
  <resource>
    <partition>/machine</partition>
  </resource>
  <os>
    <type arch='ppc64le' machine='pseries-rhel7.4.0'>hvm</type>
    <boot dev='network'/>
    <boot dev='hd'/>
  </os>
  <features>
    <acpi/>
    <apic/>
    <pae/>
  </features>
  <clock offset='utc'/>
  <on_poweroff>destroy</on_poweroff>
  <on_reboot>restart</on_reboot>
  <on_crash>destroy</on_crash>
  <devices>
    <emulator>/usr/libexec/qemu-kvm</emulator>
    <disk type='block' device='disk'>
      <driver name='qemu' type='raw'/>
      <source dev='/dev/mapper/vdiskvg00-vdisk00n14'/>
      <backingStore/>
      <target dev='sda' bus='scsi'/>
      <alias name='scsi0-0-0-0'/>
      <address type='drive' controller='0' bus='0' target='0' unit='0'/>
    </disk>
    <disk type='file' device='cdrom'>
      <driver name='qemu' type='raw'/>
      <backingStore/>
      <target dev='sdd' bus='scsi'/>
      <readonly/>
      <alias name='scsi0-0-0-3'/>
      <address type='drive' controller='0' bus='0' target='0' unit='3'/>
    </disk>
    <controller type='usb' index='0' model='qemu-xhci'>
      <alias name='usb'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
    </controller>
    <controller type='pci' index='0' model='pci-root'>
      <model name='spapr-pci-host-bridge'/>
      <target index='0'/>
      <alias name='pci.0'/>
    </controller>
    <controller type='scsi' index='0'>
      <alias name='scsi0'/>
      <address type='spapr-vio' reg='0x2000'/>
    </controller>
    <interface type='bridge'>
      <mac address='42:4b:0a:06:0d:0e'/>
      <source bridge='br0'/>
      <target dev='vnet18'/>
      <model type='virtio-net-pci'/>
      <alias name='net0'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x0'/>
    </interface>
    <interface type='bridge'>
      <mac address='42:d4:0a:06:0d:0e'/>
      <source bridge='private_br0'/>
      <target dev='vnet19'/>
      <model type='virtio-net-pci'/>
      <alias name='net1'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
    </interface>
    <interface type='bridge'>
      <mac address='42:52:0a:06:0d:0e'/>
      <source bridge='private_br1'/>
      <target dev='vnet20'/>
      <model type='virtio-net-pci'/>
      <alias name='net2'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
    </interface>
    <serial type='pty'>
      <source path='/dev/pts/8'/>
      <target port='0'/>
      <alias name='serial0'/>
      <address type='spapr-vio' reg='0x30000000'/>
    </serial>
    <console type='pty' tty='/dev/pts/8'>
      <source path='/dev/pts/8'/>
      <target type='serial' port='0'/>
      <alias name='serial0'/>
      <address type='spapr-vio' reg='0x30000000'/>
    </console>
    <input type='tablet' bus='usb'>
      <alias name='input0'/>
      <address type='usb' bus='0' port='1'/>
    </input>
    <input type='keyboard' bus='usb'>
      <alias name='input1'/>
      <address type='usb' bus='0' port='2'/>
    </input>
    <input type='mouse' bus='usb'>
      <alias name='input2'/>
      <address type='usb' bus='0' port='3'/>
    </input>
    <graphics type='vnc' port='5906' autoport='yes' listen='0.0.0.0'>
      <listen type='address' address='0.0.0.0'/>
    </graphics>
    <video>
      <model type='vga' vram='8192' heads='1' primary='yes'/>
      <alias name='video0'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
    </video>
    <memballoon model='virtio'>
      <alias name='balloon0'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0'/>
    </memballoon>
    <panic model='pseries'/>
  </devices>
  <seclabel type='none' model='none'/>
  <seclabel type='dynamic' model='dac' relabel='yes'>
    <label>+107:+107</label>
    <imagelabel>+107:+107</imagelabel>
  </seclabel>
</domain>
",,
CHECK:rc == 0	[Pass]

------END::setup_vm::Passed::Time:Wed Oct 17 23:13:55 2018 ::Duration::18 sec------
```