### PR TITLE
Update required goconserver version for xCAT 2.16.1

### DIFF
--- a/xCAT/debian/control
+++ b/xCAT/debian/control
@@ -9,7 +9,7 @@ Homepage: https://xcat.org/
 
 Package: xcat
 Architecture: amd64 ppc64el
-Depends: ${perl:Depends}, goconserver, xcat-server (>= 2.13-snap000000000000), xcat-client (>= 2.13-snap000000000000), libdbd-sqlite3-perl, isc-dhcp-server, apache2, nfs-kernel-server, libxml-parser-perl, rsync, tftpd-hpa, libnet-telnet-perl, xcat-genesis-scripts-ppc64 (>= 2.13-snap000000000000), xcat-genesis-scripts-amd64 (>= 2.13-snap000000000000)
+Depends: ${perl:Depends}, goconserver(>= 0.3.3-snap000000000000), xcat-server (>= 2.13-snap000000000000), xcat-client (>= 2.13-snap000000000000), libdbd-sqlite3-perl, isc-dhcp-server, apache2, nfs-kernel-server, libxml-parser-perl, rsync, tftpd-hpa, libnet-telnet-perl, xcat-genesis-scripts-ppc64 (>= 2.13-snap000000000000), xcat-genesis-scripts-amd64 (>= 2.13-snap000000000000)
 Recommends: bind9, nmap, tftp-hpa, ipmitool-xcat (>= 1.8.17-1), syslinux[any-amd64], libsys-virt-perl, syslinux-xcat, xnba-undi, elilo-xcat, xcat-buildkit (>= 2.13-snap000000000000), xcat-probe (>= 2.13-snap000000000000)
 Suggests: yaboot-xcat
 Description: Metapackage for a common, default xCAT setup

--- a/xCAT/xCAT.spec
+++ b/xCAT/xCAT.spec
@@ -64,7 +64,7 @@ Requires: perl-IO-Stty
 %endif
 
 %ifos linux
-Requires: goconserver
+Requires: goconserver >= 0.3.3
 %endif
 
 #support mixed cluster

--- a/xCATsn/debian/control
+++ b/xCATsn/debian/control
@@ -8,7 +8,7 @@ Homepage: https://xcat.org/
 
 Package: xcatsn
 Architecture: amd64 ppc64el
-Depends: ${perl:Depends}, goconserver, xcat-server (>= 2.13-snap000000000000), xcat-client (>= 2.13-snap000000000000), libdbd-sqlite3-perl, libxml-parser-perl, tftpd-hpa, libnet-telnet-perl, isc-dhcp-server, apache2, nfs-kernel-server, xcat-genesis-scripts-ppc64 (>= 2.13-snap000000000000), xcat-genesis-scripts-amd64 (>= 2.13-snap000000000000)
+Depends: ${perl:Depends}, goconserver (>=0.3.3-snap000000000000), xcat-server (>= 2.13-snap000000000000), xcat-client (>= 2.13-snap000000000000), libdbd-sqlite3-perl, libxml-parser-perl, tftpd-hpa, libnet-telnet-perl, isc-dhcp-server, apache2, nfs-kernel-server, xcat-genesis-scripts-ppc64 (>= 2.13-snap000000000000), xcat-genesis-scripts-amd64 (>= 2.13-snap000000000000)
 Recommends: bind9, nmap, tftp-hpa, ipmitool-xcat (>= 1.8.17-1), syslinux[any-amd64], libsys-virt-perl, syslinux-xcat, xnba-undi, elilo-xcat, xcat-buildkit (>= 2.13-snap000000000000), xcat-probe (>= 2.13-snap000000000000)
 Suggests: yaboot-xcat
 Description: Metapackage for a common, default xCAT service node setup

--- a/xCATsn/xCATsn.spec
+++ b/xCATsn/xCATsn.spec
@@ -47,7 +47,7 @@ Requires: perl-IO-Stty
 %endif
 
 %ifos linux
-Requires: goconserver
+Requires: goconserver >= 0.3.3
 %endif
 
 #support mixed cluster


### PR DESCRIPTION
Force xCAT 2.16.1 to require `goconserver` version 0.3.3 or later.

When upgrading from xCAT 2.16 to 2.16.1:

```
=================================================================================================================================
 Package                           Arch          Version                           Repository                                   S
=================================================================================================================================
Updating:
 xCAT                              ppc64le       2.16.1-snap202011031521           /xCAT-2.16.1-snap202011031521.ppc64le       92
Updating for dependencies:
 goconserver                       ppc64le       0.3.3-snap202011021041            xcat-dep                                    6.
 perl-xCAT                         noarch        4:2.16.1-snap202011031521         xcat-core                                   60
 xCAT-client                       noarch        4:2.16.1-snap202011031521         xcat-core                                   44
 xCAT-genesis-scripts-ppc64        noarch        1:2.16.1-snap202011031521         xcat-core                                    5
 xCAT-genesis-scripts-x86_64       noarch        1:2.16.1-snap202011031521         xcat-core                                    5
 xCAT-probe                        noarch        4:2.16.1-snap202011031521         xcat-core                                    9
 xCAT-server                       noarch        4:2.16.1-snap202011031521         xcat-core                                   1.

Transaction Summary
=================================================================================================================================
Upgrade  1 Package (+7 Dependent packages)
```