### PR TITLE
Add test case for issue 3542 : to ensure that CSM required info is to ensure that CSM required info is not removed from /opt/xcat/xcatinfo

### DIFF
--- a/xCAT-test/autotest/testcase/installation/SN_diskless_setup_case
+++ b/xCAT-test/autotest/testcase/installation/SN_diskless_setup_case
@@ -107,6 +107,11 @@ check:output=~\d\d:\d\d:\d\d
 cmd:xdsh $$SN mount
 check:rc==0
 check:output=~on / type tmpfs
+cmd:xdsh $$SN cat /opt/xcat/xcatinfo
+check:rc==0
+check:output=~NODE=$$SN
+check:output=~IMAGENAME='__GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-netboot-service'
+check:output=~IMAGEUUID='\w+-\w+-\w+-\w+-\w+'
 cmd:xdsh $$SN rpm -qa|grep "xCAT-openbmc-py"
 check:rc==0
 check:output=~xCAT-openbmc-py-\d

--- a/xCAT-test/autotest/testcase/installation/SN_setup_case
+++ b/xCAT-test/autotest/testcase/installation/SN_setup_case
@@ -91,6 +91,10 @@ check:output=~/install on /install
 cmd:xdsh $$SN "mount"
 check:rc==0
 check:output=~/tftpboot on /tftpboot
+cmd:xdsh $$SN cat /opt/xcat/xcatinfo
+check:rc==0
+check:output=~NODE=$$SN
+check:output=~IMAGENAME=__GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-install-service
 cmd:xdsh $$SN  "cat /var/log/xcat/xcat.log"
 cmd:if [[ "__GETNODEATTR($$SN,arch)__" =~ "x86_64" ]]; then if [[ "__GETNODEATTR($$SN,os)__" =~ "sles" ]];then xdsh $$SN "zypper -n install perl-Sys-Virt"; elif [[ "__GETNODEATTR($$SN,os)__" =~ "rh" ]];then xdsh $$SN "yum install -y perl-Sys-Virt";fi;fi
 check:rc==0

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_flat
@@ -58,6 +58,10 @@ check:rc==0
 check:output=~\d\d:\d\d:\d\d
 cmd:xdsh $$CN mount
 check:rc==0
+cmd:xdsh $$CN cat /opt/xcat/xcatinfo
+check:rc==0
+check:output=~NODE=$$CN
+check:output=~IMAGENAME=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 cmd:sleep 120
 #comment for further discussion
 #cmd:if ! ([[ "__GETNODEATTR($$CN,os)__" = "sles12.1" ]] || [[ "__GETNODEATTR($$CN,os)__" =~ "ubuntu" && "__GETNODEATTR($$CN,arch)__" = "x86_64" ]]) ;then xdsh $$CN service ntpd status;fi

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_hierarchy
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_hierarchy
@@ -66,6 +66,11 @@ check:rc==0
 check:output=~\d\d:\d\d:\d\d
 cmd:xdsh $$CN mount
 check:rc==0
+cmd:xdsh $$CN cat /opt/xcat/xcatinfo
+check:rc==0
+check:output=~NODE=$$CN
+check:output=~IMAGENAME=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+check:output=~SERVICEGROUP=$$SN
 cmd:xdsh $$CN  "cat /var/log/xcat/xcat.log"
 cmd:xdsh $$CN "cat /test.synclist"
 check:rc==0

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat
@@ -63,6 +63,11 @@ check:output=~\d\d:\d\d:\d\d
 cmd:xdsh $$CN mount
 check:rc==0
 check:output=~on / type tmpfs
+cmd:xdsh $$CN cat /opt/xcat/xcatinfo
+check:rc==0
+check:output=~NODE=$$CN
+check:output=~IMAGENAME='__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute'
+check:output=~IMAGEUUID='\w+-\w+-\w+-\w+-\w+'
 cmd:sleep 120
 cmd:ping $$CN -c 3
 check:rc==0

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_hierarchy
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_hierarchy
@@ -69,6 +69,12 @@ check:output=~\d\d:\d\d:\d\d
 cmd:xdsh $$CN mount
 check:rc==0
 check:output=~on / type tmpfs
