### PR TITLE
Make xCAT-server require httpd

### DIFF
--- a/xCAT-server/xCAT-server.spec
+++ b/xCAT-server/xCAT-server.spec
@@ -58,7 +58,7 @@ Requires: grub2-xcat >= 2.02-0.76.el7.1.snap201905160255 perl-Net-HTTPS-NB perl-
 %else
 %ifos linux
 # do this for non-fsm linux
-Requires: perl-IO-Tty perl-Crypt-SSLeay make
+Requires: perl-IO-Tty perl-Crypt-SSLeay make httpd
 %endif
 %endif
 


### PR DESCRIPTION
Make `xCAT-server` require `httpd` during installation.

Prior to this change `xCAT` and `xCATsn` were requiring `httpd`, but not `xCAT-server`.
However in `%post` section of `xCAT-server.spec` file a decision is made which `xcat-ws.conf.apacheXX` file to copy into ` /etc/httpd/conf.d/xcat-ws.conf`. If `httpd` is not running at the time of `xCAT-server` installation, the default file `xcat-ws.conf.apache22` will be used.

When `go-xcat` installs xCAT management node, it passes a list of packages to installer utility:
```
GO_XCAT_INSTALL_LIST=(perl-xCAT xCAT-client xCAT xCAT-buildkit
    xCAT-genesis-scripts-ppc64 xCAT-genesis-scripts-x86_64 xCAT-server
    elilo-xcat grub2-xcat ipmitool-xcat syslinux-xcat
    xCAT-genesis-base-ppc64 xCAT-genesis-base-x86_64 xnba-undi yaboot-xcat)
```
Listing `xCAT` (which requires `httpd`) before `xCAT-server`. 

On RHEL8.2 and prior `dnf/yum` would install `xCAT` and `httpd` before `xCAT-server`. But it appears on RHEL8.3 `dnf/yum` installs `xCAT-server` before `xCAT` and `httpd`.

Perhaps a newer version of `dnf/yum` chooses different installation order ?
On Power RHEL8.3
`dnf-4.2.23-4.el8.noarch`
`yum-4.2.23-4.el8.noarch`

On Power RHEL8.2
`dnf-4.2.17-6.el8.noarch`
`yum-4.2.17-6.el8.noarch`
