### PR TITLE
Improve xcatprobe check for firewall

### DIFF
--- a/xCAT-probe/lib/perl/probe_utils.pm
+++ b/xCAT-probe/lib/perl/probe_utils.pm
@@ -282,15 +282,11 @@ sub is_firewall_open {
 
     my $output = `iptables -nvL -t filter 2>&1`;
 
-    `echo "$output" |grep "Chain INPUT (policy ACCEPT" > /dev/null  2>&1`;
-    $rst = 1 if ($?);
-
-    `echo "$output" |grep "Chain FORWARD (policy ACCEPT" > /dev/null  2>&1`;
-    $rst = 1 if ($?);
-
-    `echo "$output" |grep "Chain OUTPUT (policy ACCEPT" > /dev/null  2>&1`;
-    $rst = 1 if ($?);
-
+    if ($output =~ /DROP|RETURN/) {
+        # If output contains DROP or RETURN rules, assume firewall
+        # is blocking some traffic
+        $rst=1;
+    }
     return $rst;
 }
 


### PR DESCRIPTION
Improve how `xcatprobe` checks for firewall being enabled.
Currently code in `xCAT-probe/lib/perl/probe_utils.pm` function `is_firewall_open()` 
* greps for 3 strings in the output of `iptables` command: `Chain INPUT (policy ACCEPT`, `Chain FORWARD (policy ACCEPT` and `Chain OUTPUT (policy ACCEPT`. 
If there, it is assumed the firewall is opened. But those strings are present if `iptables` rules are set to block some traffic.
```
[root@c910f04x37v07 ~]# iptables -nvL -t filter
Chain INPUT (policy ACCEPT 1475 packets, 392K bytes)
 pkts bytes target     prot opt in     out     source               destination
    0     0 DROP       tcp  --  *      *       10.10.10.10          0.0.0.0/0            tcp dpt:22
Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination
Chain OUTPUT (policy ACCEPT 878 packets, 242K bytes)
 pkts bytes target     prot opt in     out     source               destination
    0     0 ACCEPT     tcp  --  *      *       0.0.0.0/0            129.42.38.10
    5   300 DROP       tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            tcp dpt:80
    0     0 RETURN     tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            tcp dpt:443
[root@c910f04x37v07 ~]#
```
* Does not check if `iptables` command is present, resulting in grepping empty output for 3 strings above. This causes function to return incorrect indication that firewall is enabled.

This PR makes the function to check only for `DROP` or `RETURN` strings in the output of `iptables`, and if there, return indication that firewall is enabled. Even if `iptables` command is not present (firewall packages are not installed), the output will not contain `DROP` or `RETURN` strings, and return indication that firewall is not enabled.

### UT:

#### No rules set:
```
[root@c910f04x37v07 xcat]# iptables -nvL -t filter
Chain INPUT (policy ACCEPT 40065 packets, 12M bytes)
 pkts bytes target     prot opt in     out     source               destination

Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination

Chain OUTPUT (policy ACCEPT 14628 packets, 3951K bytes)
 pkts bytes target     prot opt in     out     source               destination
[root@c910f04x37v07 xcat]#
```
```
[root@c910f04x37v07 xcat]# xcatprobe xcatmn
[mn]: Checking all xCAT daemons are running...                                    [ OK ]
[mn]: Checking xcatd can receive command request...                               [ OK ]
[mn]: Checking 'site' table is configured...                                      [ OK ]
:
:
:
[mn]: Checking firewall is disabled...                                            [ OK ]
:
:
```
#### Some DROP or RETURN rules are set:
```
Chain INPUT (policy ACCEPT 39000 packets, 11M bytes)
 pkts bytes target     prot opt in     out     source               destination
    0     0 DROP       tcp  --  *      *       10.10.10.10          0.0.0.0/0            tcp dpt:22

Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination

Chain OUTPUT (policy ACCEPT 13875 packets, 3726K bytes)
 pkts bytes target     prot opt in     out     source               destination
[root@c910f04x37v07 xcat]#
```
```
[root@c910f04x37v07 xcat]# xcatprobe xcatmn
[mn]: Checking all xCAT daemons are running...                                                     [ OK ]
[mn]: Checking xcatd can receive command request...                                                [ OK ]
[mn]: Checking 'site' table is configured...                                                       [ OK ]
:
:
:
[mn]: Checking firewall is disabled...                                                             [WARN]
:
:
```

#### iptables command not present:
```
c910f04x35v02:/opt/xcat #  iptables -nvL -t filter
-bash: iptables: command not found
c910f04x35v02:/opt/xcat #
```
```
c910f04x35v02:/opt/xcat # xcatprobe xcatmn
[mn]: Checking all xCAT daemons are running...                                    [ OK ]
[mn]: Checking xcatd can receive command request...                               [ OK ]
:
:
:
[mn]: Checking firewall is disabled...                                            [ OK ]
:
:
```