### PR TITLE
Add new REST API test cases with curl.

### DIFF
--- a/xCAT-test/autotest/testcase/restapi/cases0
+++ b/xCAT-test/autotest/testcase/restapi/cases0
@@ -1,0 +1,115 @@
+start:restapi_list_all_resources
+description: List all resources on the management node with "curl -X GET"
+label:restapi
+cmd:xdsh $$CN "curl -X GET --cacert /root/ca-cert.pem 'https://$$MN/xcatws?userName=$$username&userPW=$$password'"
+check:rc==0
+end
+
+start:restapi_list_globalconf
+description: List globalconf on the management node with "curl -X GET"
+label:restapi
+cmd:xdsh $$CN "curl -X GET --cacert /root/ca-cert.pem 'https://$$MN/xcatws/globalconf?userName=$$username&userPW=$$password'"
+check:rc==0
+end
+
+start:restapi_list_groups
+description: List groups on the management node with "curl -X GET"
+label:restapi
+cmd:xdsh $$CN "curl -X GET --cacert /root/ca-cert.pem 'https://$$MN/xcatws/groups?userName=$$username&userPW=$$password'"
+check:rc==0
+end
+
+start:restapi_list_nodes
+description: List nodes on the management node with "curl -X GET"
+label:restapi
+cmd:xdsh $$CN "curl -X GET --cacert /root/ca-cert.pem 'https://$$MN/xcatws/nodes?userName=$$username&userPW=$$password'"
+check:rc==0
+end
+
+start:restapi_list_nodes_CN
+description: Display details of the compute node with "curl -X GET"
+label:restapi
+cmd:xdsh $$CN "curl -X GET --cacert /root/ca-cert.pem 'https://$$MN/xcatws/nodes/$$CN?userName=$$username&userPW=$$password'"
+check:rc==0
+end
+
+start:restapi_list_networks
+description: List networks on the management node with "curl -X GET"
+label:restapi
+cmd:xdsh $$CN "curl -X GET --cacert /root/ca-cert.pem 'https://$$MN/xcatws/networks?userName=$$username&userPW=$$password'"
+check:rc==0
+end
+
+start:restapi_list_osimages
+description: List osimages on the management node with "curl -X GET"
+label:restapi
+cmd:xdsh $$CN "curl -X GET --cacert /root/ca-cert.pem 'https://$$MN/xcatws/osimages?userName=$$username&userPW=$$password'"
+end
+
+start:restapi_list_policy
+description: List policies on the management node with "curl -X GET"
+label:restapi
+cmd:xdsh $$CN "curl -X GET --cacert /root/ca-cert.pem 'https://$$MN/xcatws/policy?userName=$$username&userPW=$$password'"
+check:rc==0
+end
+
+start:restapi_create_temp_CN_put
+description: Created a temporary compute node with "curl -X PUT"
+label:restapi
+cmd:xdsh $$CN "curl -X PUT --cacert /root/ca-cert.pem 'https://$$MN/xcatws/nodes/temp_node?userName=$$username&userPW=$$password' -H Content-Type:application/json --data '{\"groups\":\"all\",\"mgt\":\"kvm\",\"vmmemory\":\"2048\"}'"
+check:rc==0
+cmd:lsdef
+check:output=~temp_node
+end
+
+start:restapi_delete_temp_CN
+description: Delete a temporary compute node with "curl -X DELETE"
+label:restapi
+cmd:xdsh $$CN "curl -X DELETE --cacert /root/ca-cert.pem 'https://$$MN/xcatws/nodes/temp_node?userName=$$username&userPW=$$password'"
+check:rc==0
+cmd:lsdef
+check:output!=temp_node
+end
+
+start:restapi_create_temp_CN_post
+description: Created a temporary compute node with "curl -X POST"
+label:restapi
+cmd:xdsh $$CN "curl -X POST --cacert /root/ca-cert.pem 'https://$$MN/xcatws/nodes/temp_node?userName=$$username&userPW=$$password' -H Content-Type:application/json --data '{\"groups\":\"all\",\"mgt\":\"kvm\",\"vmmemory\":\"2048\",\"rcons\":\"kvm\"}'"
+check:rc==0
+cmd:lsdef
+check:output=~temp_node
+end
+
+start:restapi_add_id_temp_CN
+description: Add an id field of a temporary compute node with "curl -X PUT"
+label:restapi
+cmd:xdsh $$CN "curl -X PUT --cacert /root/ca-cert.pem 'https://$$MN/xcatws/nodes/temp_node?userName=$$username&userPW=$$password' -H Content-Type:application/json --data '{\"id\":\"100\"}'"
+check:rc==0
+cmd:lsdef temp_node
+check:output=~id=100
+end
+
+start:restapi_modify_vmmemory_temp_CN
+description: Modify the vmmemory field of a temporary computer node with "curl -X PUT"
+label:restapi
+cmd:xdsh $$CN "curl -X PUT --cacert /root/ca-cert.pem 'https://$$MN/xcatws/nodes/temp_node?userName=$$username&userPW=$$password' -H Content-Type:application/json --data '{\"vmmemory\":\"4096\"}'"
+check:rc==0
+cmd:lsdef temp_node
+check:output=~vmmemory=4096
+end
+
+start:restapi_delete_id_temp_CN
+description: Delete the id field of a temporary compute node with "curl -X DELETE"
+label:restapi
+cmd:xdsh $$CN "curl -X PUT --cacert /root/ca-cert.pem 'https://$$MN/xcatws/nodes/temp_node?userName=$$username&userPW=$$password' -H Content-Type:application/json --data '{\"id\":\" \"}'"
+check:rc==0
+cmd:lsdef temp_node
+check:output!~id=
+end
+
+start:restapi_show_temp_CN_osimage
+description: Show the detail of the osimage of CN with "curl -X GET"
+label:restapi
+cmd:NN=`lsdef $$CN | grep provmethod | tr -d " " | cut --complement -c 1-11`;/opt/xcat/share/xcat/tools/autotest/testcase/restapi/node/get_details.sh $$MN $$CN $$username $$password osimages $NN
+check:rc==0
+end

