### PR TITLE
Use ext4 filesystem instead of ext3 when formatting node partitions

### DIFF
--- a/docs/source/advanced/hamn/setup_ha_mgmt_node_with_shared_data.rst
+++ b/docs/source/advanced/hamn/setup_ha_mgmt_node_with_shared_data.rst
@@ -499,13 +499,13 @@ The operating system is installed on the internal disks.
 
 #. Create file systems on shared disks
 
-   Run the ``mkfs.ext3`` command on the primary management node to create file systems on the shared disk that will contain the xCAT data. For example: ::
+   Run the ``mkfs.ext4`` command on the primary management node to create file systems on the shared disk that will contain the xCAT data. For example: ::
 
-    mkfs.ext3 -v /dev/sdc1
-    mkfs.ext3 -v /dev/sdc2
-    mkfs.ext3 -v /dev/sdc3
-    mkfs.ext3 -v /dev/sdc4
-    mkfs.ext3 -v /dev/sdc5
+    mkfs.ext4 -v /dev/sdc1
+    mkfs.ext4 -v /dev/sdc2
+    mkfs.ext4 -v /dev/sdc3
+    mkfs.ext4 -v /dev/sdc4
+    mkfs.ext4 -v /dev/sdc5
 
    If you place entries for the disk in ``/etc/fstab``, which is not required, ensure that the entries do not have the system automatically mount the disk.
 

--- a/docs/source/guides/admin-guides/manage_clusters/common/deployment/cfg_partition.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/deployment/cfg_partition.rst
@@ -107,7 +107,7 @@ Here is partition definition file example for SLES standard partition in X86_64 
             </partition>
             <partition>
                 <create config:type="boolean">true</create>
-                <filesystem config:type="symbol">ext3</filesystem>
+                <filesystem config:type="symbol">ext4</filesystem>
                 <format config:type="boolean">true</format>
                 <mount>/</mount>
                 <mountby config:type="symbol">path</mountby>
@@ -131,7 +131,7 @@ The following is an example of a partition definition file for a SLES LVM Partit
 		<partition>
 		  <create config:type="boolean">true</create>
 		  <crypt_fs config:type="boolean">false</crypt_fs>
-		  <filesystem config:type="symbol">ext3</filesystem>
+		  <filesystem config:type="symbol">ext4</filesystem>
 		  <format config:type="boolean">true</format>
 		  <loop_fs config:type="boolean">false</loop_fs>
 		  <mountby config:type="symbol">device</mountby>
@@ -148,7 +148,7 @@ The following is an example of a partition definition file for a SLES LVM Partit
 		<partition>
 		  <create config:type="boolean">true</create>
 		  <crypt_fs config:type="boolean">false</crypt_fs>
-		  <filesystem config:type="symbol">ext3</filesystem>
+		  <filesystem config:type="symbol">ext4</filesystem>
 		  <format config:type="boolean">true</format>
 		  <loop_fs config:type="boolean">false</loop_fs>
 		  <mount>/boot</mount>
@@ -211,7 +211,7 @@ The following is an example of a partition definition file for a SLES LVM Partit
 		<partition>
 		  <create config:type="boolean">true</create>
 		  <crypt_fs config:type="boolean">false</crypt_fs>
-		  <filesystem config:type="symbol">ext3</filesystem>
+		  <filesystem config:type="symbol">ext4</filesystem>
 		  <format config:type="boolean">true</format>
 		  <loop_fs config:type="boolean">false</loop_fs>
 		  <lv_name>root</lv_name>
@@ -248,7 +248,7 @@ Here is partition definition file example for SLES standard partition in ppc64 m
             <partition>
                 <create config:type="boolean">true</create>
                 <crypt_fs config:type="boolean">false</crypt_fs>
-                <filesystem config:type="symbol">ext3</filesystem>
+                <filesystem config:type="symbol">ext4</filesystem>
                 <format config:type="boolean">false</format>
                 <loop_fs config:type="boolean">false</loop_fs>
                 <mountby config:type="symbol">device</mountby>
