### PR TITLE
Have xCAT client try IPv6 if IPv4 fails

### DIFF
--- a/perl-xCAT/xCAT/Client.pm
+++ b/perl-xCAT/xCAT/Client.pm
@@ -232,7 +232,8 @@ sub submit_request {
         $pclient = IO::Socket::INET6->new(
             %connargs,
         );
-    } else {
+    }
+    unless ($pclient) {
         $pclient = IO::Socket::INET->new(
             PeerAddr => $xcathost,
             Timeout  => 15,


### PR DESCRIPTION
If IPv6 support is added to a system after xcat is running,
then trying to reach 'localhost' may end up being '::1' instead
of '127.0.0.1'.  This will be fine after xCAT restarts from before
IPv6 support being available, but until that time the daemon is
IPv4 only.  Have Client try IPv4 if IPv6 fails to accomodate this
situation.