### PR TITLE
Health check xcat-dep files before building tar

### DIFF
--- a/builddep.sh
+++ b/builddep.sh
@@ -35,6 +35,10 @@ fi
 USER=xcat
 TARGET_MACHINE=xcat.org
 
+BASE_GSA=/gsa/pokgsa/projects/x/xcat/build
+AIX_GSA=$BASE_GSA/aix/xcat-dep
+LINUX_GSA=$BASE_GSA/linux/xcat-dep
+
 FRS=/var/www/xcat.org/files/xcat
 OSNAME=$(uname)
 
@@ -49,10 +53,10 @@ done
 
 if [ "$OSNAME" == "AIX" ]; then
 	DFNAME=dep-aix-`date +%Y%m%d%H%M`.tar.gz
-	GSA=/gsa/pokgsa/projects/x/xcat/build/aix/xcat-dep
+	GSA=$AIX_GSA
 else
 	DFNAME=xcat-dep-`date +%Y%m%d%H%M`.tar.bz2
-	GSA=/gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep
+	GSA=$LINUX_GSA
 fi
 
 if [ ! -d $GSA ]; then
@@ -136,13 +140,13 @@ if [[ ${CHECK} -eq 1 ]]; then
             # Find regular noarch.rpm files in <OS>/<ARCH> directory
             for file in `find $arch -type f -name "*noarch.rpm"`; do
                 ERROR=1
-                echo "Error: Regular 'noarch' file $file found in 'arch' directory. Expected a link."
+                echo -e "\nError: Regular 'noarch' file $file found in 'arch' directory. Expected a link."
             done
 
             # Find broken links file
             for file in `find $arch -xtype l -name "*noarch.rpm"`; do
                 ERROR=1
-                echo "Error: Broken link file $file"
+                echo -e "\nError: Broken link file $file"
             done
 
             # Save a link of everything being linked to for later use
@@ -172,7 +176,7 @@ if [[ ${CHECK} -eq 1 ]]; then
     if [ -n "$VERBOSEMODE" ]; then
         # In verbose mode print contents of array containing all the files someone links to from <OS>/<ARCH>
         for var in "${LINKED_TO_FILES_ARRAY[@]}"; do
-            echo "Someone links to file: ${var} "
+            echo "Symlink detected to file: ${var} "
         done
     fi
 
@@ -188,12 +192,12 @@ if [[ ${CHECK} -eq 1 ]]; then
             fi
         done
         if [[ ${FOUND} -eq 0 ]]; then
-            echo "Warning: no one links to real file: $GSA/$file"
+            echo "Warning: No symlinks to file: $GSA/$file"
         fi
     done
 
     if [[ ${ERROR} -eq 1 ]]; then
-        echo -e "\nErrors found verifying files. Rerun this secript with CHECK=0 to skip file verification."
+        echo -e "\nErrors found verifying files. Rerun this script with CHECK=0 to skip file verification."
         exit 1
     fi
 fi


### PR DESCRIPTION
Do some verification to check health of the `xcat-dep` files in GSA before building `.tar`

```
[gurevich@c910loginx02 xcat-core]$ ./builddep.sh CHECK=1
Checking for package=rpm-sign ...
Checking for package=createrepo ...
INFO: Running script from here: /u/gurevich/xcat211/xcat-core ...
INFO: Target package name: xcat-dep-201908221553.tar.bz2
INFO: Target package will be created here: /u/gurevich/xcat211/xcat-core/../xcat-dep-build
Error: Regular 'noarch' file /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/sles12/x86_64/perl-Crypt-CBC-2.33-3.7.noarch.rpm found in 'arch' directory. Expected a link.
Error: Regular 'noarch' file /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/sles12/x86_64/perl-HTML-Form-6.03-5.1.noarch.rpm found in 'arch' directory. Expected a link.
Error: Regular 'noarch' file /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/rh7/s390x/perl-Expect-1.21-1.noarch.rpm found in 'arch' directory. Expected a link.

Error: Multiple real files with the same name found (perl-HTTP-Async-0.30-2.noarch.rpm):
-rw-rw-r-- 1 vhu p/xcat/admin 19796 Jun  5 21:19 /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/perl-HTTP-Async-0.30-2.noarch.rpm
-rw-rw-r-- 1 vhu p/xcat/admin 22408 Jun  5 21:19 /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/rh8/perl-HTTP-Async-0.30-2.noarch.rpm

Error: Multiple real files with the same name found (perl-Net-HTTPS-NB-0.14-2.noarch.rpm):
-rw-rw-r-- 1 vhu p/xcat/admin 10068 Jun  5 21:19 /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/perl-Net-HTTPS-NB-0.14-2.noarch.rpm
-rw-rw-r-- 1 vhu p/xcat/admin 9132 Jun  5 21:19 /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/rh8/perl-Net-HTTPS-NB-0.14-2.noarch.rpm

Error: Multiple real files with the same name found (perl-SOAP-Lite-0.710.08-1.noarch.rpm):
-rw-rw-r-- 1 vhu p/xcat/admin 363809 Jun  5 21:19 /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/perl-SOAP-Lite-0.710.08-1.noarch.rpm
-rw-rw-r-- 1 vhu p/xcat/admin 333754 Jun  5 21:19 /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/sles12/perl-SOAP-Lite-0.710.08-1.noarch.rpm
-rw-rw-r-- 1 vhu p/xcat/admin 274705 Jun  5 21:19 /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/rh7/perl-SOAP-Lite-0.710.08-1.noarch.rpm

Error: Multiple real files with the same name found (perl-version-0.76-1.noarch.rpm):
-rw-rw-r-- 1 vhu p/xcat/admin 28087 Jun  5 21:19 /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/perl-version-0.76-1.noarch.rpm
-rw-rw-r-- 1 vhu p/xcat/admin 27805 Jun  5 21:19 /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/sles12/perl-version-0.76-1.noarch.rpm
-rw-rw-r-- 1 vhu p/xcat/admin 74785 Jun  5 21:19 /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/rh7/perl-version-0.76-1.noarch.rpm

Warning: no one links to real file: /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/perl-SOAP-Lite-0.710.08-1.noarch.rpm
Warning: no one links to real file: /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/perl-version-0.76-1.noarch.rpm
Warning: no one links to real file: /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/rh7/perl-version-0.76-1.noarch.rpm
Warning: no one links to real file: /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/sles12/perl-version-0.76-1.noarch.rpm
Warning: no one links to real file: /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/sles12/perl-XML-Simple-2.18-1.noarch.rpm
Warning: no one links to real file: /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/sles12/perl-Expect-1.21-1.noarch.rpm

Errors found verifying files. Rerun this secript with CHECK=0 to skip file verification.
```