### PR TITLE
Add repoonly option for otherpkgs to only generate repo for pkgdir and otherpkgdir

### DIFF
--- a/xCAT/postscripts/otherpkgs
+++ b/xCAT/postscripts/otherpkgs
@@ -221,11 +221,11 @@ if [ $argnum -eq 1 ]; then
         repoonly=1
     else
         echo "$(basename $0): option $args is not supported"
-        exit 0
+        exit 1
     fi
-else
-    echo "$(basename $0): option $args is not supported"
-    exit 0
+elif [ $argnum -gt 1 ]; then
+    echo "$(basename $0): only option \"--repoonly\"is supported"
+    exit 1
 fi
 if [ "$(uname -s)" = "AIX" ]; then
       logger -p local4.info -t $log_label "otherpkgs not support on AIX, exiting "

--- a/xCAT/postscripts/otherpkgs
+++ b/xCAT/postscripts/otherpkgs
@@ -213,7 +213,20 @@ apt_get_update_if_repos_changed()
 #do nothing for diskless deployment case because it is done in the image already
 
 RETURNVAL=0
-
+repoonly=0
+argnum=$#
+args=$@
+if [ $argnum -eq 1 ]; then
+    if ( pmatch "$args" "--repoonly" ); then
+        repoonly=1
+    else
+        echo "$(basename $0): option $args is not supported"
+        exit 0
+    fi
+else
+    echo "$(basename $0): option $args is not supported"
+    exit 0
+fi
 if [ "$(uname -s)" = "AIX" ]; then
       logger -p local4.info -t $log_label "otherpkgs not support on AIX, exiting "
       exit 0
@@ -231,7 +244,12 @@ if [ -z "$UPDATENODE" ] || [ $UPDATENODE -ne 1 ]; then
   fi
 fi
 
-if [ -z "$OTHERPKGS_INDEX" ]; then
+if ! pmatch $OSVER "rhel*" && [ "$repoonly" -eq 1 ]; then
+    echo "$0: the option \"repoonly\" only support rhel right now"
+    exit 0
+fi
+
+if [ -z "$OTHERPKGS_INDEX" ] && [ "$repoonly" -ne 1 ]; then
   echo "$(basename $0): no extra rpms to install"
   exit 0
 fi
@@ -813,6 +831,11 @@ EOF`
          fi
     fi
 
+    if [ "$repoonly" -eq 1 ]; then
+        echo "otherpkgs: "repoonly set, so ignore pkg installation ...""
+        op_index=$((op_index+1))
+        continue
+    fi
     #now update all the existing rpms
     if [ $hasyum -eq 1 ]; then
         if [ $VERBOSE  ]; then


### PR DESCRIPTION
### The PR is to add option `--repoonly` for otherpkgs script to generate repo based on pkgdir and otherpkgdir

_##Feature description##_
Only support rhels right now.

### The UT result
```
root@c910f03c05k10:/install/postscripts# updatenode c910f03c05k02 -P "otherpkgs --repoonly"
c910f03c05k02: Warning: the ECDSA host key for 'c910f03c05k02' differs from the key for the IP address '10.3.5.2'
c910f03c05k02: Offending key for IP in /root/.ssh/known_hosts:189
c910f03c05k02: Matching host key in /root/.ssh/known_hosts:341

c910f03c05k02: vpdupdate is not supported on the pSeries KVM Guest platform
c910f03c05k02: updating VPD database
c910f03c05k02: trying to download postscripts...
c910f03c05k02: postscripts downloaded successfully
c910f03c05k02: trying to get mypostscript from 10.3.5.10...
c910f03c05k02: Running postscript: otherpkgs
c910f03c05k02: There are no enabled repos.
c910f03c05k02:  Run "yum repolist all" to see the repos you have.
c910f03c05k02:  To enable Red Hat Subscription Management repositories:
c910f03c05k02:      subscription-manager repos --enable <repo>
c910f03c05k02:  To enable custom repositories:
c910f03c05k02:      yum-config-manager --enable <repo>
c910f03c05k02: pkgsarray: python2-matplotlib python2-scikit-image, 2
c910f03c05k02: yum: 1, apt: 0, zypper: 0
c910f03c05k02: Loaded plugins: product-id, search-disabled-repos, subscription-manager
c910f03c05k02: This system is not registered with an entitlement server. You can use subscription-manager to register.
c910f03c05k02: Cleaning repos: xCAT-rhels7.5-alternate-path0 xCAT-rhels7.5-alternate-path1
c910f03c05k02:               : xCAT-rhels7.5-alternate-path2 xCAT-rhels7.5-alternate-path3
c910f03c05k02:               : xCAT-rhels7.5-alternate-path4 xCAT-rhels7.5-alternate-path5
c910f03c05k02:               : xcat-otherpkgs0
c910f03c05k02: Cleaning up everything
c910f03c05k02: Maybe you want: rm -rf /var/cache/yum, to also free up space taken by orphaned data from disabled or removed repos
c910f03c05k02: Loaded plugins: product-id, search-disabled-repos, subscription-manager
c910f03c05k02: This system is not registered with an entitlement server. You can use subscription-manager to register.
c910f03c05k02: Cleaning repos: xCAT-rhels7.5-alternate-path0 xCAT-rhels7.5-alternate-path1
c910f03c05k02:               : xCAT-rhels7.5-alternate-path2 xCAT-rhels7.5-alternate-path3
c910f03c05k02:               : xCAT-rhels7.5-alternate-path4 xCAT-rhels7.5-alternate-path5
c910f03c05k02:               : xcat-otherpkgs0
c910f03c05k02: Cleaning up everything
c910f03c05k02: Maybe you want: rm -rf /var/cache/yum, to also free up space taken by orphaned data from disabled or removed repos
c910f03c05k02: otherpkgs: repoonly set, so ignore pkg installation ...
c910f03c05k02: postscript: otherpkgs exited with code 0
c910f03c05k02: Running of postscripts has completed.
```