### PR TITLE
bmcsetup Other LAN and 802.3 LAN for Channel Medium Type

### DIFF
--- a/xCAT-genesis-scripts/usr/bin/bmcsetup
+++ b/xCAT-genesis-scripts/usr/bin/bmcsetup
@@ -271,14 +271,16 @@ fi
 
 LAN_MED_TYPE="802.3"
 if [ ! -z "$ISOPENBMC" ]; then
-    # Overvide the default value for OpenBMC
-    LAN_MED_TYPE="Other LAN"
+    # For OpenBMC, the value of "Channel Medium Type" attribute could be "Other LAN" for FW drivers prior to OP940.01
+    # and "802.3" for FW drivers OP940.01 and later
+    LAN_MED_TYPE="802.3|Other LAN"
 fi
+# Loop through channels and pick the one to communicate on
 while [ -z "$LANCHAN" ]; do
     logger -s -t $log_label -p local4.info "Auto detecting LAN channel..."
     for TLANCHAN in {1..16}; do
         # Try to get the channel information; then get the MAC which is used for the channel
-        if ipmitool channel info $TLANCHAN 2> /dev/null | grep "$LAN_MED_TYPE" > /dev/null 2>&1 && ipmitool raw 0xc 2 $TLANCHAN 5 0 0 > /dev/null 2>&1; then
+        if ipmitool channel info $TLANCHAN 2> /dev/null | grep -E "$LAN_MED_TYPE" > /dev/null 2>&1 && ipmitool raw 0xc 2 $TLANCHAN 5 0 0 > /dev/null 2>&1; then
             LANCHAN=$TLANCHAN
             break;
         fi;


### PR DESCRIPTION
### The PR is to fix issue _#6454_

This PR looks for a channel with either `Other LAN` or `802.3` for `Channel Medium Type` attribute returned by `ipmitool channel info x`


## UT ##

### With OP940.01 driver (simulated with OP910-10) ###

```
[root@briggs01 c910env]# rflash mid05tor12cn15 -l
mid05tor12cn15: ID       Purpose State      Version
mid05tor12cn15: -------------------------------------------------------
mid05tor12cn15: 21383693 BMC     Active     op940.00-r1-0-ga11be91
mid05tor12cn15: 4d05046e Host    Active(*)  IBM-witherspoon-OP9-v2.3-rc2-3.23
mid05tor12cn15: 423ae9e4 BMC     Active(*)  op940.00-10-0-g9575468
mid05tor12cn15:
[root@briggs01 c910env]#
```
```
[root@briggs01 c910env]# ipmitool -I lanplus -H 172.11.139.15 -U root -P 0penBmc channel info 1
Channel 0x1 info:
  Channel Medium Type   : 802.3 LAN
  Channel Protocol Type : IPMB-1.0
  Session Support       : multi-session
  Active Session Count  : 0
  Protocol Vendor ID    : 7154
  Volatile(active) Settings
    Alerting            : enabled
    Per-message Auth    : enabled
    User Level Auth     : enabled
    Access Mode         : always available
  Non-Volatile Settings
    Alerting            : enabled
    Per-message Auth    : enabled
    User Level Auth     : enabled
    Access Mode         : always available
[root@briggs01 c910env]#
```

* Reset to DHCP - `/root/c910env/tools/openbmc/reset_to_dhcp.sh mid05tor12cn15`. 
* Verify previous BMC IP is no longer pingable:
```
[root@briggs01 c910env]# ping 172.11.139.15
PING 172.11.139.15 (172.11.139.15) 56(84) bytes of data.
From 172.11.253.27 icmp_seq=1 Destination Host Unreachable
From 172.11.253.27 icmp_seq=2 Destination Host Unreachable
From 172.11.253.27 icmp_seq=3 Destination Host Unreachable
^C
--- 172.11.139.15 ping statistics ---
5 packets transmitted, 0 received, +3 errors, 100% packet loss, time 157ms
[root@briggs01 c910env]#
```
* Remove old IP from lease file - `makedhcp -d mid05tor12cn15`
* Remove MAC entry for node definition - `chdef mid05tor12cn15 mac=`
* Look in `/var/log/messages` for new IP offered for this BMC - `DHCPACK on 172.12.253.104 to 08:94:ef:80:8f:bd (witherspoon) via enP34p1s0f0`
* Discover BMC on this IP :
```
[root@briggs01 c910env]# bmcdiscover --range 172.12.253.104 -u root -p 0penBmc -w
Writing node-8335-gth-789d81a (172.12.253.104,8335-GTH,789D81A,root,0penBmc,mp,bmc,,,) to database...
[root@briggs01 c910env]#
```
* Set to boot from network:
```
[root@briggs01 c910env]# rsetboot node-8335-gth-789d81a net
node-8335-gth-789d81a: Network
[root@briggs01 c910env]#
```
* Reset BMC:
 ```
[root@briggs01 c910env]# rpower node-8335-gth-789d81a reset
node-8335-gth-789d81a: reset
[root@briggs01 c910env]#
```
* Verify previous BMC IP is pingable again:
```
[root@briggs01 c910env]# ping 172.11.139.15 -c 1
PING 172.11.139.15 (172.11.139.15) 56(84) bytes of data.
64 bytes from 172.11.139.15: icmp_seq=1 ttl=64 time=0.400 ms

--- 172.11.139.15 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 0.400/0.400/0.400/0.000 ms
[root@briggs01 c910env]#
```
* Verify MAC is filled into node definition:
```
[root@briggs01 c910env]# lsdef mid05tor12cn15 -i mac -c
mid05tor12cn15: mac=08:94:ef:80:8f:be
[root@briggs01 c910env]#
```

