### PR TITLE
Compare the curl and lsdef output in restapi_list_groups

### DIFF
--- a/xCAT-test/autotest/testcase/restapi/cases0
+++ b/xCAT-test/autotest/testcase/restapi/cases0
@@ -57,7 +57,7 @@ end
 start:restapi_list_groups
 description: List groups on the management node with "curl -X GET"
 label:restapi
-cmd:username=__GETTABLEVALUE(key,system,username,passwd)__;password=__GETTABLEVALUE(key,system,password,passwd)__;curl_v=`xdsh $$CN "curl -X GET -s -k --cacert /root/ca-cert.pem 'https://$$MN/xcatws/groups?userName=$username&userPW=$password' | sed 's/\"//g' | sed 's/\[//' | sed 's/\]//'"`;lsdef -t group > list; tr -d '\n' < list > list1; sed -i 's/[[:blank:]][[:blank:]]/,/g' list1; sed -i 's/(group)//g' list1; sed -i 's/,$//' list1; sed -i 's/^/$$CN: /' list1; lsdef_v=`cat list1`; echo $curl_v; echo $lsdef_v; if [[ $curl_v = $lsdef_v ]]; then echo YES; else echo NO; fi
+cmd:username=__GETTABLEVALUE(key,system,username,passwd)__;password=__GETTABLEVALUE(key,system,password,passwd)__;curl_v=`xdsh $$CN "curl -X GET -s -k --cacert /root/ca-cert.pem 'https://$$MN/xcatws/groups?userName=$username&userPW=$password' | sed 's/\"//g' | sed 's/\[//' | sed 's/\]//'"`;lsdef -t group > list; tr -d '\n' < list > list1; sed -i 's/[[:blank:]][[:blank:]]/,/g' list1; sed -i 's/(group)//g' list1; sed -i 's/,$//' list1; sed -i 's/^/$$CN: /' list1; lsdef_v=`cat list1`; echo $curl_v; echo $lsdef_v; rm -f list list1; if [[ $curl_v = $lsdef_v ]]; then echo YES; else echo NO; fi
 check:rc==0
 check:output=~YES
 end

--- a/xCAT-test/autotest/testcase/restapi/cases0
+++ b/xCAT-test/autotest/testcase/restapi/cases0
@@ -57,9 +57,9 @@ end
 start:restapi_list_groups
 description: List groups on the management node with "curl -X GET"
 label:restapi
-cmd:username=__GETTABLEVALUE(key,system,username,passwd)__;password=__GETTABLEVALUE(key,system,password,passwd)__;curl_v=`xdsh $$CN "curl -X GET -s -k --cacert /root/ca-cert.pem 'https://$$MN/xcatws/groups?userName=$username&userPW=$password' | sed 's/\"//g' | sed 's/\[//' | sed 's/\]//'"`;lsdef -t group > list; tr -d '\n' < list > list1; sed -i 's/[[:blank:]][[:blank:]]/,/g' list1; sed -i 's/(group)//g' list1; sed -i 's/,$//' list1; sed -i 's/^/$$CN: /' list1; lsdef_v=`cat list1`; echo $curl_v; echo $lsdef_v; rm -f list list1; if [[ $curl_v = $lsdef_v ]]; then echo YES; else echo NO; fi
+cmd:username=__GETTABLEVALUE(key,system,username,passwd)__;password=__GETTABLEVALUE(key,system,password,passwd)__;curl_v=`xdsh $$CN "curl -X GET -s -k --cacert /root/ca-cert.pem 'https://$$MN/xcatws/groups?userName=$username&userPW=$password' | sed 's/\"//g' | sed 's/\[//' | sed 's/\]//'"`;lsdef -t group > list; tr -d '\n' < list > list1; sed -i 's/[[:blank:]][[:blank:]]/,/g' list1; sed -i 's/(group)//g' list1; sed -i 's/,$//' list1; sed -i 's/^/$$CN: /' list1; lsdef_v=`cat list1`; echo $curl_v; echo $lsdef_v; rm -f list list1; if [[ $curl_v = $lsdef_v ]]; then echo Match; else echo No-Match; fi
 check:rc==0
-check:output=~YES
+check:output=~Match
 end
 
 start:restapi_list_nodes

--- a/xCAT-test/autotest/testcase/restapi/cases0
+++ b/xCAT-test/autotest/testcase/restapi/cases0
@@ -57,9 +57,9 @@ end
 start:restapi_list_groups
 description: List groups on the management node with "curl -X GET"
 label:restapi
-cmd:username=__GETTABLEVALUE(key,system,username,passwd)__;password=__GETTABLEVALUE(key,system,password,passwd)__;xdsh $$CN "curl -X GET -s -k --cacert /root/ca-cert.pem 'https://$$MN/xcatws/groups?userName=$username&userPW=$password' | sed 's/\"//g'"
+cmd:username=__GETTABLEVALUE(key,system,username,passwd)__;password=__GETTABLEVALUE(key,system,password,passwd)__;curl_v=`xdsh $$CN "curl -X GET -s -k --cacert /root/ca-cert.pem 'https://$$MN/xcatws/groups?userName=$username&userPW=$password' | sed 's/\"//g' | sed 's/\[//' | sed 's/\]//'"`;lsdef -t group > list; tr -d '\n' < list > list1; sed -i 's/[[:blank:]][[:blank:]]/,/g' list1; sed -i 's/(group)//g' list1; sed -i 's/,$//' list1; sed -i 's/^/$$CN: /' list1; lsdef_v=`cat list1`; echo $curl_v; echo $lsdef_v; if [[ $curl_v = $lsdef_v ]]; then echo YES; else echo NO; fi
 check:rc==0
-check:output=~__GETTABLEVALUE(node,$$CN,groups,nodelist)__
+check:output=~YES
 end
 
 start:restapi_list_nodes


### PR DESCRIPTION
lsdef -t group
 adam  (group)
 all  (group)
 dave  (group)
 ken  (group)
 sam  (group)

------START::restapi_list_groups::Time:Tue Oct  6 17:05:17 2020------

RUN:username=__GETTABLEVALUE(key,system,username,passwd)__;password=__GETTABLEVALUE(key,system,password,passwd)__;curl_v=`xdsh fs2vm107 "curl -X GET -s -k --cacert /root/ca-cert.pem 'https://fs2vm104/xcatws/groups?userName=$username&userPW=$password' | sed 's/\"//g' | sed 's/\[//' | sed 's/\]//'"`;lsdef -t group > list; tr -d '\n' < list > list1; sed -i 's/[[:blank:]][[:blank:]]/,/g' list1; sed -i 's/(group)//g' list1; sed -i 's/,$//' list1; sed -i 's/^/fs2vm107: /' list1; lsdef_v=`cat list1`; echo $curl_v; echo $lsdef_v; if [[ $curl_v = $lsdef_v ]]; then echo YES; else echo NO; fi [Tue Oct  6 17:05:17 2020]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
fs2vm107: adam,all,dave,ken,sam
fs2vm107: adam,all,dave,ken,sam
YES
CHECK:rc == 0   [Pass]
CHECK:output =~ YES     [Pass]

------END::restapi_list_groups::Passed::Time:Tue Oct  6 17:05:20 2020 ::Duration::3 sec------
------Total: 1 , Failed: 0------

The curl result is saved in curl_v, and the lsdef result in lsdef_v.
If they match, echo YES, else echo NO.