### PR TITLE
update genimage and confignetwork cases

### DIFF
--- a/xCAT-test/autotest/testcase/confignetwork/cases0
+++ b/xCAT-test/autotest/testcase/confignetwork/cases0
@@ -32,6 +32,8 @@ check:output=~64 bytes from $$CN
 cmd:lsdef -l $$CN | grep status
 check:rc==0
 check:output=~booted
+cmd:xdsh $$CN hostname
+check:output=~$$CN
 cmd:installnic=`xdsh $$CN ip addr |grep __GETNODEATTR($$CN,ip)__|awk -F " " '{print $NF}'`; if grep SUSE /etc/*release;then xdsh $$CN "cat /etc/sysconfig/network/ifcfg-$installnic"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "cat /etc/sysconfig/network-scripts/ifcfg-$installnic"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep __GETNODEATTR($$CN,ip)__ /etc/network/interfaces.d/*";else echo "Sorry,this is not supported os"; fi
 check:rc==0
 check:output=~__GETNODEATTR($$CN,ip)__
@@ -80,6 +82,8 @@ check:output=~64 bytes from $$CN
 cmd:lsdef -l $$CN | grep status
 check:rc==0
 check:output=~booted
+cmd:xdsh $$CN hostname
+check:output=~$$CN
 cmd:installnic=`xdsh $$CN ip addr |grep __GETNODEATTR($$CN,ip)__|awk -F " " '{print $NF}'`; if grep SUSE /etc/*release;then xdsh $$CN "cat /etc/sysconfig/network/ifcfg-$installnic"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "cat /etc/sysconfig/network-scripts/ifcfg-$installnic"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cat /etc/network/interfaces.d/*";else echo "Sorry,this is not supported os"; fi
 check:rc==0
 check:output=~__GETNODEATTR($$CN,ip)__

--- a/xCAT-test/autotest/testcase/installation/SN_diskless_setup_case
+++ b/xCAT-test/autotest/testcase/installation/SN_diskless_setup_case
@@ -80,7 +80,7 @@ cmd:genimage __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-netboot-service
 check:rc==0
 
 cmd:mount |sort > /tmp/mountoutput/file.new
-cmd:diff -y /tmp/mountoutput/file.org /tmp/mountoutput/file.new
+cmd:diff -y /tmp/mountoutput/file.org /tmp/mountoutput/file.new --ignore-matching-lines="fusectl"
 check:rc==0
 cmd:rm -rf /tmp/mountoutput
 

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat
@@ -37,7 +37,7 @@ cmd:genimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-comput
 check:rc==0
 cmd:mount |sort > /tmp/mountoutput/file.new
 cmd:cat /tmp/mountoutput/file.new
-cmd:diff /tmp/mountoutput/file.org /tmp/mountoutput/file.new
+cmd:diff /tmp/mountoutput/file.org /tmp/mountoutput/file.new --ignore-matching-lines="fusectl"
 check:rc==0
 cmd:rm -rf /tmp/mountoutput
 cmd:packimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat_postscripts_failed
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat_postscripts_failed
@@ -41,7 +41,7 @@ cmd:genimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-comput
 check:rc==0
 cmd:mount |sort > /tmp/mountoutput/file.new
 cmd:cat /tmp/mountoutput/file.new
-cmd:diff /tmp/mountoutput/file.org /tmp/mountoutput/file.new
+cmd:diff /tmp/mountoutput/file.org /tmp/mountoutput/file.new --ignore-matching-lines="fusectl"
 check:rc==0
 cmd:rm -rf /tmp/mountoutput
 cmd:packimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute


### PR DESCRIPTION
### The PR is to do task https://github.ibm.com/xcat2/task_management/issues/45
and task https://github.ibm.com/xcat2/task_management/issues/49

The UT of genimage case
```
RUN:diff /tmp/mountoutput/file.org /tmp/mountoutput/file.new --ignore-matching-lines="fusectl" [Mon Mar 25 21:46:36 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
```

The UT of confignetworks case
```
RUN:xdsh c910f03c09k08 hostname [Tue Mar 26 02:10:18 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
c910f03c09k08: c910f03c09k08
[c910f03c09k06]: c910f03c09k08: @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
c910f03c09k08: @    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
c910f03c09k08: @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
c910f03c09k08: IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!
c910f03c09k08: Someone could be eavesdropping on you right now (man-in-the-middle attack)!
c910f03c09k08: It is also possible that a host key has just been changed.
c910f03c09k08: The fingerprint for the ECDSA key sent by the remote host is
c910f03c09k08: SHA256:bPS/iPyXBqX19fMaYCKE5+T69U5l+E/WYsNFSHi19Lw.
c910f03c09k08: Please contact your system administrator.
c910f03c09k08: Add correct host key in /root/.ssh/known_hosts to get rid of this message.
c910f03c09k08: Offending ECDSA key in /root/.ssh/known_hosts:3
c910f03c09k08: Password authentication is disabled to avoid man-in-the-middle attacks.
c910f03c09k08: Keyboard-interactive authentication is disabled to avoid man-in-the-middle attacks.

CHECK:output =~ c910f03c09k08	[Pass]
```