### PR TITLE
configib support nmcli

### DIFF
--- a/xCAT/postscripts/configib
+++ b/xCAT/postscripts/configib
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash  
 # IBM(c) 2013 EPL license http://www.eclipse.org/legal/epl-v10.html
 # Internal script used by confignics only
 # xCAT post script for configuring ib adapters.
@@ -27,6 +27,16 @@ if [ -n "$LOGLABEL" ]; then
     log_label=$LOGLABEL
 else
     log_label="xcat"
+fi
+
+########################################################################
+# nmcli_used=0: use network.service
+# nmcli_used=1: use NetworkManager
+########################################################################
+nmcli_used=0
+ps -ef|grep -v grep|grep NetworkManager >/dev/null 2>/dev/null
+if [ $? -eq 0 ]; then
+    nmcli_used=1
 fi
 
 #This is the number of ports for each ib adpator.
@@ -461,11 +471,20 @@ IPADDR_$ipindex=$nicip" >> $dir/ifcfg-$nic
                # First ip address
                if [ $ipindex -eq 1 ]
                then
+                   nmcontrol=""
+                   devtype=""
+                   if [ $nmcli_used -eq 0 ]; then
+                        nmcontrol="NM_CONTROLLED=no"
+                   else
+                        devtype="TYPE=InfiniBand"
+                   fi
                    # Write the info to the ifcfg file
                    echo "DEVICE=$nic
-NM_CONTROLLED=no
+$nmcontrol
+$devtype
 BOOTPROTO=none
 ONBOOT=yes
+NAME=$nic
 IPADDR=$nicip" > $dir/ifcfg-$nic
                     # ipv6
                     if echo $nicip | grep : 2>&1 1>/dev/null
@@ -514,11 +533,25 @@ IPV6ADDR=$nicip/$netmask" >> $dir/ifcfg-$nic
                            echo "IPV6_DEFAULTGW=$gateway" >> $dir/ifcfg-$nic
                        fi
                     else # ipv4 address
-                        echo "DEVICE=$nic:$ipindex
+                        cfgfile=$dir"/ifcfg-"$nic
+                        if [ $nmcli_used -eq 0 ]; then
+                            cfgfile=$dir"/ifcfg-"$nic":"$ipindex
+                            cfgcontent= "DEVICE=$nic:$ipindex
 NM_CONTROLLED=no
 BOOTPROTO=none
 ONBOOT=yes
-IPADDR=$nicip" > $dir/ifcfg-$nic:$ipindex
+NETMASK=$netmask
+IPADDR=$nicip
+DEVICE=$nic:$ipindex"
+                        else
+                            cfgcontent="NETMASK$ipindex=$netmask
+IPADDR$ipindex=$nicip"
+                        fi
+                        if [ $nmcli_used -eq 0 ]; then
+                            echo "$cfgcontent" > $cfgfile
+                        else           
+                            echo "$cfgcontent" >> $cfgfile
+                        fi
                         if [[ "$OSVER" == rhels6* ]]
                         then
                             #get prefix from netmask, this is for IPv4 only
@@ -526,11 +559,15 @@ IPADDR=$nicip" > $dir/ifcfg-$nic:$ipindex
                             prefix=$(convert_netmask_to_cidr $netmask)
                             echo "PREFIX=$prefix" >> $dir/ifcfg-$nic:$ipindex
                         else
-                            echo "NETMASK=$netmask" >> $dir/ifcfg-$nic:$ipindex
+                            echo "$nicnetmask" >> $cfgfile
                         fi
 
                         if [ -n "$gateway" ]; then
-                           echo "GATEWAY=$gateway" >> $dir/ifcfg-$nic:$ipindex
+                            if [ $nmcli_used -eq 0 ]; then 
+                                echo "GATEWAY=$gateway" >> $cfgfile
+                            else
+                                echo "GATEWAY$ipindex=$gateway" >> $cfgfile
+                            fi
                         fi
 
 						#add extra params
