### PR TITLE
linux_diskless_kdump testcase enhancement

### DIFF
--- a/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
+++ b/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
@@ -72,7 +72,10 @@ check:output=~\d\d:\d\d:\d\d
 cmd:xdsh $$CN "echo 'echo 1 > /proc/sys/kernel/sysrq; echo c > /proc/sysrq-trigger' > /tmp/kdump.trigger"
 cmd:xdsh $$CN "chmod 755 /tmp/kdump.trigger"
 
-cmd:xdsh $$CN "rpm -q at"
+# at package should have been installed during provisioning.
+# If it is still missing, install it with "yum install"
+cmd:a=`xdsh $$CN rpm -q at`;if [[ $a =~ "package at is not installed" ]]; then xdsh $$CN yum install -y at; fi
+
 cmd:xdsh $$CN "service atd start"
 check:rc==0
 


### PR DESCRIPTION
Still seeing failures of `linux_diskless_kdump` testcase during weekly regression on P8 VMs with RHEL 7.6

Even though during provisioning `at` package is shown as installed:
```
Installed:
  at.ppc64le 0:3.1.13-24.el7                                                    
  bash.ppc64le 0:4.2.46-31.el7                                                  
  bc.ppc64le 0:1.06.95-13.el7                                                   
  bzip2.ppc64le 0:1.0.6-13.el7
:
:
```

When we query it, it is not there:
```
RUN:xdsh c910f03c09k11 "rpm -q at" [Sun Nov 10 08:01:03 2019]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
c910f03c09k11: package at is not installed
```

This PR changes the testcase to check if `at` package is there. If not, install it with `yum install`.
Since this testcase is only part of `rhels_ppcle_weekly`, no need to worry about running this on Ubuntu