### PR TITLE
Port Generic CentOS check from Lenovo tree

### DIFF
--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -2064,6 +2064,8 @@ sub copycd
         {
             $distname = $xCAT::data::discinfo::distnames{$did};
         }
+    } elsif ($desc and $desc =~ /CentOS Linux (.*)/) {
+          $distname = "centos" . $1;
     }
 
     unless ($dno) {


### PR DESCRIPTION
This will do a more generic check if a discid is not found.

