### PR TITLE
Add option to bmcdiscover command to change default BMC password

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/bmcdiscover.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/bmcdiscover.1.rst
@@ -171,7 +171,7 @@ Output is similar to:
      bmcdiscover -s nmap --range "10.4.22-23.100-254" -w -z
 
 
-5. Discover the BMC with the specified IP address, change its default BMC password and display in xCAT stanze format:
+5. Discover the BMC with the specified IP address, change its default BMC password and display in xCAT stanza format:
 
 
 .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man1/bmcdiscover.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/bmcdiscover.1.rst
@@ -23,7 +23,7 @@ SYNOPSIS
 
 \ **bmcdiscover**\  [\ **-v | -**\ **-version**\ ]
 
-\ **bmcdiscover**\   \ **-**\ **-range**\  \ *ip_ranges*\  [\ **-**\ **-sn**\  \ *SN_nodename*\ ] [\ **-s**\  \ *scan_method*\ ] [\ **-u**\  \ *bmc_user*\ ] [\ **-p**\  \ *bmc_passwd*\ ] [\ **-z**\ ] [\ **-w**\ ]
+\ **bmcdiscover**\   \ **-**\ **-range**\  \ *ip_ranges*\  [\ **-**\ **-sn**\  \ *SN_nodename*\ ] [\ **-s**\  \ *scan_method*\ ] [\ **-u**\  \ *bmc_user*\ ] [\ **-p**\  \ *bmc_passwd*\ ] [\ **-n**\  \ *new_bmc_passwd*\ ] [\ **-z**\ ] [\ **-w**\ ]
 
 
 ***********
@@ -37,7 +37,7 @@ The command uses \ **nmap**\  to scan active nodes over a specified IP range.  T
 
 \ **Note:**\  The scan method currently supported is \ **nmap**\ .
 
-\ **Note:**\  Starting on January 1, 2020, some newly shipped systems will require the default BMC password to be changed before they can be managed by xCAT. \ **bmcdiscover**\  will not be able to discover such systems. Run \ */opt/xcat/share/xcat/scripts/BMC_change_password.sh*\  script to change the default password for BMCs in specified range, then rerun \ **bmcdiscover**\  with \ **-p "new bmc password"**\  flag to discover systems with the changed password.
+\ **Note:**\  Starting on January 1, 2020, some newly shipped systems will require the default BMC password to be changed before they can be managed by xCAT. Use \ **bmcdiscover**\  with \ **-n**\  option to specify new BMC password.
 
 
 *******
@@ -85,6 +85,12 @@ OPTIONS
 \ **-p|-**\ **-bmcpasswd**\ 
  
  BMC user password.
+ 
+
+
+\ **-n|-**\ **-newbmcpw**\ 
+ 
+ New BMC user password.
  
 
 
@@ -163,6 +169,14 @@ Output is similar to:
 .. code-block:: perl
 
      bmcdiscover -s nmap --range "10.4.22-23.100-254" -w -z
+
+
+5. Discover the BMC with the specified IP address, change its default BMC password and display in xCAT stanze format:
+
+
+.. code-block:: perl
+
+     bmcdiscover --range "10.4.22-23.100" -u root -p 0penBmc -n 0penBmc123 -z
 
 
 

--- a/xCAT-client/pods/man1/bmcdiscover.1.pod
+++ b/xCAT-client/pods/man1/bmcdiscover.1.pod
@@ -106,7 +106,7 @@ Output is similar to:
 
     bmcdiscover -s nmap --range "10.4.22-23.100-254" -w -z
 
-5. Discover the BMC with the specified IP address, change its default BMC password and display in xCAT stanze format:
+5. Discover the BMC with the specified IP address, change its default BMC password and display in xCAT stanza format:
 
     bmcdiscover --range "10.4.22-23.100" -u root -p 0penBmc -n 0penBmc123 -z
 

--- a/xCAT-client/pods/man1/bmcdiscover.1.pod
+++ b/xCAT-client/pods/man1/bmcdiscover.1.pod
@@ -8,7 +8,7 @@ B<bmcdiscover> [B<-?>|B<-h>|B<--help>]
 
 B<bmcdiscover> [B<-v>|B<--version>]
 
