### PR TITLE
missing /etc/rsyslog.d/ from litefile table

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/statelite/config_statelite.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/statelite/config_statelite.rst
@@ -47,6 +47,7 @@ This is the minimal list of files needed, you can add additional files to the li
     "ALL","/etc/ntp.conf","tmpfs",,
     "ALL","/etc/rsyslog.conf","tmpfs",,
     "ALL","/etc/rsyslog.conf.XCATORIG","tmpfs",,
+    "ALL","/etc/rsyslog.d/","tmpfs",,
     "ALL","/etc/udev/","tmpfs",,
     "ALL","/etc/ntp.conf.predhclient","tmpfs",,
     "ALL","/etc/resolv.conf","tmpfs",,


### PR DESCRIPTION
### The PR is to fix issue 
https://github.com/xcat2/xcat-core/issues/5766

### The modification include

add entry in litefile table:
```
"ALL","/etc/rsyslog.d/","tmpfs",,
```

### The UT result
1. the testing doc link:
http://10.5.106.1/install/syslog/xcat-core/docs/build/html/guides/admin-guides/manage_clusters/ppc64le/statelite/config_statelite.html?highlight=litefile#sample-data-for-redhat-statelite-setup
2. Before this fix:
```
Tue Nov  6 03:19:05 EST 2018 [info]: xcat.deployment.postbootscript: postbootscript start..: syslog
grep: /etc/rsyslog.d/remote.conf: No such file or directory
grep: /etc/rsyslog.d/remote.conf: No such file or directory
./syslog: line 281: /etc/rsyslog.d/remote.conf: Read-only file system
./syslog: line 282: /etc/rsyslog.d/remote.conf: Read-only file system
./syslog: line 283: /etc/rsyslog.d/remote.conf: Read-only file system
./syslog: line 284: /etc/rsyslog.d/remote.conf: Read-only file system
```
after fixed and provisioned statelite , check the xcat.log
```
Tue Nov  6 03:26:55 EST 2018 [info]: xcat.deployment.postbootscript: postbootscript start..: syslog
grep: /etc/rsyslog.d/remote.conf: No such file or directory
grep: /etc/rsyslog.d/remote.conf: No such file or directory
Tue Nov  6 03:26:55 EST 2018 [info]: xcat.deployment.postbootscript: postbootscript end...:syslog return with 0
```