### PR TITLE
feat: add ability to create usergroup based policy rules

### DIFF
--- a/perl-xCAT/xCAT/Utils.pm
+++ b/perl-xCAT/xCAT/Utils.pm
@@ -4987,6 +4987,26 @@ sub natural_sort_cmp($$) {
 
 #--------------------------------------------------------------------------------
 
+=head3  groups
+      Pure perl implementation of /bin/groups
+=cut
+
+#--------------------------------------------------------------------------------
+sub groups($) {
+    my ($name)=@_;
+    my @list;
+    my $n=(getpwnam($name))[3];
+    @list=((getgrgid($n))[0]);
+    while (my @l=getgrent()) {
+        if ($l[3] && $l[3] ne "" && $l[3] =~ /$name/) {
+            push @list, $l[0];
+        }
+    }
+    endgrent();
+}
+
+#--------------------------------------------------------------------------------
+
 =head3  console_sleep
       A wrap for sleep subroutine, if goconserver is used, just exit immidiately
       as goconserver has its own sleep mechanism.

--- a/xCAT-server/lib/perl/xCAT/xcatd.pm
+++ b/xCAT-server/lib/perl/xCAT/xcatd.pm
@@ -105,11 +105,17 @@ sub validate {
         }
     }
 
+    # Get groups for peername
+    my $usergroups = xCAT::Utils->groups($peername);
+
   RULE: foreach $rule (@sortedpolicies) {
         if ($rule->{name} and $rule->{name} ne '*') {
 
             #TODO: more complex matching (lists, wildcards)
-            next unless ($peername and $peername eq $rule->{name});
+	    if (!$usergroups or index($usergroups,$rule->{name}) < 0) {
+		# If the user's group is empty, or usergroups doesn't contain rule name then...
+                next unless ($peername and $peername eq $rule->{name});
+	    }
         }
         if ($rule->{name} and $rule->{name} eq '*') { #a name is required, but can be any name whatsoever....
             next unless ($peername);


### PR DESCRIPTION
### The PR is to implement feature #1848 

_##Feature description##_
In the case of lots of users (or user churn) of a cluster, it is easier to add a group based policy instead of creating individual policies for users.

Code logic:
* Given the request's `peername`, get the groups for the user.
* If the group list contains the rule name, it's a match, so carry forward as previously, or check for username and carry forward as previously.

### The UT result
As I no longer have access to an xCAT environment, I am unable to unit-test this.