### PR TITLE
Modify configinterface postscripts to handle the MASTER IP address

### DIFF
--- a/xCAT/postscripts/configinterface
+++ b/xCAT/postscripts/configinterface
@@ -11,13 +11,14 @@ xcat_intf="/etc/network/interfaces.d/xCAT.intf"
 
 if [ -f /xcatpost/mypostscript ]; then
     MASTER=`grep '^MASTER_IP=' /xcatpost/mypostscript |cut -d= -f2|sed s/\'//g`
-else
-    MASTER=$(cat /var/lib/dhcp/dhclient.eth0.leases|sed -n 's/.*cumulus-provision-url.*http:\/\+\([^\/]\+\)\/.*/\1/p'|tail -1)
 fi
 
 if [ -z "$MASTER" ]; then
-    echo "xCAT Master unset! Cannot download interface description"
-    exit 2
+    MASTER=$(cat /var/lib/dhcp/dhclient.eth0.leases|sed -n 's/.*cumulus-provision-url.*http:\/\+\([^\/]\+\)\/.*/\1/p'|tail -1)
+    if [ -z "$MASTER" ]; then
+        echo "xCAT Master unset! Cannot download interface description"
+        exit 2
+    fi
 fi
 
 #Validate if this IP is reachable
@@ -29,7 +30,7 @@ fi
 
 ORIGFILE=/tmp/xCAT.intf.orig
 TMPINT=/tmp/xCAT.intf
-rm $TMPINT 2>/dev/null
+rm -f $TMPINT 2>/dev/null
 UPDATED=0
 DOWNLOADED=0
 
@@ -38,8 +39,9 @@ for name in $NODE ${GROUP//,/ } default; do
     if [ -f $TMPINT ]; then
         DOWNLOADED=1
         if ! diff $TMPINT $xcat_intf > /dev/null; then
+            rm -f $ORIGFILE
             cp $xcat_intf $ORIGFILE
-            mv $TMPINT $xcat_intf
+            mv -f $TMPINT $xcat_intf
             UPDATED=1
             echo "New interface file downloaded, keep old one to $ORIGFILE";
         fi

--- a/xCAT/postscripts/configinterface
+++ b/xCAT/postscripts/configinterface
@@ -9,29 +9,55 @@ fi
 
 xcat_intf="/etc/network/interfaces.d/xCAT.intf"
 
-MASTER=$(cat /var/lib/dhcp/dhclient.eth0.leases|sed -n 's/.*cumulus-provision-url.*http:\/\+\([^\/]\+\)\/.*/\1/p'|tail -1)
+if [ -f /xcatpost/mypostscript ]; then
+    MASTER=`grep '^MASTER_IP=' /xcatpost/mypostscript |cut -d= -f2|sed s/\'//g`
+else
+    MASTER=$(cat /var/lib/dhcp/dhclient.eth0.leases|sed -n 's/.*cumulus-provision-url.*http:\/\+\([^\/]\+\)\/.*/\1/p'|tail -1)
+fi
+
 if [ -z "$MASTER" ]; then
     echo "xCAT Master unset! Cannot download interface description"
     exit 2
 fi
 
+#Validate if this IP is reachable
+ping $MASTER -c 1 >/dev/null
+if [ $? -ne 0 ]; then
+   echo "ERROR: The xCAT Master ip address $MASTER is not reachable";
+   exit 1;
+fi
+
+ORIGFILE=/tmp/xCAT.intf.orig
 TMPINT=/tmp/xCAT.intf
 rm $TMPINT 2>/dev/null
 UPDATED=0
+DOWNLOADED=0
 
 for name in $NODE ${GROUP//,/ } default; do
     curl -s -o $TMPINT -f http://${MASTER}/install/custom/sw_os/cumulus/interface/$name
     if [ -f $TMPINT ]; then
+        DOWNLOADED=1
         if ! diff $TMPINT $xcat_intf > /dev/null; then
+            cp $xcat_intf $ORIGFILE
             mv $TMPINT $xcat_intf
             UPDATED=1
+            echo "New interface file downloaded, keep old one to $ORIGFILE";
         fi
         break
     fi
 done
 
+if [ $DOWNLOADED -eq 1 ] && [ $UPDATED -eq 0 ]; then
+   echo "New interface file downloaded to $TMPINT, same as $xcat_intf file";
+fi
+
+if [ $DOWNLOADED -eq 0 ] && [ -f $xcat_intf ]; then
+   echo "NO new interface file downloaded, keep same $xcat_intf file";
+fi
+
 if [ ! -f $xcat_intf ]; then
     UPDATED=1
+    echo "NO new interface file downloaded, create a default $xcat_intf file";
 
     echo "#This is sample interface file provided by xCAT" > $xcat_intf
     echo "# bridge-vlan-aware: set to yes to indicate that the bridge is VLAN-aware. " >> $xcat_intf


### PR DESCRIPTION
The PR is to fix issue  #5785 

The modification include
1) get Master from mypostscript first, if not , get from dhcpd lease file.  ping the ip address first before call issue `curl` command
2) better handle the error message and return code

### The UT result
````
Fri Feb  9 09:18:15 EST 2001 [info]: xcat.mypostscript: Running postscript: configinterface
ERROR: The xCAT Master ip address 10.5.100.250 is not reachable
Fri Feb  9 09:18:26 EST 2001 [info]: xcat.mypostscript: postscript configinterface return with 1

````

