### PR TITLE
Modify the test cases to support SLE15

### DIFF
--- a/xCAT-test/autotest/testcase/installation/SN_setup_case
+++ b/xCAT-test/autotest/testcase/installation/SN_setup_case
@@ -46,13 +46,13 @@ check:rc==0
 cmd:cd /install/post/otherpkgs/__GETNODEATTR($$SN,os)__/__GETNODEATTR($$SN,arch)__/xcat/xcat-core && createrepo .
 check:rc==0
 
-cmd:if [[ "__GETNODEATTR($$SN,os)__" =~ "rh" ]]; then path="rh";elif [[ "__GETNODEATTR($$SN,os)__" =~ "sles" ]];then path="sles";fi; ver="__GETNODEATTR($$SN,os)__"; tmp=${ver%%.*};ver=`echo "$tmp"|sed 's:[a-zA-Z]::g'`;cd /install/post/otherpkgs/__GETNODEATTR($$SN,os)__/__GETNODEATTR($$SN,arch)__/xcat/xcat-dep/$path$ver/__GETNODEATTR($$SN,arch)__ && createrepo .;
+cmd:if [[ "__GETNODEATTR($$SN,os)__" =~ "rh" ]]; then path="rh";elif [[ "__GETNODEATTR($$SN,os)__" =~ "sle" ]];then path="sles";fi; ver="__GETNODEATTR($$SN,os)__"; tmp=${ver%%.*};ver=`echo "$tmp"|sed 's:[a-zA-Z]::g'`;cd /install/post/otherpkgs/__GETNODEATTR($$SN,os)__/__GETNODEATTR($$SN,arch)__/xcat/xcat-dep/$path$ver/__GETNODEATTR($$SN,arch)__ && createrepo .;
 check:rc==0
 
 cmd:chdef -t osimage __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-install-service otherpkgdir=/install/post/otherpkgs/__GETNODEATTR($$SN,os)__/__GETNODEATTR($$SN,arch)__
 check:rc==0
 
-cmd:if [[ "__GETNODEATTR($$SN,os)__" =~ "rh" ]]; then path="rh";elif [[ "__GETNODEATTR($$SN,os)__" =~ "sles" ]];then path="sles";fi; ver="__GETNODEATTR($$SN,os)__"; chdef -t osimage __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-install-service otherpkglist=/opt/xcat/share/xcat/install/$path/service.${ver%%.*}.__GETNODEATTR($$SN,arch)__.otherpkgs.pkglist;
+cmd:if [[ "__GETNODEATTR($$SN,os)__" =~ "rh" ]]; then path="rh";elif [[ "__GETNODEATTR($$SN,os)__" =~ "sle" ]];then path="sles";fi; ver="__GETNODEATTR($$SN,os)__"; chdef -t osimage __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-install-service otherpkglist=/opt/xcat/share/xcat/install/$path/service.${ver%%.*}.__GETNODEATTR($$SN,arch)__.otherpkgs.pkglist;
 check:rc==0
 
 #add support python in sn
@@ -78,7 +78,7 @@ cmd:xdsh $$SN date
 check:rc==0
 check:output=~\d\d:\d\d:\d\d
 #after bug 2586 is fixed, following 2 lines should be removed.
-cmd:if [[ "__GETNODEATTR($$SN,os)__" =~ "sles" ]];then xdsh $$SN service xcatd restart; fi
+cmd:if [[ "__GETNODEATTR($$SN,os)__" =~ "sle" ]];then xdsh $$SN service xcatd restart; fi
 check:rc==0
 cmd:xdsh $$SN "ps -ef |grep xcatd"
 check:rc==0
@@ -106,7 +106,7 @@ check:rc==0
 cmd:if rpm -qa|grep xCAT-openbmc-py 2>&1; then xdsh $$SN "rpm -qa|grep python2-greenlet"; else echo "there is no xCAT-openbmc-py installed in MN, skip check python2-greenlet installation in SN"; exit 0;fi
 check:rc==0
 cmd:xdsh $$SN  "cat /var/log/xcat/xcat.log"
