### PR TITLE
fix issue 5719, make output of commands against openbmc same

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_inventory.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/executor/openbmc_inventory.py
@@ -60,7 +60,7 @@ class OpenBMCInventoryTask(ParallelNodesCommand):
                 continue
 
             firm_info.append('%s Firmware Product: %s (%s)%s' %
-                              (firm_obj_dict[key].purpose,
+                              (firm_obj_dict[key].purpose.upper(),
                                firm_obj_dict[key].version,
                                firm_obj_dict[key].active,
                                flag))
@@ -70,7 +70,7 @@ class OpenBMCInventoryTask(ParallelNodesCommand):
                 for extended in extendeds:
                     firm_info.append('%s Firmware Product: ' \
                                      '-- additional info: %s' % \
-                                      (firm_obj_dict[key].purpose, extended))
+                                      (firm_obj_dict[key].purpose.upper(), extended))
 
         return firm_info
 

--- a/xCAT-server/lib/xcat/plugins/openbmc2.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc2.pm
@@ -202,7 +202,7 @@ sub parse_args {
 
     if ($command eq "rbeacon") {
         unless ($subcommand =~ /^on$|^off$|^stat$/) {
-            return ([ 1, "Only 'on', 'off' or 'stat' is supported for OpenBMC managed nodes."]);
+            return ([ 1, "Only 'on', 'off' and 'stat' are supported for OpenBMC managed nodes."]);
         }
     } elsif ($command eq "rflash") {
         my ($activate, $check, $delete, $directory, $list, $upload) = (0) x 6;

--- a/xCAT-test/autotest/testcase/UT_openbmc/supported_commands_case0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/supported_commands_case0
@@ -27,7 +27,7 @@ check:rc==0
 check:output=~$$CN: SYSTEM SerialNumber
 cmd: rinv $$CN firm
 check:rc==0
-check:output=~$$CN: Host Firmware
+check:output=~$$CN: HOST Firmware
 check:output=~$$CN: BMC Firmware
 cmd: rinv $$CN cpu
 check:rc==0
@@ -53,13 +53,13 @@ check:rc==0
 check:output=~$$CN: Ps0 Input Voltage:
 cmd: rvitals $$CN wattage
 check:rc==0
-check:output=~$$CN: Total Power:
+check:output=~$$CN: Ps0 Input Power:
 cmd: rvitals $$CN fanspeed
 check:rc==0
 check:output=~$$CN: Fan
 cmd: rvitals $$CN power
 check:rc==0
-check:output=~$$CN: Total Power:
+check:output=~$$CN: Ps0 Input Power:
 cmd: rvitals $$CN leds
 check:rc==0
 check:output=~$$CN: LEDs Front

--- a/xCAT-test/autotest/testcase/rspconfig/cases1
+++ b/xCAT-test/autotest/testcase/rspconfig/cases1
@@ -197,7 +197,7 @@ cmd:rspconfig $$CN powerrestorepolicy=restore
 check:output =~$$CN:\s*BMC Setting BMC PowerRestorePolicy...
 check:rc == 0
 cmd:rspconfig $$CN powerrestorepolicy=abc
-check:output =~$$CN:\s*(\[.*?\]: )?Error: Invalid value '\S*' for 'powerrestorepolicy', Valid values: restore,always_on,always_off
+check:output =~$$CN:\s*Error: Invalid value '\S*' for 'powerrestorepolicy', Valid values: always_off,always_on,restore
 check:rc != 0
 cmd:rspconfig $$CN powerrestorepolicy
 check:rc == 0
@@ -256,7 +256,7 @@ cmd:rspconfig $$CN timesyncmethod
 check:rc == 0
 check:output =~$$CN:\s*BMC TimeSyncMethod:\s*Manual
 cmd:rspconfig $$CN  timesyncmethod=abc
-check:output =~$$CN:\s*(\[.*?\]: )?Error: Invalid value \S* for 'timesyncmethod', Valid values: ntp,manual
+check:output =~$$CN:\s*(\[.*?\]: )?Error: Invalid value \S* for 'timesyncmethod', Valid values: manual,ntp
 check:rc != 0
 cmd:syncmethod=`cat /tmp/timesyncmethod | awk -F ":" '{print $3}'`;newsyncmethod=`echo $syncmethod |tr 'A-Z' 'a-z'`;rspconfig $$CN timesyncmethod=$newsyncmethod
 check:rc == 0
@@ -290,7 +290,7 @@ cmd:rspconfig $$CN bootmode
 check:rc == 0
 check:output =~$$CN:\s*BMC BootMode:\s*Setup
 cmd:rspconfig $$CN bootmode=abc
-check:output =~$$CN:\s*(\[.*?\]: )?Error: Invalid value \S* for 'bootmode', Valid values: regular,safe,setup
+check:output =~$$CN:\s*Error: Invalid value \S* for 'bootmode', Valid values: regular,safe,setup
 check:rc != 0
 cmd:mode=`cat /tmp/bootmode |awk -F ":" '{print $3}'`;newmode=`echo $mode |tr 'A-Z' 'a-z'`;rspconfig $$CN bootmode=$newmode
 check:rc == 0

--- a/xCAT-test/autotest/testcase/rspconfig/rspconfig.sh
+++ b/xCAT-test/autotest/testcase/rspconfig/rspconfig.sh
@@ -177,7 +177,7 @@ function change_all
 	if [[ $? -eq 0 ]];then
 		BMCIP=`rspconfig $1 ip |awk -F":" '{print $3}'|sed s/[[:space:]]//g`;
 		BMCNETMASK=`rspconfig  $1 netmask |awk -F":" '{print $3}'|sed s/[[:space:]]//g`;
-		BMCGGATEWAY=`rspconfig  $1 gateway |awk -F":" '{print $3}'|sed s/[[:space:]]//g`;
+		BMCGGATEWAY=`rspconfig  $1 gateway |awk -F":" '{print $3}'| awk -F" " '{print $1}' |sed s/[[:space:]]//g`;
 		output=`rspconfig  $1 vlan`
 		if [[ $output =~ "BMC VLAN ID enabled" ]];then
 			BMCVLAN=`rspconfig  $1 vlan |awk -F":" '{print $3}'|sed s/[[:space:]]//g`


### PR DESCRIPTION
### The PR is to fix issue _#5719_

### The modification include

_##Output of perl version_

_##Output of python version_

_##Cases_

### The UT result

Perl 
```
RUN:rbeacon f5u14 abc [Wed Nov 21 02:30:50 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Wed Nov 21 02:30:51 2018 OpenBMC: [openbmc_debug_perl]
f5u14: Error: Only 'on', 'off' and 'stat' are supported for OpenBMC managed nodes.
CHECK:rc != 0   [Pass]
CHECK:output =~ f5u14\s*:\s*Error:\s*Only \'on\', \'off\' and \'stat\' are supported    [Pass]

RUN:reventlog f5u14 resolved=Led [Wed Nov 21 02:31:27 2018]
ElapsedTime:2 sec
RETURN rc = 1
OUTPUT:
f5u14: [f6u13k10]: Error: No event log entries needed to be resolved
Attempting to resolve the following log entries: Led...
CHECK:rc == 1   [Pass]
CHECK:output =~ Attempting to resolve the following log entries: Led... [Pass]

RUN:reventlog f5u14 resolved 1,2,3 [Wed Nov 21 02:41:52 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Wed Nov 21 02:41:52 2018 OpenBMC: [openbmc_debug_perl]
f5u14: Error: Only one option is supported at the same time for reventlog
CHECK:rc == 1   [Pass]
CHECK:output =~ Error: (\[.*?\]: )?Only one option is supported at the same time for reventlog  [Pass]

RUN:reventlog f5u14 resolved=abc [Wed Nov 21 02:17:35 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
f5u14: [f6u13k10]: Error: Invalid ID: abc provided to be resolved. [403 Forbidden]
Attempting to resolve the following log entries: abc...
CHECK:rc == 1   [Pass]
CHECK:output =~ Error: (\[.*?\]: )?Invalid ID:  [Pass]

RUN:rspconfig f5u14 autoreboot=2 [Wed Nov 21 02:18:44 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Wed Nov 21 02:18:44 2018 OpenBMC: [openbmc_debug_perl]
f5u14: Error: Invalid value '2' for 'autoreboot', Valid values: 0,1

RUN:rspconfig f5u14 bootmode|tee /tmp/bootmode [Wed Nov 21 02:19:12 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f5u14: BMC BootMode: Setup
CHECK:output =~ f5u14:\s*BMC BootMode:\s*Regular|Safe|Setup     [Pass]
CHECK:rc == 0   [Pass]

RUN:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;rspconfig f5u14 dump --clear $dumpnumber [Wed Nov 21 20:26:58 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f5u14: [263] clear
CHECK:rc == 0	[Pass]
CHECK:output =~ f5u14:\s*\[\d+\]\s* clear	[Pass]

RUN:rspconfig f5u14 hostname=witherspoon [Wed Nov 21 02:18:09 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
f5u14: BMC Hostname: witherspoon
CHECK:rc == 0   [Pass]
CHECK:output =~ f5u14: BMC Setting BMC Hostname...      [Pass]

RUN:rspconfig f5u14 powerrestorepolicy |tee /tmp/powerrestorepolicy [Wed Nov 21 02:19:42 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f5u14: BMC PowerRestorePolicy: Restore
CHECK:output =~ f5u14:\s*BMC PowerRestorePolicy:\s*AlwaysOff|AlwaysOn|Restore   [Pass]

RUN:rspconfig f5u14 powersupplyredundancy |tee /tmp/powersupplyredundancy [Wed Nov 21 02:18:23 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
f5u14: BMC PowerSupplyRedundancy: Disabled
CHECK:output =~ f5u14:\s*BMC PowerSupplyRedundancy:\s*Enabled|Disabled  [Pass]
CHECK:rc == 0   [Pass]

RUN:rspconfig f5u14 timesyncmethod |tee /tmp/timesyncmethod [Wed Nov 21 02:17:45 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f5u14: BMC TimeSyncMethod: Manual
CHECK:output =~ f5u14:\s*BMC TimeSyncMethod:\s*NTP|Manual       [Pass]
CHECK:rc == 0   [Pass]

RUN:rinv f5u14 firm [Wed Nov 21 20:13:31 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f5u14: BMC Firmware Product:   ibm-v2.0-0-r46-0-gbed584c (Active)*
f5u14: HOST Firmware Product:   IBM-witherspoon-ibm-OP9_v1.19_1.192 (Active)*
f5u14: HOST Firmware Product: -- additional info: buildroot-2018.02.1-6-ga8d1126
f5u14: HOST Firmware Product: -- additional info: capp-ucode-p9-dd2-v4
f5u14: HOST Firmware Product: -- additional info: hostboot-4bd54cb-p8235b67
f5u14: HOST Firmware Product: -- additional info: hostboot-binaries-d01b024
f5u14: HOST Firmware Product: -- additional info: linux-4.16.13-openpower1-p4213cac
f5u14: HOST Firmware Product: -- additional info: machine-xml-94a137f
f5u14: HOST Firmware Product: -- additional info: occ-f796766
f5u14: HOST Firmware Product: -- additional info: op-build-v2.0.5-343-g6f85520
f5u14: HOST Firmware Product: -- additional info: petitboot-v1.7.2-p439439e
f5u14: HOST Firmware Product: -- additional info: sbe-defe254
f5u14: HOST Firmware Product: -- additional info: skiboot-v6.0.8
CHECK:rc == 0	[Pass]
CHECK:output =~ f5u14: HOST Firmware	[Pass]
CHECK:output =~ f5u14: BMC Firmware	[Pass]
```

Python
```
RUN:rbeacon f5u14 abc [Wed Nov 21 03:50:42 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f5u14: Error: Only 'on', 'off' and 'stat' are supported for OpenBMC managed nodes.
CHECK:rc != 0   [Pass]
CHECK:output =~ f5u14\s*:\s*Error:\s*Only \'on\', \'off\' and \'stat\' are supported    [Pass]

RUN:reventlog f5u14 resolved=Led [Wed Nov 21 03:51:18 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
f5u14: [f6u13k10]: Error: No event log entries needed to be resolved
Attempting to resolve the following log entries: Led...
CHECK:rc == 1   [Pass]
CHECK:output =~ Attempting to resolve the following log entries: Led... [Pass]

RUN:reventlog f5u14 resolved 1,2,3 [Wed Nov 21 04:01:45 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f5u14: Error: Only one option is supported at the same time for reventlog
CHECK:rc == 1   [Pass]
CHECK:output =~ Error: (\[.*?\]: )?Only one option is supported at the same time for reventlog  [Pass]

RUN:reventlog f5u14 resolved=-1 [Wed Nov 21 03:34:35 2018]
ElapsedTime:3 sec
RETURN rc = 1
OUTPUT:
f5u14: [f6u13k10]: Error: Invalid ID: -1 provided to be resolved. [403 Forbidden]
Attempting to resolve the following log entries: -1...
CHECK:rc == 1   [Pass]
CHECK:output =~ Error: (\[.*?\]: )?Invalid ID:  [Pass]

RUN:rspconfig f5u14 autoreboot=2 [Wed Nov 21 03:37:04 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f5u14: Error: Invalid value '2' for 'autoreboot', Valid values: 0,1
CHECK:output =~ f5u14:\s*(\[.*?\]: )?Error: Invalid value \S* for 'autoreboot', Valid values: 0,1       [Pass]
CHECK:rc != 0   [Pass]

RUN:rspconfig f5u14 bootmode|tee /tmp/bootmode [Wed Nov 21 03:37:55 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
f5u14: BMC BootMode: Setup
CHECK:output =~ f5u14:\s*BMC BootMode:\s*Regular|Safe|Setup     [Pass]
CHECK:rc == 0   [Pass]

RUN:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;rspconfig f5u14 dump --clear $dumpnumber [Wed Nov 21 04:07:06 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f5u14: [257] clear
CHECK:rc == 0   [Pass]
CHECK:output =~ f5u14:\s*\[\d+\]\s* clear       [Pass]

RUN:rspconfig f5u14 hostname=witherspoon [Wed Nov 21 03:35:48 2018]
ElapsedTime:5 sec
RETURN rc = 0
OUTPUT:
f5u14: BMC Setting BMC Hostname...
f5u14: BMC Hostname: witherspoon
CHECK:rc == 0   [Pass]
CHECK:output =~ f5u14: BMC Setting BMC Hostname...      [Pass]

RUN:rspconfig f5u14 powerrestorepolicy [Wed Nov 21 03:38:57 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
f5u14: BMC PowerRestorePolicy: AlwaysOn
CHECK:rc == 0   [Pass]
CHECK:output =~ f5u14:\s*BMC PowerRestorePolicy:\s*AlwaysOn     [Pass]

RUN:rspconfig f5u14 powersupplyredundancy |tee /tmp/powersupplyredundancy [Wed Nov 21 03:36:08 2018]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
f5u14: BMC PowerSupplyRedundancy: Disabled
CHECK:output =~ f5u14:\s*BMC PowerSupplyRedundancy:\s*Enabled|Disabled  [Pass]
CHECK:rc == 0   [Pass]

RUN:rspconfig f5u14 timesyncmethod [Wed Nov 21 03:34:55 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
f5u14: BMC TimeSyncMethod: NTP
CHECK:rc == 0   [Pass]
CHECK:output =~ f5u14:\s*BMC TimeSyncMethod:\s*NTP      [Pass]

RUN:rinv f5u14 firm [Wed Nov 21 03:51:02 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f5u14: BMC Firmware Product:   ibm-v2.0-0-r46-0-gbed584c (Active)*
f5u14: HOST Firmware Product:   IBM-witherspoon-ibm-OP9_v1.19_1.192 (Active)*
f5u14: HOST Firmware Product: -- additional info: buildroot-2018.02.1-6-ga8d1126
f5u14: HOST Firmware Product: -- additional info: capp-ucode-p9-dd2-v4
f5u14: HOST Firmware Product: -- additional info: hostboot-4bd54cb-p8235b67
f5u14: HOST Firmware Product: -- additional info: hostboot-binaries-d01b024
f5u14: HOST Firmware Product: -- additional info: linux-4.16.13-openpower1-p4213cac
f5u14: HOST Firmware Product: -- additional info: machine-xml-94a137f
f5u14: HOST Firmware Product: -- additional info: occ-f796766
f5u14: HOST Firmware Product: -- additional info: op-build-v2.0.5-343-g6f85520
f5u14: HOST Firmware Product: -- additional info: petitboot-v1.7.2-p439439e
f5u14: HOST Firmware Product: -- additional info: sbe-defe254
f5u14: HOST Firmware Product: -- additional info: skiboot-v6.0.8
CHECK:rc == 0   [Pass]
CHECK:output =~ f5u14: HOST Firmware    [Pass]
CHECK:output =~ f5u14: BMC Firmware     [Pass]
```