### PR TITLE
Fix issue that site.master is not set

### DIFF
--- a/perl-xCAT/xCAT/ServiceNodeUtils.pm
+++ b/perl-xCAT/xCAT/ServiceNodeUtils.pm
@@ -555,6 +555,10 @@ sub get_ServiceNode
                 {
                     push @{ $snhash{$master} }, $node;
                 }
+                else
+                {
+                    xCAT::MsgUtils->message('SW', "Unknown master for node: $node, neither noderes.servicenode nor site.master is set\n");
+                }
             }
         }
 

--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -2283,6 +2283,10 @@ sub dispatch_request {
         $SIG{CHLD} = 'DEFAULT';
         xCAT::MsgUtils->trace(0, "D", "xcatd: handle request '$req->{command}->[0]' by plugin '$modname''s preprocess_request");
         $reqs = ${ "xCAT_plugin::" . $modname . "::" }{preprocess_request}->($req, $dispatch_cb, \&do_request);
+        if (not(scalar @$reqs) and not(defined xCAT::TableUtils->get_site_attribute('master'))) {
+            $dispatch_cb->({ error => ['No site.master set, please check'], errorcode => [1] });
+            return;
+        }
     } else {    # otherwise, pass it in without hierarchy support
         $reqs = [$req];
     }

--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -2284,7 +2284,7 @@ sub dispatch_request {
         xCAT::MsgUtils->trace(0, "D", "xcatd: handle request '$req->{command}->[0]' by plugin '$modname''s preprocess_request");
         $reqs = ${ "xCAT_plugin::" . $modname . "::" }{preprocess_request}->($req, $dispatch_cb, \&do_request);
         if (not(scalar @$reqs) and not(defined xCAT::TableUtils->get_site_attribute('master'))) {
-            $dispatch_cb->({ error => ['No site.master set, please check'], errorcode => [1] });
+            $dispatch_cb->({ warning => ["The 'master' attribute is not set in the site table and may cause  unexpected behavior."]});
             return;
         }
     } else {    # otherwise, pass it in without hierarchy support


### PR DESCRIPTION
### The PR is to fix issue that site.master is missing when doing hardware control

### The modification include

1. In get_ServiceNode, add WARN message if no noderes.servicenode and site.master are not set
2. In xcatd, if preprocess_request return null, checking site.master and report error if not set.

### The UT result
Without fix, nothing returned:
```
~# rpower xcatcn state
~#
```
With fix
```
~# rpower xcatcn state
Warning: [xcatmn]: The 'master' attribute is not set in the site table and may cause  unexpected behavior.
```