### PR TITLE
Prevent updatenode running when xCAT post-booting process is not completed on compute node

### DIFF
--- a/xCAT/postscripts/xcatdsklspost
+++ b/xCAT/postscripts/xcatdsklspost
@@ -285,6 +285,41 @@ else
   esac
 fi
 
+# The cheat sheet for ${MODE}
+# Empty
+#   node deployment
+# 1 - updatenode -P
+#   Execute postscripts listed in the postscripts table or parameters
+# 2 - updatenode -S
+#   Perform Software Maintenanc - updatenode -S
+# 3 - moncfg rmcmon
+#   Abosoulted
+# 4
+#   Statelite mode
+# 5
+#   Update security
+# 6 - xcatpostinit1
+#   During node reboot
+case "${MODE}" in
+"1"|"2"|"5")
+  # The cheat sheet for checkservicestatus
+  # Return code
+  # 0 - active
+  # 1 - inactive
+  # 2 - failed
+  # 3 - others
+  # 17 - activating
+  # 127 - error
+  checkservicestatus xcatpostinit1 >/dev/null 2>&1
+  case "$?" in
+  "17")
+    echolog "warning" "xCAT post-booting process is not completed yet. Abort. Please try later."
+    exit 255
+    ;;
+  esac
+  ;;
+esac
+
 update_VPD()
 {
     if [ -f /usr/sbin/vpdupdate ]; then

--- a/xCAT/postscripts/xcatdsklspost
+++ b/xCAT/postscripts/xcatdsklspost
@@ -293,7 +293,7 @@ fi
 # 2 - updatenode -S
 #   Perform Software Maintenanc - updatenode -S
 # 3 - moncfg rmcmon
-#   Abosoulted
+#   Obsoleted
 # 4
 #   Statelite mode
 # 5

--- a/xCAT/postscripts/xcatlib.sh
+++ b/xCAT/postscripts/xcatlib.sh
@@ -317,7 +317,7 @@ function servicemap {
       #all the service unit files are placed under /lib/systemd/system/ on ubuntu
       #all the service unit files are placed under /usr/lib/systemd/system/ on redhat and sles
       #path should be delimited with space
-      path="/usr/lib/systemd/system/ /lib/systemd/system/"
+      path="/usr/lib/systemd/system/ /lib/systemd/system/ /etc/systemd/system/"
       postfix=".service"
       svcmgrcmd="systemctl"
    elif [ "$svcmgrtype" = "2"  ];then

--- a/xCAT/postscripts/xcatlib.sh
+++ b/xCAT/postscripts/xcatlib.sh
@@ -549,6 +549,8 @@ function checkservicestatus {
          retcode=1
       elif echo $output|grep -E -i "^failed$";then
          retcode=2
+      elif echo $output|grep -E -i "^activating$";then
+         retcode=17
       fi
    elif [ -n "$svcjob"  ];then
       output=$(initctl status $svcjob)


### PR DESCRIPTION
### The PR is to fix issue _#5498_

### The modification include

_##Revise function `servicemap()` to check directory `/etc/systemd/system/`_
_##Add a new return code `17` for systemd service in `activating` state
_##Abort `updatenode` when service `xcatpostinit1` is still in `activating` state on a xCAT compute node_

### The UT result

```
# updatenode c910f03c01p10 -V foo
Running command on c910f03c01p19: ip -4 --oneline addr show |awk -F ' ' '{print $4}'|awk -F '/' '{print $1}' 2>&1

Running command on c910f03c01p19: chmod -R a+r /install/postscripts 2>&1

  c910f03c01p19: Internal call command: xdsh c910f03c01p10 --nodestatus -s -v -e /install/postscripts/xcatdsklspost 1 -m 10.3.1.19:80 'foo' --tftp /tftpboot --installdir /install --nfsv4 no -c -V
Running command on c910f03c01p19: ip -4 --oneline addr show |awk -F ' ' '{print $4}'|awk -F '/' '{print $1}' 2>&1
Running command on c910f03c01p19: hostname 2>&1
Running command on c910f03c01p19: /opt/xcat/bin/pping c910f03c01p10 2>&1
c910f03c01p10: xCAT post-booting process is not completed yet. Abort. Please try later.
```