### PR TITLE
add 15-minute quick start doc

### DIFF
--- a/docs/source/guides/get-started/index.rst
+++ b/docs/source/guides/get-started/index.rst
@@ -1,10 +1,9 @@
-.. _get_started:
-
 Get Started
 ===========
 
+
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    quick_start.rst
    workflow_guide.rst

--- a/docs/source/guides/get-started/index.rst
+++ b/docs/source/guides/get-started/index.rst
@@ -1,0 +1,10 @@
+.. _get_started:
+
+Get Started
+===========
+
+.. toctree::
+   :maxdepth: 2
+
+   quick_start.rst
+   workflow_guide.rst

--- a/docs/source/guides/get-started/quick_start.rst
+++ b/docs/source/guides/get-started/quick_start.rst
@@ -80,7 +80,7 @@ Stage 2 Deploy Compute Node
 
     copycds RHEL-7.6-20181010.0-Server-x86_64-dvd1.iso
 
-After ``copycds``, the corresponding basic osimage will be generated automatically. And then you can list the new osimage name here. You can refer document to customize the package list or postscript for target compute nodes, but here just use the default one: ::
+   After ``copycds``, the corresponding basic osimage will be generated automatically. And then you can list the new osimage name here. You can refer document to customize the package list or postscript for target compute nodes, but here just use the default one: ::
 
     lsdef -t osimage
 
@@ -114,7 +114,7 @@ After ``copycds``, the corresponding basic osimage will be generated automatical
 
    **Note**: The keystroke ``ctrl+e c .`` will disconnect you from the console.
 
-   After a while (5-10 min), check the provision status is ``booted``: ::
+   After 5-10 min verify provision status is ``booted``: ::
     
     lsdef cn1 -i status
     Object name: cn1

--- a/docs/source/guides/get-started/quick_start.rst
+++ b/docs/source/guides/get-started/quick_start.rst
@@ -6,7 +6,14 @@ The steps below will be focused on RHEL7, however they should work for other dis
 
 Prerequisites
 -------------
-Assume there are two servers named ``xcatmn.mydomain.com`` and ``cn1.mydomain.com``. They are in the same subnet ``192.168.0.0``. ``cn1.mydomain.com`` has BMC which ``xcatmn.mydomain.com`` can access it. ``xcatmn.mydomain.com`` has Red Hat OS installed, and uses IP ``192.168.0.2``. ``xcatmn.mydomain.com`` has access to internet. ``cn1.mydomain.com`` BMC IP address is ``10.4.40.254``. Prepare a full DVD for OS provision, and not a ``Live CD`` ISO, for this example, will use ``RHEL-7.6-20181010.0-Server-x86_64-dvd1.iso`` ISO, you can download it from Red Hat website.
+Assume there are two servers named ``xcatmn.mydomain.com`` and ``cn1.mydomain.com``. 
+
+    #. They are in the same subnet ``192.168.0.0``. 
+    #. ``cn1.mydomain.com`` has BMC which ``xcatmn.mydomain.com`` can access it. 
+    #. ``xcatmn.mydomain.com`` has Red Hat OS installed, and uses IP ``192.168.0.2``. 
+    #. ``xcatmn.mydomain.com`` has access to internet. 
+    #. ``cn1.mydomain.com`` BMC IP address is ``10.4.40.254``. 
+    #. Prepare a full DVD for OS provision, and not a ``Live CD`` ISO, for this example, will use ``RHEL-7.6-20181010.0-Server-x86_64-dvd1.iso`` ISO, you can download it from Red Hat website.
 
 All the following steps should be executed in ``xcatmn.mydomain.com``.
 
@@ -22,7 +29,9 @@ Prepare the Management Node ``xcatmn.mydomain.com``
 
     hostname xcatmn.mydomain.com
 
-#. Set the IP to STATIC in the ``/etc/sysconfig/network-scripts/ifcfg-eth0`` file
+#. Set the IP to STATIC in the ``/etc/sysconfig/network-scripts/ifcfg-<proc_nic>`` file
+
+#. Update your ``/etc/resolv.conf`` with DNS settings and make sure that the node could visit ``github`` and ``xcat`` official website.
 
 #. Configure any domain search strings and nameservers to the ``/etc/resolv.conf`` file
 
