### PR TITLE
More go-xcat testcases and add to daily bundle

### DIFF
--- a/xCAT-test/autotest/bundle/rhels_ppcle_daily.bundle
+++ b/xCAT-test/autotest/bundle/rhels_ppcle_daily.bundle
@@ -304,3 +304,7 @@ xcatstanzafile_normal
 xcatstanzafile_objtype
 xcatstanzafile_specificvalue
 xcatstanzafile_tab
+go_xcat_devel_from_repo
+go_xcat_stable_from_repo
+go_xcat_stable_from_repo_upgrade
+go_xcat_stable_from_repo_reinstall_devel

--- a/xCAT-test/autotest/bundle/sles_ppcle_daily.bundle
+++ b/xCAT-test/autotest/bundle/sles_ppcle_daily.bundle
@@ -248,3 +248,7 @@ xcatstanzafile_normal
 xcatstanzafile_objtype
 xcatstanzafile_specificvalue
 xcatstanzafile_tab
+go_xcat_devel_from_repo
+go_xcat_stable_from_repo
+go_xcat_stable_from_repo_upgrade
+go_xcat_stable_from_repo_reinstall_devel

--- a/xCAT-test/autotest/bundle/ubuntu_ppcle_daily.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu_ppcle_daily.bundle
@@ -228,3 +228,7 @@ xdsh_permission_denied
 xdsh_q
 xdsh_regular_command
 xdsh_t
+go_xcat_devel_from_repo
+go_xcat_stable_from_repo
+go_xcat_stable_from_repo_upgrade
+go_xcat_stable_from_repo_reinstall_devel

--- a/xCAT-test/autotest/testcase/go_xcat/case3
+++ b/xCAT-test/autotest/testcase/go_xcat/case3
@@ -2,9 +2,8 @@ start:go_xcat_devel_from_repo
 description:test go-xcat devel on a newly provisioned node
 label:go_xcat
 os:Linux
-#Make sure service node is booted
-cmd:rpower $$SN on
-cmd:sleep 300
+#Make sure service node is not off, if it is, power it on
+cmd:if rpower $$SN stat | grep "off";then rpower $$SN on; sleep 300; fi
 cmd:lsdef $$SN -i status
 check:output=~booted
 
@@ -25,9 +24,129 @@ check:rc==0
 cmd:xdsh $$CN "cat /tmp/go-xcat.log"
 cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;lsxcatd -a"
 check:rc==0
