### PR TITLE
bmcdiscover with bmc password expiration

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/bmcdiscover.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/bmcdiscover.1.rst
@@ -23,7 +23,7 @@ SYNOPSIS
 
 \ **bmcdiscover**\  [\ **-v | -**\ **-version**\ ]
 
-\ **bmcdiscover**\  [\ **-**\ **-sn**\  \ *SN_nodename*\ ] [\ **-s**\  \ *scan_method*\ ] [\ **-u**\  \ *bmc_user*\ ] [\ **-p**\  \ *bmc_passwd*\ ] [\ **-z**\ ] [\ **-w**\ ] \ **-**\ **-range**\  \ *ip_ranges*\ 
+\ **bmcdiscover**\   \ **-**\ **-range**\  \ *ip_ranges*\  [\ **-**\ **-sn**\  \ *SN_nodename*\ ] [\ **-s**\  \ *scan_method*\ ] [\ **-u**\  \ *bmc_user*\ ] [\ **-p**\  \ *bmc_passwd*\ ] [\ **-z**\ ] [\ **-w**\ ]
 
 
 ***********
@@ -35,9 +35,9 @@ The \ **bmcdiscover**\  command will discover Baseboard Management Controllers (
 
 The command uses \ **nmap**\  to scan active nodes over a specified IP range.  The IP range format should be a format that is acceptable by \ **nmap**\ .
 
-The \ **bmcdiscover**\  command can also obtain some information about the BMC. (Check username/password, IP address source, DHCP/static configuration)
+\ **Note:**\  The scan method currently supported is \ **nmap**\ .
 
-Note: The scan method currently support is \ **nmap**\ .
+\ **Note:**\  Starting on January 1, 2020, some newly shipped systems will require the default BMC password to be changed before they can be managed by xCAT. \ **bmcdiscover**\  will not be able to discover such systems. Run \ */opt/xcat/share/xcat/scripts/BMC_change_password.sh*\  script to change the default password for BMCs in specified range, then rerun \ **bmcdiscover**\  with \ **-p "new bmc password"**\  flag to discover systems with the changed password.
 
 
 *******
@@ -48,13 +48,13 @@ OPTIONS
 
 \ **-**\ **-range**\ 
  
- Specify one or more IP ranges acceptable to \ **nmap**\ .  IP range can be hostnames, IP addresses, networks, etc.  A single IP address (10.1.2.3), several IPs with commas (10.1.2.3,10.1.2.10), Ip range with "-" (10.1.2.0-100) or an IP range (10.1.2.0/24) can be specified.  If the range is very large, the \ **bmcdiscover**\  command may take a long time to return.
+ Specify one or more IP ranges acceptable to \ **nmap**\ .  IP range can be hostnames, IP addresses, networks, etc.  A single IP address (10.1.2.3), several IPs with commas (10.1.2.3,10.1.2.10), IP range with "-" (10.1.2.0-100) or an IP range (10.1.2.0/24) can be specified.  If the range is very large, the \ **bmcdiscover**\  command may take a long time to return.
  
 
 
 \ **-**\ **-sn**\ 
  
- Specify one or more service nodes on which bmcdiscover will run. In hierarchical cluster, the MN may not be able to access the BMC of CN directly, but SN can. With this option, \ **bmcdiscover**\  will be dispatched to the specified SNs. Then, the nodename of the service node that \ **bmcdiscover**\  is running on will be set to the 'servicenode' attribute of the discovered BMC node.
+ Specify one or more service nodes on which \ **bmcdiscover**\  will run. In hierarchical cluster, the MN may not be able to access the BMC of CN directly, but SN can. In that case, \ **bmcdiscover**\  will be dispatched to the specified SNs. Then, the nodename of the service node that \ **bmcdiscover**\  is running on will be set to the 'servicenode' attribute of the discovered BMC node.
  
 
 
@@ -73,12 +73,6 @@ OPTIONS
 \ **-w**\ 
  
  Write to the xCAT database.
- 
-
-
-\ **-i|-**\ **-bmcip**\ 
- 
- BMC IP address.
  
 
 
@@ -122,7 +116,7 @@ EXAMPLES
 ********
 
 
-1. To get all responding BMCs from IP range "10.4.23.100-254" and 50.3.15.1-2":
+1. To get all responding BMCs from IP range "10.4.23.100-254" and "50.3.15.1-2":
 
 
 .. code-block:: perl

--- a/xCAT-client/pods/man1/bmcdiscover.1.pod
+++ b/xCAT-client/pods/man1/bmcdiscover.1.pod
@@ -8,7 +8,7 @@ B<bmcdiscover> [B<-?>|B<-h>|B<--help>]
 
 B<bmcdiscover> [B<-v>|B<--version>]
 
-B<bmcdiscover> [B<--sn> I<SN_nodename>] [B<-s> I<scan_method>] [B<-u> I<bmc_user>] [B<-p> I<bmc_passwd>] [B<-z>] [B<-w>] B<--range> I<ip_ranges>
+B<bmcdiscover>  B<--range> I<ip_ranges> [B<--sn> I<SN_nodename>] [B<-s> I<scan_method>] [B<-u> I<bmc_user>] [B<-p> I<bmc_passwd>] [B<-z>] [B<-w>]
 
 
 =head1 DESCRIPTION
@@ -17,9 +17,10 @@ The B<bmcdiscover> command will discover Baseboard Management Controllers (BMCs)
 
 The command uses B<nmap> to scan active nodes over a specified IP range.  The IP range format should be a format that is acceptable by B<nmap>.
 
-The B<bmcdiscover> command can also obtain some information about the BMC. (Check username/password, IP address source, DHCP/static configuration)
+B<Note:> The scan method currently supported is B<nmap>.
 
-Note: The scan method currently support is B<nmap>.
+
+B<Note:> Starting on January 1, 2020, some newly shipped systems will require the default BMC password to be changed before they can be managed by xCAT. B<bmcdiscover> will not be able to discover such systems. Run I</opt/xcat/share/xcat/scripts/BMC_change_password.sh> script to change the default password for BMCs in specified range, then rerun B<bmcdiscover> with B<-p "new bmc password"> flag to discover systems with the changed password. 
 
 =head1 OPTIONS
 
@@ -27,11 +28,11 @@ Note: The scan method currently support is B<nmap>.
 
 =item B<--range>
 
-Specify one or more IP ranges acceptable to B<nmap>.  IP range can be hostnames, IP addresses, networks, etc.  A single IP address (10.1.2.3), several IPs with commas (10.1.2.3,10.1.2.10), Ip range with "-" (10.1.2.0-100) or an IP range (10.1.2.0/24) can be specified.  If the range is very large, the B<bmcdiscover> command may take a long time to return.
+Specify one or more IP ranges acceptable to B<nmap>.  IP range can be hostnames, IP addresses, networks, etc.  A single IP address (10.1.2.3), several IPs with commas (10.1.2.3,10.1.2.10), IP range with "-" (10.1.2.0-100) or an IP range (10.1.2.0/24) can be specified.  If the range is very large, the B<bmcdiscover> command may take a long time to return.
 
 =item B<--sn>
 
-Specify one or more service nodes on which bmcdiscover will run. In hierarchical cluster, the MN may not be able to access the BMC of CN directly, but SN can. With this option, B<bmcdiscover> will be dispatched to the specified SNs. Then, the nodename of the service node that B<bmcdiscover> is running on will be set to the 'servicenode' attribute of the discovered BMC node.
+Specify one or more service nodes on which B<bmcdiscover> will run. In hierarchical cluster, the MN may not be able to access the BMC of CN directly, but SN can. In that case, B<bmcdiscover> will be dispatched to the specified SNs. Then, the nodename of the service node that B<bmcdiscover> is running on will be set to the 'servicenode' attribute of the discovered BMC node.
 
 =item B<-s>
 
@@ -44,10 +45,6 @@ List the data returned in xCAT stanza format
 =item B<-w>
 
 Write to the xCAT database.
-
-=item B<-i|--bmcip>
-
-BMC IP address.
 
 =item B<-u|--bmcuser>
 
@@ -76,7 +73,7 @@ Display version information
 =head1 EXAMPLES
 
 
-1. To get all responding BMCs from IP range "10.4.23.100-254" and 50.3.15.1-2":
+1. To get all responding BMCs from IP range "10.4.23.100-254" and "50.3.15.1-2":
 
     bmcdiscover -s nmap --range "10.4.23.100-254 50.3.15.1-2"
 

--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -200,7 +200,7 @@ sub bmcdiscovery_usage {
     push @{ $rsp->{data} }, "Usage:";
     push @{ $rsp->{data} }, "\tbmcdiscover [-?|-h|--help]";
     push @{ $rsp->{data} }, "\tbmcdiscover [-v|--version]";
-    push @{ $rsp->{data} }, "\tbmcdiscover [--sn <SN_nodename>] [-s scan_method] [-u bmc_user] [-p bmc_passwd] [-z] [-w] --range ip_range\n";
+    push @{ $rsp->{data} }, "\tbmcdiscover --range ip_range <ip_range> [--sn <SN_nodename>] [-s <scan_method>] [-u <bmc_user>] [-p <bmc_passwd>] [-z] [-w]\n";
 
     xCAT::MsgUtils->message("I", $rsp, $::CALLBACK);
     return 0;

--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -51,6 +51,10 @@ my $openbmc_pass;
 my $done_num = 0;
 $::P9_WITHERSPOON_MFG_ID     = "42817";
 $::P9_WITHERSPOON_PRODUCT_ID = "16975";
+$::CHANGE_PW_REQUIRED="The password provided for this account must be changed before access is granted";
+$::NO_SESSION="Unable to establish IPMI v2 / RMCP";
+$::CHANGE_PW_INSTRUCTIONS_1="Run script '/opt/xcat/share/xcat/scripts/BMC_change_password.sh' to change default password";
+$::CHANGE_PW_INSTRUCTIONS_2="Rerun 'bmcdiscover' command with '-p new_bmc_password' flag";
 %::VPDHASH = ();
 my %node_in_list = ();
 
@@ -748,9 +752,11 @@ sub scan_process {
                 $bmcpassword = "-P $bmc_pass" if ($bmc_pass);
 
                 my @mc_cmds = ("/opt/xcat/bin/ipmitool-xcat -I lanplus -H ${$live_ip}[$i] -P $openbmc_pass mc info -N 1 -R 1",
-                              "/opt/xcat/bin/ipmitool-xcat -I lanplus -H ${$live_ip}[$i] $bmcusername $bmcpassword mc info -N 1 -R 1");
+                               "/opt/xcat/bin/ipmitool-xcat -I lanplus -H ${$live_ip}[$i] -U $openbmc_user -P $openbmc_pass mc info -N 1 -R 1",
+                               "/opt/xcat/bin/ipmitool-xcat -I lanplus -H ${$live_ip}[$i] $bmcusername $bmcpassword mc info -N 1 -R 1");
                 my $mc_info;
                 my $is_openbmc = 0;
+                my $is_ipmi = 0;
                 foreach my $mc_cmd (@mc_cmds) {
                     $mc_info = xCAT::Utils->runcmd($mc_cmd, -1);
                     if ($::RUNCMD_RC != 0) {
@@ -761,12 +767,37 @@ sub scan_process {
                         if ($1 eq $::P9_WITHERSPOON_MFG_ID and $2 eq $::P9_WITHERSPOON_PRODUCT_ID) {
                             bmcdiscovery_openbmc(${$live_ip}[$i], $opz, $opw, $request_command,$parent_fd);
                             $is_openbmc = 1;
+                            $is_ipmi = 0;
+                            last;
+                        }
+                        else {
+                            # System replied to mc info but not with $::P9_WITHERSPOON_MFG_ID and $::P9_WITHERSPOON_PRODUCT_ID, assume IPMI
+                            $is_openbmc = 0;
+                            $is_ipmi = 1;
                             last;
                         }
                     }
                 }
-                unless ($is_openbmc) {
+
+                if ($is_ipmi) {
                     bmcdiscovery_ipmi(${$live_ip}[$i], $opz, $opw, $request_command,$parent_fd);
+                }
+                if (!$is_openbmc and !$is_ipmi) {
+                    if ($mc_info =~ /$::NO_SESSION/) {
+                        # Did not get usefull data from ipmi mc info, could be one of two possibilities:
+                        # 1. Incorrect pw was used
+                        # 2. New system installed after January 1, 2020 where default password needs to be changed
+                        #
+                        # Verify this is case 2, by attempting to establish a RedFish session
+                        my $redfish_session_cmd = "curl -sD - --data '{\"UserName\":\"$openbmc_user\",\"Password\":\"$openbmc_pass\"}' -k -X POST https://${$live_ip}[$i]/redfish/v1/SessionService/Sessions";
+                        my $redfish_session_info = xCAT::Utils->runcmd($redfish_session_cmd, -1);
+                        if ($redfish_session_info =~ /$::CHANGE_PW_REQUIRED/) {
+                            # RedFish session replied that password change is needed. Print instructions and exit
+                            xCAT::MsgUtils->message("I", { data => ["${$live_ip}[$i]: $::CHANGE_PW_REQUIRED"] }, $::CALLBACK);
+                            xCAT::MsgUtils->message("I", { data => ["$::CHANGE_PW_INSTRUCTIONS_1"] }, $::CALLBACK);
+                            xCAT::MsgUtils->message("I", { data => ["$::CHANGE_PW_INSTRUCTIONS_2"] }, $::CALLBACK);
+                        }
+                    }
                 }
                 close($parent_fd);
                 exit 0;


### PR DESCRIPTION
This pull request deals with California S.B. 327 new security requirements described by issues:
https://github.ibm.com/xcat2/team_process/issues/196
https://github.ibm.com/xcat2/team_process/issues/200

The following changes are introduced by this PR:
* If no success after attempting to contact the BMC with `ipmitool ... mc info` command, call RedFish `redfish/v1/SessionService/Sessions`
* If RedFish call above returns `The password provided for this account must be changed before access is granted`, display informational messages and exit.
* `bmcdiscover` man page updated for expired password changes.

#### UT:
* Witherspoon node with OP940.01 driver and expired password (now code) :
```
[root@briggs01 xcat]# bmcdiscover --range 172.11.139.5 -p 0penBmc321 -u backupadmin2
172.11.139.5: The password provided for this account must be changed before access is granted
Run script '/opt/xcat/share/xcat/scripts/BMC_change_password.sh' to change default password
Rerun 'bmcdiscover' command with '-p new_bmc_password' flag
Warning: [briggs01]: No bmc found.

[root@briggs01 xcat]#
```
* Witherspoon node with OP940.01 driver and not expired password (same as before this PR) :
```
[root@briggs01 xcat]# bmcdiscover --range 172.11.139.5 -p 0penBmc321 -u backupadmin2 -z
node-8335-gth-1318c4a:
        objtype=node
        groups=all
        bmc=172.11.139.5
        cons=openbmc
        mgt=openbmc
        mtm=8335-GTH
        serial=1318C4A
        bmcusername=backupadmin2
        bmcpassword=0penBmc321

[root@briggs01 xcat]#
```

* Witherspoon node with OP930 driver (same as before this PR) :
```
[root@briggs01 xcat]# bmcdiscover --range 172.11.139.3 -z
node-8335-gth-1318d3a:
        objtype=node
        groups=all
        bmc=172.11.139.3
        cons=openbmc
        mgt=openbmc
        mtm=8335-GTH
        serial=1318D3A

[root@briggs01 xcat]#
```

* Boston nodes with range specified (same as before this PR) :
```
[root@stratton01 xcat]# bmcdiscover --range 50.6.27-38.0-255 -p ADMIN -u ADMIN -z
node-8001-12c-130124a:
        objtype=node
        groups=all
        bmc=50.6.29.1
        cons=ipmi
        mgt=ipmi
        mtm=8001-12C
        serial=130124A
        bmcusername=ADMIN
        bmcpassword=ADMIN

node-8001-22c-130122a:
        objtype=node
        groups=all
        bmc=50.6.27.1
        cons=ipmi
        mgt=ipmi
        mtm=8001-22C
        serial=130122A
        bmcusername=ADMIN
        bmcpassword=ADMIN

node-9006-22c-130259a:
        objtype=node
        groups=all
        bmc=50.6.31.10
        cons=ipmi
        mgt=ipmi
        mtm=9006-22C
        serial=130259A
        bmcusername=ADMIN
        bmcpassword=ADMIN

node-9006-22c-1309aga:
        objtype=node
        groups=all
        bmc=50.6.30.1
        cons=ipmi
        mgt=ipmi
        mtm=9006-22C
        serial=1309AGA
        bmcusername=ADMIN
        bmcpassword=ADMIN

node-9006-22c-1309ala:
        objtype=node
        groups=all
        bmc=50.6.36.1
        cons=ipmi
        mgt=ipmi
        mtm=9006-22C
        serial=1309ALA
        bmcusername=ADMIN
        bmcpassword=ADMIN

node-9006-22c-1309gda:
        objtype=node
        groups=all
        bmc=50.6.32.1
        cons=ipmi
        mgt=ipmi
        mtm=9006-22C
        serial=1309GDA
        bmcusername=ADMIN
        bmcpassword=ADMIN

node-9006-22c-13025ka:
        objtype=node
        groups=all
        bmc=50.6.37.1
        cons=ipmi
        mgt=ipmi
        mtm=9006-22C
        serial=13025KA
        bmcusername=ADMIN
        bmcpassword=ADMIN

[root@stratton01 xcat]#
```