### PR TITLE
Regression test failed on the nodeset_shell_incorrectmasterip

### DIFF
--- a/xCAT-test/autotest/testcase/genesis/test.sh
+++ b/xCAT-test/autotest/testcase/genesis/test.sh
@@ -23,7 +23,7 @@ MASTER_PRIVATE_NETWORK="192_168_0_0-255_255_0_0"
 
 
 function check_destiny() {
-    cmd="chdef ${TESTNODE} arch=ppc64le cons=ipmi groups=all ip=${TESTNODE_IP} mac=4e:ee:ee:ee:ee:0e netboot=$NETBOOT";
+    cmd="chdef ${TESTNODE} arch=ppc64le cons=ipmi groups=all ip=${TESTNODE_IP} mac=4e:ee:ee:ee:ee:0e netboot=$NETBOOT" tftpserver=$MASTER_PRIVATE_IP xcatmaster=$MASTER_PRIVATE_IP;
     runcmd $cmd;
     lsdef ${TESTNODE}
 
@@ -44,7 +44,8 @@ function check_destiny() {
         cmd="makenetworks";
         runcmd $cmd;
         ip addr show
-        makehosts ${TESTNODE}
+        cmd="makehosts ${TESTNODE}"
+        runcmd $cmd
         grep ${TESTNODE} /etc/hosts 
         cmd="nodeset ${TESTNODE}  shell";
         runcmd $cmd;


### PR DESCRIPTION
the `rhels8.0.0-P9VMs-PostgreSQL-master-daily` failed on test cases `nodeset_shell_incorrectmasterip`
```
testnode: [f6u13k13]: Error: f6u13k13: The IP address of node testnode is in an undefined subnet
Error: [f6u13k13]: Failed to generate petitboot configurations for some node(s) on f6u13k13. Check xCAT log file for more details.
Run command nodeset testnode shell... [Failed]

Run command ip addr del 192.168.1.1/255.255.0.0 dev enp0s2 ...
RTNETLINK answers: Cannot assign requested address
Run command ip addr del 192.168.1.1/255.255.0.0 dev enp0s2... [Failed]
````

All the regression test bucket set up as hierarchy,   If `xcatmaster` didn't define in the compute node definition,  it will send request to service node also.  for this case,  the service node doesn't know the `testnode`,  it will failed to resolve the `testnode` ip address. 

Adding `xcatmaster` and `tftpserver` to `testnode` definition will not send request to service node.   
