### PR TITLE
Add support for provision SLE15 diskless compute

### DIFF
--- a/xCAT-server/share/xcat/netboot/sles/compute.sle15.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/compute.sle15.pkglist
@@ -1,7 +1,7 @@
 aaa_base
 coreutils
 bash
-dbus
+dbus-1
 wicked
 device-mapper
 dracut

--- a/xCAT-server/share/xcat/netboot/sles/compute.sle15.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/compute.sle15.x86_64.pkglist
@@ -1,7 +1,7 @@
 aaa_base
 coreutils
 bash
-dbus
+dbus-1
 wicked
 device-mapper
 dracut

--- a/xCAT-server/share/xcat/netboot/sles/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/sles/dracut_033/xcatroot
@@ -336,6 +336,9 @@ fi
 
 [ "$xcatdebugmode" > "0" ] && logger -t $log_label -p debug "setting hostname..."
 echo `hostname` > $NEWROOT/etc/hostname
+if [ ! -z $NODE ]; then
+    echo $NODE > $NEWROOT/etc/hostname
+fi
 
 logger $SYSLOGHOST -t $log_label -p debug "Exiting xcatroot..."
 

--- a/xCAT-server/share/xcat/netboot/sles/genimage
+++ b/xCAT-server/share/xcat/netboot/sles/genimage
@@ -185,7 +185,7 @@ if ($netdriver) {
 
 # Add the default driver list
 if ($arch eq 'x86' or $arch eq 'x86_64') {
-    push @ndrivers, qw/tg3 bnx2 bnx2x e1000 e1000e virtio_net virtio_balloon igb mlx_en be2net/;
+    push @ndrivers, qw/tg3 bnx2 bnx2x e1000 e1000e virtio_net virtio_balloon igb mlx4_en be2net/;
 } elsif ($arch eq 'ppc64') {
     push @ndrivers, qw/tg3 e1000 e1000e igb ibmveth ehea be2net/;
 } elsif ($arch eq "s390x") {
@@ -203,7 +203,7 @@ unless (grep /af_packet/, @ndrivers) {
 }
 
 my $osver_host;
-if (`grep VERSION /etc/SuSE-release` =~ /VERSION = (\d+)/) {
+if (`grep VERSION /etc/os-release` =~ /VERSION = (\d+)/) {
     $osver_host = $1;
 } else {
     $osver_host = 11;
@@ -397,6 +397,10 @@ unless ($onlyinitrd) {
     #my $yumcmd = "yum -y -c /tmp/genimage.$$.yum.conf --installroot=$rootimg_dir --disablerepo=* ";
     #$yumcmd .= "install ";
     #mkpath("$rootimg_dir/var/lib/yum");
+    mkpath("$rootimg_dir/etc/");
+    my $passwdfile;
+    open($passwdfile, ">", "$rootimg_dir/etc/passwd");
+    print $passwdfile "root:x:0:0:root:/root:/bin/bash\n";
     my $yumcmd;
     if ($osver_host < 11) {
         $yumcmd = "zypper -R $rootimg_dir $non_interactive install ";
@@ -1944,6 +1948,10 @@ sub generic_post { # This function is meant to leave the image in a state approx
         system("sed  -i 's!\\(HWCLOCK=\\).*!\\1\"--localtime\"!' $rootimg_dir/etc/sysconfig/clock");
     }
 
+    if (-e "$rootimg_dir/etc/sysconfig/network/dhcp") {
+        system("sed  -i 's!^DHCLIENT_SET_HOSTNAME=\\\"no\\\"!DHCLIENT_SET_HOSTNAME=\\\"yes\\\"!' $rootimg_dir/etc/sysconfig/network/dhcp");
+    }
+
     unlink("$rootimg_dir/dev/null");
     system("mknod $rootimg_dir/dev/null c 1 3");
     open($cfgfile, ">", "$rootimg_dir/etc/fstab");
@@ -2053,8 +2061,10 @@ sub generic_post { # This function is meant to leave the image in a state approx
         chmod(0755, "$rootimg_dir/etc/init.d/gettyset");
     }
 
-    copy("$installroot/postscripts/xcatpostinit", "$rootimg_dir/etc/init.d/xcatpostinit");
-    chmod(0755, "$rootimg_dir/etc/init.d/xcatpostinit");
+    system("mkdir -p $rootimg_dir/opt/xcat");
+    copy("$installroot/postscripts/xcatpostinit", "$rootimg_dir/opt/xcat/xcatpostinit");
+    chmod(0755, "$rootimg_dir/opt/xcat/xcatpostinit");
+    copy("$installroot/postscripts/xcatpostinit.service", "$rootimg_dir/usr/lib/systemd/system/xcatpostinit.service");
 
     #
     # set certain system services to start on boot, if the file exists in /etc/init.d as a script,
@@ -2073,7 +2083,7 @@ sub generic_post { # This function is meant to leave the image in a state approx
             system("$cmd");
         }
         else {
-            $cmd = $cmd . "systemctl start $service.service";
+            $cmd = $cmd . "systemctl enable $service.service";
             system("$cmd");
         }
     }


### PR DESCRIPTION
Had issue when diskless compute is provisioned, the hostname for compute node is `none`,  it seems xCAT postscripts `xcatdsklspost` never ran.  
To fix this:  
1) add `$NODE` to `/etc/hostname` in the dracut
2) copy `postscripts/xcatpostinit` to `$rootimg_dir/opt/xcat/xcatpostinit`
3) Add `$rootimg_dir/usr/lib/systemd/system/xcatpostinit.service`