### PR TITLE
Make lsdef -z could display all attribute by default

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/lsdef.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/lsdef.1.rst
@@ -21,13 +21,13 @@ SYNOPSIS
 
 \ **lsdef**\  [\ **-h | -**\ **-help**\ ] [\ **-t**\  \ *object-types*\ ] [\ **-i**\  \ *attr-list*\ ]
 
-\ **lsdef**\  [\ **-V | -**\ **-verbose**\ ] [\ **-l | -**\ **-long**\ ] [\ **-s | -**\ **-short**\ ] [\ **-a | -**\ **-all**\ ] [\ **-S**\ ]
-[\ **-t**\  \ *object-types*\ ] [\ **-o**\  \ *object-names*\ ] [\ **-z | -**\ **-stanza**\ ] [\ **-i**\  \ *attr-list*\ ]
+\ **lsdef**\  [\ **-V | -**\ **-verbose**\ ] [\ **-a | -**\ **-all**\ ] [\ **-S**\ ]
+[\ **-t**\  \ *object-types*\ ] [\ **-o**\  \ *object-names*\ ] [\ **-z | -**\ **-stanza**\ ] [\ [\ **-i**\  \ *attr-list*\] | [\ **-l | -**\ **-long**\ ] | [\ **-s | -**\ **-short**\ ]]
 [\ **-c | -**\ **-compress**\ ] [\ **-**\ **-osimage**\ ] [\ **-**\ **-nics**\ ] [[\ **-w**\  \ *attr*\ ==\ *val*\ ]
 [\ **-w**\  \ *attr*\ =~\ *val*\ ] ...] [\ *noderange*\ ]
 
-\ **lsdef**\  [\ **-l | -**\ **-long**\ ] [\ **-a | -**\ **-all**\ ] [\ **-t**\  \ *object-types*\ ] [\ **-z | -**\ **-stanza**\ ]
-[\ **-i**\  \ *attr-list*\ ] [\ **-**\ **-template**\  [\ *template-object-name*\ ]]
+\ **lsdef**\  [\ **-a | -**\ **-all**\ ] [\ **-t**\  \ *object-types*\ ] [\ **-z | -**\ **-stanza**\ ]
+[\ [\ **-i**\  \ *attr-list*\] | [\ **-l | -**\ **-long**\ ] | [\ **-s | -**\ **-short**\ ]] [\ **-**\ **-template**\  [\ *template-object-name*\ ]]
 
 
 ***********

--- a/xCAT-client/pods/man1/lsdef.1.pod
+++ b/xCAT-client/pods/man1/lsdef.1.pod
@@ -100,7 +100,7 @@ Note: if the "val" fields includes spaces or any other characters that will be p
 
 =item B<-z|--stanza>
 
-Display output in stanza format. See the xcatstanzafile man page for details on using xCAT stanza files. And default is to list complete object definition, use B<-i> to specify the attribute scope.
+Display output in stanza format. See the "xcatstanzafile" man page for details on using xCAT stanza files. And default is to list complete object definition, use B<-i> to specify the attribute scope.
 
 =back
 

--- a/xCAT-client/pods/man1/lsdef.1.pod
+++ b/xCAT-client/pods/man1/lsdef.1.pod
@@ -6,13 +6,13 @@ B<lsdef> - Use this command to list xCAT data object definitions.
 
 B<lsdef> [B<-h>|B<--help>] [B<-t> I<object-types>] [B<-i> I<attr-list>]
 
-B<lsdef> [B<-V>|B<--verbose>] [B<-l>|B<--long>] [B<-s>|B<--short>] [B<-a>|B<--all>] [B<-S>]
-[B<-t> I<object-types>] [B<-o> I<object-names>] [B<-z>|B<--stanza>] [B<-i> I<attr-list>]
+B<lsdef> [B<-V>|B<--verbose>] [B<-a>|B<--all>] [B<-S>]
+[B<-t> I<object-types>] [B<-o> I<object-names>] [B<-z>|B<--stanza>] [B<-i> I<attr-list> | [B<-l>|B<--long>] | [B<-s>|B<--short>]]
 [B<-c>|B<--compress>] [B<--osimage>] [B<--nics>] [[B<-w> I<attr>==I<val>]
 [B<-w> I<attr>=~I<val>] ...] [I<noderange>]
 
