### PR TITLE
Make postscript enabledkump work on RHEL 8

### DIFF
--- a/xCAT/postscripts/enablekdump
+++ b/xCAT/postscripts/enablekdump
@@ -101,7 +101,7 @@ if [ ! -z "$DUMP" ]; then
     MOUNTPATH=""
     if (pmatch $OSVER "*6\.*"); then
 	MOUNTPATH="/tmp"
-    elif (pmatch $OSVER "*7\.*"); then
+    elif (pmatch $OSVER "*[78]\.*"); then
         MOUNTPATH="/mnt"
     else
 	MOUNTPATH="/var/tmp"
@@ -215,7 +215,7 @@ EOF
                 mv ${oldremount}.bak $oldremount
             fi
 	else
-            if (pmatch $OSVER "rhel7*") || (pmatch $OSVER "rhels7*");then
+            if (pmatch $OSVER "rhel[78]*") || (pmatch $OSVER "rhels[78]*");then
                nfsvers=$(/usr/sbin/rpcinfo -p $KDIP|grep -w nfs|awk /tcp/'{print $2}'|sort)
                nfsver=0
                if [ -n "$nfsvers" ]; then
@@ -246,8 +246,10 @@ EOF
 
                echo "nfs $KDIP:$KDPATH" > /etc/kdump.conf
                echo "default shell" >> /etc/kdump.conf
-               #strip "xcat" out of the initramfs for kdump
-               echo "dracut_args --omit \"xcat\"" >> /etc/kdump.conf
+               if (pmatch $OSVER "rhel7*") || (pmatch $OSVER "rhels7*");then
+                   #strip "xcat" out of the initramfs for kdump
+                   echo "dracut_args --omit \"xcat\"" >> /etc/kdump.conf
+               fi
                #strip the unnecessary kernel options from /proc/cmdline
                #the modified "cmdline" will be used as the kernel options
                #for kdump initramfs; otherwise, the "service kdump restart" will fail


### PR DESCRIPTION
### The PR is to fix issue _#6146_

### The modification include

_##Patch `enablekdump` for RHEL 8_

### The unit test result

The osimage definition. Notice, set `crashkernelsize=512M@64M` for 4GB RAM compute node.
```
# lsdef -t osimage rhels8.0.0-ppc64le-netboot-kdump-compute
Object name: rhels8.0.0-ppc64le-netboot-kdump-compute
    crashkernelsize=512M@64M
    dump=nfs://10.3.1.19/install/kdump
    exlist=/install/custom/netboot/rhels8.0.0/kdump.rhels8.ppc64le.exlist
    imagetype=linux
    osarch=ppc64le
    osdistroname=rhels8.0.0-ppc64le
    osname=Linux
    osvers=rhels8.0.0
    otherpkgdir=/install/post/otherpkgs/rhels8.0.0/ppc64le
    permission=755
    pkgdir=/install/rhels8.0.0/ppc64le
    pkglist=/install/custom/netboot/rhels8.0.0/kdump.rhels8.ppc64le.pkglist
    postinstall=/install/custom/netboot/rhels8.0.0/kdump.rhels8.ppc64le.postinstall
    profile=compute
    provmethod=netboot
    rootimgdir=/install/netboot/rhels8.0.0/ppc64le/kdump-compute
```

```
[  OK  ] Started dracut pre-pivot and cleanup hook.
         Starting Kdump Vmcore Save Service...
[  OK  ] Started Cleanup squashfs mounts when switch root.
kdump: dump target is 10.3.1.19:/install/kdump
kdump: saving to /sysroot//var/crash/10.3.1.7-2019-03-21-06:09:25/
kdump: saving vmcore-dmesg.txt
kdump: saving vmcore-dmesg.txt complete
kdump: saving vmcore
Copying data                                      : [ 22.9 %] -           eta: 3s[   18.934882] env3: Budget exhausted after napi rescheduled
Copying data                                      : [100.0 %] /           eta: 0s
kdump: saving vmcore complete
[   21.538728] systemd-shutdow: 22 output lines suppressed due to ratelimiting
[   21.549551] systemd-shutdown[1]: Syncing filesystems and block devices.
[   21.550108] systemd-shutdown[1]: Sending SIGTERM to remaining processes...
[   21.553426] systemd-journald[136]: Received SIGTERM from PID 1 (systemd-shutdow).
[   21.574768] systemd-shutdown[1]: Sending SIGKILL to remaining processes...
[   21.577620] systemd-shutdown[1]: Unmounting file systems.
```
