### PR TITLE
Power off compute node before rinstall in kdump testcase

### DIFF
--- a/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
+++ b/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
@@ -57,6 +57,7 @@ check:rc==0
 cmd:lsdef -t node $$CN -i postscripts,postbootscripts
 cmd:lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute -i crashkernelsize,dump
 
+cmd rpower $$CN off
 cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute -V
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN


### PR DESCRIPTION
`rinstall` command calls `rpower boot` at the end. If the node is `off` the `boot` option is supposed to turn it `on`, if the node is `on`, the `boot` option is supposed to do `reset`.

Normally during running of the `kdump` testcase, the node is `on`, so `boot` will attempt to do `reset`. This PR powers node `off` before calling `rinstall`, so that `boot` will power it `on`. Will see during next weekly run to see if that makes a diff.