### PR TITLE
Add insserv-compat to sle15 pkglist

### DIFF
--- a/xCAT-server/share/xcat/install/sles/compute.sle15.pkglist
+++ b/xCAT-server/share/xcat/install/sles/compute.sle15.pkglist
@@ -2,4 +2,4 @@ iputils
 vim
 openssl
 rsync
-insserv
+insserv-compat

--- a/xCAT-server/share/xcat/install/sles/compute.sle15.pkglist
+++ b/xCAT-server/share/xcat/install/sles/compute.sle15.pkglist
@@ -2,3 +2,4 @@ iputils
 vim
 openssl
 rsync
+insserv

--- a/xCAT-server/share/xcat/install/sles/service.sle15.pkglist
+++ b/xCAT-server/share/xcat/install/sles/service.sle15.pkglist
@@ -3,6 +3,7 @@
 openssl
 ntp
 rsync
+insserv
 nmap
 perl-DBI
 vsftpd

--- a/xCAT-server/share/xcat/install/sles/service.sle15.pkglist
+++ b/xCAT-server/share/xcat/install/sles/service.sle15.pkglist
@@ -3,7 +3,7 @@
 openssl
 ntp
 rsync
-insserv
+insserv-compat
 nmap
 perl-DBI
 vsftpd

--- a/xCAT-server/share/xcat/netboot/sles/compute.sle15.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/compute.sle15.pkglist
@@ -46,4 +46,4 @@ kernel-default
 kernel-firmware
 adaptec-firmware
 xz
-insserv
+insserv-compat

--- a/xCAT-server/share/xcat/netboot/sles/compute.sle15.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/compute.sle15.pkglist
@@ -46,3 +46,4 @@ kernel-default
 kernel-firmware
 adaptec-firmware
 xz
+insserv

--- a/xCAT-server/share/xcat/netboot/sles/compute.sle15.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/compute.sle15.x86_64.pkglist
@@ -47,3 +47,4 @@ kernel-firmware
 adaptec-firmware
 xz
 SLE_HPC-release
+insserv

--- a/xCAT-server/share/xcat/netboot/sles/compute.sle15.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/compute.sle15.x86_64.pkglist
@@ -47,4 +47,4 @@ kernel-firmware
 adaptec-firmware
 xz
 SLE_HPC-release
-insserv
+insserv-compat

--- a/xCAT-server/share/xcat/netboot/sles/service.sle15.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/service.sle15.pkglist
@@ -57,7 +57,7 @@ vsftpd
 wget
 which
 zypper
-insserv
+insserv-compat
 
 #for database
 unixODBC

--- a/xCAT-server/share/xcat/netboot/sles/service.sle15.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/service.sle15.pkglist
@@ -57,6 +57,7 @@ vsftpd
 wget
 which
 zypper
+insserv
 
 #for database
 unixODBC

--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -848,7 +848,7 @@ sub load_config_file {
             }
         } elsif ($type eq "Varible") {
             ##NODE_BLOCK##
-            if ($line =~ /(\w+)\s*=\s*([\w\.\-\+\/:]+)/) {
+            if ($line =~ /(\w+)\s*=\s*([\w\.\-\+\ \/:]+)/) {
                 $$config_ref{var}{$1} = $2;
             }
         }
@@ -1796,10 +1796,16 @@ sub is_valid_case_name {
 sub get_current_os {
     if (-f "/etc/redhat-release") {
         return "rhels";
-    } elsif (-f "/etc/SuSE-release") {
-        return "sles";
     } elsif (-f "/etc/lsb-release") {
         return "ubuntu";
+    } elsif (-f "/etc/os-release") {
+        my $file="/etc/os-release";
+        &runcmd("grep -q sles $file");
+        if ($::RUNCMD_RC == 0) {
+            return "sles";
+        }
+    } elsif (-f "/etc/SuSE-release") {
+        return "sles";
     } else {
         return "aix";
     }


### PR DESCRIPTION
For issue #6525 .
```
c910f03c09k18:/tmp # cat /etc/os-release
NAME="SLES"
VERSION="15"
VERSION_ID="15"
PRETTY_NAME="SUSE Linux Enterprise Server 15"
ID="sles"
ID_LIKE="suse"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:suse:sles:15"

c910f03c09k18:/tmp # rpm -qa | grep insserv
insserv-compat-0.1-2.15.noarch

c910f03c09k18:/tmp # lsxcatd -a
Version 2.15.1 (git commit 01a02a833b216615baa6477fc9676aec8a89eae3, built Fri Jan 10 01:37:32 EST 2020)
This is a Management Node
dbengine=SQLite
````