### PR TITLE
refine test cases for issue #6071

### DIFF
--- a/xCAT-test/autotest/testcase/xcatconfig/case0
+++ b/xCAT-test/autotest/testcase/xcatconfig/case0
@@ -335,8 +335,8 @@ start:xcatconfig_u_check_xcatsslversion_rhels_sles
 description:after xcatconfig -u the site.xcatsslversion will not be changed
 os:rhels,sles
 label:mn_only
-cmd:lsdef -t site -i xcatsslversion -c | grep '=TLSv1$'
-check:rc==0
+cmd:mkdir -p /tmp/xcatconfig_u_check_xcatsslversion_rhels_sles
+cmd:lsdef -t site  clustersite -z >/tmp/xcatconfig_u_check_xcatsslversion_rhels_sles/clustersite.stanza
 cmd:chtab key=xcatsslversion site.value=TLSv12
 check:rc==0
 cmd:lsdef -t site -i xcatsslversion -c | grep '=TLSv12$'
@@ -345,8 +345,8 @@ cmd:xcatconfig -u
 check:rc==0
 cmd:lsdef -t site -i xcatsslversion -c | grep '=TLSv12$'
 check:rc==0
-cmd:chtab key=xcatsslversion site.value=TLSv1
-check:rc==0
+cmd: cat /tmp/xcatconfig_u_check_xcatsslversion_rhels_sles/clustersite.stanza |mkdef -zf
+cmd: rm -rf /tmp/xcatconfig_u_check_xcatsslversion_rhels_sles
 end
 
 
@@ -354,8 +354,8 @@ start:xcatconfig_u_check_xcatsslversion_ubuntu
 description:after xcatconfig -u the site.xcatsslversion will not be changed
 os:ubuntu
 label:mn_only
-cmd:lsdef -t site -i xcatsslversion -c | grep '=TLSv1$'
-check:rc==0
+cmd:mkdir -p /tmp/xcatconfig_u_check_xcatsslversion_ubuntu
+cmd:lsdef -t site  clustersite -z >/tmp/xcatconfig_u_check_xcatsslversion_ubuntu/clustersite.stanza
 cmd:chtab key=xcatsslversion site.value=TLSv1_2
 check:rc==0
 cmd:lsdef -t site -i xcatsslversion -c | grep '=TLSv1_2$'
@@ -364,6 +364,6 @@ cmd:xcatconfig -u
 check:rc==0
 cmd:lsdef -t site -i xcatsslversion -c | grep '=TLSv1_2$'
 check:rc==0
-cmd:chtab key=xcatsslversion site.value=TLSv1
-check:rc==0
+cmd: cat /tmp/xcatconfig_u_check_xcatsslversion_ubuntu/clustersite.stanza |mkdef -zf
+cmd: rm -rf /tmp/xcatconfig_u_check_xcatsslversion_ubuntu
 end


### PR DESCRIPTION
### The PR is to fix issue #6071 

### The modification include

* refine test case ``xcatconfig_u_check_xcatsslversion_ubuntu``

* refine test case ``xcatconfig_u_check_xcatsslversion_rhels_sles``

### The UT result

```
------START::xcatconfig_u_check_xcatsslversion_rhels_sles::Time:Thu Mar 14 00:48:51 2019------

RUN:mkdir -p /tmp/xcatconfig_u_check_xcatsslversion_rhels_sles [Thu Mar 14 00:48:52 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:lsdef -t site  clustersite -z >/tmp/xcatconfig_u_check_xcatsslversion_rhels_sles/clustersite.stanza [Thu Mar 14 00:48:52 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:chtab key=xcatsslversion site.value=TLSv12 [Thu Mar 14 00:48:52 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:lsdef -t site -i xcatsslversion -c | grep '=TLSv12$' [Thu Mar 14 00:48:52 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
clustersite: xcatsslversion=TLSv12
CHECK:rc == 0	[Pass]

RUN:xcatconfig -u [Thu Mar 14 00:48:53 2019]
ElapsedTime:11 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:lsdef -t site -i xcatsslversion -c | grep '=TLSv12$' [Thu Mar 14 00:49:04 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
clustersite: xcatsslversion=TLSv12
CHECK:rc == 0	[Pass]

RUN:cat /tmp/xcatconfig_u_check_xcatsslversion_rhels_sles/clustersite.stanza |mkdef -zf [Thu Mar 14 00:49:05 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.

RUN:rm -rf /tmp/xcatconfig_u_check_xcatsslversion_rhels_sles [Thu Mar 14 00:49:05 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::xcatconfig_u_check_xcatsslversion_rhels_sles::Passed::Time:Thu Mar 14 00:49:05 2019 ::Duration::14 sec------


------START::xcatconfig_u_check_xcatsslversion_ubuntu::Time:Thu Mar 14 00:51:46 2019------

RUN:mkdir -p /tmp/xcatconfig_u_check_xcatsslversion_ubuntu [Thu Mar 14 00:51:46 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:lsdef -t site  clustersite -z >/tmp/xcatconfig_u_check_xcatsslversion_ubuntu/clustersite.stanza [Thu Mar 14 00:51:46 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:chtab key=xcatsslversion site.value=TLSv1_2 [Thu Mar 14 00:51:46 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:lsdef -t site -i xcatsslversion -c | grep '=TLSv1_2$' [Thu Mar 14 00:51:47 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
clustersite: xcatsslversion=TLSv1_2
CHECK:rc == 0	[Pass]

RUN:xcatconfig -u [Thu Mar 14 00:51:47 2019]
ElapsedTime:11 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:lsdef -t site -i xcatsslversion -c | grep '=TLSv1_2$' [Thu Mar 14 00:51:58 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
clustersite: xcatsslversion=TLSv1_2
CHECK:rc == 0	[Pass]

RUN:cat /tmp/xcatconfig_u_check_xcatsslversion_ubuntu/clustersite.stanza |mkdef -zf [Thu Mar 14 00:51:58 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.

RUN:rm -rf /tmp/xcatconfig_u_check_xcatsslversion_ubuntu [Thu Mar 14 00:51:59 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::xcatconfig_u_check_xcatsslversion_ubuntu::Passed::Time:Thu Mar 14 00:51:59 2019 ::Duration::13 sec------
```