### PR TITLE
Speedup execution of go-xcat testcases

### DIFF
--- a/xCAT-test/autotest/testcase/go_xcat/case3
+++ b/xCAT-test/autotest/testcase/go_xcat/case3
@@ -2,11 +2,10 @@ start:go_xcat_devel_from_repo
 description:test go-xcat devel on a newly provisioned node
 label:go_xcat
 os:Linux
-#Make sure service node is not off, if it is, power it on
-cmd:if rpower $$SN stat | grep "off"; then rpower $$SN on; echo "Service node was off, powering on, waiting for 5 min"; sleep 300; fi
 
-#Service not did not boot after 5 min, reprovision it if not on Ubuntu
-cmd:if lsdef $$SN -i status -c | grep -v "booted"; then if grep Ubuntu /etc/*release; then echo "Will not attempt to reprovision service node on Ubuntu"; else echo "Service node did not power on, trying to reprovision"; /opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$SN __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-install-service 2; fi; fi
+#Remove compute node reference to service node
+cmd:chdef -t node -o $$CN servicenode= monserver=$$MN nfsserver=$$MN tftpserver=$$MN xcatmaster=$$MN
+check:rc==0
 
 #Provision compute node
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute 2
@@ -47,11 +46,10 @@ start:go_xcat_stable_from_repo
 description:test go-xcat GA on a newly provisioned node
 label:go_xcat
 os:Linux
-#Make sure service node is not off, if it is, power it on
-cmd:if rpower $$SN stat | grep "off"; then rpower $$SN on; echo "Service node was off, powering on, waiting for 5 min"; sleep 300; fi
 
-#Service not did not boot after 5 min, reprovision it if not on Ubuntu
-cmd:if lsdef $$SN -i status -c | grep -v "booted"; then if grep Ubuntu /etc/*release; then echo "Will not attempt to reprovision service node on Ubuntu"; else echo "Service node did not power on, trying to reprovision"; /opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$SN __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-install-service 2; fi; fi
+#Remove compute node reference to service node
+cmd:chdef -t node -o $$CN servicenode= monserver=$$MN nfsserver=$$MN tftpserver=$$MN xcatmaster=$$MN
+check:rc==0
 
 #Provision compute node
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute 2
@@ -92,11 +90,10 @@ start:go_xcat_stable_from_repo_upgrade
 description:test go-xcat GA on a newly provisioned node upgrade to devel
 label:go_xcat
 os:Linux
-#Make sure service node is not off, if it is, power it on
-cmd:if rpower $$SN stat | grep "off"; then rpower $$SN on; echo "Service node was off, powering on, waiting for 5 min"; sleep 300; fi
 
-#Service not did not boot after 5 min, reprovision it if not on Ubuntu
-cmd:if lsdef $$SN -i status -c | grep -v "booted"; then if grep Ubuntu /etc/*release; then echo "Will not attempt to reprovision service node on Ubuntu"; else echo "Service node did not power on, trying to reprovision"; /opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$SN __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-install-service 2; fi; fi
+#Remove compute node reference to service node
+cmd:chdef -t node -o $$CN servicenode= monserver=$$MN nfsserver=$$MN tftpserver=$$MN xcatmaster=$$MN
+check:rc==0
 
 #Provision compute node
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute 2
@@ -147,11 +144,10 @@ start:go_xcat_stable_from_repo_reinstall_devel
 description:test go-xcat GA on a newly provisioned node, remove, install devel
 label:go_xcat
 os:Linux
-#Make sure service node is not off, if it is, power it on
-cmd:if rpower $$SN stat | grep "off"; then rpower $$SN on; echo "Service node was off, powering on, waiting for 5 min"; sleep 300; fi
 
-#Service not did not boot after 5 min, reprovision it if not on Ubuntu
-cmd:if lsdef $$SN -i status -c | grep -v "booted"; then if grep Ubuntu /etc/*release; then echo "Will not attempt to reprovision service node on Ubuntu"; else echo "Service node did not power on, trying to reprovision"; /opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$SN __GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-install-service 2; fi; fi
+#Remove compute node reference to service node
+cmd:chdef -t node -o $$CN servicenode= monserver=$$MN nfsserver=$$MN tftpserver=$$MN xcatmaster=$$MN
+check:rc==0
 
 #Provision compute node
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute 2


### PR DESCRIPTION
Speedup `go-xcat` testcases by removing the need to wait for service node to boot up. Instead, just run `go-xcat` testcases in non-hierarchy environment by removing service node reference from compute node.