### PR TITLE
add more debug information for dynamic group test cases

### DIFF
--- a/xCAT-test/autotest/testcase/chdef/cases0
+++ b/xCAT-test/autotest/testcase/chdef/cases0
@@ -153,12 +153,17 @@ end
 start:chdef_dynamic_group
 description:chdef with dynamic node group
 label:mn_only,ci_test,db
+cmd:tabdump nodegroup
+cmd:tabdump nodelist
 cmd:mkdef -t node -o testnode1-testnode2 mgt=hmc cons=hmc groups=all,systemp
 check:rc==0
+cmd:tabdump nodelist|grep testnode
 cmd:mkdef -t node -o testnode3-testnode4 mgt=hmc cons=ipmi groups=all,systemx
 check:rc==0
+cmd:tabdump nodelist|grep testnode
 cmd:mkdef -t group -o dyngrp -d -w cons==hmc
 check:rc==0
+cmd:tabdump nodegroup
 cmd:lsdef -s dyngrp
 check:rc==0
 check:output=~testnode1
@@ -167,6 +172,7 @@ check:output!~testnode3
 check:output!~testnode4
 cmd:chdef -t group -o dyngrp -d -w mgt==hmc
 check:rc==0
+cmd:tabdump nodegroup
 cmd:lsdef -s dyngrp
 check:rc==0
 check:output=~testnode1
@@ -175,6 +181,7 @@ check:output=~testnode3
 check:output=~testnode4
 cmd:chdef -t group -o dyngrp -d -p -w cons==hmc -w groups=~systemp
 check:rc==0
+cmd:tabdump nodegroup
 cmd:lsdef -s dyngrp
 check:rc==0
 check:output=~testnode1
@@ -186,6 +193,7 @@ check:rc==0
 check:output=~wherevals=mgt==hmc::cons==hmc::groups=~systemp
 cmd:chdef -t group -o dyngrp -d -m -w cons==hmc -w groups=~systemp
 check:rc==0
+cmd:tabdump nodegroup
 cmd:lsdef -s dyngrp
 check:output=~testnode1
 check:output=~testnode2
@@ -193,6 +201,7 @@ check:output=~testnode3
 check:output=~testnode4
 cmd:rmdef -t group -o dyngrp
 check:rc==0
+cmd:tabdump nodegroup
 cmd:rmdef -t node -o testnode1-testnode4
 check:rc==0
 end

--- a/xCAT-test/autotest/testcase/mkdef/cases0
+++ b/xCAT-test/autotest/testcase/mkdef/cases0
@@ -95,12 +95,17 @@ end
 start:mkdef_dynamic_group
 description:mkdef with dynamic node group
 label:mn_only,ci_test,db
+cmd:tabdump nodegroup
+cmd:tabdump nodelist
 cmd:mkdef -t node -o testnode1-testnode2 mgt=hmc cons=hmc groups=all,systemp
 check:rc==0
+cmd:tabdump nodelist|grep testnode
 cmd:mkdef -t node -o testnode3-testnode4 mgt=ipmi cons=ipmi groups=all,systemx
 check:rc==0
+cmd:tabdump nodelist|grep testnode
 cmd:mkdef -t group -o dyngrp1 -d -w mgt==hmc
 check:rc==0
+cmd:tabdump nodegroup
 cmd:lsdef -s dyngrp1
 check:rc==0
 check:output=~testnode1
@@ -109,6 +114,7 @@ check:output!~testnode3
 check:output!~testnode4
 cmd:mkdef -t group -o dyngrp2 -d -w mgt==hmc -w cons==hmc
 check:rc==0
+cmd:tabdump nodegroup
 cmd:lsdef -s dyngrp2
 check:rc==0
 check:output=~testnode1
@@ -117,6 +123,7 @@ check:output!~testnode3
 check:output!~testnode4
 cmd:mkdef -t group -o dyngrp3 -d -w mgt==hmc -w cons==ipmi
 check:rc==0
+cmd:tabdump nodegroup
 cmd:lsdef -s dyngrp3
 check:rc!=0
 check:output!~testnode1
@@ -125,6 +132,7 @@ check:output!~testnode3
 check:output!~testnode4
 cmd:rmdef -t group -o dyngrp1,dyngrp2,dyngrp3
 check:rc==0
+cmd:tabdump nodegroup
 cmd:rmdef -t node -o testnode1-testnode4
 check:rc==0
 end

