### PR TITLE
Fix repodata files permission in xcat-dep

### DIFF
--- a/builddep.sh
+++ b/builddep.sh
@@ -268,8 +268,8 @@ chgrp -R -h $SYSGRP *
 chmod -R g+w *
 
 # Change permission on all repodata files to be readable by all
-chmod a+r */*/repodata/*.gz
-chmod a+r */*/repodata/*.bz2
+chmod a+rx */*/repodata
+chmod a+r */*/repodata/*
 
 TARBALL_WORKING_DIR="${XCATCOREDIR}/${DESTDIR}"
 echo "===> Building the tarball at: ${TARBALL_WORKING_DIR} ..."


### PR DESCRIPTION
Make sure **all** files in `.../repodata` directory have "read by all" permission, not just `.gz` and `.bz2` files.
Also make sure the directory itself has "read and execute by all" permission.

This seems to matter when on the private network, the file `/etc/yum.repo.d/xcat-dep.repo` contains:
```
baseurl=http://192.x.x.x/install/xcat.org/files/xcat/repos/yum/devel/xcat-dep/rh7/ppc64le
```
And installing xCAT with `yum install xCAT`. the error reported:
```
Retrieving key from http://<MN>//install/xcat/xcat-dep/rh7/ppc64le/repodata/repomd.xml.key


GPG key retrieval failed: [Errno 14] HTTP Error 403 - Forbidden
```

Installing with `go-xcat` does not expose this problem.