### PR TITLE
Add a new case updatenode_syncfile_EXECUTEALWAYS_noderange to cover test for bug 5755

### DIFF
--- a/xCAT-test/autotest/testcase/updatenode/cases0
+++ b/xCAT-test/autotest/testcase/updatenode/cases0
@@ -525,31 +525,74 @@ cmd:chtab key=xcatdebugmode site.value=0
 check:rc==0
 end
 
-start:updatenode_syncfile_EXECUTEALWAYS_noderange_hierarchy
+start:updatenode_syncfile_EXECUTE_EXECUTEALWAYS_noderange
 label:others,updatenode
-description:this teast case is to verify bug #5755,synclist: EXECUTEALWAYS ignore noderange. This test case should be executed on mn with hierarchy environment, with at least 2 installed diskful cn.In this case, $$CN and $$C2 are the 2 compute nodes. 
-cmd:xdsh $$CN,$$C2 rm /tmp/file.post
-cmd:xdsh $$CN,$$C2 rm /tmp/test
-cmd:echo "echo hello >> /tmp/test" > /tmp/file.post
+description:this teast case is to verify pr #5834. This test case should be executed on mn with hierarchy environment, with 2 comput nodes.In this case, $$CN and $$C2 are the 2 compute nodes. 
+cmd:xdsh $$CN,$$C2 rm /tmp/file.post1 /tmp/file.post2
+cmd:xdsh $$CN,$$C2 rm /tmp/test1 /tmp/test2
+cmd:echo "echo hello1 >> /tmp/test1" > /tmp/file.post1
 check:rc==0
-cmd:chmod a+x /tmp/file.post
-cmd:echo "/tmp/file.post -> ($$CN) /tmp/file.post" > /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
+cmd:echo "echo hello2 >> /tmp/test2" > /tmp/file.post2
+check:rc==0
+cmd:chmod a+x /tmp/file.post1 /tmp/file.post2
+cmd:mkdir -p /install/custom/install/__GETNODEATTR($$CN,os)__
+cmd:echo "/tmp/file.post1 -> ($$CN) /tmp/file.post1" > /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
+cmd:echo "/tmp/file.post2 -> ($$C2) /tmp/file.post2" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
+cmd:echo "EXECUTE:" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
+cmd:echo "/tmp/file.post1" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
 cmd:echo "EXECUTEALWAYS:" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
-cmd:echo "/tmp/file.post" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
+cmd:echo "/tmp/file.post2" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
 cmd:chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute synclists=/install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
 check:rc==0
 cmd:updatenode $$CN -F
+check:output=~File synchronization has completed 
 check:rc==0
-cmd:xdsh $$CN "cat /tmp/test"
+cmd:xdsh $$CN "cat /tmp/test1"
 check:rc==0
-check:output=~hello
+check:output=~hello1
+cmd:xdsh $$CN "rm -rf /tmp/test1"
+check:rc==0
+cmd:updatenode $$CN -F
+check:output=~File synchronization has completed
+check:rc==0
+cmd:xdsh $$CN "cat /tmp/test1"
+check:rc!=0
 cmd:updatenode $$C2 -F
+check:output=~File synchronization has completed
 check:rc==0
-cmd:xdsh $$C2 ls /tmp/file.post
+cmd:xdsh $$C2 ls /tmp/file.post2
+check:rc==0
+cmd:xdsh $$C2 "cat /tmp/test2"
+check:rc==0
+check:output=~hello2
+cmd:xdsh $$C2 "rm -rf /tmp/test2"
+check:rc==0
+cmd:updatenode $$C2 -F
+check:output=~File synchronization has completed
+check:rc==0
+cmd:xdsh $$C2 ls /tmp/file.post2
+check:rc==0
+cmd:xdsh $$C2 "cat /tmp/test2"
+check:rc==0
+check:output=~hello2
+cmd:xdsh $$C2 rm -rf /tmp/file.post2 /tmp/test2
+cmd:rm -rf /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
+cmd:echo "/tmp/file.post1 -> ($$CN) /tmp/file.post1" > /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
+cmd:echo "/tmp/file.post1 -> ($$C2) /tmp/file.post1" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
+cmd:echo "EXECUTE:" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
+cmd:echo "/tmp/file.post1" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
+cmd:echo "EXECUTEALWAYS:" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
+cmd:echo "/tmp/file.post2" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
+cmd:chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute synclists=/install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
+check:rc==0
+cmd:updatenode $$C2 -F
+check:output=~File synchronization has completed
+check:rc==0
+cmd:xdsh $$C2 ls /tmp/file.post2
 check:rc!=0
