### PR TITLE
Remove duplicates: post_host from restapi/service/cases0 and lskitcom…

### DIFF
--- a/xCAT-test/autotest/testcase/lskitcomp/case0
+++ b/xCAT-test/autotest/testcase/lskitcomp/case0
@@ -55,38 +55,6 @@ cmd:rm -f /opt/xcat/share/xcat/tools/autotest/testcase/lskitcomp/mykits/mykits-1
 cmd:rm -rf /opt/xcat/share/xcat/tools/autotest/testcase/lskitcomp/mykits
 end
 
-start:lskitcomp_C
-label:others,KIT
-os:Linux
-cmd:rm -rf /opt/xcat/share/xcat/tools/autotest/testcase/lskitcomp/mykits
-cmd:cd /opt/xcat/share/xcat/tools/autotest/testcase/lskitcomp;buildkit create mykits
-check:rc==0
-check:output=~Kit template for mykits created in /opt/xcat/share/xcat/tools/autotest/testcase/lskitcomp/mykits directory
-cmd:cd /opt/xcat/share/xcat/tools/autotest/testcase/lskitcomp/mykits;buildkit buildrepo all
-check:rc==0
-cmd:cd /opt/xcat/share/xcat/tools/autotest/testcase/lskitcomp/mykits;buildkit buildtar
-check:rc==0
-cmd:addkit /opt/xcat/share/xcat/tools/autotest/testcase/lskitcomp/mykits/mykits-1.0-1.tar.bz2
-check:rc==0
-cmd:compname=`lskit mykits-1.0-1 |grep kitcompname|awk -F= '{print $2}'`;lskitcomp -C basename $compname
-check:rc==0
-check:output=~basename
-cmd:compname=`lskit mykits-1.0-1 |grep kitcompname|awk -F= '{print $2}'`;lskitcomp -C kitcompname $compname
-check:output=~kitcompname
-check:rc==0
-cmd:compname=`lskit mykits-1.0-1 |grep kitcompname|awk -F= '{print $2}'`;lskitcomp -C kitreponame $compname
-check:rc==0
-check:output=~kitreponame
-cmd:compname=`lskit mykits-1.0-1 |grep kitcompname|awk -F= '{print $2}'`;lskitcomp -C serverroles $compname
-check:rc==0
-check:output=~serverroles
-cmd:rmkit mykits-1.0-1
-check:rc==0
-cmd:rm -f /opt/xcat/share/xcat/tools/autotest/testcase/lskitcomp/mykits/mykits-1.0-1.tar.bz2
-cmd:rm -rf /opt/xcat/share/xcat/tools/autotest/testcase/lskitcomp/mykits
-end
-
-
 start:lskitcomp_S
 label:others,KIT
 os:Linux

--- a/xCAT-test/autotest/testcase/restapi/service/cases0
+++ b/xCAT-test/autotest/testcase/restapi/service/cases0
@@ -19,13 +19,6 @@ cmd:restapitest -m POST -r /services/host
 check:rc==201
 end
 
-start:post_host
-description: post_host
-label:others,restapi
-cmd:restapitest -m POST -r /services/host
-check:rc==201
-end
-
 start:get_slpnodes
 description: get_slpnodes
 label:others,restapi


### PR DESCRIPTION
…p_C gfrom liskitcomp/case0. It turns out many duplicates identified earlier actually have different OSes, so they are left unchanged.

There is no issue associated with it. This is basically a cleanup job.