### PR TITLE
Handle the bad return code if rinstall is failed on nodeset

### DIFF
--- a/xCAT-server/lib/xcat/plugins/rinstall.pm
+++ b/xCAT-server/lib/xcat/plugins/rinstall.pm
@@ -387,6 +387,16 @@ sub rinstall {
             xCAT::MsgUtils->message("I", $rsp, $callback);
         }
 
+        # if only provision one node and failed nodeset, will exit the command
+        # instead of continue with rnetboot/rsetboot, rpower.
+        if (scalar(@nodes) == 1) {
+            $rsp->{error}->[0] = "Failed to run 'nodeset' against the node: @nodes";
+            $rsp->{errorcode}->[0] = 1;
+            xCAT::MsgUtils->message("E", $rsp, $callback);
+            return 1;
+        }
+
+
         foreach my $node (@failurenodes) {
             delete $nodes{$node};
         }


### PR DESCRIPTION
For issue #6335 , 
the fixes is only apply to one node,  if `rinstall` command run for multiple nodes, the flow will be same as before.

multiple nodes case:
```
 # rinstall c910f04x35v05,c910f04x37v08
Provision node(s): c910f04x37v08 c910f04x35v05
c910f04x35v05: Failed to detect copycd configured install source at /install/sles12.3/x86_64
c910f04x37v08: install rhels7.6-x86_64-compute
Failed to generate xnba configurations for some node(s) on c910f03c17k07. Check xCAT log file for more details.
# echo $?
0
```
one node case:
```
# rinstall c910f04x35v05 'osimage=sles12.3-x86_64-install-compute'
Provision node(s): c910f04x35v05
c910f04x35v05: Failed to detect copycd configured install source at /install/sles12.3/x86_64
Failed to generate xnba configurations for some node(s) on c910f03c17k07. Check xCAT log file for more details.
Error: Failed to run 'nodeset' against the node: c910f04x35v05
# echo $?
1
```

