### PR TITLE
update packimage test cases

### DIFF
--- a/xCAT-test/autotest/testcase/packimg/cases0
+++ b/xCAT-test/autotest/testcase/packimg/cases0
@@ -64,6 +64,8 @@ cmd:if [ -x /usr/bin/goconserver ]; then makegocons $$CN; else makeconservercf $
 check:rc==0
 cmd:ls /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg;if [ $? -eq 0 ];then mv -f /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg /rootimg.bak;fi
 cmd:ls /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.cpio.gz;if [ $? -eq 0 ];then mv -f /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.cpio.gz /rootimg.cpio.gz.bak;fi
+cmd:if [[ "__GETNODEATTR($$CN,os)__" =~ "ubuntu16.04.5" ]] && [[ "__GETNODEATTR($$CN,arch)__" =~ "x86" ]]; then chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute  -p pkgdir="http://archive.ubuntu.com/ubuntu xenial universe main,http://archive.ubuntu.com/ubuntu xenial-updates universe main,http://security.ubuntu.com/ubuntu xenial-security main restricted";fi
+cmd:lsdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 cmd:genimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 cmd:ls -l /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg
@@ -102,11 +104,13 @@ start:packimage_m_cpio_c_pigz
 os:Linux
 description:test packimage -m cpio -c pigz
 label:others,packaging,invoke_provision
-#cmd:copycds $$ISO
+cmd:copycds $$ISO
 cmd:if [ -x /usr/bin/goconserver ]; then makegocons $$CN; else makeconservercf $$CN; fi
 check:rc==0
 cmd:ls /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg;if [ $? -eq 0 ];then mv -f /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg /rootimg.bak;fi
 cmd:ls /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.cpio.gz;if [ $? -eq 0 ];then mv -f /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.cpio.gz /rootimg.cpio.gz.bak;fi
+cmd:if [[ "__GETNODEATTR($$CN,os)__" =~ "ubuntu16.04.5" ]] && [[ "__GETNODEATTR($$CN,arch)__" =~ "x86" ]]; then chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute  -p pkgdir="http://archive.ubuntu.com/ubuntu xenial universe main,http://archive.ubuntu.com/ubuntu xenial-updates universe main,http://security.ubuntu.com/ubuntu xenial-security main restricted";fi
+cmd:lsdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 cmd:genimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 cmd:ls -l /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg
@@ -149,11 +153,13 @@ start:packimage_m_cpio_c_xz
 os:Linux
 description:test packimage -m cpio -c xz
 label:others,packaging,invoke_provision
-#cmd:copycds $$ISO
+cmd:copycds $$ISO
 cmd:if [ -x /usr/bin/goconserver ]; then makegocons $$CN; else makeconservercf $$CN; fi
 check:rc==0
 cmd:ls /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg;if [ $? -eq 0 ];then mv -f /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg /rootimg.bak;fi
 cmd:ls /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.cpio.xz;if [ $? -eq 0 ];then mv -f /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.cpio.xz /rootimg.cpio.xz.bak;fi
+cmd:if [[ "__GETNODEATTR($$CN,os)__" =~ "ubuntu16.04.5" ]] && [[ "__GETNODEATTR($$CN,arch)__" =~ "x86" ]]; then chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute  -p pkgdir="http://archive.ubuntu.com/ubuntu xenial universe main,http://archive.ubuntu.com/ubuntu xenial-updates universe main,http://security.ubuntu.com/ubuntu xenial-security main restricted";fi
+cmd:lsdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 cmd:genimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 cmd:ls -l /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg
@@ -192,11 +198,13 @@ start:packimage_m_tar_c_pigz
 os:Linux
 description:test packimage -m tar -c pigz
 label:others,packaging,invoke_provision
-#cmd:copycds $$ISO
+cmd:copycds $$ISO
 cmd:if [ -x /usr/bin/goconserver ]; then makegocons $$CN; else makeconservercf $$CN; fi
 check:rc==0
 cmd:ls /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg;if [ $? -eq 0 ];then mv -f /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg /rootimg.bak;fi
 cmd:ls /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.tar.gz;if [ $? -eq 0 ];then mv -f /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.tar.gz /rootimg.tar.gz.bak;fi
+cmd:if [[ "__GETNODEATTR($$CN,os)__" =~ "ubuntu16.04.5" ]] && [[ "__GETNODEATTR($$CN,arch)__" =~ "x86" ]]; then chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute  -p pkgdir="http://archive.ubuntu.com/ubuntu xenial universe main,http://archive.ubuntu.com/ubuntu xenial-updates universe main,http://security.ubuntu.com/ubuntu xenial-security main restricted";fi
+cmd:lsdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 cmd:genimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 cmd:ls -l /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg
@@ -250,11 +258,13 @@ start:packimage_m_tar_c_gzip
 os:Linux
 description:test packimage -m tar -c gzip
 label:others,packaging,invoke_provision
-#cmd:copycds $$ISO
+cmd:copycds $$ISO
 cmd:if [ -x /usr/bin/goconserver ]; then makegocons $$CN; else makeconservercf $$CN; fi
 check:rc==0
 cmd:ls /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg;if [ $? -eq 0 ];then mv -f /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg /rootimg.bak;fi
 cmd:ls /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.tar.gz;if [ $? -eq 0 ];then mv -f /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.tar.gz /rootimg.tar.gz.bak;fi
+cmd:if [[ "__GETNODEATTR($$CN,os)__" =~ "ubuntu16.04.5" ]] && [[ "__GETNODEATTR($$CN,arch)__" =~ "x86" ]]; then chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute  -p pkgdir="http://archive.ubuntu.com/ubuntu xenial universe main,http://archive.ubuntu.com/ubuntu xenial-updates universe main,http://security.ubuntu.com/ubuntu xenial-security main restricted";fi
+cmd:lsdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 cmd:genimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 cmd:ls -l /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg
@@ -304,11 +314,13 @@ start:packimage_m_tar_c_xz
 os:Linux
 description:test packimage -m tar -c xz
 label:others,packaging,invoke_provision
-#cmd:copycds $$ISO
+cmd:copycds $$ISO
 cmd:if [ -x /usr/bin/goconserver ]; then makegocons $$CN; else makeconservercf $$CN; fi
 check:rc==0
 cmd:ls /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg;if [ $? -eq 0 ];then mv -f /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg /rootimg.bak;fi
 cmd:ls /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.tar.xz;if [ $? -eq 0 ];then mv -f /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.tar.xz /rootimg.tar.xz.bak;fi
+cmd:if [[ "__GETNODEATTR($$CN,os)__" =~ "ubuntu16.04.5" ]] && [[ "__GETNODEATTR($$CN,arch)__" =~ "x86" ]]; then chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute  -p pkgdir="http://archive.ubuntu.com/ubuntu xenial universe main,http://archive.ubuntu.com/ubuntu xenial-updates universe main,http://security.ubuntu.com/ubuntu xenial-security main restricted";fi
+cmd:lsdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 cmd:genimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 cmd:ls -l /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg


