### PR TITLE
modify nodeset return code for hierarchy support

### DIFF
--- a/xCAT-server/lib/xcat/plugins/rinstall.pm
+++ b/xCAT-server/lib/xcat/plugins/rinstall.pm
@@ -389,13 +389,17 @@ sub rinstall {
 
         # if only provision one node and failed nodeset, will exit the command
         # instead of continue with rnetboot/rsetboot, rpower.
+        # check if it is hierarchy cluster 
         if (scalar(@nodes) == 1) {
-            $rsp->{error}->[0] = "Failed to run 'nodeset' against the node: @nodes";
-            $rsp->{errorcode}->[0] = 1;
-            xCAT::MsgUtils->message("E", $rsp, $callback);
-            return 1;
+            my $nrtab  = xCAT::Table->new('noderes');
+            my $sn = $nrtab->getNodeAttribs(@nodes,['servicenode']);
+            if (!$sn) {
+                $rsp->{error}->[0] = "Failed to run 'nodeset' against the node: @nodes";
+                $rsp->{errorcode}->[0] = 1;
+                xCAT::MsgUtils->message("E", $rsp, $callback);
+                return 1;
+            }
         }
-
 
         foreach my $node (@failurenodes) {
             delete $nodes{$node};


### PR DESCRIPTION
more modification for PR #6428 

In the hierarchy cluster, if service node is down and rinstall output will have:
```
# rinstall c910f02c39p08 osimage=rhels7.6-ppc64-install-compute
Provision node(s): c910f02c39p08
c910f02c39p08: install rhels7.6-ppc64-compute
c910f02c39p07: Unable to dispatch hierarchical sub-command to c910f02c39p07:3001.  Error: Connection failure: IO::Socket::INET: connect: No route to host at /opt/xcat/lib/perl/xCAT/Client.pm line 248.
.
Error: [c910f02c39p06]: Failed to run 'nodeset' against the node: c910f02c39p08
````
but in this case,  c910f02c39p08 doesn't have service node, the `rinstall` should continue


