### PR TITLE
Update some openbmc test cases

### DIFF
--- a/xCAT-test/autotest/testcase/UT_openbmc/rflash_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rflash_cases0
@@ -85,6 +85,6 @@ os:Linux
 hcp:openbmc
 label:cn_bmc_ready,hctrl_openbmc
 cmd: rflash $$CN -l | grep \* | grep BMC | awk '{print $2}' | xargs -i{} rflash $$CN --delete {}
-check:rc==1
+check:rc!=0
 check:output=~$$CN: (\[.*?\]: )?Error: Deleting currently active BMC firmware is not supported
 end

--- a/xCAT-test/autotest/testcase/UT_openbmc/supported_commands_case0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/supported_commands_case0
@@ -62,9 +62,9 @@ check:rc==0
 check:output=~$$CN: Total Power:
 cmd: rvitals $$CN leds
 check:rc==0
-check:output=~$$CN: Front
-check:output=~$$CN: Front Fans
-check:output=~$$CN: Rear
+check:output=~$$CN: LEDs Front
+check:output=~$$CN: LEDs Fan 
+check:output=~$$CN: LEDs Rear 
 cmd: rvitals $$CN all
 check:rc==0
 check:output=~$$CN: Ambient:

--- a/xCAT-test/autotest/testcase/rpower/cases0
+++ b/xCAT-test/autotest/testcase/rpower/cases0
@@ -197,35 +197,3 @@ check:output=~Error: (\[.*?\]: )?[Uu]nsupported command[:]* rpower ddd
 check:rc==1
 end
 
-start:rpower_bmcreboot_perl_python_output
-description:record the output for rpower bmcreboot and compare the output for perl and python version.
-hcp:openbmc
-label:cn_bmc_ready,hctrl_openbmc
-cmd: /opt/xcat/share/xcat/tools/autotest/testcase/UT_openbmc/scripts/bmcreboot.sh $$CN /tmp/xcattest.rpower.bmcstate.perl.out PERL
-check:rc==0
-cmd: grep "Login to BMC failed: 500" /tmp/xcattest.rpower.bmcstate.perl.out | sort | uniq | wc -l
-check:output=~3
-cmd: grep "timeout" /tmp/xcattest.rpower.bmcstate.perl.out | sort | uniq | wc -l
-check:output=~1
-cmd: grep "No route to host" /tmp/xcattest.rpower.bmcstate.perl.out | sort | uniq | wc -l
-check:output=~1
-cmd: grep "BMC NotReady" /tmp/xcattest.rpower.bmcstate.perl.out | sort | uniq | wc -l
-check:output=~1
-cmd: grep "BMC Ready" /tmp/xcattest.rpower.bmcstate.perl.out | sort | uniq | wc -l
-check:output=~1
-cmd: cat /tmp/xcattest.rpower.bmcstate.perl.out
-cmd: /opt/xcat/share/xcat/tools/autotest/testcase/UT_openbmc/scripts/bmcreboot.sh $$CN /tmp/xcattest.rpower.bmcstate.python.out PYTHON
-check:rc==0
-cmd: grep "Login to BMC failed: 500" /tmp/xcattest.rpower.bmcstate.python.out | sort | uniq | wc -l
-check:output=~3
-cmd: grep "timeout" /tmp/xcattest.rpower.bmcstate.python.out | sort | uniq | wc -l
-check:output=~1
-cmd: grep "No route to host" /tmp/xcattest.rpower.bmcstate.python.out | sort | uniq | wc -l
-check:output=~1
-cmd: grep "BMC NotReady" /tmp/xcattest.rpower.bmcstate.python.out | sort | uniq | wc -l
-check:output=~1
-cmd: grep "BMC Ready" /tmp/xcattest.rpower.bmcstate.python.out | sort | uniq | wc -l
-check:output=~1
-cmd: cat /tmp/xcattest.rpower.bmcstate.python.out
-cmd:rm -rf /tmp/xcattest.rpower.bmcstate.perl.out /tmp/xcattest.rpower.bmcstate.python.out
-end

--- a/xCAT-test/autotest/testcase/rspconfig/cases0
+++ b/xCAT-test/autotest/testcase/rspconfig/cases0
@@ -45,7 +45,7 @@ end
 
 start:rspconfig_sshcfg
 hcp:hmc
-label:cn_bmc_ready,hctrl_hmc,hctrl_openbmc
+label:cn_bmc_ready,hctrl_hmc
 cmd:rspconfig __GETNODEATTR($$CN,hcp)__ sshcfg
 check:rc==0
 check:output=~__GETNODEATTR($$CN,hcp)__: \w+
