### PR TITLE
refine test case run_command_with_XCATBYPASS for task #603

### DIFF
--- a/xCAT-test/autotest/testcase/xcatd/case0
+++ b/xCAT-test/autotest/testcase/xcatd/case0
@@ -104,9 +104,9 @@ check:rc==0
 cmd:service xcatd stop
 check:rc==0
 cmd:sleep 3
+cmd:ps aux|grep -v grep|grep xcatd
+check:rc!=0
 cmd:service xcatd status
-check:output=~xcatd service|xcatd.service
-check:output=~xcatd service is not running|inactive \(dead\)
 cmd:tabdump site
 check:rc!=0
 cmd:XCATBYPASS=YES tabdump site

--- a/xCAT-test/autotest/testcase/xcatd/case0
+++ b/xCAT-test/autotest/testcase/xcatd/case0
@@ -104,8 +104,10 @@ check:rc==0
 cmd:service xcatd stop
 check:rc==0
 cmd:sleep 3
-cmd:ps aux|grep -v grep|grep xcatd
+cmd:ps aux|tee /tmp/run_command_with_XCATBYPASS.log
+cmd:awk '{print $11}' /tmp/run_command_with_XCATBYPASS.log|grep -E ^xcatd
 check:rc!=0
+cmd:rm -rf /tmp/run_command_with_XCATBYPASS.log
 cmd:service xcatd status
 cmd:tabdump site
 check:rc!=0


### PR DESCRIPTION
### The PR is for task https://github.com/xcat2/xcat2-task-management/issues/603

### The modification include

* refine the check method of test case ``run_command_with_XCATBYPASS``

### The UT result

