### PR TITLE
refine test cases which were designed in flat originally to support both flat and hierarchy

### DIFF
--- a/xCAT-test/autotest/testcase/chtab/cases0
+++ b/xCAT-test/autotest/testcase/chtab/cases0
@@ -79,7 +79,7 @@ description:chtab with error table
 label:mn_only,ci_test,db
 cmd:chtab error=error site.comment=error
 check:rc!=0
-check:output=~no such column|column \"error\" does not exist
+check:output=~no such column|column \"error\" does not exist|Unknown column \'error\'
 end
 
 

--- a/xCAT-test/autotest/testcase/xdcp/cases1
+++ b/xCAT-test/autotest/testcase/xdcp/cases1
@@ -1,10 +1,10 @@
 start:xdcp_nonroot_user
 label:cn_os_ready,parallel_cmds
-cmd:useradd -m xyzzy
+cmd:servicenode=`lsdef $$CN |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh $$SN "useradd -m xyzzy";else useradd -m xyzzy;fi
 check:rc==0
-cmd:bash -c "( cd ~root && tar cf - .xcat .ssh ) | ( cd ~xyzzy && tar xf - )"
+cmd:servicenode=`lsdef $$CN |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh $$SN "bash -c \"( cd ~root && tar cf - .xcat .ssh ) | ( cd ~xyzzy && tar xf - )\"";else bash -c "( cd ~root && tar cf - .xcat .ssh ) | ( cd ~xyzzy && tar xf - )";fi
 check:rc==0
-cmd:chown -R xyzzy ~xyzzy/.xcat ~xyzzy/.ssh
+cmd:servicenode=`lsdef $$CN |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh $$SN "chown -R xyzzy ~xyzzy/.xcat ~xyzzy/.ssh";else chown -R xyzzy ~xyzzy/.xcat ~xyzzy/.ssh;fi
 check:rc==0
 cmd:xdsh $$CN "useradd -m xyzzy"
 check:rc==0
@@ -12,12 +12,12 @@ cmd:xdsh $$CN "( cd ~ && tar cf - .ssh ) | ( cd ~xyzzy && tar xf - )"
 check:rc==0
 cmd:xdsh $$CN "chown -R xyzzy ~xyzzy/.ssh"
 check:rc==0
-cmd:su -c "xdcp $$CN /etc/sysctl.conf /tmp/sysctl.conf" - xyzzy
+cmd:servicenode=`lsdef $$CN |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh $$SN "su -c \"xdcp $$CN /etc/sysctl.conf /tmp/sysctl.conf\" - xyzzy";else su -c "xdcp $$CN /etc/sysctl.conf /tmp/sysctl.conf" - xyzzy;fi
 check:rc==0
 cmd:xdsh $$CN "stat -c '%U' /tmp/sysctl.conf"
 check:output=~xyzzy
 cmd:xdsh $$CN "userdel xyzzy"
 check:rc==0
-cmd:userdel xyzzy
+cmd:servicenode=`lsdef $$CN |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh $$SN "userdel xyzzy";else userdel xyzzy;fi
 check:rc==0
 end

--- a/xCAT-test/autotest/testcase/xdcp/cases1
+++ b/xCAT-test/autotest/testcase/xdcp/cases1
@@ -1,5 +1,7 @@
 start:xdcp_nonroot_user
 label:cn_os_ready,parallel_cmds
+cmd:lsdef -t site -z clustersite > /tmp/site.stanza
+cmd:chdef -t site SNsyncfiledir=/tmp
 cmd:servicenode=`lsdef $$CN |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh $servicenode "useradd -m xyzzy";useradd -m xyzzy;else useradd -m xyzzy;fi
 check:rc==0
 cmd:servicenode=`lsdef $$CN |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh $servicenode "bash -c \"( cd ~root && tar cf - .xcat .ssh ) | ( cd ~xyzzy && tar xf - )\"";bash -c "( cd ~root && tar cf - .xcat .ssh ) | ( cd ~xyzzy && tar xf - )";else bash -c "( cd ~root && tar cf - .xcat .ssh ) | ( cd ~xyzzy && tar xf - )";fi
@@ -20,4 +22,5 @@ cmd:xdsh $$CN "userdel xyzzy"
 check:rc==0
 cmd:servicenode=`lsdef $$CN |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh $servicenode "userdel xyzzy";userdel xyzzy;else userdel xyzzy;fi
 check:rc==0
+cmd:if [ -e /tmp/site.standa ]; then cat /tmp/site.standa | mkdef -z -f; rm -rf /tmp/site.standa; fi
 end

--- a/xCAT-test/autotest/testcase/xdcp/cases1
+++ b/xCAT-test/autotest/testcase/xdcp/cases1
@@ -1,10 +1,10 @@
 start:xdcp_nonroot_user
 label:cn_os_ready,parallel_cmds
-cmd:servicenode=`lsdef $$CN |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh $$SN "useradd -m xyzzy";else useradd -m xyzzy;fi
+cmd:servicenode=`lsdef $$CN |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh $servicenode "useradd -m xyzzy";useradd -m xyzzy;else useradd -m xyzzy;fi
 check:rc==0
-cmd:servicenode=`lsdef $$CN |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh $$SN "bash -c \"( cd ~root && tar cf - .xcat .ssh ) | ( cd ~xyzzy && tar xf - )\"";else bash -c "( cd ~root && tar cf - .xcat .ssh ) | ( cd ~xyzzy && tar xf - )";fi
+cmd:servicenode=`lsdef $$CN |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh $servicenode "bash -c \"( cd ~root && tar cf - .xcat .ssh ) | ( cd ~xyzzy && tar xf - )\"";bash -c "( cd ~root && tar cf - .xcat .ssh ) | ( cd ~xyzzy && tar xf - )";else bash -c "( cd ~root && tar cf - .xcat .ssh ) | ( cd ~xyzzy && tar xf - )";fi
 check:rc==0
