### PR TITLE
log tag support for servicenode and fix updatenode failed test cases

### DIFF
--- a/xCAT/postscripts/otherpkgs
+++ b/xCAT/postscripts/otherpkgs
@@ -232,7 +232,7 @@ if [ -z "$UPDATENODE" ] || [ $UPDATENODE -ne 1 ]; then
 fi
 
 if [ -z "$OTHERPKGS_INDEX" ]; then
-  echo "$0: no extra rpms to install"
+  echo "$(basename $0): no extra rpms to install"
   exit 0
 fi
 

--- a/xCAT/postscripts/servicenode
+++ b/xCAT/postscripts/servicenode
@@ -62,6 +62,10 @@ my $msg = "";
 $::osname = `uname`;
 chomp $::osname;
 
+my $log_label=$ENV{'LOGLABEL'};
+if (!$log_label) {
+    $log_label="xcat"
+}
 $::sdate = `/bin/date`;
 chomp $::sdate;
 
@@ -91,8 +95,8 @@ if ($ENV{UPDATESECURITY} && $ENV{UPDATESECURITY} eq "1") {
     my $mounted = xCAT::Utils->isMounted($installdir);
     if ($mounted == 0) {    # not mounted
         if (&runcmd("mkdir -p $installdir/postscripts; cp -p -R /xcatpost/* $installdir/postscripts > /dev/null 2>&1") != 0) {
-            $msg = "$::sdate servicenode: Could not copy postscripts to $installdir/postscripts.\n";
-            `logger -t xcat -p local4.warning $msg`;
+            $msg = "servicenode: Could not copy postscripts to $installdir/postscripts.\n";
+            `logger -t $log_label -p local4.warning $msg`;
         }
     }
 
@@ -104,9 +108,9 @@ if ($ENV{UPDATESECURITY} && $ENV{UPDATESECURITY} eq "1") {
         &getcreds;
     } else {    # Linux
          # call xcatserver,xcatclient to transfer the SSL credentials and cfgloc
-        `logger -t xcat -p local4.info $::sdate servicenode: running 'xcatserver -d'`;
+        `logger -t $log_label -p local4.info servicenode: running 'xcatserver -d'`;
         &runcmd("xcatserver -d");
-        `logger -t xcat -p local4.info $::sdate servicenode: running 'xcatclient -d'`;
+        `logger -t $log_label -p local4.info servicenode: running 'xcatclient -d'`;
         &runcmd("xcatclient -d");
     }
 
@@ -120,10 +124,10 @@ if ($::osname eq 'AIX')
     # AIX service node setup
     $rc = &setupAIXsn;
     if ($rc != 0) {
-        my $msg = "$::sdate  servicenode: One or more errors occurred when attempting to configure node $::hname as an xCAT service node.\n";
+        my $msg = "servicenode: One or more errors occurred when attempting to configure node $::hname as an xCAT service node.\n";
 
         #		print "$msg\n";
-        `logger -t xcat -p local4.warning $msg`;
+        `logger -t $log_label -p local4.warning $msg`;
     }
 }
 else
@@ -132,21 +136,21 @@ else
     #  remove OpenIPMI-tools
     #  install xcat from /install/xcat
     #  Copy Certificates, and config file to apprpriate directories
-    #  from /install and restart xcatd
+    #  from /install and restart xcat
     &runcmd("rpm -e OpenIPMI-tools");
 
     &copycerts;
 
-    `logger -t xcat -p local4.info $::sdate servicenode: running 'xcatserver -d'`;
+    `logger -t $log_label -p local4.info servicenode: running 'xcatserver -d'`;
     &runcmd("xcatserver -d");
-    `logger -t xcat -p local4.info $::sdate servicenode: running 'xcatclient -d'`;
+    `logger -t $log_label -p local4.info servicenode: running 'xcatclient -d'`;
     &runcmd("xcatclient -d");
