### PR TITLE
modify checking from sles to sle

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/post.xcat
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat
@@ -332,7 +332,7 @@ EOF
     if [[ $OSVER == ubuntu* ]]; then
         update-rc.d xcatpostinit1 defaults
     else
-        if [[ $OSVER == sles* ]]; then
+        if [[ $OSVER == sle* ]]; then
             if [[ $OSVER == sles10* ]]; then
                 /sbin/insserv xcatpostinit1
             else


### PR DESCRIPTION
more changes for PR #6537,  missed one more checking from `sles` to `sle` which cause postscripts `otherpkgs` didn't get run for service node provision.