### PR TITLE
fix issue 6270, support new interface of powersupplyredundancy on python

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -200,12 +200,16 @@ RSPCONFIG_APIS = {
         'baseurl': "/sensors/chassis/PowerSupplyRedundancy/",
         'set_url': "action/setValue",
         'get_url': "action/getValue",
+        'get_url_new': '/control/power_supply_redundancy',
         'get_method': 'POST',
+        'get_method_new': 'GET',
         'get_data': [],
         'display_name': "BMC PowerSupplyRedundancy",
         'attr_values': {
             'disabled': ["Disabled"],
             'enabled': ["Enabled"],
+            'False': ['Disabled'],
+            'True':  ["Enabled"],
         },
     },
     'powerrestorepolicy': {
@@ -789,6 +793,10 @@ class OpenBMCRest(object):
         if 'get_data' in attr_info:
             data={"data": attr_info['get_data']}
         return self.request(method, get_url, payload=data, cmd="get_%s" % key)
+
+    def get_powersupplyredundancy(self):
+        attr_info = RSPCONFIG_APIS['powersupplyredundancy']
+        return self.request(attr_info['get_method_new'], attr_info['get_url_new'], cmd='get_powersupplyredundancy')
 
     def set_admin_passwd(self, passwd):
 


### PR DESCRIPTION
### The PR is to fix issue _#6270_

### The modification include

_##modify ``rspconfig powersupplyredundancy`` logic as #6282  _

_##add ``_get_powersupplyredundancy_value`` function to deal with new interface_

### The UT result
```
# rflash f5u14 -l
f5u14: ID       Purpose State      Version
f5u14: -------------------------------------------------------
f5u14: b04fff27 BMC     Active     ibm-v2.0-0-r46-0-gbed584c
f5u14: 33029bc1 Host    Active     IBM-witherspoon-ibm-OP9_v1.19_1.192
f5u14: cf421794 BMC     Active(*)  ibm-v2.3-476-g2d622cb-r32-0-g9973ab0
f5u14: 1be29de2 Host    Active(*)  IBM-witherspoon-OP9_v2.0.14_1.2
f5u14:

# rspconfig f5u14 powersupplyredundancy=enabled -V
[c910f03c17k21]: Running command in Python
[c910f03c17k21]: Sat May  4 22:54:04 2019 f5u14: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.5.14.100/login -d '{"data": ["root", "xxxxxx"]}'
[c910f03c17k21]: Sat May  4 22:54:04 2019 f5u14: [openbmc_debug] login 200 OK
[c910f03c17k21]: Sat May  4 22:54:04 2019 f5u14: [openbmc_debug] set_powersupplyredundancy curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.5.14.100/xyz/openbmc_project/sensors/chassis/PowerSupplyRedundancy/action/setValue -d '{"data": ["Enabled"]}'
[c910f03c17k21]: Sat May  4 22:54:04 2019 f5u14: [openbmc_debug] set_powersupplyredundancy [404] org.freedesktop.DBus.Error.FileNotFound: path or object not found: /xyz/openbmc_project/sensors/chassis/PowerSupplyRedundancy
f5u14: [c910f03c17k21]: Error: 404 Not Found - Requested endpoint does not exist or may indicate function is not supported on this OpenBMC firmware.

# rspconfig f5u14 powersupplyredundancy -V
[c910f03c17k21]: Running command in Python
[c910f03c17k21]: Sat May  4 22:55:14 2019 f5u14: [openbmc_debug] login curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.5.14.100/login -d '{"data": ["root", "xxxxxx"]}'
[c910f03c17k21]: Sat May  4 22:55:14 2019 f5u14: [openbmc_debug] login 200 OK
[c910f03c17k21]: Sat May  4 22:55:14 2019 f5u14: [openbmc_debug] get_powersupplyredundancy curl -k -c cjar -b cjar -X POST -H "Content-Type: application/json" https://10.5.14.100/xyz/openbmc_project/sensors/chassis/PowerSupplyRedundancy/action/getValue -d '{"data": []}'
[c910f03c17k21]: Sat May  4 22:55:14 2019 f5u14: [openbmc_debug] get_powersupplyredundancy [404] org.freedesktop.DBus.Error.FileNotFound: path or object not found: /xyz/openbmc_project/sensors/chassis/PowerSupplyRedundancy
[c910f03c17k21]: Sat May  4 22:55:14 2019 f5u14: [openbmc_debug] get_powersupplyredundancy curl -k -c cjar -b cjar -X GET -H "Content-Type: application/json" https://10.5.14.100/xyz/openbmc_project/control/power_supply_redundancy
[c910f03c17k21]: Sat May  4 22:55:14 2019 f5u14: [openbmc_debug] get_powersupplyredundancy 200 OK
[c910f03c17k21]: f5u14: BMC PowerSupplyRedundancy: Disabled
```