-    # start xcatd if it is not up when stateless or statelite
+    # start xcat if it is not up when stateless or statelite
     if ($ENV{NODESETSTATE} && ($ENV{NODESETSTATE} eq "netboot" || $ENV{NODESETSTATE} eq "statelite")) {
         $rc = &runcmd("$::XCATROOT/bin/lsxcatd -v 2>/dev/null || service xcatd restart");
         if ($rc != 0) {
-            $msg = "$::sdate servicenode: Could not start xcatd.\n\n $::outref \n";
-            `logger -t xcat -p local4.warning $msg`;
+            $msg = " servicenode: Could not start xcat.\n\n $::outref \n";
+            `logger -t $log_label -p local4.warning $msg`;
         }
     }
 }
@@ -175,8 +179,8 @@ sub runcmd
         $rc = $? >> 8;
         if ($rc > 0)
         {
-            my $msg = "$::sdate servicenode: $cmd returned rc=$rc \n";
-            `logger -t xcat -p local4.info  $msg`;
+            my $msg = "servicenode: $cmd returned rc=$rc \n";
+            `logger -t $log_label -p local4.info  $msg`;
             return 1;
         }
     }
@@ -193,14 +197,14 @@ sub setupAIXsn
 
     # makes it a service node
     if (&runcmd("touch /etc/xCATSN") != 0) {
-        $msg = "$::sdate servicenode: Could not touch /etc/xCATSN\n";
-        `logger -t xcat -p local4.warning $msg`;
+        $msg = "servicenode: Could not touch /etc/xCATSN\n";
+        `logger -t $log_label -p local4.warning $msg`;
     }
 
     # copy the postscripts to /install/postscripts
     if (&runcmd("mkdir -p $installdir/postscripts; cp -p -R /xcatpost/* $installdir/postscripts > /dev/null 2>&1") != 0) {
-        $msg = "$::sdate servicenode: Could not copy postscripts to $installdir/postscripts.\n";
-        `logger -t xcat -p local4.warning $msg`;
+        $msg = "servicenode: Could not copy postscripts to $installdir/postscripts.\n";
+        `logger -t $log_label -p local4.warning $msg`;
     }
 
     # check if /install/postscripts is in /etc/exports
@@ -218,16 +222,16 @@ sub setupAIXsn
         }
         if ($res != 0)
         {
-            $msg = "$::sdate servicenode: Could not update the /etc/exports file.\n";
-            `logger -t xcat -p local4.warning  $msg`;
+            $msg = "servicenode: Could not update the /etc/exports file.\n";
+            `logger -t $log_label -p local4.warning  $msg`;
         }
     }
 
     # make sure we don't have xCATMN file
     if (-f "/etc/xCATMN") {
         if (&runcmd("rm  /etc/xCATMN") != 0) {
-            $msg = "$::sdate servicenode: Could not remove /etc/xCATMN\n";
-            `logger -t xcat -p local4.warning $msg`;
+            $msg = "servicenode: Could not remove /etc/xCATMN\n";
+            `logger -t $log_label -p local4.warning $msg`;
         }
     }
 
@@ -241,14 +245,14 @@ sub setupAIXsn
     my $mkssys_cmd = "mkssys -p $::XCATROOT/sbin/xcatd -s xcatd -u 0 -S -n 15 -f 15 -a '-f' ";
 
     if (&runcmd($mkssys_cmd) != 0) {
-        $msg = "$::sdate servicenode: Could not create subsystem for xcatd. It maybe already have been added.\n";
-        `logger -t xcat -p local4.warning $msg`;
+        $msg = "servicenode: Could not create subsystem for xcatd. It maybe already have been added.\n";
+        `logger -t $log_label -p local4.warning $msg`;
     }
 
     # start xcatd
     if (&runcmd("$::XCATROOT/sbin/restartxcatd") != 0) {
-        $msg = "$::sdate servicenode: Could not start xcatd.\n\n $::outref \n";
-        `logger -t xcat -p local4.warning  $msg`;
+        $msg = "servicenode: Could not start xcat.\n\n $::outref \n";
+        `logger -t $log_label -p local4.warning  $msg`;
     }
 
     # add xcatd to /etc/inittab???
@@ -259,31 +263,31 @@ sub setupAIXsn
         # error might just mean that the entry is already there!
 
         #	$msg = "$::sdate servicenode: Could not add xcatd to /etc/inittab.\n";
