### PR TITLE
Revise openssl settings for RHEL 8

### DIFF
--- a/xCAT-server/share/xcat/ca/openssl.cnf.tmpl
+++ b/xCAT-server/share/xcat/ca/openssl.cnf.tmpl
@@ -6,7 +6,7 @@
 # This definition stops the following lines choking if HOME isn't
 # defined.
 HOME			= .
-RANDFILE		= $ENV::HOME/.rnd
+#RANDFILE		= $ENV::HOME/.rnd
 
 # Extra OBJECT IDENTIFIER info:
 #oid_file		= $ENV::HOME/.oid

--- a/xCAT-server/share/xcat/ca/openssl.cnf.tmpl
+++ b/xCAT-server/share/xcat/ca/openssl.cnf.tmpl
@@ -30,6 +30,11 @@ oid_section		= new_oids
 # Or use config file substitution like this:
 # testoid2=${testoid1}.5.6
 
+# Policies used by the TSA examples.
+#tsa_policy1 = 1.2.3.4.1
+#tsa_policy2 = 1.2.3.4.5.6
+#tsa_policy3 = 1.2.3.4.5.7
+
 ####################################################################
 [ ca ]
 default_ca	= CA_default		# The default ca section
@@ -245,7 +250,7 @@ subjectAltName = @alt_names
 
 subjectKeyIdentifier=hash
 
-authorityKeyIdentifier=keyid:always,issuer:always
+authorityKeyIdentifier=keyid:always,issuer
 
 basicConstraints = critical,CA:true
 
@@ -274,7 +279,7 @@ nsCertType = sslCA, emailCA
 # Only issuerAltName and authorityKeyIdentifier make any sense in a CRL.
 
 # issuerAltName=issuer:copy
-authorityKeyIdentifier=keyid:always,issuer:always
+authorityKeyIdentifier=keyid:always
 
 [ proxy_cert_ext ]
 # These extensions should be added when creating a proxy certificate
@@ -307,7 +312,7 @@ nsComment			= "OpenSSL Generated Certificate"
 
 # PKIX recommendations harmless if included in all certificates.
 subjectKeyIdentifier=hash
-authorityKeyIdentifier=keyid,issuer:always
+authorityKeyIdentifier=keyid,issuer
 
 # This stuff is for subjectAltName and issuerAltname.
 # Import the email address.

--- a/xCAT-server/share/xcat/ca/openssl.cnf.tmpl
+++ b/xCAT-server/share/xcat/ca/openssl.cnf.tmpl
@@ -3,10 +3,13 @@
 # This is mostly being used for generation of certificate requests.
 #
 
+# Note that you can include other files from the main configuration
+# file using the .include directive.
+#.include filename
+
 # This definition stops the following lines choking if HOME isn't
 # defined.
 HOME			= .
-#RANDFILE		= $ENV::HOME/.rnd
 
 # Extra OBJECT IDENTIFIER info:
 #oid_file		= $ENV::HOME/.oid
@@ -21,7 +24,7 @@ oid_section		= new_oids
 
 [ new_oids ]
 
-# We can add new OIDs in here for use by 'ca' and 'req'.
+# We can add new OIDs in here for use by 'ca', 'req' and 'ts'.
 # Add a simple OID like this:
 # testoid1=1.2.3.4
 # Or use config file substitution like this:
@@ -37,7 +40,7 @@ default_ca	= CA_default		# The default ca section
 dir		= ##XCATCADIR##		# Where everything is kept
 certs		= $dir/certs		# Where the issued certs are kept
 crl_dir		= $dir/crl		# Where the issued crl are kept
-database	= $dir/index	# database index file.
+database	= $dir/index		# database index file.
 #unique_subject	= no			# Set to 'no' to allow creation of
 					# several ctificates with same subject.
 new_certs_dir	= $dir/certs		# default place for new certs.
@@ -47,10 +50,9 @@ serial		= $dir/serial 		# The current serial number
 crlnumber	= $dir/crlnumber	# the current crl number
 					# must be commented out to leave a V1 CRL
 crl		= $dir/crl.pem 		# The current CRL
