### PR TITLE
Extract full version information

### DIFF
--- a/xCAT-client/bin/mysqlsetup
+++ b/xCAT-client/bin/mysqlsetup
@@ -146,7 +146,8 @@ if (-e "/etc/debian_version") {
 }
 
 # determine whether redhat or sles
-$::linuxos = xCAT::Utils->osver();
+$::linuxos = xCAT::Utils->osver("all"); # returns "name,version.release"
+$::linuxos =~ tr/,//d; # remove comma separating release name and version numbers
 
 # is this MariaDB or MySQL
 $::MariaDB = 0;

--- a/xCAT-client/bin/mysqlsetup
+++ b/xCAT-client/bin/mysqlsetup
@@ -146,8 +146,7 @@ if (-e "/etc/debian_version") {
 }
 
 # determine whether redhat or sles
-$::linuxos = xCAT::Utils->osver("all"); # returns "name,version.release"
-$::linuxos =~ tr/,//d; # remove comma separating release name and version numbers
+$::linuxos = xCAT::Utils->osver();
 
 # is this MariaDB or MySQL
 $::MariaDB = 0;
@@ -901,14 +900,12 @@ sub initmysqldb
         }
 
         $cmd = "$sqlcmd --user=mysql";
-        #on rhels7.7, /usr/bin/mysql_install_db requires /usr/libexec/resolveip, 
-        #but it's available at the /usr/bin/resolveip
-        if ($::linuxos eq "rhels7.7") {
-            my $resolveip="/usr/libexec/resolveip";
-            if (!(-x ($resolveip))) {
-                my $linkcmd="ln -s /usr/bin/resolveip $resolveip";
-                xCAT::Utils->runcmd($linkcmd, 0);
-            }
+        # On rhels7.7, /usr/bin/mysql_install_db requires /usr/libexec/resolveip
+        # Link it to /usr/bin/resolveip for all OSes, just in case some future releases have the same requirement
+        my $resolveip="/usr/libexec/resolveip";
+        if (!(-x ($resolveip))) {
+            my $linkcmd="ln -s /usr/bin/resolveip $resolveip";
+            xCAT::Utils->runcmd($linkcmd, 0);
         }
     }
     xCAT::Utils->runcmd($cmd, 0);


### PR DESCRIPTION
Without any arguments, `xCAT::Utils->osver()` returns osname and version number, something like `rhels7`.
However, around line 906 a check is make which including release number also: `if ($::linuxos eq "rhels7.7") {`.
As a result when running on `rhels7.7` the section of the code intended for that os was not executed.

This PR formats `$::linuxos` to include osname,version and release numbers. 