### PR TITLE
Show contents sources.list during Travis run

### DIFF
--- a/travis.pl
+++ b/travis.pl
@@ -344,6 +344,8 @@ sub install_xcat{
             return 1;
         }
     }
+    my @cat_output = runcmd("sudo cat /etc/apt/sources.list");
+    print Dumper \@cat_output;
 
     my $cmd = "sudo apt-get install xcat --allow-remove-essential --allow-unauthenticated";
     @output = runcmd("$cmd");


### PR DESCRIPTION
Display contents of `/etc/apt/sources.list` during `travis.pl` run.

The installation of xCAT works on x86 Ubuntu during Travis but fails during regression. (https://github.ibm.com/xcat2/team_process/issues/197)