### PR TITLE
update xcat inventory cases for template and format change

### DIFF
--- a/xCAT-test/autotest/testcase/xcat_inventory/cases.node
+++ b/xCAT-test/autotest/testcase/xcat_inventory/cases.node
@@ -784,7 +784,7 @@ check:rc==0
 end
 
 start:xcat_inventory_try_to_export_all_type_is_node_default_format
-label:others,xcat_inventory
+label:others,inventory_ci
 description:This case is used to test xcat-inventory export all definition which type is node by default format. I.e, do not specify the format of export.
 cmd:mkdir -p /tmp/xcat_inventory_try_to_export_all_type_is_node_default_format
 check:rc==0
@@ -811,7 +811,7 @@ cmd:dn=$(cat /tmp/xcat_inventory_try_to_export_all_type_is_node_default_format/n
 check:rc==0
 cmd:a=0;for i in `awk -F':' '{print $1}' /tmp/xcat_inventory_try_to_export_all_type_is_node_default_format/group_in_xcat_db`; do  grep -E " $i:" /tmp/xcat_inventory_try_to_export_all_type_is_node_default_format/export_all_node; if [[ $? -eq 0 ]]; then ((a++));fi;done;dg=$(cat /tmp/xcat_inventory_try_to_export_all_type_is_node_default_format/group_in_xcat_db|wc -l);if [[ $a -eq $dg ]]; then exit 0; else exit 1;fi
 check:rc==0
-cmd:a=0;for i in `awk -F' ' '{print $1}' /tmp/xcat_inventory_try_to_export_all_type_is_node_default_format/node_in_xcat_db`;do  grep -E ""$i:" /tmp/xcat_inventory_try_to_export_all_type_is_node_default_format/export_all_node; if [[ $? -eq 0 ]]; then ((a++));fi;done;dn=$(cat /tmp/xcat_inventory_try_to_export_all_type_is_node_default_format/node_in_xcat_db |wc -l); if [[ $dn -eq $a ]]; then exit 0; else exit 1;fi
+cmd:a=0;for i in `awk -F' ' '{print $1}' /tmp/xcat_inventory_try_to_export_all_type_is_node_default_format/node_in_xcat_db`;do  grep -E " $i:" /tmp/xcat_inventory_try_to_export_all_type_is_node_default_format/export_all_node; if [[ $? -eq 0 ]]; then ((a++));fi;done;dn=$(cat /tmp/xcat_inventory_try_to_export_all_type_is_node_default_format/node_in_xcat_db |wc -l); if [[ $dn -eq $a ]]; then exit 0; else exit 1;fi
 check:rc==0
 cmd:rmdef bogusnode[1-3]
 check:rc==0
@@ -870,7 +870,7 @@ end
 
 
 start:xcat_inventory_try_to_export_all_type_is_node_json_format
-label:others,xcat_inventory
+label:others,inventory_ci
 description:This case is used to test xcat-inventory export all definition which type is node by json format.
 cmd:mkdir -p /tmp/xcat_inventory_try_to_export_all_type_is_node_json_format
 check:rc==0
@@ -888,9 +888,9 @@ cmd:lsdef -t group -i grouptype  -c|grep "grouptype=static" |tee /tmp/xcat_inven
 check:rc==0
 cmd:xcat-inventory export  --format=json -t node  |tee /tmp/xcat_inventory_try_to_export_all_type_is_node_json_format/export_all_node
 check:rc==0
-cmd: grep "xcatdefaults:" /tmp/xcat_inventory_try_to_export_all_type_is_node_json_format/export_all_node > /dev/null 2>&1; if [[ $? -eq 0 ]]; then exit 0; else exit 1;fi
+cmd: grep "xcatdefaults" /tmp/xcat_inventory_try_to_export_all_type_is_node_json_format/export_all_node > /dev/null 2>&1; if [[ $? -eq 0 ]]; then exit 0; else exit 1;fi
 check:rc==0
-cmd: grep "service:" /tmp/xcat_inventory_try_to_export_all_type_is_node_json_format/export_all_node > /dev/null 2>&1; if [[ $? -eq 0 ]]; then exit 0; else exit 1;fi
+cmd: grep "service" /tmp/xcat_inventory_try_to_export_all_type_is_node_json_format/export_all_node > /dev/null 2>&1; if [[ $? -eq 0 ]]; then exit 0; else exit 1;fi
 check:rc==0
 cmd:dn=$(cat /tmp/xcat_inventory_try_to_export_all_type_is_node_json_format/node_in_xcat_db|wc -l);dg=$(cat /tmp/xcat_inventory_try_to_export_all_type_is_node_json_format/group_in_xcat_db |wc -l);((da=$dn+$dg+2));ia=$(grep " \"obj_type\": " /tmp/xcat_inventory_try_to_export_all_type_is_node_json_format/export_all_node|wc -l); if [[ $da -eq $ia ]];then exit 0; else exit 1;fi
 check:rc==0
@@ -2020,7 +2020,7 @@ check:rc!=0
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/validatehelper "node" "bogusnode" "obj_type" "node" "import_validation_node_obj_type"
 check:rc==0
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/validatehelper "node" "bogusnode" "obj_type" "group" "import_validation_node_obj_type"
-check:rc==0
+check:rc!=0
 cmd:if [[ -e /tmp/import_validation_node_obj_type_bak/bogusnode.stanza ]]; then cat /tmp/import_validation_node_obj_type_bak/bogusnode.stanza | mkdef -z;fi
 check:rc==0
 cmd:if [[ -e /tmp/import_validation_node_obj_type_bak/bogusgroup.stanza ]]; then cat /tmp/import_validation_node_obj_type_bak/bogusgroup.stanza |mkdef -z -f;fi
@@ -2064,13 +2064,13 @@ check:rc!=0
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/validatehelper "node" "bogusnode" "device_type" "aaa" "import_validation_node_device_type"
 check:rc!=0
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/validatehelper "node" "bogusnode" "device_type" "switch" "import_validation_node_device_type"
-check:rc==0
+check:rc!=0
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/validatehelper "node" "bogusnode" "device_type" "pdu" "import_validation_node_device_type"
-check:rc==0
+check:rc!=0
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/validatehelper "node" "bogusnode" "device_type" "rack" "import_validation_node_device_type"
-check:rc==0
+check:rc!=0
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/validatehelper "node" "bogusnode" "device_type" "hmc"  "import_validation_node_device_type"
-check:rc==0
+check:rc!=0
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/validatehelper "node" "bogusnode" "device_type" "server"  "import_validation_node_device_type"
 check:rc==0
 cmd:if [[ -e /tmp/import_validation_node_device_type_bak/bogusnode.stanza ]]; then cat /tmp/import_validation_node_device_type_bak/bogusnode.stanza | mkdef -z;fi
@@ -2310,26 +2310,26 @@ check:rc==0
 end
 
 
-start:import_validation_node_network_info_primarynic_switchport
-label:others,xcat_inventory
-descrswitchporttion:This case is used to test node validation function of xcat-inventory import yaml and json file. To test "network_info.primarynic.switchport" attribute
-cmd:mkdir -p /tmp/import_validation_node_network_info_primarynic_switchport_bak
+start:import_validation_node_network_info_connections_switchport
+label:others,inventory_ci
+descrswitchporttion:This case is used to test node validation function of xcat-inventory import yaml and json file. To test "network_info.connections.switchport" attribute
+cmd:mkdir -p /tmp/import_validation_node_network_info_connections_switchport_bak
 check:rc==0
-cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/import_validation_node_network_info_primarynic_switchport_bak/bogusnode.stanza ;rmdef bogusnode;fi
+cmd:lsdef bogusnode > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef bogusnode -z >/tmp/import_validation_node_network_info_connections_switchport_bak/bogusnode.stanza ;rmdef bogusnode;fi
 check:rc==0
-cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/import_validation_node_network_info_primarynic_switchport_bak/bogusgroup.stanza; rmdef -t group bogusgroup;fi
+cmd:lsdef -t group bogusgroup  > /dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t group bogusgroup -z > /tmp/import_validation_node_network_info_connections_switchport_bak/bogusgroup.stanza; rmdef -t group bogusgroup;fi
 check:rc==0
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/validatehelper "node" "bogusnode" "network_info.primarynic.switchport" "" "/tmp/import_validation_node_network_info_primarynic_switchport"
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/validatehelper "node" "bogusnode" "network_info.connections.switchport" "" "/tmp/import_validation_node_network_info_connections_switchport"
 check:rc==0
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/validatehelper "node" "bogusnode" "network_info.primarynic.switchport" "70" "/tmp/import_validation_node_network_info_primarynic_switchport"
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/validatehelper "node" "bogusnode" "network_info.connections.switchport" "70" "/tmp/import_validation_node_network_info_connections_switchport"
 check:rc==0
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/validatehelper "node" "bogusnode" "network_info.primarynic.switchport" "a90" "/tmp/import_validation_node_network_info_primarynic_switchport"
-check:rc!=0
-cmd:if [[ -e /tmp/import_validation_node_network_info_primarynic_switchport_bak/bogusnode.stanza ]]; then cat /tmp/import_validation_node_network_info_primarynic_switchport_bak/bogusnode.stanza | mkdef -z;fi
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/validatehelper "node" "bogusnode" "network_info.connections.switchport" "a90" "/tmp/import_validation_node_network_info_connections_switchport"
 check:rc==0
-cmd:if [[ -e /tmp/import_validation_node_network_info_primarynic_switchport_bak/bogusgroup.stanza ]]; then cat /tmp/import_validation_node_network_info_primarynic_switchport_bak/bogusgroup.stanza |mkdef -z -f;fi
+cmd:if [[ -e /tmp/import_validation_node_network_info_connections_switchport_bak/bogusnode.stanza ]]; then cat /tmp/import_validation_node_network_info_connections_switchport_bak/bogusnode.stanza | mkdef -z;fi
 check:rc==0
-cmd:rm -rf /tmp/import_validation_node_network_info_primarynic_switchport_bak
+cmd:if [[ -e /tmp/import_validation_node_network_info_connections_switchport_bak/bogusgroup.stanza ]]; then cat /tmp/import_validation_node_network_info_connections_switchport_bak/bogusgroup.stanza |mkdef -z -f;fi
+check:rc==0
+cmd:rm -rf /tmp/import_validation_node_network_info_connections_switchport_bak
 check:rc==0
 end
 
@@ -2425,7 +2425,7 @@ check:rc==0
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/validatehelper "node" "bogusnode" "role" "compute" "/tmp/import_validation_node_role"
 check:rc==0
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/validatehelper "node" "bogusnode" "role" "service" "/tmp/import_validation_node_role"
-check:rc==0
+check:rc!=0
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/validatehelper "node" "bogusnode" "role" "" "/tmp/import_validation_node_role"
 check:rc!=0
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/validatehelper "node" "bogusnode" "role" "Compute" "/tmp/import_validation_node_role"

--- a/xCAT-test/autotest/testcase/xcat_inventory/cases.site
+++ b/xCAT-test/autotest/testcase/xcat_inventory/cases.site
@@ -93,7 +93,7 @@ end
 
 
 start:xcat_inventory_try_to_export_all_type_is_site_default_format
-label:others,xcat_inventory
+label:others,inventory_ci
 description:This case is used to test xcat-inventory export all definition which type is site to default file. I.e. json file
 cmd:mkdir -p /tmp/xcat_inventory_try_to_export_all_type_is_site_default_format
 check:rc==0
@@ -101,100 +101,99 @@ cmd: lsdef -t site -o clustersite -z >/tmp/xcat_inventory_try_to_export_all_type
 check:rc==0
 cmd:mnip=$(lsdef -t site -o clustersite -i master -c|awk -F'=' '{print $2}');chdef -t site -o clustersite  useSSHonAIX=0 useNFSv4onAIX=0 FQDNfirst=1 SNsyncfiledir='/var/xcat/syncfiles' auditnosyslog=0 auditskipcmds=ALL blademaxp=64 cleanupxcatpost=no consoleondemand=no databaseloc='/var/lib' db2installloc='/mntdb2' dbtracelevel=0 defserialflow=0 defserialport=0 defserialspeed=9600 dhcpinterfaces=eth0 dhcplease=43200 dhcpsetup=n disjointdhcps=1 dnshandler=ddns dnsinterfaces='xcatmn|eth1,eth2;service|bond0' dnsupdaters=dnsupdaters domain='pok.stglabs.ibm.com' enableASMI=no excludenodes=excludenodes externaldns=externaldns extntpservers=extntpservers forwarders=$mnip fsptimeout=0 genmacprefix='00:11:aa' genpasswords=genpasswords hierarchicalattrs=hierarchicalattrs httpport=80 hwctrldispatch=y installdir='/install/' installloc='hostname:/path' ipmidispatch=y ipmimaxp=64 ipmiretries=3 ipmisdrcache=no ipmitimeout=2 iscsidir='/iscsidir' managedaddressmode=dhcp master=$mnip maxssh=8 mnroutenames=mnroutenames nameservers=$mnip nmapoptions='--min-rtt-timeout' nodestatus=n nodesyncfiledir='/var/xcat/node/syncfiles' ntpservers=$mnip persistkvmguests=y powerinterval=0 ppcmaxp=64 ppcretry=3 ppctimeout=0 precreatemypostscripts=1 pruneservices=1 runbootscripts=yes setinstallnic=1 sharedinstall=no sharedtftp=1 skiptables=nics skipvalidatelog=1 snmpc=snmpc sshbetweennodes=ALLGROUPS svloglocal=1 syspowerinterval=10 syspowermaxnodes=10 tftpdir='/tftprot/' tftpflags='-v' timezone='America/New_York' useNmapfromMN=no useflowcontrol=no usexhrm=no vcenterautojoin=no vmwarereconfigonpower=no vsftp=n xcatconfdir='/etc/xcat' xcatdebugmode=1 xcatdport=3001 xcatiport=3002 xcatlport=3003 xcatmaxbatchconnections=64 xcatmaxconnections=60 xcatsslciphers='3DES' xcatsslversion=TLSv1
 check:rc==0
-cmd:#!/bin/bash
-echo " 
- schema_version: '2.0'
- site:
-   clustersite:
-     FQDNfirst: '1'
-     SNsyncfiledir: /var/xcat/syncfiles
-     auditnosyslog: '0'
-     auditskipcmds: ALL
-     blademaxp: '64'
-     cleanupxcatpost: 'no'
-     consoleondemand: 'no'
-     databaseloc: /var/lib
-     db2installloc: /mntdb2
-     dbtracelevel: '0'
-     defserialflow: '0'
-     defserialport: '0'
-     defserialspeed: '9600'
-     dhcpinterfaces: eth0
-     dhcplease: '43200'
-     dhcpsetup: n
-     disjointdhcps: '1'
-     dnshandler: ddns
-     dnsinterfaces: xcatmn|eth1,eth2;service|bond0
-     dnsupdaters: dnsupdaters
-     domain: pok.stglabs.ibm.com
-     enableASMI: 'no'
-     excludenodes: excludenodes
-     externaldns: externaldns
-     extntpservers: extntpservers
-     forwarders: 10.3.1.13
-     fsptimeout: '0'
-     genmacprefix: 00:11:aa
-     genpasswords: genpasswords
-     hierarchicalattrs: hierarchicalattrs
-     httpport: '80'
-     hwctrldispatch: y
-     installdir: /install/
-     installloc: hostname:/path
-     ipmidispatch: y
-     ipmimaxp: '64'
-     ipmiretries: '3'
-     ipmisdrcache: 'no'
-     ipmitimeout: '2'
-     iscsidir: /iscsidir
-     managedaddressmode: dhcp
-     master: 10.3.1.13
-     maxssh: '8'
-     mnroutenames: mnroutenames
-     nameservers: 10.3.1.13
-     nmapoptions: --min-rtt-timeout
-     nodestatus: n
-     nodesyncfiledir: /var/xcat/node/syncfiles
-     ntpservers: 10.3.1.13
-     persistkvmguests: y
-     powerinterval: '0'
-     ppcmaxp: '64'
-     ppcretry: '3'
-     ppctimeout: '0'
-     precreatemypostscripts: '1'
-     pruneservices: '1'
-     runbootscripts: 'yes'
-     setinstallnic: '1'
-     sharedinstall: 'no'
-     sharedtftp: '1'
-     skiptables: nics
-     skipvalidatelog: '1'
-     snmpc: snmpc
-     sshbetweennodes: ALLGROUPS
-     svloglocal: '1'
-     syspowerinterval: '10'
-     syspowermaxnodes: '10'
-     tftpdir: /tftprot/
-     tftpflags: -v
-     timezone: America/New_York
-     useNFSv4onAIX: '0'
-     useNmapfromMN: 'no'
-     useSSHonAIX: '0'
-     useflowcontrol: 'no'
-     usexhrm: 'no'
-     vcenterautojoin: 'no'
-     vmwarereconfigonpower: 'no'
-     vsftp: n
-     xcatconfdir: /etc/xcat
-     xcatdebugmode: '1'
-     xcatdport: '3001'
-     xcatiport: '3002'
-     xcatlport: '3003'
-     xcatmaxbatchconnections: '64'
-     xcatmaxconnections: '60'
-     xcatsslciphers: 3DES
-     xcatsslversion: TLSv1
- " > /tmp/xcat_inventory_try_to_export_all_type_is_site_default_format/site.org
-cmd:mnip=$(lsdef -t site -o clustersite -i master -c|awk -F'=' '{print $2}');sed -i "s/10.3.5.8/$mnip/g" /tmp/xcat_inventory_try_to_export_all_type_is_site_default_format/site.org
+cmd:echo " 
+schema_version: '2.0'
+site:
+  clustersite:
+    FQDNfirst: '1'
+    SNsyncfiledir: /var/xcat/syncfiles
+    auditnosyslog: '0'
+    auditskipcmds: ALL
+    blademaxp: '64'
+    cleanupxcatpost: 'no'
+    consoleondemand: 'no'
+    databaseloc: /var/lib
+    db2installloc: /mntdb2
+    dbtracelevel: '0'
+    defserialflow: '0'
+    defserialport: '0'
+    defserialspeed: '9600'
+    dhcpinterfaces: eth0
+    dhcplease: '43200'
+    dhcpsetup: n
+    disjointdhcps: '1'
+    dnshandler: ddns
+    dnsinterfaces: xcatmn|eth1,eth2;service|bond0
+    dnsupdaters: dnsupdaters
+    domain: pok.stglabs.ibm.com
+    enableASMI: 'no'
+    excludenodes: excludenodes
+    externaldns: externaldns
+    extntpservers: extntpservers
+    forwarders: 10.3.1.13
+    fsptimeout: '0'
+    genmacprefix: 00:11:aa
+    genpasswords: genpasswords
+    hierarchicalattrs: hierarchicalattrs
+    httpport: '80'
+    hwctrldispatch: y
+    installdir: /install/
+    installloc: hostname:/path
+    ipmidispatch: y
+    ipmimaxp: '64'
+    ipmiretries: '3'
+    ipmisdrcache: 'no'
+    ipmitimeout: '2'
+    iscsidir: /iscsidir
+    managedaddressmode: dhcp
+    master: 10.3.1.13
+    maxssh: '8'
+    mnroutenames: mnroutenames
+    nameservers: 10.3.1.13
+    nmapoptions: --min-rtt-timeout
+    nodestatus: n
+    nodesyncfiledir: /var/xcat/node/syncfiles
+    ntpservers: 10.3.1.13
+    persistkvmguests: y
+    powerinterval: '0'
+    ppcmaxp: '64'
+    ppcretry: '3'
+    ppctimeout: '0'
+    precreatemypostscripts: '1'
+    pruneservices: '1'
+    runbootscripts: 'yes'
+    setinstallnic: '1'
+    sharedinstall: 'no'
+    sharedtftp: '1'
+    skiptables: nics
+    skipvalidatelog: '1'
+    snmpc: snmpc
+    sshbetweennodes: ALLGROUPS
+    svloglocal: '1'
+    syspowerinterval: '10'
+    syspowermaxnodes: '10'
+    tftpdir: /tftprot/
+    tftpflags: -v
+    timezone: America/New_York
+    useNFSv4onAIX: '0'
+    useNmapfromMN: 'no'
+    useSSHonAIX: '0'
+    useflowcontrol: 'no'
+    usexhrm: 'no'
+    vcenterautojoin: 'no'
+    vmwarereconfigonpower: 'no'
+    vsftp: n
+    xcatconfdir: /etc/xcat
+    xcatdebugmode: '1'
+    xcatdport: '3001'
+    xcatiport: '3002'
+    xcatlport: '3003'
+    xcatmaxbatchconnections: '64'
+    xcatmaxconnections: '60'
+    xcatsslciphers: 3DES
+    xcatsslversion: TLSv1
+" > /tmp/xcat_inventory_try_to_export_all_type_is_site_default_format/site.org
+cmd:mnip=$(lsdef -t site -o clustersite -i master -c|awk -F'=' '{print $2}');sed -i "s/10.3.1.13/$mnip/g" /tmp/xcat_inventory_try_to_export_all_type_is_site_default_format/site.org
 check:rc==0
 cmd:xcat-inventory export -t site |tee /tmp/xcat_inventory_try_to_export_all_type_is_site_default_format/site.export
 check:rc==0

--- a/xCAT-test/autotest/testcase/xcat_inventory/templates/network.json
+++ b/xCAT-test/autotest/testcase/xcat_inventory/templates/network.json
@@ -12,5 +12,5 @@
             }
         }
     },
