### PR TITLE
refine test case "xcatd_start"

### DIFF
--- a/xCAT-test/autotest/testcase/xcatd/case0
+++ b/xCAT-test/autotest/testcase/xcatd/case0
@@ -10,7 +10,7 @@ check:output=~Active: active \(running\)|xcatd service is running
 cmd:ps axjf |grep -v grep |grep "xcatd:" | tee /tmp/xcatd_start/original_xcatd_processes_status
 check:rc==0
 cmd:cat /tmp/xcatd_start/original_xcatd_processes_status |wc -l
-check:output=~6
+#check:output=~6
 cmd:service xcatd stop
 check:rc==0
 cmd:sleep 3


### PR DESCRIPTION
### The PR is to refine test case  ``xcatd_start``

In normal case, there are 6 processes alive for xcatd daemon. But there is a short time window, when xcatd receives a request, there will be more then 6 processes alive for xcatd daemon. For example

```

RUN:ps axjf |grep -v grep |grep "xcatd:" | tee /tmp/xcatd_start/original_xcatd_processes_status [Sat Dec 29 14:42:40 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
    1 24149 24149 24149 ?           -1 Ss       0   0:02 xcatd: SSL listener
24149 24151 24149 24149 ?           -1 R        0   0:58  \_ xcatd: DB Access
24149 24153 24149 24149 ?           -1 S        0   0:00  \_ xcatd: UDP listener
24153 24157 24149 24149 ?           -1 S        0   0:00  |   \_ xcatd: Discovery worker
24149 24154 24149 24149 ?           -1 S        0   0:00  \_ xcatd: install monitor
24149 24155 24149 24149 ?           -1 S        0   0:00  \_ xcatd: Command log writer
24149 23007 24149 24149 ?           -1 R        0   0:00  \_ xcatd: SSL listener
```

So when test case ``xcatd_start`` check the original status of xcatd before restarting it, below check maybe failed.

```
cmd:ps axjf |grep -v grep |grep "xcatd:" | tee /tmp/xcatd_start/original_xcatd_processes_status
check:rc==0
cmd:cat /tmp/xcatd_start/original_xcatd_processes_status |wc -l
check:output=~6
```

In order to avoid failed in non-critical path, move ``check:output=~6`` out.