### PR TITLE
Ubuntu dependency build

### DIFF
--- a/build-ubunturepo
+++ b/build-ubunturepo
@@ -24,6 +24,10 @@
 #                            prep for a release.
 #               GPGSIGN=0 -  Do not sign the repo in the end of the build. The repo will be signed by default
 #
+#               LOCAL_KEY=1  Use local keys to sign repo instead of WGET from GSA. By default use GSA.
+#
+#               SETUP=1      Setup environment for build. By default do not setup environment.
+#
 #               LOG=<filename> - provide an LOG file option to redirect some output into log file
 #
 #               DEST=<directory> - provide a directory to contains the build result
@@ -48,16 +52,8 @@ if [[ ! -f /etc/lsb-release ]]; then
 fi
 . /etc/lsb-release
 
-# Check the necessary packages before starting the build
-declare -a packages=( "reprepro" "devscripts" "debhelper" "libsoap-lite-perl" "libdbi-perl" "quilt" "git")
+export HOME=/root
 
-for package in ${packages[@]}; do
-    RC=`dpkg -l | grep $package >> /dev/null 2>&1; echo $?`
-    if [[ ${RC} != 0 ]]; then
-        echo "ERROR: Could not find $package, install using 'apt-get install $package' to continue"
-        exit 1
-    fi
-done
 
 # Process cmd line variable assignments, assigning each attr=val pair to a variable of same name
 for i in $*; do
@@ -68,6 +64,44 @@ for i in $*; do
         # upper case the variable name
         varstring=`echo "$i"|cut -d '=' -f 1|tr '[a-z]' '[A-Z]'`=`echo "$i"|cut -d '=' -f 2`
         export $varstring
+done
+
+#Setup environment so the xcat-deps can be built on a FVT test machine
+if [ "$SETUP" = "1" ];then
+   #Mount GSA
+   POKGSA="/gsa/pokgsa"
+   POKGSA2="/gsa/pokgsa-p2"
+   POKGSAIBM="pokgsa.ibm.com"
+   if [ ! -d $POKGSA ];then
+      mkdir -p $POKGSA
+      mount ${POKGSAIBM}:${POKGSA} ${POKGSA}
+   fi
+   if [ ! -d $POKGSA2 ];then
+      mkdir -p $POKGSA2
+      mount ${POKGSAIBM}:${POKGSA2} ${POKGSA2}
+   fi
+
+   # Verify needed packages installed
+   REPREPO="reprepro"
+   DEVSCRIPTS="devscripts"
+   DEBHELPER="debhelper"
+   QUILT="quilt"
+
+   apt-get -y install $REPREPO $DEVSCRIPTS $DEBHELPER $QUILT
+
+   echo "Finised setup for xcat-dep build. Rerun this script with SETUP=0 LOCAL_KEY=1 flags"
+   exit 1
+fi
+
+# Check the necessary packages before starting the build
+declare -a packages=( "reprepro" "devscripts" "debhelper" "libsoap-lite-perl" "libdbi-perl" "quilt" "git")
+
+for package in ${packages[@]}; do
+    RC=`dpkg -l | grep $package >> /dev/null 2>&1; echo $?`
+    if [[ ${RC} != 0 ]]; then
+        echo "ERROR: Could not find $package, install using 'apt-get install $package' to continue"
+        exit 1
+    fi
 done
 
 # Supported distributions
@@ -136,8 +170,6 @@ function setbranch {
     fi
 }
 
-export HOME=/root
-
 WGET_CMD="wget"
 if [ ! -z ${LOG} ]; then
     WGET_CMD="wget -o ${LOG}"
@@ -150,10 +182,16 @@ else
     gsa_url=http://pokgsa.ibm.com/projects/x/xcat/build/linux
     mkdir -p $HOME/.gnupg
     for key_name in pubring.gpg secring.gpg trustdb.gpg; do
-        if [ ! -f $HOME/.gnupg/$key_name ] || [ `wc -c $HOME/.gnupg/$key_name|cut -f 1 -d' '` == 0 ]; then
-            rm -f $HOME/.gnupg/$key_name
-            ${WGET_CMD} -P $HOME/.gnupg $gsa_url/keys/$key_name
+        if [ "$LOCAL_KEY" = "1" ];then
+            # Keys are already in the local $HOME/.gnupg directory
             chmod 600 $HOME/.gnupg/$key_name
+        else
+            # Need to download keys from GSA
+            if [ ! -f $HOME/.gnupg/$key_name ] || [ `wc -c $HOME/.gnupg/$key_name|cut -f 1 -d' '` == 0 ]; then
+                rm -f $HOME/.gnupg/$key_name
+                ${WGET_CMD} -P $HOME/.gnupg $gsa_url/keys/$key_name
+                chmod 600 $HOME/.gnupg/$key_name
+            fi
         fi
     done
 fi
@@ -424,9 +462,8 @@ then
 
     #the path of ubuntu xcat-dep deb packages on GSA
     GSA="/gsa/pokgsa/projects/x/xcat/build/ubuntu/xcat-dep"
-
     if [ ! -d $GSA ]; then
-       echo "build-ubunturepo:  It appears that you do not have gsa installed to access the xcat-dep pkgs."
+       echo "build-ubunturepo:  It appears that you do not have GSA to access the xcat-dep pkgs."
        exit 1;
     fi
 


### PR DESCRIPTION
Add a little more automation to building Ubuntu `xcat-dep` package.
This pull request adds `SETUP` and `LOCAL_KEY` flags to ` build-ubunturepo` script.

* The `SETUP=1` flag will mount GSA directories and install needed packages to the server chosen for `xcat-dep` build.
* The `LOCAL_KEY=1` flag allows using keys manually copied from GSA `/gsa/pokgsa/projects/x/xcat/build/linux/keys/*.gpg` to `$HOME/.gnupg` directory for signing packages. If   `LOCAL_KEY=0` is specified, the script attempts to use `wget` to get the keys from GSA.