### PR TITLE
[doc only] Add vlan to networks documentation

### DIFF
--- a/docs/source/advanced/networks/index.rst
+++ b/docs/source/advanced/networks/index.rst
@@ -7,5 +7,6 @@ Networking
    ethernet_switches/index.rst
    onie_switches/index.rst
    switchdiscover/index.rst
+   vlan/index.rst
    infiniband/index.rst
    getadapter.rst


### PR DESCRIPTION
Apparently the doc was contributed some time ago and is live (https://xcat-docs.readthedocs.io/en/stable/advanced/networks/vlan/index.html) but not referenced in the toc for networking (https://xcat-docs.readthedocs.io/en/stable/advanced/networks/index.html)
