### PR TITLE
Add timeout to confignetwork testcases

### DIFF
--- a/xCAT-test/autotest/testcase/confignetwork/cases0
+++ b/xCAT-test/autotest/testcase/confignetwork/cases0
@@ -790,7 +790,7 @@ check:rc==0
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=101.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test2 net=$secondnet mask=255.255.0.0 mgtifname=$$THIRDNIC
 check:rc==0
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$THIRDNIC=$second1ip nictypes.$$THIRDNIC=Ethernet nicnetworks.$$THIRDNIC=confignetworks_test2
-cmd:updatenode $$CN -P confignetwork
+cmd:updatenode $$CN -P confignetwork -t 1800
 check:rc==0
 cmd:chdef $$CN nicips.$$SECONDNIC= nictypes.$$SECONDNIC= nicnetworks.$$SECONDNIC= nicips.$$THIRDNIC= nictypes.$$THIRDNIC= nicnetworks.$$THIRDNIC=
 check:rc==0
@@ -798,7 +798,7 @@ cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=102.;var4=`echo $cnip |awk -F.
 check:rc==0
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=103;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;br0ip=$var1$var2;chdef $$CN nicnetworks.br0=confignetworks_test3 nicdevices.br0=bond0 nictypes.br0=bridge nicips.br0=$br0ip nicdevices.bond0="$$SECONDNIC|$$THIRDNIC" nictypes.bond0=bond nictypes.$$SECONDNIC=ethernet nictypes.$$THIRDNIC=ethernet
 check:rc==0
-cmd:updatenode $$CN -P confignetwork
+cmd:updatenode $$CN -P confignetwork -t 1800
 check:rc==0
 cmd:xdsh $$CN "ls /sys/class/net"
 check:output=~br0
@@ -846,7 +846,7 @@ cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=101.;var4=`echo $cnip |awk -F.
 check:rc==0
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;chdef $$CN nicips.$$THIRDNIC=$second1ip nictypes.$$THIRDNIC=Ethernet nicnetworks.$$THIRDNIC=confignetworks_test2
 check:rc==0
-cmd:updatenode $$CN -P confignetwork
+cmd:updatenode $$CN -P confignetwork -t 1800
 check:rc==0
 cmd:chdef $$CN nicips.$$SECONDNIC= nictypes.$$SECONDNIC= nicnetworks.$$SECONDNIC= nicips.$$THIRDNIC= nictypes.$$THIRDNIC= nicnetworks.$$THIRDNIC=
 check:rc==0
@@ -855,7 +855,7 @@ check:rc==0
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=103.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test4 net=$secondnet mask=255.255.0.0
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=103;var3=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;br22ip=$var1$var3;br33ip=$var2$var3;chdef $$CN nicdevices.br22=bond0.2 nicdevices.br33=bond0.3 nictypes.br22=bridge nictypes.br33=bridge nicnetworks.br22=confignetworks_test3 nicnetworks.br33=confignetworks_test4 nicips.br22=$br22ip nicips.br33=$br33ip nicdevices.bond0.2=bond0 nicdevices.bond0.3=bond0 nictypes.bond0.2=vlan nictypes.bond0.3=vlan nictypes.bond0=bond nictypes.$$SECONDNIC=ethernet nictypes.$$THIRDNIC=ethernet nicdevices.bond0="$$SECONDNIC|$$THIRDNIC"
 check:rc==0
-cmd:updatenode $$CN -P confignetwork
+cmd:updatenode $$CN -P confignetwork -t 1800
 check:rc==0
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var3=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;br22ip=$var1$var3;if grep SUSE /etc/*release;then xdsh $$CN "grep $br22ip /etc/sysconfig/network/ifcfg-br22"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN  "grep $br22ip /etc/sysconfig/network-scripts/ifcfg-*br22*"; elif grep Ubuntu /etc/*release;then xdsh $$CN "grep $br22ip /etc/network/interfaces.d/br22";else echo "Sorry,this is not supported os"; fi
 check:rc==0


### PR DESCRIPTION
Sometimes the following testcases take over 2 hours each.
They get stuck executing `updatenode` command, which eventually fails.

```
		 Cases longer than 30 min:

------END::confignetwork_2eth_bridge_br0::Failed::Time:Fri May 14 09:47:18 2021 ::Duration::7376 sec------ (02 h 02 min)
------END::confignetwork_2eth_bridge_br22_br33::Failed::Time:Fri May 14 12:06:28 2021 ::Duration::8350 sec------ (02 h 19 min)
```

This PR adds a timeout of 30 min to `updatenode` command. While the testcase should still fail, it will do so much faster.