### PR TITLE
Change private key permissions to 600

### DIFF
--- a/xCAT/postscripts/remoteshell
+++ b/xCAT/postscripts/remoteshell
@@ -152,7 +152,7 @@ if [ $? -ne 0 ]; then
                 getcredentials.awk ssh_dsa_hostkey | grep -v '<'|sed -e 's/&lt;/</' -e 's/&gt;/>/' -e 's/&amp;/&/' -e 's/&quot/"/' -e "s/&apos;/'/" > /etc/ssh/ssh_host_dsa_key
                 MYCONT=`cat /etc/ssh/ssh_host_dsa_key`
    done
-   egrep  -i "^ssh_keys:" /etc/group >/dev/null 2>&1 && chown root:ssh_keys /etc/ssh/ssh_host_dsa_key 2>/dev/null && chmod 640 /etc/ssh/ssh_host_dsa_key
+   egrep  -i "^ssh_keys:" /etc/group >/dev/null 2>&1 && chown root:ssh_keys /etc/ssh/ssh_host_dsa_key 2>/dev/null && chmod 600 /etc/ssh/ssh_host_dsa_key
    if ! grep "PRIVATE KEY" /etc/ssh/ssh_host_dsa_key > /dev/null 2>&1 ; then
         rm /etc/ssh/ssh_host_dsa_key
 	else
@@ -218,7 +218,7 @@ if [ $? -ne 0 ]; then
     		getcredentials.awk ssh_rsa_hostkey | grep -v '<'|sed -e 's/&lt;/</' -e 's/&gt;/>/' -e 's/&amp;/&/' -e 's/&quot/"/' -e "s/&apos;/'/" > /etc/ssh/ssh_host_rsa_key
     		MYCONT=`cat /etc/ssh/ssh_host_rsa_key`
 	done
-        egrep  -i "^ssh_keys:" /etc/group >/dev/null 2>&1 && chown root:ssh_keys /etc/ssh/ssh_host_rsa_key 2>/dev/null && chmod 640 /etc/ssh/ssh_host_rsa_key
+        egrep  -i "^ssh_keys:" /etc/group >/dev/null 2>&1 && chown root:ssh_keys /etc/ssh/ssh_host_rsa_key 2>/dev/null && chmod 600 /etc/ssh/ssh_host_rsa_key
 	if ! grep "PRIVATE KEY" /etc/ssh/ssh_host_rsa_key > /dev/null 2>&1 ; then
    		rm /etc/ssh/ssh_host_rsa_key
 	else
@@ -289,7 +289,7 @@ if ssh-keygen -t ecdsa -f /tmp/ecdsa_key -P "" &>/dev/null ; then
     		getcredentials.awk ssh_ecdsa_hostkey | grep -v '<'|sed -e 's/&lt;/</' -e 's/&gt;/>/' -e 's/&amp;/&/' -e 's/&quot/"/' -e "s/&apos;/'/" > /etc/ssh/ssh_host_ecdsa_key
     		MYCONT=`cat /etc/ssh/ssh_host_ecdsa_key`
 	done
-	egrep  -i "^ssh_keys:" /etc/group >/dev/null 2>&1 && chown root:ssh_keys /etc/ssh/ssh_host_ecdsa_key 2>/dev/null && chmod 640 /etc/ssh/ssh_host_ecdsa_key
+	egrep  -i "^ssh_keys:" /etc/group >/dev/null 2>&1 && chown root:ssh_keys /etc/ssh/ssh_host_ecdsa_key 2>/dev/null && chmod 600 /etc/ssh/ssh_host_ecdsa_key
 	if ! grep "PRIVATE KEY" /etc/ssh/ssh_host_ecdsa_key > /dev/null 2>&1 ; then
    		rm /etc/ssh/ssh_host_ecdsa_key
 	else


### PR DESCRIPTION
### The PR is to fix issue https://github.com/xcat2/xcat-core/issues/6832

Some versions of OpenSSH will not load private keys with permissive permissions. Setting permission to 600 allows OpenSSH to start and load the created private keys and avoid some downstream errors during postbootscript sequences.

### The modification include
* postscripts/remoteshell - changes the permissions of private keys from 640 to 600
