### PR TITLE
Remove old debug statements

### DIFF
--- a/xCAT-server/lib/xcat/plugins/kvm.pm
+++ b/xCAT-server/lib/xcat/plugins/kvm.pm
@@ -49,7 +49,6 @@ if (Sys::Virt->VERSION =~ /^0\.[10]\./) {
 use XML::Simple;
 $XML::Simple::PREFERRED_PARSER = 'XML::Parser';
 
-use Data::Dumper;
 use POSIX "WNOHANG";
 use Storable qw(freeze thaw store_fd fd_retrieve);
 use IO::Select;
@@ -3887,20 +3886,12 @@ sub process_request {
     $confdata = {};
     unless ($command eq 'rscan') {
         xCAT::VMCommon::grab_table_data($noderange, $confdata, $callback);
-        # Add debug info for issue 1958, the rmvm issue
-        my $test_file_fd;
-        open($test_file_fd, ">> $::XCATROOT//share/xcat/tools/autotest/result/$command.$$.rec");
-        print $test_file_fd "====================start==========================\n";
         my $kvmdatatab = xCAT::Table->new("kvm_nodedata", -create => 0); #grab any pertinent pre-existing xml
         if ($kvmdatatab) {
             $confdata->{kvmnodedata} = $kvmdatatab->getNodesAttribs($noderange, [qw/xml/]);
-            print $test_file_fd Dumper($confdata->{kvmnodedata});
         } else {
             $confdata->{kvmnodedata} = {};
-            print $test_file_fd "***Error: Can not open kvm_nodedata table==\n";
         }
-        print $test_file_fd "====================end==========================\n";
-        close $test_file_fd;
     }
     if ($command eq 'mkvm' or ($command eq 'clonevm' and (grep { "$_" eq '-b' } @exargs)) or ($command eq 'rpower' and (grep { "$_" eq "on" or $_ eq "boot" or $_ eq "reset" } @exargs))) {
         xCAT::VMCommon::requestMacAddresses($confdata, $noderange);


### PR DESCRIPTION
Back in 2016 while working on issue #1958 a PR #2166 was merged which added some debug statements to be written to a file each time console connection was attempted to a VM.

That code causes thousands of files to be generated on MN in `/opt/xcat/share/xcat/tools/autotest/result/` with VM debug information.