### PR TITLE
do task 397,on ubuntu for commands could not found for xcat-inventory cases

### DIFF
--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.node
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.node
@@ -4,15 +4,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_ppc_by_json
 check:rc==0
-cmd:ssh $$DSTMN 'mkdir -p /tmp/export_import_single_ppc_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_ppc_by_json_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_ppc_by_json/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_ppc_by_json/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_ppc_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_ppc_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_ppc_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_ppc_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup  mgt=hmc nodetype=ppc,osi  addkcmdline=addkcmdline arch=ppc64 authdomain=authdomain cfgmgr=cfgmgr cfgmgtroles=cfgmgtroles cfgserver=cfgserver chain=chain chassis=chassis cmdmapping=cmdmapping cons=cons conserver=conserver consoleondemand=consoleondemand cpucount=cpucount cputype=cputype  dhcpinterfaces=dhcpinterfaces disksize=disksize domainadminpassword=domainadminpassword domainadminuser=domainadminuser domaintype=domaintype getmac=getmac hcp=HMC height=height hidden=hidden hostcluster=hostcluster hostinterface=hostinterface hostmanager=hostmanager hostnames=hostnames hosttype=hosttype hwtype=hwtype id=5 installnic=installnic interface=interface ip=10.10.10.10 iscsipassword=iscsipassword iscsiserver=iscsiserver iscsitarget=iscsitarget iscsiuserid=iscsiuserid mac=42:d6:0a:03:05:08 memory=memory migrationdest=migrationdest monserver=monserver mpa=mpa mtm=mtm nameservers=nameservers netboot=grub2 nfsdir=nfsdir nfsserver=nfsserver  nimserver=nimserver node=node ondiscover=ondiscover osvolume=osvolume otherinterfaces=otherinterfaces ou=ou parent=parent password=password pdu=pdu postbootscripts=postbootscripts postscripts=postscripts power=power pprofile=pprofile prescripts-begin=prescripts-begin prescripts-end=prescripts-end primarynic=primarynic primarysn=primarysn productkey=productkey  provmethod=provmethod rack=rack room=room routenames=routenames serial=serial serialflow=serialflow serialport=serialport serialspeed=serialspeed servicenode=servicenode setupconserver=0 setupdhcp=0 setupftp=setupftp setupipforward=0 setupldap=0 setupnameserver=0 setupnfs=0 setupnim=setupnim setupntp=0 setupproxydhcp=0 setuptftp=0 sfp=sfp side=side slot=slot  storagcontroller=storagcontroller storagetype=storagetype supernode=supernode supportedarchs=supportedarchs supportproxydhcp=supportproxydhcp switch=switch switchinterface=switchinterface switchport=50 switchvlan=switchvlan syslog=syslog termport=termport termserver=termserver tftpdir=tftpdir tftpserver=tftpserver unit=unit  usercomment=usercomment username=username vmbeacon=vmbeacon vmbootorder=vmbootorder vmcfgstore=vmcfgstore vmcluster=vmcluster vmmanager=vmmanager vmmaster=vmmaster vmnicnicmodel=vmnicnicmodel vmphyslots=vmphyslots vmstorage=vmstorage vmstoragecache=vmstoragecache vmstorageformat=vmstorageformat vmstoragemodel=vmstoragemodel vmtextconsole=vmtextconsole vmvirtflags=vmvirtflags vmvncport=vmvncport xcatmaster=xcatmaster zonename=zonename  nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 check:rc==0
@@ -24,9 +24,9 @@ cmd:scp /tmp/export_import_single_ppc_by_json/bogusnode_json.inv $$DSTMN:/tmp/ex
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'xcat-inventory import -f /tmp/export_import_single_ppc_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_ppc_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_ppc_by_json_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_ppc_by_json_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_ppc_by_json_$$DSTMN/dstbogusnode.stanza /tmp/export_import_single_ppc_by_json/dstbogusnode.stanza
 check:rc==0
@@ -34,17 +34,17 @@ cmd: cat /tmp/export_import_single_ppc_by_json/dstbogusnode.stanza
 check:rc==0
 cmd:diff -y /tmp/export_import_single_ppc_by_json/srcbogusnode.stanza /tmp/export_import_single_ppc_by_json/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'rmdef bogusnode'
+cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_ppc_by_json/bogusnode.stanza ]]; then cat /tmp/export_import_single_ppc_by_json/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_ppc_by_json/bogusgroup.stanza ]]; then cat /tmp/export_import_single_ppc_by_json/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_ppc_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_ppc_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_ppc_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_ppc_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_ppc_by_json_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_ppc_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_ppc_by_json_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_ppc_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'rm -rf /tmp/export_import_single_ppc_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_ppc_by_json_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_ppc_by_json
 check:rc==0
@@ -57,15 +57,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_ppc_by_yaml
 check:rc==0
-cmd:ssh $$DSTMN 'mkdir -p /tmp/export_import_single_ppc_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_ppc_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_ppc_by_yaml/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_ppc_by_yaml/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup  mgt=hmc nodetype=ppc,osi  addkcmdline=addkcmdline arch=ppc64 authdomain=authdomain cfgmgr=cfgmgr cfgmgtroles=cfgmgtroles cfgserver=cfgserver chain=chain chassis=chassis cmdmapping=cmdmapping cons=cons conserver=conserver consoleondemand=consoleondemand cpucount=cpucount cputype=cputype  dhcpinterfaces=dhcpinterfaces disksize=disksize domainadminpassword=domainadminpassword domainadminuser=domainadminuser domaintype=domaintype getmac=getmac hcp=HMC height=height hidden=hidden hostcluster=hostcluster hostinterface=hostinterface hostmanager=hostmanager hostnames=hostnames hosttype=hosttype hwtype=hwtype id=5 installnic=installnic interface=interface ip=10.10.10.10 iscsipassword=iscsipassword iscsiserver=iscsiserver iscsitarget=iscsitarget iscsiuserid=iscsiuserid mac=42:d6:0a:03:05:08 memory=memory migrationdest=migrationdest monserver=monserver mpa=mpa mtm=mtm nameservers=nameservers netboot=grub2 nfsdir=nfsdir nfsserver=nfsserver  nimserver=nimserver node=node ondiscover=ondiscover osvolume=osvolume otherinterfaces=otherinterfaces ou=ou parent=parent password=password pdu=pdu postbootscripts=postbootscripts postscripts=postscripts power=power pprofile=pprofile prescripts-begin=prescripts-begin prescripts-end=prescripts-end primarynic=primarynic primarysn=primarysn productkey=productkey  provmethod=provmethod rack=rack room=room routenames=routenames serial=serial serialflow=serialflow serialport=serialport serialspeed=serialspeed servicenode=servicenode setupconserver=0 setupdhcp=0 setupftp=setupftp setupipforward=0 setupldap=0 setupnameserver=0 setupnfs=0 setupnim=setupnim setupntp=0 setupproxydhcp=0 setuptftp=0 sfp=sfp side=side slot=slot  storagcontroller=storagcontroller storagetype=storagetype supernode=supernode supportedarchs=supportedarchs supportproxydhcp=supportproxydhcp switch=switch switchinterface=switchinterface switchport=50 switchvlan=switchvlan syslog=syslog termport=termport termserver=termserver tftpdir=tftpdir tftpserver=tftpserver unit=unit  usercomment=usercomment username=username vmbeacon=vmbeacon vmbootorder=vmbootorder vmcfgstore=vmcfgstore vmcluster=vmcluster vmmanager=vmmanager vmmaster=vmmaster vmnicnicmodel=vmnicnicmodel vmphyslots=vmphyslots vmstorage=vmstorage vmstoragecache=vmstoragecache vmstorageformat=vmstorageformat vmstoragemodel=vmstoragemodel vmtextconsole=vmtextconsole vmvirtflags=vmvirtflags vmvncport=vmvncport xcatmaster=xcatmaster zonename=zonename  nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 check:rc==0
@@ -77,9 +77,9 @@ cmd:scp /tmp/export_import_single_ppc_by_yaml/bogusnode_yaml.inv $$DSTMN:/tmp/ex
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'xcat-inventory import -f /tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_ppc_by_yaml_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_ppc_by_yaml_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_ppc_by_yaml_$$DSTMN/dstbogusnode.stanza /tmp/export_import_single_ppc_by_yaml/dstbogusnode.stanza
 check:rc==0
@@ -87,17 +87,17 @@ cmd: cat /tmp/export_import_single_ppc_by_yaml/dstbogusnode.stanza
 check:rc==0
 cmd:diff -y /tmp/export_import_single_ppc_by_yaml/srcbogusnode.stanza /tmp/export_import_single_ppc_by_yaml/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'rmdef bogusnode'
+cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_ppc_by_yaml/bogusnode.stanza ]]; then cat /tmp/export_import_single_ppc_by_yaml/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_ppc_by_yaml/bogusgroup.stanza ]]; then cat /tmp/export_import_single_ppc_by_yaml/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'rm -rf /tmp/export_import_single_ppc_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_ppc_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_ppc_by_yaml
 check:rc==0
@@ -110,15 +110,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_kvm_by_json
 check:rc==0
-cmd:ssh $$DSTMN 'mkdir -p /tmp/export_import_single_kvm_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_kvm_by_json_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_kvm_by_json/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_kvm_by_json/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_kvm_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_kvm_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_kvm_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_kvm_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup mgt=kvm  addkcmdline=addkcmdline arch=ppc64le authdomain=authdomain cfgmgr=cfgmgr cfgmgtroles=cfgmgtroles cfgserver=cfgserver chain=chain chassis=chassis cmdmapping=cmdmapping cons=cons conserver=conserver consoleondemand=consoleondemand cpucount=cpucount cputype=cputype dhcpinterfaces=dhcpinterfaces disksize=disksize domainadminpassword=domainadminpassword domainadminuser=domainadminuser domaintype=domaintype getmac=getmac  height=height hidden=hidden hostcluster=hostcluster hostinterface=hostinterface hostmanager=hostmanager hostnames=hostnames hosttype=hosttype id=5 installnic=installnic interface=interface ip=10.10.10.10 iscsipassword=iscsipassword iscsiserver=iscsiserver iscsitarget=iscsitarget iscsiuserid=iscsiuserid mac=42:d6:0a:03:05:08 memory=memory migrationdest=migrationdest monserver=monserver mpa=mpa mtm=mtm nameservers=nameservers netboot=grub2 nfsdir=nfsdir nfsserver=nfsserver  nimserver=nimserver node=node ondiscover=ondiscover osvolume=osvolume otherinterfaces=otherinterfaces ou=ou pdu=pdu postbootscripts=postbootscripts postscripts=postscripts power=power prescripts-begin=prescripts-begin prescripts-end=prescripts-end primarynic=primarynic primarysn=primarysn productkey=productkey provmethod=provmethod rack=rack room=room routenames=routenames serial=serial serialflow=serialflow serialport=serialport serialspeed=serialspeed servicenode=servicenode setupconserver=0 setupdhcp=0 setupftp=setupftp setupipforward=0 setupldap=0 setupnameserver=0 setupnfs=0 setupnim=setupnim setupntp=0 setupproxydhcp=0 setuptftp=0 sfp=sfp side=side slot=slot storagcontroller=storagcontroller storagetype=storagetype supernode=supernode supportedarchs=supportedarchs supportproxydhcp=supportproxydhcp switch=switch switchinterface=switchinterface switchport=50 switchvlan=switchvlan syslog=syslog termport=termport termserver=termserver tftpdir=tftpdir tftpserver=tftpserver unit=unit usercomment=usercomment vmbeacon=vmbeacon vmbootorder=vmbootorder vmcfgstore=vmcfgstore vmcluster=vmcluster vmcpus=vmcpus vmhost=vmhost vmmanager=vmmanager vmmaster=vmmaster vmmemory=vmmemory vmnicnicmodel=vmnicnicmodel vmnics=vmnics vmothersetting=vmothersetting vmphyslots=vmphyslots vmstorage=vmstorage vmstoragecache=vmstoragecache vmstorageformat=vmstorageformat vmstoragemodel=vmstoragemodel vmtextconsole=vmtextconsole vmvirtflags=vmvirtflags vmvncport=vmvncport xcatmaster=xcatmaster zonename=zonename   nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 check:rc==0
@@ -130,9 +130,9 @@ cmd:scp /tmp/export_import_single_kvm_by_json/bogusnode_json.inv $$DSTMN:/tmp/ex
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'xcat-inventory import -f /tmp/export_import_single_kvm_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_kvm_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_kvm_by_json_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_kvm_by_json_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_kvm_by_json_$$DSTMN/dstbogusnode.stanza /tmp/export_import_single_kvm_by_json/dstbogusnode.stanza
 check:rc==0
@@ -140,17 +140,17 @@ cmd: cat /tmp/export_import_single_kvm_by_json/dstbogusnode.stanza
 check:rc==0
 cmd:diff -y /tmp/export_import_single_kvm_by_json/srcbogusnode.stanza /tmp/export_import_single_kvm_by_json/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'rmdef bogusnode'
+cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_kvm_by_json/bogusnode.stanza ]]; then cat /tmp/export_import_single_kvm_by_json/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_kvm_by_json/bogusgroup.stanza ]]; then cat /tmp/export_import_single_kvm_by_json/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_kvm_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_kvm_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_kvm_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_kvm_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_kvm_by_json_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_kvm_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_kvm_by_json_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_kvm_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'rm -rf /tmp/export_import_single_kvm_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_kvm_by_json_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_kvm_by_json
 check:rc==0
@@ -164,15 +164,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_kvm_by_yaml
 check:rc==0
-cmd:ssh $$DSTMN 'mkdir -p /tmp/export_import_single_kvm_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_kvm_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_kvm_by_yaml/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_kvm_by_yaml/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup mgt=kvm  addkcmdline=addkcmdline arch=ppc64le authdomain=authdomain cfgmgr=cfgmgr cfgmgtroles=cfgmgtroles cfgserver=cfgserver chain=chain chassis=chassis cmdmapping=cmdmapping cons=cons conserver=conserver consoleondemand=consoleondemand cpucount=cpucount cputype=cputype dhcpinterfaces=dhcpinterfaces disksize=disksize domainadminpassword=domainadminpassword domainadminuser=domainadminuser domaintype=domaintype getmac=getmac  height=height hidden=hidden hostcluster=hostcluster hostinterface=hostinterface hostmanager=hostmanager hostnames=hostnames hosttype=hosttype id=5 installnic=installnic interface=interface ip=10.10.10.10 iscsipassword=iscsipassword iscsiserver=iscsiserver iscsitarget=iscsitarget iscsiuserid=iscsiuserid mac=42:d6:0a:03:05:08 memory=memory migrationdest=migrationdest monserver=monserver mpa=mpa mtm=mtm nameservers=nameservers netboot=grub2 nfsdir=nfsdir nfsserver=nfsserver  nimserver=nimserver node=node ondiscover=ondiscover osvolume=osvolume otherinterfaces=otherinterfaces ou=ou pdu=pdu postbootscripts=postbootscripts postscripts=postscripts power=power prescripts-begin=prescripts-begin prescripts-end=prescripts-end primarynic=primarynic primarysn=primarysn productkey=productkey provmethod=provmethod rack=rack room=room routenames=routenames serial=serial serialflow=serialflow serialport=serialport serialspeed=serialspeed servicenode=servicenode setupconserver=0 setupdhcp=0 setupftp=setupftp setupipforward=0 setupldap=0 setupnameserver=0 setupnfs=0 setupnim=setupnim setupntp=0 setupproxydhcp=0 setuptftp=0 sfp=sfp side=side slot=slot storagcontroller=storagcontroller storagetype=storagetype supernode=supernode supportedarchs=supportedarchs supportproxydhcp=supportproxydhcp switch=switch switchinterface=switchinterface switchport=50 switchvlan=switchvlan syslog=syslog termport=termport termserver=termserver tftpdir=tftpdir tftpserver=tftpserver unit=unit usercomment=usercomment vmbeacon=vmbeacon vmbootorder=vmbootorder vmcfgstore=vmcfgstore vmcluster=vmcluster vmcpus=vmcpus vmhost=vmhost vmmanager=vmmanager vmmaster=vmmaster vmmemory=vmmemory vmnicnicmodel=vmnicnicmodel vmnics=vmnics vmothersetting=vmothersetting vmphyslots=vmphyslots vmstorage=vmstorage vmstoragecache=vmstoragecache vmstorageformat=vmstorageformat vmstoragemodel=vmstoragemodel vmtextconsole=vmtextconsole vmvirtflags=vmvirtflags vmvncport=vmvncport xcatmaster=xcatmaster zonename=zonename   nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 check:rc==0
@@ -184,9 +184,9 @@ cmd:scp /tmp/export_import_single_kvm_by_yaml/bogusnode_yaml.inv $$DSTMN:/tmp/ex
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'xcat-inventory import -f /tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_kvm_by_yaml_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_kvm_by_yaml_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_kvm_by_yaml_$$DSTMN/dstbogusnode.stanza /tmp/export_import_single_kvm_by_yaml/dstbogusnode.stanza
 check:rc==0
@@ -194,17 +194,17 @@ cmd: cat /tmp/export_import_single_kvm_by_yaml/dstbogusnode.stanza
 check:rc==0
 cmd:diff -y /tmp/export_import_single_kvm_by_yaml/srcbogusnode.stanza /tmp/export_import_single_kvm_by_yaml/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'rmdef bogusnode'
+cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_kvm_by_yaml/bogusnode.stanza ]]; then cat /tmp/export_import_single_kvm_by_yaml/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_kvm_by_yaml/bogusgroup.stanza ]]; then cat /tmp/export_import_single_kvm_by_yaml/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'rm -rf /tmp/export_import_single_kvm_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_kvm_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_kvm_by_yaml
 check:rc==0
@@ -218,15 +218,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_pdu_by_json
 check:rc==0
-cmd:ssh $$DSTMN 'mkdir -p /tmp/export_import_single_pdu_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_pdu_by_json_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_pdu_by_json/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_pdu_by_json/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_pdu_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_pdu_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_pdu_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_pdu_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup mgt=pdu nodetype=pdu  addkcmdline=addkcmdline arch=ppc64 authdomain=authdomain authkey=authkey authtype=MD5 cfgmgr=cfgmgr cfgmgtroles=cfgmgtroles cfgserver=cfgserver chain=chain chassis=chassis cmdmapping=cmdmapping community=community cons=cons conserver=conserver consoleondemand=consoleondemand cpucount=cpucount cputype=cputype dhcpinterfaces=dhcpinterfaces disksize=disksize domainadminpassword=domainadminpassword domainadminuser=domainadminuser domaintype=domaintype getmac=getmac  height=height hidden=hidden hostcluster=hostcluster hostinterface=hostinterface hostmanager=hostmanager hostnames=hostnames hosttype=hosttype  installnic=installnic interface=interface ip=10.10.10.10 iscsipassword=iscsipassword iscsiserver=iscsiserver iscsitarget=iscsitarget iscsiuserid=iscsiuserid mac=42:d6:0a:03:05:08 memory=memory migrationdest=migrationdest monserver=monserver mpa=mpa mtm=mtm nameservers=nameservers netboot=grub2 nfsdir=nfsdir nfsserver=nfsserver  nimserver=nimserver node=node ondiscover=ondiscover  osvolume=osvolume otherinterfaces=otherinterfaces ou=ou outlet=outlet password=password pdu=pdu pdutype=pdutype postbootscripts=postbootscripts postscripts=postscripts power=power prescripts-begin=prescripts-begin prescripts-end=prescripts-end primarynic=primarynic primarysn=primarysn privkey=privkey privtype=AES productkey=productkey provmethod=provmethod rack=rack room=room routenames=routenames seclevel=noAuthNoPriv serial=serial serialflow=serialflow serialport=serialport serialspeed=serialspeed servicenode=servicenode setupconserver=0 setupdhcp=0 setupftp=setupftp setupipforward=0 setupldap=0 setupnameserver=0 setupnfs=0 setupnim=setupnim setupntp=0 setupproxydhcp=0 setuptftp=0 sfp=sfp side=side slot=slot snmpuser=snmpuser snmpversion=SNMPv1 storagcontroller=storagcontroller storagetype=storagetype supernode=supernode supportedarchs=supportedarchs supportproxydhcp=supportproxydhcp switch=switch switchinterface=switchinterface switchport=50 switchvlan=switchvlan syslog=syslog termport=termport termserver=termserver tftpdir=tftpdir tftpserver=tftpserver unit=unit usercomment=usercomment username=username vmbeacon=vmbeacon vmbootorder=vmbootorder vmcfgstore=vmcfgstore vmcluster=vmcluster vmmanager=vmmanager vmmaster=vmmaster vmnicnicmodel=vmnicnicmodel vmphyslots=vmphyslots vmstorage=vmstorage vmstoragecache=vmstoragecache vmstorageformat=vmstorageformat vmstoragemodel=vmstoragemodel vmtextconsole=vmtextconsole vmvirtflags=vmvirtflags vmvncport=vmvncport xcatmaster=xcatmaster zonename=zonename nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 check:rc==0
@@ -238,9 +238,9 @@ cmd:scp /tmp/export_import_single_pdu_by_json/bogusnode_json.inv $$DSTMN:/tmp/ex
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'xcat-inventory import -f /tmp/export_import_single_pdu_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_pdu_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_pdu_by_json_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_pdu_by_json_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_pdu_by_json_$$DSTMN/dstbogusnode.stanza /tmp/export_import_single_pdu_by_json/dstbogusnode.stanza
 check:rc==0
@@ -248,17 +248,17 @@ cmd: cat /tmp/export_import_single_pdu_by_json/dstbogusnode.stanza
 check:rc==0
 cmd:diff -y /tmp/export_import_single_pdu_by_json/srcbogusnode.stanza /tmp/export_import_single_pdu_by_json/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'rmdef bogusnode'
+cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_pdu_by_json/bogusnode.stanza ]]; then cat /tmp/export_import_single_pdu_by_json/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_pdu_by_json/bogusgroup.stanza ]]; then cat /tmp/export_import_single_pdu_by_json/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_pdu_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_pdu_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_pdu_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_pdu_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_pdu_by_json_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_pdu_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_pdu_by_json_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_pdu_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'rm -rf /tmp/export_import_single_pdu_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_pdu_by_json_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_pdu_by_json
 check:rc==0
@@ -271,15 +271,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_pdu_by_yaml
 check:rc==0
-cmd:ssh $$DSTMN 'mkdir -p /tmp/export_import_single_pdu_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_pdu_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_pdu_by_yaml/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_pdu_by_yaml/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup mgt=pdu nodetype=pdu  addkcmdline=addkcmdline arch=ppc64 authdomain=authdomain authkey=authkey authtype=MD5 cfgmgr=cfgmgr cfgmgtroles=cfgmgtroles cfgserver=cfgserver chain=chain chassis=chassis cmdmapping=cmdmapping community=community cons=cons conserver=conserver consoleondemand=consoleondemand cpucount=cpucount cputype=cputype dhcpinterfaces=dhcpinterfaces disksize=disksize domainadminpassword=domainadminpassword domainadminuser=domainadminuser domaintype=domaintype getmac=getmac  height=height hidden=hidden hostcluster=hostcluster hostinterface=hostinterface hostmanager=hostmanager hostnames=hostnames hosttype=hosttype installnic=installnic interface=interface ip=10.10.10.10 iscsipassword=iscsipassword iscsiserver=iscsiserver iscsitarget=iscsitarget iscsiuserid=iscsiuserid mac=42:d6:0a:03:05:08 memory=memory migrationdest=migrationdest monserver=monserver mpa=mpa mtm=mtm nameservers=nameservers netboot=grub2 nfsdir=nfsdir nfsserver=nfsserver  nimserver=nimserver node=node ondiscover=ondiscover  osvolume=osvolume otherinterfaces=otherinterfaces ou=ou outlet=outlet password=password pdu=pdu pdutype=pdutype postbootscripts=postbootscripts postscripts=postscripts power=power prescripts-begin=prescripts-begin prescripts-end=prescripts-end primarynic=primarynic primarysn=primarysn privkey=privkey privtype=AES productkey=productkey provmethod=provmethod rack=rack room=room routenames=routenames seclevel=noAuthNoPriv serial=serial serialflow=serialflow serialport=serialport serialspeed=serialspeed servicenode=servicenode setupconserver=0 setupdhcp=0 setupftp=setupftp setupipforward=0 setupldap=0 setupnameserver=0 setupnfs=0 setupnim=setupnim setupntp=0 setupproxydhcp=0 setuptftp=0 sfp=sfp side=side slot=slot snmpuser=snmpuser snmpversion=SNMPv1 storagcontroller=storagcontroller storagetype=storagetype supernode=supernode supportedarchs=supportedarchs supportproxydhcp=supportproxydhcp switch=switch switchinterface=switchinterface switchport=50 switchvlan=switchvlan syslog=syslog termport=termport termserver=termserver tftpdir=tftpdir tftpserver=tftpserver unit=unit usercomment=usercomment username=username vmbeacon=vmbeacon vmbootorder=vmbootorder vmcfgstore=vmcfgstore vmcluster=vmcluster vmmanager=vmmanager vmmaster=vmmaster vmnicnicmodel=vmnicnicmodel vmphyslots=vmphyslots vmstorage=vmstorage vmstoragecache=vmstoragecache vmstorageformat=vmstorageformat vmstoragemodel=vmstoragemodel vmtextconsole=vmtextconsole vmvirtflags=vmvirtflags vmvncport=vmvncport xcatmaster=xcatmaster zonename=zonename nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 check:rc==0
@@ -291,9 +291,9 @@ cmd:scp /tmp/export_import_single_pdu_by_yaml/bogusnode_yaml.inv $$DSTMN:/tmp/ex
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'xcat-inventory import -f /tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_pdu_by_yaml_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_pdu_by_yaml_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_pdu_by_yaml_$$DSTMN/dstbogusnode.stanza /tmp/export_import_single_pdu_by_yaml/dstbogusnode.stanza
 check:rc==0
@@ -301,17 +301,17 @@ cmd: cat /tmp/export_import_single_pdu_by_yaml/dstbogusnode.stanza
 check:rc==0
 cmd:diff -y /tmp/export_import_single_pdu_by_yaml/srcbogusnode.stanza /tmp/export_import_single_pdu_by_yaml/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'rmdef bogusnode'
+cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_pdu_by_yaml/bogusnode.stanza ]]; then cat /tmp/export_import_single_pdu_by_yaml/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_pdu_by_yaml/bogusgroup.stanza ]]; then cat /tmp/export_import_single_pdu_by_yaml/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'rm -rf /tmp/export_import_single_pdu_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_pdu_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_pdu_by_yaml
 check:rc==0
@@ -324,15 +324,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_boston_by_yaml
 check:rc==0
-cmd:ssh $$DSTMN 'mkdir -p /tmp/export_import_single_boston_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_boston_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_boston_by_yaml/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_boston_by_yaml/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup mgt=ipmi  addkcmdline=addkcmdline  arch=ppc64le authdomain=authdomain bmc=bmc bmcpassword=bmcpassword bmcport=bmcport bmcusername=bmcusername bmcvlantag=bmcvlantag cfgmgr=cfgmgr cfgmgtroles=cfgmgtroles cfgserver=cfgserver chain=chain chassis=chassis cmdmapping=cmdmapping cons=cons conserver=conserver consoleondemand=consoleondemand cpucount=cpucount cputype=cputype dhcpinterfaces=dhcpinterfaces disksize=disksize domainadminpassword=domainadminpassword domainadminuser=domainadminuser domaintype=domaintype getmac=getmac  height=height hidden=hidden hostcluster=hostcluster hostinterface=hostinterface hostmanager=hostmanager hostnames=hostnames hosttype=hosttype hwtype=hwtype  installnic=installnic interface=interface ip=10.10.10.10 iscsipassword=iscsipassword iscsiserver=iscsiserver iscsitarget=iscsitarget iscsiuserid=iscsiuserid mac=42:d6:0a:03:05:08 memory=memory migrationdest=migrationdest monserver=monserver mpa=mpa mtm=mtm nameservers=nameservers netboot=grub2 nfsdir=nfsdir nfsserver=nfsserver nimserver=nimserver node=node ondiscover=ondiscover osvolume=osvolume otherinterfaces=otherinterfaces ou=ou pdu=pdu postbootscripts=postbootscripts postscripts=postscripts power=power prescripts-begin=prescripts-begin prescripts-end=prescripts-end primarynic=primarynic primarysn=primarysn productkey=productkey  provmethod=provmethod rack=rack room=room routenames=routenames serial=serial serialflow=serialflow serialport=serialport serialspeed=serialspeed servicenode=servicenode setupconserver=0 setupdhcp=0 setupftp=setupftp setupipforward=0 setupldap=0 setupnameserver=0 setupnfs=0 setupnim=setupnim setupntp=0 setupproxydhcp=0 setuptftp=0 sfp=sfp side=side slot=slot slotid=slotid  storagcontroller=storagcontroller storagetype=storagetype supernode=supernode supportedarchs=supportedarchs supportproxydhcp=supportproxydhcp switch=switch switchinterface=switchinterface switchport=50 switchvlan=switchvlan syslog=syslog termport=termport termserver=termserver tftpdir=tftpdir tftpserver=tftpserver unit=unit usercomment=usercomment vmbeacon=vmbeacon vmbootorder=vmbootorder vmcfgstore=vmcfgstore vmcluster=vmcluster vmmanager=vmmanager vmmaster=vmmaster vmnicnicmodel=vmnicnicmodel vmphyslots=vmphyslots vmstorage=vmstorage vmstoragecache=vmstoragecache vmstorageformat=vmstorageformat vmstoragemodel=vmstoragemodel vmtextconsole=vmtextconsole vmvirtflags=vmvirtflags vmvncport=vmvncport xcatmaster=xcatmaster zonename=zonename  nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 check:rc==0
@@ -344,9 +344,9 @@ cmd:scp /tmp/export_import_single_boston_by_yaml/bogusnode_yaml.inv $$DSTMN:/tmp
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'xcat-inventory import -f /tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_boston_by_yaml_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_boston_by_yaml_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_boston_by_yaml_$$DSTMN/dstbogusnode.stanza /tmp/export_import_single_boston_by_yaml/dstbogusnode.stanza
 check:rc==0
@@ -354,17 +354,17 @@ cmd: cat /tmp/export_import_single_boston_by_yaml/dstbogusnode.stanza
 check:rc==0
 cmd:diff -y /tmp/export_import_single_boston_by_yaml/srcbogusnode.stanza /tmp/export_import_single_boston_by_yaml/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'rmdef bogusnode'
+cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_boston_by_yaml/bogusnode.stanza ]]; then cat /tmp/export_import_single_boston_by_yaml/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_boston_by_yaml/bogusgroup.stanza ]]; then cat /tmp/export_import_single_boston_by_yaml/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'rm -rf /tmp/export_import_single_boston_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_boston_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_boston_by_yaml
 check:rc==0
@@ -376,15 +376,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_boston_by_json
 check:rc==0
-cmd:ssh $$DSTMN 'mkdir -p /tmp/export_import_single_boston_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_boston_by_json_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_boston_by_json/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_boston_by_json/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_boston_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_boston_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_boston_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_boston_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup mgt=ipmi  addkcmdline=addkcmdline  arch=ppc64le authdomain=authdomain bmc=bmc bmcpassword=bmcpassword bmcport=bmcport bmcusername=bmcusername bmcvlantag=bmcvlantag cfgmgr=cfgmgr cfgmgtroles=cfgmgtroles cfgserver=cfgserver chain=chain chassis=chassis cmdmapping=cmdmapping cons=cons conserver=conserver consoleondemand=consoleondemand cpucount=cpucount cputype=cputype dhcpinterfaces=dhcpinterfaces disksize=disksize domainadminpassword=domainadminpassword domainadminuser=domainadminuser domaintype=domaintype getmac=getmac  height=height hidden=hidden hostcluster=hostcluster hostinterface=hostinterface hostmanager=hostmanager hostnames=hostnames hosttype=hosttype hwtype=hwtype installnic=installnic interface=interface ip=10.10.10.10 iscsipassword=iscsipassword iscsiserver=iscsiserver iscsitarget=iscsitarget iscsiuserid=iscsiuserid mac=42:d6:0a:03:05:08 memory=memory migrationdest=migrationdest monserver=monserver mpa=mpa mtm=mtm nameservers=nameservers netboot=grub2 nfsdir=nfsdir nfsserver=nfsserver nimserver=nimserver node=node ondiscover=ondiscover osvolume=osvolume otherinterfaces=otherinterfaces ou=ou pdu=pdu postbootscripts=postbootscripts postscripts=postscripts power=power prescripts-begin=prescripts-begin prescripts-end=prescripts-end primarynic=primarynic primarysn=primarysn productkey=productkey  provmethod=provmethod rack=rack room=room routenames=routenames serial=serial serialflow=serialflow serialport=serialport serialspeed=serialspeed servicenode=servicenode setupconserver=0 setupdhcp=0 setupftp=setupftp setupipforward=0 setupldap=0 setupnameserver=0 setupnfs=0 setupnim=setupnim setupntp=0 setupproxydhcp=0 setuptftp=0 sfp=sfp side=side slot=slot slotid=slotid  storagcontroller=storagcontroller storagetype=storagetype supernode=supernode supportedarchs=supportedarchs supportproxydhcp=supportproxydhcp switch=switch switchinterface=switchinterface switchport=50 switchvlan=switchvlan syslog=syslog termport=termport termserver=termserver tftpdir=tftpdir tftpserver=tftpserver unit=unit usercomment=usercomment vmbeacon=vmbeacon vmbootorder=vmbootorder vmcfgstore=vmcfgstore vmcluster=vmcluster vmmanager=vmmanager vmmaster=vmmaster vmnicnicmodel=vmnicnicmodel vmphyslots=vmphyslots vmstorage=vmstorage vmstoragecache=vmstoragecache vmstorageformat=vmstorageformat vmstoragemodel=vmstoragemodel vmtextconsole=vmtextconsole vmvirtflags=vmvirtflags vmvncport=vmvncport xcatmaster=xcatmaster zonename=zonename  nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 check:rc==0
@@ -396,9 +396,9 @@ cmd:scp /tmp/export_import_single_boston_by_json/bogusnode_json.inv $$DSTMN:/tmp
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'xcat-inventory import -f /tmp/export_import_single_boston_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_boston_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_boston_by_json_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_boston_by_json_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_boston_by_json_$$DSTMN/dstbogusnode.stanza /tmp/export_import_single_boston_by_json/dstbogusnode.stanza
 check:rc==0
@@ -406,17 +406,17 @@ cmd: cat /tmp/export_import_single_boston_by_json/dstbogusnode.stanza
 check:rc==0
 cmd:diff -y /tmp/export_import_single_boston_by_json/srcbogusnode.stanza /tmp/export_import_single_boston_by_json/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'rmdef bogusnode'
+cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_boston_by_json/bogusnode.stanza ]]; then cat /tmp/export_import_single_boston_by_json/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_boston_by_json/bogusgroup.stanza ]]; then cat /tmp/export_import_single_boston_by_json/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_boston_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_boston_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_boston_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_boston_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_boston_by_json_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_boston_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_boston_by_json_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_boston_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'rm -rf /tmp/export_import_single_boston_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_boston_by_json_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_boston_by_json
 check:rc==0
@@ -428,15 +428,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_witherspoon_by_yaml
 check:rc==0