-        #    `logger -t xcat $msg`;
+        #    `logger -t $log_label $msg`;
     }
 
     # set ulimit - so we can copy over large files - like spot
     if (&runcmd("/usr/bin/chuser fsize=-1 root") != 0) {
-        $msg = "$::sdate servicenode: Could not change ulimit\n";
-        `logger -t xcat -p local4.warning $msg`;
+        $msg = "servicenode: Could not change ulimit\n";
+        `logger -t $log_label -p local4.warning $msg`;
     }
 
     # stop inetd, make sure bootp & tftp are in /etc/inetd.conf and restart
     if (&runcmd("stopsrc -s inetd") != 0) {
-        $msg = "$::sdate servicenode: Could not stop inetd.\n";
-        `logger -t xcat -p local4.warning  $msg`;
+        $msg = "servicenode: Could not stop inetd.\n";
+        `logger -t $log_label -p local4.warning  $msg`;
     }
 
     my $tmp_inetd_file = "/etc/inetd.conf.tmp";
     unless (open(TMPINETD, ">>$tmp_inetd_file")) {
-        $msg = "$::sdate servicenode: Could not open $tmp_inetd_file.\n";
-        `logger -t xcat  -p local4.warning  $msg`;
+        $msg = "servicenode: Could not open $tmp_inetd_file.\n";
+        `logger -t $log_label  -p local4.warning  $msg`;
     }
 
     my $inetd_file_name = "/etc/inetd.conf";
     unless (open(INETDFILE, "<$inetd_file_name")) {
-        $msg = "$::sdate servicenode: Could not open $inetd_file_name.\n";
-        `logger -t xcat  -p local4.warning $msg`;
+        $msg = "servicenode: Could not open $inetd_file_name.\n";
+        `logger -t $log_label  -p local4.warning $msg`;
     }
 
     while (my $l = <INETDFILE>) {
@@ -299,19 +303,19 @@ sub setupAIXsn
     close(INETDFILE);
 
     if (&runcmd("mv $tmp_inetd_file $inetd_file_name > /dev/null 2>&1") != 0) {
-        $msg = "$::sdate servicenode: Could not update /etc/inetd.conf.\n";
-        `logger -t xcat  -p local4.warning $msg`;
+        $msg = "servicenode: Could not update /etc/inetd.conf.\n";
+        `logger -t $log_label  -p local4.warning $msg`;
     }
 
     if (&runcmd("startsrc -s inetd") != 0) {
-        $msg = "$::sdate servicenode: Could not restart inetd.\n";
-        `logger -t xcat  -p local4.warning $msg`;
+        $msg = "servicenode: Could not restart inetd.\n";
+        `logger -t $log_label  -p local4.warning $msg`;
     }
 
     # do nim master setup - master fileset already installed
     if (&runcmd("/usr/sbin/nim_master_setup -a mk_resource=no") != 0) {
-        $msg = "$::sdate servicenode: Could not run nim_master_setup.\n";
-        `logger -t xcat  -p local4.warning  $msg`;
+        $msg = "servicenode: Could not run nim_master_setup.\n";
+        `logger -t $log_label  -p local4.warning  $msg`;
     }
 
     #
@@ -321,8 +325,8 @@ sub setupAIXsn
 
     # restore the original .rhosts that was removed by NIM setup
     if (&runcmd("cp /.rhosts.prev /.rhosts ") != 0) {
-        $msg = "$::sdate servicenode: Could not restore the .rhosts file.\n";
-        `logger -t xcat  -p local4.warning $msg`;
+        $msg = "servicenode: Could not restore the .rhosts file.\n";
+        `logger -t $log_label  -p local4.warning $msg`;
     }
 
     return 0;
@@ -352,8 +356,8 @@ sub getcreds
         &runcmd($cmd);
     }
     else {
-        $msg = "$::sdate servicenode: Could not get client-cred.pem file.\n";
-        `logger -t xcat  -p local4.warning $msg`;
+        $msg = "servicenode: Could not get client-cred.pem file.\n";
+        `logger -t $log_label  -p local4.warning $msg`;
     }
 
     $response = &getresponse("xcat_server_cred");
