### PR TITLE
refine some test cases

### DIFF
--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_flat_postscripts_failed
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_flat_postscripts_failed
@@ -41,7 +41,7 @@ cmd:chdef $$CN -p  postscripts=test
 check:rc==0
 cmd:lsdef -l $$CN
 check:rc==0
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat_postscripts_failed
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat_postscripts_failed
@@ -47,7 +47,7 @@ cmd:rm -rf /tmp/mountoutput
 cmd:packimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 

--- a/xCAT-test/autotest/testcase/xcatconfig/case0
+++ b/xCAT-test/autotest/testcase/xcatconfig/case0
@@ -94,7 +94,6 @@ cmd:rm -rf /tmp/xcatconfig.test
 check:rc==0
 end
 
-
 start:xcatconfig_c
 description:To regenerate cretials
 label:mn_only
@@ -117,7 +116,7 @@ check:rc!=0
 #step4:restore test environment
 cmd:rm -rf /tmp/xcatconfig.test
 check:rc==0
-cmd:mv -f /etc/xcat/cabak /etc/xcat/ca ;mv -f /etc/xcat/certbak /etc/xcat/cert
+cmd:rm -rf /etc/xcat/cabak /etc/xcat/certbak
 check:rc==0
 end
 

--- a/xCAT-test/autotest/testcase/xcatconfig/case0
+++ b/xCAT-test/autotest/testcase/xcatconfig/case0
@@ -118,6 +118,10 @@ cmd:rm -rf /tmp/xcatconfig.test
 check:rc==0
 cmd:rm -rf /etc/xcat/cabak /etc/xcat/certbak
 check:rc==0
+cmd:if lsdef service > /dev/null 2>&1; then updatenode service -P servicenode;fi
+check:rc==0
+cmd:if lsdef service > /dev/null 2>&1; then xdsh $$CN date;fi
+check:rc==0
 end
 
 start:xcatconfig_s


### PR DESCRIPTION
This Pr is to refine test case xcatconfig_c, reg_linux_diskless_installation_flat_postscripts_failed and reg_linux_diskfull_installation_flat_postscripts_failed.

The UT
```
------START::xcatconfig_c::Time:Fri Feb 15 01:29:27 2019------

RUN:cp -r /etc/xcat/ca /etc/xcat/cabak;cp -r /etc/xcat/cert /etc/xcat/certbak [Fri Feb 15 01:29:27 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:xcatconfig  -c 2>&1 | tee /tmp/xcatconfig.test [Fri Feb 15 01:29:27 2019]
ElapsedTime:6 sec
RETURN rc = 0
OUTPUT:

Setting up basic certificates.  Respond with a 'y' when prompted.

Existing xCAT certificate authority detected at /etc/xcat/ca, delete? (y/n):# NOTE use "-newkey rsa:2048" if running OpenSSL 0.9.8a or higher
Generating RSA private key, 2048 bit long modulus
...........+++
.............................................+++
.....

-----END CERTIFICATE REQUEST-----				-----END CERTIFICATE REQUEST-----
CHECK:rc != 0	[Pass]

RUN:rm -rf /tmp/xcatconfig.test [Fri Feb 15 01:29:33 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:rm -rf /etc/xcat/cabak /etc/xcat/certbak [Fri Feb 15 01:29:33 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::xcatconfig_c::Passed::Time:Fri Feb 15 01:29:33 2019 ::Duration::6 sec------
------Total: 1 , Failed: 0------
```