### PR TITLE
fix issue xdcp EXECUTE of .post script not working as expected #5987

### DIFF
--- a/perl-xCAT/xCAT/DSHCLI.pm
+++ b/perl-xCAT/xCAT/DSHCLI.pm
@@ -5936,6 +5936,11 @@ sub run_rsync_postscripts
         # return from rsync is tmp/file1  not /tmp/file1
         substr($tmppostfile, 0, 1) = "";
 
+        # now remove .post from the postscript file for the compare
+        # with the returned file name
+        my($tp,$post) = split(/\.post/,$tmppostfile);
+        $tmppostfile = $tp;
+
         foreach my $line (@rsync_output) {
             my ($hostname, $ps) = split(/: /, $line);
             chomp $ps;
@@ -5948,7 +5953,11 @@ sub run_rsync_postscripts
                 }
                 next;
             }
-            if ($tmppostfile eq $ps) {
+
+            #the $postsfile <file>.post will be run if:
+            # the <file> is updated, or
+            # the <file>.post file is updated
+            if ($ps eq $tmppostfile or $ps eq $tmppostfile.".post" ) {
 
                 # build xdsh queue
                 # build host and all scripts to execute


### PR DESCRIPTION
### The PR is to fix issue https://github.com/xcat2/xcat-core/issues/5987

The <file>.post script will be run if:
1.  `<file>` is updated, or
2. `<file>.post` is updated

UT:

the sync list file:
```
[root@boston36 xCAT]# cat /install/custom/synclist
/etc/test -> /tmp/etc/test
/etc/test.post -> /tmp/etc/test.post
EXECUTE:
/etc/test.post
[root@boston36 xCAT]# cat /etc/test.post
#!/bin/bash
date >> /tmp/hosts.date
```

1. perform file sync first, the `/etc/test.post` is invoked: 
```
[root@boston36 xCAT]# ssh mid21tor24cn01 'echo ""> /tmp/hosts.date'
[root@boston36 xCAT]# ssh mid21tor24cn01 cat /tmp/hosts.date

[root@boston36 xCAT]# ssh mid21tor24cn01 rm  /tmp/etc/test
[root@boston36 xCAT]# ssh mid21tor24cn01 rm   /tmp/etc/test.post
[root@boston36 xCAT]# xdcp mid21tor24cn01 -v -T -F /install/custom/synclist
TRACE:Default context is XCAT.
TRACE:Fanout Value is 64.
TRACE:Timeout Value is .
TRACE:Verifying remaining targets with pping command.
 TRACE: Executing Command:/bin/sh -c /tmp/rsync_mid21tor24cn01
TRACE:Default context is XCAT
TRACE:Node RSH is
TRACE: Fanout value is 64.
TRACE: Timeout value is
TRACE: Verify value is
TRACE: Execute option specified.
TRACE:Execute: Exporting File:/usr/bin/scp -B /etc/test.post root@mid21tor24cn01:/tmp/Fb9lLdGrEN.dsh
Command name: /usr/bin/ssh -o BatchMode=yes -x root@mid21tor24cn01 export NODE=mid21tor24cn01; export LANG=en_US.UTF-8 LC_CTYPE="C" LC_NUMERIC="C" LC_TIME="C" LC_COLLATE="C" LC_MONETARY="C" LC_MESSAGES="C" LC_PAPER="C" LC_NAME="C" LC_ADDRESS="C" LC_TELEPHONE="C" LC_MEASUREMENT="C" LC_IDENTIFICATION="C" LC_ALL=C PERL_BADLANG=0 ;  /tmp/Fb9lLdGrEN.dsh ; export DSH_TARGET_RC=$?; echo ":DSH_TARGET_RC=${DSH_TARGET_RC}:";rm /tmp/Fb9lLdGrEN.dsh
[root@boston36 xCAT]# ssh mid21tor24cn01 cat /tmp/hosts.date

Tue Feb 12 03:12:42 EST 2019
[root@boston36 xCAT]#
```

2. nothing will be invoked on 2nd time file sync operation, due to nothing is updated 
```
[root@boston36 xCAT]# xdcp mid21tor24cn01 -v -T -F /install/custom/synclist
TRACE:Default context is XCAT.
TRACE:Fanout Value is 64.
TRACE:Timeout Value is .
TRACE:Verifying remaining targets with pping command.
 TRACE: Executing Command:/bin/sh -c /tmp/rsync_mid21tor24cn01
[root@boston36 xCAT]# ssh mid21tor24cn01 cat /tmp/hosts.date

Tue Feb 12 03:12:42 EST 2019
[root@boston36 xCAT]#
```


3. `/etc/test.post` will be invoked if `/etc/test` is updated:
```
[root@boston36 xCAT]# touch /etc/test
[root@boston36 xCAT]# xdcp mid21tor24cn01 -v -T -F /install/custom/synclist
TRACE:Default context is XCAT.
TRACE:Fanout Value is 64.
TRACE:Timeout Value is .
TRACE:Verifying remaining targets with pping command.
 TRACE: Executing Command:/bin/sh -c /tmp/rsync_mid21tor24cn01
TRACE:Default context is XCAT
TRACE:Node RSH is
TRACE: Fanout value is 64.
TRACE: Timeout value is
TRACE: Verify value is
TRACE: Execute option specified.
TRACE:Execute: Exporting File:/usr/bin/scp -B /etc/test.post root@mid21tor24cn01:/tmp/Fb9lLdGrEN.dsh
Command name: /usr/bin/ssh -o BatchMode=yes -x root@mid21tor24cn01 export NODE=mid21tor24cn01; export LANG=en_US.UTF-8 LC_CTYPE="C" LC_NUMERIC="C" LC_TIME="C" LC_COLLATE="C" LC_MONETARY="C" LC_MESSAGES="C" LC_PAPER="C" LC_NAME="C" LC_ADDRESS="C" LC_TELEPHONE="C" LC_MEASUREMENT="C" LC_IDENTIFICATION="C" LC_ALL=C PERL_BADLANG=0 ;  /tmp/Fb9lLdGrEN.dsh ; export DSH_TARGET_RC=$?; echo ":DSH_TARGET_RC=${DSH_TARGET_RC}:";rm /tmp/Fb9lLdGrEN.dsh
[root@boston36 xCAT]# ssh mid21tor24cn01 cat /tmp/hosts.date

Tue Feb 12 03:12:42 EST 2019
Tue Feb 12 03:15:14 EST 2019
[root@boston36 xCAT]#
```

4. `/etc/test.post` will be invoked if `/etc/test.post` is updated:
```
[root@boston36 xCAT]# touch /etc/test.post
[root@boston36 xCAT]# xdcp mid21tor24cn01 -v -T -F /install/custom/synclist
TRACE:Default context is XCAT.
TRACE:Fanout Value is 64.
TRACE:Timeout Value is .
TRACE:Verifying remaining targets with pping command.
 TRACE: Executing Command:/bin/sh -c /tmp/rsync_mid21tor24cn01
TRACE:Default context is XCAT
TRACE:Node RSH is
TRACE: Fanout value is 64.
TRACE: Timeout value is
TRACE: Verify value is
TRACE: Execute option specified.
TRACE:Execute: Exporting File:/usr/bin/scp -B /etc/test.post root@mid21tor24cn01:/tmp/Fb9lLdGrEN.dsh
Command name: /usr/bin/ssh -o BatchMode=yes -x root@mid21tor24cn01 export NODE=mid21tor24cn01; export LANG=en_US.UTF-8 LC_CTYPE="C" LC_NUMERIC="C" LC_TIME="C" LC_COLLATE="C" LC_MONETARY="C" LC_MESSAGES="C" LC_PAPER="C" LC_NAME="C" LC_ADDRESS="C" LC_TELEPHONE="C" LC_MEASUREMENT="C" LC_IDENTIFICATION="C" LC_ALL=C PERL_BADLANG=0 ;  /tmp/Fb9lLdGrEN.dsh ; export DSH_TARGET_RC=$?; echo ":DSH_TARGET_RC=${DSH_TARGET_RC}:";rm /tmp/Fb9lLdGrEN.dsh
[root@boston36 xCAT]# ssh mid21tor24cn01 cat /tmp/hosts.date

Tue Feb 12 03:12:42 EST 2019
Tue Feb 12 03:15:14 EST 2019
Tue Feb 12 03:16:00 EST 2019
[root@boston36 xCAT]#
```
