### PR TITLE
Reduce maximum socket buffer size so select works

### DIFF
--- a/perl-xCAT/xCAT/SLP.pm
+++ b/perl-xCAT/xCAT/SLP.pm
@@ -64,6 +64,11 @@ sub dodiscover {
             my $sysctl;
             open($sysctl, "<", "/proc/sys/net/core/rmem_max");
             my $maxrcvbuf = <$sysctl>;
+            # select() on a socket will never succeed if the buffer is too large (i.e. near INT_MAX)
+            my $cap_maxrcvbuf = 2047*1024*1024;
+            if ($maxrcvbuf > $cap_maxrcvbuf) {
+                $maxrcvbuf = $cap_maxrcvbuf;
+            }
             my $rcvbuf    = $args{'socket'}->sockopt(SO_RCVBUF);
             if ($maxrcvbuf > $rcvbuf) {
                 $args{'socket'}->sockopt(SO_RCVBUF, $maxrcvbuf / 2);

--- a/xCAT-server/lib/perl/xCAT/IPMI.pm
+++ b/xCAT-server/lib/perl/xCAT/IPMI.pm
@@ -209,6 +209,11 @@ sub new {
             my $sysctl;
             open($sysctl, "<", "/proc/sys/net/core/rmem_max");
             my $maxrcvbuf = <$sysctl>;
+            # select() on a socket will never succeed if the buffer is too large (i.e. near INT_MAX)
+            my $cap_maxrcvbuf = 2047*1024*1024;
+            if ($maxrcvbuf > $cap_maxrcvbuf) {
+                $maxrcvbuf = $cap_maxrcvbuf;
+            }
             my $rcvbuf    = $socket->sockopt(SO_RCVBUF);
             if ($maxrcvbuf > $rcvbuf) {
                 $socket->sockopt(SO_RCVBUF, $maxrcvbuf / 2);


### PR DESCRIPTION
The maximum socket receive buffer size (SO_RCVBUF) is set from the value
in /proc/sys/net/core/rmem_max.  When this value is close to INT_MAX,
the select() system call used by IO::Select->can_read() never returns
true.  This causes packets to never be read.  Therefore, reduce the
maximum socket receive buffer size to a value which works.

