### PR TITLE
add test case for issue 3602: confignetwork cannot work when regular expression is used in nics table

### DIFF
--- a/xCAT-test/autotest/testcase/confignetwork/cases1
+++ b/xCAT-test/autotest/testcase/confignetwork/cases1
@@ -16,6 +16,7 @@ cmd:chdef $$CN nicips.$$SECONDNIC="|\D+\d+\D+\d+\D+\d+\D+(\d+)|30.0.0.(\$1/1000+
 check:rc==0
 cmd:chdef $$CN nicips.$$THIRDNIC="|\D+\d+\D+\d+\D+\d+\D+(\d+)|40.0.0.(\$1/1000+8)|" nictypes.$$THIRDNIC=Ethernet nicnetworks.$$THIRDNIC="40_0_0_0-255_255_0_0"
 check:rc==0
+cmd:lsdef $$CN
 cmd:cp /etc/hosts /etc/hosts.bak
 cmd:rc==0
 cmd:makehosts $$CN

--- a/xCAT-test/autotest/testcase/confignetwork/cases1
+++ b/xCAT-test/autotest/testcase/confignetwork/cases1
@@ -1,0 +1,46 @@
+start:confignetwork_secondarynic_third_regex_updatenode
+description:this case is to verify if confignetwork could config serveral nics with regex patten.This case is to verify defect 3602.
+label:others,network
+cmd:lsdef $$CN;if [ $? -eq 0 ]; then lsdef -l $$CN -z >/tmp/CN.standa ;fi
+check:rc==0
+cmd:xdsh $$CN "rm -rf /tmp/backupnet/"
+cmd:xdsh $$CN "mkdir -p /tmp/backupnet/"
+check:rc==0
+cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network/ifcfg-* /tmp/backupnet/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network-scripts/ifcfg-* /tmp/backupnet/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /etc/network/interfaces.d/* /tmp/backupnet/";else echo "Sorry,this is not supported os"; fi
+check:rc==0
+cmd:mkdef -t network -o 30_0_0_0-255_255_0_0 net=30.0.0.0 mask=255.0.0.0 mgtifname=$$SECONDNIC
+check:rc==0
+cmd:mkdef -t network -o 40_0_0_0-255_255_0_0 net=40.0.0.0 mask=255.0.0.0 mgtifname=$$THIRDNIC
+check:rc==0
+cmd:chdef $$CN nicips.$$SECONDNIC="|\D+\d+\D+\d+\D+\d+\D+(\d+)|30.0.0.(\$1/1000+9)|" nictypes.$$SECONDNIC=Ethernet nicnetworks.$$SECONDNIC="30_0_0_0-255_255_0_0"
+check:rc==0
+cmd:chdef $$CN nicips.$$THIRDNIC="|\D+\d+\D+\d+\D+\d+\D+(\d+)|40.0.0.(\$1/1000+8)|" nictypes.$$THIRDNIC=Ethernet nicnetworks.$$THIRDNIC="40_0_0_0-255_255_0_0"
+check:rc==0
+cmd:cp /etc/hosts /etc/hosts.bak
+cmd:rc==0
+cmd:makehosts $$CN
+check:rc==0
+cmd:cat /etc/hosts
+check:output=~$$CN-$$SECONDNIC
+check:output=~$$CN-$$THIRDNIC
+cmd:updatenode $$CN -P confignetwork
+check:rc==0
+cmd:if grep SUSE /etc/*release;then xdsh $$CN "grep 30.0.0.9 /etc/sysconfig/network/ifcfg-$$SECONDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep 30.0.0.9 /etc/sysconfig/network-scripts/ifcfg-$$SECONDNIC"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep 30.0.0.9 /etc/network/interfaces.d/$$SECONDNIC";else echo "Sorry,this is not supported os"; fi
+check:output=~30.0.0.9
+cmd:if grep SUSE /etc/*release;then xdsh $$CN "grep 40.0.0.8 /etc/sysconfig/network/ifcfg-$$THIRDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep 40.0.0.8 /etc/sysconfig/network-scripts/ifcfg-$$THIRDNIC"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep 40.0.0.8 /etc/network/interfaces.d/$$THIRDNIC";else echo "Sorry,this is not supported os"; fi
+check:output=~40.0.0.8
+cmd:rmdef -t network -o 30_0_0_0-255_255_0_0
+cmd:rmdef -t network -o 40_0_0_0-255_255_0_0
+cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifcfg-$$SECONDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts/ifcfg-$$SECONDNIC"; elif grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /etc/network/interfaces.d/$$SECONDNIC";else echo "Sorry,this is not supported os"; fi
+check:rc==0
+cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifcfg-$$THIRDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts/ifcfg-$$THIRDNIC"; elif grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /etc/network/interfaces.d/$$THIRDNIC";else echo "Sorry,this is not supported os"; fi
+check:rc==0
+cmd:xdsh $$CN "ip addr del 30.0.0.9/8 dev $$SECONDNIC"
+cmd:xdsh $$CN "ip addr del 40.0.0.8/8 dev $$THIRDNIC"
+cmd:if [ -e /tmp/CN.standa ]; then rmdef $$CN; cat /tmp/CN.standa | mkdef -z; rm -rf /tmp/CN.standa; fi
+check:rc==0
+cmd:mv -f /etc/hosts.bak /etc/hosts
+cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network-scripts/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/network/interfaces.d/";else echo "Sorry,this is not supported os"; fi
+cmd:xdsh $$CN "rm -rf /tmp/backupnet/"
+end
+


### PR DESCRIPTION
### The PR is to do task https://github.com/xcat2/xcat2-task-management/issues/87
The test case cover the test for confignetwork cannot work when regular expression is used in nics table

The nics table for test
```
#node,nicips,nichostnamesuffixes,nichostnameprefixes,nictypes,niccustomscripts,nicnetworks,nicaliases,nicextraparams,nicdevices,nicsadapter,comments,disable
"c910f02c02p19","eth1!|\D+\d+\D+\d+\D+\d+\D+(\d+)|30.0.0.($1/1000+9)|",,,"eth1!Ethernet",,"eth1!30_0_0_0-255_255_0_0",,,,,,
```


The UT
```
------START::confignetwork_secondarynic_third_regex_updatenode::Time:Tue Jan 15 01:48:16 2019------

RUN:lsdef c910f02c02p19;if [ $? -eq 0 ]; then lsdef -l c910f02c02p19 -z >/tmp/CN.standa ;fi [Tue Jan 15 01:48:16 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
Object name: c910f02c02p19
    arch=ppc64
    cons=hmc
    conserver=c910f02c02p17
    currchain=boot
    currstate=boot
    groups=regex1
    hcp=c910hmc01
    hwtype=lpar
    id=19
    mac=da:08:47:20:93:03
    mgt=hmc
    monserver=c910f02c02p17
    netboot=grub2
    nodetype=ppc,osi
    os=rhels7.6
    parent=c910f02fsp02
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
    pprofile=c910f02c02p19
    profile=compute
    provmethod=rhels7.6-ppc64-install-compute
    status=booted
    statustime=01-14-2019 03:14:10
    tftpserver=c910f02c02p16
    updatestatus=failed
    updatestatustime=01-14-2019 03:17:29
    xcatmaster=c910f02c02p16
CHECK:rc == 0	[Pass]

RUN:xdsh c910f02c02p19 "rm -rf /tmp/backupnet/" [Tue Jan 15 01:48:18 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:xdsh c910f02c02p19 "mkdir -p /tmp/backupnet/" [Tue Jan 15 01:48:18 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:if grep SUSE /etc/*release;then xdsh c910f02c02p19 "cp -f /etc/sysconfig/network/ifcfg-* /tmp/backupnet/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh c910f02c02p19 "cp -f /etc/sysconfig/network-scripts/ifcfg-* /tmp/backupnet/"; elif grep Ubuntu /etc/*release;then xdsh c910f02c02p19 "cp -f /etc/network/interfaces.d/* /tmp/backupnet/";else echo "Sorry,this is not supported os"; fi [Tue Jan 15 01:48:19 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
/etc/os-release:NAME="Red Hat Enterprise Linux Server"
/etc/os-release:PRETTY_NAME="Red Hat Enterprise Linux Server 7.6 (Maipo)"
/etc/os-release:REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
/etc/os-release:REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
/etc/redhat-release:Red Hat Enterprise Linux Server release 7.6 (Maipo)
/etc/system-release:Red Hat Enterprise Linux Server release 7.6 (Maipo)
CHECK:rc == 0	[Pass]

RUN:mkdef -t network -o 30_0_0_0-255_255_0_0 net=30.0.0.0 mask=255.0.0.0 mgtifname=eth1 [Tue Jan 15 01:48:20 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:mkdef -t network -o 40_0_0_0-255_255_0_0 net=40.0.0.0 mask=255.0.0.0 mgtifname=eth2 [Tue Jan 15 01:48:21 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:chdef c910f02c02p19 nicips.eth1="|\D+\d+\D+\d+\D+\d+\D+(\d+)|30.0.0.(\$1/1000+9)|" nictypes.eth1=Ethernet nicnetworks.eth1="30_0_0_0-255_255_0_0" [Tue Jan 15 01:48:21 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:chdef c910f02c02p19 nicips.eth2="|\D+\d+\D+\d+\D+\d+\D+(\d+)|40.0.0.(\$1/1000+8)|" nictypes.eth2=Ethernet nicnetworks.eth2="40_0_0_0-255_255_0_0" [Tue Jan 15 01:48:22 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:lsdef c910f02c02p19 [Tue Jan 15 01:48:23 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Object name: c910f02c02p19
    arch=ppc64
    cons=hmc
    conserver=c910f02c02p17
    currchain=boot
    currstate=boot
    groups=regex1
    hcp=c910hmc01
    hwtype=lpar
    id=19
    mac=da:08:47:20:93:03
    mgt=hmc
    monserver=c910f02c02p17
    netboot=grub2
    nicips.eth2=40.0.0.8
    nicips.eth1=30.0.0.9
    nicnetworks.eth2=40_0_0_0-255_255_0_0
    nicnetworks.eth1=30_0_0_0-255_255_0_0
    nictypes.eth2=Ethernet
    nictypes.eth1=Ethernet
    nodetype=ppc,osi
    os=rhels7.6
    parent=c910f02fsp02
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
    pprofile=c910f02c02p19
    profile=compute
    provmethod=rhels7.6-ppc64-install-compute
    status=booted
    statustime=01-14-2019 03:14:10
    tftpserver=c910f02c02p16
    updatestatus=failed
    updatestatustime=01-14-2019 03:17:29
    xcatmaster=c910f02c02p16

RUN:cp /etc/hosts /etc/hosts.bak [Tue Jan 15 01:48:23 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:rc==0 [Tue Jan 15 01:48:23 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:makehosts c910f02c02p19 [Tue Jan 15 01:48:23 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:cat /etc/hosts [Tue Jan 15 01:48:23 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
::1         localhost localhost.localdomain localhost6 localhost6.localdomain6

216.34.181.60 sourceforge.net
9.56.248.25 pokgsa.ibm.com

############################################################
# c910 xCAT Private network system
# network 10.0.0.0
# netmask 255.0.0.0
# gateway 10.255.255.254
############################################################

10.0.0.101      c910loginx01    c910loginx01.pok.stglabs.ibm.com
10.0.0.102      c910loginx02    c910loginx02.pok.stglabs.ibm.com
10.0.0.103      c910loginx03    c910loginx03.pok.stglabs.ibm.com
10.0.0.104      c910loginx04    c910loginx04.pok.stglabs.ibm.com
10.0.0.105      c910loginp05    c910loginp05.pok.stglabs.ibm.com
10.0.0.106      c910loginp06    c910loginp06.pok.stglabs.ibm.com
10.0.0.107      c910loginp07    c910loginp07.pok.stglabs.ibm.com
10.0.0.108      c910loginp08    c910loginp08.pok.stglabs.ibm.com
10.0.0.109      c910loginp09    c910loginp09.pok.stglabs.ibm.com
10.0.0.110      c910loginp10    c910loginp10.pok.stglabs.ibm.com

10.0.0.111      c910mnx01       c910mnx01.pok.stglabs.ibm.com
10.0.0.112      c910mnp02       c910mnp02.pok.stglabs.ibm.com
10.0.0.113      c910mnx03       c910mnx03.pok.stglabs.ibm.com
10.0.0.114      c910mnx04       c910mnx04.pok.stglabs.ibm.com
10.0.0.115      c910mnx05       c910mnx05.pok.stglabs.ibm.com
10.0.0.116      c910mnx06       c910mnx06.pok.stglabs.ibm.com
10.0.0.117      c910mnx07       c910mnx07.pok.stglabs.ibm.com
10.0.0.118      c910mnx08       c910mnx08.pok.stglabs.ibm.com
10.0.0.119      c910mnx09       c910mnx09.pok.stglabs.ibm.com
10.0.0.120      c910mnx10       c910mnx10.pok.stglabs.ibm.com

10.0.0.121      c910gpfs01      c910gpfs01.pok.stglabs.ibm.com
10.0.0.122      c910gpfs02      c910gpfs02.pok.stglabs.ibm.com
10.0.0.123      c910gpfs03      c910gpfs03.pok.stglabs.ibm.com
10.0.0.124      c910gpfs04      c910gpfs04.pok.stglabs.ibm.com
10.0.0.125      c910gpfs05      c910gpfs05.pok.stglabs.ibm.com
10.0.0.126      c910gpfs06      c910gpfs06.pok.stglabs.ibm.com
10.0.0.127      c910gpfs07      c910gpfs07.pok.stglabs.ibm.com
10.0.0.128      c910gpfs08      c910gpfs08.pok.stglabs.ibm.com
10.0.0.129      c910gpfs09      c910gpfs09.pok.stglabs.ibm.com
10.0.0.130      c910gpfs10      c910gpfs10.pok.stglabs.ibm.com

10.0.0.201      c910hmc01       c910hmc01.pok.stglabs.ibm.com
10.0.0.202      c910hmc02       c910hmc02.pok.stglabs.ibm.com
10.0.0.203      c910hmc03       c910hmc03.pok.stglabs.ibm.com
10.0.0.204      c910hmc04       c910hmc04.pok.stglabs.ibm.com
10.0.0.205      c910hmc05       c910hmc05.pok.stglabs.ibm.com

10.2.1.1        c910f02c01v01   c910f02c01v01.pok.stglabs.ibm.com   f02c01v01     f2c1v1
10.2.1.2        c910f02c01p02   c910f02c01p02.pok.stglabs.ibm.com   f02c01p02     f2c1p2
10.2.1.3        c910f02c01p03   c910f02c01p03.pok.stglabs.ibm.com   f02c01p03     f2c1p3
10.2.1.4        c910f02c01p04   c910f02c01p04.pok.stglabs.ibm.com   f02c01p04     f2c1p4
10.2.1.5        c910f02c01p05   c910f02c01p05.pok.stglabs.ibm.com   f02c01p05     f2c1p5
10.2.1.6        c910f02c01p06   c910f02c01p06.pok.stglabs.ibm.com   f02c01p06     f2c1p6
10.2.1.7        c910f02c01p07   c910f02c01p07.pok.stglabs.ibm.com   f02c01p07     f2c1p7
10.2.1.8        c910f02c01p08   c910f02c01p08.pok.stglabs.ibm.com   f02c01p08     f2c1p8
10.2.1.9        c910f02c01p09   c910f02c01p09.pok.stglabs.ibm.com   f02c01p09     f2c1p9
10.2.1.10       c910f02c01p10   c910f02c01p10.pok.stglabs.ibm.com   f02c01p10     f2c1p10
10.2.1.11       c910f02c01p11   c910f02c01p11.pok.stglabs.ibm.com   f02c01p11     f2c1p11
10.2.1.12       c910f02c01p12   c910f02c01p12.pok.stglabs.ibm.com   f02c01p12     f2c1p12
10.2.1.13       c910f02c01p13   c910f02c01p13.pok.stglabs.ibm.com   f02c01p13     f2c1p13
10.2.1.14       c910f02c01p14   c910f02c01p14.pok.stglabs.ibm.com   f02c01p14     f2c1p14
10.2.1.15       c910f02c01p15   c910f02c01p15.pok.stglabs.ibm.com   f02c01p15     f2c1p15
10.2.1.16       c910f02c01p16   c910f02c01p16.pok.stglabs.ibm.com   f02c01p16     f2c1p16
10.2.1.17       c910f02c01p17   c910f02c01p17.pok.stglabs.ibm.com   f02c01p17     f2c1p17
10.2.1.18       c910f02c01p18   c910f02c01p18.pok.stglabs.ibm.com   f02c01p18     f2c1p18
10.2.1.19       c910f02c01p19   c910f02c01p19.pok.stglabs.ibm.com   f02c01p19     f2c1p19
10.2.1.20       c910f02c01p20   c910f02c01p20.pok.stglabs.ibm.com   f02c01p20     f2c1p20
10.2.1.21       c910f02c01p21   c910f02c01p21.pok.stglabs.ibm.com   f02c01p21     f2c1p21
10.2.1.22       c910f02c01p22   c910f02c01p22.pok.stglabs.ibm.com   f02c01p22     f2c1p22
10.2.1.23       c910f02c01p23   c910f02c01p23.pok.stglabs.ibm.com   f02c01p23     f2c1p23
10.2.1.24       c910f02c01p24   c910f02c01p24.pok.stglabs.ibm.com   f02c01p24     f2c1p24
10.2.1.25       c910f02c01p25   c910f02c01p25.pok.stglabs.ibm.com   f02c01p25     f2c1p25
10.2.1.26       c910f02c01p26   c910f02c01p26.pok.stglabs.ibm.com   f02c01p26     f2c1p26
10.2.1.27       c910f02c01p27   c910f02c01p27.pok.stglabs.ibm.com   f02c01p27     f2c1p27
10.2.1.28       c910f02c01p28   c910f02c01p28.pok.stglabs.ibm.com   f02c01p28     f2c1p28
10.2.1.29       c910f02c01p29   c910f02c01p29.pok.stglabs.ibm.com   f02c01p29     f2c1p29
10.2.1.30       c910f02c01p30   c910f02c01p30.pok.stglabs.ibm.com   f02c01p30     f2c1p30
10.2.1.31       c910f02c01p31   c910f02c01p31.pok.stglabs.ibm.com   f02c01p31     f2c1p31

10.2.2.1        c910f02c02v01   c910f02c02v01.pok.stglabs.ibm.com   f02c02v01     f2c2v1
10.2.2.2        c910f02c02p02   c910f02c02p02.pok.stglabs.ibm.com   f02c02p02     f2c2p2
10.2.2.3        c910f02c02p03   c910f02c02p03.pok.stglabs.ibm.com   f02c02p03     f2c2p3
10.2.2.4        c910f02c02p04   c910f02c02p04.pok.stglabs.ibm.com   f02c02p04     f2c2p4
10.2.2.5        c910f02c02p05   c910f02c02p05.pok.stglabs.ibm.com   f02c02p05     f2c2p5
10.2.2.6        c910f02c02p06   c910f02c02p06.pok.stglabs.ibm.com   f02c02p06     f2c2p6
10.2.2.7        c910f02c02p07   c910f02c02p07.pok.stglabs.ibm.com   f02c02p07     f2c2p7
10.2.2.8        c910f02c02p08   c910f02c02p08.pok.stglabs.ibm.com   f02c02p08     f2c2p8
10.2.2.9        c910f02c02p09   c910f02c02p09.pok.stglabs.ibm.com   f02c02p09     f2c2p9
10.2.2.10       c910f02c02p10   c910f02c02p10.pok.stglabs.ibm.com   f02c02p10     f2c2p10
10.2.2.11       c910f02c02p11   c910f02c02p11.pok.stglabs.ibm.com   f02c02p11     f2c2p11
10.2.2.12       c910f02c02p12   c910f02c02p12.pok.stglabs.ibm.com   f02c02p12     f2c2p12
10.2.2.13       c910f02c02p13   c910f02c02p13.pok.stglabs.ibm.com   f02c02p13     f2c2p13
10.2.2.14       c910f02c02p14   c910f02c02p14.pok.stglabs.ibm.com   f02c02p14     f2c2p14
10.2.2.15       c910f02c02p15   c910f02c02p15.pok.stglabs.ibm.com   f02c02p15     f2c2p15
10.2.2.16       c910f02c02p16   c910f02c02p16.pok.stglabs.ibm.com   f02c02p16     f2c2p16
10.2.2.17       c910f02c02p17   c910f02c02p17.pok.stglabs.ibm.com   f02c02p17     f2c2p17
10.2.2.18       c910f02c02p18   c910f02c02p18.pok.stglabs.ibm.com   f02c02p18     f2c2p18
10.2.2.19 c910f02c02p19 c910f02c02p19.pok.stglabs.ibm.com
10.2.2.20       c910f02c02p20   c910f02c02p20.pok.stglabs.ibm.com   f02c02p20     f2c2p20
10.2.2.21       c910f02c02p21   c910f02c02p21.pok.stglabs.ibm.com   f02c02p21     f2c2p21
10.2.2.22       c910f02c02p22   c910f02c02p22.pok.stglabs.ibm.com   f02c02p22     f2c2p22
10.2.2.23       c910f02c02p23   c910f02c02p23.pok.stglabs.ibm.com   f02c02p23     f2c2p23
10.2.2.24       c910f02c02p24   c910f02c02p24.pok.stglabs.ibm.com   f02c02p24     f2c2p24
10.2.2.25       c910f02c02p25   c910f02c02p25.pok.stglabs.ibm.com   f02c02p25     f2c2p25
10.2.2.26       c910f02c02p26   c910f02c02p26.pok.stglabs.ibm.com   f02c02p26     f2c2p26
10.2.2.27       c910f02c02p27   c910f02c02p27.pok.stglabs.ibm.com   f02c02p27     f2c2p27
10.2.2.28       c910f02c02p28   c910f02c02p28.pok.stglabs.ibm.com   f02c02p28     f2c2p28
10.2.2.29       c910f02c02p29   c910f02c02p29.pok.stglabs.ibm.com   f02c02p29     f2c2p29
10.2.2.30       c910f02c02p30   c910f02c02p30.pok.stglabs.ibm.com   f02c02p30     f2c2p30
10.2.2.31       c910f02c02p31   c910f02c02p31.pok.stglabs.ibm.com   f02c02p31     f2c2p31

10.2.3.1        c910f02c03v01   c910f02c03v01.pok.stglabs.ibm.com   f02c03v01     f2c3v1
10.2.3.2        c910f02c03p02   c910f02c03p02.pok.stglabs.ibm.com   f02c03p02     f2c3p2
10.2.3.3        c910f02c03p03   c910f02c03p03.pok.stglabs.ibm.com   f02c03p03     f2c3p3
10.2.3.4        c910f02c03p04   c910f02c03p04.pok.stglabs.ibm.com   f02c03p04     f2c3p4
10.2.3.5        c910f02c03p05   c910f02c03p05.pok.stglabs.ibm.com   f02c03p05     f2c3p5
10.2.3.6        c910f02c03p06   c910f02c03p06.pok.stglabs.ibm.com   f02c03p06     f2c3p6
10.2.3.7        c910f02c03p07   c910f02c03p07.pok.stglabs.ibm.com   f02c03p07     f2c3p7
10.2.3.8        c910f02c03p08   c910f02c03p08.pok.stglabs.ibm.com   f02c03p08     f2c3p8
10.2.3.9        c910f02c03p09   c910f02c03p09.pok.stglabs.ibm.com   f02c03p09     f2c3p9
10.2.3.10       c910f02c03p10   c910f02c03p10.pok.stglabs.ibm.com   f02c03p10     f2c3p10
10.2.3.11       c910f02c03p11   c910f02c03p11.pok.stglabs.ibm.com   f02c03p11     f2c3p11
10.2.3.12       c910f02c03p12   c910f02c03p12.pok.stglabs.ibm.com   f02c03p12     f2c3p12
10.2.3.13       c910f02c03p13   c910f02c03p13.pok.stglabs.ibm.com   f02c03p13     f2c3p13
10.2.3.14       c910f02c03p14   c910f02c03p14.pok.stglabs.ibm.com   f02c03p14     f2c3p14
10.2.3.15       c910f02c03p15   c910f02c03p15.pok.stglabs.ibm.com   f02c03p15     f2c3p15
10.2.3.16       c910f02c03p16   c910f02c03p16.pok.stglabs.ibm.com   f02c03p16     f2c3p16
10.2.3.17       c910f02c03p17   c910f02c03p17.pok.stglabs.ibm.com   f02c03p17     f2c3p17
10.2.3.18       c910f02c03p18   c910f02c03p18.pok.stglabs.ibm.com   f02c03p18     f2c3p18
10.2.3.19       c910f02c03p19   c910f02c03p19.pok.stglabs.ibm.com   f02c03p19     f2c3p19
10.2.3.20       c910f02c03p20   c910f02c03p20.pok.stglabs.ibm.com   f02c03p20     f2c3p20
10.2.3.21       c910f02c03p21   c910f02c03p21.pok.stglabs.ibm.com   f02c03p21     f2c3p21
10.2.3.22       c910f02c03p22   c910f02c03p22.pok.stglabs.ibm.com   f02c03p22     f2c3p22
10.2.3.23       c910f02c03p23   c910f02c03p23.pok.stglabs.ibm.com   f02c03p23     f2c3p23
10.2.3.24       c910f02c03p24   c910f02c03p24.pok.stglabs.ibm.com   f02c03p24     f2c3p24
10.2.3.25       c910f02c03p25   c910f02c03p25.pok.stglabs.ibm.com   f02c03p25     f2c3p25
10.2.3.26       c910f02c03p26   c910f02c03p26.pok.stglabs.ibm.com   f02c03p26     f2c3p26
10.2.3.27       c910f02c03p27   c910f02c03p27.pok.stglabs.ibm.com   f02c03p27     f2c3p27
10.2.3.28       c910f02c03p28   c910f02c03p28.pok.stglabs.ibm.com   f02c03p28     f2c3p28
10.2.3.29       c910f02c03p29   c910f02c03p29.pok.stglabs.ibm.com   f02c03p29     f2c3p29
10.2.3.30       c910f02c03p30   c910f02c03p30.pok.stglabs.ibm.com   f02c03p30     f2c3p30
10.2.3.31       c910f02c03p31   c910f02c03p31.pok.stglabs.ibm.com   f02c03p31     f2c3p31

10.2.4.1        c910f02c04v01   c910f02c04v01.pok.stglabs.ibm.com   f02c04v01     f2c4v1
10.2.4.2        c910f02c04p02   c910f02c04p02.pok.stglabs.ibm.com   f02c04p02     f2c4p2
10.2.4.3        c910f02c04p03   c910f02c04p03.pok.stglabs.ibm.com   f02c04p03     f2c4p3
10.2.4.4        c910f02c04p04   c910f02c04p04.pok.stglabs.ibm.com   f02c04p04     f2c4p4
10.2.4.5        c910f02c04p05   c910f02c04p05.pok.stglabs.ibm.com   f02c04p05     f2c4p5
10.2.4.6        c910f02c04p06   c910f02c04p06.pok.stglabs.ibm.com   f02c04p06     f2c4p6
10.2.4.7        c910f02c04p07   c910f02c04p07.pok.stglabs.ibm.com   f02c04p07     f2c4p7
10.2.4.8        c910f02c04p08   c910f02c04p08.pok.stglabs.ibm.com   f02c04p08     f2c4p8
10.2.4.9        c910f02c04p09   c910f02c04p09.pok.stglabs.ibm.com   f02c04p09     f2c4p9
10.2.4.10       c910f02c04p10   c910f02c04p10.pok.stglabs.ibm.com   f02c04p10     f2c4p10
10.2.4.11       c910f02c04p11   c910f02c04p11.pok.stglabs.ibm.com   f02c04p11     f2c4p11
10.2.4.12       c910f02c04p12   c910f02c04p12.pok.stglabs.ibm.com   f02c04p12     f2c4p12
10.2.4.13       c910f02c04p13   c910f02c04p13.pok.stglabs.ibm.com   f02c04p13     f2c4p13
10.2.4.14       c910f02c04p14   c910f02c04p14.pok.stglabs.ibm.com   f02c04p14     f2c4p14
10.2.4.15       c910f02c04p15   c910f02c04p15.pok.stglabs.ibm.com   f02c04p15     f2c4p15
10.2.4.16       c910f02c04p16   c910f02c04p16.pok.stglabs.ibm.com   f02c04p16     f2c4p16
10.2.4.17       c910f02c04p17   c910f02c04p17.pok.stglabs.ibm.com   f02c04p17     f2c4p17
10.2.4.18       c910f02c04p18   c910f02c04p18.pok.stglabs.ibm.com   f02c04p18     f2c4p18
10.2.4.19       c910f02c04p19   c910f02c04p19.pok.stglabs.ibm.com   f02c04p19     f2c4p19
10.2.4.20       c910f02c04p20   c910f02c04p20.pok.stglabs.ibm.com   f02c04p20     f2c4p20
10.2.4.21       c910f02c04p21   c910f02c04p21.pok.stglabs.ibm.com   f02c04p21     f2c4p21
10.2.4.22       c910f02c04p22   c910f02c04p22.pok.stglabs.ibm.com   f02c04p22     f2c4p22
10.2.4.23       c910f02c04p23   c910f02c04p23.pok.stglabs.ibm.com   f02c04p23     f2c4p23
10.2.4.24       c910f02c04p24   c910f02c04p24.pok.stglabs.ibm.com   f02c04p24     f2c4p24
10.2.4.25       c910f02c04p25   c910f02c04p25.pok.stglabs.ibm.com   f02c04p25     f2c4p25
10.2.4.26       c910f02c04p26   c910f02c04p26.pok.stglabs.ibm.com   f02c04p26     f2c4p26
10.2.4.27       c910f02c04p27   c910f02c04p27.pok.stglabs.ibm.com   f02c04p27     f2c4p27
10.2.4.28       c910f02c04p28   c910f02c04p28.pok.stglabs.ibm.com   f02c04p28     f2c4p28
10.2.4.29       c910f02c04p29   c910f02c04p29.pok.stglabs.ibm.com   f02c04p29     f2c4p29
10.2.4.30       c910f02c04p30   c910f02c04p30.pok.stglabs.ibm.com   f02c04p30     f2c4p30
10.2.4.31       c910f02c04p31   c910f02c04p31.pok.stglabs.ibm.com   f02c04p31     f2c4p31

10.2.5.1        c910f02c05v01   c910f02c05v01.pok.stglabs.ibm.com   f02c05v01     f2c5v1
10.2.5.2        c910f02c05p02   c910f02c05p02.pok.stglabs.ibm.com   f02c05p02     f2c5p2
10.2.5.3        c910f02c05p03   c910f02c05p03.pok.stglabs.ibm.com   f02c05p03     f2c5p3
10.2.5.4        c910f02c05p04   c910f02c05p04.pok.stglabs.ibm.com   f02c05p04     f2c5p4
10.2.5.5        c910f02c05p05   c910f02c05p05.pok.stglabs.ibm.com   f02c05p05     f2c5p5
10.2.5.6        c910f02c05p06   c910f02c05p06.pok.stglabs.ibm.com   f02c05p06     f2c5p6
10.2.5.7        c910f02c05p07   c910f02c05p07.pok.stglabs.ibm.com   f02c05p07     f2c5p7
10.2.5.8        c910f02c05p08   c910f02c05p08.pok.stglabs.ibm.com   f02c05p08     f2c5p8
10.2.5.9        c910f02c05p09   c910f02c05p09.pok.stglabs.ibm.com   f02c05p09     f2c5p9
10.2.5.10       c910f02c05p10   c910f02c05p10.pok.stglabs.ibm.com   f02c05p10     f2c5p10
10.2.5.11       c910f02c05p11   c910f02c05p11.pok.stglabs.ibm.com   f02c05p11     f2c5p11
10.2.5.12       c910f02c05p12   c910f02c05p12.pok.stglabs.ibm.com   f02c05p12     f2c5p12
10.2.5.13       c910f02c05p13   c910f02c05p13.pok.stglabs.ibm.com   f02c05p13     f2c5p13
10.2.5.14       c910f02c05p14   c910f02c05p14.pok.stglabs.ibm.com   f02c05p14     f2c5p14
10.2.5.15       c910f02c05p15   c910f02c05p15.pok.stglabs.ibm.com   f02c05p15     f2c5p15
10.2.5.16       c910f02c05p16   c910f02c05p16.pok.stglabs.ibm.com   f02c05p16     f2c5p16
10.2.5.17       c910f02c05p17   c910f02c05p17.pok.stglabs.ibm.com   f02c05p17     f2c5p17
10.2.5.18       c910f02c05p18   c910f02c05p18.pok.stglabs.ibm.com   f02c05p18     f2c5p18
10.2.5.19       c910f02c05p19   c910f02c05p19.pok.stglabs.ibm.com   f02c05p19     f2c5p19
10.2.5.20       c910f02c05p20   c910f02c05p20.pok.stglabs.ibm.com   f02c05p20     f2c5p20
10.2.5.21       c910f02c05p21   c910f02c05p21.pok.stglabs.ibm.com   f02c05p21     f2c5p21
10.2.5.22       c910f02c05p22   c910f02c05p22.pok.stglabs.ibm.com   f02c05p22     f2c5p22
10.2.5.23       c910f02c05p23   c910f02c05p23.pok.stglabs.ibm.com   f02c05p23     f2c5p23
10.2.5.24       c910f02c05p24   c910f02c05p24.pok.stglabs.ibm.com   f02c05p24     f2c5p24
10.2.5.25       c910f02c05p25   c910f02c05p25.pok.stglabs.ibm.com   f02c05p25     f2c5p25
10.2.5.26       c910f02c05p26   c910f02c05p26.pok.stglabs.ibm.com   f02c05p26     f2c5p26
10.2.5.27       c910f02c05p27   c910f02c05p27.pok.stglabs.ibm.com   f02c05p27     f2c5p27
10.2.5.28       c910f02c05p28   c910f02c05p28.pok.stglabs.ibm.com   f02c05p28     f2c5p28
10.2.5.29       c910f02c05p29   c910f02c05p29.pok.stglabs.ibm.com   f02c05p29     f2c5p29
10.2.5.30       c910f02c05p30   c910f02c05p30.pok.stglabs.ibm.com   f02c05p30     f2c5p30
10.2.5.31       c910f02c05p31   c910f02c05p31.pok.stglabs.ibm.com   f02c05p31     f2c5p31

10.2.6.1        c910f02c06v01   c910f02c06v01.pok.stglabs.ibm.com   f02c06v01     f2c6v1
10.2.6.2        c910f02c06p02   c910f02c06p02.pok.stglabs.ibm.com   f02c06p02     f2c6p2
10.2.6.3        c910f02c06p03   c910f02c06p03.pok.stglabs.ibm.com   f02c06p03     f2c6p3
10.2.6.4        c910f02c06p04   c910f02c06p04.pok.stglabs.ibm.com   f02c06p04     f2c6p4
10.2.6.5        c910f02c06p05   c910f02c06p05.pok.stglabs.ibm.com   f02c06p05     f2c6p5
10.2.6.6        c910f02c06p06   c910f02c06p06.pok.stglabs.ibm.com   f02c06p06     f2c6p6
10.2.6.7        c910f02c06p07   c910f02c06p07.pok.stglabs.ibm.com   f02c06p07     f2c6p7
10.2.6.8        c910f02c06p08   c910f02c06p08.pok.stglabs.ibm.com   f02c06p08     f2c6p8
10.2.6.9        c910f02c06p09   c910f02c06p09.pok.stglabs.ibm.com   f02c06p09     f2c6p9
10.2.6.10       c910f02c06p10   c910f02c06p10.pok.stglabs.ibm.com   f02c06p10     f2c6p10
10.2.6.11       c910f02c06p11   c910f02c06p11.pok.stglabs.ibm.com   f02c06p11     f2c6p11
10.2.6.12       c910f02c06p12   c910f02c06p12.pok.stglabs.ibm.com   f02c06p12     f2c6p12
10.2.6.13       c910f02c06p13   c910f02c06p13.pok.stglabs.ibm.com   f02c06p13     f2c6p13
10.2.6.14       c910f02c06p14   c910f02c06p14.pok.stglabs.ibm.com   f02c06p14     f2c6p14
10.2.6.15       c910f02c06p15   c910f02c06p15.pok.stglabs.ibm.com   f02c06p15     f2c6p15
10.2.6.16       c910f02c06p16   c910f02c06p16.pok.stglabs.ibm.com   f02c06p16     f2c6p16
10.2.6.17       c910f02c06p17   c910f02c06p17.pok.stglabs.ibm.com   f02c06p17     f2c6p17
10.2.6.18       c910f02c06p18   c910f02c06p18.pok.stglabs.ibm.com   f02c06p18     f2c6p18
10.2.6.19       c910f02c06p19   c910f02c06p19.pok.stglabs.ibm.com   f02c06p19     f2c6p19
10.2.6.20       c910f02c06p20   c910f02c06p20.pok.stglabs.ibm.com   f02c06p20     f2c6p20
10.2.6.21       c910f02c06p21   c910f02c06p21.pok.stglabs.ibm.com   f02c06p21     f2c6p21
10.2.6.22       c910f02c06p22   c910f02c06p22.pok.stglabs.ibm.com   f02c06p22     f2c6p22
10.2.6.23       c910f02c06p23   c910f02c06p23.pok.stglabs.ibm.com   f02c06p23     f2c6p23
10.2.6.24       c910f02c06p24   c910f02c06p24.pok.stglabs.ibm.com   f02c06p24     f2c6p24
10.2.6.25       c910f02c06p25   c910f02c06p25.pok.stglabs.ibm.com   f02c06p25     f2c6p25
10.2.6.26       c910f02c06p26   c910f02c06p26.pok.stglabs.ibm.com   f02c06p26     f2c6p26
10.2.6.27       c910f02c06p27   c910f02c06p27.pok.stglabs.ibm.com   f02c06p27     f2c6p27
10.2.6.28       c910f02c06p28   c910f02c06p28.pok.stglabs.ibm.com   f02c06p28     f2c6p28
10.2.6.29       c910f02c06p29   c910f02c06p29.pok.stglabs.ibm.com   f02c06p29     f2c6p29
10.2.6.30       c910f02c06p30   c910f02c06p30.pok.stglabs.ibm.com   f02c06p30     f2c6p30
10.2.6.31       c910f02c06p31   c910f02c06p31.pok.stglabs.ibm.com   f02c06p31     f2c6p31

10.2.7.1        c910f02c07v01   c910f02c07v01.pok.stglabs.ibm.com   f02c07v01     f2c7v1
10.2.7.2        c910f02c07p02   c910f02c07p02.pok.stglabs.ibm.com   f02c07p02     f2c7p2
10.2.7.3        c910f02c07p03   c910f02c07p03.pok.stglabs.ibm.com   f02c07p03     f2c7p3
10.2.7.4        c910f02c07p04   c910f02c07p04.pok.stglabs.ibm.com   f02c07p04     f2c7p4
10.2.7.5        c910f02c07p05   c910f02c07p05.pok.stglabs.ibm.com   f02c07p05     f2c7p5
10.2.7.6        c910f02c07p06   c910f02c07p06.pok.stglabs.ibm.com   f02c07p06     f2c7p6
10.2.7.7        c910f02c07p07   c910f02c07p07.pok.stglabs.ibm.com   f02c07p07     f2c7p7
10.2.7.8        c910f02c07p08   c910f02c07p08.pok.stglabs.ibm.com   f02c07p08     f2c7p8
10.2.7.9        c910f02c07p09   c910f02c07p09.pok.stglabs.ibm.com   f02c07p09     f2c7p9
10.2.7.10       c910f02c07p10   c910f02c07p10.pok.stglabs.ibm.com   f02c07p10     f2c7p10
10.2.7.11       c910f02c07p11   c910f02c07p11.pok.stglabs.ibm.com   f02c07p11     f2c7p11
10.2.7.12       c910f02c07p12   c910f02c07p12.pok.stglabs.ibm.com   f02c07p12     f2c7p12
10.2.7.13       c910f02c07p13   c910f02c07p13.pok.stglabs.ibm.com   f02c07p13     f2c7p13
10.2.7.14       c910f02c07p14   c910f02c07p14.pok.stglabs.ibm.com   f02c07p14     f2c7p14
10.2.7.15       c910f02c07p15   c910f02c07p15.pok.stglabs.ibm.com   f02c07p15     f2c7p15
10.2.7.16       c910f02c07p16   c910f02c07p16.pok.stglabs.ibm.com   f02c07p16     f2c7p16
10.2.7.17       c910f02c07p17   c910f02c07p17.pok.stglabs.ibm.com   f02c07p17     f2c7p17
10.2.7.18       c910f02c07p18   c910f02c07p18.pok.stglabs.ibm.com   f02c07p18     f2c7p18
10.2.7.19       c910f02c07p19   c910f02c07p19.pok.stglabs.ibm.com   f02c07p19     f2c7p19
10.2.7.20       c910f02c07p20   c910f02c07p20.pok.stglabs.ibm.com   f02c07p20     f2c7p20
10.2.7.21       c910f02c07p21   c910f02c07p21.pok.stglabs.ibm.com   f02c07p21     f2c7p21
10.2.7.22       c910f02c07p22   c910f02c07p22.pok.stglabs.ibm.com   f02c07p22     f2c7p22
10.2.7.23       c910f02c07p23   c910f02c07p23.pok.stglabs.ibm.com   f02c07p23     f2c7p23
10.2.7.24       c910f02c07p24   c910f02c07p24.pok.stglabs.ibm.com   f02c07p24     f2c7p24
10.2.7.25       c910f02c07p25   c910f02c07p25.pok.stglabs.ibm.com   f02c07p25     f2c7p25
10.2.7.26       c910f02c07p26   c910f02c07p26.pok.stglabs.ibm.com   f02c07p26     f2c7p26
10.2.7.27       c910f02c07p27   c910f02c07p27.pok.stglabs.ibm.com   f02c07p27     f2c7p27
10.2.7.28       c910f02c07p28   c910f02c07p28.pok.stglabs.ibm.com   f02c07p28     f2c7p28
10.2.7.29       c910f02c07p29   c910f02c07p29.pok.stglabs.ibm.com   f02c07p29     f2c7p29
10.2.7.30       c910f02c07p30   c910f02c07p30.pok.stglabs.ibm.com   f02c07p30     f2c7p30
10.2.7.31       c910f02c07p31   c910f02c07p31.pok.stglabs.ibm.com   f02c07p31     f2c7p31

10.2.8.1        c910f02c08v01   c910f02c08v01.pok.stglabs.ibm.com   f02c08v01     f2c8v1
10.2.8.2        c910f02c08p02   c910f02c08p02.pok.stglabs.ibm.com   f02c08p02     f2c8p2
10.2.8.3        c910f02c08p03   c910f02c08p03.pok.stglabs.ibm.com   f02c08p03     f2c8p3
10.2.8.4        c910f02c08p04   c910f02c08p04.pok.stglabs.ibm.com   f02c08p04     f2c8p4
10.2.8.5        c910f02c08p05   c910f02c08p05.pok.stglabs.ibm.com   f02c08p05     f2c8p5
10.2.8.6        c910f02c08p06   c910f02c08p06.pok.stglabs.ibm.com   f02c08p06     f2c8p6
10.2.8.7        c910f02c08p07   c910f02c08p07.pok.stglabs.ibm.com   f02c08p07     f2c8p7
10.2.8.8        c910f02c08p08   c910f02c08p08.pok.stglabs.ibm.com   f02c08p08     f2c8p8
10.2.8.9        c910f02c08p09   c910f02c08p09.pok.stglabs.ibm.com   f02c08p09     f2c8p9
10.2.8.10       c910f02c08p10   c910f02c08p10.pok.stglabs.ibm.com   f02c08p10     f2c8p10
10.2.8.11       c910f02c08p11   c910f02c08p11.pok.stglabs.ibm.com   f02c08p11     f2c8p11
10.2.8.12       c910f02c08p12   c910f02c08p12.pok.stglabs.ibm.com   f02c08p12     f2c8p12
10.2.8.13       c910f02c08p13   c910f02c08p13.pok.stglabs.ibm.com   f02c08p13     f2c8p13
10.2.8.14       c910f02c08p14   c910f02c08p14.pok.stglabs.ibm.com   f02c08p14     f2c8p14
10.2.8.15       c910f02c08p15   c910f02c08p15.pok.stglabs.ibm.com   f02c08p15     f2c8p15
10.2.8.16       c910f02c08p16   c910f02c08p16.pok.stglabs.ibm.com   f02c08p16     f2c8p16
10.2.8.17       c910f02c08p17   c910f02c08p17.pok.stglabs.ibm.com   f02c08p17     f2c8p17
10.2.8.18       c910f02c08p18   c910f02c08p18.pok.stglabs.ibm.com   f02c08p18     f2c8p18
10.2.8.19       c910f02c08p19   c910f02c08p19.pok.stglabs.ibm.com   f02c08p19     f2c8p19
10.2.8.20       c910f02c08p20   c910f02c08p20.pok.stglabs.ibm.com   f02c08p20     f2c8p20
10.2.8.21       c910f02c08p21   c910f02c08p21.pok.stglabs.ibm.com   f02c08p21     f2c8p21
10.2.8.22       c910f02c08p22   c910f02c08p22.pok.stglabs.ibm.com   f02c08p22     f2c8p22
10.2.8.23       c910f02c08p23   c910f02c08p23.pok.stglabs.ibm.com   f02c08p23     f2c8p23
10.2.8.24       c910f02c08p24   c910f02c08p24.pok.stglabs.ibm.com   f02c08p24     f2c8p24
10.2.8.25       c910f02c08p25   c910f02c08p25.pok.stglabs.ibm.com   f02c08p25     f2c8p25
10.2.8.26       c910f02c08p26   c910f02c08p26.pok.stglabs.ibm.com   f02c08p26     f2c8p26
10.2.8.27       c910f02c08p27   c910f02c08p27.pok.stglabs.ibm.com   f02c08p27     f2c8p27
10.2.8.28       c910f02c08p28   c910f02c08p28.pok.stglabs.ibm.com   f02c08p28     f2c8p28
10.2.8.29       c910f02c08p29   c910f02c08p29.pok.stglabs.ibm.com   f02c08p29     f2c8p29
10.2.8.30       c910f02c08p30   c910f02c08p30.pok.stglabs.ibm.com   f02c08p30     f2c8p30
10.2.8.31       c910f02c08p31   c910f02c08p31.pok.stglabs.ibm.com   f02c08p31     f2c8p31

10.2.9.1        c910f02c09v01   c910f02c09v01.pok.stglabs.ibm.com   f02c09v01     f2c9v1
10.2.9.2        c910f02c09p02   c910f02c09p02.pok.stglabs.ibm.com   f02c09p02     f2c9p2
10.2.9.3        c910f02c09p03   c910f02c09p03.pok.stglabs.ibm.com   f02c09p03     f2c9p3
10.2.9.4        c910f02c09p04   c910f02c09p04.pok.stglabs.ibm.com   f02c09p04     f2c9p4
10.2.9.5        c910f02c09p05   c910f02c09p05.pok.stglabs.ibm.com   f02c09p05     f2c9p5
10.2.9.6        c910f02c09p06   c910f02c09p06.pok.stglabs.ibm.com   f02c09p06     f2c9p6
10.2.9.7        c910f02c09p07   c910f02c09p07.pok.stglabs.ibm.com   f02c09p07     f2c9p7
10.2.9.8        c910f02c09p08   c910f02c09p08.pok.stglabs.ibm.com   f02c09p08     f2c9p8
10.2.9.9        c910f02c09p09   c910f02c09p09.pok.stglabs.ibm.com   f02c09p09     f2c9p9
10.2.9.10       c910f02c09p10   c910f02c09p10.pok.stglabs.ibm.com   f02c09p10     f2c9p10
10.2.9.11       c910f02c09p11   c910f02c09p11.pok.stglabs.ibm.com   f02c09p11     f2c9p11
10.2.9.12       c910f02c09p12   c910f02c09p12.pok.stglabs.ibm.com   f02c09p12     f2c9p12
10.2.9.13       c910f02c09p13   c910f02c09p13.pok.stglabs.ibm.com   f02c09p13     f2c9p13
10.2.9.14       c910f02c09p14   c910f02c09p14.pok.stglabs.ibm.com   f02c09p14     f2c9p14
10.2.9.15       c910f02c09p15   c910f02c09p15.pok.stglabs.ibm.com   f02c09p15     f2c9p15
10.2.9.16       c910f02c09p16   c910f02c09p16.pok.stglabs.ibm.com   f02c09p16     f2c9p16
10.2.9.17       c910f02c09p17   c910f02c09p17.pok.stglabs.ibm.com   f02c09p17     f2c9p17
10.2.9.18       c910f02c09p18   c910f02c09p18.pok.stglabs.ibm.com   f02c09p18     f2c9p18
10.2.9.19       c910f02c09p19   c910f02c09p19.pok.stglabs.ibm.com   f02c09p19     f2c9p19
10.2.9.20       c910f02c09p20   c910f02c09p20.pok.stglabs.ibm.com   f02c09p20     f2c9p20
10.2.9.21       c910f02c09p21   c910f02c09p21.pok.stglabs.ibm.com   f02c09p21     f2c9p21
10.2.9.22       c910f02c09p22   c910f02c09p22.pok.stglabs.ibm.com   f02c09p22     f2c9p22
10.2.9.23       c910f02c09p23   c910f02c09p23.pok.stglabs.ibm.com   f02c09p23     f2c9p23
10.2.9.24       c910f02c09p24   c910f02c09p24.pok.stglabs.ibm.com   f02c09p24     f2c9p24
10.2.9.25       c910f02c09p25   c910f02c09p25.pok.stglabs.ibm.com   f02c09p25     f2c9p25
10.2.9.26       c910f02c09p26   c910f02c09p26.pok.stglabs.ibm.com   f02c09p26     f2c9p26
10.2.9.27       c910f02c09p27   c910f02c09p27.pok.stglabs.ibm.com   f02c09p27     f2c9p27
10.2.9.28       c910f02c09p28   c910f02c09p28.pok.stglabs.ibm.com   f02c09p28     f2c9p28
10.2.9.29       c910f02c09p29   c910f02c09p29.pok.stglabs.ibm.com   f02c09p29     f2c9p29
10.2.9.30       c910f02c09p30   c910f02c09p30.pok.stglabs.ibm.com   f02c09p30     f2c9p30
10.2.9.31       c910f02c09p31   c910f02c09p31.pok.stglabs.ibm.com   f02c09p31     f2c9p31

10.3.1.1        c910f03c01v01   c910f03c01v01.pok.stglabs.ibm.com   f03c01v01     f3c1v1
10.3.1.2        c910f03c01p02   c910f03c01p02.pok.stglabs.ibm.com   f03c01p02     f3c1p2
10.3.1.3        c910f03c01p03   c910f03c01p03.pok.stglabs.ibm.com   f03c01p03     f3c1p3
10.3.1.4        c910f03c01p04   c910f03c01p04.pok.stglabs.ibm.com   f03c01p04     f3c1p4
10.3.1.5        c910f03c01p05   c910f03c01p05.pok.stglabs.ibm.com   f03c01p05     f3c1p5
10.3.1.6        c910f03c01p06   c910f03c01p06.pok.stglabs.ibm.com   f03c01p06     f3c1p6
10.3.1.7        c910f03c01p07   c910f03c01p07.pok.stglabs.ibm.com   f03c01p07     f3c1p7
10.3.1.8        c910f03c01p08   c910f03c01p08.pok.stglabs.ibm.com   f03c01p08     f3c1p8
10.3.1.9        c910f03c01p09   c910f03c01p09.pok.stglabs.ibm.com   f03c01p09     f3c1p9
10.3.1.10       c910f03c01p10   c910f03c01p10.pok.stglabs.ibm.com   f03c01p10     f3c1p10
10.3.1.11       c910f03c01p11   c910f03c01p11.pok.stglabs.ibm.com   f03c01p11     f3c1p11
10.3.1.12       c910f03c01p12   c910f03c01p12.pok.stglabs.ibm.com   f03c01p12     f3c1p12
10.3.1.13       c910f03c01p13   c910f03c01p13.pok.stglabs.ibm.com   f03c01p13     f3c1p13
10.3.1.14       c910f03c01p14   c910f03c01p14.pok.stglabs.ibm.com   f03c01p14     f3c1p14
10.3.1.15       c910f03c01p15   c910f03c01p15.pok.stglabs.ibm.com   f03c01p15     f3c1p15
10.3.1.16       c910f03c01p16   c910f03c01p16.pok.stglabs.ibm.com   f03c01p16     f3c1p16
10.3.1.17       c910f03c01p17   c910f03c01p17.pok.stglabs.ibm.com   f03c01p17     f3c1p17
10.3.1.18       c910f03c01p18   c910f03c01p18.pok.stglabs.ibm.com   f03c01p18     f3c1p18
10.3.1.19       c910f03c01p19   c910f03c01p19.pok.stglabs.ibm.com   f03c01p19     f3c1p19
10.3.1.20       c910f03c01p20   c910f03c01p20.pok.stglabs.ibm.com   f03c01p20     f3c1p20
10.3.1.21       c910f03c01p21   c910f03c01p21.pok.stglabs.ibm.com   f03c01p21     f3c1p21
10.3.1.22       c910f03c01p22   c910f03c01p22.pok.stglabs.ibm.com   f03c01p22     f3c1p22
10.3.1.23       c910f03c01p23   c910f03c01p23.pok.stglabs.ibm.com   f03c01p23     f3c1p23
10.3.1.24       c910f03c01p24   c910f03c01p24.pok.stglabs.ibm.com   f03c01p24     f3c1p24
10.3.1.25       c910f03c01p25   c910f03c01p25.pok.stglabs.ibm.com   f03c01p25     f3c1p25
10.3.1.26       c910f03c01p26   c910f03c01p26.pok.stglabs.ibm.com   f03c01p26     f3c1p26
10.3.1.27       c910f03c01p27   c910f03c01p27.pok.stglabs.ibm.com   f03c01p27     f3c1p27
10.3.1.28       c910f03c01p28   c910f03c01p28.pok.stglabs.ibm.com   f03c01p28     f3c1p28
10.3.1.29       c910f03c01p29   c910f03c01p29.pok.stglabs.ibm.com   f03c01p29     f3c1p29
10.3.1.30       c910f03c01p30   c910f03c01p30.pok.stglabs.ibm.com   f03c01p30     f3c1p30
10.3.1.31       c910f03c01p31   c910f03c01p31.pok.stglabs.ibm.com   f03c01p31     f3c1p31

10.3.2.1        c910f03c02v01   c910f03c02v01.pok.stglabs.ibm.com   f03c02v01     f3c2v1
10.3.2.2        c910f03c02p02   c910f03c02p02.pok.stglabs.ibm.com   f03c02p02     f3c2p2
10.3.2.3        c910f03c02p03   c910f03c02p03.pok.stglabs.ibm.com   f03c02p03     f3c2p3
10.3.2.4        c910f03c02p04   c910f03c02p04.pok.stglabs.ibm.com   f03c02p04     f3c2p4
10.3.2.5        c910f03c02p05   c910f03c02p05.pok.stglabs.ibm.com   f03c02p05     f3c2p5
10.3.2.6        c910f03c02p06   c910f03c02p06.pok.stglabs.ibm.com   f03c02p06     f3c2p6
10.3.2.7        c910f03c02p07   c910f03c02p07.pok.stglabs.ibm.com   f03c02p07     f3c2p7
10.3.2.8        c910f03c02p08   c910f03c02p08.pok.stglabs.ibm.com   f03c02p08     f3c2p8
10.3.2.9        c910f03c02p09   c910f03c02p09.pok.stglabs.ibm.com   f03c02p09     f3c2p9
10.3.2.10       c910f03c02p10   c910f03c02p10.pok.stglabs.ibm.com   f03c02p10     f3c2p10
10.3.2.11       c910f03c02p11   c910f03c02p11.pok.stglabs.ibm.com   f03c02p11     f3c2p11
10.3.2.12       c910f03c02p12   c910f03c02p12.pok.stglabs.ibm.com   f03c02p12     f3c2p12
10.3.2.13       c910f03c02p13   c910f03c02p13.pok.stglabs.ibm.com   f03c02p13     f3c2p13
10.3.2.14       c910f03c02p14   c910f03c02p14.pok.stglabs.ibm.com   f03c02p14     f3c2p14
10.3.2.15       c910f03c02p15   c910f03c02p15.pok.stglabs.ibm.com   f03c02p15     f3c2p15
10.3.2.16       c910f03c02p16   c910f03c02p16.pok.stglabs.ibm.com   f03c02p16     f3c2p16
10.3.2.17       c910f03c02p17   c910f03c02p17.pok.stglabs.ibm.com   f03c02p17     f3c2p17
10.3.2.18       c910f03c02p18   c910f03c02p18.pok.stglabs.ibm.com   f03c02p18     f3c2p18
10.3.2.19       c910f03c02p19   c910f03c02p19.pok.stglabs.ibm.com   f03c02p19     f3c2p19
10.3.2.20       c910f03c02p20   c910f03c02p20.pok.stglabs.ibm.com   f03c02p20     f3c2p20
10.3.2.21       c910f03c02p21   c910f03c02p21.pok.stglabs.ibm.com   f03c02p21     f3c2p21
10.3.2.22       c910f03c02p22   c910f03c02p22.pok.stglabs.ibm.com   f03c02p22     f3c2p22
10.3.2.23       c910f03c02p23   c910f03c02p23.pok.stglabs.ibm.com   f03c02p23     f3c2p23
10.3.2.24       c910f03c02p24   c910f03c02p24.pok.stglabs.ibm.com   f03c02p24     f3c2p24
10.3.2.25       c910f03c02p25   c910f03c02p25.pok.stglabs.ibm.com   f03c02p25     f3c2p25
10.3.2.26       c910f03c02p26   c910f03c02p26.pok.stglabs.ibm.com   f03c02p26     f3c2p26
10.3.2.27       c910f03c02p27   c910f03c02p27.pok.stglabs.ibm.com   f03c02p27     f3c2p27
10.3.2.28       c910f03c02p28   c910f03c02p28.pok.stglabs.ibm.com   f03c02p28     f3c2p28
10.3.2.29       c910f03c02p29   c910f03c02p29.pok.stglabs.ibm.com   f03c02p29     f3c2p29
10.3.2.30       c910f03c02p30   c910f03c02p30.pok.stglabs.ibm.com   f03c02p30     f3c2p30
10.3.2.31       c910f03c02p31   c910f03c02p31.pok.stglabs.ibm.com   f03c02p31     f3c2p31

10.3.3.2        c910f03c03      c910f03c03.pok.stglabs.ibm.com      f03c03        f3c3
10.3.3.3        c910f03c03k03   c910f03c03k03.pok.stglabs.ibm.com   f03c03k03     f3c3k3
10.3.3.4        c910f03c03k04   c910f03c03k04.pok.stglabs.ibm.com   f03c03k04     f3c3k4
10.3.3.5        c910f03c03k05   c910f03c03k05.pok.stglabs.ibm.com   f03c03k05     f3c3k5
10.3.3.6        c910f03c03k06   c910f03c03k06.pok.stglabs.ibm.com   f03c03k06     f3c3k6
10.3.3.7        c910f03c03k07   c910f03c03k07.pok.stglabs.ibm.com   f03c03k07     f3c3k7
10.3.3.8        c910f03c03k08   c910f03c03k08.pok.stglabs.ibm.com   f03c03k08     f3c3k8
10.3.3.9        c910f03c03k09   c910f03c03k09.pok.stglabs.ibm.com   f03c03k09     f3c3k9
10.3.3.10       c910f03c03k10   c910f03c03k10.pok.stglabs.ibm.com   f03c03k10     f3c3k10
10.3.3.11       c910f03c03k11   c910f03c03k11.pok.stglabs.ibm.com   f03c03k11     f3c3k11
10.3.3.12       c910f03c03k12   c910f03c03k12.pok.stglabs.ibm.com   f03c03k12     f3c3k12
10.3.3.13       c910f03c03k13   c910f03c03k13.pok.stglabs.ibm.com   f03c03k13     f3c3k13
10.3.3.14       c910f03c03k14   c910f03c03k14.pok.stglabs.ibm.com   f03c03k14     f3c3k14
10.3.3.15       c910f03c03k15   c910f03c03k15.pok.stglabs.ibm.com   f03c03k15     f3c3k15
10.3.3.16       c910f03c03k16   c910f03c03k16.pok.stglabs.ibm.com   f03c03k16     f3c3k16
10.3.3.17       c910f03c03k17   c910f03c03k17.pok.stglabs.ibm.com   f03c03k17     f3c3k17
10.3.3.18       c910f03c03k18   c910f03c03k18.pok.stglabs.ibm.com   f03c03k18     f3c3k18
10.3.3.19       c910f03c03k19   c910f03c03k19.pok.stglabs.ibm.com   f03c03k19     f3c3k19
10.3.3.20       c910f03c03k20   c910f03c03k20.pok.stglabs.ibm.com   f03c03k20     f3c3k20
10.3.3.21       c910f03c03k21   c910f03c03k21.pok.stglabs.ibm.com   f03c03k21     f3c3k21
10.3.3.22       c910f03c03k22   c910f03c03k22.pok.stglabs.ibm.com   f03c03k22     f3c3k22
10.3.3.23       c910f03c03k23   c910f03c03k23.pok.stglabs.ibm.com   f03c03k23     f3c3k23
10.3.3.24       c910f03c03k24   c910f03c03k24.pok.stglabs.ibm.com   f03c03k24     f3c3k24
10.3.3.25       c910f03c03k25   c910f03c03k25.pok.stglabs.ibm.com   f03c03k25     f3c3k25
10.3.3.26       c910f03c03k26   c910f03c03k26.pok.stglabs.ibm.com   f03c03k26     f3c3k26
10.3.3.27       c910f03c03k27   c910f03c03k27.pok.stglabs.ibm.com   f03c03k27     f3c3k27
10.3.3.28       c910f03c03k28   c910f03c03k28.pok.stglabs.ibm.com   f03c03k28     f3c3k28
10.3.3.29       c910f03c03k29   c910f03c03k29.pok.stglabs.ibm.com   f03c03k29     f3c3k29
10.3.3.30       c910f03c03k30   c910f03c03k30.pok.stglabs.ibm.com   f03c03k30     f3c3k30
10.3.3.31       c910f03c03k31   c910f03c03k31.pok.stglabs.ibm.com   f03c03k31     f3c3k31

10.3.4.2        c910f03c04      c910f03c04.pok.stglabs.ibm.com      f03c04        f3c4
10.3.4.3        c910f03c04k03   c910f03c04k03.pok.stglabs.ibm.com   f03c04k03     f3c4k3
10.3.4.4        c910f03c04k04   c910f03c04k04.pok.stglabs.ibm.com   f03c04k04     f3c4k4
10.3.4.5        c910f03c04k05   c910f03c04k05.pok.stglabs.ibm.com   f03c04k05     f3c4k5
10.3.4.6        c910f03c04k06   c910f03c04k06.pok.stglabs.ibm.com   f03c04k06     f3c4k6
10.3.4.7        c910f03c04k07   c910f03c04k07.pok.stglabs.ibm.com   f03c04k07     f3c4k7
10.3.4.8        c910f03c04k08   c910f03c04k08.pok.stglabs.ibm.com   f03c04k08     f3c4k8
10.3.4.9        c910f03c04k09   c910f03c04k09.pok.stglabs.ibm.com   f03c04k09     f3c4k9
10.3.4.10       c910f03c04k10   c910f03c04k10.pok.stglabs.ibm.com   f03c04k10     f3c4k10
10.3.4.11       c910f03c04k11   c910f03c04k11.pok.stglabs.ibm.com   f03c04k11     f3c4k11
10.3.4.12       c910f03c04k12   c910f03c04k12.pok.stglabs.ibm.com   f03c04k12     f3c4k12
10.3.4.13       c910f03c04k13   c910f03c04k13.pok.stglabs.ibm.com   f03c04k13     f3c4k13
10.3.4.14       c910f03c04k14   c910f03c04k14.pok.stglabs.ibm.com   f03c04k14     f3c4k14
10.3.4.15       c910f03c04k15   c910f03c04k15.pok.stglabs.ibm.com   f03c04k15     f3c4k15
10.3.4.16       c910f03c04k16   c910f03c04k16.pok.stglabs.ibm.com   f03c04k16     f3c4k16
10.3.4.17       c910f03c04k17   c910f03c04k17.pok.stglabs.ibm.com   f03c04k17     f3c4k17
10.3.4.18       c910f03c04k18   c910f03c04k18.pok.stglabs.ibm.com   f03c04k18     f3c4k18
10.3.4.19       c910f03c04k19   c910f03c04k19.pok.stglabs.ibm.com   f03c04k19     f3c4k19
10.3.4.20       c910f03c04k20   c910f03c04k20.pok.stglabs.ibm.com   f03c04k20     f3c4k20
10.3.4.21       c910f03c04k21   c910f03c04k21.pok.stglabs.ibm.com   f03c04k21     f3c4k21
10.3.4.22       c910f03c04k22   c910f03c04k22.pok.stglabs.ibm.com   f03c04k22     f3c4k22
10.3.4.23       c910f03c04k23   c910f03c04k23.pok.stglabs.ibm.com   f03c04k23     f3c4k23
10.3.4.24       c910f03c04k24   c910f03c04k24.pok.stglabs.ibm.com   f03c04k24     f3c4k24
10.3.4.25       c910f03c04k25   c910f03c04k25.pok.stglabs.ibm.com   f03c04k25     f3c4k25
10.3.4.26       c910f03c04k26   c910f03c04k26.pok.stglabs.ibm.com   f03c04k26     f3c4k26
10.3.4.27       c910f03c04k27   c910f03c04k27.pok.stglabs.ibm.com   f03c04k27     f3c4k27
10.3.4.28       c910f03c04k28   c910f03c04k28.pok.stglabs.ibm.com   f03c04k28     f3c4k28
10.3.4.29       c910f03c04k29   c910f03c04k29.pok.stglabs.ibm.com   f03c04k29     f3c4k29
10.3.4.30       c910f03c04k30   c910f03c04k30.pok.stglabs.ibm.com   f03c04k30     f3c4k30
10.3.4.31       c910f03c04k31   c910f03c04k31.pok.stglabs.ibm.com   f03c04k31     f3c4k31

10.3.5.254      c910f03c05      c910f03c05.pok.stglabs.ibm.com      f03c05        f3c5
10.3.5.2        c910f03c05k02   c910f03c05k02.pok.stglabs.ibm.com   f03c05k02     f3c5k2
10.3.5.3        c910f03c05k03   c910f03c05k03.pok.stglabs.ibm.com   f03c05k03     f3c5k3
10.3.5.4        c910f03c05k04   c910f03c05k04.pok.stglabs.ibm.com   f03c05k04     f3c5k4
10.3.5.5        c910f03c05k05   c910f03c05k05.pok.stglabs.ibm.com   f03c05k05     f3c5k5
10.3.5.6        c910f03c05k06   c910f03c05k06.pok.stglabs.ibm.com   f03c05k06     f3c5k6
10.3.5.7        c910f03c05k07   c910f03c05k07.pok.stglabs.ibm.com   f03c05k07     f3c5k7
10.3.5.8        c910f03c05k08   c910f03c05k08.pok.stglabs.ibm.com   f03c05k08     f3c5k8
10.3.5.9        c910f03c05k09   c910f03c05k09.pok.stglabs.ibm.com   f03c05k09     f3c5k9
10.3.5.10       c910f03c05k10   c910f03c05k10.pok.stglabs.ibm.com   f03c05k10     f3c5k10
10.3.5.11       c910f03c05k11   c910f03c05k11.pok.stglabs.ibm.com   f03c05k11     f3c5k11
10.3.5.12       c910f03c05k12   c910f03c05k12.pok.stglabs.ibm.com   f03c05k12     f3c5k12
10.3.5.13       c910f03c05k13   c910f03c05k13.pok.stglabs.ibm.com   f03c05k13     f3c5k13
10.3.5.14       c910f03c05k14   c910f03c05k14.pok.stglabs.ibm.com   f03c05k14     f3c5k14
10.3.5.15       c910f03c05k15   c910f03c05k15.pok.stglabs.ibm.com   f03c05k15     f3c5k15
10.3.5.16       c910f03c05k16   c910f03c05k16.pok.stglabs.ibm.com   f03c05k16     f3c5k16
10.3.5.17       c910f03c05k17   c910f03c05k17.pok.stglabs.ibm.com   f03c05k17     f3c5k17
10.3.5.18       c910f03c05k18   c910f03c05k18.pok.stglabs.ibm.com   f03c05k18     f3c5k18
10.3.5.19       c910f03c05k19   c910f03c05k19.pok.stglabs.ibm.com   f03c05k19     f3c5k19
10.3.5.20       c910f03c05k20   c910f03c05k20.pok.stglabs.ibm.com   f03c05k20     f3c5k20
10.3.5.21       c910f03c05k21   c910f03c05k21.pok.stglabs.ibm.com   f03c05k21     f3c5k21
10.3.5.22       c910f03c05k22   c910f03c05k22.pok.stglabs.ibm.com   f03c05k22     f3c5k22
10.3.5.23       c910f03c05k23   c910f03c05k23.pok.stglabs.ibm.com   f03c05k23     f3c5k23
10.3.5.24       c910f03c05k24   c910f03c05k24.pok.stglabs.ibm.com   f03c05k24     f3c5k24
10.3.5.25       c910f03c05k25   c910f03c05k25.pok.stglabs.ibm.com   f03c05k25     f3c5k25
10.3.5.26       c910f03c05k26   c910f03c05k26.pok.stglabs.ibm.com   f03c05k26     f3c5k26
10.3.5.27       c910f03c05k27   c910f03c05k27.pok.stglabs.ibm.com   f03c05k27     f3c5k27
10.3.5.28       c910f03c05k28   c910f03c05k28.pok.stglabs.ibm.com   f03c05k28     f3c5k28
10.3.5.29       c910f03c05k29   c910f03c05k29.pok.stglabs.ibm.com   f03c05k29     f3c5k29
10.3.5.30       c910f03c05k30   c910f03c05k30.pok.stglabs.ibm.com   f03c05k30     f3c5k30
10.3.5.31       c910f03c05k31   c910f03c05k31.pok.stglabs.ibm.com   f03c05k31     f3c5k31

10.4.12.1       c910f04x12      c910f04x12.pok.stglabs.ibm.com
10.4.14.1       c910f04x14      c910f04x14.pok.stglabs.ibm.com
10.4.16.1       c910f04x16      c910f04x16.pok.stglabs.ibm.com
10.4.18.1       c910f04x18      c910f04x18.pok.stglabs.ibm.com
10.4.20.1       c910f04x20      c910f04x20.pok.stglabs.ibm.com
10.4.21.1       c910f04x21      c910f04x21.pok.stglabs.ibm.com
10.4.22.1       c910f04x22      c910f04x22.pok.stglabs.ibm.com
10.4.23.1       c910f04x23      c910f04x23.pok.stglabs.ibm.com
10.4.27.1       c910f04x27      c910f04x27.pok.stglabs.ibm.com
10.4.28.1       c910f04x28      c910f04x28.pok.stglabs.ibm.com
10.4.29.1       c910f04x29      c910f04x29.pok.stglabs.ibm.com
10.4.30.1       c910f04x30      c910f04x30.pok.stglabs.ibm.com
10.4.31.1       c910f04x31      c910f04x31.pok.stglabs.ibm.com
10.4.32.1       c910f04x32      c910f04x32.pok.stglabs.ibm.com
10.4.33.1       c910f04x33      c910f04x33.pok.stglabs.ibm.com
10.4.34.1       c910f04x34      c910f04x34.pok.stglabs.ibm.com
10.4.35.1       c910f04x35      c910f04x35.pok.stglabs.ibm.com
10.4.36.1       c910f04x36      c910f04x36.pok.stglabs.ibm.com
10.4.37.1       c910f04x37      c910f04x37.pok.stglabs.ibm.com
10.4.38.1       c910f04x38      c910f04x38.pok.stglabs.ibm.com
10.4.39.1       c910f04x39      c910f04x39.pok.stglabs.ibm.com
10.4.40.1       c910f04x40      c910f04x40.pok.stglabs.ibm.com
10.4.41.1       c910f04x41      c910f04x41.pok.stglabs.ibm.com
10.4.42.1       c910f04x42      c910f04x42.pok.stglabs.ibm.com

10.5.101.1      c910f05c01bc01  c910f05c01bc01.pok.stglabs.ibm.com
10.5.102.1      c910f05c01bc02  c910f05c01bc02.pok.stglabs.ibm.com
10.5.103.1      c910f05c01bc03  c910f05c01bc03.pok.stglabs.ibm.com
10.5.104.1      c910f05c01bc04  c910f05c01bc04.pok.stglabs.ibm.com
10.5.105.1      c910f05c01bc05  c910f05c01bc05.pok.stglabs.ibm.com
10.5.106.1      c910f05c01bc06  c910f05c01bc06.pok.stglabs.ibm.com
10.5.107.1      c910f05c01bc07  c910f05c01bc07.pok.stglabs.ibm.com
10.5.108.1      c910f05c01bc08  c910f05c01bc08.pok.stglabs.ibm.com
10.5.109.1      c910f05c01bc09  c910f05c01bc09.pok.stglabs.ibm.com
10.5.110.1      c910f05c01bc10  c910f05c01bc10.pok.stglabs.ibm.com
10.5.111.1      c910f05c01bc11  c910f05c01bc11.pok.stglabs.ibm.com
10.5.112.1      c910f05c01bc12  c910f05c01bc12.pok.stglabs.ibm.com
10.5.113.1      c910f05c01bc13  c910f05c01bc13.pok.stglabs.ibm.com
10.5.114.1      c910f05c01bc14  c910f05c01bc14.pok.stglabs.ibm.com

50.5.1.1        c910f05c01cmm01 c910f05c01cmm01.pok.stglabs.ibm.com
50.5.1.2        c910f05c01cmm02 c910f05c01cmm02.pok.stglabs.ibm.com
50.5.1.251      c910f05c01io01  c910f05c01io01.pok.stglabs.ibm.com
50.5.1.252      c910f05c01io02  c910f05c01io02.pok.stglabs.ibm.com
50.5.1.253      c910f05c01io03  c910f05c01io03.pok.stglabs.ibm.com
50.5.1.254      c910f05c01io04  c910f05c01io04.pok.stglabs.ibm.com

10.5.121.1      c910f05c11bc01  c910f05c11bc01.pok.stglabs.ibm.com
10.5.122.1      c910f05c11bc02  c910f05c11bc02.pok.stglabs.ibm.com
10.5.123.1      c910f05c11bc03  c910f05c11bc03.pok.stglabs.ibm.com
10.5.124.1      c910f05c11bc04  c910f05c11bc04.pok.stglabs.ibm.com
10.5.125.1      c910f05c11bc05  c910f05c11bc05.pok.stglabs.ibm.com
10.5.126.1      c910f05c11bc06  c910f05c11bc06.pok.stglabs.ibm.com
10.5.127.1      c910f05c11bc07  c910f05c11bc07.pok.stglabs.ibm.com
10.5.128.1      c910f05c11bc08  c910f05c11bc08.pok.stglabs.ibm.com
10.5.129.1      c910f05c11bc09  c910f05c11bc09.pok.stglabs.ibm.com
10.5.130.1      c910f05c11bc10  c910f05c11bc10.pok.stglabs.ibm.com
10.5.131.1      c910f05c11bc11  c910f05c11bc11.pok.stglabs.ibm.com
10.5.132.1      c910f05c11bc12  c910f05c11bc12.pok.stglabs.ibm.com
10.5.133.1      c910f05c11bc13  c910f05c11bc13.pok.stglabs.ibm.com
10.5.134.1      c910f05c11bc14  c910f05c11bc14.pok.stglabs.ibm.com

10.5.133.1      c910f05c11b13v01 c910f05c11b13v01.pok.stglabs.ibm.com
10.5.133.2      c910f05c11b13p02 c910f05c11b13p02.pok.stglabs.ibm.com
10.5.133.3      c910f05c11b13p03 c910f05c11b13p03.pok.stglabs.ibm.com
10.5.133.4      c910f05c11b13p04 c910f05c11b13p04.pok.stglabs.ibm.com
10.5.133.5      c910f05c11b13p05 c910f05c11b13p05.pok.stglabs.ibm.com
10.5.133.6      c910f05c11b13p06 c910f05c11b13p06.pok.stglabs.ibm.com
10.5.133.7      c910f05c11b13p07 c910f05c11b13p07.pok.stglabs.ibm.com
10.5.133.8      c910f05c11b13p08 c910f05c11b13p08.pok.stglabs.ibm.com
10.5.133.9      c910f05c11b13p09 c910f05c11b13p09.pok.stglabs.ibm.com
10.5.133.10     c910f05c11b13p10 c910f05c11b13p10.pok.stglabs.ibm.com
10.5.133.11     c910f05c11b13p11 c910f05c11b13p11.pok.stglabs.ibm.com
10.5.133.12     c910f05c11b13p12 c910f05c11b13p12.pok.stglabs.ibm.com
10.5.133.13     c910f05c11b13p13 c910f05c11b13p13.pok.stglabs.ibm.com
10.5.133.14     c910f05c11b13p14 c910f05c11b13p14.pok.stglabs.ibm.com
10.5.133.15     c910f05c11b13p15 c910f05c11b13p15.pok.stglabs.ibm.com
10.5.133.16     c910f05c11b13p16 c910f05c11b13p16.pok.stglabs.ibm.com
10.5.133.17     c910f05c11b13p17 c910f05c11b13p17.pok.stglabs.ibm.com
10.5.133.18     c910f05c11b13p18 c910f05c11b13p18.pok.stglabs.ibm.com
10.5.133.19     c910f05c11b13p19 c910f05c11b13p19.pok.stglabs.ibm.com

50.5.11.1       c910f05c11cmm01 c910f05c11cmm01.pok.stglabs.ibm.com
50.5.11.2       c910f05c11cmm02 c910f05c11cmm02.pok.stglabs.ibm.com
50.5.11.101     c910f05c11fsp01 c910f05c11fsp01.pok.stglabs.ibm.com
50.5.11.103     c910f05c11fsp03 c910f05c11fsp03.pok.stglabs.ibm.com
50.5.11.105     c910f05c11fsp05 c910f05c11fsp05.pok.stglabs.ibm.com
50.5.11.107     c910f05c11fsp07 c910f05c11fsp07.pok.stglabs.ibm.com
50.5.11.109     c910f05c11fsp09 c910f05c11fsp09.pok.stglabs.ibm.com
50.5.11.111     c910f05c11fsp11 c910f05c11fsp11.pok.stglabs.ibm.com
50.5.11.113     c910f05c11fsp13 c910f05c11fsp13.pok.stglabs.ibm.com
50.5.11.251     c910f05c11io01  c910f05c11io01.pok.stglabs.ibm.com
50.5.11.252     c910f05c11io02  c910f05c11io02.pok.stglabs.ibm.com
50.5.11.253     c910f05c11io03  c910f05c11io03.pok.stglabs.ibm.com
50.5.11.254     c910f05c11io04  c910f05c11io04.pok.stglabs.ibm.com
10.4.27.20 c910f04x27v20 c910f04x27v20.pok.stglabs.ibm.com
10.3.5.199 Server8286

100.100.100.2 testnode

100.100.100.2 testnode

100.100.100.2 testnode

100.100.100.2 testnode
40.0.0.8 c910f02c02p19-eth2 c910f02c02p19-eth2.pok.stglabs.ibm.com
30.0.0.9 c910f02c02p19-eth1 c910f02c02p19-eth1.pok.stglabs.ibm.com
CHECK:output =~ c910f02c02p19-eth1	[Pass]
CHECK:output =~ c910f02c02p19-eth2	[Pass]

RUN:updatenode c910f02c02p19 -P confignetwork [Tue Jan 15 01:48:23 2019]
ElapsedTime:6 sec
RETURN rc = 0
OUTPUT:
c910f02c02p19: updating VPD database
c910f02c02p19: =============updatenode starting====================
c910f02c02p19: trying to download postscripts...
c910f02c02p19: postscripts downloaded successfully
c910f02c02p19: trying to get mypostscript from 10.2.2.16...
c910f02c02p19: postscript start..: confignetwork
c910f02c02p19: [I]: All valid nics and device list:
c910f02c02p19: [I]: eth1
c910f02c02p19: [I]: eth2
c910f02c02p19: [I]: NetworkManager is inactive.
c910f02c02p19: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f02c02p19: configure nic and its device : eth1
c910f02c02p19: [I]: configure eth1
c910f02c02p19: [I]: call: configeth eth1 30.0.0.9 30_0_0_0-255_255_0_0
c910f02c02p19: [I]: configeth on c910f02c02p19: os type: redhat
c910f02c02p19: configeth on c910f02c02p19: old configuration: 3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UNKNOWN group default qlen 1000
c910f02c02p19:     link/ether da:08:47:20:93:04 brd ff:ff:ff:ff:ff:ff
c910f02c02p19:     inet6 fe80::d808:47ff:fe20:9304/64 scope link
c910f02c02p19:        valid_lft forever preferred_lft forever
c910f02c02p19: [I]: configeth on c910f02c02p19: new configuration
c910f02c02p19:        30.0.0.9, 30.0.0.0, 255.0.0.0,
c910f02c02p19: 3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UNKNOWN mode DEFAULT group default qlen 1000
c910f02c02p19: eth1
c910f02c02p19: [I]: configeth on c910f02c02p19: add 30.0.0.9_8 for eth1 temporary.
c910f02c02p19: [I]: configeth on c910f02c02p19: eth1 changed, modify the configuration files
c910f02c02p19: eth1
c910f02c02p19: ['/etc/sysconfig/network-scripts/ifcfg-eth1']
c910f02c02p19: [I]: >> DEVICE=eth1
c910f02c02p19: [I]: >> BOOTPROTO=static
c910f02c02p19: [I]: >> NM_CONTROLLED=no
c910f02c02p19: [I]: >> IPADDR=30.0.0.9
c910f02c02p19: [I]: >> NETMASK=255.0.0.0
c910f02c02p19: [I]: >> ONBOOT=yes
c910f02c02p19: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f02c02p19: configure nic and its device : eth2
c910f02c02p19: [I]: configure eth2
c910f02c02p19: [I]: call: configeth eth2 40.0.0.8 40_0_0_0-255_255_0_0
c910f02c02p19: [I]: configeth on c910f02c02p19: os type: redhat
c910f02c02p19: configeth on c910f02c02p19: old configuration: 4: eth2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
c910f02c02p19:     link/ether 00:21:5e:a9:50:52 brd ff:ff:ff:ff:ff:ff
c910f02c02p19:     inet6 fe80::221:5eff:fea9:5052/64 scope link
c910f02c02p19:        valid_lft forever preferred_lft forever
c910f02c02p19: [I]: configeth on c910f02c02p19: new configuration
c910f02c02p19:        40.0.0.8, 40.0.0.0, 255.0.0.0,
c910f02c02p19: 4: eth2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
c910f02c02p19: eth2
c910f02c02p19: [I]: configeth on c910f02c02p19: add 40.0.0.8_8 for eth2 temporary.
c910f02c02p19: [I]: configeth on c910f02c02p19: eth2 changed, modify the configuration files
c910f02c02p19: eth2
c910f02c02p19: ['/etc/sysconfig/network-scripts/ifcfg-eth2']
c910f02c02p19: [I]: >> DEVICE=eth2
c910f02c02p19: [I]: >> BOOTPROTO=static
c910f02c02p19: [I]: >> NM_CONTROLLED=no
c910f02c02p19: [I]: >> IPADDR=40.0.0.8
c910f02c02p19: [I]: >> NETMASK=255.0.0.0
c910f02c02p19: [I]: >> ONBOOT=yes
c910f02c02p19: postscript end....: confignetwork exited with code 0
c910f02c02p19: Running of postscripts has completed.
c910f02c02p19: =============updatenode ending====================
CHECK:rc == 0	[Pass]

RUN:if grep SUSE /etc/*release;then xdsh c910f02c02p19 "grep 30.0.0.9 /etc/sysconfig/network/ifcfg-eth1"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh c910f02c02p19  "grep 30.0.0.9 /etc/sysconfig/network-scripts/ifcfg-eth1"; elif grep Ubuntu /etc/*release;then xdsh c910f02c02p19 "grep 30.0.0.9 /etc/network/interfaces.d/eth1";else echo "Sorry,this is not supported os"; fi [Tue Jan 15 01:48:29 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
/etc/os-release:NAME="Red Hat Enterprise Linux Server"
/etc/os-release:PRETTY_NAME="Red Hat Enterprise Linux Server 7.6 (Maipo)"
/etc/os-release:REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
/etc/os-release:REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
/etc/redhat-release:Red Hat Enterprise Linux Server release 7.6 (Maipo)
/etc/system-release:Red Hat Enterprise Linux Server release 7.6 (Maipo)
c910f02c02p19: IPADDR=30.0.0.9
CHECK:output =~ 30.0.0.9	[Pass]

RUN:if grep SUSE /etc/*release;then xdsh c910f02c02p19 "grep 40.0.0.8 /etc/sysconfig/network/ifcfg-eth2"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh c910f02c02p19  "grep 40.0.0.8 /etc/sysconfig/network-scripts/ifcfg-eth2"; elif grep Ubuntu /etc/*release;then xdsh c910f02c02p19 "grep 40.0.0.8 /etc/network/interfaces.d/eth2";else echo "Sorry,this is not supported os"; fi [Tue Jan 15 01:48:30 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
/etc/os-release:NAME="Red Hat Enterprise Linux Server"
/etc/os-release:PRETTY_NAME="Red Hat Enterprise Linux Server 7.6 (Maipo)"
/etc/os-release:REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
/etc/os-release:REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
/etc/redhat-release:Red Hat Enterprise Linux Server release 7.6 (Maipo)
/etc/system-release:Red Hat Enterprise Linux Server release 7.6 (Maipo)
c910f02c02p19: IPADDR=40.0.0.8
CHECK:output =~ 40.0.0.8	[Pass]

RUN:rmdef -t network -o 30_0_0_0-255_255_0_0 [Tue Jan 15 01:48:31 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.

RUN:rmdef -t network -o 40_0_0_0-255_255_0_0 [Tue Jan 15 01:48:32 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.

RUN:if grep SUSE /etc/*release;then xdsh c910f02c02p19 "rm -rf /etc/sysconfig/network/ifcfg-eth1"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh c910f02c02p19 "rm -rf /etc/sysconfig/network-scripts/ifcfg-eth1"; elif grep Ubuntu /etc/*release;then xdsh c910f02c02p19 "rm -rf /etc/network/interfaces.d/eth1";else echo "Sorry,this is not supported os"; fi [Tue Jan 15 01:48:32 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
/etc/os-release:NAME="Red Hat Enterprise Linux Server"
/etc/os-release:PRETTY_NAME="Red Hat Enterprise Linux Server 7.6 (Maipo)"
/etc/os-release:REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
/etc/os-release:REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
/etc/redhat-release:Red Hat Enterprise Linux Server release 7.6 (Maipo)
/etc/system-release:Red Hat Enterprise Linux Server release 7.6 (Maipo)
CHECK:rc == 0	[Pass]

RUN:if grep SUSE /etc/*release;then xdsh c910f02c02p19 "rm -rf /etc/sysconfig/network/ifcfg-eth2"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh c910f02c02p19 "rm -rf /etc/sysconfig/network-scripts/ifcfg-eth2"; elif grep Ubuntu /etc/*release;then xdsh c910f02c02p19 "rm -rf /etc/network/interfaces.d/eth2";else echo "Sorry,this is not supported os"; fi [Tue Jan 15 01:48:33 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
/etc/os-release:NAME="Red Hat Enterprise Linux Server"
/etc/os-release:PRETTY_NAME="Red Hat Enterprise Linux Server 7.6 (Maipo)"
/etc/os-release:REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
/etc/os-release:REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
/etc/redhat-release:Red Hat Enterprise Linux Server release 7.6 (Maipo)
/etc/system-release:Red Hat Enterprise Linux Server release 7.6 (Maipo)
CHECK:rc == 0	[Pass]

RUN:xdsh c910f02c02p19 "ip addr del 30.0.0.9/8 dev eth1" [Tue Jan 15 01:48:34 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:xdsh c910f02c02p19 "ip addr del 40.0.0.8/8 dev eth2" [Tue Jan 15 01:48:35 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:if [ -e /tmp/CN.standa ]; then rmdef c910f02c02p19; cat /tmp/CN.standa | mkdef -z; rm -rf /tmp/CN.standa; fi [Tue Jan 15 01:48:35 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:mv -f /etc/hosts.bak /etc/hosts [Tue Jan 15 01:48:37 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:if grep SUSE /etc/*release;then xdsh c910f02c02p19 "cp -f /tmp/backupnet/* /etc/sysconfig/network/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh c910f02c02p19 "cp -f /tmp/backupnet/* /etc/sysconfig/network-scripts/"; elif grep Ubuntu /etc/*release;then xdsh c910f02c02p19 "cp -f /tmp/backupnet/* /etc/network/interfaces.d/";else echo "Sorry,this is not supported os"; fi [Tue Jan 15 01:48:37 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
/etc/os-release:NAME="Red Hat Enterprise Linux Server"
/etc/os-release:PRETTY_NAME="Red Hat Enterprise Linux Server 7.6 (Maipo)"
/etc/os-release:REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
/etc/os-release:REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
/etc/redhat-release:Red Hat Enterprise Linux Server release 7.6 (Maipo)
/etc/system-release:Red Hat Enterprise Linux Server release 7.6 (Maipo)

RUN:xdsh c910f02c02p19 "rm -rf /tmp/backupnet/" [Tue Jan 15 01:48:38 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::confignetwork_secondarynic_third_regex_updatenode::Passed::Time:Tue Jan 15 01:48:38 2019 ::Duration::22 sec------
------Total: 1 , Failed: 0------
```