### PR TITLE
remove node definition from rscan

### DIFF
--- a/xCAT-test/autotest/testcase/rscan/cases0
+++ b/xCAT-test/autotest/testcase/rscan/cases0
@@ -24,6 +24,7 @@ end
 start:rscan_w
 label:others,hctrl_hmc
 hcp:hmc
+cmd:lsdef -t node all -z > /tmp/all.stanza
 cmd:lsdef -t node -l $$CN -z > /tmp/$$CN.stanza
 check:rc==0
 cmd:perl -pi -e 's/$$CN/testnode/g' /tmp/$$CN.stanza
@@ -37,14 +38,15 @@ check:output=~hmc\s+__GETNODEATTR($$CN,hcp)__+\s+\w{4}-\w{3}\s+\w{7}
 cmd:lsdef -l $$CN
 check:rc==0
 check:output=~hcp=__GETNODEATTR($$CN,hcp)__
-cmd:rmdef $$CN,testnode
-cmd:perl -pi -e 's/testnode/$$CN/g' /tmp/$$CN.stanza
-cmd:cat /tmp/$$CN.stanza | mkdef -z
+cmd:rmdef all
+cmd:cat /tmp/all.stanza | mkdef -z
+cmd:rm -f /tmp/all.stanza
 cmd:rm -f /tmp/$$CN.stanza
 end
 start:rscan_x_w
 label:others,hctrl_hmc
 hcp:hmc
+cmd:lsdef -t node all -z > /tmp/all.stanza
 cmd:lsdef -t node -l $$CN -z > /tmp/$$CN.stanza
 check:rc==0
 cmd:perl -pi -e 's/$$CN/testnode/g' /tmp/$$CN.stanza
@@ -56,14 +58,15 @@ check:output=~<parent>[\w-]+</parent>
 cmd:lsdef -l $$CN
 check:rc==0
 check:output=~hcp=__GETNODEATTR($$CN,hcp)__
-cmd:rmdef $$CN,testnode
-cmd:perl -pi -e 's/testnode/$$CN/g' /tmp/$$CN.stanza
-cmd:cat /tmp/$$CN.stanza | mkdef -z
+cmd:rmdef all
+cmd:cat /tmp/all.stanza | mkdef -z
+cmd:rm -f /tmp/all.stanza
 cmd:rm -f /tmp/$$CN.stanza
 end
 start:rscan_z_w
 label:others,hctrl_hmc
 hcp:hmc
+cmd:lsdef -t node all -z > /tmp/all.stanza
 cmd:lsdef -t node -l $$CN -z > /tmp/$$CN.stanza
 check:rc==0
 cmd:perl -pi -e 's/$$CN/testnode/g' /tmp/$$CN.stanza
@@ -75,9 +78,8 @@ check:output=~parent=[\w-]+
 check:lsdef -l $$CN
 check:rc==0
 check:output=~parent=[\w-]+
-cmd:rmdef $$CN,testnode
-cmd:perl -pi -e 's/testnode/$$CN/g' /tmp/$$CN.stanza
-cmd:cat /tmp/$$CN.stanza | mkdef -z
+cmd:rmdef all
+cmd:cat /tmp/all.stanza | mkdef -z
+cmd:rm -f /tmp/all.stanza
 cmd:rm -f /tmp/$$CN.stanza
 end
-


### PR DESCRIPTION
In the regression test case `rhels7.6-P8LPARs-Mysql-master-daily`,  the test cases `rscan_w` or `rscan_x_w` or `rscan_z_w`  created all the node definitions into xcat database from `rscan c901hmc2` and the node definitions didn't get to removed after test cases finished.
```
[root@c910f02c39p09 ~]# nodels | wc
     81      81    1115
```
81 node definitions created on the regression test cluster, normally should be only four for lpar clusters.
```
[root@c910f02c39p06 ~]# nodels
c910f02c39p07      <---server node
c910f02c39p08       <---compute node
c910f02fsp39         <--- fsp/cec
c910hmc02             <-- hmc
```
