### PR TITLE
test: remove imgexport -v test case

### DIFF
--- a/xCAT-test/autotest/testcase/imgexport/cases0
+++ b/xCAT-test/autotest/testcase/imgexport/cases0
@@ -62,13 +62,3 @@ check:output=~Usage|usage
 cmd:imgexport --help
 check:output=~Usage|usage
 end
-
-
-start:imgexport_v
-os:Linux
-label:others
-cmd:imgexport -v
-check:output=~version|Version
-cmd:imgexport --version
-check:output=~version|Version
-edn


### PR DESCRIPTION
we don't support show version of imgexport.
-v means verbose for imgexprot.
So delete this testcase.

Issue:
# imgexport -v
Exporting  to /root...
Error: [xcat-test]: Cannot find image '' from the osimage table.

Signed-off-by: Chen Hanxiao <chen_han_xiao@126.com>