### PR TITLE
 Add retry mechanism into makedhcp_remote_network test case to avoid time issue

### DIFF
--- a/xCAT-test/autotest/testcase/makedhcp/cases0
+++ b/xCAT-test/autotest/testcase/makedhcp/cases0
@@ -213,7 +213,7 @@ cmd:if [ -f /var/lib/dhcpd/dhcpd.leases ]; then a="/var/lib/dhcpd/dhcpd.leases";
 cmd:makedhcp testnode
 check:rc==0
 cmd:if [ -f /var/lib/dhcpd/dhcpd.leases ]; then a="/var/lib/dhcpd/dhcpd.leases"; elif [ -f /var/lib/dhcp/db/dhcpd.leases ]; then a="/var/lib/dhcp/db/dhcpd.leases"; elif [ -f "/var/lib/dhcp/dhcpd.leases" ]; then a="/var/lib/dhcp/dhcpd.leases";fi; ls -l $a; cat $a
-cmd:a=0;while true; do [ $a -eq 100 ] && exit 1;output=$(makedhcp -q testnode);[ $? -ne 0 ] && exit 1;echo $output|grep testnode 2>/dev/null && exit 0;a=$[$a+1];sleep 1;done
+cmd:a=2;while true; do [ $a -eq 64 ] && exit 1;output=$(makedhcp -q testnode);[ $? -ne 0 ] && exit 1;echo $output|grep testnode 2>/dev/null && exit 0;a=$[$a*2];sleep $a;done
 check:rc==0
 check:output=~testnode: ip-address = 100.100.100.2
 cmd:makedhcp -d testnode

--- a/xCAT-test/autotest/testcase/makedhcp/cases0
+++ b/xCAT-test/autotest/testcase/makedhcp/cases0
@@ -213,7 +213,7 @@ cmd:if [ -f /var/lib/dhcpd/dhcpd.leases ]; then a="/var/lib/dhcpd/dhcpd.leases";
 cmd:makedhcp testnode
 check:rc==0
 cmd:if [ -f /var/lib/dhcpd/dhcpd.leases ]; then a="/var/lib/dhcpd/dhcpd.leases"; elif [ -f /var/lib/dhcp/db/dhcpd.leases ]; then a="/var/lib/dhcp/db/dhcpd.leases"; elif [ -f "/var/lib/dhcp/dhcpd.leases" ]; then a="/var/lib/dhcp/dhcpd.leases";fi; ls -l $a; cat $a
-cmd:makedhcp -q testnode
+cmd:a=0;while true; do [ $a -eq 100 ] && exit 1;output=$(makedhcp -q testnode);[ $? -ne 0 ] && exit 1;echo $output|grep testnode 2>/dev/null && exit 0;a=$[$a+1];sleep 1;done
 check:rc==0
 check:output=~testnode: ip-address = 100.100.100.2
 cmd:makedhcp -d testnode


### PR DESCRIPTION
### The PR is to do task https://github.com/xcat2/xcat2-task-management/issues/551

