### PR TITLE
Testcase kdump increase sleep

### DIFF
--- a/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
+++ b/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
@@ -71,8 +71,9 @@ check:output=~\d\d:\d\d:\d\d
 cmd:xdsh $$CN "echo 'echo 1 > /proc/sys/kernel/sysrq; echo c > /proc/sysrq-trigger' > /tmp/kdump.trigger"
 cmd:xdsh $$CN "chmod 755 /tmp/kdump.trigger"
 cmd:xdsh $$CN "service atd start"
+cmd:sleep 30
 cmd:xdsh $$CN "at now +1 minutes <<< /tmp/kdump.trigger"
-cmd:sleep 300
+cmd:sleep 600
 
 cmd:vmcorefile=`find /opt/xcat/share/xcat/tools/autotest/kdumpdir/ -name vmcore`;if [[ -s $vmcorefile ]]; then echo "this file is not empty";else echo "this file is empty"; fi
 check:output=~not empty


### PR DESCRIPTION
Trying to fix intermittent `linux_diskless_kdump` testcase failures:

1. Add sleep of 30 seconds for `atd` service to start
2. Increase wait time from 300 to 600 seconds for the dump to be generated