### PR TITLE
localdisk to support user customize the partition table type

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/common/deployment/enable_localdisk.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/deployment/enable_localdisk.rst
@@ -23,17 +23,18 @@ An example ``localdisk`` configuration file: ::
     enablepart=no
 
     [disk]
-    dev=/dev/sdb
-    clear=yes
-    parts=100M-200M,1G-2G
-
-    [disk]
     dev=/dev/sda
     clear=yes
     parts=10,20,30
 
     [disk]
+    dev=/dev/sdb
+    clear=yes
+    parts=100M-200M,1G-2G
+
+    [disk]
     dev=/dev/sdc
+    ptype=gpt
     clear=yes
     parts=10,20,30
 
@@ -53,6 +54,7 @@ The ``[disk]`` section is used to configure how to partition a hard disk:
 
     * dev: The path of the device file.
     * clear: If set to ``yes`` it will clear all the existing partitions on this disk.
+    * ptype: The partition table type of the disk. For example, ``msdos`` or ``gpt``, and ``msdos`` is the default.
     * fstype: The file system type for the new created partitions. ``ext3`` is the default.
     * parts: A comma separated list of space ranges, one for each partition that will be created on the device. The valid format for each space range is ``<startpoint>-<endpoint>`` or ``<percentage of the disk>``. For example, you could set it to ``100M-10G`` or ``50``. If set to ``50``, 50% of the disk space will be assigned to that partition.
 

--- a/xCAT-server/lib/xcat/plugins/getpartition.pm
+++ b/xCAT-server/lib/xcat/plugins/getpartition.pm
@@ -54,7 +54,7 @@ sub process_request
 
     if ($client) { ($client) = noderange($client) }
     unless ($client) {    #Not able to do identify the host in question
-        xCAT::MsgUtils->message("S", "Received syncfiles from $client, which couldn't be correlated to a node (domain mismatch?)");
+        xCAT::MsgUtils->message("S", "Received getpartition from $client, which couldn't be correlated to a node (domain mismatch?)");
         return;
     }
 

