### PR TITLE
Log Number of Nodes for xCAT command to command.log

### DIFF
--- a/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
+++ b/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
@@ -4155,6 +4155,8 @@ sub defls
 
     # Display the definition of objects
     if (defined($rsp_info->{data}) && scalar(@{ $rsp_info->{data} }) > 0) {
+        my $nodenum = $numobjects;
+        push(@{ $rsp_info->{data} }, "$nodenum object definitions have been listed.");
         xCAT::MsgUtils->message("I", $rsp_info, $::callback);
     }
 

--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -30,6 +30,8 @@ my $udpctl;
 my $pid_UDP;
 my $pid_MON;
 
+my $numofnodes=0;
+
 # ----used for command log start---------
 my $cmdlog_svrpid;
 
@@ -2165,6 +2167,7 @@ sub plugin_command {
             }
         }
     }
+
 }
 
 my $dispatch_parentfd;
@@ -2660,6 +2663,18 @@ sub send_response {
                 my $rsp = $response->{xcatresponse};
                 if ( (ref($rsp) eq 'ARRAY') && scalar(@$rsp) > 0 ) {
                     foreach (@$rsp) {
+                        if ($_->{data}->[0]) {
+                            if ( ($_->{data}->[0]) =~ /object definitions have been/ ) {
+                                my $str = $_->{data}->[0];
+                                ($numofnodes) = $str =~ /(\d+)/;
+                            }
+                        }
+                        if ($_->{info}) {
+                            if ( ($_->{info}->[-1]) =~ /object definitions have been/ ) {
+                                my $str = $_->{info}->[-1];
+                                ($numofnodes) = $str =~ /(\d+)/;
+                            }
+                        }
                         $_->{xcatdsource}->[0] = $MYXCATSERVER unless ($_->{xcatdsource});
                     }
                 }
@@ -2803,6 +2818,12 @@ sub service_connection {
             if ($enable_perf) {
                 xCAT::MsgUtils->perf_log_process('immediate', $req);
             }
+
+             if (exists($req->{noderange}) && defined($req->{noderange}->[0])) {
+                my @nnodes = xCAT::NodeRange::noderange($req->{noderange}->[0]);
+                $numofnodes = (scalar(@nnodes));
+            }
+
             # ----used for command log start----------
             $cmdlog_starttime = time();
             my ($sec, $min, $hour, $mday, $mon, $year) = localtime($cmdlog_starttime);
@@ -3018,6 +3039,7 @@ sub service_connection {
     }
 
     # ----used for command log start-------
+    $cmdlog_alllog .= "[NumberNodes] $numofnodes \n";
     my $reqhandletime = sprintf("%.3f", time()-$cmdlog_starttime);
     $cmdlog_alllog .= "[ElapsedTime] $reqhandletime s\n";
     cmdlog_submitlog();


### PR DESCRIPTION
For scaling and performance issue, we like to log number of nodes for certain xCAT command to command.log so we can gather the data from large cluster to do some data analysis.  

````
[Request]    nodels
[NumberNodes] 1012
[ElapsedTime] 0.625 s

[Request]    lsdef cn100
[NumberNodes] 1
[ElapsedTime] 0.355 s

[Request]    lsdef 'cn[100-105]'
[NumberNodes] 6
[ElapsedTime] 0.630 s
````
for `nodels` and `lsdef` command, add a extra line to end of command output to show number of nodes listed to help determine number of nodes for those two commands.
````
# nodels switch
core01
mgmtsw01
mid08
mid08tor03
mid08tor04
mid08tor06
6 object definitions have been listed.  <-----

# lsdef core01
Object name: core01
    groups=switch,core_switch
    ip=10.6.25.1
    mac=7c:fe:90:e0:84:2c
    mgt=switch
    nodetype=switch
    password=admin
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
    switchtype=Mellanox
    usercomment=Mellanox MSX1410,MLNX-OS,SWv3.5.1006
    username=admin
1 object definitions have been listed.     <------
````

