### PR TITLE
fix issue nodeset calculate wrong path for deploying sles when using "copycds -p" 

### DIFF
--- a/xCAT-server/lib/xcat/plugins/sles.pm
+++ b/xCAT-server/lib/xcat/plugins/sles.pm
@@ -937,14 +937,12 @@ sub mkinstall
 
         # trim the "/" in /install/sles11.3/x86_64/
         $pkgdir =~ s/\/$//;
-        if ($pkgdir =~ /^($installroot\/$os\/$arch)$/) {
-            if ( -d "$pkgdir/2") {
-                $srcdirs[0] = "$pkgdir/1,$pkgdir/2";
-            }else{
-                $srcdirs[0] = "$pkgdir/1";
-            }
-            $tmppkgdir = join(",", @srcdirs);
+        if ( -d "$pkgdir/2") {
+            $srcdirs[0] = "$pkgdir/1,$pkgdir/2";
+        }else{
+            $srcdirs[0] = "$pkgdir/1";
         }
+        $tmppkgdir = join(",", @srcdirs);
 
         #Call the Template class to do substitution to produce a kickstart file in the autoinst dir
         my $tmperr;


### PR DESCRIPTION

### The PR is to fix issue https://github.com/xcat2/xcat-core/issues/5966

### the UT output:
```
[root@briggs01 ~]# copycds /mnt/xcat/iso/suse/12.3/SLE-12-SP3-Server-DVD-ppc64le-GM-DVD1.iso  -p /install/test/
Copying media to /install/test/1
Media copy operation successful
[root@briggs01 test]# tree -L 2 /install/test/
/install/test/
└── 1
    ├── ARCHIVES.gz
    ├── boot
    ├── ChangeLog
    ├── content
    ├── content.asc
    ├── content.key
    ├── control.xml
    ├── COPYRIGHT
    ├── COPYRIGHT.de
    ├── directory.yast
    ├── docu
    ├── gpg-pubkey-39db7c82-5847eb1f.asc
    ├── gpg-pubkey-50a3dd1c-50f35137.asc
    ├── INDEX.gz
    ├── license.tar.gz
    ├── ls-lR.gz
    ├── media.1
    ├── NEWS
    ├── ppc
    ├── pubring.gpg
    ├── README
    └── suse

[root@briggs01 ~]# lsdef -t osimage -o sles12.3-ppc64le-install-compute
Object name: sles12.3-ppc64le-install-compute
    imagetype=linux
    osarch=ppc64le
    osdistroname=sles12.3-ppc64le
    osname=Linux
    osvers=sles12.3
    otherpkgdir=/install/post/otherpkgs/sles12.3/ppc64le
    pkgdir=/install/test
    pkglist=/opt/xcat/share/xcat/install/sles/compute.sles12.pkglist
    profile=compute
    provmethod=install
    template=/opt/xcat/share/xcat/install/sles/compute.sles12.ppc64le.tmpl
[root@briggs01 ~]# nodeset cn1 osimage=sles12.3-ppc64le-install-compute
cn1: install sles12.3-ppc64le-compute
[root@briggs01 ~]# cat /install/autoinst/cn1 |grep add-on -B2 -A3
export nextserver=`cat /proc/cmdline | grep http | awk -F'autoyast=http://' {'print \$2'} | awk -F':' {'print \$1'}`
cp /tmp/profile/modified.xml /tmp/profile/modified1.xml
sed -e 's!<software>!<add-on><add_on_products config:type="list"><listentry><media_url>http://'$nextserver':80/install/test/1</media_url><product>SuSE-Linux-pkg0</product><product_dir>/</product_dir><ask_on_error config:type="boolean">false</ask_on_error><name>SuSE-Linux-pkg0</name></listentry></add_on_products></add-on><software>!'  /tmp/profile/modified1.xml > /tmp/profile/modified.xml

if [ "$XCATDEBUGMODE" = "1" ] || [ "$XCATDEBUGMODE" = "2" ]; then
    set +x
```