### PR TITLE
xCAT-genesis-builder - avoid remove symbolic link as directory

### DIFF
--- a/xCAT-genesis-builder/xCAT-genesis-base.spec
+++ b/xCAT-genesis-builder/xCAT-genesis-base.spec
@@ -112,11 +112,16 @@ local function remove_directory_deep(directory)
 
     -- print(directory)
 
-    num_dirs, num_files = remove_directory(directory, 0, '')
+    local info = assert(posix.stat(directory))
+    if info.type == 'directory' then
+        num_dirs, num_files = remove_directory(directory, 0, '')
 
-    -- printf('\ndropped %d directories, %d files\n', num_dirs, num_files)
+        -- printf('\ndropped %d directories, %d files\n', num_dirs, num_files)
 
-    posix.rmdir(directory)
+        posix.rmdir(directory)
+    else
+        posix.unlink(directory)
+    end
 end
 
 remove_directory_deep("/opt/xcat/share/xcat/netboot/genesis/%{tarch}/fs/bin")

--- a/xCAT-genesis-builder/xCAT-genesis-base.spec
+++ b/xCAT-genesis-builder/xCAT-genesis-base.spec
@@ -89,7 +89,7 @@ local function remove_directory(directory, level, prefix)
                 posix.unlink(full_name)
             end
 
-             -- printf('%s%s%s%s\n', prefix, prefix2, name, link)
+            -- printf('%s%s%s%s\n', prefix, prefix2, name, link)
 
             if info.type == 'directory' then
                 local indent = is_tail and tail_leaf_indent or leaf_indent
@@ -132,13 +132,13 @@ remove_directory_deep("/opt/xcat/share/xcat/netboot/genesis/%{tarch}/fs/var/run"
 
 %post
 if [ "$1" == "2" ]; then #only on upgrade, as on install it's probably not going to work...
-	if [ -f "/proc/cmdline" ]; then   # prevent running it during install into chroot image
-   		. /etc/profile.d/xcat.sh
-   		#mknb %{tarch}
+    if [ -f "/proc/cmdline" ]; then   # prevent running it during install into chroot image
+        . /etc/profile.d/xcat.sh
+        #mknb %{tarch}
         echo "If you are installing/updating xCAT-genesis-base separately, not as part of installing/updating all of xCAT, run 'mknb <arch>' manually"
         mkdir -p /etc/xcat
         touch /etc/xcat/genesis-base-updated
-   	fi
+    fi
 fi
 
 %Files


### PR DESCRIPTION
### The PR is to fix issue _#5740_

### The modification include

_Avoid remove symbolic link as directory_

### The UT result
```
# /opt/xcat/share/xcat/netboot/genesis/builder/buildrpm
/root
cp: omitting directory ‘/opt/xcat/share/xcat/netboot/genesis/builder/debian’
Creating the initramfs in /tmp/xcatgenesis.932.rfs using dracut ...

Expanding the initramfs into /tmp/xcatgenesis.932/opt/xcat/share/xcat/netboot/genesis/ppc64/fs ...
709973 blocks
Adding perl libary /usr/share/perl5
Adding perl libary /usr/lib64/perl5
Adding perl libary /usr/local/share/perl5
Adding kernel /boot/vmlinuz-ppc64 ...
/root
Tarring /tmp/xcatgenesis.932/opt into /root/rpmbuild/SOURCES/xCAT-genesis-base-ppc64.tar.bz2 ...
Building xCAT-genesis-base rpm from /root/rpmbuild/SOURCES/xCAT-genesis-base-ppc64.tar.bz2 and /opt/xcat/share/xcat/netboot/genesis/builder/xCAT-genesis-base.spec ...
Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.THbyZ7
+ umask 022
+ cd /root/rpmbuild/BUILD
+ exit 0
Executing(%build): /bin/sh -e /var/tmp/rpm-tmp.zLrLv6
+ umask 022
+ cd /root/rpmbuild/BUILD
+ exit 0
Executing(%install): /bin/sh -e /var/tmp/rpm-tmp.5RRp44
+ umask 022
+ cd /root/rpmbuild/BUILD
+ '[' /root/rpmbuild/BUILDROOT/xCAT-genesis-base-ppc64-2.14-snap201810290350.ppc64le '!=' / ']'
+ rm -rf /root/rpmbuild/BUILDROOT/xCAT-genesis-base-ppc64-2.14-snap201810290350.ppc64le
++ dirname /root/rpmbuild/BUILDROOT/xCAT-genesis-base-ppc64-2.14-snap201810290350.ppc64le
+ mkdir -p /root/rpmbuild/BUILDROOT
+ mkdir /root/rpmbuild/BUILDROOT/xCAT-genesis-base-ppc64-2.14-snap201810290350.ppc64le
+ rm -rf /root/rpmbuild/BUILDROOT/xCAT-genesis-base-ppc64-2.14-snap201810290350.ppc64le
+ mkdir -p /root/rpmbuild/BUILDROOT/xCAT-genesis-base-ppc64-2.14-snap201810290350.ppc64le
+ cd /root/rpmbuild/BUILDROOT/xCAT-genesis-base-ppc64-2.14-snap201810290350.ppc64le
+ tar jxf /root/rpmbuild/SOURCES/xCAT-genesis-base-ppc64.tar.bz2
+ cd -
/root/rpmbuild/BUILD
+ :
Processing files: xCAT-genesis-base-ppc64-2.14-snap201810290350.noarch
Provides: xCAT-genesis-base-ppc64 = 3:2.14-snap201810290350
Requires(interp): /bin/sh
Requires(rpmlib): rpmlib(BuiltinLuaScripts) <= 4.2.2-1 rpmlib(PartialHardlinkSets) <= 4.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1 rpmlib(CompressedFileNames) <= 3.0.4-1
Requires(post): /bin/sh
Conflicts: xCAT-genesis-scripts-ppc64 < 1:2.13.10
Checking for unpackaged file(s): /usr/lib/rpm/check-files /root/rpmbuild/BUILDROOT/xCAT-genesis-base-ppc64-2.14-snap201810290350.ppc64le
Wrote: /root/rpmbuild/SRPMS/xCAT-genesis-base-ppc64-2.14-snap201810290350.src.rpm
Wrote: /root/rpmbuild/RPMS/noarch/xCAT-genesis-base-ppc64-2.14-snap201810290350.noarch.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.VmdCH5
+ umask 022
+ cd /root/rpmbuild/BUILD
+ /usr/bin/rm -rf /root/rpmbuild/BUILDROOT/xCAT-genesis-base-ppc64-2.14-snap201810290350.ppc64le
+ exit 0
[root@c910f03c17k04 ~]# rpm -Uvh --force /root/rpmbuild/RPMS/noarch/xCAT-genesis-base-ppc64-2.14-snap201810290350.noarch.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:xCAT-genesis-base-ppc64-3:2.14-sn################################# [ 50%]
If you are installing/updating xCAT-genesis-base separately, not as part of installing/updating all of xCAT, run 'mknb <arch>' manually
Cleaning up / removing...
   2:xCAT-genesis-base-ppc64-3:2.14-sn################################# [100%]
# rpm -V xCAT-genesis-scripts-ppc64
# echo $?
0
```