### PR TITLE
spec file not be used for xCAT-openbmc-py3 build

### DIFF
--- a/xCAT-openbmc-py/xCAT-openbmc-py3.build
+++ b/xCAT-openbmc-py/xCAT-openbmc-py3.build
@@ -1,0 +1,68 @@
+%undefine __brp_mangle_shebangs
+Summary: xCAT openbmc python3
+Name: xCAT-openbmc-py3
+#Version: %{?version:%{version}}%{!?version:%(cat Version)}
+Version: 2.14.6
+Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
+Epoch: 1
+License: EPL
+Group: Applications/System
+Source: xCAT-openbmc-py-%{version}.tar.gz
+Packager: IBM Corp.
+Vendor: IBM Corp.
+Distribution: %{?_distribution:%{_distribution}}%{!?_distribution:%{_vendor}}
+Prefix: /opt/xcat
+BuildRoot: /var/tmp/%{name}-%{version}-%{release}-root
+
+%ifnos linux
+AutoReqProv: no
+%endif
+
+BuildArch: noarch
+Requires: xCAT-server
+Requires: python3-gevent >= 1.2.2-2
+Requires: python3-greenlet >= 0.4.13-2
+Requires: python3-paramiko >= 2.0.0
+Requires: python3-docopt python3-requests python3-scp
+
+%description
+xCAT-openbmc-py3 provides openbmc related functions python3 based.
+
+%prep
+%setup -q -n xCAT-openbmc-py
+%build
+
+%install
+rm -rf $RPM_BUILD_ROOT
+install -d $RPM_BUILD_ROOT/%{prefix}/lib/python/agent
+install -d $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/xcatagent
+install -d $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/common
+install -d $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/hwctl
+install -d $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/hwctl/openbmc
+install -d $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/hwctl/redfish
+install -m755 lib/python/agent/*.py $RPM_BUILD_ROOT/%{prefix}/lib/python/agent
+install -m644 lib/python/agent/xcatagent/*.py $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/xcatagent
+install -m644 lib/python/agent/common/*.py $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/common
+install -m644 lib/python/agent/hwctl/*.py $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/hwctl
+install -m644 lib/python/agent/hwctl/openbmc/*.py $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/hwctl/openbmc/
+install -m644 lib/python/agent/hwctl/redfish/*.py $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/hwctl/redfish/
+
+%ifnos linux
+rm -rf $RPM_BUILD_ROOT/%{prefix}/lib/python/agent
+%endif
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files
+%defattr(-,root,root)
+%{prefix}
+
+%changelog
+
+%pre
+
+%post
+
+%preun
+


### PR DESCRIPTION
### The PR is for task _#https://github.ibm.com/xcat2/task_management/issues/41_

_##Feature description##_
Provide spec file to build xCAT-openbmc-py for python3

### The content of the PR:
* [x] _##Modified some ``Requires`` to python3 version_

### The UT result

Build rpm after build xcat:
``# rpmbuild -bb xCAT-openbmc-py3.spec``

Test Scenario: 
OS: redhat8 ppc64le

Steps:
based on https://xcat-docs.readthedocs.io/en/latest/references/coral/cluster_mgmt/scalability/python/install/rpm.html
for 4.2:
Download the rpms below: 
```
wget https://www.rpmfind.net/linux/fedora-secondary/releases/28/Everything/ppc64le/os/Packages/p/python3-bcrypt-3.1.4-3.fc28.ppc64le.rpm 
wget https://www.rpmfind.net/linux/fedora-secondary/releases/28/Everything/ppc64le/os/Packages/p/python3-docopt-0.6.2-8.fc28.noarch.rpm 
wget https://www.rpmfind.net/linux/fedora-secondary/releases/28/Everything/ppc64le/os/Packages/p/python3-paramiko-2.4.1-1.fc28.noarch.rpm 
wget https://www.rpmfind.net/linux/fedora-secondary/releases/28/Everything/ppc64le/os/Packages/p/python3-pynacl-1.2.0-2.fc28.ppc64le.rpm 
wget https://www.rpmfind.net/linux/fedora-secondary/releases/28/Everything/ppc64le/os/Packages/p/python3-scp-0.10.2-7.fc28.noarch.rpm
```
Config python:
```
# update-alternatives --config python

There are 2 programs which provide 'python'.

  Selection    Command
-----------------------------------------------
*  1           /usr/libexec/no-python
 + 2           /usr/bin/python3

Enter to keep the current selection[+], or type selection number: 2
```
Install ``xCAT-openbmc-py3-2.14.6-snap201903202308.noarch.rpm``
Verify command:
```
# rpower f5u14 state
Thu Mar 21 03:40:41 2019 f5u14: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.5.14.100/login -d '{"data": ["root", "xxxxxx"]}'
Thu Mar 21 03:40:41 2019 f5u14: [openbmc_debug] login 200 OK
Thu Mar 21 03:40:41 2019 f5u14: [openbmc_debug] list_power_states curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://10.5.14.100/xyz/openbmc_project/state/enumerate
Thu Mar 21 03:40:42 2019 f5u14: [openbmc_debug] list_power_states 200 OK
f5u14: on
```

**This pr is just for save xCAT-openbmc-py3.build file, will rename to xCAT-openbmc-py3.spec if want to build it by buildcore.sh called.**