### PR TITLE
kdump testcase enhancements3

### DIFF
--- a/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
+++ b/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
@@ -47,15 +47,15 @@ check:rc==0
 cmd:chdef -t node $$CN -p postscripts=enablekdump
 check:rc==0
 
-# Verify kdump related attributes showup in the osimage and node definitions
-cmd:lsdef -t node $$CN -i postscripts
-cmd:lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute -i crashkernelsize,dump
-
 cmd:rmimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 cmd:genimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 cmd:packimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
+
+# Verify kdump related attributes showup in the osimage and node definitions
+cmd:lsdef -t node $$CN -i postscripts
+cmd:lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute -i crashkernelsize,dump
 
 cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
@@ -87,7 +87,7 @@ check:rc==0
 cmd:xdsh $$CN df -H
 
 # Verify enablekdump postscript was executed on the compute node
-cmd:xdsh $$CN grep "enablekdump return with" /var/log/xcat/xcat.log
+cmd:xdsh $$CN grep "enablekdump\ return\ with" /var/log/xcat/xcat.log
 
 cmd:xdsh $$CN "at now +1 minutes <<< /tmp/kdump.trigger"
 cmd:sleep 300


### PR DESCRIPTION
Still seeing failures of `linux_diskless_kdump` testcase during weekly regression on P8 VMs

* Move verification of image attributes right before rinstall
* `xdsh grep` needs to have spaces escaped