### PR TITLE
Support multiple options for nicextraparams

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/common/deployment/network/cfg_network_extra_param.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/deployment/network/cfg_network_extra_param.rst
@@ -19,3 +19,7 @@ Use ``nicextraparams`` to customize attributes in NIC configuration file. For ex
       HWADDR=42:f5:0a:05:6a:09
       MTU=1456
 
+  #. Example to add `nicextraparams` to `bond` interface ::
+
+      chdef cn1 nicextraparams.bond0='BONDING_OPTS="mode=active-backup;abc=100" MTU=6400 XYZ="4800" IOP="mode=1 phase=2"'
+

--- a/docs/source/guides/admin-guides/references/man5/nics.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/nics.5.rst
@@ -121,6 +121,8 @@ nics Attributes:
                      <nic1>!<param1=value1 param2=value2>,<nic2>!<param3=value3>, for example, eth0!MTU=1500,ib0!MTU=65520 CONNECTED_MODE=yes.
                  If multiple ip addresses are associated with each NIC:
                      <nic1>!<param1=value1 param2=value2>|<param3=value3>,<nic2>!<param4=value4 param5=value5>|<param6=value6>, for example, eth0!MTU=1500|MTU=1460,ib0!MTU=65520 CONNECTED_MODE=yes.
+The semicolon-separated is needed if there are multiple values for extra parameters:
+                     bond0!BONDING_OPTS=lacp_rate=1;miimon=100;mode=802.3ad
              The xCAT object definition commands support to use nicextraparams.<nicname> as the sub attributes.
  
 

--- a/docs/source/guides/admin-guides/references/man5/nics.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/nics.5.rst
@@ -121,6 +121,8 @@ nics Attributes:
                      <nic1>!<param1=value1 param2=value2>,<nic2>!<param3=value3>, for example, eth0!MTU=1500,ib0!MTU=65520 CONNECTED_MODE=yes.
                  If multiple ip addresses are associated with each NIC:
                      <nic1>!<param1=value1 param2=value2>|<param3=value3>,<nic2>!<param4=value4 param5=value5>|<param6=value6>, for example, eth0!MTU=1500|MTU=1460,ib0!MTU=65520 CONNECTED_MODE=yes.
+             The semicolon separator is needed if there are multiple values for extra parameters:
+                      bond0!BONDING_OPTS=lacp_rate=1;miimon=100;mode=802.3ad
              The xCAT object definition commands support to use nicextraparams.<nicname> as the sub attributes.
  
 

--- a/docs/source/guides/admin-guides/references/man5/nics.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/nics.5.rst
@@ -121,8 +121,6 @@ nics Attributes:
                      <nic1>!<param1=value1 param2=value2>,<nic2>!<param3=value3>, for example, eth0!MTU=1500,ib0!MTU=65520 CONNECTED_MODE=yes.
                  If multiple ip addresses are associated with each NIC:
                      <nic1>!<param1=value1 param2=value2>|<param3=value3>,<nic2>!<param4=value4 param5=value5>|<param6=value6>, for example, eth0!MTU=1500|MTU=1460,ib0!MTU=65520 CONNECTED_MODE=yes.
-The semicolon-separated is needed if there are multiple values for extra parameters:
-                     bond0!BONDING_OPTS=lacp_rate=1;miimon=100;mode=802.3ad
              The xCAT object definition commands support to use nicextraparams.<nicname> as the sub attributes.
  
 

--- a/docs/source/guides/admin-guides/references/man7/group.7.rst
+++ b/docs/source/guides/admin-guides/references/man7/group.7.rst
@@ -629,6 +629,8 @@ group Attributes:
                      <nic1>!<param1=value1 param2=value2>,<nic2>!<param3=value3>, for example, eth0!MTU=1500,ib0!MTU=65520 CONNECTED_MODE=yes.
                  If multiple ip addresses are associated with each NIC:
                      <nic1>!<param1=value1 param2=value2>|<param3=value3>,<nic2>!<param4=value4 param5=value5>|<param6=value6>, for example, eth0!MTU=1500|MTU=1460,ib0!MTU=65520 CONNECTED_MODE=yes.
+The semicolon-separated is needed if there are multiple values for extra parameters:
+                     bond0!BONDING_OPTS=lacp_rate=1;miimon=100;mode=802.3ad
              The xCAT object definition commands support to use nicextraparams.<nicname> as the sub attributes.
  
 

--- a/docs/source/guides/admin-guides/references/man7/group.7.rst
+++ b/docs/source/guides/admin-guides/references/man7/group.7.rst
@@ -629,8 +629,6 @@ group Attributes:
                      <nic1>!<param1=value1 param2=value2>,<nic2>!<param3=value3>, for example, eth0!MTU=1500,ib0!MTU=65520 CONNECTED_MODE=yes.
                  If multiple ip addresses are associated with each NIC:
                      <nic1>!<param1=value1 param2=value2>|<param3=value3>,<nic2>!<param4=value4 param5=value5>|<param6=value6>, for example, eth0!MTU=1500|MTU=1460,ib0!MTU=65520 CONNECTED_MODE=yes.
