### PR TITLE
add wicked check in confignetwork for sles

### DIFF
--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -695,7 +695,7 @@ elif [ "$1" = "-s" ];then
             nmcli con up $con_name
 	    wait_for_ifstate $str_inst_nic UP 10 5
 	else
-            ip link set dev $str_inst_nic up
+            ifup $str_inst_nic
         fi
     fi
     if [ $? -ne 0 ]; then
@@ -1111,7 +1111,7 @@ else
                     nmcli con up $con_name
 		    wait_for_ifstate $str_nic_name UP 10 10
 		else
-                    ip link set dev $str_nic_name up
+                    ifup $str_nic_name
 		fi
                 if [ $? -ne 0 ]; then
                     log_error "bring $str_nic_name up failed."

--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -633,6 +633,27 @@ errorcode=0
 #nictypes should support capital letters, for example, Ethernet and ethernet
 utolcmd="sed -e y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/"
 
+#get for installnic
+installnic=''
+installnic=`get_installnic`
+instnic_conf=0
+if [ $boot_install_nic -eq 1 ];then
+    if [ -n "$installnic" ]; then
+        echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+        log_info "configure the install nic $installnic. "
+        instnic_conf=1
+        configeth -s $installnic
+        if [ $? -ne 0 ]; then
+            errorcode=1
+        fi
+        get_nic_cfg_file_content $installnic
+        echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+    else
+        log_error "Can not determine proper install nic."
+        errorcode=1
+    fi
+fi
+
 #check if using NetworkManager or  network service
 networkmanager_active=2
 check_NetworkManager_or_network_service
@@ -653,27 +674,6 @@ if [ $? -ne 0 ]; then
     cp -rf $nwdir $nwdirbak > /dev/null 2>/dev/null
     if [ $? -ne 0 ]; then
         log_warn "back up $nwdir to $nwdirbak failed."
