### PR TITLE
Add Oracle Linux to go-xcat

### DIFF
--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -2,7 +2,7 @@
 #
 # go-xcat - Install xCAT automatically.
 #
-# Version 1.0.47
+# Version 1.0.48
 #
 # Copyright (C) 2016 - 2019 International Business Machines
 # Eclipse Public License, Version 1.0 (EPL-1.0)
@@ -34,6 +34,8 @@
 #			go-xcat --xcat-version=stable install
 # 2021-02-18 Mark Gurevich <gurevich@us.ibm.com>
 #     - On Ubuntu remove packages one at a time
+# 2021-05-07 Mark Gurevich <gurevich@us.ibm.com>
+#     - Add support for Oracle Linux
 #
 
 
@@ -1397,6 +1399,7 @@ function add_xcat_dep_repo_yum_or_zypper()
 	local distro="${GO_XCAT_LINUX_DISTRO}${GO_XCAT_LINUX_VERSION%%.*}"
 	case "${distro}" in
 	"centos"*)             distro="rh${distro#centos}" ;;
+	"ol"*)                 distro="rh${distro#ol}" ;;
 	"fedora10"|"fedora11") distro="fedora9" ;;
 	"fedora1"[678])        distro="rh6" ;;
 	"fedora19"|"fedora2"?) distro="rh7" ;;
@@ -2096,7 +2099,7 @@ Version:            ${GO_XCAT_LINUX_VERSION}
 EOF
 
 case "${GO_XCAT_LINUX_DISTRO}" in
-"centos"|"fedora"|"rhel"|"sles"|"ubuntu")
+"centos"|"fedora"|"rhel"|"sles"|"ubuntu"|"ol")
 	;;
 *)
 	warn_if_bad 1 "${GO_XCAT_LINUX_DISTRO}: unsupported Linux distro"


### PR DESCRIPTION
Add support to `go-xcat` to install xCAT on Oracle Linux

```
[root@c910f04x35v02 /]# hostnamectl
   Static hostname: localhost.localdomain
Transient hostname: c910f04x35v02
         Icon name: computer-vm
           Chassis: vm
        Machine ID: 1e82e3ec7745e9118bb742110a040e02
           Boot ID: 0a87af6c570846a5aa961ed1352b9b2c
    Virtualization: kvm
  Operating System: Oracle Linux Server 7.9
       CPE OS Name: cpe:/o:oracle:linux:7:9:server
            Kernel: Linux 5.4.17-2011.6.2.el7uek.x86_64
      Architecture: x86-64
[root@c910f04x35v02 /]#
[root@c910f04x35v02 /]# lsxcatd -a
Version 2.16.1 (git commit a85566c8be85ee7eec991b0840e53295de686e49, built Wed Nov  4 16:55:06 EST 2020)
This is a Management Node
dbengine=SQLite
[root@c910f04x35v02 /]#
```