### PR TITLE
Add VM memory display to rpower testcase

### DIFF
--- a/xCAT-test/autotest/testcase/rpower/cases0
+++ b/xCAT-test/autotest/testcase/rpower/cases0
@@ -42,6 +42,8 @@ cmd:rpower $$CN off
 cmd:a=0;while ! `rpower $$CN stat|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$CN stat
 check:output=~Not Activated|off
+# Display active VMs and memory on VM host
+cmd:vmhost=`lsdef $$CN -i vmhost -c | cut -d '=' -f 2`; if [[ ! -z $vmhost ]]; then echo "Memory on vmhost $vmhost"; ssh $vmhost free -g; echo "Active VMs on vmhost $vmhost"; ssh $vmhost virsh list; fi
 cmd:rpower $$CN boot
 check:rc==0
 cmd:a=0;while ! `rpower $$CN stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done


### PR DESCRIPTION
Sometimes `rpower_boot` testcase fails because VM memory allocation fails with:
```
c910f03c09k11: [c910f03c09k10]: Error: internal error: qemu unexpectedly closed the monitor: 2020-03-04T08:18:02.756831Z qemu-kvm: Failed to allocate KVM HPT of order 26 (try smaller maxmem?): Cannot allocate memory
```

This PR adds, for debugging, running some commands on VM host to display free memory and number of active VMs.