@@ -370,8 +374,8 @@ sub getcreds
         &runcmd($cmd);
     }
     else {
-        $msg = "$::sdate servicenode: Could not get server-cred.pem file.\n";
-        `logger -t xcat  -p local4.warning $msg`;
+        $msg = "servicenode: Could not get server-cred.pem file.\n";
+        `logger -t $log_label  -p local4.warning $msg`;
     }
 
     $response = &getresponse("xcat_cfgloc");
@@ -401,8 +405,8 @@ sub getcreds
         &runcmd($cmd);
     }
     else {
-        $msg = "$::sdate servicenode: Could not get cfgloc file.\n";
-        `logger -t xcat  -p local4.warning  $msg`;
+        $msg = "servicenode: Could not get cfgloc file.\n";
+        `logger -t $log_label  -p local4.warning  $msg`;
     }
 
     return 0;
@@ -450,8 +454,8 @@ sub getresponse
     }
 
     unless ($sock) {
-        my $msg = "$::sdate servicenode:  Cannot connect to host \'$::servnode\'\n";
-        `logger -t xcat  -p local4.err $msg`;
+        my $msg = "servicenode:  Cannot connect to host \'$::servnode\'\n";
+        `logger -t $log_label  -p local4.err $msg`;
         print $msg;
         return undef;
     }
@@ -507,8 +511,8 @@ sub openlistener
     unless (defined $pid) {
 
         # fork failed
-        $msg = "$::sdate servicenode:  Could not fork process.\n";
-        `logger -t xcat  -p local4.err $msg`;
+        $msg = "servicenode:  Could not fork process.\n";
+        `logger -t $log_label  -p local4.err $msg`;
 
         #print $msg;
         return undef;
@@ -528,8 +532,8 @@ sub openlistener
     );
 
     unless ($listener) {
-        my $msg = "$::sdate servicenode:  Cannot open socket on \'$node\'\n";
-        `logger -t xcat  -p local4.err  $msg`;
+        my $msg = "servicenode:  Cannot open socket on \'$node\'\n";
+        `logger -t $log_label  -p local4.err  $msg`;
         print $msg;
         exit 1;
     }
@@ -583,8 +587,8 @@ sub copycerts
     }
     else
     {
-        $msg = "$::sdate servicenode: /xcatpost/_xcat directory does not exist\n";
-        `logger -t xcat  -p local4.warning $msg`;
+        $msg = "servicenode: /xcatpost/_xcat directory does not exist\n";
+        `logger -t $log_label  -p local4.warning $msg`;
 
     }
     if (-d "/xcatpost/ca")
@@ -602,8 +606,8 @@ sub copycerts
     }
     else
     {
-        $msg = "$::sdate servicenode: /xcatpost/ca directory does not exist\n";
-        `logger -t xcat  -p local4.warning $msg`;
+        $msg = "servicenode: /xcatpost/ca directory does not exist\n";
+        `logger -t $log_label  -p local4.warning $msg`;
 
     }
 
@@ -624,8 +628,8 @@ sub copycerts
         }
         else
         {
-            $msg = "$::sdate servicenode: /xcatpost/_xcat directory does not exist\n";
-            `logger -t xcat  -p local4.warning $msg`;
+            $msg = "servicenode: /xcatpost/_xcat directory does not exist\n";
+            `logger -t $log_label  -p local4.warning $msg`;
         }
     }
     return $rc;

--- a/xCAT/postscripts/xcatdsklspost
+++ b/xCAT/postscripts/xcatdsklspost
@@ -994,6 +994,7 @@ fi
 
 #tell user it is done when this is called by updatenode command
 if [ "$MODE" = "1" ] || [ "$MODE" = "2" ] || [ "$MODE" = "5" ]; then
+  echo "returned from postscript"
   echolog "info" "=============updatenode ending===================="
 fi
 


### PR DESCRIPTION
### The PR is for task 
https://github.com/xcat2/xcat2-task-management/issues/354
https://github.com/xcat2/xcat-core/issues/5745
_##Feature description##_
1. support log tag for servicenode
2. fix updatenode failed test cases
`updatenode_without_flag`
`updatenode_diskful_syncfiles_P_script1`

