### PR TITLE
Revert "[RH8] Revise xcatconfig, show warning message if `TLSv1' is used"

### DIFF
--- a/xCAT-server/sbin/xcatconfig
+++ b/xCAT-server/sbin/xcatconfig
@@ -1597,32 +1597,6 @@ sub genCredentials
     chomp $hname;
     if ((!-d "/etc/xcat/ca") || $::FORCE || $::genCredentials)
     {
-        # Show warning message if `TLSv1' is used
-        my $cmds = "XCATBYPASS=Y $::XCATROOT/sbin/tabdump site 2>/dev/null | grep '\"xcatsslversion\",\"TLSv1\",'";
-        xCAT::Utils->runcmd("$cmds", -1);
-        if ($::RUNCMD_RC == 0) {
-            xCAT::MsgUtils->message('I',
-                "__      ___   ___ _  _ ___ _  _  ___");
-            xCAT::MsgUtils->message('I',
-                "\\ \\    / /_\\ | _ \\ \\| |_ _| \\| |/ __|                      _     +-+-+-+-+-+-+-+");
-            xCAT::MsgUtils->message('I',
-                " \\ \\/\\/ / _ \\|   / .` || || .` | (_ |                     oo\\    |W|A|R|N|I|N|G|");
-            xCAT::MsgUtils->message('I',
-                "  \\_/\\_/_/ \\_\\_|_\\_|\\_|___|_|\\_|\\___|                    (__)\\   +-+-+-+-+-+-+-+");
-            xCAT::MsgUtils->message('I',
-                "+--------------------------------------------------------------+ +-+-+-+-+-+-+-+");
-            xCAT::MsgUtils->message('I',
-                "| Using `TSLv1' for `site.xcatsslversion' was depracated.      |:|W|A|R|N|I|N|G|");
-            xCAT::MsgUtils->message('I',
-                "| Run `chdef -t site xcatsslversion=' to update your system to |:+-+-+-+-+-+-+-+");
-            xCAT::MsgUtils->message('I',
-                "| the new default value. See `man site' for more details.      |:+-+-+-+-+-+-+-+");
-            xCAT::MsgUtils->message('I',
-                "+--------------------------------------------------------------+:|W|A|R|N|I|N|G|");
-            xCAT::MsgUtils->message('I',
-                " ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::+-+-+-+-+-+-+-+");
-        }
-
         xCAT::MsgUtils->message(
             'I',
 "\nSetting up basic certificates.  Respond with a \'y\' when prompted.\n"


### PR DESCRIPTION
Reverts xcat2/xcat-core#6095