### PR TITLE
Add test case for issue 3571, 4085 and 3927  for makenetworks,chdef and mkdef for networks.

### DIFF
--- a/xCAT-test/autotest/testcase/chdef/cases0
+++ b/xCAT-test/autotest/testcase/chdef/cases0
@@ -273,3 +273,46 @@ check:output=~300
 cmd:if [ -f  /tmp/sitevalue ];then var=`cat /tmp/sitevalue`;chdef -t site clustersite dhcplease=$var;rm -rf /tmp/sitevalue;fi
 check:rc==0
 end
+
+start:chdef_network_not_exist
+description:This case is use to create a network, but not set net and mask. 
+label:mn_only,db
+cmd:chdef -t network aaaaa_not_exist
+check:output=~No object definitions have been created or modified
+#check:rc!=0
+cmd:chdef -t network aaaaa_not_exist mtu=1500
+check:rc!=0
+check:output=~Net or mask value should not be empty
+cmd:chdef -t network aaaaa_not_exist mtu=1500 net=10.0.0.0
+check:rc!=0
+check:output=~Net or mask value should not be empty
+cmd:chdef -t network aaaaa_not_exist mtu=1500 mask=255.255.255.0
+check:rc!=0
+check:output=~Net or mask value should not be empty
+cmd:chdef -t network aaaaa_not_exist mask=255.255.255.0 net=100.0.0.0 mtu=1500
+check:rc==0
+check:output=~1 object definitions have been created or modified
+cmd:lsdef -t network aaaaa_not_exist
+check:rc==0
+cmd:chdef -t network aaaaa_not_exist gateway=10.0.0.101
+check:rc==0
+cmd:lsdef -t network aaaaa_not_exist -i gateway
+check:output=~10.0.0.101
+cmd:chdef -t network bbbbb_not_exist mask=255.255.255.0 net=100.0.0.0
+check:rc!=0
+check:output=~A network definition called 'aaaaa_not_exist' already exists
+cmd:echo '
+bbbbb_not_exist:
+    objtype=network
+    net=150.0.0.0
+' > /tmp/bbbbb_not_exist.def
+cmd:cat /tmp/bbbbb_not_exist.def |mkdef -z
+check:rc!=0
+check:output=~Net or mask value should not be empty
+cmd:lsdef -t network -o bbbbb_not_exist
+check:rc!=0
+cmd:rmdef -t network -o aaaaa_not_exist
+check:rc==0
+cmd:rm -rf /tmp/bbbbb_not_exist.def
+end
+

--- a/xCAT-test/autotest/testcase/makenetworks/cases0
+++ b/xCAT-test/autotest/testcase/makenetworks/cases0
@@ -70,5 +70,11 @@ cmd:rm -f /tmp/testnetworks
 cmd:rm -f /tmp/inetworktest1
 end
 
-
-
+start:makenetworks_netname_exist
+os:Linux
+description:test makenetworks works as design when netname exists.
+label:others,network
+cmd:netname=`lsdef -t network |cut -d" " -f1 |sed -n '1p'`;makenetworks $netname
+check:rc==0
+check:output=~(already exists)
+end

--- a/xCAT-test/autotest/testcase/mkdef/cases0
+++ b/xCAT-test/autotest/testcase/mkdef/cases0
@@ -175,6 +175,25 @@ label:mn_only,ci_test,db
 cmd:mkdef -t network -o testnetworkwithoutnetandmask 
 check:rc!=0
 check:output=~Error
+cmd:mkdef -t network -o testnetworkwithoutnetandmask mtu=1500
+check:rc!=0
+check:output=~Net or mask value should not be empty
+cmd:mkdef -t network -o testnetworkwithoutnetandmask net=10.0.0.0 mtu=1500
+check:rc!=0
+check:output=~Net or mask value should not be empty
+cmd:mkdef -t network -o testnetworkwithoutnetandmask mask=255.0.0.0 mtu=1500
+check:rc!=0
+check:output=~Net or mask value should not be empty
+cmd:mkdef -t network -o testnetworkwithoutnetandmask net=100.0.0.1 mask=255.0.0.0 mtu=1500
+check:rc==0
+check:output=~1 object definitions have been created or modified
+cmd:lsdef -t network -z testnetworkwithoutnetandmask |tee /tmp/testnetworkwithoutnetandmask.stanza
+check:rc==0
+cmd:cat /tmp/testnetworkwithoutnetandmask.stanza|mkdef -z
+check:rc!=0
+check:output=~(already exists)
+cmd:rmdef -t network testnetworkwithoutnetandmask
+check:rc==0
 end
 
 start:mkdef_networks_if_net_mask_exists