--- a/xCAT-test/autotest/testcase/rmdef/cases0
+++ b/xCAT-test/autotest/testcase/rmdef/cases0
@@ -90,21 +90,27 @@ description:rmdef to remove dynamic node group
 label:mn_only,ci_test,db
 cmd:lsdef testnode1;if [ $? -eq 0 ]; then lsdef -l testnode1 -z >/tmp/testnode1.standa ; rmdef testnode1;fi
 cmd:lsdef testnode2;if [ $? -eq 0 ]; then lsdef -l testnode2 -z >/tmp/testnode2.standa ; rmdef testnode2;fi
+cmd:tabdump nodegroup
+cmd:tabdump nodelist
 cmd:mkdef -t node -o testnode1-testnode2 mgt=hmc cons=hmc groups=all,systemp
 check:rc==0
+cmd:tabdump nodelist|grep testnode
 cmd:mkdef -t group -o dyngrp -d -w mgt==hmc -w cons==hmc -w groups==all,systemp
 check:rc==0
+cmd:tabdump nodegroup
 cmd:lsdef -s dyngrp
 check:rc==0
 check:output=~testnode1
 check:output=~testnode2
 cmd:rmdef -t node -o dyngrp
 check:rc=0
+cmd:tabdump nodegroup
 cmd:lsdef -t node testnode1,testnode2
 check:output=~Could not find an object named 'testnode1' of type 'node'.
 check:output=~Could not find an object named 'testnode2' of type 'node'.
 cmd:rmdef -t group -o dyngrp
 check:rc==0
+cmd:tabdump nodegroup
 cmd:lsdef -t group -o dyngrp
 check:output=~Could not find an object named 'dyngrp' of type 'group'.
 cmd:if [ -e /tmp/testnode1.standa ]; then cat /tmp/testnode1.standa | mkdef -z; rm -rf /tmp/testnode1.standa; fi


### PR DESCRIPTION
### The PR is for task  https://github.ibm.com/xcat2/task_management/issues/21

### The modification include

*  add more debug information for dynamic group test cases

### The UT result

* rmdef_dynamic_group
```
RUN:lsdef testnode1;if [ $? -eq 0 ]; then lsdef -l testnode1 -z >/tmp/testnode1.standa ; rmdef testnode1;fi [Wed Mar 13 02:32:29 2019]
Error: [c910f03c17k25]: Could not find an object named 'testnode1' of type 'node'.
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
No object definitions have been found

RUN:lsdef testnode2;if [ $? -eq 0 ]; then lsdef -l testnode2 -z >/tmp/testnode2.standa ; rmdef testnode2;fi [Wed Mar 13 02:32:30 2019]
Error: [c910f03c17k25]: Could not find an object named 'testnode2' of type 'node'.
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
No object definitions have been found

RUN:tabdump nodegroup [Wed Mar 13 02:32:30 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
#groupname,grouptype,members,membergroups,wherevals,comments,disable

RUN:tabdump nodelist [Wed Mar 13 02:32:30 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
#node,groups,status,statustime,appstatus,appstatustime,primarysn,hidden,updatestatus,updatestatustime,zonename,comments,disable
"c910f03c17k07","all","booted","01-09-2019 02:32:11",,,,,"synced","01-17-2019 04:16:05",,,
......
"c910f04x38v05","all,vm38","booted","03-12-2019 03:19:52",,,,,"failed","10-09-2018 07:47:42",,,

RUN:mkdef -t node -o testnode1-testnode2 mgt=hmc cons=hmc groups=all,systemp [Wed Mar 13 02:32:31 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
2 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:tabdump nodelist|grep testnode [Wed Mar 13 02:32:31 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
"testnode1","all,systemp",,,,,,,,,,,
"testnode2","all,systemp",,,,,,,,,,,

RUN:mkdef -t group -o dyngrp -d -w mgt==hmc -w cons==hmc -w groups==all,systemp [Wed Mar 13 02:32:32 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:tabdump nodegroup [Wed Mar 13 02:32:32 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
#groupname,grouptype,members,membergroups,wherevals,comments,disable
"dyngrp","dynamic","dynamic",,"mgt==hmc::cons==hmc::groups==all,systemp",,

RUN:lsdef -s dyngrp [Wed Mar 13 02:32:32 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
testnode1  (node)
testnode2  (node)
CHECK:rc == 0	[Pass]
CHECK:output =~ testnode1	[Pass]
CHECK:output =~ testnode2	[Pass]

RUN:rmdef -t node -o dyngrp [Wed Mar 13 02:32:33 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
2 object definitions have been removed.
CHECK:rc = 0	[Pass]

RUN:tabdump nodegroup [Wed Mar 13 02:32:34 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
#groupname,grouptype,members,membergroups,wherevals,comments,disable
"dyngrp","dynamic","dynamic",,"mgt==hmc::cons==hmc::groups==all,systemp",,

RUN:lsdef -t node testnode1,testnode2 [Wed Mar 13 02:32:35 2019]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Error: [c910f03c17k25]: Could not find an object named 'testnode1' of type 'node'.
Error: [c910f03c17k25]: Could not find an object named 'testnode2' of type 'node'.
No object definitions have been found
CHECK:output =~ Could not find an object named 'testnode1' of type 'node'.	[Pass]
CHECK:output =~ Could not find an object named 'testnode2' of type 'node'.	[Pass]

RUN:rmdef -t group -o dyngrp [Wed Mar 13 02:32:35 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:tabdump nodegroup [Wed Mar 13 02:32:36 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
#groupname,grouptype,members,membergroups,wherevals,comments,disable

RUN:lsdef -t group -o dyngrp [Wed Mar 13 02:32:36 2019]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Error: [c910f03c17k25]: Could not find an object named 'dyngrp' of type 'group'.
No object definitions have been found
CHECK:output =~ Could not find an object named 'dyngrp' of type 'group'.	[Pass]

RUN:if [ -e /tmp/testnode1.standa ]; then cat /tmp/testnode1.standa | mkdef -z; rm -rf /tmp/testnode1.standa; fi [Wed Mar 13 02:32:36 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:if [ -e /tmp/testnode2.standa ]; then cat /tmp/testnode2.standa | mkdef -z; rm -rf /tmp/testnode2.standa; fi [Wed Mar 13 02:32:36 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::rmdef_dynamic_group::Passed::Time:Wed Mar 13 02:32:36 2019 ::Duration::7 sec------
```

