### PR TITLE
linux_diskless_kdump testcase typo

### DIFF
--- a/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
+++ b/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
@@ -57,7 +57,7 @@ check:rc==0
 cmd:lsdef -t node $$CN -i postscripts,postbootscripts
 cmd:lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute -i crashkernelsize,dump
 
-cmd rpower $$CN off
+cmd:rpower $$CN off
 cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute -V
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN


### PR DESCRIPTION
Missing `:` in the testcase