### PR DESCRIPTION
The UT result
```
------START::packimage_m_cpio_c_gzip::Time:Tue May 21 04:41:46 2019------

RUN:copycds /ubuntu-16.04.5-server-amd64-stable.iso [Tue May 21 04:41:46 2019]
ElapsedTime:11 sec
RETURN rc = 0
OUTPUT:
Copying media to /install/ubuntu16.04.5/x86_64
Media copy operation successful

RUN:if [ -x /usr/bin/goconserver ]; then makegocons c910f04x12v07; else makeconservercf c910f04x12v07; fi [Tue May 21 04:41:57 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f04x12v07: Created
CHECK:rc == 0	[Pass]

RUN:ls /install/netboot/__GETNODEATTR(c910f04x12v07,os)__/__GETNODEATTR(c910f04x12v07,arch)__/compute/rootimg;if [ $? -eq 0 ];then mv -f /install/netboot/__GETNODEATTR(c910f04x12v07,os)__/__GETNODEATTR(c910f04x12v07,arch)__/compute/rootimg /rootimg.bak;fi [Tue May 21 04:41:58 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
bin
boot
dev
etc
home
initrd.img
initrd.img.old
lib
lib64
media
mnt
opt
proc
root
run
sbin
srv
sys
test.synclist
tmp
usr
var
vmlinuz
vmlinuz.old
xcatpost

RUN:ls /install/netboot/__GETNODEATTR(c910f04x12v07,os)__/__GETNODEATTR(c910f04x12v07,arch)__/compute/rootimg.cpio.gz;if [ $? -eq 0 ];then mv -f /install/netboot/__GETNODEATTR(c910f04x12v07,os)__/__GETNODEATTR(c910f04x12v07,arch)__/compute/rootimg.cpio.gz /rootimg.cpio.gz.bak;fi [Tue May 21 04:41:59 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
/install/netboot/ubuntu16.04.5/x86_64/compute/rootimg.cpio.gz

RUN:if [[ "__GETNODEATTR(c910f04x12v07,os)__" =~ "ubuntu16.04.5" ]] && [[ "__GETNODEATTR(c910f04x12v07,arch)__" =~ "x86" ]]; then chdef -t osimage -o __GETNODEATTR(c910f04x12v07,os)__-__GETNODEATTR(c910f04x12v07,arch)__-netboot-compute  -p pkgdir="http://archive.ubuntu.com/ubuntu xenial universe main,http://archive.ubuntu.com/ubuntu xenial-updates universe main,http://security.ubuntu.com/ubuntu xenial-security main restricted";fi [Tue May 21 04:42:00 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.

RUN:lsdef -t osimage -o __GETNODEATTR(c910f04x12v07,os)__-__GETNODEATTR(c910f04x12v07,arch)__-netboot-compute [Tue May 21 04:42:01 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
Object name: ubuntu16.04.5-x86_64-netboot-compute
    exlist=/opt/xcat/share/xcat/netboot/ubuntu/compute.exlist
    imagetype=linux
    osarch=x86_64
    osname=Linux
    osvers=ubuntu16.04.5
    otherpkgdir=/install/post/otherpkgs/ubuntu16.04.5/x86_64
    permission=755
    pkgdir=/install/ubuntu16.04.5/x86_64,http://archive.ubuntu.com/ubuntu xenial universe main,http://archive.ubuntu.com/ubuntu xenial-updates universe main,http://security.ubuntu.com/ubuntu xenial-security main restricted
    pkglist=/opt/xcat/share/xcat/netboot/ubuntu/compute.ubuntu16.04.x86_64.pkglist
    postinstall=/opt/xcat/share/xcat/netboot/ubuntu/compute.postinstall
    profile=compute
    provmethod=netboot
    rootimgdir=/install/netboot/ubuntu16.04.5/x86_64/compute

RUN:genimage __GETNODEATTR(c910f04x12v07,os)__-__GETNODEATTR(c910f04x12v07,arch)__-netboot-compute [Tue May 21 04:42:03 2019]
ElapsedTime:388 sec
RETURN rc = 0
OUTPUT:
Generating image:
cd /opt/xcat/share/xcat/netboot/ubuntu; ./genimage -a x86_64 -o ubuntu16.04.5 -p compute --permission 755 --srcdir "/install/ubuntu16.04.5/x86_64,http://archive.ubuntu.com/ubuntu xenial universe main,http://archive.ubuntu.com/ubuntu xenial-updates universe main,http://security.ubuntu.com/ubuntu xenial-security main restricted" --pkglist /opt/xcat/share/xcat/netboot/ubuntu/compute.ubuntu16.04.x86_64.pkglist --otherpkgdir "/install/post/otherpkgs/ubuntu16.04.5/x86_64" --postinstall "/opt/xcat/share/xcat/netboot/ubuntu/compute.postinstall" --rootimgdir /install/netboot/ubuntu16.04.5/x86_64/compute --tempfile /tmp/xcat_genimage.23007 ubuntu16.04.5-x86_64-netboot-compute
Run cmd [debootstrap --verbose --arch amd64 xenial /install/netboot/ubuntu16.04.5/x86_64/compute/rootimg http://archive.ubuntu.com/ubuntu] to create rootimage bootstraps
I: Retrieving InRelease
I: Checking Release signature
I: Valid Release signature (key id 790BC7277767219C42C86F933B4FE6ACC0B21F32)
I: Retrieving Packages
I: Validating Packages
I: Resolving dependencies of required packages...
I: Resolving dependencies of base packages...
I: Checking component main on http://archive.ubuntu.com/ubuntu...
I: Retrieving adduser 3.113+nmu3ubuntu4
I: Validating adduser 3.113+nmu3ubuntu4
I: Retrieving apt 1.2.10ubuntu1
I: Validating apt 1.2.10ubuntu1
I: Retrieving apt-utils 1.2.10ubuntu1
I: Validating apt-utils 1.2.10ubuntu1
I: Retrieving base-files 9.4ubuntu4
I: Validating base-files 9.4ubuntu4
I: Retrieving base-passwd 3.5.39
I: Validating base-passwd 3.5.39
I: Retrieving bash 4.3-14ubuntu1
I: Validating bash 4.3-14ubuntu1
I: Retrieving bsdutils 1:2.27.1-6ubuntu3
I: Validating bsdutils 1:2.27.1-6ubuntu3
I: Retrieving busybox-initramfs 1:1.22.0-15ubuntu1
I: Validating busybox-initramfs 1:1.22.0-15ubuntu1
I: Retrieving bzip2 1.0.6-8
I: Validating bzip2 1.0.6-8
I: Retrieving console-setup 1.108ubuntu15
I: Validating console-setup 1.108ubuntu15
I: Retrieving console-setup-linux 1.108ubuntu15
I: Validating console-setup-linux 1.108ubuntu15
I: Retrieving coreutils 8.25-2ubuntu2
I: Validating coreutils 8.25-2ubuntu2
I: Retrieving cpio 2.11+dfsg-5ubuntu1
I: Validating cpio 2.11+dfsg-5ubuntu1
I: Retrieving cron 3.0pl1-128ubuntu2
I: Validating cron 3.0pl1-128ubuntu2
I: Retrieving dash 0.5.8-2.1ubuntu2
I: Validating dash 0.5.8-2.1ubuntu2
I: Retrieving debconf 1.5.58ubuntu1
I: Validating debconf 1.5.58ubuntu1
I: Retrieving debconf-i18n 1.5.58ubuntu1
I: Validating debconf-i18n 1.5.58ubuntu1
I: Retrieving debianutils 4.7
I: Validating debianutils 4.7
I: Retrieving dh-python 2.20151103ubuntu1
I: Validating dh-python 2.20151103ubuntu1
I: Retrieving diffutils 1:3.3-3
I: Validating diffutils 1:3.3-3
I: Retrieving distro-info-data 0.28
I: Validating distro-info-data 0.28
I: Retrieving dpkg 1.18.4ubuntu1
I: Validating dpkg 1.18.4ubuntu1
I: Retrieving e2fslibs 1.42.13-1ubuntu1
I: Validating e2fslibs 1.42.13-1ubuntu1
I: Retrieving e2fsprogs 1.42.13-1ubuntu1
I: Validating e2fsprogs 1.42.13-1ubuntu1
I: Retrieving eject 2.1.5+deb1+cvs20081104-13.1
I: Validating eject 2.1.5+deb1+cvs20081104-13.1
I: Retrieving file 1:5.25-2ubuntu1
I: Validating file 1:5.25-2ubuntu1
I: Retrieving findutils 4.6.0+git+20160126-2
I: Validating findutils 4.6.0+git+20160126-2
I: Retrieving gcc-5-base 5.3.1-14ubuntu2
I: Validating gcc-5-base 5.3.1-14ubuntu2
I: Retrieving gcc-6-base 6.0.1-0ubuntu1
I: Validating gcc-6-base 6.0.1-0ubuntu1
I: Retrieving gnupg 1.4.20-1ubuntu3
I: Validating gnupg 1.4.20-1ubuntu3
I: Retrieving gpgv 1.4.20-1ubuntu3
I: Validating gpgv 1.4.20-1ubuntu3
I: Retrieving grep 2.24-1
I: Validating grep 2.24-1
I: Retrieving gzip 1.6-4ubuntu1
I: Validating gzip 1.6-4ubuntu1
I: Retrieving hostname 3.16ubuntu2
I: Validating hostname 3.16ubuntu2
I: Retrieving ifupdown 0.8.10ubuntu1
I: Validating ifupdown 0.8.10ubuntu1
I: Retrieving init 1.29ubuntu1
I: Validating init 1.29ubuntu1
I: Retrieving init-system-helpers 1.29ubuntu1
I: Validating init-system-helpers 1.29ubuntu1
I: Retrieving initramfs-tools 0.122ubuntu8
I: Validating initramfs-tools 0.122ubuntu8
I: Retrieving initramfs-tools-bin 0.122ubuntu8
I: Validating initramfs-tools-bin 0.122ubuntu8
I: Retrieving initramfs-tools-core 0.122ubuntu8
I: Validating initramfs-tools-core 0.122ubuntu8
I: Retrieving initscripts 2.88dsf-59.3ubuntu2
I: Validating initscripts 2.88dsf-59.3ubuntu2
I: Retrieving insserv 1.14.0-5ubuntu3
I: Validating insserv 1.14.0-5ubuntu3
I: Retrieving iproute2 4.3.0-1ubuntu3
I: Validating iproute2 4.3.0-1ubuntu3
I: Retrieving iputils-ping 3:20121221-5ubuntu2
I: Validating iputils-ping 3:20121221-5ubuntu2
I: Retrieving isc-dhcp-client 4.3.3-5ubuntu12
I: Validating isc-dhcp-client 4.3.3-5ubuntu12
I: Retrieving isc-dhcp-common 4.3.3-5ubuntu12
I: Validating isc-dhcp-common 4.3.3-5ubuntu12
I: Retrieving kbd 1.15.5-1ubuntu4
I: Validating kbd 1.15.5-1ubuntu4
I: Retrieving keyboard-configuration 1.108ubuntu15
I: Validating keyboard-configuration 1.108ubuntu15
I: Retrieving klibc-utils 2.0.4-8ubuntu1
I: Validating klibc-utils 2.0.4-8ubuntu1
I: Retrieving kmod 22-1ubuntu4
I: Validating kmod 22-1ubuntu4
I: Retrieving less 481-2.1
I: Validating less 481-2.1
I: Retrieving libacl1 2.2.52-3
I: Validating libacl1 2.2.52-3
I: Retrieving libapparmor1 2.10.95-0ubuntu2
I: Validating libapparmor1 2.10.95-0ubuntu2
I: Retrieving libapt-inst2.0 1.2.10ubuntu1
I: Validating libapt-inst2.0 1.2.10ubuntu1
I: Retrieving libapt-pkg5.0 1.2.10ubuntu1
I: Validating libapt-pkg5.0 1.2.10ubuntu1
I: Retrieving libatm1 1:2.5.1-1.5
I: Validating libatm1 1:2.5.1-1.5
I: Retrieving libattr1 1:2.4.47-2
I: Validating libattr1 1:2.4.47-2
I: Retrieving libaudit-common 1:2.4.5-1ubuntu2
I: Validating libaudit-common 1:2.4.5-1ubuntu2
I: Retrieving libaudit1 1:2.4.5-1ubuntu2
I: Validating libaudit1 1:2.4.5-1ubuntu2
I: Retrieving libblkid1 2.27.1-6ubuntu3
I: Validating libblkid1 2.27.1-6ubuntu3
I: Retrieving libbsd0 0.8.2-1
I: Validating libbsd0 0.8.2-1
I: Retrieving libbz2-1.0 1.0.6-8
I: Validating libbz2-1.0 1.0.6-8
I: Retrieving libc-bin 2.23-0ubuntu3
I: Validating libc-bin 2.23-0ubuntu3
I: Retrieving libc6 2.23-0ubuntu3
I: Validating libc6 2.23-0ubuntu3
I: Retrieving libcap2 1:2.24-12
I: Validating libcap2 1:2.24-12
I: Retrieving libcap2-bin 1:2.24-12
I: Validating libcap2-bin 1:2.24-12
I: Retrieving libcomerr2 1.42.13-1ubuntu1
I: Validating libcomerr2 1.42.13-1ubuntu1
I: Retrieving libcryptsetup4 2:1.6.6-5ubuntu2
I: Validating libcryptsetup4 2:1.6.6-5ubuntu2
I: Retrieving libdb5.3 5.3.28-11
I: Validating libdb5.3 5.3.28-11
I: Retrieving libdebconfclient0 0.198ubuntu1
I: Validating libdebconfclient0 0.198ubuntu1
I: Retrieving libdevmapper1.02.1 2:1.02.110-1ubuntu10
I: Validating libdevmapper1.02.1 2:1.02.110-1ubuntu10
I: Retrieving libdns-export162 1:9.10.3.dfsg.P4-8
I: Validating libdns-export162 1:9.10.3.dfsg.P4-8
I: Retrieving libestr0 0.1.10-1
I: Validating libestr0 0.1.10-1
I: Retrieving libexpat1 2.1.0-7
I: Validating libexpat1 2.1.0-7
I: Retrieving libfdisk1 2.27.1-6ubuntu3
I: Validating libfdisk1 2.27.1-6ubuntu3
I: Retrieving libffi6 3.2.1-4
I: Validating libffi6 3.2.1-4
I: Retrieving libfribidi0 0.19.7-1
I: Validating libfribidi0 0.19.7-1
I: Retrieving libgcc1 1:6.0.1-0ubuntu1
I: Validating libgcc1 1:6.0.1-0ubuntu1
I: Retrieving libgcrypt20 1.6.5-2
I: Validating libgcrypt20 1.6.5-2
I: Retrieving libgmp10 2:6.1.0+dfsg-2
I: Validating libgmp10 2:6.1.0+dfsg-2
I: Retrieving libgnutls-openssl27 3.4.10-4ubuntu1
I: Validating libgnutls-openssl27 3.4.10-4ubuntu1
I: Retrieving libgnutls30 3.4.10-4ubuntu1
I: Validating libgnutls30 3.4.10-4ubuntu1
I: Retrieving libgpg-error0 1.21-2ubuntu1
I: Validating libgpg-error0 1.21-2ubuntu1
I: Retrieving libhogweed4 3.2-1
I: Validating libhogweed4 3.2-1
I: Retrieving libidn11 1.32-3ubuntu1
I: Validating libidn11 1.32-3ubuntu1
I: Retrieving libisc-export160 1:9.10.3.dfsg.P4-8
I: Validating libisc-export160 1:9.10.3.dfsg.P4-8
I: Retrieving libjson-c2 0.11-4ubuntu2
I: Validating libjson-c2 0.11-4ubuntu2
I: Retrieving libklibc 2.0.4-8ubuntu1
I: Validating libklibc 2.0.4-8ubuntu1
I: Retrieving libkmod2 22-1ubuntu4
I: Validating libkmod2 22-1ubuntu4
I: Retrieving liblocale-gettext-perl 1.07-1build1
I: Validating liblocale-gettext-perl 1.07-1build1
I: Retrieving liblz4-1 0.0~r131-2ubuntu2
I: Validating liblz4-1 0.0~r131-2ubuntu2
I: Retrieving liblzma5 5.1.1alpha+20120614-2ubuntu2
I: Validating liblzma5 5.1.1alpha+20120614-2ubuntu2
I: Retrieving libmagic1 1:5.25-2ubuntu1
I: Validating libmagic1 1:5.25-2ubuntu1
I: Retrieving libmnl0 1.0.3-5
I: Validating libmnl0 1.0.3-5
I: Retrieving libmount1 2.27.1-6ubuntu3
I: Validating libmount1 2.27.1-6ubuntu3
I: Retrieving libmpdec2 2.4.2-1
I: Validating libmpdec2 2.4.2-1
I: Retrieving libncurses5 6.0+20160213-1ubuntu1
I: Validating libncurses5 6.0+20160213-1ubuntu1
I: Retrieving libncursesw5 6.0+20160213-1ubuntu1
I: Validating libncursesw5 6.0+20160213-1ubuntu1
I: Retrieving libnettle6 3.2-1
I: Validating libnettle6 3.2-1
I: Retrieving libnewt0.52 0.52.18-1ubuntu2
I: Validating libnewt0.52 0.52.18-1ubuntu2
I: Retrieving libnih1 1.0.3-4.3ubuntu1
I: Validating libnih1 1.0.3-4.3ubuntu1
I: Retrieving libp11-kit0 0.23.2-3
I: Validating libp11-kit0 0.23.2-3
I: Retrieving libpam-modules 1.1.8-3.2ubuntu2
I: Validating libpam-modules 1.1.8-3.2ubuntu2
I: Retrieving libpam-modules-bin 1.1.8-3.2ubuntu2
I: Validating libpam-modules-bin 1.1.8-3.2ubuntu2
I: Retrieving libpam-runtime 1.1.8-3.2ubuntu2
I: Validating libpam-runtime 1.1.8-3.2ubuntu2
I: Retrieving libpam0g 1.1.8-3.2ubuntu2
I: Validating libpam0g 1.1.8-3.2ubuntu2
I: Retrieving libpcre3 2:8.38-3.1
I: Validating libpcre3 2:8.38-3.1
I: Retrieving libpng12-0 1.2.54-1ubuntu1
I: Validating libpng12-0 1.2.54-1ubuntu1
I: Retrieving libpopt0 1.16-10
I: Validating libpopt0 1.16-10
I: Retrieving libprocps4 2:3.3.10-4ubuntu2
I: Validating libprocps4 2:3.3.10-4ubuntu2
I: Retrieving libpython3-stdlib 3.5.1-3
I: Validating libpython3-stdlib 3.5.1-3
I: Retrieving libpython3.5-minimal 3.5.1-10
I: Validating libpython3.5-minimal 3.5.1-10
I: Retrieving libpython3.5-stdlib 3.5.1-10
I: Validating libpython3.5-stdlib 3.5.1-10
I: Retrieving libreadline6 6.3-8ubuntu2
I: Validating libreadline6 6.3-8ubuntu2
I: Retrieving libseccomp2 2.2.3-3ubuntu3
I: Validating libseccomp2 2.2.3-3ubuntu3
I: Retrieving libselinux1 2.4-3build2
I: Validating libselinux1 2.4-3build2
I: Retrieving libsemanage-common 2.3-1build3
I: Validating libsemanage-common 2.3-1build3
I: Retrieving libsemanage1 2.3-1build3
I: Validating libsemanage1 2.3-1build3
I: Retrieving libsepol1 2.4-2
I: Validating libsepol1 2.4-2
I: Retrieving libslang2 2.3.0-2ubuntu1
I: Validating libslang2 2.3.0-2ubuntu1
I: Retrieving libsmartcols1 2.27.1-6ubuntu3
I: Validating libsmartcols1 2.27.1-6ubuntu3
I: Retrieving libsqlite3-0 3.11.0-1ubuntu1
I: Validating libsqlite3-0 3.11.0-1ubuntu1
I: Retrieving libss2 1.42.13-1ubuntu1
I: Validating libss2 1.42.13-1ubuntu1
I: Retrieving libssl1.0.0 1.0.2g-1ubuntu4
I: Validating libssl1.0.0 1.0.2g-1ubuntu4
I: Retrieving libstdc++6 5.3.1-14ubuntu2
I: Validating libstdc++6 5.3.1-14ubuntu2
I: Retrieving libsystemd0 229-4ubuntu4
I: Validating libsystemd0 229-4ubuntu4
I: Retrieving libtasn1-6 4.7-3
I: Validating libtasn1-6 4.7-3
I: Retrieving libtext-charwidth-perl 0.04-7build5
I: Validating libtext-charwidth-perl 0.04-7build5
I: Retrieving libtext-iconv-perl 1.7-5build4
I: Validating libtext-iconv-perl 1.7-5build4
I: Retrieving libtext-wrapi18n-perl 0.06-7.1
I: Validating libtext-wrapi18n-perl 0.06-7.1
I: Retrieving libtinfo5 6.0+20160213-1ubuntu1
I: Validating libtinfo5 6.0+20160213-1ubuntu1
I: Retrieving libudev1 229-4ubuntu4
I: Validating libudev1 229-4ubuntu4
I: Retrieving libusb-0.1-4 2:0.1.12-28
I: Validating libusb-0.1-4 2:0.1.12-28
I: Retrieving libustr-1.0-1 1.0.4-5
I: Validating libustr-1.0-1 1.0.4-5
I: Retrieving libuuid1 2.27.1-6ubuntu3
I: Validating libuuid1 2.27.1-6ubuntu3
I: Retrieving libxtables11 1.6.0-2ubuntu3
I: Validating libxtables11 1.6.0-2ubuntu3
I: Retrieving linux-base 4.0ubuntu1
I: Validating linux-base 4.0ubuntu1
I: Retrieving locales 2.23-0ubuntu3
I: Validating locales 2.23-0ubuntu3
I: Retrieving login 1:4.2-3.1ubuntu5
I: Validating login 1:4.2-3.1ubuntu5
I: Retrieving logrotate 3.8.7-2ubuntu2
I: Validating logrotate 3.8.7-2ubuntu2
I: Retrieving lsb-base 9.20160110
I: Validating lsb-base 9.20160110
I: Retrieving lsb-release 9.20160110
I: Validating lsb-release 9.20160110
I: Retrieving makedev 2.3.1-93ubuntu1
I: Validating makedev 2.3.1-93ubuntu1
I: Retrieving mawk 1.3.3-17ubuntu2
I: Validating mawk 1.3.3-17ubuntu2
I: Retrieving mime-support 3.59ubuntu1
I: Validating mime-support 3.59ubuntu1
I: Retrieving mount 2.27.1-6ubuntu3
I: Validating mount 2.27.1-6ubuntu3
I: Retrieving multiarch-support 2.23-0ubuntu3
I: Validating multiarch-support 2.23-0ubuntu3
I: Retrieving ncurses-base 6.0+20160213-1ubuntu1
I: Validating ncurses-base 6.0+20160213-1ubuntu1
I: Retrieving ncurses-bin 6.0+20160213-1ubuntu1
I: Validating ncurses-bin 6.0+20160213-1ubuntu1
I: Retrieving net-tools 1.60-26ubuntu1
I: Validating net-tools 1.60-26ubuntu1
I: Retrieving netbase 5.3
I: Validating netbase 5.3
I: Retrieving netcat-openbsd 1.105-7ubuntu1
I: Validating netcat-openbsd 1.105-7ubuntu1
I: Retrieving passwd 1:4.2-3.1ubuntu5
I: Validating passwd 1:4.2-3.1ubuntu5
I: Retrieving perl-base 5.22.1-9
I: Validating perl-base 5.22.1-9
I: Retrieving procps 2:3.3.10-4ubuntu2
I: Validating procps 2:3.3.10-4ubuntu2
I: Retrieving python3 3.5.1-3
I: Validating python3 3.5.1-3
I: Retrieving python3-minimal 3.5.1-3
I: Validating python3-minimal 3.5.1-3
I: Retrieving python3.5 3.5.1-10
I: Validating python3.5 3.5.1-10
I: Retrieving python3.5-minimal 3.5.1-10
I: Validating python3.5-minimal 3.5.1-10
I: Retrieving readline-common 6.3-8ubuntu2
I: Validating readline-common 6.3-8ubuntu2
I: Retrieving resolvconf 1.78ubuntu2
I: Validating resolvconf 1.78ubuntu2
I: Retrieving rsyslog 8.16.0-1ubuntu3
I: Validating rsyslog 8.16.0-1ubuntu3
I: Retrieving sed 4.2.2-7
I: Validating sed 4.2.2-7
I: Retrieving sensible-utils 0.0.9
I: Validating sensible-utils 0.0.9
I: Retrieving sudo 1.8.16-0ubuntu1
I: Validating sudo 1.8.16-0ubuntu1
I: Retrieving systemd 229-4ubuntu4
I: Validating systemd 229-4ubuntu4
I: Retrieving systemd-sysv 229-4ubuntu4
I: Validating systemd-sysv 229-4ubuntu4
I: Retrieving sysv-rc 2.88dsf-59.3ubuntu2
I: Validating sysv-rc 2.88dsf-59.3ubuntu2
I: Retrieving sysvinit-utils 2.88dsf-59.3ubuntu2
I: Validating sysvinit-utils 2.88dsf-59.3ubuntu2
I: Retrieving tar 1.28-2.1
I: Validating tar 1.28-2.1
I: Retrieving tzdata 2016d-0ubuntu0.16.04
I: Validating tzdata 2016d-0ubuntu0.16.04
I: Retrieving ubuntu-keyring 2012.05.19
I: Validating ubuntu-keyring 2012.05.19
I: Retrieving ubuntu-minimal 1.361
I: Validating ubuntu-minimal 1.361
I: Retrieving ucf 3.0036
I: Validating ucf 3.0036
I: Retrieving udev 229-4ubuntu4
I: Validating udev 229-4ubuntu4
I: Retrieving ureadahead 0.100.0-19
I: Validating ureadahead 0.100.0-19
I: Retrieving util-linux 2.27.1-6ubuntu3
I: Validating util-linux 2.27.1-6ubuntu3
I: Retrieving vim-common 2:7.4.1689-3ubuntu1
I: Validating vim-common 2:7.4.1689-3ubuntu1
I: Retrieving vim-tiny 2:7.4.1689-3ubuntu1
I: Validating vim-tiny 2:7.4.1689-3ubuntu1
I: Retrieving whiptail 0.52.18-1ubuntu2
I: Validating whiptail 0.52.18-1ubuntu2
I: Retrieving xkb-data 2.16-1ubuntu1
I: Validating xkb-data 2.16-1ubuntu1
I: Retrieving zlib1g 1:1.2.8.dfsg-2ubuntu4
I: Validating zlib1g 1:1.2.8.dfsg-2ubuntu4
I: Chosen extractor for .deb packages: dpkg-deb
I: Extracting adduser...
I: Extracting base-files...
I: Extracting base-passwd...
I: Extracting bash...
I: Extracting bsdutils...
I: Extracting coreutils...
I: Extracting dash...
I: Extracting debconf...
I: Extracting debianutils...
I: Extracting diffutils...
I: Extracting dpkg...
I: Extracting e2fslibs...
I: Extracting e2fsprogs...
I: Extracting findutils...
I: Extracting gcc-6-base...
I: Extracting grep...
I: Extracting gzip...
I: Extracting hostname...
I: Extracting init...
I: Extracting init-system-helpers...
I: Extracting initscripts...
I: Extracting insserv...
I: Extracting libacl1...
I: Extracting libapparmor1...
I: Extracting libattr1...
I: Extracting libaudit-common...
I: Extracting libaudit1...
I: Extracting libblkid1...
I: Extracting libbz2-1.0...
I: Extracting libc-bin...
I: Extracting libc6...
I: Extracting libcap2...
I: Extracting libcap2-bin...
I: Extracting libcomerr2...
I: Extracting libcryptsetup4...
I: Extracting libdb5.3...
I: Extracting libdebconfclient0...
I: Extracting libdevmapper1.02.1...
I: Extracting libfdisk1...
I: Extracting libgcc1...
I: Extracting libgcrypt20...
I: Extracting libgpg-error0...
I: Extracting libkmod2...
I: Extracting liblzma5...
I: Extracting libmount1...
I: Extracting libncurses5...
I: Extracting libncursesw5...
I: Extracting libpam-modules...
I: Extracting libpam-modules-bin...
I: Extracting libpam-runtime...
I: Extracting libpam0g...
I: Extracting libpcre3...
I: Extracting libprocps4...
I: Extracting libseccomp2...
I: Extracting libselinux1...
I: Extracting libsemanage-common...
I: Extracting libsemanage1...
I: Extracting libsepol1...
I: Extracting libsmartcols1...
I: Extracting libss2...
I: Extracting libsystemd0...
I: Extracting libtinfo5...
I: Extracting libudev1...
I: Extracting libustr-1.0-1...
I: Extracting libuuid1...
I: Extracting locales...
I: Extracting login...
I: Extracting lsb-base...
I: Extracting makedev...
I: Extracting mawk...
I: Extracting mount...
I: Extracting multiarch-support...
I: Extracting ncurses-base...
I: Extracting ncurses-bin...
I: Extracting passwd...
I: Extracting perl-base...
I: Extracting procps...
I: Extracting sed...
I: Extracting sensible-utils...
I: Extracting systemd...
I: Extracting systemd-sysv...
I: Extracting sysv-rc...
I: Extracting sysvinit-utils...
I: Extracting tar...
I: Extracting tzdata...
I: Extracting util-linux...
I: Extracting zlib1g...
I: Installing core packages...
I: Unpacking required packages...
I: Unpacking adduser...
I: Unpacking base-files...
I: Unpacking base-passwd...
I: Unpacking bash...
I: Unpacking bsdutils...
I: Unpacking coreutils...
I: Unpacking dash...
I: Unpacking debconf...
I: Unpacking debianutils...
I: Unpacking diffutils...
I: Unpacking dpkg...
I: Unpacking e2fslibs:amd64...
I: Unpacking e2fsprogs...
I: Unpacking findutils...
I: Unpacking gcc-6-base:amd64...
I: Unpacking grep...
I: Unpacking gzip...
I: Unpacking hostname...
I: Unpacking init...
I: Unpacking init-system-helpers...
I: Unpacking initscripts...
I: Unpacking insserv...
I: Unpacking libacl1:amd64...
I: Unpacking libapparmor1:amd64...
I: Unpacking libattr1:amd64...
I: Unpacking libaudit-common...
I: Unpacking libaudit1:amd64...
I: Unpacking libblkid1:amd64...
I: Unpacking libbz2-1.0:amd64...
I: Unpacking libc-bin...
I: Unpacking libc6:amd64...
I: Unpacking libcap2:amd64...
I: Unpacking libcap2-bin...
I: Unpacking libcomerr2:amd64...
I: Unpacking libcryptsetup4:amd64...
I: Unpacking libdb5.3:amd64...
I: Unpacking libdebconfclient0:amd64...
I: Unpacking libdevmapper1.02.1:amd64...
I: Unpacking libfdisk1:amd64...
I: Unpacking libgcc1:amd64...
I: Unpacking libgcrypt20:amd64...
I: Unpacking libgpg-error0:amd64...
I: Unpacking libkmod2:amd64...
I: Unpacking liblzma5:amd64...
I: Unpacking libmount1:amd64...
I: Unpacking libncurses5:amd64...
I: Unpacking libncursesw5:amd64...
I: Unpacking libpam-modules:amd64...
I: Unpacking libpam-modules-bin...
I: Unpacking libpam-runtime...
I: Unpacking libpam0g:amd64...
I: Unpacking libpcre3:amd64...
I: Unpacking libprocps4:amd64...
I: Unpacking libseccomp2:amd64...
I: Unpacking libselinux1:amd64...
I: Unpacking libsemanage-common...
I: Unpacking libsemanage1:amd64...
I: Unpacking libsepol1:amd64...
I: Unpacking libsmartcols1:amd64...
I: Unpacking libss2:amd64...
I: Unpacking libsystemd0:amd64...
I: Unpacking libtinfo5:amd64...
I: Unpacking libudev1:amd64...
I: Unpacking libustr-1.0-1:amd64...
I: Unpacking libuuid1:amd64...
I: Unpacking locales...
I: Unpacking login...
I: Unpacking lsb-base...
I: Unpacking makedev...
I: Unpacking mawk...
I: Unpacking mount...
I: Unpacking multiarch-support...
I: Unpacking ncurses-base...
I: Unpacking ncurses-bin...
I: Unpacking passwd...
I: Unpacking perl-base...
I: Unpacking procps...
I: Unpacking sed...
I: Unpacking sensible-utils...
I: Unpacking systemd...
I: Unpacking systemd-sysv...
I: Unpacking sysv-rc...
I: Unpacking sysvinit-utils...
I: Unpacking tar...
I: Unpacking tzdata...
I: Unpacking util-linux...
I: Unpacking zlib1g:amd64...
I: Configuring required packages...
I: Configuring gcc-6-base:amd64...
I: Configuring lsb-base...
I: Configuring sensible-utils...
I: Configuring ncurses-base...
I: Configuring libsemanage-common...
I: Configuring libaudit-common...
I: Configuring libc6:amd64...
I: Configuring libbz2-1.0:amd64...
I: Configuring libkmod2:amd64...
I: Configuring libgpg-error0:amd64...
I: Configuring libc-bin...
I: Configuring libseccomp2:amd64...
I: Configuring libapparmor1:amd64...
I: Configuring libdebconfclient0:amd64...
I: Configuring diffutils...
I: Configuring insserv...
I: Configuring libcomerr2:amd64...
I: Configuring libsepol1:amd64...
I: Configuring libgcc1:amd64...
I: Configuring libustr-1.0-1:amd64...
I: Configuring libsmartcols1:amd64...
I: Configuring libaudit1:amd64...
I: Configuring libtinfo5:amd64...
I: Configuring libudev1:amd64...
I: Configuring libss2:amd64...
I: Configuring base-passwd...
I: Configuring e2fslibs:amd64...
I: Configuring debianutils...
I: Configuring libgcrypt20:amd64...
I: Configuring libncursesw5:amd64...
I: Configuring libdb5.3:amd64...
I: Configuring zlib1g:amd64...
I: Configuring hostname...
I: Configuring multiarch-support...
I: Configuring mawk...
I: Configuring libcap2:amd64...
I: Configuring libpcre3:amd64...
I: Configuring base-files...
I: Configuring libselinux1:amd64...
I: Configuring findutils...
I: Configuring ncurses-bin...
I: Configuring libncurses5:amd64...
I: Configuring makedev...
I: Configuring libattr1:amd64...
I: Configuring liblzma5:amd64...
I: Configuring libcap2-bin...
I: Configuring libsystemd0:amd64...
I: Configuring libdevmapper1.02.1:amd64...
I: Configuring libsemanage1:amd64...
I: Configuring libacl1:amd64...
I: Configuring libprocps4:amd64...
I: Configuring bsdutils...
I: Configuring coreutils...
I: Configuring tar...
I: Configuring dpkg...
I: Configuring sed...
I: Configuring perl-base...
I: Configuring grep...
I: Configuring debconf...
I: Configuring tzdata...
I: Configuring gzip...
I: Configuring dash...
I: Configuring init-system-helpers...
I: Configuring sysvinit-utils...
I: Configuring sysv-rc...
I: Configuring libpam0g:amd64...
I: Configuring locales...
I: Configuring libpam-modules-bin...
I: Configuring bash...
I: Configuring libpam-modules:amd64...
I: Configuring libpam-runtime...
I: Configuring passwd...
I: Configuring login...
I: Configuring adduser...
I: Configuring libuuid1:amd64...
I: Configuring libblkid1:amd64...
I: Configuring libmount1:amd64...
I: Configuring libcryptsetup4:amd64...
I: Configuring mount...
I: Configuring libfdisk1:amd64...
I: Configuring initscripts...
I: Configuring util-linux...
I: Configuring e2fsprogs...
I: Configuring procps...
I: Configuring systemd...
I: Configuring systemd-sysv...
I: Configuring init...
I: Configuring libc-bin...
I: Unpacking the base system...
I: Unpacking apt...
I: Unpacking apt-utils...
I: Unpacking busybox-initramfs...
I: Unpacking bzip2...
I: Unpacking console-setup...
I: Unpacking console-setup-linux...
I: Unpacking cpio...
I: Unpacking cron...
I: Unpacking debconf-i18n...
I: Unpacking dh-python...
I: Unpacking distro-info-data...
I: Unpacking eject...
I: Unpacking file...
I: Unpacking gcc-5-base:amd64...
I: Unpacking gnupg...
I: Unpacking gpgv...
I: Unpacking ifupdown...
I: Unpacking initramfs-tools...
I: Unpacking initramfs-tools-bin...
I: Unpacking initramfs-tools-core...
I: Unpacking iproute2...
I: Unpacking iputils-ping...
I: Unpacking isc-dhcp-client...
I: Unpacking isc-dhcp-common...
I: Unpacking kbd...
I: Unpacking keyboard-configuration...
I: Unpacking klibc-utils...
I: Unpacking kmod...
I: Unpacking less...
I: Unpacking libapt-inst2.0:amd64...
I: Unpacking libapt-pkg5.0:amd64...
I: Unpacking libatm1:amd64...
I: Unpacking libbsd0:amd64...
I: Unpacking libdns-export162...
I: Unpacking libestr0...
I: Unpacking libffi6:amd64...
I: Unpacking libfribidi0:amd64...
I: Unpacking libgmp10:amd64...
I: Unpacking libgnutls-openssl27:amd64...
I: Unpacking libgnutls30:amd64...
I: Unpacking libhogweed4:amd64...
I: Unpacking libidn11:amd64...
I: Unpacking libisc-export160...
I: Unpacking libjson-c2:amd64...
I: Unpacking libklibc...
I: Unpacking liblocale-gettext-perl...
I: Unpacking liblz4-1:amd64...
I: Unpacking libmagic1:amd64...
I: Unpacking libmnl0:amd64...
I: Unpacking libmpdec2:amd64...
I: Unpacking libnettle6:amd64...
I: Unpacking libnewt0.52:amd64...
I: Unpacking libnih1:amd64...
I: Unpacking libp11-kit0:amd64...
I: Unpacking libpng12-0:amd64...
I: Unpacking libpopt0:amd64...
I: Unpacking libpython3-stdlib:amd64...
I: Unpacking libpython3.5-stdlib:amd64...
I: Unpacking libreadline6:amd64...
I: Unpacking libslang2:amd64...
I: Unpacking libsqlite3-0:amd64...
I: Unpacking libstdc++6:amd64...
I: Unpacking libtasn1-6:amd64...
I: Unpacking libtext-charwidth-perl...
I: Unpacking libtext-iconv-perl...
I: Unpacking libtext-wrapi18n-perl...
I: Unpacking libusb-0.1-4:amd64...
I: Unpacking libxtables11:amd64...
I: Unpacking linux-base...
I: Unpacking logrotate...
I: Unpacking lsb-release...
I: Unpacking mime-support...
I: Unpacking net-tools...
I: Unpacking netbase...
I: Unpacking netcat-openbsd...
I: Unpacking python3...
I: Unpacking python3.5...
I: Unpacking readline-common...
I: Unpacking resolvconf...
I: Unpacking rsyslog...
I: Unpacking sudo...
I: Unpacking ubuntu-keyring...
I: Unpacking ubuntu-minimal...
I: Unpacking ucf...
I: Unpacking udev...
I: Unpacking ureadahead...
I: Unpacking vim-common...
I: Unpacking vim-tiny...
I: Unpacking whiptail...
I: Unpacking xkb-data...
I: Configuring the base system...
I: Configuring readline-common...
I: Configuring libnettle6:amd64...
I: Configuring cpio...
I: Configuring libpopt0:amd64...
I: Configuring kmod...
I: Configuring libestr0...
I: Configuring less...
I: Configuring libisc-export160...
I: Configuring liblz4-1:amd64...
I: Configuring mime-support...
I: Configuring sudo...
I: Configuring isc-dhcp-common...
I: Configuring libklibc...
I: Configuring gpgv...
I: Configuring xkb-data...
I: Configuring linux-base...
I: Configuring libxtables11:amd64...
I: Configuring libdns-export162...
I: Configuring distro-info-data...
I: Configuring libbsd0:amd64...
I: Configuring libpng12-0:amd64...
I: Configuring ucf...
I: Configuring libtasn1-6:amd64...
I: Configuring bzip2...
I: Configuring libmagic1:amd64...
I: Configuring netcat-openbsd...
I: Configuring busybox-initramfs...
I: Configuring libgmp10:amd64...
I: Configuring libatm1:amd64...
I: Configuring udev...
I: Configuring libtext-iconv-perl...
I: Configuring vim-common...
I: Configuring libsqlite3-0:amd64...
I: Configuring libfribidi0:amd64...
I: Configuring liblocale-gettext-perl...
I: Configuring libffi6:amd64...
I: Configuring libtext-charwidth-perl...
I: Configuring initramfs-tools-bin...
I: Configuring net-tools...
I: Configuring libslang2:amd64...
I: Configuring cron...
I: Configuring libmnl0:amd64...
I: Configuring libusb-0.1-4:amd64...
I: Configuring libnih1:amd64...
I: Configuring logrotate...
I: Configuring libidn11:amd64...
I: Configuring libmpdec2:amd64...
I: Configuring ubuntu-keyring...
I: Configuring libreadline6:amd64...
I: Configuring gcc-5-base:amd64...
I: Configuring libjson-c2:amd64...
I: Configuring eject...
I: Configuring netbase...
I: Configuring vim-tiny...
I: Configuring keyboard-configuration...
I: Configuring klibc-utils...
I: Configuring ureadahead...
I: Configuring initramfs-tools-core...
I: Configuring libpython3.5-stdlib:amd64...
I: Configuring gnupg...
I: Configuring initramfs-tools...
I: Configuring file...
I: Configuring iproute2...
I: Configuring isc-dhcp-client...
I: Configuring libhogweed4:amd64...
I: Configuring libtext-wrapi18n-perl...
I: Configuring libp11-kit0:amd64...
I: Configuring libstdc++6:amd64...
I: Configuring libnewt0.52:amd64...
I: Configuring rsyslog...
I: Configuring python3.5...
I: Configuring libpython3-stdlib:amd64...
I: Configuring libapt-pkg5.0:amd64...
I: Configuring libapt-inst2.0:amd64...
I: Configuring ifupdown...
I: Configuring debconf-i18n...
I: Configuring whiptail...
I: Configuring libgnutls30:amd64...
I: Configuring libgnutls-openssl27:amd64...
I: Configuring apt...
I: Configuring resolvconf...
I: Configuring iputils-ping...
I: Configuring apt-utils...
I: Configuring kbd...
I: Configuring console-setup-linux...
I: Configuring console-setup...
I: Configuring python3...
I: Configuring lsb-release...
I: Configuring ubuntu-minimal...
I: Configuring dh-python...
I: Configuring libc-bin...
I: Configuring systemd...
I: Configuring initramfs-tools...
I: Configuring ureadahead...
I: Configuring resolvconf...
I: Base system installed successfully.
Mount /proc, /dev, /sys, pkgdir and otherpkgdir to the rootimg.
108 blocks
/opt/xcat/share/xcat/netboot/ubuntu
108 blocks
/opt/xcat/share/xcat/netboot/ubuntu
The specified kerneldir /install/kernels does not exist!
The specified otherpkgdir /install/post/otherpkgs/ubuntu16.04.5/x86_64 does not exist!
Err:1 http://security.ubuntu.com/ubuntu xenial-security InRelease
  Could not resolve 'security.ubuntu.com'
Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease
Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]
Ign:4 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial InRelease
Get:5 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial Release [4613 B]
Get:6 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial Release.gpg [819 B]
Get:7 http://archive.ubuntu.com/ubuntu xenial/universe amd64 Packages [7532 kB]
Ign:8 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 Packages
Get:8 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 Packages [528 kB]
Get:9 http://archive.ubuntu.com/ubuntu xenial/universe Translation-en [4354 kB]
Get:10 http://archive.ubuntu.com/ubuntu xenial/main Translation-en [568 kB]
Get:11 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [747 kB]
Get:12 http://archive.ubuntu.com/ubuntu xenial-updates/universe Translation-en [311 kB]
Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [947 kB]
Get:14 http://archive.ubuntu.com/ubuntu xenial-updates/main Translation-en [379 kB]
Fetched 15.5 MB in 3s (4654 kB/s)
Reading package lists...
W: Failed to fetch http://security.ubuntu.com/ubuntu/dists/xenial-security/InRelease  Could not resolve 'security.ubuntu.com'
W: Some index files failed to download. They have been ignored, or old ones used instead.
Reading package lists...
Building dependency tree...
Calculating upgrade...
The following packages have been kept back:
  ubuntu-minimal
The following packages will be upgraded:
  apt apt-utils base-files bash bsdutils busybox-initramfs console-setup
  console-setup-linux coreutils dh-python distro-info-data dpkg eject file
  gcc-5-base gnupg gpgv grep ifupdown init init-system-helpers initramfs-tools
  initramfs-tools-bin initramfs-tools-core iproute2 isc-dhcp-client
  isc-dhcp-common kbd keyboard-configuration klibc-utils kmod less
  libapparmor1 libapt-inst2.0 libapt-pkg5.0 libaudit-common libaudit1
  libblkid1 libc-bin libc6 libcryptsetup4 libdb5.3 libdns-export162 libexpat1
  libfdisk1 libgcrypt20 libgnutls-openssl27 libgnutls30 libhogweed4 libidn11
  libisc-export160 libklibc libkmod2 libmagic1 libmount1 libnettle6
  libp11-kit0 libpam-modules libpam-modules-bin libpam-runtime libpam0g
  libpng12-0 libprocps4 libpython3.5-minimal libpython3.5-stdlib libseccomp2
  libslang2 libsmartcols1 libsqlite3-0 libssl1.0.0 libstdc++6 libsystemd0
  libtasn1-6 libudev1 libuuid1 linux-base locales login logrotate lsb-base
  lsb-release makedev mount multiarch-support passwd perl-base procps
  python3.5 python3.5-minimal resolvconf rsyslog sensible-utils sudo systemd
  systemd-sysv tar tzdata udev ureadahead util-linux vim-common vim-tiny
  zlib1g
103 upgraded, 0 newly installed, 0 to remove and 1 not upgraded.
Need to get 38.4 MB of archives.
After this operation, 501 kB of additional disk space will be used.
Get:1 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 coreutils amd64 8.25-2ubuntu3~16.04 [1174 kB]
Get:2 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 init-system-helpers all 1.29ubuntu4 [32.3 kB]
Get:3 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libaudit-common all 1:2.4.5-1ubuntu2.1 [3924 B]
Get:4 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libaudit1 amd64 1:2.4.5-1ubuntu2.1 [36.2 kB]
Get:5 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libpam0g amd64 1.1.8-3.2ubuntu2.1 [55.6 kB]
Get:6 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libpam-modules-bin amd64 1.1.8-3.2ubuntu2.1 [36.9 kB]
Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 base-files amd64 9.4ubuntu4.8 [69.4 kB]
Get:8 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libpam-modules amd64 1.1.8-3.2ubuntu2.1 [244 kB]
Get:9 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libuuid1 amd64 2.27.1-6ubuntu3.6 [15.1 kB]
Get:10 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libblkid1 amd64 2.27.1-6ubuntu3.6 [107 kB]
Get:11 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libprocps4 amd64 2:3.3.10-4ubuntu2.4 [33.1 kB]
Get:12 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 procps amd64 2:3.3.10-4ubuntu2.4 [222 kB]
Get:13 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libdb5.3 amd64 5.3.28-11ubuntu0.1 [670 kB]
Get:14 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 bash amd64 4.3-14ubuntu1.2 [583 kB]
Get:15 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libgcrypt20 amd64 1.6.5-2ubuntu0.5 [338 kB]
Get:16 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libmount1 amd64 2.27.1-6ubuntu3.6 [114 kB]
Get:17 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 klibc-utils amd64 2.0.4-8ubuntu1.16.04.4 [108 kB]
Get:18 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libklibc amd64 2.0.4-8ubuntu1.16.04.4 [41.0 kB]
Get:19 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 linux-base all 4.5ubuntu1~16.04.1 [18.1 kB]
Get:20 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 lsb-base all 9.20160110ubuntu0.2 [13.7 kB]
Get:21 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 util-linux amd64 2.27.1-6ubuntu3.6 [848 kB]
Get:22 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 bsdutils amd64 1:2.27.1-6ubuntu3.6 [51.2 kB]
Get:23 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 dpkg amd64 1.18.4ubuntu1.5 [2085 kB]
Get:24 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 mount amd64 2.27.1-6ubuntu3.6 [121 kB]
Get:25 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 tar amd64 1.28-2.1ubuntu0.1 [209 kB]
Get:26 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 zlib1g amd64 1:1.2.8.dfsg-2ubuntu4.1 [51.2 kB]
Get:27 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libexpat1 amd64 2.1.0-7ubuntu0.16.04.3 [71.2 kB]
Get:28 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libfdisk1 amd64 2.27.1-6ubuntu3.6 [138 kB]
Get:29 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libsmartcols1 amd64 2.27.1-6ubuntu3.6 [62.7 kB]
Get:30 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 sensible-utils all 0.0.9ubuntu0.16.04.1 [10.0 kB]
Get:31 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libpng12-0 amd64 1.2.54-1ubuntu1.1 [116 kB]
Get:32 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grep amd64 2.25-1~16.04.1 [153 kB]
Get:33 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl-base amd64 5.22.1-9ubuntu0.6 [1283 kB]
Get:34 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 init amd64 1.29ubuntu4 [4624 B]
Get:35 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 login amd64 1:4.2-3.1ubuntu5.4 [304 kB]
Get:36 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libudev1 amd64 229-4ubuntu21.21 [53.6 kB]
Get:37 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 udev amd64 229-4ubuntu21.21 [993 kB]
Get:38 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ifupdown amd64 0.8.10ubuntu1.4 [54.9 kB]
Get:39 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libsystemd0 amd64 229-4ubuntu21.21 [204 kB]
Get:40 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 systemd amd64 229-4ubuntu21.21 [3629 kB]
Get:41 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libc6 amd64 2.23-0ubuntu11 [2577 kB]
Get:42 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 passwd amd64 1:4.2-3.1ubuntu5.4 [780 kB]
Get:43 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 kmod amd64 22-1ubuntu5.2 [88.6 kB]
Get:44 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libkmod2 amd64 22-1ubuntu5.2 [39.9 kB]
Get:45 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iproute2 amd64 4.3.0-1ubuntu3.16.04.5 [523 kB]
Get:46 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libapparmor1 amd64 2.10.95-0ubuntu2.10 [29.7 kB]
Get:47 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libcryptsetup4 amd64 2:1.6.6-5ubuntu2.1 [73.3 kB]
Get:48 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libseccomp2 amd64 2.3.1-2.1ubuntu2~16.04.1 [38.7 kB]
Get:49 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 kbd amd64 1.15.5-1ubuntu5 [183 kB]
Get:50 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 console-setup-linux all 1.108ubuntu15.5 [984 kB]
Get:51 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 initramfs-tools-core all 0.122ubuntu8.14 [44.9 kB]
Get:52 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 initramfs-tools all 0.122ubuntu8.14 [8938 B]
Get:53 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 console-setup all 1.108ubuntu15.5 [117 kB]
Get:54 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 keyboard-configuration all 1.108ubuntu15.5 [658 kB]
Get:55 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 initramfs-tools-bin amd64 0.122ubuntu8.14 [9776 B]
Get:56 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 busybox-initramfs amd64 1:1.22.0-15ubuntu1.4 [179 kB]
Get:57 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 locales all 2.23-0ubuntu11 [3196 kB]
Get:58 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libc-bin amd64 2.23-0ubuntu11 [631 kB]
Get:59 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 gcc-5-base amd64 5.4.0-6ubuntu1~16.04.11 [17.3 kB]
Get:60 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libstdc++6 amd64 5.4.0-6ubuntu1~16.04.11 [393 kB]
Get:61 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libapt-pkg5.0 amd64 1.2.31 [712 kB]
Get:62 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libapt-inst2.0 amd64 1.2.31 [55.6 kB]
Get:63 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 apt amd64 1.2.31 [1087 kB]
Get:64 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 apt-utils amd64 1.2.31 [196 kB]
Get:65 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 gpgv amd64 1.4.20-1ubuntu3.3 [165 kB]
Get:66 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 gnupg amd64 1.4.20-1ubuntu3.3 [626 kB]
Get:67 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 systemd-sysv amd64 229-4ubuntu21.21 [11.1 kB]
Get:68 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libssl1.0.0 amd64 1.0.2g-1ubuntu4.15 [1084 kB]
Get:69 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 python3.5 amd64 3.5.2-2ubuntu0~16.04.5 [165 kB]
Get:70 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libpython3.5-stdlib amd64 3.5.2-2ubuntu0~16.04.5 [2134 kB]
Get:71 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 python3.5-minimal amd64 3.5.2-2ubuntu0~16.04.5 [1598 kB]
Get:72 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libpython3.5-minimal amd64 3.5.2-2ubuntu0~16.04.5 [524 kB]
Get:73 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libsqlite3-0 amd64 3.11.0-1ubuntu1.1 [396 kB]
Get:74 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libpam-runtime all 1.1.8-3.2ubuntu2.1 [37.9 kB]
Get:75 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 multiarch-support amd64 2.23-0ubuntu11 [6822 B]
Get:76 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 makedev all 2.3.1-93ubuntu2~ubuntu16.04.1 [24.4 kB]
Get:77 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 tzdata all 2019a-0ubuntu0.16.04 [167 kB]
Get:78 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 dh-python all 2.20151103ubuntu1.1 [74.1 kB]
Get:79 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 distro-info-data all 0.28ubuntu0.11 [4648 B]
Get:80 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 eject amd64 2.1.5+deb1+cvs20081104-13.1ubuntu0.16.04.1 [23.0 kB]
Get:81 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 file amd64 1:5.25-2ubuntu1.2 [21.2 kB]
Get:82 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libmagic1 amd64 1:5.25-2ubuntu1.2 [216 kB]
Get:83 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libisc-export160 amd64 1:9.10.3.dfsg.P4-8ubuntu1.14 [153 kB]
Get:84 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libdns-export162 amd64 1:9.10.3.dfsg.P4-8ubuntu1.14 [667 kB]
Get:85 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 isc-dhcp-client amd64 4.3.3-5ubuntu12.10 [224 kB]
Get:86 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 isc-dhcp-common amd64 4.3.3-5ubuntu12.10 [105 kB]
Get:87 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 less amd64 481-2.1ubuntu0.2 [110 kB]
Get:88 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libhogweed4 amd64 3.2-1ubuntu0.16.04.1 [136 kB]
Get:89 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libnettle6 amd64 3.2-1ubuntu0.16.04.1 [93.5 kB]
Get:90 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libidn11 amd64 1.32-3ubuntu1.2 [46.5 kB]
Get:91 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libp11-kit0 amd64 0.23.2-5~ubuntu16.04.1 [105 kB]
Get:92 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libtasn1-6 amd64 4.7-3ubuntu0.16.04.3 [43.5 kB]
Get:93 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libgnutls-openssl27 amd64 3.4.10-4ubuntu1.4 [22.0 kB]
Get:94 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libgnutls30 amd64 3.4.10-4ubuntu1.4 [548 kB]
Get:95 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libslang2 amd64 2.3.0-2ubuntu1.1 [415 kB]
Get:96 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 logrotate amd64 3.8.7-2ubuntu2.16.04.2 [37.7 kB]
Get:97 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 lsb-release all 9.20160110ubuntu0.2 [11.8 kB]
Get:98 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 resolvconf all 1.78ubuntu6 [51.8 kB]
Get:99 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 rsyslog amd64 8.16.0-1ubuntu3.1 [366 kB]
Get:100 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 sudo amd64 1.8.16-0ubuntu1.5 [390 kB]
Get:101 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ureadahead amd64 0.100.0-19.1 [19.4 kB]
Get:102 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 vim-tiny amd64 2:7.4.1689-3ubuntu1.2 [445 kB]
Get:103 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 vim-common amd64 2:7.4.1689-3ubuntu1.2 [103 kB]

Extracting templates from packages: 29%
Extracting templates from packages: 58%
Extracting templates from packages: 87%
Extracting templates from packages: 100%
Preconfiguring packages ...
Fetched 38.4 MB in 1s (21.0 MB/s)
E: Can not write log (Is /dev/pts mounted?) - posix_openpt (19: No such device)
(Reading database ... 10444 files and directories currently installed.)
Preparing to unpack .../base-files_9.4ubuntu4.8_amd64.deb ...
Unpacking base-files (9.4ubuntu4.8) over (9.4ubuntu4) ...
Setting up base-files (9.4ubuntu4.8) ...
Installing new version of config file /etc/issue ...
Installing new version of config file /etc/issue.net ...
Installing new version of config file /etc/lsb-release ...
Installing new version of config file /etc/update-motd.d/10-help-text ...
(Reading database ... 10444 files and directories currently installed.)
Preparing to unpack .../bash_4.3-14ubuntu1.2_amd64.deb ...
Unpacking bash (4.3-14ubuntu1.2) over (4.3-14ubuntu1) ...
Setting up bash (4.3-14ubuntu1.2) ...
Installing new version of config file /etc/skel/.profile ...
update-alternatives: using /usr/share/man/man7/bash-builtins.7.gz to provide /usr/share/man/man7/builtins.7.gz (builtins.7.gz) in auto mode
(Reading database ... 10444 files and directories currently installed.)
Preparing to unpack .../bsdutils_1%3a2.27.1-6ubuntu3.6_amd64.deb ...
Unpacking bsdutils (1:2.27.1-6ubuntu3.6) over (1:2.27.1-6ubuntu3) ...
Setting up bsdutils (1:2.27.1-6ubuntu3.6) ...
(Reading database ... 10444 files and directories currently installed.)
Preparing to unpack .../coreutils_8.25-2ubuntu3~16.04_amd64.deb ...
Unpacking coreutils (8.25-2ubuntu3~16.04) over (8.25-2ubuntu2) ...
Setting up coreutils (8.25-2ubuntu3~16.04) ...
(Reading database ... 10444 files and directories currently installed.)
Preparing to unpack .../dpkg_1.18.4ubuntu1.5_amd64.deb ...
Unpacking dpkg (1.18.4ubuntu1.5) over (1.18.4ubuntu1) ...
Setting up dpkg (1.18.4ubuntu1.5) ...
(Reading database ... 10444 files and directories currently installed.)
Preparing to unpack .../grep_2.25-1~16.04.1_amd64.deb ...
Unpacking grep (2.25-1~16.04.1) over (2.24-1) ...
Setting up grep (2.25-1~16.04.1) ...
(Reading database ... 10444 files and directories currently installed.)
Preparing to unpack .../perl-base_5.22.1-9ubuntu0.6_amd64.deb ...
Unpacking perl-base (5.22.1-9ubuntu0.6) over (5.22.1-9) ...
Setting up perl-base (5.22.1-9ubuntu0.6) ...
(Reading database ... 10444 files and directories currently installed.)
Preparing to unpack .../init-system-helpers_1.29ubuntu4_all.deb ...
Unpacking init-system-helpers (1.29ubuntu4) over (1.29ubuntu1) ...
Setting up init-system-helpers (1.29ubuntu4) ...
(Reading database ... 10444 files and directories currently installed.)
Preparing to unpack .../init_1.29ubuntu4_amd64.deb ...
Unpacking init (1.29ubuntu4) over (1.29ubuntu1) ...
Setting up init (1.29ubuntu4) ...
(Reading database ... 10444 files and directories currently installed.)
Preparing to unpack .../login_1%3a4.2-3.1ubuntu5.4_amd64.deb ...
Unpacking login (1:4.2-3.1ubuntu5.4) over (1:4.2-3.1ubuntu5) ...
Setting up login (1:4.2-3.1ubuntu5.4) ...
(Reading database ... 10444 files and directories currently installed.)
Preparing to unpack .../libudev1_229-4ubuntu21.21_amd64.deb ...
Unpacking libudev1:amd64 (229-4ubuntu21.21) over (229-4ubuntu4) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
Setting up libudev1:amd64 (229-4ubuntu21.21) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
(Reading database ... 10444 files and directories currently installed.)
Preparing to unpack .../udev_229-4ubuntu21.21_amd64.deb ...
Unpacking udev (229-4ubuntu21.21) over (229-4ubuntu4) ...
Preparing to unpack .../ifupdown_0.8.10ubuntu1.4_amd64.deb ...
Unpacking ifupdown (0.8.10ubuntu1.4) over (0.8.10ubuntu1) ...
Preparing to unpack .../libsystemd0_229-4ubuntu21.21_amd64.deb ...
Unpacking libsystemd0:amd64 (229-4ubuntu21.21) over (229-4ubuntu4) ...
Processing triggers for ureadahead (0.100.0-19) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
Setting up libsystemd0:amd64 (229-4ubuntu21.21) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
(Reading database ... 10445 files and directories currently installed.)
Preparing to unpack .../systemd_229-4ubuntu21.21_amd64.deb ...
Unpacking systemd (229-4ubuntu21.21) over (229-4ubuntu4) ...
Processing triggers for ureadahead (0.100.0-19) ...
Setting up systemd (229-4ubuntu21.21) ...
Installing new version of config file /etc/systemd/system.conf ...
addgroup: The group `systemd-journal' already exists as a system group. Exiting.
(Reading database ... 10436 files and directories currently installed.)
Preparing to unpack .../libc6_2.23-0ubuntu11_amd64.deb ...
Unpacking libc6:amd64 (2.23-0ubuntu11) over (2.23-0ubuntu3) ...
Setting up libc6:amd64 (2.23-0ubuntu11) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
(Reading database ... 10436 files and directories currently installed.)
Preparing to unpack .../libaudit-common_1%3a2.4.5-1ubuntu2.1_all.deb ...
Unpacking libaudit-common (1:2.4.5-1ubuntu2.1) over (1:2.4.5-1ubuntu2) ...
Setting up libaudit-common (1:2.4.5-1ubuntu2.1) ...
(Reading database ... 10436 files and directories currently installed.)
Preparing to unpack .../libaudit1_1%3a2.4.5-1ubuntu2.1_amd64.deb ...
Unpacking libaudit1:amd64 (1:2.4.5-1ubuntu2.1) over (1:2.4.5-1ubuntu2) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
Setting up libaudit1:amd64 (1:2.4.5-1ubuntu2.1) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
(Reading database ... 10436 files and directories currently installed.)
Preparing to unpack .../libpam0g_1.1.8-3.2ubuntu2.1_amd64.deb ...
Unpacking libpam0g:amd64 (1.1.8-3.2ubuntu2.1) over (1.1.8-3.2ubuntu2) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
Setting up libpam0g:amd64 (1.1.8-3.2ubuntu2.1) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
(Reading database ... 10436 files and directories currently installed.)
Preparing to unpack .../libpam-modules-bin_1.1.8-3.2ubuntu2.1_amd64.deb ...
Unpacking libpam-modules-bin (1.1.8-3.2ubuntu2.1) over (1.1.8-3.2ubuntu2) ...
Setting up libpam-modules-bin (1.1.8-3.2ubuntu2.1) ...
(Reading database ... 10436 files and directories currently installed.)
Preparing to unpack .../libpam-modules_1.1.8-3.2ubuntu2.1_amd64.deb ...
Unpacking libpam-modules:amd64 (1.1.8-3.2ubuntu2.1) over (1.1.8-3.2ubuntu2) ...
Setting up libpam-modules:amd64 (1.1.8-3.2ubuntu2.1) ...
(Reading database ... 10436 files and directories currently installed.)
Preparing to unpack .../passwd_1%3a4.2-3.1ubuntu5.4_amd64.deb ...
Unpacking passwd (1:4.2-3.1ubuntu5.4) over (1:4.2-3.1ubuntu5) ...
Processing triggers for ureadahead (0.100.0-19) ...
Setting up passwd (1:4.2-3.1ubuntu5.4) ...
(Reading database ... 10436 files and directories currently installed.)
Preparing to unpack .../libuuid1_2.27.1-6ubuntu3.6_amd64.deb ...
Unpacking libuuid1:amd64 (2.27.1-6ubuntu3.6) over (2.27.1-6ubuntu3) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
Setting up libuuid1:amd64 (2.27.1-6ubuntu3.6) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
(Reading database ... 10436 files and directories currently installed.)
Preparing to unpack .../libblkid1_2.27.1-6ubuntu3.6_amd64.deb ...
Unpacking libblkid1:amd64 (2.27.1-6ubuntu3.6) over (2.27.1-6ubuntu3) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
Setting up libblkid1:amd64 (2.27.1-6ubuntu3.6) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
(Reading database ... 10436 files and directories currently installed.)
Preparing to unpack .../kmod_22-1ubuntu5.2_amd64.deb ...
Unpacking kmod (22-1ubuntu5.2) over (22-1ubuntu4) ...
Preparing to unpack .../libkmod2_22-1ubuntu5.2_amd64.deb ...
Unpacking libkmod2:amd64 (22-1ubuntu5.2) over (22-1ubuntu4) ...
Processing triggers for ureadahead (0.100.0-19) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
Setting up libkmod2:amd64 (22-1ubuntu5.2) ...
Processing triggers for systemd (229-4ubuntu21.21) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
(Reading database ... 10436 files and directories currently installed.)
Preparing to unpack .../libprocps4_2%3a3.3.10-4ubuntu2.4_amd64.deb ...
Unpacking libprocps4:amd64 (2:3.3.10-4ubuntu2.4) over (2:3.3.10-4ubuntu2) ...
Preparing to unpack .../procps_2%3a3.3.10-4ubuntu2.4_amd64.deb ...
Running in chroot, ignoring request.
Unpacking procps (2:3.3.10-4ubuntu2.4) over (2:3.3.10-4ubuntu2) ...
Preparing to unpack .../libdb5.3_5.3.28-11ubuntu0.1_amd64.deb ...
Unpacking libdb5.3:amd64 (5.3.28-11ubuntu0.1) over (5.3.28-11) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
Processing triggers for ureadahead (0.100.0-19) ...
Processing triggers for systemd (229-4ubuntu21.21) ...
Setting up libdb5.3:amd64 (5.3.28-11ubuntu0.1) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
(Reading database ... 10436 files and directories currently installed.)
Preparing to unpack .../iproute2_4.3.0-1ubuntu3.16.04.5_amd64.deb ...
Unpacking iproute2 (4.3.0-1ubuntu3.16.04.5) over (4.3.0-1ubuntu3) ...
Preparing to unpack .../libapparmor1_2.10.95-0ubuntu2.10_amd64.deb ...
Unpacking libapparmor1:amd64 (2.10.95-0ubuntu2.10) over (2.10.95-0ubuntu2) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
Setting up libapparmor1:amd64 (2.10.95-0ubuntu2.10) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
(Reading database ... 10436 files and directories currently installed.)
Preparing to unpack .../libgcrypt20_1.6.5-2ubuntu0.5_amd64.deb ...
Unpacking libgcrypt20:amd64 (1.6.5-2ubuntu0.5) over (1.6.5-2) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
Setting up libgcrypt20:amd64 (1.6.5-2ubuntu0.5) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
(Reading database ... 10436 files and directories currently installed.)
Preparing to unpack .../libcryptsetup4_2%3a1.6.6-5ubuntu2.1_amd64.deb ...
Unpacking libcryptsetup4:amd64 (2:1.6.6-5ubuntu2.1) over (2:1.6.6-5ubuntu2) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
Setting up libcryptsetup4:amd64 (2:1.6.6-5ubuntu2.1) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
(Reading database ... 10436 files and directories currently installed.)
Preparing to unpack .../libmount1_2.27.1-6ubuntu3.6_amd64.deb ...
Unpacking libmount1:amd64 (2.27.1-6ubuntu3.6) over (2.27.1-6ubuntu3) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
Setting up libmount1:amd64 (2.27.1-6ubuntu3.6) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
(Reading database ... 10436 files and directories currently installed.)
Preparing to unpack .../libseccomp2_2.3.1-2.1ubuntu2~16.04.1_amd64.deb ...
Unpacking libseccomp2:amd64 (2.3.1-2.1ubuntu2~16.04.1) over (2.2.3-3ubuntu3) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
Setting up libseccomp2:amd64 (2.3.1-2.1ubuntu2~16.04.1) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
(Reading database ... 10436 files and directories currently installed.)
Preparing to unpack .../kbd_1.15.5-1ubuntu5_amd64.deb ...
Unpacking kbd (1.15.5-1ubuntu5) over (1.15.5-1ubuntu4) ...
Preparing to unpack .../console-setup-linux_1.108ubuntu15.5_all.deb ...
Unpacking console-setup-linux (1.108ubuntu15.5) over (1.108ubuntu15) ...
Preparing to unpack .../klibc-utils_2.0.4-8ubuntu1.16.04.4_amd64.deb ...
Unpacking klibc-utils (2.0.4-8ubuntu1.16.04.4) over (2.0.4-8ubuntu1) ...
Preparing to unpack .../initramfs-tools-core_0.122ubuntu8.14_all.deb ...
Unpacking initramfs-tools-core (0.122ubuntu8.14) over (0.122ubuntu8) ...
Preparing to unpack .../initramfs-tools_0.122ubuntu8.14_all.deb ...
Unpacking initramfs-tools (0.122ubuntu8.14) over (0.122ubuntu8) ...
Preparing to unpack .../console-setup_1.108ubuntu15.5_all.deb ...
Unpacking console-setup (1.108ubuntu15.5) over (1.108ubuntu15) ...
Preparing to unpack .../keyboard-configuration_1.108ubuntu15.5_all.deb ...
Unpacking keyboard-configuration (1.108ubuntu15.5) over (1.108ubuntu15) ...
Preparing to unpack .../initramfs-tools-bin_0.122ubuntu8.14_amd64.deb ...
Unpacking initramfs-tools-bin (0.122ubuntu8.14) over (0.122ubuntu8) ...
Preparing to unpack .../busybox-initramfs_1%3a1.22.0-15ubuntu1.4_amd64.deb ...
Unpacking busybox-initramfs (1:1.22.0-15ubuntu1.4) over (1:1.22.0-15ubuntu1) ...
Preparing to unpack .../libklibc_2.0.4-8ubuntu1.16.04.4_amd64.deb ...
Unpacking libklibc (2.0.4-8ubuntu1.16.04.4) over (2.0.4-8ubuntu1) ...
Preparing to unpack .../linux-base_4.5ubuntu1~16.04.1_all.deb ...
Unpacking linux-base (4.5ubuntu1~16.04.1) over (4.0ubuntu1) ...
Preparing to unpack .../lsb-base_9.20160110ubuntu0.2_all.deb ...
Unpacking lsb-base (9.20160110ubuntu0.2) over (9.20160110) ...
Processing triggers for ureadahead (0.100.0-19) ...
Processing triggers for systemd (229-4ubuntu21.21) ...
Setting up lsb-base (9.20160110ubuntu0.2) ...
(Reading database ... 10446 files and directories currently installed.)
Preparing to unpack .../util-linux_2.27.1-6ubuntu3.6_amd64.deb ...
Unpacking util-linux (2.27.1-6ubuntu3.6) over (2.27.1-6ubuntu3) ...
Processing triggers for mime-support (3.59ubuntu1) ...
Processing triggers for ureadahead (0.100.0-19) ...
Setting up util-linux (2.27.1-6ubuntu3.6) ...
Processing triggers for systemd (229-4ubuntu21.21) ...
(Reading database ... 10446 files and directories currently installed.)
Preparing to unpack .../mount_2.27.1-6ubuntu3.6_amd64.deb ...
Unpacking mount (2.27.1-6ubuntu3.6) over (2.27.1-6ubuntu3) ...
Setting up mount (2.27.1-6ubuntu3.6) ...
(Reading database ... 10446 files and directories currently installed.)
Preparing to unpack .../tar_1.28-2.1ubuntu0.1_amd64.deb ...
Unpacking tar (1.28-2.1ubuntu0.1) over (1.28-2.1) ...
Processing triggers for mime-support (3.59ubuntu1) ...
Setting up tar (1.28-2.1ubuntu0.1) ...
(Reading database ... 10446 files and directories currently installed.)
Preparing to unpack .../locales_2.23-0ubuntu11_all.deb ...
Unpacking locales (2.23-0ubuntu11) over (2.23-0ubuntu3) ...
Preparing to unpack .../libc-bin_2.23-0ubuntu11_amd64.deb ...
Unpacking libc-bin (2.23-0ubuntu11) over (2.23-0ubuntu3) ...
Setting up libc-bin (2.23-0ubuntu11) ...
(Reading database ... 10446 files and directories currently installed.)
Preparing to unpack .../gcc-5-base_5.4.0-6ubuntu1~16.04.11_amd64.deb ...
Unpacking gcc-5-base:amd64 (5.4.0-6ubuntu1~16.04.11) over (5.3.1-14ubuntu2) ...
Setting up gcc-5-base:amd64 (5.4.0-6ubuntu1~16.04.11) ...
(Reading database ... 10446 files and directories currently installed.)
Preparing to unpack .../libstdc++6_5.4.0-6ubuntu1~16.04.11_amd64.deb ...
Unpacking libstdc++6:amd64 (5.4.0-6ubuntu1~16.04.11) over (5.3.1-14ubuntu2) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
Setting up libstdc++6:amd64 (5.4.0-6ubuntu1~16.04.11) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
(Reading database ... 10446 files and directories currently installed.)
Preparing to unpack .../zlib1g_1%3a1.2.8.dfsg-2ubuntu4.1_amd64.deb ...
Unpacking zlib1g:amd64 (1:1.2.8.dfsg-2ubuntu4.1) over (1:1.2.8.dfsg-2ubuntu4) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
Setting up zlib1g:amd64 (1:1.2.8.dfsg-2ubuntu4.1) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
(Reading database ... 10446 files and directories currently installed.)
Preparing to unpack .../libapt-pkg5.0_1.2.31_amd64.deb ...
Unpacking libapt-pkg5.0:amd64 (1.2.31) over (1.2.10ubuntu1) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
Setting up libapt-pkg5.0:amd64 (1.2.31) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
(Reading database ... 10446 files and directories currently installed.)
Preparing to unpack .../libapt-inst2.0_1.2.31_amd64.deb ...
Unpacking libapt-inst2.0:amd64 (1.2.31) over (1.2.10ubuntu1) ...
Preparing to unpack .../archives/apt_1.2.31_amd64.deb ...
Unpacking apt (1.2.31) over (1.2.10ubuntu1) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
Setting up apt (1.2.31) ...
Installing new version of config file /etc/apt/apt.conf.d/01autoremove ...
Installing new version of config file /etc/cron.daily/apt-compat ...
Installing new version of config file /etc/kernel/postinst.d/apt-auto-removal ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
(Reading database ... 10457 files and directories currently installed.)
Preparing to unpack .../apt-utils_1.2.31_amd64.deb ...
Unpacking apt-utils (1.2.31) over (1.2.10ubuntu1) ...
Preparing to unpack .../gpgv_1.4.20-1ubuntu3.3_amd64.deb ...
Unpacking gpgv (1.4.20-1ubuntu3.3) over (1.4.20-1ubuntu3) ...
Setting up gpgv (1.4.20-1ubuntu3.3) ...
(Reading database ... 10457 files and directories currently installed.)
Preparing to unpack .../gnupg_1.4.20-1ubuntu3.3_amd64.deb ...
Unpacking gnupg (1.4.20-1ubuntu3.3) over (1.4.20-1ubuntu3) ...
Setting up gnupg (1.4.20-1ubuntu3.3) ...
(Reading database ... 10457 files and directories currently installed.)
Preparing to unpack .../systemd-sysv_229-4ubuntu21.21_amd64.deb ...
Unpacking systemd-sysv (229-4ubuntu21.21) over (229-4ubuntu4) ...
Setting up systemd-sysv (229-4ubuntu21.21) ...
(Reading database ... 10457 files and directories currently installed.)
Preparing to unpack .../libssl1.0.0_1.0.2g-1ubuntu4.15_amd64.deb ...
Unpacking libssl1.0.0:amd64 (1.0.2g-1ubuntu4.15) over (1.0.2g-1ubuntu4) ...
Preparing to unpack .../python3.5_3.5.2-2ubuntu0~16.04.5_amd64.deb ...
Unpacking python3.5 (3.5.2-2ubuntu0~16.04.5) over (3.5.1-10) ...
Preparing to unpack .../libpython3.5-stdlib_3.5.2-2ubuntu0~16.04.5_amd64.deb ...
Unpacking libpython3.5-stdlib:amd64 (3.5.2-2ubuntu0~16.04.5) over (3.5.1-10) ...
Preparing to unpack .../python3.5-minimal_3.5.2-2ubuntu0~16.04.5_amd64.deb ...
Unpacking python3.5-minimal (3.5.2-2ubuntu0~16.04.5) over (3.5.1-10) ...
Preparing to unpack .../libpython3.5-minimal_3.5.2-2ubuntu0~16.04.5_amd64.deb ...
Unpacking libpython3.5-minimal:amd64 (3.5.2-2ubuntu0~16.04.5) over (3.5.1-10) ...
Preparing to unpack .../libsqlite3-0_3.11.0-1ubuntu1.1_amd64.deb ...
Unpacking libsqlite3-0:amd64 (3.11.0-1ubuntu1.1) over (3.11.0-1ubuntu1) ...
Preparing to unpack .../libexpat1_2.1.0-7ubuntu0.16.04.3_amd64.deb ...
Unpacking libexpat1:amd64 (2.1.0-7ubuntu0.16.04.3) over (2.1.0-7) ...
Preparing to unpack .../libfdisk1_2.27.1-6ubuntu3.6_amd64.deb ...
Unpacking libfdisk1:amd64 (2.27.1-6ubuntu3.6) over (2.27.1-6ubuntu3) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
Processing triggers for mime-support (3.59ubuntu1) ...
Setting up libfdisk1:amd64 (2.27.1-6ubuntu3.6) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
(Reading database ... 10457 files and directories currently installed.)
Preparing to unpack .../libpam-runtime_1.1.8-3.2ubuntu2.1_all.deb ...
Unpacking libpam-runtime (1.1.8-3.2ubuntu2.1) over (1.1.8-3.2ubuntu2) ...
Setting up libpam-runtime (1.1.8-3.2ubuntu2.1) ...
(Reading database ... 10457 files and directories currently installed.)
Preparing to unpack .../libsmartcols1_2.27.1-6ubuntu3.6_amd64.deb ...
Unpacking libsmartcols1:amd64 (2.27.1-6ubuntu3.6) over (2.27.1-6ubuntu3) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
Setting up libsmartcols1:amd64 (2.27.1-6ubuntu3.6) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
(Reading database ... 10457 files and directories currently installed.)
Preparing to unpack .../multiarch-support_2.23-0ubuntu11_amd64.deb ...
Unpacking multiarch-support (2.23-0ubuntu11) over (2.23-0ubuntu3) ...
Setting up multiarch-support (2.23-0ubuntu11) ...
(Reading database ... 10457 files and directories currently installed.)
Preparing to unpack .../sensible-utils_0.0.9ubuntu0.16.04.1_all.deb ...
Unpacking sensible-utils (0.0.9ubuntu0.16.04.1) over (0.0.9) ...
Processing triggers for mime-support (3.59ubuntu1) ...
Setting up sensible-utils (0.0.9ubuntu0.16.04.1) ...
(Reading database ... 10457 files and directories currently installed.)
Preparing to unpack .../makedev_2.3.1-93ubuntu2~ubuntu16.04.1_all.deb ...
Unpacking makedev (2.3.1-93ubuntu2~ubuntu16.04.1) over (2.3.1-93ubuntu1) ...
Preparing to unpack .../tzdata_2019a-0ubuntu0.16.04_all.deb ...
Unpacking tzdata (2019a-0ubuntu0.16.04) over (2016d-0ubuntu0.16.04) ...
Preparing to unpack .../dh-python_2.20151103ubuntu1.1_all.deb ...
Unpacking dh-python (2.20151103ubuntu1.1) over (2.20151103ubuntu1) ...
Preparing to unpack .../distro-info-data_0.28ubuntu0.11_all.deb ...
Unpacking distro-info-data (0.28ubuntu0.11) over (0.28) ...
Preparing to unpack .../eject_2.1.5+deb1+cvs20081104-13.1ubuntu0.16.04.1_amd64.deb ...
Unpacking eject (2.1.5+deb1+cvs20081104-13.1ubuntu0.16.04.1) over (2.1.5+deb1+cvs20081104-13.1) ...
Preparing to unpack .../file_1%3a5.25-2ubuntu1.2_amd64.deb ...
Unpacking file (1:5.25-2ubuntu1.2) over (1:5.25-2ubuntu1) ...
Preparing to unpack .../libmagic1_1%3a5.25-2ubuntu1.2_amd64.deb ...
Unpacking libmagic1:amd64 (1:5.25-2ubuntu1.2) over (1:5.25-2ubuntu1) ...
Preparing to unpack .../libisc-export160_1%3a9.10.3.dfsg.P4-8ubuntu1.14_amd64.deb ...
Unpacking libisc-export160 (1:9.10.3.dfsg.P4-8ubuntu1.14) over (1:9.10.3.dfsg.P4-8) ...
Preparing to unpack .../libdns-export162_1%3a9.10.3.dfsg.P4-8ubuntu1.14_amd64.deb ...
Unpacking libdns-export162 (1:9.10.3.dfsg.P4-8ubuntu1.14) over (1:9.10.3.dfsg.P4-8) ...
Preparing to unpack .../isc-dhcp-client_4.3.3-5ubuntu12.10_amd64.deb ...
Unpacking isc-dhcp-client (4.3.3-5ubuntu12.10) over (4.3.3-5ubuntu12) ...
Preparing to unpack .../isc-dhcp-common_4.3.3-5ubuntu12.10_amd64.deb ...
Unpacking isc-dhcp-common (4.3.3-5ubuntu12.10) over (4.3.3-5ubuntu12) ...
Preparing to unpack .../less_481-2.1ubuntu0.2_amd64.deb ...
Unpacking less (481-2.1ubuntu0.2) over (481-2.1) ...
Preparing to unpack .../libhogweed4_3.2-1ubuntu0.16.04.1_amd64.deb ...
Unpacking libhogweed4:amd64 (3.2-1ubuntu0.16.04.1) over (3.2-1) ...
Preparing to unpack .../libnettle6_3.2-1ubuntu0.16.04.1_amd64.deb ...
Unpacking libnettle6:amd64 (3.2-1ubuntu0.16.04.1) over (3.2-1) ...
Preparing to unpack .../libidn11_1.32-3ubuntu1.2_amd64.deb ...
Unpacking libidn11:amd64 (1.32-3ubuntu1.2) over (1.32-3ubuntu1) ...
Preparing to unpack .../libp11-kit0_0.23.2-5~ubuntu16.04.1_amd64.deb ...
Unpacking libp11-kit0:amd64 (0.23.2-5~ubuntu16.04.1) over (0.23.2-3) ...
Preparing to unpack .../libtasn1-6_4.7-3ubuntu0.16.04.3_amd64.deb ...
Unpacking libtasn1-6:amd64 (4.7-3ubuntu0.16.04.3) over (4.7-3) ...
Preparing to unpack .../libgnutls-openssl27_3.4.10-4ubuntu1.4_amd64.deb ...
Unpacking libgnutls-openssl27:amd64 (3.4.10-4ubuntu1.4) over (3.4.10-4ubuntu1) ...
Preparing to unpack .../libgnutls30_3.4.10-4ubuntu1.4_amd64.deb ...
Unpacking libgnutls30:amd64 (3.4.10-4ubuntu1.4) over (3.4.10-4ubuntu1) ...
Preparing to unpack .../libpng12-0_1.2.54-1ubuntu1.1_amd64.deb ...
Unpacking libpng12-0:amd64 (1.2.54-1ubuntu1.1) over (1.2.54-1ubuntu1) ...
Preparing to unpack .../libslang2_2.3.0-2ubuntu1.1_amd64.deb ...
Unpacking libslang2:amd64 (2.3.0-2ubuntu1.1) over (2.3.0-2ubuntu1) ...
Preparing to unpack .../logrotate_3.8.7-2ubuntu2.16.04.2_amd64.deb ...
Unpacking logrotate (3.8.7-2ubuntu2.16.04.2) over (3.8.7-2ubuntu2) ...
Preparing to unpack .../lsb-release_9.20160110ubuntu0.2_all.deb ...
Unpacking lsb-release (9.20160110ubuntu0.2) over (9.20160110) ...
Preparing to unpack .../resolvconf_1.78ubuntu6_all.deb ...
Unpacking resolvconf (1.78ubuntu6) over (1.78ubuntu2) ...
Preparing to unpack .../rsyslog_8.16.0-1ubuntu3.1_amd64.deb ...
Unpacking rsyslog (8.16.0-1ubuntu3.1) over (8.16.0-1ubuntu3) ...
Preparing to unpack .../sudo_1.8.16-0ubuntu1.5_amd64.deb ...
Unpacking sudo (1.8.16-0ubuntu1.5) over (1.8.16-0ubuntu1) ...
Preparing to unpack .../ureadahead_0.100.0-19.1_amd64.deb ...
Unpacking ureadahead (0.100.0-19.1) over (0.100.0-19) ...
Preparing to unpack .../vim-tiny_2%3a7.4.1689-3ubuntu1.2_amd64.deb ...
Unpacking vim-tiny (2:7.4.1689-3ubuntu1.2) over (2:7.4.1689-3ubuntu1) ...
Preparing to unpack .../vim-common_2%3a7.4.1689-3ubuntu1.2_amd64.deb ...
Unpacking vim-common (2:7.4.1689-3ubuntu1.2) over (2:7.4.1689-3ubuntu1) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
Processing triggers for mime-support (3.59ubuntu1) ...
Processing triggers for systemd (229-4ubuntu21.21) ...
Setting up libprocps4:amd64 (2:3.3.10-4ubuntu2.4) ...
Setting up procps (2:3.3.10-4ubuntu2.4) ...
update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
Setting up udev (229-4ubuntu21.21) ...
addgroup: The group `input' already exists as a system group. Exiting.
A chroot environment has been detected, udev not started.
update-initramfs: deferring update (trigger activated)
Setting up iproute2 (4.3.0-1ubuntu3.16.04.5) ...
Setting up ifupdown (0.8.10ubuntu1.4) ...
Setting up kmod (22-1ubuntu5.2) ...
Installing new version of config file /etc/modprobe.d/blacklist.conf ...
Setting up keyboard-configuration (1.108ubuntu15.5) ...
update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
update-initramfs: deferring update (trigger activated)
Setting up libklibc (2.0.4-8ubuntu1.16.04.4) ...
Setting up klibc-utils (2.0.4-8ubuntu1.16.04.4) ...
Setting up initramfs-tools-bin (0.122ubuntu8.14) ...
Setting up busybox-initramfs (1:1.22.0-15ubuntu1.4) ...
Setting up initramfs-tools-core (0.122ubuntu8.14) ...
Setting up linux-base (4.5ubuntu1~16.04.1) ...
Setting up initramfs-tools (0.122ubuntu8.14) ...
update-initramfs: deferring update (trigger activated)
Setting up locales (2.23-0ubuntu11) ...
Generating locales (this might take a while)...
Generation complete.
Setting up libapt-inst2.0:amd64 (1.2.31) ...
Setting up apt-utils (1.2.31) ...
Setting up libssl1.0.0:amd64 (1.0.2g-1ubuntu4.15) ...
Setting up libpython3.5-minimal:amd64 (3.5.2-2ubuntu0~16.04.5) ...
Setting up libexpat1:amd64 (2.1.0-7ubuntu0.16.04.3) ...
Setting up python3.5-minimal (3.5.2-2ubuntu0~16.04.5) ...
Setting up libsqlite3-0:amd64 (3.11.0-1ubuntu1.1) ...
Setting up libpython3.5-stdlib:amd64 (3.5.2-2ubuntu0~16.04.5) ...
Setting up python3.5 (3.5.2-2ubuntu0~16.04.5) ...
Setting up makedev (2.3.1-93ubuntu2~ubuntu16.04.1) ...
Setting up tzdata (2019a-0ubuntu0.16.04) ...
Current default time zone: 'Etc/UTC'
Local time is now:      Tue May 21 08:44:02 UTC 2019.
Universal Time is now:  Tue May 21 08:44:02 UTC 2019.
Run 'dpkg-reconfigure tzdata' if you wish to change it.
Setting up dh-python (2.20151103ubuntu1.1) ...
Setting up distro-info-data (0.28ubuntu0.11) ...
Setting up eject (2.1.5+deb1+cvs20081104-13.1ubuntu0.16.04.1) ...
Setting up libmagic1:amd64 (1:5.25-2ubuntu1.2) ...
Setting up file (1:5.25-2ubuntu1.2) ...
Setting up libisc-export160 (1:9.10.3.dfsg.P4-8ubuntu1.14) ...
Setting up libdns-export162 (1:9.10.3.dfsg.P4-8ubuntu1.14) ...
Setting up isc-dhcp-client (4.3.3-5ubuntu12.10) ...
Setting up isc-dhcp-common (4.3.3-5ubuntu12.10) ...
Setting up less (481-2.1ubuntu0.2) ...
Setting up libnettle6:amd64 (3.2-1ubuntu0.16.04.1) ...
Setting up libhogweed4:amd64 (3.2-1ubuntu0.16.04.1) ...
Setting up libidn11:amd64 (1.32-3ubuntu1.2) ...
Setting up libp11-kit0:amd64 (0.23.2-5~ubuntu16.04.1) ...
Setting up libtasn1-6:amd64 (4.7-3ubuntu0.16.04.3) ...
Setting up libgnutls30:amd64 (3.4.10-4ubuntu1.4) ...
Setting up libgnutls-openssl27:amd64 (3.4.10-4ubuntu1.4) ...
Setting up libpng12-0:amd64 (1.2.54-1ubuntu1.1) ...
Setting up libslang2:amd64 (2.3.0-2ubuntu1.1) ...
Setting up logrotate (3.8.7-2ubuntu2.16.04.2) ...
Setting up lsb-release (9.20160110ubuntu0.2) ...
Setting up resolvconf (1.78ubuntu6) ...
Setting up rsyslog (8.16.0-1ubuntu3.1) ...
Installing new version of config file /etc/logrotate.d/rsyslog ...
The user `syslog' is already a member of `adm'.
Running in chroot, ignoring request.
Setting up sudo (1.8.16-0ubuntu1.5) ...
Installing new version of config file /etc/sudoers ...
Setting up ureadahead (0.100.0-19.1) ...
Setting up vim-common (2:7.4.1689-3ubuntu1.2) ...
Setting up vim-tiny (2:7.4.1689-3ubuntu1.2) ...
Setting up kbd (1.15.5-1ubuntu5) ...
Setting up console-setup-linux (1.108ubuntu15.5) ...
Installing new version of config file /etc/console-setup/compose.ISO-8859-1.inc ...
Installing new version of config file /etc/console-setup/compose.ISO-8859-13.inc ...
Installing new version of config file /etc/console-setup/compose.ISO-8859-14.inc ...
Installing new version of config file /etc/console-setup/compose.ISO-8859-15.inc ...
Installing new version of config file /etc/console-setup/compose.ISO-8859-2.inc ...
Installing new version of config file /etc/console-setup/compose.ISO-8859-3.inc ...
Installing new version of config file /etc/console-setup/compose.ISO-8859-4.inc ...
Installing new version of config file /etc/console-setup/compose.ISO-8859-7.inc ...
Installing new version of config file /etc/console-setup/compose.ISO-8859-9.inc ...
Setting up console-setup (1.108ubuntu15.5) ...
update-initramfs: deferring update (trigger activated)
Processing triggers for libc-bin (2.23-0ubuntu11) ...
Processing triggers for systemd (229-4ubuntu21.21) ...
Processing triggers for initramfs-tools (0.122ubuntu8.14) ...
Processing triggers for resolvconf (1.78ubuntu6) ...
bash
nfs-common
openssl
isc-dhcp-client
libc-bin
linux-image-generic
openssh-server
openssh-client
wget
ntp
ntpdate
rsync
busybox-static
gawk
dnsutils
tar
gzip
xz-utils
 DEBIAN_FRONTEND=noninteractive chroot /install/netboot/ubuntu16.04.5/x86_64/compute/rootimg apt-get -y  install bash nfs-common openssl isc-dhcp-client libc-bin openssh-server openssh-client wget ntp ntpdate rsync busybox-static gawk dnsutils tar gzip xz-utils