-cmd:ssh $$DSTMN 'mkdir -p /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_witherspoon_by_yaml/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_witherspoon_by_yaml/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup mgt=openbmc nodetype=mp  addkcmdline=addkcmdline  arch=ppc64le authdomain=authdomain bmc=bmc bmcpassword=bmcpassword bmcusername=bmcusername bmcvlantag=bmcvlantag cfgmgr=cfgmgr cfgmgtroles=cfgmgtroles cfgserver=cfgserver chain=chain chassis=chassis cmdmapping=cmdmapping cons=cons conserver=conserver consoleondemand=consoleondemand consport=consport cpucount=cpucount cputype=cputype dhcpinterfaces=dhcpinterfaces disksize=disksize domainadminpassword=domainadminpassword domainadminuser=domainadminuser domaintype=domaintype getmac=getmac  height=height hidden=hidden hostcluster=hostcluster hostinterface=hostinterface hostmanager=hostmanager hostnames=hostnames hosttype=hosttype hwtype=hwtype  installnic=installnic interface=interface ip=10.10.10.10 iscsipassword=iscsipassword iscsiserver=iscsiserver iscsitarget=iscsitarget iscsiuserid=iscsiuserid  mac=42:d6:0a:03:05:08 memory=memory migrationdest=migrationdest monserver=monserver mpa=mpa mtm=mtm nameservers=nameservers netboot=grub2 nfsdir=nfsdir nfsserver=nfsserver  nimserver=nimserver node=node ondiscover=ondiscover osvolume=osvolume otherinterfaces=otherinterfaces ou=ou pdu=pdu postbootscripts=postbootscripts postscripts=postscripts power=power prescripts-begin=prescripts-begin prescripts-end=prescripts-end primarynic=primarynic primarysn=primarysn productkey=productkey provmethod=provmethod rack=rack room=room routenames=routenames serial=serial serialflow=serialflow serialport=serialport serialspeed=serialspeed servicenode=servicenode setupconserver=0 setupdhcp=0 setupftp=setupftp setupipforward=0 setupldap=0 setupnameserver=0 setupnfs=0 setupnim=setupnim setupntp=0 setupproxydhcp=0 setuptftp=0 sfp=sfp side=side slot=slot storagcontroller=storagcontroller storagetype=storagetype supernode=supernode supportedarchs=supportedarchs supportproxydhcp=supportproxydhcp switch=switch switchinterface=switchinterface switchport=50 switchvlan=switchvlan syslog=syslog termport=termport termserver=termserver tftpdir=tftpdir tftpserver=tftpserver unit=unit usercomment=usercomment vmbeacon=vmbeacon vmbootorder=vmbootorder vmcfgstore=vmcfgstore vmcluster=vmcluster vmmanager=vmmanager vmmaster=vmmaster vmnicnicmodel=vmnicnicmodel vmphyslots=vmphyslots vmstorage=vmstorage vmstoragecache=vmstoragecache vmstorageformat=vmstorageformat vmstoragemodel=vmstoragemodel vmtextconsole=vmtextconsole vmvirtflags=vmvirtflags vmvncport=vmvncport xcatmaster=xcatmaster zonename=zonename  nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 check:rc==0
@@ -448,9 +448,9 @@ cmd:scp /tmp/export_import_single_witherspoon_by_yaml/bogusnode_yaml.inv $$DSTMN
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'xcat-inventory import -f /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/dstbogusnode.stanza /tmp/export_import_single_witherspoon_by_yaml/dstbogusnode.stanza
 check:rc==0
@@ -458,17 +458,17 @@ cmd: cat /tmp/export_import_single_witherspoon_by_yaml/dstbogusnode.stanza
 check:rc==0
 cmd:diff -y /tmp/export_import_single_witherspoon_by_yaml/srcbogusnode.stanza /tmp/export_import_single_witherspoon_by_yaml/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'rmdef bogusnode'
+cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_witherspoon_by_yaml/bogusnode.stanza ]]; then cat /tmp/export_import_single_witherspoon_by_yaml/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_witherspoon_by_yaml/bogusgroup.stanza ]]; then cat /tmp/export_import_single_witherspoon_by_yaml/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'rm -rf /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_witherspoon_by_yaml
 check:rc==0
@@ -480,15 +480,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_witherspoon_by_json
 check:rc==0
-cmd:ssh $$DSTMN 'mkdir -p /tmp/export_import_single_witherspoon_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_witherspoon_by_json_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_witherspoon_by_json/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_witherspoon_by_json/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup mgt=openbmc nodetype=mp  addkcmdline=addkcmdline  arch=ppc64le authdomain=authdomain bmc=bmc bmcpassword=bmcpassword bmcusername=bmcusername bmcvlantag=bmcvlantag cfgmgr=cfgmgr cfgmgtroles=cfgmgtroles cfgserver=cfgserver chain=chain chassis=chassis cmdmapping=cmdmapping cons=cons conserver=conserver consoleondemand=consoleondemand consport=consport cpucount=cpucount cputype=cputype dhcpinterfaces=dhcpinterfaces disksize=disksize domainadminpassword=domainadminpassword domainadminuser=domainadminuser domaintype=domaintype getmac=getmac  height=height hidden=hidden hostcluster=hostcluster hostinterface=hostinterface hostmanager=hostmanager hostnames=hostnames hosttype=hosttype hwtype=hwtype installnic=installnic interface=interface ip=10.10.10.10 iscsipassword=iscsipassword iscsiserver=iscsiserver iscsitarget=iscsitarget iscsiuserid=iscsiuserid  mac=42:d6:0a:03:05:08 memory=memory migrationdest=migrationdest monserver=monserver mpa=mpa mtm=mtm nameservers=nameservers netboot=grub2 nfsdir=nfsdir nfsserver=nfsserver  nimserver=nimserver node=node ondiscover=ondiscover osvolume=osvolume otherinterfaces=otherinterfaces ou=ou pdu=pdu postbootscripts=postbootscripts postscripts=postscripts power=power prescripts-begin=prescripts-begin prescripts-end=prescripts-end primarynic=primarynic primarysn=primarysn productkey=productkey provmethod=provmethod rack=rack room=room routenames=routenames serial=serial serialflow=serialflow serialport=serialport serialspeed=serialspeed servicenode=servicenode setupconserver=0 setupdhcp=0 setupftp=setupftp setupipforward=0 setupldap=0 setupnameserver=0 setupnfs=0 setupnim=setupnim setupntp=0 setupproxydhcp=0 setuptftp=0 sfp=sfp side=side slot=slot storagcontroller=storagcontroller storagetype=storagetype supernode=supernode supportedarchs=supportedarchs supportproxydhcp=supportproxydhcp switch=switch switchinterface=switchinterface switchport=50 switchvlan=switchvlan syslog=syslog termport=termport termserver=termserver tftpdir=tftpdir tftpserver=tftpserver unit=unit usercomment=usercomment vmbeacon=vmbeacon vmbootorder=vmbootorder vmcfgstore=vmcfgstore vmcluster=vmcluster vmmanager=vmmanager vmmaster=vmmaster vmnicnicmodel=vmnicnicmodel vmphyslots=vmphyslots vmstorage=vmstorage vmstoragecache=vmstoragecache vmstorageformat=vmstorageformat vmstoragemodel=vmstoragemodel vmtextconsole=vmtextconsole vmvirtflags=vmvirtflags vmvncport=vmvncport xcatmaster=xcatmaster zonename=zonename  nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 check:rc==0
@@ -500,9 +500,9 @@ cmd:scp /tmp/export_import_single_witherspoon_by_json/bogusnode_json.inv $$DSTMN
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'xcat-inventory import -f /tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_witherspoon_by_json_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_witherspoon_by_json_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_witherspoon_by_json_$$DSTMN/dstbogusnode.stanza /tmp/export_import_single_witherspoon_by_json/dstbogusnode.stanza
 check:rc==0
@@ -510,17 +510,17 @@ cmd: cat /tmp/export_import_single_witherspoon_by_json/dstbogusnode.stanza
 check:rc==0
 cmd:diff -y /tmp/export_import_single_witherspoon_by_json/srcbogusnode.stanza /tmp/export_import_single_witherspoon_by_json/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'rmdef bogusnode'
+cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_witherspoon_by_json/bogusnode.stanza ]]; then cat /tmp/export_import_single_witherspoon_by_json/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_witherspoon_by_json/bogusgroup.stanza ]]; then cat /tmp/export_import_single_witherspoon_by_json/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'rm -rf /tmp/export_import_single_witherspoon_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_witherspoon_by_json_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_witherspoon_by_json
 check:rc==0
@@ -533,15 +533,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_switch_by_json
 check:rc==0
-cmd:ssh $$DSTMN 'mkdir -p /tmp/export_import_single_switch_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_switch_by_json_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_switch_by_json/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_switch_by_json/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_switch_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_switch_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_switch_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_switch_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup mgt=switch nodetype=switch addkcmdline=addkcmdline arch=ppc64 authdomain=authdomain cfgmgr=cfgmgr cfgmgtroles=cfgmgtroles cfgserver=cfgserver chain=chain chassis=chassis cmdmapping=cmdmapping cons=cons conserver=conserver consoleondemand=consoleondemand cpucount=cpucount cputype=cputype dhcpinterfaces=dhcpinterfaces disksize=disksize domainadminpassword=domainadminpassword domainadminuser=domainadminuser domaintype=domaintype getmac=getmac height=height hidden=hidden hostcluster=hostcluster hostinterface=hostinterface hostmanager=hostmanager hostnames=hostnames hosttype=hosttype installnic=installnic interface=interface ip=10.10.10.10 iscsipassword=iscsipassword iscsiserver=iscsiserver iscsitarget=iscsitarget iscsiuserid=iscsiuserid linkports=linkports mac=42:d6:0a:03:05:08 memory=memory migrationdest=migrationdest monserver=monserver mpa=mpa mtm=mtm nameservers=nameservers netboot=grub2 nfsdir=nfsdir nfsserver=nfsserver nimserver=nimserver node=node ondiscover=ondiscover osvolume=osvolume otherinterfaces=otherinterfaces ou=ou password=password pdu=pdu postbootscripts=postbootscripts postscripts=postscripts power=power prescripts-begin=prescripts-begin prescripts-end=prescripts-end primarynic=primarynic primarysn=primarysn productkey=productkey protocol=ssh provmethod=provmethod rack=rack room=room routenames=routenames serial=serial serialflow=serialflow serialport=serialport serialspeed=serialspeed servicenode=servicenode setupconserver=0 setupdhcp=0 setupftp=setupftp setupipforward=0 setupldap=0 setupnameserver=0 setupnfs=0 setupnim=setupnim setupntp=0 setupproxydhcp=0 setuptftp=0 sfp=sfp side=side slot=slot snmpauth=SHA snmppassword=snmppassword snmpprivacy=DES snmpusername=snmpusername snmpversion=SNMPv1 storagcontroller=storagcontroller storagetype=storagetype supernode=supernode supportedarchs=supportedarchs supportproxydhcp=supportproxydhcp switch=switch switchinterface=switchinterface switchport=50 switchtype=switchtype switchvlan=switchvlan syslog=syslog termport=termport termserver=termserver tftpdir=tftpdir tftpserver=tftpserver unit=unit usercomment=usercomment username=username vmbeacon=vmbeacon vmbootorder=vmbootorder vmcfgstore=vmcfgstore vmcluster=vmcluster vmmanager=vmmanager vmmaster=vmmaster vmnicnicmodel=vmnicnicmodel vmphyslots=vmphyslots vmstorage=vmstorage vmstoragecache=vmstoragecache vmstorageformat=vmstorageformat vmstoragemodel=vmstoragemodel vmtextconsole=vmtextconsole vmvirtflags=vmvirtflags vmvncport=vmvncport xcatmaster=xcatmaster zonename=zonename  nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 check:rc==0
@@ -553,9 +553,9 @@ cmd:scp /tmp/export_import_single_switch_by_json/bogusnode_json.inv $$DSTMN:/tmp
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'xcat-inventory import -f /tmp/export_import_single_switch_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_switch_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_switch_by_json_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_switch_by_json_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_switch_by_json_$$DSTMN/dstbogusnode.stanza /tmp/export_import_single_switch_by_json/dstbogusnode.stanza
 check:rc==0
@@ -563,17 +563,17 @@ cmd: cat /tmp/export_import_single_switch_by_json/dstbogusnode.stanza
 check:rc==0
 cmd:diff -y /tmp/export_import_single_switch_by_json/srcbogusnode.stanza /tmp/export_import_single_switch_by_json/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'rmdef bogusnode'
+cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_switch_by_json/bogusnode.stanza ]]; then cat /tmp/export_import_single_switch_by_json/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_switch_by_json/bogusgroup.stanza ]]; then cat /tmp/export_import_single_switch_by_json/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_switch_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_switch_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_switch_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_switch_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_switch_by_json_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_switch_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_switch_by_json_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_switch_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'rm -rf /tmp/export_import_single_switch_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_switch_by_json_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_switch_by_json
 check:rc==0
@@ -585,15 +585,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_switch_by_yaml
 check:rc==0
-cmd:ssh $$DSTMN 'mkdir -p /tmp/export_import_single_switch_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_switch_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_switch_by_yaml/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_switch_by_yaml/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup mgt=switch nodetype=switch addkcmdline=addkcmdline arch=ppc64 authdomain=authdomain cfgmgr=cfgmgr cfgmgtroles=cfgmgtroles cfgserver=cfgserver chain=chain chassis=chassis cmdmapping=cmdmapping cons=cons conserver=conserver consoleondemand=consoleondemand cpucount=cpucount cputype=cputype dhcpinterfaces=dhcpinterfaces disksize=disksize domainadminpassword=domainadminpassword domainadminuser=domainadminuser domaintype=domaintype getmac=getmac  height=height hidden=hidden hostcluster=hostcluster hostinterface=hostinterface hostmanager=hostmanager hostnames=hostnames hosttype=hosttype  installnic=installnic interface=interface ip=10.10.10.10 iscsipassword=iscsipassword iscsiserver=iscsiserver iscsitarget=iscsitarget iscsiuserid=iscsiuserid linkports=linkports mac=42:d6:0a:03:05:08 memory=memory migrationdest=migrationdest monserver=monserver mpa=mpa mtm=mtm nameservers=nameservers netboot=grub2 nfsdir=nfsdir nfsserver=nfsserver nimserver=nimserver node=node ondiscover=ondiscover osvolume=osvolume otherinterfaces=otherinterfaces ou=ou password=password pdu=pdu postbootscripts=postbootscripts postscripts=postscripts power=power prescripts-begin=prescripts-begin prescripts-end=prescripts-end primarynic=primarynic primarysn=primarysn productkey=productkey protocol=ssh provmethod=provmethod rack=rack room=room routenames=routenames serial=serial serialflow=serialflow serialport=serialport serialspeed=serialspeed servicenode=servicenode setupconserver=0 setupdhcp=0 setupftp=setupftp setupipforward=0 setupldap=0 setupnameserver=0 setupnfs=0 setupnim=setupnim setupntp=0 setupproxydhcp=0 setuptftp=0 sfp=sfp side=side slot=slot snmpauth=SHA snmppassword=snmppassword snmpprivacy=DES snmpusername=snmpusername snmpversion=SNMPv1 storagcontroller=storagcontroller storagetype=storagetype supernode=supernode supportedarchs=supportedarchs supportproxydhcp=supportproxydhcp switch=switch switchinterface=switchinterface switchport=50 switchtype=switchtype switchvlan=switchvlan syslog=syslog termport=termport termserver=termserver tftpdir=tftpdir tftpserver=tftpserver unit=unit usercomment=usercomment username=username vmbeacon=vmbeacon vmbootorder=vmbootorder vmcfgstore=vmcfgstore vmcluster=vmcluster vmmanager=vmmanager vmmaster=vmmaster vmnicnicmodel=vmnicnicmodel vmphyslots=vmphyslots vmstorage=vmstorage vmstoragecache=vmstoragecache vmstorageformat=vmstorageformat vmstoragemodel=vmstoragemodel vmtextconsole=vmtextconsole vmvirtflags=vmvirtflags vmvncport=vmvncport xcatmaster=xcatmaster zonename=zonename  nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 check:rc==0
@@ -605,9 +605,9 @@ cmd:scp /tmp/export_import_single_switch_by_yaml/bogusnode_yaml.inv $$DSTMN:/tmp
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'xcat-inventory import -f /tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_switch_by_yaml_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_switch_by_yaml_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_switch_by_yaml_$$DSTMN/dstbogusnode.stanza /tmp/export_import_single_switch_by_yaml/dstbogusnode.stanza
 check:rc==0
@@ -615,17 +615,17 @@ cmd: cat /tmp/export_import_single_switch_by_yaml/dstbogusnode.stanza
 check:rc==0
 cmd:diff -y /tmp/export_import_single_switch_by_yaml/srcbogusnode.stanza /tmp/export_import_single_switch_by_yaml/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'rmdef bogusnode'
+cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_switch_by_yaml/bogusnode.stanza ]]; then cat /tmp/export_import_single_switch_by_yaml/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_switch_by_yaml/bogusgroup.stanza ]]; then cat /tmp/export_import_single_switch_by_yaml/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'rm -rf /tmp/export_import_single_switch_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_switch_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_switch_by_yaml
 check:rc==0
@@ -638,15 +638,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_nodes_delimited_with_comma_by_yaml
 check:rc==0
-cmd:ssh $$DSTMN 'mkdir -p /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:for i in 1 2 3; do lsdef bogusnode$i > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode$i -z >> /tmp/export_import_nodes_delimited_with_comma_by_yaml/bogusnode.stanza ;rmdef bogusnode$i;fi; done
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_nodes_delimited_with_comma_by_yaml/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'for i in 1 2 3; do lsdef bogusnode$i > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode$i -z >> /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode$i;fi; done'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'for i in 1 2 3; do lsdef bogusnode$i > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode$i -z >> /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode$i;fi; done'
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef  bogusnode[1-3] groups=bogusgroup mgt=openbmc cons=openbmc netboot=petitboot
 check:rc==0
@@ -658,9 +658,9 @@ cmd:scp /tmp/export_import_nodes_delimited_with_comma_by_yaml/bogusnode_yaml.inv
 check:rc==0
 cmd:rmdef bogusnode[1-3]
 check:rc==0
-cmd: ssh  $$DSTMN 'xcat-inventory import -f /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode1,bogusnode2,bogusnode3'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode1,bogusnode2,bogusnode3'
 check:rc==0
-cmd: ssh  $$DSTMN 'lsdef bogusnode[1-3] -z|sort -t'=' -k1 |tee /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode[1-3] -z|sort -t'=' -k1 |tee /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/dstbogusnode.stanza /tmp/export_import_nodes_delimited_with_comma_by_yaml/dstbogusnode.stanza
 check:rc==0
@@ -668,17 +668,17 @@ cmd: cat /tmp/export_import_nodes_delimited_with_comma_by_yaml/dstbogusnode.stan
 check:rc==0
 cmd:diff -y /tmp/export_import_nodes_delimited_with_comma_by_yaml/srcbogusnode.stanza /tmp/export_import_nodes_delimited_with_comma_by_yaml/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'rmdef bogusnode[1-3]'
+cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode[1-3]'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_nodes_delimited_with_comma_by_yaml/bogusnode.stanza ]]; then cat /tmp/export_import_nodes_delimited_with_comma_by_yaml/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_nodes_delimited_with_comma_by_yaml/bogusgroup.stanza ]];then cat /tmp/export_import_nodes_delimited_with_comma_by_yaml/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusgroup.stanza ]];then cat /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusgroup.stanza ]];then cat /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'rm -rf /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_nodes_delimited_with_comma_by_yaml
 check:rc==0
@@ -690,15 +690,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_nodes_delimited_with_comma_by_json
 check:rc==0
-cmd:ssh $$DSTMN 'mkdir -p /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/'
 check:rc==0
 cmd:for i in 1 2 3; do lsdef bogusnode$i > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode$i -z >> /tmp/export_import_nodes_delimited_with_comma_by_json/bogusnode.stanza ;rmdef bogusnode$i;fi; done
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_nodes_delimited_with_comma_by_json/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'for i in 1 2 3; do lsdef bogusnode$i > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode$i -z >> /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode$i;fi; done'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'for i in 1 2 3; do lsdef bogusnode$i > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode$i -z >> /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode$i;fi; done'
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef  bogusnode[1-3] groups=bogusgroup mgt=openbmc cons=openbmc netboot=petitboot
 check:rc==0
@@ -710,9 +710,9 @@ cmd:scp /tmp/export_import_nodes_delimited_with_comma_by_json/bogusnode_json.inv
 check:rc==0
 cmd:rmdef bogusnode[1-3]
 check:rc==0
-cmd: ssh  $$DSTMN 'xcat-inventory import -f /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode1,bogusnode2,bogusnode3'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode1,bogusnode2,bogusnode3'
 check:rc==0
-cmd: ssh  $$DSTMN 'lsdef bogusnode[1-3] -z|sort -t'=' -k1 |tee /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode[1-3] -z|sort -t'=' -k1 |tee /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/dstbogusnode.stanza /tmp/export_import_nodes_delimited_with_comma_by_json/dstbogusnode.stanza
 check:rc==0
@@ -720,17 +720,17 @@ cmd: cat /tmp/export_import_nodes_delimited_with_comma_by_json/dstbogusnode.stan
 check:rc==0
 cmd:diff -y /tmp/export_import_nodes_delimited_with_comma_by_json/srcbogusnode.stanza /tmp/export_import_nodes_delimited_with_comma_by_json/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'rmdef bogusnode[1-3]'
+cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode[1-3]'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_nodes_delimited_with_comma_by_json/bogusnode.stanza ]]; then cat /tmp/export_import_nodes_delimited_with_comma_by_json/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_nodes_delimited_with_comma_by_json/bogusgroup.stanza ]];then cat /tmp/export_import_nodes_delimited_with_comma_by_json/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusgroup.stanza ]];then cat /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusgroup.stanza ]];then cat /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'rm -rf /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_nodes_delimited_with_comma_by_json
 check:rc==0
@@ -1730,15 +1730,15 @@ description:This case is used to test xcat-inventory import a node , then modify
 Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 cmd:mkdir -p /tmp/export_single_node_then_modify_yaml_then_import
 check:rc==0
-cmd:ssh $$DSTMN 'mkdir -p /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_single_node_then_modify_yaml_then_import/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_single_node_then_modify_yaml_then_import/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup mgt=openbmc nodetype=mp addkcmdline=1111 arch=ppc64 authdomain=1111 bmc=1111 bmcpassword=1111 bmcusername=1111 bmcvlantag=1111 cfgmgr=1111 cfgmgtroles=1111 cfgserver=1111 chain=1111 chassis=1111 cmdmapping=1111 cons=1111 conserver=1111 consoleondemand=1111 consport=1111 cpucount=1111 cputype=1111 dhcpinterfaces=1111 disksize=1111 domainadminpassword=1111 domainadminuser=1111 domaintype=1111 getmac=1111 height=1111 hidden=1111 hostcluster=1111 hostinterface=1111 hostmanager=1111 hostnames=1111 hosttype=1111 hwtype=1111  installnic=1111 interface=1111 ip=10.10.10.10 iscsipassword=1111 iscsiserver=1111 iscsitarget=1111 iscsiuserid=1111 mac=42:d6:0a:03:05:08 memory=1111 migrationdest=1111 monserver=1111 mpa=1111 mtm=1111 nameservers=1111 netboot=grub2 nfsdir=1111 nfsserver=1111 nimserver=1111 node=1111 ondiscover=1111 osvolume=1111 otherinterfaces=1111 ou=1111 pdu=1111 postbootscripts=1111 postscripts=1111 power=1111 prescripts-begin=1111 prescripts-end=1111 primarynic=1111 primarysn=1111 productkey=1111 provmethod=1111 rack=1111 room=1111 routenames=1111 serial=1111 serialflow=1111 serialport=1111 serialspeed=1111 servicenode=1111 setupconserver=1 setupdhcp=1 setupftp=1111 setupipforward=1 setupldap=1 setupnameserver=1 setupnfs=1 setupnim=1111 setupntp=1 setupproxydhcp=1 setuptftp=1 sfp=1111 side=1111 slot=1111 storagcontroller=1111 storagetype=1111 supernode=1111 supportedarchs=1111 supportproxydhcp=1111 switch=1111 switchinterface=1111 switchport=1111 switchvlan=1111 syslog=1111 termport=1111 termserver=1111 tftpdir=1111 tftpserver=1111 unit=1111 usercomment=1111 vmbeacon=1111 vmbootorder=1111 vmcfgstore=1111 vmcluster=1111 vmmanager=1111 vmmaster=1111 vmnicnicmodel=1111 vmphyslots=1111 vmstorage=1111 vmstoragecache=1111 vmstorageformat=1111 vmstoragemodel=1111 vmtextconsole=1111 vmvirtflags=1111 vmvncport=1111 xcatmaster=1111 zonename=1111 nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 cmd:lsdef bogusnode -z|sed 's/1111/2222/g'|sed 's/unused/used/g'|sed 's/10.10.100.9/20.10.200.9/g'|sort -t'=' -k1 |tee  /tmp/export_single_node_then_modify_yaml_then_import/srcbogusnode.stanza
@@ -1777,9 +1777,9 @@ cmd:scp /tmp/export_single_node_then_modify_yaml_then_import/bogusnode_yaml.inv 
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'xcat-inventory import -f /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/dstbogusnode.stanza /tmp/export_single_node_then_modify_yaml_then_import/dstbogusnode.stanza
 check:rc==0
@@ -1787,17 +1787,17 @@ cmd: cat /tmp/export_single_node_then_modify_yaml_then_import/dstbogusnode.stanz
 check:rc==0
 cmd:diff -y /tmp/export_single_node_then_modify_yaml_then_import/srcbogusnode.stanza /tmp/export_single_node_then_modify_yaml_then_import/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'rmdef bogusnode'
+cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_single_node_then_modify_yaml_then_import/bogusnode.stanza ]]; then cat /tmp/export_single_node_then_modify_yaml_then_import/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_single_node_then_modify_yaml_then_import/bogusgroup.stanza ]]; then cat /tmp/export_single_node_then_modify_yaml_then_import/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'rm -rf /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_single_node_then_modify_yaml_then_import
 check:rc==0
@@ -1809,15 +1809,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_single_node_then_modify_json_then_import
 check:rc==0
-cmd:ssh $$DSTMN 'mkdir -p /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_single_node_then_modify_json_then_import/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_single_node_then_modify_json_then_import/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup mgt=openbmc nodetype=mp addkcmdline=1111 arch=ppc64 authdomain=1111 bmc=1111 bmcpassword=1111 bmcusername=1111 bmcvlantag=1111 cfgmgr=1111 cfgmgtroles=1111 cfgserver=1111 chain=1111 chassis=1111 cmdmapping=1111 cons=1111 conserver=1111 consoleondemand=1111 consport=1111 cpucount=1111 cputype=1111 dhcpinterfaces=1111 disksize=1111 domainadminpassword=1111 domainadminuser=1111 domaintype=1111 getmac=1111 height=1111 hidden=1111 hostcluster=1111 hostinterface=1111 hostmanager=1111 hostnames=1111 hosttype=1111 hwtype=1111  installnic=1111 interface=1111 ip=10.10.10.10 iscsipassword=1111 iscsiserver=1111 iscsitarget=1111 iscsiuserid=1111 mac=42:d6:0a:03:05:08 memory=1111 migrationdest=1111 monserver=1111 mpa=1111 mtm=1111 nameservers=1111 netboot=grub2 nfsdir=1111 nfsserver=1111 nimserver=1111 node=1111 ondiscover=1111 osvolume=1111 otherinterfaces=1111 ou=1111 pdu=1111 postbootscripts=1111 postscripts=1111 power=1111 prescripts-begin=1111 prescripts-end=1111 primarynic=1111 primarysn=1111 productkey=1111 provmethod=1111 rack=1111 room=1111 routenames=1111 serial=1111 serialflow=1111 serialport=1111 serialspeed=1111 servicenode=1111 setupconserver=1 setupdhcp=1 setupftp=1111 setupipforward=1 setupldap=1 setupnameserver=1 setupnfs=1 setupnim=1111 setupntp=1 setupproxydhcp=1 setuptftp=1 sfp=1111 side=1111 slot=1111 storagcontroller=1111 storagetype=1111 supernode=1111 supportedarchs=1111 supportproxydhcp=1111 switch=1111 switchinterface=1111 switchport=1111 switchvlan=1111 syslog=1111 termport=1111 termserver=1111 tftpdir=1111 tftpserver=1111 unit=1111 usercomment=1111 vmbeacon=1111 vmbootorder=1111 vmcfgstore=1111 vmcluster=1111 vmmanager=1111 vmmaster=1111 vmnicnicmodel=1111 vmphyslots=1111 vmstorage=1111 vmstoragecache=1111 vmstorageformat=1111 vmstoragemodel=1111 vmtextconsole=1111 vmvirtflags=1111 vmvncport=1111 xcatmaster=1111 zonename=1111 nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 cmd:lsdef bogusnode -z|sed 's/1111/2222/g'|sed 's/unused/used/g'|sed 's/10.10.100.9/20.10.200.9/g'|sort -t'=' -k1 |tee  /tmp/export_single_node_then_modify_json_then_import/srcbogusnode.stanza
@@ -1854,9 +1854,9 @@ cmd:scp /tmp/export_single_node_then_modify_json_then_import/bogusnode_json.inv 
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'xcat-inventory import -f /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_single_node_then_modify_json_then_import_$$DSTMN/dstbogusnode.stanza /tmp/export_single_node_then_modify_json_then_import/dstbogusnode.stanza
 check:rc==0
@@ -1864,17 +1864,17 @@ cmd: cat /tmp/export_single_node_then_modify_json_then_import/dstbogusnode.stanz
 check:rc==0
 cmd:diff -y /tmp/export_single_node_then_modify_json_then_import/srcbogusnode.stanza /tmp/export_single_node_then_modify_json_then_import/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'rmdef bogusnode'
+cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_single_node_then_modify_json_then_import/bogusnode.stanza ]]; then cat /tmp/export_single_node_then_modify_json_then_import/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_single_node_then_modify_json_then_import/bogusgroup.stanza ]]; then cat /tmp/export_single_node_then_modify_json_then_import/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'rm -rf /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_single_node_then_modify_json_then_import
 check:rc==0
@@ -1885,15 +1885,15 @@ label:others,xcat_inventory
 description:This case is used to test xcat-inventory export and import the definition of group
 cmd:mkdir -p /tmp/export_import_single_group_json
 check:rc==0
-cmd:ssh $$DSTMN 'mkdir -p /tmp/export_import_single_group_json_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_group_json_$$DSTMN/'
 check:rc==0
 cmd:for i in 1 2 3; do lsdef bogusnode$i > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode$i -z >> /tmp/export_import_single_group_json/bogusnode.stanza ;rmdef bogusnode$i;fi; done
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_group_json/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'for i in 1 2 3; do lsdef bogusnode$i > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode$i -z >> /tmp/export_import_single_group_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode$i;fi; done'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'for i in 1 2 3; do lsdef bogusnode$i > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode$i -z >> /tmp/export_import_single_group_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode$i;fi; done'
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_group_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_group_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t group -o bogusgroup mgt=openbmc cons=openbmc netboot=petitboot  ip='|\D+(\d+)|10.100.100.($1)|' bmcusername=root bmcpassword=0penBmc
 check:rc==0
@@ -1913,17 +1913,17 @@ cmd:rmdef -t node -o bogusnode[1-3]
 check:rc==0
 cmd:rmdef -t group -o bogusgroup
 check:rc==0
-cmd:ssh $$DSTMN 'xcat-inventory import -f /tmp/export_import_single_group_json_$$DSTMN/export.file -t node -o bogusnode1,bogusnode2,bogusnode3,bogusgroup'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_group_json_$$DSTMN/export.file -t node -o bogusnode1,bogusnode2,bogusnode3,bogusgroup'
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t node -o bogusnode[1-3] > /tmp/export_import_single_group_json_$$DSTMN/import_nodes_group'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t node -o bogusnode[1-3] > /tmp/export_import_single_group_json_$$DSTMN/import_nodes_group'
 check:rc==0
-cmd:ssh  $$DSTMN 'lsdef -t group -o bogusgroup >> /tmp/export_import_single_group_json_$$DSTMN/import_nodes_group'
+cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group -o bogusgroup >> /tmp/export_import_single_group_json_$$DSTMN/import_nodes_group'
 check:rc==0
 cmd:scp $$DSTMN:/tmp/export_import_single_group_json_$$DSTMN/import_nodes_group /tmp/export_import_single_group_json/import_nodes_group
 check:rc==0
-cmd:ssh  $$DSTMN 'rmdef -t node -o bogusnode[1-3]'
+cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef -t node -o bogusnode[1-3]'
 check:rc==0
-cmd: ssh $$DSTMN 'rmdef -t group -o bogusgroup'
+cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef -t group -o bogusgroup'
 check:rc==0
 cmd:sed -e 's/members=.*$/members='"$(awk -F = '/members=/ { print $2 }' < /tmp/export_import_single_group_json/import_nodes_group | tr , ' ' | xargs -n 1 | sort -g | xargs -n 999 | tr ' ' ,)"'/' < /tmp/export_import_single_group_json/import_nodes_group > /tmp/export_import_single_group_json/import_nodes_group.1; cp -rf /tmp/export_import_single_group_json/import_nodes_group.1 /tmp/export_import_single_group_json/import_nodes_group
 check:rc==0
@@ -1933,11 +1933,11 @@ cmd:if [[ -e /tmp/export_import_single_group_json/bogusnode.stanza ]]; then cat 
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_group_json/bogusgroup.stanza ]];then cat /tmp/export_import_single_group_json/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_group_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_group_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_group_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_group_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_group_json_$$DSTMN/bogusgroup.stanza ]];then cat /tmp/export_import_single_group_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_group_json_$$DSTMN/bogusgroup.stanza ]];then cat /tmp/export_import_single_group_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'rm -rf /tmp/export_import_single_group_json_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_group_json_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_group_json
 check:rc==0
@@ -1948,15 +1948,15 @@ label:others,xcat_inventory
 description:This case is used to test xcat-inventory export and import the definition of group
 cmd:mkdir -p /tmp/export_import_single_group_yaml
 check:rc==0
-cmd:ssh $$DSTMN 'mkdir -p /tmp/export_import_single_group_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_group_yaml_$$DSTMN/'
 check:rc==0
 cmd:for i in 1 2 3; do lsdef bogusnode$i > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode$i -z >> /tmp/export_import_single_group_yaml/bogusnode.stanza ;rmdef bogusnode$i;fi; done
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_group_yaml/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'for i in 1 2 3; do lsdef bogusnode$i > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode$i -z >> /tmp/export_import_single_group_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode$i;fi; done'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'for i in 1 2 3; do lsdef bogusnode$i > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode$i -z >> /tmp/export_import_single_group_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode$i;fi; done'
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_group_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_group_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t group -o bogusgroup mgt=openbmc cons=openbmc netboot=petitboot  ip='|\D+(\d+)|10.100.100.($1)|' bmcusername=root bmcpassword=0penBmc
 check:rc==0
@@ -1976,17 +1976,17 @@ cmd:rmdef -t node -o bogusnode[1-3]
 check:rc==0
 cmd:rmdef -t group -o bogusgroup
 check:rc==0
-cmd:ssh $$DSTMN 'xcat-inventory import -f /tmp/export_import_single_group_yaml_$$DSTMN/export.file -t node -o bogusnode1,bogusnode2,bogusnode3,bogusgroup'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_group_yaml_$$DSTMN/export.file -t node -o bogusnode1,bogusnode2,bogusnode3,bogusgroup'
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t node -o bogusnode[1-3] > /tmp/export_import_single_group_yaml_$$DSTMN/import_nodes_group'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t node -o bogusnode[1-3] > /tmp/export_import_single_group_yaml_$$DSTMN/import_nodes_group'
 check:rc==0
