### PR TITLE
Add extra debug output to confignetwork script

### DIFF
--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -756,9 +756,12 @@ function check_brctl() {
 function check_and_set_device_managed() {
     devname=$1
     rc=1
+    log_info "check_and_set_device_managed for device $devname"
     $nmcli device show $devname >/dev/null 2>/dev/null
     if [ $? -ne 0 ]; then
         log_error "Device $devname not found"
+        # Could not find the device we wanted. Display all devices
+        $nmcli device show
     else
         $nmcli -g GENERAL.STATE device show $devname|grep unmanaged >/dev/null 2>/dev/null
         if [ $? -eq 0 ]; then


### PR DESCRIPTION
`confignetwork_2eth_bridge_br22_br33` testcase continues to fail with
```
c910f03c09k17: configure nic and its device : br33 bond0.3
c910f03c09k17: [I]: create_bridge_interface_nmcli ifname=br33 _brtype=bridge _port=bond0.3 _pretype=vlan _ipaddr=103.3.9.17
c910f03c09k17: [I]: Pickup xcatnet, "confignetworks_test4", from NICNETWORKS for interface "br33".
c910f03c09k17: [E]:Error: Device bond0.3 not found
c910f03c09k17: [E]:Error: create bridge interface br33 failed
c910f03c09k17: postscript end....: confignetwork exited with code 1
```

This PR adds extra output to help debug why this happens. Continuing from #6822 