### PR TITLE
fix 5800 nicextraparams does not overwrite existed ifcfg attribute

### DIFF
--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -573,18 +573,16 @@ function create_persistent_ifcfg {
         attrs=${attrs}${attrs:+,}"${name}=${value}"
         i=$((i+1))
     done
-
     # record manual and auto attributes first
     # since input attributes might overwrite them.
     #
-    # record input attributes later. They will overwrite
+    # record extra attributes later. They will overwrite
     # previous generated attributes if duplicate.
     [ -f $fcfg ] && mv -f $fcfg `dirname $fcfg`/.`basename $fcfg`.bak
-    echo "$attrs,$inattrs" \ | $sed -e 's/,/\n/g' | grep -v "^$" \
+    echo "$inattrs,$attrs" \ | $sed -e 's/,/\n/g' | grep -v "^$" \
     | $sed -e 's/=/="/' -e 's/ *$/"/' \
     | uniq_per_key -t'=' -k1 >$fcfg
     local rc=$?
-
     # log for debug
     echo "['ifcfg-${ifname}']" >&2
     cat $fcfg | $sed -e 's/^/ >> /g' | log_lines info

--- a/xCAT/postscripts/xcatlib.sh
+++ b/xCAT/postscripts/xcatlib.sh
@@ -733,7 +733,7 @@ function parse_nic_extra_params() {
 	do
 		token2="${params_temp[$k]}"
 		array_extra_param_names[$k]=`echo "$token2" | cut -d'=' -f 1`
-		array_extra_param_values[$k]=`echo "$token2" | cut -d'=' -f 2`	
+		array_extra_param_values[$k]=`echo "$token2" | cut -d'=' -f 2-`	
 		k=$((k+1))
 	done
 }


### PR DESCRIPTION
### The PR is to fix issue 
https://github.com/xcat2/xcat-core/issues/5800

### The modification include

xcatlib.sh
nicutils.sh

### The UT result
1. configure:
```
]# lsdef byrh09 --nics
Object name: byrh09
    nicdevices.bond0=eth1|eth2
    nicextraparams.bond0=BONDING_OPTS=mode=1 MTU=1000 BOOTPROTO=static
    nicips.bond0=30.5.106.9
    nicnetworks.bond0=30_5_0_0-255_255_0_0
    nictypes.eth2=ethernet
    nictypes.bond0=bond
    nictypes.eth1=ethernet
```
results:
```
byrh09: [I]: create_persistent_ifcfg ifname=bond0 xcatnet=30_5_0_0-255_255_0_0 inattrs=ONBOOT=yes,USERCTL=no,TYPE=Bond,BONDING_MASTER=yes,BONDING_OPTS='mode=802.3ad miimon=100',BOOTPROTO=none,DHCLIENTARGS='-timeout 200'
byrh09: bond0!BONDING_OPTS=mode=1 MTU=1000 BOOTPROTO=static
byrh09: ['ifcfg-bond0']
byrh09: [I]: >> ONBOOT="yes"
byrh09: [I]: >> USERCTL="no"
byrh09: [I]: >> TYPE="Bond"
byrh09: [I]: >> BONDING_MASTER="yes"
byrh09: [I]: >> BONDING_OPTS="mode=1"
byrh09: [I]: >> BOOTPROTO="static"
byrh09: [I]: >> DHCLIENTARGS="-timeout 200"
byrh09: [I]: >> DEVICE="bond0"
byrh09: [I]: >> IPADDR="30.5.106.9"
byrh09: [I]: >> NETMASK="255.255.0.0"
byrh09: [I]: >> NAME="bond0"
byrh09: [I]: >> MTU="1000"
byrh09: postscript end....: confignetwork exited with code 0
```
2. default configure:
```
]# lsdef byrh09 |sed s/[[:space:]]//g|grep ^nic
nicdevices.bond0=eth1|eth2
nicips.bond0=30.5.106.9
nicnetworks.bond0=30_5_0_0-255_255_0_0
nictypes.eth2=ethernet
nictypes.bond0=bond
nictypes.eth1=ethernet
```
results:
```
byrh09: [I]: create_persistent_ifcfg ifname=bond0 xcatnet=30_5_0_0-255_255_0_0 inattrs=ONBOOT=yes,USERCTL=no,TYPE=Bond,BONDING_MASTER=yes,BONDING_OPTS='mode=802.3ad miimon=100',BOOTPROTO=none,DHCLIENTARGS='-timeout 200'
byrh09: ['ifcfg-bond0']
byrh09: [I]: >> ONBOOT="yes"
byrh09: [I]: >> USERCTL="no"
byrh09: [I]: >> TYPE="Bond"
byrh09: [I]: >> BONDING_MASTER="yes"
byrh09: [I]: >> BONDING_OPTS="mode=802.3ad miimon=100"
byrh09: [I]: >> BOOTPROTO="static"
byrh09: [I]: >> DHCLIENTARGS="-timeout 200"
byrh09: [I]: >> DEVICE="bond0"
byrh09: [I]: >> IPADDR="30.5.106.9"
byrh09: [I]: >> NETMASK="255.255.0.0"
byrh09: [I]: >> NAME="bond0"
byrh09: postscript end....: confignetwork exited with code 0
byrh09: Running of postscripts has completed.
```
