### PR TITLE
filter out non-osimage messages from lsdef output in case "export_import_osimages_by_dir_with_c"

### DIFF
--- a/xCAT-test/autotest/testcase/xcat_inventory/cases.osimage
+++ b/xCAT-test/autotest/testcase/xcat_inventory/cases.osimage
@@ -1269,11 +1269,9 @@ start:export_import_osimages_by_dir_with_c
 label:others,inventory_ci
 description:This case is used to test xcat-inventory export and import  linux osimage definition witch -c option.
 cmd:dir="/tmp/export";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi; mkdir -p $dir
-#cmd:imgdir='/tmp/export';for img in $(lsdef -t osimage -s|awk -F' ' '{print $1}'); do lsdef -t osimage -o $img -z > $imgdir/${img}.stanza;done
-cmd:imgdir='/tmp/export';for img in `lsdef -t osimage -s|awk -F' ' '{print $1}'`; do lsdef -t osimage -o $img -z > $imgdir/${img}.stanza;done
+cmd:imgdir='/tmp/export';for img in $(lsdef -t osimage -s|grep '(osimage)'|awk -F' ' '{print $1}'); do lsdef -t osimage -o $img -z > $imgdir/${img}.stanza;done
 check:rc==0
-#cmd:for img in $(lsdef -t osimage -s|awk -F' ' '{print $1}');do rmdef -t osimage -o $img;done
-cmd:for img in `lsdef -t osimage -s|awk -F' ' '{print $1}'`;do rmdef -t osimage -o $img;done
+cmd:for img in $(lsdef -t osimage -s|grep '(osimage)'|awk -F' ' '{print $1}');do rmdef -t osimage -o $img;done
 check:rc==0
 cmd:chdef -t osimage -o test_myimage1,test_myimage2,test_myimage3 imagetype=linux provmethod=install
 check:rc==0


### PR DESCRIPTION
### The PR is to fix issue in test case
```
          '------START::export_import_osimages_by_dir_with_c::Time:Fri Dec 28 02:56:31 2018------',
          '',
          'RUN:dir="/tmp/export";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi; mkdir -p $dir [Fri Dec 28 02:56:31 2018]',
          'ElapsedTime:0 sec',
          'RETURN rc = 0',
          'OUTPUT:',
          ' ',
          'RUN:imgdir=\'/tmp/export\';for img in `lsdef -t osimage -s|awk -F\' \' \'{print $1}\'`; do lsdef -t osimage -o $img -z > $imgdir/${img}.stanza;done [Fri Dec 28 02:56:31 2018]',
          'ElapsedTime:1 sec',
          'RETURN rc = 1',
          'OUTPUT:',
          'Error: [travis-job-3ae7309c-7bfe-4691-ad51-8f7f565c0ba6]: Could not find an object named \'Could\' of type \'osimage\'.',
          'CHECK:rc == 0	[Failed]',
```