-cmd:xdsh $$C2 "cat /tmp/test"
+cmd:xdsh $$C2 "cat /tmp/test2"
 check:rc!=0
-check:output!=~hello
+check:output!=~hello2
 cmd:chdef -t osimage -o  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute synclists=
 check:rc==0
 cmd:rm -rf /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist

--- a/xCAT-test/autotest/testcase/updatenode/cases0
+++ b/xCAT-test/autotest/testcase/updatenode/cases0
@@ -525,3 +525,33 @@ cmd:chtab key=xcatdebugmode site.value=0
 check:rc==0
 end
 
+start:updatenode_syncfile_EXECUTEALWAYS_noderange_hierarchy
+label:others,updatenode
+description:this teast case is to verify bug #5755,synclist: EXECUTEALWAYS ignore noderange. This test case should be executed on mn with hierarchy environment, with at least 2 installed diskful cn.In this case, $$CN and $$C2 are the 2 compute nodes. 
+cmd:xdsh $$CN,$$C2 rm /tmp/file.post
+cmd:xdsh $$CN,$$C2 rm /tmp/test
+cmd:echo "echo hello >> /tmp/test" > /tmp/file.post
+check:rc==0
+cmd:chmod a+x /tmp/file.post
+cmd:echo "/tmp/file.post -> ($$CN) /tmp/file.post" > /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
+cmd:echo "EXECUTEALWAYS:" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
+cmd:echo "/tmp/file.post" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
+cmd:chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute synclists=/install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
+check:rc==0
+cmd:updatenode $$CN -F
+check:rc==0
+cmd:xdsh $$CN "cat /tmp/test"
+check:rc==0
+check:output=~hello
+cmd:updatenode $$C2 -F
+check:rc==0
+cmd:xdsh $$C2 ls /tmp/file.post
+check:rc!=0
+cmd:xdsh $$C2 "cat /tmp/test"
+check:rc!=0
+check:output!=~hello
+cmd:chdef -t osimage -o  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute synclists=
+check:rc==0
+cmd:rm -rf /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
+check:rc==0
+end

--- a/xCAT-test/autotest/testcase/updatenode/cases0
+++ b/xCAT-test/autotest/testcase/updatenode/cases0
@@ -598,3 +598,56 @@ check:rc==0
 cmd:rm -rf /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
 check:rc==0
 end
+
+
+start:updatenode_syncfile_EXECUTEALWAYS_src_dst_diff
+label:others,updatenode
+description:this teast case is to verify pr #5888. 
+cmd:lsdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute -z >> /tmp/myimage.stanza
+cmd:xdsh $$CN rm /tmp/h /tmp/script.sh  /root/script2.sh /tmp/script2.sh /tmp/script3.sh 
+cmd:xdsh $$CN rm /tmp/test /tmp/test2 /root/test3 /root/test1
+cmd:echo "echo hello >> /tmp/test" > /tmp/script.sh
+check:rc==0
+cmd:echo "echo hello2  >> /tmp/test2" > /tmp/script2.sh
+check:rc==0
+cmd:echo "echo hello3 >> /tmp/test3" > /root/script3.sh
+check:rc==0
+cmd:echo "echo hello1 >> /tmp/test1" > /root/script1.sh
+check:rc==0
+cmd:chmod a+x /tmp/script.sh /tmp/script2.sh /root/script3.sh /root/script1.sh 
+cmd:mkdir -p /install/custom/install/__GETNODEATTR($$CN,os)__
+cmd:echo "/etc/hosts -> ($$CN) /tmp/h" > /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.srcdstdiff.synclist
+cmd:echo "/tmp/script.sh -> ($$CN) /tmp/script.sh" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.srcdstdiff.synclist
+cmd:echo "/root/script1.sh -> ($$CN) /root/script2.sh" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.srcdstdiff.synclist
+cmd:echo "/tmp/script2.sh -> ($$CN) /tmp/script2.sh" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.srcdstdiff.synclist
+cmd:echo "/root/script3.sh -> ($$CN) /tmp/script3.sh" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.srcdstdiff.synclist
+cmd:echo "EXECUTEALWAYS:" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.srcdstdiff.synclist
+cmd:echo "/tmp/script.sh" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.srcdstdiff.synclist
+cmd:echo "/tmp/script2.sh" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.srcdstdiff.synclist
+cmd:echo "/root/script3.sh" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.srcdstdiff.synclist
+cmd:echo "/root/script1.sh" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.srcdstdiff.synclist
+cmd:chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute synclists=/install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.srcdstdiff.synclist
+check:rc==0
+cmd:updatenode $$CN -F
+check:output=~File synchronization has completed for nodes:\s*"$$CN"\s*
+check:rc==0
+cmd:xdsh $$CN ls /tmp/h
+check:rc==0
+cmd:xdsh $$CN ls /tmp/test
+check:rc==0
+cmd:xdsh $$CN ls /tmp/test2
+check:rc==0
+cmd:xdsh $$CN ls /tmp/test3
+check:rc==0
+cmd:xdsh $$CN ls /tmp/test1
+check:rc==0
+cmd:if [ -e /tmp/myimage.stanza ]; then rmdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute; cat /tmp/myimage.stanza | mkdef -z; rm -rf /tmp/myimage.stanza; fi
+check:rc==0
+cmd:rm -rf /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.srcdstdiff.synclist
+check:rc==0
+end
+
+
+
+
+


