### PR TITLE
stop conserver service in makeconservercf cases

### DIFF
--- a/xCAT-test/autotest/testcase/makeconservercf/cases0
+++ b/xCAT-test/autotest/testcase/makeconservercf/cases0
@@ -1,5 +1,5 @@
 start:makeconservercf_null
-label:others,ci_test
+label:others,conserver
 cmd:chdef -t node -o testnodetmp cons=hmc groups=all
 cmd:service goconserver stop
 cmd:#!/bin/bash
@@ -26,11 +26,12 @@ else
     exit $?
 fi
 check:rc==0
+cmd:service conserver stop
 cmd:rmdef -t node testnodetmp
 end
 
 start:makeconservercf_noderange
-label:others,ci_test
+label:others,conserver
 cmd:chdef -t node -o testnodetmp cons=hmc groups=all
 cmd:service goconserver stop
 cmd:#!/bin/bash
@@ -68,10 +69,11 @@ else
 fi
 check:rc==0
 cmd:rmdef -t node testnodetmp
+cmd:service conserver stop
 end
 
 start:makeconservercf_d
-label:others,ci_test
+label:others,conserver
 cmd:chdef -t node -o testnodetmp cons=hmc groups=all
 cmd:service goconserver stop
 cmd:#!/bin/bash
@@ -115,6 +117,7 @@ fi
 check:rc==0
 cmd:cat /etc/conserver.cf | grep testnodetmp
 check:output!~testnodetmp
+cmd:service conserver stop
 cmd:rmdef -t node testnodetmp
 end
 


### PR DESCRIPTION
### The PR is to fix issue _#influent other cases_

### The modification include

_##stop conserver cases to clear test env_

### The UT result
```
------START::makeconservercf_null::Time:Wed Mar 27 22:31:27 2019------

RUN:chdef -t node -o testnodetmp cons=hmc groups=all [Wed Mar 27 22:31:27 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
New object definitions 'testnodetmp' have been created.

RUN:service goconserver stop [Wed Mar 27 22:31:27 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Redirecting to /bin/systemctl stop goconserver.service

RUN: [Wed Mar 27 22:31:27 2019]
#!/bin/bash
lsgoconser=`ls /usr/bin/goconserver`
lsconser=`ls /usr/sbin/conserver`
output=`makeconservercf 2>&1`
if [[ ! "$lsgoconser" ]] && [[ ! "$lsconser" ]]; then
    echo "No goconserver and conserver installed"
    exit 1
elif [[ ! "$lsconser" ]]; then
    if echo $output | grep "conserver is not supported or not installed."; then
        exit 0
    else
        exit 1
    fi
else
    if [[ "$lsgoconser" ]]; then
        msg=`echo $output | grep "makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver."`
        if [ ! "$msg" ]; then
            exit 1
        fi
    fi
    service conserver status
    exit $?
fi
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
● conserver.service - LSB: conserver
   Loaded: loaded (/etc/rc.d/init.d/conserver; bad; vendor preset: disabled)
   Active: active (running) since Wed 2019-03-27 22:31:28 EDT; 107ms ago
     Docs: man:systemd-sysv-generator(8)
  Process: 23065 ExecStop=/etc/rc.d/init.d/conserver stop (code=exited, status=0/SUCCESS)
  Process: 23089 ExecStart=/etc/rc.d/init.d/conserver start (code=exited, status=0/SUCCESS)
   CGroup: /system.slice/conserver.service
           ├─23096 /usr/sbin/conserver -o -O1 -d
           └─23097 /usr/sbin/conserver -o -O1 -d

Mar 27 22:31:28 c910f04x12v02 systemd[1]: Starting LSB: conserver...
Mar 27 22:31:28 c910f04x12v02 conserver[23089]: Starting conserver: [Wed Mar 27 22:31:28 2019] conserver (23095): conserver.com version 8.2.1
Mar 27 22:31:28 c910f04x12v02 conserver[23089]: [Wed Mar 27 22:31:28 2019] conserver (23095): started as `root' by `root'
Mar 27 22:31:28 c910f04x12v02 conserver[23089]: [Wed Mar 27 22:31:28 2019] conserver (23095): daemonizing
Mar 27 22:31:28 c910f04x12v02 conserver[23089]: [17B blob data]
Mar 27 22:31:28 c910f04x12v02 systemd[1]: Started LSB: conserver.
CHECK:rc == 0	[Pass]

