### PR TITLE
do task395, update xcat-inventory cases for code design change -- fix the output change

### DIFF
--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.environment
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.environment
@@ -112,7 +112,7 @@ check:rc==0
 cmd:xcat-inventory export  -t osimage -o test.environments.osimage -f /tmp/export/test.environments.osimage.yaml --format yaml
 check:rc==0
 check:output=~The inventory data has been dumped to /tmp/export/test.environments.osimage.yaml
-cmd:diff -y  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.yaml /tmp/export/test.environments.osimage.yaml --ignore-blank-lines  -I "^#"
+cmd:#! /bin/bash diff -y  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.yaml /tmp/export/test.environments.osimage.yaml --ignore-blank-lines  -I "^#" -I "schema_version" 
 check:rc==0
 cmd:rmdef -t osimage -o test.environments.osimage
 check:rc==0
@@ -131,7 +131,7 @@ cmd:diff -y /tmp/export/test.environments.osimage.json.stanza /opt/xcat/share/xc
 check:rc==0
 cmd:xcat-inventory export  -t osimage -o test.environments.osimage -f /tmp/export/test.environments.osimage.json
 check:rc==0
-cmd:diff -y  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json /tmp/export/test.environments.osimage.json --ignore-blank-lines  -I "^#"
+cmd:#! /bin/bash diff -y  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json /tmp/export/test.environments.osimage.json --ignore-blank-lines  -I "^#" -I "schema_version" 
 check:rc==0
 cmd:dir="/tmp/export"; rm -rf $dir; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi
 cmd: rmdef -t osimage -o test.environments.osimage

--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.nics
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.nics
@@ -9,11 +9,11 @@ check:rc==0
 cmd:xcat-inventory export  -t node -o testnodes -f /tmp/export/nics.yaml --format yaml
 check:rc==0
 check:output=~The inventory data has been dumped to /tmp/export/nics.yaml 
-cmd:diff -y  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/nics.yaml /tmp/export/nics.yaml --ignore-blank-lines  -I "^#"
+cmd:#! /bin/bash diff -y  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/nics.yaml /tmp/export/nics.yaml --ignore-blank-lines  -I "^#" -I "schema_version"
 check:rc==0
 cmd:xcat-inventory export  -t node -o testnodes -f /tmp/export/nics.json --format json 
 check:rc==0
-cmd:diff -y  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/nics.json /tmp/export/nics.json --ignore-blank-lines  -I "^#"
+cmd:#! /bin/bash diff -y  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/nics.json /tmp/export/nics.json --ignore-blank-lines  -I "^#" -I "schema_version"
 check:rc==0
 cmd:tabch -d node="testnodes" nics
 check:rc==0

--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.osimage
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.osimage
@@ -28,7 +28,7 @@ cmd: scp $$DSTMN:/tmp/export_import_single_osimage_by_yaml_$$DSTMN/dst_bogus_ima
 check:rc==0
 cmd: cat /tmp/export_import_single_osimage_by_yaml/dst_bogus_image.stanza
 check:rc==0
-cmd:diff -y /tmp/export_import_single_osimage_by_yaml/src_bogus_osimage.stanza /tmp/export_import_single_osimage_by_yaml/dst_bogus_image.stanza
+cmd:diff -y /tmp/export_import_single_osimage_by_yaml/src_bogus_osimage.stanza /tmp/export_import_single_osimage_by_yaml/dst_bogus_image.stanza -I "environvar"
 check:rc==0
 cmd:ssh  $$DSTMN 'rmdef -t osimage -o bogus_image'
 check:rc==0
@@ -72,7 +72,7 @@ cmd: scp $$DSTMN:/tmp/export_import_single_osimage_by_json_$$DSTMN/dst_bogus_ima
 check:rc==0
 cmd: cat /tmp/export_import_single_osimage_by_json/dst_bogus_image.stanza
 check:rc==0
-cmd:diff -y /tmp/export_import_single_osimage_by_json/src_bogus_osimage.stanza /tmp/export_import_single_osimage_by_json/dst_bogus_image.stanza
+cmd:diff -y /tmp/export_import_single_osimage_by_json/src_bogus_osimage.stanza /tmp/export_import_single_osimage_by_json/dst_bogus_image.stanza -I "environvar"
 check:rc==0
 cmd:ssh  $$DSTMN 'rmdef -t osimage -o bogus_image'
 check:rc==0
@@ -99,27 +99,27 @@ cmd:chdef -t osimage -o bogus_image addkcmdline=addkcmdline boottarget=boottarge
 check:rc==0
 cmd:xcat-inventory export -t osimage |tee /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc==0
-cmd:grep ' "osimage": {' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd:grep "osimage:"  /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc==0
-cmd:grep '"bogus_image": {' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd:grep "bogus_image:" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc==0
-cmd: grep '"node": {' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd: grep -w "node:"  /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc!=0
-cmd: grep '"obj_type": "node",' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd: grep "obj_type: node" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc!=0
-cmd: grep '"policy": {'' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd: grep "policy:"  /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc!=0
-cmd: grep '"passwd": {' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd: grep "passwd:" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc!=0
-cmd: grep '"network": {' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd: grep "network:" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc!=0
-cmd: grep '"route": {' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd: grep "route:" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc!=0
-cmd: grep '"site": {' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd: grep "site:" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc!=0
 cmd:lsdef -t osimage |tee  /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/osimage_in_xcat_db
 check:rc==0
-cmd: a=0;for i in `awk -F' ' '{print $1}' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/osimage_in_xcat_db`; do if grep -E "\"$i\": {" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file > /dev/null; then ((a++));fi; done; do=$(cat /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/osimage_in_xcat_db|wc -l);if [[ $do -eq $a ]]; then exit 0; else exit 1;fi
+cmd: a=0;for i in `awk -F' ' '{print $1}' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/osimage_in_xcat_db`; do if grep -E "$i:" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file > /dev/null; then ((a++));fi; done; do=$(cat /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/osimage_in_xcat_db|wc -l);if [[ $do -eq $a ]]; then exit 0; else exit 1;fi
 check:rc==0
 cmd: rmdef -t osimage -o  bogus_image
 check:rc==0
@@ -437,7 +437,7 @@ cmd:xcat-inventory import -f /tmp/xcat_inventory_try_to_import_all_type_is_osima
 check:rc==0
 cmd:lsdef -t osimage -l|sort > /tmp/xcat_inventory_try_to_import_all_type_is_osimage_yaml_format/import_osimage
 check:rc==0
-cmd:diff -y /tmp/xcat_inventory_try_to_import_all_type_is_osimage_yaml_format/target_osimage_sort /tmp/xcat_inventory_try_to_import_all_type_is_osimage_yaml_format/import_osimage
+cmd:diff -y /tmp/xcat_inventory_try_to_import_all_type_is_osimage_yaml_format/target_osimage_sort /tmp/xcat_inventory_try_to_import_all_type_is_osimage_yaml_format/import_osimage -I "environvar=OBJNAME=bogus_image"
 check:rc==0
 cmd:lsdef -t node -l > /tmp/xcat_inventory_try_to_import_all_type_is_osimage_yaml_format/after_nodes_db
 check:rc==0
@@ -768,7 +768,7 @@ cmd:xcat-inventory import -f /tmp/xcat_inventory_try_to_import_all_type_is_osima
 check:rc==0
 cmd:lsdef -t osimage -l|sort > /tmp/xcat_inventory_try_to_import_all_type_is_osimage_json_format/import_osimage
 check:rc==0
-cmd:diff -y /tmp/xcat_inventory_try_to_import_all_type_is_osimage_json_format/target_osimage_sort /tmp/xcat_inventory_try_to_import_all_type_is_osimage_json_format/import_osimage
+cmd:diff -y /tmp/xcat_inventory_try_to_import_all_type_is_osimage_json_format/target_osimage_sort /tmp/xcat_inventory_try_to_import_all_type_is_osimage_json_format/import_osimage -I "environvar=OBJNAME=bogus_image"
 check:rc==0
 cmd:lsdef -t node -l > /tmp/xcat_inventory_try_to_import_all_type_is_osimage_json_format/after_nodes_db
 check:rc==0
@@ -851,7 +851,7 @@ cmd: scp $$DSTMN:/tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN
 check:rc==0
 cmd: cat /tmp/export_single_osimage_then_modify_json_then_import/dst_bogus_image.stanza
 check:rc==0
-cmd:diff -y /tmp/export_single_osimage_then_modify_json_then_import/src_bogus_osimage.stanza /tmp/export_single_osimage_then_modify_json_then_import/dst_bogus_image.stanza
+cmd:diff -y /tmp/export_single_osimage_then_modify_json_then_import/src_bogus_osimage.stanza /tmp/export_single_osimage_then_modify_json_then_import/dst_bogus_image.stanza -I "environvar=OBJNAME=bogus_image"
 check:rc==0
 cmd:ssh  $$DSTMN 'rmdef -t osimage -o bogus_image'
 check:rc==0
@@ -908,7 +908,7 @@ cmd: scp $$DSTMN:/tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN
 check:rc==0
 cmd: cat /tmp/export_single_osimage_then_modify_yaml_then_import/dst_bogus_image.stanza
 check:rc==0
