### PR TITLE
fix5209 nodeset cannot find pxelinux.0

### DIFF
--- a/xCAT-server/lib/xcat/plugins/mknb.pm
+++ b/xCAT-server/lib/xcat/plugins/mknb.pm
@@ -253,6 +253,10 @@ sub process_request {
             copy("/usr/lib/syslinux/pxelinux.0", "$tftpdir/pxelinux.0");
         } elsif (-r "/usr/share/syslinux/pxelinux.0") {
             copy("/usr/share/syslinux/pxelinux.0", "$tftpdir/pxelinux.0");
+        } elsif ("/usr/lib/PXELINUX/pxelinux.0") {
+            copy("/usr/lib/PXELINUX/pxelinux.0", "$tftpdir/pxelinux.0");
+        } else {
+            copy("/opt/xcat/share/xcat/netboot/syslinux/pxelinux.0", "$tftpdir/pxelinux.0");
         }
         if (-r "$tftpdir/pxelinux.0") {
             chmod(0644, "$tftpdir/pxelinux.0");

--- a/xCAT-server/lib/xcat/plugins/pxe.pm
+++ b/xCAT-server/lib/xcat/plugins/pxe.pm
@@ -478,15 +478,18 @@ sub process_request {
     }
 
     #end prescripts code
+    $tftpdir=$globaltftpdir;
     if (!-r "$tftpdir/pxelinux.0") {
-        unless (-r "/usr/lib/syslinux/pxelinux.0" or -r "/usr/share/syslinux/pxelinux.0") {
+        unless (-r "/usr/lib/syslinux/pxelinux.0" or -r "/usr/share/syslinux/pxelinux.0" or -r "/opt/xcat/share/xcat/netboot/syslinux/pxelinux.0") {
             $::PXE_callback->({ error => ["Unable to find pxelinux.0 "], errorcode => [1] });
             return;
         }
         if (-r "/usr/lib/syslinux/pxelinux.0") {
             copy("/usr/lib/syslinux/pxelinux.0", "$tftpdir/pxelinux.0");
-        } else {
+        } elsif ( -r "/usr/share/syslinux/pxelinux.0") {
             copy("/usr/share/syslinux/pxelinux.0", "$tftpdir/pxelinux.0");
+        } else {
+            copy("/opt/xcat/share/xcat/netboot/syslinux/pxelinux.0","$tftpdir/pxelinux.0");
         }
         chmod(0644, "$tftpdir/pxelinux.0");
     }
@@ -494,7 +497,6 @@ sub process_request {
         $::PXE_callback->({ errror => ["Unable to find pxelinux.0 from syslinux"], errorcode => [1] });
         return;
     }
-
 
     $errored = 0;
     my %bphash;

--- a/xCAT-server/lib/xcat/plugins/pxe.pm
+++ b/xCAT-server/lib/xcat/plugins/pxe.pm
@@ -478,23 +478,16 @@ sub process_request {
     }
 
     #end prescripts code
-    $tftpdir=$globaltftpdir;
-    if (!-r "$tftpdir/pxelinux.0") {
-        unless (-r "/usr/lib/syslinux/pxelinux.0" or -r "/usr/share/syslinux/pxelinux.0" or -r "/opt/xcat/share/xcat/netboot/syslinux/pxelinux.0") {
-            $::PXE_callback->({ error => ["Unable to find pxelinux.0 "], errorcode => [1] });
-            return;
+    my @pxelinuxpaths=("/usr/lib/syslinux/pxelinux.0","/usr/share/syslinux/pxelinux.0","/usr/lib/PXELINUX/pxelinux.0","/opt/xcat/share/xcat/netboot/syslinux/pxelinux.0");
+    foreach $path (@pxelinuxpaths) {
+        if (-r "$path") {
+            copy("$path","$globaltftpdir/pxelinux.0");
+            chmod(0644, "$globaltftpdir/pxelinux.0");
+            last;
         }
-        if (-r "/usr/lib/syslinux/pxelinux.0") {
-            copy("/usr/lib/syslinux/pxelinux.0", "$tftpdir/pxelinux.0");
-        } elsif ( -r "/usr/share/syslinux/pxelinux.0") {
-            copy("/usr/share/syslinux/pxelinux.0", "$tftpdir/pxelinux.0");
-        } else {
-            copy("/opt/xcat/share/xcat/netboot/syslinux/pxelinux.0","$tftpdir/pxelinux.0");
-        }
-        chmod(0644, "$tftpdir/pxelinux.0");
     }
-    unless (-r "$tftpdir/pxelinux.0") {
-        $::PXE_callback->({ errror => ["Unable to find pxelinux.0 from syslinux"], errorcode => [1] });
+    unless (-r "$globaltftpdir/pxelinux.0") {
+        $::PXE_callback->({ errror => ["Unable to find pxelinux.0 from syslinux or pxelinux"], errorcode => [1] });
         return;
     }
 


### PR DESCRIPTION
### The PR is to fix issue 

https://github.com/xcat2/xcat-core/issues/5209

### The modification include

1. get right tftpdir 
2. "/opt/xcat/share/xcat/netboot/syslinux/pxelinux.0" is as one of pxelinux.0 source file.

### The UT result
Before fix:
```
nodeset node3 osimage=ubuntu16.04.4-x86_64-install-compute
Error: Unable to find pxelinux.0
```

After fixing this issue:
```
/# nodeset byrh09 osimage
byrh09: netboot ubuntu16.04.5-x86_64-compute
/# ls /tftpboot/pxelinux.0
/tftpboot/pxelinux.0
```
```