### PR TITLE
refine diff cases according to latest code

### DIFF
--- a/xCAT-test/autotest/testcase/xcat_inventory/cases.diff
+++ b/xCAT-test/autotest/testcase/xcat_inventory/cases.diff
@@ -13,7 +13,7 @@ start:xcat_inventory_diff_without_option
 description:This case is used to test xcat-inventory diff without option, should be error
 label:others,inventory_ci
 cmd:xcat-inventory diff
-check:output=~Error: No valid source type!
+check:output=~Backend not initialized, please initialize the backend with
 check:rc!=0
 end
 
@@ -45,7 +45,7 @@ start:xcat_inventory_diff_filename
 description:This case is used to test xcat-inventory diff filename, should be error
 label:others,inventory_ci
 cmd:xcat-inventory diff --filename test_filename
-check:output=~Error: No valid source type!
+check:output=~Backend not initialized, please initialize the backend with
 check:rc!=0
 end
 


### PR DESCRIPTION
### The PR is to refine the test case of `xcat-inventory diff` according to the latest code

UT:
```
[root@c910f03c05k21 xcat_inventory]# xcattest -t xcat_inventory_diff_without_option
xCAT automated test started at Mon Dec 17 03:46:16 2018
******************************
To detect current test environment
******************************
Detecting: OS = linux
Warning: No compute node defined, can't get ARCH of compute node
Warning: No compute node defined, can't get HCP TYPE of compute node
******************************
loading test cases
******************************
To run:
xcat_inventory_diff_without_option
******************************
Start to run test cases
******************************
------START::xcat_inventory_diff_without_option::Time:Mon Dec 17 03:46:17 2018------

RUN:xcat-inventory diff [Mon Dec 17 03:46:17 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Backend not initialized, please initialize the backend with 'xcat-inventory init'
CHECK:output =~ Backend not initialized, please initialize the backend with	[Pass]
CHECK:rc != 0	[Pass]

------END::xcat_inventory_diff_without_option::Passed::Time:Mon Dec 17 03:46:17 2018 ::Duration::0 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished at Mon Dec 17 03:46:17 2018

[root@c910f03c05k21 xcat_inventory]# xcattest -t xcat_inventory_diff_filename
xCAT automated test started at Mon Dec 17 03:47:09 2018
******************************
To detect current test environment
******************************
Detecting: OS = linux
Warning: No compute node defined, can't get ARCH of compute node
Warning: No compute node defined, can't get HCP TYPE of compute node
******************************
loading test cases
******************************
To run:
xcat_inventory_diff_filename
******************************
Start to run test cases
******************************
------START::xcat_inventory_diff_filename::Time:Mon Dec 17 03:47:10 2018------

RUN:xcat-inventory diff --filename test_filename [Mon Dec 17 03:47:10 2018]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Backend not initialized, please initialize the backend with 'xcat-inventory init'
CHECK:output =~ Backend not initialized, please initialize the backend with	[Pass]
CHECK:rc != 0	[Pass]

------END::xcat_inventory_diff_filename::Passed::Time:Mon Dec 17 03:47:11 2018 ::Duration::1 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished at Mon Dec 17 03:47:11 2018
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20181217034709 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20181217034709 file for time consumption
[root@c910f03c05k21 xcat_inventory]#
```