### The UT result
1. servicenode log tag support format exemple:
old format:
```
Oct 30 23:18:11 byrh10 xcat.updatenode.postscript: INFO  postscript start..: servicenode
Oct 30 23:18:11 byrh10 xcat.updatenode.postscript: INFO  Tue Oct 30 23:45:04 EDT 2018 servicenode: running xcatserver -d
Oct 30 23:20:57 byrh10 xcat.updatenode.postscript: INFO  Tue Oct 30 23:45:04 EDT 2018 servicenode: running xcatclient -d
Oct 30 23:20:58 byrh10 xcat.updatenode.postscript: INFO  postscript end...:servicenode return with 0
```
new format:
```
Oct 30 23:29:41 byrh10 xcat.updatenode.postscript: INFO  postscript start..: servicenode
Oct 30 23:29:41 byrh10 xcat.updatenode.postscript: INFO  servicenode: running xcatserver -d
Oct 30 23:32:05 byrh10 xcat.updatenode.postscript: INFO  servicenode: running xcatclient -d
Oct 30 23:32:06 byrh10 xcat.updatenode.postscript: INFO  postscript end...:servicenode return with 0
```
2.  `updatenode_without_flag` and `otherpkgs` new output:
```
c910f02c01p11: updating VPD database
c910f02c01p11: =============updatenode starting====================
c910f02c01p11: trying to download postscripts...
c910f02c01p11: postscripts downloaded successfully
c910f02c01p11: trying to get mypostscript from 10.2.1.9...
c910f02c01p11: postscript start..: ospkgs
c910f02c01p11: postscript end....: ospkgs exited with code 0
c910f02c01p11: postscript start..: otherpkgs
c910f02c01p11: otherpkgs: no extra rpms to install
c910f02c01p11: postscript end....: otherpkgs exited with code 0
c910f02c01p11: postscript start..: syscloneimgupdate
c910f02c01p11: postscript end....: syscloneimgupdate exited with code 0
c910f02c01p11: Running of Software Maintenance has completed.
c910f02c01p11: =============updatenode ending====================
c910f02c01p11: updating VPD database
c910f02c01p11: =============updatenode starting====================
c910f02c01p11: trying to download postscripts...
c910f02c01p11: postscripts downloaded successfully
c910f02c01p11: trying to get mypostscript from 10.2.1.9...
c910f02c01p11: postscript start..: syslog
c910f02c01p11: postscript end....: syslog exited with code 0
c910f02c01p11: postscript start..: remoteshell
c910f02c01p11: postscript end....: remoteshell exited with code 0
c910f02c01p11: postscript start..: syncfiles
c910f02c01p11: postscript end....: syncfiles exited with code 0
c910f02c01p11: postscript start..: otherpkgs
c910f02c01p11: otherpkgs: no extra rpms to install
c910f02c01p11: postscript end....: otherpkgs exited with code 0
c910f02c01p11: Running of postscripts has completed.
c910f02c01p11: =============updatenode ending====================
CHECK:rc == 0	[Pass]
CHECK:output !~ (E|e)rror	[Pass]
CHECK:output =~ File synchronization has completed	[Pass]
CHECK:output =~ postscripts has completed	[Pass]
CHECK:output =~ Software Maintenance has completed	[Pass]
```
3. `updatenode_diskful_syncfiles_P_script1` new output:
```
RUN:updatenode c910f02c01p11 -F -P script1 [Tue Oct 30 22:54:37 2018]
ElapsedTime:4 sec
RETURN rc = 0
OUTPUT:
File synchronization has completed for nodes: "c910f02c01p11"
c910f02c01p11: updating VPD database
c910f02c01p11: =============updatenode starting====================
c910f02c01p11: trying to download postscripts...
c910f02c01p11: postscripts downloaded successfully
c910f02c01p11: trying to get mypostscript from 10.2.1.9...
c910f02c01p11: postscript start..: script1
c910f02c01p11: postscript end....: script1 exited with code 0
c910f02c01p11: Running of postscripts has completed.
c910f02c01p11: =============updatenode ending====================
CHECK:rc == 0	[Pass]
CHECK:output !~ (E|e)rror	[Pass]
CHECK:output =~ File synchronization has completed	[Pass]
CHECK:output =~ postscripts has completed	[Pass]
```