### PR TITLE
OpenBMC Thermal Mode [Python]

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -234,6 +234,18 @@ RSPCONFIG_APIS = {
             'setup': "xyz.openbmc_project.Control.Boot.Mode.Modes.Setup",
         },
     },
+    'thermalmode': {
+        'baseurl': "/control/thermal/0",
+        'set_url': "/attr/Current",
+        'get_url': "/attr/Current",
+        'display_name':"BMC ThermalMode",
+        'attr_values': {
+            'default': "DEFAULT",
+            'custom': "CUSTOM",
+            'heavy_io': "HEAVY_IO",
+            'max_base_fan_floor': "MAX_BASE_FAN_FLOOR",
+        },
+    },
     'timesyncmethod': {
         'baseurl': '/time/sync_method',
         'get_url': '',

--- a/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
+++ b/xCAT-openbmc-py/lib/python/agent/xcatagent/openbmc.py
@@ -53,7 +53,7 @@ all_nodes_result = {}
 # global variables of rbeacon
 BEACON_OPTIONS = ('on', 'off', 'stat')
 
-RSPCONFIG_GET_OPTIONS = ['ip','ipsrc','netmask','gateway','vlan','ntpservers','hostname','bootmode','autoreboot','powersupplyredundancy','powerrestorepolicy', 'timesyncmethod']
+RSPCONFIG_GET_OPTIONS = ['ip','ipsrc','netmask','gateway','vlan','ntpservers','hostname','bootmode','thermalmode','autoreboot','powersupplyredundancy','powerrestorepolicy', 'timesyncmethod']
 
 RSPCONFIG_SET_OPTIONS = {
     'ip':'.*',
@@ -66,6 +66,7 @@ RSPCONFIG_SET_OPTIONS = {
     'powersupplyredundancy':"^enabled$|^disabled$",
     'powerrestorepolicy':"^always_on$|^always_off$|^restore$",
     'bootmode':"^regular$|^safe$|^setup$",
+    'thermalmode':"^default$|^custom$|^heavy_io$|^max_base_fan_floor$",
     'admin_passwd':'.*,.*',
     'timesyncmethod':'^ntp$|^manual$',
 }

--- a/xCAT-server/lib/xcat/plugins/openbmc2.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc2.pm
@@ -160,12 +160,13 @@ sub process_request {
     xCAT::AGENT::wait_agent($pid, $callback);
 }
 
-my @rsp_common_options = qw/autoreboot bootmode powersupplyredundancy powerrestorepolicy timesyncmethod
+my @rsp_common_options = qw/autoreboot bootmode thermalmode powersupplyredundancy powerrestorepolicy timesyncmethod
                             ip netmask gateway hostname vlan ntpservers/;
 my @rspconfig_set_options = (@rsp_common_options, qw/admin_passwd/);
 my %rsp_set_valid_values = (
     autoreboot            => "0|1",
     bootmode              => "regular|safe|setup",
+    thermalmode           => "default|custom|heavy_io|max_base_fan_floor",
     powersupplyredundancy => "disabled|enabled",
     powerrestorepolicy    => "always_off|always_on|restore",
     timesyncmethod        => "manual|ntp",


### PR DESCRIPTION
### The PR is to fix issue _#6466_

* Python support for OpenBMC thermal mode

#### UT ####

* Valid set and query:
```
[root@stratton01 xcat]# rspconfig f5u14 thermalmode -V
[stratton01]: Running command in Python
[stratton01]: f5u14: BMC ThermalMode: DEFAULT

[root@stratton01 xcat]# rspconfig f5u14 thermalmode=heavy_io -V
[stratton01]: Running command in Python
[stratton01]: f5u14: BMC Setting BMC ThermalMode...

[root@stratton01 xcat]# rspconfig f5u14 thermalmode -V
[stratton01]: Running command in Python
[stratton01]: f5u14: BMC ThermalMode: HEAVY_IO
[root@stratton01 xcat]#
```

* Invalid value:
```
[root@stratton01 xcat]# rspconfig f5u14 thermalmode=abc -V
[stratton01]: f5u14: Error: Invalid value 'abc' for 'thermalmode', Valid values: default,custom,heavy_io,max_base_fan_floor
[root@stratton01 xcat]#
```