### PR TITLE
update go_xcat cases to let cn could resolv hostname

### DIFF
--- a/xCAT-test/autotest/testcase/go_xcat/case0
+++ b/xCAT-test/autotest/testcase/go_xcat/case0
@@ -18,7 +18,7 @@ check:rc==0
 cmd:xdsh $$CN "cd /xcat-core; ./mklocalrepo.sh"
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
 check:rc==0
@@ -57,7 +57,7 @@ check:rc==0
 cmd:xdsh $$CN "cd /; tar -jxf /xcat-core.tar.bz2"
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
 check:rc==0
@@ -96,7 +96,7 @@ check:rc==0
 cmd:xdsh $$CN "cd /; bunzip2 /xcat-core.tar.bz2"
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
 check:rc==0
@@ -135,7 +135,7 @@ check:rc==0
 cmd:xdsh $$CN "cd /; scp -r $$MN:/xcat-dep*.tar.bz2 /xcat-dep.tar.bz2"
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
 check:rc==0
@@ -182,7 +182,7 @@ check:rc==0
 cmd:xdsh $$CN "cd /xcat-core; ./mklocalrepo.sh"
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
 check:rc==0
@@ -225,7 +225,7 @@ check:rc==0
 cmd:xdsh $$CN "cd /; tar -jxf /xcat-core.tar.bz2"
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
 check:rc==0
@@ -262,7 +262,7 @@ check:rc==0
 cmd:xdsh $$CN "cd /; scp -r $$MN:/xcat-dep*.tar.bz2 /xcat-dep.tar.bz2"
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
 check:rc==0

--- a/xCAT-test/autotest/testcase/go_xcat/case1
+++ b/xCAT-test/autotest/testcase/go_xcat/case1
@@ -13,7 +13,7 @@ check:rc==0
 cmd:xdsh $$CN "cd /; scp -r $$MN:/opt/xcat/share/xcat/tools/go-xcat ./"
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
 check:rc==0
@@ -48,7 +48,7 @@ check:rc==0
 cmd:xdsh $$CN "cd /; scp -r $$MN:/opt/xcat/share/xcat/tools/go-xcat ./"
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
 check:rc==0
@@ -90,7 +90,7 @@ check:rc==0
 cmd:xdsh $$CN "cd /; scp -r $$MN:/opt/xcat/share/xcat/tools/go-xcat ./"
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
 check:rc==0
@@ -125,7 +125,7 @@ check:rc==0
 cmd:xdsh $$CN "cd /; scp -r $$MN:/opt/xcat/share/xcat/tools/go-xcat ./"
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
 check:rc==0

--- a/xCAT-test/autotest/testcase/go_xcat/case2
+++ b/xCAT-test/autotest/testcase/go_xcat/case2
@@ -43,7 +43,7 @@ check:rc==0
 cmd:xdsh $$CN "cd /; scp -r $$MN:/opt/xcat/share/xcat/tools/go-xcat ./"
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
 check:rc==0
@@ -79,7 +79,7 @@ check:rc==0
 cmd:xdsh $$CN "cd /; scp -r $$MN:/opt/xcat/share/xcat/tools/go-xcat ./"
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
 check:rc==0
