### PR TITLE
Remove conserver-xcat from all xCAT shipped RPM requirements

### DIFF
--- a/xCAT-server/xCAT-server.spec
+++ b/xCAT-server/xCAT-server.spec
@@ -48,7 +48,7 @@ Obsoletes: atftp-xcat
 #
 # PCM does not use or ship grub2-xcat
 %if %nots390x
-Requires: grub2-xcat perl-Net-HTTPS-NB perl-HTTP-Async
+Requires: grub2-xcat >= 2.02-0.76 perl-Net-HTTPS-NB perl-HTTP-Async
 %endif
 %endif
 %endif

--- a/xCAT/xCAT.spec
+++ b/xCAT/xCAT.spec
@@ -63,16 +63,6 @@ Requires: perl-IO-Stty
 %endif
 %endif
 
-# The aix rpm cmd forces us to do this outside of ifos type stmts
-%if %notpcm
-%ifos linux
-%if %nots390x
-# PCM does not use or ship conserver
-Requires: conserver-xcat
-%endif
-%endif
-%endif
-
 %ifos linux
 Requires: goconserver
 %endif

--- a/xCATsn/xCATsn.spec
+++ b/xCATsn/xCATsn.spec
@@ -46,16 +46,6 @@ Requires: perl-IO-Stty
 %endif
 %endif
 
-# The aix rpm cmd forces us to do this outside of ifos type stmts
-%if %notpcm
-%ifos linux
-%ifnarch s390x
-# PCM does not use or ship conserver
-Requires: conserver-xcat
-%endif
-%endif
-%endif
-
 %ifos linux
 Requires: goconserver
 %endif


### PR DESCRIPTION
* Remove `conserver-xcat` from `xCAT.spec`
* Remove `conserver-xcat` from `xCATsn.spec`
* `xCAT-server` requires `grub2-xcat >= 2.02-0.76`