-    "schema_version": "1.0"
+    "schema_version": "2.0"
 }

--- a/xCAT-test/autotest/testcase/xcat_inventory/templates/network.yaml
+++ b/xCAT-test/autotest/testcase/xcat_inventory/templates/network.yaml
@@ -7,5 +7,4 @@ network:
     pool:
       dynamicrange: 123.0.0.100-123.0.0.200
       staticrange: 123.0.0.201-123.0.0.222
-schema_version: '1.0'
-
+schema_version: '2.0'

--- a/xCAT-test/autotest/testcase/xcat_inventory/templates/node.json
+++ b/xCAT-test/autotest/testcase/xcat_inventory/templates/node.json
@@ -114,6 +114,12 @@
                 }
             },
             "network_info": {
+                "connections": {
+                    "interface": "switchinterface",
+                    "switch": "switch",
+                    "switchport": "50",
+                    "vlan": "switchvlan"
+                },
                 "nics": {
                     "bond0": {
                         "nicdevices": [
@@ -200,11 +206,11 @@
                         "hostnameprefixe": [
                             "eth0-"
                         ],
-                        "ips": [
-                            "1.1.1.1"
-                        ],
                         "hostnamesuffixes": [
                             "-eth0"
+                        ],
+                        "ips": [
+                            "1.1.1.1"
                         ]
                     },
                     "eth1": {
@@ -270,17 +276,14 @@
                     "ip": "10.10.10.10",
                     "mac": [
                         "42:d6:0a:03:05:08"
-                    ],
-                    "switch": "switch",
-                    "switchinterface": "switchinterface",
-                    "switchport": "50",
-                    "switchvlan": "switchvlan"
+                    ]
                 },
                 "routenames": "routenames"
             },
             "obj_info": {
                 "description": "usercomment",
-                "groups": "bogusgroup"
+                "groups": "bogusgroup",
+                "grouptype": "static"
             },
             "obj_type": "node",
             "position_info": {
@@ -313,7 +316,9 @@
                 "xcatmaster": "xcatmaster"
             },
             "security_info": {
-                "productkey": "productkey",
+                "productkey": {
+                    "key": "productkey"
+                },
                 "zonename": "zonename"
             }
         },