-cmd:ssh  $$DSTMN 'lsdef -t group -o bogusgroup >> /tmp/export_import_single_group_yaml_$$DSTMN/import_nodes_group'
+cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group -o bogusgroup >> /tmp/export_import_single_group_yaml_$$DSTMN/import_nodes_group'
 check:rc==0
 cmd:scp $$DSTMN:/tmp/export_import_single_group_yaml_$$DSTMN/import_nodes_group /tmp/export_import_single_group_yaml/import_nodes_group
 check:rc==0
-cmd:ssh  $$DSTMN 'rmdef -t node -o bogusnode[1-3]'
+cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef -t node -o bogusnode[1-3]'
 check:rc==0
-cmd: ssh $$DSTMN 'rmdef -t group -o bogusgroup'
+cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef -t group -o bogusgroup'
 check:rc==0
 cmd:sed -e 's/members=.*$/members='"$(awk -F = '/members=/ { print $2 }' < /tmp/export_import_single_group_yaml/import_nodes_group | tr , ' ' | xargs -n 1 | sort -g | xargs -n 999 | tr ' ' ,)"'/' < /tmp/export_import_single_group_yaml/import_nodes_group > /tmp/export_import_single_group_yaml/import_nodes_group.1; cp -rf /tmp/export_import_single_group_yaml/import_nodes_group.1 /tmp/export_import_single_group_yaml/import_nodes_group
 check:rc==0
@@ -1996,11 +1996,11 @@ cmd:if [[ -e /tmp/export_import_single_group_yaml/bogusnode.stanza ]]; then cat 
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_group_yaml/bogusgroup.stanza ]];then cat /tmp/export_import_single_group_yaml/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_group_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_group_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_group_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_group_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_group_yaml_$$DSTMN/bogusgroup.stanza ]];then cat /tmp/export_import_single_group_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_group_yaml_$$DSTMN/bogusgroup.stanza ]];then cat /tmp/export_import_single_group_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'rm -rf /tmp/export_import_single_group_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_group_yaml_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_group_yaml
 check:rc==0

--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.node
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.node
@@ -4,15 +4,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_ppc_by_json
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_ppc_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_import_single_ppc_by_json_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_ppc_by_json/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_ppc_by_json/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_ppc_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_ppc_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_ppc_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_ppc_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup  mgt=hmc nodetype=ppc,osi  addkcmdline=addkcmdline arch=ppc64 authdomain=authdomain cfgmgr=cfgmgr cfgmgtroles=cfgmgtroles cfgserver=cfgserver chain=chain chassis=chassis cmdmapping=cmdmapping cons=cons conserver=conserver consoleondemand=consoleondemand cpucount=cpucount cputype=cputype  dhcpinterfaces=dhcpinterfaces disksize=disksize domainadminpassword=domainadminpassword domainadminuser=domainadminuser domaintype=domaintype getmac=getmac hcp=HMC height=height hidden=hidden hostcluster=hostcluster hostinterface=hostinterface hostmanager=hostmanager hostnames=hostnames hosttype=hosttype hwtype=hwtype id=5 installnic=installnic interface=interface ip=10.10.10.10 iscsipassword=iscsipassword iscsiserver=iscsiserver iscsitarget=iscsitarget iscsiuserid=iscsiuserid mac=42:d6:0a:03:05:08 memory=memory migrationdest=migrationdest monserver=monserver mpa=mpa mtm=mtm nameservers=nameservers netboot=grub2 nfsdir=nfsdir nfsserver=nfsserver  nimserver=nimserver node=node ondiscover=ondiscover osvolume=osvolume otherinterfaces=otherinterfaces ou=ou parent=parent password=password pdu=pdu postbootscripts=postbootscripts postscripts=postscripts power=power pprofile=pprofile prescripts-begin=prescripts-begin prescripts-end=prescripts-end primarynic=primarynic primarysn=primarysn productkey=productkey  provmethod=provmethod rack=rack room=room routenames=routenames serial=serial serialflow=serialflow serialport=serialport serialspeed=serialspeed servicenode=servicenode setupconserver=0 setupdhcp=0 setupftp=setupftp setupipforward=0 setupldap=0 setupnameserver=0 setupnfs=0 setupnim=setupnim setupntp=0 setupproxydhcp=0 setuptftp=0 sfp=sfp side=side slot=slot  storagcontroller=storagcontroller storagetype=storagetype supernode=supernode supportedarchs=supportedarchs supportproxydhcp=supportproxydhcp switch=switch switchinterface=switchinterface switchport=50 switchvlan=switchvlan syslog=syslog termport=termport termserver=termserver tftpdir=tftpdir tftpserver=tftpserver unit=unit  usercomment=usercomment username=username vmbeacon=vmbeacon vmbootorder=vmbootorder vmcfgstore=vmcfgstore vmcluster=vmcluster vmmanager=vmmanager vmmaster=vmmaster vmnicnicmodel=vmnicnicmodel vmphyslots=vmphyslots vmstorage=vmstorage vmstoragecache=vmstoragecache vmstorageformat=vmstorageformat vmstoragemodel=vmstoragemodel vmtextconsole=vmtextconsole vmvirtflags=vmvirtflags vmvncport=vmvncport xcatmaster=xcatmaster zonename=zonename  nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 check:rc==0
@@ -24,9 +24,9 @@ cmd:scp /tmp/export_import_single_ppc_by_json/bogusnode_json.inv $$DSTMN:/tmp/ex
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_ppc_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_import_single_ppc_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_ppc_by_json_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_ppc_by_json_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_ppc_by_json_$$DSTMN/dstbogusnode.stanza /tmp/export_import_single_ppc_by_json/dstbogusnode.stanza
 check:rc==0
@@ -34,17 +34,17 @@ cmd: cat /tmp/export_import_single_ppc_by_json/dstbogusnode.stanza
 check:rc==0
 cmd:diff -y /tmp/export_import_single_ppc_by_json/srcbogusnode.stanza /tmp/export_import_single_ppc_by_json/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
+cmd:ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_ppc_by_json/bogusnode.stanza ]]; then cat /tmp/export_import_single_ppc_by_json/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_ppc_by_json/bogusgroup.stanza ]]; then cat /tmp/export_import_single_ppc_by_json/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_ppc_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_ppc_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_ppc_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_ppc_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_ppc_by_json_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_ppc_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_ppc_by_json_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_ppc_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_ppc_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_import_single_ppc_by_json_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_ppc_by_json
 check:rc==0
@@ -57,15 +57,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_ppc_by_yaml
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_ppc_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_import_single_ppc_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_ppc_by_yaml/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_ppc_by_yaml/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup  mgt=hmc nodetype=ppc,osi  addkcmdline=addkcmdline arch=ppc64 authdomain=authdomain cfgmgr=cfgmgr cfgmgtroles=cfgmgtroles cfgserver=cfgserver chain=chain chassis=chassis cmdmapping=cmdmapping cons=cons conserver=conserver consoleondemand=consoleondemand cpucount=cpucount cputype=cputype  dhcpinterfaces=dhcpinterfaces disksize=disksize domainadminpassword=domainadminpassword domainadminuser=domainadminuser domaintype=domaintype getmac=getmac hcp=HMC height=height hidden=hidden hostcluster=hostcluster hostinterface=hostinterface hostmanager=hostmanager hostnames=hostnames hosttype=hosttype hwtype=hwtype id=5 installnic=installnic interface=interface ip=10.10.10.10 iscsipassword=iscsipassword iscsiserver=iscsiserver iscsitarget=iscsitarget iscsiuserid=iscsiuserid mac=42:d6:0a:03:05:08 memory=memory migrationdest=migrationdest monserver=monserver mpa=mpa mtm=mtm nameservers=nameservers netboot=grub2 nfsdir=nfsdir nfsserver=nfsserver  nimserver=nimserver node=node ondiscover=ondiscover osvolume=osvolume otherinterfaces=otherinterfaces ou=ou parent=parent password=password pdu=pdu postbootscripts=postbootscripts postscripts=postscripts power=power pprofile=pprofile prescripts-begin=prescripts-begin prescripts-end=prescripts-end primarynic=primarynic primarysn=primarysn productkey=productkey  provmethod=provmethod rack=rack room=room routenames=routenames serial=serial serialflow=serialflow serialport=serialport serialspeed=serialspeed servicenode=servicenode setupconserver=0 setupdhcp=0 setupftp=setupftp setupipforward=0 setupldap=0 setupnameserver=0 setupnfs=0 setupnim=setupnim setupntp=0 setupproxydhcp=0 setuptftp=0 sfp=sfp side=side slot=slot  storagcontroller=storagcontroller storagetype=storagetype supernode=supernode supportedarchs=supportedarchs supportproxydhcp=supportproxydhcp switch=switch switchinterface=switchinterface switchport=50 switchvlan=switchvlan syslog=syslog termport=termport termserver=termserver tftpdir=tftpdir tftpserver=tftpserver unit=unit  usercomment=usercomment username=username vmbeacon=vmbeacon vmbootorder=vmbootorder vmcfgstore=vmcfgstore vmcluster=vmcluster vmmanager=vmmanager vmmaster=vmmaster vmnicnicmodel=vmnicnicmodel vmphyslots=vmphyslots vmstorage=vmstorage vmstoragecache=vmstoragecache vmstorageformat=vmstorageformat vmstoragemodel=vmstoragemodel vmtextconsole=vmtextconsole vmvirtflags=vmvirtflags vmvncport=vmvncport xcatmaster=xcatmaster zonename=zonename  nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 check:rc==0
@@ -77,9 +77,9 @@ cmd:scp /tmp/export_import_single_ppc_by_yaml/bogusnode_yaml.inv $$DSTMN:/tmp/ex
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_ppc_by_yaml_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_ppc_by_yaml_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_ppc_by_yaml_$$DSTMN/dstbogusnode.stanza /tmp/export_import_single_ppc_by_yaml/dstbogusnode.stanza
 check:rc==0
@@ -87,17 +87,17 @@ cmd: cat /tmp/export_import_single_ppc_by_yaml/dstbogusnode.stanza
 check:rc==0
 cmd:diff -y /tmp/export_import_single_ppc_by_yaml/srcbogusnode.stanza /tmp/export_import_single_ppc_by_yaml/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
+cmd:ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_ppc_by_yaml/bogusnode.stanza ]]; then cat /tmp/export_import_single_ppc_by_yaml/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_ppc_by_yaml/bogusgroup.stanza ]]; then cat /tmp/export_import_single_ppc_by_yaml/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_ppc_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_ppc_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_import_single_ppc_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_ppc_by_yaml
 check:rc==0
@@ -110,15 +110,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_kvm_by_json
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_kvm_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_import_single_kvm_by_json_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_kvm_by_json/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_kvm_by_json/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_kvm_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_kvm_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_kvm_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_kvm_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup mgt=kvm  addkcmdline=addkcmdline arch=ppc64le authdomain=authdomain cfgmgr=cfgmgr cfgmgtroles=cfgmgtroles cfgserver=cfgserver chain=chain chassis=chassis cmdmapping=cmdmapping cons=cons conserver=conserver consoleondemand=consoleondemand cpucount=cpucount cputype=cputype dhcpinterfaces=dhcpinterfaces disksize=disksize domainadminpassword=domainadminpassword domainadminuser=domainadminuser domaintype=domaintype getmac=getmac  height=height hidden=hidden hostcluster=hostcluster hostinterface=hostinterface hostmanager=hostmanager hostnames=hostnames hosttype=hosttype id=5 installnic=installnic interface=interface ip=10.10.10.10 iscsipassword=iscsipassword iscsiserver=iscsiserver iscsitarget=iscsitarget iscsiuserid=iscsiuserid mac=42:d6:0a:03:05:08 memory=memory migrationdest=migrationdest monserver=monserver mpa=mpa mtm=mtm nameservers=nameservers netboot=grub2 nfsdir=nfsdir nfsserver=nfsserver  nimserver=nimserver node=node ondiscover=ondiscover osvolume=osvolume otherinterfaces=otherinterfaces ou=ou pdu=pdu postbootscripts=postbootscripts postscripts=postscripts power=power prescripts-begin=prescripts-begin prescripts-end=prescripts-end primarynic=primarynic primarysn=primarysn productkey=productkey provmethod=provmethod rack=rack room=room routenames=routenames serial=serial serialflow=serialflow serialport=serialport serialspeed=serialspeed servicenode=servicenode setupconserver=0 setupdhcp=0 setupftp=setupftp setupipforward=0 setupldap=0 setupnameserver=0 setupnfs=0 setupnim=setupnim setupntp=0 setupproxydhcp=0 setuptftp=0 sfp=sfp side=side slot=slot storagcontroller=storagcontroller storagetype=storagetype supernode=supernode supportedarchs=supportedarchs supportproxydhcp=supportproxydhcp switch=switch switchinterface=switchinterface switchport=50 switchvlan=switchvlan syslog=syslog termport=termport termserver=termserver tftpdir=tftpdir tftpserver=tftpserver unit=unit usercomment=usercomment vmbeacon=vmbeacon vmbootorder=vmbootorder vmcfgstore=vmcfgstore vmcluster=vmcluster vmcpus=vmcpus vmhost=vmhost vmmanager=vmmanager vmmaster=vmmaster vmmemory=vmmemory vmnicnicmodel=vmnicnicmodel vmnics=vmnics vmothersetting=vmothersetting vmphyslots=vmphyslots vmstorage=vmstorage vmstoragecache=vmstoragecache vmstorageformat=vmstorageformat vmstoragemodel=vmstoragemodel vmtextconsole=vmtextconsole vmvirtflags=vmvirtflags vmvncport=vmvncport xcatmaster=xcatmaster zonename=zonename   nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 check:rc==0
@@ -130,9 +130,9 @@ cmd:scp /tmp/export_import_single_kvm_by_json/bogusnode_json.inv $$DSTMN:/tmp/ex
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_kvm_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_import_single_kvm_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_kvm_by_json_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_kvm_by_json_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_kvm_by_json_$$DSTMN/dstbogusnode.stanza /tmp/export_import_single_kvm_by_json/dstbogusnode.stanza
 check:rc==0
@@ -140,17 +140,17 @@ cmd: cat /tmp/export_import_single_kvm_by_json/dstbogusnode.stanza
 check:rc==0
 cmd:diff -y /tmp/export_import_single_kvm_by_json/srcbogusnode.stanza /tmp/export_import_single_kvm_by_json/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
+cmd:ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_kvm_by_json/bogusnode.stanza ]]; then cat /tmp/export_import_single_kvm_by_json/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_kvm_by_json/bogusgroup.stanza ]]; then cat /tmp/export_import_single_kvm_by_json/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_kvm_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_kvm_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_kvm_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_kvm_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_kvm_by_json_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_kvm_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_kvm_by_json_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_kvm_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_kvm_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_import_single_kvm_by_json_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_kvm_by_json
 check:rc==0
@@ -164,15 +164,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_kvm_by_yaml
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_kvm_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_import_single_kvm_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_kvm_by_yaml/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_kvm_by_yaml/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup mgt=kvm  addkcmdline=addkcmdline arch=ppc64le authdomain=authdomain cfgmgr=cfgmgr cfgmgtroles=cfgmgtroles cfgserver=cfgserver chain=chain chassis=chassis cmdmapping=cmdmapping cons=cons conserver=conserver consoleondemand=consoleondemand cpucount=cpucount cputype=cputype dhcpinterfaces=dhcpinterfaces disksize=disksize domainadminpassword=domainadminpassword domainadminuser=domainadminuser domaintype=domaintype getmac=getmac  height=height hidden=hidden hostcluster=hostcluster hostinterface=hostinterface hostmanager=hostmanager hostnames=hostnames hosttype=hosttype id=5 installnic=installnic interface=interface ip=10.10.10.10 iscsipassword=iscsipassword iscsiserver=iscsiserver iscsitarget=iscsitarget iscsiuserid=iscsiuserid mac=42:d6:0a:03:05:08 memory=memory migrationdest=migrationdest monserver=monserver mpa=mpa mtm=mtm nameservers=nameservers netboot=grub2 nfsdir=nfsdir nfsserver=nfsserver  nimserver=nimserver node=node ondiscover=ondiscover osvolume=osvolume otherinterfaces=otherinterfaces ou=ou pdu=pdu postbootscripts=postbootscripts postscripts=postscripts power=power prescripts-begin=prescripts-begin prescripts-end=prescripts-end primarynic=primarynic primarysn=primarysn productkey=productkey provmethod=provmethod rack=rack room=room routenames=routenames serial=serial serialflow=serialflow serialport=serialport serialspeed=serialspeed servicenode=servicenode setupconserver=0 setupdhcp=0 setupftp=setupftp setupipforward=0 setupldap=0 setupnameserver=0 setupnfs=0 setupnim=setupnim setupntp=0 setupproxydhcp=0 setuptftp=0 sfp=sfp side=side slot=slot storagcontroller=storagcontroller storagetype=storagetype supernode=supernode supportedarchs=supportedarchs supportproxydhcp=supportproxydhcp switch=switch switchinterface=switchinterface switchport=50 switchvlan=switchvlan syslog=syslog termport=termport termserver=termserver tftpdir=tftpdir tftpserver=tftpserver unit=unit usercomment=usercomment vmbeacon=vmbeacon vmbootorder=vmbootorder vmcfgstore=vmcfgstore vmcluster=vmcluster vmcpus=vmcpus vmhost=vmhost vmmanager=vmmanager vmmaster=vmmaster vmmemory=vmmemory vmnicnicmodel=vmnicnicmodel vmnics=vmnics vmothersetting=vmothersetting vmphyslots=vmphyslots vmstorage=vmstorage vmstoragecache=vmstoragecache vmstorageformat=vmstorageformat vmstoragemodel=vmstoragemodel vmtextconsole=vmtextconsole vmvirtflags=vmvirtflags vmvncport=vmvncport xcatmaster=xcatmaster zonename=zonename   nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 check:rc==0
@@ -184,9 +184,9 @@ cmd:scp /tmp/export_import_single_kvm_by_yaml/bogusnode_yaml.inv $$DSTMN:/tmp/ex
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_kvm_by_yaml_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_kvm_by_yaml_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_kvm_by_yaml_$$DSTMN/dstbogusnode.stanza /tmp/export_import_single_kvm_by_yaml/dstbogusnode.stanza
 check:rc==0
@@ -194,17 +194,17 @@ cmd: cat /tmp/export_import_single_kvm_by_yaml/dstbogusnode.stanza
 check:rc==0
 cmd:diff -y /tmp/export_import_single_kvm_by_yaml/srcbogusnode.stanza /tmp/export_import_single_kvm_by_yaml/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
+cmd:ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_kvm_by_yaml/bogusnode.stanza ]]; then cat /tmp/export_import_single_kvm_by_yaml/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_kvm_by_yaml/bogusgroup.stanza ]]; then cat /tmp/export_import_single_kvm_by_yaml/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_kvm_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_kvm_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_import_single_kvm_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_kvm_by_yaml
 check:rc==0
@@ -218,15 +218,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_pdu_by_json
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_pdu_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_import_single_pdu_by_json_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_pdu_by_json/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_pdu_by_json/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_pdu_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_pdu_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_pdu_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_pdu_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup mgt=pdu nodetype=pdu  addkcmdline=addkcmdline arch=ppc64 authdomain=authdomain authkey=authkey authtype=MD5 cfgmgr=cfgmgr cfgmgtroles=cfgmgtroles cfgserver=cfgserver chain=chain chassis=chassis cmdmapping=cmdmapping community=community cons=cons conserver=conserver consoleondemand=consoleondemand cpucount=cpucount cputype=cputype dhcpinterfaces=dhcpinterfaces disksize=disksize domainadminpassword=domainadminpassword domainadminuser=domainadminuser domaintype=domaintype getmac=getmac  height=height hidden=hidden hostcluster=hostcluster hostinterface=hostinterface hostmanager=hostmanager hostnames=hostnames hosttype=hosttype  installnic=installnic interface=interface ip=10.10.10.10 iscsipassword=iscsipassword iscsiserver=iscsiserver iscsitarget=iscsitarget iscsiuserid=iscsiuserid mac=42:d6:0a:03:05:08 memory=memory migrationdest=migrationdest monserver=monserver mpa=mpa mtm=mtm nameservers=nameservers netboot=grub2 nfsdir=nfsdir nfsserver=nfsserver  nimserver=nimserver node=node ondiscover=ondiscover  osvolume=osvolume otherinterfaces=otherinterfaces ou=ou outlet=outlet password=password pdu=pdu pdutype=pdutype postbootscripts=postbootscripts postscripts=postscripts power=power prescripts-begin=prescripts-begin prescripts-end=prescripts-end primarynic=primarynic primarysn=primarysn privkey=privkey privtype=AES productkey=productkey provmethod=provmethod rack=rack room=room routenames=routenames seclevel=noAuthNoPriv serial=serial serialflow=serialflow serialport=serialport serialspeed=serialspeed servicenode=servicenode setupconserver=0 setupdhcp=0 setupftp=setupftp setupipforward=0 setupldap=0 setupnameserver=0 setupnfs=0 setupnim=setupnim setupntp=0 setupproxydhcp=0 setuptftp=0 sfp=sfp side=side slot=slot snmpuser=snmpuser snmpversion=SNMPv1 storagcontroller=storagcontroller storagetype=storagetype supernode=supernode supportedarchs=supportedarchs supportproxydhcp=supportproxydhcp switch=switch switchinterface=switchinterface switchport=50 switchvlan=switchvlan syslog=syslog termport=termport termserver=termserver tftpdir=tftpdir tftpserver=tftpserver unit=unit usercomment=usercomment username=username vmbeacon=vmbeacon vmbootorder=vmbootorder vmcfgstore=vmcfgstore vmcluster=vmcluster vmmanager=vmmanager vmmaster=vmmaster vmnicnicmodel=vmnicnicmodel vmphyslots=vmphyslots vmstorage=vmstorage vmstoragecache=vmstoragecache vmstorageformat=vmstorageformat vmstoragemodel=vmstoragemodel vmtextconsole=vmtextconsole vmvirtflags=vmvirtflags vmvncport=vmvncport xcatmaster=xcatmaster zonename=zonename nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 check:rc==0
@@ -238,9 +238,9 @@ cmd:scp /tmp/export_import_single_pdu_by_json/bogusnode_json.inv $$DSTMN:/tmp/ex
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_pdu_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_import_single_pdu_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_pdu_by_json_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_pdu_by_json_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_pdu_by_json_$$DSTMN/dstbogusnode.stanza /tmp/export_import_single_pdu_by_json/dstbogusnode.stanza
 check:rc==0
@@ -248,17 +248,17 @@ cmd: cat /tmp/export_import_single_pdu_by_json/dstbogusnode.stanza
 check:rc==0
 cmd:diff -y /tmp/export_import_single_pdu_by_json/srcbogusnode.stanza /tmp/export_import_single_pdu_by_json/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
+cmd:ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_pdu_by_json/bogusnode.stanza ]]; then cat /tmp/export_import_single_pdu_by_json/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_pdu_by_json/bogusgroup.stanza ]]; then cat /tmp/export_import_single_pdu_by_json/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_pdu_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_pdu_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_pdu_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_pdu_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_pdu_by_json_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_pdu_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_pdu_by_json_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_pdu_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_pdu_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_import_single_pdu_by_json_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_pdu_by_json
 check:rc==0
@@ -271,15 +271,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_pdu_by_yaml
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_pdu_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_import_single_pdu_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_pdu_by_yaml/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_pdu_by_yaml/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup mgt=pdu nodetype=pdu  addkcmdline=addkcmdline arch=ppc64 authdomain=authdomain authkey=authkey authtype=MD5 cfgmgr=cfgmgr cfgmgtroles=cfgmgtroles cfgserver=cfgserver chain=chain chassis=chassis cmdmapping=cmdmapping community=community cons=cons conserver=conserver consoleondemand=consoleondemand cpucount=cpucount cputype=cputype dhcpinterfaces=dhcpinterfaces disksize=disksize domainadminpassword=domainadminpassword domainadminuser=domainadminuser domaintype=domaintype getmac=getmac  height=height hidden=hidden hostcluster=hostcluster hostinterface=hostinterface hostmanager=hostmanager hostnames=hostnames hosttype=hosttype installnic=installnic interface=interface ip=10.10.10.10 iscsipassword=iscsipassword iscsiserver=iscsiserver iscsitarget=iscsitarget iscsiuserid=iscsiuserid mac=42:d6:0a:03:05:08 memory=memory migrationdest=migrationdest monserver=monserver mpa=mpa mtm=mtm nameservers=nameservers netboot=grub2 nfsdir=nfsdir nfsserver=nfsserver  nimserver=nimserver node=node ondiscover=ondiscover  osvolume=osvolume otherinterfaces=otherinterfaces ou=ou outlet=outlet password=password pdu=pdu pdutype=pdutype postbootscripts=postbootscripts postscripts=postscripts power=power prescripts-begin=prescripts-begin prescripts-end=prescripts-end primarynic=primarynic primarysn=primarysn privkey=privkey privtype=AES productkey=productkey provmethod=provmethod rack=rack room=room routenames=routenames seclevel=noAuthNoPriv serial=serial serialflow=serialflow serialport=serialport serialspeed=serialspeed servicenode=servicenode setupconserver=0 setupdhcp=0 setupftp=setupftp setupipforward=0 setupldap=0 setupnameserver=0 setupnfs=0 setupnim=setupnim setupntp=0 setupproxydhcp=0 setuptftp=0 sfp=sfp side=side slot=slot snmpuser=snmpuser snmpversion=SNMPv1 storagcontroller=storagcontroller storagetype=storagetype supernode=supernode supportedarchs=supportedarchs supportproxydhcp=supportproxydhcp switch=switch switchinterface=switchinterface switchport=50 switchvlan=switchvlan syslog=syslog termport=termport termserver=termserver tftpdir=tftpdir tftpserver=tftpserver unit=unit usercomment=usercomment username=username vmbeacon=vmbeacon vmbootorder=vmbootorder vmcfgstore=vmcfgstore vmcluster=vmcluster vmmanager=vmmanager vmmaster=vmmaster vmnicnicmodel=vmnicnicmodel vmphyslots=vmphyslots vmstorage=vmstorage vmstoragecache=vmstoragecache vmstorageformat=vmstorageformat vmstoragemodel=vmstoragemodel vmtextconsole=vmtextconsole vmvirtflags=vmvirtflags vmvncport=vmvncport xcatmaster=xcatmaster zonename=zonename nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 check:rc==0
@@ -291,9 +291,9 @@ cmd:scp /tmp/export_import_single_pdu_by_yaml/bogusnode_yaml.inv $$DSTMN:/tmp/ex
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_pdu_by_yaml_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_pdu_by_yaml_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_pdu_by_yaml_$$DSTMN/dstbogusnode.stanza /tmp/export_import_single_pdu_by_yaml/dstbogusnode.stanza
 check:rc==0
@@ -301,17 +301,17 @@ cmd: cat /tmp/export_import_single_pdu_by_yaml/dstbogusnode.stanza
 check:rc==0
 cmd:diff -y /tmp/export_import_single_pdu_by_yaml/srcbogusnode.stanza /tmp/export_import_single_pdu_by_yaml/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
+cmd:ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_pdu_by_yaml/bogusnode.stanza ]]; then cat /tmp/export_import_single_pdu_by_yaml/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_pdu_by_yaml/bogusgroup.stanza ]]; then cat /tmp/export_import_single_pdu_by_yaml/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_pdu_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_pdu_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_import_single_pdu_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_pdu_by_yaml
 check:rc==0
@@ -324,15 +324,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_boston_by_yaml
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_boston_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_import_single_boston_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_boston_by_yaml/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_boston_by_yaml/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup mgt=ipmi  addkcmdline=addkcmdline  arch=ppc64le authdomain=authdomain bmc=bmc bmcpassword=bmcpassword bmcport=bmcport bmcusername=bmcusername bmcvlantag=bmcvlantag cfgmgr=cfgmgr cfgmgtroles=cfgmgtroles cfgserver=cfgserver chain=chain chassis=chassis cmdmapping=cmdmapping cons=cons conserver=conserver consoleondemand=consoleondemand cpucount=cpucount cputype=cputype dhcpinterfaces=dhcpinterfaces disksize=disksize domainadminpassword=domainadminpassword domainadminuser=domainadminuser domaintype=domaintype getmac=getmac  height=height hidden=hidden hostcluster=hostcluster hostinterface=hostinterface hostmanager=hostmanager hostnames=hostnames hosttype=hosttype hwtype=hwtype  installnic=installnic interface=interface ip=10.10.10.10 iscsipassword=iscsipassword iscsiserver=iscsiserver iscsitarget=iscsitarget iscsiuserid=iscsiuserid mac=42:d6:0a:03:05:08 memory=memory migrationdest=migrationdest monserver=monserver mpa=mpa mtm=mtm nameservers=nameservers netboot=grub2 nfsdir=nfsdir nfsserver=nfsserver nimserver=nimserver node=node ondiscover=ondiscover osvolume=osvolume otherinterfaces=otherinterfaces ou=ou pdu=pdu postbootscripts=postbootscripts postscripts=postscripts power=power prescripts-begin=prescripts-begin prescripts-end=prescripts-end primarynic=primarynic primarysn=primarysn productkey=productkey  provmethod=provmethod rack=rack room=room routenames=routenames serial=serial serialflow=serialflow serialport=serialport serialspeed=serialspeed servicenode=servicenode setupconserver=0 setupdhcp=0 setupftp=setupftp setupipforward=0 setupldap=0 setupnameserver=0 setupnfs=0 setupnim=setupnim setupntp=0 setupproxydhcp=0 setuptftp=0 sfp=sfp side=side slot=slot slotid=slotid  storagcontroller=storagcontroller storagetype=storagetype supernode=supernode supportedarchs=supportedarchs supportproxydhcp=supportproxydhcp switch=switch switchinterface=switchinterface switchport=50 switchvlan=switchvlan syslog=syslog termport=termport termserver=termserver tftpdir=tftpdir tftpserver=tftpserver unit=unit usercomment=usercomment vmbeacon=vmbeacon vmbootorder=vmbootorder vmcfgstore=vmcfgstore vmcluster=vmcluster vmmanager=vmmanager vmmaster=vmmaster vmnicnicmodel=vmnicnicmodel vmphyslots=vmphyslots vmstorage=vmstorage vmstoragecache=vmstoragecache vmstorageformat=vmstorageformat vmstoragemodel=vmstoragemodel vmtextconsole=vmtextconsole vmvirtflags=vmvirtflags vmvncport=vmvncport xcatmaster=xcatmaster zonename=zonename  nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 check:rc==0
@@ -344,9 +344,9 @@ cmd:scp /tmp/export_import_single_boston_by_yaml/bogusnode_yaml.inv $$DSTMN:/tmp
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_boston_by_yaml_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_boston_by_yaml_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_boston_by_yaml_$$DSTMN/dstbogusnode.stanza /tmp/export_import_single_boston_by_yaml/dstbogusnode.stanza
 check:rc==0
@@ -354,17 +354,17 @@ cmd: cat /tmp/export_import_single_boston_by_yaml/dstbogusnode.stanza
 check:rc==0
 cmd:diff -y /tmp/export_import_single_boston_by_yaml/srcbogusnode.stanza /tmp/export_import_single_boston_by_yaml/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
+cmd:ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_boston_by_yaml/bogusnode.stanza ]]; then cat /tmp/export_import_single_boston_by_yaml/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_boston_by_yaml/bogusgroup.stanza ]]; then cat /tmp/export_import_single_boston_by_yaml/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_boston_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_boston_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_import_single_boston_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_boston_by_yaml
 check:rc==0
@@ -376,15 +376,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_boston_by_json
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_boston_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_import_single_boston_by_json_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_boston_by_json/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_boston_by_json/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_boston_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_boston_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_boston_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_boston_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup mgt=ipmi  addkcmdline=addkcmdline  arch=ppc64le authdomain=authdomain bmc=bmc bmcpassword=bmcpassword bmcport=bmcport bmcusername=bmcusername bmcvlantag=bmcvlantag cfgmgr=cfgmgr cfgmgtroles=cfgmgtroles cfgserver=cfgserver chain=chain chassis=chassis cmdmapping=cmdmapping cons=cons conserver=conserver consoleondemand=consoleondemand cpucount=cpucount cputype=cputype dhcpinterfaces=dhcpinterfaces disksize=disksize domainadminpassword=domainadminpassword domainadminuser=domainadminuser domaintype=domaintype getmac=getmac  height=height hidden=hidden hostcluster=hostcluster hostinterface=hostinterface hostmanager=hostmanager hostnames=hostnames hosttype=hosttype hwtype=hwtype installnic=installnic interface=interface ip=10.10.10.10 iscsipassword=iscsipassword iscsiserver=iscsiserver iscsitarget=iscsitarget iscsiuserid=iscsiuserid mac=42:d6:0a:03:05:08 memory=memory migrationdest=migrationdest monserver=monserver mpa=mpa mtm=mtm nameservers=nameservers netboot=grub2 nfsdir=nfsdir nfsserver=nfsserver nimserver=nimserver node=node ondiscover=ondiscover osvolume=osvolume otherinterfaces=otherinterfaces ou=ou pdu=pdu postbootscripts=postbootscripts postscripts=postscripts power=power prescripts-begin=prescripts-begin prescripts-end=prescripts-end primarynic=primarynic primarysn=primarysn productkey=productkey  provmethod=provmethod rack=rack room=room routenames=routenames serial=serial serialflow=serialflow serialport=serialport serialspeed=serialspeed servicenode=servicenode setupconserver=0 setupdhcp=0 setupftp=setupftp setupipforward=0 setupldap=0 setupnameserver=0 setupnfs=0 setupnim=setupnim setupntp=0 setupproxydhcp=0 setuptftp=0 sfp=sfp side=side slot=slot slotid=slotid  storagcontroller=storagcontroller storagetype=storagetype supernode=supernode supportedarchs=supportedarchs supportproxydhcp=supportproxydhcp switch=switch switchinterface=switchinterface switchport=50 switchvlan=switchvlan syslog=syslog termport=termport termserver=termserver tftpdir=tftpdir tftpserver=tftpserver unit=unit usercomment=usercomment vmbeacon=vmbeacon vmbootorder=vmbootorder vmcfgstore=vmcfgstore vmcluster=vmcluster vmmanager=vmmanager vmmaster=vmmaster vmnicnicmodel=vmnicnicmodel vmphyslots=vmphyslots vmstorage=vmstorage vmstoragecache=vmstoragecache vmstorageformat=vmstorageformat vmstoragemodel=vmstoragemodel vmtextconsole=vmtextconsole vmvirtflags=vmvirtflags vmvncport=vmvncport xcatmaster=xcatmaster zonename=zonename  nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 check:rc==0
@@ -396,9 +396,9 @@ cmd:scp /tmp/export_import_single_boston_by_json/bogusnode_json.inv $$DSTMN:/tmp
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_boston_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_import_single_boston_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_boston_by_json_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_boston_by_json_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_boston_by_json_$$DSTMN/dstbogusnode.stanza /tmp/export_import_single_boston_by_json/dstbogusnode.stanza
 check:rc==0
@@ -406,17 +406,17 @@ cmd: cat /tmp/export_import_single_boston_by_json/dstbogusnode.stanza
 check:rc==0
 cmd:diff -y /tmp/export_import_single_boston_by_json/srcbogusnode.stanza /tmp/export_import_single_boston_by_json/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
