### PR TITLE
Extend XML Simple to pass parser options

### DIFF
--- a/xCAT-server/lib/perl/xCAT/Goconserver.pm
+++ b/xCAT-server/lib/perl/xCAT/Goconserver.pm
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-## IBM(c) 2107 EPL license http://www.eclipse.org/legal/epl-v10.html
+## IBM(c) 2017 EPL license http://www.eclipse.org/legal/epl-v10.html
 
 package xCAT::Goconserver;
 

--- a/xCAT-server/lib/perl/xCAT/IPMI.pm
+++ b/xCAT-server/lib/perl/xCAT/IPMI.pm
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-# IBM(c) 2107 EPL license http://www.eclipse.org/legal/epl-v10.html
+# IBM(c) 2017 EPL license http://www.eclipse.org/legal/epl-v10.html
 #(C)IBM Corp
 #modified by jbjohnso@us.ibm.com
 #This module abstracts the session management aspects of IPMI

--- a/xCAT-server/lib/perl/xCAT/OPENBMC.pm
+++ b/xCAT-server/lib/perl/xCAT/OPENBMC.pm
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-## IBM(c) 2107 EPL license http://www.eclipse.org/legal/epl-v10.html
+## IBM(c) 2017 EPL license http://www.eclipse.org/legal/epl-v10.html
 
 package xCAT::OPENBMC;
 

--- a/xCAT-server/lib/perl/xCAT/XML.pm
+++ b/xCAT-server/lib/perl/xCAT/XML.pm
@@ -1,0 +1,83 @@
+#!/usr/bin/perl
+# IBM(c) 2021 EPL license http://www.eclipse.org/legal/epl-v10.html
+# 
+# This module extends XML::Simple class.
+#
+# For versions of XML::Simple class which implement new_xml_parser():
+# Overwrite XML::Simple::new_xml_parser() to pass parser options
+# directly to the XML::Parser. The passing of parser options with
+# XML::Simple::XMLin() has been depricated.
+# 
+#
+# For older versions of XML::Simple class which do not implement new_xml_parser():
+# Overwrite XML::Simple::build_tree_xml_parser() to pass parser options
+# directly to the XML::Parser. The passing of parser options with
+# XML::Simple::XMLin() has been depricated.
+#
+package xCAT::XML;
+use XML::Simple;
+use xCAT::MsgUtils;
+use Carp;
+$XML::Simple::PREFERRED_PARSER = 'XML::Parser';
+use parent 'XML::Simple';
+
+sub build_tree_xml_parser {
+  my $self     = shift;
+  my $filename = shift;
+  my $string   = shift;
+
+  # Check if parent class XML::Simple has implemented new_xml_parser(), 
+  # if it has, just call XML::Simple::build_tree_xml_parser() from parent
+  # and it in turn will call new_xml_parser() overwritten by this module.
+  #
+  # If parent class XML::Simple does not have new_xml_parser() implemented, 
+  # fall through and execute the build_tree_xml_parser() overwritten
+  # by this module.
+  #
+  if (exists &{XML::Simple::new_xml_parser}) {
+      return $self->SUPER::build_tree_xml_parser($filename, $string);
+  }
+
+  eval {
+    local($^W) = 0;      # Suppress warning from Expat.pm re File::Spec::load()
+    require XML::Parser; # We didn't need it until now
+  };
+  if($@) {
+    croak "XMLin() requires either XML::SAX or XML::Parser";
+  }
+
+  if($self->{opt}->{nsexpand}) {
+    carp "'nsexpand' option requires XML::SAX";
+  }
+ 
+  my $xp = XML::Parser->new(Style => 'Tree',
+                             [ load_ext_dtd => 0,
+                               ext_ent_handler => undef,
+                               no_network => 1,
+                               expand_entities => 0,
+                             ]);
+  my($tree);
+  if($filename) {
+      # $tree = $xp->parsefile($filename);  # Changed due to prob w/mod_perl
+      open(my $xfh, '<', $filename) || croak qq($filename - $!);
+    $tree = $xp->parse($xfh);
+  }
+  else {
+    $tree = $xp->parse($$string);
+  }
+ 
+  return($tree);
+}
+
+sub new_xml_parser {
+  my($self) = @_;
+  my $xp = XML::Parser->new(Style => 'Tree', 
+                             [ load_ext_dtd => 0,
+                               ext_ent_handler => undef,
+                               no_network => 1,
+                               expand_entities => 0,
+                             ]);
+  $xp->setHandlers(ExternEnt => sub {return $_[2]});
+  return $xp;
+}
+1;

