### PR TITLE
update install new kernel doc

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/common/deployment/install_new_kernel.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/deployment/install_new_kernel.rst
@@ -4,9 +4,9 @@ Installing a New Kernel in the Diskless Image
 
 Note: This procedure assumes you are using xCAT 2.6.1 or later.
 
-The kerneldir attribute in linuximage table can be used to assign a directory containing kernel RPMs that can be installed into diskless images. The default for kernerdir is /install/kernels. To add a new kernel, create a directory named <kernelver> under the kerneldir, and genimage will pick them up from there.
+To add a new kernel, create a directory named <kernelver> under ``/install/kernels`` directory, and ``genimage`` will pick them up from there.
 
-The following examples assume you have the kernel RPM in /tmp and is using the default value for kerneldir (/install/kernels).
+The following examples assume you have the kernel RPM in ``/tmp`` and is using a new kernel in the directory ``/install/kernels/<kernelver>``.
 
 
 The RPM names below are only examples, substitute your specific level and architecture.
@@ -20,6 +20,9 @@ For example, kernel-3.10.0-229.ael7b.ppc64le.rpm means kernelver=3.10.0-229.ael7
         mkdir -p /install/kernels/3.10.0-229.ael7b.ppc64le
         cp /tmp/kernel-3.10.0-229.ael7b.ppc64le.rpm /install/kernels/3.10.0-229.ael7b.ppc64le
         createrepo /install/kernels/3.10.0-229.ael7b.ppc64le/
+
+Append kernel directory ``/install/kernels/<kernelver>`` in ``pkgdir`` of specific osimage. ::
+
         chdef -t osimage <imagename> -p pkgdir=/install/kernels/3.10.0-229.ael7b.ppc64le/
 
 Run genimage/packimage to update the image with the new kernel.
@@ -45,6 +48,9 @@ The "4.6.ppc64le" is replaced with "4-ppc64le": ::
          cp /tmp/kernel-default-3.12.28-4.6.ppc64le.rpm /install/kernels/3.12.28-4-ppc64le/
          cp /tmp/kernel-default-base-3.12.28-4.6.ppc64le.rpm /install/kernels/3.12.28-4-ppc64le/
          cp /tmp/kernel-default-devel-3.12.28-4.6.ppc64le.rpm /install/kernels/3.12.28-4-ppc64le/
+
+Append kernel directory ``/install/kernels/<kernelver>`` in ``pkgdir`` of specific osimage. ::
+
          chdef -t osimage <imagename> -p pkgdir=/install/kernels/3.12.28-4-ppc64le/
 
 Run genimage/packimage to update the image with the new kernel.


### PR DESCRIPTION
### The PR is to fix issue _#xxx_
https://github.com/xcat2/xcat-core/issues/5864

The `kerneldir` mislead user to use `kerneldir` in osimage definition. We should make clear about this.
User have the following misunderstanding:
The document seems to have a problem with the examples —
the description talks about “kerneldir” attribute, but the example uses “pkgdir”.
When I use pkgdir it clobbers the existing value (/install/rhels7.3/x86_64)
with new value (/install/kernels/3.10.0-862.14.14.el7.x86_64)
I think it should say chdef -t osimage <> -p kerneldir=<>
I got further using that format. However, I’m still having trouble with the packimage
command “Error: Cannot find rhels7.3-x86_64-neboot-comp_kup from the linuximage table.
But it’s there:
...

### The UT result
http://10.5.106.1/install/kernel/xcat-core/docs/build/html/guides/admin-guides/manage_clusters/ppc64le/diskless/customize_image/install_new_kernel.html

