### PR TITLE
Remove ldd messages from ubuntu genimage command

### DIFF
--- a/xCAT-server/share/xcat/netboot/ubuntu/genimage
+++ b/xCAT-server/share/xcat/netboot/ubuntu/genimage
@@ -889,6 +889,11 @@ sub getlibs {
     my @libs    = split /\n/, $liblist;
     my @return;
     foreach (@libs) {
+	# vdso is a shared library that's embedded in the kernel 
+	# automatically loaded whenever a new process is exec-ed
+	if ( $_ =~ /linux-vdso64/ ) {
+	    next;
+	}
         if (/statically linked/ or /not a dynamic executable/) {
             return;
         }
@@ -1152,7 +1157,6 @@ PATH="\$PATH:/usr/sbin:/sbin"
 export PATH
 
 echo "Creating device nodes with udev"
-/sbin/udevd --daemon
 if [ -f "/sbin/udevadm" ]
 then
     /sbin/udevadm trigger
@@ -1648,7 +1652,7 @@ EOMS
     }
 
     # add extra commands for initrd
-    foreach ("usr/bin/dig", "bin/busybox", "bin/bash", "sbin/mount.nfs", "usr/bin/rsync", "sbin/insmod", "sbin/udevd", "sbin/udevadm", "sbin/modprobe", "sbin/blkid", "sbin/depmod", "usr/bin/wget", "usr/bin/xz", "bin/gzip", "bin/tar") {
+    foreach ("usr/bin/dig", "bin/busybox", "bin/bash", "sbin/mount.nfs", "usr/bin/rsync", "sbin/insmod", "sbin/udevadm", "sbin/modprobe", "sbin/blkid", "sbin/depmod", "usr/bin/wget", "usr/bin/xz", "bin/gzip", "bin/tar") {
         getlibs($_);
         push @filestoadd, $_;
     }


### PR DESCRIPTION
`genimage` output for ubuntu 18.04 diskless  showed a lot of ldd messages:
```
ldd: ./linux-vdso64.so.1: No such file or directory
```
`linux-vdso64.so` is a shared library that's embedded in the kernel and it automatically loaded whenever a new process is exec-ed.   so it's safe to not checking `ldd` for this libs.
