### PR TITLE
add tar to compute.rhels8.pkglist

### DIFF
--- a/xCAT-server/share/xcat/install/rh/compute.rhels8.pkglist
+++ b/xCAT-server/share/xcat/install/rh/compute.rhels8.pkglist
@@ -7,3 +7,4 @@ rsync
 util-linux
 wget
 python3
+tar

--- a/xCAT-server/share/xcat/install/rh/service.rhels8.pkglist
+++ b/xCAT-server/share/xcat/install/rh/service.rhels8.pkglist
@@ -11,3 +11,4 @@ perl-DBD-MySQL
 perl-DBD-Pg
 unixODBC
 python3
+tar

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels8.ppc64le.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels8.ppc64le.pkglist
@@ -9,3 +9,4 @@ tar
 util-linux
 wget
 python3
+tar

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels8.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels8.x86_64.pkglist
@@ -9,3 +9,4 @@ tar
 util-linux
 wget
 python3
+tar

--- a/xCAT-server/share/xcat/netboot/rh/service.rhels8.ppc64le.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/service.rhels8.ppc64le.pkglist
@@ -11,3 +11,4 @@ wget
 perl-DBD-MySQL
 perl-DBD-Pg
 python3
+tar

--- a/xCAT-server/share/xcat/netboot/rh/service.rhels8.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/service.rhels8.x86_64.pkglist
@@ -11,3 +11,4 @@ wget
 perl-DBD-MySQL
 perl-DBD-Pg
 python3
+tar


### PR DESCRIPTION
### The PR is to add tar to compute.rhels8.pkglist

Due to ``tar`` is a very useful and common command in Linux, should install it by default when provision a rhels8.0 node. For rhels7 and earlier version, the ``tar`` is installed by default. 