### PR TITLE
nodeset ubuntu16.04.5 x86_64 support

### DIFF
--- a/xCAT-server/lib/xcat/plugins/debian.pm
+++ b/xCAT-server/lib/xcat/plugins/debian.pm
@@ -770,7 +770,7 @@ sub mkinstall {
 
         if ($arch =~ /ppc64/i and !(-e "$pkgdir/install/netboot/initrd.gz") and
             !(-e "$pkgdir/install/netboot/ubuntu-installer/$darch/initrd.gz")) {
-            xCAT::MsgUtils->report_node_error($callback, $node,
+            xCAT::MsgUtils->report_node_error($callback, $node, 
                 "The network boot initrd.gz is not found in $pkgdir/install/netboot.  This is provided by Ubuntu, please download and retry."
                 );
             next;
@@ -788,7 +788,7 @@ sub mkinstall {
                 ($arch =~ /x86/ and
                     (
                         (-r "$pkgdir/install/hwe-netboot/ubuntu-installer/$darch/linux"
-                            and $kernpath = "$pkgdir/hwe-install/netboot/ubuntu-installer/$darch/linux"
+                            and $kernpath = "$pkgdir/install/hwe-netboot/ubuntu-installer/$darch/linux"
                             and -r "$pkgdir/install/hwe-netboot/ubuntu-installer/$darch/initrd.gz"
                             and $initrdpath = "$pkgdir/install/hwe-netboot/ubuntu-installer/$darch/initrd.gz"
                         ) or


### PR DESCRIPTION
### The PR is to fix issue
https://github.com/xcat2/xcat-core/issues/5734
### The modification include

`nodeset` found wrong kernel path

### The UT result
```
]# nodeset c910f04x35v02 osimage=ubuntu16.04.5-x86_64-install-compute
... ...
]# ls /tftpboot/xcat/osimage/ubuntu16.04.5-x86_64-install-compute
initrd.img  vmlinuz
```