@@ -428,6 +433,12 @@
                 }
             },
             "network_info": {
+                "connections": {
+                    "interface": "switchinterface",
+                    "switch": "switch",
+                    "switchport": "50",
+                    "vlan": "switchvlan"
+                },
                 "nics": {
                     "bond0": {
                         "nicdevices": [
@@ -581,11 +592,7 @@
                     "ip": "10.10.10.10",
                     "mac": [
                         "42:d6:0a:03:05:08"
-                    ],
-                    "switch": "switch",
-                    "switchinterface": "switchinterface",
-                    "switchport": "50",
-                    "switchvlan": "switchvlan"
+                    ]
                 },
                 "routenames": "routenames"
             },
@@ -624,7 +631,9 @@
                 "xcatmaster": "xcatmaster"
             },
             "security_info": {
-                "productkey": "productkey",
+                "productkey": {
+                    "key": "productkey"
+                },
                 "remotecontrol": {
                     "password": "password",
                     "username": "username"
@@ -751,6 +760,12 @@
                 }
             },
             "network_info": {
+                "connections": {
+                    "interface": "switchinterface",
+                    "switch": "switch",
+                    "switchport": "50",
+                    "vlan": "switchvlan"
+                },
                 "linkports": "linkports",
                 "nics": {
                     "bond0": {
@@ -905,11 +920,7 @@
                     "ip": "10.10.10.10",
                     "mac": [
                         "42:d6:0a:03:05:08"
-                    ],
-                    "switch": "switch",
-                    "switchinterface": "switchinterface",
-                    "switchport": "50",
-                    "switchvlan": "switchvlan"
+                    ]
                 },
                 "routenames": "routenames"
             },