--- a/xCAT-test/autotest/testcase/restapi/get_details.sh
+++ b/xCAT-test/autotest/testcase/restapi/get_details.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# This script display the detail of a resource.
+# MN, CN, username, password, resource and specific resource must be specified.
+
+MN=$1
+CN=$2
+username=$3
+password=$4
+RS=$5
+ITEM=$6
+
+xdsh $CN "curl -X GET --cacert /root/ca-cert.pem 'https://$MN/xcatws/$RS/$ITEM?userName=$username&userPW=$password'"


### PR DESCRIPTION
### The PR is to address issue 6801 ###

Enhancement is done to the original write-up of "test case name, the command and the output" for increased clarity.

Users often use browsers to access database objects stored in servers. (The returned items are in the JSON format.) Therefore, it is adequate to submit REST API requests from a computer node to access data on the management node. Therefore, each test case makes use of "xdsh $$CN" to achieve the HTTP client-server operations and exercise code paths on both sides.

**curl -X GET/PUT/POST/DELETE** is used to get, create, modify or delete objects in the database.

For running each test manually, run "xcattest -f default.conf -t <test case name> at /opt/xcat/share/xcat/tools/autotest.

For nightly runs, default.conf is created by xcatjktest programmatically. For the private sandbox tests, it is created manually.

=  =  =  =   =
**start:restapi_list_all_resources**

cmd:xdsh $$CN "curl -X GET --cacert /root/ca-cert.pem 'https://$$MN/xcatws?userName=$$username&userPW=$$password'"

**Output:**
fs2vm115: ["globalconf","groups","localres","networks","nodes","osimages","policy","services","tables","templates","tokens"]

**Will check whether the output has "nodes".**
=  =  =  =   =
**start:restapi_list_globalconf**

cmd:xdsh $$CN "curl -X GET --cacert /root/ca-cert.pem 'https://$$MN/xcatws/globalconf?userName=$$username&userPW=$$password'"

