### PR TITLE
Display VM disk purge message instead of just logging it

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rmvm.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rmvm.1.rst
@@ -45,7 +45,7 @@ DESCRIPTION
 ***********
 
 
-The rmvm command removes the partitions specified in noderange. If noderange is an CEC, all the partitions associated with that CEC will be removed. Note that removed partitions are automatically removed from the xCAT database. For IVM-managed systems, care must be taken to not remove the VIOS partition, or all the associated partitions will be removed as well.
+The \ **rmvm**\  command removes the partitions specified in \ *noderange*\ . If \ *noderange*\  is an CEC, all the partitions associated with that CEC will be removed. Note that removed partitions are automatically removed from the xCAT database. For IVM-managed systems, care must be taken to not remove the VIOS partition, or all the associated partitions will be removed as well.
 
 For DFM-managed (short For Direct FSP Management mode) normal power machines, only partitions can be removed. No options is needed.
 
@@ -65,7 +65,11 @@ OPTIONS
 
 \ **-**\ **-service**\    Remove the service partitions of the specified CECs.
 
-\ **-p**\           KVM: Purge the existence of the VM from persistent storage.  This will erase all storage related to the VM in addition to removing it from the active virtualization configuration. PPC: Remove the specified partition on normal power machine.
+\ **-p**\ 
+
+KVM: Purge the existence of the VM from persistent storage. This will erase all storage related to the VM in addition to removing it from the active virtualization configuration. Storage devices of "raw" or "block" type are not removed.
+
+PPC: Remove the specified partition on normal power machine.
 
 \ **-f**\           Force remove the VM, even if the VM appears to be online.  This will bring down a live VM if requested.
 

--- a/xCAT-client/pods/man1/rmvm.1.pod
+++ b/xCAT-client/pods/man1/rmvm.1.pod
@@ -20,7 +20,7 @@ B<rmvm [-p]> I<noderange>
 
 =head1 DESCRIPTION
 
-The rmvm command removes the partitions specified in noderange. If noderange is an CEC, all the partitions associated with that CEC will be removed. Note that removed partitions are automatically removed from the xCAT database. For IVM-managed systems, care must be taken to not remove the VIOS partition, or all the associated partitions will be removed as well.
+The B<rmvm> command removes the partitions specified in I<noderange>. If I<noderange> is an CEC, all the partitions associated with that CEC will be removed. Note that removed partitions are automatically removed from the xCAT database. For IVM-managed systems, care must be taken to not remove the VIOS partition, or all the associated partitions will be removed as well.
 
 For DFM-managed (short For Direct FSP Management mode) normal power machines, only partitions can be removed. No options is needed.
 
@@ -37,7 +37,11 @@ B<-r>          Retain the data object definitions of the nodes.
 
 B<--service>   Remove the service partitions of the specified CECs.
 
-B<-p>          KVM: Purge the existence of the VM from persistent storage.  This will erase all storage related to the VM in addition to removing it from the active virtualization configuration. PPC: Remove the specified partition on normal power machine.
+B<-p>          
+
+KVM: Purge the existence of the VM from persistent storage. This will erase all storage related to the VM in addition to removing it from the active virtualization configuration. Storage devices of "raw" or "block" type are not removed.
+
+PPC: Remove the specified partition on normal power machine.
 
 B<-f>          Force remove the VM, even if the VM appears to be online.  This will bring down a live VM if requested.
 

--- a/xCAT-server/lib/xcat/plugins/kvm.pm
+++ b/xCAT-server/lib/xcat/plugins/kvm.pm
@@ -1802,13 +1802,13 @@ sub rmvm {
             unless ($driver[0]) { next; }
             my $drivertype = $driver[0]->getAttribute("type");
             if (($drivertype eq "raw") || ($disktype eq "block")) {
-                #For raw or block devices, do not remove, even if purge was specified. Log info message.
-                xCAT::MsgUtils->trace(0, "i", "Not purging raw or block storage device: $disk");
+                # For raw or block devices, do not remove device, even if purge was specified. Display info message.
+                xCAT::SvrUtils::sendmsg("Not purging raw or block storage device: $disk", $callback, $node);
                 next;
             }
             my $file = $disk->getAttribute("file");
             unless ($file) {
-                xCAT::MsgUtils->trace(0, "w", "Not able to find 'file' attribute value for: $disk");
+                xCAT::SvrUtils::sendmsg("Not able to find 'file' attribute value for: $disk", $callback, $node);
                 next;
             }
 


### PR DESCRIPTION
### The PR is to fix issue _#4741_

* Display informational message instead of logging the message.

* Update `rmvm` man page to indicate that `raw` and `block` storage devices will not be removed with `-p` option.

#### UT:

```
[root@stratton01 xcat]# rmvm fs2vm114 -p
fs2vm114: Not purging raw or block storage device: <source file="/var/lib/libvirt/images/fs2vm114.sda.raw"/>

[root@stratton01 xcat]# echo $?
0
```

```
[root@c910f3u31-fs2 ~]# ls -l /var/lib/libvirt/images/fs2vm114.sda.raw
-rw-------. 1 root root 10737418240 Jan 15 10:55 /var/lib/libvirt/images/fs2vm114.sda.raw
[root@c910f3u31-fs2 ~]#
```