```
------START::run_command_with_XCATBYPASS::Time:Tue Feb 19 03:18:12 2019------

RUN:service xcatd status [Tue Feb 19 03:18:12 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
● xcatd.service - xCAT management service
   Loaded: loaded (/lib/systemd/system/xcatd.service; enabled; vendor preset: enabled)
   Active: active (running) since Tue 2019-02-19 03:16:44 EST; 1min 27s ago
  Process: 23004 ExecStop=/etc/init.d/xcatd stop (code=exited, status=0/SUCCESS)
  Process: 23129 ExecStart=/etc/init.d/xcatd start (code=exited, status=0/SUCCESS)
 Main PID: 23186 (xcatd: SSL list)
    Tasks: 7 (limit: 4730)
   CGroup: /system.slice/xcatd.service
           ├─23179 /usr/sbin/in.tftpd -v -l -s /tftpboot -m /etc/tftpmapfile4xcat.conf
           ├─23186 xcatd: SSL listener
           ├─23187 xcatd: DB Access
           ├─23188 xcatd: UDP listener
           ├─23189 xcatd: install monitor
           ├─23190 xcatd: Command log writer
           └─23191 xcatd: Discovery worker

Feb 19 03:16:42 f6u13k13 xcatd[23129]: when is experimental at /opt/xcat/lib/perl/xCAT_plugin/kvm.pm line 3577.
Feb 19 03:16:42 f6u13k13 xcatd[23129]: when is experimental at /opt/xcat/lib/perl/xCAT_plugin/kvm.pm line 3579.
Feb 19 03:16:43 f6u13k13 xcatd[23129]: Smartmatch is experimental at /opt/xcat/lib/perl/xCAT/OPENBMC.pm line 95.
Feb 19 03:16:43 f6u13k13 xcatd[23129]: Smartmatch is experimental at /opt/xcat/lib/perl/xCAT_plugin/openbmc.pm line 1233.
Feb 19 03:16:44 f6u13k13 xcat[23190]: xcatd: Command log writer process 23190 start
Feb 19 03:16:44 f6u13k13 xcat[23189]: xcatd: install monitor process 23189 start
Feb 19 03:16:44 f6u13k13 xcat[23188]: xcatd: UDP listener process 23188 start
Feb 19 03:16:44 f6u13k13 xcat[23191]: xcatd: Discovery worker process 23191 start
Feb 19 03:16:44 f6u13k13 xcatd[23129]:  *
Feb 19 03:16:44 f6u13k13 systemd[1]: Started xCAT management service.
CHECK:rc == 0	[Pass]
CHECK:output =~ xcatd service|xcatd.service	[Pass]
CHECK:output =~ xcatd service is running|active \(running\)	[Pass]

RUN:XCATBYPASS=YES tabdump site [Tue Feb 19 03:18:12 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
given is experimental at /opt/xcat/lib/perl/xCAT_plugin/kvm.pm line 3564.
when is experimental at /opt/xcat/lib/perl/xCAT_plugin/kvm.pm line 3565.
when is experimental at /opt/xcat/lib/perl/xCAT_plugin/kvm.pm line 3567.
when is experimental at /opt/xcat/lib/perl/xCAT_plugin/kvm.pm line 3569.
when is experimental at /opt/xcat/lib/perl/xCAT_plugin/kvm.pm line 3571.
when is experimental at /opt/xcat/lib/perl/xCAT_plugin/kvm.pm line 3573.
when is experimental at /opt/xcat/lib/perl/xCAT_plugin/kvm.pm line 3575.
when is experimental at /opt/xcat/lib/perl/xCAT_plugin/kvm.pm line 3577.
when is experimental at /opt/xcat/lib/perl/xCAT_plugin/kvm.pm line 3579.
Smartmatch is experimental at /opt/xcat/lib/perl/xCAT/OPENBMC.pm line 95.
Smartmatch is experimental at /opt/xcat/lib/perl/xCAT_plugin/openbmc.pm line 1233.
#key,value,comments,disable
"blademaxp","64",,
"fsptimeout","0",,
"installdir","/install",,
"ipmimaxp","64",,
"ipmiretries","3",,
"ipmitimeout","2",,
"consoleondemand","no",,
"master","10.6.13.13",,
"forwarders","10.0.0.103",,
"nameservers","10.6.13.13",,
"maxssh","8",,
"ppcmaxp","64",,
"ppcretry","3",,
"ppctimeout","0",,
"powerinterval","0",,
"syspowerinterval","0",,
"sharedtftp","1",,
"SNsyncfiledir","/tmp",,
"nodesyncfiledir","/var/xcat/node/syncfiles",,
"tftpdir","/tftpboot",,
"xcatdport","3001",,
"xcatiport","3002",,
"xcatconfdir","/etc/xcat",,
"timezone","America/New_York",,
"useNmapfromMN","no",,
"enableASMI","no",,
"db2installloc","/mntdb2",,
"databaseloc","/var/lib",,
"sshbetweennodes","ALLGROUPS",,
"dnshandler","ddns",,
"vsftp","n",,
"cleanupxcatpost","no",,
"dhcplease","43200",,
"auditnosyslog","0",,
"xcatsslversion","TLSv1",,
"auditskipcmds","ALL",,
"domain","pok.stglabs.ibm.com",,
"ntpservers","<xcatmaster>",,
"rsh_test","/opt/xcat/bin/scp,/opt/xcat/bin/rcp","the rcp command",
"skiptables",,,
CHECK:rc == 0	[Pass]

RUN:service xcatd stop [Tue Feb 19 03:18:13 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:sleep 3 [Tue Feb 19 03:18:15 2019]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:

RUN:ps aux|tee /tmp/run_command_with_XCATBYPASS.log [Tue Feb 19 03:18:18 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         1  0.0  0.3 169088 14400 ?        Ss   Feb18   0:16 /sbin/init
root         2  0.0  0.0      0     0 ?        S    Feb18   0:00 [kthreadd]
root         4  0.0  0.0      0     0 ?        I<   Feb18   0:00 [kworker/0:0H]
root         6  0.0  0.0      0     0 ?        I<   Feb18   0:00 [mm_percpu_wq]
root         7  0.0  0.0      0     0 ?        S    Feb18   0:06 [ksoftirqd/0]
root         8  0.0  0.0      0     0 ?        I    Feb18   0:03 [rcu_sched]
root         9  0.0  0.0      0     0 ?        I    Feb18   0:00 [rcu_bh]
root        10  0.0  0.0      0     0 ?        S    Feb18   0:00 [migration/0]
root        11  0.0  0.0      0     0 ?        S    Feb18   0:00 [watchdog/0]
root        12  0.0  0.0      0     0 ?        S    Feb18   0:00 [cpuhp/0]
root        13  0.0  0.0      0     0 ?        S    Feb18   0:00 [cpuhp/1]
root        14  0.0  0.0      0     0 ?        S    Feb18   0:00 [watchdog/1]
root        15  0.0  0.0      0     0 ?        S    Feb18   0:00 [migration/1]
root        16  0.0  0.0      0     0 ?        S    Feb18   0:06 [ksoftirqd/1]
root        18  0.0  0.0      0     0 ?        I<   Feb18   0:00 [kworker/1:0H]
root        19  0.0  0.0      0     0 ?        S    Feb18   0:00 [kdevtmpfs]
root        20  0.0  0.0      0     0 ?        I<   Feb18   0:00 [netns]
root        21  0.0  0.0      0     0 ?        S    Feb18   0:00 [rcu_tasks_kthre]
root        22  0.0  0.0      0     0 ?        S    Feb18   0:00 [eehd]
root        23  0.0  0.0      0     0 ?        S    Feb18   0:00 [kauditd]
root        25  0.0  0.0      0     0 ?        S    Feb18   0:00 [khungtaskd]
root        26  0.0  0.0      0     0 ?        S    Feb18   0:00 [oom_reaper]
root        27  0.0  0.0      0     0 ?        I<   Feb18   0:00 [writeback]
root        28  0.0  0.0      0     0 ?        S    Feb18   0:00 [kcompactd0]
root        29  0.0  0.0      0     0 ?        SN   Feb18   0:00 [ksmd]
root        30  0.0  0.0      0     0 ?        SN   Feb18   0:00 [khugepaged]
root        31  0.0  0.0      0     0 ?        I<   Feb18   0:00 [crypto]
root        32  0.0  0.0      0     0 ?        I<   Feb18   0:00 [kintegrityd]
root        33  0.0  0.0      0     0 ?        I<   Feb18   0:00 [kblockd]
root        34  0.0  0.0      0     0 ?        I<   Feb18   0:00 [ata_sff]
root        35  0.0  0.0      0     0 ?        I<   Feb18   0:00 [md]
root        36  0.0  0.0      0     0 ?        I<   Feb18   0:00 [edac-poller]
root        37  0.0  0.0      0     0 ?        I<   Feb18   0:00 [devfreq_wq]
root        38  0.0  0.0      0     0 ?        I<   Feb18   0:00 [watchdogd]
root        41  0.0  0.0      0     0 ?        S    Feb18   0:02 [kswapd0]
root        42  0.0  0.0      0     0 ?        S    Feb18   0:00 [ecryptfs-kthrea]
root        84  0.0  0.0      0     0 ?        I<   Feb18   0:00 [kthrotld]
root        85  0.0  0.0      0     0 ?        S    Feb18   0:00 [khvcd]
root        87  0.0  0.0      0     0 ?        I<   Feb18   0:00 [vfio-irqfd-clea]
root        88  0.0  0.0      0     0 ?        I<   Feb18   0:00 [ipv6_addrconf]
root        97  0.0  0.0      0     0 ?        I<   Feb18   0:00 [kstrp]
root       114  0.0  0.0      0     0 ?        I<   Feb18   0:00 [charger_manager]
root       152  0.0  0.0      0     0 ?        S    Feb18   0:00 [scsi_eh_0]
root       153  0.0  0.0      0     0 ?        I<   Feb18   0:00 [scsi_tmf_0]
root       154  0.0  0.0      0     0 ?        S<   Feb18   0:00 [ibmvscsi_0]
root       160  0.0  0.0      0     0 ?        I<   Feb18   0:05 [kworker/1:1H]
root       163  0.0  0.0      0     0 ?        I<   Feb18   0:02 [kworker/0:1H]
root       183  0.0  0.0      0     0 ?        S    Feb18   0:18 [jbd2/sda2-8]
root       184  0.0  0.0      0     0 ?        I<   Feb18   0:00 [ext4-rsv-conver]
root       217  0.0  1.6 100544 66816 ?        S<s  Feb18   0:06 /lib/systemd/systemd-journald
root       237  0.0  0.1  20416  7552 ?        Ss   Feb18   0:00 /lib/systemd/systemd-udevd
root       238  0.0  0.0      0     0 ?        I<   Feb18   0:00 [rpciod]
root       239  0.0  0.0      0     0 ?        I<   Feb18   0:00 [xprtiod]
systemd+   243  0.0  0.2  27456  9280 ?        Ss   Feb18   0:00 /lib/systemd/systemd-networkd
root       266  0.0  0.1  11008  5824 ?        Ss   Feb18   0:00 /sbin/rpcbind -f -w
systemd+   267  0.0  0.2  18368 11136 ?        Ss   Feb18   0:00 /lib/systemd/systemd-resolved
root       646  0.0  0.1  85120  5824 ?        Ssl  Feb18   0:00 /usr/sbin/irqbalance --foreground
root       649  0.0  0.1   8448  5056 ?        Ss   Feb18   0:00 /usr/sbin/cron -f
root       651  0.0  0.2 240320  9152 ?        Ssl  Feb18   0:01 /usr/lib/accountsservice/accounts-daemon
message+   652  0.0  0.1  11840  7360 ?        Ss   Feb18   0:02 /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only
root       654  0.0  0.0  85184   512 ?        Ss   Feb18   0:00 /sbin/iprdump --daemon
root       660  0.0  0.4 109312 17856 ?        Ssl  Feb18   0:00 /usr/bin/python3 /usr/bin/networkd-dispatcher --run-startup-triggers
root       661  0.0  0.2  17280 10176 ?        Ss   Feb18   0:00 /lib/systemd/systemd-logind
root       693  0.0  0.0   3456   576 ?        Ss   Feb18   0:00 /sbin/iprupdate --daemon
root       695  0.0  0.0   3456  2304 ?        Ss   Feb18   0:00 /sbin/iprinit --daemon
root       740  0.0  0.0   6144  3200 hvc0     Ss+  Feb18   0:00 /sbin/agetty -o -p -- \u --keep-baud 115200,38400,9600 hvc0 vt220
root       741  0.0  0.1   7552  4416 ?        Ss   Feb18   0:00 /usr/sbin/rtas_errd
root       756  0.0  0.0   6464  2944 tty1     Ss+  Feb18   0:00 /sbin/agetty -o -p -- \u --noclear tty1 linux
root       758  0.0  0.2  17152  8640 ?        Ss   Feb18   0:00 /usr/sbin/sshd -D
root      1290  0.0  0.0      0     0 ?        I<   Feb18   0:00 [nfsiod]
root      1303  0.0  0.0      0     0 ?        S    Feb18   0:00 [NFSv4 callback]
root      8003  0.0  0.0      0     0 ?        I    Feb18   0:00 [kworker/1:2]
_chrony   8014  0.0  0.1  82304  6208 ?        S    Feb18   0:01 /usr/sbin/chronyd
root      8264  0.0  0.1   6400  4416 ?        Ss   Feb18   0:00 /usr/sbin/xinetd -pidfile /run/xinetd.pid -stayalive -inetd_compat -inetd_ipv6
daemon    8927  0.0  0.1   6464  4352 ?        Ss   Feb18   0:00 /usr/sbin/atd -f
dhcpd    19644  0.0  0.4  21184 18112 ?        Ss   Feb18   0:00 dhcpd -user dhcpd -group dhcpd -f -4 -pf /run/dhcp-server/dhcpd.pid -cf /etc/dhcp/dhcpd.conf enp0s1
bind     19696  0.0  0.7 236032 31104 ?        Ssl  Feb18   0:00 /usr/sbin/named -f -u bind
root     21340  0.0  0.0  81024  2624 ?        Ss   Feb18   0:00 /sbin/lvmetad -f
root     21527  0.0  0.0      0     0 ?        I    00:40   0:00 [kworker/u4:1]
root     21705  0.0  0.3  21312 15744 ?        Ss   01:31   0:00 sshd: root@pts/3
root     21707  0.0  0.3  20096 13440 ?        Ss   01:31   0:00 /lib/systemd/systemd --user
root     21708  0.0  0.0   5632  1664 ?        Ss   Feb18   0:00 /usr/sbin/rpc.idmapd
root     21709  0.0  0.1  11264  5888 ?        Ss   Feb18   0:00 /usr/sbin/rpc.mountd --manage-gids
root     21710  0.0  0.2 172608  9024 ?        S    01:31   0:00 (sd-pam)
root     21712  0.0  0.0      0     0 ?        S    Feb18   0:00 [lockd]
root     21714  0.0  0.0      0     0 ?        S    Feb18   0:00 [nfsd]
root     21715  0.0  0.0      0     0 ?        S    Feb18   0:00 [nfsd]
root     21716  0.0  0.0      0     0 ?        S    Feb18   0:00 [nfsd]
root     21717  0.0  0.0      0     0 ?        S    Feb18   0:00 [nfsd]
root     21718  0.0  0.0      0     0 ?        S    Feb18   0:00 [nfsd]
root     21719  0.0  0.0      0     0 ?        S    Feb18   0:00 [nfsd]
root     21720  0.0  0.0      0     0 ?        S    Feb18   0:00 [nfsd]
root     21721  0.0  0.0      0     0 ?        S    Feb18   0:00 [nfsd]
root     21752  0.0  0.1   9920  7680 pts/3    Ss   01:31   0:00 -bash
root     21974  0.0  0.0      0     0 ?        I    01:33   0:00 [kworker/1:0]
root     22674  0.0  0.0      0     0 ?        I    01:57   0:00 [kworker/0:1]
root     22795  0.0  0.0      0     0 ?        I    02:10   0:00 [kworker/u4:2]
root     22923  0.0  0.0      0     0 ?        I    02:52   0:00 [kworker/0:0]
root     22964  0.0  0.0      0     0 ?        I    03:16   0:00 [kworker/u4:0]
root     23082  0.0  0.0      0     0 ?        I    03:16   0:00 [kworker/0:2]
root     23213  6.0  0.3  16384 13120 pts/3    S+   03:18   0:00 perl /opt/xcat/bin/xcattest -t run_command_with_XCATBYPASS
root     23330  0.0  0.0      0     0 ?        I    03:18   0:00 [kworker/1:1]
root     23331  0.0  0.1   7744  4544 pts/3    S+   03:18   0:00 sh -c ps aux|tee /tmp/run_command_with_XCATBYPASS.log 2>&1
root     23332  0.0  0.1  11072  6208 pts/3    R+   03:18   0:00 ps aux
root     23333  0.0  0.0   5312  1408 pts/3    S+   03:18   0:00 tee /tmp/run_command_with_XCATBYPASS.log
root     24278  0.0  0.2  14208 11200 ?        Ss   Feb18   0:00 /usr/sbin/apache2 -k start
www-data 24280  0.0  0.4 1225664 19072 ?       Sl   Feb18   0:01 /usr/sbin/apache2 -k start
www-data 24281  0.0  0.4 1225664 19136 ?       Sl   Feb18   0:01 /usr/sbin/apache2 -k start
syslog   25892  0.0  0.2 382208  9664 ?        Ssl  Feb18   0:01 /usr/sbin/rsyslogd -n

RUN:awk '{print $11}' /tmp/run_command_with_XCATBYPASS.log|grep -E ^xcatd [Tue Feb 19 03:18:18 2019]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
CHECK:rc != 0	[Pass]

RUN:rm -rf /tmp/run_command_with_XCATBYPASS.log [Tue Feb 19 03:18:18 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:service xcatd status [Tue Feb 19 03:18:18 2019]
ElapsedTime:0 sec
RETURN rc = 3
OUTPUT:
● xcatd.service - xCAT management service
   Loaded: loaded (/lib/systemd/system/xcatd.service; enabled; vendor preset: enabled)
   Active: inactive (dead) since Tue 2019-02-19 03:18:15 EST; 3s ago
  Process: 23251 ExecStop=/etc/init.d/xcatd stop (code=exited, status=0/SUCCESS)
  Process: 23129 ExecStart=/etc/init.d/xcatd start (code=exited, status=0/SUCCESS)
 Main PID: 23186 (code=exited, status=0/SUCCESS)

Feb 19 03:16:44 f6u13k13 xcat[23191]: xcatd: Discovery worker process 23191 start
Feb 19 03:16:44 f6u13k13 xcatd[23129]:  *
Feb 19 03:16:44 f6u13k13 systemd[1]: Started xCAT management service.
Feb 19 03:18:14 f6u13k13 systemd[1]: Stopping xCAT management service...
Feb 19 03:18:14 f6u13k13 xcat[23189]: xcatd install monitor 23189 quiescing
Feb 19 03:18:14 f6u13k13 xcat[23186]: xcatd is going to stop, waiting for 0 plugins to quit...
Feb 19 03:18:14 f6u13k13 xcat[23188]: xcatd udp service 23188 quiescing
Feb 19 03:18:14 f6u13k13 xcat[23190]: xcatd: 'Command log writer' process 23190 is terminated by TERM or INT signal
Feb 19 03:18:15 f6u13k13 xcatd[23251]: Stopping xcatd  *
Feb 19 03:18:15 f6u13k13 systemd[1]: Stopped xCAT management service.

RUN:tabdump site [Tue Feb 19 03:18:18 2019]
ElapsedTime:0 sec
RETURN rc = 111
OUTPUT:
Connection failure: IO::Socket::INET: connect: Connection refused at /opt/xcat/lib/perl/xCAT/Client.pm line 248.
Unable to open socket connection to xcatd daemon on localhost:3001.
Verify that the xcatd daemon is running and that your SSL setup is correct.
CHECK:rc != 0	[Pass]

RUN:XCATBYPASS=YES tabdump site [Tue Feb 19 03:18:18 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
given is experimental at /opt/xcat/lib/perl/xCAT_plugin/kvm.pm line 3564.
when is experimental at /opt/xcat/lib/perl/xCAT_plugin/kvm.pm line 3565.
when is experimental at /opt/xcat/lib/perl/xCAT_plugin/kvm.pm line 3567.
when is experimental at /opt/xcat/lib/perl/xCAT_plugin/kvm.pm line 3569.
when is experimental at /opt/xcat/lib/perl/xCAT_plugin/kvm.pm line 3571.
when is experimental at /opt/xcat/lib/perl/xCAT_plugin/kvm.pm line 3573.
when is experimental at /opt/xcat/lib/perl/xCAT_plugin/kvm.pm line 3575.
when is experimental at /opt/xcat/lib/perl/xCAT_plugin/kvm.pm line 3577.
when is experimental at /opt/xcat/lib/perl/xCAT_plugin/kvm.pm line 3579.
Smartmatch is experimental at /opt/xcat/lib/perl/xCAT/OPENBMC.pm line 95.
Smartmatch is experimental at /opt/xcat/lib/perl/xCAT_plugin/openbmc.pm line 1233.
#key,value,comments,disable
"blademaxp","64",,
"fsptimeout","0",,
"installdir","/install",,
"ipmimaxp","64",,
"ipmiretries","3",,
"ipmitimeout","2",,
"consoleondemand","no",,
"master","10.6.13.13",,
"forwarders","10.0.0.103",,
"nameservers","10.6.13.13",,
"maxssh","8",,
"ppcmaxp","64",,
"ppcretry","3",,
"ppctimeout","0",,
"powerinterval","0",,
"syspowerinterval","0",,
"sharedtftp","1",,
"SNsyncfiledir","/tmp",,
"nodesyncfiledir","/var/xcat/node/syncfiles",,
"tftpdir","/tftpboot",,
"xcatdport","3001",,
"xcatiport","3002",,
"xcatconfdir","/etc/xcat",,
"timezone","America/New_York",,
"useNmapfromMN","no",,
"enableASMI","no",,
"db2installloc","/mntdb2",,
"databaseloc","/var/lib",,
"sshbetweennodes","ALLGROUPS",,
"dnshandler","ddns",,
"vsftp","n",,
"cleanupxcatpost","no",,
"dhcplease","43200",,
"auditnosyslog","0",,
"xcatsslversion","TLSv1",,
"auditskipcmds","ALL",,
"domain","pok.stglabs.ibm.com",,
"ntpservers","<xcatmaster>",,
"rsh_test","/opt/xcat/bin/scp,/opt/xcat/bin/rcp","the rcp command",
"skiptables",,,
CHECK:rc == 0	[Pass]

RUN:service xcatd start [Tue Feb 19 03:18:20 2019]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:service xcatd status [Tue Feb 19 03:18:23 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
● xcatd.service - xCAT management service
   Loaded: loaded (/lib/systemd/system/xcatd.service; enabled; vendor preset: enabled)
   Active: active (running) since Tue 2019-02-19 03:18:23 EST; 14ms ago
  Process: 23251 ExecStop=/etc/init.d/xcatd stop (code=exited, status=0/SUCCESS)
  Process: 23377 ExecStart=/etc/init.d/xcatd start (code=exited, status=0/SUCCESS)
 Main PID: 23434 (xcatd: SSL list)
    Tasks: 9 (limit: 4730)
   CGroup: /system.slice/xcatd.service
           ├─23427 /usr/sbin/in.tftpd -v -l -s /tftpboot -m /etc/tftpmapfile4xcat.conf
           ├─23434 xcatd: SSL listener
           ├─23435 xcatd: DB Access
           ├─23436 xcatd: UDP listener
           ├─23437 xcatd: install monitor
           ├─23438 xcatd: Command log writer
           └─23439 xcatd: Discovery worker

Feb 19 03:18:22 f6u13k13 xcatd[23377]: when is experimental at /opt/xcat/lib/perl/xCAT_plugin/kvm.pm line 3577.
Feb 19 03:18:22 f6u13k13 xcatd[23377]: when is experimental at /opt/xcat/lib/perl/xCAT_plugin/kvm.pm line 3579.
Feb 19 03:18:22 f6u13k13 xcatd[23377]: Smartmatch is experimental at /opt/xcat/lib/perl/xCAT/OPENBMC.pm line 95.
Feb 19 03:18:22 f6u13k13 xcatd[23377]: Smartmatch is experimental at /opt/xcat/lib/perl/xCAT_plugin/openbmc.pm line 1233.
Feb 19 03:18:23 f6u13k13 xcat[23438]: xcatd: Command log writer process 23438 start
Feb 19 03:18:23 f6u13k13 xcat[23437]: xcatd: install monitor process 23437 start
Feb 19 03:18:23 f6u13k13 xcat[23436]: xcatd: UDP listener process 23436 start
Feb 19 03:18:23 f6u13k13 xcat[23439]: xcatd: Discovery worker process 23439 start
Feb 19 03:18:23 f6u13k13 xcatd[23377]:  *
Feb 19 03:18:23 f6u13k13 systemd[1]: Started xCAT management service.
CHECK:rc == 0	[Pass]
CHECK:output =~ xcatd service|xcatd.service	[Pass]
CHECK:output =~ xcatd service is running|active \(running\)	[Pass]

------END::run_command_with_XCATBYPASS::Passed::Time:Tue Feb 19 03:18:23 2019 ::Duration::11 sec------
```