**Output:**
fs2vm115: {"clustersite":{"syspowerinterval":"0","dnshandler":"ddns","databaseloc":"/var/lib","enableASMI":"no","ntpservers":"<xcatmaster>","db2installloc":"/mntdb2","consoleondemand":"no","vsftp":"n","auditskipcmds":"ALL","xcatiport":"3002","xcatconfdir":"/etc/xcat","cleanupxcatpost":"no","powerinterval":"0","ppcretry":"3","maxssh":"8","nameservers":"10.3.31.114","installdir":"/install","nodesyncfiledir":"/var/xcat/node/syncfiles","domain":"pok.stglabs.ibm.com","xcatdport":"3001","ipmitimeout":"2","sshbetweennodes":"ALLGROUPS","dhcplease":"43200","fsptimeout":"0","timezone":"US/Eastern","blademaxp":"64","ppcmaxp":"64","SNsyncfiledir":"/var/xcat/syncfiles","forwarders":"10.6.29.1","ipmimaxp":"64","ipmiretries":"3","ppctimeout":"0","useNmapfromMN":"no","master":"10.3.31.114","auditnosyslog":"0","tftpdir":"/tftpboot","sharedtftp":"1"}}

**Will check whether the output has "tftpdir":"/tftpboot".**
=  =  =  =   =
**start:restapi_list_groups**

cmd:xdsh $$CN "curl -X GET --cacert /root/ca-cert.pem 'https://$$MN/xcatws/groups?userName=$$username&userPW=$$password'"

**Output:**
fs2vm115: ["all"]

**Will check whether the output has "all".**
=  =  =  =   =
**start:restapi_list_nodes**

cmd:xdsh $$CN "curl -X GET --cacert /root/ca-cert.pem 'https://$$MN/xcatws/nodes$userName=$$username&userPW=$$password'"

**Output:**
fs2vm115: ["fs2vm115"]

**Will check whether the output has "$$CN".**
=  =  =  =   =
**start:restapi_list_nodes_CN**

cmd:xdsh $$CN "curl -X GET --cacert /root/ca-cert.pem 'https://$$MN/xcatws/nodes/$$CN?userName=$$username&userPW=$$password'"

**Output:**
fs2vm115: {"fs2vm115":{"currchain":"boot","netboot":"grub2","postscripts":"syslog,remoteshell,syncfiles","vmmemory":"8192","groups":"all","vmnics":"br0,br1","currstate":"boot","status":"booted","monserver":"fs2vm114","vmcpus":"4","provmethod":"rhels8.1.0-ppc64le-install-compute","postbootscripts":"otherpkgs","ip":"10.3.31.115","mgt":"kvm","profile":"compute","serialflow":"hard","xcatmaster":"fs2vm114","id":"115","serialspeed":"115200","vmstorage":"dir:///var/lib/libvirt/images","cons":"kvm","tftpserver":"fs2vm114","vmhost":"c910f3u31-fs2","os":"rhels8.1.0","consoleenabled":"1","serialport":"0","updatestatustime":"08-02-2020 22:33:51","arch":"ppc64le","updatestatus":"synced","vmnicnicmodel":"virtio","mac":"42:fc:2a:19:df:b4|42:c5:18:30:0e:0d!*NOIP*","statustime":"08-11-2020 17:47:57","nfsserver":"fs2vm114"}}

**Will check whether the output has "nfsserver":"$$MN".**
=  =  =  =   =
**start:restapi_list_networks**

cmd:xdsh $$CN "curl -X GET --cacert /root/ca-cert.pem 'https://$$MN/xcatws/networks?userName=$$username&userPW=$$password'"

**Output:**
fs2vm115: ["10_0_0_0-255_0_0_0"]

**Will decide what to check against the output. _GETTABLEVALUE(...)_ could be used here.**
=  =  =  =   =
**start:restapi_list_osimages**

cmd:xdsh $$CN "curl -X GET --cacert /root/ca-cert.pem 'https://$$MN/xcatws/osimages?userName=$$username&userPW=$$password'"

**Output:**
fs2vm115: ["rhels8.1.0-ppc64le-install-compute","rhels8.1.0-ppc64le-install-service","rhels8.1.0-ppc64le-netboot-compute","rhels8.1.0-ppc64le-statelite-compute"]

**Will use _GETNODEATTR(...)_ to get the osimage name.**

=  =  =  =   =
**start:restapi_list_policy**

cmd:xdsh $$CN "curl -X GET --cacert /root/ca-cert.pem 'https://$$MN/xcatws/policy?userName=$$username&userPW=$$password'"

**Output:**
fs2vm115: ["1","1.2","2","2.1","2.3","3","4","4.4","4.5","4.6","4.7","4.8","4.9"]

**Will decide what to check against the output.**
=  =  =  =   =
**start:restapi_create_temp_CN_put**

