### PR TITLE
update case to be compatible with xcat inventory ci test

### DIFF
--- a/xCAT-test/autotest/testcase/xcat_inventory/cases.osimage
+++ b/xCAT-test/autotest/testcase/xcat_inventory/cases.osimage
@@ -1133,9 +1133,11 @@ cmd:lsdef -t osimage -z | tee /tmp/osimage.list
 check:rc==0
 #backup all osimage
 cmd:if [ -e /tmp/osimages ]; then cp -f /tmp/osimages /tmp/osimages.bak ; else mkdir -p /tmp/osimages; fi
-cmd:imgdir='/tmp/osimages';for img in $(lsdef -t osimage -s|awk -F' ' '{print $1}'); do lsdef -t osimage -o $img -z > $imgdir/${img}.stanza;done
+#cmd:imgdir='/tmp/osimages';for img in $(lsdef -t osimage -s|awk -F' ' '{print $1}'); do lsdef -t osimage -o $img -z > $imgdir/${img}.stanza;done
+cmd:imgdir='/tmp/osimages';for img in `lsdef -t osimage -s|awk -F' ' '{print $1}'`; do lsdef -t osimage -o $img -z > $imgdir/${img}.stanza;done
 check:rc==0
-cmd:for img in $(lsdef -t osimage -s|awk -F' ' '{print $1}');do rmdef -t osimage -o $img;done
+#cmd:for img in $(lsdef -t osimage -s|awk -F' ' '{print $1}');do rmdef -t osimage -o $img;done
+cmd:for img in `lsdef -t osimage -s|awk -F' ' '{print $1}'`;do rmdef -t osimage -o $img;done
 check:rc==0
 cmd:if [ -e /tmp/otherpkglist ]; then cp -f /tmp/otherpkglist /tmp/otherpkglist.bak; fi
 cmd:echo "test" >> /tmp/otherpkglist
@@ -1267,9 +1269,11 @@ start:export_import_osimages_by_dir_with_c
 label:others,inventory_ci
 description:This case is used to test xcat-inventory export and import  linux osimage definition witch -c option.
 cmd:dir="/tmp/export";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi; mkdir -p $dir
-cmd:imgdir='/tmp/export';for img in $(lsdef -t osimage -s|awk -F' ' '{print $1}'); do lsdef -t osimage -o $img -z > $imgdir/${img}.stanza;done
+#cmd:imgdir='/tmp/export';for img in $(lsdef -t osimage -s|awk -F' ' '{print $1}'); do lsdef -t osimage -o $img -z > $imgdir/${img}.stanza;done
+cmd:imgdir='/tmp/export';for img in `lsdef -t osimage -s|awk -F' ' '{print $1}'`; do lsdef -t osimage -o $img -z > $imgdir/${img}.stanza;done
 check:rc==0
-cmd:for img in $(lsdef -t osimage -s|awk -F' ' '{print $1}');do rmdef -t osimage -o $img;done
+#cmd:for img in $(lsdef -t osimage -s|awk -F' ' '{print $1}');do rmdef -t osimage -o $img;done
+cmd:for img in `lsdef -t osimage -s|awk -F' ' '{print $1}'`;do rmdef -t osimage -o $img;done
 check:rc==0
 cmd:chdef -t osimage -o test_myimage1,test_myimage2,test_myimage3 imagetype=linux provmethod=install
 check:rc==0


### PR DESCRIPTION
This is only update for ci_test failed cases.

export_import_osimages_by_dir_with_c
export_import_all_osimages_by_dir

The error is as follows.
```
 'RUN:imgdir=\'/tmp/osimages\';for img in $(lsdef -t osimage -s|awk -F\' \' \'{print $1}\'); do lsdef -t osimage -o $img -z > $imgdir/${img}.stanza;done [Thu Dec 27 08:38:18 2018]',
          'ElapsedTime:1 sec',
          'RETURN rc = 1',
          'OUTPUT:',
          'Error: [travis-job-b768b190-54ec-4952-916c-51444f7e7c91]: Could not find an object named \'Could\' of type \'osimage\'.',
          'CHECK:rc == 0	[Failed]',
```