### PR TITLE
add wait time to wait nmcli device ready

### DIFF
--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -1878,7 +1878,7 @@ function wait_nic_connect_intime {
     fi
     i=0
     while [ $i -lt "$time_out" ]; do
-	con_name=$(nmcli dev show $_port|grep GENERAL.CONNECTION|awk -F: '{print $2}'|sed 's/^[ \t]*//g')
+	con_name=$(nmcli dev show $nic_name|grep GENERAL.CONNECTION|awk -F: '{print $2}'|sed 's/^[ \t]*//g')
         if [ ! -z "$con_name" -a "$con_name" != "--" ]; then
             break
         fi


### PR DESCRIPTION
### The PR is to fix issue 
https://github.com/xcat2/xcat-core/issues/6228

### The modification include
In some servers, after `nmcli` create vlan connection, it need time to connect device and connection. In `updatenode`, the speed is too fast between `nmcli` create slave vlan and master bridge, here adding a function to add wait time.   

### The UT result
```
]# updatenode c910f04x37v10 confignetwork
c910f04x37v10: =============updatenode starting====================
c910f04x37v10: trying to download postscripts...
c910f04x37v10: postscripts downloaded successfully
c910f04x37v10: trying to get mypostscript from 10.4.37.8...
c910f04x37v10: postscript start..: confignetwork
c910f04x37v10: [I]: NetworkManager is active
c910f04x37v10: [I]: All valid nics and device list:
c910f04x37v10: [I]: bond0 ens4@ens5
c910f04x37v10: [I]: bond0.2 bond0
c910f04x37v10: [I]: br22 bond0.2
c910f04x37v10: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f04x37v10: configure nic and its device : bond0 ens4@ens5
c910f04x37v10: [I]: create_bond_interface_nmcli bondname=bond0 slave_ports=ens4,ens5 slave_type=ethernet _ipaddr= next_nic=bond0.2
c910f04x37v10: [I]: xcat-bond-bond0 exists, rename old xcat-bond-bond0 to xcat-bond-bond0-tmp
c910f04x37v10: [I]: create bond connection xcat-bond-bond0
c910f04x37v10: [I]: nmcli con add type bond con-name xcat-bond-bond0 ifname bond0 bond.options mode=802.3ad,miimon=100 autoconnect yes connection.autoconnect-priority 9
c910f04x37v10: Connection 'xcat-bond-bond0' (05afe791-776b-4b4e-b582-cf79ab58f778) successfully added.
c910f04x37v10: Connection 'xcat-bond-slave-ens4' successfully deactivated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/913)
c910f04x37v10: [I]: rename xcat-bond-slave-ens4 to xcat-bond-slave-ens4-tmp
c910f04x37v10: [I]: nmcli con add type Ethernet con-name xcat-bond-slave-ens4 method none ifname ens4 master xcat-bond-bond0 autoconnect yes connection.autoconnect-priority 9
c910f04x37v10: Connection 'xcat-bond-slave-ens4' (ffae2342-1eac-4534-bdc1-1ad964f9e1a0) successfully added.
c910f04x37v10: [I]: nmcli con up xcat-bond-slave-ens4
c910f04x37v10: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/922)
c910f04x37v10: Connection 'xcat-bond-slave-ens5' successfully deactivated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/923)
c910f04x37v10: [I]: rename xcat-bond-slave-ens5 to xcat-bond-slave-ens5-tmp
c910f04x37v10: [I]: nmcli con add type Ethernet con-name xcat-bond-slave-ens5 method none ifname ens5 master xcat-bond-bond0 autoconnect yes connection.autoconnect-priority 9
c910f04x37v10: Connection 'xcat-bond-slave-ens5' (6b140641-bce6-43f6-ba7b-2ba4bb21bdc7) successfully added.
c910f04x37v10: [I]: nmcli con up xcat-bond-slave-ens5
c910f04x37v10: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/927)
c910f04x37v10: [I]: nmcli con up xcat-bond-bond0
c910f04x37v10: Connection successfully activated (master waiting for slaves) (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/928)
c910f04x37v10: Connection 'xcat-bond-bond0-tmp' (13b50ed7-21c9-49c9-a8cf-07d10cddb8cf) successfully deleted.
c910f04x37v10: Connection 'xcat-bond-slave-ens4-tmp' (854a0251-ec50-47bd-819c-2c638b8f7375) successfully deleted.
c910f04x37v10: Connection 'xcat-bond-slave-ens5-tmp' (f7af64f2-b292-42d4-8ed9-6dc485d9dfb8) successfully deleted.
c910f04x37v10: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f04x37v10: configure nic and its device : bond0.2 bond0
c910f04x37v10: [I]: create_vlan_interface_nmcli ifname=bond0 vlanid=2 ipaddrs= next_nic=br22
c910f04x37v10: [I]: check parent interface bond0 whether it is managed by NetworkManager
c910f04x37v10: Connection 'xcat-vlan-bond0.2' (c6aa1eaa-7b14-4f5e-913a-b12189fea13a) successfully added.
c910f04x37v10: [I]: create NetworkManager connection for bond0.2
c910f04x37v10: Connection 'xcat-vlan-bond0.2-tmp' (e298ae56-1152-4331-83cd-717a4dd91679) successfully deleted.
c910f04x37v10: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f04x37v10: configure nic and its device : br22 bond0.2
c910f04x37v10: [I]: create_bridge_interface_nmcli ifname=br22 _brtype=bridge _port=bond0.2 _pretype=vlan _ipaddr=102.3.9.8
c910f04x37v10: [I]: Pickup xcatnet, "confignetworks_test3", from NICNETWORKS for interface "br22".
c910f04x37v10: [I]: xcat-bridge-br22 exists, down it first
c910f04x37v10: Connection 'xcat-bridge-br22' successfully deactivated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/820)
c910f04x37v10: Cannot find device "br22"
c910f04x37v10: [I]: xcat-bridge-br22 exists, rename old xcat-bridge-br22 to xcat-bridge-br22-tmp
c910f04x37v10: [I]: create bridge connection xcat-bridge-br22
c910f04x37v10: [I]: nmcli con add type bridge con-name xcat-bridge-br22 ifname br22 mtu 1500 connection.autoconnect-priority 9
c910f04x37v10: Connection 'xcat-bridge-br22' (fbe9910a-9551-4f74-af20-25ff78113d38) successfully added.
c910f04x37v10: [I]: create vlan slaves connetcion xcat-vlan-bond0.2 for bridge
c910f04x37v10: [I]: nmcli con mod xcat-vlan-bond0.2 master br22 mtu 1500 connection.autoconnect-priority 9
c910f04x37v10: [I]: add ip 102.3.9.8/16 to bridge
c910f04x37v10: [I]: nmcli con up xcat-bridge-br22
c910f04x37v10: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/932)
c910f04x37v10: [I]: nmcli con up xcat-vlan-bond0.2
c910f04x37v10: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/933)
c910f04x37v10: Connection 'xcat-bridge-br22-tmp' (24512d15-5a33-4833-afb4-dc2707b7961a) successfully deleted.
c910f04x37v10: [I]: State of "br22" was "DOWN" instead of expected "UP". Wait 0 of 20 with interval 40.
c910f04x37v10: [I]: [bridge] >> 167: br22: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
c910f04x37v10: [I]: [bridge] >>     link/ether 42:59:0a:04:25:0a brd ff:ff:ff:ff:ff:ff
c910f04x37v10: [I]: [bridge] >>     inet 102.3.9.8/16 brd 102.3.255.255 scope global noprefixroute br22
c910f04x37v10: [I]: [bridge] >>        valid_lft forever preferred_lft forever
c910f04x37v10: [I]: [bridge] >>     inet6 fe80::8cdc:5bc9:d4a5:c52/64 scope link noprefixroute
c910f04x37v10: [I]: [bridge] >>        valid_lft forever preferred_lft forever
c910f04x37v10: postscript end....: confignetwork exited with code 0
c910f04x37v10: Running of postscripts has completed.
c910f04x37v10: =============updatenode ending====================
```