* mkdef_dynamic_group
```
------START::mkdef_dynamic_group::Time:Wed Mar 13 02:28:25 2019------

RUN:tabdump nodegroup [Wed Mar 13 02:28:25 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
#groupname,grouptype,members,membergroups,wherevals,comments,disable

RUN:tabdump nodelist [Wed Mar 13 02:28:25 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
#node,groups,status,statustime,appstatus,appstatustime,primarysn,hidden,updatestatus,updatestatustime,zonename,comments,disable
"c910f03c17k07","all","booted","01-09-2019 02:32:11",,,,,"synced","01-17-2019 04:16:05",,,
.......
"c910f04x38v05","all,vm38","booted","03-12-2019 03:19:52",,,,,"failed","10-09-2018 07:47:42",,,

RUN:mkdef -t node -o testnode1-testnode2 mgt=hmc cons=hmc groups=all,systemp [Wed Mar 13 02:28:26 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
2 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:tabdump nodelist|grep testnode [Wed Mar 13 02:28:26 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
"testnode1","all,systemp",,,,,,,,,,,
"testnode2","all,systemp",,,,,,,,,,,

RUN:mkdef -t node -o testnode3-testnode4 mgt=ipmi cons=ipmi groups=all,systemx [Wed Mar 13 02:28:27 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
2 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:tabdump nodelist|grep testnode [Wed Mar 13 02:28:27 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
"testnode1","all,systemp",,,,,,,,,,,
"testnode2","all,systemp",,,,,,,,,,,
"testnode3","all,systemx",,,,,,,,,,,
"testnode4","all,systemx",,,,,,,,,,,

RUN:mkdef -t group -o dyngrp1 -d -w mgt==hmc [Wed Mar 13 02:28:28 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:tabdump nodegroup [Wed Mar 13 02:28:28 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
#groupname,grouptype,members,membergroups,wherevals,comments,disable
"dyngrp1","dynamic","dynamic",,"mgt==hmc",,

RUN:lsdef -s dyngrp1 [Wed Mar 13 02:28:28 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f02c01p09  (node)
c910f02c01p13  (node)
c910f02c01p14  (node)
c910f02c01p15  (node)
c910f02fsp01  (node)
c910hmc01  (node)
testnode1  (node)
testnode2  (node)
CHECK:rc == 0	[Pass]
CHECK:output =~ testnode1	[Pass]
CHECK:output =~ testnode2	[Pass]
CHECK:output !~ testnode3	[Pass]
CHECK:output !~ testnode4	[Pass]

RUN:mkdef -t group -o dyngrp2 -d -w mgt==hmc -w cons==hmc [Wed Mar 13 02:28:29 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:tabdump nodegroup [Wed Mar 13 02:28:30 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
#groupname,grouptype,members,membergroups,wherevals,comments,disable
"dyngrp1","dynamic","dynamic",,"mgt==hmc",,
"dyngrp2","dynamic","dynamic",,"mgt==hmc::cons==hmc",,

RUN:lsdef -s dyngrp2 [Wed Mar 13 02:28:30 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f02c01p09  (node)
c910f02c01p13  (node)
c910f02c01p14  (node)
c910f02c01p15  (node)
testnode1  (node)
testnode2  (node)
CHECK:rc == 0	[Pass]
CHECK:output =~ testnode1	[Pass]
CHECK:output =~ testnode2	[Pass]
CHECK:output !~ testnode3	[Pass]
CHECK:output !~ testnode4	[Pass]

RUN:mkdef -t group -o dyngrp3 -d -w mgt==hmc -w cons==ipmi [Wed Mar 13 02:28:31 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:tabdump nodegroup [Wed Mar 13 02:28:31 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
#groupname,grouptype,members,membergroups,wherevals,comments,disable
"dyngrp1","dynamic","dynamic",,"mgt==hmc",,
"dyngrp2","dynamic","dynamic",,"mgt==hmc::cons==hmc",,
"dyngrp3","dynamic","dynamic",,"mgt==hmc::cons==ipmi",,

RUN:lsdef -s dyngrp3 [Wed Mar 13 02:28:31 2019]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: [c910f03c17k25]: No node in 'dyngrp3', check the noderange syntax.
CHECK:rc != 0	[Pass]
CHECK:output !~ testnode1	[Pass]
CHECK:output !~ testnode2	[Pass]
CHECK:output !~ testnode3	[Pass]
CHECK:output !~ testnode4	[Pass]

RUN:rmdef -t group -o dyngrp1,dyngrp2,dyngrp3 [Wed Mar 13 02:28:32 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
3 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:tabdump nodegroup [Wed Mar 13 02:28:33 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
#groupname,grouptype,members,membergroups,wherevals,comments,disable

RUN:rmdef -t node -o testnode1-testnode4 [Wed Mar 13 02:28:33 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
4 object definitions have been removed.
CHECK:rc == 0	[Pass]

------END::mkdef_dynamic_group::Passed::Time:Wed Mar 13 02:28:34 2019 ::Duration::9 sec------
```