Reading package lists...
Building dependency tree...
Reading state information...
tar is already the newest version (1.28-2.1ubuntu0.1).
gzip is already the newest version (1.6-4ubuntu1).
bash is already the newest version (4.3-14ubuntu1.2).
isc-dhcp-client is already the newest version (4.3.3-5ubuntu12.10).
libc-bin is already the newest version (2.23-0ubuntu11).
The following additional packages will be installed:
  bind9-host ca-certificates geoip-database keyutils krb5-locales
  libasn1-8-heimdal libbind9-140 libdns162 libedit2 libevent-2.0-5 libgdbm3
  libgeoip1 libgssapi-krb5-2 libgssapi3-heimdal libhcrypto4-heimdal
  libheimbase1-heimdal libheimntlm0-heimdal libhx509-5-heimdal libicu55
  libisc160 libisccc140 libisccfg140 libk5crypto3 libkeyutils1
  libkrb5-26-heimdal libkrb5-3 libkrb5support0 libldap-2.4-2 liblwres141
  libmpfr4 libnfsidmap2 libopts25 libperl5.22 libpython-stdlib
  libpython2.7-minimal libpython2.7-stdlib libroken18-heimdal libsasl2-2
  libsasl2-modules libsasl2-modules-db libsigsegv2 libtirpc1 libwind0-heimdal
  libwrap0 libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxext6 libxml2
  libxmuu1 ncurses-term openssh-sftp-server perl perl-modules-5.22 python
  python-minimal python2.7 python2.7-minimal python3-chardet
  python3-pkg-resources python3-requests python3-six python3-urllib3 rename
  rpcbind sgml-base ssh-import-id tcpd xauth xml-core
