### PR TITLE
Refine cases rmdef_dynamic_group and lsdef_nics to reduce failure for environment

### DIFF
--- a/xCAT-test/autotest/testcase/lsdef/cases0
+++ b/xCAT-test/autotest/testcase/lsdef/cases0
@@ -214,6 +214,7 @@ end
 start:lsdef_nics
 description:lsdef --nics
 label:mn_only,ci_test,db
+cmd:lsdef testnode1;if [ $? -eq 0 ]; then lsdef -l testnode1 -z >/tmp/testnode1.standa ; rmdef testnode1;fi
 cmd:mkdef -t node -o testnode1 groups=all mgt=ipmi nicips.eth0=1.1.1.1
 check:rc==0
 cmd:lsdef testnode1 --nics
@@ -223,6 +224,7 @@ cmd:rmdef testnode1
 check:rc==0
 cmd:lsdef testnode1
 check:output=~Could not find
+cmd:if [ -e /tmp/testnode1.standa ]; then cat /tmp/testnode1.standa | mkdef -z; rm -rf /tmp/testnode1.standa; fi
 end
 
 start:lsdef_template

--- a/xCAT-test/autotest/testcase/rmdef/cases0
+++ b/xCAT-test/autotest/testcase/rmdef/cases0
@@ -88,6 +88,8 @@ end
 start:rmdef_dynamic_group
 description:rmdef to remove dynamic node group
 label:mn_only,ci_test,db
+cmd:lsdef testnode1;if [ $? -eq 0 ]; then lsdef -l testnode1 -z >/tmp/testnode1.standa ; rmdef testnode1;fi
+cmd:lsdef testnode2;if [ $? -eq 0 ]; then lsdef -l testnode2 -z >/tmp/testnode2.standa ; rmdef testnode2;fi
 cmd:mkdef -t node -o testnode1-testnode2 mgt=hmc cons=hmc groups=all,systemp
 check:rc==0
 cmd:mkdef -t group -o dyngrp -d -w mgt==hmc -w cons==hmc -w groups==all,systemp
@@ -105,6 +107,8 @@ cmd:rmdef -t group -o dyngrp
 check:rc==0
 cmd:lsdef -t group -o dyngrp
 check:output=~Could not find an object named 'dyngrp' of type 'group'.
+cmd:if [ -e /tmp/testnode1.standa ]; then cat /tmp/testnode1.standa | mkdef -z; rm -rf /tmp/testnode1.standa; fi
+cmd:if [ -e /tmp/testnode2.standa ]; then cat /tmp/testnode2.standa | mkdef -z; rm -rf /tmp/testnode2.standa; fi
 end
 
 #start:rmdef_f_all


### PR DESCRIPTION
### The PR is to to task https://github.com/xcat2/xcat2-task-management/issues/562
To save the node information and clear environment before test, restore the node information after the test.
The UT for case rmdef_dynamic_group
```
------START::rmdef_dynamic_group::Time:Wed Jan 16 00:53:33 2019------

RUN:lsdef testnode1;if [ $? -eq 0 ]; then lsdef -l testnode1 -z >/tmp/testnode1.standa ; rmdef testnode1;fi [Wed Jan 16 00:53:33 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
Object name: testnode1
    groups=all
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
1 object definitions have been removed.

RUN:lsdef testnode2;if [ $? -eq 0 ]; then lsdef -l testnode2 -z >/tmp/testnode2.standa ; rmdef testnode2;fi [Wed Jan 16 00:53:35 2019]
Error: [c910f02c02p16]: Could not find an object named 'testnode2' of type 'node'.
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
No object definitions have been found

RUN:mkdef -t node -o testnode1-testnode2 mgt=hmc cons=hmc groups=all,systemp [Wed Jan 16 00:53:36 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
2 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:mkdef -t group -o dyngrp -d -w mgt==hmc -w cons==hmc -w groups==all,systemp [Wed Jan 16 00:53:37 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:lsdef -s dyngrp [Wed Jan 16 00:53:37 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
testnode1  (node)
testnode2  (node)
CHECK:rc == 0	[Pass]
CHECK:output =~ testnode1	[Pass]
CHECK:output =~ testnode2	[Pass]

RUN:rmdef -t node -o dyngrp [Wed Jan 16 00:53:38 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
2 object definitions have been removed.
CHECK:rc = 0	[Pass]

RUN:lsdef -t node testnode1,testnode2 [Wed Jan 16 00:53:39 2019]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: [c910f02c02p16]: Could not find an object named 'testnode1' of type 'node'.
Error: [c910f02c02p16]: Could not find an object named 'testnode2' of type 'node'.
No object definitions have been found
CHECK:output =~ Could not find an object named 'testnode1' of type 'node'.	[Pass]
CHECK:output =~ Could not find an object named 'testnode2' of type 'node'.	[Pass]

RUN:rmdef -t group -o dyngrp [Wed Jan 16 00:53:40 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:lsdef -t group -o dyngrp [Wed Jan 16 00:53:41 2019]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Error: [c910f02c02p16]: Could not find an object named 'dyngrp' of type 'group'.
No object definitions have been found
CHECK:output =~ Could not find an object named 'dyngrp' of type 'group'.	[Pass]

RUN:if [ -e /tmp/testnode1.standa ]; then cat /tmp/testnode1.standa | mkdef -z; rm -rf /tmp/testnode1.standa; fi [Wed Jan 16 00:53:41 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.

RUN:if [ -e /tmp/testnode2.standa ]; then cat /tmp/testnode2.standa | mkdef -z; rm -rf /tmp/testnode2.standa; fi [Wed Jan 16 00:53:42 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::rmdef_dynamic_group::Passed::Time:Wed Jan 16 00:53:42 2019 ::Duration::9 sec------
------Total: 1 , Failed: 0------
```

The UT for case lsdef_nics
```
------START::lsdef_nics::Time:Wed Jan 16 01:00:53 2019------

RUN:lsdef testnode1;if [ $? -eq 0 ]; then lsdef -l testnode1 -z >/tmp/testnode1.standa ; rmdef testnode1;fi [Wed Jan 16 01:00:53 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
Object name: testnode1
    groups=all
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
1 object definitions have been removed.

RUN:mkdef -t node -o testnode1 groups=all mgt=ipmi nicips.eth0=1.1.1.1 [Wed Jan 16 01:00:55 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:lsdef testnode1 --nics [Wed Jan 16 01:00:55 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Object name: testnode1
    nicips.eth0=1.1.1.1
CHECK:rc == 0	[Pass]
CHECK:output =~ 1.1.1.1	[Pass]

RUN:rmdef testnode1 [Wed Jan 16 01:00:56 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:lsdef testnode1 [Wed Jan 16 01:00:57 2019]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Error: [c910f02c02p16]: Could not find an object named 'testnode1' of type 'node'.
No object definitions have been found
CHECK:output =~ Could not find	[Pass]

RUN:if [ -e /tmp/testnode1.standa ]; then cat /tmp/testnode1.standa | mkdef -z; rm -rf /tmp/testnode1.standa; fi [Wed Jan 16 01:00:57 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.

------END::lsdef_nics::Passed::Time:Wed Jan 16 01:00:58 2019 ::Duration::5 sec------
------Total: 1 , Failed: 0------
```