### PR TITLE
Fix mistake where someone used ext4

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/pre.rhels8
+++ b/xCAT-server/share/xcat/install/scripts/pre.rhels8
@@ -248,8 +248,8 @@ then
     instdisk="$(cat /tmp/xcat.install_disk)"
 fi
 
-BOOTFSTYPE=ext4
-FSTYPE=ext4
+BOOTFSTYPE=xfs
+FSTYPE=xfs
 EFIFSTYPE=efi
 
 #remove any exiting "xcatvg" VG to avoid fatal error


### PR DESCRIPTION
RHEL uses `xfs` by default, selecting `ext4` is a peculiar thing
to do.

`git cherry-pick f492c10ec38e11fb10212317ac92915654d1982e`