### PR TITLE
Add xCAT-client as dependency for xCAT-probe

### DIFF
--- a/xCAT-probe/xCAT-probe.spec
+++ b/xCAT-probe/xCAT-probe.spec
@@ -11,6 +11,7 @@ Vendor: IBM Corp.
 Distribution: %{?_distribution:%{_distribution}}%{!?_distribution:%{_vendor}}
 Prefix: /opt/xcat
 BuildRoot: /var/tmp/%{name}-%{version}-%{release}-root
+Requires: xCAT-client
 
 %ifos linux
 BuildArch: noarch


### PR DESCRIPTION
The PR is to fix issue #6026

xCAT-client needs to be install before xCAT-probe,  so the symbolic link for switchprobe will be always available

````
[root@fs2vm113 /]# rpm -e --nodeps xCAT-client-2.14.6-snap201902280617.noarch
[root@fs2vm113 /]# ls -ltr /opt/xcat/probe/subcmds/bin
total 0
lrwxrwxrwx 1 root root 24 Feb 28 14:19 switchprobe -> /opt/xcat/bin/xcatclient   <---link is broken after uninstall xCAT-clinet
[root@fs2vm113 /]# rpm -e --nodeps xCAT-probe-2.14.6-snap000000000000.noarch
[root@fs2vm113 /]# ls -ltr /opt/xcat/probe/subcmds/bin
ls: cannot access /opt/xcat/probe/subcmds/bin: No such file or directory

[root@fs2vm113 /]# rpm -ihv /root/xCAT-probe-2.14.6-snap000000000000.noarch.rpm
error: Failed dependencies:                                                    <--- will ask for dependency
        xCAT-client is needed by xCAT-probe-4:2.14.6-snap000000000000.noarch

[root@fs2vm113 /]# yum install xCAT-client
[root@fs2vm113 /]# rpm -ihv /root/xCAT-probe-2.14.6-snap000000000000.noarch.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:xCAT-probe-4:2.14.6-snap000000000################################# [100%]
[root@fs2vm113 /]# ls -ltr /opt/xcat/probe/subcmds/bin
total 0
lrwxrwxrwx 1 root root 24 Feb 28 14:25 switchprobe -> /opt/xcat/bin/xcatclient
````


 

