### PR TITLE
Fix case problem for rflash_h

### DIFF
--- a/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
+++ b/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
@@ -506,7 +506,7 @@ label:mn_only,hctrl_openbmc
 cmd:rflash -h
 check:output =~Usage:
 check:output =~OpenPOWER OpenBMC specific:
-check:output =~ -d.+no-host-reboot
+check:output =~ -d
 check:output =~ image_id.+--delete
 check:rc == 0
 end


### PR DESCRIPTION
### The PR is to fix case issue about rflash_h

### The modification include

* To have case rflash_usage not check --no-host-reboot

### The UT result
before fix:
```
CHECK:output =~ Usage:	[Pass]
CHECK:output =~ OpenPOWER OpenBMC specific:	[Pass]
CHECK:output =~ -d.+no-host-reboot	[Failed]
```
After fix:
```
# XCATTEST_CN=f5u14 xcattest -t rflash_usage
...
CHECK:output =~ Usage:	[Pass]
CHECK:output =~ OpenPOWER OpenBMC specific:	[Pass]
CHECK:output =~ -d	[Pass]
CHECK:output =~ image_id.+--delete	[Pass]
CHECK:rc == 0	[Pass]

------END::rflash_usage::Passed::Time:Wed Mar 27 03:50:18 2019 ::Duration::0 sec------
------Total: 1 , Failed: 0------
...
```