### PR TITLE
Add perl to the rhels8 pkglist

### DIFF
--- a/xCAT-server/share/xcat/install/centos/compute.centos8.pkglist
+++ b/xCAT-server/share/xcat/install/centos/compute.centos8.pkglist
@@ -9,3 +9,4 @@ wget
 python3
 tar
 bzip2
+perl-interpreter

--- a/xCAT-server/share/xcat/install/rh/compute.rhels8.pkglist
+++ b/xCAT-server/share/xcat/install/rh/compute.rhels8.pkglist
@@ -9,3 +9,4 @@ wget
 python3
 tar
 bzip2
+perl-interpreter

--- a/xCAT-server/share/xcat/install/rh/service.rhels8.pkglist
+++ b/xCAT-server/share/xcat/install/rh/service.rhels8.pkglist
@@ -13,3 +13,4 @@ unixODBC
 python3
 tar
 bzip2
+perl-interpreter

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels8.ppc64le.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels8.ppc64le.pkglist
@@ -30,3 +30,4 @@ gzip
 grub2
 grub2-tools
 lsvpd
+perl-interpreter

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels8.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels8.x86_64.pkglist
@@ -26,4 +26,5 @@ bash
 vim-minimal
 rpm
 iputils
+perl-interpreter
 


### PR DESCRIPTION
For issue #6835 

The `perl` command is not install in the rhels8 compute node,   which cause post scripts failed to use perl command.
 