### PR TITLE
Add a check for some required rpm package to successfully create the xcat-deps package

### DIFF
--- a/builddep.sh
+++ b/builddep.sh
@@ -19,6 +19,14 @@
 #                       of the FRS area.
 #       VERBOSE=1     - Set to 1 to see more VERBOSE output
 
+# This script should only be run on RPM based machines 
+# This test is not foolproof, but at least tries to detect
+if [ `/bin/rpm -q -f /bin/rpm >/dev/null 2>&1; echo $?` != 0 ]; then
+	echo "ERROR: This script should only be executed on a RPM based Operation System."
+	exit 1
+fi
+
+exit 0    
 # you can change this if you need to
 USER=xcat
 TARGET_MACHINE=xcat.org

--- a/builddep.sh
+++ b/builddep.sh
@@ -49,6 +49,12 @@ if [ ! -d $GSA ]; then
 	exit 1
 fi
 
+REQPKG="rpm-sign"
+if [ `rpm -q $REQPKG >> /dev/null; echo $?` != 0 ]; then
+	echo "ERROR: $REQPKG is required to successfully create the xcat-deps package. Install and rerun."
+	exit 1
+fi
+
 # set grep to quiet by default
 GREP="grep -q"
 if [ "$VERBOSE" = "1" -o "$VERBOSE" = "yes" ]; then

--- a/builddep.sh
+++ b/builddep.sh
@@ -64,14 +64,10 @@ if [ "$VERBOSE" = "1" -o "$VERBOSE" = "yes" ]; then
 fi
 
 # this is needed only when we are transitioning the yum over to frs
-# YUMREPOURL1="http://xcat.org/yum"
-# YUMREPOURL2="http://xcat.org/files/yum"
 if [ "$FRSYUM" != 0 ]; then
 	YUMDIR="$FRS/repos"
-	# YUMREPOURL="$YUMREPOURL2"
 else
 	YUMDIR=htdocs
-	# YUMREPOURL="$YUMREPOURL1"
 fi
 
 cd `dirname $0`
@@ -133,18 +129,6 @@ if [ "$OSNAME" != "AIX" ]; then
 
 	# Modify xcat-dep.repo files to point to the correct place
 	echo "===> Modifying the xcat-dep.repo files to point to the correct location..."
-	# 10/01/2015 - vkhu
-	# The URLs have been updated in GSA, this section is not needed at the moment
-	#
-	#if [ "$FRSYUM" != 0 ]; then
-	#	newurl="$YUMREPOURL2"
-	#	oldurl="$YUMREPOURL1"
-	#else
-	#	newurl="$YUMREPOURL1"
-	#	oldurl="$YUMREPOURL2"
-	#fi
-	#
-	#sed -i -e "s|=$oldurl|=$newurl|g" `find . -name "xcat-dep.repo" `
 fi
 
 if [ "$OSNAME" == "AIX" ]; then

--- a/builddep.sh
+++ b/builddep.sh
@@ -26,7 +26,6 @@ if [ `/bin/rpm -q -f /bin/rpm >/dev/null 2>&1; echo $?` != 0 ]; then
 	exit 1
 fi
 
-exit 0    
 # you can change this if you need to
 USER=xcat
 TARGET_MACHINE=xcat.org
@@ -57,11 +56,15 @@ if [ ! -d $GSA ]; then
 	exit 1
 fi
 
-REQPKG="rpm-sign"
-if [ `rpm -q $REQPKG >> /dev/null; echo $?` != 0 ]; then
-	echo "ERROR: $REQPKG is required to successfully create the xcat-deps package. Install and rerun."
-	exit 1
-fi
+REQPKG=("rpm-sign" "createrepo")
+for pkg in ${REQPKG[*]}; do
+	if [ `rpm -q $pkg >> /dev/null; echo $?` != 0 ]; then
+		echo "ERROR: $pkg is required to successfully create the xcat-deps package. Install and rerun."
+		exit 1
+	else
+		echo "Checking for package=$pkg ..."
+	fi
+done
 
 # set grep to quiet by default
 GREP="grep -q"


### PR DESCRIPTION
Some internal build machines have been cleaned up and so as I was looking at the process to build the xcat-deps package on other machines we have, found that we can add some verification to make sure the machine has the correct packages to successfully build the linux xcat-dep packages. 

### The modification include

Testing for `rpm-sign` installed on the machine running `builddeps.sh` so that it actively checks that the machine we are running the deps build is configured correctly . 

Clean up commented code that was removed 3 years back 

### The UT result

```
[vhu@c910loginx01 xcat-core]$ rpm -q rpm-sign
package rpm-sign is not installed
[vhu@c910loginx01 xcat-core]$ ./builddep.sh UP=0
ERROR: rpm-sign is required to successfully create the xcat-deps package. Install and rerun.
[vhu@c910loginx01 xcat-core]$
```


