### PR TITLE
refine getmacs test cases

### DIFF
--- a/xCAT-test/autotest/testcase/getmacs/cases0
+++ b/xCAT-test/autotest/testcase/getmacs/cases0
@@ -2,30 +2,40 @@ start:getmacs_noderange
 label:others
 cmd:tabdump mac > /tmp/mac.csv
 cmd:chtab -d node=$$CN mac
+cmd:if [ -x /usr/bin/goconserver ]; then makegocons $$CN; else makeconservercf $$CN; fi
+cmd:sleep 10
 cmd:getmacs $$CN
 check:rc==0
 check:output=~[a-f0-9A-F]{12}|[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}
 cmd:tabdump mac | grep $$CN
 check:output=~[a-f0-9A-F]{12}|[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}
 cmd:tabrestore /tmp/mac.csv
+cmd:if [ -x /usr/bin/goconserver ]; then makegocons -d $$CN; else makeconservercf -d $$CN; fi
 cmd:rm /tmp/mac.csv
 end
+
 start:getmacs_d
 label:others
 cmd:tabdump mac > /tmp/mac.csv
 cmd:chtab -d node=$$CN mac
+cmd:if [ -x /usr/bin/goconserver ]; then makegocons $$CN; else makeconservercf $$CN; fi
+cmd:sleep 10
 cmd:getmacs $$CN -d
 check:rc==0
 check:output=~[a-f0-9A-F]{12}|[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}
 cmd:tabdump mac | grep $$CN
 check:output!~[a-f0-9A-F]{12}|[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}
 cmd:tabrestore /tmp/mac.csv
+cmd:if [ -x /usr/bin/goconserver ]; then makegocons -d $$CN; else makeconservercf -d $$CN; fi
 cmd:rm /tmp/mac.csv
 end
+
 start:getmacs_f_D
 label:others
 cmd:tabdump mac > /tmp/mac.csv
 cmd:chtab -d node=$$CN mac
+cmd:if [ -x /usr/bin/goconserver ]; then makegocons $$CN; else makeconservercf $$CN; fi
+cmd:sleep 10
 cmd:getmacs $$CN -f -D
 check:rc==0
 check:output=~[a-f0-9A-F]{12}|[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}
@@ -35,4 +45,5 @@ cmd:tabrestore /tmp/mac.csv
 cmd:rm /tmp/mac.csv
 cmd:rpower $$CN on
 cmd:sleep 300
+cmd:if [ -x /usr/bin/goconserver ]; then makegocons -d $$CN; else makeconservercf -d $$CN; fi
 end


### PR DESCRIPTION
### The PR is for task https://github.ibm.com/xcat2/task_management/issues/66

### The modification include

*  The PR is to refine test cases about getmacs


### The UT result
```
------START::getmacs_f_D::Time:Wed Mar 27 04:23:15 2019------

RUN:tabdump mac > /tmp/mac.csv [Wed Mar 27 04:23:15 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:chtab -d node=c910f02c01p11 mac [Wed Mar 27 04:23:15 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:if [ -x /usr/bin/goconserver ]; then makegocons c910f02c01p11; else makeconservercf c910f02c01p11; fi [Wed Mar 27 04:23:16 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:sleep 10 [Wed Mar 27 04:23:16 2019]
ElapsedTime:10 sec
RETURN rc = 0
OUTPUT:

RUN:getmacs c910f02c01p11 -f -D [Wed Mar 27 04:23:26 2019]
ElapsedTime:229 sec
RETURN rc = 0
OUTPUT:
c910f02c01p11:
# Type 	Location Code 	MAC Address	 Full Path Name	 Ping Result	 Device Type
ent U8233.E8B.103A4EP-V11-C3-T1 e6:d4:d0:13:a4:03 /vdevice/l-lan@30000003 successful virtual
ent U8233.E8B.103A4EP-V11-C4-T1 e6:d4:d0:13:a4:04 /vdevice/l-lan@30000004 unsuccessful virtual
ent U78A0.001.DNWHYK9-P1-C6-T1 00:21:5e:a9:a3:2a /lhea@200000000000000/ethernet@20000000000000b unsuccessful physical

CHECK:rc == 0	[Pass]
CHECK:output =~ [a-f0-9A-F]{12}|[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}	[Pass]

RUN:tabdump mac | grep c910f02c01p11 [Wed Mar 27 04:27:15 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
"c910f02c01p11",,"e6:d4:d0:13:a4:03",,
CHECK:output =~ [a-f0-9A-F]{12}|[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}:[a-f0-9A-F]{2}	[Pass]

RUN:tabrestore /tmp/mac.csv [Wed Mar 27 04:27:16 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:rm /tmp/mac.csv [Wed Mar 27 04:27:16 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:rpower c910f02c01p11 on [Wed Mar 27 04:27:16 2019]
ElapsedTime:5 sec
RETURN rc = 0
OUTPUT:
c910f02c01p11: Success
```