### PR TITLE
Add a separate test case to compare postscripts on MN and CN.

### DIFF
--- a/xCAT-test/autotest/bundle/rhels_ppcle_daily.bundle
+++ b/xCAT-test/autotest/bundle/rhels_ppcle_daily.bundle
@@ -2,6 +2,7 @@ SN_setup_case
 reg_linux_diskless_installation_hierarchy
 reg_linux_diskless_installation_hierarchy_squashfs
 reg_linux_diskfull_installation_hierarchy
+compare_postscripts
 updatenode_P_script1
 updatenode_P_script1_script2
 updatenode_P_script2

--- a/xCAT-test/autotest/bundle/rhels_ppcle_weekly.bundle
+++ b/xCAT-test/autotest/bundle/rhels_ppcle_weekly.bundle
@@ -24,6 +24,7 @@ nodeset_cmdline
 nodeset_runimg
 nodeset_shell
 reg_linux_diskfull_installation_flat
+compare_postscripts
 reg_linux_diskless_installation_flat
 reg_linux_diskless_installation_flat_squashfs
 reg_linux_statelite_installation_flat

--- a/xCAT-test/autotest/bundle/rhels_x86_daily.bundle
+++ b/xCAT-test/autotest/bundle/rhels_x86_daily.bundle
@@ -2,6 +2,7 @@ SN_setup_case
 reg_linux_diskless_installation_hierarchy
 reg_linux_diskless_installation_hierarchy_squashfs
 reg_linux_diskfull_installation_hierarchy
+compare_postscripts
 updatenode_P_script1
 updatenode_P_script1_script2
 updatenode_P_script2

--- a/xCAT-test/autotest/bundle/rhels_x86_weekly.bundle
+++ b/xCAT-test/autotest/bundle/rhels_x86_weekly.bundle
@@ -24,6 +24,7 @@ nodeset_cmdline
 nodeset_runimg
 nodeset_shell
 reg_linux_diskfull_installation_flat
+compare_postscripts
 reg_linux_diskless_installation_flat
 reg_linux_diskless_installation_flat_squashfs
 reg_linux_statelite_installation_flat

--- a/xCAT-test/autotest/bundle/sles_ppcle_daily.bundle
+++ b/xCAT-test/autotest/bundle/sles_ppcle_daily.bundle
@@ -2,6 +2,7 @@ SN_setup_case
 reg_linux_diskless_installation_hierarchy
 reg_linux_diskless_installation_hierarchy_squashfs
 reg_linux_diskfull_installation_hierarchy
+compare_postscripts
 assign_certain_command_permission
 bmcdiscover_help
 bmcdiscover_q

--- a/xCAT-test/autotest/bundle/sles_ppcle_weekly.bundle
+++ b/xCAT-test/autotest/bundle/sles_ppcle_weekly.bundle
@@ -15,6 +15,7 @@ nodeset_cmdline
 nodeset_runimg
 nodeset_shell
 reg_linux_diskfull_installation_flat
+compare_postscripts
 reg_linux_diskless_installation_flat
 reg_linux_diskless_installation_flat_squashfs
 reg_linux_statelite_installation_flat

--- a/xCAT-test/autotest/bundle/sles_x86_daily.bundle
+++ b/xCAT-test/autotest/bundle/sles_x86_daily.bundle
@@ -2,6 +2,7 @@ SN_setup_case
 reg_linux_diskless_installation_hierarchy
 reg_linux_diskless_installation_hierarchy_squashfs
 reg_linux_diskfull_installation_hierarchy
+compare_postscripts
 assign_certain_command_permission
 bmcdiscover_help
 bmcdiscover_q

--- a/xCAT-test/autotest/bundle/sles_x86_weekly.bundle
+++ b/xCAT-test/autotest/bundle/sles_x86_weekly.bundle
@@ -15,6 +15,7 @@ nodeset_cmdline
 nodeset_runimg
 nodeset_shell
 reg_linux_diskfull_installation_flat
+compare_postscripts
 reg_linux_diskless_installation_flat
 reg_linux_diskless_installation_flat_squashfs
 reg_linux_statelite_installation_flat

--- a/xCAT-test/autotest/bundle/ubuntu_ppcle_daily.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu_ppcle_daily.bundle
@@ -1,6 +1,7 @@
 reg_linux_diskless_installation_flat
 reg_linux_diskless_installation_flat_squashfs
 reg_linux_diskfull_installation_flat
+compare_postscripts
 assign_certain_command_permission
 bmcdiscover_help
 bmcdiscover_q

--- a/xCAT-test/autotest/bundle/ubuntu_x86_daily.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu_x86_daily.bundle
@@ -1,6 +1,7 @@
 reg_linux_diskless_installation_flat
 reg_linux_diskless_installation_flat_squashfs
 reg_linux_diskfull_installation_flat
+compare_postscripts
 assign_certain_command_permission
 bmcdiscover_help
 bmcdiscover_q

