### PR TITLE
confignetwork extra params support and multiple ipv4 address ethernet nic support using nmcli

### DIFF
--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -31,6 +31,12 @@ networkmanager_active=0
 checkservicestatus NetworkManager > /dev/null
 if [ $? -eq 0 ]; then
     networkmanager_active=1
+else
+    #In RH8 postscripts stage, NetworkManager is active but nmcli cannot modify NIC configure file
+    ps -ef|grep -v grep|grep NetworkManager >/dev/null 2>/dev/null
+    if [ $? -eq 0 ]; then
+        networkmanager_active=2
+    fi
 fi
 str_conf_file=""
 str_conf_file_xcatbak=""
@@ -135,6 +141,9 @@ function configipv4(){
             str_if_name=${str_if_name}:${num_v4num}
         fi
         str_conf_file="/etc/sysconfig/network-scripts/ifcfg-${str_if_name}"
+        if [ $networkmanager_active -ne 0 ]; then
+            str_conf_file="/etc/sysconfig/network-scripts/ifcfg-xcat-${str_if_name}" 
+        fi
         if [ $networkmanager_active -eq 1 ]; then
             if [ $num_v4num -eq 0 ]; then
                 is_nmcli_connection_exist $con_name
@@ -146,6 +155,19 @@ function configipv4(){
             else
                 nmcli con modify $con_name +ipv4.addresses ${str_v4ip}/${str_prefix}
             fi
+        elif [ $networkmanager_active -eq 2 ]; then
+            if [ $num_v4num -eq 0 ]; then
+                echo "DEVICE=${str_if_name}" > $str_conf_file
+                echo "BOOTPROTO=none" >> $str_conf_file
+                echo "IPADDR=${str_v4ip}" >> $str_conf_file
+                echo "NETMASK=${str_v4mask}" >> $str_conf_file
+                echo "NAME=xcat-${str_if_name}" >> $str_conf_file 
+                echo "ONBOOT=yes" >> $str_conf_file
+                echo "AUTOCONNECT_PRIORITY=9" >> $str_conf_file
+            else
+                echo "IPADDR$num_v4num=${str_v4ip}" >> $str_conf_file
+                echo "NETMASK$num_v4num=${str_v4mask}" >> $str_conf_file 
+            fi  
         else
             echo "DEVICE=${str_if_name}" > $str_conf_file
             echo "BOOTPROTO=none" >> $str_conf_file
@@ -156,10 +178,10 @@ function configipv4(){
         fi
         if [ "$str_nic_mtu" != "$str_default_token" ]; then
             if [ $networkmanager_active -eq 1 ]; then
-		nmcli con modify $con_name mtu $str_nic_mtu
+                nmcli con modify $con_name mtu $str_nic_mtu
             else
                 echo "MTU=${str_nic_mtu}" >> $str_conf_file
-	    fi
+            fi
         fi
 
         if [[ ${str_if_name} == [a-zA-Z0-9]*.[0-9]* ]]; then
@@ -174,10 +196,12 @@ function configipv4(){
             value="${array_extra_param_values[$i]}"
             echo "$i: name=$name value=$value"
             if [ $networkmanager_active -eq 1 ]; then
-                nmcli con modify $con_name $name $value
-            else
-                echo "${name}=${value}" >> $str_conf_file
+                str_conf_file_1="/etc/sysconfig/network-scripts/ifcfg-xcat-${str_if_name}-1"
+                if [ -e $str_conf_file_1 ]; then
+                    echo "${name}=${value}" >> $str_conf_file_1
+                fi
             fi
+            echo "${name}=${value}" >> $str_conf_file
     	    i=$((i+1))
         done		
     fi
@@ -638,6 +662,9 @@ elif [ "$1" = "-s" ];then
         con_name="xcat-install-"${str_inst_nic}
         str_inst_prefix=$(v4mask2prefix ${str_inst_mask})
         str_conf_file="/etc/sysconfig/network-scripts/ifcfg-${str_inst_nic}"
+        if [ $networkmanager_active -eq 2 ]; then
+            str_conf_file="/etc/sysconfig/network-scripts/ifcfg-xcat-install-${str_inst_nic}"
+        fi
         if [ $networkmanager_active -eq 1 ]; then
             is_nmcli_connection_exist "$con_name"
             if [ $? -eq 0 ]; then
@@ -651,14 +678,18 @@ elif [ "$1" = "-s" ];then
             echo "NETMASK=${str_inst_mask}" >> $str_conf_file
             echo "BOOTPROTO=none" >> $str_conf_file
             echo "ONBOOT=yes" >> $str_conf_file
+            echo "NAME=xcat-install-${str_inst_nic}" >> $str_conf_file
             echo "HWADDR=${str_inst_mac}" >> $str_conf_file
         fi
+        if [ $networkmanager_active -eq 2 ]; then
+            echo "AUTOCONNECT_PRIORITY=9" >> $str_conf_file
+        fi
         if [ -n "${str_inst_mtu}" ];then
-	    if [ $networkmanager_active -eq 1 ]; then
-		nmcli con modify $con_name mtu ${str_inst_mtu}
+	        if [ $networkmanager_active -eq 1 ]; then
+		        nmcli con modify $con_name mtu ${str_inst_mtu}
             else
                 echo "MTU=${str_inst_mtu}" >> $str_conf_file
-	    fi
+	        fi
         fi
         if [ -n "$str_inst_gateway" ];then
             grep -i "GATEWAY" /etc/sysconfig/network
@@ -669,7 +700,7 @@ elif [ "$1" = "-s" ];then
             fi
         fi
 
-	#add extra params
+	    #add extra params
         i=0
         while [ $i -lt ${#array_extra_param_names[@]} ]
         do
@@ -677,10 +708,12 @@ elif [ "$1" = "-s" ];then
             value="${array_extra_param_values[$i]}"
             echo "$i: name=$name value=$value"
             if [ $networkmanager_active -eq 1 ]; then
-                nmcli con modify $con_name $name $value
-            else
-                echo "${name}=${value}" >> $str_conf_file
-	    fi
+                str_conf_file_1="/etc/sysconfig/network-scripts/ifcfg-xcat-install-${str_if_name}-1"
+                if [ -e $str_conf_file_1 ]; then
+                    echo "${name}=${value}" >> $str_conf_file_1
+                fi
+            fi
+            echo "${name}=${value}" >> $str_conf_file
             i=$((i+1))
         done		
 
@@ -704,7 +737,8 @@ elif [ "$1" = "-s" ];then
         else
             ip link set dev $str_inst_nic down
         fi
-	if [ $networkmanager_active -eq 1 ]; then
+        if [ $networkmanager_active -eq 1 ]; then
+            nmcli con reload
             nmcli con up $con_name
 	else
             ifup $str_inst_nic
@@ -1123,11 +1157,12 @@ else
             if [ $reboot_nic_bool -eq 1 ]; then
                 if_state=0
                 echo "bring up ip"
-		if [ $networkmanager_active -eq 1 ]; then
+                if [ $networkmanager_active -eq 1 ]; then
+                    nmcli con reload
                     nmcli con up $con_name
-		else
+                else
                     ifup $str_nic_name
-		fi
+                fi
                 if [ $? -ne 0 ]; then
                     if_state=$(wait_for_ifstate $str_nic_name UP 20 5)
                 fi

--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -171,11 +171,11 @@ function configipv4(){
                 echo "NETMASK$num_v4num=${str_v4mask}" >> $str_conf_file 
             fi  
         else
-            str_conf_file="/etc/sysconfig/network-scripts/ifcfg-${str_if_name}"
             #If using network service, the NIC alias device format is <NIC>:<num_v4num> like eth0:1
             if [ $num_v4num -ne 0 ]; then
                 str_if_name=${str_if_name}:${num_v4num}
             fi
+            str_conf_file="/etc/sysconfig/network-scripts/ifcfg-${str_if_name}"
             echo "DEVICE=${str_if_name}" > $str_conf_file
             echo "BOOTPROTO=none" >> $str_conf_file
             echo "NM_CONTROLLED=no" >> $str_conf_file

--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -131,17 +131,21 @@ function configipv4(){
         # Write the info to the ifcfg file for redhat
         con_name="xcat-"${str_if_name}
         str_conf_file=""
-        if [ $num_v4num -ne 0 ]; then
+        if [ $num_v4num -ne 0 ] && [ $networkmanager_active -eq 0 ]; then
             str_if_name=${str_if_name}:${num_v4num}
         fi
         str_conf_file="/etc/sysconfig/network-scripts/ifcfg-${str_if_name}"
         if [ $networkmanager_active -eq 1 ]; then
-            is_nmcli_connection_exist $con_name
-            if [ $? -eq 0 ]; then
-                tmp_con_name=$con_name"-tmp"
-                nmcli con modify $con_name connection.id $tmp_con_name
+            if [ $num_v4num -eq 0 ]; then
+                is_nmcli_connection_exist $con_name
+                if [ $? -eq 0 ]; then
+                    tmp_con_name=$con_name"-tmp"
+                    nmcli con modify $con_name connection.id $tmp_con_name
+                fi
+                nmcli con add type ethernet con-name $con_name ifname ${str_if_name} ipv4.method manual  ipv4.addresses  ${str_v4ip}/${str_prefix} connection.autoconnect-priority 9
+            else
+                nmcli con modify $con_name +ipv4.addresses ${str_v4ip}/${str_prefix}
             fi
-            nmcli con add type ethernet con-name $con_name ifname ${str_if_name} ipv4.method manual  ipv4.addresses  ${str_v4ip}/${str_prefix} connection.autoconnect-priority 9
         else
             echo "DEVICE=${str_if_name}" > $str_conf_file
             echo "BOOTPROTO=none" >> $str_conf_file
@@ -345,7 +349,7 @@ function add_ip_temporary(){
         else
             str_label=''
             ip addr show dev $str_temp_name | grep inet | grep "global" | grep -v ':' | grep "${str_temp_name}"
-            if [ $? -eq 0 ];then
+            if [ $? -eq 0 ] && [ $networkmanager_active -eq 0 ]; then
                 for num_i in {1..1000}
                 do
                     ip addr show dev $str_temp_name | grep inet | grep "global" | grep ":${num_i}"

--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -183,27 +183,27 @@ function configipv4(){
                 echo "MTU=${str_nic_mtu}" >> $str_conf_file
             fi
         fi
-
+        if [ $networkmanager_active -eq 1 ]; then
+            str_conf_file_1="/etc/sysconfig/network-scripts/ifcfg-xcat-${str_if_name}-1"
+            if [ -f $str_conf_file_1 ]; then
+                grep -x "NAME=$con_name" $str_conf_file_1 >/dev/null 2>/dev/null
+                if [ $? -eq 0 ]; then
+                    str_conf_file=$str_conf_file_1
+                fi
+            fi
+        fi
         if [[ ${str_if_name} == [a-zA-Z0-9]*.[0-9]* ]]; then
             echo "VLAN=yes" >> $str_conf_file
         fi
-
         #add extra params
         i=0
         while [ $i -lt ${#array_extra_param_names[@]} ]
         do
             name="${array_extra_param_names[$i]}"
             value="${array_extra_param_values[$i]}"
-            echo "$i: name=$name value=$value"
-            if [ $networkmanager_active -eq 1 ]; then
-                str_conf_file_1="/etc/sysconfig/network-scripts/ifcfg-xcat-${str_if_name}-1"
-                if [ -e $str_conf_file_1 ]; then
-                    echo "${name}=${value}" >> $str_conf_file_1
-                fi
-            fi
-            echo "${name}=${value}" >> $str_conf_file
+            echo "${name}=${value}" >> $str_conf_file 
     	    i=$((i+1))
-        done		
+        done
     fi
 }
 
@@ -699,7 +699,15 @@ elif [ "$1" = "-s" ];then
                 echo "GATEWAY=${str_inst_gateway}" >> /etc/sysconfig/network
             fi
         fi
-
+        if [ $networkmanager_active -eq 1 ]; then
+            str_conf_file_1="/etc/sysconfig/network-scripts/ifcfg-xcat-${str_if_name}-1"
+            if [ -f $str_conf_file_1 ]; then
+                grep $con_name $str_conf_file_1 >/dev/null 2>/dev/null
+                if [ $? -eq 0 ]; then
+                    $str_conf_file=$str_conf_file_1
+                fi
+            fi
+        fi
 	    #add extra params
         i=0
         while [ $i -lt ${#array_extra_param_names[@]} ]
@@ -707,12 +715,6 @@ elif [ "$1" = "-s" ];then
             name="${array_extra_param_names[$i]}"
             value="${array_extra_param_values[$i]}"
             echo "$i: name=$name value=$value"
-            if [ $networkmanager_active -eq 1 ]; then
-                str_conf_file_1="/etc/sysconfig/network-scripts/ifcfg-xcat-install-${str_if_name}-1"
-                if [ -e $str_conf_file_1 ]; then
-                    echo "${name}=${value}" >> $str_conf_file_1
-                fi
-            fi
             echo "${name}=${value}" >> $str_conf_file
             i=$((i+1))
         done		
@@ -740,7 +742,7 @@ elif [ "$1" = "-s" ];then
         if [ $networkmanager_active -eq 1 ]; then
             nmcli con reload
             nmcli con up $con_name
-	else
+	    else
             ifup $str_inst_nic
         fi
         if [ $? -ne 0 ]; then

--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -162,16 +162,20 @@ function configipv4(){
             echo "VLAN=yes" >> $str_conf_file
         fi
 
-		#add extra params
-		i=0
-		while [ $i -lt ${#array_extra_param_names[@]} ]
-		do
-			name="${array_extra_param_names[$i]}"
-			value="${array_extra_param_values[$i]}"
-            echo "  $i: name=$name value=$value"
-			echo "${name}=${value}" >> $str_conf_file
-			i=$((i+1))
-		done		
+        #add extra params
+        i=0
+        while [ $i -lt ${#array_extra_param_names[@]} ]
+        do
+            name="${array_extra_param_names[$i]}"
+            value="${array_extra_param_values[$i]}"
+            echo "$i: name=$name value=$value"
+            if [ $networkmanager_active -eq 1 ]; then
+                nmcli con modify $con_name $name $value
+            else
+                echo "${name}=${value}" >> $str_conf_file
+            fi
+    	    i=$((i+1))
+        done		
     fi
 }
 
@@ -661,16 +665,20 @@ elif [ "$1" = "-s" ];then
             fi
         fi
 
-		#add extra params
-		i=0
-		while [ $i -lt ${#array_extra_param_names[@]} ]
-		do
-			name="${array_extra_param_names[$i]}"
-			value="${array_extra_param_values[$i]}"
-            echo "  $i: name=$name value=$value"
-			echo "${name}=${value}" >> $str_conf_file
-			i=$((i+1))
-		done		
+	#add extra params
+        i=0
+        while [ $i -lt ${#array_extra_param_names[@]} ]
+        do
+            name="${array_extra_param_names[$i]}"
+            value="${array_extra_param_values[$i]}"
+            echo "$i: name=$name value=$value"
+            if [ $networkmanager_active -eq 1 ]; then
+                nmcli con modify $con_name $name $value
+            else
+                echo "${name}=${value}" >> $str_conf_file
+	    fi
+            i=$((i+1))
+        done		
 
         hostname $NODE
         if [ -f "/etc/hostname" ]; then

--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -46,7 +46,7 @@ function configipv4(){
     str_v4ip=$2
     str_v4net=$3
     str_v4mask=$4
-    num_v4num=$5
+    num_v4num=$5 #If NIC has multiple IPs, the ordinal number of IP is num_v4num
     str_extra_params=$6
     str_nic_mtu=$7
 
@@ -137,13 +137,6 @@ function configipv4(){
         # Write the info to the ifcfg file for redhat
         con_name="xcat-"${str_if_name}
         str_conf_file=""
-        if [ $num_v4num -ne 0 ] && [ $networkmanager_active -eq 0 ]; then
-            str_if_name=${str_if_name}:${num_v4num}
-        fi
-        str_conf_file="/etc/sysconfig/network-scripts/ifcfg-${str_if_name}"
-        if [ $networkmanager_active -ne 0 ]; then
-            str_conf_file="/etc/sysconfig/network-scripts/ifcfg-xcat-${str_if_name}" 
-        fi
         if [ $networkmanager_active -eq 1 ]; then
             if [ $num_v4num -eq 0 ]; then
                 is_nmcli_connection_exist $con_name
@@ -155,7 +148,16 @@ function configipv4(){
             else
                 nmcli con modify $con_name +ipv4.addresses ${str_v4ip}/${str_prefix}
             fi
+            str_conf_file="/etc/sysconfig/network-scripts/ifcfg-xcat-${str_if_name}"
+            str_conf_file_1="/etc/sysconfig/network-scripts/ifcfg-xcat-${str_if_name}-1"
+            if [ -f $str_conf_file_1 ]; then
+                grep -x "NAME=$con_name" $str_conf_file_1 >/dev/null 2>/dev/null
+                if [ $? -eq 0 ]; then
+                    str_conf_file=$str_conf_file_1
+                fi
+            fi
         elif [ $networkmanager_active -eq 2 ]; then
+            str_conf_file="/etc/sysconfig/network-scripts/ifcfg-xcat-${str_if_name}"
             if [ $num_v4num -eq 0 ]; then
                 echo "DEVICE=${str_if_name}" > $str_conf_file
                 echo "BOOTPROTO=none" >> $str_conf_file
@@ -169,6 +171,11 @@ function configipv4(){
                 echo "NETMASK$num_v4num=${str_v4mask}" >> $str_conf_file 
             fi  
         else
+            str_conf_file="/etc/sysconfig/network-scripts/ifcfg-${str_if_name}"
+            #If using network service, the NIC alias device format is <NIC>:<num_v4num> like eth0:1
+            if [ $num_v4num -ne 0 ]; then
+                str_if_name=${str_if_name}:${num_v4num}
+            fi
             echo "DEVICE=${str_if_name}" > $str_conf_file
             echo "BOOTPROTO=none" >> $str_conf_file
             echo "NM_CONTROLLED=no" >> $str_conf_file
@@ -181,15 +188,6 @@ function configipv4(){
                 nmcli con modify $con_name mtu $str_nic_mtu
             else
                 echo "MTU=${str_nic_mtu}" >> $str_conf_file
-            fi
-        fi
-        if [ $networkmanager_active -eq 1 ]; then
-            str_conf_file_1="/etc/sysconfig/network-scripts/ifcfg-xcat-${str_if_name}-1"
-            if [ -f $str_conf_file_1 ]; then
-                grep -x "NAME=$con_name" $str_conf_file_1 >/dev/null 2>/dev/null
-                if [ $? -eq 0 ]; then
-                    str_conf_file=$str_conf_file_1
-                fi
             fi
         fi
         if [[ ${str_if_name} == [a-zA-Z0-9]*.[0-9]* ]]; then
@@ -672,6 +670,13 @@ elif [ "$1" = "-s" ];then
                 nmcli con modify $con_name connection.id $tmp_con_name
             fi
             nmcli con add type ethernet con-name $con_name ifname ${str_inst_nic} ipv4.method manual ipv4.addresses  ${str_inst_ip}/${str_inst_prefix} connection.autoconnect-priority 9
+            str_conf_file_1="/etc/sysconfig/network-scripts/ifcfg-xcat-${str_if_name}-1"
+            if [ -f $str_conf_file_1 ]; then
+                grep $con_name $str_conf_file_1 >/dev/null 2>/dev/null
+                if [ $? -eq 0 ]; then
+                    $str_conf_file=$str_conf_file_1
+                fi
+            fi
         else
             echo "DEVICE=${str_inst_nic}" > $str_conf_file
             echo "IPADDR=${str_inst_ip}" >> $str_conf_file
@@ -697,15 +702,6 @@ elif [ "$1" = "-s" ];then
                 sed -i "s/.*GATEWAY.*/GATEWAY=${str_inst_gateway}/i" /etc/sysconfig/network
             else
                 echo "GATEWAY=${str_inst_gateway}" >> /etc/sysconfig/network
-            fi
-        fi
-        if [ $networkmanager_active -eq 1 ]; then
-            str_conf_file_1="/etc/sysconfig/network-scripts/ifcfg-xcat-${str_if_name}-1"
-            if [ -f $str_conf_file_1 ]; then
-                grep $con_name $str_conf_file_1 >/dev/null 2>/dev/null
-                if [ $? -eq 0 ]; then
-                    $str_conf_file=$str_conf_file_1
-                fi
             fi
         fi
 	    #add extra params

--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -63,6 +63,7 @@ function get_nic_cfg_file_content {
     elif [ $is_debian -eq 1 ]; then
          cfg_file="$nwdir/${cfg_dev}"
     fi
+    #TODO:this is networkmanager_active=2 
     ps -ef|grep -v grep|grep NetworkManager >/dev/null 2>/dev/null
     if [ $? -eq 0 ]; then
         $ip address show dev ${cfg_dev}| $sed -e 's/^/[Ethernet] >> /g' | log_lines info
@@ -562,16 +563,20 @@ function configure_nicdevice {
         #linux bridge type is bridge
         #openvswitch bridge type is bridge_ovs
         elif [ x"$nic_dev_type" = "xbridge_ovs" -o x"$nic_dev_type" = "xbridge" ]; then
-            if [ "$networkmanager_active" = "0" ]; then
-                ps -ef|grep -v grep|grep NetworkManager >/dev/null 2>/dev/null
-                nmcli_used=$?
-                check_brctl $nic_dev_type
-                if [ $? -ne 0 ] && [ $nmcli_used -ne 0 ]; then
-                    errorcode=1
+            ps -ef|grep -v grep|grep NetworkManager >/dev/null 2>/dev/null
+            nmcli_used=$?
+            if [ "$networkmanager_active" != "1" ]; then
+                if [ "$networkmanager_active" = "0" ]; then
+                    check_brctl $nic_dev_type
+                    if [ $? -ne 0 ]; then
+                        errorcode=1
+                    else
+                        create_bridge_interface ifname=$nic_dev _brtype=$nic_dev_type _port=$base_nic_dev _pretype=$base_nic_type
+                    if
                 else
                     create_bridge_interface ifname=$nic_dev _brtype=$nic_dev_type _port=$base_nic_dev _pretype=$base_nic_type
                 fi
-            elif [ "$networkmanager_active" = "1" ]; then
+            else
                 create_bridge_interface_nmcli ifname=$nic_dev _brtype=$nic_dev_type _port=$base_nic_dev _pretype=$base_nic_type _ipaddr=$ipaddrs
             fi
             if [ $? -ne 0 ]; then
@@ -588,9 +593,9 @@ function configure_nicdevice {
                 vlanname=`echo "$nic_dev" | $sed -e 's/^\(.*\)vla\?n\?\([0-9]\+\)$/\1/'`
             fi
             ipaddrs=$(find_nic_ips $nic_dev)
-            if [ "$networkmanager_active" = "0" ]; then
+            if [ "$networkmanager_active" != "1" ]; then
                 create_vlan_interface ifname=$vlanname vlanid=$vlanid
-            elif [ "$networkmanager_active" = "1" ]; then
+            else
                 create_vlan_interface_nmcli ifname=$vlanname vlanid=$vlanid ipaddrs=$ipaddrs next_nic=$is_mid_device
             fi
             if [ $? -ne 0 ]; then
@@ -599,9 +604,9 @@ function configure_nicdevice {
             fi
         #configure bond
         elif [ x"$nic_dev_type" = "xbond" ]; then
-            if [ "$networkmanager_active" = "0" ]; then
+            if [ "$networkmanager_active" != "1" ]; then
                 create_bond_interface ifname=$nic_dev slave_ports=$base_nic_for_bond slave_type=$base_nic_type
-            elif [ "$networkmanager_active" = "1" ]; then
+            else
                 create_bond_interface_nmcli bondname=$nic_dev slave_ports=$base_nic_for_bond slave_type=$base_nic_type _ipaddr=$ipaddrs next_nic=$is_mid_device
             fi
             if [ $? -ne 0 ]; then
@@ -658,13 +663,15 @@ if [ $boot_install_nic -eq 1 ];then
 fi
 
 #check if using NetworkManager or  network service
-networkmanager_active=2
+networkmanager_active=3
 check_NetworkManager_or_network_service
 is_active=$?
 if [ $is_active -eq 0 ]; then
     networkmanager_active=0
 elif [ $is_active -eq 1 ]; then
     networkmanager_active=1
+elif [ $is_active -eq 2 ]; then
+    networkmanager_active=2
 else
     exit 1
 fi

--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -563,8 +563,6 @@ function configure_nicdevice {
         #linux bridge type is bridge
         #openvswitch bridge type is bridge_ovs
         elif [ x"$nic_dev_type" = "xbridge_ovs" -o x"$nic_dev_type" = "xbridge" ]; then
-            ps -ef|grep -v grep|grep NetworkManager >/dev/null 2>/dev/null
-            nmcli_used=$?
             if [ "$networkmanager_active" != "1" ]; then
                 if [ "$networkmanager_active" = "0" ]; then
                     check_brctl $nic_dev_type
@@ -572,7 +570,7 @@ function configure_nicdevice {
                         errorcode=1
                     else
                         create_bridge_interface ifname=$nic_dev _brtype=$nic_dev_type _port=$base_nic_dev _pretype=$base_nic_type
-                    if
+                    fi
                 else
                     create_bridge_interface ifname=$nic_dev _brtype=$nic_dev_type _port=$base_nic_dev _pretype=$base_nic_type
                 fi

--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -63,7 +63,8 @@ function get_nic_cfg_file_content {
     elif [ $is_debian -eq 1 ]; then
          cfg_file="$nwdir/${cfg_dev}"
     fi
-    if [ "$networkmanager_active" = "1" ]; then
+    ps -ef|grep -v grep|grep NetworkManager >/dev/null 2>/dev/null
+    if [ $? -eq 0 ]; then
         $ip address show dev ${cfg_dev}| $sed -e 's/^/[Ethernet] >> /g' | log_lines info
     else
         if [ -f $cfg_file ]; then

--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -563,8 +563,10 @@ function configure_nicdevice {
         #openvswitch bridge type is bridge_ovs
         elif [ x"$nic_dev_type" = "xbridge_ovs" -o x"$nic_dev_type" = "xbridge" ]; then
             if [ "$networkmanager_active" = "0" ]; then
+                ps -ef|grep -v grep|grep NetworkManager >/dev/null 2>/dev/null
+                nmcli_used=$?
                 check_brctl $nic_dev_type
-                if [ $? -ne 0 ]; then
+                if [ $? -ne 0 ] && [ $nmcli_used -ne 0 ]; then
                     errorcode=1
                 else
                     create_bridge_interface ifname=$nic_dev _brtype=$nic_dev_type _port=$base_nic_dev _pretype=$base_nic_type

--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -563,17 +563,15 @@ function configure_nicdevice {
         #linux bridge type is bridge
         #openvswitch bridge type is bridge_ovs
         elif [ x"$nic_dev_type" = "xbridge_ovs" -o x"$nic_dev_type" = "xbridge" ]; then
-            if [ "$networkmanager_active" != "1" ]; then
-                if [ "$networkmanager_active" = "0" ]; then
-                    check_brctl $nic_dev_type
-                    if [ $? -ne 0 ]; then
-                        errorcode=1
-                    else
-                        create_bridge_interface ifname=$nic_dev _brtype=$nic_dev_type _port=$base_nic_dev _pretype=$base_nic_type
-                    fi
+            if [ "$networkmanager_active" = "0" ]; then
+                check_brctl $nic_dev_type
+                if [ $? -ne 0 ]; then
+                    errorcode=1
                 else
                     create_bridge_interface ifname=$nic_dev _brtype=$nic_dev_type _port=$base_nic_dev _pretype=$base_nic_type
                 fi
+            elif [ "$networkmanager_active" = "2" ]; then
+                create_bridge_interface ifname=$nic_dev _brtype=$nic_dev_type _port=$base_nic_dev _pretype=$base_nic_type
             else
                 create_bridge_interface_nmcli ifname=$nic_dev _brtype=$nic_dev_type _port=$base_nic_dev _pretype=$base_nic_type _ipaddr=$ipaddrs
             fi


### PR DESCRIPTION
### The PR is to fix issue 

https://github.ibm.com/xcat2/task_management/issues/48
https://github.com/xcat2/xcat-core/issues/6135
https://github.com/xcat2/xcat-core/pull/6201

### The modification include
1. confignetwork extra params support using nmcli including:
    1. configeth
    2. configure vlan
    3. configure bond
    4. configure bridge
2. configure multiple ipv4 address ethernet NIC support 
3. support confignetwork can run in postscripts RH8

### The UT result
1. configeth:
```
]# lsdef byrh10 -i nicips,nictypes,nicnetworks,nicextraparams
Object name: byrh10
    nicextraparams.ens4=MTU=1333
    nicips.ens4=20.4.41.10|50.4.41.10
    nicnetworks.ens4=20_0_0_0-255_0_0_0|50_0_0_0-255_0_0_0
    nictypes.ens4=Ethernet

# updatenode byrh10 "confignetwork -s"
byrh10: =============updatenode starting====================
byrh10: trying to download postscripts...
byrh10: postscripts downloaded successfully
byrh10: trying to get mypostscript from 10.4.41.9...
byrh10: postscript start..: confignetwork
byrh10: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh10: [I]: configure the install nic ens3.
byrh10: [I]: configeth on byrh10: os type: redhat
byrh10: ens4!MTU=1333
byrh10: Connection 'xcat-install-ens3' (7a8fa7cd-1c04-47d0-aad2-24383da355ad) successfully added.
byrh10: GATEWAY=10.0.0.103
byrh10: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/91)
byrh10: Connection 'ens3-tmp' (aeb71ab6-7477-4d11-aaf4-f927c3794dde) successfully deleted.
byrh10: [I]: [Ethernet] >> 2: ens3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
byrh10: [I]: [Ethernet] >>     link/ether 42:56:0a:04:29:0a brd ff:ff:ff:ff:ff:ff
byrh10: [I]: [Ethernet] >>     inet 10.4.41.10/8 brd 10.255.255.255 scope global noprefixroute ens3
byrh10: [I]: [Ethernet] >>        valid_lft forever preferred_lft forever
byrh10: [I]: [Ethernet] >>     inet6 fe80::c1d5:efe1:f18a:1d16/64 scope link tentative noprefixroute
byrh10: [I]: [Ethernet] >>        valid_lft forever preferred_lft forever
byrh10: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh10: [I]: NetworkManager is active
byrh10: [I]: All valid nics and device list:
byrh10: [I]: ens4
byrh10: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh10: configure nic and its device : ens4
byrh10: [I]: configure ens4
byrh10: [I]: call: configeth ens4 20.4.41.10|50.4.41.10 20_0_0_0-255_0_0_0|50_0_0_0-255_0_0_0
byrh10: [I]: configeth on byrh10: os type: redhat
byrh10: configeth on byrh10: old configuration: 3: ens4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1333 qdisc fq_codel state UP group default qlen 1000
byrh10:     link/ether 42:0d:0a:04:29:0a brd ff:ff:ff:ff:ff:ff
byrh10:     inet 20.4.41.10/8 brd 20.255.255.255 scope global noprefixroute ens4
byrh10:        valid_lft forever preferred_lft forever
byrh10:     inet 50.4.41.10/8 brd 50.255.255.255 scope global noprefixroute ens4
byrh10:        valid_lft forever preferred_lft forever
byrh10:     inet6 fe80::1ccc:edcc:cdad:e66e/64 scope link noprefixroute
byrh10:        valid_lft forever preferred_lft forever
byrh10: ens4!MTU=1333
byrh10: array_nic_params 0=MTU=1333
byrh10: [I]: configeth on byrh10: new configuration
byrh10:        20.4.41.10, 20.0.0.0, 255.0.0.0, <xcatmaster>
byrh10:        50.4.41.10, 50.0.0.0, 255.0.0.0, <xcatmaster>
byrh10: 3: ens4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1333 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
byrh10: ens4
byrh10: [I]: configeth on byrh10: ens4 changed, modify the configuration files
byrh10: ens4
byrh10: Connection 'xcat-ens4' (8ffff7a4-8942-4f37-bfde-3854b3331025) successfully added.
byrh10: bring up ip
byrh10: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/92)
byrh10: Connection 'xcat-ens4-tmp' (dd8a9c3c-0406-4b65-8863-418cf829bbd6) successfully deleted.
byrh10: [I]: [Ethernet] >> 3: ens4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1333 qdisc fq_codel state UP group default qlen 1000
byrh10: [I]: [Ethernet] >>     link/ether 42:0d:0a:04:29:0a brd ff:ff:ff:ff:ff:ff
byrh10: [I]: [Ethernet] >>     inet 20.4.41.10/8 brd 20.255.255.255 scope global noprefixroute ens4
byrh10: [I]: [Ethernet] >>        valid_lft forever preferred_lft forever
byrh10: [I]: [Ethernet] >>     inet 50.4.41.10/8 brd 50.255.255.255 scope global noprefixroute ens4
byrh10: [I]: [Ethernet] >>        valid_lft forever preferred_lft forever
byrh10: [I]: [Ethernet] >>     inet6 fe80::ce12:849d:86b9:7c79/64 scope link tentative noprefixroute
byrh10: [I]: [Ethernet] >>        valid_lft forever preferred_lft forever
byrh10: postscript end....: confignetwork exited with code 0
byrh10: Running of postscripts has completed.
byrh10: =============updatenode ending====================
```
2. configure vlan
```
]# lsdef byrh09 -i nicdevices,nicextraparams,nicips,nicnetworks,nictypes
Object name: byrh09
    nicdevices.ens5.1=ens5
    nicextraparams.ens5.1=MTU=1333
    nicips.ens5.1=50.4.41.151
    nicnetworks.ens5.1=50_0_0_0-255_0_0_0
    nictypes.ens5=ethernet
    nictypes.ens5.1=vlan

[root@c910f04x41 postscripts]# updatenode byrh09 confignetwork
byrh09: =============updatenode starting====================
byrh09: trying to download postscripts...
byrh09: postscripts downloaded successfully
byrh09: trying to get mypostscript from 10.4.41.1...
byrh09: postscript start..: confignetwork
byrh09: [I]: NetworkManager is active
byrh09: [I]: All valid nics and device list:
byrh09: [I]: ens5.1 ens5
byrh09: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh09: configure nic and its device : ens5.1 ens5
byrh09: [I]: create_vlan_interface_nmcli ifname=ens5 vlanid=1 ipaddrs=50.4.41.151 next_nic=
byrh09: [I]: Pickup xcatnet, "50_0_0_0-255_0_0_0", from NICNETWORKS for interface "ens5".
byrh09: [I]: check parent interface ens5 whether it is managed by NetworkManager
byrh09: Connection 'xcat-vlan-ens5.1' (a3ae4201-882a-4ac2-ac26-9139972f1f69) successfully added.
byrh09: [I]: create NetworkManager connection for ens5.1
byrh09: ens5.1!MTU=1333
byrh09: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/17)
byrh09: [I]: [vlan] >> 297: ens5.1@ens5: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1333 qdisc noqueue state UP group default qlen 1000
byrh09: [I]: [vlan] >>     link/ether 42:9b:0a:04:29:09 brd ff:ff:ff:ff:ff:ff
byrh09: [I]: [vlan] >>     inet 50.4.41.151/8 brd 50.255.255.255 scope global noprefixroute ens5.1
byrh09: [I]: [vlan] >>        valid_lft forever preferred_lft forever
byrh09: [I]: [vlan] >>     inet6 fe80::9764:7e5b:e92e:68fd/64 scope link tentative noprefixroute
byrh09: [I]: [vlan] >>        valid_lft forever preferred_lft forever
byrh09: postscript end....: confignetwork exited with code 0
byrh09: Running of postscripts has completed.
byrh09: =============updatenode ending====================
```
3. configure bridge
```
]# lsdef byrh09 -i nicdevices,nicextraparams,nicips,nicnetworks,nictypes
Object name: byrh09
    nicdevices.br51=ens5.1
    nicdevices.ens5.1=ens5
    nicextraparams.br51=MTU=1333
    nicips.br51=50.4.41.151
    nicnetworks.br51=50_0_0_0-255_0_0_0
    nictypes.br51=bridge
    nictypes.ens5=ethernet
    nictypes.ens5.1=vlan

]# updatenode byrh09 confignetwork
byrh09: =============updatenode starting====================
byrh09: trying to download postscripts...
byrh09: postscripts downloaded successfully
byrh09: trying to get mypostscript from 10.4.41.1...
byrh09: postscript start..: confignetwork
byrh09: [I]: NetworkManager is active
byrh09: [I]: All valid nics and device list:
byrh09: [I]: ens5.1 ens5
byrh09: [I]: br51 ens5.1
byrh09: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh09: configure nic and its device : ens5.1 ens5
byrh09: [I]: create_vlan_interface_nmcli ifname=ens5 vlanid=1 ipaddrs= next_nic=br51
byrh09: [I]: check parent interface ens5 whether it is managed by NetworkManager
byrh09: Connection 'xcat-vlan-ens5.1' (481f2f90-8f6a-4575-af2f-6a20da04a8cd) successfully added.
byrh09: [I]: create NetworkManager connection for ens5.1
byrh09: br51!MTU=1333
byrh09: Connection 'xcat-vlan-ens5.1-tmp' (0b5d482a-ec17-43f0-bfc6-ec630516d707) successfully deleted.
byrh09: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh09: configure nic and its device : br51 ens5.1
byrh09: [I]: create_bridge_interface_nmcli ifname=br51 _brtype=bridge _port=ens5.1 _pretype=vlan _ipaddr=50.4.41.151
byrh09: [I]: Pickup xcatnet, "50_0_0_0-255_0_0_0", from NICNETWORKS for interface "br51".
byrh09: [I]: xcat-bridge-br51 exists, down it first
byrh09: Connection 'xcat-bridge-br51' successfully deactivated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/10)
byrh09: Cannot find device "br51"
byrh09: [I]: xcat-bridge-br51 exists, rename old xcat-bridge-br51 to xcat-bridge-br51-tmp
byrh09: [I]: create bridge connection xcat-bridge-br51
byrh09: [I]: nmcli con add type bridge con-name xcat-bridge-br51 ifname br51 connection.autoconnect-priority 9
byrh09: Connection 'xcat-bridge-br51' (44f36427-39ad-4ff1-9707-f06a31669212) successfully added.
byrh09: [I]: create vlan slaves connetcion xcat-vlan-ens5.1 for bridge
byrh09: [I]: nmcli con mod xcat-vlan-ens5.1 master br51  connection.autoconnect-priority 9
byrh09: [I]: add ip 50.4.41.151/8 to bridge
byrh09: br51!MTU=1333
byrh09: [I]: nmcli con up xcat-bridge-br51
byrh09: Connection successfully activated (master waiting for slaves) (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/14)
byrh09: [I]: nmcli con up xcat-vlan-ens5.1
byrh09: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/15)
byrh09: Connection 'xcat-bridge-br51-tmp' (94c6c720-091d-4495-ace3-34ed05ba63d2) successfully deleted.
byrh09: [I]: State of "br51" was "UNKNOWN" instead of expected "UP". Wait 0 of 20 with interval 40.
byrh09: [I]: [bridge] >> 295: br51: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1333 qdisc noqueue state UP group default qlen 1000
byrh09: [I]: [bridge] >>     link/ether 42:9b:0a:04:29:09 brd ff:ff:ff:ff:ff:ff
byrh09: [I]: [bridge] >>     inet 50.4.41.151/8 brd 50.255.255.255 scope global noprefixroute br51
byrh09: [I]: [bridge] >>        valid_lft forever preferred_lft forever
byrh09: [I]: [bridge] >>     inet6 fe80::74c1:e355:7987:b4df/64 scope link noprefixroute
byrh09: [I]: [bridge] >>        valid_lft forever preferred_lft forever
byrh09: postscript end....: confignetwork exited with code 0
byrh09: Running of postscripts has completed.
byrh09: =============updatenode ending====================
```

5. configure bond ---->valid extra params
```
]# lsdef byrh09 -i nicdevices,nicextraparams,nicips,nicnetworks,nictypes
Object name: byrh09
    nicdevices.bond5=ens4|ens5
    nicextraparams.bond5=MTU=1422
    nicips.bond5=50.4.41.151
    nicnetworks.bond5=50_0_0_0-255_0_0_0
    nictypes.ens5=ethernet
    nictypes.ens4=ethernet
    nictypes.bond5=bond

]# updatenode byrh09 confignetwork
byrh09: =============updatenode starting====================
byrh09: trying to download postscripts...
byrh09: postscripts downloaded successfully
byrh09: trying to get mypostscript from 10.4.41.1...
byrh09: postscript start..: confignetwork
byrh09: [I]: NetworkManager is active
byrh09: [I]: All valid nics and device list:
byrh09: [I]: bond5 ens4@ens5
byrh09: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh09: configure nic and its device : bond5 ens4@ens5
byrh09: [I]: create_bond_interface_nmcli bondname=bond5 slave_ports=ens4,ens5 slave_type=ethernet _ipaddr=50.4.41.151 next_nic=
byrh09: [I]: Pickup xcatnet, "50_0_0_0-255_0_0_0", from NICNETWORKS for interface "bond5".
byrh09: [I]: create bond connection xcat-bond-bond5
byrh09: [I]: nmcli con add type bond con-name xcat-bond-bond5 ifname bond5 bond.options mode=802.3ad,miimon=100 method none ipv4.method manual ipv4.addresses 50.4.41.151/8 connection.autoconnect-priority 9
byrh09: Connection 'xcat-bond-bond5' (b722ef71-a739-4b49-8f43-8692973283b3) successfully added.
byrh09: Connection 'ens4' successfully deactivated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/2)
byrh09:
byrh09: (process:26007): GLib-GIO-WARNING **: 04:29:55.260: gdbusobjectmanagerclient.c:1589: Processing InterfaceRemoved signal for path /org/freedesktop/NetworkManager/Settings/5 but no object proxy exists
byrh09: [I]: nmcli con add type Ethernet con-name xcat-bond-slave-ens4 method none ifname ens4 master xcat-bond-bond5 autoconnect yes connection.autoconnect-priority 9
byrh09: Connection 'xcat-bond-slave-ens4' (fb5bfc34-1e3c-49cc-8ebd-9c826d54588d) successfully added.
byrh09: [I]: nmcli con up xcat-bond-slave-ens4
byrh09: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/25)
byrh09: [I]: nmcli con add type Ethernet con-name xcat-bond-slave-ens5 method none ifname ens5 master xcat-bond-bond5 autoconnect yes connection.autoconnect-priority 9
byrh09: Connection 'xcat-bond-slave-ens5' (2da08a44-848e-45e8-831e-7bce9c78b6e2) successfully added.
byrh09: [I]: nmcli con up xcat-bond-slave-ens5
byrh09: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/27)
byrh09: bond5!MTU=1422
byrh09: [I]: nmcli con up xcat-bond-bond5
byrh09: Connection successfully activated (master waiting for slaves) (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/28)
byrh09: [I]: State of "bond5" was "DOWN" instead of expected "UP". Wait 0 of 20 with interval 10.
byrh09: [I]: [bond] >> 299: bond5: <BROADCAST,MULTICAST,MASTER,UP,LOWER_UP> mtu 1422 qdisc noqueue state UP group default qlen 1000
byrh09: [I]: [bond] >>     link/ether 42:20:0a:04:29:09 brd ff:ff:ff:ff:ff:ff
byrh09: [I]: [bond] >>     inet 50.4.41.151/8 brd 50.255.255.255 scope global noprefixroute bond5
byrh09: [I]: [bond] >>        valid_lft forever preferred_lft forever
byrh09: [I]: [bond] >>     inet6 fe80::77a7:4d81:b01f:abed/64 scope link noprefixroute
byrh09: [I]: [bond] >>        valid_lft forever preferred_lft forever
byrh09: postscript end....: confignetwork exited with code 0
byrh09: Running of postscripts has completed.
byrh09: =============updatenode ending====================



]# xdsh byrh10 "nmcli -g 802-3-ethernet.mtu con show xcat-bond-bond1"
byrh10: 1422
```
