### PR TITLE
update makeconservercf cases

### DIFF
--- a/xCAT-test/autotest/testcase/makeconservercf/cases0
+++ b/xCAT-test/autotest/testcase/makeconservercf/cases0
@@ -1,36 +1,36 @@
 start:makeconservercf_null
 label:others,ci_test
 cmd:chdef -t node -o testnodetmp cons=hmc groups=all
-cmd:makeconservercf testnodetmp
+cmd:service goconserver stop
+cmd:output=$(makeconservercf);if [[ "__GETNODEATTR($$CN,os)__" =~ "rhels8" ]];then if echo $output |grep "Failed to get conserver version" 2>/dev/null;then exit 0;fi;else if echo $output |grep "makeconservercf is deprecrated as well as conserver" 2>/dev/null;then exit 0;fi;fi
 check:rc==0
-cmd:cat /etc/conserver.cf
-check:output=~console testnodetmp \{
-check:output=~  /opt/xcat/share/xcat/cons/hmc testnodetmp;
-check:output=~\}
 cmd:rmdef -t node testnodetmp
+cmd:service goconserver start
 end
 
 start:makeconservercf_noderange
 label:others,ci_test
 cmd:chdef -t node -o testnodetmp cons=hmc groups=all
-cmd:makeconservercf testnodetmp
+cmd:service goconserver stop
+cmd:output=$(makeconservercf);if [[ "__GETNODEATTR($$CN,os)__" =~ "rhels8" ]];then if echo $output |grep "Failed to get conserver version" 2>/dev/null;then exit 0;fi;else if echo $output |grep "makeconservercf is deprecrated as well as conserver" 2>/dev/null;then exit 0;fi;fi
 check:rc==0
-cmd:cat /etc/conserver.cf
-check:output=~console testnodetmp \{
-check:output=~  /opt/xcat/share/xcat/cons/hmc testnodetmp;
-check:output=~\}
+cmd:if [[ "__GETNODEATTR($$CN,os)__" != "rhels8" ]]; then if grep "console testnodetmp {
+/opt/xcat/share/xcat/cons/hmc testnodetmp;
+}" /etc/conserver.cf;then exit 0;fi;fi
+check:rc==0
 cmd:rmdef -t node testnodetmp
+cmd:service goconserver start
 end
 
 start:makeconservercf_d
 label:others,ci_test
 cmd:chdef -t node -o testnodetmp cons=hmc groups=all
-cmd:makeconservercf testnodetmp
+cmd:service goconserver stop
+cmd:output=$(makeconservercf);if [[ "__GETNODEATTR($$CN,os)__" =~ "rhels8" ]];then if echo $output |grep "Failed to get conserver version" 2>/dev/null;then exit 0;fi;else if echo $output |grep "makeconservercf is deprecrated as well as conserver" 2>/dev/null;then exit 0;fi;fi
 check:rc==0
-cmd:makeconservercf -d testnodetmp
+cmd:if [[ "__GETNODEATTR($$CN,os)__" != "rhels8" ]];then makeconservercf -d testnodetmp;fi; if cat /etc/conserver.cf | grep testnodetmp;then exit 1;else exit 0;fi
 check:rc==0
-cmd:cat /etc/conserver.cf | grep testnodetmp
-check:output!~testnodetmp
 cmd:rmdef -t node testnodetmp
+cmd:service goconserver start
 end
 


### PR DESCRIPTION
### The PR is to do task https://github.ibm.com/xcat2/task_management/issues/42

