### PR TITLE
optimize confignetwork_2eth_bridge_br22_br33 test case

### DIFF
--- a/xCAT-test/autotest/testcase/confignetwork/cases0
+++ b/xCAT-test/autotest/testcase/confignetwork/cases0
@@ -842,9 +842,6 @@ cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r '
 check:rc==0
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=101.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test2 net=$secondnet mask=255.255.0.0 mgtifname=$$THIRDNIC
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$THIRDNIC=$second1ip nictypes.$$THIRDNIC=Ethernet nicnetworks.$$THIRDNIC=confignetworks_test2
-cmd:updatenode $$CN -P confignetwork
-check:rc==0
 cmd:chdef $$CN nicips.$$SECONDNIC= nictypes.$$SECONDNIC= nicnetworks.$$SECONDNIC= nicips.$$THIRDNIC= nictypes.$$THIRDNIC= nicnetworks.$$THIRDNIC=
 check:rc==0
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=102.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test3 net=$secondnet mask=255.255.0.0


### PR DESCRIPTION
### The PR is fix
 fix #6228

### The modification include

`confignetwork_2eth_bridge_br22_br33`  is failed when running xcattest daily_bundle on one of x86_64 redhat8.0 VM. The failed state is br33 timeout of UP state. It cannot be reproduced using confignetwork bundle on the same VM. 

I think at that time, this VM is too busy,  here I delete the first updatenode which is to configure ethernet covered by other test case. Let confignetwork_2eth_bridge_br22_br33 configure 2eth->bond->vlan->bridge to see if it is better in this VM.

