### PR TITLE
Use ip instead of deprecated netstat

### DIFF
--- a/docs/source/guides/admin-guides/references/man8/makenetworks.8.rst
+++ b/docs/source/guides/admin-guides/references/man8/makenetworks.8.rst
@@ -35,9 +35,9 @@ The \ **makenetworks**\  command can be used to gather network information from 
 
 Every network that will be used to install a cluster node must be defined in the xCAT database.
 
-The default behavior is to gather network information from the management node, and any configured xCAT service nodes, and automatically save this information in the xCAT database.
+The default behavior is to gather network information from the management node, and any configured xCAT service nodes, and automatically save that information in the xCAT database.
 
-You can use the "-d" option to display the network information without writing it to the database.
+You can use the \ **-d**\  option to display the network information without writing it to the database.
 
 You can also redirect the output to a file that can be used with the xCAT \ **mkdef**\  command to define the networks.
 
@@ -53,9 +53,9 @@ For example:
 
 This features allows you to verify and modify the network information before writing it to the database.
 
-When the network information is gathered a default value is created for the "netname" attribute.  This is done to make it possible to use the mkdef, chdef, lsdef, and rmdef commands to manage this data.
+When the network information is gathered a default value is created for the "netname" attribute.  This is done to make it possible to use the \ **mkdef**\ , \ **chdef**\ , \ **lsdef**\ , and \ **rmdef**\  commands to manage this data.
 
-The default naming convention is to use a hyphen separated "net" and "mask" value with the "." replace by "_". (ex. "8_124_47_64-255_255_255_0")
+The default naming convention is to use a hyphen separated "net" and "mask" values with the "." replaced by "_". (ex. "8_124_47_64-255_255_255_0")
 
 You can also modify the xCAT "networks" database table directly using the xCAT \ **tabedit**\  command.
 
@@ -121,13 +121,19 @@ EXAMPLES
   	makenetworks -d
  
  
- The output would be one or more stanzas of information similar to the following. The line that ends with a colon is the value of the "netname" attribute and is the name of the network object to use with the lsdef, mkdef, chdef and rmdef commands.
+ The output would be one or more stanzas of information similar to the following. The line that ends with a colon is the value of the "netname" attribute and is the name of the network object to use with the \ **lsdef**\ , \ **mkdef**\ , \ **chdef**\  and \ **rmdef**\  commands.
  
- 9_114_37_0-255_255_255_0:
-     objtype=network
-     gateway=9.114.37.254
-     mask=255.255.255.0
-     net=9.114.37.0
+ 
+ .. code-block:: perl
+ 
+   9_114_37_0-255_255_255_0:
+      objtype=network
+      gateway=9.114.37.254
+      mask=255.255.255.0
+      net=9.114.37.0
+      mgtifname=ens3
+      mtu=1500
+ 
  
 
 

--- a/xCAT-client/pods/man8/makenetworks.8.pod
+++ b/xCAT-client/pods/man8/makenetworks.8.pod
@@ -16,9 +16,9 @@ The B<makenetworks> command can be used to gather network information from an xC
 
 Every network that will be used to install a cluster node must be defined in the xCAT database.
 
-The default behavior is to gather network information from the management node, and any configured xCAT service nodes, and automatically save this information in the xCAT database.
+The default behavior is to gather network information from the management node, and any configured xCAT service nodes, and automatically save that information in the xCAT database.
 
-You can use the "-d" option to display the network information without writing it to the database.
+You can use the B<-d> option to display the network information without writing it to the database.
 
 You can also redirect the output to a file that can be used with the xCAT B<mkdef> command to define the networks.
 
@@ -30,9 +30,9 @@ For example:
 
 This features allows you to verify and modify the network information before writing it to the database.
 
-When the network information is gathered a default value is created for the "netname" attribute.  This is done to make it possible to use the mkdef, chdef, lsdef, and rmdef commands to manage this data.
+When the network information is gathered a default value is created for the "netname" attribute.  This is done to make it possible to use the B<mkdef>, B<chdef>, B<lsdef>, and B<rmdef> commands to manage this data.
 
-The default naming convention is to use a hyphen separated "net" and "mask" value with the "." replace by "_". (ex. "8_124_47_64-255_255_255_0")
+The default naming convention is to use a hyphen separated "net" and "mask" values with the "." replaced by "_". (ex. "8_124_47_64-255_255_255_0")
 
 You can also modify the xCAT "networks" database table directly using the xCAT B<tabedit> command.
 
