### PR TITLE
Add no-cache option to go-xcat testcases

### DIFF
--- a/xCAT-test/autotest/testcase/go_xcat/case3
+++ b/xCAT-test/autotest/testcase/go_xcat/case3
@@ -22,8 +22,8 @@ check:rc==0
 cmd:if xdsh $$CN "grep \"Red Hat\" /etc/*release >/dev/null"; then xdsh $$CN "yum install -y yum-utils dnf-utils bzip2"; fi
 
 #Pull down core and deps repomd.xml on SLES to prevent caching of the wrong file
-cmd:if xdsh $$CN "grep \"SUSE\" /etc/*release >/dev/null"; then xdsh $$CN "wget http://xcat.org/files/xcat/repos/yum/devel/core-snap/repodata/repomd.xml"; fi
-cmd:if xdsh $$CN "grep \"SUSE\" /etc/*release >/dev/null"; then os=`echo __GETNODEATTR($$CN,os)__ | cut -d "." -f1` && xdsh $$CN "wget http://xcat.org/files/xcat/repos/yum/devel/xcat-dep/$os/__GETNODEATTR($$CN,arch)__/repodata/repomd.xml"; fi
+cmd:if xdsh $$CN "grep \"SUSE\" /etc/*release >/dev/null"; then xdsh $$CN "wget --no-cache http://xcat.org/files/xcat/repos/yum/devel/core-snap/repodata/repomd.xml"; fi
+cmd:if xdsh $$CN "grep \"SUSE\" /etc/*release >/dev/null"; then os=`echo __GETNODEATTR($$CN,os)__ | cut -d "." -f1 | sed s/sle1/sles1/` && xdsh $$CN "wget --no-cache http://xcat.org/files/xcat/repos/yum/devel/xcat-dep/$os/__GETNODEATTR($$CN,arch)__/repodata/repomd.xml"; fi
 
 #Install additional packages on Ubuntu
 cmd:if xdsh $$CN "grep \"Ubuntu\" /etc/*release >/dev/null"; then xdsh $$CN "DEBIAN_FRONTEND=noninteractive apt-get install -y gnupg"; fi


### PR DESCRIPTION
It appears `--no-cache` option to `wget` command allows clearing the remote proxy that sits between xcat.org and lab machines.