### PR TITLE
refine configeth using nmcli

### DIFF
--- a/xCAT-test/autotest/testcase/confignetwork/cases0
+++ b/xCAT-test/autotest/testcase/confignetwork/cases0
@@ -190,7 +190,7 @@ check:rc==0
 cmd:xdsh $$CN "rm -rf /tmp/backupnet/"
 cmd:xdsh $$CN "mkdir -p /tmp/backupnet/"
 check:rc==0
-cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network/ifcfg-* /tmp/backupnet/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network-scripts/ifcfg-* /tmp/backupnet/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /etc/network/interfaces.d/* /tmp/backupnet/";else echo "Sorry,this is not supported os"; fi
+cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network/ifcfg-* /tmp/backupnet/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "cp -rf /etc/sysconfig/network-scripts /tmp/backupnet/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /etc/network/interfaces.d/* /tmp/backupnet/";else echo "Sorry,this is not supported os"; fi
 check:rc==0
 cmd:mkdef -t network -o 11_1_0_0-255_255_0_0 net=11.1.0.0 mask=255.255.0.0 mgtifname=$$SECONDNIC mtu=1496
 check:rc==0
@@ -208,7 +208,8 @@ cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifc
 check:rc==0
 cmd:if [ -e /tmp/CN.standa ]; then rmdef $$CN; cat /tmp/CN.standa | mkdef -z; rm -rf /tmp/CN.standa; fi
 check:rc==0
-cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network-scripts/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/network/interfaces.d/";else echo "Sorry,this is not supported os"; fi
+cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "cp -rf /tmp/backupnet/network-scripts /etc/sysconfig/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/network/interfaces.d/";else echo "Sorry,this is not supported os"; fi
+cmd:xdsh $$CN "systemctl status NetworkManager >/dev/null 2>/dev/null && which nmcli >/dev/null 2>/dev/null && nmcli con reload"
 cmd:xdsh $$CN "rm -rf /tmp/backupnet/"
 end
 
@@ -975,7 +976,7 @@ cmd:lsdef $$CN -z && lsdef -l $$CN -z >/tmp/CN.stanza
 check:rc==0
 cmd:xdsh $$CN "mkdir -p /tmp/backupnet"
 check:rc==0
-cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network/ifcfg-* /tmp/backupnet/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network-scripts/ifcfg-* /tmp/backupnet/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /etc/network/interfaces.d/* /tmp/backupnet/;cp -f /etc/network/interfaces /tmp";else echo "Sorry,this is not supported os"; fi
+cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network/ifcfg-* /tmp/backupnet/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "cp -rf /etc/sysconfig/network-scripts /tmp/backupnet/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /etc/network/interfaces.d/* /tmp/backupnet/;cp -f /etc/network/interfaces /tmp";else echo "Sorry,this is not supported os"; fi
 check:rc==0
 cmd:xdsh $$CN "ps -A --format pid,comm | awk '/dhclient/ { print \$1 }' | xargs -r -n 1 kill"
 cmd:xdsh $$CN "ps -A --format pid,comm | awk '/dhclient/ { print \$1 }' | xargs -r -n 1 kill -KILL"
@@ -987,7 +988,8 @@ cmd:xdsh $$CN date
 check:rc==0
 # Clean up
 cmd:test -e /tmp/CN.stanza && rmdef $$CN && mkdef -z </tmp/CN.stanza; rm -rf /tmp/CN.stanza
-cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network-scripts/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/network/interfaces.d/;cp -f /tmp/interfaces /etc/network/";else echo "Sorry,this is not supported os"; fi
+cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts;cp -rf /tmp/backupnet/network-scripts /etc/sysconfig/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/network/interfaces.d/;cp -f /tmp/interfaces /etc/network/";else echo "Sorry,this is not supported os"; fi
 cmd:xdsh $$CN "rm -rf /tmp/backupnet/ /tmp/interfaces"
 cmd:xdsh $$CN "if [ -f /etc/init.d/network ] ; then /etc/init.d/network restart ; elif [ -f /etc/init.d/networking ] ; then /etc/init.d/networking restart ; fi"
+cmd:xdsh $$CN "systemctl status NetworkManager >/dev/null 2>/dev/null && which nmcli >/dev/null 2>/dev/null && nmcli con reload"
 end

--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -32,6 +32,9 @@ checkservicestatus NetworkManager > /dev/null
 if [ $? -eq 0 ]; then
     networkmanager_active=1
 fi
+str_conf_file=""
+str_conf_file_xcatbak=""
+tmp_con_name=""
 function configipv4(){
     str_if_name=$1
     str_v4ip=$2
@@ -126,19 +129,19 @@ function configipv4(){
     else
         str_prefix=$(v4mask2prefix $str_v4mask)
         # Write the info to the ifcfg file for redhat
-        con_name=""
+        con_name="xcat-"${str_if_name}
         str_conf_file=""
         if [ $num_v4num -ne 0 ]; then
             str_if_name=${str_if_name}:${num_v4num}
         fi
         str_conf_file="/etc/sysconfig/network-scripts/ifcfg-${str_if_name}"
         if [ $networkmanager_active -eq 1 ]; then
-            con_name=$(nmcli dev show ${str_if_name}|grep GENERAL.CONNECTION|awk -F: '{print $2}'|sed 's/^[ \t]*//g')
-            if [ "$con_name" = "--" ] || [ ! -f "$str_conf_file" ]; then
-                nmcli con add type ethernet con-name ${str_if_name} ifname ${str_if_name} ipv4.method manual  ipv4.addresses  ${str_v4ip}/${str_prefix}
-            else
-                nmcli con mod "${con_name}" ipv4.method manual ipv4.addresses ${str_v4ip}/${str_prefix}
+            is_nmcli_connection_exist $con_name
+            if [ $? -eq 0 ]; then
+                tmp_con_name=$con_name"-tmp"
+                nmcli con modify $con_name connection.id $tmp_con_name
             fi
