### PR TITLE
Automatically find first unlocked user slot

### DIFF
--- a/xCAT-genesis-scripts/usr/bin/bmcsetup
+++ b/xCAT-genesis-scripts/usr/bin/bmcsetup
@@ -429,6 +429,14 @@ for user in $BMCUS; do
         USERSLOT=$((`ipmitool raw 6 0x44 1 1|awk '{print $3}'` + 1))
     fi
     if [ "$USERSLOT" == 0 -o -z "$LOCKEDUSERS" ]; then USERSLOT=2; fi
+    # automatically find first unlocked user slot
+    for slot in {1..16}; do
+        USERLOCKED=`ipmitool channel getaccess $LANCHAN $slot | grep Fixed | awk '{print $4}'`
+        if [ "$USERLOCKED" == "No" ]; then
+            USERSLOT=$slot
+            break
+        fi
+    done
     if [ "$ISITE" = 1 ]; then
         allowcred.awk &
         CREDPID=$!


### PR DESCRIPTION
## Description ##
Instead of relying on hard coded offsets, query each slot's status with ```ipmitool channel getaccess``` and use the first slot that is unlocked.

This fixes an issue on certain Cray x86 nodes that have arbitrary locked IPMI user slots.

### Before change ###
```
[xCAT Genesis running on j2n02 /]# bmcsetup
ipmitool version 1.8.18
/usr/bin/bmcsetup: line 150:  1963 Terminated              allowcred.awk
xcat.genesis.bmcsetup: BMC Information obtained from xCAT
xcat.genesis.bmcsetup: NUMBMCS=1 ==> BMC IP=10.188.2.112/255.255.192.0, GW=, VLAN=1880
xcat.genesis.bmcsetup: IPMIVER=2.0, IPMIMFG=343, XPROD=115
xcat.genesis.bmcsetup: Auto detecting LAN channel...
xcat.genesis.bmcsetup: Detected LAN channel 1
Setting LAN IP Address to 10.188.2.112
Setting LAN Subnet Mask to 255.255.192.0
xcat.genesis.bmcsetup: CURRENTUSER=root, DISABLEUSERS=1  3 4 5 6 7 8 9 10 11 12 13 14 15
Unable to send RAW command (channel=0x0 netfn=0x6 lun=0x0 cmd=0x43 rsp=0xc7): Request data length invalid
xcat.genesis.bmcsetup: CURRPRIV=ADMINISTRATOR
IPMI command failed: Invalid data field in request
Unable to Set User Access (channel 1 id 2)
IPMI command failed: Invalid data field in request
Unable to Set User Access (channel 1 id 2)
IPMI command failed: Invalid data field in request
Unable to Set User Access (channel 1 id 2)
IPMI command failed: Invalid data field in request
Unable to Set User Access (channel 1 id 2)
IPMI command failed: Invalid data field in request
Unable to Set User Access (channel 1 id 2)
IPMI command failed: Invalid data field in request
Unable to Set User Access (channel 1 id 2)
IPMI command failed: Invalid data field in request
Unable to Set User Access (channel 1 id 2)
IPMI command failed: Invalid data field in request
Unable to Set User Access (channel 1 id 2)
IPMI command failed: Invalid data field in request
Unable to Set User Access (channel 1 id 2)
IPMI command failed: Invalid data field in request
Unable to Set User Access (channel 1 id 2)
IPMI command failed: Invalid data field in request
Unable to Set User Access (channel 1 id 2)
IPMI command failed: Invalid data field in request
Unable to Set User Access (channel 1 id 2)
IPMI command failed: Invalid data field in request
Unable to Set User Access (channel 1 id 2)
IPMI command failed: Invalid data field in request
Unable to Set User Access (channel 1 id 2)
IPMI command failed: Invalid data field in request
Unable to Set User Access (channel 1 id 2)
IPMI command failed: Invalid data field in request
Unable to Set User Access (channel 1 id 2)
Set User Name command failed (user 2, name admin): Invalid data field in request
Set User Name command failed (user 2, name admin): Invalid data field in request
Set User Name command failed (user 2, name admin): Invalid data field in request
Set User Name command failed (user 2, name admin): Invalid data field in request
Set User Name command failed (user 2, name admin): Invalid data field in request
Set User Name command failed (user 2, name admin): Invalid data field in request
Set User Name command failed (user 2, name admin): Invalid data field in request
Set User Name command failed (user 2, name admin): Invalid data field in request
Set User Name command failed (user 2, name admin): Invalid data field in request
Set User Name command failed (user 2, name admin): Invalid data field in request
Set User Name command failed (user 2, name admin): Invalid data field in request
Set User Name command failed (user 2, name admin): Invalid data field in request
Set User Name command failed (user 2, name admin): Invalid data field in request
Set User Name command failed (user 2, name admin): Invalid data field in request
Set User Name command failed (user 2, name admin): Invalid data field in request
Set User Name command failed (user 2, name admin): Invalid data field in request
Set User Password command successful (user 2)
xcat.genesis.bmcsetup: Set up following user table:
ID  Name             Callin  Link Auth  IPMI Msg   Channel Priv Limit
1                    false   false      true       ADMINISTRATOR
2   root             false   true       true       ADMINISTRATOR
3   admin            true    true       true       ADMINISTRATOR
4   ace              false   false      true       OPERATOR
5   test3            false   false      true       ADMINISTRATOR
6                    true    false      false      NO ACCESS
7                    true    false      false      NO ACCESS
8                    true    false      false      NO ACCESS
9                    true    false      false      NO ACCESS
10                   true    false      false      NO ACCESS
11                   true    false      false      NO ACCESS
12                   true    false      false      NO ACCESS
13                   true    false      false      NO ACCESS
14                   true    false      false      NO ACCESS
15                   true    false      false      NO ACCESS
xcat.genesis.bmcsetup: Enabling the non-volatile channel access (1)
xcat.genesis.bmcsetup: Enabling the non-volatile channel access (1): OK
xcat.genesis.bmcsetup: Enabling the volatile channel access (1)
xcat.genesis.bmcsetup: Enabling the volatile channel access (1): OK
xcat.genesis.bmcsetup: Enabling ARP responses
xcat.genesis.bmcsetup: Enabling ARP responses: OK
xcat.genesis.bmcsetup: Enabling IPMI MD5 LAN access
xcat.genesis.bmcsetup: Enabling IPMI MD5 LAN access: OK
xcat.genesis.bmcsetup: Enabling IPMI v 2.0 LAN access
xcat.genesis.bmcsetup: Set the cipher_privileges for the channel
xcat.genesis.bmcsetup: Set the cipher_privileges for the channel: OK
xcat.genesis.bmcsetup: Enabling SOL for channel 1
xcat.genesis.bmcsetup: Enabling SOL for channel 1: OK
xcat.genesis.bmcsetup: Enabling SOL for admin
xcat.genesis.bmcsetup: Enabling SOL for admin: OK
xcat.genesis.bmcsetup: Lighting Identify Light
[xCAT Genesis running on j2n02 /]#
```

