### PR TITLE
Handle the exit code properly when `copycds` failed, and pass through outputs of `cpio`

### DIFF
--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -2250,7 +2250,7 @@ sub copycd
             print $KID $_ . "\n";
         }
         close($KID);
-        $rc = $?;
+        $rc = $? >> 8;
     }
     else
     {
@@ -2267,16 +2267,8 @@ sub copycd
             $callback->({ sinfo => "$fout" });
             ++$copied;
         }
-        if ($copied == $numFiles)
-        {
-            #media copy success
-            exit(0);
-        }
-        else
-        {
-            #media copy failed
-            exit(1);
-        }
+        close(PIPE);
+        exit($? >> 8);
     }
 
     #my $rc = system("cd $path; find . | nice -n 20 cpio -dump $installroot/$distname/$arch");

--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -2293,7 +2293,7 @@ sub copycd
 
     if ($rc != 0)
     {
-        $callback->({ error => "Media copy operation failed, status $rc" });
+        $callback->({ error => "Media copy operation failed, status $rc", errorcode => [1] });
     }
     else
     {

--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -2261,7 +2261,11 @@ sub copycd
         my $copied = 0;
         my ($percent, $fout);
         while (<PIPE>) {
-            next if /^cpio:/;
+            if (/^cpio:/) {
+                chomp;
+                $callback->({ data => $_ });
+                next;
+            }
             $percent = $copied / $numFiles;
             $fout = sprintf "%0.2f%%", $percent * 100;
             $callback->({ sinfo => "$fout" });


### PR DESCRIPTION
### The PR is to fix issue _#6068_

### The modification include

_##Handle the exit code of child process (`cpio`) properly_
_##Handle the output of `cpio` properly_
_##Handle the exit code properly when `copycds` failed_

### The unit test ###
 result
```
# copycds /mnt/iso//redhat/8/RHEL-8.0.0-RC-1.0/RHEL-8.0.0-20190228.1-ppc64le-dvd1.is
Copying media to /install/rhels8.0.0/ppc64le
cpio: write error: No space left on device
Error: [c910f03c05k21]: Media copy operation failed, status 1
# echo $?
1
```