+cmd:ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_boston_by_json/bogusnode.stanza ]]; then cat /tmp/export_import_single_boston_by_json/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_boston_by_json/bogusgroup.stanza ]]; then cat /tmp/export_import_single_boston_by_json/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_boston_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_boston_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_boston_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_boston_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_boston_by_json_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_boston_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_boston_by_json_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_boston_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_boston_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_import_single_boston_by_json_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_boston_by_json
 check:rc==0
@@ -428,15 +428,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_witherspoon_by_yaml
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_witherspoon_by_yaml/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_witherspoon_by_yaml/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup mgt=openbmc nodetype=mp  addkcmdline=addkcmdline  arch=ppc64le authdomain=authdomain bmc=bmc bmcpassword=bmcpassword bmcusername=bmcusername bmcvlantag=bmcvlantag cfgmgr=cfgmgr cfgmgtroles=cfgmgtroles cfgserver=cfgserver chain=chain chassis=chassis cmdmapping=cmdmapping cons=cons conserver=conserver consoleondemand=consoleondemand consport=consport cpucount=cpucount cputype=cputype dhcpinterfaces=dhcpinterfaces disksize=disksize domainadminpassword=domainadminpassword domainadminuser=domainadminuser domaintype=domaintype getmac=getmac  height=height hidden=hidden hostcluster=hostcluster hostinterface=hostinterface hostmanager=hostmanager hostnames=hostnames hosttype=hosttype hwtype=hwtype  installnic=installnic interface=interface ip=10.10.10.10 iscsipassword=iscsipassword iscsiserver=iscsiserver iscsitarget=iscsitarget iscsiuserid=iscsiuserid  mac=42:d6:0a:03:05:08 memory=memory migrationdest=migrationdest monserver=monserver mpa=mpa mtm=mtm nameservers=nameservers netboot=grub2 nfsdir=nfsdir nfsserver=nfsserver  nimserver=nimserver node=node ondiscover=ondiscover osvolume=osvolume otherinterfaces=otherinterfaces ou=ou pdu=pdu postbootscripts=postbootscripts postscripts=postscripts power=power prescripts-begin=prescripts-begin prescripts-end=prescripts-end primarynic=primarynic primarysn=primarysn productkey=productkey provmethod=provmethod rack=rack room=room routenames=routenames serial=serial serialflow=serialflow serialport=serialport serialspeed=serialspeed servicenode=servicenode setupconserver=0 setupdhcp=0 setupftp=setupftp setupipforward=0 setupldap=0 setupnameserver=0 setupnfs=0 setupnim=setupnim setupntp=0 setupproxydhcp=0 setuptftp=0 sfp=sfp side=side slot=slot storagcontroller=storagcontroller storagetype=storagetype supernode=supernode supportedarchs=supportedarchs supportproxydhcp=supportproxydhcp switch=switch switchinterface=switchinterface switchport=50 switchvlan=switchvlan syslog=syslog termport=termport termserver=termserver tftpdir=tftpdir tftpserver=tftpserver unit=unit usercomment=usercomment vmbeacon=vmbeacon vmbootorder=vmbootorder vmcfgstore=vmcfgstore vmcluster=vmcluster vmmanager=vmmanager vmmaster=vmmaster vmnicnicmodel=vmnicnicmodel vmphyslots=vmphyslots vmstorage=vmstorage vmstoragecache=vmstoragecache vmstorageformat=vmstorageformat vmstoragemodel=vmstoragemodel vmtextconsole=vmtextconsole vmvirtflags=vmvirtflags vmvncport=vmvncport xcatmaster=xcatmaster zonename=zonename  nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 check:rc==0
@@ -448,9 +448,9 @@ cmd:scp /tmp/export_import_single_witherspoon_by_yaml/bogusnode_yaml.inv $$DSTMN
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/dstbogusnode.stanza /tmp/export_import_single_witherspoon_by_yaml/dstbogusnode.stanza
 check:rc==0
@@ -458,17 +458,17 @@ cmd: cat /tmp/export_import_single_witherspoon_by_yaml/dstbogusnode.stanza
 check:rc==0
 cmd:diff -y /tmp/export_import_single_witherspoon_by_yaml/srcbogusnode.stanza /tmp/export_import_single_witherspoon_by_yaml/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
+cmd:ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_witherspoon_by_yaml/bogusnode.stanza ]]; then cat /tmp/export_import_single_witherspoon_by_yaml/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_witherspoon_by_yaml/bogusgroup.stanza ]]; then cat /tmp/export_import_single_witherspoon_by_yaml/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_import_single_witherspoon_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_witherspoon_by_yaml
 check:rc==0
@@ -480,15 +480,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_witherspoon_by_json
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_witherspoon_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_import_single_witherspoon_by_json_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_witherspoon_by_json/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_witherspoon_by_json/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup mgt=openbmc nodetype=mp  addkcmdline=addkcmdline  arch=ppc64le authdomain=authdomain bmc=bmc bmcpassword=bmcpassword bmcusername=bmcusername bmcvlantag=bmcvlantag cfgmgr=cfgmgr cfgmgtroles=cfgmgtroles cfgserver=cfgserver chain=chain chassis=chassis cmdmapping=cmdmapping cons=cons conserver=conserver consoleondemand=consoleondemand consport=consport cpucount=cpucount cputype=cputype dhcpinterfaces=dhcpinterfaces disksize=disksize domainadminpassword=domainadminpassword domainadminuser=domainadminuser domaintype=domaintype getmac=getmac  height=height hidden=hidden hostcluster=hostcluster hostinterface=hostinterface hostmanager=hostmanager hostnames=hostnames hosttype=hosttype hwtype=hwtype installnic=installnic interface=interface ip=10.10.10.10 iscsipassword=iscsipassword iscsiserver=iscsiserver iscsitarget=iscsitarget iscsiuserid=iscsiuserid  mac=42:d6:0a:03:05:08 memory=memory migrationdest=migrationdest monserver=monserver mpa=mpa mtm=mtm nameservers=nameservers netboot=grub2 nfsdir=nfsdir nfsserver=nfsserver  nimserver=nimserver node=node ondiscover=ondiscover osvolume=osvolume otherinterfaces=otherinterfaces ou=ou pdu=pdu postbootscripts=postbootscripts postscripts=postscripts power=power prescripts-begin=prescripts-begin prescripts-end=prescripts-end primarynic=primarynic primarysn=primarysn productkey=productkey provmethod=provmethod rack=rack room=room routenames=routenames serial=serial serialflow=serialflow serialport=serialport serialspeed=serialspeed servicenode=servicenode setupconserver=0 setupdhcp=0 setupftp=setupftp setupipforward=0 setupldap=0 setupnameserver=0 setupnfs=0 setupnim=setupnim setupntp=0 setupproxydhcp=0 setuptftp=0 sfp=sfp side=side slot=slot storagcontroller=storagcontroller storagetype=storagetype supernode=supernode supportedarchs=supportedarchs supportproxydhcp=supportproxydhcp switch=switch switchinterface=switchinterface switchport=50 switchvlan=switchvlan syslog=syslog termport=termport termserver=termserver tftpdir=tftpdir tftpserver=tftpserver unit=unit usercomment=usercomment vmbeacon=vmbeacon vmbootorder=vmbootorder vmcfgstore=vmcfgstore vmcluster=vmcluster vmmanager=vmmanager vmmaster=vmmaster vmnicnicmodel=vmnicnicmodel vmphyslots=vmphyslots vmstorage=vmstorage vmstoragecache=vmstoragecache vmstorageformat=vmstorageformat vmstoragemodel=vmstoragemodel vmtextconsole=vmtextconsole vmvirtflags=vmvirtflags vmvncport=vmvncport xcatmaster=xcatmaster zonename=zonename  nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 check:rc==0
@@ -500,9 +500,9 @@ cmd:scp /tmp/export_import_single_witherspoon_by_json/bogusnode_json.inv $$DSTMN
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_witherspoon_by_json_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_witherspoon_by_json_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_witherspoon_by_json_$$DSTMN/dstbogusnode.stanza /tmp/export_import_single_witherspoon_by_json/dstbogusnode.stanza
 check:rc==0
@@ -510,17 +510,17 @@ cmd: cat /tmp/export_import_single_witherspoon_by_json/dstbogusnode.stanza
 check:rc==0
 cmd:diff -y /tmp/export_import_single_witherspoon_by_json/srcbogusnode.stanza /tmp/export_import_single_witherspoon_by_json/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
+cmd:ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_witherspoon_by_json/bogusnode.stanza ]]; then cat /tmp/export_import_single_witherspoon_by_json/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_witherspoon_by_json/bogusgroup.stanza ]]; then cat /tmp/export_import_single_witherspoon_by_json/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_witherspoon_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_witherspoon_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_import_single_witherspoon_by_json_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_witherspoon_by_json
 check:rc==0
@@ -533,15 +533,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_switch_by_json
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_switch_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_import_single_switch_by_json_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_switch_by_json/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_switch_by_json/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_switch_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_switch_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_switch_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_switch_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup mgt=switch nodetype=switch addkcmdline=addkcmdline arch=ppc64 authdomain=authdomain cfgmgr=cfgmgr cfgmgtroles=cfgmgtroles cfgserver=cfgserver chain=chain chassis=chassis cmdmapping=cmdmapping cons=cons conserver=conserver consoleondemand=consoleondemand cpucount=cpucount cputype=cputype dhcpinterfaces=dhcpinterfaces disksize=disksize domainadminpassword=domainadminpassword domainadminuser=domainadminuser domaintype=domaintype getmac=getmac height=height hidden=hidden hostcluster=hostcluster hostinterface=hostinterface hostmanager=hostmanager hostnames=hostnames hosttype=hosttype installnic=installnic interface=interface ip=10.10.10.10 iscsipassword=iscsipassword iscsiserver=iscsiserver iscsitarget=iscsitarget iscsiuserid=iscsiuserid linkports=linkports mac=42:d6:0a:03:05:08 memory=memory migrationdest=migrationdest monserver=monserver mpa=mpa mtm=mtm nameservers=nameservers netboot=grub2 nfsdir=nfsdir nfsserver=nfsserver nimserver=nimserver node=node ondiscover=ondiscover osvolume=osvolume otherinterfaces=otherinterfaces ou=ou password=password pdu=pdu postbootscripts=postbootscripts postscripts=postscripts power=power prescripts-begin=prescripts-begin prescripts-end=prescripts-end primarynic=primarynic primarysn=primarysn productkey=productkey protocol=ssh provmethod=provmethod rack=rack room=room routenames=routenames serial=serial serialflow=serialflow serialport=serialport serialspeed=serialspeed servicenode=servicenode setupconserver=0 setupdhcp=0 setupftp=setupftp setupipforward=0 setupldap=0 setupnameserver=0 setupnfs=0 setupnim=setupnim setupntp=0 setupproxydhcp=0 setuptftp=0 sfp=sfp side=side slot=slot snmpauth=SHA snmppassword=snmppassword snmpprivacy=DES snmpusername=snmpusername snmpversion=SNMPv1 storagcontroller=storagcontroller storagetype=storagetype supernode=supernode supportedarchs=supportedarchs supportproxydhcp=supportproxydhcp switch=switch switchinterface=switchinterface switchport=50 switchtype=switchtype switchvlan=switchvlan syslog=syslog termport=termport termserver=termserver tftpdir=tftpdir tftpserver=tftpserver unit=unit usercomment=usercomment username=username vmbeacon=vmbeacon vmbootorder=vmbootorder vmcfgstore=vmcfgstore vmcluster=vmcluster vmmanager=vmmanager vmmaster=vmmaster vmnicnicmodel=vmnicnicmodel vmphyslots=vmphyslots vmstorage=vmstorage vmstoragecache=vmstoragecache vmstorageformat=vmstorageformat vmstoragemodel=vmstoragemodel vmtextconsole=vmtextconsole vmvirtflags=vmvirtflags vmvncport=vmvncport xcatmaster=xcatmaster zonename=zonename  nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 check:rc==0
@@ -553,9 +553,9 @@ cmd:scp /tmp/export_import_single_switch_by_json/bogusnode_json.inv $$DSTMN:/tmp
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_switch_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_import_single_switch_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_switch_by_json_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_switch_by_json_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_switch_by_json_$$DSTMN/dstbogusnode.stanza /tmp/export_import_single_switch_by_json/dstbogusnode.stanza
 check:rc==0
@@ -563,17 +563,17 @@ cmd: cat /tmp/export_import_single_switch_by_json/dstbogusnode.stanza
 check:rc==0
 cmd:diff -y /tmp/export_import_single_switch_by_json/srcbogusnode.stanza /tmp/export_import_single_switch_by_json/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
+cmd:ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_switch_by_json/bogusnode.stanza ]]; then cat /tmp/export_import_single_switch_by_json/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_switch_by_json/bogusgroup.stanza ]]; then cat /tmp/export_import_single_switch_by_json/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_switch_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_switch_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_switch_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_switch_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_switch_by_json_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_switch_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_switch_by_json_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_switch_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_switch_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_import_single_switch_by_json_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_switch_by_json
 check:rc==0
@@ -585,15 +585,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_switch_by_yaml
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_switch_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_import_single_switch_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_switch_by_yaml/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_switch_by_yaml/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup mgt=switch nodetype=switch addkcmdline=addkcmdline arch=ppc64 authdomain=authdomain cfgmgr=cfgmgr cfgmgtroles=cfgmgtroles cfgserver=cfgserver chain=chain chassis=chassis cmdmapping=cmdmapping cons=cons conserver=conserver consoleondemand=consoleondemand cpucount=cpucount cputype=cputype dhcpinterfaces=dhcpinterfaces disksize=disksize domainadminpassword=domainadminpassword domainadminuser=domainadminuser domaintype=domaintype getmac=getmac  height=height hidden=hidden hostcluster=hostcluster hostinterface=hostinterface hostmanager=hostmanager hostnames=hostnames hosttype=hosttype  installnic=installnic interface=interface ip=10.10.10.10 iscsipassword=iscsipassword iscsiserver=iscsiserver iscsitarget=iscsitarget iscsiuserid=iscsiuserid linkports=linkports mac=42:d6:0a:03:05:08 memory=memory migrationdest=migrationdest monserver=monserver mpa=mpa mtm=mtm nameservers=nameservers netboot=grub2 nfsdir=nfsdir nfsserver=nfsserver nimserver=nimserver node=node ondiscover=ondiscover osvolume=osvolume otherinterfaces=otherinterfaces ou=ou password=password pdu=pdu postbootscripts=postbootscripts postscripts=postscripts power=power prescripts-begin=prescripts-begin prescripts-end=prescripts-end primarynic=primarynic primarysn=primarysn productkey=productkey protocol=ssh provmethod=provmethod rack=rack room=room routenames=routenames serial=serial serialflow=serialflow serialport=serialport serialspeed=serialspeed servicenode=servicenode setupconserver=0 setupdhcp=0 setupftp=setupftp setupipforward=0 setupldap=0 setupnameserver=0 setupnfs=0 setupnim=setupnim setupntp=0 setupproxydhcp=0 setuptftp=0 sfp=sfp side=side slot=slot snmpauth=SHA snmppassword=snmppassword snmpprivacy=DES snmpusername=snmpusername snmpversion=SNMPv1 storagcontroller=storagcontroller storagetype=storagetype supernode=supernode supportedarchs=supportedarchs supportproxydhcp=supportproxydhcp switch=switch switchinterface=switchinterface switchport=50 switchtype=switchtype switchvlan=switchvlan syslog=syslog termport=termport termserver=termserver tftpdir=tftpdir tftpserver=tftpserver unit=unit usercomment=usercomment username=username vmbeacon=vmbeacon vmbootorder=vmbootorder vmcfgstore=vmcfgstore vmcluster=vmcluster vmmanager=vmmanager vmmaster=vmmaster vmnicnicmodel=vmnicnicmodel vmphyslots=vmphyslots vmstorage=vmstorage vmstoragecache=vmstoragecache vmstorageformat=vmstorageformat vmstoragemodel=vmstoragemodel vmtextconsole=vmtextconsole vmvirtflags=vmvirtflags vmvncport=vmvncport xcatmaster=xcatmaster zonename=zonename  nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 check:rc==0
@@ -605,9 +605,9 @@ cmd:scp /tmp/export_import_single_switch_by_yaml/bogusnode_yaml.inv $$DSTMN:/tmp
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_switch_by_yaml_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_import_single_switch_by_yaml_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_switch_by_yaml_$$DSTMN/dstbogusnode.stanza /tmp/export_import_single_switch_by_yaml/dstbogusnode.stanza
 check:rc==0
@@ -615,17 +615,17 @@ cmd: cat /tmp/export_import_single_switch_by_yaml/dstbogusnode.stanza
 check:rc==0
 cmd:diff -y /tmp/export_import_single_switch_by_yaml/srcbogusnode.stanza /tmp/export_import_single_switch_by_yaml/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
+cmd:ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_switch_by_yaml/bogusnode.stanza ]]; then cat /tmp/export_import_single_switch_by_yaml/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_switch_by_yaml/bogusgroup.stanza ]]; then cat /tmp/export_import_single_switch_by_yaml/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_import_single_switch_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_switch_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_import_single_switch_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_switch_by_yaml
 check:rc==0
@@ -638,15 +638,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_nodes_delimited_with_comma_by_yaml
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:for i in 1 2 3; do lsdef bogusnode$i > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode$i -z >> /tmp/export_import_nodes_delimited_with_comma_by_yaml/bogusnode.stanza ;rmdef bogusnode$i;fi; done
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_nodes_delimited_with_comma_by_yaml/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'for i in 1 2 3; do lsdef bogusnode$i > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode$i -z >> /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode$i;fi; done'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;for i in 1 2 3; do lsdef bogusnode$i > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode$i -z >> /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode$i;fi; done'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef  bogusnode[1-3] groups=bogusgroup mgt=openbmc cons=openbmc netboot=petitboot
 check:rc==0
@@ -658,9 +658,9 @@ cmd:scp /tmp/export_import_nodes_delimited_with_comma_by_yaml/bogusnode_yaml.inv
 check:rc==0
 cmd:rmdef bogusnode[1-3]
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode1,bogusnode2,bogusnode3'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode1,bogusnode2,bogusnode3'
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode[1-3] -z|sort -t'=' -k1 |tee /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode[1-3] -z|sort -t'=' -k1 |tee /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/dstbogusnode.stanza /tmp/export_import_nodes_delimited_with_comma_by_yaml/dstbogusnode.stanza
 check:rc==0
@@ -668,17 +668,17 @@ cmd: cat /tmp/export_import_nodes_delimited_with_comma_by_yaml/dstbogusnode.stan
 check:rc==0
 cmd:diff -y /tmp/export_import_nodes_delimited_with_comma_by_yaml/srcbogusnode.stanza /tmp/export_import_nodes_delimited_with_comma_by_yaml/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode[1-3]'
+cmd:ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;rmdef bogusnode[1-3]'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_nodes_delimited_with_comma_by_yaml/bogusnode.stanza ]]; then cat /tmp/export_import_nodes_delimited_with_comma_by_yaml/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_nodes_delimited_with_comma_by_yaml/bogusgroup.stanza ]];then cat /tmp/export_import_nodes_delimited_with_comma_by_yaml/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusgroup.stanza ]];then cat /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusgroup.stanza ]];then cat /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_import_nodes_delimited_with_comma_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_nodes_delimited_with_comma_by_yaml
 check:rc==0
@@ -690,15 +690,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_nodes_delimited_with_comma_by_json
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/'
 check:rc==0
 cmd:for i in 1 2 3; do lsdef bogusnode$i > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode$i -z >> /tmp/export_import_nodes_delimited_with_comma_by_json/bogusnode.stanza ;rmdef bogusnode$i;fi; done
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_nodes_delimited_with_comma_by_json/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'for i in 1 2 3; do lsdef bogusnode$i > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode$i -z >> /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode$i;fi; done'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;for i in 1 2 3; do lsdef bogusnode$i > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode$i -z >> /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode$i;fi; done'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef  bogusnode[1-3] groups=bogusgroup mgt=openbmc cons=openbmc netboot=petitboot
 check:rc==0
@@ -710,9 +710,9 @@ cmd:scp /tmp/export_import_nodes_delimited_with_comma_by_json/bogusnode_json.inv
 check:rc==0
 cmd:rmdef bogusnode[1-3]
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode1,bogusnode2,bogusnode3'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusnode_json.inv -t node -o bogusnode1,bogusnode2,bogusnode3'
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode[1-3] -z|sort -t'=' -k1 |tee /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode[1-3] -z|sort -t'=' -k1 |tee /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/dstbogusnode.stanza /tmp/export_import_nodes_delimited_with_comma_by_json/dstbogusnode.stanza
 check:rc==0
@@ -720,17 +720,17 @@ cmd: cat /tmp/export_import_nodes_delimited_with_comma_by_json/dstbogusnode.stan
 check:rc==0
 cmd:diff -y /tmp/export_import_nodes_delimited_with_comma_by_json/srcbogusnode.stanza /tmp/export_import_nodes_delimited_with_comma_by_json/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode[1-3]'
+cmd:ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;rmdef bogusnode[1-3]'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_nodes_delimited_with_comma_by_json/bogusnode.stanza ]]; then cat /tmp/export_import_nodes_delimited_with_comma_by_json/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_import_nodes_delimited_with_comma_by_json/bogusgroup.stanza ]];then cat /tmp/export_import_nodes_delimited_with_comma_by_json/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusgroup.stanza ]];then cat /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusgroup.stanza ]];then cat /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_import_nodes_delimited_with_comma_by_json_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_nodes_delimited_with_comma_by_json
 check:rc==0
@@ -1730,15 +1730,15 @@ description:This case is used to test xcat-inventory import a node , then modify
 Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 cmd:mkdir -p /tmp/export_single_node_then_modify_yaml_then_import
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_single_node_then_modify_yaml_then_import/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_single_node_then_modify_yaml_then_import/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup mgt=openbmc nodetype=mp addkcmdline=1111 arch=ppc64 authdomain=1111 bmc=1111 bmcpassword=1111 bmcusername=1111 bmcvlantag=1111 cfgmgr=1111 cfgmgtroles=1111 cfgserver=1111 chain=1111 chassis=1111 cmdmapping=1111 cons=1111 conserver=1111 consoleondemand=1111 consport=1111 cpucount=1111 cputype=1111 dhcpinterfaces=1111 disksize=1111 domainadminpassword=1111 domainadminuser=1111 domaintype=1111 getmac=1111 height=1111 hidden=1111 hostcluster=1111 hostinterface=1111 hostmanager=1111 hostnames=1111 hosttype=1111 hwtype=1111  installnic=1111 interface=1111 ip=10.10.10.10 iscsipassword=1111 iscsiserver=1111 iscsitarget=1111 iscsiuserid=1111 mac=42:d6:0a:03:05:08 memory=1111 migrationdest=1111 monserver=1111 mpa=1111 mtm=1111 nameservers=1111 netboot=grub2 nfsdir=1111 nfsserver=1111 nimserver=1111 node=1111 ondiscover=1111 osvolume=1111 otherinterfaces=1111 ou=1111 pdu=1111 postbootscripts=1111 postscripts=1111 power=1111 prescripts-begin=1111 prescripts-end=1111 primarynic=1111 primarysn=1111 productkey=1111 provmethod=1111 rack=1111 room=1111 routenames=1111 serial=1111 serialflow=1111 serialport=1111 serialspeed=1111 servicenode=1111 setupconserver=1 setupdhcp=1 setupftp=1111 setupipforward=1 setupldap=1 setupnameserver=1 setupnfs=1 setupnim=1111 setupntp=1 setupproxydhcp=1 setuptftp=1 sfp=1111 side=1111 slot=1111 storagcontroller=1111 storagetype=1111 supernode=1111 supportedarchs=1111 supportproxydhcp=1111 switch=1111 switchinterface=1111 switchport=1111 switchvlan=1111 syslog=1111 termport=1111 termserver=1111 tftpdir=1111 tftpserver=1111 unit=1111 usercomment=1111 vmbeacon=1111 vmbootorder=1111 vmcfgstore=1111 vmcluster=1111 vmmanager=1111 vmmaster=1111 vmnicnicmodel=1111 vmphyslots=1111 vmstorage=1111 vmstoragecache=1111 vmstorageformat=1111 vmstoragemodel=1111 vmtextconsole=1111 vmvirtflags=1111 vmvncport=1111 xcatmaster=1111 zonename=1111 nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 cmd:lsdef bogusnode -z|sed 's/1111/2222/g'|sed 's/unused/used/g'|sed 's/10.10.100.9/20.10.200.9/g'|sort -t'=' -k1 |tee  /tmp/export_single_node_then_modify_yaml_then_import/srcbogusnode.stanza
@@ -1777,9 +1777,9 @@ cmd:scp /tmp/export_single_node_then_modify_yaml_then_import/bogusnode_yaml.inv 
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusnode_yaml.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/dstbogusnode.stanza /tmp/export_single_node_then_modify_yaml_then_import/dstbogusnode.stanza
 check:rc==0
@@ -1787,17 +1787,17 @@ cmd: cat /tmp/export_single_node_then_modify_yaml_then_import/dstbogusnode.stanz
 check:rc==0
 cmd:diff -y /tmp/export_single_node_then_modify_yaml_then_import/srcbogusnode.stanza /tmp/export_single_node_then_modify_yaml_then_import/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
+cmd:ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_single_node_then_modify_yaml_then_import/bogusnode.stanza ]]; then cat /tmp/export_single_node_then_modify_yaml_then_import/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_single_node_then_modify_yaml_then_import/bogusgroup.stanza ]]; then cat /tmp/export_single_node_then_modify_yaml_then_import/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_single_node_then_modify_yaml_then_import_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_single_node_then_modify_yaml_then_import
 check:rc==0
@@ -1809,15 +1809,15 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_single_node_then_modify_json_then_import
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/'
 check:rc==0
 cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_single_node_then_modify_json_then_import/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_single_node_then_modify_json_then_import/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusnode.stanza ;rmdef bogusnode;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t node -o bogusnode groups=bogusgroup mgt=openbmc nodetype=mp addkcmdline=1111 arch=ppc64 authdomain=1111 bmc=1111 bmcpassword=1111 bmcusername=1111 bmcvlantag=1111 cfgmgr=1111 cfgmgtroles=1111 cfgserver=1111 chain=1111 chassis=1111 cmdmapping=1111 cons=1111 conserver=1111 consoleondemand=1111 consport=1111 cpucount=1111 cputype=1111 dhcpinterfaces=1111 disksize=1111 domainadminpassword=1111 domainadminuser=1111 domaintype=1111 getmac=1111 height=1111 hidden=1111 hostcluster=1111 hostinterface=1111 hostmanager=1111 hostnames=1111 hosttype=1111 hwtype=1111  installnic=1111 interface=1111 ip=10.10.10.10 iscsipassword=1111 iscsiserver=1111 iscsitarget=1111 iscsiuserid=1111 mac=42:d6:0a:03:05:08 memory=1111 migrationdest=1111 monserver=1111 mpa=1111 mtm=1111 nameservers=1111 netboot=grub2 nfsdir=1111 nfsserver=1111 nimserver=1111 node=1111 ondiscover=1111 osvolume=1111 otherinterfaces=1111 ou=1111 pdu=1111 postbootscripts=1111 postscripts=1111 power=1111 prescripts-begin=1111 prescripts-end=1111 primarynic=1111 primarysn=1111 productkey=1111 provmethod=1111 rack=1111 room=1111 routenames=1111 serial=1111 serialflow=1111 serialport=1111 serialspeed=1111 servicenode=1111 setupconserver=1 setupdhcp=1 setupftp=1111 setupipforward=1 setupldap=1 setupnameserver=1 setupnfs=1 setupnim=1111 setupntp=1 setupproxydhcp=1 setuptftp=1 sfp=1111 side=1111 slot=1111 storagcontroller=1111 storagetype=1111 supernode=1111 supportedarchs=1111 supportproxydhcp=1111 switch=1111 switchinterface=1111 switchport=1111 switchvlan=1111 syslog=1111 termport=1111 termserver=1111 tftpdir=1111 tftpserver=1111 unit=1111 usercomment=1111 vmbeacon=1111 vmbootorder=1111 vmcfgstore=1111 vmcluster=1111 vmmanager=1111 vmmaster=1111 vmnicnicmodel=1111 vmphyslots=1111 vmstorage=1111 vmstoragecache=1111 vmstorageformat=1111 vmstoragemodel=1111 vmtextconsole=1111 vmvirtflags=1111 vmvncport=1111 xcatmaster=1111 zonename=1111 nicaliases.eth0="moe larry curly" nicaliases.eth1="tom|jerry" niccustomscripts.eth0="configeth eth0" niccustomscripts.ib0="configib ib0" nicdevices.bond0="eth0|eth2" nicdevices.br0=bond0 nicextraparams.eth0="MTU=1500" nicextraparams.ib0="MTU=65520 CONNECTED_MODE=yes" nichostnameprefixes.eth0="eth0-" nichostnameprefixes.ib0="ib-" nichostnamesuffixes.eth0="-eth0" nichostnamesuffixes.ib0="-ib0" nicips.ib0=10.10.100.9 nicips.enP48p1s0f0=129.40.234.11 nicips.ib1=10.11.100.9 nicnetworks.enP5p1s0f1.4=xcat_bmc nicnetworks.enP48p1s0f1=xcat_util nicnetworks.ib0=IB00 nicnetworks.enP48p1s0f0=pub_yellow nicnetworks.ib3=IB03 nicnetworks.ib2=IB02 nicnetworks.enP5p1s0f1=xcat_compute nicnetworks.ib1=IB01 nicnetworks.enP5p1s0f1.5=xcat_infra nicnetworks.enP5p1s0f1.6=xcat_pdu nicsadapter.enP3p3s0f1="mac=98:be:94:59:fa:cd linkstate=DOWN" nicsadapter.enP3p3s0f2="mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face" nictypes.enP5p1s0f1.4=unused nictypes.enP48p1s0f1=unused nictypes.ib0=Infiniband nictypes.enP48p1s0f0=Ethernet nictypes.ib3=unused nictypes.ib2=unused nictypes.enP5p1s0f1=unused nictypes.ib1=Infiniband nictypes.enP5p1s0f1.5=unused nictypes.enP5p1s0f1.6=unused
 cmd:lsdef bogusnode -z|sed 's/1111/2222/g'|sed 's/unused/used/g'|sed 's/10.10.100.9/20.10.200.9/g'|sort -t'=' -k1 |tee  /tmp/export_single_node_then_modify_json_then_import/srcbogusnode.stanza
@@ -1854,9 +1854,9 @@ cmd:scp /tmp/export_single_node_then_modify_json_then_import/bogusnode_json.inv 
 check:rc==0
 cmd:rmdef bogusnode
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusnode_json.inv -t node -o bogusnode'
 check:rc==0
-cmd: ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/dstbogusnode.stanza'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef bogusnode -z |sort -t'=' -k1|tee /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/dstbogusnode.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_single_node_then_modify_json_then_import_$$DSTMN/dstbogusnode.stanza /tmp/export_single_node_then_modify_json_then_import/dstbogusnode.stanza
 check:rc==0
@@ -1864,17 +1864,17 @@ cmd: cat /tmp/export_single_node_then_modify_json_then_import/dstbogusnode.stanz
 check:rc==0
 cmd:diff -y /tmp/export_single_node_then_modify_json_then_import/srcbogusnode.stanza /tmp/export_single_node_then_modify_json_then_import/dstbogusnode.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef bogusnode'
+cmd:ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;rmdef bogusnode'
 check:rc==0
 cmd:if [[ -e /tmp/export_single_node_then_modify_json_then_import/bogusnode.stanza ]]; then cat /tmp/export_single_node_then_modify_json_then_import/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/export_single_node_then_modify_json_then_import/bogusgroup.stanza ]]; then cat /tmp/export_single_node_then_modify_json_then_import/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusgroup.stanza ]]; then cat /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_single_node_then_modify_json_then_import_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_single_node_then_modify_json_then_import
 check:rc==0
@@ -1885,15 +1885,15 @@ label:others,xcat_inventory
 description:This case is used to test xcat-inventory export and import the definition of group
 cmd:mkdir -p /tmp/export_import_single_group_json
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_group_json_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_import_single_group_json_$$DSTMN/'
 check:rc==0
 cmd:for i in 1 2 3; do lsdef bogusnode$i > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode$i -z >> /tmp/export_import_single_group_json/bogusnode.stanza ;rmdef bogusnode$i;fi; done
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_group_json/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'for i in 1 2 3; do lsdef bogusnode$i > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode$i -z >> /tmp/export_import_single_group_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode$i;fi; done'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;for i in 1 2 3; do lsdef bogusnode$i > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode$i -z >> /tmp/export_import_single_group_json_$$DSTMN/bogusnode.stanza ;rmdef bogusnode$i;fi; done'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_group_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_group_json_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t group -o bogusgroup mgt=openbmc cons=openbmc netboot=petitboot  ip='|\D+(\d+)|10.100.100.($1)|' bmcusername=root bmcpassword=0penBmc
 check:rc==0
@@ -1913,17 +1913,17 @@ cmd:rmdef -t node -o bogusnode[1-3]
 check:rc==0
 cmd:rmdef -t group -o bogusgroup
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_group_json_$$DSTMN/export.file -t node -o bogusnode1,bogusnode2,bogusnode3,bogusgroup'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_import_single_group_json_$$DSTMN/export.file -t node -o bogusnode1,bogusnode2,bogusnode3,bogusgroup'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t node -o bogusnode[1-3] > /tmp/export_import_single_group_json_$$DSTMN/import_nodes_group'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t node -o bogusnode[1-3] > /tmp/export_import_single_group_json_$$DSTMN/import_nodes_group'
 check:rc==0
-cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group -o bogusgroup >> /tmp/export_import_single_group_json_$$DSTMN/import_nodes_group'
+cmd:ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t group -o bogusgroup >> /tmp/export_import_single_group_json_$$DSTMN/import_nodes_group'
 check:rc==0
 cmd:scp $$DSTMN:/tmp/export_import_single_group_json_$$DSTMN/import_nodes_group /tmp/export_import_single_group_json/import_nodes_group
 check:rc==0
-cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef -t node -o bogusnode[1-3]'
+cmd:ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;rmdef -t node -o bogusnode[1-3]'
 check:rc==0
-cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef -t group -o bogusgroup'
+cmd: ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rmdef -t group -o bogusgroup'
 check:rc==0
 cmd:sed -e 's/members=.*$/members='"$(awk -F = '/members=/ { print $2 }' < /tmp/export_import_single_group_json/import_nodes_group | tr , ' ' | xargs -n 1 | sort -g | xargs -n 999 | tr ' ' ,)"'/' < /tmp/export_import_single_group_json/import_nodes_group > /tmp/export_import_single_group_json/import_nodes_group.1; cp -rf /tmp/export_import_single_group_json/import_nodes_group.1 /tmp/export_import_single_group_json/import_nodes_group
 check:rc==0
@@ -1933,11 +1933,11 @@ cmd:if [[ -e /tmp/export_import_single_group_json/bogusnode.stanza ]]; then cat 
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_group_json/bogusgroup.stanza ]];then cat /tmp/export_import_single_group_json/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_group_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_group_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_group_json_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_group_json_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_group_json_$$DSTMN/bogusgroup.stanza ]];then cat /tmp/export_import_single_group_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_group_json_$$DSTMN/bogusgroup.stanza ]];then cat /tmp/export_import_single_group_json_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_group_json_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_import_single_group_json_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_group_json
 check:rc==0
