### PR TITLE
xcatprobe xcatmn:  do not check DNS status on mn if site.externaldns=1

### DIFF
--- a/xCAT-probe/subcmds/xcatmn
+++ b/xCAT-probe/subcmds/xcatmn
@@ -946,13 +946,24 @@ sub check_dns_service {
     my $nodename = `hostname -s 2>&1`;
     chomp($nodename);
 
+    # For mn, 'externaldns' attribute could be set to '0' or '1' or not defined.
+    #   if '1', mn does not need to provide DNS service, so will not check it.
+    #   if '0' or undefined, proceed with check.
     # For sn, 'setupdns' attribute could be set to '0' or '1'.
-    # if '0', sn does not need to provie DNS service, will not check it
+    #   if '0', sn does not need to provide DNS service, will not check it
     my $checkdns = 1;
     if ($is_sn) {
         $checkdns = `lsdef $nodename -i setupnameserver -c  2>&1| awk -F'=' '{print \$2}'`;
         chomp($checkdns);
-    }
+    } else { # management node
+        my $dns_is_external = `lsdef -t site -i externaldns -c 2>&1 | awk -F'=' {print \$2}'`;
+        chomp($dns_is_external);
+        if ($dns_is_external eq "1") {
+          $checkdns = 0;
+        } else {
+          $checkdns = 1;
+        }
+    } 
 
     if ($checkdns) {
         `which nslookup > /dev/null 2>&1`;


### PR DESCRIPTION
This pull request is to fix an issue with xcatprobe.

Currently, xcatprobe checks for DNS service on the management node unconditionally.  If site.externaldns is set to 1, there should not be a DNS service running on the management node, but `xcatprobe xcatmn` reports failure anyway.  This patch corrects this behavior, skipping themanagement node DNS check iff site.externaldns=1.

alter xcatmn to check the site table:
- if not on a service node 
- AND if externaldns is set to 1
  - skip the checkdns block
- otherwise check dns