### PR TITLE
update case lsvmkvmhost to check the correct output

### DIFF
--- a/xCAT-test/autotest/testcase/lsvm/cases0
+++ b/xCAT-test/autotest/testcase/lsvm/cases0
@@ -96,7 +96,7 @@ start:lsvm_kvmhost
 description:lsvm could give out the kvm host information. This case should be run on a mn which has kvm host defined.In this case, $$CN should be a kvm host. 
 label:others,hctrl_kvm
 cmd:lsvm $$CN 
-check:output=~$$CN
+check:output=~$$CN:\s*$$CN\w.
 end
 
 start:lsvm_mixed_vm_defined_and_not

--- a/xCAT-test/autotest/testcase/lsvm/cases0
+++ b/xCAT-test/autotest/testcase/lsvm/cases0
@@ -96,7 +96,7 @@ start:lsvm_kvmhost
 description:lsvm could give out the kvm host information. This case should be run on a mn which has kvm host defined.In this case, $$CN should be a kvm host. 
 label:others,hctrl_kvm
 cmd:lsvm $$CN 
-check:output=~$$CN:\s*$$CN\w.
+check:output=~$$CN:\s*\b\w+\b(\r\n|\n|\r)
 end
 
 start:lsvm_mixed_vm_defined_and_not


### PR DESCRIPTION
### The PR is to fix case lsvm_kvmhost
for following discussion

```
c910f03c09k11: Could not get any information about specified object
CHECK:output =~ c910f03c09k11: \s*\w.	[Pass]
Based on the habit of our vm naming, i think we probably could rewrite the case as follows

check:output=~$$CN:\s*$$CN\w.
```