### PR TITLE
fix issue 5883

### DIFF
--- a/xCAT-test/autotest/testcase/installation/setup_vm
+++ b/xCAT-test/autotest/testcase/installation/setup_vm
@@ -7,8 +7,8 @@ check:rc==0
 cmd:if [ "__GETNODEATTR($$CN,arch)__" != "ppc64"  -a  "__GETNODEATTR($$CN,mgt)__" != "ipmi" -a  "__GETNODEATTR($$CN,mgt)__" != "openbmc" ]; then echo "CN node is a vm, need to repower it on"; echo "rpower $$CN on"; rpower $$CN on; else echo "CN node $$CN is a non-VM; do not need to repower on it"; fi
 check:rc==0
 
-cmd:rpower $$CN stat
-check:output=~on
+cmd:if [ "__GETNODEATTR($$CN,arch)__" != "ppc64"  -a  "__GETNODEATTR($$CN,mgt)__" != "ipmi" -a  "__GETNODEATTR($$CN,mgt)__" != "openbmc" ]; then rpower $$CN stat;else echo "skip";fi
+check:output=~on|skip
 
 cmd:if [ "__GETNODEATTR($$CN,arch)__" != "ppc64" -a  "__GETNODEATTR($$CN,mgt)__" != "ipmi" -a "__GETNODEATTR($$CN,mgt)__" != "openbmc" ]; then tabdump -w node==$$CN kvm_nodedata; fi
 check:rc==0
@@ -20,8 +20,8 @@ check:rc==0
 cmd:if [ "__GETNODEATTR($$SN,arch)__" != "ppc64"  -a  "__GETNODEATTR($$SN,mgt)__" != "ipmi" -a  "__GETNODEATTR($$SN,mgt)__" != "openbmc" ];then echo "SN node $$SN is a VM, need to rpower it on"; echo "rpower $$SN on"; rpower $$SN on; fi
 check:rc==0
 
-cmd:rpower $$SN stat
-check:output=~on
+cmd:if [ "__GETNODEATTR($$CN,arch)__" != "ppc64"  -a  "__GETNODEATTR($$CN,mgt)__" != "ipmi" -a  "__GETNODEATTR($$CN,mgt)__" != "openbmc" ]; then rpower $$SN stat;else echo "skip"; fi
+check:output=~on|skip
 
 check:rc==0
 cmd:if [ "__GETNODEATTR($$SN,arch)__" != "ppc64" -a  "__GETNODEATTR($$SN,mgt)__" != "ipmi" -a "__GETNODEATTR($$SN,mgt)__" != "openbmc" ]; then tabdump -w node==$$SN kvm_nodedata; fi


### PR DESCRIPTION
### The PR is to fix issue _#5883

### The modification include

* enhance test case ``setup_vm`` to let it work on p7 harmlessly.