-B<lsdef> [B<-l>|B<--long>] [B<-a>|B<--all>] [B<-t> I<object-types>] [B<-z>|B<--stanza>]
-[B<-i> I<attr-list>] [B<--template> [I<template-object-name>]]
+B<lsdef> [B<-a>|B<--all>] [B<-t> I<object-types>] [B<-z>|B<--stanza>]
+[B<-i> I<attr-list> | [B<-l>|B<--long>] | [B<-s>|B<--short>]] [B<--template> [I<template-object-name>]]
 
 =head1 DESCRIPTION
 
@@ -99,7 +99,7 @@ Note: if the "val" fields includes spaces or any other characters that will be p
 
 =item B<-z|--stanza>
 
-Display output in stanza format. See the xcatstanzafile man page for details on using xCAT stanza files.
+Display output in stanza format. See the xcatstanzafile man page for details on using xCAT stanza files. And default is to list complete object definition, use B<-i> to specify the attribute scope.
 
 =back
 

--- a/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
+++ b/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
@@ -3274,7 +3274,7 @@ sub defls
 
 
     # do we want just the object names or all the attr=val
-    if ($::opt_l || @::noderange || $::opt_o || $::opt_i || $::opt_template)
+    if ($::opt_l || @::noderange || $::opt_o || $::opt_i || $::opt_z || $::opt_template)
     {
 
         # assume we want the the details - not just the names
@@ -3297,7 +3297,7 @@ sub defls
 
         # is -i then just get the ones in the list
         $::ATTRLIST = $::opt_i;
-    } elsif (@::noderange || $::opt_o) {
+    } elsif (@::noderange || $::opt_o || $::opt_z) {
 
         # if they gave a list of objects then they must want more
         # than the object names!


### PR DESCRIPTION
### The PR is to fix issue (#5241)

### The modification include

##modify the code logic, when using -z, using long format by default 
And in old codes, the behavior is not consistent:
- without noderange, it will output only name. While with noderagen, it will output all attribute.

After the fix, if you give `-z`, it will show all by default unless you use `-s` or `-i`

##update manpage accordingly to describe this change

### The UT result
```
lsdef -z
# <xCAT data object stanza file>
...
...

restnode:
    objtype=node
    groups=all
    mac=00:1a:64:54:14:80
    mgt=openbmc
    netboot=petitboot
    provmethod=xcat.redhat-alt.full.install
    usercomment=abc
```

Before the patch:
```
lsdef -z
# <xCAT data object stanza file>

boston02:

boston02-bmc:

boston30:

boston30-bmc:

boston32:

boston32-bmc:

boston32-redfish:

boston36:

boston36-bmc:

boston38:

boston38-bmc:

briggs01:

c910f2u39:

c910f2u39-bmc:

c910f3u29:

c910f3zz01:

f2u39vm001:

f4u18-bmc:

f5u14:

f5u14-bmc:

f5u16:

f5u16-bmc:

f6u07:

f6u07-bmc:

f6u13:

f6u13-bmc:

f6u13k01:

f6u13k02:

f6u13k03:

f6u13k04:

f6u13k05:

f6u13k10:

f6u13k11:

f6u13k12:

f6u13k13:

f6u13k14:

f6u13k15:

f6u13k16:

f6u13k17:

f6u13k18:

frame5u39:

fs2:

fs2vm110:

fs2vm111:

fs2vm112:

fs2vm113:

fs2vm114:

fs2vm115:

fs3:

restnode:
```
