### PR TITLE
Testcase and packimage fixes for squashfs

### DIFF
--- a/xCAT-server/lib/xcat/plugins/packimage.pm
+++ b/xCAT-server/lib/xcat/plugins/packimage.pm
@@ -573,15 +573,13 @@ sub process_request {
         chmod 0644, "$destdir/rootimg.$suffix";
         umask $oldmask;
     } elsif ($method =~ /squashfs/) {
-        my $flags;
-        if ($arch =~ /x86/) {
-            $flags = "-le";
-        } elsif ($arch =~ /ppc/) {
-            $flags = "-be";
-        }
-
-        if (($osver =~ /rhels/ && $osver !~ /rhels5/) || ($osver =~ /centos/)) {
-            $flags = "";
+        my $flags = "";
+        if ($osver =~ /rhels5/) {
+            if ($arch =~ /x86/) {
+                $flags = "-le";
+            } elsif ($arch =~ /ppc/) {
+                $flags = "-be";
+            }
         }
 
         if (!-x "/sbin/mksquashfs" && !-x "/usr/bin/mksquashfs") {

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat
@@ -130,11 +130,14 @@ cmd:diff /tmp/mountoutput/file.org /tmp/mountoutput/file.new --ignore-matching-l
 check:rc==0
 cmd:rm -rf /tmp/mountoutput
 
+#Make sure squashfs-tools rpm is installed on RHEL
+cmd:if [ "$$OS" =~ "rhel" ];then yum install -y squashfs-tools; fi
+
 #Make sure squashfs-tools rpm is installed on Ubuntu
-cmd:if [ "$$OS" = "ubuntu" ];then apt-get install -y squashfs-tools; fi
+cmd:if [ "$$OS" =~ "ubuntu" ];then apt-get install -y squashfs-tools; fi
 
 #Make sure squashfs rpm is installed on SLES
-cmd:if [ "$$OS" = "sle" ];then zypper install -y squashfs; fi
+cmd:if [ "$$OS" =~ "sle" ];then zypper install -y squashfs; fi
 
 cmd:packimage -m squashfs __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
@@ -157,7 +160,7 @@ check:rc==0
 check:output=~\d\d:\d\d:\d\d
 cmd:xdsh $$CN mount
 check:rc==0
-check:output=~on / type tmpfs
+check:output=~on / type overlay
 cmd:xdsh $$CN cat /opt/xcat/xcatinfo
 check:rc==0
 check:output=~NODE=$$CN

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_hierarchy
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_hierarchy
@@ -153,11 +153,14 @@ cmd:lsdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netb
 cmd:genimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 
+#Make sure squashfs-tools rpm is installed on RHEL
+cmd:if [ "$$OS" =~ "rhel" ];then yum install -y squashfs-tools; fi
+
 #Make sure squashfs-tools rpm is installed on Ubuntu
-cmd:if [ "$$OS" = "ubuntu" ];then apt-get install -y squashfs-tools; fi
+cmd:if [ "$$OS" =~ "ubuntu" ];then apt-get install -y squashfs-tools; fi
 
 #Make sure squashfs rpm is installed on SLES
-cmd:if [ "$$OS" = "sle" ];then zypper install -y squashfs; fi
+cmd:if [ "$$OS" =~ "sle" ];then zypper install -y squashfs; fi
 
 cmd:packimage -m squashfs __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
@@ -185,7 +188,7 @@ check:rc==0
 check:output=~\d\d:\d\d:\d\d
 cmd:xdsh $$CN mount
 check:rc==0
-check:output=~on / type tmpfs
+check:output=~on / type overlay
 cmd:xdsh $$CN cat /opt/xcat/xcatinfo
 check:rc==0
 check:output=~NODE=$$CN


### PR DESCRIPTION
* The `-le` and `-be` flags are no longer supported by `mksquashfs`. Leave them only for RHEL5, just in case, everything else should have no flags.
* Fix `squashfs` testcases to install `squashfs-tools` for RH and to check correct output from `mount` command