+cmd:xdsh $$CN cat /opt/xcat/xcatinfo
+check:rc==0
+check:output=~NODE=$$CN
+check:output=~IMAGENAME='__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute'
+check:output=~IMAGEUUID='\w+-\w+-\w+-\w+-\w+'
+check:output=~SERVICEGROUP=$$SN
 cmd:xdsh $$CN  "cat /var/log/xcat/xcat.log"
 cmd:rootimgdir=`lsdef -t osimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir.regbak ]; then rm -rf $rootimgdir; mv $rootimgdir.regbak $rootimgdir; fi
 check:rc==0

--- a/xCAT-test/autotest/testcase/packimg/cases0
+++ b/xCAT-test/autotest/testcase/packimg/cases0
@@ -370,3 +370,29 @@ cmd:rm -rf /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/
 cmd:mv -f /rootimg.bak /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg
 end
 
+start:packimage_uuid
+os:Linux
+description:this case is to verfy bug 3542,ensure that CSM required info is not removed from /opt/xcat/xcatinfo.
+label:others,packaging
+cmd:lsdef -z $$CN >> /tmp/node.stanza
+cmd:ls /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg;if [ $? -eq 0 ];then mv -f /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg /rootimg.bak;fi
+cmd:ls /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.cpio.gz;if [ $? -eq 0 ];then mv -f /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.cpio.gz /rootimg.cpio.gz.bak;fi
+cmd:copycds $$ISO
+cmd:genimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+check:rc==0
+cmd:packimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+check:rc==0
+cmd:cp /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg/opt/xcat/xcatinfo /tmp/uuid
+cmd:packimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+check:rc==0
+cmd:uuid=`cat /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg/opt/xcat/xcatinfo |grep UUID|awk -F= '{print $2}'`;grep $uuid /tmp/uuid
+check:rc!=0
+cmd:ls -l /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.cpio.gz
+check:rc==0
+cmd:rm -rf /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.cpio.gz
+cmd:mv -f /rootimg.cpio.gz.bak /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.cpio.gz
+cmd:rm -rf /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg
+cmd:mv -f /rootimg.bak /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg
+cmd:if [ -e /tmp/node.stanza ]; then rmdef $$CN; cat /tmp/node.stanza | mkdef -z; rm -rf /tmp/node.stanza; fi
+end
+


### PR DESCRIPTION
### The PR is to add cases for  https://github.com/xcat2/xcat-core/issues/3542

The UT
```
------START::test_for_xcatinfo_diskful::Time:Mon Jan 28 03:44:00 2019------

