### PR TITLE
update case updatenode_without_options to verify bug 5142

### DIFF
--- a/xCAT-test/autotest/bundle/rhels6.9_ppc64.bundle
+++ b/xCAT-test/autotest/bundle/rhels6.9_ppc64.bundle
@@ -1,7 +1,7 @@
 reg_linux_diskfull_installation_flat
 updatenode_h
 updatenode_v
-updatenode_without_flag
+updatenode_without_options
 updatenode_diskful_syncfiles
 updatenode_diskful_syncfiles_rename
 updatenode_diskful_syncfiles_dir

--- a/xCAT-test/autotest/bundle/rhels6.9_ppc64.bundle
+++ b/xCAT-test/autotest/bundle/rhels6.9_ppc64.bundle
@@ -1,6 +1,7 @@
 reg_linux_diskfull_installation_flat
 updatenode_h
 updatenode_v
+updatenode_without_flag
 updatenode_diskful_syncfiles
 updatenode_diskful_syncfiles_rename
 updatenode_diskful_syncfiles_dir

--- a/xCAT-test/autotest/bundle/rhels6.9_ppc64.bundle
+++ b/xCAT-test/autotest/bundle/rhels6.9_ppc64.bundle
@@ -1,7 +1,6 @@
 reg_linux_diskfull_installation_flat
 updatenode_h
 updatenode_v
-updatenode_without_options
 updatenode_diskful_syncfiles
 updatenode_diskful_syncfiles_rename
 updatenode_diskful_syncfiles_dir
@@ -18,6 +17,7 @@ updatenode_diskful_syncfiles_P_script1
 updatenode_script3
 updatenode_P_script1_script2
 updatenode_without_flag
+updatenode_without_options
 confignetwork_static_installnic
 confignetwork_secondarynic_nicnetworks_updatenode_false
 confignetwork_secondarynic_nicips_updatenode_false

--- a/xCAT-test/autotest/bundle/rhels7.4_ppc64.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.4_ppc64.bundle
@@ -1,7 +1,7 @@
 reg_linux_diskfull_installation_flat
 updatenode_h
 updatenode_v
-updatenode_without_flag
+updatenode_without_options
 updatenode_diskful_syncfiles
 updatenode_diskful_syncfiles_rename
 updatenode_diskful_syncfiles_dir

--- a/xCAT-test/autotest/bundle/rhels7.4_ppc64.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.4_ppc64.bundle
@@ -1,6 +1,7 @@
 reg_linux_diskfull_installation_flat
 updatenode_h
 updatenode_v
+updatenode_without_flag
 updatenode_diskful_syncfiles
 updatenode_diskful_syncfiles_rename
 updatenode_diskful_syncfiles_dir

--- a/xCAT-test/autotest/bundle/rhels7.4_ppc64.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.4_ppc64.bundle
@@ -1,7 +1,6 @@
 reg_linux_diskfull_installation_flat
 updatenode_h
 updatenode_v
-updatenode_without_options
 updatenode_diskful_syncfiles
 updatenode_diskful_syncfiles_rename
 updatenode_diskful_syncfiles_dir
@@ -18,6 +17,7 @@ updatenode_diskful_syncfiles_P_script1
 updatenode_script3
 updatenode_P_script1_script2
 updatenode_without_flag
+updatenode_without_options
 confignetwork_static_installnic
 confignetwork_secondarynic_nicnetworks_updatenode_false
 confignetwork_secondarynic_nicips_updatenode_false

--- a/xCAT-test/autotest/bundle/rhels7.4_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.4_ppc64le.bundle
@@ -4,7 +4,7 @@ reg_linux_diskfull_installation_flat
 go_xcat_noinput
 updatenode_h
 updatenode_v
-updatenode_without_flag
+updatenode_without_options
 updatenode_diskful_syncfiles
 updatenode_diskful_syncfiles_rename
 updatenode_diskful_syncfiles_dir

--- a/xCAT-test/autotest/bundle/rhels7.4_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.4_ppc64le.bundle
@@ -4,7 +4,6 @@ reg_linux_diskfull_installation_flat
 go_xcat_noinput
 updatenode_h
 updatenode_v
-updatenode_without_options
 updatenode_diskful_syncfiles
 updatenode_diskful_syncfiles_rename
 updatenode_diskful_syncfiles_dir
@@ -21,6 +20,7 @@ updatenode_diskful_syncfiles_P_script1
 updatenode_script3
 updatenode_P_script1_script2
 updatenode_without_flag
+updatenode_without_options
 confignetwork_static_installnic
 confignetwork_s_installnic_secondarynic_updatenode
 confignetwork_secondarynic_updatenode

--- a/xCAT-test/autotest/bundle/rhels7.4_ppc64le.bundle
+++ b/xCAT-test/autotest/bundle/rhels7.4_ppc64le.bundle
@@ -4,6 +4,7 @@ reg_linux_diskfull_installation_flat
 go_xcat_noinput
 updatenode_h
 updatenode_v
