### PR TITLE
Remove conserver-xcat during uninstall

### DIFF
--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -2,7 +2,7 @@
 #
 # go-xcat - Install xCAT automatically.
 #
-# Version 1.0.42
+# Version 1.0.43
 #
 # Copyright (C) 2016 - 2019 International Business Machines
 # Eclipse Public License, Version 1.0 (EPL-1.0)
@@ -27,6 +27,8 @@
 #     - Removed references to buildkit
 # 2019-08-12 Mark Gurevich <gurevich@us.ibm.com>
 #     - Added xCAT-buildkit to uninstall list
+# 2019-08-15 Mark Gurevich <gurevich@us.ibm.com>
+#     - Added conserver-xcat to uninstall list
 #
 
 function usage()
@@ -179,12 +181,12 @@ GO_XCAT_INSTALL_LIST=(perl-xcat xcat xcat-client
 GO_XCAT_UNINSTALL_LIST=("${GO_XCAT_INSTALL_LIST[@]}"
 	goconserver xCAT-SoftLayer xCAT-confluent xCAT-csm xCAT-genesis-builder
 	xCAT-openbmc-py xCAT-probe xCAT-test xCAT-vlan xCATsn xCAT-UI-deps
-    xCAT-buildkit)
+    xCAT-buildkit conserver-xcat)
 # For Debian/Ubuntu, it will need a sight different package list
 type dpkg >/dev/null 2>&1 &&
 GO_XCAT_UNINSTALL_LIST=("${GO_XCAT_INSTALL_LIST[@]}"
 	goconserver xcat-confluent xcat-probe xcat-test xcat-vlan xcatsn
-    xcat-buildkit)
+    xcat-buildkit conserver-xcat)
 
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
 export PATH


### PR DESCRIPTION
### The PR is to fix issue _#6403_

### The modification include

Add `conserver-xcat` to uninstall list, so that it gets removed during `go-xcat uninstall`