### PR TITLE
OpenBMC rvitals command to handle variable number of fans

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/common/parallel_cmd.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/parallel_cmd.rst
@@ -31,7 +31,7 @@ Examples for xdsh
 
 - To run the ``ps`` command on node targets node1 and run the remote command with the ``-v`` and ``-t`` flag, enter: ::
 
-    xdsh node1,node2 -o"-v -t" ps =item *
+    xdsh node1,node2 -o "-v -t" ps
 
 - To execute the commands contained in myfile in the XCAT context on several node targets, with a fanout of 1, enter: ::
 

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -4409,6 +4409,7 @@ sub rvitals_response {
     my @sorted_output;
 
     my %leds = ();
+    my $number_of_fan_leds = 0;
 
     foreach my $key_url (keys %{$response_info->{data}}) {
         my %content = %{ ${ $response_info->{data} }{$key_url} };
@@ -4425,10 +4426,11 @@ sub rvitals_response {
             $calc_value = (split(/\./, $content{State}))[-1];
             $content_info = $label . ": " . $calc_value ;
 
-            if ($key_url =~ "fan0") { $leds{fan0} = $calc_value; }
-            if ($key_url =~ "fan1") { $leds{fan1} = $calc_value; }
-            if ($key_url =~ "fan2") { $leds{fan2} = $calc_value; }
-            if ($key_url =~ "fan3") { $leds{fan3} = $calc_value; }
+            # There could be multiple fan LEDs. Match a string "fan" followed by digits, but only at the end of a string
+            if ($key_url =~ /fan(\d+)$/) {
+                $leds{"fan" . $1} = $calc_value;
+                $number_of_fan_leds++;
+            }
             if ($key_url =~ "front_id") { $leds{front_id} = $calc_value; }
             if ($key_url =~ "front_fault") { $leds{front_fault} = $calc_value; }
             if ($key_url =~ "front_power") { $leds{front_power} = $calc_value; }
@@ -4500,7 +4502,7 @@ sub rvitals_response {
                 }
             }
             # Fans
-            for (my $i = 0; $i < 4; $i++) {
+            for (my $i = 0; $i < $number_of_fan_leds; $i++) {
                 my $tmp_key = "fan" . $i;
                 $content_info = "LEDs Fan$i: $leds{$tmp_key}";
                 push (@sorted_output, $content_info);


### PR DESCRIPTION
### The PR is to fix issue _#6551_

Do better parsing of fan LED information:
1. Handle variable number of fan LEDs
2. Only match "fanX" at the end of the string.

### UT:

* Witherspoon with 4 fan LEDs and extra `/xyz/openbmc_project/led/physical/fan0/inventory` entries:
```
[root@briggs01 xcat]# rvitals mid05tor12cn05 leds
mid05tor12cn05: LEDs Fan0: Off
mid05tor12cn05: LEDs Fan1: Off
mid05tor12cn05: LEDs Fan2: Off
mid05tor12cn05: LEDs Fan3: Off
mid05tor12cn05: LEDs Front Fault: Off
mid05tor12cn05: LEDs Front Identify: Off
mid05tor12cn05: LEDs Front Power: On
mid05tor12cn05: LEDs Rear Fault: Off
mid05tor12cn05: LEDs Rear Identify: Off
mid05tor12cn05: LEDs Rear Power: On
[root@briggs01 xcat]#
```

* Witherspoon with 4 fan LEDs and **no** extra `/xyz/openbmc_project/led/physical/fan0/inventory` entries:
```
[root@briggs01 xcat]# rvitals mid05tor12cn03 leds
mid05tor12cn03: LEDs Fan0: Off
mid05tor12cn03: LEDs Fan1: Off
mid05tor12cn03: LEDs Fan2: Off
mid05tor12cn03: LEDs Fan3: Off
mid05tor12cn03: LEDs Front Fault: Off
mid05tor12cn03: LEDs Front Identify: Off
mid05tor12cn03: LEDs Front Power: On
mid05tor12cn03: LEDs Rear Fault: Off
mid05tor12cn03: LEDs Rear Identify: Off
mid05tor12cn03: LEDs Rear Power: On
[root@briggs01 xcat]#
```
* Multiple Witherspoons in the noderange:
```
[root@briggs01 xcat]# rvitals mid05tor12cn03,mid05tor12cn05 leds
mid05tor12cn03: LEDs Fan0: Off
mid05tor12cn03: LEDs Fan1: Off
mid05tor12cn03: LEDs Fan2: Off
mid05tor12cn03: LEDs Fan3: Off
mid05tor12cn03: LEDs Front Fault: Off
mid05tor12cn03: LEDs Front Identify: Off
mid05tor12cn03: LEDs Front Power: On
mid05tor12cn03: LEDs Rear Fault: Off
mid05tor12cn03: LEDs Rear Identify: Off
mid05tor12cn03: LEDs Rear Power: On
mid05tor12cn05: LEDs Fan0: Off
mid05tor12cn05: LEDs Fan1: Off
mid05tor12cn05: LEDs Fan2: Off
mid05tor12cn05: LEDs Fan3: Off
mid05tor12cn05: LEDs Front Fault: Off
mid05tor12cn05: LEDs Front Identify: Off
mid05tor12cn05: LEDs Front Power: On
mid05tor12cn05: LEDs Rear Fault: Off
mid05tor12cn05: LEDs Rear Identify: Off
mid05tor12cn05: LEDs Rear Power: On
[root@briggs01 xcat]#
```
* Mihawk with 6 fan LEDs
```
(0) root @ xcat1: /opt/xcat
# rvitals mihawk-gurevich leds
mihawk-gurevich: LEDs Fan0: Off
mihawk-gurevich: LEDs Fan1: Off
mihawk-gurevich: LEDs Fan2: Off
mihawk-gurevich: LEDs Fan3: Off
mihawk-gurevich: LEDs Fan4: Off
mihawk-gurevich: LEDs Fan5: Off
mihawk-gurevich: LEDs Front Fault:
mihawk-gurevich: LEDs Front Identify:
mihawk-gurevich: LEDs Front Power:
mihawk-gurevich: LEDs Rear Fault:
mihawk-gurevich: LEDs Rear Identify: Off
mihawk-gurevich: LEDs Rear Power:

(0) root @ xcat1: /opt/xcat
```