### PR TITLE
Add getadapter to xCAT readdoc

### DIFF
--- a/docs/source/advanced/networks/getadapter.rst
+++ b/docs/source/advanced/networks/getadapter.rst
@@ -12,11 +12,11 @@ information to help customer configure the network.
 How to use getadapter
 -----------------------
 
-Set the chian table to run ``getadapter`` script ::
+Set the chain table to run ``getadapter`` script ::
 
   chdef <noderange> chain="runcmd=getadapter"
 
-After the discovery completed, the column ``nicsadapter`` of ```nics`` table is
+After the discovery completed, the column ``nicsadapter`` of ``nics`` table is
 updated.
 
 View result with ``lsdef`` command ::

--- a/docs/source/advanced/networks/index.rst
+++ b/docs/source/advanced/networks/index.rst
@@ -8,3 +8,4 @@ Networking
    onie_switches/index.rst
    switchdiscover/index.rst
    infiniband/index.rst
+   getadapter.rst

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -103,7 +103,7 @@ exclude_patterns = ['guides/install-guides/common_sections.rst',
                     #'**hamn/setup_ha_mgmt_node_with_shared_data.rst',
                     #'**hamn/setup_xcat_high_available_management_node_in_softlayer.rst',
                     '**hierarchy/databases/postgres_tips.rst',
-                    '**hierarchy/define_and_install_compute_node.rst',
+                    '**hierarchy/define_and_install_compute_node.rst'
                     #'**hierarchy/define_service_node.rst',
                     #'**networks/getadapter.rst'
                     #'**networks/vlan/index.rst',

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -105,7 +105,7 @@ exclude_patterns = ['guides/install-guides/common_sections.rst',
                     '**hierarchy/databases/postgres_tips.rst',
                     '**hierarchy/define_and_install_compute_node.rst',
                     #'**hierarchy/define_service_node.rst',
-                    '**networks/getadapter.rst'
+                    #'**networks/getadapter.rst'
                     #'**networks/vlan/index.rst',
                     #'**networks/vlan/vlan.rst',
                     #'**license/xcat_corporate_contributor_license_agreement.rst',


### PR DESCRIPTION
The `getadpater.rst` file is available, but didn't add to xCAT readdoc.
