### PR TITLE
update case rspconfig_dump_download and rspconfig_dump_no_option

### DIFF
--- a/xCAT-test/autotest/testcase/rspconfig/cases1
+++ b/xCAT-test/autotest/testcase/rspconfig/cases1
@@ -113,7 +113,7 @@ cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;rspconfig $$CN d
 check:rc == 0
 cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;grep "Downloading dump $dumpnumber to /var/log/xcat/dump/" /tmp/dumpdown
 check:rc == 0
-cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`rspconfig $$CN dump -l |grep "\[$dumpnumber\] Generated" |cut -d : -f 6`;if lsdef service > /dev/null 2>&1; then xdsh $$SN ls -l /var/log/xcat/dump/*_$$CN_dump_$dumpnumber.tar.xz|grep $dumpsize;else ls -l /var/log/xcat/dump/*_$$CN_dump_$dumpnumber.tar.xz|grep $dumpsize;fi
+cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`rspconfig $$CN dump -l |grep "\[$dumpnumber\] Generated" |cut -d : -f 6`;sn=`lsdef $$CN -i servicenode -c | awk -F '=' '{print $2}'`;if [[ -z "$sn" ]]; then ls -l /var/log/xcat/dump/*_$$CN_dump_$dumpnumber.tar.xz|grep $dumpsize;else xdsh $sn ls -l /var/log/xcat/dump/*_$$CN_dump_$dumpnumber.tar.xz|grep $dumpsize;fi
 check:rc == 0
 cmd:rspconfig $$CN dump -g |tee /tmp/dumpgenerate
 check:rc == 0
@@ -123,7 +123,7 @@ cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;rspconfig $$CN d
 check:rc == 0
 cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;grep "Downloading dump $dumpnumber to /var/log/xcat/dump/" /tmp/dumpdown
 check:rc == 0
-cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`rspconfig $$CN dump -l |grep "\[$dumpnumber\] Generated" |cut -d : -f 6`;if lsdef service > /dev/null 2>&1; then xdsh $$SN ls -l /var/log/xcat/dump/*_$$CN_dump_$dumpnumber.tar.xz|grep $dumpsize;else ls -l /var/log/xcat/dump/*_$$CN_dump_$dumpnumber.tar.xz|grep $dumpsize;fi
+cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`rspconfig $$CN dump -l |grep "\[$dumpnumber\] Generated" |cut -d : -f 6`;sn=`lsdef $$CN -i servicenode -c | awk -F '=' '{print $2}'`;if [[ -z "$sn" ]]; then ls -l /var/log/xcat/dump/*_$$CN_dump_$dumpnumber.tar.xz|grep $dumpsize;else xdsh $sn ls -l /var/log/xcat/dump/*_$$CN_dump_$dumpnumber.tar.xz|grep $dumpsize;fi
 check:rc == 0
 cmd:rspconfig $$CN dump -d all
 check:rc == 0
@@ -145,7 +145,7 @@ check:output =~$$CN:\s*Dump requested
 check:output =~$$CN:\s*Downloading dump
 cmd:rspconfig $$CN dump -l |tail -n 1 |tee /tmp/dumpgenerate
 check:rc == 0
-cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`grep "\[$dumpnumber\] Generated" /tmp/dumpgenerate |cut -d : -f 6`;if lsdef service > /dev/null 2>&1; then xdsh $$SN ls -l /var/log/xcat/dump/*_dump_$dumpnumber.tar.xz|grep $dumpsize|grep $$CN;else ls -l /var/log/xcat/dump/*_dump_$dumpnumber.tar.xz|grep $dumpsize|grep $$CN;fi
+cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`grep "\[$dumpnumber\] Generated" /tmp/dumpgenerate |cut -d : -f 6`;sn=`lsdef $$CN -i servicenode -c | awk -F '=' '{print $2}'`;if [[ -z "$sn" ]]; then ls -l /var/log/xcat/dump/*_$$CN_dump_$dumpnumber.tar.xz|grep $dumpsize|grep $$CN;else xdsh $sn ls -l /var/log/xcat/dump/*_$$CN_dump_$dumpnumber.tar.xz|grep $dumpsize|grep $$CN;fi
 check:rc == 0
 cmd:rm -rf /tmp/dumpgenerate
 end

--- a/xCAT-test/autotest/testcase/rspconfig/cases1
+++ b/xCAT-test/autotest/testcase/rspconfig/cases1
@@ -111,9 +111,9 @@ check:output =~$$CN:\s*\[\d+\]\s* success
 cmd:sleep 300
 cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;rspconfig $$CN dump -d $dumpnumber |tee /tmp/dumpdown
 check:rc == 0
-cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;grep "Downloaded dump $dumpnumber to /var/log/xcat/dump/" /tmp/dumpdown
+cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;grep "Downloading dump $dumpnumber to /var/log/xcat/dump/" /tmp/dumpdown
 check:rc == 0
-cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`rspconfig $$CN dump -l |grep "\[$dumpnumber\] Generated" |cut -d : -f 6`;ls -l /var/log/xcat/dump/*_$$CN_dump_$dumpnumber.tar.xz|grep $dumpsize
+cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`rspconfig $$CN dump -l |grep "\[$dumpnumber\] Generated" |cut -d : -f 6`;if lsdef service > /dev/null 2>&1; then xdsh $$SN ls -l /var/log/xcat/dump/*_$$CN_dump_$dumpnumber.tar.xz|grep $dumpsize;else ls -l /var/log/xcat/dump/*_$$CN_dump_$dumpnumber.tar.xz|grep $dumpsize;fi
 check:rc == 0
 cmd:rspconfig $$CN dump -g |tee /tmp/dumpgenerate
 check:rc == 0
@@ -121,9 +121,9 @@ check:output =~$$CN:\s*\[\d+\]\s* success
 cmd:sleep 300
 cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;rspconfig $$CN dump --download $dumpnumber |tee /tmp/dumpdown
 check:rc == 0
-cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;grep "Downloaded dump $dumpnumber to /var/log/xcat/dump/" /tmp/dumpdown
+cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;grep "Downloading dump $dumpnumber to /var/log/xcat/dump/" /tmp/dumpdown
 check:rc == 0
-cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`rspconfig $$CN dump -l |grep "\[$dumpnumber\] Generated" |cut -d : -f 6`;ls -l /var/log/xcat/dump/*_$$CN_dump_$dumpnumber.tar.xz|grep $dumpsize
+cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`rspconfig $$CN dump -l |grep "\[$dumpnumber\] Generated" |cut -d : -f 6`;if lsdef service > /dev/null 2>&1; then xdsh $$SN ls -l /var/log/xcat/dump/*_$$CN_dump_$dumpnumber.tar.xz|grep $dumpsize;else ls -l /var/log/xcat/dump/*_$$CN_dump_$dumpnumber.tar.xz|grep $dumpsize;fi
 check:rc == 0
 cmd:rspconfig $$CN dump -d all
 check:rc == 0
@@ -145,7 +145,7 @@ check:output =~$$CN:\s*Dump requested
 check:output =~$$CN:\s*Downloading dump
 cmd:rspconfig $$CN dump -l |tail -n 1 |tee /tmp/dumpgenerate
 check:rc == 0
-cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`grep "\[$dumpnumber\] Generated" /tmp/dumpgenerate |cut -d : -f 6`;ls -l /var/log/xcat/dump/*_dump_$dumpnumber.tar.xz|grep $dumpsize|grep $$CN
+cmd:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`grep "\[$dumpnumber\] Generated" /tmp/dumpgenerate |cut -d : -f 6`;if lsdef service > /dev/null 2>&1; then xdsh $$SN ls -l /var/log/xcat/dump/*_dump_$dumpnumber.tar.xz|grep $dumpsize|grep $$CN;else ls -l /var/log/xcat/dump/*_dump_$dumpnumber.tar.xz|grep $dumpsize|grep $$CN;fi
 check:rc == 0
 cmd:rm -rf /tmp/dumpgenerate
 end


### PR DESCRIPTION
### The PR is to do task https://github.ibm.com/xcat2/task_management/issues/43

The UT
```
------START::rspconfig_dump_download::Time:Mon Apr  1 01:50:26 2019------

RUN:rspconfig f5u14 dump -g |tee /tmp/dumpgenerate [Mon Apr  1 01:50:26 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
f5u14: [536] success
CHECK:rc == 0	[Pass]
CHECK:output =~ f5u14:\s*\[\d+\]\s* success	[Pass]

RUN:sleep 300 [Mon Apr  1 01:50:28 2019]
ElapsedTime:300 sec
RETURN rc = 0
OUTPUT:

RUN:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;rspconfig f5u14 dump -d $dumpnumber |tee /tmp/dumpdown [Mon Apr  1 01:55:28 2019]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
f5u14: Downloading dump 536 to /var/log/xcat/dump/20190401-0155_f5u14_dump_536.tar.xz
CHECK:rc == 0	[Pass]

RUN:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;grep "Downloading dump $dumpnumber to /var/log/xcat/dump/" /tmp/dumpdown [Mon Apr  1 01:55:31 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
f5u14: Downloading dump 536 to /var/log/xcat/dump/20190401-0155_f5u14_dump_536.tar.xz
CHECK:rc == 0	[Pass]

RUN:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`rspconfig f5u14 dump -l |grep "\[$dumpnumber\] Generated" |cut -d : -f 6`;if lsdef service > /dev/null 2>&1; then xdsh f6u13k11 ls -l /var/log/xcat/dump/*_f5u14_dump_$dumpnumber.tar.xz|grep $dumpsize;else ls -l /var/log/xcat/dump/*_f5u14_dump_$dumpnumber.tar.xz|grep $dumpsize;fi [Mon Apr  1 01:55:31 2019]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
f6u13k11: -rw-r--r-- 1 root root 70768 Apr  1 01:55 /var/log/xcat/dump/20190401-0155_f5u14_dump_536.tar.xz
CHECK:rc == 0	[Pass]

RUN:rspconfig f5u14 dump -g |tee /tmp/dumpgenerate [Mon Apr  1 01:55:34 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
f5u14: [537] success
CHECK:rc == 0	[Pass]
CHECK:output =~ f5u14:\s*\[\d+\]\s* success	[Pass]

RUN:sleep 300 [Mon Apr  1 01:55:36 2019]
ElapsedTime:300 sec
RETURN rc = 0
OUTPUT:

RUN:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;rspconfig f5u14 dump --download $dumpnumber |tee /tmp/dumpdown [Mon Apr  1 02:00:36 2019]
ElapsedTime:4 sec
RETURN rc = 0
OUTPUT:
f5u14: Downloading dump 537 to /var/log/xcat/dump/20190401-0200_f5u14_dump_537.tar.xz
CHECK:rc == 0	[Pass]

RUN:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;grep "Downloading dump $dumpnumber to /var/log/xcat/dump/" /tmp/dumpdown [Mon Apr  1 02:00:40 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
f5u14: Downloading dump 537 to /var/log/xcat/dump/20190401-0200_f5u14_dump_537.tar.xz
CHECK:rc == 0	[Pass]

RUN:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`rspconfig f5u14 dump -l |grep "\[$dumpnumber\] Generated" |cut -d : -f 6`;if lsdef service > /dev/null 2>&1; then xdsh f6u13k11 ls -l /var/log/xcat/dump/*_f5u14_dump_$dumpnumber.tar.xz|grep $dumpsize;else ls -l /var/log/xcat/dump/*_f5u14_dump_$dumpnumber.tar.xz|grep $dumpsize;fi [Mon Apr  1 02:00:40 2019]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
f6u13k11: -rw-r--r-- 1 root root 71092 Apr  1 02:00 /var/log/xcat/dump/20190401-0200_f5u14_dump_537.tar.xz
CHECK:rc == 0	[Pass]

RUN:rspconfig f5u14 dump -d all [Mon Apr  1 02:00:43 2019]
ElapsedTime:5 sec
RETURN rc = 0
OUTPUT:
Downloading all dumps...
f5u14: Downloading dump 536 to /var/log/xcat/dump/20190401-0200_f5u14_dump_536.tar.xz
f5u14: Downloading dump 537 to /var/log/xcat/dump/20190401-0200_f5u14_dump_537.tar.xz
CHECK:rc == 0	[Pass]
CHECK:output =~ Downloading all dumps	[Pass]

RUN:rspconfig f5u14 dump --download all [Mon Apr  1 02:00:48 2019]
ElapsedTime:5 sec
RETURN rc = 0
OUTPUT:
Downloading all dumps...
f5u14: Downloading dump 536 to /var/log/xcat/dump/20190401-0200_f5u14_dump_536.tar.xz
f5u14: Downloading dump 537 to /var/log/xcat/dump/20190401-0200_f5u14_dump_537.tar.xz
CHECK:rc == 0	[Pass]
CHECK:output =~ Downloading all dumps	[Pass]

RUN:rm -rf /tmp/dumpgenerate /tmp/dumpdown [Mon Apr  1 02:00:53 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::rspconfig_dump_download::Passed::Time:Mon Apr  1 02:00:53 2019 ::Duration::627 sec------
------START::rspconfig_dump_no_option::Time:Mon Apr  1 02:00:53 2019------

RUN:rspconfig f5u14 dump [Mon Apr  1 02:00:53 2019]
ElapsedTime:113 sec
RETURN rc = 0
OUTPUT:
Capturing BMC Diagnostic information, this will take some time...
f5u14: Dump requested. Target ID is 538, waiting for BMC to generate...
f5u14: Still waiting for dump 538 to be generated...
f5u14: Downloading dump 538 to /var/log/xcat/dump/20190401-0200_f5u14_dump_538.tar.xz
CHECK:rc == 0	[Pass]
CHECK:output =~ f5u14:\s*Dump requested	[Pass]
CHECK:output =~ f5u14:\s*Downloading dump	[Pass]

RUN:rspconfig f5u14 dump -l |tail -n 1 |tee /tmp/dumpgenerate [Mon Apr  1 02:02:46 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
f5u14: [538] Generated: 04/01/2019 01:53:29, Size: 71444
CHECK:rc == 0	[Pass]

RUN:dumpnumber=`sed -r 's/.+\[(.+)\].+/\1/g' /tmp/dumpgenerate`;dumpsize=`grep "\[$dumpnumber\] Generated" /tmp/dumpgenerate |cut -d : -f 6`;if lsdef service > /dev/null 2>&1; then xdsh f6u13k11 ls -l /var/log/xcat/dump/*_dump_$dumpnumber.tar.xz|grep $dumpsize|grep f5u14;else ls -l /var/log/xcat/dump/*_dump_$dumpnumber.tar.xz|grep $dumpsize|grep f5u14;fi [Mon Apr  1 02:02:48 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
f6u13k11: -rw-r--r-- 1 root root 71444 Apr  1 02:02 /var/log/xcat/dump/20190401-0200_f5u14_dump_538.tar.xz
CHECK:rc == 0	[Pass]

RUN:rm -rf /tmp/dumpgenerate [Mon Apr  1 02:02:50 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::rspconfig_dump_no_option::Passed::Time:Mon Apr  1 02:02:50 2019 ::Duration::117 sec------
------Total: 2 , Failed: 0------
```