### PR TITLE
Update readdoc for MariaDB on SLE15

### DIFF
--- a/docs/source/advanced/hierarchy/databases/mysql_install.rst
+++ b/docs/source/advanced/hierarchy/databases/mysql_install.rst
@@ -63,6 +63,16 @@ Suse Linux Enterprise Server
        libmysqlclient18-*
        perl-DBD-mysql-*
 
+* For SLE15, MariaDB is shipped. Using ``zypper``, ensure that the following packages are installed on the management node: ::
+
+       mariadb
+       mariadb-client
+       mariadb-errormessages
+       perl-DBD-mysql
+       libmariadb-devel
+       mariadb-tools
+       libmariadb_plugins
+
 
 Debian/Ubuntu
 -------------

--- a/docs/source/advanced/hierarchy/databases/mysql_using.rst
+++ b/docs/source/advanced/hierarchy/databases/mysql_using.rst
@@ -19,6 +19,11 @@ Start/Stop MySQL/MariaDB service
     service mysql start
     service mysql stop
 
+**[SLE15]** :  ::
+
+    systemctl start mariadb
+    systemctl stop mariadb
+
 
 Basic MySQL/MariaDB commands
 -----------------------------


### PR DESCRIPTION
xCAT documentation update to support MariaDB on the SLE15
The package names are different. 