### PR TITLE
Do not use modinfo to test module availability

### DIFF
--- a/xCAT-server/share/xcat/netboot/fedora/dracut_009/xcatroot
+++ b/xCAT-server/share/xcat/netboot/fedora/dracut_009/xcatroot
@@ -52,12 +52,11 @@ if [ -r /rootimg.sfs ]; then
   mkdir -p /rw
   mount -t squashfs /rootimg.sfs /ro
   mount -t tmpfs rw /rw
-  modinfo overlay
+  modprobe overlay
   if [ $? -eq 0 ]; then
       echo "Mounting $NEWROOT with type overlay"
       mkdir -p /rw/upper
       mkdir -p /rw/work
-      modprobe overlay
       mount -t overlay -o lowerdir=/ro,upperdir=/rw/upper,workdir=/rw/work mergedroot $NEWROOT
   else
       echo "Mounting $NEWROOT with type aufs"

--- a/xCAT-server/share/xcat/netboot/rh/dracut/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut/xcatroot
@@ -62,12 +62,11 @@ if [ -r /rootimg.sfs ]; then
   mkdir -p /rw
   mount -t squashfs /rootimg.sfs /ro
   mount -t tmpfs rw /rw
-  modinfo overlay
+  modprobe overlay
   if [ $? -eq 0 ]; then
       echo "Mounting $NEWROOT with type overlay"
       mkdir -p /rw/upper
       mkdir -p /rw/work
-      modprobe overlay
       mount -t overlay -o lowerdir=/ro,upperdir=/rw/upper,workdir=/rw/work mergedroot $NEWROOT
   else
       echo "Mounting $NEWROOT with type aufs"

--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/xcatroot
@@ -69,12 +69,11 @@ if [ -r /rootimg.sfs ]; then
     mkdir -p /rw
     mount -t squashfs /rootimg.sfs /ro
     mount -t tmpfs rw /rw
-    modinfo overlay
+    modprobe overlay
     if [ $? -eq 0 ]; then
         echo "Mounting $NEWROOT with type overlay"
         mkdir -p /rw/upper
         mkdir -p /rw/work
-        modprobe overlay
         mount -t overlay -o lowerdir=/ro,upperdir=/rw/upper,workdir=/rw/work mergedroot $NEWROOT
     else
         echo "Mounting $NEWROOT with type aufs"

--- a/xCAT-server/share/xcat/netboot/rh/dracut_047/xcatroot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_047/xcatroot
@@ -69,12 +69,11 @@ if [ -r /rootimg.sfs ]; then
     mkdir -p /rw
     mount -t squashfs /rootimg.sfs /ro
     mount -t tmpfs rw /rw
-    modinfo overlay
+    modprobe overlay
     if [ $? -eq 0 ]; then
         echo "Mounting $NEWROOT with type overlay"
         mkdir -p /rw/upper
         mkdir -p /rw/work
-        modprobe overlay
         mount -t overlay -o lowerdir=/ro,upperdir=/rw/upper,workdir=/rw/work mergedroot $NEWROOT
     else
         echo "Mounting $NEWROOT with type aufs"

--- a/xCAT-server/share/xcat/netboot/sles/dracut_033/xcatroot
+++ b/xCAT-server/share/xcat/netboot/sles/dracut_033/xcatroot
@@ -65,12 +65,11 @@ if [ -r /rootimg.sfs ]; then
   mkdir -p /rw
   mount -t squashfs /rootimg.sfs /ro
   mount -t tmpfs rw /rw
-  modinfo overlay
+  modprobe overlay
   if [ $? -eq 0 ]; then
       echo "Mounting $NEWROOT with type overlay"
       mkdir -p /rw/upper
       mkdir -p /rw/work
-      modprobe overlay
       mount -t overlay -o lowerdir=/ro,upperdir=/rw/upper,workdir=/rw/work mergedroot $NEWROOT
   else
       echo "Mounting $NEWROOT with type aufs"

--- a/xCAT-server/share/xcat/netboot/ubuntu/dracut/xcatroot
+++ b/xCAT-server/share/xcat/netboot/ubuntu/dracut/xcatroot
@@ -34,12 +34,11 @@ if [ -r /rootimg.sfs ]; then
   mkdir -p /rw
   mount -t squashfs /rootimg.sfs /ro
   mount -t tmpfs rw /rw
-  modinfo overlay
+  modprobe overlay
   if [ $? -eq 0 ]; then
       echo "Mounting $NEWROOT with type overlay"
       mkdir -p /rw/upper
       mkdir -p /rw/work
-      modprobe overlay
       mount -t overlay -o lowerdir=/ro,upperdir=/rw/upper,workdir=/rw/work mergedroot $NEWROOT
   else
       echo "Mounting $NEWROOT with type aufs"


### PR DESCRIPTION
Not all OSes have `modinfo` command to test if module is there (#6680).
Instead just use `modprobe` to attempt to load the module and check its return code.