### PR TITLE
Modify mysqlsetup scripts on rhels7.7

### DIFF
--- a/xCAT-client/bin/mysqlsetup
+++ b/xCAT-client/bin/mysqlsetup
@@ -930,9 +930,12 @@ sub initmysqldb
         $cmd = "$sqlcmd --user=mysql";
         #on rhels7.7, /usr/bin/mysql_install_db requires /usr/libexec/resolveip, 
         #but it's available at the /usr/bin/resolveip
-        #use --force to grant table entries use ipaddress instead of hostname
         if ($::linuxos == "rhels7.7") {
-            $cmd = "$cmd --force";
+            my $resolveip="/usr/libexec/resolveip";
+            if (!(-x ($resolveip))) {
+                my $linkcmd="ln -s /usr/bin/resolveip $resolveip";
+                xCAT::Utils->runcmd($linkcmd, 0);
+            }
         }
     }
     xCAT::Utils->runcmd($cmd, 0);

--- a/xCAT-client/bin/mysqlsetup
+++ b/xCAT-client/bin/mysqlsetup
@@ -928,6 +928,12 @@ sub initmysqldb
         }
 
         $cmd = "$sqlcmd --user=mysql";
+        #on rhels7.7, /usr/bin/mysql_install_db requires /usr/libexec/resolveip, 
+        #but it's available at the /usr/bin/resolveip
+        #use --force to grant table entries use ipaddress instead of hostname
+        if ($::linuxos == "rhels7.7") {
+            $cmd = "$cmd --force";
+        }
     }
     xCAT::Utils->runcmd($cmd, 0);
     if ($::RUNCMD_RC != 0)


### PR DESCRIPTION
The PR is to fix issue  #6618 

Add `--force` option to `/usr/bin/mysql_install_db` for rhels7.7 only.
```
 --force              Causes mysql_install_db to run even if DNS does not
                       work.  In that case, grant table entries that
                       normally use hostnames will use IP addresses.
 ```
If `--force` is set, it will not call `/usr/libexec/resolveip`,  and this function only used here to check if ip address can resolved the hostname.  
```
[root@c910f03c09k09 ~]# nslookup 10.3.9.9
9.9.3.10.in-addr.arpa   name = c910f03c09k09.pok.stglabs.ibm.com.

[root@c910f03c09k09 ~]# /usr/bin/resolveip 10.3.9.9
Host name of 10.3.9.9 is c910f03c09k09, c910f03c09k09.pok.stglabs.ibm.com
```