### PR TITLE
update console configuration for statelite test cases

### DIFF
--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_flat
@@ -11,7 +11,7 @@ check:rc==0
 
 cmd:makedns -n
 check:rc==0
-cmd:makeconservercf $$CN
+cmd:if [ -x /usr/bin/goconserver ]; then makegocons $$CN; else makeconservercf $$CN; fi
 check:rc==0
 cmd:sleep 20
 cmd:if [[ "__GETNODEATTR($$CN,arch)__" = "ppc64" ]]; then getmacs -D $$CN; fi
@@ -124,7 +124,7 @@ cmd:rm -rf /tmp/image;mkdir /tmp/image
 check:rc==0
 cmd:imgexport __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute /tmp/image/image.tgz
 check:rc==0
-
+cmd:if [ -x /usr/bin/goconserver ]; then makegocons -d $$CN; else makeconservercf -d $$CN; fi
 cmd:rootimgdir=`lsdef -t osimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir.regbak ]; then rm -rf $rootimgdir; mv $rootimgdir.regbak $rootimgdir; fi
 check:rc==0
 end

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_nfs
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_nfs
@@ -17,7 +17,7 @@ check:rc==0
 
 cmd:makedns -n
 check:rc==0
-cmd:makeconservercf
+cmd:if [ -x /usr/bin/goconserver ]; then makegocons $$CN; else makeconservercf $$CN; fi
 check:rc==0
 cmd:sleep 20
 cmd:if [[ "__GETNODEATTR($$CN,arch)__" = "ppc64" ]]; then getmacs -D $$CN; fi
@@ -100,6 +100,7 @@ check:output=~$$CN: $$CN
 cmd:xdsh $$CN  "cat /var/log/xcat/xcat.log"
 cmd:xdsh $$CN "echo "test"> /test.statelite"
 check:rc!=0
+cmd:if [ -x /usr/bin/goconserver ]; then makegocons -d $$CN; else makeconservercf -d $$CN; fi
 cmd:output=$(xdsh $$CN ls -al / |grep test.statelite);if [[ $? -eq 0 ]];then  xdsh $$CN rm -rf /test.tatelite;fi
 cmd:rootimgdir=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir ]; then rm -rf $rootimgdir;fi
 check:rc==0

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_ramdisk
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_ramdisk
@@ -17,7 +17,7 @@ check:rc==0
 
 cmd:makedns -n
 check:rc==0
-cmd:makeconservercf
+cmd:if [ -x /usr/bin/goconserver ]; then makegocons $$CN; else makeconservercf $$CN; fi
 check:rc==0
 cmd:sleep 20
 cmd:if [[ "__GETNODEATTR($$CN,arch)__" = "ppc64" ]]; then getmacs -D $$CN; fi
@@ -92,6 +92,7 @@ cmd:xdsh $$CN hostname
 check:rc==0
 check:output=~$$CN: $$CN
 cmd:xdsh $$CN  "cat /var/log/xcat/xcat.log"
+cmd:if [ -x /usr/bin/goconserver ]; then makegocons -d $$CN; else makeconservercf -d $$CN; fi
 cmd:rootimgdir=`lsdef -t osimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir.regbak ]; then rm -rf $rootimgdir; mv $rootimgdir.regbak $rootimgdir; fi
 check:rc==0
 end


### PR DESCRIPTION
### The PR is for task  https://github.ibm.com/xcat2/task_management/issues/39

what modify in this PR:

* update console configuration for statelite test cases

The UT are:
```
RUN:if [ -x /usr/bin/goconserver ]; then makegocons c910f04x38v06; else makeconservercf c910f04x38v06;fi [Sun Mar 24 07:23:51 2019]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
Starting goconserver service ...
c910f04x38v06: Created
CHECK:rc == 0   [Pass]
```