@@ -1948,15 +1948,15 @@ label:others,xcat_inventory
 description:This case is used to test xcat-inventory export and import the definition of group
 cmd:mkdir -p /tmp/export_import_single_group_yaml
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_group_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_import_single_group_yaml_$$DSTMN/'
 check:rc==0
 cmd:for i in 1 2 3; do lsdef bogusnode$i > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode$i -z >> /tmp/export_import_single_group_yaml/bogusnode.stanza ;rmdef bogusnode$i;fi; done
 check:rc==0
 cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_group_yaml/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'for i in 1 2 3; do lsdef bogusnode$i > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode$i -z >> /tmp/export_import_single_group_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode$i;fi; done'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;for i in 1 2 3; do lsdef bogusnode$i > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode$i -z >> /tmp/export_import_single_group_yaml_$$DSTMN/bogusnode.stanza ;rmdef bogusnode$i;fi; done'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_group_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/export_import_single_group_yaml_$$DSTMN/bogusgroup.stanza; rmdef -t group bogusgroup;fi'
 check:rc==0
 cmd:mkdef -t group -o bogusgroup mgt=openbmc cons=openbmc netboot=petitboot  ip='|\D+(\d+)|10.100.100.($1)|' bmcusername=root bmcpassword=0penBmc
 check:rc==0
@@ -1976,17 +1976,17 @@ cmd:rmdef -t node -o bogusnode[1-3]
 check:rc==0
 cmd:rmdef -t group -o bogusgroup
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_import_single_group_yaml_$$DSTMN/export.file -t node -o bogusnode1,bogusnode2,bogusnode3,bogusgroup'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_import_single_group_yaml_$$DSTMN/export.file -t node -o bogusnode1,bogusnode2,bogusnode3,bogusgroup'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t node -o bogusnode[1-3] > /tmp/export_import_single_group_yaml_$$DSTMN/import_nodes_group'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t node -o bogusnode[1-3] > /tmp/export_import_single_group_yaml_$$DSTMN/import_nodes_group'
 check:rc==0
-cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t group -o bogusgroup >> /tmp/export_import_single_group_yaml_$$DSTMN/import_nodes_group'
+cmd:ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t group -o bogusgroup >> /tmp/export_import_single_group_yaml_$$DSTMN/import_nodes_group'
 check:rc==0
 cmd:scp $$DSTMN:/tmp/export_import_single_group_yaml_$$DSTMN/import_nodes_group /tmp/export_import_single_group_yaml/import_nodes_group
 check:rc==0
-cmd:ssh  $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef -t node -o bogusnode[1-3]'
+cmd:ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;rmdef -t node -o bogusnode[1-3]'
 check:rc==0
-cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rmdef -t group -o bogusgroup'
+cmd: ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rmdef -t group -o bogusgroup'
 check:rc==0
 cmd:sed -e 's/members=.*$/members='"$(awk -F = '/members=/ { print $2 }' < /tmp/export_import_single_group_yaml/import_nodes_group | tr , ' ' | xargs -n 1 | sort -g | xargs -n 999 | tr ' ' ,)"'/' < /tmp/export_import_single_group_yaml/import_nodes_group > /tmp/export_import_single_group_yaml/import_nodes_group.1; cp -rf /tmp/export_import_single_group_yaml/import_nodes_group.1 /tmp/export_import_single_group_yaml/import_nodes_group
 check:rc==0
@@ -1996,11 +1996,11 @@ cmd:if [[ -e /tmp/export_import_single_group_yaml/bogusnode.stanza ]]; then cat 
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_group_yaml/bogusgroup.stanza ]];then cat /tmp/export_import_single_group_yaml/bogusgroup.stanza |mkdef -z -f;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_group_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_group_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_group_yaml_$$DSTMN/bogusnode.stanza ]]; then cat /tmp/export_import_single_group_yaml_$$DSTMN/bogusnode.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_group_yaml_$$DSTMN/bogusgroup.stanza ]];then cat /tmp/export_import_single_group_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_group_yaml_$$DSTMN/bogusgroup.stanza ]];then cat /tmp/export_import_single_group_yaml_$$DSTMN/bogusgroup.stanza |mkdef -z -f;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_group_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_import_single_group_yaml_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_group_yaml
 check:rc==0

--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.osimage
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.osimage
@@ -4,11 +4,11 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_osimage_by_yaml
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_osimage_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_import_single_osimage_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:lsdef -t osimage -o bogus_image >/dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t osimage -o bogus_image -z >/tmp/export_import_single_osimage_by_yaml/bogus_image.stanza ;rmdef -t osimage -o bogus_image;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t osimage -o  bogus_image > /dev/null 2>&1; if [[ $? -eq 0 ]]; then lsdef -t osimage -o bogus_image -z >/tmp/export_import_single_osimage_by_yaml_$$DSTMN/bogus_image.stanza ;rmdef -t osimage -o bogus_image;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t osimage -o  bogus_image > /dev/null 2>&1; if [[ $? -eq 0 ]]; then lsdef -t osimage -o bogus_image -z >/tmp/export_import_single_osimage_by_yaml_$$DSTMN/bogus_image.stanza ;rmdef -t osimage -o bogus_image;fi'
 check:rc==0
 cmd:chdef -t osimage -o bogus_image addkcmdline=addkcmdline boottarget=boottarget cfmdir=cfmdir crashkernelsize=crashkernelsize description=description driverupdatesrc=driverupdatesrc dump=dump exlist=exlist groups=groups imagename=imagename imagetype=linux isdeletable=isdeletable kerneldir=kerneldir kernelver=kernelver kitcomponents=kitcomponents krpmver=krpmver netdrivers=netdrivers nodebootif=nodebootif osarch=osarch osdistroname=osdistroname osname=osname osupdatename=osupdatename osvers=osvers otherifce=otherifce otherpkgdir=otherpkgdir otherpkglist=otherpkglist partitionfile=partitionfile permission=permission pkgdir=pkgdir pkglist=pkglist postbootscripts=postbootscripts postinstall=postinstall postscripts=postscripts profile=compute provmethod=netboot rootfstype=nfs rootimgdir=rootimgdir serverrole=serverrole synclists=synclists template=template usercomment=usercomment
 check:rc==0
@@ -20,23 +20,23 @@ cmd:scp /tmp/export_import_single_osimage_by_yaml/bogus_image.yaml $$DSTMN:/tmp/
 check:rc==0
 cmd: rmdef -t osimage -o  bogus_image
 check:rc==0
-cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'xcat-inventory import -f /tmp/export_import_single_osimage_by_yaml_$$DSTMN/bogus_image.yaml -t osimage -o bogus_image'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_import_single_osimage_by_yaml_$$DSTMN/bogus_image.yaml -t osimage -o bogus_image'
 check:rc==0
-cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'lsdef -t osimage -o bogus_image -z |sort -t'=' -k1|tee /tmp/export_import_single_osimage_by_yaml_$$DSTMN/dst_bogus_image.stanza'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t osimage -o bogus_image -z |sort -t'=' -k1|tee /tmp/export_import_single_osimage_by_yaml_$$DSTMN/dst_bogus_image.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_osimage_by_yaml_$$DSTMN/dst_bogus_image.stanza /tmp/export_import_single_osimage_by_yaml/dst_bogus_image.stanza
 check:rc==0
 cmd: cat /tmp/export_import_single_osimage_by_yaml/dst_bogus_image.stanza
 check:rc==0
-cmd:diff -y /tmp/export_import_single_osimage_by_yaml/src_bogus_osimage.stanza /tmp/export_import_single_osimage_by_yaml/dst_bogus_image.stanza
+cmd:diff -y /tmp/export_import_single_osimage_by_yaml/src_bogus_osimage.stanza /tmp/export_import_single_osimage_by_yaml/dst_bogus_image.stanza -I "environvar"
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'rmdef -t osimage -o bogus_image'
+cmd:ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;rmdef -t osimage -o bogus_image'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_osimage_by_yaml/bogus_image.stanza ]]; then cat /tmp/export_import_single_osimage_by_yaml/bogus_image.stanza | mkdef -z;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_osimage_by_yaml_$$DSTMN/bogus_image.stanza ]]; then cat /tmp/export_import_single_osimage_by_yaml_$$DSTMN/bogus_image.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_osimage_by_yaml_$$DSTMN/bogus_image.stanza ]]; then cat /tmp/export_import_single_osimage_by_yaml_$$DSTMN/bogus_image.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_osimage_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_import_single_osimage_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_osimage_by_yaml
 check:rc==0
@@ -48,11 +48,11 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_osimage_by_json
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_osimage_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_import_single_osimage_by_json_$$DSTMN/'
 check:rc==0
 cmd:lsdef -t osimage -o bogus_image >/dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t osimage -o bogus_image -z >/tmp/export_import_single_osimage_by_json/bogus_image.stanza ;rmdef -t osimage -o bogus_image;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t osimage -o  bogus_image > /dev/null 2>&1; if [[ $? -eq 0 ]]; then lsdef -t osimage -o bogus_image -z >/tmp/export_import_single_osimage_by_json_$$DSTMN/bogus_image.stanza ;rmdef -t osimage -o bogus_image;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t osimage -o  bogus_image > /dev/null 2>&1; if [[ $? -eq 0 ]]; then lsdef -t osimage -o bogus_image -z >/tmp/export_import_single_osimage_by_json_$$DSTMN/bogus_image.stanza ;rmdef -t osimage -o bogus_image;fi'
 check:rc==0
 cmd:chdef -t osimage -o bogus_image addkcmdline=addkcmdline boottarget=boottarget cfmdir=cfmdir crashkernelsize=crashkernelsize description=description driverupdatesrc=driverupdatesrc dump=dump exlist=exlist groups=groups imagename=imagename imagetype=linux isdeletable=isdeletable kerneldir=kerneldir kernelver=kernelver kitcomponents=kitcomponents krpmver=krpmver netdrivers=netdrivers nodebootif=nodebootif osarch=osarch osdistroname=osdistroname osname=osname osupdatename=osupdatename osvers=osvers otherifce=otherifce otherpkgdir=otherpkgdir otherpkglist=otherpkglist partitionfile=partitionfile permission=permission pkgdir=pkgdir pkglist=pkglist postbootscripts=postbootscripts postinstall=postinstall postscripts=postscripts profile=compute provmethod=netboot rootfstype=nfs rootimgdir=rootimgdir serverrole=serverrole synclists=synclists template=template usercomment=usercomment
 check:rc==0
@@ -64,23 +64,23 @@ cmd:scp /tmp/export_import_single_osimage_by_json/bogus_image.json $$DSTMN:/tmp/
 check:rc==0
 cmd: rmdef -t osimage -o  bogus_image
 check:rc==0
-cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'xcat-inventory import -f /tmp/export_import_single_osimage_by_json_$$DSTMN/bogus_image.json -t osimage -o bogus_image'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_import_single_osimage_by_json_$$DSTMN/bogus_image.json -t osimage -o bogus_image'
 check:rc==0
-cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'lsdef -t osimage -o bogus_image -z |sort -t'=' -k1|tee /tmp/export_import_single_osimage_by_json_$$DSTMN/dst_bogus_image.stanza'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t osimage -o bogus_image -z |sort -t'=' -k1|tee /tmp/export_import_single_osimage_by_json_$$DSTMN/dst_bogus_image.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_osimage_by_json_$$DSTMN/dst_bogus_image.stanza /tmp/export_import_single_osimage_by_json/dst_bogus_image.stanza
 check:rc==0
 cmd: cat /tmp/export_import_single_osimage_by_json/dst_bogus_image.stanza
 check:rc==0
-cmd:diff -y /tmp/export_import_single_osimage_by_json/src_bogus_osimage.stanza /tmp/export_import_single_osimage_by_json/dst_bogus_image.stanza
+cmd:diff -y /tmp/export_import_single_osimage_by_json/src_bogus_osimage.stanza /tmp/export_import_single_osimage_by_json/dst_bogus_image.stanza -I "environvar"
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'rmdef -t osimage -o bogus_image'
+cmd:ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;rmdef -t osimage -o bogus_image'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_osimage_by_json/bogus_image.stanza ]]; then cat /tmp/export_import_single_osimage_by_json/bogus_image.stanza | mkdef -z;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_osimage_by_json_$$DSTMN/bogus_image.stanza ]]; then cat /tmp/export_import_single_osimage_by_json_$$DSTMN/bogus_image.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_import_single_osimage_by_json_$$DSTMN/bogus_image.stanza ]]; then cat /tmp/export_import_single_osimage_by_json_$$DSTMN/bogus_image.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_osimage_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_import_single_osimage_by_json_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_osimage_by_json
 check:rc==0
@@ -99,27 +99,27 @@ cmd:chdef -t osimage -o bogus_image addkcmdline=addkcmdline boottarget=boottarge
 check:rc==0
 cmd:xcat-inventory export -t osimage |tee /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc==0
-cmd:grep ' "osimage": {' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd:grep "osimage:"  /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc==0
-cmd:grep '"bogus_image": {' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd:grep "bogus_image:" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc==0
-cmd: grep '"node": {' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd: grep -w "node:"  /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc!=0
-cmd: grep '"obj_type": "node",' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd: grep "obj_type: node" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc!=0
-cmd: grep '"policy": {'' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd: grep "policy:"  /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc!=0
-cmd: grep '"passwd": {' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd: grep "passwd:" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc!=0
-cmd: grep '"network": {' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd: grep "network:" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc!=0
-cmd: grep '"route": {' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd: grep "route:" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc!=0
-cmd: grep '"site": {' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd: grep "site:" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc!=0
 cmd:lsdef -t osimage |tee  /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/osimage_in_xcat_db
 check:rc==0
-cmd: a=0;for i in `awk -F' ' '{print $1}' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/osimage_in_xcat_db`; do if grep -E "\"$i\": {" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file > /dev/null; then ((a++));fi; done; do=$(cat /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/osimage_in_xcat_db|wc -l);if [[ $do -eq $a ]]; then exit 0; else exit 1;fi
+cmd: a=0;for i in `awk -F' ' '{print $1}' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/osimage_in_xcat_db`; do if grep -E "$i:" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file > /dev/null; then ((a++));fi; done; do=$(cat /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/osimage_in_xcat_db|wc -l);if [[ $do -eq $a ]]; then exit 0; else exit 1;fi
 check:rc==0
 cmd: rmdef -t osimage -o  bogus_image
 check:rc==0
@@ -437,7 +437,7 @@ cmd:xcat-inventory import -f /tmp/xcat_inventory_try_to_import_all_type_is_osima
 check:rc==0
 cmd:lsdef -t osimage -l|sort > /tmp/xcat_inventory_try_to_import_all_type_is_osimage_yaml_format/import_osimage
 check:rc==0
-cmd:diff -y /tmp/xcat_inventory_try_to_import_all_type_is_osimage_yaml_format/target_osimage_sort /tmp/xcat_inventory_try_to_import_all_type_is_osimage_yaml_format/import_osimage
+cmd:diff -y /tmp/xcat_inventory_try_to_import_all_type_is_osimage_yaml_format/target_osimage_sort /tmp/xcat_inventory_try_to_import_all_type_is_osimage_yaml_format/import_osimage -I "environvar=OBJNAME=bogus_image"
 check:rc==0
 cmd:lsdef -t node -l > /tmp/xcat_inventory_try_to_import_all_type_is_osimage_yaml_format/after_nodes_db
 check:rc==0
@@ -768,7 +768,7 @@ cmd:xcat-inventory import -f /tmp/xcat_inventory_try_to_import_all_type_is_osima
 check:rc==0
 cmd:lsdef -t osimage -l|sort > /tmp/xcat_inventory_try_to_import_all_type_is_osimage_json_format/import_osimage
 check:rc==0
-cmd:diff -y /tmp/xcat_inventory_try_to_import_all_type_is_osimage_json_format/target_osimage_sort /tmp/xcat_inventory_try_to_import_all_type_is_osimage_json_format/import_osimage
+cmd:diff -y /tmp/xcat_inventory_try_to_import_all_type_is_osimage_json_format/target_osimage_sort /tmp/xcat_inventory_try_to_import_all_type_is_osimage_json_format/import_osimage -I "environvar=OBJNAME=bogus_image"
 check:rc==0
 cmd:lsdef -t node -l > /tmp/xcat_inventory_try_to_import_all_type_is_osimage_json_format/after_nodes_db
 check:rc==0
@@ -813,11 +813,11 @@ label:others,xcat_inventory
 description:This case is used to test xcat-inventory import a osimage , then modify the export json file, then import the json file
 cmd:mkdir -p /tmp/export_single_osimage_then_modify_json_then_import
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/'
 check:rc==0
 cmd:lsdef -t osimage -o bogus_image >/dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t osimage -o bogus_image -z >/tmp/export_single_osimage_then_modify_json_then_import/bogus_image.stanza ;rmdef -t osimage -o bogus_image;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t osimage -o  bogus_image > /dev/null 2>&1; if [[ $? -eq 0 ]]; then lsdef -t osimage -o bogus_image -z >/tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/bogus_image.stanza ;rmdef -t osimage -o bogus_image;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t osimage -o  bogus_image > /dev/null 2>&1; if [[ $? -eq 0 ]]; then lsdef -t osimage -o bogus_image -z >/tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/bogus_image.stanza ;rmdef -t osimage -o bogus_image;fi'
 check:rc==0
 cmd:chdef -t osimage -o bogus_image addkcmdline=1111 boottarget=1111 cfmdir=1111 crashkernelsize=1111 description=1111 driverupdatesrc=1111 dump=1111 exlist=1111 groups=1111 imagename=1111 imagetype=linux isdeletable=1111 kerneldir=1111 kernelver=1111 kitcomponents=1111 krpmver=1111 netdrivers=1111 nodebootif=1111 osarch=1111 osdistroname=1111 osname=1111 osupdatename=1111 osvers=1111 otherifce=1111 otherpkgdir=1111 otherpkglist=1111 partitionfile=1111 permission=1111 pkgdir=1111 pkglist=1111 postbootscripts=1111 postinstall=1111 postscripts=1111 profile=compute  provmethod=statelite rootfstype=nfs rootimgdir=1111 serverrole=1111 synclists=1111 template=1111 usercomment=1111
 check:rc==0
@@ -843,23 +843,23 @@ cmd:scp /tmp/export_single_osimage_then_modify_json_then_import/bogus_image.json
 check:rc==0
 cmd: rmdef -t osimage -o  bogus_image
 check:rc==0
-cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'xcat-inventory import -f /tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/bogus_image.json -t osimage -o bogus_image'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/bogus_image.json -t osimage -o bogus_image'
 check:rc==0
-cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'lsdef -t osimage -o bogus_image -z |sort -t'=' -k1|tee /tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/dst_bogus_image.stanza'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t osimage -o bogus_image -z |sort -t'=' -k1|tee /tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/dst_bogus_image.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/dst_bogus_image.stanza /tmp/export_single_osimage_then_modify_json_then_import/dst_bogus_image.stanza
 check:rc==0
 cmd: cat /tmp/export_single_osimage_then_modify_json_then_import/dst_bogus_image.stanza
 check:rc==0
-cmd:diff -y /tmp/export_single_osimage_then_modify_json_then_import/src_bogus_osimage.stanza /tmp/export_single_osimage_then_modify_json_then_import/dst_bogus_image.stanza
+cmd:diff -y /tmp/export_single_osimage_then_modify_json_then_import/src_bogus_osimage.stanza /tmp/export_single_osimage_then_modify_json_then_import/dst_bogus_image.stanza -I "environvar=OBJNAME=bogus_image"
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'rmdef -t osimage -o bogus_image'
+cmd:ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;rmdef -t osimage -o bogus_image'
 check:rc==0
 cmd:if [[ -e /tmp/export_single_osimage_then_modify_json_then_import/bogus_image.stanza ]]; then cat /tmp/export_single_osimage_then_modify_json_then_import/bogus_image.stanza | mkdef -z;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/bogus_image.stanza ]]; then cat /tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/bogus_image.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/bogus_image.stanza ]]; then cat /tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/bogus_image.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_single_osimage_then_modify_json_then_import
 check:rc==0
@@ -870,11 +870,11 @@ label:others,xcat_inventory
 description:This case is used to test xcat-inventory import a osimage , then modify the export yaml file, then import the yaml file
 cmd:mkdir -p /tmp/export_single_osimage_then_modify_yaml_then_import
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/'
 check:rc==0
 cmd:lsdef -t osimage -o bogus_image >/dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t osimage -o bogus_image -z >/tmp/export_single_osimage_then_modify_yaml_then_import/bogus_image.stanza ;rmdef -t osimage -o bogus_image;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t osimage -o  bogus_image > /dev/null 2>&1; if [[ $? -eq 0 ]]; then lsdef -t osimage -o bogus_image -z >/tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/bogus_image.stanza ;rmdef -t osimage -o bogus_image;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t osimage -o  bogus_image > /dev/null 2>&1; if [[ $? -eq 0 ]]; then lsdef -t osimage -o bogus_image -z >/tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/bogus_image.stanza ;rmdef -t osimage -o bogus_image;fi'
 check:rc==0
 cmd:chdef -t osimage -o bogus_image addkcmdline=1111 boottarget=1111 cfmdir=1111 crashkernelsize=1111 description=1111 driverupdatesrc=1111 dump=1111 exlist=1111 groups=1111 imagename=1111 imagetype=linux isdeletable=1111 kerneldir=1111 kernelver=1111 kitcomponents=1111 krpmver=1111 netdrivers=1111 nodebootif=1111 osarch=1111 osdistroname=1111 osname=1111 osupdatename=1111 osvers=1111 otherifce=1111 otherpkgdir=1111 otherpkglist=1111 partitionfile=1111 permission=1111 pkgdir=1111 pkglist=1111 postbootscripts=1111 postinstall=1111 postscripts=1111 profile=compute provmethod=statelite rootfstype=nfs rootimgdir=1111 serverrole=1111 synclists=1111 template=1111 usercomment=1111
 check:rc==0
@@ -900,23 +900,23 @@ cmd:scp /tmp/export_single_osimage_then_modify_yaml_then_import/bogus_image.yaml
 check:rc==0
 cmd: rmdef -t osimage -o  bogus_image
 check:rc==0
-cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'xcat-inventory import -f /tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/bogus_image.yaml -t osimage -o bogus_image'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/bogus_image.yaml -t osimage -o bogus_image'
 check:rc==0
-cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'lsdef -t osimage -o bogus_image -z |sort -t'=' -k1|tee /tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/dst_bogus_image.stanza'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t osimage -o bogus_image -z |sort -t'=' -k1|tee /tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/dst_bogus_image.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/dst_bogus_image.stanza /tmp/export_single_osimage_then_modify_yaml_then_import/dst_bogus_image.stanza
 check:rc==0
 cmd: cat /tmp/export_single_osimage_then_modify_yaml_then_import/dst_bogus_image.stanza
 check:rc==0
-cmd:diff -y /tmp/export_single_osimage_then_modify_yaml_then_import/src_bogus_osimage.stanza /tmp/export_single_osimage_then_modify_yaml_then_import/dst_bogus_image.stanza
+cmd:diff -y /tmp/export_single_osimage_then_modify_yaml_then_import/src_bogus_osimage.stanza /tmp/export_single_osimage_then_modify_yaml_then_import/dst_bogus_image.stanza -I "environvar=OBJNAME=bogus_image"
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'rmdef -t osimage -o bogus_image'
+cmd:ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;rmdef -t osimage -o bogus_image'
 check:rc==0
 cmd:if [[ -e /tmp/export_single_osimage_then_modify_yaml_then_import/bogus_image.stanza ]]; then cat /tmp/export_single_osimage_then_modify_yaml_then_import/bogus_image.stanza | mkdef -z;fi
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/bogus_image.stanza ]]; then cat /tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/bogus_image.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;if [[ -e /tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/bogus_image.stanza ]]; then cat /tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/bogus_image.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_single_osimage_then_modify_yaml_then_import
 check:rc==0
@@ -1208,12 +1208,8 @@ check:rc==0
 cmd:rm -rf /tmp/otherpkglist /tmp/synclists /tmp/postinstall /tmp/exlist /tmp/pkglist /tmp/template /tmp/partitionfile
 cmd:xcat-inventory import -t osimage -d /opt/inventory/site
 check:rc==0
-check:output=~Importing object: test_myimage1
 check:output=~Inventory import successfully!
-check:output=~The object test_myimage1 has been imported
-check:output=~Importing object: test_myimage2
 check:output=~Inventory import successfully!
-check:output=~The object test_myimage2 has been imported
 cmd:lsdef -t osimage -o test_myimage1,test_myimage2
 check:rc==0
 cmd:otherpkglist=`lsdef -t osimage -o test_myimage1 |grep otherpkglist|awk -F= '{print $2}'`;diff -y $otherpkglist /opt/inventory/site/osimage/test_myimage1$otherpkglist
@@ -1248,7 +1244,6 @@ cmd: rmdef -t osimage -o  test_myimage1,test_myimage2
 check:rc==0
 cmd: if [ -e /tmp/test_myimage1.stanza ]; then cat /tmp/test_myimage1.stanza |mkdef -z;fi
 cmd: if [ -e /tmp/test_myimage2.stanza ]; then cat /tmp/test_myimage2.stanza |mkdef -z;fi
-cmd:dir="/opt/inventory/site/osimage"; rm -rf $dir; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi
 cmd:dir="/opt/inventory/site/osimage"; rm -rf $dir; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi
 cmd:file="/tmp/otherpkglist"; rm -rf $file; if [ -d ${file}".bak" ];then mv ${file}".bak" $file; fi
 cmd:file="/tmp/synclists"; rm -rf $file; if [ -d ${file}".bak" ];then mv ${file}".bak" $file; fi
@@ -1285,10 +1280,8 @@ check:output=~The osimage objects has been exported to directory /tmp/export
 cmd:ls -lFR /tmp/export
 cmd: xcat-inventory import -t osimage -d /tmp/export -c
 check:rc==0
-check:output=~Importing object: test_myimage1
 check:output=~Inventory import successfully!
 check:output=~The object test_myimage1 has been imported
-check:output=~Importing object: test_myimage2
 check:output=~Inventory import successfully!
 check:output=~The object test_myimage2 has been imported
 cmd:lsdef -t osimage -o test_myimage1,test_myimage2

--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.osimage
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.osimage
@@ -4,11 +4,11 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_osimage_by_yaml
 check:rc==0
-cmd:ssh $$DSTMN 'mkdir -p /tmp/export_import_single_osimage_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_osimage_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:lsdef -t osimage -o bogus_image >/dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t osimage -o bogus_image -z >/tmp/export_import_single_osimage_by_yaml/bogus_image.stanza ;rmdef -t osimage -o bogus_image;fi
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t osimage -o  bogus_image > /dev/null 2>&1; if [[ $? -eq 0 ]]; then lsdef -t osimage -o bogus_image -z >/tmp/export_import_single_osimage_by_yaml_$$DSTMN/bogus_image.stanza ;rmdef -t osimage -o bogus_image;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t osimage -o  bogus_image > /dev/null 2>&1; if [[ $? -eq 0 ]]; then lsdef -t osimage -o bogus_image -z >/tmp/export_import_single_osimage_by_yaml_$$DSTMN/bogus_image.stanza ;rmdef -t osimage -o bogus_image;fi'
 check:rc==0
 cmd:chdef -t osimage -o bogus_image addkcmdline=addkcmdline boottarget=boottarget cfmdir=cfmdir crashkernelsize=crashkernelsize description=description driverupdatesrc=driverupdatesrc dump=dump exlist=exlist groups=groups imagename=imagename imagetype=linux isdeletable=isdeletable kerneldir=kerneldir kernelver=kernelver kitcomponents=kitcomponents krpmver=krpmver netdrivers=netdrivers nodebootif=nodebootif osarch=osarch osdistroname=osdistroname osname=osname osupdatename=osupdatename osvers=osvers otherifce=otherifce otherpkgdir=otherpkgdir otherpkglist=otherpkglist partitionfile=partitionfile permission=permission pkgdir=pkgdir pkglist=pkglist postbootscripts=postbootscripts postinstall=postinstall postscripts=postscripts profile=compute provmethod=netboot rootfstype=nfs rootimgdir=rootimgdir serverrole=serverrole synclists=synclists template=template usercomment=usercomment
 check:rc==0
@@ -20,23 +20,23 @@ cmd:scp /tmp/export_import_single_osimage_by_yaml/bogus_image.yaml $$DSTMN:/tmp/
 check:rc==0
 cmd: rmdef -t osimage -o  bogus_image
 check:rc==0
-cmd: ssh  $$DSTMN 'xcat-inventory import -f /tmp/export_import_single_osimage_by_yaml_$$DSTMN/bogus_image.yaml -t osimage -o bogus_image'
+cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'xcat-inventory import -f /tmp/export_import_single_osimage_by_yaml_$$DSTMN/bogus_image.yaml -t osimage -o bogus_image'
 check:rc==0
-cmd: ssh  $$DSTMN 'lsdef -t osimage -o bogus_image -z |sort -t'=' -k1|tee /tmp/export_import_single_osimage_by_yaml_$$DSTMN/dst_bogus_image.stanza'
+cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'lsdef -t osimage -o bogus_image -z |sort -t'=' -k1|tee /tmp/export_import_single_osimage_by_yaml_$$DSTMN/dst_bogus_image.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_osimage_by_yaml_$$DSTMN/dst_bogus_image.stanza /tmp/export_import_single_osimage_by_yaml/dst_bogus_image.stanza
 check:rc==0
 cmd: cat /tmp/export_import_single_osimage_by_yaml/dst_bogus_image.stanza
 check:rc==0
-cmd:diff -y /tmp/export_import_single_osimage_by_yaml/src_bogus_osimage.stanza /tmp/export_import_single_osimage_by_yaml/dst_bogus_image.stanza -I "environvar"
+cmd:diff -y /tmp/export_import_single_osimage_by_yaml/src_bogus_osimage.stanza /tmp/export_import_single_osimage_by_yaml/dst_bogus_image.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'rmdef -t osimage -o bogus_image'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'rmdef -t osimage -o bogus_image'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_osimage_by_yaml/bogus_image.stanza ]]; then cat /tmp/export_import_single_osimage_by_yaml/bogus_image.stanza | mkdef -z;fi
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_osimage_by_yaml_$$DSTMN/bogus_image.stanza ]]; then cat /tmp/export_import_single_osimage_by_yaml_$$DSTMN/bogus_image.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_osimage_by_yaml_$$DSTMN/bogus_image.stanza ]]; then cat /tmp/export_import_single_osimage_by_yaml_$$DSTMN/bogus_image.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'rm -rf /tmp/export_import_single_osimage_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_osimage_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_osimage_by_yaml
 check:rc==0
@@ -48,11 +48,11 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_single_osimage_by_json
 check:rc==0
-cmd:ssh $$DSTMN 'mkdir -p /tmp/export_import_single_osimage_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_single_osimage_by_json_$$DSTMN/'
 check:rc==0
 cmd:lsdef -t osimage -o bogus_image >/dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t osimage -o bogus_image -z >/tmp/export_import_single_osimage_by_json/bogus_image.stanza ;rmdef -t osimage -o bogus_image;fi
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t osimage -o  bogus_image > /dev/null 2>&1; if [[ $? -eq 0 ]]; then lsdef -t osimage -o bogus_image -z >/tmp/export_import_single_osimage_by_json_$$DSTMN/bogus_image.stanza ;rmdef -t osimage -o bogus_image;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t osimage -o  bogus_image > /dev/null 2>&1; if [[ $? -eq 0 ]]; then lsdef -t osimage -o bogus_image -z >/tmp/export_import_single_osimage_by_json_$$DSTMN/bogus_image.stanza ;rmdef -t osimage -o bogus_image;fi'
 check:rc==0
 cmd:chdef -t osimage -o bogus_image addkcmdline=addkcmdline boottarget=boottarget cfmdir=cfmdir crashkernelsize=crashkernelsize description=description driverupdatesrc=driverupdatesrc dump=dump exlist=exlist groups=groups imagename=imagename imagetype=linux isdeletable=isdeletable kerneldir=kerneldir kernelver=kernelver kitcomponents=kitcomponents krpmver=krpmver netdrivers=netdrivers nodebootif=nodebootif osarch=osarch osdistroname=osdistroname osname=osname osupdatename=osupdatename osvers=osvers otherifce=otherifce otherpkgdir=otherpkgdir otherpkglist=otherpkglist partitionfile=partitionfile permission=permission pkgdir=pkgdir pkglist=pkglist postbootscripts=postbootscripts postinstall=postinstall postscripts=postscripts profile=compute provmethod=netboot rootfstype=nfs rootimgdir=rootimgdir serverrole=serverrole synclists=synclists template=template usercomment=usercomment
 check:rc==0
@@ -64,23 +64,23 @@ cmd:scp /tmp/export_import_single_osimage_by_json/bogus_image.json $$DSTMN:/tmp/
 check:rc==0
 cmd: rmdef -t osimage -o  bogus_image
 check:rc==0
-cmd: ssh  $$DSTMN 'xcat-inventory import -f /tmp/export_import_single_osimage_by_json_$$DSTMN/bogus_image.json -t osimage -o bogus_image'
+cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'xcat-inventory import -f /tmp/export_import_single_osimage_by_json_$$DSTMN/bogus_image.json -t osimage -o bogus_image'
 check:rc==0
-cmd: ssh  $$DSTMN 'lsdef -t osimage -o bogus_image -z |sort -t'=' -k1|tee /tmp/export_import_single_osimage_by_json_$$DSTMN/dst_bogus_image.stanza'
+cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'lsdef -t osimage -o bogus_image -z |sort -t'=' -k1|tee /tmp/export_import_single_osimage_by_json_$$DSTMN/dst_bogus_image.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_single_osimage_by_json_$$DSTMN/dst_bogus_image.stanza /tmp/export_import_single_osimage_by_json/dst_bogus_image.stanza
 check:rc==0
 cmd: cat /tmp/export_import_single_osimage_by_json/dst_bogus_image.stanza
 check:rc==0
-cmd:diff -y /tmp/export_import_single_osimage_by_json/src_bogus_osimage.stanza /tmp/export_import_single_osimage_by_json/dst_bogus_image.stanza -I "environvar"
+cmd:diff -y /tmp/export_import_single_osimage_by_json/src_bogus_osimage.stanza /tmp/export_import_single_osimage_by_json/dst_bogus_image.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'rmdef -t osimage -o bogus_image'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'rmdef -t osimage -o bogus_image'
 check:rc==0
 cmd:if [[ -e /tmp/export_import_single_osimage_by_json/bogus_image.stanza ]]; then cat /tmp/export_import_single_osimage_by_json/bogus_image.stanza | mkdef -z;fi
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_import_single_osimage_by_json_$$DSTMN/bogus_image.stanza ]]; then cat /tmp/export_import_single_osimage_by_json_$$DSTMN/bogus_image.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_import_single_osimage_by_json_$$DSTMN/bogus_image.stanza ]]; then cat /tmp/export_import_single_osimage_by_json_$$DSTMN/bogus_image.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'rm -rf /tmp/export_import_single_osimage_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_single_osimage_by_json_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_single_osimage_by_json
 check:rc==0
@@ -99,27 +99,27 @@ cmd:chdef -t osimage -o bogus_image addkcmdline=addkcmdline boottarget=boottarge
 check:rc==0
 cmd:xcat-inventory export -t osimage |tee /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc==0
-cmd:grep "osimage:"  /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd:grep ' "osimage": {' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc==0
-cmd:grep "bogus_image:" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd:grep '"bogus_image": {' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc==0
-cmd: grep -w "node:"  /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd: grep '"node": {' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc!=0
-cmd: grep "obj_type: node" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd: grep '"obj_type": "node",' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc!=0
-cmd: grep "policy:"  /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd: grep '"policy": {'' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc!=0
-cmd: grep "passwd:" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd: grep '"passwd": {' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc!=0
-cmd: grep "network:" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd: grep '"network": {' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc!=0
-cmd: grep "route:" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd: grep '"route": {' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc!=0
-cmd: grep "site:" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
+cmd: grep '"site": {' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file
 check:rc!=0
 cmd:lsdef -t osimage |tee  /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/osimage_in_xcat_db
 check:rc==0
