### PR TITLE
Make xcat-dep tar file readable by all

### DIFF
--- a/builddep.sh
+++ b/builddep.sh
@@ -292,6 +292,7 @@ fi
 
 echo "===> Creating $DFNAME ..."
 tar $verbosetar -jcf $DFNAME xcat-dep
+chmod a+r $DFNAME
 
 if [[ ${UP} -eq 0 ]]; then
 	echo "Upload not being done, set UP=1 to upload to xcat.org"


### PR DESCRIPTION
Force `xcat-dep` .tar file readable by all. 
Reported by https://github.ibm.com/xcat2/team_process/issues/186

```
[gurevich@c910loginx02 xcat-core]$ ls -l ../xcat-dep-build/
total 822512
drwxrwsr-x 5 gurevich gurevich      2048 Sep  5 11:01 xcat-dep
-rw-r--r-- 1 gurevich gurevich 280863877 Sep  5 10:05 xcat-dep-201909051002.tar.bz2
-rw-r--r-- 1 gurevich gurevich 280690968 Sep  5 10:50 xcat-dep-201909051048.tar.bz2
-rw-r--r-- 1 gurevich gurevich 280691605 Sep  5 11:04 xcat-dep-201909051101.tar.bz2
[gurevich@c910loginx02 xcat-core]$
```
```
xcat@sense:/var/www/xcat.org/files/xcat/xcat-dep/2.x_Linux$ ls -ltr /var/www/xcat.org/files/xcat/xcat-dep/2.x_Linux/xcat-dep-201909051*
-rw-r--r-- 1 xcat xcat 280863877 Sep  5 08:07 /var/www/xcat.org/files/xcat/xcat-dep/2.x_Linux/xcat-dep-201909051002.tar.bz2
-rw-r--r-- 1 xcat xcat 280691605 Sep  5 09:05 /var/www/xcat.org/files/xcat/xcat-dep/2.x_Linux/xcat-dep-201909051101.tar.bz2
xcat@sense:/var/www/xcat.org/files/xcat/xcat-dep/2.x_Linux$
```