### PR TITLE
refine test case makehost_n_r for task #604

### DIFF
--- a/xCAT-test/autotest/testcase/makehosts/cases0
+++ b/xCAT-test/autotest/testcase/makehosts/cases0
@@ -141,6 +141,7 @@ start:makehost_n_r
 label:mn_only,dns,wait_fix
 descriptions:modify makehosts testcases according to special node name eg:s01 and s01r* . for issue #2717 and #2683
 cmd:cp -f /etc/hosts /etc/hosts.xcatbakautotest
+cmd:sed -i '/s01/d' /etc/hosts
 cmd:cat /etc/hosts
 cmd:lsdef s01;if [ $? -eq 0 ]; then lsdef -l s01 -z >/tmp/s01.standa ;rmdef s01;fi
 check:rc==0
@@ -149,56 +150,65 @@ check:rc==0
 cmd:nodeadd s01 groups=service; chdef s01 ip=70.2.0.254;nodeadd s01r1b01 groups=compute; chdef s01r1b01 ip=80.2.0.254
 check:rc==0
 cmd:lsdef -l s01,s01r1b01
-cmd:makehosts || XCATBYPASS=YES makehosts
+cmd:makehosts 
 check:rc==0
-cmd:cat /etc/hosts
 cmd:#!/bin/bash
 file="/etc/hosts"
-for i in {1..5}; do
-    if (grep "70.2.0.254 s01" $file >/dev/null 2>&1) && (grep "80.2.0.254 s01r1b01" $file >/dev/null 2>&1); then
-        exit 0;
-    else
-        echo "Do not find s01 and s01r1b01 in $file, sleep $[i*2] seconds and try again"
-        sleep $[i*2]
-    fi
-done
-exit 1
+if (! grep "s01" $file 2>&1); then
+    echo "makehosts failed, try XCATBYPASS=YES makehosts again"
+    XCATBYPASS=YES makehosts    
+    if (! grep "s01" $file 2>&1); then
+        echo "XCATBYPASS=YES makehosts failed either"
+        exit 1
+    fi 
+fi 
+if (grep "70.2.0.254 s01" $file >/dev/null 2>&1) && (grep "80.2.0.254 s01r1b01" $file >/dev/null 2>&1); then
+    exit 0
+else
+    exit 1
+fi
 check:rc==0
-cmd:cp -f /etc/hosts.xcatbakautotest /etc/hosts
-cmd:makehosts s01 || XCATBYPASS=YES makehosts s01
+cmd:sed -i '/s01/d' /etc/hosts
+cmd:makehosts s01 
 check:rc==0
-cmd:cat /etc/hosts
 cmd:#!/bin/bash
 file="/etc/hosts"
-for i in {1..5}; do
-    if (grep "70.2.0.254 s01" $file >/dev/null 2>&1) && ( ! grep "80.2.0.254 s01r1b01" $file >/dev/null 2>&1); then
-        exit 0;
-    else
-        echo "sleep $[i*2] seconds and try again"
-        sleep $[i*2]
+if (! grep "s01 " $file 2>&1); then
+    echo "makehosts s01 failed, try XCATBYPASS=YES makehosts s01 again"
+    XCATBYPASS=YES makehosts s01
+    if (! grep "s01 " $file 2>&1); then
+         echo "XCATBYPASS=YES makehosts s01 failed either"
+         exit 1
     fi
-done
-exit 1
+fi
+if (grep "70.2.0.254 s01" $file >/dev/null 2>&1) && ( ! grep "80.2.0.254 s01r1b01" $file >/dev/null 2>&1); then
+    exit 0;
+else
+    exit 1
+fi
 check:rc==0
-cmd:cp -f /etc/hosts.xcatbakautotest /etc/hosts
-cmd:makehosts service || XCATBYPASS=YES makehosts service
+cmd:sed -i '/s01/d' /etc/hosts
+cmd:makehosts service 
 check:rc==0
