### PR TITLE
enhance openbmc ntpservers output

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -930,7 +930,7 @@ class OpenBMCRest(object):
                         utils.update2Ddict(netinfo, nicid, "vlanid", info.get("Id", "Disable"))
                         utils.update2Ddict(netinfo, nicid, "mac", info["MACAddress"])
                         ntpservers = None
-                        tmp_ntpservers = ''.join(info["NTPServers"])
+                        tmp_ntpservers = ','.join(info["NTPServers"])
                         if tmp_ntpservers:
                             ntpservers = tmp_ntpservers
                         utils.update2Ddict(netinfo, nicid, "ntpservers", ntpservers)


### PR DESCRIPTION
### The PR is to fix issue _#6229_

### The modification include

_##output of ntpservers_

### The UT result
before modify:
```
f5u14: BMC NTP Servers: f6u13k10c910f03c17k21
```
after modify:
```
f5u14: BMC NTP Servers: f6u13k10,c910f03c17k21
```