### PR TITLE
Remove experimental warnings of using given-when and smartmatch.

### DIFF
--- a/xCAT-server/lib/perl/xCAT/OPENBMC.pm
+++ b/xCAT-server/lib/perl/xCAT/OPENBMC.pm
@@ -102,7 +102,8 @@ sub run_cmd_in_perl {
     # List of commands currently not supported in Python
     my @unsupported_in_python_commands = ('rflash', 'getopenbmccons');
 
-    if ($command ~~ @unsupported_in_python_commands) {
+    my @temp = grep ({$command =~ $_ } @unsupported_in_python_commands);
+    if ( $command eq $temp[0]) {
         # Command currently not supported in Python
         if ($support_obmc and uc($support_obmc) eq 'YES') {
             return (0, ''); # Go Python: unsuppored command, but XCAT_OPENBMC_DEVEL=YES overrides

--- a/xCAT-server/lib/xcat/plugins/kvm.pm
+++ b/xCAT-server/lib/xcat/plugins/kvm.pm
@@ -3571,25 +3571,23 @@ sub lsvm {
                 if (exists $domain_info->{"state"}) {
                     my $state =  $domain_info->{"state"};
                     my $state_string;
-                    given($state) {
-                        when ($state == &Sys::Virt::Domain::STATE_NOSTATE)
-                            {$state_string = "The domain is active, but is not running / blocked (eg idle)";}
-                        when ($state == &Sys::Virt::Domain::STATE_RUNNING)
-                            {$state_string = "The domain is active and running";}
-                        when ($state == &Sys::Virt::Domain::STATE_BLOCKED)
-                            {$state_string = "The domain is active, but execution is blocked";}
-                        when ($state == &Sys::Virt::Domain::STATE_PAUSED)
-                            {$state_string = "The domain is active, but execution has been paused";}
-                        when ($state == &Sys::Virt::Domain::STATE_SHUTDOWN)
-                            {$state_string = "The domain is active, but in the shutdown phase";}
-                        when ($state == &Sys::Virt::Domain::STATE_SHUTOFF)
-                            {$state_string = "The domain is inactive, and shut down";}
-                        when ($state == &Sys::Virt::Domain::STATE_CRUSHED)
-                            {$state_string = "The domain is inactive, and crashed";}
-                        when ($state == &Sys::Virt::Domain::STATE_PMSUSPENDED)
-                            {$state_string = "The domain is active, but in power management suspend state";}
-                        default {$state_string = "Unknown"};
-                    }
+                    if ($state == &Sys::Virt::Domain::STATE_NOSTATE)
+                        {$state_string = "The domain is active, but is not running / blocked (eg idle)";}
+                    elsif ($state == &Sys::Virt::Domain::STATE_RUNNING)
+                        {$state_string = "The domain is active and running";}
+                    elsif ($state == &Sys::Virt::Domain::STATE_BLOCKED)
+                        {$state_string = "The domain is active, but execution is blocked";}
+                    elsif ($state == &Sys::Virt::Domain::STATE_PAUSED)
+                        {$state_string = "The domain is active, but execution has been paused";}
+                    elsif ($state == &Sys::Virt::Domain::STATE_SHUTDOWN)
+                        {$state_string = "The domain is active, but in the shutdown phase";}
+                    elsif ($state == &Sys::Virt::Domain::STATE_SHUTOFF)
+                        {$state_string = "The domain is inactive, and shut down";}
+                    elsif ($state == &Sys::Virt::Domain::STATE_CRUSHED)
+                        {$state_string = "The domain is inactive, and crashed";}
+                    elsif ($state == &Sys::Virt::Domain::STATE_PMSUSPENDED)
+                        {$state_string = "The domain is active, but in power management suspend state";}
+                    else {$state_string = "Unknown"};
                     push @vms, "State :" . $domain_info->{"state"} . " ($state_string)";
                 }
                 # The following block of code copied from rscan command processng for disks

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1255,7 +1255,7 @@ sub parse_args {
         my $option_s;
         GetOptions( 's' => \$option_s );
         return ([ 1, "The -s option is not supported for OpenBMC." ]) if ($option_s);
-        my @temp = grep ({$command =~ $_ } @ARGV);
+        my @temp = grep ({"resolved" =~ $_ } @ARGV);
         if ( "resolved=" eq $temp[0]) {
             return ([ 1, "$usage_errormsg $reventlog_no_id_resolved_errormsg" ]);
         }

--- a/xCAT-server/lib/xcat/plugins/openbmc.pm
+++ b/xCAT-server/lib/xcat/plugins/openbmc.pm
@@ -1255,7 +1255,8 @@ sub parse_args {
         my $option_s;
         GetOptions( 's' => \$option_s );
         return ([ 1, "The -s option is not supported for OpenBMC." ]) if ($option_s);
-        if ( "resolved=" ~~ @ARGV) {
+        my @temp = grep ({$command =~ $_ } @ARGV);
+        if ( "resolved=" eq $temp[0]) {
             return ([ 1, "$usage_errormsg $reventlog_no_id_resolved_errormsg" ]);
         }
         return ([ 1, "Only one option is supported at the same time for $command" ]);


### PR DESCRIPTION
For given-when, lsvm was used to verify the correctness. The changed file is kvm.pm.

For smartmatch, there are two files: openbmc.pm and OPENBMC.pm. 

For the change in openbmc.pm, "reventlog mid05tor12c15 resolved=" and "reventlog mid05tor12c15 resolved=48" were tested on briggs01 for correctness.

For the change in OPENBMC.pm, "rflash f5u14 -l -V" was used on stratton01 for correctness.