### PR TITLE
refine test case makedhcp_remote_network and add stop label

### DIFF
--- a/xCAT-test/autotest/testcase/makedhcp/cases0
+++ b/xCAT-test/autotest/testcase/makedhcp/cases0
@@ -194,6 +194,7 @@ end
 start:makedhcp_remote_network
 descriptiion:This case is to test when there is mgtifname='!remote!<nicname>', makedhcp could work correctly and create entrys in dhcp lease file.
 os:linux
+stop:yes
 label:mn_only,dhcp
 cmd:mkdef -t network -o testnetwork net=100.100.100.0 mask=255.255.255.0 mgtifname='!remote!eth0' gateway=100.100.100.1
 check:rc==0
@@ -213,7 +214,7 @@ cmd:if [ -f /var/lib/dhcpd/dhcpd.leases ]; then a="/var/lib/dhcpd/dhcpd.leases";
 cmd:makedhcp testnode
 check:rc==0
 cmd:if [ -f /var/lib/dhcpd/dhcpd.leases ]; then a="/var/lib/dhcpd/dhcpd.leases"; elif [ -f /var/lib/dhcp/db/dhcpd.leases ]; then a="/var/lib/dhcp/db/dhcpd.leases"; elif [ -f "/var/lib/dhcp/dhcpd.leases" ]; then a="/var/lib/dhcp/dhcpd.leases";fi; ls -l $a; cat $a
-cmd:a=2;while true; do [ $a -eq 64 ] && exit 1;output=$(makedhcp -q testnode);[ $? -ne 0 ] && exit 1;echo $output|grep testnode 2>/dev/null && exit 0;a=$[$a*2];sleep $a;done
+cmd:a=2;while true; do [ $a -eq 64 ] && exit 1;output=$(makedhcp -q testnode);[ $? -ne 0 ] && exit 1;echo $output|grep testnode 2>/dev/null && exit 0;a=$[$a*2]; makedhcp testnode; sleep $a;done
 check:rc==0
 check:output=~testnode: ip-address = 100.100.100.2
 cmd:makedhcp -d testnode


### PR DESCRIPTION
### The PR is to refine test case ``makedhcp_remote_network`` and add stop label

### The modification include

* add stop label for test case ``makedhcp_remote_network``

* refine case  ``makedhcp_remote_network``. 

### The UT result

