### PR TITLE
Restart libssl1.1 without asking for regression Ubuntu pkg install2

### DIFF
--- a/xCAT-test/autotest/testcase/migration/ubuntu_migration1_vm
+++ b/xCAT-test/autotest/testcase/migration/ubuntu_migration1_vm
@@ -43,6 +43,7 @@ cmd:xdsh $$CN "apt-get clean all"
 check:rc==0
 cmd:xdsh $$CN "apt-get update"
 check:rc==0
+cmd:xdsh $$CN "echo '* libraries/restart-without-asking boolean true' | debconf-set-selections"
 cmd:xdsh $$CN "apt-get -y install build-essential dpkg-dev dh-make debhelper fakeroot gnupg lintian pbuilder quilt reprepro libsoap-lite-perl libdbi-perl"
 check:rc==0
 cmd:xdsh $$CN "rm -rf /oldxcat"


### PR DESCRIPTION
This PR similar to #6471. It updates the testcase which updates packages on Ubuntu compute node. It forces libraries that require input during installation to automatically accept the default and not prompt the user for input. 
Since `ubuntu_migration1_vm` testcase only gets executed on x86, no need to check `arch`.