### PR TITLE
Use xcat runcmd instead of system() call for mksquash command

### DIFF
--- a/xCAT-server/lib/xcat/plugins/packimage.pm
+++ b/xCAT-server/lib/xcat/plugins/packimage.pm
@@ -591,7 +591,8 @@ sub process_request {
             return 1;
         }
         my $mksquashfs_command = "mksquashfs $temppath ../rootimg.sfs $flags";
-        my $rc = system("$mksquashfs_command");
+        xCAT::Utils->runcmd($mksquashfs_command, 0, 1);
+        my $rc = $::RUNCMD_RC;
         if ($rc) {
             $callback->({ error => ["Command \"$mksquashfs_command\" failed"], errorcode => [1] });
             return 1;


### PR DESCRIPTION
The regression test `rhels8.2.0-X86VMs-Mysql-master-daily-3` failed  at the test case `reg_linux_diskless_installation_hierarchy_squashfs`

```
RUN:packimage -m squashfs rhels8.2.0-x86_64-netboot-compute [Wed Jul 22 12:49:57 2020]
ElapsedTime:130 sec
RETURN rc = 1
OUTPUT:
Error: [c910f04x12v02]: Command "mksquashfs /tmp/packimage.104304.pC4y_FUY ../rootimg.sfs " failed
Packing contents of /install/netboot/rhels8.2.0/x86_64/compute/rootimg
archive method:squashfs
2505019 blocks
```

when run it from command line, it took about 3 mins to finish
```
]# time packimage -m squashfs rhels8.2.0-x86_64-netboot-compute
Packing contents of /install/netboot/rhels8.2.0/x86_64/compute/rootimg
archive method:squashfs
2505067 blocks


real    2m58.753s
user    0m0.186s
sys     0m0.047s

```
suspect system() call to `mksquashfs` maybe timeouted,  change it to use `xCAT::Utils->runcmd`