### PR TITLE
Shorten provision wait time

### DIFF
--- a/xCAT-test/autotest/testcase/commoncmd/retry_install.sh
+++ b/xCAT-test/autotest/testcase/commoncmd/retry_install.sh
@@ -7,13 +7,16 @@ node=$1
 osimage=$2
 vmhost=`lsdef $node -i vmhost -c | cut -d '=' -f 2`
 times=3
+wait_for_provision=30 #Min to wait for node to provision
+check_status=10 #Sec to keep checking status
+iterations=$wait_for_provision*60/$check_status #Iterations to check for "booted" status
 
 if [ $# -eq 3 ];
 then
     times=$3
 fi
 
-echo "Try to rinstall for $times  times ......" 
+echo "Try to rinstall for $times times (allowing $wait_for_provision min for each try) ......" 
 
 for (( tryreinstall = 1 ; tryreinstall <= $times ; ++tryreinstall ))
 do
@@ -43,11 +46,11 @@ do
     sleep 360
     while [ ! `lsdef -l $node|grep status|grep booted` ]
     do 
-        sleep 10
+        sleep $check_status
         stat=`lsdef $node -i status -c | cut -d '=' -f 2`
         echo "[$a] The status is not booted... ($stat)" 
         a=++a 
-        if [ $a -gt 400 ];then
+        if [ $a -gt $(($iterations + 0)) ];then
             a=0 
             break
         fi


### PR DESCRIPTION
Currently `retry_install` script attempts 3 times to provision a node. For each attempt it waits 73 min for status to turn to `booted`.
If there are provision problems with a node, `retry_install` script could wait about 3 1/2 hours before continuing. In some cases this causes regression job to exit after exceeding 11 hours of runtime.

This PR reduces each attempt wait to 30 min. Anything longer than that should indicate a problem and make the testcase fail.