### PR TITLE
copycds_iso test case failed if os has multiple '.'

### DIFF
--- a/xCAT-test/autotest/testcase/copycds/copycds.sh
+++ b/xCAT-test/autotest/testcase/copycds/copycds.sh
@@ -11,7 +11,7 @@ if [[ $OS != *"rhels"* ]]; then
     exit  0
 fi
 
-MAJOR_OS_VER=${OS%.*}
+MAJOR_OS_VER=`echo $OS | cut -d'.' -f1`
 if [[ $OS == *"$MAJOR_OS_VER"* ]]; then
     IFS='
 '


### PR DESCRIPTION
For issue #6353 and PR #6355 

fixes from PR #6355 failed if `os=rhels8.0.0`
```
RUN:/opt/xcat/share/xcat/tools/autotest/testcase/copycds/copycds.sh rhels8.0.0 [Wed Jun 12 08:52:41 2019]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
ERROR - template attribute not set correctly when copycds for rhels8.0.0-x86_64-install-compute:
ERROR - /opt/xcat/share/xcat/install/rh/compute.rhels8.tmpl
CHECK:rc == 0   [Failed]

```

the line of code `MAJOR_OS_VER=${OS%.*}`  picks major OS to last `.` , to fix this issue, will pick the OS major to first `.`.

Unit test:
```
RUN:/opt/xcat/share/xcat/tools/autotest/testcase/copycds/copycds.sh __GETNODEATTR(c910f03c09k17,os)__ [Wed Jun 12 12:01:01 2019]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Template file looks good for rhels8.0.0-ppc64le-install-compute:
        template=/opt/xcat/share/xcat/install/rh/compute.rhels8.tmpl
Template file looks good for rhels8.0.0-ppc64le-install-service:
        template=/opt/xcat/share/xcat/install/rh/service.rhels8.tmpl
CHECK:rc == 0   [Pass]

```

 