--- a/xCAT-server/share/xcat/netboot/add-on/statelite/rc.localdisk
+++ b/xCAT-server/share/xcat/netboot/add-on/statelite/rc.localdisk
@@ -75,9 +75,9 @@ xCATCmd () {
 }
 
 doconfigure () {
-    echo "DEBUG: enable=[$enable]; enablepart=[$enablepart]; disk=[$disk]; localspace=[$localspace]; swapspace=[$swapspace]; dev=[$dev]; parts=[$parts]; clear=[$clear];" >>$LOG
     # run the configure script
     if [ $isscript -eq 1 ]; then
+        echo "DEBUG: localdisk is run in script mode ..." >>$LOG
         # run the script
         chmod +x $SCRIPTFILE
         $SCRIPTFILE
@@ -85,8 +85,10 @@ doconfigure () {
     fi
 
     if [ x"$enable" != x"yes" ]; then
+        echo "WARN: localdisk is not enabled, enable=[$enable]" >>$LOG
         exit 1
     fi
+    echo "DEBUG: enablepart=[$enablepart]; disk=[$disk]; localspace=[$localspace]; swapspace=[$swapspace]; dev=[$dev]; parts=[$parts]; clear=[$clear]; ptype=[$ptype]" >>$LOG
     if [ $disk -eq 1 ]; then
         if [ x"$enablepart" != x"yes" ]; then
             return
@@ -105,7 +107,7 @@ doconfigure () {
         # To recreate the disk label when clear=yes, this action is used to resolve the issue
         # that the disk has been formatted by AIX
         if [ x$clear != x ]; then
-            `parted -s $dev mklabel msdos`
+            `parted -s $dev mklabel $ptype`
         fi
 
         # remove all the partitions on the device
@@ -125,8 +127,8 @@ doconfigure () {
 
                 if [ x$devname = x"$dev" ]; then
                     #create the label
-                    `parted -s $dev mklabel msdos`
-                    echo "parted -s $dev mklabel msdos" >>$LOG
+                    `parted -s $dev mklabel $ptype`
+                    echo "parted -s $dev mklabel $ptype" >>$LOG
                 fi
             fi
         done <  $PARTLOG
@@ -261,15 +263,15 @@ do
         firstline=$LINE
         # the format of first line should be: type=script|format
         key=`echo \$firstline |awk -F= '{print \$1}'`
-        if [ x$key != x"type" ]; then
-            echo "Error: Cannot recognize the format of the parition configuration file." >>$LOG
+        if [ x"$key" != x"type" ]; then
+            echo "Error: Cannot recognize the format of the partition configuration file." >>$LOG
             echo "Error to configure localdisk"
             exit 1
         fi
         value=`echo \$firstline |awk -F= '{print \$2}'`
-        if [ x$value = x"script" ]; then
+        if [ x"$value" = x"script" ]; then
             isscript=1
-        elif [ x$value = x"format" ]; then
+        elif [ x"$value" = x"format" ]; then
             isformat=1
         fi
         continue
@@ -288,6 +290,7 @@ do
             dev=""
             clear=""
             parts=""
+            ptype="msdos"
         elif [ x$LINE = x"[localspace]" ]; then
             doconfigure
             disk=0
@@ -308,6 +311,8 @@ do
                 dev=$value
             elif [ x$key = x"clear" ]; then
                 clear=$value
+            elif [ x$key = x"ptype" ]; then
+                ptype=$value
             elif [ x$key = x"parts" ]; then
                 parts=$value
             elif [ x$key = x"fstype" ]; then


### PR DESCRIPTION
### The PR is to fix issue #5709 

### The modification include

##localdisk to support user customize the partition table type (msdos | gpt)
##some old code issues found during UT for this feature

### The UT result
After patching `/opt/xcat/share/xcat/netboot/add-on/statelite/rc.localdisk`
1, enable localdisk feature to a stateless osimage
```
chdef -t osimage ist.redhat-alt.netboot.DL partitionfile=/install/custom/loaldisk.part

cat /install/custom/loaldisk.part
enable=yes
enablepart=yes

[disk]
dev=/dev/sdb
ptype=gpt
clear=yes
parts=100M-200M,1G-2G

[disk]
dev=/dev/sda
clear=yes
ptype=gpt
parts=10,20,30

[localspace]
dev=/dev/sda1
fstype=ext3

[swapspace]
dev=/dev/sdb2

chtab priority=7.1 policy.commands=getpartition policy.rule=allow

```
2, create image
```
genimage ist.redhat-alt.netboot.DL
packimage ist.redhat-alt.netboot.DL
rinstall mid05tor12cn05 osimage=ist.redhat-alt.netboot.DL
```
3, after it is provisioned,  check the partition table
```
nodestat mid05tor12cn05
mid05tor12cn05: sshd

xdsh mid05tor12cn05 parted -lsm
mid05tor12cn05: BYT;
mid05tor12cn05: /dev/sda:1000GB:scsi:512:4096:gpt:ATA ST1000NX0313:;
mid05tor12cn05: 1:1049kB:100GB:100GB:ext3:primary:;
mid05tor12cn05: 2:100GB:300GB:200GB:ext3:primary:;
mid05tor12cn05: 3:300GB:600GB:300GB:ext3:primary:;
mid05tor12cn05:
mid05tor12cn05: BYT;
mid05tor12cn05: /dev/sdb:1000GB:scsi:512:4096:gpt:ATA ST1000NX0313:;
mid05tor12cn05: 1:99.6MB:200MB:101MB:ext3:primary:;
mid05tor12cn05: 2:1000MB:2000MB:999MB:linux-swap(v1):primary:;
mid05tor12cn05:
[root@briggs01 xcat_clusters]#
```
