### PR TITLE
Failed to run otherpkgs for rhel8.1.0 service node

### DIFF
--- a/xCAT/postscripts/ospkgs
+++ b/xCAT/postscripts/ospkgs
@@ -23,6 +23,8 @@
 #=cut
 #-------------------------------------------------------------------------------
 
+#set -x
+
 if [ -n "$LOGLABEL" ]; then
     log_label=$LOGLABEL
 else
@@ -891,6 +893,7 @@ else
 	       fi
 	       echo "enabled=1" >> $REPOFILE
 	       echo "gpgcheck=0" >> $REPOFILE
+               echo "skip_if_unavailable=True" >> $REPOFILE
            fi
            i=$((i+1))
      done

--- a/xCAT/postscripts/otherpkgs
+++ b/xCAT/postscripts/otherpkgs
@@ -573,6 +573,7 @@ elif ( ((pmatch "$OSVER" "rhel*") || (pmatch "$OSVER" "centos*") || (pmatch "$OS
 	       fi
 	       echo "enabled=1" >> $REPOFILE
 	       echo "gpgcheck=0" >> $REPOFILE
+               echo "skip_if_unavailable=True" >> $REPOFILE
            fi
            i=$((i+1))
       done


### PR DESCRIPTION
For issue #6543 
on the `rhels8.1.0-P8VMs-PostgreSQL-master-daily` regression test case, the service node failed to install xCATsn package due to bad repo
```
# yum repoinfo
Updating Subscription Management repositories.
Unable to read consumer identity
This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.
xCAT-rhels8.1.0-path0                                                                0.0  B/s |   0  B     00:03
Failed to download metadata for repo 'xCAT-rhels8.1.0-path0'
Error: Failed to download metadata for repo 'xCAT-rhels8.1.0-path0'
```