@@ -302,27 +302,41 @@ cmd:mkdir -p /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname
 check:rc == 0
 cmd:lsdef $$CN -z > /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname/$$CN.stanza
 check:rc == 0
-cmd:chdef -t node -o bogus_bmc_hostname groups=bmc ip=__GETNODEATTR($$CN,bmc)__
+cmd:rspconfig $$CN sshcfg
 check:rc == 0
-cmd:lsdef bogus_bmc_hostname
+cmd:ssh __GETNODEATTR($$CN,bmc)__ "hostname" | tee /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname/bmc_old_name
+cmd:chdef -t node -o bogus-bmc-hostname groups=bmc ip=__GETNODEATTR($$CN,bmc)__
 check:rc == 0
-cmd:makehosts bogus_bmc_hostname
+cmd:lsdef bogus-bmc-hostname
 check:rc == 0
-cmd:chdef $$CN bmc=bogus_bmc_hostname
+cmd:makehosts bogus-bmc-hostname
+check:rc == 0
+cmd:makedns bogus-bmc-hostname
+check:rc == 0
+cmd:chdef $$CN bmc=bogus-bmc-hostname
 check:rc == 0
 cmd:lsdef $$CN -i bmc -c
 check:rc == 0
 cmd:rspconfig $$CN hostname=*
 check:rc == 0
-check:output =~$$CN: BMC Hostname: bogus_bmc_hostname
-cmd:makehosts -d bogus_bmc_hostname
+check:output =~$$CN: BMC Hostname: bogus-bmc-hostname
+cmd:ssh __GETNODEATTR(bogus-bmc-hostname,ip)__ "hostname" | tee /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname/bmc_new_name
 check:rc == 0
-cmd:rmdef bogus_bmc_hostname
+cmd:echo "bogus-bmc-hostname" > /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname/bmc_set_name
+cmd:diff -y /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname/bmc_set_name /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname/bmc_new_name
+check:rc == 0
+cmd:makedns -d bogus-bmc-hostname
+check:rc == 0
+cmd:makehosts -d bogus-bmc-hostname
+check:rc == 0
+cmd:rmdef bogus-bmc-hostname
 check:rc == 0
 cmd:rmdef $$CN
 check:rc == 0
 cmd:cat /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname/$$CN.stanza |mkdef -z
 check:rc == 0
+cmd:ip=$(cat /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname/bmc_old_name);ssh  __GETNODEATTR($$CN,bmc)__ "hostname=bogus-bmc-hostname"
+cmd:ssh __GETNODEATTR($$CN,bmc)__ "hostname"
 cmd:rm -rf /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname
 check:rc == 0
 end

--- a/xCAT-test/autotest/testcase/rspconfig/cases1
+++ b/xCAT-test/autotest/testcase/rspconfig/cases1
@@ -145,7 +145,7 @@ check:output =~$$CN:\s*Dump requested
 check:output =~$$CN:\s*Downloading dump
 cmd:rspconfig $$CN dump -l |tail -n 1 |tee /tmp/dumpgenerate
 check:rc == 0
-cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`grep "\[$dumpnumber\] Generated" /tmp/dumpgenerate |cut -d : -f 6`;ls -l /var/log/xcat/dump/*_$$CN_dump_$dumpnumber.tar.xz|grep $dumpsize
+cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`grep "\[$dumpnumber\] Generated" /tmp/dumpgenerate |cut -d : -f 6`;ls -l /var/log/xcat/dump/*_dump_$dumpnumber.tar.xz|grep $dumpsize|grep $$CN
 check:rc == 0
 cmd:rm -rf /tmp/dumpgenerate
 end


### PR DESCRIPTION
### The PR is to fix issue https://github.com/xcat2/xcat2-task-management/issues/343

what modified:
* refine ``rspconfig_set_hostname_equal_star_with_bmc_is_hostname``, ``rspconfig_dump_no_option`` , ``supported_cmds_rvitals`` and ``rflash_delete_active_bmc``.
* change the label of ``rspconfig_sshcfg``
* delete outdated test case ``rpower_bmcreboot_perl_python_output``

### The UT result
```------START::rspconfig_set_hostname_equal_star_with_bmc_is_hostname::Time:Thu Oct 25 02:31:06 2018------

RUN:mkdir -p /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname [Thu Oct 25 02:31:06 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:lsdef f5u14 -z > /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname/f5u14.stanza [Thu Oct 25 02:31:06 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:rspconfig f5u14 sshcfg [Thu Oct 25 02:31:06 2018]
ElapsedTime:4 sec
RETURN rc = 0
OUTPUT:
ssh keys copied to 10.5.14.100
CHECK:rc == 0	[Pass]

RUN:ssh __GETNODEATTR(f5u14,bmc)__ "hostname" | tee /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname/bmc_old_name [Thu Oct 25 02:31:10 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
bogus-bmc-hostname

RUN:chdef -t node -o bogus-bmc-hostname groups=bmc ip=__GETNODEATTR(f5u14,bmc)__ [Thu Oct 25 02:31:12 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
New object definitions 'bogus-bmc-hostname' have been created.
CHECK:rc == 0	[Pass]

RUN:lsdef bogus-bmc-hostname [Thu Oct 25 02:31:13 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Object name: bogus-bmc-hostname
    groups=bmc
    ip=10.5.14.100
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
CHECK:rc == 0	[Pass]

RUN:makehosts bogus-bmc-hostname [Thu Oct 25 02:31:13 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:makedns bogus-bmc-hostname [Thu Oct 25 02:31:14 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
Handling bogus-bmc-hostname in /etc/hosts.
Getting reverse zones, this may take several minutes for a large cluster.
Completed getting reverse zones.
Updating zones.
Completed updating zones.
Updating DNS records, this may take several minutes for a large cluster.
Completed updating DNS records.
DNS setup is completed
CHECK:rc == 0	[Pass]

RUN:chdef f5u14 bmc=bogus-bmc-hostname [Thu Oct 25 02:31:16 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:lsdef f5u14 -i bmc -c [Thu Oct 25 02:31:17 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
f5u14: bmc=bogus-bmc-hostname
CHECK:rc == 0	[Pass]

RUN:rspconfig f5u14 hostname=* [Thu Oct 25 02:31:17 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
Thu Oct 25 02:31:18 2018 f5u14: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.5.14.100/login -d '{"data": ["root", "xxxxxx"]}'
Thu Oct 25 02:31:19 2018 f5u14: [openbmc_debug] login 200 OK
Thu Oct 25 02:31:19 2018 f5u14: [openbmc_debug] set_hostname curl -k -c cjar -b cjar -X PUT -H "Content-Type: application/json" https://10.5.14.100/xyz/openbmc_project/network/config/attr/HostName -d '{"data": "bogus-bmc-hostname"}'
Thu Oct 25 02:31:19 2018 f5u14: [openbmc_debug] set_hostname 200 OK
f5u14: BMC Setting BMC Hostname...
Thu Oct 25 02:31:19 2018 f5u14: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.5.14.100/login -d '{"data": ["root", "xxxxxx"]}'
Thu Oct 25 02:31:19 2018 f5u14: [openbmc_debug] login 200 OK
Thu Oct 25 02:31:19 2018 f5u14: [openbmc_debug] get_netinfo curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://10.5.14.100/xyz/openbmc_project/network/enumerate
Thu Oct 25 02:31:20 2018 f5u14: [openbmc_debug] get_netinfo 200 OK
Thu Oct 25 02:31:20 2018 f5u14: [openbmc_debug] get_netinfo Found LinkLocal address 169.254.234.134 for interface /xyz/openbmc_project/network/eth0, Ignoring...
f5u14: BMC Hostname: bogus-bmc-hostname
CHECK:rc == 0	[Pass]
CHECK:output =~ f5u14: BMC Hostname: bogus-bmc-hostname	[Pass]

RUN:ssh __GETNODEATTR(bogus-bmc-hostname,ip)__ "hostname" | tee /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname/bmc_new_name [Thu Oct 25 02:31:20 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
bogus-bmc-hostname
CHECK:rc == 0	[Pass]

RUN:echo "bogus-bmc-hostname" > /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname/bmc_set_name [Thu Oct 25 02:31:22 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:diff -y /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname/bmc_set_name /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname/bmc_new_name [Thu Oct 25 02:31:22 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
bogus-bmc-hostname						bogus-bmc-hostname
CHECK:rc == 0	[Pass]

RUN:makedns -d bogus-bmc-hostname [Thu Oct 25 02:31:22 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
Handling bogus-bmc-hostname in /etc/hosts.
Getting reverse zones, this may take several minutes for a large cluster.
Completed getting reverse zones.
Updating zones.
Completed updating zones.
Updating DNS records, this may take several minutes for a large cluster.
Completed updating DNS records.
DNS setup is completed
CHECK:rc == 0	[Pass]

RUN:makehosts -d bogus-bmc-hostname [Thu Oct 25 02:31:24 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:rmdef bogus-bmc-hostname [Thu Oct 25 02:31:25 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:rmdef f5u14 [Thu Oct 25 02:31:25 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:cat /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname/f5u14.stanza |mkdef -z [Thu Oct 25 02:31:26 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:ip=$(cat /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname/bmc_old_name);ssh  __GETNODEATTR(f5u14,bmc)__ "hostname=bogus-bmc-hostname" [Thu Oct 25 02:31:27 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:

RUN:ssh __GETNODEATTR(f5u14,bmc)__ "hostname" [Thu Oct 25 02:31:29 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
bogus-bmc-hostname

RUN:rm -rf /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname [Thu Oct 25 02:31:30 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::rspconfig_set_hostname_equal_star_with_bmc_is_hostname::Passed::Time:Thu Oct 25 02:31:30 2018 ::Duration::24 sec------
------Total: 1 , Failed: 0------


------START::rspconfig_dump_no_option::Time:Thu Oct 25 02:56:20 2018------

RUN:rspconfig f5u14 dump [Thu Oct 25 02:56:20 2018]
ElapsedTime:130 sec
RETURN rc = 0
OUTPUT:
.....
f5u14: Dump requested. Target ID is 171, waiting for BMC to generate...
.....
f5u14: Downloaded dump 171 to /var/log/xcat/dump/20181025-0258_f5u14_dump_171.tar.xz.
CHECK:rc == 0	[Pass]
CHECK:output =~ f5u14:\s*Dump requested	[Pass]
CHECK:output =~ f5u14:\s*Downloading dump	[Pass]

RUN:rspconfig f5u14 dump -l |tail -n 1 |tee /tmp/dumpgenerate [Thu Oct 25 02:58:30 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
f5u14: [171] Generated: 10/25/2018 02:56:27, Size: 85272
CHECK:rc == 0	[Pass]

RUN:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`grep "\[$dumpnumber\] Generated" /tmp/dumpgenerate |cut -d : -f 6`;ls -l /var/log/xcat/dump/*_dump_$dumpnumber.tar.xz|grep $dumpsize|grep f5u14 [Thu Oct 25 02:58:32 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
-rw-r--r-- 1 root root 85272 10月 25 02:58 /var/log/xcat/dump/20181025-0258_f5u14_dump_171.tar.xz
CHECK:rc == 0	[Pass]

RUN:rm -rf /tmp/dumpgenerate [Thu Oct 25 02:58:32 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::rspconfig_dump_no_option::Passed::Time:Thu Oct 25 02:58:32 2018 ::Duration::132 sec------
------Total: 1 , Failed: 0------





------START::supported_cmds_rvitals::Time:Thu Oct 25 03:12:22 2018------

RUN:rvitals f5u14 [Thu Oct 25 03:12:22 2018]
....

RUN:rvitals f5u14 leds [Thu Oct 25 03:13:26 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
Thu Oct 25 03:13:27 2018 f5u14: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.5.14.100/login -d '{"data": ["root", "xxxxxx"]}'
Thu Oct 25 03:13:28 2018 f5u14: [openbmc_debug] login 200 OK
Thu Oct 25 03:13:28 2018 f5u14: [openbmc_debug] get_beacon_info curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://10.5.14.100/xyz/openbmc_project/led/physical/enumerate
Thu Oct 25 03:13:29 2018 f5u14: [openbmc_debug] get_beacon_info 200 OK
f5u14: LEDs Fan0: Off
f5u14: LEDs Fan1: Off
f5u14: LEDs Fan2: Off
f5u14: LEDs Fan3: Off
f5u14: LEDs Front Fault: Off
f5u14: LEDs Front Identify: Off
f5u14: LEDs Front Power: On
f5u14: LEDs Rear Fault: Off
f5u14: LEDs Rear Identify: Off
f5u14: LEDs Rear Power: On
CHECK:rc == 0	[Pass]
CHECK:output =~ f5u14: LEDs Front	[Pass]
CHECK:output =~ f5u14: LEDs Fan	[Pass]
CHECK:output =~ f5u14: LEDs Rear	[Pass]

RUN:rvitals f5u14 all [Thu Oct 25 03:13:29 2018]
ElapsedTime:12 sec
RETURN rc = 0
OUTPUT:
....
CHECK:rc == 0	[Pass]
CHECK:output =~ f5u14: Ambient:	[Pass]

------END::supported_cmds_rvitals::Passed::Time:Thu Oct 25 03:13:41 2018 ::Duration::79 sec------
------Total: 1 , Failed: 0------

```