### PR TITLE
Add display statement to genesis testcase script

### DIFF
--- a/xCAT-test/autotest/testcase/genesis/test.sh
+++ b/xCAT-test/autotest/testcase/genesis/test.sh
@@ -43,6 +43,7 @@ function check_destiny() {
         runcmd $cmd;
         cmd="makenetworks";
         runcmd $cmd;
+        ip addr show
         makehosts ${TESTNODE}
         grep ${TESTNODE} /etc/hosts 
         cmd="nodeset ${TESTNODE}  shell";


### PR DESCRIPTION
Sometimes genesis testcase fails when it tries to delete an IP entry with 
`ip addr del 192.168.1.1/255.255.0.0 dev enp0s2`

This PR addes a `show` command to see that the entry is still there after `makenetworks`