### PR TITLE
update the script to remove false error

### DIFF
--- a/xCAT-test/autotest/testcase/genesis/test.sh
+++ b/xCAT-test/autotest/testcase/genesis/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 function check_destiny(){
-chdef testnode arch=ppc64le cons=ipmi groups=all ip=60.1.1.1 netboot=$NETBOOT;
+chdef testnode arch=ppc64le cons=ipmi groups=all ip=60.1.1.1 mac=4e:ee:ee:ee:ee:0e netboot=$NETBOOT;
 masterip=`lsdef -t site -i master -c 2>&1 | awk -F'=' '{print $2}'`;
 masternet=`ifconfig  | awk "BEGIN{RS=\"\"}/\<$masterip\>/{print \$1}"|head -n 1 | awk -F ' ' '{print $1}'|awk -F ":"  '{print \$1}' 2>&1`;
 net2=`netstat -i -a|grep -v Kernel|grep -v Iface |grep -v lo|grep -v $masternet|head -n 1|awk '{print $1}'`;echo net2 is  $net2;


### PR DESCRIPTION
This is for task https://github.ibm.com/xcat2/task_management/issues/190

When there is no mac in node definition, nodeset will return error. This is correct.  Need to add mac in the node definition to let the case pass.


The UT on rhels7.6
```
------START::nodeset_shell_incorrectmasterip::Time:Mon May  6 23:46:00 2019------

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh --check xnba [Mon May  6 23:46:00 2019]
ElapsedTime:31 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
New object definitions 'testnode' have been created.
net2 is eth1
testnode: shell
imgargs kernel quiet xcatd=60.3.3.3:3001 destiny=shell BOOTIF=01-${netX/machyp}
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh --check grub2 [Mon May  6 23:46:31 2019]
ElapsedTime:32 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
net2 is eth1
testnode: shell
    linux /xcat/genesis.kernel.ppc64 quiet xcatd=60.3.3.3:3001 destiny=shell
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh --check petitboot [Mon May  6 23:47:03 2019]
ElapsedTime:31 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
net2 is eth1
testnode: shell
	append "quiet xcatd=60.3.3.3:3001 destiny=shell"
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh -c [Mon May  6 23:47:34 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

------END::nodeset_shell_incorrectmasterip::Passed::Time:Mon May  6 23:47:35 2019 ::Duration::95 sec------
------Total: 1 , Failed: 0------

```

The UT on rhels8
```
------START::nodeset_shell_incorrectmasterip::Time:Tue May  7 01:54:21 2019------

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh --check xnba [Tue May  7 01:54:21 2019]
ElapsedTime:30 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
New object definitions 'testnode' have been created.
net2 is enp0s2
testnode: shell
imgargs kernel quiet xcatd=60.3.3.3:3001 destiny=shell BOOTIF=01-${netX/machyp}
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh --check grub2 [Tue May  7 01:54:51 2019]
ElapsedTime:30 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
net2 is enp0s2
testnode: shell
    linux /xcat/genesis.kernel.ppc64 quiet xcatd=60.3.3.3:3001 destiny=shell
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh --check petitboot [Tue May  7 01:55:21 2019]
ElapsedTime:30 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
net2 is enp0s2
testnode: shell
	append "quiet xcatd=60.3.3.3:3001 destiny=shell"
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh -c [Tue May  7 01:55:51 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

------END::nodeset_shell_incorrectmasterip::Passed::Time:Tue May  7 01:55:52 2019 ::Duration::91 sec------
------Total: 1 , Failed: 0------
```

The UT on ubuntu
```
------START::nodeset_shell_incorrectmasterip::Time:Tue May  7 01:52:22 2019------

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh --check xnba [Tue May  7 01:52:22 2019]
ElapsedTime:62 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
New object definitions 'testnode' have been created.
net2 is enp0s2
testnode: shell
imgargs kernel quiet xcatd=60.3.3.3:3001 destiny=shell BOOTIF=01-${netX/machyp}
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh --check grub2 [Tue May  7 01:53:24 2019]
ElapsedTime:61 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
net2 is enp0s2
testnode: shell
    linux /xcat/genesis.kernel.ppc64 quiet xcatd=60.3.3.3:3001 destiny=shell
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh --check petitboot [Tue May  7 01:54:25 2019]
ElapsedTime:60 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
net2 is enp0s2
testnode: shell
	append "quiet xcatd=60.3.3.3:3001 destiny=shell"
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh -c [Tue May  7 01:55:25 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

------END::nodeset_shell_incorrectmasterip::Passed::Time:Tue May  7 01:55:26 2019 ::Duration::184 sec------
------Total: 1 , Failed: 0------
```

The UT on sles
```
------START::nodeset_shell_incorrectmasterip::Time:Tue May  7 06:01:44 2019------

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh --check xnba [Tue May  7 06:01:44 2019]
ElapsedTime:37 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
New object definitions 'testnode' have been created.
net2 is eth1
testnode: shell
imgargs kernel quiet xcatd=60.3.3.3:3001 destiny=shell BOOTIF=01-${netX/machyp}
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh --check grub2 [Tue May  7 06:02:21 2019]
ElapsedTime:35 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
net2 is eth1
testnode: shell
    linux /xcat/genesis.kernel.ppc64 quiet xcatd=60.3.3.3:3001 destiny=shell
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh --check petitboot [Tue May  7 06:02:56 2019]
ElapsedTime:36 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
net2 is eth1
testnode: shell
	append "quiet xcatd=60.3.3.3:3001 destiny=shell"
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh -c [Tue May  7 06:03:32 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

------END::nodeset_shell_incorrectmasterip::Passed::Time:Tue May  7 06:03:33 2019 ::Duration::109 sec------
------Total: 1 , Failed: 0------

```