### PR TITLE
add wait ifstate since power NIC ifup is slower in test env

### DIFF
--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -693,10 +693,10 @@ elif [ "$1" = "-s" ];then
         fi
 	if [ $networkmanager_active -eq 1 ]; then
             nmcli con up $con_name
-	    wait_for_ifstate $str_inst_nic UP 10 5
 	else
             ifup $str_inst_nic
         fi
+        wait_for_ifstate $str_inst_nic UP 20 5
     fi
     if [ $? -ne 0 ]; then
         log_error "bring $str_inst_nic up failed."
@@ -1109,10 +1109,10 @@ else
                 echo "bring up ip"
 		if [ $networkmanager_active -eq 1 ]; then
                     nmcli con up $con_name
-		    wait_for_ifstate $str_nic_name UP 10 10
 		else
                     ifup $str_nic_name
 		fi
+                wait_for_ifstate $str_nic_name UP 20 5
                 if [ $? -ne 0 ]; then
                     log_error "bring $str_nic_name up failed."
                     error_code=1


### PR DESCRIPTION
### The PR is to fix issue 
https://github.com/xcat2/xcat-core/issues/6174

### The modification include

add wait ifstate since power NIC ifup is slower in test env

### The UT result
```
c910f03c11k11: =============updatenode starting====================
c910f03c11k11: trying to download postscripts...
c910f03c11k11: postscripts downloaded successfully
c910f03c11k11: trying to get mypostscript from 10.3.11.9...
c910f03c11k11: postscript start..: confignetwork
c910f03c11k11: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f03c11k11: [I]: configure the install nic eth2.
c910f03c11k11: [I]: configeth on c910f03c11k11: os type: sles
c910f03c11k11: str_inst_gateway is 10.0.0.101
c910f03c11k11: default 10.0.0.101 - -
c910f03c11k11: eth2            up
c910f03c11k11: ['/etc/sysconfig/network/ifcfg-eth2']
c910f03c11k11: [I]: >> DEVICE=eth2
c910f03c11k11: [I]: >> BOOTPROTO=static
c910f03c11k11: [I]: >> IPADDR=10.3.11.11
c910f03c11k11: [I]: >> NETMASK=255.0.0.0
c910f03c11k11: [I]: >> HWADDR=42:52:0a:03:0b:0b
c910f03c11k11: [I]: >> MTU=1500
c910f03c11k11: [I]: >> STARTMODE=onboot
c910f03c11k11: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f03c11k11: [I]: network service is active
c910f03c11k11: [I]: All valid nics and device list:
c910f03c11k11: [I]: eth1
c910f03c11k11: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f03c11k11: configure nic and its device : eth1
c910f03c11k11: [I]: configure eth1
c910f03c11k11: [I]: call: configeth eth1 100.3.11.11 confignetworks_test1
c910f03c11k11: [I]: configeth on c910f03c11k11: os type: sles
c910f03c11k11: configeth on c910f03c11k11: old configuration: 3: eth1: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
c910f03c11k11:     link/ether 42:91:0a:03:0b:0b brd ff:ff:ff:ff:ff:ff
c910f03c11k11: [I]: configeth on c910f03c11k11: new configuration
c910f03c11k11:        100.3.11.11, 100.3.0.0, 255.255.0.0,
c910f03c11k11: [I]: configeth on c910f03c11k11: eth1 changed, modify the configuration files
c910f03c11k11: bring up ip
c910f03c11k11: eth1            up
c910f03c11k11: ['/etc/sysconfig/network/ifcfg-eth1']
c910f03c11k11: [I]: >> DEVICE=eth1
c910f03c11k11: [I]: >> BOOTPROTO=static
c910f03c11k11: [I]: >> IPADDR=100.3.11.11
c910f03c11k11: [I]: >> NETMASK=255.255.0.0
c910f03c11k11: [I]: >> NETWORK=100.3.0.0
c910f03c11k11: [I]: >> STARTMODE=onboot
c910f03c11k11: [I]: >> USERCONTROL=no
c910f03c11k11: [I]: >> _nm_name=static-0
c910f03c11k11: postscript end....: confignetwork exited with code 0
c910f03c11k11: Running of postscripts has completed.
c910f03c11k11: =============updatenode ending====================
CHECK:rc == 0	[Pass]
```
