### PR TITLE
log error message if running kits on rhel8

### DIFF
--- a/xCAT-buildkit/bin/buildkit
+++ b/xCAT-buildkit/bin/buildkit
@@ -344,6 +344,13 @@ if ($tempstring =~ /debian/ || $tempstring =~ /ubuntu/) {
     $debianflag = 1;
 }
 
+my ($sysos, $sysver) = split /,/, $tempstring;
+if ( ($sysos =~ /rh/) && ($sysver ge 8) ) {
+    print "ERROR:  KITs are not supported on rhel8 or above\n";
+    exit(1);
+}
+
+
 # This is an undocumented flag to support our local build team
 #   to allow building Ubuntu kits on our RH build machines.
 #   It requires RH rpms such as dep, fakeroot, perl-File-DesktopEntry,

--- a/xCAT-server/lib/xcat/plugins/kit.pm
+++ b/xCAT-server/lib/xcat/plugins/kit.pm
@@ -33,7 +33,7 @@ $::KITFRAMEWORK = "2";
 $::COMPATIBLE_KITFRAMEWORKS = "0,1,2";
 
 my $debianflag = 0;
-my $tempstring = xCAT::Utils->osver();
+my $tempstring = xCAT::Utils->osver(all);
 if ($tempstring =~ /debian/ || $tempstring =~ /ubuntu/) {
     $debianflag = 1;
 
@@ -97,6 +97,12 @@ sub process_request
         }
 
         $::PID = $$;
+    }
+
+    my ($sysos, $sysver) = split /,/, $tempstring;
+    if ( ($sysos =~ /rh/) && ($sysver ge 8) ) {
+        $callback->({ error => ["KITs are not supported on rhel8 or above"], errorcode => [1] });
+        return 1;
     }
 
     my $command = $request->{command}->[0];


### PR DESCRIPTION
for the xcat 2.15 release,   xCAT kit is not support on rhel8 ,  log the error message when user is running `buildkit` or `addkit` on the rhel8 cluster
```
# buildkit mykit
ERROR:  KITs are not supported on rhel8 or above
# addkit mykit
Error: [f6u13k13]: KITs are not supported on rhel8 or above
````