### PR TITLE
Testcase fixes

### DIFF
--- a/xCAT-test/autotest/testcase/migration/sles_migration
+++ b/xCAT-test/autotest/testcase/migration/sles_migration
@@ -27,7 +27,7 @@ cmd:service dhcpd restart
 check:rc==0
 cmd:if cat /etc/*release |grep SUSE >/dev/null;then cat /var/lib/dhcp/db/dhcpd.leases|grep $$CN;elif cat /etc/*release |grep "Red Hat" >/dev/null;then cat /var/lib/dhcpd/dhcpd.leases|grep $$CN;fi
 check:output=~$$CN
-cmd:copycds $$ISO
+cmd:copycds $$ISO  | grep -v "%"
 check:rc==0
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
@@ -146,7 +146,7 @@ cmd:service dhcpd restart
 check:rc==0
 cmd:if cat /etc/*release |grep SUSE >/dev/null;then cat /var/lib/dhcp/db/dhcpd.leases|grep $$CN;elif cat /etc/*release |grep "Red Hat" >/dev/null;then cat /var/lib/dhcpd/dhcpd.leases|grep $$CN;fi
 check:output=~$$CN
-cmd:copycds $$ISO
+cmd:copycds $$ISO  | grep -v "%"
 check:rc==0
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
@@ -188,10 +188,11 @@ cmd:xdsh $$CN "zypper sl -U;zypper --gpg-auto-import-keys search --match-exact -
 check:rc==0
 cmd:xdsh $$CN "zypper -n install xCAT"
 check:rc==0
-cmd:xdsh $$CN "zypper -n install createrepo"
+# Name of createrepo package on sles15 is different from sles12
+cmd:if [ "__GETNODEATTR($$CN,os)__" = "sle15" ]; then xdsh $$CN "zypper -n install createrepo_c"; else xdsh $$CN "zypper -n install createrepo";fi
 check:rc==0
 cmd:xdsh $$CN "source /etc/profile.d/xcat.sh"
-eck:rc==0
+check:rc==0
 cmd:xdsh $$CN "lsxcatd -v"
 check:rc==0
 check:output=~$$MIGRATION2_VERSION

--- a/xCAT-test/autotest/testcase/nodeset/cases0
+++ b/xCAT-test/autotest/testcase/nodeset/cases0
@@ -171,7 +171,7 @@ label:others
 cmd:mkdef -t node -o testnode1 arch=ppc64el cons=ipmi groups=pbmc mgt=ipmi ip=10.1.1.200 mac=e6:d4:d2:3a:ad:06  monserver=10.1.1.1 nameservers=10.1.1.1 nodetype=ppc,osi profile=compute tftpserver=10.1.1.1 xcatmaster=10.1.1.1
 check:rc==0
 cmd:chdef testnode1 os=rhels7.5 netboot=petitboot
-eck:rc==0
+check:rc==0
 cmd: mkdef "rhels7.5-ppc64el-install-compute" -u profile=compute provmethod=install osvers=rhels7.5
 check:rc==0
 cmd:nodeset testnode1 osimage="rhels7.5-ppc64el-install-compute"

--- a/xCAT-test/autotest/testcase/xcat_inventory/cases.common
+++ b/xCAT-test/autotest/testcase/xcat_inventory/cases.common
@@ -88,7 +88,7 @@ check:output ~=usage
 check:output ~= error: argument -f/--path: expected one argument
 cmd:xcat-inventory export -t node -o bogusnode --path
 check:rc!=0
-eck:output ~=usage
+check:output ~=usage
 check:output ~= error: argument -f/--path: expected one argument
 cmd:mkdir /tmp/xcat_inventory_export_option_f/testdir
 check:rc==0


### PR DESCRIPTION
This PR:
* Fixes testcase typos `eck` instead of `check`
* For SLES 15 packagename is `createrepo_c` instead of `createrepo`
* Do not save "percentage completed" output of `copycds`. Saves several pages of output in log files.