### PR TITLE
Improve xcattest reporting of invalid OS, ARCH and HCP

### DIFF
--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -962,6 +962,10 @@ sub load_case {
     my $fd          = undef;
 
     my %invalidcases;
+    
+    # invalidoptions saves invalid OS, or ARCH, or HCP
+    my %invalidoptions;
+
     my %case_name_index_map_bak;
     foreach my $file (@files) {
         if (!open($fd, "<$file")) {
@@ -1036,7 +1040,7 @@ sub load_case {
                     my @newvalidoslist = ();
                     foreach my $validos (@validoslist) {
                         if ($validos =~ /linux/i) {
-                            push(@newvalidoslist, ("rhel", "sles", "ubuntu"));
+                            push(@newvalidoslist, ("rhels", "sles", "ubuntu"));
                         } else {
                             push(@newvalidoslist, $validos);
                         }
@@ -1062,6 +1066,7 @@ sub load_case {
                             delete $$case_name_index_map_ref{ $case_ref->[$i]->{name} };
                             if (!grep (/$case_ref->[$i]->{name}/, @{ $invalidcases{"noruncases"} })) {
                                 push @{ $invalidcases{"noruncases"} }, $case_ref->[$i]->{name};
+                                push @{ $invalidoptions{"invalid-os"} }, "$case_ref->[$i]->{os}";
                             }
                         }
                     }
@@ -1121,6 +1126,7 @@ sub load_case {
                             delete $$case_name_index_map_ref{ $case_ref->[$i]->{name} };
                             if (!grep (/$case_ref->[$i]->{name}/, @{ $invalidcases{"noruncases"} })) {
                                 push @{ $invalidcases{"noruncases"} }, $case_ref->[$i]->{name};
+                                push @{ $invalidoptions{"invalid-arch"} }, "$case_ref->[$i]->{arch}";
                             }
                         }
                     }
@@ -1152,6 +1158,7 @@ sub load_case {
                             delete $$case_name_index_map_ref{ $case_ref->[$i]->{name} };
                             if (!grep (/$case_ref->[$i]->{name}/, @{ $invalidcases{"noruncases"} })) {
                                 push @{ $invalidcases{"noruncases"} }, $case_ref->[$i]->{name};
+                                push @{ $invalidoptions{"invalid-hcp"} }, "$case_ref->[$i]->{hcp}";
                             }
                         }
                     }
@@ -1249,7 +1256,18 @@ sub load_case {
         }
 
         if ($invalidcases{"noruncases"} && @{ $invalidcases{"noruncases"} }) {
-            log_this($running_log_fd, "Unsuitable current environment:", @{ $invalidcases{"noruncases"} });
+            my $temp_invalid_op;
+            my $test_case = $invalidcases{"noruncases"}[0];
+            if (exists $invalidoptions{"invalid-os"}) {
+               $temp_invalid_op = $invalidoptions{"invalid-os"}[0];
+               print "Test case $test_case has an invalid OS option - $temp_invalid_op\n";
+            } elsif (exists $invalidoptions{"invalid-arch"}) {
+               $temp_invalid_op = $invalidoptions{"invalid-arch"}[0];
+               print "Test case $test_case has an invalid ARCH option - $temp_invalid_op\n";
+            } elsif (exists $invalidoptions{"invalid-hcp"}) {
+               $temp_invalid_op = $invalidoptions{"invalid-hcp"}[0];
+               print "Test case $test_case has an invalid HCP option - $temp_invalid_op\n";
+            }
             push @wrong_cases, @{ $invalidcases{"noruncases"} };
             $caseerror = 2;
         }


### PR DESCRIPTION
This PR improves upon #6700 

Given an invalid OS in a test case, say restapi_list_nodes, the existing xcattest reports the following:

******************************
loading test cases
******************************
Unsuitable current environment:
restapi_list_nodes
To run:
There is no valid case to run

It prints out "Unsuitable current environment: and the test case name" on two separate line. "sub log_this" does the printing on two lines.

chenhanxiao made an improvement in xcattest:

******************************
loading test cases
******************************
Unsuitable current environment(OS/ARCH/HCP):
restapi_list_nodes
To run:
There is no valid case to run

The added **(OS/ARCH/HCP)** indicates an error on OS or ARCH or HCP.

The following improvement reports invalid options.

Given the following invalid options for restapi_list_nodes:
os:linu
arch:ppc
hcp:open

My code will report:

******************************
loading test cases
******************************
Test case restapi_list_nodes has an invalid OS option - linx
To run:
There is no valid case to run

It reports the problem in one line.

By correcting os:linu to os:linux, it reports:

******************************
loading test cases
******************************
Test case restapi_list_nodes has an invalid ARCH option - ppc
To run:
There is no valid case to run

By correcting arch:ppc to arch:ppc64le, it reports:

******************************
loading test cases
******************************
Test case restapi_list_nodes has an invalid HCP option - open
To run:
There is no valid case to run

Currently, my code reports the first invalid option. A bit more work is needed to report all invalid options at once.

In addition, chenhaoxiao changes

                            push(@newvalidoslist, ("rhel", "sles", "ubuntu"));
to
                            push(@newvalidoslist, ("rhels", "sles", "ubuntu"));

for consistency purposes since "rhels" is supposed to represent RHEL distros.

In fact, rhel and rhels work fine for the following conditional statement:

                       if ($currentos =~ /$os/i) {

$currentos is rhels on a RHEL system. As long as $os is a **SUBSTRING** of $currentos, the conditional statement is true. $os=rhel or $os=rhels works.

At any rate, rhel is changed to rhels for consistency purposes.