### PR TITLE
Fix build failure for openbmc py reported in issue 5933

### DIFF
--- a/xCAT-openbmc-py/debian/dirs
+++ b/xCAT-openbmc-py/debian/dirs
@@ -2,4 +2,5 @@ opt/xcat/lib/python/agent
 opt/xcat/lib/python/agent/xcatagent
 opt/xcat/lib/python/agent/common
 opt/xcat/lib/python/agent/hwctl
-opt/xcat/lib/python/agent/hwctl/executor
+opt/xcat/lib/python/agent/hwctl/openbmc
+opt/xcat/lib/python/agent/hwctl/redfish

--- a/xCAT-openbmc-py/xCAT-openbmc-py.spec
+++ b/xCAT-openbmc-py/xCAT-openbmc-py.spec
@@ -36,12 +36,14 @@ install -d $RPM_BUILD_ROOT/%{prefix}/lib/python/agent
 install -d $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/xcatagent
 install -d $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/common
 install -d $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/hwctl
-install -d $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/hwctl/executor
+install -d $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/hwctl/openbmc
+install -d $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/hwctl/redfish
 install -m755 lib/python/agent/*.py $RPM_BUILD_ROOT/%{prefix}/lib/python/agent
 install -m644 lib/python/agent/xcatagent/*.py $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/xcatagent
 install -m644 lib/python/agent/common/*.py $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/common
 install -m644 lib/python/agent/hwctl/*.py $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/hwctl
-install -m644 lib/python/agent/hwctl/executor/*.py $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/hwctl/executor
+install -m644 lib/python/agent/hwctl/openbmc/*.py $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/hwctl/openbmc/
+install -m644 lib/python/agent/hwctl/redfish/*.py $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/hwctl/redfish/
 
 %ifnos linux
 rm -rf $RPM_BUILD_ROOT/%{prefix}/lib/python/agent


### PR DESCRIPTION
### The PR is to fix issue #5933 

### The modification include

xCAT-openbmc-py.spec

xCAT-openbmc-py/debian/dirs

### The UT result
`##The UT output##`
Before fix:
```
# ./makerpm xCAT-openbmc-py
Building /root/rpmbuild/RPMS/noarch/xCAT-openbmc-py-2.14.6-snap*.noarch.rpm ...
install: cannot stat 'lib/python/agent/hwctl/executor/*.py': No such file or directory
error: Bad exit status from /var/tmp/rpm-tmp.iRI9Mx (%install)
    Bad exit status from /var/tmp/rpm-tmp.iRI9Mx (%install)
```
After fix:
```
./makerpm xCAT-openbmc-py
Building /root/rpmbuild/RPMS/noarch/xCAT-openbmc-py-2.14.6-snap*.noarch.rpm ...
```