### PR TITLE
Add go-xcat testcases to x86 daily regression bundles

### DIFF
--- a/xCAT-test/autotest/bundle/rhels_x86_daily.bundle
+++ b/xCAT-test/autotest/bundle/rhels_x86_daily.bundle
@@ -303,3 +303,7 @@ xcatstanzafile_normal
 xcatstanzafile_objtype
 xcatstanzafile_specificvalue
 xcatstanzafile_tab
+go_xcat_devel_from_repo
+go_xcat_stable_from_repo
+go_xcat_stable_from_repo_upgrade
+go_xcat_stable_from_repo_reinstall_devel

--- a/xCAT-test/autotest/bundle/sles_x86_daily.bundle
+++ b/xCAT-test/autotest/bundle/sles_x86_daily.bundle
@@ -247,3 +247,7 @@ xcatstanzafile_normal
 xcatstanzafile_objtype
 xcatstanzafile_specificvalue
 xcatstanzafile_tab
+go_xcat_devel_from_repo
+go_xcat_stable_from_repo
+go_xcat_stable_from_repo_upgrade
+go_xcat_stable_from_repo_reinstall_devel

--- a/xCAT-test/autotest/bundle/ubuntu_x86_daily.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu_x86_daily.bundle
@@ -228,3 +228,7 @@ xdsh_permission_denied
 xdsh_q
 xdsh_regular_command
 xdsh_t
+go_xcat_devel_from_repo
+go_xcat_stable_from_repo
+go_xcat_stable_from_repo_upgrade
+go_xcat_stable_from_repo_reinstall_devel


### PR DESCRIPTION
Run `go-xcat` testcases during x86 daily regression tests