### PR TITLE
Use overlay mount type for squashfs diskless images

### DIFF
--- a/xCAT-server/share/xcat/netboot/fedora/dracut_009/xcatroot
+++ b/xCAT-server/share/xcat/netboot/fedora/dracut_009/xcatroot
@@ -52,11 +52,21 @@ if [ -r /rootimg.sfs ]; then
   mkdir -p /rw
   mount -t squashfs /rootimg.sfs /ro
   mount -t tmpfs rw /rw
-  mount -t aufs -o dirs=/rw:/ro mergedroot $NEWROOT
-  mkdir -p $NEWROOT/ro
-  mkdir -p $NEWROOT/rw
-  mount --move /ro $NEWROOT/ro
-  mount --move /rw $NEWROOT/rw
+  modinfo overlay
+  if [ $? -eq 0 ]; then
+      echo "Mounting $NEWROOT with type overlay"
+      mkdir -p /rw/upper
+      mkdir -p /rw/work
+      modprobe overlay
+      mount -t overlay -o lowerdir=/ro,upperdir=/rw/upper,workdir=/rw/work mergedroot $NEWROOT
+  else
+      echo "Mounting $NEWROOT with type aufs"
+      mount -t aufs -o dirs=/rw:/ro mergedroot $NEWROOT
+      mkdir -p $NEWROOT/ro
+      mkdir -p $NEWROOT/rw
+      mount --move /ro $NEWROOT/ro
+      mount --move /rw $NEWROOT/rw
+  fi
 elif [ -r /rootimg.gz ]; then
   echo Setting up RAM-root tmpfs.
   if [ -z $rootlimit ];then

--- a/xCAT-server/share/xcat/netboot/rh/dracut/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut/xcatroot
@@ -62,11 +62,21 @@ if [ -r /rootimg.sfs ]; then
   mkdir -p /rw
   mount -t squashfs /rootimg.sfs /ro
   mount -t tmpfs rw /rw
-  mount -t aufs -o dirs=/rw:/ro mergedroot $NEWROOT
-  mkdir -p $NEWROOT/ro
-  mkdir -p $NEWROOT/rw
-  mount --move /ro $NEWROOT/ro
-  mount --move /rw $NEWROOT/rw
+  modinfo overlay
+  if [ $? -eq 0 ]; then
+      echo "Mounting $NEWROOT with type overlay"
+      mkdir -p /rw/upper
+      mkdir -p /rw/work
+      modprobe overlay
+      mount -t overlay -o lowerdir=/ro,upperdir=/rw/upper,workdir=/rw/work mergedroot $NEWROOT
+  else
+      echo "Mounting $NEWROOT with type aufs"
+      mount -t aufs -o dirs=/rw:/ro mergedroot $NEWROOT
+      mkdir -p $NEWROOT/ro
+      mkdir -p $NEWROOT/rw
+      mount --move /ro $NEWROOT/ro
+      mount --move /rw $NEWROOT/rw
+  fi
 elif [ -r /rootimg.cpio.gz ] || [ -r /rootimg.cpio.xz ]; then
   [ "$xcatdebugmode" > "0" ] && logger -t xcat -p debug "rootimg downloaded,setting up RAM-root tmpfs...."
   echo Setting up RAM-root tmpfs.

--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
@@ -69,11 +69,21 @@ if [ -r /rootimg.sfs ]; then
     mkdir -p /rw
     mount -t squashfs /rootimg.sfs /ro
     mount -t tmpfs rw /rw
-    mount -t aufs -o dirs=/rw:/ro mergedroot $NEWROOT
-    mkdir -p $NEWROOT/ro
-    mkdir -p $NEWROOT/rw
-    mount --move /ro $NEWROOT/ro
-    mount --move /rw $NEWROOT/rw
+    modinfo overlay
+    if [ $? -eq 0 ]; then
+        echo "Mounting $NEWROOT with type overlay"
+        mkdir -p /rw/upper
+        mkdir -p /rw/work
+        modprobe overlay
+        mount -t overlay -o lowerdir=/ro,upperdir=/rw/upper,workdir=/rw/work mergedroot $NEWROOT
+    else
+        echo "Mounting $NEWROOT with type aufs"
+        mount -t aufs -o dirs=/rw:/ro mergedroot $NEWROOT
+        mkdir -p $NEWROOT/ro
+        mkdir -p $NEWROOT/rw
+        mount --move /ro $NEWROOT/ro
+        mount --move /rw $NEWROOT/rw
+    fi
 elif [ -r /rootimg.cpio.gz ] || [ -r /rootimg.cpio.xz ]; then
     logger $SYSLOGHOST -t $log_label -p local4.info "Setting up RAM-root tmpfs on downloaded rootimg.cpio.[gz/xz]..."
     echo Setting up RAM-root tmpfs.

--- a/xCAT-server/share/xcat/netboot/rh/dracut_047/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_047/xcatroot
@@ -69,11 +69,21 @@ if [ -r /rootimg.sfs ]; then
     mkdir -p /rw
     mount -t squashfs /rootimg.sfs /ro
     mount -t tmpfs rw /rw
