### PR TITLE
handle the case when conserver is not available

### DIFF
--- a/xCAT-server/lib/xcat/plugins/conserver.pm
+++ b/xCAT-server/lib/xcat/plugins/conserver.pm
@@ -212,10 +212,16 @@ sub process_request {
             } else {
                 my $rsp->{data}->[0] = "makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver.";
                 xCAT::MsgUtils->message("W", $rsp, $cb);
+                xCAT::Goconserver::switch_conserver($cb) if (-x "/usr/sbin/conserver");
             }
-            xCAT::Goconserver::switch_conserver($cb);
         }
-        makeconservercf($req, $cb);
+        if (-x "/usr/sbin/conserver") {
+            makeconservercf($req, $cb);
+        } else {
+            my $rsp->{data}->[0] = "conserver is not supported or not installed.";
+            xCAT::MsgUtils->message("E", $rsp, $cb);
+            return;
+        }
     }
 }
 


### PR DESCRIPTION
### The PR is to fix issue #6177

### The modification include
when conserver is not available, makeconserver could give the reasonable message. 


### The UT result
```
makeconservercf c910f04x27v10
Error: [c910f04x27v22]: goconserver is being used as the console service, did you mean: makegocons <noderange>? If not, stop goconserver and retry.
# systemctl stop goconserver
# makeconservercf c910f04x27v10
Warning: [c910f04x27v22]: makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver.
Error: [c910f04x27v22]: conserver is not supported or not installed.

# which conserver
/usr/bin/which: no conserver in (/opt/xcat/bin:/opt/xcat/sbin:/opt/xcat/share/xcat/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin)
```

In a conserver installed environment
```
# mv /usr/sbin/conserver.bak /usr/sbin/conserver
# makeconservercf c910f04x27v10
Warning: [c910f04x27v22]: makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver.

grep c910f04x27v10 /etc/conserver.cf
#xCAT BEGIN c910f04x27v10 CONS
console c910f04x27v10 {
  exec /opt/xcat/share/xcat/cons/kvm c910f04x27v10;
#xCAT END c910f04x27v10 CONS
```
