### PR TITLE
add dnsforwardmode for makedns

### DIFF
--- a/docs/source/guides/admin-guides/references/man5/site.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/site.5.rst
@@ -135,6 +135,11 @@ site Attributes:
                 service nodes will ignore this value and always be configured to forward 
                 to the management node.
   
+   dnsforwardmode: (first or only or no). This is to set forward value in named.conf options section. 
+                "first": causes DNS requests to be forwarded before an attempt is made to resolve them via the root name servers. 
+                "only": all requests are forwarded and none sent to the root name servers.
+                "no": no request will be forwarded. This is the default value if not specified. 
+  
    emptyzonesenable: (yes or no). This is to set empty-zones-enable value in named.conf options section. 
   
    master:  The hostname of the xCAT management node, as known by the nodes.

--- a/perl-xCAT/xCAT/Schema.pm
+++ b/perl-xCAT/xCAT/Schema.pm
@@ -1059,6 +1059,7 @@ passed as argument rather than by table value',
 "              requests it does not know to these servers. Note that the DNS servers on the\n" .
 "              service nodes will ignore this value and always be configured to forward \n" .
 "              to the management node.\n\n" .
+" forwardmode: (first or only). This is to set forward value in named.conf options section. \n\n" .
 " emptyzonesenable: (yes or no). This is to set empty-zones-enable value in named.conf options section. \n\n" .
 " master:  The hostname of the xCAT management node, as known by the nodes.\n\n" .
 " nameservers:  A comma delimited list of DNS servers that each node in the cluster should\n" .

--- a/perl-xCAT/xCAT/Schema.pm
+++ b/perl-xCAT/xCAT/Schema.pm
@@ -1059,7 +1059,10 @@ passed as argument rather than by table value',
 "              requests it does not know to these servers. Note that the DNS servers on the\n" .
 "              service nodes will ignore this value and always be configured to forward \n" .
 "              to the management node.\n\n" .
-" forwardmode: (first or only). This is to set forward value in named.conf options section. \n\n" .
+" dnsforwardmode: (first or only or no). This is to set forward value in named.conf options section. \n" .
+"              \"first\": causes DNS requests to be forwarded before an attempt is made to resolve them via the root name servers. \n" .
+"              \"only\": all requests are forwarded and none sent to the root name servers.\n".
+"              \"no\": no request will be forwarded. This is the default value if not specified. \n\n" .              
 " emptyzonesenable: (yes or no). This is to set empty-zones-enable value in named.conf options section. \n\n" .
 " master:  The hostname of the xCAT management node, as known by the nodes.\n\n" .
 " nameservers:  A comma delimited list of DNS servers that each node in the cluster should\n" .

--- a/xCAT-server/lib/xcat/plugins/ddns.pm
+++ b/xCAT-server/lib/xcat/plugins/ddns.pm
@@ -946,8 +946,8 @@ sub get_forwardmode {
             $forwardmode = ""
         }else {
             my $rsp = {};
-            $rsp->{data}->[0] = "forward mode $site_entry is not supported.";
-            xCAT::MsgUtils->message("S", "forward mode $site_entry is not supported.");
+            $rsp->{data}->[0] = "forward mode $site_entry is not supported, supported value is only or first or no.";
+            xCAT::MsgUtils->message("S", "forward mode $site_entry is not supported, supported value is only or first or no.");
             xCAT::MsgUtils->message("W", $rsp, $callback);
             return;
         }

--- a/xCAT-server/lib/xcat/plugins/ddns.pm
+++ b/xCAT-server/lib/xcat/plugins/ddns.pm
@@ -946,8 +946,8 @@ sub get_forwardmode {
             $forwardmode = ""
         }else {
             my $rsp = {};
-            $rsp->{data}->[0] = "forward mode $site_entry is not supported, supported value is only or first or no.";
-            xCAT::MsgUtils->message("S", "forward mode $site_entry is not supported, supported value is only or first or no.");
+            $rsp->{data}->[0] = "forward mode $site_entry is not supported, supported value: only, first, no.";
+            xCAT::MsgUtils->message("S", "forward mode $site_entry is not supported, supported value: only, first, no.");
             xCAT::MsgUtils->message("W", $rsp, $callback);
             return;
         }

