### PR TITLE
Extend the REST test cases to SLES

### DIFF
--- a/xCAT-test/autotest/bundle/sles_ppcle_daily.bundle
+++ b/xCAT-test/autotest/bundle/sles_ppcle_daily.bundle
@@ -7,6 +7,7 @@ assign_certain_command_permission
 bmcdiscover_help
 bmcdiscover_q
 bmcdiscover_version
+#INCLUDE:restapi.bundle#
 xdcp_nonroot_user
 xdsh_E
 xdsh_Q_command

--- a/xCAT-test/autotest/bundle/sles_x86_daily.bundle
+++ b/xCAT-test/autotest/bundle/sles_x86_daily.bundle
@@ -7,6 +7,7 @@ assign_certain_command_permission
 bmcdiscover_help
 bmcdiscover_q
 bmcdiscover_version
+#INCLUDE:restapi.bundle#
 xdcp_nonroot_user
 xdsh_E
 xdsh_Q_command

--- a/xCAT-test/autotest/testcase/restapi/cases0
+++ b/xCAT-test/autotest/testcase/restapi/cases0
@@ -4,9 +4,18 @@ label:restapi
 #Install the mod_ssl package on Red Hat
 cmd:if cat /etc/*release | grep "Red Hat" >/dev/null; then yum install mod_ssl -y; rpm -qa | grep mod_ssl; fi
 check:rc==0
-cmd:sed -i 's/^\(\s*\)SSLCertificateFile.*$/\1SSLCertificateFile \/etc\/xcat\/cert\/server-cred.pem/' /etc/httpd/conf.d/ssl.conf 
-cmd:sed -i 's/^\(\s*SSLCertificateKeyFile.*\)$/#\1/' /etc/httpd/conf.d/ssl.conf
+cmd:if cat /etc/*release | grep "Red Hat" >/dev/null; then sed -i 's/^\(\s*\)SSLCertificateFile.*$/\1SSLCertificateFile \/etc\/xcat\/cert\/server-cred.pem/' /etc/httpd/conf.d/ssl.conf; fi
+cmd:if cat /etc/*release | grep "Red Hat" >/dev/null; then sed -i 's/^\(\s*SSLCertificateKeyFile.*\)$/#\1/' /etc/httpd/conf.d/ssl.conf; fi
+check:rc==0
 cmd:if cat /etc/*release | grep "Red Hat" >/dev/null; then service httpd restart; fi
+check:rc==0
+#Configure the SLES environment
+cmd:if cat /etc/*release | grep "SLES" >/dev/null; then a2enmod ssl; a2enflag SSL; cp /etc/apache2/vhosts.d/vhost-ssl.template /etc/apache2/vhosts.d/vhost-ssl.conf; fi
+check:rc==0
+cmd:if cat /etc/*release | grep "SLES" >/dev/null; then sed -i 's/^\(\s*\)SSLCertificateFile.*$/\1SSLCertificateFile \/etc\/xcat\/cert\/server-cred.pem/' /etc/apache2/vhosts.d/vhost-ssl.conf; fi
+cmd:if cat /etc/*release | grep "SLES" >/dev/null; then sed -i 's/^\(\s*SSLCertificateKeyFile.*\)$/#\1/' /etc/apache2/vhosts.d/vhost-ssl.conf; fi
+check:rc==0
+cmd:if cat /etc/*release | grep "SLES" >/dev/null; then service apache2 restart; fi
 check:rc==0
 cmd:scp /install/postscripts/ca/ca-cert.pem $$CN:/root
 check:rc==0
@@ -22,8 +31,11 @@ check:rc==0
 cmd:tabch -d key=xcat passwd
 check:rc==0
 #Remove the mod_ssl package on Red Hat
-cmd:if cat /etc/*release | grep "Red Hat" >/dev/null; then yum remove mod_ssl -y; service httpd restart; rpm -qa | grep mod_ssl; fi
-check:rc==1
+cmd:if cat /etc/*release | grep "Red Hat" >/dev/null; then yum remove mod_ssl -y; service httpd restart; fi
+check:rc==0
+#Clean up the SLES environment
+cmd:if cat /etc/*release | grep "SLES" >/dev/null; then rm /etc/apache2/vhosts.d/vhost-ssl.conf; service apache2 restart; fi
+check:rc==0
 end
 
 start:restapi_list_all_resources


### PR DESCRIPTION
restapi_setup_on_MN_CN and restapi_cleanup_on_MN_CN were modified to handle both RHEL and SLES systems.

If the changes look good, we can indeed test them over the weekend. Otherwise, I will make more changes on Monday.

Here are the key points:
(1) Multiple testings for "Red Hat" and "SLES" are for readability. They can be put together under one if-then statement.
(2) And, if there is failure, we can isolate it much easier.
(3) There are two adjacent substitution commands in the ssl.conf file. I intended to add "check:rc==0" after the first one. But there is a strange syntax error for the second command. Running the second command at the prompt by itself is fine. Without being able to figure out the cause of the syntax error, I keep it the old way.
(4) In the RHEL clean-up step, "rpm -qa | grep mod_ssl" causes a failure, even on RHEL systems. It definitely ran fine in the regression testing in past few nights. Since "rpm -qa | grep mod_ssl" is used to ascertain the removal of mod_ssl, which is not really critical, so I remove it.

They were tested successfully on a 3-node RHEL cluster and a 3-node SLES cluster.