### PR TITLE
Exclude processing host entries for makenetworks

### DIFF
--- a/xCAT-server/lib/xcat/plugins/networks.pm
+++ b/xCAT-server/lib/xcat/plugins/networks.pm
@@ -458,7 +458,13 @@ sub donets
             my $firstoctet = $ent[0];
             $firstoctet =~ s/^(\d+)\..*/$1/;
 
-            if ($ent[0] eq "169.254.0.0" or ($firstoctet >= 224 and $firstoctet <= 239) or $ent[0] eq "127.0.0.0")
+            # Do not process network entries that
+            # match 169.254.0.0 or 127.0.0.0
+            # OR
+            # in range 224.x.x.x thru 239.x.x.x
+            # OR
+            # do not contain '/'
+            if ($ent[0] eq "169.254.0.0" or ($firstoctet >= 224 and $firstoctet <= 239) or $ent[0] eq "127.0.0.0" or $ent[0] !~ "/")
             {
                 next;
             }


### PR DESCRIPTION
Continuation of #6964 


With the old code  (prior to #6964), calling `netstat -rn` from the output below we ignored any entries with `UH`:
```
[root@c910f03c09k15 xcat]# netstat -rn
Kernel IP routing table
Destination     Gateway         Genmask         Flags   MSS Window  irtt Iface
0.0.0.0         10.0.0.102      0.0.0.0         UG        0 0          0 enp0s1
0.0.0.0         10.0.0.102      0.0.0.0         UG        0 0          0 enp0s2
10.0.0.0        0.0.0.0         255.0.0.0       U         0 0          0 enp0s1
10.0.0.102      0.0.0.0         255.255.255.255 UH        0 0          0 enp0s2
50.0.0.0        0.0.0.0         255.0.0.0       U         0 0          0 enp0s2
[root@c910f03c09k15 xcat]#
```
The meaning of `UH`:
```
H      RTF_HOST     Host entry (net otherwise)
U      RTF_UP       Route usable
```
With the new code (added by  #6964), using `ip -4 route` we try to process the `10.0.0.102` entry, which we previously ignored:
```
[root@c910f03c09k15 xcat]# ip -4 route
default via 10.0.0.102 dev enp0s1 proto static metric 100
default via 10.0.0.102 dev enp0s2 proto static metric 101
10.0.0.0/8 dev enp0s1 proto kernel scope link src 10.3.9.15 metric 100
10.0.0.102 dev enp0s2 proto static scope link metric 101
50.0.0.0/8 dev enp0s2 proto kernel scope link src 50.3.9.15 metric 101
[root@c910f03c09k15 xcat]#
```

This PR adds another check to the type of entries to filter out. Any entry not containing `/` in the network field will also be skipped.