### PR TITLE
fix configeth does not reload new ifcfg-* for installnic when diskless/statelite node reboot 

### DIFF
--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -628,7 +628,7 @@ elif [ "$1" = "-s" ];then
             if [ "$con_name" == "--" ] ; then
                 nmcli con add type ethernet con-name ${str_inst_nic} ifname ${str_inst_nic} ipv4.method manual ipv4.addresses  ${str_inst_ip}/${str_inst_prefix}
             else
-                nmcli con mod "System ens3" ipv4.method manual ipv4.addresses ${str_inst_ip}/${str_inst_prefix}
+                nmcli con mod "System ${str_inst_nic}" ipv4.method manual ipv4.addresses ${str_inst_ip}/${str_inst_prefix}
             fi
         else
             echo "DEVICE=${str_inst_nic}" > $str_conf_file
@@ -674,7 +674,7 @@ elif [ "$1" = "-s" ];then
         fi
     fi
 
-    if [ "$UPDATENODE" = "1" ] || grep "REBOOT=TRUE" /opt/xcat/xcatinfo >/dev/null 2>&1; then
+    if [ "$UPDATENODE" = "1" ] || [ "$NODESETSTATE" = "netboot" ] || [ "$NODESETSTATE" = "statelite" ] || grep "REBOOT=TRUE" /opt/xcat/xcatinfo >/dev/null 2>&1; then
         if [ "$str_os_type" = "debian" ];then
             ifdown --force $str_inst_nic
         else


### PR DESCRIPTION
### The PR is to fix issue
https://github.com/xcat2/xcat-core/issues/6028
### The modification include
configeth will reload new ifcfg-* for installnic when diskless/statelite node reboot 
### The UT result
1. Reboot diskless node, and check xcat.log, `confignetwork` runs.
```
Fri Feb 22 04:16:23 EST 2019 [info]: xcat.deployment.postbootscript: postbootscript start..: confignetwork
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
[I]: configure the install nic eth0.
[I]: configeth on byrh07: os type: redhat
['/etc/sysconfig/network-scripts/ifcfg-eth0']
[I]: >> DEVICE=eth0
[I]: >> IPADDR=10.4.41.7
[I]: >> NETMASK=255.0.0.0
[I]: >> BOOTPROTO=none
[I]: >> ONBOOT=yes
[I]: >> HWADDR=42:66:0a:04:29:07
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
```
2. check install nic is not dynamic configured
```
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
    link/ether 42:66:0a:04:29:07 brd ff:ff:ff:ff:ff:ff
    inet 10.4.41.7/8 brd 10.255.255.255 scope global eth0
       valid_lft forever preferred_lft forever
    inet6 fe80::4066:aff:fe04:2907/64 scope link
       valid_lft forever preferred_lft forever
```