### PR TITLE
Remove perl-IO-Stty requirement from xCAT spec

### DIFF
--- a/xCAT/xCAT.spec
+++ b/xCAT/xCAT.spec
@@ -58,8 +58,10 @@ Requires: /usr/bin/ssh
 %if %nots390x
 Requires: /usr/sbin/in.tftpd
 Requires: xCAT-buildkit
-# Stty is only needed for rcons on ppc64 nodes, but for mixed clusters require it on both x and p
+# Stty is only needed for rcons on ppc64 nodes
+%ifarch ppc64
 Requires: perl-IO-Stty
+%endif
 %endif
 %endif
 

--- a/xCATsn/xCATsn.spec
+++ b/xCATsn/xCATsn.spec
@@ -41,8 +41,10 @@ Requires: /usr/sbin/dhcpd
 Requires: /usr/bin/ssh
 %ifnarch s390x
 Requires: /usr/sbin/in.tftpd
-# Stty is only needed for rcons on ppc64 nodes, but for mixed clusters require it on both x and p
+# Stty is only needed for rcons on ppc64 nodes
+%ifarch ppc64
 Requires: perl-IO-Stty
+%endif
 %endif
 %endif
 


### PR DESCRIPTION
For sle15,  xCAT installation will failed because perl-IO-Stty package is not available.    
```
Problem: nothing provides perl-IO-Stty needed by xCAT-2.15.1-snap201911230129.ppc64le
 Solution 1: do not install xCAT-2.15.1-snap201911230129.ppc64le
 Solution 2: break xCAT-2.15.1-snap201911230129.ppc64le by ignoring some of its dependencies
````
search the xCAT code, this package is only required for ppc64.  so should be safe to remove this requirement from xCAT spec.