### PR TITLE
Change the build script for xcat-dep tar ball, due to internal environment changes 

### DIFF
--- a/builddep.sh
+++ b/builddep.sh
@@ -68,8 +68,8 @@ done
 GNU_KEYDIR="$HOME/.gnupg"
 MACROS=$HOME/.rpmmacros
 if [[ -d ${GNU_KEYDIR} ]]; then
-	echo "WARNING: The gnupg key dir: $GNU_KEYDIR exists, it will be overwitten. Stop."
-	echo "WARNING: To continue, remove it and rerun the script."
+	echo "ERROR: The gnupg key dir: $GNU_KEYDIR exists, it will be overwitten. Stop."
+	echo "ERROR:    To continue, remove it and rerun the script."
 	exit 1
 fi
 

--- a/builddep.sh
+++ b/builddep.sh
@@ -65,6 +65,14 @@ for pkg in ${REQPKG[*]}; do
 	fi
 done
 
+GNU_KEYDIR="$HOME/.gnupg"
+MACROS=$HOME/.rpmmacros
+if [[ -d ${GNU_KEYDIR} ]]; then
+	echo "WARNING: The gnupg key dir: $GNU_KEYDIR exists, it will be overwitten. Stop."
+	echo "WARNING: To continue, remove it and rerun the script."
+	exit 1
+fi
+
 # set grep to quiet by default
 GREP="grep -q"
 if [ "$VERBOSE" = "1" -o "$VERBOSE" = "yes" ]; then
@@ -123,15 +131,8 @@ cd $DESTDIR/xcat-dep
 # add a comment to indicate the latest xcat-dep tar ball name
 sed -i -e "s#REPLACE_LATEST_SNAP_LINE#The latest xcat-dep tar ball is ${DFNAME}#g" README
 
-GNU_KEYDIR="$HOME/.gnupg"
-MACROS=$HOME/.rpmmacros
 if [ "$OSNAME" != "AIX" ]; then
 	# Get gpg keys in place
-        if [[ -d ${GNU_KEYDIR} ]]; then
-		echo "WARNING: The gnupg key dir: $GNU_KEYDIR exists, it will be overwitten. Stop."
-		echo "WARNING: To continue, remove it and rerun the script."
-		exit 1
-	fi
 	mkdir -p ${GNU_KEYDIR}
 	checkrc
 	for i in pubring.gpg secring.gpg trustdb.gpg; do

--- a/builddep.sh
+++ b/builddep.sh
@@ -277,15 +277,16 @@ fi
 chgrp -R -h $SYSGRP *
 chmod -R g+w *
 
-echo "===> Building the tarball..."
+TARBALL_WORKING_DIR="${XCATCOREDIR}/${DESTDIR}"
+echo "===> Building the tarball at: ${TARBALL_WORKING_DIR} ..."
 #
 # Want to stay one level above xcat-dep so that the script 
 # can rsync the directory up to xcat.org. 
 #
 # DO NOT CHANGE DIRECTORY AFTER THIS POINT!!
 #
-cd ..
-pwd
+
+cd ${TARBALL_WORKING_DIR}
 
 verbosetar=""
 if [ -n "$VERBOSEMODE" ]; then

--- a/builddep.sh
+++ b/builddep.sh
@@ -98,6 +98,7 @@ if [ -z "$DESTDIR" ]; then
 	fi
 fi
 
+echo "INFO: xcat-dep package name: $DFNAME"
 echo "INFO: xcat-dep package will be created here: $XCATCOREDIR/$DESTDIR"
 
 # Create a function to check the return code, 
@@ -117,7 +118,7 @@ checkrc
 echo "Syncing RPMs from $GSA/ to $DESTDIR/xcat-dep ..."
 rsync -ilrtpu --delete $GSA/ $DESTDIR/xcat-dep
 checkrc
-ls -ltr $DESTDIR/xcat-dep
+ls $DESTDIR/xcat-dep
 cd $DESTDIR/xcat-dep
 
 # add a comment to indicate the latest xcat-dep tar ball name
@@ -126,6 +127,7 @@ sed -i -e "s#REPLACE_LATEST_SNAP_LINE#The latest xcat-dep tar ball is ${DFNAME}#
 if [ "$OSNAME" != "AIX" ]; then
 	# Get gpg keys in place
 	mkdir -p $HOME/.gnupg
+        checkrc
 	for i in pubring.gpg secring.gpg trustdb.gpg; do
 		if [ ! -f $HOME/.gnupg/$i ] || [ `wc -c $HOME/.gnupg/$i|cut -f 1 -d' '` == 0 ]; then
 			rm -f $HOME/.gnupg/$i

--- a/builddep.sh
+++ b/builddep.sh
@@ -47,7 +47,6 @@ if [ "$OSNAME" == "AIX" ]; then
 else
 	DFNAME=xcat-dep-`date +%Y%m%d%H%M`.tar.bz2
 	GSA=/gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep
