### PR TITLE
configvlan with nmcli

### DIFF
--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -576,9 +576,13 @@ function configure_nicdevice {
             fi
             ipaddrs=$(find_nic_ips $nic_dev)
             if [ "$networkmanager_active" = "0" ]; then
-                create_vlan_interface ifname=$vlanname vlanid=$vlanid ipaddrs=$ipaddrs
+                create_vlan_interface ifname=$vlanname vlanid=$vlanid
             elif [ "$networkmanager_active" = "1" ]; then
                 create_vlan_interface_nmcli ifname=$vlanname vlanid=$vlanid ipaddrs=$ipaddrs
+            fi
+            if [ $? -ne 0 ]; then
+                log_error "configvlan failed."
+                errorcode=1
             fi
         #configure bond
         elif [ x"$nic_dev_type" = "xbond" ]; then

--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -574,10 +574,11 @@ function configure_nicdevice {
                 vlanid=`echo "$nic_dev" | $sed -e 's/^\(.*\)vla\?n\?\([0-9]\+\)$/\2/'`
                 vlanname=`echo "$nic_dev" | $sed -e 's/^\(.*\)vla\?n\?\([0-9]\+\)$/\1/'`
             fi
+            ipaddrs=$(find_nic_ips $nic_dev)
             if [ "$networkmanager_active" = "0" ]; then
-                create_vlan_interface ifname=$vlanname vlanid=$vlanid
+                create_vlan_interface ifname=$vlanname vlanid=$vlanid ipaddrs=$ipaddrs
             elif [ "$networkmanager_active" = "1" ]; then
-                create_vlan_interface_nmcli ifname=$vlanname vlanid=$vlanid
+                create_vlan_interface_nmcli ifname=$vlanname vlanid=$vlanid ipaddrs=$ipaddrs
             fi
         #configure bond
         elif [ x"$nic_dev_type" = "xbond" ]; then

--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -581,7 +581,7 @@ function configure_nicdevice {
                 create_vlan_interface_nmcli ifname=$vlanname vlanid=$vlanid ipaddrs=$ipaddrs
             fi
             if [ $? -ne 0 ]; then
-                log_error "configvlan failed."
+                log_error "configure VLAN failed."
                 errorcode=1
             fi
         #configure bond


### PR DESCRIPTION
### The PR is for task https://github.com/xcat2/xcat2-task-management/issues/609

### The content of the PR:
* [x] implement subroutine create_vlan_interface_nmcli

### The UT result
1. On Peer Node:
```
# ip a show dev ens6.194
111: ens6.194@ens6: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 42:2d:0a:04:1c:67 brd ff:ff:ff:ff:ff:ff
    inet 194.4.28.103/8 brd 194.255.255.255 scope global noprefixroute ens6.194
       valid_lft forever preferred_lft forever
    inet6 fe80::f1a0:df4f:66ef:a65d/64 scope link noprefixroute
       valid_lft forever preferred_lft forever
```
2. For CN to config:
```
# lsdef c910f04x28v04 | grep nic
    nicdevices.ens6.194=ens6
    nichostnamesuffixes.ens6.194=-ens6-194
    nicips.ens6.194=194.4.28.104
    nicnetworks.ens6.194=net194
    nictypes.ens6=ethernet
    nictypes.ens6.194=vlan
```
3. updatenode to configure vlan:
```
# updatenode c910f04x28v04 -P confignetwork
c910f04x28v04: =============updatenode starting====================
c910f04x28v04: trying to download postscripts...
c910f04x28v04: postscripts downloaded successfully
c910f04x28v04: trying to get mypostscript from 10.4.28.101...
c910f04x28v04: postscript start..: confignetwork
c910f04x28v04: [I]: NetworkManager is active
c910f04x28v04: [I]: All valid nics and device list:
c910f04x28v04: [I]: ens6.194 ens6
c910f04x28v04: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f04x28v04: configure nic and its device : ens6.194 ens6
c910f04x28v04: [I]: create_vlan_interface_nmcli ifname=ens6 vlanid=194 ipaddrs=194.4.28.104
c910f04x28v04: [I]: Pickup xcatnet, "net194", from NICNETWORKS for interface "ens6".
c910f04x28v04: [I]: check parent interface ens6 whether it is managed by NetworkManager
c910f04x28v04: Connection 'xcat.ens6.194' (e2d817cf-0b5a-4641-9328-fe9899f21c05) successfully added.
c910f04x28v04: [I]: create NetworkManager connection for ens6.194
c910f04x28v04: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/2544)
c910f04x28v04: Connection 'xcat.ens6.194-tmp' (f199c096-249e-42a1-9c2c-8b8195a3b453) successfully deleted.
c910f04x28v04: [I]: [vlan] >> 21: ens6.194@ens6: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
c910f04x28v04: [I]: [vlan] >>     link/ether 42:18:0a:04:1c:68 brd ff:ff:ff:ff:ff:ff
c910f04x28v04: [I]: [vlan] >>     inet 194.4.28.104/8 brd 194.255.255.255 scope global noprefixroute ens6.194
c910f04x28v04: [I]: [vlan] >>        valid_lft forever preferred_lft forever
c910f04x28v04: [I]: [vlan] >>     inet6 fe80::d5dc:fbc3:e539:e6f/64 scope link tentative noprefixroute
c910f04x28v04: [I]: [vlan] >>        valid_lft forever preferred_lft forever
c910f04x28v04: postscript end....: confignetwork exited with code 0
c910f04x28v04: Running of postscripts has completed.
c910f04x28v04: =============updatenode ending====================
```
4. On target CN to ping peer node:
Before configure
```
# ip a |grep ens6
5: ens6: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
```
After configure
```
# ip a |grep ens6
5: ens6: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
18: ens6.194@ens6: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    inet 194.4.28.104/8 brd 194.255.255.255 scope global noprefixroute ens6.194
# ping 194.4.28.103 -c 2
PING 194.4.28.103 (194.4.28.103) 56(84) bytes of data.
64 bytes from 194.4.28.103: icmp_seq=1 ttl=64 time=0.265 ms
64 bytes from 194.4.28.103: icmp_seq=2 ttl=64 time=0.339 ms

--- 194.4.28.103 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 55ms
rtt min/avg/max/mdev = 0.265/0.302/0.339/0.037 ms
```