### PR TITLE
Health check xcat-dep files before building tar and remove AIX support

### DIFF
--- a/builddep.sh
+++ b/builddep.sh
@@ -17,6 +17,11 @@
 #       UP=0 or UP=1  - override the default upload behavior
 #       FRSYUM=0      - put the directory of individual rpms in the project web area instead
 #                       of the FRS area.
+#       CHECK=0 or 1  - verify proper file location and links. Default is to check.
+#                       Verifies all noarch files in ..../<OS>/<ARCH>/ are links
+#                       Verifies no broken link files in ..../<OS>/<ARCH>/
+#                       Verifies there are no multiple, real (non-link) files with the same name
+#                       Verifies all real (non-link) files have a link to it
 #       VERBOSE=1     - Set to 1 to see more VERBOSE output
 
 # This script should only be run on RPM based machines 
@@ -30,10 +35,14 @@ fi
 USER=xcat
 TARGET_MACHINE=xcat.org
 
+BASE_GSA=/gsa/pokgsa/projects/x/xcat/build
+GSA=$BASE_GSA/linux/xcat-dep
+
 FRS=/var/www/xcat.org/files/xcat
 OSNAME=$(uname)
 
 UP=0
+CHECK=1
 # Process cmd line variable assignments, assigning each attr=val pair to a variable of same name
 for i in $*; do
 	# upper case the variable name
@@ -41,13 +50,7 @@ for i in $*; do
 	export $varstring
 done
 
-if [ "$OSNAME" == "AIX" ]; then
-	DFNAME=dep-aix-`date +%Y%m%d%H%M`.tar.gz
-	GSA=/gsa/pokgsa/projects/x/xcat/build/aix/xcat-dep
-else
-	DFNAME=xcat-dep-`date +%Y%m%d%H%M`.tar.bz2
-	GSA=/gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep
-fi
+DFNAME=xcat-dep-`date +%Y%m%d%H%M`.tar.bz2
 
 if [ ! -d $GSA ]; then
 	echo "ERROR: This script is intended to be used by xCAT development..."
@@ -117,6 +120,81 @@ function checkrc {
     fi
 }
 
