### PR TITLE
Restart libssl1.1 without asking for regression Ubuntu install

### DIFF
--- a/xCAT-test/autotest/testcase/install_xCAT/case0
+++ b/xCAT-test/autotest/testcase/install_xCAT/case0
@@ -31,8 +31,7 @@ stop:yes
 cmd:arc_all=`uname -a`; code=`lsb_release -sc`;if [[ $arc_all =~ "ppc64le" ]]; then arch="ppc64el";else arch="x86_64";fi; cp "/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-$arch.sources.list" "/etc/apt/sources.list"
 cmd:apt-get clean;apt-get update
 check:rc==0
-cmd:echo '* libraries/restart-without-asking boolean true' | debconf-set-selections
-check:rc==0
+cmd:arc_all=`uname -a`; if [[ $arc_all =~ "x86_64" ]]; then echo '* libraries/restart-without-asking boolean true' | debconf-set-selections; fi
 cmd:debconf-show libssl1.1
 cmd:cp /core-*-snap.tar.bz2 /install_xCAT_xcat-core.tar.bz2
 check:rc==0


### PR DESCRIPTION
### The PR is to fix issue _https://github.ibm.com/xcat2/team_process/issues/197_

This PR updates the testcase which installs xCAT on Ubuntu. It forces libraries that require input during installation to automatically accept the default and not prompt the user for input.