### PR TITLE
Fix issue 5150: tabch and tabdump commands can not deal with invalid attribute names

### DIFF
--- a/perl-xCAT/xCAT/Table.pm
+++ b/perl-xCAT/xCAT/Table.pm
@@ -4330,8 +4330,10 @@ sub delimitcol {
 #--------------------------------------------------------------------------------
 sub buildWhereClause {
     my $attrvalstr = shift;    # array of atr<op>val strings
+    my $getkeysonly = shift;
     my $whereclause;           # Where Clause
     my $firstpass = 1;
+    my @gotkeys = ();
     foreach my $m (@{$attrvalstr})
     {
         my $attr;
@@ -4372,6 +4374,9 @@ sub buildWhereClause {
             ($attr, $val) = split />/, $m, 2;
             $operator = ' > ';
         } else {
+            if (defined($getkeysonly)) {
+                return "Unsupported operator:$m on -w flag input";
+            }
             xCAT::MsgUtils->message("S", "Unsupported operator:$m  on -w flag input, could not build a Where Clause.");
             $whereclause = "";
             return $whereclause;
@@ -4386,7 +4391,12 @@ sub buildWhereClause {
 
         #$whereclause .="\')";
         $whereclause .= "\'";
-
+        if (defined($getkeysonly)) {
+            push @gotkeys, $attr;
+        }
+    }
+    if (defined($getkeysonly)) {
+        return \@gotkeys;
     }
     return $whereclause;
 

--- a/xCAT-server/lib/xcat/plugins/tabutils.pm
+++ b/xCAT-server/lib/xcat/plugins/tabutils.pm
@@ -730,6 +730,11 @@ sub tabdump
             $recs = $tabh->getAllEntries("all");
         } else {           # filter entries
             foreach my $w (@{$OPTW}) {    # get each attr=val
+                my ($k, $v) = split('=', $w, 2);
+                unless (grep /$k/, @{ $xCAT::Schema::tabspec{$table}->{cols} }) {
+                    $cb->({ error => "Table \"$table\" have no column called \"$k\"", errorcode => [1] });
+                    return;
+                }
                 push @attrarray, $w;
             }
             @ents = $tabh->getAllAttribsWhere(\@attrarray, 'ALL');
@@ -2369,6 +2374,16 @@ sub tabch {
                     return 1;
 
                 }
+            }
+            my $err_found = 0;
+            for my $k (keys %keyhash) {
+                unless (grep /$k/, @{ $xCAT::Schema::tabspec{$table}->{cols} }) {
+                    $callback->({ error => "Table \"$table\" have no column called \"$k\"", errorcode => [1] });
+                    $err_found = 1;
+                }
+            }
+            if ($err_found) {
+                return 1;
             }
 
             #splice assignment


### PR DESCRIPTION

### The PR is to fix issue #5150 

### The modification include

checking the specified column name before doing SQL query.

### The UT result
Before fix:
```
root@c910f03c05k10:~# tabch networkxyz='abcnetwork' networks.comments="ABC"
root@c910f03c05k10:~# echo $?
0
root@c910f03c05k10:~# tabdump -w 'netmaskxyz==255.0.0.0' networks
Error: [c910f03c05k10]: tabutils plugin bug, pid 6433, process description: 'xcatd SSL: tabdump for root@localhost: tabutils instance' with error 'Can't use string ("*XCATBUGDETECTED*:Can't call met"...) as a HASH ref while "strict refs" in use at /opt/xcat/lib/perl/xCAT_plugin/tabutils.pm line 1301.
'
root@c910f03c05k10:~# echo $?
1
```
With fix
```
root@c910f03c05k10:~# tabch networkxyz='abcnetwork' networks.comments="ABC"
Error: [c910f03c05k10]: Table "networks" have no column called "networkxyz"
root@c910f03c05k10:~# echo $?
1
root@c910f03c05k10:~# tabdump -w 'netmaskxyz==255.0.0.0' networks
Error: [c910f03c05k10]: Table "networks" have no column called "netmaskxyz"
root@c910f03c05k10:~# echo $?
1
```