@@ -41,8 +50,8 @@ Prepare the Management Node ``xcatmn.mydomain.com``
 
     chtab key=system passwd.username=root passwd.password=abc123
 
-Stage 1 Enable Hardware Control
--------------------------------
+Stage 1 Add your first node and control it with out-of-band BMC interface
+-------------------------------------------------------------------------
 
 #. Define compute node ``cn1``: ::
 
@@ -69,8 +78,8 @@ Stage 1 Enable Hardware Control
     cn1: Backup IMM Version: 1.25 (1AOO26K 2012/02/23)
     cn1: BMC Firmware: 3.10 (1AOO48H 2013/08/22 18:49:44)
 
-Stage 2 Deploy Compute Node
----------------------------
+Stage 2 Provision a node and manage it with parallel shell
+----------------------------------------------------------
 
 #. In order to PXE boot, you need a DHCP server to hand out addresses and direct the booting system to the TFTP server where it can download the network boot files. Configure DHCP: ::
 

--- a/docs/source/guides/get-started/quick_start.rst
+++ b/docs/source/guides/get-started/quick_start.rst
@@ -1,25 +1,26 @@
 Quick Start Guide
 =================
+xCAT can be a comprehensive system to manage infrastructure elements in Data Center, bare-metal servers, switches, PDUs, and Operation System distributions. This quick start guide will instruct you to set up a xCAT system and manage an IPMI managed bare metal server with Red Hat-based distribution in 15 minutes. 
 
-This quick start guide is a 15-minute procedure to set up an xCAT cluster on Red Hat-based distribution. These examples are based on IPMI managed baremetal servers.
+The steps below will be focused on RHEL7, however they should work for other distribution, such as CentOS, SLES, etc, details :doc:`Operating System & Hardware Support Matrix <../../overview/support_matrix>`
 
 Prerequisites
 -------------
-Assume there are two servers named ``xcatmn1`` and ``cn1``. They are in the same subnet ``192.168.0.0``, their BMCs are in the same network ``10.0.0.0``. ``xcatmn1`` has Red Hat OS installed, and uses IP ``192.168.0.2``. ``xcatmn1`` has access to ``xcat.org``. ``cn1`` BMC IP address is ``10.4.40.254``. Prepare a full DVD for OS provision, and not a ``Live CD`` ISO, for this example, use ``RHEL-7.6-20181010.0-Server-x86_64-dvd1.iso`` ISO.
+Assume there are two servers named ``xcatmn.mydomain.com`` and ``cn1.mydomain.com``. They are in the same subnet ``192.168.0.0``. ``cn1.mydomain.com`` has BMC which ``xcatmn.mydomain.com`` can access it. ``xcatmn.mydomain.com`` has Red Hat OS installed, and uses IP ``192.168.0.2``. ``xcatmn.mydomain.com`` has access to internet. ``cn1.mydomain.com`` BMC IP address is ``10.4.40.254``. Prepare a full DVD for OS provision, and not a ``Live CD`` ISO, for this example, will use ``RHEL-7.6-20181010.0-Server-x86_64-dvd1.iso`` ISO, you can download it from Red Hat website.
 
-All the following steps should be executed in ``xcatmn1``.
+All the following steps should be executed in ``xcatmn.mydomain.com``.
 
-Prepare the Management Node ``xcatmn1``
-```````````````````````````````````````
+Prepare the Management Node ``xcatmn.mydomain.com``
+```````````````````````````````````````````````````
 
 #. Disable SELinux: ::
 
     echo 0 > /selinux/enforce
     sed -i 's/^SELINUX=.*$/SELINUX=disabled/' /etc/selinux/config
 
-#. Set the hostname of ``xcatmn.cluster.com``: ::
+#. Set the hostname of ``xcatmn.mydomain.com``: ::
 
-    hostname xcatmn.cluster.com
+    hostname xcatmn.mydomain.com
 
 #. Set the IP to STATIC in the ``/etc/sysconfig/network-scripts/ifcfg-eth0`` file
 
@@ -27,7 +28,7 @@ Prepare the Management Node ``xcatmn1``
 
 #. Add ``xcatmn`` into ``/etc/hosts``: ::
 
-    192.168.0.2 xcatmn xcatmn.cluster.com
+    192.168.0.2 xcatmn xcatmn.mydomain.com
 
 #. Install xCAT: ::
 
