### PR TITLE
Add cpio command as required for xCAT-client packages

### DIFF
--- a/xCAT-client/xCAT-client.spec
+++ b/xCAT-client/xCAT-client.spec
@@ -25,6 +25,7 @@ BuildArch: noarch
 %endif
 
 Requires: perl-xCAT = 4:%{version}-%{release}
+Requires: cpio
 
 # fping or nmap is needed by pping (in case xCAT-client is installed by itself on a remote client)
 %ifos linux


### PR DESCRIPTION
For issue #6844 

`copycds` is installed by xCAT-client package.  Add `cpio` command as required in the `xCAT-client.spec`, so `cpio` can be installed if it is not available.