### PR TITLE
update test.sh to add network information

### DIFF
--- a/xCAT-test/autotest/testcase/genesis/test.sh
+++ b/xCAT-test/autotest/testcase/genesis/test.sh
@@ -6,7 +6,7 @@ masternet=`ifconfig  | awk "BEGIN{RS=\"\"}/\<$masterip\>/{print \$1}"|head -n 1 
 net2=`netstat -i -a|grep -v Kernel|grep -v Iface |grep -v lo|grep -v $masternet|head -n 1|awk '{print $1}'`;echo net2 is  $net2;
 net2ip="";
     if [[ -z $net2 ]];then
-        echo "could not verify the test"
+        echo "There is no second network,could not verify the test"
         return 1;
     else
         net2ipstring=`ifconfig $net2 |grep inet|grep -v inet6`;
@@ -19,6 +19,7 @@ net2ip="";
                 net2ip=0.0.0.0;
             fi
         ifconfig $net2 60.3.3.3 ;
+        makenetworks;        
         makehosts testnode;
         nodeset testnode  shell;
         ifconfig $net2 "$net2ip";
@@ -32,6 +33,7 @@ net2ip="";
     fi
 }
 function clear_env(){
+rmdef -t network -o 60_0_0_0-255_0_0_0
 makehosts -d testnode
 rmdef testnode
     if [[ $? -eq 0 ]];then


### PR DESCRIPTION
### The PR is to fix failed case nodeset_shell_incorrectmasterip

The UT
```
------START::nodeset_shell_incorrectmasterip::Time:Thu May 16 02:32:07 2019------

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh --check xnba [Thu May 16 02:32:07 2019]
ElapsedTime:32 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
New object definitions 'testnode' have been created.
net2 is enp0s2
Warning: [c910f03c09k15]: The network entry '10_0_0_0-255_0_0_0' already exists in xCAT networks table. Cannot create a definition for '10_0_0_0-255_0_0_0'
testnode: shell
imgargs kernel quiet xcatd=60.3.3.3:3001 destiny=shell BOOTIF=01-${netX/machyp}
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh --check grub2 [Thu May 16 02:32:39 2019]
ElapsedTime:32 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
net2 is enp0s2
Warning: [c910f03c09k15]: The network entry '10_0_0_0-255_0_0_0' already exists in xCAT networks table. Cannot create a definition for '10_0_0_0-255_0_0_0'
Warning: [c910f03c09k15]: The network entry '60_0_0_0-255_0_0_0' already exists in xCAT networks table. Cannot create a definition for '60_0_0_0-255_0_0_0'
testnode: shell
    linux /xcat/genesis.kernel.ppc64 quiet xcatd=60.3.3.3:3001 destiny=shell
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh --check petitboot [Thu May 16 02:33:11 2019]
ElapsedTime:31 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
net2 is enp0s2
Warning: [c910f03c09k15]: The network entry '10_0_0_0-255_0_0_0' already exists in xCAT networks table. Cannot create a definition for '10_0_0_0-255_0_0_0'
Warning: [c910f03c09k15]: The network entry '60_0_0_0-255_0_0_0' already exists in xCAT networks table. Cannot create a definition for '60_0_0_0-255_0_0_0'
testnode: shell
	append "quiet xcatd=60.3.3.3:3001 destiny=shell"
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh -c [Thu May 16 02:33:42 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

------END::nodeset_shell_incorrectmasterip::Passed::Time:Thu May 16 02:33:43 2019 ::Duration::96 sec------
------Total: 1 , Failed: 0------
```