### PR TITLE
Remove the RC checking for the file removal command.

### DIFF
--- a/xCAT-test/autotest/testcase/installation/compare_postscripts
+++ b/xCAT-test/autotest/testcase/installation/compare_postscripts
@@ -12,5 +12,5 @@ check:rc==0
 cmd:cat /tmp/diff.list
 check:rc==0
 
-cmd:rm -fr /tmp/mn; rm -fr /tmp/cn; rm /tmp/mn.tar; rm /tmp/diff.list"
+cmd:rm -fr /tmp/mn; rm -fr /tmp/cn; rm /tmp/mn.tar; rm /tmp/diff.list
 end

--- a/xCAT-test/autotest/testcase/installation/compare_postscripts
+++ b/xCAT-test/autotest/testcase/installation/compare_postscripts
@@ -1,0 +1,16 @@
+start:compare_postscripts
+os:Linux
+label:provision
+cmd:cd /install/postscripts; tar cvf /tmp/mn.tar *
+cmd:xdsh $$CN "cd /xcatpost; tar cvf /tmp/cn.tar *"
+cmd:scp $$CN:/tmp/cn.tar /tmp
+cmd:xdsh $$CN "rm /tmp/cn.tar"
+cmd:mkdir -p /tmp/mn; tar xvf /tmp/mn.tar -C /tmp/mn
+cmd:mkdir -p /tmp/cn; tar xvf /tmp/cn.tar -C /tmp/cn; rm /tmp/cn/mypost*
+cmd:diff -r /tmp/mn /tmp/cn > /tmp/diff.list
+check:rc==0
+cmd:cat /tmp/diff.list
+check:rc==0
+
+cmd:rm -fr /tmp/mn; rm -fr /tmp/cn; rm /tmp/mn.tar; rm /tmp/diff.list"
+end


### PR DESCRIPTION
RC=1 (not 0) due to the deletion of files at the end of the test need not cause failure.

The reason for the failure will be investigated.

Note that SUSE, Ubuntu and RHEL 7.x do NOT have missing postscripts with long names. The HTTP setup will be look into.