### PR TITLE
documentation: change the vmnicnicmodel from virtio to e1000

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/common/kvm/manage_vm.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/kvm/manage_vm.rst
@@ -50,7 +50,7 @@ After the VM object is created, several key attributes need to be specified with
 6. The **vmnicnicmodel** attribute is used to set the type and corresponding driver for the nic. If not set, the default value is 'virtio'.
    ::
 
-    chdef vm1 vmnicnicmodel=virtio
+    chdef vm1 vmnicnicmodel=e1000
 
 7. Define the storage for the vm1, three types of storage source format are supported.
 


### PR DESCRIPTION
xcatnba doesn't boot with virtio. Using e1000 it will boot correctly.

## env

### os
```
[root@vm3 custom]# cat /etc/centos-release
CentOS Linux release 7.6.1810 (Core) 
[root@vm3 custom]#
```

### xcat server env

```
[root@vm3 custom]# rpm -qa | grep -i xcat
xCAT-genesis-base-x86_64-2.14.5-snap201811190037.noarch
perl-xCAT-2.14.6-snap201903290319.noarch
xCAT-2.14.6-snap201903290319.x86_64
conserver-xcat-8.2.1-1.x86_64
elilo-xcat-3.14-4.noarch
xCAT-genesis-scripts-x86_64-2.14.6-snap201903290319.noarch
xCAT-buildkit-2.14.6-snap201903290319.noarch
xCAT-probe-2.14.6-snap201903290319.noarch
xCAT-client-2.14.6-snap201903290319.noarch
xCAT-server-2.14.6-snap201903290319.noarch
yaboot-xcat-1.3.17-rc1.noarch
syslinux-xcat-3.86-2.noarch
xCAT-genesis-scripts-ppc64-2.14.6-snap201903290319.noarch
ipmitool-xcat-1.8.18-0.x86_64
xCAT-genesis-base-ppc64-2.14.5-snap201811160710.noarch
grub2-xcat-2.02-0.16.el7.snap201506090204.noarch
[root@vm3 custom]#
```
### hypervisor env

```
n26:/mnt/local-scratch/vm# rpm -qa | grep qemu | sort
ipxe-roms-qemu-20170123-1.git4e85b27.el7_4.1.noarch
libvirt-daemon-driver-qemu-4.5.0-10.el7_6.12.x86_64
qemu-2.0.0-1.el7.6.x86_64
qemu-common-2.0.0-1.el7.6.x86_64
qemu-img-1.5.3-160.el7_6.3.x86_64
qemu-kvm-1.5.3-160.el7_6.3.x86_64
qemu-kvm-common-1.5.3-160.el7_6.3.x86_64
qemu-kvm-tools-1.5.3-160.el7_6.3.x86_64
qemu-system-alpha-2.0.0-1.el7.6.x86_64
qemu-system-arm-2.0.0-1.el7.6.x86_64
qemu-system-cris-2.0.0-1.el7.6.x86_64
qemu-system-lm32-2.0.0-1.el7.6.x86_64
qemu-system-m68k-2.0.0-1.el7.6.x86_64
qemu-system-microblaze-2.0.0-1.el7.6.x86_64
qemu-system-mips-2.0.0-1.el7.6.x86_64
qemu-system-moxie-2.0.0-1.el7.6.x86_64
qemu-system-or32-2.0.0-1.el7.6.x86_64
qemu-system-s390x-2.0.0-1.el7.6.x86_64
qemu-system-sh4-2.0.0-1.el7.6.x86_64
qemu-system-unicore32-2.0.0-1.el7.6.x86_64
qemu-system-x86-2.0.0-1.el7.6.x86_64
qemu-system-xtensa-2.0.0-1.el7.6.x86_64
qemu-user-2.0.0-1.el7.6.x86_64
n26:/mnt/local-scratch/vm# 
n26:/mnt/local-scratch/vm# 
n26:/mnt/local-scratch/vm# rpm -qa | grep libvirt | sort
libvirt-4.5.0-10.el7_6.12.x86_64
libvirt-admin-4.5.0-10.el7_6.12.x86_64
libvirt-bash-completion-4.5.0-10.el7_6.12.x86_64
libvirt-client-4.5.0-10.el7_6.12.x86_64
libvirt-daemon-4.5.0-10.el7_6.12.x86_64
libvirt-daemon-config-network-4.5.0-10.el7_6.12.x86_64
libvirt-daemon-config-nwfilter-4.5.0-10.el7_6.12.x86_64
libvirt-daemon-driver-interface-4.5.0-10.el7_6.12.x86_64
libvirt-daemon-driver-lxc-4.5.0-10.el7_6.12.x86_64
libvirt-daemon-driver-network-4.5.0-10.el7_6.12.x86_64
libvirt-daemon-driver-nodedev-4.5.0-10.el7_6.12.x86_64
libvirt-daemon-driver-nwfilter-4.5.0-10.el7_6.12.x86_64
libvirt-daemon-driver-qemu-4.5.0-10.el7_6.12.x86_64
libvirt-daemon-driver-secret-4.5.0-10.el7_6.12.x86_64
libvirt-daemon-driver-storage-4.5.0-10.el7_6.12.x86_64
libvirt-daemon-driver-storage-core-4.5.0-10.el7_6.12.x86_64
libvirt-daemon-driver-storage-disk-4.5.0-10.el7_6.12.x86_64
libvirt-daemon-driver-storage-gluster-4.5.0-10.el7_6.12.x86_64
libvirt-daemon-driver-storage-iscsi-4.5.0-10.el7_6.12.x86_64
libvirt-daemon-driver-storage-logical-4.5.0-10.el7_6.12.x86_64
libvirt-daemon-driver-storage-mpath-4.5.0-10.el7_6.12.x86_64
libvirt-daemon-driver-storage-rbd-4.5.0-10.el7_6.12.x86_64
libvirt-daemon-driver-storage-scsi-4.5.0-10.el7_6.12.x86_64
libvirt-daemon-kvm-4.5.0-10.el7_6.12.x86_64
libvirt-gconfig-1.0.0-1.el7.x86_64
libvirt-glib-1.0.0-1.el7.x86_64
libvirt-gobject-1.0.0-1.el7.x86_64
libvirt-libs-4.5.0-10.el7_6.12.x86_64
libvirt-python-4.5.0-1.el7.x86_64
n26:/mnt/local-scratch/vm# rpm -qa | grep kvm | sort
libvirt-daemon-kvm-4.5.0-10.el7_6.12.x86_64
qemu-kvm-1.5.3-160.el7_6.3.x86_64
qemu-kvm-common-1.5.3-160.el7_6.3.x86_64
qemu-kvm-tools-1.5.3-160.el7_6.3.x86_64
n26:/mnt/local-scratch/vm# uname -r
3.10.0-957.27.2.el7.x86_64
n26:/mnt/local-scratch/vm# cat /etc/centos-release
CentOS Linux release 7.6.1810 (Core) 
n26:/mnt/local-scratch/vm#
```


