### PR TITLE
copycds fix, plugin should not return error becaue it may look at other plugins 

### DIFF
--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -2034,7 +2034,7 @@ sub copycd
 
     if (-r $mntpath . "/.discinfo")
     {
-        print "DEBUG - Attempt to detemine OS information from the .discinfo file ...\n";
+        print "DEBUG - [anaconda.pm] Attempt to detemine OS information from the .discinfo file ...\n";
         open($dinfo, $mntpath . "/.discinfo");
 
         $did = <$dinfo>;
@@ -2050,7 +2050,7 @@ sub copycd
     }
     else
     {
-        print "DEBUG - No .discinfo file found on media, will continue ...\n";
+        print "DEBUG - [anaconda.pm] No .discinfo file found on media, will continue ...\n";
     }
 
     if ($darch and $darch =~ /i.86/)
@@ -2072,12 +2072,12 @@ sub copycd
             $dno = $1;
         }
     }
-    print "DEBUG - Distname=$distname, OS=$desc, ARCH=$arch, Version=$dno\n";
+    print "DEBUG - [anaconda.pm] Distname=$distname, OS=$desc, ARCH=$arch, Version=$dno\n";
 
     unless ($distname)
     {
-        print "DEBUG - Could not find ID=$did in the discinfo database for OS=$desc ARCH=$darch NUM=$dno\n";
-        print "DEBUG - Attempting to auto-detect...\n";
+        print "DEBUG - [anaconda.pm] Could not find ID=$did in the discinfo database for OS=$desc ARCH=$darch NUM=$dno\n";
+        print "DEBUG - [anaconda.pm] Attempting to auto-detect...\n";
         if ($desc =~ /IBM_PowerKVM/)
         {
             # check for PowerKVM support
@@ -2124,7 +2124,7 @@ sub copycd
         }
         else
         {
-            print "DEBUG - Could not auto-detect operating system.\n";
+            print "DEBUG - [anaconda.pm] Could not auto-detect operating system.\n";
             # Cannot continue with what was detected, or attributes provided
             return;
         }
@@ -2173,7 +2173,7 @@ sub copycd
     my $osdistroname = $distname . "-" . $arch;
 
     my $defaultpath = "$installroot/$distname/$arch";
-    print "DEBUG - Detected distname=$distname, arch=$arch defaultpath=$defaultpath osdistroname=$osdistroname\n";
+    print "DEBUG - [anaconda.pm] Detected distname=$distname, arch=$arch defaultpath=$defaultpath osdistroname=$osdistroname\n";
     unless ($path)
     {
         $path = $defaultpath;

--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -2124,8 +2124,8 @@ sub copycd
         }
         else
         {
-            print "DEBUG - [anaconda.pm] Could not auto-detect operating system.\n";
             # Cannot continue with what was detected, or attributes provided
+            print "DEBUG - [anaconda.pm] Could not auto-detect operating system. Maybe some other plugin can, return.\n";
             return;
         }
     }
@@ -2147,10 +2147,14 @@ sub copycd
         if ($arch eq "ppc") { $arch = "ppc64" }
     }
 
-    # At this point, if arch is not provided and we cannot determine it, return
+    # At this point, if arch is not provided and we cannot determine it, inform the user
     unless ($arch)
     {
-        print "DEBUG - [anaconda.pm] ARCH not detected, provided an OS ARCH using the -a option.\n";
+        $callback->(
+            {
+               error => "copycds could not identify the ARCH, you may wish to try -a <arch>.", errorcode => [1]
+            }
+        );
         return;
     }
 

--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -2022,11 +2022,7 @@ sub copycd
     {
 
         #If they say to call it something unidentifiable, give up?
-        $callback->(
-            {
-                error => "The name specified ($distname) is not supported. Use the following format: rh*,pkvm*,centos*,fedora*,SL*,ol*", errorcode => [1]
-            }
-        );
+        print "DEBUG - [anaconda.pm] The name specified ($distname) is not supported for anaconda images, continue to another plugin...";
         return;
     }
 
@@ -2151,14 +2147,10 @@ sub copycd
         if ($arch eq "ppc") { $arch = "ppc64" }
     }
 
-    # At this point, arch should have been detected from the .discinfo, if not, then we require the user to provide it. 
+    # At this point, if arch is not provided and we cannot determine it, return
     unless ($arch)
     {
-        $callback->(
-            {
-                error => "ARCH not be detected, provide an OS ARCH using the -a option. (ppc64le, x86_64)", errorcode => [1]
-            }
-        );
+        print "DEBUG - [anaconda.pm] ARCH not detected, provided an OS ARCH using the -a option.";
         return;
     }
 

--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -2022,7 +2022,7 @@ sub copycd
     {
 
         #If they say to call it something unidentifiable, give up?
-        print "DEBUG - [anaconda.pm] The name specified ($distname) is not supported for anaconda images, continue to another plugin...";
+        print "DEBUG - [anaconda.pm] The name specified ($distname) is not supported for anaconda images, continue to another plugin...\n";
         return;
     }
 
@@ -2150,7 +2150,7 @@ sub copycd
     # At this point, if arch is not provided and we cannot determine it, return
     unless ($arch)
     {
-        print "DEBUG - [anaconda.pm] ARCH not detected, provided an OS ARCH using the -a option.";
+        print "DEBUG - [anaconda.pm] ARCH not detected, provided an OS ARCH using the -a option.\n";
         return;
     }
 


### PR DESCRIPTION
Fix issues introduced in #6283 

#  Unit Test output

The centOS image that we want to support: 

```
[root@briggs01 ~]# copycds /mnt/xcat/iso/centos/7.6/CentOS-7-power9-Minimal-1810.iso -n centos7.6
Error: [briggs01]: copycds could not identify the ISO supplied, you may wish to try -n <osver>
```

So now without XCATBYPASS, there's still no output....


```
[root@briggs01 ~]# XCATBYPASS=1 copycds /mnt/xcat/iso/centos/7.6/CentOS-7-power9-Minimal-1810.iso -n centos7.6
DEBUG - [anaconda.pm] No .discinfo file found on media, will continue ...
DEBUG - [anaconda.pm] Distname=centos7.6, OS=, ARCH=, Version=7.6
DEBUG - [anaconda.pm] ARCH not detected, provided an OS ARCH using the -a option.
Error: copycds could not identify the ISO supplied, you may wish to try -n <osver>
[root@briggs01 ~]#
```

With everything specified, it does  work 
```
[root@briggs01 ~]# copycds /mnt/xcat/iso/centos/7.6/CentOS-7-power9-Minimal-1810.iso -n centos7.6 -a ppc64le
Copying media to /install/centos7.6/ppc64le
0.29%
```

This is because with the original code change, It broke other OS release ....


With the new code SLES works again: 
```
[root@briggs01 ~]# copycds -n sles12.3 /mnt/xcat/iso/suse/12.3/SLE-12-SP3-SDK-DVD-ppc64le-GM-DVD3.iso
Copying media to /install/sles12.3/ppc64le/sdk3
Media copy operation successful
[root@briggs01 ~]# echo $?
0
```

And trying with Ubuntu: 

```[root@briggs01 ~]# copycds /mnt/xcat/iso/ubuntu/18.04.2/ubuntu-18.04.2-server-ppc64el.iso
Copying media to /install/ubuntu18.04.2/ppc64el
Media copy operation successful
[root@briggs01 ~]# echo $?
0
```
