### PR TITLE
update confignetwork cases to support new os

### DIFF
--- a/xCAT-test/autotest/testcase/confignetwork/cases0
+++ b/xCAT-test/autotest/testcase/confignetwork/cases0
@@ -287,12 +287,12 @@ check:output=~$$CN-$$SECONDNIC-1
 check:output=~$$CN-$$SECONDNIC-2
 cmd:updatenode $$CN -P confignetwork
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var3;if grep SUSE /etc/*release;then xdsh $$CN "grep $second1ip /etc/sysconfig/network/ifcfg-$$SECONDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $second1ip /etc/sysconfig/network-scripts/ifcfg-$$SECONDNIC"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $second1ip /etc/network/interfaces.d/$$SECONDNIC";else echo "Sorry,this is not supported os"; fi
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var3;if grep SUSE /etc/*release;then xdsh $$CN "grep $second1ip /etc/sysconfig/network/ifcfg-$$SECONDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $second1ip /etc/sysconfig/network-scripts/ifcfg-*$$SECONDNIC*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $second1ip /etc/network/interfaces.d/$$SECONDNIC";else echo "Sorry,this is not supported os"; fi
 check:rc==0
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "cat /etc/sysconfig/network/ifcfg-$$SECONDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "cat /etc/sysconfig/network-scripts/ifcfg-*$$SECONDNIC*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cat /etc/network/interfaces.d/$$SECONDNIC";else echo "Sorry,this is not supported os"; fi
 check:output=~BOOTPROTO=none|static
 check:output=~CONNECTED_MODE=yes|CONNECTED_MODE yes
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var3;if grep SUSE /etc/*release;then xdsh $$CN "grep $second1ip /etc/sysconfig/network/ifcfg-$$SECONDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $second1ip /etc/sysconfig/network-scripts/ifcfg-$$SECONDNIC:1"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $second1ip /etc/network/interfaces.d/$$SECONDNIC";else echo "Sorry,this is not supported os"; fi
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var3;if grep SUSE /etc/*release;then xdsh $$CN "grep $second1ip /etc/sysconfig/network/ifcfg-$$SECONDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $second1ip /etc/sysconfig/network-scripts/ifcfg-*$$SECONDNIC*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $second1ip /etc/network/interfaces.d/$$SECONDNIC";else echo "Sorry,this is not supported os"; fi
 check:rc==0
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "cat /etc/sysconfig/network/ifcfg-$$SECONDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "cat /etc/sysconfig/network-scripts/ifcfg-*$$SECONDNIC*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cat /etc/network/interfaces.d/$$SECONDNIC";else echo "Sorry,this is not supported os"; fi
 check:output=~CONNECTED_MODE=yes|CONNECTED_MODE yes
@@ -568,7 +568,7 @@ cmd:chdef $$CN nicips.$$SECONDNIC=11.1.0.100 nictypes.$$SECONDNIC=Ethernet nicne
 check:rc==0
 cmd:updatenode $$CN -P confignetwork
 check:rc==0
-cmd:xdsh $$CN "if grep SUSE /etc/*release;then grep 11.1.0.100 /etc/sysconfig/network/ifcfg-$$SECONDNIC; elif grep -E \"Red Hat|CentOS\" /etc/*release;then grep 11.1.0.100 /etc/sysconfig/network-scripts/ifcfg-*$$SECONDNIC; elif grep Ubuntu /etc/*release;then grep 11.1.0.100 /etc/network/interfaces.d/$$SECONDNIC;else echo \"Sorry,this is not supported os\"; fi"
+cmd:xdsh $$CN "if grep SUSE /etc/*release;then grep 11.1.0.100 /etc/sysconfig/network/ifcfg-$$SECONDNIC; elif grep -E \"Red Hat|CentOS\" /etc/*release;then grep 11.1.0.100 /etc/sysconfig/network-scripts/ifcfg-*$$SECONDNIC*; elif grep Ubuntu /etc/*release;then grep 11.1.0.100 /etc/network/interfaces.d/$$SECONDNIC;else echo \"Sorry,this is not supported os\"; fi"
 check:output=~11.1.0.100
 cmd:chdef $$CN nicips.$$SECONDNIC= nictypes.$$SECONDNIC= nicnetworks.$$SECONDNIC=
 check:rc==0
@@ -733,9 +733,9 @@ cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=103;var3=`echo $cnip 
 check:rc==0
 cmd:updatenode $$CN -P confignetwork
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;bond2ip=$var1$var3;if grep SUSE /etc/*release;then xdsh $$CN "grep $bond2ip /etc/sysconfig/network/ifcfg-bond0.2"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $bond2ip /etc/sysconfig/network-scripts/ifcfg-bond0.2"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $bond2ip /etc/network/interfaces.d/bond0.2";else echo "Sorry,this is not supported os"; fi
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;bond2ip=$var1$var3;if grep SUSE /etc/*release;then xdsh $$CN "grep $bond2ip /etc/sysconfig/network/ifcfg-bond0.2"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $bond2ip /etc/sysconfig/network-scripts/ifcfg-*bond0.2*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $bond2ip /etc/network/interfaces.d/bond0.2";else echo "Sorry,this is not supported os"; fi
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var2=103;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;bond3ip=$var2$var3;if grep SUSE /etc/*release;then xdsh $$CN "grep $bond3ip /etc/sysconfig/network/ifcfg-bond0.3"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $bond3ip /etc/sysconfig/network-scripts/ifcfg-bond0.3"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $bond3ip /etc/network/interfaces.d/bond0.3";else echo "Sorry,this is not supported os"; fi
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var2=103;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;bond3ip=$var2$var3;if grep SUSE /etc/*release;then xdsh $$CN "grep $bond3ip /etc/sysconfig/network/ifcfg-bond0.3"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $bond3ip /etc/sysconfig/network-scripts/ifcfg-*bond0.3*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $bond3ip /etc/network/interfaces.d/bond0.3";else echo "Sorry,this is not supported os"; fi
 check:rc==0
 cmd:xdsh $$CN "ls /sys/class/net"
 check:output=~bond0
@@ -766,7 +766,6 @@ check:rc==0
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "cp -rf /tmp/backupnet/network-scripts /etc/sysconfig/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/network/interfaces.d/;cp -f /tmp/interfaces /etc/network/";else echo "Sorry,this is not supported os"; fi
 check:rc==0	
 cmd:xdsh $$CN "systemctl status NetworkManager >/dev/null 2>/dev/null && which nmcli >/dev/null 2>/dev/null && nmcli con reload"
-check:rc==0
 cmd:xdsh $$CN "rm -rf /tmp/backupnet/ /tmp/interfaces"
 check:rc==0
 cmd:chtab -d node=$$CN nics
@@ -921,14 +920,14 @@ cmd:chdef $$CN nicdevices.br22=bond0.2 nicdevices.br33=bond0.3 nictypes.br22=bri
 check:rc==0
 cmd:updatenode $$CN -P "confignetwork -s"
 check:rc==0
-cmd:installnic=`xdsh $$CN ip addr |grep __GETNODEATTR($$CN,ip)__|awk -F " " '{print $NF}'`; if grep SUSE /etc/*release;then xdsh $$CN "cat /etc/sysconfig/network/ifcfg-$installnic"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "cat /etc/sysconfig/network-scripts/ifcfg-$installnic"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cat /etc/network/interfaces.d/*";else echo "Sorry,this is not supported os"; fi
+cmd:installnic=`xdsh $$CN ip addr |grep __GETNODEATTR($$CN,ip)__|awk -F " " '{print $NF}'`; if grep SUSE /etc/*release;then xdsh $$CN "cat /etc/sysconfig/network/ifcfg-$installnic"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "cat /etc/sysconfig/network-scripts/ifcfg-*$installnic*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cat /etc/network/interfaces.d/*";else echo "Sorry,this is not supported os"; fi
 check:rc==0
 check:output=~__GETNODEATTR($$CN,ip)__
 check:output=~BOOTPROTO=none|static
-cmd:if grep SUSE /etc/*release;then xdsh $$CN "grep 30.5.106.8 /etc/sysconfig/network/ifcfg-br22"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep 30.5.106.8 /etc/sysconfig/network-scripts/ifcfg-br22"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep 30.5.106.8 /etc/network/interfaces.d/br22";else echo "Sorry,this is not supported os"; fi
+cmd:if grep SUSE /etc/*release;then xdsh $$CN "grep 30.5.106.8 /etc/sysconfig/network/ifcfg-br22"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep 30.5.106.8 /etc/sysconfig/network-scripts/ifcfg-*br22*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep 30.5.106.8 /etc/network/interfaces.d/br22";else echo "Sorry,this is not supported os"; fi
 check:output=~30.5.106.8
 check:rc==0
-cmd:if grep SUSE /etc/*release;then xdsh $$CN "grep 40.5.106.8 /etc/sysconfig/network/ifcfg-br33"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep 40.5.106.8 /etc/sysconfig/network-scripts/ifcfg-br33"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep 40.5.106.8 /etc/network/interfaces.d/br33";else echo "Sorry,this is not supported os"; fi
+cmd:if grep SUSE /etc/*release;then xdsh $$CN "grep 40.5.106.8 /etc/sysconfig/network/ifcfg-br33"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep 40.5.106.8 /etc/sysconfig/network-scripts/ifcfg-*br33*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep 40.5.106.8 /etc/network/interfaces.d/br33";else echo "Sorry,this is not supported os"; fi
 check:output=~40.5.106.8
 check:rc==0
 cmd:xdsh $$CN "ls /sys/class/net"


### PR DESCRIPTION
update confignetwork cases to support new os

The UT
```
------START::confignetwork_2eth_bridge_br22_br33::Time:Mon May  6 01:54:28 2019------

RUN:lsdef c910f03c09k17;if [ $? -eq 0 ]; then lsdef -l c910f03c09k17 -z >/tmp/CN.standa ;fi [Mon May  6 01:54:28 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Object name: c910f03c09k17
    arch=ppc64le
    cons=kvm
    currchain=boot
    currstate=boot
    groups=all
    id=17
    ip=10.3.9.17
    mac=42:e4:0a:03:09:11|42:ce:0a:03:09:11!*NOIP*|42:5b:0a:03:09:11!*NOIP*
    mgt=kvm
    monserver=c910f03c09k15
    netboot=grub2
    nfsserver=c910f03c09k15
    os=rhels8.0.0
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles,enablekdump
    profile=compute
    provmethod=rhels8.0.0-ppc64le-install-compute
    serialflow=hard
    serialport=0
    serialspeed=115200
    status=booted
    statustime=05-05-2019 23:45:22
    tftpserver=c910f03c09k15
    updatestatus=synced
    updatestatustime=05-05-2019 08:23:49
    vmcpus=4
    vmhost=c910f03c09
    vmmemory=8192
    vmnicnicmodel=virtio-net-pci
    vmnics=br10,br50,br4093
    vmstorage=phy:/dev/mapper/vdiskvg1-vdisk01n17
    xcatmaster=c910f03c09k15
CHECK:rc == 0	[Pass]

RUN:xdsh c910f03c09k17 "rm -rf /tmp/backupnet/" [Mon May  6 01:54:29 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
[c910f03c09k15]: c910f03c09k17: Warning: Permanently added 'c910f03c09k17,10.3.9.17' (ECDSA) to the list of known hosts.


RUN:xdsh c910f03c09k17 "mkdir -p /tmp/backupnet/" [Mon May  6 01:54:29 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:if grep SUSE /etc/*release;then xdsh c910f03c09k17 "cp -f /etc/sysconfig/network/ifcfg-* /tmp/backupnet/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh c910f03c09k17 "cp -rf /etc/sysconfig/network-scripts /tmp/backupnet/"; elif grep Ubuntu /etc/*release;then xdsh c910f03c09k17 "cp -f /etc/network/interfaces.d/* /tmp/backupnet/;cp -f /etc/network/interfaces /tmp";else echo "Sorry,this is not supported os"; fi [Mon May  6 01:54:30 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
/etc/os-release:NAME="Red Hat Enterprise Linux"
/etc/os-release:PRETTY_NAME="Red Hat Enterprise Linux 8.0 (Ootpa)"
/etc/os-release:REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 8"
/etc/os-release:REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
/etc/redhat-release:Red Hat Enterprise Linux release 8.0 (Ootpa)
/etc/system-release:Red Hat Enterprise Linux release 8.0 (Ootpa)

RUN:if grep -E "Red Hat|CentOS" /etc/*release;then xdsh c910f03c09k17 "yum -y install bridge-utils";fi [Mon May  6 01:54:31 2019]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
/etc/os-release:NAME="Red Hat Enterprise Linux"
/etc/os-release:PRETTY_NAME="Red Hat Enterprise Linux 8.0 (Ootpa)"
/etc/os-release:REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 8"
/etc/os-release:REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
/etc/redhat-release:Red Hat Enterprise Linux release 8.0 (Ootpa)
/etc/system-release:Red Hat Enterprise Linux release 8.0 (Ootpa)
c910f03c09k17: Updating Subscription Management repositories.
c910f03c09k17: Unable to read consumer identity
c910f03c09k17: This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.
[c910f03c09k15]: c910f03c09k17: Error: There are no enabled repos.

RUN:cnip=__GETNODEATTR(c910f03c09k17,ip)__;echo $cnip;var3=100.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test1 net=$secondnet mask=255.255.0.0 mgtifname=enp0s2 [Mon May  6 01:54:32 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
10.3.9.17
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:cnip=__GETNODEATTR(c910f03c09k17,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;chdef c910f03c09k17 nicips.enp0s2=$second1ip nictypes.enp0s2=Ethernet nicnetworks.enp0s2=confignetworks_test1 [Mon May  6 01:54:33 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
10.3.9.17
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:cnip=__GETNODEATTR(c910f03c09k17,ip)__;echo $cnip;var3=101.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test2 net=$secondnet mask=255.255.0.0 mgtifname=enp0s3 [Mon May  6 01:54:34 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
10.3.9.17
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:cnip=__GETNODEATTR(c910f03c09k17,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;chdef c910f03c09k17 nicips.enp0s3=$second1ip nictypes.enp0s3=Ethernet nicnetworks.enp0s3=confignetworks_test2 [Mon May  6 01:54:35 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
10.3.9.17
1 object definitions have been created or modified.

RUN:updatenode c910f03c09k17 -P confignetwork [Mon May  6 01:54:36 2019]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
c910f03c09k17: =============updatenode starting====================
c910f03c09k17: trying to download postscripts...
c910f03c09k17: postscripts downloaded successfully
c910f03c09k17: trying to get mypostscript from 10.3.9.15...
c910f03c09k17: postscript start..: confignetwork
c910f03c09k17: [I]: NetworkManager is active
c910f03c09k17: [I]: back up /etc/sysconfig/network-scripts to /etc/sysconfig/network-scripts.xcatbak
c910f03c09k17: [I]: All valid nics and device list:
c910f03c09k17: [I]: enp0s2
c910f03c09k17: [I]: enp0s3
c910f03c09k17: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f03c09k17: configure nic and its device : enp0s2
c910f03c09k17: [I]: configure enp0s2
c910f03c09k17: [I]: call: NMCLI_USED=1 configeth enp0s2 100.3.9.17 confignetworks_test1
c910f03c09k17: [I]: configeth on c910f03c09k17: os type: redhat
c910f03c09k17: configeth on c910f03c09k17: old configuration: 3: enp0s2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
c910f03c09k17:     link/ether 42:ce:0a:03:09:11 brd ff:ff:ff:ff:ff:ff
c910f03c09k17: [I]: configeth on c910f03c09k17: new configuration
c910f03c09k17:        100.3.9.17, 100.3.0.0, 255.255.0.0,
c910f03c09k17: 3: enp0s2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
c910f03c09k17: [I]: configeth on c910f03c09k17: enp0s2 changed, modify the configuration files
c910f03c09k17: Connection 'xcat-enp0s2' (da343603-cd55-480d-8e1b-62c5420a8f53) successfully added.
c910f03c09k17: bring up ip
c910f03c09k17: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/146)
c910f03c09k17: [I]: [Ethernet] >> 3: enp0s2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
c910f03c09k17: [I]: [Ethernet] >>     link/ether 42:ce:0a:03:09:11 brd ff:ff:ff:ff:ff:ff
c910f03c09k17: [I]: [Ethernet] >>     inet 100.3.9.17/16 brd 100.3.255.255 scope global noprefixroute enp0s2
c910f03c09k17: [I]: [Ethernet] >>        valid_lft forever preferred_lft forever
c910f03c09k17: [I]: [Ethernet] >>     inet6 fe80::98c5:7002:2db3:b5bb/64 scope link tentative noprefixroute
c910f03c09k17: [I]: [Ethernet] >>        valid_lft forever preferred_lft forever
c910f03c09k17: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f03c09k17: configure nic and its device : enp0s3
c910f03c09k17: [I]: configure enp0s3
c910f03c09k17: [I]: call: NMCLI_USED=1 configeth enp0s3 101.3.9.17 confignetworks_test2
c910f03c09k17: [I]: configeth on c910f03c09k17: os type: redhat
c910f03c09k17: configeth on c910f03c09k17: old configuration: 4: enp0s3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
c910f03c09k17:     link/ether 42:5b:0a:03:09:11 brd ff:ff:ff:ff:ff:ff
c910f03c09k17: [I]: configeth on c910f03c09k17: new configuration
c910f03c09k17:        101.3.9.17, 101.3.0.0, 255.255.0.0,
c910f03c09k17: 4: enp0s3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
c910f03c09k17: [I]: configeth on c910f03c09k17: enp0s3 changed, modify the configuration files
c910f03c09k17: Connection 'xcat-enp0s3' (58df5154-16f7-4f34-bbb2-5536c929e981) successfully added.
c910f03c09k17: bring up ip
c910f03c09k17: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/147)
c910f03c09k17: [I]: [Ethernet] >> 4: enp0s3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
c910f03c09k17: [I]: [Ethernet] >>     link/ether 42:5b:0a:03:09:11 brd ff:ff:ff:ff:ff:ff
c910f03c09k17: [I]: [Ethernet] >>     inet 101.3.9.17/16 brd 101.3.255.255 scope global noprefixroute enp0s3
c910f03c09k17: [I]: [Ethernet] >>        valid_lft forever preferred_lft forever
c910f03c09k17: [I]: [Ethernet] >>     inet6 fe80::37a7:f2e0:7b63:3833/64 scope link tentative noprefixroute
c910f03c09k17: [I]: [Ethernet] >>        valid_lft forever preferred_lft forever
c910f03c09k17: postscript end....: confignetwork exited with code 0
c910f03c09k17: Running of postscripts has completed.
c910f03c09k17: =============updatenode ending====================
CHECK:rc == 0	[Pass]

RUN:chdef c910f03c09k17 nicips.enp0s2= nictypes.enp0s2= nicnetworks.enp0s2= nicips.enp0s3= nictypes.enp0s3= nicnetworks.enp0s3= [Mon May  6 01:54:39 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:cnip=__GETNODEATTR(c910f03c09k17,ip)__;echo $cnip;var3=102.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test3 net=$secondnet mask=255.255.0.0 [Mon May  6 01:54:39 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
10.3.9.17
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:cnip=__GETNODEATTR(c910f03c09k17,ip)__;echo $cnip;var3=103.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test4 net=$secondnet mask=255.255.0.0 [Mon May  6 01:54:40 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
10.3.9.17
1 object definitions have been created or modified.

RUN:cnip=__GETNODEATTR(c910f03c09k17,ip)__;echo $cnip;var1=102;var2=103;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;br22ip=$var1$var3;br33ip=$var2$var3;chdef c910f03c09k17 nicdevices.br22=bond0.2 nicdevices.br33=bond0.3 nictypes.br22=bridge nictypes.br33=bridge nicnetworks.br22=confignetworks_test3 nicnetworks.br33=confignetworks_test4 nicips.br22=$br22ip nicips.br33=$br33ip nicdevices.bond0.2=bond0 nicdevices.bond0.3=bond0 nictypes.bond0.2=vlan nictypes.bond0.3=vlan nictypes.bond0=bond nictypes.enp0s2=ethernet nictypes.enp0s3=ethernet nicdevices.bond0="enp0s2|enp0s3" [Mon May  6 01:54:41 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
10.3.9.17
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:updatenode c910f03c09k17 -P confignetwork [Mon May  6 01:54:42 2019]
ElapsedTime:91 sec
RETURN rc = 0
OUTPUT:
c910f03c09k17: =============updatenode starting====================
c910f03c09k17: trying to download postscripts...
c910f03c09k17: postscripts downloaded successfully
c910f03c09k17: trying to get mypostscript from 10.3.9.15...
c910f03c09k17: postscript start..: confignetwork
c910f03c09k17: [I]: NetworkManager is active
c910f03c09k17: [I]: All valid nics and device list:
c910f03c09k17: [I]: bond0 enp0s2@enp0s3
c910f03c09k17: [I]: bond0.2 bond0
c910f03c09k17: [I]: bond0.3 bond0
c910f03c09k17: [I]: br22 bond0.2
c910f03c09k17: [I]: br33 bond0.3
c910f03c09k17: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f03c09k17: configure nic and its device : bond0 enp0s2@enp0s3
c910f03c09k17: [I]: create_bond_interface_nmcli bondname=bond0 slave_ports=enp0s2,enp0s3 slave_type=ethernet _ipaddr= next_nic=bond0.2 bond0.3
c910f03c09k17: [I]: create bond connection xcat-bond-bond0
c910f03c09k17: [I]: nmcli con add type bond con-name xcat-bond-bond0 ifname bond0 bond.options mode=802.3ad,miimon=100 autoconnect yes connection.autoconnect-priority 9
c910f03c09k17: Connection 'xcat-bond-bond0' (056a95a4-76a0-4c76-beb0-e1cf30046be0) successfully added.
c910f03c09k17: Connection 'xcat-enp0s2' successfully deactivated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/146)
c910f03c09k17: [I]: nmcli con add type Ethernet con-name xcat-bond-slave-enp0s2 method none ifname enp0s2 master xcat-bond-bond0 autoconnect yes connection.autoconnect-priority 9
c910f03c09k17: Connection 'xcat-bond-slave-enp0s2' (bee49ce6-e878-46af-b8be-60339b74b86f) successfully added.
c910f03c09k17: [I]: nmcli con up xcat-bond-slave-enp0s2
c910f03c09k17: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/149)
c910f03c09k17: Connection 'xcat-enp0s3' successfully deactivated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/147)
c910f03c09k17: [I]: nmcli con add type Ethernet con-name xcat-bond-slave-enp0s3 method none ifname enp0s3 master xcat-bond-bond0 autoconnect yes connection.autoconnect-priority 9
c910f03c09k17: Connection 'xcat-bond-slave-enp0s3' (c24d0ef0-060e-4794-927b-691c610a85e7) successfully added.
c910f03c09k17: [I]: nmcli con up xcat-bond-slave-enp0s3
c910f03c09k17: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/150)
c910f03c09k17: [I]: nmcli con up xcat-bond-bond0
c910f03c09k17: Connection successfully activated (master waiting for slaves) (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/151)
c910f03c09k17: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f03c09k17: configure nic and its device : bond0.2 bond0
c910f03c09k17: [I]: create_vlan_interface_nmcli ifname=bond0 vlanid=2 ipaddrs= next_nic=br22
c910f03c09k17: [I]: check parent interface bond0 whether it is managed by NetworkManager
c910f03c09k17: Connection 'xcat-vlan-bond0.2' (ed6b91fd-fda5-4a1f-b959-dba75e6ef9a6) successfully added.
c910f03c09k17: [I]: create NetworkManager connection for bond0.2
c910f03c09k17: [I]: [vlan] >> 6: bond0.2@bond0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default qlen 1000
c910f03c09k17: [I]: [vlan] >>     link/ether 42:ce:0a:03:09:11 brd ff:ff:ff:ff:ff:ff
c910f03c09k17: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f03c09k17: configure nic and its device : bond0.3 bond0
c910f03c09k17: [I]: create_vlan_interface_nmcli ifname=bond0 vlanid=3 ipaddrs= next_nic=br33
c910f03c09k17: [I]: check parent interface bond0 whether it is managed by NetworkManager
c910f03c09k17: Connection 'xcat-vlan-bond0.3' (16e56dd1-0f70-4353-8397-8b4e356348d5) successfully added.
c910f03c09k17: [I]: create NetworkManager connection for bond0.3
c910f03c09k17: [I]: [vlan] >> 7: bond0.3@bond0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
c910f03c09k17: [I]: [vlan] >>     link/ether 42:ce:0a:03:09:11 brd ff:ff:ff:ff:ff:ff
c910f03c09k17: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f03c09k17: configure nic and its device : br22 bond0.2
c910f03c09k17: [I]: create_bridge_interface_nmcli ifname=br22 _brtype=bridge _port=bond0.2 _pretype=vlan _ipaddr=102.3.9.17
c910f03c09k17: [I]: Pickup xcatnet, "confignetworks_test3", from NICNETWORKS for interface "br22".
c910f03c09k17: [I]: create bridge connection xcat-bridge-br22
c910f03c09k17: [I]: nmcli con add type bridge con-name xcat-bridge-br22 ifname br22 connection.autoconnect-priority 9
c910f03c09k17: Connection 'xcat-bridge-br22' (b625f892-8801-4e50-9018-b2da6e95754f) successfully added.
c910f03c09k17: [I]: create vlan slaves connetcion xcat-vlan-bond0.2 for bridge
c910f03c09k17: [I]: nmcli con mod xcat-vlan-bond0.2 master br22  connection.autoconnect-priority 9
c910f03c09k17: [I]: add ip 102.3.9.17/16 to bridge
c910f03c09k17: [I]: nmcli con up xcat-bridge-br22
c910f03c09k17: Connection successfully activated (master waiting for slaves) (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/157)
c910f03c09k17: [I]: nmcli con up xcat-vlan-bond0.2
c910f03c09k17: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/158)
c910f03c09k17: [I]: State of "br22" was "DOWN" instead of expected "UP". Wait 0 of 20 with interval 40.
c910f03c09k17: [I]: [bridge] >> 8: br22: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
c910f03c09k17: [I]: [bridge] >>     link/ether 42:ce:0a:03:09:11 brd ff:ff:ff:ff:ff:ff
c910f03c09k17: [I]: [bridge] >>     inet 102.3.9.17/16 brd 102.3.255.255 scope global noprefixroute br22
c910f03c09k17: [I]: [bridge] >>        valid_lft forever preferred_lft forever
c910f03c09k17: [I]: [bridge] >>     inet6 fe80::9ee5:a59e:9b52:1907/64 scope link noprefixroute
c910f03c09k17: [I]: [bridge] >>        valid_lft forever preferred_lft forever
c910f03c09k17: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f03c09k17: configure nic and its device : br33 bond0.3
c910f03c09k17: [I]: create_bridge_interface_nmcli ifname=br33 _brtype=bridge _port=bond0.3 _pretype=vlan _ipaddr=103.3.9.17
c910f03c09k17: [I]: Pickup xcatnet, "confignetworks_test4", from NICNETWORKS for interface "br33".
c910f03c09k17: [I]: create bridge connection xcat-bridge-br33
c910f03c09k17: [I]: nmcli con add type bridge con-name xcat-bridge-br33 ifname br33 connection.autoconnect-priority 9
c910f03c09k17: Connection 'xcat-bridge-br33' (cdbca0c3-4fa7-4221-abd6-0eb40818fe5b) successfully added.
c910f03c09k17: [I]: create vlan slaves connetcion xcat-vlan-bond0.3 for bridge
c910f03c09k17: [I]: nmcli con mod xcat-vlan-bond0.3 master br33  connection.autoconnect-priority 9
c910f03c09k17: [I]: add ip 103.3.9.17/16 to bridge
c910f03c09k17: [I]: nmcli con up xcat-bridge-br33
c910f03c09k17: Connection successfully activated (master waiting for slaves) (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/160)
c910f03c09k17: [I]: nmcli con up xcat-vlan-bond0.3
c910f03c09k17: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/161)
c910f03c09k17: [I]: State of "br33" was "DOWN" instead of expected "UP". Wait 0 of 20 with interval 40.
c910f03c09k17: [I]: [bridge] >> 9: br33: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
c910f03c09k17: [I]: [bridge] >>     link/ether 42:ce:0a:03:09:11 brd ff:ff:ff:ff:ff:ff
c910f03c09k17: [I]: [bridge] >>     inet 103.3.9.17/16 brd 103.3.255.255 scope global noprefixroute br33
c910f03c09k17: [I]: [bridge] >>        valid_lft forever preferred_lft forever
c910f03c09k17: [I]: [bridge] >>     inet6 fe80::2c59:490b:97d0:637b/64 scope link noprefixroute
c910f03c09k17: [I]: [bridge] >>        valid_lft forever preferred_lft forever
c910f03c09k17: postscript end....: confignetwork exited with code 0
c910f03c09k17: Running of postscripts has completed.
c910f03c09k17: =============updatenode ending====================
CHECK:rc == 0	[Pass]

RUN:cnip=__GETNODEATTR(c910f03c09k17,ip)__;echo $cnip;var1=102;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;br22ip=$var1$var3;if grep SUSE /etc/*release;then xdsh c910f03c09k17 "grep $br22ip /etc/sysconfig/network/ifcfg-br22"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh c910f03c09k17  "grep $br22ip /etc/sysconfig/network-scripts/ifcfg-*br22*"; elif grep Ubuntu /etc/*release;then xdsh c910f03c09k17 "grep $br22ip /etc/network/interfaces.d/br22";else echo "Sorry,this is not supported os"; fi [Mon May  6 01:56:13 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
10.3.9.17
/etc/os-release:NAME="Red Hat Enterprise Linux"
/etc/os-release:PRETTY_NAME="Red Hat Enterprise Linux 8.0 (Ootpa)"
/etc/os-release:REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 8"
/etc/os-release:REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
/etc/redhat-release:Red Hat Enterprise Linux release 8.0 (Ootpa)
/etc/system-release:Red Hat Enterprise Linux release 8.0 (Ootpa)
c910f03c09k17: IPADDR=102.3.9.17
CHECK:rc == 0	[Pass]

RUN:cnip=__GETNODEATTR(c910f03c09k17,ip)__;echo $cnip;var1=103;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;br33ip=$var1$var3;if grep SUSE /etc/*release;then xdsh c910f03c09k17 "grep $br33ip /etc/sysconfig/network/ifcfg-br33"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh c910f03c09k17  "grep $br33ip /etc/sysconfig/network-scripts/ifcfg-*br33*"; elif grep Ubuntu /etc/*release;then xdsh c910f03c09k17 "grep $br33ip /etc/network/interfaces.d/br33";else echo "Sorry,this is not supported os"; fi [Mon May  6 01:56:14 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
10.3.9.17
/etc/os-release:NAME="Red Hat Enterprise Linux"
/etc/os-release:PRETTY_NAME="Red Hat Enterprise Linux 8.0 (Ootpa)"
/etc/os-release:REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 8"
/etc/os-release:REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
/etc/redhat-release:Red Hat Enterprise Linux release 8.0 (Ootpa)
/etc/system-release:Red Hat Enterprise Linux release 8.0 (Ootpa)
c910f03c09k17: IPADDR=103.3.9.17
CHECK:rc == 0	[Pass]

RUN:xdsh c910f03c09k17 "ls /sys/class/net" [Mon May  6 01:56:15 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f03c09k17: bond0
c910f03c09k17: bond0.2
c910f03c09k17: bond0.3
c910f03c09k17: bonding_masters
c910f03c09k17: br22
c910f03c09k17: br33
c910f03c09k17: enp0s1
c910f03c09k17: enp0s2
c910f03c09k17: enp0s3
c910f03c09k17: lo
CHECK:output =~ br22	[Pass]
CHECK:output =~ br33	[Pass]

RUN:xdsh c910f03c09k17 "cat /sys/class/net/bonding_masters" [Mon May  6 01:56:16 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f03c09k17: bond0
CHECK:output =~ bond0	[Pass]

RUN:rmdef -t network -o confignetworks_test1 [Mon May  6 01:56:17 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.

RUN:rmdef -t network -o confignetworks_test2 [Mon May  6 01:56:17 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.

RUN:if grep SUSE /etc/*release;then xdsh c910f03c09k17 "rm -rf /etc/sysconfig/network/ifcfg-enp0s2"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh c910f03c09k17 "rm -rf /etc/sysconfig/network-scripts"; elif grep Ubuntu /etc/*release;then xdsh c910f03c09k17 "rm -rf /etc/network/interfaces.d/enp0s2";else echo "Sorry,this is not supported os"; fi [Mon May  6 01:56:18 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
/etc/os-release:NAME="Red Hat Enterprise Linux"
/etc/os-release:PRETTY_NAME="Red Hat Enterprise Linux 8.0 (Ootpa)"
/etc/os-release:REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 8"
/etc/os-release:REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
/etc/redhat-release:Red Hat Enterprise Linux release 8.0 (Ootpa)
/etc/system-release:Red Hat Enterprise Linux release 8.0 (Ootpa)
CHECK:rc == 0	[Pass]

RUN:rmdef -t network -o confignetworks_test3 [Mon May  6 01:56:18 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.

RUN:cnip=__GETNODEATTR(c910f03c09k17,ip)__;echo $cnip;var1=102;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;br22ip=$var1$var2;xdsh c910f03c09k17 "ip addr del $br22ip/16 dev br22" [Mon May  6 01:56:19 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
10.3.9.17

RUN:xdsh c910f03c09k17 "ip link del dev br22" [Mon May  6 01:56:20 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:rmdef -t network -o confignetworks_test4 [Mon May  6 01:56:21 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.

RUN:cnip=__GETNODEATTR(c910f03c09k17,ip)__;echo $cnip;var1=103;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;br33ip=$var1$var2;xdsh c910f03c09k17 "ip addr del $br33ip/16 dev br33" [Mon May  6 01:56:21 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
10.3.9.17

RUN:xdsh c910f03c09k17 "ip link del dev br33" [Mon May  6 01:56:23 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:xdsh c910f03c09k17 "ip link del dev bond0.2" [Mon May  6 01:56:24 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:xdsh c910f03c09k17 "ip link del dev bond0.3" [Mon May  6 01:56:24 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:xdsh c910f03c09k17 "ip link del dev bond0" [Mon May  6 01:56:25 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:cnip=__GETNODEATTR(c910f03c09k17,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;secondip=$var1$var2;xdsh c910f03c09k17 "ip addr del $secondip/16 dev enp0s2" [Mon May  6 01:56:26 2019]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
10.3.9.17
[c910f03c09k15]: c910f03c09k17: RTNETLINK answers: Cannot assign requested address

RUN:cnip=__GETNODEATTR(c910f03c09k17,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;secondip=$var1$var2;xdsh c910f03c09k17 "ip addr del $secondip/16 dev enp0s3" [Mon May  6 01:56:27 2019]
ElapsedTime:2 sec
RETURN rc = 1
OUTPUT:
10.3.9.17
[c910f03c09k15]: c910f03c09k17: RTNETLINK answers: Cannot assign requested address

RUN:xdsh c910f03c09k17 "echo -bond0 > /sys/class/net/bonding_masters" [Mon May  6 01:56:29 2019]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
[c910f03c09k15]: c910f03c09k17: bash: line 0: echo: write error: No such device

RUN:if grep SUSE /etc/*release;then xdsh c910f03c09k17 "rm -rf /etc/sysconfig/network/ifcfg-bond0 /etc/sysconfig/network/ifcfg-bond0.2 /etc/sysconfig/network/ifcfg-bond0.3 /etc/sysconfig/network/ifcfg-br22 /etc/sysconfig/network/ifcfg-br33"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh c910f03c09k17 "rm -rf /etc/sysconfig/network-scripts"; elif grep Ubuntu /etc/*release;then xdsh c910f03c09k17 "rm -rf /etc/network/interfaces.d/bond0 /etc/network/interfaces.d/bond0.2 /etc/network/interfaces.d/bond0.3 /etc/network/interfaces.d/br22 /etc/network/interfaces.d/br33";else echo "Sorry,this is not supported os"; fi [Mon May  6 01:56:29 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
/etc/os-release:NAME="Red Hat Enterprise Linux"
/etc/os-release:PRETTY_NAME="Red Hat Enterprise Linux 8.0 (Ootpa)"
/etc/os-release:REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 8"
/etc/os-release:REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
/etc/redhat-release:Red Hat Enterprise Linux release 8.0 (Ootpa)
/etc/system-release:Red Hat Enterprise Linux release 8.0 (Ootpa)
CHECK:rc == 0	[Pass]

RUN:if [ -e /tmp/CN.standa ]; then rmdef c910f03c09k17; cat /tmp/CN.standa | mkdef -z; rm -rf /tmp/CN.standa; fi [Mon May  6 01:56:30 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:if grep SUSE /etc/*release;then xdsh c910f03c09k17 "cp -f /tmp/backupnet/* /etc/sysconfig/network/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh c910f03c09k17 "cp -rf /tmp/backupnet/network-scripts /etc/sysconfig/"; elif grep Ubuntu /etc/*release;then xdsh c910f03c09k17 "cp -f /tmp/backupnet/* /etc/network/interfaces.d/;cp -f /tmp/interfaces /etc/network/";else echo "Sorry,this is not supported os"; fi [Mon May  6 01:56:31 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
/etc/os-release:NAME="Red Hat Enterprise Linux"
/etc/os-release:PRETTY_NAME="Red Hat Enterprise Linux 8.0 (Ootpa)"
/etc/os-release:REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 8"
/etc/os-release:REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
/etc/redhat-release:Red Hat Enterprise Linux release 8.0 (Ootpa)
/etc/system-release:Red Hat Enterprise Linux release 8.0 (Ootpa)
CHECK:rc == 0	[Pass]

RUN:xdsh c910f03c09k17 "systemctl status NetworkManager >/dev/null 2>/dev/null && which nmcli >/dev/null 2>/dev/null && nmcli con reload" [Mon May  6 01:56:32 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:xdsh c910f03c09k17 "rm -rf /tmp/backupnet/ /tmp/interfaces" [Mon May  6 01:56:33 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:chtab -d node=c910f03c09k17 nics [Mon May  6 01:56:34 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::confignetwork_2eth_bridge_br22_br33::Passed::Time:Mon May  6 01:56:34 2019 ::Duration::126 sec------
```