### PR TITLE
Better message for Ubuntu uninstall

### DIFF
--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -2,7 +2,7 @@
 #
 # go-xcat - Install xCAT automatically.
 #
-# Version 1.0.43
+# Version 1.0.44
 #
 # Copyright (C) 2016 - 2019 International Business Machines
 # Eclipse Public License, Version 1.0 (EPL-1.0)
@@ -25,6 +25,8 @@
 #     - Better debug log when reading repository failed
 # 2019-08-15 Mark Gurevich <gurevich@us.ibm.com>
 #     - Added conserver-xcat to uninstall list
+# 2019-10-23 Mark Gurevich <gurevich@us.ibm.com>
+#     - Display a list of packages that could not be uninstalled
 #
 
 function usage()
@@ -173,7 +175,7 @@ GO_XCAT_INSTALL_LIST=(perl-xcat xcat xcat-buildkit xcat-client
 	xcat-genesis-scripts-amd64 xcat-genesis-scripts-ppc64 xcat-server
 	elilo-xcat grub2-xcat ipmitool-xcat syslinux-xcat
 	xcat-genesis-base-amd64 xcat-genesis-base-ppc64 xnba-undi)
-# The package list of all the packages should be installed
+# The package list of all the packages should be uninstalled
 GO_XCAT_UNINSTALL_LIST=("${GO_XCAT_INSTALL_LIST[@]}"
 	goconserver xCAT-SoftLayer xCAT-confluent xCAT-csm xCAT-genesis-builder
 	xCAT-openbmc-py xCAT-probe xCAT-test xCAT-vlan xCATsn xCAT-UI-deps
@@ -1576,6 +1578,7 @@ function remove_package_apt()
 	local -a yes=()
 	[[ "$1" = "-y" ]] && yes=("-y") && shift
 	apt-get --allow-unauthenticated remove "${yes[@]}" "$@"
+	warn_if_bad "$?" "Unable to remove xCAT packages: "`apt --installed list 2>&1 | grep xcat | cut -d '/' -f 1`
 }
 
 function remove_package()
@@ -1590,6 +1593,7 @@ function purge_package_apt()
 	local -a yes=()
 	[[ "$1" = "-y" ]] && yes=("-y") && shift
 	apt-get --allow-unauthenticated purge "${yes[@]}" "$@"
+	warn_if_bad "$?" "Unable to purge xCAT packages: "`apt --installed list 2>&1 | grep xcat | cut -d '/' -f 1`
 }
 
 function purge_package_others()
@@ -2092,22 +2096,17 @@ case "${GO_XCAT_ACTION}" in
 
 		debug_logger <<-EOF
 
-		xCAT has been completely uninstalled!
+		xCAT has been uninstalled.
+		To install again - https://xcat.org/download.html
 		EOF
 		;;
 	"uninstall")
 		debug_trace uninstall_xcat -y
-		boo_boo_if_bad "$?"
 
 		debug_logger <<-EOF
 
-		xCAT has been uninstalled!
-		==========================
-
-		If you intend to install xCAT again, please follow the guideline on the
-		xcat.org website.
-
-		https://xcat.org/download.html
+		xCAT has been uninstalled.
+		To install again - https://xcat.org/download.html
 		EOF
 		;;
 	esac


### PR DESCRIPTION
Small enhancement to `go-xcat` to add warning message to `go-xcat uninstall` when some packages could not be removed. 

This is only for Ubuntu for now, as we are seeing `go-xcat` unable to uninstall some packages. Did not come across uninstall problems with other OSes.

```
root@c910f04x37v08:/# ./go-xcat completely uninstall
Operating system:   linux
Architecture:       x86_64
Linux Distribution: ubuntu
Version:            18.04
go-xcat Version:    1.0.43


xCAT is going to be trashed.
Continue? [y/n] y
Reading package lists...
Building dependency tree...
Reading state information...
Package 'xcat-buildkit' is not installed, so not removed
Package 'elilo-xcat' is not installed, so not removed
Package 'xcat-probe' is not installed, so not removed
Package 'xcat-buildkit' is not installed, so not removed
E: Unable to locate package xcat-confluent
E: Unable to locate package xcat-test
E: Unable to locate package xcat-vlan
E: Unable to locate package xcatsn
E: Unable to locate package conserver-xcat
go-xcat: Unable to purge xCAT packages: grub2-xcat ipmitool-xcat perl-xcat syslinux-xcat xcat-client xcat-genesis-base-amd64 xcat-genesis-base-ppc64 xcat-genesis-scripts-amd64

xCAT has been uninstalled.
To install again - https://xcat.org/download.html
root@c910f04x37v08:/#
```

```
root@c910f04x37v08:/# ./go-xcat  uninstall
Operating system:   linux
Architecture:       x86_64
Linux Distribution: ubuntu
Version:            18.04
go-xcat Version:    1.0.43


xCAT is going to be uninstalled.
Continue? [y/n] y
Reading package lists...
Building dependency tree...
Reading state information...
Package 'xcat-buildkit' is not installed, so not removed
Package 'elilo-xcat' is not installed, so not removed
Package 'xcat-probe' is not installed, so not removed
Package 'xcat-buildkit' is not installed, so not removed
E: Unable to locate package xcat-confluent
E: Unable to locate package xcat-test
E: Unable to locate package xcat-vlan
E: Unable to locate package xcatsn
E: Unable to locate package conserver-xcat
go-xcat: Unable to remove xCAT packages: grub2-xcat ipmitool-xcat perl-xcat syslinux-xcat xcat-client xcat-genesis-base-amd64 xcat-genesis-base-ppc64 xcat-genesis-scripts-amd64

xCAT has been uninstalled.
To install again - https://xcat.org/download.html
root@c910f04x37v08:/#
```