-cmd:xdsh $$CN "cat /etc/yum.repos.d/xcat-core.repo"
-cmd:xdsh $$CN "cat /etc/yum.repos.d/xcat-dep.repo"
-cmd:xdsh $$CN "cat /etc/yum.repos.d/local-repository-0.repo"
+cmd:xdsh $$CN "service xcatd status"
+check:rc==0
+check:output=~running
+cmd:xdsh $$CN "service xcatd stop"
+end
+
+start:go_xcat_stable_from_repo
+description:test go-xcat GA on a newly provisioned node
+label:go_xcat
+os:Linux
+#Make sure service node is not off, if it is, power it on
+cmd:if rpower $$SN stat | grep "off";then rpower $$SN on; sleep 300; fi
+cmd:lsdef $$SN -i status
+check:output=~booted
+
+#Provision compute node
+cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+check:rc==0
+check:output=~Provision node\(s\)\: $$CN
+cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 20; echo "[$a] " $(lsdef $$CN -i status -c); ((a++));if [ $a -gt 30 ];then break;fi done
+cmd:lsdef -l $$CN | grep status
+
+#Copy go-xcat script
+cmd:xdsh $$CN "cd /; scp -r $$MN:/opt/xcat/share/xcat/tools/go-xcat ./"
+check:rc==0
+
+#Install GA version of xCAT
+cmd:xdsh $$CN "cd /; ./go-xcat -y install"
+check:rc==0
+cmd:xdsh $$CN "cat /tmp/go-xcat.log"
+cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;lsxcatd -a"
+check:rc==0
+cmd:xdsh $$CN "service xcatd status"
+check:rc==0
+check:output=~running
+cmd:xdsh $$CN "service xcatd stop"
+end
+
+start:go_xcat_stable_from_repo_upgrade
+description:test go-xcat GA on a newly provisioned node upgrade to devel
+label:go_xcat
+os:Linux
+#Make sure service node is not off, if it is, power it on
+cmd:if rpower $$SN stat | grep "off";then rpower $$SN on; sleep 300; fi
+cmd:lsdef $$SN -i status
+check:output=~booted
+
+#Provision compute node
+cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+check:rc==0
+check:output=~Provision node\(s\)\: $$CN
+cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 20; echo "[$a] " $(lsdef $$CN -i status -c); ((a++));if [ $a -gt 30 ];then break;fi done
+cmd:lsdef -l $$CN | grep status
+
+#Copy go-xcat script
+cmd:xdsh $$CN "cd /; scp -r $$MN:/opt/xcat/share/xcat/tools/go-xcat ./"
+check:rc==0
+
+#Install GA version of xCAT
+cmd:xdsh $$CN "cd /; ./go-xcat -y install"
+check:rc==0
+cmd:xdsh $$CN "cat /tmp/go-xcat.log"
+cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;lsxcatd -a"
+check:rc==0
+cmd:xdsh $$CN "service xcatd status"
+check:rc==0
+check:output=~running
+
+#Update to devel version of xCAT
+cmd:xdsh $$CN "cd /; ./go-xcat --xcat-version=devel -y update"
+check:rc==0
+cmd:xdsh $$CN "cat /tmp/go-xcat.log"
+cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;lsxcatd -a"
+check:rc==0
+cmd:xdsh $$CN "service xcatd status"
+check:rc==0
+check:output=~running
+cmd:xdsh $$CN "service xcatd stop"
+end
+
+start:go_xcat_stable_from_repo_reinstall_devel
+description:test go-xcat GA on a newly provisioned node, remove, install devel
+label:go_xcat
+os:Linux
+#Make sure service node is not off, if it is, power it on
+cmd:if rpower $$SN stat | grep "off";then rpower $$SN on; sleep 300; fi
+cmd:lsdef $$SN -i status
+check:output=~booted
+
+#Provision compute node
+cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+check:rc==0
+check:output=~Provision node\(s\)\: $$CN
+cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 20; echo "[$a] " $(lsdef $$CN -i status -c); ((a++));if [ $a -gt 30 ];then break;fi done
+cmd:lsdef -l $$CN | grep status
+
+#Copy go-xcat script
+cmd:xdsh $$CN "cd /; scp -r $$MN:/opt/xcat/share/xcat/tools/go-xcat ./"
+check:rc==0
+
+#Install GA version of xCAT
+cmd:xdsh $$CN "cd /; ./go-xcat -y install"
+check:rc==0
+cmd:xdsh $$CN "cat /tmp/go-xcat.log"
+cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;lsxcatd -a"
+check:rc==0
+cmd:xdsh $$CN "service xcatd status"
+check:rc==0
+check:output=~running
+
+#Uninstall xCAT
+cmd:xdsh $$CN "cd /; ./go-xcat -y completely uninstall"
+check:rc==0
+cmd:xdsh $$CN "service xcatd status"
+check:rc!=0
+check:output=~could not be found|dead
+
+#Install devel version of xCAT
+cmd:xdsh $$CN "cd /; ./go-xcat --xcat-version=devel -y install"
+check:rc==0
+cmd:xdsh $$CN "cat /tmp/go-xcat.log"
+cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;lsxcatd -a"
+check:rc==0
 cmd:xdsh $$CN "service xcatd status"
 check:rc==0
 check:output=~running


### PR DESCRIPTION
* Four new testcases to test `go-xcat` installing from online repository on a newly provisioned compute node.

* Add `go-xcat` testcases to the daily testcase bundles