### PR TITLE
Make xcatprobe xcatmn recognize default SQLite DB

### DIFF
--- a/docs/source/advanced/hierarchy/databases/index.rst
+++ b/docs/source/advanced/hierarchy/databases/index.rst
@@ -1,6 +1,8 @@
 Configure a Database
 ====================
 
+SQLite
+------
 xCAT uses the SQLite database (https://www.sqlite.org/) as the default database and it is initialized during xCAT installation of the Management Node.  If using Service Nodes, SQLite **cannot** be used because Service Nodes require remote access to the xCAT database.  One of the following databases should be used:
 
     * :ref:`mysql_reference_label`

--- a/docs/source/advanced/hierarchy/databases/mysql_install.rst
+++ b/docs/source/advanced/hierarchy/databases/mysql_install.rst
@@ -82,7 +82,7 @@ Debian/Ubuntu
         mysql-server
         mysql-common
         libdbd-mysql-perl
-        libmysqlclient18
+        libmysqlclient*
         mysql-client-5*
         mysql-client-core-5*
         mysql-server-5*

--- a/xCAT-probe/subcmds/xcatmn
+++ b/xCAT-probe/subcmds/xcatmn
@@ -322,7 +322,7 @@ sub check_all_xcat_daemons {
                     $rst_type = "w" if ($child_pid);
                 }
             }
-            push @$error_ref, "More Daemon '$daemon' is running";
+            push @$error_ref, "More than one instance of '$daemon' is running";
             $rst = 1;
         } elsif ($counter == 0) {
             push @$error_ref, "Daemon '$daemon' isn't running";
@@ -1310,8 +1310,13 @@ sub check_db_pkgs {
 
     my $cfgloc_file = "/etc/xcat/cfgloc";
     if (! -e $cfgloc_file) {
-        push @$error_ref, "$cfgloc_file does not exist, check xcat installation.";
-        return 1;
+        # no $cfgloc_file, check if running with default SQLite
+        if (-d "/etc/xcat") {
+            return 0; #Default SQLite
+        } else {
+            push @$error_ref, "Can not find $cfgloc_file or /etc/xcat, check xcat database installation.";
+            return 1;
+        }
     }
     my $db_type = `cat $cfgloc_file | awk -F ':' '{print \$1}'`;
     chomp($db_type);


### PR DESCRIPTION
Currently `xcatprobe xcatmn` flags default SQLite DB as an error if MySQL or Postgres are not installed.