### PR TITLE
Openbmc hardware control with OP940 firmware

### DIFF
--- a/xCAT-server/lib/perl/xCAT/OPENBMC.pm
+++ b/xCAT-server/lib/perl/xCAT/OPENBMC.pm
@@ -25,6 +25,8 @@ use xCAT::TableUtils;
 my $PYTHON_AGENT_FILE = "/opt/xcat/lib/python/agent/agent.py";
 
 my $header = HTTP::Headers->new('Content-Type' => 'application/json');
+# Currently not used, example of header to use for authorization
+#my $header = HTTP::Headers->new('X-Auth-Token' => 'xfMHrrxdMgbiITnX0TlN');
 
 sub new {
     my $async = shift;
@@ -44,8 +46,16 @@ sub send_request {
     my $method = shift;
     my $url = shift;
     my $content = shift;
+    my $username = shift;
+    my $password = shift;
 
     my $request = HTTP::Request->new( $method, $url, $header, $content );
+    if (defined $username and defined $password) {
+        # If username and password were passed in use authorization_basic()
+        # This is required to connect to BMC with OP940 level, ignored for 
+        # lower OP levels
+        $request->authorization_basic($username, $password);
+    }
     my $id = $async->add_with_opts($request, {});
     return $id;
 }

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -2452,7 +2452,7 @@ sub gen_send_request {
         }
         process_debug_info($node, $debug_info);
     }
-    my $handle_id = xCAT::OPENBMC->send_request($async, $method, $request_url, $content);
+    my $handle_id = xCAT::OPENBMC->send_request($async, $method, $request_url, $content, $node_info{$node}{username}, $node_info{$node}{password});
     $handle_id_node{$handle_id} = $node;
     $node_info{$node}{cur_status} = $next_status{ $node_info{$node}{cur_status} };
 
@@ -4212,7 +4212,7 @@ sub rspconfig_dump_response {
 sub dump_download_process {
     my $node = shift;
 
-    my $request_url = "$http_protocol://" . $node_info{$node}{bmc};
+    my $request_url = "$http_protocol://" . $node_info{$node}{username} . ":" . $node_info{$node}{password} . "@" . $node_info{$node}{bmc};
     my $content_login = '{ "data": [ "' . $node_info{$node}{username} .'", "' . $node_info{$node}{password} . '" ] }';
     my $content_logout = '{ "data": [ ] }';
     my $cjar_id = "/tmp/_xcat_cjar.$node";
@@ -4876,7 +4876,7 @@ sub rflash_response {
 
 sub rflash_upload {
     my ($node, $callback) = @_;
-    my $request_url = "$http_protocol://" . $node_info{$node}{bmc};
+    my $request_url = "$http_protocol://" . $node_info{$node}{username} . ":" . $node_info{$node}{password} . "@" . $node_info{$node}{bmc};
     my $content_login = '{ "data": [ "' . $node_info{$node}{username} .'", "' . $node_info{$node}{password} . '" ] }';
     my $content_logout = '{ "data": [ ] }';
     my $cjar_id = "/tmp/_xcat_cjar.$node";


### PR DESCRIPTION
### The PR is to fix issue _#6424_

### The modification include:

- For `rflash` command use `username:password@bmc/path...`  in `curl` call
- For `rspconfig dump` command use `username:password@bmc/path...`  in `curl` call
- Everything else, add `$request->authorization_basic($username, $password);` to each request

### The UT result

- OP940 installed:
```
[root@stratton01 xcat]# rflash f5u14 -l
f5u14: ID       Purpose State      Version
f5u14: -------------------------------------------------------
f5u14: 5db5efd5 BMC     Active(*)  ibm-v2.7.0-rc1-5-gfd9b55f-r15-0-g1eef031
f5u14: 33029bc1 Host    Active     IBM-witherspoon-ibm-OP9_v1.19_1.192
f5u14: cf421794 BMC     Active     ibm-v2.3-476-g2d622cb-r32-0-g9973ab0
f5u14: 1be29de2 Host    Active(*)  IBM-witherspoon-OP9_v2.0.14_1.2
f5u14:
[root@stratton01 xcat]#
```
- Setting `autoreboot`:
```
[root@stratton01 xcat]# rspconfig f5u14 autoreboot=0
f5u14: BMC Setting BMC AutoReboot...
[root@stratton01 xcat]#
```
- Generating a dump:
```
[root@stratton01 xcat]# rspconfig f5u14 dump
Capturing BMC Diagnostic information, this will take some time...
f5u14: Dump requested. Target ID is 444, waiting for BMC to generate...
f5u14: Still waiting for dump 444 to be generated...
f5u14: Downloading dump 444 to stratton01:/var/log/xcat/dump/20190912-1446_f5u14_dump_444.tar.xz
[root@stratton01 xcat]#
```
- `rbeacon` command:
```
[root@stratton01 xcat]# rbeacon f5u14 on
f5u14: on
[root@stratton01 xcat]#
```

- `rflash` command:
```
[root@stratton01 OP930]# rflash f5u14 -u ./witherspoon.pnor.squashfs.tar
Attempting to upload /tmp/OP930/./witherspoon.pnor.squashfs.tar, please wait...
f5u14: Firmware upload successful. Use -l option to list.
[root@stratton01 OP930]#
```

- `rpower` command:
```
[root@stratton01 OP930]# rpower f5u14 state
f5u14: off
[root@stratton01 OP930]# rpower f5u14 on
f5u14: on
[root@stratton01 OP930]# rpower f5u14 state
f5u14: on
[root@stratton01 OP930]#
```