-private_key	= $dir/private/ca-key.pem # The private key
-RANDFILE	= $dir/private/.rand	# private random number file
+private_key	= $dir/private/ca-key.pem	# The private key
 
-x509_extensions	= usr_cert		# The extentions to add to the cert
+x509_extensions	= usr_cert		# The extensions to add to the cert
 
 # Comment out the following two lines for the "traditional"
 # (and highly broken) format.
@@ -67,7 +69,7 @@ cert_opt 	= ca_default		# Certificate field options
 
 default_days	= 7300			# how long to certify for
 default_crl_days= 30			# how long before next CRL
-default_md	= sha1			# which md to use.
+default_md	= default		# which md to use.
 preserve	= no			# keep passed DN ordering
 
 # A few difference way of specifying how similar the request should look
@@ -102,7 +104,7 @@ default_bits		= 2048
 default_keyfile 	= private/ca-key.pem
 distinguished_name	= req_distinguished_name
 attributes		= req_attributes
-x509_extensions	= v3_ca	# The extentions to add to the self signed cert
+x509_extensions	= v3_ca	# The extensions to add to the self signed cert
 
 # Passwords for private keys if not present they will be prompted for
 # input_password = secret
@@ -110,13 +112,12 @@ x509_extensions	= v3_ca	# The extentions to add to the self signed cert
 
 # This sets a mask for permitted string types. There are several options.
 # default: PrintableString, T61String, BMPString.
-# pkix	 : PrintableString, BMPString.
-# utf8only: only UTF8Strings.
+# pkix	 : PrintableString, BMPString (PKIX recommendation before 2004)
+# utf8only: only UTF8Strings (PKIX recommendation after 2004).
 # nombstr : PrintableString, T61String (no BMPStrings or UTF8Strings).
 # MASK:XXXX a literal mask value.
-# WARNING: current versions of Netscape crash on BMPStrings or UTF8Strings
-# so use this option with caution!
-string_mask = nombstr
+# WARNING: ancient versions of Netscape crash on BMPStrings or UTF8Strings.
+string_mask = utf8only
 
 # req_extensions = v3_req # The extensions to add to a certificate request
 
@@ -141,7 +142,7 @@ string_mask = nombstr
 #organizationalUnitName		= Organizational Unit Name (eg, section)
 #organizationalUnitName_default	=
 
-commonName			= Common Name (eg, YOUR name)
+commonName			= Common Name (e.g. server FQDN or YOUR name)
 commonName_max			= 64
 
 #emailAddress			= Email Address
@@ -218,6 +219,9 @@ authorityKeyIdentifier=keyid,issuer
 #nsCaPolicyUrl
 #nsSslServerName
 
+# This is required for TSA certificates.
+# extendedKeyUsage = critical,timeStamping
+
 [ v3_req ]
 
 # Extensions to add to a certificate request
@@ -243,11 +247,7 @@ subjectKeyIdentifier=hash
 
 authorityKeyIdentifier=keyid:always,issuer:always
 
-# This is what PKIX recommends but some broken software chokes on critical
-# extensions.
-#basicConstraints = critical,CA:true
-# So we do this instead.
-basicConstraints = CA:true
+basicConstraints = critical,CA:true
 
 # Key usage: this is typical for a CA certificate. However since it will
 # prevent it being used as an test self-signed certificate it is best
@@ -328,3 +328,35 @@ authorityKeyIdentifier=keyid,issuer:always
 
 # This really needs to be in place for it to be a proxy certificate.
 proxyCertInfo=critical,language:id-ppl-anyLanguage,pathlen:3,policy:foo
