### PR TITLE
Revert "Update xCAT-server.spec to require a new version of grub2-xcat"

### DIFF
--- a/xCAT-server/xCAT-server.spec
+++ b/xCAT-server/xCAT-server.spec
@@ -48,7 +48,7 @@ Obsoletes: atftp-xcat
 #
 # PCM does not use or ship grub2-xcat
 %if %nots390x
-Requires: grub2-xcat >= 2.02-0.76 perl-Net-HTTPS-NB perl-HTTP-Async
+Requires: grub2-xcat perl-Net-HTTPS-NB perl-HTTP-Async
 %endif
 %endif
 %endif


### PR DESCRIPTION
This reverts commit 337fb4fa070a5cbd0303f23e0cd4613d6fa0bc11.

### The PR is to fix issue _#6055_

This modification will make the xcat-core tarball work with the original xCAT dependency released for xCAT 2.14.5