### PR TITLE
fix 5733 genimage in ubuntu16.04.5 failure

### DIFF
--- a/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu16.04.pkglist
+++ b/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu16.04.pkglist
@@ -6,7 +6,6 @@ linux-image-generic-lts-xenial
 openssh-server
 openssh-client
 wget
-vim
 ntp
 rsyslog
 rsync

--- a/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu16.04.ppc64el.pkglist
+++ b/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu16.04.ppc64el.pkglist
@@ -7,7 +7,6 @@ linux-image-generic
 openssh-server
 openssh-client
 wget
-vim
 ntp
 ntpdate
 rsync

--- a/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu16.04.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu16.04.x86_64.pkglist
@@ -7,7 +7,6 @@ linux-image-generic
 openssh-server
 openssh-client
 wget
-vim
 ntp
 ntpdate
 rsync


### PR DESCRIPTION
### The PR is to fix issue 

https://github.com/xcat2/xcat-core/issues/5733

### The modification include

remove `vim` from ubuntu16.04 pkglist, `vi` as the default editor, `vi` is from `vim-tiny`

### The UT result
1. genimage is successful
```
u# lsdef -t osimage ubuntu16.04.5-x86_64-netboot-compute
Object name: ubuntu16.04.5-x86_64-netboot-compute
    exlist=/opt/xcat/share/xcat/netboot/ubuntu/compute.exlist
    imagetype=linux
    osarch=x86_64
    osname=Linux
    osvers=ubuntu16.04.5
    otherpkgdir=/install/post/otherpkgs/ubuntu16.04.5/x86_64
    permission=755
    pkgdir=/install/ubuntu16.04.5/x86_64
    pkglist=/opt/xcat/share/xcat/netboot/ubuntu/compute.ubuntu16.04.x86_64.pkglist
    postinstall=/opt/xcat/share/xcat/netboot/ubuntu/compute.postinstall
    profile=compute
    provmethod=netboot
    rootimgdir=/install/netboot/ubuntu16.04.5/x86_64/compute

u#genimage ubuntu16.04.5-x86_64-netboot-compute
... ...
reparing to unpack .../libnl-genl-3-200_3.2.27-1ubuntu0.16.04.1_amd64.deb ...
Unpacking libnl-genl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
Selecting previously unselected package wireless-regdb.
Preparing to unpack .../wireless-regdb_2018.05.09-0ubuntu1~16.04.1_all.deb ...
Unpacking wireless-regdb (2018.05.09-0ubuntu1~16.04.1) ...
Selecting previously unselected package iw.
Preparing to unpack .../archives/iw_3.17-1_amd64.deb ...
Unpacking iw (3.17-1) ...
Selecting previously unselected package crda.
Preparing to unpack .../archives/crda_3.13-1_amd64.deb ...
Unpacking crda (3.13-1) ...
Selecting previously unselected package iucode-tool.
Preparing to unpack .../iucode-tool_1.5.1-1ubuntu0.1_amd64.deb ...
Unpacking iucode-tool (1.5.1-1ubuntu0.1) ...
Selecting previously unselected package linux-firmware.
Preparing to unpack .../linux-firmware_1.157.20_all.deb ...
Unpacking linux-firmware (1.157.20) ...
Selecting previously unselected package linux-image-4.4.0-131-generic.
Preparing to unpack .../linux-image-4.4.0-131-generic_4.4.0-131.157_amd64.deb ...
Done.
Unpacking linux-image-4.4.0-131-generic (4.4.0-131.157) ...
Selecting previously unselected package linux-image-extra-4.4.0-131-generic.
Preparing to unpack .../linux-image-extra-4.4.0-131-generic_4.4.0-131.157_amd64.deb ...
Unpacking linux-image-extra-4.4.0-131-generic (4.4.0-131.157) ...
Selecting previously unselected package intel-microcode.
Preparing to unpack .../intel-microcode_3.20180425.1~ubuntu0.16.04.2_amd64.deb ...
Unpacking intel-microcode (3.20180425.1~ubuntu0.16.04.2) ...
Selecting previously unselected package amd64-microcode.
Preparing to unpack .../amd64-microcode_3.20180524.1~ubuntu0.16.04.2_amd64.deb ...
Unpacking amd64-microcode (3.20180524.1~ubuntu0.16.04.2) ...
Selecting previously unselected package linux-image-generic.
Preparing to unpack .../linux-image-generic_4.4.0.131.137_amd64.deb ...
Unpacking linux-image-generic (4.4.0.131.137) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
Setting up libnl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
Setting up libnl-genl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
Setting up wireless-regdb (2018.05.09-0ubuntu1~16.04.1) ...
Setting up iw (3.17-1) ...
Setting up crda (3.13-1) ...
Setting up iucode-tool (1.5.1-1ubuntu0.1) ...
Setting up linux-firmware (1.157.20) ...
Setting up linux-image-4.4.0-131-generic (4.4.0-131.157) ...
Running depmod.
update-initramfs: deferring update (hook will be called later)
Examining /etc/kernel/postinst.d.
run-parts: executing /etc/kernel/postinst.d/apt-auto-removal 4.4.0-131-generic /boot/vmlinuz-4.4.0-131-generic
run-parts: executing /etc/kernel/postinst.d/initramfs-tools 4.4.0-131-generic /boot/vmlinuz-4.4.0-131-generic
update-initramfs: Generating /boot/initrd.img-4.4.0-131-generic
Setting up linux-image-extra-4.4.0-131-generic (4.4.0-131.157) ...
run-parts: executing /etc/kernel/postinst.d/apt-auto-removal 4.4.0-131-generic /boot/vmlinuz-4.4.0-131-generic
run-parts: executing /etc/kernel/postinst.d/initramfs-tools 4.4.0-131-generic /boot/vmlinuz-4.4.0-131-generic
update-initramfs: Generating /boot/initrd.img-4.4.0-131-generic
Setting up intel-microcode (3.20180425.1~ubuntu0.16.04.2) ...
update-initramfs: deferring update (trigger activated)
intel-microcode: microcode will be updated at next boot
Setting up amd64-microcode (3.20180524.1~ubuntu0.16.04.2) ...
update-initramfs: deferring update (trigger activated)
amd64-microcode: microcode will be updated at next boot
Setting up linux-image-generic (4.4.0.131.137) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
Processing triggers for initramfs-tools (0.122ubuntu8.11) ...
update-initramfs: Generating /boot/initrd.img-4.4.0-131-generic
Ign:1 http://10.4.41.10/install/ubuntu16.04.5/x86_64 xenial InRelease
Hit:2 http://10.4.41.10/install/ubuntu16.04.5/x86_64 xenial Release
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
Calculating upgrade...
The following packages have been kept back:
  libsystemd0
0 upgraded, 0 newly installed, 0 to remove and 1 not upgraded.
Reading package lists...
Building dependency tree...
Reading state information...
Calculating upgrade...
The following packages have been kept back:
  libsystemd0
0 upgraded, 0 newly installed, 0 to remove and 1 not upgraded.
Umount /proc, /dev, /sys, pkgdir and otherpkgdir to the rootimg.
Setting up the locales
Generating locales (this might take a while)...
  en_US.ISO-8859-1... done
  en_US.UTF-8... done
Generation complete.
Generating locales (this might take a while)...
  en_US.ISO-8859-1... done
  en_US.UTF-8... done
Generation complete.
Added ptp.ko as an autodetected dependency
Added pps_core.ko as an autodetected dependency
Added dca.ko as an autodetected dependency
Added i2c-algo-bit.ko as an autodetected dependency
Added vxlan.ko as an autodetected dependency
    arch=x86_64
Added ip6_udp_tunnel.ko as an autodetected dependency
Added udp_tunnel.ko as an autodetected dependency
Added mdio.ko as an autodetected dependency
Added libcrc32c.ko as an autodetected dependency
ldd: sbin/udevd: No such file or directory
cd /tmp/xcatinitrd.11489;find .|cpio -H newc -o|gzip -9 -c - > /install/netboot/ubuntu16.04.5/x86_64/compute/initrd-statelite.gz
600922 blocks
ldd: sbin/udevd: No such file or directory
cd /tmp/xcatinitrd.11489;find .|cpio -H newc -o|gzip -9 -c - > /install/netboot/ubuntu16.04.5/x86_64/compute/initrd-stateless.gz
598103 blocks
```
2. after provision diskless, can use vi:
```
u# xdsh byrh09 "vi --version"
byrh09: VIM - Vi IMproved 7.4 (2013 Aug 10, compiled Apr 08 2016 11:38:28)
byrh09: Included patches: 1-1689
byrh09: Modified by pkg-vim-maintainers@lists.alioth.debian.org
byrh09: Compiled by pkg-vim-maintainers@lists.alioth.debian.org
byrh09: Small version without GUI.  Features included (+) or not (-):
```