-The semicolon-separated is needed if there are multiple values for extra parameters:
-                     bond0!BONDING_OPTS=lacp_rate=1;miimon=100;mode=802.3ad
              The xCAT object definition commands support to use nicextraparams.<nicname> as the sub attributes.
  
 

--- a/docs/source/guides/admin-guides/references/man7/group.7.rst
+++ b/docs/source/guides/admin-guides/references/man7/group.7.rst
@@ -629,6 +629,8 @@ group Attributes:
                      <nic1>!<param1=value1 param2=value2>,<nic2>!<param3=value3>, for example, eth0!MTU=1500,ib0!MTU=65520 CONNECTED_MODE=yes.
                  If multiple ip addresses are associated with each NIC:
                      <nic1>!<param1=value1 param2=value2>|<param3=value3>,<nic2>!<param4=value4 param5=value5>|<param6=value6>, for example, eth0!MTU=1500|MTU=1460,ib0!MTU=65520 CONNECTED_MODE=yes.
+             The semicolon separator is needed if there are multiple values for extra parameters:
+                      bond0!BONDING_OPTS=lacp_rate=1;miimon=100;mode=802.3ad
              The xCAT object definition commands support to use nicextraparams.<nicname> as the sub attributes.
  
 

--- a/docs/source/guides/admin-guides/references/man7/node.7.rst
+++ b/docs/source/guides/admin-guides/references/man7/node.7.rst
@@ -629,6 +629,8 @@ node Attributes:
                      <nic1>!<param1=value1 param2=value2>,<nic2>!<param3=value3>, for example, eth0!MTU=1500,ib0!MTU=65520 CONNECTED_MODE=yes.
                  If multiple ip addresses are associated with each NIC:
                      <nic1>!<param1=value1 param2=value2>|<param3=value3>,<nic2>!<param4=value4 param5=value5>|<param6=value6>, for example, eth0!MTU=1500|MTU=1460,ib0!MTU=65520 CONNECTED_MODE=yes.
+The semicolon-separated is needed if there are multiple values for extra parameters:
+                     bond0!BONDING_OPTS=lacp_rate=1;miimon=100;mode=802.3ad
              The xCAT object definition commands support to use nicextraparams.<nicname> as the sub attributes.
  
 

--- a/docs/source/guides/admin-guides/references/man7/node.7.rst
+++ b/docs/source/guides/admin-guides/references/man7/node.7.rst
@@ -629,6 +629,8 @@ node Attributes:
                      <nic1>!<param1=value1 param2=value2>,<nic2>!<param3=value3>, for example, eth0!MTU=1500,ib0!MTU=65520 CONNECTED_MODE=yes.
                  If multiple ip addresses are associated with each NIC:
                      <nic1>!<param1=value1 param2=value2>|<param3=value3>,<nic2>!<param4=value4 param5=value5>|<param6=value6>, for example, eth0!MTU=1500|MTU=1460,ib0!MTU=65520 CONNECTED_MODE=yes.
+             The semicolon separator is needed if there are multiple values for extra parameters:
+                      bond0!BONDING_OPTS=lacp_rate=1;miimon=100;mode=802.3ad
              The xCAT object definition commands support to use nicextraparams.<nicname> as the sub attributes.
  
 

--- a/docs/source/guides/admin-guides/references/man7/node.7.rst
+++ b/docs/source/guides/admin-guides/references/man7/node.7.rst
@@ -629,8 +629,6 @@ node Attributes:
                      <nic1>!<param1=value1 param2=value2>,<nic2>!<param3=value3>, for example, eth0!MTU=1500,ib0!MTU=65520 CONNECTED_MODE=yes.
                  If multiple ip addresses are associated with each NIC:
                      <nic1>!<param1=value1 param2=value2>|<param3=value3>,<nic2>!<param4=value4 param5=value5>|<param6=value6>, for example, eth0!MTU=1500|MTU=1460,ib0!MTU=65520 CONNECTED_MODE=yes.
-The semicolon-separated is needed if there are multiple values for extra parameters:
-                     bond0!BONDING_OPTS=lacp_rate=1;miimon=100;mode=802.3ad
              The xCAT object definition commands support to use nicextraparams.<nicname> as the sub attributes.
  
 

