### PR TITLE
test: confignetwork: update regexp to fix IP matching

### DIFF
--- a/xCAT-test/autotest/testcase/confignetwork/cases0
+++ b/xCAT-test/autotest/testcase/confignetwork/cases0
@@ -166,20 +166,20 @@ cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network/ifcf
 check:rc==0
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=100.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test1 net=$secondnet mask=255.255.0.0 mgtifname=$$SECONDNIC
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$SECONDNIC=$second1ip nictypes.$$SECONDNIC=Ethernet nicnetworks.$$SECONDNIC=confignetworks_test1
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$SECONDNIC=$second1ip nictypes.$$SECONDNIC=Ethernet nicnetworks.$$SECONDNIC=confignetworks_test1
 check:rc==0
 cmd:updatenode $$CN -P "confignetwork -s"
 check:rc==0
 cmd:rmdef -t network -o confignetworks_test1
 cmd:if [ -e /tmp/CN.standa ]; then rmdef $$CN; cat /tmp/CN.standa | mkdef -z; rm -rf /tmp/CN.standa; fi
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;if grep SUSE /etc/*release;then xdsh $$CN "grep $second1ip /etc/sysconfig/network/ifcfg-$$SECONDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $second1ip /etc/sysconfig/network-scripts/ifcfg-*$$SECONDNIC*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $second1ip /etc/network/interfaces.d/$$SECONDNIC";else echo "Sorry,this is not supported os"; fi
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;if grep SUSE /etc/*release;then xdsh $$CN "grep $second1ip /etc/sysconfig/network/ifcfg-$$SECONDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $second1ip /etc/sysconfig/network-scripts/ifcfg-*$$SECONDNIC*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $second1ip /etc/network/interfaces.d/$$SECONDNIC";else echo "Sorry,this is not supported os"; fi
 check:rc==0
 cmd:installnic=`xdsh $$CN ip addr |grep __GETNODEATTR($$CN,ip)__|awk -F " " '{print $NF}'`; if grep SUSE /etc/*release;then xdsh $$CN "cat /etc/sysconfig/network/ifcfg-$installnic"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "cat /etc/sysconfig/network-scripts/ifcfg-*$installnic*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cat /etc/network/interfaces.d/*";else echo "Sorry,this is not supported os"; fi
 check:rc==0
 check:output=~__GETNODEATTR($$CN,ip)__
 check:output=~BOOTPROTO=none|static
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;xdsh $$CN "ip addr del $second1ip/16 dev $$SECONDNIC"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;xdsh $$CN "ip addr del $second1ip/16 dev $$SECONDNIC"
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifcfg-$$SECONDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts"; elif grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /etc/network/interfaces.d/$$SECONDNIC";else echo "Sorry,this is not supported os"; fi
 check:rc==0
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/sysconfig/network/"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "cp -rf /tmp/backupnet/network-scripts /etc/sysconfig/"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cp -f /tmp/backupnet/* /etc/network/interfaces.d/;cp -f /tmp/interfaces /etc/network/";else echo "Sorry,this is not supported os"; fi
@@ -278,7 +278,7 @@ cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=100.;var4=`echo $cnip |awk -F.
 check:rc==0
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=101.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test2 net=$secondnet mask=255.255.0.0 mgtifname=$$SECONDNIC
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=101;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var3;second2ip=$var2$var3;chdef $$CN nicips.$$SECONDNIC="$second1ip|$second2ip" nictypes.$$SECONDNIC=Ethernet nicnetworks.$$SECONDNIC="confignetworks_test1|confignetworks_test2" nichostnamesuffixes.$$SECONDNIC="-$$SECONDNIC-1|-$$SECONDNIC-2" nicextraparams.$$SECONDNIC="CONNECTED_MODE=yes"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=101;var3=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var3;second2ip=$var2$var3;chdef $$CN nicips.$$SECONDNIC="$second1ip|$second2ip" nictypes.$$SECONDNIC=Ethernet nicnetworks.$$SECONDNIC="confignetworks_test1|confignetworks_test2" nichostnamesuffixes.$$SECONDNIC="-$$SECONDNIC-1|-$$SECONDNIC-2" nicextraparams.$$SECONDNIC="CONNECTED_MODE=yes"
 check:rc==0
 cmd:makehosts $$CN
 check:rc==0
@@ -287,12 +287,12 @@ check:output=~$$CN-$$SECONDNIC-1
 check:output=~$$CN-$$SECONDNIC-2
 cmd:updatenode $$CN -P confignetwork
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var3;if grep SUSE /etc/*release;then xdsh $$CN "grep $second1ip /etc/sysconfig/network/ifcfg-$$SECONDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $second1ip /etc/sysconfig/network-scripts/ifcfg-*$$SECONDNIC*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $second1ip /etc/network/interfaces.d/$$SECONDNIC";else echo "Sorry,this is not supported os"; fi
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var3=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var3;if grep SUSE /etc/*release;then xdsh $$CN "grep $second1ip /etc/sysconfig/network/ifcfg-$$SECONDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $second1ip /etc/sysconfig/network-scripts/ifcfg-*$$SECONDNIC*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $second1ip /etc/network/interfaces.d/$$SECONDNIC";else echo "Sorry,this is not supported os"; fi
 check:rc==0
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "cat /etc/sysconfig/network/ifcfg-$$SECONDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "cat /etc/sysconfig/network-scripts/ifcfg-*$$SECONDNIC*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cat /etc/network/interfaces.d/$$SECONDNIC";else echo "Sorry,this is not supported os"; fi
 check:output=~BOOTPROTO=none|static
 check:output=~CONNECTED_MODE=yes|CONNECTED_MODE yes
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var3;if grep SUSE /etc/*release;then xdsh $$CN "grep $second1ip /etc/sysconfig/network/ifcfg-$$SECONDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $second1ip /etc/sysconfig/network-scripts/ifcfg-*$$SECONDNIC*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $second1ip /etc/network/interfaces.d/$$SECONDNIC";else echo "Sorry,this is not supported os"; fi
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var3=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var3;if grep SUSE /etc/*release;then xdsh $$CN "grep $second1ip /etc/sysconfig/network/ifcfg-$$SECONDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $second1ip /etc/sysconfig/network-scripts/ifcfg-*$$SECONDNIC*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $second1ip /etc/network/interfaces.d/$$SECONDNIC";else echo "Sorry,this is not supported os"; fi
 check:rc==0
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "cat /etc/sysconfig/network/ifcfg-$$SECONDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "cat /etc/sysconfig/network-scripts/ifcfg-*$$SECONDNIC*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "cat /etc/network/interfaces.d/$$SECONDNIC";else echo "Sorry,this is not supported os"; fi
 check:output=~CONNECTED_MODE=yes|CONNECTED_MODE yes
@@ -301,8 +301,8 @@ cmd:rmdef -t network -o confignetworks_test1
 cmd:rmdef -t network -o confignetworks_test2
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifcfg-$$SECONDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts"; elif grep Ubuntu /etc/*release;then xdsh $$CN "rm -f /etc/network/interfaces.d/$$SECONDNIC /etc/network/interfaces.d/$$SECONDNIC:1";else echo "Sorry,this is not supported os"; fi
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;xdsh $$CN "ip addr del $second1ip/16 dev $$SECONDNIC"
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;xdsh $$CN "ip addr del $second1ip/16 dev $$SECONDNIC"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;xdsh $$CN "ip addr del $second1ip/16 dev $$SECONDNIC"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;xdsh $$CN "ip addr del $second1ip/16 dev $$SECONDNIC"
 cmd:if [ -e /tmp/CN.standa ]; then rmdef $$CN; cat /tmp/CN.standa | mkdef -z; rm -rf /tmp/CN.standa; fi
 check:rc==0
 cmd:mv -f /etc/hosts.bak /etc/hosts
@@ -512,7 +512,7 @@ check:rc==0
 cmd:xdsh $$CN "if grep SUSE /etc/*release;then cp -f /etc/sysconfig/network/ifcfg-* /tmp/backupnet/; elif grep -E \"Red Hat|CentOS\" /etc/*release;then cp -f /etc/sysconfig/network-scripts/ifcfg-* /tmp/backupnet/; elif grep Ubuntu /etc/*release;then cp -f /etc/network/interfaces.d/* /tmp/backupnet/;else echo \"Sorry,this is not supported os\"; fi"
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=100.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test1 net=$secondnet mask=255.255.0.0 mgtifname=$$SECONDNIC
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$SECONDNIC=$second1ip nictypes.$$SECONDNIC=Ethernet nicnetworks.$$SECONDNIC=confignetworks_test1
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$SECONDNIC=$second1ip nictypes.$$SECONDNIC=Ethernet nicnetworks.$$SECONDNIC=confignetworks_test1
 check:rc==0
 cmd:updatenode $$CN -P confignetwork
 check:rc==0
@@ -522,28 +522,28 @@ cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=105.;var4=`echo $cnip |awk -F.
 check:rc==0
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=106.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test7 net=$secondnet mask=255.255.0.0 mgtifname=$$SECONDNIC
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;xdsh $$CN "if grep SUSE /etc/*release;then grep $second1ip /etc/sysconfig/network/ifcfg-$$SECONDNIC; elif grep -E \"Red Hat|CentOS\" /etc/*release;then grep $second1ip /etc/sysconfig/network-scripts/ifcfg-*$$SECONDNIC*; elif grep Ubuntu /etc/*release;then grep $second1ip /etc/network/interfaces.d/$$SECONDNIC;else echo \"Sorry,this is not supported os\"; fi"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;xdsh $$CN "if grep SUSE /etc/*release;then grep $second1ip /etc/sysconfig/network/ifcfg-$$SECONDNIC; elif grep -E \"Red Hat|CentOS\" /etc/*release;then grep $second1ip /etc/sysconfig/network-scripts/ifcfg-*$$SECONDNIC*; elif grep Ubuntu /etc/*release;then grep $second1ip /etc/network/interfaces.d/$$SECONDNIC;else echo \"Sorry,this is not supported os\"; fi"
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=105;var2=106;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second6ip=$var1$var3;second7ip=$var2$var3;chdef $$CN nicnetworks.$$SECONDNIC.6=confignetworks_test6 nicnetworks.$$SECONDNIC.7=confignetworks_test7 nictypes.$$SECONDNIC.6=vlan nictypes.$$SECONDNIC.7=vlan nicips.$$SECONDNIC.6=$second6ip nicips.$$SECONDNIC.7=$second7ip nicdevices.$$SECONDNIC.6=$$SECONDNIC nicdevices.$$SECONDNIC.7=$$SECONDNIC nictypes.$$SECONDNIC=ethernet
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=105;var2=106;var3=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second6ip=$var1$var3;second7ip=$var2$var3;chdef $$CN nicnetworks.$$SECONDNIC.6=confignetworks_test6 nicnetworks.$$SECONDNIC.7=confignetworks_test7 nictypes.$$SECONDNIC.6=vlan nictypes.$$SECONDNIC.7=vlan nicips.$$SECONDNIC.6=$second6ip nicips.$$SECONDNIC.7=$second7ip nicdevices.$$SECONDNIC.6=$$SECONDNIC nicdevices.$$SECONDNIC.7=$$SECONDNIC nictypes.$$SECONDNIC=ethernet
 check:rc==0
 cmd:updatenode $$CN -P confignetwork
 check:rc==0
 cmd:if [ -e /tmp/CN.standa ]; then rmdef $$CN; cat /tmp/CN.standa | mkdef -z; rm -rf /tmp/CN.standa; fi
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=105;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second6ip=$var1$var3; echo $second6ip; xdsh $$CN "if grep SUSE /etc/*release;then grep $second6ip /etc/sysconfig/network/ifcfg-$$SECONDNIC.6;elif grep -E \"Red Hat|CentOS\" /etc/*release;then grep $second6ip /etc/sysconfig/network-scripts/ifcfg-*$$SECONDNIC.6*; elif grep Ubuntu /etc/*release;then grep $second6ip /etc/network/interfaces.d/$$SECONDNIC.6;else echo \"Sorry,this is not supported os\"; fi"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=105;var3=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second6ip=$var1$var3; echo $second6ip; xdsh $$CN "if grep SUSE /etc/*release;then grep $second6ip /etc/sysconfig/network/ifcfg-$$SECONDNIC.6;elif grep -E \"Red Hat|CentOS\" /etc/*release;then grep $second6ip /etc/sysconfig/network-scripts/ifcfg-*$$SECONDNIC.6*; elif grep Ubuntu /etc/*release;then grep $second6ip /etc/network/interfaces.d/$$SECONDNIC.6;else echo \"Sorry,this is not supported os\"; fi"
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var2=106;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second7ip=$var2$var3; echo $second6ip; xdsh $$CN "if grep SUSE /etc/*release;then grep $second7ip /etc/sysconfig/network/ifcfg-$$SECONDNIC.7; elif grep -E \"Red Hat|CentOS\" /etc/*release;then grep $second7ip /etc/sysconfig/network-scripts/ifcfg-*$$SECONDNIC.7*; elif grep Ubuntu /etc/*release;then grep $second7ip /etc/network/interfaces.d/$$SECONDNIC.7;else echo \"Sorry,this is not supported os\"; fi"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var2=106;var3=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second7ip=$var2$var3; echo $second6ip; xdsh $$CN "if grep SUSE /etc/*release;then grep $second7ip /etc/sysconfig/network/ifcfg-$$SECONDNIC.7; elif grep -E \"Red Hat|CentOS\" /etc/*release;then grep $second7ip /etc/sysconfig/network-scripts/ifcfg-*$$SECONDNIC.7*; elif grep Ubuntu /etc/*release;then grep $second7ip /etc/network/interfaces.d/$$SECONDNIC.7;else echo \"Sorry,this is not supported os\"; fi"
 check:rc==0
 cmd:xdsh $$CN "if grep SUSE /etc/*release;then rm -rf /etc/sysconfig/network/ifcfg-$$SECONDNIC; elif grep -E \"Red Hat|CentOS\" /etc/*release;then rm -rf /etc/sysconfig/network-scripts/ifcfg-$$SECONDNIC*; elif grep Ubuntu /etc/*release;then rm -rf /etc/network/interfaces.d/$$SECONDNIC;else echo \"Sorry,this is not supported os\"; fi"
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=105;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second6ip=$var1$var3;xdsh $$CN "ip addr del $second6ip/8 dev $$SECONDNIC.6"
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var2=106;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second7ip=$var2$var3;xdsh $$CN "ip addr del $second7ip/8 dev $$SECONDNIC.7"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=105;var3=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second6ip=$var1$var3;xdsh $$CN "ip addr del $second6ip/8 dev $$SECONDNIC.6"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var2=106;var3=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second7ip=$var2$var3;xdsh $$CN "ip addr del $second7ip/8 dev $$SECONDNIC.7"
 cmd:rmdef -t network -o confignetworks_test1
 cmd:rmdef -t network -o confignetworks_test6
 cmd:rmdef -t network -o confignetworks_test7
 cmd:xdsh $$CN "ip link del dev $$SECONDNIC.6"
 cmd:xdsh $$CN "ip link del dev $$SECONDNIC.7"
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;xdsh $$CN "ip addr del $second1ip/16 dev $$SECONDNIC"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;xdsh $$CN "ip addr del $second1ip/16 dev $$SECONDNIC"
 cmd:xdsh $$CN "if grep SUSE /etc/*release;then rm -rf /etc/sysconfig/network/ifcfg-$$SECONDNIC.6 /etc/sysconfig/network/ifcfg-$$SECONDNIC.7; elif grep -E \"Red Hat|CentOS\" /etc/*release;then rm -rf /etc/sysconfig/network-scripts/ifcfg-*$$SECONDNIC.6 /etc/sysconfig/network-scripts/ifcfg-*$$SECONDNIC.7; elif grep Ubuntu /etc/*release;then rm -rf /etc/network/interfaces.d/$$SECONDNIC.6 /etc/network/interfaces.d/$$SECONDNIC.7;else echo \"Sorry,this is not supported os\"; fi"
 check:rc==0
 cmd:xdsh $$CN "if grep SUSE /etc/*release;then cp -f /tmp/backupnet/* /etc/sysconfig/network/; elif grep -E \"Red Hat .* 8.*|CentOS .* 8.*\" /etc/*release; then cp -f /tmp/backupnet/* /etc/sysconfig/network-scripts/; nmcli con reload;elif grep -E \"Red Hat|CentOS\" /etc/*release;then cp -f /tmp/backupnet/* /etc/sysconfig/network-scripts/; elif grep Ubuntu /etc/*release;then cp -f /tmp/backupnet/* /etc/network/interfaces.d/;cp -f /tmp/interfaces /etc/network/;else echo \"Sorry,this is not supported os\"; fi"
@@ -610,11 +610,11 @@ cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network/ifcf
 cmd:if grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "yum -y install bridge-utils";fi
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=100.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test1 net=$secondnet mask=255.255.0.0 mgtifname=$$SECONDNIC
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$SECONDNIC=$second1ip nictypes.$$SECONDNIC=Ethernet nicnetworks.$$SECONDNIC=confignetworks_test1
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$SECONDNIC=$second1ip nictypes.$$SECONDNIC=Ethernet nicnetworks.$$SECONDNIC=confignetworks_test1
 check:rc==0
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=101.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test2 net=$secondnet mask=255.255.0.0 mgtifname=$$THIRDNIC
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$THIRDNIC=$second1ip nictypes.$$THIRDNIC=Ethernet nicnetworks.$$THIRDNIC=confignetworks_test2
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$THIRDNIC=$second1ip nictypes.$$THIRDNIC=Ethernet nicnetworks.$$THIRDNIC=confignetworks_test2
 check:rc==0
 cmd:updatenode $$CN -P confignetwork
 check:rc==0
@@ -622,7 +622,7 @@ cmd:chdef $$CN nicips.$$SECONDNIC= nictypes.$$SECONDNIC= nicnetworks.$$SECONDNIC
 check:rc==0
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=102.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test3 net=$secondnet mask=255.255.0.0 
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;bond0ip=$var1$var2;chdef $$CN nicnetworks.bond0=confignetworks_test3 nictypes.$$SECONDNIC=ethernet nictypes.$$THIRDNIC=ethernet nictypes.bond0=bond nicips.bond0=$bond0ip nicdevices.bond0="$$SECONDNIC|$$THIRDNIC"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;bond0ip=$var1$var2;chdef $$CN nicnetworks.bond0=confignetworks_test3 nictypes.$$SECONDNIC=ethernet nictypes.$$THIRDNIC=ethernet nictypes.bond0=bond nicips.bond0=$bond0ip nicdevices.bond0="$$SECONDNIC|$$THIRDNIC"
 check:rc==0
 cmd:updatenode $$CN -P confignetwork
 check:rc==0
@@ -630,7 +630,7 @@ cmd:xdsh $$CN "ls /sys/class/net"
 check:output=~bond0
 cmd:xdsh $$CN "cat /sys/class/net/bonding_masters"
 check:output=~bond0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;bond0ip=$var1$var2;if grep SUSE /etc/*release;then xdsh $$CN "grep $bond0ip /etc/sysconfig/network/ifcfg-bond0"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $bond0ip /etc/sysconfig/network-scripts/ifcfg-*bond0"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $bond0ip /etc/network/interfaces.d/bond0";else echo "Sorry,this is not supported os"; fi
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;bond0ip=$var1$var2;if grep SUSE /etc/*release;then xdsh $$CN "grep $bond0ip /etc/sysconfig/network/ifcfg-bond0"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $bond0ip /etc/sysconfig/network-scripts/ifcfg-*bond0"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $bond0ip /etc/network/interfaces.d/bond0";else echo "Sorry,this is not supported os"; fi
 check:rc==0
 cmd:rmdef -t network -o confignetworks_test1 
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifcfg-$$SECONDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts/ifcfg-$$SECONDNIC"; elif grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /etc/network/interfaces.d/$$SECONDNIC";else echo "Sorry,this is not supported os"; fi
@@ -639,7 +639,7 @@ cmd:rmdef -t network -o confignetworks_test2
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifcfg-$$THIRDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts/ifcfg-$$THIRDNIC"; elif grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /etc/network/interfaces.d/$$THIRDNIC";else echo "Sorry,this is not supported os"; fi
 check:rc==0
 cmd:rmdef -t network -o confignetworks_test3
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;bond0ip=$var1$var2;xdsh $$CN "ip addr del $bond0ip/16 dev bond0"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;bond0ip=$var1$var2;xdsh $$CN "ip addr del $bond0ip/16 dev bond0"
 cmd:xdsh $$CN "ip link del dev bond0"
 cmd:xdsh $$CN "echo -bond0 > /sys/class/net/bonding_masters"
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifcfg-bond0"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts"; elif grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /etc/network/interfaces.d/bond0";else echo "Sorry,this is not supported os"; fi
@@ -666,27 +666,27 @@ cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network/ifcf
 cmd:if grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "yum -y install bridge-utils";fi
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=100.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test1 net=$secondnet mask=255.255.0.0 mgtifname=$$SECONDNIC
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$SECONDNIC=$second1ip nictypes.$$SECONDNIC=Ethernet nicnetworks.$$SECONDNIC=confignetworks_test1
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$SECONDNIC=$second1ip nictypes.$$SECONDNIC=Ethernet nicnetworks.$$SECONDNIC=confignetworks_test1
 check:rc==0
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=101.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test2 net=$secondnet mask=255.255.0.0 mgtifname=$$THIRDNIC
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$THIRDNIC=$second1ip nictypes.$$THIRDNIC=Ethernet nicnetworks.$$THIRDNIC=confignetworks_test2
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$THIRDNIC=$second1ip nictypes.$$THIRDNIC=Ethernet nicnetworks.$$THIRDNIC=confignetworks_test2
 cmd:updatenode $$CN -P confignetwork
 check:rc==0
 cmd:chdef $$CN nicips.$$SECONDNIC= nictypes.$$SECONDNIC= nicnetworks.$$SECONDNIC= nicips.$$THIRDNIC= nictypes.$$THIRDNIC= nicnetworks.$$THIRDNIC=
 check:rc==0
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=102.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test3 net=$secondnet mask=255.255.0.0
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;bond0ip=$var1$var2;chdef $$CN nicnetworks.bond0=confignetworks_test3 nictypes.$$SECONDNIC=ethernet nictypes.$$THIRDNIC=ethernet nictypes.bond0=bond nicips.bond0=$bond0ip nicdevices.bond0=
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;bond0ip=$var1$var2;chdef $$CN nicnetworks.bond0=confignetworks_test3 nictypes.$$SECONDNIC=ethernet nictypes.$$THIRDNIC=ethernet nictypes.bond0=bond nicips.bond0=$bond0ip nicdevices.bond0=
 check:rc==0
 cmd:updatenode $$CN -P confignetwork
 check:rc!=0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;bond0ip=$var1$var2;chdef $$CN nicnetworks.bond0=confignetworks_test3 nictypes.$$SECONDNIC=ethernet nictypes.$$THIRDNIC=ethernet nictypes.bond0=bond nicips.bond0=$bond0ip nicdevices.$$SECONDNIC=bond0
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;bond0ip=$var1$var2;chdef $$CN nicnetworks.bond0=confignetworks_test3 nictypes.$$SECONDNIC=ethernet nictypes.$$THIRDNIC=ethernet nictypes.bond0=bond nicips.bond0=$bond0ip nicdevices.$$SECONDNIC=bond0
 check:rc==0
 cmd:updatenode $$CN -P confignetwork
 check:rc!=0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;xdsh $$CN "ip addr del $second1ip/16 dev $$SECONDNIC"
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;xdsh $$CN "ip addr del $second1ip/16 dev $$THIRDNIC"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;xdsh $$CN "ip addr del $second1ip/16 dev $$SECONDNIC"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;xdsh $$CN "ip addr del $second1ip/16 dev $$THIRDNIC"
 cmd:rmdef -t network -o confignetworks_test1 
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifcfg-$$SECONDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts/ifcfg-$$SECONDNIC"; elif grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /etc/network/interfaces.d/$$SECONDNIC";else echo "Sorry,this is not supported os"; fi
 check:rc==0
@@ -715,11 +715,11 @@ cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network/ifcf
 cmd:if grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "yum -y install bridge-utils";fi
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=100.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test1 net=$secondnet mask=255.255.0.0 mgtifname=$$SECONDNIC mtu=1500
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$SECONDNIC=$second1ip nictypes.$$SECONDNIC=Ethernet nicnetworks.$$SECONDNIC=confignetworks_test1
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$SECONDNIC=$second1ip nictypes.$$SECONDNIC=Ethernet nicnetworks.$$SECONDNIC=confignetworks_test1
 check:rc==0
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=101.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test2 net=$secondnet mask=255.255.0.0 mgtifname=$$THIRDNIC mtu=1500
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$THIRDNIC=$second1ip nictypes.$$THIRDNIC=Ethernet nicnetworks.$$THIRDNIC=confignetworks_test2
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$THIRDNIC=$second1ip nictypes.$$THIRDNIC=Ethernet nicnetworks.$$THIRDNIC=confignetworks_test2
 check:rc==0
 cmd:updatenode $$CN -P confignetwork
 check:rc==0
@@ -729,13 +729,13 @@ cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=102.;var4=`echo $cnip |awk -F.
 check:rc==0
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=103.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test4 net=$secondnet mask=255.255.0.0 mtu=1500
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=103;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;bond2ip=$var1$var3;bond3ip=$var2$var3;chdef $$CN nicdevices.bond0.2=bond0 nicdevices.bond0.3=bond0 nicips.bond0.2=$bond2ip nicips.bond0.3=$bond3ip nicnetworks.bond0.2=confignetworks_test3 nicnetworks.bond0.3=confignetworks_test4 nictypes.bond0.2=vlan nictypes.bond0.3=vlan nictypes.bond0=bond nictypes.$$SECONDNIC=ethernet nictypes.$$THIRDNIC=ethernet nicdevices.bond0="$$SECONDNIC|$$THIRDNIC"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=103;var3=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;bond2ip=$var1$var3;bond3ip=$var2$var3;chdef $$CN nicdevices.bond0.2=bond0 nicdevices.bond0.3=bond0 nicips.bond0.2=$bond2ip nicips.bond0.3=$bond3ip nicnetworks.bond0.2=confignetworks_test3 nicnetworks.bond0.3=confignetworks_test4 nictypes.bond0.2=vlan nictypes.bond0.3=vlan nictypes.bond0=bond nictypes.$$SECONDNIC=ethernet nictypes.$$THIRDNIC=ethernet nicdevices.bond0="$$SECONDNIC|$$THIRDNIC"
 check:rc==0
 cmd:updatenode $$CN -P confignetwork
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;bond2ip=$var1$var3;if grep SUSE /etc/*release;then xdsh $$CN "grep $bond2ip /etc/sysconfig/network/ifcfg-bond0.2"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $bond2ip /etc/sysconfig/network-scripts/ifcfg-*bond0.2*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $bond2ip /etc/network/interfaces.d/bond0.2";else echo "Sorry,this is not supported os"; fi
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var3=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;bond2ip=$var1$var3;if grep SUSE /etc/*release;then xdsh $$CN "grep $bond2ip /etc/sysconfig/network/ifcfg-bond0.2"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $bond2ip /etc/sysconfig/network-scripts/ifcfg-*bond0.2*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $bond2ip /etc/network/interfaces.d/bond0.2";else echo "Sorry,this is not supported os"; fi
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var2=103;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;bond3ip=$var2$var3;if grep SUSE /etc/*release;then xdsh $$CN "grep $bond3ip /etc/sysconfig/network/ifcfg-bond0.3"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $bond3ip /etc/sysconfig/network-scripts/ifcfg-*bond0.3*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $bond3ip /etc/network/interfaces.d/bond0.3";else echo "Sorry,this is not supported os"; fi
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var2=103;var3=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;bond3ip=$var2$var3;if grep SUSE /etc/*release;then xdsh $$CN "grep $bond3ip /etc/sysconfig/network/ifcfg-bond0.3"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $bond3ip /etc/sysconfig/network-scripts/ifcfg-*bond0.3*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $bond3ip /etc/network/interfaces.d/bond0.3";else echo "Sorry,this is not supported os"; fi
 check:rc==0
 cmd:xdsh $$CN "ls /sys/class/net"
 check:output=~bond0
@@ -751,10 +751,10 @@ cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifc
 check:rc==0
 cmd:rmdef -t network -o confignetworks_test3 
 cmd:rmdef -t network -o confignetworks_test4 
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;xdsh $$CN "ip addr del $second1ip/16 dev $$SECONDNIC"
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;xdsh $$CN "ip addr del $second1ip/16 dev $$THIRDNIC"
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;bond2ip=$var1$var3;xdsh $$CN "ip addr del $bond2ip/16 dev bond0.2"
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var2=103;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;bond3ip=$var2$var3;xdsh $$CN "ip addr del $bond3ip/16 dev bond0.3"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;xdsh $$CN "ip addr del $second1ip/16 dev $$SECONDNIC"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;xdsh $$CN "ip addr del $second1ip/16 dev $$THIRDNIC"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var3=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;bond2ip=$var1$var3;xdsh $$CN "ip addr del $bond2ip/16 dev bond0.2"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var2=103;var3=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;bond3ip=$var2$var3;xdsh $$CN "ip addr del $bond3ip/16 dev bond0.3"
 cmd:xdsh $$CN "ip link del dev bond0"
 cmd:xdsh $$CN "ip link del dev bond0.2"
 cmd:xdsh $$CN "ip link del dev bond0.3"
@@ -783,18 +783,18 @@ cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network/ifcf
 cmd:if grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "yum -y install bridge-utils";fi
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=100.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test1 net=$secondnet mask=255.255.0.0 mgtifname=$$SECONDNIC
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$SECONDNIC=$second1ip nictypes.$$SECONDNIC=Ethernet nicnetworks.$$SECONDNIC=confignetworks_test1
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$SECONDNIC=$second1ip nictypes.$$SECONDNIC=Ethernet nicnetworks.$$SECONDNIC=confignetworks_test1
 check:rc==0
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=101.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test2 net=$secondnet mask=255.255.0.0 mgtifname=$$THIRDNIC
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$THIRDNIC=$second1ip nictypes.$$THIRDNIC=Ethernet nicnetworks.$$THIRDNIC=confignetworks_test2
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$THIRDNIC=$second1ip nictypes.$$THIRDNIC=Ethernet nicnetworks.$$THIRDNIC=confignetworks_test2
 cmd:updatenode $$CN -P confignetwork
 check:rc==0
 cmd:chdef $$CN nicips.$$SECONDNIC= nictypes.$$SECONDNIC= nicnetworks.$$SECONDNIC= nicips.$$THIRDNIC= nictypes.$$THIRDNIC= nicnetworks.$$THIRDNIC=
 check:rc==0
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=102.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test3 net=$secondnet mask=255.255.0.0
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=103;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;br0ip=$var1$var2;chdef $$CN nicnetworks.br0=confignetworks_test3 nicdevices.br0=bond0 nictypes.br0=bridge nicips.br0=$br0ip nicdevices.bond0="$$SECONDNIC|$$THIRDNIC" nictypes.bond0=bond nictypes.$$SECONDNIC=ethernet nictypes.$$THIRDNIC=ethernet
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=103;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;br0ip=$var1$var2;chdef $$CN nicnetworks.br0=confignetworks_test3 nicdevices.br0=bond0 nictypes.br0=bridge nicips.br0=$br0ip nicdevices.bond0="$$SECONDNIC|$$THIRDNIC" nictypes.bond0=bond nictypes.$$SECONDNIC=ethernet nictypes.$$THIRDNIC=ethernet
 check:rc==0
 cmd:updatenode $$CN -P confignetwork
 check:rc==0
@@ -802,7 +802,7 @@ cmd:xdsh $$CN "ls /sys/class/net"
 check:output=~br0
 cmd:xdsh $$CN "cat /sys/class/net/bonding_masters"
 check:output=~bond0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=103;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;br0ip=$var1$var2;if grep SUSE /etc/*release;then xdsh $$CN "grep $br0ip /etc/sysconfig/network/ifcfg-br0"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $br0ip /etc/sysconfig/network-scripts/ifcfg-*br0"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $br0ip /etc/network/interfaces.d/br0";else echo "Sorry,this is not supported os"; fi
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=103;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;br0ip=$var1$var2;if grep SUSE /etc/*release;then xdsh $$CN "grep $br0ip /etc/sysconfig/network/ifcfg-br0"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $br0ip /etc/sysconfig/network-scripts/ifcfg-*br0"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $br0ip /etc/network/interfaces.d/br0";else echo "Sorry,this is not supported os"; fi
 check:rc==0
 cmd:rmdef -t network -o confignetworks_test1
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifcfg-$$SECONDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts/ifcfg-$$SECONDNIC"; elif grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /etc/network/interfaces.d/$$SECONDNIC";else echo "Sorry,this is not supported os"; fi
@@ -811,9 +811,9 @@ cmd:rmdef -t network -o confignetworks_test2
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifcfg-$$THIRDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts/ifcfg-$$THIRDNIC"; elif grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /etc/network/interfaces.d/$$THIRDNIC";else echo "Sorry,this is not supported os"; fi
 check:rc==0
 cmd:rmdef -t network -o confignetworks_test3
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=103;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;br0ip=$var1$var2;xdsh $$CN "ip addr del $br0ip/16 dev br0"
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;xdsh $$CN "ip addr del $second1ip/16 dev $$SECONDNIC"
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;xdsh $$CN "ip addr del $second1ip/16 dev $$THIRDNIC"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=103;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;br0ip=$var1$var2;xdsh $$CN "ip addr del $br0ip/16 dev br0"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;xdsh $$CN "ip addr del $second1ip/16 dev $$SECONDNIC"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;xdsh $$CN "ip addr del $second1ip/16 dev $$THIRDNIC"
 cmd:xdsh $$CN "ip link del dev br0"
 cmd:xdsh $$CN "echo -bond0 > /sys/class/net/bonding_masters"
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifcfg-br0"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts"; elif grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /etc/network/interfaces.d/br0";else echo "Sorry,this is not supported os"; fi
@@ -838,11 +838,11 @@ cmd:if grep SUSE /etc/*release;then xdsh $$CN "cp -f /etc/sysconfig/network/ifcf
 cmd:if grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "yum -y install bridge-utils";fi
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=100.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test1 net=$secondnet mask=255.255.0.0 mgtifname=$$SECONDNIC
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$SECONDNIC=$second1ip nictypes.$$SECONDNIC=Ethernet nicnetworks.$$SECONDNIC=confignetworks_test1
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$SECONDNIC=$second1ip nictypes.$$SECONDNIC=Ethernet nicnetworks.$$SECONDNIC=confignetworks_test1
 check:rc==0
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=101.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test2 net=$secondnet mask=255.255.0.0 mgtifname=$$THIRDNIC
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$THIRDNIC=$second1ip nictypes.$$THIRDNIC=Ethernet nicnetworks.$$THIRDNIC=confignetworks_test2
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$THIRDNIC=$second1ip nictypes.$$THIRDNIC=Ethernet nicnetworks.$$THIRDNIC=confignetworks_test2
 check:rc==0
 cmd:updatenode $$CN -P confignetwork
 check:rc==0
@@ -851,13 +851,13 @@ check:rc==0
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=102.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test3 net=$secondnet mask=255.255.0.0
 check:rc==0
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=103.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test4 net=$secondnet mask=255.255.0.0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=103;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;br22ip=$var1$var3;br33ip=$var2$var3;chdef $$CN nicdevices.br22=bond0.2 nicdevices.br33=bond0.3 nictypes.br22=bridge nictypes.br33=bridge nicnetworks.br22=confignetworks_test3 nicnetworks.br33=confignetworks_test4 nicips.br22=$br22ip nicips.br33=$br33ip nicdevices.bond0.2=bond0 nicdevices.bond0.3=bond0 nictypes.bond0.2=vlan nictypes.bond0.3=vlan nictypes.bond0=bond nictypes.$$SECONDNIC=ethernet nictypes.$$THIRDNIC=ethernet nicdevices.bond0="$$SECONDNIC|$$THIRDNIC"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=103;var3=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;br22ip=$var1$var3;br33ip=$var2$var3;chdef $$CN nicdevices.br22=bond0.2 nicdevices.br33=bond0.3 nictypes.br22=bridge nictypes.br33=bridge nicnetworks.br22=confignetworks_test3 nicnetworks.br33=confignetworks_test4 nicips.br22=$br22ip nicips.br33=$br33ip nicdevices.bond0.2=bond0 nicdevices.bond0.3=bond0 nictypes.bond0.2=vlan nictypes.bond0.3=vlan nictypes.bond0=bond nictypes.$$SECONDNIC=ethernet nictypes.$$THIRDNIC=ethernet nicdevices.bond0="$$SECONDNIC|$$THIRDNIC"
 check:rc==0
 cmd:updatenode $$CN -P confignetwork
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;br22ip=$var1$var3;if grep SUSE /etc/*release;then xdsh $$CN "grep $br22ip /etc/sysconfig/network/ifcfg-br22"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $br22ip /etc/sysconfig/network-scripts/ifcfg-*br22*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $br22ip /etc/network/interfaces.d/br22";else echo "Sorry,this is not supported os"; fi
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var3=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;br22ip=$var1$var3;if grep SUSE /etc/*release;then xdsh $$CN "grep $br22ip /etc/sysconfig/network/ifcfg-br22"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $br22ip /etc/sysconfig/network-scripts/ifcfg-*br22*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $br22ip /etc/network/interfaces.d/br22";else echo "Sorry,this is not supported os"; fi
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=103;var3=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;br33ip=$var1$var3;if grep SUSE /etc/*release;then xdsh $$CN "grep $br33ip /etc/sysconfig/network/ifcfg-br33"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $br33ip /etc/sysconfig/network-scripts/ifcfg-*br33*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $br33ip /etc/network/interfaces.d/br33";else echo "Sorry,this is not supported os"; fi
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=103;var3=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;br33ip=$var1$var3;if grep SUSE /etc/*release;then xdsh $$CN "grep $br33ip /etc/sysconfig/network/ifcfg-br33"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $br33ip /etc/sysconfig/network-scripts/ifcfg-*br33*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $br33ip /etc/network/interfaces.d/br33";else echo "Sorry,this is not supported os"; fi
 check:rc==0
 cmd:xdsh $$CN "ls /sys/class/net"
 check:output=~br22
@@ -869,16 +869,16 @@ cmd:rmdef -t network -o confignetworks_test2
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifcfg-$$SECONDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts"; elif grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /etc/network/interfaces.d/$$SECONDNIC";else echo "Sorry,this is not supported os"; fi
 check:rc==0
 cmd:rmdef -t network -o confignetworks_test3
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;br22ip=$var1$var2;xdsh $$CN "ip addr del $br22ip/16 dev br22"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;br22ip=$var1$var2;xdsh $$CN "ip addr del $br22ip/16 dev br22"
 cmd:xdsh $$CN "ip link del dev br22"
 cmd:rmdef -t network -o confignetworks_test4
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=103;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;br33ip=$var1$var2;xdsh $$CN "ip addr del $br33ip/16 dev br33"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=103;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;br33ip=$var1$var2;xdsh $$CN "ip addr del $br33ip/16 dev br33"
 cmd:xdsh $$CN "ip link del dev br33"
 cmd:xdsh $$CN "ip link del dev bond0.2"
 cmd:xdsh $$CN "ip link del dev bond0.3"
 cmd:xdsh $$CN "ip link del dev bond0"
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;secondip=$var1$var2;xdsh $$CN "ip addr del $secondip/16 dev $$SECONDNIC"
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]*(..\..*)/\1/'`;secondip=$var1$var2;xdsh $$CN "ip addr del $secondip/16 dev $$THIRDNIC"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=100;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;secondip=$var1$var2;xdsh $$CN "ip addr del $secondip/16 dev $$SECONDNIC"
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;secondip=$var1$var2;xdsh $$CN "ip addr del $secondip/16 dev $$THIRDNIC"
 cmd:xdsh $$CN "echo -bond0 > /sys/class/net/bonding_masters"
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifcfg-bond0 /etc/sysconfig/network/ifcfg-bond0.2 /etc/sysconfig/network/ifcfg-bond0.3 /etc/sysconfig/network/ifcfg-br22 /etc/sysconfig/network/ifcfg-br33"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts"; elif grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /etc/network/interfaces.d/bond0 /etc/network/interfaces.d/bond0.2 /etc/network/interfaces.d/bond0.3 /etc/network/interfaces.d/br22 /etc/network/interfaces.d/br33";else echo "Sorry,this is not supported os"; fi
 check:rc==0


### PR DESCRIPTION
update regexp to get the right IP address

Issue:
When running testcase, bad ip address will be generated: 10092.168.200.20,

xcat-com001: configure nic and its device : eth0
xcat-com001: [I]: configure eth0
xcat-com001: [I]: call: NMCLI_USED=0 configeth eth0 10092.168.200.20 confignetworks_test1
xcat-com001: [I]: configeth on xcat-com001: os type: redhat
xcat-com001: configeth on xcat-com001: old configuration: 2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
xcat-com001:     link/ether 52:54:00:7d:fe:76 brd ff:ff:ff:ff:ff:ff
xcat-com001:     inet6 fe80::5054:ff:fe7d:fe76/64 scope link
xcat-com001:        valid_lft forever preferred_lft forever
xcat-com001: [I]: configeth on xcat-com001: new configuration
xcat-com001:        10092.168.200.20, 100.168.0.0, 255.255.0.0,		
                                 ^
                                 ||

Command:
 XCATTEST_MN=192.168.200.10 XCATTEST_SN=192.168.200.10 XCATTEST_ISO=/opt/xcat/CentOS-7-x86_64-DVD-1804.iso XCATTEST_SECONDNIC=eth0 XCATTEST_THIRDNIC=eth2 XCATTEST_CN=xcat-com001 xcattest -t confignetwork_vlan_eth0

# lsdef -t node xcat-com001
Object name: xcat-com001
    arch=x86_64
    currchain=shell
    currstate=runimage=http://192.168.102.124/install/my_image/my_image.tgz
    groups=compute,all
    ip=192.168.200.20
    mac=52:54:00:16:ba:39
    mgt=ipmi
    monserver=192.168.200.10
    netboot=xnba
    nfsserver=192.168.200.10
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
    serialport=0
    serialspeed=115200
    status=powering-off
    statustime=05-12-2020 05:39:46
    tftpserver=192.168.200.10
    xcatmaster=192.168.200.10

Signed-off-by: Chen Hanxiao <chen_han_xiao@126.com>

