### PR TITLE
xCAT-genesis-builder - Revise the error handling for directory detecting

### DIFF
--- a/xCAT-genesis-builder/xCAT-genesis-base.spec
+++ b/xCAT-genesis-builder/xCAT-genesis-base.spec
@@ -72,7 +72,7 @@ end
 local function remove_directory(directory, level, prefix)
     local num_dirs = 0
     local num_files = 0
-    if posix.access(directory,"rw") then
+    if posix.access(directory, "rw") then
     local files = posix.dir(directory)
     local last_file_index = table.getn(files)
     table.sort(files)
@@ -112,15 +112,17 @@ local function remove_directory_deep(directory)
 
     -- print(directory)
 
-    local info = assert(posix.stat(directory))
-    if info.type == 'directory' then
-        num_dirs, num_files = remove_directory(directory, 0, '')
+    if posix.access(directory, "rw") then
+        local info = assert(posix.stat(directory))
+        if info.type == 'directory' then
+            num_dirs, num_files = remove_directory(directory, 0, '')
 
-        -- printf('\ndropped %d directories, %d files\n', num_dirs, num_files)
+            -- printf('\ndropped %d directories, %d files\n', num_dirs, num_files)
 
-        posix.rmdir(directory)
-    else
-        posix.unlink(directory)
+            posix.rmdir(directory)
+        else
+            posix.unlink(directory)
+        end
     end
 end
 


### PR DESCRIPTION
### The PR is to fix issue _#5740_

### The modification include

_##Revise the error handling for directory detecting_

The old fix in pull request #5742 will cause the following problem when `xCAT-genesis-base-ppc64` was clean installed.
```
[root@c910f03c17k04 ~]# rpm -ivh /root/rpmbuild/RPMS/noarch/xCAT-genesis-base-ppc64-2.14.5-snap201810310323.noarch.rpm
error: lua script failed: [string "%pretrans(xCAT-genesis-base-ppc64-2:2.14.5-snap201810310323.noarch)"]:60: /opt/xcat/share/xcat/netboot/genesis/ppc64/fs/bin: No such file or directory
Preparing...                          ################################# [100%]
error: xCAT-genesis-base-ppc64-2:2.14.5-snap201810310323.noarch: install skipped
```

### The UT result
```
Processing files: xCAT-genesis-base-ppc64-2.14.5-snap201810310347.noarch
Provides: xCAT-genesis-base-ppc64 = 2:2.14.5-snap201810310347
Requires(interp): /bin/sh
Requires(rpmlib): rpmlib(BuiltinLuaScripts) <= 4.2.2-1 rpmlib(PartialHardlinkSets) <= 4.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1 rpmlib(CompressedFileNames) <= 3.0.4-1
Requires(post): /bin/sh
Conflicts: xCAT-genesis-scripts-ppc64 < 1:2.13.10
Checking for unpackaged file(s): /usr/lib/rpm/check-files /root/rpmbuild/BUILDROOT/xCAT-genesis-base-ppc64-2.14.5-snap201810310347.ppc64le
Wrote: /root/rpmbuild/SRPMS/xCAT-genesis-base-ppc64-2.14.5-snap201810310347.src.rpm
Wrote: /root/rpmbuild/RPMS/noarch/xCAT-genesis-base-ppc64-2.14.5-snap201810310347.noarch.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.VqwR0G
+ umask 022
+ cd /root/rpmbuild/BUILD
+ /usr/bin/rm -rf /root/rpmbuild/BUILDROOT/xCAT-genesis-base-ppc64-2.14.5-snap201810310347.ppc64le
+ exit 0
[root@c910f03c17k04 ~]# rpm -ivh /root/rpmbuild/RPMS/noarch/xCAT-genesis-base-ppc64-2.14.5-snap201810310347.noarch.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:xCAT-genesis-base-ppc64-2:2.14.5-################################# [100%]
```