### PR TITLE
Added check for 'stable' flag via the command ${script} go-xcat --xcat-version=stable to install the latest version.

### DIFF
--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -1993,10 +1993,6 @@ do
 	"-x"|"--xcat-version")
 		shift
 		GO_XCAT_VERSION="$1"
-		if [ "${GO_XCAT_VERSION}" = "stable" ];
-                then
-                        GO_XCAT_VERSION="latest"
-                fi
 		;;
 	"--xcat-version="*)
 		GO_XCAT_VERSION="${1##--xcat-version=}"

--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -1993,9 +1993,17 @@ do
 	"-x"|"--xcat-version")
 		shift
 		GO_XCAT_VERSION="$1"
+		if [ "${GO_XCAT_VERSION}" = "stable" ];
+                then
+                        GO_XCAT_VERSION="latest"
+                fi
 		;;
 	"--xcat-version="*)
 		GO_XCAT_VERSION="${1##--xcat-version=}"
+		if [ "${GO_XCAT_VERSION}" = "stable" ];
+		then
+			GO_XCAT_VERSION="latest"
+		fi
 		;;
 	"-y"|"--yes")
 		GO_XCAT_YES=("-y")
@@ -2020,11 +2028,6 @@ do
 	esac
 	shift
 done
-
-if [[ ${GO_XCAT_VERSION} == "stable" ]]
-	then
-		${GO_XCAT_VERSION} = "latest"
-fi
 
 case "${GO_XCAT_ACTION}" in
 "away")

--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -1322,6 +1322,12 @@ function add_xcat_core_repo_yum_or_zypper()
 	local ver="$2"
 	local tmp=""
 	[[ -z "${ver}" ]] && ver="latest"
+
+	if [[ ${ver} == "stable" ]]
+	then
+		ver="latest"
+	fi
+
 	if [[ -z "${url}" ]]
 	then
 		case "${ver}" in
@@ -1348,6 +1354,12 @@ function add_xcat_core_repo_apt()
 	local ver="$2"
 	local tmp=""
 	[[ -z "${ver}" ]] && ver="latest"
+	
+	if [[ ${ver} == "stable" ]]
+	then
+		ver="latest"
+	fi
+
 	if [[ -z "${url}" ]]
 	then
 		# get the apt.key
@@ -1382,6 +1394,12 @@ function add_xcat_dep_repo_yum_or_zypper()
 	local url="$1"
 	local ver="$2"
 	[[ -z "${ver}" ]] && ver="latest"
+
+	if [[ ${ver} == "stable" ]]
+	then
+		ver="latest"
+	fi
+
 	local tmp=""
 	local install_path="${GO_XCAT_DEFAULT_INSTALL_PATH}"
 	local distro="${GO_XCAT_LINUX_DISTRO}${GO_XCAT_LINUX_VERSION%%.*}"
@@ -1450,6 +1468,12 @@ function add_xcat_dep_repo_apt()
 	local url="$1"
 	local ver="$2"
 	[[ -z "${ver}" ]] && ver="latest"
+
+	if [[ ${ver} == "stable" ]]
+	then
+		ver="latest"
+	fi
+
 	[[ -z "${url}" ]] &&
 		url="${GO_XCAT_DEFAULT_BASE_URL}/apt/${ver}/xcat-dep"
 	add_repo_by_url_apt "${url}" "xcat-dep"

--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -2,7 +2,7 @@
 #
 # go-xcat - Install xCAT automatically.
 #
-# Version 1.0.45
+# Version 1.0.46
 #
 # Copyright (C) 2016 - 2019 International Business Machines
 # Eclipse Public License, Version 1.0 (EPL-1.0)
@@ -29,7 +29,11 @@
 #     - Display a list of packages that could not be uninstalled
 # 2019-11-05 Mark Gurevich <gurevich@us.ibm.com>
 #     - Display a list of packages that will be installed before "Continue?"
+# 2020-5-7 Nic Mays <Nicolas.Mays@ibm.com>
+#	  - Handles 'stable' as a flag to install latest version via the command:
+#			go-xcat --xcat-version=stable install
 #
