### PR TITLE
modify rmimage_diskless test cases

### DIFF
--- a/xCAT-test/autotest/testcase/rmimage/case0
+++ b/xCAT-test/autotest/testcase/rmimage/case0
@@ -23,5 +23,6 @@ check:output=~Image files have been removed successfully from this management no
 cmd:nodeset $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc!=0
 check:output=~kernel cannot be found at /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/kernel
+cmd:rm -rf /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute
 cmd:ls /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute.bak/;if [ $? -eq 0 ];then mv -f /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute.bak /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute;fi
 end


### PR DESCRIPTION
For `rmimage_disless` test cases,  the `compute.bak` dir didn't clean up via `mv -f` command, we are seeing:
```
ls -ltr /install/netboot/sle15/x86_64/compute/compute.bak/compute.bak/compute.bak
```

This PR will add code to remove `/install/netboot/sle15/x86_64/compute` dir also after `rmimage` command.