### PR TITLE
EXECUTEALWAYS will only execute syncfile in the syncfile list

### DIFF
--- a/perl-xCAT/xCAT/DSHCLI.pm
+++ b/perl-xCAT/xCAT/DSHCLI.pm
@@ -6313,7 +6313,18 @@ sub run_always_rsync_postscripts
 
             # build xdsh queue
             # build host and all scripts to execute
-            push(@{ $dshparms->{'postscripts'}{$postsfile} }, $host);
+            # EXECUTEALWAYS will only execute the syncfile in the syncfile list
+            foreach my $key (keys $$options{'destDir_srcFile'}{$host}) {
+              foreach my $key1 (keys %{ $$options{'destDir_srcFile'}{$host}{$key} }) {
+                my $index = 0;
+                while (my $src_file = $$options{'destDir_srcFile'}{$host}{$key}{$key1}->[$index]) {
+                  if ($src_file eq $tmppostfile) {
+                      push(@{ $dshparms->{'postscripts'}{$postsfile} }, $host);
+                  }
+                  $index++;
+                }
+              }
+            }
         }
     }
 


### PR DESCRIPTION
The PR is to fix issue #5755 

### The modification include 
only execute the syncfile  if it in the syncfile list and  associate with the hostname in the nodelist via `updatenode` command

### The UT result
`##The UT output##`

````
]# cat /tmp/compute.synclist
/tmp/script.sh -> (mid21tor24cn06) /tmp/script.sh
/tmp/script3.sh -> (mid21tor24cn07) /tmp/script3.sh
EXECUTE:
/tmp/script.sh
EXECUTEALWAYS:
/tmp/script3.sh

[root@boston36 ~]# chdef -t osimage xcat.redhat.full.netboot synclists=/tmp/compute.synclist
1 object definitions have been created or modified.
````
1) only run EXECUTE cause for mid21tor24cn06, and will not run /tmp/script3.sh since this postscript only associate with mid21tor24cn07
````
[root@boston36 ~]# updatenode mid21tor24cn06 -F      
mid21tor24cn06: /tmp/script running on mid21tor24cn06
File synchronization has completed for nodes: "mid21tor24cn06"
[root@boston36 ~]# updatenode mid21tor24cn06 -F    <---- file already synced, nothing to run
File synchronization has completed for nodes: "mid21tor24cn06"
````
2) will always run EXECUTEALWAYS clause for mid21tor24cn07
````
[root@boston36 ~]# updatenode mid21tor24cn07 -F  
mid21tor24cn07: /tmp/script3 running on mid21tor24cn07
File synchronization has completed for nodes: "mid21tor24cn07"
[root@boston36 ~]# updatenode mid21tor24cn07 -F  
mid21tor24cn07: /tmp/script3 running on mid21tor24cn07
File synchronization has completed for nodes: "mid21tor24cn07"
````
3) modified syncfile file only has /tmp/script.sh in the syncfile list
```
[root@boston36 ~]# vi /tmp/compute.synclist
[root@boston36 ~]# cat /tmp/compute.synclist
/tmp/script.sh -> (mid21tor24cn06) /tmp/script.sh
/tmp/script.sh -> (mid21tor24cn07) /tmp/script.sh
EXECUTE:
/tmp/script.sh
EXECUTEALWAYS:
/tmp/script3.sh
````
4) the EXECUTEALWAYS should not run because it's not in the syncfile list
````
[root@boston36 ~]# updatenode mid21tor24cn07 -F
mid21tor24cn07: /tmp/script running on mid21tor24cn07
File synchronization has completed for nodes: "mid21tor24cn07"
[root@boston36 ~]# updatenode mid21tor24cn07 -F
File synchronization has completed for nodes: "mid21tor24cn07"
````
