### PR TITLE
Improve install script and testcases

### DIFF
--- a/xCAT-test/autotest/bundle/rhels_ppcle_daily.bundle
+++ b/xCAT-test/autotest/bundle/rhels_ppcle_daily.bundle
@@ -305,6 +305,3 @@ xcatstanzafile_objtype
 xcatstanzafile_specificvalue
 xcatstanzafile_tab
 go_xcat_devel_from_repo
-go_xcat_stable_from_repo
-go_xcat_stable_from_repo_upgrade
-go_xcat_stable_from_repo_reinstall_devel

--- a/xCAT-test/autotest/bundle/rhels_x86_daily.bundle
+++ b/xCAT-test/autotest/bundle/rhels_x86_daily.bundle
@@ -304,6 +304,3 @@ xcatstanzafile_objtype
 xcatstanzafile_specificvalue
 xcatstanzafile_tab
 go_xcat_devel_from_repo
-go_xcat_stable_from_repo
-go_xcat_stable_from_repo_upgrade
-go_xcat_stable_from_repo_reinstall_devel

--- a/xCAT-test/autotest/bundle/sles_ppcle_daily.bundle
+++ b/xCAT-test/autotest/bundle/sles_ppcle_daily.bundle
@@ -249,6 +249,3 @@ xcatstanzafile_objtype
 xcatstanzafile_specificvalue
 xcatstanzafile_tab
 go_xcat_devel_from_repo
-go_xcat_stable_from_repo
-go_xcat_stable_from_repo_upgrade
-go_xcat_stable_from_repo_reinstall_devel

--- a/xCAT-test/autotest/bundle/sles_x86_daily.bundle
+++ b/xCAT-test/autotest/bundle/sles_x86_daily.bundle
@@ -248,6 +248,3 @@ xcatstanzafile_objtype
 xcatstanzafile_specificvalue
 xcatstanzafile_tab
 go_xcat_devel_from_repo
-go_xcat_stable_from_repo
-go_xcat_stable_from_repo_upgrade
-go_xcat_stable_from_repo_reinstall_devel

--- a/xCAT-test/autotest/bundle/ubuntu_ppcle_daily.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu_ppcle_daily.bundle
@@ -228,7 +228,3 @@ xdsh_permission_denied
 xdsh_q
 xdsh_regular_command
 xdsh_t
-go_xcat_devel_from_repo
-go_xcat_stable_from_repo
-go_xcat_stable_from_repo_upgrade
-go_xcat_stable_from_repo_reinstall_devel

--- a/xCAT-test/autotest/bundle/ubuntu_x86_daily.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu_x86_daily.bundle
@@ -228,7 +228,3 @@ xdsh_permission_denied
 xdsh_q
 xdsh_regular_command
 xdsh_t
-go_xcat_devel_from_repo
-go_xcat_stable_from_repo
-go_xcat_stable_from_repo_upgrade
-go_xcat_stable_from_repo_reinstall_devel

--- a/xCAT-test/autotest/testcase/go_xcat/case3
+++ b/xCAT-test/autotest/testcase/go_xcat/case3
@@ -11,8 +11,9 @@ check:output=~booted
 cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
-cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 20; echo "[$a] " $(lsdef $$CN -i status -c); ((a++));if [ $a -gt 30 ];then break;fi done
+cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 20; echo "[$a] " $(lsdef $$CN -i status -c); ((a++));if [ $a -gt 50 ];then break;fi done
 cmd:lsdef -l $$CN | grep status
+check:output=~booted
 
 #Copy go-xcat script
 cmd:xdsh $$CN "cd /; scp -r $$MN:/opt/xcat/share/xcat/tools/go-xcat ./"
@@ -43,8 +44,9 @@ check:output=~booted
 cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
-cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 20; echo "[$a] " $(lsdef $$CN -i status -c); ((a++));if [ $a -gt 30 ];then break;fi done
+cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 20; echo "[$a] " $(lsdef $$CN -i status -c); ((a++));if [ $a -gt 50 ];then break;fi done
 cmd:lsdef -l $$CN | grep status
+check:output=~booted
 
 #Copy go-xcat script
 cmd:xdsh $$CN "cd /; scp -r $$MN:/opt/xcat/share/xcat/tools/go-xcat ./"
@@ -75,8 +77,9 @@ check:output=~booted
 cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
-cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 20; echo "[$a] " $(lsdef $$CN -i status -c); ((a++));if [ $a -gt 30 ];then break;fi done
+cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 20; echo "[$a] " $(lsdef $$CN -i status -c); ((a++));if [ $a -gt 50 ];then break;fi done
 cmd:lsdef -l $$CN | grep status
+check:output=~booted
 
 #Copy go-xcat script
 cmd:xdsh $$CN "cd /; scp -r $$MN:/opt/xcat/share/xcat/tools/go-xcat ./"
@@ -117,8 +120,9 @@ check:output=~booted
 cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
-cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 20; echo "[$a] " $(lsdef $$CN -i status -c); ((a++));if [ $a -gt 30 ];then break;fi done
+cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 20; echo "[$a] " $(lsdef $$CN -i status -c); ((a++));if [ $a -gt 50 ];then break;fi done
 cmd:lsdef -l $$CN | grep status
+check:output=~booted
 
 #Copy go-xcat script
 cmd:xdsh $$CN "cd /; scp -r $$MN:/opt/xcat/share/xcat/tools/go-xcat ./"


### PR DESCRIPTION
Improve testcases and install script due to recent daily regression failures

* Some testcases were not able to power on VMs due to lack of memory - Display free memory and active VMs on the VM host.
* Some `go-xcat` testcases were failing on SLES due to not waiting long enough for node to boot - Increase waiting time from 30 to 50 iterations
* `go-xcat` testcases that install GA version of xCAT were failing on SLES - remove `go-xcat` testcases that install GA version from bundles, they can not be run on all versions of SLES (only `devel` can be installed on SLES 15) Related issue https://github.ibm.com/xcat2/xcat_automation_clusters/pull/84 was used to add those testcases to when running a specific version of SLES.
* `go-xcat` testcases that install GA version of xCAT were failing on RHEL - remove `go-xcat` testcases that install GA version from bundles, they can not be run on all versions of RHEL (only `devel` can be installed on RHEL 8.1) Related issue https://github.ibm.com/xcat2/xcat_automation_clusters/pull/84 was used to add those testcases to when running a specific version of RHEL.
* Some `go-xcat` testcases were failing on Ubuntu - remove `go-xcat` testcases from Ubuntu bundles and open a new issue (https://github.ibm.com/xcat2/team_process/issues/211) to investigate.