### PR TITLE
Clean genimage before kdump test

### DIFF
--- a/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
+++ b/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
@@ -47,6 +47,7 @@ check:rc==0
 cmd:chdef -t node $$CN -p postscripts=enablekdump
 check:rc==0
 
+cmd:rmimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 cmd:genimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 cmd:packimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
@@ -70,10 +71,13 @@ check:rc==0
 check:output=~\d\d:\d\d:\d\d
 cmd:xdsh $$CN "echo 'echo 1 > /proc/sys/kernel/sysrq; echo c > /proc/sysrq-trigger' > /tmp/kdump.trigger"
 cmd:xdsh $$CN "chmod 755 /tmp/kdump.trigger"
+
+cmd:xdsh $$CN "rpm -q at"
 cmd:xdsh $$CN "service atd start"
-cmd:sleep 30
+check:rc==0
+
 cmd:xdsh $$CN "at now +1 minutes <<< /tmp/kdump.trigger"
-cmd:sleep 600
+cmd:sleep 300
 
 cmd:vmcorefile=`find /opt/xcat/share/xcat/tools/autotest/kdumpdir/ -name vmcore`;if [[ -s $vmcorefile ]]; then echo "this file is not empty";else echo "this file is empty"; fi
 check:output=~not empty


### PR DESCRIPTION
Changes introduced by PR #6413 did not work.
The `linux_diskless_kdump` testcase still fails.

Even though the `at` package appears to be installed into the diskless image, when the node boots, it is not there.

This PR:
* Restores the delay changed by #6413
* Adds `rmimage` to cleanup the image before `genimage`
* Adds RC check so that we can see if `service at start` fails.
* Adds command to display if `at` service is installed.