### PR TITLE
update bundle since rhels8 is initial supported from 2.15

### DIFF
--- a/xCAT-test/autotest/bundle/rhels_ppc_weekly.bundle
+++ b/xCAT-test/autotest/bundle/rhels_ppc_weekly.bundle
@@ -25,5 +25,3 @@ reg_linux_statelite_installation_flat
 rmimage_diskless
 rpower_reset
 runcmdinstaller_command
-redhat_migration1
-redhat_migration2

--- a/xCAT-test/autotest/bundle/rhels_ppcle_weekly.bundle
+++ b/xCAT-test/autotest/bundle/rhels_ppcle_weekly.bundle
@@ -28,6 +28,4 @@ reg_linux_statelite_installation_flat
 rmimage_diskless
 rpower_reset
 runcmdinstaller_command
-redhat_migration1
-redhat_migration2
 linux_diskless_kdump

--- a/xCAT-test/autotest/bundle/rhels_x86_weekly.bundle
+++ b/xCAT-test/autotest/bundle/rhels_x86_weekly.bundle
@@ -28,5 +28,3 @@ reg_linux_statelite_installation_flat
 rmimage_diskless
 rpower_reset
 runcmdinstaller_command
-redhat_migration1
-redhat_migration2


### PR DESCRIPTION
update bundle since rhels8 is initial supported from 2.15
This is for task https://github.ibm.com/xcat2/task_management/issues/240