### PR TITLE
go-xcat testcase on Ubuntu to accept default package installation

### DIFF
--- a/xCAT-test/autotest/testcase/go_xcat/case3
+++ b/xCAT-test/autotest/testcase/go_xcat/case3
@@ -28,6 +28,9 @@ cmd:if xdsh $$CN "grep \"Ubuntu\" /etc/*release >/dev/null"; then xdsh $$CN "DEB
 #Replace sources.list file on Ubuntu
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 
+#Set flag to accept install dependent packages by default on Ubuntu
+cmd:if grep Ubuntu /etc/*release;then arc_all=`uname -a`; if [[ $arc_all =~ "x86_64" ]]; then xdsh $$CN "echo '* libraries/restart-without-asking boolean true' | debconf-set-selections"; fi; fi
+
 #Install devel version of xCAT
 cmd:xdsh $$CN "cd /; ./go-xcat --xcat-version=devel -y install"
 check:rc==0
@@ -70,6 +73,9 @@ cmd:if xdsh $$CN "grep \"Ubuntu\" /etc/*release >/dev/null"; then xdsh $$CN "DEB
 #Replace sources.list file on Ubuntu
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
 
+#Set flag to accept install dependent packages by default on Ubuntu
+cmd:if grep Ubuntu /etc/*release;then arc_all=`uname -a`; if [[ $arc_all =~ "x86_64" ]]; then xdsh $$CN "echo '* libraries/restart-without-asking boolean true' | debconf-set-selections"; fi; fi
+
 #Install GA version of xCAT
 cmd:xdsh $$CN "cd /; ./go-xcat -y install"
 check:rc==0
@@ -111,6 +117,9 @@ cmd:if xdsh $$CN "grep \"Ubuntu\" /etc/*release >/dev/null"; then xdsh $$CN "DEB
 
 #Replace sources.list file on Ubuntu
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
+
+#Set flag to accept install dependent packages by default on Ubuntu
+cmd:if grep Ubuntu /etc/*release;then arc_all=`uname -a`; if [[ $arc_all =~ "x86_64" ]]; then xdsh $$CN "echo '* libraries/restart-without-asking boolean true' | debconf-set-selections"; fi; fi
 
 #Install GA version of xCAT
 cmd:xdsh $$CN "cd /; ./go-xcat -y install"
@@ -163,6 +172,9 @@ cmd:if xdsh $$CN "grep \"Ubuntu\" /etc/*release >/dev/null"; then xdsh $$CN "DEB
 
 #Replace sources.list file on Ubuntu
 cmd:if grep Ubuntu /etc/*release;then code=`lsb_release -sc` && xdsh $$CN "scp -r $$MN:/opt/xcat/share/xcat/tools/autotest/testcase/go_xcat/$code-__GETNODEATTR($$CN,arch)__.sources.list /etc/apt/sources.list"; fi
+
+#Set flag to accept install dependent packages by default on Ubuntu
+cmd:if grep Ubuntu /etc/*release;then arc_all=`uname -a`; if [[ $arc_all =~ "x86_64" ]]; then xdsh $$CN "echo '* libraries/restart-without-asking boolean true' | debconf-set-selections"; fi; fi
 
 #Install GA version of xCAT
 cmd:xdsh $$CN "cd /; ./go-xcat -y install"


### PR DESCRIPTION
Similar to #6499 

During execution of `go-xcat` testcase on x86 Ubuntu, package installation hangs. The following screen is displayed:

![image](https://user-images.githubusercontent.com/16106630/78719439-ed2fb680-78f1-11ea-9f8f-a4095d422679.png)

This PR adds commands to testcase so that default is accepted and installation can continue