### PR TITLE
Verify if kernel-modules-extra exists before adding

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -1079,9 +1079,9 @@ sub mkinitrd_dracut {
 
         #update etc/dracut.conf
         open($DRACUTCONF, '>', "$rootimg_dir/etc/dracut.conf");
-        my $dracutmodulelist = "xcat nfs base network kernel-modules kernel-modules-extra syslog";
+        my $dracutmodulelist = "xcat nfs base network kernel-modules syslog";
 
-        foreach (qw/systemd systemd-initrd dracut-systemd fadump/) {
+        foreach (qw/systemd systemd-initrd dracut-systemd fadump kernel-modules-extra/) {
             my ($dir) = glob($dracutmoduledir . "[0-9]*" . $_);
             if (-d $dir) {
                 $dracutmodulelist .= " $_";
@@ -1120,9 +1120,9 @@ sub mkinitrd_dracut {
         $perm = (stat("$fullpath/$dracutdir/installkernel"))[2];
         chmod($perm & 07777, "$dracutmpath/installkernel");
 
-        my $dracutmodulelist = "xcat nfs base network kernel-modules kernel-modules-extra syslog";
+        my $dracutmodulelist = "xcat nfs base network kernel-modules syslog";
 
-        foreach (qw/systemd systemd-initrd dracut-systemd fadump/) {
+        foreach (qw/systemd systemd-initrd dracut-systemd fadump kernel-modules-extra/) {
             my ($dir) = glob($dracutmoduledir . "[0-9]*" . $_);
             if (-d $dir) {
                 $dracutmodulelist .= " $_";


### PR DESCRIPTION
### The PR is to fix PR _#6805_

`genimage` fails when generating RHEL7.6 image, because module directory `kernel-modules-extra` added by PR #6805 is not there.

This PR adds `kernel-modules-extra` to the list of modules, existence of which is verified before module is added to `dracutmodulelist`

Verified on RHEL7.6 and RHEL8.1