@@ -540,12 +577,14 @@ IPADDR=$nicip" > $dir/ifcfg-$nic:$ipindex
 							name="${array_extra_param_names[$i]}"
 							value="${array_extra_param_values[$i]}"
 							echo "  $i: name=$name value=$value"
-							echo "${name}=${value}" >> $dir/ifcfg-$nic:$ipindex
+							echo "${name}=${value}" >> $cfgfile
 							i=$((i+1))
 						done		
 
                         # need to run ifup eth1:1 for RedHat
-                        goodnics="$goodnics,$nic:$ipindex"
+                        if [ $nmcli_used -eq 0 ]; then
+                            goodnics="$goodnics,$nic:$ipindex"
+                        fi
                     fi
                 fi # end not the first ip address
             elif [ $OS_name == 'ubuntu' ]
@@ -705,8 +744,13 @@ then
                     sleep 2
                     ifup   $tmp > /dev/null 2>&1
                 done
-            else
-                ifup $nic > /dev/null 2>&1
+            else 
+                if [ $nmcli_used -eq 1 ]; then
+                    nmcli con reload $dir/ifcfg-$nic
+                    nmcli con up $nic 2>&1
+                else
+                    ifup $nic > /dev/null 2>&1
+                fi
             fi
         fi
     done

--- a/xCAT/postscripts/configib
+++ b/xCAT/postscripts/configib
@@ -553,7 +553,7 @@ IPADDR$ipindex=$nicip"
                             #get prefix from netmask, this is for IPv4 only
                             prefix=24
                             prefix=$(convert_netmask_to_cidr $netmask)
-                            echo "PREFIX=$prefix" >> $dir/ifcfg-$nic:$ipindex
+                            echo "PREFIX=$prefix" >> $cfgfile
                         else
                             echo "$nicnetmask" >> $cfgfile
                         fi

--- a/xCAT/postscripts/configib
+++ b/xCAT/postscripts/configib
@@ -533,7 +533,6 @@ IPV6ADDR=$nicip/$netmask" >> $dir/ifcfg-$nic
                            echo "IPV6_DEFAULTGW=$gateway" >> $dir/ifcfg-$nic
                        fi
                     else # ipv4 address
-                        cfgfile=$dir"/ifcfg-"$nic
                         if [ $nmcli_used -eq 0 ]; then
                             cfgfile=$dir"/ifcfg-"$nic":"$ipindex
                             cfgcontent= "DEVICE=$nic:$ipindex
@@ -541,15 +540,12 @@ NM_CONTROLLED=no
 BOOTPROTO=none
 ONBOOT=yes
 NETMASK=$netmask
-IPADDR=$nicip
-DEVICE=$nic:$ipindex"
+IPADDR=$nicip"
+                            echo "$cfgcontent" > $cfgfile
                         else
+                            cfgfile=$dir"/ifcfg-"$nic
                             cfgcontent="NETMASK$ipindex=$netmask
 IPADDR$ipindex=$nicip"
