### PR TITLE
[go-xcat] Force use POSIX locale when do rpm query

### DIFF
--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -538,7 +538,7 @@ function check_package_version_rpm()
 		else
 			echo "${ver}"
 		fi
-	done < <(rpm -q --qf '%{version}-%{release}\n' "$@" 2>/dev/null)
+	done < <(LC_ALL="C" rpm -q --qf '%{version}-%{release}\n' "$@" 2>/dev/null)
 	return 0
 }
 


### PR DESCRIPTION
### The PR is to fix issue _#5802_

### The modification include

_##Force use POSIX locale when do rpm query_
