### PR TITLE
Modify mysqlsetup to support SLE15

### DIFF
--- a/xCAT-client/bin/mysqlsetup
+++ b/xCAT-client/bin/mysqlsetup
@@ -971,7 +971,7 @@ sub mysqlstart
     else
     {
         if ($::MariaDB == 1) {    # running MariaDB
-            if ($::linuxos =~ /rh.*/) || ($::linuxos =~ /sle15.*/ {
+            if ( ($::linuxos =~ /rh.*/) || ($::linuxos =~ /sles15.*/) ) {
                 $ret = xCAT::Utils->startservice("mariadb");
             } else {              # sles
                 $ret = xCAT::Utils->startservice("mysql");
@@ -1084,7 +1084,7 @@ sub mysqlreboot
     {
         if ($::MariaDB == 1) {    # MariaDB not MySQL
 
-            if ($::linuxos =~ /rh.*/) || ($::linuxos =~ /sle15.*/{
+            if ( ($::linuxos =~ /rh.*/) || ($::linuxos =~ /sles15.*/) ){
                 $cmd = "chkconfig mariadb on";
             } else {              #sles
                 $cmd = "chkconfig mysql on";

--- a/xCAT-client/bin/mysqlsetup
+++ b/xCAT-client/bin/mysqlsetup
@@ -971,7 +971,7 @@ sub mysqlstart
     else
     {
         if ($::MariaDB == 1) {    # running MariaDB
-            if ($::linuxos =~ /rh.*/) {
+            if ($::linuxos =~ /rh.*/) || ($::linuxos =~ /sle15.*/ {
                 $ret = xCAT::Utils->startservice("mariadb");
             } else {              # sles
                 $ret = xCAT::Utils->startservice("mysql");
@@ -1084,7 +1084,7 @@ sub mysqlreboot
     {
         if ($::MariaDB == 1) {    # MariaDB not MySQL
 
-            if ($::linuxos =~ /rh.*/) {
+            if ($::linuxos =~ /rh.*/) || ($::linuxos =~ /sle15.*/{
                 $cmd = "chkconfig mariadb on";
             } else {              #sles
                 $cmd = "chkconfig mysql on";

--- a/xCAT-server/share/xcat/install/sles/service.sle15.x86_64.otherpkgs.pkglist
+++ b/xCAT-server/share/xcat/install/sles/service.sle15.x86_64.otherpkgs.pkglist
@@ -1,2 +1,2 @@
 xcat/xcat-core/xCATsn
-xcat/xcat-dep/sles12/x86_64/goconserver
+xcat/xcat-dep/sles15/x86_64/goconserver

--- a/xCAT-server/share/xcat/netboot/sles/service.sle15.otherpkgs.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/service.sle15.otherpkgs.pkglist
@@ -1,3 +1,0 @@
--perl-doc
-xcat/xcat-core/xCATsn
-xcat/xcat-dep/sles12/x86_64/conserver-xcat

--- a/xCAT-server/share/xcat/netboot/sles/service.sle15.ppc64le.otherpkgs.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/service.sle15.ppc64le.otherpkgs.pkglist
@@ -1,0 +1,3 @@
+-perl-doc
+xcat/xcat-core/xCATsn
+xcat/xcat-dep/sles15/ppc64le/goconserver

--- a/xCAT-server/share/xcat/netboot/sles/service.sle15.x86_64.otherpkgs.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/service.sle15.x86_64.otherpkgs.pkglist
@@ -1,3 +1,3 @@
 -perl-doc
 xcat/xcat-core/xCATsn
-xcat/xcat-dep/sles12/x86_64/conserver-xcat
+xcat/xcat-dep/sles15/x86_64/goconserver


### PR DESCRIPTION
For the SLE15,  the name of service for the mariadb is `mariadb`,   not `mysqld` anymore as old sles release.
 ```
# chkconfig mysql on
Failed to enable unit: Refusing to operate on linked unit file mysql.service

# systemctl status mariadb
● mariadb.service - MySQL server
   Loaded: loaded (/usr/lib/systemd/system/mariadb.service; enabled; vendor preset: disabled)
   Active: active (running) since Tue 2020-02-18 16:47:28 EST; 22min ago
 Main PID: 2341 (mysqld)
   Status: "Taking your SQL requests now..."
    Tasks: 34 (limit: 4915)
   CGroup: /system.slice/mariadb.service
           └─2341 /usr/sbin/mysqld --defaults-file=/etc/my.cnf --user=mysql

Feb 18 16:47:27 c910f04x35v02 systemd[1]: Starting MySQL server...
Feb 18 16:47:27 c910f04x35v02 mysql-systemd-helper[2341]: 2020-02-18 16:47:27 139722146707648 [Note] /usr/sb
in/mysqld (mysqld 10.2.15-MariaDB) starting as process 2341 ...
Feb 18 16:47:28 c910f04x35v02 systemd[1]: Started MySQL server.
````