### PR TITLE
Support xfs filesystem for statelite images

### DIFF
--- a/xCAT-server/share/xcat/netboot/add-on/statelite/rc.localdisk
+++ b/xCAT-server/share/xcat/netboot/add-on/statelite/rc.localdisk
@@ -212,18 +212,18 @@ doconfigure () {
 
             # create the filesystem
             if [ x$fstype = x ]; then
-                fstype=ext3
+                fstype=ext4
             fi
             partnum=`expr $partnum + 1`
             partdev=$dev$partnum
             echo "Create filesystem $fstype on $partdev" >>$LOG
-            echo "mke2fs -q $partdev -t $fstype" >>$LOG
-            `mke2fs -q $partdev -t $fstype > /dev/null`
+            echo "mkfs.$fstype -q $partdev" >>$LOG
+            `mkfs.$fstype -q $partdev  > /dev/null`
             sleep 1
         done
     elif [ $localspace -eq 1 ]; then
         if [ x$fstype = x ]; then
-            fstype=ext3
+            fstype=ext4
         fi
         echo "Mount $dev to $LOCAL with $fstype" >>$LOG
         echo "mount -t $fstype $dev $MNTDIR$LOCAL" >>$LOG

--- a/xCAT-server/share/xcat/netboot/add-on/statelite/rc.localdisk
+++ b/xCAT-server/share/xcat/netboot/add-on/statelite/rc.localdisk
@@ -217,8 +217,8 @@ doconfigure () {
             partnum=`expr $partnum + 1`
             partdev=$dev$partnum
             echo "Create filesystem $fstype on $partdev" >>$LOG
-            echo "mkfs.$fstype -q $partdev" >>$LOG
-            `mkfs.$fstype -q $partdev  > /dev/null`
+            echo "mkfs.$fstype -f -q $partdev" >>$LOG
+            `mkfs.$fstype -f -q $partdev  > /dev/null`
             sleep 1
         done
     elif [ $localspace -eq 1 ]; then

--- a/xCAT-server/share/xcat/netboot/rh/dracut/install.netboot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut/install.netboot
@@ -4,7 +4,7 @@ dracut_install wget tar cpio gzip dash modprobe touch echo cut wc xz
 dracut_install -o ctorrent
 dracut_install grep ifconfig hostname awk egrep grep dirname expr
 dracut_install mount.nfs
-dracut_install parted mke2fs bc mkswap swapon chmod
+dracut_install parted mke2fs bc mkswap swapon chmod mkfs mkfs.ext4 mkfs.xfs xfs_db
 inst "$moddir/xcat-updateflag" "/tmp/updateflag"
 inst "$moddir/xcatroot" "/sbin/xcatroot"
 inst_hook cmdline 10 "$moddir/xcat-cmdline.sh"

--- a/xCAT-server/share/xcat/netboot/rh/dracut/install.statelite
+++ b/xCAT-server/share/xcat/netboot/rh/dracut/install.statelite
@@ -3,7 +3,7 @@ echo $drivers
 dracut_install wget tar cpio gzip dash modprobe wc touch echo cut
 dracut_install -o ctorrent
 dracut_install grep ifconfig hostname awk egrep grep dirname expr
-dracut_install parted mke2fs bc mkswap swapon chmod
+dracut_install parted mke2fs bc mkswap swapon chmod mkfs mkfs.ext4 mkfs.xfs xfs_db
 inst "$moddir/xcat-updateflag" "/tmp/updateflag"
 inst_hook pre-mount 5 "$moddir/xcat-premount.sh"
 inst_hook pre-pivot 5 "$moddir/xcat-prepivot.sh"

--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/install.netboot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/install.netboot
@@ -3,7 +3,7 @@ echo $drivers
 dracut_install wget tar cpio gzip modprobe touch echo cut wc xz
 dracut_install grep ifconfig hostname awk egrep grep dirname expr
 dracut_install mount.nfs
-dracut_install parted mke2fs bc mkswap swapon chmod
+dracut_install parted mke2fs bc mkswap swapon chmod mkfs mkfs.ext4 mkfs.xfs xfs_db
 dracut_install ethtool
 inst "$moddir/xcat-updateflag" "/tmp/updateflag"
 inst "$moddir/xcatroot" "/sbin/xcatroot"

--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/install.statelite
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/install.statelite
@@ -2,7 +2,7 @@
 echo $drivers
 dracut_install wget cpio gzip modprobe wc touch echo cut
 dracut_install grep ifconfig hostname awk egrep grep dirname expr
-dracut_install parted mke2fs bc mkswap swapon chmod
+dracut_install parted mke2fs bc mkswap swapon chmod mkfs mkfs.ext4 mkfs.xfs xfs_db 
 dracut_install ethtool
 inst "$moddir/xcat-updateflag" "/tmp/updateflag"
 inst_hook pre-mount 5 "$moddir/xcat-premount.sh"

--- a/xCAT-server/share/xcat/netboot/rh/dracut_047/install.netboot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_047/install.netboot
@@ -3,7 +3,7 @@ echo $drivers
 dracut_install curl tar cpio gzip modprobe touch echo cut wc xz
 dracut_install grep ifconfig hostname awk egrep grep dirname expr
 dracut_install mount.nfs
-dracut_install parted mke2fs bc mkswap swapon chmod
+dracut_install parted mke2fs bc mkswap swapon chmod mkfs mkfs.ext4 mkfs.xfs xfs_db
 dracut_install ethtool
 inst "$moddir/xcat-updateflag" "/tmp/updateflag"
 inst "$moddir/xcatroot" "/sbin/xcatroot"

--- a/xCAT-server/share/xcat/netboot/rh/dracut_047/install.statelite
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_047/install.statelite
@@ -2,7 +2,7 @@
 echo $drivers
 dracut_install curl cpio gzip modprobe wc touch echo cut
 dracut_install grep ifconfig hostname awk egrep grep dirname expr
-dracut_install parted mke2fs bc mkswap swapon chmod
+dracut_install parted mke2fs bc mkswap swapon chmod mkfs mkfs.ext4 mkfs.xfs xfs_db
 dracut_install ethtool
 inst "$moddir/xcat-updateflag" "/tmp/updateflag"
 inst_hook pre-mount 5 "$moddir/xcat-premount.sh"

--- a/xCAT-server/share/xcat/netboot/sles/dracut_033/install.netboot
+++ b/xCAT-server/share/xcat/netboot/sles/dracut_033/install.netboot
@@ -3,7 +3,7 @@ echo $drivers
 dracut_install wget tar cpio gzip modprobe touch echo cut wc xz
 dracut_install grep ifconfig ip hostname awk egrep grep dirname expr
 dracut_install mount.nfs
-dracut_install parted mke2fs bc mkswap swapon chmod
+dracut_install parted mke2fs bc mkswap swapon chmod mkfs mkfs.ext4 mkfs.xfs xfs_db
 inst "$moddir/xcat-updateflag" "/tmp/updateflag"
 inst "$moddir/xcatroot" "/sbin/xcatroot"
 inst_hook cmdline 10 "$moddir/xcat-cmdline.sh"

--- a/xCAT-server/share/xcat/netboot/sles/dracut_033/install.statelite
+++ b/xCAT-server/share/xcat/netboot/sles/dracut_033/install.statelite
@@ -2,7 +2,7 @@
 echo $drivers
 dracut_install wget cpio gzip modprobe wc touch echo cut
 dracut_install grep ifconfig ip hostname awk egrep grep dirname expr logger
-dracut_install parted mke2fs bc mkswap swapon chmod
+dracut_install parted mke2fs bc mkswap swapon chmod mkfs mkfs.ext4 mkfs.xfs xfs_db
 inst "$moddir/xcat-updateflag" "/tmp/updateflag"
 inst_hook pre-mount 5 "$moddir/xcat-premount.sh"
 inst_hook pre-pivot 5 "$moddir/xcat-prepivot.sh"


### PR DESCRIPTION
 The PR is to fix issue #6664

I documented steps to verify this fixes for future use.
1) created a partitionfile 
```
# cat /tmp/partxfs
enable=yes
enablepart=yes

[disk]
dev=/dev/sda
clear=yes
parts=10,20,30
fstype=xfs

[localspace]
dev=/dev/sda1
fstype=xfs

[swapspace]
dev=/dev/sda2
```
2) add partition file to statelite image
```
# chdef -t osimage rhels8.0.0-ppc64le-statelite-compute partitionfile=/tmp/partxfs
```
3) add partition to policy table
```
# chtab priority=7.1 policy.commands=getpartition policy.rule=allow
```
4) regenerate the statelite image
```
# genimage rhels8.0.0-ppc64le-statelite-compute
# liteimg rhels8.0.0-ppc64le-statelite-compute
# rinstall c910f03c09k17 osimage=rhels8.0.0-ppc64le-statelite-compute
```
after node provisioned:
```
]# parted -lsm
BYT;
/dev/sda:42.9GB:scsi:512:512:msdos:QEMU QEMU HARDDISK:;
1:1049kB:4000MB:3999MB:xfs::;
2:4000MB:12.0GB:8000MB:linux-swap(v1)::;
3:12.0GB:24.0GB:12.0GB:ext4::;
# df -h | grep sda1
/dev/sda1                              3.8G   59M  3.7G   2% /.sllocal/localmnt
# xfs_info /.sllocal/localmnt
meta-data=/dev/sda1              isize=512    agcount=4, agsize=244096 blks
         =                       sectsz=512   attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=1, rmapbt=0
         =                       reflink=1
data     =                       bsize=4096   blocks=976384, imaxpct=25
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0, ftype=1
log      =internal log           bsize=4096   blocks=2560, version=2
         =                       sectsz=512   sunit=0 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
```
