### PR TITLE
Update --allow instead of --force-yes for CI

### DIFF
--- a/travis.pl
+++ b/travis.pl
@@ -339,7 +339,7 @@ sub install_xcat{
         }
     }
 
-    my $cmd = "sudo apt-get install xcat --force-yes";
+    my $cmd = "sudo apt-get install --allow-unauthenticated --allow-remove-essential --allow-change-held-packages --allow-downgrades xcat";
     @output = runcmd("$cmd");
     #print ">>>>>Dumper the output of '$cmd'\n";
     #print Dumper \@output;


### PR DESCRIPTION
### The PR is to fix CI building issue

```
          'W: --force-yes is deprecated, use one of the options starting with --allow instead.',
          'W: --force-yes is deprecated, use one of the options starting with --allow instead.',
          'E: Sub-process /usr/bin/dpkg returned an error code (1)'
```