### PR TITLE
Verify nslookup output with hostname instead of Server ip address

### DIFF
--- a/xCAT-probe/lib/perl/probe_utils.pm
+++ b/xCAT-probe/lib/perl/probe_utils.pm
@@ -454,9 +454,6 @@ sub is_dns_ready {
         return 0;
     } else {
         chomp($output);
-        my $tmp = grep {$_ =~ "Server:[\t\s]*$serverip"} split(/\n/, $output);
-        return 0 if ($tmp == 0);
-
         $tmp = grep {$_ =~ "name = $hostname\.$domain"} split(/\n/, $output);
         return 0 if ($tmp == 0);
         return 1;

--- a/xCAT-probe/lib/perl/probe_utils.pm
+++ b/xCAT-probe/lib/perl/probe_utils.pm
@@ -454,7 +454,7 @@ sub is_dns_ready {
         return 0;
     } else {
         chomp($output);
-        $tmp = grep {$_ =~ "name = $hostname\.$domain"} split(/\n/, $output);
+        my $tmp = grep {$_ =~ "name = $hostname\.$domain"} split(/\n/, $output);
         return 0 if ($tmp == 0);
         return 1;
     }

--- a/xCAT-probe/subcmds/xcatmn
+++ b/xCAT-probe/subcmds/xcatmn
@@ -1008,7 +1008,7 @@ sub check_dns_service {
                     # if there is no sn, nslookup mnip
                     my $nslkp = `nslookup $serverip $serverip 2>&1`;
                     chomp($nslkp);
-                    my $tmp = grep { $_ =~ "Server:[\t\s]*$serverip" } split(/\n/, $nslkp);
+                    my $tmp = grep {$_ =~ "name = $nodename\.$sitetable_ref->{domain}"} split(/\n/, $nslkp);
                     if (!$tmp) {
                         $rc = 1;
                     }


### PR DESCRIPTION
on the redhat8.0 xCAT management node,  `xcatprobe xcatmn` command always failed with `DNS` issue.
```
[MN]: Checking on MN...                                                                                           [FAIL]
    Checking DNS service is configured...                                                                         [FAIL]
        DNS service isn't ready on 172.12.253.27
```

In the subcmds/xcatmn,  Verify if DNS ready via Server ip address of `nslookup` output
output from redhat7.4:
```
# nslookup 172.20.253.31 172.20.253.31
Server:         172.20.253.31
Address:        172.20.253.31#53

31.253.20.172.in-addr.arpa      name = boston02.pok.stglabs.ibm.com.

```
But on the redhat 8.0.0,  the `nslookup $ipaddress` output didn't contain `Server` ip address
```
# nslookup 172.12.253.27 172.12.253.27
27.253.12.172.IN-ADDR.ARPA      name = briggs01.pok.stglabs.ibm.com.
```

To fix this, we will check hostname instead of Server ip address 