### PR TITLE
Verify packaging commands can be executed during genimage processing

### DIFF
--- a/xCAT-server/share/xcat/netboot/sles/genimage
+++ b/xCAT-server/share/xcat/netboot/sles/genimage
@@ -255,6 +255,12 @@ unless ($onlyinitrd) {
     my $non_interactive;
     if (!$prompt) { $non_interactive = "--non-interactive --no-gpg-checks --gpg-auto-import-keys"; }
 
+    my $zypper_cmd = "zypper";
+    if (! -x $zypper_cmd) {
+        print "Can not execute $zypper_cmd command. Make sure you are running on SUSE based system";
+        exit 1;
+    }
+
     if ($osver_host >= 11) {                      #zypper in SLES11 is different
 
         system("rm -rf $rootimg_dir/etc/zypp/repos.d/$osver-*.repo");

--- a/xCAT-server/share/xcat/netboot/ubuntu/genimage
+++ b/xCAT-server/share/xcat/netboot/ubuntu/genimage
@@ -333,10 +333,14 @@ unless ($onlyinitrd) {
         }
     }
 
+    if (! -x $aptcmd1) {
+        print "Error: Can not execute $aptcmd1 command. Make sure you are running on a Debian based system.\n";
+        exit 1;
+    }
     print "Run cmd [$aptcmd1 $aptcmd2] to create rootimage bootstraps\n";
     my $rc = system("$aptcmd1 $aptcmd2");
     if ($rc) {
-        print "Error: cannnot create bootstraps for rootimage. Make sure you specified full http mirror path.\n";
+        print "Error: Can not create bootstraps for rootimage. Make sure you specified full http mirror path.\n";
         exit 1;
     }
 


### PR DESCRIPTION
1. Today, when trying to `genimage` Ubuntu image on RH MN, a confusing message is displayed:
```
 Error: Can not create bootstraps for rootimage. Make sure you specified full http mirror path.
```

But the real reason is that `bootstrap` command is not there.
This PR adds a check to verify `bootstrap` is executable and displays a message if it is not:
```
Error: Can not execute debootstrap command. Make sure you are running on a Debian based system.
```

2. Today, when trying to `genimage` SLES image on RH MN, a confusing message is displayed:
```
 zypper invocation failed with rc: 72057594037927935
```

But the real reason is that `zypper` command is not there.
This PR adds a check to verify `zypper` is executable and displays a message if it is not:
```
Can not execute zypper command. Make sure you are running on SUSE based system.
```