### PR TITLE
update case xcatconfig_c to make it to run on hierarchy environment

### DIFF
--- a/xCAT-test/autotest/testcase/xcatconfig/case0
+++ b/xCAT-test/autotest/testcase/xcatconfig/case0
@@ -121,7 +121,7 @@ cmd:mv -f /etc/xcat/cabak /etc/xcat/ca ;mv -f /etc/xcat/certbak /etc/xcat/cert
 check:rc==0
 cmd:if lsdef service > /dev/null 2>&1; then updatenode service -P servicenode;fi
 check:rc==0
-cmd:if lsdef service > /dev/null 2>&1; then makedhcp -a;fi
+cmd:if lsdef service > /dev/null 2>&1; then xdsh $$CN date;fi
 check:rc==0
 end
 

--- a/xCAT-test/autotest/testcase/xcatconfig/case0
+++ b/xCAT-test/autotest/testcase/xcatconfig/case0
@@ -119,6 +119,10 @@ cmd:rm -rf /tmp/xcatconfig.test
 check:rc==0
 cmd:mv -f /etc/xcat/cabak /etc/xcat/ca ;mv -f /etc/xcat/certbak /etc/xcat/cert
 check:rc==0
+cmd:if lsdef service > /dev/null 2>&1; then updatenode service -P servicenode;fi
+check:rc==0
+cmd:if lsdef service > /dev/null 2>&1; then makedhcp -a;fi
+check:rc==0
 end
 
 start:xcatconfig_s


### PR DESCRIPTION
### The PR is to do task https://github.com/xcat2/xcat2-task-management/issues/566