@@ -35,47 +36,96 @@ Prepare the Management Node ``xcatmn1``
     chmod +x /tmp/go-xcat
     go-xcat --yes install
     source /etc/profile.d/xcat.sh
+   
+#. Configure the system password for the root user on the compute nodes: ::
+
+    chtab key=system passwd.username=root passwd.password=abc123
 
 Stage 1 Enable Hardware Control
 -------------------------------
 
 #. Define compute node ``cn1``: ::
 
-    chdef cn1 bmc=10.4.40.254 mgt=ipmi groups=all bmcusername=USERID bmcpassword=PASSW0RD
+    mkdef -t node cn1 --template x86_64-template ip=192.168.0.3 mac=42:3d:0a:05:27:0c bmc=10.4.40.254 bmcusername=USERID bmcpassword=PASSW0RD
 
-#. Check ``cn1`` Power state: ::
+#. Configure DNS: ::
 
+    makehosts cn1 
+    makedns -n
+
+#. Check ``cn1`` Hardware Control:
+
+``cn1`` power management: ::
+
+    rpower cn1 on
     rpower cn1 state
     cn1: on
+
+``cn1`` firmware information: ::
+
+    rinv cn1 firm
+    cn1: UEFI Version: 1.31 (TDE134EUS  2013/08/27)
+    cn1: Backup UEFI Version: 1.00 (TDE112DUS )
+    cn1: Backup IMM Version: 1.25 (1AOO26K 2012/02/23)
+    cn1: BMC Firmware: 3.10 (1AOO48H 2013/08/22 18:49:44)
 
 Stage 2 Deploy Compute Node
 ---------------------------
 
-#. Configure DNS: ::
-
-    chdef cn1 ip=192.168.0.3
-    makehosts cn1
-    makedns -n
-    
-#. Configure DHCP: ::
+#. In order to PXE boot, you need a DHCP server to hand out addresses and direct the booting system to the TFTP server where it can download the network boot files. Configure DHCP: ::
 
     makedhcp -n
-    makedhcp -a
 
-#. Create osimage: ::
+#. Copy all contents of Distribution ISO into ``/install`` directory, create OS repository and osimage for OS provision: ::
 
     copycds RHEL-7.6-20181010.0-Server-x86_64-dvd1.iso
+
+After ``copycds``, the corresponding basic osimage will be generated automatically. And then you can list the new osimage name here. You can refer document to customize the package list or postscript for target compute nodes, but here just use the default one: ::
+
     lsdef -t osimage
+
+#. Use ``xcatprobe`` to precheck xCAT management node ready for OS provision: ::
+
+    xcatprobe xcatmn
+    [mn]: Checking all xCAT daemons are running...                                      [ OK ]
+    [mn]: Checking xcatd can receive command request...                                 [ OK ]
+    [mn]: Checking 'site' table is configured...                                        [ OK ]
+    [mn]: Checking provision network is configured...                                   [ OK ]
+    [mn]: Checking 'passwd' table is configured...                                      [ OK ]
+    [mn]: Checking important directories(installdir,tftpdir) are configured...          [ OK ]
+    [mn]: Checking SELinux is disabled...                                               [ OK ]
+    [mn]: Checking HTTP service is configured...                                        [ OK ]
+    [mn]: Checking TFTP service is configured...                                        [ OK ]
+    [mn]: Checking DNS service is configured...                                         [ OK ]
+    [mn]: Checking DHCP service is configured...                                        [ OK ]
+    ... ...
+    [mn]: Checking dhcpd.leases file is less than 100M...                               [ OK ]
+    =================================== SUMMARY ====================================
+    [MN]: Checking on MN...                                                             [ OK ]
 
 #. Start the Diskful OS Deployment: ::
 
-    chdef cn1 mgt=ipmi netboot=xnba arch=x86_64 mac=34:40:b5:b9:d6:4f
     rinstall cn1 osimage=rhels7.6-x86_64-install-compute
 
 #. Monitor Installation Process: ::
 
-    chdef cn1 serialport=0 serialspeed=115200 cons=ipmi
     makegocons cn1
     rcons cn1
 
    **Note**: The keystroke ``ctrl+e c .`` will disconnect you from the console.
