### PR TITLE
Change the default_md in openssl.cnf.tmpl to sha384

### DIFF
--- a/xCAT-server/share/xcat/ca/openssl.cnf.tmpl
+++ b/xCAT-server/share/xcat/ca/openssl.cnf.tmpl
@@ -74,7 +74,7 @@ cert_opt 	= ca_default		# Certificate field options
 
 default_days	= 7300			# how long to certify for
 default_crl_days= 30			# how long before next CRL
-default_md	= default		# which md to use.
+default_md	= sha384		# which md to use.
 preserve	= no			# keep passed DN ordering
 
 # A few difference way of specifying how similar the request should look


### PR DESCRIPTION
### The PR is to fix issue _#6076_

### The modification include

_##Change the default_md in `openssl.cnf.tmpl` to sha384_