@@ -948,7 +959,9 @@
                 "xcatmaster": "xcatmaster"
             },
             "security_info": {
-                "productkey": "productkey",
+                "productkey": {
+                    "key": "productkey"
+                },
                 "remotecontrol": {
                     "password": "password",
                     "remoteprotocol": "ssh",
@@ -966,5 +979,5 @@
             }
         }
     },
-    "schema_version": "1.0"
+    "schema_version": "2.0"
 }

--- a/xCAT-test/autotest/testcase/xcat_inventory/templates/node.yaml
+++ b/xCAT-test/autotest/testcase/xcat_inventory/templates/node.yaml
@@ -101,6 +101,11 @@ node:
           pdu: pdu
         engine_type: power
     network_info:
+      connections:
+        interface: switchinterface
+        switch: switch
+        switchport: '50'
+        vlan: switchvlan
       nics:
         bond0:
           nicdevices:
@@ -202,14 +207,11 @@ node:
         ip: 10.10.10.10
         mac:
         - 42:d6:0a:03:05:08
-        switch: switch
-        switchinterface: switchinterface
-        switchport: '50'
-        switchvlan: switchvlan
       routenames: routenames
     obj_info:
       description: usercomment
       groups: bogusgroup
+      grouptype: static
     obj_type: node
     position_info:
       chassis: chassis
