### PR TITLE
Improve genimage message

### DIFF
--- a/xCAT-server/share/xcat/netboot/ubuntu/genimage
+++ b/xCAT-server/share/xcat/netboot/ubuntu/genimage
@@ -336,6 +336,11 @@ unless ($onlyinitrd) {
     print "Run cmd [$aptcmd1 $aptcmd2] to create rootimage bootstraps\n";
     my $rc = system("$aptcmd1 $aptcmd2");
     if ($rc) {
+        my $os=xCAT::Utils->osver("os");
+        if ($os ne 'ubuntu') {
+            print "Error: Can not run genimage for Ubunty OS on a non-Ubunty system ($os)";
+            exit 1;
+        }
         print "Error: Can not create bootstraps for rootimage. Make sure you specified full http mirror path.\n";
         exit 1;
     }


### PR DESCRIPTION
When running `genimage` for Ubunty image on a non-Ubunty management node, this message is displayed: `Error: Can not create bootstraps for rootimage. Make sure you specified full http mirror path.` It is very confusing, since it does not tell the use what went wrong.

This PR checks to make sure `genimage` is running on an Ubunty system, and if not, issues a more meaningful message.

```
[root@c910f04x12v02 xcat]# genimage ubuntu18.04.3-x86_64-netboot-compute
Generating image:
cd /opt/xcat/share/xcat/netboot/ubuntu; ./genimage -a x86_64 -o ubuntu18.04.3 -p compute --srcdir "/install/ubuntu18.04.3/x86_64" --pkglist /opt/xcat/share/xcat/netboot/ubuntu/compute.ubuntu18.04.2.x86_64.pkglist --otherpkgdir "/install/post/otherpkgs/ubuntu18.04.3/x86_64" --postinstall "/opt/xcat/share/xcat/netboot/ubuntu/compute.postinstall" --rootimgdir /install/netboot/ubuntu18.04.3/x86_64/compute --tempfile /tmp/xcat_genimage.4984 ubuntu18.04.3-x86_64-netboot-compute
Run cmd [debootstrap --verbose  --arch amd64 bionic /install/netboot/ubuntu18.04.3/x86_64/compute/rootimg http://archive.ubuntu.com/ubuntu/] to create rootimage bootstraps
Error: Can not run geimage for Ubunty OS on a non-Ubunty system (rhel)
Error: [c910f04x12v02]: Command failed: cd /opt/xcat/share/xcat/netboot/ubuntu; ./genimage -a x86_64 -o ubuntu18.04.3 -p compute --srcdir "/install/ubuntu18.04.3/x86_64" --pkglist /opt/xcat/share/xcat/netboot/ubuntu/compute.ubuntu18.04.2.x86_64.pkglist --otherpkgdir "/install/post/otherpkgs/ubuntu18.04.3/x86_64" --postinstall "/opt/xcat/share/xcat/netboot/ubuntu/compute.postinstall" --rootimgdir /install/netboot/ubuntu18.04.3/x86_64/compute --tempfile /tmp/xcat_genimage.4984 ubuntu18.04.3-x86_64-netboot-compute 2>&1. Error message: Run cmd [debootstrap --verbose  --arch amd64 bionic /install/netboot/ubuntu18.04.3/x86_64/compute/rootimg http://archive.ubuntu.com/ubuntu/] to create rootimage bootstraps
Error: Can not run geimage for Ubunty OS on a non-Ubunty system (rhel).

[root@c910f04x12v02 xcat]#
```