### PR TITLE
classify deployment log and updatenode log

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/post.xcat
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat
@@ -39,6 +39,7 @@ chmod 0755 /tmp/updateflag
 
 cd /tmp
 log_label="xcat.deployment"
+msgutil_r "$MASTER_IP" "info" "=============deployment starting====================" "/var/log/xcat/xcat.log" "$log_label"
 msgutil_r "$MASTER_IP" "info" "Executing post.xcat to prepare for firstbooting ..." "/var/log/xcat/xcat.log" "$log_label"
 
 RAND=$(perl -e 'print int(rand(50)). "\n"')
@@ -196,9 +197,9 @@ run_ps () {
     if [ -z \"\$scriptype\" ]; then
         scriptype=\"postscript\"
     fi
-
+    log_label=\"xcat.deployment.\"\$scriptype
     if [ -f \$1 ]; then
-        msgutil_r \"\$MASTER_IP\" \"info\" "\"Running \$scriptype: \$1\"" \"\$logfile\" \"xcat.mypostscript\"
+        msgutil_r \"\$MASTER_IP\" \"info\" "\"\$scriptype start..: \$1\"" \"\$logfile\" \"\$log_label\"
         if [ \"\$XCATDEBUGMODE\" = \"1\" ] || [ \"\$XCATDEBUGMODE\" = \"2\" ]; then
             local compt=\$(file \$1)
             local reg=\"shell script\"
@@ -217,9 +218,9 @@ run_ps () {
         if [ \"\$ret_local\" -ne \"0\" ]; then
             return_value=\$ret_local
         fi
-        msgutil_r \"\$MASTER_IP\" \"info\" "\"\$scriptype \$1 return with \$ret_local\"" \"\$logfile\" \"xcat.mypostscript\"
+        msgutil_r \"\$MASTER_IP\" \"info\" "\"\$scriptype end...: \$1 return with \$ret_local\"" \"\$logfile\" \"\$log_label\"
     else
-        msgutil_r \"\$MASTER_IP\" \"error\" "\"\$scriptype \$1 does NOT exist.\"" \"\$logfile\" \"xcat.mypostscript\"
+        msgutil_r \"\$MASTER_IP\" \"error\" "\"\$scriptype \$1 does NOT exist.\"" \"\$logfile\" \"\$log_label\"
         return_value=-1
     fi
 

--- a/xCAT-server/share/xcat/install/scripts/post.xcat.ng
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat.ng
@@ -242,9 +242,9 @@ run_ps () {
     if [ -z \"\$scriptype\" ]; then
         scriptype=\"postscript\"
     fi
-
+    log_label=\"xcat.deployment.\"\$scriptype
     if [ -f \$1 ]; then
-        msgutil_r \"\$MASTER_IP\" \"info\" "\"Running \$scriptype: \$1\"" \"\$logfile\" \"xcat.mypostscript\"
+        msgutil_r \"\$MASTER_IP\" \"info\" "\"Running \$scriptype: \$1\"" \"\$logfile\" \"\$log_label\"
         if [ \"\$XCATDEBUGMODE\" = \"1\" ] || [ \"\$XCATDEBUGMODE\" = \"2\" ]; then
             local compt=\$(file \$1)
             local reg=\"shell script\"
@@ -263,9 +263,9 @@ run_ps () {
         if [ \"\$ret_local\" -ne \"0\" ]; then
             return_value=\$ret_local
         fi
-        msgutil_r \"\$MASTER_IP\" \"info\" "\"\$scriptype \$1 return with \$ret_local\"" \"\$logfile\" \"xcat.mypostscript\"
+        msgutil_r \"\$MASTER_IP\" \"info\" "\"\$scriptype \$1 return with \$ret_local\"" \"\$logfile\" \"\$log_label\"
     else
-        msgutil_r \"\$MASTER_IP\" \"error\" "\"\$scriptype \$1 does NOT exist.\"" \"\$logfile\" \"xcat.mypostscript\"
+        msgutil_r \"\$MASTER_IP\" \"error\" "\"\$scriptype \$1 does NOT exist.\"" \"\$logfile\" \"\$log_label\"
         return_value=-1
     fi
 

--- a/xCAT-server/share/xcat/netboot/rh/dracut/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut/xcatroot
@@ -2,7 +2,7 @@
 NEWROOT=$3
 RWDIR=.statelite
 XCATMASTER=$XCAT
-
+log_label="xcat.deployment"
 . /lib/dracut-lib.sh
 rootlimit="$(getarg rootlimit=)"
 
@@ -20,7 +20,7 @@ xcatdebugmode="$(getarg xcatdebugmode=)"
 
 [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "running xcatroot...."
 [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "MASTER=$MASTER XCATIPORT=$XCATIPORT"
-
+logger -t $log_label -p local4.info "=============deployment starting===================="
 if [ "$NODESTATUS" != "0" ]; then
     [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "nodestatus: netbooting,reporting..."
     /tmp/updateflag $MASTER $XCATIPORT "installstatus netbooting"

--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
@@ -21,7 +21,7 @@ if [ $? -ne 0 ]; then
 fi
 
 [ "$xcatdebugmode" = "1" -o "$xcatdebugmode" = "2" ] && SYSLOGHOST="" || SYSLOGHOST="-n $MASTER"
-
+logger $SYSLOGHOST -t $log_label -p local4.info "=============deployment starting===================="
 logger $SYSLOGHOST -t $log_label -p local4.info "Executing xcatroot to prepare for netbooting (dracut_33)..."
 [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "MASTER=$MASTER XCATIPORT=$XCATIPORT NODESTATUS=$NODESTATUS"
 

--- a/xCAT-server/share/xcat/netboot/rh/dracut_047/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_047/xcatroot
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -x
 log_label="xcat.deployment"
 
 NEWROOT=$3
@@ -22,7 +21,7 @@ if [ $? -ne 0 ]; then
 fi
 
 [ "$xcatdebugmode" = "1" -o "$xcatdebugmode" = "2" ] && SYSLOGHOST="" || SYSLOGHOST="-n $MASTER"
-
+logger $SYSLOGHOST -t $log_label -p local4.info "=============deployment starting===================="
 logger $SYSLOGHOST -t $log_label -p local4.info "Executing xcatroot to prepare for netbooting (dracut_33)..."
 [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p local4.debug "MASTER=$MASTER XCATIPORT=$XCATIPORT NODESTATUS=$NODESTATUS"
 

--- a/xCAT/postscripts/xcatdsklspost
+++ b/xCAT/postscripts/xcatdsklspost
@@ -68,11 +68,11 @@ echolog()
          echo "$msgstr"
       fi
       if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
-            msgutil_r  "$MASTER_IP" "$msgtype" "$msgstr" "/var/log/xcat/xcat.log" "xcat.xcatdsklspost"
+            msgutil_r  "$MASTER_IP" "$msgtype" "$msgstr" "/var/log/xcat/xcat.log" "$log_label"
       fi
    else
       echo "$msgstr"
-      msgutil_r "$MASTER_IP"  "$msgtype" "$msgstr" "/var/log/xcat/xcat.log" "xcat.xcatdsklspost"
+      msgutil_r "$MASTER_IP"  "$msgtype" "$msgstr" "/var/log/xcat/xcat.log" "$log_label"
    fi
 
    #reload the functions defined in./xcatlib.sh
@@ -119,7 +119,6 @@ download_postscripts()
             INSTALLDIR="/install"
         fi
     fi
-
     echolog "debug" "trying to download postscripts from http://$server$INSTALLDIR/postscripts/"
     max_retries=5
     retry=0
@@ -216,8 +215,12 @@ pmatch ()
 ARGNUM=$#;
 if [ -z $1 ]; then
   NODE_DEPLOYMENT=1
+  log_label="xcat.deployment"
+  echolog "info" "=============deployment starting===================="
 else
   NODE_DEPLOYMENT=0
+  log_label="xcat.updatenode"
+  echolog "info" "=============updatenode starting===================="
   case $1 in
     1|2|5)
       MODE=$1
@@ -885,18 +888,22 @@ run_ps () {
  if [ -z \"\$scriptype\" ]; then
   scriptype=\"postscript\"
  fi
-
+ if [ \$UPDATENODE -eq 0 ]; then
+     log_label=\"xcat.deployment.\"\$scriptype
+ else
+     log_label=\"xcat.updatenode.\"\$scriptype
+ fi
  if [ -f \$1 ]; then
-  echo \"Running \$scriptype: \$1\"
-  msgutil_r \"\$MASTER_IP\" \"info\" "\"Running \$scriptype: \$1\"" \"\$logfile\" \"xcat.mypostscript\"
+  echo \"\$scriptype start..: \$1\"
+  msgutil_r \"\$MASTER_IP\" \"info\" "\"\$scriptype start..: \$1\"" \"\$logfile\" \"\$log_label\"
   if [ \"\$XCATDEBUGMODE\" = \"1\" ] || [ \"\$XCATDEBUGMODE\" = \"2\" ]; then
      local compt=\$(file \$1)
      local reg=\"shell script\"
      if [[ \"\$compt\" =~ \$reg ]]; then
-        bash -x ./\$@ 2>&1 | tee -a \$logfile | tee >(logger -t xcat.mypostscript -p debug)
+        bash -x ./\$@ 2>&1 | tee -a \$logfile | tee >(logger -t \$log_label -p debug)
         ret_local=\${PIPESTATUS[0]}
      else
-        ./\$@ 2>&1 | tee -a \$logfile | tee >(logger -t xcat.mypostscript -p debug)
+        ./\$@ 2>&1 | tee -a \$logfile | tee >(logger -t \$log_label -p debug)
         ret_local=\${PIPESTATUS[0]}
      fi
   else
@@ -907,11 +914,11 @@ run_ps () {
   if [ \"\$ret_local\" -ne \"0\" ]; then
      return_value=\$ret_local
   fi
-  echo \"\$scriptype: \$1 exited with code \$ret_local\"
-  msgutil_r \"\$MASTER_IP\" \"info\" "\"\$scriptype \$1 return with \$ret_local\"" \"\$logfile\" \"xcat.mypostscript\"
+  echo \"\$scriptype end....: \$1 exited with code \$ret_local\"
+  msgutil_r \"\$MASTER_IP\" \"info\" "\"\$scriptype end...:\$1 return with \$ret_local\"" \"\$logfile\" \"\$log_label\"
  else
   echo \"\`date\` \$scriptype \$1 does NOT exist.\"
-  msgutil_r \"\$MASTER_IP\" \"error\" "\"\$scriptype \$1 does NOT exist.\"" \"\$logfile\" \"xcat.mypostscript\"
+  msgutil_r \"\$MASTER_IP\" \"error\" "\"\$scriptype \$1 does NOT exist.\"" \"\$logfile\" \"\$log_label\"
   return_value=-1
  fi
 
@@ -937,23 +944,23 @@ if [ $NODE_DEPLOYMENT -eq 1 ] || [ "$MODE" = "4" ] || [ "$MODE" = "6" ]; then
     if [ "$MODE" = "6" ]; then
         echo "
 if [ \"\$return_value\" -eq \"0\" ]; then
-    msgutil_r \$MASTER_IP \"debug\" \"node booted successfully, reporting status...\" \"/var/log/xcat/xcat.log\" \"xcat.mypostscript\"
+    msgutil_r \$MASTER_IP \"debug\" \"node booted successfully, reporting status...\" \"/var/log/xcat/xcat.log\" \"\$log_label\"
     updateflag.awk \$MASTER 3002 \"installstatus booted\"
 else
-    msgutil_r \$MASTER_IP \"debug\" \"node boot failed, reporting status...\" \"/var/log/xcat/xcat.log\" \"xcat.mypostscript\"
+    msgutil_r \$MASTER_IP \"debug\" \"node boot failed, reporting status...\" \"/var/log/xcat/xcat.log\" \"\$log_label\"
     updateflag.awk \$MASTER 3002 \"installstatus failed\"
 fi
         " >> /$xcatpost/mypostscript
     else
         echo "
 if [ \"\$return_value\" -eq \"0\" ]; then
-    msgutil_r \$MASTER_IP \"debug\" \"node booted successfully, reporting status...\" \"/var/log/xcat/xcat.log\" \"xcat.mypostscript\"
+    msgutil_r \$MASTER_IP \"debug\" \"node booted successfully, reporting status...\" \"/var/log/xcat/xcat.log\" \"\$log_label\"
     updateflag.awk \$MASTER 3002 \"installstatus booted\"
-    msgutil_r \$MASTER_IP \"info\" \"provision completed.(\$NODE)\" \"/var/log/xcat/xcat.log\" \"xcat.mypostscript\"
+    msgutil_r \$MASTER_IP \"info\" \"provision completed.(\$NODE)\" \"/var/log/xcat/xcat.log\" \"\$log_label\"
 else
-    msgutil_r \$MASTER_IP \"debug\" \"node boot failed, reporting status...\" \"/var/log/xcat/xcat.log\" \"xcat.mypostscript\"
+    msgutil_r \$MASTER_IP \"debug\" \"node boot failed, reporting status...\" \"/var/log/xcat/xcat.log\" \"\$log_label\"
     updateflag.awk \$MASTER 3002 \"installstatus failed\"
-    msgutil_r \$MASTER_IP \"error\" \"provision completed with error.(\$NODE)\" \"/var/log/xcat/xcat.log\" \"xcat.mypostscript\"
+    msgutil_r \$MASTER_IP \"error\" \"provision completed with error.(\$NODE)\" \"/var/log/xcat/xcat.log\" \"\$log_label\"
 fi
         " >> /$xcatpost/mypostscript
     fi
@@ -987,6 +994,11 @@ fi
 #tell user it is done when this is called by updatenode command
 if [ "$MODE" = "1" ] || [ "$MODE" = "2" ] || [ "$MODE" = "5" ]; then
   echolog "info" "returned from postscript"
+  echolog "info" "=============updatenode ending===================="
+fi
+
+if [ $NODE_DEPLOYMENT -eq 1 ] || [ "$MODE" = "4" ] || [ "$MODE" = "6" ]; then
+  echolog "info" "=============deployment ending===================="
 fi
 
 exit $VRET_POST

--- a/xCAT/postscripts/xcatinstallpost
+++ b/xCAT/postscripts/xcatinstallpost
@@ -6,7 +6,7 @@
 #################################################################
 
 . /xcatpost/xcatlib.sh
-log_label="xcat.xcatinstallpost"
+log_label="xcat.deployment"
 if [ -f /xcatpost/mypostscript.post ]; then
     XCATDEBUGMODE=`grep 'XCATDEBUGMODE=' /xcatpost/mypostscript.post |cut -d= -f2 | tr -d \'\" | tr A-Z a-z `
     MASTER_IP=`grep '^MASTER_IP=' /xcatpost/mypostscript.post |cut -d= -f2|sed s/\'//g`
@@ -125,16 +125,16 @@ echo "
 
 if [ \"\$return_value\" -eq \"0\" ]; then
     if [ \"\$XCATDEBUGMODE\" = \"1\" ] || [ \"\$XCATDEBUGMODE\" = \"2\" ]; then
-        msgutil_r \"\$MASTER_IP\" \"debug\" \"node booted, reporting status...\" \"/var/log/xcat/xcat.log\" \"xcat.mypostscript\"
+        msgutil_r \"\$MASTER_IP\" \"debug\" \"node booted, reporting status...\" \"/var/log/xcat/xcat.log\" \"\$log_label\"
     fi
     updateflag.awk \$MASTER 3002 \"installstatus booted\"
-    msgutil_r \$MASTER_IP \"info\" \"provision completed.(\$NODE)\" \"/var/log/xcat/xcat.log\" \"xcat.mypostscript\"
+    msgutil_r \$MASTER_IP \"info\" \"provision completed.(\$NODE)\" \"/var/log/xcat/xcat.log\" \"\$log_label\"
 else
     if [ \"\$XCATDEBUGMODE\" = \"1\" ] || [ \"\$XCATDEBUGMODE\" = \"2\" ]; then
-        msgutil_r \"\$MASTER_IP\" \"debug\" \"node boot failed, reporting status...\" \"/var/log/xcat/xcat.log\" \"xcat.mypostscript\"
+        msgutil_r \"\$MASTER_IP\" \"debug\" \"node boot failed, reporting status...\" \"/var/log/xcat/xcat.log\" \"\$log_label\"
     fi
     updateflag.awk \$MASTER 3002 \"installstatus failed\"
-    msgutil_r \$MASTER_IP \"error\" \"provision completed with error.(\$NODE)\" \"/var/log/xcat/xcat.log\" \"xcat.mypostscript\"
+    msgutil_r \$MASTER_IP \"error\" \"provision completed with error.(\$NODE)\" \"/var/log/xcat/xcat.log\" \"\$log_label\"
 fi
 " >> /xcatpost/mypostscript.post
 fi
@@ -145,4 +145,5 @@ if [ -x /xcatpost/mypostscript.post ];then
    msgutil_r "$MASTER_IP" "info" "Running /xcatpost/mypostscript.post" "/var/log/xcat/xcat.log" "$log_label"
    /xcatpost/mypostscript.post
    msgutil_r "$MASTER_IP" "info" "/xcatpost/mypostscript.post return" "/var/log/xcat/xcat.log" "$log_label"
+   msgutil_r "$MASTER_IP" "info" "=============deployment ending====================" "/var/log/xcat/xcat.log" "$log_label"
 fi


### PR DESCRIPTION
### The PR is for task 

https://github.com/xcat2/xcat2-task-management/issues/336
https://github.com/xcat2/xcat2-task-management/issues/335

_##Feature description##_

1. add `start` and `end` title for `deployment` and `updatenode` process 
2. add `xcat.<deployment|updatenode>[.mod]` tag for main `deployment` and `updatenode` process

### The UT result
1. diskful deployment:
```
[root@bybc0607 xcat]# grep xcat.deployment computes.log
Oct 22 05:27:53 byrh10 xcat.deployment: INFO  =============deployment starting====================
Oct 22 05:27:53 byrh10 xcat.deployment: INFO  Executing post.xcat to prepare for firstbooting ...
Oct 22 05:28:15 byrh10 xcat.deployment: INFO  trying to download postscripts from 10.5.106.7...
Oct 22 05:28:16 byrh10 xcat.deployment: INFO  postscripts downloaded successfully
Oct 22 05:28:16 byrh10 xcat.deployment: INFO  trying to get mypostscript from 10.5.106.7...
Oct 22 05:28:16 byrh10 xcat.deployment.postscript: INFO  postscript start..: syslog
Oct 22 05:28:16 byrh10 xcat.deployment.postscript: INFO  postscript end...: syslog return with 0
Oct 22 05:28:16 byrh10 xcat.deployment.postscript: INFO  postscript start..: remoteshell
Oct 22 05:28:18 byrh10 xcat.deployment.postscript: INFO  postscript end...: remoteshell return with 0
Oct 22 05:28:18 byrh10 xcat.deployment.postscript: INFO  postscript start..: syncfiles
Oct 22 05:28:18 byrh10 xcat.deployment.postscript: INFO  postscript end...: syncfiles return with 0
Oct 22 05:28:18 byrh10 xcat.deployment: INFO  finished firstboot preparation, sending request to 10.5.106.7:3002 for changing status...
Oct 22 05:31:05 byrh10 xcat.deployment: INFO  Running /xcatpost/mypostscript.post
Oct 22 05:31:05 byrh10 xcat.deployment.postbootscript: INFO  postbootscript start..: otherpkgs
Oct 22 05:31:05 byrh10 xcat.deployment.postbootscript: INFO  postbootscript end...: otherpkgs return with 0
Oct 22 05:31:05 byrh10 xcat.deployment.postbootscript: INFO  postbootscript start..: confignetwork
Oct 22 05:31:11 byrh10 xcat.deployment.postbootscript: INFO  postbootscript end...: confignetwork return with 0
Oct 22 05:31:11 byrh10 xcat.deployment.postbootscript: INFO  provision completed.(byrh10)
Oct 22 05:31:11 byrh10 xcat.deployment: INFO  /xcatpost/mypostscript.post return
Oct 22 05:31:11 byrh10 xcat.deployment: INFO  =============deployment ending====================
```
2. diskful updatenode process:
```
[root@bybc0607 xcat]# updatenode byrh10 -P
byrh10: =============updatenode starting====================
byrh10: trying to download postscripts...
byrh10: postscripts downloaded successfully
byrh10: trying to get mypostscript from 10.5.106.7...
byrh10: postscript start..: syslog
byrh10: postscript end....: syslog exited with code 0
byrh10: postscript start..: remoteshell
byrh10:
byrh10: postscript end....: remoteshell exited with code 0
byrh10: postscript start..: syncfiles
byrh10: postscript end....: syncfiles exited with code 0
byrh10: postscript start..: otherpkgs
byrh10: ./otherpkgs: no extra rpms to install
byrh10: postscript end....: otherpkgs exited with code 0
byrh10: postscript start..: confignetwork
byrh10: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh10: [I]: configure the install nic eth0.
byrh10: [I]: configeth on byrh10: os type: redhat
byrh10: GATEWAY=10.0.0.103
byrh10: ['/etc/sysconfig/network-scripts/ifcfg-eth0']
byrh10: [I]: >> DEVICE=eth0
byrh10: [I]: >> IPADDR=10.4.41.10
byrh10: [I]: >> NETMASK=255.0.0.0
byrh10: [I]: >> BOOTPROTO=static
byrh10: [I]: >> ONBOOT=yes
byrh10: [I]: >> HWADDR=42:a8:49:57:97:1d
byrh10: [I]: >> MTU=1500
byrh10: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh10: [I]: There is no other nic device to configure.
byrh10: postscript end....: confignetwork exited with code 0
byrh10: Running of postscripts has completed.
byrh10: =============updatenode ending====================

[root@bybc0607 xcat]# grep xcat.updatenode computes.log
Oct 23 02:50:12 byrh10 xcat.updatenode: INFO  =============updatenode starting====================
Oct 23 02:50:12 byrh10 xcat.updatenode: INFO  trying to download postscripts...
Oct 23 02:50:12 byrh10 xcat.updatenode: INFO  postscripts downloaded successfully
Oct 23 02:50:12 byrh10 xcat.updatenode: INFO  trying to get mypostscript from 10.5.106.7...
Oct 23 02:50:12 byrh10 xcat.updatenode.postscript: INFO  postscript start..: syslog
Oct 23 02:50:12 byrh10 xcat.updatenode.postscript: INFO  postscript end...:syslog return with 0
Oct 23 02:50:12 byrh10 xcat.updatenode.postscript: INFO  postscript start..: remoteshell
Oct 23 02:50:14 byrh10 xcat.updatenode.postscript: INFO  postscript end...:remoteshell return with 0
Oct 23 02:50:14 byrh10 xcat.updatenode.postscript: INFO  postscript start..: syncfiles
Oct 23 02:50:14 byrh10 xcat.updatenode.postscript: INFO  postscript end...:syncfiles return with 0
Oct 23 02:50:14 byrh10 xcat.updatenode.postscript: INFO  postscript start..: otherpkgs
Oct 23 02:50:14 byrh10 xcat.updatenode.postscript: INFO  postscript end...:otherpkgs return with 0
Oct 23 02:50:14 byrh10 xcat.updatenode.postscript: INFO  postscript start..: confignetwork
Oct 23 02:50:20 byrh10 xcat.updatenode.postscript: INFO  postscript end...:confignetwork return with 0
Oct 23 02:50:20 byrh10 xcat.updatenode: INFO  returned from postscript
Oct 23 02:50:20 byrh10 xcat.updatenode: INFO  =============updatenode ending====================
```
3. diskless deployment process
```
Oct 23 03:57:11 byrh10 xcat.deployment: INFO  =============deployment starting====================
Oct 23 03:57:11 byrh10 xcat.deployment: INFO  Executing xcatroot to prepare for netbooting (dracut_33)...
Oct 23 03:57:11 byrh10 xcat.deployment: INFO  Sending request to 10.5.106.7:3002 for changing status to netbooting...
Oct 23 03:57:11 byrh10 xcat.deployment: INFO  Downloading rootfs image from http://10.5.106.7:80//install/netboot/rhels7.4/x86_64/compute/rootimg.cpio.gz...
Oct 23 03:57:13 byrh10 xcat.deployment: INFO  Setting up RAM-root tmpfs on downloaded rootimg.cpio.[gz/xz]...
Oct 23 03:57:18 byrh10 xcat.deployment: INFO  Exiting xcatroot...
Oct 23 03:57:22 byrh10 xcat.deployment.postbootscript: INFO  postbootscript start..: syslog
Oct 23 03:57:22 byrh10 xcat.deployment.postbootscript: INFO  postbootscript end...:syslog return with 0
Oct 23 03:57:22 byrh10 xcat.deployment.postbootscript: INFO  postbootscript start..: remoteshell
Oct 23 03:57:24 byrh10 xcat.deployment.postbootscript: INFO  postbootscript end...:remoteshell return with 0
Oct 23 03:57:24 byrh10 xcat.deployment.postbootscript: INFO  postbootscript start..: syncfiles
Oct 23 03:57:24 byrh10 xcat.deployment.postbootscript: INFO  postbootscript end...:syncfiles return with 0
Oct 23 03:57:24 byrh10 xcat.deployment.postbootscript: INFO  postbootscript start..: otherpkgs
Oct 23 03:57:24 byrh10 xcat.deployment.postbootscript: INFO  postbootscript end...:otherpkgs return with 0
Oct 23 03:57:24 byrh10 xcat.deployment.postbootscript: INFO  postbootscript start..: confignetwork
Oct 23 03:57:24 byrh10 xcat.deployment.postbootscript: INFO  postbootscript end...:confignetwork return with 0
Oct 23 03:57:24 byrh10 xcat.deployment.postbootscript: DEBUG  node booted successfully, reporting status...
Oct 23 03:57:24 byrh10 xcat.deployment.postbootscript: INFO  provision completed.(byrh10)
Oct 23 03:57:24 byrh10 xcat.deployment: INFO  =============deployment ending====================
``` 