### PR TITLE
Add server name to rspconfig dump output

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc/openbmc_bmcconfig.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc/openbmc_bmcconfig.py
@@ -49,8 +49,9 @@ class OpenBMCBmcConfigTask(ParallelNodesCommand):
 
         formatted_time = time.strftime("%Y%m%d-%H%M", time.localtime(time.time()))
         dump_log_file = '%s%s_%s_dump_%s.tar.xz' % (XCAT_LOG_DUMP_DIR, formatted_time, node, download_id)
+        host_name = os.uname()[1].split('.', 1)[0]
         if flag_dump_process:
-            self.callback.info('%s: Downloading dump %s to %s' % (node, download_id, dump_log_file))
+            self.callback.info('%s: Downloading dump %s to %s:%s' % (node, download_id, host_name, dump_log_file))
 
         obmc.download_dump(download_id, dump_log_file)
         if os.path.exists(dump_log_file):
@@ -61,7 +62,7 @@ class OpenBMCBmcConfigTask(ParallelNodesCommand):
             if grep_string:
                 self.callback.error('Invalid dump %s was specified. Use -l option to list.' % download_id, node)
             else:
-                self.callback.info('%s: Downloaded dump %s to %s.' % (node, download_id, dump_log_file))
+                self.callback.info('%s: Downloaded dump %s to %s:%s.' % (node, download_id, host_name, dump_log_file))
         else:
             self.callback.error('Failed to download dump %s to %s.' % (download_id, dump_log_file), node)
         return

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -4198,7 +4198,7 @@ sub dump_download_process {
     }
     if ($h->{message} eq $::RESPONSE_OK) {
         my $host_name = hostname();
-        xCAT::SvrUtils::sendmsg("Downloading dump $dump_id to $host_name:$file_name", $callback, $node);
+        xCAT::MsgUtils->message("I", { data => ["$node: Downloading dump $dump_id to $host_name:$file_name"] }, $callback);
         my $curl_dwld_result = `$curl_dwld_cmd -s`;
         if (!$curl_dwld_result) {
             if ($xcatdebugmode) {
@@ -4217,7 +4217,7 @@ sub dump_download_process {
                     # Remove downloaded file, nothing useful inside of it
                     unlink $file_name;
                 } else {
-                    xCAT::SvrUtils::sendmsg("Downloaded dump $dump_id to $host_name:$file_name", $callback, $node) if ($::VERBOSE);
+                    xCAT::MsgUtils->message("I", { data => ["$node: Downloaded dump $dump_id to $host_name:$file_name"] }, $callback) if ($::VERBOSE);
                 }
             }
             else {

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -19,6 +19,7 @@ use JSON;
 use HTTP::Async;
 use HTTP::Cookies;
 use LWP::UserAgent;
+use Net::Domain qw(hostname);
 use File::Basename;
 use File::Spec;
 use File::Copy qw/copy cp mv move/;
@@ -4196,7 +4197,8 @@ sub dump_download_process {
         return 1;
     }
     if ($h->{message} eq $::RESPONSE_OK) {
-        xCAT::SvrUtils::sendmsg("Downloading dump $dump_id to $file_name", $callback, $node);
+        my $host_name = hostname();
+        xCAT::SvrUtils::sendmsg("Downloading dump $dump_id to $host_name:$file_name", $callback, $node);
         my $curl_dwld_result = `$curl_dwld_cmd -s`;
         if (!$curl_dwld_result) {
             if ($xcatdebugmode) {
@@ -4215,7 +4217,7 @@ sub dump_download_process {
                     # Remove downloaded file, nothing useful inside of it
                     unlink $file_name;
                 } else {
-                    xCAT::SvrUtils::sendmsg("Downloaded dump $dump_id to $file_name", $callback, $node) if ($::VERBOSE);
+                    xCAT::SvrUtils::sendmsg("Downloaded dump $dump_id to $host_name:$file_name", $callback, $node) if ($::VERBOSE);
                 }
             }
             else {

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -19,7 +19,7 @@ use JSON;
 use HTTP::Async;
 use HTTP::Cookies;
 use LWP::UserAgent;
-use Net::Domain qw(hostname);
+use Sys::Hostname;
 use File::Basename;
 use File::Spec;
 use File::Copy qw/copy cp mv move/;
@@ -4197,8 +4197,8 @@ sub dump_download_process {
         return 1;
     }
     if ($h->{message} eq $::RESPONSE_OK) {
-        my $host_name = hostname();
-        xCAT::MsgUtils->message("I", { data => ["$node: Downloading dump $dump_id to $host_name:$file_name"] }, $callback);
+        my @host_name = split(/\./, hostname());
+        xCAT::MsgUtils->message("I", { data => ["$node: Downloading dump $dump_id to $host_name[0]:$file_name"] }, $callback);
         my $curl_dwld_result = `$curl_dwld_cmd -s`;
         if (!$curl_dwld_result) {
             if ($xcatdebugmode) {
@@ -4217,7 +4217,7 @@ sub dump_download_process {
                     # Remove downloaded file, nothing useful inside of it
                     unlink $file_name;
                 } else {
-                    xCAT::MsgUtils->message("I", { data => ["$node: Downloaded dump $dump_id to $host_name:$file_name"] }, $callback) if ($::VERBOSE);
+                    xCAT::MsgUtils->message("I", { data => ["$node: Downloaded dump $dump_id to $host_name[0]:$file_name"] }, $callback) if ($::VERBOSE);
                 }
             }
             else {


### PR DESCRIPTION
### The PR is to fix issue _#5290_

This pull request adds a hostname to the output of `rspconfig dump` command to indicate which host the dump is stored on.

Perl, MN to CN:
```
[root@boston02 xcat]# rspconfig sn02 dump -d 1 -V
[boston02]: Running command in Perl
sn02: [boston02]: Downloading dump 1 to boston02: /var/log/xcat/dump/20190408-1508_sn02_dump_1.tar.xz
sn02: [boston02]: Downloaded dump 1 to boston02: /var/log/xcat/dump/20190408-1508_sn02_dump_1.tar.xz
[root@boston02 xcat]#
```

Python MN to CN:
```
[root@boston02 xcat]# rspconfig sn02 dump -d 1 -V
[boston02]: Running command in Python
[boston02]: sn02: Downloaded dump 1 to boston02:/var/log/xcat/dump/20190408-1507_sn02_dump_1.tar.xz.
[root@boston02 xcat]#
```

Perl, MN to SN to CN:
```
[root@boston02 xcat]# rspconfig mid08tor03cn01 dump -d 12 -V
[sn02]: Running command in Perl
mid08tor03cn01: [sn02]: Downloading dump 12 to sn02: /var/log/xcat/dump/20190408-1509_mid08tor03cn01_dump_12.tar.xz
mid08tor03cn01: [sn02]: Downloaded dump 12 to sn02: /var/log/xcat/dump/20190408-1509_mid08tor03cn01_dump_12.tar.xz
[root@boston02 xcat]#
```
Python, MN to SN to CN:
```
[root@boston02 xcat]# rspconfig mid08tor03cn01 dump -d 12 -V
[boston02]: Running command in Python
[sn02]: mid08tor03cn01: Downloaded dump 12 to sn02:/var/log/xcat/dump/20190408-1507_mid08tor03cn01_dump_12.tar.xz.
[root@boston02 xcat]#
```