### PR TITLE
A more real world partitioning scheme for RHEL8

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/pre.rhels8
+++ b/xCAT-server/share/xcat/install/scripts/pre.rhels8
@@ -171,14 +171,17 @@ case "$(uname -m)" in
 esac
 if [ -d /sys/firmware/efi ]
 then
-    echo "part /boot/efi --fstype=$EFIFSTYPE --ondisk=$instdisk --size=250" >>/tmp/partitionfile
+    echo "part /boot/efi --fstype=$EFIFSTYPE --ondisk=$instdisk --size=256" >>/tmp/partitionfile
 fi
 
 # TODO: Ondisk detection, /dev/disk/by-id/edd-int13_dev80 for legacy maybe, and no idea about efi. At least maybe blacklist SAN if mptsas/mpt2sas/megaraid_sas seen...
 echo "part /boot --fstype=$BOOTFSTYPE --asprimary --ondisk=$instdisk --size=512" >>/tmp/partitionfile
-echo "part pv.000997 --grow --asprimary --ondisk=$instdisk --size=8192" >>/tmp/partitionfile
+echo "part pv.000997 --grow --asprimary --ondisk=$instdisk --size=18432" >>/tmp/partitionfile
 echo "volgroup system --pesize=4096 pv.000997" >>/tmp/partitionfile
-echo "logvol / --fstype=$FSTYPE --name=root --vgname=system --grow --size=1024" >>/tmp/partitionfile
+echo "logvol / --fstype=$FSTYPE --name=root --vgname=system --grow --size=4096 --maxsize=8192" >>/tmp/partitionfile
+echo "logvol /var --fstype=$FSTYPE --name=var --vgname=system --grow --size=2048 --maxsize=8192" >>/tmp/partitionfile
+echo "logvol /tmp --fstype=$FSTYPE --name=tmp --vgname=system --grow --size=1024 --maxsize=4096" >>/tmp/partitionfile
+echo "logvol /home --fstype=$FSTYPE --name=home --vgname=system --grow --percent=10 --maxsize=10240" >>/tmp/partitionfile
 echo "logvol swap --name=swap --vgname=system --recommended" >>/tmp/partitionfile
 
 # Specify "bootloader" configuration in "/tmp/partitionfile" if there is no user customized partition file


### PR DESCRIPTION
### The PR is to fix issue _#842_

### The modification include

_##A more real world partitioning scheme_

* A separate `/boot/efi` partition, size 256MiB, if needed.
* A separate `/boot` partition, size 512MiB.
* All the remain disk space will be used as LVM physical volume. Inside which, one volume group will be created.
* Root file system will be inside the LVM volume group, minimal 4096MiB, maximum 8192MiB.
* `/var` file system will be inside the LVM volume group, minimal 2048MiB, maximum 8192MiB.
* `/tmp` file system will be inside the LVM volume group, minimal 1024MiB, maximum 4096MiB.
* `/home` file system will be inside the LVM volume group, with 10% of the remain available space of the volume group, maximum 10240MiB.
* A swap partition will be created inside the LVM volume group with the Red Hat recommended size.