-cmd:if [[ "__GETNODEATTR($$SN,arch)__" =~ "x86_64" ]]; then if [[ "__GETNODEATTR($$SN,os)__" =~ "sles" ]];then xdsh $$SN "zypper -n install perl-Sys-Virt"; elif [[ "__GETNODEATTR($$SN,os)__" =~ "rh" ]];then xdsh $$SN "yum install -y perl-Sys-Virt";fi;fi
+cmd:if [[ "__GETNODEATTR($$SN,arch)__" =~ "x86_64" ]]; then if [[ "__GETNODEATTR($$SN,os)__" =~ "sle" ]];then xdsh $$SN "zypper -n install perl-Sys-Virt"; elif [[ "__GETNODEATTR($$SN,os)__" =~ "rh" ]];then xdsh $$SN "yum install -y perl-Sys-Virt";fi;fi
 check:rc==0
 cmd:makentp -a
 check:rc==0

--- a/xCAT-test/autotest/testcase/makedhcp/cases0
+++ b/xCAT-test/autotest/testcase/makedhcp/cases0
@@ -2,7 +2,7 @@ start:makedhcp_n
 description:Create a new dhcp configuration file with a network statement for each network the dhcp daemon should listen on
 os:Linux
 label:mn_only,ci_test,dhcp
-cmd:if [ -f "/etc/dhcp/dhcpd.conf" ];then mv -f /etc/dhcp/dhcpd.conf /etc/dhcp/dhcpd.conf.bak ; elif [ -f "/etc/dhcpd.conf" ]; then mv -f /etc/dhcpd.conf /etc/dhcpd.conf.bak; fi
+cmd:if [ -f "/etc/dhcp/dhcpd.conf" ];then cp -f /etc/dhcp/dhcpd.conf /etc/dhcp/dhcpd.conf.bak ; elif [ -f "/etc/dhcpd.conf" ]; then cp -f /etc/dhcpd.conf /etc/dhcpd.conf.bak; fi
 cmd:makedhcp -n
 check:rc==0
 cmd:cat $(ls /etc/dhcp/dhcpd.conf || ls /etc/dhcpd.conf)
@@ -36,7 +36,7 @@ start:makedhcp_n_linux
 description:Create a new dhcp configuration file with a network statement for each network the dhcp daemon should listen on
 label:others,ci_test
 os:Linux
-cmd:if [ -f "/etc/dhcp/dhcpd.conf" ];then mv -f /etc/dhcp/dhcpd.conf /etc/dhcp/dhcpd.conf.bak ; elif [ -f "/etc/dhcpd.conf" ]; then mv -f /etc/dhcpd.conf /etc/dhcpd.conf.bak; fi
+cmd:if [ -f "/etc/dhcp/dhcpd.conf" ];then cp -f /etc/dhcp/dhcpd.conf /etc/dhcp/dhcpd.conf.bak ; elif [ -f "/etc/dhcpd.conf" ]; then cp -f /etc/dhcpd.conf /etc/dhcpd.conf.bak; fi
 cmd:makedhcp -n
 check:rc==0
 cmd:ls /etc/dhcp/dhcpd.conf || ls /etc/dhcpd.conf
@@ -44,7 +44,7 @@ check:rc==0
 cmd:ps -e | grep dhcpd
 check:rc==0
 check:output=~dhcpd
-cmd:if [ -f "/etc/dhcp/dhcpd.conf" ];then mv -f /etc/dhcp/dhcpd.conf /etc/dhcp/dhcpd.conf.bak ; elif [ -f "/etc/dhcpd.conf" ]; then mv -f /etc/dhcpd.conf /etc/dhcpd.conf.bak; fi
+cmd:if [ -f "/etc/dhcp/dhcpd.conf" ];then mv -f /etc/dhcp/dhcpd.conf.bak /etc/dhcp/dhcpd.conf ; elif [ -f "/etc/dhcpd.conf" ]; then mv -f /etc/dhcpd.conf.bak /etc/dhcpd.conf; fi
 end
 
 start:makedhcp_a_linux
@@ -55,7 +55,7 @@ cmd:mkdef -t node -o testnode1 groups=compute mac=11:22:33:55:66:88 arch=ppc64
 cmd:chdef -t node -o testnode1 netboot=yaboot tftpserver=192.16.10.0 nfsserver=192.16.10.0 monserver=192.16.10.0 xcatmaster=192.16.10.0 installnic="mac" primarynic="mac"
 cmd:lsdef -l testnode1 -z | tee /tmp/CN.stanza
 cmd:chdef -t node -o testnode1 mac=11:22:33:44:55:66