--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -117,9 +117,7 @@ my $dispatch_requests = 1;    # govern whether commands are dispatchable
 use IO::Socket;
 use IO::Handle;
 use IO::Select;
-use XML::Simple;
-$XML::Simple::PREFERRED_PARSER = 'XML::Parser';
-use XML::LibXML;
+use xCAT::XML;
 use xCAT::Table;
 my $dbmaster;
 use xCAT::ExtTab;
@@ -692,12 +690,9 @@ sub do_discovery_process {
             IO::Uncompress::Gunzip::gunzip(\$data, \$bigdata);
             $data = $bigdata;
         }
-        my $req = eval { XMLin($data, SuppressEmpty => undef, ForceArray => qr/.*/, ParserOpts => [
-            load_ext_dtd => 0,
-            ext_ent_handler => undef,
-            no_network => 1,
-            expand_entities => 0,
-        ]) };
+        my $xs = xCAT::XML->new();
+        my $req = eval { $xs->XMLin($data, SuppressEmpty => undef, ForceArray => qr/.*/) };
+        xCAT::MsgUtils->message("S", "xcatd: Error parsing XML data - $@") if $@;
         if ($req and $req->{command} and ($req->{command}->[0] eq "findme" and $sport < 1000)) { # only consider priveleged port requests to start with
             $req->{'_xcat_clientip'}   = $clientip;
             $req->{'_xcat_clientport'} = $sport;
@@ -2688,14 +2683,14 @@ sub send_response {
                     }
                 }
             }
-            $xml = XMLout($response, KeyAttr => [], NoAttr => 1, KeepRoot => 1);
+            $xml = xCAT::XML::XMLout($response, KeyAttr => [], NoAttr => 1, KeepRoot => 1);
         } else {
             if ($MYXCATSERVER) {
                 unless (exists($response->{serverdone})) {
                     $response->{xcatdsource}->[0] = $MYXCATSERVER;
                 }
             }
-            $xml = XMLout($response, RootName => 'xcatresponse', NoAttr => 1);
+            $xml = xCAT::XML::XMLout($response, RootName => 'xcatresponse', NoAttr => 1);
         }
         $xml =~ tr/\011-\177/?/c;
 
@@ -2720,12 +2715,8 @@ sub send_response {
         my $cmdlog_xml = "<massresponse>";
         $tmp_xml =~ s/\e/xxxxESCxxxx/g;
         $cmdlog_xml .= $tmp_xml . "</massresponse>";
-        my $cmdlog_rsp = XMLin($cmdlog_xml, SuppressEmpty => undef, ForceArray => qr/.*/, ParserOpts => [
-            load_ext_dtd => 0,
-            ext_ent_handler => undef,
-            no_network => 1,
-            expand_entities => 0,
-        ]);
+        my $xs = xCAT::XML->new();
+        my $cmdlog_rsp = $xs->XMLin($cmdlog_xml, SuppressEmpty => undef, ForceArray => qr/.*/ );
         cmdlog_collectlog($cmdlog_rsp);
 
         # ----used for command log end --------
@@ -2782,12 +2773,10 @@ sub get_request {
                 return undef;
             }
         }
-        return eval { XMLin($request, SuppressEmpty => undef, ForceArray => qr/.*/, ParserOpts => [
-            load_ext_dtd => 0,
-            ext_ent_handler => undef,
-            no_network => 1,
-            expand_entities => 0,
-        ]) };
+        my $xs = xCAT::XML->new();
+        my $request_hash = eval { $xs->XMLin($request, SuppressEmpty => undef, ForceArray => qr/.*/) };
+        xCAT::MsgUtils->message("S", "xcatd: Error parsing XML request - $@") if $@;
+        return $request_hash;
     } elsif ($encode eq "storable") {
         my $return = eval { fd_retrieve($sock); };   # suppres end of stream err
         return $return;


### PR DESCRIPTION
Recent Ubuntu 18 regression test failures are due to deprecation of passing parser options into `XML::Simple::XMLin()`

This PR changes some of the work done by #6688 and #6703.

This PR overwrites two methods from `XML::Simple` -  `build_tree_xml_parser()` and `new_xml_parser()`.
If running with newer version of `XML::Simple`, overwritten `new_xml_parser()` will be called, if running with older versions, overwritten `build_tree_xml_parser()` will be called.