-cmd:diff -y /tmp/export_single_osimage_then_modify_yaml_then_import/src_bogus_osimage.stanza /tmp/export_single_osimage_then_modify_yaml_then_import/dst_bogus_image.stanza
+cmd:diff -y /tmp/export_single_osimage_then_modify_yaml_then_import/src_bogus_osimage.stanza /tmp/export_single_osimage_then_modify_yaml_then_import/dst_bogus_image.stanza -I "environvar=OBJNAME=bogus_image"
 check:rc==0
 cmd:ssh  $$DSTMN 'rmdef -t osimage -o bogus_image'
 check:rc==0
@@ -1208,12 +1208,8 @@ check:rc==0
 cmd:rm -rf /tmp/otherpkglist /tmp/synclists /tmp/postinstall /tmp/exlist /tmp/pkglist /tmp/template /tmp/partitionfile
 cmd:xcat-inventory import -t osimage -d /opt/inventory/site
 check:rc==0
-check:output=~Importing object: test_myimage1
 check:output=~Inventory import successfully!
-check:output=~The object test_myimage1 has been imported
-check:output=~Importing object: test_myimage2
 check:output=~Inventory import successfully!
-check:output=~The object test_myimage2 has been imported
 cmd:lsdef -t osimage -o test_myimage1,test_myimage2
 check:rc==0
 cmd:otherpkglist=`lsdef -t osimage -o test_myimage1 |grep otherpkglist|awk -F= '{print $2}'`;diff -y $otherpkglist /opt/inventory/site/osimage/test_myimage1$otherpkglist
@@ -1248,7 +1244,6 @@ cmd: rmdef -t osimage -o  test_myimage1,test_myimage2
 check:rc==0
 cmd: if [ -e /tmp/test_myimage1.stanza ]; then cat /tmp/test_myimage1.stanza |mkdef -z;fi
 cmd: if [ -e /tmp/test_myimage2.stanza ]; then cat /tmp/test_myimage2.stanza |mkdef -z;fi
-cmd:dir="/opt/inventory/site/osimage"; rm -rf $dir; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi
 cmd:dir="/opt/inventory/site/osimage"; rm -rf $dir; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi
 cmd:file="/tmp/otherpkglist"; rm -rf $file; if [ -d ${file}".bak" ];then mv ${file}".bak" $file; fi
 cmd:file="/tmp/synclists"; rm -rf $file; if [ -d ${file}".bak" ];then mv ${file}".bak" $file; fi
@@ -1285,10 +1280,8 @@ check:output=~The osimage objects has been exported to directory /tmp/export
 cmd:ls -lFR /tmp/export
 cmd: xcat-inventory import -t osimage -d /tmp/export -c
 check:rc==0
-check:output=~Importing object: test_myimage1
 check:output=~Inventory import successfully!
 check:output=~The object test_myimage1 has been imported
-check:output=~Importing object: test_myimage2
 check:output=~Inventory import successfully!
 check:output=~The object test_myimage2 has been imported
 cmd:lsdef -t osimage -o test_myimage1,test_myimage2


### PR DESCRIPTION
### The PR is to fix issue  https://github.com/xcat2/xcat2-task-management/issues/395

