### PR TITLE
Set the default value of site.xcatsslversion to SSLv23:!SSLv2:!SSLv3:!TLSv1

### DIFF
--- a/xCAT-server/sbin/xcatconfig
+++ b/xCAT-server/sbin/xcatconfig
@@ -1206,7 +1206,6 @@ sub initDB
         $chtabcmds .= "$::XCATROOT/sbin/chtab key=cleanupxcatpost site.value=no;";
         $chtabcmds .= "$::XCATROOT/sbin/chtab key=dhcplease site.value=43200;";
         $chtabcmds .= "$::XCATROOT/sbin/chtab key=auditnosyslog site.value=0;";
-        $chtabcmds .= "$::XCATROOT/sbin/chtab key=xcatsslversion site.value=TLSv1_2;";
         $chtabcmds .= "$::XCATROOT/sbin/chtab key=auditskipcmds site.value=ALL;";
 
         #$chtabcmds .= "$::XCATROOT/sbin/chtab key=useflowcontrol site.value=yes;"; # need to fix 4031
@@ -1470,19 +1469,6 @@ sub initDB
             if ($::RUNCMD_RC != 0)
             {
                 xCAT::MsgUtils->message('E', "Could not set ddns as dnshandler.");
-            }
-        }
-
-        # Set default value for site.xcatsslversion when update xcat
-        $cmds = "XCATBYPASS=Y $::XCATROOT/sbin/tabdump site 2>/dev/null |grep xcatsslversion";
-        xCAT::Utils->runcmd("$cmds", -1);
-        if ($::RUNCMD_RC != 0) {
-
-            # if site.xcatsslversion was not set, then set the default value TLSv1_2
-            $cmds = "$::XCATROOT/sbin/chtab key=xcatsslversion site.value=TLSv1_2;";
-            xCAT::Utils->runcmd("$cmds", 0);
-            if ($::RUNCMD_RC != 0) {
-                xCAT::MsgUtils->message('E', "Could not add default value for site.xcatsslversion.");
             }
         }
     }

--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -1548,7 +1548,10 @@ until ($quit) {
 
         populate_site_hash();
         my %extrasslargs;
+
         if ($::XCATSITEVALS{xcatsslversion}) { $extrasslargs{SSL_version} = $::XCATSITEVALS{xcatsslversion}; }
+        $extrasslargs{SSL_version} = "SSLv23:!SSLv2:!SSLv3:!TLSv1" unless length $extrasslargs{SSL_version};
+
         if ($::XCATSITEVALS{xcatsslciphers}) { $extrasslargs{SSL_cipher_list} = $::XCATSITEVALS{xcatsslciphers}; }
         use Data::Dumper;
 


### PR DESCRIPTION
### The PR is to fix issue _#6058_

### The modification include

_##Set the default value of `site.xcatsslversion` to `SSLv23:!SSLv2:!SSLv3:!TLSv1`_

See https://metacpan.org/pod/IO::Socket::SSL for detailed explanation.

> **SSL_version**
>
> Sets the version of the SSL protocol used to transmit data. 'SSLv23' uses a handshake compatible with SSL2.0, SSL3.0 and TLS1.x, while 'SSLv2', 'SSLv3', 'TLSv1', 'TLSv1_1', 'TLSv1_2', or 'TLSv1_3' restrict handshake and protocol to the specified version. All values are case-insensitive. Instead of 'TLSv1_1', 'TLSv1_2', and 'TLSv1_3' one can also use 'TLSv11', 'TLSv12', and 'TLSv13'. Support for 'TLSv1_1', 'TLSv1_2', and 'TLSv1_3' requires recent versions of Net::SSLeay and openssl.
>
> Independent from the handshake format you can limit to set of accepted SSL versions by adding !version separated by ':'.
>
> The default SSL_version is 'SSLv23:!SSLv3:!SSLv2' which means, that the handshake format is compatible to SSL2.0 and higher, but that the successful handshake is limited to TLS1.0 and higher, that is no SSL2.0 or SSL3.0 because both of these versions have serious security issues and should not be used anymore. You can also use !TLSv1_1 and !TLSv1_2 to disable TLS versions 1.1 and 1.2 while still allowing TLS version 1.0.
>
> Setting the version instead to 'TLSv1' might break interaction with older clients, which need and SSL2.0 compatible handshake. On the other side some clients just close the connection when they receive a TLS version 1.1 request. In this case setting the version to 'SSLv23:!SSLv2:!SSLv3:!TLSv1_1:!TLSv1_2' might help.