### PR TITLE
[DO NOT MERGE] Add interface identifier for multple ip message

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -917,9 +917,9 @@ class OpenBMCRest(object):
                     if 'ip' in netinfo[nicid]:
                         msg = "Another valid ip %s found." % (v["Address"])
                         self._print_record_log(msg, 'get_netinfo')
-                        del netinfo[nicid]
                         netinfo['error'] = 'Interfaces with multiple IP addresses are not supported: %s' % (k)
-                        break
+                        # Store error, but keep going in case info is needed later
+
                     utils.update2Ddict(netinfo, nicid, "ipsrc", v["Origin"].split('.')[-1])
                     utils.update2Ddict(netinfo, nicid, "netmask", v["PrefixLength"])
                     utils.update2Ddict(netinfo, nicid, "gateway", v["Gateway"])

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -918,7 +918,7 @@ class OpenBMCRest(object):
                         msg = "Another valid ip %s found." % (v["Address"])
                         self._print_record_log(msg, 'get_netinfo')
                         del netinfo[nicid]
-                        netinfo['error'] = 'Interfaces with multiple IP addresses are not supported'
+                        netinfo['error'] = 'Interfaces with multiple IP addresses are not supported: %s' % (k)
                         break
                     utils.update2Ddict(netinfo, nicid, "ipsrc", v["Origin"].split('.')[-1])
                     utils.update2Ddict(netinfo, nicid, "netmask", v["PrefixLength"])


### PR DESCRIPTION
When displaying a message about detecting multiple IPs for the same interface, it would be helpful to know which interface.

Before the fix:
```
[root@briggs01 xcat]# rspconfig mid05tor12cn05 ntpservers
mid05tor12cn05: Interfaces with multiple IP addresses are not supported
[root@briggs01 xcat]#
```
After the fix:
```
[root@briggs01 xcat]# rspconfig mid05tor12cn05 ntpservers
mid05tor12cn05: Interfaces with multiple IP addresses are not supported: /xyz/openbmc_project/network/eth0_11/ipv4/ac98f1aa
[root@briggs01 xcat]#
```

