### PR TITLE
Use 'find' command to consistently locate vmlinu* file on the disk partition

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/getinstdisk
+++ b/xCAT-server/share/xcat/install/scripts/getinstdisk
@@ -109,7 +109,7 @@ if [ -z "$install_disk" ]; then
             # If there is kernel file, add partition's disk into disk_array
             # It seems the kernel file in ubuntu and sles are named like vmlinux, but in RH it is called vmlinuz
             # To check both vmlinux and vmlinuz, use regular expression "vmlinu*" to match them
-            for i in $ker_dir/vmlinu*; do
+            for i in $(find $ker_dir -maxdepth 1 -name "vmlinu*"); do
                 case $partition in
                     nvme*)
                         # Expected nvme partition format example: nvme0n1p1


### PR DESCRIPTION
### The PR is to fix issue _#6923_

The shell used by the installer seems to behave differently on different OSes when expanding `*` with the `ls` command.
Use `find` instead, which appears to be more consistent.

Tested on RHEL8.3, SLES15.0 and Ubuntu 18.04