### PR TITLE
Add regression test tabdump debug for service node not removed 2

### DIFF
--- a/xCAT-test/autotest/bundle/rhels_ppc_daily.bundle
+++ b/xCAT-test/autotest/bundle/rhels_ppc_daily.bundle
@@ -266,10 +266,14 @@ rpower_noderange_nodeps
 rpower_off
 rpower_on
 rpower_stat
+tabdump_servicenode
 rscan_noderange
+tabdump_servicenode
 rscan_w
+tabdump_servicenode
 rscan_x
 rscan_x_w
+tabdump_servicenode
 rscan_z
 rscan_z_w
 tabdump_servicenode


### PR DESCRIPTION
Adding more `tabdump servicenode` command in different places to the regression bundle so we can see where the service node gets removed in the success environment and where is does not in failing environment. Continuing work from #6456 