### PR TITLE
Use `ip addr` instead of `ifconfig` command

### DIFF
--- a/xCAT-test/autotest/testcase/genesis/test.sh
+++ b/xCAT-test/autotest/testcase/genesis/test.sh
@@ -39,17 +39,14 @@ function check_destiny() {
         echo "There is no second network, could not verify the test"
         return 1;
     else
-        echo "Add ip addr $MASTER_PRIVATE_IP/$MASTER_PRIVATE_NETMASK to $NET2"
         cmd="ip addr add $MASTER_PRIVATE_IP/$MASTER_PRIVATE_NETMASK dev $NET2";
         runcmd $cmd;
-        echo "Running makenetworks command"
         cmd="makenetworks";
         runcmd $cmd;
         makehosts ${TESTNODE}
         grep ${TESTNODE} /etc/hosts 
         cmd="nodeset ${TESTNODE}  shell";
         runcmd $cmd;
-        echo "Delete ip addr $MASTER_PRIVATE_IP/$MASTER_PRIVATE_NETMASK from $NET2"
         cmd="ip addr del $MASTER_PRIVATE_IP/$MASTER_PRIVATE_NETMASK dev $NET2";
         runcmd $cmd;
         echo "Check if 'nodeset ${TESTNODE} shell' is added to ${SHELLFOLDER}/${TESTNODE}"


### PR DESCRIPTION
during the weekly regress test, one of test cases `rhels8.0.0-P8VMs-PostgreSQL-master-weekly` failed due to 50 network route is deleted  by `xCAT-test/autotest/testcase/genesis/test.sh`.
This script used `ifconfig` command created `192` network and replaced `50` network on interface `enp0s2`, which cause `50` network removed from  route table.  
```
[root@c910f03c09k09 ~]# route
Kernel IP routing table
Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
default         c910loginx02    0.0.0.0         UG    0      0        0 enp0s1
10.0.0.0        0.0.0.0         255.0.0.0       U     0      0        0 enp0s1
50.0.0.0        0.0.0.0         255.0.0.0       U     0      0        0 enp0s2
[root@c910f03c09k09 ~]# ifconfig enp0s2 192.168.1.1 netmask 255.255.0.0
[root@c910f03c09k09 ~]# route
Kernel IP routing table
Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
default         c910loginx02    0.0.0.0         UG    0      0        0 enp0s1
10.0.0.0        0.0.0.0         255.0.0.0       U     0      0        0 enp0s1
192.168.0.0     0.0.0.0         255.255.0.0     U     0      0        0 enp0s2
[root@c910f03c09k09 ~]# route
Kernel IP routing table
Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
default         c910loginx02    0.0.0.0         UG    0      0        0 enp0s1
10.0.0.0        0.0.0.0         255.0.0.0       U     0      0        0 enp0s1

````
looks like this issue is only happened on rhels 8 cluster.
so, to fix this, change `ifconfig` command to `ip addr`, `ifconfig` will be deprecated on rhels8 anyway.

