### PR TITLE
Remove ntp from rhel8 pkglist

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels8.ppc64le.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels8.ppc64le.pkglist
@@ -29,5 +29,4 @@ iputils
 gzip
 grub2
 grub2-tools
-ntp
 lsvpd

--- a/xCAT-server/share/xcat/netboot/rh/service.rhels8.ppc64le.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/service.rhels8.ppc64le.pkglist
@@ -29,7 +29,6 @@ iputils
 gzip
 grub2
 grub2-tools
-ntp
 lsvpd
 perl-DBD-MySQL
 perl-DBD-Pg


### PR DESCRIPTION
PR #6641 cause `genimage` failed for rhels8
```
Updating Subscription Management repositories.
Unable to read consumer identity
This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.
rhels8.1.0-ppc64le-0                            187 MB/s | 4.8 MB     00:00
rhels8.1.0-ppc64le-1                            183 MB/s | 1.9 MB     00:00
No match for argument: ntp
Error: Unable to find a match: ntp
yum invocation failed.
```
on rhels8,  `ntp` is replaced by the `chrony` , so will remove `ntp` from pkglist