### PR TITLE
refine test case  rspconfig_set_hostname_equal_star_with_bmc_is_hostname for task #165

### DIFF
--- a/xCAT-test/autotest/testcase/rspconfig/cases0
+++ b/xCAT-test/autotest/testcase/rspconfig/cases0
@@ -311,6 +311,7 @@ cmd:lsdef bogus-bmc-hostname
 check:rc == 0
 cmd:makehosts bogus-bmc-hostname
 check:rc == 0
+cmd:makedns -n
 cmd:makedns bogus-bmc-hostname
 check:rc == 0
 cmd:chdef $$CN bmc=bogus-bmc-hostname


### PR DESCRIPTION
### The PR is for task  https://github.ibm.com/xcat2/task_management/issues/165

### The UT result
```
------START::rspconfig_set_hostname_equal_star_with_bmc_is_hostname::Time:Mon Apr 22 08:41:22 2019------

RUN:mkdir -p /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname [Mon Apr 22 08:41:22 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:lsdef f5u14 -z > /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname/f5u14.stanza [Mon Apr 22 08:41:22 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:rspconfig f5u14 sshcfg [Mon Apr 22 08:41:23 2019]
ElapsedTime:7 sec
RETURN rc = 0
OUTPUT:
f5u14: ssh keys copied to 10.5.14.100
CHECK:rc == 0	[Pass]

RUN:ssh __GETNODEATTR(f5u14,bmc)__ "hostname" | tee /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname/bmc_old_name [Mon Apr 22 08:41:30 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
test_bogus-bmc-hostname

RUN:chdef -t node -o bogus-bmc-hostname groups=bmc ip=__GETNODEATTR(f5u14,bmc)__ [Mon Apr 22 08:41:32 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
New object definitions 'bogus-bmc-hostname' have been created.
CHECK:rc == 0	[Pass]

RUN:lsdef bogus-bmc-hostname [Mon Apr 22 08:41:33 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Object name: bogus-bmc-hostname
    groups=bmc
    ip=10.5.14.100
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
CHECK:rc == 0	[Pass]

RUN:makehosts bogus-bmc-hostname [Mon Apr 22 08:41:33 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:makedns -n [Mon Apr 22 08:41:34 2019]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
Handling c910f02c39p11 in /etc/hosts.
Handling c910f04x37v07 in /etc/hosts.
Handling c910f03c09k06 in /etc/hosts.
Handling frame5u39 in /etc/hosts.
Handling c910f04x37v02 in /etc/hosts.
Handling c910f02c39p10 in /etc/hosts.
Handling c910f04x37 in /etc/hosts.
Handling c910f02c39p17 in /etc/hosts.
Handling c910f02c09p30 in /etc/hosts.
Handling c910f02c39p09 in /etc/hosts.
Handling c910f04x38v02 in /etc/hosts.
Handling c910f04x29 in /etc/hosts.
Handling c910f03c11k08 in /etc/hosts.
Handling c910f02c39p12 in /etc/hosts.
Handling c910f02c39p07 in /etc/hosts.
Handling c910f02c01p23 in /etc/hosts.
Handling c910f02c01p22 in /etc/hosts.
Handling f6u13k13 in /etc/hosts.
Handling c910f02c09p28 in /etc/hosts.
Handling localhost in /etc/hosts.
Handling c910f02c39p05 in /etc/hosts.
Handling c910f02c39p04 in /etc/hosts.
Handling c910f02c39p14 in /etc/hosts.
Handling c910f05c01cmm01 in /etc/hosts.
Ignoring host c910f05c01cmm01, it does not belong to any nets defined in networks table or the net it belongs to is configured to use an external nameserver.
Handling c910f04x38v05 in /etc/hosts.
Handling c910f03c11k03 in /etc/hosts.
Handling f6u13k11 in /etc/hosts.
Handling c910f04x38v03 in /etc/hosts.
Handling c910f04x42 in /etc/hosts.
Handling c910f05c01bc04 in /etc/hosts.
Handling xcat.org in /etc/hosts.
Ignoring host xcat.org, it does not belong to any nets defined in networks table or the net it belongs to is configured to use an external nameserver.
Handling c910f04x33 in /etc/hosts.
Handling f6u13k10 in /etc/hosts.
Handling p9euh01 in /etc/hosts.
Handling c910f03c09 in /etc/hosts.
Handling c910f04x34 in /etc/hosts.
Handling f6u13k18 in /etc/hosts.
Handling f6u13k14 in /etc/hosts.
Handling f6u03 in /etc/hosts.
Handling c910f05c01bc06 in /etc/hosts.
Handling c910f02c01p21 in /etc/hosts.
Handling c910f02c39p06 in /etc/hosts.
Handling f6u13 in /etc/hosts.
Handling c910f02c39p13 in /etc/hosts.
Handling c910f02c39p03 in /etc/hosts.
Handling c910f03c05k06 in /etc/hosts.
Handling c910f03c09k05 in /etc/hosts.
Handling c910f03c09k03 in /etc/hosts.
Handling c910f04x38v06 in /etc/hosts.
Handling f5u14-enP5p1s0f1 in /etc/hosts.
Ignoring host f5u14-enP5p1s0f1, it does not belong to any nets defined in networks table or the net it belongs to is configured to use an external nameserver.
Handling c910f04x38 in /etc/hosts.
Handling c910f05c01bc04v04 in /etc/hosts.
Handling f6u13k17 in /etc/hosts.
Handling c910f03c09k08 in /etc/hosts.
Handling fs3 in /etc/hosts.
Handling c910f04x38v07 in /etc/hosts.
Handling c910f03c11k04 in /etc/hosts.
Handling c910f02c09p29 in /etc/hosts.
Handling fs4 in /etc/hosts.
Handling c910f02c01p16 in /etc/hosts.
Handling c910hmc01 in /etc/hosts.
Handling c910f03c09k07 in /etc/hosts.
Handling c910f04x37v03 in /etc/hosts.
Handling c910f05c01bc04v02 in /etc/hosts.
Handling c910f04x37v05 in /etc/hosts.
Handling localhost in /etc/hosts.
Handling c910f05c01bc04v03 in /etc/hosts.
Handling c910f03c11k05 in /etc/hosts.
Handling c910f03c09k04 in /etc/hosts.
Handling c910f04x30v13 in /etc/hosts.
Handling c910f04x37v06 in /etc/hosts.
Handling c910f04x30v12 in /etc/hosts.
Handling f6u13k15 in /etc/hosts.
Handling c910f04x37v04 in /etc/hosts.
Handling c910f02c39p08 in /etc/hosts.
Handling f5u25 in /etc/hosts.
Handling f5u14-enP5p1s0f1-1 in /etc/hosts.
Ignoring host f5u14-enP5p1s0f1-1, it does not belong to any nets defined in networks table or the net it belongs to is configured to use an external nameserver.
Handling c910f03c05k28 in /etc/hosts.
Handling c910f03c05k25 in /etc/hosts.
Handling c910f02c39p16 in /etc/hosts.
Handling c910f03c11 in /etc/hosts.
Handling bogus-bmc-hostname in /etc/hosts.
Handling f6u17 in /etc/hosts.
Handling c910f2u39 in /etc/hosts.
Handling c910f02c39p15 in /etc/hosts.
Handling f6u13k12 in /etc/hosts.
Handling c910f04x30v11 in /etc/hosts.
Handling c910f02c01p17 in /etc/hosts.
Handling c910f04x38v04 in /etc/hosts.
Handling c910f04x30v02 in /etc/hosts.
Handling f5u14 in /etc/hosts.
Handling c910f02c01p15 in /etc/hosts.
Handling c910f05c01bc05 in /etc/hosts.
Handling c910f04x30 in /etc/hosts.
Handling f6u13k16 in /etc/hosts.
Handling archive.ubuntu.com in /etc/hosts.
Handling f5u14-enP5p1s0f1-2 in /etc/hosts.
Ignoring host f5u14-enP5p1s0f1-2, it does not belong to any nets defined in networks table or the net it belongs to is configured to use an external nameserver.
Getting reverse zones, this may take several minutes for a large cluster.
Completed getting reverse zones.
Updating zones.
Completed updating zones.
Restarting named
Restarting named complete
Updating DNS records, this may take several minutes for a large cluster.
Completed updating DNS records.
DNS setup is completed

RUN:makedns bogus-bmc-hostname [Mon Apr 22 08:41:37 2019]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
Handling bogus-bmc-hostname in /etc/hosts.
Getting reverse zones, this may take several minutes for a large cluster.
Completed getting reverse zones.
Updating zones.
Completed updating zones.
Updating DNS records, this may take several minutes for a large cluster.
Completed updating DNS records.
DNS setup is completed
CHECK:rc == 0	[Pass]

RUN:chdef f5u14 bmc=bogus-bmc-hostname [Mon Apr 22 08:41:40 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:lsdef f5u14 -i bmc -c [Mon Apr 22 08:41:40 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f5u14: bmc=bogus-bmc-hostname
CHECK:rc == 0	[Pass]

RUN:rspconfig f5u14 hostname=* [Mon Apr 22 08:41:41 2019]
ElapsedTime:4 sec
RETURN rc = 0
OUTPUT:
f5u14: BMC Setting BMC Hostname...
f5u14: BMC Hostname: bogus-bmc-hostname
CHECK:rc == 0	[Pass]
CHECK:output =~ f5u14: BMC Hostname: bogus-bmc-hostname	[Pass]

RUN:ssh __GETNODEATTR(bogus-bmc-hostname,ip)__ "hostname" | tee /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname/bmc_new_name [Mon Apr 22 08:41:45 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
bogus-bmc-hostname
CHECK:rc == 0	[Pass]

RUN:echo "bogus-bmc-hostname" > /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname/bmc_set_name [Mon Apr 22 08:41:47 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:diff -y /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname/bmc_set_name /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname/bmc_new_name [Mon Apr 22 08:41:47 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
bogus-bmc-hostname						bogus-bmc-hostname
CHECK:rc == 0	[Pass]

RUN:makedns -d bogus-bmc-hostname [Mon Apr 22 08:41:47 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
Handling bogus-bmc-hostname in /etc/hosts.
Getting reverse zones, this may take several minutes for a large cluster.
Completed getting reverse zones.
Updating zones.
Completed updating zones.
Updating DNS records, this may take several minutes for a large cluster.
Completed updating DNS records.
DNS setup is completed
CHECK:rc == 0	[Pass]

RUN:makehosts -d bogus-bmc-hostname [Mon Apr 22 08:41:49 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:rmdef bogus-bmc-hostname [Mon Apr 22 08:41:49 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:rmdef f5u14 [Mon Apr 22 08:41:49 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:cat /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname/f5u14.stanza |mkdef -z [Mon Apr 22 08:41:50 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:ip=$(cat /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname/bmc_old_name);ssh  __GETNODEATTR(f5u14,bmc)__ "hostname=bogus-bmc-hostname" [Mon Apr 22 08:41:51 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:ssh __GETNODEATTR(f5u14,bmc)__ "hostname" [Mon Apr 22 08:41:52 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
bogus-bmc-hostname

RUN:rm -rf /tmp/rspconfig_set_hostname_equal_star_with_bmc_is_hostname [Mon Apr 22 08:41:54 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

------END::rspconfig_set_hostname_equal_star_with_bmc_is_hostname::Passed::Time:Mon Apr 22 08:41:54 2019 ::Duration::32 sec------
------Total: 1 , Failed: 0------
```