### PR TITLE
OpenBMC Thermal Mode [Perl]

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
@@ -527,7 +527,7 @@ OPTIONS
 
 \ **thermalmode**\ 
  
- Display or set the thermal mode of the system to a setting, depending on your system, adapter, and cable type. After a factory reset of the system, the thermal mode setting is lost and must be reapplied. To choose the correct setting for your system, see http://blaze.aus.stglabs.ibm.com/kc20A-cur/POWER9/p9ei3/p9ei3_thermal_mode.htm [OpenBMC]
+ Display or set the thermal mode of the system to a setting, depending on your system, adapter, and cable type. After a factory reset of the system, the thermal mode setting is lost and must be reapplied. To choose the correct setting for your system, see https://www.ibm.com/support/knowledgecenter/POWER9/p9ei3/p9ei3_thermal_mode.htm [OpenBMC]
  
 
 

--- a/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
@@ -83,6 +83,10 @@ OpenBMC specific:
 
 \ **rspconfig**\  \ *noderange*\  \ **sshcfg**\ 
 
+\ **rspconfig**\  \ *noderange*\  \ **thermalmode**\ 
+
+\ **rspconfig**\  \ *noderange*\  \ **thermalmode={default|custom|heavy_io|max_base_fan_floor}**\ 
+
 \ **rspconfig**\  \ *noderange*\  \ **timesyncmethod**\ 
 
 \ **rspconfig**\  \ *noderange*\  \ **timesyncmethod={manual|ntp}**\ 
@@ -518,6 +522,12 @@ OPTIONS
  \ **-d**\  will download a single dump or all generated dumps from the BMC to /var/log/xcat/dump on management or service node.
  
  
+ 
+
+
+\ **thermalmode**\ 
+ 
+ Display or set the thermal mode of the system to a setting, depending on your system, adapter, and cable type. After a factory reset of the system, the thermal mode setting is lost and must be reapplied. To choose the correct setting for your system, see http://blaze.aus.stglabs.ibm.com/kc20A-cur/POWER9/p9ei3/p9ei3_thermal_mode.htm [OpenBMC]
  
 
 

--- a/perl-xCAT/xCAT/Usage.pm
+++ b/perl-xCAT/xCAT/Usage.pm
@@ -193,6 +193,8 @@ my %usage = (
        rspconfig <noderange> timesyncmethod={ntp|manual}
        rspconfig <noderange> bootmode
        rspconfig <noderange> bootmode={safe|regular|setup}
+       rspconfig <noderange> thermalmode
+       rspconfig <noderange> thermalmode={default|custom|heavy_io|max_base_fan_floor}
        rspconfig <noderange> autoreboot
        rspconfig <noderange> autoreboot={0|1}
 ",

--- a/xCAT-client/pods/man1/rspconfig.1.pod
+++ b/xCAT-client/pods/man1/rspconfig.1.pod
@@ -60,6 +60,10 @@ B<rspconfig> I<noderange> B<powersupplyredundancy={disabled|enabled}>
 
 B<rspconfig> I<noderange> B<sshcfg>
 
+B<rspconfig> I<noderange> B<thermalmode>
+
+B<rspconfig> I<noderange> B<thermalmode={default|custom|heavy_io|max_base_fan_floor}>
+
 B<rspconfig> I<noderange> B<timesyncmethod>
 
 B<rspconfig> I<noderange> B<timesyncmethod={manual|ntp}>
@@ -401,6 +405,10 @@ B<-g> will generate a new dump on the BMC. Dump generation can take a few minute
 B<-d> will download a single dump or all generated dumps from the BMC to /var/log/xcat/dump on management or service node.
 
 =back
+
+=item B<thermalmode>
+
+Display or set the thermal mode of the system to a setting, depending on your system, adapter, and cable type. After a factory reset of the system, the thermal mode setting is lost and must be reapplied. To choose the correct setting for your system, see http://blaze.aus.stglabs.ibm.com/kc20A-cur/POWER9/p9ei3/p9ei3_thermal_mode.htm [OpenBMC]
 
 =item B<timesyncmethod>
 

--- a/xCAT-client/pods/man1/rspconfig.1.pod
+++ b/xCAT-client/pods/man1/rspconfig.1.pod
@@ -408,7 +408,7 @@ B<-d> will download a single dump or all generated dumps from the BMC to /var/lo
 
 =item B<thermalmode>
 
-Display or set the thermal mode of the system to a setting, depending on your system, adapter, and cable type. After a factory reset of the system, the thermal mode setting is lost and must be reapplied. To choose the correct setting for your system, see http://blaze.aus.stglabs.ibm.com/kc20A-cur/POWER9/p9ei3/p9ei3_thermal_mode.htm [OpenBMC]
+Display or set the thermal mode of the system to a setting, depending on your system, adapter, and cable type. After a factory reset of the system, the thermal mode setting is lost and must be reapplied. To choose the correct setting for your system, see https://www.ibm.com/support/knowledgecenter/POWER9/p9ei3/p9ei3_thermal_mode.htm [OpenBMC]
 
 =item B<timesyncmethod>
 

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -676,6 +676,21 @@ my %api_config_info = (
             manual      => "xyz.openbmc_project.Time.Synchronization.Method.Manual",
         },
     },
+    RSPCONFIG_THERMAL_MODE => {
+        command      => "rspconfig",
+        url          => "/control/thermal/0",
+        attr_url     => "Current",
+        display_name => "BMC ThermalMode",
+        instruct_msg => "",
+        type         => "attribute",
+        subcommand   => "thermalmode",
+        attr_value   => {
+            default            => "DEFAULT",
+            custom             => "CUSTOM",
+            heavy_io           => "HEAVY_IO",
+            max_base_fan_floor => "MAX_BASE_FAN_FLOOR",
+        },
+    },
 );
 
 $::RESPONSE_OK                  = "200 OK";


### PR DESCRIPTION
### The PR is to fix issue _#6466_

* Perl support for thermal mode
* Usage update
* `rspconfig` man page update

#### UT ####

* Valid set and query:
```
[root@briggs01 xcat]# rspconfig mid05tor12cn15 thermalmode
mid05tor12cn15: BMC ThermalMode: DEFAULT

[root@briggs01 xcat]# rspconfig mid05tor12cn15 thermalmode=heavy_io
mid05tor12cn15: BMC Setting BMC ThermalMode...

[root@briggs01 xcat]# rspconfig mid05tor12cn15 thermalmode
mid05tor12cn15: BMC ThermalMode: HEAVY_IO
[root@briggs01 xcat]#
```

* Invalid value:
```
[root@briggs01 xcat]# rspconfig mid05tor12cn15 thermalmode=abc
mid05tor12cn15: Error: Invalid value 'abc' for 'thermalmode', Valid values: custom,default,heavy_io,max_base_fan_floor
[root@briggs01 xcat]#
```