### PR TITLE
fix issue of site.httpport support in makedhcp

### DIFF
--- a/xCAT-server/lib/xcat/plugins/dhcp.pm
+++ b/xCAT-server/lib/xcat/plugins/dhcp.pm
@@ -2677,7 +2677,7 @@ sub addnet
             }
         }
         #for cumulus ZTP process
-        push @netent, "    option cumulus-provision-url \"http://$tftp.':' . $httpport/install/postscripts/cumulusztp\";\n";
+        push @netent, "    option cumulus-provision-url \"http://$tftp:$httpport/install/postscripts/cumulusztp\";\n";
 
         my $ddnserver = $nameservers;
         $ddnserver =~ s/,.*//;
@@ -2717,9 +2717,9 @@ sub addnet
         # $lstatements = 'if exists gpxe.bus-id { filename = \"\"; } else if exists client-architecture { filename = \"xcat/xnba.kpxe\"; } '.$lstatements;
         push @netent, "    if option user-class-identifier = \"xNBA\" and option client-architecture = 00:00 { #x86, xCAT Network Boot Agent\n";
         push @netent, "        always-broadcast on;\n";
-        push @netent, "        filename = \"http://$tftp.':' . $httpport/tftpboot/xcat/xnba/nets/" . $net . "_" . $maskbits . "\";\n";
+        push @netent, "        filename = \"http://$tftp:$httpport/tftpboot/xcat/xnba/nets/" . $net . "_" . $maskbits . "\";\n";
         push @netent, "    } else if option user-class-identifier = \"xNBA\" and option client-architecture = 00:09 { #x86, xCAT Network Boot Agent\n";
-        push @netent, "        filename = \"http://$tftp.':' . $httpport/tftpboot/xcat/xnba/nets/" . $net . "_" . $maskbits . ".uefi\";\n";
+        push @netent, "        filename = \"http://$tftp:$httpport/tftpboot/xcat/xnba/nets/" . $net . "_" . $maskbits . ".uefi\";\n";
         push @netent, "    } else if option client-architecture = 00:00  { #x86\n";
         push @netent, "        filename \"xcat/xnba.kpxe\";\n";
         push @netent, "    } else if option vendor-class-identifier = \"Etherboot-5.4\"  { #x86\n";
@@ -2735,10 +2735,10 @@ sub addnet
         push @netent, "        filename \"elilo.efi\";\n";
         push @netent,
           "    } else if option client-architecture = 00:0e { #OPAL-v3\n ";
-        push @netent, "        option conf-file = \"http://$tftp.':' . $httpport/tftpboot/pxelinux.cfg/p/" . $net . "_" . $maskbits . "\";\n";
+        push @netent, "        option conf-file = \"http://$tftp:$httpport/tftpboot/pxelinux.cfg/p/" . $net . "_" . $maskbits . "\";\n";
         push @netent,
           "    } else if substring (option vendor-class-identifier,0,11) = \"onie_vendor\" { #for onie on cumulus switch\n";
-        push @netent, "        option www-server = \"http://$tftp.':' . $httpport/install/onie/onie-installer\";\n";
+        push @netent, "        option www-server = \"http://$tftp:$httpport/install/onie/onie-installer\";\n";
         push @netent,
           "    } else if substring(filename,0,1) = null { #otherwise, provide yaboot if the client isn't specific\n ";
         push @netent, "        filename \"/yaboot\";\n";


### PR DESCRIPTION
### The PR is to fix issue https://github.com/xcat2/xcat-core/issues/5905

It is code error when we doing customized http port feature.

UT:

