### PR TITLE
Set UEFI filesystem to fat32

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/common/deployment/cfg_partition.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/deployment/cfg_partition.rst
@@ -36,7 +36,7 @@ The partition file must follow the partitioning syntax of the respective install
    * SLES: `Autoyast documentation  <https://doc.opensuse.org/projects/autoyast/configuration.html#CreateProfile.Partitioning>`_ 
 
      * Use yast2 autoyast in GUI or CLI mode to customize the installation options and create autoyast file
-     * Use yast2 clone_system to create autoyast configuration file /root/autoinst.xml to clone an existing system
+     * Use yast2 clone_system to create autoyast configuration file ``/root/autoinst.xml`` to clone an existing system
 
    * Ubuntu: `Preseed documentation  <https://www.debian.org/releases/stable/i386/apbs04.en.html#preseed-partman>`_ 
 
@@ -376,13 +376,13 @@ To generate the configuration, run the ``nodeset`` command: ::
 
 .. BEGIN_Partition_Definition_Script_overview
 
-Create a shell script that will be run on the node during the install process to dynamically create the disk partitioning definition. This script will be run during the OS installer %pre script on RedHat or preseed/early_command on Unbuntu execution and must write the correct partitioning definition into the file /tmp/partitionfile on the node
+Create a shell script that will be run on the node during the install process to dynamically create the disk partitioning definition. This script will be run during the OS installer %pre script on RedHat or preseed/early_command on Unbuntu execution and must write the correct partitioning definition into the file ``/tmp/partitionfile`` on the node
 
 .. END_Partition_Definition_Script_overview
 
 .. BEGIN_Partition_Definition_Script_Create_partition_script_content
 
-The purpose of the partition script is to create the /tmp/partionfile that will be inserted into the kickstart/autoyast/preseed template, the script could include complex logic like select which disk to install and even configure RAID, etc
+The purpose of the partition script is to create the ``/tmp/partionfile`` that will be inserted into the kickstart/autoyast/preseed template, the script could include complex logic like select which disk to install and even configure RAID, etc
 
 **Note**: the partition script feature is not thoroughly tested on SLES, there might be problems, use this feature on SLES at your own risk.
 
@@ -429,11 +429,11 @@ Here is an example of the partition script on RedHat and SLES, the partitioning 
 
 .. BEGIN_Partition_Definition_Script_Create_partition_script_example_ubuntu
 
-The following is an example of the partition script on Ubuntu, the partitioning script is /install/custom/my-partitions.sh: ::
+The following is an example of the partition script on Ubuntu, the partitioning script is ``/install/custom/my-partitions.sh``: ::
 
 	if [ -d /sys/firmware/efi ]; then
 		echo "ubuntu-efi ::" > /tmp/partitionfile
-		echo "    512 512 1024 fat16" >> /tmp/partitionfile
+		echo "    512 512 1024 fat32" >> /tmp/partitionfile
 		echo '    $iflabel{ gpt } $reusemethod{ } method{ efi } format{ }' >> /tmp/partitionfile
 		echo "    ." >> /tmp/partitionfile
 	else
@@ -458,9 +458,9 @@ Run below commands to associate partition script with osimage: ::
         chdef -t osimage <osimagename> partitionfile='s:/install/custom/my-partitions.sh'
         nodeset <nodename> osimage=<osimage>
 
-    - The "s:" preceding the filename tells nodeset that this is a script.
-    - For RedHat, when nodeset runs and generates the /install/autoinst file for a node, it will add the execution of the contents of this script to the %pre section of that file. The nodeset command will then replace the #XCAT_PARTITION_START#...#XCAT_PARTITION_END# directives from the osimage template file with "%include /tmp/partitionfile" to dynamically include the tmp definition file your script created.
-    - For Ubuntu, when nodeset runs and generates the /install/autoinst file for a node, it will replace the "#XCA_PARTMAN_RECIPE_SCRIPT#" directive and add the execution of the contents of this script to the /install/autoinst/<node>.pre, the /install/autoinst/<node>.pre script will be run in the preseed/early_command.
+- The ``s:`` preceding the filename tells nodeset that this is a script.
+- For RedHat, when nodeset runs and generates the ``/install/autoinst`` file for a node, it will add the execution of the contents of this script to the %pre section of that file. The ``nodeset`` command will then replace the ``#XCAT_PARTITION_START#...#XCAT_PARTITION_END#`` directives from the osimage template file with ``%include /tmp/partitionfile`` to dynamically include the tmp definition file your script created.
+    - For Ubuntu, when nodeset runs and generates the ``/install/autoinst`` file for a node, it will replace the ``#XCA_PARTMAN_RECIPE_SCRIPT#`` directive and add the execution of the contents of this script to the ``/install/autoinst/<node>.pre``, the ``/install/autoinst/<node>.pre`` script will be run in the preseed/early_command.
 
 .. END_Partition_Definition_Script_Associate_partition_script_with_osimage_common
 
@@ -477,14 +477,14 @@ If not specified, the default value will be used.
     chdef -t osimage <osimagename> -p partitionfile='d:/install/custom/partitiondisk'
     nodeset <nodename> osimage=<osimage>
 