--- a/perl-xCAT/xCAT/Schema.pm
+++ b/perl-xCAT/xCAT/Schema.pm
@@ -1626,6 +1626,8 @@ zvmivp => {
                     <nic1>!<param1=value1 param2=value2>,<nic2>!<param3=value3>, for example, eth0!MTU=1500,ib0!MTU=65520 CONNECTED_MODE=yes.
                 If multiple ip addresses are associated with each NIC:
                     <nic1>!<param1=value1 param2=value2>|<param3=value3>,<nic2>!<param4=value4 param5=value5>|<param6=value6>, for example, eth0!MTU=1500|MTU=1460,ib0!MTU=65520 CONNECTED_MODE=yes.
+            The semicolon separator is needed if there are multiple values for extra parameters:
+                     bond0!BONDING_OPTS=lacp_rate=1;miimon=100;mode=802.3ad
             The xCAT object definition commands support to use nicextraparams.<nicname> as the sub attributes.',
             nicdevices => 'Comma-separated list of NIC device per NIC, multiple ethernet devices can be bonded as bond device, these ethernet devices are separated by | . <nic1>!<dev1>|<dev3>,<nic2>!<dev2>, e.g. bond0!eth0|eth2,br0!bond0. The xCAT object definition commands support to use nicdevices.<nicname> as the sub attributes.',
             nicsadapter => 'Comma-separated list of NIC information collected by getadapter. <nic1>!<param1=value1 param2=value2>,<nic2>!<param4=value4 param5=value5>, for example, enP3p3s0f1!mac=98:be:94:59:fa:cd linkstate=DOWN,enP3p3s0f2!mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face',

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -1822,7 +1822,8 @@ function add_extra_params_nmcli {
         if [ -n "$name" -a -n "$value" ]; then
             grep $name $str_conf_file >/dev/null 2>/dev/null
             if [ $? -eq 0 ]; then
-                sed -i 's/^$name.*/$name=\"$vlaue\"/g' $str_conf_file
+                replacevalue="$name=$value"
+                sed -i "s/^$name=.*/$replacevalue/" $str_conf_file
             else
                 echo "$name="$value"" >> $str_conf_file
             fi

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -1820,7 +1820,12 @@ function add_extra_params_nmcli {
         name="${array_extra_param_names[$i]}"
         value="${array_extra_param_values[$i]}"
         if [ -n "$name" -a -n "$value" ]; then
-            echo "$name=$value" >> $str_conf_file
+            grep $name $str_conf_file >/dev/null 2>/dev/null
+            if [ $? -eq 0 ]; then
+                sed -i 's/^$name.*/$name=\"$vlaue\"/g' $str_conf_file
+            else
+                echo "$name="$value"" >> $str_conf_file
+            fi
         else
             log_error "invalid extra params $name $value, please check nics.nicextraparams"
             rc=1

--- a/xCAT/postscripts/xcatlib.sh
+++ b/xCAT/postscripts/xcatlib.sh
@@ -710,11 +710,12 @@ function get_nic_extra_params() {
 # This functions parse the extra parameters for an ip address of a nic
 # Input is like this:
 #     MTU=65520 something=yes
+#     MTU=65520 something=yes;no;maybe
 # After the function is called:
 #     array_extra_param_names[0]="MTU"
 #     array_extra_param_values[0]="65520"
 #     array_extra_param_names[1]="something"
-#     array_extra_param_values[0]="yes"
+#     array_extra_param_values[1]="yes"  or array_extra_param_values[1]="yes no maybe"
 #
 function parse_nic_extra_params() {
     str_extra=$1
@@ -731,7 +732,7 @@ function parse_nic_extra_params() {
 	do
 		token2="${params_temp[$k]}"
 		array_extra_param_names[$k]=`echo "$token2" | cut -d'=' -f 1`
-		array_extra_param_values[$k]=`echo "$token2" | cut -d'=' -f 2-`	
+                array_extra_param_values[$k]=`echo "$token2" | cut -d'=' -f 2- | sed 's,\;, ,g'`
 		k=$((k+1))
 	done
 }


### PR DESCRIPTION
For issue #6587 
Introduce a new string delimiter `;` for `nicextraparams` to support multiple options
```
# lsdef c910f04x12v04 | grep nic
    nicdevices.bond0=ens4|ens5
    nicextraparams.bond0=BONDING_OPTS=lacp_rate=1;miimon=100;mode=802.3ad
    nicips.bond0=102.4.12.4
    nicnetworks.bond0=confignetworks_test3
    nictypes.bond0=bond
    nictypes.ens4=ethernet
    nictypes.ens5=ethernet
    vmnicnicmodel=virtio
    vmnics=br10,br4091,br4093
```
after run `updatenode c910f04x12v04 -P confignetwork`

```
[root@c910f04x12v04 network-scripts]# cat ifcfg-xcat-bond-bond0-1
TYPE=Bond
BONDING_MASTER=yes
PROXY_METHOD=none
BROWSER_ONLY=no
BOOTPROTO=none
IPADDR=102.4.12.4
PREFIX=16
DEFROUTE=yes
IPV4_FAILURE_FATAL=no
IPV6INIT=yes
IPV6_AUTOCONF=yes
IPV6_DEFROUTE=yes
IPV6_FAILURE_FATAL=no
IPV6_ADDR_GEN_MODE=stable-privacy
NAME=xcat-bond-bond0
UUID=5f82ff74-807c-46a1-b7b2-22f63f505fb7
DEVICE=bond0
ONBOOT=yes
AUTOCONNECT_PRIORITY=9
AUTOCONNECT_RETRIES=0
AUTOCONNECT_SLAVES=yes
BONDING_OPTS="miimon=100 mode=802.3ad lacp_rate=1"
```