### PR TITLE
Add namedincludes to site table documentation

### DIFF
--- a/docs/source/guides/admin-guides/references/man5/site.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/site.5.rst
@@ -173,6 +173,11 @@ site Attributes:
                    the IP maps to your hostname of xCAT MN is not blocked since xCAT needs
                    to use this IP to communicate with the local NDS server on MN.
   
+   namedincludes:  A comma-separated list of file paths that will be included in
+                   named.conf, using named 'include' statement. This can allow users
+                   to include local configuration options that will not be overwritten
+                   by 'makedns -n'
+  
    -------------------------
   HARDWARE CONTROL ATTRIBUTES
    -------------------------

--- a/perl-xCAT/xCAT/Schema.pm
+++ b/perl-xCAT/xCAT/Schema.pm
@@ -1089,6 +1089,10 @@ passed as argument rather than by table value',
 "                 NOTE: If using this attribute to block certain interfaces, make sure\n" .
 "                 the IP maps to your hostname of xCAT MN is not blocked since xCAT needs\n" .
 "                 to use this IP to communicate with the local NDS server on MN.\n\n" .
+" namedincludes:  A comma-separated list of file paths that will be included in\n" .
+"                 named.conf, using named 'include' statement. This can allow users\n" .
+"                 to include local configuration options that will not be overwritten\n" .
+"                 by 'makedns -n'\n\n" .
 " -------------------------\n" .
 "HARDWARE CONTROL ATTRIBUTES\n" .
 " -------------------------\n" .


### PR DESCRIPTION
Replaces #6721

Add `namedincludes` to site table documentation and man page.