### PR TITLE
[go-xcat] Fix command line argument handling bug introduced by previous commits

### DIFF
--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -2,7 +2,7 @@
 #
 # go-xcat - Install xCAT automatically.
 #
-# Version 1.0.30
+# Version 1.0.32
 #
 # Copyright (C) 2016, 2017, 2018 International Business Machines
 # Eclipse Public License, Version 1.0 (EPL-1.0)
@@ -1868,7 +1868,7 @@ do
 		verbose_usage
 		exit 0
 		;;
-	"-x"|"--xcat-core")
+	"--xcat-core")
 		shift
 		GO_XCAT_CORE_URL="$1"
 		;;
@@ -1882,7 +1882,7 @@ do
 	"--xcat-dep="*)
 		GO_XCAT_DEP_URL="${1##--xcat-dep=}"
 		;;
-	"--xcat-version")
+	"-x"|"--xcat-version")
 		shift
 		GO_XCAT_VERSION="$1"
 		;;


### PR DESCRIPTION
### The PR is to fix a bug introduces by pull request #5674

#### The modification include

 Handle `-x` command line argument properly.


#### The UT result
```
# ./go-xcat -x 2.13 install
Operating system:   linux
Architecture:       ppc64le
Linux Distribution: rhel
Version:            7.5
go-xcat Version:    1.0.32


Reading repositories ...... done

xCAT is going to be installed.
Continue? [y/n] y
Loaded plugins: product-id, search-disabled-repos, subscription-manager
This system is not registered with an entitlement server. You can use subscription-manager to register.
Resolving Dependencies
--> Running transaction check
---> Package conserver-xcat.ppc64le 0:8.2.1-1 will be installed
---> Package elilo-xcat.noarch 0:3.14-4 will be installed
---> Package grub2-xcat.noarch 0:2.02-0.16.el7.snap201506090204 will be installed
---> Package ipmitool-xcat.ppc64le 0:1.8.18-0 will be installed
---> Package perl-xCAT.noarch 4:2.13.11-snap201803130745 will be installed
---> Package syslinux-xcat.noarch 0:3.86-2 will be installed
---> Package xCAT.ppc64le 0:2.13.11-snap201803130745 will be installed
--> Processing Dependency: xCAT-probe = 4:2.13.11-snap201803130745 for package: xCAT-2.13.11-snap201803130745.ppc64le
--> Processing Dependency: goconserver for package: xCAT-2.13.11-snap201803130745.ppc64le
---> Package xCAT-buildkit.noarch 4:2.13.11-snap201803130745 will be installed
---> Package xCAT-client.noarch 4:2.13.11-snap201803130745 will be installed
---> Package xCAT-genesis-base-ppc64.noarch 2:2.13.10-snap201801170133 will be installed
---> Package xCAT-genesis-base-x86_64.noarch 2:2.13.10-snap201801170129 will be installed
---> Package xCAT-genesis-scripts-ppc64.noarch 1:2.13.11-snap201803130745 will be installed
---> Package xCAT-genesis-scripts-x86_64.noarch 1:2.13.11-snap201803130745 will be installed
---> Package xCAT-server.noarch 4:2.13.11-snap201803130745 will be installed
---> Package xnba-undi.noarch 0:1.0.3-131028 will be installed
---> Package yaboot-xcat.noarch 0:1.3.17-rc1 will be installed
--> Running transaction check
---> Package goconserver.ppc64le 0:0.2.1-snap201803020124 will be installed
---> Package xCAT-probe.noarch 4:2.13.11-snap201803130745 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package                     Arch    Version                    Repository
                                                                           Size
================================================================================
Installing:
 conserver-xcat              ppc64le 8.2.1-1                    xcat-dep  184 k
 elilo-xcat                  noarch  3.14-4                     xcat-dep   75 k
 grub2-xcat                  noarch  2.02-0.16.el7.snap201506090204
                                                                xcat-dep  1.9 M
 ipmitool-xcat               ppc64le 1.8.18-0                   xcat-dep  294 k
 perl-xCAT                   noarch  4:2.13.11-snap201803130745 xcat-core 662 k
 syslinux-xcat               noarch  3.86-2                     xcat-dep  498 k
 xCAT                        ppc64le 2.13.11-snap201803130745   xcat-core 239 k
 xCAT-buildkit               noarch  4:2.13.11-snap201803130745 xcat-core  67 k
 xCAT-client                 noarch  4:2.13.11-snap201803130745 xcat-core 519 k
 xCAT-genesis-base-ppc64     noarch  2:2.13.10-snap201801170133 xcat-dep   91 M
 xCAT-genesis-base-x86_64    noarch  2:2.13.10-snap201801170129 xcat-dep   87 M
 xCAT-genesis-scripts-ppc64  noarch  1:2.13.11-snap201803130745 xcat-core  59 k
 xCAT-genesis-scripts-x86_64 noarch  1:2.13.11-snap201803130745 xcat-core  59 k
 xCAT-server                 noarch  4:2.13.11-snap201803130745 xcat-core 1.8 M
 xnba-undi                   noarch  1.0.3-131028               xcat-dep  151 k
 yaboot-xcat                 noarch  1.3.17-rc1                 xcat-dep   97 k
Installing for dependencies:
 goconserver                 ppc64le 0.2.1-snap201803020124     xcat-dep  4.9 M
 xCAT-probe                  noarch  4:2.13.11-snap201803130745 xcat-core  87 k

Transaction Summary
================================================================================
Install  16 Packages (+2 Dependent packages)

Total size: 189 M
Total download size: 183 M
Installed size: 674 M
Downloading packages:
No Presto metadata available for xcat-dep
--------------------------------------------------------------------------------
Total                                               24 MB/s | 183 MB  00:07
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : 2:xCAT-genesis-base-x86_64-2.13.10-snap201801170129.noar    1/18
  Installing : 1:xCAT-genesis-scripts-x86_64-2.13.11-snap201803130745.n    2/18
If you are installing/updating xCAT-genesis-base separately, not as part of installing/updating all of xCAT, run 'mknb <arch>' manually
  Installing : grub2-xcat-2.02-0.16.el7.snap201506090204.noarch            3/18
  Installing : 4:xCAT-client-2.13.11-snap201803130745.noarch               4/18
  Installing : 4:perl-xCAT-2.13.11-snap201803130745.noarch                 5/18
  Installing : 4:xCAT-server-2.13.11-snap201803130745.noarch               6/18
  Installing : 4:xCAT-probe-2.13.11-snap201803130745.noarch                7/18
  Installing : xnba-undi-1.0.3-131028.noarch                               8/18
  Installing : conserver-xcat-8.2.1-1.ppc64le                              9/18
  Installing : syslinux-xcat-3.86-2.noarch                                10/18
  Installing : ipmitool-xcat-1.8.18-0.ppc64le                             11/18
  Installing : 4:xCAT-buildkit-2.13.11-snap201803130745.noarch            12/18
  Installing : goconserver-0.2.1-snap201803020124.ppc64le                 13/18
  Installing : 2:xCAT-genesis-base-ppc64-2.13.10-snap201801170133.noarc   14/18
  Installing : 1:xCAT-genesis-scripts-ppc64-2.13.11-snap201803130745.no   15/18
If you are installing/updating xCAT-genesis-base separately, not as part of installing/updating all of xCAT, run 'mknb <arch>' manually
  Installing : elilo-xcat-3.14-4.noarch                                   16/18
  Installing : xCAT-2.13.11-snap201803130745.ppc64le                      17/18
Generating new node hostkeys...
Generating SSH2 RSA Key...
Generating SSH2 DSA Key...
Generating SSH2 ECDSA Key...
Copied /root/.ssh/id_rsa.pub to /install/postscripts/_ssh/authorized_keys.
Restarting xcatd (via systemctl):  [  OK  ]
dns server has been enabled on boot.
httpd has been restarted.
xCAT is now running, it is recommended to tabedit networks
and set a dynamic ip address range on any networks where nodes
are to be discovered. Then, run makedhcp -n to create a new dhcpd
configuration file, and /etc/init.d/dhcpd restart. Either examine sample
configuration templates, or write your own, or specify a value per
node with nodeadd or tabedit.
Running '/opt/xcat/sbin/mknb', triggered by the installation/update of xCAT-genesis-scripts ...
Creating genesis.fs.ppc64.gz in /tftpboot/xcat
The 'mknb ppc64' command completed successfully.
Creating genesis.fs.x86_64.gz in /tftpboot/xcat
The 'mknb x86_64' command completed successfully.
  Installing : yaboot-xcat-1.3.17-rc1.noarch                              18/18
  Verifying  : elilo-xcat-3.14-4.noarch                                    1/18
  Verifying  : 2:xCAT-genesis-base-ppc64-2.13.10-snap201801170133.noarc    2/18
  Verifying  : goconserver-0.2.1-snap201803020124.ppc64le                  3/18
  Verifying  : 4:xCAT-server-2.13.11-snap201803130745.noarch               4/18
  Verifying  : xCAT-2.13.11-snap201803130745.ppc64le                       5/18
  Verifying  : 4:perl-xCAT-2.13.11-snap201803130745.noarch                 6/18
  Verifying  : 4:xCAT-probe-2.13.11-snap201803130745.noarch                7/18
  Verifying  : yaboot-xcat-1.3.17-rc1.noarch                               8/18
  Verifying  : 4:xCAT-buildkit-2.13.11-snap201803130745.noarch             9/18
  Verifying  : ipmitool-xcat-1.8.18-0.ppc64le                             10/18
  Verifying  : syslinux-xcat-3.86-2.noarch                                11/18
  Verifying  : conserver-xcat-8.2.1-1.ppc64le                             12/18
  Verifying  : 1:xCAT-genesis-scripts-ppc64-2.13.11-snap201803130745.no   13/18
  Verifying  : xnba-undi-1.0.3-131028.noarch                              14/18
  Verifying  : grub2-xcat-2.02-0.16.el7.snap201506090204.noarch           15/18
  Verifying  : 1:xCAT-genesis-scripts-x86_64-2.13.11-snap201803130745.n   16/18
  Verifying  : 4:xCAT-client-2.13.11-snap201803130745.noarch              17/18
  Verifying  : 2:xCAT-genesis-base-x86_64-2.13.10-snap201801170129.noar   18/18

Installed:
  conserver-xcat.ppc64le 0:8.2.1-1
  elilo-xcat.noarch 0:3.14-4
  grub2-xcat.noarch 0:2.02-0.16.el7.snap201506090204
  ipmitool-xcat.ppc64le 0:1.8.18-0
  perl-xCAT.noarch 4:2.13.11-snap201803130745
  syslinux-xcat.noarch 0:3.86-2
  xCAT.ppc64le 0:2.13.11-snap201803130745
  xCAT-buildkit.noarch 4:2.13.11-snap201803130745
  xCAT-client.noarch 4:2.13.11-snap201803130745
  xCAT-genesis-base-ppc64.noarch 2:2.13.10-snap201801170133
  xCAT-genesis-base-x86_64.noarch 2:2.13.10-snap201801170129
  xCAT-genesis-scripts-ppc64.noarch 1:2.13.11-snap201803130745
  xCAT-genesis-scripts-x86_64.noarch 1:2.13.11-snap201803130745
  xCAT-server.noarch 4:2.13.11-snap201803130745
  xnba-undi.noarch 0:1.0.3-131028
  yaboot-xcat.noarch 0:1.3.17-rc1

Dependency Installed:
  goconserver.ppc64le 0:0.2.1-snap201803020124
  xCAT-probe.noarch 4:2.13.11-snap201803130745

Complete!

xCAT has been installed!
========================

If this is the very first time xCAT has been installed, run one of the
following commands to set the environment variables.

For sh:
    source /etc/profile.d/xcat.sh

For csh:
    source /etc/profile.d/xcat.csh
```