### PR TITLE
xcatprobe xcatmn: Allow selinux permissive

### DIFF
--- a/xCAT-probe/lib/perl/probe_utils.pm
+++ b/xCAT-probe/lib/perl/probe_utils.pm
@@ -242,6 +242,33 @@ sub is_selinux_enable {
 
 =head3
     Description:
+        Test if SELinux is enforcing in current operating system
+    Arguments:
+         None
+    Returns:
+        1 : yes
+        0 : no
+=cut
+
+#------------------------------------------
+sub is_selinux_enforcing {
+    if (-e "/usr/sbin/getenforce") {
+        my $enforce_mode = `/usr/sbin/getenforce`;
+        chomp $enforce_mode;
+        switch ($enforce_mode) {
+          case "Disabled" { return 0; }
+          case "Permissive" { return 0; }
+          case "Enforcing" { return 1; }
+          else { return 0; }
+    } else {
+        return 0;
+    }
+}
+
+#------------------------------------------
+
+=head3
+    Description:
         Test if firewall is opened in current operating system
     Arguments:
          None

--- a/xCAT-probe/subcmds/xcatmn
+++ b/xCAT-probe/subcmds/xcatmn
@@ -93,8 +93,9 @@ sub do_main_job {
     $rc |= $rst;
 
     #check if SElinux is disabled
-    $rst        = check_selinux(\$checkpoint, \@error);
-    print_check_result($checkpoint, "f", $rst, \@error);
+    ($rst, $flag) = check_selinux(\$checkpoint, \@error);
+    print_check_result($checkpoint, $flag, $rst, \@error);
+    $rst = 0 if ($flag == "w");
     $rc |= $rst;
 
     #check http service
@@ -677,16 +678,26 @@ sub check_selinux {
     my $checkpoint_ref =  shift;
     my $error_ref = shift;
     my $rst       = 0;
+    my $flag      = "w";
+    my $msg       = "";
 
     $$checkpoint_ref = "Checking SELinux is disabled...";
     @$error_ref = ();
 
     if (probe_utils->is_selinux_enable()) {
-        push @$error_ref, "SELinux is enabled on current server";
+        $msg = "SELinux is enabled on current server";
         $rst = 1;
+        $flag = "w";
     }
-
-    return $rst;
+    if (probe_utils->is_selinux_enforcing()) {
+        $msg = "SELinux is enforcing on current server";
+        $rst = 1;
+        $flag = "f";
+    }
+    if ($rst) { 
+        push @error_ref, "$msg";
+    }
+    return ($rst, $flag);
 }
 
 sub check_firewall {


### PR DESCRIPTION
This pull request is to fix an issue with xcatprobe.

Currently, xcatprobe checks to see if selinux is enabled, and reports failure if selinux is enabled.  However, selinux has three possible modes:  "disabled," "permissive," and "enforcing."  Of the three, only "enforcing" means that selinux is actively working on the system.  "Permissive" mode loads policies but does not interfere with operation, but merely logs potential violations.

This change adds a second test to `probe_utils`, which explicitly checks whether selinux is in "enforcing" mode.  In addition, the `check_selinux` test in xcatmn is modified:  if selinux is enabled and enforcing, the test reports failure.  If selinux is enabled but NOT enforcing (this is "permissive" mode), the test reports a warning.  If selinux is "disabled," the test passes with no warnings.

This allows sites who use selinux in "permissive" mode to monitor their systems to pass the `xcatprobe xcatmn` testing.