### PR TITLE
Multiple nicutils.sh fixes

### DIFF
--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -2246,6 +2246,10 @@ function create_bond_interface_nmcli {
             $ip link set dev $ifslave down 
             wait_for_ifstate $ifslave DOWN 20 2
         fi
+        # InfiniBand slaves should have no MTU defined, only the bond interface
+        if [ "$slave_type" = "Infiniband" ]; then
+            _mtu=""
+        fi
         cmd="$nmcli con add type $slave_type con-name $xcat_slave_con $_mtu ifname $ifslave master $xcat_con_name slave-type bond autoconnect yes connection.autoconnect-priority 9 connection.autoconnect-retries 0"
         log_info $cmd
         $cmd

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -2135,7 +2135,7 @@ function create_bond_interface_nmcli {
     else
         _bonding_opts="mode=active-backup"
     fi
-    if [ -z "$next_nic" ]; then
+    if [ -n "$_ipaddr" ]; then
         # query "nicnetworks" table about its target "xcatnet"
         xcatnet=$(query_nicnetworks_net $bondname)
         log_info "Pickup xcatnet, \"$xcatnet\", from NICNETWORKS for interface \"$bondname\"."
@@ -2198,7 +2198,7 @@ function create_bond_interface_nmcli {
     # create raw bond device
     log_info "create bond connection $xcat_con_name"
     cmd=""
-    if [ -n "$next_nic" ]; then
+    if [ -z "$_ipaddr" ]; then
         cmd="$nmcli con add type bond con-name $xcat_con_name ifname $bondname bond.options $_bonding_opts ipv4.method disabled ipv6.method ignore autoconnect yes connection.autoconnect-priority 9 connection.autoconnect-slaves 1 connection.autoconnect-retries 0"
     else
         cmd="$nmcli con add type bond con-name $xcat_con_name ifname $bondname bond.options $_bonding_opts method none ipv4.method manual ipv4.addresses $ipv4_addr/$str_prefix $_mtu connection.autoconnect-priority 9 connection.autoconnect-slaves 1 connection.autoconnect-retries 0"
@@ -2286,7 +2286,7 @@ function create_bond_interface_nmcli {
         # bring up interface formally
         log_info "$nmcli con up $xcat_con_name"
         $nmcli con up $xcat_con_name
-        if [ -z "$next_nic" ]; then
+        if [ -n "$_ipaddr" ]; then
             is_connection_activate_intime $xcat_con_name
             is_active=$?
             if [ "$is_active" -eq 0 ]; then

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -289,6 +289,10 @@ function load_kmod {
 #
 #################################################################
 function query_extra_params {
+    # reset global variables
+    unset array_nic_params
+    unset array_extra_param_names
+    unset array_extra_param_values
 
     nic=$1
     if [ -z "$nic" ]; then
@@ -479,9 +483,6 @@ function create_persistent_ifcfg {
     local _netmask=""
     local _mtu=""
     local inattrs=""
-    unset array_nic_params
-    unset array_extra_param_names
-    unset array_extra_param_values
 
     # parser input arguments
     while [ -n "$1" ];


### PR DESCRIPTION
## The PR fixes multiple nicutils.sh issues

### Properly reset nic extra params 598a75fb8643394a07f6ff143e6b7e3a12d41d76
The global variables were not reset for bonds.
Therefore, the nic extra params from the first bond interface were used if the second one had no nic extra params.

### Configure bond IP even if there is a `$next_nic` but also `$_ipaddr`  097bf969d418c5e6bdf9e2bf412ad9dfac6cc0e8
Check for `$_ipaddr` instead of `$next_nic`.
The followint configuration is totally valid but fails with the old logic because it does not configure any bond0 IP because `$next_nic` is set to bond0.10.

```
nictypes.eno1=Ethernet
nictypes.eno2=Ethernet
nicdevices.bond0=eno1|eno2
nictypes.bond0=bond
nicnetworks.bond0=management
nicips.bond0=192.168.0.1
nicdevices.bond0.10=bond0
nictypes.bond0.10=vlan
nicnetworks.bond0.10=production
nicips.bond0.10=192.168.1.1
```

**May needs some additional testing with bridges etc! I don't have time to test all this sorry :/**

### Do not set MTU for InfiniBand slaves a274097b341b09d8356762317bace48e1f2024ae
Slaves should have no MTU set. This should be set globally on the bond interface.
Furthermore, RHEL 8.0 does not correctly set the given MTU as shown below.
This breaks any IB bonds with non-default (2044) MTU.

```
$ # IB slave with 4092 MTU
$ nmcli con add type Infiniband con-name slave-ib1-mtu mtu 4092 ifname ib1 master ibbond0 slave-type bond
$ # IB slave without MTU
$ nmcli con add type Infiniband con-name slave-ib1-wo-mtu ifname ib1 master ibbond0 slave-type bond

$ # should be 4092, but is 2044 instead
$ nmcli -f infiniband.mtu con show slave-ib1-mtu
infiniband.mtu:                         2044

$ grep MTU /etc/sysconfig/network-scripts/ifcfg-slave-ib1-*
/etc/sysconfig/network-scripts/ifcfg-slave-ib1-mtu:MTU=2044

$ # is auto :)
$ nmcli -f infiniband.mtu con show slave-ib1-wo-mtu
infiniband.mtu:                         auto
```

Please do some additional testing, especially with 097bf969d418c5e6bdf9e2bf412ad9dfac6cc0e8. This just includes some fixes I had to do but I didn't test all different configurations. It might break something else.