### PR TITLE
Retry rpower boot command

### DIFF
--- a/xCAT-test/autotest/testcase/rpower/cases0
+++ b/xCAT-test/autotest/testcase/rpower/cases0
@@ -47,7 +47,7 @@ cmd:rpower $$CN stat
 check:output=~Not Activated|off
 # Display active VMs and memory on VM host
 cmd:vmhost=`lsdef $$CN -i vmhost -c | cut -d '=' -f 2`; if [[ ! -z $vmhost ]]; then echo "Memory on vmhost $vmhost"; ssh $vmhost free -m; echo "Active VMs on vmhost $vmhost"; ssh $vmhost virsh list; fi
-cmd:rpower $$CN boot
+cmd:rpower_boot_out=`rpower $$CN boot`; if [[ $rpower_boot_out =~ qemu-kvm ]]; then echo "rpower boot failed with $rpower_boot_out. Will retry"; rpower $$CN boot; else echo "rpower boot success on first try"; exit 0; fi
 check:rc==0
 cmd:a=0;while ! `rpower $$CN stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$CN stat


### PR DESCRIPTION
Sometimes `rpower_boot` testcase fails with 
`Error: internal error: qemu unexpectedly closed the monitor: 2020-08-31T07:36:02.418864Z qemu-kvm: Failed to allocate KVM HPT of order 26 (try smaller maxmem?): Cannot allocate memory` error. 

If that happens, retry.