### PR TITLE
Add verification test case for copycds

### DIFF
--- a/xCAT-test/autotest/testcase/copycds/cases0
+++ b/xCAT-test/autotest/testcase/copycds/cases0
@@ -9,6 +9,8 @@ check:output=~Copying media to /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($
 check:output=~Media copy operation successful
 cmd:ls /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__
 check:rc==0
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/copycds/copycds.sh __GETNODEATTR($$CN,os)__
+check:rc==0
 end
 
 start:lskmodules_o

--- a/xCAT-test/autotest/testcase/copycds/copycds.sh
+++ b/xCAT-test/autotest/testcase/copycds/copycds.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+if [[ -z ${1} ]]; then
+    echo "ERROR, pass in the '\$OS' variable as the second argument"
+    exit  1
+fi
+OS=${1}
+
+if [[ $OS != *"rhels"* ]]; then
+    echo "INFO: will not run this test for $OS"
+    exit  0
+fi
+
+MAJOR_OS_VER=${OS%.*}
+if [[ $OS == *"$MAJOR_OS_VER"* ]]; then
+    IFS='
+'
+    for image in `lsdef -t osimage -i template -c | grep $OS | grep "install"`; do
+        THE_NAME=`echo $image | cut -d' ' -f1`
+        THE_TEMPLATE=`echo $image | cut -d' ' -f2`
+        TEMPLATE_FILE=`echo $THE_TEMPLATE | cut -d= -f2`
+
+        if [[ $TEMPLATE_FILE != *"$MAJOR_OS_VER"* ]]; then
+            echo "ERROR - template attribute not set correctly when copycds for $THE_NAME"
+            echo -e "ERROR - $TEMPLATE_FILE"
+            exit  1
+        else
+            echo "Template file looks good for $THE_NAME"
+            echo -e "\t$THE_TEMPLATE"
+        fi
+    done
+fi
+
+exit 0


### PR DESCRIPTION
Add a verification test case for PR #6354 

for the autotest `copycds_iso`, add a verification script to verify the template attribute has correct os version.  

### The UT result
1) good case with `os=rhels7.5`
```
RUN:copycds /RHEL-7.5-Server-ppc64le-dvd1-stable.iso [Tue Jun 11 11:19:45 2019]
ElapsedTime:30 sec
RETURN rc = 0
OUTPUT:
Copying media to /install/rhels7.5/ppc64le
Media copy operation successful
CHECK:rc == 0   [Pass]
CHECK:output =~ Copying media to /install/rhels7.5/ppc64le      [Pass]
CHECK:output =~ Media copy operation successful [Pass]

RUN:ls /install/__GETNODEATTR(f6u13k18,os)__/__GETNODEATTR(f6u13k18,arch)__ [Tue Jun 11 11:20:16 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
addons
boot
EULA
extra_files.json
GPL
images
LiveOS
media.repo
Packages
ppc
repodata
RPM-GPG-KEY-redhat-beta
RPM-GPG-KEY-redhat-release
TRANS.TBL
CHECK:rc == 0   [Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/copycds/copycds.sh __GETNODEATTR(f6u13k18,os)__ [Tue Jun 11 11:20:17 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Template file looks good for rhels7.5-ppc64le-install-compute:
        template=/opt/xcat/share/xcat/install/rh/compute.rhels7.tmpl
Template file looks good for rhels7.5-ppc64le-install-service:
        template=/opt/xcat/share/xcat/install/rh/service.rhels7.tmpl
CHECK:rc == 0   [Pass]
```
2) bad case with os=rhels7.6-alternate
```
RUN:copycds /Pegas-7.6-Server-ppc64le-dvd1-stable.iso [Tue Jun 11 11:22:23 2019]
ElapsedTime:30 sec
RETURN rc = 0
OUTPUT:
Copying media to /install/rhels7.6-alternate/ppc64le
Media copy operation successful
CHECK:rc == 0   [Pass]
CHECK:output =~ Copying media to /install/rhels7.6-alternate/ppc64le    [Pass]
CHECK:output =~ Media copy operation successful [Pass]

RUN:ls /install/__GETNODEATTR(f6u13k18,os)__/__GETNODEATTR(f6u13k18,arch)__ [Tue Jun 11 11:22:54 2019]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
boot
EULA
extra_files.json
GPL
images
LiveOS
media.repo
Packages
ppc
repodata
RPM-GPG-KEY-redhat-beta
RPM-GPG-KEY-redhat-release
TRANS.TBL
CHECK:rc == 0   [Pass]

RUN:/opt/xcat/share/xcat/tools/autotest/testcase/copycds/copycds.sh __GETNODEATTR(f6u13k18,os)__ [Tue Jun 11 11:22:54 2019]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
ERROR - template attribute not set correctly when copycds for rhels7.6-alternate-ppc64le-install-compute:
ERROR - /opt/xcat/share/xcat/install/rh/compute.tmpl
CHECK:rc == 0   [Failed]
```

