### PR TITLE
Fix python error, TabError: inconsistent use of tabs and spaces in indentation

### DIFF
--- a/xCAT-server/lib/perl/xCAT/Template.pm
+++ b/xCAT-server/lib/perl/xCAT/Template.pm
@@ -394,7 +394,7 @@ sub subvars {
         $inc =~ s/#COLONHTTPPORT#/$httpportsuffix/eg;
 
         if (($::XCATSITEVALS{xcatdebugmode} eq "1") or ($::XCATSITEVALS{xcatdebugmode} eq "2")) {
-            $inc =~ s/#UNCOMMENTOENABLEDEBUGPORT#/ /g;
+            $inc =~ s/#UNCOMMENTOENABLEDEBUGPORT#//g;
         }
 
         if ($::XCATSITEVALS{xcatdebugmode} eq "2") {

--- a/xCAT-server/share/xcat/install/scripts/pre.rhels8
+++ b/xCAT-server/share/xcat/install/scripts/pre.rhels8
@@ -116,8 +116,8 @@ try:
 #UNCOMMENTOENABLEDEBUGPORT#				newcommand = b""
 #UNCOMMENTOENABLEDEBUGPORT#				for i in command[1:]:
 #UNCOMMENTOENABLEDEBUGPORT#					newcommand = newcommand + i + b" "
-#UNCOMMENTOENABLEDEBUGPORT#				output = os.popen(newcommand.decode('utf-8')).read()
-#UNCOMMENTOENABLEDEBUGPORT#				newSocket.send(output.encode())
+#UNCOMMENTOENABLEDEBUGPORT#				output = os.popen(newcommand.decode('utf-8')).read().encode()
+#UNCOMMENTOENABLEDEBUGPORT#				newSocket.send(output)
 #UNCOMMENTOENABLEDEBUGPORT#				break
 			if(command[0] == b"screendump"):
 				newcommand = "cat /dev/vcs"


### PR DESCRIPTION
### The PR is to fix issue _#6132_

### The modification include

_##Fix #UNCOMMENTOENABLEDEBUGPORT# replacement_

_##Make variable output byte instead of string_