### PR TITLE
configib: pass NMCLI_USED from confignetwork instead of checking again

### DIFF
--- a/xCAT/postscripts/configib
+++ b/xCAT/postscripts/configib
@@ -32,11 +32,15 @@ fi
 ########################################################################
 # nmcli_used=0: use network.service
 # nmcli_used=1: use NetworkManager
+# nmcli_used=2: RH8 postscripts stage, NetworkManager is active but nmcli cannot modify NIC configure file
 ########################################################################
 nmcli_used=0
-ps -ef|grep -v grep|grep NetworkManager >/dev/null 2>/dev/null
-if [ $? -eq 0 ]; then
+if [ -n "$NMCLI_USED" ] ; then
+    if [ "$NMCLI_USED" = "1" ]; then
     nmcli_used=1
+    elif [ "$NMCLI_USED" = "2" ]; then
+        nmcli_used=2
+    fi
 fi
 
 #This is the number of ports for each ib adpator.

--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -610,8 +610,8 @@ function configure_nicdevice {
             fi
         elif [ x"$nic_dev_type" = "xinfiniband" ] || [ x"$nic_dev_type" = "xOmnipath" ]; then
             log_info "Call configib for IB nics: $nic_dev, ports: $num_iba_ports"
-            log_info "NIC_IBNICS=$nic_dev NIC_IBAPORTS=$num_iba_ports configib"
-            NIC_IBNICS=$nic_dev NIC_IBAPORTS=$num_iba_ports configib
+            log_info "NMCLI_USED=$networkmanager_active NIC_IBNICS=$nic_dev NIC_IBAPORTS=$num_iba_ports configib"
+            NMCLI_USED=$networkmanager_active NIC_IBNICS=$nic_dev NIC_IBAPORTS=$num_iba_ports configib
             if [ $? -ne 0 ]; then
                 log_error "configib failed."
                 errorcode=1


### PR DESCRIPTION
The `configib` postscript currently uses its own method to determine if NetworkManager should be used or not. The other network configuration scripts (like `configeth`) get a `NMCLI_USED` variable insted, that is set in `confignetwork` in a more robust fashion.

This PR let `configib` use the same mechanism, by calling it from `confignetwork` with:
```
NMCLI_USED=$networkmanager_active [...] configib
```