### PR TITLE
[RH8] Revise xcatconfig, show warning message if `TLSv1' is used

### DIFF
--- a/xCAT-server/sbin/xcatconfig
+++ b/xCAT-server/sbin/xcatconfig
@@ -1597,6 +1597,32 @@ sub genCredentials
     chomp $hname;
     if ((!-d "/etc/xcat/ca") || $::FORCE || $::genCredentials)
     {
+        # Show warning message if `TLSv1' is used
+        my $cmds = "XCATBYPASS=Y $::XCATROOT/sbin/tabdump site 2>/dev/null | grep '\"xcatsslversion\",\"TLSv1\",'";
+        xCAT::Utils->runcmd("$cmds", -1);
+        if ($::RUNCMD_RC == 0) {
+            xCAT::MsgUtils->message('I',
+                "__      ___   ___ _  _ ___ _  _  ___");
+            xCAT::MsgUtils->message('I',
+                "\\ \\    / /_\\ | _ \\ \\| |_ _| \\| |/ __|                      _     +-+-+-+-+-+-+-+");
+            xCAT::MsgUtils->message('I',
+                " \\ \\/\\/ / _ \\|   / .` || || .` | (_ |                     oo\\    |W|A|R|N|I|N|G|");
+            xCAT::MsgUtils->message('I',
+                "  \\_/\\_/_/ \\_\\_|_\\_|\\_|___|_|\\_|\\___|                    (__)\\   +-+-+-+-+-+-+-+");
+            xCAT::MsgUtils->message('I',
+                "+--------------------------------------------------------------+ +-+-+-+-+-+-+-+");
+            xCAT::MsgUtils->message('I',
+                "| Using `TSLv1' for `site.xcatsslversion' was depracated.      |:|W|A|R|N|I|N|G|");
+            xCAT::MsgUtils->message('I',
+                "| Run `chdef -t site xcatsslversion=' to update your system to |:+-+-+-+-+-+-+-+");
+            xCAT::MsgUtils->message('I',
+                "| the new default value. See `man site' for more details.      |:+-+-+-+-+-+-+-+");
+            xCAT::MsgUtils->message('I',
+                "+--------------------------------------------------------------+:|W|A|R|N|I|N|G|");
+            xCAT::MsgUtils->message('I',
+                " ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::+-+-+-+-+-+-+-+");
+        }
+
         xCAT::MsgUtils->message(
             'I',
 "\nSetting up basic certificates.  Respond with a \'y\' when prompted.\n"


### PR DESCRIPTION


### The modification include

_##Revise xcatconfig, show warning message if `TLSv1' is used_

<details>
<summary>The UT result</summary>

```
# xcatconfig -c
__      ___   ___ _  _ ___ _  _  ___
\ \    / /_\ | _ \ \| |_ _| \| |/ __|                      _     +-+-+-+-+-+-+-+
 \ \/\/ / _ \|   / .` || || .` | (_ |                     oo\    |W|A|R|N|I|N|G|
  \_/\_/_/ \_\_|_\_|\_|___|_|\_|\___|                    (__)\   +-+-+-+-+-+-+-+
+--------------------------------------------------------------+ +-+-+-+-+-+-+-+
| Using `TSLv1' for `site.xcatsslversion' was depracated.      |:|W|A|R|N|I|N|G|
| Run `chdef -t site xcatsslversion=' to update your system to |:+-+-+-+-+-+-+-+
| the new default value. See `man site' for more details.      |:+-+-+-+-+-+-+-+
+--------------------------------------------------------------+:|W|A|R|N|I|N|G|
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::+-+-+-+-+-+-+-+

Setting up basic certificates.  Respond with a 'y' when prompted.

Existing xCAT certificate authority detected at /etc/xcat/ca, delete? (y/n):# NOTE use "-newkey rsa:2048" if running OpenSSL 0.9.8a or higher
Generating RSA private key, 2048 bit long modulus (2 primes)
.........................+++++
......................................................+++++
e is 65537 (0x010001)
Using configuration from openssl.cnf
Check that the request matches the signature
Signature ok
Certificate Details:
        Serial Number: 1 (0x1)
        Validity
            Not Before: Jan  1 01:01:01 1970 GMT
            Not After : Mar 14 06:00:42 2039 GMT
        Subject:
            commonName                = xCAT CA
        X509v3 extensions:
            X509v3 Subject Key Identifier:
                C9:6D:65:7F:58:E7:88:A7:D1:4D:16:F4:75:96:EA:F6:11:65:75:B5
            X509v3 Authority Key Identifier:
                keyid:C9:6D:65:7F:58:E7:88:A7:D1:4D:16:F4:75:96:EA:F6:11:65:75:B5

            X509v3 Basic Constraints: critical
                CA:TRUE
            X509v3 Key Usage:
                Certificate Sign, CRL Sign
            Netscape Cert Type:
                SSL CA, S/MIME CA
Certificate is to be certified until Mar 14 06:00:42 2039 GMT (7305 days)
Sign the certificate? [y/n]:

1 out of 1 certificate requests certified, commit? [y/n]Write out database with 1 new entries
Data Base Updated
/root
Created xCAT certificate.
/etc/xcat/cert already exists, delete and start over (y/n)?Generating RSA private key, 2048 bit long modulus (2 primes)
..............................+++++
..............+++++
e is 65537 (0x010001)
/root
Using configuration from openssl.cnf
Check that the request matches the signature
Signature ok
Certificate Details:
        Serial Number: 2 (0x2)
        Validity
            Not Before: Jan  1 01:01:01 1960 GMT
            Not After : Mar  9 06:00:42 2039 GMT
        Subject:
            commonName                = c910f03c01p19
        X509v3 extensions:
            X509v3 Subject Alternative Name:
                DNS:c910f03c01p19.pok.stglabs.ibm.com, DNS:c910f03c01p19
Certificate is to be certified until Mar  9 06:00:42 2039 GMT (7300 days)
Sign the certificate? [y/n]:

1 out of 1 certificate requests certified, commit? [y/n]Write out database with 1 new entries
Data Base Updated
/root
Created xCAT certificate.
/opt/xcat/share/xcat/scripts/setup-dockerhost-cert.sh xcatdockerhost
/etc/xcatdockerca/cert already exists, delete and start over (y/n)?Generating RSA private key, 2048 bit long modulus (2 primes)
............................................+++++
...+++++
e is 65537 (0x010001)
/root
Using configuration from openssl.cnf
Check that the request matches the signature
Signature ok
Certificate Details:
        Serial Number: 0 (0x0)
        Validity
            Not Before: Jan  1 01:01:01 1960 GMT
            Not After : Mar  9 06:00:42 2039 GMT
        Subject:
            commonName                = xcatdockerhost
        X509v3 extensions:
            X509v3 Basic Constraints:
                CA:FALSE
            Netscape Cert Type:
                SSL Client, SSL Server, Object Signing
            Netscape Comment:
                OpenSSL Generated Server Certificate
            X509v3 Subject Key Identifier:
                DA:70:D1:3D:66:F1:08:5C:C1:BD:9C:9D:B9:BE:F0:BE:7B:1B:A9:03
            X509v3 Authority Key Identifier:
                keyid:3C:DD:10:AD:CB:72:C5:AB:8F:12:E5:03:A4:0B:B7:7D:EA:32:8F:B5

            X509v3 Key Usage:
                Digital Signature, Key Encipherment, Key Agreement
            X509v3 Extended Key Usage:
                TLS Web Server Authentication, TLS Web Client Authentication
Certificate is to be certified until Mar  9 06:00:42 2039 GMT (7300 days)

Write out database with 1 new entries
Data Base Updated
/root
/root/.xcat already exists, delete and start over (y/n)?Generating RSA private key, 2048 bit long modulus (2 primes)
........................................+++++
....................................+++++
e is 65537 (0x010001)
Using configuration from openssl.cnf
Check that the request matches the signature
Signature ok
Certificate Details:
        Serial Number: 3 (0x3)
        Validity
            Not Before: Jan  1 01:01:01 1960 GMT
            Not After : Mar  9 06:00:42 2039 GMT
        Subject:
            commonName                = root
        X509v3 extensions:
            X509v3 Basic Constraints:
                CA:FALSE
            X509v3 Key Usage:
                Digital Signature, Key Encipherment, Key Agreement
            X509v3 Extended Key Usage:
                TLS Web Client Authentication
            Netscape Cert Type:
                SSL Client, S/MIME, Object Signing
            Netscape Comment:
                OpenSSL Generated Client Certificate
            X509v3 Subject Key Identifier:
                07:65:FA:FC:34:54:F8:C7:7D:43:B6:AB:41:C0:CF:E8:E7:61:66:27
            X509v3 Authority Key Identifier:
                keyid:C9:6D:65:7F:58:E7:88:A7:D1:4D:16:F4:75:96:EA:F6:11:65:75:B5

Certificate is to be certified until Mar  9 06:00:42 2039 GMT (7300 days)
Sign the certificate? [y/n]:

1 out of 1 certificate requests certified, commit? [y/n]Write out database with 1 new entries
Data Base Updated
Created xCAT certificate.
/home/conserver/.xcat already exists, delete and start over (y/n)?Generating RSA private key, 2048 bit long modulus (2 primes)
...........................................................................................+++++
.............................................................................+++++
e is 65537 (0x010001)
Using configuration from openssl.cnf
Check that the request matches the signature
Signature ok
Certificate Details:
        Serial Number: 4 (0x4)
        Validity
            Not Before: Jan  1 01:01:01 1960 GMT
            Not After : Mar  9 06:00:43 2039 GMT
        Subject:
            commonName                = conserver
        X509v3 extensions:
            X509v3 Basic Constraints:
                CA:FALSE
            X509v3 Key Usage:
                Digital Signature, Key Encipherment, Key Agreement
            X509v3 Extended Key Usage:
                TLS Web Client Authentication
            Netscape Cert Type:
                SSL Client, S/MIME, Object Signing
            Netscape Comment:
                OpenSSL Generated Client Certificate
            X509v3 Subject Key Identifier:
                7F:CC:A3:8A:48:D6:EC:6D:F3:39:85:F8:EE:D0:61:85:B1:DF:9D:9E
            X509v3 Authority Key Identifier:
                keyid:C9:6D:65:7F:58:E7:88:A7:D1:4D:16:F4:75:96:EA:F6:11:65:75:B5

Certificate is to be certified until Mar  9 06:00:43 2039 GMT (7300 days)
Sign the certificate? [y/n]:

1 out of 1 certificate requests certified, commit? [y/n]Write out database with 1 new entries
Data Base Updated
Created xCAT certificate.
```
</details>