### PR TITLE
Revert "For Ubuntu 18.04.2, change back to use the original linux-image-generic kernel"

### DIFF
--- a/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu18.04.2.ppc64el.pkglist
+++ b/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu18.04.2.ppc64el.pkglist
@@ -4,7 +4,7 @@ nfs-common
 openssl
 isc-dhcp-client
 libc-bin
-linux-image-generic
+linux-image-generic-hwe-18.04
 openssh-server
 openssh-client
 wget


### PR DESCRIPTION
Reverts xcat2/xcat-core#6336

Intend to revert this one. Since issue #6305 only affected the KVM guest run POWER9. But for xCAT user who run bare-metal POWER 9 machine, the HWE kernel is important.