### PR TITLE
Add support for SLES15 SP2

### DIFF
--- a/xCAT-server/lib/perl/xCAT/Template.pm
+++ b/xCAT-server/lib/perl/xCAT/Template.pm
@@ -342,6 +342,9 @@ sub subvars {
                             $product_dir=$subdir;
                             if($subdir =~ /^Module-/){
                                 $product_name="sle-".lc($subdir);
+                            }elsif($subdir =~ /^Product-SUSE-Manager-Server|^Product-SLES_SAP/){
+                                # Skip product directories that are not "SLES", causes conflict on SLE15.2
+                                next;
                             }elsif($subdir =~ /^Product-/){
                                 $subdir=~s/Product-//;
                                 $product_name=$subdir;

--- a/xCAT-server/lib/perl/xCAT/Template.pm
+++ b/xCAT-server/lib/perl/xCAT/Template.pm
@@ -342,7 +342,7 @@ sub subvars {
                             $product_dir=$subdir;
                             if($subdir =~ /^Module-/){
                                 $product_name="sle-".lc($subdir);
-                            }elsif($subdir =~ /^Product-SUSE-Manager-Server|^Product-SLES_SAP/){
+                            }elsif($subdir =~ /^Product-SUSE-Manager-Server|^Product-SLES_SAP|^Product-SLED/){
                                 # Skip product directories that are not "SLES", causes conflict on SLE15.2
                                 next;
                             }elsif($subdir =~ /^Product-/){

--- a/xCAT-server/share/xcat/install/sles/compute.sle15.pkglist
+++ b/xCAT-server/share/xcat/install/sles/compute.sle15.pkglist
@@ -6,3 +6,4 @@ insserv-compat
 net-tools-deprecated
 rsyslog
 nfs-client
+wget

--- a/xCAT-server/share/xcat/netboot/sles/genimage
+++ b/xCAT-server/share/xcat/netboot/sles/genimage
@@ -2006,7 +2006,13 @@ sub generic_post { # This function is meant to leave the image in a state approx
     print $cfgfile "NETWORKING=yes\n";
     close($cfgfile);
 
-    # SLE15 has a symlink to /run/netconfig/resolv.conf and does not need a dummy file
+    # SLE15.2 has a symlink to /run/netconfig/resolv.conf but still need a dummy file
+    if (-l "$rootimg_dir/etc/resolv.conf" && $osver =~ "15.2") {
+        # Remove resolv.conf, so that link is gone and code below will
+        # create a dummy file
+        unlink("$rootimg_dir/etc/resolv.conf");
+    }
+    # SLE15.0 has a symlink to /run/netconfig/resolv.conf and does not need a dummy file
     if (! -l "$rootimg_dir/etc/resolv.conf") {
         open($cfgfile, ">", "$rootimg_dir/etc/resolv.conf");
         print $cfgfile "#Dummy resolv.conf to make boot cleaner";

--- a/xCAT-server/share/xcat/netboot/sles/genimage
+++ b/xCAT-server/share/xcat/netboot/sles/genimage
@@ -299,12 +299,20 @@ unless ($onlyinitrd) {
             if (-d "$dir/1") {
                 $ddir .= "/1";
             }
-            system("zypper -R $rootimg_dir $non_interactive ar file:$ddir $osver-$i");
-            $i++;
-            if (-d "$dir/2") {
-                $ddir = $dir . "/2";
+            if ($osver =~ "^sle15.2") {
+                # For SLE15 SP2 need 'baseurl' to point to a 3 module subdirs 
+                system("zypper -R $rootimg_dir $non_interactive ar file:$ddir/Product-SLES $osver-$i-Product-SLES");
+                system("zypper -R $rootimg_dir $non_interactive ar file:$ddir/Module-Basesystem $osver-$i-Module-Basesystem");
+                system("zypper -R $rootimg_dir $non_interactive ar file:$ddir/Module-Legacy $osver-$i-Module-Legacy");
+
+            } else {
                 system("zypper -R $rootimg_dir $non_interactive ar file:$ddir $osver-$i");
                 $i++;
+                if (-d "$dir/2") {
+                    $ddir = $dir . "/2";
+                    system("zypper -R $rootimg_dir $non_interactive ar file:$ddir $osver-$i");
+                    $i++;
+                }
             }
         }
 

--- a/xCAT-server/share/xcat/netboot/sles/genimage
+++ b/xCAT-server/share/xcat/netboot/sles/genimage
@@ -299,8 +299,8 @@ unless ($onlyinitrd) {
             if (-d "$dir/1") {
                 $ddir .= "/1";
             }
-            if ($osver =~ "^sle15.2") {
-                # For SLE15 SP2 need 'baseurl' to point to a 3 module subdirs 
+            if (-d "$ddir/Product-SLES" && -d "$ddir/Module-Basesystem" && -d "$ddir/Module-Legacy") {
+                # If "Modile" and "Product" directories are there, use them for package repositories
                 system("zypper -R $rootimg_dir $non_interactive ar file:$ddir/Product-SLES $osver-$i-Product-SLES");
                 system("zypper -R $rootimg_dir $non_interactive ar file:$ddir/Module-Basesystem $osver-$i-Module-Basesystem");
                 system("zypper -R $rootimg_dir $non_interactive ar file:$ddir/Module-Legacy $osver-$i-Module-Legacy");
@@ -2006,14 +2006,21 @@ sub generic_post { # This function is meant to leave the image in a state approx
     print $cfgfile "NETWORKING=yes\n";
     close($cfgfile);
 
-    # SLE15.2 has a symlink to /run/netconfig/resolv.conf but still need a dummy file
-    if (-l "$rootimg_dir/etc/resolv.conf" && $osver =~ "15.2") {
-        # Remove resolv.conf, so that link is gone and code below will
-        # create a dummy file
-        unlink("$rootimg_dir/etc/resolv.conf");
+    # Check resolv.conf file.
+    # If it is a link and link leads to an empty file, remove that link
+    # If it is a link and link leads to a non emply file, leave it alone
+    # If it is not a link, fill it it with some "dummy" text
+    if (-l "$rootimg_dir/etc/resolv.conf" ) {
+        my $link_file = readlink "$rootimg_dir/etc/resolv.conf";
+        if (-z "$rootimg_dir/$link_file") {
+            # Link leading to an empty file
+            # Remove resolv.conf, so that link is gone and code below will
+            # create a dummy file
+            unlink("$rootimg_dir/etc/resolv.conf");
+        }
     }
-    # SLE15.0 has a symlink to /run/netconfig/resolv.conf and does not need a dummy file
     if (! -l "$rootimg_dir/etc/resolv.conf") {
+        # Not a link, fill in with "dummy" text
         open($cfgfile, ">", "$rootimg_dir/etc/resolv.conf");
         print $cfgfile "#Dummy resolv.conf to make boot cleaner";
         close($cfgfile);


### PR DESCRIPTION
### The PR is to fix issue _#6856_

To support SLES15 SP2, the following changes were needed.

* Skip over directories `/install/sle15.2/ppc64le/1/Product-SLES_SAP` and `/install/sle15.2/ppc64le/1/Product-SUSE-Manager-Server-4.1` when building a list of products to include when generating AutoYaST file.
Since AutoYaST specifies `<product>SLES</product>`, all other "products" included in the `<add_on_products>` section cause conflict when installing SLES15 SP2.
* Add `wget` to the pkglist file. Needed to get postscripts file to the provisioned node.
* Add extra subdirectory repositories so `genimage` can find packages when building diskless image.
* Remove soft link of `resolve.conf` file when building diskless image. The destination of the link is a local file, which does not exist when booting the node and therefore fails when writing contents to it.