### PR TITLE
Fix squashfs flags for centos

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/packimage.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/packimage.1.rst
@@ -23,7 +23,7 @@ SYNOPSIS
 
 \ **packimage  [-v| -**\ **-version]**\ 
 
-\ **packimage**\  [\ **-m | -**\ **-method**\  \ *cpio|tar*\ ] [\ **-c | -**\ **-compress**\  \ *gzip|pigz|xz*\ ] [\ **-**\ **-nosyncfiles**\ ] \ *imagename*\ 
+\ **packimage**\  [\ **-m | -**\ **-method**\  \ **cpio|tar|squashfs**\ ] [\ **-c | -**\ **-compress**\  \ **gzip|pigz|xz**\ ] [\ **-**\ **-nosyncfiles**\ ] \ *imagename*\ 
 
 
 ***********
@@ -33,7 +33,7 @@ DESCRIPTION
 
 Packs the stateless image from the chroot file system into a file to be sent to the node for a diskless boot.
 
-Note: For an osimage that is deployed on a cluster, running packimage will overwrite the existing rootimage file and be unavailable to the compute nodes while packimage is running.
+Note: For an osimage that is deployed on a cluster, running \ **packimage**\  will overwrite the existing rootimage file and be unavailable to the compute nodes while \ **packimage**\  is running.
 
 
 **********
@@ -49,15 +49,36 @@ OPTIONS
 *******
 
 
-\ **-h**\           Display usage message.
 
-\ **-v**\           Command Version.
+\ **-h**\ 
+ 
+ Display usage message.
+ 
 
-\ **-m| -**\ **-method**\           Archive Method (cpio,tar,squashfs, default is cpio)
 
-\ **-c| -**\ **-compress**\           Compress Method (pigz,gzip,xz, default is pigz/gzip)
+\ **-v**\ 
+ 
+ Command Version.
+ 
 
-\ **-**\ **-nosyncfiles**\           Bypass of syncfiles requested, will not sync files to root image directory
+
+\ **-m| -**\ **-method**\ 
+ 
+ Archive Method (cpio, tar, squashfs (requires overlayFS or aufs modules during provisioning), default is cpio)
+ 
+
+
+\ **-c| -**\ **-compress**\ 
+ 
+ Compress Method (pigz, gzip, xz, default is pigz/gzip)
+ 
+
+
+\ **-**\ **-nosyncfiles**\ 
+ 
+ Bypass of syncfiles requested, will not sync files to root image directory
+ 
+
 
 
 ************

--- a/xCAT-client/pods/man1/packimage.1.pod
+++ b/xCAT-client/pods/man1/packimage.1.pod
@@ -8,13 +8,13 @@ B<packimage [-h| --help]>
 
 B<packimage  [-v| --version]>
 
-B<packimage> [B<-m>|B<--method> I<cpio|tar>] [B<-c>|B<--compress> I<gzip|pigz|xz>] [B<--nosyncfiles>] I<imagename>
+B<packimage> [B<-m>|B<--method> B<cpio|tar|squashfs>] [B<-c>|B<--compress> B<gzip|pigz|xz>] [B<--nosyncfiles>] I<imagename>
 
 =head1 DESCRIPTION
 
 Packs the stateless image from the chroot file system into a file to be sent to the node for a diskless boot.
 
-Note: For an osimage that is deployed on a cluster, running packimage will overwrite the existing rootimage file and be unavailable to the compute nodes while packimage is running.
+Note: For an osimage that is deployed on a cluster, running B<packimage> will overwrite the existing rootimage file and be unavailable to the compute nodes while B<packimage> is running.
 
 =head1 PARAMETERS
 
@@ -22,17 +22,29 @@ I<imagename> specifies the name of a OS image definition to be used. The specifi
 
 =head1 OPTIONS
 
+=over 10
 
-B<-h>          Display usage message.
+=item B<-h>
 
-B<-v>          Command Version.
+Display usage message.
 
-B<-m| --method>          Archive Method (cpio,tar,squashfs, default is cpio)
+=item B<-v>
 
-B<-c| --compress>          Compress Method (pigz,gzip,xz, default is pigz/gzip)
+Command Version.
 
-B<--nosyncfiles>          Bypass of syncfiles requested, will not sync files to root image directory
+=item B<-m| --method> 
 
