### PR TITLE
Modify restapi_list_groups for correct output matching

### DIFF
--- a/xCAT-test/autotest/testcase/restapi/cases0
+++ b/xCAT-test/autotest/testcase/restapi/cases0
@@ -45,7 +45,8 @@ end
 start:restapi_list_groups
 description: List groups on the management node with "curl -X GET"
 label:restapi
-cmd:username=__GETTABLEVALUE(key,system,username,passwd)__;password=__GETTABLEVALUE(key,system,password,passwd)__;xdsh $$CN "curl -X GET -s -k --cacert /root/ca-cert.pem 'https://$$MN/xcatws/groups?userName=$username&userPW=$password'"
+cmd:username=__GETTABLEVALUE(key,system,username,passwd)__;password=__GETTABLEVALUE(key,system,password,passwd)__;xdsh $$CN "curl -X GET -s -k --cacert /root/ca-cert.pem 'https://$$MN/xcatws/groups?userName=$
+username&userPW=$password' | sed 's/\"//g'"
 check:rc==0
 check:output=~__GETTABLEVALUE(node,$$CN,groups,nodelist)__
 end


### PR DESCRIPTION
On our RHEL ppc64le systems, the output is ["all"] for
curl -X GET -s -k --cacert /root/ca-cert.pem 'https://$$MN/xcatws/groups?userName=$username&userPW=$password'.
__GETTABLEVALUE(node,$$CN,groups,nodelist)__ returns all.
So check:output=~all returns [Pass].

However on our RHEL x86 systems, curl returns ["abc","all","vm12"] and __GETTABLEVALUE(node,$$CN,groups,nodelist)__ returns all,vm2.
Indeed, **all,vm12** is NOT a sub-string.

**sed 's/\"//g'** changes  ["abc","all","vm12"] into  [abc,all,vm12]. It then finds all.vm12 in it.

Note **sed "s/\"//g"** does not work, but the single quote (') works.

Interestingly, **sed "s/\,//g"** is fine (, is a comma). Perl does not like so many double quotes.