### PR TITLE
Improve verification of makentp_extntpserver_value

### DIFF
--- a/xCAT-test/autotest/testcase/makentp/cases0
+++ b/xCAT-test/autotest/testcase/makentp/cases0
@@ -54,12 +54,8 @@ cmd:if [[ "__GETNODEATTR($$CN,os)__" =~ "rhel" ]];then clock -w;else hwclock -w 
 check:rc==0
 cmd:makentp
 check:rc==0
-check:output=~configuring management node: $$MN
 cmd:makentp -V
-check:rc==0
-check:output=~configuring management node: $$MN
-check:output=~Calling ... /install/postscripts/setupntp
-check:output=~Daemon chronyd configured
+check:output!~Error
 cmd:curryear=`cat /tmp/currentyear`;date | grep $curryear
 check:rc==0
 check:output=~\d

--- a/xCAT-test/autotest/testcase/makentp/cases0
+++ b/xCAT-test/autotest/testcase/makentp/cases0
@@ -54,8 +54,6 @@ cmd:if [[ "__GETNODEATTR($$CN,os)__" =~ "rhel" ]];then clock -w;else hwclock -w 
 check:rc==0
 cmd:makentp
 check:rc==0
-cmd:makentp -V
-check:output!~Error
 cmd:curryear=`cat /tmp/currentyear`;date | grep $curryear
 check:rc==0
 check:output=~\d


### PR DESCRIPTION
This is an improvement on https://github.com/xcat2/xcat-core/pull/6960 .

For example, when this test case fails on RHEL 8.3 with a bad NTP server, it does not fail on **makentp** nor **makntp -V**, but fails on the next command to compare year 2000 to the current year. When this test case fails on Ubuntu 16.04.5, it fails on "makentp" right away with rc=1. That is, the failures occur at different points in the test case.

Therefore, unnecessary **output comparisons** are removed.

**check:output!~Error** is added for **makentp -V** mainly for older versions of distros, although it may not be needed since the error could have been captured by the previous command **makentp**. At any rate, this is an extra checking and does not hurt.