### PR TITLE
configeth support redhat8

### DIFF
--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -23,6 +23,15 @@ if [ -z "$UPDATENODE" ] || [ $UPDATENODE -ne 1 ] ; then
         reboot_nic_bool=0
     fi
 fi
+########################################################################
+# networkmanager_active=0: use network.service
+# networkmanager_active=1: use NetworkManager
+########################################################################
+networkmanager_active=0
+checkservicestatus NetworkManager > /dev/null
+if [ $? -eq 0 ]; then
+    networkmanager_active=1
+fi
 function configipv4(){
     str_if_name=$1
     str_v4ip=$2
@@ -115,22 +124,30 @@ function configipv4(){
             echo "  vlan-raw-device ${parent_device}" >> $str_conf_file
         fi
     else
+        str_prefix=$(v4mask2prefix $str_v4mask)
         # Write the info to the ifcfg file for redhat
+        con_name=""
         str_conf_file=""
-        if [ $num_v4num -eq 0 ];then
-            str_conf_file="/etc/sysconfig/network-scripts/ifcfg-${str_if_name}"
-            echo "DEVICE=${str_if_name}" > $str_conf_file
-        else
-            str_conf_file="/etc/sysconfig/network-scripts/ifcfg-${str_if_name}:${num_v4num}"
-            echo "DEVICE=${str_if_name}:${num_v4num}" > $str_conf_file
+        if [ $num_v4num -ne 0 ]; then
+            str_if_name=${str_if_name}:${num_v4num}
         fi
-
-
-        echo "BOOTPROTO=static" >> $str_conf_file
-        echo "NM_CONTROLLED=no" >> $str_conf_file
-        echo "IPADDR=${str_v4ip}" >> $str_conf_file
-        echo "NETMASK=${str_v4mask}" >> $str_conf_file
-        echo "ONBOOT=yes" >> $str_conf_file
+        str_conf_file="/etc/sysconfig/network-scripts/ifcfg-${str_if_name}"
+        if [ $networkmanager_active -eq 1 ]; then
+            nmcli con show | grep ${str_if_name}
+            if [ $? -ne 0 ] ; then
+                nmcli con add type ethernet con-name ${str_if_name} ifname ${str_if_name} ipv4.method manual  ipv4.addresses  ${str_v4ip}/${str_prefix}
+            else
+                con_name=$(nmcli dev show ${str_if_name}|grep CONNECTION|awk -F: '{print $2}'|sed 's/^ *//')
+                nmcli con mod "${con_name}" ipv4.method manual ipv4.addresses ${str_v4ip}/${str_prefix}
+            fi
+        else
+            echo "DEVICE=${str_if_name}" > $str_conf_file
+            echo "BOOTPROTO=static" >> $str_conf_file
+            echo "NM_CONTROLLED=no" >> $str_conf_file
+            echo "IPADDR=${str_v4ip}" >> $str_conf_file
+            echo "NETMASK=${str_v4mask}" >> $str_conf_file
+            echo "ONBOOT=yes" >> $str_conf_file
+        fi
         if [ "$str_nic_mtu" != "$str_default_token" ]; then
             echo "MTU=${str_nic_mtu}" >> $str_conf_file
         fi
@@ -519,7 +536,7 @@ elif [ "$1" = "-s" ];then
         log_info "configeth on $NODE: config install nic, can not find information from dhcp lease file, return."
         exit 1
     fi
-
+    
     str_inst_net=$(v4calcnet $str_inst_ip $str_inst_mask)
     num_index=1
     while [ $num_index -le $NETWORKS_LINES ];do
@@ -604,13 +621,26 @@ elif [ "$1" = "-s" ];then
         hostname $NODE
         echo $NODE > /etc/HOSTNAME
     else
+        #write ifcfg-* file for redhat
+        con_name=""
+        str_inst_prefix=$(v4mask2prefix ${str_inst_mask})
         str_conf_file="/etc/sysconfig/network-scripts/ifcfg-${str_inst_nic}"
-        echo "DEVICE=${str_inst_nic}" > $str_conf_file
-        echo "IPADDR=${str_inst_ip}" >> $str_conf_file
-        echo "NETMASK=${str_inst_mask}" >> $str_conf_file
-        echo "BOOTPROTO=static" >> $str_conf_file
-        echo "ONBOOT=yes" >> $str_conf_file
-        echo "HWADDR=${str_inst_mac}" >> $str_conf_file
+        if [ $networkmanager_active -eq 1 ]; then
+            nmcli con show | grep ${str_inst_nic}
+            if [ $? -ne 0 ] ; then
+                nmcli con add type ethernet con-name ${str_inst_nic} ifname ${str_inst_nic} ipv4.method manual ipv4.addresses  ${str_inst_ip}/${str_inst_prefix}
+            else
+                con_name=$(nmcli dev show ${str_inst_nic}|grep CONNECTION|awk -F: '{print $2}'|sed 's/^ *//')
+                nmcli con mod "System ens3" ipv4.method manual ipv4.addresses ${str_inst_ip}/${str_inst_prefix}
+            fi
+        else
+            echo "DEVICE=${str_inst_nic}" > $str_conf_file
+            echo "IPADDR=${str_inst_ip}" >> $str_conf_file
+            echo "NETMASK=${str_inst_mask}" >> $str_conf_file
+            echo "BOOTPROTO=static" >> $str_conf_file
+            echo "ONBOOT=yes" >> $str_conf_file
+            echo "HWADDR=${str_inst_mac}" >> $str_conf_file
+        fi
         if [ -n "${str_inst_mtu}" ];then
             echo "MTU=${str_inst_mtu}" >> $str_conf_file
         fi
@@ -893,7 +923,6 @@ else
     bool_modify_flag=0
     str_nic_status='down'
     str_his_file=${str_cfg_dir}xcat_history_important
-
     str_history=`ip addr show dev $str_nic_name | grep inet | grep -iv dynamic | grep -iv link | grep  $str_nic_name | awk '{print $2}'`
     old_ifs=$IFS
     IFS=$'\n'

--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -133,11 +133,10 @@ function configipv4(){
         fi
         str_conf_file="/etc/sysconfig/network-scripts/ifcfg-${str_if_name}"
         if [ $networkmanager_active -eq 1 ]; then
-            nmcli con show | grep ${str_if_name}
-            if [ $? -ne 0 ] ; then
+            con_name=$(nmcli dev show ${str_if_name}|grep CONNECTION|awk -F: '{print $2}'|sed 's/^[ \t]*$//g')
+            if [ "$con_name" == "--" ] ; then
                 nmcli con add type ethernet con-name ${str_if_name} ifname ${str_if_name} ipv4.method manual  ipv4.addresses  ${str_v4ip}/${str_prefix}
             else
-                con_name=$(nmcli dev show ${str_if_name}|grep CONNECTION|awk -F: '{print $2}'|sed 's/^ *//')
                 nmcli con mod "${con_name}" ipv4.method manual ipv4.addresses ${str_v4ip}/${str_prefix}
             fi
         else
@@ -536,7 +535,6 @@ elif [ "$1" = "-s" ];then
         log_info "configeth on $NODE: config install nic, can not find information from dhcp lease file, return."
         exit 1
     fi
-    
     str_inst_net=$(v4calcnet $str_inst_ip $str_inst_mask)
     num_index=1
     while [ $num_index -le $NETWORKS_LINES ];do
@@ -626,18 +624,17 @@ elif [ "$1" = "-s" ];then
         str_inst_prefix=$(v4mask2prefix ${str_inst_mask})
         str_conf_file="/etc/sysconfig/network-scripts/ifcfg-${str_inst_nic}"
         if [ $networkmanager_active -eq 1 ]; then
-            nmcli con show | grep ${str_inst_nic}
-            if [ $? -ne 0 ] ; then
+            con_name=$(nmcli dev show ${str_if_name}|grep CONNECTION|awk -F: '{print $2}'|sed 's/^[ \t]*$//g')
+            if [ "$con_name" == "--" ] ; then
                 nmcli con add type ethernet con-name ${str_inst_nic} ifname ${str_inst_nic} ipv4.method manual ipv4.addresses  ${str_inst_ip}/${str_inst_prefix}
             else
-                con_name=$(nmcli dev show ${str_inst_nic}|grep CONNECTION|awk -F: '{print $2}'|sed 's/^ *//')
                 nmcli con mod "System ens3" ipv4.method manual ipv4.addresses ${str_inst_ip}/${str_inst_prefix}
             fi
         else
             echo "DEVICE=${str_inst_nic}" > $str_conf_file
             echo "IPADDR=${str_inst_ip}" >> $str_conf_file
             echo "NETMASK=${str_inst_mask}" >> $str_conf_file
-            echo "BOOTPROTO=static" >> $str_conf_file
+            echo "BOOTPROTO=none" >> $str_conf_file
             echo "ONBOOT=yes" >> $str_conf_file
             echo "HWADDR=${str_inst_mac}" >> $str_conf_file
         fi

--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -141,7 +141,7 @@ function configipv4(){
             fi
         else
             echo "DEVICE=${str_if_name}" > $str_conf_file
-            echo "BOOTPROTO=static" >> $str_conf_file
+            echo "BOOTPROTO=none" >> $str_conf_file
             echo "NM_CONTROLLED=no" >> $str_conf_file
             echo "IPADDR=${str_v4ip}" >> $str_conf_file
             echo "NETMASK=${str_v4mask}" >> $str_conf_file


### PR DESCRIPTION
### The PR is to fix issue 
https://github.com/xcat2/xcat2-task-management/issues/399

### The modification include
configeth is called by confignetwork, this modification contains configure Ethernet installnic and secondary static ip.

### The UT result
1.  Run `confignetwork -s` on redhat8 compute node to configure install NIC and secondary NIC, automation test case parts:
```
RUN:updatenode byrh09 -P "confignetwork -s" [Wed Jan 23 03:41:52 2019]
ElapsedTime:4 sec
RETURN rc = 0
OUTPUT:
byrh09: =============updatenode starting====================
byrh09: trying to download postscripts...
byrh09: postscripts downloaded successfully
byrh09: trying to get mypostscript from 10.5.106.7...
byrh09: postscript start..: confignetwork
byrh09: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh09: [I]: configure the install nic ens3.
byrh09: [I]: configeth on byrh09: os type: redhat
byrh09: ls: cannot access '/var/lib/dhclient/*ens3*': No such file or directory
byrh09: System ens3  a26ac740-efef-4e45-87b0-936a7236b397  ethernet  ens3
byrh09: Connection 'System ens3' successfully deactivated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/165)
byrh09: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/191)
byrh09: ['/etc/sysconfig/network-scripts/ifcfg-ens3']
byrh09: [I]: >> # Generated by parse-kickstart
byrh09: [I]: >> TYPE=Ethernet
byrh09: [I]: >> DEVICE=ens3
byrh09: [I]: >> UUID=a26ac740-efef-4e45-87b0-936a7236b397
byrh09: [I]: >> ONBOOT=yes
byrh09: [I]: >> BOOTPROTO=none
byrh09: [I]: >> IPV6INIT=yes
byrh09: [I]: >> MTU=1500
byrh09: [I]: >> PROXY_METHOD=none
byrh09: [I]: >> BROWSER_ONLY=no
byrh09: [I]: >> IPADDR=10.4.41.9
byrh09: [I]: >> PREFIX=8
byrh09: [I]: >> DEFROUTE=yes
byrh09: [I]: >> IPV4_FAILURE_FATAL=no
byrh09: [I]: >> IPV6_AUTOCONF=yes
byrh09: [I]: >> IPV6_DEFROUTE=yes
byrh09: [I]: >> IPV6_FAILURE_FATAL=no
byrh09: [I]: >> NAME="System ens3"
byrh09: [I]: >> MTU=1500
byrh09: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh09: [I]: All valid nics and device list:
byrh09: [I]: ens4
byrh09: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh09: configure nic and its device : ens4
byrh09: [I]: configure ens4
byrh09: [I]: call: configeth ens4 11.1.0.100 11_1_0_0-255_255_0_0
byrh09: [I]: configeth on byrh09: os type: redhat
byrh09: configeth on byrh09: old configuration: 3: ens4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
byrh09:     link/ether 42:20:0a:04:29:09 brd ff:ff:ff:ff:ff:ff
byrh09: [I]: configeth on byrh09: new configuration
byrh09:        11.1.0.100, 11.1.0.0, 255.255.0.0,
byrh09: 3: ens4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
byrh09: ens4
byrh09: [I]: configeth on byrh09: add 11.1.0.100_16 for ens4 temporary.
byrh09: [I]: configeth on byrh09: ens4 changed, modify the configuration files
byrh09: ens4
byrh09: ens4         b7ef91e8-b7e2-4cb5-a774-740b9b30c23b  ethernet  ens4
byrh09: ens4         6dab9d60-7d01-4782-838a-5236bb5f51a5  ethernet  --
byrh09: ['/etc/sysconfig/network-scripts/ifcfg-ens4']
byrh09: [I]: >> TYPE=Ethernet
byrh09: [I]: >> PROXY_METHOD=none
byrh09: [I]: >> BROWSER_ONLY=no
byrh09: [I]: >> BOOTPROTO=none
byrh09: [I]: >> DEFROUTE=yes
byrh09: [I]: >> IPV4_FAILURE_FATAL=no
byrh09: [I]: >> IPV6INIT=yes
byrh09: [I]: >> IPV6_AUTOCONF=yes
byrh09: [I]: >> IPV6_DEFROUTE=yes
byrh09: [I]: >> IPV6_FAILURE_FATAL=no
byrh09: [I]: >> IPV6_ADDR_GEN_MODE=stable-privacy
byrh09: [I]: >> NAME=ens4
byrh09: [I]: >> UUID=6dab9d60-7d01-4782-838a-5236bb5f51a5
byrh09: [I]: >> DEVICE=ens4
byrh09: [I]: >> ONBOOT=yes
byrh09: [I]: >> MTU=1496
byrh09: [I]: >> IPADDR=11.1.0.100
byrh09: [I]: >> PREFIX=16
byrh09: postscript end....: confignetwork exited with code 0
byrh09: Running of postscripts has completed.
byrh09: =============updatenode ending====================
CHECK:rc == 0	[Pass]
```
2. Run `confignetwork -s` on redhat7.4 compute node to configure install NIC and secondary NIC, automation test case parts:
```
RUN:updatenode bybc0609 -P "confignetwork -s" [Wed Jan 23 03:36:38 2019]
ElapsedTime:13 sec
RETURN rc = 0
OUTPUT:
bybc0609: Warning: the ECDSA host key for 'bybc0609' differs from the key for the IP address '10.5.106.9'
bybc0609: Offending key for IP in /root/.ssh/known_hosts:6
bybc0609: Matching host key in /root/.ssh/known_hosts:17

bybc0609: =============updatenode starting====================
bybc0609: trying to download postscripts...
bybc0609: postscripts downloaded successfully
bybc0609: trying to get mypostscript from 10.5.106.7...
bybc0609: postscript start..: confignetwork
bybc0609: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bybc0609: [I]: configure the install nic eth0.
bybc0609: [I]: configeth on bybc0609: os type: redhat
bybc0609: ['/etc/sysconfig/network-scripts/ifcfg-eth0']
bybc0609: [I]: >> DEVICE=eth0
bybc0609: [I]: >> IPADDR=10.5.106.9
bybc0609: [I]: >> NETMASK=255.0.0.0
bybc0609: [I]: >> BOOTPROTO=static
bybc0609: [I]: >> ONBOOT=yes
bybc0609: [I]: >> HWADDR=42:f5:0a:05:6a:09
bybc0609: [I]: >> MTU=1500
bybc0609: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bybc0609: [I]: All valid nics and device list:
bybc0609: [I]: eth1
bybc0609: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bybc0609: configure nic and its device : eth1
bybc0609: [I]: configure eth1
bybc0609: [I]: call: configeth eth1 11.1.0.100 11_1_0_0-255_255_0_0
bybc0609: [I]: configeth on bybc0609: os type: redhat
bybc0609: configeth on bybc0609: old configuration: 3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
bybc0609:     link/ether 42:74:0a:05:6a:09 brd ff:ff:ff:ff:ff:ff
bybc0609:     inet6 fe80::4074:aff:fe05:6a09/64 scope link
bybc0609:        valid_lft forever preferred_lft forever
bybc0609: [I]: configeth on bybc0609: new configuration
bybc0609:        11.1.0.100, 11.1.0.0, 255.255.0.0,
bybc0609: 3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP mode DEFAULT qlen 1000
bybc0609: [I]: configeth on bybc0609: eth1 changed, modify the configuration files
bybc0609: bring up ip
bybc0609: ['/etc/sysconfig/network-scripts/ifcfg-eth1']
bybc0609: [I]: >> DEVICE=eth1
bybc0609: [I]: >> BOOTPROTO=static
bybc0609: [I]: >> NM_CONTROLLED=no
bybc0609: [I]: >> IPADDR=11.1.0.100
bybc0609: [I]: >> NETMASK=255.255.0.0
bybc0609: [I]: >> ONBOOT=yes
bybc0609: postscript end....: confignetwork exited with code 0
bybc0609: Running of postscripts has completed.
bybc0609: =============updatenode ending====================
CHECK:rc == 0   [Pass]
```
```