### PR TITLE
Remove pidfile /dev/null for chronyd in setupntp on Ubuntu systems

### DIFF
--- a/xCAT/postscripts/setupntp
+++ b/xCAT/postscripts/setupntp
@@ -168,15 +168,13 @@ warn_if_bad "$?" "Failed to configure the system to maintain the RTC in universa
 # Synchronize and set the system clock once
 logger -t $log_label -p local4.info "Syncing the clock ..."
 
-OS_name=`cat /etc/os-release | grep "NAME=\"Ubuntu\""`
-
-if [ -z $OS_name ]
+if [ -f /etc/os-release ] && cat /etc/os-release |grep NAME|grep Ubuntu>/dev/null
 then
-       pidfile_option="pidfile /dev/null"
-else
        # Some versions of chronyd on Ubuntu distros have an issue
        # with the valid option "pidfile /dev/null".
        pidfile_option=""
+else
+       pidfile_option="pidfile /dev/null"
 fi
 
 chronyd -f /dev/null -q "$(

--- a/xCAT/postscripts/setupntp
+++ b/xCAT/postscripts/setupntp
@@ -145,7 +145,7 @@ fi
 unset MASTER
 unset NTPSERVERS
 
-check_exec_or_exit cp cat logger
+check_exec_or_exit cp cat logger grep
 check_exec_or_exit systemctl timedatectl hwclock
 
 systemctl stop ntp.service 2>/dev/null

--- a/xCAT/postscripts/setupntp
+++ b/xCAT/postscripts/setupntp
@@ -167,6 +167,18 @@ warn_if_bad "$?" "Failed to configure the system to maintain the RTC in universa
 
 # Synchronize and set the system clock once
 logger -t $log_label -p local4.info "Syncing the clock ..."
+
+OS_name=`cat /etc/os-release | grep "NAME=\"Ubuntu\""`
+
+if [ -z $OS_name ]
+then
+       pidfile_option="pidfile /dev/null"
+else
+       # Some versions of chronyd on Ubuntu distros have an issue
+       # with the valid option "pidfile /dev/null".
+       pidfile_option=""
+fi
+
 chronyd -f /dev/null -q "$(
 	if [ "${#NTP_SERVERS[@]}" -gt "0" ]
 	then
@@ -174,7 +186,7 @@ chronyd -f /dev/null -q "$(
 	else
 		echo "pool pool.ntp.org iburst"
 	fi
-)" "pidfile /dev/null"
+)" "$pidfile_option"
 
 rm -f /etc/adjtime
 # Set the hardware clock from the system clock


### PR DESCRIPTION
The test case nodeset_cmdline fails on Ubuntu 18.04.2. This test case wants to load the genesis kernel on a compute node.

It turns out that the TFTP server does not run at this point.

Further investigation indicates that "chronyd ... "pidfile /dev/null"" turns the character-oriented device /dev/null into a text file /dev/null. By having that, the TFTP server stops working. Since the genesis kernel cannot be passed to the compute node through the TFTP server, the compute node loads whatever on its own hard drive.

This change removes "pidfile /dev/null" only if the management node runs a Ubuntu distro.