### PR TITLE
increase memory in kvm guide

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/common/kvm/manage_vm.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/kvm/manage_vm.rst
@@ -39,7 +39,7 @@ After the VM object is created, several key attributes need to be specified with
 
 4. the virtual memory size, with the unit "Megabit". Specify 1GB memory to "vm1" here: ::
 
-     chdef vm1 vmmemory=1024
+     chdef vm1 vmmemory=2048
 
 **Note**: For diskless node, the **vmmemory** should be at least 2048 MB, otherwise the node cannot boot up.
 


### PR DESCRIPTION
with current CentOS, download of kickstart file will fail when 1G memory is used.
I believe it's related to this RHEL bug, https://bugzilla.redhat.com/show_bug.cgi?id=1595369, "Bug 1595369 - rhel 7.5 installation fails with 1GB ram ".

### The PR is to fix issue _#xxx_

### The modification include

_##item1_

_##item2_

### The UT result
`##The UT output##`

# Please remove this line and below if fix issue

# Please remove this line and above for tasks or features

### The PR is for task _#xxx_ or to implement feature #xxx

_##Feature description##_

### The content of the PR:
* [ ] _##The mini-design link_
* [ ] _##The basic code logic_

### The UT result
`##The UT output##`