UT
```
[root@c910f03c01p13 autotest]# xcattest -f default.conf -t export_osimage_with_environments
xCAT automated test started at Mon Nov 12 03:24:30 2018
******************************
loading Configure file
******************************
OBJECT:c910f03c01p14,TYPE:node
    profile = compute;
    tftpserver = 10.3.1.13;
    status = powering-off;
    netboot = grub2;
    ip = 10.3.1.14;
    arch = ppc64le;
    os = rhels7.5;
    hwtype = lpar;
    mgt = hmc;
    groups = all;
    hcp = c910hmc02;
    id = 14;
    nfsserver = c910f03c01p13;
    mac = ba:60:8d:69:be:03;
    currstate = netboot;
    postscripts = syslog,remoteshell,syncfiles;
    provmethod = test.environments.osimage;
    parent = c910f03fsp01;
    xcatmaster = 10.3.1.13;
    pprofile = c910f03c01p14;
    conserver = c910f03c01p13;
    nodetype = ppc,osi;
    statustime = 10-23-2018;
    postbootscripts = otherpkgs;
    monserver = c910f03c01p13;
Varible:
    CN = c910f03c01p14
    ISO = /RHEL-7.5-Server-ppc64le-dvd1-stable.iso
    DSTMN = 10.3.1.13
    MN = c910f03c01p13
******************************
Initialize xCAT test environment by definition in configure file
******************************
chdef -t node -o c910f03c01p14 profile=compute tftpserver=10.3.1.13 status=powering-off netboot=grub2 ip=10.3.1.14 arch=ppc64le os=rhels7.5 hwtype=lpar mgt=hmc groups=all hcp=c910hmc02 id=14 nfsserver=c910f03c01p13 mac=ba:60:8d:69:be:03 currstate=netboot postscripts=syslog,remoteshell,syncfiles provmethod=test.environments.osimage parent=c910f03fsp01 xcatmaster=10.3.1.13 pprofile=c910f03c01p14 conserver=c910f03c01p13 nodetype=ppc,osi statustime=10-23-2018 postbootscripts=otherpkgs monserver=c910f03c01p13
******************************
To detect current test environment
******************************
Detecting: OS = linux
Detecting: ARCH = ppc64le
Detecting: HCP = hmc
******************************
loading test cases
******************************
To run:
export_osimage_with_environments
******************************
Start to run test cases
******************************
------START::export_osimage_with_environments::Time:Mon Nov 12 03:24:33 2018------

RUN:lsdef -t osimage -o test.environments.osimage >/dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t osimage -o test.environments.osimage -z >/tmp/test.environments.osimage_image.stanza ;rmdef -t osimage -o test.environments.osimage;fi [Mon Nov 12 03:24:33 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:dir="/tmp/export";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi; mkdir -p $dir [Mon Nov 12 03:24:34 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:osarch=$(lsdef -t osimage __GETNODEATTR(c910f03c01p14,os)__-__GETNODEATTR(c910f03c01p14,arch)__-netboot-compute|grep osarch|awk -F'=' '{print $2}');sed -i "s/OSARCH/$osarch/g" /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.yaml [Mon Nov 12 03:24:34 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:

RUN:osvers=$(lsdef -t osimage __GETNODEATTR(c910f03c01p14,os)__-__GETNODEATTR(c910f03c01p14,arch)__-netboot-compute|grep osvers|awk -F'=' '{print $2}');sed -i "s/OSVERS/$osvers/g" /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.yaml [Mon Nov 12 03:24:36 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:

RUN:pkgdir=$(lsdef -t osimage __GETNODEATTR(c910f03c01p14,os)__-__GETNODEATTR(c910f03c01p14,arch)__-netboot-compute|grep -w pkgdir|awk -F'=' '{print $2}');sed -i "s!PKGDIR!$pkgdir!g" /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.yaml [Mon Nov 12 03:24:38 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:

RUN:pkglist=$(lsdef -t osimage __GETNODEATTR(c910f03c01p14,os)__-__GETNODEATTR(c910f03c01p14,arch)__-netboot-compute|grep -w pkglist|awk -F'=' '{print $2}');sed -i "s!PKGLIST!$pkglist!g" /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.yaml [Mon Nov 12 03:24:40 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:postinstall=$(lsdef -t osimage __GETNODEATTR(c910f03c01p14,os)__-__GETNODEATTR(c910f03c01p14,arch)__-netboot-compute|grep -w postinstall|awk -F'=' '{print $2}');sed -i "s!POSTINSTALL!$postinstall!g" /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.yaml [Mon Nov 12 03:24:41 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:osmajor=$(lsdef -t osimage __GETNODEATTR(c910f03c01p14,os)__-__GETNODEATTR(c910f03c01p14,arch)__-netboot-compute|grep osvers|awk -F'=' '{print $2}');sed -i "s/OSMAJOR/$osmajor/g" /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.yaml [Mon Nov 12 03:24:42 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:xcat-inventory import -f /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.yaml -e GITREPO=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo -e SWDIR=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir [Mon Nov 12 03:24:43 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
loading inventory date in "/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.yaml"
start to import "osimage" type objects
 preprocessing "osimage" type objects
 writting "osimage" type objects
Inventory import successfully!
CHECK:output =~ Inventory import successfully!	[Pass]
CHECK:rc == 0	[Pass]

RUN:lsdef -t osimage -o test.environments.osimage -z >> /tmp/export/test.environments.osimage.yaml.stanza [Mon Nov 12 03:24:44 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:osarch=$(lsdef -t osimage __GETNODEATTR(c910f03c01p14,os)__-__GETNODEATTR(c910f03c01p14,arch)__-netboot-compute|grep osarch|awk -F'=' '{print $2}');sed -i "s/OSARCH/$osarch/g" /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.stanza [Mon Nov 12 03:24:44 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:

RUN:osvers=$(lsdef -t osimage __GETNODEATTR(c910f03c01p14,os)__-__GETNODEATTR(c910f03c01p14,arch)__-netboot-compute|grep osvers|awk -F'=' '{print $2}');sed -i "s/OSVERS/$osvers/g" /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.stanza [Mon Nov 12 03:24:46 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:pkgdir=$(lsdef -t osimage __GETNODEATTR(c910f03c01p14,os)__-__GETNODEATTR(c910f03c01p14,arch)__-netboot-compute|grep -w pkgdir|awk -F'=' '{print $2}');sed -i "s!PKGDIR!$pkgdir!g" /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.stanza [Mon Nov 12 03:24:47 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:pkglist=$(lsdef -t osimage __GETNODEATTR(c910f03c01p14,os)__-__GETNODEATTR(c910f03c01p14,arch)__-netboot-compute|grep -w pkglist|awk -F'=' '{print $2}');sed -i "s!PKGLIST!$pkglist!g" /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.stanza [Mon Nov 12 03:24:48 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:postinstall=$(lsdef -t osimage __GETNODEATTR(c910f03c01p14,os)__-__GETNODEATTR(c910f03c01p14,arch)__-netboot-compute|grep -w postinstall|awk -F'=' '{print $2}');sed -i "s!POSTINSTALL!$postinstall!g" /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.stanza [Mon Nov 12 03:24:49 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:osmajor=$(lsdef -t osimage __GETNODEATTR(c910f03c01p14,os)__-__GETNODEATTR(c910f03c01p14,arch)__-netboot-compute|grep osvers|awk -F'=' '{print $2}');sed -i "s/OSMAJOR/$osmajor/g" /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.stanza [Mon Nov 12 03:24:50 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:diff -y /tmp/export/test.environments.osimage.yaml.stanza /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.stanza [Mon Nov 12 03:24:51 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
# <xCAT data object stanza file>				# <xCAT data object stanza file>

test.environments.osimage:					test.environments.osimage:
    objtype=osimage						    objtype=osimage
    environvar=GITREPO=/opt/xcat/share/xcat/tools/autotest/te	    environvar=GITREPO=/opt/xcat/share/xcat/tools/autotest/te
    imagetype=linux						    imagetype=linux
    osarch=ppc64le						    osarch=ppc64le
    osdistroname=rhels7.5-ppc64le				    osdistroname=rhels7.5-ppc64le
    osname=Linux						    osname=Linux
    osvers=rhels7.5						    osvers=rhels7.5
    otherpkgdir=/opt/xcat/share/xcat/tools/autotest/testcase/	    otherpkgdir=/opt/xcat/share/xcat/tools/autotest/testcase/
    otherpkglist=/opt/xcat/share/xcat/tools/autotest/testcase	    otherpkglist=/opt/xcat/share/xcat/tools/autotest/testcase
    permission=755						    permission=755
    pkgdir=/install/rhels7.5/ppc64le,/opt/xcat/share/xcat/too	    pkgdir=/install/rhels7.5/ppc64le,/opt/xcat/share/xcat/too
    pkglist=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.pp	    pkglist=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.pp
    postinstall=/opt/xcat/share/xcat/netboot/rh/compute.rhels	    postinstall=/opt/xcat/share/xcat/netboot/rh/compute.rhels
    profile=compute						    profile=compute
    provmethod=netboot						    provmethod=netboot
    rootimgdir=/install/custom/test.environments.osimage	    rootimgdir=/install/custom/test.environments.osimage
    synclists=/opt/xcat/share/xcat/tools/autotest/testcase/xc	    synclists=/opt/xcat/share/xcat/tools/autotest/testcase/xc
    usercomment=rhels7.5,test_environment_variables		    usercomment=rhels7.5,test_environment_variables
CHECK:rc == 0	[Pass]

RUN:xcat-inventory export  -t osimage -o test.environments.osimage -f /tmp/export/test.environments.osimage.yaml --format yaml [Mon Nov 12 03:24:51 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
The inventory data has been dumped to /tmp/export/test.environments.osimage.yaml
CHECK:rc == 0	[Pass]
CHECK:output =~ The inventory data has been dumped to /tmp/export/test.environments.osimage.yaml	[Pass]

RUN:#! /bin/bash diff -y  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.yaml /tmp/export/test.environments.osimage.yaml --ignore-blank-lines  -I "^ [Mon Nov 12 03:24:52 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:rmdef -t osimage -o test.environments.osimage [Mon Nov 12 03:24:52 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:osarch=$(lsdef -t osimage __GETNODEATTR(c910f03c01p14,os)__-__GETNODEATTR(c910f03c01p14,arch)__-netboot-compute|grep osarch|awk -F'=' '{print $2}');sed -i "s/OSARCH/$osarch/g" /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json [Mon Nov 12 03:24:52 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:osvers=$(lsdef -t osimage __GETNODEATTR(c910f03c01p14,os)__-__GETNODEATTR(c910f03c01p14,arch)__-netboot-compute|grep osvers|awk -F'=' '{print $2}');sed -i "s/OSVERS/$osvers/g" /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json [Mon Nov 12 03:24:53 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:pkgdir=$(lsdef -t osimage __GETNODEATTR(c910f03c01p14,os)__-__GETNODEATTR(c910f03c01p14,arch)__-netboot-compute|grep -w pkgdir|awk -F'=' '{print $2}');sed -i "s!PKGDIR!$pkgdir!g" /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json [Mon Nov 12 03:24:54 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:pkglist=$(lsdef -t osimage __GETNODEATTR(c910f03c01p14,os)__-__GETNODEATTR(c910f03c01p14,arch)__-netboot-compute|grep -w pkglist|awk -F'=' '{print $2}');sed -i "s!PKGLIST!$pkglist!g" /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json [Mon Nov 12 03:24:55 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:

RUN:postinstall=$(lsdef -t osimage __GETNODEATTR(c910f03c01p14,os)__-__GETNODEATTR(c910f03c01p14,arch)__-netboot-compute|grep -w postinstall|awk -F'=' '{print $2}');sed -i "s!POSTINSTALL!$postinstall!g" /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json [Mon Nov 12 03:24:57 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:osmajor=$(lsdef -t osimage __GETNODEATTR(c910f03c01p14,os)__-__GETNODEATTR(c910f03c01p14,arch)__-netboot-compute|grep osvers|awk -F'=' '{print $2}');sed -i "s/OSMAJOR/$osmajor/g" /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json [Mon Nov 12 03:24:58 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:xcat-inventory import -f /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json -e GITREPO=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo -e SWDIR=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir [Mon Nov 12 03:24:59 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
loading inventory date in "/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json"
start to import "osimage" type objects
 preprocessing "osimage" type objects
 writting "osimage" type objects
Inventory import successfully!
CHECK:output =~ Inventory import successfully!	[Pass]
CHECK:rc == 0	[Pass]

RUN:lsdef -t osimage -o test.environments.osimage -z >> /tmp/export/test.environments.osimage.json.stanza [Mon Nov 12 03:25:00 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:diff -y /tmp/export/test.environments.osimage.json.stanza /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.stanza [Mon Nov 12 03:25:00 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
# <xCAT data object stanza file>				# <xCAT data object stanza file>

test.environments.osimage:					test.environments.osimage:
    objtype=osimage						    objtype=osimage
    environvar=GITREPO=/opt/xcat/share/xcat/tools/autotest/te	    environvar=GITREPO=/opt/xcat/share/xcat/tools/autotest/te
    imagetype=linux						    imagetype=linux
    osarch=ppc64le						    osarch=ppc64le
    osdistroname=rhels7.5-ppc64le				    osdistroname=rhels7.5-ppc64le
    osname=Linux						    osname=Linux
    osvers=rhels7.5						    osvers=rhels7.5
    otherpkgdir=/opt/xcat/share/xcat/tools/autotest/testcase/	    otherpkgdir=/opt/xcat/share/xcat/tools/autotest/testcase/
    otherpkglist=/opt/xcat/share/xcat/tools/autotest/testcase	    otherpkglist=/opt/xcat/share/xcat/tools/autotest/testcase
    permission=755						    permission=755
    pkgdir=/install/rhels7.5/ppc64le,/opt/xcat/share/xcat/too	    pkgdir=/install/rhels7.5/ppc64le,/opt/xcat/share/xcat/too
    pkglist=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.pp	    pkglist=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.pp
    postinstall=/opt/xcat/share/xcat/netboot/rh/compute.rhels	    postinstall=/opt/xcat/share/xcat/netboot/rh/compute.rhels
    profile=compute						    profile=compute
    provmethod=netboot						    provmethod=netboot
    rootimgdir=/install/custom/test.environments.osimage	    rootimgdir=/install/custom/test.environments.osimage
    synclists=/opt/xcat/share/xcat/tools/autotest/testcase/xc	    synclists=/opt/xcat/share/xcat/tools/autotest/testcase/xc
    usercomment=rhels7.5,test_environment_variables		    usercomment=rhels7.5,test_environment_variables
CHECK:rc == 0	[Pass]

RUN:xcat-inventory export  -t osimage -o test.environments.osimage -f /tmp/export/test.environments.osimage.json [Mon Nov 12 03:25:00 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
The inventory data has been dumped to /tmp/export/test.environments.osimage.json
CHECK:rc == 0	[Pass]

RUN:#! /bin/bash diff -y  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json /tmp/export/test.environments.osimage.json --ignore-blank-lines  -I "^ [Mon Nov 12 03:25:01 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:dir="/tmp/export"; rm -rf $dir; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi [Mon Nov 12 03:25:01 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:rmdef -t osimage -o test.environments.osimage [Mon Nov 12 03:25:01 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:if [ -e /tmp/test.environments.osimage.stanza ]; then cat /tmp/test.environments.osimage.stanza |mkdef -z;fi [Mon Nov 12 03:25:01 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::export_osimage_with_environments::Passed::Time:Mon Nov 12 03:25:01 2018 ::Duration::28 sec------
------Total: 1 , Failed: 0------

------START::export_import_nics_with_regex::Time:Mon Nov 12 03:27:28 2018------

RUN:dir="/tmp/export";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi; mkdir -p $dir [Mon Nov 12 03:27:28 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:tabdump nics |tee /tmp/export/nics.cvs [Mon Nov 12 03:27:28 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
#node,nicips,nichostnamesuffixes,nichostnameprefixes,nictypes,niccustomscripts,nicnetworks,nicaliases,nicextraparams,nicdevices,nicsadapter,comments,disable
"bogusnode","ib0!10.10.100.9,enP48p1s0f0!129.40.234.11,ib1!10.11.100.9,eth0!10.1.1.1","ib0!-ib0,eth0!-eth0","ib0!ib-,eth0!eth0-","enP5p1s0f1.4!unused,ib0!Infiniband,enP48p1s0f0!Ethernet,enP48p1s0f1!unused,ib3!unused,ib2!unused,enP5p1s0f1!unused,ib1!Infiniband,enP5p1s0f1.5!unused,enP5p1s0f1.6!unused","ib0!configib ib0,eth0!configeth eth0","enP5p1s0f1.4!xcat_bmc,enP48p1s0f1!xcat_util,ib0!IB00,enP48p1s0f0!pub_yellow,ib3!IB03,ib2!IB02,enP5p1s0f1!xcat_compute,ib1!IB01,enP5p1s0f1.5!xcat_infra,enP5p1s0f1.6!xcat_pdu","eth1!tom|jerry,eth0!moe larry curly","ib0!MTU=65520 CONNECTED_MODE=yes,eth0!MTU=1500","bond0!eth0|eth2,br0!bond0","enP3p3s0f2!mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face,enP3p3s0f1!mac=98:be:94:59:fa:cd linkstate=DOWN",,
CHECK:rc == 0	[Pass]

RUN:tabrestore  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/nics.csv [Mon Nov 12 03:27:28 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xcat-inventory export  -t node -o testnodes -f /tmp/export/nics.yaml --format yaml [Mon Nov 12 03:27:29 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
The inventory data has been dumped to /tmp/export/nics.yaml
CHECK:rc == 0	[Pass]
CHECK:output =~ The inventory data has been dumped to /tmp/export/nics.yaml	[Pass]

RUN:#! /bin/bash diff -y  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/nics.yaml /tmp/export/nics.yaml --ignore-blank-lines  -I "^ [Mon Nov 12 03:27:30 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xcat-inventory export  -t node -o testnodes -f /tmp/export/nics.json --format json [Mon Nov 12 03:27:30 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
The inventory data has been dumped to /tmp/export/nics.json
CHECK:rc == 0	[Pass]

RUN:#! /bin/bash diff -y  /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/nics.json /tmp/export/nics.json --ignore-blank-lines  -I "^ [Mon Nov 12 03:27:31 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:tabch -d node="testnodes" nics [Mon Nov 12 03:27:31 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xcat-inventory import  -t node -o testnodes -f /tmp/export/nics.yaml [Mon Nov 12 03:27:31 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
loading inventory date in "/tmp/export/nics.yaml"
start to import "node" type objects
 preprocessing "node" type objects
 writting "node" type objects
Inventory import successfully!
CHECK:rc == 0	[Pass]
CHECK:output =~ loading inventory date in "/tmp/export/nics.yaml"	[Pass]
CHECK:output =~ start to import "node" type objects	[Pass]
CHECK:output =~ preprocessing "node" type objects	[Pass]
CHECK:output =~ writting "node" type objects	[Pass]
CHECK:output =~ Inventory import successfully!	[Pass]

RUN:tabdump nics |tee /tmp/export/nics.yaml.cvs;diff -y /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/nics.csv /tmp/export/nics.yaml.cvs [Mon Nov 12 03:27:32 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
#node,nicips,nichostnamesuffixes,nichostnameprefixes,nictypes,niccustomscripts,nicnetworks,nicaliases,nicextraparams,nicdevices,nicsadapter,comments,disable
"testnodes","|(.)(..)n(..)|ib0!(ipadd(10,41,0,100,dim2idx(a2idx($1),36,$2,18,$3),2,1))|","ib0!ib",,"ib0!Infiniband",,"ib0!ipoib",,,,,,
#node,nicips,nichostnamesuffixes,nichostnameprefixes,nictypes	#node,nicips,nichostnamesuffixes,nichostnameprefixes,nictypes
"testnodes","|(.)(..)n(..)|ib0!(ipadd(10,41,0,100,dim2idx(a2i	"testnodes","|(.)(..)n(..)|ib0!(ipadd(10,41,0,100,dim2idx(a2i
CHECK:rc == 0	[Pass]

RUN:tabch -d node="testnodes" nics [Mon Nov 12 03:27:32 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xcat-inventory import  -t node -o testnodes -f /tmp/export/nics.json [Mon Nov 12 03:27:32 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
loading inventory date in "/tmp/export/nics.json"
start to import "node" type objects
 preprocessing "node" type objects
 writting "node" type objects
Inventory import successfully!
CHECK:rc == 0	[Pass]
CHECK:output =~ loading inventory date in "/tmp/export/nics.json"	[Pass]
CHECK:output =~ start to import "node" type objects	[Pass]
CHECK:output =~ preprocessing "node" type objects	[Pass]
CHECK:output =~ writting "node" type objects	[Pass]
CHECK:output =~ Inventory import successfully!	[Pass]

RUN:tabdump nics |tee /tmp/export/nics.json.cvs;diff -y /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/nics.csv /tmp/export/nics.json.cvs [Mon Nov 12 03:27:33 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
#node,nicips,nichostnamesuffixes,nichostnameprefixes,nictypes,niccustomscripts,nicnetworks,nicaliases,nicextraparams,nicdevices,nicsadapter,comments,disable
"testnodes","|(.)(..)n(..)|ib0!(ipadd(10,41,0,100,dim2idx(a2idx($1),36,$2,18,$3),2,1))|","ib0!ib",,"ib0!Infiniband",,"ib0!ipoib",,,,,,
#node,nicips,nichostnamesuffixes,nichostnameprefixes,nictypes	#node,nicips,nichostnamesuffixes,nichostnameprefixes,nictypes
"testnodes","|(.)(..)n(..)|ib0!(ipadd(10,41,0,100,dim2idx(a2i	"testnodes","|(.)(..)n(..)|ib0!(ipadd(10,41,0,100,dim2idx(a2i
CHECK:rc == 0	[Pass]

RUN:tabch -d node="testnodes" nics [Mon Nov 12 03:27:33 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:tabrestore /tmp/export/nics.cvs [Mon Nov 12 03:27:33 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:dir="/tmp/export"; rm -rf $dir; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi [Mon Nov 12 03:27:34 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::export_import_nics_with_regex::Passed::Time:Mon Nov 12 03:27:34 2018 ::Duration::6 sec------
------START::xcat_inventory_try_to_export_all_type_is_osimage_default_format::Time:Mon Nov 12 03:29:14 2018------

RUN:mkdir -p /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format [Mon Nov 12 03:29:14 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:lsdef -t osimage -o bogus_image >/dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t osimage -o bogus_image -z >/tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/bogus_image.stanza ;rmdef -t osimage -o bogus_image;fi [Mon Nov 12 03:29:14 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:chdef -t osimage -o bogus_image addkcmdline=addkcmdline boottarget=boottarget cfmdir=cfmdir crashkernelsize=crashkernelsize description=description driverupdatesrc=driverupdatesrc dump=dump exlist=exlist groups=groups imagename=imagename imagetype=linux isdeletable=isdeletable kerneldir=kerneldir kernelver=kernelver kitcomponents=kitcomponents krpmver=krpmver netdrivers=netdrivers nodebootif=nodebootif osarch=osarch osdistroname=osdistroname osname=osname osupdatename=osupdatename osvers=osvers otherifce=otherifce otherpkgdir=otherpkgdir otherpkglist=otherpkglist partitionfile=partitionfile permission=permission pkgdir=pkgdir pkglist=pkglist postbootscripts=postbootscripts postinstall=postinstall postscripts=postscripts profile=compute provmethod=netboot rootfstype=nfs rootimgdir=rootimgdir serverrole=serverrole synclists=synclists template=template usercomment=usercomment [Mon Nov 12 03:29:15 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
New object definitions 'bogus_image' have been created.
CHECK:rc == 0	[Pass]

RUN:xcat-inventory export -t osimage |tee /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file [Mon Nov 12 03:29:16 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
osimage:
  bogus_image:
    addkcmdline: addkcmdline
    basic_attributes:
      arch: osarch
      description: description
      distribution: osvers
      groups: groups
      osdistro: osdistroname
      osname: osname
    boottarget: boottarget
    deprecated:
      cfmdir: cfmdir
      comments:
      - usercomment
      isdeletable: isdeletable
      kitcomponents: kitcomponents
      krpmver: krpmver
      otherifce: otherifce
      serverrole: serverrole
    diskpartitionspec: partitionfile
    filestosync:
    - synclists
    genimgoptions:
      exlist:
      - exlist
      nodebootif: nodebootif
      permission: permission
      postinstall:
      - postinstall
      rootfstype: nfs
      rootimgdir: rootimgdir
    imagetype: linux
    kernel_driver:
      driverupdatesrc: driverupdatesrc
      kerneldir: kerneldir
      kernelver: kernelver
      netdrivers: netdrivers
    kernel_dump:
      crashkernelsize: crashkernelsize
      dump: dump
    osupdatename: osupdatename
    package_selection:
      otherpkgdir:
      - otherpkgdir
      otherpkglist:
      - otherpkglist
      pkgdir:
      - pkgdir
      pkglist:
      - pkglist
    provision_mode: netboot
    role: compute
    scripts:
      postbootscripts:
      - postbootscripts
      postscripts:
      - postscripts
    template: template
  rhels7.5-ppc64le-install-compute:
    basic_attributes:
      arch: ppc64le
      distribution: rhels7.5
      osdistro: rhels7.5-ppc64le
      osname: Linux
    imagetype: linux
    package_selection:
      otherpkgdir:
      - /install/post/otherpkgs/rhels7.5/ppc64le
      pkgdir:
      - /install/rhels7.5/ppc64le
      pkglist:
      - /opt/xcat/share/xcat/install/rh/compute.rhels7.pkglist
    provision_mode: install
    role: compute
    template: /opt/xcat/share/xcat/install/rh/compute.rhels7.tmpl
  rhels7.5-ppc64le-install-service:
    basic_attributes:
      arch: ppc64le
      distribution: rhels7.5
      osdistro: rhels7.5-ppc64le
      osname: Linux
    imagetype: linux
    package_selection:
      otherpkgdir:
      - /install/post/otherpkgs/rhels7.5/ppc64le
      otherpkglist:
      - /opt/xcat/share/xcat/install/rh/service.rhels7.ppc64le.otherpkgs.pkglist
      pkgdir:
      - /install/rhels7.5/ppc64le
      pkglist:
      - /opt/xcat/share/xcat/install/rh/service.rhels7.ppc64le.pkglist
    provision_mode: install
    role: service
    scripts:
      postscripts:
      - servicenode
    template: /opt/xcat/share/xcat/install/rh/service.rhels7.tmpl
  rhels7.5-ppc64le-netboot-compute:
    basic_attributes:
      arch: ppc64le
      distribution: rhels7.5
      osdistro: rhels7.5-ppc64le
      osname: Linux
    genimgoptions:
      exlist:
      - /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.exlist
      postinstall:
      - /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.postinstall
      rootimgdir: /install/netboot/rhels7.5/ppc64le/compute
    imagetype: linux
    package_selection:
      otherpkgdir:
      - /install/post/otherpkgs/rhels7.5/ppc64le
      pkgdir:
      - /install/rhels7.5/ppc64le
      pkglist:
      - /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist
    provision_mode: netboot
    role: compute
  rhels7.5-ppc64le-stateful-mgmtnode:
    basic_attributes:
      arch: ppc64le
      distribution: rhels7.5
      osdistro: rhels7.5-ppc64le
      osname: Linux
    imagetype: linux
    package_selection:
      otherpkgdir:
      - /install/post/otherpkgs/rhels7.5/ppc64le
      pkgdir:
      - /install/rhels7.5/ppc64le
      pkglist:
      - /opt/xcat/share/xcat/install/rh/compute.rhels7.pkglist
    provision_mode: install
    role: compute
    template: /opt/xcat/share/xcat/install/rh/compute.rhels7.tmpl
  rhels7.5-ppc64le-statelite-compute:
    basic_attributes:
      arch: ppc64le
      distribution: rhels7.5
      osdistro: rhels7.5-ppc64le
      osname: Linux
    genimgoptions:
      exlist:
      - /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.exlist
      postinstall:
      - /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.postinstall
      rootimgdir: /install/netboot/rhels7.5/ppc64le/compute
    imagetype: linux
    package_selection:
      otherpkgdir:
      - /install/post/otherpkgs/rhels7.5/ppc64le
      pkgdir:
      - /install/rhels7.5/ppc64le
      pkglist:
      - /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist
    provision_mode: statelite
    role: compute
  test_myimage:
    diskpartitionspec: /tmp/test_myimage/partitionfile
    filestosync:
    - /tmp/test_myimage/synclists
    genimgoptions:
      exlist:
      - /tmp/test_myimage/exlist
      postinstall:
      - /tmp/test_myimage/postinstall
    imagetype: linux
    package_selection:
      otherpkglist:
      - /tmp/test_myimage/otherpkglist
      pkglist:
      - /opt/xcat/share/xcat/install/rh/compute.rhels7.pkglist
      - /tmp/aa
    provision_mode: install
    template: /opt/xcat/share/xcat/install/rh/compute.rhels7.tmpl
  test_myimage1:
    diskpartitionspec: /tmp/partitionfile
    filestosync:
    - /tmp/synclists
    genimgoptions:
      exlist:
      - /tmp/exlist
      postinstall:
      - /tmp/postinstall
    imagetype: linux
    package_selection:
      otherpkglist:
      - /tmp/otherpkglist
      pkglist:
      - /opt/xcat/share/xcat/install/rh/compute.rhels7.pkglist
    provision_mode: install
    template: /opt/xcat/share/xcat/install/rh/compute.rhels7.tmpl
  test_myimage2:
    diskpartitionspec: /opt/xcat/share/xcat/install/rh/partitionfile
    filestosync:
    - /opt/xcat/share/xcat/install/rh/synclists
    genimgoptions:
      exlist:
      - /opt/xcat/share/xcat/install/rh/exlist
      postinstall:
      - /opt/xcat/share/xcat/install/rh/postinstall
    imagetype: linux
    package_selection:
      otherpkglist:
      - /opt/xcat/share/xcat/install/rh/otherpkglist
      pkglist:
      - /tmp/pkglist
    provision_mode: install
    template: /tmp/template
schema_version: '2.0'

#Version 2.14.5 (git commit 4042193c2100b874d58c9e85c7d35ad9bbd8f135, built Mon Nov  5 06:16:43 EST 2018)
CHECK:rc == 0	[Pass]

RUN:grep "osimage:"  /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file [Mon Nov 12 03:29:17 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
osimage:
CHECK:rc == 0	[Pass]

RUN:grep "bogus_image:" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file [Mon Nov 12 03:29:17 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
  bogus_image:
CHECK:rc == 0	[Pass]

RUN:grep -w "node:"  /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file [Mon Nov 12 03:29:17 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
CHECK:rc != 0	[Pass]

RUN:grep "obj_type: node" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file [Mon Nov 12 03:29:17 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
CHECK:rc != 0	[Pass]

RUN:grep "policy:"  /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file [Mon Nov 12 03:29:17 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
CHECK:rc != 0	[Pass]

RUN:grep "passwd:" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file [Mon Nov 12 03:29:17 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
CHECK:rc != 0	[Pass]

RUN:grep "network:" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file [Mon Nov 12 03:29:17 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
CHECK:rc != 0	[Pass]

RUN:grep "route:" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file [Mon Nov 12 03:29:17 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
CHECK:rc != 0	[Pass]

RUN:grep "site:" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file [Mon Nov 12 03:29:17 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
CHECK:rc != 0	[Pass]

RUN:lsdef -t osimage |tee  /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/osimage_in_xcat_db [Mon Nov 12 03:29:17 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
bogus_image  (osimage)
rhels7.5-ppc64le-install-compute  (osimage)
rhels7.5-ppc64le-install-service  (osimage)
rhels7.5-ppc64le-netboot-compute  (osimage)
rhels7.5-ppc64le-stateful-mgmtnode  (osimage)
rhels7.5-ppc64le-statelite-compute  (osimage)
test_myimage  (osimage)
test_myimage1  (osimage)
test_myimage2  (osimage)
CHECK:rc == 0	[Pass]

RUN:a=0;for i in `awk -F' ' '{print $1}' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/osimage_in_xcat_db`; do if grep -E "$i:" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file > /dev/null; then ((a++));fi; done; do=$(cat /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/osimage_in_xcat_db|wc -l);if [[ $do -eq $a ]]; then exit 0; else exit 1;fi [Mon Nov 12 03:29:17 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:rmdef -t osimage -o  bogus_image [Mon Nov 12 03:29:17 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:if [[ -e /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/bogus_image.stanza ]]; then cat /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/bogus_image.stanza | mkdef -z;fi [Mon Nov 12 03:29:17 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:rm -rf /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format [Mon Nov 12 03:29:18 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::xcat_inventory_try_to_export_all_type_is_osimage_default_format::Passed::Time:Mon Nov 12 03:29:18 2018 ::Duration::4 sec------
------Total: 1 , Failed: 0------
------START::export_import_all_osimages_by_dir::Time:Mon Nov 12 03:30:08 2018------

RUN:lsdef -t osimage -z | tee /tmp/osimage.list [Mon Nov 12 03:30:08 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
# <xCAT data object stanza file>

bogus_image:

rhels7.5-ppc64le-install-compute:

rhels7.5-ppc64le-install-service:

rhels7.5-ppc64le-netboot-compute:

rhels7.5-ppc64le-stateful-mgmtnode:

rhels7.5-ppc64le-statelite-compute:

test_myimage:

test_myimage1:

test_myimage2:
CHECK:rc == 0	[Pass]

RUN:if [ -e /tmp/osimages ]; then cp -f /tmp/osimages /tmp/osimages.bak ; else mkdir -p /tmp/osimages; fi [Mon Nov 12 03:30:08 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
cp: omitting directory '/tmp/osimages'

RUN:imgdir='/tmp/osimages';for img in $(lsdef -t osimage -s|awk -F' ' '{print $1}'); do lsdef -t osimage -o $img -z > $imgdir/${img}.stanza;done [Mon Nov 12 03:30:08 2018]
ElapsedTime:4 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:for img in $(lsdef -t osimage -s|awk -F' ' '{print $1}');do rmdef -t osimage -o $img;done [Mon Nov 12 03:30:12 2018]
ElapsedTime:4 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
1 object definitions have been removed.
1 object definitions have been removed.
1 object definitions have been removed.
1 object definitions have been removed.
1 object definitions have been removed.
1 object definitions have been removed.
1 object definitions have been removed.
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:if [ -e /tmp/otherpkglist ]; then cp -f /tmp/otherpkglist /tmp/otherpkglist.bak; fi [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "test" >> /tmp/otherpkglist [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:if [ -e /tmp/synclists ]; then cp -f /tmp/synclists /tmp/synclists.bak; fi [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "test" >> /tmp/synclists [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:if [ -e /tmp/postinstall ]; then cp -f /tmp/postinstall /tmp/postinstall.bak; fi [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "test" >> /tmp/postinstall [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:if [ -e /tmp/exlist ]; then cp -f /tmp/exlist /tmp/exlist.bak; fi [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "test" >> /tmp/exlist [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:if [ -e /tmp/partitionfile ]; then cp -f /tmp/partitionfile /tmp/partitionfile.bak; fi [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "test" >> /tmp/partitionfile [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:if [ -e /tmp/pkglist ]; then cp -f /tmp/pkglist /tmp/pkglist.bak; fi [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "test" >> /tmp/pkglist [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:if [ -e /tmp/template ]; then cp -f /tmp/template /tmp/pkglist.bak; fi [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "test" >> /tmp/template [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:if [ -e /opt/xcat/share/xcat/install/rh/otherpkglist ]; then cp -f /opt/xcat/share/xcat/install/rh/otherpkglist /opt/xcat/share/xcat/install/rh/otherpkglist.bak; fi [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "test" >> /opt/xcat/share/xcat/install/rh/otherpkglist [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:if [ -e /opt/xcat/share/xcat/install/rh/synclists ]; then cp -f /opt/xcat/share/xcat/install/rh/synclists /opt/xcat/share/xcat/install/rh/synclists.bak; fi [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "test" >> /opt/xcat/share/xcat/install/rh/synclists [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:if [ -e /opt/xcat/share/xcat/install/rh/postinstall ]; then cp -f /opt/xcat/share/xcat/install/rh/postinstall /opt/xcat/share/xcat/install/rh/postinstall.bak; fi [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "test" >> /opt/xcat/share/xcat/install/rh/postinstall [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:if [ -e /opt/xcat/share/xcat/install/rh/exlist ]; then cp -f /opt/xcat/share/xcat/install/rh/exlist /opt/xcat/share/xcat/install/rh/exlist.bak; fi [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "test" >> /opt/xcat/share/xcat/install/rh/exlist [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:if [ -e /opt/xcat/share/xcat/install/rh/partitionfile ]; then cp -f /opt/xcat/share/xcat/install/rh/partitionfile /opt/xcat/share/xcat/install/rh/partitionfile.bak; fi [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "test" >> /opt/xcat/share/xcat/install/rh/partitionfile [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:if [ -e /opt/xcat/share/xcat/install/rh/pkglist ]; then cp -f /opt/xcat/share/xcat/install/rh/pkglist /opt/xcat/share/xcat/install/rh/pkglist.bak; fi [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "test" >> /opt/xcat/share/xcat/install/rh/pkglist [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:if [ -e /opt/xcat/share/xcat/install/rh/template ]; then cp -f /opt/xcat/share/xcat/install/rh/template /opt/xcat/share/xcat/install/rh/template.bak; fi [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "test" >> /opt/xcat/share/xcat/install/rh/template [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:chdef -t osimage -o test_myimage1 imagetype=linux provmethod=install pkglist=/opt/xcat/share/xcat/install/rh/compute.rhels7.pkglist template=/opt/xcat/share/xcat/install/rh/compute.rhels7.tmpl otherpkglist=/tmp/otherpkglist synclists=/tmp/synclists postinstall=/tmp/postinstall exlist=/tmp/exlist partitionfile=/tmp/partitionfile [Mon Nov 12 03:30:16 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
New object definitions 'test_myimage1' have been created.
CHECK:rc == 0	[Pass]

RUN:chdef -t osimage -o test_myimage2 imagetype=linux provmethod=install pkglist=/tmp/pkglist template=/tmp/template otherpkglist=/opt/xcat/share/xcat/install/rh/otherpkglist synclists=/opt/xcat/share/xcat/install/rh/synclists postinstall=/opt/xcat/share/xcat/install/rh/postinstall exlist=/opt/xcat/share/xcat/install/rh/exlist partitionfile=/opt/xcat/share/xcat/install/rh/partitionfile [Mon Nov 12 03:30:16 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
New object definitions 'test_myimage2' have been created.
CHECK:rc == 0	[Pass]

RUN:lsdef -t osimage -o test_myimage1,test_myimage2 [Mon Nov 12 03:30:17 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Object name: test_myimage1
    exlist=/tmp/exlist
    imagetype=linux
    otherpkglist=/tmp/otherpkglist
    partitionfile=/tmp/partitionfile
    pkglist=/opt/xcat/share/xcat/install/rh/compute.rhels7.pkglist
    postinstall=/tmp/postinstall
    provmethod=install
    synclists=/tmp/synclists
    template=/opt/xcat/share/xcat/install/rh/compute.rhels7.tmpl
Object name: test_myimage2
    exlist=/opt/xcat/share/xcat/install/rh/exlist
    imagetype=linux
    otherpkglist=/opt/xcat/share/xcat/install/rh/otherpkglist
    partitionfile=/opt/xcat/share/xcat/install/rh/partitionfile
    pkglist=/tmp/pkglist
    postinstall=/opt/xcat/share/xcat/install/rh/postinstall
    provmethod=install
    synclists=/opt/xcat/share/xcat/install/rh/synclists
    template=/tmp/template

RUN:dir="/opt/inventory/site/osimage";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi; mkdir -p $dir [Mon Nov 12 03:30:17 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:xcat-inventory export -d /opt/inventory/site/ [Mon Nov 12 03:30:17 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
The credential objects has been exported to directory /opt/inventory/site/
The osimage objects has been exported to directory /opt/inventory/site/
The cluster inventory data has been dumped to /opt/inventory/site/cluster.yaml
CHECK:rc == 0	[Pass]
CHECK:output =~ The osimage objects has been exported to directory /opt/inventory/site/	[Pass]

RUN:ls -lFR /opt/inventory/site/ [Mon Nov 12 03:30:18 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
/opt/inventory/site/:
total 12
-rw-r--r-- 1 root root 11277 Nov 12 03:30 cluster.yaml
drwxr-xr-x 3 root root    24 Nov 12 03:30 credential/
drwxr-xr-x 4 root root    48 Nov 12 03:30 osimage/

/opt/inventory/site/credential:
total 0
drwxr-xr-x 4 root root 52 Nov 12 03:30 credential/

/opt/inventory/site/credential/credential:
total 4
-rw-r--r-- 1 root root 352 Nov 12 03:30 definition.yaml
drwxr-xr-x 3 root root  18 Nov 12 03:30 etc/
drwxr-xr-x 3 root root  19 Nov 12 03:30 root/

/opt/inventory/site/credential/credential/etc:
total 0
drwxr-xr-x 4 root root 28 Nov 12 03:30 xcat/

/opt/inventory/site/credential/credential/etc/xcat:
total 0
drwxr-xr-x 3 root root 40 Nov 12 03:30 ca/
drwxr-xr-x 2 root root 29 Nov 12 03:30 cert/

/opt/inventory/site/credential/credential/etc/xcat/ca:
total 8
-rw-r--r-- 1 root root 4296 Nov 12 03:30 ca-cert.pem
drwxr-xr-x 2 root root   24 Nov 12 03:30 private/

/opt/inventory/site/credential/credential/etc/xcat/ca/private:
total 4
-rw-r--r-- 1 root root 1675 Nov 12 03:30 ca-key.pem

/opt/inventory/site/credential/credential/etc/xcat/cert:
total 8
-rw-r--r-- 1 root root 5444 Nov 12 03:30 server-cred.pem

/opt/inventory/site/credential/credential/root:
total 0

/opt/inventory/site/osimage:
total 0
drwxr-xr-x 5 root root 63 Nov 12 03:30 test_myimage1/
drwxr-xr-x 5 root root 63 Nov 12 03:30 test_myimage2/

/opt/inventory/site/osimage/test_myimage1:
total 4
-rw-r--r-- 1 root root 593 Nov 12 03:30 definition.yaml
drwxr-xr-x 3 root root  18 Nov 12 03:30 etc/
drwxr-xr-x 3 root root  19 Nov 12 03:30 root/
drwxr-xr-x 2 root root  97 Nov 12 03:30 tmp/

/opt/inventory/site/osimage/test_myimage1/etc:
total 0
drwxr-xr-x 4 root root 28 Nov 12 03:30 xcat/

/opt/inventory/site/osimage/test_myimage1/etc/xcat:
total 0
drwxr-xr-x 3 root root 40 Nov 12 03:30 ca/
drwxr-xr-x 2 root root 29 Nov 12 03:30 cert/

/opt/inventory/site/osimage/test_myimage1/etc/xcat/ca:
total 8
-rw-r--r-- 1 root root 4296 Nov 12 03:30 ca-cert.pem
drwxr-xr-x 2 root root   24 Nov 12 03:30 private/

/opt/inventory/site/osimage/test_myimage1/etc/xcat/ca/private:
total 4
-rw-r--r-- 1 root root 1675 Nov 12 03:30 ca-key.pem

/opt/inventory/site/osimage/test_myimage1/etc/xcat/cert:
total 8
-rw-r--r-- 1 root root 5444 Nov 12 03:30 server-cred.pem

/opt/inventory/site/osimage/test_myimage1/root:
total 0

/opt/inventory/site/osimage/test_myimage1/tmp:
total 20
-rw-r--r-- 1 root root 5 Nov 12 03:30 exlist
-rw-r--r-- 1 root root 5 Nov 12 03:30 otherpkglist
-rw-r--r-- 1 root root 5 Nov 12 03:30 partitionfile
-rw-r--r-- 1 root root 5 Nov 12 03:30 postinstall
-rw-r--r-- 1 root root 5 Nov 12 03:30 synclists

/opt/inventory/site/osimage/test_myimage2:
total 4
-rw-r--r-- 1 root root 648 Nov 12 03:30 definition.yaml
drwxr-xr-x 3 root root  18 Nov 12 03:30 etc/
drwxr-xr-x 3 root root  19 Nov 12 03:30 root/
drwxr-xr-x 2 root root  37 Nov 12 03:30 tmp/

/opt/inventory/site/osimage/test_myimage2/etc:
total 0
drwxr-xr-x 4 root root 28 Nov 12 03:30 xcat/

/opt/inventory/site/osimage/test_myimage2/etc/xcat:
total 0
drwxr-xr-x 3 root root 40 Nov 12 03:30 ca/
drwxr-xr-x 2 root root 29 Nov 12 03:30 cert/

/opt/inventory/site/osimage/test_myimage2/etc/xcat/ca:
total 8
-rw-r--r-- 1 root root 4296 Nov 12 03:30 ca-cert.pem
drwxr-xr-x 2 root root   24 Nov 12 03:30 private/

/opt/inventory/site/osimage/test_myimage2/etc/xcat/ca/private:
total 4
-rw-r--r-- 1 root root 1675 Nov 12 03:30 ca-key.pem

/opt/inventory/site/osimage/test_myimage2/etc/xcat/cert:
total 8
-rw-r--r-- 1 root root 5444 Nov 12 03:30 server-cred.pem

/opt/inventory/site/osimage/test_myimage2/root:
total 0

/opt/inventory/site/osimage/test_myimage2/tmp:
total 8
-rw-r--r-- 1 root root 5 Nov 12 03:30 pkglist
-rw-r--r-- 1 root root 5 Nov 12 03:30 template

RUN:otherpkglist=`lsdef -t osimage -o test_myimage1 |grep otherpkglist|awk -F= '{print $2}'`;diff -y $otherpkglist /opt/inventory/site/osimage/test_myimage1$otherpkglist [Mon Nov 12 03:30:18 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
test								test
CHECK:rc == 0	[Pass]

RUN:synclists=`lsdef -t osimage -o test_myimage1 |grep synclists|awk -F= '{print $2}'`;diff -y $synclists /opt/inventory/site/osimage/test_myimage1$synclists [Mon Nov 12 03:30:19 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
test								test
CHECK:rc == 0	[Pass]

RUN:postinstall=`lsdef -t osimage -o test_myimage1 |grep postinstall|awk -F= '{print $2}'`;diff -y $postinstall /opt/inventory/site/osimage/test_myimage1$postinstall [Mon Nov 12 03:30:19 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
test								test
CHECK:rc == 0	[Pass]

RUN:exlist=`lsdef -t osimage -o test_myimage1 |grep exlist|awk -F= '{print $2}'`;diff -y $exlist /opt/inventory/site/osimage/test_myimage1$exlist [Mon Nov 12 03:30:19 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
test								test
CHECK:rc == 0	[Pass]

RUN:partitionfile=`lsdef -t osimage -o test_myimage1 |grep partitionfile|awk -F= '{print $2}'`;diff -y $partitionfile /opt/inventory/site/osimage/test_myimage1$partitionfile [Mon Nov 12 03:30:20 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
test								test
CHECK:rc == 0	[Pass]

RUN:pkglist=`lsdef -t osimage -o test_myimage1 |grep -w pkglist|awk -F= '{print $2}'`;ls -l /opt/inventory/site/osimage/test_myimage1$pkglist [Mon Nov 12 03:30:20 2018]
ElapsedTime:0 sec
RETURN rc = 2
OUTPUT:
ls: cannot access /opt/inventory/site/osimage/test_myimage1/opt/xcat/share/xcat/install/rh/compute.rhels7.pkglist: No such file or directory
CHECK:rc != 0	[Pass]

RUN:template=`lsdef -t osimage -o test_myimage1 |grep template|awk -F= '{print $2}'`;ls -l /opt/inventory/site/osimage/test_myimage1$template [Mon Nov 12 03:30:20 2018]
ElapsedTime:1 sec
RETURN rc = 2
OUTPUT:
ls: cannot access /opt/inventory/site/osimage/test_myimage1/opt/xcat/share/xcat/install/rh/compute.rhels7.tmpl: No such file or directory
CHECK:rc != 0	[Pass]

RUN:otherpkglist=`lsdef -t osimage -o test_myimage2 |grep otherpkglist|awk -F= '{print $2}'`;ls -l /opt/inventory/site/osimage/test_myimage2$otherpkglist [Mon Nov 12 03:30:21 2018]
ElapsedTime:0 sec
RETURN rc = 2
OUTPUT:
ls: cannot access /opt/inventory/site/osimage/test_myimage2/opt/xcat/share/xcat/install/rh/otherpkglist: No such file or directory
CHECK:rc != 0	[Pass]

RUN:synclists=`lsdef -t osimage -o test_myimage2 |grep synclists|awk -F= '{print $2}'`;ls -l /opt/inventory/site/osimage/test_myimage2$synclists [Mon Nov 12 03:30:21 2018]
ElapsedTime:1 sec
RETURN rc = 2
OUTPUT:
ls: cannot access /opt/inventory/site/osimage/test_myimage2/opt/xcat/share/xcat/install/rh/synclists: No such file or directory
CHECK:rc != 0	[Pass]

RUN:postinstall=`lsdef -t osimage -o test_myimage2 |grep postinstall|awk -F= '{print $2}'`;ls -l /opt/inventory/site/osimage/test_myimage2$postinstall [Mon Nov 12 03:30:22 2018]
ElapsedTime:0 sec
RETURN rc = 2
OUTPUT:
ls: cannot access /opt/inventory/site/osimage/test_myimage2/opt/xcat/share/xcat/install/rh/postinstall: No such file or directory
CHECK:rc != 0	[Pass]

RUN:exlist=`lsdef -t osimage -o test_myimage2 |grep exlist|awk -F= '{print $2}'`;ls -l /opt/inventory/site/osimage/test_myimage2$exlist [Mon Nov 12 03:30:22 2018]
ElapsedTime:0 sec
RETURN rc = 2
OUTPUT:
ls: cannot access /opt/inventory/site/osimage/test_myimage2/opt/xcat/share/xcat/install/rh/exlist: No such file or directory
CHECK:rc != 0	[Pass]

RUN:partitionfile=`lsdef -t osimage -o test_myimage2 |grep partitionfile|awk -F= '{print $2}'`;ls -l /opt/inventory/site/osimage/test_myimage2$partitionfile [Mon Nov 12 03:30:22 2018]
ElapsedTime:1 sec
RETURN rc = 2
OUTPUT:
ls: cannot access /opt/inventory/site/osimage/test_myimage2/opt/xcat/share/xcat/install/rh/partitionfile: No such file or directory
CHECK:rc != 0	[Pass]

RUN:pkglist=`lsdef -t osimage -o test_myimage2 |grep -w pkglist|awk -F= '{print $2}'`;diff -y $pkglist /opt/inventory/site/osimage/test_myimage2$pkglist [Mon Nov 12 03:30:23 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
test								test
CHECK:rc == 0	[Pass]

RUN:template=`lsdef -t osimage -o test_myimage2 |grep template|awk -F= '{print $2}'`;diff -y $template /opt/inventory/site/osimage/test_myimage2$template [Mon Nov 12 03:30:23 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
test								test
CHECK:rc == 0	[Pass]

RUN:rmdef -t osimage -o  test_myimage1,test_myimage2 [Mon Nov 12 03:30:23 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
2 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:rm -rf /tmp/otherpkglist /tmp/synclists /tmp/postinstall /tmp/exlist /tmp/pkglist /tmp/template /tmp/partitionfile [Mon Nov 12 03:30:24 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:xcat-inventory import -t osimage -d /opt/inventory/site [Mon Nov 12 03:30:24 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
loading inventory date in "/opt/inventory/site/osimage/test_myimage1/definition.yaml"
start to import "osimage" type objects
 preprocessing "osimage" type objects
 writting "osimage" type objects
Inventory import successfully!
The object test_myimage1 has been imported
loading inventory date in "/opt/inventory/site/osimage/test_myimage2/definition.yaml"
start to import "osimage" type objects
 preprocessing "osimage" type objects
 writting "osimage" type objects
Inventory import successfully!
The object test_myimage2 has been imported
CHECK:rc == 0	[Pass]
CHECK:output =~ Inventory import successfully!	[Pass]
CHECK:output =~ Inventory import successfully!	[Pass]

RUN:lsdef -t osimage -o test_myimage1,test_myimage2 [Mon Nov 12 03:30:25 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Object name: test_myimage1
    environvar=OBJNAME=test_myimage1
    exlist=/tmp/exlist
    imagetype=linux
    otherpkglist=/tmp/otherpkglist
    partitionfile=/tmp/partitionfile
    pkglist=/opt/xcat/share/xcat/install/rh/compute.rhels7.pkglist
    postinstall=/tmp/postinstall
    provmethod=install
    synclists=/tmp/synclists
    template=/opt/xcat/share/xcat/install/rh/compute.rhels7.tmpl
Object name: test_myimage2
    environvar=OBJNAME=test_myimage2
    exlist=/opt/xcat/share/xcat/install/rh/exlist
    imagetype=linux
    otherpkglist=/opt/xcat/share/xcat/install/rh/otherpkglist
    partitionfile=/opt/xcat/share/xcat/install/rh/partitionfile
    pkglist=/tmp/pkglist
    postinstall=/opt/xcat/share/xcat/install/rh/postinstall
    provmethod=install
    synclists=/opt/xcat/share/xcat/install/rh/synclists
    template=/tmp/template
CHECK:rc == 0	[Pass]

RUN:otherpkglist=`lsdef -t osimage -o test_myimage1 |grep otherpkglist|awk -F= '{print $2}'`;diff -y $otherpkglist /opt/inventory/site/osimage/test_myimage1$otherpkglist [Mon Nov 12 03:30:25 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
test								test
CHECK:rc == 0	[Pass]

RUN:synclists=`lsdef -t osimage -o test_myimage1 |grep synclists|awk -F= '{print $2}'`;diff -y $synclists /opt/inventory/site/osimage/test_myimage1$synclists [Mon Nov 12 03:30:25 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
test								test
CHECK:rc == 0	[Pass]

RUN:postinstall=`lsdef -t osimage -o test_myimage1 |grep postinstall|awk -F= '{print $2}'`;diff -y $postinstall /opt/inventory/site/osimage/test_myimage1$postinstall [Mon Nov 12 03:30:26 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
test								test
CHECK:rc == 0	[Pass]

RUN:exlist=`lsdef -t osimage -o test_myimage1 |grep exlist|awk -F= '{print $2}'`;diff -y $exlist /opt/inventory/site/osimage/test_myimage1$exlist [Mon Nov 12 03:30:26 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
test								test
CHECK:rc == 0	[Pass]

RUN:partitionfile=`lsdef -t osimage -o test_myimage1 |grep partitionfile|awk -F= '{print $2}'`;diff -y $partitionfile /opt/inventory/site/osimage/test_myimage1$partitionfile [Mon Nov 12 03:30:27 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
test								test
CHECK:rc == 0	[Pass]

RUN:pkglist=`lsdef -t osimage -o test_myimage1 |grep -w pkglist|awk -F= '{print $2}'`;if [ $pkglist == "/opt/xcat/share/xcat/install/rh/compute.rhels7.pkglist" ]; then exit 0; else exit 1; fi [Mon Nov 12 03:30:27 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:template=`lsdef -t osimage -o test_myimage1 |grep template|awk -F= '{print $2}'`;if [ $template == "/opt/xcat/share/xcat/install/rh/compute.rhels7.tmpl" ]; then exit 0; else exit 1; fi [Mon Nov 12 03:30:27 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:otherpkglist=`lsdef -t osimage -o test_myimage2 |grep otherpkglist|awk -F= '{print $2}'`;if [ $otherpkglist == "/opt/xcat/share/xcat/install/rh/otherpkglist" ]; then exit 0; else exit 1; fi [Mon Nov 12 03:30:28 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:synclists=`lsdef -t osimage -o test_myimage2 |grep synclists|awk -F= '{print $2}'`;if [ $synclists == "/opt/xcat/share/xcat/install/rh/synclists" ]; then exit 0; else exit 1; fi [Mon Nov 12 03:30:28 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:postinstall=`lsdef -t osimage -o test_myimage2 |grep postinstall|awk -F= '{print $2}'`;if [ $postinstall == "/opt/xcat/share/xcat/install/rh/postinstall" ]; then exit 0; else exit 1; fi [Mon Nov 12 03:30:28 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:exlist=`lsdef -t osimage -o test_myimage2 |grep exlist|awk -F= '{print $2}'`;if [ $exlist == "/opt/xcat/share/xcat/install/rh/exlist" ]; then exit 0; else exit 1; fi [Mon Nov 12 03:30:29 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:partitionfile=`lsdef -t osimage -o test_myimage2 |grep partitionfile|awk -F= '{print $2}'`;if [ $partitionfile == "/opt/xcat/share/xcat/install/rh/partitionfile" ]; then exit 0; else exit 1; fi [Mon Nov 12 03:30:29 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:pkglist=`lsdef -t osimage -o test_myimage2 |grep -w pkglist|awk -F= '{print $2}'`;diff -y $pkglist /opt/inventory/site/osimage/test_myimage2$pkglist [Mon Nov 12 03:30:29 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
test								test
CHECK:rc == 0	[Pass]

RUN:template=`lsdef -t osimage -o test_myimage2 |grep template|awk -F= '{print $2}'`;diff -y $template /opt/inventory/site/osimage/test_myimage2$template [Mon Nov 12 03:30:30 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
test								test
CHECK:rc == 0	[Pass]

RUN:rmdef -t osimage -o  test_myimage1,test_myimage2 [Mon Nov 12 03:30:30 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
2 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:if [ -e /tmp/test_myimage1.stanza ]; then cat /tmp/test_myimage1.stanza |mkdef -z;fi [Mon Nov 12 03:30:31 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:if [ -e /tmp/test_myimage2.stanza ]; then cat /tmp/test_myimage2.stanza |mkdef -z;fi [Mon Nov 12 03:30:31 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:dir="/opt/inventory/site/osimage"; rm -rf $dir; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi [Mon Nov 12 03:30:31 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:file="/tmp/otherpkglist"; rm -rf $file; if [ -d ${file}".bak" ];then mv ${file}".bak" $file; fi [Mon Nov 12 03:30:31 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:file="/tmp/synclists"; rm -rf $file; if [ -d ${file}".bak" ];then mv ${file}".bak" $file; fi [Mon Nov 12 03:30:31 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:file="/tmp/postinstall"; rm -rf $file; if [ -d ${file}".bak" ];then mv ${file}".bak" $file; fi [Mon Nov 12 03:30:31 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:file="/tmp/exlist"; rm -rf $file; if [ -d ${file}".bak" ];then mv ${file}".bak" $file; fi [Mon Nov 12 03:30:31 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:file="/tmp/partitionfile"; rm -rf $file; if [ -d ${file}".bak" ];then mv ${file}".bak" $file; fi [Mon Nov 12 03:30:31 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:file="/tmp/pkglist"; rm -rf $file; if [ -d ${file}".bak" ];then mv ${file}".bak" $file; fi [Mon Nov 12 03:30:31 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:file="/tmp/template"; rm -rf $file; if [ -d ${file}".bak" ];then mv ${file}".bak" $file; fi [Mon Nov 12 03:30:31 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:file="/opt/xcat/share/xcat/install/rh/otherpkglist"; rm -rf $file; if [ -d ${file}".bak" ];then mv ${file}".bak" $file; fi [Mon Nov 12 03:30:31 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:file="/opt/xcat/share/xcat/install/rh/synclists"; rm -rf $file; if [ -d ${file}".bak" ];then mv ${file}".bak" $file; fi [Mon Nov 12 03:30:31 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:file="/opt/xcat/share/xcat/install/rh/postinstall"; rm -rf $file; if [ -d ${file}".bak" ];then mv ${file}".bak" $file; fi [Mon Nov 12 03:30:31 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:file="/opt/xcat/share/xcat/install/rh/exlist"; rm -rf $file; if [ -d ${file}".bak" ];then mv ${file}".bak" $file; fi [Mon Nov 12 03:30:31 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:file="/opt/xcat/share/xcat/install/rh/partitionfile"; rm -rf $file; if [ -d ${file}".bak" ];then mv ${file}".bak" $file; fi [Mon Nov 12 03:30:31 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:file="/opt/xcat/share/xcat/install/rh/pkglist"; rm -rf $file; if [ -d ${file}".bak" ];then mv ${file}".bak" $file; fi [Mon Nov 12 03:30:31 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:file="/opt/xcat/share/xcat/install/rh/template"; rm -rf $file; if [ -d ${file}".bak" ];then mv ${file}".bak" $file; fi [Mon Nov 12 03:30:31 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:for file in /tmp/osimages/*.stanza; do cat $file|mkdef -z; done [Mon Nov 12 03:30:31 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
1 object definitions have been created or modified.
1 object definitions have been created or modified.
1 object definitions have been created or modified.
1 object definitions have been created or modified.
1 object definitions have been created or modified.
1 object definitions have been created or modified.
1 object definitions have been created or modified.
1 object definitions have been created or modified.

RUN:if [ -e /tmp/osimages.bak ]; then mv -f /tmp/osimages.bak /tmp/osimages; fi [Mon Nov 12 03:30:34 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::export_import_all_osimages_by_dir::Passed::Time:Mon Nov 12 03:30:34 2018 ::Duration::26 sec------
------Total: 1 , Failed: 0------
```