### PR TITLE
Remove depricated Perl usage of keys on scalar

### DIFF
--- a/xCAT-server/xCAT-wsapi/xcatws.cgi
+++ b/xCAT-server/xCAT-wsapi/xcatws.cgi
@@ -2879,7 +2879,7 @@ sub tablerowhdl {
     # Check if there is any real data in response
     # One key ('xcatdsource' => '<node>') is always returned.
     # If no other keys in response - no matches on key or attribute were returned from xcatd
-    if (keys @$responses[0] <= 1) {
+    if (keys (%{@$responses[0]}) <= 1) {
         @$responses[0]->{error} = "No table rows matched specified keys or attributes";
     }
     return $responses;


### PR DESCRIPTION
### The PR is to fix issue _#6799_

The version of Perl used on CentOS 8.x and RHEL 8.x no longer allows usage of keys on scalar.

Before the fix:
```
[root@c910f03c17k07 ~]#  curl -X GET -k 'https://c910f04x12v02/xcatws/nodes?userName=root&userPW=xxx'
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at
 root@localhost to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
</body></html>
[root@c910f03c17k07 ~]#
```

After this PR:
```
[root@c910f03c17k07 ~]#  curl -X GET -k 'https://c910f04x12v02/xcatws/nodes?userName=root&userPW=xxxxx'
["c910f04x12v03","c910f04x12v04"]
[root@c910f03c17k07 ~]#
```

Fix verified on RHEL8.1 and RHEL7.6