### PR TITLE
Do not hide output of apt-key add

### DIFF
--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -1355,7 +1355,7 @@ function add_xcat_core_repo_apt()
 		local tmp="${TMP_DIR}/tmp_xcat.key"
 		download_file "${url}" "${tmp}"
 		warn_if_bad "$?" "download xcat apt key failed" || return 1
-		apt-key add "${tmp}" >/dev/null 2>&1
+		apt-key add "${tmp}"
 		warn_if_bad "$?" "import xcat apt key failed" || return 1
 		case "${ver}" in
 		"devel")


### PR DESCRIPTION
When running on Ubuntu, `go-xcat` calls `apt-key add` command, but throws away the output.
If that command fails, `go-xcat` just prints:
```go-xcat: import xcat apt key failed```
That message is not enough info for the user to decide what to do.

This PR will let `apt-key add` command to display its output:

```
E: gnupg, gnupg2 and gnupg1 do not seem to be installed, but one of them is required for this operation
go-xcat: import xcat apt key failed
```