### PR TITLE
Modify mysqlsetup scripts to support Mariadb for SLE15 x86_64 hierarchy system

### DIFF
--- a/xCAT-client/bin/mysqlsetup
+++ b/xCAT-client/bin/mysqlsetup
@@ -888,23 +888,25 @@ sub initmysqldb
         }
     }    # end AIX only
 
-    #on debian/ubuntu should comment the bind-adress line in my.cnf
+    #bind-adress line in my.cnf should comment out
     #on Ubuntu16.04, the bind-address line is in the mariadb.conf.d/50-server.cnf
-    if ($::debianflag) {
-        my $bind_file;
-        if (-e "/etc/mysql/mariadb.conf.d/50-server.cnf")
-        {
-            $bind_file = "/etc/mysql/mariadb.conf.d/50-server.cnf";
-        } else {
-            $bind_file = "/etc/mysql/my.cnf";
-        }
-        $cmd = "sed 's/\\(^\\s*bind.*\\)/#\\1/' $bind_file > /tmp/my.cnf; mv -f /tmp/my.cnf $bind_file;chmod 644 $bind_file";
-        xCAT::Utils->runcmd($cmd, 0);
-        if ($::RUNCMD_RC != 0)
-        {
-            xCAT::MsgUtils->message("E", " comment the bind-address line in $bind_file failed: $cmd.");
-            exit(1);
-        }
+    #on SLE15, the bind-address line is in the /etc/my.cnf
+    my $bind_file;
+    if (-e "/etc/mysql/mariadb.conf.d/50-server.cnf")
+    {
+        $bind_file = "/etc/mysql/mariadb.conf.d/50-server.cnf";
+    } elsif (-e "/etc/mysql/my.cnf") 
+    {
+        $bind_file = "/etc/mysql/my.cnf";
+    } else {
+        $bind_file = "/etc/my.cnf";
+    }
+    $cmd = "sed 's/^bind/#&/' $bind_file > /tmp/my.cnf; mv -f /tmp/my.cnf $bind_file;chmod 644 $bind_file";
+    xCAT::Utils->runcmd($cmd, 0);
+    if ($::RUNCMD_RC != 0)
+    {
+        xCAT::MsgUtils->message("E", " comment the bind-address line in $bind_file failed: $cmd.");
+        exit(1);
     }
 
     # Create the MySQL data directory and initialize the grant tables
@@ -1244,6 +1246,14 @@ sub setupxcatdb
     $grantall_localhost .= "\'";
     $grantall_localhost .= " IDENTIFIED BY \'$::adminpassword\';\r";
 
+    #GRAND root to host account
+    my $grantroot = "";
+    $grantroot = "GRANT ALL on xcatdb.* TO root@";
+    $grantroot .= "\'";
+    $grantroot .= "$::MN";
+    $grantroot .= "\'";
+    $grantroot .= " IDENTIFIED BY \'$::rootpassword\';\r";
+
     #
     # -re $pwd_prompt
     #     Enter the password for root
@@ -1311,6 +1321,8 @@ sub setupxcatdb
                 $mysql->send("$grantall");
                 $mysql->clear_accum();
                 $mysql->send("$grantall_localhost");
+                $mysql->clear_accum();
+                $mysql->send("$grantroot");
                 $mysql->clear_accum();
                 $mysql->send("exit;\r");
 


### PR DESCRIPTION
On the SLE15, the mariaDB configuration file `my.cnf` has `bind-address` to loopback,  it caused more than one hour to restored xcatdb, normally only needs around 5 mins.  Remove/comment out the `bind-address` fixed this issue.
after finish `mysqlsetup` integration,   the xcatd no longer can start.  
```
Feb 20 10:48:19 c910f04x35v02 xcat[16588]: INFO  Failed to connect to site table after retrying 3 times: DBI connect('dbname=xcatdb;host=10.4.35.2','xcatadmin',...) failed: Can't connect to MySQL server on '10.4.35.2' (115) at /opt/xcat/lib/perl/xCAT/Table.pm line 973.
Feb 20 10:48:19 c910f04x35v02 xcat[16588]: INFO  Could not connect to the database. Database handle not defined.
```
Grant root user for the xCATdb fixed above the error message.