### PR TITLE
files to install CentOS 8

### DIFF
--- a/xCAT-server/share/xcat/install/centos/compute.centos8.pkglist
+++ b/xCAT-server/share/xcat/install/centos/compute.centos8.pkglist
@@ -1,0 +1,11 @@
+@^minimal-environment
+chrony
+net-tools
+nfs-utils
+openssh-server
+rsync
+util-linux
+wget
+python3
+tar
+bzip2

--- a/xCAT-server/share/xcat/install/centos/compute.centos8.tmpl
+++ b/xCAT-server/share/xcat/install/centos/compute.centos8.tmpl
@@ -1,0 +1,59 @@
+#version=CentOS8
+# Use text install
+text
+# Use network installation
+%include /tmp/repos
+# Keyboard layouts
+keyboard --vckeymap=us --xlayouts='us'
+# System language
+lang en_US.UTF-8
+
+# Network information
+#KICKSTARTNET#
+# Root password
+rootpw --iscrypted #CRYPT:passwd:key=system,username=root:password#
+# Not run the Setup Agent on first boot
+firstboot --disable
+# Do not configure the X Window System
+skipx
+# System services
+#services --enabled="chronyd"
+# System timezone
+timezone #TABLE:site:key=timezone:value# --isUtc
+# Partition clearing information
+zerombr
+clearpart --all --initlabel
+#XCAT_PARTITION_START#
+%include /tmp/partitionfile
+#XCAT_PARTITION_END#
+
+# Do not configure any iptables rules
+firewall --disable
+selinux --disable
+reboot
+
+%packages
+#INCLUDE_DEFAULT_PKGLIST#
+
+%end
+
+%anaconda
+pwpolicy root --minlen=6 --minquality=1 --notstrict --nochanges --emptyok
+pwpolicy user --minlen=6 --minquality=1 --notstrict --nochanges --emptyok
+pwpolicy luks --minlen=6 --minquality=1 --notstrict --nochanges --emptyok
+%end
+%pre
+{
+echo "Running Kickstart Pre-installation script..."
+#INCLUDE:#ENV:XCATROOT#/share/xcat/install/scripts/pre.rhels8#
+} &>>/tmp/pre-install.log
+%end
+%post --interpreter=/bin/bash
+mkdir -p /var/log/xcat/
+cat /tmp/pre-install.log >>/var/log/xcat/xcat.log
+{
+echo "Running Kickstart Post-installation script..."
+#INCLUDE:#ENV:XCATROOT#/share/xcat/install/scripts/post.xcat.ng#
+#INCLUDE:#ENV:XCATROOT#/share/xcat/install/scripts/post.rhels8#
+} &>>/var/log/xcat/xcat.log
+%end


### PR DESCRIPTION
### The PR is to make xCAT ready for installing CentOS 8
I executed: 
* `copycds -n centos8.0 CentOS-8-x86_64-1905-dvd1.iso`

* `chdef -t osimage -o centos8.0-x86_64-install-compute template=/opt/xcat/share/xcat/install/centos/compute.centos8.tmpl`

* `chdef -t osimage -o centos8.0-x86_64-install-compute pkglist=/opt/xcat/share/xcat/install/centos/compute.centos8.pkglist`

The files are copies of `rh/compute.rhels8.pkglist` and `rh/compute.rhels8.tmpl` but could also used for CentOS 8. My installation of CentOS 8 worked fine with this files.

-- Gerd