### PR TITLE
enhance configure bond and bridge 2 test cases

### DIFF
--- a/xCAT-test/autotest/testcase/confignetwork/cases0
+++ b/xCAT-test/autotest/testcase/confignetwork/cases0
@@ -589,7 +589,7 @@ check:rc==0
 cmd:xdsh $$CN "rm -rf /tmp/backupnet/"
 cmd:xdsh $$CN "mkdir -p /tmp/backupnet/"
 check:rc==0
-cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network/ifcfg-* /tmp/backupnet/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network-scripts/ifcfg-* /tmp/backupnet/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /etc/network/interfaces.d/* /tmp/backupnet/";else echo "Sorry,this is not supported os"; fi
+cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network/ifcfg-* /tmp/backupnet/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "cp -rf /etc/sysconfig/network-scripts /tmp/backupnet/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /etc/network/interfaces.d/* /tmp/backupnet/";else echo "Sorry,this is not supported os"; fi
 cmd:if grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "yum -y install bridge-utils";fi
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=100.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test1 net=$secondnet mask=255.255.0.0 mgtifname=$$SECONDNIC
 check:rc==0
@@ -609,12 +609,12 @@ cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=`echo $cnip |sed -r '
 check:rc==0
 cmd:updatenode $$CN -P confignetwork
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;bond0ip=$var1$var2;if grep SUSE /etc/*release;then xdsh $$CN "grep $bond0ip /etc/sysconfig/network/ifcfg-bond0"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $bond0ip /etc/sysconfig/network-scripts/ifcfg-bond0"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $bond0ip /etc/network/interfaces.d/bond0";else echo "Sorry,this is not supported os"; fi
-check:rc==0
 cmd:xdsh $$CN "ls /sys/class/net"
 check:output=~bond0
 cmd:xdsh $$CN "cat /sys/class/net/bonding_masters"
 check:output=~bond0
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;bond0ip=$var1$var2;if grep SUSE /etc/*release;then xdsh $$CN "grep $bond0ip /etc/sysconfig/network/ifcfg-bond0"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $bond0ip /etc/sysconfig/network-scripts/ifcfg-*bond0"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $bond0ip /etc/network/interfaces.d/bond0";else echo "Sorry,this is not supported os"; fi
+check:rc==0
 cmd:rmdef -t network -o confignetworks_test1 
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifcfg-$$SECONDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts/ifcfg-$$SECONDNIC"; elif grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /etc/network/interfaces.d/$$SECONDNIC";else echo "Sorry,this is not supported os"; fi
 check:rc==0
@@ -625,12 +625,13 @@ cmd:rmdef -t network -o confignetworks_test3
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;bond0ip=$var1$var2;xdsh $$CN "ip addr del $bond0ip/16 dev bond0"
 cmd:xdsh $$CN "ip link del dev bond0"
 cmd:xdsh $$CN "echo -bond0 > /sys/class/net/bonding_masters"
-cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifcfg-bond0"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts/ifcfg-bond0"; elif grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /etc/network/interfaces.d/bond0";else echo "Sorry,this is not supported os"; fi
+cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifcfg-bond0"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "date"; elif grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /etc/network/interfaces.d/bond0";else echo "Sorry,this is not supported os"; fi
 check:rc==0
 cmd:if [ -e /tmp/CN.standa ]; then rmdef $$CN; cat /tmp/CN.standa | mkdef -z; rm -rf /tmp/CN.standa; fi
 check:rc==0
-cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network-scripts/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/network/interfaces.d/;cp -f /tmp/interfaces /etc/network/";else echo "Sorry,this is not supported os"; fi
+cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts;cp -rf /tmp/backupnet/network-scripts /etc/sysconfig/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/network/interfaces.d/;cp -f /tmp/interfaces /etc/network/";else echo "Sorry,this is not supported os"; fi
 check:rc==0
+cmd:xdsh $$CN "systemctl status NetworkManager >/dev/null 2>/dev/null && which nmcli >/dev/null 2>/dev/null && nmcli con reload"
 cmd:xdsh $$CN "rm -rf /tmp/backupnet/ /tmp/interfaces"
 check:rc==0
 end
@@ -757,7 +758,7 @@ check:rc==0
 cmd:xdsh $$CN "rm -rf /tmp/backupnet/"
 cmd:xdsh $$CN "mkdir -p /tmp/backupnet/"
 check:rc==0
-cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network/ifcfg-* /tmp/backupnet/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network-scripts/ifcfg-* /tmp/backupnet/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /etc/network/interfaces.d/* /tmp/backupnet/";else echo "Sorry,this is not supported os"; fi
+cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network/ifcfg-* /tmp/backupnet/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "cp -rf /etc/sysconfig/network-scripts /tmp/backupnet/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /etc/network/interfaces.d/* /tmp/backupnet/";else echo "Sorry,this is not supported os"; fi
 cmd:if grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "yum -y install bridge-utils";fi
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=100.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test1 net=$secondnet mask=255.255.0.0 mgtifname=$$SECONDNIC
 check:rc==0
@@ -776,12 +777,12 @@ cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=103;var2=`echo $cnip |sed -r '
 check:rc==0
 cmd:updatenode $$CN -P confignetwork
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=103;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;br0ip=$var1$var2;if grep SUSE /etc/*release;then xdsh $$CN "grep $br0ip /etc/sysconfig/network/ifcfg-br0"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $br0ip /etc/sysconfig/network-scripts/ifcfg-br0"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $br0ip /etc/network/interfaces.d/br0";else echo "Sorry,this is not supported os"; fi
-check:rc==0
 cmd:xdsh $$CN "ls /sys/class/net"
 check:output=~br0
 cmd:xdsh $$CN "cat /sys/class/net/bonding_masters"
 check:output=~bond0
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=103;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;br0ip=$var1$var2;if grep SUSE /etc/*release;then xdsh $$CN "grep $br0ip /etc/sysconfig/network/ifcfg-br0"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $br0ip /etc/sysconfig/network-scripts/ifcfg-*br0"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $br0ip /etc/network/interfaces.d/br0";else echo "Sorry,this is not supported os"; fi
+check:rc==0
 cmd:rmdef -t network -o confignetworks_test1
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifcfg-$$SECONDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts/ifcfg-$$SECONDNIC"; elif grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /etc/network/interfaces.d/$$SECONDNIC";else echo "Sorry,this is not supported os"; fi
 check:rc==0
@@ -794,11 +795,12 @@ cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r '
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;xdsh $$CN "ip addr del $second1ip/16 dev $$THIRDNIC"
 cmd:xdsh $$CN "ip link del dev br0"
 cmd:xdsh $$CN "echo -bond0 > /sys/class/net/bonding_masters"
-cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifcfg-br0"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts/ifcfg-br0"; elif grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /etc/network/interfaces.d/br0";else echo "Sorry,this is not supported os"; fi
+cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifcfg-br0"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "date"; elif grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /etc/network/interfaces.d/br0";else echo "Sorry,this is not supported os"; fi
 check:rc==0
 cmd:if [ -e /tmp/CN.standa ]; then rmdef $$CN; cat /tmp/CN.standa | mkdef -z; rm -rf /tmp/CN.standa; fi
 check:rc==0
-cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network-scripts/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/network/interfaces.d/;cp -f /tmp/interfaces /etc/network/";else echo "Sorry,this is not supported os"; fi
+cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts; cp -rf /tmp/backupnet/network-scripts /etc/sysconfig/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/network/interfaces.d/;cp -f /tmp/interfaces /etc/network/";else echo "Sorry,this is not supported os"; fi
+cmd:xdsh $$CN "systemctl status NetworkManager >/dev/null 2>/dev/null && which nmcli >/dev/null 2>/dev/null && nmcli con reload"
 cmd:xdsh $$CN "rm -rf /tmp/backupnet/ /tmp/interfaces"
 end
 

--- a/xCAT-test/autotest/testcase/confignetwork/cases0
+++ b/xCAT-test/autotest/testcase/confignetwork/cases0
@@ -625,11 +625,11 @@ cmd:rmdef -t network -o confignetworks_test3
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;bond0ip=$var1$var2;xdsh $$CN "ip addr del $bond0ip/16 dev bond0"
 cmd:xdsh $$CN "ip link del dev bond0"
 cmd:xdsh $$CN "echo -bond0 > /sys/class/net/bonding_masters"
-cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifcfg-bond0"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "date"; elif grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /etc/network/interfaces.d/bond0";else echo "Sorry,this is not supported os"; fi
+cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifcfg-bond0"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts"; elif grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /etc/network/interfaces.d/bond0";else echo "Sorry,this is not supported os"; fi
 check:rc==0
 cmd:if [ -e /tmp/CN.standa ]; then rmdef $$CN; cat /tmp/CN.standa | mkdef -z; rm -rf /tmp/CN.standa; fi
 check:rc==0
-cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts;cp -rf /tmp/backupnet/network-scripts /etc/sysconfig/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/network/interfaces.d/;cp -f /tmp/interfaces /etc/network/";else echo "Sorry,this is not supported os"; fi
+cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "cp -rf /tmp/backupnet/network-scripts /etc/sysconfig/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/network/interfaces.d/;cp -f /tmp/interfaces /etc/network/";else echo "Sorry,this is not supported os"; fi
 check:rc==0
 cmd:xdsh $$CN "systemctl status NetworkManager >/dev/null 2>/dev/null && which nmcli >/dev/null 2>/dev/null && nmcli con reload"
 cmd:xdsh $$CN "rm -rf /tmp/backupnet/ /tmp/interfaces"
@@ -795,11 +795,11 @@ cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r '
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;xdsh $$CN "ip addr del $second1ip/16 dev $$THIRDNIC"
 cmd:xdsh $$CN "ip link del dev br0"
 cmd:xdsh $$CN "echo -bond0 > /sys/class/net/bonding_masters"
-cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifcfg-br0"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "date"; elif grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /etc/network/interfaces.d/br0";else echo "Sorry,this is not supported os"; fi
+cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifcfg-br0"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts"; elif grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /etc/network/interfaces.d/br0";else echo "Sorry,this is not supported os"; fi
 check:rc==0
 cmd:if [ -e /tmp/CN.standa ]; then rmdef $$CN; cat /tmp/CN.standa | mkdef -z; rm -rf /tmp/CN.standa; fi
 check:rc==0
-cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts; cp -rf /tmp/backupnet/network-scripts /etc/sysconfig/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/network/interfaces.d/;cp -f /tmp/interfaces /etc/network/";else echo "Sorry,this is not supported os"; fi
+cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "cp -rf /tmp/backupnet/network-scripts /etc/sysconfig/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/network/interfaces.d/;cp -f /tmp/interfaces /etc/network/";else echo "Sorry,this is not supported os"; fi
 cmd:xdsh $$CN "systemctl status NetworkManager >/dev/null 2>/dev/null && which nmcli >/dev/null 2>/dev/null && nmcli con reload"
 cmd:xdsh $$CN "rm -rf /tmp/backupnet/ /tmp/interfaces"
 end

--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -133,8 +133,8 @@ function configipv4(){
         fi
         str_conf_file="/etc/sysconfig/network-scripts/ifcfg-${str_if_name}"
         if [ $networkmanager_active -eq 1 ]; then
-            con_name=$(nmcli dev show ${str_if_name}|grep CONNECTION|awk -F: '{print $2}'|sed 's/^[ \t]*$//g')
-            if [ "$con_name" == "--" ] ; then
+            con_name=$(nmcli dev show ${str_if_name}|grep GENERAL.CONNECTION|awk -F: '{print $2}'|sed 's/^[ \t]*//g')
+            if [ "$con_name" = "--" ] || [ ! -f "$str_conf_file" ]; then
                 nmcli con add type ethernet con-name ${str_if_name} ifname ${str_if_name} ipv4.method manual  ipv4.addresses  ${str_v4ip}/${str_prefix}
             else
                 nmcli con mod "${con_name}" ipv4.method manual ipv4.addresses ${str_v4ip}/${str_prefix}