```
------START::makedhcp_remote_network::Time:Mon Feb 18 01:29:06 2019------

RUN:mkdef -t network -o testnetwork net=100.100.100.0 mask=255.255.255.0 mgtifname='!remote!eth0' gateway=100.100.100.1 [Mon Feb 18 01:29:06 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:lsdef -t network [Mon Feb 18 01:29:06 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
10_0_0_0-255_0_0_0  (network)
testnetwork  (network)
CHECK:rc == 0	[Pass]
CHECK:output =~ testnetwork	[Pass]

RUN:mkdef -t node -o testnode ip=100.100.100.2 groups=all mac=42:3d:0a:05:27:0b [Mon Feb 18 01:29:07 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:cat /etc/hosts [Mon Feb 18 01:29:07 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
10.3.17.2 c910f03c17 c910f03c17.pok.stglabs.ibm.com
10.3.17.6 c910f03c17k06 c910f03c17k06.pok.stglabs.ibm.com
.....
10.3.11.12 c910f03c11k12 c910f03c11k12.pok.stglabs.ibm.com

RUN:echo -e "\n100.100.100.2 testnode" >> /etc/hosts [Mon Feb 18 01:29:07 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:cat /etc/hosts [Mon Feb 18 01:29:07 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
10.3.17.2 c910f03c17 c910f03c17.pok.stglabs.ibm.com
....
10.3.11.12 c910f03c11k12 c910f03c11k12.pok.stglabs.ibm.com

100.100.100.2 testnode

RUN:makedhcp -n [Mon Feb 18 01:29:07 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Warning: [c910f03c17k25]: No dynamic range specified for 10.0.0.0. If hardware discovery is being used, a dynamic range is required.
Warning: [c910f03c17k25]: No dynamic range specified for 50.0.0.0. If hardware discovery is being used, a dynamic range is required.
Renamed existing dhcp configuration file to  /etc/dhcp/dhcpd.conf.xcatbak

CHECK:rc == 0	[Pass]

RUN:makedhcp -d testnode [Mon Feb 18 01:29:08 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:if [ -f /var/lib/dhcpd/dhcpd.leases ]; then a="/var/lib/dhcpd/dhcpd.leases"; elif [ -f /var/lib/dhcp/db/dhcpd.leases ]; then a="/var/lib/dhcp/db/dhcpd.leases"; elif [ -f "/var/lib/dhcp/dhcpd.leases" ]; then a="/var/lib/dhcp/dhcpd.leases";fi; ls -l $a; cat $a [Mon Feb 18 01:29:08 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
-rw-r--r-- 1 dhcpd dhcpd 3733 Feb 18 01:29 /var/lib/dhcpd/dhcpd.leases
# The format of this file is documented in the dhcpd.leases(5) manual page.
# This lease file was written by isc-dhcp-4.2.5

host f6u13k10-noip42ae0a060d0a {
  dynamic;
  hardware ethernet 42:ae:0a:06:0d:0a;
  uid 42:ae:0a:06:0d:0a;
        supersede server.allow-booting = 00;
}
.....
server-duid "\000\001\000\001#O;JB\273\012\003\021\031";


RUN:makedhcp testnode [Mon Feb 18 01:29:08 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:if [ -f /var/lib/dhcpd/dhcpd.leases ]; then a="/var/lib/dhcpd/dhcpd.leases"; elif [ -f /var/lib/dhcp/db/dhcpd.leases ]; then a="/var/lib/dhcp/db/dhcpd.leases"; elif [ -f "/var/lib/dhcp/dhcpd.leases" ]; then a="/var/lib/dhcp/dhcpd.leases";fi; ls -l $a; cat $a [Mon Feb 18 01:29:09 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
-rw-r--r-- 1 dhcpd dhcpd 3952 Feb 18 01:29 /var/lib/dhcpd/dhcpd.leases
# The format of this file is documented in the dhcpd.leases(5) manual page.
# This lease file was written by isc-dhcp-4.2.5

host f6u13k10-noip42ae0a060d0a {
.....
server-duid "\000\001\000\001#O;JB\273\012\003\021\031";

host testnode {
  dynamic;
  hardware ethernet 42:3d:0a:05:27:0b;
  uid 42:3d:0a:05:27:0b;
  fixed-address 100.100.100.2;
        supersede server.ddns-hostname = "testnode";
        supersede host-name = "testnode";
}

RUN:a=2;while true; do [ $a -eq 64 ] && exit 1;output=$(makedhcp -q testnode);[ $? -ne 0 ] && exit 1;echo $output|grep testnode 2>/dev/null && exit 0;a=$[$a*2]; makedhcp testnode; sleep $a;done [Mon Feb 18 01:29:09 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
testnode: ip-address = 100.100.100.2, hardware-address = 42:3d:0a:05:27:0b
CHECK:rc == 0	[Pass]
CHECK:output =~ testnode: ip-address = 100.100.100.2	[Pass]

RUN:makedhcp -d testnode [Mon Feb 18 01:29:09 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:makedhcp -n [Mon Feb 18 01:29:09 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Warning: [c910f03c17k25]: No dynamic range specified for 10.0.0.0. If hardware discovery is being used, a dynamic range is required.
Warning: [c910f03c17k25]: No dynamic range specified for 50.0.0.0. If hardware discovery is being used, a dynamic range is required.
Renamed existing dhcp configuration file to  /etc/dhcp/dhcpd.conf.xcatbak

CHECK:rc == 0	[Pass]

RUN:noderm testnode [Mon Feb 18 01:29:10 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:chtab -d netname=testnetwork networks [Mon Feb 18 01:29:10 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:cp -f /etc/hosts.bak /etc/hosts [Mon Feb 18 01:29:11 2019]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
cp: cannot stat '/etc/hosts.bak': No such file or directory

------END::makedhcp_remote_network::Passed::Time:Mon Feb 18 01:29:11 2019 ::Duration::5 sec------
```