### PR DESCRIPTION
### The PR is to do task https://github.com/xcat2/xcat2-task-management/issues/424

For the verification of bug https://github.com/xcat2/xcat-core/issues/5755
synclist: EXECUTE{ALWAYS} ignore noderange 

This test case  covers following 2 scenarios
1. if the synclist file is  as follows, run updatenode will execute /tmp/post1 on node1, execute /tmp/post2 on node2.   run updatenode again will not execute /tmp/post1 on node1 but will execute /tmp/post2 on node2 
```
#cat compute.synclist
/tmp/post1 -> (node1) /tmp/post1
/tmp/post2 -> (node2) /tmp/post2
EXECUTE:
/tmp/post1
EXECUTEALWAYS:
/tmp/post2
```

2. if the synclist file is as follows, run updatenode will not run /tmp/post2 on any nodes.
```
#cat compute.synclist
/tmp/post1 -> (node1) /tmp/post1
/tmp/post1 -> (node2) /tmp/post1
EXECUTE:
/tmp/post1
EXECUTEALWAYS:
/tmp/post2
```

The UT
```
------START::updatenode_syncfile_EXECUTE_EXECUTEALWAYS_noderange::Time:Thu Jan 10 01:05:12 2019------

RUN:xdsh c910f02c02p18,c910f02c02p19 rm /tmp/file.post1 /tmp/file.post2 [Thu Jan 10 01:05:12 2019]
ElapsedTime:1 sec
RETURN rc = 2
OUTPUT:
[c910f02c02p17]: c910f02c02p18: rm: cannot remove '/tmp/file.post1': No such file or directory
[c910f02c02p17]: c910f02c02p19: rm: cannot remove '/tmp/file.post1': No such file or directory
c910f02c02p19: rm: cannot remove '/tmp/file.post2': No such file or directory

RUN:xdsh c910f02c02p18,c910f02c02p19 rm /tmp/test1 /tmp/test2 [Thu Jan 10 01:05:13 2019]
ElapsedTime:1 sec
RETURN rc = 2
OUTPUT:
[c910f02c02p17]: c910f02c02p18: rm: cannot remove '/tmp/test1': No such file or directory
[c910f02c02p17]: c910f02c02p19: rm: cannot remove '/tmp/test1': No such file or directory
c910f02c02p19: rm: cannot remove '/tmp/test2': No such file or directory

RUN:echo "echo hello1 >> /tmp/test1" > /tmp/file.post1 [Thu Jan 10 01:05:14 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:echo "echo hello2 >> /tmp/test2" > /tmp/file.post2 [Thu Jan 10 01:05:14 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:chmod a+x /tmp/file.post1 /tmp/file.post2 [Thu Jan 10 01:05:14 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:mkdir -p /install/custom/install/__GETNODEATTR(c910f02c02p18,os)__ [Thu Jan 10 01:05:14 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "/tmp/file.post1 -> (c910f02c02p18) /tmp/file.post1" > /install/custom/install/__GETNODEATTR(c910f02c02p18,os)__/compute.linux.synclist [Thu Jan 10 01:05:14 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:echo "/tmp/file.post2 -> (c910f02c02p19) /tmp/file.post2" >> /install/custom/install/__GETNODEATTR(c910f02c02p18,os)__/compute.linux.synclist [Thu Jan 10 01:05:15 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:echo "EXECUTE:" >> /install/custom/install/__GETNODEATTR(c910f02c02p18,os)__/compute.linux.synclist [Thu Jan 10 01:05:16 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "/tmp/file.post1" >> /install/custom/install/__GETNODEATTR(c910f02c02p18,os)__/compute.linux.synclist [Thu Jan 10 01:05:16 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:echo "EXECUTEALWAYS:" >> /install/custom/install/__GETNODEATTR(c910f02c02p18,os)__/compute.linux.synclist [Thu Jan 10 01:05:17 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:echo "/tmp/file.post2" >> /install/custom/install/__GETNODEATTR(c910f02c02p18,os)__/compute.linux.synclist [Thu Jan 10 01:05:18 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:chdef -t osimage -o __GETNODEATTR(c910f02c02p18,os)__-__GETNODEATTR(c910f02c02p18,arch)__-install-compute synclists=/install/custom/install/__GETNODEATTR(c910f02c02p18,os)__/compute.linux.synclist [Thu Jan 10 01:05:18 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:updatenode c910f02c02p18 -F [Thu Jan 10 01:05:20 2019]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
File synchronization has completed for nodes: "c910f02c02p17,c910f02c02p18"
CHECK:output =~ File synchronization has completed	[Pass]
CHECK:rc == 0	[Pass]

RUN:xdsh c910f02c02p18 "cat /tmp/test1" [Thu Jan 10 01:05:23 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f02c02p18: hello1
CHECK:rc == 0	[Pass]
CHECK:output =~ hello1	[Pass]

RUN:xdsh c910f02c02p18 "rm -rf /tmp/test1" [Thu Jan 10 01:05:24 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:updatenode c910f02c02p18 -F [Thu Jan 10 01:05:25 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
File synchronization has completed for nodes: "c910f02c02p17,c910f02c02p18"
CHECK:output =~ File synchronization has completed	[Pass]
CHECK:rc == 0	[Pass]

RUN:xdsh c910f02c02p18 "cat /tmp/test1" [Thu Jan 10 01:05:27 2019]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
[c910f02c02p17]: c910f02c02p18: cat: /tmp/test1: No such file or directory
CHECK:rc != 0	[Pass]

RUN:updatenode c910f02c02p19 -F [Thu Jan 10 01:05:28 2019]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
File synchronization has completed for nodes: "c910f02c02p17,c910f02c02p19"
CHECK:output =~ File synchronization has completed	[Pass]
CHECK:rc == 0	[Pass]

RUN:xdsh c910f02c02p19 ls /tmp/file.post2 [Thu Jan 10 01:05:31 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f02c02p19: /tmp/file.post2
CHECK:rc == 0	[Pass]

RUN:xdsh c910f02c02p19 "cat /tmp/test2" [Thu Jan 10 01:05:32 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f02c02p19: hello2
CHECK:rc == 0	[Pass]
CHECK:output =~ hello2	[Pass]

RUN:xdsh c910f02c02p19 "rm -rf /tmp/test2" [Thu Jan 10 01:05:33 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:updatenode c910f02c02p19 -F [Thu Jan 10 01:05:34 2019]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
File synchronization has completed for nodes: "c910f02c02p17,c910f02c02p19"
CHECK:output =~ File synchronization has completed	[Pass]
CHECK:rc == 0	[Pass]

RUN:xdsh c910f02c02p19 ls /tmp/file.post2 [Thu Jan 10 01:05:37 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f02c02p19: /tmp/file.post2
CHECK:rc == 0	[Pass]

RUN:xdsh c910f02c02p19 "cat /tmp/test2" [Thu Jan 10 01:05:38 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f02c02p19: hello2
CHECK:rc == 0	[Pass]
CHECK:output =~ hello2	[Pass]

RUN:xdsh c910f02c02p19 rm -rf /tmp/file.post2 /tmp/test2 [Thu Jan 10 01:05:39 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:rm -rf /install/custom/install/__GETNODEATTR(c910f02c02p18,os)__/compute.linux.synclist [Thu Jan 10 01:05:40 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "/tmp/file.post1 -> (c910f02c02p18) /tmp/file.post1" > /install/custom/install/__GETNODEATTR(c910f02c02p18,os)__/compute.linux.synclist [Thu Jan 10 01:05:40 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:echo "/tmp/file.post1 -> (c910f02c02p19) /tmp/file.post1" >> /install/custom/install/__GETNODEATTR(c910f02c02p18,os)__/compute.linux.synclist [Thu Jan 10 01:05:41 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:echo "EXECUTE:" >> /install/custom/install/__GETNODEATTR(c910f02c02p18,os)__/compute.linux.synclist [Thu Jan 10 01:05:42 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "/tmp/file.post1" >> /install/custom/install/__GETNODEATTR(c910f02c02p18,os)__/compute.linux.synclist [Thu Jan 10 01:05:42 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:echo "EXECUTEALWAYS:" >> /install/custom/install/__GETNODEATTR(c910f02c02p18,os)__/compute.linux.synclist [Thu Jan 10 01:05:43 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:echo "/tmp/file.post2" >> /install/custom/install/__GETNODEATTR(c910f02c02p18,os)__/compute.linux.synclist [Thu Jan 10 01:05:44 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:chdef -t osimage -o __GETNODEATTR(c910f02c02p18,os)__-__GETNODEATTR(c910f02c02p18,arch)__-install-compute synclists=/install/custom/install/__GETNODEATTR(c910f02c02p18,os)__/compute.linux.synclist [Thu Jan 10 01:05:44 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:updatenode c910f02c02p19 -F [Thu Jan 10 01:05:46 2019]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
File synchronization has completed for nodes: "c910f02c02p17,c910f02c02p19"
CHECK:output =~ File synchronization has completed	[Pass]
CHECK:rc == 0	[Pass]

RUN:xdsh c910f02c02p19 ls /tmp/file.post2 [Thu Jan 10 01:05:49 2019]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
[c910f02c02p17]: c910f02c02p19: ls: cannot access /tmp/file.post2: No such file or directory
CHECK:rc != 0	[Pass]

RUN:xdsh c910f02c02p19 "cat /tmp/test2" [Thu Jan 10 01:05:50 2019]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
[c910f02c02p17]: c910f02c02p19: cat: /tmp/test2: No such file or directory
CHECK:rc != 0	[Pass]
CHECK:output !=~ hello2	[Pass]

RUN:chdef -t osimage -o  __GETNODEATTR(c910f02c02p18,os)__-__GETNODEATTR(c910f02c02p18,arch)__-install-compute synclists= [Thu Jan 10 01:05:51 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:rm -rf /install/custom/install/__GETNODEATTR(c910f02c02p18,os)__/compute.linux.synclist [Thu Jan 10 01:05:53 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::updatenode_syncfile_EXECUTE_EXECUTEALWAYS_noderange::Passed::Time:Thu Jan 10 01:05:53 2019 ::Duration::41 sec------
------Total: 1 , Failed: 0------
```

