### PR TITLE
Remove squashfs testcases from Ubuntu regression bundles

### DIFF
--- a/xCAT-test/autotest/bundle/ubuntu_ppcle_daily.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu_ppcle_daily.bundle
@@ -1,5 +1,4 @@
 reg_linux_diskless_installation_flat
-reg_linux_diskless_installation_flat_squashfs
 reg_linux_diskfull_installation_flat
 assign_certain_command_permission
 bmcdiscover_help

--- a/xCAT-test/autotest/bundle/ubuntu_x86_daily.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu_x86_daily.bundle
@@ -1,5 +1,4 @@
 reg_linux_diskless_installation_flat
-reg_linux_diskless_installation_flat_squashfs
 reg_linux_diskfull_installation_flat
 assign_certain_command_permission
 bmcdiscover_help


### PR DESCRIPTION
Remove squashfs testcases from Ubuntu regression.
Somehow on Ubuntu the loading to `overlay` module with `modprobe overlay` command fails.