+            nmcli con add type ethernet con-name $con_name ifname ${str_if_name} ipv4.method manual  ipv4.addresses  ${str_v4ip}/${str_prefix}
         else
             echo "DEVICE=${str_if_name}" > $str_conf_file
             echo "BOOTPROTO=none" >> $str_conf_file
@@ -148,7 +151,11 @@ function configipv4(){
             echo "ONBOOT=yes" >> $str_conf_file
         fi
         if [ "$str_nic_mtu" != "$str_default_token" ]; then
-            echo "MTU=${str_nic_mtu}" >> $str_conf_file
+            if [ $networkmanager_active -eq 1 ]; then
+		nmcli con modify $con_name mtu $str_nic_mtu
+            else
+                echo "MTU=${str_nic_mtu}" >> $str_conf_file
+	    fi
         fi
 
         if [[ ${str_if_name} == [a-zA-Z0-9]*.[0-9]* ]]; then
@@ -432,7 +439,7 @@ if [ "$1" = "-r" ];then
             if [ "$str_os_type" = "debian" ];then
                 ifdown --force $str_nic_name
             else
-                ifdown $str_nic_name
+                ip link set dev $str_nic_name  down
             fi
         fi
 
@@ -620,16 +627,16 @@ elif [ "$1" = "-s" ];then
         echo $NODE > /etc/HOSTNAME
     else
         #write ifcfg-* file for redhat
-        con_name=""
+        con_name="xcat-install-"${str_inst_nic}
         str_inst_prefix=$(v4mask2prefix ${str_inst_mask})
         str_conf_file="/etc/sysconfig/network-scripts/ifcfg-${str_inst_nic}"
         if [ $networkmanager_active -eq 1 ]; then
-            con_name=$(nmcli dev show ${str_inst_nic}|grep GENERAL.CONNECTION|awk -F: '{print $2}'|sed 's/^[ \t]*//g')
-            if [ "$con_name" == "--" ] || [ ! -f "$str_conf_file" ]; then
-                nmcli con add type ethernet con-name ${str_inst_nic} ifname ${str_inst_nic} ipv4.method manual ipv4.addresses  ${str_inst_ip}/${str_inst_prefix}
-            else
-                nmcli con mod "System ${str_inst_nic}" ipv4.method manual ipv4.addresses ${str_inst_ip}/${str_inst_prefix}
+            is_nmcli_connection_exist "$con_name"
+            if [ $? -eq 0 ]; then
+                tmp_con_name=${str_inst_nic}"-tmp"
+                nmcli con modify $con_name connection.id $tmp_con_name
             fi
+            nmcli con add type ethernet con-name $con_name ifname ${str_inst_nic} ipv4.method manual ipv4.addresses  ${str_inst_ip}/${str_inst_prefix}
         else
             echo "DEVICE=${str_inst_nic}" > $str_conf_file
             echo "IPADDR=${str_inst_ip}" >> $str_conf_file
@@ -639,7 +646,11 @@ elif [ "$1" = "-s" ];then
             echo "HWADDR=${str_inst_mac}" >> $str_conf_file
         fi
         if [ -n "${str_inst_mtu}" ];then
-            echo "MTU=${str_inst_mtu}" >> $str_conf_file
+	    if [ $networkmanager_active -eq 1 ]; then
+		nmcli con modify $con_name mtu ${str_inst_mtu}
+            else
+                echo "MTU=${str_inst_mtu}" >> $str_conf_file
+	    fi
         fi
         if [ -n "$str_inst_gateway" ];then
             grep -i "GATEWAY" /etc/sysconfig/network
@@ -678,15 +689,26 @@ elif [ "$1" = "-s" ];then
         if [ "$str_os_type" = "debian" ];then
             ifdown --force $str_inst_nic
         else
-            ifdown $str_inst_nic
+            ip link set dev $str_inst_nic down
         fi
-        ifup $str_inst_nic
+	if [ $networkmanager_active -eq 1 ]; then
+            nmcli con up $con_name
+	    wait_for_ifstate $str_inst_nic UP 10 5
+	else
+            ip link set dev $str_inst_nic up
+        fi
     fi
     if [ $? -ne 0 ]; then
-        log_error "ifup $str_inst_nic failed."
+        log_error "bring $str_inst_nic up failed."
         error_code=1
     fi
-
+    if [ $networkmanager_active -eq 1 ] && [ -n "$tmp_con_name" ]; then
+    	if [ $error_code -eq 1 ]; then
+            nmcli con modify $tmp_con_name connection.id $con_name
+        else
+            nmcli con delete $tmp_con_name
+        fi
+    fi
     exit $error_code
 fi
 
@@ -1005,7 +1027,7 @@ else
                     ifdown --force $str_nic_name > /dev/null
                 else
                     if [ $reboot_nic_bool -eq 1 ]; then
-                        ifdown $str_nic_name > /dev/null
+                        ip link set dev $str_nic_name down > /dev/null 2>/dev/null
                     fi
                 fi
             fi
@@ -1085,14 +1107,25 @@ else
         else
             if [ $reboot_nic_bool -eq 1 ]; then
                 echo "bring up ip"
-                ifup $str_nic_name
+		if [ $networkmanager_active -eq 1 ]; then
+                    nmcli con up $con_name
+		    wait_for_ifstate $str_nic_name UP 10 10
+		else
+                    ip link set dev $con_name up
+		fi
                 if [ $? -ne 0 ]; then
-                    log_error "ifup $str_nic_name failed."
+                    log_error "bring $con_name up failed."
                     error_code=1
                 fi
             fi
         fi
     fi
 fi
-
+if [ $networkmanager_active -eq 1 ] && [ -n "$tmp_con_name" ]; then
+    if [ $error_code -eq 1 ]; then
+        nmcli con modify $tmp_con_name connection.id $con_name
+    else
+        nmcli con delete $tmp_con_name
+    fi
+fi
 exit $error_code

--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -63,13 +63,16 @@ function get_nic_cfg_file_content {
     elif [ $is_debian -eq 1 ]; then
          cfg_file="$nwdir/${cfg_dev}"
     fi
-
-    if [ -f $cfg_file ]; then
-        echo "['${cfg_file}']" >&2
-        cat ${cfg_file}| $sed -e 's/^/ >> /g' | log_lines info
+    if [ "$networkmanager_active" = "1" ]; then
+        $ip address show dev ${cfg_dev}| $sed -e 's/^/[Ethernet] >> /g' | log_lines info
     else
-        log_error "Can not find $cfg_file."
-        errorcode=1
+        if [ -f $cfg_file ]; then
+            echo "['${cfg_file}']" >&2
+            cat ${cfg_file}| $sed -e 's/^/ >> /g' | log_lines info
+        else
+            log_error "Can not find $cfg_file."
+            errorcode=1
+        fi
     fi
 }
 
@@ -641,6 +644,17 @@ if [ $? -ne 0 ]; then
     fi
 fi
 
+#check if using NetworkManager or  network service
+networkmanager_active=2
+check_NetworkManager_or_network_service
+if [ $? -eq 0 ]; then
+    networkmanager_active=0
+elif [ $? -eq 1 ]; then
+    networkmanager_active=1
+else
+    exit 1
+fi
+
 #get for installnic
 installnic=''
 installnic=`get_installnic`
@@ -660,17 +674,6 @@ if [ $boot_install_nic -eq 1 ];then
         log_error "Can not determine proper install nic."
         errorcode=1
     fi
-fi
-
-#check if using NetworkManager or  network service
-networkmanager_active=2
-check_NetworkManager_or_network_service
-if [ $? -eq 0 ]; then
-    networkmanager_active=0
-elif [ $? -eq 1 ]; then
-    networkmanager_active=1
-else
-    exit 1
 fi
 
 #replace | with "@", for example, eth1|eth2  ---->   eth1@eth2


### PR DESCRIPTION
### The PR is to fix issue 
https://github.com/xcat2/xcat-core/issues/6161
### The modification include

refine configeth using nmcli

### The UT result
```
******************************
Start to run test cases
******************************
------START::confignetwork_bond_eth2_eth3::Time:Mon Mar 25 05:19:02 2019------

RUN:lsdef c910f03c09k05;if [ $? -eq 0 ]; then lsdef -l c910f03c09k05 -z >/tmp/CN.standa ;fi [Mon Mar 25 05:19:02 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Object name: c910f03c09k05
... ...
RUN:updatenode c910f03c09k05 -P confignetwork [Mon Mar 25 05:19:13 2019]
ElapsedTime:4 sec
RETURN rc = 0
OUTPUT:
c910f03c09k05: =============updatenode starting====================
c910f03c09k05: trying to download postscripts...
c910f03c09k05: postscripts downloaded successfully
c910f03c09k05: trying to get mypostscript from 10.3.9.3...
c910f03c09k05: postscript start..: confignetwork
c910f03c09k05: [I]: NetworkManager is active
c910f03c09k05: [I]: All valid nics and device list:
c910f03c09k05: [I]: enp0s2
c910f03c09k05: [I]: enp0s3
c910f03c09k05: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f03c09k05: configure nic and its device : enp0s2
c910f03c09k05: [I]: configure enp0s2
c910f03c09k05: [I]: call: configeth enp0s2 100.3.9.5 confignetworks_test1
c910f03c09k05: [I]: configeth on c910f03c09k05: os type: redhat
c910f03c09k05: configeth on c910f03c09k05: old configuration: 3: enp0s2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1496 qdisc fq_codel state UP group default qlen 1000
c910f03c09k05:     link/ether 42:de:0a:03:09:05 brd ff:ff:ff:ff:ff:ff
c910f03c09k05:     inet6 fe80::2d62:ec86:34c1:276d/64 scope link noprefixroute
c910f03c09k05:        valid_lft forever preferred_lft forever
c910f03c09k05: [I]: configeth on c910f03c09k05: new configuration
c910f03c09k05:        100.3.9.5, 100.3.0.0, 255.255.0.0,
c910f03c09k05: 3: enp0s2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1496 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
c910f03c09k05: enp0s2
c910f03c09k05: [I]: configeth on c910f03c09k05: add 100.3.9.5_16 for enp0s2 temporary.
c910f03c09k05: [I]: configeth on c910f03c09k05: enp0s2 changed, modify the configuration files
c910f03c09k05: enp0s2
c910f03c09k05: Connection 'xcat-enp0s2' (55e29992-4023-4e64-a059-de0b59ea4b1d) successfully added.
c910f03c09k05: Connection 'xcat-enp0s2-tmp' (42f0d0a1-dc99-4a6f-b209-536814db1710) successfully deleted.
c910f03c09k05: [I]: [Ethernet] >> 3: enp0s2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1496 qdisc fq_codel state UP group default qlen 1000
c910f03c09k05: [I]: [Ethernet] >>     link/ether 42:de:0a:03:09:05 brd ff:ff:ff:ff:ff:ff
c910f03c09k05: [I]: [Ethernet] >>     inet 100.3.9.5/16 brd 100.3.255.255 scope global enp0s2
c910f03c09k05: [I]: [Ethernet] >>        valid_lft forever preferred_lft forever
c910f03c09k05: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f03c09k05: configure nic and its device : enp0s3
c910f03c09k05: [I]: configure enp0s3
c910f03c09k05: [I]: call: configeth enp0s3 101.3.9.5 confignetworks_test2
c910f03c09k05: [I]: configeth on c910f03c09k05: os type: redhat
c910f03c09k05: configeth on c910f03c09k05: old configuration: 4: enp0s3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
c910f03c09k05:     link/ether 42:83:0a:03:09:05 brd ff:ff:ff:ff:ff:ff
c910f03c09k05: [I]: configeth on c910f03c09k05: new configuration
c910f03c09k05:        101.3.9.5, 101.3.0.0, 255.255.0.0,
c910f03c09k05: 4: enp0s3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
c910f03c09k05: [I]: configeth on c910f03c09k05: enp0s3 changed, modify the configuration files
c910f03c09k05: Connection 'xcat-enp0s3' (b3ed9161-90b2-4cba-93fb-d45469ea9cea) successfully added.
c910f03c09k05: bring up ip
c910f03c09k05: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/25)
c910f03c09k05: [I]: [Ethernet] >> 4: enp0s3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
c910f03c09k05: [I]: [Ethernet] >>     link/ether 42:83:0a:03:09:05 brd ff:ff:ff:ff:ff:ff
c910f03c09k05: [I]: [Ethernet] >>     inet 101.3.9.5/16 brd 101.3.255.255 scope global noprefixroute enp0s3
c910f03c09k05: [I]: [Ethernet] >>        valid_lft forever preferred_lft forever
c910f03c09k05: [I]: [Ethernet] >>     inet6 fe80::9050:64a6:787e:a3c5/64 scope link tentative noprefixroute
c910f03c09k05: [I]: [Ethernet] >>        valid_lft forever preferred_lft forever
c910f03c09k05: postscript end....: confignetwork exited with code 0
c910f03c09k05: Running of postscripts has completed.
c910f03c09k05: =============updatenode ending====================
CHECK:rc == 0   [Pass]

RUN:chdef c910f03c09k05 nicips.enp0s2= nictypes.enp0s2= nicnetworks.enp0s2= nicips.enp0s3= nictypes.enp0s3= nicnetworks.enp0s3= [Mon Mar 25 05:19:17 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0   [Pass]

RUN:cnip=__GETNODEATTR(c910f03c09k05,ip)__;echo $cnip;var3=102.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test3 net=$secondnet mask=255.255.0.0 [Mon Mar 25 05:19:17 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
10.3.9.5
1 object definitions have been created or modified.
CHECK:rc == 0   [Pass]

RUN:cnip=__GETNODEATTR(c910f03c09k05,ip)__;echo $cnip;var1=102;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;bond0ip=$var1$var2;chdef c910f03c09k05 nicnetworks.bond0=confignetworks_test3 nictypes.enp0s2=ethernet nictypes.enp0s3=ethernet nictypes.bond0=bond nicips.bond0=$bond0ip nicdevices.bond0="enp0s2|enp0s3" [Mon Mar 25 05:19:18 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
10.3.9.5
1 object definitions have been created or modified.
CHECK:rc == 0   [Pass]
RUN:updatenode c910f03c09k05 -P confignetwork [Mon Mar 25 05:19:19 2019]
ElapsedTime:13 sec
RETURN rc = 0
OUTPUT:
c910f03c09k05: =============updatenode starting====================
c910f03c09k05: trying to download postscripts...
c910f03c09k05: postscripts downloaded successfully
c910f03c09k05: trying to get mypostscript from 10.3.9.3...
c910f03c09k05: postscript start..: confignetwork
c910f03c09k05: [I]: NetworkManager is active
c910f03c09k05: [I]: All valid nics and device list:
c910f03c09k05: [I]: bond0 enp0s2@enp0s3
c910f03c09k05: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f03c09k05: configure nic and its device : bond0 enp0s2@enp0s3
c910f03c09k05: [I]: create_bond_interface_nmcli bondname=bond0 slave_ports=enp0s2,enp0s3 slave_type=ethernet _ipaddr=102.3.9.5 next_nic=
c910f03c09k05: [I]: Pickup xcatnet, "confignetworks_test3", from NICNETWORKS for interface "bond0".
c910f03c09k05: [I]: create bond connection xcat-bond-bond0
c910f03c09k05: [I]: nmcli con add type bond con-name xcat-bond-bond0 ifname bond0 bond.options mode=802.3ad,miimon=100 method none ipv4.method manual ipv4.addresses 102.3.9.5/16
c910f03c09k05: Connection 'xcat-bond-bond0' (35fb5baa-1f5d-4ce1-8cde-70eafa3b8120) successfully added.
c910f03c09k05: Connection 'enp0s2' successfully deactivated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/24)
c910f03c09k05: [I]: nmcli con add type Ethernet con-name xcat-bond-slave-enp0s2 method none ifname enp0s2 master xcat-bond-bond0 autoconnect yes
c910f03c09k05: Connection 'xcat-bond-slave-enp0s2' (93568c56-58ea-4450-8c35-0d8a869e80a2) successfully added.
c910f03c09k05: [I]: nmcli con up xcat-bond-slave-enp0s2
c910f03c09k05: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/28)
c910f03c09k05: Connection 'xcat-enp0s3' successfully deactivated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/25)
c910f03c09k05: [I]: nmcli con add type Ethernet con-name xcat-bond-slave-enp0s3 method none ifname enp0s3 master xcat-bond-bond0 autoconnect yes
c910f03c09k05: Connection 'xcat-bond-slave-enp0s2' (93568c56-58ea-4450-8c35-0d8a869e80a2) successfully added.
c910f03c09k05: [I]: nmcli con up xcat-bond-slave-enp0s2
c910f03c09k05: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/28)
c910f03c09k05: Connection 'xcat-enp0s3' successfully deactivated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/25)
c910f03c09k05: [I]: nmcli con add type Ethernet con-name xcat-bond-slave-enp0s3 method none ifname enp0s3 master xcat-bond-bond0 autoconnect yes
c910f03c09k05: Connection 'xcat-bond-slave-enp0s3' (3f4bc932-e85d-4a4e-8718-27b56b46b9de) successfully added.
c910f03c09k05: [I]: nmcli con up xcat-bond-slave-enp0s3
c910f03c09k05: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/29)
c910f03c09k05: [I]: nmcli con up xcat-bond-bond0
c910f03c09k05: Connection successfully activated (master waiting for slaves) (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/30)
c910f03c09k05: [I]: State of "bond0" was "DOWN" instead of expected "UP". Wait 0 of 20 with interval 10.
c910f03c09k05: [I]: [bond] >> 5: bond0: <BROADCAST,MULTICAST,MASTER,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
c910f03c09k05: [I]: [bond] >>     link/ether 42:de:0a:03:09:05 brd ff:ff:ff:ff:ff:ff
c910f03c09k05: [I]: [bond] >>     inet 102.3.9.5/16 brd 102.3.255.255 scope global noprefixroute bond0
c910f03c09k05: [I]: [bond] >>        valid_lft forever preferred_lft forever
c910f03c09k05: [I]: [bond] >>     inet6 fe80::b86f:6d6e:3188:ae71/64 scope link noprefixroute
c910f03c09k05: [I]: [bond] >>        valid_lft forever preferred_lft forever
c910f03c09k05: postscript end....: confignetwork exited with code 0
c910f03c09k05: Running of postscripts has completed.
c910f03c09k05: =============updatenode ending====================
CHECK:rc == 0   [Pass]
... ...

------END::confignetwork_bond_eth2_eth3::Passed::Time:Mon Mar 25 05:19:44 2019 ::Duration::42 sec------
------Total: 1 , Failed: 0------
```