### PR TITLE
Modify logrotate conf file to reduce log missing

### DIFF
--- a/xCAT-server/share/xcat/conf/goconslogrotate
+++ b/xCAT-server/share/xcat/conf/goconslogrotate
@@ -3,6 +3,8 @@
 {
     missingok
     sharedscripts
+    copytruncate
+    delaycompress
     postrotate
         kill -HUP `systemctl show -p MainPID goconserver.service 2> /dev/null |awk -F= '{print $2}'` 2> /dev/null || true
     endscript

--- a/xCAT/etc/logrotate.d/xcat
+++ b/xCAT/etc/logrotate.d/xcat
@@ -1,6 +1,8 @@
 /var/log/xcat/*.log {
     missingok
     sharedscripts
+    copytruncate
+    delaycompress
     postrotate
         test -f /var/run/rsyslogd.pid && kill -HUP `cat /var/run/rsyslogd.pid 2> /dev/null` 2> /dev/null || true
         test -f /var/run/syslogd.pid && kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true


### PR DESCRIPTION
The PR is to fix issue #6485

Add `copytruncate` and  `delaycompress` to goconsover logrotate conf file.  It seems worked for `hourly` and `daily` logrorate`
```
[root@boston02 consoles]# tail mid08tor03cn01.log.2019121103
[2019-12-10T16:17:06-05:00]  34.01820|ISTEP 13. 4 - mem_pll_setup
[2019-12-10T16:17:06-05:00]  34.04244|ISTEP 13. 6 - mem_startclocks
[2019-12-10T16:17:06-05:00]  34.06559|ISTEP 13. 7 - host_enable_memvolt
[2019-12-10T16:17:06-05:00]  34.06866|ISTEP 13. 8 - mss_scominit
[2019-12-10T16:17:06-05:00]  34.41800|ISTEP 13. 9 - mss_ddr_phy_reset
[2019-12-10T16:17:06-05:00]  34.50363|ISTEP 13.10 - mss_draminit
[2019-12-10T16:17:07-05:00]  34.79198|ISTEP 13.11 - mss_draminit_training
[2019-12-10T16:17:07-05:00]  35.68051|ISTEP 13.12 - mss_draminit_trainadv
[2019-12-10T16:17:08-05:00]  35.96152|ISTEP 13.13 - mss_draminit_mc
[2019-12-10T16:17:08-05:00]  35.99413|ISTEP 14. 1 - mss_memdiag
[root@boston02 consoles]# head mid08tor03cn01.log
[2019-12-10T16:17:25-05:00]  55.53322|ISTEP 14. 2 - mss_thermal_init
[2019-12-10T16:17:25-05:00]  55.55844|ISTEP 14. 3 - proc_pcie_config
[2019-12-10T16:17:25-05:00]  55.58094|ISTEP 14. 4 - mss_power_cleanup
[2019-12-10T16:17:25-05:00]  55.58771|ISTEP 14. 5 - proc_setup_bars
[2019-12-10T16:17:25-05:00]  55.63268|ISTEP 14. 6 - proc_htm_setup
[2019-12-10T16:17:25-05:00]  55.64289|ISTEP 14. 7 - proc_exit_cache_contained
[2019-12-10T16:17:25-05:00]  55.65756|ISTEP 15. 1 - host_build_stop_image
[2019-12-10T16:17:27-05:00]  57.39942|ISTEP 15. 2 - proc_set_pba_homer_bar
[2019-12-10T16:17:27-05:00]  57.40879|ISTEP 15. 3 - host_establish_ex_chiplet
[2019-12-10T16:17:27-05:00]  57.41551|ISTEP 15. 4 - host_start_stop_engine
```
