### PR TITLE
Adding some notes to clarify genesis-base workaround for Power9 Hardware

### DIFF
--- a/docs/source/references/coral/known_issues/genesis_base.rst
+++ b/docs/source/references/coral/known_issues/genesis_base.rst
@@ -1,7 +1,7 @@
 xCAT Genesis Base
 =================
 
-*Note*: Please rebuild ``xCAT-genesis-base`` with ``xCAT-genesis-builder`` version equal and newer than *2.13.10* before updating xCAT *2.13.10* and higher.
+.. note:: Ensure that you rebuild ``xCAT-genesis-base`` with ``xCAT-genesis-builder`` version >= to *2.13.10* before updating xCAT to *2.13.10* or higher.
 
 xCAT ships a ``xCAT-genesis-base`` package as part of xcat-deps.  This is a light-weight diskless linux image based on Fedora (Fedora26, currently) that is used by xCAT to do hardware discovery.
 
@@ -9,6 +9,8 @@ To support the Power9 hardware, changes are made to the kernel in the Red Hat En
 
 Work-around
 -----------
+
+.. note:: The genesis-base must be compiled on the Power9 hardware.  If the management node is not Power9 hardware, manually provision a compute node, build the genesis-base RPM, then install it on the management node.
 
 xCAT cannot ship a kernel based on RHEL distribution, so the customer needs to build a version of the ``xCAT-genesis-base`` on-site using a server running Red Hat Enterprise Linux.
 


### PR DESCRIPTION
Some questions have come up and we had some problems where a Power8 managment node was being used  to provision a Power9 AC922 box.  The genesis-base was built on Power8 running a different kernel, so it did not work. 

The contents changes to this with  the  PR: 


![image](https://user-images.githubusercontent.com/10049070/60833089-7eb79f80-a18b-11e9-9cbf-82845976634e.png)

![image](https://user-images.githubusercontent.com/10049070/60833094-824b2680-a18b-11e9-84ec-5d223d4c355e.png)
