### PR TITLE
Display packages and version before go-xcat install

### DIFF
--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -2,7 +2,7 @@
 #
 # go-xcat - Install xCAT automatically.
 #
-# Version 1.0.44
+# Version 1.0.45
 #
 # Copyright (C) 2016 - 2019 International Business Machines
 # Eclipse Public License, Version 1.0 (EPL-1.0)
@@ -27,6 +27,8 @@
 #     - Added conserver-xcat to uninstall list
 # 2019-10-23 Mark Gurevich <gurevich@us.ibm.com>
 #     - Display a list of packages that could not be uninstalled
+# 2019-11-05 Mark Gurevich <gurevich@us.ibm.com>
+#     - Display a list of packages that will be installed before "Continue?"
 #
 
 function usage()
@@ -2156,6 +2158,7 @@ case "${GO_XCAT_ACTION}" in
 	;;
 "install"|"update")
 	GO_XCAT_INSTALLER="${GO_XCAT_ACTION}_xcat"
+	list_xcat_packages
 	ask_to_continue "${GO_XCAT_YES[0]}" "xCAT is going to be ${GO_XCAT_ACTION/%e/}ed."
 	# Use `-y' here. Since the STDOUT is redirected.
 	# `yum' does not display the prompt message properly when


### PR DESCRIPTION
### The PR is to fix issue __https://github.ibm.com/hpc-devops/xcat_clusters/issues/322__

Before asking user to `Continue? [y/n]` Display a list of packages comparing what is installed vs what will be installed during `go-xcat` execution. 
Prior to this PR, similar information was displayed **after** user answered `y`.

* If new installation of xCAT:
```
[root@fs2vm113 tmp]# ./go-xcat install
Operating system:   linux
Architecture:       ppc64le
Linux Distribution: rhel
Version:            7.6
go-xcat Version:    1.0.44


Reading repositories ...... done

xCAT Core Packages
==================

Package Name                Installed                      In Repository
------------                ---------                      -------------
perl-xCAT                   (not installed)                2.14.6-snap201903290319
xCAT                        (not installed)                2.14.6-snap201903290319
xCAT-SoftLayer              (not installed)                2.14.6-snap201903290319
xCAT-buildkit               (not installed)                2.14.6-snap201903290319
xCAT-client                 (not installed)                2.14.6-snap201903290319
xCAT-confluent              (not installed)                2.14.6-snap201903290319
xCAT-csm                    (not installed)                2.14.6-snap201903290319
xCAT-genesis-scripts-ppc64  (not installed)                2.14.6-snap201903290319
xCAT-genesis-scripts-x86_64 (not installed)                2.14.6-snap201903290319
xCAT-openbmc-py             (not installed)                2.14.6-snap201903290319
xCAT-probe                  (not installed)                2.14.6-snap201903290319
xCAT-server                 (not installed)                2.14.6-snap201903290319
xCAT-test                   (not installed)                2.14.6-snap201903290319
xCAT-vlan                   (not installed)                2.14.6-snap201903290319
xCATsn                      (not installed)                2.14.6-snap201903290319

xCAT Dependency Packages
========================

Package Name                Installed                      In Repository
------------                ---------                      -------------
conserver-xcat              (not installed)                8.2.1-1
elilo-xcat                  (not installed)                3.14-4
fping                       (not installed)                2.4b2_to-2
goconserver                 (not installed)                0.3.2-snap201811080416
grub2-xcat                  (not installed)                2.02-0.16.el7.snap201506090204
ipmitool-xcat               (not installed)                1.8.18-0
lldpd                       (not installed)                0.7.15-6.1
net-snmp-perl               (not installed)                5.7.2-20.ael7b
perl-AppConfig              (not installed)                1.52-4
perl-Crypt-CBC              (not installed)                2.33-2.el7
perl-Crypt-Rijndael         (not installed)                1.09-2.ael7a
perl-Expect                 (not installed)                1.21-1
perl-HTML-Form              (not installed)                6.03-6.el7
perl-HTTP-Async             (not installed)                0.30-2
perl-IO-Stty                (not installed)                0.03-1
perl-IO-Tty                 (not installed)                1.07-1
perl-JSON                   (not installed)                2.59-2.el7
perl-Net-HTTPS-NB           (not installed)                0.14-2
perl-Net-Telnet             (not installed)                3.03-19.el7
perl-SOAP-Lite              (not installed)                0.710.08-1
perl-XML-Simple             (not installed)                2.20-5.el7
pyodbc                      (not installed)                3.0.7-1.ael7a
syslinux-xcat               (not installed)                3.86-2
systemconfigurator          (not installed)                2.2.11-1
systemimager-client         (not installed)                4.3.0-0.1
systemimager-common         (not installed)                4.3.0-0.1
systemimager-server         (not installed)                4.3.0-0.3
xCAT-UI-deps                (not installed)                2.8-2
xCAT-genesis-base-ppc64     (not installed)                2.14.5-snap201811160710
xCAT-genesis-base-x86_64    (not installed)                2.14.5-snap201811190037
xCAT-genesis-x86_64         (not installed)                2.7.7-snap201301100842
xnba-undi                   (not installed)                1.0.3-131028
yaboot-xcat                 (not installed)                1.3.17-rc1

xCAT is going to be installed.
Continue? [y/n] n
Good-bye!
[root@fs2vm113 tmp]#
```

