### PR TITLE
replace makeconserver by makegocons

### DIFF
--- a/xCAT-test/autotest/testcase/migration/sles_migration
+++ b/xCAT-test/autotest/testcase/migration/sles_migration
@@ -14,11 +14,9 @@ cmd:makedns -n
 check:rc==0
 cmd:service named restart
 check:rc==0
-cmd:makeconservercf $$CN
+cmd:if [ -x /usr/bin/goconserver ]; then makegocons $$CN; else makeconservercf $$CN; fi
 check:rc==0
-cmd:cat /etc/conserver.cf | grep $$CN
-check:output=~$$CN
-cmd:sleep 60
+cmd:sleep 20
 cmd:if [ "__GETNODEATTR($$CN,arch)__" = "ppc64" -a  "__GETNODEATTR($$CN,mgt)__" != "ipmi" ]; then getmacs -D $$CN; fi
 check:rc==0
 cmd:makedhcp -n
@@ -112,6 +110,7 @@ cmd:xdsh $$CN "noderm node0001"
 check:rc==0
 cmd:latest_version_info=`lsxcatd -v`;xdsh $$CN "lsxcatd -v" | grep "$latest_version_info"
 check:rc==0
+cmd:if [ -x /usr/bin/goconserver ]; then makegocons -d $$CN; else makeconservercf -d $$CN; fi
 cmd:if [[ -f /tmp/servicelabel ]];then chdef $$SN -p groups=service;rm -rf /tmp/servicelabel;fi
 check:rc==0
 cmd:if [[ -f /tmp/poweroffsn ]];then rpower $$SN on > /dev/null;rm -rf /tmp/poweroffsn;fi
@@ -122,7 +121,6 @@ start:sles_migration2
 os:Linux
 description:update xCAT from $$MIGRATION22VERSION to latest version, these two global parameter defined in config file
 label:others,migration,invoke_provision
-
 cmd:if ping -c 1 $$SN > /dev/null;then rpower $$SN off > /dev/null;echo "poweroffsn">/tmp/poweroffsn;fi
 check:rc==0
 cmd:if [[ "__GETNODEATTR($$SN,groups)__" =~ "service" ]];then chdef $$SN -m groups=service;echo "servicelabel" >/tmp/servicelabel;fi
@@ -135,11 +133,9 @@ cmd:makedns -n
 check:rc==0
 cmd:service named restart
 check:rc==0
-cmd:makeconservercf $$CN
+cmd:if [ -x /usr/bin/goconserver ]; then makegocons $$CN; else makeconservercf $$CN; fi
 check:rc==0
-cmd:cat /etc/conserver.cf | grep $$CN
-check:output=~$$CN
-cmd:sleep 60
+cmd:sleep 20
 cmd:if [ "__GETNODEATTR($$CN,arch)__" = "ppc64" -a  "__GETNODEATTR($$CN,mgt)__" != "ipmi" ]; then getmacs -D $$CN; fi
 check:rc==0
 cmd:makedhcp -n
@@ -233,6 +229,7 @@ cmd:xdsh $$CN "noderm node0001"
 check:rc==0
 cmd:latest_version_info=`lsxcatd -v`;xdsh $$CN "lsxcatd -v" | grep "$latest_version_info"
 check:rc==0
+cmd:if [ -x /usr/bin/goconserver ]; then makegocons -d $$CN; else makeconservercf -d $$CN; fi
 cmd:if [[ -f /tmp/servicelabel ]];then chdef $$SN -p groups=service;rm -rf /tmp/servicelabel;fi
 check:rc==0
 cmd:if [[ -f /tmp/poweroffsn ]];then rpower $$SN on > /dev/null;rm -rf /tmp/poweroffsn;fi

--- a/xCAT-test/autotest/testcase/migration/ubuntu_migration1_p8le
+++ b/xCAT-test/autotest/testcase/migration/ubuntu_migration1_p8le
@@ -2,7 +2,6 @@ start:ubuntu_migration1_p8le
 os:Linux
 description:update xCAT from $$UBUNTU_MIGRATION1_VERSION to latest version, these two global parameter defined in config file
 label:others,migration,invoke_provision
-
 cmd:copycds $$ISO
 check:rc==0
 cmd:if [[ "__GETNODEATTR($$CN,os)__" =~ "ubuntu" ]];then mkdir /tmp/iso; mount -o loop $$MINIISO /tmp/iso ;  mkdir -p  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot; cp  /tmp/iso/install/initrd.gz  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot;umount /tmp/iso; rmdir /tmp/iso; fi
@@ -13,10 +12,8 @@ cmd:makedhcp -a
 check:rc==0
 cmd:makedns -n
 check:rc==0
-cmd:makeconservercf $$CN
+cmd:if [ -x /usr/bin/goconserver ]; then makegocons $$CN; else makeconservercf $$CN; fi
 check:rc==0
