### PR TITLE
fix configeth using nmcli connection name with space

### DIFF
--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -133,7 +133,7 @@ function configipv4(){
         fi
         str_conf_file="/etc/sysconfig/network-scripts/ifcfg-${str_if_name}"
         if [ $networkmanager_active -eq 1 ]; then
-            con_name=$(nmcli dev show ${str_if_name}|grep CONNECTION|awk -F: '{print $2}'|sed 's/^[ \t]*$//g')
+            con_name=$(nmcli -g CONNECTIONS dev show ${str_if_name}|awk -F"|" '{print $NF}'|sed 's/^[ \t]*//g')
             if [ "$con_name" == "--" ] ; then
                 nmcli con add type ethernet con-name ${str_if_name} ifname ${str_if_name} ipv4.method manual  ipv4.addresses  ${str_v4ip}/${str_prefix}
             else
@@ -624,7 +624,7 @@ elif [ "$1" = "-s" ];then
         str_inst_prefix=$(v4mask2prefix ${str_inst_mask})
         str_conf_file="/etc/sysconfig/network-scripts/ifcfg-${str_inst_nic}"
         if [ $networkmanager_active -eq 1 ]; then
-            con_name=$(nmcli dev show ${str_if_name}|grep CONNECTION|awk -F: '{print $2}'|sed 's/^[ \t]*$//g')
+            con_name=$(nmcli -g CONNECTIONS dev show ${str_if_name}|awk -F"|" '{print $NF}'|sed 's/^[ \t]*//g')
             if [ "$con_name" == "--" ] ; then
                 nmcli con add type ethernet con-name ${str_inst_nic} ifname ${str_inst_nic} ipv4.method manual ipv4.addresses  ${str_inst_ip}/${str_inst_prefix}
             else


### PR DESCRIPTION
### The PR is to fix issue

confignetwork_secondarynic_updatenode
confignetwork_s_installnic_secondarynic_updatenode

### The modification include
delete space before nmcli connection name

### The UT result
1.
The old code:
```
[root@byrh09 xcat-core]# nmcli dev show ens4|grep CONNECTION|awk -F: '{print $2}'|sed 's/^[ \t]*$//g'
                     ens4
```
The new code
```
[root@byrh09 xcat-core]# nmcli -g CONNECTIONS dev show ens4 |awk -F"|" '{print $NF}'|sed 's/^[ \t]*//g'
ens4
```
2. updatenode results:
```
RUN:updatenode byrh09 -P confignetwork [Thu Mar 21 01:18:19 2019]
ElapsedTime:4 sec
RETURN rc = 0
OUTPUT:
byrh09: =============updatenode starting====================
byrh09: trying to download postscripts...
byrh09: postscripts downloaded successfully
byrh09: trying to get mypostscript from 10.4.41.1...
byrh09: postscript start..: confignetwork
byrh09: [I]: NetworkManager is active
byrh09: [I]: All valid nics and device list:
byrh09: [I]: ens4
byrh09: [I]: ens5
byrh09: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh09: configure nic and its device : ens4
byrh09: [I]: configure ens4
byrh09: [I]: call: configeth ens4 11.1.0.100 11_1_0_0-255_255_0_0
byrh09: [I]: configeth on byrh09: os type: redhat
byrh09: configeth on byrh09: old configuration: 3: ens4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
byrh09:     link/ether 42:20:0a:04:29:09 brd ff:ff:ff:ff:ff:ff
byrh09:     inet6 fe80::eadb:8d91:68e9:aec/64 scope link noprefixroute
byrh09:        valid_lft forever preferred_lft forever
byrh09: [I]: configeth on byrh09: new configuration
byrh09:        11.1.0.100, 11.1.0.0, 255.255.0.0,
byrh09: 3: ens4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
byrh09: ens4
byrh09: [I]: configeth on byrh09: add 11.1.0.100_16 for ens4 temporary.
byrh09: [I]: configeth on byrh09: ens4 changed, modify the configuration files
byrh09: ens4
byrh09: ['/etc/sysconfig/network-scripts/ifcfg-ens4']
byrh09: [I]: >> TYPE=Ethernet
byrh09: [I]: >> PROXY_METHOD=none
byrh09: [I]: >> BROWSER_ONLY=no
byrh09: [I]: >> BOOTPROTO=none
byrh09: [I]: >> DEFROUTE=yes
byrh09: [I]: >> IPV4_FAILURE_FATAL=no
byrh09: [I]: >> IPV6INIT=yes
byrh09: [I]: >> IPV6_AUTOCONF=yes
byrh09: [I]: >> IPV6_DEFROUTE=yes
byrh09: [I]: >> IPV6_FAILURE_FATAL=no
byrh09: [I]: >> IPV6_ADDR_GEN_MODE=stable-privacy
byrh09: [I]: >> NAME=ens4
byrh09: [I]: >> UUID=6dab9d60-7d01-4782-838a-5236bb5f51a5
byrh09: [I]: >> DEVICE=ens4
byrh09: [I]: >> ONBOOT=yes
byrh09: [I]: >> IPADDR=11.1.0.100
byrh09: [I]: >> PREFIX=16
byrh09: [I]: >> GATEWAY=10.0.0.103
byrh09: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh09: configure nic and its device : ens5
byrh09: [I]: configure ens5
byrh09: [I]: call: configeth ens5 12.1.0.100 12_1_0_0-255_255_0_0
byrh09: [I]: configeth on byrh09: os type: redhat
byrh09: configeth on byrh09: old configuration: 4: ens5: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
byrh09:     link/ether 42:9b:0a:04:29:09 brd ff:ff:ff:ff:ff:ff
byrh09:     inet 50.4.41.101/8 brd 50.255.255.255 scope global noprefixroute ens5
byrh09:        valid_lft forever preferred_lft forever
byrh09:     inet6 fe80::67d1:2fc4:2433:1780/64 scope link noprefixroute
byrh09:        valid_lft forever preferred_lft forever
byrh09: [I]: configeth on byrh09: new configuration
byrh09:        12.1.0.100, 12.1.0.0, 255.255.0.0,
byrh09: 4: ens5: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
byrh09: ens5
byrh09: [I]: configeth on byrh09: delete 50.4.41.101_8 for ens5 temporary.
byrh09: [I]: configeth on byrh09: add 12.1.0.100_16 for ens5 temporary.
byrh09: [I]: configeth on byrh09: ens5 changed, modify the configuration files
byrh09: ens5
byrh09: ['/etc/sysconfig/network-scripts/ifcfg-ens5']
byrh09: [I]: >> TYPE=Ethernet
byrh09: [I]: >> PROXY_METHOD=none
byrh09: [I]: >> BROWSER_ONLY=no
byrh09: [I]: >> BOOTPROTO=none
byrh09: [I]: >> IPADDR=12.1.0.100
byrh09: [I]: >> PREFIX=16
byrh09: [I]: >> DEFROUTE=yes
byrh09: [I]: >> IPV4_FAILURE_FATAL=no
byrh09: [I]: >> IPV6INIT=yes
byrh09: [I]: >> IPV6_AUTOCONF=yes
byrh09: [I]: >> IPV6_DEFROUTE=yes
byrh09: [I]: >> IPV6_FAILURE_FATAL=no
byrh09: [I]: >> IPV6_ADDR_GEN_MODE=stable-privacy
byrh09: [I]: >> NAME=ens5
byrh09: [I]: >> UUID=0e3f33de-a0f2-4911-bc74-ca9baf9736d7
byrh09: [I]: >> DEVICE=ens5
byrh09: [I]: >> ONBOOT=yes
byrh09: postscript end....: confignetwork exited with code 0
byrh09: Running of postscripts has completed.
byrh09: =============updatenode ending====================
CHECK:rc == 0	[Pass]
```