### PR TITLE
configure bond support using nmcli

### DIFF
--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -592,7 +592,11 @@ function configure_nicdevice {
             if [ "$networkmanager_active" = "0" ]; then
                 create_bond_interface ifname=$nic_dev slave_ports=$base_nic_for_bond slave_type=$base_nic_type
             elif [ "$networkmanager_active" = "1" ]; then
-                create_bond_interface_nmcli ifname=$nic_dev slave_ports=$base_nic_for_bond slave_type=$base_nic_type
+                create_bond_interface_nmcli bondname=$nic_dev slave_ports=$base_nic_for_bond slave_type=$base_nic_type _ipaddr=$ipaddrs
+            fi
+            if [ $? -ne 0 ]; then
+                log_error "configure bond $nic_dev failed."
+                errorcode=1
             fi
         elif [ x"$nic_dev_type" = "xinfiniband" ] || [ x"$nic_dev_type" = "xOmnipath" ]; then
             log_info "Call configib for IB nics: $nic_dev, ports: $num_iba_ports"

--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -524,7 +524,10 @@ function configure_nicdevice {
         nic_pair=`echo "$nics_pair" |sed -n "${num}p"`
         echo "configure nic and its device : $nic_pair"
         ipaddrs=$(find_nic_ips $nic_dev)
-        next_nic=$(echo "$nics_pair"|awk /${nic_dev}$/'{ print $1}')
+        # if a device is middle device, it may have no IP, for example, configure eth0->vlan.1->br0, vlan1.1 is middle device
+        # is_mid_device is to label if ${nic_dev} is middle device
+        # if $is_mid_device has value, the ${nic_dev} is middle device, or else, it is not middle device
+        is_mid_device=$(echo "$nics_pair"|awk /${nic_dev}$/'{ print $1}')
         #ignore bmc interfaces. They're allowed in the nics table to generate DNS/hostname records, but they
         #can't be configured here (it's done in bmcsetup
         if [ x"$nic_dev_type" = "xbmc" ]; then
@@ -582,7 +585,7 @@ function configure_nicdevice {
             if [ "$networkmanager_active" = "0" ]; then
                 create_vlan_interface ifname=$vlanname vlanid=$vlanid
             elif [ "$networkmanager_active" = "1" ]; then
-                create_vlan_interface_nmcli ifname=$vlanname vlanid=$vlanid ipaddrs=$ipaddrs next_nic=$next_nic
+                create_vlan_interface_nmcli ifname=$vlanname vlanid=$vlanid ipaddrs=$ipaddrs next_nic=$is_mid_device
             fi
             if [ $? -ne 0 ]; then
                 log_error "configure VLAN failed."
@@ -593,7 +596,7 @@ function configure_nicdevice {
             if [ "$networkmanager_active" = "0" ]; then
                 create_bond_interface ifname=$nic_dev slave_ports=$base_nic_for_bond slave_type=$base_nic_type
             elif [ "$networkmanager_active" = "1" ]; then
-                create_bond_interface_nmcli bondname=$nic_dev slave_ports=$base_nic_for_bond slave_type=$base_nic_type _ipaddr=$ipaddrs next_nic=$next_nic
+                create_bond_interface_nmcli bondname=$nic_dev slave_ports=$base_nic_for_bond slave_type=$base_nic_type _ipaddr=$ipaddrs next_nic=$is_mid_device
             fi
             if [ $? -ne 0 ]; then
                 log_error "configure bond $nic_dev failed."
@@ -628,7 +631,7 @@ errorcode=0
 utolcmd="sed -e y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/"
 
 #back up all network interface configure files
-nwdirbak="/tmp/"
+nwdirbak=$nwdir".xcatbak"
 ls $nwdirbak > /dev/null 2>/dev/null
 if [ $? -ne 0 ]; then
     log_info "back up $nwdir to $nwdirbak"

--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -524,6 +524,7 @@ function configure_nicdevice {
         nic_pair=`echo "$nics_pair" |sed -n "${num}p"`
         echo "configure nic and its device : $nic_pair"
         ipaddrs=$(find_nic_ips $nic_dev)
+        next_nic=$(echo "$nics_pair"|awk /${nic_dev}$/'{ print $1}')
         #ignore bmc interfaces. They're allowed in the nics table to generate DNS/hostname records, but they
         #can't be configured here (it's done in bmcsetup
         if [ x"$nic_dev_type" = "xbmc" ]; then
@@ -592,7 +593,7 @@ function configure_nicdevice {
             if [ "$networkmanager_active" = "0" ]; then
                 create_bond_interface ifname=$nic_dev slave_ports=$base_nic_for_bond slave_type=$base_nic_type
             elif [ "$networkmanager_active" = "1" ]; then
-                create_bond_interface_nmcli bondname=$nic_dev slave_ports=$base_nic_for_bond slave_type=$base_nic_type _ipaddr=$ipaddrs
+                create_bond_interface_nmcli bondname=$nic_dev slave_ports=$base_nic_for_bond slave_type=$base_nic_type _ipaddr=$ipaddrs next_nic=$next_nic
             fi
             if [ $? -ne 0 ]; then
                 log_error "configure bond $nic_dev failed."
@@ -627,13 +628,13 @@ errorcode=0
 utolcmd="sed -e y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/"
 
 #back up all network interface configure files
-nwdirbak=$nwdir".xcatbak"
+nwdirbak="/tmp/"
 ls $nwdirbak > /dev/null 2>/dev/null
 if [ $? -ne 0 ]; then
-    log_info "back up $nwdir to $newdirbak"
+    log_info "back up $nwdir to $nwdirbak"
     cp -rf $nwdir $nwdirbak > /dev/null 2>/dev/null
     if [ $? -ne 0 ]; then
-        log_warn "back up $nwdir to $newdirbak failed."
+        log_warn "back up $nwdir to $nwdirbak failed."
     fi
 fi
 

--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -582,7 +582,7 @@ function configure_nicdevice {
             if [ "$networkmanager_active" = "0" ]; then
                 create_vlan_interface ifname=$vlanname vlanid=$vlanid
             elif [ "$networkmanager_active" = "1" ]; then
-                create_vlan_interface_nmcli ifname=$vlanname vlanid=$vlanid ipaddrs=$ipaddrs
+                create_vlan_interface_nmcli ifname=$vlanname vlanid=$vlanid ipaddrs=$ipaddrs next_nic=$next_nic
             fi
             if [ $? -ne 0 ]; then
                 log_error "configure VLAN failed."

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -1878,7 +1878,9 @@ function create_bridge_interface_nmcli {
             fi
         fi
         log_info "create bridge connection $xcat_con_name"
-        $nmcli con add type bridge con-name $xcat_con_name ifname $ifname
+        cmd="$nmcli con add type bridge con-name $xcat_con_name ifname $ifname $_mtu"
+        log_info $cmd
+        $cmd
         if [ $? -ne 0 ]; then
             log_error "nmcli failed to add bridge $ifname"
             is_nmcli_connection_exist $tmp_con_name
@@ -1906,7 +1908,9 @@ function create_bridge_interface_nmcli {
             fi
         fi
         log_info "create $_pretype slaves connetcion $xcat_slave_con for bridge"
-        $nmcli con add type $_pretype con-name $xcat_slave_con ifname $_port master $ifname $_mtu
+        cmd="$nmcli con add type $_pretype con-name $xcat_slave_con ifname $_port master $ifname $_mtu"
+        log_info "$cmd"
+        $cmd
         if [ $? -ne 0 ]; then
             log_error "nmcli failed to add bridge slave $_port"
             is_nmcli_connection_exist $tmp_slave_con_name
@@ -1924,15 +1928,6 @@ function create_bridge_interface_nmcli {
     if [ -n "$ipv4_addr" ]; then
         log_info "add ip $ipv4_addr/$str_prefix to bridge"
         $nmcli con mod $xcat_con_name ipv4.method manual ipv4.addresses $ipv4_addr/$str_prefix;
-    fi
-
-    # Configure MTU
-    if [ -n "$_mtu" ]; then
-        $nmcli con mod $xcat_con_name $_mtu
-        if [ $? -ne 0 ]; then
-            log_error "$nmcli con mod $xcat_con_name $_mtu failed"
-            rc=1
-        fi
     fi
 
     # bring up interface formally
@@ -1976,12 +1971,244 @@ function create_bridge_interface_nmcli {
 #############################################################################################################################
 #
 # create bond or bond->vlan interface
-# https://www.kernel.org/doc/Documentation/networking/bonding.txt
-# https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Networking_Guide/sec-Using_Channel_Bonding.html
 #
-# input : ifname=<nic> xcatnet=<xcatnetwork> _ipaddr=<ip> _netmask=<netmask> _bonding_opts=<bonding_opts> _mtu=<mtu> slave_ports=<port1,port2>
+# input : bondname=<nic> _ipaddr=<ip> slave_ports=<port1,port2> slave_type=<base_nic_type>
+# return : 0 successful
+#          other unsuccessful
 #
 ############################################################################################################################
 function create_bond_interface_nmcli {
     log_info "create_bond_interface $@"
+    local lines=""
+    local bondname=""
+    local xcatnet=""
+    local _ipaddr=""
+    local _netmask=""
+    local _bonding_opts=""
+    local _mtu=""
+    local slave_ports="" #bond slaves
+    local slave_type=""
+    local rc=0
+    local cleanup=0
+    # parser input arguments
+    while [ -n "$1" ];
+    do
+        key=$(echo "$1" | $cut -s -d= -f1)
+        if [ "$key" = "bondname" ] || \
+           [ "$key" = "_ipaddr" ] || \
+           [ "$key" = "slave_ports" ] || \
+           [ "$key" = "slave_type" ]; then
+            eval "$1"
+        fi
+        shift
+    done
+    if [ "$slave_type" = "ethernet" ]; then
+        slave_type="Ethernet"
+        # - "802.3ad" mode requires a switch that is 802.3ad compliant.
+        _bonding_opts="mode=802.3ad,miimon=100"
+    elif [ "$slave_type" = "infiniband" ]; then
+        slave_type="Infiniband"
+        _bonding_opts="mode=1,miimon=100,fail_over_mac=1"
+    fi
+    # query "nicnetworks" table about its target "xcatnet"
+    xcatnet=$(query_nicnetworks_net $bondname)
+    log_info "Pickup xcatnet, \"$xcatnet\", from NICNETWORKS for interface \"$bondname\"."
+
+    # Query mtu value from "networks" table
+    _mtu_num=$(get_network_attr $xcatnet mtu)
+    if [ $? -ne 0 ]; then
+        _mtu=""
+    else
+        _mtu="mtu $_mtu_num"
+    fi
+
+    # Query mask value from "networks" table
+    _netmask=$(get_network_attr $xcatnet mask)
+    if [ $? -ne 0 ]; then
+        log_error "No valid netmask get for $bondname"
+        return 1
+    fi
+
+    # Calculate prefix based on mask
+    str_prefix=$(v4mask2prefix $_netmask)
+
+    # Get first valid ip from nics.nicips
+    ipv4_addr=$(get_first_addr_ipv4 $_ipaddr)
+    if [ $? -ne 0 ]; then
+        log_error "No valid IP address get for $bondname, please check $ipaddrs"
+        return 1
+    fi
+
+    # check if all slave dev managed or not by nmcli
+    for ifslave in $(echo "$slave_ports" | $sed -e 's/,/ /g')
+    do
+        check_and_set_device_managed $ifslave
+        if [ $? -ne 0 ]; then
+            return 1
+        fi
+
+    done
+
+    # check if bond connection exist or not
+    xcat_con_name="xcat-"$bondname
+    tmp_con_name=""
+    is_nmcli_connection_exist $xcat_con_name
+    if [ $? -eq 0 ]; then
+        is_connection_activate_intime $xcat_con_name 10
+        if [ $? -eq 1 ]; then
+            $nmcli con down $xcat_con_name
+            wait_for_ifstate $bondname DOWN 40 1
+        fi 
+        tmp_con_name="xcat-bond-$xcat_con_name-tmp"
+        log_info "$xcat_con_name exists, rename old $xcat_con_name to $tmp_con_name"
+        $nmcli con modify $xcat_con_name connection.id $tmp_con_name
+        if [ $? -ne 0 ] ; then
+            log_error "$nmcli rename $xcat_con_name failed"
+            return 1
+        fi
+    fi
+
+    # create raw bond device
+    log_info "create bond connection $xcat_con_name"
+    cmd="$nmcli con add type bond con-name $xcat_con_name ifname $bondname bond.options $_bonding_opts method none ipv4.method manual ipv4.addresses $ipv4_addr/$str_prefix $_mtu"
+    log_info $cmd
+    $cmd
+    if [ $? -ne 0 ]; then
+        log_error "nmcli failed to add bond connection $xcat_con_name"
+        if [ -n "$tmp_con_name" ] ; then
+            $nmcli con modify $tmp_con_name connection.id $xcat_con_name
+        fi
+        return 1
+    fi
+
+    # Create slaves connection
+    num=1
+    xcat_slave_con_names=""
+    tmp_slave_con_names=""
+    for ifslave in $(echo "$slave_ports" | $sed -e 's/,/ /g')
+    do
+        tmp_slave_con_name=""
+        xcat_slave_con="xcat-bond-slave-"$ifslave
+        is_nmcli_connection_exist $xcat_slave_con
+        if [ $? -eq 0 ] ; then
+            tmp_slave_con_name=$xcat_slave_con"-tmp-"$num
+            log_info "rename $xcat_slave_con to $tmp_slave_con_name"
+            $nmcli con modify $xcat_slave_con connection.id $tmp_slave_con_name
+            if [ -n "$tmp_slave_con_names" ]; then
+                tmp_slave_con_names="$tmp_slave_con_names $tmp_slave_con_name"
+            else
+                tmp_slave_con_names=$tmp_slave_con_name
+            fi
+            
+        fi
+        cmd="$nmcli con add type $slave_type con-name $xcat_slave_con $_mtu method none ifname $ifslave master $xcat_con_name"
+        log_info $cmd
+        $cmd
+        if [ $? -ne 0 ]; then
+            log_error "nmcli failed to add bond slave connection $xcat_slave_name"
+            if [ -n "$tmp_slave_con_name" ] ; then
+                $nmcli con modify $tmp_slave_con_name connection.id $xcat_slave_name
+            fi
+            rc=1
+            break
+        else
+            if [ -n "$xcat_slave_con_names" ]; then
+                xcat_slave_con_names="$xcat_slave_con_names $xcat_slave_con"
+            else
+                xcat_slave_con_names=$xcat_slave_con
+            fi
+        fi
+        if [ -n "$tmp_slave_con_name" ]; then
+            is_connection_activate_intime $tmp_slave_con_name 10
+            if [ $? -eq 1 ]; then
+                $nmcli con down $tmp_slave_con_name
+            fi 
+        fi
+        cmd="$nmcli con up $xcat_slave_con"
+        log_info $cmd
+        $cmd
+        is_connection_activate_intime $xcat_slave_con
+        is_active=$?
+        if [ "$is_active" -eq 0 ]; then
+            log_error "The bond slave connection $xcat_slave_con can not be booted up"
+            $nmcli con delete $xcat_slave_con
+            if [ -n "$tmp_slave_con_name" ]; then
+                $nmcli con modify $tmp_slave_con_name connection.id $xcat_slave_con
+            fi
+            rc=1
+            break
+        fi 
+    done
+    # bring up interface formally
+    if [ $rc -ne 1 ]; then 
+        log_info "$nmcli con up $xcat_con_name"
+        lines=$($nmcli con up $xcat_con_name)
+        is_connection_activate_intime $xcat_con_name
+        is_active=$?
+        if [ "$is_active" -eq 0 ]; then
+            log_error "connection $xcat_con_name failed to activate"
+            rc=1
+        else
+            wait_for_ifstate $bondname UP 20 10
+            if [ $? -ne 0 ]; then
+                rc=1
+            else
+                $ip address show dev $bondname| $sed -e 's/^/[bond] >> /g' | log_lines info
+            fi
+        fi
+    fi
+
+    if [ $rc -eq 1 ]; then
+        # delete all bond slave and master which is created by xCAT
+        if [ -n "$xcat_slave_con_names" ]; then
+            log_info "delete connection $xcat_slave_con_names"
+            delete_bond_slaves_con "$xcat_slave_con_names"
+        fi
+        if [ -n "$tmp_slave_con_names" ]; then
+            for tmpslave in $tmp_slave_con_names
+            do  
+                slavecon=$(echo $tmpslave|awk -F"-" '{print $1"-"$2"-"$3"-"$4}')
+                log_info "restore connection $slavecon"
+                $nmcli con modify $tmpslave connection.id $slavecon 
+            done
+        fi
+        is_nmcli_connection_exist $xcat_con_name
+        if [ $? -eq 0 ] ; then
+            log_info "delete bond connection $xcat_con_name"
+            $nmcli con delete $xcat_con_name
+        fi
+        if [ -n "$tmp_con_name" ] ; then
+            log_info "restore bond connection $tmp_con_name"
+            $nmcli con modify $tmp_con_name connection.id $xcat_con_name
+        fi
+    else
+        # delete  tmp master and tmp slaves 
+        if [ -n "$tmp_con_name" ] ; then
+            $nmcli con delete $tmp_con_name
+        fi
+        if [ -n "$tmp_slave_con_names" ]; then
+            delete_bond_slaves_con "$tmp_slave_con_names"
+        fi
+    fi
+    return $rc
+}
+######################################################################
+#
+# delete bond slaves connection
+# imput format: <slave1> <slave2> <slave3> ... ...<slaven>
+#
+######################################################################
+function delete_bond_slaves_con {
+    slaves_con_names=$1
+    if [ -z "$slaves_con_names" ]; then
+        log_error "bond slaves connection list is empty"
+        return
+    fi
+    for slave in $slaves_con_names
+    do
+        is_nmcli_connection_exist $slave
+        if [ $? -eq 0 ] ; then
+            $nmcli con delete $slave
+        fi
+    done
 }

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -2123,7 +2123,7 @@ function create_bond_interface_nmcli {
         if [ $? -eq 0 ] ; then
             is_connection_activate_intime $xcat_slave_con 1
             if [ $? -eq 1 ]; then
-                $nmcli con down $xcat_con_name 
+                $nmcli con down $xcat_slave_con
                 ip link set dev $ifslave down
                 wait_for_ifstate $ifslave DOWN 40 1
             fi


### PR DESCRIPTION
### The PR is for task 

https://github.com/xcat2/xcat2-task-management/issues/610

_##Feature description##_
configure bond support using nmcli

### The UT result
1.  configure nics table:
```
"byrh09","bond51!50.4.41.141",,,"bond51!bond,ens5!ethernet,ens4!ethernet",,"bond51!50_0_0_0-255_0_0_0",,,"bond51!ens5|ens4",,,
```
2. configure bond when the bond connection is not existed
```
]# updatenode byrh09 confignetwork
byrh09: =============updatenode starting====================
byrh09: trying to download postscripts...
byrh09: postscripts downloaded successfully
byrh09: trying to get mypostscript from 10.4.41.1...
byrh09: postscript start..: confignetwork
byrh09: [I]: NetworkManager is active
byrh09: [I]: All valid nics and device list:
byrh09: [I]: bond51 ens5@ens4
byrh09: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh09: configure nic and its device : bond51 ens5@ens4
byrh09: [I]: create_bond_interface bondname=bond51 slave_ports=ens5,ens4 slave_type=ethernet _ipaddr=50.4.41.141
byrh09: [I]: Pickup xcatnet, "50_0_0_0-255_0_0_0", from NICNETWORKS for interface "bond51".
byrh09: [I]: create bond connection xcat-bond51
byrh09: [I]: nmcli con add type bond con-name xcat-bond51 ifname bond51 bond.options mode=802.3ad,miimon=100 method none ipv4.method manual ipv4.addresses 50.4.41.141/8 mtu 1400
byrh09: Connection 'xcat-bond51' (f8dd01a0-3c4d-4d8f-97e1-be869c53a5d3) successfully added.
byrh09: [I]: nmcli con add type Ethernet con-name xcat-bond-slave-ens5 mtu 1400 method none ifname ens5 master xcat-bond51
byrh09: Connection 'xcat-bond-slave-ens5' (2dd338fc-3443-4062-8716-8af4a8565eb8) successfully added.
byrh09: [I]: nmcli con up xcat-bond-slave-ens5
byrh09: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/17755)
byrh09: [I]: nmcli con add type Ethernet con-name xcat-bond-slave-ens4 mtu 1400 method none ifname ens4 master xcat-bond51
byrh09: Connection 'xcat-bond-slave-ens4' (d551897f-8e6f-4f02-971b-82742fb1c52b) successfully added.
byrh09: [I]: nmcli con up xcat-bond-slave-ens4
byrh09: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/17756)
byrh09: [I]: nmcli con up xcat-bond51
byrh09: [I]: [bond] >> 69: bond51: <BROADCAST,MULTICAST,MASTER,UP,LOWER_UP> mtu 1400 qdisc noqueue state UP group default qlen 1000
byrh09: [I]: [bond] >>     link/ether 42:9b:0a:04:29:09 brd ff:ff:ff:ff:ff:ff
byrh09: [I]: [bond] >>     inet 50.4.41.141/8 brd 50.255.255.255 scope global noprefixroute bond51
byrh09: [I]: [bond] >>        valid_lft forever preferred_lft forever
byrh09: [I]: [bond] >>     inet6 fe80::5669:e83e:aa8f:24fb/64 scope link tentative noprefixroute
byrh09: [I]: [bond] >>        valid_lft forever preferred_lft forever
byrh09: postscript end....: confignetwork exited with code 0
byrh09: Running of postscripts has completed.
byrh09: =============updatenode ending====================
```
3. configure bond when the bond connection is existed
```
]# updatenode byrh09 confignetwork
byrh09: =============updatenode starting====================
byrh09: trying to download postscripts...
byrh09: postscripts downloaded successfully
byrh09: trying to get mypostscript from 10.4.41.1...
byrh09: postscript start..: confignetwork
byrh09: [I]: NetworkManager is active
byrh09: [I]: All valid nics and device list:
byrh09: [I]: bond51 ens5@ens4
byrh09: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh09: configure nic and its device : bond51 ens5@ens4
byrh09: [I]: create_bond_interface bondname=bond51 slave_ports=ens5,ens4 slave_type=ethernet _ipaddr=50.4.41.141
byrh09: [I]: Pickup xcatnet, "50_0_0_0-255_0_0_0", from NICNETWORKS for interface "bond51".
byrh09: Connection 'xcat-bond51' successfully deactivated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/17741)
byrh09: [I]: xcat-bond51 exists, rename old xcat-bond51 to xcat-bond-xcat-bond51-tmp
byrh09: [I]: create bond connection xcat-bond51
byrh09: [I]: nmcli con add type bond con-name xcat-bond51 ifname bond51 bond.options mode=802.3ad,miimon=100 method none ipv4.method manual ipv4.addresses 50.4.41.141/8 mtu 1400
byrh09: Connection 'xcat-bond51' (72b538ff-e7db-463e-9f40-783cc31df0e2) successfully added.
byrh09: [I]: rename xcat-bond-slave-ens5 to xcat-bond-slave-ens5-tmp-1
byrh09: [I]: nmcli con add type Ethernet con-name xcat-bond-slave-ens5 mtu 1400 method none ifname ens5 master xcat-bond51
byrh09: Connection 'xcat-bond-slave-ens5' (8748282a-a70f-4650-a2ea-b03077cb1cef) successfully added.
byrh09: [I]: nmcli con up xcat-bond-slave-ens5
byrh09: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/17747)
byrh09: [I]: rename xcat-bond-slave-ens4 to xcat-bond-slave-ens4-tmp-1
byrh09: [I]: nmcli con add type Ethernet con-name xcat-bond-slave-ens4 mtu 1400 method none ifname ens4 master xcat-bond51
byrh09: Connection 'xcat-bond-slave-ens4' (ab118652-9fff-4c82-b10f-0da466dc6199) successfully added.
byrh09: [I]: nmcli con up xcat-bond-slave-ens4
byrh09: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/17748)
byrh09: [I]: nmcli con up xcat-bond51
byrh09: [I]: [bond] >> 69: bond51: <BROADCAST,MULTICAST,MASTER,UP,LOWER_UP> mtu 1400 qdisc noqueue state UP group default qlen 1000
byrh09: [I]: [bond] >>     link/ether 42:9b:0a:04:29:09 brd ff:ff:ff:ff:ff:ff
byrh09: [I]: [bond] >>     inet 50.4.41.141/8 brd 50.255.255.255 scope global noprefixroute bond51
byrh09: [I]: [bond] >>        valid_lft forever preferred_lft forever
byrh09: [I]: [bond] >>     inet6 fe80::c074:5f9d:be9d:7b4d/64 scope link tentative noprefixroute
byrh09: [I]: [bond] >>        valid_lft forever preferred_lft forever
byrh09: Connection 'xcat-bond-xcat-bond51-tmp' (e7d56555-0539-494a-b866-a1db13e210b9) successfully deleted.
byrh09: Connection 'xcat-bond-slave-ens5-tmp-1' (395668ea-682e-4a80-af77-e2e4bbe397d9) successfully deleted.
byrh09: Connection 'xcat-bond-slave-ens4-tmp-1' (90b91718-b6a4-4d8a-985a-311554506138) successfully deleted.
byrh09: postscript end....: confignetwork exited with code 0
byrh09: Running of postscripts has completed.
byrh09: =============updatenode ending====================
```
4. check results in compute node
```
]# ip link
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: ens3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
    link/ether 42:c5:0a:04:29:09 brd ff:ff:ff:ff:ff:ff
3: ens4: <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> mtu 1400 qdisc fq_codel master bond51 state UP mode DEFAULT group default qlen 1000
    link/ether 42:9b:0a:04:29:09 brd ff:ff:ff:ff:ff:ff
4: ens5: <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> mtu 1400 qdisc fq_codel master bond51 state UP mode DEFAULT group default qlen 1000
    link/ether 42:9b:0a:04:29:09 brd ff:ff:ff:ff:ff:ff
69: bond51: <BROADCAST,MULTICAST,MASTER,UP,LOWER_UP> mtu 1400 qdisc noqueue state UP mode DEFAULT group default qlen 1000
    link/ether 42:9b:0a:04:29:09 brd ff:ff:ff:ff:ff:ff

]# nmcli con show
NAME                  UUID                                  TYPE      DEVICE
System ens3           a26ac740-efef-4e45-87b0-936a7236b397  ethernet  ens3
xcat-bond-slave-ens4  ab118652-9fff-4c82-b10f-0da466dc6199  ethernet  ens4
xcat-bond-slave-ens5  8748282a-a70f-4650-a2ea-b03077cb1cef  ethernet  ens5
xcat-bond51           72b538ff-e7db-463e-9f40-783cc31df0e2  bond      bond51
Wired connection 1    0ca29f07-18e0-3c16-9b2b-d0566d76d990  ethernet  --
Wired connection 2    a1686b80-8b9d-34b3-a674-c32599fda6d2  ethernet  --
```
5. regression bridge:
```
]# tabdump nics
"byrh09","br51!50.4.41.141",,,"br51!bridge,ens5!ethernet",,"br51!50_0_0_0-255_0_0_0",,,"br51!ens5",,,

]# updatenode byrh09 confignetwork
byrh09: =============updatenode starting====================
byrh09: trying to download postscripts...
byrh09: postscripts downloaded successfully
byrh09: trying to get mypostscript from 10.4.41.1...
byrh09: postscript start..: confignetwork
byrh09: [I]: NetworkManager is active
byrh09: [I]: All valid nics and device list:
byrh09: [I]: br51 ens5
byrh09: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh09: configure nic and its device : br51 ens5
byrh09: [I]: create_bridge_interface_nmcli ifname=br51 _brtype=bridge _port=ens5 _pretype=ethernet _ipaddr=50.4.41.141
byrh09: [I]: Pickup xcatnet, "50_0_0_0-255_0_0_0", from NICNETWORKS for interface "br51".
byrh09: [I]: create bridge connection xcatbr51
byrh09: [I]: nmcli con add type bridge con-name xcatbr51 ifname br51 mtu 1400
byrh09: Connection 'xcatbr51' (3fd4cb9f-29e5-4172-b7c9-5a58cb59216f) successfully added.
byrh09: [I]: create ethernet slaves connetcion xcat_br_ens5 for bridge
byrh09: [I]: nmcli con add type ethernet con-name xcat_br_ens5 ifname ens5 master br51 mtu 1400
byrh09: Connection 'xcat_br_ens5' (e4a68d91-eeaa-4551-bd27-a82e31f63cc1) successfully added.
byrh09: [I]: add ip 50.4.41.141/8 to bridge
byrh09: [I]: nmcli con up xcat_br_ens5; nmcli con up xcatbr51
byrh09: [I]: State of "br51" was "DOWN" instead of expected "UP". Wait 0 of 20 with interval 40.
byrh09: [I]: [bridge] >> 70: br51: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1400 qdisc noqueue state UP group default qlen 1000
byrh09: [I]: [bridge] >>     link/ether 42:9b:0a:04:29:09 brd ff:ff:ff:ff:ff:ff
byrh09: [I]: [bridge] >>     inet 50.4.41.141/8 brd 50.255.255.255 scope global noprefixroute br51
byrh09: [I]: [bridge] >>        valid_lft forever preferred_lft forever
byrh09: [I]: [bridge] >>     inet6 fe80::9b9c:3ad0:1e2a:45e7/64 scope link noprefixroute
byrh09: [I]: [bridge] >>        valid_lft forever preferred_lft forever
byrh09: postscript end....: confignetwork exited with code 0
byrh09: Running of postscripts has completed.
byrh09: =============updatenode ending====================
```