--- a/xCAT-test/autotest/testcase/mkdef/cases0
+++ b/xCAT-test/autotest/testcase/mkdef/cases0
@@ -159,6 +159,34 @@ check:output=~gateway=1.2.3.1
 cmd:rmdef -t network testnetwork
 end
 
+start:mkdef_netname_exist
+os:Linux
+description:test mkdef works as design when netname exists.
+label:mn_only,ci_test,db
+cmd:netname=`lsdef -t network |cut -d" " -f1 |sed -n '1p'`;mkdef -t network -o $netname 
+check:rc==0
+check:output=~(already exists)
+end
+
+start:mkdef_netname_notexist_without_net_mask
+os:Linux
+description:test mkdef works as design when net and mask is not defined.
+label:mn_only,ci_test,db
+cmd:mkdef -t network -o testnetworkwithoutnetandmask 
+check:rc!=0
+check:output=~Error
+end
+
+start:mkdef_networks_if_net_mask_exists
+os:Linux
+description:test makenetworks works as design when net and mask exists. The network could not be created since net and mask are
+the same.
+label:mn_only,ci_test,db
+cmd:netname=`lsdef -t network |cut -d" " -f1 |sed -n '1p'`;net=`lsdef -t network -o $netname |grep -i net |awk -F = '{print $2}'`;mask=`lsdef -t network -o $netname |grep -i mask |awk -F = '{print $2}'`;mkdef -t network -o testnetworkwithnetandmask net=$net mask=$mask
+check:rc!=0
+check:output=~(already exists)
+end
+
 start:mkdef_t_o_error
 description:mkdef -t wrongtype
 label:mn_only,ci_test,db


### PR DESCRIPTION
### The PR is to for task https://github.com/xcat2/xcat2-task-management/issues/84
and task https://github.com/xcat2/xcat2-task-management/issues/88

