### PR TITLE
Add goconserver to the SLES12 otherpkgs.pkglist. In order to pull the xcat-dep directory into the zypper repository

### DIFF
--- a/xCAT-server/share/xcat/install/sles/service.sles12.ppc64le.otherpkgs.pkglist
+++ b/xCAT-server/share/xcat/install/sles/service.sles12.ppc64le.otherpkgs.pkglist
@@ -1,1 +1,2 @@
 xcat/xcat-core/xCATsn
+xcat/xcat-dep/sles12/ppc64le/goconserver

--- a/xCAT-server/share/xcat/install/sles/service.sles12.x86_64.otherpkgs.pkglist
+++ b/xCAT-server/share/xcat/install/sles/service.sles12.x86_64.otherpkgs.pkglist
@@ -1,1 +1,2 @@
 xcat/xcat-core/xCATsn
+xcat/xcat-dep/sles12/x86_64/goconserver

--- a/xCAT-server/share/xcat/netboot/sles/service.sles12.ppc64le.otherpkgs.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/service.sles12.ppc64le.otherpkgs.pkglist
@@ -1,1 +1,2 @@
 xcat/xcat-core/xCATsn
+xcat/xcat-dep/sles12/ppc64le/goconserver

--- a/xCAT-server/share/xcat/netboot/sles/service.sles12.x86_64.otherpkgs.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/service.sles12.x86_64.otherpkgs.pkglist
@@ -1,2 +1,3 @@
 -perl-doc
 xcat/xcat-core/xCATsn
+xcat/xcat-dep/sles12/x86_64/goconserver


### PR DESCRIPTION
### The PR is to fix issue _#6258_

### The modification include

_##Add goconserver to the SLES12 otherpkgs.pkglist. In order to pull the xcat-dep directory into the zypper repository_
