### PR TITLE
Fix remoteshell compatibility with custom Match

### DIFF
--- a/xCAT/postscripts/remoteshell
+++ b/xCAT/postscripts/remoteshell
@@ -59,6 +59,7 @@ then
 	logger -t $log_label -p local4.info "remoteshell:  setup /etc/ssh/sshd_config and ssh_config"
 	cp /etc/ssh/sshd_config /etc/ssh/sshd_config.ORIG
         #delete all occurance of the attribute and then add xCAT settings
+        echo "Match all" >>/etc/ssh/sshd_config
         sed -i '/X11Forwarding /'d /etc/ssh/sshd_config
         echo "X11Forwarding yes" >>/etc/ssh/sshd_config
         sed -i '/MaxStartups /'d /etc/ssh/sshd_config


### PR DESCRIPTION
If a user has a custom Match directive, remoteshell would
create an invalid configuration.  Fix by ensuring we are
outside of a match context by doing Match all explicitly at the end.

### The PR is to fix issue _#xxx_

### The modification include

_##item1_

_##item2_

### The UT result
`##The UT output##`

# Please remove this line and below if fix issue

# Please remove this line and above for tasks or features

### The PR is for task _#xxx_ or to implement feature #xxx

_##Feature description##_

### The content of the PR:
* [ ] _##The mini-design link_
* [ ] _##The basic code logic_

### The UT result
`##The UT output##`
