### PR TITLE
Remove the RC checking for the file removal command.

### DIFF
--- a/xCAT-test/autotest/testcase/installation/compare_postscripts
+++ b/xCAT-test/autotest/testcase/installation/compare_postscripts
@@ -13,5 +13,4 @@ cmd:cat /tmp/diff.list
 check:rc==0
 
 cmd:rm -fr /tmp/mn; rm -fr /tmp/cn; rm /tmp/mn.tar; rm /tmp/diff.list"
-check:rc==0
 end


### PR DESCRIPTION
Will investigate which rm command causes failure. It is likely that RC=1 when diff.list is empty.

Note: SUSE, Ubuntu and RHEL 7.x do not have missing postscripts with long names. Their HTTP setup could be different.

