### PR TITLE
work around some RH version ip link state UNKNOWN issue

### DIFF
--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -686,6 +686,7 @@ elif [ "$1" = "-s" ];then
     fi
 
     if [ "$UPDATENODE" = "1" ] || [ "$NODESETSTATE" = "netboot" ] || [ "$NODESETSTATE" = "statelite" ] || grep "REBOOT=TRUE" /opt/xcat/xcatinfo >/dev/null 2>&1; then
+        if_state=0
         if [ "$str_os_type" = "debian" ];then
             ifdown --force $str_inst_nic
         else
@@ -696,11 +697,13 @@ elif [ "$1" = "-s" ];then
 	else
             ifup $str_inst_nic
         fi
-        wait_for_ifstate $str_inst_nic UP 20 5
-    fi
-    if [ $? -ne 0 ]; then
-        log_error "bring $str_inst_nic up failed."
-        error_code=1
+        if [ $? -ne 0 ]; then
+            if_state=$(wait_for_ifstate $str_inst_nic UP 20 5)
+        fi
+        if [ $if_state -ne 0 ]; then
+            log_error "bring $str_inst_nic up failed."
+            error_code=1
+        fi
     fi
     if [ $networkmanager_active -eq 1 ] && [ -n "$tmp_con_name" ]; then
     	if [ $error_code -eq 1 ]; then
@@ -1106,14 +1109,17 @@ else
             fi
         else
             if [ $reboot_nic_bool -eq 1 ]; then
+                if_state=0
                 echo "bring up ip"
 		if [ $networkmanager_active -eq 1 ]; then
                     nmcli con up $con_name
 		else
                     ifup $str_nic_name
 		fi
-                wait_for_ifstate $str_nic_name UP 20 5
                 if [ $? -ne 0 ]; then
+                    if_state=$(wait_for_ifstate $str_nic_name UP 20 5)
+                fi
+                if [ $if_state -ne 0 ]; then
                     log_error "bring $str_nic_name up failed."
                     error_code=1
                 fi


### PR DESCRIPTION
### The PR is to fix issue 
https://github.com/xcat2/xcat-core/issues/6175

### The modification include

In some RH version, ``ifup <NIC>`` execute successfully execute successfully, but ip link state is "UNKNOWN" which is OS issue refer to https://bugzilla.redhat.com/show_bug.cgi?id=809912 and https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1541907, in such case, ``<NIC>`` is working well, only state is not "UNKNOWN" .

This PR is to work around some RH version ip link state UNKNOWN issue. 
1. If ``ifup <NIC>`` execute successfully, we regard ``<NIC>`` is configured well. 
2. Or else, wait for check ``<NIC>`` state. If the ``<NIC>`` state is "UP" finally, we regard ``<NIC>`` is configure well, this case is for sles OS,  in sles12.3, some ``ifup <NIC>`` is setup in progress, need wait for NIC state UP.


### The UT result
```
c910f02c01p08: =============updatenode starting====================
c910f02c01p08: trying to download postscripts...
c910f02c01p08: postscripts downloaded successfully
c910f02c01p08: trying to get mypostscript from 10.2.1.13...
c910f02c01p08: postscript start..: confignetwork
c910f02c01p08: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f02c01p08: [I]: configure the install nic eth1.
c910f02c01p08: [I]: configeth on c910f02c01p08: os type: redhat
c910f02c01p08: GATEWAY=10.0.0.101
c910f02c01p08: HOSTNAME=c910f02c01p08
c910f02c01p08: ['/etc/sysconfig/network-scripts/ifcfg-eth1']
c910f02c01p08: [I]: >> DEVICE=eth1
c910f02c01p08: [I]: >> IPADDR=10.2.1.8
c910f02c01p08: [I]: >> NETMASK=255.0.0.0
c910f02c01p08: [I]: >> BOOTPROTO=none
c910f02c01p08: [I]: >> ONBOOT=yes
c910f02c01p08: [I]: >> HWADDR=e6:d4:d3:4f:08:03
c910f02c01p08: [I]: >> MTU=1500
c910f02c01p08: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f02c01p08: [I]: network service is active
c910f02c01p08: [I]: All valid nics and device list:
c910f02c01p08: [I]: eth2
c910f02c01p08: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f02c01p08: configure nic and its device : eth2
c910f02c01p08: [I]: configure eth2
c910f02c01p08: [I]: call: configeth eth2 100.2.1.8 confignetworks_test1
c910f02c01p08: [I]: configeth on c910f02c01p08: os type: redhat
c910f02c01p08: configeth on c910f02c01p08: old configuration: 4: eth2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UNKNOWN qlen 1000
c910f02c01p08:     link/ether e6:d4:d3:4f:08:04 brd ff:ff:ff:ff:ff:ff
c910f02c01p08:     inet6 fe80::e4d4:d3ff:fe4f:804/64 scope link
c910f02c01p08:        valid_lft forever preferred_lft forever
c910f02c01p08: [I]: configeth on c910f02c01p08: new configuration
c910f02c01p08:        100.2.1.8, 100.2.0.0, 255.255.0.0,
c910f02c01p08: 4: eth2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UNKNOWN qlen 1000
c910f02c01p08: [I]: configeth on c910f02c01p08: eth2 changed, modify the configuration files
c910f02c01p08: bring up ip
c910f02c01p08: Determining if ip address 100.2.1.8 is already in use for device eth2...
c910f02c01p08: ['/etc/sysconfig/network-scripts/ifcfg-eth2']
c910f02c01p08: [I]: >> DEVICE=eth2
c910f02c01p08: [I]: >> BOOTPROTO=none
c910f02c01p08: [I]: >> NM_CONTROLLED=no
c910f02c01p08: [I]: >> IPADDR=100.2.1.8
c910f02c01p08: [I]: >> NETMASK=255.255.0.0
c910f02c01p08: [I]: >> ONBOOT=yes
c910f02c01p08: postscript end....: confignetwork exited with code 0
c910f02c01p08: Running of postscripts has completed.
c910f02c01p08: =============updatenode ending====================
CHECK:rc == 0	[Pass]
```
