### PR TITLE
Enable clusterstatus xcatprobe on Perl 5.23

### DIFF
--- a/xCAT-probe/subcmds/clusterstatus
+++ b/xCAT-probe/subcmds/clusterstatus
@@ -45,6 +45,8 @@ my %type_nodesnum = ();
 #    matching --> matched --> installing --> booting --> booted
 #    matching --> matched --> booting --> installing --> xxx --> booted
 #   The terminal state is configured(For PDU/Switch) or booted(for Node)
+#   matching means node found matching the range, but no status attribute value
+#   matched means node found matching the range, with mac attribute value, but no status attribute value
 #-----------------------------
 my %state_node_hash = ();
 
@@ -240,7 +242,7 @@ sub update_nodes_info {
         foreach (@unmatched_nodes_attributes) {
             if (/^(.*):\s*mac=(.*)$/) {
                 if ($2) {
-                    update_node_info($1, "Matched");
+                    update_node_info($1, "matched (no status)");
                 }
             }
         }
@@ -279,7 +281,7 @@ sub update_node_info {
     if (exists($state_node_hash{$node_type}{$node_state}{$node})) {
         delete($state_node_hash{$node_type}{$node_state}{$node});
     }
-    unless (scalar keys ($state_node_hash{$node_type}{$node_state})) {
+    unless (scalar keys (%{$state_node_hash{$node_type}{$node_state}})) {
         delete($state_node_hash{$node_type}{$node_state});
     }
 
@@ -307,10 +309,10 @@ sub check_nodes_attributes {
             $node_info{$_}{state} = $nodehash{$_}{status};
             $unfinished_nodes{$_} = 1;
         } elsif ($nodehash{$_}{mac}) {
-            $node_info{$_}{state} = "Matched";
+            $node_info{$_}{state} = "matched (no status)";
             $unfinished_nodes{$_} = 1;
         } else {
-            $node_info{$_}{state} = "matching";
+            $node_info{$_}{state} = "matching (no status, no mac)";
             $unmatched_nodes{$_} = 1;
         }
         if ($nodehash{$_}{mgt} eq 'pdu') {

--- a/xCAT-probe/subcmds/code_template
+++ b/xCAT-probe/subcmds/code_template
@@ -144,7 +144,7 @@ if ($help) {
 }
 
 if ($test) {
-    probe_utils->send_msg("$output", "o", "This isn't a probe tool, this is just a template for sub command coding. Using it to develop sub command which need to cover hierarchical cluster");
+    probe_utils->send_msg("$output", "o", "This isn't a probe tool, this is just a template for sub command coding. Use it to develop sub command which need to cover hierarchical cluster");
     exit 0;
 }
 

--- a/xCAT-server/share/xcat/tools/powervm/configvios
+++ b/xCAT-server/share/xcat/tools/powervm/configvios
@@ -139,7 +139,7 @@ sub get_cmd
 
         foreach (@hdisk)
         {
-            `lspv|grep $_ >/dev/nul 2>&1`;
+            `lspv|grep $_ >/dev/null 2>&1`;
             $err++ if ($? != 0)
         }
 
@@ -152,7 +152,7 @@ sub get_cmd
             next;
         }
 
-        `lsvg $key > /dev/nul 2>&1`;
+        `lsvg $key > /dev/null 2>&1`;
         if ($? == 0)
         {
             #print "Invalid configuration item $key: vg $key already existed\n";
@@ -193,7 +193,7 @@ sub get_cmd
             next;
         }
 
-        `su - padmin " -c ioscli lslv $conf[0]" > /dev/nul 2>&1`;
+        `su - padmin " -c ioscli lslv $conf[0]" > /dev/null 2>&1`;
         if ($? == 0)
         {
             #print "Invalid configuration item $key:the lv name $conf[0] already existed\n";
@@ -203,7 +203,7 @@ sub get_cmd
             next;
         }
 
-        `su - padmin " -c ioscli lsvg $conf[1]" > /dev/nul 2>&1`;
+        `su - padmin " -c ioscli lsvg $conf[1]" > /dev/null 2>&1`;
         if ($? != 0)
         {
             #print "Invalid configuration item $key:the vg $conf[1] doesn't exist\n";
@@ -242,7 +242,7 @@ sub get_cmd
     print "Mapping logical volumes to virtual adapters...";
     while (my ($key, $value) = each %config)
     {
-        `su - padmin " -c ioscli lslv $value" > /dev/nul 2>&1`;
+        `su - padmin " -c ioscli lslv $value" > /dev/null 2>&1`;
         if ($? != 0)
         {
             #print "Invalid configuration item $key: lv $value doesn't exist\n";
@@ -252,7 +252,7 @@ sub get_cmd
             next;
         }
 
-        `su - padmin " -c ioscli lsdev -virtual |grep $key " >/dev/nul 2>&1`;
+        `su - padmin " -c ioscli lsdev -virtual |grep $key " >/dev/null 2>&1`;
         if ($? != 0)
         {
             #print "Invaild configuration item $key: virtual adapter $key doesn't exist\n";

--- a/xCAT-server/share/xcat/tools/xCATreg
+++ b/xCAT-server/share/xcat/tools/xCATreg
@@ -1173,7 +1173,7 @@ sub send_email {
 sub git_update {
     send_msg(2, "[git update] starting to update xcat source code from git");
 
-    my $res = system("cd $xcatcoredir && git checkout $branch > /dev/nul 2>&1");
+    my $res = system("cd $xcatcoredir && git checkout $branch > /dev/null 2>&1");
     if ($res != 0) {
         send_msg(0, "[git update] change to branch $branch....[failed]");
         return 2;
@@ -1198,7 +1198,7 @@ sub git_update {
         return 2;
     }
 
-    $res = system("grep 'Already up-to-date' $gitpulloutput > /dev/nul 2>&1");
+    $res = system("grep 'Already up-to-date' $gitpulloutput > /dev/null 2>&1");
     if ($res == 0 && !$forceregwithoutupdate) {
         send_msg(2, "[git update] code is already at latest version. exit regresson");
         return 1;

--- a/xCAT-test/autotest/bundle/rhels_ppcle_weekly.bundle
+++ b/xCAT-test/autotest/bundle/rhels_ppcle_weekly.bundle
@@ -17,6 +17,7 @@ bmcdiscover_range_z
 bmcdiscover_help
 bmcdiscover_q
 bmcdiscover_version
+xcatprobe_work
 confignetwork_static_installnic
 get_xcat_postscripts_loginfo
 nodeset_cmdline

--- a/xCAT-test/autotest/bundle/rhels_x86_weekly.bundle
+++ b/xCAT-test/autotest/bundle/rhels_x86_weekly.bundle
@@ -17,6 +17,7 @@ bmcdiscover_range_z
 bmcdiscover_help
 bmcdiscover_q
 bmcdiscover_version
+xcatprobe_work
 confignetwork_static_installnic
 get_xcat_postscripts_loginfo
 nodeset_cmdline

--- a/xCAT/postscripts/check_mlnx_firmware
+++ b/xCAT/postscripts/check_mlnx_firmware
@@ -6,7 +6,7 @@
 #
 BINARIES="ofed_info mst ibdev2netdev"
 for PROG in ${BINARIES}; do
-    RC=`command -v ${PROG} >> /dev/nul 2>&1; echo $?`
+    RC=`command -v ${PROG} >> /dev/null 2>&1; echo $?`
     if [[ ${RC} != 0 ]]; then
         echo "${PROG} is not installed on this node, unable to check firmware levels."
         exit 1

--- a/xCAT/postscripts/enablecapi
+++ b/xCAT/postscripts/enablecapi
@@ -29,7 +29,7 @@ function logerr {
 #check if mlnx ofed commands are installed
 COMMANDS="ofed_info mst mlxconfig"
 for CMD in ${COMMANDS}; do
-    RC=`command -v ${CMD} >> /dev/nul 2>&1; echo $?`
+    RC=`command -v ${CMD} >> /dev/null 2>&1; echo $?`
     if [[ ${RC} != 0 ]]; then
         ERRMSG="Command: ${CMD} is not found, unable to run the scripts"
         logerr $ERRMSG


### PR DESCRIPTION
### The PR is to fix issue _#6759_

This PR:
* Fixes clusterstatus xcatprobe subcommand so that it does not fail on Perl 5.23 and later 
* Added explanation to what `matched` and `unmatched` states mean in the output of `xcatprobe clusterstatus`
* Adds xcatprobe testcase to RHEL weekly regression test bundles
* Fixes typo `nul` instead of `null`, originally reported by #6737 

### UT
Verified on Perl versions before 5.23 and after 5.23:
```
====Wed Jul  8 13:57:56 2020(33 seconds Elapsed)
node(Total: 46)--------------------------
        matching (no status, no mac) : 6(13.04%)
        matched (no status) : 11(23.91%)
        booted : 20(43.48%)
        installing : 1(2.17%)
        failed : 2(4.35%)
        powering-off : 2(4.35%)
        booting : 1(2.17%)
        powering-on : 3(6.52%)

The cluster state===============================
node(Total: 46)--------------------------
        matching (no status, no mac)(6): fs2vm105,fs2vm110,fs2vm112,c910f03c15,fs2vm111,fs2vm104
        matched (no status)(11): boston30-bmc,f6u07-bmc,boston32-bmc,f5u14-bmc,f5u25-bmc,boston38-bmc,c910hmc02,c910h...
        booted(20): briggs01,fs2vm100,gpfs01,zztop,boston36,fs2vm113,frame5u39,fs2vm114,ws-seq-fw-2,fs2vm102,c910f3u2...
        installing(1): c910f03c15p01
        failed(2): c910f3u27-fs3,f6u07
        powering-off(2): c910f3zz01,c910f3c06v01
        booting(1): c910f3u29-fs1
        powering-on(3): boston32,c910f03c15v01,f5u25
[root@stratton01 xcat]#
```