### PR TITLE
Make status changing log more clear

### DIFF
--- a/xCAT-probe/subcmds/osdeploy
+++ b/xCAT-probe/subcmds/osdeploy
@@ -1169,10 +1169,11 @@ sub handle_cluster_msg {
     my $log_msg = $log_ref->{msg};
     my @split_log = split(/\s+/, $log_msg);
 
-    if ($split_log[1] eq "Allowing") {
-        my $command     = $split_log[2];
-        my $nodes_str   = $split_log[4];
-        my $sub_command = $split_log[5];
+    # As xcat log message will in both messages.log and cluster.log, need to filter one to avoid the duplication
+    if ($split_log[1] eq "xCAT:" && $split_log[2] eq "Allowing") {
+        my $command     = $split_log[3];
+        my $nodes_str   = $split_log[5];
+        my $sub_command = $split_log[6];
 
         if ($command eq "rinstall" or $command eq "rnetboot" or ($command eq "rpower" and $sub_command =~ /on|boot|reset/) or ($command eq "xdsh" and $log_msg =~ /reboot|shutdown -r/)) {
             my @nodes = probe_utils->parse_node_range($nodes_str);
@@ -1188,7 +1189,7 @@ sub handle_cluster_msg {
                 }
             }
         }
-    } elsif ($log_ref->{msg} =~ /(.+)\s+status:\s+(.+)\s+statustime:/) {
+    } elsif ($log_ref->{msg} =~ /INFO xcat.updatestatus - (.+):\s+changing status=(.+)/) {
         my $nodes  = $1;
         my $status = $2;
         my $record = "Node status is changed to $status";

--- a/xCAT-server/lib/xcat/monitoring/monitorctrl.pm
+++ b/xCAT-server/lib/xcat/monitoring/monitorctrl.pm
@@ -627,7 +627,7 @@ sub getNodeStatusFromNodesetState {
     Arguments:
        status -- a hash pointer of the node status. A key is a status string. The value is
                 an array pointer of nodes that have the same status.
-                for example: {alive=>["node1", "node1"], unreachable=>["node5","node100"]}
+                for example: {alive=>["node1", "node2"], unreachable=>["node5","node100"]}
        force -- 1 force the input values to be set.
              -- 0 make sure if the input value is the next valid value.
     Returns:
@@ -637,7 +637,7 @@ sub getNodeStatusFromNodesetState {
 
 #--------------------------------------------------------------------------------
 sub setNodeStatusAttributes {
-    print "monitorctrl::setNodeStatusAttributes called\n";
+    #print "monitorctrl::setNodeStatusAttributes called\n";
     my $temp = shift;
     if ($temp =~ /xCAT_monitoring::monitorctrl/) {
         $temp = shift;
@@ -703,8 +703,12 @@ sub setNodeStatusAttributes {
             if (@$nodes > 0) {
                 $updates{'status'}     = $_;
                 $updates{'statustime'} = $currtime;
-                my $nodestate = "@$nodes status: $updates{'status'} statustime: $updates{'statustime'}";
-                xCAT::MsgUtils->message('S', "$nodestate");
+                #my $nodestate = "@$nodes status: $updates{'status'} statustime: $updates{'statustime'}";
+                foreach my $node (@$nodes) {
+                    # To make the log clear, iterate for each node. This might be potential performance issue!
+                    my $nodestate = "xcat.updatestatus - $node: changing status=$updates{'status'}";
+                    xCAT::MsgUtils->message('S', "$nodestate");
+                }
                 my $where_clause;
                 my $dbname = xCAT::Utils->get_DBName();
 

--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -509,7 +509,12 @@ sub do_installm_service {
                             node    => [$node],
                             arg     => ["$newstat"],
                         );
-                        xCAT::MsgUtils->trace(0, "I", "xcatd: triggering \'updatenodestat $node $newstat\'...");
+                        # TODO, better to use constant here for the specified status
+                        if ($newstat eq 'installing') {
+                            xCAT::MsgUtils->trace(0, "I", "xcat.updatestatus - $node: provisioning detected...");
+                        } elsif ($newstat eq 'netbooting') {
+                            xCAT::MsgUtils->trace(0, "I", "xcat.updatestatus - $node: provisioning detected...");
+                        }
                         # node should be blocked, race condition may occur otherwise
                         #my $pid=xCAT::Utils->xfork();
                         #unless ($pid) { # fork off the nodeset and potential slowness


### PR DESCRIPTION
### The PR is to fix issue (#5618)

### The modification include
Clear key words for install status update log message 
- detect provisioning when updateing status to installing/netbooting
- consistent message format "xcat.updatestatus - ($node): changing status=($status)" (no need to log the time as syslog has the timestamp)
- xcatprobe - osdeploy will parse the log content, so it needs to be revised.

### The UT result
```
grep xcat.updatestatus /var/log/xcat/cluster.log
Nov 27 01:05:10 briggs01 xcat[111048]: INFO xcat.updatestatus - mid05tor12cn05: changing status=powering-off
Nov 27 01:05:45 briggs01 xcat[111048]: INFO xcat.updatestatus - mid05tor12cn05: changing status=powering-on
Nov 27 01:08:52 briggs01 xcat[110999]: INFO xcat.updatestatus - mid05tor12cn05: provisioning detected...
Nov 27 01:08:52 briggs01 xcat[110999]: INFO xcat.updatestatus - mid05tor12cn05: changing status=installing
Nov 27 01:25:20 briggs01 xcat[110999]: INFO xcat.updatestatus - mid05tor12cn05: changing status=booting
Nov 27 01:28:32 briggs01 xcat[110999]: INFO xcat.updatestatus - mid05tor12cn05: changing status=postbooting
Nov 27 01:29:49 briggs01 xcat[110999]: INFO xcat.updatestatus - mid05tor12cn05: changing status=booted
```

```
Nov 27 02:36:04 boston36 xcat[120448]: INFO xcat.updatestatus - mid21tor24cn04: changing status=powering-on
Nov 27 02:38:50 boston36 xcat[120391]: INFO xcat.updatestatus - mid21tor24cn04: provisioning detected...
Nov 27 02:38:50 boston36 xcat[120391]: INFO xcat.updatestatus - mid21tor24cn04: changing status=netbooting
Nov 27 02:40:52 boston36 xcat[120391]: INFO xcat.updatestatus - mid21tor24cn04: changing status=postbooting
Nov 27 02:41:06 boston36 xcat[120391]: INFO xcat.updatestatus - mid21tor24cn04: changing status=failed
```


