### PR TITLE
when no ipmitool-xcat tool, report error before go ahead the real discovery

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -322,18 +322,25 @@ sub bmcdiscovery_processargs {
         ######################################
         # check if there is nmap or not
         ######################################
-        if (-x '/usr/bin/nmap')
-        {
+        if (-x '/usr/bin/nmap') {
             $nmap_path = "/usr/bin/nmap";
         }
-        elsif (-x '/usr/local/bin/nmap')
-        {
+        elsif (-x '/usr/local/bin/nmap') {
             $nmap_path = "/usr/local/bin/nmap";
         }
-        else
-        {
+        else {
             my $rsp;
             push @{ $rsp->{data} }, "\tThere is no nmap in /usr/bin/ or /usr/local/bin/. \n ";
+            xCAT::MsgUtils->message("E", $rsp, $::CALLBACK);
+            return 1;
+        }
+
+        ######################################
+        # check if there is ipmitool-xcat or not
+        ######################################
+        unless (-x '/opt/xcat/bin/ipmitool-xcat') {
+            my $rsp;
+            push @{ $rsp->{data} }, "\tThere is no ipmitool-xcat in /opt/xcat/bin/, make sure that package ipmitool-xcat is installed successfully.\n ";
             xCAT::MsgUtils->message("E", $rsp, $::CALLBACK);
             return 1;
         }


### PR DESCRIPTION
### The PR is to fix issue about bmcdiscover from mail list
1, remove /opt/xcat/bin/ipmitool-xcat by accident
2, run `bmcdiscover`

### The modification include
Check if the tool is there, quit with error as other missing tool (`nmap`).

### The UT result
```
mv /opt/xcat/bin/ipmitool-xcat /opt/xcat/bin/ipmitool-xcat.bak
 bmcdiscover -s nmap --range 1.1.1.1
Error: 	There is no ipmitool-xcat in /opt/xcat/bin/, make sure that package ipmitool-xcat is installed successfully.
mv /opt/xcat/bin/ipmitool-xcat.bak /opt/xcat/bin/ipmitool-xcat
```