RUN:xdsh c910f02c02p18 cat /opt/xcat/xcatinfo [Mon Jan 28 03:44:00 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f02c02p18: XCATSERVER=10.2.2.17
c910f02c02p18: INSTALLDIR=/install
c910f02c02p18: HTTPPORT=80
c910f02c02p18: REBOOT=TRUE
c910f02c02p18: NODE=c910f02c02p18
c910f02c02p18: IMAGENAME=rhels7.6-ppc64-install-compute
c910f02c02p18: SERVICEGROUP=c910f02c02p17
c910f02c02p18: USEFLOWCONTROL=NO
CHECK:rc == 0	[Pass]
CHECK:output =~ NODE=c910f02c02p18	[Pass]
CHECK:output =~ IMAGENAME=rhels7.6-ppc64-install-compute	[Pass]

------END::test_for_xcatinfo_diskful::Passed::Time:Mon Jan 28 03:44:02 2019 ::Duration::2 sec------
------START::test_for_xcatinfo_diskful_hierarchy::Time:Mon Jan 28 03:44:02 2019------

RUN:xdsh c910f02c02p18 cat /opt/xcat/xcatinfo [Mon Jan 28 03:44:02 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f02c02p18: XCATSERVER=10.2.2.17
c910f02c02p18: INSTALLDIR=/install
c910f02c02p18: HTTPPORT=80
c910f02c02p18: REBOOT=TRUE
c910f02c02p18: NODE=c910f02c02p18
c910f02c02p18: IMAGENAME=rhels7.6-ppc64-install-compute
c910f02c02p18: SERVICEGROUP=c910f02c02p17
c910f02c02p18: USEFLOWCONTROL=NO
CHECK:rc == 0	[Pass]
CHECK:output =~ NODE=c910f02c02p18	[Pass]
CHECK:output =~ IMAGENAME=rhels7.6-ppc64-install-compute	[Pass]
CHECK:output =~ SERVICEGROUP=c910f02c02p17	[Pass]

------END::test_for_xcatinfo_diskful_hierarchy::Passed::Time:Mon Jan 28 03:44:04 2019 ::Duration::2 sec------
------START::test_for_xcatinfo_diskful_SN::Time:Mon Jan 28 03:44:04 2019------

RUN:xdsh c910f02c02p17 cat /opt/xcat/xcatinfo [Mon Jan 28 03:44:04 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f02c02p17: XCATSERVER=10.2.2.16
c910f02c02p17: INSTALLDIR=/install
c910f02c02p17: HTTPPORT=80
c910f02c02p17: REBOOT=TRUE
c910f02c02p17: NODE=c910f02c02p17
c910f02c02p17: IMAGENAME=rhels7.6-ppc64-install-service
c910f02c02p17: USEFLOWCONTROL=NO
CHECK:rc == 0	[Pass]
CHECK:output =~ NODE=c910f02c02p17	[Pass]
CHECK:output =~ IMAGENAME=rhels7.6-ppc64-install-service	[Pass]

------END::test_for_xcatinfo_diskful_SN::Passed::Time:Mon Jan 28 03:44:07 2019 ::Duration::3 sec------
------START::test_for_xcatinfo_diskless::Time:Mon Jan 28 03:47:39 2019------

RUN:xdsh c910f02c02p19 cat /opt/xcat/xcatinfo [Mon Jan 28 03:47:39 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f02c02p19: IMAGENAME='rhels7.6-ppc64-netboot-compute'
c910f02c02p19: IMAGEUUID='d27e622d-36b1-41e5-99d9-33818b30aac8'
c910f02c02p19: TIMESTAMP='Sun Jan 27 21:36:14 EST 2019'
c910f02c02p19: XCATSERVER='c910f02c02p16'
c910f02c02p19: HTTPPORT=80
c910f02c02p19: USEFLOWCONTROL=NO
c910f02c02p19: NODE=c910f02c02p19
CHECK:rc == 0	[Pass]
CHECK:output =~ NODE=c910f02c02p19	[Pass]
CHECK:output =~ IMAGENAME='rhels7.6-ppc64-netboot-compute'	[Pass]
CHECK:output =~ IMAGEUUID='\w+-\w+-\w+-\w+-\w+'	[Pass]

------END::test_for_xcatinfo_diskless::Passed::Time:Mon Jan 28 03:47:41 2019 ::Duration::2 sec------
------START::test_for_xcatinfo_diskless_heirarchy::Time:Mon Jan 28 03:47:41 2019------

RUN:xdsh c910f02c02p19 cat /opt/xcat/xcatinfo [Mon Jan 28 03:47:41 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f02c02p19: IMAGENAME='rhels7.6-ppc64-netboot-compute'
c910f02c02p19: IMAGEUUID='d27e622d-36b1-41e5-99d9-33818b30aac8'
c910f02c02p19: TIMESTAMP='Sun Jan 27 21:36:14 EST 2019'
c910f02c02p19: XCATSERVER='c910f02c02p16'
c910f02c02p19: HTTPPORT=80
c910f02c02p19: USEFLOWCONTROL=NO
c910f02c02p19: NODE=c910f02c02p19
CHECK:rc == 0	[Pass]
CHECK:output =~ NODE=c910f02c02p19	[Pass]
CHECK:output =~ IMAGENAME='rhels7.6-ppc64-netboot-compute'	[Pass]
CHECK:output =~ IMAGEUUID='\w+-\w+-\w+-\w+-\w+'	[Pass]
CHECK:output =~ SERVICEGROUP=c910f02c02p17	[Pass]
```

The UT for packimage_uuid
```
------START::packimage_uuid::Time:Tue Jan 29 01:47:28 2019------

RUN:lsdef -z c910f02c02p19 >> /tmp/node.stanza [Tue Jan 29 01:47:28 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:ls /install/netboot/__GETNODEATTR(c910f02c02p19,os)__/__GETNODEATTR(c910f02c02p19,arch)__/compute/rootimg;if [ $? -eq 0 ];then mv -f /install/netboot/__GETNODEATTR(c910f02c02p19,os)__/__GETNODEATTR(c910f02c02p19,arch)__/compute/rootimg /rootimg.bak;fi [Tue Jan 29 01:47:28 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
bin
boot
dev
etc
home
lib
lib64
media
mnt
opt
proc
root
run
sbin
srv
sys
tmp
usr
var
xcatpost

RUN:ls /install/netboot/__GETNODEATTR(c910f02c02p19,os)__/__GETNODEATTR(c910f02c02p19,arch)__/compute/rootimg.cpio.gz;if [ $? -eq 0 ];then mv -f /install/netboot/__GETNODEATTR(c910f02c02p19,os)__/__GETNODEATTR(c910f02c02p19,arch)__/compute/rootimg.cpio.gz /rootimg.cpio.gz.bak;fi [Tue Jan 29 01:47:30 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
/install/netboot/rhels7.6/ppc64/compute/rootimg.cpio.gz

RUN:copycds /RHEL-7.6-20181010.0-Server-ppc64-dvd1.iso [Tue Jan 29 01:47:31 2019]
ElapsedTime:80 sec
RETURN rc = 0
OUTPUT:
Copying media to /install/rhels7.6/ppc64
Media copy operation successful
CHECK:rc == 0	[Pass]

RUN:packimage __GETNODEATTR(c910f02c02p19,os)__-__GETNODEATTR(c910f02c02p19,arch)__-netboot-compute [Tue Jan 29 01:48:51 2019]
ElapsedTime:4 sec
RETURN rc = 0
OUTPUT:
Packing contents of /install/netboot/rhels7.6/ppc64/compute/rootimg
archive method:cpio
compress method:gzip

CHECK:rc == 0	[Pass]

RUN:cp /install/netboot/__GETNODEATTR(c910f02c02p19,os)__/__GETNODEATTR(c910f02c02p19,arch)__/compute/rootimg/opt/xcat/xcatinfo /tmp/uuid [Tue Jan 29 01:48:55 2019]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
cp: cannot stat '/install/netboot/rhels7.6/ppc64/compute/rootimg/opt/xcat/xcatinfo': No such file or directory

RUN:packimage __GETNODEATTR(c910f02c02p19,os)__-__GETNODEATTR(c910f02c02p19,arch)__-netboot-compute [Tue Jan 29 01:48:56 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
Packing contents of /install/netboot/rhels7.6/ppc64/compute/rootimg
archive method:cpio
compress method:gzip

CHECK:rc == 0	[Pass]

RUN:uuid=`cat /install/netboot/__GETNODEATTR(c910f02c02p19,os)__/__GETNODEATTR(c910f02c02p19,arch)__/compute/rootimg/opt/xcat/xcatinfo |grep UUID|awk -F= '{print $2}'`;grep $uuid /tmp/uuid [Tue Jan 29 01:48:58 2019]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
CHECK:rc != 0	[Pass]

RUN:ls -l /install/netboot/__GETNODEATTR(c910f02c02p19,os)__/__GETNODEATTR(c910f02c02p19,arch)__/compute/rootimg.cpio.gz [Tue Jan 29 01:48:59 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
-rw-r--r-- 1 root root 249956 Jan 29 01:48 /install/netboot/rhels7.6/ppc64/compute/rootimg.cpio.gz
CHECK:rc == 0	[Pass]

RUN:rm -rf /install/netboot/__GETNODEATTR(c910f02c02p19,os)__/__GETNODEATTR(c910f02c02p19,arch)__/compute/rootimg.cpio.gz [Tue Jan 29 01:49:01 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:mv -f /rootimg.cpio.gz.bak /install/netboot/__GETNODEATTR(c910f02c02p19,os)__/__GETNODEATTR(c910f02c02p19,arch)__/compute/rootimg.cpio.gz [Tue Jan 29 01:49:02 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:rm -rf /install/netboot/__GETNODEATTR(c910f02c02p19,os)__/__GETNODEATTR(c910f02c02p19,arch)__/compute/rootimg [Tue Jan 29 01:49:03 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:mv -f /rootimg.bak /install/netboot/__GETNODEATTR(c910f02c02p19,os)__/__GETNODEATTR(c910f02c02p19,arch)__/compute/rootimg [Tue Jan 29 01:49:04 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:

RUN:if [ -e /tmp/node.stanza ]; then rmdef c910f02c02p19; cat /tmp/node.stanza | mkdef -z; rm -rf /tmp/node.stanza; fi [Tue Jan 29 01:49:06 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
1 object definitions have been created or modified.

------END::packimage_uuid::Passed::Time:Tue Jan 29 01:49:07 2019 ::Duration::99 sec------
------Total: 1 , Failed: 0------
```
