### PR TITLE
Improve verification of prsync command in testcases

### DIFF
--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_nfs
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_nfs
@@ -72,8 +72,13 @@ cmd:genimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compu
 check:rc==0
 cmd:liteimg __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
 check:rc==0
+#Before doing prsync of /install to the service node, check if there is enough space there
+cmd:du -sh /install
+cmd:xdsh $$SN du -H
 cmd:prsync /install $$SN:/
 check:rc==0
+check:output=~$$SN: done
+check:output!=write failed
 
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
 check:rc==0

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_ramdisk
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_ramdisk
@@ -65,9 +65,13 @@ cmd:genimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compu
 check:rc==0
 cmd:liteimg __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
 check:rc==0
+#Before doing prsync of /install to the service node, check if there is enough space there
+cmd:du -sh /install
+cmd:xdsh $$SN du -H
 cmd:prsync /install $$SN:/
 check:rc==0
-
+check:output=~$$SN: done
+check:output!=write failed
 
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
 check:rc==0


### PR DESCRIPTION
Some testcases executing `prsync` command do not report error even if `prsync` command fails with `No space left on device` message. 
This PR adds:
* Output check verification.
* Additional commands to see how much will be copied and available space on the target node.