### PR TITLE
Add net-tools-deprecated package to SLE15 package list

### DIFF
--- a/xCAT-server/share/xcat/install/sles/compute.sle15.pkglist
+++ b/xCAT-server/share/xcat/install/sles/compute.sle15.pkglist
@@ -3,3 +3,4 @@ vim
 openssl
 rsync
 insserv-compat
+net-tools-deprecated

--- a/xCAT-server/share/xcat/install/sles/service.sle15.pkglist
+++ b/xCAT-server/share/xcat/install/sles/service.sle15.pkglist
@@ -4,6 +4,7 @@ openssl
 ntp
 rsync
 insserv-compat
+net-tools-deprecated
 nmap
 perl-DBI
 vsftpd

--- a/xCAT-server/share/xcat/netboot/sles/compute.sle15.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/compute.sle15.pkglist
@@ -47,3 +47,4 @@ kernel-firmware
 adaptec-firmware
 xz
 insserv-compat
+net-tools-deprecated

--- a/xCAT-server/share/xcat/netboot/sles/compute.sle15.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/compute.sle15.x86_64.pkglist
@@ -48,3 +48,4 @@ adaptec-firmware
 xz
 SLE_HPC-release
 insserv-compat
+net-tools-deprecated

--- a/xCAT-server/share/xcat/netboot/sles/service.sle15.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/service.sle15.pkglist
@@ -58,7 +58,7 @@ wget
 which
 zypper
 insserv-compat
-
+net-tools-deprecated
 #for database
 unixODBC
 perl-DBD-mysql


### PR DESCRIPTION
This is workaround for issue #6527 .
xCAT makenetwork created empty networks due to `netstat` command is not available on SLE15
```
910f03c09k18:/tmp # makenetworks
c910f03c09k18:/tmp # tabdump networks
#netname,net,mask,mgtifname,gateway,dhcpserver,tftpserver,nameservers,ntpservers,logservers,dynamicrange,staticrange,staticrangeincrement,nodehostname,ddnsdomain,vlanid,domain,mtu,comments,disable
c910f03c09k18:/tmp # 
```
Currently, SlE15 provides 'net-tools-deprecated` packages to include those commands,  We are going to install this package for now as workaround, will work on replace those deprecated net-tools next.
```
c910f03c09k18:/tmp # zypper install net-tools-deprecated
Loading repository data...
Reading installed packages...
Resolving package dependencies...

The following NEW package is going to be installed:
  net-tools-deprecated

1 new package to install.
Overall download size: 184.1 KiB. Already cached: 0 B. After the operation, additional 802.9 KiB will be used.
Continue? [y/n/...? shows all options] (y): y
Retrieving package net-tools-deprecated-2.0+git20170221.479bb4a-3.11.ppc64le           (1/1), 184.1 KiB (802.9 KiB unpacked)
Retrieving: net-tools-deprecated-2.0+git20170221.479bb4a-3.11.ppc64le.rpm ............................................[done]
Checking for file conflicts: .........................................................................................[done]
(1/1) Installing: net-tools-deprecated-2.0+git20170221.479bb4a-3.11.ppc64le ................
c910f03c09k18:/tmp # makenetworks
c910f03c09k18:/tmp # tabdump networks
#netname,net,mask,mgtifname,gateway,dhcpserver,tftpserver,nameservers,ntpservers,logservers,dynamicrange,staticrange,staticrangeincrement,nodehostname,ddnsdomain,vlanid,domain,mtu,comments,disable
"10_0_0_0-255_0_0_0","10.0.0.0","255.0.0.0","eth0","10.0.0.102",,"<xcatmaster>",,,,,,,,,,,"1500",,
c910f03c09k18:/tmp # route
Kernel IP routing table
Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
default         c910loginx02.po 0.0.0.0         UG    0      0        0 eth0
10.0.0.0        0.0.0.0         255.0.0.0       U     0      0        0 eth0
c910f03c09k18:/tmp #
```

