### PR TITLE
On RHEL8 do not use vers=3 when mounting kdump filesystem

### DIFF
--- a/xCAT/postscripts/enablekdump
+++ b/xCAT/postscripts/enablekdump
@@ -217,6 +217,10 @@ EOF
                    for i in $nfsvers
                    do
                        if [ $i -eq 3 ] && ! [ grep -w nfs /proc/filesystems >/dev/null 2>&1 ]; then
+                           if (pmatch $OSVER "rhel8*") || (pmatch $OSVER "rhels8*");then
+                               # For RHEL8 do not mount with vers=3 option
+                               continue
+                           fi
                            nfsver=3
                            break
                        elif [ $i -eq 4 ] && ! [ grep -w nfs4 /proc/filesystems >/dev/null 2>&1 ]; then


### PR DESCRIPTION
Failure of `linux_diskless_kdump` testcase on RHEL8.2 seems to be due to the fact that `enablekdump` postscript mounts the filesystem intended to save the dump with `-o vers=3`. That seems to work on RHEL8.0 and RHEL8.1. But on RHEL8.2, when kdump is triggered console displays:

```
kdump: dump target c910f03c09k18:/opt/xcat/share/xcat/tools/autotest/kdumpdir is not mounted, trying to mount...

mount.nfs: rpc.statd is not running but is required for remote locking.

mount.nfs: Either use '-o nolock' to keep locks local, or start statd.

kdump: mounting failed (mount point: /kdumproot//mnt, option: rw,relatime,vers=3,rsize=1048576,wsize=1048576,namlen=255,hard,timeo=600,retrans=2,sec=sys,mountaddr=10.3.9.18,mountvers=3,mountport=20048,mountproto=udp,local_lock=none,noauto)

kdump: saving vmcore failed
```

This PR fixes `enablekdump` postscript to make sure `-o vers=3` is not used when mounting filesystem on RHEL8.x

Then when filesystem is mounted with `-o vers=4`, the ``linux_diskless_kdump` testcase passes on RHEL8.2 and RHEL8.1:

```
:
:
:
RUN:vmcorefile=`find /opt/xcat/share/xcat/tools/autotest/kdumpdir/ -name vmcore`;if [[ -s $vmcorefile ]]; then echo "vmcore file is not empty";else echo "vmcore file is empty"; fi [Thu Aug  6 15:49:54 2020]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
vmcore file is not empty
CHECK:output =~ not empty       [Pass]

:
:
:
------END::linux_diskless_kdump::Passed::Time:Thu Aug  6 15:50:00 2020 ::Duration::1070 sec------
```