### PR TITLE
remove mistake breaks

### DIFF
--- a/xCAT/postscripts/xcatdsklspost
+++ b/xCAT/postscripts/xcatdsklspost
@@ -380,7 +380,6 @@ if [ "$MODE" = "4" ]; then # for statelite mode
             else
                 echo "XCATSERVER=$XCATSERVER" >> /opt/xcat/xcatinfo
             fi
-            break
         elif [ "$KEY" =  "XCATHTTPPORT" ]; then
             HTTPPORT=`echo $i | awk -F= '{print $2}'`
             grep 'HTTPPORT' /opt/xcat/xcatinfo > /dev/null  2>&1
@@ -389,8 +388,6 @@ if [ "$MODE" = "4" ]; then # for statelite mode
             else
                 echo "HTTPPORT=$HTTPPORT" >> /opt/xcat/xcatinfo
             fi
-            break
-            
         fi
     done
 


### PR DESCRIPTION
### The PR is to fix issues found in site.httpport for statelite

remove additional `break` s

UT:
```
[root@c910f03c09k03 postscripts]# rinstall c910f03c09k05 osimage
Provision node(s): c910f03c09k05
[root@c910f03c09k03 postscripts]# lsdef c910f03c09k05 -i provmethod^C
(reverse-i-search)`ssh': ^Ch c910f03c09k05
[root@c910f03c09k03 postscripts]# lsdef c910f03c09k05
Object name: c910f03c09k05
    arch=ppc64le
    cons=kvm
    currchain=boot
    currstate=statelite rhels7.6-ppc64le-compute
    groups=all
    id=5
    ip=10.3.9.5
    mac=42:be:0a:03:09:05|42:0d:0a:03:09:05!*NOIP*|42:10:0a:03:09:05!*NOIP*
    mgt=kvm
    monserver=c910f03c09k04
    netboot=grub2
    nfsserver=c910f03c09k04
    os=rhels7.6
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
    profile=compute
    provmethod=rhels7.6-ppc64le-statelite-compute
    serialflow=hard
    serialport=0
    serialspeed=115200
    servicenode=c910f03c09k04
    status=booted
    statustime=11-09-2018 05:27:23
    tftpserver=c910f03c09k04
    updatestatus=syncing
    updatestatustime=11-08-2018 05:28:33
    vmcpus=4
    vmhost=c910f03c09
    vmmemory=8192
    vmnicnicmodel=virtio-net-pci
    vmnics=br10,br50,br4093
    vmstorage=phy:/dev/mapper/vdiskvg-vdisk00n05
    xcatmaster=c910f03c09k04
```