-cmd: a=0;for i in `awk -F' ' '{print $1}' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/osimage_in_xcat_db`; do if grep -E "$i:" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file > /dev/null; then ((a++));fi; done; do=$(cat /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/osimage_in_xcat_db|wc -l);if [[ $do -eq $a ]]; then exit 0; else exit 1;fi
+cmd: a=0;for i in `awk -F' ' '{print $1}' /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/osimage_in_xcat_db`; do if grep -E "\"$i\": {" /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/export.file > /dev/null; then ((a++));fi; done; do=$(cat /tmp/xcat_inventory_try_to_export_all_type_is_osimage_default_format/osimage_in_xcat_db|wc -l);if [[ $do -eq $a ]]; then exit 0; else exit 1;fi
 check:rc==0
 cmd: rmdef -t osimage -o  bogus_image
 check:rc==0
@@ -437,7 +437,7 @@ cmd:xcat-inventory import -f /tmp/xcat_inventory_try_to_import_all_type_is_osima
 check:rc==0
 cmd:lsdef -t osimage -l|sort > /tmp/xcat_inventory_try_to_import_all_type_is_osimage_yaml_format/import_osimage
 check:rc==0
-cmd:diff -y /tmp/xcat_inventory_try_to_import_all_type_is_osimage_yaml_format/target_osimage_sort /tmp/xcat_inventory_try_to_import_all_type_is_osimage_yaml_format/import_osimage -I "environvar=OBJNAME=bogus_image"
+cmd:diff -y /tmp/xcat_inventory_try_to_import_all_type_is_osimage_yaml_format/target_osimage_sort /tmp/xcat_inventory_try_to_import_all_type_is_osimage_yaml_format/import_osimage
 check:rc==0
 cmd:lsdef -t node -l > /tmp/xcat_inventory_try_to_import_all_type_is_osimage_yaml_format/after_nodes_db
 check:rc==0
@@ -768,7 +768,7 @@ cmd:xcat-inventory import -f /tmp/xcat_inventory_try_to_import_all_type_is_osima
 check:rc==0
 cmd:lsdef -t osimage -l|sort > /tmp/xcat_inventory_try_to_import_all_type_is_osimage_json_format/import_osimage
 check:rc==0
-cmd:diff -y /tmp/xcat_inventory_try_to_import_all_type_is_osimage_json_format/target_osimage_sort /tmp/xcat_inventory_try_to_import_all_type_is_osimage_json_format/import_osimage -I "environvar=OBJNAME=bogus_image"
+cmd:diff -y /tmp/xcat_inventory_try_to_import_all_type_is_osimage_json_format/target_osimage_sort /tmp/xcat_inventory_try_to_import_all_type_is_osimage_json_format/import_osimage
 check:rc==0
 cmd:lsdef -t node -l > /tmp/xcat_inventory_try_to_import_all_type_is_osimage_json_format/after_nodes_db
 check:rc==0
@@ -813,11 +813,11 @@ label:others,xcat_inventory
 description:This case is used to test xcat-inventory import a osimage , then modify the export json file, then import the json file
 cmd:mkdir -p /tmp/export_single_osimage_then_modify_json_then_import
 check:rc==0
-cmd:ssh $$DSTMN 'mkdir -p /tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/'
 check:rc==0
 cmd:lsdef -t osimage -o bogus_image >/dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t osimage -o bogus_image -z >/tmp/export_single_osimage_then_modify_json_then_import/bogus_image.stanza ;rmdef -t osimage -o bogus_image;fi
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t osimage -o  bogus_image > /dev/null 2>&1; if [[ $? -eq 0 ]]; then lsdef -t osimage -o bogus_image -z >/tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/bogus_image.stanza ;rmdef -t osimage -o bogus_image;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t osimage -o  bogus_image > /dev/null 2>&1; if [[ $? -eq 0 ]]; then lsdef -t osimage -o bogus_image -z >/tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/bogus_image.stanza ;rmdef -t osimage -o bogus_image;fi'
 check:rc==0
 cmd:chdef -t osimage -o bogus_image addkcmdline=1111 boottarget=1111 cfmdir=1111 crashkernelsize=1111 description=1111 driverupdatesrc=1111 dump=1111 exlist=1111 groups=1111 imagename=1111 imagetype=linux isdeletable=1111 kerneldir=1111 kernelver=1111 kitcomponents=1111 krpmver=1111 netdrivers=1111 nodebootif=1111 osarch=1111 osdistroname=1111 osname=1111 osupdatename=1111 osvers=1111 otherifce=1111 otherpkgdir=1111 otherpkglist=1111 partitionfile=1111 permission=1111 pkgdir=1111 pkglist=1111 postbootscripts=1111 postinstall=1111 postscripts=1111 profile=compute  provmethod=statelite rootfstype=nfs rootimgdir=1111 serverrole=1111 synclists=1111 template=1111 usercomment=1111
 check:rc==0
@@ -843,23 +843,23 @@ cmd:scp /tmp/export_single_osimage_then_modify_json_then_import/bogus_image.json
 check:rc==0
 cmd: rmdef -t osimage -o  bogus_image
 check:rc==0
-cmd: ssh  $$DSTMN 'xcat-inventory import -f /tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/bogus_image.json -t osimage -o bogus_image'
+cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'xcat-inventory import -f /tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/bogus_image.json -t osimage -o bogus_image'
 check:rc==0
-cmd: ssh  $$DSTMN 'lsdef -t osimage -o bogus_image -z |sort -t'=' -k1|tee /tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/dst_bogus_image.stanza'
+cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'lsdef -t osimage -o bogus_image -z |sort -t'=' -k1|tee /tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/dst_bogus_image.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/dst_bogus_image.stanza /tmp/export_single_osimage_then_modify_json_then_import/dst_bogus_image.stanza
 check:rc==0
 cmd: cat /tmp/export_single_osimage_then_modify_json_then_import/dst_bogus_image.stanza
 check:rc==0
-cmd:diff -y /tmp/export_single_osimage_then_modify_json_then_import/src_bogus_osimage.stanza /tmp/export_single_osimage_then_modify_json_then_import/dst_bogus_image.stanza -I "environvar=OBJNAME=bogus_image"
+cmd:diff -y /tmp/export_single_osimage_then_modify_json_then_import/src_bogus_osimage.stanza /tmp/export_single_osimage_then_modify_json_then_import/dst_bogus_image.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'rmdef -t osimage -o bogus_image'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'rmdef -t osimage -o bogus_image'
 check:rc==0
 cmd:if [[ -e /tmp/export_single_osimage_then_modify_json_then_import/bogus_image.stanza ]]; then cat /tmp/export_single_osimage_then_modify_json_then_import/bogus_image.stanza | mkdef -z;fi
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/bogus_image.stanza ]]; then cat /tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/bogus_image.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/bogus_image.stanza ]]; then cat /tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/bogus_image.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'rm -rf /tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_single_osimage_then_modify_json_then_import_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_single_osimage_then_modify_json_then_import
 check:rc==0
@@ -870,11 +870,11 @@ label:others,xcat_inventory
 description:This case is used to test xcat-inventory import a osimage , then modify the export yaml file, then import the yaml file
 cmd:mkdir -p /tmp/export_single_osimage_then_modify_yaml_then_import
 check:rc==0
-cmd:ssh $$DSTMN 'mkdir -p /tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/'
 check:rc==0
 cmd:lsdef -t osimage -o bogus_image >/dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t osimage -o bogus_image -z >/tmp/export_single_osimage_then_modify_yaml_then_import/bogus_image.stanza ;rmdef -t osimage -o bogus_image;fi
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t osimage -o  bogus_image > /dev/null 2>&1; if [[ $? -eq 0 ]]; then lsdef -t osimage -o bogus_image -z >/tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/bogus_image.stanza ;rmdef -t osimage -o bogus_image;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t osimage -o  bogus_image > /dev/null 2>&1; if [[ $? -eq 0 ]]; then lsdef -t osimage -o bogus_image -z >/tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/bogus_image.stanza ;rmdef -t osimage -o bogus_image;fi'
 check:rc==0
 cmd:chdef -t osimage -o bogus_image addkcmdline=1111 boottarget=1111 cfmdir=1111 crashkernelsize=1111 description=1111 driverupdatesrc=1111 dump=1111 exlist=1111 groups=1111 imagename=1111 imagetype=linux isdeletable=1111 kerneldir=1111 kernelver=1111 kitcomponents=1111 krpmver=1111 netdrivers=1111 nodebootif=1111 osarch=1111 osdistroname=1111 osname=1111 osupdatename=1111 osvers=1111 otherifce=1111 otherpkgdir=1111 otherpkglist=1111 partitionfile=1111 permission=1111 pkgdir=1111 pkglist=1111 postbootscripts=1111 postinstall=1111 postscripts=1111 profile=compute provmethod=statelite rootfstype=nfs rootimgdir=1111 serverrole=1111 synclists=1111 template=1111 usercomment=1111
 check:rc==0
@@ -900,23 +900,23 @@ cmd:scp /tmp/export_single_osimage_then_modify_yaml_then_import/bogus_image.yaml
 check:rc==0
 cmd: rmdef -t osimage -o  bogus_image
 check:rc==0
-cmd: ssh  $$DSTMN 'xcat-inventory import -f /tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/bogus_image.yaml -t osimage -o bogus_image'
+cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'xcat-inventory import -f /tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/bogus_image.yaml -t osimage -o bogus_image'
 check:rc==0
-cmd: ssh  $$DSTMN 'lsdef -t osimage -o bogus_image -z |sort -t'=' -k1|tee /tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/dst_bogus_image.stanza'
+cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'lsdef -t osimage -o bogus_image -z |sort -t'=' -k1|tee /tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/dst_bogus_image.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/dst_bogus_image.stanza /tmp/export_single_osimage_then_modify_yaml_then_import/dst_bogus_image.stanza
 check:rc==0
 cmd: cat /tmp/export_single_osimage_then_modify_yaml_then_import/dst_bogus_image.stanza
 check:rc==0
-cmd:diff -y /tmp/export_single_osimage_then_modify_yaml_then_import/src_bogus_osimage.stanza /tmp/export_single_osimage_then_modify_yaml_then_import/dst_bogus_image.stanza -I "environvar=OBJNAME=bogus_image"
+cmd:diff -y /tmp/export_single_osimage_then_modify_yaml_then_import/src_bogus_osimage.stanza /tmp/export_single_osimage_then_modify_yaml_then_import/dst_bogus_image.stanza
 check:rc==0
-cmd:ssh  $$DSTMN 'rmdef -t osimage -o bogus_image'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'rmdef -t osimage -o bogus_image'
 check:rc==0
 cmd:if [[ -e /tmp/export_single_osimage_then_modify_yaml_then_import/bogus_image.stanza ]]; then cat /tmp/export_single_osimage_then_modify_yaml_then_import/bogus_image.stanza | mkdef -z;fi
 check:rc==0
-cmd:ssh $$DSTMN 'if [[ -e /tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/bogus_image.stanza ]]; then cat /tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/bogus_image.stanza | mkdef -z;fi'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'if [[ -e /tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/bogus_image.stanza ]]; then cat /tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/bogus_image.stanza | mkdef -z;fi'
 check:rc==0
-cmd:ssh $$DSTMN 'rm -rf /tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_single_osimage_then_modify_yaml_then_import_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_single_osimage_then_modify_yaml_then_import
 check:rc==0
@@ -1208,8 +1208,12 @@ check:rc==0
 cmd:rm -rf /tmp/otherpkglist /tmp/synclists /tmp/postinstall /tmp/exlist /tmp/pkglist /tmp/template /tmp/partitionfile
 cmd:xcat-inventory import -t osimage -d /opt/inventory/site
 check:rc==0
+check:output=~Importing object: test_myimage1
 check:output=~Inventory import successfully!
+check:output=~The object test_myimage1 has been imported
+check:output=~Importing object: test_myimage2
 check:output=~Inventory import successfully!
+check:output=~The object test_myimage2 has been imported
 cmd:lsdef -t osimage -o test_myimage1,test_myimage2
 check:rc==0
 cmd:otherpkglist=`lsdef -t osimage -o test_myimage1 |grep otherpkglist|awk -F= '{print $2}'`;diff -y $otherpkglist /opt/inventory/site/osimage/test_myimage1$otherpkglist
@@ -1244,6 +1248,7 @@ cmd: rmdef -t osimage -o  test_myimage1,test_myimage2
 check:rc==0
 cmd: if [ -e /tmp/test_myimage1.stanza ]; then cat /tmp/test_myimage1.stanza |mkdef -z;fi
 cmd: if [ -e /tmp/test_myimage2.stanza ]; then cat /tmp/test_myimage2.stanza |mkdef -z;fi
+cmd:dir="/opt/inventory/site/osimage"; rm -rf $dir; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi
 cmd:dir="/opt/inventory/site/osimage"; rm -rf $dir; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi
 cmd:file="/tmp/otherpkglist"; rm -rf $file; if [ -d ${file}".bak" ];then mv ${file}".bak" $file; fi
 cmd:file="/tmp/synclists"; rm -rf $file; if [ -d ${file}".bak" ];then mv ${file}".bak" $file; fi
@@ -1280,8 +1285,10 @@ check:output=~The osimage objects has been exported to directory /tmp/export
 cmd:ls -lFR /tmp/export
 cmd: xcat-inventory import -t osimage -d /tmp/export -c
 check:rc==0
+check:output=~Importing object: test_myimage1
 check:output=~Inventory import successfully!
 check:output=~The object test_myimage1 has been imported
+check:output=~Importing object: test_myimage2
 check:output=~Inventory import successfully!
 check:output=~The object test_myimage2 has been imported
 cmd:lsdef -t osimage -o test_myimage1,test_myimage2

--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.site
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.site
@@ -4,11 +4,11 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_site_by_yaml
 check:rc==0
-cmd:ssh $$DSTMN 'mkdir -p /tmp/export_import_site_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_site_by_yaml_$$DSTMN/'
 check:rc==0
 cmd: lsdef -t site -o clustersite -z >/tmp/export_import_site_by_yaml/site.stanza
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t site -o clustersite -z >/tmp/export_import_site_by_yaml_$$DSTMN/site.stanza '
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t site -o clustersite -z >/tmp/export_import_site_by_yaml_$$DSTMN/site.stanza '
 check:rc==0
 cmd:mnip=$(lsdef -t site -o clustersite -i master -c|awk -F'=' '{print $2}');chdef -t site -o clustersite  useSSHonAIX=0 useNFSv4onAIX=0 FQDNfirst=1 SNsyncfiledir='/var/xcat/syncfiles' auditnosyslog=0 auditskipcmds=ALL blademaxp=64 cleanupxcatpost=no consoleondemand=no databaseloc='/var/lib' db2installloc='/mntdb2' dbtracelevel=0 defserialflow=0 defserialport=0 defserialspeed=9600 dhcpinterfaces=eth0 dhcplease=43200 dhcpsetup=n disjointdhcps=1 dnshandler=ddns dnsinterfaces='xcatmn|eth1,eth2;service|bond0' dnsupdaters=dnsupdaters domain='pok.stglabs.ibm.com' enableASMI=no excludenodes=excludenodes externaldns=externaldns extntpservers=extntpservers forwarders=$mnip fsptimeout=0 genmacprefix='00:11:aa' genpasswords=genpasswords hierarchicalattrs=hierarchicalattrs httpport=80 hwctrldispatch=y installdir='/install/' installloc='hostname:/path' ipmidispatch=y ipmimaxp=64 ipmiretries=3 ipmisdrcache=no ipmitimeout=2 iscsidir='/iscsidir' managedaddressmode=dhcp master=$mnip maxssh=8 mnroutenames=mnroutenames nameservers=$mnip nmapoptions='--min-rtt-timeout' nodestatus=n nodesyncfiledir='/var/xcat/node/syncfiles' ntpservers=$mnip persistkvmguests=y powerinterval=0 ppcmaxp=64 ppcretry=3 ppctimeout=0 precreatemypostscripts=1 pruneservices=1 runbootscripts=yes setinstallnic=1 sharedinstall=no sharedtftp=1 skiptables=nics skipvalidatelog=1 snmpc=snmpc sshbetweennodes=ALLGROUPS svloglocal=1 syspowerinterval=10 syspowermaxnodes=10 tftpdir='/tftprot/' tftpflags='-v' timezone='America/New_York' useNmapfromMN=no useflowcontrol=no usexhrm=no vcenterautojoin=no vmwarereconfigonpower=no vsftp=n xcatconfdir='/etc/xcat' xcatdebugmode=1 xcatdport=3001 xcatiport=3002 xcatlport=3003 xcatmaxbatchconnections=64 xcatmaxconnections=60 xcatsslciphers='3DES' xcatsslversion=TLSv1
 check:rc==0
@@ -22,9 +22,9 @@ cmd:cat /tmp/export_import_site_by_yaml/export_site_yaml.inv
 check:rc==0
 cmd:scp /tmp/export_import_site_by_yaml/export_site_yaml.inv $$DSTMN:/tmp/export_import_site_by_yaml_$$DSTMN/
 check:rc==0
-cmd: ssh  $$DSTMN 'xcat-inventory import -f /tmp/export_import_site_by_yaml_$$DSTMN/export_site_yaml.inv -t site -o clustersite'
+cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'xcat-inventory import -f /tmp/export_import_site_by_yaml_$$DSTMN/export_site_yaml.inv -t site -o clustersite'
 check:rc==0
-cmd: ssh  $$DSTMN 'lsdef  -t site -o clustersite  -z |sort -t'=' -k1|tee /tmp/export_import_site_by_yaml_$$DSTMN/dstsite.stanza'
+cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'lsdef  -t site -o clustersite  -z |sort -t'=' -k1|tee /tmp/export_import_site_by_yaml_$$DSTMN/dstsite.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_site_by_yaml_$$DSTMN/dstsite.stanza /tmp/export_import_site_by_yaml/dstsite.stanza
 check:rc==0
@@ -36,9 +36,9 @@ cmd:diff -y --ignore-blank-lines  /tmp/export_import_site_by_yaml/srcsite.stanza
 check:rc==0
 cmd:cat /tmp/export_import_site_by_yaml/site.stanza | mkdef -z -f
 check:rc==0
-cmd:ssh $$DSTMN 'cat /tmp/export_import_site_by_yaml_$$DSTMN/site.stanza | mkdef -z -f'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'cat /tmp/export_import_site_by_yaml_$$DSTMN/site.stanza | mkdef -z -f'
 check:rc==0
-cmd:ssh $$DSTMN 'rm -rf /tmp/export_import_site_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_site_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_site_by_yaml
 check:rc==0
@@ -51,11 +51,11 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_site_by_json
 check:rc==0
-cmd:ssh $$DSTMN 'mkdir -p /tmp/export_import_site_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_site_by_json_$$DSTMN/'
 check:rc==0
 cmd: lsdef -t site -o clustersite -z >/tmp/export_import_site_by_json/site.stanza
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t site -o clustersite -z >/tmp/export_import_site_by_json_$$DSTMN/site.stanza '
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t site -o clustersite -z >/tmp/export_import_site_by_json_$$DSTMN/site.stanza '
 check:rc==0
 cmd:mnip=$(lsdef -t site -o clustersite -i master -c|awk -F'=' '{print $2}');chdef -t site -o clustersite  useSSHonAIX=0 useNFSv4onAIX=0 FQDNfirst=1 SNsyncfiledir='/var/xcat/syncfiles' auditnosyslog=0 auditskipcmds=ALL blademaxp=64 cleanupxcatpost=no consoleondemand=no databaseloc='/var/lib' db2installloc='/mntdb2' dbtracelevel=0 defserialflow=0 defserialport=0 defserialspeed=9600 dhcpinterfaces=eth0 dhcplease=43200 dhcpsetup=n disjointdhcps=1 dnshandler=ddns dnsinterfaces='xcatmn|eth1,eth2;service|bond0' dnsupdaters=dnsupdaters domain='pok.stglabs.ibm.com' enableASMI=no excludenodes=excludenodes externaldns=externaldns extntpservers=extntpservers forwarders=$mnip fsptimeout=0 genmacprefix='00:11:aa' genpasswords=genpasswords hierarchicalattrs=hierarchicalattrs httpport=80 hwctrldispatch=y installdir='/install/' installloc='hostname:/path' ipmidispatch=y ipmimaxp=64 ipmiretries=3 ipmisdrcache=no ipmitimeout=2 iscsidir='/iscsidir' managedaddressmode=dhcp master=$mnip maxssh=8 mnroutenames=mnroutenames nameservers=$mnip nmapoptions='--min-rtt-timeout' nodestatus=n nodesyncfiledir='/var/xcat/node/syncfiles' ntpservers=$mnip persistkvmguests=y powerinterval=0 ppcmaxp=64 ppcretry=3 ppctimeout=0 precreatemypostscripts=1 pruneservices=1 runbootscripts=yes setinstallnic=1 sharedinstall=no sharedtftp=1 skiptables=nics skipvalidatelog=1 snmpc=snmpc sshbetweennodes=ALLGROUPS svloglocal=1 syspowerinterval=10 syspowermaxnodes=10 tftpdir='/tftprot/' tftpflags='-v' timezone='America/New_York' useNmapfromMN=no useflowcontrol=no usexhrm=no vcenterautojoin=no vmwarereconfigonpower=no vsftp=n xcatconfdir='/etc/xcat' xcatdebugmode=1 xcatdport=3001 xcatiport=3002 xcatlport=3003 xcatmaxbatchconnections=64 xcatmaxconnections=60 xcatsslciphers='3DES' xcatsslversion=TLSv1
 check:rc==0
@@ -69,9 +69,9 @@ cmd:cat /tmp/export_import_site_by_json/export_site_json.inv
 check:rc==0
 cmd:scp /tmp/export_import_site_by_json/export_site_json.inv $$DSTMN:/tmp/export_import_site_by_json_$$DSTMN/
 check:rc==0
-cmd: ssh  $$DSTMN 'xcat-inventory import -f /tmp/export_import_site_by_json_$$DSTMN/export_site_json.inv -t site -o clustersite'
+cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'xcat-inventory import -f /tmp/export_import_site_by_json_$$DSTMN/export_site_json.inv -t site -o clustersite'
 check:rc==0
-cmd: ssh  $$DSTMN 'lsdef  -t site -o clustersite  -z |sort -t'=' -k1|tee /tmp/export_import_site_by_json_$$DSTMN/dstsite.stanza'
+cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'lsdef  -t site -o clustersite  -z |sort -t'=' -k1|tee /tmp/export_import_site_by_json_$$DSTMN/dstsite.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_site_by_json_$$DSTMN/dstsite.stanza /tmp/export_import_site_by_json/dstsite.stanza
 check:rc==0
@@ -83,9 +83,9 @@ cmd:diff -y --ignore-blank-lines  /tmp/export_import_site_by_json/srcsite.stanza
 check:rc==0
 cmd:cat /tmp/export_import_site_by_json/site.stanza | mkdef -z -f
 check:rc==0
-cmd:ssh $$DSTMN 'cat /tmp/export_import_site_by_json_$$DSTMN/site.stanza | mkdef -z -f'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'cat /tmp/export_import_site_by_json_$$DSTMN/site.stanza | mkdef -z -f'
 check:rc==0
-cmd:ssh $$DSTMN 'rm -rf /tmp/export_import_site_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_site_by_json_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_site_by_json
 check:rc==0
@@ -1245,11 +1245,11 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_site_table_then_modify_yaml_then_import
 check:rc==0
-cmd:ssh $$DSTMN 'mkdir -p /tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/'
 check:rc==0
 cmd: lsdef -t site -o clustersite -z >/tmp/export_site_table_then_modify_yaml_then_import/site.stanza
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t site -o clustersite -z >/tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/site.stanza '
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t site -o clustersite -z >/tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/site.stanza '
 check:rc==0
 cmd:mnip=$(lsdef -t site -o clustersite -i master -c|awk -F'=' '{print $2}');chdef -t site -o clustersite  useSSHonAIX=1111 useNFSv4onAIX=1111 FQDNfirst=1111 SNsyncfiledir='/var/xcat/1111' auditnosyslog=1111 auditskipcmds=ALL blademaxp=641111 cleanupxcatpost=1111 consoleondemand=1111 databaseloc='/var/lib1111' db2installloc='/mntdb1111' dbtracelevel=0 defserialflow=1111 defserialport=1111 defserialspeed=9611111111 dhcpinterfaces=eth1111 dhcplease=43211111111 dhcpsetup=1111 disjointdhcps=0 dnshandler=ddns1111 dnsinterfaces='xcatmn|eth1,eth2;service|bond1111' dnsupdaters=dnsupdaters1111 domain='pok1111.stglabs.ibm.com' enableASMI=1111 excludenodes=1111 externaldns=1111 extntpservers=1111 forwarders=$mnip fsptimeout=1111 genmacprefix='11111111:11:aa' genpasswords=1111 hierarchicalattrs=1111 httpport=81111 hwctrldispatch=1111 installdir='/install1111/' installloc='hostname:/path1111' ipmidispatch=1111 ipmimaxp=641111 ipmiretries=31111 ipmisdrcache=1111 ipmitimeout=21111 iscsidir='/iscsidir1111' managedaddressmode=dhcp master=$mnip maxssh=81111 mnroutenames=1111 nameservers=$mnip nmapoptions='--min-rtt-timeout 1111' nodestatus=n nodesyncfiledir='/var/xcat/node/syncfiles1111' ntpservers=$mnip persistkvmguests=1111 powerinterval=1111 ppcmaxp=641111 ppcretry=31111 ppctimeout=1111 precreatemypostchdef -t site -o clustersite  useSSHonAIX=1111 useNFSv4onAIX=1111 FQDNfirst=1111 SNsyncfiledir='/var/xcat/1111' auditnosyslog=1111 auditskipcmds=ALL blademaxp=641111 pruneservices=1111 runbootscripts=1111 setinstallnic=1111 sharedinstall=no sharedtftp=1111 skiptables=nics1111 skipvalidatelog=1111 snmpc=xc1111 sshbetweennodes=ALLGROUPS svloglocal=1111 syspowerinterval=11111 syspowermaxnodes=11111 tftpdir='/tftprot1111/' tftpflags='-v1111' timezone='America/New_York1111' useNmapfromMN=1111 useflowcontrol=1111 usexhrm=1111 vcenterautojoin=1111 vmwarereconfigonpower=1111 vsftp=1111 xcatconfdir='/etc/xcat1111' xcatdebugmode=0 xcatdport=3001 xcatiport=3002 xcatlport=3003 xcatmaxbatchconnections=641111 xcatmaxconnections=61111 xcatsslciphers='3DES' xcatsslversion=TLSv1
 check:rc==0
@@ -1281,9 +1281,9 @@ cmd:cat /tmp/export_site_table_then_modify_yaml_then_import/export_site_yaml.inv
 check:rc==0
 cmd:scp /tmp/export_site_table_then_modify_yaml_then_import/export_site_yaml.inv $$DSTMN:/tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/
 check:rc==0
-cmd: ssh  $$DSTMN 'xcat-inventory import -f /tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/export_site_yaml.inv -t site -o clustersite'
+cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'xcat-inventory import -f /tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/export_site_yaml.inv -t site -o clustersite'
 check:rc==0
-cmd: ssh  $$DSTMN 'lsdef  -t site -o clustersite  -z |sort -t'=' -k1|tee /tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/dstsite.stanza'
+cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'lsdef  -t site -o clustersite  -z |sort -t'=' -k1|tee /tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/dstsite.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/dstsite.stanza /tmp/export_site_table_then_modify_yaml_then_import/dstsite.stanza
 check:rc==0
@@ -1295,9 +1295,9 @@ cmd:diff -y --ignore-blank-lines  /tmp/export_site_table_then_modify_yaml_then_i
 check:rc==0
 cmd:cat /tmp/export_site_table_then_modify_yaml_then_import/site.stanza | mkdef -z -f
 check:rc==0
-cmd:ssh $$DSTMN 'cat /tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/site.stanza | mkdef -z -f'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'cat /tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/site.stanza | mkdef -z -f'
 check:rc==0
-cmd:ssh $$DSTMN 'rm -rf /tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_site_table_then_modify_yaml_then_import
 check:rc==0
@@ -1309,11 +1309,11 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_site_table_then_modify_json_then_import
 check:rc==0
-cmd:ssh $$DSTMN 'mkdir -p /tmp/export_site_table_then_modify_json_then_import_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_site_table_then_modify_json_then_import_$$DSTMN/'
 check:rc==0
 cmd: lsdef -t site -o clustersite -z >/tmp/export_site_table_then_modify_json_then_import/site.stanza
 check:rc==0
-cmd:ssh $$DSTMN 'lsdef -t site -o clustersite -z >/tmp/export_site_table_then_modify_json_then_import_$$DSTMN/site.stanza '
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t site -o clustersite -z >/tmp/export_site_table_then_modify_json_then_import_$$DSTMN/site.stanza '
 check:rc==0
 cmd:mnip=$(lsdef -t site -o clustersite -i master -c|awk -F'=' '{print $2}');chdef -t site -o clustersite  useSSHonAIX=1111 useNFSv4onAIX=1111 FQDNfirst=1111 SNsyncfiledir='/var/xcat/1111' auditnosyslog=1111 auditskipcmds=ALL blademaxp=641111 cleanupxcatpost=1111 consoleondemand=1111 databaseloc='/var/lib1111' db2installloc='/mntdb1111' dbtracelevel=0 defserialflow=1111 defserialport=1111 defserialspeed=9611111111 dhcpinterfaces=eth1111 dhcplease=43211111111 dhcpsetup=1111 disjointdhcps=0 dnshandler=ddns1111 dnsinterfaces='xcatmn|eth1,eth2;service|bond1111' dnsupdaters=dnsupdaters1111 domain='pok1111.stglabs.ibm.com' enableASMI=1111 excludenodes=1111 externaldns=1111 extntpservers=1111 forwarders=$mnip fsptimeout=1111 genmacprefix='11111111:11:aa' genpasswords=1111 hierarchicalattrs=1111 httpport=81111 hwctrldispatch=1111 installdir='/install1111/' installloc='hostname:/path1111' ipmidispatch=1111 ipmimaxp=641111 ipmiretries=31111 ipmisdrcache=1111 ipmitimeout=21111 iscsidir='/iscsidir1111' managedaddressmode=dhcp master=$mnip maxssh=81111 mnroutenames=1111 nameservers=$mnip nmapoptions='--min-rtt-timeout 1111' nodestatus=n nodesyncfiledir='/var/xcat/node/syncfiles1111' ntpservers=$mnip persistkvmguests=1111 powerinterval=1111 ppcmaxp=641111 ppcretry=31111 ppctimeout=1111 precreatemypostchdef -t site -o clustersite  useSSHonAIX=1111 useNFSv4onAIX=1111 FQDNfirst=1111 SNsyncfiledir='/var/xcat/1111' auditnosyslog=1111 auditskipcmds=ALL blademaxp=641111 pruneservices=1111 runbootscripts=1111 setinstallnic=1111 sharedinstall=no sharedtftp=1111 skiptables=nics1111 skipvalidatelog=1111 snmpc=xc1111 sshbetweennodes=ALLGROUPS svloglocal=1111 syspowerinterval=11111 syspowermaxnodes=11111 tftpdir='/tftprot1111/' tftpflags='-v1111' timezone='America/New_York1111' useNmapfromMN=1111 useflowcontrol=1111 usexhrm=1111 vcenterautojoin=1111 vmwarereconfigonpower=1111 vsftp=1111 xcatconfdir='/etc/xcat1111' xcatdebugmode=0 xcatdport=3001 xcatiport=3002 xcatlport=3003 xcatmaxbatchconnections=641111 xcatmaxconnections=61111 xcatsslciphers='3DES' xcatsslversion=TLSv1
 check:rc==0
@@ -1345,9 +1345,9 @@ cmd:cat /tmp/export_site_table_then_modify_json_then_import/export_site_json.inv
 check:rc==0
 cmd:scp /tmp/export_site_table_then_modify_json_then_import/export_site_json.inv $$DSTMN:/tmp/export_site_table_then_modify_json_then_import_$$DSTMN/
 check:rc==0
-cmd: ssh  $$DSTMN 'xcat-inventory import -f /tmp/export_site_table_then_modify_json_then_import_$$DSTMN/export_site_json.inv -t site -o clustersite'
+cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_site_table_then_modify_json_then_import_$$DSTMN/export_site_json.inv -t site -o clustersite'
 check:rc==0
-cmd: ssh  $$DSTMN 'lsdef  -t site -o clustersite  -z |sort -t'=' -k1|tee /tmp/export_site_table_then_modify_json_then_import_$$DSTMN/dstsite.stanza'
+cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'lsdef  -t site -o clustersite  -z |sort -t'=' -k1|tee /tmp/export_site_table_then_modify_json_then_import_$$DSTMN/dstsite.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_site_table_then_modify_json_then_import_$$DSTMN/dstsite.stanza /tmp/export_site_table_then_modify_json_then_import/dstsite.stanza
 check:rc==0
@@ -1359,9 +1359,9 @@ cmd:diff -y --ignore-blank-lines  /tmp/export_site_table_then_modify_json_then_i
 check:rc==0
 cmd:cat /tmp/export_site_table_then_modify_json_then_import/site.stanza | mkdef -z -f
 check:rc==0
-cmd:ssh $$DSTMN 'cat /tmp/export_site_table_then_modify_json_then_import_$$DSTMN/site.stanza | mkdef -z -f'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'cat /tmp/export_site_table_then_modify_json_then_import_$$DSTMN/site.stanza | mkdef -z -f'
 check:rc==0
-cmd:ssh $$DSTMN 'rm -rf /tmp/export_site_table_then_modify_json_then_import_$$DSTMN/'
+cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_site_table_then_modify_json_then_import_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_site_table_then_modify_json_then_import
 check:rc==0

