### PR TITLE
Put the dracut_args --omit back into /etc/kdump.conf

### DIFF
--- a/xCAT/postscripts/enablekdump
+++ b/xCAT/postscripts/enablekdump
@@ -246,10 +246,8 @@ EOF
 
                echo "nfs $KDIP:$KDPATH" > /etc/kdump.conf
                echo "default shell" >> /etc/kdump.conf
-               if (pmatch $OSVER "rhel7*") || (pmatch $OSVER "rhels7*");then
-                   #strip "xcat" out of the initramfs for kdump
-                   echo "dracut_args --omit \"xcat\"" >> /etc/kdump.conf
-               fi
+               #strip "xcat" out of the initramfs for kdump
+               echo "dracut_args --omit \"xcat\"" >> /etc/kdump.conf
                #strip the unnecessary kernel options from /proc/cmdline
                #the modified "cmdline" will be used as the kernel options
                #for kdump initramfs; otherwise, the "service kdump restart" will fail


### PR DESCRIPTION
### Improve kdump support for xCAT diskless compute node

### The modification include

_##Put the dracut_args --omit back into /etc/kdump.conf_