-cmd:if [ -f "/etc/dhcp/dhcpd.conf" ];then mv -f /etc/dhcp/dhcpd.conf /etc/dhcp/dhcpd.conf.bak ; elif [ -f "/etc/dhcpd.conf" ]; then mv -f /etc/dhcpd.conf /etc/dhcpd.conf.bak; fi
+cmd:if [ -f "/etc/dhcp/dhcpd.conf" ];then cp -f /etc/dhcp/dhcpd.conf /etc/dhcp/dhcpd.conf.bak ; elif [ -f "/etc/dhcpd.conf" ]; then cp -f /etc/dhcpd.conf /etc/dhcpd.conf.bak; fi
 cmd:makedhcp -n
 cmd:makedhcp -a
 check:rc==0
@@ -64,7 +64,7 @@ check:output=~testnode1
 check:output=~11:22:33:44:55:66
 cmd:cat /tmp/CN.stanza | chdef -z
 cmd:rmdef testnode1
-cmd:if [ -f "/etc/dhcp/dhcpd.conf" ];then mv -f /etc/dhcp/dhcpd.conf /etc/dhcp/dhcpd.conf.bak ; elif [ -f "/etc/dhcpd.conf" ]; then mv -f /etc/dhcpd.conf /etc/dhcpd.conf.bak; fi
+cmd:if [ -f "/etc/dhcp/dhcpd.conf" ];then mv -f /etc/dhcp/dhcpd.conf.bak /etc/dhcp/dhcpd.conf ; elif [ -f "/etc/dhcpd.conf" ]; then mv -f /etc/dhcpd.conf.bak /etc/dhcpd.conf; fi
 end
 
 start:makedhcp_a_linux_check_invalid_mac
@@ -86,7 +86,7 @@ label:mn_only,dhcp
 cmd:lsdef -t node -l -z > /tmp/all.nodes
 cmd:mkdef -t node -o testnode1 groups=compute mac=11:22:33:55:66:88 arch=ppc64
 cmd:mkdef -t node -o testnode2 groups=compute mac=11:22:33:55:66:99 arch=ppc64
-cmd:if [ -f "/etc/dhcp/dhcpd.conf" ];then mv -f /etc/dhcp/dhcpd.conf /etc/dhcp/dhcpd.conf.bak ; elif [ -f "/etc/dhcpd.conf" ]; then mv -f /etc/dhcpd.conf /etc/dhcpd.conf.bak; fi
+cmd:if [ -f "/etc/dhcp/dhcpd.conf" ];then cp -f /etc/dhcp/dhcpd.conf /etc/dhcp/dhcpd.conf.bak ; elif [ -f "/etc/dhcpd.conf" ]; then cp -f /etc/dhcpd.conf /etc/dhcpd.conf.bak; fi
 cmd:makedhcp -n
 cmd:makedhcp -a
 check:rc==0
@@ -110,7 +110,7 @@ os:Linux
 label:mn_only,dhcp
 cmd:mkdef -t node -o testnode1 groups=compute mac=11:22:33:55:66:88 arch=ppc64
 cmd:chdef -t node -o testnode1 netboot=yaboot tftpserver=192.16.10.0 nfsserver=192.16.10.0 monserver=192.16.10.0 xcatmaster=192.16.10.0 installnic="mac" primarynic="mac"
-cmd:if [ -f "/etc/dhcp/dhcpd.conf" ];then mv -f /etc/dhcp/dhcpd.conf /etc/dhcp/dhcpd.conf.bak ; elif [ -f "/etc/dhcpd.conf" ]; then mv -f /etc/dhcpd.conf /etc/dhcpd.conf.bak; fi
+cmd:if [ -f "/etc/dhcp/dhcpd.conf" ];then cp -f /etc/dhcp/dhcpd.conf /etc/dhcp/dhcpd.conf.bak ; elif [ -f "/etc/dhcpd.conf" ]; then cp -f /etc/dhcpd.conf /etc/dhcpd.conf.bak; fi
 cmd:lsdef -l testnode1 -z > /tmp/CN.stanza
 cmd:chdef -t node -o testnode1 mac=11:22:33:44:55:66
 cmd:makedhcp -n

--- a/xCAT/postscripts/configbond
+++ b/xCAT/postscripts/configbond
@@ -74,6 +74,9 @@ if [ "$str_os_type" = "linux" ];then
     elif [ -f "/etc/SuSE-release" -o -n "$str_temp" ];then
         str_os_type="sles"
         str_cfg_dir="/etc/sysconfig/network"
+    elif [ -f /etc/os-release ] && cat /etc/os-release |grep NAME|grep -i SLE >/dev/null; then
+        str_os_type="sles"
+        str_cfg_dir="/etc/sysconfig/network"
     else
         showmsg "Only supports RHEL and SLES" "error"
         exit -1