* If updating to a new version of xCAT
```
[root@fs2vm101 tmp]# ./go-xcat --xcat-version=devel install
Operating system:   linux
Architecture:       ppc64le
Linux Distribution: rhel
Version:            7.6
go-xcat Version:    1.0.44


Reading repositories ...... done

xCAT Core Packages
==================

Package Name                Installed                      In Repository
------------                ---------                      -------------
perl-xCAT                   2.14.6-snap201903290319        2.15-snap201911050137
xCAT                        2.14.6-snap201903290319        2.15-snap201911050137
xCAT-SoftLayer              (not installed)                2.15-snap201911050137
xCAT-buildkit               2.14.6-snap201903290319        2.15-snap201911050137
xCAT-client                 2.14.6-snap201903290319        2.15-snap201911050137
xCAT-confluent              (not installed)                2.15-snap201911050137
xCAT-csm                    (not installed)                2.15-snap201911050137
xCAT-genesis-scripts-ppc64  2.14.6-snap201903290319        2.15-snap201911050137
xCAT-genesis-scripts-x86_64 2.14.6-snap201903290319        2.15-snap201911050137
xCAT-openbmc-py             (not installed)                2.15-snap201911050137
xCAT-probe                  2.14.6-snap201903290319        2.15-snap201911050137
xCAT-server                 2.14.6-snap201903290319        2.15-snap201911050137
xCAT-test                   (not installed)                2.15-snap201911050137
xCAT-vlan                   (not installed)                2.15-snap201911050137
xCATsn                      (not installed)                2.15-snap201911050137

xCAT Dependency Packages
========================

Package Name                Installed                      In Repository
------------                ---------                      -------------
elilo-xcat                  3.14-4                         3.14-4
fping                       (not installed)                2.4b2_to-2
goconserver                 0.3.2-snap201811080416         0.3.2-snap201909171016
grub2-xcat                  2.02-0.16.el7.snap201506090204 2.02-0.76.el7.1.snap2019051602
ipmitool-xcat               1.8.18-0                       1.8.18-0
lldpd                       (not installed)                0.7.15-6.1
net-snmp-perl               5.7.2-20.ael7b                 5.7.2-20.ael7b
perl-AppConfig              (not installed)                1.52-4
perl-Crypt-CBC              2.33-2.el7                     2.33-2.el7
perl-Crypt-Rijndael         1.09-2.ael7a                   1.09-2.ael7a
perl-Expect                 1.21-1                         1.21-1
perl-HTML-Form              6.03-6.el7                     6.03-6.el7
perl-HTTP-Async             0.30-2                         0.30-2
perl-IO-Stty                0.03-1                         0.03-1
perl-IO-Tty                 1.07-1                         1.07-1
perl-JSON                   2.59-2.el7                     2.59-2.el7
perl-Net-HTTPS-NB           0.14-2                         0.14-2
perl-Net-Telnet             3.03-19.el7                    3.03-19.el7
perl-SOAP-Lite              (not installed)                0.710.08-1
perl-XML-Simple             2.20-5.el7                     2.20-5.el7
pyodbc                      (not installed)                3.0.7-1.ael7a
syslinux-xcat               3.86-2                         3.86-2
systemconfigurator          (not installed)                2.2.11-1
systemimager-client         (not installed)                4.3.0-0.1
systemimager-common         (not installed)                4.3.0-0.1
systemimager-server         (not installed)                4.3.0-0.3
xCAT-genesis-base-ppc64     2.14.5-snap201811160710        2.14.5-snap201811160710
xCAT-genesis-base-x86_64    2.14.5-snap201811190037        2.14.5-snap201811190037
xnba-undi                   1.0.3-131028                   1.0.3-131028
yaboot-xcat                 1.3.17-rc1                     1.3.17-rc1

xCAT is going to be installed.
Continue? [y/n] n
Good-bye!
[root@fs2vm101 tmp]#
```