### PR TITLE
Improve genesistest.pl script

### DIFF
--- a/xCAT-test/autotest/testcase/genesis/genesistest.pl
+++ b/xCAT-test/autotest/testcase/genesis/genesistest.pl
@@ -250,6 +250,7 @@ sub testxdsh {
     print "The input parameter is $value \n";
     my $checkstring;
     my $checkfile;
+    my $nodestatus;
     if ($value == 1) {
         #mean runcmd test using test scripts genesistest.pl writes
         $checkstring = "testcmd";
@@ -268,7 +269,8 @@ sub testxdsh {
             my @i = (1..10);
             for (@i) {
                 sleep 300;
-                send_msg(1,"[$_] Running \"$xdsh_command\" to check the results again");
+                $nodestatus=`lsdef $noderange -i status -c  2>&1 | awk -F'=' '{print \$2}'`;
+                send_msg(1,"[$_] Running \"$xdsh_command\" to check results. Node status: $nodestatus");
                 `$xdsh_command`;
                 last if ($? == 0);
             }


### PR DESCRIPTION
Display node status when running genesistest.pl script.
Sometimes testcase `nodeset_runimg` fails. The output of the failure will display node status for better debugging.