### PR TITLE
Improve OpenBMC reventlog message for missing policyTable.json

### DIFF
--- a/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
+++ b/xCAT-openbmc-py/lib/python/agent/hwctl/openbmc_client.py
@@ -265,7 +265,8 @@ EVENTLOG_URLS     = {
 }
 
 RAS_POLICY_TABLE  = "/opt/ibm/ras/lib/policyTable.json"
-RAS_POLICY_MSG    = "Install the OpenBMC RAS package to obtain more detailed logging messages."
+RAS_POLICY_TABLE_RPM_LOC = "https://www.ibm.com/support/customercare/sas/f/lopdiags/scaleOutLCdebugtool.html#OpenBMC"
+RAS_POLICY_MSG    = "Install the openbmctool rpm from " + RAS_POLICY_TABLE_RPM_LOC + " to obtain more detailed logging messages."
 RAS_NOT_FOUND_MSG = " Not found in policy table: "
 
 RESULT_OK = 'ok'

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1123,7 +1123,7 @@ rmdir \"/tmp/\$userid\" \n";
     while (1) {
         unless ($wait_node_num) {
             if ($event_mapping and (ref($event_mapping) ne "HASH")) {
-                xCAT::SvrUtils::sendmsg("$event_mapping, install the openbmctool rpm from $::RAS_POLICY_TABLE_RPM_LOC to obtain more detailed logging messages.", $callback);
+                xCAT::MsgUtils->message("I", { data=> ["$event_mapping, install the openbmctool rpm from $::RAS_POLICY_TABLE_RPM_LOC to obtain more detailed logging messages."]}, $callback);
             }
             if ($next_status{LOGIN_RESPONSE} eq "RSPCONFIG_SSHCFG_REQUEST") {
                 my $home = xCAT::Utils->getHomeDir("root");

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -91,6 +91,7 @@ $::RSPCONFIG_CONFIGURED_API_KEY  = -1;
 
 $::XCAT_LOG_DIR             = "/var/log/xcat";
 $::RAS_POLICY_TABLE         = "/opt/ibm/ras/lib/policyTable.json";
+$::RAS_POLICY_TABLE_RPM_LOC = "https://www.ibm.com/support/customercare/sas/f/lopdiags/scaleOutLCdebugtool.html#OpenBMC";
 $::XCAT_LOG_RFLASH_DIR      = $::XCAT_LOG_DIR . "/rflash/";
 $::XCAT_LOG_DUMP_DIR        = $::XCAT_LOG_DIR . "/dump/";
 
@@ -1122,7 +1123,7 @@ rmdir \"/tmp/\$userid\" \n";
     while (1) {
         unless ($wait_node_num) {
             if ($event_mapping and (ref($event_mapping) ne "HASH")) {
-                xCAT::SvrUtils::sendmsg("$event_mapping, install the OpenBMC RAS package to obtain more details logging messages.", $callback);
+                xCAT::SvrUtils::sendmsg("$event_mapping, install the openbmctool rpm from $::RAS_POLICY_TABLE_RPM_LOC to obtain more detailed logging messages.", $callback);
             }
             if ($next_status{LOGIN_RESPONSE} eq "RSPCONFIG_SSHCFG_REQUEST") {
                 my $home = xCAT::Utils->getHomeDir("root");


### PR DESCRIPTION
Display a better message for `reventlog` on OpenBMC when `policyTable.json` file is not found.

#### Perl:
```
[root@briggs01 xcat]# reventlog mid05tor12cn03 -V
[briggs01]: Running command in Perl
[briggs01]: mid05tor12cn03: 03/28/2019 15:00:51 [1]: xyz.openbmc_project.Software.Version.Error.Incompatible (PID: 1383), Resolved: 0
[briggs01]: mid05tor12cn03: 03/28/2019 15:06:43 [2]: xyz.openbmc_project.Software.Version.Error.Incompatible (PID: 1372), Resolved: 0
[briggs01]: mid05tor12cn03: 03/28/2019 15:08:24 [3]: xyz.openbmc_project.Software.Version.Error.Incompatible (PID: 1587), Resolved: 0
:
:
:
[briggs01]: mid05tor12cn03: 01/05/2020 21:22:48 [316]: org.open_power.OCC.Metrics.Error.Event (PID: 1405), Resolved: 0
[briggs01]: mid05tor12cn03: 01/06/2020 21:26:19 [317]: org.open_power.OCC.Metrics.Error.Event (PID: 1405), Resolved: 0
[briggs01]: Could not find '/opt/ibm/ras/lib/policyTable.json', install the openbmctool rpm from https://www.ibm.com/support/customercare/sas/f/lopdiags/scaleOutLCdebugtool.html#OpenBMC to obtain more detailed logging messages.
[root@briggs01 xcat]#
```

#### Python:
```
[root@stratton01 xcat]# reventlog f5u16 all -V
[stratton01]: Running command in Python
[stratton01]: Install the openbmctool rpm from https://www.ibm.com/support/customercare/sas/f/lopdiags/scaleOutLCdebugtool.html#OpenBMC to obtain more detailed logging messages.
[stratton01]: f5u16: 05/17/2018 09:08:41 [1]: org.open_power.Host.Boot.Error.Checkstop (PID: 2235), Resolved: False
[stratton01]: f5u16: 05/17/2018 09:12:02 [2]: org.open_power.Host.Boot.Error.Checkstop (PID: 2944), Resolved: False
[stratton01]: f5u16: 05/17/2018 09:15:28 [3]: org.open_power.Host.Boot.Error.Checkstop (PID: 3614), Resolved: False
:
:
:
```