### PR TITLE
Modify xCAT-server.spec to copy whole xcat/sample dir 

### DIFF
--- a/xCAT-server/xCAT-server.spec
+++ b/xCAT-server/xCAT-server.spec
@@ -148,7 +148,7 @@ chmod 644 $RPM_BUILD_ROOT/%{prefix}/share/xcat/ca/*
 cp share/xcat/mypostscript/* $RPM_BUILD_ROOT/%{prefix}/share/xcat/mypostscript
 cp share/xcat/scripts/* $RPM_BUILD_ROOT/%{prefix}/share/xcat/scripts
 cp share/xcat/conf/* $RPM_BUILD_ROOT/%{prefix}/share/xcat/conf
-cp share/xcat/samples/* $RPM_BUILD_ROOT/%{prefix}/share/xcat/samples
+cp -r share/xcat/samples/* $RPM_BUILD_ROOT/%{prefix}/share/xcat/samples
 cp -r share/xcat/tools/* $RPM_BUILD_ROOT/%{prefix}/share/xcat/tools
 cp -r share/xcat/hamn/* $RPM_BUILD_ROOT/%{prefix}/share/xcat/hamn
 cp share/xcat/rollupdate/* $RPM_BUILD_ROOT/%{prefix}/share/xcat/rollupdate


### PR DESCRIPTION
PR #6736 cause xcat-server build failed with following error
```
error:  build of the following RPMs failed:  xCAT-server
2020-06-19 08:31:33,252 buildxcat WARNING:cp: omitting directory 'share/xcat/samples/cuda11'
error: Bad exit status from /var/tmp/rpm-tmp.iS7dc5 (%install)
    Bad exit status from /var/tmp/rpm-tmp.iS7dc5 (%install)
```
