### PR TITLE
Deprecate nodechmac command

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/nodechmac.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/nodechmac.1.rst
@@ -29,6 +29,16 @@ DESCRIPTION
 ***********
 
 
+\ **Note:**\  The command \ **nodechmac**\  has been deprecated. To change the MAC address of the node:
+
+
+.. code-block:: perl
+
+  makedhcp -d <nodename>
+  chdef -t node -o  <nodename> mac=<new-mac>
+  makedhcp <nodename>
+
+
 The \ **nodechmac**\  command changes the MAC address for provisioned node's network interface.
 
 You can use this command to keep an existing node configuration. For example, if an existing node has hardware problems, the replacement node can use the old configurations. By using the nodechmac command, the node name and network settings of the old node can be used by the new node.

--- a/xCAT-client/pods/man1/nodechmac.1.pod
+++ b/xCAT-client/pods/man1/nodechmac.1.pod
@@ -10,6 +10,12 @@ B<nodechmac> I<node-name> B<mac=>I<mac-address>
 
 =head1 DESCRIPTION
 
+B<Note:> The command B<nodechmac> has been deprecated. To change the MAC address of the node:
+
+ makedhcp -d <nodename>
+ chdef -t node -o  <nodename> mac=<new-mac>
+ makedhcp <nodename>
+
 The B<nodechmac> command changes the MAC address for provisioned node's network interface.
 
 You can use this command to keep an existing node configuration. For example, if an existing node has hardware problems, the replacement node can use the old configurations. By using the nodechmac command, the node name and network settings of the old node can be used by the new node.


### PR DESCRIPTION
### The PR is to fix issue _#6323_

Add note to man page of `nodechmac` command to indicate that it has been deprecated.