### PR TITLE
Retry rpower command in testcases

### DIFF
--- a/xCAT-test/autotest/testcase/rpower/cases0
+++ b/xCAT-test/autotest/testcase/rpower/cases0
@@ -16,7 +16,10 @@ start:rpower_stat
 description:This case is to test stat option could show the power status of nodes
 Attribute: $$CN-The operation object of rpower command
 label:cn_bmc_ready,hctrl_general
-cmd:rpower $$CN on
+
+#If rpower fails on the first try, try again with smaller memory
+cmd:out=`rpower $$CN on 2>&1`;if [ $? -eq 1 ];then memory=`lsdef $$CN -i vmmemory -c | cut -d '=' -f 2`; chvm $$CN --mem $((memory-2048)); echo "'rpower on' failed with ${out}. Trying with smaller memory."; rpower $$CN on; fi
+
 cmd:a=0;while ! `rpower $$CN stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 5 ];then break;fi done
 cmd:rpower $$CN stat
 check:rc==0
@@ -89,8 +92,11 @@ cmd:rpower $$CN off
 cmd:a=0;while ! `rpower $$CN stat|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$CN stat
 check:output=~Not Activated|off
-cmd:rpower $$CN on
+
+#If rpower fails on the first try, try again with smaller memory
+cmd:out=`rpower $$CN on 2>&1`;if [ $? -eq 1 ];then memory=`lsdef $$CN -i vmmemory -c | cut -d '=' -f 2`; chvm $$CN --mem $((memory-2048)); echo "'rpower on' failed with ${out}. Trying with smaller memory."; rpower $$CN on; fi
 check:rc==0
+
 cmd:a=0;while ! `rpower $$CN stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$CN stat
 check:output=~Running|on


### PR DESCRIPTION
Sometimes `rpower` testcases fail with 
```
c910f03c09k17: [c910f03c09k16]: Error: internal error: qemu unexpectedly closed the monitor: 2020-04-03T07:08:21.058131Z qemu-kvm: Failed to allocate KVM HPT of order 26 (try smaller maxmem?): Cannot allocate memory
```
When that or other power on error happens, try to call `rpower` command again with smaller memory (subtract 2G).