### PR TITLE
Get the correct path for nice command

### DIFF
--- a/xCAT-server/share/xcat/netboot/add-on/statelite/rc.statelite.ppc.redhat
+++ b/xCAT-server/share/xcat/netboot/add-on/statelite/rc.statelite.ppc.redhat
@@ -128,7 +128,12 @@ GetSyncInfo () {
 xCATCmd () {
 # $1 is the xCAT server
 # $2 is the command
-	echo "<xcatrequest>\n<command>${2}</command>\n</xcatrequest>" | /usr/sbin/chroot ${MNTDIR} /usr/bin/openssl s_client -quiet -no_ssl3 $(/usr/sbin/chroot ${MNTDIR} /usr/bin/openssl s_client -help 2>&1 | grep -m 1 -o -- -no_ssl2) -connect ${1} -rand /bin/nice 2>/dev/null
+        if [ -f "/usr/bin/nice" ]; then
+            NICE="/usr/bin/nice"
+        else
+            NICE="/bin/nice"
+        fi
+	echo "<xcatrequest>\n<command>${2}</command>\n</xcatrequest>" | /usr/sbin/chroot ${MNTDIR} /usr/bin/openssl s_client -quiet -no_ssl3 $(/usr/sbin/chroot ${MNTDIR} /usr/bin/openssl s_client -help 2>&1 | grep -m 1 -o -- -no_ssl2) -connect ${1} -rand ${NICE} 2>/dev/null
 
 }
 

--- a/xCAT-server/share/xcat/netboot/add-on/statelite/rc.statelite.ppc.redhat
+++ b/xCAT-server/share/xcat/netboot/add-on/statelite/rc.statelite.ppc.redhat
@@ -129,11 +129,11 @@ xCATCmd () {
 # $1 is the xCAT server
 # $2 is the command
         if [ -f "/usr/bin/nice" ]; then
-            NICE="/usr/bin/nice"
+            RANDOMBYTES="-rand /usr/bin/nice"
         else
-            NICE="/bin/nice"
+            RANDOMBYTES=""
         fi
-	echo "<xcatrequest>\n<command>${2}</command>\n</xcatrequest>" | /usr/sbin/chroot ${MNTDIR} /usr/bin/openssl s_client -quiet -no_ssl3 $(/usr/sbin/chroot ${MNTDIR} /usr/bin/openssl s_client -help 2>&1 | grep -m 1 -o -- -no_ssl2) -connect ${1} -rand ${NICE} 2>/dev/null
+	echo "<xcatrequest>\n<command>${2}</command>\n</xcatrequest>" | /usr/sbin/chroot ${MNTDIR} /usr/bin/openssl s_client -quiet -no_ssl3 $(/usr/sbin/chroot ${MNTDIR} /usr/bin/openssl s_client -help 2>&1 | grep -m 1 -o -- -no_ssl2) -connect ${1} ${RANDOMBYTES} 2>/dev/null
 
 }
 

--- a/xCAT/postscripts/getcredentials.awk
+++ b/xCAT/postscripts/getcredentials.awk
@@ -1,12 +1,9 @@
 #!/usr/bin/awk -f
 BEGIN {
-        if (!system("test -f /bin/nice")) {
-           nice = "/bin/nice"
-        } else if (!system("test -f /usr/bin/nice")) {
-           nice = "/usr/bin/nice"
+        if (!system("test -f /usr/bin/nice")) {
+           randombytes = "-rand /usr/bin/nice"
         } else {
-           print "Error: nice utility missing"
-           exit 1
+           randombytes = ""
         }
         if (!system("test -f openssl")) {
            print "Error: openssl utility missing"
@@ -14,9 +11,9 @@ BEGIN {
         }
 
         if ((ENVIRON["USEOPENSSLFORXCAT"]) || (ENVIRON["AIX"])) {
-            server = "openssl s_client -quiet -no_ssl3 -connect " ENVIRON["XCATSERVER"] " -rand "nice" 2> /dev/null"
+            server = "openssl s_client -quiet -no_ssl3 -connect " ENVIRON["XCATSERVER"] " "randombytes" 2> /dev/null"
             if (!system("openssl s_client -help 2>&1 | grep -m 1 -q -- -no_ssl2")) {
-                server = "openssl s_client -quiet -no_ssl3 -no_ssl2 -connect " ENVIRON["XCATSERVER"] " -rand "nice" 2> /dev/null"
+                server = "openssl s_client -quiet -no_ssl3 -no_ssl2 -connect " ENVIRON["XCATSERVER"] " "randombytes" 2> /dev/null"
             }
         } else {
             server = "/inet/tcp/0/127.0.0.1/400"

--- a/xCAT/postscripts/getcredentials.awk
+++ b/xCAT/postscripts/getcredentials.awk
@@ -1,9 +1,22 @@
 #!/usr/bin/awk -f
 BEGIN {
+        if (!system("test -f /bin/nice")) {
+           nice = "/bin/nice"
+        } else if (!system("test -f /usr/bin/nice")) {
+           nice = "/usr/bin/nice"
+        } else {
+           print "Error: nice utility missing"
+           exit 1
+        }
+        if (!system("test -f openssl")) {
+           print "Error: openssl utility missing"
+           exit 1
+        }
+
         if ((ENVIRON["USEOPENSSLFORXCAT"]) || (ENVIRON["AIX"])) {
-            server = "openssl s_client -quiet -no_ssl3 -connect " ENVIRON["XCATSERVER"] " -rand /bin/nice 2> /dev/null"
+            server = "openssl s_client -quiet -no_ssl3 -connect " ENVIRON["XCATSERVER"] " -rand "nice" 2> /dev/null"
             if (!system("openssl s_client -help 2>&1 | grep -m 1 -q -- -no_ssl2")) {
-                server = "openssl s_client -quiet -no_ssl3 -no_ssl2 -connect " ENVIRON["XCATSERVER"] " -rand /bin/nice 2> /dev/null"
+                server = "openssl s_client -quiet -no_ssl3 -no_ssl2 -connect " ENVIRON["XCATSERVER"] " -rand "nice" 2> /dev/null"
             }
         } else {
             server = "/inet/tcp/0/127.0.0.1/400"

--- a/xCAT/postscripts/getpostscript.awk
+++ b/xCAT/postscripts/getpostscript.awk
@@ -1,12 +1,9 @@
 #!/usr/bin/awk -f
 BEGIN {
-        if (!system("test -f /bin/nice")) {
-           nice = "/bin/nice"
-        } else if (!system("test -f /usr/bin/nice")) {
-           nice = "/usr/bin/nice"
+        if (!system("test -f /usr/bin/nice")) {
+           randombytes = "-rand /usr/bin/nice"
         } else {
-           print "Error: nice utility missing"
-           exit 1
+           randombytes = ""
         }
         if (!system("test -f openssl")) {
            print "Error: openssl utility missing"
@@ -14,9 +11,9 @@ BEGIN {
         }
 
         if (ENVIRON["USEOPENSSLFORXCAT"]) {
-            server = "openssl s_client -no_ssl3 -connect " ENVIRON["XCATSERVER"] " -rand "nice" 2> /dev/null"
+            server = "openssl s_client -no_ssl3 -connect " ENVIRON["XCATSERVER"] " "randombytes" 2> /dev/null"
             if (!system("openssl s_client -help 2>&1 | grep -m 1 -q -- -no_ssl2")) {
-                server = "openssl s_client -no_ssl3 -no_ssl2 -connect " ENVIRON["XCATSERVER"] " -rand "nice" 2> /dev/null"
+                server = "openssl s_client -no_ssl3 -no_ssl2 -connect " ENVIRON["XCATSERVER"] " "randombytes" 2> /dev/null"
             }
         } else {
             server = "/inet/tcp/0/127.0.0.1/400"

--- a/xCAT/postscripts/getpostscript.awk
+++ b/xCAT/postscripts/getpostscript.awk
@@ -1,9 +1,22 @@
 #!/usr/bin/awk -f
 BEGIN {
+        if (!system("test -f /bin/nice")) {
+           nice = "/bin/nice"
+        } else if (!system("test -f /usr/bin/nice")) {
+           nice = "/usr/bin/nice"
+        } else {
+           print "Error: nice utility missing"
+           exit 1
+        }
+        if (!system("test -f openssl")) {
+           print "Error: openssl utility missing"
+           exit 1
+        }
+
         if (ENVIRON["USEOPENSSLFORXCAT"]) {
-            server = "openssl s_client -no_ssl3 -connect " ENVIRON["XCATSERVER"] " -rand /bin/nice 2> /dev/null"
+            server = "openssl s_client -no_ssl3 -connect " ENVIRON["XCATSERVER"] " -rand "nice" 2> /dev/null"
             if (!system("openssl s_client -help 2>&1 | grep -m 1 -q -- -no_ssl2")) {
-                server = "openssl s_client -no_ssl3 -no_ssl2 -connect " ENVIRON["XCATSERVER"] " -rand /bin/nice 2> /dev/null"
+                server = "openssl s_client -no_ssl3 -no_ssl2 -connect " ENVIRON["XCATSERVER"] " -rand "nice" 2> /dev/null"
             }
         } else {
             server = "/inet/tcp/0/127.0.0.1/400"

--- a/xCAT/postscripts/startsyncfiles.awk
+++ b/xCAT/postscripts/startsyncfiles.awk
@@ -1,9 +1,22 @@
 #!/usr/bin/awk -f
 BEGIN {
+  if (!system("test -f /bin/nice")) {
+       nice = "/bin/nice"
+  } else if (!system("test -f /usr/bin/nice")) {
+       nice = "/usr/bin/nice"
+  } else {
+       print "Error: nice utility missing"
+       exit 1
+  }
+  if (!system("test -f openssl")) {
+       print "Error: openssl utility missing"
+       exit 1
+  }
+
   if (ENVIRON["USEOPENSSLFORXCAT"]) {
-      server = "openssl s_client -no_ssl3 -connect " ENVIRON["XCATSERVER"] " -rand /bin/nice 2> /dev/null"
+      server = "openssl s_client -no_ssl3 -connect " ENVIRON["XCATSERVER"] " -rand "nice" 2> /dev/null"
       if (!system("openssl s_client -help 2>&1 | grep -m 1 -q -- -no_ssl2")) {
-          server = "openssl s_client -no_ssl3 -no_ssl2 -connect " ENVIRON["XCATSERVER"] " -rand /bin/nice 2> /dev/null"
+          server = "openssl s_client -no_ssl3 -no_ssl2 -connect " ENVIRON["XCATSERVER"] " -rand "nice 2> /dev/null"
       }
   } else {
       server = "/inet/tcp/0/127.0.0.1/400"

--- a/xCAT/postscripts/startsyncfiles.awk
+++ b/xCAT/postscripts/startsyncfiles.awk
@@ -1,12 +1,9 @@
 #!/usr/bin/awk -f
 BEGIN {
-  if (!system("test -f /bin/nice")) {
-       nice = "/bin/nice"
-  } else if (!system("test -f /usr/bin/nice")) {
-       nice = "/usr/bin/nice"
+  if (!system("test -f /usr/bin/nice")) {
+       randombytes = "-rand /usr/bin/nice"
   } else {
-       print "Error: nice utility missing"
-       exit 1
+       randombytes = ""
   }
   if (!system("test -f openssl")) {
        print "Error: openssl utility missing"
@@ -14,9 +11,9 @@ BEGIN {
   }
 
   if (ENVIRON["USEOPENSSLFORXCAT"]) {
-      server = "openssl s_client -no_ssl3 -connect " ENVIRON["XCATSERVER"] " -rand "nice" 2> /dev/null"
+      server = "openssl s_client -no_ssl3 -connect " ENVIRON["XCATSERVER"] " "randombytes" 2> /dev/null"
       if (!system("openssl s_client -help 2>&1 | grep -m 1 -q -- -no_ssl2")) {
-          server = "openssl s_client -no_ssl3 -no_ssl2 -connect " ENVIRON["XCATSERVER"] " -rand "nice 2> /dev/null"
+          server = "openssl s_client -no_ssl3 -no_ssl2 -connect " ENVIRON["XCATSERVER"] " "randombytes" 2> /dev/null"
       }
   } else {
       server = "/inet/tcp/0/127.0.0.1/400"


### PR DESCRIPTION
for issue #6850  and #6837

During the installing process,  the compute node will send `getpostscript` request to server and ask for mypostscript.  The openssl command failed due to incorrect path for `nice` command.
```
# openssl s_client -no_ssl3 -connect c910f04x35v05:3001 -rand /bin/nice
Can't load /bin/nice into RNG
140404628300224:error:2406F079:random number generator:RAND_load_file:Cannot open file:../crypto/rand/randfile.c:88:Filename=/bin/nice

```
because that,  `mypostscript` didn't  set up correctly and no exported env variable is  added to the file which cause `MASTER` is not available and no postscript is running.