### PR TITLE
xcattest: proper replace vars in test cases

### DIFF
--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -1867,9 +1867,11 @@ sub getvar
 {
     my $str        = shift;
     my $config_ref = shift;
+    my @vars = ($str =~ /\$\$(\w+)/g);
+    my @reverse_sorted_vars = reverse sort @vars;
 
-    while ($str =~ /\$\$(\w+)/) {
-        my $varname = $1;
+    # let $$AA and $$A have the same chance to be replaced.
+    for my $varname (@reverse_sorted_vars) {
         if (exists($$config_ref{var}{$varname})) {
             $str =~ s/\$\$$varname/$$config_ref{var}{$varname}/g;
         } else {


### PR DESCRIPTION
xcattest will replace vars in testcases.
But vars with same prefix will lead to a replacement failure.

Issue:
XCATTEST_PORT=500 XCATTEST_CN=xcat-com001 XCATTEST_PDU=xmount XCATTEST_PDUIP=192.168.200.100 xcattest -t mkdef_pdu_object

cmd:mkdef $$PDU groups=pdu ip=$$PDUIP mgt=pdu nodetype=pdu

will be :

RUN:mkdef xmount groups=pdu ip=xmountIP mgt=pdu nodetype=pdu

$$PDUIP had no chance to be substituted.

Reported-by: Yang Jian <fun_yang@foxmail.com>
Signed-off-by: Chen Hanxiao <chen_han_xiao@126.com>