@@ -274,7 +274,7 @@ Here is partition definition file example for SLES standard partition in ppc64 m
             <partition>
                 <create config:type="boolean">true</create>
                 <crypt_fs config:type="boolean">false</crypt_fs>
-                <filesystem config:type="symbol">ext3</filesystem>
+                <filesystem config:type="symbol">ext4</filesystem>
                 <format config:type="boolean">true</format>
                 <fstopt>acl,user_xattr</fstopt>
                 <loop_fs config:type="boolean">false</loop_fs>
@@ -328,19 +328,19 @@ Here is partition definition file example for Ubuntu standard partition in x86_6
 			filesystem{ vfat }
 			mountpoint{ /boot/efi } .
 
-	256 256 512 ext3
+	256 256 512 ext4
 			$primary{ }
 			method{ format }
 			format{ }
 			use_filesystem{ }
-			filesystem{ ext3 }
+			filesystem{ ext4 }
 			mountpoint{ /boot } .
 
 	64 512 300% linux-swap
 			method{ swap }
 			format{ } .
 
-	512 1024 4096 ext3
+	512 1024 4096 ext4
 			$primary{ }
 			method{ format }
 			format{ }
@@ -348,7 +348,7 @@ Here is partition definition file example for Ubuntu standard partition in x86_6
 			filesystem{ ext4 }
 			mountpoint{ / } .
 
-	100 10000 1000000000 ext3
+	100 10000 1000000000 ext4
 			method{ format }
 			format{ }
 			use_filesystem{ }
@@ -403,7 +403,7 @@ Here is an example of the partition script on RedHat and SLES, the partitioning 
     else
         FSTYPE=ext3
     fi
-    BOOTFSTYPE=ext3
+    BOOTFSTYPE=ext4
     EFIFSTYPE=vfat
     if uname -r|grep ^3.*el7 > /dev/null; then
         FSTYPE=xfs
@@ -438,12 +438,12 @@ The following is an example of the partition script on Ubuntu, the partitioning 
 		echo "    ." >> /tmp/partitionfile
 	else
 		echo "ubuntu-boot ::" > /tmp/partitionfile
-		echo "100 50 100 ext3" >> /tmp/partitionfile
-		echo '    $primary{ } $bootable{ } method{ format } format{ } use_filesystem{ } filesystem{ ext3 } mountpoint{ /boot }' >> /tmp/partitionfile
+		echo "100 50 100 ext4" >> /tmp/partitionfile
+		echo '    $primary{ } $bootable{ } method{ format } format{ } use_filesystem{ } filesystem{ ext4 } mountpoint{ /boot }' >> /tmp/partitionfile
 		echo "    ." >> /tmp/partitionfile
 	fi
-	echo "500 10000 1000000000 ext3" >> /tmp/partitionfile
-	echo "    method{ format } format{ } use_filesystem{ } filesystem{ ext3 } mountpoint{ / }" >> /tmp/partitionfile
+	echo "500 10000 1000000000 ext4" >> /tmp/partitionfile
+	echo "    method{ format } format{ } use_filesystem{ } filesystem{ ext4 } mountpoint{ / }" >> /tmp/partitionfile
 	echo "    ." >> /tmp/partitionfile
 	echo "2048 512 300% linux-swap" >> /tmp/partitionfile
 	echo "    method{ swap } format{ }" >> /tmp/partitionfile

--- a/docs/source/guides/admin-guides/manage_clusters/common/deployment/enable_localdisk.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/deployment/enable_localdisk.rst
@@ -40,7 +40,7 @@ An example ``localdisk`` configuration file: ::
 
     [localspace]
     dev=/dev/sda1
-    fstype=ext3
+    fstype=ext4
 
     [swapspace]
     dev=/dev/sda2
@@ -55,7 +55,7 @@ The ``[disk]`` section is used to configure how to partition a hard disk:
     * dev: The path of the device file.
     * clear: If set to ``yes`` it will clear all the existing partitions on this disk.
     * ptype: The partition table type of the disk. For example, ``msdos`` or ``gpt``, and ``msdos`` is the default.