+updatenode_without_flag
 updatenode_diskful_syncfiles
 updatenode_diskful_syncfiles_rename
 updatenode_diskful_syncfiles_dir

--- a/xCAT-test/autotest/testcase/updatenode/cases0
+++ b/xCAT-test/autotest/testcase/updatenode/cases0
@@ -11,6 +11,14 @@ check:rc==0
 check:output=~Version
 end
 
+start:updatenode_without_flag
+description:this case is to verify defect 5142; updatenode without options causes command to crash.
+label:others,updatenode
+cmd:updatenode 
+check:rc!=0
+check:output=~Usage
+end
+
 start:updatenode_diskful_syncfiles
 label:others,updatenode
 cmd:mkdir -p /install/custom/install/__GETNODEATTR($$CN,os)__/

--- a/xCAT-test/autotest/testcase/updatenode/cases0
+++ b/xCAT-test/autotest/testcase/updatenode/cases0
@@ -13,7 +13,7 @@ end
 
 start:updatenode_without_options
 description:this case is to verify defect 5142; updatenode without options causes command to crash.
-label:others,updatenode
+label:mn_only,ci_test,updatenode
 cmd:updatenode 
 check:rc!=0
 check:output=~Usage

--- a/xCAT-test/autotest/testcase/updatenode/cases0
+++ b/xCAT-test/autotest/testcase/updatenode/cases0
@@ -11,7 +11,7 @@ check:rc==0
 check:output=~Version
 end
 
-start:updatenode_without_flag
+start:updatenode_without_options
 description:this case is to verify defect 5142; updatenode without options causes command to crash.
 label:others,updatenode
 cmd:updatenode 


### PR DESCRIPTION
### The PR is to do task https://github.com/xcat2/xcat2-task-management/issues/432

Add a case to verify updatenode without options causes command to crash

UT
```
------START::updatenode_without_options::Time:Tue Dec 11 20:59:11 2018------

RUN:updatenode [Tue Dec 11 20:59:11 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Usage:
    updatenode [-h|--help|-v|--version | -g|--genmypost]
    or
    updatenode <noderange> [-V|--verbose] [-k|--security] [-s|--sn] [-t <timeout>]
    or
    updatenode <noderange> [-V|--verbose] [-F|--sync | -f|--snsync] [-r|--node-rcp <node_remote_copy>] [-l|--user[username]] [--fanout=[fanout value]] [-S|--sw] [-t <timeout>]
        [-P|--scripts [script1,script2,...]] [-s|--sn]
        [-A|--updateallsw] [-c|--cmdlineonly] [-d alt_source_dir]
        [attr=val [attr=val...]]
    or
    updatenode <noderange> [-V|--verbose] [script1,script2,...]

Options:
    <noderange> A list of nodes or groups.

    [-k|--security] Update the security keys and certificates for the
        target nodes.

    [-F|--sync] Perform File Syncing.

    [--fanout]  Allows you to assign the fanout value for the command.
        See xdsh/xdcp fanout parameter in the man page.

    [-f|--snsync] Performs File Syncing to the service nodes that service
        the nodes in the noderange.

    [-r|--node-rcp] Specifies  the  full  path of the remote copy command used for sync files to node targets, such as /usr/bin/rsync and /usr/bin/scp

    [-g|--genmypost] Will generate a new mypostscript file for the
        the nodes in the noderange, if site precreatemypostscripts is 1 or YES.

    [-l|--user] User name to run the updatenode command.  It overrides the
        current user which is the default.

    [-S|--sw] Perform Software Maintenance.

    [-P|--scripts] Execute postscripts listed in the postscripts table or
        parameters.

    [-c|--cmdlineonly] Only use AIX software maintenance information
        provided on the command line. (AIX only)

    [-s|--sn] Set the server information stored on the nodes.

    [-t|--timeout] Time out in seconds to allow the command to run. Default is no timeout,
        except for updatenode -k which has a 10 second default timeout.

    [-A|--updateallsw] Install or update all software contained in the source
        directory. (AIX only)

    [-d <alt_source_dir>] Used to indicate a source directory other than
        the standard lpp_source directory specified in the xCAT osimage
        definition.  (AIX only)

    [script1,script2,...] A comma separated list of postscript names.
        If omitted, all the post scripts defined for the nodes will be run.

    [attr=val [attr=val...]]  Specifies one or more 'attribute equals value'
        pairs, separated by spaces. (AIX only)
The noderange should be the first argument.
CHECK:rc != 0	[Pass]
CHECK:output =~ Usage	[Pass]

------END::updatenode_without_options::Passed::Time:Tue Dec 11 20:59:11 2018 ::Duration::0 sec------
------Total: 1 , Failed: 0------

```