@@ -239,7 +241,8 @@ node:
       tftpserver: tftpserver
       xcatmaster: xcatmaster
     security_info:
-      productkey: productkey
+      productkey:
+        key: productkey
       zonename: zonename
   boguspdu:
     deprecated:
@@ -340,6 +343,11 @@ node:
           pdu: pdu
         engine_type: power
     network_info:
+      connections:
+        interface: switchinterface
+        switch: switch
+        switchport: '50'
+        vlan: switchvlan
       nics:
         bond0:
           nicdevices:
@@ -439,14 +447,11 @@ node:
         ip: 10.10.10.10
         mac:
         - 42:d6:0a:03:05:08
-        switch: switch
-        switchinterface: switchinterface
-        switchport: '50'
-        switchvlan: switchvlan
       routenames: routenames
     obj_info:
       description: usercomment
       groups: bogusgroup
+      grouptype: static
     obj_type: node
     position_info:
       chassis: chassis
@@ -476,7 +481,8 @@ node:
       tftpserver: tftpserver
       xcatmaster: xcatmaster
     security_info:
-      productkey: productkey
+      productkey:
+        key: productkey
       remotecontrol:
         password: password
         username: username
@@ -587,6 +593,11 @@ node:
           pdu: pdu
         engine_type: power
     network_info:
