### PR TITLE
Tinker ospkgs for RHEL 8 support

### DIFF
--- a/xCAT/postscripts/ospkgs
+++ b/xCAT/postscripts/ospkgs
@@ -402,6 +402,8 @@ do
         tmp=${x#@}
         #remove leading and trailing spaces
         tmp=`echo $tmp |sed 's/^ *//;s/ *$//'`
+        #remove the leading ^
+        [ "^" = "${tmp:0:1}" ] && tmp="${tmp:1}"
         #if there are spaces in the middle of the name, quote it
         pos=`expr index "$tmp" "\ "`
         if [ $pos -gt 0  ]; then


### PR DESCRIPTION
_##Feature description##_

The correct syntax for a minimal environment if use `@^minimal-environment` in the package list. Thus, tinker the code to handle this.

See https://bugzilla.redhat.com/show_bug.cgi?id=1168062

### The UT result
```
# updatenode c910f03c01p10
There were no syncfiles defined to process. File synchronization has completed.
Performing software maintenance operations. This could take a while, if there are packages to install.

c910f03c01p10: updating VPD database
c910f03c01p10: =============updatenode starting====================
c910f03c01p10: trying to download postscripts...
c910f03c01p10: postscripts downloaded successfully
c910f03c01p10: trying to get mypostscript from 10.3.1.19...
c910f03c01p10: postscript start..: ospkgs
c910f03c01p10: postscript end....: ospkgs exited with code 0
c910f03c01p10: postscript start..: otherpkgs
c910f03c01p10: otherpkgs: no extra rpms to install
c910f03c01p10: postscript end....: otherpkgs exited with code 0
c910f03c01p10: postscript start..: syscloneimgupdate
c910f03c01p10: postscript end....: syscloneimgupdate exited with code 0
c910f03c01p10: Running of Software Maintenance has completed.
c910f03c01p10: =============updatenode ending====================
c910f03c01p10: updating VPD database
c910f03c01p10: =============updatenode starting====================
c910f03c01p10: trying to download postscripts...
c910f03c01p10: postscripts downloaded successfully
c910f03c01p10: trying to get mypostscript from 10.3.1.19...
c910f03c01p10: postscript start..: syslog
c910f03c01p10: postscript end....: syslog exited with code 0
c910f03c01p10: postscript start..: remoteshell
c910f03c01p10:
c910f03c01p10: cp: -r not specified; omitting directory '/etc/ssh/ssh_config.d'
c910f03c01p10: postscript end....: remoteshell exited with code 0
c910f03c01p10: postscript start..: syncfiles
c910f03c01p10: postscript end....: syncfiles exited with code 0
c910f03c01p10: postscript start..: setupntp
c910f03c01p10: 2019-01-23T07:08:27Z chronyd version 3.3 starting (+CMDMON +NTP +REFCLOCK +RTC +PRIVDROP +SCFILTER +SIGND +ASYNCDNS +SECHASH +IPV6 +DEBUG)
c910f03c01p10: 2019-01-23T07:08:28Z Initial frequency -23.777 ppm
c910f03c01p10: 2019-01-23T07:08:32Z System clock wrong by -0.000002 seconds (step)
c910f03c01p10: 2019-01-23T07:08:32Z chronyd exiting
c910f03c01p10: postscript end....: setupntp exited with code 0
c910f03c01p10: postscript start..: otherpkgs
c910f03c01p10: otherpkgs: no extra rpms to install
c910f03c01p10: postscript end....: otherpkgs exited with code 0
c910f03c01p10: Running of postscripts has completed.
c910f03c01p10: =============updatenode ending====================
```