+
+   After a while (5-10 min), check the provision status is ``booted``: ::
+    
+    lsdef cn1 -i status
+    Object name: cn1
+    status=booted
+
+   Use ``xdsh`` to check ``cn1`` OS version, OS provision is successful: ::
+    
+    xdsh cn1 more /etc/*release
+    cn1: ::::::::::::::
+    cn1: /etc/os-release
+    cn1: ::::::::::::::
+    cn1: NAME="Red Hat Enterprise Linux Server"
+    cn1: VERSION="7.6 (Maipo)"
+    ... ...

--- a/docs/source/guides/get-started/quick_start.rst
+++ b/docs/source/guides/get-started/quick_start.rst
@@ -1,11 +1,11 @@
 Quick Start Guide
 =================
 
-This quickstart guide is a 15-minute procedure to set up an xCAT cluster on Red Hat-based distribution. The focus and examples are based on IPMI managed baremetal servers.
+This quick start guide is a 15-minute procedure to set up an xCAT cluster on Red Hat-based distribution. These examples are based on IPMI managed baremetal servers.
 
 Prerequisites
 -------------
-Assume there are 2 servers named ``xcatmn1`` and ``cn1``. They are in the same subnet ``192.168.0.0``, their BMC is in the same network ``10.0.0.0``. ``xcatmn1`` is with redhat OS installed, ``192.168.0.2`` is its ip, it can be used for xCAT management IP. ``xcatmn1`` has access to ``xcat.org``. ``10.4.40.254`` is ``cn1`` BMC ip address.
+Assume there are two servers named ``xcatmn1`` and ``cn1``. They are in the same subnet ``192.168.0.0``, their BMCs are in the same network ``10.0.0.0``. ``xcatmn1`` has Red Hat OS installed, and uses IP ``192.168.0.2``. ``xcatmn1`` has access to ``xcat.org``. ``cn1`` BMC IP address is ``10.4.40.254``. Prepare a full DVD for OS provision, and not a ``Live CD`` ISO, for this example, use ``RHEL-7.6-20181010.0-Server-x86_64-dvd1.iso`` ISO.
 
 All the following steps should be executed in ``xcatmn1``.
 
@@ -17,11 +17,11 @@ Prepare the Management Node ``xcatmn1``
     echo 0 > /selinux/enforce
     sed -i 's/^SELINUX=.*$/SELINUX=disabled/' /etc/selinux/config
 
-#. To set the hostname of ``xcatmn.cluster.com``: ::
+#. Set the hostname of ``xcatmn.cluster.com``: ::
 
     hostname xcatmn.cluster.com
 
-#. setting the IP to STATIC in the ``/etc/sysconfig/network-scripts/ifcfg-eth0`` file
+#. Set the IP to STATIC in the ``/etc/sysconfig/network-scripts/ifcfg-eth0`` file
 
 #. Configure any domain search strings and nameservers to the ``/etc/resolv.conf`` file
 
@@ -29,7 +29,7 @@ Prepare the Management Node ``xcatmn1``
 
     192.168.0.2 xcatmn xcatmn.cluster.com
 
-#. Installing xCAT: ::
+#. Install xCAT: ::
 
     wget https://raw.githubusercontent.com/xcat2/xcat-core/master/xCAT-server/share/xcat/tools/go-xcat -O - >/tmp/go-xcat
     chmod +x /tmp/go-xcat
@@ -70,9 +70,12 @@ Stage 2 Deploy Compute Node
 #. Start the Diskful OS Deployment: ::
 
     chdef cn1 mgt=ipmi netboot=xnba arch=x86_64 mac=34:40:b5:b9:d6:4f
+    rinstall cn1 osimage=rhels7.6-x86_64-install-compute
 
-#. Monitor Installing Process: ::
+#. Monitor Installation Process: ::
 
     chdef cn1 serialport=0 serialspeed=115200 cons=ipmi
     makegocons cn1
     rcons cn1
+
+   **Note**: The keystroke ``ctrl+e c .`` will disconnect you from the console.

--- a/docs/source/guides/get-started/quick_start.rst
+++ b/docs/source/guides/get-started/quick_start.rst
@@ -1,0 +1,78 @@
+Quick Start Guide
+=================
+
+This quickstart guide is a 15-minute procedure to set up an xCAT cluster on Red Hat-based distribution. The focus and examples are based on IPMI managed baremetal servers.
+
+Prerequisites
+-------------
+Assume there are 2 servers named ``xcatmn1`` and ``cn1``. They are in the same subnet ``192.168.0.0``, their BMC is in the same network ``10.0.0.0``. ``xcatmn1`` is with redhat OS installed, ``192.168.0.2`` is its ip, it can be used for xCAT management IP. ``xcatmn1`` has access to ``xcat.org``. ``10.4.40.254`` is ``cn1`` BMC ip address.
+
+All the following steps should be executed in ``xcatmn1``.
+
+Prepare the Management Node ``xcatmn1``
+```````````````````````````````````````
+
+#. Disable SELinux: ::
+
+    echo 0 > /selinux/enforce
+    sed -i 's/^SELINUX=.*$/SELINUX=disabled/' /etc/selinux/config
+
+#. To set the hostname of ``xcatmn.cluster.com``: ::
+
+    hostname xcatmn.cluster.com
+
+#. setting the IP to STATIC in the ``/etc/sysconfig/network-scripts/ifcfg-eth0`` file
+
+#. Configure any domain search strings and nameservers to the ``/etc/resolv.conf`` file
+
+#. Add ``xcatmn`` into ``/etc/hosts``: ::
+
+    192.168.0.2 xcatmn xcatmn.cluster.com
+
+#. Installing xCAT: ::
+
+    wget https://raw.githubusercontent.com/xcat2/xcat-core/master/xCAT-server/share/xcat/tools/go-xcat -O - >/tmp/go-xcat
+    chmod +x /tmp/go-xcat
+    go-xcat --yes install
+    source /etc/profile.d/xcat.sh
+
+Stage 1 Enable Hardware Control
+-------------------------------
+
+#. Define compute node ``cn1``: ::
+
+    chdef cn1 bmc=10.4.40.254 mgt=ipmi groups=all bmcusername=USERID bmcpassword=PASSW0RD
+
+#. Check ``cn1`` Power state: ::
+
+    rpower cn1 state
+    cn1: on
+
+Stage 2 Deploy Compute Node
+---------------------------
+
+#. Configure DNS: ::
+
+    chdef cn1 ip=192.168.0.3
+    makehosts cn1
+    makedns -n
+    
+#. Configure DHCP: ::
+
+    makedhcp -n
+    makedhcp -a
+
+#. Create osimage: ::
+
+    copycds RHEL-7.6-20181010.0-Server-x86_64-dvd1.iso
+    lsdef -t osimage
+
+#. Start the Diskful OS Deployment: ::
+
+    chdef cn1 mgt=ipmi netboot=xnba arch=x86_64 mac=34:40:b5:b9:d6:4f
+
+#. Monitor Installing Process: ::
+
+    chdef cn1 serialport=0 serialspeed=115200 cons=ipmi
+    makegocons cn1
+    rcons cn1

--- a/docs/source/guides/get-started/workflow_guide.rst
+++ b/docs/source/guides/get-started/workflow_guide.rst
@@ -1,5 +1,5 @@
-Quick Start Guide
-=================
+Workflow Guide
+==============
 
 If xCAT looks suitable for your requirement, following steps are recommended procedure to set up an xCAT cluster.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,6 +30,7 @@ Table of Contents
 
    overview/index.rst
    guides/install-guides/index.rst
+   guides/get-started/index.rst
    guides/admin-guides/index.rst
    advanced/index.rst
    QA/index.rst

--- a/docs/source/overview/index.rst
+++ b/docs/source/overview/index.rst
@@ -10,5 +10,4 @@ xCAT enables you to easily manage large number of servers for any type of techni
    features.rst
    support_matrix.rst
    architecture.rst
-   quick_start.rst
    xcat2_release.rst


### PR DESCRIPTION
### The PR is for task
https://github.com/xcat2/xcat.org/issues/132

### The modification include
Usually, "quick start" contain series of documentations and other materials. The first doc should be a simple and quick doc. This quick start doc is as the first simple 15-minute quick start doc.
1. This "Quick start" will cover an compute node OS deployment on Redhat OS. It will be divided into 2 stages.
    Stage 1: enable hardware control
    Stage 2: deploy a compute node
2. Rename old "Quick Start Guide" as "Workflow Guide"
3. Add "Get Started" index between "Overview" and "Install Guides" in index part, move "Quick Start" and "Workflow Guide" docs under "Get Started" index

### The UT result
http://10.4.41.1/install/xcat-core/docs/build/html/guides/get-started/quick_start.html
