### PR TITLE
Remove sp1flag from mysqlsetup

### DIFF
--- a/xCAT-client/bin/mysqlsetup
+++ b/xCAT-client/bin/mysqlsetup
@@ -148,30 +148,6 @@ if (-e "/etc/debian_version") {
 # determine whether redhat or sles
 $::linuxos = xCAT::Utils->osver();
 
-# SLES SP 1
-my $sp1flag;
-
-# if linuxos==sles12
-if ($::linuxos eq "sles12") {
-
-    # open /etc/os-release
-    my @lines;
-    my $relfile;
-    $sp1flag = 0;
-    open($relfile, "<", "/etc/os-release");
-
-    # parse lines
-    @lines = <$relfile>;
-    close($relfile);
-    chomp(@lines);
-
-    # for sles12.x
-    $sp1flag = 1;
-}
-
-# set flag
-# SLES SP 1
-
 # is this MariaDB or MySQL
 $::MariaDB = 0;
 my $cmd;
@@ -226,28 +202,24 @@ if (grep(/$mysqlcheck/, @output))
     $::mysqlrunning = 1;
 }
 
-#for ubuntu 14,  after install mysql/maria server, the mysql will running
-#need to stop mysql in order to setup init xcat mysql
-if ($::debianflag or $sp1flag) {
-    $cmd = "pidof mysqld";
-    xCAT::Utils->runcmd($cmd, -1);
-    if ($::RUNCMD_RC == 0)
+# Stop mysql in order to setup init xcat mysql
+$cmd = "pidof mysqld";
+xCAT::Utils->runcmd($cmd, -1);
+if ($::RUNCMD_RC == 0)
+{
+    if ($::INIT)
     {
-        if ($::INIT)
+        my $ret = xCAT::Utils->stopservice("mysql");
+        if ($ret != 0)
         {
-            my $ret = xCAT::Utils->stopservice("mysql");
-            if ($ret != 0)
-            {
-                xCAT::MsgUtils->message("E", " failed to stop mysql/mariadb.");
-                exit(1);
-            }
+            xCAT::MsgUtils->message("E", " failed to stop mysql/mariadb.");
+            exit(1);
         }
-        else {
-            $::mysqlrunning = 1;
-        }
+    } else {
+        $::mysqlrunning = 1;
     }
-
 }
+
 if (-e ("/etc/xcat/cfgloc"))    # check to see if xcat is using mysql
 {                               # cfgloc exists
     $cmd = "fgrep mysql /etc/xcat/cfgloc";
@@ -1012,10 +984,8 @@ sub mysqlstart
     for ($i = 0 ; $i < 12 ; $i++)
     {
         my @output = xCAT::Utils->runcmd($cmd, 0);
-        my $mysqlcheck = "--datadir";    # see if really running
-        if ($::debianflag or $sp1flag) {
-            $mysqlcheck = "mysqld";
-        }
+        $mysqlcheck = "mysqld";
+
         if (grep(/$mysqlcheck/, @output))
         {
             sleep 10;    # give a few extra seconds to be sure
@@ -1027,7 +997,7 @@ sub mysqlstart
         }
     }
     xCAT::MsgUtils->message("E",
-        " Could not start the mysql daemon, in time allocated ( 2minutes)");
+        " Could not start the mysql daemon, in time allocated (2 minutes)");
     exit(1);
 
 }


### PR DESCRIPTION
Remove `sp1flag` from `mysqlsetup`.
This flags was originally introduced by #377 but never worked correctly since it used `==` for string comparison.
