### PR TITLE
Lost DNS after run confignetwork -s postscripts

### DIFF
--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -524,6 +524,7 @@ elif [ "$1" = "-s" ];then
     str_inst_mask=''
     str_inst_gateway=''
     str_inst_mtu=''
+    str_inst_dns=''
     if [ "$str_os_type" = "aix" ];then
         log_error "configeth on $NODE: aix does not support -s flag"
         exit 1
@@ -578,6 +579,7 @@ elif [ "$1" = "-s" ];then
             str_inst_ip=`grep fixed-address $str_lease_file | tail -n 1 | awk '{print $2}' | sed 's/;$//'`
             str_inst_mask=`grep subnet-mask $str_lease_file | tail -n 1 | awk '{print $3}' | sed 's/;$//'`
             str_inst_gateway=`grep routers $str_lease_file | tail -n 1 | awk '{print $3}' | sed 's/;$//'`
+            str_inst_dns=`grep domain-name-servers $str_lease_file | tail -n 1 | awk '{print $3}' | sed 's/;$//'`
         else
             if [ -n "$MACADDRESS" ];then
                 str_inst_mac=$MACADDRESS
@@ -733,6 +735,11 @@ elif [ "$1" = "-s" ];then
         fi
         if [ $networkmanager_active -eq 2 ]; then
             echo "AUTOCONNECT_PRIORITY=9" >> $str_conf_file
+        fi
+        if [ -n "${str_inst_dns}" ];then
+	        if [ $networkmanager_active -eq 1 ]; then
+		        nmcli con modify $con_name ipv4.dns ${str_inst_dns}
+                fi
         fi
         if [ -n "${str_inst_mtu}" ];then
 	        if [ $networkmanager_active -eq 1 ]; then


### PR DESCRIPTION
This issue is seen on the redhat 8.1 system
The node is provisioned with `rhels8.1.0-x86_64-netboot-compute` images,  and `confignetwork -s` postscripts is defined for the node attribute, but nothing define in the nic table
```
# lsdef  c910f04x12v04 -i postscripts
Object name: c910f04x12v04
    postscripts=syslog,remoteshell,syncfiles,confignetwork -s
# tabdump nics
#node,nicips,nichostnamesuffixes,nichostnameprefixes,nictypes,niccustomscripts,nicnetworks,nicaliases,nicextraparams,nicdevices,nicsadapter,comments,disable
```
after node provisioned, `/etc/resolv.conf` showed empty, and the node can ping it's ip address, but can't ping it's hostname.   the node status stuck at the `postbooting`
```
[root@c910f04x12v04 ~]# ip addr show ens3
2: ens3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 42:f9:0a:04:0c:04 brd ff:ff:ff:ff:ff:ff
    inet 10.4.12.4/8 brd 10.255.255.255 scope global noprefixroute ens3
       valid_lft forever preferred_lft forever
    inet6 fe80::9bbe:5730:124a:8c59/64 scope link noprefixroute
       valid_lft forever preferred_lft forever
[root@c910f04x12v04 ~]# ping 10.4.12.4
PING 10.4.12.4 (10.4.12.4) 56(84) bytes of data.
64 bytes from 10.4.12.4: icmp_seq=1 ttl=64 time=0.027 ms
64 bytes from 10.4.12.4: icmp_seq=2 ttl=64 time=0.014 ms
64 bytes from 10.4.12.4: icmp_seq=3 ttl=64 time=0.015 ms
^C
--- 10.4.12.4 ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 54ms
rtt min/avg/max/mdev = 0.014/0.018/0.027/0.007 ms

[root@c910f04x12v04 ~]# cat /etc/resolv.conf
# Generated by NetworkManager
[root@c910f04x12v04 ~]# ping c910f04x12v04
ping: c910f04x12v04: Name or service not known

# lsdef c910f04x12v04 -i status
Object name: c910f04x12v04
    status=postbooting

``` 