### PR TITLE
extend nmcli autoconnect-retries and autoconnect-slaves to replace default value

### DIFF
--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -1758,7 +1758,7 @@ function create_vlan_interface_nmcli {
         $nmcli con modify $con_name connection.id $tmp_con_name
     fi
     #create VLAN connetion
-    $nmcli con add type vlan con-name $con_name dev $ifname id $(( 10#$vlanid )) method none $_ipaddrs $_mtu connection.autoconnect-priority 9 autoconnect yes
+    $nmcli con add type vlan con-name $con_name dev $ifname id $(( 10#$vlanid )) method none $_ipaddrs $_mtu connection.autoconnect-priority 9 autoconnect yes connection.autoconnect-slaves 1
     log_info "create NetworkManager connection for $ifname.$vlanid"
 
     #add extra params
@@ -1970,7 +1970,7 @@ function create_bridge_interface_nmcli {
             fi
         fi
         log_info "create bridge connection $xcat_con_name"
-        cmd="$nmcli con add type bridge con-name $xcat_con_name ifname $ifname $_mtu connection.autoconnect-priority 9"
+        cmd="$nmcli con add type bridge con-name $xcat_con_name ifname $ifname $_mtu connection.autoconnect-priority 9 autoconnect yes connection.autoconnect-retries 0 connection.autoconnect-slaves 1"
         log_info $cmd
         $cmd
         if [ $? -ne 0 ]; then
@@ -2006,10 +2006,10 @@ function create_bridge_interface_nmcli {
         fi
         con_use_same_dev=$(wait_nic_connect_intime $_port)
         if [ "$con_use_same_dev" != "--" -a -n "$con_use_same_dev" ]; then
-            cmd="$nmcli con mod "$con_use_same_dev" master $ifname $_mtu connection.autoconnect-priority 9"
+            cmd="$nmcli con mod "$con_use_same_dev" master $ifname $_mtu connection.autoconnect-priority 9 autoconnect yes connection.autoconnect-slaves 1"
             xcat_slave_con=$con_use_same_dev
         else
-            cmd="$nmcli con add type $_pretype con-name $xcat_slave_con ifname $_port master $ifname $_mtu connection.autoconnect-priority 9"
+            cmd="$nmcli con add type $_pretype con-name $xcat_slave_con ifname $_port master $ifname $_mtu connection.autoconnect-priority 9 autoconnect yes connection.autoconnect-slaves 1"
         fi
         log_info "create $_pretype slaves connetcion $xcat_slave_con for bridge"
         log_info "$cmd"
@@ -2183,9 +2183,9 @@ function create_bond_interface_nmcli {
     log_info "create bond connection $xcat_con_name"
     cmd=""
     if [ -n "$next_nic" ]; then
-        cmd="$nmcli con add type bond con-name $xcat_con_name ifname $bondname bond.options $_bonding_opts autoconnect yes connection.autoconnect-priority 9"
+        cmd="$nmcli con add type bond con-name $xcat_con_name ifname $bondname bond.options $_bonding_opts autoconnect yes connection.autoconnect-priority 9 connection.autoconnect-slaves 1 connection.autoconnect-retries 0"
     else
-        cmd="$nmcli con add type bond con-name $xcat_con_name ifname $bondname bond.options $_bonding_opts method none ipv4.method manual ipv4.addresses $ipv4_addr/$str_prefix $_mtu connection.autoconnect-priority 9"
+        cmd="$nmcli con add type bond con-name $xcat_con_name ifname $bondname bond.options $_bonding_opts method none ipv4.method manual ipv4.addresses $ipv4_addr/$str_prefix $_mtu connection.autoconnect-priority 9 connection.autoconnect-slaves 1 connection.autoconnect-retries 0"
     fi
     log_info $cmd
     $cmd


### PR DESCRIPTION
### The PR is to fix issue 
https://github.com/xcat2/xcat-core/issues/6228

### The modification include
When activate NICs on some servers, `nmcli con up <con_name>` is timeout, so I add extend nmcli autoconnect-retries and autoconnect-slaves to replace default value, the connect can retry activate itself and its slaves.


autoconnect-retries | int32 | -1 | The number of times a connection should be tried when autoactivating  before giving up. Zero means forever, -1 means the global default (4  times if not overridden). Setting this to 1 means to try activation only  once before blocking autoconnect. Note that after a timeout,  NetworkManager will try to autoconnect again.
-- | -- | -- | --
autoconnect-slaves | NMSettingConnectionAutoconnectSlaves (int32) |   | Whether or not slaves of this connection should be automatically  brought up when NetworkManager activates this connection. This only has a  real effect for master connections. The properties "autoconnect",  "autoconnect-priority" and "autoconnect-retries" are unrelated to this  setting. The permitted values are: 0: leave slave connections untouched,  1: activate all the slave connections with this connection, -1:  default. If -1 (default) is set, global connection.autoconnect-slaves is  read to determine the real value. If it is default as well, this  fallbacks to 0.



### The UT result
The following auto test cases are passed:
```
]# grep END /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20190507233039
END::confignetwork_2eth_bridge_br0::Passed::Time:Tue May  7 23:32:00 2019 ::Duration::77 sec
END::confignetwork_2eth_bridge_br22_br33::Passed::Time:Tue May  7 23:34:07 2019 ::Duration::127 sec
END::confignetwork__bridge_false::Passed::Time:Tue May  7 23:34:33 2019 ::Duration::26 sec
END::confignetwork_bond_eth2_eth3::Passed::Time:Tue May  7 23:35:20 2019 ::Duration::47 sec
END::confignetwork_bond_false::Passed::Time:Tue May  7 23:35:54 2019 ::Duration::34 sec
END::confignetwork_disable_set_to_1::Passed::Time:Tue May  7 23:36:02 2019 ::Duration::8 sec
END::confignetwork_disable_set_to_yes::Passed::Time:Tue May  7 23:36:10 2019 ::Duration::8 sec
END::confignetwork_installnic_2eth_bridge_br22_br33::Passed::Time:Tue May  7 23:38:17 2019 ::Duration::127 sec
END::confignetwork_niccustomscripts::Passed::Time:Tue May  7 23:38:25 2019 ::Duration::8 sec
END::confignetwork_s_installnic_secondarynic_updatenode::Passed::Time:Tue May  7 23:38:47 2019 ::Duration::22 sec
END::confignetwork_secondarynic_nicaliases_updatenode::Passed::Time:Tue May  7 23:39:04 2019 ::Duration::17 sec
END::confignetwork_secondarynic_nicextraparams_updatenode::Passed::Time:Tue May  7 23:39:25 2019 ::Duration::21 sec
END::confignetwork_secondarynic_nicips_updatenode_false::Passed::Time:Tue May  7 23:39:32 2019 ::Duration::7 sec
END::confignetwork_secondarynic_nicnetworks_updatenode_false::Passed::Time:Tue May  7 23:39:38 2019 ::Duration::6 sec
END::confignetwork_secondarynic_nictype_updatenode_false::Passed::Time:Tue May  7 23:39:45 2019 ::Duration::7 sec
END::confignetwork_secondarynic_thirdnic_multiplevalue_updatenode::Passed::Time:Tue May  7 23:40:09 2019 ::Duration::24 sec
END::confignetwork_secondarynic_updatenode::Passed::Time:Tue May  7 23:40:23 2019 ::Duration::14 sec
END::confignetwork_vlan_bond::Passed::Time:Tue May  7 23:41:05 2019 ::Duration::42 sec
END::confignetwork_vlan_eth0::Passed::Time:Tue May  7 23:41:35 2019 ::Duration::30 sec
END::confignetwork_vlan_false::Passed::Time:Tue May  7 23:41:57 2019 ::Duration::22 sec
```
