### PR TITLE
confignetwork need run twice when install NIC has multiple IPs

### DIFF
--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -660,7 +660,7 @@ elif [ "$1" = "-s" ];then
         str_inst_prefix=$(v4mask2prefix ${str_inst_mask})
         str_conf_file="/etc/sysconfig/network-scripts/ifcfg-${str_inst_nic}"
         if [ $networkmanager_active -eq 2 ]; then
-            str_conf_file="/etc/sysconfig/network-scripts/ifcfg-xcat-${str_inst_nic}"
+            str_conf_file="/etc/sysconfig/network-scripts/ifcfg-$con_name"
         fi
         if [ $networkmanager_active -eq 1 ]; then
             is_nmcli_connection_exist "$con_name"
@@ -682,7 +682,7 @@ elif [ "$1" = "-s" ];then
             echo "NETMASK=${str_inst_mask}" >> $str_conf_file
             echo "BOOTPROTO=none" >> $str_conf_file
             echo "ONBOOT=yes" >> $str_conf_file
-            echo "NAME=xcat-${str_inst_nic}" >> $str_conf_file
+            echo "NAME=${con_name}" >> $str_conf_file
             echo "HWADDR=${str_inst_mac}" >> $str_conf_file
         fi
         if [ $networkmanager_active -eq 2 ]; then

--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -26,18 +26,17 @@ fi
 ########################################################################
 # networkmanager_active=0: use network.service
 # networkmanager_active=1: use NetworkManager
+# networkmanager_active=2: RH8 postscripts stage, NetworkManager is active but nmcli cannot modify NIC configure file
 ########################################################################
 networkmanager_active=0
-checkservicestatus NetworkManager > /dev/null
-if [ $? -eq 0 ]; then
-    networkmanager_active=1
-else
-    #In RH8 postscripts stage, NetworkManager is active but nmcli cannot modify NIC configure file
-    ps -ef|grep -v grep|grep NetworkManager >/dev/null 2>/dev/null
-    if [ $? -eq 0 ]; then
+if [ -n "$NMCLI_USED" ] ; then
+    if [ "$NMCLI_USED" = "1" ]; then
+        networkmanager_active=1
+    elif [ "$NMCLI_USED" = "2" ]; then
         networkmanager_active=2
     fi
 fi
+
 str_conf_file=""
 str_conf_file_xcatbak=""
 tmp_con_name=""
@@ -657,11 +656,11 @@ elif [ "$1" = "-s" ];then
         echo $NODE > /etc/HOSTNAME
     else
         #write ifcfg-* file for redhat
-        con_name="xcat-install-"${str_inst_nic}
+        con_name="xcat-"${str_inst_nic}
         str_inst_prefix=$(v4mask2prefix ${str_inst_mask})
         str_conf_file="/etc/sysconfig/network-scripts/ifcfg-${str_inst_nic}"
         if [ $networkmanager_active -eq 2 ]; then
-            str_conf_file="/etc/sysconfig/network-scripts/ifcfg-xcat-install-${str_inst_nic}"
+            str_conf_file="/etc/sysconfig/network-scripts/ifcfg-xcat-${str_inst_nic}"
         fi
         if [ $networkmanager_active -eq 1 ]; then
             is_nmcli_connection_exist "$con_name"
@@ -683,7 +682,7 @@ elif [ "$1" = "-s" ];then
             echo "NETMASK=${str_inst_mask}" >> $str_conf_file
             echo "BOOTPROTO=none" >> $str_conf_file
             echo "ONBOOT=yes" >> $str_conf_file
-            echo "NAME=xcat-install-${str_inst_nic}" >> $str_conf_file
+            echo "NAME=xcat-${str_inst_nic}" >> $str_conf_file
             echo "HWADDR=${str_inst_mac}" >> $str_conf_file
         fi
         if [ $networkmanager_active -eq 2 ]; then

