### PR TITLE
/sbin/mksquashfs does not understand -le and -be

### DIFF
--- a/xCAT-server/lib/xcat/plugins/packimage.pm
+++ b/xCAT-server/lib/xcat/plugins/packimage.pm
@@ -574,12 +574,7 @@ sub process_request {
         umask $oldmask;
     } elsif ($method =~ /squashfs/) {
         my $flags;
-        if ($arch =~ /x86/) {
-            $flags = "-le";
-        } elsif ($arch =~ /ppc/) {
-            $flags = "-be";
-        }
-
+        
         if ($osver =~ /rhels/ && $osver !~ /rhels5/) {
             $flags = "";
         }


### PR DESCRIPTION
... at least on CentOS 7.7, it doesn't. Building squashfs images thus fails with "mksquashfs could not be run successfully", missing the real reason why not.
As I understand it, mksquashfs should build little or big endian .sfs files according to the architecture it runs on. If the -le / -be switches need to remain, eg. for the sake of cross-architecture or POWER builds: perhaps some experienced xcat programmer can look over the check for "$osver" to be extended to cover CentOS as well (emptying $flags as it does for rhels already).

### The PR is to fix issue _#xxx_

### The modification include

_##item1_

_##item2_

### The UT result
`##The UT output##`

# Please remove this line and below if fix issue

# Please remove this line and above for tasks or features

### The PR is for task _#xxx_ or to implement feature #xxx

_##Feature description##_

### The content of the PR:
* [ ] _##The mini-design link_
* [ ] _##The basic code logic_

### The UT result
`##The UT output##`
