### PR TITLE
Fix xdcp man page formatting

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/xdcp.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/xdcp.1.rst
@@ -19,7 +19,7 @@ xdcp.1
 ****************
 
 
-\ **xdcp**\  \ *noderange*\   [[\ **-B**\  | \ **-**\ **-bypass**\ ] [\ **-f**\  \ *fanout*\ ] [\ **-L**\ ]  [\ **-l**\   \ *userID*\ ] [\ **-o**\  \ *node_options*\ ] [\ **-p**\ ] [\ **-P**\ ] [\ **-r**\  \ *node remote copy command] [\ \*\*-R\*\*\ ] [\ \*\*-t\*\*\  \ \*timeout\*\ ] [\ \*\*-T\*\*\ ] [\ \*\*-v\*\*\ ] [\ \*\*-q\*\*\ ] [\ \*\*-X\*\*\  \ \*env_list\*\ ] \ \*sourcefile.... targetpath\*\ *\ 
+\ **xdcp**\  \ *noderange*\   [[\ **-B**\  | \ **-**\ **-bypass**\ ] [\ **-f**\  \ *fanout*\ ] [\ **-L**\ ]  [\ **-l**\   \ *user_ID*\ ] [\ **-o**\  \ *node_options*\ ] [\ **-p**\ ] [\ **-P**\ ] [\ **-r**\  \ *node remote copy command*\ ] [\ **-R**\ ] [\ **-t**\  \ *timeout*\ ] [\ **-T**\ ] [\ **-v**\ ] [\ **-q**\ ] [\ **-X**\  \ *env_list*\ ] \ *sourcefile.... targetpath*\ 
 
 \ **xdcp**\  \ *noderange*\   [\ **-F**\  \ *rsynclist input file*\ ] [\ **-r**\  \ *node remote copy command*\ ]
 
@@ -46,7 +46,7 @@ If the Management Node is target node, it must be defined in the xCAT database w
 
 \ **REMOTE**\  \ **USER**\ :
 
-A user_ID can be specified for the remote copy command. Remote user
+A \ *user_ID*\  can be specified for the remote copy command. Remote user
 specification is identical for the \ **xdcp**\  and \ **xdsh**\  commands. 
 See the \ **xdsh**\  command for more information.
 
@@ -165,8 +165,8 @@ standard output or standard error is displayed.
 \ **-P | -**\ **-pull**\ 
  
  Pulls (copies) the files from the targets and places  them  in
- the  \ *targetpath*\   directory on the local host. The \ *targetpath*\ 
- must be a directory. Files pulled from  remote  machines  have
+ the \ *targetpath*\  directory on the local host. The \ *targetpath*\  must
+ be a directory. Files pulled from  remote  machines  have
  \ **._target**\   appended  to  the  file  name to distinguish between
  them. When the \ **-P**\  flag is used with the \ **-R**\  flag,  \ **._target**\   is
  appended to the directory. Only one file per invocation of the
@@ -201,7 +201,7 @@ standard output or standard error is displayed.
  
 
 
-\ **-R | -**\ **-recursive**\  \ *recursive*\ 
+\ **-R | -**\ **-recursive**\ 
  
  Recursively  copies files from a local directory to the remote
  targets, or when specified with the \ **-P**\  flag, recursively pulls

--- a/xCAT-client/pods/man1/xdcp.1.pod
+++ b/xCAT-client/pods/man1/xdcp.1.pod
@@ -4,7 +4,7 @@ B<xdcp> - Concurrently copies files to or from multiple nodes. In addition, prov
 
 =head1 B<SYNOPSIS>
 
-B<xdcp> I<noderange>  [[B<-B> | B<--bypass>] [B<-f> I<fanout>] [B<-L>]  [B<-l>  I<userID>] [B<-o> I<node_options>] [B<-p>] [B<-P>] [B<-r> I<node remote copy command] [B<-R>] [B<-t> I<timeout>] [B<-T>] [B<-v>] [B<-q>] [B<-X> I<env_list>] I<sourcefile.... targetpath>
+B<xdcp> I<noderange>  [[B<-B> | B<--bypass>] [B<-f> I<fanout>] [B<-L>]  [B<-l>  I<user_ID>] [B<-o> I<node_options>] [B<-p>] [B<-P>] [B<-r> I<node remote copy command>] [B<-R>] [B<-t> I<timeout>] [B<-T>] [B<-v>] [B<-q>] [B<-X> I<env_list>] I<sourcefile.... targetpath>
 
 B<xdcp> I<noderange>  [B<-F> I<rsynclist input file>] [B<-r> I<node remote copy command>]
 
@@ -28,7 +28,7 @@ If the Management Node is target node, it must be defined in the xCAT database w
 
 B<REMOTE> B<USER>:
 
-A user_ID can be specified for the remote copy command. Remote user
+A I<user_ID> can be specified for the remote copy command. Remote user
 specification is identical for the B<xdcp> and B<xdsh> commands. 
 See the B<xdsh> command for more information.
 
@@ -130,8 +130,8 @@ the configured remote copy command.
 =item B<-P>|B<--pull>
 
 Pulls (copies) the files from the targets and places  them  in
-the  I<targetpath>  directory on the local host. The I<targetpath>
-must be a directory. Files pulled from  remote  machines  have
+the I<targetpath> directory on the local host. The I<targetpath> must
+be a directory. Files pulled from  remote  machines  have
 B<._target>  appended  to  the  file  name to distinguish between
 them. When the B<-P> flag is used with the B<-R> flag,  B<._target>  is
 appended to the directory. Only one file per invocation of the
@@ -162,7 +162,7 @@ Note: The synclist processing for B<-r /usr/bin/scp> has some differences with B
 3) if the destination file specified in synclist file is an existing directory on target node, B<xdcp -r /usr/bin/scp> will fail with "scp: <destination file>: Is a directory"
 
 
-=item B<-R>|B<--recursive> I<recursive>
+=item B<-R>|B<--recursive>
 
 Recursively  copies files from a local directory to the remote
 targets, or when specified with the B<-P> flag, recursively pulls


### PR DESCRIPTION
Fix formatting of the `xdcp` man page.
Mainly to fix the SYNOPSIS line from:

![image](https://user-images.githubusercontent.com/16106630/118278713-47595e80-b498-11eb-92a1-1af868507796.png)

to:

![image](https://user-images.githubusercontent.com/16106630/118279843-96ec5a00-b499-11eb-900f-2d6b599eae93.png)
