### PR TITLE
add autoconnect-priority for xCAT nmcli con and fix RH7.6 failure

### DIFF
--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -141,7 +141,7 @@ function configipv4(){
                 tmp_con_name=$con_name"-tmp"
                 nmcli con modify $con_name connection.id $tmp_con_name
             fi
-            nmcli con add type ethernet con-name $con_name ifname ${str_if_name} ipv4.method manual  ipv4.addresses  ${str_v4ip}/${str_prefix}
+            nmcli con add type ethernet con-name $con_name ifname ${str_if_name} ipv4.method manual  ipv4.addresses  ${str_v4ip}/${str_prefix} connection.autoconnect-priority 9
         else
             echo "DEVICE=${str_if_name}" > $str_conf_file
             echo "BOOTPROTO=none" >> $str_conf_file
@@ -636,7 +636,7 @@ elif [ "$1" = "-s" ];then
                 tmp_con_name=${str_inst_nic}"-tmp"
                 nmcli con modify $con_name connection.id $tmp_con_name
             fi
-            nmcli con add type ethernet con-name $con_name ifname ${str_inst_nic} ipv4.method manual ipv4.addresses  ${str_inst_ip}/${str_inst_prefix}
+            nmcli con add type ethernet con-name $con_name ifname ${str_inst_nic} ipv4.method manual ipv4.addresses  ${str_inst_ip}/${str_inst_prefix} connection.autoconnect-priority 9
         else
             echo "DEVICE=${str_inst_nic}" > $str_conf_file
             echo "IPADDR=${str_inst_ip}" >> $str_conf_file
@@ -1111,10 +1111,10 @@ else
                     nmcli con up $con_name
 		    wait_for_ifstate $str_nic_name UP 10 10
 		else
-                    ip link set dev $con_name up
+                    ip link set dev $str_nic_name up
 		fi
                 if [ $? -ne 0 ]; then
-                    log_error "bring $con_name up failed."
+                    log_error "bring $str_nic_name up failed."
                     error_code=1
                 fi
             fi

--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -633,6 +633,18 @@ errorcode=0
 #nictypes should support capital letters, for example, Ethernet and ethernet
 utolcmd="sed -e y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/"
 
+#check if using NetworkManager or  network service
+networkmanager_active=2
+check_NetworkManager_or_network_service
+is_active=$?
+if [ $is_active -eq 0 ]; then
+    networkmanager_active=0
+elif [ $is_active -eq 1 ]; then
+    networkmanager_active=1
+else
+    exit 1
+fi
+
 #back up all network interface configure files
 nwdirbak=$nwdir".xcatbak"
 ls $nwdirbak > /dev/null 2>/dev/null
@@ -642,17 +654,6 @@ if [ $? -ne 0 ]; then
     if [ $? -ne 0 ]; then
         log_warn "back up $nwdir to $nwdirbak failed."
     fi
-fi
-
-#check if using NetworkManager or  network service
-networkmanager_active=2
-check_NetworkManager_or_network_service
-if [ $? -eq 0 ]; then
-    networkmanager_active=0
-elif [ $? -eq 1 ]; then
-    networkmanager_active=1
-else
-    exit 1
 fi
 
 #get for installnic

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -1751,7 +1751,7 @@ function create_vlan_interface_nmcli {
         $nmcli con modify $con_name connection.id $tmp_con_name
     fi
 
-    $nmcli con add type vlan con-name $con_name dev $ifname id $(( 10#$vlanid )) $_ipaddrs $_mtu
+    $nmcli con add type vlan con-name $con_name dev $ifname id $(( 10#$vlanid )) $_ipaddrs $_mtu connection.autoconnect-priority 9
     log_info "create NetworkManager connection for $ifname.$vlanid"
     if [ -z "$next_nic" ]; then
         $nmcli con up $con_name
@@ -1888,7 +1888,7 @@ function create_bridge_interface_nmcli {
             fi
         fi
         log_info "create bridge connection $xcat_con_name"
-        cmd="$nmcli con add type bridge con-name $xcat_con_name ifname $ifname $_mtu"
+        cmd="$nmcli con add type bridge con-name $xcat_con_name ifname $ifname $_mtu connection.autoconnect-priority 9"
         log_info $cmd
         $cmd
         if [ $? -ne 0 ]; then
@@ -1924,10 +1924,10 @@ function create_bridge_interface_nmcli {
         fi
         con_use_same_dev=$(nmcli dev show $_port|grep GENERAL.CONNECTION|awk -F: '{print $2}'|sed 's/^[ \t]*//g')
         if [ "$con_use_same_dev" != "--" -a -n "$con_use_same_dev" ]; then
-            cmd="$nmcli con mod "$con_use_same_dev" master $ifname $_mtu"
+            cmd="$nmcli con mod "$con_use_same_dev" master $ifname $_mtu connection.autoconnect-priority 9"
             xcat_slave_con=$con_use_same_dev
         else
-            cmd="$nmcli con add type $_pretype con-name $xcat_slave_con ifname $_port master $ifname $_mtu"
+            cmd="$nmcli con add type $_pretype con-name $xcat_slave_con ifname $_port master $ifname $_mtu connection.autoconnect-priority 9"
         fi
         log_info "create $_pretype slaves connetcion $xcat_slave_con for bridge"
         log_info "$cmd"
@@ -2098,9 +2098,9 @@ function create_bond_interface_nmcli {
     log_info "create bond connection $xcat_con_name"
     cmd=""
     if [ -n "$next_nic" ]; then
-        cmd="$nmcli con add type bond con-name $xcat_con_name ifname $bondname bond.options $_bonding_opts autoconnect yes"
+        cmd="$nmcli con add type bond con-name $xcat_con_name ifname $bondname bond.options $_bonding_opts autoconnect yes connection.autoconnect-priority 9"
     else
-        cmd="$nmcli con add type bond con-name $xcat_con_name ifname $bondname bond.options $_bonding_opts method none ipv4.method manual ipv4.addresses $ipv4_addr/$str_prefix $_mtu"
+        cmd="$nmcli con add type bond con-name $xcat_con_name ifname $bondname bond.options $_bonding_opts method none ipv4.method manual ipv4.addresses $ipv4_addr/$str_prefix $_mtu connection.autoconnect-priority 9"
     fi
     log_info $cmd
     $cmd
@@ -2144,7 +2144,7 @@ function create_bond_interface_nmcli {
             $ip link set dev $ifslave down 
             wait_for_ifstate $ifslave DOWN 20 2
         fi
-        cmd="$nmcli con add type $slave_type con-name $xcat_slave_con $_mtu method none ifname $ifslave master $xcat_con_name autoconnect yes"
+        cmd="$nmcli con add type $slave_type con-name $xcat_slave_con $_mtu method none ifname $ifslave master $xcat_con_name autoconnect yes connection.autoconnect-priority 9"
         log_info $cmd
         $cmd
         if [ $? -ne 0 ]; then


### PR DESCRIPTION
### The PR is to fix issue 
https://github.com/xcat2/xcat-core/issues/6161

### The modification include
1. add "autoconnect-priority 9 " for xCAT nmcli con, keep xcat connection have high priority.
2. fix bring up nic failure in RH7.6
3. put check NetworkManager|network service before backup all configuration files. If there is no "NetworkManager" or netowork service, it is no need to backup configuration files.

### The UT result
```
RUN:updatenode byrh10 -P confignetwork [Tue Mar 26 03:05:17 2019]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
byrh10: Warning: the ECDSA host key for 'byrh10' differs from the key for the IP address '10.4.41.10'
byrh10: Offending key for IP in /root/.ssh/known_hosts:110
byrh10: Matching host key in /root/.ssh/known_hosts:121

byrh10: =============updatenode starting====================
byrh10: trying to download postscripts...
byrh10: postscripts downloaded successfully
byrh10: trying to get mypostscript from 10.4.41.1...
byrh10: postscript start..: confignetwork
byrh10: [I]: NetworkManager is active
byrh10: [I]: All valid nics and device list:
byrh10: [I]: ens4
byrh10: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh10: configure nic and its device : ens4
byrh10: [I]: configure ens4
byrh10: [I]: call: configeth ens4 11.1.0.100 11_1_0_0-255_255_0_0
byrh10: [I]: configeth on byrh10: os type: redhat
byrh10: configeth on byrh10: old configuration: 3: ens4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
byrh10:     link/ether 42:0d:0a:04:29:0a brd ff:ff:ff:ff:ff:ff
byrh10:     inet6 fe80::44c0:d694:db34:5ec4/64 scope link noprefixroute
byrh10:        valid_lft forever preferred_lft forever
byrh10: [I]: configeth on byrh10: new configuration
byrh10:        11.1.0.100, 11.1.0.0, 255.255.0.0,
byrh10: 3: ens4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
byrh10: ens4
byrh10: [I]: configeth on byrh10: add 11.1.0.100_16 for ens4 temporary.
byrh10: [I]: configeth on byrh10: ens4 changed, modify the configuration files
byrh10: ens4
byrh10: Warning: There are 2 other connections with the name 'xcat-ens4'. Reference the connection by its uuid '6b6ef646-891f-436e-8148-e1682229b1e1'
byrh10: Connection 'xcat-ens4' (6b6ef646-891f-436e-8148-e1682229b1e1) successfully added.
byrh10: Connection 'xcat-ens4-tmp' (6c9fb71e-b5a9-42f7-8379-fb24f3f8a567) successfully deleted.
byrh10: [I]: [Ethernet] >> 3: ens4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
byrh10: [I]: [Ethernet] >>     link/ether 42:0d:0a:04:29:0a brd ff:ff:ff:ff:ff:ff
byrh10: [I]: [Ethernet] >>     inet 11.1.0.100/16 brd 11.1.255.255 scope global ens4
byrh10: [I]: [Ethernet] >>        valid_lft forever preferred_lft forever
byrh10: postscript end....: confignetwork exited with code 0
byrh10: Running of postscripts has completed.
byrh10: =============updatenode ending====================
CHECK:rc == 0	[Pass]
... ...
RUN:updatenode byrh10 -P confignetwork [Tue Mar 26 03:05:24 2019]
ElapsedTime:4 sec
RETURN rc = 0
OUTPUT:
byrh10: Warning: the ECDSA host key for 'byrh10' differs from the key for the IP address '10.4.41.10'
byrh10: Offending key for IP in /root/.ssh/known_hosts:110
byrh10: Matching host key in /root/.ssh/known_hosts:121

byrh10: =============updatenode starting====================
byrh10: trying to download postscripts...
byrh10: postscripts downloaded successfully
byrh10: trying to get mypostscript from 10.4.41.1...
byrh10: postscript start..: confignetwork
byrh10: [I]: NetworkManager is active
byrh10: [I]: All valid nics and device list:
byrh10: [I]: ens4.6 ens4
byrh10: [I]: ens4.7 ens4
byrh10: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh10: configure nic and its device : ens4.6 ens4
byrh10: [I]: create_vlan_interface_nmcli ifname=ens4 vlanid=6 ipaddrs=60.5.106.9 next_nic=
byrh10: [I]: Pickup xcatnet, "60_0_0_0-255_0_0_0", from NICNETWORKS for interface "ens4".
byrh10: [I]: check parent interface ens4 whether it is managed by NetworkManager
byrh10: Connection 'xcat-vlan-ens4.6' (25b7c720-7034-4fc8-bc75-37ce02070231) successfully added.
byrh10: [I]: create NetworkManager connection for ens4.6
byrh10: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/1034)
byrh10: Connection 'xcat-vlan-ens4.6-tmp' (94de18c6-c6fb-43a3-a61c-9a66ae8b4820) successfully deleted.
byrh10: [I]: [vlan] >> 19: ens4.6@ens4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
byrh10: [I]: [vlan] >>     link/ether 42:0d:0a:04:29:0a brd ff:ff:ff:ff:ff:ff
byrh10: [I]: [vlan] >>     inet 60.5.106.9/8 brd 60.255.255.255 scope global noprefixroute ens4.6
byrh10: [I]: [vlan] >>        valid_lft forever preferred_lft forever
byrh10: [I]: [vlan] >>     inet6 fe80::83b6:4e19:a528:21a7/64 scope link tentative noprefixroute
byrh10: [I]: [vlan] >>        valid_lft forever preferred_lft forever
byrh10: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh10: configure nic and its device : ens4.7 ens4
byrh10: [I]: create_vlan_interface_nmcli ifname=ens4 vlanid=7 ipaddrs=70.5.106.9 next_nic=
byrh10: [I]: Pickup xcatnet, "70_0_0_0-255_0_0_0", from NICNETWORKS for interface "ens4".
byrh10: [I]: check parent interface ens4 whether it is managed by NetworkManager
byrh10: Connection 'xcat-vlan-ens4.7' (19d5a6dc-c09a-42cb-987d-c730e1c7e824) successfully added.
byrh10: [I]: create NetworkManager connection for ens4.7
byrh10: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/1035)
byrh10: Connection 'xcat-vlan-ens4.7-tmp' (822f101b-3944-4ab9-bed9-585786559d74) successfully deleted.
byrh10: [I]: [vlan] >> 20: ens4.7@ens4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
byrh10: [I]: [vlan] >>     link/ether 42:0d:0a:04:29:0a brd ff:ff:ff:ff:ff:ff
byrh10: [I]: [vlan] >>     inet 70.5.106.9/8 brd 70.255.255.255 scope global noprefixroute ens4.7
byrh10: [I]: [vlan] >>        valid_lft forever preferred_lft forever
byrh10: [I]: [vlan] >>     inet6 fe80::e2b8:62b0:4c3:ffb2/64 scope link tentative noprefixroute
byrh10: [I]: [vlan] >>        valid_lft forever preferred_lft forever
byrh10: postscript end....: confignetwork exited with code 0
byrh10: Running of postscripts has completed.
byrh10: =============updatenode ending====================
```