The UT
```
------START::chdef_network_not_exist::Time:Sun Dec 16 22:27:07 2018------

RUN:chdef -t network aaaaa_not_exist [Sun Dec 16 22:27:07 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
No object definitions have been created or modified.
CHECK:output =~ No object definitions have been created or modified	[Pass]

RUN:chdef -t network aaaaa_not_exist mtu=1500 [Sun Dec 16 22:27:07 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: [c910f02c02p15]: Net or mask value should not be empty for xCAT network object 'aaaaa_not_exist'.
Error: [c910f02c02p15]: One or more errors occured when attempting to create or modify xCAT object definitions.
CHECK:rc != 0	[Pass]
CHECK:output =~ Net or mask value should not be empty	[Pass]

RUN:chdef -t network aaaaa_not_exist mtu=1500 net=10.0.0.0 [Sun Dec 16 22:27:08 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: [c910f02c02p15]: Net or mask value should not be empty for xCAT network object 'aaaaa_not_exist'.
Error: [c910f02c02p15]: One or more errors occured when attempting to create or modify xCAT object definitions.
CHECK:rc != 0	[Pass]
CHECK:output =~ Net or mask value should not be empty	[Pass]

RUN:chdef -t network aaaaa_not_exist mtu=1500 mask=255.255.255.0 [Sun Dec 16 22:27:09 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Error: [c910f02c02p15]: Net or mask value should not be empty for xCAT network object 'aaaaa_not_exist'.
Error: [c910f02c02p15]: One or more errors occured when attempting to create or modify xCAT object definitions.
CHECK:rc != 0	[Pass]
CHECK:output =~ Net or mask value should not be empty	[Pass]

RUN:chdef -t network aaaaa_not_exist mask=255.255.255.0 net=100.0.0.0 mtu=1500 [Sun Dec 16 22:27:09 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
New object definitions 'aaaaa_not_exist' have been created.
CHECK:rc == 0	[Pass]
CHECK:output =~ 1 object definitions have been created or modified	[Pass]

RUN:lsdef -t network aaaaa_not_exist [Sun Dec 16 22:27:10 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Object name: aaaaa_not_exist
    mask=255.255.255.0
    mtu=1500
    net=100.0.0.0
CHECK:rc == 0	[Pass]

RUN:chdef -t network aaaaa_not_exist gateway=10.0.0.101 [Sun Dec 16 22:27:10 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:lsdef -t network aaaaa_not_exist -i gateway [Sun Dec 16 22:27:11 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Object name: aaaaa_not_exist
    gateway=10.0.0.101
CHECK:output =~ 10.0.0.101	[Pass]

RUN:chdef -t network bbbbb_not_exist mask=255.255.255.0 net=100.0.0.0 [Sun Dec 16 22:27:11 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: [c910f02c02p15]: A network definition called 'aaaaa_not_exist' already exists that contains the same net and mask values. Cannot create a definition for 'bbbbb_not_exist'.
Error: [c910f02c02p15]: One or more errors occured when attempting to create or modify xCAT object definitions.
CHECK:rc != 0	[Pass]
CHECK:output =~ A network definition called 'aaaaa_not_exist' already exists	[Pass]

RUN: [Sun Dec 16 22:27:12 2018]
echo '
bbbbb_not_exist:
    objtype=network
    net=150.0.0.0
' > /tmp/bbbbb_not_exist.def
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:cat /tmp/bbbbb_not_exist.def |mkdef -z [Sun Dec 16 22:27:12 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: [c910f02c02p15]: Net or mask value should not be empty for xCAT network object 'bbbbb_not_exist'.
Error: [c910f02c02p15]: One or more errors occured when attempting to create or modify xCAT object definitions.
CHECK:rc != 0	[Pass]
CHECK:output =~ Net or mask value should not be empty	[Pass]

RUN:lsdef -t network -o bbbbb_not_exist [Sun Dec 16 22:27:13 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Error: [c910f02c02p15]: Could not find an object named 'bbbbb_not_exist' of type 'network'.
No object definitions have been found
CHECK:rc != 0	[Pass]

RUN:rmdef -t network -o aaaaa_not_exist [Sun Dec 16 22:27:13 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:rm -rf /tmp/bbbbb_not_exist.def [Sun Dec 16 22:27:14 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::chdef_network_not_exist::Passed::Time:Sun Dec 16 22:27:14 2018 ::Duration::7 sec------
------START::makenetworks_netname_exist::Time:Sun Dec 16 22:27:14 2018------

RUN:netname=`lsdef -t network |cut -d" " -f1 |sed -n '1p'`;makenetworks $netname [Sun Dec 16 22:27:14 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Warning: [c910f02c02p15]: The network entry '10_0_0_0-255_0_0_0' already exists in xCAT networks table. Cannot create a definition for '10_0_0_0-255_0_0_0'
CHECK:rc == 0	[Pass]
CHECK:output =~ (already exists)	[Pass]

------END::makenetworks_netname_exist::Passed::Time:Sun Dec 16 22:27:15 2018 ::Duration::1 sec------
------START::mkdef_netname_exist::Time:Sun Dec 16 22:27:15 2018------

RUN:netname=`lsdef -t network |cut -d" " -f1 |sed -n '1p'`;mkdef -t network -o $netname [Sun Dec 16 22:27:15 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: [c910f02c02p15]: 0 object definitions have been created or modified.
CHECK:rc == 0	[Failed]

------END::mkdef_netname_exist::Failed::Time:Sun Dec 16 22:27:16 2018 ::Duration::1 sec------
------START::mkdef_netname_notexist_without_net_mask::Time:Sun Dec 16 22:27:16 2018------

RUN:mkdef -t network -o testnetworkwithoutnetandmask [Sun Dec 16 22:27:16 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Error: [c910f02c02p15]: 0 object definitions have been created or modified.
CHECK:rc != 0	[Pass]
CHECK:output =~ Error	[Pass]

RUN:mkdef -t network -o testnetworkwithoutnetandmask mtu=1500 [Sun Dec 16 22:27:16 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: [c910f02c02p15]: A network definition called 'testnetworkwithoutnetandmask' already exists. Cannot create a definition for 'testnetworkwithoutnetandmask'.
Error: [c910f02c02p15]: One or more errors occured when attempting to create or modify xCAT object definitions.
CHECK:rc != 0	[Pass]
CHECK:output =~ Net or mask value should not be empty	[Failed]

RUN:mkdef -t network -o testnetworkwithoutnetandmask net=10.0.0.0 mtu=1500 [Sun Dec 16 22:27:17 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Error: [c910f02c02p15]: A network definition called 'testnetworkwithoutnetandmask' already exists. Cannot create a definition for 'testnetworkwithoutnetandmask'.
Error: [c910f02c02p15]: One or more errors occured when attempting to create or modify xCAT object definitions.

RUN:mkdef -t network -o testnetworkwithoutnetandmask mask=255.0.0.0 mtu=1500 [Sun Dec 16 22:27:17 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: [c910f02c02p15]: A network definition called 'testnetworkwithoutnetandmask' already exists. Cannot create a definition for 'testnetworkwithoutnetandmask'.
Error: [c910f02c02p15]: One or more errors occured when attempting to create or modify xCAT object definitions.

RUN:mkdef -t network -o testnetworkwithoutnetandmask net=100.0.0.1 mask=255.0.0.0 mtu=1500 [Sun Dec 16 22:27:18 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Error: [c910f02c02p15]: A network definition called 'testnetworkwithoutnetandmask' already exists. Cannot create a definition for 'testnetworkwithoutnetandmask'.
Error: [c910f02c02p15]: One or more errors occured when attempting to create or modify xCAT object definitions.

RUN:lsdef -t network -z testnetworkwithoutnetandmask |tee /tmp/testnetworkwithoutnetandmask.stanza [Sun Dec 16 22:27:18 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
# <xCAT data object stanza file>

testnetworkwithoutnetandmask:
    objtype=network
    mask=255.0.0.0
    mtu=1500
    net=100.0.0.1

RUN:cat /tmp/testnetworkwithoutnetandmask.stanza|mkdef -z [Sun Dec 16 22:27:19 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: [c910f02c02p15]: A network definition called 'testnetworkwithoutnetandmask' already exists. Cannot create a definition for 'testnetworkwithoutnetandmask'.
Error: [c910f02c02p15]: One or more errors occured when attempting to create or modify xCAT object definitions.

RUN:rmdef -t network testnetworkwithoutnetandmask [Sun Dec 16 22:27:20 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.

------END::mkdef_netname_notexist_without_net_mask::Failed::Time:Sun Dec 16 22:27:20 2018 ::Duration::4 sec------
------START::mkdef_networks_if_net_mask_exists::Time:Sun Dec 16 22:27:20 2018------

RUN:netname=`lsdef -t network |cut -d" " -f1 |sed -n '1p'`;net=`lsdef -t network -o $netname |grep -i net |awk -F = '{print $2}'`;mask=`lsdef -t network -o $netname |grep -i mask |awk -F = '{print $2}'`;mkdef -t network -o testnetworkwithnetandmask net=$net mask=$mask [Sun Dec 16 22:27:20 2018]
ElapsedTime:2 sec
RETURN rc = 1
OUTPUT:
Error: [c910f02c02p15]: A network definition called '10_0_0_0-255_0_0_0' already exists that contains the same net and mask values. Cannot create a definition for 'testnetworkwithnetandmask'.
Error: [c910f02c02p15]: One or more errors occured when attempting to create or modify xCAT object definitions.
CHECK:rc != 0	[Pass]
CHECK:output =~ (already exists)	[Pass]

------END::mkdef_networks_if_net_mask_exists::Passed::Time:Sun Dec 16 22:27:22 2018 ::Duration::2 sec------
------Total: 5 , Failed: 2------
```