### PR TITLE
[xCAT-server]Change DNS/DHCP control key algorithm MD5 -> SHA512

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ddns.pm
+++ b/xCAT-server/lib/xcat/plugins/ddns.pm
@@ -1244,7 +1244,7 @@ sub update_namedconf {
                 if ($ctx->{privkey}) {
 
                     #for now, assume the field is correct
-                    #push @newnamed,"key xcat_key {\n","\talgorithm hmac-md5;\n","\tsecret \"".$ctx->{privkey}."\";\n","};\n\n";
+                    #push @newnamed,"key xcat_key {\n","\talgorithm hmac-sha512;\n","\tsecret \"".$ctx->{privkey}."\";\n","};\n\n";
                     push @newnamed, $line;
                     do {
                         $i++;
@@ -1351,7 +1351,7 @@ sub update_namedconf {
                 $ctx->{privkey} = encode_base64(genpassword(32));
                 chomp($ctx->{privkey});
             }
-            push @newnamed, "key xcat_key {\n", "\talgorithm hmac-md5;\n", "\tsecret \"" . $ctx->{privkey} . "\";\n", "};\n\n";
+            push @newnamed, "key xcat_key {\n", "\talgorithm hmac-sha512;\n", "\tsecret \"" . $ctx->{privkey} . "\";\n", "};\n\n";
             $ctx->{restartneeded} = 1;
         }
     }

--- a/xCAT-server/lib/xcat/plugins/dhcp.pm
+++ b/xCAT-server/lib/xcat/plugins/dhcp.pm
@@ -193,6 +193,7 @@ sub listnode
     print $OMIN "key "
       . $omapiuser . " \""
       . $omapikey . "\"\n";
+    print $OMIN "key-algorithm HMAC-SHA512\n";
     print $OMIN "connect\n";
     print $OMIN "new host\n";
 
@@ -258,6 +259,7 @@ sub listnode
         print $OMIN6 "key "
           . $omapiuser . " \""
           . $omapikey . "\"\n";
+        print $OMIN6 "key-algorithm HMAC-SHA512\n";
         print $OMIN6 "connect\n";
         print $OMIN6 "new host\n";
 
@@ -2035,19 +2037,17 @@ sub process_request
             print $omshell "key "
               . $ent->{username} . " \""
               . $ent->{password} . "\"\n";
-            if ($::XCATSITEVALS{externaldhcpservers}) {
-                print $omshell "server $::XCATSITEVALS{externaldhcpservers}\n";
-            }
+            print $omshell "key-algorithm HMAC-SHA512\n";
+            print $omshell "server $::XCATSITEVALS{externaldhcpservers}\n" if($::XCATSITEVALS{externaldhcpservers});
             print $omshell "connect\n";
             if ($usingipv6) {
                 open($omshell6, "|/usr/bin/omshell > /dev/null");
-                if ($::XCATSITEVALS{externaldhcpservers}) {
-                    print $omshell "server $::XCATSITEVALS{externaldhcpservers}\n";
-                }
+	        print $omshell "server $::XCATSITEVALS{externaldhcpservers}\n" if($::XCATSITEVALS{externaldhcpservers});
                 print $omshell6 "port 7912\n";
                 print $omshell6 "key "
                   . $ent->{username} . " \""
                   . $ent->{password} . "\"\n";
+                print $omshell6 "key-algorithm HMAC-SHA512\n";
                 print $omshell6 "connect\n";
             }
         }
@@ -2963,7 +2963,7 @@ sub newconfig6 {
     #    push @dhcp6conf, "update-static-leases on;\n";
     push @dhcp6conf, "omapi-port 7912;\n";        #Enable omapi...
     push @dhcp6conf, "key xcat_key {\n";
-    push @dhcp6conf, "  algorithm hmac-md5;\n";
+    push @dhcp6conf, "  algorithm hmac-sha512;\n";
     my $passtab = xCAT::Table->new('passwd', -create => 1);
     (my $passent) =
       $passtab->getAttribs({ key => 'omapi', username => 'xcat_key' }, 'password');
@@ -3026,7 +3026,7 @@ sub newconfig
     push @dhcpconf, "\n";
     push @dhcpconf, "omapi-port 7911;\n";            #Enable omapi...
     push @dhcpconf, "key xcat_key {\n";
-    push @dhcpconf, "  algorithm hmac-md5;\n";
+    push @dhcpconf, "  algorithm hmac-sha512;\n";
     (my $passent) =
       $passtab->getAttribs({ key => 'omapi', username => 'xcat_key' }, 'password');
     my $secret = encode_base64(genpassword(32));     #Random from set of  62^32

--- a/xCAT-server/lib/xcat/plugins/dhcp.pm
+++ b/xCAT-server/lib/xcat/plugins/dhcp.pm
@@ -2042,7 +2042,7 @@ sub process_request
             print $omshell "connect\n";
             if ($usingipv6) {
                 open($omshell6, "|/usr/bin/omshell > /dev/null");
-	        print $omshell "server $::XCATSITEVALS{externaldhcpservers}\n" if($::XCATSITEVALS{externaldhcpservers});
+                print $omshell "server $::XCATSITEVALS{externaldhcpservers}\n" if($::XCATSITEVALS{externaldhcpservers});
                 print $omshell6 "port 7912\n";
                 print $omshell6 "key "
                   . $ent->{username} . " \""

--- a/xCAT-server/share/xcat/tools/dhcpop
+++ b/xCAT-server/share/xcat/tools/dhcpop
@@ -39,6 +39,7 @@ if($help){
     print $omshell "key "
       . $id . " \""
       . $passwd . "\"\n";
+    print $omshell "key-algorithm HMAC-SHA512\n";
     print $omshell "connect\n";
 
     if($hostname){


### PR DESCRIPTION
### The PR is to fix issue #6757

### The modification include

- Change all `omshell` access to use `key-algorithm hmac-sha512` instead of the default `hmac-md5`
- Change named/dhcpd config generating code to use `algorithm hmac-sha512` instead of `hmac-md5`


### The UT result
I don't have a test environment for this, so nothing tested.