### PR TITLE
imgimport/imgexport better messages and option handling

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/imgexport.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/imgexport.1.rst
@@ -21,7 +21,7 @@ SYNOPSIS
 
 \ **imgexport [-h| -**\ **-help]**\ 
 
-\ **imgexport**\  \ *image_name*\  [\ *destination*\ ] [[\ **-e | -**\ **-extra**\  \ *file:dir*\ ] ... ] [\ **-p | -**\ **-postscripts**\  \ *node_name*\ ] [\ **-v | -**\ **-verbose**\ ]
+\ **imgexport**\  \ *image_name*\  [\ *destination*\ ] [\ **-e | -**\ **-extra**\  \ *file:dir*\ ] ... ] [\ **-p | -**\ **-postscripts**\  \ *node_name*\ ] [\ **-R | -**\ **-remotehost**\  \ *user@host*\ ] [\ **-v | -**\ **-verbose**\ ]
 
 
 ***********
@@ -90,6 +90,12 @@ OPTIONS
  
 
 
+\ **-R|-**\ **-remotehost**\  \ *user@host*\ 
+ 
+ Export the image to remote host. Passwordless ssh must be setup to the remote host.
+ 
+
+
 \ **-v|-**\ **-verbose**\ 
  
  Verbose output.
@@ -132,7 +138,7 @@ EXAMPLES
   imgexport foo
 
 
-foo.tgz will be built in the current working directory.  Make sure that you have enough space in the directory that you are in to run imgexport if you have a big image to tar up.
+foo.tgz will be built in the current working directory.  Make sure that you have enough space in the directory that you are in to run imgexport, if you have a big image to tar up.
 
 2. To include extra files with your image:
 

--- a/docs/source/guides/admin-guides/references/man1/imgimport.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/imgimport.1.rst
@@ -21,7 +21,7 @@ SYNOPSIS
 
 \ **imgimport [-h|-**\ **-help]**\ 
 
-\ **imgimport**\  \ *bundle_file_name*\  [\ **-p | -**\ **-postscripts**\  \ *nodelist*\ ] [\ **-f | -**\ **-profile**\  \ *new_profile*\ ] [\ **-v | -**\ **-verbose**\ ]
+\ **imgimport**\  \ *bundle_file_name*\  [\ **-p | -**\ **-postscripts**\  \ *nodelist*\ ] [\ **-f | -**\ **-profile**\  \ *new_profile*\ ] [\ **-R | -**\ **-remotehost**\  \ *user@host*\ ] [\ **-v | -**\ **-verbose**\ ]
 
 
 ***********
@@ -106,6 +106,12 @@ OPTIONS
 \ **-p|-**\ **-postscripts**\  \ *nodelist*\ 
  
  Import the postscripts. The postscripts contained in the image will be set in the postscripts table for \ *nodelist*\ .
+ 
+
+
+\ **-R|-**\ **-remotehost**\  \ *user@host*\ 
+ 
+ Import the image from remote host. Passwordless ssh must be setup to the remote host.
  
 
 

--- a/xCAT-client/pods/man1/imgexport.1.pod
+++ b/xCAT-client/pods/man1/imgexport.1.pod
@@ -6,7 +6,7 @@ B<imgexport> - Exports an xCAT image.
 
 B<imgexport [-h| --help]>
 
-B<imgexport> I<image_name> [I<destination>] [[B<-e>|B<--extra> I<file:dir>] ... ] [B<-p>|B<--postscripts> I<node_name>] [B<-v>|B<--verbose>]
+B<imgexport> I<image_name> [I<destination>] [B<-e>|B<--extra> I<file:dir>] ... ] [B<-p>|B<--postscripts> I<node_name>] [B<-R>|B<--remotehost> I<user@host>] [B<-v>|B<--verbose>]
 
 
 =head1 DESCRIPTION
@@ -65,6 +65,10 @@ Display usage message.
 
 Get the names of the postscripts and postbootscripts for the given node and pack them into the image.
 
+=item B<-R|--remotehost> I<user@host>
+
+Export the image to remote host. Passwordless ssh must be setup to the remote host.
+
 =item B<-v|--verbose>
 
 Verbose output.
@@ -92,7 +96,7 @@ The output bundle file name.
 
  imgexport foo
 
-foo.tgz will be built in the current working directory.  Make sure that you have enough space in the directory that you are in to run imgexport if you have a big image to tar up.
+foo.tgz will be built in the current working directory.  Make sure that you have enough space in the directory that you are in to run imgexport, if you have a big image to tar up.
 
 2. To include extra files with your image:
 

--- a/xCAT-client/pods/man1/imgimport.1.pod
+++ b/xCAT-client/pods/man1/imgimport.1.pod
@@ -6,7 +6,7 @@ B<imgimport> - Imports an xCAT image or configuration file into the xCAT tables 
 
 B<imgimport [-h|--help]>
 
-B<imgimport> I<bundle_file_name> [B<-p>|B<--postscripts> I<nodelist>] [B<-f>|B<--profile> I<new_profile>] [B<-v>|B<--verbose>]
+B<imgimport> I<bundle_file_name> [B<-p>|B<--postscripts> I<nodelist>] [B<-f>|B<--profile> I<new_profile>] [B<-R>|B<--remotehost> I<user@host>] [B<-v>|B<--verbose>]
 
 =head1 DESCRIPTION
 
@@ -81,6 +81,10 @@ Display usage message.
 =item B<-p|--postscripts> I<nodelist>
 
 Import the postscripts. The postscripts contained in the image will be set in the postscripts table for I<nodelist>.
+
+=item B<-R|--remotehost> I<user@host>
+
+Import the image from remote host. Passwordless ssh must be setup to the remote host.
 
 =item B<-v|--verbose>
 


### PR DESCRIPTION
### The PR is to fix issue _#6745_

This PR:
1. Improves error messages for remote host image copy
2. Displays usage when image name is not specified
3. Updates man pages to describe `--remotehost` flag