```
~# makedhcp -n
~# cat /etc/dhcp/dhcpd.conf
#xCAT generated dhcp configuration

...
shared-network enP2p1s0f0 {
  subnet 10.0.0.0 netmask 255.0.0.0 {
    authoritative;
    max-lease-time 43200;
    min-lease-time 43200;
    default-lease-time 43200;
    option routers  10.0.0.101;
    next-server  10.6.29.1;
    option log-servers 10.6.29.1;
    option ntp-servers 10.6.29.1;
    option domain-name "pok.stglabs.ibm.com";
    option domain-name-servers  10.6.29.1;
    option domain-search  "pok.stglabs.ibm.com";
    option cumulus-provision-url "http://10.6.29.1:80/install/postscripts/cumulusztp";
    zone pok.stglabs.ibm.com. {
       primary 10.6.29.1; key xcat_key;
    }
    zone 10.IN-ADDR.ARPA. {
       primary 10.6.29.1; key xcat_key;
    }
    if option user-class-identifier = "xNBA" and option client-architecture = 00:00 { #x86, xCAT Network Boot Agent
        always-broadcast on;
        filename = "http://10.6.29.1:80/tftpboot/xcat/xnba/nets/10.0.0.0_8";
    } else if option user-class-identifier = "xNBA" and option client-architecture = 00:09 { #x86, xCAT Network Boot Agent
        filename = "http://10.6.29.1:80/tftpboot/xcat/xnba/nets/10.0.0.0_8.uefi";
    } else if option client-architecture = 00:00  { #x86
        filename "xcat/xnba.kpxe";
    } else if option vendor-class-identifier = "Etherboot-5.4"  { #x86
        filename "xcat/xnba.kpxe";
    } else if option client-architecture = 00:07 { #x86_64 uefi
         filename "xcat/xnba.efi";
    } else if option client-architecture = 00:09 { #x86_64 uefi alternative id
         filename "xcat/xnba.efi";
    } else if option client-architecture = 00:02 { #ia64
         filename "elilo.efi";
    } else if option client-architecture = 00:0e { #OPAL-v3
         option conf-file = "http://10.6.29.1:80/tftpboot/pxelinux.cfg/p/10.0.0.0_8";
    } else if substring (option vendor-class-identifier,0,11) = "onie_vendor" { #for onie on cumulus switch
        option www-server = "http://10.6.29.1:80/install/onie/onie-installer";
    } else if substring(filename,0,1) = null { #otherwise, provide yaboot if the client isn't specific
         filename "/yaboot";
    }
  } # 10.0.0.0/255.0.0.0 subnet_end
} # enP2p1s0f0 nic_end
shared-network enP2p1s0f2 {
  subnet 50.0.0.0 netmask 255.0.0.0 {
    authoritative;
    max-lease-time 43200;
    min-lease-time 43200;
    default-lease-time 43200;
    option routers  50.6.29.2;
    next-server  50.6.29.2;
    option log-servers 50.6.29.2;
    option ntp-servers 50.6.29.2;
    option domain-name "pok.stglabs.ibm.com";
    option domain-name-servers  10.6.29.1;
    option domain-search  "pok.stglabs.ibm.com";
    option cumulus-provision-url "http://50.6.29.2:80/install/postscripts/cumulusztp";
    zone pok.stglabs.ibm.com. {
       primary 10.6.29.1; key xcat_key;
    }
    zone 50.IN-ADDR.ARPA. {
       primary 10.6.29.1; key xcat_key;
    }
    if option user-class-identifier = "xNBA" and option client-architecture = 00:00 { #x86, xCAT Network Boot Agent
        always-broadcast on;
        filename = "http://50.6.29.2:80/tftpboot/xcat/xnba/nets/50.0.0.0_8";
    } else if option user-class-identifier = "xNBA" and option client-architecture = 00:09 { #x86, xCAT Network Boot Agent
        filename = "http://50.6.29.2:80/tftpboot/xcat/xnba/nets/50.0.0.0_8.uefi";
    } else if option client-architecture = 00:00  { #x86
        filename "xcat/xnba.kpxe";
    } else if option vendor-class-identifier = "Etherboot-5.4"  { #x86
        filename "xcat/xnba.kpxe";
    } else if option client-architecture = 00:07 { #x86_64 uefi
         filename "xcat/xnba.efi";
    } else if option client-architecture = 00:09 { #x86_64 uefi alternative id
         filename "xcat/xnba.efi";
    } else if option client-architecture = 00:02 { #ia64
         filename "elilo.efi";
    } else if option client-architecture = 00:0e { #OPAL-v3
         option conf-file = "http://50.6.29.2:80/tftpboot/pxelinux.cfg/p/50.0.0.0_8";
    } else if substring (option vendor-class-identifier,0,11) = "onie_vendor" { #for onie on cumulus switch
        option www-server = "http://50.6.29.2:80/install/onie/onie-installer";
    } else if substring(filename,0,1) = null { #otherwise, provide yaboot if the client isn't specific
         filename "/yaboot";
    }
  } # 50.0.0.0/255.0.0.0 subnet_end
} # enP2p1s0f2 nic_end
[root@stratton01 xCAT_plugin
```