### PR TITLE
Revert "Fix issue that site.master is not set"

### DIFF
--- a/perl-xCAT/xCAT/ServiceNodeUtils.pm
+++ b/perl-xCAT/xCAT/ServiceNodeUtils.pm
@@ -555,10 +555,6 @@ sub get_ServiceNode
                 {
                     push @{ $snhash{$master} }, $node;
                 }
-                else
-                {
-                    xCAT::MsgUtils->message('SW', "Unknown master for node: $node, neither noderes.servicenode nor site.master is set\n");
-                }
             }
         }
 

--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -2286,10 +2286,6 @@ sub dispatch_request {
         $SIG{CHLD} = 'DEFAULT';
         xCAT::MsgUtils->trace(0, "D", "xcatd: handle request '$req->{command}->[0]' by plugin '$modname''s preprocess_request");
         $reqs = ${ "xCAT_plugin::" . $modname . "::" }{preprocess_request}->($req, $dispatch_cb, \&do_request);
-        if (not(scalar @$reqs) and not(defined xCAT::TableUtils->get_site_attribute('master'))) {
-            $dispatch_cb->({ warning => ["The 'master' attribute is not set in the site table and may cause  unexpected behavior."]});
-            return;
-        }
     } else {    # otherwise, pass it in without hierarchy support
         $reqs = [$req];
     }


### PR DESCRIPTION
Reverts xcat2/xcat-core#6074
The return message have such issue:
```
# rpower c910f04x28v03,c910f04x28v04,f5u16 state
Warning: [c910f04x28v01]: The 'master' attribute is not set in the site table and may cause  unexpected behavior.
Warning: [c910f04x28v01]: The 'master' attribute is not set in the site table and may cause  unexpected behavior.
Warning: [c910f04x28v01]: The 'master' attribute is not set in the site table and may cause  unexpected behavior.
```