### PR TITLE
Pick correct pkglist/tmpl files based on the osvers

### DIFF
--- a/xCAT-server/lib/perl/xCAT/SvrUtils.pm
+++ b/xCAT-server/lib/perl/xCAT/SvrUtils.pm
@@ -482,7 +482,9 @@ sub getsynclistfile()
 
 sub get_os_search_list {
     my $os = shift;
-    my @word = split(/\./, $os);
+    #example: for os=rhels7.6-alternate
+    my ($baseos, $alter) = split(/\-/, $os);
+    my @word = split(/\./, $baseos);
     my @list = ();
 
     while ($word[-1] =~ /^[0-9]+$/) {
@@ -713,7 +715,7 @@ sub update_tables_with_templates
     my $genos = $osver;
     $genos =~ s/\..*//;
     if ($genos =~ /rh.*s(\d*)/) {
-        $genos = "rhel$1";
+        $genos = "rhels$1";
     }
 
 
@@ -935,7 +937,7 @@ sub update_tables_with_mgt_image
     my $genos = $osver;
     $genos =~ s/\..*//;
     if ($genos =~ /rh.*s(\d*)/) {
-        $genos = "rhel$1";
+        $genos = "rhels$1";
     }
 
     #if the osver does not match the osver of MN, return
@@ -1141,7 +1143,7 @@ sub update_tables_with_diskless_image
     my $genos = $osver;
     $genos =~ s/\..*//;
     if ($genos =~ /rh.*s(\d*)/) {
-        $genos = "rhel$1";
+        $genos = "rhels$1";
     }
 
     #print "osver=$osver, arch=$arch, osname=$osname, genos=$genos, profile=$profile\n";


### PR DESCRIPTION
The PR is to fix issue #6353 

### The modification include

_##item1_
split os if it has  string at the end, like `rhels7.6-alternate`

_##item2_
change genos from `rhel` to `rhels`,  all the most recently pktlist/tmpl files has `rhels`

### The UT result
`##The UT output##`
```
# lsdef -t osimage rhels7.6-alternate-ppc64le-install-service
Object name: rhels7.6-alternate-ppc64le-install-service
    imagetype=linux
    osarch=ppc64le
    osdistroname=rhels7.6-alternate-ppc64le
    osname=Linux
    osvers=rhels7.6-alternate
    otherpkgdir=/install/post/otherpkgs/rhels7.6-alternate/ppc64le
    otherpkglist=/opt/xcat/share/xcat/install/rh/service.rhels7.ppc64le.otherpkgs.pkglist
    pkgdir=/install/rhels7.6-alternate/ppc64le
    pkglist=/opt/xcat/share/xcat/install/rh/service.rhels7.ppc64le.pkglist
    postscripts=servicenode
    profile=service
    provmethod=install
    template=/opt/xcat/share/xcat/install/rh/service.rhels7.tmpl
```
