### PR TITLE
Flush out repomd.xml

### DIFF
--- a/xCAT-test/autotest/testcase/go_xcat/case3
+++ b/xCAT-test/autotest/testcase/go_xcat/case3
@@ -21,6 +21,9 @@ check:rc==0
 #Install additional packages on Red Hat
 cmd:if xdsh $$CN "grep \"Red Hat\" /etc/*release >/dev/null"; then xdsh $$CN "yum install -y yum-utils dnf-utils bzip2"; fi
 
+#Pull down repomd.xml on SLES to prevent caching of the wrong file
+cmd:if xdsh $$CN "grep \"SUSE\" /etc/*release >/dev/null"; then xdsh $$CN "wget http://xcat.org/files/xcat/repos/yum/devel/core-snap/repodata/repomd.xml"; fi
+
 #Install additional packages on Ubuntu
 cmd:if xdsh $$CN "grep \"Ubuntu\" /etc/*release >/dev/null"; then xdsh $$CN "DEBIAN_FRONTEND=noninteractive apt-get install -y gnupg"; fi
 


### PR DESCRIPTION
Sometimes `go_xcat_devel_from_repo` testcase fails on sles.
The error:
```
c910f04x12v07: Signature verification failed for file 'repomd.xml' from repository 'xcat-core'.
c910f04x12v07: 
c910f04x12v07:     Note: Signing data enables the recipient to verify that no modifications occurred after the data
c910f04x12v07:     were signed. Accepting data with no, wrong or unknown signature can lead to a corrupted system
c910f04x12v07:     and in extreme cases even to a system compromise.
c910f04x12v07: 
c910f04x12v07:     Note: File 'repomd.xml' is the repositories master index file. It ensures the integrity of the
c910f04x12v07:     whole repo.
c910f04x12v07: 
c910f04x12v07:     Warning: This file was modified after it has been signed. This may have been a malicious change,
c910f04x12v07:     so it might not be trustworthy anymore! You should not continue unless you know it's safe.
c910f04x12v07: 
```
is probably because there is a cached version of `repomd.xml` somewhere on the network.

This PR calls `wget repomd.xml` before running `go-xcat` to try to flush out cached version of `repomd.xml` file.