-	export HOME=/root		# This is so rpm and gpg will know home, even in sudo
 fi
 
 if [ ! -d $GSA ]; then
@@ -90,11 +89,11 @@ if [ -z "$DESTDIR" ]; then
 	if [[ $XCATCOREDIR == *"xcat2_autobuild_daily_builds"* ]]; then
 		# This shows we are in the daily build environment path, create the 
 		# deps package at the top level of the build directory
-		DESTDIR=../../xcat-dep
+		DESTDIR=../../xcat-dep-build
 	else
 		# This means we are building in some other clone of xcat-core, 
 		# so just place the destination one level up.
-		DESTDIR=../xcat-dep
+		DESTDIR=../xcat-dep-build
 	fi
 fi
 
@@ -128,8 +127,13 @@ GNU_KEYDIR="$HOME/.gnupg"
 MACROS=$HOME/.rpmmacros
 if [ "$OSNAME" != "AIX" ]; then
 	# Get gpg keys in place
+        if [[ -d ${GNU_KEYDIR} ]]; then
+		echo "WARNING: The gnupg key dir: $GNU_KEYDIR exists, it will be overwitten. Stop."
+		echo "WARNING: To continue, remove it and rerun the script."
+		exit 1
+	fi
 	mkdir -p ${GNU_KEYDIR}
-        checkrc
+	checkrc
 	for i in pubring.gpg secring.gpg trustdb.gpg; do
 		if [ ! -f ${GNU_KEYDIR}/$i ] || [ `wc -c ${GNU_KEYDIR}/$i|cut -f 1 -d' '` == 0 ]; then
 			rm -f ${GNU_KEYDIR}/$i

--- a/builddep.sh
+++ b/builddep.sh
@@ -124,20 +124,21 @@ cd $DESTDIR/xcat-dep
 # add a comment to indicate the latest xcat-dep tar ball name
 sed -i -e "s#REPLACE_LATEST_SNAP_LINE#The latest xcat-dep tar ball is ${DFNAME}#g" README
 
+GNU_KEYDIR="$HOME/.gnupg"
+MACROS=$HOME/.rpmmacros
 if [ "$OSNAME" != "AIX" ]; then
 	# Get gpg keys in place
-	mkdir -p $HOME/.gnupg
+	mkdir -p ${GNU_KEYDIR}
         checkrc
 	for i in pubring.gpg secring.gpg trustdb.gpg; do
-		if [ ! -f $HOME/.gnupg/$i ] || [ `wc -c $HOME/.gnupg/$i|cut -f 1 -d' '` == 0 ]; then
-			rm -f $HOME/.gnupg/$i
-			cp $GSA/../keys/$i $HOME/.gnupg
-			chmod 600 $HOME/.gnupg/$i
+		if [ ! -f ${GNU_KEYDIR}/$i ] || [ `wc -c ${GNU_KEYDIR}/$i|cut -f 1 -d' '` == 0 ]; then
+			rm -f ${GNU_KEYDIR}/$i
+			cp $GSA/../keys/$i ${GNU_KEYDIR}
+			chmod 600 ${GNU_KEYDIR}/$i
 		fi
 	done
 
 	# Tell rpm to use gpg to sign
-	MACROS=$HOME/.rpmmacros
 	if ! $GREP -q '%_signature gpg' $MACROS 2>/dev/null; then
 		echo '%_signature gpg' >> $MACROS
 	fi

--- a/builddep.sh
+++ b/builddep.sh
@@ -178,11 +178,11 @@ if [ "$OSNAME" != "AIX" ]; then
 	echo "===> Making sure that the mklocalrepo.sh file contains execute permission ..." 
         ls -ltr ${SCRIPTPATH}/${WORKING_TARGET_DIR}/mklocalrepo.sh
 	if [[ ! -x "${SCRIPTPATH}/${WORKING_TARGET_DIR}/mklocalrepo.sh" ]]; then
-		echo "==> Adding execute ..."
+		echo "===> --- found not execute, changing +x ..."
 		chmod +x ${SCRIPTPATH}/${WORKING_TARGET_DIR}/mklocalrepo.sh
 	fi
 
-	echo "==> Checking if 'replacelinks' is in the xcat-deps, removing if there ..." 
+	echo "===> Checking if 'replacelinks' is in the xcat-deps, removing if there ..." 
 	if [[ -f ${SCRIPTPATH}/${WORKING_TARGET_DIR}/replacelinks ]]; then
 		rm -f ${SCRIPTPATH}/${WORKING_TARGET_DIR}/replacelinks
 	fi

--- a/builddep.sh
+++ b/builddep.sh
@@ -175,12 +175,16 @@ if [ "$OSNAME" != "AIX" ]; then
 	# Modify xcat-dep.repo files to point to the correct place
 	echo "===> Modifying the xcat-dep.repo files to point to the correct location..."
 
