### PR TITLE
update makeconservercf cases

### DIFF
--- a/xCAT-test/autotest/testcase/makeconservercf/cases0
+++ b/xCAT-test/autotest/testcase/makeconservercf/cases0
@@ -1,33 +1,117 @@
 start:makeconservercf_null
 label:others,ci_test
 cmd:chdef -t node -o testnodetmp cons=hmc groups=all
-cmd:makeconservercf testnodetmp
+cmd:service goconserver stop
+cmd:#!/bin/bash
+lsgoconser=`ls /usr/bin/goconserver`
+lsconser=`ls /usr/sbin/conserver`
+output=`makeconservercf 2>&1`
+if [[ ! "$lsgoconser" ]] && [[ ! "$lsconser" ]]; then
+    echo "No goconserver and conserver installed"
+    exit 1
+elif [[ ! "$lsconser" ]]; then
+    if echo $output | grep "conserver is not supported or not installed."; then
+        exit 0
+    else
+        exit 1
+    fi
+else
+    if [[ "$lsgoconser" ]]; then
+        msg=`echo $output | grep "makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver."`
+        if [ ! "$msg" ]; then
+            exit 1
+        fi
+    fi
+    service conserver status
+    exit $?
+fi
 check:rc==0
-cmd:cat /etc/conserver.cf
-check:output=~console testnodetmp \{
-check:output=~  /opt/xcat/share/xcat/cons/hmc testnodetmp;
-check:output=~\}
 cmd:rmdef -t node testnodetmp
 end
 
 start:makeconservercf_noderange
 label:others,ci_test
 cmd:chdef -t node -o testnodetmp cons=hmc groups=all
-cmd:makeconservercf testnodetmp
+cmd:service goconserver stop
+cmd:#!/bin/bash
+lsgoconser=`ls /usr/bin/goconserver`
+lsconser=`ls /usr/sbin/conserver`
+output=`makeconservercf testnodetmp 2>&1`
+if [[ ! "$lsgoconser" ]] && [[ ! "$lsconser" ]]; then
+    echo "No goconserver and conserver installed"
+    exit 1
+elif [[ ! "$lsconser" ]]; then
+    if echo $output | grep "conserver is not supported or not installed."; then
+        exit 0
+    else
+        exit 1
+    fi
+else
+    if [[ "$lsgoconser" ]]; then
+        msg=`echo $output | grep "makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver."`
+        if [ ! "$msg" ]; then
+            exit 1
+        fi 
+    fi
+    service conserver status
+    if [ $? != 0 ]; then
+        exit $?
+    else
+        if grep "console testnodetmp {
+/opt/xcat/share/xcat/cons/hmc testnodetmp;
+}" /etc/conserver.cf;then
+            exit 0
+        else
+            exit 1
+        fi
+    fi
+fi
 check:rc==0
-cmd:cat /etc/conserver.cf
-check:output=~console testnodetmp \{
-check:output=~  /opt/xcat/share/xcat/cons/hmc testnodetmp;
-check:output=~\}
 cmd:rmdef -t node testnodetmp
 end
 
 start:makeconservercf_d
 label:others,ci_test
 cmd:chdef -t node -o testnodetmp cons=hmc groups=all
-cmd:makeconservercf testnodetmp
+cmd:service goconserver stop
+cmd:#!/bin/bash
+lsgoconser=`ls /usr/bin/goconserver`
+lsconser=`ls /usr/sbin/conserver`
+output=`makeconservercf testnodetmp 2>&1`
+if [[ ! "$lsgoconser" ]] && [[ ! "$lsconser" ]]; then
+    echo "No goconserver and conserver installed"
+    exit 1
+elif [[ ! "$lsconser" ]]; then
+    if echo $output | grep "conserver is not supported or not installed."; then
+        exit 0
+    else
+        exit 1
+    fi
+else
+    if [[ "$lsgoconser" ]]; then
+        msg=`echo $output | grep "makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver."`
+        if [ ! "$msg" ]; then
+            exit 1
+        fi
+    fi
+    service conserver status
+    exit $?
+fi
 check:rc==0
-cmd:makeconservercf -d testnodetmp
+cmd:#!/bin/bash
+lsconser=`ls /usr/sbin/conserver`
+if [[ ! "$lsconser" ]]; then
+    exit 0
+else
+    makeconservercf -d testnodetmp
+    if [ $? != 0 ]; then
+        exit $?
+    else
+        if cat /etc/conserver.cf | grep testnodetmp; then
+            exit 1
+        fi
+    fi
+fi
 check:rc==0
 cmd:cat /etc/conserver.cf | grep testnodetmp
 check:output!~testnodetmp


### PR DESCRIPTION
### The PR is for task _#https://github.ibm.com/xcat2/task_management/issues/42_ 

_##Feature description##_

### The content of the PR:
* [x] _##Support 3 scenario_
goconserver with no conserver
goconserver and conserver
conserver with no goconserver