-    mount -t aufs -o dirs=/rw:/ro mergedroot $NEWROOT
-    mkdir -p $NEWROOT/ro
-    mkdir -p $NEWROOT/rw
-    mount --move /ro $NEWROOT/ro
-    mount --move /rw $NEWROOT/rw
+    modinfo overlay
+    if [ $? -eq 0 ]; then
+        echo "Mounting $NEWROOT with type overlay"
+        mkdir -p /rw/upper
+        mkdir -p /rw/work
+        modprobe overlay
+        mount -t overlay -o lowerdir=/ro,upperdir=/rw/upper,workdir=/rw/work mergedroot $NEWROOT
+    else
+        echo "Mounting $NEWROOT with type aufs"
+        mount -t aufs -o dirs=/rw:/ro mergedroot $NEWROOT
+        mkdir -p $NEWROOT/ro
+        mkdir -p $NEWROOT/rw
+        mount --move /ro $NEWROOT/ro
+        mount --move /rw $NEWROOT/rw
+    fi
 elif [ -r /rootimg.cpio.gz ] || [ -r /rootimg.cpio.xz ]; then
     logger $SYSLOGHOST -t $log_label -p local4.info "Setting up RAM-root tmpfs on downloaded rootimg.cpio.[gz/xz]..."
     echo Setting up RAM-root tmpfs.

--- a/xCAT-server/share/xcat/netboot/sles/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/sles/dracut_033/xcatroot
@@ -66,10 +66,20 @@ if [ -r /rootimg.sfs ]; then
   mount -t squashfs /rootimg.sfs /ro
   mount -t tmpfs rw /rw
   mount -t aufs -o dirs=/rw:/ro mergedroot $NEWROOT
-  mkdir -p $NEWROOT/ro
-  mkdir -p $NEWROOT/rw
-  mount --move /ro $NEWROOT/ro
-  mount --move /rw $NEWROOT/rw
+  modinfo overlay
+  if [ $? -eq 0 ]; then
+      echo "Mounting $NEWROOT with type overlay"
+      mkdir -p /rw/upper
+      mkdir -p /rw/work
+      modprobe overlay
+      mount -t overlay -o lowerdir=/ro,upperdir=/rw/upper,workdir=/rw/work mergedroot $NEWROOT
+  else
+      echo "Mounting $NEWROOT with type aufs"
+      mkdir -p $NEWROOT/ro
+      mkdir -p $NEWROOT/rw
+      mount --move /ro $NEWROOT/ro
+      mount --move /rw $NEWROOT/rw
+  fi
 elif [ -r /rootimg.cpio.gz ] || [ -r /rootimg.cpio.xz ]; then
   logger $SYSLOGHOST -t $log_label -p local4.info "Setting up RAM-root tmpfs on downloaded rootimg.cpio.[gz/xz]..."
   echo Setting up RAM-root tmpfs.

--- a/xCAT-server/share/xcat/netboot/ubuntu/dracut/xcatroot
+++ b/xCAT-server/share/xcat/netboot/ubuntu/dracut/xcatroot
@@ -34,11 +34,21 @@ if [ -r /rootimg.sfs ]; then
   mkdir -p /rw
   mount -t squashfs /rootimg.sfs /ro
   mount -t tmpfs rw /rw
-  mount -t aufs -o dirs=/rw:/ro mergedroot $NEWROOT
-  mkdir -p $NEWROOT/ro
-  mkdir -p $NEWROOT/rw
-  mount --move /ro $NEWROOT/ro
-  mount --move /rw $NEWROOT/rw
+  modinfo overlay
+  if [ $? -eq 0 ]; then
+      echo "Mounting $NEWROOT with type overlay"
+      mkdir -p /rw/upper
+      mkdir -p /rw/work
+      modprobe overlay
+      mount -t overlay -o lowerdir=/ro,upperdir=/rw/upper,workdir=/rw/work mergedroot $NEWROOT
+  else
+      echo "Mounting $NEWROOT with type aufs"
+      mount -t aufs -o dirs=/rw:/ro mergedroot $NEWROOT
+      mkdir -p $NEWROOT/ro
+      mkdir -p $NEWROOT/rw
+      mount --move /ro $NEWROOT/ro
+      mount --move /rw $NEWROOT/rw
+  fi
 elif [ -r /rootimg.cpio.gz ] || [ -r /rootimg.cpio.xz ]; then
   echo Setting up RAM-root tmpfs.
   mount -t tmpfs -o mode=755 rootfs $NEWROOT


### PR DESCRIPTION
### The PR is to fix issue _#6583_

`packimage` allows generating `squashfs` type of image. Provisioning of such image will fail when `xcatroot` tries to execute:
```
mount -t aufs -o dirs=/rw:/ro mergedroot $NEWROOT
```

When `genimage` runs, it copies `share/xcat/netboot/rh/<dracut_dir>/xcatroot` file to `rootimg/usr/lib/dracut/modules.d/98xcat/xcatroot` under the `rootimg` attribute of the osimage definition.

The `aufs` type is no longer used and [in 2015, the patch/change on how to switch to 'overlayfs' ](https://sourceforge.net/p/xcat/mailman/message/34251334/) has been submitted.

This PR uses suggested change, if `overlay` module is available.

This fix has been unit tested on RH8.1
A separate PR #6682 adds a testcase to verify the fix on all OS environments.

