### PR TITLE
linux_diskless_kdump testcase enhancement2

### DIFF
--- a/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
+++ b/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
@@ -86,6 +86,9 @@ check:rc==0
 # Verify that kdump directory from management node is still mounted on the compute node
 cmd:xdsh $$CN df -H
 
+# Verify enablekdump postscript was executed on the compute node
+cmd:xdsh $$CN grep "enablekdump return with" /var/log/xcat/xcat.log
+
 cmd:xdsh $$CN "at now +1 minutes <<< /tmp/kdump.trigger"
 cmd:sleep 300
 

--- a/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
+++ b/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
@@ -47,6 +47,10 @@ check:rc==0
 cmd:chdef -t node $$CN -p postscripts=enablekdump
 check:rc==0
 
+# Verify kdump related attributes showup in the osimage and node definitions
+cmd:lsdef -t node $$CN -i postscripts
+cmd:lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute -i crashkernelsize,dump
+
 cmd:rmimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 cmd:genimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
@@ -78,6 +82,9 @@ cmd:a=`xdsh $$CN rpm -q at`;if [[ $a =~ "package at is not installed" ]]; then x
 
 cmd:xdsh $$CN "service atd start"
 check:rc==0
+
+# Verify that kdump directory from management node is still mounted on the compute node
+cmd:xdsh $$CN df -H
 
 cmd:xdsh $$CN "at now +1 minutes <<< /tmp/kdump.trigger"
 cmd:sleep 300


### PR DESCRIPTION
Still seeing failures of `linux_diskless_kdump` testcase during weekly regression on P8 VMs with RHEL 7.7

When `kdump` is triggered, the generated dump is supposed to be placed into NFS mounted `/opt/xcat/share/xcat/tools/autotest/kdumpdir` from management node.

This PR adds some commands to verify that 
* `kdump` related osimage and node attributes are displayed by `lsdef` 
* compute node properly mounted the dump directory from management node.
* `enablekdump` postscript successfully executed on the compute node
