### PR TITLE
fix issue 5858 test cases  failed due to the change of output of rbeacon

### DIFF
--- a/xCAT-test/autotest/testcase/rbeacon/cases0
+++ b/xCAT-test/autotest/testcase/rbeacon/cases0
@@ -55,6 +55,6 @@ hcp:openbmc
 label:cn_bmc_ready,hctrl_openbmc
 cmd:rbeacon $$CN abc
 check:rc!=0
-check:output=~$$CN\s*:\s*Error:\s*Only \'on\', \'off\' or \'stat\' is supported
+check:output=~$$CN\s*:\s*Error:\s*Only \'on\', \'off\' and \'stat\' are supported
 end
 


### PR DESCRIPTION
### The PR is to fix issue #5858 

### The modification include

* update test case `rbeacon_false`

### The UT result

```
------START::rbeacon_false::Time:Fri Nov 30 19:57:01 2018------

RUN:rbeacon f5u14 abc [Fri Nov 30 19:57:01 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
f5u14: Error: Only 'on', 'off' and 'stat' are supported for OpenBMC managed nodes.
CHECK:rc != 0	[Pass]
CHECK:output =~ f5u14\s*:\s*Error:\s*Only \'on\', \'off\' and \'stat\' are supported	[Pass]

------END::rbeacon_false::Passed::Time:Fri Nov 30 19:57:01 2018 ::Duration::0 sec------
```