Suggested packages:
  rblcheck gawk-doc geoip-bin krb5-doc krb5-user libsasl2-modules-otp
  libsasl2-modules-ldap libsasl2-modules-sql libsasl2-modules-gssapi-mit
  | libsasl2-modules-gssapi-heimdal open-iscsi watchdog ntp-doc apparmor
  ssh-askpass libpam-ssh keychain monkeysphere rssh molly-guard ufw perl-doc
  libterm-readline-gnu-perl | libterm-readline-perl-perl make python-doc
  python-tk python2.7-doc binutils binfmt-support python3-setuptools
  python3-ndg-httpsclient python3-openssl python3-pyasn1 sgml-base-doc
  debhelper
The following NEW packages will be installed:
  bind9-host busybox-static ca-certificates dnsutils gawk geoip-database
  keyutils krb5-locales libasn1-8-heimdal libbind9-140 libdns162 libedit2
  libevent-2.0-5 libgdbm3 libgeoip1 libgssapi-krb5-2 libgssapi3-heimdal
  libhcrypto4-heimdal libheimbase1-heimdal libheimntlm0-heimdal
  libhx509-5-heimdal libicu55 libisc160 libisccc140 libisccfg140 libk5crypto3
  libkeyutils1 libkrb5-26-heimdal libkrb5-3 libkrb5support0 libldap-2.4-2
  liblwres141 libmpfr4 libnfsidmap2 libopts25 libperl5.22 libpython-stdlib
  libpython2.7-minimal libpython2.7-stdlib libroken18-heimdal libsasl2-2
  libsasl2-modules libsasl2-modules-db libsigsegv2 libtirpc1 libwind0-heimdal
  libwrap0 libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxext6 libxml2
  libxmuu1 ncurses-term nfs-common ntp ntpdate openssh-client openssh-server
  openssh-sftp-server openssl perl perl-modules-5.22 python python-minimal
  python2.7 python2.7-minimal python3-chardet python3-pkg-resources
  python3-requests python3-six python3-urllib3 rename rpcbind rsync sgml-base
  ssh-import-id tcpd wget xauth xml-core xz-utils
