### PR TITLE
Remove the extra double quote at the end of the rm command.

### DIFF
--- a/xCAT-test/autotest/testcase/installation/compare_postscripts
+++ b/xCAT-test/autotest/testcase/installation/compare_postscripts
@@ -12,6 +12,5 @@ check:rc==0
 cmd:cat /tmp/diff.list
 check:rc==0
 
-cmd:rm -fr /tmp/mn; rm -fr /tmp/cn; rm /tmp/mn.tar; rm /tmp/diff.list"
-check:rc==0
+cmd:rm -fr /tmp/mn; rm -fr /tmp/cn; rm /tmp/mn.tar; rm /tmp/diff.list
 end


### PR DESCRIPTION
The extra double quote causes failure for the removal of files.

I used xdsh to remove files on CN. I forgot to remove the ending double quote as the removal is switched to MN.
