### PR TITLE
Add bzip2 to rhels8 pkglist

### DIFF
--- a/xCAT-server/share/xcat/install/rh/compute.rhels8.pkglist
+++ b/xCAT-server/share/xcat/install/rh/compute.rhels8.pkglist
@@ -8,3 +8,4 @@ util-linux
 wget
 python3
 tar
+bzip2

--- a/xCAT-server/share/xcat/install/rh/service.rhels8.pkglist
+++ b/xCAT-server/share/xcat/install/rh/service.rhels8.pkglist
@@ -12,3 +12,4 @@ perl-DBD-Pg
 unixODBC
 python3
 tar
+bzip2

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels8.ppc64le.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels8.ppc64le.pkglist
@@ -10,3 +10,4 @@ util-linux
 wget
 python3
 tar
+bzip2

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels8.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels8.x86_64.pkglist
@@ -10,3 +10,4 @@ util-linux
 wget
 python3
 tar
+bzip2

--- a/xCAT-server/share/xcat/netboot/rh/service.rhels8.ppc64le.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/service.rhels8.ppc64le.pkglist
@@ -12,3 +12,4 @@ perl-DBD-MySQL
 perl-DBD-Pg
 python3
 tar
+bzip2

--- a/xCAT-server/share/xcat/netboot/rh/service.rhels8.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/service.rhels8.x86_64.pkglist
@@ -12,3 +12,4 @@ perl-DBD-MySQL
 perl-DBD-Pg
 python3
 tar
+bzip2


### PR DESCRIPTION
For the rhels8 regression test cases, it failed on decompress
```
2019-06-05 07:14:51 14206 Notice: [prepare_mn] start to prepare mn c910f03c09k15.......
2019-06-05 07:14:51 14206 Notice: [prepare_mn] starting to copy core-rpms-snap.tar.bz2 and xcat-dep-201905220119.tar.bz2 to c910f03c09k15
2019-06-05 07:14:55 14206 Notice: [prepare_mn] copy core-rpms-snap.tar.bz2 and xcat-dep-201905220119.tar.bz2 to c910f03c09k15...[done]
2019-06-05 07:14:55 14206 Notice: [prepare_mn] starting to copy go-xcat to c910f03c09k15
2019-06-05 07:14:56 14206 Notice: [prepare_mn] copy go-xcat to c910f03c09k15...[done]
2019-06-05 07:14:56 14206 Notice: [prepare_mn] starting to decompress xcat packages.....
2019-06-05 07:14:57 14206 Fatal error: [prepare_mn] decompress core-rpms-snap.tar.bz2 on c910f03c09k15 failed
2019-06-05 07:14:58 13389 Fatal error: [[main]]: prepare c910f03c09k15 failed
2019-06-05 07:14:59 13389 Notice: [[main]]: regression test return on time
```

manually run the command on the test machine:
```
[root@c910f03c17k07 ~]# xdsh c910f03c09k15 "cd / && tar xvf /core-rpms-snap.tar.bz2"
[c910f03c17k07]: c910f03c09k15: tar (child): cannot run bzip2: No such file or directory
c910f03c09k15: tar (child): trying lbzip2
c910f03c09k15: tar (child): lbzip2: Cannot exec: No such file or directory
c910f03c09k15: tar (child): Error is not recoverable: exiting now
[c910f03c17k07]: c910f03c09k15: tar: Child returned status 2
c910f03c09k15: tar: Error is not recoverable: exiting now
```
For the bzip2 file, tar specifically tries to call bzip2 -d to decompress the bzipped archive, looks like on the rhel8 MN, there is no bzip2 command available
```
[root@c910f03c09k15 /]# which bzip2
/usr/bin/which: no bzip2 in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin)
```