### PR TITLE
Add new Edgecore Mac address to switchinfo file

### DIFF
--- a/perl-xCAT/xCAT/data/switchinfo.pm
+++ b/perl-xCAT/xCAT/data/switchinfo.pm
@@ -22,6 +22,8 @@ our %global_mac_identity = (
     "a8:2b:b5" => "Edgecore Networks Switch",
     "3c:2c:99" => "Edgecore Networks Switch",
     "70:72:cf" => "Edgecore Networks Switch",
+    "80:a2:35" => "Edgecore Networks Switch",
+    "b8:6a:97" => "Edgecore Networks Switch",
     "6c:64:1a" => "Penguin Computing switch"
 );
 


### PR DESCRIPTION
the issue reported from Glen Handlogten: 
```
I have an Accton (Cumulus) switch directly connected to the Management Node.  I added a network to the xCAT network table. I can ping it and ssh to it but when I do *switchdiscover, the switch in not seen*.
```
The nmap output showed there are no vendor information and xCAT didn't recolonize this mac address as Edgecore switch
```
[root@hpcmn01 ~]# /usr/bin/nmap -sn -oX - 192.168.0.13
<?xml version="1.0"?>
<?xml-stylesheet href="file:///usr/bin/../share/nmap/nmap.xsl" type="text/xsl"?>
<!-- Nmap 6.40 scan initiated Tue Jul  9 14:26:42 2019 as: /usr/bin/nmap -sn -oX - 192.168.0.13 -->
<nmaprun scanner="nmap" args="/usr/bin/nmap -sn -oX - 192.168.0.13" start="1562696802" startstr="Tue Jul  9 14:26:42 2019" version="6.40" xmloutputversion="1.04">
<verbose level="0"/>
<debugging level="0"/>
mass_dns: warning: Unable to determine any DNS servers. Reverse DNS is disabled. Try using --system-dns or specify valid servers with --dns-servers
<host><status state="up" reason="arp-response" reason_ttl="0"/>
<address addr="192.168.0.13" addrtype="ipv4"/>
<address addr="B8:6A:97:15:B4:C0" addrtype="mac"/>
<hostnames>
</hostnames>
<times srtt="153" rttvar="5000" to="100000"/>
</host>
<runstats><finished time="1562696802" timestr="Tue Jul  9 14:26:42 2019" elapsed="0.18" summary="Nmap done at Tue Jul  9 14:26:42 2019; 1 IP address (1 host up) scanned in 0.18 seconds" exit="success"/><hosts up="1" down="0" total="1"/>
</runstats>
</nmaprun>
```

In order for xCAT to know this as Edgecore switch, need to add the mac address to switchinfo file, Here are the current mac address range assigned to  Edgecore Networks Corp.

![image](https://user-images.githubusercontent.com/12398836/60916545-a7f43080-a25c-11e9-810a-dc5272878f85.png)