-cmd:cat /etc/hosts
 cmd:#!/bin/bash
 file="/etc/hosts"
-for i in {1..5}; do
-    if (grep "70.2.0.254 s01" $file >/dev/null 2>&1) && (! grep "80.2.0.254 s01r1b01" $file >/dev/null 2>&1); then
-        exit 0;
-    else
-        echo "sleep $[i*2] seconds and try again"
-        sleep $[i*2]
-    fi
-done
-exit 1
+if (! grep "s01 " $file 2>&1); then
+     echo "makehosts service failed, try XCATBYPASS=YES makehosts service again"
+     XCATBYPASS=YES makehosts service
+     if (! grep "s01 " $file 2>&1); then
+         echo "XCATBYPASS=YES makehosts service failed either"
+         exit 1
+     fi
+fi
+if (grep "70.2.0.254 s01" $file >/dev/null 2>&1) && (! grep "80.2.0.254 s01r1b01" $file >/dev/null 2>&1); then
+    exit 0;
+else
+    exit 1
+fi
 check:rc==0
-cmd:makehosts -d s01 || XCATBYPASS=YES makehosts -d s01
+cmd:makehosts -d s01
 check:rc==0
-cmd:cat /etc/hosts
+cmd:grep "s01" /etc/hosts
 cmd:#!/bin/bash
 file="/etc/hosts"
 for i in {1..5}; do
@@ -211,13 +221,14 @@ for i in {1..5}; do
 done
 exit 1
 check:rc==0
-cmd:cp -f /etc/hosts.xcatbakautotest /etc/hosts
-cmd:makehosts || XCATBYPASS=YES makehosts
+cmd:sed -i '/s01/d' /etc/hosts
+cmd:XCATBYPASS=YES makehosts
 check:rc==0
-cmd:cat /etc/hosts
-cmd:makehosts -d service || XCATBYPASS=YES makehosts  -d service
+cmd:cat /etc/hosts |grep s01
 check:rc==0
-cmd:cat /etc/hosts
+cmd:makehosts -d service 
+check:rc==0
+cmd:grep "s01" /etc/hosts
 cmd:#!/bin/bash
 file="/etc/hosts"
 for i in {1..5}; do
@@ -230,13 +241,14 @@ for i in {1..5}; do
 done
 exit 1
 check:rc==0
-cmd:cp -f /etc/hosts.xcatbakautotest /etc/hosts
-cmd:makehosts  || XCATBYPASS=YES makehosts
+cmd:sed -i '/s01/d' /etc/hosts
+cmd:XCATBYPASS=YES makehosts
 check:rc==0
-cmd:cat /etc/hosts
-cmd:makehosts -d s01r1b01 || XCATBYPASS=YES makehosts -d s01r1b01
+cmd:grep "s01" /etc/hosts 
 check:rc==0
-cmd:cat /etc/hosts
+cmd:makehosts -d s01r1b01
+check:rc==0
+cmd:grep "s01" /etc/hosts
 cmd:#!/bin/bash
 file="/etc/hosts"
 for i in {1..5}; do

--- a/xCAT-test/autotest/testcase/makehosts/cases0
+++ b/xCAT-test/autotest/testcase/makehosts/cases0
@@ -149,7 +149,7 @@ check:rc==0
 cmd:nodeadd s01 groups=service; chdef s01 ip=70.2.0.254;nodeadd s01r1b01 groups=compute; chdef s01r1b01 ip=80.2.0.254
 check:rc==0
 cmd:lsdef -l s01,s01r1b01
-cmd:makehosts
+cmd:makehosts || XCATBYPASS=YES makehosts
 check:rc==0
 cmd:cat /etc/hosts
 cmd:#!/bin/bash
@@ -165,7 +165,7 @@ done
 exit 1
 check:rc==0
 cmd:cp -f /etc/hosts.xcatbakautotest /etc/hosts
-cmd:makehosts s01
+cmd:makehosts s01 || XCATBYPASS=YES makehosts s01
 check:rc==0
 cmd:cat /etc/hosts
 cmd:#!/bin/bash