+      connections:
+        interface: switchinterface
+        switch: switch
+        switchport: '50'
+        vlan: switchvlan
       linkports: linkports
       nics:
         bond0:
@@ -687,14 +698,11 @@ node:
         ip: 10.10.10.10
         mac:
         - 42:d6:0a:03:05:08
-        switch: switch
-        switchinterface: switchinterface
-        switchport: '50'
-        switchvlan: switchvlan
       routenames: routenames
     obj_info:
       description: usercomment
       groups: bogusgroup
+      grouptype: static
     obj_type: node
     position_info:
       chassis: chassis
@@ -724,7 +732,8 @@ node:
       tftpserver: tftpserver
       xcatmaster: xcatmaster
     security_info:
-      productkey: productkey
+      productkey:
+        key: productkey
       remotecontrol:
         password: password
         remoteprotocol: ssh
@@ -737,5 +746,4 @@ node:
         username: snmpusername
         version: SNMPv1
       zonename: zonename
-schema_version: '1.0'
-
+schema_version: '2.0'

--- a/xCAT-test/autotest/testcase/xcat_inventory/templates/osimage.json
+++ b/xCAT-test/autotest/testcase/xcat_inventory/templates/osimage.json
@@ -6,22 +6,35 @@
                 "distribution": "sles12.2",
                 "osdistro": "sles12.2-ppc64le"
             },
