### PR TITLE
move kdump test cases from sles ubuntu and rhel in x86 and ppc

### DIFF
--- a/xCAT-test/autotest/bundle/rhels_ppc_weekly.bundle
+++ b/xCAT-test/autotest/bundle/rhels_ppc_weekly.bundle
@@ -69,4 +69,3 @@ rpower_reset
 runcmdinstaller_command
 redhat_migration1
 redhat_migration2
-linux_diskless_kdump

--- a/xCAT-test/autotest/bundle/rhels_x86_weekly.bundle
+++ b/xCAT-test/autotest/bundle/rhels_x86_weekly.bundle
@@ -72,4 +72,3 @@ rpower_reset
 runcmdinstaller_command
 redhat_migration1
 redhat_migration2
-linux_diskless_kdump

--- a/xCAT-test/autotest/bundle/sles_ppc_weekly.bundle
+++ b/xCAT-test/autotest/bundle/sles_ppc_weekly.bundle
@@ -12,4 +12,3 @@ reg_linux_diskless_installation_flat
 reg_linux_statelite_installation_flat
 sles_migration1
 sles_migration2
-linux_diskless_kdump

--- a/xCAT-test/autotest/bundle/sles_ppcle_weekly.bundle
+++ b/xCAT-test/autotest/bundle/sles_ppcle_weekly.bundle
@@ -19,4 +19,3 @@ reg_linux_diskless_installation_flat
 reg_linux_statelite_installation_flat
 sles_migration1
 sles_migration2
-linux_diskless_kdump

--- a/xCAT-test/autotest/bundle/sles_x86_weekly.bundle
+++ b/xCAT-test/autotest/bundle/sles_x86_weekly.bundle
@@ -19,4 +19,3 @@ reg_linux_diskless_installation_flat
 reg_linux_statelite_installation_flat
 sles_migration1
 sles_migration2
-linux_diskless_kdump

--- a/xCAT-test/autotest/bundle/ubuntu_ppcle_weekly.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu_ppcle_weekly.bundle
@@ -14,4 +14,3 @@ packimage_m_tar_c_xz
 packimage_o_p_a_m
 rmimage_diskless
 ubuntu_migration2_p8le
-linux_diskless_kdump

--- a/xCAT-test/autotest/bundle/ubuntu_x86_weekly.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu_x86_weekly.bundle
@@ -14,4 +14,3 @@ packimage_m_tar_c_xz
 packimage_o_p_a_m
 rmimage_diskless
 ubuntu_migration2_vm
-linux_diskless_kdump


### PR DESCRIPTION
### The PR is related of https://github.com/xcat2/xcat-core/issues/6159

### The modification include

* move ``linux_diskless_kdump`` test cases from sles ubuntu 

* due to kdump just related os, so just keep it in ``rhel+ppcle`` weekly bundle.