### PR TITLE
Remove stty command from Expect process

### DIFF
--- a/xCAT-server/lib/xcat/plugins/onie.pm
+++ b/xCAT-server/lib/xcat/plugins/onie.pm
@@ -382,7 +382,6 @@ sub cumulus_connect {
 
      $ssh->debug(0);
      $ssh->log_stdout(0);    # suppress stdout output..
-     $ssh->slave->stty(qw(sane -echo));
 
      unless ($ssh->spawn($command, @parameters))
      {

--- a/xCAT-server/lib/xcat/plugins/pdu.pm
+++ b/xCAT-server/lib/xcat/plugins/pdu.pm
@@ -826,7 +826,6 @@ sub session_connect {
 
      $ssh->debug(0);
      $ssh->log_stdout(0);    # suppress stdout output..
-     $ssh->slave->stty(qw(sane -echo));
 
      unless ($ssh->spawn($command, @parameters))
      {
@@ -1485,8 +1484,8 @@ sub netcfg_for_irpdu {
 
     my $mypdu = new Expect;
 
-    $mypdu->log_stdout(1);    # suppress stdout output..
-    $mypdu->slave->stty(qw(sane -echo));
+    $mypdu->debug(0);
+    $mypdu->log_stdout(0);    # suppress stdout output..
 
     unless ($mypdu->spawn($login_cmd))
     {

--- a/xCAT-server/share/xcat/scripts/configBNT
+++ b/xCAT-server/share/xcat/scripts/configBNT
@@ -409,7 +409,8 @@ sub config_snmp {
         my $cfg_access3="snmp-server access 5 security usm\r";
         my $cfg_access4="snmp-server access 5 read-view iso\r";
 
-        $mysw->slave->stty(qw(sane -echo));
+        $mysw->debug(0);
+        $mysw->log_stdout(0);    # suppress stdout output..
 
         unless ($mysw->spawn($login_cmd))
         {
@@ -522,7 +523,8 @@ sub config_G8264 {
     my $main_prompt="Main#";
     my $authpw_cmd = "/cfg/sys/ssnmp/snmpv3/usm 5/authpw\r";
 
-    $mysw->slave->stty(qw(sane -echo));
+    $mysw->debug(0);
+    $mysw->log_stdout(0);    # suppress stdout output..
 
     unless ($mysw->spawn($login_cmd))
     {

--- a/xCAT-server/share/xcat/scripts/configonie
+++ b/xCAT-server/share/xcat/scripts/configonie
@@ -226,7 +226,6 @@ sub cumulus_connect {
 
      $ssh->debug(0);
      $ssh->log_stdout(0);    # suppress stdout output..
-     $ssh->slave->stty(qw(sane -echo));
 
      unless ($ssh->spawn($command, @parameters))
      {


### PR DESCRIPTION
This PR is for issue: https://github.ibm.com/hpc-devops/xcat_clusters/issues/338
```
ersion 2.15.1 (git commit 4c025a7c9a67cf1f6f38c75559c2ed0fd59af8e4, built Wed Jan 29 01:30:34 EST 2020)
Linux c690csm01 4.18.0-147.el8.ppc64le #1 SMP Thu Sep 26 15:44:34 UTC 2019 ppc64le ppc64le ppc64le GNU/Linux
[root@c690csm01 ~]# rspconfig f5tor sshcfg
Error: [csm01]: onie plugin bug, pid 44677, process description: 'xcatd SSL: rspconfig to f5tor for root@localhost: onie instance' with error 'Can't locate object method "stty" via package "IO::Tty" at /opt/xcat/lib/perl/xCAT_plugin/onie.pm line 385.
' while trying to fulfill request for the following nodes: f5tor
```
line `$ssh->slave->stty(qw(sane -echo));` caused this issue.  it used to reset all terminal settings to `sane` and disable echoing of terminal input.   For this case, we didn't need this setting.

Recreate the issue with this line:
```
[root@boston02 scripts]# ssh mid08tor06
root@mid08tor06's password:

[root@boston02 scripts]# rspconfig mid08tor06 sshcfg
Error: [boston02]: onie plugin bug, pid 34395, process description: 'xcatd SSL: rspconfig to mid08tor06 for root@localhost: onie instance' with error 'Can't locate object method "stty" via package "IO::Tty" at /opt/xcat/lib/perl/xCAT_plugin/onie.pm line 385.
' while trying to fulfill request for the following nodes: mid08tor06
````
After remove `$ssh->slave->stty(qw(sane -echo));`
```
[root@boston02 scripts]# rspconfig mid08tor06 sshcfg
mid08tor06: SSH enabled
[root@boston02 scripts]# ssh mid08tor06
Warning: Permanently added 'mid08tor06' (ECDSA) to the list of known hosts.

Welcome to Cumulus (R) Linux (R)

For support and online technical documentation, visit
http://www.cumulusnetworks.com/support

The registered trademark Linux (R) is used pursuant to a sublicense from LMI,
the exclusive licensee of Linus Torvalds, owner of the mark on a world-wide
basis.
root@mid08tor06:~#
```


