### PR TITLE
Revise test case xcatconfig_u_check_xcatsslversion_rhels_sles

### DIFF
--- a/xCAT-test/autotest/testcase/xcatconfig/case0
+++ b/xCAT-test/autotest/testcase/xcatconfig/case0
@@ -332,7 +332,7 @@ start:xcatconfig_u_check_xcatsslversion_rhels_sles
 description:after xcatconfig -u the site.xcatsslversion will not be changed
 os:rhels,sles
 label:mn_only
-cmd:lsdef -t site -i xcatsslversion -c | grep '=TLSv1$'
+cmd:lsdef -t site -i xcatsslversion -c | grep '=TLSv1_2$'
 check:rc==0
 cmd:chtab key=xcatsslversion site.value=TLSv12
 check:rc==0
@@ -342,7 +342,7 @@ cmd:xcatconfig -u
 check:rc==0
 cmd:lsdef -t site -i xcatsslversion -c | grep '=TLSv12$'
 check:rc==0
-cmd:chtab key=xcatsslversion site.value=TLSv1
+cmd:chtab key=xcatsslversion site.value=TLSv1_2
 check:rc==0
 end
 


### PR DESCRIPTION
### The PR is to fix issue https://github.com/xcat2/xcat2-task-management/issues/556

### The modification include

_## Change xCAT default `xcatsslversion` setting to `TLSv1_2`.