### PR TITLE
confignics find wrong network for nic when mask is empty

### DIFF
--- a/xCAT/postscripts/confignics
+++ b/xCAT/postscripts/confignics
@@ -111,7 +111,7 @@ function findnetwork(){
         fi
         num_i=$((num_i+1))
     done
-    echo "Error: Can not find the corresponding network defination for ip address: $str_ip . Check networks table netname/net/mask."
+    echo "Error: Can not find a valid network defination for ip address: $str_ip , make sure netname,net and mask are correct in networks table."
     error_code=1
 }
 

--- a/xCAT/postscripts/confignics
+++ b/xCAT/postscripts/confignics
@@ -81,6 +81,10 @@ function findnetwork(){
         eval str_temp=\$NETWORKS_LINE$num_i
         str_net=`echo $str_temp | awk -F'net=' '{print $2}' | awk -F'|' '{print $1}'`
         str_mask=`echo $str_temp | awk -F'mask=' '{print $2}' | awk -F'|' '{print $1}' | sed 's:^/::'`
+        if [ ! $str_mask ]; then
+            num_i=$((num_i+1))
+            continue
+        fi
         echo $str_net | grep ':' > /dev/null
         if [ $? -ne 0 ];then
             if [ $flag_v6 -eq 0 ];then
@@ -107,8 +111,7 @@ function findnetwork(){
         fi
         num_i=$((num_i+1))
     done
-
-    echo "Error: Can not find the corresponding network defination for ip address: $str_ip ."
+    echo "Error: Can not find the corresponding network defination for ip address: $str_ip . Check networks table netname/net/mask."
     error_code=1
 }
 
@@ -339,7 +342,6 @@ do
             error_code=1
             continue
         fi
-
         str_network=$(checknetwork ${array_temp[0]})
         echo "$str_network" | grep -i 'error' > /dev/null
         if [ $? -eq 0 ];then
@@ -347,7 +349,6 @@ do
             echo "confignics on $NODE: $str_network"
             continue
         fi
-
         if [ "$str_nic_type" = "ethernet" ];then
              logger -t $log_label -p local4.info "confignics: call 'configeth $key ${array_temp[0]} $str_network'"
              echo "confignics on $NODE: call 'configeth $key ${array_temp[0]} $str_network'"


### PR DESCRIPTION
### The PR is to fix issue 
https://github.com/xcat2/xcat-core/issues/5789
### The modification include
confignics

### The UT result
1. when mask is empty:
```
[root@bybc0607 postscripts]# updatenode byrh09 "confignics"
byrh09: =============updatenode starting====================
byrh09: trying to download postscripts...
byrh09: postscripts downloaded successfully
byrh09: trying to get mypostscript from 10.5.106.7...
byrh09: postscript start..: confignics
byrh09: confignics on byrh09: config install nic:0, remove: 0, iba ports:
byrh09: eth1!30.5.0.9
byrh09: confignics on byrh09: Error: Can not find the corresponding network defination for ip address: 30.5.0.9 . Check networks table netname/net/mask.
byrh09: postscript end....: confignics exited with code 1
byrh09: Running of postscripts has completed.
byrh09: =============updatenode ending====================
```
2. when configuration is correct:
```
[root@bybc0607 postscripts]# updatenode byrh09 "confignics"
byrh09: =============updatenode starting====================
byrh09: trying to download postscripts...
byrh09: postscripts downloaded successfully
byrh09: trying to get mypostscript from 10.5.106.7...
byrh09: postscript start..: confignics
byrh09: confignics on byrh09: config install nic:0, remove: 0, iba ports:
byrh09: eth1!30.5.0.9
byrh09: confignics on byrh09: call 'configeth eth1 30.5.0.9 30_5_0_0-255_255_0_0|'
byrh09: [I]: configeth on byrh09: os type: redhat
byrh09: configeth on byrh09: old configuration: 3: eth1: <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast master bond0 state UP qlen 1000
byrh09:     link/ether 42:20:0a:04:29:09 brd ff:ff:ff:ff:ff:ff
byrh09:     inet 30.5.0.9/0 brd 255.255.255.255 scope global eth1
byrh09:        valid_lft forever preferred_lft forever
byrh09: [I]: configeth on byrh09: new configuration
byrh09:        30.5.0.9, 30.5.0.0, 255.255.0.0,
byrh09: 3: eth1: <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast master bond0 state UP mode DEFAULT qlen 1000
byrh09: eth1
byrh09: [I]: configeth on byrh09: delete 30.5.0.9_0 for eth1 temporary.
byrh09: [I]: configeth on byrh09: add 30.5.0.9_16 for eth1 temporary.
byrh09: [I]: configeth on byrh09: eth1 changed, modify the configuration files
byrh09: eth1
byrh09: postscript end....: confignics exited with code 0
byrh09: Running of postscripts has completed.
byrh09: =============updatenode ending====================
```

