### PR TITLE
fix confignetwork confignetwork_installnic_2eth_bridge_br22_br33 failure

### DIFF
--- a/xCAT-test/autotest/testcase/confignetwork/cases0
+++ b/xCAT-test/autotest/testcase/confignetwork/cases0
@@ -903,10 +903,6 @@ cmd:chdef $$CN nicips.$$SECONDNIC=11.1.0.100 nictypes.$$SECONDNIC=Ethernet nicne
 check:rc==0
 cmd:mkdef -t network -o 12_1_0_0-255_255_0_0 net=12.1.0.0 mask=255.255.0.0 mgtifname=$$THIRDNIC
 check:rc==0
-cmd:chdef $$CN nicips.$$THIRDNIC=12.1.0.100 nictypes.$$THIRDNIC=Ethernet nicnetworks.$$THIRDNIC=12_1_0_0-255_255_0_0
-check:rc==0
-cmd:updatenode $$CN -P confignetwork
-check:rc==0
 cmd:chdef $$CN nicips.$$SECONDNIC= nictypes.$$SECONDNIC= nicnetworks.$$SECONDNIC= nicips.$$THIRDNIC= nictypes.$$THIRDNIC= nicnetworks.$$THIRDNIC=
 check:rc==0
 cmd:mkdef -t network -o 30_5_0_0-255_255_0_0 net=30.5.0.0 mask=255.255.0.0
@@ -921,6 +917,8 @@ cmd:installnic=`xdsh $$CN ip addr |grep __GETNODEATTR($$CN,ip)__|awk -F " " '{pr
 check:rc==0
 check:output=~__GETNODEATTR($$CN,ip)__
 check:output=~BOOTPROTO=none|static
+cmd:xdsh $$CN "cat /sys/class/net/bonding_masters"
+check:output=~bond0
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "grep 30.5.106.8 /etc/sysconfig/network/ifcfg-br22"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep 30.5.106.8 /etc/sysconfig/network-scripts/ifcfg-*br22*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep 30.5.106.8 /etc/network/interfaces.d/br22";else echo "Sorry,this is not supported os"; fi
 check:output=~30.5.106.8
 check:rc==0
@@ -930,8 +928,6 @@ check:rc==0
 cmd:xdsh $$CN "ls /sys/class/net"
 check:output=~br22
 check:output=~br33
-cmd:xdsh $$CN "cat /sys/class/net/bonding_masters"
-check:output=~bond0
 cmd:rmdef -t network -o 11_1_0_0-255_255_0_0
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifcfg-$$SECONDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts"; elif grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /etc/network/interfaces.d/$$SECONDNIC";else echo "Sorry,this is not supported os"; fi
 cmd:rmdef -t network -o 12_1_0_0-255_255_0_0

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -27,6 +27,7 @@ brctl="brctl"
 uniq="uniq"
 xargs="xargs"
 modprobe="modprobe"
+xcatcreatedcon=''
 if [ -n "$LOGLABEL" ]; then
     log_label=$LOGLABEL
 else
@@ -2067,6 +2068,10 @@ function create_bridge_interface_nmcli {
         if [ $? -eq 0 ]; then
             $nmcli con delete $tmp_slave_con_name
         fi
+        if [ -n "$xcatcreatedcon" ]; then
+            $nmcli con up $xcatcreatedcon
+            log_info "$nmcli con up $xcatcreatedcon"
+        fi
         wait_for_ifstate $ifname UP 40 40
         [ $? -ne 0 ] && rc=1
         $ip address show dev $ifname| $sed -e 's/^/[bridge] >> /g' | log_lines info
@@ -2187,6 +2192,7 @@ function create_bond_interface_nmcli {
     else
         cmd="$nmcli con add type bond con-name $xcat_con_name ifname $bondname bond.options $_bonding_opts method none ipv4.method manual ipv4.addresses $ipv4_addr/$str_prefix $_mtu connection.autoconnect-priority 9 connection.autoconnect-slaves 1 connection.autoconnect-retries 0"
     fi
+    xcatcreatedcon=$xcat_con_name
     log_info $cmd
     $cmd
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
### The PR is to fix issue 

fix #6228

### The modification include

1. enhance the test case confignetwork_installnic_2eth_bridge_br22_br33
2. after the last bridge is created, re-up the bond device, make sure bond device and its slaves do not connect timeout.

### The UT result
```
... ...
c910f04x12v04: configure nic and its device : br33 bond0.3
c910f04x12v04: [I]: create_bridge_interface_nmcli ifname=br33 _brtype=bridge _port=bond0.3 _pretype=vlan _ipaddr=40.5.106.8
c910f04x12v04: [I]: Pickup xcatnet, "40_5_0_0-255_255_0_0", from NICNETWORKS for interface "br33".
c910f04x12v04: [I]: create bridge connection xcat-bridge-br33
c910f04x12v04: [I]: nmcli con add type bridge con-name xcat-bridge-br33 ifname br33 connection.autoconnect-priority 9 autoconnect yes connection.autoconnect-retries 0 connection.autoconnect-slaves 1
c910f04x12v04: Connection 'xcat-bridge-br33' (dc7d8603-4d7a-4860-83ab-76c77c1cb357) successfully added.
c910f04x12v04: [I]: create vlan slaves connetcion xcat-vlan-bond0.3 for bridge
c910f04x12v04: [I]: nmcli con mod xcat-vlan-bond0.3 master br33  connection.autoconnect-priority 9 autoconnect yes connection.autoconnect-slaves 1 connection.autoconnect-retries 0
c910f04x12v04: [I]: add ip 40.5.106.8/16 to bridge
c910f04x12v04: [I]: nmcli con up xcat-bridge-br33
c910f04x12v04: Connection successfully activated (master waiting for slaves) (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/326)
c910f04x12v04: [I]: nmcli con up xcat-vlan-bond0.3
c910f04x12v04: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/328)
c910f04x12v04: Connection successfully activated (master waiting for slaves) (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/329)
c910f04x12v04: [I]: nmcli con up xcat-bond-bond0.       --------------------> this is fix
c910f04x12v04: [I]: State of "br33" was "DOWN" instead of expected "UP". Wait 0 of 40 with interval 40.
c910f04x12v04: [I]: [bridge] >> 72: br33: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
c910f04x12v04: [I]: [bridge] >>     link/ether 42:c8:0a:04:0c:04 brd ff:ff:ff:ff:ff:ff
c910f04x12v04: [I]: [bridge] >>     inet 40.5.106.8/16 brd 40.5.255.255 scope global noprefixroute br33
c910f04x12v04: [I]: [bridge] >>        valid_lft forever preferred_lft forever
c910f04x12v04: [I]: [bridge] >>     inet6 fe80::b431:9f19:6a04:508d/64 scope link noprefixroute
c910f04x12v04: [I]: [bridge] >>        valid_lft forever preferred_lft forever
c910f04x12v04: postscript end....: confignetwork exited with code 0
c910f04x12v04: Running of postscripts has completed.
c910f04x12v04: =============updatenode ending====================
CHECK:rc == 0	[Pass]
```
