### PR TITLE
Let makentp fall back to use ntpd when systemctl is not available.

### DIFF
--- a/xCAT-server/lib/xcat/plugins/makentp.pm
+++ b/xCAT-server/lib/xcat/plugins/makentp.pm
@@ -253,7 +253,8 @@ sub process_request {
     }
 
     # Handle chronyd here,
-    if (-f "/usr/sbin/chronyd") {
+    if (-x "/usr/sbin/chronyd" &&
+		(-x "/usr/bin/systemctl" || -x "/bin/systemctl")) {
         send_msg(\%request, 0, "Will configure chronyd instead.");
 
         my $cmd = "/install/postscripts/setupntp " .

--- a/xCAT/postscripts/setupntp
+++ b/xCAT/postscripts/setupntp
@@ -130,6 +130,7 @@ then
 fi
 
 check_executes chronyd >/dev/null 2>&1 || USE_NTPD="yes"
+check_executes systemctl >/dev/null 2>&1 || USE_NTPD="yes"
 
 if [ -n "${USE_NTPD}" ]
 then


### PR DESCRIPTION
### The PR is to fix issue _#6247_

### The modification include

_##Let `makentp` fall back to use `ntpd` when `systemctl` is not available._
_##Let postscript `setupntp` fall back to use `ntpd` when `systemctl `is not available._

### The UT result
```
# makentp
configuring management node: c910f03c01p06.
# ps ax | grep -v grep | grep ntp
24426 ?        Ss     0:00 ntpd -u ntp:ntp -p /var/run/ntpd.pid -g
```