### PR TITLE
implement a script to achieve retry mechanism against rinstall

### DIFF
--- a/xCAT-test/autotest/testcase/commoncmd/retry_install.sh
+++ b/xCAT-test/autotest/testcase/commoncmd/retry_install.sh
@@ -7,7 +7,15 @@ declare -i tryreinstall=1
 node=$1
 osimage=$2
 
-for (( tryreinstall = 1 ; tryreinstall < 6 ; ++tryreinstall ))
+if [ $# -eq 3 ];
+then
+    times=$3+1
+else
+    times=6 
+fi
+
+
+for (( tryreinstall = 1 ; tryreinstall < $times ; ++tryreinstall ))
 do
     echo "Try to install $node on the $tryreinstall time..."
 

--- a/xCAT-test/autotest/testcase/commoncmd/retry_install.sh
+++ b/xCAT-test/autotest/testcase/commoncmd/retry_install.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+echo "Try to retry rinstall 5 times ......"
+
+declare -i installsuccess=0
+declare -i a=0
+declare -i tryreinstall=1
+node=$1
+osimage=$2
+
+for (( tryreinstall = 1 ; tryreinstall < 6 ; ++tryreinstall ))
+do
+    echo "Try to install $node on the $tryreinstall time..."
+
+    echo "rinstall $node osimage=$osimage"
+    rinstall $node osimage=$osimage
+    if [ $? != 0 ];then
+        echo "rinstall failed, double check xcat command rinstall to see if it is a bug..."
+        exit 1
+    fi
+
+    #sleep while for installation.
+    sleep 360
+    while [ ! `lsdef -l $node|grep status|grep booted` ]
+    do 
+        sleep 10
+        echo "The status is not booted..." 
+        a=++a 
+        if [ $a -gt 400 ];then
+            a=0 
+            break
+        fi
+    done
+
+    lsdef -l $node|grep status|grep booted
+    tobooted=$?
+    echo "The tobooted is $tobooted"
+
+    ping -c 2 $node
+    pingable=$?
+    echo "The pingable is $pingable"
+
+    xdsh $node date
+    canruncmd=$?
+    echo "The canruncmd is $canruncmd"
+
+    if [[ $canruncmd -eq 0  &&  $tobooted -eq 0  &&  $pingable -eq 0 ]];then
+        echo "The provision succeed on the $tryreinstall time....."
+        installsuccess=1
+        break
+    fi
+
+done       
+
+if [ $installsuccess -eq 1 ];then
+    echo "The provision succeed......"
+    exit 0 
+else
+    echo "The provision failed......"
+    exit 1
+fi

--- a/xCAT-test/autotest/testcase/commoncmd/retry_install.sh
+++ b/xCAT-test/autotest/testcase/commoncmd/retry_install.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-echo "Try to retry rinstall 5 times ......"
 
 declare -i installsuccess=0
 declare -i a=0
@@ -10,8 +9,10 @@ osimage=$2
 if [ $# -eq 3 ];
 then
     times=$3+1
+    echo "Try to retry rinstall $3 times ......"
 else
-    times=6 
+    times=6
+    echo "Try to retry rinstall 5 times ......" 
 fi
 
 

--- a/xCAT-test/autotest/testcase/confignetwork/cases0
+++ b/xCAT-test/autotest/testcase/confignetwork/cases0
@@ -22,7 +22,7 @@ cmd:copycds $$ISO
 check:rc==0
 cmd:chdef $$CN postscripts="confignetwork -s"
 check:rc==0
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
 cmd:sleep 300
 cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 20;((a++));if [ $a -gt 300 ];then break;fi done
@@ -70,7 +70,7 @@ cmd:genimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-comput
 check:rc==0
 cmd:packimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 cmd:sleep 180
 cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 10;((a++));if [ $a -gt 60 ];then break;fi done
@@ -123,7 +123,7 @@ cmd:genimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-comput
 check:rc==0
 cmd:packimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 cmd:sleep 180
 cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 10;((a++));if [ $a -gt 60 ];then break;fi done

--- a/xCAT-test/autotest/testcase/installation/SN_diskless_setup_case
+++ b/xCAT-test/autotest/testcase/installation/SN_diskless_setup_case
@@ -84,7 +84,7 @@ cmd:rm -rf /tmp/mountoutput
 cmd:packimage __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-netboot-service
 check:rc==0
 
-cmd:rinstall $$SN osimage=__GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-netboot-service
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$SN __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-netboot-service
 check:rc==0
 check:output=~Provision node\(s\)\: $$SN
 

--- a/xCAT-test/autotest/testcase/installation/SN_setup_case
+++ b/xCAT-test/autotest/testcase/installation/SN_setup_case
@@ -57,7 +57,7 @@ check:rc==0
 #cmd:chdef -t osimage __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-install-service pkgdir="/install/__GETNODEATTR($$SN,os)__/__GETNODEATTR($$SN,arch)__"
 #check:rc==0
 
-cmd:rinstall $$SN osimage=__GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-install-service
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$SN __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-install-service
 check:rc==0
 check:output=~Provision node\(s\)\: $$SN
 

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_flat
@@ -41,7 +41,7 @@ cmd:if ! ([[ "__GETNODEATTR($$CN,os)__" = "sles12.1" ]] || [[ "__GETNODEATTR($$C
 check:rc==0
 cmd:lsdef -l $$CN
 check:rc==0
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 cmd:if [[ -f /var/lib/dhcp/db/dhcpd.leases ]]; then cat /var/lib/dhcp/db/dhcpd.leases; elif [[ -f /var/lib/dhcpd/dhcpd.leases ]];then cat /var/lib/dhcpd/dhcpd.leases;elif [[ -f /var/lib/dhcp/dhcpd.leases ]];then cat /var/lib/dhcp/dhcpd.leases; fi

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_flat_postscripts_failed
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_flat_postscripts_failed
@@ -41,7 +41,7 @@ cmd:chdef $$CN -p  postscripts=test
 check:rc==0
 cmd:lsdef -l $$CN
 check:rc==0
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_hierarchy
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_hierarchy
@@ -42,7 +42,7 @@ cmd:nodeset $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-ins
 check:rc==0
 cmd:updatenode $$CN -f
 check:rc==0
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat
@@ -43,7 +43,7 @@ cmd:rm -rf /tmp/mountoutput
 cmd:packimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat_postscripts_failed
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat_postscripts_failed
@@ -47,7 +47,7 @@ cmd:rm -rf /tmp/mountoutput
 cmd:packimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_hierarchy
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_hierarchy
@@ -49,7 +49,7 @@ check:rc==0
 
 cmd:updatenode $$CN -f
 check:rc==0
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_flat
@@ -55,7 +55,7 @@ check:rc==0
 cmd:liteimg  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
 check:rc==0
 
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 
@@ -93,7 +93,7 @@ check:rc==0
 cmd:liteimg __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
 check:rc==0
 
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_nfs
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_nfs
@@ -75,7 +75,7 @@ check:rc==0
 cmd:prsync /install $$SN:/
 check:rc==0
 
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_ramdisk
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_ramdisk
@@ -69,7 +69,7 @@ cmd:prsync /install $$SN:/
 check:rc==0
 
 
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 

--- a/xCAT-test/autotest/testcase/installation/ubuntu_full_installation_vm_docker
+++ b/xCAT-test/autotest/testcase/installation/ubuntu_full_installation_vm_docker
@@ -21,7 +21,7 @@ cmd:if [[ "__GETNODEATTR($$CN,os)__" =~ "ubuntu14.04" ]];then ver=`cat /etc/*-re
 check:rc==0
 cmd: chdef $$CN -p postbootscripts="setupdockerhost mynet0=$$MYNET0VALUE@$$DOCKERHOSIP:$$NICNAME"
 check:rc==0
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-dockerhost
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-dockerhost
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 

--- a/xCAT-test/autotest/testcase/migration/redhat_migration
+++ b/xCAT-test/autotest/testcase/migration/redhat_migration
@@ -32,7 +32,7 @@ cmd:if cat /etc/*release |grep SUSE >/dev/null;then cat /var/lib/dhcp/db/dhcpd.l
 check:output=~$$CN
 cmd:copycds $$ISO
 check:rc==0
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 cmd:sleep 600
@@ -140,7 +140,7 @@ cmd:if cat /etc/*release |grep SUSE >/dev/null;then cat /var/lib/dhcp/db/dhcpd.l
 check:output=~$$CN
 cmd:copycds $$ISO
 check:rc==0
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 cmd:sleep 600

--- a/xCAT-test/autotest/testcase/migration/sles_migration
+++ b/xCAT-test/autotest/testcase/migration/sles_migration
@@ -31,7 +31,7 @@ cmd:if cat /etc/*release |grep SUSE >/dev/null;then cat /var/lib/dhcp/db/dhcpd.l
 check:output=~$$CN
 cmd:copycds $$ISO
 check:rc==0
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 cmd:sleep 600
@@ -152,7 +152,7 @@ cmd:if cat /etc/*release |grep SUSE >/dev/null;then cat /var/lib/dhcp/db/dhcpd.l
 check:output=~$$CN
 cmd:copycds $$ISO
 check:rc==0
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 cmd:sleep 600

--- a/xCAT-test/autotest/testcase/migration/ubuntu_migration1_p8le
+++ b/xCAT-test/autotest/testcase/migration/ubuntu_migration1_p8le
@@ -17,7 +17,7 @@ cmd:makeconservercf $$CN
 check:rc==0
 cmd:cat /etc/conserver.cf | grep $$CN
 check:output=~$$CN
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 cmd:sleep 600

--- a/xCAT-test/autotest/testcase/migration/ubuntu_migration1_vm
+++ b/xCAT-test/autotest/testcase/migration/ubuntu_migration1_vm
@@ -16,7 +16,7 @@ cmd:makeconservercf $$CN
 check:rc==0
 cmd:cat /etc/conserver.cf | grep $$CN
 check:output=~$$CN
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 cmd:sleep 600

--- a/xCAT-test/autotest/testcase/migration/ubuntu_migration2_p8le
+++ b/xCAT-test/autotest/testcase/migration/ubuntu_migration2_p8le
@@ -17,7 +17,7 @@ cmd:makeconservercf $$CN
 check:rc==0
 cmd:cat /etc/conserver.cf | grep $$CN
 check:output=~$$CN
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 cmd:sleep 300

--- a/xCAT-test/autotest/testcase/migration/ubuntu_migration2_vm
+++ b/xCAT-test/autotest/testcase/migration/ubuntu_migration2_vm
@@ -16,7 +16,7 @@ cmd:makeconservercf $$CN
 check:rc==0
 cmd:cat /etc/conserver.cf | grep $$CN
 check:output=~$$CN
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 cmd:sleep 600

--- a/xCAT-test/autotest/testcase/packimg/cases0
+++ b/xCAT-test/autotest/testcase/packimg/cases0
@@ -72,10 +72,7 @@ check:output=~archive method:cpio
 check:output=~compress method:gzip
 cmd:ls -l /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.cpio.gz
 check:rc==0
-cmd:nodeset $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
-check:rc==0
-cmd:if [[ "__GETNODEATTR($$CN,arch)__" = "ppc64" ]]; then rnetboot $$CN;else rpower $$CN boot; fi
-check:rc==0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 10;((a++));if [ $a -gt 150 ];then break;fi done
 cmd:ping $$CN -c 3
 check:rc==0
@@ -118,9 +115,7 @@ check:output=~archive method:cpio
 check:output=~compress method:pigz
 cmd:ls -l /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.cpio.gz
 check:rc==0
-cmd:nodeset $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
-check:rc==0
-cmd:if [[ "__GETNODEATTR($$CN,arch)__" = "ppc64" ]]; then rnetboot $$CN;else rpower $$CN boot; fi
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 10;((a++));if [ $a -gt 150 ];then break;fi done
 cmd:ping $$CN -c 3
@@ -160,9 +155,7 @@ check:output=~archive method:cpio
 check:output=~compress method:xz
 cmd:ls -l /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.cpio.xz
 check:rc==0
-cmd:nodeset $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
-check:rc==0
-cmd:if [[ "__GETNODEATTR($$CN,arch)__" = "ppc64" ]]; then rnetboot $$CN;else rpower $$CN boot; fi
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 10;((a++));if [ $a -gt 150 ];then break;fi done
 cmd:ping $$CN -c 3

--- a/xCAT-test/autotest/testcase/packimg/cases0
+++ b/xCAT-test/autotest/testcase/packimg/cases0
@@ -73,6 +73,7 @@ check:output=~compress method:gzip
 cmd:ls -l /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.cpio.gz
 check:rc==0
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+check:rc==0
 cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 10;((a++));if [ $a -gt 150 ];then break;fi done
 cmd:ping $$CN -c 3
 check:rc==0

--- a/xCAT-test/autotest/testcase/packimg/cases0
+++ b/xCAT-test/autotest/testcase/packimg/cases0
@@ -206,7 +206,7 @@ check:output=~archive method:tar
 check:output=~compress method:pigz
 cmd:ls -l /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.tar.gz
 check:rc==0
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 10;((a++));if [ $a -gt 150 ];then break;fi done
@@ -257,7 +257,7 @@ check:output=~archive method:tar
 check:output=~compress method:gzip
 cmd:ls -l /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.tar.gz
 check:rc==0
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 10;((a++));if [ $a -gt 150 ];then break;fi done
@@ -308,7 +308,7 @@ check:output=~archive method:tar
 check:output=~compress method:xz
 cmd:ls -l /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.tar.xz
 check:rc==0
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 10;((a++));if [ $a -gt 150 ];then break;fi done

--- a/xCAT-test/autotest/testcase/runcmdinstaller/cases0
+++ b/xCAT-test/autotest/testcase/runcmdinstaller/cases0
@@ -10,7 +10,7 @@ description:runcmdinstaller
 label:others,postscripts
 cmd:chtab key=xcatdebugmode site.value="2"
 check:rc==0
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 cmd:a=0;while ! `lsdef -l $$CN|grep status|grep installing >/dev/null`; do sleep 20;((a++));if [ $a -gt 30 ];then break;fi done
@@ -25,7 +25,7 @@ description:get xcat post scripts loginfo
 label:others,postscripts
 cmd:chtab key=xcatdebugmode site.value="1"
 check:rc==0
-cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 10;((a++));if [ $a -gt 300 ];then break;fi done


### PR DESCRIPTION
### The PR is to do task 549 https://github.com/xcat2/xcat2-task-management/issues/549

The UT result
```
A lot of message for installation case....
RUN:makeconservercf [Fri Jan 11 02:04:44 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Warning: [c910f04x12v02]: makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver.
CHECK:rc == 0	[Pass]

RUN:cat /etc/conserver.cf | grep c910f04x12v04 [Fri Jan 11 02:04:45 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
#xCAT BEGIN c910f04x12v04 CONS
console c910f04x12v04 {
  exec /opt/xcat/share/xcat/cons/kvm c910f04x12v04;
#xCAT END c910f04x12v04 CONS
CHECK:output =~ c910f04x12v04	[Pass]

RUN:sleep 20 [Fri Jan 11 02:04:45 2019]
ElapsedTime:20 sec
RETURN rc = 0
OUTPUT:

RUN:if [[ "__GETNODEATTR(c910f04x12v04,arch)__" = "ppc64" ]] && [[ "__GETNODEATTR(c910f04x12v04,mgt)__" != "ipmi" ]]; then getmacs -D c910f04x12v04; fi [Fri Jan 11 02:05:05 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:chtab key=extntpservers site.value="" [Fri Jan 11 02:05:07 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:chtab key=ntpservers site.value="<xcatmaster>" [Fri Jan 11 02:05:07 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:makentp [Fri Jan 11 02:05:07 2019]
ElapsedTime:7 sec
RETURN rc = 0
OUTPUT:
configuring management node: c910f04x12v02.
Will configure chronyd instead.
Calling ... /install/postscripts/setupntp
Daemon chronyd configured.
CHECK:rc == 0	[Pass]

RUN:makedhcp -n [Fri Jan 11 02:05:14 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Warning: [c910f04x12v02]: No dynamic range specified for 10.0.0.0. If hardware discovery is being used, a dynamic range is required.
Renamed existing dhcp configuration file to  /etc/dhcp/dhcpd.conf.xcatbak

CHECK:rc == 0	[Pass]

RUN:makedhcp -a [Fri Jan 11 02:05:15 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:sleep 10 [Fri Jan 11 02:05:15 2019]
ElapsedTime:10 sec
RETURN rc = 0
OUTPUT:

RUN:a=0;while true; do [ $a -eq 100 ] && exit 1;output=$(makedhcp -q c910f04x12v04);[ $? -ne 0 ] && exit 1;echo $output|grep c910f04x12v04 2>/dev/null && exit 0;a=$[$a+1];sleep 1;done [Fri Jan 11 02:05:25 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f04x12v04: ip-address = 10.4.12.4, hardware-address = 42:4a:0a:04:0c:04
CHECK:rc == 0	[Pass]

RUN:copycds /RHEL-7.6-Server-x86_64-dvd1-stable.iso [Fri Jan 11 02:05:26 2019]
ElapsedTime:77 sec
RETURN rc = 0
OUTPUT:
Copying media to /install/rhels7.6/x86_64
Media copy operation successful
CHECK:rc == 0	[Pass]

RUN:if [[ -f /test.synclist ]] ;then mv -f /test.synclist /test.synclist.bak;fi; [Fri Jan 11 02:06:43 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "/test.synclist -> /test.synclist" > /test.synclist;chdef -t osimage -o __GETNODEATTR(c910f04x12v04,os)__-__GETNODEATTR(c910f04x12v04,arch)__-install-compute synclists=/test.synclist [Fri Jan 11 02:06:43 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:if ! ([[ "__GETNODEATTR(c910f04x12v04,os)__" = "sles12.1" ]] || [[ "__GETNODEATTR(c910f04x12v04,os)__" =~ "ubuntu" && "__GETNODEATTR(c910f04x12v04,arch)__" = "x86_64" ]]) ; then  chdef -t node -o c910f04x12v04 postscripts=setupntp; fi [Fri Jan 11 02:06:45 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:lsdef -l c910f04x12v04 [Fri Jan 11 02:06:47 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Object name: c910f04x12v04
    arch=x86_64
    cons=kvm
    currchain=boot
    currstate=boot
    groups=all,vm12
    ip=10.4.12.4
    mac=42:4a:0a:04:0c:04|42:b0:0a:04:0c:04!*NOIP*|42:03:0a:04:0c:04!*NOIP*
    mgt=kvm
    monserver=c910f04x12v02
    netboot=xnba
    nfsserver=c910f04x12v02
    os=rhels7.6
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles,setupntp
    profile=compute
    provmethod=rhels7.6-x86_64-install-compute
    serialflow=hard
    serialport=0
    serialspeed=115200
    status=powering-off
    statustime=01-10-2019 17:04:59
    tftpserver=c910f04x12v02
    updatestatus=syncing
    updatestatustime=01-10-2019 15:43:17
    vmcpus=2
    vmhost=c910f04x12
    vmmemory=4096
    vmnicnicmodel=virtio
    vmnics=br10,br4091,br4093
    vmstorage=dir:///var/lib/libvirt/images/
    xcatmaster=c910f04x12v02
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh c910f04x12v04 __GETNODEATTR(c910f04x12v04,os)__-__GETNODEATTR(c910f04x12v04,arch)__-install-compute [Fri Jan 11 02:06:48 2019]
ElapsedTime:613 sec
RETURN rc = 0
OUTPUT:
Try to retry rinstall 5 times ......
Try to install c910f04x12v04 on the 1 time...
rinstall c910f04x12v04 osimage=rhels7.6-x86_64-install-compute
Provision node(s): c910f04x12v04
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
    status=booted
The tobooted is 0
PING c910f04x12v04 (10.4.12.4) 56(84) bytes of data.
64 bytes from c910f04x12v04 (10.4.12.4): icmp_seq=1 ttl=64 time=0.350 ms
64 bytes from c910f04x12v04 (10.4.12.4): icmp_seq=2 ttl=64 time=0.309 ms

--- c910f04x12v04 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1000ms
rtt min/avg/max/mdev = 0.309/0.329/0.350/0.027 ms
The pingable is 0
c910f04x12v04: Fri Jan 11 02:17:01 EST 2019
The canruncmd is 0
The provision succeed on the 1 time.....
The provision succeed......
CHECK:rc == 0	[Pass]
CHECK:output =~ Provision node\(s\)\: c910f04x12v04	[Pass]

RUN:ping c910f04x12v04 -c 3 [Fri Jan 11 02:17:01 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
PING c910f04x12v04 (10.4.12.4) 56(84) bytes of data.
64 bytes from c910f04x12v04 (10.4.12.4): icmp_seq=1 ttl=64 time=0.288 ms
64 bytes from c910f04x12v04 (10.4.12.4): icmp_seq=2 ttl=64 time=0.374 ms
64 bytes from c910f04x12v04 (10.4.12.4): icmp_seq=3 ttl=64 time=0.289 ms

--- c910f04x12v04 ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2001ms
rtt min/avg/max/mdev = 0.288/0.317/0.374/0.040 ms
CHECK:rc == 0	[Pass]
CHECK:output =~ 64 bytes from c910f04x12v04	[Pass]

RUN:lsdef -l c910f04x12v04 | grep status [Fri Jan 11 02:17:03 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
    status=booted
    statustime=01-11-2019 02:16:49
    updatestatus=syncing
    updatestatustime=01-10-2019 15:43:17
CHECK:rc == 0	[Pass]
CHECK:output =~ booted	[Pass]

RUN:xdsh c910f04x12v04 date [Fri Jan 11 02:17:03 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f04x12v04: Fri Jan 11 02:17:04 EST 2019
CHECK:rc == 0	[Pass]
CHECK:output =~ \d\d:\d\d:\d\d	[Pass]

RUN:xdsh c910f04x12v04 mount [Fri Jan 11 02:17:04 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f04x12v04: sysfs on /sys type sysfs (rw,nosuid,nodev,noexec,relatime)
c910f04x12v04: proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)
c910f04x12v04: devtmpfs on /dev type devtmpfs (rw,nosuid,size=1928196k,nr_inodes=482049,mode=755)
c910f04x12v04: securityfs on /sys/kernel/security type securityfs (rw,nosuid,nodev,noexec,relatime)
c910f04x12v04: tmpfs on /dev/shm type tmpfs (rw,nosuid,nodev)
c910f04x12v04: devpts on /dev/pts type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000)
c910f04x12v04: tmpfs on /run type tmpfs (rw,nosuid,nodev,mode=755)
c910f04x12v04: tmpfs on /sys/fs/cgroup type tmpfs (ro,nosuid,nodev,noexec,mode=755)
c910f04x12v04: cgroup on /sys/fs/cgroup/systemd type cgroup (rw,nosuid,nodev,noexec,relatime,xattr,release_agent=/usr/lib/systemd/systemd-cgroups-agent,name=systemd)
c910f04x12v04: pstore on /sys/fs/pstore type pstore (rw,nosuid,nodev,noexec,relatime)
c910f04x12v04: cgroup on /sys/fs/cgroup/perf_event type cgroup (rw,nosuid,nodev,noexec,relatime,perf_event)
c910f04x12v04: cgroup on /sys/fs/cgroup/freezer type cgroup (rw,nosuid,nodev,noexec,relatime,freezer)
c910f04x12v04: cgroup on /sys/fs/cgroup/devices type cgroup (rw,nosuid,nodev,noexec,relatime,devices)
c910f04x12v04: cgroup on /sys/fs/cgroup/cpuset type cgroup (rw,nosuid,nodev,noexec,relatime,cpuset)
c910f04x12v04: cgroup on /sys/fs/cgroup/pids type cgroup (rw,nosuid,nodev,noexec,relatime,pids)
c910f04x12v04: cgroup on /sys/fs/cgroup/cpu,cpuacct type cgroup (rw,nosuid,nodev,noexec,relatime,cpuacct,cpu)
c910f04x12v04: cgroup on /sys/fs/cgroup/net_cls,net_prio type cgroup (rw,nosuid,nodev,noexec,relatime,net_prio,net_cls)
c910f04x12v04: cgroup on /sys/fs/cgroup/hugetlb type cgroup (rw,nosuid,nodev,noexec,relatime,hugetlb)
c910f04x12v04: cgroup on /sys/fs/cgroup/blkio type cgroup (rw,nosuid,nodev,noexec,relatime,blkio)
c910f04x12v04: cgroup on /sys/fs/cgroup/memory type cgroup (rw,nosuid,nodev,noexec,relatime,memory)
c910f04x12v04: configfs on /sys/kernel/config type configfs (rw,relatime)
c910f04x12v04: /dev/mapper/xcatvg-root on / type xfs (rw,relatime,attr2,inode64,noquota)
c910f04x12v04: debugfs on /sys/kernel/debug type debugfs (rw,relatime)
c910f04x12v04: systemd-1 on /proc/sys/fs/binfmt_misc type autofs (rw,relatime,fd=29,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=15420)
c910f04x12v04: mqueue on /dev/mqueue type mqueue (rw,relatime)
c910f04x12v04: hugetlbfs on /dev/hugepages type hugetlbfs (rw,relatime)
c910f04x12v04: /dev/sda1 on /boot type xfs (rw,relatime,attr2,inode64,noquota)
c910f04x12v04: sunrpc on /var/lib/nfs/rpc_pipefs type rpc_pipefs (rw,relatime)
c910f04x12v04: tmpfs on /run/user/0 type tmpfs (rw,nosuid,nodev,relatime,size=388056k,mode=700)
CHECK:rc == 0	[Pass]

RUN:sleep 120 [Fri Jan 11 02:17:05 2019]
ElapsedTime:120 sec
RETURN rc = 0
OUTPUT:

RUN:if ! ([[ "__GETNODEATTR(c910f04x12v04,os)__" = "sles12.1" ]] || [[ "__GETNODEATTR(c910f04x12v04,os)__" =~ "ubuntu" && "__GETNODEATTR(c910f04x12v04,arch)__" = "x86_64" ]]) ;then chdef  -t node -o c910f04x12v04 -m postscripts="setupntp"; fi [Fri Jan 11 02:19:05 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:lsdef -l c910f04x12v04 [Fri Jan 11 02:19:07 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Object name: c910f04x12v04
    arch=x86_64
    cons=kvm
    currchain=boot
    currstate=boot
    groups=all,vm12
    ip=10.4.12.4
    mac=42:4a:0a:04:0c:04|42:b0:0a:04:0c:04!*NOIP*|42:03:0a:04:0c:04!*NOIP*
    mgt=kvm
    monserver=c910f04x12v02
    netboot=xnba
    nfsserver=c910f04x12v02
    os=rhels7.6
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
    profile=compute
    provmethod=rhels7.6-x86_64-install-compute
    serialflow=hard
    serialport=0
    serialspeed=115200
    status=booted
    statustime=01-11-2019 02:16:49
    tftpserver=c910f04x12v02
    updatestatus=syncing
    updatestatustime=01-10-2019 15:43:17
    vmcpus=2
    vmhost=c910f04x12
    vmmemory=4096
    vmnicnicmodel=virtio
    vmnics=br10,br4091,br4093
    vmstorage=dir:///var/lib/libvirt/images/
    xcatmaster=c910f04x12v02

RUN:ping c910f04x12v04 -c 3 [Fri Jan 11 02:19:08 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
PING c910f04x12v04 (10.4.12.4) 56(84) bytes of data.
64 bytes from c910f04x12v04 (10.4.12.4): icmp_seq=1 ttl=64 time=0.280 ms
64 bytes from c910f04x12v04 (10.4.12.4): icmp_seq=2 ttl=64 time=0.449 ms
64 bytes from c910f04x12v04 (10.4.12.4): icmp_seq=3 ttl=64 time=0.332 ms

--- c910f04x12v04 ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2001ms
rtt min/avg/max/mdev = 0.280/0.353/0.449/0.073 ms
CHECK:rc == 0	[Pass]
CHECK:output =~ 64 bytes from c910f04x12v04	[Pass]

RUN:xdsh c910f04x12v04  "cat /var/log/xcat/xcat.log" [Fri Jan 11 02:19:10 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
c910f04x12v04: Running Kickstart Pre-Installation script...
c910f04x12v04: /tmp/ks-script-CWPXyu: line 58: stty: command not found
c910f04x12v04: mknod: '/dev/vcs1': File exists
c910f04x12v04: mknod: '/dev/vcsa1': File exists
c910f04x12v04: mknod: '/dev/vcs2': File exists
c910f04x12v04: mknod: '/dev/vcsa2': File exists
c910f04x12v04: mknod: '/dev/vcs3': File exists
c910f04x12v04: mknod: '/dev/vcsa3': File exists
c910f04x12v04: mknod: '/dev/vcs4': File exists
c910f04x12v04: mknod: '/dev/vcsa4': File exists
c910f04x12v04: mknod: '/dev/vcs5': File exists
c910f04x12v04: mknod: '/dev/vcsa5': File exists
c910f04x12v04: mknod: '/dev/vcs6': File exists
c910f04x12v04: mknod: '/dev/vcsa6': File exists
c910f04x12v04: installstatus installing
c910f04x12v04: [get_install_disk]Information from /proc/partitions:
c910f04x12v04: major minor  #blocks  name
c910f04x12v04:
c910f04x12v04:   11        0    1048575 sr0
c910f04x12v04:    8        0   20971520 sda
c910f04x12v04:    8        1     524288 sda1
c910f04x12v04:    8        2    2097152 sda2
c910f04x12v04:    8        3   18349056 sda3
c910f04x12v04:    7        0     420084 loop0
c910f04x12v04:    7        1    2097152 loop1
c910f04x12v04:    7        2     524288 loop2
c910f04x12v04:  253        0    2097152 dm-0
c910f04x12v04:  253        1    2097152 dm-1
c910f04x12v04:  253        2   18345984 dm-2
c910f04x12v04:
c910f04x12v04: [get_install_disk]Check the partition sda1.
c910f04x12v04: [get_install_disk]    Partition sda1 mount success.
c910f04x12v04: [get_install_disk]    The partition sda1 has kernel file.
c910f04x12v04: [get_install_disk]Check the partition sda2.
c910f04x12v04: [get_install_disk]    The disk sda had OS installed, check next partition.
c910f04x12v04: [get_install_disk]Check the partition sda3.
c910f04x12v04: [get_install_disk]    The disk sda had OS installed, check next partition.
c910f04x12v04: [get_install_disk]The disks which have kernel:
c910f04x12v04: [get_install_disk]    sda
c910f04x12v04:
c910f04x12v04: [get_install_disk]The disk sda information:
c910f04x12v04: [get_install_disk]    disk_wwn=
c910f04x12v04: [get_install_disk]    disk_path=/devices/pci0000:00/0000:00:07.0/virtio3/host2/target2:0:0/2:0:0:0/block/sda
c910f04x12v04: [get_install_disk]    disk_driver=virtio_scsi
c910f04x12v04: [get_install_disk]    Add disk: sda /devices/pci0000:00/0000:00:07.0/virtio3/host2/target2:0:0/2:0:0:0/block/sda into path thirdchoicedisks
c910f04x12v04: [get_install_disk]The install_disk is /dev/sda by sorting path and DRIVER.
c910f04x12v04:   0 logical volume(s) in volume group "xcatvg" now active
c910f04x12v04:   Logical volume "root" successfully removed
c910f04x12v04:   Volume group "xcatvg" successfully removed
c910f04x12v04: =================The Partition Scheme================
c910f04x12v04: ignoredisk --only-use=/dev/sda
c910f04x12v04: part /boot --size 512 --fstype xfs --ondisk /dev/sda
c910f04x12v04: part swap --recommended --ondisk /dev/sda
c910f04x12v04: part pv.01 --size 1 --grow --ondisk /dev/sda
c910f04x12v04: volgroup xcatvg pv.01
c910f04x12v04: logvol / --vgname=xcatvg --name=root --size 1 --grow --fstype xfs
c910f04x12v04: bootloader  --boot-drive=sda
c910f04x12v04: =====================================================
c910f04x12v04: quiet inst.repo=http://c910f04x12v02:80/install/rhels7.6/x86_64 inst.ks=http://c910f04x12v02:80/install/autoinst/c910f04x12v04 ip=dhcp inst.cmdline console=tty0 console=ttyS0,115200n8r BOOTIF=01-42-4a-0a-04-0c-04
c910f04x12v04: Running Kickstart Post-Installation script...
c910f04x12v04: Fri Jan 11 02:13:27 EST 2019 [info]: xcat.deployment: Executing post.xcat to prepare for firstbooting ...
c910f04x12v04: Fri Jan 11 02:14:00 EST 2019 [info]: xcat.deployment: trying to download postscripts from 10.4.12.2...
c910f04x12v04: Fri Jan 11 02:14:00 EST 2019 [info]: xcat.deployment: postscripts downloaded successfully
c910f04x12v04: Fri Jan 11 02:14:00 EST 2019 [info]: xcat.deployment: trying to get mypostscript from 10.4.12.2...
c910f04x12v04: systemd 219
c910f04x12v04: +PAM +AUDIT +SELINUX +IMA -APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 -SECCOMP +BLKID +ELFUTILS +KMOD +IDN
c910f04x12v04: Fri Jan 11 02:14:01 EST 2019 [info]: xcat.deployment.postscript: postscript start..: syslog
c910f04x12v04: grep: /etc/rsyslog.d/remote.conf: No such file or directory
c910f04x12v04: grep: /etc/rsyslog.d/remote.conf: No such file or directory
c910f04x12v04: Fri Jan 11 02:14:01 EST 2019 [info]: xcat.deployment.postscript: postscript end...: syslog return with 0
c910f04x12v04: Fri Jan 11 02:14:01 EST 2019 [info]: xcat.deployment.postscript: postscript start..: remoteshell
c910f04x12v04:
c910f04x12v04: Could not load host key: /etc/ssh/ssh_host_ed25519_key
c910f04x12v04: Fri Jan 11 02:14:03 EST 2019 [info]: xcat.deployment.postscript: postscript end...: remoteshell return with 0
c910f04x12v04: Fri Jan 11 02:14:03 EST 2019 [info]: xcat.deployment.postscript: postscript start..: syncfiles
c910f04x12v04: Fri Jan 11 02:14:05 EST 2019 [info]: xcat.deployment.postscript: postscript end...: syncfiles return with 0
c910f04x12v04: Fri Jan 11 02:14:05 EST 2019 [info]: xcat.deployment.postscript: postscript start..: setupntp
c910f04x12v04: 2019-01-11T07:14:05Z chronyd version 3.2 starting (+CMDMON +NTP +REFCLOCK +RTC +PRIVDROP +SCFILTER +SECHASH +SIGND +ASYNCDNS +IPV6 +DEBUG)
c910f04x12v04: 2019-01-11T07:14:05Z Wrong owner of /var/run/chrony (UID != 998)
c910f04x12v04: 2019-01-11T07:14:05Z Disabled command socket /var/run/chrony/chronyd.sock
c910f04x12v04: 2019-01-11T07:14:05Z Initial frequency 5.747 ppm
c910f04x12v04: 2019-01-11T07:14:09Z System clock wrong by -0.001541 seconds (step)
c910f04x12v04: 2019-01-11T07:14:09Z chronyd exiting
c910f04x12v04: Fri Jan 11 02:14:10 EST 2019 [info]: xcat.deployment.postscript: postscript end...: setupntp return with 0
c910f04x12v04: Fri Jan 11 02:14:10 EST 2019 [info]: xcat.deployment: finished firstboot preparation, sending request to c910f04x12v02:3002 for changing status...
c910f04x12v04: Removed /etc/systemd/system/multi-user.target.wants/NetworkManager.service.
c910f04x12v04: Removed /etc/systemd/system/dbus-org.freedesktop.NetworkManager.service.
c910f04x12v04: Removed /etc/systemd/system/dbus-org.freedesktop.nm-dispatcher.service.
c910f04x12v04: Removed /etc/systemd/system/network-online.target.wants/NetworkManager-wait-online.service.
c910f04x12v04: Fri Jan 11 02:16:49 EST 2019 [info]: xcat.deployment: Running /xcatpost/mypostscript.post
c910f04x12v04: Fri Jan 11 02:16:49 EST 2019 [info]: xcat.deployment.postbootscript: postbootscript start..: otherpkgs
c910f04x12v04: Fri Jan 11 02:16:49 EST 2019 [info]: xcat.deployment.postbootscript: postbootscript end...: otherpkgs return with 0
c910f04x12v04: Fri Jan 11 02:16:49 EST 2019 [info]: xcat.deployment.postbootscript: provision completed.(c910f04x12v04)
c910f04x12v04: Fri Jan 11 02:16:49 EST 2019 [info]: xcat.deployment: /xcatpost/mypostscript.post return
c910f04x12v04: Fri Jan 11 02:16:49 EST 2019 [info]: xcat.deployment: =============deployment ending====================

RUN:xdsh c910f04x12v04 "cat /test.synclist" [Fri Jan 11 02:19:10 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f04x12v04: /test.synclist -> /test.synclist
CHECK:rc == 0	[Pass]

RUN:if [[ -f /test.synclist.bak ]] ;then mv -f /test.synclist.bak /tmp/test.synclist;else rm -rf /test.synclist;fi [Fri Jan 11 02:19:11 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:chdef -t osimage -o __GETNODEATTR(c910f04x12v04,os)__-__GETNODEATTR(c910f04x12v04,arch)__-install-compute synclists= [Fri Jan 11 02:19:11 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.

------END::reg_linux_diskfull_installation_flat::Passed::Time:Fri Jan 11 02:19:13 2019 ::Duration::880 sec------
------Total: 1 , Failed: 0------

```

The UT result with 3 input parameters
```
[root@c910f04x12v02 commoncmd]#  ./retry_install.sh  c910f04x12v04 rhels7.6-x86_64-install-compute
Try to retry rinstall 5 times ......
Try to install c910f04x12v04 on the 1 time...
rinstall c910f04x12v04 osimage=rhels7.6-x86_64-install-compute
Provision node(s): c910f04x12v04
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
    status=booted
The tobooted is 0
PING c910f04x12v04 (10.4.12.4) 56(84) bytes of data.
64 bytes from c910f04x12v04 (10.4.12.4): icmp_seq=1 ttl=64 time=0.319 ms
64 bytes from c910f04x12v04 (10.4.12.4): icmp_seq=2 ttl=64 time=0.409 ms

--- c910f04x12v04 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1000ms
rtt min/avg/max/mdev = 0.319/0.364/0.409/0.045 ms
The pingable is 0
c910f04x12v04: Fri Jan 11 03:22:24 EST 2019
The canruncmd is 0
The provision succeed on the 1 time.....
The provision succeed......
[root@c910f04x12v02 commoncmd]#  ./retry_install.sh  c910f04x12v04 rhels7.6-x86_64-install-compute 2
Try to retry rinstall 5 times ......
Try to install c910f04x12v04 on the 1 time...
rinstall c910f04x12v04 osimage=rhels7.6-x86_64-install-compute
Provision node(s): c910f04x12v04
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
The status is not booted...
    status=booted
The tobooted is 0
PING c910f04x12v04 (10.4.12.4) 56(84) bytes of data.
64 bytes from c910f04x12v04 (10.4.12.4): icmp_seq=1 ttl=64 time=0.268 ms
64 bytes from c910f04x12v04 (10.4.12.4): icmp_seq=2 ttl=64 time=0.326 ms

--- c910f04x12v04 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1001ms
rtt min/avg/max/mdev = 0.268/0.297/0.326/0.029 ms
The pingable is 0
c910f04x12v04: Fri Jan 11 03:32:56 EST 2019
The canruncmd is 0
The provision succeed on the 1 time.....
The provision succeed......
```