### PR TITLE
Spec file fix for XML::LibXML

### DIFF
--- a/xCAT-server/xCAT-server.spec
+++ b/xCAT-server/xCAT-server.spec
@@ -37,7 +37,7 @@ BuildArch: noarch
 %if %s390x
 Requires: perl-IO-Socket-SSL perl-XML-Simple perl-XML-Parser
 %else
-Requires: perl-IO-Socket-SSL perl-XML-Simple perl-XML-Parser perl-Digest-SHA1 perl(LWP::Protocol::https) perl-XML-LibXML-Simple
+Requires: perl-IO-Socket-SSL perl-XML-Simple perl-XML-Parser perl-Digest-SHA1 perl(LWP::Protocol::https) perl-XML-LibXML
 %endif
 Obsoletes: atftp-xcat
 %endif


### PR DESCRIPTION
Fixing error from #6688 

The correct package name is `perl-XML-LibXML`

```
[root@c910f03c09k15 /]# yum info perl-XML-LibXML
Updating Subscription Management repositories.
Unable to read consumer identity
This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.
Last metadata expiration check: 0:14:47 ago on Mon 11 May 2020 09:15:51 AM EDT.
Installed Packages
Name         : perl-XML-LibXML
Epoch        : 1
Version      : 2.0132
Release      : 2.el8
Architecture : ppc64le
Size         : 1.1 M
Source       : perl-XML-LibXML-2.0132-2.el8.src.rpm
Repository   : @System
From repo    : local-rhels8.1.0-ppc64le--install-shared_repo-ISOs-rhels8.1.0-ppc64le-AppStream
Summary      : Perl interface to the libxml2 library
URL          : http://search.cpan.org/dist/XML-LibXML/
License      : (GPL+ or Artistic) and MIT
Description  : This module implements a Perl interface to the GNOME libxml2
             : library which provides interfaces for parsing and manipulating
             : XML files. This module allows Perl programmers to make use of the
             : highly capable validating XML parser and the high performance DOM
             : implementation.

```