### PR TITLE
Do not modify installnic's interface in enablekdump postscripts

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/common/deployment/enable_kdump.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/deployment/enable_kdump.rst
@@ -166,6 +166,8 @@ Appedix
 
     * https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/kernel_crash_dump_guide/sect-kdump-config-cli.
 
+    * https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/system_design_guide/installing-and-configuring-kdump_system-design-guide 
+
 #. OS Documentation on dump analysis:
 
     * http://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/5/html/Deployment_Guide/s1-kdump-crash.htmlRHELdocument

--- a/docs/source/guides/admin-guides/manage_clusters/common/deployment/enable_kdump.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/deployment/enable_kdump.rst
@@ -170,5 +170,5 @@ Appedix
 
 #. OS Documentation on dump analysis:
 
-    * http://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/5/html/Deployment_Guide/s1-kdump-crash.htmlRHELdocument
+    * https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/deployment_guide/s1-kdump-crashdd 
 

--- a/xCAT/postscripts/enablekdump
+++ b/xCAT/postscripts/enablekdump
@@ -58,11 +58,6 @@ if [ ! -z "$MACX" ] && [ ! -z "$ETHX" ]; then
         echo "ONBOOT=yes" >> $CONFFILE
         echo "IPADDR=$IP" >> $CONFFILE
         echo "NETMASK=$MASK" >> $CONFFILE
-    else
-        echo "DEVICE=$ETHX" > $CONFFILE
-        echo "BOOTPROTO=dhcp" >> $CONFFILE
-        echo "HWADDR=$MACX" >> $CONFFILE
-        echo "ONBOOT=yes" >> $CONFFILE
     fi
 fi
 


### PR DESCRIPTION
This PR is fix issue #6748 .

According the redhat8 documention guide:
https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/system_design_guide/installing-and-configuring-kdump_system-design-guide

I didn't find it's necessary to change interface `ifcfg` file to dhcp for kdump process,  so will keep interface as-is.