### PR TITLE
[go-xcat] Fix bug of command line argument processing

### DIFF
--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -1979,8 +1979,8 @@ do
 		GO_XCAT_ACTION="$1"
 		case "$1 $2" in
 		"completely uninstall"|"smoke test")
-			shift
 			GO_XCAT_ACTION="$1 $2"
+			shift
 			;;
 		esac
 		;;


### PR DESCRIPTION
### The PR is to fix a bug of command line argument processing for `go-xcat`

### The modification include

_##Fix bug of command line argument processing_

See below for details.
```
/tmp/go-xcat completely uninstall
go-xcat: invalid action -- `uninstall '
go-xcat: Try `/tmp/go-xcat --help' for more information
```

### The UT result
```
# /tmp/go-xcat completely uninstall
Operating system:   linux
Architecture:       ppc64le
Linux Distribution: rhel
Version:            8.0
go-xcat Version:    1.0.36


xCAT is going to be trashed.
Continue? [y/n] n
Good-bye!
```