### PR TITLE
Add non zero return code to the error callback for copycds 

### DIFF
--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -2024,7 +2024,7 @@ sub copycd
         #If they say to call it something unidentifiable, give up?
         $callback->(
             {
-                error => "The name specified ($distname) is not supported. Use the following format: rh*,pkvm*,centos*,fedora*,SL*,ol*"
+                error => "The name specified ($distname) is not supported. Use the following format: rh*,pkvm*,centos*,fedora*,SL*,ol*", errorcode => [1]
             }
         );
         return;
@@ -2143,7 +2143,7 @@ sub copycd
         {
             $callback->(
                 {
-                    error => "Requested distribution architecture $arch, but media is $darch"
+                    error => "Requested distribution architecture $arch, but media is $darch", errorcode => [1]
                 }
             );
             return;
@@ -2156,7 +2156,7 @@ sub copycd
     {
         $callback->(
             {
-                error => "ARCH not be detected, provide an OS ARCH using the -a option. (ppc64le, x86_64)"
+                error => "ARCH not be detected, provide an OS ARCH using the -a option. (ppc64le, x86_64)", errorcode => [1]
             }
         );
         return;


### PR DESCRIPTION
Resolves  #6291 

Missing non  zero error in the return callback... copy  and pasted  code that  didn't have it. 

UT of the 3 locations that I changed... 

```
[root@stratton01 xCAT_plugin]# copycds -n aix /mnt/xcat/iso/redhat/7.4/RHEL-7.4-20170711.0-Server-x86_64-dvd1.iso
Error: [stratton01]: The name specified (aix) is not supported. Use the following format: rh*,pkvm*,centos*,fedora*,SL*,ol*
[root@stratton01 xCAT_plugin]# echo $?
1
```
```
[root@stratton01 xCAT_plugin]# copycds -a ppc64le /mnt/xcat/iso/redhat/7.4/RHEL-7.4-20170711.0-Server-x86_64-dvd1.iso
Error: [stratton01]: Requested distribution architecture ppc64le, but media is x86_64
[root@stratton01 xCAT_plugin]# echo $?
1
```

```
[root@stratton01 xCAT_plugin]# copycds -n centos7.6 /mnt/xcat/iso/centos/7.6/CentOS-7-power9-Minimal-1810.iso
Error: [stratton01]: ARCH not be detected, provide an OS ARCH using the -a option. (ppc64le, x86_64)
[root@stratton01 xCAT_plugin]# echo $?
1
```