cmd:xdsh $$CN "curl -X PUT --cacert /root/ca-cert.pem 'https://$$MN/xcatws/nodes/temp_node?userName=$$username&userPW=$$password' -H Content-Type:application/json --data '{\"groups\":\"all\",\"mgt\":\"kvm\",\"vmmemory\":\"2048\"}'"

**Output:**
fs2vm115  (node)
temp_node  (node)
CHECK:output =~ temp_node       [Pass]
=  =  =  =   =
**start:restapi_delete_temp_CN**

cmd:xdsh $$CN "curl -X DELETE --cacert /root/ca-cert.pem 'https://$$MN/xcatws/nodes/temp_node?userName=$$username&userPW=$$password'"

**Output:**
fs2vm115  (node)
CHECK:output != temp_node       [Pass]
=  =  =  =   =
start:restapi_create_temp_CN_post

cmd:xdsh $$CN "curl -X POST --cacert /root/ca-cert.pem 'https://$$MN/xcatws/nodes/temp_node?userName=$$username&userPW=$$password' -H Content-Type:application/json --data '{\"groups\":\"all\",\"mgt\":\"kvm\",\"vmmemory\":\"2048\",\"rcons\":\"kvm\"}'"

OUTPUT:
fs2vm115  (node)
temp_node  (node)
CHECK:output =~ temp_node       [Pass]
=  =  =  =   =
**start:restapi_add_id_temp_CN**

cmd:xdsh $$CN "curl -X PUT --cacert /root/ca-cert.pem 'https://$$MN/xcatws/nodes/temp_node?userName=$$username&userPW=$$password' -H Content-Type:application/json --data '{\"id\":\"100\"}'"

**Output:**
Object name: temp_node
    groups=all
    id=100
    mgt=kvm
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
    vmmemory=2048
CHECK:output =~ id=100  [Pass]
=  =  =  =   =
**start:restapi_modify_vmmemory_temp_CN**

cmd:xdsh $$CN "curl -X PUT --cacert /root/ca-cert.pem 'https://$$MN/xcatws/nodes/temp_node?userName=$$username&userPW=$$password' -H Content-Type:application/json --data '{\"vmmemory\":\"4096\"}'"

**Output:**
Object name: temp_node
    groups=all
    id=100
    mgt=kvm
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
    vmmemory=4096
CHECK:output =~ vmmemory=4096   [Pass]
=  =  =  =   =
**start:restapi_delete_id_temp_CN**

cmd:xdsh $$CN "curl -X PUT --cacert /root/ca-cert.pem 'https://$$MN/xcatws/nodes/temp_node?userName=$$username&userPW=$$password' -H Content-Type:application/json --data '{\"id\":\" \"}'"

**Output:**
Object name: temp_node
    groups=all
    mgt=kvm
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
    vmmemory=4096
CHECK:output !~ id=     [Pass]
=  =  =  =   =
**start:restapi_show_temp_CN_osimage**

cmd:NN=`lsdef $$CN | grep provmethod | tr -d " " | cut --complement -c 1-11`;/opt/xcat/share/xcat/tools/autotest/testcase/restapi/node/get_details.sh $$MN $$CN $$username $$password osimages $NN

**Output:**
fs2vm115: {"rhels8.1.0-ppc64le-install-compute":{"provmethod":"install","otherpkgdir":"/install/post/otherpkgs/rhels8.1.0/ppc64le","osname":"Linux","profile":"compute","template":"/opt/xcat/share/xcat/install/rh/compute.rhels8.tmpl","osdistroname":"rhels8.1.0-ppc64le","osarch":"ppc64le","imagetype":"linux","pkgdir":"/install/rhels8.1.0/ppc64le","osvers":"rhels8.1.0","pkglist":"/opt/xcat/share/xcat/install/rh/compute.rhels8.pkglist"}}

**Will use _GETNODEATTR(...)_ to get the osimage name.**
**Therefore, the following script get_details.sh need not be used.**
- - - - -
A supporting script, get_details.sh:

#!/bin/bash

This script display the detail of a resource.
MN, CN, username, password, resource and specific resource must be specified.

MN=$1
CN=$2
username=$3
password=$4
RS=$5
ITEM=$6

xdsh $CN "curl -X GET --cacert /root/ca-cert.pem 'https://$MN/xcatws/$RS/$ITEM?userName=$username&userPW=$password'"