### PR TITLE
Add test case for issue 4138 : the node status cannot be updated on normal system reboot

### DIFF
--- a/xCAT-test/autotest/testcase/rpower/cases0
+++ b/xCAT-test/autotest/testcase/rpower/cases0
@@ -213,6 +213,7 @@ check:rc==0
 cmd:a=0;while ! `rpower $$CN stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$CN stat
 check:output=~Running|on
-cmd:a=0;while ! `lsdef -l $$CN -i status|grep "booted" >/dev/null`; do sleep 5;((a++));if [ $a -gt 30 ];then break;fi done
+cmd:a=0;while ! `lsdef -l $$CN -i status|grep "booted" >/dev/null`; do sleep 5;((a++));if [ $a -gt 50 ];then break;fi done
+cmd:lsdef -l $$CN -i status|grep "booted"
 check:rc==0
 end

--- a/xCAT-test/autotest/testcase/rpower/cases0
+++ b/xCAT-test/autotest/testcase/rpower/cases0
@@ -197,3 +197,22 @@ check:output=~Error: (\[.*?\]: )?[Uu]nsupported command[:]* rpower ddd
 check:rc==1
 end
 
+start:rpower_off_on
+description:This case is to test off and on option could work for a diskful node. This case is do task 82, for bug 4132, the node status cannot be updated on normal system reboot #4138. 
+Attribute: $$CN-The operation object of rpower command
+label:others,hctrl_general
+cmd:rpower $$CN stat 
+check:output=~Running|on
+cmd:lsdef -l $$CN -i status
+check:output=~booted
+cmd:rpower $$CN off
+check:rc==0
+cmd:a=0;while ! `rpower $$CN stat|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
+cmd:rpower $$CN on
+check:rc==0
+cmd:a=0;while ! `rpower $$CN stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
+cmd:rpower $$CN stat
+check:output=~Running|on
+cmd:a=0;while ! `lsdef -l $$CN -i status|grep "booted" >/dev/null`; do sleep 5;((a++));if [ $a -gt 30 ];then break;fi done
+check:rc==0
+end


### PR DESCRIPTION
This case is to add case for issue https://github.com/xcat2/xcat-core/issues/4138

And for task  https://github.com/xcat2/xcat2-task-management/issues/82

the UT result
```
------START::rpower_off_on::Time:Fri Dec 21 03:12:22 2018------

RUN:rpower f6u13k15 stat [Fri Dec 21 03:12:22 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
f6u13k15: on
CHECK:output =~ Running|on	[Pass]

RUN:lsdef -l f6u13k15 -i status [Fri Dec 21 03:12:22 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Object name: f6u13k15
    status=booted
CHECK:output =~ booted	[Pass]

RUN:rpower f6u13k15 off [Fri Dec 21 03:12:23 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u13k15: off
CHECK:rc == 0	[Pass]

RUN:a=0;while ! `rpower f6u13k15 stat|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done [Fri Dec 21 03:12:24 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:rpower f6u13k15 on [Fri Dec 21 03:12:25 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
f6u13k15: on
CHECK:rc == 0	[Pass]

RUN:a=0;while ! `rpower f6u13k15 stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done [Fri Dec 21 03:12:25 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:rpower f6u13k15 stat [Fri Dec 21 03:12:26 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
f6u13k15: on
CHECK:output =~ Running|on	[Pass]

RUN:a=0;while ! `lsdef -l f6u13k15 -i status|grep "booted" >/dev/null`; do sleep 5;((a++));if [ $a -gt 30 ];then break;fi done [Fri Dec 21 03:12:26 2018]
ElapsedTime:23 sec
RETURN rc = 0
OUTPUT:

RUN:lsdef -l f6u13k15 -i status|grep "booted" [Fri Dec 21 03:12:49 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
    status=booted
CHECK:rc == 0	[Pass]

------END::rpower_off_on::Passed::Time:Fri Dec 21 03:12:50 2018 ::Duration::28 sec------
------Total: 1 , Failed: 0------

```