### The UT result
```
------START::makeconservercf_null::Time:Wed Mar 27 03:13:58 2019------

RUN:chdef -t node -o testnodetmp cons=hmc groups=all [Wed Mar 27 03:13:58 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
New object definitions 'testnodetmp' have been created.

RUN:service goconserver stop [Wed Mar 27 03:13:59 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Redirecting to /bin/systemctl stop goconserver.service

RUN: [Wed Mar 27 03:13:59 2019]
#!/bin/bash
lsgoconser=`ls /usr/bin/goconserver`
lsconser=`ls /usr/sbin/conserver`
output=`makeconservercf 2>&1`
if [[ ! "$lsgoconser" ]] && [[ ! "$lsconser" ]]; then
    echo "No goconserver and conserver installed"
    exit 1
elif [[ ! "$lsconser" ]]; then
    if echo $output | grep "conserver is not supported or not installed."; then
        exit 0
    else
        exit 1
    fi
else
    if [[ "$lsgoconser" ]]; then
        msg=`echo $output | grep "makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver."`
        if [ ! "$msg" ]; then
            exit 1
        fi
    fi
    service conserver status
    exit $?
fi
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
ls: cannot access '/usr/sbin/conserver': No such file or directory
Warning: [c910f03c09k03]: makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver. Error: [c910f03c09k03]: conserver is not supported or not installed.
CHECK:rc == 0	[Pass]

RUN:rmdef -t node testnodetmp [Wed Mar 27 03:13:59 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.

------END::makeconservercf_null::Passed::Time:Wed Mar 27 03:13:59 2019 ::Duration::1 sec------
------START::makeconservercf_noderange::Time:Wed Mar 27 03:13:59 2019------

RUN:chdef -t node -o testnodetmp cons=hmc groups=all [Wed Mar 27 03:13:59 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
New object definitions 'testnodetmp' have been created.

RUN:service goconserver stop [Wed Mar 27 03:14:00 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Redirecting to /bin/systemctl stop goconserver.service

RUN: [Wed Mar 27 03:14:00 2019]
#!/bin/bash
lsgoconser=`ls /usr/bin/goconserver`
lsconser=`ls /usr/sbin/conserver`
output=`makeconservercf testnodetmp 2>&1`
if [[ ! "$lsgoconser" ]] && [[ ! "$lsconser" ]]; then
    echo "No goconserver and conserver installed"
    exit 1
elif [[ ! "$lsconser" ]]; then
    if echo $output | grep "conserver is not supported or not installed."; then
        exit 0
    else
        exit 1
    fi
else
    if [[ "$lsgoconser" ]]; then
        msg=`echo $output | grep "makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver."`
        if [ ! "$msg" ]; then
            exit 1
        fi
    fi
    service conserver status
    if [ $? != 0 ]; then
        exit $?
    else
        if grep "console testnodetmp {
/opt/xcat/share/xcat/cons/hmc testnodetmp;
}" /etc/conserver.cf;then
            exit 0
        else
            exit 1
        fi
    fi
fi
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
ls: cannot access '/usr/sbin/conserver': No such file or directory
Warning: [c910f03c09k03]: makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver. Error: [c910f03c09k03]: conserver is not supported or not installed.
CHECK:rc == 0	[Pass]

RUN:rmdef -t node testnodetmp [Wed Mar 27 03:14:00 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.

------END::makeconservercf_noderange::Passed::Time:Wed Mar 27 03:14:01 2019 ::Duration::2 sec------
------START::makeconservercf_d::Time:Wed Mar 27 03:14:01 2019------

RUN:chdef -t node -o testnodetmp cons=hmc groups=all [Wed Mar 27 03:14:01 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
New object definitions 'testnodetmp' have been created.

RUN:service goconserver stop [Wed Mar 27 03:14:01 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Redirecting to /bin/systemctl stop goconserver.service

RUN: [Wed Mar 27 03:14:01 2019]
#!/bin/bash
lsgoconser=`ls /usr/bin/goconserver`
lsconser=`ls /usr/sbin/conserver`
output=`makeconservercf testnodetmp 2>&1`
if [[ ! "$lsgoconser" ]] && [[ ! "$lsconser" ]]; then
    echo "No goconserver and conserver installed"
    exit 1
elif [[ ! "$lsconser" ]]; then
    if echo $output | grep "conserver is not supported or not installed."; then
        exit 0
    else
        exit 1
    fi
else
    if [[ "$lsgoconser" ]]; then
        msg=`echo $output | grep "makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver."`
        if [ ! "$msg" ]; then
            exit 1
        fi
    fi
    service conserver status
    exit $?
fi
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
ls: cannot access '/usr/sbin/conserver': No such file or directory
Warning: [c910f03c09k03]: makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver. Error: [c910f03c09k03]: conserver is not supported or not installed.
CHECK:rc == 0	[Pass]

RUN:makeconservercf -d testnodetmp [Wed Mar 27 03:14:01 2019]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Warning: [c910f03c09k03]: makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver.
Error: [c910f03c09k03]: conserver is not supported or not installed.

RUN: [Wed Mar 27 03:14:02 2019]
#!/bin/bash
lsconser=`ls /usr/sbin/conserver`
if [[ ! "$lsconser" ]]; then
    exit 0
else
    makeconservercf -d testnodetmp
    if [ $? != 0 ]; then
        exit $?
    else
        if cat /etc/conserver.cf | grep testnodetmp; then
            exit 1
        fi
    fi
fi
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
ls: cannot access '/usr/sbin/conserver': No such file or directory
CHECK:rc == 0	[Pass]

RUN:cat /etc/conserver.cf | grep testnodetmp [Wed Mar 27 03:14:02 2019]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
CHECK:output !~ testnodetmp	[Pass]

RUN:rmdef -t node testnodetmp [Wed Mar 27 03:14:02 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.

------END::makeconservercf_d::Passed::Time:Wed Mar 27 03:14:02 2019 ::Duration::1 sec------
------Total: 3 , Failed: 0------
```