### PR TITLE
test: remove imgimport -v test case

### DIFF
--- a/xCAT-test/autotest/testcase/imgimport/cases0
+++ b/xCAT-test/autotest/testcase/imgimport/cases0
@@ -9,17 +9,6 @@ check:output=~usage|Usage
 end
 
 
-start:imgimport_v
-os:Linux
-description:imgimport -v and --version
-label:others
-cmd:imgimport -v
-check:output=~version|Version
-cmd:imgimport --version
-check:output=~version|Version
-end
-
-
 start:imgimport_bundlefile
 os:Linux
 description:imgimport foo.tgz


### PR DESCRIPTION
we don't support show version of imgimport.
-v means verbose for imgimport.
So delete this testcase.

Issue:
# imgexport -v
Error: [xcat]: Cannot find /root/-v

Reported-by: Yang Jian <fun_yang@foxmail.com>
Signed-off-by: Chen Hanxiao <chen_han_xiao@126.com>