### PR TITLE
`makehosts` command failed to add nicalias regular expression to the `/etc/hosts`

### DIFF
--- a/xCAT-server/lib/xcat/plugins/hosts.pm
+++ b/xCAT-server/lib/xcat/plugins/hosts.pm
@@ -790,6 +790,11 @@ sub donics
                 next;
             }
 
+            # for example: nicaliases.ib0=|maestro-(\d+)$|m($1)-ib0|
+            if ($aliases =~ /^\|\S*\|$/) {
+                $aliases = xCAT::Table::transRegexAttrs($node, $aliases);
+            }
+
             if ($aliases =~ /\|/) {
                 my @names = split(/\|/, $aliases);
                 my $index = 0;


### PR DESCRIPTION
For issue #6670 

use the nicalias regular expression can be add to node definition, but `makehosts` command failed to add it to the `/etc/hosts` 

after this fix: 
```
[root@boston02 ~]# lsdef -t group nic_group
Object name: nic_group
    arch=x86_64
    grouptype=static
    hostnames=|maestro-(\d+)$|m($1)|
    ip=|maestro-(\d+)$|172.20.($1/250/2).($1%250+2)|
    members=maestro-100
    nicaliases.ib0=|maestro-(\d+)$|m($1)-ib0|
    nicextraparams.ib0=DEFROUTE=no
    nichostnamesuffixes.ib0=-ib0
    nicips.ib0=|maestro-(\d+)$|172.21.($1/250/2).($1%250+2)|
    nicnetworks.ib0=172_21_0_0-255_255_0_0
    nictypes.ib0=Infiniband
    os=centor8.1
    profile=cpu
[root@boston02 ~]# mkdef maestro-99 groups=nic_group
1 object definitions have been created or modified.
[root@boston02 ~]# lsdef maestro-99
Object name: maestro-99
    arch=x86_64
    groups=nic_group
    hostnames=m99
    ip=172.20.0.101
    nicaliases.ib0=m99-ib0
    nicextraparams.ib0=DEFROUTE=no
    nichostnamesuffixes.ib0=-ib0
    nicips.ib0=172.21.0.101
    nicnetworks.ib0=172_21_0_0-255_255_0_0
    nictypes.ib0=Infiniband
    os=centor8.1
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
    profile=cpu
[root@boston02 ~]# makehosts maestro-99
[root@boston02 ~]# grep "0.101" /etc/hosts
172.20.0.101 maestro-99 maestro-99.pok.stglabs.ibm.com m99
172.21.0.101 maestro-99-ib0 maestro-99-ib0.pok.stglabs.ibm.com m99-ib0
[root@boston02 xCAT_plugin]# makedns
[root@boston02 xCAT_plugin]# host maestro-99
maestro-99.pok.stglabs.ibm.com has address 172.20.0.101
[root@boston02 xCAT_plugin]# host maestro-99-ib0
maestro-99-ib0.pok.stglabs.ibm.com has address 172.21.0.101
[root@boston02 xCAT_plugin]# host m99-ib0
m99-ib0.pok.stglabs.ibm.com is an alias for maestro-99-ib0.pok.stglabs.ibm.com.
maestro-99-ib0.pok.stglabs.ibm.com has address 172.21.0.101

```