### PR TITLE
Handle openbmc login and rflash errors

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -314,8 +314,12 @@ class OpenBMCRest(object):
 
     def handle_response (self, resp, cmd=''):
 
-        data = resp.json() # it will raise ValueError
         code = resp.status_code
+        if code == requests.codes.bad_gateway:
+            error = "(Verify REST server is running on the BMC)"
+            self._print_error_log(error, cmd)
+            raise SelfServerException(code, error, host_and_port=self.bmcip)
+        data = resp.json() # it will raise ValueError
         if code != requests.codes.ok:
             description = ''.join(data['data']['description'])
             error = '[%d] %s' % (code, description)


### PR DESCRIPTION
### The PR is to fix issue _#6173_

### The modification include

* Better message suggesting to run `reventlog` if Host does not power on after `rflash -d` command

* Better message suggesting to verify REST server is running if 502 code returned from login attempt

### The UT result
Python with debug
```
[root@briggs01 xcat]# rpower mid05tor12cn03 stat -V
[briggs01]: Running command in Python
[briggs01]: Wed Apr  3 15:58:44 2019 mid05tor12cn03: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://172.11.139.3/login -d '{"data": ["root", "xxxxxx"]}'
[briggs01]: Wed Apr  3 15:58:45 2019 mid05tor12cn03: [openbmc_debug] login (Verify REST server is running on the BMC)
[briggs01]: Wed Apr  3 15:58:45 2019 mid05tor12cn03: [openbmc_debug] login Login to BMC failed: Can't connect to 172.11.139.3 (Verify REST server is running on the BMC).
mid05tor12cn03: [briggs01]: Error: Login to BMC failed: Can't connect to 172.11.139.3 (Verify REST server is running on the BMC).
[root@briggs01 xcat]#
```

Python no debug
```
[root@briggs01 xcat]# rpower mid05tor12cn03 stat -V
[briggs01]: Running command in Python
mid05tor12cn03: [briggs01]: Error: Login to BMC failed: Can't connect to 172.11.139.3 (Verify REST server is running on the BMC).
[root@briggs01 xcat]#
```
Perl with debug
```
[root@briggs01 xcat]# rpower mid05tor12cn03 stat -V
Wed Apr  3 16:08:04 2019 OpenBMC: [briggs01]: [openbmc_debug_perl]
[briggs01]: Running command in Perl
mid05tor12cn03: [briggs01]: Error: [502] Login to BMC failed: 502 Bad Gateway. Verify REST server is running on the BMC.
mid05tor12cn03: [briggs01]: Error: BMC did not respond. Validate BMC configuration and retry the command.
[root@briggs01 xcat]#
```

Perl no debug
```
[root@briggs01 xcat]# rpower mid05tor12cn03 stat -V
[briggs01]: Running command in Perl
mid05tor12cn03: [briggs01]: Error: [502] Login to BMC failed: 502 Bad Gateway. Verify REST server is running on the BMC.
mid05tor12cn03: [briggs01]: Error: BMC did not respond. Validate BMC configuration and retry the command.
[root@briggs01 xcat]#
```