### PR TITLE
Fix issue 5721: xCAT-client rpm seems to depend on xCAT-server

### DIFF
--- a/perl-xCAT/xCAT/FSPpower.pm
+++ b/perl-xCAT/xCAT/FSPpower.pm
@@ -8,7 +8,6 @@ use xCAT::PPCcli qw(SUCCESS EXPECT_ERROR RC_ERROR NR_ERROR);
 use xCAT::PPCpower;
 use xCAT::FSPUtils;
 use xCAT::GlobalDef;
-use xCAT_monitoring::monitorctrl;
 
 #use Data::Dumper;
 
@@ -183,6 +182,7 @@ sub powercmd_boot {
         }
     }
     if (%newnodestatus) {
+        require xCAT_monitoring::monitorctrl;
         xCAT_monitoring::monitorctrl::setNodeStatusAttributes(\%newnodestatus, 1);
     }
     return (\@output);
@@ -364,6 +364,7 @@ sub powercmd {
     }
 
     if (%newnodestatus) {
+        require xCAT_monitoring::monitorctrl;
         xCAT_monitoring::monitorctrl::setNodeStatusAttributes(\%newnodestatus, 1);
     }
     return (\@output);

--- a/perl-xCAT/xCAT/PPCboot.pm
+++ b/perl-xCAT/xCAT/PPCboot.pm
@@ -614,6 +614,7 @@ sub rnetboot {
         my $newstat       = $::STATUS_POWERING_ON;
         my %newnodestatus = ();
         $newnodestatus{$newstat} = [$node];
+        require xCAT_monitoring::monitorctrl;
         xCAT_monitoring::monitorctrl::setNodeStatusAttributes(\%newnodestatus, 1);
         return ([ [ $node, "Success", $Rc ] ]);
     }

--- a/perl-xCAT/xCAT/PPCpower.pm
+++ b/perl-xCAT/xCAT/PPCpower.pm
@@ -9,7 +9,6 @@ use xCAT::MsgUtils;
 use xCAT::FSPpower;
 
 use xCAT::GlobalDef;
-use xCAT_monitoring::monitorctrl;
 
 ##########################################################################
 # Parse the command line for options and operands
@@ -301,6 +300,7 @@ sub powercmd_boot {
         }
     }
 
+    require xCAT_monitoring::monitorctrl;
     xCAT_monitoring::monitorctrl::setNodeStatusAttributes(\%newnodestatus, 1);
     return (\@output);
 }
@@ -423,6 +423,7 @@ sub powercmd {
             }
         }
     }
+    require xCAT_monitoring::monitorctrl;
     xCAT_monitoring::monitorctrl::setNodeStatusAttributes(\%newnodestatus, 1);
     return (\@result);
 }


### PR DESCRIPTION
### The PR is to fix issue #5721 

### The modification include
1. files
perl-xCAT/xCAT/FSPpower.pm
perl-xCAT/xCAT/PPCboot.pm
perl-xCAT/xCAT/PPCpower.pm
2. replace use with require in lines

### The UT result
```
[root@briggs01 xcat-core]# ls /root/xcatbuild/fix_issue_5721
ls: cannot access /root/xcatbuild/fix_issue_5721: No such file or directory
[root@briggs01 xcat-core]# ./buildcore.sh UP=0 BUILDALL=1
Building /root/rpmbuild/RPMS/noarch/perl-xCAT-2.14.5-snap*.noarch.rpm ...
Building /root/rpmbuild/RPMS/noarch/xCAT-client-2.14.5-snap*.noarch.rpm ...
...
Workers Finished
Saving Primary metadata
Saving file lists metadata
Saving other metadata
Generating sqlite DBs
Sqlite DBs complete
Creating /root/xcatbuild/fix_issue_5721/core-rpms-snap.tar.bz2 ...
[root@briggs01 xcat-core]# rpm -qpR /root/xcatbuild/fix_issue_5721/xcat-core/perl-xCAT-2.14.5-snap201811210011.noarch.rpm | grep -i xCAT::Utils
perl(xCAT::Utils)
[root@briggs01 xcat-core]# rpm -qpR /root/xcatbuild/fix_issue_5721/xcat-core/perl-xCAT-2.14.5-snap201811210011.noarch.rpm | grep -i xCAT_monitoring::monitorctrl
[root@briggs01 xcat-core]#
```