The UT result
```
------START::makedhcp_remote_network::Time:Fri Jan 11 02:43:57 2019------

RUN:mkdef -t network -o testnetwork net=100.100.100.0 mask=255.255.255.0 mgtifname='!remote!eth0' gateway=100.100.100.1 [Fri Jan 11 02:43:57 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:lsdef -t network [Fri Jan 11 02:43:58 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
10_0_0_0-255_0_0_0  (network)
autotest_ent  (network)
testnetwork  (network)
CHECK:rc == 0	[Pass]
CHECK:output =~ testnetwork	[Pass]

RUN:mkdef -t node -o testnode ip=100.100.100.2 groups=all mac=42:3d:0a:05:27:0b [Fri Jan 11 02:43:58 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:echo -e "\n100.100.100.2 testnode" >> /etc/hosts [Fri Jan 11 02:43:59 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:makedhcp -n [Fri Jan 11 02:43:59 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Warning: [c910f02c02p16]: No dynamic range specified for 10.0.0.0. If hardware discovery is being used, a dynamic range is required.
Warning: [c910f02c02p17]: No dynamic range specified for 10.0.0.0. If hardware discovery is being used, a dynamic range is required.
Renamed existing dhcp configuration file to  /etc/dhcp/dhcpd.conf.xcatbak

Renamed existing dhcp configuration file to  /etc/dhcp/dhcpd.conf.xcatbak

CHECK:rc == 0	[Pass]

RUN:makedhcp -d testnode [Fri Jan 11 02:44:00 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:if [ -f /var/lib/dhcpd/dhcpd.leases ]; then a="/var/lib/dhcpd/dhcpd.leases"; elif [ -f /var/lib/dhcp/db/dhcpd.leases ]; then a="/var/lib/dhcp/db/dhcpd.leases"; elif [ -f "/var/lib/dhcp/dhcpd.leases" ]; then a="/var/lib/dhcp/dhcpd.leases";fi; ls -l $a; cat $a [Fri Jan 11 02:44:00 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
-rw-r--r-- 1 dhcpd dhcpd 1141 Jan 11 02:44 /var/lib/dhcpd/dhcpd.leases
# The format of this file is documented in the dhcpd.leases(5) manual page.
# This lease file was written by isc-dhcp-4.2.5

host c910f02c02p17 {
  dynamic;
  hardware ethernet da:08:43:47:53:03;
  uid da:08:43:47:53:03;
  fixed-address 10.2.2.17;
        supersede server.ddns-hostname = "c910f02c02p17";
        supersede host-name = "c910f02c02p17";
        supersede server.filename = "/boot/grub2/grub2-c910f02c02p17";
        supersede server.next-server = 0a:02:02:10;
}
host c910f02c02p18 {
  dynamic;
  hardware ethernet da:08:46:fc:e7:03;
  uid da:08:46:fc:e7:03;
  fixed-address 10.2.2.18;
        supersede server.ddns-hostname = "c910f02c02p18";
        supersede host-name = "c910f02c02p18";
        supersede server.filename = "/boot/grub2/grub2-c910f02c02p18";
}
host c910f02c02p19 {
  dynamic;
  hardware ethernet da:08:47:20:93:03;
  uid da:08:47:20:93:03;
  fixed-address 10.2.2.19;
        supersede server.ddns-hostname = "c910f02c02p19";
        supersede host-name = "c910f02c02p19";
        supersede server.filename = "/boot/grub2/grub2-c910f02c02p19";
}
server-duid "\000\001\000\001#\310!(\332\010A\326\360\003";


RUN:makedhcp testnode [Fri Jan 11 02:44:00 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Warning: [c910f02c02p17]: The hostname testnode of node testnode could not be resolved.
CHECK:rc == 0	[Pass]

RUN:if [ -f /var/lib/dhcpd/dhcpd.leases ]; then a="/var/lib/dhcpd/dhcpd.leases"; elif [ -f /var/lib/dhcp/db/dhcpd.leases ]; then a="/var/lib/dhcp/db/dhcpd.leases"; elif [ -f "/var/lib/dhcp/dhcpd.leases" ]; then a="/var/lib/dhcp/dhcpd.leases";fi; ls -l $a; cat $a [Fri Jan 11 02:44:01 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
-rw-r--r-- 1 dhcpd dhcpd 1360 Jan 11 02:44 /var/lib/dhcpd/dhcpd.leases
# The format of this file is documented in the dhcpd.leases(5) manual page.
# This lease file was written by isc-dhcp-4.2.5

host c910f02c02p17 {
  dynamic;
  hardware ethernet da:08:43:47:53:03;
  uid da:08:43:47:53:03;
  fixed-address 10.2.2.17;
        supersede server.ddns-hostname = "c910f02c02p17";
        supersede host-name = "c910f02c02p17";
        supersede server.filename = "/boot/grub2/grub2-c910f02c02p17";
        supersede server.next-server = 0a:02:02:10;
}
host c910f02c02p18 {
  dynamic;
  hardware ethernet da:08:46:fc:e7:03;
  uid da:08:46:fc:e7:03;
  fixed-address 10.2.2.18;
        supersede server.ddns-hostname = "c910f02c02p18";
        supersede host-name = "c910f02c02p18";
        supersede server.filename = "/boot/grub2/grub2-c910f02c02p18";
}
host c910f02c02p19 {
  dynamic;
  hardware ethernet da:08:47:20:93:03;
  uid da:08:47:20:93:03;
  fixed-address 10.2.2.19;
        supersede server.ddns-hostname = "c910f02c02p19";
        supersede host-name = "c910f02c02p19";
        supersede server.filename = "/boot/grub2/grub2-c910f02c02p19";
}
server-duid "\000\001\000\001#\310!(\332\010A\326\360\003";

host testnode {
  dynamic;
  hardware ethernet 42:3d:0a:05:27:0b;
  uid 42:3d:0a:05:27:0b;
  fixed-address 100.100.100.2;
        supersede server.ddns-hostname = "testnode";
        supersede host-name = "testnode";
}

RUN:a=2;while true; do [ $a -eq 64 ] && exit 1;output=$(makedhcp -q testnode);[ $? -ne 0 ] && exit 1;echo $output|grep testnode 2>/dev/null && exit 0;a=$[$a*2];sleep $a;done [Fri Jan 11 02:44:01 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
testnode: ip-address = 100.100.100.2, hardware-address = 42:3d:0a:05:27:0b
CHECK:rc == 0	[Pass]
CHECK:output =~ testnode: ip-address = 100.100.100.2	[Pass]

RUN:makedhcp -d testnode [Fri Jan 11 02:44:02 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:makedhcp -n [Fri Jan 11 02:44:02 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Warning: [c910f02c02p16]: No dynamic range specified for 10.0.0.0. If hardware discovery is being used, a dynamic range is required.
Warning: [c910f02c02p17]: No dynamic range specified for 10.0.0.0. If hardware discovery is being used, a dynamic range is required.
start:makedhcp_n
description:Create a new dhcp configuration file with a network statement for each network the dhcp daemon should listen on
os:Linux
label:mn_only,ci_test,dhcp
cmd:if [ -f "/etc/dhcp/dhcpd.conf" ];then mv -f /etc/dhcp/dhcpd.conf /etc/dhcp/dhcpd.conf.bak ; elif [ -f "/etc/dhcpd.conf" ]; then mv -f /etc/dhcpd.conf /etc/dhcpd.conf.bak; fi
cmd:makedhcp -n
check:rc==0
cmd:cat $(ls /etc/dhcp/dhcpd.conf || ls /etc/dhcpd.conf)
check:rc==0
cmd:sleep 20
cmd:ps -e | grep dhcpd
check:rc==0
check:output=~dhcpd
cmd:if  cat /etc/*release |grep Ubuntu >/dev/null;then service isc-dhcp-server status;else service dhcpd status;fi
check:output=~running
cmd:if [ -f "/etc/dhcp/dhcpd.conf" ]; then mv -f /etc/dhcp/dhcpd.conf.bak /etc/dhcp/dhcpd.conf; elif [ -f "/etc/dhcpd.conf" ]; then mv -f /etc/dhcpd.conf.bak /etc/dhcpd.conf; fi
end

start:makedhcp_h
description:help
label:mn_only,ci_test,dhcp
cmd:makedhcp -h
check:rc==0
check:output=~Usage
end

start:makedhcp_help
description:help
label:mn_only,ci_test,dhcp
cmd:makedhcp -h
/remote
cmd:lsdef -t network
Renamed existing dhcp configuration file to  /etc/dhcp/dhcpd.conf.xcatbak

Renamed existing dhcp configuration file to  /etc/dhcp/dhcpd.conf.xcatbak

CHECK:rc == 0	[Pass]

RUN:noderm testnode [Fri Jan 11 02:44:03 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:chtab -d netname=testnetwork networks [Fri Jan 11 02:44:03 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:cp -f /etc/hosts.bak /etc/hosts [Fri Jan 11 02:44:04 2019]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
cp: cannot stat '/etc/hosts.bak': No such file or directory

------END::makedhcp_remote_network::Passed::Time:Fri Jan 11 02:44:04 2019 ::Duration::7 sec------
------Total: 1 , Failed: 0------
```