### PR TITLE
Verify nbk kernel file is present before defaulting to use it

### DIFF
--- a/docs/source/advanced/hierarchy/define_service_nodes.rst
+++ b/docs/source/advanced/hierarchy/define_service_nodes.rst
@@ -103,5 +103,7 @@ The following table illustrates the cluster being used in this example:
          chdef -t site clustersite installloc=
          rsync -auv --exclude 'autoinst' /install r1n01:/
          rsync -auv --exclude 'autoinst' /install r2n01:/
-         rsync -auv --exclude 'autoinst' /tftpboot r1n01:/
-         rsync -auv --exclude 'autoinst' /tftpboot r2n01:/
+         rsync -auv /tftpboot r1n01:/
+         rsync -auv /tftpboot r2n01:/
+
+.. note:: If ``/install`` and ``/tftpboot`` directories local to each Service Node are used and ``mknb`` command is executed to generate a diskless network boot image with custom changes, it will not be automatically copied to the Service Node. Make sure to run the above ``rsync`` commands after executing the ``mknb``. Verify ``/tftpboot/xcat`` directory on Service node contains ``genesis.kernel.<arch>`` and ``genesis.fs.<arch>.gz`` files.

--- a/xCAT-server/lib/xcat/plugins/destiny.pm
+++ b/xCAT-server/lib/xcat/plugins/destiny.pm
@@ -711,10 +711,16 @@ sub setdestiny {
                     $bphash->{$_}->[0]->{initrd} = "xcat/genesis.fs.$arch.$othersuffix";
                     $bphash->{$_}->[0]->{kcmdline} = $kcmdline . "xcatd=$master:$xcatdport destiny=$state";
                 }
-            } else {    #'legacy' environment
+            } else {    # genesis.kernel file is not there, assume 'legacy' environment
+                if (-r "$tftpdir/xcat/nbk.$arch") {
                     $bphash->{$_}->[0]->{kernel} = "xcat/nbk.$arch";
                     $bphash->{$_}->[0]->{initrd} = "xcat/nkfs.$arch.gz";
                     $bphash->{$_}->[0]->{kcmdline} = $kcmdline . "xcatd=$master:$xcatdport";
+                    $callback->({ warning => ["No genesis.kernel.$arch file found. Defaulting to legacy nbk.$arch"]});
+                } else { # can not find genesis.kernel or nbk file
+                    $callback->({ error => ["Could not find genesis.kernel.$arch or legacy nbk.$arch files"], errorcode => [1] });
+                    exit(1);
+                }
             }
         }
 


### PR DESCRIPTION
### The PR is to fix issue _#6739_

When `nodeset <node> shell` is executed, it tries to find `/tftpboot/xcat/genesis.kernel.<arch>` file and places the entry for it into boot file `/tftpboot/xcat/xnba/nodes/<node>`. If no `/tftpboot/xcat/genesis.kernel.<arch>` file is found, a "legacy" environment is assumed and an entry for `nbk.<arch>` file is placed into boot file `/tftpboot/xcat/xnba/nodes/<node>`. 

This PR adds some checking to verify that `nbk.<arch>` file is there before placing it into boot file and gives user a warning that `/tftpboot/xcat/genesis.kernel.<arch>` file was not found. If neither `nbk.<arch>` nor `genesis.kernel.<arch>` files are found, `nodeset` will issue an error.

### UT

* When `genesis.kernel.<arch>` file is not there but `nbk.<arch>` is:
```
[root@c910f04x12v02 xcat]#  nodeset c910f04x12v04 shell
c910f04x12v04: shell
Warning: [c910f04x12v03]: No genesis.kernel.x86_64 file found. Defaulting to legacy nbk.x86_64
c910f04x12v04: shell
[root@c910f04x12v02 xcat]#
```

* When both `genesis.kernel.<arch>` and `nbk.<arch>` are missing
```
[root@c910f04x12v02 xcat]#  nodeset c910f04x12v04 shell
c910f04x12v04: shell
Error: [c910f04x12v03]: Could not find genesis.kernel.x86_64 or legacy nbk.x86_64 files
[root@c910f04x12v02 xcat]#
```

This PR also adds a not to documentation for users to verify that `genesis.kernel.<arch>` file is present on the service node.