-	# make sure the mklocalrepo.sh script has execute permission (to ensure quality control)
 	echo "===> Making sure that the mklocalrepo.sh file contains execute permission ..." 
         ls -ltr ${SCRIPTPATH}/${WORKING_TARGET_DIR}/mklocalrepo.sh
 	if [[ ! -x "${SCRIPTPATH}/${WORKING_TARGET_DIR}/mklocalrepo.sh" ]]; then
 		echo "==> Adding execute ..."
 		chmod +x ${SCRIPTPATH}/${WORKING_TARGET_DIR}/mklocalrepo.sh
+	fi
+
+	echo "==> Checking if 'replacelinks' is in the xcat-deps, removing if there ..." 
+	if [[ -f ${SCRIPTPATH}/${WORKING_TARGET_DIR}/replacelinks ]]; then
+		rm -f ${SCRIPTPATH}/${WORKING_TARGET_DIR}/replacelinks
 	fi
 fi
 

--- a/builddep.sh
+++ b/builddep.sh
@@ -89,11 +89,10 @@ else
 fi
 
 SCRIPT=$(readlink -f "$0")
-SCRIPTPATH=$(dirname "$SCRIPT")
-echo "INFO: Running script from here: $SCRIPTPATH ..."
+XCATCOREDIR=$(dirname "$SCRIPT")
+echo "INFO: Running script from here: $XCATCOREDIR ..."
 
-cd $SCRIPTPATH
-XCATCOREDIR=`/bin/pwd`
+cd $XCATCOREDIR 
 if [ -z "$DESTDIR" ]; then
 	if [[ $XCATCOREDIR == *"xcat2_autobuild_daily_builds"* ]]; then
 		# This shows we are in the daily build environment path, create the 
@@ -176,15 +175,15 @@ if [ "$OSNAME" != "AIX" ]; then
 	echo "===> Modifying the xcat-dep.repo files to point to the correct location..."
 
 	echo "===> Making sure that the mklocalrepo.sh file contains execute permission ..." 
-        ls -ltr ${SCRIPTPATH}/${WORKING_TARGET_DIR}/mklocalrepo.sh
-	if [[ ! -x "${SCRIPTPATH}/${WORKING_TARGET_DIR}/mklocalrepo.sh" ]]; then
+        ls -ltr ${XCATCOREDIR}/${WORKING_TARGET_DIR}/mklocalrepo.sh
+	if [[ ! -x "${XCATCOREDIR}/${WORKING_TARGET_DIR}/mklocalrepo.sh" ]]; then
 		echo "===> --- found not execute, changing +x ..."
-		chmod +x ${SCRIPTPATH}/${WORKING_TARGET_DIR}/mklocalrepo.sh
+		chmod +x ${XCATCOREDIR}/${WORKING_TARGET_DIR}/mklocalrepo.sh
 	fi
 
 	echo "===> Checking if 'replacelinks' is in the xcat-deps, removing if there ..." 
-	if [[ -f ${SCRIPTPATH}/${WORKING_TARGET_DIR}/replacelinks ]]; then
-		rm -f ${SCRIPTPATH}/${WORKING_TARGET_DIR}/replacelinks
+	if [[ -f ${XCATCOREDIR}/${WORKING_TARGET_DIR}/replacelinks ]]; then
+		rm -f ${XCATCOREDIR}/${WORKING_TARGET_DIR}/replacelinks
 	fi
 fi
 
@@ -280,7 +279,9 @@ chmod -R g+w *
 
 echo "===> Building the tarball..."
 #
-# Want to stay above xcat-dep so we can rsync the whole directory
+# Want to stay one level above xcat-dep so that the script 
+# can rsync the directory up to xcat.org. 
+#
 # DO NOT CHANGE DIRECTORY AFTER THIS POINT!!
 #
 cd ..

--- a/builddep.sh
+++ b/builddep.sh
@@ -12,7 +12,7 @@
 # - createrepo command needs to be present on the build machine
 #
 # Usage:  builddep.sh [attr=value attr=value ...]
-#       DESTDIR=<dir> - the dir to place the dep tarball in.  The default is ../../xcat-dep,
+#       DESTDIR=<dir> - the dir to place the dep tarball in.  The default is ../../xcat-dep-build,
 #                       relative to where this script is located.
 #       UP=0 or UP=1  - override the default upload behavior
 #       FRSYUM=0      - put the directory of individual rpms in the project web area instead


### PR DESCRIPTION
Internally, we've moved build servers to docker containers for xcat-core, so the build server that we used  to run build of deps package is no longer there. 

It would be far easier to be able to build the package from our git clone of `xcat-core` since it's just a key signing and tarup process.. 

This pull request makes changes to the build script  to allow for this script to be able  to run in our own home directories, given we have access to the files in the shared filesystem. 

Also taking this opportunity to clean up the build script and check non zero return code so it doesn't  run rogue. 
