### PR TITLE
fix issue No installing status during redhat8 install #6115

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/pre.rhels8
+++ b/xCAT-server/share/xcat/install/scripts/pre.rhels8
@@ -28,24 +28,24 @@ then
 fi
 
 cat >/tmp/baz.py <<'EOF'
-#!/usr/bin/python3
+#!/usr/libexec/platform-python
 import socket
 import sys
 
 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 sock.connect(('#XCATVAR:XCATMASTER#',#TABLE:site:key=xcatiport:value#))
 
-print sys.argv[1]
+print(sys.argv[1])
 response = sock.recv(100)
-if(response == "ready\n"):
-        sock.send(sys.argv[1]+"\n")
+if(response == b"ready\n"):
+        sock.send((sys.argv[1]+"\n").encode())
         response = sock.recv(100)
 
 sock.close()
 EOF
 
 cat >/tmp/foo.py <<'EOF'
-#!/usr/bin/python3
+#!/usr/libexec/platform-python
 
 import socket
 import os
@@ -56,8 +56,8 @@ sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 sock.connect(('#XCATVAR:XCATMASTER#',#TABLE:site:key=xcatiport:value#))
 
 response = sock.recv(100)
-if(response == "ready\n"):
-	sock.send("installmonitor\n")
+if(response == b"ready\n"):
+	sock.send("installmonitor\n".encode())
 	response = sock.recv(100)
 
 sock.close()
@@ -78,7 +78,7 @@ try:
 			if not received:
 				break
 			command = re.split('\s+',received)
-			if(command[0] == "stat"):
+			if(command[0] == b"stat"):
 				ilog = ""
 				line = ""
 				post = 0
@@ -110,21 +110,21 @@ try:
 					line = "installing " + line
 				if(not line):
 					line = "installing prep"
-				newSocket.send(line)
+				newSocket.send(line.encode())
 				break
-#UNCOMMENTOENABLEDEBUGPORT#			if(command[0] == "sh"): #DEBUG purposes only, wide open root priv command here.
+#UNCOMMENTOENABLEDEBUGPORT#			if(command[0] == b"sh"): #DEBUG purposes only, wide open root priv command here.
 #UNCOMMENTOENABLEDEBUGPORT#				newcommand = ""
 #UNCOMMENTOENABLEDEBUGPORT#				for i in command[1:]:
 #UNCOMMENTOENABLEDEBUGPORT#					newcommand = newcommand + i + " "
 #UNCOMMENTOENABLEDEBUGPORT#				output = os.popen(newcommand).read()
-#UNCOMMENTOENABLEDEBUGPORT#				newSocket.send(output)
+#UNCOMMENTOENABLEDEBUGPORT#				newSocket.send(output.encode())
 #UNCOMMENTOENABLEDEBUGPORT#				break
-			if(command[0] == "screendump"):
+			if(command[0] == b"screendump"):
 				newcommand = "cat /dev/vcs"
 				for i in command[1:]:
 					newcommand = newcommand + i
 				output = os.popen(newcommand).read()
-				newSocket.send(output)
+				newSocket.send(output.encode())
 				break
 				
 		newSocket.close()


### PR DESCRIPTION
### The PR is to fix issuehttps://github.com/xcat2/xcat-core/issues/6115

### The modification include

* there is no python2/python3 in anaconda, use `/usr/libexec/platform-python` instead
* port `/tmp/baz.py` and `/tmp/foo.py`  to platform-python(python3) syntax

UT:
```
Mar 19 03:45:11 c910f04x27v22 xcat[20564]: INFO xcatd: install monitor received a connection request from 10.4.27.10
Mar 19 03:45:11 c910f04x27v22 xcat[20564]: INFO xcatd: 10.4.27.10 is matched with node c910f04x27v10
Mar 19 03:45:11 c910f04x27v22 xcat[20564]: INFO xcat.updatestatus - c910f04x27v10: provisioning detected...
Mar 19 03:45:11 c910f04x27v22 xcat[20564]: DEBUG xcatd: dispatch request 'updatenodestat installing' to plugin 'updatenode'
Mar 19 03:45:11 c910f04x27v22 xcat[20564]: DEBUG xcatd: handle request 'updatenodestat' by plugin 'updatenode''s preprocess_request
Mar 19 03:45:11 c910f04x27v22 xcat[20564]: DEBUG xcatd: handle request 'updatenodestat' by plugin 'updatenode''s process_request
Mar 19 03:45:11 c910f04x27v22 xcat[20564]: INFO xcat.updatestatus - c910f04x27v10: changing status=installing
Mar 19 03:45:11 c910f04x27v22 xcat[20564]: INFO xcatd: finish a connection request for c910f04x27v10 from 10.4.27.10
```