--- a/xCAT-server/lib/xcat/plugins/ddns.pm
+++ b/xCAT-server/lib/xcat/plugins/ddns.pm
@@ -943,7 +943,6 @@ sub get_forwardmode {
         if ($site_entry =~ /^only$|^first$/) {
             $forwardmode = $site_entry;
         } else {
-            `echo "forwardmode value is wrong"|logger -p local4.error -t xcat`;
             my $rsp = {};
             $rsp->{data}->[0] = "forward mode is wrong.";
             xCAT::MsgUtils->message("W", $rsp, $callback);

--- a/xCAT-server/lib/xcat/plugins/ddns.pm
+++ b/xCAT-server/lib/xcat/plugins/ddns.pm
@@ -937,14 +937,17 @@ sub get_zonesdir {
 
 sub get_forwardmode {
     my $forwardmode;
-    my @entries    = xCAT::TableUtils->get_site_attribute("forwardmode"); 
+    my @entries    = xCAT::TableUtils->get_site_attribute("dnsforwardmode"); 
     my $site_entry = $entries[0];
     if (defined($site_entry)) {
         if ($site_entry =~ /^only$|^first$/) {
             $forwardmode = $site_entry;
-        } else {
+        } elsif ($site_entry =~ /^no$/) {
+            $forwardmode = ""
+        }else {
             my $rsp = {};
-            $rsp->{data}->[0] = "forward mode is wrong.";
+            $rsp->{data}->[0] = "forward mode $site_entry is not supported.";
+            xCAT::MsgUtils->message("S", "forward mode $site_entry is not supported.");
             xCAT::MsgUtils->message("W", $rsp, $callback);
             return;
         }

--- a/xCAT-server/lib/xcat/plugins/ddns.pm
+++ b/xCAT-server/lib/xcat/plugins/ddns.pm
@@ -785,7 +785,7 @@ sub process_request {
                   "Update Named Conf dir $ctx->{dbdir} $ctx->{zonesdir}";
                 xCAT::MsgUtils->message("I", $rsp, $callback);
             }
-
+            $ctx->{forwardmode} = get_forwardmode();
             update_namedconf($ctx, $slave);
 
             unless ($slave)
@@ -934,6 +934,25 @@ sub get_zonesdir {
 
     return "$ZonesDir";
 }
+
+sub get_forwardmode {
+    my $forwardmode;
+    my @entries    = xCAT::TableUtils->get_site_attribute("forwardmode"); 
+    my $site_entry = $entries[0];
+    if (defined($site_entry)) {
+        if ($site_entry =~ /^only$|^first$/) {
+            $forwardmode = $site_entry;
+        } else {
+            `echo "forwardmode value is wrong"|logger -p local4.error -t xcat`;
+            my $rsp = {};
+            $rsp->{data}->[0] = "forward mode is wrong.";
+            xCAT::MsgUtils->message("W", $rsp, $callback);
+            return;
+        }
+    }
+    return "$forwardmode";
+}
+
 
 sub get_conf {
     my $conf = "/etc/named.conf";
@@ -1114,6 +1133,8 @@ sub update_namedconf {
                             push @newnamed, "\t\t" . $_ . ";\n";
                         }
                         push @newnamed, "\t};\n";
+                    } elsif ($ctx->{forwardmode} and $line =~ /forward/) {
+                        push @newnamed, "\tforward " . $ctx->{forwardmode} . ";\n";
                     } elsif ($ctx->{empty_zones_enable} and $line =~ /empty-zones-enable/) {
                         push @newnamed, "\tempty-zones-enable " . $ctx->{empty_zones_enable} . ";\n";
                     } elsif ($ctx->{slaves} and $line =~ /allow-transfer \{/) {
@@ -1253,6 +1274,10 @@ sub update_namedconf {
                 push @newnamed, "\t\t$_;\n";
             }
             push @newnamed, "\t};\n";
+        }
+
+        if ($ctx->{forwardmode}){
+            push @newnamed, "\tforward " . $ctx->{forwardmode} . ";\n";
         }
 
         if ($ctx->{empty_zones_enable}){


### PR DESCRIPTION
### The PR is to fix issue https://github.com/xcat2/xcat-core/issues/5958

### The modification include

Add `dnsforwardmode` in `site` table. Its value can be `only` or `first` or `no`. After it is set in site table correctly, `forward` section will be set in `named.conf`.

### The UT result
xCAT management node with service node.
The MN site table:
```
# lsdef -t site -i master,forwarders
Object name: clustersite
    forwarders=10.0.0.103
    master=10.3.9.9
```

1. When `dnsforwardmode` is empty or `no`, `makedns` works the same with before.
2.  When `dnsforwardmode` is `only`, and `setupnameserver=1`
```
chdef -t site dnsforwardmode=only
makedns -n
```
In MN /etc/named.conf:
```
options {
	directory "/var/named/";
	allow-recursion { any; };
	forwarders {
		10.0.0.103;
	};
	forward only;
};
```
In SN /etc/named.conf:
```
options {
	directory "/var/named";
	dump-file "/var/named/data/cache_dump.db";
	statistics-file "/var/named/data/named_stats.txt";
	memstatistics-file "/var/named/data/named_mem_stats.txt";
	recursion yes;
	forward only;
	forwarders {
		10.3.9.9;
	};
};
```

3.  When `dnsforwardmode` is `first`, and `setupnameserver=1`
```
chdef -t site dnsforwardmode=first
makedns -n
```
In MN /etc/named.conf:
```
options {
	directory "/var/named/";
	allow-recursion { any; };
	forwarders {
		10.0.0.103;
	};
	forward first;
};
```
In SN /etc/named.conf:
```
]# cat /etc/named.conf
options {
	directory "/var/named";
	dump-file "/var/named/data/cache_dump.db";
	statistics-file "/var/named/data/named_stats.txt";
	memstatistics-file "/var/named/data/named_mem_stats.txt";
	recursion yes;
	forward only;
	forwarders {
		10.3.9.9;
	};
};
```

4. When `dnsforwardmode` is `first`, `setupnameserver=2`
```
makedns -n
```
In MN /etc/named.conf:
```
options {
	directory "/var/named/";
	allow-recursion { any; };
	forwarders {
		10.0.0.103;
	};
	forward first;
	notify yes;
	allow-transfer {
		10.3.9.10;
	};
	also-notify {
		10.3.9.10;
	};
};
```
In SN /etc/named.conf:
```
options {
	directory "/var/named/";
	forwarders {
		10.0.0.103;
	};
	allow-transfer { any; };
};
```

5. When `dnsforwardmode` is `only`, setupnameserver=2
```
makedns -n
```
In MN /etc/named.conf:
```
options {
	directory "/var/named/";
	allow-recursion { any; };
	forwarders {
		10.0.0.103;
	};
	forward only;
	notify yes;
	allow-transfer {
		10.3.9.10;
	};
	also-notify {
		10.3.9.10;
	};
};
```
In SN /etc/named.conf:
```
options {
	directory "/var/named/";
	forwarders {
		10.0.0.103;
	};
	allow-transfer { any; };
};
```

6. When `dnsforwardmode` with wrong value, print warning in output and system log, do not write `dnsforwardmode` value into /etc/named.conf
```
makedns -n
… …
Getting reverse zones, this may take several minutes for a large cluster.
Completed getting reverse zones.
Warning: [bybc0607]: forward mode haha is not supported.
Updating zones.
Completed updating zones.
… …
```
In MN /etc/named.conf:
```
options {
	directory "/var/named/";
	allow-recursion { any; };
	forwarders {
		10.0.0.103;
	};
	notify yes;
	allow-transfer {
		10.3.9.10;
	};
	also-notify {
		10.3.9.10;
	};
};
```
In SN /etc/named.conf:
```
options {
	directory "/var/named/";
	forwarders {
		10.0.0.103;
	};
	allow-transfer { any; };
};
```
In /var/log/messages:
```
Jan 22 02:49:29 c910f03c09k09 systemd: Stopped Berkeley Internet Name Domain (DNS).
Jan 22 02:49:29 c910f03c09k09 xcat: forward mode haha is not supported.
Jan 22 02:49:29 c910f03c09k09 systemd: Starting Generate rndc key for BIND (DNS)...
```
