### PR TITLE
Fix arguments parsing issue in DBobjUtils->gettbldesc

### DIFF
--- a/perl-xCAT/xCAT/DBobjUtils.pm
+++ b/perl-xCAT/xCAT/DBobjUtils.pm
@@ -246,7 +246,9 @@ sub getobjattrs
 
 #-----------------------------------------------------------------------------
 sub gettbldesc {
-    my ($class, $objtype) = @_;
+
+    my $class   = shift;
+    my $objtype = shift;
     my @attrs;
     # The $attrs is an optional argument
     if (ref $_[0]) {


### PR DESCRIPTION
xCAT::DBobjUtils->gettbldesc does not parse params correctly and then cannot filter non used table and columns

### The PR is to fix issue #6035 

### The modification include

Fix the code error when parsing the params, so that the expected attributes could be used to filter the tables and columns.

### The UT result
1, enable postgresql query logging capability by modify `postgresql.conf`
```
grep ^log /var/lib/pgsql/data/postgresql.conf
logging_collector = on			# Enable capturing of stderr and csvlog
log_filename = 'postgresql-%a.log'	# log file name pattern,
log_truncate_on_rotation = on		# If on, an existing log file with the
log_rotation_age = 1d			# Automatic rotation of logfiles will
log_rotation_size = 0			# Automatic rotation of logfiles will
log_timezone = 'US/Eastern'
log_duration = on
log_line_prefix = '%h-%p %t '            # special values:
log_statement = 'all'            # none, ddl, mod, all
```
and restart postgresql service `systemctl restart postgresql`

2, stop xcatd a to avoid the periodically querying in xcatd `systemctl stop xcatd`
3, record the query number in current day log, not the name will be different when you do it in another week day
```
grep -i select postgresql-Tue.log|grep FROM|wc
  14936  300104 2542248
```   
4, apply the patch and run 
```
XCATBYPASS=1 /opt/xcat/bin/lsdef mid05tor12cn15 -i usercomment
Object name: mid05tor12cn15
    usercomment=
```
After it done, check the query count again
```
grep -i select postgresql-Tue.log|grep FROM|wc
  14962  300686 2546915
```

So after fix, only **26** query (14962 -  14936)


Before fixing, the query is so many:  15240  -  14988
```
grep -i select postgresql-Tue.log|grep FROM|wc
  14988  301268 2551582

grep -i select postgresql-Tue.log|grep FROM|wc
  15240  307048 2597624
```