RUN:service conserver stop [Wed Mar 27 22:31:28 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Stopping conserver (via systemctl):  [  OK  ]

RUN:rmdef -t node testnodetmp [Wed Mar 27 22:31:29 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.

------END::makeconservercf_null::Passed::Time:Wed Mar 27 22:31:29 2019 ::Duration::2 sec------
------START::makeconservercf_noderange::Time:Wed Mar 27 22:31:29 2019------

RUN:chdef -t node -o testnodetmp cons=hmc groups=all [Wed Mar 27 22:31:29 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
New object definitions 'testnodetmp' have been created.

RUN:service goconserver stop [Wed Mar 27 22:31:30 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Redirecting to /bin/systemctl stop goconserver.service

RUN: [Wed Mar 27 22:31:30 2019]
#!/bin/bash
lsgoconser=`ls /usr/bin/goconserver`
lsconser=`ls /usr/sbin/conserver`
output=`makeconservercf testnodetmp 2>&1`
if [[ ! "$lsgoconser" ]] && [[ ! "$lsconser" ]]; then
    echo "No goconserver and conserver installed"
    exit 1
elif [[ ! "$lsconser" ]]; then
    if echo $output | grep "conserver is not supported or not installed."; then
        exit 0
    else
        exit 1
    fi
else
    if [[ "$lsgoconser" ]]; then
        msg=`echo $output | grep "makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver."`
        if [ ! "$msg" ]; then
            exit 1
        fi
    fi
    service conserver status
    if [ $? != 0 ]; then
        exit $?
    else
        if grep "console testnodetmp {
/opt/xcat/share/xcat/cons/hmc testnodetmp;
}" /etc/conserver.cf;then
            exit 0
        else
            exit 1
        fi
    fi
fi
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
● conserver.service - LSB: conserver
   Loaded: loaded (/etc/rc.d/init.d/conserver; bad; vendor preset: disabled)
   Active: active (running) since Wed 2019-03-27 22:31:30 EDT; 108ms ago
     Docs: man:systemd-sysv-generator(8)
  Process: 23254 ExecStart=/etc/rc.d/init.d/conserver start (code=exited, status=0/SUCCESS)
   CGroup: /system.slice/conserver.service
           ├─23261 /usr/sbin/conserver -o -O1 -d
           └─23262 /usr/sbin/conserver -o -O1 -d

Mar 27 22:31:30 c910f04x12v02 systemd[1]: Starting LSB: conserver...
Mar 27 22:31:30 c910f04x12v02 conserver[23254]: Starting conserver: [Wed Mar 27 22:31:30 2019] conserver (23260): conserver.com version 8.2.1
Mar 27 22:31:30 c910f04x12v02 conserver[23254]: [Wed Mar 27 22:31:30 2019] conserver (23260): started as `root' by `root'
Mar 27 22:31:30 c910f04x12v02 conserver[23254]: [Wed Mar 27 22:31:30 2019] conserver (23260): daemonizing
Mar 27 22:31:30 c910f04x12v02 conserver[23254]: [17B blob data]
Mar 27 22:31:30 c910f04x12v02 systemd[1]: Started LSB: conserver.
}
}
}
default cyclades { type host; portbase 7000; portinc 1; }
default mrv { type host; portbase 2000; portinc 100; }
#default full	{ rw *; }
#default cisco	{ type host; portbase 2000; portinc 1; }
#default xyplex	{ type host; portbase 2000; portinc 100; }
#default iolan	{ type host; portbase 10000; portinc 1; }
#break 4 { string "+\d+\d+"; delay 300; }
#break 5 { string "\033c"; }
#}
#}
#console web1.conserver.com { include ts1.conserver.com; port 2; rw !bryan; }
#console ns1.conserver.com { include ts1.conserver.com; port 10; }
#console ns2.conserver.com { include ts1.conserver.com; port 8; }
#default ts2.conserver.com { include cisco; host ts2.conserver.com; }
#console ldap1.conserver.com { include ts2.conserver.com; port 7; }
#}
#}
#}
#}
#}
#console modem1.conserver.com { include cyclades; port 2; break 4; }
#console modem2.conserver.com { include cyclades; port 6; rw !todd; }
#}
}
}
}
console testnodetmp {
  exec /opt/xcat/share/xcat/cons/hmc testnodetmp;
}
CHECK:rc == 0	[Pass]

