### PR TITLE
change /var/named permission to default 0750 in makedns

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ddns.pm
+++ b/xCAT-server/lib/xcat/plugins/ddns.pm
@@ -206,6 +206,7 @@ sub process_request {
     $callback = shift;
     my $oldmask = umask(0007);
     my $ctx     = {};
+    my $permissionmode;
     my @nodes   = ();
     my $hadargs = 0;
     my $allnodes;
@@ -777,6 +778,8 @@ sub process_request {
             #We manipulate local namedconf
             $ctx->{dbdir}    = get_dbdir();
             $ctx->{zonesdir} = get_zonesdir();
+            #backup named directory permission
+            $permissionmode = (stat($ctx->{dbdir}))[2] & 07777;
             chmod 0775, $ctx->{dbdir}; # assure dynamic dns can actually execute against the directory
             if ($::VERBOSE)
             {
@@ -918,7 +921,10 @@ sub process_request {
     unless ($ret) {
         xCAT::SvrUtils::sendmsg("DNS setup is completed", $callback);
     }
-    chmod 0750, $ctx->{dbdir};
+    #restore named directory permission
+    if (defined($permissionmode)) {
+        chmod $permissionmode, $ctx->{dbdir};   
+    }
     umask($oldmask);
 }
 

--- a/xCAT-server/lib/xcat/plugins/ddns.pm
+++ b/xCAT-server/lib/xcat/plugins/ddns.pm
@@ -918,7 +918,7 @@ sub process_request {
     unless ($ret) {
         xCAT::SvrUtils::sendmsg("DNS setup is completed", $callback);
     }
-
+    chmod 0750, $ctx->{dbdir};
     umask($oldmask);
 }
 


### PR DESCRIPTION
### The PR is to fix issue 
https://github.com/xcat2/xcat-core/issues/5992
### The modification include

`makedns` changed `/var/named` permission to 0775, after makedns finished, it should change the `/var/named` to default permission 0750

### The UT result
```
]# makedns -n
Handling testnode8.cluster.com in /etc/hosts.
Handling c910f04x19.cluster.com in /etc/hosts.
Handling cn2.cluster.com in /etc/hosts.
Ignoring host cn2.cluster.com, it does not belong to any nets defined in networks table or the net it belongs to is configured to use an external nameserver.
Handling bysle03.cluster.com in /etc/hosts.
Handling bysle01.cluster.com in /etc/hosts.
Handling c910f04x40.cluster.com in /etc/hosts.
Handling c910f04x41 in /etc/hosts.
Handling byrh04.cluster.com in /etc/hosts.
Handling byrh09-br51.cluster.com in /etc/hosts.
Handling byrh05-eth2.cluster.com in /etc/hosts.
Handling byrh07.cluster.com in /etc/hosts.
Handling byrh05.cluster.com in /etc/hosts.
Handling byubu01.cluster.com in /etc/hosts.
Handling byrh06.cluster.com in /etc/hosts.
Handling byrh05-eth1.cluster.com in /etc/hosts.
Handling byrh02.cluster.com in /etc/hosts.
Handling byrh06-eth1.cluster.com in /etc/hosts.
Handling c910f05c01bc07.cluster.com in /etc/hosts.
Handling localhost in /etc/hosts.
Handling byrh10.cluster.com in /etc/hosts.
Handling byrh09.cluster.com in /etc/hosts.
Handling byrh06-eth2.cluster.com in /etc/hosts.
Handling c910f04x23.cluster.com in /etc/hosts.
Handling bysle02.cluster.com in /etc/hosts.
Getting reverse zones, this may take several minutes for a large cluster.
Completed getting reverse zones.
Updating zones.
Completed updating zones.
Restarting named
Restarting named complete
Updating DNS records, this may take several minutes for a large cluster.
Completed updating DNS records.
DNS setup is completed

]# ls -l /var | grep named
drwxr-x---   5 root named 4096 Apr 19 06:39 named
```