### PR TITLE
replace check brctl position since there is no bridge-utils RH8

### DIFF
--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -554,19 +554,19 @@ function configure_nicdevice {
         #linux bridge type is bridge
         #openvswitch bridge type is bridge_ovs
         elif [ x"$nic_dev_type" = "xbridge_ovs" -o x"$nic_dev_type" = "xbridge" ]; then
-            check_brctl $nic_dev_type
+            if [ "$networkmanager_active" = "0" ]; then
+                check_brctl $nic_dev_type
+                if [ $? -ne 0 ]; then
+                    errorcode=1
+                else
+                    create_bridge_interface ifname=$nic_dev _brtype=$nic_dev_type _port=$base_nic_dev _pretype=$base_nic_type
+                fi
+            elif [ "$networkmanager_active" = "1" ]; then
+                create_bridge_interface_nmcli ifname=$nic_dev _brtype=$nic_dev_type _port=$base_nic_dev _pretype=$base_nic_type _ipaddr=$ipaddrs
+            fi
             if [ $? -ne 0 ]; then
-                errorcode=1
-            else
-               if [ "$networkmanager_active" = "0" ]; then
-                   create_bridge_interface ifname=$nic_dev _brtype=$nic_dev_type _port=$base_nic_dev _pretype=$base_nic_type
-               elif [ "$networkmanager_active" = "1" ]; then
-                   create_bridge_interface_nmcli ifname=$nic_dev _brtype=$nic_dev_type _port=$base_nic_dev _pretype=$base_nic_type _ipaddr=$ipaddrs
-                   if [ $? -ne 0 ]; then
-                       log_error "create bridge interface $nic_dev failed"
-                       errorcode=1;
-                   fi
-               fi
+                log_error "create bridge interface $nic_dev failed"
+                errorcode=1;
             fi
         #configure vlan
         elif [ x"$nic_dev_type" = "xvlan" ]; then


### PR DESCRIPTION
### The PR is for task 
https://github.com/xcat2/xcat2-task-management/issues/611

_##Feature description##_
`bridge-utils`  is removed in RH8 based on https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8-beta/html-single/8.0_beta_release_notes/index

### The UT result
```
]# updatenode byrh09 confignetwork
byrh09: =============updatenode starting====================
byrh09: trying to download postscripts...
byrh09: postscripts downloaded successfully
byrh09: trying to get mypostscript from 10.4.41.1...
byrh09: postscript start..: confignetwork
byrh09: [I]: NetworkManager is active
byrh09: [I]: All valid nics and device list:
byrh09: [I]: br51 ens5
byrh09: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh09: configure nic and its device : br51 ens5
byrh09: [I]: create_bridge_interface_nmcli ifname=br51 _brtype=bridge _port=ens5 _pretype=ethernet _ipaddr=50.4.41.141
byrh09: [I]: Pickup xcatnet, "50_0_0_0-255_0_0_0", from NICNETWORKS for interface "br51".
byrh09: [I]: xcatbr51 exists, rename old xcatbr51 to xcatbr51-tmp
byrh09: [I]: create bridge connection xcatbr51
byrh09: Connection 'xcatbr51' (12f00752-57ab-4c26-b068-fa8d82ccf299) successfully added.
byrh09: [I]: xcat_br_ens5 exists, rename old connetion xcat_br_ens5 to xcat_br_ens5-tmp
byrh09: [I]: create ethernet slaves connetcion xcat_br_ens5 for bridge
byrh09: Connection 'xcat_br_ens5' (1a0a5a72-db2d-4710-ad74-5582d5249486) successfully added.
byrh09: [I]: nmcli con up xcat_br_ens5; nmcli con up xcatbr51
byrh09: Connection 'xcatbr51-tmp' (f136ec59-4579-4ca7-b07b-4aad0332404a) successfully deleted.
byrh09: Connection 'xcat_br_ens5-tmp' (97079ea9-3677-4147-ae48-600e829a0f33) successfully deleted.
byrh09: [I]: State of "br51" was "DOWN" instead of expected "UP". Wait 0 of 20 with interval 40.
byrh09: [I]: [bridge] >> 59: br51: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1400 qdisc noqueue state UP group default qlen 1000
byrh09: [I]: [bridge] >>     link/ether 42:9b:0a:04:29:09 brd ff:ff:ff:ff:ff:ff
byrh09: [I]: [bridge] >>     inet 50.4.41.141/8 brd 50.255.255.255 scope global noprefixroute br51
byrh09: [I]: [bridge] >>        valid_lft forever preferred_lft forever
byrh09: [I]: [bridge] >>     inet6 fe80::b27b:1ccc:513e:bec1/64 scope link noprefixroute
byrh09: [I]: [bridge] >>        valid_lft forever preferred_lft forever
byrh09: postscript end....: confignetwork exited with code 0
byrh09: Running of postscripts has completed.
byrh09: =============updatenode ending====================
```