### PR TITLE
[DO NOT MERGE] Fix for MacMap failing to map all vlans for Cisco switches

### DIFF
--- a/perl-xCAT/xCAT/MacMap.pm
+++ b/perl-xCAT/xCAT/MacMap.pm
@@ -985,7 +985,6 @@ sub refresh_switch {
                 push @{ $self->{mtuinfo}->{$switch}->{$port_name} } , $mtu;
 
             }
-            return;
         }
 
         foreach my $oid (keys %$namemap) {


### PR DESCRIPTION
## The PR is to fix issue #5912

### The modifications include

### Remove early return in vlan loop in MacMap.pm->refresh_switch

Before fix, refresh_switch would return after successfully mapping the first VLAN in vlans_to_check on Cisco switches. Removing the early return allows the loop to correctly map the rest of the VLANs.

### After fix
```
Switch      Port(MTU)                   MAC address(VLAN)           Node
--------------------------------------------------------------------------------------
br1coresw2  Ethernet1/1(1500)           N/A                         
br1coresw2  Ethernet1/2(1500)           N/A                             
br1coresw2  Ethernet1/3(1500)           54:48:10:fb:6e:f4(84)       
br1coresw2  Ethernet1/4(1500)           N/A                         
br1coresw2  Ethernet1/5(1500)           N/A                         
br1coresw2  Ethernet1/6(1500)           N/A                         
br1coresw2  Ethernet1/13(1500)          N/A                         
br1coresw2  Ethernet1/14(1500)          N/A                         
br1coresw2  Ethernet1/15(1500)          N/A                         
br1coresw2  Ethernet1/16(1500)          N/A                         
br1coresw2  Ethernet1/17(1500)          N/A                         
br1coresw2  Ethernet1/18(1500)          N/A                         
br1coresw2  Ethernet1/19(1500)          N/A                         
br1coresw2  Ethernet1/20(1500)          N/A                         
br1coresw2  Ethernet1/21(1500)          N/A                         vzn-cr12-h12-sw1
br1coresw2  Ethernet1/22(1500)          N/A                         
br1coresw2  Ethernet1/23(1500)          N/A                         
br1coresw2  Ethernet1/24(1500)          N/A                         
br1coresw2  Ethernet1/25(1500)          N/A                         vzn-cr09-f05-sw1
br1coresw2  Ethernet1/25(1500)          f8:c2:88:ee:99:bf(248)      vzn-cr09-f05-sw1
br1coresw2  Ethernet1/25(1500)          f8:c2:88:ee:99:bf(248)      vzn-cr09-f05-sw1
br1coresw2  Ethernet1/25(1500)          f8:c2:88:ee:99:bf(248)      vzn-cr09-f05-sw1
br1coresw2  Ethernet1/27(1500)          N/A                         
br1coresw2  Ethernet1/28(1500)          64:12:25:9d:e6:18(100)      
br1coresw2  Ethernet1/28(1500)          64:12:25:9d:e6:18(100)      
br1coresw2  Ethernet1/28(1500)          b8:83:03:f2:e7:fe(184)      
br1coresw2  Ethernet1/28(1500)          28:ac:9e:ad:31:90(40)       
br1coresw2  Ethernet1/28(1500)          54:80:28:6a:ad:75(84)       
br1coresw2  Ethernet1/28(1500)          a4:5d:36:b7:cf:e8(164)      
br1coresw2  Ethernet1/28(1500)          64:12:25:9d:e6:18(100)      
br1coresw2  Ethernet1/28(1500)          b8:83:03:f2:e7:fe(184)      
br1coresw2  Ethernet1/28(1500)          28:ac:9e:ad:31:90(40)       
br1coresw2  Ethernet1/28(1500)          54:80:28:6a:ad:75(84)       
br1coresw2  Ethernet1/28(1500)          a4:5d:36:b7:cf:e8(164)      
br1coresw2  Ethernet1/28(1500)          b8:83:03:f2:e7:fe(184)      
br1coresw2  Ethernet1/28(1500)          28:ac:9e:ad:31:90(40)       
br1coresw2  Ethernet1/28(1500)          54:80:28:6a:ad:75(84)       
br1coresw2  Ethernet1/28(1500)          a4:5d:36:b7:cf:e8(164)      
br1coresw2  Ethernet1/29(1500)          N/A                         
br1coresw2  Ethernet1/30(1500)          N/A                         
br1coresw2  Ethernet1/31(1500)          N/A                         
br1coresw2  Ethernet1/33(1500)          N/A                         
br1coresw2  Ethernet1/34(1500)          N/A                         
br1coresw2  Ethernet1/35(1500)          N/A                         
br1coresw2  Ethernet1/36(1500)          N/A                         
br1coresw2  Ethernet1/38(1500)          N/A                         
br1coresw2  Ethernet1/39(1500)          N/A                         
br1coresw2  Ethernet1/40(1500)          N/A                         
br1coresw2  Ethernet1/41(1500)          N/A                         
br1coresw2  Ethernet1/42(1500)          N/A                         
br1coresw2  Ethernet1/43(1500)          N/A                         
br1coresw2  Ethernet1/44(1500)          N/A                         
br1coresw2  Ethernet1/45(1500)          N/A                         
br1coresw2  Ethernet1/47(1500)          N/A                         
br1coresw2  Ethernet1/48(1500)          00:41:d2:45:aa:a3           
br1coresw2  Ethernet1/48(1500)          00:41:d2:45:aa:a3           
br1coresw2  Ethernet1/48(1500)          00:41:d2:45:aa:a3           
br1coresw2  Ethernet199/1/1(1500)       N/A                         
br1coresw2  Ethernet199/1/2(1500)       N/A                         
br1coresw2  Ethernet199/1/3(1500)       N/A                         
br1coresw2  Ethernet199/1/4(1500)       N/A                         
br1coresw2  Ethernet199/1/5(1500)       N/A                         
br1coresw2  Ethernet199/1/6(1500)       N/A                         
br1coresw2  Ethernet199/1/7(1500)       N/A                         
br1coresw2  Ethernet199/1/8(1500)       N/A                         
br1coresw2  Ethernet199/1/9(1500)       N/A                         
br1coresw2  Ethernet199/1/10(1500)      N/A                         
br1coresw2  Ethernet199/1/11(1500)      N/A                         
br1coresw2  Ethernet199/1/12(1500)      N/A                         
br1coresw2  Ethernet199/1/13(1500)      N/A                         
br1coresw2  Ethernet199/1/14(1500)      N/A                         
br1coresw2  Ethernet199/1/15(1500)      N/A                         
br1coresw2  Ethernet199/1/16(1500)      N/A                         
br1coresw2  Ethernet199/1/17(1500)      N/A                         
br1coresw2  Ethernet199/1/18(1500)      98:5d:82:4d:cc:da(152)      
br1coresw2  Ethernet199/1/18(1500)      98:5d:82:4d:cc:da(152)      
br1coresw2  Ethernet199/1/18(1500)      98:5d:82:4d:cc:da(152)      
br1coresw2  Ethernet199/1/19(1500)      N/A                         
br1coresw2  Ethernet199/1/20(1500)      N/A                         
br1coresw2  Ethernet199/1/21(1500)      N/A                         vzn-cr12-h12-sw1
br1coresw2  Ethernet199/1/22(1500)      N/A                         
br1coresw2  Ethernet199/1/23(1500)      N/A                         
br1coresw2  Ethernet199/1/24(1500)      N/A                         
br1coresw2  Ethernet199/1/25(1500)      N/A                         vzn-cr09-f05-sw1
br1coresw2  Ethernet199/1/26(1500)      N/A                         
br1coresw2  Ethernet199/1/27(1500)      N/A                         
br1coresw2  Ethernet199/1/28(1500)      N/A                         
br1coresw2  Ethernet199/1/29(1500)      N/A                         
br1coresw2  Ethernet199/1/30(1500)      N/A                         
br1coresw2  Ethernet199/1/31(1500)      N/A                         
br1coresw2  Ethernet199/1/32(1500)      N/A                         
br1coresw2  Ethernet199/1/33(1500)      N/A                         
br1coresw2  Ethernet199/1/34(1500)      N/A                         
br1coresw2  Ethernet199/1/35(1500)      N/A                         
br1coresw2  Ethernet199/1/36(1500)      N/A                         
br1coresw2  Ethernet199/1/37(1500)      N/A                         
br1coresw2  Ethernet199/1/38(1500)      N/A                         
br1coresw2  Ethernet199/1/39(1500)      N/A                         
br1coresw2  Ethernet199/1/40(1500)      N/A                         
br1coresw2  Ethernet199/1/41(1500)      N/A                         
br1coresw2  Ethernet199/1/42(1500)      N/A                         
br1coresw2  Ethernet199/1/43(1500)      N/A                         
br1coresw2  Ethernet199/1/44(1500)      N/A                         
br1coresw2  Ethernet199/1/45(1500)      N/A                         
br1coresw2  Ethernet199/1/46(1500)      N/A                         
br1coresw2  Ethernet199/1/47(1500)      N/A                         
br1coresw2  Ethernet2/4(1500)           N/A                         
br1coresw2  Ethernet2/5(1500)           N/A                         
br1coresw2  Ethernet2/6(1500)           N/A                         
br1coresw2  Ethernet2/1/2(1500)         N/A                         
br1coresw2  Ethernet2/1/2(1500)         00:2a:6a:63:53:01           
br1coresw2  Ethernet2/1/2(1500)         00:2a:6a:63:53:01           
br1coresw2  Ethernet2/1/2(1500)         00:2a:6a:63:53:01           
br1coresw2  Ethernet2/1/4(1500)         N/A                         
br1coresw2  Ethernet2/2/1(1500)         N/A                         
br1coresw2  Ethernet2/2/3(1500)         N/A                         
br1coresw2  Ethernet2/2/4(1500)         N/A                         
br1coresw2  Ethernet2/3/1(1500)         N/A                         
br1coresw2  Ethernet2/3/2(1500)         N/A                         
br1coresw2  Ethernet2/3/3(1500)         N/A                         
br1coresw2  Ethernet2/3/4(1500)         N/A                         
```


### Before fix
```
Switch      Port(MTU)               MAC address(VLAN)           Node
--------------------------------------------------------------------------------------
br1coresw2  Ethernet1/1(1500)       N/A                         
br1coresw2  Ethernet1/2(1500)       N/A                         
br1coresw2  Ethernet1/3(1500)       N/A                         
br1coresw2  Ethernet1/4(1500)       N/A                         
br1coresw2  Ethernet1/5(1500)       N/A                         
br1coresw2  Ethernet1/6(1500)       N/A                         
br1coresw2  Ethernet1/13(1500)      N/A                         
br1coresw2  Ethernet1/14(1500)      N/A                         
br1coresw2  Ethernet1/15(1500)      N/A                         
br1coresw2  Ethernet1/16(1500)      N/A                         
br1coresw2  Ethernet1/17(1500)      N/A                         
br1coresw2  Ethernet1/18(1500)      N/A                         
br1coresw2  Ethernet1/19(1500)      N/A                         
br1coresw2  Ethernet1/20(1500)      N/A                         
br1coresw2  Ethernet1/21(1500)      N/A                         vzn-cr12-h12-sw1
br1coresw2  Ethernet1/22(1500)      N/A                         
br1coresw2  Ethernet1/23(1500)      N/A                         
br1coresw2  Ethernet1/24(1500)      N/A                         
br1coresw2  Ethernet1/25(1500)      N/A                         vzn-cr09-f05-sw1
br1coresw2  Ethernet1/27(1500)      N/A                         
br1coresw2  Ethernet1/28(1500)      64:12:25:9d:e6:18(100)      
br1coresw2  Ethernet1/29(1500)      N/A                         
br1coresw2  Ethernet1/30(1500)      N/A                         
br1coresw2  Ethernet1/31(1500)      N/A                         
br1coresw2  Ethernet1/33(1500)      N/A                         
br1coresw2  Ethernet1/34(1500)      N/A                         
br1coresw2  Ethernet1/35(1500)      N/A                         
br1coresw2  Ethernet1/36(1500)      N/A                         
br1coresw2  Ethernet1/39(1500)      N/A                         
br1coresw2  Ethernet1/40(1500)      N/A                         
br1coresw2  Ethernet1/41(1500)      N/A                         
br1coresw2  Ethernet1/42(1500)      N/A                         
br1coresw2  Ethernet1/43(1500)      N/A                         
br1coresw2  Ethernet1/44(1500)      N/A                         
br1coresw2  Ethernet1/45(1500)      N/A                         
br1coresw2  Ethernet1/47(1500)      N/A                         
br1coresw2  Ethernet1/48(1500)      00:41:d2:45:aa:a3           
br1coresw2  Ethernet2/5(1500)       N/A                         
br1coresw2  Ethernet2/6(1500)       N/A                         
br1coresw2  Ethernet2/1/2(1500)     N/A                         
br1coresw2  Ethernet2/1/4(1500)     N/A                         
br1coresw2  Ethernet2/2/1(1500)     N/A                         
br1coresw2  Ethernet2/2/3(1500)     N/A                         
br1coresw2  Ethernet2/2/4(1500)     N/A                         
br1coresw2  Ethernet2/3/1(1500)     N/A                         
br1coresw2  Ethernet2/3/2(1500)     N/A                         
br1coresw2  Ethernet2/3/3(1500)     N/A                         
br1coresw2  Ethernet2/3/4(1500)     N/A                         
br1coresw2  port-channel1(1500)     N/A                         
br1coresw2  port-channel3(1500)     8c:60:4f:d4:65:41(140)      
```
