### PR TITLE
Compare /install/postscripts/* on MN/SN and /xcatpost/* on CN and display the difference as part of the diskfull and diskless hierarchical provisionings.

### DIFF
--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_hierarchy
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_hierarchy
@@ -58,6 +58,16 @@ check:output=~Provision node\(s\)\: $$CN
 cmd:xdsh $$SN "if [[ -f /var/lib/dhcp/db/dhcpd.leases ]]; then cat /var/lib/dhcp/db/dhcpd.leases; elif [[ -f /var/lib/dhcpd/dhcpd.leases ]];then cat /var/lib/dhcpd/dhcpd.leases;elif [[ -f /var/lib/dhcp/dhcpd.leases ]];then cat /var/lib/dhcp/dhcpd.leases; fi"
 cmd:if [[ "__GETNODEATTR($$CN,arch)__" =~ "ppc" ]]; then sleep 120;elif [[ "__GETNODEATTR($$CN,arch)__" =~ "x86_64" ]];then sleep 200;else sleep 180;fi
 
+cmd:xdsh $$SN "cd /install/postscripts; tar cvf /tmp/sn.tar *"
+cmd:xdsh $$SN "scp /tmp/sn.tar $$CN:/tmp"
+cmd:xdsh $$CN "cd /xcatpost; tar cvf /tmp/cn.tar *"
+cmd:xdsh $$CN "mkdir -p /tmp/sn; tar xvf /tmp/sn.tar -C /tmp/sn"
+cmd:xdsh $$CN "mkdir -p /tmp/cn; tar xvf /tmp/cn.tar -C /tmp/cn; rm -f /tmp/cn/mypost*"
+cmd:xdsh $$CN "diff -r /tmp/sn /tmp/cn > /tmp/diff.list"
+check:rc==0
+cmd:xdsh $$CN "cat /tmp/diff.list"
+check:rc==0
+
 #cmd:lsdef -l $$CN | grep status
 #check:rc==0
 #check:output!~booted
@@ -99,5 +109,9 @@ check:rc==0
 cmd:xdsh $$CN "cd /xcatpost; rmdir -p dir1/dir2/dir3"
 check:rc==0
 cmd:chdef -m -t node -o $$CN postscripts="dir1/dir2/dir3/foo.bar"
+check:rc==0
+
+cmd:xdsh $$SN "rm /tmp/sn.tar"
+cmd:xdsh $$CN "rm /tmp/cn.tar; rm -fr /tmp/sn; rm -fr /tmp/cn; rm /tmp/diff.list"
 check:rc==0
 end

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_hierarchy
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_hierarchy
@@ -64,6 +64,16 @@ check:output=~Provision node\(s\)\: $$CN
 
 cmd:xdsh $$SN "if [[ -f /var/lib/dhcp/db/dhcpd.leases ]]; then cat /var/lib/dhcp/db/dhcpd.leases; elif [[ -f /var/lib/dhcpd/dhcpd.leases ]];then cat /var/lib/dhcpd/dhcpd.leases;elif [[ -f /var/lib/dhcp/dhcpd.leases ]];then cat /var/lib/dhcp/dhcpd.leases; fi"
 
+cmd:xdsh $$SN "cd /install/postscripts; tar cvf /tmp/sn.tar *"
+cmd:xdsh $$SN "scp /tmp/sn.tar $$CN:/tmp"
+cmd:xdsh $$CN "cd /xcatpost; tar cvf /tmp/cn.tar *"
+cmd:xdsh $$CN "mkdir -p /tmp/sn; tar xvf /tmp/sn.tar -C /tmp/sn"
+cmd:xdsh $$CN "mkdir -p /tmp/cn; tar xvf /tmp/cn.tar -C /tmp/cn; rm -f /tmp/cn/mypost*"
+cmd:xdsh $$CN "diff -r /tmp/sn /tmp/cn > /tmp/diff.list"
+check:rc==0
+cmd:xdsh $$CN "cat /tmp/diff.list"
+check:rc==0
+
 cmd:ping $$CN -c 3
 check:rc==0
 check:output=~64 bytes from $$CN
@@ -106,6 +116,9 @@ check:rc==0
 cmd:xdsh $$CN "cd /xcatpost; rmdir -p dir1/dir2/dir3"
 check:rc==0
 cmd:chdef -m -t node -o $$CN postscripts="dir1/dir2/dir3/foo.bar"
+check:rc==0
+cmd:xdsh $$SN "rm /tmp/sn.tar"
+cmd:xdsh $$CN "rm /tmp/cn.tar; rm -fr /tmp/sn; rm -fr /tmp/cn; rm /tmp/diff.list"
 check:rc==0
 end
 


### PR DESCRIPTION
**xcat-core Issue #6578: custom postscripts not downloaded to nodes**

This problem can be reproduced in our environment. Postscript files with long names are not downloaded from /install/postscripts of MN/SN to /xcatpost of CN. However, if the scripts with long names are not processed in the postscript phase, we usually do not notice that they are missing.
It has to do with (curl --fail --retry 20 --max-time 60 "${url}/" | grep -o '<a href="\([^"]\)">\1</a>' | cut -d '"' -f 2) in the subroutine download_recursive of /opt/xcat/share/xcat/install/scripts/post.xcat.ng.
The curl command returns a list of HTTP records for the to-be-downloaded files in /install/postscripts. Two of them are shown here for illustration purposes.
(1) `<tr><td valign="top"><img src="/icons/text.gif" alt="[TXT]"></td><td><a href="confignics">confignics</a>           </td><td align="right">2020-06-16 16:07  </td><td align="right"> 12K</td><td>&nbsp;</td></tr>`
(2)`<tr><td valign="top"><img src="/icons/text.gif" alt="[TXT]"></td><td><a href="xcatpostinit1.service.yast2">xcatpostinit1.servic..&gt;</a></td><td align="right">2020-06-16 16:07  </td><td align="right">346 </td><td>&nbsp;</td></tr>`
   (Notice ..&gt is in href.)
The regular expression <a href="\([^"]\)">\1</a> has the following meaning:
After "href=", get a string NOT including double quotes before ">", then use the matched string (\1) to find the identical string between ">" and "</a>".
For Record (1), we have `<a href="confignics">confignics</a>` and "confignics" appear twice in the right places, so confignics is downloaded.
For Record (2), we have `<a href="xcatpostinit1.service.yast2">xcatpostinit1.servic..&gt;</a>`. Since the file name is long, the string after ">" is cut short with "..&gt", where gt stands for greater than. Since two strings are not the same, this file is ignored.

The regex can modified to fix this problem. "\1" is replaced by ".*\", which matches any string, including "..&gt". Now, scripts with long names are downloaded as well.
Currently, HTTP allows about 50+ characters for the attribute href. If there is a VERY LONG file name, say 50 characters long, which is in general unlikely, this problem would occur even with the above regex change.
If we assume that the file name is not too long (i.e., the file name is short enough to be followed by a ">" in href),  the above change should do the job.
Otherwise, we can add IndexOptions NameWidth=* to /etc/httpd/conf.d/xcat.conf (the length of href is set to the the maximum by HTTP) as suggested by the issue submitter. It definitely works too.

This PR contains changes in reg_linux_diskfull_installation_hierarchy and reg_linux_diskless_installation_hierarchy.  The new code is to compare /install/postscripts/* on MN/SN and /xcatpost/* on CN and display the difference, if any.

For the diskless installation, those postscripts with long names under /install/postscripts are included during the process of genimage on MN/SN, so they are NOT missing in the diskless node.
If postscripts with long names are dynamically added, both diskfull and diskless provisioning making use of httpd could miss those files, as described above.

The following is a sample output for **xdsh NodeA "cat /tmp/diff.list"** 

NodeA: Only in /tmp/sn: disableconsistentNICrename
NodeA: Only in /tmp/sn: install_chef_workstation
NodeA: Only in /tmp/sn: update_mlnx_adapter_firmware
NodeA: Only in /tmp/sn: updatenode_P_script_input
NodeA: Only in /tmp/sn: xcatpostinit1.service.yast2

Note: mypostscript is created in /xcatpost on CN, so it is removed from /tmp/cn before comparison is done.