@@ -147,7 +147,7 @@ cmd:xdsh $$CN "cd /; scp -r $$MN:/opt/xcat/share/xcat/tools/go-xcat ./"
 check:rc==0
 cmd:dir="__GETNODEATTR($$CN,os)__"; if grep SUSE /etc/*release;then os=`echo $dir |cut -c 1-6` && xdsh $$CN "cd /xcat-dep/$os/__GETNODEATTR($$CN,arch)__/; ./mklocalrepo.sh" ; elif grep "Red Hat" /etc/*release;then os=`echo $dir |cut -c 1-2` && xdsh $$CN "cd /xcat-dep/$os`echo __GETNODEATTR($$CN,os)__ | cut -c6`/__GETNODEATTR($$CN,arch)__/; ./mklocalrepo.sh"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cd /xcat-dep; ./mklocalrepo.sh"; else echo "Sorry,this is not supported os"; fi
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
 check:rc==0
@@ -183,7 +183,7 @@ check:rc==0
 cmd:cp /xcat-dep-*.tar.bz2 /install/
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
 check:rc==0

--- a/xCAT-test/autotest/testcase/go_xcat/case4
+++ b/xCAT-test/autotest/testcase/go_xcat/case4
@@ -16,7 +16,7 @@ check:rc==0
 cmd:xdsh $$CN "cd /; scp -r $$MN:/xcat-dep*.tar.bz2 /xcat-dep.tar.bz2"
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
 check:rc==0


### PR DESCRIPTION
### The PR is to do task 582 https://github.com/xcat2/xcat2-task-management/issues/582

The UT result
```
------START::go_xcat_local_repo_case1::Time:Mon Feb 11 01:27:11 2019------

RUN:if xdsh c910f04x35v04 "zypper -h"; then  xdsh c910f04x35v04 "zypper remove -y *xCAT*"; elif xdsh c910f04x35v04 "yum -h";then xdsh c910f04x35v04  "yum remove -y *xCAT*"; elif xdsh c910f04x35v04 "apt-get -h";then xdsh c910f04x35v04 "apt-get purge perl-xcat xcat-client xcat-server xcat -y"; else echo "Sorry,this is not supported os"; fi [Mon Feb 11 01:27:11 2019]
ElapsedTime:11 sec
RETURN rc = 0
OUTPUT:
[c910f04x35v02]: c910f04x35v04: bash: zypper: command not found
[c910f04x35v02]: c910f04x35v04: bash: yum: command not found
c910f04x35v04: apt 1.6.6 (amd64)
c910f04x35v04: Usage: apt-get [options] command
c910f04x35v04:        apt-get [options] install|remove pkg1 [pkg2 ...]
c910f04x35v04:        apt-get [options] source pkg1 [pkg2 ...]
c910f04x35v04:
c910f04x35v04: apt-get is a command line interface for retrieval of packages
c910f04x35v04: and information about them from authenticated sources and
c910f04x35v04: for installation, upgrade and removal of packages together
c910f04x35v04: with their dependencies.
c910f04x35v04:
c910f04x35v04: Most used commands:
c910f04x35v04:   update - Retrieve new lists of packages
c910f04x35v04:   upgrade - Perform an upgrade
c910f04x35v04:   install - Install new packages (pkg is libc6 not libc6.deb)
c910f04x35v04:   remove - Remove packages
c910f04x35v04:   purge - Remove packages and config files
c910f04x35v04:   autoremove - Remove automatically all unused packages
c910f04x35v04:   dist-upgrade - Distribution upgrade, see apt-get(8)
c910f04x35v04:   dselect-upgrade - Follow dselect selections
c910f04x35v04:   build-dep - Configure build-dependencies for source packages
c910f04x35v04:   clean - Erase downloaded archive files
c910f04x35v04:   autoclean - Erase old downloaded archive files
c910f04x35v04:   check - Verify that there are no broken dependencies
c910f04x35v04:   source - Download source archives
c910f04x35v04:   download - Download the binary package into the current directory
c910f04x35v04:   changelog - Download and display the changelog for the given package
c910f04x35v04:
c910f04x35v04: See apt-get(8) for more information about the available commands.
c910f04x35v04: Configuration options and syntax is detailed in apt.conf(5).
c910f04x35v04: Information about how to configure sources can be found in sources.list(5).
c910f04x35v04: Package and version choices can be expressed via apt_preferences(5).
c910f04x35v04: Security details are available in apt-secure(8).
c910f04x35v04:                                         This APT has Super Cow Powers.
c910f04x35v04: Reading package lists...
c910f04x35v04: Building dependency tree...
c910f04x35v04: Reading state information...
c910f04x35v04: The following packages were automatically installed and are no longer required:
c910f04x35v04:   apache2 apache2-bin apache2-data apache2-utils bind9 bind9utils
c910f04x35v04:   conserver-xcat dmeventd elilo-xcat goconserver grub2-xcat ipmitool-xcat
c910f04x35v04:   isc-dhcp-server libapr1 libaprutil1 libaprutil1-dbd-sqlite3 libaprutil1-ldap
c910f04x35v04:   libavahi-client3 libavahi-common-data libavahi-common3 libblas3
c910f04x35v04:   libcommon-sense-perl libcrypt-cbc-perl libcrypt-rijndael-perl
c910f04x35v04:   libdbd-sqlite3-perl libdevmapper-event1.02.1 libexpect-perl
c910f04x35v04:   libfile-copy-recursive-perl libhttp-async-perl libio-stty-perl
c910f04x35v04:   libirs-export160 libisccfg-export160 libjson-perl libjson-xs-perl liblinear3
c910f04x35v04:   liblua5.2-0 liblua5.3-0 liblvm2app2.2 liblvm2cmd2.02 libnet-https-nb-perl
c910f04x35v04:   libnet-telnet-perl libreadline5 libsensors4 libsnmp-base libsnmp-perl
c910f04x35v04:   libsnmp30 libsys-virt-perl libtypes-serialiser-perl libvirt0 libyajl2 lvm2
c910f04x35v04:   mtools nfs-kernel-server nmap python3-ply ssl-cert syslinux syslinux-common
c910f04x35v04:   syslinux-xcat tftp-hpa tftpd-hpa update-inetd xcat-buildkit
c910f04x35v04:   xcat-genesis-base-amd64 xcat-genesis-base-ppc64 xcat-genesis-scripts-amd64
c910f04x35v04:   xcat-genesis-scripts-ppc64 xcat-probe xinetd xnba-undi
c910f04x35v04: Use 'apt autoremove' to remove them.
c910f04x35v04: The following packages will be REMOVED:
c910f04x35v04:   perl-xcat* xcat* xcat-client* xcat-server*
c910f04x35v04: 0 upgraded, 0 newly installed, 4 to remove and 80 not upgraded.
c910f04x35v04: After this operation, 21.0 MB disk space will be freed.
c910f04x35v04: (Reading database ...
(Reading database ... 5%
(Reading database ... 10%
(Reading database ... 15%
(Reading database ... 20%
(Reading database ... 25%
(Reading database ... 30%
(Reading database ... 35%
(Reading database ... 40%
(Reading database ... 45%
(Reading database ... 50%
(Reading database ... 55%
(Reading database ... 60%
(Reading database ... 65%
(Reading database ... 70%
(Reading database ... 75%
(Reading database ... 80%
(Reading database ... 85%
(Reading database ... 90%
(Reading database ... 95%
(Reading database ... 100%
(Reading database ... 93270 files and directories currently installed.)

c910f04x35v04: Removing xcat (2.14.6-snap201902080617) ...

c910f04x35v04: Removing xcat-server (2.14.6-snap201902080617) ...

c910f04x35v04: Synchronizing state of xcatd.service with SysV service script with /lib/systemd/systemd-sysv-install.
c910f04x35v04: Executing: /lib/systemd/systemd-sysv-install disable xcatd

c910f04x35v04: Removing xcat-client (2.14.6-snap201902080617) ...

c910f04x35v04: Removing perl-xcat (2.14.6-snap201902080617) ...

c910f04x35v04: (Reading database ...
(Reading database ... 5%
(Reading database ... 10%
(Reading database ... 15%
(Reading database ... 20%
(Reading database ... 25%
(Reading database ... 30%
(Reading database ... 35%
(Reading database ... 40%
(Reading database ... 45%
(Reading database ... 50%
(Reading database ... 55%
(Reading database ... 60%
(Reading database ... 65%
(Reading database ... 70%
(Reading database ... 75%
(Reading database ... 80%
(Reading database ... 85%
(Reading database ... 90%
(Reading database ... 95%
(Reading database ... 100%
(Reading database ... 91177 files and directories currently installed.)

c910f04x35v04: Purging configuration files for xcat (2.14.6-snap201902080617) ...

c910f04x35v04: dpkg: warning: while removing xcat, directory '/install/postscripts/hostkeys' not empty so not removed

c910f04x35v04: Purging configuration files for xcat-client (2.14.6-snap201902080617) ...

c910f04x35v04: Purging configuration files for perl-xcat (2.14.6-snap201902080617) ...

c910f04x35v04: Purging configuration files for xcat-server (2.14.6-snap201902080617) ...

c910f04x35v04: dpkg: warning: while removing xcat-server, directory '/etc/xcat' not empty so not removed

c910f04x35v04: Processing triggers for ureadahead (0.100.0-20) ...

c910f04x35v04: Processing triggers for systemd (237-3ubuntu10.11) ...

c910f04x35v04: Processing triggers for rsyslog (8.32.0-1ubuntu4) ...


RUN:if grep Ubuntu /etc/*release;then xdsh c910f04x35v04 "dpkg -l |grep -i perl-xcat";else xdsh c910f04x35v04 "rpm -qa |grep -i perl-xcat";fi [Mon Feb 11 01:27:22 2019]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
/etc/lsb-release:DISTRIB_ID=Ubuntu
/etc/lsb-release:DISTRIB_DESCRIPTION="Ubuntu 18.04.1 LTS"
/etc/os-release:NAME="Ubuntu"
/etc/os-release:PRETTY_NAME="Ubuntu 18.04.1 LTS"
CHECK:rc != 0	[Pass]

RUN:if xdsh c910f04x35v04 "grep \"Red Hat\" /etc/*release >/dev/null"; then xdsh c910f04x35v04 "yum install -y yum-utils bzip2"; fi [Mon Feb 11 01:27:23 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xdsh c910f04x35v04 "cd /; rm -rf /xcat-core* /go-xcat" [Mon Feb 11 01:27:24 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xdsh c910f04x35v04 "cd /; scp -r c910f04x35v02:/opt/xcat/share/xcat/tools/go-xcat ./" [Mon Feb 11 01:27:25 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xdsh c910f04x35v04 "cd /; scp -r c910f04x35v02:/core-*-snap.tar.bz2 /xcat-core.tar.bz2" [Mon Feb 11 01:27:27 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xdsh c910f04x35v04 "cd /; tar -jxf /xcat-core.tar.bz2" [Mon Feb 11 01:27:28 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xdsh c910f04x35v04 "cd /xcat-core; ./mklocalrepo.sh" [Mon Feb 11 01:27:30 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh c910f04x35v04 "scp -r c910f04x35v02:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR(c910f04x35v04,arch)__.sources.list /etc/apt/sources.list"; fi [Mon Feb 11 01:27:31 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
/etc/lsb-release:DISTRIB_ID=Ubuntu
/etc/lsb-release:DISTRIB_DESCRIPTION="Ubuntu 18.04.1 LTS"
/etc/os-release:NAME="Ubuntu"
/etc/os-release:PRETTY_NAME="Ubuntu 18.04.1 LTS"

RUN:if grep Ubuntu /etc/*release;then xdsh c910f04x35v04 "scp -r c910f04x35v02:/etc/hosts /etc/hosts" && xdsh c910f04x35v04 "scp -r c910f04x35v02:/etc/resolv.conf /etc/resolv.conf" && xdsh c910f04x35v04 "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi [Mon Feb 11 01:27:33 2019]
ElapsedTime:4 sec
RETURN rc = 0
OUTPUT:
/etc/lsb-release:DISTRIB_ID=Ubuntu
/etc/lsb-release:DISTRIB_DESCRIPTION="Ubuntu 18.04.1 LTS"
/etc/os-release:NAME="Ubuntu"
/etc/os-release:PRETTY_NAME="Ubuntu 18.04.1 LTS"
c910f04x35v04: OK
[c910f04x35v02]: c910f04x35v04: --2019-02-11 01:27:37--  http://xcat.org/files/xcat/repos/apt/apt.key
c910f04x35v04: Resolving xcat.org (xcat.org)... 166.70.135.166
[c910f04x35v02]: c910f04x35v04: Connecting to xcat.org (xcat.org)|166.70.135.166|:80... connected.
[c910f04x35v02]: c910f04x35v04: HTTP request sent, awaiting response... 200 OK
c910f04x35v04: Length: 4786 (4.7K) [application/pgp-keys]
c910f04x35v04: Saving to: 'STDOUT'
c910f04x35v04:
c910f04x35v04:      0K ....                                                  100%  553M=0s
c910f04x35v04:
c910f04x35v04: 2019-02-11 01:27:37 (553 MB/s) - written to stdout [4786/4786]
[c910f04x35v02]: c910f04x35v04: Warning: apt-key output should not be parsed (stdout is not a terminal)
CHECK:rc == 0	[Pass]

```