--- a/xCAT-test/autotest/testcase/xcat-inventory/cases.site
+++ b/xCAT-test/autotest/testcase/xcat-inventory/cases.site
@@ -4,11 +4,11 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_site_by_yaml
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_site_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_import_site_by_yaml_$$DSTMN/'
 check:rc==0
 cmd: lsdef -t site -o clustersite -z >/tmp/export_import_site_by_yaml/site.stanza
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t site -o clustersite -z >/tmp/export_import_site_by_yaml_$$DSTMN/site.stanza '
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t site -o clustersite -z >/tmp/export_import_site_by_yaml_$$DSTMN/site.stanza '
 check:rc==0
 cmd:mnip=$(lsdef -t site -o clustersite -i master -c|awk -F'=' '{print $2}');chdef -t site -o clustersite  useSSHonAIX=0 useNFSv4onAIX=0 FQDNfirst=1 SNsyncfiledir='/var/xcat/syncfiles' auditnosyslog=0 auditskipcmds=ALL blademaxp=64 cleanupxcatpost=no consoleondemand=no databaseloc='/var/lib' db2installloc='/mntdb2' dbtracelevel=0 defserialflow=0 defserialport=0 defserialspeed=9600 dhcpinterfaces=eth0 dhcplease=43200 dhcpsetup=n disjointdhcps=1 dnshandler=ddns dnsinterfaces='xcatmn|eth1,eth2;service|bond0' dnsupdaters=dnsupdaters domain='pok.stglabs.ibm.com' enableASMI=no excludenodes=excludenodes externaldns=externaldns extntpservers=extntpservers forwarders=$mnip fsptimeout=0 genmacprefix='00:11:aa' genpasswords=genpasswords hierarchicalattrs=hierarchicalattrs httpport=80 hwctrldispatch=y installdir='/install/' installloc='hostname:/path' ipmidispatch=y ipmimaxp=64 ipmiretries=3 ipmisdrcache=no ipmitimeout=2 iscsidir='/iscsidir' managedaddressmode=dhcp master=$mnip maxssh=8 mnroutenames=mnroutenames nameservers=$mnip nmapoptions='--min-rtt-timeout' nodestatus=n nodesyncfiledir='/var/xcat/node/syncfiles' ntpservers=$mnip persistkvmguests=y powerinterval=0 ppcmaxp=64 ppcretry=3 ppctimeout=0 precreatemypostscripts=1 pruneservices=1 runbootscripts=yes setinstallnic=1 sharedinstall=no sharedtftp=1 skiptables=nics skipvalidatelog=1 snmpc=snmpc sshbetweennodes=ALLGROUPS svloglocal=1 syspowerinterval=10 syspowermaxnodes=10 tftpdir='/tftprot/' tftpflags='-v' timezone='America/New_York' useNmapfromMN=no useflowcontrol=no usexhrm=no vcenterautojoin=no vmwarereconfigonpower=no vsftp=n xcatconfdir='/etc/xcat' xcatdebugmode=1 xcatdport=3001 xcatiport=3002 xcatlport=3003 xcatmaxbatchconnections=64 xcatmaxconnections=60 xcatsslciphers='3DES' xcatsslversion=TLSv1
 check:rc==0
@@ -22,9 +22,9 @@ cmd:cat /tmp/export_import_site_by_yaml/export_site_yaml.inv
 check:rc==0
 cmd:scp /tmp/export_import_site_by_yaml/export_site_yaml.inv $$DSTMN:/tmp/export_import_site_by_yaml_$$DSTMN/
 check:rc==0
-cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'xcat-inventory import -f /tmp/export_import_site_by_yaml_$$DSTMN/export_site_yaml.inv -t site -o clustersite'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_import_site_by_yaml_$$DSTMN/export_site_yaml.inv -t site -o clustersite'
 check:rc==0
-cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'lsdef  -t site -o clustersite  -z |sort -t'=' -k1|tee /tmp/export_import_site_by_yaml_$$DSTMN/dstsite.stanza'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef  -t site -o clustersite  -z |sort -t'=' -k1|tee /tmp/export_import_site_by_yaml_$$DSTMN/dstsite.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_site_by_yaml_$$DSTMN/dstsite.stanza /tmp/export_import_site_by_yaml/dstsite.stanza
 check:rc==0
@@ -36,9 +36,9 @@ cmd:diff -y --ignore-blank-lines  /tmp/export_import_site_by_yaml/srcsite.stanza
 check:rc==0
 cmd:cat /tmp/export_import_site_by_yaml/site.stanza | mkdef -z -f
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'cat /tmp/export_import_site_by_yaml_$$DSTMN/site.stanza | mkdef -z -f'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;cat /tmp/export_import_site_by_yaml_$$DSTMN/site.stanza | mkdef -z -f'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_site_by_yaml_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_import_site_by_yaml_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_site_by_yaml
 check:rc==0
@@ -51,11 +51,11 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_import_site_by_json
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_import_site_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_import_site_by_json_$$DSTMN/'
 check:rc==0
 cmd: lsdef -t site -o clustersite -z >/tmp/export_import_site_by_json/site.stanza
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t site -o clustersite -z >/tmp/export_import_site_by_json_$$DSTMN/site.stanza '
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t site -o clustersite -z >/tmp/export_import_site_by_json_$$DSTMN/site.stanza '
 check:rc==0
 cmd:mnip=$(lsdef -t site -o clustersite -i master -c|awk -F'=' '{print $2}');chdef -t site -o clustersite  useSSHonAIX=0 useNFSv4onAIX=0 FQDNfirst=1 SNsyncfiledir='/var/xcat/syncfiles' auditnosyslog=0 auditskipcmds=ALL blademaxp=64 cleanupxcatpost=no consoleondemand=no databaseloc='/var/lib' db2installloc='/mntdb2' dbtracelevel=0 defserialflow=0 defserialport=0 defserialspeed=9600 dhcpinterfaces=eth0 dhcplease=43200 dhcpsetup=n disjointdhcps=1 dnshandler=ddns dnsinterfaces='xcatmn|eth1,eth2;service|bond0' dnsupdaters=dnsupdaters domain='pok.stglabs.ibm.com' enableASMI=no excludenodes=excludenodes externaldns=externaldns extntpservers=extntpservers forwarders=$mnip fsptimeout=0 genmacprefix='00:11:aa' genpasswords=genpasswords hierarchicalattrs=hierarchicalattrs httpport=80 hwctrldispatch=y installdir='/install/' installloc='hostname:/path' ipmidispatch=y ipmimaxp=64 ipmiretries=3 ipmisdrcache=no ipmitimeout=2 iscsidir='/iscsidir' managedaddressmode=dhcp master=$mnip maxssh=8 mnroutenames=mnroutenames nameservers=$mnip nmapoptions='--min-rtt-timeout' nodestatus=n nodesyncfiledir='/var/xcat/node/syncfiles' ntpservers=$mnip persistkvmguests=y powerinterval=0 ppcmaxp=64 ppcretry=3 ppctimeout=0 precreatemypostscripts=1 pruneservices=1 runbootscripts=yes setinstallnic=1 sharedinstall=no sharedtftp=1 skiptables=nics skipvalidatelog=1 snmpc=snmpc sshbetweennodes=ALLGROUPS svloglocal=1 syspowerinterval=10 syspowermaxnodes=10 tftpdir='/tftprot/' tftpflags='-v' timezone='America/New_York' useNmapfromMN=no useflowcontrol=no usexhrm=no vcenterautojoin=no vmwarereconfigonpower=no vsftp=n xcatconfdir='/etc/xcat' xcatdebugmode=1 xcatdport=3001 xcatiport=3002 xcatlport=3003 xcatmaxbatchconnections=64 xcatmaxconnections=60 xcatsslciphers='3DES' xcatsslversion=TLSv1
 check:rc==0
@@ -69,9 +69,9 @@ cmd:cat /tmp/export_import_site_by_json/export_site_json.inv
 check:rc==0
 cmd:scp /tmp/export_import_site_by_json/export_site_json.inv $$DSTMN:/tmp/export_import_site_by_json_$$DSTMN/
 check:rc==0
-cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'xcat-inventory import -f /tmp/export_import_site_by_json_$$DSTMN/export_site_json.inv -t site -o clustersite'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_import_site_by_json_$$DSTMN/export_site_json.inv -t site -o clustersite'
 check:rc==0
-cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'lsdef  -t site -o clustersite  -z |sort -t'=' -k1|tee /tmp/export_import_site_by_json_$$DSTMN/dstsite.stanza'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef  -t site -o clustersite  -z |sort -t'=' -k1|tee /tmp/export_import_site_by_json_$$DSTMN/dstsite.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_import_site_by_json_$$DSTMN/dstsite.stanza /tmp/export_import_site_by_json/dstsite.stanza
 check:rc==0
@@ -83,9 +83,9 @@ cmd:diff -y --ignore-blank-lines  /tmp/export_import_site_by_json/srcsite.stanza
 check:rc==0
 cmd:cat /tmp/export_import_site_by_json/site.stanza | mkdef -z -f
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'cat /tmp/export_import_site_by_json_$$DSTMN/site.stanza | mkdef -z -f'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;cat /tmp/export_import_site_by_json_$$DSTMN/site.stanza | mkdef -z -f'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_import_site_by_json_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_import_site_by_json_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_import_site_by_json
 check:rc==0
@@ -1245,11 +1245,11 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_site_table_then_modify_yaml_then_import
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/'
 check:rc==0
 cmd: lsdef -t site -o clustersite -z >/tmp/export_site_table_then_modify_yaml_then_import/site.stanza
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t site -o clustersite -z >/tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/site.stanza '
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t site -o clustersite -z >/tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/site.stanza '
 check:rc==0
 cmd:mnip=$(lsdef -t site -o clustersite -i master -c|awk -F'=' '{print $2}');chdef -t site -o clustersite  useSSHonAIX=1111 useNFSv4onAIX=1111 FQDNfirst=1111 SNsyncfiledir='/var/xcat/1111' auditnosyslog=1111 auditskipcmds=ALL blademaxp=641111 cleanupxcatpost=1111 consoleondemand=1111 databaseloc='/var/lib1111' db2installloc='/mntdb1111' dbtracelevel=0 defserialflow=1111 defserialport=1111 defserialspeed=9611111111 dhcpinterfaces=eth1111 dhcplease=43211111111 dhcpsetup=1111 disjointdhcps=0 dnshandler=ddns1111 dnsinterfaces='xcatmn|eth1,eth2;service|bond1111' dnsupdaters=dnsupdaters1111 domain='pok1111.stglabs.ibm.com' enableASMI=1111 excludenodes=1111 externaldns=1111 extntpservers=1111 forwarders=$mnip fsptimeout=1111 genmacprefix='11111111:11:aa' genpasswords=1111 hierarchicalattrs=1111 httpport=81111 hwctrldispatch=1111 installdir='/install1111/' installloc='hostname:/path1111' ipmidispatch=1111 ipmimaxp=641111 ipmiretries=31111 ipmisdrcache=1111 ipmitimeout=21111 iscsidir='/iscsidir1111' managedaddressmode=dhcp master=$mnip maxssh=81111 mnroutenames=1111 nameservers=$mnip nmapoptions='--min-rtt-timeout 1111' nodestatus=n nodesyncfiledir='/var/xcat/node/syncfiles1111' ntpservers=$mnip persistkvmguests=1111 powerinterval=1111 ppcmaxp=641111 ppcretry=31111 ppctimeout=1111 precreatemypostchdef -t site -o clustersite  useSSHonAIX=1111 useNFSv4onAIX=1111 FQDNfirst=1111 SNsyncfiledir='/var/xcat/1111' auditnosyslog=1111 auditskipcmds=ALL blademaxp=641111 pruneservices=1111 runbootscripts=1111 setinstallnic=1111 sharedinstall=no sharedtftp=1111 skiptables=nics1111 skipvalidatelog=1111 snmpc=xc1111 sshbetweennodes=ALLGROUPS svloglocal=1111 syspowerinterval=11111 syspowermaxnodes=11111 tftpdir='/tftprot1111/' tftpflags='-v1111' timezone='America/New_York1111' useNmapfromMN=1111 useflowcontrol=1111 usexhrm=1111 vcenterautojoin=1111 vmwarereconfigonpower=1111 vsftp=1111 xcatconfdir='/etc/xcat1111' xcatdebugmode=0 xcatdport=3001 xcatiport=3002 xcatlport=3003 xcatmaxbatchconnections=641111 xcatmaxconnections=61111 xcatsslciphers='3DES' xcatsslversion=TLSv1
 check:rc==0
@@ -1281,9 +1281,9 @@ cmd:cat /tmp/export_site_table_then_modify_yaml_then_import/export_site_yaml.inv
 check:rc==0
 cmd:scp /tmp/export_site_table_then_modify_yaml_then_import/export_site_yaml.inv $$DSTMN:/tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/
 check:rc==0
-cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'xcat-inventory import -f /tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/export_site_yaml.inv -t site -o clustersite'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/export_site_yaml.inv -t site -o clustersite'
 check:rc==0
-cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'lsdef  -t site -o clustersite  -z |sort -t'=' -k1|tee /tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/dstsite.stanza'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef  -t site -o clustersite  -z |sort -t'=' -k1|tee /tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/dstsite.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/dstsite.stanza /tmp/export_site_table_then_modify_yaml_then_import/dstsite.stanza
 check:rc==0
@@ -1295,9 +1295,9 @@ cmd:diff -y --ignore-blank-lines  /tmp/export_site_table_then_modify_yaml_then_i
 check:rc==0
 cmd:cat /tmp/export_site_table_then_modify_yaml_then_import/site.stanza | mkdef -z -f
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'cat /tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/site.stanza | mkdef -z -f'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;cat /tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/site.stanza | mkdef -z -f'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_site_table_then_modify_yaml_then_import_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_site_table_then_modify_yaml_then_import
 check:rc==0
@@ -1309,11 +1309,11 @@ Attribute: $$DSTMN - the ip of MN which is used to run import operation.
 label:others,xcat_inventory
 cmd:mkdir -p /tmp/export_site_table_then_modify_json_then_import
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'mkdir -p /tmp/export_site_table_then_modify_json_then_import_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_site_table_then_modify_json_then_import_$$DSTMN/'
 check:rc==0
 cmd: lsdef -t site -o clustersite -z >/tmp/export_site_table_then_modify_json_then_import/site.stanza
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'lsdef -t site -o clustersite -z >/tmp/export_site_table_then_modify_json_then_import_$$DSTMN/site.stanza '
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef -t site -o clustersite -z >/tmp/export_site_table_then_modify_json_then_import_$$DSTMN/site.stanza '
 check:rc==0
 cmd:mnip=$(lsdef -t site -o clustersite -i master -c|awk -F'=' '{print $2}');chdef -t site -o clustersite  useSSHonAIX=1111 useNFSv4onAIX=1111 FQDNfirst=1111 SNsyncfiledir='/var/xcat/1111' auditnosyslog=1111 auditskipcmds=ALL blademaxp=641111 cleanupxcatpost=1111 consoleondemand=1111 databaseloc='/var/lib1111' db2installloc='/mntdb1111' dbtracelevel=0 defserialflow=1111 defserialport=1111 defserialspeed=9611111111 dhcpinterfaces=eth1111 dhcplease=43211111111 dhcpsetup=1111 disjointdhcps=0 dnshandler=ddns1111 dnsinterfaces='xcatmn|eth1,eth2;service|bond1111' dnsupdaters=dnsupdaters1111 domain='pok1111.stglabs.ibm.com' enableASMI=1111 excludenodes=1111 externaldns=1111 extntpservers=1111 forwarders=$mnip fsptimeout=1111 genmacprefix='11111111:11:aa' genpasswords=1111 hierarchicalattrs=1111 httpport=81111 hwctrldispatch=1111 installdir='/install1111/' installloc='hostname:/path1111' ipmidispatch=1111 ipmimaxp=641111 ipmiretries=31111 ipmisdrcache=1111 ipmitimeout=21111 iscsidir='/iscsidir1111' managedaddressmode=dhcp master=$mnip maxssh=81111 mnroutenames=1111 nameservers=$mnip nmapoptions='--min-rtt-timeout 1111' nodestatus=n nodesyncfiledir='/var/xcat/node/syncfiles1111' ntpservers=$mnip persistkvmguests=1111 powerinterval=1111 ppcmaxp=641111 ppcretry=31111 ppctimeout=1111 precreatemypostchdef -t site -o clustersite  useSSHonAIX=1111 useNFSv4onAIX=1111 FQDNfirst=1111 SNsyncfiledir='/var/xcat/1111' auditnosyslog=1111 auditskipcmds=ALL blademaxp=641111 pruneservices=1111 runbootscripts=1111 setinstallnic=1111 sharedinstall=no sharedtftp=1111 skiptables=nics1111 skipvalidatelog=1111 snmpc=xc1111 sshbetweennodes=ALLGROUPS svloglocal=1111 syspowerinterval=11111 syspowermaxnodes=11111 tftpdir='/tftprot1111/' tftpflags='-v1111' timezone='America/New_York1111' useNmapfromMN=1111 useflowcontrol=1111 usexhrm=1111 vcenterautojoin=1111 vmwarereconfigonpower=1111 vsftp=1111 xcatconfdir='/etc/xcat1111' xcatdebugmode=0 xcatdport=3001 xcatiport=3002 xcatlport=3003 xcatmaxbatchconnections=641111 xcatmaxconnections=61111 xcatsslciphers='3DES' xcatsslversion=TLSv1
 check:rc==0
@@ -1345,9 +1345,9 @@ cmd:cat /tmp/export_site_table_then_modify_json_then_import/export_site_json.inv
 check:rc==0
 cmd:scp /tmp/export_site_table_then_modify_json_then_import/export_site_json.inv $$DSTMN:/tmp/export_site_table_then_modify_json_then_import_$$DSTMN/
 check:rc==0
-cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'xcat-inventory import -f /tmp/export_site_table_then_modify_json_then_import_$$DSTMN/export_site_json.inv -t site -o clustersite'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_site_table_then_modify_json_then_import_$$DSTMN/export_site_json.inv -t site -o clustersite'
 check:rc==0
-cmd: ssh $$DSTMN 'source /etc/profile.d/xcat.sh';'lsdef  -t site -o clustersite  -z |sort -t'=' -k1|tee /tmp/export_site_table_then_modify_json_then_import_$$DSTMN/dstsite.stanza'
+cmd: ssh  $$DSTMN ' source /etc/profile.d/xcat.sh;lsdef  -t site -o clustersite  -z |sort -t'=' -k1|tee /tmp/export_site_table_then_modify_json_then_import_$$DSTMN/dstsite.stanza'
 check:rc==0
 cmd: scp $$DSTMN:/tmp/export_site_table_then_modify_json_then_import_$$DSTMN/dstsite.stanza /tmp/export_site_table_then_modify_json_then_import/dstsite.stanza
 check:rc==0
@@ -1359,9 +1359,9 @@ cmd:diff -y --ignore-blank-lines  /tmp/export_site_table_then_modify_json_then_i
 check:rc==0
 cmd:cat /tmp/export_site_table_then_modify_json_then_import/site.stanza | mkdef -z -f
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'cat /tmp/export_site_table_then_modify_json_then_import_$$DSTMN/site.stanza | mkdef -z -f'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;cat /tmp/export_site_table_then_modify_json_then_import_$$DSTMN/site.stanza | mkdef -z -f'
 check:rc==0
-cmd:ssh $$DSTMN 'source /etc/profile.d/xcat.sh'; 'rm -rf /tmp/export_site_table_then_modify_json_then_import_$$DSTMN/'
+cmd:ssh $$DSTMN ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_site_table_then_modify_json_then_import_$$DSTMN/'
 check:rc==0
 cmd:rm -rf /tmp/export_site_table_then_modify_json_then_import
 check:rc==0


### PR DESCRIPTION
### The PR is to for task 397 https://github.com/xcat2/xcat2-task-management/issues/397

On ubuntu for commands could not found for xcat-inventory cases

UT on rhels
```
------START::export_import_site_by_yaml::Time:Mon Nov 19 00:54:55 2018------

RUN:mkdir -p /tmp/export_import_site_by_yaml [Mon Nov 19 00:54:55 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:ssh 10.3.1.13 ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_import_site_by_yaml_10.3.1.13/' [Mon Nov 19 00:54:55 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:lsdef -t site -o clustersite -z >/tmp/export_import_site_by_yaml/site.stanza [Mon Nov 19 00:54:55 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:ssh 10.3.1.13 ' source /etc/profile.d/xcat.sh;lsdef -t site -o clustersite -z >/tmp/export_import_site_by_yaml_10.3.1.13/site.stanza ' [Mon Nov 19 00:54:55 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:mnip=$(lsdef -t site -o clustersite -i master -c|awk -F'=' '{print $2}');chdef -t site -o clustersite  useSSHonAIX=0 useNFSv4onAIX=0 FQDNfirst=1 SNsyncfiledir='/var/xcat/syncfiles' auditnosyslog=0 auditskipcmds=ALL blademaxp=64 cleanupxcatpost=no consoleondemand=no databaseloc='/var/lib' db2installloc='/mntdb2' dbtracelevel=0 defserialflow=0 defserialport=0 defserialspeed=9600 dhcpinterfaces=eth0 dhcplease=43200 dhcpsetup=n disjointdhcps=1 dnshandler=ddns dnsinterfaces='xcatmn|eth1,eth2;service|bond0' dnsupdaters=dnsupdaters domain='pok.stglabs.ibm.com' enableASMI=no excludenodes=excludenodes externaldns=externaldns extntpservers=extntpservers forwarders=$mnip fsptimeout=0 genmacprefix='00:11:aa' genpasswords=genpasswords hierarchicalattrs=hierarchicalattrs httpport=80 hwctrldispatch=y installdir='/install/' installloc='hostname:/path' ipmidispatch=y ipmimaxp=64 ipmiretries=3 ipmisdrcache=no ipmitimeout=2 iscsidir='/iscsidir' managedaddressmode=dhcp master=$mnip maxssh=8 mnroutenames=mnroutenames nameservers=$mnip nmapoptions='--min-rtt-timeout' nodestatus=n nodesyncfiledir='/var/xcat/node/syncfiles' ntpservers=$mnip persistkvmguests=y powerinterval=0 ppcmaxp=64 ppcretry=3 ppctimeout=0 precreatemypostscripts=1 pruneservices=1 runbootscripts=yes setinstallnic=1 sharedinstall=no sharedtftp=1 skiptables=nics skipvalidatelog=1 snmpc=snmpc sshbetweennodes=ALLGROUPS svloglocal=1 syspowerinterval=10 syspowermaxnodes=10 tftpdir='/tftprot/' tftpflags='-v' timezone='America/New_York' useNmapfromMN=no useflowcontrol=no usexhrm=no vcenterautojoin=no vmwarereconfigonpower=no vsftp=n xcatconfdir='/etc/xcat' xcatdebugmode=1 xcatdport=3001 xcatiport=3002 xcatlport=3003 xcatmaxbatchconnections=64 xcatmaxconnections=60 xcatsslciphers='3DES' xcatsslversion=TLSv1 [Mon Nov 19 00:54:57 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:lsdef -t site -o clustersite -z|sort -t'=' -k1 |tee  /tmp/export_import_site_by_yaml/srcsite.stanza [Mon Nov 19 00:54:58 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

    FQDNfirst=1
    SNsyncfiledir=/var/xcat/syncfiles
    auditnosyslog=0
    auditskipcmds=ALL
    blademaxp=64
    cleanupxcatpost=no
    consoleondemand=no
    databaseloc=/var/lib
    db2installloc=/mntdb2
    dbtracelevel=0
    defserialflow=0
    defserialport=0
    defserialspeed=9600
    dhcpinterfaces=eth0
    dhcplease=43200
    dhcpsetup=n
    disjointdhcps=1
    dnshandler=ddns
    dnsinterfaces=xcatmn|eth1,eth2;service|bond0
    dnsupdaters=dnsupdaters
    domain=pok.stglabs.ibm.com
    enableASMI=no
    excludenodes=excludenodes
    externaldns=externaldns
    extntpservers=extntpservers
    forwarders=10.3.1.13
    fsptimeout=0
    genmacprefix=00:11:aa
    genpasswords=genpasswords
    hierarchicalattrs=hierarchicalattrs
    httpport=80
    hwctrldispatch=y
    installdir=/install/
    installloc=hostname:/path
    ipmidispatch=y
    ipmimaxp=64
    ipmiretries=3
    ipmisdrcache=no
    ipmitimeout=2
    iscsidir=/iscsidir
    managedaddressmode=dhcp
    master=10.3.1.13
    maxssh=8
    mnroutenames=mnroutenames
    nameservers=10.3.1.13
    nmapoptions=--min-rtt-timeout
    nodestatus=n
    nodesyncfiledir=/var/xcat/node/syncfiles
    ntpservers=10.3.1.13
    objtype=site
    persistkvmguests=y
    powerinterval=0
    ppcmaxp=64
    ppcretry=3
    ppctimeout=0
    precreatemypostscripts=1
    pruneservices=1
    runbootscripts=yes
    setinstallnic=1
    sharedinstall=no
    sharedtftp=1
    skiptables=nics
    skipvalidatelog=1
    snmpc=snmpc
    sshbetweennodes=ALLGROUPS
    svloglocal=1
    syspowerinterval=10
    syspowermaxnodes=10
    tftpdir=/tftprot/
    tftpflags=-v
    timezone=America/New_York
    useNFSv4onAIX=0
    useNmapfromMN=no
    useSSHonAIX=0
    useflowcontrol=no
    usexhrm=no
    vcenterautojoin=no
    vmwarereconfigonpower=no
    vsftp=n
    xcatconfdir=/etc/xcat
    xcatdebugmode=1
    xcatdport=3001
    xcatiport=3002
    xcatlport=3003
    xcatmaxbatchconnections=64
    xcatmaxconnections=60
    xcatsslciphers=3DES
    xcatsslversion=TLSv1
# <xCAT data object stanza file>
clustersite:
CHECK:rc == 0	[Pass]

RUN:xcat-inventory export --format=yaml -t site -o clustersite |tee /tmp/export_import_site_by_yaml/export_site_yaml.inv [Mon Nov 19 00:54:58 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
schema_version: '2.0'
site:
  clustersite:
    FQDNfirst: '1'
    SNsyncfiledir: /var/xcat/syncfiles
    auditnosyslog: '0'
    auditskipcmds: ALL
    blademaxp: '64'
    cleanupxcatpost: 'no'
    consoleondemand: 'no'
    databaseloc: /var/lib
    db2installloc: /mntdb2
    dbtracelevel: '0'
    defserialflow: '0'
    defserialport: '0'
    defserialspeed: '9600'
    dhcpinterfaces: eth0
    dhcplease: '43200'
    dhcpsetup: n
    disjointdhcps: '1'
    dnshandler: ddns
    dnsinterfaces: xcatmn|eth1,eth2;service|bond0
    dnsupdaters: dnsupdaters
    domain: pok.stglabs.ibm.com
    enableASMI: 'no'
    excludenodes: excludenodes
    externaldns: externaldns
    extntpservers: extntpservers
    forwarders: 10.3.1.13
    fsptimeout: '0'
    genmacprefix: 00:11:aa
    genpasswords: genpasswords
    hierarchicalattrs: hierarchicalattrs
    httpport: '80'
    hwctrldispatch: y
    installdir: /install/
    installloc: hostname:/path
    ipmidispatch: y
    ipmimaxp: '64'
    ipmiretries: '3'
    ipmisdrcache: 'no'
    ipmitimeout: '2'
    iscsidir: /iscsidir
    managedaddressmode: dhcp
    master: 10.3.1.13
    maxssh: '8'
    mnroutenames: mnroutenames
    nameservers: 10.3.1.13
    nmapoptions: --min-rtt-timeout
    nodestatus: n
    nodesyncfiledir: /var/xcat/node/syncfiles
    ntpservers: 10.3.1.13
    persistkvmguests: y
    powerinterval: '0'
    ppcmaxp: '64'
    ppcretry: '3'
    ppctimeout: '0'
    precreatemypostscripts: '1'
    pruneservices: '1'
    runbootscripts: 'yes'
    setinstallnic: '1'
    sharedinstall: 'no'
    sharedtftp: '1'
    skiptables: nics
    skipvalidatelog: '1'
    snmpc: snmpc
    sshbetweennodes: ALLGROUPS
    svloglocal: '1'
    syspowerinterval: '10'
    syspowermaxnodes: '10'
    tftpdir: /tftprot/
    tftpflags: -v
    timezone: America/New_York
    useNFSv4onAIX: '0'
    useNmapfromMN: 'no'
    useSSHonAIX: '0'
    useflowcontrol: 'no'
    usexhrm: 'no'
    vcenterautojoin: 'no'
    vmwarereconfigonpower: 'no'
    vsftp: n
    xcatconfdir: /etc/xcat
    xcatdebugmode: '1'
    xcatdport: '3001'
    xcatiport: '3002'
    xcatlport: '3003'
    xcatmaxbatchconnections: '64'
    xcatmaxconnections: '60'
    xcatsslciphers: 3DES
    xcatsslversion: TLSv1

#Version 2.14.5 (git commit 4042193c2100b874d58c9e85c7d35ad9bbd8f135, built Mon Nov  5 06:16:43 EST 2018)
CHECK:rc == 0	[Pass]

RUN:mnip=$(lsdef -t site -o clustersite -i master -c|awk -F'=' '{print $2}');sed -i "s/$mnip/10.3.1.13/g" /tmp/export_import_site_by_yaml/export_site_yaml.inv [Mon Nov 19 00:54:59 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:cat /tmp/export_import_site_by_yaml/export_site_yaml.inv [Mon Nov 19 00:54:59 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
schema_version: '2.0'
site:
  clustersite:
    FQDNfirst: '1'
    SNsyncfiledir: /var/xcat/syncfiles
    auditnosyslog: '0'
    auditskipcmds: ALL
    blademaxp: '64'
    cleanupxcatpost: 'no'
    consoleondemand: 'no'
    databaseloc: /var/lib
    db2installloc: /mntdb2
    dbtracelevel: '0'
    defserialflow: '0'
    defserialport: '0'
    defserialspeed: '9600'
    dhcpinterfaces: eth0
    dhcplease: '43200'
    dhcpsetup: n
    disjointdhcps: '1'
    dnshandler: ddns
    dnsinterfaces: xcatmn|eth1,eth2;service|bond0
    dnsupdaters: dnsupdaters
    domain: pok.stglabs.ibm.com
    enableASMI: 'no'
    excludenodes: excludenodes
    externaldns: externaldns
    extntpservers: extntpservers
    forwarders: 10.3.1.13
    fsptimeout: '0'
    genmacprefix: 00:11:aa
    genpasswords: genpasswords
    hierarchicalattrs: hierarchicalattrs
    httpport: '80'
    hwctrldispatch: y
    installdir: /install/
    installloc: hostname:/path
    ipmidispatch: y
    ipmimaxp: '64'
    ipmiretries: '3'
    ipmisdrcache: 'no'
    ipmitimeout: '2'
    iscsidir: /iscsidir
    managedaddressmode: dhcp
    master: 10.3.1.13
    maxssh: '8'
    mnroutenames: mnroutenames
    nameservers: 10.3.1.13
    nmapoptions: --min-rtt-timeout
    nodestatus: n
    nodesyncfiledir: /var/xcat/node/syncfiles
    ntpservers: 10.3.1.13
    persistkvmguests: y
    powerinterval: '0'
    ppcmaxp: '64'
    ppcretry: '3'
    ppctimeout: '0'
    precreatemypostscripts: '1'
    pruneservices: '1'
    runbootscripts: 'yes'
    setinstallnic: '1'
    sharedinstall: 'no'
    sharedtftp: '1'
    skiptables: nics
    skipvalidatelog: '1'
    snmpc: snmpc
    sshbetweennodes: ALLGROUPS
    svloglocal: '1'
    syspowerinterval: '10'
    syspowermaxnodes: '10'
    tftpdir: /tftprot/
    tftpflags: -v
    timezone: America/New_York
    useNFSv4onAIX: '0'
    useNmapfromMN: 'no'
    useSSHonAIX: '0'
    useflowcontrol: 'no'
    usexhrm: 'no'
    vcenterautojoin: 'no'
    vmwarereconfigonpower: 'no'
    vsftp: n
    xcatconfdir: /etc/xcat
    xcatdebugmode: '1'
    xcatdport: '3001'
    xcatiport: '3002'
    xcatlport: '3003'
    xcatmaxbatchconnections: '64'
    xcatmaxconnections: '60'
    xcatsslciphers: 3DES
    xcatsslversion: TLSv1

#Version 2.14.5 (git commit 4042193c2100b874d58c9e85c7d35ad9bbd8f135, built Mon Nov  5 06:16:43 EST 2018)
CHECK:rc == 0	[Pass]

RUN:scp /tmp/export_import_site_by_yaml/export_site_yaml.inv 10.3.1.13:/tmp/export_import_site_by_yaml_10.3.1.13/ [Mon Nov 19 00:54:59 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:ssh  10.3.1.13 ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_import_site_by_yaml_10.3.1.13/export_site_yaml.inv -t site -o clustersite' [Mon Nov 19 00:54:59 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
loading inventory date in "/tmp/export_import_site_by_yaml_10.3.1.13/export_site_yaml.inv"
start to import "site" type objects
 preprocessing "site" type objects
 writting "site" type objects
Inventory import successfully!
CHECK:rc == 0	[Pass]

RUN:ssh  10.3.1.13 ' source /etc/profile.d/xcat.sh;lsdef  -t site -o clustersite  -z |sort -t'=' -k1|tee /tmp/export_import_site_by_yaml_10.3.1.13/dstsite.stanza' [Mon Nov 19 00:55:01 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:

    FQDNfirst=1
    SNsyncfiledir=/var/xcat/syncfiles
    auditnosyslog=0
    auditskipcmds=ALL
    blademaxp=64
    cleanupxcatpost=no
    consoleondemand=no
    databaseloc=/var/lib
    db2installloc=/mntdb2
    dbtracelevel=0
    defserialflow=0
    defserialport=0
    defserialspeed=9600
    dhcpinterfaces=eth0
    dhcplease=43200
    dhcpsetup=n
    disjointdhcps=1
    dnshandler=ddns
    dnsinterfaces=xcatmn|eth1,eth2;service|bond0
    dnsupdaters=dnsupdaters
    domain=pok.stglabs.ibm.com
    enableASMI=no
    excludenodes=excludenodes
    externaldns=externaldns
    extntpservers=extntpservers
    forwarders=10.3.1.13
    fsptimeout=0
    genmacprefix=00:11:aa
    genpasswords=genpasswords
    hierarchicalattrs=hierarchicalattrs
    httpport=80
    hwctrldispatch=y
    installdir=/install/
    installloc=hostname:/path
    ipmidispatch=y
    ipmimaxp=64
    ipmiretries=3
    ipmisdrcache=no
    ipmitimeout=2
    iscsidir=/iscsidir
    managedaddressmode=dhcp
    master=10.3.1.13
    maxssh=8
    mnroutenames=mnroutenames
    nameservers=10.3.1.13
    nmapoptions=--min-rtt-timeout
    nodestatus=n
    nodesyncfiledir=/var/xcat/node/syncfiles
    ntpservers=10.3.1.13
    objtype=site
    persistkvmguests=y
    powerinterval=0
    ppcmaxp=64
    ppcretry=3
    ppctimeout=0
    precreatemypostscripts=1
    pruneservices=1
    runbootscripts=yes
    setinstallnic=1
    sharedinstall=no
    sharedtftp=1
    skiptables=nics
    skipvalidatelog=1
    snmpc=snmpc
    sshbetweennodes=ALLGROUPS
    svloglocal=1
    syspowerinterval=10
    syspowermaxnodes=10
    tftpdir=/tftprot/
    tftpflags=-v
    timezone=America/New_York
    useNFSv4onAIX=0
    useNmapfromMN=no
    useSSHonAIX=0
    useflowcontrol=no
    usexhrm=no
    vcenterautojoin=no
    vmwarereconfigonpower=no
    vsftp=n
    xcatconfdir=/etc/xcat
    xcatdebugmode=1
    xcatdport=3001
    xcatiport=3002
    xcatlport=3003
    xcatmaxbatchconnections=64
    xcatmaxconnections=60
    xcatsslciphers=3DES
    xcatsslversion=TLSv1
# <xCAT data object stanza file>
clustersite:
CHECK:rc == 0	[Pass]

RUN:scp 10.3.1.13:/tmp/export_import_site_by_yaml_10.3.1.13/dstsite.stanza /tmp/export_import_site_by_yaml/dstsite.stanza [Mon Nov 19 00:55:03 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:mnip=$(lsdef -t site -o clustersite -i master -c|awk -F'=' '{print $2}');sed -i "s/10.3.1.13/$mnip/g" /tmp/export_import_site_by_yaml/dstsite.stanza [Mon Nov 19 00:55:03 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:cat /tmp/export_import_site_by_yaml/dstsite.stanza [Mon Nov 19 00:55:03 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

    FQDNfirst=1
    SNsyncfiledir=/var/xcat/syncfiles
    auditnosyslog=0
    auditskipcmds=ALL
    blademaxp=64
    cleanupxcatpost=no
    consoleondemand=no
    databaseloc=/var/lib
    db2installloc=/mntdb2
    dbtracelevel=0
    defserialflow=0
    defserialport=0
    defserialspeed=9600
    dhcpinterfaces=eth0
    dhcplease=43200
    dhcpsetup=n
    disjointdhcps=1
    dnshandler=ddns
    dnsinterfaces=xcatmn|eth1,eth2;service|bond0
    dnsupdaters=dnsupdaters
    domain=pok.stglabs.ibm.com
    enableASMI=no
    excludenodes=excludenodes
    externaldns=externaldns
    extntpservers=extntpservers
    forwarders=10.3.1.13
    fsptimeout=0
    genmacprefix=00:11:aa
    genpasswords=genpasswords
    hierarchicalattrs=hierarchicalattrs
    httpport=80
    hwctrldispatch=y
    installdir=/install/
    installloc=hostname:/path
    ipmidispatch=y
    ipmimaxp=64
    ipmiretries=3
    ipmisdrcache=no
    ipmitimeout=2
    iscsidir=/iscsidir
    managedaddressmode=dhcp
    master=10.3.1.13
    maxssh=8
    mnroutenames=mnroutenames
    nameservers=10.3.1.13
    nmapoptions=--min-rtt-timeout
    nodestatus=n
    nodesyncfiledir=/var/xcat/node/syncfiles
    ntpservers=10.3.1.13
    objtype=site
    persistkvmguests=y
    powerinterval=0
    ppcmaxp=64
    ppcretry=3
    ppctimeout=0
    precreatemypostscripts=1
    pruneservices=1
    runbootscripts=yes
    setinstallnic=1
    sharedinstall=no
    sharedtftp=1
    skiptables=nics
    skipvalidatelog=1
    snmpc=snmpc
    sshbetweennodes=ALLGROUPS
    svloglocal=1
    syspowerinterval=10
    syspowermaxnodes=10
    tftpdir=/tftprot/
    tftpflags=-v
    timezone=America/New_York
    useNFSv4onAIX=0
    useNmapfromMN=no
    useSSHonAIX=0
    useflowcontrol=no
    usexhrm=no
    vcenterautojoin=no
    vmwarereconfigonpower=no
    vsftp=n
    xcatconfdir=/etc/xcat
    xcatdebugmode=1
    xcatdport=3001
    xcatiport=3002
    xcatlport=3003
    xcatmaxbatchconnections=64
    xcatmaxconnections=60
    xcatsslciphers=3DES
    xcatsslversion=TLSv1
# <xCAT data object stanza file>
clustersite:
CHECK:rc == 0	[Pass]

RUN:diff -y --ignore-blank-lines  /tmp/export_import_site_by_yaml/srcsite.stanza /tmp/export_import_site_by_yaml/dstsite.stanza [Mon Nov 19 00:55:03 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

    FQDNfirst=1							    FQDNfirst=1
    SNsyncfiledir=/var/xcat/syncfiles				    SNsyncfiledir=/var/xcat/syncfiles
    auditnosyslog=0						    auditnosyslog=0
    auditskipcmds=ALL						    auditskipcmds=ALL
    blademaxp=64						    blademaxp=64
    cleanupxcatpost=no						    cleanupxcatpost=no
    consoleondemand=no						    consoleondemand=no
    databaseloc=/var/lib					    databaseloc=/var/lib
    db2installloc=/mntdb2					    db2installloc=/mntdb2
    dbtracelevel=0						    dbtracelevel=0
    defserialflow=0						    defserialflow=0
    defserialport=0						    defserialport=0
    defserialspeed=9600						    defserialspeed=9600
    dhcpinterfaces=eth0						    dhcpinterfaces=eth0
    dhcplease=43200						    dhcplease=43200
    dhcpsetup=n							    dhcpsetup=n
    disjointdhcps=1						    disjointdhcps=1
    dnshandler=ddns						    dnshandler=ddns
    dnsinterfaces=xcatmn|eth1,eth2;service|bond0		    dnsinterfaces=xcatmn|eth1,eth2;service|bond0
    dnsupdaters=dnsupdaters					    dnsupdaters=dnsupdaters
    domain=pok.stglabs.ibm.com					    domain=pok.stglabs.ibm.com
    enableASMI=no						    enableASMI=no
    excludenodes=excludenodes					    excludenodes=excludenodes
    externaldns=externaldns					    externaldns=externaldns
    extntpservers=extntpservers					    extntpservers=extntpservers
    forwarders=10.3.1.13					    forwarders=10.3.1.13
    fsptimeout=0						    fsptimeout=0
    genmacprefix=00:11:aa					    genmacprefix=00:11:aa
    genpasswords=genpasswords					    genpasswords=genpasswords
    hierarchicalattrs=hierarchicalattrs				    hierarchicalattrs=hierarchicalattrs
    httpport=80							    httpport=80
    hwctrldispatch=y						    hwctrldispatch=y
    installdir=/install/					    installdir=/install/
    installloc=hostname:/path					    installloc=hostname:/path
    ipmidispatch=y						    ipmidispatch=y
    ipmimaxp=64							    ipmimaxp=64
    ipmiretries=3						    ipmiretries=3
    ipmisdrcache=no						    ipmisdrcache=no
    ipmitimeout=2						    ipmitimeout=2
    iscsidir=/iscsidir						    iscsidir=/iscsidir
    managedaddressmode=dhcp					    managedaddressmode=dhcp
    master=10.3.1.13						    master=10.3.1.13
    maxssh=8							    maxssh=8
    mnroutenames=mnroutenames					    mnroutenames=mnroutenames
    nameservers=10.3.1.13					    nameservers=10.3.1.13
    nmapoptions=--min-rtt-timeout				    nmapoptions=--min-rtt-timeout
    nodestatus=n						    nodestatus=n
    nodesyncfiledir=/var/xcat/node/syncfiles			    nodesyncfiledir=/var/xcat/node/syncfiles
    ntpservers=10.3.1.13					    ntpservers=10.3.1.13
    objtype=site						    objtype=site
    persistkvmguests=y						    persistkvmguests=y
    powerinterval=0						    powerinterval=0
    ppcmaxp=64							    ppcmaxp=64
    ppcretry=3							    ppcretry=3
    ppctimeout=0						    ppctimeout=0
    precreatemypostscripts=1					    precreatemypostscripts=1
    pruneservices=1						    pruneservices=1
    runbootscripts=yes						    runbootscripts=yes
    setinstallnic=1						    setinstallnic=1
    sharedinstall=no						    sharedinstall=no
    sharedtftp=1						    sharedtftp=1
    skiptables=nics						    skiptables=nics
    skipvalidatelog=1						    skipvalidatelog=1
    snmpc=snmpc							    snmpc=snmpc
    sshbetweennodes=ALLGROUPS					    sshbetweennodes=ALLGROUPS
    svloglocal=1						    svloglocal=1
    syspowerinterval=10						    syspowerinterval=10
    syspowermaxnodes=10						    syspowermaxnodes=10
    tftpdir=/tftprot/						    tftpdir=/tftprot/
    tftpflags=-v						    tftpflags=-v
    timezone=America/New_York					    timezone=America/New_York
    useNFSv4onAIX=0						    useNFSv4onAIX=0
    useNmapfromMN=no						    useNmapfromMN=no
    useSSHonAIX=0						    useSSHonAIX=0
    useflowcontrol=no						    useflowcontrol=no
    usexhrm=no							    usexhrm=no
    vcenterautojoin=no						    vcenterautojoin=no
    vmwarereconfigonpower=no					    vmwarereconfigonpower=no
    vsftp=n							    vsftp=n
    xcatconfdir=/etc/xcat					    xcatconfdir=/etc/xcat
    xcatdebugmode=1						    xcatdebugmode=1
    xcatdport=3001						    xcatdport=3001
    xcatiport=3002						    xcatiport=3002
    xcatlport=3003						    xcatlport=3003
    xcatmaxbatchconnections=64					    xcatmaxbatchconnections=64
    xcatmaxconnections=60					    xcatmaxconnections=60
    xcatsslciphers=3DES						    xcatsslciphers=3DES
    xcatsslversion=TLSv1					    xcatsslversion=TLSv1
# <xCAT data object stanza file>				# <xCAT data object stanza file>
clustersite:							clustersite:
CHECK:rc == 0	[Pass]

RUN:cat /tmp/export_import_site_by_yaml/site.stanza | mkdef -z -f [Mon Nov 19 00:55:03 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:ssh 10.3.1.13 ' source /etc/profile.d/xcat.sh;cat /tmp/export_import_site_by_yaml_10.3.1.13/site.stanza | mkdef -z -f' [Mon Nov 19 00:55:04 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:ssh 10.3.1.13 ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_import_site_by_yaml_10.3.1.13/' [Mon Nov 19 00:55:04 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:rm -rf /tmp/export_import_site_by_yaml [Mon Nov 19 00:55:04 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::export_import_site_by_yaml::Passed::Time:Mon Nov 19 00:55:04 2018 ::Duration::9 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished at Mon Nov 19 00:55:04 2018
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20181119005453 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20181119005453 file for time consumption
```