-            "filestosync": "/install/custom/netboot/sles/compute.synclist",
+            "filestosync": [
+                "/install/custom/netboot/sles/compute.synclist"
+            ],
             "genimgoptions": {
-                "exlist": "/opt/xcat/share/xcat/netboot/sles/compute.sles12.ppc64le.exlist",
-                "postinstall": "/opt/xcat/share/xcat/netboot/sles/compute.sles12.ppc64le.postinstall",
-                "rootimgdir": "/install/netboot/sles12.2/ppc64le/compute",
-                "rootfstype": "nfs"
+                "exlist": [
+                    "/opt/xcat/share/xcat/netboot/sles/compute.sles12.ppc64le.exlist"
+                ],
+                "postinstall": [
+                    "/opt/xcat/share/xcat/netboot/sles/compute.sles12.ppc64le.postinstall"
+                ],
+                "rootfstype": "nfs",
+                "rootimgdir": "/install/netboot/sles12.2/ppc64le/compute"
             },
             "imagetype": "linux",
             "package_selection": {
-                "otherpkgdir": "/install/post/otherpkgs/sles12.2/ppc64le",
-                "pkgdir": "/install/sles12.2/ppc64le",
-                "pkglist": "/opt/xcat/share/xcat/netboot/sles/compute.sles12.ppc64le.pkglist"
+                "otherpkgdir": [
+                    "/install/post/otherpkgs/sles12.2/ppc64le"
+                ],
+                "pkgdir": [
+                    "/install/sles12.2/ppc64le"
+                ],
+                "pkglist": [
+                    "/opt/xcat/share/xcat/netboot/sles/compute.sles12.ppc64le.pkglist"
+                ]
             },
             "provision_mode": "statelite",
             "role": "compute"
         }
     },
-    "schema_version": "1.0"
+    "schema_version": "2.0"
 }
+#Version 2.14.5 (git commit e9d8db94e349c383a6686ecfd853536abe7a8c2b, built Wed Nov 21 06:17:14 EST 2018)

--- a/xCAT-test/autotest/testcase/xcat_inventory/templates/osimage.yaml
+++ b/xCAT-test/autotest/testcase/xcat_inventory/templates/osimage.yaml
@@ -4,18 +4,25 @@ osimage:
       arch: ppc64le
       distribution: sles12.2
       osdistro: sles12.2-ppc64le
-    filestosync: /install/custom/netboot/sles/compute.synclist
+    filestosync:
+    - /install/custom/netboot/sles/compute.synclist
     genimgoptions:
-      exlist: /opt/xcat/share/xcat/netboot/sles/compute.sles12.ppc64le.exlist
-      postinstall: /opt/xcat/share/xcat/netboot/sles/compute.sles12.ppc64le.postinstall
-      rootimgdir: /install/netboot/sles12.2/ppc64le/compute
+      exlist:
+      - /opt/xcat/share/xcat/netboot/sles/compute.sles12.ppc64le.exlist
+      postinstall:
+      - /opt/xcat/share/xcat/netboot/sles/compute.sles12.ppc64le.postinstall
       rootfstype: nfs
