### PR TITLE
Remove quotes XCATSERVER from xcatinfo

### DIFF
--- a/xCAT/postscripts/xcatdsklspost
+++ b/xCAT/postscripts/xcatdsklspost
@@ -429,8 +429,8 @@ if [ "$MODE" = "4" ]; then # for statelite mode
     done
 
     if [ -f /opt/xcat/xcatinfo ]; then
-        SIP=`grep 'XCATSERVER' /opt/xcat/xcatinfo |cut -d= -f2`
-        HTTPPORT=`grep 'HTTPPORT' /opt/xcat/xcatinfo |cut -d= -f2`
+        SIP=`grep 'XCATSERVER' /opt/xcat/xcatinfo |cut -d= -f2 | sed "s/'//g"` 
+        HTTPPORT=`grep 'HTTPPORT' /opt/xcat/xcatinfo |cut -d= -f2 | sed "s/'//g"`
         if [ -n "$SIP" ]; then
             download_postscripts $SIP:${HTTPPORT}
             if [ $? -eq 0 ]; then
@@ -498,8 +498,8 @@ else # for common mode  MODE=1,2,3,5 (updatenode,moncfg,node deployment)
 
         # if not updatenode, then look in xcatinfo for the xcatmaster
         if [ -f /opt/xcat/xcatinfo ]; then
-            SIP=`grep 'XCATSERVER' /opt/xcat/xcatinfo |cut -d= -f2`
-            HTTPPORT=`grep 'HTTPPORT' /opt/xcat/xcatinfo |cut -d= -f2`
+            SIP=`grep 'XCATSERVER' /opt/xcat/xcatinfo |cut -d= -f2 | sed "s/'//g"`
+            HTTPPORT=`grep 'HTTPPORT' /opt/xcat/xcatinfo |cut -d= -f2 | sed "s/'//g"`
             [ -z "$HTTPPORT" ] && HTTPPORT="80" 
             if [ -n "$SIP" ]; then
                 download_postscripts ${SIP}:${HTTPPORT}


### PR DESCRIPTION
for issue #6704 .

remove quotes when grep `XCATSERVER` from xcatinfo file
```
# cat /opt/xcat/xcatinfo
IMAGENAME='rhels7.6-x86_64-netboot-compute'
IMAGEUUID='e0a9302f-3448-4709-a98b-a00570145319'
TIMESTAMP='Fri May 15 10:34:55 EDT 2020'
XCATSERVER='c910f04x37v08'
HTTPPORT=80
USEFLOWCONTROL=NO
NODE=c910f04x37v10
```
Before:
```
# grep 'XCATSERVER' /opt/xcat/xcatinfo |cut -d= -f2
'c910f04x37v08'
```
After the fixes:
```
# grep 'XCATSERVER' /opt/xcat/xcatinfo |cut -d= -f2 | sed "s/'//g"
c910f04x37v08
```
