### PR TITLE
Testcase debug for rmimage_diskless

### DIFF
--- a/xCAT-test/autotest/testcase/rmimage/case0
+++ b/xCAT-test/autotest/testcase/rmimage/case0
@@ -2,12 +2,13 @@ start:rmimage_diskless
 description:This case is to test rmimage could work correctly to remove all image files.
 label:others,packaging
 cmd:ls /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/;if [ $? -eq 0 ];then mv -f /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute.bak;fi
-cmd:copycds $$ISO
+cmd:copycds $$ISO | grep -v "%"
 check:rc==0
 cmd:genimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 cmd:packimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
+cmd:df -H
 cmd:cp -f /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.cpio.gz /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg.gz
 check:rc==0
 cmd:rmimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute


### PR DESCRIPTION
Try to debug weekly regression failure of `rmimage_diskless` testcase.
The error:
```
RUN:cp -f /install/netboot/sle15/x86_64/compute/rootimg.cpio.gz /install/netboot/sle15/x86_64/compute/rootimg.gz [Sat Mar 14 04:53:14 2020]
ElapsedTime:2 sec
RETURN rc = 1
OUTPUT:
cp: error writing '/install/netboot/sle15/x86_64/compute/rootimg.gz': No space left on device
```

Add `df` to the testcase to see space left after `genimage`.
Also get rid of pages of output from `copycds` displaying % completion.