### PR TITLE
OpenBMC fixes for OP940 changes [Python]

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/common/rest.py
+++ b/xCAT-openbmc-py/lib/python/agent/common/rest.py
@@ -15,10 +15,12 @@ from . import exceptions as xcat_exception
 
 class RestSession(object):
 
-    def __init__(self):
+    def __init__(self, auth=None):
         self.session = requests.Session()
         self.cookies = None
-        self.auth = None
+        # If userid and password were passed in, use them for basic authorization
+        # This is required to connect to BMC with OP940 level, ignored for lower OP levels
+        self.auth = auth
 
     def request(self, method, url, headers, data=None, timeout=30):
 

--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -248,12 +248,12 @@ RSPCONFIG_APIS = {
 
 EVENTLOG_URLS     = {
         "list":      "/logging/enumerate",
-        "clear_all": "/logging/action/deleteAll",
+        "clear_all": "/logging/action/DeleteAll",
         "resolve":   "/logging/entry/{}/attr/Resolved",
 }
 
 RAS_POLICY_TABLE  = "/opt/ibm/ras/lib/policyTable.json"
-RAS_POLICY_MSG    = "Install the OpenBMC RAS package to obtain more details logging messages."
+RAS_POLICY_MSG    = "Install the OpenBMC RAS package to obtain more detailed logging messages."
 RAS_NOT_FOUND_MSG = " Not found in policy table: "
 
 RESULT_OK = 'ok'
@@ -279,7 +279,7 @@ class OpenBMCRest(object):
         # print back to xcatd or just stdout
         self.messager = kwargs.get('messager')
 
-        self.session = rest.RestSession()
+        self.session = rest.RestSession((self.username,self.password))
         self.root_url = HTTP_PROTOCOL + self.bmcip + PROJECT_URL
         self.download_root_url = HTTP_PROTOCOL + self.bmcip + '/'
 


### PR DESCRIPTION
### The PR is to fix issue _#6424_ in Python

In Python version of xCAT code only 2 things need to be fixed:

* _DeleteAll_ - New REST server is case sensitive. Need to use `DeleteAll` instead of `deleteAll`
* Everything else, use basic authorization for each request

## UT: ##

* Basic authentication with OP940:
```
[root@stratton01 xcat]# rflash f5u14 -l
f5u14: ID       Purpose State      Version
f5u14: -------------------------------------------------------
f5u14: 9a7dd126 Host    Ready      IBM-witherspoon-OP9-v2.4-4.13
f5u14: 5db5efd5 BMC     Active(*)  ibm-v2.7.0-rc1-5-gfd9b55f-r15-0-g1eef031
f5u14: 33029bc1 Host    Active     IBM-witherspoon-ibm-OP9_v1.19_1.192
f5u14: cf421794 BMC     Active     ibm-v2.3-476-g2d622cb-r32-0-g9973ab0
f5u14: 1be29de2 Host    Active(*)  IBM-witherspoon-OP9_v2.0.14_1.2
f5u14:
[root@stratton01 xcat]#

[root@stratton01 xcat]# rbeacon f5u14 on -V
[stratton01]: Running command in Python
[stratton01]: f5u14: on
[root@stratton01 xcat]#
```

* Basic authentication with prior to OP940:

```
[root@stratton01 xcat]# rflash f6u07 -l
f6u07: ID       Purpose State      Version
f6u07: -------------------------------------------------------
f6u07: 1c2485da Host    Active     IBM-witherspoon-ibm-OP9_v1.19_1.102
f6u07: b04fff27 BMC     Active(*)  ibm-v2.0-0-r46-0-gbed584c
f6u07: 33029bc1 Host    Active(*)  IBM-witherspoon-ibm-OP9_v1.19_1.192
f6u07: f57b7b1b BMC     Active     ibm-v2.0-0-r26-0-g7285b52
f6u07:
[root@stratton01 xcat]#

[root@stratton01 xcat]# rbeacon f6u07 on -V
[stratton01]: Running command in Python
[stratton01]: f6u07: on
[root@stratton01 xcat]#
```


