### PR TITLE
filter out non-osimage messages in case export_import_all_osimages_by_dir

### DIFF
--- a/xCAT-test/autotest/testcase/xcat_inventory/cases.osimage
+++ b/xCAT-test/autotest/testcase/xcat_inventory/cases.osimage
@@ -1133,11 +1133,9 @@ cmd:lsdef -t osimage -z | tee /tmp/osimage.list
 check:rc==0
 #backup all osimage
 cmd:if [ -e /tmp/osimages ]; then cp -f /tmp/osimages /tmp/osimages.bak ; else mkdir -p /tmp/osimages; fi
-#cmd:imgdir='/tmp/osimages';for img in $(lsdef -t osimage -s|awk -F' ' '{print $1}'); do lsdef -t osimage -o $img -z > $imgdir/${img}.stanza;done
-cmd:imgdir='/tmp/osimages';for img in `lsdef -t osimage -s|awk -F' ' '{print $1}'`; do lsdef -t osimage -o $img -z > $imgdir/${img}.stanza;done
+cmd:imgdir='/tmp/osimages';for img in $(lsdef -t osimage -s|grep '(osimage)'|awk -F' ' '{print $1}'); do lsdef -t osimage -o $img -z > $imgdir/${img}.stanza;done
 check:rc==0
-#cmd:for img in $(lsdef -t osimage -s|awk -F' ' '{print $1}');do rmdef -t osimage -o $img;done
-cmd:for img in `lsdef -t osimage -s|awk -F' ' '{print $1}'`;do rmdef -t osimage -o $img;done
+cmd:for img in $(lsdef -t osimage -s|grep '(osimage)'|awk -F' ' '{print $1}');do rmdef -t osimage -o $img;done
 check:rc==0
 cmd:if [ -e /tmp/otherpkglist ]; then cp -f /tmp/otherpkglist /tmp/otherpkglist.bak; fi
 cmd:echo "test" >> /tmp/otherpkglist


### PR DESCRIPTION
### The PR is to fix issue in export_import_all_osimages_by_dir in CI:

```
          '------START::export_import_all_osimages_by_dir::Time:Fri Dec 28 03:48:44 2018------',
          '',
          'RUN:lsdef -t osimage -z | tee /tmp/osimage.list [Fri Dec 28 03:48:44 2018]',
          'ElapsedTime:0 sec',
          'RETURN rc = 0',
          'OUTPUT:',
          'Could not find any object definitions to display.',
          'CHECK:rc == 0	[Pass]',
          ' ',
          'RUN:if [ -e /tmp/osimages ]; then cp -f /tmp/osimages /tmp/osimages.bak ; else mkdir -p /tmp/osimages; fi [Fri Dec 28 03:48:44 2018]',
          'ElapsedTime:0 sec',
          'RETURN rc = 0',
          'OUTPUT:',
          ' ',
          'RUN:imgdir=\'/tmp/osimages\';for img in `lsdef -t osimage -s|awk -F\' \' \'{print $1}\'`; do lsdef -t osimage -o $img -z > $imgdir/${img}.stanza;done [Fri Dec 28 03:48:44 2018]',
          'ElapsedTime:1 sec',
          'RETURN rc = 1',
          'OUTPUT:',
          'Error: [travis-job-a65aba0c-b8ed-44ae-b445-8caf2d3859ab]: Could not find an object named \'Could\' of type \'osimage\'.',
          'CHECK:rc == 0	[Failed]',

```
