### PR TITLE
Make `makedhcp` working on RHEL 8 xCAT management node

### DIFF
--- a/xCAT-server/lib/xcat/plugins/dhcp.pm
+++ b/xCAT-server/lib/xcat/plugins/dhcp.pm
@@ -1757,7 +1757,7 @@ sub process_request
                 my $os_ver = $os;
                 $os_ver =~ s/[^0-9.^0-9]//g;
                 if (($os =~ /sles/i && $os_ver >= 11) ||
-                    ($os =~ /rhels/i && $os_ver >= 7)) {
+                    ($os =~ /rhels?/i && $os_ver >= 7)) {
 
                     $dhcpd_key = "DHCPD_INTERFACE";
                     if ($usingipv6 and $dhcpver eq "dhcpd6") {
@@ -1825,7 +1825,10 @@ sub process_request
         if ($usingipv6) {
 
             # sles11.3 and rhels7 has dhcpd and dhcpd6 config in the dhcp file
-            if ($os =~ /sles/i || $os =~ /rhels7/i) {
+            my $os_ver = $os;
+            $os_ver =~ s/[^0-9.^0-9]//g;
+            if (($os =~ /sles/i && $os_ver >= 11) ||
+                ($os =~ /rhels?/i && $os_ver >= 7)) {
                 if ($missingfiles{dhcpd}) {
                     $callback->({ error => ["The file /etc/sysconfig/dhcpd doesn't exist, check the dhcp server"] });
                 }

--- a/xCAT-server/lib/xcat/plugins/networks.pm
+++ b/xCAT-server/lib/xcat/plugins/networks.pm
@@ -391,7 +391,8 @@ sub donets
         foreach (@ip6table)
         {
             my @ent = split /\s+/, $_;
-            if ($ent[0] eq 'fe80::/64' or $ent[0] eq 'unreachable' or $ent[1] eq 'via') {
+            if ($ent[0] eq 'fe80::/64' or $ent[0] eq 'unreachable' or
+                $ent[1] eq 'via' or $ent[2] eq 'lo') {
 
                 #Do not contemplate link-local, unreachable, or gatewayed networks further
                 #DHCPv6 relay will be manually entered into networks as was the case for IPv4

--- a/xCAT-server/lib/xcat/plugins/networks.pm
+++ b/xCAT-server/lib/xcat/plugins/networks.pm
@@ -394,7 +394,8 @@ sub donets
             if ($ent[0] eq 'fe80::/64' or $ent[0] eq 'unreachable' or
                 $ent[1] eq 'via' or $ent[2] eq 'lo') {
 
-                #Do not contemplate link-local, unreachable, or gatewayed networks further
+                #Do not contemplate link-local, unreachable, gatewayed networks,
+                #  or networks connected to loopback interface
                 #DHCPv6 relay will be manually entered into networks as was the case for IPv4
                 next;
             }


### PR DESCRIPTION
### The PR is to make `makedhcp` working on RHEL 8 xCAT management node.

_##Feature description##_

### The content of the PR:
* [x] _##Patch `dhcp.pm` for the operating system version detection_
* [x] _##Patch `makenetworks` to make it ignore the `lo` interface_

### The UT result
```
# lsdef -t network
Could not find any object definitions to display.
# makenetworks
# lsdef -t network
10_0_0_0-255_0_0_0  (network)
```
```
# makedhcp -n
Renamed existing dhcp configuration file to  /etc/dhcp/dhcpd.conf.xcatbak

Warning: [c910f03c01p19]: No dynamic range specified for 10.0.0.0. If hardware discovery is being used, a dynamic range is required.
```