-- the 'd:' preceding the filename tells nodeset that this is a partition disk file.
-- For Ubuntu, when nodeset runs and generates the /install/autoinst file for a node, it will generate a script to write the content of the partition disk file to /tmp/install_disk, this context to run the script will replace the #XCA_PARTMAN_DISK_SCRIPT# directive in /install/autoinst/<node>.pre.
+- the ``d:`` preceding the filename tells nodeset that this is a partition disk file.
+- For Ubuntu, when nodeset runs and generates the ``/install/autoinst`` file for a node, it will generate a script to write the content of the partition disk file to ``/tmp/install_disk``, this context to run the script will replace the ``#XCA_PARTMAN_DISK_SCRIPT#`` directive in ``/install/autoinst/<node>.pre``.
 
 .. END_Partition_Disk_File_ubuntu_only
 
 .. BEGIN_Partition_Disk_Script_ubuntu_only
 
-The disk script contains a script to generate a partitioning disk file named "/tmp/install_disk". for example: ::
+The disk script contains a script to generate a partitioning disk file named ``/tmp/install_disk``. for example: ::
 
     rm /tmp/devs-with-boot 2>/dev/null || true;
     for d in $(list-devices partition); do
@@ -512,8 +512,8 @@ If not specified, the default value will be used.
     chdef -t osimage <osimagename> -p partitionfile='s:d:/install/custom/partitiondiskscript'
     nodeset <nodename> osimage=<osimage>
 
-- the 's:' prefix tells nodeset that is a script, the 's:d:' preceding the filename tells nodeset that this is a script to generate the partition disk file.
-- For Ubuntu, when nodeset runs and generates the /install/autoinst file for a node, this context to run the script will replace the #XCA_PARTMAN_DISK_SCRIPT# directive in /install/autoinst/<node>.pre.
+- the ``s:`` prefix tells ``nodeset`` that is a script, the ``s:d:`` preceding the filename tells ``nodeset`` that this is a script to generate the partition disk file.
+- For Ubuntu, when nodeset runs and generates the ``/install/autoinst`` file for a node, this context to run the script will replace the ``#XCA_PARTMAN_DISK_SCRIPT#`` directive in ``/install/autoinst/<node>.pre``.
 
 .. END_Partition_Disk_Script_ubuntu_only
 
@@ -522,7 +522,7 @@ If not specified, the default value will be used.
 
 To support other specific partition methods such as RAID or LVM in Ubuntu, some additional preseed configuration entries should be specified.
 
-If using file way, 'c:<the absolute path of the additional preseed config file>', the additional preseed config file contains the additional preseed entries in "d-i ..." syntax. When "nodeset", the #XCA_PARTMAN_ADDITIONAL_CFG# directive in /install/autoinst/<node> will be replaced with content of the config file.  For example: ::
+If using file way, ``c:<the absolute path of the additional preseed config file>``, the additional preseed config file contains the additional preseed entries in ``d-i ...`` syntax. When ``nodeset``, the ``#XCA_PARTMAN_ADDITIONAL_CFG#`` directive in ``/install/autoinst/<node>`` will be replaced with content of the config file.  For example: ::
 
     d-i partman-auto/method string raid
     d-i partman-md/confirm boolean true

--- a/docs/source/guides/admin-guides/manage_clusters/common/deployment/raid_cfg.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/deployment/raid_cfg.rst
@@ -90,7 +90,7 @@ Deploy Diskful Nodes with RAID1 Setup on SLES
 
 xCAT provides one sample autoyast template files with the RAID1 settings ``/opt/xcat/share/xcat/install/sles/service.raid1.sles11.tmpl``. You can customize the template file and put it under ``/install/custom/install/<platform>/`` if the default one does not match your requirements.
 
-Here is the RAID1 partitioning section in service.raid1.sles11.tmpl: ::
+Here is the RAID1 partitioning section in ``service.raid1.sles11.tmpl``: ::
 
      <partitioning config:type="list">
         <drive>
@@ -188,13 +188,13 @@ The samples above created one 24MB PReP partition on each disk, one 2GB mirrored
 Since the PReP partition can not be mirrored between the two disks, some additional postinstall commands should be run to make the second disk bootable, here the commands needed to make the second disk bootable: ::
 
      # Set the second disk to be bootable for RAID1 setup
-     parted -s /dev/sdb mkfs 1 fat16
+     parted -s /dev/sdb mkfs 1 fat32
      parted /dev/sdb set 1 type 6
      parted /dev/sdb set 1 boot on
      dd if=/dev/sda1 of=/dev/sdb1
      bootlist -m normal sda sdb
 
-The procedure listed above has been added to the file ``/opt/xcat/share/xcat/install/scripts/post.sles11.raid1`` to make it be automated. The autoyast template file service.raid1.sles11.tmpl will include the content of post.sles11.raid1, so no manual steps are needed here.	
+The procedure listed above has been added to the file ``/opt/xcat/share/xcat/install/scripts/post.sles11.raid1`` to make it be automated. The autoyast template file ``service.raid1.sles11.tmpl`` will include the content of ``post.sles11.raid1``, so no manual steps are needed here.	
 
 After the diskful nodes are up and running, you can check the RAID1 settings with the following commands:
 