+
 
 function usage()
 {
@@ -72,6 +76,7 @@ function usage()
 	  ${script} --yes install
 	  ${script} -x 2.12 -y install
 	  ${script} --xcat-version=devel install
+	  ${script} --xcat-version=stable install
 	  ${script} --xcat-core=/path/to/xcat-core.tar.bz2 \\
 	          --xcat-dep=/path/to/xcat-dep.tar.bz2 install
 	  ${script} --xcat-core=http://xcat.org/path/to/xcat-core.tar.bz2 \\

--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -1322,6 +1322,8 @@ function add_xcat_core_repo_yum_or_zypper()
 	local ver="$2"
 	local tmp=""
 	[[ -z "${ver}" ]] && ver="latest"
+	
+	echo "\nim here!!!!!\n"
 
 	if [[ ${ver} == "stable" ]]
 	then
@@ -1355,6 +1357,8 @@ function add_xcat_core_repo_apt()
 	local tmp=""
 	[[ -z "${ver}" ]] && ver="latest"
 	
+	echo "\nim here2!!!!!\n"
+
 	if [[ ${ver} == "stable" ]]
 	then
 		ver="latest"
@@ -1394,6 +1398,8 @@ function add_xcat_dep_repo_yum_or_zypper()
 	local url="$1"
 	local ver="$2"
 	[[ -z "${ver}" ]] && ver="latest"
+
+	echo "\nim here3!!!!!\n"
 
 	if [[ ${ver} == "stable" ]]
 	then
@@ -1468,6 +1474,8 @@ function add_xcat_dep_repo_apt()
 	local url="$1"
 	local ver="$2"
 	[[ -z "${ver}" ]] && ver="latest"
+
+	echo "\nim here4!!!!!\n"
 
 	if [[ ${ver} == "stable" ]]
 	then

--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -1322,13 +1322,6 @@ function add_xcat_core_repo_yum_or_zypper()
 	local ver="$2"
 	local tmp=""
 	[[ -z "${ver}" ]] && ver="latest"
-	
-	echo "\nim here!!!!!\n"
-
-	if [[ ${ver} == "stable" ]]
-	then
-		ver="latest"
-	fi
 
 	if [[ -z "${url}" ]]
 	then
@@ -1356,13 +1349,6 @@ function add_xcat_core_repo_apt()
 	local ver="$2"
 	local tmp=""
 	[[ -z "${ver}" ]] && ver="latest"
-	
-	echo "\nim here2!!!!!\n"
-
-	if [[ ${ver} == "stable" ]]
-	then
-		ver="latest"
-	fi
 
 	if [[ -z "${url}" ]]
 	then
@@ -1398,13 +1384,6 @@ function add_xcat_dep_repo_yum_or_zypper()
 	local url="$1"
 	local ver="$2"
 	[[ -z "${ver}" ]] && ver="latest"
-
-	echo "\nim here3!!!!!\n"
-
-	if [[ ${ver} == "stable" ]]
-	then
-		ver="latest"
-	fi
 
 	local tmp=""
 	local install_path="${GO_XCAT_DEFAULT_INSTALL_PATH}"
@@ -1474,13 +1453,6 @@ function add_xcat_dep_repo_apt()
 	local url="$1"
 	local ver="$2"
 	[[ -z "${ver}" ]] && ver="latest"
-
-	echo "\nim here4!!!!!\n"
-
-	if [[ ${ver} == "stable" ]]
-	then
-		ver="latest"
-	fi
 
 	[[ -z "${url}" ]] &&
 		url="${GO_XCAT_DEFAULT_BASE_URL}/apt/${ver}/xcat-dep"
@@ -2048,6 +2020,11 @@ do
 	esac
 	shift
 done
+
+if [[ ${GO_XCAT_VERSION} == "stable" ]]
+	then
+		${GO_XCAT_VERSION} = "latest"
+fi
 
 case "${GO_XCAT_ACTION}" in
 "away")


### PR DESCRIPTION
### The PR is to fix issue 6349
[Link to the issue](https://github.com/xcat2/xcat-core/issues/6349)

### The modification includes:

- editing of go-xcat to handle the command `go-xcat --xcat-version=stable install` and treat it as downloading the latest version.