@@ -181,7 +181,7 @@ done
 exit 1
 check:rc==0
 cmd:cp -f /etc/hosts.xcatbakautotest /etc/hosts
-cmd:makehosts service
+cmd:makehosts service || XCATBYPASS=YES makehosts service
 check:rc==0
 cmd:cat /etc/hosts
 cmd:#!/bin/bash
@@ -196,7 +196,7 @@ for i in {1..5}; do
 done
 exit 1
 check:rc==0
-cmd:makehosts -d s01
+cmd:makehosts -d s01 || XCATBYPASS=YES makehosts -d s01
 check:rc==0
 cmd:cat /etc/hosts
 cmd:#!/bin/bash
@@ -212,10 +212,10 @@ done
 exit 1
 check:rc==0
 cmd:cp -f /etc/hosts.xcatbakautotest /etc/hosts
-cmd:makehosts
+cmd:makehosts || XCATBYPASS=YES makehosts
 check:rc==0
 cmd:cat /etc/hosts
-cmd:makehosts -d service
+cmd:makehosts -d service || XCATBYPASS=YES makehosts  -d service
 check:rc==0
 cmd:cat /etc/hosts
 cmd:#!/bin/bash
@@ -231,10 +231,10 @@ done
 exit 1
 check:rc==0
 cmd:cp -f /etc/hosts.xcatbakautotest /etc/hosts
-cmd:makehosts
+cmd:makehosts  || XCATBYPASS=YES makehosts
 check:rc==0
 cmd:cat /etc/hosts
-cmd:makehosts -d s01r1b01
+cmd:makehosts -d s01r1b01 || XCATBYPASS=YES makehosts -d s01r1b01
 check:rc==0
 cmd:cat /etc/hosts
 cmd:#!/bin/bash

--- a/xCAT-test/autotest/testcase/makehosts/cases0
+++ b/xCAT-test/autotest/testcase/makehosts/cases0
@@ -222,9 +222,9 @@ done
 exit 1
 check:rc==0
 cmd:sed -i '/s01/d' /etc/hosts
-cmd:XCATBYPASS=YES makehosts
+cmd:domain=$(lsdef -t site  -i domain -c |awk -F'=' '{print $2}'); echo "70.2.0.254 s01 s01.$domain" >> /etc/hosts; echo "80.2.0.254 s01r1b01 s01r1b01.$domain" >> /etc/hosts
 check:rc==0
-cmd:cat /etc/hosts |grep s01
+cmd:grep "s01" /etc/hosts
 check:rc==0
 cmd:makehosts -d service 
 check:rc==0
@@ -242,7 +242,7 @@ done
 exit 1
 check:rc==0
 cmd:sed -i '/s01/d' /etc/hosts
-cmd:XCATBYPASS=YES makehosts
+cmd:domain=$(lsdef -t site  -i domain -c |awk -F'=' '{print $2}'); echo "70.2.0.254 s01 s01.$domain" >> /etc/hosts; echo "80.2.0.254 s01r1b01 s01r1b01.$domain" >> /etc/hosts
 check:rc==0
 cmd:grep "s01" /etc/hosts 
 check:rc==0


### PR DESCRIPTION
### The PR is for task https://github.com/xcat2/xcat2-task-management/issues/604

### The modification include

* refine test case makehost_n_r to double check through XCATBYPASS

### The UT result

