### PR TITLE
dhcp.pm fix

### DIFF
--- a/xCAT-server/lib/xcat/plugins/dhcp.pm
+++ b/xCAT-server/lib/xcat/plugins/dhcp.pm
@@ -816,6 +816,8 @@ sub addnode
                                   ]
                             }
                         );
+                        print $omshell "close\n";
+                        next;
                     }
                 }
                 if ($lstatements)


### PR DESCRIPTION
dhcp.pm claimed to not add ip address of a node, overlapping with dhcp dynamic range, but added anyway