### PR TITLE
fix issue 5700, support site.httpport to be used in discovery in xcatprobe

### DIFF
--- a/xCAT-probe/subcmds/discovery
+++ b/xCAT-probe/subcmds/discovery
@@ -585,9 +585,15 @@ sub check_genesis_file {
         }
     }
 
-    my $tftpdir = `tabdump site | awk -F',' '/^"tftpdir",/ { gsub(/"/, "", \$2) ; print \$2 }'`;
-    chomp($tftpdir);
-    $tftpdir =~ s/"//g;
+    my $site_info = `lsdef -t site -i tftpdir,httpport -c`;
+    my $tftpdir = "";
+    my $httpport = 80;
+    if ($site_info =~ /clustersite: tftpdir=(\S*)/) {
+        $tftpdir = $1;
+    }
+    if ($site_info =~ /clustersite: httpport=(\S*)/) {
+        $httpport = $1;
+    }
     my $genesis_folder;
     my @genesis_files;
     my $genesis_line;
@@ -623,14 +629,22 @@ sub check_genesis_file {
                 if ($genesis_line =~ /^initrd/) {
                     @initrd_info = split(' ', $genesis_line);
                     $initrd_path = $initrd_info[1];
-                    $wget_rst = system("wget -q --spider $initrd_path -T 0.5 -t 3");
-                    if ($wget_rst) {
-                        push @errors, "'initrd' cannot be downloaded from $initrd_path.";
-                        $rst = 1;
-                    }
 
-                    if ($initrd_path =~ /http:\/\/.+:80(\/.+)/) {
-                        my $initrd_file = $1;
+                    if ($initrd_path =~ /http:\/\/.+:(\d*)(\/.+)/) {
+                        my $initrd_port = $1;
+                        my $initrd_file = $2;
+
+                        if ($initrd_port != $httpport) {
+                            push @errors, "The http port for initrd file in '$file' is not the same with defined in 'site' table.";
+                            $rst = 1;
+                        } else {
+                            $wget_rst = system("wget -q --spider $initrd_path -T 0.5 -t 3");
+                            if ($wget_rst) {
+                                push @errors, "'initrd' cannot be downloaded from $initrd_path.";
+                                $rst = 1;
+                            }
+                        }
+
                         my $initrd_time = `stat $initrd_file | grep Modify | cut -d ' ' -f 2-3`;
                         if ($genesis_time and $initrd_time < $genesis_time) {
                             $genesis_update_flag_p = 1;
@@ -641,10 +655,18 @@ sub check_genesis_file {
                 if ($genesis_line =~ /^kernel/) {
                     @kernel_info = split(' ', $genesis_line);
                     $kernel_path = $kernel_info[1];
-                    $wget_rst = system("wget -q --spider $kernel_path -T 0.5 -t 3");
-                    if ($wget_rst) {
-                        push @errors, "kernel cannot be downloaded from $kernel_path.";
-                        $rst = 1;
+                    if ($kernel_path =~ /http:\/\/.+:(\d*)\/.+/) {
+                        my $kernel_port = $1;
+                        if ($kernel_port != $httpport) {
+                            push @errors, "The http port for kernel file in '$file' is not the same with defined in 'site' table.";
+                            $rst = 1;
+                        } else {
+                            $wget_rst = system("wget -q --spider $kernel_path -T 0.5 -t 3");
+                            if ($wget_rst) {
+                                push @errors, "kernel cannot be downloaded from $kernel_path.";
+                                $rst = 1;
+                            }
+                        }
                     }
                 }
             }
@@ -703,7 +725,7 @@ sub check_genesis_file {
                     next;
                 }
 
-                $host_ip .= ":80";
+                $host_ip .= ":$httpport";
                 while ($genesis_line = <FILE>) {
                     chomp($genesis_line);
                     $genesis_line =~ s/^\s+|\s+$//g;


### PR DESCRIPTION
### The PR is to fix issue _#5700_

### The modification include

_##Read httpport in site table_

1. Check whether defined ``httpport`` attribute in site table
2. If defined, check whether same with port used in genesis file
3. If same, try to download

### The UT result
If ``httpport`` defined in site table is not same with used in genesis file
```
Genesis files are available                                                                                       [FAIL]
The http port for kernel file in '/tftpboot/pxelinux.cfg/p/10.0.0.0_8' is not the same with defined in 'site' t...
The http port for initrd file in '/tftpboot/pxelinux.cfg/p/10.0.0.0_8' is not the same with defined in 'site' t...
The http port for kernel file in '/tftpboot/pxelinux.cfg/p/127.0.0.0_8' is not the same with defined in 'site' ...
The http port for initrd file in '/tftpboot/pxelinux.cfg/p/127.0.0.0_8' is not the same with defined in 'site' ...
```

If could not download initrd/kernel file
```
Genesis files are available                                                                                       [FAIL]
elilo-x64.efi cannot be downloaded from http://10.3.17.21:81/tftpboot/xcat/elilo-x64.efi.
elilo file cannot be downloaded from http://10.3.17.21:81//tftpboot/xcat/xnba/nets/10.0.0.0_8.elilo.
elilo-x64.efi cannot be downloaded from http://127.0.0.1:81/tftpboot/xcat/elilo-x64.efi.
elilo file cannot be downloaded from http://127.0.0.1:81//tftpboot/xcat/xnba/nets/127.0.0.0_8.elilo.
```
