### PR TITLE
fix for issue5848

### DIFF
--- a/xCAT-test/autotest/testcase/go_xcat/case0
+++ b/xCAT-test/autotest/testcase/go_xcat/case0
@@ -17,7 +17,7 @@ cmd:xdsh $$CN "cd /; tar -jxf /xcat-core.tar.bz2"
 check:rc==0
 cmd:xdsh $$CN "cd /xcat-core; ./mklocalrepo.sh"
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go-xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
+cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
@@ -56,7 +56,7 @@ cmd:xdsh $$CN "cd /; scp -r $$MN:/core-*-snap.tar.bz2 /xcat-core.tar.bz2"
 check:rc==0
 cmd:xdsh $$CN "cd /; tar -jxf /xcat-core.tar.bz2"
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go-xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
+cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
@@ -95,7 +95,7 @@ cmd:xdsh $$CN "cd /; scp -r $$MN:/core-*-snap.tar.bz2 /xcat-core.tar.bz2"
 check:rc==0
 cmd:xdsh $$CN "cd /; bunzip2 /xcat-core.tar.bz2"
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go-xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
+cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
@@ -134,7 +134,7 @@ cmd:xdsh $$CN "cd /; scp -r $$MN:/core-*-snap.tar.bz2 /xcat-core.tar.bz2"
 check:rc==0
 cmd:xdsh $$CN "cd /; scp -r $$MN:/xcat-dep*.tar.bz2 /xcat-dep.tar.bz2"
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go-xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
+cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
@@ -181,7 +181,7 @@ cmd:xdsh $$CN "cd /; tar -jxf /xcat-core.tar.bz2"
 check:rc==0
 cmd:xdsh $$CN "cd /xcat-core; ./mklocalrepo.sh"
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go-xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
+cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
@@ -224,7 +224,7 @@ cmd:xdsh $$CN "cd /; tar -jxf /xcat-dep.tar.bz2"
 check:rc==0
 cmd:xdsh $$CN "cd /; tar -jxf /xcat-core.tar.bz2"
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go-xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
+cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
@@ -261,7 +261,7 @@ cmd:xdsh $$CN "cd /; scp -r $$MN:/core-*-snap.tar.bz2 /xcat-core.tar.bz2"
 check:rc==0
 cmd:xdsh $$CN "cd /; scp -r $$MN:/xcat-dep*.tar.bz2 /xcat-dep.tar.bz2"
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go-xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
+cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi

--- a/xCAT-test/autotest/testcase/go_xcat/case1
+++ b/xCAT-test/autotest/testcase/go_xcat/case1
@@ -12,7 +12,7 @@ cmd:xdsh $$CN "cd /; rm -rf /go-xcat"
 check:rc==0
 cmd:xdsh $$CN "cd /; scp -r $$MN:/opt/xcat/share/xcat/tools/go-xcat ./"
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go-xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
+cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
@@ -47,7 +47,7 @@ cmd:xdsh $$CN "cd /; rm -rf /go-xcat"
 check:rc==0
 cmd:xdsh $$CN "cd /; scp -r $$MN:/opt/xcat/share/xcat/tools/go-xcat ./"
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go-xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
+cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
@@ -89,7 +89,7 @@ cmd:xdsh $$CN "cd /; rm -rf /go-xcat"
 check:rc==0
 cmd:xdsh $$CN "cd /; scp -r $$MN:/opt/xcat/share/xcat/tools/go-xcat ./"
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go-xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
+cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
@@ -124,7 +124,7 @@ cmd:xdsh $$CN "cd /; rm -rf /go-xcat"
 check:rc==0
 cmd:xdsh $$CN "cd /; scp -r $$MN:/opt/xcat/share/xcat/tools/go-xcat ./"
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go-xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
+cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi

--- a/xCAT-test/autotest/testcase/go_xcat/case2
+++ b/xCAT-test/autotest/testcase/go_xcat/case2
@@ -42,7 +42,7 @@ cmd:xdsh $$CN "cd /; rm -rf /go-xcat"
 check:rc==0
 cmd:xdsh $$CN "cd /; scp -r $$MN:/opt/xcat/share/xcat/tools/go-xcat ./"
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go-xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
+cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
@@ -78,7 +78,7 @@ cmd:xdsh $$CN "cd /; rm -rf /go-xcat"
 check:rc==0
 cmd:xdsh $$CN "cd /; scp -r $$MN:/opt/xcat/share/xcat/tools/go-xcat ./"
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go-xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
+cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
@@ -146,7 +146,7 @@ check:rc==0
 cmd:xdsh $$CN "cd /; scp -r $$MN:/opt/xcat/share/xcat/tools/go-xcat ./"
 check:rc==0
 cmd:dir="__GETNODEATTR($$CN,os)__"; if grep SUSE /etc/*release;then os=`echo $dir |cut -c 1-6` && xdsh $$CN "cd /xcat-dep/$os/__GETNODEATTR($$CN,arch)__/; ./mklocalrepo.sh" ; elif grep "Red Hat" /etc/*release;then os=`echo $dir |cut -c 1-2` && xdsh $$CN "cd /xcat-dep/$os`echo __GETNODEATTR($$CN,os)__ | cut -c6`/__GETNODEATTR($$CN,arch)__/; ./mklocalrepo.sh"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cd /xcat-dep; ./mklocalrepo.sh"; else echo "Sorry,this is not supported os"; fi
-cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go-xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
+cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
@@ -182,7 +182,7 @@ cmd:xdsh $$CN "cd /; scp -r $$MN:/opt/xcat/share/xcat/tools/go-xcat ./"
 check:rc==0
 cmd:cp /xcat-dep-*.tar.bz2 /install/
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go-xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
+cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi

--- a/xCAT-test/autotest/testcase/go_xcat/case4
+++ b/xCAT-test/autotest/testcase/go_xcat/case4
@@ -15,7 +15,7 @@ cmd:xdsh $$CN "cd /; scp -r $$MN:/core-*-snap.tar.bz2 /xcat-core.tar.bz2"
 check:rc==0
 cmd:xdsh $$CN "cd /; scp -r $$MN:/xcat-dep*.tar.bz2 /xcat-dep.tar.bz2"
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go-xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
+cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi

--- a/xCAT-test/autotest/testcase/install_xCAT/case0
+++ b/xCAT-test/autotest/testcase/install_xCAT/case0
@@ -28,7 +28,7 @@ description:install xCAT with go-xcat tool in a fresh environment for ubuntu
 label:xcat_install
 os:Linux
 stop:yes
-cmd:arc_all=`uname -a`; code=`lsb_release -sc`;if [[ $arc_all =~ "ppc64le" ]]; then arch="ppc64el";else arch="x86_64";fi; cp "/opt/xcat/share/xcat/tools/autotest/testcase/go-xcat/$code-$arch.sources.list" "/etc/apt/sources.list"
+cmd:arc_all=`uname -a`; code=`lsb_release -sc`;if [[ $arc_all =~ "ppc64le" ]]; then arch="ppc64el";else arch="x86_64";fi; cp "/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-$arch.sources.list" "/etc/apt/sources.list"
 cmd:apt-get clean;apt-get update
 check:rc==0
 cmd:cp /core-*-snap.tar.bz2 /install_xCAT_xcat-core.tar.bz2


### PR DESCRIPTION
### The PR is to fix issue #5848 

### The modification include

* change the directory from "go-xcat" to "go_xcat:

### The UT result
```
------START::install_xCAT_on_ubuntu::Time:Wed Nov 28 23:58:17 2018------

RUN:arc_all=`uname -a`; code=`lsb_release -sc`;if [[ $arc_all =~ "ppc64le" ]]; then arch="ppc64el";else arch="x86_64";fi; cp "/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-$arch.sources.list" "/etc/apt/sources.list" [Wed Nov 28 23:58:17 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:apt-get clean;apt-get update [Wed Nov 28 23:58:17 2018]
ElapsedTime:4 sec
RETURN rc = 0
OUTPUT:
Hit:1 http://ports.ubuntu.com/ubuntu-ports bionic InRelease
Get:2 http://ports.ubuntu.com/ubuntu-ports bionic-updates InRelease [88.7 kB]
Get:3 http://ports.ubuntu.com/ubuntu-ports bionic-security InRelease [83.2 kB]
Get:4 http://ports.ubuntu.com/ubuntu-ports bionic/restricted ppc64el Packages [664 B]
Get:5 http://ports.ubuntu.com/ubuntu-ports bionic/restricted Translation-en [3584 B]
Get:6 http://ports.ubuntu.com/ubuntu-ports bionic-updates/main ppc64el Packages [366 kB]
Get:7 http://ports.ubuntu.com/ubuntu-ports bionic-updates/main Translation-en [166 kB]
Get:8 http://ports.ubuntu.com/ubuntu-ports bionic-updates/restricted ppc64el Packages [668 B]
Get:9 http://ports.ubuntu.com/ubuntu-ports bionic-updates/restricted Translation-en [3076 B]
Get:10 http://ports.ubuntu.com/ubuntu-ports bionic-updates/universe ppc64el Packages [490 kB]
Get:11 http://ports.ubuntu.com/ubuntu-ports bionic-security/main ppc64el Packages [154 kB]
Get:12 http://ports.ubuntu.com/ubuntu-ports bionic-security/main Translation-en [81.8 kB]
Get:13 http://ports.ubuntu.com/ubuntu-ports bionic-security/universe ppc64el Packages [89.9 kB]
Get:14 http://ports.ubuntu.com/ubuntu-ports bionic-security/universe Translation-en [55.1 kB]
Fetched 1584 kB in 3s (564 kB/s)
Reading package lists...
CHECK:rc == 0	[Pass]
.....
RUN:service xcatd status [Thu Nov 29 00:05:36 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
● xcatd.service - xCAT management service
   Loaded: loaded (/lib/systemd/system/xcatd.service; enabled; vendor preset: enabled)
   Active: active (running) since Thu 2018-11-29 00:00:05 EST; 5min ago
 Main PID: 26279 (xcatd: SSL list)
    Tasks: 9 (limit: 4730)
   CGroup: /system.slice/xcatd.service
           ├─ 1725 xcatd SSL: lsxcatd for root@localhost
           ├─26266 /usr/sbin/in.tftpd -v -l -s /tftpboot -m /etc/tftpmapfile4xcat.conf
           ├─26279 xcatd: SSL listener
           ├─26280 xcatd: DB Access
           ├─26283 xcatd: UDP listener
           ├─26284 xcatd: install monitor
           ├─26285 xcatd: Command log writer
           └─26290 xcatd: Discovery worker

Nov 29 00:00:03 f6u13k13 xcatd[26216]: Smartmatch is experimental at /opt/xcat/lib/perl/xCAT_plugin/openbmc.pm line 1233.
Nov 29 00:00:04 f6u13k13 xcat[26285]: xcatd: Command log writer process 26285 start
Nov 29 00:00:04 f6u13k13 xcat[26284]: xcatd: install monitor process 26284 start
Nov 29 00:00:04 f6u13k13 xcat[26283]: xcatd: UDP listener process 26283 start
Nov 29 00:00:04 f6u13k13 xcat[26290]: xcatd: Discovery worker process 26290 start
Nov 29 00:00:04 f6u13k13 xcatd[26216]:  *
Nov 29 00:00:05 f6u13k13 systemd[1]: Started xCAT management service.
Nov 29 00:00:08 f6u13k13 xcat[26564]: xCAT: Allowing mknb ppc64 for root from localhost
Nov 29 00:02:52 f6u13k13 xcat[26581]: xCAT: Allowing mknb x86_64 for root from localhost
Nov 29 00:05:36 f6u13k13 xcat[1725]: xCAT: Allowing lsxcatd -v for root from localhost
CHECK:rc == 0	[Pass]
CHECK:output =~ running	[Pass]

RUN:rm -rf /install_xCAT_xcat-core.tar.bz2 /install_xCAT_xcat-dep.tar.bz2 [Thu Nov 29 00:05:36 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::install_xCAT_on_ubuntu::Passed::Time:Thu Nov 29 00:05:36 2018 ::Duration::439 sec------
------Total: 1 , Failed: 0------
```