### PR TITLE
squashfs on RHEL8.2 hierarchy testcase debug

### DIFF
--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_hierarchy
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_hierarchy
@@ -175,6 +175,8 @@ cmd:if [[ "$$OS" =~ "ubuntu" ]]; then apt-get install -y squashfs-tools; fi
 #Make sure squashfs rpm is installed on SLES
 cmd:if [[ "$$OS" =~ "sle" ]]; then zypper install -y squashfs; fi
 
+cmd:xdsh fdisk -l
+cmd:xdsh df -T
 cmd:packimage -m squashfs __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 check:output=~archive method:squashfs

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_hierarchy
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_hierarchy
@@ -175,8 +175,8 @@ cmd:if [[ "$$OS" =~ "ubuntu" ]]; then apt-get install -y squashfs-tools; fi
 #Make sure squashfs rpm is installed on SLES
 cmd:if [[ "$$OS" =~ "sle" ]]; then zypper install -y squashfs; fi
 
-cmd:xdsh fdisk -l
-cmd:xdsh df -T
+cmd:fdisk -l
+cmd:df -T
 cmd:packimage -m squashfs __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
 check:output=~archive method:squashfs


### PR DESCRIPTION
`reg_linux_diskless_installation_hierarchy_squashfs` testcase is failing on x86 RHEL8.2
I suspect we are running out of diskspace to generate the image.
This PR adds some statements to see diskspace prior to `packimage` command.