### PR TITLE
add sys log for redhat statelite

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/dracut/xcat-premount.sh
+++ b/xCAT-server/share/xcat/netboot/rh/dracut/xcat-premount.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 #script to update nodelist.nodestatus during provision
 
+XCAT="$(getarg XCAT=)"
+STATEMNT="$(getarg STATEMNT=)"
 MASTER=`echo $XCAT |awk -F: '{print $1}'`
 
 getarg nonodestatus
@@ -11,8 +13,12 @@ if [ $? -ne 0 ]; then
 XCATIPORT="3002"
 fi
 
-
-
+log_label="xcat.deployment"
+[ "$xcatdebugmode" = "1" -o "$xcatdebugmode" = "2" ] && SYSLOGHOST="" || SYSLOGHOST="-n $MASTER"
+logger $SYSLOGHOST -t $log_label -p local4.info "=============deployment starting===================="
+logger $SYSLOGHOST -t $log_label -p local4.info "Starting xcat-premount..."
+[ "$xcatdebugmode" > "0" ] && logger $SYSLOGHOST -t $log_label -p local4.debug "MASTER=$MASTER XCATIPORT=$XCATIPORT NODESTATUS=$NODESTATUS"
 if [ $NODESTATUS -ne 0 ];then
+    logger $SYSLOGHOST -t $log_label -p local4.info "Sending request to $MASTER:$XCATIPORT for changing status to netbooting..."
 /tmp/updateflag $MASTER $XCATIPORT "installstatus netbooting"
 fi

--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/xcat-premount.sh
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/xcat-premount.sh
@@ -13,8 +13,12 @@ if [ $? -ne 0 ]; then
 XCATIPORT="3002"
 fi
 
-
-
+log_label="xcat.deployment"
+[ "$xcatdebugmode" = "1" -o "$xcatdebugmode" = "2" ] && SYSLOGHOST="" || SYSLOGHOST="-n $MASTER"
+logger $SYSLOGHOST -t $log_label -p local4.info "=============deployment starting===================="
+logger $SYSLOGHOST -t $log_label -p local4.info "Starting xcat-premount..."
+[ "$xcatdebugmode" > "0" ] && logger $SYSLOGHOST -t $log_label -p local4.debug "MASTER=$MASTER XCATIPORT=$XCATIPORT NODESTATUS=$NODESTATUS"
 if [ $NODESTATUS -ne 0 ];then
+    logger $SYSLOGHOST -t $log_label -p local4.info "Sending request to $MASTER:$XCATIPORT for changing status to netbooting..."
 /tmp/updateflag $MASTER $XCATIPORT "installstatus netbooting"
 fi

--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/xcat-prepivot.sh
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/xcat-prepivot.sh
@@ -128,9 +128,10 @@ if [ ! -z $SNAPSHOTSERVER ]; then
 fi
 
 # TODO: handle the dhclient/resolv.conf/ntp, etc
-logger $SYSLOGHOST -t $log_label -p local4.info "Get to enable localdisk"
-echo "Get to enable localdisk"
+logger $SYSLOGHOST -t $log_label -p local4.info "Enabling localdisk ..."
+echo "Enable localdisk ..."
 $NEWROOT/etc/init.d/localdisk
+logger $SYSLOGHOST -t $log_label -p local4.info "Preparing mount points ..."
 $NEWROOT/etc/init.d/statelite
 READONLY=yes
 export READONLY

--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/xcat-prepivot.sh
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/xcat-prepivot.sh
@@ -1,9 +1,13 @@
 #!/bin/sh
