### PR TITLE
postscripts:  make remoteshell work with Match directives

### DIFF
--- a/xCAT/postscripts/remoteshell
+++ b/xCAT/postscripts/remoteshell
@@ -59,15 +59,12 @@ then
 	logger -t $log_label -p local4.info "remoteshell:  setup /etc/ssh/sshd_config and ssh_config"
 	cp /etc/ssh/sshd_config /etc/ssh/sshd_config.ORIG
         #delete all occurance of the attribute and then add xCAT settings
-        sed -i '/X11Forwarding /'d /etc/ssh/sshd_config
-        echo "X11Forwarding yes" >>/etc/ssh/sshd_config
-        sed -i '/MaxStartups /'d /etc/ssh/sshd_config
-        echo "MaxStartups 1024" >>/etc/ssh/sshd_config
+        sed -i 's/X11Forwarding .*/X11Forwarding yes/' /etc/ssh/sshd_config
+        sed -i 's/MaxStartups .*/MaxStartups 1024/' /etc/ssh/sshd_config
 
     if [ "$SETUPFORPCM" = "1" ]; then
         if [[ $OSVER == sle* ]];then
-            sed -i '/PasswordAuthentication /'d /etc/ssh/sshd_config
-            echo "PasswordAuthentication yes" >>/etc/ssh/sshd_config
+            sed -i 's/PasswordAuthentication /PasswordAuthentication yes/' /etc/ssh/sshd_config
         elif [[ $OSVER == ubuntu* ]];then
             sed -i 's/^PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
         fi
@@ -76,8 +73,7 @@ fi
 
 if [ -r /etc/ssh/ssh_config ]
 then
-   sed -i '/StrictHostKeyChecking /'d /etc/ssh/ssh_config
-   echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config
+   sed -i 's/StrictHostKeyChecking .*/StrictHostKeyChecking no/' /etc/ssh/ssh_config
 
 fi
 xcatpost="xcatpost"

--- a/xCAT/postscripts/remoteshell
+++ b/xCAT/postscripts/remoteshell
@@ -63,7 +63,7 @@ then
 		sed -i 's/[# ]\+\?X11Forwarding .*/X11Forwarding yes/' /etc/ssh/sshd_config
 	elif grep -q Match /etc/ssh/sshd_config; then
 		# insert before Match blocks if doesn't exit
-		sed -i '/Match/i X11Forwarding yes' /etc/ssh/sshd_config
+		sed -i '1,/Match/i X11Forwarding yes' /etc/ssh/sshd_config
 	else 
 		# append if doesn't exist and no Match blocks
 		echo 'X11Forwarding yes' >> /etc/ssh/sshd_config
@@ -74,7 +74,7 @@ then
 		sed -i 's/[# ]\+\?MaxStartups .*/MaxStartups 1024/' /etc/ssh/sshd_config
 	elif grep -q Match /etc/ssh/sshd_config; then
 		# insert before Match blocks if doesn't exit
-		sed -i '/Match/i MaxStartups 1024' /etc/ssh/sshd_config
+		sed -i '1,/Match/i MaxStartups 1024' /etc/ssh/sshd_config
 	else 
 		# append if doesn't exist and no Match blocks
 		echo 'MaxStartups 1024' >> /etc/ssh/sshd_config
@@ -91,15 +91,15 @@ fi
 
 if [ -r /etc/ssh/ssh_config ]
 then
-	if grep -q StrictHostKeyChecking /etc/ssh/sshd_config; then
+	if grep -q StrictHostKeyChecking /etc/ssh/ssh_config; then
 		# replace config options if they exist
-		sed -i 's/[# ]\+\?StrictHostKeyChecking .*/StrictHostKeyChecking no/' /etc/ssh/sshd_config
-	elif grep -q Match /etc/ssh/sshd_config; then
-		# insert before Match blocks if doesn't exit
-		sed -i '/Match/i StrictHostKeyChecking no' /etc/ssh/sshd_config
+		sed -i 's/[# ]\+\?StrictHostKeyChecking .*/StrictHostKeyChecking no/' /etc/ssh/ssh_config
+	elif grep -q Host /etc/ssh/ssh_config; then
+		# insert before Host blocks if doesn't exit
+		sed -i '1,/^[# ]\+\?Host/i StrictHostKeyChecking no' /etc/ssh/ssh_config
 	else 
