### PR TITLE
Partitioning of disk too large

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/pre.rhels8
+++ b/xCAT-server/share/xcat/install/scripts/pre.rhels8
@@ -273,7 +273,7 @@ DISKSIZE="$(getdisksize "${instdisk}")"
 
 # TODO: Ondisk detection, /dev/disk/by-id/edd-int13_dev80 for legacy maybe, and no idea about efi. At least maybe blacklist SAN if mptsas/mpt2sas/megaraid_sas seen...
 echo "part /boot --fstype=$BOOTFSTYPE --asprimary --ondisk=$instdisk --size=1024" >>/tmp/partitionfile
-echo "part pv.000997 --grow --asprimary --ondisk=$instdisk --size=18432" >>/tmp/partitionfile
+echo "part pv.000997 --grow --asprimary --ondisk=$instdisk --size=1024" >>/tmp/partitionfile
 echo "volgroup xcatvg --pesize=4096 pv.000997" >>/tmp/partitionfile
 echo "logvol swap --name=swap --vgname=xcatvg --recommended" >>/tmp/partitionfile
 


### PR DESCRIPTION
Initial allocation for primary disk partition of 18G for RHEL8 is too large for some c910 lab VMs.
Better to start with 1G and let them grow as needed.

After the fix:
```
[root@fs2vm100 ~]# hostnamectl
   Static hostname: localhost.localdomain
Transient hostname: fs2vm100
         Icon name: computer-vm
           Chassis: vm
        Machine ID: a1006ac4c4664075ade5ec3f31410482
           Boot ID: 3c2291f14617428cab6f9304e16f84a1
    Virtualization: kvm
  Operating System: Red Hat Enterprise Linux 8.1 (Ootpa)
       CPE OS Name: cpe:/o:redhat:enterprise_linux:8.1:GA
            Kernel: Linux 4.18.0-147.el8.ppc64le
      Architecture: ppc64-le
[root@fs2vm100 ~]#
```
```
[root@fs2vm100 ~]# df -H
Filesystem               Size  Used Avail Use% Mounted on
devtmpfs                 1.9G     0  1.9G   0% /dev
tmpfs                    1.9G     0  1.9G   0% /dev/shm
tmpfs                    1.9G   15M  1.9G   1% /run
tmpfs                    1.9G     0  1.9G   0% /sys/fs/cgroup
/dev/mapper/xcatvg-root   14G  1.6G   11G  13% /
/dev/sda2                1.1G  176M  778M  19% /boot
tmpfs                    373M     0  373M   0% /run/user/0
[root@fs2vm100 ~]#
```