### PR TITLE
Remove kits from Ubuntu and go-xcat

### DIFF
--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -161,13 +161,13 @@ GO_XCAT_CORE_PACKAGE_LIST=()
 GO_XCAT_DEP_PACKAGE_LIST=()
 
 # The package list of all the packages should be installed
-GO_XCAT_INSTALL_LIST=(perl-xCAT xCAT xCAT-buildkit xCAT-client
+GO_XCAT_INSTALL_LIST=(perl-xCAT xCAT xCAT-client
 	xCAT-genesis-scripts-ppc64 xCAT-genesis-scripts-x86_64 xCAT-server
 	elilo-xcat grub2-xcat ipmitool-xcat syslinux-xcat
 	xCAT-genesis-base-ppc64 xCAT-genesis-base-x86_64 xnba-undi yaboot-xcat)
-# For Debian/Ubuntu, it will need a sight different package list
+# For Debian/Ubuntu, it will need a sightly different package list
 type dpkg >/dev/null 2>&1 &&
-GO_XCAT_INSTALL_LIST=(perl-xcat xcat xcat-buildkit xcat-client
+GO_XCAT_INSTALL_LIST=(perl-xcat xcat xcat-client
 	xcat-genesis-scripts-amd64 xcat-genesis-scripts-ppc64 xcat-server
 	elilo-xcat grub2-xcat ipmitool-xcat syslinux-xcat
 	xcat-genesis-base-amd64 xcat-genesis-base-ppc64 xnba-undi)

--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -2,7 +2,7 @@
 #
 # go-xcat - Install xCAT automatically.
 #
-# Version 1.0.40
+# Version 1.0.41
 #
 # Copyright (C) 2016 - 2019 International Business Machines
 # Eclipse Public License, Version 1.0 (EPL-1.0)
@@ -23,6 +23,8 @@
 #     - xCAT uninstallation
 # 2019-03-22 GONG Jie <gongjie@linux.vnet.ibm.com>
 #     - Better debug log when reading repository failed
+# 2019-07-24 Mark Gurevich <gurevich@us.ibm.com>
+#     - Removed references to buildkit
 #
 
 function usage()

--- a/xCAT/debian/control
+++ b/xCAT/debian/control
@@ -10,7 +10,7 @@ Homepage: https://xcat.org/
 Package: xcat
 Architecture: amd64 ppc64el
 Depends: ${perl:Depends}, goconserver, xcat-server (>= 2.13-snap000000000000), xcat-client (>= 2.13-snap000000000000), libdbd-sqlite3-perl, isc-dhcp-server, apache2, nfs-kernel-server, libxml-parser-perl, rsync, tftpd-hpa, libnet-telnet-perl, xcat-genesis-scripts-ppc64 (>= 2.13-snap000000000000), xcat-genesis-scripts-amd64 (>= 2.13-snap000000000000)
-Recommends: bind9, nmap, tftp-hpa, ipmitool-xcat (>= 1.8.17-1), syslinux[any-amd64], libsys-virt-perl, syslinux-xcat, xnba-undi, elilo-xcat, xcat-buildkit (>= 2.13-snap000000000000), xcat-probe (>= 2.13-snap000000000000)
+Recommends: bind9, nmap, tftp-hpa, ipmitool-xcat (>= 1.8.17-1), syslinux[any-amd64], libsys-virt-perl, syslinux-xcat, xnba-undi, elilo-xcat, xcat-probe (>= 2.13-snap000000000000)
 Suggests: yaboot-xcat
 Description: Metapackage for a common, default xCAT setup
  xCAT is Extreme Cluster/Cloud Administration Toolkit. xCAT offers complete

--- a/xCATsn/debian/control
+++ b/xCATsn/debian/control
@@ -9,7 +9,7 @@ Homepage: https://xcat.org/
 Package: xcatsn
 Architecture: amd64 ppc64el
 Depends: ${perl:Depends}, goconserver, xcat-server (>= 2.13-snap000000000000), xcat-client (>= 2.13-snap000000000000), libdbd-sqlite3-perl, libxml-parser-perl, tftpd-hpa, libnet-telnet-perl, isc-dhcp-server, apache2, nfs-kernel-server, xcat-genesis-scripts-ppc64 (>= 2.13-snap000000000000), xcat-genesis-scripts-amd64 (>= 2.13-snap000000000000)
-Recommends: bind9, nmap, tftp-hpa, ipmitool-xcat (>= 1.8.17-1), syslinux[any-amd64], libsys-virt-perl, syslinux-xcat, xnba-undi, elilo-xcat, xcat-buildkit (>= 2.13-snap000000000000), xcat-probe (>= 2.13-snap000000000000)
+Recommends: bind9, nmap, tftp-hpa, ipmitool-xcat (>= 1.8.17-1), syslinux[any-amd64], libsys-virt-perl, syslinux-xcat, xnba-undi, elilo-xcat, xcat-probe (>= 2.13-snap000000000000)
 Suggests: yaboot-xcat
 Description: Metapackage for a common, default xCAT service node setup
  xCATsn is a service node management package intended for at-scale


### PR DESCRIPTION
The release regression test did its job and caught a failure installing xCAT on Ubuntu. It appears there is still some dependency on the kits:
```
Package xcat-buildkit is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
```

However, the Travis CI passed in the PR #6382 

Removing some more references to `xcat-buildkit`