### PR TITLE
Use correct zypper flag --auto-agree-with-licenses

### DIFF
--- a/xCAT/postscripts/otherpkgs
+++ b/xCAT/postscripts/otherpkgs
@@ -843,9 +843,9 @@ EOF`
         fi
     elif [ $haszypper -eq 1 ]; then
         if [ $VERBOSE  ]; then
-          echo "$envlist zypper --non-interactive update --auto-agree-with-license"
+          echo "$envlist zypper --non-interactive update --auto-agree-with-licenses"
         fi
-	result=`eval $envlist zypper --non-interactive update --auto-agree-with-license 2>&1`
+	result=`eval $envlist zypper --non-interactive update --auto-agree-with-licenses 2>&1`
 
         R=$?
         if [ $R -ne 0 ]; then


### PR DESCRIPTION
Postscript `otherpkgs` was using incorrect `zypper` flag `--auto-agree-with-license`.
On OSes prior to SLES15.2 this was not reported as a problem and `RC=0` was being returned. 
But on SLES15.2  `The flag --auto-agree-with-license is not known.` error is displayed and `RC=2` is set.

As a result `otherpkgs` postscript also exits with `RC=2`, and service node provisioning is set to `failed`
```
xcat.updatenode.postscript INFO postscript end...:otherpkgs return with 2
```