-                        fi
-                        if [ $nmcli_used -eq 0 ]; then
-                            echo "$cfgcontent" > $cfgfile
-                        else           
                             echo "$cfgcontent" >> $cfgfile
                         fi
                         if [[ "$OSVER" == rhels6* ]]

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -1580,7 +1580,8 @@ function decode_arguments {
 ###############################################################################
 #
 # check NetworkManager
-# output: 2 error
+# output: 3 error
+#         2 using NetworkManager but service(systemctl) can not used, this happens in RH8 postscripts
 #         1 using NetworkManager
 #         0 using network
 #
@@ -1601,7 +1602,7 @@ function check_NetworkManager_or_network_service() {
     #In RH8 postscripts stage, nmcli can not modify persistent configure file
     ps -ef|grep -v grep|grep NetworkManager >/dev/null 2>/dev/null
     if [ $? -eq 0 ]; then
-        return 0
+        return 2
     fi
     checkservicestatus network > /dev/null 2>/dev/null || checkservicestatus wicked > /dev/null 2>/dev/null
     if [ $? -eq 0 ]; then

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -1595,12 +1595,13 @@ function check_NetworkManager_or_network_service() {
         if [ $? -ne 0 ]; then
             log_error "There is no nmcli"
         else
-            stopservice network | log_lines info
-            disableservice network | log_lines info
-            stopservice networking | log_lines info
-            disableservice networking | log_lines info
             return 1
         fi
+    fi
+    #In RH8 postscripts stage, nmcli can not modify persistent configure file
+    ps -ef|grep -v grep|grep NetworkManager >/dev/null 2>/dev/null
+    if [ $? -eq 0 ]; then
+        return 0
     fi
     checkservicestatus network > /dev/null 2>/dev/null || checkservicestatus wicked > /dev/null 2>/dev/null
     if [ $? -eq 0 ]; then


### PR DESCRIPTION
### The PR is to fix issue 
https://github.ibm.com/xcat2/task_management/issues/47

### The modification include
1. nicutils.sh : in RH8 postscripts stage, NetworkManager is active, but nmcli cannot modify NIC configure  files, so manually create IB NIC configure file
2. In RH7.6, if stop network service, NetworkManager cannot work well, in RH8, there is no network service, so delete stop network service code.
3. configib: 
    a. multiple IB IPV4 IP configure support
    b. nmcli use customized IB NIC configure file 

### The UT result
1. I did UT in both diskful postscripts and diskless postbootscripts.
2. `updatenode` UT results:
```
]# updatenode mid21tor24cn06 -P "confignetwork --ibaports=2"
mid21tor24cn06: =============updatenode starting====================
mid21tor24cn06: trying to download postscripts...
mid21tor24cn06: postscripts downloaded successfully
mid21tor24cn06: trying to get mypostscript from 172.16.253.100...
mid21tor24cn06: postscript start..: confignetwork
mid21tor24cn06: [I]: NetworkManager is active
mid21tor24cn06: [I]: All valid nics and device list:
mid21tor24cn06: [I]: ib0,ib1
mid21tor24cn06: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
mid21tor24cn06: configure nic and its device : ib0,ib1
mid21tor24cn06: [I]: Call configib for IB nics: ib0,ib1, ports: 2
mid21tor24cn06: [I]: NIC_IBNICS=ib0,ib1 NIC_IBAPORTS=2 configib
mid21tor24cn06: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/48)
mid21tor24cn06: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/49)
mid21tor24cn06: postscript end....: confignetwork exited with code 0
mid21tor24cn06: Running of postscripts has completed.
mid21tor24cn06: =============updatenode ending====================

]# xdsh mid21tor24cn06 "ip a"
... ...
6: ib0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 65520 qdisc pfifo_fast state UP group default qlen 256
    link/infiniband 80:00:00:2c:fe:80:00:00:00:00:00:00:f4:52:14:03:00:27:35:d0 brd 00:ff:ff:ff:ff:12:40:1b:ff:ff:00:00:00:00:00:00:ff:ff:ff:ff
    inet 192.168.24.66/24 brd 192.168.24.255 scope global ib0
       valid_lft forever preferred_lft forever
    inet 192.168.24.16/24 brd 192.168.24.255 scope global secondary ib0
       valid_lft forever preferred_lft forever
    inet6 fe80::f652:1403:27:35d0/64 scope link
       valid_lft forever preferred_lft forever
7: ib1: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 65520 qdisc pfifo_fast state DOWN group default qlen 256
    link/infiniband 80:00:00:2e:fe:80:00:00:00:00:00:00:f4:52:14:03:00:27:35:d8 brd 00:ff:ff:ff:ff:12:40:1b:ff:ff:00:00:00:00:00:00:ff:ff:ff:ff
    inet 192.168.25.66/24 brd 192.168.25.255 scope global ib1
       valid_lft forever preferred_lft forever

]#tabdump nics
"mid21tor24cn06","ib0!192.168.24.66|192.168.24.16,ib1!192.168.25.66",,,"ib0!Infiniband,ib1!Infiniband",,"ib0!ibnet|ibnet,ib1!ibnet2",,,,,,
```