* chdef_dynamic_group
```
------START::chdef_dynamic_group::Time:Wed Mar 13 02:17:48 2019------

RUN:tabdump nodegroup [Wed Mar 13 02:17:48 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
#groupname,grouptype,members,membergroups,wherevals,comments,disable

RUN:tabdump nodelist [Wed Mar 13 02:17:48 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
#node,groups,status,statustime,appstatus,appstatustime,primarysn,hidden,updatestatus,updatestatustime,zonename,comments,disable
"c910f03c17k07","all","booted","01-09-2019 02:32:11",,,,,"synced","01-17-2019 04:16:05",,,
......
"c910f04x38v05","all,vm38","booted","03-12-2019 03:19:52",,,,,"failed","10-09-2018 07:47:42",,,

RUN:mkdef -t node -o testnode1-testnode2 mgt=hmc cons=hmc groups=all,systemp [Wed Mar 13 02:17:48 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
2 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:tabdump nodelist|grep testnode [Wed Mar 13 02:17:49 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
"testnode1","all,systemp",,,,,,,,,,,
"testnode2","all,systemp",,,,,,,,,,,

RUN:mkdef -t node -o testnode3-testnode4 mgt=hmc cons=ipmi groups=all,systemx [Wed Mar 13 02:17:49 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
2 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:tabdump nodelist|grep testnode [Wed Mar 13 02:17:50 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
"testnode1","all,systemp",,,,,,,,,,,
"testnode2","all,systemp",,,,,,,,,,,
"testnode3","all,systemx",,,,,,,,,,,
"testnode4","all,systemx",,,,,,,,,,,

RUN:mkdef -t group -o dyngrp -d -w cons==hmc [Wed Mar 13 02:17:51 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:tabdump nodegroup [Wed Mar 13 02:17:51 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
#groupname,grouptype,members,membergroups,wherevals,comments,disable
"dyngrp","dynamic","dynamic",,"cons==hmc",,

RUN:lsdef -s dyngrp [Wed Mar 13 02:17:51 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f02c01p09  (node)
c910f02c01p13  (node)
c910f02c01p14  (node)
c910f02c01p15  (node)
testnode1  (node)
testnode2  (node)
CHECK:rc == 0	[Pass]
CHECK:output =~ testnode1	[Pass]
CHECK:output =~ testnode2	[Pass]
CHECK:output !~ testnode3	[Pass]
CHECK:output !~ testnode4	[Pass]

RUN:chdef -t group -o dyngrp -d -w mgt==hmc [Wed Mar 13 02:17:52 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:tabdump nodegroup [Wed Mar 13 02:17:53 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
#groupname,grouptype,members,membergroups,wherevals,comments,disable
"dyngrp","dynamic","dynamic",,"mgt==hmc",,

RUN:lsdef -s dyngrp [Wed Mar 13 02:17:53 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f02c01p09  (node)
c910f02c01p13  (node)
c910f02c01p14  (node)
c910f02c01p15  (node)
c910f02fsp01  (node)
c910hmc01  (node)
testnode1  (node)
testnode2  (node)
testnode3  (node)
testnode4  (node)
CHECK:rc == 0	[Pass]
CHECK:output =~ testnode1	[Pass]
CHECK:output =~ testnode2	[Pass]
CHECK:output =~ testnode3	[Pass]
CHECK:output =~ testnode4	[Pass]

RUN:chdef -t group -o dyngrp -d -p -w cons==hmc -w groups=~systemp [Wed Mar 13 02:17:54 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:tabdump nodegroup [Wed Mar 13 02:17:54 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
#groupname,grouptype,members,membergroups,wherevals,comments,disable
"dyngrp","dynamic","dynamic",,"mgt==hmc::cons==hmc::groups=~systemp",,

RUN:lsdef -s dyngrp [Wed Mar 13 02:17:55 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
testnode1  (node)
testnode2  (node)
CHECK:rc == 0	[Pass]
CHECK:output =~ testnode1	[Pass]
CHECK:output =~ testnode2	[Pass]
CHECK:output !~ testnode3	[Pass]
CHECK:output !~ testnode4	[Pass]

RUN:lsdef -t group -o dyngrp [Wed Mar 13 02:17:56 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Object name: dyngrp
    grouptype=dynamic
    members=testnode1,testnode2
    wherevals=mgt==hmc::cons==hmc::groups=~systemp
CHECK:rc == 0	[Pass]
CHECK:output =~ wherevals=mgt==hmc::cons==hmc::groups=~systemp	[Pass]

RUN:chdef -t group -o dyngrp -d -m -w cons==hmc -w groups=~systemp [Wed Mar 13 02:17:56 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:tabdump nodegroup [Wed Mar 13 02:17:57 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
#groupname,grouptype,members,membergroups,wherevals,comments,disable
"dyngrp","dynamic","dynamic",,"mgt==hmc",,

RUN:lsdef -s dyngrp [Wed Mar 13 02:17:57 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f02c01p09  (node)
c910f02c01p13  (node)
c910f02c01p14  (node)
c910f02c01p15  (node)
c910f02fsp01  (node)
c910hmc01  (node)
testnode1  (node)
testnode2  (node)
testnode3  (node)
testnode4  (node)
CHECK:output =~ testnode1	[Pass]
CHECK:output =~ testnode2	[Pass]
CHECK:output =~ testnode3	[Pass]
CHECK:output =~ testnode4	[Pass]

RUN:rmdef -t group -o dyngrp [Wed Mar 13 02:17:58 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:tabdump nodegroup [Wed Mar 13 02:17:59 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
#groupname,grouptype,members,membergroups,wherevals,comments,disable

RUN:rmdef -t node -o testnode1-testnode4 [Wed Mar 13 02:17:59 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
4 object definitions have been removed.
CHECK:rc == 0	[Pass]

------END::chdef_dynamic_group::Passed::Time:Wed Mar 13 02:18:01 2019 ::Duration::13 sec------
```