### PR TITLE
[FVT]Missing tftpserver and xcatmaster for the testnode

### DIFF
--- a/xCAT-test/autotest/testcase/genesis/test.sh
+++ b/xCAT-test/autotest/testcase/genesis/test.sh
@@ -23,7 +23,7 @@ MASTER_PRIVATE_NETWORK="192_168_0_0-255_255_0_0"
 
 
 function check_destiny() {
-    cmd="chdef ${TESTNODE} arch=ppc64le cons=ipmi groups=all ip=${TESTNODE_IP} mac=4e:ee:ee:ee:ee:0e netboot=$NETBOOT" tftpserver=$MASTER_PRIVATE_IP xcatmaster=$MASTER_PRIVATE_IP;
+    cmd="chdef ${TESTNODE} arch=ppc64le cons=ipmi groups=all ip=${TESTNODE_IP} mac=4e:ee:ee:ee:ee:0e netboot=$NETBOOT tftpserver=$MASTER_PRIVATE_IP xcatmaster=$MASTER_PRIVATE_IP";
     runcmd $cmd;
     lsdef ${TESTNODE}
 


### PR DESCRIPTION
The testcase `nodeset_shell_incorrectmasterip` often failed in some of regression tests.  
```
OUTPUT:
Run command chdef testnode arch=ppc64le cons=ipmi groups=all ip=192.168.3.1 mac=4e:ee:ee:ee:ee:0e netboot=xnba ...
Run command chdef testnode arch=ppc64le cons=ipmi groups=all ip=192.168.3.1 mac=4e:ee:ee:ee:ee:0e netboot=xnba ... [Succeed]
Object name: testnode
    arch=ppc64le
    cons=ipmi
    groups=all
    ip=192.168.3.1
    mac=4e:ee:ee:ee:ee:0e
    netboot=grub2
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles

#netname,net,mask,mgtifname,gateway,dhcpserver,tftpserver,nameservers,ntpservers,logservers,dynamicrange,staticrange,staticrangeincrement,nodehostname,ddnsdomain,vlanid,domain,mtu,comments,disable
"10_0_0_0-255_0_0_0","10.0.0.0","255.0.0.0","ens3","10.0.0.102",,"<xcatmaster>",,,,,,,,,,,"1500",,
"192_168_0_0-255_255_0_0","192.168.0.0","255.255.0.0","ens4","<xcatmaster>",,"<xcatmaster>",,,,,,,,,,,"1500",,
Run command makehosts testnode ...
Run command makehosts testnode ... [Succeed]

Check if testnode can be found in /etc/hosts
192.168.3.1 testnode testnode.pok.stglabs.ibm.com
Run command nodeset testnode shell ...
testnode: [c910f04x12v02]: Error: The IP address of node testnode is in an undefined subnet
Error: [c910f04x12v02]: Failed to generate grub2 configurations for some node(s) on c910f04x12v02. Check xCAT log file for more details.
Run command nodeset testnode shell ... [Failed]

Run command ip addr del 192.168.1.1/255.255.0.0 dev ens4 ...
RTNETLINK answers: Cannot assign requested address
Run command ip addr del 192.168.1.1/255.255.0.0 dev ens4 ... [Failed]
````
definition of `testnode` missed `tftpserver` and `xcatmaster` attributes,   somehow it's outside of `"` , move `"` to end of line.
```
OUTPUT:
Run command chdef testnode arch=ppc64le cons=ipmi groups=all ip=192.168.3.1 mac=4e:ee:ee:ee:ee:0e netboot=xnba tftpserver=192.168.1.1 xcatmaster=192.168.1.1 ...
Run command chdef testnode arch=ppc64le cons=ipmi groups=all ip=192.168.3.1 mac=4e:ee:ee:ee:ee:0e netboot=xnba tftpserver=192.168.1.1 xcatmaster=192.168.1.1 ... [Succeed]

Object name: testnode
    arch=ppc64le
    cons=ipmi
    groups=all
    ip=192.168.3.1
    mac=4e:ee:ee:ee:ee:0e
    netboot=xnba
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
    tftpserver=192.168.1.1
    xcatmaster=192.168.1.1
```
