### PR TITLE
fix issue 5701, support site.httpport setting for xcatmn check

### DIFF
--- a/xCAT-probe/subcmds/xcatmn
+++ b/xCAT-probe/subcmds/xcatmn
@@ -715,10 +715,18 @@ sub check_http_service {
         push @$error_ref, "HTTP check need 'wget' tool, please install 'wget' tool and try again";
     } else {
         {
-            my $installdir = `lsdef -t site -i installdir -c 2>&1 | awk -F'=' '{print \$2}'`;
-            chomp($installdir);
+            my $httpinfo = `lsdef -t site -i installdir,httpport -c 2>&1`;
+            my $installdir = "";
+            my $httpport = 80;
+            if ($httpinfo =~ /clustersite: installdir=(\S*)/) {
+                $installdir = $1;
+            }
+            if ($httpinfo =~ /clustersite: httpport=(\S*)/) {
+                $httpport = $1;
+            }
+
             unless($installdir){
-                push @$error_ref, "HTTP work path(installdir) isn't configured in 'sit' table";
+                push @$error_ref, "HTTP work path(installdir) isn't configured in 'site' table";
                 last;
             }
 
@@ -728,7 +736,7 @@ sub check_http_service {
             }
 
             my $errormsg;
-            unless(probe_utils->is_http_ready("$serverip", $installdir, \$errormsg)) {
+            unless(probe_utils->is_http_ready("$serverip", $httpport, $installdir, \$errormsg)) {
                 push @$error_ref, "$errormsg";
                 last;
             }


### PR DESCRIPTION
### The PR is to fix issue _#5701_

### The modification include

_##Read http port from site table_

For http service check in xcatmn, support to read ``httpport`` attribute in site table.
If set in site table, check whether is listening by http/apache. If listening, check whether could download file.

### The UT result
If no http/apache is listening:
```
[mn]: Checking SELinux is disabled...                                                                             [ OK ]
[mn]: Checking HTTP service is configured...                                                                      [FAIL]
[mn]: No HTTP listenning status get by command 'netstat'
[mn]: Checking TFTP service is configured...                                                                      [ OK ]
```

If the listening port is not the same with set in site table:
```
[mn]: Checking HTTP service is configured...                                                                      [FAIL]
[mn]: The port HTTP listenning is not the same with defined in 'site' table
[mn]: Checking TFTP service is configured...                                                                      [ OK ]
[mn]: Checking DNS service is configured...                                                                       [ OK ]
[mn]: Checking DHCP service is configured...                                                                      [ OK ]
```

If could not download file:
```
[mn]: Checking SELinux is disabled...                                                                             [ OK ]
[mn]: Checking HTTP service is configured...                                                                      [FAIL]
[mn]: Network failure, the server refuse connection. Please check if httpd service is running first.
[mn]: Checking TFTP service is configured...                                                                      [ OK ]
[mn]: Checking DNS service is configured...                                                                       [ OK ]
```