### PR TITLE
Install xCAT-client before xCAT-probe package

### DIFF
--- a/xCAT-probe/xCAT-probe.spec
+++ b/xCAT-probe/xCAT-probe.spec
@@ -11,7 +11,7 @@ Vendor: IBM Corp.
 Distribution: %{?_distribution:%{_distribution}}%{!?_distribution:%{_vendor}}
 Prefix: /opt/xcat
 BuildRoot: /var/tmp/%{name}-%{version}-%{release}-root
-Requires: xCAT-client = 4:%{version}-%{release}
+PreReq: xCAT-client = 4:%{version}-%{release}
 
 %ifos linux
 BuildArch: noarch


### PR DESCRIPTION
PR #6765 did not fix the problem.
Attempt to use `PreReq` directive to ensure `xCAT-client` is installed before `xCAT-probe`