### PR TITLE
Fix rsyslog.conf syntax error on RHEL 8

### DIFF
--- a/xCAT/postscripts/syslog
+++ b/xCAT/postscripts/syslog
@@ -231,7 +231,7 @@ config_rsyslog_V8()
     if [ -f "$conf_file" ]; then
         #rhels7.4 ships rsyslogd 8.24.0, which does not ship remote.conf
         #the relevant sections are included in rsyslog.conf
-        sed -i '/#\$ModLoad \+imudp\|imtcp\|imudp.so\|imtcp.so/s/^#//;
+        sed -i '/#\$ModLoad \+imudp\|#\$ModLoad \+imtcp\|imudp.so\|imtcp.so/s/^#//;
                        /#\$InputTCPServerRun\|UDPServerRun.*/s/^#//' $conf_file
 
         #ubuntu16.04 ships rsyslog 8.16.0,which does not ship remote.conf


### PR DESCRIPTION
### The PR is to fix issue xcat2/xcat2-task-management#560

### The modification include

_##FIx the wrongly regex replacement against `/etc/rsyslog.conf`_


### The UT result
#### Before the fix
On RHEL 7
```
# diff -u /etc/rsyslog.conf.XCATORIG <(sed '/#\$ModLoad \+imudp\|imtcp\|imudp.so\|imtcp.so/s/^#//;
/#\$InputTCPServerRun\|UDPServerRun.*/s/^#//' /etc/rsyslog.conf.XCATORIG)
--- /etc/rsyslog.conf.XCATORIG	2017-06-15 01:23:29.550059266 -0400
+++ /dev/fd/63	2019-01-15 03:50:28.820953721 -0500
@@ -12,12 +12,12 @@
 #$ModLoad immark  # provides --MARK-- message capability

 # Provides UDP syslog reception
-#$ModLoad imudp
-#$UDPServerRun 514
+$ModLoad imudp
+$UDPServerRun 514

 # Provides TCP syslog reception
-#$ModLoad imtcp
-#$InputTCPServerRun 514
+$ModLoad imtcp
+$InputTCPServerRun 514
```

On RHEL 8
```
# diff -u /etc/rsyslog.conf.XCATORIG <(sed '/#\$ModLoad \+imudp\|imtcp\|imudp.so\|imtcp.so/s/^#//;
> /#\$InputTCPServerRun\|UDPServerRun.*/s/^#//' /etc/rsyslog.conf.XCATORIG)
--- /etc/rsyslog.conf.XCATORIG	2019-01-07 03:34:45.408950851 -0500
+++ /dev/fd/63	2019-01-15 03:50:40.464792743 -0500
@@ -20,9 +20,9 @@
 #input(type="imudp" port="514")

 # Provides TCP syslog reception
-# for parameters see http://www.rsyslog.com/doc/imtcp.html
-#module(load="imtcp") # needs to be done just once
-#input(type="imtcp" port="514")
+ for parameters see http://www.rsyslog.com/doc/imtcp.html
+module(load="imtcp") # needs to be done just once
+input(type="imtcp" port="514")

 #### GLOBAL DIRECTIVES ####

```

#### After the fix
On RHEL 7
```
# diff -u /etc/rsyslog.conf.XCATORIG <(sed '/#\$ModLoad \+imudp\|#\$ModLoad \+imtcp\|imudp.so\|imtcp.so/s/^#//;
/#\$InputTCPServerRun\|UDPServerRun.*/s/^#//' /etc/rsyslog.conf.XCATORIG)
--- /etc/rsyslog.conf.XCATORIG	2017-06-15 01:23:29.550059266 -0400
+++ /dev/fd/63	2019-01-15 03:55:57.918781089 -0500
@@ -12,12 +12,12 @@
 #$ModLoad immark  # provides --MARK-- message capability

 # Provides UDP syslog reception
-#$ModLoad imudp
-#$UDPServerRun 514
+$ModLoad imudp
+$UDPServerRun 514

 # Provides TCP syslog reception
-#$ModLoad imtcp
-#$InputTCPServerRun 514
+$ModLoad imtcp
+$InputTCPServerRun 514


 #### GLOBAL DIRECTIVES ####
```

On RHEL 8
```
# diff -u /etc/rsyslog.conf.XCATORIG <(sed '/#\$ModLoad \+imudp\|\$ModLoad \+imtcp\|imudp.so\|imtcp.so/s/^#//;
> /#\$InputTCPServerRun\|UDPServerRun.*/s/^#//' /etc/rsyslog.conf.XCATORIG)
```
