### PR TITLE
[xcat_test] remove service node from servicenode table for rscan test cases

### DIFF
--- a/xCAT-test/autotest/testcase/rscan/cases0
+++ b/xCAT-test/autotest/testcase/rscan/cases0
@@ -40,6 +40,7 @@ check:rc==0
 check:output=~hcp=__GETNODEATTR($$CN,hcp)__
 cmd:rmdef all
 cmd:cat /tmp/all.stanza | mkdef -z
+cmd:chtab -d node=$$SN servicenode
 cmd:rm -f /tmp/all.stanza
 cmd:rm -f /tmp/$$CN.stanza
 end
@@ -60,6 +61,7 @@ check:rc==0
 check:output=~hcp=__GETNODEATTR($$CN,hcp)__
 cmd:rmdef all
 cmd:cat /tmp/all.stanza | mkdef -z
+cmd:chtab -d node=$$SN servicenode
 cmd:rm -f /tmp/all.stanza
 cmd:rm -f /tmp/$$CN.stanza
 end
@@ -80,6 +82,7 @@ check:rc==0
 check:output=~parent=[\w-]+
 cmd:rmdef all
 cmd:cat /tmp/all.stanza | mkdef -z
+cmd:chtab -d node=$$SN servicenode
 cmd:rm -f /tmp/all.stanza
 cmd:rm -f /tmp/$$CN.stanza
 end


### PR DESCRIPTION
on regression test for `rhels7.6-P8LPARs-Mysql-master-daily`, the test cases `rscan_w` caused service node to be added to `servicenode` table
```
tabdump servicenode 
#node,nameserver,dhcpserver,tftpserver,nfsserver,conserver,monserver,ldapserver,ntpserver,ftpserver,nimserver,ipforward,dhcpinterfaces,proxydhcp,comments,disable
"c910f02c39p07","1","1","1","1","1",,,"1",,,,,,,
"service","1","1","1","1","1",,,"1",,,,,,,
```
it didn't get to clean up after test cases finished,   this cause the `makedhcp -n` failed on some other test cases.
```
RUN:makedhcp -n [Sun Oct 20 06:47:55 2019]
ElapsedTime:16 sec
RETURN rc = 1
OUTPUT:
Warning: [c910f02c39p06]: No dynamic range specified for 10.0.0.0. If hardware discovery is being used, a dynamic range is required.
Error: [c910f02c39p06]: Unable to dispatch hierarchical sub-command to c910f02c39p07:3001.  Error: Connection failure: IO::Socket::INET: connect: timeout at /opt/xcat/lib/perl/xCAT/Client.pm line 248.
.
Renamed existing dhcp configuration file to  /etc/dhcp/dhcpd.conf.xcatbak

CHECK:rc == 0   [Failed]
````