### PR TITLE
Additional info display for rspconfig

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
@@ -379,7 +379,7 @@ rmdir \"/tmp/$userid\" \n")
         except (SelfServerException, SelfClientException) as e:
             self.callback.error(e.message, node)
 
-        self.callback.warn("%s: Make sure to update 'bmcpassword' node attribute or 'passwd' table with the new BMC password." % node)
+        self.callback.info("%s: BMC password changed. Update 'bmcpasswd' for the node or the 'passwd' table with the new password." % node)
 
     def _set_apis_values(self, key, value, **kw):
         node = kw['node']
@@ -487,7 +487,7 @@ rmdir \"/tmp/$userid\" \n")
 
         try:
             # Display Zero Config information in case IP setting fails or set IP is not accessible
-            self.callback.info('%s: Setting BMC IP configuration... Zero Config IP: %s' % (node, zeroconf))
+            self.callback.info('%s: Setting BMC IP configuration... [Zero Config IP: %s]' % (node, zeroconf))
             obmc.set_netinfo(nic, ip, prefix, gateway)
             sleep( 5 )
             nic_netinfo = obmc.get_nic_netinfo(nic)
@@ -506,7 +506,7 @@ rmdir \"/tmp/$userid\" \n")
                 set_success = True
 
         if not set_success:
-            return self.callback.error('Setting BMC IP configuration failed. Zero Config IP: %s' % zeroconf, node)
+            return self.callback.error('Setting BMC IP configuration failed. [Zero Config IP: %s]' % zeroconf, node)
 
         try:
             if origin_type == 'DHCP':

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
@@ -379,6 +379,8 @@ rmdir \"/tmp/$userid\" \n")
         except (SelfServerException, SelfClientException) as e:
             self.callback.error(e.message, node)
 
+        self.callback.warn("%s: Make sure to update 'bmcpassword' node attribute or 'passwd' table with the new BMC password." % node)
+
     def _set_apis_values(self, key, value, **kw):
         node = kw['node']
         obmc = openbmc.OpenBMCRest(name=node, nodeinfo=kw['nodeinfo'], messager=self.callback,
@@ -430,8 +432,8 @@ rmdir \"/tmp/$userid\" \n")
 
     def _print_bmc_netinfo(self, node, ip, netmask, gateway, vlan):
 
-        self.callback.info('%s: BMC IP: %s'% (node, ip))
-        self.callback.info('%s: BMC Netmask: %s' %  (node, netmask))
+        self.callback.info('%s: BMC IP: %s'      % (node, ip))
+        self.callback.info('%s: BMC Netmask: %s' % (node, netmask))
         self.callback.info('%s: BMC Gateway: %s' % (node, gateway))
         if vlan:
             self.callback.info('%s: BMC VLAN ID: %s' % (node, vlan))
@@ -440,6 +442,7 @@ rmdir \"/tmp/$userid\" \n")
 
         node = kw['node']
         node_info = kw['nodeinfo']
+        zeroconf = "Unknown"
         obmc = openbmc.OpenBMCRest(name=node, nodeinfo=node_info, messager=self.callback,
                                    debugmode=self.debugmode, verbose=self.verbose)
 
@@ -451,7 +454,7 @@ rmdir \"/tmp/$userid\" \n")
             return
 
         if not netinfo:
-            return self.callback.error("No network information get", node)
+            return self.callback.error("Can not get network information", node)
         if 'error' in netinfo:
             return self.callback.info('%s: %s' % (node, netinfo['error']))
 
@@ -468,8 +471,9 @@ rmdir \"/tmp/$userid\" \n")
                 self._print_bmc_netinfo(node, ip, netmask, gateway, vlan)
                 return
 
-        origin_type = netinfo[origin_nic]['ipsrc']
+        origin_type   = netinfo[origin_nic]['ipsrc']
         origin_ip_obj = netinfo[origin_nic]['ipobj']
+        zeroconf      = netinfo['zeroconf']
 
         if vlan:
             pre_nic = nic.split('_')[0]
@@ -483,6 +487,8 @@ rmdir \"/tmp/$userid\" \n")
 
         try:
             obmc.set_netinfo(nic, ip, prefix, gateway)
+            # Display Zero Config information in case IP setting fails or set IP is not accessible
+            self.callback.info('Setting BMC IP configuration... Zero Config IP: %s' % zeroconf)
             sleep( 5 )
             nic_netinfo = obmc.get_nic_netinfo(nic)
         except (SelfServerException, SelfClientException) as e:
@@ -490,7 +496,7 @@ rmdir \"/tmp/$userid\" \n")
             return
 
         if not nic_netinfo:
-            return self.callback.error('Did not get info for NIC %s' % nic, node)
+            return self.callback.error('Can not get info for NIC %s' % nic, node)
 
         set_success = False
         for net_id, attr in nic_netinfo.items():
@@ -500,7 +506,7 @@ rmdir \"/tmp/$userid\" \n")
                 set_success = True
 
         if not set_success:
-            return self.callback.error('Config BMC IP failed', node)
+            return self.callback.error('Setting BMC IP configuration failed. Zero Config IP: %s' % zeroconf, node)
 
         try:
             if origin_type == 'DHCP':
@@ -508,7 +514,7 @@ rmdir \"/tmp/$userid\" \n")
             elif origin_type == 'Static':
                 obmc.delete_ip_object(origin_nic, origin_ip_obj)
             else:
-                self.callback.error('Get wrong Origin type %s for NIC %s IP object %s' % (origin_type, nic, origin_ip_obj), node)
+                self.callback.error('Got wrong origin type %s for NIC %s IP object %s' % (origin_type, nic, origin_ip_obj), node)
         except (SelfServerException, SelfClientException) as e:
             self.callback.error(e.message, node)
 
