### PR TITLE
Replace misspelled gpgpcheck with gpgcheck

### DIFF
--- a/xCAT-server/share/xcat/netboot/debian/genimage
+++ b/xCAT-server/share/xcat/netboot/debian/genimage
@@ -266,7 +266,7 @@ unless ($onlyinitrd) {
         foreach $pass (sort (keys(%extra_hash))) {
             foreach (keys(%{ $extra_hash{$pass} })) {
                 if (($_ eq "PRE_REMOVE") || ($_ eq "POST_REMOVE")) { next; }
-                print $yumconfig "[otherpkgs$index]\nname=otherpkgs$index\nbaseurl=file://$srcdir_otherpkgs/$_\ngpgpcheck=0\n\n";
+                print $yumconfig "[otherpkgs$index]\nname=otherpkgs$index\nbaseurl=file://$srcdir_otherpkgs/$_\ngpgcheck=0\n\n";
                 $index++;
                 my $pa = $extra_hash{$pass}{$_};
                 $extrapkgnames{$pass} .= " " . join(' ', @$pa);

--- a/xCAT-server/share/xcat/netboot/fedora12/genimage
+++ b/xCAT-server/share/xcat/netboot/fedora12/genimage
@@ -178,7 +178,7 @@ unless ($onlyinitrd) {
     open($yumconfig, ">", "/tmp/genimage.$$.yum.conf");
     my $repnum = 0;
     foreach $srcdir (@yumdirs) {
-        print $yumconfig "[$osver-$arch-$repnum]\nname=$osver-$arch-$repnum\nbaseurl=file://$srcdir\ngpgpcheck=0\n\n";
+        print $yumconfig "[$osver-$arch-$repnum]\nname=$osver-$arch-$repnum\nbaseurl=file://$srcdir\ngpgcheck=0\n\n";
         $repnum += 1;
     }
     $repnum -= 1;
@@ -263,7 +263,7 @@ unless ($onlyinitrd) {
                 }
 
                 if (($_ eq "PRE_REMOVE") || ($_ eq "POST_REMOVE")) { next; }
-                print $yumconfig "[otherpkgs$index]\nname=otherpkgs$index\nbaseurl=file://$srcdir_otherpkgs/$_\ngpgpcheck=0\n\n";
+                print $yumconfig "[otherpkgs$index]\nname=otherpkgs$index\nbaseurl=file://$srcdir_otherpkgs/$_\ngpgcheck=0\n\n";
                 $index++;
                 my $pa = $extra_hash{$pass}{$_};
                 $extrapkgnames{$pass} .= " " . join(' ', @$pa);

--- a/xCAT-server/share/xcat/netboot/fedora12/geninitrd
+++ b/xCAT-server/share/xcat/netboot/fedora12/geninitrd
@@ -211,7 +211,7 @@ unless ($onlyinitrd) {
     open($yumconfig, ">", "/tmp/genimage.$$.yum.conf");
     my $repnum = 0;
     foreach $srcdir (@yumdirs) {
-        print $yumconfig "[$osver-$arch-$repnum]\nname=$osver-$arch-$repnum\nbaseurl=file://$srcdir\ngpgpcheck=0\n\n";
+        print $yumconfig "[$osver-$arch-$repnum]\nname=$osver-$arch-$repnum\nbaseurl=file://$srcdir\ngpgcheck=0\n\n";
         $repnum += 1;
     }
     $repnum -= 1;
@@ -279,7 +279,7 @@ unless ($onlyinitrd) {
         foreach $pass (sort (keys(%extra_hash))) {
             foreach (keys(%{ $extra_hash{$pass} })) {
                 if (($_ eq "PRE_REMOVE") || ($_ eq "POST_REMOVE")) { next; }
-                print $yumconfig "[otherpkgs$index]\nname=otherpkgs$index\nbaseurl=file://$srcdir_otherpkgs/$_\ngpgpcheck=0\n\n";
+                print $yumconfig "[otherpkgs$index]\nname=otherpkgs$index\nbaseurl=file://$srcdir_otherpkgs/$_\ngpgcheck=0\n\n";
                 $index++;
                 my $pa = $extra_hash{$pass}{$_};
                 $extrapkgnames{$pass} .= " " . join(' ', @$pa);

--- a/xCAT-server/share/xcat/netboot/mic/genimage
+++ b/xCAT-server/share/xcat/netboot/mic/genimage
@@ -125,7 +125,7 @@ if ($otherpkglist) {
     open($yumconfig, ">", "/tmp/genimage.$$.yum.conf");
     my $repnum = 0;
     foreach $srcdir (@yumdirs) {
-        print $yumconfig "[$aiddistro-$repnum]\nname=$aiddistro-$repnum\nbaseurl=file://$srcdir\ngpgpcheck=0\n\n";
+        print $yumconfig "[$aiddistro-$repnum]\nname=$aiddistro-$repnum\nbaseurl=file://$srcdir\ngpgcheck=0\n\n";
         $repnum += 1;
     }
     $repnum -= 1;
@@ -148,7 +148,7 @@ if ($otherpkglist) {
                 }
 
                 if (($_ eq "PRE_REMOVE") || ($_ eq "POST_REMOVE") || ($_ eq "ENVLIST")) { next; }
-                print $yumconfig "[otherpkgs$index]\nname=otherpkgs$index\nbaseurl=file://$srcdir_otherpkgs/$_\ngpgpcheck=0\n\n";
+                print $yumconfig "[otherpkgs$index]\nname=otherpkgs$index\nbaseurl=file://$srcdir_otherpkgs/$_\ngpgcheck=0\n\n";
                 $repohash{$pass}{$index} = 1;
                 $index++;
                 my $pa = $extra_hash{$pass}{$_};

--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -336,11 +336,11 @@ if($onlyinitrd){
 
     my $repnum = 0;
     foreach $srcdir (@yumdirs) {
-        print $yumconfig "[$osver-$arch-$repnum]\nname=$osver-$arch-$repnum\nbaseurl=file://$srcdir\ngpgpcheck=0\nskip_if_unavailable=True\n\n";
+        print $yumconfig "[$osver-$arch-$repnum]\nname=$osver-$arch-$repnum\nbaseurl=file://$srcdir\ngpgcheck=0\nskip_if_unavailable=True\n\n";
         $repnum += 1;
     }
     foreach $srcdir (@pkgdir_internet) {
-       print $yumconfig "[$osver-$arch-$repnum]\nname=$osver-$arch-$repnum\nbaseurl=$srcdir\ngpgpcheck=0\nskip_if_unavailable=True\n\n";
+       print $yumconfig "[$osver-$arch-$repnum]\nname=$osver-$arch-$repnum\nbaseurl=$srcdir\ngpgcheck=0\nskip_if_unavailable=True\n\n";
        $repnum += 1;
     }
     $repnum -= 1;
@@ -516,12 +516,12 @@ if($onlyinitrd){
 
                 if (($_ eq "PRE_REMOVE") || ($_ eq "POST_REMOVE") || ($_ eq "ENVLIST")) { next; }
                 foreach(@otherpkgdir_url){
-                    print $yumconfig "[otherpkgs$index]\nname=otherpkgs$index\nbaseurl=$_\ngpgpcheck=0\nskip_if_unavailable=True\n\n";
+                    print $yumconfig "[otherpkgs$index]\nname=otherpkgs$index\nbaseurl=$_\ngpgcheck=0\nskip_if_unavailable=True\n\n";
                     $repohash{$pass}{$index} = 1;
                     $index++;
                 }
 
-                print $yumconfig "[otherpkgs$index]\nname=otherpkgs$index\nbaseurl=file://$srcdir_otherpkgs_local/$_\ngpgpcheck=0\nskip_if_unavailable=True\n\n";
+                print $yumconfig "[otherpkgs$index]\nname=otherpkgs$index\nbaseurl=file://$srcdir_otherpkgs_local/$_\ngpgcheck=0\nskip_if_unavailable=True\n\n";
                 $repohash{$pass}{$index} = 1;
                 $index++;
                 my $pa = $extra_hash{$pass}{$_};

--- a/xCAT-server/share/xcat/netboot/rh/genimage.rh4
+++ b/xCAT-server/share/xcat/netboot/rh/genimage.rh4
@@ -211,7 +211,7 @@ unless ($onlyinitrd) {
     open($yumconfig, ">", "/tmp/genimage.$$.yum.conf");
     my $repnum = 0;
     foreach $srcdir (@yumdirs) {
-        print $yumconfig "[$osver-$arch-$repnum]\nname=$osver-$arch-$repnum\nbaseurl=file://$srcdir\ngpgpcheck=0\n\n";
+        print $yumconfig "[$osver-$arch-$repnum]\nname=$osver-$arch-$repnum\nbaseurl=file://$srcdir\ngpgcheck=0\n\n";
         $repnum += 1;
     }
     $repnum -= 1;
@@ -285,7 +285,7 @@ unless ($onlyinitrd) {
         foreach $pass (sort (keys(%extra_hash))) {
             foreach (keys(%{ $extra_hash{$pass} })) {
                 if (($_ eq "PRE_REMOVE") || ($_ eq "POST_REMOVE")) { next; }
-                print $yumconfig "[otherpkgs$index]\nname=otherpkgs$index\nbaseurl=file://$srcdir_otherpkgs/$_\ngpgpcheck=0\n\n";
+                print $yumconfig "[otherpkgs$index]\nname=otherpkgs$index\nbaseurl=file://$srcdir_otherpkgs/$_\ngpgcheck=0\n\n";
                 $index++;
                 my $pa = $extra_hash{$pass}{$_};
                 $extrapkgnames{$pass} .= " " . join(' ', @$pa);

--- a/xCAT-server/share/xcat/netboot/sles/genimage.yum
+++ b/xCAT-server/share/xcat/netboot/sles/genimage.yum
@@ -116,14 +116,14 @@ unless ($onlyinitrd) {
     open($yumconfig, ">", "/tmp/genimage.$$.yum.conf");
     my $repnum = 0;
     foreach $srcdir (@yumdirs) {
-        print $yumconfig "[$osver-$arch-$repnum]\nname=$osver-$arch-$repnum\nbaseurl=file://$srcdir\ngpgpcheck=0\n\n";
+        print $yumconfig "[$osver-$arch-$repnum]\nname=$osver-$arch-$repnum\nbaseurl=file://$srcdir\ngpgcheck=0\n\n";
         $repnum += 1;
     }
     $repnum -= 1;
 
     #add the section for other packages
     if ($pkgnames) {
-        print $yumconfig "[$osver-$arch-otherpkgs]\nname=$osver-$arch-otherpkgs\nbaseurl=file://$srcdir_otherpkgs\ngpgpcheck=0\n\n";
+        print $yumconfig "[$osver-$arch-otherpkgs]\nname=$osver-$arch-otherpkgs\nbaseurl=file://$srcdir_otherpkgs\ngpgcheck=0\n\n";
     }
     close($yumconfig);
 


### PR DESCRIPTION
### The PR is to fix issue _#6767_

Used command ` grep -lr gpgpcheck xCAT-server/share/xcat/netboot | xargs -I % sh -c 'sed -i s/gpgpcheck/gpgcheck/g %'`

From the man page of `yum.conf(5)`:

![image](https://user-images.githubusercontent.com/16106630/87551047-c82faa00-c67d-11ea-9de6-23416106e088.png)