+Archive Method (cpio, tar, squashfs (requires overlayFS or aufs modules during provisioning), default is cpio)
+
+=item B<-c| --compress> 
+
+Compress Method (pigz, gzip, xz, default is pigz/gzip)
+
+=item B<--nosyncfiles> 
+
+Bypass of syncfiles requested, will not sync files to root image directory
+
+=back
 
 =head1 RETURN VALUE
 

--- a/xCAT-server/lib/xcat/plugins/packimage.pm
+++ b/xCAT-server/lib/xcat/plugins/packimage.pm
@@ -580,7 +580,7 @@ sub process_request {
             $flags = "-be";
         }
 
-        if ($osver =~ /rhels/ && $osver !~ /rhels5/) {
+        if (($osver =~ /rhels/ && $osver !~ /rhels5/) || ($osver =~ /centos/)) {
             $flags = "";
         }
 
@@ -588,9 +588,10 @@ sub process_request {
             $callback->({ error => ["mksquashfs not found, squashfs-tools rpm should be installed on the management node"], errorcode => [1] });
             return 1;
         }
-        my $rc = system("mksquashfs $temppath ../rootimg.sfs $flags");
+        my $mksquashfs_command = "mksquashfs $temppath ../rootimg.sfs $flags";
+        my $rc = system("$mksquashfs_command");
         if ($rc) {
-            $callback->({ error => ["mksquashfs could not be run successfully"], errorcode => [1] });
+            $callback->({ error => ["Command \"$mksquashfs_command\" failed"], errorcode => [1] });
             return 1;
         }
         $rc = system("rm -rf $temppath");


### PR DESCRIPTION
### The PR is to partially fix issue _#6583_

This PR:
* Removes `-be` or `-le` flags when OS is CentOS. These flags are no longer supported as suggested by #6573 
* Improves error message when `mksquashfs` command fails
* Improves man page for `packimage` command (as suggested by #6574)

#### UT:
* Original error message:
```
[root@stratton01 xcat]# packimage -m squashfs centos7.5-x86_64-netboot-compute
Packing contents of /install/netboot/centos7.5/x86_64/compute/rootimg
archive method:squashfs
1658144 blocks

Error: [stratton01]: mksquashfs could not be run successfully
[root@stratton01 xcat]#
```
* Error message after this PR:
```
[root@stratton01 xcat]# packimage -m squashfs centos7.5-x86_64-netboot-compute
Packing contents of /install/netboot/centos7.5/x86_64/compute/rootimg
archive method:squashfs
1658144 blocks

Error: [stratton01]: Command "mksquashfs /tmp/packimage.9426.rZJEHrjm ../rootimg.sfs -le" failed
[root@stratton01 xcat]#
```

* Before this PR `packimage` of CentOS with `squashfs` method would fail:
```
[root@stratton01 xcat]# packimage -m squashfs centos7.5-x86_64-netboot-compute
Packing contents of /install/netboot/centos7.5/x86_64/compute/rootimg
archive method:squashfs
1658144 blocks

Error: [stratton01]: mksquashfs could not be run successfully
[root@stratton01 xcat]#
```

* After this PR correct `rootimg.sfs` generated:
```
[root@stratton01 xcat]# packimage -m squashfs centos7.5-x86_64-netboot-compute
Packing contents of /install/netboot/centos7.5/x86_64/compute/rootimg
archive method:squashfs
1658144 blocks

[root@stratton01 xcat]# lsdef -t osimage -i rootimgdir centos7.5-x86_64-netboot-compute
Object name: centos7.5-x86_64-netboot-compute
    rootimgdir=/install/netboot/centos7.5/x86_64/compute

[root@stratton01 xcat]# ls -l /install/netboot/centos7.5/x86_64/compute
total 900184
-rw------- 1 root root  39105472 Sep  4  2019 initrd-stateless.gz
-rw------- 1 root root  36501006 Sep  4  2019 initrd-statelite.gz
-rwxr-xr-x 1 root root   6224704 Sep  4  2019 kernel
drwxr-xr-x 4 root root      4096 Apr 21 09:36 rootimg
-rw-r--r-- 1 root root 839020544 Apr 21 09:36 rootimg.sfs
[root@stratton01 xcat]#
