### PR TITLE
Add go-xcat testcases to Ubuntu daily bundles

### DIFF
--- a/xCAT-test/autotest/bundle/ubuntu_ppcle_daily.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu_ppcle_daily.bundle
@@ -228,3 +228,5 @@ xdsh_permission_denied
 xdsh_q
 xdsh_regular_command
 xdsh_t
+go_xcat_devel_from_repo
+go_xcat_stable_from_repo

--- a/xCAT-test/autotest/bundle/ubuntu_x86_daily.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu_x86_daily.bundle
@@ -228,3 +228,5 @@ xdsh_permission_denied
 xdsh_q
 xdsh_regular_command
 xdsh_t
+go_xcat_devel_from_repo
+go_xcat_stable_from_repo


### PR DESCRIPTION
`go-xcat` testcases are now ready to be added to the daily bundles