### PR TITLE
Throw away confusing zypper message

### DIFF
--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -1285,7 +1285,7 @@ function remove_repo_zypper()
 {
 	type zypper >/dev/null 2>&1 || return 255
 	local repo_id="$1"
-	zypper removerepo "${repo_id}"
+	zypper removerepo "${repo_id}" > /dev/null
 	case "${repo_id}" in
 	"xcat-core")
 		mv /etc/zypp/repos.d/xCAT-core.repo{,.nouse} 2>/dev/null


### PR DESCRIPTION
When `go-xcat install` is running, it tries to clean up existing online repositories before creating new ones for the install. If the repository was not setup to begin with, on SLES, the log message contains these confusing entries, making it look like there was a problem **adding** the repository.
```
c910f03c09k14: .-> add_xcat_core_repo -y '' latest
c910f03c09k14: '========
c910f03c09k14: Repository 'xcat-core' not found by alias, number or URI.
c910f03c09k14: .========
c910f03c09k14: '-> add_xcat_core_repo       ... returned with 0
c910f03c09k14: 
c910f03c09k14: .-> add_xcat_dep_repo -y '' latest
c910f03c09k14: '========
c910f03c09k14: Repository 'xcat-dep' not found by alias, number or URI.
c910f03c09k14: .========
c910f03c09k14: '-> add_xcat_dep_repo        ... returned with 0
c910f03c09k14: 
```

This PR throws away output of the `zypper removerepo` command. The success or failure of this command is not important and processing should continue.