-		# append if doesn't exist and no Match blocks
-		echo 'StrictHostKeyChecking no' >> /etc/ssh/sshd_config
+		# append if doesn't exist and no Host blocks
+		echo 'StrictHostKeyChecking no' >> /etc/ssh/ssh_config
 	fi
 fi
 

--- a/xCAT/postscripts/remoteshell
+++ b/xCAT/postscripts/remoteshell
@@ -58,9 +58,27 @@ if [ -r /etc/ssh/sshd_config ]
 then
 	logger -t $log_label -p local4.info "remoteshell:  setup /etc/ssh/sshd_config and ssh_config"
 	cp /etc/ssh/sshd_config /etc/ssh/sshd_config.ORIG
-        #delete all occurance of the attribute and then add xCAT settings
-        sed -i 's/X11Forwarding .*/X11Forwarding yes/' /etc/ssh/sshd_config
-        sed -i 's/MaxStartups .*/MaxStartups 1024/' /etc/ssh/sshd_config
+	if grep -q X11Forwarding /etc/ssh/sshd_config; then
+		# replace config options if they exist
+		sed -i 's/[# ]\+\?X11Forwarding .*/X11Forwarding yes/' /etc/ssh/sshd_config
+	elif grep -q Match /etc/ssh/sshd_config; then
+		# insert before Match blocks if doesn't exit
+		sed -i '/Match/i X11Forwarding yes' /etc/ssh/sshd_config
+	else 
+		# append if doesn't exist and no Match blocks
+		echo 'X11Forwarding yes' >> /etc/ssh/sshd_config
+	fi
+
+	if grep -q MaxStartups /etc/ssh/sshd_config; then
+		# replace config options if they exist
+		sed -i 's/[# ]\+\?MaxStartups .*/MaxStartups 1024/' /etc/ssh/sshd_config
+	elif grep -q Match /etc/ssh/sshd_config; then
+		# insert before Match blocks if doesn't exit
+		sed -i '/Match/i MaxStartups 1024' /etc/ssh/sshd_config
+	else 
+		# append if doesn't exist and no Match blocks
+		echo 'MaxStartups 1024' >> /etc/ssh/sshd_config
+	fi
 
     if [ "$SETUPFORPCM" = "1" ]; then
         if [[ $OSVER == sle* ]];then
@@ -73,9 +91,18 @@ fi
 
 if [ -r /etc/ssh/ssh_config ]
 then
-   sed -i 's/StrictHostKeyChecking .*/StrictHostKeyChecking no/' /etc/ssh/ssh_config
-
+	if grep -q StrictHostKeyChecking /etc/ssh/sshd_config; then
+		# replace config options if they exist
+		sed -i 's/[# ]\+\?StrictHostKeyChecking .*/StrictHostKeyChecking no/' /etc/ssh/sshd_config
+	elif grep -q Match /etc/ssh/sshd_config; then
+		# insert before Match blocks if doesn't exit
+		sed -i '/Match/i StrictHostKeyChecking no' /etc/ssh/sshd_config
+	else 
+		# append if doesn't exist and no Match blocks
+		echo 'StrictHostKeyChecking no' >> /etc/ssh/sshd_config
+	fi
 fi
+
 xcatpost="xcatpost"
 if [ -d /xcatpost/_ssh ]
 then


### PR DESCRIPTION
currently remoteshell uses sed to delete lines from the sshd_config
file and appends new lines.  if there are Match blocks in the
sshd_config file, sshd will fail to start after remoteshell runs.

this change moves from 'delete then append' to using s/// commands
so sed directly edits the files in situ.  this way the configuration
directives remain in their original order, and sshd_config files
containing Match blocks do not break.