-    * fstype: The file system type for the new created partitions. ``ext3`` is the default.
+    * fstype: The file system type for the new created partitions. ``ext4`` is the default.
     * parts: A comma separated list of space ranges, one for each partition that will be created on the device. The valid format for each space range is ``<startpoint>-<endpoint>`` or ``<percentage of the disk>``. For example, you could set it to ``100M-10G`` or ``50``. If set to ``50``, 50% of the disk space will be assigned to that partition.
 
 The ``[localspace]`` section is used to specify which partition will be used as local storage for the node.

--- a/xCAT-server/share/xcat/install/SL/compute.tmpl
+++ b/xCAT-server/share/xcat/install/SL/compute.tmpl
@@ -36,7 +36,7 @@ key --skip
 #/boot really significant for this sort of setup nowadays?
 #part /boot --size 50 --fstype ext3
 part swap --size 1024
-part / --size 1 --grow --fstype ext3
+part / --size 1 --grow --fstype ext4
 #XCAT_PARTITION_END#
 
 #RAID 0 /scr for performance

--- a/xCAT-server/share/xcat/install/centos/all.tmpl
+++ b/xCAT-server/share/xcat/install/centos/all.tmpl
@@ -34,9 +34,9 @@ clearpart --all --initlabel
 
 #XCAT_PARTITION_START#
 #No RAID
-part /boot --size 50 --ondisk sda --fstype ext3
+part /boot --size 50 --ondisk sda --fstype ext4
 part swap --size 1024 --ondisk sda
-part / --size 6000 --grow --ondisk sda --fstype ext3
+part / --size 6000 --grow --ondisk sda --fstype ext4
 #XCAT_PARTITION_END#
 
 #RAID 0 /scr for performance

--- a/xCAT-server/share/xcat/install/centos/iscsi.tmpl
+++ b/xCAT-server/share/xcat/install/centos/iscsi.tmpl
@@ -39,7 +39,7 @@ iscsi --ipaddr #TABLE:iscsi:$NODE:server# --user "#TABLEBLANKOKAY:iscsi:$NODE:us
 #No RAID
 #/boot really significant for this sort of setup nowadays?
 #part /boot --size 50 --fstype ext3
-part / --size 1 --grow --fstype ext3
+part / --size 1 --grow --fstype ext4
 #XCAT_PARTITION_END#
 
 #RAID 0 /scr for performance

--- a/xCAT-server/share/xcat/install/centos/storage.tmpl
+++ b/xCAT-server/share/xcat/install/centos/storage.tmpl
@@ -36,9 +36,9 @@ clearpart --all --initlabel
 
 #XCAT_PARTITION_START#
 #No RAID
-part /boot --size 100 --ondisk sda --fstype ext3
+part /boot --size 100 --ondisk sda --fstype ext4
 part swap --size 2048 --ondisk sda
-part / --size 6000 --grow --ondisk sda --fstype ext3
+part / --size 6000 --grow --ondisk sda --fstype ext4
 #XCAT_PARTITION_END#
 
 #RAID 0 /scr for performance

--- a/xCAT-server/share/xcat/install/centos/xen.tmpl
+++ b/xCAT-server/share/xcat/install/centos/xen.tmpl
@@ -36,7 +36,7 @@ clearpart --all --initlabel
 #/boot really significant for this sort of setup nowadays?
 #part /boot --size 50 --fstype ext3
 part swap --size 1024
-part / --size 1 --grow --fstype ext3
+part / --size 1 --grow --fstype ext4
 #XCAT_PARTITION_END#
 
 #RAID 0 /scr for performance

--- a/xCAT-server/share/xcat/install/debian/compute.tmpl
+++ b/xCAT-server/share/xcat/install/debian/compute.tmpl
@@ -44,15 +44,15 @@ d-i partman-md/device_remove_md boolean true
 
 d-i partman-auto/expert_recipe string                         \
       boot-root ::                                            \
