### PR TITLE
requirement of "aufs" added to "squashfs" method

### DIFF
--- a/xCAT-client/pods/man1/packimage.1.pod
+++ b/xCAT-client/pods/man1/packimage.1.pod
@@ -27,7 +27,7 @@ B<-h>          Display usage message.
 
 B<-v>          Command Version.
 
-B<-m| --method>          Archive Method (cpio,tar,squashfs, default is cpio)
+B<-m| --method>          Archive Method (cpio,tar,squashfs (requires aufs), default is cpio)
 
 B<-c| --compress>          Compress Method (pigz,gzip,xz, default is pigz/gzip)
 


### PR DESCRIPTION
As some mainstream distributions don't provide "aufs" for their kernels, at least a hint to that essential requirement is prudent, I think.
