### PR TITLE
refine test.sh to add more debug info

### DIFF
--- a/xCAT-test/autotest/testcase/genesis/cases0
+++ b/xCAT-test/autotest/testcase/genesis/cases0
@@ -38,7 +38,11 @@ label:others,genesis
 description:very if computenode need to do nodeset shell in different net with master will success
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh --check xnba
 check:rc==0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh -c
+check:rc==0
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh --check grub2
+check:rc==0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh -c
 check:rc==0
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh --check petitboot
 check:rc==0


### PR DESCRIPTION
### The PR is to fix https://github.ibm.com/xcat2/task_management/issues/190

The UT
```
[root@c910f04x12v02 /]# /opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh --check xnba
Run command chdef testnode arch=ppc64le cons=ipmi groups=all ip=60.1.1.1 mac=4e:ee:ee:ee:ee:0e netboot=xnba
1 object definitions have been created or modified.
Run command chdef testnode arch=ppc64le cons=ipmi groups=all ip=60.1.1.1 mac=4e:ee:ee:ee:ee:0e netboot=xnba....[Succeed]\n
masterip is 10.4.12.2
masternet is ens3
net2 is ens4
The original net2 ip is 60.3.3.3
Run command ifconfig ens4 60.3.3.3

Run command ifconfig ens4 60.3.3.3....[Succeed]\n
Run command makenetworks
Warning: [c910f04x12v02]: The network entry '10_0_0_0-255_0_0_0' already exists in xCAT networks table. Cannot create a definition for '10_0_0_0-255_0_0_0'
Warning: [c910f04x12v02]: The network entry '60_0_0_0-255_0_0_0' already exists in xCAT networks table. Cannot create a definition for '60_0_0_0-255_0_0_0'

Run command makenetworks....[Succeed]\n
Run command nodeset testnode shell
testnode: shell
Run command nodeset testnode shell....[Succeed]\n
Run command ifconfig ens4 60.3.3.3

Run command ifconfig ens4 60.3.3.3....[Succeed]\n
Check if nodeset testnode shell is added to /tftpboot/xcat/xnba/nodes/
imgargs kernel quiet xcatd=60.3.3.3:3001 destiny=shell BOOTIF=01-${netX/machyp}
```


The whole case ut
```
------START::nodeset_shell_incorrectmasterip::Time:Fri May 24 05:02:52 2019------

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh --check xnba [Fri May 24 05:02:52 2019]
ElapsedTime:31 sec
RETURN rc = 0
OUTPUT:
Run command chdef testnode arch=ppc64le cons=ipmi groups=all ip=60.1.1.1 mac=4e:ee:ee:ee:ee:0e netboot=xnba
1 object definitions have been created or modified.
Run command chdef testnode arch=ppc64le cons=ipmi groups=all ip=60.1.1.1 mac=4e:ee:ee:ee:ee:0e netboot=xnba....[Succeed]\n
The original net2 ip is 60.3.3.3
Run command ifconfig ens4 60.3.3.3

Run command ifconfig ens4 60.3.3.3....[Succeed]\n
Run command makenetworks
Warning: [c910f04x12v02]: The network entry '10_0_0_0-255_0_0_0' already exists in xCAT networks table. Cannot create a definition for '10_0_0_0-255_0_0_0'
Warning: [c910f04x12v02]: The network entry '60_0_0_0-255_0_0_0' already exists in xCAT networks table. Cannot create a definition for '60_0_0_0-255_0_0_0'

Run command makenetworks....[Succeed]\n
Run command nodeset testnode shell
testnode: shell
Run command nodeset testnode shell....[Succeed]\n
Run command ifconfig ens4 60.3.3.3

Run command ifconfig ens4 60.3.3.3....[Succeed]\n
Check if nodeset testnode shell is added to /tftpboot/xcat/xnba/nodes/
imgargs kernel quiet xcatd=60.3.3.3:3001 destiny=shell BOOTIF=01-${netX/machyp}
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh -c [Fri May 24 05:03:23 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh --check grub2 [Fri May 24 05:03:25 2019]
ElapsedTime:32 sec
RETURN rc = 0
OUTPUT:
Run command chdef testnode arch=ppc64le cons=ipmi groups=all ip=60.1.1.1 mac=4e:ee:ee:ee:ee:0e netboot=grub2
1 object definitions have been created or modified. New object definitions 'testnode' have been created.
Run command chdef testnode arch=ppc64le cons=ipmi groups=all ip=60.1.1.1 mac=4e:ee:ee:ee:ee:0e netboot=grub2....[Succeed]\n
The original net2 ip is 60.3.3.3
Run command ifconfig ens4 60.3.3.3

Run command ifconfig ens4 60.3.3.3....[Succeed]\n
Run command makenetworks
Warning: [c910f04x12v02]: The network entry '10_0_0_0-255_0_0_0' already exists in xCAT networks table. Cannot create a definition for '10_0_0_0-255_0_0_0'

Run command makenetworks....[Succeed]\n
Run command nodeset testnode shell
testnode: shell
Run command nodeset testnode shell....[Succeed]\n
Run command ifconfig ens4 60.3.3.3

Run command ifconfig ens4 60.3.3.3....[Succeed]\n
Check if nodeset testnode shell is added to /tftpboot/boot/grub2/
    linux /xcat/genesis.kernel.ppc64 quiet xcatd=60.3.3.3:3001 destiny=shell
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh -c [Fri May 24 05:03:57 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh --check petitboot [Fri May 24 05:03:58 2019]
ElapsedTime:32 sec
RETURN rc = 0
OUTPUT:
Run command chdef testnode arch=ppc64le cons=ipmi groups=all ip=60.1.1.1 mac=4e:ee:ee:ee:ee:0e netboot=petitboot
1 object definitions have been created or modified. New object definitions 'testnode' have been created.
Run command chdef testnode arch=ppc64le cons=ipmi groups=all ip=60.1.1.1 mac=4e:ee:ee:ee:ee:0e netboot=petitboot....[Succeed]\n
The original net2 ip is 60.3.3.3
Run command ifconfig ens4 60.3.3.3

Run command ifconfig ens4 60.3.3.3....[Succeed]\n
Run command makenetworks
Warning: [c910f04x12v02]: The network entry '10_0_0_0-255_0_0_0' already exists in xCAT networks table. Cannot create a definition for '10_0_0_0-255_0_0_0'

Run command makenetworks....[Succeed]\n
Run command nodeset testnode shell
testnode: shell
Run command nodeset testnode shell....[Succeed]\n
Run command ifconfig ens4 60.3.3.3

Run command ifconfig ens4 60.3.3.3....[Succeed]\n
Check if nodeset testnode shell is added to /tftpboot/petitboot/
        echo "The original net2 ip is $net2ip"
	append "quiet xcatd=60.3.3.3:3001 destiny=shell"
CHECK:rc == 0	[Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/genesis/test.sh -c [Fri May 24 05:04:30 2019]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

------END::nodeset_shell_incorrectmasterip::Passed::Time:Fri May 24 05:04:32 2019 ::Duration::100 sec------
------Total: 1 , Failed: 0------
```