### PR TITLE
Fix restapi_list_groups: The command was in TWO lines, not ONE.

### DIFF
--- a/xCAT-test/autotest/testcase/restapi/cases0
+++ b/xCAT-test/autotest/testcase/restapi/cases0
@@ -45,8 +45,7 @@ end
 start:restapi_list_groups
 description: List groups on the management node with "curl -X GET"
 label:restapi
-cmd:username=__GETTABLEVALUE(key,system,username,passwd)__;password=__GETTABLEVALUE(key,system,password,passwd)__;xdsh $$CN "curl -X GET -s -k --cacert /root/ca-cert.pem 'https://$$MN/xcatws/groups?userName=$
-username&userPW=$password' | sed 's/\"//g'"
+cmd:username=__GETTABLEVALUE(key,system,username,passwd)__;password=__GETTABLEVALUE(key,system,password,passwd)__;xdsh $$CN "curl -X GET -s -k --cacert /root/ca-cert.pem 'https://$$MN/xcatws/groups?userName=$username&userPW=$password' | sed 's/\"//g'"
 check:rc==0
 check:output=~__GETTABLEVALUE(node,$$CN,groups,nodelist)__
 end


### PR DESCRIPTION
username&userPW=$password' | sed 's/\"//g'" was mistakenly put in the next line. (PR #6843)

There is one command line now.