-B<bmcdiscover>  B<--range> I<ip_ranges> [B<--sn> I<SN_nodename>] [B<-s> I<scan_method>] [B<-u> I<bmc_user>] [B<-p> I<bmc_passwd>] [B<-z>] [B<-w>]
+B<bmcdiscover>  B<--range> I<ip_ranges> [B<--sn> I<SN_nodename>] [B<-s> I<scan_method>] [B<-u> I<bmc_user>] [B<-p> I<bmc_passwd>] [B<-n> I<new_bmc_passwd>] [B<-z>] [B<-w>]
 
 
 =head1 DESCRIPTION
@@ -20,7 +20,7 @@ The command uses B<nmap> to scan active nodes over a specified IP range.  The IP
 B<Note:> The scan method currently supported is B<nmap>.
 
 
-B<Note:> Starting on January 1, 2020, some newly shipped systems will require the default BMC password to be changed before they can be managed by xCAT. B<bmcdiscover> will not be able to discover such systems. Run I</opt/xcat/share/xcat/scripts/BMC_change_password.sh> script to change the default password for BMCs in specified range, then rerun B<bmcdiscover> with B<-p "new bmc password"> flag to discover systems with the changed password. 
+B<Note:> Starting on January 1, 2020, some newly shipped systems will require the default BMC password to be changed before they can be managed by xCAT. Use B<bmcdiscover> with B<-n> option to specify new BMC password. 
 
 =head1 OPTIONS
 
@@ -53,6 +53,10 @@ BMC user name.
 =item B<-p|--bmcpasswd>
 
 BMC user password.
+
+=item B<-n|--newbmcpw>
+
+New BMC user password.
 
 =item B<-h|--help>
 
@@ -101,6 +105,10 @@ Output is similar to:
 4. Discover the BMCs and write the discovered node definitions into the xCAT database and write out the stanza format to the console:
 
     bmcdiscover -s nmap --range "10.4.22-23.100-254" -w -z
+
+5. Discover the BMC with the specified IP address, change its default BMC password and display in xCAT stanze format:
+
+    bmcdiscover --range "10.4.22-23.100" -u root -p 0penBmc -n 0penBmc123 -z
 
 =head1 SEE ALSO
 

