### PR TITLE
[RH8.2] parse the rsyslog version output

### DIFF
--- a/xCAT/postscripts/syslog
+++ b/xCAT/postscripts/syslog
@@ -304,8 +304,8 @@ fi
 # Do not even touch rsyslog.conf
 # There is no /etc/sysconfig/rsyslog file, so we use  rsyslogd -v to get the version
 if [ -e "/sbin/rsyslogd" -o -e "/usr/sbin/rsyslogd" ]; then
-    SYSLOGPROD=`rsyslogd -v | grep rsyslogd |awk {'print $1'}`
-    SYSLOGVER=`rsyslogd -v | grep rsyslogd |awk {'print $2'}`
+    SYSLOGPROD=`rsyslogd -v | grep rsyslogd |grep -v PID |awk {'print $1'}`
+    SYSLOGVER=`rsyslogd -v | grep rsyslogd |grep -v PID |awk {'print $2'}`
     if ( pmatch $SYSLOGPROD "*rsyslogd*" ) && ( pmatch $SYSLOGVER "8*" ); then
       config_rsyslog_V8
       #keep a record


### PR DESCRIPTION
on the rhel8.2, the output rsyslogd -v is different than previous OS.
```
# rsyslogd -v
rsyslogd  8.1911.0-3.el8 (aka 2019.11) compiled with:
        PLATFORM:                               powerpc64le-redhat-linux-gnu
        PLATFORM (lsb_release -d):
        FEATURE_REGEXP:                         Yes
        GSSAPI Kerberos 5 support:              Yes
        FEATURE_DEBUG (debug build, slow code): No
        32bit Atomic operations supported:      Yes
        64bit Atomic operations supported:      Yes
        memory allocator:                       system default
        Runtime Instrumentation (slow code):    No
        uuid support:                           Yes
        systemd support:                        Yes
        Config file:                            /etc/rsyslog.conf
        PID file:                               /var/run/rsyslogd.pid
        Number of Bits in RainerScript integers: 64
```
that cause wrong version of rsyslogd in the syslog postscripts
```
# rsyslogd -v | grep rsyslogd |awk {'print $1'}
rsyslogd
PID
# rsyslogd -v | grep rsyslogd |awk {'print $2'}
8.1911.0-3.el8
file:
```
