### PR TITLE
Change shabang for python on rhels8.1

### DIFF
--- a/xCAT-test/autotest/testcase/xcat_inventory/validatehelper
+++ b/xCAT-test/autotest/testcase/xcat_inventory/validatehelper
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 
 import yaml


### PR DESCRIPTION
The PR is to fix issue #6086 

Manually built xCAT-test rpm
```
# ./makerpm xCAT-test
Building /gsa/pokgsa/home/c/x/cxhong/rpmbuild/RPMS/noarch/xCAT-test-2.15.1-snap*.noarch.rpm ...
```
The new rpm doesn't have `/usr/bin/python`  line as depends
```
# rpm -qpR xCAT-test-2.15.1-snap000000000000.noarch.rpm
/bin/bash
/bin/sh
/bin/sh
/bin/sh
/usr/bin/env
perl(Data::Dumper)
perl(File::Basename)
perl(File::Copy)
perl(File::Path)
perl(Getopt::Long)
perl(POSIX)
perl(Sys::Hostname)
perl(Term::ANSIColor)
perl(Time::Local)
perl(integer)
perl(lib)
perl(strict)
perl(warnings)
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsXz) <= 5.2-1

]# yum install xCAT-test
Updating Subscription Management repositories.
Unable to read consumer identity
This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.
xCAT configured yum repository for /install/shared_repo/ISOs/rhels8.1.0/ppc64l  26 MB/s | 1.9 MB     00:00
xCAT configured yum repository for /install/shared_repo/ISOs/rhels8.1.0/ppc64l  46 MB/s | 4.8 MB     00:00
xcat-core                                                                       30 MB/s |  31 kB     00:00
xcat-dep                                                                        46 MB/s | 104 kB     00:00
Dependencies resolved.
===============================================================================================================
 Package               Architecture       Version                                  Repository             Size
===============================================================================================================
Installing:
 xCAT-test             noarch             4:2.15.1-snap000000000000                xcat-core             1.0 M

Transaction Summary
===============================================================================================================
Install  1 Package

Total size: 1.0 M
Installed size: 3.1 M
Is this ok [y/N]: y

```

