### PR TITLE
Avoid noisy warning message on rh8 for makegocons 

### DIFF
--- a/xCAT-server/lib/perl/xCAT/Goconserver.pm
+++ b/xCAT-server/lib/perl/xCAT/Goconserver.pm
@@ -503,11 +503,13 @@ sub is_goconserver_running {
 sub switch_goconserver {
     my $callback = shift;
     # ignore SN as it is handled by AAsn
-    if ((-x "/usr/bin/systemctl" || -x "-x /bin/systemctl") && !$isSN) {
+    if ((-x "/usr/bin/systemctl" || -x "/bin/systemctl") && !$isSN) {
         my $cmd = "systemctl disable conserver";
-        xCAT::Utils->runcmd($cmd, -1);
-        if ($::RUNCMD_RC != 0) {
-            xCAT::MsgUtils->warn_message("Failed to execute command: $cmd.", $callback);
+        if (-x "/usr/sbin/conserver") {
+            xCAT::Utils->runcmd($cmd, -1);
+            if ($::RUNCMD_RC != 0) {
+                xCAT::MsgUtils->warn_message("Failed to execute command: $cmd.", $callback);
+            }
         }
         $cmd = "systemctl enable goconserver";
         xCAT::Utils->runcmd($cmd, -1);
@@ -537,9 +539,11 @@ sub switch_conserver {
     # ignore SN as it is handled by AAsn
     if ((-x "/usr/bin/systemctl" || -x "-x /bin/systemctl") && !$isSN) {
         my $cmd = "systemctl disable goconserver";
-        xCAT::Utils->runcmd($cmd, -1);
-        if ($::RUNCMD_RC != 0) {
-            xCAT::MsgUtils->warn_message("Failed to execute command: $cmd.", $callback);
+        if (-x "/usr/bin/goconserver") {
+            xCAT::Utils->runcmd($cmd, -1);
+            if ($::RUNCMD_RC != 0) {
+                xCAT::MsgUtils->warn_message("Failed to execute command: $cmd.", $callback);
+            }
         }
         $cmd = "systemctl enable conserver";
         xCAT::Utils->runcmd($cmd, -1);


### PR DESCRIPTION
Ignore the disable when not installed, not using package checking as we use a fake package there

### The PR is to fix issue #6145 

### The modification include

Add a checking before run `systemctl disable xxx`

### The UT result
```
# mv /usr/sbin/conserver /usr/sbin/conserver.bak
# mv /etc/init.d/conserver /etc/init.d/conserver.bak
# systemctl daemon-reload
# systemctl stop goconserver

#makegocons c910f04x27v10
Warning: [c910f04x27v22]: Failed to execute command: systemctl disable conserver.
c910f04x27v10: Created
#makegocons -d c910f04x27v10
c910f04x27v10: Deleted

Apply the patch and restart xcatd

# systemctl stop goconserver
# makegocons c910f04x27v10
Starting goconserver service ...
c910f04x27v10: Created
```

