### PR TITLE
Add IndexOptions NameWidth=* to xCAT/xcat.conf and xCATsn/xcat.conf.

### DIFF
--- a/xCAT/xcat.conf
+++ b/xCAT/xcat.conf
@@ -27,3 +27,5 @@ Alias /xcat-doc "/opt/xcat/share/doc"
  Order allow,deny
  Allow from all
 </Directory>
+
+IndexOptions NameWidth=*

--- a/xCATsn/xcat.conf
+++ b/xCATsn/xcat.conf
@@ -27,3 +27,5 @@ Alias /xcat-doc "/opt/xcat/share/doc"
  Order allow,deny
  Allow from all
 </Directory>
+
+IndexOptions NameWidth=*


### PR DESCRIPTION
The changed files are supposedly to be put in /etc/httpd/conf.d on MN/SN.

These files are under xcat-core/xCAT and xCATsn in the xcat-core repository and may not look like they go to the above directory. However, their contents match, so I think I make the right changes.

The idea is to get the maximum width for href.

#6780 is one solution and this the other. Let's decide the better one.
