### PR TITLE
fix issue 6229 based on customer suggestion

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc/openbmc_bmcconfig.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc/openbmc_bmcconfig.py
@@ -556,12 +556,12 @@ rmdir \"/tmp/$userid\" \n")
             addon_string = ''
             if dic_length > 1:
                 addon_string = " for %s" % nic
-            netinfodict['ip'].append("BMC IP"+addon_string+": %s" % attrs["ip"])
-            netinfodict['netmask'].append("BMC Netmask"+addon_string+": %s" % utils.mask_int2str(attrs["netmask"]))
-            netinfodict['gateway'].append("BMC Gateway"+addon_string+": %s (default: %s)" % (attrs["gateway"], defaultgateway))
-            netinfodict['vlan'].append("BMC VLAN ID"+addon_string+": %s" % attrs["vlanid"])
-            netinfodict['ipsrc'].append("BMC IP Source"+addon_string+": %s" % attrs["ipsrc"])
-            netinfodict['ntpservers'].append("BMC NTP Servers"+addon_string+": %s" % attrs["ntpservers"])
+            netinfodict['ip'].append("BMC IP"+addon_string+": %s" % attrs.get("ip", None))
+            netinfodict['netmask'].append("BMC Netmask"+addon_string+": %s" % utils.mask_int2str(attrs.get("netmask", 24)))
+            netinfodict['gateway'].append("BMC Gateway"+addon_string+": %s (default: %s)" % (attrs.get("gateway", None), defaultgateway))
+            netinfodict['vlan'].append("BMC VLAN ID"+addon_string+": %s" % attrs.get("vlanid", None))
+            netinfodict['ipsrc'].append("BMC IP Source"+addon_string+": %s" % attrs.get("ipsrc", None))
+            netinfodict['ntpservers'].append("BMC NTP Servers"+addon_string+": %s" % attrs.get("ntpservers", None))
         if ip:
             for i in netinfodict['ip']:
                 self.callback.info("%s: %s" % (node, i))

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -797,7 +797,7 @@ class OpenBMCRest(object):
 
     def set_ntp_servers(self, nic, servers):
 
-        payload = { "data": [servers] }
+        payload = { "data": servers.split(',') }
         url = RSPCONFIG_NETINFO_URL['ntpservers'].replace('#NIC#', nic)
         self.request('PUT', url, payload=payload, cmd='set_ntp_servers')
 
@@ -915,7 +915,7 @@ class OpenBMCRest(object):
                         netinfo[nicid]["zeroconf"] = v["Address"]
                         continue
                     if 'ip' in netinfo[nicid]:
-                        msg = "%s: Another valid ip %s found." % (node, v["Address"])
+                        msg = "Another valid ip %s found." % (v["Address"])
                         self._print_record_log(msg, 'get_netinfo')
                         del netinfo[nicid]
                         netinfo['error'] = 'Interfaces with multiple IP addresses are not supported'


### PR DESCRIPTION
### The PR is to fix issue _#6229_

### The modification include

_##use <dict>.get replace read value directly_

_##modify msg to avoid invalid var "node"_

### The UT result
```
# rspconfig f5u14 ntpservers
f5u14: BMC NTP Servers: None
```