### PR TITLE
Remove option -no-host-reboot for rflash

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/management/advanced/rflash/openbmc/openbmc_common.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/management/advanced/rflash/openbmc/openbmc_common.rst
@@ -6,16 +6,11 @@ Unattended flash of OpenBMC firmware will do the following events:
 #. Activate both BMC firmware and Host firmware
 #. If BMC firmware becomes activate, reboot BMC to apply new BMC firmware, or else, ``rflash`` will exit
 #. If BMC itself state is ``NotReady``, ``rflash`` will exit
-#. If BMC itself state is ``Ready``, and use ``--no-host-reboot`` option, ``rflash`` will not reboot the compute node
-#. If BMC itself state is ``Ready``, and do not use ``--no-host-reboot`` option, ``rflash`` will reboot the compute node to apply Host firmware
+#. If BMC itself state is ``Ready``, ``rflash`` will reboot the compute node to apply Host firmware
 
 Use the following command to flash the firmware unattended: ::
 
     rflash <noderange> -d /path/to/directory
-
-Use the following command to flash the firmware unattended and not reboot the compute node: ::
-
-    rflash <noderange> -d /path/to/directory --no-host-reboot
 
 If there are errors encountered during the flash process, take a look at the manual steps to continue flashing the BMC.
 

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -422,7 +422,7 @@ my %usage = (
     "OpenPOWER OpenBMC specific:
         rflash <noderange> {[-c|--check] | [-l|--list]}
         rflash <noderange> <tar_file_path> {[-c|--check] | [-a|--activate] | [-u|--upload]}
-        rflash <noderange> <tar_file_diretory> [-d] [--no-host-reboot]
+        rflash <noderange> <tar_file_diretory> [-d]
         rflash <noderange> <image_id> {[-a|--activate] | [--delete]}",
     "mkhwconn" =>
       "Usage:

--- a/xCAT-client/pods/man1/rflash.1.pod
+++ b/xCAT-client/pods/man1/rflash.1.pod
@@ -34,7 +34,7 @@ B<rflash> I<noderange> {[B<-c>|B<--check>] | [B<-l>|B<--list>]}
 
 B<rflash> I<noderange> I<tar_file_path> {[B<-c>|B<--check>] | [B<-a>|B<--activate>] | [B<-u>|B<--upload>]}
 
-B<rflash> I<noderange> I<tar_file_directory> [B<-d>] [B<--no-host-reboot>]
+B<rflash> I<noderange> I<tar_file_directory> [B<-d>]
 
 B<rflash> I<noderange> I<image_id> {[B<-a>|B<--activate>] | [B<--delete>]}
 
@@ -124,8 +124,6 @@ B<Note:> When using B<rflash> in hierarchical environment, the .tar file must be
 B<-d>:
 
 This option steamlines the update, activate, reboot BMC and reboot HOST procedure. It expects a directory containing both BMC and Host .tar files. When BMC and Host tar files are provided, the command will upload and activate firmware. After BMC becomes activate, it will reboot BMC. If BMC state is Ready, the command will reboot the HOST. If BMC state is NotReady, the command will exit.
-
-B<Note:> When using B<--no-host-reboot>, it will not reboot the host after BMC is reboot.
 
 B<--delete>:
 


### PR DESCRIPTION
### The PR is to fix issue  #6065

The modification include
* Remove --no-host-reboot option from rflash usage.
* Update documentation

The UT result
