### PR TITLE
Better testcase output when makedhcp -q fails

### DIFF
--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat
@@ -20,7 +20,7 @@ cmd:makedhcp -n
 check:rc==0
 cmd:makedhcp -a
 check:rc==0
-cmd:a=0;while true; do [ $a -eq 100 ] && exit 1;output=$(makedhcp -q $$CN);[ $? -ne 0 ] && exit 1;echo $output|grep $$CN 2>/dev/null && exit 0;a=$[$a+1];sleep 1;done
+cmd:a=0;while true; do [ $a -eq 100 ] && { echo "After 100 iterations, makedhcp -q $$CN did not return any output"; makedhcp -q all; exit 1; }; output=$(makedhcp -q $$CN);[ $? -ne 0 ] && exit 1;echo $output|grep $$CN 2>/dev/null && exit 0;echo "[$a] Waiting for makedhcp -q $$CN to return output"; a=$[$a+1]; sleep 1;done
 check:rc==0
 cmd:copycds $$ISO
 check:rc==0
@@ -106,7 +106,7 @@ cmd:makedhcp -n
 check:rc==0
 cmd:makedhcp -a
 check:rc==0
-cmd:a=0;while true; do [ $a -eq 100 ] && exit 1;output=$(makedhcp -q $$CN);[ $? -ne 0 ] && exit 1;echo $output|grep $$CN 2>/dev/null && exit 0;a=$[$a+1];sleep 1;done
+cmd:a=0;while true; do [ $a -eq 100 ] && { echo "After 100 iterations, makedhcp -q $$CN did not return any output"; makedhcp -q all; exit 1; }; output=$(makedhcp -q $$CN);[ $? -ne 0 ] && exit 1;echo $output|grep $$CN 2>/dev/null && exit 0;echo "[$a] Waiting for makedhcp -q $$CN to return output"; a=$[$a+1]; sleep 1;done
 check:rc==0
 cmd:copycds $$ISO
 check:rc==0


### PR DESCRIPTION
Testcase `reg_linux_diskless_installation_flat` sometimes fails, because `makedhcp -q <CN>` does not return expected output after waiting for about 2 min.
When that happens, print out `makedhcp -q all` to see what are all the entries `makedhcp` knows about.