### PR TITLE
SLE15: Fix makenamed.conf + pkglist

### DIFF
--- a/xCAT-server/sbin/makenamed.conf
+++ b/xCAT-server/sbin/makenamed.conf
@@ -30,7 +30,10 @@ is_lsb_ubuntu ()
 
 DIRECTORY=/var/named
 
-if [ -f /etc/SuSE-release ]; then
+# check for SLES
+grep -s -q sles /etc/os-release
+IS_SLES=$?
+if [ -f /etc/SuSE-release ] || [ $IS_SLES -eq 0 ]; then
   DIRECTORY=/var/lib/named
 fi
 FILE=/etc/named.conf

--- a/xCAT-server/share/xcat/netboot/sles/compute.sle15.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/compute.sle15.pkglist
@@ -28,7 +28,6 @@ binutils
 tar
 open-iscsi
 curl
-plymouth
 btrfsprogs
 cryptsetup
 dmraid
@@ -40,7 +39,6 @@ cifs-utils
 open-lldp
 fcoe-utils
 util-linux-systemd
-plymouth-dracut
 udev
 kernel-default
 kernel-firmware

--- a/xCAT-server/share/xcat/netboot/sles/compute.sle15.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/compute.sle15.x86_64.pkglist
@@ -28,7 +28,6 @@ binutils
 tar
 open-iscsi
 curl
-plymouth
 btrfsprogs
 cryptsetup
 dmraid
@@ -40,7 +39,6 @@ cifs-utils
 open-lldp
 fcoe-utils
 util-linux-systemd
-plymouth-dracut
 udev
 kernel-default
 kernel-firmware


### PR DESCRIPTION
There are more issues like this everywhere in the codebase.
This is just an initial quick fix.

SLE15 replaced `/etc/SuSE-release` with `/etc/os-release`.