### PR TITLE
Add test case for issue 2727 : run xCAT in XCATBYPASS mode and simply reload xCAT to check if there is any errors

### DIFF
--- a/xCAT-test/autotest/testcase/xcatd/case0
+++ b/xCAT-test/autotest/testcase/xcatd/case0
@@ -160,4 +160,20 @@ cmd:chtab name=root policy.commands= policy.rule=allow
 check:rc==0
 end
 
-
+start:reload_xcatd_with_XCATBYPASS
+description:with XCATBYPASS=YES, there is no error when restart xcatd deamon. This case is add test case for issue 2727 : run xCAT in "XCATBYPASS" mode and simply reload xCAT to check if there is any errors. 
+label:mn_only,ci_test,xcatd
+cmd:service xcatd status
+check:rc==0
+check:output=~xcatd service|xcatd.service
+check:output=~xcatd service is running|active \(running\)
+cmd:XCATBYPASS=YES lsxcatd -a
+check:rc==0
+check:output!=~Error|ERROR
+cmd:XCATBYPASS=YES service xcatd status
+check:rc==0
+check:output!=~Error|ERROR
+cmd:XCATBYPASS=YES service xcatd restart
+check:rc==0
+check:output!=~Error|ERROR 
+end


### PR DESCRIPTION
### The PR is to for task https://github.com/xcat2/xcat2-task-management/issues/190
Add test case for issue  #2727 : run xCAT in XCATBYPASS mode and simply reload xCAT to check if there is any errors

The UT result
```
------START::reload_xcatd_with_XCATBYPASS::Time:Tue Jan 29 21:51:40 2019------

RUN:service xcatd status [Tue Jan 29 21:51:40 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
xcatd service is running
CHECK:rc == 0	[Pass]
CHECK:output =~ xcatd service|xcatd.service	[Pass]
CHECK:output =~ xcatd service is running|active \(running\)	[Pass]

RUN:XCATBYPASS=YES lsxcatd -a [Tue Jan 29 21:51:40 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
Version 2.14.6 (git commit e75fc7fbb1bb2f6d33091a70f7e71228c165ccf3, built Thu Jan 24 06:16:43 EST 2019)
This is a Management Node
cfgloc=mysql:dbname=xcatdb;host=10.2.2.16|xcatadmin
dbengine=mysql
dbname=xcatdb
dbhost=10.2.2.16
dbadmin=xcatadmin
CHECK:rc == 0	[Pass]
CHECK:output !=~ Error|ERROR	[Pass]

RUN:XCATBYPASS=YES service xcatd status [Tue Jan 29 21:51:42 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
xcatd service is running
CHECK:rc == 0	[Pass]
CHECK:output !=~ Error|ERROR	[Pass]

RUN:XCATBYPASS=YES service xcatd restart [Tue Jan 29 21:51:42 2019]
ElapsedTime:4 sec
RETURN rc = 0
OUTPUT:
Restarting xcatd (via systemctl):  [  OK  ]
CHECK:rc == 0	[Pass]
CHECK:output !=~ Error|ERROR	[Pass]

------END::reload_xcatd_with_XCATBYPASS::Passed::Time:Tue Jan 29 21:51:46 2019 ::Duration::6 sec------
------Total: 1 , Failed: 0------
```