--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -473,10 +473,10 @@ function configure_nicdevice {
     do
         nic_dev=`echo "$nics_pair" |sed -n "${num}p"|awk '{print $1}'`
         ipaddrs=$(find_nic_ips $nic_dev)
-        contain_alias=$(echo $ipaddrs|grep "|")
+        multiple_ips=$(echo $ipaddrs|grep "|")
         #If install nic is configured, skip to reconfigure it
-        if [ x"$nic_dev" = x"$installnic" -a $instnic_conf -eq 1 -a x"$contain_alias" = x ]; then
-            log_warn "install nic $nic_dev has been configured, skip to reconfigure it $contain_alias."
+        if [ x"$nic_dev" = x"$installnic" -a $instnic_conf -eq 1 -a x"$multiple_ips" = x ]; then
+            log_warn "install nic $nic_dev has been configured, continue."
             ((num+=1))
             continue
         fi

--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -63,9 +63,7 @@ function get_nic_cfg_file_content {
     elif [ $is_debian -eq 1 ]; then
          cfg_file="$nwdir/${cfg_dev}"
     fi
-    #TODO:this is networkmanager_active=2 
-    ps -ef|grep -v grep|grep NetworkManager >/dev/null 2>/dev/null
-    if [ $? -eq 0 ]; then
+    if [ "$networkmanager_active" != "0" ]; then
         $ip address show dev ${cfg_dev}| $sed -e 's/^/[Ethernet] >> /g' | log_lines info
     else
         if [ -f $cfg_file ]; then
@@ -474,9 +472,11 @@ function configure_nicdevice {
     while [ $num -lt $max ];
     do
         nic_dev=`echo "$nics_pair" |sed -n "${num}p"|awk '{print $1}'`
+        ipaddrs=$(find_nic_ips $nic_dev)
+        contain_alias=$(echo $ipaddrs|grep "|")
         #If install nic is configured, skip to reconfigure it
-        if [ x"$nic_dev" = x"$installnic" -a $instnic_conf -eq 1 ]; then
-            log_warn "install nic $nic_dev has been configured, skip to reconfigure it."
+        if [ x"$nic_dev" = x"$installnic" -a $instnic_conf -eq 1 -a x"$contain_alias" = x ]; then
+            log_warn "install nic $nic_dev has been configured, skip to reconfigure it $contain_alias."
             ((num+=1))
             continue
         fi
@@ -528,7 +528,6 @@ function configure_nicdevice {
         echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
         nic_pair=`echo "$nics_pair" |sed -n "${num}p"`
         echo "configure nic and its device : $nic_pair"
-        ipaddrs=$(find_nic_ips $nic_dev)
         # if a device is middle device, it may have no IP, for example, configure eth0->vlan.1->br0, vlan1.1 is middle device
         # is_mid_device is to label if ${nic_dev} is middle device
         # if $is_mid_device has value, the ${nic_dev} is middle device, or else, it is not middle device
@@ -543,8 +542,8 @@ function configure_nicdevice {
             xcatnet=`query_nicnetworks_net $nic_dev`
             if [ -n "$ipaddrs" ]; then
                 log_info "configure $nic_dev"
-                log_info "call: configeth $nic_dev $ipaddrs $xcatnet"
-                configeth $nic_dev $ipaddrs $xcatnet
+                log_info "call: NMCLI_USED=$networkmanager_active configeth $nic_dev $ipaddrs $xcatnet"
+                NMCLI_USED=$networkmanager_active configeth $nic_dev $ipaddrs $xcatnet
                 if [ $? -ne 0 ]; then
                     errorcode=1
                 fi
@@ -637,27 +636,6 @@ errorcode=0
 #nictypes should support capital letters, for example, Ethernet and ethernet
 utolcmd="sed -e y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/"
 
-#get for installnic
-installnic=''
-installnic=`get_installnic`
-instnic_conf=0
-if [ $boot_install_nic -eq 1 ];then
-    if [ -n "$installnic" ]; then
-        echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
-        log_info "configure the install nic $installnic. "
-        instnic_conf=1
-        configeth -s $installnic
-        if [ $? -ne 0 ]; then
-            errorcode=1
-        fi
-        get_nic_cfg_file_content $installnic
-        echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
-    else
-        log_error "Can not determine proper install nic."
-        errorcode=1
-    fi
-fi
-
 #check if using NetworkManager or  network service
 networkmanager_active=3
 check_NetworkManager_or_network_service
@@ -670,6 +648,28 @@ elif [ $is_active -eq 2 ]; then
     networkmanager_active=2
 else
     exit 1
+fi
+
+#get for installnic
+installnic=''
+installnic=`get_installnic`
+instnic_conf=0
+if [ $boot_install_nic -eq 1 ];then
+    if [ -n "$installnic" ]; then
+        echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+        log_info "configure the install nic $installnic."
+        log_info "NMCLI_USED=$networkmanager_active configeth -s $installnic"
+        instnic_conf=1
+        NMCLI_USED=$networkmanager_active configeth -s $installnic
+        if [ $? -ne 0 ]; then
+            errorcode=1
+        fi
+        get_nic_cfg_file_content $installnic
+        echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+    else
+        log_error "Can not determine proper install nic."
+        errorcode=1
+    fi
 fi
 
 #back up all network interface configure files

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -1587,6 +1587,10 @@ function decode_arguments {
 #
 ##############################################################################
 function check_NetworkManager_or_network_service() {
+    #In RH7.6 postscripts stage, network service is active, but xCAT uses NetworkManager to configure IP,
+    #after that, xCAT disable NetworkManager, when CN is booted, CN use network service.
+    #In RH8, there is only NetworkManager
+    #So check network service should before check NetworkManager.
     checkservicestatus network > /dev/null 2>/dev/null || checkservicestatus wicked > /dev/null 2>/dev/null 
     if [ $? -eq 0 ]; then
         stopservice NetworkManager | log_lines info

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -1587,6 +1587,13 @@ function decode_arguments {
 #
 ##############################################################################
 function check_NetworkManager_or_network_service() {
+    checkservicestatus network > /dev/null 2>/dev/null || checkservicestatus wicked > /dev/null 2>/dev/null 
+    if [ $? -eq 0 ]; then
+        stopservice NetworkManager | log_lines info
+        disableservice NetworkManager | log_lines info
+        log_info "network service is active"
+        return 0
+    fi
     #check NetworkManager is active
     checkservicestatus NetworkManager > /dev/null 2>/dev/null
     if [ $? -eq 0 ]; then
@@ -1603,13 +1610,6 @@ function check_NetworkManager_or_network_service() {
     ps -ef|grep -v grep|grep NetworkManager >/dev/null 2>/dev/null
     if [ $? -eq 0 ]; then
         return 2
-    fi
-    checkservicestatus network > /dev/null 2>/dev/null || checkservicestatus wicked > /dev/null 2>/dev/null
-    if [ $? -eq 0 ]; then
-        stopservice NetworkManager | log_lines info
-        disableservice NetworkManager | log_lines info
-        log_info "network service is active"
-        return 0
     fi
     checkservicestatus networking > /dev/null 2>/dev/null
     if [ $? -eq 0 ]; then


### PR DESCRIPTION
### The PR is to fix issue 
https://github.com/xcat2/xcat-core/issues/6246

### The modification include
1. confignetwork need to run twice when install NIC has multiple IPs, it is an old issue.
In the past, `confignetwork -s` only configure install NIC provision IP, `confignetwork`  reconfigure install NIC configured in `nics` table. In this PR, `confignetwork -s` should configure install NIC multiple IPs at once.
2. In RH7.6 postscripts stage, network service is active, but xCAT uses NetworkManager to configure IP, after that, xCAT disable NetworkManager, when CN is booted, CN use network service. So check network service should before check NetworkManager.

### The UT result
1. tested `confignetwork -s` in postscripts on both RH8 and RH7.6
2.  updatenode on RH8
```
]# updatenode byrh10 -P "confignetwork -s"
byrh10: Warning: the ECDSA host key for 'byrh10' differs from the key for the IP address '10.4.41.10'
byrh10: Offending key for IP in /root/.ssh/known_hosts:108
byrh10: Matching host key in /root/.ssh/known_hosts:118

byrh10: =============updatenode starting====================
byrh10: trying to download postscripts...
byrh10: postscripts downloaded successfully
byrh10: trying to get mypostscript from 10.4.41.1...
byrh10: postscript start..: confignetwork
byrh10: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh10: [I]: configure the install nic ens3.
byrh10: [I]: NMCLI_USED=1 configeth -s ens3
byrh10: [I]: configeth on byrh10: os type: redhat
byrh10: ls: cannot access '/var/lib/dhclient/*ens3*': No such file or directory
byrh10: ens3!MTU=1422
byrh10: Connection 'xcat-install-ens3' (c300148e-4ddb-4e87-b12f-ffbb810880dc) successfully added.
byrh10: GATEWAY=10.0.0.103
byrh10: 0: name=MTU value=1422
byrh10: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/14813)
byrh10: Connection 'ens3-tmp' (3a0a6dfa-c6f9-4a9c-a8d8-2b04fecb428c) successfully deleted.
byrh10: [I]: [Ethernet] >> 2: ens3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
byrh10: [I]: [Ethernet] >>     link/ether 42:56:0a:04:29:0a brd ff:ff:ff:ff:ff:ff
byrh10: [I]: [Ethernet] >>     inet 10.4.41.10/8 brd 10.255.255.255 scope global noprefixroute ens3
byrh10: [I]: [Ethernet] >>        valid_lft forever preferred_lft forever
byrh10: [I]: [Ethernet] >>     inet6 fe80::25c0:b4a2:1a4f:7c0b/64 scope link tentative noprefixroute
byrh10: [I]: [Ethernet] >>        valid_lft forever preferred_lft forever
byrh10: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh10: [I]: NetworkManager is active
byrh10: [I]: All valid nics and device list:
byrh10: [I]: ens3
byrh10: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
byrh10: configure nic and its device : ens3
byrh10: [I]: configure ens3
byrh10: [I]: call: NMCLI_USED=1 configeth ens3 10.4.41.10|50.4.41.10 10_0_0_0-255_0_0_0|50_0_0_0-255_0_0_0
byrh10: [I]: configeth on byrh10: os type: redhat
byrh10: configeth on byrh10: old configuration: 2: ens3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
byrh10:     link/ether 42:56:0a:04:29:0a brd ff:ff:ff:ff:ff:ff
byrh10:     inet 10.4.41.10/8 brd 10.255.255.255 scope global noprefixroute ens3
byrh10:        valid_lft forever preferred_lft forever
byrh10:     inet6 fe80::25c0:b4a2:1a4f:7c0b/64 scope link tentative noprefixroute
byrh10:        valid_lft forever preferred_lft forever
byrh10: ens3!MTU=1422
byrh10: array_nic_params 0=MTU=1422
byrh10: [I]: configeth on byrh10: new configuration
byrh10:        10.4.41.10, 10.0.0.0, 255.0.0.0, 10.0.0.103
byrh10:        50.4.41.10, 50.0.0.0, 255.0.0.0, <xcatmaster>
byrh10: 2: ens3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
byrh10: [I]: configeth on byrh10: ens3 changed, modify the configuration files
byrh10: Connection 'xcat-ens3' (417320d1-58de-434a-9e40-e23aa7842a46) successfully added.
byrh10: bring up ip
byrh10: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/14814)
byrh10: [I]: [Ethernet] >> 2: ens3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1422 qdisc fq_codel state UP group default qlen 1000
byrh10: [I]: [Ethernet] >>     link/ether 42:56:0a:04:29:0a brd ff:ff:ff:ff:ff:ff
byrh10: [I]: [Ethernet] >>     inet 10.4.41.10/8 brd 10.255.255.255 scope global noprefixroute ens3
byrh10: [I]: [Ethernet] >>        valid_lft forever preferred_lft forever
byrh10: [I]: [Ethernet] >>     inet 50.4.41.10/8 brd 50.255.255.255 scope global noprefixroute ens3
byrh10: [I]: [Ethernet] >>        valid_lft forever preferred_lft forever
byrh10: [I]: [Ethernet] >>     inet6 fe80::1bed:8f0:5f3b:f8b7/64 scope link tentative noprefixroute
byrh10: [I]: [Ethernet] >>        valid_lft forever preferred_lft forever
byrh10: postscript end....: confignetwork exited with code 0
byrh10: Running of postscripts has completed.
byrh10: =============updatenode ending====================
]# xdsh byrh10 ip a
byrh10: 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
... ...
byrh10: 2: ens3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1422 qdisc fq_codel state UP group default qlen 1000
byrh10:     link/ether 42:56:0a:04:29:0a brd ff:ff:ff:ff:ff:ff
byrh10:     inet 10.4.41.10/8 brd 10.255.255.255 scope global noprefixroute ens3
byrh10:        valid_lft forever preferred_lft forever
byrh10:     inet 50.4.41.10/8 brd 50.255.255.255 scope global noprefixroute ens3
byrh10:        valid_lft forever preferred_lft forever
byrh10:     inet6 fe80::1bed:8f0:5f3b:f8b7/64 scope link noprefixroute
byrh10:        valid_lft forever preferred_lft forever
```

3. updatenode on RH7.6
```
]# updatenode c910f04x40 "confignetwork -s"
c910f04x40: =============updatenode starting====================
c910f04x40: trying to download postscripts...
c910f04x40: postscripts downloaded successfully
c910f04x40: trying to get mypostscript from 10.4.41.1...
c910f04x40: postscript start..: confignetwork
c910f04x40: [I]: systemctl stop NetworkManager
c910f04x40: [I]: network service is active
c910f04x40: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f04x40: [I]: configure the install nic eno1.
c910f04x40: [I]: NMCLI_USED=0 configeth -s eno1
c910f04x40: [I]: configeth on c910f04x40: os type: redhat
c910f04x40: eno1!MTU=1422
c910f04x40: GATEWAY=10.0.0.103
c910f04x40: 0: name=MTU value=1422
c910f04x40: ['/etc/sysconfig/network-scripts/ifcfg-eno1']
c910f04x40: [I]: >> DEVICE=eno1
c910f04x40: [I]: >> IPADDR=10.4.40.1
c910f04x40: [I]: >> NETMASK=255.0.0.0
c910f04x40: [I]: >> BOOTPROTO=none
c910f04x40: [I]: >> ONBOOT=yes
c910f04x40: [I]: >> NAME=xcat-eno1
c910f04x40: [I]: >> HWADDR=34:40:b5:b9:d6:4f
c910f04x40: [I]: >> MTU=1422
c910f04x40: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f04x40: [I]: All valid nics and device list:
c910f04x40: [I]: eno1
c910f04x40: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f04x40: configure nic and its device : eno1
c910f04x40: [I]: configure eno1
c910f04x40: [I]: call: NMCLI_USED=0 configeth eno1 10.4.40.1|50.4.40.11 10_0_0_0-255_0_0_0|50_0_0_0-255_0_0_0
c910f04x40: [I]: configeth on c910f04x40: os type: redhat
c910f04x40: configeth on c910f04x40: old configuration: 2: eno1: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1422 qdisc mq state DOWN group default qlen 1000
c910f04x40:     link/ether 34:40:b5:b9:d6:4f brd ff:ff:ff:ff:ff:ff
c910f04x40:     inet 10.4.40.1/8 brd 10.255.255.255 scope global eno1
c910f04x40:        valid_lft forever preferred_lft forever
c910f04x40: eno1!MTU=1422
c910f04x40: array_nic_params 0=MTU=1422
c910f04x40: [I]: configeth on c910f04x40: new configuration
c910f04x40:        10.4.40.1, 10.0.0.0, 255.0.0.0, 10.0.0.103
c910f04x40:        50.4.40.11, 50.0.0.0, 255.0.0.0, <xcatmaster>
c910f04x40: 2: eno1: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1422 qdisc mq state DOWN mode DEFAULT group default qlen 1000
c910f04x40: eno1
c910f04x40: [I]: configeth on c910f04x40: eno1 changed, modify the configuration files
c910f04x40: eno1
c910f04x40: bring up ip
c910f04x40: Determining if ip address 50.4.40.11 is already in use for device eno1...
c910f04x40: ['/etc/sysconfig/network-scripts/ifcfg-eno1']
c910f04x40: [I]: >> DEVICE=eno1
c910f04x40: [I]: >> BOOTPROTO=none
c910f04x40: [I]: >> NM_CONTROLLED=no
c910f04x40: [I]: >> IPADDR=10.4.40.1
c910f04x40: [I]: >> NETMASK=255.0.0.0
c910f04x40: [I]: >> ONBOOT=yes
c910f04x40: [I]: >> MTU=1422
c910f04x40: postscript end....: confignetwork exited with code 0
c910f04x40: Running of postscripts has completed.
c910f04x40: =============updatenode ending====================
[root@c910f04x41 ~]# ssh c910f04x40
Last login: Mon Apr 22 10:25:54 2019 from c910f04x41.cluster.com
[root@c910f04x40 ~]# ip a
... ...
2: eno1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1422 qdisc mq state UP group default qlen 1000
    link/ether 34:40:b5:b9:d6:4f brd ff:ff:ff:ff:ff:ff
    inet 10.4.40.1/8 brd 10.255.255.255 scope global eno1
       valid_lft forever preferred_lft forever
    inet 50.4.40.11/8 brd 50.255.255.255 scope global eno1:1
       valid_lft forever preferred_lft forever
    inet6 fe80::3640:b5ff:feb9:d64f/64 scope link
       valid_lft forever preferred_lft forever
... ...
```