### PR TITLE
Make sure squashfs-tools installed on Ubuntu for squashfs testcase

### DIFF
--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat
@@ -129,6 +129,10 @@ cmd:cat /tmp/mountoutput/file.new
 cmd:diff /tmp/mountoutput/file.org /tmp/mountoutput/file.new --ignore-matching-lines="fusectl"
 check:rc==0
 cmd:rm -rf /tmp/mountoutput
+
+#Make sure squashfs-tools rpm is installed on Ubuntu
+cmd:if [ "$$OS" = "ubuntu" ];then apt-get install -y squashfs-tools; fi
+
 cmd:packimage -m squashfs __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 check:output=~archive method:squashfs

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_hierarchy
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_hierarchy
@@ -152,7 +152,11 @@ cmd:if [[ "__GETNODEATTR($$CN,os)__" =~ "ubuntu16.04.5" ]] && [[ "__GETNODEATTR(
 cmd:lsdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 cmd:genimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
-cmd:packimage -m squashfs__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+
+#Make sure squashfs-tools rpm is installed on Ubuntu
+cmd:if [ "$$OS" = "ubuntu" ];then apt-get install -y squashfs-tools; fi
+
+cmd:packimage -m squashfs __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 check:output=~archive method:squashfs
 


### PR DESCRIPTION
On Ubintu `squashfs-tools` is not installed by default.
It is needed to run `squashfs` testcases.