### PR TITLE
Verify second parameter to rcons is a host

### DIFF
--- a/xCAT-client/bin/rcons
+++ b/xCAT-client/bin/rcons
@@ -36,11 +36,17 @@ for parameter in $@; do
     if [ $param_n -eq 2 ]; then
         if [ "$parameter" != "-f" ] && [ "$parameter" != "-s" ]; then
             CONSERVER=$parameter
+            # verify the specified CONSERVER can be resolved
+            host $CONSERVER > /dev/null 2>&1
+            if [ $? -ne 0 ]; then
+                echo "Error: cannot recognize parameter or conserver host \"$parameter\". Run \"rcons -h\" for usage."
+                exit 1
+            fi
         fi
     fi
 
     if [ $param_n -ge 2 ]; then
-        if [ "$parameter" = "-f" ] || [ "$parameter" = "-s" ]; then
+        if [ "$parameter" == "-f" ] || [ "$parameter" == "-s" ]; then
             if [ -z "$FORCE" ]; then
                 FORCE=$parameter
             elif [ "$FORCE" != "$parameter" ]; then
@@ -52,7 +58,7 @@ for parameter in $@; do
 
     if [ $param_n -ge 3 ]; then
         if [ "$parameter" != "-f" ] && [ "$parameter" != "-s" ]; then
-            echo "Error: cannot recognize parameter \"$parameter\"."
+            echo "Error: cannot recognize parameter \"$parameter\". Run \"rcons -h\" for usage."
             exit 1
         fi
     fi


### PR DESCRIPTION
### The PR is to fix issue _#6646_

The problem reported in the issue is not really wrong usage, but the fact that `rcons` assumes the second parameter passed to `rcons` is an optional conserver name. No checking was done, and if the user issued `rcons <nodename> -a`, the `-a` was assumed the name of conserver and `ssh -a` was issued to attempt to login to it. As a result, `ssh` usage was displayed.

This PR attempts to do a simple verification that second parameter can be resolved.

### UT

```
[root@stratton01 xcat]# rcons fs2vm101 fs2vm102 -f -s
Error: cannot use option -s and -f together.
```
```
[root@stratton01 xcat]# rcons fs2vm101 -f -s
Error: cannot use option -s and -f together.
```
```
[root@stratton01 xcat]# rcons fs2vm101 -a
Error: cannot recognize parameter or conserver host "-a". Run "rcons -h" for usage.
```
```
[root@stratton01 xcat]# rcons -h
rcons - remotely accesses the serial console of a node
rcons <singlenode> [conserver] [-f]
rcons <singlenode> [conserver] [-s]
rcons [-h|--help|-v|--version]
```
```
[root@stratton01 xcat]# rcons fs2vm101 fs2vm100
bash: /usr/bin/congo: No such file or directory
Connection to fs2vm100 closed.
[root@stratton01 xcat]#
```
```
[root@stratton01 xcat]# rcons fs2vm101 fs2vm100 -s
bash: /usr/bin/congo: No such file or directory
Connection to fs2vm100 closed.
[root@stratton01 xcat]#
```
```
[root@stratton01 xcat]# rcons fs2vm101 fs2vm100 -a
Error: cannot recognize parameter "-a". Run "rcons -h" for usage.
[root@stratton01 xcat]#
```
```
[root@stratton01 xcat]# rcons fs2vm101 markg
Error: cannot recognize parameter or conserver host "markg". Run "rcons -h" for usage.
```
```
[root@stratton01 xcat]# rcons fs2vm101 markg -s
Error: cannot recognize parameter or conserver host "markg". Run "rcons -h" for usage.
[root@stratton01 xcat]#
```
```
[root@stratton01 xcat]# rcons  markg
Could not connect to markg, error: Node not exist
```
```
[root@stratton01 xcat]# rcons  fs2vm101
[Enter `^Ec?' for help]
goconserver(2020-04-17T11:56:29-04:00): Hello 10.6.29.1:58616, welcome to the session of fs2vm101
```