### PR TITLE
Add extra output to confignetwork testcase

### DIFF
--- a/xCAT-test/autotest/testcase/confignetwork/cases0
+++ b/xCAT-test/autotest/testcase/confignetwork/cases0
@@ -864,6 +864,8 @@ check:output=~br22
 check:output=~br33
 cmd:xdsh $$CN "cat /sys/class/net/bonding_masters"
 check:output=~bond0
+cmd:xdsh $$CN "ip addr show bond0.3"
+cmd:xdsh $$CN "ip addr show br33"
 cmd:rmdef -t network -o confignetworks_test1
 cmd:rmdef -t network -o confignetworks_test2
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifcfg-$$SECONDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts"; elif grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /etc/network/interfaces.d/$$SECONDNIC";else echo "Sorry,this is not supported os"; fi


### PR DESCRIPTION
Sometimes `confignetwork_2eth_bridge_br22_br33` testcase fails with 

```
c910f03c09k17: configure nic and its device : br33 bond0.3
c910f03c09k17: [I]: create_bridge_interface_nmcli ifname=br33 _brtype=bridge _port=bond0.3 _pretype=vlan _ipaddr=103.3.9.17
c910f03c09k17: [I]: Pickup xcatnet, "confignetworks_test4", from NICNETWORKS for interface "br33".
c910f03c09k17: [E]:Error: Device bond0.3 not found
c910f03c09k17: [E]:Error: create bridge interface br33 failed
c910f03c09k17: postscript end....: confignetwork exited with code 1
```

This PR adds extra output to help debug why this happens.