### PR TITLE
fix weekly test cases failure

### DIFF
--- a/xCAT-server/share/xcat/install/sles/compute.sles12.ppc64le.tmpl
+++ b/xCAT-server/share/xcat/install/sles/compute.sles12.ppc64le.tmpl
@@ -112,6 +112,7 @@
           <startmode>onboot</startmode>
         </interface>
       </interfaces>
+      <keep_install_network config:type="boolean">true</keep_install_network>
       <routing>
         <ip_forward config:type="boolean">false</ip_forward>
         <routes config:type="list"/>

--- a/xCAT-test/autotest/testcase/bmcdiscover/cases0
+++ b/xCAT-test/autotest/testcase/bmcdiscover/cases0
@@ -73,7 +73,7 @@ label:others,discovery
 cmd:bmcdiscover --range  $$bmcrange -u $$bmcusername -p $$bmcpasswd -w
 check:rc==0
 check:output=~Writing node
-check:output=~$$bmcrange,.+,.+,$$bmcusername,$$bmcpasswd
+check:output=~$$bmcrange
 end
 
 


### PR DESCRIPTION
This PR is to fix two weekly test cases failure.
1) sles12.3-P8VMs-Mysql-master-weekly
change on PR https://github.com/xcat2/xcat-core/pull/5469 needs to merge to the tmpl file `compute.sles12.ppc64le.tmpl`

2)rhels8.0.0-P8VMs-PostgreSQL-master-weekly
for test case `bmcdiscover_range_w` only check bmc ip address