### PR TITLE
fix issue 5881: xcattest failed to add component directory name as default label

### DIFF
--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -2132,7 +2132,8 @@ sub calculate_case_belong_to_which_cmd {
     my $file_path = shift;
     my $command   = undef;
 
-    if ($file_path =~ "\/autotest\/testcase") {
+    $file_path =~ s|[\/]{2,}|\/|g;
+    if ($file_path =~ /\/autotest\/testcase/) {
         my @path_str = split("/", $file_path);
         #print Dumper \@path_str;
         my $index = 0;


### PR DESCRIPTION
### The PR is to fix issue #5881 

### The UT result
```
[root@c910f03c09k09 bin]# xcattest -l labelinfo |grep   addkit_h
addkit_h                                                                  addkit,others,KIT
```

