### PR TITLE
Add test case for issue 4511 : rflash -d did not support relative paths

### DIFF
--- a/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
+++ b/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
@@ -547,4 +547,5 @@ cmd:dir="/tmp/rflashnotexist"; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir;
 cmd:dir="/tmp/rflashdir"; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi
 cmd:rmdef -t node -o testnode
 check:rc == 0
+cmd:if [ -e /tmp/testnode.standa ]; then cat /tmp/testnode.standa | mkdef -z; rm -rf /tmp/testnode.standa; fi
 end

--- a/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
+++ b/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
@@ -524,3 +524,23 @@ check:rc != 0
 check:output =~~$$CN\s*:\s*(\[.*?\]: )?Error: Deleting currently active BMC firmware is not supported
 end
 
+start:rflash_d_relative_path
+description:this case is to check if -d support relative directory path. This case is for issue 4511.
+os:Linux
+hcp:openbmc
+label:cn_bmc_ready,hctrl_openbmc
+cmd:lsdef testnode;if [ $? -eq 0 ]; then lsdef -l testnode -z >/tmp/testnode.standa ; rmdef testnode;fi
+cmd:mkdef -t node -o testnode groups=all arch=ppc64le bmc=testnode-bmc bmcvlantag=11 cons=openbmc mgt=openbmc
+check:rc == 0
+cmd:dir="/tmp/rflashdir";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi
+cmd:mkdir -p /tmp/rflashdir;touch /tmp/rflashdir/witherspoon.pnor.squashfs.tar
+cmd:cd /tmp;rflash testnode ./rflashdir -d
+check:rc != 0
+check:output =~~testnode\s*:\s*Error:\s*Unable to resolved ip address for bmc:\s*testnode-bmc
+cmd:dir="/tmp/rflashnotexist/";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi
+cmd:cd /tmp;rflash testnode ./rflashnotexist -d
+check:rc != 0
+check:output =~~testnode\s*:\s*Error:\s*Invalid option specified with -d:\s*./rflashnotexist
+cmd:dir="/tmp/rflashnotexist"; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi
+cmd:dir="/tmp/rflashdir"; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi
+end

--- a/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
+++ b/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
@@ -536,11 +536,15 @@ cmd:dir="/tmp/rflashdir";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi
 cmd:mkdir -p /tmp/rflashdir;touch /tmp/rflashdir/witherspoon.pnor.squashfs.tar
 cmd:cd /tmp;rflash testnode ./rflashdir -d
 check:rc != 0
-check:output =~~testnode\s*:\s*Error:\s*Unable to resolved ip address for bmc:\s*testnode-bmc
+check:output =~Error:\s*\[.*?\]:\s*No BMC tar file found in ./rflashdir
+check:output =~Error:\s*\[.*?\]:\s*No Host tar file found in ./rflashdir
+check:output =~testnode\s*:\s*Error:\s*Unable to resolved ip address for bmc:\s*testnode-bmc
 cmd:dir="/tmp/rflashnotexist/";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi
 cmd:cd /tmp;rflash testnode ./rflashnotexist -d
 check:rc != 0
-check:output =~~testnode\s*:\s*Error:\s*Invalid option specified with -d:\s*./rflashnotexist
+check:output =~testnode\s*:\s*Error:\s*Invalid option specified with -d:\s*./rflashnotexist
 cmd:dir="/tmp/rflashnotexist"; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi
 cmd:dir="/tmp/rflashdir"; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi
+cmd:rmdef -t node -o testnode
+check:rc == 0
 end


### PR DESCRIPTION
The PR is to do task https://github.com/xcat2/xcat2-task-management/issues/76 to add case to verify rflash -d could support relative paths

The UT
```
------START::rflash_d_relative_path::Time:Wed Jan 16 21:38:21 2019------

RUN:lsdef testnode;if [ $? -eq 0 ]; then lsdef -l testnode -z >/tmp/testnode.standa ; rmdef testnode;fi [Wed Jan 16 21:38:21 2019]
Error: [briggs01]: Could not find an object named 'testnode' of type 'node'.
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
No object definitions have been found

RUN:mkdef -t node -o testnode groups=all arch=ppc64le bmc=testnode-bmc bmcvlantag=11 cons=openbmc mgt=openbmc [Wed Jan 16 21:38:22 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:dir="/tmp/rflashdir";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi [Wed Jan 16 21:38:22 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:mkdir -p /tmp/rflashdir;touch /tmp/rflashdir/witherspoon.pnor.squashfs.tar [Wed Jan 16 21:38:22 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:cd /tmp;rflash testnode ./rflashdir -d [Wed Jan 16 21:38:22 2019]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Error: [briggs01]: No BMC tar file found in ./rflashdir
Error: [briggs01]: No Host tar file found in ./rflashdir
testnode: Error: Unable to resolved ip address for bmc: testnode-bmc
CHECK:rc != 0	[Pass]
CHECK:output =~ Error:\s*\[.*?\]:\s*No BMC tar file found in ./rflashdir	[Pass]
CHECK:output =~ Error:\s*\[.*?\]:\s*No Host tar file found in ./rflashdir	[Pass]
CHECK:output =~ testnode\s*:\s*Error:\s*Unable to resolved ip address for bmc:\s*testnode-bmc	[Pass]

RUN:dir="/tmp/rflashnotexist/";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi [Wed Jan 16 21:38:22 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:cd /tmp;rflash testnode ./rflashnotexist -d [Wed Jan 16 21:38:22 2019]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
testnode: Error: Invalid option specified with -d: ./rflashnotexist
CHECK:rc != 0	[Pass]
CHECK:output =~ testnode\s*:\s*Error:\s*Invalid option specified with -d:\s*./rflashnotexist	[Pass]

RUN:dir="/tmp/rflashnotexist"; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi [Wed Jan 16 21:38:23 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:dir="/tmp/rflashdir"; if [ -d ${dir}".bak" ];then mv ${dir}".bak" $dir; fi [Wed Jan 16 21:38:23 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:rmdef -t node -o testnode [Wed Jan 16 21:38:23 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:if [ -e /tmp/testnode.standa ]; then cat /tmp/testnode.standa | mkdef -z; rm -rf /tmp/testnode.standa; fi [Thu Jan 17 01:38:53 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
------END::rflash_d_relative_path::Passed::Time:Wed Jan 16 21:38:23 2019 ::Duration::2 sec------
------Total: 1 , Failed: 0------
```