### PR TITLE
Support otherpkgs as postbootscript for SLE15

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/post.xcat
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat
@@ -282,7 +282,7 @@ if [ $? -eq 0 ]; then
 fi
 
 if [ $hassystemd -eq 1 ] ; then
-    if [[ $OSVER == sles12* ]]; then
+    if [[ $OSVER =~ sle && $OSVER != sles11* ]]; then
         cat >/etc/systemd/system/xcatpostinit1.service <<'EOF'
 #INCLUDE:/install/postscripts/xcatpostinit1.service.yast2#
 EOF
@@ -514,7 +514,7 @@ cd /
 # To skip the conflict, the network service should be stoped in the yast first stage. Then base on the service
 # dependency, the service start order will be 'YaST2-Second-Stage.service'->'network'->'xcatpostinit1' in serial.
 # Then the Yast2 will be stopped before running the zypper in otherpkgs.
-if [[ $OSVER =~ sles && $OSVER != sles11* ]]; then
+if [[ $OSVER =~ sle && $OSVER != sles11* ]]; then
     service network stop
 fi
 

--- a/xCAT/postscripts/enablekdump
+++ b/xCAT/postscripts/enablekdump
@@ -40,7 +40,7 @@ for i in `/bin/cat /proc/cmdline`; do
 done
 
 if [ ! -z "$MACX" ] && [ ! -z "$ETHX" ]; then
-	if (pmatch $OSVER "sles*") || (pmatch $OSVER "suse*") || [ -f /etc/SuSE-release ]; then
+	if (pmatch $OSVER "sle*") || (pmatch $OSVER "suse*") || [ -f /etc/SuSE-release ]; then
 		CONFFILE=$MNTDIR/etc/sysconfig/network/ifcfg-$ETHX
 	fi
 	if (pmatch $OSVER "fedora*") || (pmatch $OSVER "rhel6*") || (pmatch $OSVER "rhels6*") || [ -f /etc/fedora-release ] || [ -f /etc/redhat-release ];then
@@ -108,7 +108,7 @@ if [ ! -z "$DUMP" ]; then
     fi
 
     if [ "$KDPROTO" = "nfs" ]; then
-	if (pmatch $OSVER "sles*") || (pmatch $OSVER "suse*") || [ -f /etc/SuSE-release ]; then
+	if (pmatch $OSVER "sle*") || (pmatch $OSVER "suse*") || [ -f /etc/SuSE-release ]; then
             if (pmatch $OSVER "*10*"); then
                 #run mkinitrd to generater the kdump-init base
                 if (pmatch $ARCH "x86*"); then

--- a/xCAT/postscripts/setupntp.traditional
+++ b/xCAT/postscripts/setupntp.traditional
@@ -94,7 +94,7 @@ if [ $OS_TYPE = Linux ]; then
 
     mkdir -p /var/lib/ntp
     chown ntp /var/lib/ntp
-    if ( pmatch $OSVER "sles*" ) || ( pmatch $OSVER "suse*" ) || [ -f /etc/SuSE-release ];then
+    if ( pmatch $OSVER "sle*" ) || ( pmatch $OSVER "suse*" ) || [ -f /etc/SuSE-release ];then
         echo "driftfile /var/lib/ntp/drift/ntp.drift" >>$conf_file
     else
         echo "driftfile /var/lib/ntp/drift" >>$conf_file
@@ -135,7 +135,7 @@ if [ $OS_TYPE = Linux ]; then
     hwclock --systohc --utc
 
     #setup the RTC is UTC format, which will be used by os
-    if ( pmatch $OSVER "sles*" ) || ( pmatch $OSVER "suse*" ) || [ -f /etc/SuSE-release ];then
+    if ( pmatch $OSVER "sle*" ) || ( pmatch $OSVER "suse*" ) || [ -f /etc/SuSE-release ];then
         grep -i -q "HWCLOCK" /etc/sysconfig/clock
         if [ $? -eq 0 ];then
             sed -i 's/.*HWCLOCK.*/HWCLOCK=\"-u\"/' /etc/sysconfig/clock


### PR DESCRIPTION
During the development stage, otherpkgs didn't get run as postbootscripts,  but worked fine with `updatenode` command.
this is known issue for sles12.  after modify `post.xcat` and ran same path as SLES12, the otherpkgs is installed on the service node, and xcatd is running .
```
c910f03c09k19:/opt/xcat # lsxcatd -a
Version 2.15.1 (git commit 98295ce99314abad4aa473173a98b1cb2796ac27, built Wed Jan 15 01:36:48 EST 2020)
This is a Service Node
cfgloc=Pg:dbname=xcatdb;host=c910f03c09k18|xcatadm
dbengine=Pg
dbname=xcatdb
dbhost=c910f03c09k18
dbadmin=xcatadm
```