+
+####################################################################
+[ tsa ]
+
+default_tsa = tsa_config1	# the default TSA section
+
+[ tsa_config1 ]
+
+# These are used by the TSA reply generation only.
+dir		= ./demoCA		# TSA root directory
+serial		= $dir/tsaserial	# The current serial number (mandatory)
+crypto_device	= builtin		# OpenSSL engine to use for signing
+signer_cert	= $dir/tsacert.pem 	# The TSA signing certificate
+					# (optional)
+certs		= $dir/cacert.pem	# Certificate chain to include in reply
+					# (optional)
+signer_key	= $dir/private/tsakey.pem # The TSA private key (optional)
+signer_digest  = sha256			# Signing digest to use. (Optional)
+default_policy	= tsa_policy1		# Policy if request did not specify it
+					# (optional)
+other_policies	= tsa_policy2, tsa_policy3	# acceptable policies (optional)
+digests     = sha1, sha256, sha384, sha512  # Acceptable message digests (mandatory)
+accuracy	= secs:1, millisecs:500, microsecs:100	# (optional)
+clock_precision_digits  = 0	# number of digits after dot. (optional)
+ordering		= yes	# Is ordering defined for timestamps?
+				# (optional, default: no)
+tsa_name		= yes	# Must the TSA name be included in the reply?
+				# (optional, default: no)
+ess_cert_id_chain	= no	# Must the ESS cert id chain be included?
+				# (optional, default: no)
+ess_cert_id_alg		= sha1	# algorithm to compute certificate
+				# identifier (optional, default: sha1)

--- a/xCAT-server/share/xcat/netboot/add-on/statelite/rc.localdisk
+++ b/xCAT-server/share/xcat/netboot/add-on/statelite/rc.localdisk
@@ -68,9 +68,9 @@ xCATCmd () {
 # $2 is the command
     ARCH=`uname -m`
     if [ x$ARCH = x"ppc64" -a x$OS = x"rh" ]; then
-        echo "<xcatrequest>\n<command>${2}</command>\n</xcatrequest>" | /usr/sbin/chroot ${MNTDIR} /usr/bin/openssl s_client -quiet -no_ssl3 $(/usr/sbin/chroot ${MNTDIR} /usr/bin/openssl s_client -help 2>&1 | grep -m 1 -o -- -no_ssl2) -connect ${1} -rand /bin/nice 2>/dev/null
+        echo "<xcatrequest>\n<command>${2}</command>\n</xcatrequest>" | /usr/sbin/chroot ${MNTDIR} /usr/bin/openssl s_client -quiet -no_ssl3 -connect ${1} -rand /bin/nice 2>/dev/null
     else
-        echo "<xcatrequest>\n<command>${2}</command>\n</xcatrequest>" | LD_LIBRARY_PATH=${MNTDIR}/lib64:${MNTDIR}/usr/lib64 ${MNTDIR}/usr/bin/openssl s_client -quiet -no_ssl3 $(LD_LIBRARY_PATH=${MNTDIR}/lib64:${MNTDIR}/usr/lib64 ${MNTDIR}/usr/bin/openssl s_client -help 2>&1 | grep -m 1 -o -- -no_ssl2) -connect ${1} -rand /bin/nice 2>/dev/null
+        echo "<xcatrequest>\n<command>${2}</command>\n</xcatrequest>" | LD_LIBRARY_PATH=${MNTDIR}/lib64:${MNTDIR}/usr/lib64 ${MNTDIR}/usr/bin/openssl s_client -quiet -no_ssl3 -connect ${1} -rand /bin/nice 2>/dev/null
     fi
 }
 