-              40 50 100 ext3                                  \
+              40 50 100 ext4                                  \
                       $primary{ } $bootable{ }                \
                       method{ format } format{ }              \
-                      use_filesystem{ } filesystem{ ext3 }    \
+                      use_filesystem{ } filesystem{ ext4 }    \
                       mountpoint{ /boot }                     \
               .                                               \
-              500 10000 1000000000 ext3                       \
+              500 10000 1000000000 ext4                       \
                       method{ format } format{ }              \
-                      use_filesystem{ } filesystem{ ext3 }    \
+                      use_filesystem{ } filesystem{ ext4 }    \
                       mountpoint{ / }                         \
               .                                               \
               64 512 300% linux-swap                          \

--- a/xCAT-server/share/xcat/install/esx/esx.tmpl
+++ b/xCAT-server/share/xcat/install/esx/esx.tmpl
@@ -15,8 +15,8 @@ reboot
 url --url http://#TABLE:noderes:$NODE:nfsserver#/install/#TABLE:nodetype:$NODE:os#/#TABLE:nodetype:$NODE:arch#
 zerombr yes
 clearpart --all --initlabel --drives=sda
-part /boot    --fstype ext3    --size=100   --ondisk=sda
-part /        --fstype ext3    --size=2048  --ondisk=sda
+part /boot    --fstype ext4    --size=100   --ondisk=sda
+part /        --fstype ext4    --size=2048  --ondisk=sda
 part swap                      --size=2048   --ondisk=sda
 part None     --fstype vmfs3   --size=900 --ondisk=sda --grow
 part None     --fstype vmkcore --size=100   --ondisk=sda

--- a/xCAT-server/share/xcat/install/fedora/compute.ppc64.tmpl
+++ b/xCAT-server/share/xcat/install/fedora/compute.ppc64.tmpl
@@ -36,9 +36,9 @@ clearpart --all --initlabel
 #No RAID
 #/boot really significant for this sort of setup nowadays?
 part None --fstype "PPC PReP Boot" --size 8
-part /boot --size 50 --fstype ext3
+part /boot --size 50 --fstype ext4
 part swap --size 1024
-part / --size 1 --grow --fstype ext3
+part / --size 1 --grow --fstype ext4
 #XCAT_PARTITION_END#
 
 #RAID 0 /scr for performance

--- a/xCAT-server/share/xcat/install/fedora/compute.tmpl
+++ b/xCAT-server/share/xcat/install/fedora/compute.tmpl
@@ -37,7 +37,7 @@ clearpart --all --initlabel
 #/boot really significant for this sort of setup nowadays?
 #part /boot --size 50 --fstype ext3
 part swap --size 1024
-part / --size 1 --grow --fstype ext3
+part / --size 1 --grow --fstype ext4
 #XCAT_PARTITION_END#
 
 #RAID 0 /scr for performance

--- a/xCAT-server/share/xcat/install/fedora/iscsi.tmpl
+++ b/xCAT-server/share/xcat/install/fedora/iscsi.tmpl
@@ -39,7 +39,7 @@ iscsi --ipaddr #TABLE:iscsi:$NODE:server# --user "#TABLEBLANKOKAY:iscsi:$NODE:us
 #No RAID
 #/boot really significant for this sort of setup nowadays?
 #part /boot --size 50 --fstype ext3
-part / --size 1 --grow --fstype ext3
+part / --size 1 --grow --fstype ext4
 #XCAT_PARTITION_END#
 
 #RAID 0 /scr for performance

--- a/xCAT-server/share/xcat/install/fedora/service.tmpl
+++ b/xCAT-server/share/xcat/install/fedora/service.tmpl
@@ -37,7 +37,7 @@ clearpart --all --initlabel
 #/boot really significant for this sort of setup nowadays?
 #part /boot --size 50 --fstype ext3
 part swap --size 1024
-part / --size 1 --grow --fstype ext3
+part / --size 1 --grow --fstype ext4
 #XCAT_PARTITION_END#
 
 #RAID 0 /scr for performance

