### PR TITLE
go-xcat stderr messages to discard for SLES installation

### DIFF
--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -1285,7 +1285,7 @@ function remove_repo_zypper()
 {
 	type zypper >/dev/null 2>&1 || return 255
 	local repo_id="$1"
-	zypper removerepo "${repo_id}" > /dev/null
+	zypper removerepo "${repo_id}" 2> /dev/null
 	case "${repo_id}" in
 	"xcat-core")
 		mv /etc/zypp/repos.d/xCAT-core.repo{,.nouse} 2>/dev/null


### PR DESCRIPTION
Continuing #6655
But errors are displayed in stderr