### PR TITLE
More improvements to go-xcat testcases

### DIFF
--- a/xCAT-test/autotest/testcase/go_xcat/case3
+++ b/xCAT-test/autotest/testcase/go_xcat/case3
@@ -131,7 +131,7 @@ check:output=~running
 #Update to devel version of xCAT
 cmd:xdsh $$CN "cd /; ./go-xcat --xcat-version=devel -y update"
 cmd:version=`xdsh $$CN /opt/xcat/bin/lsxcatd -v`; if [[ $version =~ "Version" ]]; then echo "xCAT updated successfully first time"; else echo "First attempt to update xCAT failed, attempting to update xCAT again"; xdsh $$CN "cd /; ./go-xcat --xcat-version=devel -y update"; fi
-check:output=~"xCAT updated successfully first time"|"xCAT has been successfully updated"
+check:output=~xCAT updated successfully first time|xCAT has been successfully updated
 cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;lsxcatd -v"
 check:rc==0
 cmd:xdsh $$CN "service xcatd status"
@@ -191,8 +191,8 @@ check:output=~could not be found|dead|no such service xcatd
 
 #Install devel version of xCAT
 cmd:xdsh $$CN "cd /; ./go-xcat --xcat-version=devel -y install"
-check:rc==0
-cmd:xdsh $$CN "cat /tmp/go-xcat.log"
+cmd:version=`xdsh $$CN /opt/xcat/bin/lsxcatd -v`; if [[ $version =~ "Version" ]]; then echo "xCAT installed successfully first time"; else echo "First attempt to install xCAT failed, attempting to install xCAT again"; xdsh $$CN "cd /; ./go-xcat -y --xcat-version=devel install"; fi
+check:output=~xCAT updated successfully first time|xCAT has been successfully updated
 cmd:xdsh $$CN "source /etc/profile.d/xcat.sh;lsxcatd -a"
 check:rc==0
 cmd:xdsh $$CN "service xcatd status"


### PR DESCRIPTION
Fix output match and add second retry to `go_xcat_stable_from_repo_reinstall_devel` testcase.