+# Verify files in $GSA
+if [[ ${CHECK} -eq 1 ]]; then
+    ERROR=0
+    LINKED_TO_FILES_ARRAY=[]
+    counter=0
+    OSes=`find $GSA -maxdepth 1 -mindepth 1 -type d`
+    for os in $OSes; do
+        ARCHes=`find $os -maxdepth 1 -mindepth 1 -type d`
+        for arch in $ARCHes; do
+
+            # Find regular noarch.rpm files in <OS>/<ARCH> directory
+            for file in `find $arch -type f -name "*noarch.rpm"`; do
+                ERROR=1
+                echo -e "\nError: Regular 'noarch' file $file found in 'arch' directory. Expected a link."
+            done
+
+            # Find broken links file
+            for file in `find $arch -xtype l -name "*noarch.rpm"`; do
+                ERROR=1
+                echo -e "\nError: Broken link file $file"
+            done
+
+            # Save a link of everything being linked to for later use
+            for link_file in `find $arch -type l -name "*.rpm"`; do
+               LINKED_TO_FILE=`realpath --relative-to=$GSA $link_file`
+               LINKED_TO_FILES_ARRAY[$counter]=$LINKED_TO_FILE
+               counter=$counter+1
+            done
+
+
+        done
+    done
+
+    # Find identical files in $GSA and $GSA/<OS> directory
+    for short_file in $GSA/*.rpm; do
+        basename=$(basename -- "$short_file")
+        DUP_FILES=`find $GSA/*/ -type f -name $basename`
+        if [[ ! -z $DUP_FILES ]]; then
+            ERROR=1
+            echo -e "\nError: Multiple real files with the same name found ($basename):"
+            for dup_file in `find $GSA -type f -name $basename`; do
+                ls -l $dup_file
+            done
+        fi
+    done
+
+    if [ -n "$VERBOSEMODE" ]; then
+        # In verbose mode print contents of array containing all the files someone links to from <OS>/<ARCH>
+        for var in "${LINKED_TO_FILES_ARRAY[@]}"; do
+            echo "Symlink detected to file: ${var} "
+        done
+    fi
+
+    echo " "
+    # Find all files no one links to
+    REAL_FILES=`find $GSA/* -maxdepth 1 -type f -name "*.rpm" | cut -d / -f 10,11 --output-delimiter="/"`
+    for file in $REAL_FILES; do
+        FOUND=0
+        for used_link in "${LINKED_TO_FILES_ARRAY[@]}"; do
+            if [[ $file == $used_link ]]; then
+                FOUND=1
+                break
+            fi
+        done
+        if [[ ${FOUND} -eq 0 ]]; then
+            echo "Warning: No symlinks to file: $GSA/$file"
+        fi
+    done
+
+    if [[ ${ERROR} -eq 1 ]]; then
+        echo -e "\nErrors found verifying files. Rerun this script with CHECK=0 to skip file verification."
+        exit 1
+    fi
+fi
+
 WORKING_TARGET_DIR="${DESTDIR}/xcat-dep"
 # Sync from the GSA master copy of the dep rpms
 mkdir -p ${WORKING_TARGET_DIR}
@@ -132,148 +210,63 @@ cd ${WORKING_TARGET_DIR}
 # add a comment to indicate the latest xcat-dep tar ball name
 sed -i -e "s#REPLACE_LATEST_SNAP_LINE#The latest xcat-dep tar ball is ${DFNAME}#g" README
 
-if [ "$OSNAME" != "AIX" ]; then
-	# Get gpg keys in place
-	mkdir -p ${GNU_KEYDIR}
-	checkrc
-	for i in pubring.gpg secring.gpg trustdb.gpg; do
-		if [ ! -f ${GNU_KEYDIR}/$i ] || [ `wc -c ${GNU_KEYDIR}/$i|cut -f 1 -d' '` == 0 ]; then
-			rm -f ${GNU_KEYDIR}/$i
-			cp $GSA/../keys/$i ${GNU_KEYDIR}
-			chmod 600 ${GNU_KEYDIR}/$i
-		fi
-	done
-
-	# Tell rpm to use gpg to sign
-	if ! $GREP -q '%_signature gpg' $MACROS 2>/dev/null; then
-		echo '%_signature gpg' >> $MACROS
+# Get gpg keys in place
+mkdir -p ${GNU_KEYDIR}
+checkrc
+for i in pubring.gpg secring.gpg trustdb.gpg; do
+	if [ ! -f ${GNU_KEYDIR}/$i ] || [ `wc -c ${GNU_KEYDIR}/$i|cut -f 1 -d' '` == 0 ]; then
+		rm -f ${GNU_KEYDIR}/$i
+		cp $GSA/../keys/$i ${GNU_KEYDIR}
+		chmod 600 ${GNU_KEYDIR}/$i
 	fi
-	if ! $GREP -q '%_gpg_name' $MACROS 2>/dev/null; then
-		echo '%_gpg_name xCAT Automatic Signing Key' >> $MACROS
-	fi
-
-	# Sign the rpms that are not already signed.  The "standard input reopened" warnings are normal.
-	echo "===> Signing RPMs..."
-	$XCATCOREDIR/build-utils/rpmsign.exp `find . -type f -name '*.rpm'` | grep -v -E '(already contains identical signature|was already signed|rpm --quiet --resign|WARNING: standard input reopened)'
-
-	# Create the repodata dirs
-	echo "===> Creating repodata directories..."
-	for i in `find -mindepth 2 -maxdepth 2 -type d `; do
-		if [ -n "$VERBOSEMODE" ]; then
-			createrepo $i            # specifying checksum so the repo will work on rhel5
-		else
-			createrepo $i >/dev/null
-		fi
-		rm -f $i/repodata/repomd.xml.asc
-		gpg -a --detach-sign --default-key 5619700D $i/repodata/repomd.xml
-		if [ ! -f $i/repodata/repomd.xml.key ]; then
-			cp $GSA/../keys/repomd.xml.key $i/repodata
-		fi
-	done
-
-	# Modify xcat-dep.repo files to point to the correct place
-	echo "===> Modifying the xcat-dep.repo files to point to the correct location..."
-
-	echo "===> Making sure that the mklocalrepo.sh file contains execute permission ..." 
-        ls -ltr ${XCATCOREDIR}/${WORKING_TARGET_DIR}/mklocalrepo.sh
-	if [[ ! -x "${XCATCOREDIR}/${WORKING_TARGET_DIR}/mklocalrepo.sh" ]]; then
-		echo "===> --- found not execute, changing +x ..."
-		chmod +x ${XCATCOREDIR}/${WORKING_TARGET_DIR}/mklocalrepo.sh
-	fi
-
-	echo "===> Checking if 'replacelinks' is in the xcat-deps, removing if there ..." 
-	if [[ -f ${XCATCOREDIR}/${WORKING_TARGET_DIR}/replacelinks ]]; then
-		rm -f ${XCATCOREDIR}/${WORKING_TARGET_DIR}/replacelinks
-	fi
-fi
-
-if [ "$OSNAME" == "AIX" ]; then
-	# Build the instoss file ------------------------------------------
-
-	cat >instoss << 'EOF'
-#!/bin/ksh
-# IBM(c) 2007 EPL license http://www.eclipse.org/legal/epl-v10.html
-# xCAT on AIX - prerequisite install script
-cd `dirname $0`
-PERLVER=`perl -v|grep 'This is perl'|cut -d' ' -f 4`
-if [ "$PERLVER" == "v5.8.2" ]; then
-        OSVER='5.3'
-elif [ "$PERLVER" == "v5.8.8" ]; then
-        OSVER='6.1'
-        aixver=`lslpp -lc|grep 'bos.rte:'|head -1|cut -d: -f3`
-                if [[ $aixver < '6.1.9.0' ]]; then
-                        AIX61Y=0
-                else
-                        AIX61Y=1
-                fi
-elif [ "$PERLVER" == "v5.10.1" ]; then
-        OSVER='7.1'
-        aixver=`lslpp -lc|grep 'bos.rte:'|head -1|cut -d: -f3`
-		if [[ $aixver < '7.1.3.0' ]]; then
-			AIX71L=0
-		else
-			AIX71L=1
-		fi
-
-else
-        echo "Error: the perl version of '$PERLVER' is not one that instoss understands.  Exiting..."
-        exit 2
-fi
-cd $OSVER
-# Have to install rpms 1 at a time, since some may be already installed.
-# The only interdependency between the dep rpms so far is that net-snmp requires bash, and
-# pyodbc requires unixODBC.  (The bash dependency is taken care of automatically because it
-# comes earlier in the alphabet.)
-
-# first run /usr/sbin/updtvpkg to make sure any installp software is
-# registered with RPM.
-echo "Running updtvpkg. This could take a few minutes."
-/usr/sbin/updtvpkg
-echo "updtvpkg has completed."
-
-# unixODBC is required by pyodbc, so install it first
-rpm -Uvh unixODBC*
-# Now install the bulk of the rpms, one at a time, in case some are already installed
-for i in `ls *.rpm|grep -v -E '^tcl-|^tk-|^expect-|^unixODBC-|^xCAT-UI-deps|^perl-DBD-DB2Lite|^net-snmp'`; do
-	if [ "$i" == "perl-Net-DNS-0.66-1.aix5.3.ppc.rpm" ]; then
-		opts="--nodeps"
-	else
-		opts=""
-	fi
-
-	# On 7.1L and 6.1Y we need a newer version of perl-Net_SSLeay.pm
-	if [[ $AIX71L -eq 1 || $AIX61Y -eq 1 ]]; then
-		if [[ $i == perl-Net_SSLeay.pm-1.30-* ]]; then continue; fi 	# skip the old rpm
-	else
-		if [[ $i == perl-Net_SSLeay.pm-1.55-* ]]; then continue; fi 	# skip the new rpm
-	fi
-	
-	echo rpm -Uvh $opts $i
-	rpm -Uvh $opts $i
 done
-# Have to upgrade all of the net-snmp rpms together because they depend on each other.
-# Also, they require bash, so do it after the loop, rather than before
-rpm -Uvh net-snmp*
 
-EOF
-# end of instoss file content ---------------------------------------------
+# Tell rpm to use gpg to sign
+if ! $GREP -q '%_signature gpg' $MACROS 2>/dev/null; then
+	echo '%_signature gpg' >> $MACROS
+fi
+if ! $GREP -q '%_gpg_name' $MACROS 2>/dev/null; then
+	echo '%_gpg_name xCAT Automatic Signing Key' >> $MACROS
+fi
 
+# Sign the rpms that are not already signed.  The "standard input reopened" warnings are normal.
+echo "===> Signing RPMs..."
+$XCATCOREDIR/build-utils/rpmsign.exp `find . -type f -name '*.rpm'` | grep -v -E '(already contains identical signature|was already signed|rpm --quiet --resign|WARNING: standard input reopened)'
 
-	chmod +x instoss
+# Create the repodata dirs
+echo "===> Creating repodata directories..."
+for i in `find -mindepth 2 -maxdepth 2 -type d `; do
+	if [ -n "$VERBOSEMODE" ]; then
+		createrepo $i            # specifying checksum so the repo will work on rhel5
+	else
+		createrepo $i >/dev/null
+	fi
+	rm -f $i/repodata/repomd.xml.asc
+	gpg -a --detach-sign --default-key 5619700D $i/repodata/repomd.xml
+	if [ ! -f $i/repodata/repomd.xml.key ]; then
+		cp $GSA/../keys/repomd.xml.key $i/repodata
+	fi
+done
+
+# Modify xcat-dep.repo files to point to the correct place
+echo "===> Modifying the xcat-dep.repo files to point to the correct location..."
+
+echo "===> Making sure that the mklocalrepo.sh file contains execute permission ..." 
+ls -ltr ${XCATCOREDIR}/${WORKING_TARGET_DIR}/mklocalrepo.sh
+if [[ ! -x "${XCATCOREDIR}/${WORKING_TARGET_DIR}/mklocalrepo.sh" ]]; then
+	echo "===> --- found not execute, changing +x ..."
+	chmod +x ${XCATCOREDIR}/${WORKING_TARGET_DIR}/mklocalrepo.sh
+fi
+
+echo "===> Checking if 'replacelinks' is in the xcat-deps, removing if there ..." 
+if [[ -f ${XCATCOREDIR}/${WORKING_TARGET_DIR}/replacelinks ]]; then
+	rm -f ${XCATCOREDIR}/${WORKING_TARGET_DIR}/replacelinks
 fi
 
 # Get the permissions and group correct
-if [ "$OSNAME" == "AIX" ]; then
-	# AIX
-	SYSGRP=system
-	YUM=aix
-	FRSDIR='2.x_AIX'
-else
-	# Linux
-	SYSGRP=root
-	YUM=yum/devel
-	FRSDIR='2.x_Linux'
-fi
+SYSGRP=root
+YUM=yum/devel
+FRSDIR='2.x_Linux'
 chgrp -R -h $SYSGRP *
 chmod -R g+w *
 
@@ -298,14 +291,7 @@ if [ -n "$VERBOSEMODE" ]; then
 fi
 
 echo "===> Creating $DFNAME ..."
-if [ "$OSNAME" == "AIX" ]; then
-	tar $verbosetar -cf ${DFNAME%.gz} xcat-dep
-	rm -f $DFNAME
-	gzip ${DFNAME%.gz}
-else
-	# Linux
-	tar $verbosetar -jcf $DFNAME xcat-dep
-fi
+tar $verbosetar -jcf $DFNAME xcat-dep
 
 if [[ ${UP} -eq 0 ]]; then
 	echo "Upload not being done, set UP=1 to upload to xcat.org"


### PR DESCRIPTION
Do some verification to check health of the `xcat-dep` files in GSA before building `.tar`
Remove support for AIX last supported in xCAT 2.9.x

```
[gurevich@c910loginx02 xcat-core]$ ./builddep.sh CHECK=1
Checking for package=rpm-sign ...
Checking for package=createrepo ...
INFO: Running script from here: /u/gurevich/xcat211/xcat-core ...
INFO: Target package name: xcat-dep-201909031130.tar.bz2
INFO: Target package will be created here: /u/gurevich/xcat211/xcat-core/../xcat-dep-build

Error: Regular 'noarch' file /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/sles12/x86_64/perl-Crypt-CBC-2.33-3.7.noarch.rpm found in 'arch' directory. Expected a link.

Error: Regular 'noarch' file /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/sles12/x86_64/perl-HTML-Form-6.03-5.1.noarch.rpm found in 'arch' directory. Expected a link.

Error: Regular 'noarch' file /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/rh7/s390x/perl-Expect-1.21-1.noarch.rpm found in 'arch' directory. Expected a link.

Error: Multiple real files with the same name found (perl-HTTP-Async-0.30-2.noarch.rpm):
-rw-rw-r-- 1 vhu p/xcat/admin 19796 Jun  5 21:19 /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/perl-HTTP-Async-0.30-2.noarch.rpm
-rw-rw-r-- 1 vhu p/xcat/admin 22408 Jun  5 21:19 /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/rh8/perl-HTTP-Async-0.30-2.noarch.rpm

Error: Multiple real files with the same name found (perl-Net-HTTPS-NB-0.14-2.noarch.rpm):
-rw-rw-r-- 1 vhu p/xcat/admin 10068 Jun  5 21:19 /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/perl-Net-HTTPS-NB-0.14-2.noarch.rpm
-rw-rw-r-- 1 vhu p/xcat/admin 9132 Jun  5 21:19 /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/rh8/perl-Net-HTTPS-NB-0.14-2.noarch.rpm

Error: Multiple real files with the same name found (perl-SOAP-Lite-0.710.08-1.noarch.rpm):
-rw-rw-r-- 1 vhu p/xcat/admin 363809 Jun  5 21:19 /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/perl-SOAP-Lite-0.710.08-1.noarch.rpm
-rw-rw-r-- 1 vhu p/xcat/admin 333754 Jun  5 21:19 /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/sles12/perl-SOAP-Lite-0.710.08-1.noarch.rpm
-rw-rw-r-- 1 vhu p/xcat/admin 274705 Jun  5 21:19 /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/rh7/perl-SOAP-Lite-0.710.08-1.noarch.rpm

Error: Multiple real files with the same name found (perl-version-0.76-1.noarch.rpm):
-rw-rw-r-- 1 vhu p/xcat/admin 28087 Jun  5 21:19 /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/perl-version-0.76-1.noarch.rpm
-rw-rw-r-- 1 vhu p/xcat/admin 27805 Jun  5 21:19 /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/sles12/perl-version-0.76-1.noarch.rpm
-rw-rw-r-- 1 vhu p/xcat/admin 74785 Jun  5 21:19 /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/rh7/perl-version-0.76-1.noarch.rpm

Warning: No symlinks to file: /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/perl-SOAP-Lite-0.710.08-1.noarch.rpm
Warning: No symlinks to file: /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/perl-version-0.76-1.noarch.rpm
Warning: No symlinks to file: /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/rh7/perl-version-0.76-1.noarch.rpm
Warning: No symlinks to file: /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/sles12/perl-version-0.76-1.noarch.rpm
Warning: No symlinks to file: /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/sles12/perl-XML-Simple-2.18-1.noarch.rpm
Warning: No symlinks to file: /gsa/pokgsa/projects/x/xcat/build/linux/xcat-dep/sles12/perl-Expect-1.21-1.noarch.rpm

Errors found verifying files. Rerun this script with CHECK=0 to skip file verification.
[gurevich@c910loginx02 xcat-core]$
```