### PR TITLE
Extend timeout for xcatd

### DIFF
--- a/xCAT-server/etc/init.d/xcatd.service
+++ b/xCAT-server/etc/init.d/xcatd.service
@@ -12,6 +12,7 @@ LimitNOFILE=16000
 RemainAfterExit=no
 Restart=on-failure
 RestartSec=5s
+TimeoutStartSec=600
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Particularly on service nodes, it takes longer to startup
and systemd needs to be more patient.

`git cherry-pick 249b76ebc3f2b04002824e99ffbcdd7f0e26f20d`
