### PR TITLE
fix issue PR #6001 resulted in test case updatenode_syncfile_EXECUTE failed #6016

### DIFF
--- a/xCAT-test/autotest/testcase/updatenode/cases0
+++ b/xCAT-test/autotest/testcase/updatenode/cases0
@@ -166,23 +166,33 @@ end
 
 start:updatenode_syncfile_EXECUTE
 label:others,updatenode
-cmd:echo "echo hello > /tmp/test" > /tmp/file.post
+cmd:mkdir -p /tmp/updatenode_syncfile_EXECUTE/
 check:rc==0
-cmd:chmod a+x /tmp/file.post
-cmd:echo "/tmp/file.post -> /tmp/file.post" > /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
-cmd:echo "EXECUTE:" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
-cmd:echo "/tmp/file.post" >> /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
-cmd:chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute synclists=/install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
+cmd:touch /tmp/updatenode_syncfile_EXECUTE/file
+check:rc==0
+cmd:echo "echo hello > /tmp/test" > /tmp/updatenode_syncfile_EXECUTE/file.post
+check:rc==0
+cmd:chmod a+x /tmp/updatenode_syncfile_EXECUTE/file.post
+cmd:echo "/tmp/updatenode_syncfile_EXECUTE/file -> /tmp/file" > /tmp/updatenode_syncfile_EXECUTE/synclist
+cmd:echo "EXECUTE:" >> /tmp/updatenode_syncfile_EXECUTE/synclist
+cmd:echo "/tmp/updatenode_syncfile_EXECUTE/file.post" >> /tmp/updatenode_syncfile_EXECUTE/synclist
+cmd:chdef -t osimage -o __GETNODEATTR($$CN,provmethod)__ synclists=/tmp/updatenode_syncfile_EXECUTE/synclist
 check:rc==0
 cmd:updatenode $$CN -F
 check:rc==0
 cmd:xdsh $$CN "cat /tmp/test"
 check:rc==0
 check:output=~hello
-cmd:chdef -t osimage -o  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute synclists=
+cmd:xdsh $$CN "rm -rf /tmp/test"
+cmd:updatenode $$CN -F
 check:rc==0
-cmd:rm -rf /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist
+cmd:xdsh $$CN "cat /tmp/test"
+check:rc!=0
+check:output=~No such file or directory
+cmd:xdsh $$CN "rm -rf /tmp/test"
+cmd:chdef -t osimage -o  __GETNODEATTR($$CN,provmethod)__ synclists=
 check:rc==0
+cmd:rm -rf /tmp/updatenode_syncfile_EXECUTE/
 end
 
 start:updatenode_syncfile_EXECUTEALWAYS


### PR DESCRIPTION
This PR fixes issue #6016 :

for `EXECUTE`, only the update of `<file>` in sync list will trigger the invocation of post sync file `<file>.post` 

UT:
```
[root@boston02 updatenode]# XCATTEST_CN=sn02 xcattest -t updatenode_syncfile_EXECUTE
xCAT automated test started at Wed Feb 20 23:08:47 2019
******************************
To detect current test environment
******************************
Detecting: OS = linux
Detecting: ARCH = ppc64le
Detecting: HCP = openbmc
******************************
loading test cases
******************************
To run:
updatenode_syncfile_EXECUTE
******************************
Start to run test cases
******************************
------START::updatenode_syncfile_EXECUTE::Time:Wed Feb 20 23:08:49 2019------

RUN:mkdir -p /tmp/updatenode_syncfile_EXECUTE/ [Wed Feb 20 23:08:49 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:touch /tmp/updatenode_syncfile_EXECUTE/file [Wed Feb 20 23:08:49 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:echo "echo hello > /tmp/test" > /tmp/updatenode_syncfile_EXECUTE/file.post [Wed Feb 20 23:08:49 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:chmod a+x /tmp/updatenode_syncfile_EXECUTE/file.post [Wed Feb 20 23:08:49 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:mkdir -p /tmp/updatenode_syncfile_EXECUTE/ [Wed Feb 20 23:08:49 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "/tmp/updatenode_syncfile_EXECUTE/file -> /tmp/file" > /tmp/updatenode_syncfile_EXECUTE/synclist [Wed Feb 20 23:08:49 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "EXECUTE:" >> /tmp/updatenode_syncfile_EXECUTE/synclist [Wed Feb 20 23:08:49 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:echo "/tmp/updatenode_syncfile_EXECUTE/file.post" >> /tmp/updatenode_syncfile_EXECUTE/synclist [Wed Feb 20 23:08:49 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:chdef -t osimage -o __GETNODEATTR(sn02,provmethod)__ synclists=/tmp/updatenode_syncfile_EXECUTE/synclist [Wed Feb 20 23:08:49 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:updatenode sn02 -F [Wed Feb 20 23:08:50 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
File synchronization has completed for nodes: "sn02"
CHECK:rc == 0	[Pass]

RUN:xdsh sn02 "cat /tmp/test" [Wed Feb 20 23:08:52 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
sn02: hello
CHECK:rc == 0	[Pass]
CHECK:output =~ hello	[Pass]

RUN:xdsh sn02 "rm -rf /tmp/test" [Wed Feb 20 23:08:53 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:updatenode sn02 -F [Wed Feb 20 23:08:53 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
File synchronization has completed for nodes: "sn02"
CHECK:rc == 0	[Pass]

RUN:xdsh sn02 "cat /tmp/test" [Wed Feb 20 23:08:55 2019]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
[boston02]: sn02: cat: /tmp/test: No such file or directory
CHECK:rc != 0	[Pass]
CHECK:output =~ No such file or directory	[Pass]

RUN:xdsh sn02 "rm -rf /tmp/test" [Wed Feb 20 23:08:55 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:chdef -t osimage -o  __GETNODEATTR(sn02,provmethod)__ synclists= [Wed Feb 20 23:08:56 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:rm -rf /tmp/updatenode_syncfile_EXECUTE/ [Wed Feb 20 23:08:57 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::updatenode_syncfile_EXECUTE::Passed::Time:Wed Feb 20 23:08:57 2019 ::Duration::8 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished at Wed Feb 20 23:08:57 2019
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20190220230847 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20190220230847 file for time consumption
[root@boston02 updatenode]#
```