### PR TITLE
remove xcat release info comment line from inventory json files

### DIFF
--- a/xCAT-test/autotest/testcase/xcat_inventory/templates/cluster_invdir/osimage/test_myimage/definition.json
+++ b/xCAT-test/autotest/testcase/xcat_inventory/templates/cluster_invdir/osimage/test_myimage/definition.json
@@ -18,4 +18,3 @@
     },
     "schema_version": "1.0"
 }
-#Version 2.14.1 (git commit ac941fd2501e8a581bfcc4c79b9301f6ec37ab93, built Mon May 21 06:15:46 EDT 2018)

--- a/xCAT-test/autotest/testcase/xcat_inventory/templates/cluster_invdir/osimage/test_myimage2/definition.json
+++ b/xCAT-test/autotest/testcase/xcat_inventory/templates/cluster_invdir/osimage/test_myimage2/definition.json
@@ -18,4 +18,3 @@
     },
     "schema_version": "1.0"
 }
-#Version 2.14.1 (git commit ac941fd2501e8a581bfcc4c79b9301f6ec37ab93, built Mon May 21 06:15:46 EDT 2018)

--- a/xCAT-test/autotest/testcase/xcat_inventory/templates/environment/test.environments.osimage.update.json
+++ b/xCAT-test/autotest/testcase/xcat_inventory/templates/environment/test.environments.osimage.update.json
@@ -50,4 +50,3 @@
     },
     "schema_version": "1.0"
 }
-#Version 2.14.4 (git commit 722709b61e63feb7f6d3ee787afa8113eefbe27e, built Wed Sep 26 06:17:57 EDT 2018)

--- a/xCAT-test/autotest/testcase/xcat_inventory/templates/osimage.json
+++ b/xCAT-test/autotest/testcase/xcat_inventory/templates/osimage.json
@@ -37,4 +37,3 @@
     },
     "schema_version": "2.0"
 }
-#Version 2.14.5 (git commit e9d8db94e349c383a6686ecfd853536abe7a8c2b, built Wed Nov 21 06:17:14 EST 2018)


### PR DESCRIPTION
### The PR is to fix issue remove xcat release info comment lines from inventory json files in test cases

Due to https://github.com/xcat2/xcat-inventory/issues/183, the comment lines is not supported in json spec