### PR TITLE
Replace No-Match by No-match for correct regex comparison

### DIFF
--- a/xCAT-test/autotest/testcase/restapi/cases0
+++ b/xCAT-test/autotest/testcase/restapi/cases0
@@ -57,7 +57,7 @@ end
 start:restapi_list_groups
 description: List groups on the management node with "curl -X GET"
 label:restapi
-cmd:username=__GETTABLEVALUE(key,system,username,passwd)__;password=__GETTABLEVALUE(key,system,password,passwd)__;curl_v=`xdsh $$CN "curl -X GET -s -k --cacert /root/ca-cert.pem 'https://$$MN/xcatws/groups?userName=$username&userPW=$password' | sed 's/\"//g' | sed 's/\[//' | sed 's/\]//'"`;lsdef -t group > list; tr -d '\n' < list > list1; sed -i 's/[[:blank:]][[:blank:]]/,/g' list1; sed -i 's/(group)//g' list1; sed -i 's/,$//' list1; sed -i 's/^/$$CN: /' list1; lsdef_v=`cat list1`; echo $curl_v; echo $lsdef_v; rm -f list list1; if [[ $curl_v = $lsdef_v ]]; then echo Match; else echo No-Match; fi
+cmd:username=__GETTABLEVALUE(key,system,username,passwd)__;password=__GETTABLEVALUE(key,system,password,passwd)__;curl_v=`xdsh $$CN "curl -X GET -s -k --cacert /root/ca-cert.pem 'https://$$MN/xcatws/groups?userName=$username&userPW=$password' | sed 's/\"//g' | sed 's/\[//' | sed 's/\]//'"`;lsdef -t group > list; tr -d '\n' < list > list1; sed -i 's/[[:blank:]][[:blank:]]/,/g' list1; sed -i 's/(group)//g' list1; sed -i 's/,$//' list1; sed -i 's/^/$$CN: /' list1; lsdef_v=`cat list1`; echo $curl_v; echo $lsdef_v; rm -f list list1; if [[ $curl_v = $lsdef_v ]]; then echo Match; else echo No-match; fi
 check:rc==0
 check:output=~Match
 end


### PR DESCRIPTION
After the change, I purposely replace ":" by "-A" after $$CN for testing purposes. The two strings would mismatch, and the failure is shown.

------START::restapi_list_groups::Time:Wed Oct  7 09:40:49 2020------

RUN:username=__GETTABLEVALUE(key,system,username,passwd)__;password=__GETTABLEVALUE(key,system,password,passwd)__;curl_v=`xdsh fs2vm107 "curl -X GET -s -k --cacert /root/ca-cert.pem 'https://fs2vm104/xcatws/groups?userName=$username&userPW=$password' | sed 's/\"//g' | sed 's/\[//' | sed 's/\]//'"`;lsdef -t group > list; tr -d '\n' < list > list1; sed -i 's/[[:blank:]][[:blank:]]/,/g' list1; sed -i 's/(group)//g' list1; sed -i 's/,$//' list1; sed -i 's/^/fs2vm107-A /' list1; lsdef_v=`cat list1`; echo $curl_v; echo $lsdef_v; rm -f list list1; if [[ $curl_v = $lsdef_v ]]; then echo Match; else echo No-match; fi [Wed Oct  7 09:40:49 2020]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
fs2vm107: adam,all,dave,ken,sam
fs2vm107-A adam,all,dave,ken,sam
No-match
CHECK:rc == 0   [Pass]
CHECK:output =~ Match   [Failed]

------END::restapi_list_groups::Failed::Time:Wed Oct  7 09:40:52 2020 ::Duration::3 sec------
------Total: 1 , Failed: 1------