### PR TITLE
Fix synatex error in test case nodeset_errorcommand

### DIFF
--- a/xCAT-test/autotest/testcase/nodeset/cases0
+++ b/xCAT-test/autotest/testcase/nodeset/cases0
@@ -347,7 +347,7 @@ end
 start:nodeset_errorcommand
 description:This testcase is to very nodeset osimage errorcommand could give right output
 Attribute: $$CN-The operation object of nodeset command
-cmd:nodeset $$CN osimage= __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+cmd:nodeset $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==1
 check:output=~Error: (\[.*?\]: )?Invalid argument:
 check:output=~Usage: nodeset <noderange>


### PR DESCRIPTION
### The PR is to fix a failure of test case `nodeset_errorcommand`

### The modification include

_##Fix a syntax error that cause the test case fail_
