### PR TITLE
Use . instead of source to source xcat.sh file

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/restartxcatd.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/restartxcatd.1.rst
@@ -29,21 +29,28 @@ DESCRIPTION
 
 The \ **restartxcatd**\  command restarts the xCAT daemon (xcatd).
 
-\ **Linux Specific**\ 
+\ **Linux Specific**\ :
 
 
 It will perform the xcatd \ *fast restart*\ . The xcatd \ *fast restart*\  is a specific restart which has two advantages compares to the \ *stop*\  and then \ *start*\ .
-    1. The interval of xcatd out of service is very short.
-    2. The in processing request which initiated by old xcatd will not be stopped by force. The old xcatd will hand over the sockets to new xcatd, but old xcat will still be waiting for the in processing request to finish before the exit.
-
-It does the same thing as 'service xcatd restart' on NON-systemd enabled Operating System like rh6.x and sles11.x. But for the systemd enabled Operating System like rh7 and sles12, the 'service xcatd restart' just do the \ *stop*\  and \ *start*\  instead of xcatd \ *fast restart*\ .
-
-It's recommended to use \ **restartxcatd**\  command to restart xcatd on systemd enable system like rh7 and sles12 instead of 'service xcatd restart' or 'systemctl restart xcatd'.
-
-\ **AIX Specific**\ 
 
 
-It runs 'stopsrc -s xcatd' to stop xcatd first if xcatd is active, then runs 'startsrc -s xcatd' to start xcatd.
+1. The interval of xcatd out of service is very short.
+
+
+
+2. The in processing request which initiated by old xcatd will not be stopped by force. The old xcatd will hand over the sockets to new xcatd, but old xcat will still be waiting for the in processing request to finish before the exit.
+
+
+
+It does the same thing as \ **service xcatd restart**\  on NON-systemd enabled Operating System like rh6.x and sles11.x. But for the systemd enabled Operating System like rh7 and sles12, the \ **service xcatd restart**\  will just do the \ *stop*\  and \ *start*\  instead of xcatd \ *fast restart*\ .
+
+It's recommended to use \ **restartxcatd**\  command to restart xcatd on systemd enabled system like rh7 and sles12 instead of \ **service xcatd restart**\  or \ **systemctl restart xcatd**\ .
+
+\ **AIX Specific**\ :
+
+
+It runs \ **stopsrc -s xcatd**\  to stop xcatd first if xcatd is active, then runs \ **startsrc -s xcatd**\  to start xcatd.
 
 If the xcatd subsystem was not created, \ **restartxcatd**\  will create it automatically.
 

--- a/xCAT-client/pods/man1/restartxcatd.1.pod
+++ b/xCAT-client/pods/man1/restartxcatd.1.pod
@@ -11,25 +11,31 @@ B<restartxcatd> [[B<-h>|B<--help>] | [B<-v>|B<--version>] | [B<-r>|B<--reload>]]
 
 The B<restartxcatd> command restarts the xCAT daemon (xcatd).
 
-B<Linux Specific>
+B<Linux Specific>:
+
+=over 4
+
+It will perform the xcatd I<fast restart>. The xcatd I<fast restart> is a specific restart which has two advantages compares to the I<stop> and then I<start>.
 
 =over 2
 
-It will perform the xcatd I<fast restart>. The xcatd I<fast restart> is a specific restart which has two advantages compares to the I<stop> and then I<start>.
-    1. The interval of xcatd out of service is very short.
-    2. The in processing request which initiated by old xcatd will not be stopped by force. The old xcatd will hand over the sockets to new xcatd, but old xcat will still be waiting for the in processing request to finish before the exit.
+=item 1. The interval of xcatd out of service is very short.
 
-It does the same thing as 'service xcatd restart' on NON-systemd enabled Operating System like rh6.x and sles11.x. But for the systemd enabled Operating System like rh7 and sles12, the 'service xcatd restart' just do the I<stop> and I<start> instead of xcatd I<fast restart>.
-
-It's recommended to use B<restartxcatd> command to restart xcatd on systemd enable system like rh7 and sles12 instead of 'service xcatd restart' or 'systemctl restart xcatd'.
+=item 2. The in processing request which initiated by old xcatd will not be stopped by force. The old xcatd will hand over the sockets to new xcatd, but old xcat will still be waiting for the in processing request to finish before the exit.
 
 =back
 
-B<AIX Specific>
+It does the same thing as B<service xcatd restart> on NON-systemd enabled Operating System like rh6.x and sles11.x. But for the systemd enabled Operating System like rh7 and sles12, the B<service xcatd restart> will just do the I<stop> and I<start> instead of xcatd I<fast restart>.
 
-=over 2
+It's recommended to use B<restartxcatd> command to restart xcatd on systemd enabled system like rh7 and sles12 instead of B<service xcatd restart> or B<systemctl restart xcatd>.
 
-It runs 'stopsrc -s xcatd' to stop xcatd first if xcatd is active, then runs 'startsrc -s xcatd' to start xcatd.
+=back
+
+B<AIX Specific>:
+
+=over 4
+
+It runs B<stopsrc -s xcatd> to stop xcatd first if xcatd is active, then runs B<startsrc -s xcatd> to start xcatd.
 
 If the xcatd subsystem was not created, B<restartxcatd> will create it automatically.
 

--- a/xCAT-server/sbin/restartxcatd
+++ b/xCAT-server/sbin/restartxcatd
@@ -70,7 +70,7 @@ if (xCAT::Utils->isLinux())
 {
     print "Restarting xCATd                                           ";
     if (-r "/etc/profile.d/xcat.sh") {
-        $cmd = "source /etc/profile.d/xcat.sh;";
+        $cmd = ". /etc/profile.d/xcat.sh;";
     }
 
     $cmd .= "xcatd -p /var/run/xcatd.pid";


### PR DESCRIPTION
On Ubuntu the `source` shell command results in error when called from `restartxcatd`.
Replace with a POSIX compilant `.` instead.

Before this PR change:
```
root@c910f03c05k10:~# restartxcatd
restartxcatd invoked by root.

Restarting xCATd                                           sh: 1: source: not found
[  OK  ]
root@c910f03c05k10:~#
``` 

After change on Ubuntu:
```
root@c910f03c05k10:~# restartxcatd
restartxcatd invoked by root.

Restarting xCATd                                           [  OK  ]
root@c910f03c05k10:~
```

After change on RH:
```
[root@stratton01 rflash]# restartxcatd
restartxcatd invoked by root.

Restarting xCATd                                           [  OK  ]
[root@stratton01 rflash]#
```