### PR TITLE
add case nodeset_prescripts for Failed to parse the prescripts without action defined 

### DIFF
--- a/xCAT-test/autotest/testcase/nodeset/cases2
+++ b/xCAT-test/autotest/testcase/nodeset/cases2
@@ -1,0 +1,33 @@
+start:nodeset_prescripts
+description:This case is to run test for prescripts actions. This test case should be tested on an provisioned compute node.
+os:Linux
+label:others
+cmd:dir="/install/prescripts/";if [ ! -e "${dir}" ];then mkdir -p $dir; fi
+cmd:echo "echo all" >> /install/prescripts/test_prescripts_all.sh;chmod a+x /install/prescripts/test_prescripts_all.sh
+check:rc==0
+cmd:echo "echo boot" >> /install/prescripts/test_prescripts_boot.sh;chmod a+x /install/prescripts/test_prescripts_boot.sh
+check:rc==0
+cmd:echo "echo osimage" >> /install/prescripts/test_prescripts_osimage.sh;chmod a+x /install/prescripts/test_prescripts_osimage.sh
+check:rc==0
+cmd:pre=`lsdef -l $$CN |grep prescripts-begin|awk -F= '{print $2}'`;echo $pre >> /tmp/prescriptssave;chdef $$CN prescripts-begin="test_prescripts_all.sh|boot:test_prescripts_boot.sh|osimage:test_prescripts_osimage.sh"
+check:rc==0
+cmd:nodeset $$CN install 
+check:output=~Running begin script test_prescripts_all.sh for nodes $$CN 
+check:output!=~test_prescripts_boot.sh
+check:output!=~test_prescripts_osimage.sh
+cmd:nodeset $$CN boot
+check:rc==0
+check:output=~Running begin script test_prescripts_all.sh for nodes $$CN
+check:output=~Running begin script test_prescripts_boot.sh for nodes $$CN
+check:output!=~test_prescripts_osimage.sh
+cmd:nodeset $$CN osimage 
+check:rc==0
+check:output=~Running begin script test_prescripts_all.sh for nodes $$CN
+check:output=~Running begin script test_prescripts_osimage.sh for nodes $$CN
+check:output!=~test_prescripts_boot.sh
+cmd:rm -rf /install/prescripts/test_prescripts_all.sh /install/prescripts/test_prescripts_boot.sh /install/prescripts/test_prescripts_osimage.sh
+cmd:pre=`cat /tmp/prescriptssave`;chdef $$CN prescripts-begin=$pre 
+check:rc==0
+cmd:rm -rf /tmp/prescriptssave
+end
+


### PR DESCRIPTION
### The PR is to do task https://github.com/xcat2/xcat2-task-management/issues/425

The UT
```
------START::nodeset_prescripts::Time:Mon Jan 14 01:44:11 2019------

RUN:dir="/install/prescripts/";if [ ! -e "${dir}" ];then mkdir -p $dir; fi [Mon Jan 14 01:44:11 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "echo all" >> /install/prescripts/test_prescripts_all.sh;chmod a+x /install/prescripts/test_prescripts_all.sh [Mon Jan 14 01:44:11 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:echo "echo boot" >> /install/prescripts/test_prescripts_boot.sh;chmod a+x /install/prescripts/test_prescripts_boot.sh [Mon Jan 14 01:44:11 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:echo "echo osimage" >> /install/prescripts/test_prescripts_osimage.sh;chmod a+x /install/prescripts/test_prescripts_osimage.sh [Mon Jan 14 01:44:11 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:pre=`lsdef -l c910f03c09k14 |grep prescripts-begin|awk -F= '{print $2}'`;echo $pre >> /tmp/prescriptssave;chdef c910f03c09k14 prescripts-begin="test_prescripts_all.sh|boot:test_prescripts_boot.sh|osimage:test_prescripts_osimage.sh" [Mon Jan 14 01:44:11 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:nodeset c910f03c09k14 install [Mon Jan 14 01:44:12 2019]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: [c910f03c09k12]: The options "install", "netboot", and "statelite" have been deprecated, use "osimage=<osimage_name>" instead.
c910f03c09k12: Running begin script test_prescripts_all.sh for nodes c910f03c09k14.
c910f03c09k12: test_prescripts_all.sh: all

CHECK:output =~ Running begin script test_prescripts_all.sh for nodes c910f03c09k14	[Pass]
CHECK:output !=~ test_prescripts_boot.sh	[Pass]
CHECK:output !=~ test_prescripts_osimage.sh	[Pass]

RUN:nodeset c910f03c09k14 boot [Mon Jan 14 01:44:13 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
c910f03c09k12: Running begin script test_prescripts_all.sh for nodes c910f03c09k14.
c910f03c09k12: test_prescripts_all.sh: all

c910f03c09k12: Running begin script test_prescripts_boot.sh for nodes c910f03c09k14.
c910f03c09k12: test_prescripts_boot.sh: boot

c910f03c09k14: boot
CHECK:rc == 0	[Pass]
CHECK:output =~ Running begin script test_prescripts_all.sh for nodes c910f03c09k14	[Pass]
CHECK:output =~ Running begin script test_prescripts_boot.sh for nodes c910f03c09k14	[Pass]
CHECK:output !=~ test_prescripts_osimage.sh	[Pass]

RUN:nodeset c910f03c09k14 osimage [Mon Jan 14 01:44:13 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
c910f03c09k12: Running begin script test_prescripts_all.sh for nodes c910f03c09k14.
c910f03c09k12: test_prescripts_all.sh: all

c910f03c09k12: Running begin script test_prescripts_osimage.sh for nodes c910f03c09k14.
c910f03c09k12: test_prescripts_osimage.sh: osimage

c910f03c09k14: install ubuntu18.04.1-ppc64el-compute
CHECK:rc == 0	[Pass]
CHECK:output =~ Running begin script test_prescripts_all.sh for nodes c910f03c09k14	[Pass]
CHECK:output =~ Running begin script test_prescripts_osimage.sh for nodes c910f03c09k14	[Pass]
CHECK:output !=~ test_prescripts_boot.sh	[Pass]

RUN:rm -rf /install/prescripts/test_prescripts_all.sh /install/prescripts/test_prescripts_boot.sh /install/prescripts/test_prescripts_osimage.sh [Mon Jan 14 01:44:15 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:pre=`cat /tmp/prescriptssave`;chdef c910f03c09k14 prescripts-begin=$pre [Mon Jan 14 01:44:15 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:rm -rf /tmp/prescriptssave [Mon Jan 14 01:44:15 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::nodeset_prescripts::Passed::Time:Mon Jan 14 01:44:15 2019 ::Duration::4 sec------
------Total: 1 , Failed: 0------
```