### PR TITLE
site.httpport for ubuntu diskless support

### DIFF
--- a/xCAT-server/lib/xcat/plugins/debian.pm
+++ b/xCAT-server/lib/xcat/plugins/debian.pm
@@ -973,6 +973,7 @@ sub mknetboot
     my $xcatdport  = "3001";
     my $xcatiport  = "3002";
     my $nodestatus = "y";
+    my $httpport="80";
     my @myself     = xCAT::NetworkUtils->determinehostname();
     my $myname     = $myself[ (scalar @myself) - 1 ];
 
@@ -1003,6 +1004,12 @@ sub mknetboot
         {
             $nodestatus = $ref->{value};
         }
+        ($ref) = $sitetab->getAttribs({ key => 'httpport' }, 'value');
+        if ($ref and $ref->{value})
+        {
+            $httpport = $ref->{value};
+        }
+
     }
     my %donetftp = ();
     my %oents = %{ $ostab->getNodesAttribs(\@nodes, [qw(os arch profile provmethod)]) };


### PR DESCRIPTION
### The PR is to fix issue found by autotest on ubuntu diskless support

UT:
```
root@c910f03c09k03:/opt/xcat/share/xcat/tools/autotest/bundle# xcattest -b ./non_default_http_port_test.bundle   -f /opt/xcat/share/xcat/tools/autotest/default.conf
...
------END::clean_up_env::Passed::Time:Mon Dec 17 04:02:10 2018 ::Duration::366 sec------
------Total: 14 , Failed: 0------

xCAT automated test finished at Mon Dec 17 04:02:10 2018
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20181217032903 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20181217032903 file for time consumption
```