### PR TITLE
Use nslookup option type=A for xcatprobe xcatmn command

### DIFF
--- a/xCAT-probe/lib/perl/probe_utils.pm
+++ b/xCAT-probe/lib/perl/probe_utils.pm
@@ -448,7 +448,7 @@ sub is_dns_ready {
     my $hostname = shift;
     my $domain   = shift;
 
-    my $output = `nslookup $mnip $serverip 2>&1`;
+    my $output = `nslookup -type=A $mnip $serverip 2>&1`;
 
     if ($?) {
         return 0;

--- a/xCAT-probe/subcmds/xcatmn
+++ b/xCAT-probe/subcmds/xcatmn
@@ -1006,7 +1006,7 @@ sub check_dns_service {
                 } else {
 
                     # if there is no sn, nslookup mnip
-                    my $nslkp = `nslookup $serverip $serverip 2>&1`;
+                    my $nslkp = `nslookup -type=A $serverip $serverip 2>&1`;
                     chomp($nslkp);
                     my $tmp = grep { $_ =~ "Server:[\t\s]*$serverip" } split(/\n/, $nslkp);
                     if (!$tmp) {


### PR DESCRIPTION
For PR #6414 

UT output on redhel 8 cluster:
```
# xcatprobe xcatmn -i enp0s1
[mn]: Checking all xCAT daemons are running...                                                        [ OK ]
[mn]: Checking xcatd can receive command request...                                                   [ OK ]
[mn]: Checking 'site' table is configured...                                                          [ OK ]
[mn]: Checking provision network is configured...                                                     [ OK ]
[mn]: Checking 'passwd' table is configured...                                                        [ OK ]
[mn]: Checking important directories(installdir,tftpdir) are configured...                            [ OK ]
[mn]: Checking SELinux is disabled...                                                                 [ OK ]
[mn]: Checking HTTP service is configured...                                                          [ OK ]
[mn]: Checking TFTP service is configured...                                                          [ OK ]
[mn]: Checking DNS service is configured...                                                           [ OK ]
[mn]: Checking DHCP service is configured...                                                          [ OK ]
[mn]: Checking NTP service is configured...                                                           [ OK ]
[mn]: Checking rsyslog service is configured...                                                       [ OK ]
```