### PR TITLE
doc: use pkill instead of ps | grep | awk | xargs

### DIFF
--- a/docs/source/guides/admin-guides/references/man5/site.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/site.5.rst
@@ -401,7 +401,7 @@ site Attributes:
   
    dbtracelevel:  The trace level for the database access log. To activate this setting, please. 
                   restart xcatd or send HUP signal to the 'xcatd: DB Access' process, Like: .
-                  ps -ef | grep 'xcatd: DB Access' | grep -v grep | awk '{print $2}' | xargs kill -HUP  
+                  pkill -f -HUP 'xcatd: DB Access'
                   Currrent support values: 
                   0: disable the trace log for db 
                   1: trace the calls of database subroutines 

--- a/perl-xCAT/xCAT/Schema.pm
+++ b/perl-xCAT/xCAT/Schema.pm
@@ -1262,7 +1262,7 @@ passed as argument rather than by table value',
 "                     delimiter, to specify delimiter for those columns as format of 'column:delimiter'.\n\n" .
 " dbtracelevel:  The trace level for the database access log. To activate this setting, please. \n".
 "                restart xcatd or send HUP signal to the 'xcatd: DB Access' process, Like: .\n".
-"                ps -ef | grep 'xcatd: DB Access' | grep -v grep | awk '{print \$2}' | xargs kill -HUP  \n".
+"                pkill -f -HUP 'xcatd: DB Access' \n".
 "                Currrent support values: \n" .
 "                0: disable the trace log for db \n" .
 "                1: trace the calls of database subroutines \n" .


### PR DESCRIPTION
pkill is provided by the same procps package as ps, so should be present
wherever ps is.