### PR TITLE
IC922 node support for bmcdiscover and bmcsetup

### DIFF
--- a/xCAT-genesis-scripts/usr/bin/bmcsetup
+++ b/xCAT-genesis-scripts/usr/bin/bmcsetup
@@ -167,7 +167,8 @@ logger -s -t $log_label -p local4.info "IPMIVER=$IPMIVER, IPMIMFG=$IPMIMFG, XPRO
 #
 # IPMIMFG=2 = IBM
 # IPMIMFG=0 = OpenPOWER
-# IPMIMFG=42817 and XPROD=16975 = OpenBMC
+# IPMIMFG=42817 and XPROD=16975 = OpenBMC (Witherspoon)
+# IPMIMFG=42817 and XPROD=1 = OpenBMC (Mihawk)
 #
 if [ "$IPMIMFG" == 2 ]; then #IBM
     if [ "$XPROD" == "220" ]; then
@@ -265,7 +266,9 @@ elif [ "$IPMIMFG" == "674" ]; then # DELL
         ipmitool delloem lan set shared with lom$BMCPORT &>/dev/null
         ipmitool delloem lan set shared with failover all loms &>/dev/null
     fi
-elif [ "$IPMIMFG" = "42817" -a "$XPROD" = "16975" ]; then # IBM OpenPOWER servers with OpenBMC
+elif [ "$IPMIMFG" == "42817" -a "$XPROD" == "16975" ]; then # IBM OpenPOWER servers with OpenBMC (Witherspoon)
+    ISOPENBMC=1
+elif [ "$IPMIMFG" == "42817" -a "$XPROD" == "1" ]; then # IBM OpenPOWER servers with OpenBMC (Mihawk)
     ISOPENBMC=1
 fi
 

--- a/xCAT-genesis-scripts/usr/bin/bmcsetup
+++ b/xCAT-genesis-scripts/usr/bin/bmcsetup
@@ -167,8 +167,8 @@ logger -s -t $log_label -p local4.info "IPMIVER=$IPMIVER, IPMIMFG=$IPMIMFG, XPRO
 #
 # IPMIMFG=2 = IBM
 # IPMIMFG=0 = OpenPOWER
-# IPMIMFG=42817 and XPROD=16975 = OpenBMC (Witherspoon)
-# IPMIMFG=42817 and XPROD=1 = OpenBMC (Mihawk)
+# IPMIMFG=42817 and XPROD=16975 = OpenBMC (AC922)
+# IPMIMFG=42817 and XPROD=1 = OpenBMC (IC922)
 #
 if [ "$IPMIMFG" == 2 ]; then #IBM
     if [ "$XPROD" == "220" ]; then
@@ -266,9 +266,9 @@ elif [ "$IPMIMFG" == "674" ]; then # DELL
         ipmitool delloem lan set shared with lom$BMCPORT &>/dev/null
         ipmitool delloem lan set shared with failover all loms &>/dev/null
     fi
-elif [ "$IPMIMFG" == "42817" -a "$XPROD" == "16975" ]; then # IBM OpenPOWER servers with OpenBMC (Witherspoon)
+elif [ "$IPMIMFG" == "42817" -a "$XPROD" == "16975" ]; then # IBM OpenPOWER servers with OpenBMC (AC922)
     ISOPENBMC=1
-elif [ "$IPMIMFG" == "42817" -a "$XPROD" == "1" ]; then # IBM OpenPOWER servers with OpenBMC (Mihawk)
+elif [ "$IPMIMFG" == "42817" -a "$XPROD" == "1" ]; then # IBM OpenPOWER servers with OpenBMC (IC922)
     ISOPENBMC=1
 fi
 

--- a/xCAT-genesis-scripts/usr/bin/getipmi
+++ b/xCAT-genesis-scripts/usr/bin/getipmi
@@ -32,7 +32,9 @@ BMCMAC=`ipmitool lan print $LANCHAN|grep ^MAC|awk '{print $4}'` #bmcconfig may o
 IPMIMFG=`ipmitool mc info |grep "^Manufacturer ID"|awk  '{print $4}'`
 XPROD=`ipmitool mc info | grep "^Product ID"|awk '{print $4}'`
 if [ "$IPMIMFG" == "42817" -a "$XPROD" == "16975" ]; then
-    ISOPENBMC=1
+    ISOPENBMC=1 # Witherspoon
+elif [ "$IPMIMFG" == "42817" -a "$XPROD" == "1" ]; then
+    ISOPENBMC=1 # Mihawk
 else
     ISOPENBMC=0
 fi

--- a/xCAT-genesis-scripts/usr/bin/getipmi
+++ b/xCAT-genesis-scripts/usr/bin/getipmi
@@ -32,9 +32,9 @@ BMCMAC=`ipmitool lan print $LANCHAN|grep ^MAC|awk '{print $4}'` #bmcconfig may o
 IPMIMFG=`ipmitool mc info |grep "^Manufacturer ID"|awk  '{print $4}'`
 XPROD=`ipmitool mc info | grep "^Product ID"|awk '{print $4}'`
 if [ "$IPMIMFG" == "42817" -a "$XPROD" == "16975" ]; then
-    ISOPENBMC=1 # Witherspoon
+    ISOPENBMC=1 # AC922
 elif [ "$IPMIMFG" == "42817" -a "$XPROD" == "1" ]; then
-    ISOPENBMC=1 # Mihawk
+    ISOPENBMC=1 # IC922
 else
     ISOPENBMC=0
 fi

--- a/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
+++ b/xCAT-server/lib/xcat/plugins/bmcdiscover.pm
@@ -1289,7 +1289,7 @@ sub bmcdiscovery_openbmc{
     my $login_endpoint = "login";
     my $system_endpoint = "inventory/system";
     my $motherboard_boxelder_endpoint = "$system_endpoint/chassis/motherboard/boxelder/bmc";
-    my $motherboard_tpm_endpoint = "$system_endpoint/chassis/motherboard/tpm";
+    my $motherboard_bmc_endpoint = "$system_endpoint/chassis/motherboard/bmc";
 
     my $node_data = $ip;
     my $brower = LWP::UserAgent->new( ssl_opts => { SSL_verify_mode => 0x00, verify_hostname => 0  }, );
@@ -1309,9 +1309,9 @@ sub bmcdiscovery_openbmc{
         my $req_output = $brower->request($req);
         if ($req_output->is_error) {
             # If the host system has not yet been powered on, system_endpoint call will return error
-            # Instead, check the boxelder (for Witherspoon) or tpm (for Mihawk) info for model/serial
+            # Instead, check the boxelder (for AC922) or bmc (for IC922) info for model/serial
             if ($model_id eq $::P9_MIHAWK_PRODUCT_ID) {
-                $url = "$http_protocol://$ip/$openbmc_project_url/$motherboard_tpm_endpoint";
+                $url = "$http_protocol://$ip/$openbmc_project_url/$motherboard_bmc_endpoint";
             }
             else {
                 $url = "$http_protocol://$ip/$openbmc_project_url/$motherboard_boxelder_endpoint";


### PR DESCRIPTION
This PR adds support for IC922 nodes. Issue #6541 

Changes include:
* IC922 node product ID is `1`
* `/xyz/openbmc_project/inventory/system/chassis/motherboard/bmc` to get Model and Serial Number before Chassis is powered on