### PR TITLE
Add output verification to kdump testcase

### DIFF
--- a/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
+++ b/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
@@ -91,6 +91,7 @@ check:rc==0
 
 # Verify that kdump directory from management node is still mounted on the compute node
 cmd:xdsh $$CN df -H
+check:output=~/opt/xcat/share/xcat/tools/autotest/kdumpdir
 
 # Verify kdump parameters are in /proc/cmdline file
 cmd:xdsh $$CN cat /proc/cmdline


### PR DESCRIPTION
`diskless_kdump` testcase still keeps failing sometimes.

Add output verification to the testcase to make sure the kdump directory is mounted after the node is provisioned.
