### PR TITLE
Use postscript file efibootmgr to check http service instead of syslog

### DIFF
--- a/xCAT-probe/lib/perl/probe_utils.pm
+++ b/xCAT-probe/lib/perl/probe_utils.pm
@@ -298,8 +298,9 @@ sub is_http_ready {
         $$errormsg_ref = "The port defined in 'site' table HTTP is not listening";
         return 0;
     }
+    my $test_file = "efibootmgr";
 
-    my $http      = "http://$mnip:$httpport/$installdir/postscripts/syslog";
+    my $http      = "http://$mnip:$httpport/$installdir/postscripts/$test_file";
     my %httperror = (
     "400" => "The request $http could not be understood by the server due to malformed syntax",
     "401" => "The request requires user authentication.",
@@ -330,12 +331,12 @@ sub is_http_ready {
         $$errormsg_ref = "Prepare test environment error: $!";
         return 0;
     }
-    my @outputtmp = `wget -O $tmpdir/syslog $http 2>&1`;
+    my @outputtmp = `wget -O $tmpdir/$test_file $http 2>&1`;
     my $rst       = $?;
     $rst = $rst >> 8;
 
-    if ((!$rst) && (-e "$tmpdir/syslog")) {
-        unlink("$tmpdir/syslog");
+    if ((!$rst) && (-e "$tmpdir/$test_file")) {
+        unlink("$tmpdir/$test_file");
         rmdir ("$tmpdir");
         return 1;
     } elsif ($rst == 4) {
@@ -355,7 +356,7 @@ sub is_http_ready {
             $$errormsg_ref = "Unknown return code of wget <$returncode>.";
         }
     }
-    unlink("$tmpdir/syslog");
+    unlink("$tmpdir/$test_file");
     if(! rmdir ("$tmpdir")){
         $$errormsg_ref .= " Clean test environment error(rmdir $tmpdir): $!";
     }


### PR DESCRIPTION
### The PR is to fix modify file for http service_

### The modification include

_##Use efibootmgr file_

### The UT result
```
[mn]: Checking important directories(installdir,tftpdir) are configured...                                        [ OK ]
[mn]: Checking SELinux is disabled...                                                                             [ OK ]
[mn]: Checking HTTP service is configured...                                                                      [ OK ]
[mn]: Checking TFTP service is configured...                                                                      [ OK ]
[mn]: Checking DNS service is configured...                                                                       [ OK ]
```