### PR TITLE
Remove debug output from kdump testcase

### DIFF
--- a/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
+++ b/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
@@ -61,7 +61,8 @@ cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-ne
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 
-# Verify kdump related attributes showup in tftpboot file
+# Verify kdump related attributes showup in tftpboot file and file was changed
+cmd:ls -l /tftpboot/boot/grub2/$$CN
 cmd:cat /tftpboot/boot/grub2/$$CN
 
 cmd:sleep 300
@@ -92,17 +93,16 @@ cmd:xdsh $$CN df -H
 # Verify kdump parameters are in /proc/cmdline file
 cmd:xdsh $$CN cat /proc/cmdline
 
-# Verify enablekdump postscript was executed on the compute node
-cmd:xdsh $$CN cat /var/log/xcat/xcat.log | grep "kdump"
+# Verify no error configuring kdump server
+cmd:xdsh $$CN cat /var/log/xcat/xcat.log | grep "The kdump server is not configured"
+check:output!="The kdump server is not configured"
+check:rc!=0
 
 cmd:xdsh $$CN "at now +1 minutes <<< /tmp/kdump.trigger"
 cmd:sleep 300
 
 cmd:vmcorefile=`find /opt/xcat/share/xcat/tools/autotest/kdumpdir/ -name vmcore`;if [[ -s $vmcorefile ]]; then echo "vmcore file is not empty";else echo "vmcore file is empty"; fi
 check:output=~not empty
-
-# Check for errors in messages log file
-cmd:xdsh $$CN grep "kdump" /var/log/messages
 
 cmd:pkglistfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep pkglist|awk -F'=' '{print $2}'`;mv -f $pkglistfile.bak $pkglistfile
 cmd:exlistfile=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep exlist|awk -F'=' '{print $2}'`;mv -f $exlistfile.bak $exlistfile


### PR DESCRIPTION
Improve `linux_diskless_kdump` testcase. Remove some unneeded debug output and show date of tftpfile to better understand why it is not being changed.