--- a/xCAT-test/autotest/testcase/installation/compare_postscripts
+++ b/xCAT-test/autotest/testcase/installation/compare_postscripts
@@ -3,7 +3,8 @@ os:Linux
 label:provision
 cmd:cd /install/postscripts; tar cvf /tmp/mn.tar *
 cmd:xdsh $$CN "cd /xcatpost; tar cvf /tmp/cn.tar *"
-cmd:scp $$CN:/tmp/cn.tar /tmp; rm $$CN:/tmp/cn.tar
+cmd:scp $$CN:/tmp/cn.tar /tmp
+cmd:xdsh $$CN "rm /tmp/cn.tar"
 cmd:mkdir -p /tmp/mn; tar xvf /tmp/mn.tar -C /tmp/mn
 cmd:mkdir -p /tmp/cn; tar xvf /tmp/cn.tar -C /tmp/cn; rm /tmp/cn/mypost*
 cmd:diff -r /tmp/mn /tmp/cn > /tmp/diff.list
@@ -11,6 +12,6 @@ check:rc==0
 cmd:cat /tmp/diff.list
 check:rc==0
 
-cmd:rm -fr /tmp/mn; rm -fr /tmp/cn; rm /tmp/diff.list"
+cmd:rm -fr /tmp/mn; rm -fr /tmp/cn; rm /tmp/mn.tar; rm /tmp/diff.list"
 check:rc==0
 end

--- a/xCAT-test/autotest/testcase/installation/compare_postscripts
+++ b/xCAT-test/autotest/testcase/installation/compare_postscripts
@@ -1,0 +1,17 @@
+start:compare_postscripts
+os:Linux
+label:provision
+cmd:cd /install/postscripts; tar cvf /tmp/sn.tar *
+cmd:scp /tmp/sn.tar $$CN:/tmp
+cmd:xdsh $$CN "cd /xcatpost; tar cvf /tmp/cn.tar *"
+cmd:xdsh $$CN "mkdir -p /tmp/sn; tar xvf /tmp/sn.tar -C /tmp/sn"
+cmd:xdsh $$CN "mkdir -p /tmp/cn; tar xvf /tmp/cn.tar -C /tmp/cn; rm -f /tmp/cn/mypost*"
+cmd:xdsh $$CN "diff -r /tmp/sn /tmp/cn > /tmp/diff.list"
+check:rc==0
+cmd:xdsh $$CN "cat /tmp/diff.list"
+check:rc==0
+
+cmd:rm /tmp/sn.tar
+cmd:xdsh $$CN "rm /tmp/cn.tar; rm -fr /tmp/sn; rm -fr /tmp/cn; rm /tmp/diff.list"
+check:rc==0
+end

--- a/xCAT-test/autotest/testcase/installation/compare_postscripts
+++ b/xCAT-test/autotest/testcase/installation/compare_postscripts
@@ -1,17 +1,16 @@
 start:compare_postscripts
 os:Linux
 label:provision
-cmd:cd /install/postscripts; tar cvf /tmp/sn.tar *
-cmd:scp /tmp/sn.tar $$CN:/tmp
+cmd:cd /install/postscripts; tar cvf /tmp/mn.tar *
 cmd:xdsh $$CN "cd /xcatpost; tar cvf /tmp/cn.tar *"
-cmd:xdsh $$CN "mkdir -p /tmp/sn; tar xvf /tmp/sn.tar -C /tmp/sn"
-cmd:xdsh $$CN "mkdir -p /tmp/cn; tar xvf /tmp/cn.tar -C /tmp/cn; rm -f /tmp/cn/mypost*"
-cmd:xdsh $$CN "diff -r /tmp/sn /tmp/cn > /tmp/diff.list"
+cmd:scp $$CN:/tmp/cn.tar /tmp; rm $$CN:/tmp/cn.tar
+cmd:mkdir -p /tmp/mn; tar xvf /tmp/mn.tar -C /tmp/mn
+cmd:mkdir -p /tmp/cn; tar xvf /tmp/cn.tar -C /tmp/cn; rm /tmp/cn/mypost*
+cmd:diff -r /tmp/mn /tmp/cn > /tmp/diff.list
 check:rc==0
-cmd:xdsh $$CN "cat /tmp/diff.list"
+cmd:cat /tmp/diff.list
 check:rc==0
 
-cmd:rm /tmp/sn.tar
-cmd:xdsh $$CN "rm /tmp/cn.tar; rm -fr /tmp/sn; rm -fr /tmp/cn; rm /tmp/diff.list"
+cmd:rm -fr /tmp/mn; rm -fr /tmp/cn; rm /tmp/diff.list"
 check:rc==0
 end


### PR DESCRIPTION
It is added after diskfull installations in 10 bundles. Note that the Ubuntu bundles do not include diskfull installations.

Also note that diskless installations would not have this problem because all postscripts are copied and included in the install image without involvement of HTTP.