### PR TITLE
support https:// prefix in otherpkgdir and pkgdir; ignore invalid repos

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -302,7 +302,7 @@ if($onlyinitrd){
     my @pkgdir_internet; #Put all of the http mirrors in this array
     my $dir;
     foreach $dir (@pkgdirs) {
-      if ($dir =~ /^http.*/) {
+      if ($dir =~ /^http[s]?:|^ftp:/) {
         push @pkgdir_internet, $dir;
       } else {
         find(\&isyumdir, <$dir/>);
@@ -336,11 +336,11 @@ if($onlyinitrd){
 
     my $repnum = 0;
     foreach $srcdir (@yumdirs) {
-        print $yumconfig "[$osver-$arch-$repnum]\nname=$osver-$arch-$repnum\nbaseurl=file://$srcdir\ngpgpcheck=0\n\n";
+        print $yumconfig "[$osver-$arch-$repnum]\nname=$osver-$arch-$repnum\nbaseurl=file://$srcdir\ngpgpcheck=0\nskip_if_unavailable=True\n\n";
         $repnum += 1;
     }
     foreach $srcdir (@pkgdir_internet) {
-       print $yumconfig "[$osver-$arch-$repnum]\nname=$osver-$arch-$repnum\nbaseurl=$srcdir\ngpgpcheck=0\n\n";
+       print $yumconfig "[$osver-$arch-$repnum]\nname=$osver-$arch-$repnum\nbaseurl=$srcdir\ngpgpcheck=0\nskip_if_unavailable=True\n\n";
        $repnum += 1;
     }
     $repnum -= 1;
@@ -486,7 +486,7 @@ if($onlyinitrd){
         my @otherpkgdir_url;
         my @otherpkgdir_local;
         foreach my $tmpdir (split ',', $srcdir_otherpkgs){
-            if($tmpdir =~ /^http:.*/){
+            if($tmpdir =~ /^http[s]?:|^ftp:/){
                 push @otherpkgdir_url, $tmpdir;
             }else{
                 push @otherpkgdir_local,$tmpdir;
@@ -516,12 +516,12 @@ if($onlyinitrd){
 
                 if (($_ eq "PRE_REMOVE") || ($_ eq "POST_REMOVE") || ($_ eq "ENVLIST")) { next; }
                 foreach(@otherpkgdir_url){
-                    print $yumconfig "[otherpkgs$index]\nname=otherpkgs$index\nbaseurl=$_\ngpgpcheck=0\n\n";
+                    print $yumconfig "[otherpkgs$index]\nname=otherpkgs$index\nbaseurl=$_\ngpgpcheck=0\nskip_if_unavailable=True\n\n";
                     $repohash{$pass}{$index} = 1;
                     $index++;
                 }
 
-                print $yumconfig "[otherpkgs$index]\nname=otherpkgs$index\nbaseurl=file://$srcdir_otherpkgs_local/$_\ngpgpcheck=0\n\n";
+                print $yumconfig "[otherpkgs$index]\nname=otherpkgs$index\nbaseurl=file://$srcdir_otherpkgs_local/$_\ngpgpcheck=0\nskip_if_unavailable=True\n\n";
                 $repohash{$pass}{$index} = 1;
                 $index++;
                 my $pa = $extra_hash{$pass}{$_};
@@ -1160,6 +1160,7 @@ sub mkinitrd_dracut {
             $additional_options .= " --compress \"$compress -p $processnum \"";
         }
     }
+
 
     print "\nchroot $rootimg_dir dracut $additional_options -f /tmp/initrd.$$.gz $kernelver\n";
     !system("chroot $rootimg_dir dracut $additional_options -f /tmp/initrd.$$.gz $kernelver")


### PR DESCRIPTION
### The PR is to fix issue https://github.com/xcat2/xcat-core/issues/6239:

* support `https://` prefix in otherpkgdir and pkgdir
* ignore invalid repos 


UT:
```
[root@briggs01 ~]# lsdef -t osimage -o rhels7.6-alternate-ppc64le-netboot-compute
Object name: rhels7.6-alternate-ppc64le-netboot-compute
    exlist=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.exlist
    imagetype=linux
    osarch=ppc64le
    osdistroname=rhels7.6-alternate-ppc64le
    osname=Linux
    osvers=rhels7.6-alternate
    otherpkgdir=/install/post/otherpkgs/rhels7.6-alternate/ppc64le,https://mirrors.sonic.net/epel/7/ppc64le/
    otherpkglist=/tmp/otherpkglist
    permission=755
    pkgdir=/tmp/victor/rhels/7.6/rhels7.6-alt-rc1/ppc64le
    pkglist=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist
    postinstall=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.postinstall
    profile=compute
    provmethod=netboot
    rootimgdir=/install/netboot/rhels7.6-alternate/ppc64le/compute

[root@briggs01 ~]# genimage rhels7.6-alternate-ppc64le-netboot-compute
Generating image:
cd /opt/xcat/share/xcat/netboot/rh; ./genimage -a ppc64le -o rhels7.6-alternate -p compute --permission 755 --srcdir "/tmp/victor/rhels/7.6/rhels7.6-alt-rc1/ppc64le" --pkglist /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist --otherpkgdir "/install/post/otherpkgs/rhels7.6-alternate/ppc64le,https://mirrors.sonic.net/epel/7/ppc64le/" --otherpkglist /tmp/otherpkglist --postinstall "/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.postinstall" --rootimgdir /install/netboot/rhels7.6-alternate/ppc64le/compute --tempfile /tmp/xcat_genimage.4048 rhels7.6-alternate-ppc64le-netboot-compute
128 blocks
/opt/xcat/share/xcat/netboot/rh
128 blocks
/opt/xcat/share/xcat/netboot/rh
 yum -y -c /tmp/genimage.4067.yum.conf --installroot=/install/netboot/rhels7.6-alternate/ppc64le/compute/rootimg/ --disablerepo=* --enablerepo=rhels7.6-alternate-ppc64le-0  install  bash nfs-utils openssl dhclient kernel openssh-server openssh-clients wget rsyslog vim-minimal ntp rsyslog rpm rsync ppc64-utils iputils dracut dracut-network e2fsprogs bc file lsvpd irqbalance procps-ng parted net-tools gzip tar xz grub2 grub2-tools bzip2 ethtool
Package bash-4.2.46-31.el7.ppc64le already installed and latest version
Package 1:nfs-utils-1.3.0-0.61.el7.ppc64le already installed and latest version
Package 1:openssl-1.0.2k-16.el7.ppc64le already installed and latest version
Package 12:dhclient-4.2.5-68.el7_5.1.ppc64le already installed and latest version
Package kernel-4.14.0-115.el7a.ppc64le already installed and latest version
Package openssh-server-7.4p1-16.el7.ppc64le already installed and latest version
Package openssh-clients-7.4p1-16.el7.ppc64le already installed and latest version
Package wget-1.14-18.el7.ppc64le already installed and latest version
Package rsyslog-8.24.0-34.el7.ppc64le already installed and latest version
Package 2:vim-minimal-7.4.160-5.el7.ppc64le already installed and latest version
Package ntp-4.2.6p5-28.el7.ppc64le already installed and latest version
Package rsyslog-8.24.0-34.el7.ppc64le already installed and latest version
Package rpm-4.11.3-35.el7.ppc64le already installed and latest version
Package rsync-3.1.2-4.el7.ppc64le already installed and latest version
Package ppc64-utils-0.14-16.el7.ppc64le already installed and latest version
Package iputils-20160308-10.el7.ppc64le already installed and latest version
Package dracut-033-554.el7.ppc64le already installed and latest version
Package dracut-network-033-554.el7.ppc64le already installed and latest version
Package e2fsprogs-1.42.9-13.el7.ppc64le already installed and latest version
Package bc-1.06.95-13.el7.ppc64le already installed and latest version
Package file-5.11-35.el7.ppc64le already installed and latest version
Package lsvpd-1.7.9-1.el7.ppc64le already installed and latest version
Package 3:irqbalance-1.0.7-11.el7.ppc64le already installed and latest version
Package procps-ng-3.3.10-23.el7.ppc64le already installed and latest version
Package parted-3.1-29.el7.ppc64le already installed and latest version
Package net-tools-2.0-0.24.20131004git.el7.ppc64le already installed and latest version
Package gzip-1.5-10.el7.ppc64le already installed and latest version
Package 2:tar-1.26-35.el7.ppc64le already installed and latest version
Package xz-5.2.2-1.el7.ppc64le already installed and latest version
Package 1:grub2-2.02-0.76.el7.ppc64le already installed and latest version
Package 1:grub2-tools-2.02-0.76.el7.ppc64le already installed and latest version
Package bzip2-1.0.6-13.el7.ppc64le already installed and latest version
Package 2:ethtool-4.8-9.el7.ppc64le already installed and latest version
Nothing to do
Cleaning repos: otherpkgs1 otherpkgs2 rhels7.6-alternate-ppc64le-0
Cleaning up everything
 yum -y -c /tmp/genimage.4067.yum.conf --installroot=/install/netboot/rhels7.6-alternate/ppc64le/compute/rootimg/ --disablerepo=* --enablerepo=rhels7.6-alternate-ppc64le-0 --enablerepo=otherpkgs1 --enablerepo=otherpkgs2 install   tinyxml
file:///install/post/otherpkgs/rhels7.6-alternate/ppc64le/./repodata/repomd.xml: [Errno 14] curl#37 - "Couldn't open file /install/post/otherpkgs/rhels7.6-alternate/ppc64le/./repodata/repomd.xml"
Trying other mirror.
Resolving Dependencies
--> Running transaction check
---> Package tinyxml.ppc64le 0:2.6.2-3.el7 will be installed
--> Finished Dependency Resolution
Dependencies Resolved
================================================================================
 Package         Arch            Version               Repository          Size
================================================================================
Installing:
 tinyxml         ppc64le         2.6.2-3.el7           otherpkgs1          50 k
Transaction Summary
================================================================================
Install  1 Package
Total download size: 50 k
Installed size: 167 k
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
Warning: RPMDB altered outside of yum.
  Installing : tinyxml-2.6.2-3.el7.ppc64le                                  1/1
  Verifying  : tinyxml-2.6.2-3.el7.ppc64le                                  1/1
Installed:
  tinyxml.ppc64le 0:2.6.2-3.el7
Complete!
file:///install/post/otherpkgs/rhels7.6-alternate/ppc64le/./repodata/repomd.xml: [Errno 14] curl#37 - "Couldn't open file /install/post/otherpkgs/rhels7.6-alternate/ppc64le/./repodata/repomd.xml"
Trying other mirror.
No packages marked for update
Enter the dracut mode. Dracut version: 033. Dracut directory: dracut_033.
Try to load drivers: ext3 ext4 to initrd.
chroot /install/netboot/rhels7.6-alternate/ppc64le/compute/rootimg dracut  -f /tmp/initrd.4067.gz 4.14.0-115.el7a.ppc64le
No '/dev/log' or 'logger' included for syslog logging
Turning off host-only mode: '/sys' is not mounted!
Turning off host-only mode: '/proc' is not mounted!
Turning off host-only mode: '/run' is not mounted!
Turning off host-only mode: '/dev' is not mounted!
...


```