### PR TITLE
Add kernel-modules-extra to dracut module list

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -1079,7 +1079,7 @@ sub mkinitrd_dracut {
 
         #update etc/dracut.conf
         open($DRACUTCONF, '>', "$rootimg_dir/etc/dracut.conf");
-        my $dracutmodulelist = "xcat nfs base network kernel-modules syslog";
+        my $dracutmodulelist = "xcat nfs base network kernel-modules kernel-modules-extra syslog";
 
         foreach (qw/systemd systemd-initrd dracut-systemd fadump/) {
             my ($dir) = glob($dracutmoduledir . "[0-9]*" . $_);
@@ -1120,7 +1120,7 @@ sub mkinitrd_dracut {
         $perm = (stat("$fullpath/$dracutdir/installkernel"))[2];
         chmod($perm & 07777, "$dracutmpath/installkernel");
 
-        my $dracutmodulelist = "xcat nfs base network kernel-modules syslog";
+        my $dracutmodulelist = "xcat nfs base network kernel-modules kernel-modules-extra syslog";
 
         foreach (qw/systemd systemd-initrd dracut-systemd fadump/) {
             my ($dir) = glob($dracutmoduledir . "[0-9]*" . $_);


### PR DESCRIPTION
The customer reported `mlx5_core` driver is not built into initrd-stateless image  and provision is stuck at the dracut mode with the error mesage:
```
mlx5_core: disagrees about version of symbol mlxfw_firmware_flash
mlx5_core: Unknown symbol mlxfw_firmware_flash (err -22)
```
From the rootimg,  the `mlx5_core.ko` is installed
```
# find /install/custom/redhat8.1-mlnx-pmr/rootimg/lib/modules -name mlx5_core*
/install/custom/redhat8.1-mlnx-pmr/rootimg/lib/modules/4.18.0-147.13.2.el8_1.ppc64le/kernel/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko.xz
/install/custom/redhat8.1-mlnx-pmr/rootimg/lib/modules/4.18.0-147.13.2.el8_1.ppc64le/extra/mlnx-ofa_kernel/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko

```
but this module is not included in the `initrd-stateless.gz`.  
in order to add this module to initrd, needs to add `kernel-modules-extra` to the dracut module list
