### PR TITLE
extend connection.autoconnect-retries for xcat nmcli connection

### DIFF
--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -1758,7 +1758,7 @@ function create_vlan_interface_nmcli {
         $nmcli con modify $con_name connection.id $tmp_con_name
     fi
     #create VLAN connetion
-    $nmcli con add type vlan con-name $con_name dev $ifname id $(( 10#$vlanid )) method none $_ipaddrs $_mtu connection.autoconnect-priority 9 autoconnect yes connection.autoconnect-slaves 1
+    $nmcli con add type vlan con-name $con_name dev $ifname id $(( 10#$vlanid )) method none $_ipaddrs $_mtu connection.autoconnect-priority 9 autoconnect yes connection.autoconnect-slaves 1 connection.autoconnect-retries 0
     log_info "create NetworkManager connection for $ifname.$vlanid"
 
     #add extra params
@@ -2006,10 +2006,10 @@ function create_bridge_interface_nmcli {
         fi
         con_use_same_dev=$(wait_nic_connect_intime $_port)
         if [ "$con_use_same_dev" != "--" -a -n "$con_use_same_dev" ]; then
-            cmd="$nmcli con mod "$con_use_same_dev" master $ifname $_mtu connection.autoconnect-priority 9 autoconnect yes connection.autoconnect-slaves 1"
+            cmd="$nmcli con mod "$con_use_same_dev" master $ifname $_mtu connection.autoconnect-priority 9 autoconnect yes connection.autoconnect-slaves 1 connection.autoconnect-retries 0"
             xcat_slave_con=$con_use_same_dev
         else
-            cmd="$nmcli con add type $_pretype con-name $xcat_slave_con ifname $_port master $ifname $_mtu connection.autoconnect-priority 9 autoconnect yes connection.autoconnect-slaves 1"
+            cmd="$nmcli con add type $_pretype con-name $xcat_slave_con ifname $_port master $ifname $_mtu connection.autoconnect-priority 9 autoconnect yes connection.autoconnect-slaves 1 connection.autoconnect-retries 0"
         fi
         log_info "create $_pretype slaves connetcion $xcat_slave_con for bridge"
         log_info "$cmd"
@@ -2067,7 +2067,7 @@ function create_bridge_interface_nmcli {
         if [ $? -eq 0 ]; then
             $nmcli con delete $tmp_slave_con_name
         fi
-        wait_for_ifstate $ifname UP 20 40
+        wait_for_ifstate $ifname UP 40 40
         [ $? -ne 0 ] && rc=1
         $ip address show dev $ifname| $sed -e 's/^/[bridge] >> /g' | log_lines info
     fi
@@ -2229,7 +2229,7 @@ function create_bond_interface_nmcli {
             $ip link set dev $ifslave down 
             wait_for_ifstate $ifslave DOWN 20 2
         fi
-        cmd="$nmcli con add type $slave_type con-name $xcat_slave_con $_mtu method none ifname $ifslave master $xcat_con_name autoconnect yes connection.autoconnect-priority 9"
+        cmd="$nmcli con add type $slave_type con-name $xcat_slave_con $_mtu method none ifname $ifslave master $xcat_con_name autoconnect yes connection.autoconnect-priority 9 connection.autoconnect-retries 0"
         log_info $cmd
         $cmd
         if [ $? -ne 0 ]; then


### PR DESCRIPTION
### The PR is to fix issue 
https://github.com/xcat2/xcat-core/issues/6228
### The modification include

In auto test one compute VM, when activating bridge interface, its slaves VLAN/BOND connection timeout, if retry `nmcli con UP <NIC>`, all NICs can activate.
So extend "connection.autoconnect-retries 0" for all slaves and master NIC.

### The UT result
`##The UT output##`
Ran the confignetwork bundle in the VM, all can be passed.
```
]# grep END /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20190508221846
END::confignetwork_2eth_bridge_br0::Passed::Time:Wed May  8 22:20:12 2019 ::Duration::82 sec
END::confignetwork_2eth_bridge_br22_br33::Passed::Time:Wed May  8 22:22:20 2019 ::Duration::128 sec
END::confignetwork__bridge_false::Passed::Time:Wed May  8 22:22:47 2019 ::Duration::27 sec
END::confignetwork_bond_eth2_eth3::Passed::Time:Wed May  8 22:23:33 2019 ::Duration::46 sec
END::confignetwork_bond_false::Passed::Time:Wed May  8 22:24:02 2019 ::Duration::29 sec
END::confignetwork_disable_set_to_1::Passed::Time:Wed May  8 22:24:09 2019 ::Duration::7 sec
END::confignetwork_disable_set_to_yes::Passed::Time:Wed May  8 22:24:17 2019 ::Duration::8 sec
END::confignetwork_installnic_2eth_bridge_br22_br33::Passed::Time:Wed May  8 22:26:20 2019 ::Duration::123 sec
END::confignetwork_niccustomscripts::Passed::Time:Wed May  8 22:26:28 2019 ::Duration::8 sec
END::confignetwork_s_installnic_secondarynic_updatenode::Passed::Time:Wed May  8 22:26:49 2019 ::Duration::21 sec
END::confignetwork_secondarynic_nicaliases_updatenode::Passed::Time:Wed May  8 22:27:06 2019 ::Duration::17 sec
END::confignetwork_secondarynic_nicextraparams_updatenode::Passed::Time:Wed May  8 22:27:28 2019 ::Duration::22 sec
END::confignetwork_secondarynic_nicips_updatenode_false::Passed::Time:Wed May  8 22:27:34 2019 ::Duration::6 sec
END::confignetwork_secondarynic_nicnetworks_updatenode_false::Passed::Time:Wed May  8 22:27:40 2019 ::Duration::6 sec
END::confignetwork_secondarynic_nictype_updatenode_false::Passed::Time:Wed May  8 22:27:46 2019 ::Duration::6 sec
END::confignetwork_secondarynic_thirdnic_multiplevalue_updatenode::Passed::Time:Wed May  8 22:28:11 2019 ::Duration::25 sec
END::confignetwork_secondarynic_updatenode::Passed::Time:Wed May  8 22:28:25 2019 ::Duration::14 sec
END::confignetwork_vlan_bond::Passed::Time:Wed May  8 22:29:07 2019 ::Duration::42 sec
END::confignetwork_vlan_eth0::Passed::Time:Wed May  8 22:29:37 2019 ::Duration::30 sec
END::confignetwork_vlan_false::Passed::Time:Wed May  8 22:29:59 2019 ::Duration::22 sec
```
