### PR TITLE
update linux_diskless_kdump to  consistent with fix 6189

### DIFF
--- a/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
+++ b/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
@@ -31,7 +31,7 @@ cmd:exlistfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arc
 check:rc==0
 
 cmd:postinstallfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep postinstall|awk -F'=' '{print $2}'`;cp $postinstallfile $postinstallfile.bak
-cmd:postinstallfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep postinstall|awk -F'=' '{print $2}'`; if grep SUSE /etc/*release;then sed -i "/\/tmp/ s/10/200/g" $postinstallfile; elif grep "Red Hat" /etc/*release;then sed -i /devpts/a"tmpfs         /var/tmp    tmpfs   defaults,size=200m   0 2" $postinstallfile;fi
+cmd:postinstallfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep postinstall|awk -F'=' '{print $2}'`; if grep SUSE /etc/*release;then sed -i "/\/tmp/ s/10/500/g" $postinstallfile; elif grep "Red Hat" /etc/*release;then sed -i /devpts/a"tmpfs         /var/tmp    tmpfs   defaults,size=500m   0 2" $postinstallfile;fi
 check:rc==0
 
 cmd:if [ ! -d /kdumpdir ]; then mkdir -p /kdumpdir && chmod 777 /kdumpdir; fi


### PR DESCRIPTION
### The PR is for task https://github.ibm.com/xcat2/task_management/issues/70

### The modification include

* update test case linux_diskless_kdump to consistent with pr https://github.com/xcat2/xcat-core/pull/6189

### The UT result

```
....
RUN:postinstallfile=`lsdef -t osimage __GETNODEATTR(c910f03c09k11,os)__-__GETNODEATTR(c910f03c09k11,arch)__-netboot-compute|grep postinstall|awk -F'=' '{print $2}'`; if grep SUSE /etc/*release;then sed -i "/\/tmp/ s/10/500/g" $postinstallfile; elif grep "Red Hat" /etc/*release;then sed -i /devpts/a"tmpfs         /var/tmp    tmpfs   defaults,size=500m   0 2" $postinstallfile;fi
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
/etc/os-release:NAME="Red Hat Enterprise Linux Server"
/etc/os-release:PRETTY_NAME="Red Hat Enterprise Linux Server 7.6 (Maipo)"
/etc/os-release:REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
/etc/os-release:REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
/etc/redhat-release:Red Hat Enterprise Linux Server release 7.6 (Maipo)
/etc/system-release:Red Hat Enterprise Linux Server release 7.6 (Maipo)
CHECK:rc == 0   [Pass]
......
```