### PR TITLE
fix 5789 xcatlib.sh: line 186: &0 : syntax error

### DIFF
--- a/xCAT/postscripts/xcatlib.sh
+++ b/xCAT/postscripts/xcatlib.sh
@@ -107,7 +107,7 @@ function v4prefix2mask(){
     local num_index=1
     local str_temp=''
     local str_mask=''
-
+    [ ! $a ] && a=0
     while [[ $num_index -le 4 ]]
     do
         if [ $a -ge 8 ];then


### PR DESCRIPTION
### The PR is to fix issue 

https://github.com/xcat2/xcat-core/issues/5789

### The modification include

xcatlib.sh

### The UT result
Before fix:
```
byrh10: +++ v4prefix2mask
byrh10: +++ local a=
byrh10: +++ local b=0
byrh10: +++ local num_index=1
byrh10: +++ local str_temp=
byrh10: +++ local str_mask=
byrh10: +++ [[ 1 -le 4 ]]
byrh10: +++ '[' -ge 8 ']'
byrh10: ./xcatlib.sh: line 113: [: -ge: unary operator expected
byrh10: +++ b=
byrh10: +++ a=0
byrh10: +++ case $b in
byrh10: +++ str_mask=.
byrh10: +++ num_index=2
byrh10: +++ [[ 2 -le 4 ]]
byrh10: +++ '[' 0 -ge 8 ']'
byrh10: +++ b=0
byrh10: +++ a=0
byrh10: +++ case $b in
byrh10: +++ str_temp=0
byrh10: +++ str_mask=.0.
byrh10: +++ num_index=3
byrh10: +++ [[ 3 -le 4 ]]
byrh10: +++ '[' 0 -ge 8 ']'
byrh10: +++ b=0
byrh10: +++ a=0
byrh10: +++ case $b in
byrh10: +++ str_temp=0
byrh10: +++ str_mask=.0.0.
byrh10: +++ num_index=4
byrh10: +++ [[ 4 -le 4 ]]
byrh10: +++ '[' 0 -ge 8 ']'
byrh10: +++ b=0
byrh10: +++ a=0
byrh10: +++ case $b in
byrh10: +++ str_temp=0
byrh10: +++ str_mask=.0.0.0.
byrh10: +++ num_index=5
byrh10: +++ [[ 5 -le 4 ]]
byrh10: ++++ sed 's/\.$//'
byrh10: ++++ echo .0.0.0.
byrh10: +++ str_mask=.0.0.0
byrh10: +++ echo .0.0.0
byrh10: ++ str_mask=.0.0.0
byrh10: ++ local str_net=
byrh10: ++ local str_temp=
byrh10: ++ local 'str_ifs=
byrh10: '
byrh10: ++ IFS=.
byrh10: ++ array_ip=($1)
byrh10: ++ local array_ip
byrh10: ++ array_mask=($str_mask)
byrh10: ++ local array_mask
byrh10: ++ IFS='
byrh10: '
byrh10: ++ for index in '{0..3}'
byrh10: ./xcatlib.sh: line 186: 10& : syntax error: operand expected (error token is "& ")
byrh10: ++ str_temp=
byrh10: ++ str_net=.
byrh10: ++ for index in '{0..3}'
byrh10: +++ echo 0
byrh10: ++ str_temp=0
byrh10: ++ str_net=.0.
byrh10: ++ for index in '{0..3}'
byrh10: +++ echo 0
byrh10: ++ str_temp=0
byrh10: ++ str_net=.0.0.
byrh10: ++ for index in '{0..3}'
byrh10: +++ echo 0
byrh10: ++ str_temp=0
byrh10: ++ str_net=.0.0.0.
byrh10: +++ echo .0.0.0.
byrh10: +++ sed 's/\.$//'
byrh10: ++ str_net=.0.0.0
byrh10: ++ echo .0.0.0
byrh10: + str_temp_net1=.0.0.0
```

After fix:
```
byrh10: +++ v4prefix2mask
byrh10: +++ local a=
byrh10: +++ local b=0
byrh10: +++ local num_index=1
byrh10: +++ local str_temp=
byrh10: +++ local str_mask=
byrh10: +++ '[' '!' ']'
byrh10: +++ a=0
byrh10: +++ [[ 1 -le 4 ]]
byrh10: +++ '[' 0 -ge 8 ']'
byrh10: +++ b=0
byrh10: +++ a=0
byrh10: +++ case $b in
byrh10: +++ str_temp=0
byrh10: +++ str_mask=0.
byrh10: +++ num_index=2
byrh10: +++ [[ 2 -le 4 ]]
byrh10: +++ '[' 0 -ge 8 ']'
byrh10: +++ b=0
byrh10: +++ a=0
byrh10: +++ case $b in
byrh10: +++ str_temp=0
byrh10: +++ str_mask=0.0.
byrh10: +++ num_index=3
byrh10: +++ [[ 3 -le 4 ]]
byrh10: +++ '[' 0 -ge 8 ']'
byrh10: +++ b=0
byrh10: +++ a=0
byrh10: +++ case $b in
byrh10: +++ str_temp=0
byrh10: +++ str_mask=0.0.0.
byrh10: +++ num_index=4
byrh10: +++ [[ 4 -le 4 ]]
byrh10: +++ '[' 0 -ge 8 ']'
byrh10: +++ b=0
byrh10: +++ a=0
byrh10: +++ case $b in
byrh10: +++ str_temp=0
byrh10: +++ str_mask=0.0.0.0.
byrh10: +++ num_index=5
byrh10: +++ [[ 5 -le 4 ]]
byrh10: ++++ echo 0.0.0.0.
byrh10: ++++ sed 's/\.$//'
byrh10: +++ str_mask=0.0.0.0
byrh10: +++ echo 0.0.0.0
byrh10: ++ str_mask=0.0.0.0
byrh10: ++ local str_net=
byrh10: ++ local str_temp=
byrh10: ++ local 'str_ifs=
byrh10: '
byrh10: ++ IFS=.
byrh10: ++ array_ip=($1)
byrh10: ++ local array_ip
byrh10: ++ array_mask=($str_mask)
byrh10: ++ local array_mask
byrh10: ++ IFS='
byrh10: '
byrh10: ++ for index in '{0..3}'
byrh10: +++ echo 0
byrh10: ++ str_temp=0
byrh10: ++ str_net=0.
byrh10: ++ for index in '{0..3}'
byrh10: +++ echo 0
byrh10: ++ str_temp=0
byrh10: ++ str_net=0.0.
byrh10: ++ for index in '{0..3}'
byrh10: +++ echo 0
byrh10: ++ str_temp=0
byrh10: ++ str_net=0.0.0.
byrh10: ++ for index in '{0..3}'
byrh10: +++ echo 0
byrh10: ++ str_temp=0
byrh10: ++ str_net=0.0.0.0.
byrh10: +++ echo 0.0.0.0.
byrh10: +++ sed 's/\.$//'
byrh10: ++ str_net=0.0.0.0
byrh10: ++ echo 0.0.0.0
byrh10: + str_temp_net1=0.0.0.0
```
