### PR TITLE
Retry rinstall if first one fails

### DIFF
--- a/xCAT-test/autotest/testcase/commoncmd/retry_install.sh
+++ b/xCAT-test/autotest/testcase/commoncmd/retry_install.sh
@@ -30,8 +30,13 @@ do
     echo "rinstall $node osimage=$osimage"
     rinstall $node osimage=$osimage
     if [ $? != 0 ];then
-        echo "rinstall command failed ..."
-        exit 1
+        echo "First attempt to run rinstall command failed ..."
+        # First rinstall failed, try again with verbose flag
+        rinstall $node osimage=$osimage -V
+        if [ $? != 0 ];then
+            echo "Second attempt to run rinstall command failed ..."
+            exit 1
+        fi
     fi
 
     #sleep while for installation.


### PR DESCRIPTION
Some testcases fail with 
```
rinstall c910f03c09k14 osimage=rhels7.7-ppc64le-netboot-compute
Error: [c910f03c09k12]: Failed to run 'rpower' against the following nodes: c910f03c09k14
Provision node(s): c910f03c09k14
c910f03c09k14: internal error: qemu unexpectedly closed the monitor: 2020-08-12T06:52:27.926449Z qemu-kvm: Failed to allocate KVM HPT of order 26 (try smaller maxmem?): Cannot allocate memory
rinstall command failed ...
CHECK:rc == 0	[Failed]
```

This PR retries running `rinstall` with verbose flag on, if first `rinstall` failed.