### PR TITLE
[OpenBMC] fix reventlog for python2

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -661,7 +661,7 @@ class OpenBMCRest(object):
         # Check if policy table file is there
         ras_event_mapping = {}
         if os.path.isfile(RAS_POLICY_TABLE):
-            with open(RAS_POLICY_TABLE, encoding="utf8", errors='ignore') as data_file:
+            with open(RAS_POLICY_TABLE) as data_file:
                 policy_hash = json.load(data_file)
                 if policy_hash:
                     ras_event_mapping = policy_hash['events']


### PR DESCRIPTION
python2 does not have `encoding` and `errors` in `open()`, therefore reventlog didn't work.

The `/opt/ibm/ras/lib/policyTable.json` has no `UTF-8`, so no need to use `UTF-8`.
There might be a better solution though. This is just a quick fix I've made.

Before:
```
# reventlog node1
# (no output)

# cat /var/log/xcat/agent.log
Traceback (most recent call last):
  File "/opt/xcat/lib/python/agent/common/task.py", line 90, in run
    self._execute_in_parallel(op, *args, **kwargs)
  File "/opt/xcat/lib/python/agent/common/task.py", line 69, in _execute_in_parallel
    func(*args, node=node, nodeinfo=self.inventory[node], **kw)
  File "/opt/xcat/lib/python/agent/hwctl/openbmc/openbmc_eventlog.py", line 40, in get_ev_info
    eventlog_info_dict = obmc.get_eventlog_info()
  File "/opt/xcat/lib/python/agent/hwctl/openbmc_client.py", line 652, in get_eventlog_info
    return self.parse_eventlog_data(eventlog_data)
  File "/opt/xcat/lib/python/agent/hwctl/openbmc_client.py", line 660, in parse_eventlog_data
    with open(RAS_POLICY_TABLE, encoding="utf8", errors='ignore') as data_file:
TypeError: 'errors' is an invalid keyword argument for this function

Traceback (most recent call last):
  File "/opt/xcat/lib/python/agent/common/task.py", line 90, in run
    self._execute_in_parallel(op, *args, **kwargs)
  File "/opt/xcat/lib/python/agent/common/task.py", line 69, in _execute_in_parallel
    func(*args, node=node, nodeinfo=self.inventory[node], **kw)
  File "/opt/xcat/lib/python/agent/hwctl/openbmc/openbmc_eventlog.py", line 40, in get_ev_info
    eventlog_info_dict = obmc.get_eventlog_info()
  File "/opt/xcat/lib/python/agent/hwctl/openbmc_client.py", line 652, in get_eventlog_info
    return self.parse_eventlog_data(eventlog_data)
  File "/opt/xcat/lib/python/agent/hwctl/openbmc_client.py", line 660, in parse_eventlog_data
    with open(RAS_POLICY_TABLE, encoding="utf8") as data_file:
TypeError: 'encoding' is an invalid keyword argument for this function
```

After:
```
# reventlog node1
[... correct output ...]

# no error in /var/log/xcat/agent.log
```