### PR TITLE
Get input from command line for `xdsh -c` command

### DIFF
--- a/xCAT-test/autotest/testcase/xdsh/cases0
+++ b/xCAT-test/autotest/testcase/xdsh/cases0
@@ -31,7 +31,7 @@ cmd:xdsh $$SN "ls -l /var/xcat/syncfiles" > /dev/null 2>&1; if [ "$?" -ne "0" ];
 check:rc==0
 cmd: xdsh $$SN "echo 'test' > /var/xcat/syncfiles/xdsh_c.tmp"
 check:rc==0
-cmd: xdsh $$SN -c
+cmd: echo Y | xdsh $$SN -c 2>/dev/null
 check:rc==0
 cmd:xdsh $$SN "ls -l /var/xcat/syncfiles"
 check:rc==0
@@ -44,7 +44,7 @@ cmd:xdsh $$CN "ls -l /var/xcat/node/syncfiles" > /dev/null 2>&1; if [ "$?" -ne "
 check:rc==0
 cmd: xdsh $$CN "echo 'test' > /var/xcat/node/syncfiles/xdsh_c.tmp"
 check:rc==0
-cmd: xdsh $$CN -c
+cmd: echo Y | xdsh $$CN -c 2>/dev/null
 check:rc==0
 cmd:xdsh $$CN "ls -l /var/xcat/node"
 check:rc==0


### PR DESCRIPTION
The PR is to fix issue #6362

### The modification include

use `echo Y | xdsh $$CN -c 2>/dev/null` instead of `xdsh $$CN -c`

### The UT result
`##The UT output##`
Change `SNsyncfiledir` attribute in the site table to `/var/xcat/xcat/syncfiles`

```
[root@boston02 ~]# xdsh mid08tor03cn26 "cat /var/xcat/node/syncfiles/test"
mid08tor03cn26: compute
[root@boston02 ~]# echo Y | xdsh mid08tor03cn26 -c 2>/dev/null
Do you wish to erase /var/xcat/xcat/syncfiles,/var/xcat/node/syncfiles and all subdirectories?
 Enter Y or N.
[root@boston02 ~]# xdsh mid08tor03cn26 "cat /var/xcat/node/syncfiles/test"
[sn02]: mid08tor03cn26: cat: /var/xcat/node/syncfiles/test: No such file or directory
```