@@ -525,7 +531,7 @@ rmdir \"/tmp/$userid\" \n")
             self.callback.error(e.message, node)
             return
         if not netinfo:
-            return self.callback.error("No network information get", node)
+            return self.callback.error("Can not get network information", node)
         defaultgateway = "n/a"
         bmchostname = ""
         if 'defaultgateway' in netinfo:

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
@@ -473,7 +473,7 @@ rmdir \"/tmp/$userid\" \n")
 
         origin_type   = netinfo[origin_nic]['ipsrc']
         origin_ip_obj = netinfo[origin_nic]['ipobj']
-        zeroconf      = netinfo['zeroconf']
+        zeroconf      = netinfo[origin_nic]['zeroconf']
 
         if vlan:
             pre_nic = nic.split('_')[0]
@@ -486,9 +486,9 @@ rmdir \"/tmp/$userid\" \n")
             nic = pre_nic + '_' + vlan
 
         try:
-            obmc.set_netinfo(nic, ip, prefix, gateway)
             # Display Zero Config information in case IP setting fails or set IP is not accessible
-            self.callback.info('Setting BMC IP configuration... Zero Config IP: %s' % zeroconf)
+            self.callback.info('%s: Setting BMC IP configuration... Zero Config IP: %s' % (node, zeroconf))
+            obmc.set_netinfo(nic, ip, prefix, gateway)
             sleep( 5 )
             nic_netinfo = obmc.get_nic_netinfo(nic)
         except (SelfServerException, SelfClientException) as e:

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_bmcconfig.py
@@ -432,7 +432,7 @@ rmdir \"/tmp/$userid\" \n")
 
     def _print_bmc_netinfo(self, node, ip, netmask, gateway, vlan):
 
-        self.callback.info('%s: BMC IP: %s'      % (node, ip))
+        self.callback.info('%s: BMC IP: %s' % (node, ip))
         self.callback.info('%s: BMC Netmask: %s' % (node, netmask))
         self.callback.info('%s: BMC Gateway: %s' % (node, gateway))
         if vlan:
@@ -471,9 +471,9 @@ rmdir \"/tmp/$userid\" \n")
                 self._print_bmc_netinfo(node, ip, netmask, gateway, vlan)
                 return
 
-        origin_type   = netinfo[origin_nic]['ipsrc']
+        origin_type = netinfo[origin_nic]['ipsrc']
         origin_ip_obj = netinfo[origin_nic]['ipobj']
-        zeroconf      = netinfo[origin_nic]['zeroconf']
+        zeroconf = netinfo[origin_nic]['zeroconf']
 
         if vlan:
             pre_nic = nic.split('_')[0]

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -903,6 +903,8 @@ class OpenBMCRest(object):
                     if 'LinkLocal' in v["Origin"] or v["Address"].startswith("169.254"):
                         msg = "Found LinkLocal address %s for interface %s, Ignoring..." % (v["Address"], dev)
                         self._print_record_log(msg, 'get_netinfo')
+                        # Save Zero Conf information
+                        netinfo["zeroconf"] = v["Address"]
                         continue
                     nicid = dev.split('/')[-1]
                     if nicid not in netinfo:

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -900,15 +900,15 @@ class OpenBMCRest(object):
                     continue
                 dev,match,netid = k.partition("/ipv4/")
                 if netid:
+                    nicid = dev.split('/')[-1]
+                    if nicid not in netinfo:
+                        netinfo[nicid] = {}
                     if 'LinkLocal' in v["Origin"] or v["Address"].startswith("169.254"):
                         msg = "Found LinkLocal address %s for interface %s, Ignoring..." % (v["Address"], dev)
                         self._print_record_log(msg, 'get_netinfo')
                         # Save Zero Conf information
-                        netinfo["zeroconf"] = v["Address"]
+                        netinfo[nicid]["zeroconf"] = v["Address"]
                         continue
-                    nicid = dev.split('/')[-1]
-                    if nicid not in netinfo:
-                        netinfo[nicid] = {}
                     if 'ip' in netinfo[nicid]:
                         msg = "%s: Another valid ip %s found." % (node, v["Address"])
                         self._print_record_log(msg, 'get_netinfo')


### PR DESCRIPTION
### The PR is to fix issue _5775_

Resolves #5775 

### The modification include (Python version only)

_* Warning message when changing BMC password_

_* Zero config display when changing network information_

UT:
* Changing BMC password:
```
[root@stratton01 xcat]# rspconfig f5u16 admin_passwd=0penBmc,0penBmc2
f5u16: BMC Setting Password...
f5u16: BMC password changed. Update 'bmcpasswd' for the node or the 'passwd' table with the new password.
[root@stratton01 xcat]#
```

* Changing BMC network information failure:
```
[root@stratton01 xcat]# rspconfig f5u16 ip=10.5.16.101 netmask=255.0.0.0 gateway=10.0.0.102
f5u16: Setting BMC IP configuration... [Zero Config IP: 169.254.151.236]
f5u16: [stratton01]: Error: Setting BMC IP configuration failed. [Zero Config IP: 169.254.151.236]
[root@stratton01 xcat]#
```

* Changing BMC network information success:
```
[root@stratton01 xcat]# rspconfig f5u16 ip=10.5.16.102 netmask=255.0.0.0 gateway=10.0.0.102
f5u16: Setting BMC IP configuration... [Zero Config IP: 169.254.151.236]
f5u16: BMC IP: 10.5.16.102
f5u16: BMC Netmask: 255.0.0.0
f5u16: BMC Gateway: 10.0.0.102
[root@stratton01 xcat]#
```