### PR TITLE
fix issue PR #5936 resulted in remoteshell failed in rhels6.10 #5944

### DIFF
--- a/xCAT/postscripts/remoteshell
+++ b/xCAT/postscripts/remoteshell
@@ -59,11 +59,13 @@ then
 	logger -t $log_label -p local4.info "remoteshell:  setup /etc/ssh/sshd_config and ssh_config"
 	cp /etc/ssh/sshd_config /etc/ssh/sshd_config.ORIG
         #delete all occurance of the attribute and then add xCAT settings
-        echo "Match all" >>/etc/ssh/sshd_config
-        sed -i '/X11Forwarding /'d /etc/ssh/sshd_config
-        echo "X11Forwarding yes" >>/etc/ssh/sshd_config
         sed -i '/MaxStartups /'d /etc/ssh/sshd_config
         echo "MaxStartups 1024" >>/etc/ssh/sshd_config
+
+        echo "Match Host *" >>/etc/ssh/sshd_config
+        sed -i '/X11Forwarding /'d /etc/ssh/sshd_config
+        echo "X11Forwarding yes" >>/etc/ssh/sshd_config
+
 
     if [ "$SETUPFORPCM" = "1" ]; then
         if [[ $OSVER == sle* ]];then


### PR DESCRIPTION
### The PR is to fix issue https://github.com/xcat2/xcat-core/issues/5944

* rename `Match all` to `Match Host *` in `/etc/sshd_config`
* move `MaxStartups 1024` line to outside the `Match` block