### PR TITLE
xCAT-probe rpm installation of switchprobe

### DIFF
--- a/xCAT-probe/xCAT-probe.spec
+++ b/xCAT-probe/xCAT-probe.spec
@@ -11,7 +11,7 @@ Vendor: IBM Corp.
 Distribution: %{?_distribution:%{_distribution}}%{!?_distribution:%{_vendor}}
 Prefix: /opt/xcat
 BuildRoot: /var/tmp/%{name}-%{version}-%{release}-root
-Requires: xCAT-client
+Requires: xCAT-client = 4:%{version}-%{release}
 
 %ifos linux
 BuildArch: noarch

--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -172,13 +172,13 @@ GO_XCAT_CORE_PACKAGE_LIST=()
 GO_XCAT_DEP_PACKAGE_LIST=()
 
 # The package list of all the packages should be installed
-GO_XCAT_INSTALL_LIST=(perl-xCAT xCAT xCAT-buildkit xCAT-client
+GO_XCAT_INSTALL_LIST=(perl-xCAT xCAT-client xCAT xCAT-buildkit
 	xCAT-genesis-scripts-ppc64 xCAT-genesis-scripts-x86_64 xCAT-server
 	elilo-xcat grub2-xcat ipmitool-xcat syslinux-xcat
 	xCAT-genesis-base-ppc64 xCAT-genesis-base-x86_64 xnba-undi yaboot-xcat)
 # For Debian/Ubuntu, it will need a sight different package list
 type dpkg >/dev/null 2>&1 &&
-GO_XCAT_INSTALL_LIST=(perl-xcat xcat xcat-buildkit xcat-client
+GO_XCAT_INSTALL_LIST=(perl-xcat xcat-client xcat xcat-buildkit
 	xcat-genesis-scripts-amd64 xcat-genesis-scripts-ppc64 xcat-server
 	elilo-xcat grub2-xcat ipmitool-xcat syslinux-xcat
 	xcat-genesis-base-amd64 xcat-genesis-base-ppc64 xnba-undi)


### PR DESCRIPTION
Problem reported by #6026 still exists on xCAT regression test cluster. It seems the even though the `xCAT-probe` lists `xCAT-client` in its `Requires` statement, it does not guarantee on RHEL7.6 that `xCAT-client` gets installed before `xCAT-probe`. It appears it just means they are installed together.

This PR fixes format of `Requires` statement, to match other xCAT spec files. It also moves `xCAT-client` more towards the beginning of the install list in `go-xcat`, the hope is that `xCAT-client` gets installed before `xCAT-probe`

Nodes installed with RHEL7.6 are missing `switchprobe` 

```
[root@c910f03c17k07 ~]# xdsh nodelist.status==booted ls /opt/xcat/probe/subcmds/bin/switchprobe
[c910f03c17k07]: c910f02c39p06: ls: cannot access /opt/xcat/probe/subcmds/bin/switchprobe: No such file or directory
[c910f03c17k07]: c910f03c09k09: ls: cannot access /opt/xcat/probe/subcmds/bin/switchprobe: No such file or directory
[c910f03c17k07]: c910f02c39p03: ls: cannot access /opt/xcat/probe/subcmds/bin/switchprobe: No such file or directory
[c910f03c17k07]: c910f02c39p09: ls: cannot access /opt/xcat/probe/subcmds/bin/switchprobe: No such file or directory
[c910f03c17k07]: c910f04x37v08: ls: cannot access /opt/xcat/probe/subcmds/bin/switchprobe: No such file or directory
c910f03c09k12: /opt/xcat/probe/subcmds/bin/switchprobe
c910f03c11k09: /opt/xcat/probe/subcmds/bin/switchprobe
c910f03c09k18: /opt/xcat/probe/subcmds/bin/switchprobe
f6u13k13:      /opt/xcat/probe/subcmds/bin/switchprobe
c910f04x35v02: /opt/xcat/probe/subcmds/bin/switchprobe
c910f03c11k15: /opt/xcat/probe/subcmds/bin/switchprobe
c910f03c09k15: /opt/xcat/probe/subcmds/bin/switchprobe
c910f04x12v02: /opt/xcat/probe/subcmds/bin/switchprobe
c910f04x12v05: /opt/xcat/probe/subcmds/bin/switchprobe
c910f04x35v05: /opt/xcat/probe/subcmds/bin/switchprobe
c910f03c11k12: /opt/xcat/probe/subcmds/bin/switchprobe
f6u13k16:      /opt/xcat/probe/subcmds/bin/switchprobe
f6u13k10:      /opt/xcat/probe/subcmds/bin/switchprobe
[root@c910f03c17k07 ~]#
```

```
[root@c910f03c17k07 ~]# lsdef c910f02c39p06,c910f03c09k09,c910f02c39p03,c910f02c39p09,c910f04x37v08 -i provmethod -c
c910f02c39p03: provmethod=rhels7.6-ppc64-install-compute
c910f02c39p06: provmethod=rhels7.6-ppc64-install-compute
c910f02c39p09: provmethod=rhels7.6-ppc64-install-compute
c910f03c09k09: provmethod=rhels7.6-ppc64le-install-compute
c910f04x37v08: provmethod=rhels7.6-x86_64-install-compute
[root@c910f03c17k07 ~]#
```