### PR TITLE
fix issue [automation] Installation failed on several OS because error in DSHCLI.pm #5840

### DIFF
--- a/perl-xCAT/xCAT/DSHCLI.pm
+++ b/perl-xCAT/xCAT/DSHCLI.pm
@@ -6314,7 +6314,7 @@ sub run_always_rsync_postscripts
             # build xdsh queue
             # build host and all scripts to execute
             # EXECUTEALWAYS will only execute the syncfile in the syncfile list
-            foreach my $key (keys $$options{'destDir_srcFile'}{$host}) {
+            foreach my $key (keys %{$$options{'destDir_srcFile'}{$host}}) {
               foreach my $key1 (keys %{ $$options{'destDir_srcFile'}{$host}{$key} }) {
                 my $index = 0;
                 while (my $src_file = $$options{'destDir_srcFile'}{$host}{$key}{$key1}->[$index]) {


### PR DESCRIPTION

### The PR is to fix issue https://github.com/xcat2/xcat-core/issues/5840

### The modification include
fix the issue due to perl syntax before perl 5.14, see https://stackoverflow.com/questions/20824920/perl-array-references-and-avoiding-type-of-arg-1-to-keys-must-be-hash-error

### The UT result
```
c910f02c01p14:~ # xdsh c910f02c01p06 "ls -l /tmp"
c910f02c01p06: total 24
c910f02c01p06: -rw------- 1 root root 227 Dec  4 10:11 ecdsa_key
c910f02c01p06: -rw------- 1 root root 180 Dec  4 10:11 ecdsa_key.pub
c910f02c01p06: -rwxr-xr-x 1 root root 966 Dec  4 10:11 updateflag
c910f02c01p06: -rw-r--r-- 1 root root 230 Dec  4 10:11 wget.log
c910f02c01p06: -rw-r--r-- 1 root root 145 Dec  4 10:11 xCAT-otherpkgs0.repo
c910f02c01p06: -rw-r--r-- 1 root root 157 Dec  4 10:11 xCAT-otherpkgs1.repo
c910f02c01p14:~ # cat /etc/os-release
NAME="SLES"
VERSION="11.4"
VERSION_ID="11.4"
PRETTY_NAME="SUSE Linux Enterprise Server 11 SP4"
ID="sles"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:suse:sles:11:4"
```