UT on ubuntu
```
------START::export_import_site_by_yaml::Time:Mon Nov 19 01:07:49 2018------

RUN:mkdir -p /tmp/export_import_site_by_yaml [Mon Nov 19 01:07:49 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:ssh 10.3.11.12 ' source /etc/profile.d/xcat.sh;mkdir -p /tmp/export_import_site_by_yaml_10.3.11.12/' [Mon Nov 19 01:07:49 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:lsdef -t site -o clustersite -z >/tmp/export_import_site_by_yaml/site.stanza [Mon Nov 19 01:07:49 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:ssh 10.3.11.12 ' source /etc/profile.d/xcat.sh;lsdef -t site -o clustersite -z >/tmp/export_import_site_by_yaml_10.3.11.12/site.stanza ' [Mon Nov 19 01:07:50 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:mnip=$(lsdef -t site -o clustersite -i master -c|awk -F'=' '{print $2}');chdef -t site -o clustersite  useSSHonAIX=0 useNFSv4onAIX=0 FQDNfirst=1 SNsyncfiledir='/var/xcat/syncfiles' auditnosyslog=0 auditskipcmds=ALL blademaxp=64 cleanupxcatpost=no consoleondemand=no databaseloc='/var/lib' db2installloc='/mntdb2' dbtracelevel=0 defserialflow=0 defserialport=0 defserialspeed=9600 dhcpinterfaces=eth0 dhcplease=43200 dhcpsetup=n disjointdhcps=1 dnshandler=ddns dnsinterfaces='xcatmn|eth1,eth2;service|bond0' dnsupdaters=dnsupdaters domain='pok.stglabs.ibm.com' enableASMI=no excludenodes=excludenodes externaldns=externaldns extntpservers=extntpservers forwarders=$mnip fsptimeout=0 genmacprefix='00:11:aa' genpasswords=genpasswords hierarchicalattrs=hierarchicalattrs httpport=80 hwctrldispatch=y installdir='/install/' installloc='hostname:/path' ipmidispatch=y ipmimaxp=64 ipmiretries=3 ipmisdrcache=no ipmitimeout=2 iscsidir='/iscsidir' managedaddressmode=dhcp master=$mnip maxssh=8 mnroutenames=mnroutenames nameservers=$mnip nmapoptions='--min-rtt-timeout' nodestatus=n nodesyncfiledir='/var/xcat/node/syncfiles' ntpservers=$mnip persistkvmguests=y powerinterval=0 ppcmaxp=64 ppcretry=3 ppctimeout=0 precreatemypostscripts=1 pruneservices=1 runbootscripts=yes setinstallnic=1 sharedinstall=no sharedtftp=1 skiptables=nics skipvalidatelog=1 snmpc=snmpc sshbetweennodes=ALLGROUPS svloglocal=1 syspowerinterval=10 syspowermaxnodes=10 tftpdir='/tftprot/' tftpflags='-v' timezone='America/New_York' useNmapfromMN=no useflowcontrol=no usexhrm=no vcenterautojoin=no vmwarereconfigonpower=no vsftp=n xcatconfdir='/etc/xcat' xcatdebugmode=1 xcatdport=3001 xcatiport=3002 xcatlport=3003 xcatmaxbatchconnections=64 xcatmaxconnections=60 xcatsslciphers='3DES' xcatsslversion=TLSv1 [Mon Nov 19 01:07:51 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:lsdef -t site -o clustersite -z|sort -t'=' -k1 |tee  /tmp/export_import_site_by_yaml/srcsite.stanza [Mon Nov 19 01:07:52 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

    FQDNfirst=1
    SNsyncfiledir=/var/xcat/syncfiles
    auditnosyslog=0
    auditskipcmds=ALL
    blademaxp=64
    cleanupxcatpost=no
    consoleondemand=no
    databaseloc=/var/lib
    db2installloc=/mntdb2
    dbtracelevel=0
    defserialflow=0
    defserialport=0
    defserialspeed=9600
    dhcpinterfaces=eth0
    dhcplease=43200
    dhcpsetup=n
    disjointdhcps=1
    dnshandler=ddns
    dnsinterfaces=xcatmn|eth1,eth2;service|bond0
    dnsupdaters=dnsupdaters
    domain=pok.stglabs.ibm.com
    enableASMI=no
    excludenodes=excludenodes
    externaldns=externaldns
    extntpservers=extntpservers
    forwarders=10.3.11.12
    fsptimeout=0
    genmacprefix=00:11:aa
    genpasswords=genpasswords
    hierarchicalattrs=hierarchicalattrs
    httpport=80
    hwctrldispatch=y
    installdir=/install/
    installloc=hostname:/path
    ipmidispatch=y
    ipmimaxp=64
    ipmiretries=3
    ipmisdrcache=no
    ipmitimeout=2
    iscsidir=/iscsidir
    managedaddressmode=dhcp
    master=10.3.11.12
    maxssh=8
    mnroutenames=mnroutenames
    nameservers=10.3.11.12
    nmapoptions=--min-rtt-timeout
    nodestatus=n
    nodesyncfiledir=/var/xcat/node/syncfiles
    ntpservers=10.3.11.12
    objtype=site
    persistkvmguests=y
    powerinterval=0
    ppcmaxp=64
    ppcretry=3
    ppctimeout=0
    precreatemypostscripts=1
    pruneservices=1
    runbootscripts=yes
    setinstallnic=1
    sharedinstall=no
    sharedtftp=1
    skiptables=nics
    skipvalidatelog=1
    snmpc=snmpc
    sshbetweennodes=ALLGROUPS
    svloglocal=1
    syspowerinterval=10
    syspowermaxnodes=10
    tftpdir=/tftprot/
    tftpflags=-v
    timezone=America/New_York
    useNFSv4onAIX=0
    useNmapfromMN=no
    useSSHonAIX=0
    useflowcontrol=no
    usexhrm=no
    vcenterautojoin=no
    vmwarereconfigonpower=no
    vsftp=n
    xcatconfdir=/etc/xcat
    xcatdebugmode=1
    xcatdport=3001
    xcatiport=3002
    xcatlport=3003
    xcatmaxbatchconnections=64
    xcatmaxconnections=60
    xcatsslciphers=3DES
    xcatsslversion=TLSv1
# <xCAT data object stanza file>
clustersite:
CHECK:rc == 0	[Pass]

RUN:xcat-inventory export --format=yaml -t site -o clustersite |tee /tmp/export_import_site_by_yaml/export_site_yaml.inv [Mon Nov 19 01:07:53 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
schema_version: '2.0'
site:
  clustersite:
    FQDNfirst: '1'
    SNsyncfiledir: /var/xcat/syncfiles
    auditnosyslog: '0'
    auditskipcmds: ALL
    blademaxp: '64'
    cleanupxcatpost: 'no'
    consoleondemand: 'no'
    databaseloc: /var/lib
    db2installloc: /mntdb2
    dbtracelevel: '0'
    defserialflow: '0'
    defserialport: '0'
    defserialspeed: '9600'
    dhcpinterfaces: eth0
    dhcplease: '43200'
    dhcpsetup: n
    disjointdhcps: '1'
    dnshandler: ddns
    dnsinterfaces: xcatmn|eth1,eth2;service|bond0
    dnsupdaters: dnsupdaters
    domain: pok.stglabs.ibm.com
    enableASMI: 'no'
    excludenodes: excludenodes
    externaldns: externaldns
    extntpservers: extntpservers
    forwarders: 10.3.11.12
    fsptimeout: '0'
    genmacprefix: 00:11:aa
    genpasswords: genpasswords
    hierarchicalattrs: hierarchicalattrs
    httpport: '80'
    hwctrldispatch: y
    installdir: /install/
    installloc: hostname:/path
    ipmidispatch: y
    ipmimaxp: '64'
    ipmiretries: '3'
    ipmisdrcache: 'no'
    ipmitimeout: '2'
    iscsidir: /iscsidir
    managedaddressmode: dhcp
    master: 10.3.11.12
    maxssh: '8'
    mnroutenames: mnroutenames
    nameservers: 10.3.11.12
    nmapoptions: --min-rtt-timeout
    nodestatus: n
    nodesyncfiledir: /var/xcat/node/syncfiles
    ntpservers: 10.3.11.12
    persistkvmguests: y
    powerinterval: '0'
    ppcmaxp: '64'
    ppcretry: '3'
    ppctimeout: '0'
    precreatemypostscripts: '1'
    pruneservices: '1'
    runbootscripts: 'yes'
    setinstallnic: '1'
    sharedinstall: 'no'
    sharedtftp: '1'
    skiptables: nics
    skipvalidatelog: '1'
    snmpc: snmpc
    sshbetweennodes: ALLGROUPS
    svloglocal: '1'
    syspowerinterval: '10'
    syspowermaxnodes: '10'
    tftpdir: /tftprot/
    tftpflags: -v
    timezone: America/New_York
    useNFSv4onAIX: '0'
    useNmapfromMN: 'no'
    useSSHonAIX: '0'
    useflowcontrol: 'no'
    usexhrm: 'no'
    vcenterautojoin: 'no'
    vmwarereconfigonpower: 'no'
    vsftp: n
    xcatconfdir: /etc/xcat
    xcatdebugmode: '1'
    xcatdport: '3001'
    xcatiport: '3002'
    xcatlport: '3003'
    xcatmaxbatchconnections: '64'
    xcatmaxconnections: '60'
    xcatsslciphers: 3DES
    xcatsslversion: TLSv1

#Version 2.14.4 (git commit 332a5fb210d385d0a7db1f20722a2fddbad2ba6d, built Thu Oct 18 07:16:24 EDT 2018)
CHECK:rc == 0	[Pass]

RUN:mnip=$(lsdef -t site -o clustersite -i master -c|awk -F'=' '{print $2}');sed -i "s/$mnip/10.3.11.12/g" /tmp/export_import_site_by_yaml/export_site_yaml.inv [Mon Nov 19 01:07:53 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:cat /tmp/export_import_site_by_yaml/export_site_yaml.inv [Mon Nov 19 01:07:54 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
schema_version: '2.0'
site:
  clustersite:
    FQDNfirst: '1'
    SNsyncfiledir: /var/xcat/syncfiles
    auditnosyslog: '0'
    auditskipcmds: ALL
    blademaxp: '64'
    cleanupxcatpost: 'no'
    consoleondemand: 'no'
    databaseloc: /var/lib
    db2installloc: /mntdb2
    dbtracelevel: '0'
    defserialflow: '0'
    defserialport: '0'
    defserialspeed: '9600'
    dhcpinterfaces: eth0
    dhcplease: '43200'
    dhcpsetup: n
    disjointdhcps: '1'
    dnshandler: ddns
    dnsinterfaces: xcatmn|eth1,eth2;service|bond0
    dnsupdaters: dnsupdaters
    domain: pok.stglabs.ibm.com
    enableASMI: 'no'
    excludenodes: excludenodes
    externaldns: externaldns
    extntpservers: extntpservers
    forwarders: 10.3.11.12
    fsptimeout: '0'
    genmacprefix: 00:11:aa
    genpasswords: genpasswords
    hierarchicalattrs: hierarchicalattrs
    httpport: '80'
    hwctrldispatch: y
    installdir: /install/
    installloc: hostname:/path
    ipmidispatch: y
    ipmimaxp: '64'
    ipmiretries: '3'
    ipmisdrcache: 'no'
    ipmitimeout: '2'
    iscsidir: /iscsidir
    managedaddressmode: dhcp
    master: 10.3.11.12
    maxssh: '8'
    mnroutenames: mnroutenames
    nameservers: 10.3.11.12
    nmapoptions: --min-rtt-timeout
    nodestatus: n
    nodesyncfiledir: /var/xcat/node/syncfiles
    ntpservers: 10.3.11.12
    persistkvmguests: y
    powerinterval: '0'
    ppcmaxp: '64'
    ppcretry: '3'
    ppctimeout: '0'
    precreatemypostscripts: '1'
    pruneservices: '1'
    runbootscripts: 'yes'
    setinstallnic: '1'
    sharedinstall: 'no'
    sharedtftp: '1'
    skiptables: nics
    skipvalidatelog: '1'
    snmpc: snmpc
    sshbetweennodes: ALLGROUPS
    svloglocal: '1'
    syspowerinterval: '10'
    syspowermaxnodes: '10'
    tftpdir: /tftprot/
    tftpflags: -v
    timezone: America/New_York
    useNFSv4onAIX: '0'
    useNmapfromMN: 'no'
    useSSHonAIX: '0'
    useflowcontrol: 'no'
    usexhrm: 'no'
    vcenterautojoin: 'no'
    vmwarereconfigonpower: 'no'
    vsftp: n
    xcatconfdir: /etc/xcat
    xcatdebugmode: '1'
    xcatdport: '3001'
    xcatiport: '3002'
    xcatlport: '3003'
    xcatmaxbatchconnections: '64'
    xcatmaxconnections: '60'
    xcatsslciphers: 3DES
    xcatsslversion: TLSv1

#Version 2.14.4 (git commit 332a5fb210d385d0a7db1f20722a2fddbad2ba6d, built Thu Oct 18 07:16:24 EDT 2018)
CHECK:rc == 0	[Pass]

RUN:scp /tmp/export_import_site_by_yaml/export_site_yaml.inv 10.3.11.12:/tmp/export_import_site_by_yaml_10.3.11.12/ [Mon Nov 19 01:07:54 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:ssh  10.3.11.12 ' source /etc/profile.d/xcat.sh;xcat-inventory import -f /tmp/export_import_site_by_yaml_10.3.11.12/export_site_yaml.inv -t site -o clustersite' [Mon Nov 19 01:07:54 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
loading inventory date in "/tmp/export_import_site_by_yaml_10.3.11.12/export_site_yaml.inv"
start to import "site" type objects
 preprocessing "site" type objects
 writting "site" type objects
Inventory import successfully!
CHECK:rc == 0	[Pass]

RUN:ssh  10.3.11.12 ' source /etc/profile.d/xcat.sh;lsdef  -t site -o clustersite  -z |sort -t'=' -k1|tee /tmp/export_import_site_by_yaml_10.3.11.12/dstsite.stanza' [Mon Nov 19 01:07:56 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:

    FQDNfirst=1
    SNsyncfiledir=/var/xcat/syncfiles
    auditnosyslog=0
    auditskipcmds=ALL
    blademaxp=64
    cleanupxcatpost=no
    consoleondemand=no
    databaseloc=/var/lib
    db2installloc=/mntdb2
    dbtracelevel=0
    defserialflow=0
    defserialport=0
    defserialspeed=9600
    dhcpinterfaces=eth0
    dhcplease=43200
    dhcpsetup=n
    disjointdhcps=1
    dnshandler=ddns
    dnsinterfaces=xcatmn|eth1,eth2;service|bond0
    dnsupdaters=dnsupdaters
    domain=pok.stglabs.ibm.com
    enableASMI=no
    excludenodes=excludenodes
    externaldns=externaldns
    extntpservers=extntpservers
    forwarders=10.3.11.12
    fsptimeout=0
    genmacprefix=00:11:aa
    genpasswords=genpasswords
    hierarchicalattrs=hierarchicalattrs
    httpport=80
    hwctrldispatch=y
    installdir=/install/
    installloc=hostname:/path
    ipmidispatch=y
    ipmimaxp=64
    ipmiretries=3
    ipmisdrcache=no
    ipmitimeout=2
    iscsidir=/iscsidir
    managedaddressmode=dhcp
    master=10.3.11.12
    maxssh=8
    mnroutenames=mnroutenames
    nameservers=10.3.11.12
    nmapoptions=--min-rtt-timeout
    nodestatus=n
    nodesyncfiledir=/var/xcat/node/syncfiles
    ntpservers=10.3.11.12
    objtype=site
    persistkvmguests=y
    powerinterval=0
    ppcmaxp=64
    ppcretry=3
    ppctimeout=0
    precreatemypostscripts=1
    pruneservices=1
    runbootscripts=yes
    setinstallnic=1
    sharedinstall=no
    sharedtftp=1
    skiptables=nics
    skipvalidatelog=1
    snmpc=snmpc
    sshbetweennodes=ALLGROUPS
    svloglocal=1
    syspowerinterval=10
    syspowermaxnodes=10
    tftpdir=/tftprot/
    tftpflags=-v
    timezone=America/New_York
    useNFSv4onAIX=0
    useNmapfromMN=no
    useSSHonAIX=0
    useflowcontrol=no
    usexhrm=no
    vcenterautojoin=no
    vmwarereconfigonpower=no
    vsftp=n
    xcatconfdir=/etc/xcat
    xcatdebugmode=1
    xcatdport=3001
    xcatiport=3002
    xcatlport=3003
    xcatmaxbatchconnections=64
    xcatmaxconnections=60
    xcatsslciphers=3DES
    xcatsslversion=TLSv1
# <xCAT data object stanza file>
clustersite:
CHECK:rc == 0	[Pass]

RUN:scp 10.3.11.12:/tmp/export_import_site_by_yaml_10.3.11.12/dstsite.stanza /tmp/export_import_site_by_yaml/dstsite.stanza [Mon Nov 19 01:07:58 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:mnip=$(lsdef -t site -o clustersite -i master -c|awk -F'=' '{print $2}');sed -i "s/10.3.11.12/$mnip/g" /tmp/export_import_site_by_yaml/dstsite.stanza [Mon Nov 19 01:07:58 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:cat /tmp/export_import_site_by_yaml/dstsite.stanza [Mon Nov 19 01:07:58 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

    FQDNfirst=1
    SNsyncfiledir=/var/xcat/syncfiles
    auditnosyslog=0
    auditskipcmds=ALL
    blademaxp=64
    cleanupxcatpost=no
    consoleondemand=no
    databaseloc=/var/lib
    db2installloc=/mntdb2
    dbtracelevel=0
    defserialflow=0
    defserialport=0
    defserialspeed=9600
    dhcpinterfaces=eth0
    dhcplease=43200
    dhcpsetup=n
    disjointdhcps=1
    dnshandler=ddns
    dnsinterfaces=xcatmn|eth1,eth2;service|bond0
    dnsupdaters=dnsupdaters
    domain=pok.stglabs.ibm.com
    enableASMI=no
    excludenodes=excludenodes
    externaldns=externaldns
    extntpservers=extntpservers
    forwarders=10.3.11.12
    fsptimeout=0
    genmacprefix=00:11:aa
    genpasswords=genpasswords
    hierarchicalattrs=hierarchicalattrs
    httpport=80
    hwctrldispatch=y
    installdir=/install/
    installloc=hostname:/path
    ipmidispatch=y
    ipmimaxp=64
    ipmiretries=3
    ipmisdrcache=no
    ipmitimeout=2
    iscsidir=/iscsidir
    managedaddressmode=dhcp
    master=10.3.11.12
    maxssh=8
    mnroutenames=mnroutenames
    nameservers=10.3.11.12
    nmapoptions=--min-rtt-timeout
    nodestatus=n
    nodesyncfiledir=/var/xcat/node/syncfiles
    ntpservers=10.3.11.12
    objtype=site
    persistkvmguests=y
    powerinterval=0
    ppcmaxp=64
    ppcretry=3
    ppctimeout=0
    precreatemypostscripts=1
    pruneservices=1
    runbootscripts=yes
    setinstallnic=1
    sharedinstall=no
    sharedtftp=1
    skiptables=nics
    skipvalidatelog=1
    snmpc=snmpc
    sshbetweennodes=ALLGROUPS
    svloglocal=1
    syspowerinterval=10
    syspowermaxnodes=10
    tftpdir=/tftprot/
    tftpflags=-v
    timezone=America/New_York
    useNFSv4onAIX=0
    useNmapfromMN=no
    useSSHonAIX=0
    useflowcontrol=no
    usexhrm=no
    vcenterautojoin=no
    vmwarereconfigonpower=no
    vsftp=n
    xcatconfdir=/etc/xcat
    xcatdebugmode=1
    xcatdport=3001
    xcatiport=3002
    xcatlport=3003
    xcatmaxbatchconnections=64
    xcatmaxconnections=60
    xcatsslciphers=3DES
    xcatsslversion=TLSv1
# <xCAT data object stanza file>
clustersite:
CHECK:rc == 0	[Pass]

RUN:diff -y --ignore-blank-lines  /tmp/export_import_site_by_yaml/srcsite.stanza /tmp/export_import_site_by_yaml/dstsite.stanza [Mon Nov 19 01:07:58 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

    FQDNfirst=1							    FQDNfirst=1
    SNsyncfiledir=/var/xcat/syncfiles				    SNsyncfiledir=/var/xcat/syncfiles
    auditnosyslog=0						    auditnosyslog=0
    auditskipcmds=ALL						    auditskipcmds=ALL
    blademaxp=64						    blademaxp=64
    cleanupxcatpost=no						    cleanupxcatpost=no
    consoleondemand=no						    consoleondemand=no
    databaseloc=/var/lib					    databaseloc=/var/lib
    db2installloc=/mntdb2					    db2installloc=/mntdb2
    dbtracelevel=0						    dbtracelevel=0
    defserialflow=0						    defserialflow=0
    defserialport=0						    defserialport=0
    defserialspeed=9600						    defserialspeed=9600
    dhcpinterfaces=eth0						    dhcpinterfaces=eth0
    dhcplease=43200						    dhcplease=43200
    dhcpsetup=n							    dhcpsetup=n
    disjointdhcps=1						    disjointdhcps=1
    dnshandler=ddns						    dnshandler=ddns
    dnsinterfaces=xcatmn|eth1,eth2;service|bond0		    dnsinterfaces=xcatmn|eth1,eth2;service|bond0
    dnsupdaters=dnsupdaters					    dnsupdaters=dnsupdaters
    domain=pok.stglabs.ibm.com					    domain=pok.stglabs.ibm.com
    enableASMI=no						    enableASMI=no
    excludenodes=excludenodes					    excludenodes=excludenodes
    externaldns=externaldns					    externaldns=externaldns
    extntpservers=extntpservers					    extntpservers=extntpservers
    forwarders=10.3.11.12					    forwarders=10.3.11.12
    fsptimeout=0						    fsptimeout=0
    genmacprefix=00:11:aa					    genmacprefix=00:11:aa
    genpasswords=genpasswords					    genpasswords=genpasswords
    hierarchicalattrs=hierarchicalattrs				    hierarchicalattrs=hierarchicalattrs
    httpport=80							    httpport=80
    hwctrldispatch=y						    hwctrldispatch=y
    installdir=/install/					    installdir=/install/
    installloc=hostname:/path					    installloc=hostname:/path
    ipmidispatch=y						    ipmidispatch=y
    ipmimaxp=64							    ipmimaxp=64
    ipmiretries=3						    ipmiretries=3
    ipmisdrcache=no						    ipmisdrcache=no
    ipmitimeout=2						    ipmitimeout=2
    iscsidir=/iscsidir						    iscsidir=/iscsidir
    managedaddressmode=dhcp					    managedaddressmode=dhcp
    master=10.3.11.12						    master=10.3.11.12
    maxssh=8							    maxssh=8
    mnroutenames=mnroutenames					    mnroutenames=mnroutenames
    nameservers=10.3.11.12					    nameservers=10.3.11.12
    nmapoptions=--min-rtt-timeout				    nmapoptions=--min-rtt-timeout
    nodestatus=n						    nodestatus=n
    nodesyncfiledir=/var/xcat/node/syncfiles			    nodesyncfiledir=/var/xcat/node/syncfiles
    ntpservers=10.3.11.12					    ntpservers=10.3.11.12
    objtype=site						    objtype=site
    persistkvmguests=y						    persistkvmguests=y
    powerinterval=0						    powerinterval=0
    ppcmaxp=64							    ppcmaxp=64
    ppcretry=3							    ppcretry=3
    ppctimeout=0						    ppctimeout=0
    precreatemypostscripts=1					    precreatemypostscripts=1
    pruneservices=1						    pruneservices=1
    runbootscripts=yes						    runbootscripts=yes
    setinstallnic=1						    setinstallnic=1
    sharedinstall=no						    sharedinstall=no
    sharedtftp=1						    sharedtftp=1
    skiptables=nics						    skiptables=nics
    skipvalidatelog=1						    skipvalidatelog=1
    snmpc=snmpc							    snmpc=snmpc
    sshbetweennodes=ALLGROUPS					    sshbetweennodes=ALLGROUPS
    svloglocal=1						    svloglocal=1
    syspowerinterval=10						    syspowerinterval=10
    syspowermaxnodes=10						    syspowermaxnodes=10
    tftpdir=/tftprot/						    tftpdir=/tftprot/
    tftpflags=-v						    tftpflags=-v
    timezone=America/New_York					    timezone=America/New_York
    useNFSv4onAIX=0						    useNFSv4onAIX=0
    useNmapfromMN=no						    useNmapfromMN=no
    useSSHonAIX=0						    useSSHonAIX=0
    useflowcontrol=no						    useflowcontrol=no
    usexhrm=no							    usexhrm=no
    vcenterautojoin=no						    vcenterautojoin=no
    vmwarereconfigonpower=no					    vmwarereconfigonpower=no
    vsftp=n							    vsftp=n
    xcatconfdir=/etc/xcat					    xcatconfdir=/etc/xcat
    xcatdebugmode=1						    xcatdebugmode=1
    xcatdport=3001						    xcatdport=3001
    xcatiport=3002						    xcatiport=3002
    xcatlport=3003						    xcatlport=3003
    xcatmaxbatchconnections=64					    xcatmaxbatchconnections=64
    xcatmaxconnections=60					    xcatmaxconnections=60
    xcatsslciphers=3DES						    xcatsslciphers=3DES
    xcatsslversion=TLSv1					    xcatsslversion=TLSv1
# <xCAT data object stanza file>				# <xCAT data object stanza file>
clustersite:							clustersite:
CHECK:rc == 0	[Pass]

RUN:cat /tmp/export_import_site_by_yaml/site.stanza | mkdef -z -f [Mon Nov 19 01:07:58 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:ssh 10.3.11.12 ' source /etc/profile.d/xcat.sh;cat /tmp/export_import_site_by_yaml_10.3.11.12/site.stanza | mkdef -z -f' [Mon Nov 19 01:07:59 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:ssh 10.3.11.12 ' source /etc/profile.d/xcat.sh;rm -rf /tmp/export_import_site_by_yaml_10.3.11.12/' [Mon Nov 19 01:08:00 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:rm -rf /tmp/export_import_site_by_yaml [Mon Nov 19 01:08:00 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::export_import_site_by_yaml::Passed::Time:Mon Nov 19 01:08:00 2018 ::Duration::11 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished at Mon Nov 19 01:08:00 2018
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20181119010744 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20181119010744 file for time consumption

```