### PR TITLE
DSHCLI.pm:  Skip noderange-specific syncfiles during local copy

### DIFF
--- a/perl-xCAT/xCAT/DSHCLI.pm
+++ b/perl-xCAT/xCAT/DSHCLI.pm
@@ -4996,6 +4996,11 @@ sub rsync_to_image
             next;
         }
 
+        if ($line =~ /.+ -> \(.+\) .+/)    # skip syncfile entries containing noderange
+        {
+            next;
+        }
+
         $line=xCAT::Utils->varsubinline($line,\%osimgenv);
 
         # process no more lines, do not exec


### PR DESCRIPTION
Currently during packimage if there is a line like
```
/path/to/file -> (noderange) /path/to/target
```
then processing of that syncfile stops, skipping the rest of the contents.  This leads to missing files in the resulting image.  

This patch detects the noderange-specific pattern and skips those lines.