+log_label="xcat.deployment"
 NEWROOT=/sysroot
 SERVER=${SERVER%%/*}
 SERVER=${SERVER%:}
 RWDIR=.statelite
 XCAT="$(getarg XCAT=)"
+xcatdebugmode="$(getarg xcatdebugmode=)"
+XCATMASTER=$XCAT
+MASTER=`echo $XCATMASTER |awk -F: '{print $1}'`
 STATEMNT="$(getarg STATEMNT=)"
 if [ ! -z $STATEMNT ]; then #btw, uri style might have left future options other than nfs open, will u    se // to detect uri in the future I guess
     SNAPSHOTSERVER=${STATEMNT%:*}
@@ -17,6 +21,9 @@ if [ ! -z $STATEMNT ]; then #btw, uri style might have left future options other
     fi
 fi
 
+
+[ "$xcatdebugmode" = "1" -o "$xcatdebugmode" = "2" ] && SYSLOGHOST="" || SYSLOGHOST="-n $MASTER"
+logger $SYSLOGHOST -t $log_label -p local4.info "Executing xcat-prepivot to set up statelite..." 
 echo Setting up Statelite
 mkdir -p $NEWROOT
 
@@ -27,14 +34,18 @@ MAXTRIES=7
 ITER=0
 if [ ! -e "$NEWROOT/$RWDIR" ]; then
     echo ""
-    echo "This NFS root directory doesn't have a /$RWDIR directory for me to mount a rw filesystem.      You'd better create it... "
+    msg="This NFS root directory doesn't have a /$RWDIR directory for me to mount a rw filesystem. You'd better create it... "
+    echo "$msg"
     echo ""
+    logger $SYSLOGHOST -t $log_label -p local4.error "$msg"
     /bin/sh
 fi
 
 if [ ! -e "$NEWROOT/etc/init.d/statelite" ]; then
     echo ""
-    echo "$NEWROOT/etc/init.d/statelite doesn't exist.  Perhaps you didn't create this image with th    e -m statelite mode"
+    msg="$NEWROOT/etc/init.d/statelite doesn't exist.  Perhaps you didn't create this image with the -m statelite mode"
+    echo "$msg"
+    logger $SYSLOGHOST -t $log_label -p local4.error "$msg"
     echo ""
     /bin/sh
 fi
@@ -59,15 +70,19 @@ if [ ! -z $SNAPSHOTSERVER ]; then
     while ! mount $SNAPSHOTSERVER:/$SNAPSHOTROOT  $NEWROOT/$RWDIR/persistent -o $MNT_OPTIONS; do
         ITER=$(( ITER + 1 ))
         if [ "$ITER" == "$MAXTRIES" ]; then
-            echo "Your are dead, rpower $ME boot to play again."
-            echo "Possible problems:
+            msg="Your are dead, rpower $ME boot to play again.
+                 Possible problems:
 1.  $SNAPSHOTSERVER is not exporting $SNAPSHOTROOT ?
 2.  Is DNS set up?  Maybe that's why I can't mount $SNAPSHOTSERVER."
+            echo "$msg"
+            logger $SYSLOGHOST -t $log_label -p local4.error "$msg"
             /bin/sh
             exit
         fi
         RS=$(( $RANDOM % 20 ))
-        echo "Trying again in $RS seconds..."
+        msg="Trying again in $RS seconds..."
+        echo "$msg"
+        logger $SYSLOGHOST -t $log_label -p local4.info "$msg"
         sleep $RS
     done
 
@@ -78,13 +93,17 @@ if [ ! -z $SNAPSHOTSERVER ]; then
     while ! umount -l $NEWROOT/$RWDIR/persistent; do
         ITER=$(( ITER + 1 ))
         if [ "$ITER" == "$MAXTRIES" ]; then
-            echo "Your are dead, rpower $ME boot to play again."
-            echo "Cannot umount $NEWROOT/$RWDIR/persistent."
+            msg="Your are dead, rpower $ME boot to play again.
+                 Cannot umount $NEWROOT/$RWDIR/persistent."
+            echo "$msg"
+            logger $SYSLOGHOST -t $log_label -p local4.error "$msg"
             /bin/sh
             exit
         fi
         RS=$(( $RANDOM % 20 ))
-        echo "Trying again in $RS seconds..."
+        msg="Trying again in $RS seconds..."
+        echo "$msg"
+        logger $SYSLOGHOST -t $log_label -p local4.info "$msg"
         sleep $RS
     done
 
@@ -93,18 +112,23 @@ if [ ! -z $SNAPSHOTSERVER ]; then
     while ! mount $SNAPSHOTSERVER:/$SNAPSHOTROOT/$ME  $NEWROOT/$RWDIR/persistent -o $MNT_OPTIONS; do
         ITER=$(( ITER + 1 ))
         if [ "$ITER" == "$MAXTRIES" ]; then
-            echo "Your are dead, rpower $ME boot to play again."
-            echo "Possible problems: cannot mount to $SNAPSHOTSERVER:/$SNAPSHOTROOT/$ME."
+            msg="Your are dead, rpower $ME boot to play again.
+                 Possible problems: cannot mount to $SNAPSHOTSERVER:/$SNAPSHOTROOT/$ME."
+            echo $msg
+            logger $SYSLOGHOST -t $log_label -p local4.info "$msg"
             /bin/sh
             exit
         fi
         RS=$(( $RANDOM % 20 ))
-        echo "Trying again in $RS seconds..."
+        msg="Trying again in $RS seconds..."
+        echo "$msg"
+        logger $SYSLOGHOST -t $log_label -p local4.info "$msg"
         sleep $RS
     done
 fi
 
 # TODO: handle the dhclient/resolv.conf/ntp, etc
+logger $SYSLOGHOST -t $log_label -p local4.info "Get to enable localdisk"
 echo "Get to enable localdisk"
 $NEWROOT/etc/init.d/localdisk
 $NEWROOT/etc/init.d/statelite
@@ -174,3 +198,4 @@ fi
 echo 'settle_exit_if_exists="--exit-if-exists=/dev/root"; rm "$job"' > $hookdir/initqueue/xcat.sh
 # force udevsettle to break
 > $hookdir/initqueue/work
+logger $SYSLOGHOST -t $log_label -p local4.info "Exit xcat-prepivot"

--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
@@ -168,6 +168,7 @@ elif [ -r /rootimg-statelite.gz ]; then
         echo ""
         echo "The /$RWDIR directory doesn't exist in the rootimg... "
         echo ""
+        logger $SYSLOGHOST -t $log_label -p local4.err "The /$RWDIR directory doesn't exist in the rootimg..."
         /bin/sh
     fi
 
@@ -175,6 +176,7 @@ elif [ -r /rootimg-statelite.gz ]; then
         echo ""
         echo "$NEWROOT/etc/init.d/statelite doesn't exist... "
         echo ""
+        logger $SYSLOGHOST -t $log_label -p local4.err "$NEWROOT/etc/init.d/statelite doesn't exist... " 
         /bin/sh
     fi
 
@@ -208,10 +210,12 @@ elif [ -r /rootimg-statelite.gz ]; then
         while ! mount $SNAPSHOTSERVER:/$SNAPSHOTROOT $NEWROOT/$RWDIR/persistent -o $MNT_OPTIONS; do
             ITER=$(( ITER + 1 ))
             if [ "$ITER" == "$MAXTRIES" ]; then
-                echo "You are dead, rpower $ME boot to play again."
-                echo "Possible problems:
+                msg="You are dead, rpower $ME boot to play again.
+                     Possible problems:
     1.  $SNAPSHOTSERVER is not exporting $SNAPSHOTROOT ?
     2.  Is DNS set up? Maybe that's why I can't mount $SNAPSHOTSERVER."
+                echo "$msg"
+                logger $SYSLOGHOST -t $log_label -p local4.err "$msg"
                 /bin/sh
                 exit
             fi
@@ -227,8 +231,10 @@ elif [ -r /rootimg-statelite.gz ]; then
         while ! umount -l $NEWROOT/$RWDIR/persistent; do
             ITER=$(( ITER + 1 ))
             if [ "$ITER" == "$MAXTRIES" ]; then
-                echo "Your are dead, rpower $ME boot to play again."
-                echo "Cannot umount $NEWROOT/$RWDIR/persistent."
+                msg="Your are dead, rpower $ME boot to play again.
+                     Cannot umount $NEWROOT/$RWDIR/persistent."
+                echo "$msg"
+                logger $SYSLOGHOST -t $log_label -p local4.err "$msg"
                 /bin/sh
                 exit
             fi
@@ -242,8 +248,10 @@ elif [ -r /rootimg-statelite.gz ]; then
         while ! mount $SNAPSHOTSERVER:/$SNAPSHOTROOT/$ME  $NEWROOT/$RWDIR/persistent -o $MNT_OPTIONS; do
             ITER=$(( ITER + 1 ))
             if [ "$ITER" == "$MAXTRIES" ]; then
-                echo "Your are dead, rpower $ME boot to play again."
-                echo "Possible problems: cannot mount to $SNAPSHOTSERVER:/$SNAPSHOTROOT/$ME."
+                msg="Your are dead, rpower $ME boot to play again.
+                     Possible problems: cannot mount to $SNAPSHOTSERVER:/$SNAPSHOTROOT/$ME."
+                echo "$msg"
+                logger $SYSLOGHOST -t $log_label -p local4.err "$msg"
                 /bin/sh
                 exit
             fi
@@ -253,7 +261,9 @@ elif [ -r /rootimg-statelite.gz ]; then
         done
     fi
 
+    logger $SYSLOGHOST -t $log_label -p local4.info "Enabling localdisk ..."
     $NEWROOT/etc/init.d/localdisk
+    logger $SYSLOGHOST -t $log_label -p local4.info "Preparing mount points ..."
     $NEWROOT/etc/init.d/statelite
     fastboot=yes
     export fastboot

--- a/xCAT-server/share/xcat/netboot/rh/dracut_047/xcat-premount.sh
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_047/xcat-premount.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-set -x
+#!/bin/sh
 #script to update nodelist.nodestatus during provision
 
 XCAT="$(getarg XCAT=)"
@@ -14,8 +13,12 @@ if [ $? -ne 0 ]; then
 XCATIPORT="3002"
 fi
 
-
-
+log_label="xcat.deployment"
+[ "$xcatdebugmode" = "1" -o "$xcatdebugmode" = "2" ] && SYSLOGHOST="" || SYSLOGHOST="-n $MASTER"
+logger $SYSLOGHOST -t $log_label -p local4.info "=============deployment starting===================="
+logger $SYSLOGHOST -t $log_label -p local4.info "Starting xcat-premount..."
+[ "$xcatdebugmode" > "0" ] && logger $SYSLOGHOST -t $log_label -p local4.debug "MASTER=$MASTER XCATIPORT=$XCATIPORT NODESTATUS=$NODESTATUS"
 if [ $NODESTATUS -ne 0 ];then
+    logger $SYSLOGHOST -t $log_label -p local4.info "Sending request to $MASTER:$XCATIPORT for changing status to netbooting..."
 /tmp/updateflag $MASTER $XCATIPORT "installstatus netbooting"
 fi

--- a/xCAT-server/share/xcat/netboot/rh/dracut_047/xcat-prepivot.sh
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_047/xcat-prepivot.sh
@@ -128,9 +128,10 @@ if [ ! -z $SNAPSHOTSERVER ]; then
 fi
 
 # TODO: handle the dhclient/resolv.conf/ntp, etc
-logger $SYSLOGHOST -t $log_label -p local4.info "Get to enable localdisk"
-echo "Get to enable localdisk"
+logger $SYSLOGHOST -t $log_label -p local4.info "Enabling localdisk ..."
+echo "Enable localdisk ..."
 $NEWROOT/etc/init.d/localdisk
+logger $SYSLOGHOST -t $log_label -p local4.info "Preparing mount points ..."
 $NEWROOT/etc/init.d/statelite
 READONLY=yes
 export READONLY

--- a/xCAT-server/share/xcat/netboot/rh/dracut_047/xcat-prepivot.sh
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_047/xcat-prepivot.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
-set -x
+log_label="xcat.deployment"
 NEWROOT=/sysroot
 SERVER=${SERVER%%/*}
 SERVER=${SERVER%:}
 RWDIR=.statelite
 XCAT="$(getarg XCAT=)"
+xcatdebugmode="$(getarg xcatdebugmode=)"
+XCATMASTER=$XCAT
+MASTER=`echo $XCATMASTER |awk -F: '{print $1}'`
 STATEMNT="$(getarg STATEMNT=)"
 if [ ! -z $STATEMNT ]; then #btw, uri style might have left future options other than nfs open, will u    se // to detect uri in the future I guess
     SNAPSHOTSERVER=${STATEMNT%:*}
@@ -18,6 +21,9 @@ if [ ! -z $STATEMNT ]; then #btw, uri style might have left future options other
     fi
 fi
 
+
+[ "$xcatdebugmode" = "1" -o "$xcatdebugmode" = "2" ] && SYSLOGHOST="" || SYSLOGHOST="-n $MASTER"
+logger $SYSLOGHOST -t $log_label -p local4.info "Executing xcat-prepivot to set up statelite..." 
 echo Setting up Statelite
 mkdir -p $NEWROOT
 
@@ -28,14 +34,18 @@ MAXTRIES=7
 ITER=0
 if [ ! -e "$NEWROOT/$RWDIR" ]; then
     echo ""
-    echo "This NFS root directory doesn't have a /$RWDIR directory for me to mount a rw filesystem.      You'd better create it... "
+    msg="This NFS root directory doesn't have a /$RWDIR directory for me to mount a rw filesystem. You'd better create it... "
+    echo "$msg"
     echo ""
+    logger $SYSLOGHOST -t $log_label -p local4.error "$msg"
     /bin/sh
 fi
 
 if [ ! -e "$NEWROOT/etc/init.d/statelite" ]; then
     echo ""
-    echo "$NEWROOT/etc/init.d/statelite doesn't exist.  Perhaps you didn't create this image with th    e -m statelite mode"
+    msg="$NEWROOT/etc/init.d/statelite doesn't exist.  Perhaps you didn't create this image with the -m statelite mode"
+    echo "$msg"
+    logger $SYSLOGHOST -t $log_label -p local4.error "$msg"
     echo ""
     /bin/sh
 fi
@@ -60,15 +70,19 @@ if [ ! -z $SNAPSHOTSERVER ]; then
     while ! mount $SNAPSHOTSERVER:/$SNAPSHOTROOT  $NEWROOT/$RWDIR/persistent -o $MNT_OPTIONS; do
         ITER=$(( ITER + 1 ))
         if [ "$ITER" == "$MAXTRIES" ]; then
-            echo "Your are dead, rpower $ME boot to play again."
-            echo "Possible problems:
+            msg="Your are dead, rpower $ME boot to play again.
+                 Possible problems:
 1.  $SNAPSHOTSERVER is not exporting $SNAPSHOTROOT ?
 2.  Is DNS set up?  Maybe that's why I can't mount $SNAPSHOTSERVER."
+            echo "$msg"
+            logger $SYSLOGHOST -t $log_label -p local4.error "$msg"
             /bin/sh
             exit
         fi
         RS=$(( $RANDOM % 20 ))
-        echo "Trying again in $RS seconds..."
+        msg="Trying again in $RS seconds..."
+        echo "$msg"
+        logger $SYSLOGHOST -t $log_label -p local4.info "$msg"
         sleep $RS
     done
 
@@ -79,13 +93,17 @@ if [ ! -z $SNAPSHOTSERVER ]; then
     while ! umount -l $NEWROOT/$RWDIR/persistent; do
         ITER=$(( ITER + 1 ))
         if [ "$ITER" == "$MAXTRIES" ]; then
-            echo "Your are dead, rpower $ME boot to play again."
-            echo "Cannot umount $NEWROOT/$RWDIR/persistent."
+            msg="Your are dead, rpower $ME boot to play again.
+                 Cannot umount $NEWROOT/$RWDIR/persistent."
+            echo "$msg"
+            logger $SYSLOGHOST -t $log_label -p local4.error "$msg"
             /bin/sh
             exit
         fi
         RS=$(( $RANDOM % 20 ))
-        echo "Trying again in $RS seconds..."
+        msg="Trying again in $RS seconds..."
+        echo "$msg"
+        logger $SYSLOGHOST -t $log_label -p local4.info "$msg"
         sleep $RS
     done
 
@@ -94,18 +112,23 @@ if [ ! -z $SNAPSHOTSERVER ]; then
     while ! mount $SNAPSHOTSERVER:/$SNAPSHOTROOT/$ME  $NEWROOT/$RWDIR/persistent -o $MNT_OPTIONS; do
         ITER=$(( ITER + 1 ))
         if [ "$ITER" == "$MAXTRIES" ]; then
-            echo "Your are dead, rpower $ME boot to play again."
-            echo "Possible problems: cannot mount to $SNAPSHOTSERVER:/$SNAPSHOTROOT/$ME."
+            msg="Your are dead, rpower $ME boot to play again.
+                 Possible problems: cannot mount to $SNAPSHOTSERVER:/$SNAPSHOTROOT/$ME."
+            echo $msg
+            logger $SYSLOGHOST -t $log_label -p local4.info "$msg"
             /bin/sh
             exit
         fi
         RS=$(( $RANDOM % 20 ))
-        echo "Trying again in $RS seconds..."
+        msg="Trying again in $RS seconds..."
+        echo "$msg"
+        logger $SYSLOGHOST -t $log_label -p local4.info "$msg"
         sleep $RS
     done
 fi
 
 # TODO: handle the dhclient/resolv.conf/ntp, etc
+logger $SYSLOGHOST -t $log_label -p local4.info "Get to enable localdisk"
 echo "Get to enable localdisk"
 $NEWROOT/etc/init.d/localdisk
 $NEWROOT/etc/init.d/statelite
@@ -175,3 +198,4 @@ fi
 echo 'settle_exit_if_exists="--exit-if-exists=/dev/root"; rm "$job"' > $hookdir/initqueue/xcat.sh
 # force udevsettle to break
 > $hookdir/initqueue/work
+logger $SYSLOGHOST -t $log_label -p local4.info "Exit xcat-prepivot"

--- a/xCAT-server/share/xcat/netboot/rh/dracut_047/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_047/xcatroot
@@ -168,6 +168,7 @@ elif [ -r /rootimg-statelite.gz ]; then
         echo ""
         echo "The /$RWDIR directory doesn't exist in the rootimg... "
         echo ""
+        logger $SYSLOGHOST -t $log_label -p local4.err "The /$RWDIR directory doesn't exist in the rootimg..."
         /bin/sh
     fi
 
@@ -175,6 +176,7 @@ elif [ -r /rootimg-statelite.gz ]; then
         echo ""
         echo "$NEWROOT/etc/init.d/statelite doesn't exist... "
         echo ""
+        logger $SYSLOGHOST -t $log_label -p local4.err "$NEWROOT/etc/init.d/statelite doesn't exist... " 
         /bin/sh
     fi
 
@@ -208,10 +210,12 @@ elif [ -r /rootimg-statelite.gz ]; then
         while ! mount $SNAPSHOTSERVER:/$SNAPSHOTROOT $NEWROOT/$RWDIR/persistent -o $MNT_OPTIONS; do
             ITER=$(( ITER + 1 ))
             if [ "$ITER" == "$MAXTRIES" ]; then
-                echo "You are dead, rpower $ME boot to play again."
-                echo "Possible problems:
+                msg="You are dead, rpower $ME boot to play again.
+                     Possible problems:
     1.  $SNAPSHOTSERVER is not exporting $SNAPSHOTROOT ?
     2.  Is DNS set up? Maybe that's why I can't mount $SNAPSHOTSERVER."
+                echo "$msg"
+                logger $SYSLOGHOST -t $log_label -p local4.err "$msg"
                 /bin/sh
                 exit
             fi
@@ -227,8 +231,10 @@ elif [ -r /rootimg-statelite.gz ]; then
         while ! umount -l $NEWROOT/$RWDIR/persistent; do
             ITER=$(( ITER + 1 ))
             if [ "$ITER" == "$MAXTRIES" ]; then
-                echo "Your are dead, rpower $ME boot to play again."
-                echo "Cannot umount $NEWROOT/$RWDIR/persistent."
+                msg="Your are dead, rpower $ME boot to play again.
+                     Cannot umount $NEWROOT/$RWDIR/persistent."
+                echo "$msg"
+                logger $SYSLOGHOST -t $log_label -p local4.err "$msg"
                 /bin/sh
                 exit
             fi
@@ -242,8 +248,10 @@ elif [ -r /rootimg-statelite.gz ]; then
         while ! mount $SNAPSHOTSERVER:/$SNAPSHOTROOT/$ME  $NEWROOT/$RWDIR/persistent -o $MNT_OPTIONS; do
             ITER=$(( ITER + 1 ))
             if [ "$ITER" == "$MAXTRIES" ]; then
-                echo "Your are dead, rpower $ME boot to play again."
-                echo "Possible problems: cannot mount to $SNAPSHOTSERVER:/$SNAPSHOTROOT/$ME."
+                msg="Your are dead, rpower $ME boot to play again.
+                     Possible problems: cannot mount to $SNAPSHOTSERVER:/$SNAPSHOTROOT/$ME."
+                echo "$msg"
+                logger $SYSLOGHOST -t $log_label -p local4.err "$msg"
                 /bin/sh
                 exit
             fi
@@ -253,7 +261,9 @@ elif [ -r /rootimg-statelite.gz ]; then
         done
     fi
 
+    logger $SYSLOGHOST -t $log_label -p local4.info "Enabling localdisk ..."
     $NEWROOT/etc/init.d/localdisk
+    logger $SYSLOGHOST -t $log_label -p local4.info "Preparing mount points ..."
     $NEWROOT/etc/init.d/statelite
     fastboot=yes
     export fastboot

--- a/xCAT-server/share/xcat/netboot/sles/dracut_033/xcat-premount.sh
+++ b/xCAT-server/share/xcat/netboot/sles/dracut_033/xcat-premount.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 #script to update nodelist.nodestatus during provision
 
+XCAT="$(getarg XCAT=)"
+STATEMNT="$(getarg STATEMNT=)"
 MASTER=`echo $XCAT |awk -F: '{print $1}'`
 
 getarg nonodestatus
@@ -11,8 +13,12 @@ if [ $? -ne 0 ]; then
 XCATIPORT="3002"
 fi
 
-
-
+log_label="xcat.deployment"
+[ "$xcatdebugmode" = "1" -o "$xcatdebugmode" = "2" ] && SYSLOGHOST="" || SYSLOGHOST="-n $MASTER"
+logger $SYSLOGHOST -t $log_label -p local4.info "=============deployment starting===================="
+logger $SYSLOGHOST -t $log_label -p local4.info "Starting xcat-premount..."
+[ "$xcatdebugmode" > "0" ] && logger $SYSLOGHOST -t $log_label -p local4.debug "MASTER=$MASTER XCATIPORT=$XCATIPORT NODESTATUS=$NODESTATUS"
 if [ $NODESTATUS -ne 0 ];then
+    logger $SYSLOGHOST -t $log_label -p local4.info "Sending request to $MASTER:$XCATIPORT for changing status to netbooting..."
 /tmp/updateflag $MASTER $XCATIPORT "installstatus netbooting"
 fi

--- a/xCAT/postscripts/xcatdsklspost
+++ b/xCAT/postscripts/xcatdsklspost
@@ -236,15 +236,13 @@ parsehttpserver ()
 
 # Main
 # parse the arguments
+log_label="xcat.updatenode"
 ARGNUM=$#;
 if [ -z $1 ]; then
   NODE_DEPLOYMENT=1
   log_label="xcat.deployment"
-  echolog "info" "=============deployment starting===================="
 else
   NODE_DEPLOYMENT=0
-  log_label="xcat.updatenode"
-  echolog "info" "=============updatenode starting===================="
   case $1 in
     1|2|5)
       MODE=$1
@@ -299,8 +297,15 @@ else
         fi
       fi
       ;;
-    3|4|6) MODE=$1;;
+    4)
+      MODE=$1
+      log_label="xcat.deployment"
+      ;;
+    3|6) MODE=$1;;
   esac
+fi
+if [ $NODE_DEPLOYMENT -ne 1 ] && [ $MODE -ne 4 ] ; then
+  echolog "info" "=============updatenode starting===================="
 fi
 # set the default path for the xcatpost directory
 xcatpost="/xcatpost"

--- a/xCAT/postscripts/xcatpostinit1.netboot
+++ b/xCAT/postscripts/xcatpostinit1.netboot
@@ -22,7 +22,7 @@ fi
 if [ -n "$LOGLABEL" ]; then
     log_label=$LOGLABEL
 else
-    log_label="xcat"
+    log_label="xcat.deployment"
 fi
 
 XCATSERVER=$(grep --only-matching "\<XCAT=[^ ]*\>" /proc/cmdline |cut -d= -f2 |cut -d: -f1 2>/dev/null)


### PR DESCRIPTION
### The PR is for task 
https://github.com/xcat2/xcat2-task-management/issues/348
_##Feature description##_
add log for redhat statelite
### The content of the PR:

- xcatdsklspost  
- xcatpostinit1.netboot  
- xcat-premount.sh  
- xcat-prepivot.sh
- xcatroot

### The UT result
1. normal mode
```
]# grep xcat.deployment computes.log
Nov  7 01:11:01 byrh10 xcat.deployment: INFO  =============deployment starting====================
Nov  7 01:11:01 byrh10 xcat.deployment: INFO  Starting xcat-premount...
Nov  7 01:11:01 byrh10 xcat.deployment: INFO  Sending request to 10.5.106.7:3002 for changing status to netbooting...
Nov  7 01:11:01 byrh10 xcat.deployment: INFO  Executing xcat-prepivot to set up statelite...
Nov  7 01:11:01 byrh10 xcat.deployment: INFO  Enabling localdisk ...
Nov  7 01:11:02 byrh10 xcat.deployment: INFO  Preparing mount points ...
Nov  7 01:11:04 byrh10 xcat.deployment: INFO  Exit xcat-prepivot
Nov  7 01:11:07 byrh10 xcat.deployment.postbootscript: INFO  postbootscript start..: syslog
Nov  7 01:11:07 byrh10 xcat.deployment.postbootscript: INFO  Install: rsyslog version 8 setup
Nov  7 01:11:07 byrh10 xcat.deployment.postbootscript: INFO  postbootscript end...:syslog return with 0
Nov  7 01:11:07 byrh10 xcat.deployment.postbootscript: INFO  postbootscript start..: remoteshell
Nov  7 01:11:07 byrh10 xcat.deployment.postbootscript: INFO  remoteshell:  setup /etc/ssh/sshd_config and ssh_config
Nov  7 01:11:07 byrh10 xcat.deployment.postbootscript: INFO  Install: setup root .ssh
Nov  7 01:11:09 byrh10 xcat.deployment.postbootscript: INFO  remoteshell: getting ssh_host_dsa_key
Nov  7 01:11:09 byrh10 xcat.deployment.postbootscript: INFO  ssh_rsa_hostkey
Nov  7 01:11:09 byrh10 xcat.deployment.postbootscript: INFO  ssh_ecdsa_hostkey
Nov  7 01:11:09 byrh10 xcat.deployment.postbootscript: INFO  remoteshell: gathering ssh_root_pub_key
Nov  7 01:11:09 byrh10 xcat.deployment.postbootscript: INFO  ssh_root_pub_key
Nov  7 01:11:09 byrh10 xcat.deployment.postbootscript: INFO  remoteshell:sshbetweennodes is yes
Nov  7 01:11:10 byrh10 xcat.deployment.postbootscript: INFO  remoteshell: gathering ssh_root_key
Nov  7 01:11:10 byrh10 xcat.deployment.postbootscript: INFO  ssh_root_key
Nov  7 01:11:10 byrh10 xcat.deployment.postbootscript: INFO  start up sshd
Nov  7 01:11:10 byrh10 xcat.deployment.postbootscript: INFO  postbootscript end...:remoteshell return with 0
Nov  7 01:11:10 byrh10 xcat.deployment.postbootscript: INFO  postbootscript start..: syncfiles
Nov  7 01:11:10 byrh10 xcat.deployment.postbootscript: INFO  Statelite does not support syncfiles, nothing to do...
Nov  7 01:11:10 byrh10 xcat.deployment.postbootscript: INFO  postbootscript end...:syncfiles return with 0
Nov  7 01:11:10 byrh10 xcat.deployment.postbootscript: INFO  postbootscript start..: otherpkgs
Nov  7 01:11:10 byrh10 xcat.deployment.postbootscript: INFO  Running otherpkgs
Nov  7 01:11:10 byrh10 xcat.deployment.postbootscript: INFO  postbootscript end...:otherpkgs return with 0
Nov  7 01:11:10 byrh10 xcat.deployment.postbootscript: INFO  postbootscript start..: confignetwork
Nov  7 01:11:10 byrh10 xcat.deployment.postbootscript: INFO  configure the install nic eth0.
Nov  7 01:11:10 byrh10 xcat.deployment.postbootscript: INFO  configeth on byrh10: os type: redhat
Nov  7 01:11:10 byrh10 xcat.deployment.postbootscript: INFO  >> DEVICE=eth0
Nov  7 01:11:10 byrh10 xcat.deployment.postbootscript: INFO  >> IPADDR=10.4.41.10
Nov  7 01:11:10 byrh10 xcat.deployment.postbootscript: INFO  >> NETMASK=255.0.0.0
Nov  7 01:11:10 byrh10 xcat.deployment.postbootscript: INFO  >> BOOTPROTO=static
Nov  7 01:11:10 byrh10 xcat.deployment.postbootscript: INFO  >> ONBOOT=yes
Nov  7 01:11:10 byrh10 xcat.deployment.postbootscript: INFO  >> HWADDR=42:a8:49:57:97:1d
Nov  7 01:11:10 byrh10 xcat.deployment.postbootscript: INFO  >> MTU=1500
Nov  7 01:11:10 byrh10 xcat.deployment.postbootscript: INFO  There is no other nic device to configure.
Nov  7 01:11:10 byrh10 xcat.deployment.postbootscript: INFO  postbootscript end...:confignetwork return with 0
Nov  7 01:11:10 byrh10 xcat.deployment.postbootscript: DEBUG  node booted successfully, reporting status...
Nov  7 01:11:10 byrh10 xcat.deployment: INFO  ready
Nov  7 01:11:10 byrh10 xcat.deployment: INFO  done
Nov  7 01:11:10 byrh10 xcat.deployment.postbootscript: INFO  provision completed.(byrh10)
Nov  7 01:11:10 byrh10 xcat.deployment: INFO  =============deployment ending====================
```
2. debug mode:
```
Nov  7 03:22:21 byrh10 xcat.deployment: INFO  =============deployment starting====================
Nov  7 03:22:21 byrh10 xcat.deployment: INFO  Starting xcat-premount...
Nov  7 03:22:21 byrh10 xcat.deployment: INFO  Sending request to 10.5.106.7:3002 for changing status to netbooting...
Nov  7 03:22:21 byrh10 xcat.deployment: INFO  ready
Nov  7 03:22:21 byrh10 xcat.deployment: INFO  done
Nov  7 03:22:22 byrh10 xcat.deployment: INFO  Executing xcat-prepivot to set up statelite...
Nov  7 03:22:22 byrh10 xcat.deployment: INFO  Enabling localdisk ...
Nov  7 03:22:22 byrh10 xcat.deployment: INFO  Preparing mount points ...
Nov  7 03:22:25 byrh10 xcat.deployment: INFO  Exit xcat-prepivot
Nov  7 03:22:27 byrh10 xcat.deployment: DEBUG  Running /opt/xcat/xcatdsklspost 4
Nov  7 03:22:27 byrh10 xcat.deployment: INFO  trying to download postscripts...
Nov  7 03:22:27 byrh10 xcat.deployment: DEBUG  trying to download postscripts from http://10.5.106.7/install/postscripts/
Nov  7 03:22:27 byrh10 xcat.deployment: DEBUG  postscripts are downloaded from 10.5.106.7 successfully.
Nov  7 03:22:27 byrh10 xcat.deployment: INFO  trying to get mypostscript from 10.5.106.7...
Nov  7 03:22:27 byrh10 xcat.deployment: DEBUG  trying to download http://10.5.106.7/tftpboot/mypostscripts/mypostscript.byrh10...
Nov  7 03:22:27 byrh10 xcat.deployment: DEBUG  http://10.5.106.7/tftpboot/mypostscripts/mypostscript.byrh10 is not available.
Nov  7 03:22:28 byrh10 xcat.deployment: DEBUG  no pre-generated mypostscript.<nodename>, trying to get it with getpostscript.awk...
Nov  7 03:22:28 byrh10 xcat.deployment: DEBUG  Running //xcatpost/mypostscript
Nov  7 03:22:28 byrh10 xcat.deployment.postbootscript: INFO  postbootscript start..: syslog
Nov  7 03:22:28 byrh10 xcat.deployment.postbootscript: INFO  Install: rsyslog version 8 setup
Nov  7 03:22:28 byrh10 xcat.deployment.postbootscript: INFO  postbootscript end...:syslog return with 0
Nov  7 03:22:28 byrh10 xcat.deployment.postbootscript: INFO  postbootscript start..: remoteshell
Nov  7 03:22:28 byrh10 xcat.deployment.postbootscript: INFO  remoteshell:  setup /etc/ssh/sshd_config and ssh_config
Nov  7 03:22:28 byrh10 xcat.deployment.postbootscript: INFO  Install: setup root .ssh
Nov  7 03:22:29 byrh10 xcat.deployment.postbootscript: DEBUG
Nov  7 03:22:29 byrh10 xcat.deployment.postbootscript: INFO  remoteshell: getting ssh_host_dsa_key
Nov  7 03:22:30 byrh10 xcat.deployment.postbootscript: INFO  ssh_rsa_hostkey
Nov  7 03:22:30 byrh10 xcat.deployment.postbootscript: INFO  ssh_ecdsa_hostkey
Nov  7 03:22:30 byrh10 xcat.deployment.postbootscript: INFO  remoteshell: gathering ssh_root_pub_key
Nov  7 03:22:30 byrh10 xcat.deployment.postbootscript: INFO  ssh_root_pub_key
Nov  7 03:22:30 byrh10 xcat.deployment.postbootscript: INFO  remoteshell:sshbetweennodes is yes
Nov  7 03:22:30 byrh10 xcat.deployment.postbootscript: INFO  remoteshell: gathering ssh_root_key
Nov  7 03:22:30 byrh10 xcat.deployment.postbootscript: INFO  ssh_root_key
Nov  7 03:22:30 byrh10 xcat.deployment.postbootscript: INFO  start up sshd
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: INFO  postbootscript end...:remoteshell return with 0
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: INFO  postbootscript start..: syncfiles
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: DEBUG  Statelite does not support syncfiles, nothing to do...
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: INFO  Statelite does not support syncfiles, nothing to do...
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: INFO  postbootscript end...:syncfiles return with 0
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: INFO  postbootscript start..: otherpkgs
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: INFO  Running otherpkgs
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: DEBUG   Did not install any extra packages.
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: INFO  postbootscript end...:otherpkgs return with 0
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: INFO  postbootscript start..: confignetwork
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: DEBUG  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: DEBUG  [I]: configure the install nic eth0.
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: INFO  configure the install nic eth0.
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: DEBUG  [I]: configeth on byrh10: os type: redhat
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: INFO  configeth on byrh10: os type: redhat
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: DEBUG  ['/etc/sysconfig/network-scripts/ifcfg-eth0']
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: DEBUG  [I]: >> DEVICE=eth0
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: INFO  >> DEVICE=eth0
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: DEBUG  [I]: >> IPADDR=10.4.41.10
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: INFO  >> IPADDR=10.4.41.10
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: DEBUG  [I]: >> NETMASK=255.0.0.0
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: INFO  >> NETMASK=255.0.0.0
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: DEBUG  [I]: >> BOOTPROTO=static
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: INFO  >> BOOTPROTO=static
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: DEBUG  [I]: >> ONBOOT=yes
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: INFO  >> ONBOOT=yes
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: DEBUG  [I]: >> HWADDR=42:a8:49:57:97:1d
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: INFO  >> HWADDR=42:a8:49:57:97:1d
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: DEBUG  [I]: >> MTU=1500
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: INFO  >> MTU=1500
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: DEBUG  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: DEBUG  [I]: There is no other nic device to configure.
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: INFO  There is no other nic device to configure.
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: INFO  postbootscript end...:confignetwork return with 0
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: DEBUG  node booted successfully, reporting status...
Nov  7 03:22:31 byrh10 xcat.deployment: INFO  ready
Nov  7 03:22:31 byrh10 xcat.deployment: INFO  done
Nov  7 03:22:31 byrh10 xcat.deployment.postbootscript: INFO  provision completed.(byrh10)
Nov  7 03:22:31 byrh10 xcat.deployment: DEBUG  //xcatpost/mypostscript return with 0
Nov  7 03:22:31 byrh10 xcat.deployment: INFO  =============deployment ending====================

```
3. ramdisk based statelite
```
Nov  7 03:39:14 byrh10 xcat.deployment: INFO  =============deployment starting====================
Nov  7 03:39:14 byrh10 xcat.deployment: INFO  Executing xcatroot to prepare for netbooting (dracut_33)...
Nov  7 03:39:14 byrh10 xcat.deployment: DEBUG  MASTER=10.5.106.7 XCATIPORT=3002 NODESTATUS=1
Nov  7 03:39:14 byrh10 xcat.deployment: INFO  Sending request to 10.5.106.7:3002 for changing status to netbooting...
Nov  7 03:39:14 byrh10 xcat.deployment: INFO  ready
Nov  7 03:39:14 byrh10 xcat.deployment: INFO  done
Nov  7 03:39:14 byrh10 xcat.deployment: INFO  Downloading rootfs image from http://10.5.106.7:80//install/netboot/rhels7.4/x86_64/compute/rootimg-statelite.gz...
Nov  7 03:39:14 byrh10 xcat.deployment: DEBUG  Downloading http://10.5.106.7:80//install/netboot/rhels7.4/x86_64/compute/rootimg-statelite.gz...
Nov  7 03:39:16 byrh10 xcat.deployment: DEBUG  Download complete.
Nov  7 03:39:16 byrh10 xcat.deployment: INFO  Setting up RAM-root tmpfs for statelite mode.
Nov  7 03:39:16 byrh10 xcat.deployment: DEBUG  Extracting root filesystem...
Nov  7 03:39:23 byrh10 xcat.deployment: DEBUG  Done extracting the root filesystem.
Nov  7 03:39:23 byrh10 xcat.deployment: DEBUG  Setting up Statelite...
Nov  7 03:39:23 byrh10 xcat.deployment: INFO  Enabling localdisk ...
Nov  7 03:39:23 byrh10 xcat.deployment: INFO  Preparing mount points ...
Nov  7 03:39:24 byrh10 xcat.deployment: DEBUG  Saving /sysroot/var/lib/dhclient/dhclient-eth0.leases
Nov  7 03:39:24 byrh10 xcat.deployment: DEBUG  Creating /sysroot/etc/sysconfig/network-scripts/ifcfg-eth0
Nov  7 03:39:24 byrh10 xcat.deployment: DEBUG  Writing /sysroot/etc/sysconfig/network-scripts/ifcfg-eth0: DEVICE=eth0;BOOTPROTO=dhcp;HWADDR=42:a8:49:57:97:1d;ONBOOT=yes
Nov  7 03:39:24 byrh10 xcat.deployment: DEBUG  Saving /sysroot/etc/resolv.conf
Nov  7 03:39:24 byrh10 xcat.deployment: DEBUG  disable selinux ...
Nov  7 03:39:24 byrh10 xcat.deployment: INFO  Exiting xcatroot...
Nov  7 03:39:29 byrh10 xcat.deployment: DEBUG  Running /opt/xcat/xcatdsklspost 4
Nov  7 03:39:29 byrh10 xcat.deployment: INFO  trying to download postscripts...
Nov  7 03:39:29 byrh10 xcat.deployment: DEBUG  trying to download postscripts from http://10.5.106.7/install/postscripts/
Nov  7 03:39:29 byrh10 xcat.deployment: DEBUG  postscripts are downloaded from 10.5.106.7 successfully.
Nov  7 03:39:29 byrh10 xcat.deployment: INFO  trying to get mypostscript from 10.5.106.7...
Nov  7 03:39:29 byrh10 xcat.deployment: DEBUG  trying to download http://10.5.106.7/tftpboot/mypostscripts/mypostscript.byrh10...
Nov  7 03:39:29 byrh10 xcat.deployment: DEBUG  http://10.5.106.7/tftpboot/mypostscripts/mypostscript.byrh10 is not available.
Nov  7 03:39:29 byrh10 xcat.deployment: DEBUG  no pre-generated mypostscript.<nodename>, trying to get it with getpostscript.awk...
Nov  7 03:39:29 byrh10 xcat.deployment: DEBUG  Running //xcatpost/mypostscript
Nov  7 03:39:29 byrh10 xcat.deployment.postbootscript: INFO  postbootscript start..: syslog
Nov  7 03:39:29 byrh10 xcat.deployment.postbootscript: INFO  Install: rsyslog version 8 setup
Nov  7 03:39:29 byrh10 xcat.deployment.postbootscript: INFO  postbootscript end...:syslog return with 0
Nov  7 03:39:29 byrh10 xcat.deployment.postbootscript: INFO  postbootscript start..: remoteshell
Nov  7 03:39:29 byrh10 xcat.deployment.postbootscript: INFO  remoteshell:  setup /etc/ssh/sshd_config and ssh_config
Nov  7 03:39:29 byrh10 xcat.deployment.postbootscript: INFO  Install: setup root .ssh
Nov  7 03:39:30 byrh10 xcat.deployment.postbootscript: DEBUG
Nov  7 03:39:30 byrh10 xcat.deployment.postbootscript: INFO  remoteshell: getting ssh_host_dsa_key
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  ssh_rsa_hostkey
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  ssh_ecdsa_hostkey
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  remoteshell: gathering ssh_root_pub_key
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  ssh_root_pub_key
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  remoteshell:sshbetweennodes is yes
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  remoteshell: gathering ssh_root_key
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  ssh_root_key
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  start up sshd
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  postbootscript end...:remoteshell return with 0
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  postbootscript start..: syncfiles
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: DEBUG  Statelite does not support syncfiles, nothing to do...
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  Statelite does not support syncfiles, nothing to do...
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  postbootscript end...:syncfiles return with 0
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  postbootscript start..: otherpkgs
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  Running otherpkgs
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: DEBUG   Did not install any extra packages.
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  postbootscript end...:otherpkgs return with 0
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  postbootscript start..: confignetwork
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: DEBUG  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: DEBUG  [I]: configure the install nic eth0.
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  configure the install nic eth0.
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: DEBUG  [I]: configeth on byrh10: os type: redhat
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  configeth on byrh10: os type: redhat
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: DEBUG  ['/etc/sysconfig/network-scripts/ifcfg-eth0']
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: DEBUG  [I]: >> DEVICE=eth0
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  >> DEVICE=eth0
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: DEBUG  [I]: >> IPADDR=10.4.41.10
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  >> IPADDR=10.4.41.10
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: DEBUG  [I]: >> NETMASK=255.0.0.0
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  >> NETMASK=255.0.0.0
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: DEBUG  [I]: >> BOOTPROTO=static
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  >> BOOTPROTO=static
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: DEBUG  [I]: >> ONBOOT=yes
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  >> ONBOOT=yes
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: DEBUG  [I]: >> HWADDR=42:a8:49:57:97:1d
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  >> HWADDR=42:a8:49:57:97:1d
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: DEBUG  [I]: >> MTU=1500
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  >> MTU=1500
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: DEBUG  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: DEBUG  [I]: There is no other nic device to configure.
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  There is no other nic device to configure.
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: INFO  postbootscript end...:confignetwork return with 0
Nov  7 03:39:31 byrh10 xcat.deployment.postbootscript: DEBUG  node booted successfully, reporting status...
Nov  7 03:39:32 byrh10 xcat.deployment: INFO  ready
Nov  7 03:39:32 byrh10 xcat.deployment: INFO  done
Nov  7 03:39:32 byrh10 xcat.deployment.postbootscript: INFO  provision completed.(byrh10)
Nov  7 03:39:32 byrh10 xcat.deployment: DEBUG  //xcatpost/mypostscript return with 0
Nov  7 03:39:32 byrh10 xcat.deployment: INFO  =============deployment ending====================
```