### PR TITLE
Fewer install retries for go-xcat testcases on Ubuntu

### DIFF
--- a/xCAT-test/autotest/testcase/go_xcat/case3
+++ b/xCAT-test/autotest/testcase/go_xcat/case3
@@ -3,13 +3,13 @@ description:test go-xcat devel on a newly provisioned node
 label:go_xcat
 os:Linux
 #Make sure service node is not off, if it is, power it on
-cmd:if rpower $$SN stat | grep "off"; then rpower $$SN on; sleep 300; fi
+cmd:if rpower $$SN stat | grep "off"; then rpower $$SN on; echo "Service node was off, powering on, waiting for 5 min"; sleep 300; fi
 
 #Service not did not boot after 5 min, reprovision it
-cmd:if lsdef $$SN -i status -c | grep -v "booted"; then /opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$SN __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-install-service; fi
+cmd:if lsdef $$SN -i status -c | grep -v "booted"; then echo "Service node did not power on, trying to reprovision"; /opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$SN __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-install-service 2; fi
 
 #Provision compute node
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute 2
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 cmd:lsdef -l $$CN | grep status
@@ -45,13 +45,13 @@ description:test go-xcat GA on a newly provisioned node
 label:go_xcat
 os:Linux
 #Make sure service node is not off, if it is, power it on
-cmd:if rpower $$SN stat | grep "off"; then rpower $$SN on; sleep 300; fi
+cmd:if rpower $$SN stat | grep "off"; then rpower $$SN on; echo "Service node was off, powering on, waiting for 5 min"; sleep 300; fi
 
 #Service not did not boot after 5 min, reprovision it
-cmd:if lsdef $$SN -i status -c | grep -v "booted"; then /opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$SN __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-install-service; fi
+cmd:if lsdef $$SN -i status -c | grep -v "booted"; then echo "Service node did not power on, trying to reprovision"; /opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$SN __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-install-service 2; fi
 
 #Provision compute node
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute 2
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 cmd:lsdef -l $$CN | grep status
@@ -87,13 +87,13 @@ description:test go-xcat GA on a newly provisioned node upgrade to devel
 label:go_xcat
 os:Linux
 #Make sure service node is not off, if it is, power it on
-cmd:if rpower $$SN stat | grep "off"; then rpower $$SN on; sleep 300; fi
+cmd:if rpower $$SN stat | grep "off"; then rpower $$SN on; echo "Service node was off, powering on, waiting for 5 min"; sleep 300; fi
 
 #Service not did not boot after 5 min, reprovision it
-cmd:if lsdef $$SN -i status -c | grep -v "booted"; then /opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$SN __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-install-service; fi
+cmd:if lsdef $$SN -i status -c | grep -v "booted"; then echo "Service node did not power on, trying to reprovision"; /opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$SN __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-install-service 2; fi
 
 #Provision compute node
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute 2
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 cmd:lsdef -l $$CN | grep status
@@ -139,13 +139,13 @@ description:test go-xcat GA on a newly provisioned node, remove, install devel
 label:go_xcat
 os:Linux
 #Make sure service node is not off, if it is, power it on
-cmd:if rpower $$SN stat | grep "off"; then rpower $$SN on; sleep 300; fi
+cmd:if rpower $$SN stat | grep "off"; then rpower $$SN on; echo "Service node was off, powering on, waiting for 5 min"; sleep 300; fi
 
 #Service not did not boot after 5 min, reprovision it
-cmd:if lsdef $$SN -i status -c | grep -v "booted"; then /opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$SN __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-install-service; fi
+cmd:if lsdef $$SN -i status -c | grep -v "booted"; then echo "Service node did not power on, trying to reprovision"; /opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$SN __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-install-service 2; fi
 
 #Provision compute node
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute 2
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 cmd:lsdef -l $$CN | grep status


### PR DESCRIPTION
Some Ubuntu daily regression runs timeout after 10 hours.
The problem appears to be reprovisioning of Service Node for `go-xcat` testcases.
By default, reprovisioning tries 5 times, which makes regression run exceed 10 yours.
This PR will retry 2 times, so that regression run completes under 10 hours.