The UT on rhels8
```
------START::makeconservercf_null::Time:Tue Mar 26 04:43:10 2019------

RUN:chdef -t node -o testnodetmp cons=hmc groups=all [Tue Mar 26 04:43:10 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.

RUN:service goconserver stop [Tue Mar 26 04:43:10 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Redirecting to /bin/systemctl stop goconserver.service

RUN:output=$(makeconservercf);if [[ "__GETNODEATTR(c910f03c09k05,os)__" =~ "rhels8" ]];then if echo $output |grep "Failed to get conserver version" 2>/dev/null;then exit 0;fi;else if echo $output |grep "makeconservercf is deprecrated as well as conserver" 2>/dev/null;then exit 0;fi;fi [Tue Mar 26 04:43:10 2019]
Warning: [c910f03c09k03]: makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver.
Warning: [c910f03c09k03]: Failed to execute command: systemctl enable conserver.
Error: [c910f03c09k03]: Failed to get conserver version
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:rmdef -t node testnodetmp [Tue Mar 26 04:43:11 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.

RUN:service goconserver start [Tue Mar 26 04:43:12 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Redirecting to /bin/systemctl start goconserver.service

------END::makeconservercf_null::Passed::Time:Tue Mar 26 04:43:12 2019 ::Duration::2 sec------
------START::makeconservercf_noderange::Time:Tue Mar 26 04:43:12 2019------

RUN:chdef -t node -o testnodetmp cons=hmc groups=all [Tue Mar 26 04:43:12 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
New object definitions 'testnodetmp' have been created.

RUN:service goconserver stop [Tue Mar 26 04:43:12 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Redirecting to /bin/systemctl stop goconserver.service

RUN:output=$(makeconservercf);if [[ "__GETNODEATTR(c910f03c09k05,os)__" =~ "rhels8" ]];then if echo $output |grep "Failed to get conserver version" 2>/dev/null;then exit 0;fi;else if echo $output |grep "makeconservercf is deprecrated as well as conserver" 2>/dev/null;then exit 0;fi;fi [Tue Mar 26 04:43:12 2019]
Warning: [c910f03c09k03]: makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver.
Warning: [c910f03c09k03]: Failed to execute command: systemctl enable conserver.
Error: [c910f03c09k03]: Failed to get conserver version
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN: [Tue Mar 26 04:43:13 2019]
if [[ "__GETNODEATTR(c910f03c09k05,os)__" != "rhels8" ]]; then if grep "console testnodetmp {
/opt/xcat/share/xcat/cons/hmc testnodetmp;
}" /etc/conserver.cf;then exit 0;fi;fi
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
}
}
}
console testnodetmp {
  exec /opt/xcat/share/xcat/cons/hmc testnodetmp;
}
CHECK:rc == 0	[Pass]

RUN:rmdef -t node testnodetmp [Tue Mar 26 04:43:13 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.

RUN:service goconserver start [Tue Mar 26 04:43:14 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Redirecting to /bin/systemctl start goconserver.service

------END::makeconservercf_noderange::Passed::Time:Tue Mar 26 04:43:14 2019 ::Duration::2 sec------
------START::makeconservercf_d::Time:Tue Mar 26 04:43:14 2019------

RUN:chdef -t node -o testnodetmp cons=hmc groups=all [Tue Mar 26 04:43:14 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
New object definitions 'testnodetmp' have been created.

RUN:service goconserver stop [Tue Mar 26 04:43:14 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Redirecting to /bin/systemctl stop goconserver.service

RUN:output=$(makeconservercf);if [[ "__GETNODEATTR(c910f03c09k05,os)__" =~ "rhels8" ]];then if echo $output |grep "Failed to get conserver version" 2>/dev/null;then exit 0;fi;else if echo $output |grep "makeconservercf is deprecrated as well as conserver" 2>/dev/null;then exit 0;fi;fi [Tue Mar 26 04:43:14 2019]
Warning: [c910f03c09k03]: makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver.
Warning: [c910f03c09k03]: Failed to execute command: systemctl enable conserver.
Error: [c910f03c09k03]: Failed to get conserver version
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:if [[ "__GETNODEATTR(c910f03c09k05,os)__" != "rhels8" ]];then makeconservercf -d testnodetmp;fi; if cat /etc/conserver.cf | grep testnodetmp;then exit 1;else exit 0;fi [Tue Mar 26 04:43:15 2019]
Warning: [c910f03c09k03]: makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver.
Warning: [c910f03c09k03]: Failed to execute command: systemctl enable conserver.
Error: [c910f03c09k03]: Failed to get conserver version
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:rmdef -t node testnodetmp [Tue Mar 26 04:43:16 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.

RUN:service goconserver start [Tue Mar 26 04:43:17 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Redirecting to /bin/systemctl start goconserver.service

------END::makeconservercf_d::Passed::Time:Tue Mar 26 04:43:17 2019 ::Duration::3 sec------
------Total: 3 , Failed: 0------
```