### The PR also covers  task https://github.com/xcat2/xcat2-task-management/issues/564
 add test case for issue 5888: EXECUTEALWAYS error when another line in the synclist references the same destination node

The UT result
```
------START::updatenode_syncfile_EXECUTEALWAYS_src_dst_diff::Time:Fri Jan 25 02:22:05 2019------

RUN:lsdef -t osimage -o __GETNODEATTR(c910f02c02p19,os)__-__GETNODEATTR(c910f02c02p19,arch)__-install-compute -z >> /tmp/myimage.stanza [Fri Jan 25 02:22:05 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:xdsh c910f02c02p19 rm /tmp/h /tmp/script.sh  /root/script2.sh /tmp/script2.sh /tmp/script3.sh [Fri Jan 25 02:22:06 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:xdsh c910f02c02p19 rm /tmp/test /tmp/test2 /root/test3 /root/test1 [Fri Jan 25 02:22:07 2019]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
[c910f02c02p16]: c910f02c02p19: rm: cannot remove '/root/test3': No such file or directory
c910f02c02p19: rm: cannot remove '/root/test1': No such file or directory

RUN:echo "echo hello >> /tmp/test" > /tmp/script.sh [Fri Jan 25 02:22:08 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:echo "echo hello2  >> /tmp/test2" > /tmp/script2.sh [Fri Jan 25 02:22:08 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:echo "echo hello3 >> /tmp/test3" > /root/script3.sh [Fri Jan 25 02:22:08 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:echo "echo hello1 >> /tmp/test1" > /root/script1.sh [Fri Jan 25 02:22:08 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:chmod a+x /tmp/script.sh /tmp/script2.sh /root/script3.sh /root/script1.sh [Fri Jan 25 02:22:08 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:mkdir -p /install/custom/install/__GETNODEATTR(c910f02c02p19,os)__ [Fri Jan 25 02:22:08 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:echo "/etc/hosts -> (c910f02c02p19) /tmp/h" > /install/custom/install/__GETNODEATTR(c910f02c02p19,os)__/compute.linux.srcdstdiff.synclist [Fri Jan 25 02:22:09 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "/tmp/script.sh -> (c910f02c02p19) /tmp/script.sh" >> /install/custom/install/__GETNODEATTR(c910f02c02p19,os)__/compute.linux.srcdstdiff.synclist [Fri Jan 25 02:22:09 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:echo "/root/script1.sh -> (c910f02c02p19) /root/script2.sh" >> /install/custom/install/__GETNODEATTR(c910f02c02p19,os)__/compute.linux.srcdstdiff.synclist [Fri Jan 25 02:22:10 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:echo "/tmp/script2.sh -> (c910f02c02p19) /tmp/script2.sh" >> /install/custom/install/__GETNODEATTR(c910f02c02p19,os)__/compute.linux.srcdstdiff.synclist [Fri Jan 25 02:22:11 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "/root/script3.sh -> (c910f02c02p19) /tmp/script3.sh" >> /install/custom/install/__GETNODEATTR(c910f02c02p19,os)__/compute.linux.srcdstdiff.synclist [Fri Jan 25 02:22:11 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:echo "EXECUTEALWAYS:" >> /install/custom/install/__GETNODEATTR(c910f02c02p19,os)__/compute.linux.srcdstdiff.synclist [Fri Jan 25 02:22:12 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "/tmp/script.sh" >> /install/custom/install/__GETNODEATTR(c910f02c02p19,os)__/compute.linux.srcdstdiff.synclist [Fri Jan 25 02:22:12 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:echo "/tmp/script2.sh" >> /install/custom/install/__GETNODEATTR(c910f02c02p19,os)__/compute.linux.srcdstdiff.synclist [Fri Jan 25 02:22:13 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:echo "/root/script3.sh" >> /install/custom/install/__GETNODEATTR(c910f02c02p19,os)__/compute.linux.srcdstdiff.synclist [Fri Jan 25 02:22:14 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "/root/script1.sh" >> /install/custom/install/__GETNODEATTR(c910f02c02p19,os)__/compute.linux.srcdstdiff.synclist [Fri Jan 25 02:22:14 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:chdef -t osimage -o __GETNODEATTR(c910f02c02p19,os)__-__GETNODEATTR(c910f02c02p19,arch)__-install-compute synclists=/install/custom/install/__GETNODEATTR(c910f02c02p19,os)__/compute.linux.srcdstdiff.synclist [Fri Jan 25 02:22:15 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:updatenode c910f02c02p19 -F [Fri Jan 25 02:22:17 2019]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
File synchronization has completed for nodes: "c910f02c02p19"
CHECK:output =~ File synchronization has completed for nodes:\s*"c910f02c02p19"\s*	[Pass]
CHECK:rc == 0	[Pass]

RUN:xdsh c910f02c02p19 ls /tmp/h [Fri Jan 25 02:22:20 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f02c02p19: /tmp/h
CHECK:rc == 0	[Pass]

RUN:xdsh c910f02c02p19 ls /tmp/test [Fri Jan 25 02:22:21 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
c910f02c02p19: /tmp/test
CHECK:rc == 0	[Pass]

RUN:xdsh c910f02c02p19 ls /tmp/test2 [Fri Jan 25 02:22:21 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f02c02p19: /tmp/test2
CHECK:rc == 0	[Pass]

RUN:xdsh c910f02c02p19 ls /tmp/test3 [Fri Jan 25 02:22:22 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f02c02p19: /tmp/test3
CHECK:rc == 0	[Pass]

RUN:xdsh c910f02c02p19 ls /tmp/test1 [Fri Jan 25 02:22:23 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f02c02p19: /tmp/test1
CHECK:rc == 0	[Pass]

RUN:if [ -e /tmp/myimage.stanza ]; then rmdef -t osimage -o __GETNODEATTR(c910f02c02p19,os)__-__GETNODEATTR(c910f02c02p19,arch)__-install-compute; cat /tmp/myimage.stanza | mkdef -z; rm -rf /tmp/myimage.stanza; fi [Fri Jan 25 02:22:24 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:rm -rf /install/custom/install/__GETNODEATTR(c910f02c02p19,os)__/compute.linux.srcdstdiff.synclist [Fri Jan 25 02:22:26 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::updatenode_syncfile_EXECUTEALWAYS_src_dst_diff::Passed::Time:Fri Jan 25 02:22:27 2019 ::Duration::22 sec------
------Total: 1 , Failed: 0------
```