### PR TITLE
imporve the performance to list group object when lots of groups defined

### DIFF
--- a/perl-xCAT/xCAT/DBobjUtils.pm
+++ b/perl-xCAT/xCAT/DBobjUtils.pm
@@ -92,19 +92,20 @@ sub getObjectsOfType
         }
 
         # if this is type "group" we need to check the nodelist table
-        my @nodeGroupList = ();
         if ($type eq 'group') {
             my $table         = "nodelist";
+            my %ext_groups = ();
             my @TableRowArray = xCAT::DBobjUtils->getDBtable($table);
-            foreach (@TableRowArray) {
-                my @tmplist = split(',', $_->{'groups'});
-                push(@nodeGroupList, @tmplist);
-            }
-            foreach my $n (@nodeGroupList) {
-                if (!grep(/^$n$/, @objlist)) {
-                    push(@objlist, $n);
+            foreach my $r (@TableRowArray) {
+                my @tmplist = split(',', $r->{'groups'});
+                foreach (@tmplist) {
+                    $ext_groups{$_} = 1 unless exists($ext_groups{$_}) ;
                 }
             }
+            foreach (@objlist) {
+                $ext_groups{$_} = 1 unless exists($ext_groups{$_}) ;
+            }
+            @objlist = sort keys %ext_groups;
         }
 
         @{ $::saveObjList{$type} } = @objlist;

--- a/perl-xCAT/xCAT/Table.pm
+++ b/perl-xCAT/xCAT/Table.pm
@@ -2797,20 +2797,21 @@ sub getNodeAttribs
     unless (scalar keys %{ $data[0] }) {
         return undef;
     }
-    my $attrib;
-    foreach $datum (@data) {
-        foreach $attrib (@attribs)
-        {
-            unless (defined $datum->{$attrib}) {
-
-                #skip undefined values, save time
-                next;
-            }
-            my $retval;
-            if (defined($retval = transRegexAttrs($node, $datum->{$attrib}))) {
-                $datum->{$attrib} = $retval;
-            } else {
-                delete $datum->{$attrib};
+    if (!exists($options{keep_raw})){
+        my $attrib;
+        foreach $datum (@data) {
+            foreach $attrib (@attribs) {
+                unless (defined $datum->{$attrib}) {
+                    #skip undefined values, save time
+                    next;
+                }
+                my $retval;
+                if (defined($retval = transRegexAttrs($node, $datum->{$attrib}))) {
+                    $datum->{$attrib} = $retval;
+                }
+                else {
+                    delete $datum->{$attrib};
+                }
             }
         }
     }
@@ -2983,6 +2984,9 @@ sub getNodeAttribs_nosub_returnany
         $nodekey = $xCAT::Schema::tabspec{ $self->{tabname} }->{nodecol}
     }
     @results = $self->getAttribs({ $nodekey => $node }, @attribs);
+
+    # return the DB without any rendering, this is for fetch attributes of group
+    return @results if (exists($options{keep_raw}));
 
     my %attribsToDo;
     for (@attribs) {


### PR DESCRIPTION
### The PR is to fix issue #5761

### The modification include

using `hash` to reduce the duplication groups in array, and then remove the `grep` action which takes large CPU time when the array is very large.

### The UT result
here just test with one group
```
time lsdef -l -t group login
Object name: login
    bmc=|(.*)|($1)-bmc|
    bmcport=0
    conserver=|(\D+)(\d+)|io01xcat(($2%2)?1:2)-prv|
    installnic=mac
    members=login01,login02,login03,login04,login05,login06,login07,login08,login09,login10
    mgt=ipmi
    netboot=pxe
    primarynic=mac
    serialflow=hard
    serialport=0
    serialspeed=115200
    servicenode=|(\D+)(\d+)|io01xcat(($2%2)?1:2)-prv|
    xcatmaster=|(\D+)(\d+)|io01xcat(($2%2)?1:2)|

real	0m3.337s
user	0m0.303s
sys	0m0.031s
```

Before modification:
```
time lsdef -l -t group login
Object name: login
    bmc=|(.*)|($1)-bmc|
    bmcport=0
    conserver=|(\D+)(\d+)|io01xcat(($2%2)?1:2)-prv|
    installnic=mac
    members=login01,login02,login03,login04,login05,login06,login07,login08,login09,login10
    mgt=ipmi
    netboot=pxe
    primarynic=mac
    serialflow=hard
    serialport=0
    serialspeed=115200
    servicenode=|(\D+)(\d+)|io01xcat(($2%2)?1:2)-prv|
    xcatmaster=|(\D+)(\d+)|io01xcat(($2%2)?1:2)|

real	1m58.389s
user	0m0.332s
sys	0m0.030s
```

But this PR cannot resolve the overall CPU issue when `lsdef` for all nodegroups