@@ -230,9 +230,9 @@ The command mdadm can query the detailed configuration for the RAID partitions: 
 Disk Replacement Procedure
 --------------------------
 
-If any one disk fails in the RAID1 array, do not panic. Follow the procedure listed below to replace the failed disk and you will be fine.
+If any one disk fails in the RAID1 array, do not panic. Follow the procedure listed below to replace the failed disk.
 
-Faulty disks should appear marked with an (F) if you look at ``/proc/mdstat``: ::
+Faulty disks should appear marked with an ``(F)`` if you look at ``/proc/mdstat``: ::
 
      # cat /proc/mdstat
      Personalities : [raid1]
@@ -248,7 +248,7 @@ Faulty disks should appear marked with an (F) if you look at ``/proc/mdstat``: :
 
      unused devices: <none>
 
-We can see that the first disk is broken because all the RAID partitions on this disk are marked as (F).
+We can see that the first disk is broken because all the RAID partitions on this disk are marked as ``(F)``.
 
 Remove the failed disk from RAID array
 ---------------------------------------
@@ -271,7 +271,7 @@ Here is the example of removing failed disk from the RAID1 array in the multipat
      mdadm --manage /dev/md1 --remove /dev/dm-8
      mdadm --manage /dev/md2 --remove /dev/dm-11
 
-After the failed disk is removed from the RAID1 array, the partitions on the failed disk will be removed from ``/proc/mdstat`` and the "mdadm --detail" output also. ::
+After the failed disk is removed from the RAID1 array, the partitions on the failed disk will be removed from ``/proc/mdstat`` and the ``mdadm --detail`` output also. ::
 
      # cat /proc/mdstat
      Personalities : [raid1]
@@ -332,7 +332,7 @@ For the multipath configuration, here is an example: ::
 
      sfdisk -d /dev/dm-1 | sfdisk /dev/dm-0
 
-If you got error message "sfdisk: I don't like these partitions - nothing changed.", you can add "--force" option to the sfdisk command: ::
+If you got error message "sfdisk: I don't like these partitions - nothing changed.", you can add ``--force`` option to the ``sfdisk`` command: ::
 
      sfdisk -d /dev/sdb | sfdisk /dev/sda --force
 
@@ -412,7 +412,7 @@ If the new disk does not have a PReP partition or the PReP partition has some pr
 
 * **[SLES]**::
 
-     parted -s /dev/sda mkfs 1 fat16
+     parted -s /dev/sda mkfs 1 fat32
      parted /dev/sda set 1 type 6
      parted /dev/sda set 1 boot on
      dd if=/dev/sdb1 of=/dev/sda1

--- a/xCAT-server/share/xcat/install/scripts/pre.ubuntu
+++ b/xCAT-server/share/xcat/install/scripts/pre.ubuntu
@@ -190,7 +190,7 @@ base64decode()
 logger -t $log_label -p "info" "Generate partition file..."
 if [ -d /sys/firmware/efi ]; then
     echo "ubuntu-efi ::" > /tmp/partitionfile
-    echo "    512 512 1024 fat16" >> /tmp/partitionfile
+    echo "    512 512 1024 fat32" >> /tmp/partitionfile
     echo '    $iflabel{ gpt } $reusemethod{ } method{ efi } format{ }' >> /tmp/partitionfile
     echo "    ." >> /tmp/partitionfile
 else

--- a/xCAT-server/share/xcat/install/scripts/pre.ubuntu.ppc64
+++ b/xCAT-server/share/xcat/install/scripts/pre.ubuntu.ppc64
@@ -203,7 +203,7 @@ base64decode()
 logger -t $log_label -p "info" "Generate partition file..."
 if [ -d /sys/firmware/efi ]; then
     echo "ubuntu-efi ::" > /tmp/partitionfile
-    echo "    512 512 1024 fat16" >> /tmp/partitionfile
+    echo "    512 512 1024 fat32" >> /tmp/partitionfile
     echo '    $iflabel{ gpt } $reusemethod{ } method{ efi } format{ }' >> /tmp/partitionfile
     echo "    ." >> /tmp/partitionfile
 else


### PR DESCRIPTION
### The PR is to fix issue _#6672_

The PR:
* Updates Ubuntu `pre.` files to specify `fat32` filesystem when booting in UEFI mode. Other OSes do not specify `fat` and take a default.
* Updates documentation for the above.
* Fixes some documentation formatting.

```
root@c910f04x14:~# parted -l
Model: IBM ServeRAID M5110e (scsi)
Disk /dev/sda: 439GB
Sector size (logical/physical): 512B/512B
Partition Table: gpt
Disk Flags:

Number  Start   End    Size    File system     Name                  Flags
 1      1049kB  512MB  511MB   fat32           EFI System Partition  boot, esp
 2      512MB   437GB  436GB   ext4
 3      437GB   439GB  2048MB  linux-swap(v1)
root@c910f04x14:~#
```