### PR TITLE
refine go-xcat test case to leverage local mirror

### DIFF
--- a/xCAT-test/autotest/testcase/go_xcat/case0
+++ b/xCAT-test/autotest/testcase/go_xcat/case0
@@ -20,7 +20,7 @@ check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update"; fi
 check:rc==0
 cmd:xdsh $$CN "rm -rf /tmp/go-xcat.log"
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "cd /; ./go-xcat --xcat-core=/etc/zypp/repos.d/xCAT-core.repo -y install"; elif grep "Red Hat" /etc/*release;then xdsh $$CN  "cd /; ./go-xcat --xcat-core=/etc/yum.repos.d/xCAT-core.repo -y install"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cd /; ./go-xcat --xcat-core=/etc/apt/sources.list.d/xcat-core.list -y install";else echo "Sorry,this is not supported os"; fi
@@ -59,7 +59,7 @@ check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update"; fi
 check:rc==0
 cmd:xdsh $$CN "rm -rf /tmp/go-xcat.log"
 cmd:xdsh $$CN "cd /; ./go-xcat --xcat-core=/xcat-core -y install"
@@ -98,7 +98,7 @@ check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update"; fi
 check:rc==0
 cmd:xdsh $$CN "rm -rf /tmp/go-xcat.log"
 cmd:xdsh $$CN "cd /; ./go-xcat --xcat-core=/xcat-core.tar -y install"
@@ -137,7 +137,7 @@ check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update"; fi
 check:rc==0
 cmd:xdsh $$CN "rm -rf /tmp/go-xcat.log"
 cmd:xdsh $$CN "cd /; ./go-xcat --xcat-core=/xcat-core.tar.bz2 --xcat-dep=/xcat-dep.tar.bz2 -y install"
@@ -184,7 +184,7 @@ check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update"; fi
 check:rc==0
 cmd:xdsh $$CN "rm -rf /tmp/go-xcat.log"
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "cd /; ./go-xcat --xcat-core=/etc/zypp/repos.d/xCAT-core.repo --xcat-dep=/etc/zypp/repos.d/xCAT-dep.repo -y install"; elif grep "Red Hat" /etc/*release;then xdsh $$CN  "cd /; ./go-xcat --xcat-core=/etc/yum.repos.d/xCAT-core.repo --xcat-dep=/etc/yum.repos.d/xCAT-dep.repo -y install"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cd /; ./go-xcat --xcat-core=/etc/apt/sources.list.d/xcat-core.list --xcat-dep=/etc/apt/sources.list.d/xcat-dep.list -y install"; else echo "Sorry,this is not supported os"; fi
@@ -227,7 +227,7 @@ check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update"; fi
 check:rc==0
 cmd:xdsh $$CN "rm -rf /tmp/go-xcat.log"
 cmd:xdsh $$CN "cd /; ./go-xcat --xcat-core=/xcat-core --xcat-dep=/xcat-dep -y install"
@@ -264,7 +264,7 @@ check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update"; fi
 check:rc==0
 cmd:xdsh $$CN "rm -rf /tmp/go-xcat.log"
 cmd:xdsh $$CN "cd /; ./go-xcat --xcat-core=/xcat-core.tar.bz2 --xcat-dep=/xcat-dep.tar.bz2 -y install"

--- a/xCAT-test/autotest/testcase/go_xcat/case1
+++ b/xCAT-test/autotest/testcase/go_xcat/case1
@@ -15,7 +15,7 @@ check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update"; fi
 check:rc==0
 cmd:xdsh $$CN "rm -rf /tmp/go-xcat.log"
 cmd:xdsh $$CN "cd /; ./go-xcat --yes install"
@@ -50,7 +50,7 @@ check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update"; fi
 check:rc==0
 cmd:xdsh $$CN "rm -rf /tmp/go-xcat.log"
 cmd:migration_version=`echo $$MIGRATION2_VERSION |cut -d "." -f -2`; xdsh $$CN "cd /; ./go-xcat -x $migration_version -y install"
@@ -92,7 +92,7 @@ check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update"; fi
 check:rc==0
 cmd:xdsh $$CN "rm -rf /tmp/go-xcat.log"
 cmd:xdsh $$CN "cd /; ./go-xcat --xcat-version=devel -y install"
@@ -127,7 +127,7 @@ check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update"; fi
 check:rc==0
 cmd:xdsh $$CN "rm -rf /tmp/go-xcat.log"
 cmd:migration_version=`echo $$MIGRATION2_VERSION |cut -d "." -f -2`; xdsh $$CN "cd /; ./go-xcat --xcat-version=$migration_version -y install"

--- a/xCAT-test/autotest/testcase/go_xcat/case2
+++ b/xCAT-test/autotest/testcase/go_xcat/case2
@@ -45,7 +45,7 @@ check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update"; fi
 check:rc==0
 cmd:xdsh $$CN "rm -rf /tmp/go-xcat.log"
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "cd /; ./go-xcat --xcat-core=http://xcat.org/files/xcat/repos/apt/$$BRANCH/core-snap/";else xdsh $$CN "cd /; ./go-xcat --xcat-core=http://xcat.org/files/xcat/repos/yum/$$BRANCH/core-snap/ -y install"; fi
@@ -81,7 +81,7 @@ check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update"; fi
 check:rc==0
 cmd:xdsh $$CN "rm -rf /tmp/go-xcat.log"
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "cd /; ./go-xcat --xcat-core=http://xcat.org/files/xcat/xcat-core/devel/Ubuntu/core-snap/core-debs-snap.tar.bz2";else xdsh $$CN "cd /; ./go-xcat --xcat-core=http://xcat.org/files/xcat/xcat-core/devel/Linux/core-snap/core-rpms-snap.tar.bz2 -y install"; fi
@@ -149,7 +149,7 @@ cmd:dir="__GETNODEATTR($$CN,os)__"; if grep SUSE /etc/*release;then os=`echo $di
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update"; fi
 check:rc==0
 cmd:xdsh $$CN "rm -rf /tmp/go-xcat.log"
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "cd /; ./go-xcat --xcat-core=http://xcat.org/files/xcat/repos/apt/devel/core-snap/ --xcat-dep=http://xcat.org/files/xcat/repos/apt/xcat-dep/ -y install"; else xdsh $$CN "cd /; ./go-xcat --xcat-core=http://xcat.org/files/xcat/repos/yum/devel/core-snap/ --xcat-dep=http://xcat.org/files/xcat/repos/yum/xcat-dep/ -y install"; fi
@@ -185,7 +185,7 @@ check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update"; fi
 check:rc==0
 cmd:xdsh $$CN "rm -rf /tmp/go-xcat.log"
 cmd:dep=`ls /install/xcat-dep-*.tar.bz2`;if grep Ubuntu /etc/*release;then  xdsh $$CN "cd /; ./go-xcat --xcat-core=http://xcat.org/files/xcat/xcat-core/devel/Ubuntu/core-snap/core-debs-snap.tar.bz2 --xcat-dep=http://$$MN/$dep -y install"; else xdsh $$CN "cd /; ./go-xcat --xcat-core=http://xcat.org/files/xcat/xcat-core/devel/Linux/core-snap/core-rpms-snap.tar.bz2 --xcat-dep=http://$$MN/$dep -y install"; fi

--- a/xCAT-test/autotest/testcase/go_xcat/case4
+++ b/xCAT-test/autotest/testcase/go_xcat/case4
@@ -18,7 +18,7 @@ check:rc==0
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "scp -r $$MN:/etc/hosts /etc/hosts" && xdsh $$CN "scp -r $$MN:/etc/resolv.conf /etc/resolv.conf" && xdsh $$CN "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi
 check:rc==0
-cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "apt-get clean && apt-get update"; fi
+cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update"; fi
 check:rc==0
 cmd:if grep Ubuntu /etc/*release;then xdsh $$CN "cd /; ./go-xcat  --xcat-core=$$UBUNTU_MIGRATION2_CORE --xcat-dep=$$UBUNTU_MIGRATION2_DEP -y install";else xdsh $$CN "cd /; ./go-xcat  -x $$MIGRATION1_VERSION -y install";fi
 check:rc==0


### PR DESCRIPTION
### The PR is to do task https://github.com/xcat2/xcat2-task-management/issues/586

The UT result
```
------START::go_xcat_noinput::Time:Tue Feb 12 03:24:51 2019------

RUN:if xdsh f6u13k15 "zypper -h"; then  xdsh f6u13k15 "zypper remove -y *xCAT*"; elif xdsh f6u13k15 "yum -h";then xdsh f6u13k15  "yum remove -y *xCAT*"; elif xdsh f6u13k15 "apt-get -h";then xdsh f6u13k15 "apt-get purge perl-xcat xcat-client xcat-server xcat xcat-buildkit xcat-genesis-scripts  xcat-genesis-base-amd64 xcat-genesis-base-ppc64 -y"; else echo "Sorry,this is not supported os"; fi [Tue Feb 12 03:24:51 2019]
ElapsedTime:5 sec
RETURN rc = 1
OUTPUT:
[f6u13k13]: f6u13k15: bash: zypper: command not found
[f6u13k13]: f6u13k15: bash: yum: command not found
f6u13k15: apt 1.6.6 (ppc64el)
f6u13k15: Usage: apt-get [options] command
f6u13k15:        apt-get [options] install|remove pkg1 [pkg2 ...]
f6u13k15:        apt-get [options] source pkg1 [pkg2 ...]
f6u13k15:
f6u13k15: apt-get is a command line interface for retrieval of packages
f6u13k15: and information about them from authenticated sources and
f6u13k15: for installation, upgrade and removal of packages together
f6u13k15: with their dependencies.
f6u13k15:
f6u13k15: Most used commands:
f6u13k15:   update - Retrieve new lists of packages
f6u13k15:   upgrade - Perform an upgrade
f6u13k15:   install - Install new packages (pkg is libc6 not libc6.deb)
f6u13k15:   remove - Remove packages
f6u13k15:   purge - Remove packages and config files
f6u13k15:   autoremove - Remove automatically all unused packages
f6u13k15:   dist-upgrade - Distribution upgrade, see apt-get(8)
f6u13k15:   dselect-upgrade - Follow dselect selections
f6u13k15:   build-dep - Configure build-dependencies for source packages
f6u13k15:   clean - Erase downloaded archive files
f6u13k15:   autoclean - Erase old downloaded archive files
f6u13k15:   check - Verify that there are no broken dependencies
f6u13k15:   source - Download source archives
f6u13k15:   download - Download the binary package into the current directory
f6u13k15:   changelog - Download and display the changelog for the given package
f6u13k15:
f6u13k15: See apt-get(8) for more information about the available commands.
f6u13k15: Configuration options and syntax is detailed in apt.conf(5).
f6u13k15: Information about how to configure sources can be found in sources.list(5).
f6u13k15: Package and version choices can be expressed via apt_preferences(5).
f6u13k15: Security details are available in apt-secure(8).
f6u13k15:                                         This APT has Super Cow Powers.
f6u13k15: Reading package lists...
f6u13k15: Building dependency tree...
f6u13k15: Reading state information...
[f6u13k13]: f6u13k15: E: Unable to locate package perl-xcat
f6u13k15: E: Unable to locate package xcat-client
[f6u13k13]: f6u13k15: E: Unable to locate package xcat-server
[f6u13k13]: f6u13k15: E: Unable to locate package xcat
[f6u13k13]: f6u13k15: E: Unable to locate package xcat-buildkit
f6u13k15: E: Unable to locate package xcat-genesis-scripts
[f6u13k13]: f6u13k15: E: Unable to locate package xcat-genesis-base-amd64
f6u13k15: E: Unable to locate package xcat-genesis-base-ppc64

RUN:if grep Ubuntu /etc/*release;then xdsh f6u13k15 "dpkg -l |grep -i perl-xcat";else xdsh f6u13k15 "rpm -qa |grep -i perl-xcat";fi [Tue Feb 12 03:24:56 2019]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
/etc/lsb-release:DISTRIB_ID=Ubuntu
/etc/lsb-release:DISTRIB_DESCRIPTION="Ubuntu 18.04.1 LTS"
/etc/os-release:NAME="Ubuntu"
/etc/os-release:PRETTY_NAME="Ubuntu 18.04.1 LTS"
CHECK:rc != 0	[Pass]

RUN:if xdsh f6u13k15 "grep \"Red Hat\" /etc/*release >/dev/null"; then xdsh f6u13k15 "yum install -y yum-utils bzip2"; fi [Tue Feb 12 03:24:56 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:if grep Ubuntu /etc/*release;then xdsh f6u13k15 "apt-get install -y gpg"; fi [Tue Feb 12 03:24:57 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
/etc/lsb-release:DISTRIB_ID=Ubuntu
/etc/lsb-release:DISTRIB_DESCRIPTION="Ubuntu 18.04.1 LTS"
/etc/os-release:NAME="Ubuntu"
/etc/os-release:PRETTY_NAME="Ubuntu 18.04.1 LTS"
f6u13k15: Reading package lists...
f6u13k15: Building dependency tree...
f6u13k15: Reading state information...
f6u13k15: gpg is already the newest version (2.2.4-1ubuntu1.2).
f6u13k15: The following packages were automatically installed and are no longer required:
f6u13k15:   apache2 apache2-bin apache2-data apache2-utils bind9 bind9utils
f6u13k15:   conserver-xcat dmeventd elilo-xcat goconserver grub2-xcat ipmitool-xcat
f6u13k15:   isc-dhcp-server libapr1 libaprutil1 libaprutil1-dbd-sqlite3 libaprutil1-ldap
f6u13k15:   libavahi-client3 libavahi-common-data libavahi-common3 libblas3
f6u13k15:   libcommon-sense-perl libcrypt-cbc-perl libcrypt-rijndael-perl
f6u13k15:   libdbd-sqlite3-perl libdevmapper-event1.02.1 libexpect-perl
f6u13k15:   libfile-copy-recursive-perl libhttp-async-perl libio-stty-perl
f6u13k15:   libirs-export160 libisccfg-export160 libjson-perl libjson-xs-perl liblinear3
f6u13k15:   liblua5.2-0 liblua5.3-0 liblvm2app2.2 liblvm2cmd2.02 libnet-https-nb-perl
f6u13k15:   libnet-telnet-perl libreadline5 libsensors4 libsnmp-base libsnmp-perl
f6u13k15:   libsnmp30 libsys-virt-perl libtypes-serialiser-perl libvirt0 libyajl2 lvm2
f6u13k15:   nfs-kernel-server nmap python3-ply ssl-cert syslinux-xcat tftp-hpa tftpd-hpa
f6u13k15:   update-inetd xcat-probe xinetd xnba-undi
f6u13k15: Use 'apt autoremove' to remove them.
f6u13k15: 0 upgraded, 0 newly installed, 0 to remove and 78 not upgraded.

RUN:xdsh f6u13k15 "cd /; rm -rf /go-xcat" [Tue Feb 12 03:24:58 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:xdsh f6u13k15 "cd /; scp -r f6u13k13:/opt/xcat/share/xcat/tools/go-xcat ./" [Tue Feb 12 03:24:59 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh f6u13k15 "scp -r f6u13k13:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR(f6u13k15,arch)__.sources.list /etc/apt/sources.list"; fi [Tue Feb 12 03:25:01 2019]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
/etc/lsb-release:DISTRIB_ID=Ubuntu
/etc/lsb-release:DISTRIB_DESCRIPTION="Ubuntu 18.04.1 LTS"
/etc/os-release:NAME="Ubuntu"
/etc/os-release:PRETTY_NAME="Ubuntu 18.04.1 LTS"
[f6u13k13]: f6u13k15: scp: /opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/bionic-ppc64le.sources.list: No such file or directory

RUN:if grep Ubuntu /etc/*release;then xdsh f6u13k15 "scp -r f6u13k13:/etc/hosts /etc/hosts" && xdsh f6u13k15 "scp -r f6u13k13:/etc/resolv.conf /etc/resolv.conf" && xdsh f6u13k15 "wget -O - http://xcat.org/files/xcat/repos/apt/apt.key | apt-key add -"; fi [Tue Feb 12 03:25:02 2019]
ElapsedTime:4 sec
RETURN rc = 0
OUTPUT:
/etc/lsb-release:DISTRIB_ID=Ubuntu
/etc/lsb-release:DISTRIB_DESCRIPTION="Ubuntu 18.04.1 LTS"
/etc/os-release:NAME="Ubuntu"
/etc/os-release:PRETTY_NAME="Ubuntu 18.04.1 LTS"
f6u13k15: OK
[f6u13k13]: f6u13k15: --2019-02-12 03:25:06--  http://xcat.org/files/xcat/repos/apt/apt.key
f6u13k15: Resolving xcat.org (xcat.org)... 166.70.135.166
[f6u13k13]: f6u13k15: Connecting to xcat.org (xcat.org)|166.70.135.166|:80... connected.
[f6u13k13]: f6u13k15: HTTP request sent, awaiting response... 200 OK
f6u13k15: Length: 4786 (4.7K) [application/pgp-keys]
f6u13k15: Saving to: 'STDOUT'
f6u13k15:
[f6u13k13]: f6u13k15:      0K ....                                                  100% 32.2M=0s
f6u13k15:
f6u13k15: 2019-02-12 03:25:06 (32.2 MB/s) - written to stdout [4786/4786]
[f6u13k13]: f6u13k15: Warning: apt-key output should not be parsed (stdout is not a terminal)
CHECK:rc == 0	[Pass]

RUN:if grep Ubuntu /etc/*release;then xdsh f6u13k15 "rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update"; fi [Tue Feb 12 03:25:06 2019]
ElapsedTime:5 sec
RETURN rc = 0
OUTPUT:
/etc/lsb-release:DISTRIB_ID=Ubuntu
/etc/lsb-release:DISTRIB_DESCRIPTION="Ubuntu 18.04.1 LTS"
/etc/os-release:NAME="Ubuntu"
/etc/os-release:PRETTY_NAME="Ubuntu 18.04.1 LTS"
f6u13k15: Get:1 http://ports.ubuntu.com/ubuntu-ports bionic-security InRelease [88.7 kB]
f6u13k15: Get:2 http://ports.ubuntu.com/ubuntu-ports bionic InRelease [242 kB]
f6u13k15: Get:3 http://ports.ubuntu.com/ubuntu-ports bionic-updates InRelease [88.7 kB]
f6u13k15: Get:4 http://ports.ubuntu.com/ubuntu-ports bionic-security/main ppc64el Packages [174 kB]
f6u13k15: Get:5 http://ports.ubuntu.com/ubuntu-ports bionic-security/main Translation-en [93.9 kB]
f6u13k15: Get:6 http://ports.ubuntu.com/ubuntu-ports bionic/universe ppc64el Packages [8260 kB]
f6u13k15: Get:7 http://ports.ubuntu.com/ubuntu-ports bionic/universe Translation-en [4941 kB]
f6u13k15: Get:8 http://ports.ubuntu.com/ubuntu-ports bionic/main ppc64el Packages [974 kB]
f6u13k15: Get:9 http://ports.ubuntu.com/ubuntu-ports bionic/main Translation-en [516 kB]
f6u13k15: Get:10 http://ports.ubuntu.com/ubuntu-ports bionic-updates/main ppc64el Packages [399 kB]
f6u13k15: Get:11 http://ports.ubuntu.com/ubuntu-ports bionic-updates/main Translation-en [186 kB]
f6u13k15: Get:12 http://ports.ubuntu.com/ubuntu-ports bionic-updates/universe ppc64el Packages [594 kB]
f6u13k15: Get:13 http://ports.ubuntu.com/ubuntu-ports bionic-updates/universe Translation-en [179 kB]
f6u13k15: Fetched 16.7 MB in 3s (4930 kB/s)
f6u13k15: Reading package lists...
CHECK:rc == 0	[Pass]

RUN:xdsh f6u13k15 "rm -rf /tmp/go-xcat.log" [Tue Feb 12 03:25:11 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:xdsh f6u13k15 "cd /; ./go-xcat --yes install" [Tue Feb 12 03:25:12 2019]

```