### PR TITLE
Python example suggestions

### DIFF
--- a/xCAT-server/xCAT-wsapi/xcatws-test.py
+++ b/xCAT-server/xCAT-wsapi/xcatws-test.py
@@ -77,20 +77,20 @@ except Exception as e:
 #
 # Send a request to get all nodes, passing in user and password
 #
-all_nodes = requests.get(get_all_nodes + "?userName=" + username + "&userPW=" + password, verify=False)
+response = requests.get(get_all_nodes + "?userName=" + username + "&userPW=" + password, verify=False)
 
 # Display returned data
 print "List of all nodes extracted with userid and password:"
-print all_nodes.content
+print response.content
 #
 # Send a request to get all nodes, passing in a token
 #
 user_data = {'userName': username,'userPW': password}
 token = requests.post(get_token, verify=False, headers={'Content-Type': 'application/json'}, data=json.dumps(user_data))
-all_nodes = requests.get(get_all_nodes, verify=False, headers={'X-Auth-Token': token.json()['token']['id']})
+response = requests.get(get_all_nodes, verify=False, headers={'X-Auth-Token': token.json()['token']['id']})
 
 # Display returned data
 print "List of all nodes extracted with authentication token:"
-print all_nodes.content
+print response.content
 
 sys.exit(0)

--- a/xCAT-server/xCAT-wsapi/xcatws-test.py
+++ b/xCAT-server/xCAT-wsapi/xcatws-test.py
@@ -81,7 +81,7 @@ response = requests.get(get_all_nodes + "?userName=" + username + "&userPW=" + p
 
 # Display returned data
 print "List of all nodes extracted with userid and password:"
-print response.content
+print response.text
 #
 # Send a request to get all nodes, passing in a token
 #
@@ -91,6 +91,6 @@ response = requests.get(get_all_nodes, verify=False, headers={'X-Auth-Token': to
 
 # Display returned data
 print "List of all nodes extracted with authentication token:"
-print response.content
+print response.text
 
 sys.exit(0)


### PR DESCRIPTION
# Python example suggestions

## Purpose
Suggested changes to python example script to make it more literal to new users. 

## Approach
I suggest a change in a variable name and an accessed attribute in the script. 

In the original script, the response object was called `all_nodes`. I suggest changing the name of this var to `response`.

Reasoning:
- `all_nodes` can imply that this is a simple python list of node names. 
- it is actually a response object with additional attributes that can be accessed such as `.content`, `.text`, and `.json`. 

In the original script, we access the `.content` attribute of the response object. I suggest we use the `.text` attribute instead.

Reasoning:
- `content` is "Content of the response, in bytes." It prints nicely in the console because python is smart enough when we call print. 
- Might be clearer to use the `.text` attribute for someone new looking at this example. This may make it clearer that we are looking at the response and printing the text of it in the console. 

## Contents
This pull request includes :
- A var name change to the example file. 
- A change in which attribute is accessed of the response object. 



