### PR TITLE
add debug info

### DIFF
--- a/xCAT-test/autotest/testcase/xcat_inventory/cases.osimage
+++ b/xCAT-test/autotest/testcase/xcat_inventory/cases.osimage
@@ -1071,6 +1071,7 @@ check:rc==0
 cmd: rmdef -t osimage -o  test_myimage1,test_myimage2
 check:rc==0
 cmd:rm -rf /tmp/otherpkglist /tmp/synclists /tmp/postinstall /tmp/exlist /tmp/partitionfile /tmp/pkglist /tmp/template
+cmd: tree /opt/inventory/site
 cmd:xcat-inventory import -t osimage -o test_myimage1,test_myimage2 -d /opt/inventory/site
 check:rc==0
 check:output=~The object test_myimage1 has been imported


### PR DESCRIPTION
### The PR is to add debug info in case export_import_multiple_osimages_by_dir

UT:
```
          'RUN:rm -rf /tmp/otherpkglist /tmp/synclists /tmp/postinstall /tmp/exlist /tmp/partitionfile /tmp/pkglist /tmp/template [Fri Dec 28 05:08:06 2018]',
          'ElapsedTime:0 sec',
          'RETURN rc = 0',
          'OUTPUT:',
          ' ',
          'RUN:xcat-inventory import -t osimage -o test_myimage1,test_myimage2 -d /opt/inventory/site [Fri Dec 28 05:08:06 2018]',
          'ElapsedTime:1 sec',
          'RETURN rc = 0',
          'OUTPUT:',
          'the specified object "test_myimage1" does not exist under "/opt/inventory/site"!',
          'the specified object "test_myimage2" does not exist under "/opt/inventory/site"!',
          'CHECK:rc == 0	[Pass]',
          'CHECK:output =~ The object test_myimage1 has been imported	[Failed]',
```