### PR TITLE
go-xcat testcase enhancements

### DIFF
--- a/xCAT-test/autotest/testcase/commoncmd/retry_install.sh
+++ b/xCAT-test/autotest/testcase/commoncmd/retry_install.sh
@@ -24,7 +24,7 @@ do
     if [[ ! -z $vmhost ]];then
         # Display memory and active VMs on VM host, when installing on VM
         echo "Memory on vmhost $vmhost"
-        ssh $vmhost free -g
+        ssh $vmhost free -m
         echo "Active VMs on vmhost $vmhost"
         ssh $vmhost virsh list
     fi

--- a/xCAT-test/autotest/testcase/go_xcat/case3
+++ b/xCAT-test/autotest/testcase/go_xcat/case3
@@ -4,8 +4,9 @@ label:go_xcat
 os:Linux
 #Make sure service node is not off, if it is, power it on
 cmd:if rpower $$SN stat | grep "off"; then rpower $$SN on; sleep 300; fi
-cmd:lsdef $$SN -i status
-check:output=~booted
+
+#Service not did not boot after 5 min, reprovision it
+cmd:if lsdef $$SN -i status -c | grep -v "booted"; then /opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$SN __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-install-service; fi
 
 #Provision compute node
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
@@ -39,8 +40,9 @@ label:go_xcat
 os:Linux
 #Make sure service node is not off, if it is, power it on
 cmd:if rpower $$SN stat | grep "off"; then rpower $$SN on; sleep 300; fi
-cmd:lsdef $$SN -i status
-check:output=~booted
+
+#Service not did not boot after 5 min, reprovision it
+cmd:if lsdef $$SN -i status -c | grep -v "booted"; then /opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$SN __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-install-service; fi
 
 #Provision compute node
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
@@ -74,8 +76,9 @@ label:go_xcat
 os:Linux
 #Make sure service node is not off, if it is, power it on
 cmd:if rpower $$SN stat | grep "off"; then rpower $$SN on; sleep 300; fi
-cmd:lsdef $$SN -i status
-check:output=~booted
+
+#Service not did not boot after 5 min, reprovision it
+cmd:if lsdef $$SN -i status -c | grep -v "booted"; then /opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$SN __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-install-service; fi
 
 #Provision compute node
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
@@ -119,8 +122,9 @@ label:go_xcat
 os:Linux
 #Make sure service node is not off, if it is, power it on
 cmd:if rpower $$SN stat | grep "off"; then rpower $$SN on; sleep 300; fi
-cmd:lsdef $$SN -i status
-check:output=~booted
+
+#Service not did not boot after 5 min, reprovision it
+cmd:if lsdef $$SN -i status -c | grep -v "booted"; then /opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$SN __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-install-service; fi
 
 #Provision compute node
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute

--- a/xCAT-test/autotest/testcase/rpower/cases0
+++ b/xCAT-test/autotest/testcase/rpower/cases0
@@ -43,7 +43,7 @@ cmd:a=0;while ! `rpower $$CN stat|grep "Not Activated\|off" >/dev/null`; do slee
 cmd:rpower $$CN stat
 check:output=~Not Activated|off
 # Display active VMs and memory on VM host
-cmd:vmhost=`lsdef $$CN -i vmhost -c | cut -d '=' -f 2`; if [[ ! -z $vmhost ]]; then echo "Memory on vmhost $vmhost"; ssh $vmhost free -g; echo "Active VMs on vmhost $vmhost"; ssh $vmhost virsh list; fi
+cmd:vmhost=`lsdef $$CN -i vmhost -c | cut -d '=' -f 2`; if [[ ! -z $vmhost ]]; then echo "Memory on vmhost $vmhost"; ssh $vmhost free -m; echo "Active VMs on vmhost $vmhost"; ssh $vmhost virsh list; fi
 cmd:rpower $$CN boot
 check:rc==0
 cmd:a=0;while ! `rpower $$CN stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done


### PR DESCRIPTION
Some `go-xcat` testcases fail because service node can not be powered back on.
This PR reprovisions service node if that happens.
Also use `free -m` instead of `free -g` to display VM host free memory. `-g` option rounds down the numbers, so `950 M` of free swap memory gets displayed as `0 G`