### PR TITLE
Flush out deps repomd.xml

### DIFF
--- a/xCAT-test/autotest/testcase/go_xcat/case3
+++ b/xCAT-test/autotest/testcase/go_xcat/case3
@@ -21,8 +21,9 @@ check:rc==0
 #Install additional packages on Red Hat
 cmd:if xdsh $$CN "grep \"Red Hat\" /etc/*release >/dev/null"; then xdsh $$CN "yum install -y yum-utils dnf-utils bzip2"; fi
 
-#Pull down repomd.xml on SLES to prevent caching of the wrong file
+#Pull down core and deps repomd.xml on SLES to prevent caching of the wrong file
 cmd:if xdsh $$CN "grep \"SUSE\" /etc/*release >/dev/null"; then xdsh $$CN "wget http://xcat.org/files/xcat/repos/yum/devel/core-snap/repodata/repomd.xml"; fi
+cmd:if xdsh $$CN "grep \"SUSE\" /etc/*release >/dev/null"; then os=`echo __GETNODEATTR($$CN,os)__ | cut -d "." -f1` && xdsh $$CN "wget http://xcat.org/files/xcat/repos/yum/devel/xcat-dep/$os/__GETNODEATTR($$CN,arch)__/repodata/repomd.xml"; fi
 
 #Install additional packages on Ubuntu
 cmd:if xdsh $$CN "grep \"Ubuntu\" /etc/*release >/dev/null"; then xdsh $$CN "DEBIAN_FRONTEND=noninteractive apt-get install -y gnupg"; fi


### PR DESCRIPTION
Sometimes `go_xcat_devel_from_repo` testcase fails on sles.
The error:
```
c910f04x12v07: Retrieving repository 'xcat-dep' metadata [..
c910f04x12v07: Signature verification failed for file 'repomd.xml' from repository 'xcat-dep'.
c910f04x12v07: Warning: This might be caused by a malicious change in the file!
c910f04x12v07: Continuing might be risky. Continue anyway? [yes/no] (no): no
c910f04x12v07: error]
c910f04x12v07: Repository 'xcat-dep' is invalid.
```

is probably because there is a cached version of `repomd.xml` somewhere on the network.

This PR calls `wget repomd.xml` before running `go-xcat` to try to flush out cached version of deps `repomd.xml` file.