--- a/xCAT-server/share/xcat/netboot/add-on/statelite/rc.statelite
+++ b/xCAT-server/share/xcat/netboot/add-on/statelite/rc.statelite
@@ -128,7 +128,7 @@ GetSyncInfo () {
 xCATCmd () {
 # $1 is the xCAT server
 # $2 is the command
-	echo "<xcatrequest>\n<command>${2}</command>\n</xcatrequest>" | LD_LIBRARY_PATH=${MNTDIR}/lib64:${MNTDIR}/usr/lib64 ${MNTDIR}/usr/bin/openssl s_client -quiet -no_ssl3 $(LD_LIBRARY_PATH=${MNTDIR}/lib64:${MNTDIR}/usr/lib64 ${MNTDIR}/usr/bin/openssl s_client -help 2>&1 | grep -m 1 -o -- -no_ssl2) -connect ${1} -rand /bin/nice 2>/dev/null
+	echo "<xcatrequest>\n<command>${2}</command>\n</xcatrequest>" | LD_LIBRARY_PATH=${MNTDIR}/lib64:${MNTDIR}/usr/lib64 ${MNTDIR}/usr/bin/openssl s_client -quiet -no_ssl3 -connect ${1} -rand /bin/nice 2>/dev/null
 
 }
 

--- a/xCAT-server/share/xcat/netboot/add-on/statelite/rc.statelite.ppc.redhat
+++ b/xCAT-server/share/xcat/netboot/add-on/statelite/rc.statelite.ppc.redhat
@@ -128,7 +128,7 @@ GetSyncInfo () {
 xCATCmd () {
 # $1 is the xCAT server
 # $2 is the command
-	echo "<xcatrequest>\n<command>${2}</command>\n</xcatrequest>" | /usr/sbin/chroot ${MNTDIR} /usr/bin/openssl s_client -quiet -no_ssl3 $(/usr/sbin/chroot ${MNTDIR} /usr/bin/openssl s_client -help 2>&1 | grep -m 1 -o -- -no_ssl2) -connect ${1} -rand /bin/nice 2>/dev/null
+	echo "<xcatrequest>\n<command>${2}</command>\n</xcatrequest>" | /usr/sbin/chroot ${MNTDIR} /usr/bin/openssl s_client -quiet -no_ssl3 -connect ${1} -rand /bin/nice 2>/dev/null
 
 }
 

--- a/xCAT/postscripts/getcredentials.awk
+++ b/xCAT/postscripts/getcredentials.awk
@@ -2,9 +2,6 @@
 BEGIN {
         if ((ENVIRON["USEOPENSSLFORXCAT"]) || (ENVIRON["AIX"])) {
             server = "openssl s_client -quiet -no_ssl3 -connect " ENVIRON["XCATSERVER"] " -rand /bin/nice 2> /dev/null"
-            if (!system("openssl s_client -help 2>&1 | grep -m 1 -q -- -no_ssl2")) {
-                server = "openssl s_client -quiet -no_ssl3 -no_ssl2 -connect " ENVIRON["XCATSERVER"] " -rand /bin/nice 2> /dev/null"
-            }
         } else {
             server = "/inet/tcp/0/127.0.0.1/400"
         }

--- a/xCAT/postscripts/getpostscript.awk
+++ b/xCAT/postscripts/getpostscript.awk
@@ -2,9 +2,6 @@
 BEGIN {
         if (ENVIRON["USEOPENSSLFORXCAT"]) {
             server = "openssl s_client -no_ssl3 -connect " ENVIRON["XCATSERVER"] " -rand /bin/nice 2> /dev/null"
-            if (!system("openssl s_client -help 2>&1 | grep -m 1 -q -- -no_ssl2")) {
-                server = "openssl s_client -no_ssl3 -no_ssl2 -connect " ENVIRON["XCATSERVER"] " -rand /bin/nice 2> /dev/null"
-            }
         } else {
             server = "/inet/tcp/0/127.0.0.1/400"
         }

--- a/xCAT/postscripts/startsyncfiles
+++ b/xCAT/postscripts/startsyncfiles
@@ -42,7 +42,7 @@ while read LINE;do
         RET=${RET%<*}
         [ "$RET" != "0" ] && RETCODE=1
     fi
-done < <(openssl s_client -no_ssl3 $(openssl s_client -help 2>&1 | grep -m 1 -o -- -no_ssl2) -connect $MASTER_IP:$XCATDPORT -ign_eof -quiet <<<$REQUEST)
+done < <(openssl s_client -no_ssl3 -connect $MASTER_IP:$XCATDPORT -ign_eof -quiet <<<$REQUEST)
 
 rm -rf $RESPFILE
 exit $RETCODE

--- a/xCAT/postscripts/startsyncfiles.awk
+++ b/xCAT/postscripts/startsyncfiles.awk
@@ -1,10 +1,7 @@
 #!/usr/bin/awk -f
 BEGIN {
   if (ENVIRON["USEOPENSSLFORXCAT"]) {
-      server = "openssl s_client -no_ssl3 -connect " ENVIRON["XCATSERVER"] " -rand /bin/nice 2> /dev/null"
-      if (!system("openssl s_client -help 2>&1 | grep -m 1 -q -- -no_ssl2")) {
-          server = "openssl s_client -no_ssl3 -no_ssl2 -connect " ENVIRON["XCATSERVER"] " 2> /dev/null"
-      }
+      server = "openssl s_client -no_ssl3 -connect " ENVIRON["XCATSERVER"] " 2> /dev/null"
   } else {
       server = "/inet/tcp/0/127.0.0.1/400"
   }


### PR DESCRIPTION
### The PR is to fix issue _xcat2/xcat2-task-management#557_

### The modification include

_##Remove the RANDFILE from openssl.cnf_
_##Update openssl.cnf.tmpl to the latest one from openssl 1.1.1a source_
_##Remove `-no_ssl2' command line argument for openssl client, totally_
e3e534d_

### The UT result
```
# xcatconfig -c

Setting up basic certificates.  Respond with a 'y' when prompted.

Existing xCAT certificate authority detected at /etc/xcat/ca, delete? (y/n):# NOTE use "-newkey rsa:2048" if running OpenSSL 0.9.8a or higher
Generating RSA private key, 2048 bit long modulus (2 primes)
............................................................................................+++++
.....+++++
e is 65537 (0x010001)
Using configuration from openssl.cnf
Check that the request matches the signature
Signature ok
Certificate Details:
        Serial Number: 1 (0x1)
        Validity
            Not Before: Jan  1 01:01:01 1970 GMT
            Not After : Jan 22 02:27:39 2039 GMT
        Subject:
            commonName                = xCAT CA
        X509v3 extensions:
            X509v3 Subject Key Identifier:
                06:CC:A5:1B:75:1F:B4:06:24:1B:C4:EE:D5:92:2E:D6:8D:DA:15:9C
            X509v3 Authority Key Identifier:
                keyid:06:CC:A5:1B:75:1F:B4:06:24:1B:C4:EE:D5:92:2E:D6:8D:DA:15:9C

            X509v3 Basic Constraints: critical
                CA:TRUE
            X509v3 Key Usage:
                Certificate Sign, CRL Sign
            Netscape Cert Type:
                SSL CA, S/MIME CA
Certificate is to be certified until Jan 22 02:27:39 2039 GMT (7305 days)
Sign the certificate? [y/n]:

1 out of 1 certificate requests certified, commit? [y/n]Write out database with 1 new entries
Data Base Updated
/root
Created xCAT certificate.
/etc/xcat/cert already exists, delete and start over (y/n)?Generating RSA private key, 2048 bit long modulus (2 primes)
....+++++
........................................................+++++
e is 65537 (0x010001)
/root
Using configuration from openssl.cnf
Check that the request matches the signature
Signature ok
Certificate Details:
        Serial Number: 2 (0x2)
        Validity
            Not Before: Jan  1 01:01:01 1960 GMT
            Not After : Jan 17 02:27:39 2039 GMT
        Subject:
            commonName                = c910f03c01p19
        X509v3 extensions:
            X509v3 Subject Alternative Name:
                DNS:c910f03c01p19.pok.stglabs.ibm.com, DNS:c910f03c01p19
Certificate is to be certified until Jan 17 02:27:39 2039 GMT (7300 days)
Sign the certificate? [y/n]:

1 out of 1 certificate requests certified, commit? [y/n]Write out database with 1 new entries
Data Base Updated
/root
Created xCAT certificate.
/opt/xcat/share/xcat/scripts/setup-dockerhost-cert.sh xcatdockerhost
/etc/xcatdockerca/cert already exists, delete and start over (y/n)?Generating RSA private key, 2048 bit long modulus (2 primes)
...............................+++++
..............................+++++
e is 65537 (0x010001)
Check that the request matches the signature
Signature ok
Certificate Details:
        Serial Number: 0 (0x0)
        Validity
            Not Before: Jan  1 01:01:01 1960 GMT
            Not After : Jan 17 02:27:39 2039 GMT
        Subject:
            commonName                = xcatdockerhost
        X509v3 extensions:
            X509v3 Basic Constraints:
                CA:FALSE
            Netscape Cert Type:
                SSL Client, SSL Server, Object Signing
            Netscape Comment:
                OpenSSL Generated Server Certificate
            X509v3 Subject Key Identifier:
                A2:17:6B:19:2F:22:40:14:80:A4:25:8B:7D:34:69:55:C7:0E:E0:6B
            X509v3 Authority Key Identifier:
                keyid:7D:DD:1A:E4:C2:50:91:7A:99:A8:EB:41:8B:98:4E:7F:D6:4C:8E:D4

            X509v3 Key Usage:
                Digital Signature, Key Encipherment, Key Agreement
            X509v3 Extended Key Usage:
                TLS Web Server Authentication, TLS Web Client Authentication
Certificate is to be certified until Jan 17 02:27:39 2039 GMT (7300 days)

Write out database with 1 new entries
Data Base Updated
/root
/root/.xcat already exists, delete and start over (y/n)?Generating RSA private key, 2048 bit long modulus (2 primes)
.............................................+++++
......................................................................................................................................................................................................................+++++
e is 65537 (0x010001)
Using configuration from openssl.cnf
Check that the request matches the signature
Signature ok
Certificate Details:
        Serial Number: 3 (0x3)
        Validity
            Not Before: Jan  1 01:01:01 1960 GMT
            Not After : Jan 17 02:27:40 2039 GMT
        Subject:
            commonName                = root
        X509v3 extensions:
            X509v3 Basic Constraints:
                CA:FALSE
            X509v3 Key Usage:
                Digital Signature, Key Encipherment, Key Agreement
            X509v3 Extended Key Usage:
                TLS Web Client Authentication
            Netscape Cert Type:
                SSL Client, S/MIME, Object Signing
            Netscape Comment:
                OpenSSL Generated Client Certificate
            X509v3 Subject Key Identifier:
                98:11:8C:B9:CE:A6:9B:42:E0:D8:0C:27:EB:0A:DE:06:78:BC:8F:11
            X509v3 Authority Key Identifier:
                keyid:06:CC:A5:1B:75:1F:B4:06:24:1B:C4:EE:D5:92:2E:D6:8D:DA:15:9C

Certificate is to be certified until Jan 17 02:27:40 2039 GMT (7300 days)
Sign the certificate? [y/n]:

1 out of 1 certificate requests certified, commit? [y/n]Write out database with 1 new entries
Data Base Updated
Created xCAT certificate.
/home/conserver/.xcat already exists, delete and start over (y/n)?Generating RSA private key, 2048 bit long modulus (2 primes)
............+++++
............................................................................................+++++
e is 65537 (0x010001)
Using configuration from openssl.cnf
Check that the request matches the signature
Signature ok
Certificate Details:
        Serial Number: 4 (0x4)
        Validity
            Not Before: Jan  1 01:01:01 1960 GMT
            Not After : Jan 17 02:27:40 2039 GMT
        Subject:
            commonName                = conserver
        X509v3 extensions:
            X509v3 Basic Constraints:
                CA:FALSE
            X509v3 Key Usage:
                Digital Signature, Key Encipherment, Key Agreement
            X509v3 Extended Key Usage:
                TLS Web Client Authentication
            Netscape Cert Type:
                SSL Client, S/MIME, Object Signing
            Netscape Comment:
                OpenSSL Generated Client Certificate
            X509v3 Subject Key Identifier:
                15:83:33:75:EE:74:BC:4F:DA:AA:A9:CF:15:B6:43:CD:F7:D9:0E:3D
            X509v3 Authority Key Identifier:
                keyid:06:CC:A5:1B:75:1F:B4:06:24:1B:C4:EE:D5:92:2E:D6:8D:DA:15:9C

Certificate is to be certified until Jan 17 02:27:40 2039 GMT (7300 days)
Sign the certificate? [y/n]:

1 out of 1 certificate requests certified, commit? [y/n]Write out database with 1 new entries
Data Base Updated
Created xCAT certificate.
# echo $?
0
```