0 upgraded, 84 newly installed, 0 to remove and 1 not upgraded.
Need to get 29.7 MB of archives.
After this operation, 136 MB of additional disk space will be used.
Get:1 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libgdbm3 amd64 1.8.3-13.1 [16.9 kB]
Get:2 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libxau6 amd64 1:1.0.8-1 [8376 B]
Get:3 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libxdmcp6 amd64 1:1.1.2-1.1 [11.0 kB]
Get:4 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libxcb1 amd64 1.11.1-1ubuntu1 [40.0 kB]
Get:5 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libxext6 amd64 2:1.3.3-1 [29.4 kB]
Get:6 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 sgml-base all 1.26+nmu4ubuntu1 [12.5 kB]
Get:7 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libmpfr4 amd64 3.1.4-1 [191 kB]
Get:8 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libsigsegv2 amd64 2.10-4 [14.1 kB]
Get:9 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 gawk amd64 1:4.1.3+dfsg-0.1 [398 kB]
Get:10 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libroken18-heimdal amd64 1.7~git20150920+dfsg-4ubuntu1.16.04.1 [41.4 kB]
Get:11 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libasn1-8-heimdal amd64 1.7~git20150920+dfsg-4ubuntu1.16.04.1 [174 kB]
Get:12 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libhcrypto4-heimdal amd64 1.7~git20150920+dfsg-4ubuntu1.16.04.1 [85.0 kB]
Get:13 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libheimbase1-heimdal amd64 1.7~git20150920+dfsg-4ubuntu1.16.04.1 [29.3 kB]
Get:14 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libwind0-heimdal amd64 1.7~git20150920+dfsg-4ubuntu1.16.04.1 [47.8 kB]
Get:15 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libhx509-5-heimdal amd64 1.7~git20150920+dfsg-4ubuntu1.16.04.1 [107 kB]
Get:16 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libkrb5-26-heimdal amd64 1.7~git20150920+dfsg-4ubuntu1.16.04.1 [202 kB]
Get:17 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libx11-data all 2:1.6.3-1ubuntu2.1 [113 kB]
Get:18 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libheimntlm0-heimdal amd64 1.7~git20150920+dfsg-4ubuntu1.16.04.1 [15.1 kB]
Get:19 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libgssapi3-heimdal amd64 1.7~git20150920+dfsg-4ubuntu1.16.04.1 [96.1 kB]
Get:20 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libnfsidmap2 amd64 0.25-5 [32.2 kB]
Get:21 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libwrap0 amd64 7.6.q-25 [46.2 kB]
Get:22 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libedit2 amd64 3.1-20150325-1ubuntu2 [76.5 kB]
Get:23 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libopts25 amd64 1:5.18.7-3 [57.8 kB]
Get:24 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 ntp amd64 1:4.2.8p4+dfsg-3ubuntu5.9 [519 kB]
Get:25 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libx11-6 amd64 2:1.6.3-1ubuntu2.1 [570 kB]
Get:26 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 ntpdate amd64 1:4.2.8p4+dfsg-3ubuntu5.9 [48.6 kB]
Get:27 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 python-minimal amd64 2.7.12-1~16.04 [28.1 kB]
Get:28 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libpython-stdlib amd64 2.7.12-1~16.04 [7768 B]
Get:29 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 python amd64 2.7.12-1~16.04 [137 kB]
Get:30 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libgeoip1 amd64 1.6.9-1 [70.1 kB]
Get:31 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libkeyutils1 amd64 1.5.9-8ubuntu1 [9904 B]
Get:32 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libicu55 amd64 55.1-7ubuntu0.4 [7646 kB]
Get:33 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libsasl2-modules-db amd64 2.1.26.dfsg1-14ubuntu0.1 [14.5 kB]
Get:34 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libsasl2-2 amd64 2.1.26.dfsg1-14ubuntu0.1 [48.6 kB]
Get:35 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libldap-2.4-2 amd64 2.4.42+dfsg-2ubuntu3.5 [161 kB]
Get:36 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl-modules-5.22 all 5.22.1-9ubuntu0.6 [2629 kB]
Get:37 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 geoip-database all 20160408-1 [1678 kB]
Get:38 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libxmuu1 amd64 2:1.1.2-2 [9674 B]
Get:39 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 rsync amd64 3.1.1-3ubuntu1.2 [329 kB]
Get:40 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 xauth amd64 1:1.0.9-1ubuntu2 [22.7 kB]
Get:41 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 xml-core all 0.13+nmu2 [23.3 kB]
Get:42 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 keyutils amd64 1.5.9-8ubuntu1 [47.1 kB]
Get:43 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libevent-2.0-5 amd64 2.0.21-stable-2ubuntu0.16.04.1 [114 kB]
Get:44 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 ncurses-term all 6.0+20160213-1ubuntu1 [249 kB]
Get:45 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 rpcbind amd64 0.2.3-0.2 [40.3 kB]
Get:46 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 nfs-common amd64 1:1.2.8-9ubuntu12.1 [184 kB]
Get:47 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 python3-pkg-resources all 20.7.0-1 [79.0 kB]
Get:48 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 python3-chardet all 2.3.0-2 [96.2 kB]
Get:49 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 python3-six all 1.10.0-3 [11.0 kB]
Get:50 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 rename all 0.20-4 [12.0 kB]
Get:51 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 tcpd amd64 7.6.q-25 [23.0 kB]
Get:52 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 xz-utils amd64 5.1.1alpha+20120614-2ubuntu2 [78.8 kB]
Get:53 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libperl5.22 amd64 5.22.1-9ubuntu0.6 [3405 kB]
Get:54 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 ssh-import-id all 5.5-0ubuntu1 [10.2 kB]
Get:55 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 perl amd64 5.22.1-9ubuntu0.6 [237 kB]
Get:56 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libpython2.7-minimal amd64 2.7.12-1ubuntu0~16.04.4 [339 kB]
Get:57 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 python2.7-minimal amd64 2.7.12-1ubuntu0~16.04.4 [1261 kB]
Get:58 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libpython2.7-stdlib amd64 2.7.12-1ubuntu0~16.04.4 [1880 kB]
Get:59 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 python2.7 amd64 2.7.12-1ubuntu0~16.04.4 [224 kB]
Get:60 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libkrb5support0 amd64 1.13.2+dfsg-5ubuntu2.1 [31.2 kB]
Get:61 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libk5crypto3 amd64 1.13.2+dfsg-5ubuntu2.1 [81.3 kB]
Get:62 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libkrb5-3 amd64 1.13.2+dfsg-5ubuntu2.1 [273 kB]
Get:63 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libgssapi-krb5-2 amd64 1.13.2+dfsg-5ubuntu2.1 [120 kB]
Get:64 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libxml2 amd64 2.9.3+dfsg1-1ubuntu0.6 [697 kB]
Get:65 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libisc160 amd64 1:9.10.3.dfsg.P4-8ubuntu1.14 [216 kB]
Get:66 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libdns162 amd64 1:9.10.3.dfsg.P4-8ubuntu1.14 [880 kB]
Get:67 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libisccc140 amd64 1:9.10.3.dfsg.P4-8ubuntu1.14 [16.3 kB]
Get:68 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libisccfg140 amd64 1:9.10.3.dfsg.P4-8ubuntu1.14 [40.5 kB]
Get:69 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libbind9-140 amd64 1:9.10.3.dfsg.P4-8ubuntu1.14 [23.6 kB]
Get:70 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 liblwres141 amd64 1:9.10.3.dfsg.P4-8ubuntu1.14 [34.1 kB]
Get:71 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 bind9-host amd64 1:9.10.3.dfsg.P4-8ubuntu1.14 [38.4 kB]
Get:72 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 busybox-static amd64 1:1.22.0-15ubuntu1.4 [874 kB]
Get:73 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 openssl amd64 1.0.2g-1ubuntu4.15 [492 kB]
Get:74 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ca-certificates all 20170717~16.04.2 [167 kB]
Get:75 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 dnsutils amd64 1:9.10.3.dfsg.P4-8ubuntu1.14 [89.0 kB]
Get:76 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 krb5-locales all 1.13.2+dfsg-5ubuntu2.1 [13.6 kB]
Get:77 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libsasl2-modules amd64 2.1.26.dfsg1-14ubuntu0.1 [47.5 kB]
Get:78 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 openssh-client amd64 1:7.2p2-4ubuntu2.8 [590 kB]
Get:79 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 wget amd64 1.17.1-1ubuntu1.5 [299 kB]
Get:80 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libtirpc1 amd64 0.2.5-1ubuntu0.1 [75.4 kB]
Get:81 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 openssh-sftp-server amd64 1:7.2p2-4ubuntu2.8 [38.9 kB]
Get:82 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 openssh-server amd64 1:7.2p2-4ubuntu2.8 [335 kB]
Get:83 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 python3-urllib3 all 1.13.1-2ubuntu0.16.04.2 [58.1 kB]
Get:84 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 python3-requests all 2.9.1-3ubuntu0.1 [55.8 kB]

