### PR TITLE
fix rspconfig error that no executor folder

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
+++ b/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
@@ -315,7 +315,7 @@ class OpenBMCManager(base.BaseManager):
 
     def rspconfig(self, nodesinfo, args):
 
-        from hwctl.executor.openbmc_bmcconfig import OpenBMCBmcConfigTask
+        from hwctl.openbmc.openbmc_bmcconfig import OpenBMCBmcConfigTask
 
         try:
             opts=docopt(RSPCONFIG_USAGE, argv=args)


### PR DESCRIPTION
### The PR is to fix issue _`` No module named executor.openbmc_bmcconfig``_

### The modification include

_##modify executor to openbmc _

### The UT result
befor modify:
```
Error: [f6u13k10]: OpenBMC management is using a Python framework and some dependency libraries could not be imported.Error: [f6u13k10]: Agent exited unexpectedly. See /var/log/xcat/agent.log for details.
```
after modified:
```
# rspconfig f5u14 hostname
f5u14: BMC Hostname: test_bogus-bmc-hostname
```