--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -514,7 +514,7 @@ elif [ "$1" = "-s" ];then
                 str_inst_gateway=`ip ro ls|grep default|awk '{print $3}'|head -1`
             fi
         fi
-    elif [ -f "/etc/SuSE-release" ];then
+    elif [ "$str_os_type" = "sles" ];then
        str_lease_file="/var/lib/dhcpcd/dhcpcd-"$str_inst_nic".info"
        if [ -e "$str_lease_file" ];then
            str_inst_ip=`grep IPADDR $str_lease_file | tail -n 1 | awk -F'=' '{print $2}' | sed "s/'//g"`
@@ -623,7 +623,7 @@ elif [ "$1" = "-s" ];then
 
         hostname $NODE
         echo $NODE > /etc/hostname
-    elif [ -f "/etc/SuSE-release" ];then
+    elif [ "$str_os_type" = "sles" ];then
         str_conf_file="/etc/sysconfig/network/ifcfg-${str_inst_nic}"
         echo "DEVICE=${str_inst_nic}" > $str_conf_file
         echo "BOOTPROTO=static" >> $str_conf_file

--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -413,6 +413,9 @@ if [ "$str_os_type" = "linux" ];then
     elif [ -f "/etc/SuSE-release" -o -n "$str_temp" ];then
         str_os_type="sles"
         str_cfg_dir="/etc/sysconfig/network/"
+    elif [ -f /etc/os-release ] && cat /etc/os-release |grep NAME|grep -i SLE >/dev/null; then
+        str_os_type="sles"
+        str_cfg_dir="/etc/sysconfig/network"
     else
         str_os_type="redhat"
         str_cfg_dir="/etc/sysconfig/network-scripts/"

--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -42,6 +42,9 @@ if [ -f "/etc/redhat-release" ];then
 elif [ -f "/etc/SuSE-release" -o -n "$str_temp" ];then
     is_sles=1
     nwdir="/etc/sysconfig/network"
+elif [ -f /etc/os-release ] && cat /etc/os-release |grep NAME|grep -i SLE >/dev/null; then
+    is_sles=1
+    nwdir="/etc/sysconfig/network"
 elif [ -f "/etc/debian_version" ];then
     nwdir="/etc/network/interfaces.d"
     is_debian=1

--- a/xCAT/postscripts/hardeths
+++ b/xCAT/postscripts/hardeths
@@ -50,12 +50,16 @@ if [ -f /etc/os-release ] && (cat /etc/os-release |grep -i  '^NAME=[ "]*Cumulus 
     OSVER="cumulus"
 fi
 
+if [ -f /etc/os-release ] && (cat /etc/os-release |grep NAME|grep -i SLE >/dev/null); then
+   OSVER="SLE"
+fi
+
 defgw=`ip route | grep default | awk '{print $3}' | head -n1`
 if ( pmatch $OSVER "ubuntu*" ) || (pmatch $OSVER "cumulus")
 then
     echo `hostname` >/etc/hostname
     mv /etc/network/interfaces /etc/network/interfaces.old # this file will be filled up next
-elif [ -f /etc/SuSE-release ]
+elif [ -f /etc/SuSE-release ] || (pmatch $OSVER "SLE")
 then
     #SLES9 and SLES10, uses /etc/sysconfig/network/ifcfg-eth-id-<mac>
     #SLES11, uses /etc/sysconfig/network/ifcfg-eth<x>


### PR DESCRIPTION
Failed to set up service node during the SLE15 regression test.  it due to `otherpkgs` didn't run because osimage for service node has wrong path of otherpkglist
```
# lsdef -t osimage sle15-ppc64le-install-service
Object name: sle15-ppc64le-install-service
    imagetype=linux
    osarch=ppc64le
    osdistroname=sle15-ppc64le
    osname=Linux
    osvers=sle15
    otherpkgdir=/install/post/otherpkgs/sle15/ppc64le
    otherpkglist=/opt/xcat/share/xcat/install//service.sle15.ppc64le.otherpkgs.pkglist  <<<----
    pkgdir=/install/sle15/ppc64le
    pkglist=/opt/xcat/share/xcat/install/sle/service.sle15.pkglist
    postscripts=servicenode
    profile=service
    provmethod=install
    template=/opt/xcat/share/xcat/install/sle/service.sle15.tmpl
```
The correct the `otherpkglist` should be 
```
otherpkglist=/opt/xcat/share/xcat/install/sle/service.sle15.ppc64le.otherpkgs.pkglist
```
