### PR TITLE
Fix automatically finding unlocked user slots

### DIFF
--- a/xCAT-genesis-scripts/usr/bin/bmcsetup
+++ b/xCAT-genesis-scripts/usr/bin/bmcsetup
@@ -433,15 +433,16 @@ for user in $BMCUS; do
     if [ -z "$USERSLOT" ]; then
         USERSLOT=$((`ipmitool raw 6 0x44 1 1|awk '{print $3}'` + 1))
     fi
-    if [ "$USERSLOT" == 0 -o -z "$LOCKEDUSERS" ]; then USERSLOT=2; fi
-    # automatically find first unlocked user slot
-    for slot in {1..16}; do
-        USERLOCKED=`ipmitool channel getaccess $LANCHAN $slot | grep Fixed | awk '{print $4}'`
-        if [ "$USERLOCKED" == "No" ]; then
-            USERSLOT=$slot
-            break
-        fi
-    done
+    if [ "$USERSLOT" == 0 -o -z "$LOCKEDUSERS" ]; then
+        # automatically find first unlocked user slot
+        for slot in {1..16}; do
+            USERLOCKED=`ipmitool channel getaccess $LANCHAN $slot | grep Fixed | awk '{print $4}'`
+            if [ "$USERLOCKED" == "No" ]; then
+                USERSLOT=$slot
+                break
+            fi
+        done
+    fi
     if [ "$ISITE" = 1 ]; then
         allowcred.awk &
         CREDPID=$!

--- a/xCAT-genesis-scripts/usr/bin/bmcsetup
+++ b/xCAT-genesis-scripts/usr/bin/bmcsetup
@@ -433,7 +433,7 @@ for user in $BMCUS; do
     if [ -z "$USERSLOT" ]; then
         USERSLOT=$((`ipmitool raw 6 0x44 1 1|awk '{print $3}'` + 1))
     fi
-    if [ "$USERSLOT" == 0 -o -z "$LOCKEDUSERS" ]; then
+    if [ "$USERSLOT" == 0 ]; then
         # automatically find first unlocked user slot
         for slot in {1..16}; do
             USERLOCKED=`ipmitool channel getaccess $LANCHAN $slot | grep Fixed | awk '{print $4}'`
@@ -443,6 +443,8 @@ for user in $BMCUS; do
             fi
         done
     fi
+    # fall back to userslot 2 as a last resort
+    if [ "$USERSLOT" == 0 ]; then $USERSLOT = 2; fi
     if [ "$ISITE" = 1 ]; then
         allowcred.awk &
         CREDPID=$!
@@ -476,6 +478,15 @@ for user in $BMCUS; do
     done
     ipmitool raw 6 0x43 $(($LANCHAN|176))  $USERSLOT 4
 
+    TRIES=0
+    if [ "$CURRENTUSER" != "$user" ]; then
+        # Change the user name, if necessary
+        while ! ipmitool -d $idev user set name $USERSLOT "$user"; do
+            sleep 1
+            let TRIES=TRIES+1
+            if [ $TRIES -gt $TIMEOUT ]; then break; fi
+        done
+    fi
 
     TRIES=0
     # Last param in ipmitool user priv is the channel to set it on.
@@ -507,15 +518,6 @@ for user in $BMCUS; do
         if [ $TRIES -gt $TIMEOUT ]; then break; fi
     done
 
-    TRIES=0
-    if [ "$CURRENTUSER" != "$user" ]; then
-        # Change the user name, if necessary
-        while ! ipmitool -d $idev user set name $USERSLOT "$user"; do
-            sleep 1
-            let TRIES=TRIES+1
-            if [ $TRIES -gt $TIMEOUT ]; then break; fi
-        done
-    fi
     let idev=idev-1
 done
 


### PR DESCRIPTION
### This PR is to fix issue #6666

### The modifications include:
- Check for ```$USERSLOT=0``` being empty, and only try to automatically find an unlocked user slot if so.  This prevents the check for an unlocked slot from stomping on special cases for specific hardware defined further up in the script.

- Don't check ```$LOCKEDUSERS``` at all, instead fall back to userslot 2 as a last resort if the user doesn't already exist, and the automatic slot detection doesn't find an unlocked slot.  This is essentially what was happening in the older version of the script before #6380 as ```$LOCKEDUSERS``` was only ever referenced here.

- Also move setting the username before setting privileges and access levels, as those steps fail if done before username is set for the slot.
