### PR TITLE
Improve rflash messages

### DIFF
--- a/perl-xCAT/xCAT/PPCrflash.pm
+++ b/perl-xCAT/xCAT/PPCrflash.pm
@@ -528,7 +528,8 @@ sub get_lic_filenames {
     @dirlist = grep /\.rpm$/, @dirlist;
     @dirlist = grep /$1/,     @dirlist;
     if (!scalar(@dirlist)) {
-        $msg = "There isn't a package suitable for $mtms";
+        # the last grep above is  using $1, which is $pns, the output message should help figure out what is wrong
+        $msg = "Existing firmware type is: $pns, no matching firmware package found in directory";
         return ("", "", "", $msg, -1);
     }
     if (scalar(@dirlist) > 1) {

--- a/perl-xCAT/xCAT/PPCrflash.pm
+++ b/perl-xCAT/xCAT/PPCrflash.pm
@@ -225,7 +225,7 @@ sub parse_args {
         return (usage());
     }
 
-    $request->{callback}->({ data => ["It may take considerable time to complete, depending on the number of systems being updated.  In particular, power subsystem updates may take an hour or more if there are many attached managed systems. Please waiting. "] });
+    $request->{callback}->({ data => ["It may take considerable time to complete, depending on the number of systems being updated.  In particular, power subsystem updates may take an hour or more if there are many attached managed systems. Please wait. "] });
 
     if ($request->{hwtype} =~ /^(fsp|bpa)$/ && $opt{activate} =~ /^disruptive$/) {
         $request->{callback}->({ data => ["You can find the log files in the /var/log/xcatd/dfm/rflash/."] });
@@ -844,7 +844,7 @@ sub rflash {
     }
 
 
-    push(@value, [ $hmc, "copy files to $hmc completely" ]);
+    push(@value, [ $hmc, "copying of files to $hmc completed" ]);
 
     ###############################################
     # Now that all the stanzas files have been built and copied to the HMCs,
@@ -886,7 +886,7 @@ sub rflash {
         my $rsp = {};
         $rsp->{data}->[0] = "Error from xdsh. Return Code = $::RUNCMD_RC";
         xCAT::MsgUtils->message("S", $rsp, $::CALLBACK, 1);
-        dpush(\@value, [ $hmc, "failed to run  xdsh" ]);
+        dpush(\@value, [ $hmc, "failed to run xdsh command - $cmd_hmc" ]);
         push(@value, [ $hmc, $rsp->{data}->[0] ]);
         push(@value, [ $hmc, "Failed to upgrade the firmware of $mtms_t  on $hmc" ]);
         return (\@value);

--- a/perl-xCAT/xCAT/PPCrflash.pm
+++ b/perl-xCAT/xCAT/PPCrflash.pm
@@ -376,8 +376,7 @@ sub preprocess_for_rflash {
         my @xmllist = grep /\.xml$/, @dirlist;
         if (@rpmlist == 0 | @xmllist == 0) {
 
-            #send_msg($request, 1, "There isn't any rpm and xml files in the  directory $packages_d!");
-            $callback->({ data => ["There isn't any rpm and xml files in the  directory $packages_d!"] });
+            $callback->({ data => ["There are no rpm and xml files in the directory $packages_d!"] });
             $request = ();
             return -1;
         }


### PR DESCRIPTION
* Remove use of `csmlicutil` on HMC when doing `rflash`

    As described in #6332 the `csmlicutil` is no longer on V9 of HMC. Current xCAT code creates a stanza file and copies it to `/tmp` on HMC. Then xCAT runs `cmslicutil <stanza_file>` command to perform the update. In the PR the process will be changed:
    - Generate stanza file as before, but do not copy it to HMC
    - After the file is generated, read the file on xCAT MN an perform actions for each line in stanza by calling `xdsh`

* Improve messages for rflash:

    When `rflash` runs `xdsh` to flash CEC from HMC and the command fails, it is useful to see which command failed.

Before the PR:
```
rflash Server-8375-42A-SN13C650W -p /mnt/xcat/iso/firmware/ibm/zz_910/b0821a_1832.910_1832F --activate concurrent -V
:
:
c910hmc03: [c910f03c05k10]: copy files to c910hmc03 completely
c910hmc03: [c910f03c05k10]: failed to run  xdsh
c910hmc03: [c910f03c05k10]: Error from xdsh. Return Code = 1
c910hmc03: [c910f03c05k10]: Failed to upgrade the firmware of  8375-42A*13C650W  on c910hmc03
[c910f03c05k10]: 13:58:24 10132 Total Elapsed Time: 12.654 sec

root@c910f03c05k10:~#
```

After PR:
```
rflash Server-8375-42A-SN13C650W -p /mnt/xcat/iso/firmware/ibm/zz_910/b0821a_1832.910_1832F --activate concurrent -V
:
:
c910hmc03: [c910f03c05k10]: copying of files to c910hmc03 completed
c910hmc03: [c910f03c05k10]: failed to run xdsh command - csmlicutil /tmp/klUk3Oz31j
c910hmc03: [c910f03c05k10]: Error from xdsh. Return Code = 1
c910hmc03: [c910f03c05k10]: Failed to upgrade the firmware of  8375-42A*13C650W  on c910hmc03
[c910f03c05k10]: 14:00:33 10208 Total Elapsed Time: 12.655 sec

root@c910f03c05k10:/opt/xcat#
```