### PR TITLE
bmcdiscover node name when serial or mtm and mac not available

### DIFF
--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -1160,8 +1160,10 @@ sub bmcdiscovery_ipmi {
             $mtm = '' if ($mtm =~ /^0+$/);
             $serial = '' if ($serial =~ /^0+$/);
 
-            unless (($mtm or $serial) or $ipmac{$ip}) {
-                xCAT::MsgUtils->message("W", { data => ["BMC Type/Model and/or Serial and MAC Address is unavailable for $ip"] }, $::CALLBACK);
+            # To constract a node name need either mac or both mtm and serial
+            # Exit if mac AND one of mtm or serial is missing
+            if (!($mtm and $serial) and !$ipmac{$ip}) {
+                xCAT::MsgUtils->message("W", { data => ["BMC Type/Model and Serial or MAC Address is unavailable for $ip"] }, $::CALLBACK);
                 return;
             }
 
@@ -1292,8 +1294,10 @@ sub bmcdiscovery_openbmc{
         $mtm = '' if ($mtm =~ /^0+$/);
         $serial = '' if ($serial =~ /^0+$/);
 
-        unless (($mtm or $serial) or $ipmac{$ip}) {
-            xCAT::MsgUtils->message("W", { data => ["Could not obtain Valid Model Type and/or Serial Number and MAC Address for BMC at $ip"] }, $::CALLBACK);
+        # To constract a node name need either mac or both mtm and serial
+        # Exit if mac AND one of mtm or serial is missing
+        if (!($mtm and $serial) and !$ipmac{$ip}) {
+            xCAT::MsgUtils->message("W", { data => ["BMC Type/Model and Serial or MAC Address is unavailable for $ip"] }, $::CALLBACK);
             return;
         }
 


### PR DESCRIPTION
### The PR is to fix issue _#6406_

`bmcdiscover` needs to construct a unique nodename for discovered BMCs

If both mtm and serial are discovered, both are used in nodename construction.
If either mtm or serial are not known but mac is known, mac is used in nodename construction.

But if either mtm or serial are not known and mac is not known, a node definition was created with a blank nodename.

This PR fixes the logic of when to display an error and exit discovery.

| MTM  | SN | MAC | Node Name Before | Node Name Now | 
|---|---|---|---|---|
| NO | NO | NO | ERROR | ERROR | 
| YES | NO | NO | BLANK | ERROR | 
| NO | YES | NO | BLANK | ERROR | 
| NO | NO | YES | MAC USED | MAC USED | 
| NO | YES | YES | MAC USED | MAC USED | 
| YES | NO | YES | MAC USED | MAC USED | 
| YES | YES | YES | MNT+SN USED | MNT+SN USED | 
| YES | YES | NO | MNT+SN USED | MNT+SN USED | 