-cmd:servicenode=`lsdef $$CN |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh $$SN "chown -R xyzzy ~xyzzy/.xcat ~xyzzy/.ssh";else chown -R xyzzy ~xyzzy/.xcat ~xyzzy/.ssh;fi
+cmd:servicenode=`lsdef $$CN |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh $servicenode "chown -R xyzzy ~xyzzy/.xcat ~xyzzy/.ssh";chown -R xyzzy ~xyzzy/.xcat ~xyzzy/.ssh;else chown -R xyzzy ~xyzzy/.xcat ~xyzzy/.ssh;fi
 check:rc==0
 cmd:xdsh $$CN "useradd -m xyzzy"
 check:rc==0
@@ -12,12 +12,12 @@ cmd:xdsh $$CN "( cd ~ && tar cf - .ssh ) | ( cd ~xyzzy && tar xf - )"
 check:rc==0
 cmd:xdsh $$CN "chown -R xyzzy ~xyzzy/.ssh"
 check:rc==0
-cmd:servicenode=`lsdef $$CN |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh $$SN "su -c \"xdcp $$CN /etc/sysctl.conf /tmp/sysctl.conf\" - xyzzy";else su -c "xdcp $$CN /etc/sysctl.conf /tmp/sysctl.conf" - xyzzy;fi
+cmd:su -c "xdcp $$CN /etc/sysctl.conf /tmp/sysctl.conf" - xyzzy
 check:rc==0
 cmd:xdsh $$CN "stat -c '%U' /tmp/sysctl.conf"
 check:output=~xyzzy
 cmd:xdsh $$CN "userdel xyzzy"
 check:rc==0
-cmd:servicenode=`lsdef $$CN |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh $$SN "userdel xyzzy";else userdel xyzzy;fi
+cmd:servicenode=`lsdef $$CN |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh $servicenode "userdel xyzzy";userdel xyzzy;else userdel xyzzy;fi
 check:rc==0
 end

--- a/xCAT-test/autotest/testcase/xdsh/cases0
+++ b/xCAT-test/autotest/testcase/xdsh/cases0
@@ -13,7 +13,7 @@ end
 
 start:xdsh_regular_command
 label:cn_os_ready,parallel_cmds
-cmd:XCATBYPASS=1 xdsh $$CN "ps -ef"
+cmd:servicenode=`lsdef $$CN |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh $$CN "ps -ef";else XCATBYPASS=1 xdsh $$CN "ps -ef";fi
 check:rc==0
 check:output=~$$CN:\s+UID\s+PID\s+PPID\s+C\s+STIME\s+TTY\s+TIME\s+CMD
 end

--- a/xCAT-test/autotest/testcase/xdsh/cases0
+++ b/xCAT-test/autotest/testcase/xdsh/cases0
@@ -13,7 +13,7 @@ end
 
 start:xdsh_regular_command
 label:cn_os_ready,parallel_cmds
-cmd:servicenode=`lsdef $$CN |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh $$CN "ps -ef";else XCATBYPASS=1 xdsh $$CN "ps -ef";fi
+cmd:xdsh $$CN "ps -ef"
 check:rc==0
 check:output=~$$CN:\s+UID\s+PID\s+PPID\s+C\s+STIME\s+TTY\s+TIME\s+CMD
 end

--- a/xCAT-test/autotest/testcase/xdsh/cases1
+++ b/xCAT-test/autotest/testcase/xdsh/cases1
@@ -3,10 +3,10 @@ description: Test the exit code when command xdsh failed
 label:cn_os_ready,parallel_cmds
 cmd:xdsh $$CN date
 check:rc==0
-cmd:mv /root/.ssh/id_rsa /root/.ssh/id_rsa.backup
+cmd:servicenode=`lsdef $$CN |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh $$SN mv /root/.ssh/id_rsa /root/.ssh/id_rsa.backup;else mv /root/.ssh/id_rsa /root/.ssh/id_rsa.backup;fi
 check:rc==0
 cmd:xdsh $$CN date
 check:rc!=0
-cmd:mv /root/.ssh/id_rsa.backup /root/.ssh/id_rsa
+cmd:servicenode=`lsdef $$CN |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh $$SN mv /root/.ssh/id_rsa.backup /root/.ssh/id_rsa;else mv /root/.ssh/id_rsa.backup /root/.ssh/id_rsa;fi
 check:rc==0
 end


### PR DESCRIPTION
## The PR is to do task https://github.com/xcat2/xcat2-task-management/issues/559
The modification are
1. update following cases to support both flat and hierarchy environment
```
xdcp_nonroot_user
xdsh_permission_denied
xdsh_regular_command
``` 
2. update following case to support both mysql and sqlite
```
chtab_err_table
```
The UT for xdcp_nonroot_user on hierarchy
```
------START::xdcp_nonroot_user::Time:Tue Jan 29 02:11:46 2019------

