### PR TITLE
confignetwork configure bridge using nmcli 

### DIFF
--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -523,7 +523,7 @@ function configure_nicdevice {
         echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
         nic_pair=`echo "$nics_pair" |sed -n "${num}p"`
         echo "configure nic and its device : $nic_pair"
-
+        ipaddrs=$(find_nic_ips $nic_dev)
         #ignore bmc interfaces. They're allowed in the nics table to generate DNS/hostname records, but they
         #can't be configured here (it's done in bmcsetup
         if [ x"$nic_dev_type" = "xbmc" ]; then
@@ -532,7 +532,6 @@ function configure_nicdevice {
         #configure standalone ethernet nic
         elif [ x"$nic_dev_type" = "xethernet" ]; then
             xcatnet=`query_nicnetworks_net $nic_dev`
-            ipaddrs=`find_nic_ips $nic_dev`
             if [ -n "$ipaddrs" ]; then
                 log_info "configure $nic_dev"
                 log_info "call: configeth $nic_dev $ipaddrs $xcatnet"
@@ -562,7 +561,11 @@ function configure_nicdevice {
                if [ "$networkmanager_active" = "0" ]; then
                    create_bridge_interface ifname=$nic_dev _brtype=$nic_dev_type _port=$base_nic_dev _pretype=$base_nic_type
                elif [ "$networkmanager_active" = "1" ]; then
-                   create_bridge_interface_nmcli ifname=$nic_dev _brtype=$nic_dev_type _port=$base_nic_dev _pretype=$base_nic_type
+                   create_bridge_interface_nmcli ifname=$nic_dev _brtype=$nic_dev_type _port=$base_nic_dev _pretype=$base_nic_type _ipaddr=$ipaddrs
+                   if [ $? -ne 0 ]; then
+                       log_error "create bridge interface $ifname failed"
+                       errorcode=1;
+                   fi
                fi
             fi
         #configure vlan

--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -563,7 +563,7 @@ function configure_nicdevice {
                elif [ "$networkmanager_active" = "1" ]; then
                    create_bridge_interface_nmcli ifname=$nic_dev _brtype=$nic_dev_type _port=$base_nic_dev _pretype=$base_nic_type _ipaddr=$ipaddrs
                    if [ $? -ne 0 ]; then
-                       log_error "create bridge interface $ifname failed"
+                       log_error "create bridge interface $nic_dev failed"
                        errorcode=1;
                    fi
                fi

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -1771,7 +1771,7 @@ function create_bridge_interface_nmcli {
         if [ $? -eq 0 ]; then
             $nmcli con delete $tmp_slave_con_name
         fi
-        wait_for_ifstate $ifname UP 200 10
+        wait_for_ifstate $ifname UP 20 40
         rc=$?
         $ip address show dev $ifname| $sed -e 's/^/[bridge] >> /g' | log_lines info
     fi

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -1646,10 +1646,8 @@ function create_bridge_interface_nmcli {
         shift
     done
     # query "nicnetworks" table about its target "xcatnet"
-    if [ -n "$ifname" ]; then
-        xcatnet=$(query_nicnetworks_net $ifname)
-        log_info "Pickup xcatnet, \"$xcatnet\", from NICNETWORKS for interface \"$ifname\"."
-    fi
+    xcatnet=$(query_nicnetworks_net $ifname)
+    log_info "Pickup xcatnet, \"$xcatnet\", from NICNETWORKS for interface \"$ifname\"."
 
     # Query mtu value from "networks" table
     _mtu_num=$(get_network_attr $xcatnet mtu)
@@ -1699,7 +1697,6 @@ function create_bridge_interface_nmcli {
             if [ $? -eq 0 ] ; then
                 $nmcli con modify $tmp_con_name connection.id $xcat_con_name
             fi
-            $nmcli con delete $xcat_con_name
             return 1
         fi
     else
@@ -1726,9 +1723,8 @@ function create_bridge_interface_nmcli {
             log_error "nmcli failed to add bridge slave $_port"
             is_nmcli_connection_exist $tmp_slave_con_name
             if [ $? -eq 0 ] ; then
-                $nmcli con modify $xcat_slave_con connection.id $tmp_slave_con_name
+                $nmcli con modify $tmp_slave_con_name connection.id $xcat_slave_con
             fi
-            $nmcli con delete $xcat_slave_con
             return 1
         fi
     else

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -1618,12 +1618,165 @@ function create_vlan_interface_nmcli {
 #
 # create  bridge
 #
-# input : ifname=<ifname> xcatnet=<xcat_network> _ipaddr=<ip> _netmask=<netmask> _port=<port> _pretype=<nic_type> _brtype=<bridge|bridge_ovs> _mtu=<mtu> _bridge=<bridge_name>
+# input : ifname=<ifname> _ipaddr=<ip> _port=<port> _pretype=<nic_type> _brtype=<bridge>
+# success: return 0
 #
 ###############################################################################
 function create_bridge_interface_nmcli {
     log_info "create_bridge_interface_nmcli $@"
+    local ifname="" #current bridge
+    local _brtype=""
+    local _pretype=""
+    local _port=""  #pre nic
+    local _mtu=""
+    local xcatnet=""
+    local _ipaddr=""
+    rc=0
+    # parser input arguments
+    while [ -n "$1" ];
+    do
+        key=`echo "$1" | $cut -s -d= -f1`
+        if [ "$key" = "ifname" ] || \
+           [ "$key" = "_brtype" ] || \
+           [ "$key" = "_pretype" ] || \
+           [ "$key" = "_port" ] || \
+           [ "$key" = "_ipaddr" ]; then
+            eval "$1"
+        fi
+        shift
+    done
+    # query "nicnetworks" table about its target "xcatnet"
+    if [ -n "$ifname" -a -z "$xcatnet" ]; then
+        xcatnet=`query_nicnetworks_net $ifname`
+        log_info "Pickup xcatnet, \"$xcatnet\", from NICNETWORKS for interface \"$ifname\"."
+    fi
 
+    # Query mtu value from "networks" table
+    _mtu_num=`get_network_attr $xcatnet mtu`
+    if [ -n "$_mtu_num" ]; then
+        _mtu="mtu $_mtu_num"
+    fi
+
+    # Query mask value from "networks" table
+    _netmask=`get_network_attr $xcatnet mask`
+    if [ $? -ne 0 ]; then
+        log_error "No valid netmask get for $ifname"
+        return 1
+    fi
+    # Calculate prefix based on mask
+    str_prefix=$(v4mask2prefix $_netmask)
+
+    # Get first valid ip from nics.nicips
+    ipv4_addr=$(get_first_addr_ipv4 $_ipaddr)
+    if [ $? -ne 0 ]; then
+        log_error "No valid IP address get for $ifname, please check $ipaddrs"
+        return 1
+    fi
+    # Check and set slave device status
+    # If slave device failed to managed, return 1
+    check_and_set_device_managed $_port
+    if [ $? -ne 0 ]; then
+        return 1
+    fi
+    # Create bridge connection
+    xcat_con_name="xcat"$ifname
+    tmp_con_name=$xcat_con_name"-tmp"
+    if [ x"$_brtype" = "xbridge" ]; then
+        is_nmcli_connection_exist $xcat_con_name
+        if [ $? -eq 0 ] ; then
+            log_info "$xcat_con_name exists, rename old $xcat_con_name to $tmp_con_name"
+            $nmcli con modify $xcat_con_name connection.id $tmp_con_name
+            if [ $? -ne 0 ] ; then
+                log_error "$nmcli rename $xcat_con_name failed"
+                return 1
+            fi
+        fi
+        log_info "create bridge connection $xcat_con_name"
+        $nmcli con add type bridge con-name $xcat_con_name ifname $ifname
+        if [ $? -ne 0 ]; then
+            log_error "nmcli failed to add bridge $ifname"
+            return 1
+        fi
+    elif [ x"$_brtype" == "xbridge_ovs" ]; then
+        log_error "OVSBridge is not supported."
+        return 1
+    fi
+
+    # Create slaves connection
+    xcat_slave_con="xcat_br_"$_port
+    tmp_slave_con_name=$xcat_slave_con"-tmp"
+    if [ x"$_pretype" = "xethernet" -o x"$_pretype" = "xvlan" -o x"$_pretype" = "xbond" ]; then
+        is_nmcli_connection_exist $xcat_slave_con
+        if [ $? -eq 0 ] ; then
+            log_info "$xcat_slave_con exists, rename old connetion $xcat_slave_con to $tmp_slave_con_name"
+            $nmcli con modify $xcat_slave_con connection.id $tmp_slave_con_name
+            if [ $? -ne 0 ] ; then
+                log_error "$nmcli rename $xcat_slave_con failed"
+                return 1
+            fi
+        fi
+        log_info "create $_pretype slaves connetcion $xcat_slave_con for bridge"
+        $nmcli con add type $_pretype con-name $xcat_slave_con ifname $_port master $ifname;
+        if [ $? -ne 0 ]; then
+            log_error "nmcli failed to add bridge slave $_port"
+            return 1
+        fi
+    else
+        log_error "create $_pretype slaves for bridge is not supported"
+        return 1
+    fi
+
+    # Add ip to bridge
+    if [ -n "$ipv4_addr" ]; then
+        log_info "add ip $ipv4_addr/$str_prefix to bridge"
+        $nmcli con mod $xcat_con_name ipv4.method manual ipv4.addresses $ipv4_addr/$str_prefix;
+    fi
+
+    # Configure MTU
+    if [ -n "$_mtu" ]; then
+        $nmcli con mod $xcat_con_name $_mtu
+        if [ $? -ne 0 ]; then
+            log_error "$nmcli con mod $xcat_con_name $_mtu failed"
+            rc=1
+        fi
+    fi
+
+    # bring up interface formally
+    log_info "$nmcli con up $xcat_slave_con; $nmcli con up $xcat_con_name"
+    lines=`$nmcli con up $xcat_slave_con; $nmcli con up $xcat_con_name`
+    rc=$?
+
+    # If bridge interface is active, delete tmp old connection
+    # If bridge interface is not active, delete new bridge and slave connection, and restore old connection
+    is_connection_activate_intime $xcat_con_name
+    is_active=$?
+    if [ "$is_active" -eq 0 ]; then
+        log_error "$nmcli con up $xcat_con_name failed with return code equals to $rc"
+        $nmcli con delete $xcat_con_name
+        is_nmcli_connection_exist $tmp_con_name
+        if [ $? -eq 0 ]; then
+            nmcli con modify $tmp_con_name connection.id $xcat_con_name
+        fi
+        $nmcli con delete $xcat_slave_con
+        is_nmcli_connection_exist $tmp_slave_con_name
+        if [ $? -eq 0 ]; then
+            nmcli con modify $xcat_slave_con connection.id $tmp_slave_con_name
+        fi
+    else
+        is_nmcli_connection_exist $tmp_con_name
+        if [ $? -eq 0 ]; then
+            $nmcli con delete $tmp_con_name
+        fi
+        is_nmcli_connection_exist $tmp_slave_con_name
+        if [ $? -eq 0 ]; then
+            $nmcli con delete $tmp_slave_con_name
+        fi
+        wait_for_ifstate $ifname UP 200 10
+        rc=$?
+        $ip address show dev $ifname| $sed -e 's/^/[bridge] >> /g' | log_lines info
+    fi
+
+    return $rc
 }
 
 #############################################################################################################################


### PR DESCRIPTION
### The PR is for task 
xcat2/xcat2-task-management#611

### The content of the PR:
configure bridge scripts using nmcli

### The UT result
1. create bridge using nmcli, when there is no old connection existed
```
]# updatenode byrh09 confignetwork
byrh09: =============updatenode starting====================
byrh09: trying to download postscripts...
byrh09: postscripts downloaded successfully
byrh09: trying to get mypostscript from 10.4.41.1...
byrh09: postscript start..: confignetwork
byrh09: [I]: NetworkManager is active
byrh09: [I]: All valid nics and device list:
byrh09: [I]: br51 ens5
byrh09: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh09: configure nic and its device : br51 ens5
byrh09: [I]: create_bridge_interface_nmcli ifname=br51 _brtype=bridge _port=ens5 _pretype=ethernet _ipaddr=50.4.41.141
byrh09: [I]: Pickup xcatnet, "50_0_0_0-255_0_0_0", from NICNETWORKS for interface "br51".
byrh09: [I]: create bridge connection xcatbr51
byrh09: Connection 'xcatbr51' (6041e379-6a6a-44e0-984f-3524f150270f) successfully added.
byrh09: [I]: create ethernet slaves connetcion xcat_br_ens5 for bridge
byrh09: Connection 'xcat_br_ens5' (39bc4779-2b88-470a-9553-3d08178576a4) successfully added.
byrh09: [I]: add ip 50.4.41.141/8 to bridge
byrh09: [I]: nmcli con up xcat_br_ens5; nmcli con up xcatbr51
byrh09: [I]: State of "br51" was "DOWN" instead of expected "UP". Wait 0 of 20 with interval 40.
byrh09: [I]: [bridge] >> 48: br51: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
byrh09: [I]: [bridge] >>     link/ether 42:9b:0a:04:29:09 brd ff:ff:ff:ff:ff:ff
byrh09: [I]: [bridge] >>     inet 50.4.41.141/8 brd 50.255.255.255 scope global noprefixroute br51
byrh09: [I]: [bridge] >>        valid_lft forever preferred_lft forever
byrh09: [I]: [bridge] >>     inet6 fe80::1fa8:e5d5:94bd:c932/64 scope link noprefixroute
byrh09: [I]: [bridge] >>        valid_lft forever preferred_lft forever
byrh09: postscript end....: confignetwork exited with code 0
byrh09: Running of postscripts has completed.
byrh09: =============updatenode ending====================
```
On compute node
```
]# ip address show dev br51
48: br51: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 42:9b:0a:04:29:09 brd ff:ff:ff:ff:ff:ff
    inet 50.4.41.141/8 brd 50.255.255.255 scope global noprefixroute br51
       valid_lft forever preferred_lft forever
    inet6 fe80::1fa8:e5d5:94bd:c932/64 scope link noprefixroute
       valid_lft forever preferred_lft forever
```

2. create bridge using nmcli, when there is old connection existed
```
]# updatenode byrh09 confignetwork
byrh09: =============updatenode starting====================
byrh09: trying to download postscripts...
byrh09: postscripts downloaded successfully
byrh09: trying to get mypostscript from 10.4.41.1...
byrh09: postscript start..: confignetwork
byrh09: [I]: NetworkManager is active
byrh09: [I]: All valid nics and device list:
byrh09: [I]: br51 ens5
byrh09: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh09: configure nic and its device : br51 ens5
byrh09: [I]: create_bridge_interface_nmcli ifname=br51 _brtype=bridge _port=ens5 _pretype=ethernet _ipaddr=50.4.41.141
byrh09: [I]: Pickup xcatnet, "50_0_0_0-255_0_0_0", from NICNETWORKS for interface "br51".
byrh09: [I]: xcatbr51 exists, rename old xcatbr51 to xcatbr51-tmp
byrh09: [I]: create bridge connection xcatbr51
byrh09: Connection 'xcatbr51' (0a652fb5-03a3-4c07-af48-dbf479c79599) successfully added.
byrh09: [I]: xcat_br_ens5 exists, rename old connetion xcat_br_ens5 to xcat_br_ens5-tmp
byrh09: [I]: create ethernet slaves connetcion xcat_br_ens5 for bridge
byrh09: Connection 'xcat_br_ens5' (a2c03268-ef47-4965-a04e-24f882a84651) successfully added.
byrh09: [I]: add ip 50.4.41.141/8 to bridge
byrh09: [I]: nmcli con up xcat_br_ens5; nmcli con up xcatbr51
byrh09: Connection 'xcatbr51-tmp' (6041e379-6a6a-44e0-984f-3524f150270f) successfully deleted.
byrh09: Connection 'xcat_br_ens5-tmp' (39bc4779-2b88-470a-9553-3d08178576a4) successfully deleted.
byrh09: [I]: State of "br51" was "DOWN" instead of expected "UP". Wait 0 of 20 with interval 40.
byrh09: [I]: [bridge] >> 48: br51: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
byrh09: [I]: [bridge] >>     link/ether 42:9b:0a:04:29:09 brd ff:ff:ff:ff:ff:ff
byrh09: [I]: [bridge] >>     inet 50.4.41.141/8 brd 50.255.255.255 scope global noprefixroute br51
byrh09: [I]: [bridge] >>        valid_lft forever preferred_lft forever
byrh09: [I]: [bridge] >>     inet6 fe80::300e:ca91:d38e:807/64 scope link noprefixroute
byrh09: [I]: [bridge] >>        valid_lft forever preferred_lft forever
byrh09: postscript end....: confignetwork exited with code 0
byrh09: Running of postscripts has completed.
byrh09: =============updatenode ending====================
```

3. network interface does not exists
```
]# updatenode byrh09 confignetwork
byrh09: =============updatenode starting====================
byrh09: trying to download postscripts...
byrh09: postscripts downloaded successfully
byrh09: trying to get mypostscript from 10.4.41.1...
byrh09: postscript start..: confignetwork
byrh09: [I]: NetworkManager is active
byrh09: [I]: All valid nics and device list:
byrh09: [I]: br51 ens6
byrh09: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh09: configure nic and its device : br51 ens6
byrh09: [I]: create_bridge_interface_nmcli ifname=br51 _brtype=bridge _port=ens6 _pretype=ethernet _ipaddr=50.4.41.141
byrh09: [I]: Pickup xcatnet, "50_0_0_0-255_0_0_0", from NICNETWORKS for interface "br51".
byrh09: [E]:Error: Device ens6 not found
byrh09: postscript end....: confignetwork exited with code 1
byrh09: Running of postscripts has completed.
byrh09: =============updatenode ending====================
```