@@ -77,13 +77,15 @@ Display cluster network information but do not write the network definitions to 
 
 	makenetworks -d
 
-The output would be one or more stanzas of information similar to the following. The line that ends with a colon is the value of the "netname" attribute and is the name of the network object to use with the lsdef, mkdef, chdef and rmdef commands.
+The output would be one or more stanzas of information similar to the following. The line that ends with a colon is the value of the "netname" attribute and is the name of the network object to use with the B<lsdef>, B<mkdef>, B<chdef> and B<rmdef> commands.
 
-9_114_37_0-255_255_255_0:
+ 9_114_37_0-255_255_255_0:
     objtype=network
     gateway=9.114.37.254
     mask=255.255.255.0
     net=9.114.37.0
+    mgtifname=ens3
+    mtu=1500
 
 =back
 

--- a/xCAT-test/autotest/bundle/rhels_ppc_daily.bundle
+++ b/xCAT-test/autotest/bundle/rhels_ppc_daily.bundle
@@ -141,6 +141,7 @@ makeknownhosts_node_d
 tabdump_servicenode
 makentp_h
 makentp_v
+makenetworks_d_V
 mkdef_null
 mkdef_regex_bmc
 mkdef_regex_ip

--- a/xCAT-test/autotest/bundle/rhels_ppcle_daily.bundle
+++ b/xCAT-test/autotest/bundle/rhels_ppcle_daily.bundle
@@ -142,6 +142,7 @@ makehosts_null
 makeknownhosts_node_d
 makentp_h
 makentp_v
+makenetworks_d_V
 mkdef_null
 mkdef_regex_bmc
 mkdef_regex_ip

--- a/xCAT-test/autotest/bundle/rhels_x86_daily.bundle
+++ b/xCAT-test/autotest/bundle/rhels_x86_daily.bundle
@@ -142,6 +142,7 @@ makehosts_null
 makeknownhosts_node_d
 makentp_h
 makentp_v
+makenetworks_d_V
 mkdef_null
 mkdef_regex_bmc
 mkdef_regex_ip

--- a/xCAT-test/autotest/bundle/sles_ppcle_daily.bundle
+++ b/xCAT-test/autotest/bundle/sles_ppcle_daily.bundle
@@ -102,6 +102,7 @@ makehosts_help
 makehosts_n
 makehosts_n_noderange
 makeknownhosts_node_d
+makenetworks_d_V
 mkdef_null
 mkdef_regex_bmc
 mkdef_regex_ip

--- a/xCAT-test/autotest/bundle/sles_x86_daily.bundle
+++ b/xCAT-test/autotest/bundle/sles_x86_daily.bundle
@@ -102,6 +102,7 @@ makehosts_help
 makehosts_n
 makehosts_n_noderange
 makeknownhosts_node_d
+makenetworks_d_V
 mkdef_null
 mkdef_regex_bmc
 mkdef_regex_ip

--- a/xCAT-test/autotest/bundle/ubuntu_ppcle_daily.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu_ppcle_daily.bundle
@@ -71,6 +71,7 @@ makehosts_help
 makehosts_n
 makehosts_n_noderange
 makeknownhosts_node_d
+makenetworks_d_V
 mkdef_null
 mkdef_regex_bmc
 mkdef_regex_ip

--- a/xCAT-test/autotest/bundle/ubuntu_x86_daily.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu_x86_daily.bundle
@@ -71,6 +71,7 @@ makehosts_help
 makehosts_n
 makehosts_n_noderange
 makeknownhosts_node_d
+makenetworks_d_V
 mkdef_null
 mkdef_regex_bmc
 mkdef_regex_ip


### PR DESCRIPTION
* `git cherry-pick 81e6453441d11ead72be263a93662b5337a97426`

Tested by running
```
[root@c910f04x37v07 gurevich]# makenetworks -d                                  
#From c910f04x37v07.
10_0_0_0-255_0_0_0:
    objtype=network
    net=10.0.0.0
    mask=255.0.0.0
    gateway=10.0.0.102
    mgtifname=ens3
    mtu=1500
[root@c910f04x37v07 gurevich]#
```

* Fixed grammar and formatting for `makenetworks` man page.
* Added `makenetworks_d_V` testcase to run `makenetworks` command in daily regression on all OSes.