### PR TITLE
Add more output to runcmdinstaller_command testcase

### DIFF
--- a/xCAT-test/autotest/testcase/runcmdinstaller/cases0
+++ b/xCAT-test/autotest/testcase/runcmdinstaller/cases0
@@ -16,7 +16,7 @@ check:rc==0
 cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
-cmd:a=0;while ! `lsdef -l $$CN|grep status|grep installing >/dev/null`; do sleep 20;((a++));if [ $a -gt 30 ];then break;fi done
+cmd:a=0;while ! `lsdef -l $$CN|grep status|grep installing >/dev/null`; do sleep 20; echo "[$a] " $(lsdef $$CN -i status -c); ((a++));if [ $a -gt 30 ];then break;fi done
 cmd:lsdef -l $$CN | grep status
 cmd:runcmdinstaller $$CN "ls /"
 check:rc==0


### PR DESCRIPTION
Weekly RHEL8.0 regression tests the weekend of 01/25/2020 have failed in `runcmdinstaller_command` testcase. The testcase starts provisioning the node and then keeps checking for `status=installing` every 20 seconds. After 30 iterations (10 min) the loop should exit and move on to the next command.
Sometimes, however, the loop never exits and gets stuck there for 10 hours, after which, Jenkins kills the job.

This PR adds some debug prints, to display the iteration number and the value of `status` attribute.
Output similar to:
```
[0]  c910f04x12v04: status=booted
[1]  c910f04x12v04: status=booted
[2]  c910f04x12v04: status=booted
[3]  c910f04x12v04: status=booted
[4]  c910f04x12v04: status=booted
```