### PR TITLE
container simulater is not setup correctly

### DIFF
--- a/xCAT-test/autotest/testcase/performance/simulatorctl.sh
+++ b/xCAT-test/autotest/testcase/performance/simulatorctl.sh
@@ -59,11 +59,31 @@ setup_docker()
         #workaround as the public repo has issue to install container-selinux
         yum install -y http://ftp.unicamp.br/pub/ppc64el/rhel/7/docker-ppc64el/container-selinux-2.9-4.el7.noarch.rpm
         yum install -y docker-ce bridge-utils initscripts
-        service docker start
-        sleep 5
 
     else
         echo "Error: not supported platform."
+        return
+    fi
+
+    systemctl start docker
+    sleep 5
+
+    local x=1
+    while [ $x -le 5 ]
+    do
+        echo "Waiting for docker daemon up: $x times"
+        systemctl is-active docker >/dev/null 2>&1
+        if [[ $? -eq 0 ]]; then
+            x=0
+            break
+        fi
+        sleep 5
+        x=$(( $x + 1 ))
+    done
+
+    if [[ $x -gt 0 ]]; then
+        echo "Error: The docker daemon is not up."
+        return
     fi
 
     # Create the bridge network for testing, and add the physical interface inside


### PR DESCRIPTION
### The PR is to fix issue https://github.com/xcat2/xcat2-task-management/issues/404

### The modification include

Add a loop for waiting for docker daemon up, if timeout, then return with error


### The UT result
```
PERF_SIM_NIC=enP1p9s0f0 PERF_SIM_ADDR=173.18.251.252 bash ./share/xcat/tools/autotest/testcase/performance/simulatorctl.sh setup docker 2>/dev/null
Loaded plugins: product-id, search-disabled-repos, subscription-manager
This system is not registered with an entitlement server. You can use subscription-manager to register.
epel-release-latest-7.noarch.rpm                                                                                      |  15 kB  00:00:00
Examining /var/tmp/yum-root-EMs1UG/epel-release-latest-7.noarch.rpm: epel-release-7-11.noarch
/var/tmp/yum-root-EMs1UG/epel-release-latest-7.noarch.rpm: does not update installed package.
Loaded plugins: product-id, search-disabled-repos, subscription-manager
This system is not registered with an entitlement server. You can use subscription-manager to register.
repo id                                                                                                                                                status
docker                                                                                                                                                      21
epel/ppc64le                                                                                                                                            12,141
local-rhels7.5-alternate-ppc64le--install-REPO-os-rhels-kernel-4.14.0-49.16.1.el7a.bz1635866-ppc64le                                                      17+1
local-rhels7.5-alternate-ppc64le--install-REPO-os-rhels-rhels7.5-alt-ga-ppc64le                                                                        3,706+1
local-rhels7.5-alternate-ppc64le--install-REPO-software-ftp3.linux.ibm.com-redhat-release_cds-RHV-4.2-GA-Management-Agent-Power-7-ppc64le-os-Packages      190
local-rhels7.5-alternate-ppc64le--install-REPO-software-ftp3.linux.ibm.com-redhat-release_cds-RHV-4.2-GA-Power_Tools-7-ppc64le-os-Packages                  10
local-rhels7.5-alternate-ppc64le--install-REPO-software-hpc-CSM-elastic-stack                                                                              4+1
local-rhels7.5-alternate-ppc64le--install-REPO-software-nvidia-cuda-core-9.2.148-1-396.47-repo-ppc64le                                                      63
local-rhels7.5-alternate-ppc64le--install-REPO-software-nvidia-cuda-dep-repo-ppc64le                                                                         3
xCAT-rhels7.5-alternate-path0                                                                                                                          3,706+1
xCAT-rhels7.5-alternate-path1                                                                                                                             17+1
xCAT-rhels7.5-alternate-path2                                                                                                                               63
xCAT-rhels7.5-alternate-path3                                                                                                                                3
xCAT-rhels7.5-alternate-path4                                                                                                                              4+1
xCAT-rhels7.5-alternate-path5                                                                                                                              190
xCAT-rhels7.5-alternate-path6                                                                                                                               10
xcat-core                                                                                                                                                 15+6
xcat-dep                                                                                                                                                    33
xcat-otherpkgs0                                                                                                                                             63
xcat-otherpkgs1                                                                                                                                              3
xcat-otherpkgs2                                                                                                                                              1
xcat-otherpkgs3                                                                                                                                              1
xcat-otherpkgs4                                                                                                                                             23
repolist: 20,287
Loaded plugins: product-id, search-disabled-repos, subscription-manager
This system is not registered with an entitlement server. You can use subscription-manager to register.
container-selinux-2.9-4.el7.noarch.rpm                                                                                |  26 kB  00:00:00
Examining /var/tmp/yum-root-EMs1UG/container-selinux-2.9-4.el7.noarch.rpm: 2:container-selinux-2.9-4.el7.noarch
/var/tmp/yum-root-EMs1UG/container-selinux-2.9-4.el7.noarch.rpm: does not update installed package.
Loaded plugins: product-id, search-disabled-repos, subscription-manager
This system is not registered with an entitlement server. You can use subscription-manager to register.
docker                                                                                                                | 2.9 kB  00:00:00
Package docker-ce-18.03.1.ce-1.el7.centos.ppc64le already installed and latest version
Package bridge-utils-1.5-9.el7.ppc64le already installed and latest version
Package initscripts-9.49.41-1.el7.ppc64le already installed and latest version
Nothing to do
Waiting for docker daemon up: 1 times
bridge name	bridge id		STP enabled	interfaces
br-b5a52d3858d9		8000.02421284f63d	no		enP1p9s0f0
Sending build context to Docker daemon  20.99kB
Step 1/5 : FROM alpine:latest
 ---> e99e8929bba1
Step 2/5 : MAINTAINER binxu <bxuxa@cn.ibm.com>
 ---> Using cache
 ---> 21c045b68727
Step 3/5 : RUN apk add --update openssh bash wget &&  ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa &&  sed -i "s/UsePrivilegeSeparation.*/UsePrivilegeSeparation no/g" /etc/ssh/sshd_config && sed -i "s/UsePAM.*/UsePAM no/g" /etc/ssh/sshd_config && sed -i "s/PermitRootLogin.*/PermitRootLogin yes/g" /etc/ssh/sshd_config && sed -i "s/#AuthorizedKeysFile/AuthorizedKeysFile/g" /etc/ssh/sshd_config &&  echo "root:cluster" | chpasswd
 ---> Using cache
 ---> efea3085cc86
Step 4/5 : EXPOSE 22
 ---> Using cache
 ---> e2f07e03a4d1
Step 5/5 : CMD ["/usr/sbin/sshd","-D", "-o PermitRootLogin=yes"]
 ---> Using cache
 ---> b74515e20df7
Successfully built b74515e20df7
Successfully tagged perf-alpine-ssh:latest
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
perf-alpine-ssh     latest              b74515e20df7        3 hours ago         17.1MB
alpine              latest              e99e8929bba1        2 months ago        5.34MB
Run docker simulator for node range...
...
```


