### PR TITLE
Added enabling nv_rsync service in cuda11_power9_setup postscripts

### DIFF
--- a/xCAT-server/share/xcat/samples/cuda11/cuda11_power9_setup
+++ b/xCAT-server/share/xcat/samples/cuda11/cuda11_power9_setup
@@ -145,6 +145,9 @@ $CHROOTCMD /bin/bash -c "systemctl enable nvidia-persistenced"
 [ ! -z "${IMG_ROOTIMGDIR}" ] && CHROOTCMD="chroot ${IMG_ROOTIMGDIR}"
 $CHROOTCMD /bin/bash -c "systemctl enable nvidia_gdrcopy_kernel.service"
 
+[ ! -z "${IMG_ROOTIMGDIR}" ] && CHROOTCMD="chroot ${IMG_ROOTIMGDIR}"
+$CHROOTCMD /bin/bash -c "systemctl enable nv_rsync_mem.service"
+
 if [ -z "${IMG_ROOTIMGDIR}" ] 
 then
     mv "${IMG_ROOTIMGDIR}/bin/uname.xcat" "${IMG_ROOTIMGDIR}/bin/uname"


### PR DESCRIPTION
On last RH82 installs IST had to enable nv_rsync and reboot after install to have all MPI GPU support modules loaded. added the sysctl to enable it in cuda11_power9_setup postscripts.