### PR TITLE
add namedincludes in site table documentation

### DIFF
--- a/docs/source/guides/admin-guides/references/man5/site.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/site.5.rst
@@ -172,6 +172,11 @@ site Attributes:
                    NOTE: If using this attribute to block certain interfaces, make sure
                    the IP maps to your hostname of xCAT MN is not blocked since xCAT needs
                    to use this IP to communicate with the local NDS server on MN.
+
+   namedincludes:  A comma-separated list of file paths that will be included in
+                   named.conf, using named' "include" statement. This can allow users
+                   to include local configuration options that will not be overwritten
+                   by 'makedns -n'.
   
    -------------------------
   HARDWARE CONTROL ATTRIBUTES


### PR DESCRIPTION
This PR adds the `namedincludes` directive from PR #4497 in the `site` table documentation.