### PR TITLE
remove conserver related steps from perf baseline case

### DIFF
--- a/xCAT-test/autotest/testcase/performance/case0
+++ b/xCAT-test/autotest/testcase/performance/case0
@@ -33,13 +33,6 @@ cmd:chdef -t node -o $$CN servicenode= monserver= nfsserver= tftpserver=  xcatma
 check:rc==0
 cmd:chdef -t node -o $$SN servicenode= monserver= nfsserver= tftpserver=  xcatmaster= status=
 check:rc==0
-cmd:makeconservercf
-check:rc==0
-cmd:cat /etc/conserver.cf | grep $$CN
-check:output=~$$CN
-cmd:cat /etc/conserver.cf | grep $$SN
-check:output=~$$SN
-cmd:sleep 20
 cmd:makedhcp -n
 check:rc==0
 cmd:makedhcp -a


### PR DESCRIPTION
### The PR is to fix issue https://github.ibm.com/xcat2/task_management/issues/196

### The modification include

remove the `mkconservercf` steps from case `perftest_5000_with_simulators`

### The UT result
```
...
RUN:chdef -t node -o c910f03c11k04 servicenode= monserver= nfsserver= tftpserver=  xcatmaster= status= [Fri May 3 08:19:49 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0   [Pass]

RUN:makedhcp -n [Fri May 3 08:20:10 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Warning: [c910f03c11k03]: No dynamic range specified for 10.0.0.0. If hardware discovery is being used, a dynamic range is required.
Renamed existing dhcp configuration file to  /etc/dhcp/dhcpd.conf.xcatbak

The dhcp server must be restarted for OMAPI function to work

RUN:makedhcp -a [Fri May 3 08:20:11 2019]
...
```