-    fi
-fi
-
-#get for installnic
-installnic=''
-installnic=`get_installnic`
-instnic_conf=0
-if [ $boot_install_nic -eq 1 ];then
-    if [ -n "$installnic" ]; then
-        echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
-        log_info "configure the install nic $installnic. "
-        instnic_conf=1
-        configeth -s $installnic
-        if [ $? -ne 0 ]; then
-            errorcode=1
-        fi
-        get_nic_cfg_file_content $installnic
-        echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
-    else
-        log_error "Can not determine proper install nic."
-        errorcode=1
     fi
 fi
 

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -1602,7 +1602,7 @@ function check_NetworkManager_or_network_service() {
             return 1
         fi
     fi
-    checkservicestatus network > /dev/null 2>/dev/null
+    checkservicestatus network > /dev/null 2>/dev/null || checkservicestatus wicked > /dev/null 2>/dev/null
     if [ $? -eq 0 ]; then
         stopservice NetworkManager | log_lines info
         disableservice NetworkManager | log_lines info


### PR DESCRIPTION
### The PR is to fix issue 
https://github.com/xcat2/xcat-core/issues/6174
https://github.com/xcat2/xcat-core/issues/6175
### The modification include

add wicked check in confignetwork for sles

### The UT result
1. sles12.3
```
]# updatenode bysle01 "confignetwork -s"
bysle01: =============updatenode starting====================
bysle01: trying to download postscripts...
bysle01: postscripts downloaded successfully
bysle01: trying to get mypostscript from 10.4.41.1...
bysle01: postscript start..: confignetwork
bysle01: [I]: network service is active
bysle01: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bysle01: [I]: configure the install nic eth0.
bysle01: [I]: configeth on bysle01: os type: sles
bysle01: str_inst_gateway is 10.0.0.103
bysle01: default 10.0.0.103 - -
bysle01: ['/etc/sysconfig/network/ifcfg-eth0']
bysle01: [I]: >> DEVICE=eth0
bysle01: [I]: >> BOOTPROTO=static
bysle01: [I]: >> IPADDR=10.4.41.100
bysle01: [I]: >> NETMASK=255.0.0.0
bysle01: [I]: >> HWADDR=42:2d:0a:04:0a:01
bysle01: [I]: >> STARTMODE=onboot
bysle01: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
bysle01: [I]: There is no other nic device to configure.
bysle01: postscript end....: confignetwork exited with code 0
bysle01: Running of postscripts has completed.
bysle01: =============updatenode ending====================
```
2. RH7.6
```
]# updatenode byrh07 "confignetwork -s"
byrh07: =============updatenode starting====================
byrh07: trying to download postscripts...
byrh07: postscripts downloaded successfully
byrh07: trying to get mypostscript from 10.4.41.1...
byrh07: postscript start..: confignetwork
byrh07: [I]: network service is active
byrh07: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh07: [I]: configure the install nic eth0.
byrh07: [I]: configeth on byrh07: os type: redhat
byrh07: ls: cannot access /var/lib/dhclient/*eth0*: No such file or directory
byrh07: GATEWAY=10.0.0.103
byrh07: HOSTNAME=byrh07
byrh07: ['/etc/sysconfig/network-scripts/ifcfg-eth0']
byrh07: [I]: >> DEVICE=eth0
byrh07: [I]: >> IPADDR=10.4.41.7
byrh07: [I]: >> NETMASK=255.0.0.0
byrh07: [I]: >> BOOTPROTO=none
byrh07: [I]: >> ONBOOT=yes
byrh07: [I]: >> HWADDR=42:66:0a:04:29:07
byrh07: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh07: [I]: There is no other nic device to configure.
byrh07: postscript end....: confignetwork exited with code 0
byrh07: Running of postscripts has completed.
byrh07: =============updatenode ending====================
```
3. RH8
```
]# updatenode byrh10 "confignetwork -s"
byrh10: Warning: the ECDSA host key for 'byrh10' differs from the key for the IP address '10.4.41.10'
byrh10: Offending key for IP in /root/.ssh/known_hosts:109
byrh10: Matching host key in /root/.ssh/known_hosts:120

byrh10: =============updatenode starting====================
byrh10: trying to download postscripts...
byrh10: postscripts downloaded successfully
byrh10: trying to get mypostscript from 10.4.41.1...
byrh10: postscript start..: confignetwork
byrh10: [I]: NetworkManager is active
byrh10: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh10: [I]: configure the install nic ens3.
byrh10: [I]: configeth on byrh10: os type: redhat
byrh10: ls: cannot access '/var/lib/dhclient/*ens3*': No such file or directory
byrh10: Warning: There are 3 other connections with the name 'xcat-install-ens3'. Reference the connection by its uuid '1d9f817a-8bac-4248-8bd8-82bbedd57b5f'
byrh10: Connection 'xcat-install-ens3' (1d9f817a-8bac-4248-8bd8-82bbedd57b5f) successfully added.
byrh10: GATEWAY=10.0.0.103
byrh10: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/1087)
byrh10: Connection 'ens3-tmp' (5f1400bd-51fd-4928-ae35-9d14072a1786) successfully deleted.
byrh10: [I]: [Ethernet] >> 2: ens3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
byrh10: [I]: [Ethernet] >>     link/ether 42:56:0a:04:29:0a brd ff:ff:ff:ff:ff:ff
byrh10: [I]: [Ethernet] >>     inet 10.4.41.10/8 brd 10.255.255.255 scope global noprefixroute ens3
byrh10: [I]: [Ethernet] >>        valid_lft forever preferred_lft forever
byrh10: [I]: [Ethernet] >>     inet6 fe80::8a39:f21:905e:ed44/64 scope link tentative noprefixroute
byrh10: [I]: [Ethernet] >>        valid_lft forever preferred_lft forever
byrh10: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh10: [I]: There is no other nic device to configure.
byrh10: postscript end....: confignetwork exited with code 0
byrh10: Running of postscripts has completed.
byrh10: =============updatenode ending====================
```
4. ubuntu
```
]# updatenode byubu01 "confignetwork -s"
byubu01: Warning: the ECDSA host key for 'byubu01' differs from the key for the IP address '10.4.41.200'
byubu01: Offending key for IP in /root/.ssh/known_hosts:74
byubu01: Matching host key in /root/.ssh/known_hosts:113

byubu01: =============updatenode starting====================
byubu01: trying to download postscripts...
byubu01: postscripts downloaded successfully
byubu01: trying to get mypostscript from 10.4.41.1...
byubu01: postscript start..: confignetwork
byubu01: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byubu01: [I]: configure the install nic ens3.
byubu01: #XCAT_CONFIG
byubu01: [I]: configeth on byubu01: os type: debian
byubu01: ['/etc/network/interfaces.d/ens3']
byubu01: [I]: >> auto ens3
byubu01: [I]: >> iface ens3 inet static
byubu01: [I]: >>   address 10.4.41.200
byubu01: [I]: >>   netmask 255.0.0.0
byubu01: [I]: >>   hwaddress ether 42:cd:0a:04:14:01
byubu01: [I]: >>   gateway 10.0.0.103
byubu01: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byubu01: [I]: systemctl stop NetworkManager
byubu01: Removed /etc/systemd/system/dbus-org.freedesktop.nm-dispatcher.service.
byubu01: Removed /etc/systemd/system/multi-user.target.wants/NetworkManager.service.
... ...
byubu01: [I]: networking service is active
byubu01: [I]: There is no other nic device to configure.
byubu01: postscript end....: confignetwork exited with code 0
byubu01: Running of postscripts has completed.
byubu01: =============updatenode ending====================
```
