### PR TITLE
enhance pr 5715 of httpport check

### DIFF
--- a/xCAT-probe/lib/perl/probe_utils.pm
+++ b/xCAT-probe/lib/perl/probe_utils.pm
@@ -290,11 +290,11 @@ sub is_http_ready {
     my $installdir = shift;
     my $errormsg_ref = shift;
 
-    my $http_status = `netstat -tunlp | grep -e "httpd" -e "apache" | grep "LISTEN" 2>&1`;
+    my $http_status = `netstat -tnlp | grep -e "httpd" -e "apache" 2>&1`;
     if (!$http_status) {
         $$errormsg_ref = "No HTTP listening status get by command 'netstat'";
         return 0;
-    } elsif ($http_status !~ /\S*\s+\S*\s+\S*\s+\S*$httpport\s+.+/) {
+    } elsif ($http_status !~ /\S*\s+\S*\s+\S*\s+\S*:$httpport\s+.+/) {
         $$errormsg_ref = "The port defined in 'site' table HTTP is not listening";
         return 0;
     }


### PR DESCRIPTION
### The PR is to fix issue _#5701_

### The modification include

_##Grep httpport with ':' before it_

### The UT result
```
[mn]: Checking important directories(installdir,tftpdir) are configured...                                        [ OK ]
[mn]: Checking SELinux is disabled...                                                                             [ OK ]
[mn]: Checking HTTP service is configured...                                                                      [FAIL]
[mn]: The port defined in 'site' table HTTP is not listening
[mn]: Checking TFTP service is configured...                                                                      [ OK ]
[mn]: Checking DNS service is configured...                                                                       [ OK ]
```