### PR TITLE
confignetwork framework refine using nmcli

### DIFF
--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -559,7 +559,11 @@ function configure_nicdevice {
             if [ $? -ne 0 ]; then
                 errorcode=1
             else
-               create_bridge_interface ifname=$nic_dev _brtype=$nic_dev_type _port=$base_nic_dev _pretype=$base_nic_type
+               if [ "$networkmanager_active" = "0" ]; then
+                   create_bridge_interface ifname=$nic_dev _brtype=$nic_dev_type _port=$base_nic_dev _pretype=$base_nic_type
+               elif [ "$networkmanager_active" = "1" ]; then
+                   create_bridge_interface_nmcli ifname=$nic_dev _brtype=$nic_dev_type _port=$base_nic_dev _pretype=$base_nic_type
+               fi
             fi
         #configure vlan
         elif [ x"$nic_dev_type" = "xvlan" ]; then
@@ -570,11 +574,18 @@ function configure_nicdevice {
                 vlanid=`echo "$nic_dev" | $sed -e 's/^\(.*\)vla\?n\?\([0-9]\+\)$/\2/'`
                 vlanname=`echo "$nic_dev" | $sed -e 's/^\(.*\)vla\?n\?\([0-9]\+\)$/\1/'`
             fi
-            create_vlan_interface ifname=$vlanname vlanid=$vlanid
-
+            if [ "$networkmanager_active" = "0" ]; then
+                create_vlan_interface ifname=$vlanname vlanid=$vlanid
+            elif [ "$networkmanager_active" = "1" ]; then
+                create_vlan_interface_nmcli ifname=$vlanname vlanid=$vlanid
+            fi
         #configure bond
         elif [ x"$nic_dev_type" = "xbond" ]; then
-            create_bond_interface ifname=$nic_dev slave_ports=$base_nic_for_bond slave_type=$base_nic_type
+            if [ "$networkmanager_active" = "0" ]; then
+                create_bond_interface ifname=$nic_dev slave_ports=$base_nic_for_bond slave_type=$base_nic_type
+            elif [ "$networkmanager_active" = "1" ]; then
+                create_bond_interface_nmcli ifname=$nic_dev slave_ports=$base_nic_for_bond slave_type=$base_nic_type
+            fi
         elif [ x"$nic_dev_type" = "xinfiniband" ] || [ x"$nic_dev_type" = "xOmnipath" ]; then
             log_info "Call configib for IB nics: $nic_dev, ports: $num_iba_ports"
             log_info "NIC_IBNICS=$nic_dev NIC_IBAPORTS=$num_iba_ports configib"
@@ -591,26 +602,6 @@ function configure_nicdevice {
         ((num+=1))
     done
     return $errorcode
-}
-
-############################################################################
-#
-# disable NetworkManager and start network
-#
-###########################################################################
-function enable_network_service {
-
-    checkservicestatus NetworkManager > /dev/null
-    if [ $? -eq 0 ]; then
-        log_info "NetworkManager is active. start to stop it ..."
-        stopservice NetworkManager | log_lines info
-        disableservice NetworkManager
-        enableservice network
-        startservice network
-    else
-        log_info "NetworkManager is inactive."
-    fi
-
 }
 
 ############################################################################
@@ -642,6 +633,17 @@ if [ $boot_install_nic -eq 1 ];then
         log_error "Can not determine proper install nic."
         errorcode=1
     fi
+fi
+
+#check if using NetworkManager or  network service
+networkmanager_active=2
+check_NetworkManager_or_network_service
+if [ $? -eq 0 ]; then
+    networkmanager_active=0
+elif [ $? -eq 1 ]; then
+    networkmanager_active=1
+else
+    exit 1
 fi
 
 #replace | with "@", for example, eth1|eth2  ---->   eth1@eth2
@@ -695,8 +697,6 @@ if [ -n "$valid_sorted_nicdevice_list" ]; then
     log_info "All valid nics and device list:"
     echo "$valid_sorted_nicdevice_list" |log_lines info
 fi
-#enable network service
-enable_network_service
 
 #config nics and ifcfg files
 configure_nicdevice "$valid_sorted_nicdevice_list"

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -1568,7 +1568,6 @@ function decode_arguments {
 #
 ##############################################################################
 function check_NetworkManager_or_network_service() {
-
     #check NetworkManager is active
     checkservicestatus NetworkManager > /dev/null 2>/dev/null
     if [ $? -eq 0 ]; then
@@ -1577,25 +1576,30 @@ function check_NetworkManager_or_network_service() {
         type $nmcli >/dev/null 2>/dev/null
         if [ $? -ne 0 ]; then
             log_error "There is no nmcli"
+        else
+            stopservice network | log_lines info
+            disableservice network | log_lines info
+            stopservice networking | log_lines info
+            disableservice networking | log_lines info
+            return 1
         fi
-        stopservice network
-        stopservice networking
-        return 1
-    else
-        checkservicestatus network > /dev/null 2>/dev/null
-        if [ $? -eq 0 ]; then
-            log_info "network service is active"
-            return 0
-        fi
-        checkservicestatus networking > /dev/null 2>/dev/null
-        if [ $? -eq 0 ]; then
-            log_info "networking service is active"
-            return 0
-        fi
-        log_error "NetworkManager, network.service and networking service are not active"
-        return 2
-        
     fi
+    checkservicestatus network > /dev/null 2>/dev/null
+    if [ $? -eq 0 ]; then
+        stopservice NetworkManager | log_lines info
+        disableservice NetworkManager | log_lines info
+        log_info "network service is active"
+        return 0
+    fi
+    checkservicestatus networking > /dev/null 2>/dev/null
+    if [ $? -eq 0 ]; then
+        stopservice NetworkManager | log_lines info
+        disableservice NetworkManager | log_lines info
+        log_info "networking service is active"
+        return 0
+    fi
+    log_error "NetworkManager, network.service and networking service are not active"
+    return 2
 }
 
 ###############################################################################

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -743,6 +743,17 @@ function check_brctl() {
     fi
 }
 
+###############################################################################
+#
+# check and set device managed
+# input: ifname
+# output: 0   managed
+#         1   umanaged
+#
+###############################################################################
+function check_and_set_device_managed() {
+    ifname=$1
+}
 
 ###############################################################################
 #
@@ -1548,3 +1559,78 @@ function decode_arguments {
     return $rc
 }
 
+###############################################################################
+#
+# check NetworkManager
+# output: 2 error
+#         1 using NetworkManager
+#         0 using network
+#
+##############################################################################
+function check_NetworkManager_or_network_service() {
+
+    #check NetworkManager is active
+    checkservicestatus NetworkManager > /dev/null 2>/dev/null
+    if [ $? -eq 0 ]; then
+        log_info "NetworkManager is active"
+        #check nmcli is installed
+        type $nmcli >/dev/null 2>/dev/null
+        if [ $? -ne 0 ]; then
+            log_error "There is no nmcli"
+        fi
+        stopservice network
+        stopservice networking
+        return 1
+    else
+        checkservicestatus network > /dev/null 2>/dev/null
+        if [ $? -eq 0 ]; then
+            log_info "network service is active"
+            return 0
+        fi
+        checkservicestatus networking > /dev/null 2>/dev/null
+        if [ $? -eq 0 ]; then
+            log_info "networking service is active"
+            return 0
+        fi
+        log_error "NetworkManager, network.service and networking service are not active"
+        return 2
+        
+    fi
+}
+
+###############################################################################
+#
+# create vlan using nmcli
+#
+# input : ifname=<ifname> slave_ports=<ports> xcatnet=<xcatnetwork> _ipaddr=<ip> _netmask=<netmask> _mtu=<mtu> _bridge=<bridge_name> vlanid=<vlanid>
+# return : 0 success
+#
+###############################################################################
+function create_vlan_interface_nmcli {
+    log_info "create_vlan_interface_nmcli $@"
+}
+
+###############################################################################
+#
+# create  bridge
+#
+# input : ifname=<ifname> xcatnet=<xcat_network> _ipaddr=<ip> _netmask=<netmask> _port=<port> _pretype=<nic_type> _brtype=<bridge|bridge_ovs> _mtu=<mtu> _bridge=<bridge_name>
+#
+###############################################################################
+function create_bridge_interface_nmcli {
+    log_info "create_bridge_interface_nmcli $@"
+
+}
+
+#############################################################################################################################
+#
+# create bond or bond->vlan interface
+# https://www.kernel.org/doc/Documentation/networking/bonding.txt
+# https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Networking_Guide/sec-Using_Channel_Bonding.html
+#
+# input : ifname=<nic> xcatnet=<xcatnetwork> _ipaddr=<ip> _netmask=<netmask> _bonding_opts=<bonding_opts> _mtu=<mtu> slave_ports=<port1,port2>
+#
+############################################################################################################################
+function create_bond_interface_nmcli {
+    log_info "create_bond_interface $@"
+}


### PR DESCRIPTION
### The PR is for task

https://github.com/xcat2/xcat2-task-management/issues/628

_##Feature description##_

In RH8, NetworkManager is default enabled and used, confignetwork use nmcli to configure network interfaces.

In RH7.x and below OS distribution, NetworkManager is disabled in xCAT managed node, confignetwork use network service to manage network interfaces. If the node is not xCAT managed node and NetworkManager is used, confignetwork use nmcli to configure network interfaces.

### The content of the PR:
The mini-design: https://github.com/xcat2/xcat-core/wiki/The-mini-design-of-confignetwork-support-NetworkManager

### The UT result
1. on RH8 using ``nmcli``, running ``create_vlan_interface_nmcli ``
```
postscripts]# updatenode byrh09 "confignetwork"
byrh09: =============updatenode starting====================
byrh09: trying to download postscripts...
byrh09: postscripts downloaded successfully
byrh09: trying to get mypostscript from 10.4.41.1...
byrh09: postscript start..: confignetwork
byrh09: [I]: NetworkManager is active
byrh09:
byrh09: [I]: All valid nics and device list:
byrh09: [I]: ens5.1 ens5
byrh09: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh09: configure nic and its device : ens5.1 ens5
byrh09: [I]: create_vlan_interface_nmcli ifname=ens5 vlanid=1
byrh09: postscript end....: confignetwork exited with code 0
byrh09: Running of postscripts has completed.
byrh09: =============updatenode ending====================
```
2. on RH7.6, using ``network.service``,  running ``create_vlan_interface``
```
xcat]# updatenode c910f04x40 "confignetwork"
c910f04x40: Warning: the ECDSA host key for 'c910f04x40' differs from the key for the IP address '10.4.40.1'
c910f04x40: Offending key for IP in /root/.ssh/known_hosts:4
c910f04x40: Matching host key in /root/.ssh/known_hosts:118

c910f04x40: =============updatenode starting====================
c910f04x40: trying to download postscripts...
c910f04x40: postscripts downloaded successfully
c910f04x40: trying to get mypostscript from 10.4.41.1...
c910f04x40: postscript start..: confignetwork
c910f04x40: [I]: network service is active
c910f04x40: [I]: All valid nics and device list:
c910f04x40: [I]: enp6s0f1.1 enp6s0f1
c910f04x40: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f04x40: configure nic and its device : enp6s0f1.1 enp6s0f1
c910f04x40: [I]: create_vlan_interface ifname=enp6s0f1 vlanid=1
c910f04x40: [I]: Pickup xcatnet, "50_0_0_0-255_0_0_0", from NICNETWORKS for interface "enp6s0f1".
c910f04x40: [I]: ip link add link enp6s0f1 name enp6s0f1.1 type vlan id 1
c910f04x40: [I]: ip link set enp6s0f1.1 up
c910f04x40: [I]: create_persistent_ifcfg ifname=enp6s0f1.1 xcatnet=50_0_0_0-255_0_0_0 inattrs=ONBOOT=yes,USERCTL=no,VLAN=yes
c910f04x40: ['ifcfg-enp6s0f1.1']
c910f04x40: [I]: >> ONBOOT="yes"
c910f04x40: [I]: >> USERCTL="no"
c910f04x40: [I]: >> VLAN="yes"
c910f04x40: [I]: >> DEVICE="enp6s0f1.1"
c910f04x40: [I]: >> BOOTPROTO="static"
c910f04x40: [I]: >> IPADDR="50.4.41.101"
c910f04x40: [I]: >> NETMASK="255.0.0.0"
c910f04x40: [I]: >> NAME="enp6s0f1.1"
c910f04x40: postscript end....: confignetwork exited with code 0
c910f04x40: Running of postscripts has completed.
c910f04x40: =============updatenode ending====================
```