### PR TITLE
Failed to set hostname on sle15 statelite compute node

### DIFF
--- a/xCAT-server/share/xcat/netboot/sles/dracut_033/xcat-prepivot.sh
+++ b/xCAT-server/share/xcat/netboot/sles/dracut_033/xcat-prepivot.sh
@@ -160,7 +160,7 @@ STARTMODE='auto'
 EOF
 
 if [ -f $NEWROOT/etc/hostname ]; then
-    echo `hostname -s` > $NEWROOT/etc/hostname
+    echo "$ME" > $NEWROOT/etc/hostname
 fi
 
 if [ ! -z "$ifname" ]; then

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_flat
@@ -48,7 +48,7 @@ check:rc==0
 cmd:chtab priority=4.8 policy.commands=litetree policy.rule=allow
 check:rc==0
 
-cmd:rootimgdir=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir ]; then mv $rootimgdir $rootimgdir.regbak;fi
+cmd:rootimgdir=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir ]; then rm -rf $rootimgdir.regbak; mv $rootimgdir $rootimgdir.regbak;fi
 check:rc==0
 
 cmd:chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute rootfstype=nfs

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_nfs
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_nfs
@@ -59,7 +59,7 @@ check:rc==0
 cmd:chtab priority=4.8 policy.commands=litetree policy.rule=allow
 check:rc==0
 
-cmd:rootimgdir=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir ]; then mv $rootimgdir $rootimgdir.regbak;fi
+cmd:rootimgdir=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir ]; then rm -rf $rootimgdir.regbak; mv $rootimgdir $rootimgdir.regbak;fi
 check:rc==0
 
 cmd:lsdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_ramdisk
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_ramdisk
@@ -57,7 +57,7 @@ check:rc==0
 cmd:chtab priority=4.8 policy.commands=litetree policy.rule=allow
 check:rc==0
 
-cmd:rootimgdir=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir ]; then mv $rootimgdir $rootimgdir.regbak;fi
+cmd:rootimgdir=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir ]; then rm -rf $rootimgdir.regbak; mv $rootimgdir $rootimgdir.regbak;fi
 check:rc==0
 cmd:chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute rootfstype=ramdisk
 check:rc==0


### PR DESCRIPTION
On the SLE15 weekly and release regression test case,  the statelite provision failed to set up hostname for the comptue nodes:
```
RUN:xdsh f6u13k18 hostname [Fri Mar  6 11:37:37 2020]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
f6u13k18: none
CHECK:rc == 0   [Pass]
CHECK:output =~ f6u13k18: f6u13k18      [Failed]
```
```
# rcons f6u13k18
[Enter `^Ec?' for help]
goconserver(2020-03-06T11:36:22-05:00): Hello 10.6.13.16:33984, welcome to the session of f6u13k18

none login:
```
the /etc/hostname also showed `none`