### PR TITLE
Move debug link from Connections

### DIFF
--- a/docs/source/troubleshooting/index.rst
+++ b/docs/source/troubleshooting/index.rst
@@ -1,7 +1,9 @@
 Troubleshooting
 ===============
 
-This chapter introduces the methods of troubleshooting a xCAT cluster. It includes the following parts.
+This chapter introduces the methods of debugging and troubleshooting a xCAT cluster. `General xCAT troubleshooting and debugging suggestions <https://sourceforge.net/p/xcat/wiki/Debugging_xCAT_Problems/>`_
+
+Additional recomendations:
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
### The PR is to fix issue https://github.ibm.com/xcat2/team_process/issues/133

Remove debug and troubleshooting link from IBM Connections, and make it available in xCAT docs.