### PR TITLE
For Ubuntu 18.04.2, change back to use the original linux-image-generic kernel

### DIFF
--- a/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu18.04.2.ppc64el.pkglist
+++ b/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu18.04.2.ppc64el.pkglist
@@ -4,7 +4,7 @@ nfs-common
 openssl
 isc-dhcp-client
 libc-bin
-linux-image-generic-hwe-18.04
+linux-image-generic
 openssh-server
 openssh-client
 wget


### PR DESCRIPTION
### The PR is to fix issue _#6305_

### The modification include

_##For Ubuntu 18.04.2, change back to use the original linux-image-generic kernel_
