### PR TITLE
SLES15.2 service node pkglist needs wget

### DIFF
--- a/xCAT-server/share/xcat/install/sles/service.sle15.pkglist
+++ b/xCAT-server/share/xcat/install/sles/service.sle15.pkglist
@@ -22,4 +22,4 @@ perl-DBD-mysql
 mariadb-client
 #libmysqlclient18
 vim
-
+wget

--- a/xCAT-server/share/xcat/netboot/sles/genimage
+++ b/xCAT-server/share/xcat/netboot/sles/genimage
@@ -300,7 +300,7 @@ unless ($onlyinitrd) {
                 $ddir .= "/1";
             }
             if (-d "$ddir/Product-SLES" && -d "$ddir/Module-Basesystem" && -d "$ddir/Module-Legacy") {
-                # If "Modile" and "Product" directories are there, use them for package repositories
+                # If "Module" and "Product" directories are there, use them for package repositories
                 system("zypper -R $rootimg_dir $non_interactive ar file:$ddir/Product-SLES $osver-$i-Product-SLES");
                 system("zypper -R $rootimg_dir $non_interactive ar file:$ddir/Module-Basesystem $osver-$i-Module-Basesystem");
                 system("zypper -R $rootimg_dir $non_interactive ar file:$ddir/Module-Legacy $osver-$i-Module-Legacy");


### PR DESCRIPTION
Regression test failure of `SN_setup_case` on SLES15.2 x86 was due to unavailability of `wget` to download postscripts during service node provisioning.

```
Thu Apr  1 13:56:30 EDT 2021 [info]: xcat.deployment: Executing post.xcat to prepare for firstbooting ...
Thu Apr  1 13:56:43 EDT 2021 [info]: xcat.deployment: trying to download postscripts from 10.4.35.2...
Thu Apr  1 13:56:43 EDT 2021 [error]: xcat.deployment: /usr/bin/wget does not exist, halt ...
```