+      rootimgdir: /install/netboot/sles12.2/ppc64le/compute
     imagetype: linux
     package_selection:
-      otherpkgdir: /install/post/otherpkgs/sles12.2/ppc64le
-      pkgdir: /install/sles12.2/ppc64le
-      pkglist: /opt/xcat/share/xcat/netboot/sles/compute.sles12.ppc64le.pkglist
+      otherpkgdir:
+      - /install/post/otherpkgs/sles12.2/ppc64le
+      pkgdir:
+      - /install/sles12.2/ppc64le
+      pkglist:
+      - /opt/xcat/share/xcat/netboot/sles/compute.sles12.ppc64le.pkglist
     provision_mode: statelite
     role: compute
-schema_version: '1.0'
+schema_version: '2.0'
 
+#Version 2.14.5 (git commit e9d8db94e349c383a6686ecfd853536abe7a8c2b, built Wed Nov 21 06:17:14 EST 2018)

--- a/xCAT-test/autotest/testcase/xcat_inventory/templates/passwd.json
+++ b/xCAT-test/autotest/testcase/xcat_inventory/templates/passwd.json
@@ -6,5 +6,5 @@
             "username": "root"
         }
     },
-    "schema_version": "1.0"
+    "schema_version": "2.0"
 }

--- a/xCAT-test/autotest/testcase/xcat_inventory/templates/passwd.yaml
+++ b/xCAT-test/autotest/testcase/xcat_inventory/templates/passwd.yaml
@@ -3,5 +3,4 @@ passwd:
     cryptmethod: md5
     password: cluster
     username: root
-schema_version: '1.0'
-
+schema_version: '2.0'

--- a/xCAT-test/autotest/testcase/xcat_inventory/templates/route.json
+++ b/xCAT-test/autotest/testcase/xcat_inventory/templates/route.json
@@ -8,5 +8,5 @@
             "usercomment": "hello world"
         }
     },
-    "schema_version": "1.0"
+    "schema_version": "2.0"
 }

--- a/xCAT-test/autotest/testcase/xcat_inventory/templates/route.yaml
+++ b/xCAT-test/autotest/testcase/xcat_inventory/templates/route.yaml
@@ -5,5 +5,4 @@ route:
     mask: 255.0.0.0
     net: 100.0.0.0
     usercomment: hello world
-schema_version: '1.0'
-
+schema_version: '2.0'

--- a/xCAT-test/autotest/testcase/xcat_inventory/templates/site.json
+++ b/xCAT-test/autotest/testcase/xcat_inventory/templates/site.json
@@ -1,13 +1,13 @@
 {
-    "schema_version": "1.0",
+    "schema_version": "2.0",
     "site": {
         "clustersite": {
             "dbtracelevel": "1",
             "dhcplease": "10240",
             "disjointdhcps": "0",
             "httpport": "80",
-            "sharedinstall": "no",
             "managedaddressmode": "dhcp",
+            "sharedinstall": "no",
             "sshbetweennodes": "ALLGROUPS",
             "xcatdebugmode": "0",
             "xcatdport": "3001",

--- a/xCAT-test/autotest/testcase/xcat_inventory/templates/site.yaml
+++ b/xCAT-test/autotest/testcase/xcat_inventory/templates/site.yaml
@@ -1,15 +1,14 @@
-schema_version: '1.0'
+schema_version: '2.0'
 site:
   clustersite:
     dbtracelevel: '1'
     dhcplease: '10240'
     disjointdhcps: '0'
     httpport: '80'
+    managedaddressmode: dhcp
     sharedinstall: 'no'
-    managedaddressmode: 'dhcp'
-    sshbetweennodes: 'ALLGROUPS'
+    sshbetweennodes: ALLGROUPS
     xcatdebugmode: '0'
     xcatdport: '3001'
     xcatiport: '3002'
     xcatlport: '3003'
-


### PR DESCRIPTION
### The PR is to do task https://github.com/xcat2/xcat2-task-management/issues/409
The change are following
```
1. change cases label from xcat_inventory to inventory_ci
2. some attributes key words format changes in command lines
3.  With the format change and attributes change, the check output return code changes.
4.  change case  import_validation_node_network_info_primarynic_switchport to  import_validation_node_network_info_connections_switchport for attribute primarynic changes to connections
5. site table change for case xcat_inventory_try_to_export_all_type_is_site_default_format

6. template changes from schema version 1 to schema version 2 for yaml and json files.

```