### PR TITLE
update nfs service setup in statelte installation test cases

### DIFF
--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_flat
@@ -38,7 +38,7 @@ cmd:cat /etc/exports|grep nodedata; if [ "$?" -ne "0" ]; then echo "/nodedata *(
 check:rc==0
 cmd:cd /etc; export exports;cd -
 check:rc==0
-cmd:if cat /etc/*release |grep SUSE >/dev/null;then service nfsserver restart; elif cat /etc/*release |grep "Red Hat" >/dev/null;then service nfs restart; fi
+cmd:if cat /etc/*release |grep SUSE >/dev/null;then service nfsserver restart; elif cat /etc/*release |grep "Red Hat" >/dev/null;then if [ -f /usr/lib/systemd/system/nfs-server.service ]; then service nfs-server restart; else service nfs restart;fi; fi
 check:rc==0
 cmd:chtab node=$$CN statelite.statemnt="$$MN:/nodedata"
 check:rc==0

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_nfs
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_nfs
@@ -41,7 +41,7 @@ cmd:xdsh $$SN 'cat /etc/exports|grep nodedata; if [ "$?" -ne "0" ]; then echo "/
 check:rc==0
 cmd:xdsh $$SN 'cd /etc; export exports;cd -'
 check:rc==0
-cmd:if cat /etc/*release |grep SUSE >/dev/null;then xdsh $$SN 'service nfsserver restart'; elif cat /etc/*release |grep "Red Hat" >/dev/null;then xdsh $$SN 'service nfs restart'; fi
+cmd:if cat /etc/*release |grep SUSE >/dev/null;then xdsh $$SN 'service nfsserver restart'; elif cat /etc/*release |grep "Red Hat" >/dev/null;then xdsh $$SN 'if [ -f /usr/lib/systemd/system/nfs-server.service ]; then service nfs-server restart; else service nfs restart;fi'; fi
 check:rc==0
 
 cmd:xdsh $$SN 'showmount -e'

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_ramdisk
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_ramdisk
@@ -41,7 +41,7 @@ cmd:xdsh $$SN 'cat /etc/exports|grep nodedata; if [ "$?" -ne "0" ]; then echo "/
 check:rc==0
 cmd:xdsh $$SN 'cd /etc; export exports;cd -'
 check:rc==0
-cmd:if cat /etc/*release |grep SUSE >/dev/null;then xdsh $$SN 'service nfsserver restart'; elif cat /etc/*release |grep "Red Hat" >/dev/null;then xdsh $$SN 'service nfs restart'; fi
+cmd:if cat /etc/*release |grep SUSE >/dev/null;then xdsh $$SN 'service nfsserver restart'; elif cat /etc/*release |grep "Red Hat" >/dev/null;then xdsh $$SN 'if [ -f /usr/lib/systemd/system/nfs-server.service ]; then service nfs-server restart; else service nfs restart;fi'; fi
 check:rc==0
 
 cmd:chtab node=$$CN statelite.statemnt="$$SN:/nodedata"


### PR DESCRIPTION
### The PR is to fix issue https://github.com/xcat2/xcat-core/issues/6169

### The modification include

* update nfs service setup in statelte installation test cases

### The UT result
```

RUN:if cat /etc/*release |grep SUSE >/dev/null;then service nfsserver restart; elif cat /etc/*release |grep "Red Hat" >/dev/null;then if [ -f /usr/lib/systemd/system/nfs-server.service ]; then service nfs-server restart; else service nfs start;fi; fi [Tue Mar 26 10:01:27 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Redirecting to /bin/systemctl restart nfs-server.service
CHECK:rc == 0	[Pass]
```