The UT on rhels7.6
```
------START::makeconservercf_null::Time:Tue Mar 26 04:24:17 2019------

RUN:chdef -t node -o testnodetmp cons=hmc groups=all [Tue Mar 26 04:24:17 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
New object definitions 'testnodetmp' have been created.

RUN:service goconserver stop [Tue Mar 26 04:24:18 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Redirecting to /bin/systemctl stop goconserver.service

RUN:output=$(makeconservercf);if [[ "__GETNODEATTR(c910f03c09k08,os)__" =~ "rhels8" ]];then if echo $output |grep "Failed to get conserver version" 2>/dev/null;then exit 0;fi;else if echo $output |grep "makeconservercf is deprecrated as well as conserver" 2>/dev/null;then exit 0;fi;fi [Tue Mar 26 04:24:18 2019]
Warning: [c910f03c09k06]: makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver.
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:rmdef -t node testnodetmp [Tue Mar 26 04:24:19 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.

RUN:service goconserver start [Tue Mar 26 04:24:20 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Redirecting to /bin/systemctl start goconserver.service

------END::makeconservercf_null::Passed::Time:Tue Mar 26 04:24:20 2019 ::Duration::3 sec------
------START::makeconservercf_noderange::Time:Tue Mar 26 04:24:20 2019------

RUN:chdef -t node -o testnodetmp cons=hmc groups=all [Tue Mar 26 04:24:20 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
New object definitions 'testnodetmp' have been created.

RUN:service goconserver stop [Tue Mar 26 04:24:20 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Redirecting to /bin/systemctl stop goconserver.service

RUN:output=$(makeconservercf);if [[ "__GETNODEATTR(c910f03c09k08,os)__" =~ "rhels8" ]];then if echo $output |grep "Failed to get conserver version" 2>/dev/null;then exit 0;fi;else if echo $output |grep "makeconservercf is deprecrated as well as conserver" 2>/dev/null;then exit 0;fi;fi [Tue Mar 26 04:24:20 2019]
Warning: [c910f03c09k06]: makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver.
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN: [Tue Mar 26 04:24:22 2019]
if [[ "__GETNODEATTR(c910f03c09k08,os)__" != "rhels8" ]]; then if grep "console testnodetmp {
/opt/xcat/share/xcat/cons/hmc testnodetmp;
}" /etc/conserver.cf;then exit 0;fi;fi
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
}
}
}
default cyclades { type host; portbase 7000; portinc 1; }
default mrv { type host; portbase 2000; portinc 100; }
#default full	{ rw *; }
#default cisco	{ type host; portbase 2000; portinc 1; }
#default xyplex	{ type host; portbase 2000; portinc 100; }
#default iolan	{ type host; portbase 10000; portinc 1; }
#break 4 { string "+\d+\d+"; delay 300; }
#break 5 { string "\033c"; }
#}
#}
#console web1.conserver.com { include ts1.conserver.com; port 2; rw !bryan; }
#console ns1.conserver.com { include ts1.conserver.com; port 10; }
#console ns2.conserver.com { include ts1.conserver.com; port 8; }
#default ts2.conserver.com { include cisco; host ts2.conserver.com; }
#console ldap1.conserver.com { include ts2.conserver.com; port 7; }
#}
#}
#}
#}
#}
#console modem1.conserver.com { include cyclades; port 2; break 4; }
#console modem2.conserver.com { include cyclades; port 6; rw !todd; }
#}
}
}
}
CHECK:rc == 0	[Pass]

RUN:rmdef -t node testnodetmp [Tue Mar 26 04:24:22 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.

RUN:service goconserver start [Tue Mar 26 04:24:23 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Redirecting to /bin/systemctl start goconserver.service

------END::makeconservercf_noderange::Passed::Time:Tue Mar 26 04:24:23 2019 ::Duration::3 sec------
------START::makeconservercf_d::Time:Tue Mar 26 04:24:23 2019------

RUN:chdef -t node -o testnodetmp cons=hmc groups=all [Tue Mar 26 04:24:23 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
New object definitions 'testnodetmp' have been created.

RUN:service goconserver stop [Tue Mar 26 04:24:23 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Redirecting to /bin/systemctl stop goconserver.service

RUN:output=$(makeconservercf);if [[ "__GETNODEATTR(c910f03c09k08,os)__" =~ "rhels8" ]];then if echo $output |grep "Failed to get conserver version" 2>/dev/null;then exit 0;fi;else if echo $output |grep "makeconservercf is deprecrated as well as conserver" 2>/dev/null;then exit 0;fi;fi [Tue Mar 26 04:24:23 2019]
Warning: [c910f03c09k06]: makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver.
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:if [[ "__GETNODEATTR(c910f03c09k08,os)__" != "rhels8" ]];then makeconservercf -d testnodetmp;fi; if cat /etc/conserver.cf | grep testnodetmp;then exit 1;else exit 0;fi [Tue Mar 26 04:24:24 2019]
Warning: [c910f03c09k06]: makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver.
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:rmdef -t node testnodetmp [Tue Mar 26 04:24:26 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.

RUN:service goconserver start [Tue Mar 26 04:24:26 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Redirecting to /bin/systemctl start goconserver.service

------END::makeconservercf_d::Passed::Time:Tue Mar 26 04:24:26 2019 ::Duration::3 sec------
------Total: 3 , Failed: 0------
```
