### PR TITLE
xcat-inventory backend testcase fix

### DIFF
--- a/xCAT-test/autotest/testcase/xcat_inventory/cases.backend
+++ b/xCAT-test/autotest/testcase/xcat_inventory/cases.backend
@@ -6,7 +6,7 @@ cmd: rm -rf /tmp/backend_test/
 cmd:rm -rf ~/.xcatinv/inventory.cfg.bak.backend_init 
 check: rc==0
 cmd: mkdir -p ~/.xcatinv/
-cmd: [ -f ~/.xcatinv/inventory.cfg ] && mv ~/.xcatinv/inventory.cfg ~/.xcatinv/inventory.cfg.bak.backend_init
+cmd: if [[ -f ~/.xcatinv/inventory.cfg ]]; then mv ~/.xcatinv/inventory.cfg ~/.xcatinv/inventory.cfg.bak.backend_init; fi
 cmd: cp /opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/templates/inventory.cfg ~/.xcatinv/inventory.cfg
 cmd: xcat-inventory init
 check: rc==0
@@ -86,7 +86,7 @@ check: output!=~ws
 
 cmd: XCATBYPASS=1 restorexCATdb -p /tmp/backend_test/backup/db
 check: rc==0
-cmd: [ -f "~/.xcatinv/inventory.cfg.bak.backend_init" ] && rm -rf "~/.xcatinv/inventory.cfg" &&  mv "~/.xcatinv/inventory.cfg.bak.backend_init" "~/.xcatinv/inventory.cfg"
+cmd: if [[ -f "~/.xcatinv/inventory.cfg.bak.backend_init" ]]; then rm -rf "~/.xcatinv/inventory.cfg"; mv "~/.xcatinv/inventory.cfg.bak.backend_init" "~/.xcatinv/inventory.cfg"; fi
 cmd: rm -rf /tmp/backend_test/
 end
 


### PR DESCRIPTION
When TravisCI runs `backend` testcase for `xcat-inventory` repository, the following error is displayed:
```
'cmd: [ -f ~/.xcatinv/inventory.cfg ] && mv ~/.xcatinv/inventory.cfg ~/.xcatinv/inventory.cfg.bak.backend_init',
'ElapsedTime:0 sec',
'RETURN rc = 127',
'OUTPUT:',
'/tmp/xCATautotest1597686081//script: line 2: cmd:: command not found',
```
I suspect the format of `if` statement is incorrect.