### PR TITLE
Set hostname sooner for SuSE stateless images

### DIFF
--- a/xCAT-server/share/xcat/netboot/sles/dracut_033/xcat-cmdline.sh
+++ b/xCAT-server/share/xcat/netboot/sles/dracut_033/xcat-cmdline.sh
@@ -2,3 +2,5 @@ root=1
 rootok=1
 netroot=xcat
 echo '[ -e $NEWROOT/proc ]' > $hookdir/initqueue/finished/xcatroot.sh
+hostname $(getarg NODE)
+


### PR DESCRIPTION
This avoids ugly behaviors where hostname is set
late or not at all.