### The UT result
```
RUN:updatenode c910f04x37v10 -P confignetwork [Mon May 13 01:54:51 2019]
ElapsedTime:330 sec
RETURN rc = 0
OUTPUT:
c910f04x37v10: =============updatenode starting====================
c910f04x37v10: trying to download postscripts...
c910f04x37v10: postscripts downloaded successfully
c910f04x37v10: trying to get mypostscript from 10.4.37.8...
c910f04x37v10: postscript start..: confignetwork
c910f04x37v10: [I]: NetworkManager is active
c910f04x37v10: [I]: All valid nics and device list:
c910f04x37v10: [I]: bond0 ens4@ens5
c910f04x37v10: [I]: bond0.2 bond0
c910f04x37v10: [I]: bond0.3 bond0
c910f04x37v10: [I]: br22 bond0.2
c910f04x37v10: [I]: br33 bond0.3
c910f04x37v10: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f04x37v10: configure nic and its device : bond0 ens4@ens5
c910f04x37v10: [I]: create_bond_interface_nmcli bondname=bond0 slave_ports=ens4,ens5 slave_type=ethernet _ipaddr= next_nic=bond0.2 bond0.3
c910f04x37v10: [I]: create bond connection xcat-bond-bond0
c910f04x37v10: [I]: nmcli con add type bond con-name xcat-bond-bond0 ifname bond0 bond.options mode=802.3ad,miimon=100 autoconnect yes connection.autoconnect-priority 9 connection.autoconnect-slaves 1 connection.autoconnect-retries 0
c910f04x37v10: Connection 'xcat-bond-bond0' (022a0cc6-3249-430b-9751-90ce6027f047) successfully added.
c910f04x37v10: [I]: nmcli con add type Ethernet con-name xcat-bond-slave-ens4 method none ifname ens4 master xcat-bond-bond0 autoconnect yes connection.autoconnect-priority 9 connection.autoconnect-retries 0
c910f04x37v10: Connection 'xcat-bond-slave-ens4' (0b622bc5-d73d-4660-b354-c4709d4b35ee) successfully added.
c910f04x37v10: [I]: nmcli con up xcat-bond-slave-ens4
c910f04x37v10: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/125)
c910f04x37v10: [I]: nmcli con add type Ethernet con-name xcat-bond-slave-ens5 method none ifname ens5 master xcat-bond-bond0 autoconnect yes connection.autoconnect-priority 9 connection.autoconnect-retries 0
c910f04x37v10: Connection 'xcat-bond-slave-ens5' (52f53ecb-49d0-4db6-8961-abdbb8ac7218) successfully added.
c910f04x37v10: [I]: nmcli con up xcat-bond-slave-ens5
c910f04x37v10: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/127)
c910f04x37v10: [I]: nmcli con up xcat-bond-bond0
c910f04x37v10: Connection successfully activated (master waiting for slaves) (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/128)
c910f04x37v10: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f04x37v10: configure nic and its device : bond0.2 bond0
c910f04x37v10: [I]: create_vlan_interface_nmcli ifname=bond0 vlanid=2 ipaddrs= next_nic=br22
c910f04x37v10: [I]: check parent interface bond0 whether it is managed by NetworkManager
c910f04x37v10: Connection 'xcat-vlan-bond0.2' (4d7aa9a1-2dbf-4979-a86f-c4d2b31954cd) successfully added.
c910f04x37v10: [I]: create NetworkManager connection for bond0.2
c910f04x37v10: [I]: [vlan] >> 36: bond0.2@bond0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state LOWERLAYERDOWN group default qlen 1000
c910f04x37v10: [I]: [vlan] >>     link/ether 42:1f:0a:04:25:0a brd ff:ff:ff:ff:ff:ff
c910f04x37v10: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f04x37v10: configure nic and its device : bond0.3 bond0
c910f04x37v10: [I]: create_vlan_interface_nmcli ifname=bond0 vlanid=3 ipaddrs= next_nic=br33
c910f04x37v10: [I]: check parent interface bond0 whether it is managed by NetworkManager
c910f04x37v10: Connection 'xcat-vlan-bond0.3' (2b51a324-be92-47e0-8864-46b1232763ae) successfully added.
c910f04x37v10: [I]: create NetworkManager connection for bond0.3
c910f04x37v10: [I]: [vlan] >> 37: bond0.3@bond0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state LOWERLAYERDOWN group default qlen 1000
c910f04x37v10: [I]: [vlan] >>     link/ether 42:1f:0a:04:25:0a brd ff:ff:ff:ff:ff:ff
c910f04x37v10: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f04x37v10: configure nic and its device : br22 bond0.2
c910f04x37v10: [I]: create_bridge_interface_nmcli ifname=br22 _brtype=bridge _port=bond0.2 _pretype=vlan _ipaddr=102.4.37.10
c910f04x37v10: [I]: Pickup xcatnet, "confignetworks_test3", from NICNETWORKS for interface "br22".
c910f04x37v10: [I]: create bridge connection xcat-bridge-br22
c910f04x37v10: [I]: nmcli con add type bridge con-name xcat-bridge-br22 ifname br22 connection.autoconnect-priority 9 autoconnect yes connection.autoconnect-retries 0 connection.autoconnect-slaves 1
c910f04x37v10: Connection 'xcat-bridge-br22' (b0803385-3e9a-4e1b-8e9f-fe4d7f3e5741) successfully added.
c910f04x37v10: [I]: create vlan slaves connetcion xcat-vlan-bond0.2 for bridge
c910f04x37v10: [I]: nmcli con mod xcat-vlan-bond0.2 master br22  connection.autoconnect-priority 9 autoconnect yes connection.autoconnect-slaves 1 connection.autoconnect-retries 0
c910f04x37v10: [I]: add ip 102.4.37.10/16 to bridge
c910f04x37v10: [I]: nmcli con up xcat-bridge-br22
c910f04x37v10: Connection successfully activated (master waiting for slaves) (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/134)
c910f04x37v10: [I]: nmcli con up xcat-vlan-bond0.2
c910f04x37v10: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/136)
c910f04x37v10: [I]: State of "br22" was "DOWN" instead of expected "UP". Wait 0 of 20 with interval 40.
c910f04x37v10: [I]: [bridge] >> 38: br22: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
c910f04x37v10: [I]: [bridge] >>     link/ether 42:1f:0a:04:25:0a brd ff:ff:ff:ff:ff:ff
c910f04x37v10: [I]: [bridge] >>     inet 102.4.37.10/16 brd 102.4.255.255 scope global noprefixroute br22
c910f04x37v10: [I]: [bridge] >>        valid_lft forever preferred_lft forever
c910f04x37v10: [I]: [bridge] >>     inet6 fe80::3c40:3903:9b62:c47d/64 scope link noprefixroute
c910f04x37v10: [I]: [bridge] >>        valid_lft forever preferred_lft forever
c910f04x37v10: ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
c910f04x37v10: configure nic and its device : br33 bond0.3
c910f04x37v10: [I]: create_bridge_interface_nmcli ifname=br33 _brtype=bridge _port=bond0.3 _pretype=vlan _ipaddr=103.4.37.10
c910f04x37v10: [I]: Pickup xcatnet, "confignetworks_test4", from NICNETWORKS for interface "br33".
c910f04x37v10: [I]: create bridge connection xcat-bridge-br33
c910f04x37v10: [I]: nmcli con add type bridge con-name xcat-bridge-br33 ifname br33 connection.autoconnect-priority 9 autoconnect yes connection.autoconnect-retries 0 connection.autoconnect-slaves 1
c910f04x37v10: Connection 'xcat-bridge-br33' (dcd377ae-8f17-4964-8578-a95858b3af64) successfully added.
c910f04x37v10: [I]: create vlan slaves connetcion xcat-vlan-bond0.3 for bridge
c910f04x37v10: [I]: nmcli con mod xcat-vlan-bond0.3 master br33  connection.autoconnect-priority 9 autoconnect yes connection.autoconnect-slaves 1 connection.autoconnect-retries 0
c910f04x37v10: [I]: add ip 103.4.37.10/16 to bridge
c910f04x37v10: [I]: nmcli con up xcat-bridge-br33
c910f04x37v10: Connection successfully activated (master waiting for slaves) (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/138)
c910f04x37v10: [I]: nmcli con up xcat-vlan-bond0.3
c910f04x37v10: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/140)
c910f04x37v10: [I]: State of "br33" was "DOWN" instead of expected "UP". Wait 0 of 20 with interval 40.
c910f04x37v10: [I]: State of "br33" was "DOWN" instead of expected "UP". Wait 1 of 20 with interval 40.
c910f04x37v10: [I]: State of "br33" was "DOWN" instead of expected "UP". Wait 2 of 20 with interval 40.
c910f04x37v10: [I]: State of "br33" was "DOWN" instead of expected "UP". Wait 3 of 20 with interval 40.
c910f04x37v10: [I]: State of "br33" was "DOWN" instead of expected "UP". Wait 4 of 20 with interval 40.
c910f04x37v10: [I]: State of "br33" was "DOWN" instead of expected "UP". Wait 5 of 20 with interval 40.
c910f04x37v10: [I]: State of "br33" was "DOWN" instead of expected "UP". Wait 6 of 20 with interval 40.
c910f04x37v10: [I]: [bridge] >> 39: br33: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
c910f04x37v10: [I]: [bridge] >>     link/ether 42:88:0a:04:25:0a brd ff:ff:ff:ff:ff:ff
c910f04x37v10: [I]: [bridge] >>     inet 103.4.37.10/16 brd 103.4.255.255 scope global noprefixroute br33
c910f04x37v10: [I]: [bridge] >>        valid_lft forever preferred_lft forever
c910f04x37v10: [I]: [bridge] >>     inet6 fe80::b14d:3e86:a263:a227/64 scope link noprefixroute
c910f04x37v10: [I]: [bridge] >>        valid_lft forever preferred_lft forever
c910f04x37v10: postscript end....: confignetwork exited with code 0
c910f04x37v10: Running of postscripts has completed.
c910f04x37v10: =============updatenode ending====================
CHECK:rc == 0	[Pass]
```