### After change ###
```
[xCAT Genesis running on j2n02 /]# bmcsetup
ipmitool version 1.8.18
/usr/bin/bmcsetup: line 150:  5405 Terminated              allowcred.awk
xcat.genesis.bmcsetup: BMC Information obtained from xCAT
xcat.genesis.bmcsetup: NUMBMCS=1 ==> BMC IP=10.188.2.112/255.255.192.0, GW=, VLAN=1880
xcat.genesis.bmcsetup: IPMIVER=2.0, IPMIMFG=343, XPROD=115
xcat.genesis.bmcsetup: Auto detecting LAN channel...
xcat.genesis.bmcsetup: Detected LAN channel 1
Setting LAN IP Address to 10.188.2.112
Setting LAN Subnet Mask to 255.255.192.0
xcat.genesis.bmcsetup: CURRENTUSER=admin, DISABLEUSERS=1 2  4 5 6 7 8 9 10 11 12 13 14 15
Unable to send RAW command (channel=0x0 netfn=0x6 lun=0x0 cmd=0x43 rsp=0xc7): Request data length invalid
xcat.genesis.bmcsetup: CURRPRIV=ADMINISTRATOR
Set User Access (channel 1 id 3) successful.
Set User Password command successful (user 3)
xcat.genesis.bmcsetup: Set up following user table:
ID  Name             Callin  Link Auth  IPMI Msg   Channel Priv Limit
1                    false   false      true       ADMINISTRATOR
2   root             false   true       true       ADMINISTRATOR
3   admin            true    true       true       ADMINISTRATOR
4   ace              false   false      true       OPERATOR
5   test3            false   false      true       ADMINISTRATOR
6                    true    false      false      NO ACCESS
7                    true    false      false      NO ACCESS
8                    true    false      false      NO ACCESS
9                    true    false      false      NO ACCESS
10                   true    false      false      NO ACCESS
11                   true    false      false      NO ACCESS
12                   true    false      false      NO ACCESS
13                   true    false      false      NO ACCESS
14                   true    false      false      NO ACCESS
15                   true    false      false      NO ACCESS
xcat.genesis.bmcsetup: Enabling the non-volatile channel access (1)
xcat.genesis.bmcsetup: Enabling the non-volatile channel access (1): OK
xcat.genesis.bmcsetup: Enabling the volatile channel access (1)
xcat.genesis.bmcsetup: Enabling the volatile channel access (1): OK
xcat.genesis.bmcsetup: Enabling ARP responses
xcat.genesis.bmcsetup: Enabling ARP responses: OK
xcat.genesis.bmcsetup: Enabling IPMI MD5 LAN access
xcat.genesis.bmcsetup: Enabling IPMI MD5 LAN access: OK
xcat.genesis.bmcsetup: Enabling IPMI v 2.0 LAN access
xcat.genesis.bmcsetup: Set the cipher_privileges for the channel
xcat.genesis.bmcsetup: Set the cipher_privileges for the channel: OK
xcat.genesis.bmcsetup: Enabling SOL for channel 1
xcat.genesis.bmcsetup: Enabling SOL for channel 1: OK
xcat.genesis.bmcsetup: Enabling SOL for admin
xcat.genesis.bmcsetup: Enabling SOL for admin: OK
xcat.genesis.bmcsetup: Lighting Identify Light
[xCAT Genesis running on j2n02 /]#
```