### PR TITLE
Change the regex in post.xcat.ng to accommodate long file names

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/post.xcat.ng
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat.ng
@@ -134,7 +134,7 @@ function download_recursive()
             [ "$?" -ne "0" ] && return 1
             ;;
         esac
-    done < <(curl --fail --retry 20 --max-time 60 "${url}/" | grep -o '<a href="\([^"]*\)">\1</a>' | cut -d '"' -f 2)
+    done < <(curl --fail --retry 20 --max-time 60 "${url}/" | grep -o '<a href="\([^"]*\)">.*</a>' | cut -d '"' -f 2)
     return 0
 }
 

--- a/xCAT-server/share/xcat/install/scripts/post.xcat.ng
+++ b/xCAT-server/share/xcat/install/scripts/post.xcat.ng
@@ -134,7 +134,7 @@ function download_recursive()
             [ "$?" -ne "0" ] && return 1
             ;;
         esac
-    done < <(curl --fail --retry 20 --max-time 60 "${url}/" | grep -o '<a href="\([^"]*\)">.*</a>' | cut -d '"' -f 2)
+    done < <(curl --fail --retry 20 --max-time 60 "${url}/" | grep -o '<a href="\([^"]*\)">.*</a>' | egrep -v "O=D|Directory" | cut -d '"' -f 2)
     return 0
 }
 


### PR DESCRIPTION
By doing so, postscirpts with long file names can still be downloaded from MN/SN to CN.

"\1" is replaced by ".*" in the regular expression.

Due to the limited width (50-55) for href, the file name after > may not be completely captured. When the file name is not identical before and after ">", the file is not downloaded.

It is not clear to me why the file name appears before and after ">" by HTTPD.

".*" would match anything. As long as the file name is captured before ">" in href, the file is downloaded.