### PR TITLE
Disable firewalld on rhels8 compute node

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels8.ppc64le.postinstall
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels8.ppc64le.postinstall
@@ -40,6 +40,18 @@ then
     sed -i 's/SELINUX=enforcing\|permissive/SELINUX=disabled/' $installroot/etc/selinux/config
 fi
 
+#--for redhat 8 and 8.1
+#-- Need to disable firewalld, otherwise, the remoteshell script will not able to get all the SSH keys
+if [ -f "$installroot/etc/systemd/system/multi-user.target.wants/firewalld.service" ]
+then
+    rm -rf $installroot/etc/systemd/system/multi-user.target.wants/firewalld.service
+fi
+if [ -f "$installroot/etc/systemd/system/dbus-org.fedoraproject.FirewallD1.service" ]
+then
+    rm -rf $installroot/etc/systemd/system/dbus-org.fedoraproject.FirewallD1.service
+fi
+
+
 #-- Example of booted image versioning
 #-- We want to know, with what configuration (version of the image) each node was booted.
 #-- Hence, we keep image definition files and postscripts in CVS. During image generation we create file /etc/IMGVERSION and fill it with CVS "$Id$" of files with image definition (.pkglist, .exlist, .repolist, .postinstall). Then, during boot, each  "CVS enabled" postscript (see /install/postscripts/cvs_template.sh and /install/postscripts/cvs_template.pl) adds one line to /etc/IMGVERSION. Then you can determine in any time what image you are running and what postscipts in which versions were run.

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels8.x86_64.postinstall
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels8.x86_64.postinstall
@@ -39,6 +39,17 @@ if [ -f "$installroot/etc/selinux/config" ]
 then
     sed -i 's/SELINUX=enforcing\|permissive/SELINUX=disabled/' $installroot/etc/selinux/config
 fi
+#--for redhat 8 and 8.1
+#-- Need to disable firewalld, otherwise, the remoteshell script will not able to get all the SSH keys
+if [ -f "$installroot/etc/systemd/system/multi-user.target.wants/firewalld.service" ]
+then
+    rm -rf $installroot/etc/systemd/system/multi-user.target.wants/firewalld.service
+fi
+if [ -f "$installroot/etc/systemd/system/dbus-org.fedoraproject.FirewallD1.service" ]
+then
+    rm -rf $installroot/etc/systemd/system/dbus-org.fedoraproject.FirewallD1.service
+fi
+
 
 #-- Example of booted image versioning
 #-- We want to know, with what configuration (version of the image) each node was booted.


### PR DESCRIPTION
We are seeing firewalld is still running when compute node provisioned.  
```
]# systemctl status firewalld
● firewalld.service - firewalld - dynamic firewall daemon
   Loaded: loaded (/usr/lib/systemd/system/firewalld.service; enabled; vendor preset: enabled)
   Active: active (running) since Wed 2020-02-26 15:33:47 EST; 2s ago
     Docs: man:firewalld(1)
 Main PID: 2215 (firewalld)
    Tasks: 2 (limit: 26213)
   Memory: 43.7M
   CGroup: /system.slice/firewalld.service
           └─2215 /usr/libexec/platform-python -s /usr/sbin/firewalld --nofork --nopid

Feb 26 15:33:47 f6u13k15 systemd[1]: Starting firewalld - dynamic firewall daemon...
Feb 26 15:33:47 f6u13k15 systemd[1]: Started firewalld - dynamic firewall daemon.
```
firewalld is running caused `remoteshell` postscripts  failed to get SSH keys and took long time to finish
```
xcattest.log.20200226033914:f6u13k14: Wed Feb 26 03:48:05 EST 2020 [info]: xcat.deployment.postscript: postscript remoteshell return with 0
xcattest.log.20200226033914:f6u13k15: Wed Feb 26 04:04:28 EST 2020 [info]: xcat.deployment.postbootscript: postbootscript start..: remoteshell
````
after disable the firewalld,  the remoteshell scripts only takes few seconds and all the SSH updated
```
# systemctl disable firewalld
Removed /etc/systemd/system/dbus-org.fedoraproject.FirewallD1.service.
Removed /etc/systemd/system/multi-user.target.wants/firewalld.service.

#Wed Feb 26 14:02:19 EST 2020 [info]: xcat.deployment.postbootscript: postbootscript start..: remoteshell

Wed Feb 26 14:02:22 EST 2020 [info]: xcat.deployment.postbootscript: postbootscript end...:remoteshell return with 0
```


