### PR TITLE
Make xCAT statelite compute node working on RHEL 8

### DIFF
--- a/xCAT-server/share/xcat/netboot/add-on/statelite/rc.localdisk
+++ b/xCAT-server/share/xcat/netboot/add-on/statelite/rc.localdisk
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 MNTDIR="/sysroot"
 LOCAL="/.sllocal/localmnt"
@@ -68,9 +68,14 @@ xCATCmd () {
 # $2 is the command
     ARCH=`uname -m`
     if [ x$ARCH = x"ppc64" -a x$OS = x"rh" ]; then
-        echo "<xcatrequest>\n<command>${2}</command>\n</xcatrequest>" | /usr/sbin/chroot ${MNTDIR} /usr/bin/openssl s_client -quiet -no_ssl3 -connect ${1} -rand /bin/nice 2>/dev/null
+        /usr/sbin/chroot ${MNTDIR} /usr/bin/openssl s_client -quiet -no_ssl3 \
+            -connect ${1} -rand /bin/bash 2>/dev/null \
+            <<<"<xcatrequest><command>${2}</command></xcatrequest>"
     else
-        echo "<xcatrequest>\n<command>${2}</command>\n</xcatrequest>" | LD_LIBRARY_PATH=${MNTDIR}/lib64:${MNTDIR}/usr/lib64 ${MNTDIR}/usr/bin/openssl s_client -quiet -no_ssl3 -connect ${1} -rand /bin/nice 2>/dev/null
+        LD_LIBRARY_PATH=${MNTDIR}/lib64:${MNTDIR}/usr/lib64 \
+            ${MNTDIR}/usr/bin/openssl s_client -quiet -no_ssl3 \
+            -connect ${1} -rand /bin/bash 2>/dev/null \
+            <<<"<xcatrequest><command>${2}</command></xcatrequest>"
     fi
 }
 

--- a/xCAT-server/share/xcat/netboot/add-on/statelite/rc.statelite
+++ b/xCAT-server/share/xcat/netboot/add-on/statelite/rc.statelite
@@ -128,7 +128,7 @@ GetSyncInfo () {
 xCATCmd () {
 # $1 is the xCAT server
 # $2 is the command
-	echo "<xcatrequest>\n<command>${2}</command>\n</xcatrequest>" | LD_LIBRARY_PATH=${MNTDIR}/lib64:${MNTDIR}/usr/lib64 ${MNTDIR}/usr/bin/openssl s_client -quiet -no_ssl3 -connect ${1} -rand /bin/nice 2>/dev/null
+	LD_LIBRARY_PATH=${MNTDIR}/lib64:${MNTDIR}/usr/lib64 ${MNTDIR}/usr/bin/openssl s_client -quiet -no_ssl3 -connect ${1} -rand /bin/bash 2>/dev/null <<<"<xcatrequest><command>${2}</command></xcatrequest>"
 
 }
 


### PR DESCRIPTION
### The PR is for task _#xxx_ or to implement feature xcat2/xcat2-task-management#647

_##Feature description##_

### The content of the PR:
* [ ] _##Make the RAMdisk-based statelite compute node working_
* [ ] _##Enabling the localdisk option_