### With OP920 driver ###

```
[root@briggs01 c910env]# rflash mid05tor12cn05 -l
mid05tor12cn05: ID       Purpose State      Version
mid05tor12cn05: -------------------------------------------------------
mid05tor12cn05: cf421794 BMC     Active     ibm-v2.3-476-g2d622cb-r32-0-g9973ab0
mid05tor12cn05: 1be29de2 Host    Active(*)  IBM-witherspoon-OP9_v2.0.14_1.2
mid05tor12cn05: 9a8028ec Host    Active     IBM-witherspoon-OP9-v2.0.14-2.6
mid05tor12cn05: 701d0446 BMC     Active(*)  ibm-v2.3-476-g2d622cb-r33-coral-cfm-0-gb2c03c9
mid05tor12cn05:
[root@briggs01 c910env]#
```
```
[root@briggs01 c910env]# ipmitool -I lanplus -H 172.11.139.5 -P 0penBmc channel info 1
Channel 0x1 info:
  Channel Medium Type   : Other LAN
  Channel Protocol Type : IPMB-1.0
  Session Support       : session-less
  Active Session Count  : 1
  Protocol Vendor ID    : 42817
  Volatile(active) Settings
    Alerting            : disabled
    Per-message Auth    : disabled
    User Level Auth     : enabled
    Access Mode         : always available
  Non-Volatile Settings
    Alerting            : disabled
    Per-message Auth    : disabled
    User Level Auth     : enabled
    Access Mode         : always available
[root@briggs01 c910env]#
```

* Reset to DHCP - `/root/c910env/tools/openbmc/reset_to_dhcp.sh mid05tor12cn05`. 
* Verify previous BMC IP is no longer pingable:
```
[root@briggs01 c910env]# ping 172.11.139.5 -c 1
PING 172.11.139.5 (172.11.139.5) 56(84) bytes of data.
From 172.11.253.27 icmp_seq=1 Destination Host Unreachable

--- 172.11.139.5 ping statistics ---
1 packets transmitted, 0 received, +1 errors, 100% packet loss, time 0ms

[root@briggs01 c910env]#
```
* Remove old IP from lease file - `makedhcp -d mid05tor12cn05`
* Remove MAC entry for node definition - `chdef mid05tor12cn05 mac=`
* Look in `/var/log/messages` for new IP offered for this BMC - `DHCPACK on 172.12.253.101 to 70:e2:84:14:28:0d (mid05tor12cn05-bmc-test) via enP34p1s0f0`
* Discover BMC on this IP :
```
[root@briggs01 c910env]# bmcdiscover --range 172.12.253.101 -w
Writing node-8335-gth-1318c4a (172.12.253.101,8335-GTH,1318C4A,,,mp,bmc,,,) to database...
[root@briggs01 c910env]#
```
* Set to boot from network:
```
[root@briggs01 c910env]# rsetboot node-8335-gth-1318c4a net
node-8335-gth-1318c4a: Network
[root@briggs01 c910env]#
```
* Reset BMC:
 ```
[root@briggs01 c910env]# rpower node-8335-gth-1318c4a reset
node-8335-gth-1318c4a: reset
[root@briggs01 c910env]#
```
* Verify previous BMC IP is pingable again:
```
[root@briggs01 c910env]# ping 172.11.139.5 -c 1
PING 172.11.139.5 (172.11.139.5) 56(84) bytes of data.
64 bytes from 172.11.139.5: icmp_seq=1 ttl=64 time=0.671 ms

--- 172.11.139.5 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 0.671/0.671/0.671/0.000 ms
[root@briggs01 c910env]#
```
* Verify MAC is filled into node definition:
```
[root@briggs01 c910env]#  lsdef mid05tor12cn05 -i mac -c
mid05tor12cn05: mac=70:e2:84:14:28:0e
[root@briggs01 c910env]#
```



