### PR TITLE
fix issue Need to enter passphrase when install redhat 6.10 on x86_84 #6119

### DIFF
--- a/xCAT/postscripts/remoteshell
+++ b/xCAT/postscripts/remoteshell
@@ -156,7 +156,7 @@ if [ $? -ne 0 ]; then
    if ! grep "PRIVATE KEY" /etc/ssh/ssh_host_dsa_key > /dev/null 2>&1 ; then
         rm /etc/ssh/ssh_host_dsa_key
 	else
-		ssh-keygen -y -f /etc/ssh/ssh_host_dsa_key > /etc/ssh/ssh_host_dsa_key.pub
+		ssh-keygen -y -f /etc/ssh/ssh_host_dsa_key -P "" > /etc/ssh/ssh_host_dsa_key.pub
 		chmod 644 /etc/ssh/ssh_host_dsa_key.pub
 		chown root /etc/ssh/ssh_host_dsa_key.pub
    fi
@@ -222,7 +222,7 @@ if [ $? -ne 0 ]; then
 	if ! grep "PRIVATE KEY" /etc/ssh/ssh_host_rsa_key > /dev/null 2>&1 ; then
    		rm /etc/ssh/ssh_host_rsa_key
 	else
-		ssh-keygen -y -f /etc/ssh/ssh_host_rsa_key > /etc/ssh/ssh_host_rsa_key.pub
+		ssh-keygen -y -f /etc/ssh/ssh_host_rsa_key -P "" > /etc/ssh/ssh_host_rsa_key.pub
                 chmod 644 /etc/ssh/ssh_host_rsa_key.pub
                 chown root /etc/ssh/ssh_host_rsa_key.pub
 	fi
@@ -298,7 +298,7 @@ if ssh-keygen -t ecdsa -f /tmp/ecdsa_key -P "" &>/dev/null ; then
 		# If ture, means support ecdsa, then generate corresponding key.pub.
 		# If false, remove ssh_host_ecdsa_key useless file, to avoid future errors.
 		if ssh-keygen -t ecdsa -y -f /etc/ssh/ssh_host_ecdsa_key -P "" &>/dev/null ; then
-			ssh-keygen -y -f /etc/ssh/ssh_host_ecdsa_key > /etc/ssh/ssh_host_ecdsa_key.pub
+			ssh-keygen -y -f /etc/ssh/ssh_host_ecdsa_key -P "" > /etc/ssh/ssh_host_ecdsa_key.pub
 			chmod 644 /etc/ssh/ssh_host_ecdsa_key.pub
 			chown root /etc/ssh/ssh_host_ecdsa_key.pub
 		else
@@ -461,7 +461,7 @@ then
   # if public key does not exist then generate one from the private key
   if [ ! -f /root/.ssh/id_rsa.pub ]; then
     if [ -r /root/.ssh/id_rsa ]; then
-     ssh-keygen -y -f /root/.ssh/id_rsa > /root/.ssh/id_rsa.pub
+     ssh-keygen -y -f /root/.ssh/id_rsa -P "" > /root/.ssh/id_rsa.pub
      logger -t $log_label -p local4.err  remoteshell:transfer of the id_rsa.pub key failed. Had to generate a public key.
     fi
   fi


### PR DESCRIPTION
### The PR is to fix issue https://github.com/xcat2/xcat-core/issues/6119

* add `-P ""` to avoid passphrase prompt


UT: 
```
...
Installing ipw2100-firmware-1.3-11.el6.noarch (604 KB)
Firmware for Intel® PRO/Wireless 2100 network adaptors
Packages completed: 425 of 428
Installing ql23xx-firmware-3.03.27-3.1.el6.noarch (256 KB)
Firmware for qlogic 23xx devices
Packages completed: 426 of 428
Installing ipw2200-firmware-3.1-4.el6.noarch (562 KB)
Firmware for Intel® PRO/Wireless 2200 network adaptors
Packages completed: 427 of 428
Installing rootfiles-8.1-6.1.el6.noarch (599 Bytes)
The basic required files for the root user's directory
Packages completed: 428 of 428




Performing post-installation configuration
Installing bootloader.
Running post-installation scripts
terminating anaconda...done
sending termination signals...done
sending kill signals...done
disabling swap...
```