### PR TITLE
RHEL8 disk partition template

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/pre.rhels8
+++ b/xCAT-server/share/xcat/install/scripts/pre.rhels8
@@ -277,15 +277,7 @@ echo "part pv.000997 --grow --asprimary --ondisk=$instdisk --size=18432" >>/tmp/
 echo "volgroup xcatvg --pesize=4096 pv.000997" >>/tmp/partitionfile
 echo "logvol swap --name=swap --vgname=xcatvg --recommended" >>/tmp/partitionfile
 
-if [ "${DISKSIZE}" -lt "62914560" ]
-then
-	echo "logvol / --fstype=$FSTYPE --name=root --vgname=xcatvg --grow --percent=86" >>/tmp/partitionfile
-else
-	echo "logvol / --fstype=$FSTYPE --name=root --vgname=xcatvg --grow --size=10240 --maxsize=20480" >>/tmp/partitionfile
-	echo "logvol /var --fstype=$FSTYPE --name=var --vgname=xcatvg --grow --size=4096 --maxsize=8192" >>/tmp/partitionfile
-	echo "logvol /tmp --fstype=$FSTYPE --name=tmp --vgname=xcatvg --grow --size=4096 --maxsize=8192" >>/tmp/partitionfile
-	echo "logvol /home --fstype=$FSTYPE --name=home --vgname=xcatvg --grow --percent=10 --maxsize=10240" >>/tmp/partitionfile
-fi
+echo "logvol / --fstype=$FSTYPE --name=root --vgname=xcatvg size=1024 --grow " >>/tmp/partitionfile
 
 # Specify "bootloader" configuration in "/tmp/partitionfile" if there is no user customized partition file
 BOOTLOADER="bootloader"


### PR DESCRIPTION
Change default disk partitioning for RHEL8 osimage.

Give all space to `/`. Start with 1G and let it grow as big as needed.