### PR TITLE
update xcatconfig_c case

### DIFF
--- a/xCAT-test/autotest/testcase/xcatconfig/case0
+++ b/xCAT-test/autotest/testcase/xcatconfig/case0
@@ -118,13 +118,9 @@ cmd:rm -rf /tmp/xcatconfig.test
 check:rc==0
 cmd:rm -rf /etc/xcat/cabak /etc/xcat/certbak
 check:rc==0
-cmd:if lsdef service > /dev/null 2>&1; then updatenode service -P servicenode;fi
+cmd:if lsdef service > /dev/null 2>&1; then updatenode service -P servicenode;makeconservercf;fi
 check:rc==0
-cmd:if lsdef service > /dev/null 2>&1; then xdsh $$CN date;fi
-check:rc==0
-cmd:if lsdef service > /dev/null 2>&1; then updatenode service -P servicenode;fi
-check:rc==0
-cmd:if lsdef service > /dev/null 2>&1; then xdsh $$CN date;fi
+cmd:if lsdef service > /dev/null 2>&1; then rpower $$CN stat;fi
 check:rc==0
 end
 


### PR DESCRIPTION
### The PR is to refine xcatconfig_c

```
------START::xcatconfig_c::Time:Thu Feb 21 02:14:27 2019------

RUN:cp -r /etc/xcat/ca /etc/xcat/cabak;cp -r /etc/xcat/cert /etc/xcat/certbak [Thu Feb 21 02:14:27 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:xcatconfig  -c 2>&1 | tee /tmp/xcatconfig.test [Thu Feb 21 02:14:27 2019]
ElapsedTime:4 sec
RETURN rc = 0
OUTPUT:

Setting up basic certificates.  Respond with a 'y' when prompted.

Existing xCAT certificate authority detected at /etc/xcat/ca, delete? (y/n):# NOTE use "-newkey rsa:2048" if running OpenSSL 0.9.8a or higher
Generating RSA private key, 2048 bit long modulus
...........+++
........+++
e is 65537 (0x10001)
Using configuration from openssl.cnf
Check that the request matches the signature
Signature ok
Certificate Details:
        Serial Number: 1 (0x1)

...
CHECK:rc != 0	[Pass]

RUN:rm -rf /tmp/xcatconfig.test [Thu Feb 21 02:14:31 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:rm -rf /etc/xcat/cabak /etc/xcat/certbak [Thu Feb 21 02:14:31 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:if lsdef service > /dev/null 2>&1; then updatenode service -P servicenode;makeconservercf;fi [Thu Feb 21 02:14:31 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:if lsdef service > /dev/null 2>&1; then rpower c910f03c09k11 stat;fi [Thu Feb 21 02:14:31 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::xcatconfig_c::Passed::Time:Thu Feb 21 02:14:32 2019 ::Duration::5 sec------
------Total: 1 , Failed: 0------
```