### PR TITLE
Add python3 to the default pkglist for RHEL 8

### DIFF
--- a/xCAT-server/share/xcat/install/rh/compute.rhels8.pkglist
+++ b/xCAT-server/share/xcat/install/rh/compute.rhels8.pkglist
@@ -6,3 +6,4 @@ openssh-server
 rsync
 util-linux
 wget
+python3

--- a/xCAT-server/share/xcat/install/rh/service.rhels8.pkglist
+++ b/xCAT-server/share/xcat/install/rh/service.rhels8.pkglist
@@ -10,3 +10,4 @@ mariadb-connector-odbc
 perl-DBD-MySQL
 perl-DBD-Pg
 unixODBC
+python3

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels8.ppc64le.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels8.ppc64le.pkglist
@@ -31,3 +31,4 @@ util-linux
 vim-minimal
 xz
 wget
+python3

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels8.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels8.x86_64.pkglist
@@ -30,3 +30,4 @@ util-linux
 vim-minimal
 xz
 wget
+python3

--- a/xCAT-server/share/xcat/netboot/rh/service.rhels8.ppc64le.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/service.rhels8.ppc64le.pkglist
@@ -33,3 +33,4 @@ xz
 wget
 perl-DBD-MySQL
 perl-DBD-Pg
+python3

--- a/xCAT-server/share/xcat/netboot/rh/service.rhels8.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/service.rhels8.x86_64.pkglist
@@ -32,3 +32,4 @@ xz
 wget
 perl-DBD-MySQL
 perl-DBD-Pg
+python3


### PR DESCRIPTION
### The PR is to fix issue _#6114_

### The modification include

_##Add python36 to the default compute node pkglist for RHEL 8_