@@ -624,8 +624,8 @@ elif [ "$1" = "-s" ];then
         str_inst_prefix=$(v4mask2prefix ${str_inst_mask})
         str_conf_file="/etc/sysconfig/network-scripts/ifcfg-${str_inst_nic}"
         if [ $networkmanager_active -eq 1 ]; then
-            con_name=$(nmcli dev show ${str_if_name}|grep CONNECTION|awk -F: '{print $2}'|sed 's/^[ \t]*$//g')
-            if [ "$con_name" == "--" ] ; then
+            con_name=$(nmcli dev show ${str_inst_nic}|grep GENERAL.CONNECTION|awk -F: '{print $2}'|sed 's/^[ \t]*//g')
+            if [ "$con_name" == "--" ] || [ ! -f "$str_conf_file" ]; then
                 nmcli con add type ethernet con-name ${str_inst_nic} ifname ${str_inst_nic} ipv4.method manual ipv4.addresses  ${str_inst_ip}/${str_inst_prefix}
             else
                 nmcli con mod "System ${str_inst_nic}" ipv4.method manual ipv4.addresses ${str_inst_ip}/${str_inst_prefix}


### PR DESCRIPTION
### The PR is for
https://github.com/xcat2/xcat-core/issues/6141

### The modification include
1. enhance 2 test cases:
confignetwork_bond_eth2_eth3
confignetwork_2eth_bridge_br

2. enhance configeth 

### The UT result
```
xcattest.log.20190321223649:confignetwork_2eth_bridge_br0
xcattest.log.20190321223649:------START::confignetwork_2eth_bridge_br0::Time:Thu Mar 21 22:36:51 2019------
xcattest.log.20190321223649:------END::confignetwork_2eth_bridge_br0::Passed::Time:Thu Mar 21 22:38:11 2019 ::Duration::80 sec----

xcattest.log.20190321222952:confignetwork_bond_eth2_eth3
xcattest.log.20190321222952:------START::confignetwork_bond_eth2_eth3::Time:Thu Mar 21 22:29:54 2019------
xcattest.log.20190321222952:------END::confignetwork_bond_eth2_eth3::Passed::Time:Thu Mar 21 22:30:49 2019 ::Duration::55 sec-----
```