Extracting templates from packages: 35%
Extracting templates from packages: 71%
Extracting templates from packages: 100%
Preconfiguring packages ...
Fetched 29.7 MB in 1s (25.7 MB/s)
E: Can not write log (Is /dev/pts mounted?) - posix_openpt (19: No such device)
Selecting previously unselected package libgdbm3:amd64.
(Reading database ... 10481 files and directories currently installed.)
Preparing to unpack .../libgdbm3_1.8.3-13.1_amd64.deb ...
Unpacking libgdbm3:amd64 (1.8.3-13.1) ...
Selecting previously unselected package libxau6:amd64.
Preparing to unpack .../libxau6_1%3a1.0.8-1_amd64.deb ...
Unpacking libxau6:amd64 (1:1.0.8-1) ...
Selecting previously unselected package libxdmcp6:amd64.
Preparing to unpack .../libxdmcp6_1%3a1.1.2-1.1_amd64.deb ...
Unpacking libxdmcp6:amd64 (1:1.1.2-1.1) ...
Selecting previously unselected package libxcb1:amd64.
Preparing to unpack .../libxcb1_1.11.1-1ubuntu1_amd64.deb ...
Unpacking libxcb1:amd64 (1.11.1-1ubuntu1) ...
Selecting previously unselected package libx11-data.
Preparing to unpack .../libx11-data_2%3a1.6.3-1ubuntu2.1_all.deb ...
Unpacking libx11-data (2:1.6.3-1ubuntu2.1) ...
Selecting previously unselected package libx11-6:amd64.
Preparing to unpack .../libx11-6_2%3a1.6.3-1ubuntu2.1_amd64.deb ...
Unpacking libx11-6:amd64 (2:1.6.3-1ubuntu2.1) ...
Selecting previously unselected package libxext6:amd64.
Preparing to unpack .../libxext6_2%3a1.3.3-1_amd64.deb ...
Unpacking libxext6:amd64 (2:1.3.3-1) ...
Selecting previously unselected package sgml-base.
Preparing to unpack .../sgml-base_1.26+nmu4ubuntu1_all.deb ...
Unpacking sgml-base (1.26+nmu4ubuntu1) ...
Selecting previously unselected package libmpfr4:amd64.
Preparing to unpack .../libmpfr4_3.1.4-1_amd64.deb ...
Unpacking libmpfr4:amd64 (3.1.4-1) ...
Selecting previously unselected package libsigsegv2:amd64.
Preparing to unpack .../libsigsegv2_2.10-4_amd64.deb ...
Unpacking libsigsegv2:amd64 (2.10-4) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
Setting up libmpfr4:amd64 (3.1.4-1) ...
Setting up libsigsegv2:amd64 (2.10-4) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
Selecting previously unselected package gawk.
(Reading database ... 10819 files and directories currently installed.)
Preparing to unpack .../gawk_1%3a4.1.3+dfsg-0.1_amd64.deb ...
Unpacking gawk (1:4.1.3+dfsg-0.1) ...
Selecting previously unselected package libroken18-heimdal:amd64.
Preparing to unpack .../libroken18-heimdal_1.7~git20150920+dfsg-4ubuntu1.16.04.1_amd64.deb ...
Unpacking libroken18-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Selecting previously unselected package libasn1-8-heimdal:amd64.
Preparing to unpack .../libasn1-8-heimdal_1.7~git20150920+dfsg-4ubuntu1.16.04.1_amd64.deb ...
Unpacking libasn1-8-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Selecting previously unselected package libhcrypto4-heimdal:amd64.
Preparing to unpack .../libhcrypto4-heimdal_1.7~git20150920+dfsg-4ubuntu1.16.04.1_amd64.deb ...
Unpacking libhcrypto4-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Selecting previously unselected package libheimbase1-heimdal:amd64.
Preparing to unpack .../libheimbase1-heimdal_1.7~git20150920+dfsg-4ubuntu1.16.04.1_amd64.deb ...
Unpacking libheimbase1-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Selecting previously unselected package libwind0-heimdal:amd64.
Preparing to unpack .../libwind0-heimdal_1.7~git20150920+dfsg-4ubuntu1.16.04.1_amd64.deb ...
Unpacking libwind0-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Selecting previously unselected package libhx509-5-heimdal:amd64.
Preparing to unpack .../libhx509-5-heimdal_1.7~git20150920+dfsg-4ubuntu1.16.04.1_amd64.deb ...
Unpacking libhx509-5-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Selecting previously unselected package libkrb5-26-heimdal:amd64.
Preparing to unpack .../libkrb5-26-heimdal_1.7~git20150920+dfsg-4ubuntu1.16.04.1_amd64.deb ...
Unpacking libkrb5-26-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Selecting previously unselected package libheimntlm0-heimdal:amd64.
Preparing to unpack .../libheimntlm0-heimdal_1.7~git20150920+dfsg-4ubuntu1.16.04.1_amd64.deb ...
Unpacking libheimntlm0-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Selecting previously unselected package libgssapi3-heimdal:amd64.
Preparing to unpack .../libgssapi3-heimdal_1.7~git20150920+dfsg-4ubuntu1.16.04.1_amd64.deb ...
Unpacking libgssapi3-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Selecting previously unselected package libsasl2-modules-db:amd64.
Preparing to unpack .../libsasl2-modules-db_2.1.26.dfsg1-14ubuntu0.1_amd64.deb ...
Unpacking libsasl2-modules-db:amd64 (2.1.26.dfsg1-14ubuntu0.1) ...
Selecting previously unselected package libsasl2-2:amd64.
Preparing to unpack .../libsasl2-2_2.1.26.dfsg1-14ubuntu0.1_amd64.deb ...
Unpacking libsasl2-2:amd64 (2.1.26.dfsg1-14ubuntu0.1) ...
Selecting previously unselected package libldap-2.4-2:amd64.
Preparing to unpack .../libldap-2.4-2_2.4.42+dfsg-2ubuntu3.5_amd64.deb ...
Unpacking libldap-2.4-2:amd64 (2.4.42+dfsg-2ubuntu3.5) ...
Selecting previously unselected package libnfsidmap2:amd64.
Preparing to unpack .../libnfsidmap2_0.25-5_amd64.deb ...
Unpacking libnfsidmap2:amd64 (0.25-5) ...
Selecting previously unselected package libwrap0:amd64.
Preparing to unpack .../libwrap0_7.6.q-25_amd64.deb ...
Unpacking libwrap0:amd64 (7.6.q-25) ...
Selecting previously unselected package libedit2:amd64.
Preparing to unpack .../libedit2_3.1-20150325-1ubuntu2_amd64.deb ...
Unpacking libedit2:amd64 (3.1-20150325-1ubuntu2) ...
Selecting previously unselected package libopts25:amd64.
Preparing to unpack .../libopts25_1%3a5.18.7-3_amd64.deb ...
Unpacking libopts25:amd64 (1:5.18.7-3) ...
Selecting previously unselected package ntp.
Preparing to unpack .../ntp_1%3a4.2.8p4+dfsg-3ubuntu5.9_amd64.deb ...
Unpacking ntp (1:4.2.8p4+dfsg-3ubuntu5.9) ...
Selecting previously unselected package ntpdate.
Preparing to unpack .../ntpdate_1%3a4.2.8p4+dfsg-3ubuntu5.9_amd64.deb ...
Unpacking ntpdate (1:4.2.8p4+dfsg-3ubuntu5.9) ...
Selecting previously unselected package perl-modules-5.22.
Preparing to unpack .../perl-modules-5.22_5.22.1-9ubuntu0.6_all.deb ...
Unpacking perl-modules-5.22 (5.22.1-9ubuntu0.6) ...
Selecting previously unselected package libperl5.22:amd64.
Preparing to unpack .../libperl5.22_5.22.1-9ubuntu0.6_amd64.deb ...
Unpacking libperl5.22:amd64 (5.22.1-9ubuntu0.6) ...
Selecting previously unselected package perl.
Preparing to unpack .../perl_5.22.1-9ubuntu0.6_amd64.deb ...
Unpacking perl (5.22.1-9ubuntu0.6) ...
Selecting previously unselected package libpython2.7-minimal:amd64.
Preparing to unpack .../libpython2.7-minimal_2.7.12-1ubuntu0~16.04.4_amd64.deb ...
Unpacking libpython2.7-minimal:amd64 (2.7.12-1ubuntu0~16.04.4) ...
Selecting previously unselected package python2.7-minimal.
Preparing to unpack .../python2.7-minimal_2.7.12-1ubuntu0~16.04.4_amd64.deb ...
Unpacking python2.7-minimal (2.7.12-1ubuntu0~16.04.4) ...
Selecting previously unselected package python-minimal.
Preparing to unpack .../python-minimal_2.7.12-1~16.04_amd64.deb ...
Unpacking python-minimal (2.7.12-1~16.04) ...
Selecting previously unselected package libpython2.7-stdlib:amd64.
Preparing to unpack .../libpython2.7-stdlib_2.7.12-1ubuntu0~16.04.4_amd64.deb ...
Unpacking libpython2.7-stdlib:amd64 (2.7.12-1ubuntu0~16.04.4) ...
Selecting previously unselected package python2.7.
Preparing to unpack .../python2.7_2.7.12-1ubuntu0~16.04.4_amd64.deb ...
Unpacking python2.7 (2.7.12-1ubuntu0~16.04.4) ...
Selecting previously unselected package libpython-stdlib:amd64.
Preparing to unpack .../libpython-stdlib_2.7.12-1~16.04_amd64.deb ...
Unpacking libpython-stdlib:amd64 (2.7.12-1~16.04) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
Processing triggers for ureadahead (0.100.0-19.1) ...
Processing triggers for systemd (229-4ubuntu21.21) ...
Processing triggers for mime-support (3.59ubuntu1) ...
Setting up libpython2.7-minimal:amd64 (2.7.12-1ubuntu0~16.04.4) ...
Setting up python2.7-minimal (2.7.12-1ubuntu0~16.04.4) ...
Setting up python-minimal (2.7.12-1~16.04) ...
Selecting previously unselected package python.
(Reading database ... 13670 files and directories currently installed.)
Preparing to unpack .../python_2.7.12-1~16.04_amd64.deb ...
Unpacking python (2.7.12-1~16.04) ...
Selecting previously unselected package libgeoip1:amd64.
Preparing to unpack .../libgeoip1_1.6.9-1_amd64.deb ...
Unpacking libgeoip1:amd64 (1.6.9-1) ...
Selecting previously unselected package libkrb5support0:amd64.
Preparing to unpack .../libkrb5support0_1.13.2+dfsg-5ubuntu2.1_amd64.deb ...
Unpacking libkrb5support0:amd64 (1.13.2+dfsg-5ubuntu2.1) ...
Selecting previously unselected package libk5crypto3:amd64.
Preparing to unpack .../libk5crypto3_1.13.2+dfsg-5ubuntu2.1_amd64.deb ...
Unpacking libk5crypto3:amd64 (1.13.2+dfsg-5ubuntu2.1) ...
Selecting previously unselected package libkeyutils1:amd64.
Preparing to unpack .../libkeyutils1_1.5.9-8ubuntu1_amd64.deb ...
Unpacking libkeyutils1:amd64 (1.5.9-8ubuntu1) ...
Selecting previously unselected package libkrb5-3:amd64.
Preparing to unpack .../libkrb5-3_1.13.2+dfsg-5ubuntu2.1_amd64.deb ...
Unpacking libkrb5-3:amd64 (1.13.2+dfsg-5ubuntu2.1) ...
Selecting previously unselected package libgssapi-krb5-2:amd64.
Preparing to unpack .../libgssapi-krb5-2_1.13.2+dfsg-5ubuntu2.1_amd64.deb ...
Unpacking libgssapi-krb5-2:amd64 (1.13.2+dfsg-5ubuntu2.1) ...
Selecting previously unselected package libicu55:amd64.
Preparing to unpack .../libicu55_55.1-7ubuntu0.4_amd64.deb ...
Unpacking libicu55:amd64 (55.1-7ubuntu0.4) ...
Selecting previously unselected package libxml2:amd64.
Preparing to unpack .../libxml2_2.9.3+dfsg1-1ubuntu0.6_amd64.deb ...
Unpacking libxml2:amd64 (2.9.3+dfsg1-1ubuntu0.6) ...
Selecting previously unselected package libisc160:amd64.
Preparing to unpack .../libisc160_1%3a9.10.3.dfsg.P4-8ubuntu1.14_amd64.deb ...
Unpacking libisc160:amd64 (1:9.10.3.dfsg.P4-8ubuntu1.14) ...
Selecting previously unselected package libdns162:amd64.
Preparing to unpack .../libdns162_1%3a9.10.3.dfsg.P4-8ubuntu1.14_amd64.deb ...
Unpacking libdns162:amd64 (1:9.10.3.dfsg.P4-8ubuntu1.14) ...
Selecting previously unselected package libisccc140:amd64.
Preparing to unpack .../libisccc140_1%3a9.10.3.dfsg.P4-8ubuntu1.14_amd64.deb ...
Unpacking libisccc140:amd64 (1:9.10.3.dfsg.P4-8ubuntu1.14) ...
Selecting previously unselected package libisccfg140:amd64.
Preparing to unpack .../libisccfg140_1%3a9.10.3.dfsg.P4-8ubuntu1.14_amd64.deb ...
Unpacking libisccfg140:amd64 (1:9.10.3.dfsg.P4-8ubuntu1.14) ...
Selecting previously unselected package libbind9-140:amd64.
Preparing to unpack .../libbind9-140_1%3a9.10.3.dfsg.P4-8ubuntu1.14_amd64.deb ...
Unpacking libbind9-140:amd64 (1:9.10.3.dfsg.P4-8ubuntu1.14) ...
Selecting previously unselected package liblwres141:amd64.
Preparing to unpack .../liblwres141_1%3a9.10.3.dfsg.P4-8ubuntu1.14_amd64.deb ...
Unpacking liblwres141:amd64 (1:9.10.3.dfsg.P4-8ubuntu1.14) ...
Selecting previously unselected package bind9-host.
Preparing to unpack .../bind9-host_1%3a9.10.3.dfsg.P4-8ubuntu1.14_amd64.deb ...
Unpacking bind9-host (1:9.10.3.dfsg.P4-8ubuntu1.14) ...
Selecting previously unselected package busybox-static.
Preparing to unpack .../busybox-static_1%3a1.22.0-15ubuntu1.4_amd64.deb ...
Unpacking busybox-static (1:1.22.0-15ubuntu1.4) ...
Selecting previously unselected package openssl.
Preparing to unpack .../openssl_1.0.2g-1ubuntu4.15_amd64.deb ...
Unpacking openssl (1.0.2g-1ubuntu4.15) ...
Selecting previously unselected package ca-certificates.
Preparing to unpack .../ca-certificates_20170717~16.04.2_all.deb ...
Unpacking ca-certificates (20170717~16.04.2) ...
Selecting previously unselected package dnsutils.
Preparing to unpack .../dnsutils_1%3a9.10.3.dfsg.P4-8ubuntu1.14_amd64.deb ...
Unpacking dnsutils (1:9.10.3.dfsg.P4-8ubuntu1.14) ...
Selecting previously unselected package geoip-database.
Preparing to unpack .../geoip-database_20160408-1_all.deb ...
Unpacking geoip-database (20160408-1) ...
Selecting previously unselected package krb5-locales.
Preparing to unpack .../krb5-locales_1.13.2+dfsg-5ubuntu2.1_all.deb ...
Unpacking krb5-locales (1.13.2+dfsg-5ubuntu2.1) ...
Selecting previously unselected package libsasl2-modules:amd64.
Preparing to unpack .../libsasl2-modules_2.1.26.dfsg1-14ubuntu0.1_amd64.deb ...
Unpacking libsasl2-modules:amd64 (2.1.26.dfsg1-14ubuntu0.1) ...
Selecting previously unselected package libxmuu1:amd64.
Preparing to unpack .../libxmuu1_2%3a1.1.2-2_amd64.deb ...
Unpacking libxmuu1:amd64 (2:1.1.2-2) ...
Selecting previously unselected package openssh-client.
Preparing to unpack .../openssh-client_1%3a7.2p2-4ubuntu2.8_amd64.deb ...
Unpacking openssh-client (1:7.2p2-4ubuntu2.8) ...
Selecting previously unselected package rsync.
Preparing to unpack .../rsync_3.1.1-3ubuntu1.2_amd64.deb ...
Unpacking rsync (3.1.1-3ubuntu1.2) ...
Selecting previously unselected package wget.
Preparing to unpack .../wget_1.17.1-1ubuntu1.5_amd64.deb ...
Unpacking wget (1.17.1-1ubuntu1.5) ...
Selecting previously unselected package xauth.
Preparing to unpack .../xauth_1%3a1.0.9-1ubuntu2_amd64.deb ...
Unpacking xauth (1:1.0.9-1ubuntu2) ...
Selecting previously unselected package xml-core.
Preparing to unpack .../xml-core_0.13+nmu2_all.deb ...
Unpacking xml-core (0.13+nmu2) ...
Selecting previously unselected package keyutils.
Preparing to unpack .../keyutils_1.5.9-8ubuntu1_amd64.deb ...
Unpacking keyutils (1.5.9-8ubuntu1) ...
Selecting previously unselected package libevent-2.0-5:amd64.
Preparing to unpack .../libevent-2.0-5_2.0.21-stable-2ubuntu0.16.04.1_amd64.deb ...
Unpacking libevent-2.0-5:amd64 (2.0.21-stable-2ubuntu0.16.04.1) ...
Selecting previously unselected package ncurses-term.
Preparing to unpack .../ncurses-term_6.0+20160213-1ubuntu1_all.deb ...
Unpacking ncurses-term (6.0+20160213-1ubuntu1) ...
Selecting previously unselected package libtirpc1:amd64.
Preparing to unpack .../libtirpc1_0.2.5-1ubuntu0.1_amd64.deb ...
Unpacking libtirpc1:amd64 (0.2.5-1ubuntu0.1) ...
Selecting previously unselected package rpcbind.
Preparing to unpack .../rpcbind_0.2.3-0.2_amd64.deb ...
Unpacking rpcbind (0.2.3-0.2) ...
Selecting previously unselected package nfs-common.
Preparing to unpack .../nfs-common_1%3a1.2.8-9ubuntu12.1_amd64.deb ...
Unpacking nfs-common (1:1.2.8-9ubuntu12.1) ...
Selecting previously unselected package openssh-sftp-server.
Preparing to unpack .../openssh-sftp-server_1%3a7.2p2-4ubuntu2.8_amd64.deb ...
Unpacking openssh-sftp-server (1:7.2p2-4ubuntu2.8) ...
Selecting previously unselected package openssh-server.
Preparing to unpack .../openssh-server_1%3a7.2p2-4ubuntu2.8_amd64.deb ...
Unpacking openssh-server (1:7.2p2-4ubuntu2.8) ...
Selecting previously unselected package python3-pkg-resources.
Preparing to unpack .../python3-pkg-resources_20.7.0-1_all.deb ...
Unpacking python3-pkg-resources (20.7.0-1) ...
Selecting previously unselected package python3-chardet.
Preparing to unpack .../python3-chardet_2.3.0-2_all.deb ...
Unpacking python3-chardet (2.3.0-2) ...
Selecting previously unselected package python3-six.
Preparing to unpack .../python3-six_1.10.0-3_all.deb ...
Unpacking python3-six (1.10.0-3) ...
Selecting previously unselected package python3-urllib3.
Preparing to unpack .../python3-urllib3_1.13.1-2ubuntu0.16.04.2_all.deb ...
Unpacking python3-urllib3 (1.13.1-2ubuntu0.16.04.2) ...
Selecting previously unselected package python3-requests.
Preparing to unpack .../python3-requests_2.9.1-3ubuntu0.1_all.deb ...
Unpacking python3-requests (2.9.1-3ubuntu0.1) ...
Selecting previously unselected package rename.
Preparing to unpack .../archives/rename_0.20-4_all.deb ...
Unpacking rename (0.20-4) ...
Selecting previously unselected package tcpd.
Preparing to unpack .../tcpd_7.6.q-25_amd64.deb ...
Unpacking tcpd (7.6.q-25) ...
Selecting previously unselected package xz-utils.
Preparing to unpack .../xz-utils_5.1.1alpha+20120614-2ubuntu2_amd64.deb ...
Unpacking xz-utils (5.1.1alpha+20120614-2ubuntu2) ...
Selecting previously unselected package ssh-import-id.
Preparing to unpack .../ssh-import-id_5.5-0ubuntu1_all.deb ...
Unpacking ssh-import-id (5.5-0ubuntu1) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
Processing triggers for ureadahead (0.100.0-19.1) ...
Processing triggers for systemd (229-4ubuntu21.21) ...
Setting up libgdbm3:amd64 (1.8.3-13.1) ...
Setting up libxau6:amd64 (1:1.0.8-1) ...
Setting up libxdmcp6:amd64 (1:1.1.2-1.1) ...
Setting up libxcb1:amd64 (1.11.1-1ubuntu1) ...
Setting up libx11-data (2:1.6.3-1ubuntu2.1) ...
Setting up libx11-6:amd64 (2:1.6.3-1ubuntu2.1) ...
Setting up libxext6:amd64 (2:1.3.3-1) ...
Setting up sgml-base (1.26+nmu4ubuntu1) ...
Setting up gawk (1:4.1.3+dfsg-0.1) ...
Setting up libroken18-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Setting up libasn1-8-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Setting up libhcrypto4-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Setting up libheimbase1-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Setting up libwind0-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Setting up libhx509-5-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Setting up libkrb5-26-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Setting up libheimntlm0-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Setting up libgssapi3-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Setting up libsasl2-modules-db:amd64 (2.1.26.dfsg1-14ubuntu0.1) ...
Setting up libsasl2-2:amd64 (2.1.26.dfsg1-14ubuntu0.1) ...
Setting up libldap-2.4-2:amd64 (2.4.42+dfsg-2ubuntu3.5) ...
Setting up libnfsidmap2:amd64 (0.25-5) ...
Setting up libwrap0:amd64 (7.6.q-25) ...
Setting up libedit2:amd64 (3.1-20150325-1ubuntu2) ...
Setting up libopts25:amd64 (1:5.18.7-3) ...
Setting up ntp (1:4.2.8p4+dfsg-3ubuntu5.9) ...
Running in chroot, ignoring request.
invoke-rc.d: policy-rc.d denied execution of start.
Setting up ntpdate (1:4.2.8p4+dfsg-3ubuntu5.9) ...
Setting up perl-modules-5.22 (5.22.1-9ubuntu0.6) ...
Setting up libperl5.22:amd64 (5.22.1-9ubuntu0.6) ...
Setting up perl (5.22.1-9ubuntu0.6) ...
update-alternatives: using /usr/bin/prename to provide /usr/bin/rename (rename) in auto mode
Setting up libpython2.7-stdlib:amd64 (2.7.12-1ubuntu0~16.04.4) ...
Setting up python2.7 (2.7.12-1ubuntu0~16.04.4) ...
Setting up libpython-stdlib:amd64 (2.7.12-1~16.04) ...
Setting up python (2.7.12-1~16.04) ...
Setting up libgeoip1:amd64 (1.6.9-1) ...
Setting up libkrb5support0:amd64 (1.13.2+dfsg-5ubuntu2.1) ...
Setting up libk5crypto3:amd64 (1.13.2+dfsg-5ubuntu2.1) ...
Setting up libkeyutils1:amd64 (1.5.9-8ubuntu1) ...
Setting up libkrb5-3:amd64 (1.13.2+dfsg-5ubuntu2.1) ...
Setting up libgssapi-krb5-2:amd64 (1.13.2+dfsg-5ubuntu2.1) ...
Setting up libicu55:amd64 (55.1-7ubuntu0.4) ...
Setting up libxml2:amd64 (2.9.3+dfsg1-1ubuntu0.6) ...
Setting up libisc160:amd64 (1:9.10.3.dfsg.P4-8ubuntu1.14) ...
Setting up libdns162:amd64 (1:9.10.3.dfsg.P4-8ubuntu1.14) ...
Setting up libisccc140:amd64 (1:9.10.3.dfsg.P4-8ubuntu1.14) ...
Setting up libisccfg140:amd64 (1:9.10.3.dfsg.P4-8ubuntu1.14) ...
Setting up libbind9-140:amd64 (1:9.10.3.dfsg.P4-8ubuntu1.14) ...
Setting up liblwres141:amd64 (1:9.10.3.dfsg.P4-8ubuntu1.14) ...
Setting up bind9-host (1:9.10.3.dfsg.P4-8ubuntu1.14) ...
Setting up busybox-static (1:1.22.0-15ubuntu1.4) ...
Setting up openssl (1.0.2g-1ubuntu4.15) ...
Setting up ca-certificates (20170717~16.04.2) ...
Setting up dnsutils (1:9.10.3.dfsg.P4-8ubuntu1.14) ...
Setting up geoip-database (20160408-1) ...
Setting up krb5-locales (1.13.2+dfsg-5ubuntu2.1) ...
Setting up libsasl2-modules:amd64 (2.1.26.dfsg1-14ubuntu0.1) ...
Setting up libxmuu1:amd64 (2:1.1.2-2) ...
Setting up openssh-client (1:7.2p2-4ubuntu2.8) ...
Setting up rsync (3.1.1-3ubuntu1.2) ...
Running in chroot, ignoring request.
invoke-rc.d: policy-rc.d denied execution of restart.
Setting up wget (1.17.1-1ubuntu1.5) ...
Setting up xauth (1:1.0.9-1ubuntu2) ...
Setting up xml-core (0.13+nmu2) ...
Setting up keyutils (1.5.9-8ubuntu1) ...
Setting up libevent-2.0-5:amd64 (2.0.21-stable-2ubuntu0.16.04.1) ...
Setting up ncurses-term (6.0+20160213-1ubuntu1) ...
Setting up libtirpc1:amd64 (0.2.5-1ubuntu0.1) ...
Setting up rpcbind (0.2.3-0.2) ...
Running in chroot, ignoring request.
invoke-rc.d: policy-rc.d denied execution of start.
Setting up nfs-common (1:1.2.8-9ubuntu12.1) ...
Creating config file /etc/idmapd.conf with new version
Creating config file /etc/default/nfs-common with new version
Adding system user `statd' (UID 107) ...
Adding new user `statd' (UID 107) with group `nogroup' ...
Not creating home directory `/var/lib/nfs'.
invoke-rc.d: unknown initscript, /etc/init.d/gssd not found.
Running in chroot, ignoring request.
invoke-rc.d: unknown initscript, /etc/init.d/idmapd not found.
Running in chroot, ignoring request.
Setting up openssh-sftp-server (1:7.2p2-4ubuntu2.8) ...
Setting up openssh-server (1:7.2p2-4ubuntu2.8) ...
Creating SSH2 RSA key; this may take some time ...
2048 SHA256:OUUvubgILNE1G8+EY3f5EzyAAwt2BbVH//P3hAZT3NE root@c910f04x12v05 (RSA)
Creating SSH2 DSA key; this may take some time ...
1024 SHA256:ue+EP7gVlwNWbPf89zDr9DGlNB3QBRhabsuOz4hyQ1o root@c910f04x12v05 (DSA)
Creating SSH2 ECDSA key; this may take some time ...
256 SHA256:eoxjVwQ59exeOu03QJbgA8dz+opKoK9x3X5pxSvBVz4 root@c910f04x12v05 (ECDSA)
Creating SSH2 ED25519 key; this may take some time ...
256 SHA256:kHGEMNRZvY1sj6aN0WPf+FH40DS2VWNUqviCzpUwqZQ root@c910f04x12v05 (ED25519)
Running in chroot, ignoring request.
invoke-rc.d: policy-rc.d denied execution of start.
Setting up python3-pkg-resources (20.7.0-1) ...
Setting up python3-chardet (2.3.0-2) ...
Setting up python3-six (1.10.0-3) ...
Setting up python3-urllib3 (1.13.1-2ubuntu0.16.04.2) ...
Setting up python3-requests (2.9.1-3ubuntu0.1) ...
Setting up rename (0.20-4) ...
update-alternatives: using /usr/bin/file-rename to provide /usr/bin/rename (rename) in auto mode
Setting up tcpd (7.6.q-25) ...
Setting up xz-utils (5.1.1alpha+20120614-2ubuntu2) ...
update-alternatives: using /usr/bin/xz to provide /usr/bin/lzma (lzma) in auto mode
Setting up ssh-import-id (5.5-0ubuntu1) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
Processing triggers for ureadahead (0.100.0-19.1) ...
Processing triggers for systemd (229-4ubuntu21.21) ...
Processing triggers for ca-certificates (20170717~16.04.2) ...
Updating certificates in /etc/ssl/certs...
148 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
Processing triggers for sgml-base (1.26+nmu4ubuntu1) ...
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  amd64-microcode crda intel-microcode iucode-tool iw libnl-3-200
  libnl-genl-3-200 linux-firmware linux-image-4.4.0-146-generic
  linux-modules-4.4.0-146-generic linux-modules-extra-4.4.0-146-generic
  wireless-regdb
Suggested packages:
  fdutils linux-doc-4.4.0 | linux-source-4.4.0 linux-tools
  linux-headers-4.4.0-146-generic
Recommended packages:
  grub-pc | grub-efi-amd64 | grub-efi-ia32 | grub | lilo thermald
The following NEW packages will be installed:
  amd64-microcode crda intel-microcode iucode-tool iw libnl-3-200
  libnl-genl-3-200 linux-firmware linux-image-4.4.0-146-generic
  linux-image-generic linux-modules-4.4.0-146-generic
  linux-modules-extra-4.4.0-146-generic wireless-regdb
0 upgraded, 13 newly installed, 0 to remove and 1 not upgraded.
Need to get 107 MB of archives.
After this operation, 465 MB of additional disk space will be used.
Get:1 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libnl-3-200 amd64 3.2.27-1ubuntu0.16.04.1 [52.2 kB]
Get:2 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libnl-genl-3-200 amd64 3.2.27-1ubuntu0.16.04.1 [11.2 kB]
Get:3 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 wireless-regdb all 2018.05.09-0ubuntu1~16.04.1 [11.7 kB]
Get:4 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 iw amd64 3.17-1 [63.5 kB]
Get:5 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 crda amd64 3.13-1 [60.5 kB]
Get:6 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 iucode-tool amd64 1.5.1-1ubuntu0.1 [33.8 kB]
Get:7 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 amd64-microcode amd64 3.20180524.1~ubuntu0.16.04.2 [32.2 kB]
Get:8 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-firmware all 1.157.21 [49.8 MB]
Get:9 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-modules-4.4.0-146-generic amd64 4.4.0-146.172 [12.0 MB]
Get:10 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-image-4.4.0-146-generic amd64 4.4.0-146.172 [6926 kB]
Get:11 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-modules-extra-4.4.0-146-generic amd64 4.4.0-146.172 [36.6 MB]
Get:12 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 intel-microcode amd64 3.20180807a.0ubuntu0.16.04.1 [1275 kB]
Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-image-generic amd64 4.4.0.146.154 [2738 B]
Fetched 107 MB in 2s (50.3 MB/s)
E: Can not write log (Is /dev/pts mounted?) - posix_openpt (19: No such device)
Selecting previously unselected package libnl-3-200:amd64.
(Reading database ... 17412 files and directories currently installed.)
Preparing to unpack .../libnl-3-200_3.2.27-1ubuntu0.16.04.1_amd64.deb ...
Unpacking libnl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
Selecting previously unselected package libnl-genl-3-200:amd64.
Preparing to unpack .../libnl-genl-3-200_3.2.27-1ubuntu0.16.04.1_amd64.deb ...
Unpacking libnl-genl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
Selecting previously unselected package wireless-regdb.
Preparing to unpack .../wireless-regdb_2018.05.09-0ubuntu1~16.04.1_all.deb ...
Unpacking wireless-regdb (2018.05.09-0ubuntu1~16.04.1) ...
Selecting previously unselected package iw.
Preparing to unpack .../archives/iw_3.17-1_amd64.deb ...
Unpacking iw (3.17-1) ...
Selecting previously unselected package crda.
Preparing to unpack .../archives/crda_3.13-1_amd64.deb ...
Unpacking crda (3.13-1) ...
Selecting previously unselected package iucode-tool.
Preparing to unpack .../iucode-tool_1.5.1-1ubuntu0.1_amd64.deb ...
Unpacking iucode-tool (1.5.1-1ubuntu0.1) ...
Selecting previously unselected package linux-firmware.
Preparing to unpack .../linux-firmware_1.157.21_all.deb ...
Unpacking linux-firmware (1.157.21) ...
Selecting previously unselected package linux-modules-4.4.0-146-generic.
Preparing to unpack .../linux-modules-4.4.0-146-generic_4.4.0-146.172_amd64.deb ...
Unpacking linux-modules-4.4.0-146-generic (4.4.0-146.172) ...
Selecting previously unselected package linux-image-4.4.0-146-generic.
Preparing to unpack .../linux-image-4.4.0-146-generic_4.4.0-146.172_amd64.deb ...
Unpacking linux-image-4.4.0-146-generic (4.4.0-146.172) ...
Selecting previously unselected package linux-modules-extra-4.4.0-146-generic.
Preparing to unpack .../linux-modules-extra-4.4.0-146-generic_4.4.0-146.172_amd64.deb ...
Unpacking linux-modules-extra-4.4.0-146-generic (4.4.0-146.172) ...
Selecting previously unselected package intel-microcode.
Preparing to unpack .../intel-microcode_3.20180807a.0ubuntu0.16.04.1_amd64.deb ...
Unpacking intel-microcode (3.20180807a.0ubuntu0.16.04.1) ...
Selecting previously unselected package amd64-microcode.
Preparing to unpack .../amd64-microcode_3.20180524.1~ubuntu0.16.04.2_amd64.deb ...
Unpacking amd64-microcode (3.20180524.1~ubuntu0.16.04.2) ...
Selecting previously unselected package linux-image-generic.
Preparing to unpack .../linux-image-generic_4.4.0.146.154_amd64.deb ...
Unpacking linux-image-generic (4.4.0.146.154) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
Setting up libnl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
Setting up libnl-genl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
Setting up wireless-regdb (2018.05.09-0ubuntu1~16.04.1) ...
Setting up iw (3.17-1) ...
Setting up crda (3.13-1) ...
Setting up iucode-tool (1.5.1-1ubuntu0.1) ...
Setting up linux-firmware (1.157.21) ...
Setting up linux-modules-4.4.0-146-generic (4.4.0-146.172) ...
Setting up linux-image-4.4.0-146-generic (4.4.0-146.172) ...
I: /vmlinuz.old is now a symlink to boot/vmlinuz-4.4.0-146-generic
I: /initrd.img.old is now a symlink to boot/initrd.img-4.4.0-146-generic
I: /vmlinuz is now a symlink to boot/vmlinuz-4.4.0-146-generic
I: /initrd.img is now a symlink to boot/initrd.img-4.4.0-146-generic
Setting up linux-modules-extra-4.4.0-146-generic (4.4.0-146.172) ...
Setting up intel-microcode (3.20180807a.0ubuntu0.16.04.1) ...
update-initramfs: deferring update (trigger activated)
intel-microcode: microcode will be updated at next boot
Setting up amd64-microcode (3.20180524.1~ubuntu0.16.04.2) ...
update-initramfs: deferring update (trigger activated)
amd64-microcode: microcode will be updated at next boot
Setting up linux-image-generic (4.4.0.146.154) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
Processing triggers for linux-image-4.4.0-146-generic (4.4.0-146.172) ...
/etc/kernel/postinst.d/initramfs-tools:
update-initramfs: Generating /boot/initrd.img-4.4.0-146-generic
Processing triggers for initramfs-tools (0.122ubuntu8.14) ...
update-initramfs: Generating /boot/initrd.img-4.4.0-146-generic
Ign:1 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial InRelease
Hit:2 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial Release
Hit:3 http://archive.ubuntu.com/ubuntu xenial InRelease
Hit:4 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
Get:6 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]
Get:7 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [647 kB]
Get:8 http://security.ubuntu.com/ubuntu xenial-security/main Translation-en [264 kB]
Get:9 http://security.ubuntu.com/ubuntu xenial-security/restricted amd64 Packages [7204 B]
Get:10 http://security.ubuntu.com/ubuntu xenial-security/restricted Translation-en [2152 B]
Fetched 1030 kB in 0s (1482 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
Calculating upgrade...
The following packages have been kept back:
  linux-image-generic ubuntu-minimal
The following packages will be upgraded:
  distro-info-data intel-microcode sudo
3 upgraded, 0 newly installed, 0 to remove and 2 not upgraded.
Need to get 2198 kB of archives.
After this operation, 677 kB of additional disk space will be used.
Get:1 http://security.ubuntu.com/ubuntu xenial-security/main amd64 distro-info-data all 0.28ubuntu0.12 [4638 B]
Get:2 http://security.ubuntu.com/ubuntu xenial-security/main amd64 sudo amd64 1.8.16-0ubuntu1.6 [390 kB]
Get:3 http://security.ubuntu.com/ubuntu xenial-security/main amd64 intel-microcode amd64 3.20190514.0ubuntu0.16.04.1 [1803 kB]
Fetched 2198 kB in 0s (4956 kB/s)
E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
(Reading database ... 24911 files and directories currently installed.)
Preparing to unpack .../distro-info-data_0.28ubuntu0.12_all.deb ...
Unpacking distro-info-data (0.28ubuntu0.12) over (0.28ubuntu0.11) ...
Preparing to unpack .../sudo_1.8.16-0ubuntu1.6_amd64.deb ...
Unpacking sudo (1.8.16-0ubuntu1.6) over (1.8.16-0ubuntu1.5) ...
Preparing to unpack .../intel-microcode_3.20190514.0ubuntu0.16.04.1_amd64.deb ...
Unpacking intel-microcode (3.20190514.0ubuntu0.16.04.1) over (3.20180807a.0ubuntu0.16.04.1) ...
Setting up distro-info-data (0.28ubuntu0.12) ...
Setting up sudo (1.8.16-0ubuntu1.6) ...
Setting up intel-microcode (3.20190514.0ubuntu0.16.04.1) ...
update-initramfs: deferring update (trigger activated)
intel-microcode: microcode will be updated at next boot
Processing triggers for initramfs-tools (0.122ubuntu8.14) ...
update-initramfs: Generating /boot/initrd.img-4.4.0-146-generic
Reading package lists...
Building dependency tree...
Reading state information...
Calculating upgrade...
The following NEW packages will be installed:
  gettext-base grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
  grub2-common libasprintf0v5 libfreetype6 libfuse2
  linux-image-4.4.0-148-generic linux-modules-4.4.0-148-generic
  linux-modules-extra-4.4.0-148-generic os-prober ubuntu-advantage-tools
The following packages will be upgraded:
  linux-image-generic ubuntu-minimal
2 upgraded, 14 newly installed, 0 to remove and 0 not upgraded.
Need to get 59.3 MB of archives.
After this operation, 241 MB of additional disk space will be used.
Get:1 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libfreetype6 amd64 2.6.1-0.1ubuntu2.3 [316 kB]
Get:2 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 libfuse2 amd64 2.9.4-1ubuntu3.1 [89.9 kB]
Get:3 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
Get:4 http://10.4.12.5:80/install/ubuntu16.04.5/x86_64 xenial/main amd64 os-prober amd64 1.70ubuntu3.3 [19.1 kB]
Get:5 http://security.ubuntu.com/ubuntu xenial-security/main amd64 linux-modules-4.4.0-148-generic amd64 4.4.0-148.174 [12.0 MB]
Get:6 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libasprintf0v5 amd64 0.19.7-2ubuntu3.1 [6568 B]
Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 gettext-base amd64 0.19.7-2ubuntu3.1 [48.0 kB]
Get:8 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-common amd64 2.02~beta2-36ubuntu3.21 [1710 kB]
Get:9 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub2-common amd64 2.02~beta2-36ubuntu3.21 [511 kB]
Get:10 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-pc-bin amd64 2.02~beta2-36ubuntu3.21 [890 kB]
Get:11 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-pc amd64 2.02~beta2-36ubuntu3.21 [198 kB]
Get:12 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ubuntu-advantage-tools all 10ubuntu0.16.04.1 [11.5 kB]
Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ubuntu-minimal amd64 1.361.3 [2696 B]
Get:14 http://security.ubuntu.com/ubuntu xenial-security/main amd64 linux-image-4.4.0-148-generic amd64 4.4.0-148.174 [6925 kB]
Get:15 http://security.ubuntu.com/ubuntu xenial-security/main amd64 linux-modules-extra-4.4.0-148-generic amd64 4.4.0-148.174 [36.6 MB]
Get:16 http://security.ubuntu.com/ubuntu xenial-security/main amd64 linux-image-generic amd64 4.4.0.148.156 [2750 B]
Preconfiguring packages ...
Fetched 59.3 MB in 3s (15.2 MB/s)
E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
Selecting previously unselected package libfreetype6:amd64.
(Reading database ... 24921 files and directories currently installed.)
Preparing to unpack .../libfreetype6_2.6.1-0.1ubuntu2.3_amd64.deb ...
Unpacking libfreetype6:amd64 (2.6.1-0.1ubuntu2.3) ...
Selecting previously unselected package libfuse2:amd64.
Preparing to unpack .../libfuse2_2.9.4-1ubuntu3.1_amd64.deb ...
Unpacking libfuse2:amd64 (2.9.4-1ubuntu3.1) ...
Selecting previously unselected package libasprintf0v5:amd64.
Preparing to unpack .../libasprintf0v5_0.19.7-2ubuntu3.1_amd64.deb ...
Unpacking libasprintf0v5:amd64 (0.19.7-2ubuntu3.1) ...
Selecting previously unselected package gettext-base.
Preparing to unpack .../gettext-base_0.19.7-2ubuntu3.1_amd64.deb ...
Unpacking gettext-base (0.19.7-2ubuntu3.1) ...
Selecting previously unselected package grub-common.
Preparing to unpack .../grub-common_2.02~beta2-36ubuntu3.21_amd64.deb ...
Unpacking grub-common (2.02~beta2-36ubuntu3.21) ...
Selecting previously unselected package grub2-common.
Preparing to unpack .../grub2-common_2.02~beta2-36ubuntu3.21_amd64.deb ...
Unpacking grub2-common (2.02~beta2-36ubuntu3.21) ...
Selecting previously unselected package grub-pc-bin.
Preparing to unpack .../grub-pc-bin_2.02~beta2-36ubuntu3.21_amd64.deb ...
Unpacking grub-pc-bin (2.02~beta2-36ubuntu3.21) ...
Selecting previously unselected package grub-gfxpayload-lists.
Preparing to unpack .../grub-gfxpayload-lists_0.7_amd64.deb ...
Unpacking grub-gfxpayload-lists (0.7) ...
Selecting previously unselected package grub-pc.
Preparing to unpack .../grub-pc_2.02~beta2-36ubuntu3.21_amd64.deb ...
Unpacking grub-pc (2.02~beta2-36ubuntu3.21) ...
Selecting previously unselected package ubuntu-advantage-tools.
Preparing to unpack .../ubuntu-advantage-tools_10ubuntu0.16.04.1_all.deb ...
Unpacking ubuntu-advantage-tools (10ubuntu0.16.04.1) ...
Preparing to unpack .../ubuntu-minimal_1.361.3_amd64.deb ...
Unpacking ubuntu-minimal (1.361.3) over (1.361) ...
Selecting previously unselected package linux-modules-4.4.0-148-generic.
Preparing to unpack .../linux-modules-4.4.0-148-generic_4.4.0-148.174_amd64.deb ...
Unpacking linux-modules-4.4.0-148-generic (4.4.0-148.174) ...
Selecting previously unselected package linux-image-4.4.0-148-generic.
Preparing to unpack .../linux-image-4.4.0-148-generic_4.4.0-148.174_amd64.deb ...
Unpacking linux-image-4.4.0-148-generic (4.4.0-148.174) ...
Selecting previously unselected package linux-modules-extra-4.4.0-148-generic.
Preparing to unpack .../linux-modules-extra-4.4.0-148-generic_4.4.0-148.174_amd64.deb ...
Unpacking linux-modules-extra-4.4.0-148-generic (4.4.0-148.174) ...
Preparing to unpack .../linux-image-generic_4.4.0.148.156_amd64.deb ...
Unpacking linux-image-generic (4.4.0.148.156) over (4.4.0.146.154) ...
Selecting previously unselected package os-prober.
Preparing to unpack .../os-prober_1.70ubuntu3.3_amd64.deb ...
Unpacking os-prober (1.70ubuntu3.3) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
Processing triggers for ureadahead (0.100.0-19.1) ...
Processing triggers for systemd (229-4ubuntu21.21) ...
Setting up libfreetype6:amd64 (2.6.1-0.1ubuntu2.3) ...
Setting up libfuse2:amd64 (2.9.4-1ubuntu3.1) ...
Setting up libasprintf0v5:amd64 (0.19.7-2ubuntu3.1) ...
Setting up gettext-base (0.19.7-2ubuntu3.1) ...
Setting up grub-common (2.02~beta2-36ubuntu3.21) ...
update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
Running in chroot, ignoring request.
invoke-rc.d: policy-rc.d denied execution of start.
Setting up grub2-common (2.02~beta2-36ubuntu3.21) ...
Setting up grub-pc-bin (2.02~beta2-36ubuntu3.21) ...
Setting up ubuntu-advantage-tools (10ubuntu0.16.04.1) ...
Setting up ubuntu-minimal (1.361.3) ...
Setting up linux-modules-4.4.0-148-generic (4.4.0-148.174) ...
Setting up linux-image-4.4.0-148-generic (4.4.0-148.174) ...
I: /vmlinuz is now a symlink to boot/vmlinuz-4.4.0-148-generic
I: /initrd.img is now a symlink to boot/initrd.img-4.4.0-148-generic
Setting up linux-modules-extra-4.4.0-148-generic (4.4.0-148.174) ...
Setting up linux-image-generic (4.4.0.148.156) ...
Setting up os-prober (1.70ubuntu3.3) ...
Setting up grub-pc (2.02~beta2-36ubuntu3.21) ...
Creating config file /etc/default/grub with new version
Setting up grub-gfxpayload-lists (0.7) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
Processing triggers for ureadahead (0.100.0-19.1) ...
Processing triggers for systemd (229-4ubuntu21.21) ...
Processing triggers for linux-image-4.4.0-148-generic (4.4.0-148.174) ...
/etc/kernel/postinst.d/initramfs-tools:
update-initramfs: Generating /boot/initrd.img-4.4.0-148-generic
Umount /proc, /dev, /sys, pkgdir and otherpkgdir to the rootimg.
Setting up the locales
Generating locales (this might take a while)...
  en_US.ISO-8859-1... done
  en_US.UTF-8... done
Generation complete.
Generating locales (this might take a while)...
  en_US.ISO-8859-1... done
  en_US.UTF-8... done
Generation complete.
Added ptp.ko as an autodetected dependency
Added pps_core.ko as an autodetected dependency
Added dca.ko as an autodetected dependency
Added i2c-algo-bit.ko as an autodetected dependency
Added vxlan.ko as an autodetected dependency
Added ip6_udp_tunnel.ko as an autodetected dependency
Added udp_tunnel.ko as an autodetected dependency
Added mdio.ko as an autodetected dependency
Added libcrc32c.ko as an autodetected dependency
ldd: sbin/udevd: No such file or directory
cd /tmp/xcatinitrd.23022;find .|cpio -H newc -o|gzip -9 -c - > /install/netboot/ubuntu16.04.5/x86_64/compute/initrd-statelite.gz
605223 blocks
ldd: sbin/udevd: No such file or directory
cd /tmp/xcatinitrd.23022;find .|cpio -H newc -o|gzip -9 -c - > /install/netboot/ubuntu16.04.5/x86_64/compute/initrd-stateless.gz
602448 blocks
CHECK:rc == 0	[Pass]

RUN:ls -l /install/netboot/__GETNODEATTR(c910f04x12v07,os)__/__GETNODEATTR(c910f04x12v07,arch)__/compute/rootimg [Tue May 21 04:48:31 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
total 76
drwxr-xr-x  2 root root 4096 May 21 04:45 bin
drwxr-xr-x  3 root root 4096 May 21 04:45 boot
drwxr-xr-x  2 root root 4096 May 21 04:45 dev
drwxr-xr-x 78 root root 4096 May 21 04:46 etc
drwxr-xr-x  2 root root 4096 Apr 12  2016 home
lrwxrwxrwx  1 root root   33 May 21 04:45 initrd.img -> boot/initrd.img-4.4.0-148-generic
lrwxrwxrwx  1 root root   33 May 21 04:44 initrd.img.old -> boot/initrd.img-4.4.0-146-generic
drwxr-xr-x 14 root root 4096 May 21 04:44 lib
drwxr-xr-x  2 root root 4096 May 21 04:43 lib64
drwxr-xr-x  2 root root 4096 May 21 04:42 media
drwxr-xr-x  2 root root 4096 May 21 04:45 mnt
drwxr-xr-x  3 root root 4096 May 21 04:45 opt
drwxr-xr-x  2 root root 4096 May 21 04:43 proc
drwx------  2 root root 4096 May 21 04:45 root
drwxr-xr-x 12 root root 4096 May 21 04:44 run
drwxr-xr-x  2 root root 4096 May 21 04:44 sbin
drwxr-xr-x  2 root root 4096 May 21 04:42 srv
drwxr-xr-x  2 root root 4096 Feb  5  2016 sys
drwxrwxrwt  7 root root 4096 May 21 04:45 tmp
drwxr-xr-x 10 root root 4096 May 21 04:42 usr
drwxr-xr-x 11 root root 4096 May 21 04:42 var
lrwxrwxrwx  1 root root   30 May 21 04:45 vmlinuz -> boot/vmlinuz-4.4.0-148-generic
lrwxrwxrwx  1 root root   30 May 21 04:44 vmlinuz.old -> boot/vmlinuz-4.4.0-146-generic
CHECK:rc == 0	[Pass]

RUN:packimage __GETNODEATTR(c910f04x12v07,os)__-__GETNODEATTR(c910f04x12v07,arch)__-netboot-compute -m cpio -c gzip [Tue May 21 04:48:33 2019]
ElapsedTime:58 sec
RETURN rc = 0
OUTPUT:
Packing contents of /install/netboot/ubuntu16.04.5/x86_64/compute/rootimg
archive method:cpio
compress method:gzip

CHECK:rc == 0	[Pass]
CHECK:output =~ archive method:cpio	[Pass]
CHECK:output =~ compress method:gzip	[Pass]

RUN:ls -l /install/netboot/__GETNODEATTR(c910f04x12v07,os)__/__GETNODEATTR(c910f04x12v07,arch)__/compute/rootimg.cpio.gz [Tue May 21 04:49:31 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
-rw-r--r-- 1 root root 370975665 May 21 04:49 /install/netboot/ubuntu16.04.5/x86_64/compute/rootimg.cpio.gz
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh c910f04x12v07 __GETNODEATTR(c910f04x12v07,os)__-__GETNODEATTR(c910f04x12v07,arch)__-netboot-compute [Tue May 21 04:49:32 2019]
ElapsedTime:367 sec
RETURN rc = 0
OUTPUT:
Try to retry rinstall 5 times ......
Try to install c910f04x12v07 on the 1 time...
rinstall c910f04x12v07 osimage=ubuntu16.04.5-x86_64-netboot-compute
Provision node(s): c910f04x12v07
    status=booted
The tobooted is 0
PING c910f04x12v07 (10.4.12.7) 56(84) bytes of data.
64 bytes from c910f04x12v07 (10.4.12.7): icmp_seq=1 ttl=64 time=0.420 ms
64 bytes from c910f04x12v07 (10.4.12.7): icmp_seq=2 ttl=64 time=0.475 ms

--- c910f04x12v07 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1012ms
rtt min/avg/max/mdev = 0.420/0.447/0.475/0.034 ms
The pingable is 0
c910f04x12v07: Tue May 21 04:39:56 EDT 2019
The canruncmd is 0
The provision succeed on the 1 time.....
The provision succeed......
CHECK:rc == 0	[Pass]

RUN:a=0;while ! `lsdef -l c910f04x12v07|grep status|grep booted >/dev/null`; do sleep 10;((a++));if [ $a -gt 150 ];then break;fi done [Tue May 21 04:55:39 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:ping c910f04x12v07 -c 3 [Tue May 21 04:55:40 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
PING c910f04x12v07 (10.4.12.7) 56(84) bytes of data.
64 bytes from c910f04x12v07 (10.4.12.7): icmp_seq=1 ttl=64 time=0.433 ms
64 bytes from c910f04x12v07 (10.4.12.7): icmp_seq=2 ttl=64 time=0.487 ms
64 bytes from c910f04x12v07 (10.4.12.7): icmp_seq=3 ttl=64 time=0.380 ms

--- c910f04x12v07 ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2048ms
rtt min/avg/max/mdev = 0.380/0.433/0.487/0.046 ms
CHECK:rc == 0	[Pass]
CHECK:output =~ 64 bytes from c910f04x12v07	[Pass]

RUN:lsdef -l c910f04x12v07 | grep status [Tue May 21 04:55:42 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
    status=booted
    statustime=05-21-2019 04:50:17
    updatestatus=failed
    updatestatustime=05-20-2019 08:24:54
CHECK:rc == 0	[Pass]
CHECK:output =~ booted	[Pass]

RUN:xdsh c910f04x12v07 date [Tue May 21 04:55:42 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f04x12v07: Tue May 21 04:40:00 EDT 2019
CHECK:rc == 0	[Pass]
CHECK:output =~ \d\d:\d\d:\d\d	[Pass]

RUN:xdsh c910f04x12v07 mount [Tue May 21 04:55:43 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f04x12v07: /proc on /proc type proc (rw,relatime)
c910f04x12v07: /sys on /sys type sysfs (rw,relatime)
c910f04x12v07: /dev on /dev type devtmpfs (rw,relatime,size=1953404k,nr_inodes=488351,mode=755)
c910f04x12v07: /dev/pts on /dev/pts type devpts (rw,relatime,gid=5,mode=620,ptmxmode=000)
c910f04x12v07: rootfs on / type tmpfs (rw,relatime,mode=755)
c910f04x12v07: securityfs on /sys/kernel/security type securityfs (rw,nosuid,nodev,noexec,relatime)
c910f04x12v07: tmpfs on /dev/shm type tmpfs (rw)
c910f04x12v07: tmpfs on /run type tmpfs (rw,nosuid,nodev,mode=755)
c910f04x12v07: tmpfs on /run/lock type tmpfs (rw,nosuid,nodev,noexec,relatime,size=5120k)
c910f04x12v07: tmpfs on /sys/fs/cgroup type tmpfs (ro,nosuid,nodev,noexec,mode=755)
c910f04x12v07: cgroup on /sys/fs/cgroup/systemd type cgroup (rw,nosuid,nodev,noexec,relatime,xattr,release_agent=/lib/systemd/systemd-cgroups-agent,name=systemd)
c910f04x12v07: pstore on /sys/fs/pstore type pstore (rw,nosuid,nodev,noexec,relatime)
c910f04x12v07: cgroup on /sys/fs/cgroup/hugetlb type cgroup (rw,nosuid,nodev,noexec,relatime,hugetlb)
c910f04x12v07: cgroup on /sys/fs/cgroup/net_cls,net_prio type cgroup (rw,nosuid,nodev,noexec,relatime,net_cls,net_prio)
c910f04x12v07: cgroup on /sys/fs/cgroup/perf_event type cgroup (rw,nosuid,nodev,noexec,relatime,perf_event)
c910f04x12v07: cgroup on /sys/fs/cgroup/pids type cgroup (rw,nosuid,nodev,noexec,relatime,pids)
c910f04x12v07: cgroup on /sys/fs/cgroup/blkio type cgroup (rw,nosuid,nodev,noexec,relatime,blkio)
c910f04x12v07: cgroup on /sys/fs/cgroup/cpu,cpuacct type cgroup (rw,nosuid,nodev,noexec,relatime,cpu,cpuacct)
c910f04x12v07: cgroup on /sys/fs/cgroup/freezer type cgroup (rw,nosuid,nodev,noexec,relatime,freezer)
c910f04x12v07: cgroup on /sys/fs/cgroup/cpuset type cgroup (rw,nosuid,nodev,noexec,relatime,cpuset)
c910f04x12v07: cgroup on /sys/fs/cgroup/memory type cgroup (rw,nosuid,nodev,noexec,relatime,memory)
c910f04x12v07: cgroup on /sys/fs/cgroup/devices type cgroup (rw,nosuid,nodev,noexec,relatime,devices)
c910f04x12v07: systemd-1 on /proc/sys/fs/binfmt_misc type autofs (rw,relatime,fd=28,pgrp=1,timeout=0,minproto=5,maxproto=5,direct)
c910f04x12v07: hugetlbfs on /dev/hugepages type hugetlbfs (rw,relatime)
c910f04x12v07: mqueue on /dev/mqueue type mqueue (rw,relatime)
c910f04x12v07: debugfs on /sys/kernel/debug type debugfs (rw,relatime)
c910f04x12v07: sunrpc on /run/rpc_pipefs type rpc_pipefs (rw,relatime)
c910f04x12v07: fusectl on /sys/fs/fuse/connections type fusectl (rw,relatime)
c910f04x12v07: tmpfs on /var/tmp type tmpfs (rw,relatime)
c910f04x12v07: tmpfs on /tmp type tmpfs (rw,relatime)
CHECK:rc == 0	[Pass]
CHECK:output =~ on / type tmpfs	[Pass]

RUN:rootimgdir=`lsdef -t osimage  __GETNODEATTR(c910f04x12v07,os)__-__GETNODEATTR(c910f04x12v07,arch)__-netboot-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir.regbak ]; then rm -rf $rootimgdir; mv $rootimgdir.regbak $rootimgdir; fi [Tue May 21 04:55:44 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:if [ -x /usr/bin/goconserver ]; then makegocons -d c910f04x12v07; else makeconservercf -d c910f04x12v07; fi [Tue May 21 04:55:45 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f04x12v07: Deleted

RUN:rm -rf  /install/netboot/__GETNODEATTR(c910f04x12v07,os)__/__GETNODEATTR(c910f04x12v07,arch)__/compute/rootimg.cpio.gz [Tue May 21 04:55:46 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:mv -f /rootimg.cpio.gz.bak /install/netboot/__GETNODEATTR(c910f04x12v07,os)__/__GETNODEATTR(c910f04x12v07,arch)__/compute/rootimg.cpio.gz [Tue May 21 04:55:47 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:rm -rf /install/netboot/__GETNODEATTR(c910f04x12v07,os)__/__GETNODEATTR(c910f04x12v07,arch)__/compute/rootimg [Tue May 21 04:55:48 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:

RUN:mv -f /rootimg.bak /install/netboot/__GETNODEATTR(c910f04x12v07,os)__/__GETNODEATTR(c910f04x12v07,arch)__/compute/rootimg [Tue May 21 04:55:50 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

------END::packimage_m_cpio_c_gzip::Passed::Time:Tue May 21 04:55:51 2019 ::Duration::845 sec------
------Total: 1 , Failed: 0------
```