### PR TITLE
mark site.installdir as obsoleted

### DIFF
--- a/docs/source/guides/admin-guides/references/man5/site.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/site.5.rst
@@ -269,7 +269,7 @@ site Attributes:
    genpasswords:  Automatically generate random passwords for BMCs when configuring
                   them.
   
-   installdir:  The local directory name used to hold the node deployment packages.
+   installdir:  The local directory name used to hold the node deployment packages(obsoleted).
   
    installloc:  The location from which the service nodes should mount the 
                 deployment packages in the format hostname:/path.  If hostname is

--- a/perl-xCAT/xCAT/Schema.pm
+++ b/perl-xCAT/xCAT/Schema.pm
@@ -1159,7 +1159,7 @@ passed as argument rather than by table value',
 "                prefix (e.g. 00:11:aa)\n\n" .
 " genpasswords:  Automatically generate random passwords for BMCs when configuring\n" .
 "                them.\n\n" .
-" installdir:  The local directory name used to hold the node deployment packages.\n\n" .
+" installdir:  The local directory name used to hold the node deployment packages(obsoleted).\n\n" .
 " installloc:  The location from which the service nodes should mount the \n" .
 "              deployment packages in the format hostname:/path.  If hostname is\n" .
 "              omitted, it defaults to the management node. The path must\n" .


### PR DESCRIPTION
this PR is to fix issue https://github.com/xcat2/xcat-core/issues/2029

Since `site.installdir` no longer work, and currently we have no plan to support it, mark this attribute as  `obsoleted` in Doc and site table schema

  