--- a/xCAT-server/share/xcat/scripts/BMC_change_password.sh
+++ b/xCAT-server/share/xcat/scripts/BMC_change_password.sh
@@ -22,6 +22,9 @@ if [ $# -le 3 ];  then
 Change the default root or ADMIN password of the BMC to the one 
 specified by '-n' flag. Use the same password when discovering new 
 BMCs, by passing it with '[-p|--bmcpasswd]' option to 'bmcdiscover' command.
+
+Note: Starting with xCAT 2.16, the changing of default BMC passwords
+can also be done with '-n' option for 'bmcdiscover' command.
 "
     echo "Usage:"
     echo "      $0  -r <ip_ranges> -n <new BMC Password> "
@@ -63,8 +66,8 @@ UNAUTHORIZED="Unauthorized"
 for name in `cat /tmp/$$.ip.list`
 do
 
-    ## Look for Witherspoon first
-    SYSTEM_TYPE="Witherspoon"
+    ## Look for OpenBMC (Witherspoon or Mihawk) first
+    SYSTEM_TYPE="OpenBMC"
     PasswordChangeNeeded=`curl -sD - --data '{"UserName":"'"$WITHERSPOON_DEFAULT_USER"'","Password":"'"$WITHERSPOON_DEFAULT_PW"'"}' -k -X POST https://$name/redfish/v1/SessionService/Sessions`
 
     if [[ "$PasswordChangeNeeded" =~ "$CHANGE_PW_REQUIRED" ]]; then
@@ -74,7 +77,7 @@ do
             echo "$name: Can not change password for $SYSTEM_TYPE system - $PW_PAM_VALIDATION"
         elif [[ -z "$PasswordChanged" ]]; then
             # If no output, password change was successful
-            echo "$name: Password for $SYSTEM_TYPE system changed. It might take up to 5 minutes for the BMC to update." 
+            echo "$name: Password for $SYSTEM_TYPE system changed." 
         else
             # Some unexpected output changing the password - report error and show output
             echo "$name: Unable to change password for $SYSTEM_TYPE system - $PasswordChanged"
@@ -83,8 +86,8 @@ do
         continue
     fi
 
-    ## Look for Boston next
-    SYSTEM_TYPE="Boston"
+    ## Look for IPMI managed (Boston) next
+    SYSTEM_TYPE="IPMI"
     PasswordChangeNeeded=`curl -sD - --data '{"UserName":"'"$BOSTON_DEFAULT_USER"'","Password":"'"$BOSTON_DEFAULT_PW"'"}' -k -X POST https://$name/redfish/v1/SessionService/Sessions`
     if [[ "$PasswordChangeNeeded" =~ "$CHANGE_PW_REQUIRED" ]]; then
         echo "$name: Password change needed for $SYSTEM_TYPE system"


### PR DESCRIPTION
### The PR is to fix issue _#6689_

This PR:

* Adds `-n` option to `bmcdiscover` command to specify new BMC password if default BMC password is required to be changed
* Updates man page for `bmcdiscover` command to list new `-n` option
* Updates `BMC_change_password.sh` script to not use node codenames in the output and to tell the user that the password change function is integrated into `bmcdiscover` command.

## UT:

#### MULTIPLE NODES, ONE NEEDS PW CHANGE:
```
[root@briggs01 xcat]# bmcdiscover --range 172.11.139.15-17 -u root -p 0penBmc123 -z
node-8335-gth-78ae03a:
        objtype=node
        groups=all
        bmc=172.11.139.17
        cons=openbmc
        mgt=openbmc
        mtm=8335-GTH
        serial=78AE03A
        bmcusername=root
        bmcpassword=0penBmc123

172.11.139.15: The password provided for this account must be changed before access is granted
Rerun 'bmcdiscover' command with '-p default_bmc_password -n new_bmc_password' flag
[root@briggs01 xcat]#
```

#### SINGLE NODE, NEEDS PW CHANGE:
```
[root@briggs01 xcat]# bmcdiscover --range 172.11.139.15 -u root -p 0penBmc123 -z
172.11.139.15: The password provided for this account must be changed before access is granted
Rerun 'bmcdiscover' command with '-p default_bmc_password -n new_bmc_password' flag
Warning: [briggs01]: No bmc found.

[root@briggs01 xcat]#
```

#### SINGLE NODE, NEEDS PW CHANGE, CHANGED WITH -n <new pw>
```
[root@briggs01 xcat]# bmcdiscover --range 172.11.139.15 -u root -p 0penBmc123 -n 0penBmc321 -z
172.11.139.15: The password provided for this account must be changed before access is granted
172.11.139.15: Password changed.
node-8335-gth-78ae07a:
        objtype=node
        groups=all
        bmc=172.11.139.15
        cons=openbmc
        mgt=openbmc
        mtm=8335-GTH
        serial=78AE07A
        bmcusername=root
        bmcpassword=0penBmc321

[root@briggs01 xcat]#
```
#### MULTIPLE NODES, NONE NEED PW CHANGE:
```
[root@briggs01 xcat]# bmcdiscover --range 172.11.139.15-17 -u root -p 0penBmc123 -z
node-8335-gth-78ae07a:
        objtype=node
        groups=all
        bmc=172.11.139.15
        cons=openbmc
        mgt=openbmc
        mtm=8335-GTH
        serial=78AE07A
        bmcusername=root
        bmcpassword=0penBmc123

node-8335-gth-78ae03a:
        objtype=node
        groups=all
        bmc=172.11.139.17
        cons=openbmc
        mgt=openbmc
        mtm=8335-GTH
        serial=78AE03A
        bmcusername=root
        bmcpassword=0penBmc123

[root@briggs01 xcat]#
```

#### MULTIPLE NODES, ONE NEEDS PW CHANGE, THE OTHER DOES NOT:
```
[root@briggs01 xcat]# bmcdiscover --range 172.11.139.15-17 -u root -p 0penBmc123 -n 0penBmc321 -z
node-8335-gth-78ae03a:
        objtype=node
        groups=all
        bmc=172.11.139.17
        cons=openbmc
        mgt=openbmc
        mtm=8335-GTH
        serial=78AE03A
        bmcusername=root
        bmcpassword=0penBmc321

172.11.139.15: The password provided for this account must be changed before access is granted
172.11.139.15: Password changed.
node-8335-gth-78ae07a:
        objtype=node
        groups=all
        bmc=172.11.139.15
        cons=openbmc
        mgt=openbmc
        mtm=8335-GTH
        serial=78AE07A
        bmcusername=root
        bmcpassword=0penBmc321

[root@briggs01 xcat]#
```
#### INVALID NEW PW:
```
[root@briggs01 xcat]# bmcdiscover --range 172.11.139.15 -u root -p 0penBmc123 -n abc -z
172.11.139.15: The password provided for this account must be changed before access is granted
Can not change password - password value failed PAM validation checks
Warning: [briggs01]: No bmc found.

[root@briggs01 xcat]#
```