--- a/xCAT-server/share/xcat/install/rh/compute.ppc64.tmpl
+++ b/xCAT-server/share/xcat/install/rh/compute.ppc64.tmpl
@@ -40,7 +40,7 @@ key --skip
 part None --fstype "PPC PReP Boot" --size 8
 #part /boot --size 50 --fstype ext3
 part swap --size 1024
-part / --size 1 --grow --fstype ext3
+part / --size 1 --grow --fstype ext4
 #XCAT_PARTITION_END#
 
 #RAID 0 /scr for performance

--- a/xCAT-server/share/xcat/install/rh/compute.tmpl
+++ b/xCAT-server/share/xcat/install/rh/compute.tmpl
@@ -39,7 +39,7 @@ key --skip
 #/boot really significant for this sort of setup nowadays?
 #part /boot --size 50 --fstype ext3
 part swap --size 1024
-part / --size 1 --grow --fstype ext3
+part / --size 1 --grow --fstype ext4
 #XCAT_PARTITION_END#
 
 #RAID 0 /scr for performance

--- a/xCAT-server/share/xcat/install/rh/iscsi.tmpl
+++ b/xCAT-server/share/xcat/install/rh/iscsi.tmpl
@@ -39,7 +39,7 @@ iscsi --ipaddr #TABLE:iscsi:$NODE:server# --user "#TABLEBLANKOKAY:iscsi:$NODE:us
 #No RAID
 #/boot really significant for this sort of setup nowadays?
 #part /boot --size 50 --fstype ext3
-part / --size 1 --grow --fstype ext3
+part / --size 1 --grow --fstype ext4
 #XCAT_PARTITION_END#
 
 #RAID 0 /scr for performance

--- a/xCAT-server/share/xcat/install/rh/kvm.tmpl
+++ b/xCAT-server/share/xcat/install/rh/kvm.tmpl
@@ -42,9 +42,9 @@ key --skip
 #XCAT_PARTITION_START#
 #No RAID
 #/boot really significant for this sort of setup nowadays?
-#part /boot --size 50 --fstype ext3
+#part /boot --size 50 --fstype ext4
 part swap --size 1024
-part / --size 1 --grow --fstype ext3
+part / --size 1 --grow --fstype ext4
 #XCAT_PARTITION_END#
 
 #RAID 0 /scr for performance

--- a/xCAT-server/share/xcat/install/rh/service.ppc64.tmpl
+++ b/xCAT-server/share/xcat/install/rh/service.ppc64.tmpl
@@ -39,7 +39,7 @@ part None --fstype "PPC PReP Boot" --size 8
 #part /boot --size 50 --fstype ext3
 
 part swap --size 1024
-part / --size 1 --grow --fstype ext3
+part / --size 1 --grow --fstype ext4
 #XCAT_PARTITION_END#
 
 #RAID 0 /scr for performance

--- a/xCAT-server/share/xcat/install/rh/service.tmpl
+++ b/xCAT-server/share/xcat/install/rh/service.tmpl
@@ -37,7 +37,7 @@ key --skip
 #/boot really significant for this sort of setup nowadays?
 #part /boot --size 50 --fstype ext3
 part swap --size 1024
-part / --size 1 --grow --fstype ext3
+part / --size 1 --grow --fstype ext4
 #XCAT_PARTITION_END#
 
 #RAID 0 /scr for performance

--- a/xCAT-server/share/xcat/install/rh/storage.tmpl
+++ b/xCAT-server/share/xcat/install/rh/storage.tmpl
@@ -36,9 +36,9 @@ clearpart --all --initlabel
 
 #XCAT_PARTITION_START#
 #No RAID
-part /boot --size 100 --ondisk sda --fstype ext3
+part /boot --size 100 --ondisk sda --fstype ext4
 part swap --size 2048 --ondisk sda
-part / --size 6000 --grow --ondisk sda --fstype ext3
+part / --size 6000 --grow --ondisk sda --fstype ext4
 #XCAT_PARTITION_END#
 
 #RAID 0 /scr for performance

