### PR TITLE
Recognize Cumulus bin file correctly on RHEL 8.x

### DIFF
--- a/xCAT-server/lib/xcat/plugins/copycds.pm
+++ b/xCAT-server/lib/xcat/plugins/copycds.pm
@@ -115,7 +115,7 @@ sub process_request {
 
                 return;
             }
-            if (grep /$file: data/, @filestat) {
+            if ((grep /$file: data/, @filestat) || (grep /$file: .* \(binary data/, @filestat)) {
                 if ($xcatdebugmode) {
                     $callback->({ info => "run copydata for data file = $file" });
                 }


### PR DESCRIPTION
The PR is to address issue https://github.com/xcat2/xcat-core/issues/6947.

This PR makes an one-line change 
from
            if (grep /$file: data/, @filestat) {
to
            if ((grep /$file: data/, @filestat) || (grep /$file: .* \(binary data/, @filestat)) {

I will explain why other previous considerations do not work.

```
On RHEL 8.1:
[root@boston02 8.1]# file RHEL-8.1.0-20191015.0-ppc64le-dvd1.iso
RHEL-8.1.0-20191015.0-ppc64le-dvd1.iso: DOS/MBR boot sector; partition 1 : ID=0x96, active, start-CHS (0x3ff,255,63), end-CHS (0x3ff,255,63), startsector 0, 5099568 sectors

[root@boston02 tmp]# file xcat-dep-2.16.1-linux.tar
xcat-dep-2.16.1-linux.tar: POSIX tar archive (GNU)

[root@boston02 armel]# file cumulus-linux-3.5.3-bcm-armel.bin
cumulus-linux-3.5.3-bcm-armel.bin: POSIX shell script executable (binary data) 

The current logic does not recognize this .bin file.
```
```
On RHEL 7.6:
[root@c910f04x37v08 iso]# file RHEL-8.1.0-20191015.0-ppc64le-dvd1.iso
RHEL-8.1.0-20191015.0-ppc64le-dvd1.iso: # ISO 9660 CD-ROM filesystem data 'RHEL-8-1-0-BaseOS-ppc64le' 

[root@c910f04x37v08 tmp]# file xcat-dep-2.16.1-linux.tar
xcat-dep-2.16.1-linux.tar: POSIX tar archive (GNU)

[root@c910f04x37v08 armel]# file cumulus-linux-3.5.3-bcm-armel.bin
cumulus-linux-3.5.3-bcm-armel.bin: data
```

The change from “**grep /$file: data/**” to “grep /$file: .* data” works for the cumulus bin file on RHEL 8.1, **BUT** it also thinks the ISO file is a bin file since **# ISO 9660 CD-ROM filesystem data** matches too.

How about using “**file –mime-encoding**” and “**grep /$file: binary**”?

[root@boston02 8.1]# file --mime-encoding RHEL-8.1.0-20191015.0-ppc64le-dvd1.iso
RHEL-8.1.0-20191015.0-ppc64le-dvd1.iso: **binary**

An ISO file falls into the .bin case. So it is no good either.

The one-line change works for RHEL 7.7 and RHEL 8.1 for ISO files, tar files and bin files.