### The UT result
```
------START::setup_vm::Time:Mon Dec 10 05:22:26 2018------

RUN:if [ "__GETNODEATTR(c910f02c01p11,arch)__" != "ppc64"  -a  "__GETNODEATTR(c910f02c01p11,mgt)__" != "ipmi" -a "__GETNODEATTR(c910f02c01p11,mgt)__" != "openbmc" ];then echo "CN node c910f02c01p11 is a vm which mgt is __GETNODEATTR(c910f02c01p11,mgt)__, start to recreate the vm now"; echo "rpower c910f02c01p11 off"; rpower c910f02c01p11 off; sleep 3; echo "rpower c910f02c01p11 stat"; rpower c910f02c01p11 stat; var=`expr substr "__GETNODEATTR(c910f02c01p11,vmstorage)__" 1 3`; echo "The disk create way of c910f02c01p11 is $var"; if [ "$var" = "phy" ]; then echo "mkvm c910f02c01p11"; mkvm c910f02c01p11; echo "rmvm c910f02c01p11 -f -p"; rmvm c910f02c01p11 -f -p; echo "mkvm c910f02c01p11"; mkvm c910f02c01p11; exit $?; elif [ "$var" = "dir" ]; then echo "mkvm c910f02c01p11 -s 20G -f"; mkvm c910f02c01p11 -s 20G -f; echo "rmvm c910f02c01p11 -f -p"; rmvm c910f02c01p11 -f -p; echo "mkvm c910f02c01p11 -s 20G -f"; mkvm c910f02c01p11 -s 20G -f; exit $?; elif ["$var" = "nfs" -o "$var" = "lvm" ];then echo  "Need to fix me"; exit 2; else echo "unsupported disk creation way"; exit 3;fi;else echo "CN node c910f02c01p11 is a non-VM; do not need to recreate it";fi [Mon Dec 10 05:22:26 2018]
ElapsedTime:28 sec
RETURN rc = 0
OUTPUT:
CN node c910f02c01p11 is a non-VM; do not need to recreate it
CHECK:rc == 0	[Pass]

RUN:if [ "__GETNODEATTR(c910f02c01p11,arch)__" != "ppc64"  -a  "__GETNODEATTR(c910f02c01p11,mgt)__" != "ipmi" -a  "__GETNODEATTR(c910f02c01p11,mgt)__" != "openbmc" ]; then echo "CN node is a vm, need to repower it on"; echo "rpower c910f02c01p11 on"; rpower c910f02c01p11 on; else echo "CN node c910f02c01p11 is a non-VM; do not need to repower on it"; fi [Mon Dec 10 05:22:54 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
CN node c910f02c01p11 is a non-VM; do not need to repower on it
CHECK:rc == 0	[Pass]

RUN:if [ "__GETNODEATTR(c910f02c01p11,arch)__" != "ppc64"  -a  "__GETNODEATTR(c910f02c01p11,mgt)__" != "ipmi" -a  "__GETNODEATTR(c910f02c01p11,mgt)__" != "openbmc" ]; then rpower c910f02c01p11 stat;else echo "skip";fi [Mon Dec 10 05:22:56 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
skip
CHECK:output =~ on|skip	[Pass]

RUN:if [ "__GETNODEATTR(c910f02c01p11,arch)__" != "ppc64" -a  "__GETNODEATTR(c910f02c01p11,mgt)__" != "ipmi" -a "__GETNODEATTR(c910f02c01p11,mgt)__" != "openbmc" ]; then tabdump -w node==c910f02c01p11 kvm_nodedata; fi [Mon Dec 10 05:22:57 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:if [ "__GETNODEATTR(c910f02c01p10,arch)__" != "ppc64"  -a  "__GETNODEATTR(c910f02c01p10,mgt)__" != "ipmi" -a "__GETNODEATTR(c910f02c01p10,mgt)__" != "openbmc" ];then echo "SN node c910f02c01p10 is a vm which mgt is __GETNODEATTR(c910f02c01p10,mgt)__, start to recreate the vm now"; echo "rpower c910f02c01p10 off"; rpower c910f02c01p10 off; sleep 3; echo "rpower c910f02c01p10 stat"; rpower c910f02c01p10 stat; var=`expr substr "__GETNODEATTR(c910f02c01p10,vmstorage)__" 1 3`; echo "The disk create way of c910f02c01p10 is $var"; if [ "$var" = "phy" ]; then echo "mkvm c910f02c01p10"; mkvm c910f02c01p10; echo "rmvm c910f02c01p10 -f -p"; rmvm c910f02c01p10 -f -p; echo "mkvm c910f02c01p10"; mkvm c910f02c01p10; exit $?; elif [ "$var" = "dir" ]; then echo "mkvm c910f02c01p10 -s 20G -f"; mkvm c910f02c01p10 -s 20G -f; echo "rmvm c910f02c01p10 -f -p"; rmvm c910f02c01p10 -f -p; echo "mkvm c910f02c01p10 -s 20G -f"; mkvm c910f02c01p10 -s 20G -f; exit $?; elif ["$var" = "nfs" -o "$var" = "lvm" ];then echo  "Need to fix me"; exit 2; else echo "unsupported disk creation way"; exit 3;fi;else echo "SN node c910f02c01p10 is a non-VM; do not need to recreate it";fi [Mon Dec 10 05:22:58 2018]
ElapsedTime:29 sec
RETURN rc = 0
OUTPUT:
SN node c910f02c01p10 is a non-VM; do not need to recreate it
CHECK:rc == 0	[Pass]

RUN:if [ "__GETNODEATTR(c910f02c01p10,arch)__" != "ppc64"  -a  "__GETNODEATTR(c910f02c01p10,mgt)__" != "ipmi" -a  "__GETNODEATTR(c910f02c01p10,mgt)__" != "openbmc" ];then echo "SN node c910f02c01p10 is a VM, need to rpower it on"; echo "rpower c910f02c01p10 on"; rpower c910f02c01p10 on; fi [Mon Dec 10 05:23:27 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:if [ "__GETNODEATTR(c910f02c01p11,arch)__" != "ppc64"  -a  "__GETNODEATTR(c910f02c01p11,mgt)__" != "ipmi" -a  "__GETNODEATTR(c910f02c01p11,mgt)__" != "openbmc" ]; then rpower c910f02c01p10 stat;else echo "skip"; fi [Mon Dec 10 05:23:28 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
skip
CHECK:output =~ on|skip	[Pass]
CHECK:rc == 0	[Pass]

RUN:if [ "__GETNODEATTR(c910f02c01p10,arch)__" != "ppc64" -a  "__GETNODEATTR(c910f02c01p10,mgt)__" != "ipmi" -a "__GETNODEATTR(c910f02c01p10,mgt)__" != "openbmc" ]; then tabdump -w node==c910f02c01p10 kvm_nodedata; fi [Mon Dec 10 05:23:30 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::setup_vm::Passed::Time:Mon Dec 10 05:23:31 2018 ::Duration::65 sec------
------Total: 1 , Failed: 0------
```