RUN:lsdef -t site -z clustersite > /tmp/site.stanza [Tue Jan 29 02:11:46 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:chdef -t site SNsyncfiledir=/tmp [Tue Jan 29 02:11:47 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.

RUN:servicenode=`lsdef c910f02c02p18 |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh $servicenode "useradd -m xyzzy";useradd -m xyzzy;else useradd -m xyzzy;fi [Tue Jan 29 02:11:47 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
[c910f02c02p16]: c910f02c02p17: useradd: warning: the home directory already exists.
c910f02c02p17: Not copying any file from skel directory into it.
c910f02c02p17: Creating mailbox file: File exists
useradd: warning: the home directory already exists.
Not copying any file from skel directory into it.
Creating mailbox file: File exists
CHECK:rc == 0	[Pass]

RUN:servicenode=`lsdef c910f02c02p18 |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh $servicenode "bash -c \"( cd ~root && tar cf - .xcat .ssh ) | ( cd ~xyzzy && tar xf - )\"";bash -c "( cd ~root && tar cf - .xcat .ssh ) | ( cd ~xyzzy && tar xf - )";else bash -c "( cd ~root && tar cf - .xcat .ssh ) | ( cd ~xyzzy && tar xf - )";fi [Tue Jan 29 02:11:49 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:servicenode=`lsdef c910f02c02p18 |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh $servicenode "chown -R xyzzy ~xyzzy/.xcat ~xyzzy/.ssh";chown -R xyzzy ~xyzzy/.xcat ~xyzzy/.ssh;else chown -R xyzzy ~xyzzy/.xcat ~xyzzy/.ssh;fi [Tue Jan 29 02:11:50 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xdsh c910f02c02p18 "useradd -m xyzzy" [Tue Jan 29 02:11:52 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
[c910f02c02p17]: c910f02c02p18: useradd: warning: the home directory already exists.
c910f02c02p18: Not copying any file from skel directory into it.
c910f02c02p18: Creating mailbox file: File exists
CHECK:rc == 0	[Pass]

RUN:xdsh c910f02c02p18 "( cd ~ && tar cf - .ssh ) | ( cd ~xyzzy && tar xf - )" [Tue Jan 29 02:11:53 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xdsh c910f02c02p18 "chown -R xyzzy ~xyzzy/.ssh" [Tue Jan 29 02:11:54 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:su -c "xdcp c910f02c02p18 /etc/sysctl.conf /tmp/sysctl.conf" - xyzzy [Tue Jan 29 02:11:55 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xdsh c910f02c02p18 "stat -c '%U' /tmp/sysctl.conf" [Tue Jan 29 02:11:57 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f02c02p18: xyzzy
CHECK:output =~ xyzzy	[Pass]

RUN:xdsh c910f02c02p18 "userdel xyzzy" [Tue Jan 29 02:11:58 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:servicenode=`lsdef c910f02c02p18 |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh $servicenode "userdel xyzzy";userdel xyzzy;else userdel xyzzy;fi [Tue Jan 29 02:11:59 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:if [ -e /tmp/site.standa ]; then cat /tmp/site.standa | mkdef -z -f; rm -rf /tmp/site.standa; fi [Tue Jan 29 02:12:01 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::xdcp_nonroot_user::Passed::Time:Tue Jan 29 02:12:01 2019 ::Duration::15 sec------
------Total: 1 , Failed: 0------
```

The UT for xdcp_nonroot_user on flat
```
------START::xdcp_nonroot_user::Time:Thu Jan 17 21:54:25 2019------

RUN:servicenode=`lsdef c910f02c02p19 |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh c910f02c02p17 "useradd -m xyzzy";else useradd -m xyzzy;fi [Thu Jan 17 21:54:25 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
useradd: warning: the home directory already exists.
Not copying any file from skel directory into it.
Creating mailbox file: File exists
CHECK:rc == 0	[Pass]

RUN:servicenode=`lsdef c910f02c02p19 |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh c910f02c02p17 "bash -c \"( cd ~root && tar cf - .xcat .ssh ) | ( cd ~xyzzy && tar xf - )\"";else bash -c "( cd ~root && tar cf - .xcat .ssh ) | ( cd ~xyzzy && tar xf - )";fi [Thu Jan 17 21:54:26 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:servicenode=`lsdef c910f02c02p19 |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh c910f02c02p17 "chown -R xyzzy ~xyzzy/.xcat ~xyzzy/.ssh";else chown -R xyzzy ~xyzzy/.xcat ~xyzzy/.ssh;fi [Thu Jan 17 21:54:26 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xdsh c910f02c02p19 "useradd -m xyzzy" [Thu Jan 17 21:54:27 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
[c910f02c02p16]: c910f02c02p19: useradd: warning: the home directory already exists.
c910f02c02p19: Not copying any file from skel directory into it.
c910f02c02p19: Creating mailbox file: File exists
CHECK:rc == 0	[Pass]

RUN:xdsh c910f02c02p19 "( cd ~ && tar cf - .ssh ) | ( cd ~xyzzy && tar xf - )" [Thu Jan 17 21:54:28 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xdsh c910f02c02p19 "chown -R xyzzy ~xyzzy/.ssh" [Thu Jan 17 21:54:29 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:servicenode=`lsdef c910f02c02p19 |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh c910f02c02p17 "su -c \"xdcp c910f02c02p19 /etc/sysctl.conf /tmp/sysctl.conf\" - xyzzy";else su -c "xdcp c910f02c02p19 /etc/sysctl.conf /tmp/sysctl.conf" - xyzzy;fi [Thu Jan 17 21:54:30 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xdsh c910f02c02p19 "stat -c '%U' /tmp/sysctl.conf" [Thu Jan 17 21:54:31 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f02c02p19: xyzzy
CHECK:output =~ xyzzy	[Pass]

RUN:xdsh c910f02c02p19 "userdel xyzzy" [Thu Jan 17 21:54:32 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:servicenode=`lsdef c910f02c02p19 |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh c910f02c02p17 "userdel xyzzy";else userdel xyzzy;fi [Thu Jan 17 21:54:33 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::xdcp_nonroot_user::Passed::Time:Thu Jan 17 21:54:34 2019 ::Duration::9 sec------
------Total: 1 , Failed: 0------

```

The UT for xdsh_permission_denied on hierarchy
```
------START::xdsh_permission_denied::Time:Thu Jan 17 01:47:19 2019------

RUN:xdsh c910f02c02p18 date [Thu Jan 17 01:47:19 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f02c02p18: Thu Jan 17 01:46:40 EST 2019
#Table configuration
[Table_passwd]
key=system
username=root
password=cluster

[Table_site]
key=nameservers
value=10.2.2.16
key=forwarders
value=10.2.2.15
key=domain
value=pok.stglabs.ibm.com
[Object_network]
Name=10_0_0_0-255_0_0_0
net=10.0.0.0
mask=255.0.0.0
gateway=10.0.0.103

#Object configuration
[Object_node]
Name=c910hmc01
groups=hmc,all
nodetype=hmc
mgt=hmc
username=hscroot
password=abc123

[Object_node]
Name=c910f02fsp02
nodetype=ppc
mtm=8233-E8B
"linux.conf.template" 73L, 1438C
    cons=hmc
CHECK:rc == 0	[Pass]

RUN:servicenode=`lsdef c910f02c02p18 |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh c910f02c02p17 mv /root/.ssh/id_rsa /root/.ssh/id_rsa.backup;else mv /root/.ssh/id_rsa /root/.ssh/id_rsa.backup;fi [Thu Jan 17 01:47:20 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xdsh c910f02c02p18 date [Thu Jan 17 01:47:22 2019]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
[c910f02c02p17]: c910f02c02p18: Permission denied (publickey,gssapi-keyex,gssapi-with-mic,password).

CHECK:rc != 0	[Pass]

RUN:servicenode=`lsdef c910f02c02p18 |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh c910f02c02p17 mv /root/.ssh/id_rsa.backup /root/.ssh/id_rsa;else mv /root/.ssh/id_rsa.backup /root/.ssh/id_rsa;fi [Thu Jan 17 01:47:23 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::xdsh_permission_denied::Passed::Time:Thu Jan 17 01:47:24 2019 ::Duration::5 sec------
------Total: 1 , Failed: 0------
```

The UT for xdsh_permission_denied on flat
```
------START::xdsh_permission_denied::Time:Thu Jan 17 01:47:51 2019------

RUN:xdsh c910f02c02p19 date [Thu Jan 17 01:47:51 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f02c02p19: Thu Jan 17 01:49:13 EST 2019
CHECK:rc == 0	[Pass]

RUN:servicenode=`lsdef c910f02c02p19 |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh c910f02c02p17 mv /root/.ssh/id_rsa /root/.ssh/id_rsa.backup;else mv /root/.ssh/id_rsa /root/.ssh/id_rsa.backup;fi [Thu Jan 17 01:47:52 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xdsh c910f02c02p19 date [Thu Jan 17 01:47:52 2019]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
[c910f02c02p16]: c910f02c02p19: Permission denied (publickey,gssapi-keyex,gssapi-with-mic,password).

CHECK:rc != 0	[Pass]

RUN:servicenode=`lsdef c910f02c02p19 |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh c910f02c02p17 mv /root/.ssh/id_rsa.backup /root/.ssh/id_rsa;else mv /root/.ssh/id_rsa.backup /root/.ssh/id_rsa;fi [Thu Jan 17 01:47:53 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::xdsh_permission_denied::Passed::Time:Thu Jan 17 01:47:54 2019 ::Duration::3 sec------
------Total: 1 , Failed: 0------
```

The UT for xdsh_regular_command on flat
```
------START::xdsh_regular_command::Time:Thu Jan 17 22:06:07 2019------

RUN:servicenode=`lsdef c910f02c02p19 |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh c910f02c02p19 "ps -ef";else XCATBYPASS=1 xdsh c910f02c02p19 "ps -ef";fi [Thu Jan 17 22:06:07 2019]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
/usr/bin/locale: Cannot set LC_CTYPE to default locale: No such file or directory
/usr/bin/locale: Cannot set LC_ALL to default locale: No such file or directory
c910f02c02p19: UID        PID  PPID  C STIME TTY          TIME CMD
c910f02c02p19: root         1     0  0 Jan14 ?        00:00:02 /usr/lib/systemd/systemd --switched-root --system --deserialize 22
c910f02c02p19: root         2     0  0 Jan14 ?        00:00:00 [kthreadd]
c910f02c02p19: root         3     2  0 Jan14 ?        00:00:00 [ksoftirqd/0]
c910f02c02p19: root         5     2  0 Jan14 ?        00:00:00 [kworker/0:0H]
c910f02c02p19: root         7     2  0 Jan14 ?        00:00:00 [migration/0]
c910f02c02p19: root         8     2  0 Jan14 ?        00:00:00 [rcu_bh]
c910f02c02p19: root         9     2  0 Jan14 ?        00:00:17 [rcu_sched]
c910f02c02p19: root        10     2  0 Jan14 ?        00:00:00 [lru-add-drain]
c910f02c02p19: root        11     2  0 Jan14 ?        00:00:00 [watchdog/0]
c910f02c02p19: root        12     2  0 Jan14 ?        00:00:00 [watchdog/1]
c910f02c02p19: root        13     2  0 Jan14 ?        00:00:00 [migration/1]
c910f02c02p19: root        14     2  0 Jan14 ?        00:00:00 [ksoftirqd/1]
c910f02c02p19: root        16     2  0 Jan14 ?        00:00:00 [kworker/1:0H]
c910f02c02p19: root        17     2  0 Jan14 ?        00:00:00 [watchdog/2]
c910f02c02p19: root        18     2  0 Jan14 ?        00:00:00 [migration/2]
c910f02c02p19: root        19     2  0 Jan14 ?        00:00:00 [ksoftirqd/2]
c910f02c02p19: root        21     2  0 Jan14 ?        00:00:00 [kworker/2:0H]
c910f02c02p19: root        22     2  0 Jan14 ?        00:00:00 [watchdog/3]
c910f02c02p19: root        23     2  0 Jan14 ?        00:00:00 [migration/3]
c910f02c02p19: root        24     2  0 Jan14 ?        00:00:00 [ksoftirqd/3]
c910f02c02p19: root        26     2  0 Jan14 ?        00:00:00 [kworker/3:0H]
c910f02c02p19: root        27     2  0 Jan14 ?        00:00:00 [kdevtmpfs]
c910f02c02p19: root        28     2  0 Jan14 ?        00:00:00 [netns]
c910f02c02p19: root        29     2  0 Jan14 ?        00:00:00 [eehd]
c910f02c02p19: root        30     2  0 Jan14 ?        00:00:00 [khungtaskd]
c910f02c02p19: root        31     2  0 Jan14 ?        00:00:00 [writeback]
c910f02c02p19: root        32     2  0 Jan14 ?        00:00:00 [kworker/1:1]
c910f02c02p19: root        33     2  0 Jan14 ?        00:00:00 [kintegrityd]
c910f02c02p19: root        34     2  0 Jan14 ?        00:00:00 [bioset]
c910f02c02p19: root        35     2  0 Jan14 ?        00:00:00 [bioset]
c910f02c02p19: root        36     2  0 Jan14 ?        00:00:00 [bioset]
c910f02c02p19: root        37     2  0 Jan14 ?        00:00:00 [kblockd]
c910f02c02p19: root        38     2  0 Jan14 ?        00:00:00 [md]
c910f02c02p19: root        39     2  0 Jan14 ?        00:00:00 [watchdogd]
c910f02c02p19: root        41     2  0 Jan14 ?        00:00:00 [kswapd0]
c910f02c02p19: root        42     2  0 Jan14 ?        00:00:00 [ksmd]
c910f02c02p19: root        43     2  0 Jan14 ?        00:00:00 [khugepaged]
c910f02c02p19: root        44     2  0 Jan14 ?        00:00:00 [crypto]
c910f02c02p19: root        52     2  0 Jan14 ?        00:00:00 [kthrotld]
c910f02c02p19: root        53     2  0 Jan14 ?        00:00:00 [khvcd]
c910f02c02p19: root        54     2  0 Jan14 ?        00:00:00 [kmpath_rdacd]
c910f02c02p19: root        55     2  0 Jan14 ?        00:00:00 [kaluad]
c910f02c02p19: root        56     2  0 Jan14 ?        00:00:00 [kpsmoused]
c910f02c02p19: root        57     2  0 Jan14 ?        00:00:00 [ipv6_addrconf]
c910f02c02p19: root        58     2  0 Jan14 ?        00:00:00 [deferwq]
c910f02c02p19: root        59     2  0 Jan14 ?        00:00:00 [kworker/u32:1]
c910f02c02p19: root        94     2  0 Jan14 ?        00:00:00 [kauditd]
c910f02c02p19: root       365     2  0 Jan14 ?        00:00:07 [kworker/3:2]
c910f02c02p19: root       694     2  0 Jan14 ?        00:00:00 [scsi_eh_0]
c910f02c02p19: root       702     2  0 Jan14 ?        00:00:00 [scsi_tmf_0]
c910f02c02p19: root       705     2  0 Jan14 ?        00:00:00 [ibmvscsi_0]
c910f02c02p19: root       726     2  0 Jan14 ?        00:00:00 [kworker/u32:2]
c910f02c02p19: postfix    943  4069  0 21:20 ?        00:00:00 pickup -l -t unix -u
c910f02c02p19: root      1018     2  0 21:45 ?        00:00:00 [kworker/0:2]
c910f02c02p19: root      1044     2  0 Jan14 ?        00:00:00 [kdmflush]
c910f02c02p19: root      1045     2  0 Jan14 ?        00:00:00 [bioset]
c910f02c02p19: root      1067     2  0 Jan14 ?        00:00:00 [bioset]
c910f02c02p19: root      1071     2  0 Jan14 ?        00:00:00 [xfsalloc]
c910f02c02p19: root      1074     2  0 Jan14 ?        00:00:00 [xfs_mru_cache]
c910f02c02p19: root      1081     2  0 Jan14 ?        00:00:00 [xfs-buf/dm-0]
c910f02c02p19: root      1083     2  0 Jan14 ?        00:00:00 [xfs-data/dm-0]
c910f02c02p19: root      1084     2  0 Jan14 ?        00:00:00 [xfs-conv/dm-0]
c910f02c02p19: root      1085     2  0 Jan14 ?        00:00:00 [xfs-cil/dm-0]
c910f02c02p19: root      1087     2  0 Jan14 ?        00:00:00 [xfs-reclaim/dm-]
c910f02c02p19: root      1088     2  0 Jan14 ?        00:00:00 [xfs-log/dm-0]
c910f02c02p19: root      1089     2  0 Jan14 ?        00:00:00 [xfs-eofblocks/d]
c910f02c02p19: root      1091     2  0 Jan14 ?        00:00:00 [xfsaild/dm-0]
c910f02c02p19: root      1092     2  0 Jan14 ?        00:00:00 [kworker/0:1H]
c910f02c02p19: root      1113     2  0 21:54 ?        00:00:00 [kworker/3:0]
c910f02c02p19: root      1140     2  0 21:54 ?        00:00:00 [kworker/1:0]
c910f02c02p19: root      1163     1  0 Jan14 ?        00:00:02 /usr/lib/systemd/systemd-journald
c910f02c02p19: root      1193     1  0 Jan14 ?        00:00:00 /usr/sbin/lvmetad -f
c910f02c02p19: root      1198     1  0 Jan14 ?        00:00:00 /usr/lib/systemd/systemd-udevd
c910f02c02p19: root      1244     2  0 22:01 ?        00:00:00 [kworker/0:1]
c910f02c02p19: root      1245  2714  0 22:07 ?        00:00:00 sshd: root@notty
c910f02c02p19: root      1247  1245  0 22:07 ?        00:00:00 bash -c export NODE=c910f02c02p19; export LANG=en_US.UTF-8 LC_CTYPE=UTF-8 LC_NUMERIC="en_US.UTF-8" LC_TIME="en_US.UTF-8" LC_COLLATE="en_US.UTF-8" LC_MONETARY="en_US.UTF-8" LC_MESSAGES="en_US.UTF-8" LC_PAPER="en_US.UTF-8" LC_NAME="en_US.UTF-8" LC_ADDRESS="en_US.UTF-8" LC_TELEPHONE="en_US.UTF-8" LC_MEASUREMENT="en_US.UTF-8" LC_IDENTIFICATION="en_US.UTF-8" LC_ALL= PERL_BADLANG=0 ; ps -ef; export DSH_TARGET_RC=$?; echo ":DSH_TARGET_RC=${DSH_TARGET_RC}:"
c910f02c02p19: root      1250  1247  0 22:07 ?        00:00:00 ps -ef
c910f02c02p19: root      2139     2  0 Jan14 ?        00:00:00 [xfs-buf/sda2]
c910f02c02p19: root      2140     2  0 Jan14 ?        00:00:00 [xfs-data/sda2]
c910f02c02p19: root      2141     2  0 Jan14 ?        00:00:00 [xfs-conv/sda2]
c910f02c02p19: root      2142     2  0 Jan14 ?        00:00:00 [xfs-cil/sda2]
c910f02c02p19: root      2143     2  0 Jan14 ?        00:00:00 [xfs-reclaim/sda]
c910f02c02p19: root      2144     2  0 Jan14 ?        00:00:00 [xfs-log/sda2]
c910f02c02p19: root      2145     2  0 Jan14 ?        00:00:00 [xfs-eofblocks/s]
c910f02c02p19: root      2146     2  0 Jan14 ?        00:00:00 [xfsaild/sda2]
c910f02c02p19: root      2175     2  0 Jan14 ?        00:00:00 [rpciod]
c910f02c02p19: root      2176     2  0 Jan14 ?        00:00:00 [xprtiod]
c910f02c02p19: root      2182     1  0 Jan14 ?        00:00:00 /sbin/auditd
c910f02c02p19: polkitd   2211     1  0 Jan14 ?        00:00:01 /usr/lib/polkit-1/polkitd --no-debug
c910f02c02p19: dbus      2213     1  0 Jan14 ?        00:00:02 /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation
c910f02c02p19: rpc       2233     1  0 Jan14 ?        00:00:00 /sbin/rpcbind -w
c910f02c02p19: root      2261     1  0 Jan14 ?        00:00:00 /usr/sbin/gssproxy -D
c910f02c02p19: root      2267     1  0 Jan14 ?        00:00:01 /usr/lib/systemd/systemd-logind
c910f02c02p19: root      2270     1  0 Jan14 ?        00:00:13 /usr/sbin/irqbalance --foreground
c910f02c02p19: root      2283     1  0 Jan14 ?        00:00:00 /usr/sbin/crond -n
c910f02c02p19: root      2287     2  0 Jan14 ?        00:00:00 [kworker/2:2]
c910f02c02p19: root      2290     1  0 Jan14 tty1     00:00:00 /sbin/agetty --noclear tty1 linux
c910f02c02p19: root      2291     1  0 Jan14 ?        00:00:00 login -- root
c910f02c02p19: chrony    2323     1  0 Jan14 ?        00:00:00 /usr/sbin/chronyd
c910f02c02p19: root      2392     1  0 Jan14 ?        00:00:00 /usr/sbin/rtas_errd
c910f02c02p19: root      2558     1  0 Jan14 ?        00:00:00 /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient-3b9a427e-91ff-478e-aa10-2910d8f53eb7-eth0.lease -pf /var/run/dhclient-eth0.pid eth0
c910f02c02p19: root      2638     2  0 Jan14 ?        00:00:00 [kworker/1:1H]
c910f02c02p19: root      2676  2291  0 Jan14 hvc0     00:00:00 -bash
c910f02c02p19: root      2708     1  0 Jan14 ?        00:00:09 /usr/bin/python2 -Es /usr/sbin/tuned -l -P
c910f02c02p19: root      2712     1  0 Jan14 ?        00:00:04 /usr/sbin/rsyslogd -n
c910f02c02p19: root      2714     1  0 Jan14 ?        00:00:00 /usr/sbin/sshd -D
c910f02c02p19: root      2725     1  0 Jan14 ?        00:00:00 /usr/bin/rhsmcertd
c910f02c02p19: root      2726     1  0 Jan14 ?        00:00:00 rhnsd
c910f02c02p19: root      4069     1  0 Jan14 ?        00:00:00 /usr/libexec/postfix/master -w
c910f02c02p19: postfix   4114  4069  0 Jan14 ?        00:00:00 qmgr -l -t unix -u
c910f02c02p19: root      4748     2  0 Jan14 ?        00:00:00 [kworker/2:1H]
c910f02c02p19: root     10776     2  0 Jan14 ?        00:00:00 [kworker/3:1H]
c910f02c02p19: root     24767     2  0 Jan14 ?        00:00:00 [kworker/2:0]
c910f02c02p19: bash: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
c910f02c02p19: bash: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
CHECK:rc == 0	[Pass]
CHECK:output =~ c910f02c02p19:\s+UID\s+PID\s+PPID\s+C\s+STIME\s+TTY\s+TIME\s+CMD	[Pass]

------END::xdsh_regular_command::Passed::Time:Thu Jan 17 22:06:10 2019 ::Duration::3 sec------
------Total: 1 , Failed: 0------
```

The UT for xdsh_regular_command on hierarchy
```
------START::xdsh_regular_command::Time:Thu Jan 17 22:07:08 2019------

RUN:servicenode=`lsdef c910f02c02p18 |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh c910f02c02p18 "ps -ef";else XCATBYPASS=1 xdsh c910f02c02p18 "ps -ef";fi [Thu Jan 17 22:07:08 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
c910f02c02p18: UID        PID  PPID  C STIME TTY          TIME CMD
c910f02c02p18: root         1     0  0 Jan09 ?        00:00:04 /usr/lib/systemd/systemd --switched-root --system --deserialize 22
c910f02c02p18: root         2     0  0 Jan09 ?        00:00:00 [kthreadd]
c910f02c02p18: root         3     2  0 Jan09 ?        00:00:00 [ksoftirqd/0]
c910f02c02p18: root         5     2  0 Jan09 ?        00:00:00 [kworker/0:0H]
c910f02c02p18: root         7     2  0 Jan09 ?        00:00:00 [migration/0]
c910f02c02p18: root         8     2  0 Jan09 ?        00:00:00 [rcu_bh]
c910f02c02p18: root         9     2  0 Jan09 ?        00:00:42 [rcu_sched]
c910f02c02p18: root        10     2  0 Jan09 ?        00:00:00 [lru-add-drain]
c910f02c02p18: root        11     2  0 Jan09 ?        00:00:01 [watchdog/0]
c910f02c02p18: root        12     2  0 Jan09 ?        00:00:01 [watchdog/1]
c910f02c02p18: root        13     2  0 Jan09 ?        00:00:00 [migration/1]
c910f02c02p18: root        14     2  0 Jan09 ?        00:00:00 [ksoftirqd/1]
c910f02c02p18: root        16     2  0 Jan09 ?        00:00:00 [kworker/1:0H]
c910f02c02p18: root        17     2  0 Jan09 ?        00:00:01 [watchdog/2]
c910f02c02p18: root        18     2  0 Jan09 ?        00:00:00 [migration/2]
c910f02c02p18: root        19     2  0 Jan09 ?        00:00:00 [ksoftirqd/2]
c910f02c02p18: root        21     2  0 Jan09 ?        00:00:00 [kworker/2:0H]
c910f02c02p18: root        22     2  0 Jan09 ?        00:00:01 [watchdog/3]
c910f02c02p18: root        23     2  0 Jan09 ?        00:00:00 [migration/3]
c910f02c02p18: root        24     2  0 Jan09 ?        00:00:00 [ksoftirqd/3]
c910f02c02p18: root        26     2  0 Jan09 ?        00:00:00 [kworker/3:0H]
c910f02c02p18: root        27     2  0 Jan09 ?        00:00:00 [kdevtmpfs]
c910f02c02p18: root        28     2  0 Jan09 ?        00:00:00 [netns]
c910f02c02p18: root        29     2  0 Jan09 ?        00:00:00 [eehd]
c910f02c02p18: root        30     2  0 Jan09 ?        00:00:00 [khungtaskd]
c910f02c02p18: root        31     2  0 Jan09 ?        00:00:00 [writeback]
c910f02c02p18: root        33     2  0 Jan09 ?        00:00:00 [kintegrityd]
c910f02c02p18: root        34     2  0 Jan09 ?        00:00:00 [bioset]
c910f02c02p18: root        35     2  0 Jan09 ?        00:00:00 [bioset]
c910f02c02p18: root        36     2  0 Jan09 ?        00:00:00 [bioset]
c910f02c02p18: root        37     2  0 Jan09 ?        00:00:00 [kblockd]
c910f02c02p18: root        38     2  0 Jan09 ?        00:00:00 [md]
c910f02c02p18: root        39     2  0 Jan09 ?        00:00:00 [watchdogd]
c910f02c02p18: root        40     2  0 Jan09 ?        00:00:09 [kworker/0:1]
c910f02c02p18: root        41     2  0 Jan09 ?        00:00:00 [kswapd0]
c910f02c02p18: root        42     2  0 Jan09 ?        00:00:00 [ksmd]
c910f02c02p18: root        43     2  0 Jan09 ?        00:00:00 [khugepaged]
c910f02c02p18: root        44     2  0 Jan09 ?        00:00:00 [crypto]
c910f02c02p18: root        52     2  0 Jan09 ?        00:00:00 [kthrotld]
c910f02c02p18: root        53     2  0 Jan09 ?        00:00:00 [khvcd]
c910f02c02p18: root        54     2  0 Jan09 ?        00:00:00 [kmpath_rdacd]
c910f02c02p18: root        55     2  0 Jan09 ?        00:00:00 [kaluad]
c910f02c02p18: root        56     2  0 Jan09 ?        00:00:00 [kpsmoused]
c910f02c02p18: root        57     2  0 Jan09 ?        00:00:00 [ipv6_addrconf]
c910f02c02p18: root        58     2  0 Jan09 ?        00:00:00 [deferwq]
c910f02c02p18: root        59     2  0 Jan09 ?        00:00:00 [kworker/u32:1]
c910f02c02p18: root        95     2  0 Jan09 ?        00:00:00 [kauditd]
c910f02c02p18: root        96     2  0 Jan09 ?        00:00:11 [kworker/1:2]
c910f02c02p18: root       436     2  0 Jan09 ?        00:00:06 [kworker/3:2]
c910f02c02p18: root       703     2  0 Jan09 ?        00:00:00 [scsi_eh_0]
c910f02c02p18: root       708     2  0 Jan09 ?        00:00:00 [scsi_tmf_0]
c910f02c02p18: root       718     2  0 Jan09 ?        00:00:00 [ibmvscsi_0]
c910f02c02p18: root       738     2  0 Jan09 ?        00:00:00 [kworker/u32:2]
c910f02c02p18: root      1044     2  0 Jan09 ?        00:00:00 [kdmflush]
c910f02c02p18: root      1045     2  0 Jan09 ?        00:00:00 [bioset]
c910f02c02p18: root      1067     2  0 Jan09 ?        00:00:00 [bioset]
c910f02c02p18: root      1072     2  0 Jan09 ?        00:00:00 [xfsalloc]
c910f02c02p18: root      1073     2  0 Jan09 ?        00:00:00 [xfs_mru_cache]
c910f02c02p18: root      1077     2  0 Jan09 ?        00:00:00 [xfs-buf/dm-0]
c910f02c02p18: root      1079     2  0 Jan09 ?        00:00:00 [xfs-data/dm-0]
c910f02c02p18: root      1081     2  0 Jan09 ?        00:00:00 [xfs-conv/dm-0]
c910f02c02p18: root      1087     2  0 Jan09 ?        00:00:00 [xfs-cil/dm-0]
c910f02c02p18: root      1088     2  0 Jan09 ?        00:00:00 [xfs-reclaim/dm-]
c910f02c02p18: root      1089     2  0 Jan09 ?        00:00:00 [xfs-log/dm-0]
c910f02c02p18: root      1090     2  0 Jan09 ?        00:00:00 [xfs-eofblocks/d]
c910f02c02p18: root      1091     2  0 Jan09 ?        00:00:01 [xfsaild/dm-0]
c910f02c02p18: root      1092     2  0 Jan09 ?        00:00:00 [kworker/0:1H]
c910f02c02p18: root      1163     1  0 Jan09 ?        00:00:02 /usr/lib/systemd/systemd-journald
c910f02c02p18: root      1193     1  0 Jan09 ?        00:00:00 /usr/lib/systemd/systemd-udevd
c910f02c02p18: root      1194     1  0 Jan09 ?        00:00:00 /usr/sbin/lvmetad -f
c910f02c02p18: root      2136     2  0 Jan09 ?        00:00:00 [xfs-buf/sda2]
c910f02c02p18: root      2137     2  0 Jan09 ?        00:00:00 [xfs-data/sda2]
c910f02c02p18: root      2138     2  0 Jan09 ?        00:00:00 [xfs-conv/sda2]
c910f02c02p18: root      2139     2  0 Jan09 ?        00:00:00 [xfs-cil/sda2]
c910f02c02p18: root      2140     2  0 Jan09 ?        00:00:00 [xfs-reclaim/sda]
c910f02c02p18: root      2141     2  0 Jan09 ?        00:00:00 [xfs-log/sda2]
c910f02c02p18: root      2142     2  0 Jan09 ?        00:00:00 [xfs-eofblocks/s]
c910f02c02p18: root      2143     2  0 Jan09 ?        00:00:00 [xfsaild/sda2]
c910f02c02p18: root      2172     2  0 Jan09 ?        00:00:00 [rpciod]
c910f02c02p18: root      2173     2  0 Jan09 ?        00:00:00 [xprtiod]
c910f02c02p18: root      2179     2  0 Jan09 ?        00:00:00 [kworker/3:1H]
c910f02c02p18: root      2180     1  0 Jan09 ?        00:00:00 /sbin/auditd
c910f02c02p18: polkitd   2208     1  0 Jan09 ?        00:00:01 /usr/lib/polkit-1/polkitd --no-debug
c910f02c02p18: root      2214     1  0 Jan09 ?        00:00:01 /usr/lib/systemd/systemd-logind
c910f02c02p18: dbus      2215     1  0 Jan09 ?        00:00:03 /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation
c910f02c02p18: rpc       2222     1  0 Jan09 ?        00:00:00 /sbin/rpcbind -w
c910f02c02p18: chrony    2224     1  0 Jan09 ?        00:00:00 /usr/sbin/chronyd
c910f02c02p18: root      2227     1  0 Jan09 ?        00:00:00 /usr/sbin/gssproxy -D
c910f02c02p18: root      2233     1  0 Jan09 ?        00:00:29 /usr/sbin/irqbalance --foreground
c910f02c02p18: root      2285     1  0 Jan09 ?        00:00:00 /usr/sbin/crond -n
c910f02c02p18: root      2296     1  0 Jan09 ?        00:00:00 login -- root
c910f02c02p18: root      2297     1  0 Jan09 tty1     00:00:00 /sbin/agetty --noclear tty1 linux
c910f02c02p18: root      2385     1  0 Jan09 ?        00:00:00 /usr/sbin/rtas_errd
c910f02c02p18: root      2555     1  0 Jan09 ?        00:00:00 /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient-cfc64414-f070-4303-a88f-0b70e3be488a-eth0.lease -pf /var/run/dhclient-eth0.pid eth0
c910f02c02p18: root      2634     2  0 Jan09 ?        00:00:00 [kworker/1:1H]
c910f02c02p18: root      2637     2  0 Jan09 ?        00:00:00 [kworker/2:1H]
c910f02c02p18: root      2691     1  0 Jan09 ?        00:00:21 /usr/bin/python2 -Es /usr/sbin/tuned -l -P
c910f02c02p18: root      2695     1  0 Jan09 ?        00:00:09 /usr/sbin/rsyslogd -n
c910f02c02p18: root      2696     1  0 Jan09 ?        00:00:00 /usr/sbin/sshd -D
c910f02c02p18: root      2708     1  0 Jan09 ?        00:00:00 rhnsd
c910f02c02p18: root      2718     1  0 Jan09 ?        00:00:00 /usr/bin/rhsmcertd
c910f02c02p18: root      4118     1  0 Jan09 ?        00:00:01 /usr/libexec/postfix/master -w
c910f02c02p18: postfix   4134  4118  0 Jan09 ?        00:00:00 qmgr -l -t unix -u
c910f02c02p18: root     10062  2296  0 Jan09 hvc0     00:00:00 -bash
c910f02c02p18: root     24069     2  0 Jan12 ?        00:00:00 [kworker/1:1]
c910f02c02p18: root     26040     2  0 Jan14 ?        00:00:00 [kworker/0:0]
c910f02c02p18: root     28564     2  0 Jan15 ?        00:00:00 [kworker/3:0]
c910f02c02p18: postfix  30277  4118  0 21:33 ?        00:00:00 pickup -l -t unix -u
c910f02c02p18: root     30332     2  0 21:48 ?        00:00:00 [kworker/2:0]
c910f02c02p18: root     30391     2  0 21:54 ?        00:00:00 [kworker/2:2]
c910f02c02p18: root     30404     2  0 22:01 ?        00:00:00 [kworker/2:1]
c910f02c02p18: root     30405  2696  0 22:06 ?        00:00:00 sshd: root@notty
c910f02c02p18: root     30407 30405  0 22:06 ?        00:00:00 bash -c export NODE=c910f02c02p18; export LANG=en_US.UTF-8 LC_CTYPE="C" LC_NUMERIC="C" LC_TIME="C" LC_COLLATE="C" LC_MONETARY="C" LC_MESSAGES="C" LC_PAPER="C" LC_NAME="C" LC_ADDRESS="C" LC_TELEPHONE="C" LC_MEASUREMENT="C" LC_IDENTIFICATION="C" LC_ALL=C PERL_BADLANG=0 ; ps -ef; export DSH_TARGET_RC=$?; echo ":DSH_TARGET_RC=${DSH_TARGET_RC}:"
c910f02c02p18: root     30410 30407  0 22:06 ?        00:00:00 ps -ef
c910f02c02p18: :DSH_TARGET_RC=0:
CHECK:rc == 0	[Pass]
CHECK:output =~ c910f02c02p18:\s+UID\s+PID\s+PPID\s+C\s+STIME\s+TTY\s+TIME\s+CMD	[Pass]

------END::xdsh_regular_command::Passed::Time:Thu Jan 17 22:07:10 2019 ::Duration::2 sec------
------Total: 1 , Failed: 0------
```

The UT for chtab_err_table 
```
------START::chtab_err_table::Time:Thu Jan 17 22:08:05 2019------

RUN:chtab error=error site.comment=error [Thu Jan 17 22:08:05 2019]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
DBD::mysql::st execute failed: Unknown column 'error' in 'where clause' at /opt/xcat/lib/perl/xCAT/Table.pm line 1770.
DBD::mysql::st fetchrow_arrayref failed: fetch() without execute() at /opt/xcat/lib/perl/xCAT/Table.pm line 1774.
DBD::mysql::st execute failed: Unknown column 'comment' in 'field list' at /opt/xcat/lib/perl/xCAT/Table.pm line 1911.
CHECK:rc != 0	[Pass]
CHECK:output =~ no such column|column \"error\" does not exist|Unknown column \'error\'	[Pass]

------END::chtab_err_table::Passed::Time:Thu Jan 17 22:08:05 2019 ::Duration::0 sec------
------Total: 1 , Failed: 0------
```