### PR TITLE
Filter out the http port from cumulus-provision-url

### DIFF
--- a/xCAT/postscripts/configinterface
+++ b/xCAT/postscripts/configinterface
@@ -15,6 +15,7 @@ fi
 
 if [ -z "$MASTER" ]; then
     MASTER=$(cat /var/lib/dhcp/dhclient.eth0.leases|sed -n 's/.*cumulus-provision-url.*http:\/\+\([^\/]\+\)\/.*/\1/p'|tail -1)
+    MASTER=$(echo $MASTER | awk -F: '{print $1}')
     if [ -z "$MASTER" ]; then
         echo "xCAT Master unset! Cannot download interface description"
         exit 2

--- a/xCAT/postscripts/cumulusztp
+++ b/xCAT/postscripts/cumulusztp
@@ -35,6 +35,7 @@ function get_last_lease()
 
 #get ip address for server node
 server_ip="$(grep 'cumulus-provision-url' < <(get_last_lease eth0) | awk -F/ '{print $3}')"
+server_ip="$(echo $server_ip | awk -F: '{print $1}')"
 hashostname="$(grep 'host-name' < <(get_last_lease eth0))"
 
 #download /install/postscripts from MN

--- a/xCAT/postscripts/documulusdiscovery
+++ b/xCAT/postscripts/documulusdiscovery
@@ -4,6 +4,7 @@
 
 # TODO: Figure out the master based on the DHCP packet
 XCATMASTER=$(cat /var/lib/dhcp/dhclient.eth0.leases |grep cumulus-provision-url|tail -1|awk -F/ '{print $3}')
+XCATMASTER=$(echo $XCATMASTER | awk -F: '{print $1}') 
 XCATPORT=3001
 log_label="xcat.documulusdiscovery"
 


### PR DESCRIPTION
### The PR is to fix issue _#6268_  , 
after add support for site.httpport, the cumulus-provision-url changed to `http://$DHCPIP:$httpport/install/postscripts/cumulusztp`,   The postscripts `cumulusztp`, `documulusdiscovery`, and `configinterface` get MASTER dhcp ip address from cumulus-provision-url,  so needs to filter out the httpport from `$DHCPIP:$httpport`.

