### PR TITLE
Explicitly calling python3 instead of python on shebangs

### DIFF
--- a/xCAT-SoftLayer/bin/getslnodes.py
+++ b/xCAT-SoftLayer/bin/getslnodes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Usage: getslnodes.py [-h] [-v] [<hostname-match>]

--- a/xCAT-SoftLayer/bin/softlayer_storage.py
+++ b/xCAT-SoftLayer/bin/softlayer_storage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 """
 Usage:
     softlayer_storage.py --type=<type> [--hostname=<hostname> --username=<username> --password=<password> --mountpoint=<mountpoint> ] (mount | unmount)

--- a/xCAT-openbmc-py/lib/python/agent/agent.py
+++ b/xCAT-openbmc-py/lib/python/agent/agent.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- encoding: utf-8 -*-
 from __future__ import print_function
 import argparse

--- a/xCAT-openbmc-py/lib/python/agent/client.py
+++ b/xCAT-openbmc-py/lib/python/agent/client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- encoding: utf-8 -*-
 # just for test
 from __future__ import print_function

--- a/xCAT-probe/scripts/dbstats.py
+++ b/xCAT-probe/scripts/dbstats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- encoding: utf-8 -*-
 from __future__ import print_function
 import argparse

--- a/xCAT-server/xCAT-wsapi/xcatws-test.py
+++ b/xCAT-server/xCAT-wsapi/xcatws-test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Usage:
   xcatws_test.py [--xcatmn=<xcatmn>] [--user=<user>] [--password=<password>]
 """

--- a/xCAT-test/autotest/testcase/xcat_inventory/validatehelper
+++ b/xCAT-test/autotest/testcase/xcat_inventory/validatehelper
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 
 import yaml


### PR DESCRIPTION
### The PR is to fix issue #6908

### The modification include

	modified:   xCAT-openbmc-py/lib/python/agent/agent.py
	modified:   xCAT-openbmc-py/lib/python/agent/client.py
	modified:   xCAT-probe/scripts/dbstats.py
	modified:   xCAT-server/xCAT-wsapi/xcatws-test.py