--- a/xCAT-server/share/xcat/install/scripts/pre.rh
+++ b/xCAT-server/share/xcat/install/scripts/pre.rh
@@ -260,7 +260,7 @@ elif grep ext4 /proc/filesystems > /dev/null; then
 else
 	FSTYPE=ext3
 fi
-BOOTFSTYPE=ext3
+BOOTFSTYPE=ext4
 EFIFSTYPE=vfat
 msgutil_r "$MASTER_IP" "info" "Found $instdisk, generate partition file..." "/var/log/xcat/xcat.log" "$log_label"
 if [ `uname -m` = "ppc64" ]; then

--- a/xCAT-server/share/xcat/install/scripts/pre.rh.rhels7
+++ b/xCAT-server/share/xcat/install/scripts/pre.rh.rhels7
@@ -226,7 +226,7 @@ elif grep ext4 /proc/filesystems > /dev/null; then
 else
 	FSTYPE=ext3
 fi
-BOOTFSTYPE=ext3
+BOOTFSTYPE=ext4
 EFIFSTYPE=vfat
 
 if uname -r|grep -q '^3.*el7'; then

--- a/xCAT-server/share/xcat/install/scripts/pre.ubuntu
+++ b/xCAT-server/share/xcat/install/scripts/pre.ubuntu
@@ -195,12 +195,12 @@ if [ -d /sys/firmware/efi ]; then
     echo "    ." >> /tmp/partitionfile
 else
     echo "ubuntu-boot ::" > /tmp/partitionfile
-    echo "256 256 512 ext3" >> /tmp/partitionfile
-    echo '    $primary{ } $bootable{ } method{ format } format{ } use_filesystem{ } filesystem{ ext3 } mountpoint{ /boot }' >> /tmp/partitionfile
+    echo "256 256 512 ext4" >> /tmp/partitionfile
+    echo '    $primary{ } $bootable{ } method{ format } format{ } use_filesystem{ } filesystem{ ext4 } mountpoint{ /boot }' >> /tmp/partitionfile
     echo "    ." >> /tmp/partitionfile
 fi
-echo "500 10000 1000000000 ext3" >> /tmp/partitionfile
-echo "    method{ format } format{ } use_filesystem{ } filesystem{ ext3 } mountpoint{ / }" >> /tmp/partitionfile
+echo "500 10000 1000000000 ext4" >> /tmp/partitionfile
+echo "    method{ format } format{ } use_filesystem{ } filesystem{ ext4 } mountpoint{ / }" >> /tmp/partitionfile
 echo "    ." >> /tmp/partitionfile
 echo "2048 512 300% linux-swap" >> /tmp/partitionfile
 echo "    method{ swap } format{ }" >> /tmp/partitionfile

--- a/xCAT/postscripts/setupscratch
+++ b/xCAT/postscripts/setupscratch
@@ -45,7 +45,7 @@ fi
 echo Creating Partition
 logger -t $log_label -p local4.info $ME Creating Partition
 parted -s /dev/sda mklabel gpt
-parted -s -- /dev/sda mkpart primary ext3 0 -0
+parted -s -- /dev/sda mkpart primary ext4 0 -0
 if grep sda1 /proc/partitions >/dev/null 2>&1
 then
 	sleep 5
@@ -58,8 +58,8 @@ else
 	exit 1
 fi
 
-echo Creating new ext3 filesystem: /dev/sda1
-logger -t $log_label -p local4.info $ME Creating new ext3 filesystem: /dev/sda1
+echo Creating new ext4 filesystem: /dev/sda1
+logger -t $log_label -p local4.info $ME Creating new ext4 filesystem: /dev/sda1
 mke2fs -j /dev/sda1
 mkdir -p $mydir
 echo mounting new /dev/sda1 to $mydir


### PR DESCRIPTION
### The PR is to fix issue _#6673_

Use ext4 instead of ext3 when formatting node partitions.
Includes doc changes.

Changes were not made for s390 or system Z files.