### PR TITLE
Make rflash -c match output of hpm check

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -2464,9 +2464,8 @@ sub rflash {
                 my $c_id          = ${ $sessdata->{component_ids} }[$i];
                 my $version       = $firmware_version{$c_id};
                 my $format_string = $comp_string{$c_id};
-                my $format_ver    = sprintf("%3d.%02x.%d",
-                    $version->[0], $version->[1],
-                    $version->[5]*0x1000000 +$version->[4]*0x10000+ $version->[3]*0x100+$version->[2]);
+                my $format_ver    = sprintf("%3d.%02x %02X%02X%02X%02X",
+                    $version->[0], $version->[1], $version->[2], $version->[3], $version->[4], $version->[5]);
                 $msg = $msg . $sessdata->{node} . ": " .
 "Node firmware version for $format_string component: $format_ver";
                 if ($i != scalar(@{ $sessdata->{component_ids} }) - 1) {
@@ -8820,16 +8819,16 @@ sub hpm_action_version {
         return -1;
     }
     my $version = $hpm_data_hash{1}{action_version};
-    my $ver = sprintf("%3d.%02x.%d", $version->[0], $version->[1],
-        $version->[5]*0x1000000+$version->[4]*0x10000+$version->[3]*0x100+$version->[2]);
+    my $ver = sprintf("%3d.%02x %02X%02X%02X%02X", $version->[0], $version->[1],
+        $version->[2], $version->[3], $version->[4], $version->[5]);
     $callback->({ data => "HPM firmware version for BOOT component:$ver" });
     $version = $hpm_data_hash{2}{action_version};
-    $ver = sprintf("%3d.%02x.%d", $version->[0], $version->[1],
-        $version->[5]*0x1000000+$version->[4]*0x10000+$version->[3]*0x100+$version->[2]);
+    $ver = sprintf("%3d.%02x %02X%02X%02X%02X", $version->[0], $version->[1],
+        $version->[2], $version->[3], $version->[4], $version->[5]);
     $callback->({ data => "HPM firmware version for APP  component:$ver" });
     $version = $hpm_data_hash{4}{action_version};
-    $ver = sprintf("%3d.%02x.%d", $version->[0], $version->[1],
-        $version->[5]*0x1000000+$version->[4]*0x10000+$version->[3]*0x100+$version->[2]);
+    $ver = sprintf("%3d.%02x %02X%02X%02X%02X", $version->[0], $version->[1],
+        $version->[2], $version->[3], $version->[4], $version->[5]);
     $callback->({ data => "HPM firmware version for BIOS component:$ver" });
 }
 


### PR DESCRIPTION
### The PR is to fix issue _#6264_

### The modification include

Undo the changes made PR #4625. At that time it was believed that output of `rflash -c` should match contents of `/proc/ractrends/Helper/FwInfo` file. But now we are not sure if contents of that file are correct, and the output should match `ipmitool hpm check`

The output of `rflash -c` should match the output of `ipmitool hpm check` command:

```
[root@stratton01 xcat]# rflash boston32  -c
boston32: Node firmware version for SMC BMC FW   component:   2.04 00000000
boston32: Node firmware version for PNOR FW      component:   0.00 20180801
boston32: Node firmware version for  component:   0.00 00000000


[root@stratton01 xcat]# ipmitool-xcat -I lanplus -H boston32-bmc -U ADMIN -P ADMIN hpm check

PICMG HPM.1 Upgrade Agent 1.0.9:

-------Target Information-------
Device Id          : 0x20
Device Revision    : 0x1
Product Id         : 0x0985
Manufacturer Id    : 0x2a7c (Supermicro)


--------------------------------------------------------------------------
|ID  | Name        |                     Versions                        |
|    |             |     Active      |     Backup      |      Deferred   |
--------------------------------------------------------------------------
|*  0|SMC BMC FW   |   2.04 00000000 | ---.-- -------- | ---.-- -------- |
|*  1|PNOR FW      |   0.00 20180801 | ---.-- -------- | ---.-- -------- |
--------------------------------------------------------------------------
(*) Component requires Payload Cold Reset


[root@stratton01 xcat]#
```

```
[root@stratton01 xcat]# rflash f5u25 -c
f5u25: Node firmware version for BOOT component:   2.13 58980100
f5u25: Node firmware version for APP component:   2.13 58980100
f5u25: Node firmware version for BIOS component:   1.12 55000000


[root@stratton01 xcat]# ipmitool-xcat -I lanplus -H f5u25-bmc -U ADMIN -P admin hpm check

PICMG HPM.1 Upgrade Agent 1.0.9:

-------Target Information-------
Device Id          : 0x20
Device Revision    : 0x1
Product Id         : 0xaabb
Manufacturer Id    : 0x0000 (Unknown)


--------------------------------------------------------------------------
|ID  | Name        |                     Versions                        |
|    |             |     Active      |     Backup      |      Deferred   |
--------------------------------------------------------------------------
|*  0|BOOT         |   2.13 58980100 | ---.-- -------- |   0.00 00000000 |
|*  1|APP          |   2.13 58980100 | ---.-- -------- |   0.00 00000000 |
|*  2|BIOS         |   1.12 55000000 | ---.-- -------- |   0.00 00000000 |
--------------------------------------------------------------------------
(*) Component requires Payload Cold Reset


[root@stratton01 xcat]#
```