```
------START::makehost_n_r::Time:Tue Feb 19 20:55:29 2019------

RUN:cp -f /etc/hosts /etc/hosts.xcatbakautotest [Tue Feb 19 20:55:29 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:sed -i '/s01/d' /etc/hosts [Tue Feb 19 20:55:29 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:cat /etc/hosts [Tue Feb 19 20:55:29 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
10.3.17.2 c910f03c17 c910f03c17.pok.stglabs.ibm.com
........
100.100.100.2 testnode

RUN:lsdef s01;if [ $? -eq 0 ]; then lsdef -l s01 -z >/tmp/s01.standa ;rmdef s01;fi [Tue Feb 19 22:16:37 2019]
Error: [c910f03c17k25]: Could not find an object named 's01' of type 'node'.
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:lsdef s01r1b01;if [ $? -eq 0 ]; then lsdef -l s01r1b01 -z >/tmp/s01r1b01.standa ;rmdef s01r1b01;fi [Tue Feb 19 22:16:37 2019]
Error: [c910f03c17k25]: Could not find an object named 's01r1b01' of type 'node'.
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:nodeadd s01 groups=service; chdef s01 ip=70.2.0.254;nodeadd s01r1b01 groups=compute; chdef s01r1b01 ip=80.2.0.254 [Tue Feb 19 22:16:38 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:lsdef -l s01,s01r1b01 [Tue Feb 19 22:16:39 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Object name: s01
    groups=service
    ip=70.2.0.254
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles,servicenode
Object name: s01r1b01
    groups=compute
    ip=80.2.0.254
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles

RUN:makehosts [Tue Feb 19 22:16:40 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN: [Tue Feb 19 22:16:40 2019]
#!/bin/bash
file="/etc/hosts"
if (! grep "s01" $file 2>&1); then
    echo "makehosts failed, try XCATBYPASS=YES makehosts again"
    XCATBYPASS=YES makehosts
    if (! grep "s01" $file 2>&1); then
        echo "XCATBYPASS=YES makehosts failed either"
        exit 1
    fi
fi
if (grep "70.2.0.254 s01" $file >/dev/null 2>&1) && (grep "80.2.0.254 s01r1b01" $file >/dev/null 2>&1); then
    exit 0
else
    exit 1
fi
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
70.2.0.254 s01 s01.pok.stglabs.ibm.com
80.2.0.254 s01r1b01 s01r1b01.pok.stglabs.ibm.com
CHECK:rc == 0	[Pass]

RUN:sed -i '/s01/d' /etc/hosts [Tue Feb 19 22:16:40 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:makehosts s01 [Tue Feb 19 22:16:40 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN: [Tue Feb 19 22:16:40 2019]
#!/bin/bash
file="/etc/hosts"
if (! grep "s01 " $file 2>&1); then
    echo "makehosts s01 failed, try XCATBYPASS=YES makehosts s01 again"
    XCATBYPASS=YES makehosts s01
    if (! grep "s01 " $file 2>&1); then
         echo "XCATBYPASS=YES makehosts s01 failed either"
         exit 1
    fi
fi
if (grep "70.2.0.254 s01" $file >/dev/null 2>&1) && ( ! grep "80.2.0.254 s01r1b01" $file >/dev/null 2>&1); then
    exit 0;
else
    exit 1
fi
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
70.2.0.254 s01 s01.pok.stglabs.ibm.com
CHECK:rc == 0	[Pass]

RUN:sed -i '/s01/d' /etc/hosts [Tue Feb 19 22:16:40 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:makehosts service [Tue Feb 19 22:16:40 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN: [Tue Feb 19 22:16:40 2019]
#!/bin/bash
file="/etc/hosts"
if (! grep "s01 " $file 2>&1); then
     echo "makehosts service failed, try XCATBYPASS=YES makehosts service again"
     XCATBYPASS=YES makehosts service
     if (! grep "s01 " $file 2>&1); then
         echo "XCATBYPASS=YES makehosts service failed either"
         exit 1
     fi
fi
if (grep "70.2.0.254 s01" $file >/dev/null 2>&1) && (! grep "80.2.0.254 s01r1b01" $file >/dev/null 2>&1); then
    exit 0;
else
    exit 1
fi
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
70.2.0.254 s01 s01.pok.stglabs.ibm.com
CHECK:rc == 0	[Pass]

RUN:makehosts -d s01 [Tue Feb 19 22:16:40 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:grep "s01" /etc/hosts [Tue Feb 19 22:16:40 2019]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:

RUN: [Tue Feb 19 22:16:40 2019]
#!/bin/bash
file="/etc/hosts"
for i in {1..5}; do
    if (! grep "70.2.0.254 s01" $file >/dev/null 2>&1) && (! grep "80.2.0.254 s01r1b01" $file >/dev/null 2>&1); then
        exit 0;
    else
        echo "sleep $[i*2] seconds and try again"
        sleep $[i*2]
    fi
done
exit 1
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:sed -i '/s01/d' /etc/hosts [Tue Feb 19 22:16:40 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:domain=$(lsdef -t site  -i domain -c |awk -F'=' '{print $2}'); echo "70.2.0.254 s01 s01.$domain" >> /etc/hosts; echo "80.2.0.254 s01r1b01 s01r1b01.$domain" >> /etc/hosts [Tue Feb 19 22:16:40 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:grep "s01" /etc/hosts [Tue Feb 19 22:16:41 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
70.2.0.254 s01 s01.pok.stglabs.ibm.com
80.2.0.254 s01r1b01 s01r1b01.pok.stglabs.ibm.com
CHECK:rc == 0	[Pass]

RUN:makehosts -d service [Tue Feb 19 22:16:41 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:grep "s01" /etc/hosts [Tue Feb 19 22:16:41 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
80.2.0.254 s01r1b01 s01r1b01.pok.stglabs.ibm.com

RUN: [Tue Feb 19 22:16:41 2019]
#!/bin/bash
file="/etc/hosts"
for i in {1..5}; do
    if (! grep "70.2.0.254 s01" $file >/dev/null 2>&1) && (grep "80.2.0.254 s01r1b01" $file >/dev/null 2>&1); then
        exit 0;
    else
        echo "sleep $[i*2] seconds and try again"
        sleep $[i*2]
    fi
done
exit 1
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:sed -i '/s01/d' /etc/hosts [Tue Feb 19 22:16:41 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:domain=$(lsdef -t site  -i domain -c |awk -F'=' '{print $2}'); echo "70.2.0.254 s01 s01.$domain" >> /etc/hosts; echo "80.2.0.254 s01r1b01 s01r1b01.$domain" >> /etc/hosts [Tue Feb 19 22:16:41 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:grep "s01" /etc/hosts [Tue Feb 19 22:16:41 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
70.2.0.254 s01 s01.pok.stglabs.ibm.com
80.2.0.254 s01r1b01 s01r1b01.pok.stglabs.ibm.com
CHECK:rc == 0	[Pass]

RUN:makehosts -d s01r1b01 [Tue Feb 19 22:16:41 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:grep "s01" /etc/hosts [Tue Feb 19 22:16:42 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
70.2.0.254 s01 s01.pok.stglabs.ibm.com

RUN: [Tue Feb 19 22:16:42 2019]
#!/bin/bash
file="/etc/hosts"
for i in {1..5}; do
    if (grep "70.2.0.254 s01" $file >/dev/null 2>&1) && (! grep "80.2.0.254 s01r1b01" $file >/dev/null 2>&1); then
        exit 0;
    else
        echo "sleep $[i*2] seconds and try again"
        sleep $[i*2]
    fi
done
exit 1
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:if [ -e /tmp/s01.standa ]; then rmdef s01; cat /tmp/s01.standa | mkdef -z; rm -rf /tmp/s01.standa; else rmdef s01;fi [Tue Feb 19 22:16:42 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:if [ -e /tmp/s01r1b01.standa ]; then rmdef s01r1b01; cat /tmp/s01r1b01.standa | mkdef -z; rm -rf /tmp/s01r1b01.standa;else rmdef s01r1b01; fi [Tue Feb 19 22:16:42 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:mv -f /etc/hosts.xcatbakautotest /etc/hosts [Tue Feb 19 22:16:43 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::makehost_n_r::Passed::Time:Tue Feb 19 22:16:43 2019 ::Duration::6 sec------
```