### PR TITLE
nodepurge test cases failed on the regression

### DIFF
--- a/xCAT-test/autotest/testcase/nodepurge/cases0
+++ b/xCAT-test/autotest/testcase/nodepurge/cases0
@@ -1,16 +1,16 @@
 start:nodepurge_noderange
 description:nodepurge testnode1,testnode2
 label:mn_only,db
-cmd:mkdef -t node -o testnode1 arch=ppc64le cons=ipmi groups=pbmc mgt=ipmi ip=10.1.1.200 mac=e6:d4:d2:3a:ad:01  monserver=10.1.1.1 nameservers=10.1.1.1 nodetype=ppc,osi profile=compute tftpserver=10.1.1.1 xcatmaster=10.1.1.1 os=rhels7.7 netboot=petitboot
+cmd:mkdef -t node -o testnode1 arch=ppc64le cons=ipmi groups=pbmc mgt=ipmi ip=10.1.1.200 mac=e6:d4:d2:3a:ad:01  monserver=10.1.1.1 nameservers=10.1.1.1 nodetype=ppc,osi profile=compute tftpserver=10.1.1.1 xcatmaster=10.1.1.1 netboot=petitboot
 check:rc==0
-cmd:mkdef -t node -o testnode2 arch=ppc64le cons=ipmi groups=pbmc mgt=ipmi ip=10.1.1.201 mac=e6:d4:d2:3a:ad:02  monserver=10.1.1.1 nameservers=10.1.1.1 nodetype=ppc,osi profile=compute tftpserver=10.1.1.1 xcatmaster=10.1.1.1 os=rhels7.7 netboot=petitboot
+cmd:mkdef -t node -o testnode2 arch=ppc64le cons=ipmi groups=pbmc mgt=ipmi ip=10.1.1.201 mac=e6:d4:d2:3a:ad:02  monserver=10.1.1.1 nameservers=10.1.1.1 nodetype=ppc,osi profile=compute tftpserver=10.1.1.1 xcatmaster=10.1.1.1 netboot=petitboot
 check:rc==0
 cmd:lsdef -t node testnode1,testnode2
 check:output=~testnode1
 check:output=~testnode2
 cmd:makehosts testnode1,testnode2
 check:rc==0
-cmd:nodeset testnode1,testnode2 osimage=rhels7.7-ppc64le-install-compute
+cmd:nodeset testnode1,testnode2 osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute 
 check:rc==0
 cmd:nodepurge testnode1,testnode2
 check:rc==0
@@ -22,9 +22,9 @@ check:output=~No such file or directory
 cmd:ls /install/autoinst/testnode2*
 check:output=~No such file or directory
 cmd:ping testnode1
-check:output=~Name or service not known
+check:rc!=0
 cmd:ping testnode2
-check:output=~Name or service not known
+check:rc!=0
 end
 
 start:nodepurge_h


### PR DESCRIPTION
All the regression test cases failed due to the PR #6491
```
 RUN:nodeset testnode1,testnode2 osimage=rhels7.7-ppc64le-install-compute [Mon Nov 25 06:49:45 2019]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Error: [f6u13k16]: Cannot find the OS image rhels7.7-ppc64le-install-compute in the osimage table.
CHECK:rc == 0   [Failed]
```
The rhels7.7 osimage will not be available for other test cases except rhels7.7 test cases,  also, output ping failure  are different for each ARCH
```
[c910f03c17k07]: c910f02c39p03: ping: testnode: Name or service not known
[c910f03c17k07]: c910f04x12: ping: unknown host testnode
[c910f03c17k07]: c910f03c11k12: ping: testnode: Temporary failure in name resolution
```
