### PR TITLE
Default to all for OpenBMC reventlog verbose

### DIFF
--- a/xCAT-server/lib/xcat/plugins/openbmc2.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc2.pm
@@ -448,7 +448,7 @@ sub refactor_args {
         }
     }
     if ($command eq "reventlog") {
-        if (!defined($extrargs->[0])) {
+        if ((!defined($extrargs->[0])) or ($extrargs->[0] =~ /^-V/)) {
             # If no parameters are passed, default to list all records
             $request->{arg} = ["list","all"];
         }


### PR DESCRIPTION
Before this fix, the Python OpenBMC `reventlog -V` would hang.
It should have defaulted to `all` records.

The problem was that code was checking only for no arguments passed, and defaulting to `all`, but when `-V` for verbose was passed, the default to `all` was skipped.

This PR defaults to `all` when no arguments or `-V` is passed.

```
[root@stratton01 xcat]# reventlog f5u16 -V
[stratton01]: Running command in Python
[stratton01]: Install the openbmctool rpm from https://www.ibm.com/support/customercare/sas/f/lopdiags/scaleOutLCdebugtool.html#OpenBMC to obtain more detailed logging messages.
[stratton01]: f5u16: 05/17/2018 09:08:41 [1]: org.open_power.Host.Boot.Error.Checkstop (PID: 2235), Resolved: False
[stratton01]: f5u16: 05/17/2018 09:12:02 [2]: org.open_power.Host.Boot.Error.Checkstop (PID: 2944), Resolved: False
[stratton01]: f5u16: 05/17/2018 09:15:28 [3]: org.open_power.Host.Boot.Error.Checkstop (PID: 3614), Resolved: False
:
:
:
```