-cmd:cat /etc/conserver.cf | grep $$CN
-check:output=~$$CN
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
@@ -117,6 +114,6 @@ cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;lsdef"
 check:output!~node0001
 cmd:xdsh $$CN "diff /oldxcat/old_version /newxcat/new_version"
 check:rc!=0
-
+cmd:if [ -x /usr/bin/goconserver ]; then makegocons -d $$CN; else makeconservercf -d $$CN; fi
 end
 

--- a/xCAT-test/autotest/testcase/migration/ubuntu_migration1_vm
+++ b/xCAT-test/autotest/testcase/migration/ubuntu_migration1_vm
@@ -2,7 +2,6 @@ start:ubuntu_migration1_vm
 os:Linux
 description:update xCAT from $$UBUNTU_MIGRATION1_VERSION to latest version, these two global parameter defined in config file
 label:others,migration,invoke_provision
-
 cmd:copycds $$ISO
 check:rc==0
 cmd:makedns -n
@@ -12,10 +11,8 @@ cmd:makedhcp -n
 check:rc==0
 cmd:makedhcp -a
 check:rc==0
-cmd:makeconservercf $$CN
+cmd:if [ -x /usr/bin/goconserver ]; then makegocons $$CN; else makeconservercf $$CN; fi
 check:rc==0
-cmd:cat /etc/conserver.cf | grep $$CN
-check:output=~$$CN
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
@@ -116,4 +113,5 @@ cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;lsdef"
 check:output!~node0001
 cmd:xdsh $$CN "diff /oldxcat/old_version /newxcat/new_version"
 check:rc!=0
+cmd:if [ -x /usr/bin/goconserver ]; then makegocons -d $$CN; else makeconservercf -d $$CN; fi
 end

--- a/xCAT-test/autotest/testcase/migration/ubuntu_migration2_p8le
+++ b/xCAT-test/autotest/testcase/migration/ubuntu_migration2_p8le
@@ -2,7 +2,6 @@ start:ubuntu_migration2_p8le
 os:Linux
 description:update xCAT from $$UBUNTU_MIGRATION2_VERSION to latest version, these two global parameter defined in config file
 label:others,migration,invoke_provision
-
 cmd:copycds $$ISO
 check:rc==0
 cmd:if [[ "__GETNODEATTR($$CN,os)__" =~ "ubuntu" ]];then mkdir /tmp/iso; mount -o loop $$MINIISO /tmp/iso ;  mkdir -p  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot; cp  /tmp/iso/install/initrd.gz  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot;umount /tmp/iso; rmdir /tmp/iso; fi
@@ -13,10 +12,8 @@ cmd:makedhcp -a
 check:rc==0
 cmd:makedns -n
 check:rc==0
-cmd:makeconservercf $$CN
+cmd:if [ -x /usr/bin/goconserver ]; then makegocons $$CN; else makeconservercf $$CN; fi
 check:rc==0
-cmd:cat /etc/conserver.cf | grep $$CN
-check:output=~$$CN
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
@@ -117,6 +114,6 @@ cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;lsdef"
 check:output!~node0001
 cmd:xdsh $$CN "diff /oldxcat/old_version /newxcat/new_version"
 check:rc!=0
-
+cmd:if [ -x /usr/bin/goconserver ]; then makegocons -d $$CN; else makeconservercf -d $$CN; fi
 end
 

--- a/xCAT-test/autotest/testcase/migration/ubuntu_migration2_vm
+++ b/xCAT-test/autotest/testcase/migration/ubuntu_migration2_vm
@@ -2,7 +2,6 @@ start:ubuntu_migration2_vm
 os:Linux
 description:update xCAT from $$UBUNTU_MIGRATION2_VERSION to latest version, these two global parameter defined in config file
 label:others,migration,invoke_provision
-
 cmd:copycds $$ISO
 check:rc==0
 cmd:makedns -n
@@ -12,10 +11,8 @@ cmd:makedhcp -n
 check:rc==0
 cmd:makedhcp -a
 check:rc==0
-cmd:makeconservercf $$CN
+cmd:if [ -x /usr/bin/goconserver ]; then makegocons $$CN; else makeconservercf $$CN; fi
 check:rc==0
-cmd:cat /etc/conserver.cf | grep $$CN
-check:output=~$$CN
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
@@ -116,4 +113,5 @@ cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;lsdef"
 check:output!~node0001
 cmd:xdsh $$CN "diff /oldxcat/old_version /newxcat/new_version"
 check:rc!=0
+cmd:if [ -x /usr/bin/goconserver ]; then makegocons -d $$CN; else makeconservercf -d $$CN; fi
 end


### PR DESCRIPTION
### The PR is for task https://github.ibm.com/xcat2/task_management/issues/39

### The modification include

Replace ``makeconserver`` by ``makegocons`` in below cases:

```
sles_migration
ubuntu_migration1_p8le
ubuntu_migration1_vm
ubuntu_migration2_p8le
ubuntu_migration2_vm
```

