### PR TITLE
Missing mount helper program on the SLE15

### DIFF
--- a/xCAT-server/share/xcat/install/sles/compute.sle15.pkglist
+++ b/xCAT-server/share/xcat/install/sles/compute.sle15.pkglist
@@ -5,3 +5,4 @@ rsync
 insserv-compat
 net-tools-deprecated
 rsyslog
+nfs-client

--- a/xCAT-server/share/xcat/install/sles/service.sle15.pkglist
+++ b/xCAT-server/share/xcat/install/sles/service.sle15.pkglist
@@ -17,6 +17,7 @@ unixODBC
 perl-Net-DNS
 perl-DBD-Pg
 postgresql-server
+postgresql
 perl-DBD-mysql
 mariadb-client
 #libmysqlclient18


### PR DESCRIPTION
Failed to mount on the SLE15 node:
```
2020-02-07 13:10:19 9895 Notice: Try to mount extra resource directory to f6u13k13
2020-02-07 13:10:20 9895 Fatal error: [runcmd] failed to run xdsh f6u13k13 'mount 10.0.0.122:/gpfs/cnfs01/data/xcat/jk /tmp/automation_mountpoint': [c910f03c17k07]: f6u13k13: mount: /tmp/automation_mountpoint: bad option; for several filesystems (e.g. nfs, cifs) you might need a /sbin/mount.<type> helper program.
2020-02-07 13:10:20 9895 Fatal error: [prepare_mn] mount extra resource 10.0.0.122:/gpfs/cnfs01/data/xcat/jk to f6u13k13 /tmp/automation_mountpoint failed
```
this is issue caused by `/sbin/mount.nfs` is not available on the node. 
