### PR TITLE
Doc fixes for osimage definition creation

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/common/deployment/create_img.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/deployment/create_img.rst
@@ -1,15 +1,15 @@
 Select or Create an osimage Definition
 ======================================
 
-Before creating an image on xCAT, the distro media should be prepared ahead. That can be ISOs or DVDs.
+Before creating an image on xCAT, the distro media should be prepared. That can be ISOs or DVDs.
 
-XCAT use 'copycds' command to create an image which will be available to install nodes. ``copycds`` will copy all contents of Distribution DVDs/ISOs or Service Pack DVDs/ISOs to a destination directory, and create several relevant osimage definitions by default.
+XCAT uses ``copycds`` command to create an image which will be available to install nodes. ``copycds`` will copy all contents of Distribution DVDs/ISOs or Service Pack DVDs/ISOs to a destination directory, and create several relevant osimage definitions by default.
 
 If using an ISO, copy it to (or NFS mount it on) the management node, and then run: ::
 
     copycds <path>/<specific-distro>.iso
 
-**Note**: while sle15 contains installer medium and packages medium, need ``copycds`` copy all contents of DVD1 of the installer medium and DVD1 of the packages medium, for example: ::
+.. note:: While sle15 contains installer medium and packages medium, need ``copycds`` copy all contents of DVD1 of the installer medium and DVD1 of the packages medium, for example: ::
     
     copycds SLE-15-Installer-DVD-ppc64le-GM-DVD1.iso SLE-15-Packages-ppc64le-GM-DVD1.iso
 	
@@ -41,11 +41,11 @@ In these osimage definitions shown above
 * **<os>-<arch>-netboot-compute** is the default osimage definition used for diskless installation
 * **<os>-<arch>-install-service** is the default osimage definition used for service node deployment which shall be used in hierarchical environment
 
-**Note**: There are more things needed for **ubuntu ppc64le** osimages:
+.. note:: Additional steps are needed for **ubuntu ppc64le** osimages:
 
-For pre-18.04 version of Ubuntu for ppc64el, the initrd.gz shipped with the ISO does not support network booting. In order to install ubuntu with xCAT, you need to follow the steps below to complete the osimage definition.
+For pre-16.04.02 version of Ubuntu for ppc64el, the ``initrd.gz`` shipped with the ISO does not support network booting. In order to install Ubuntu with xCAT, you need to follow the steps to complete the osimage definition.
 
-* Download mini.iso from
+* Download ``mini.iso`` from
 
   [ubuntu 14.04.1]: http://xcat.org/files/netboot/ubuntu14.04.1/ppc64el/mini.iso
 
@@ -59,7 +59,7 @@ For pre-18.04 version of Ubuntu for ppc64el, the initrd.gz shipped with the ISO 
 
   [ubuntu 16.04.1]: http://xcat.org/files/netboot/ubuntu16.04.1/ppc64el/mini.iso
 
-* Mount mini.iso ::
+* Mount ``mini.iso`` ::
 
     mkdir /tmp/iso
     mount -o loop mini.iso /tmp/iso
@@ -69,11 +69,9 @@ For pre-18.04 version of Ubuntu for ppc64el, the initrd.gz shipped with the ISO 
     mkdir -p /install/<ubuntu-version>/ppc64el/install/netboot
     cp /tmp/iso/install/initrd.gz /install/<ubuntu-version>/ppc64el/install/netboot
 
-**[Below tips maybe helpful for you]**
-
 **[Tips 1]**
 
-If this is the same distro version as what your management node uses, create a .repo file in /etc/yum.repos.d with contents similar to: ::
+If this is the same distro version as what your management node uses, create a ``.repo`` file in ``/etc/yum.repos.d`` with contents similar to: ::
 
     [local-<os>-<arch>]
     name=xCAT local <os> <version>
@@ -81,7 +79,7 @@ If this is the same distro version as what your management node uses, create a .
     enabled=1
     gpgcheck=0
 	
-In this way, if you need to install some additional RPMs into your MN later, you can simply install them with ``yum``. Or if you are installing a software on your MN that depends some RPMs from this disto, those RPMs will be found and installed automatically.
+This way, if you need to install some additional RPMs into your MN later, you can simply install them with ``yum``. Or if you are installing a software on your MN that depends some RPMs from this disto, those RPMs will be found and installed automatically.
 
 **[Tips 2]**
 
@@ -91,7 +89,7 @@ You can create/modify an osimage definition easily with any existing osimage def
 
 Except the specified attributes *<attribute>*, the attributes of *<new osimage>* will inherit the values of template osimage *<existing osimage>*.
 
-As an example, the following command creates a new osimage "myosimage.rh7.compute.netboot" based on the existing osimage "rhels7.4-ppc64le-netboot-compute" with some customized attributes ::
+As an example, the following command creates a new osimage ``myosimage.rh7.compute.netboot`` based on the existing osimage ``rhels7.4-ppc64le-netboot-compute`` with some customized attributes ::
 
     mkdef -t osimage -o myosimage.rh7.compute.netboot --template rhels7.4-ppc64le-netboot-compute synclists=/tmp/synclist otherpkgdir=/install/custom/osimage/myosimage.rh7.compute.netboot/3rdpkgs/ otherpkglist=/install/custom/osimage/myosimage.rh7.compute.netboot/3rd.pkglist
 


### PR DESCRIPTION
Fix some formatting and grammar problems in the doc explaining osimage definition.
Also correct the version of Ubintu with which `mini.iso` is needed (based on https://github.com/xcat2/xcat-core/issues/5702#issuecomment-431244473)