RUN:rmdef -t node testnodetmp [Wed Mar 27 22:31:31 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.

RUN:service conserver stop [Wed Mar 27 22:31:31 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Stopping conserver (via systemctl):  [  OK  ]

------END::makeconservercf_noderange::Passed::Time:Wed Mar 27 22:31:31 2019 ::Duration::2 sec------
------START::makeconservercf_d::Time:Wed Mar 27 22:31:31 2019------

RUN:chdef -t node -o testnodetmp cons=hmc groups=all [Wed Mar 27 22:31:31 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
New object definitions 'testnodetmp' have been created.

RUN:service goconserver stop [Wed Mar 27 22:31:32 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Redirecting to /bin/systemctl stop goconserver.service

RUN: [Wed Mar 27 22:31:32 2019]
#!/bin/bash
lsgoconser=`ls /usr/bin/goconserver`
lsconser=`ls /usr/sbin/conserver`
output=`makeconservercf testnodetmp 2>&1`
if [[ ! "$lsgoconser" ]] && [[ ! "$lsconser" ]]; then
    echo "No goconserver and conserver installed"
    exit 1
elif [[ ! "$lsconser" ]]; then
    if echo $output | grep "conserver is not supported or not installed."; then
        exit 0
    else
        exit 1
    fi
else
    if [[ "$lsgoconser" ]]; then
        msg=`echo $output | grep "makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver."`
        if [ ! "$msg" ]; then
            exit 1
        fi
    fi
    service conserver status
    exit $?
fi
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
● conserver.service - LSB: conserver
   Loaded: loaded (/etc/rc.d/init.d/conserver; bad; vendor preset: disabled)
   Active: active (running) since Wed 2019-03-27 22:31:33 EDT; 114ms ago
     Docs: man:systemd-sysv-generator(8)
  Process: 23416 ExecStart=/etc/rc.d/init.d/conserver start (code=exited, status=0/SUCCESS)
   CGroup: /system.slice/conserver.service
           ├─23423 /usr/sbin/conserver -o -O1 -d
           └─23424 /usr/sbin/conserver -o -O1 -d

Mar 27 22:31:33 c910f04x12v02 systemd[1]: Starting LSB: conserver...
Mar 27 22:31:33 c910f04x12v02 conserver[23416]: Starting conserver: [Wed Mar 27 22:31:33 2019] conserver (23422): conserver.com version 8.2.1
Mar 27 22:31:33 c910f04x12v02 conserver[23416]: [Wed Mar 27 22:31:33 2019] conserver (23422): started as `root' by `root'
Mar 27 22:31:33 c910f04x12v02 conserver[23416]: [Wed Mar 27 22:31:33 2019] conserver (23422): daemonizing
Mar 27 22:31:33 c910f04x12v02 conserver[23416]: [17B blob data]
Mar 27 22:31:33 c910f04x12v02 systemd[1]: Started LSB: conserver.
CHECK:rc == 0	[Pass]

RUN: [Wed Mar 27 22:31:33 2019]
#!/bin/bash
lsconser=`ls /usr/sbin/conserver`
if [[ ! "$lsconser" ]]; then
    exit 0
else
    makeconservercf -d testnodetmp
    if [ $? != 0 ]; then
        exit $?
    else
        if cat /etc/conserver.cf | grep testnodetmp; then
            exit 1
        fi
    fi
fi
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Warning: [c910f04x12v02]: makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver.
CHECK:rc == 0	[Pass]

RUN:cat /etc/conserver.cf | grep testnodetmp [Wed Mar 27 22:31:33 2019]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
CHECK:output !~ testnodetmp	[Pass]

RUN:service conserver stop [Wed Mar 27 22:31:33 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Stopping conserver (via systemctl):  [  OK  ]

RUN:rmdef -t node testnodetmp [Wed Mar 27 22:31:34 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.

------END::makeconservercf_d::Passed::Time:Wed Mar 27 22:31:34 2019 ::Duration::3 sec------
------Total: 3 , Failed: 0------
```