### PR TITLE
Remove migration testcases from weekly SLES bundle

### DIFF
--- a/xCAT-test/autotest/bundle/sles_ppcle_weekly.bundle
+++ b/xCAT-test/autotest/bundle/sles_ppcle_weekly.bundle
@@ -17,5 +17,4 @@ nodeset_shell
 reg_linux_diskfull_installation_flat
 reg_linux_diskless_installation_flat
 reg_linux_statelite_installation_flat
-sles_migration1
 sles_migration2

--- a/xCAT-test/autotest/bundle/sles_ppcle_weekly.bundle
+++ b/xCAT-test/autotest/bundle/sles_ppcle_weekly.bundle
@@ -17,4 +17,3 @@ nodeset_shell
 reg_linux_diskfull_installation_flat
 reg_linux_diskless_installation_flat
 reg_linux_statelite_installation_flat
-sles_migration2

--- a/xCAT-test/autotest/bundle/sles_x86_weekly.bundle
+++ b/xCAT-test/autotest/bundle/sles_x86_weekly.bundle
@@ -17,5 +17,4 @@ nodeset_shell
 reg_linux_diskfull_installation_flat
 reg_linux_diskless_installation_flat
 reg_linux_statelite_installation_flat
-sles_migration1
 sles_migration2

--- a/xCAT-test/autotest/bundle/sles_x86_weekly.bundle
+++ b/xCAT-test/autotest/bundle/sles_x86_weekly.bundle
@@ -17,4 +17,3 @@ nodeset_shell
 reg_linux_diskfull_installation_flat
 reg_linux_diskless_installation_flat
 reg_linux_statelite_installation_flat
-sles_migration2


### PR DESCRIPTION
Migration testcases should not be part of weekly bundles so that they do not run on SLES 15.