### PR TITLE
Remove /install/autoinst config files as part of nodepurge

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/nodepurge.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/nodepurge.1.rst
@@ -31,7 +31,7 @@ DESCRIPTION
 
 The \ **nodepurge**\  automatically removes all nodes from the database and any related configurations used by the node.
 
-After the nodes are removed, the configuration files related to these nodes are automatically updated, including the following files: /etc/hosts, DNS, DHCP. Any kits that are used by the nodes are triggered to automatically update kit configuration and services.
+After the nodes are removed, the configuration files related to these nodes are automatically updated, including the following files: \ */etc/hosts*\ , DNS, DHCP. Any kits that are used by the nodes are triggered to automatically update kit configuration and services. Any related configuration files from \ */install/autoinst*\  are also removed.
 
 
 *******
@@ -39,17 +39,11 @@ OPTIONS
 *******
 
 
-\ **-h|-**\ **-help**\ 
+\ **-h|-**\ **-help**\     Display usage message.
 
-Display usage message.
+\ **-v|-**\ **-version**\  Command Version
 
-\ **-v|-**\ **-version**\ 
-
-Command Version
-
-\ *noderange*\ 
-
-The nodes to be removed.
+\ *noderange*\     The nodes to be removed.
 
 
 ************
@@ -67,7 +61,7 @@ EXAMPLES
 ********
 
 
-To remove nodes compute-000 and compute-001, use the following command:
+To remove nodes compute-000 and compute-001:
 
 
 .. code-block:: perl

--- a/xCAT-client/pods/man1/nodepurge.1.pod
+++ b/xCAT-client/pods/man1/nodepurge.1.pod
@@ -12,21 +12,15 @@ B<nodepurge> I<noderange>
 
 The B<nodepurge> automatically removes all nodes from the database and any related configurations used by the node.
 
-After the nodes are removed, the configuration files related to these nodes are automatically updated, including the following files: /etc/hosts, DNS, DHCP. Any kits that are used by the nodes are triggered to automatically update kit configuration and services.
+After the nodes are removed, the configuration files related to these nodes are automatically updated, including the following files: I</etc/hosts>, DNS, DHCP. Any kits that are used by the nodes are triggered to automatically update kit configuration and services. Any related configuration files from I</install/autoinst> are also removed.
 
 =head1 OPTIONS
 
-B<-h|--help>
+B<-h|--help>    Display usage message.
 
-Display usage message.
+B<-v|--version> Command Version
 
-B<-v|--version>
-
-Command Version
-
-I<noderange>
-
-The nodes to be removed.
+I<noderange>    The nodes to be removed.
 
 =head1 RETURN VALUE
 
@@ -36,7 +30,7 @@ The nodes to be removed.
 
 =head1 EXAMPLES
 
-To remove nodes compute-000 and compute-001, use the following command:
+To remove nodes compute-000 and compute-001:
 
  nodepurge compute-000,compute-001
 

--- a/xCAT-server/lib/xcat/plugins/profilednodes.pm
+++ b/xCAT-server/lib/xcat/plugins/profilednodes.pm
@@ -687,7 +687,7 @@ sub nodepurge {
 Usage:
 \tnodepurge <noderange>
 \tnodepurge [-h|--help]
-\tnodepurge {-v|--version}";
+\tnodepurge [-v|--version]";
 
     my $ret = validate_args($helpmsg);
     if (!$ret) {
@@ -733,6 +733,20 @@ Usage:
         $warnstr .= "Warning: Cannot remove all nodes. The noderm command failed to remove some of the nodes.";
         if ($retstrref->[1]) {
             $warnstr .= "Details: $retstrref->[1]";
+        }
+    }
+    # For each node in the noderange remove its configureation files in $config_dir, if file exists
+    setrsp_progress("Removing configuration files...");
+    my $config_dir = "/install/autoinst/";
+    foreach my $one_node (@$nodes) {
+        if ( -e "$config_dir/$one_node") {
+            unlink "$config_dir/$one_node";
+        }
+        if ( -e "$config_dir/$one_node.post") {
+            unlink "$config_dir/$one_node.post";
+        }
+        if ( -e "$config_dir/$one_node.pre") {
+            unlink "$config_dir/$one_node.pre";
         }
     }
     setrsp_progress("Removed all nodes.");


### PR DESCRIPTION
### The PR is to fix issue _#3897_

### The modification include

* For each node in the noderange, check if there are `/install/autoinst/<node>` or  `/install/autoinst/<node>.pre` or  `/install/autoinst/<node>.post` files. If there are, remove them during `nodepurge` command processing.

* Update man page for `nodepurge` command.