### PR TITLE
Remove --no-host-reboot option from rflash

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/management/advanced/rflash/openbmc/openbmc_common.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/management/advanced/rflash/openbmc/openbmc_common.rst
@@ -6,16 +6,11 @@ Unattended flash of OpenBMC firmware will do the following events:
 #. Activate both BMC firmware and Host firmware
 #. If BMC firmware becomes activate, reboot BMC to apply new BMC firmware, or else, ``rflash`` will exit
 #. If BMC itself state is ``NotReady``, ``rflash`` will exit
-#. If BMC itself state is ``Ready``, and use ``--no-host-reboot`` option, ``rflash`` will not reboot the compute node
-#. If BMC itself state is ``Ready``, and do not use ``--no-host-reboot`` option, ``rflash`` will reboot the compute node to apply Host firmware
+#. If BMC itself state is ``Ready``, ``rflash`` will reboot the compute node to apply Host firmware
 
 Use the following command to flash the firmware unattended: ::
 
     rflash <noderange> -d /path/to/directory
-
-Use the following command to flash the firmware unattended and not reboot the compute node: ::
-
-    rflash <noderange> -d /path/to/directory --no-host-reboot
 
 If there are errors encountered during the flash process, take a look at the manual steps to continue flashing the BMC.
 

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -422,7 +422,7 @@ my %usage = (
     "OpenPOWER OpenBMC specific:
         rflash <noderange> {[-c|--check] | [-l|--list]}
         rflash <noderange> <tar_file_path> {[-c|--check] | [-a|--activate] | [-u|--upload]}
-        rflash <noderange> <tar_file_diretory> [-d] [--no-host-reboot]
+        rflash <noderange> <tar_file_diretory> [-d]
         rflash <noderange> <image_id> {[-a|--activate] | [--delete]}",
     "mkhwconn" =>
       "Usage:

--- a/xCAT-client/pods/man1/rflash.1.pod
+++ b/xCAT-client/pods/man1/rflash.1.pod
@@ -34,7 +34,7 @@ B<rflash> I<noderange> {[B<-c>|B<--check>] | [B<-l>|B<--list>]}
 
 B<rflash> I<noderange> I<tar_file_path> {[B<-c>|B<--check>] | [B<-a>|B<--activate>] | [B<-u>|B<--upload>]}
 
-B<rflash> I<noderange> I<tar_file_directory> [B<-d>] [B<--no-host-reboot>]
+B<rflash> I<noderange> I<tar_file_directory> [B<-d>]
 
 B<rflash> I<noderange> I<image_id> {[B<-a>|B<--activate>] | [B<--delete>]}
 
@@ -124,8 +124,6 @@ B<Note:> When using B<rflash> in hierarchical environment, the .tar file must be
 B<-d>:
 
 This option steamlines the update, activate, reboot BMC and reboot HOST procedure. It expects a directory containing both BMC and Host .tar files. When BMC and Host tar files are provided, the command will upload and activate firmware. After BMC becomes activate, it will reboot BMC. If BMC state is Ready, the command will reboot the HOST. If BMC state is NotReady, the command will exit.
-
-B<Note:> When using B<--no-host-reboot>, it will not reboot the host after BMC is reboot.
 
 B<--delete>:
 

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/flash.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/flash.py
@@ -26,13 +26,13 @@ class FlashInterface(object):
         """
         return task.run('delete_firm', delete_id)
 
-    def flash_process(self, task, directory, no_host_reboot):
+    def flash_process(self, task, directory):
         """Upload and activate firmware
 
         :param task: a Task instance containing the nodes to act on.
         :directory: firmware directory
         """
-        return task.run('flash_process', directory, no_host_reboot)
+        return task.run('flash_process', directory)
 
     def list_firm_info(self, task):
         """List firmware

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc/openbmc_flash.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc/openbmc_flash.py
@@ -109,7 +109,7 @@ class OpenBMCFlashTask(ParallelNodesCommand):
 
         self.callback.info('Attempting to delete ID=%s, please wait..' % delete_id)
 
-    def pre_flash_process(self, task, directory, no_host_reboot, **kw):
+    def pre_flash_process(self, task, directory, **kw):
 
         if not os.path.exists(XCAT_LOG_RFLASH_DIR):
             os.makedirs(XCAT_LOG_RFLASH_DIR)
@@ -263,7 +263,7 @@ class OpenBMCFlashTask(ParallelNodesCommand):
 
         self.activate_result.update({node: 'SUCCESS'})
 
-    def _reboot_to_effect(self, obmc, no_host_reboot, node):
+    def _reboot_to_effect(self, obmc, node):
 
         self._msg_process(node, 'Firmware will be flashed on reboot, deleting all BMC diagnostics...')
         try:
@@ -301,10 +301,6 @@ class OpenBMCFlashTask(ParallelNodesCommand):
             return self._msg_process(node, error, msg_type='E', update_rc=True)
 
         self._msg_process(node, 'BMC %s' % bmc_state, update_rc=True)
-
-        if no_host_reboot:
-            self.activate_result.update({node: 'SUCCESS'})
-            return
 
         try:
             obmc.set_power_state('off')
@@ -440,7 +436,7 @@ class OpenBMCFlashTask(ParallelNodesCommand):
         else:
             self.callback.info('%s: [%s] Firmware removed' % (node, delete_id))
 
-    def flash_process(self, directory, no_host_reboot, **kw):
+    def flash_process(self, directory, **kw):
 
         node = kw['node']
         obmc = openbmc.OpenBMCRest(name=node, nodeinfo=kw['nodeinfo'], messager=self.callback,
@@ -482,7 +478,7 @@ class OpenBMCFlashTask(ParallelNodesCommand):
 
         self._check_id_status(obmc, activate_ids, node, only_act=False)
 
-        self._reboot_to_effect(obmc, no_host_reboot, node)
+        self._reboot_to_effect(obmc, node)
 
     def list_firm_info(self, **kw):
 
@@ -572,6 +568,6 @@ class OpenBMCFlashTask(ParallelNodesCommand):
 
         self._flash_summary()
 
-    def post_flash_process(self, task, directory, no_host_reboot, **kw):
+    def post_flash_process(self, task, directory, **kw):
 
         self._flash_summary()

--- a/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
+++ b/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
@@ -174,7 +174,7 @@ class OpenBMCManager(base.BaseManager):
         # 1, parse agrs
         rflash_usage = """
         Usage:
-            rflash [[-a|--activate <arg>] | [-c|--check <arg>] | [-d <arg> [--no-host-reboot]] | [--delete <arg>] | [-l|--list] |  [-u|--upload <arg>]] [-V|--verbose]
+            rflash [[-a|--activate <arg>] | [-c|--check <arg>] | [-d <arg> ] | [--delete <arg>] | [-l|--list] |  [-u|--upload <arg>]] [-V|--verbose]
 
         Options:
             -V,--verbose          Show verbose message
@@ -184,7 +184,6 @@ class OpenBMCManager(base.BaseManager):
             -l,--list             List firmware info
             -u,--upload <arg>     Upload firmware file
             --delete <arg>        Delete firmware
-            --no-host-reboot      Not reboot host after activate
         """
 
         try:
@@ -211,7 +210,7 @@ class OpenBMCManager(base.BaseManager):
         elif opts['--list']:
             DefaultFlashManager().list_firm_info(runner)
         elif opts['-d']:
-            DefaultFlashManager().flash_process(runner, opts['-d'], opts['--no-host-reboot'])
+            DefaultFlashManager().flash_process(runner, opts['-d'])
         elif opts['--delete']:
             DefaultFlashManager().delete_firm(runner, opts['--delete'])
         elif opts['--upload']:

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2945,6 +2945,7 @@ sub rpower_response {
                     #after retry 5 times, the host is still off, print error and return
                     my $wait_time_X = $node_info{$node}{wait_on_end} - $node_info{$node}{wait_on_start};
                     xCAT::SvrUtils::sendmsg([1, "Sent power-on command but state did not change to $::POWER_STATE_ON after waiting $wait_time_X seconds. (State=$all_status)."], $callback, $node);
+                    xCAT::SvrUtils::sendmsg([1, "Run 'reventlog <BMC IP>' command to see possible reasons for failure."], $callback, $node);
                     $node_info{$node}{cur_status} = "";
                     $wait_node_num--;
                     return;

--- a/xCAT-server/lib/xcat/plugins/openbmc2.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc2.pm
@@ -206,7 +206,6 @@ sub parse_args {
         }
     } elsif ($command eq "rflash") {
         my ($activate, $check, $delete, $directory, $list, $upload) = (0) x 6;
-        my $no_host_reboot;
         GetOptions(
             'a|activate' => \$activate,
             'c|check'    => \$check,
@@ -214,7 +213,6 @@ sub parse_args {
             'd'          => \$directory,
             'l|list'     => \$list,
             'u|upload'   => \$upload,
-            'no-host-reboot' => \$no_host_reboot,
         );
         my $option_num = $activate+$check+$delete+$directory+$list+$upload;
         if ($option_num >= 2) {
@@ -470,8 +468,6 @@ sub refactor_args {
             if ($tmp =~ /^-/) {
                 if ($tmp !~ /^-V$|^--verbose$/) {
                     $new_args[0] = $tmp;
-                } elsif ($tmp =~ /^--no-host-reboot$/) {
-                    $new_args[2] = $tmp;
                 } else {
                     $new_args[3] = $tmp;
                 }


### PR DESCRIPTION
### The PR is to fix issue _#6065_

### The modification include

* Remove `--no-host-reboot` option from `rflash`. Perl and Python versions.

* Update documentation

### The UT result