The UT
```
------START::xcatconfig_c::Time:Wed Feb 13 02:25:34 2019------

RUN:cp -r /etc/xcat/ca /etc/xcat/cabak;cp -r /etc/xcat/cert /etc/xcat/certbak [Wed Feb 13 02:25:34 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:xcatconfig  -c 2>&1 | tee /tmp/xcatconfig.test [Wed Feb 13 02:25:34 2019]
ElapsedTime:5 sec
RETURN rc = 0
OUTPUT:

Setting up basic certificates.  Respond with a 'y' when prompted.

Existing xCAT certificate authority detected at /etc/xcat/ca, delete? (y/n):# NOTE use "-newkey rsa:2048" if running OpenSSL 0.9.8a or higher
Generating RSA private key, 2048 bit long modulus
......................................................................+++
...........+++
e is 65537 (0x10001)
Using configuration from openssl.cnf
Check that the request matches the signature
Signature ok
Certificate Details:
        Serial Number: 1 (0x1)
        Validity
            Not Before: Jan  1 01:01:01 1970 GMT

            Not After : Feb 13 07:25:34 2039 GMT
        Subject:
            commonName                = xCAT CA
        X509v3 extensions:
            X509v3 Subject Key Identifier:
                CA:9B:90:7D:9C:E2:F1:79:FA:C7:AB:93:92:D6:9C:D8:D1:7A:FE:9E
            X509v3 Authority Key Identifier:
                keyid:CA:9B:90:7D:9C:E2:F1:79:FA:C7:AB:93:92:D6:9C:D8:D1:7A:FE:9E
                DirName:/CN=xCAT CA
                serial:01

            X509v3 Basic Constraints:
                CA:TRUE
            X509v3 Key Usage:
                Certificate Sign, CRL Sign
            Netscape Cert Type:
                SSL CA, S/MIME CA
Certificate is to be certified until Feb 13 07:25:34 2039 GMT (7305 days)
Sign the certificate? [y/n]:

1 out of 1 certificate requests certified, commit? [y/n]Write out database with 1 new entries
Data Base Updated
/
Created xCAT certificate.
/etc/xcat/cert already exists, delete and start over (y/n)?Generating RSA private key, 2048 bit long modulus
.....................+++
........................................................+++

# copy_extensions = copy					# copy_extensions = copy

# Extensions to add to a CRL. Note: Netscape communicator cho	# Extensions to add to a CRL. Note: Netscape communicator cho
# so this is commented out by default to leave a V1 CRL.	# so this is commented out by default to leave a V1 CRL.
# crlnumber must also be commented out to leave a V1 CRL.	# crlnumber must also be commented out to leave a V1 CRL.
# crl_extensions	= crl_ext				# crl_extensions	= crl_ext

default_days	= 7300			# how long to certify	default_days	= 7300			# how long to certify
default_crl_days= 30			# how long before nex	default_crl_days= 30			# how long before nex
default_md	= sha1			# which md to use.	default_md	= sha1			# which md to use.
preserve	= no			# keep passed DN orde	preserve	= no			# keep passed DN orde

# A few difference way of specifying how similar the request 	# A few difference way of specifying how similar the request
# For type CA, the listed attributes must be the same, and th	# For type CA, the listed attributes must be the same, and th
# and supplied fields are just that :-)				# and supplied fields are just that :-)
policy		= policy_match					policy		= policy_match

# For the CA policy						# For the CA policy
[ policy_match ]						[ policy_match ]
countryName		= optional				countryName		= optional
stateOrProvinceName	= optional				stateOrProvinceName	= optional
organizationName	= optional				organizationName	= optional
organizationalUnitName	= optional				organizationalUnitName	= optional
commonName		= supplied				commonName		= supplied
emailAddress		= optional				emailAddress		= optional

# For the 'anything' policy					# For the 'anything' policy
# At this point in time, you must list all acceptable 'object	# At this point in time, you must list all acceptable 'object
# types.							# types.
[ policy_anything ]						[ policy_anything ]
countryName		= optional				countryName		= optional
stateOrProvinceName	= optional				stateOrProvinceName	= optional
localityName		= optional				localityName		= optional
organizationName	= optional				organizationName	= optional
organizationalUnitName	= optional				organizationalUnitName	= optional
commonName		= supplied				commonName		= supplied
emailAddress		= optional				emailAddress		= optional

#############################################################	#############################################################
[ req ]								[ req ]
default_bits		= 2048					default_bits		= 2048
default_keyfile 	= private/ca-key.pem			default_keyfile 	= private/ca-key.pem
distinguished_name	= req_distinguished_name		distinguished_name	= req_distinguished_name
attributes		= req_attributes			attributes		= req_attributes
x509_extensions	= v3_ca	# The extentions to add to the self s	x509_extensions	= v3_ca	# The extentions to add to the self s

# Passwords for private keys if not present they will be prom	# Passwords for private keys if not present they will be prom
# input_password = secret					# input_password = secret
# output_password = secret					# output_password = secret

# This sets a mask for permitted string types. There are seve	# This sets a mask for permitted string types. There are seve
# default: PrintableString, T61String, BMPString.		# default: PrintableString, T61String, BMPString.
# pkix	 : PrintableString, BMPString.				# pkix	 : PrintableString, BMPString.
# utf8only: only UTF8Strings.					# utf8only: only UTF8Strings.
# nombstr : PrintableString, T61String (no BMPStrings or UTF8	# nombstr : PrintableString, T61String (no BMPStrings or UTF8
# MASK:XXXX a literal mask value.				# MASK:XXXX a literal mask value.
# WARNING: current versions of Netscape crash on BMPStrings o	# WARNING: current versions of Netscape crash on BMPStrings o
# so use this option with caution!				# so use this option with caution!
string_mask = nombstr						string_mask = nombstr

# req_extensions = v3_req # The extensions to add to a certif	# req_extensions = v3_req # The extensions to add to a certif

[ req_distinguished_name ]					[ req_distinguished_name ]
#countryName			= Country Name (2 letter code	#countryName			= Country Name (2 letter code
#countryName_default		= US				#countryName_default		= US
#countryName_min			= 2			#countryName_min			= 2
#countryName_max			= 2			#countryName_max			= 2

#stateOrProvinceName		= State or Province Name (ful	#stateOrProvinceName		= State or Province Name (ful
#stateOrProvinceName_default	= Some-State			#stateOrProvinceName_default	= Some-State

#localityName			= Locality Name (eg, city)	#localityName			= Locality Name (eg, city)

#0.organizationName		= Organization Name (eg, comp	#0.organizationName		= Organization Name (eg, comp
#0.organizationName_default	= Internet Widgits Pty Ltd	#0.organizationName_default	= Internet Widgits Pty Ltd

# we can do this but it is not needed normally :-)		# we can do this but it is not needed normally :-)
#1.organizationName		= Second Organization Name (e	#1.organizationName		= Second Organization Name (e
#1.organizationName_default	= World Wide Web Pty Ltd	#1.organizationName_default	= World Wide Web Pty Ltd

#organizationalUnitName		= Organizational Unit Name (e	#organizationalUnitName		= Organizational Unit Name (e
#organizationalUnitName_default	=				#organizationalUnitName_default	=

commonName			= Common Name (eg, YOUR name)	commonName			= Common Name (eg, YOUR name)
commonName_max			= 64				commonName_max			= 64

#emailAddress			= Email Address			#emailAddress			= Email Address
#emailAddress_max		= 64				#emailAddress_max		= 64

# SET-ex3			= SET extension number 3	# SET-ex3			= SET extension number 3

[ req_attributes ]						[ req_attributes ]
#challengePassword		= A challenge password		#challengePassword		= A challenge password
#challengePassword_min		= 4				#challengePassword_min		= 4
#challengePassword_max		= 20				#challengePassword_max		= 20

#unstructuredName		= An optional company name	#unstructuredName		= An optional company name

[ server ]							[ server ]
basicConstraints=CA:FALSE					basicConstraints=CA:FALSE
nsCertType			= server, client, objsign	nsCertType			= server, client, objsign
nsComment			= "OpenSSL Generated Server C	nsComment			= "OpenSSL Generated Server C
subjectKeyIdentifier=hash					subjectKeyIdentifier=hash
authorityKeyIdentifier=keyid,issuer				authorityKeyIdentifier=keyid,issuer
keyUsage = digitalSignature,keyAgreement,keyEncipherment	keyUsage = digitalSignature,keyAgreement,keyEncipherment
extendedKeyUsage = serverAuth, clientAuth			extendedKeyUsage = serverAuth, clientAuth

[ usr_cert ]							[ usr_cert ]

# These extensions are added when 'ca' signs a request.		# These extensions are added when 'ca' signs a request.

# This goes against PKIX guidelines but some CAs do it and so	# This goes against PKIX guidelines but some CAs do it and so
# requires this to avoid interpreting an end user certificate	# requires this to avoid interpreting an end user certificate

basicConstraints=CA:FALSE					basicConstraints=CA:FALSE
keyUsage = digitalSignature,keyAgreement,keyEncipherment	keyUsage = digitalSignature,keyAgreement,keyEncipherment
extendedKeyUsage = clientAuth					extendedKeyUsage = clientAuth

# Here are some examples of the usage of nsCertType. If it is	# Here are some examples of the usage of nsCertType. If it is
# the certificate can be used for anything *except* object si	# the certificate can be used for anything *except* object si

# This is OK for an SSL server.					# This is OK for an SSL server.
# nsCertType			= server			# nsCertType			= server

# For an object signing certificate this would be used.		# For an object signing certificate this would be used.
# nsCertType = objsign						# nsCertType = objsign

# For normal client use this is typical				# For normal client use this is typical
# nsCertType = client, email					# nsCertType = client, email

# and for everything including object signing:			# and for everything including object signing:
nsCertType = client, email, objsign				nsCertType = client, email, objsign

# This is typical in keyUsage for a client certificate.		# This is typical in keyUsage for a client certificate.
# keyUsage = nonRepudiation, digitalSignature, keyEnciphermen	# keyUsage = nonRepudiation, digitalSignature, keyEnciphermen

# This will be displayed in Netscape's comment listbox.		# This will be displayed in Netscape's comment listbox.
nsComment			= "OpenSSL Generated Client C	nsComment			= "OpenSSL Generated Client C

# PKIX recommendations harmless if included in all certificat	# PKIX recommendations harmless if included in all certificat
subjectKeyIdentifier=hash					subjectKeyIdentifier=hash
authorityKeyIdentifier=keyid,issuer				authorityKeyIdentifier=keyid,issuer

# This stuff is for subjectAltName and issuerAltname.		# This stuff is for subjectAltName and issuerAltname.
# Import the email address.					# Import the email address.
# subjectAltName=email:copy					# subjectAltName=email:copy
# An alternative to produce certificates that aren't		# An alternative to produce certificates that aren't
# deprecated according to PKIX.					# deprecated according to PKIX.
# subjectAltName=email:move					# subjectAltName=email:move

# Copy subject details						# Copy subject details
# issuerAltName=issuer:copy					# issuerAltName=issuer:copy

#nsCaRevocationUrl		= http://www.domain.dom/ca-cr	#nsCaRevocationUrl		= http://www.domain.dom/ca-cr
#nsBaseUrl							#nsBaseUrl
#nsRevocationUrl						#nsRevocationUrl
#nsRenewalUrl							#nsRenewalUrl
#nsCaPolicyUrl							#nsCaPolicyUrl
#nsSslServerName						#nsSslServerName

[ v3_req ]							[ v3_req ]

# Extensions to add to a certificate request			# Extensions to add to a certificate request

basicConstraints = CA:FALSE					basicConstraints = CA:FALSE
keyUsage = nonRepudiation, digitalSignature, keyEncipherment	keyUsage = nonRepudiation, digitalSignature, keyEncipherment

[ san_env ]							[ san_env ]
subjectAltName = @alt_names					subjectAltName = @alt_names

[ alt_names ]							[ alt_names ]
DNS.1 = c910f02c02p16						DNS.1 = c910f02c02p16
DNS.2 = c910f02c02p16						DNS.2 = c910f02c02p16

[ v3_ca ]							[ v3_ca ]


# Extensions for a typical CA					# Extensions for a typical CA


# PKIX recommendation.						# PKIX recommendation.

subjectKeyIdentifier=hash					subjectKeyIdentifier=hash

authorityKeyIdentifier=keyid:always,issuer:always		authorityKeyIdentifier=keyid:always,issuer:always

# This is what PKIX recommends but some broken software choke	# This is what PKIX recommends but some broken software choke
# extensions.							# extensions.
#basicConstraints = critical,CA:true				#basicConstraints = critical,CA:true
# So we do this instead.					# So we do this instead.
basicConstraints = CA:true					basicConstraints = CA:true

# Key usage: this is typical for a CA certificate. However si	# Key usage: this is typical for a CA certificate. However si
# prevent it being used as an test self-signed certificate it	# prevent it being used as an test self-signed certificate it
# left out by default.						# left out by default.
keyUsage = cRLSign, keyCertSign					keyUsage = cRLSign, keyCertSign

# Some might want this also					# Some might want this also
nsCertType = sslCA, emailCA					nsCertType = sslCA, emailCA

# Include email address in subject alt name: another PKIX rec	# Include email address in subject alt name: another PKIX rec
# subjectAltName=email:copy					# subjectAltName=email:copy
# Copy issuer details						# Copy issuer details
# issuerAltName=issuer:copy					# issuerAltName=issuer:copy

# DER hex encoding of an extension: beware experts only!	# DER hex encoding of an extension: beware experts only!
# obj=DER:02:03							# obj=DER:02:03
# Where 'obj' is a standard or added object			# Where 'obj' is a standard or added object
# You can even override a supported extension:			# You can even override a supported extension:
# basicConstraints= critical, DER:30:03:01:01:FF		# basicConstraints= critical, DER:30:03:01:01:FF

[ crl_ext ]							[ crl_ext ]

# CRL extensions.						# CRL extensions.
# Only issuerAltName and authorityKeyIdentifier make any sens	# Only issuerAltName and authorityKeyIdentifier make any sens

# issuerAltName=issuer:copy					# issuerAltName=issuer:copy
authorityKeyIdentifier=keyid:always,issuer:always		authorityKeyIdentifier=keyid:always,issuer:always

[ proxy_cert_ext ]						[ proxy_cert_ext ]
# These extensions should be added when creating a proxy cert	# These extensions should be added when creating a proxy cert

# This goes against PKIX guidelines but some CAs do it and so	# This goes against PKIX guidelines but some CAs do it and so
# requires this to avoid interpreting an end user certificate	# requires this to avoid interpreting an end user certificate

basicConstraints=CA:FALSE					basicConstraints=CA:FALSE

# Here are some examples of the usage of nsCertType. If it is	# Here are some examples of the usage of nsCertType. If it is
# the certificate can be used for anything *except* object si	# the certificate can be used for anything *except* object si

# This is OK for an SSL server.					# This is OK for an SSL server.
# nsCertType			= server			# nsCertType			= server

# For an object signing certificate this would be used.		# For an object signing certificate this would be used.
# nsCertType = objsign						# nsCertType = objsign

# For normal client use this is typical				# For normal client use this is typical
# nsCertType = client, email					# nsCertType = client, email

# and for everything including object signing:			# and for everything including object signing:
# nsCertType = client, email, objsign				# nsCertType = client, email, objsign

# This is typical in keyUsage for a client certificate.		# This is typical in keyUsage for a client certificate.
# keyUsage = nonRepudiation, digitalSignature, keyEnciphermen	# keyUsage = nonRepudiation, digitalSignature, keyEnciphermen

# This will be displayed in Netscape's comment listbox.		# This will be displayed in Netscape's comment listbox.
nsComment			= "OpenSSL Generated Certific	nsComment			= "OpenSSL Generated Certific

# PKIX recommendations harmless if included in all certificat	# PKIX recommendations harmless if included in all certificat
subjectKeyIdentifier=hash					subjectKeyIdentifier=hash
authorityKeyIdentifier=keyid,issuer:always			authorityKeyIdentifier=keyid,issuer:always

# This stuff is for subjectAltName and issuerAltname.		# This stuff is for subjectAltName and issuerAltname.
# Import the email address.					# Import the email address.
# subjectAltName=email:copy					# subjectAltName=email:copy
# An alternative to produce certificates that aren't		# An alternative to produce certificates that aren't
# deprecated according to PKIX.					# deprecated according to PKIX.
# subjectAltName=email:move					# subjectAltName=email:move

# Copy subject details						# Copy subject details
# issuerAltName=issuer:copy					# issuerAltName=issuer:copy

#nsCaRevocationUrl		= http://www.domain.dom/ca-cr	#nsCaRevocationUrl		= http://www.domain.dom/ca-cr
#nsBaseUrl							#nsBaseUrl
#nsRevocationUrl						#nsRevocationUrl
#nsRenewalUrl							#nsRenewalUrl
#nsCaPolicyUrl							#nsCaPolicyUrl
#nsSslServerName						#nsSslServerName

# This really needs to be in place for it to be a proxy certi	# This really needs to be in place for it to be a proxy certi
proxyCertInfo=critical,language:id-ppl-anyLanguage,pathlen:3,	proxyCertInfo=critical,language:id-ppl-anyLanguage,pathlen:3,
Common subdirectories: /etc/xcat/ca/private and /etc/xcat/cabak/private
diff -y /etc/xcat/ca/root.cert /etc/xcat/cabak/root.cert
Certificate:							Certificate:
    Data:							    Data:
        Version: 3 (0x2)					        Version: 3 (0x2)
        Serial Number: 4 (0x4)					        Serial Number: 4 (0x4)
    Signature Algorithm: sha1WithRSAEncryption			    Signature Algorithm: sha1WithRSAEncryption
        Issuer: CN=xCAT CA					        Issuer: CN=xCAT CA
        Validity						        Validity
            Not Before: Jan  1 01:01:01 1960 GMT		            Not Before: Jan  1 01:01:01 1960 GMT
            Not After : Feb  8 07:25:36 2039 GMT	      |	            Not After : Feb  8 07:17:38 2039 GMT
        Subject: CN=conserver					        Subject: CN=conserver
        Subject Public Key Info:				        Subject Public Key Info:
            Public Key Algorithm: rsaEncryption			            Public Key Algorithm: rsaEncryption
                Public-Key: (2048 bit)				                Public-Key: (2048 bit)
                Modulus:					                Modulus:
                    00:be:69:8a:28:ce:a1:93:0e:00:1a:a5:b8:bb |	                    00:d7:74:be:68:2a:2e:b1:5f:84:71:7e:0b:14
                    1b:5a:d7:67:0b:7b:ba:55:db:cf:b4:25:ab:57 |	                    dc:3f:dc:12:43:0d:e5:c1:e6:37:43:78:bb:d3
                    e7:98:e0:6f:04:e6:fa:ae:37:5f:eb:dd:80:2f |	                    5e:e2:8d:3c:3e:d1:3e:4f:ef:8d:92:8f:3d:a0
                    06:be:2f:36:a2:18:99:6e:6d:ba:62:68:32:cf |	                    ba:55:c8:ad:44:0d:5a:2c:60:f2:98:04:b8:32
                    de:86:3e:94:cb:c0:c3:57:9c:aa:8d:1d:b1:90 |	                    9c:fe:64:61:1f:4d:55:18:a8:60:43:1e:29:29
                    73:b1:ba:75:9c:fa:28:86:a7:2e:73:be:88:a0 |	                    e5:b1:c0:e4:56:0f:0b:e4:33:d1:52:6d:6e:50
                    f7:a2:0b:ff:a7:10:02:06:f2:b7:70:ec:01:67 |	                    9d:54:37:d7:78:ed:3d:33:0c:6d:36:29:ed:76
                    2b:66:74:d9:61:e4:a1:4b:70:42:67:76:7b:64 |	                    82:2c:33:7f:4a:40:1c:35:1d:cb:07:1b:2e:a8
                    56:26:35:19:e2:1b:b9:d6:3e:52:69:a7:47:51 |	                    06:dd:26:ba:45:8a:26:07:fd:0d:9e:24:e6:83
                    e9:eb:5a:7f:86:3a:a6:22:b3:ca:dd:a3:ce:b5 |	                    43:a5:7f:63:95:39:1e:d0:48:ef:75:65:14:5b
                    cf:01:e1:3b:5d:a8:a2:1c:61:18:10:99:2f:a5 |	                    d3:16:83:38:e3:d0:c7:fa:10:b6:b8:d4:01:57
                    32:0d:89:8a:43:ff:07:83:a1:d4:34:8f:e5:f9 |	                    11:45:d7:78:0f:e3:18:22:a1:de:af:b8:ad:df
                    2f:39:1b:e0:07:0e:91:26:b9:fd:10:f8:d5:eb |	                    42:82:7b:1f:57:35:b0:d8:fa:de:34:2b:7a:ee
                    ce:41:d1:28:1b:52:de:2b:54:59:a1:70:eb:55 |	                    1d:63:55:aa:56:fe:bb:f6:99:51:d0:da:f5:35
                    79:43:e7:64:27:66:56:7d:ff:6e:92:30:ab:1b |	                    ef:38:62:52:26:ac:3d:ac:e0:54:74:70:7f:f6
                    f7:50:c5:54:8b:65:43:03:15:8b:63:be:83:30 |	                    97:1c:bb:48:1a:cc:89:d1:b3:e7:d6:ed:f2:00
                    dc:5a:33:0a:71:77:d8:15:65:89:c5:02:1f:83 |	                    60:b7:45:00:53:e5:23:a9:63:91:3f:6b:0f:8f
                    1f:6d				      |	                    b0:8b
                Exponent: 65537 (0x10001)			                Exponent: 65537 (0x10001)
        X509v3 extensions:					        X509v3 extensions:
            X509v3 Basic Constraints: 				            X509v3 Basic Constraints:
                CA:FALSE					                CA:FALSE
            X509v3 Key Usage: 					            X509v3 Key Usage:
                Digital Signature, Key Encipherment, Key Agre	                Digital Signature, Key Encipherment, Key Agre
            X509v3 Extended Key Usage: 				            X509v3 Extended Key Usage:
                TLS Web Client Authentication			                TLS Web Client Authentication
            Netscape Cert Type: 				            Netscape Cert Type:
                SSL Client, S/MIME, Object Signing		                SSL Client, S/MIME, Object Signing
            Netscape Comment: 					            Netscape Comment:
                OpenSSL Generated Client Certificate		                OpenSSL Generated Client Certificate
            X509v3 Subject Key Identifier: 			            X509v3 Subject Key Identifier:
                1F:2E:49:8F:4F:4E:96:B5:8F:E9:C4:E3:63:D3:EC: |	                13:FD:1B:01:CC:DB:53:A1:4A:CF:3B:24:EC:7B:4B:
            X509v3 Authority Key Identifier: 			            X509v3 Authority Key Identifier:
                keyid:CA:9B:90:7D:9C:E2:F1:79:FA:C7:AB:93:92: |	                keyid:53:F9:4E:12:2F:DB:70:15:96:87:E0:08:2D:

    Signature Algorithm: sha1WithRSAEncryption			    Signature Algorithm: sha1WithRSAEncryption
         00:be:38:92:58:00:08:a0:68:84:f1:de:e3:b4:7b:1a:5c:7 |	         52:f9:be:bf:44:be:ba:23:cd:48:e8:f6:0d:f6:77:e5:38:a
         ce:a1:13:3f:ef:4b:41:fb:50:95:98:41:2d:e4:4f:92:82:3 |	         3c:62:86:e1:77:f8:d3:75:23:ee:30:62:49:4e:80:20:8c:1
         a4:77:e8:a4:08:ef:82:7d:eb:c3:7e:b2:00:39:11:db:f1:8 |	         c3:dd:0f:3d:37:0a:4a:fe:29:8b:8b:1b:3c:8b:06:39:a2:3
         c3:23:6b:48:4f:56:3a:b4:81:a8:97:37:ff:3b:25:2a:00:6 |	         3d:56:b4:eb:6b:f2:54:03:d7:71:8b:5c:e4:b3:9e:7f:4c:c
         e6:b2:c3:58:bb:d9:c1:9e:52:31:d3:62:34:08:77:ae:84:2 |	         fa:d9:b2:22:d1:44:bb:ab:fe:83:01:de:ab:30:6e:c0:02:6
         f2:5e:24:64:3e:25:c4:18:2a:ce:9a:9a:9c:2e:25:87:6e:4 |	         e9:1b:03:5f:62:61:d6:30:67:74:1b:e1:8a:76:fc:d5:22:b
         e2:3d:18:56:ac:54:ee:5f:1c:3b:79:e2:af:70:7b:11:55:9 |	         8c:8f:6e:70:34:45:93:6c:72:5a:49:00:d5:5c:fd:03:16:a
         af:4a:f8:7e:16:5e:25:3a:bb:e0:7a:a8:67:c6:7e:bc:7a:2 |	         91:6b:e9:60:29:e1:a8:ad:02:4a:01:fd:ad:65:ad:0a:67:8
         b7:68:f3:25:05:c0:0c:0f:4c:35:07:ac:d9:33:da:93:94:2 |	         e2:e8:0f:2e:8c:ff:65:ce:81:4f:ac:0a:78:79:b4:70:d0:9
         a5:30:33:fe:ce:40:1c:a9:4d:d7:05:5c:f3:4c:c5:c3:bc:1 |	         ea:0b:0e:ca:ff:a6:91:46:24:23:ab:e4:be:c6:11:cc:8f:8
         80:51:f6:33:c7:28:1e:d1:54:8e:b3:3c:23:fa:dc:3f:6f:1 |	         8f:ea:b6:f6:80:8b:95:5f:ac:1f:d6:c9:d3:35:aa:f0:2d:e
         f3:5e:f8:22:23:55:71:95:a0:e6:46:ed:79:89:60:ce:c1:d |	         9e:74:e4:4f:c5:ad:0c:c9:0d:5e:8f:28:de:8f:ab:e8:c4:7
         b5:6f:4e:02:f5:d3:1c:25:f0:87:56:34:37:48:de:22:7b:5 |	         ac:15:41:91:ae:14:78:e8:63:06:8c:29:e1:56:fa:b4:50:5
         7f:98:41:09:48:24:ab:00:ed:02:65:10:a7:00:4b:34:3f:8 |	         ac:b6:bd:7d:1a:28:e3:a6:aa:d7:06:b9:d7:19:ca:10:23:b
         ba:0b:79:85					      |	         43:6b:16:2c
-----BEGIN CERTIFICATE-----					-----BEGIN CERTIFICATE-----
MIIDWjCCAkKgAwIBAgIBBDANBgkqhkiG9w0BAQUFADASMRAwDgYDVQQDEwd4Q	MIIDWjCCAkKgAwIBAgIBBDANBgkqhkiG9w0BAQUFADASMRAwDgYDVQQDEwd4Q
IENBMB4XDTYwMDEwMTAxMDEwMVoXDTM5MDIwODA3MjUzNlowFDESMBAGA1UEA |	IENBMB4XDTYwMDEwMTAxMDEwMVoXDTM5MDIwODA3MTczOFowFDESMBAGA1UEA
Y29uc2VydmVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvmmKK |	Y29uc2VydmVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA13S+a
kw4AGqW4u5YbWtdnC3u6VdvPtCWrVyHnmOBvBOb6rjdf692AL/gGvi82ohiZb |	sV+EcX4LFGfcP9wSQw3lweY3Q3i70wde4o08PtE+T++Nko89oOa6VcitRA1aL
YmgyzzPehj6Uy8DDV5yqjR2xkHVzsbp1nPoohqcuc76IoPL3ogv/pxACBvK3c |	mAS4MiGc/mRhH01VGKhgQx4pKRflscDkVg8L5DPRUm1uUOedVDfXeO09MwxtN
ZxErZnTZYeShS3BCZ3Z7ZKJWJjUZ4hu51j5SaadHUTfp61p/hjqmIrPK3aPOt |	dmKCLDN/SkAcNR3LBxsuqOoG3Sa6RYomB/0NniTmg45DpX9jlTke0EjvdWUUW
AeE7XaiiHGEYEJkvpbEyDYmKQ/8Hg6HUNI/l+XEvORvgBw6RJrn9EPjV6+POQ |	FoM449DH+hC2uNQBV2QRRdd4D+MYIqHer7it33pCgnsfVzWw2PreNCt67gIdY
G1LeK1RZoXDrVal5Q+dkJ2ZWff9ukjCrGzX3UMVUi2VDAxWLY76DMBDcWjMKc |	Vv679plR0Nr1NbHvOGJSJqw9rOBUdHB/9tqXHLtIGsyJ0bPn1u3yAM1gt0UAU
FWWJxQIfg5cfbQIDAQABo4G4MIG1MAkGA1UdEwQCMAAwCwYDVR0PBAQDAgOoM |	qWORP2sPj9ywiwIDAQABo4G4MIG1MAkGA1UdEwQCMAAwCwYDVR0PBAQDAgOoM
A1UdJQQMMAoGCCsGAQUFBwMCMBEGCWCGSAGG+EIBAQQEAwIEsDAzBglghkgBh	A1UdJQQMMAoGCCsGAQUFBwMCMBEGCWCGSAGG+EIBAQQEAwIEsDAzBglghkgBh
AQ0EJhYkT3BlblNTTCBHZW5lcmF0ZWQgQ2xpZW50IENlcnRpZmljYXRlMB0GA	AQ0EJhYkT3BlblNTTCBHZW5lcmF0ZWQgQ2xpZW50IENlcnRpZmljYXRlMB0GA
DgQWBBQfLkmPT06WtY/pxONj0+z6TfCLFDAfBgNVHSMEGDAWgBTKm5B9nOLxe |	DgQWBBQT/RsBzNtToUrPOyTse0vOnYl4/DAfBgNVHSMEGDAWgBRT+U4SL9twF
q5OS1pzY0Xr+njANBgkqhkiG9w0BAQUFAAOCAQEAAL44klgACKBohPHe47R7G |	4AgtS7gGaQeYNzANBgkqhkiG9w0BAQUFAAOCAQEAUvm+v0S+uiPNSOj2DfZ35
zqETP+9LQftQlZhBLeRPkoI1pHfopAjvgn3rw36yADkR2/GDwyNrSE9WOrSBq |	PGKG4Xf403Uj7jBiSU6AIIwbw90PPTcKSv4pi4sbPIsGOaI8PVa062vyVAPXc
/zslKgBk5rLDWLvZwZ5SMdNiNAh3roQq8l4kZD4lxBgqzpqanC4lh25N4j0YV |	5LOef0zO+tmyItFEu6v+gwHeqzBuwAJv6RsDX2Jh1jBndBvhinb81SK9jI9uc
7l8cO3nir3B7EVWSr0r4fhZeJTq74HqoZ8Z+vHout2jzJQXADA9MNQes2TPak |	k2xyWkkA1Vz9AxatkWvpYCnhqK0CSgH9rWWtCmeA4ugPLoz/Zc6BT6wKeHm0c
pTAz/s5AHKlN1wVc80zFw7wRgFH2M8coHtFUjrM8I/rcP28Q8174IiNVcZWg5 |	6gsOyv+mkUYkI6vkvsYRzI+Oj+q29oCLlV+sH9bJ0zWq8C3gnnTkT8WtDMkNX
eYlgzsHStW9OAvXTHCXwh1Y0N0jeIntYf5hBCUgkqwDtAmUQpwBLND+Fugt5h |	3o+r6MRyrBVBka4UeOhjBowp4Vb6tFBfrLa9fRoo46aq1wa51xnKECO8Q2sWL
-----END CERTIFICATE-----					-----END CERTIFICATE-----
diff -y /etc/xcat/ca/serial /etc/xcat/cabak/serial
05								05
diff -y /etc/xcat/ca/serial.old /etc/xcat/cabak/serial.old
04								04
CHECK:rc != 0	[Pass]

RUN:diff -y /etc/xcat/cert /etc/xcat/certbak [Wed Feb 13 02:25:39 2019]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
diff -y /etc/xcat/cert/ca.pem /etc/xcat/certbak/ca.pem
Certificate:							Certificate:
    Data:							    Data:
        Version: 3 (0x2)					        Version: 3 (0x2)
        Serial Number: 1 (0x1)					        Serial Number: 1 (0x1)
    Signature Algorithm: sha1WithRSAEncryption			    Signature Algorithm: sha1WithRSAEncryption
        Issuer: CN=xCAT CA					        Issuer: CN=xCAT CA
        Validity						        Validity
            Not Before: Jan  1 01:01:01 1970 GMT		            Not Before: Jan  1 01:01:01 1970 GMT
            Not After : Feb 13 07:25:34 2039 GMT	      |	            Not After : Feb 13 07:17:36 2039 GMT
        Subject: CN=xCAT CA					        Subject: CN=xCAT CA
        Subject Public Key Info:				        Subject Public Key Info:
            Public Key Algorithm: rsaEncryption			            Public Key Algorithm: rsaEncryption
                Public-Key: (2048 bit)				                Public-Key: (2048 bit)
                Modulus:					                Modulus:
                    00:da:6e:7a:c1:39:f4:b3:78:77:cd:37:be:95 |	                    00:d3:2e:ed:f9:cd:35:16:bb:55:9d:12:4c:b7
                    9f:43:99:c8:4e:72:bc:e5:0c:c7:19:2c:bf:1e |	                    ed:9f:d9:5c:c4:76:57:3b:e5:66:5c:0a:d2:bd
                    ca:9d:fa:81:b7:03:87:2d:a0:07:54:20:7d:0b |	                    e3:22:95:12:a6:42:8a:be:71:f0:c8:7f:9c:d5
                    b5:fe:c9:0e:b7:82:d8:00:e1:e1:ff:c2:b0:ba |	                    be:e4:56:47:63:74:5b:8e:95:3c:cb:d8:69:e3
                    42:ae:ad:34:ec:ea:10:4b:b1:87:9e:57:e7:bf |	                    c6:31:78:71:74:ac:42:c2:04:23:a2:41:46:f0
                    02:e2:f4:00:3e:2a:5b:78:0c:61:cc:2b:22:08 |	                    03:46:cf:5b:4a:4b:ed:1a:4c:ee:29:42:48:64
                    b7:ed:d6:b8:82:7f:1a:a5:87:68:52:ba:6c:ca |	                    ce:ba:1d:8a:f2:c4:8c:00:14:5e:34:32:e0:19
                    ea:b8:5b:34:a9:bc:66:bc:73:2a:86:48:c5:e3 |	                    37:fe:98:9c:57:ce:79:b0:db:dd:67:3d:31:8f
                    8d:86:2d:92:c1:cd:ea:71:d8:04:1c:8a:95:57 |	                    79:52:c6:5a:ac:fe:4c:19:70:69:5f:59:16:4a
                    26:a1:cc:ac:5d:f1:94:53:a5:2d:41:97:ef:7f |	                    f6:a9:28:d6:2b:d8:98:02:9a:2c:ea:51:13:a3
                    7f:c3:0a:ac:22:55:14:8b:67:93:b7:0a:0b:98 |	                    76:17:80:52:78:ce:7c:8f:a5:bd:47:26:17:c5
                    7c:18:e6:c2:60:60:ba:ae:94:9e:98:47:eb:e1 |	                    c1:c1:3a:d1:2a:b6:c0:d0:f2:01:67:27:7b:3c
                    aa:ca:3f:7c:17:62:4c:b6:55:fd:03:31:7d:94 |	                    01:ff:0f:37:03:16:5d:25:23:5a:87:4f:1c:a4
                    04:39:d2:f7:66:b6:7b:03:e5:b0:54:44:36:0a |	                    73:3f:b6:01:b1:12:35:3f:16:27:6c:6d:05:b4
                    8e:8e:39:43:7a:08:60:78:62:9d:bb:de:e6:d3 |	                    46:6f:81:79:2c:7f:6b:41:3e:b2:d2:2f:75:82
                    e5:6c:cb:81:78:26:fb:2e:04:86:b2:a1:cc:e0 |	                    6a:87:7c:be:cf:48:8c:ca:e5:38:7b:5d:99:dd
                    77:f7:98:a8:d3:88:9a:30:64:7c:1e:86:81:fc |	                    23:14:19:5a:3a:67:e8:b1:eb:2b:ad:5b:8e:e1
                    1f:21				      |	                    d5:69
                Exponent: 65537 (0x10001)			                Exponent: 65537 (0x10001)
        X509v3 extensions:					        X509v3 extensions:
            X509v3 Subject Key Identifier: 			            X509v3 Subject Key Identifier:
                CA:9B:90:7D:9C:E2:F1:79:FA:C7:AB:93:92:D6:9C: |	                53:F9:4E:12:2F:DB:70:15:96:87:E0:08:2D:4B:B8:
            X509v3 Authority Key Identifier: 			            X509v3 Authority Key Identifier:
                keyid:CA:9B:90:7D:9C:E2:F1:79:FA:C7:AB:93:92: |	                keyid:53:F9:4E:12:2F:DB:70:15:96:87:E0:08:2D:
                DirName:/CN=xCAT CA				                DirName:/CN=xCAT CA
                serial:01					                serial:01

            X509v3 Basic Constraints: 				            X509v3 Basic Constraints:
                CA:TRUE						                CA:TRUE
            X509v3 Key Usage: 					            X509v3 Key Usage:
                Certificate Sign, CRL Sign			                Certificate Sign, CRL Sign
            Netscape Cert Type: 				            Netscape Cert Type:
                SSL CA, S/MIME CA				                SSL CA, S/MIME CA
    Signature Algorithm: sha1WithRSAEncryption			    Signature Algorithm: sha1WithRSAEncryption
         1b:23:0f:d3:71:39:bd:13:61:5b:41:9c:26:37:f7:d1:6c:1 |	         7c:37:50:0b:1e:21:90:10:b4:0a:12:b2:fd:5e:51:00:86:1
         fd:2a:fe:57:b1:8b:b7:12:34:35:a7:a5:86:ae:19:83:22:7 |	         12:69:3a:44:cf:52:6f:2a:a8:4a:ad:7a:35:ca:41:35:33:f
         b9:07:05:9a:a1:9a:4c:3b:28:69:cd:61:8f:ad:e6:f4:7e:e |	         24:71:68:20:26:f3:04:f4:b0:a1:81:78:31:f7:84:2d:78:2
         da:cb:7c:63:54:d9:6d:ed:69:2c:ee:48:d8:ee:9f:fa:9c:d |	         37:d8:fe:b5:06:c9:e4:5d:60:cb:8c:07:24:6d:44:30:ea:a
         9f:38:d2:f3:78:b7:88:94:b6:68:c2:ff:b9:a2:e1:05:c3:8 |	         04:66:93:9f:e9:f8:df:6d:4f:61:1c:da:18:d5:36:99:a5:8
         f4:0a:dd:df:02:d4:56:70:85:3c:74:ba:50:26:22:fb:1d:4 |	         75:e4:8b:5c:1b:ab:2e:ac:b6:2c:93:f2:31:d7:98:2c:29:7
         dd:27:96:ce:03:52:d6:4f:b6:34:8b:9f:80:89:27:da:89:b |	         1e:10:ff:6e:1e:a7:46:bc:05:17:1c:4a:0c:fa:9d:14:cd:3
         62:33:f3:be:80:8c:40:e1:c4:07:67:3c:2c:7c:09:f9:2f:5 |	         5e:0c:93:55:d6:97:1c:e8:10:7a:b7:37:3e:dc:2a:2c:65:c
         a9:52:a8:8f:d8:bf:8c:ff:20:00:9a:76:3e:ba:a2:9f:41:b |	         4d:e1:77:de:64:bb:27:db:77:0e:a0:23:7b:70:19:2e:48:b
         3e:6e:35:55:fd:09:dd:df:48:49:75:be:23:b7:37:04:ac:c |	         03:c3:c9:59:6b:d3:fd:15:b1:0f:63:b3:8d:de:4f:ca:9c:0
         13:73:40:f4:ba:45:cc:b6:28:92:cf:38:ef:b7:50:29:37:f |	         b7:48:93:05:3a:4f:27:4c:36:66:be:70:08:0e:8e:e5:71:b
         1c:f7:58:57:60:b2:99:6c:e4:42:66:cf:fe:30:7f:59:75:d |	         99:cb:2f:18:cc:7d:71:1b:ef:c5:b0:1e:e3:ec:c6:75:fc:9
         52:8c:4f:40:a5:dd:15:30:d0:22:e8:68:be:cb:d8:57:7b:e |	         e2:15:c7:38:f7:5f:bd:cb:61:1e:72:c8:65:0b:f8:a2:35:7
         04:5f:a5:74:57:24:47:dd:75:6f:3d:39:35:d8:88:29:54:4 |	         2c:60:eb:8e:6a:90:bc:ba:b4:ea:f3:13:7f:b4:4d:6a:84:b
         e0:22:0d:e3					      |	         16:a9:6f:5a
-----BEGIN CERTIFICATE-----					-----BEGIN CERTIFICATE-----
MIIDLDCCAhSgAwIBAgIBATANBgkqhkiG9w0BAQUFADASMRAwDgYDVQQDEwd4Q	MIIDLDCCAhSgAwIBAgIBATANBgkqhkiG9w0BAQUFADASMRAwDgYDVQQDEwd4Q
IENBMB4XDTcwMDEwMTAxMDEwMVoXDTM5MDIxMzA3MjUzNFowEjEQMA4GA1UEA |	IENBMB4XDTcwMDEwMTAxMDEwMVoXDTM5MDIxMzA3MTczNlowEjEQMA4GA1UEA
eENBVCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANpuesE59 |	eENBVCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANMu7fnNN
d803vpWEn0OZyE5yvOUMxxksvx7+yp36gbcDhy2gB1QgfQtBtf7JDreC2ADh4 |	VZ0STLfp7Z/ZXMR2VzvlZlwK0r1Y4yKVEqZCir5x8Mh/nNW7vuRWR2N0W46VP
sLrRQq6tNOzqEEuxh55X57+sAuL0AD4qW3gMYcwrIgiKt+3WuIJ/GqWHaFK6b |	aeOSxjF4cXSsQsIEI6JBRvCWA0bPW0pL7RpM7ilCSGQ2zrodivLEjAAUXjQy4
6rhbNKm8ZrxzKoZIxePBjYYtksHN6nHYBByKlVfcJqHMrF3xlFOlLUGX738ef |	N/6YnFfOebDb3Wc9MY/oeVLGWqz+TBlwaV9ZFkq29qko1ivYmAKaLOpRE6Mbd
rCJVFItnk7cKC5i3fBjmwmBguq6UnphH6+Hgqso/fBdiTLZV/QMxfZTlBDnS9 |	UnjOfI+lvUcmF8UewcE60Sq2wNDyAWcnezxuAf8PNwMWXSUjWodPHKT8cz+2A
ewPlsFRENgr7jo45Q3oIYHhinbve5tPf5WzLgXgm+y4EhrKhzOAmd/eYqNOIm |	NT8WJ2xtBbSKRm+BeSx/a0E+stIvdYLsaod8vs9IjMrlOHtdmd3LIxQZWjpn6
fB6GgfwQHyECAwEAAaOBjDCBiTAdBgNVHQ4EFgQUypuQfZzi8Xn6x6uTktac2 |	K61bjuHp1WkCAwEAAaOBjDCBiTAdBgNVHQ4EFgQUU/lOEi/bcBWWh+AILUu4B
/p4wOgYDVR0jBDMwMYAUypuQfZzi8Xn6x6uTktac2NF6/p6hFqQUMBIxEDAOB |	mDcwOgYDVR0jBDMwMYAUU/lOEi/bcBWWh+AILUu4BmkHmDehFqQUMBIxEDAOB
BAMTB3hDQVQgQ0GCAQEwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMCAQYwEQYJY	BAMTB3hDQVQgQ0GCAQEwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMCAQYwEQYJY
AYb4QgEBBAQDAgEGMA0GCSqGSIb3DQEBBQUAA4IBAQAbIw/TcTm9E2FbQZwmN |	AYb4QgEBBAQDAgEGMA0GCSqGSIb3DQEBBQUAA4IBAQB8N1ALHiGQELQKErL9X
bBf9Kv5XsYu3EjQ1p6WGrhmDInG5BwWaoZpMOyhpzWGPreb0funay3xjVNlt7 |	hhoSaTpEz1JvKqhKrXo1ykE1M/UkcWggJvME9LChgXgx94QteCA32P61BsnkX
7kjY7p/6nNSfONLzeLeIlLZowv+5ouEFw4P0Ct3fAtRWcIU8dLpQJiL7HU/dJ |	jAckbUQw6qYEZpOf6fjfbU9hHNoY1TaZpY115ItcG6surLYsk/Ix15gsKXQeE
A1LWT7Y0i5+AiSfaibdiM/O+gIxA4cQHZzwsfAn5L1+pUqiP2L+M/yAAmnY+u |	HqdGvAUXHEoM+p0UzTZeDJNV1pcc6BB6tzc+3CosZcRN4XfeZLsn23cOoCN7c
Qbg+bjVV/Qnd30hJdb4jtzcErMITc0D0ukXMtiiSzzjvt1ApN/Mc91hXYLKZb |	SL0Dw8lZa9P9FbEPY7ON3k/KnA63SJMFOk8nTDZmvnAIDo7lcbiZyy8YzH1xG
Zs/+MH9Zdd1SjE9Apd0VMNAi6Gi+y9hXe+gEX6V0VyRH3XVvPTk12IgpVEvgI |	sB7j7MZ1/JriFcc491+9y2EecshlC/iiNXksYOuOapC8urTq8xN/tE1qhL0Wq
-----END CERTIFICATE-----					-----END CERTIFICATE-----
Only in /etc/xcat/certbak: certbak
diff -y /etc/xcat/cert/server-cert.pem /etc/xcat/certbak/server-cert.pem
Certificate:							Certificate:
    Data:							    Data:
        Version: 3 (0x2)					        Version: 3 (0x2)
        Serial Number: 2 (0x2)					        Serial Number: 2 (0x2)
    Signature Algorithm: sha1WithRSAEncryption			    Signature Algorithm: sha1WithRSAEncryption
        Issuer: CN=xCAT CA					        Issuer: CN=xCAT CA
        Validity						        Validity
            Not Before: Jan  1 01:01:01 1960 GMT		            Not Before: Jan  1 01:01:01 1960 GMT
            Not After : Feb  8 07:25:34 2039 GMT	      |	            Not After : Feb  8 07:17:37 2039 GMT
        Subject: CN=c910f02c02p16				        Subject: CN=c910f02c02p16
        Subject Public Key Info:				        Subject Public Key Info:
            Public Key Algorithm: rsaEncryption			            Public Key Algorithm: rsaEncryption
                Public-Key: (2048 bit)				                Public-Key: (2048 bit)
                Modulus:					                Modulus:
                    00:97:df:e4:33:4b:be:2e:b5:1c:b9:46:9e:ef |	                    00:a2:ad:e6:21:64:5c:14:4e:a8:41:93:f4:2b
                    1a:85:b8:4f:98:2c:b4:46:1e:a3:d7:3c:7b:05 |	                    f1:a6:bd:fa:6b:57:90:90:2e:e4:9a:11:c0:5c
                    48:00:70:94:5f:93:21:f3:b0:d0:9f:30:ef:87 |	                    50:bc:34:98:54:d8:04:97:5c:08:22:7c:de:01
                    3d:0b:a6:d1:3b:39:72:0b:30:b7:b1:76:32:81 |	                    13:3e:22:f7:21:99:bc:3f:89:b0:10:4b:5f:c6
                    d6:12:f5:20:26:e9:1d:73:00:ba:2a:f0:e1:cb |	                    fb:e8:f7:c9:42:3b:68:d1:c8:28:3d:35:94:dd
                    b1:2f:93:2b:6c:49:cd:51:34:71:c7:0d:ab:9c |	                    00:5b:18:fd:5a:e3:27:b5:3d:0d:45:d9:e1:5c
                    d3:cb:ed:24:a3:80:60:e7:81:8c:c4:4d:6f:6d |	                    11:8b:e7:9b:d6:6d:6b:db:4e:69:e4:81:84:9e
                    df:a6:63:f4:20:a7:64:64:02:16:58:12:00:a5 |	                    a7:4d:85:f2:b6:7c:47:c7:c9:83:56:cd:03:18
                    0e:c1:90:9a:c0:08:2d:bc:aa:83:40:cb:87:ef |	                    e3:fb:47:e9:ae:32:72:de:1e:d9:71:98:43:8c
                    c5:30:60:91:75:d8:c4:d8:9e:2f:53:58:36:67 |	                    85:74:35:85:79:4b:e2:d5:8f:f7:fe:54:42:c6
                    93:26:cc:fa:d2:29:f2:3f:c0:cc:e5:e4:e2:a9 |	                    dd:c5:22:cd:5a:5c:a8:ab:ba:22:c9:97:f6:0c
                    bb:f7:9e:82:95:c0:96:0a:df:4e:b5:07:e0:cd |	                    45:77:0f:33:ff:a1:eb:51:9b:f8:2b:d3:d3:ef
                    c5:4d:ae:f5:38:e2:57:6b:13:9f:1e:17:e5:9d |	                    e6:2b:23:fb:57:b9:d7:e6:c6:36:77:c0:2b:62
                    41:49:43:af:1b:39:0a:11:7c:30:a8:a7:d4:cd |	                    3f:b2:93:70:29:07:ac:fa:c6:14:19:68:44:4b
                    8e:65:14:1e:b9:3f:06:7a:a1:51:37:af:b3:2b |	                    5f:98:8c:6a:21:28:a2:28:7c:b9:46:cd:60:51
                    13:c7:e4:a7:3c:c0:da:df:9c:62:2f:4f:15:e3 |	                    3f:00:9c:d2:48:84:c0:0d:b2:c3:ca:d0:3d:02
                    53:26:8a:c1:5b:89:27:c1:e9:4b:f9:17:37:b3 |	                    aa:d6:85:92:79:ba:33:79:ec:b5:ab:cd:28:a4
                    42:c3				      |	                    af:29
                Exponent: 65537 (0x10001)			                Exponent: 65537 (0x10001)
        X509v3 extensions:					        X509v3 extensions:
            X509v3 Subject Alternative Name: 			            X509v3 Subject Alternative Name:
                DNS:c910f02c02p16, DNS:c910f02c02p16		                DNS:c910f02c02p16, DNS:c910f02c02p16
    Signature Algorithm: sha1WithRSAEncryption			    Signature Algorithm: sha1WithRSAEncryption
         90:26:0f:34:f8:a4:51:e9:d9:3a:cd:68:14:a2:45:93:72:3 |	         35:d5:98:c4:f8:aa:6d:36:99:f1:cc:da:b4:ea:64:94:77:f
         43:94:4b:ed:04:ee:06:fe:e9:d6:20:1d:4d:96:25:fa:2b:c |	         3c:d1:5f:55:a7:1f:c5:ad:f5:0c:3a:35:70:8b:d0:f3:e2:7
         d6:72:7d:2f:89:12:6d:f2:36:9c:f0:b9:24:3d:15:8b:83:6 |	         f6:75:0e:dc:85:6c:6d:b1:0c:92:e9:25:e6:37:90:1d:95:4
         72:73:22:d2:25:17:b3:be:ce:2f:2d:b4:31:6b:b8:d4:be:e |	         c7:c6:78:c5:0b:43:35:83:62:9d:64:d1:f6:0f:3a:4e:df:1
         b0:9b:c5:b0:55:98:d0:9c:ff:dd:1e:09:f9:83:b5:ed:55:4 |	         a2:a9:8f:82:f2:eb:79:01:f7:fd:6c:68:32:fb:e1:28:8d:e
         88:05:f2:1b:76:96:a5:0a:43:7a:79:1c:24:eb:ea:08:e8:c |	         91:6d:a6:65:63:0e:90:48:24:03:a1:ab:04:bc:ac:a0:f3:0
         5f:91:83:55:ee:08:8d:32:49:b5:2d:35:66:e7:50:87:3d:3 |	         e4:27:68:99:88:a3:c9:9c:3d:c3:c5:87:e1:ac:4a:b8:92:9
         50:2a:4d:19:62:67:76:f5:fa:55:62:20:af:b6:7a:2d:91:b |	         e3:20:cc:59:cf:72:98:cc:bc:21:41:e1:1d:c0:0d:a6:61:7
         94:df:45:e5:f5:ce:ea:8b:57:59:38:df:bd:53:cd:21:2c:4 |	         d7:7f:90:1c:58:24:08:dd:5d:fa:e3:75:4b:6f:52:ec:fe:d
         fb:ea:fd:86:12:e2:be:86:b4:35:ce:29:4b:28:d0:37:a8:c |	         d2:42:2f:15:73:05:4a:d4:40:83:68:77:46:c5:e7:e7:f6:b
         70:f1:76:19:d3:72:75:8c:2f:64:62:db:95:6c:3d:29:87:a |	         f2:95:9c:b0:65:c3:2a:04:ee:29:85:bd:9f:f1:54:3a:09:a
         11:dd:a7:0c:b6:2f:38:30:f1:12:0d:b3:10:05:d6:da:87:e |	         07:77:16:ba:90:50:08:ea:c6:63:35:09:cf:36:77:2e:5c:7
         20:64:90:54:49:98:d5:92:dd:d1:55:62:0a:22:6c:36:ee:3 |	         1c:ab:40:6f:37:b0:6f:b7:57:7c:82:2c:4f:ee:86:85:79:8
         e9:fa:6c:fb:d6:e6:f5:d6:61:14:01:6c:65:e0:a2:3a:8b:4 |	         59:ab:46:a0:f8:76:c0:e3:a0:61:f8:70:a5:08:7d:91:27:d
         86:bb:3b:1a					      |	         6e:03:2f:4f
-----BEGIN CERTIFICATE-----					-----BEGIN CERTIFICATE-----
MIIC0DCCAbigAwIBAgIBAjANBgkqhkiG9w0BAQUFADASMRAwDgYDVQQDEwd4Q	MIIC0DCCAbigAwIBAgIBAjANBgkqhkiG9w0BAQUFADASMRAwDgYDVQQDEwd4Q
IENBMB4XDTYwMDEwMTAxMDEwMVoXDTM5MDIwODA3MjUzNFowGDEWMBQGA1UEA |	IENBMB4XDTYwMDEwMTAxMDEwMVoXDTM5MDIwODA3MTczN1owGDEWMBQGA1UEA
YzkxMGYwMmMwMnAxNjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBA |	YzkxMGYwMmMwMnAxNjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBA
5DNLvi61HLlGnu9AGoW4T5gstEYeo9c8ewVMSABwlF+TIfOw0J8w74fnPQum0 |	5iFkXBROqEGT9Cum8aa9+mtXkJAu5JoRwFyAULw0mFTYBJdcCCJ83gFQEz4i9
cgswt7F2MoFB1hL1ICbpHXMAuirw4cvTsS+TK2xJzVE0cccNq5wu08vtJKOAY |	vD+JsBBLX8ZJ++j3yUI7aNHIKD01lN21AFsY/VrjJ7U9DUXZ4VywEYvnm9Zta
jMRNb20M36Zj9CCnZGQCFlgSAKV/DsGQmsAILbyqg0DLh+/RxTBgkXXYxNieL |	aeSBhJ6Ip02F8rZ8R8fJg1bNAxhY4/tH6a4yct4e2XGYQ4wShXQ1hXlL4tWP9
Nme7kybM+tIp8j/AzOXk4qnbu/eegpXAlgrfTrUH4M2BxU2u9TjiV2sTnx4X5 |	QsYL3cUizVpcqKu6IsmX9gwVRXcPM/+h61Gb+CvT0+/I5isj+1e51+bGNnfAK
QUlDrxs5ChF8MKin1M3tjmUUHrk/BnqhUTevsyvkE8fkpzzA2t+cYi9PFeM5U |	P7KTcCkHrPrGFBloREu1X5iMaiEooih8uUbNYFFFPwCc0kiEwA2yw8rQPQJVq
wVuJJ8HpS/kXN7OgQsMCAwEAAaMrMCkwJwYDVR0RBCAwHoINYzkxMGYwMmMwM |	knm6M3nstavNKKR6rykCAwEAAaMrMCkwJwYDVR0RBCAwHoINYzkxMGYwMmMwM
NoINYzkxMGYwMmMwMnAxNjANBgkqhkiG9w0BAQUFAAOCAQEAkCYPNPikUenZO |	NoINYzkxMGYwMmMwMnAxNjANBgkqhkiG9w0BAQUFAAOCAQEANdWYxPiqbTaZ8
FKJFk3IzQ5RL7QTuBv7p1iAdTZYl+ivL1nJ9L4kSbfI2nPC5JD0Vi4NmcnMi0 |	tOpklHf7PNFfVacfxa31DDo1cIvQ8+J49nUO3IVsbbEMkukl5jeQHZVOx8Z4x
s77OLy20MWu41L7vsJvFsFWY0Jz/3R4J+YO17VVOiAXyG3aWpQpDenkcJOvqC |	NYNinWTR9g86Tt8ZoqmPgvLreQH3/WxoMvvhKI3jkW2mZWMOkEgkA6GrBLyso
X5GDVe4IjTJJtS01ZudQhz01UCpNGWJndvX6VWIgr7Z6LZG/lN9F5fXO6otXW |	5CdomYijyZw9w8WH4axKuJKY4yDMWc9ymMy8IUHhHcANpmFw13+QHFgkCN1d+
vVPNISxP++r9hhLivoa0Nc4pSyjQN6jDcPF2GdNydYwvZGLblWw9KYeiEd2nD |	S29S7P7a0kIvFXMFStRAg2h3RsXn5/a78pWcsGXDKgTuKYW9n/FUOgmqB3cWu
ODDxEg2zEAXW2ofpIGSQVEmY1ZLd0VViCiJsNu476fps+9bm9dZhFAFsZeCiO |	COrGYzUJzzZ3Llx0HKtAbzewb7dXfIIsT+6GhXmPWatGoPh2wOOgYfhwpQh9k
hrs7Gg==						      |	bgMvTw==
-----END CERTIFICATE-----					-----END CERTIFICATE-----
diff -y /etc/xcat/cert/server-cred.pem /etc/xcat/certbak/server-cred.pem
Certificate:							Certificate:
    Data:							    Data:
        Version: 3 (0x2)					        Version: 3 (0x2)
        Serial Number: 2 (0x2)					        Serial Number: 2 (0x2)
    Signature Algorithm: sha1WithRSAEncryption			    Signature Algorithm: sha1WithRSAEncryption
        Issuer: CN=xCAT CA					        Issuer: CN=xCAT CA
        Validity						        Validity
            Not Before: Jan  1 01:01:01 1960 GMT		            Not Before: Jan  1 01:01:01 1960 GMT
            Not After : Feb  8 07:25:34 2039 GMT	      |	            Not After : Feb  8 07:17:37 2039 GMT
        Subject: CN=c910f02c02p16				        Subject: CN=c910f02c02p16
        Subject Public Key Info:				        Subject Public Key Info:
            Public Key Algorithm: rsaEncryption			            Public Key Algorithm: rsaEncryption
                Public-Key: (2048 bit)				                Public-Key: (2048 bit)
                Modulus:					                Modulus:
                    00:97:df:e4:33:4b:be:2e:b5:1c:b9:46:9e:ef |	                    00:a2:ad:e6:21:64:5c:14:4e:a8:41:93:f4:2b
                    1a:85:b8:4f:98:2c:b4:46:1e:a3:d7:3c:7b:05 |	                    f1:a6:bd:fa:6b:57:90:90:2e:e4:9a:11:c0:5c
                    48:00:70:94:5f:93:21:f3:b0:d0:9f:30:ef:87 |	                    50:bc:34:98:54:d8:04:97:5c:08:22:7c:de:01
                    3d:0b:a6:d1:3b:39:72:0b:30:b7:b1:76:32:81 |	                    13:3e:22:f7:21:99:bc:3f:89:b0:10:4b:5f:c6
                    d6:12:f5:20:26:e9:1d:73:00:ba:2a:f0:e1:cb |	                    fb:e8:f7:c9:42:3b:68:d1:c8:28:3d:35:94:dd
                    b1:2f:93:2b:6c:49:cd:51:34:71:c7:0d:ab:9c |	                    00:5b:18:fd:5a:e3:27:b5:3d:0d:45:d9:e1:5c
                    d3:cb:ed:24:a3:80:60:e7:81:8c:c4:4d:6f:6d |	                    11:8b:e7:9b:d6:6d:6b:db:4e:69:e4:81:84:9e
                    df:a6:63:f4:20:a7:64:64:02:16:58:12:00:a5 |	                    a7:4d:85:f2:b6:7c:47:c7:c9:83:56:cd:03:18
                    0e:c1:90:9a:c0:08:2d:bc:aa:83:40:cb:87:ef |	                    e3:fb:47:e9:ae:32:72:de:1e:d9:71:98:43:8c
                    c5:30:60:91:75:d8:c4:d8:9e:2f:53:58:36:67 |	                    85:74:35:85:79:4b:e2:d5:8f:f7:fe:54:42:c6
                    93:26:cc:fa:d2:29:f2:3f:c0:cc:e5:e4:e2:a9 |	                    dd:c5:22:cd:5a:5c:a8:ab:ba:22:c9:97:f6:0c
                    bb:f7:9e:82:95:c0:96:0a:df:4e:b5:07:e0:cd |	                    45:77:0f:33:ff:a1:eb:51:9b:f8:2b:d3:d3:ef
                    c5:4d:ae:f5:38:e2:57:6b:13:9f:1e:17:e5:9d |	                    e6:2b:23:fb:57:b9:d7:e6:c6:36:77:c0:2b:62
                    41:49:43:af:1b:39:0a:11:7c:30:a8:a7:d4:cd |	                    3f:b2:93:70:29:07:ac:fa:c6:14:19:68:44:4b
                    8e:65:14:1e:b9:3f:06:7a:a1:51:37:af:b3:2b |	                    5f:98:8c:6a:21:28:a2:28:7c:b9:46:cd:60:51
                    13:c7:e4:a7:3c:c0:da:df:9c:62:2f:4f:15:e3 |	                    3f:00:9c:d2:48:84:c0:0d:b2:c3:ca:d0:3d:02
                    53:26:8a:c1:5b:89:27:c1:e9:4b:f9:17:37:b3 |	                    aa:d6:85:92:79:ba:33:79:ec:b5:ab:cd:28:a4
                    42:c3				      |	                    af:29
                Exponent: 65537 (0x10001)			                Exponent: 65537 (0x10001)
        X509v3 extensions:					        X509v3 extensions:
            X509v3 Subject Alternative Name: 			            X509v3 Subject Alternative Name:
                DNS:c910f02c02p16, DNS:c910f02c02p16		                DNS:c910f02c02p16, DNS:c910f02c02p16
    Signature Algorithm: sha1WithRSAEncryption			    Signature Algorithm: sha1WithRSAEncryption
         90:26:0f:34:f8:a4:51:e9:d9:3a:cd:68:14:a2:45:93:72:3 |	         35:d5:98:c4:f8:aa:6d:36:99:f1:cc:da:b4:ea:64:94:77:f
         43:94:4b:ed:04:ee:06:fe:e9:d6:20:1d:4d:96:25:fa:2b:c |	         3c:d1:5f:55:a7:1f:c5:ad:f5:0c:3a:35:70:8b:d0:f3:e2:7
         d6:72:7d:2f:89:12:6d:f2:36:9c:f0:b9:24:3d:15:8b:83:6 |	         f6:75:0e:dc:85:6c:6d:b1:0c:92:e9:25:e6:37:90:1d:95:4
         72:73:22:d2:25:17:b3:be:ce:2f:2d:b4:31:6b:b8:d4:be:e |	         c7:c6:78:c5:0b:43:35:83:62:9d:64:d1:f6:0f:3a:4e:df:1
         b0:9b:c5:b0:55:98:d0:9c:ff:dd:1e:09:f9:83:b5:ed:55:4 |	         a2:a9:8f:82:f2:eb:79:01:f7:fd:6c:68:32:fb:e1:28:8d:e
         88:05:f2:1b:76:96:a5:0a:43:7a:79:1c:24:eb:ea:08:e8:c |	         91:6d:a6:65:63:0e:90:48:24:03:a1:ab:04:bc:ac:a0:f3:0
         5f:91:83:55:ee:08:8d:32:49:b5:2d:35:66:e7:50:87:3d:3 |	         e4:27:68:99:88:a3:c9:9c:3d:c3:c5:87:e1:ac:4a:b8:92:9
         50:2a:4d:19:62:67:76:f5:fa:55:62:20:af:b6:7a:2d:91:b |	         e3:20:cc:59:cf:72:98:cc:bc:21:41:e1:1d:c0:0d:a6:61:7
         94:df:45:e5:f5:ce:ea:8b:57:59:38:df:bd:53:cd:21:2c:4 |	         d7:7f:90:1c:58:24:08:dd:5d:fa:e3:75:4b:6f:52:ec:fe:d
         fb:ea:fd:86:12:e2:be:86:b4:35:ce:29:4b:28:d0:37:a8:c |	         d2:42:2f:15:73:05:4a:d4:40:83:68:77:46:c5:e7:e7:f6:b
         70:f1:76:19:d3:72:75:8c:2f:64:62:db:95:6c:3d:29:87:a |	         f2:95:9c:b0:65:c3:2a:04:ee:29:85:bd:9f:f1:54:3a:09:a
         11:dd:a7:0c:b6:2f:38:30:f1:12:0d:b3:10:05:d6:da:87:e |	         07:77:16:ba:90:50:08:ea:c6:63:35:09:cf:36:77:2e:5c:7
         20:64:90:54:49:98:d5:92:dd:d1:55:62:0a:22:6c:36:ee:3 |	         1c:ab:40:6f:37:b0:6f:b7:57:7c:82:2c:4f:ee:86:85:79:8
         e9:fa:6c:fb:d6:e6:f5:d6:61:14:01:6c:65:e0:a2:3a:8b:4 |	         59:ab:46:a0:f8:76:c0:e3:a0:61:f8:70:a5:08:7d:91:27:d
         86:bb:3b:1a					      |	         6e:03:2f:4f
-----BEGIN CERTIFICATE-----					-----BEGIN CERTIFICATE-----
MIIC0DCCAbigAwIBAgIBAjANBgkqhkiG9w0BAQUFADASMRAwDgYDVQQDEwd4Q	MIIC0DCCAbigAwIBAgIBAjANBgkqhkiG9w0BAQUFADASMRAwDgYDVQQDEwd4Q
IENBMB4XDTYwMDEwMTAxMDEwMVoXDTM5MDIwODA3MjUzNFowGDEWMBQGA1UEA |	IENBMB4XDTYwMDEwMTAxMDEwMVoXDTM5MDIwODA3MTczN1owGDEWMBQGA1UEA
YzkxMGYwMmMwMnAxNjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBA |	YzkxMGYwMmMwMnAxNjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBA
5DNLvi61HLlGnu9AGoW4T5gstEYeo9c8ewVMSABwlF+TIfOw0J8w74fnPQum0 |	5iFkXBROqEGT9Cum8aa9+mtXkJAu5JoRwFyAULw0mFTYBJdcCCJ83gFQEz4i9
cgswt7F2MoFB1hL1ICbpHXMAuirw4cvTsS+TK2xJzVE0cccNq5wu08vtJKOAY |	vD+JsBBLX8ZJ++j3yUI7aNHIKD01lN21AFsY/VrjJ7U9DUXZ4VywEYvnm9Zta
jMRNb20M36Zj9CCnZGQCFlgSAKV/DsGQmsAILbyqg0DLh+/RxTBgkXXYxNieL |	aeSBhJ6Ip02F8rZ8R8fJg1bNAxhY4/tH6a4yct4e2XGYQ4wShXQ1hXlL4tWP9
Nme7kybM+tIp8j/AzOXk4qnbu/eegpXAlgrfTrUH4M2BxU2u9TjiV2sTnx4X5 |	QsYL3cUizVpcqKu6IsmX9gwVRXcPM/+h61Gb+CvT0+/I5isj+1e51+bGNnfAK
QUlDrxs5ChF8MKin1M3tjmUUHrk/BnqhUTevsyvkE8fkpzzA2t+cYi9PFeM5U |	P7KTcCkHrPrGFBloREu1X5iMaiEooih8uUbNYFFFPwCc0kiEwA2yw8rQPQJVq
wVuJJ8HpS/kXN7OgQsMCAwEAAaMrMCkwJwYDVR0RBCAwHoINYzkxMGYwMmMwM |	knm6M3nstavNKKR6rykCAwEAAaMrMCkwJwYDVR0RBCAwHoINYzkxMGYwMmMwM
NoINYzkxMGYwMmMwMnAxNjANBgkqhkiG9w0BAQUFAAOCAQEAkCYPNPikUenZO |	NoINYzkxMGYwMmMwMnAxNjANBgkqhkiG9w0BAQUFAAOCAQEANdWYxPiqbTaZ8
FKJFk3IzQ5RL7QTuBv7p1iAdTZYl+ivL1nJ9L4kSbfI2nPC5JD0Vi4NmcnMi0 |	tOpklHf7PNFfVacfxa31DDo1cIvQ8+J49nUO3IVsbbEMkukl5jeQHZVOx8Z4x
s77OLy20MWu41L7vsJvFsFWY0Jz/3R4J+YO17VVOiAXyG3aWpQpDenkcJOvqC |	NYNinWTR9g86Tt8ZoqmPgvLreQH3/WxoMvvhKI3jkW2mZWMOkEgkA6GrBLyso
X5GDVe4IjTJJtS01ZudQhz01UCpNGWJndvX6VWIgr7Z6LZG/lN9F5fXO6otXW |	5CdomYijyZw9w8WH4axKuJKY4yDMWc9ymMy8IUHhHcANpmFw13+QHFgkCN1d+
vVPNISxP++r9hhLivoa0Nc4pSyjQN6jDcPF2GdNydYwvZGLblWw9KYeiEd2nD |	S29S7P7a0kIvFXMFStRAg2h3RsXn5/a78pWcsGXDKgTuKYW9n/FUOgmqB3cWu
ODDxEg2zEAXW2ofpIGSQVEmY1ZLd0VViCiJsNu476fps+9bm9dZhFAFsZeCiO |	COrGYzUJzzZ3Llx0HKtAbzewb7dXfIIsT+6GhXmPWatGoPh2wOOgYfhwpQh9k
hrs7Gg==						      |	bgMvTw==
-----END CERTIFICATE-----					-----END CERTIFICATE-----
-----BEGIN RSA PRIVATE KEY-----					-----BEGIN RSA PRIVATE KEY-----
MIIEowIBAAKCAQEAl9/kM0u+LrUcuUae70AahbhPmCy0Rh6j1zx7BUxIAHCUX |	MIIEowIBAAKCAQEAoq3mIWRcFE6oQZP0K6bxpr36a1eQkC7kmhHAXIBQvDSYV
87DQnzDvh+c9C6bROzlyCzC3sXYygUHWEvUgJukdcwC6KvDhy9OxL5MrbEnNU |	l1wIInzeAVATPiL3IZm8P4mwEEtfxkn76PfJQjto0cgoPTWU3bUAWxj9WuMnt
xw2rnC7Ty+0ko4Bg54GMxE1vbQzfpmP0IKdkZAIWWBIApX8OwZCawAgtvKqDQ |	RdnhXLARi+eb1m1r205p5IGEnoinTYXytnxHx8mDVs0DGFjj+0fprjJy3h7Zc
79HFMGCRddjE2J4vU1g2Z7uTJsz60inyP8DM5eTiqdu7956ClcCWCt9OtQfgz |	jBKFdDWFeUvi1Y/3/lRCxgvdxSLNWlyoq7oiyZf2DBVFdw8z/6HrUZv4K9PT7
Ta71OOJXaxOfHhflnRFBSUOvGzkKEXwwqKfUze2OZRQeuT8GeqFRN6+zK+QTx |	KyP7V7nX5sY2d8ArYho/spNwKQes+sYUGWhES7VfmIxqISiiKHy5Rs1gUUU/A
PMDa35xiL08V4zlTJorBW4knwelL+Rc3s6BCwwIDAQABAoIBABudxbQiKMH7g |	SITADbLDytA9AlWq1oWSebozeey1q80opHqvKQIDAQABAoIBACzFFvRRnlWoX
zdq5cFkya57DOkCp36cKw1/yQAF8dy5t5bWXSEg6MMQooywUOGWpi3hHco+da |	LgJla1OsLOKlso87mIYeJIZQeeeRwep3mKvfFA4Jtz89Pk53aPPCT2BdECsr0
dhraYe9RYl6AGlomlRhoNQbunu3A+cmzXKESdksfJLonNAtbE8PlBcDIR+Ovf |	6JzwtF6Z4vr4zropqNJrIbHwaqk8oozqRGDY2YCco/eQwf59FpXAOrw8OLc4f
A1NQvOuGiaOYGm/9i6Rc9BbJJe/xVdZLHHX/eKqUGxxVStybv8nABmclQBWyC |	ToqSIV8GQjL9MMDelb9txw29rIccHct7bbRdLrYDUL429eLMWqLA4IlTxz381
2KJr7S8uNjvIN+Hj4WgFHjsUrdwAsIl58jyTGOCbEPvCrmnJqLxIpt16RtoHm |	B2HqTJEqW8LDe+B2dVt3bFaEXfQ2afJh7POzjZfMZDHQIieM+6R321RLiVZMq
5TFcYKHhjL6MrEjPOPgloAErauaxoNAy9m7+WyDRED3gVEJ7inDmFX4DuDhjh |	wIkIe3hB4fg/t1YzMh4DDRFAuKA7SpDBnYfloNyldbatYEJDMrRrXwRDsdrdF
cwRrQdkCgYEAyH8jsiA1idbxxx7mndf8Zhcl/p9LSxRG3neUgSVIACPLAIp3T |	cthZ5hECgYEA2NHTTaBwT4Y8sX02x4WhcKDZFxKknBNOLNKurgXw7VSDwZNJF
9HvznM2BUUYgHoyj5Ix5u97Qg9R8oACnNlmAmJU3V48D6uWTSFY5MVIvmY1wi |	80TcmjlFjeldoXSjd8tpViVBWQDf0SPAssr4/1PayDGBeQIyq1yc5htdVw5Si
k/ZD0WmLbLUwPvkngAHJDx0sZtDb0gc53B4aer8vJIcy58FScoy7vRUCgYEAw |	KIg7mDa8SRzaTJJsdvRE84dS1kNEsRjblSWtQon00pq6gKk4loI/m1cCgYEAw
6Kt1Kdcr3AKDaKzA4iS4bwJh/bmACZnJVHZWhe4WanJugxCx/BGgVCscBTHth |	VVzcBWXo1cegUYH5zoRvmT7z4YyHKkZPa3YDmGyieIeR5TCTSP3PtZ3c90gFP
gBMs/Jt7uD7X6UIANy5lpiTpQUOswaB5sSajyPa42g1gtQgj3XezGfbBQ3mtV |	NMfZDvqTWbxV9bZYVf5axIp0VQyArQ6JLOncDYAmm3G7YiblbCcxW9IoAE+Ou
YJaHRWLsueSzMT0UN9hfS/UnPuzeDGni06IxZncCgYBuj0V01TQQtXmPzudmx |	37UtOP2DYQIxWHqLq93zr5u0fG2pD6RVg+2z+X8CgYEAsJ+E/UiEFRQqHv/8f
jV9DQD35wc2uoYw/hvpkMVihDLnrP2fn0G4u2lfkJGJT1kQOJLSAN8cN2x957 |	28D796K1O3syhKr/pz2pvPvK9QbRU/u5v5FKD8w1z9vZ7SuB+pVWctmYeTOQH
QyeZfDcPTmrfngcQjZNuMh7Tct5LoSMZx2PwV14t7OAU6bmxacqgTfsNG0EMW |	F2rnGb+qishhSz0yH4wrN/v0tnUxYkaE0Q/hVCbKjNiXMCdbei+Ud7m2Dlrv+
vtHlPAXYA8G7cKxxRE/GXQKBgAey9rueIxa4Lkub5e+//CB+aLwvkghq1wSKk |	qAjwMjMFoAZxhVvUgC8MN7MCgYBkvNe2/ZDXs+890AkhNo4R5huxv/ag4NczM
7QeAPm+Xf3/Ap/BkGsN8uq4SH2Ya2Mea+0xEOBNGm3ftYOjP9MU17fTjZPaDE |	g0K3eqJrnI7EKYnVymhZ1IXDm55D/JDDhd0tofYOJlzfFdeWomRwmD0TLg9+t
AOy3rvspUM+fNR1T5U6Al4fASvt5FZCiKVi95rwyslKgJC9bbd0sLJS4/s/rX |	3WFwIzocZLXmcIf7BUM56SrZnuA5MlcmJRumvC9ffYrr4LnIVgwsmfk7GTiF3
vmtdAoGBAK03XJDd4O+HiaSwbNsHN1JmkmR4gXzNXw3l1p1DsRtHBGtVtSoYU |	Hu05eQKBgGrPNJ9yvU8sWip9XTUPrL+0PSrF4lxEPvy52DlMVbIBzu7r/gijx
P7Ad7+b3ds/joM85pyVHqJLcKGUZPKDEH/6xC146jfaNFCNJswtndjuWPP5eJ |	h8JXH8vi6yFvW2zaBc9B5MEpzRpMA68c7Xlyrv9PJ+yA4X0KiUqHb9UGEvcMv
fysVckbS6Fmmq1rNDJslzaofci/xnRj3Y1irNm1304QyjgceI6wZ	      |	T0FBHLkkragO7nVvr9BfJgXDuLL76Ql169/faLPDiju6qQO2Vitb
-----END RSA PRIVATE KEY-----					-----END RSA PRIVATE KEY-----
diff -y /etc/xcat/cert/server-key.pem /etc/xcat/certbak/server-key.pem
-----BEGIN RSA PRIVATE KEY-----					-----BEGIN RSA PRIVATE KEY-----
MIIEowIBAAKCAQEAl9/kM0u+LrUcuUae70AahbhPmCy0Rh6j1zx7BUxIAHCUX |	MIIEowIBAAKCAQEAoq3mIWRcFE6oQZP0K6bxpr36a1eQkC7kmhHAXIBQvDSYV
87DQnzDvh+c9C6bROzlyCzC3sXYygUHWEvUgJukdcwC6KvDhy9OxL5MrbEnNU |	l1wIInzeAVATPiL3IZm8P4mwEEtfxkn76PfJQjto0cgoPTWU3bUAWxj9WuMnt
xw2rnC7Ty+0ko4Bg54GMxE1vbQzfpmP0IKdkZAIWWBIApX8OwZCawAgtvKqDQ |	RdnhXLARi+eb1m1r205p5IGEnoinTYXytnxHx8mDVs0DGFjj+0fprjJy3h7Zc
79HFMGCRddjE2J4vU1g2Z7uTJsz60inyP8DM5eTiqdu7956ClcCWCt9OtQfgz |	jBKFdDWFeUvi1Y/3/lRCxgvdxSLNWlyoq7oiyZf2DBVFdw8z/6HrUZv4K9PT7
Ta71OOJXaxOfHhflnRFBSUOvGzkKEXwwqKfUze2OZRQeuT8GeqFRN6+zK+QTx |	KyP7V7nX5sY2d8ArYho/spNwKQes+sYUGWhES7VfmIxqISiiKHy5Rs1gUUU/A
PMDa35xiL08V4zlTJorBW4knwelL+Rc3s6BCwwIDAQABAoIBABudxbQiKMH7g |	SITADbLDytA9AlWq1oWSebozeey1q80opHqvKQIDAQABAoIBACzFFvRRnlWoX
zdq5cFkya57DOkCp36cKw1/yQAF8dy5t5bWXSEg6MMQooywUOGWpi3hHco+da |	LgJla1OsLOKlso87mIYeJIZQeeeRwep3mKvfFA4Jtz89Pk53aPPCT2BdECsr0
dhraYe9RYl6AGlomlRhoNQbunu3A+cmzXKESdksfJLonNAtbE8PlBcDIR+Ovf |	6JzwtF6Z4vr4zropqNJrIbHwaqk8oozqRGDY2YCco/eQwf59FpXAOrw8OLc4f
A1NQvOuGiaOYGm/9i6Rc9BbJJe/xVdZLHHX/eKqUGxxVStybv8nABmclQBWyC |	ToqSIV8GQjL9MMDelb9txw29rIccHct7bbRdLrYDUL429eLMWqLA4IlTxz381
2KJr7S8uNjvIN+Hj4WgFHjsUrdwAsIl58jyTGOCbEPvCrmnJqLxIpt16RtoHm |	B2HqTJEqW8LDe+B2dVt3bFaEXfQ2afJh7POzjZfMZDHQIieM+6R321RLiVZMq
5TFcYKHhjL6MrEjPOPgloAErauaxoNAy9m7+WyDRED3gVEJ7inDmFX4DuDhjh |	wIkIe3hB4fg/t1YzMh4DDRFAuKA7SpDBnYfloNyldbatYEJDMrRrXwRDsdrdF
cwRrQdkCgYEAyH8jsiA1idbxxx7mndf8Zhcl/p9LSxRG3neUgSVIACPLAIp3T |	cthZ5hECgYEA2NHTTaBwT4Y8sX02x4WhcKDZFxKknBNOLNKurgXw7VSDwZNJF
9HvznM2BUUYgHoyj5Ix5u97Qg9R8oACnNlmAmJU3V48D6uWTSFY5MVIvmY1wi |	80TcmjlFjeldoXSjd8tpViVBWQDf0SPAssr4/1PayDGBeQIyq1yc5htdVw5Si
k/ZD0WmLbLUwPvkngAHJDx0sZtDb0gc53B4aer8vJIcy58FScoy7vRUCgYEAw |	KIg7mDa8SRzaTJJsdvRE84dS1kNEsRjblSWtQon00pq6gKk4loI/m1cCgYEAw
6Kt1Kdcr3AKDaKzA4iS4bwJh/bmACZnJVHZWhe4WanJugxCx/BGgVCscBTHth |	VVzcBWXo1cegUYH5zoRvmT7z4YyHKkZPa3YDmGyieIeR5TCTSP3PtZ3c90gFP
gBMs/Jt7uD7X6UIANy5lpiTpQUOswaB5sSajyPa42g1gtQgj3XezGfbBQ3mtV |	NMfZDvqTWbxV9bZYVf5axIp0VQyArQ6JLOncDYAmm3G7YiblbCcxW9IoAE+Ou
YJaHRWLsueSzMT0UN9hfS/UnPuzeDGni06IxZncCgYBuj0V01TQQtXmPzudmx |	37UtOP2DYQIxWHqLq93zr5u0fG2pD6RVg+2z+X8CgYEAsJ+E/UiEFRQqHv/8f
jV9DQD35wc2uoYw/hvpkMVihDLnrP2fn0G4u2lfkJGJT1kQOJLSAN8cN2x957 |	28D796K1O3syhKr/pz2pvPvK9QbRU/u5v5FKD8w1z9vZ7SuB+pVWctmYeTOQH
QyeZfDcPTmrfngcQjZNuMh7Tct5LoSMZx2PwV14t7OAU6bmxacqgTfsNG0EMW |	F2rnGb+qishhSz0yH4wrN/v0tnUxYkaE0Q/hVCbKjNiXMCdbei+Ud7m2Dlrv+
vtHlPAXYA8G7cKxxRE/GXQKBgAey9rueIxa4Lkub5e+//CB+aLwvkghq1wSKk |	qAjwMjMFoAZxhVvUgC8MN7MCgYBkvNe2/ZDXs+890AkhNo4R5huxv/ag4NczM
7QeAPm+Xf3/Ap/BkGsN8uq4SH2Ya2Mea+0xEOBNGm3ftYOjP9MU17fTjZPaDE |	g0K3eqJrnI7EKYnVymhZ1IXDm55D/JDDhd0tofYOJlzfFdeWomRwmD0TLg9+t
AOy3rvspUM+fNR1T5U6Al4fASvt5FZCiKVi95rwyslKgJC9bbd0sLJS4/s/rX |	3WFwIzocZLXmcIf7BUM56SrZnuA5MlcmJRumvC9ffYrr4LnIVgwsmfk7GTiF3
vmtdAoGBAK03XJDd4O+HiaSwbNsHN1JmkmR4gXzNXw3l1p1DsRtHBGtVtSoYU |	Hu05eQKBgGrPNJ9yvU8sWip9XTUPrL+0PSrF4lxEPvy52DlMVbIBzu7r/gijx
P7Ad7+b3ds/joM85pyVHqJLcKGUZPKDEH/6xC146jfaNFCNJswtndjuWPP5eJ |	h8JXH8vi6yFvW2zaBc9B5MEpzRpMA68c7Xlyrv9PJ+yA4X0KiUqHb9UGEvcMv
fysVckbS6Fmmq1rNDJslzaofci/xnRj3Y1irNm1304QyjgceI6wZ	      |	T0FBHLkkragO7nVvr9BfJgXDuLL76Ql169/faLPDiju6qQO2Vitb
-----END RSA PRIVATE KEY-----					-----END RSA PRIVATE KEY-----
diff -y /etc/xcat/cert/server-req.pem /etc/xcat/certbak/server-req.pem
-----BEGIN CERTIFICATE REQUEST-----				-----BEGIN CERTIFICATE REQUEST-----
MIICXTCCAUUCAQAwGDEWMBQGA1UEAxMNYzkxMGYwMmMwMnAxNjCCASIwDQYJK	MIICXTCCAUUCAQAwGDEWMBQGA1UEAxMNYzkxMGYwMmMwMnAxNjCCASIwDQYJK
hvcNAQEBBQADggEPADCCAQoCggEBAJff5DNLvi61HLlGnu9AGoW4T5gstEYeo |	hvcNAQEBBQADggEPADCCAQoCggEBAKKt5iFkXBROqEGT9Cum8aa9+mtXkJAu5
ewVMSABwlF+TIfOw0J8w74fnPQum0Ts5cgswt7F2MoFB1hL1ICbpHXMAuirw4 |	wFyAULw0mFTYBJdcCCJ83gFQEz4i9yGZvD+JsBBLX8ZJ++j3yUI7aNHIKD01l
sS+TK2xJzVE0cccNq5wu08vtJKOAYOeBjMRNb20M36Zj9CCnZGQCFlgSAKV/D |	AFsY/VrjJ7U9DUXZ4VywEYvnm9Zta9tOaeSBhJ6Ip02F8rZ8R8fJg1bNAxhY4
msAILbyqg0DLh+/RxTBgkXXYxNieL1NYNme7kybM+tIp8j/AzOXk4qnbu/eeg |	6a4yct4e2XGYQ4wShXQ1hXlL4tWP9/5UQsYL3cUizVpcqKu6IsmX9gwVRXcPM
lgrfTrUH4M2BxU2u9TjiV2sTnx4X5Z0RQUlDrxs5ChF8MKin1M3tjmUUHrk/B |	61Gb+CvT0+/I5isj+1e51+bGNnfAK2IaP7KTcCkHrPrGFBloREu1X5iMaiEoo
UTevsyvkE8fkpzzA2t+cYi9PFeM5UyaKwVuJJ8HpS/kXN7OgQsMCAwEAAaAAM |	uUbNYFFFPwCc0kiEwA2yw8rQPQJVqtaFknm6M3nstavNKKR6rykCAwEAAaAAM
CSqGSIb3DQEBCwUAA4IBAQAxgMoaJ0YVl5DTRWqfqgpj3AaDy2bnxgtylumC3 |	CSqGSIb3DQEBCwUAA4IBAQAW9MlkZYd04TZLMSwLfMdYuiEVSLdQ8TCxrBs82
1l2/+w9Qd9AJvwUu0UW+aWrP8ZYIqetmlL+ija2gF2U7C+lksdi2684EQN6gP |	6JCSzmpxwEZLp76mp1y475XvtQC64BLN8sns3VxA04EUAFQYOagy4oHLhkwr2
Q5NA/AkXPWMjxhc0vin7zCzVBZ8tIF4n21gByC923PjBwHuzHc5CziPSHwXAG |	8cZ5vgdF07PdKOlOx6QrONcOkYt8CjFqS5dqgBlrmlOkJRr2EbLNKu2GgiLbG
gUYv1/iqH8RH+It4mamEpN70v1a5BxhWKPAWDAjYoBOShTzmzKYkRZ3cuGl9Z |	RpNFxb4Z585asISyfrdJeSR5ZK9Ax4b6zDW58gy8yfnJHJ8eh1pgjNm7ifTUa
3XJonv+7oUK6sFbz1KVZil4EwFQN2pSUVUCjwKrlW3og+J/taN6HZie97mNP3 |	E72VqOXMt2NIkOJYomKjiYlPAeuIA3mzBfzVEqCBONVszjOLGEnAqPMNSEes6
SNmq/UF6BzsEQC22YEvegHEl/oB6/BoyEkkHkUvZSAkc		      |	WhDhDFWLzykQEou9YP13L0OuZYvx0TlGpEiT9KpUVU4L
-----END CERTIFICATE REQUEST-----				-----END CERTIFICATE REQUEST-----
CHECK:rc != 0	[Pass]

RUN:rm -rf /tmp/xcatconfig.test [Wed Feb 13 02:25:39 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:mv -f /etc/xcat/cabak /etc/xcat/ca ;mv -f /etc/xcat/certbak /etc/xcat/cert [Wed Feb 13 02:25:39 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:if lsdef service > /dev/null 2>&1; then updatenode service -P servicenode;fi [Wed Feb 13 02:25:39 2019]
ElapsedTime:5 sec
RETURN rc = 0
OUTPUT:
c910f02c02p17: =============updatenode starting====================
c910f02c02p17: trying to download postscripts...
c910f02c02p17: postscripts downloaded successfully
c910f02c02p17: trying to get mypostscript from 10.2.2.16...
c910f02c02p17: postscript start..: servicenode
c910f02c02p17: postscript end....: servicenode exited with code 0
c910f02c02p17: Running of postscripts has completed.
c910f02c02p17: =============updatenode ending====================
CHECK:rc == 0	[Pass]

RUN:if lsdef service > /dev/null 2>&1; then makedhcp -a;fi [Wed Feb 13 02:25:44 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::xcatconfig_c::Passed::Time:Wed Feb 13 02:25:46 2019 ::Duration::12 sec------
------Total: 1 , Failed: 0------
```