### PR TITLE
Copycds for sles15.2

### DIFF
--- a/xCAT-server/lib/xcat/plugins/sles.pm
+++ b/xCAT-server/lib/xcat/plugins/sles.pm
@@ -1769,6 +1769,15 @@ sub copycd
                     $distname = "sle15";
                 }
             };
+        } elsif ($dsc =~ /SLE-15/ and $dsc =~ /Full/) {
+            $discnumber = 1;
+            unless ($distname) {
+                if ($dsc =~ /SLE-15-SP(\d)/) {
+                    $distname = "sle15.$1";
+                } else {
+                    $distname = "sle15";
+                }
+            };
         }
     }
 

--- a/xCAT-server/lib/xcat/plugins/sles.pm
+++ b/xCAT-server/lib/xcat/plugins/sles.pm
@@ -1631,6 +1631,7 @@ sub copycd
     #parse the disc info of the os media to get the distribution, arch of the os
     my $discnumber;
     my $darch;
+    my $linktwo = 0;
     if (-r $mntpath . "/content")
     {
         my $dinfo;
@@ -1771,6 +1772,7 @@ sub copycd
             };
         } elsif ($dsc =~ /SLE-15/ and $dsc =~ /Full/) {
             $discnumber = 1;
+	    $linktwo = 1;
             unless ($distname) {
                 if ($dsc =~ /SLE-15-SP(\d)/) {
                     $distname = "sle15.$1";
@@ -1903,6 +1905,7 @@ sub copycd
         rmtree($ospkgpath);
     }
     mkpath("$ospkgpath");
+    if ($linktwo) { symlink("$path/$discnumber", "$path/2"); }
 
     my $omask = umask 0022;
     umask $omask;


### PR DESCRIPTION
`copycds` does not work for SLES15SP2 iso.

Cherry pick 2 PRs:

https://github.com/jjohnson42/xcat-core/commit/868b639dd846ce3c361ddc351245df92eaace5ec#diff-38c18dc1ab1738edf0e5b7dec5dcc8fa563b1d04328c4f853c59d56aef65aa11

https://github.com/jjohnson42/xcat-core/commit/3bb7a1e3c8921ba69fcde41ff7a76255439f1016#diff-38c18dc1ab1738edf0e5b7dec5dcc8fa563b1d04328c4f853c59d56aef65aa11

After this PR:
```
c910f04x35v02:/opt/xcat # copycds /tmp/automation_mountpoint/iso/SLE-15-SP2-Full-ppc64le-GM-Media1.iso
Copying media to /install/sle15.2/ppc64le/1
Media copy operation successful
c910f04x35v02:/opt/xcat #

c910f04x35v02:/opt/xcat # lsdef -t osimage sle15.2-ppc64le-install-compute
Object name: sle15.2-ppc64le-install-compute
    imagetype=linux
    osarch=ppc64le
    osdistroname=sle15.2-ppc64le
    osname=Linux
    osvers=sle15.2
    otherpkgdir=/install/post/otherpkgs/sle15.2/ppc64le
    pkgdir=/install/sle15.2/ppc64le
    pkglist=/opt/xcat/share/xcat/install/sle/compute.sle15.pkglist
    profile=compute
    provmethod=install
    template=/opt/xcat/share/xcat/install/sle/compute.sle15.tmpl
c910f04x35v02:/opt/xcat #
```