### PR TITLE
EXECUTE in sync list will not invoke post sync scripts if the script itself is updated

### DIFF
--- a/perl-xCAT/xCAT/DSHCLI.pm
+++ b/perl-xCAT/xCAT/DSHCLI.pm
@@ -5956,8 +5956,7 @@ sub run_rsync_postscripts
 
             #the $postsfile <file>.post will be run if:
             # the <file> is updated, or
-            # the <file>.post file is updated
-            if ($ps eq $tmppostfile or $ps eq $tmppostfile.".post" ) {
+            if ($ps eq $tmppostfile ) {
 
                 # build xdsh queue
                 # build host and all scripts to execute


### PR DESCRIPTION
### The PR is to correct the behavior in PR https://github.com/xcat2/xcat-core/pull/5997:

The update of post sync script file `<file-to-sync>.post` will not trigger the invocation of  `<file-to-sync>.post` for `EXECUTE` clause

UT:
```
[root@boston36 xCAT]# cat /install/custom/synclist
/etc/test -> /tmp/etc/test
/etc/test.post -> /tmp/test.post
EXECUTE:
/etc/test.post

[root@boston36 xCAT]# cat /install/custom/synclist
/etc/test -> /tmp/etc/test
/etc/test.post -> /tmp/test.post
EXECUTE:
/etc/test.post
[root@boston36 xCAT]# xdcp mid21tor24cn01 -v -T -F /install/custom/synclist
TRACE:Default context is XCAT.
TRACE:Fanout Value is 64.
TRACE:Timeout Value is .
TRACE:Verifying remaining targets with pping command.
 TRACE: Executing Command:/bin/sh -c /tmp/rsync_mid21tor24cn01

[root@boston36 xCAT]# touch /etc/test.post
[root@boston36 xCAT]# xdcp mid21tor24cn01 -v -T -F /install/custom/synclist
TRACE:Default context is XCAT.
TRACE:Fanout Value is 64.
TRACE:Timeout Value is .
TRACE:Verifying remaining targets with pping command.
 TRACE: Executing Command:/bin/sh -c /tmp/rsync_mid21tor24cn01

[root@boston36 xCAT]# touch /etc/test
[root@boston36 xCAT]# xdcp mid21tor24cn01 -v -T -F /install/custom/synclist
TRACE:Default context is XCAT.
TRACE:Fanout Value is 64.
TRACE:Timeout Value is .
TRACE:Verifying remaining targets with pping command.
 TRACE: Executing Command:/bin/sh -c /tmp/rsync_mid21tor24cn01
TRACE:Default context is XCAT
TRACE:Node RSH is
TRACE: Fanout value is 64.
TRACE: Timeout value is
TRACE: Verify value is
TRACE: Execute option specified.
TRACE:Execute: Exporting File:/usr/bin/scp -B /etc/test.post root@mid21tor24cn01:/tmp/Fb9lLdGrEN.dsh
Command name: /usr/bin/ssh -o BatchMode=yes -x root@mid21tor24cn01 export NODE=mid21tor24cn01; export LANG=en_US.UTF-8 LC_CTYPE="C" LC_NUMERIC="C" LC_TIME="C" LC_COLLATE="C" LC_MONETARY="C" LC_MESSAGES="C" LC_PAPER="C" LC_NAME="C" LC_ADDRESS="C" LC_TELEPHONE="C" LC_MEASUREMENT="C" LC_IDENTIFICATION="C" LC_ALL=C PERL_BADLANG=0 ;  /tmp/Fb9lLdGrEN.dsh ; export DSH_TARGET_RC=$?; echo ":DSH_TARGET_RC=${DSH_TARGET_RC}:";rm /tmp/Fb9lLdGrEN.dsh
[root@boston36 xCAT]#
```