### PR TITLE
Use non-interactive flag when calling zypper install

### DIFF
--- a/xCAT-test/autotest/testcase/migration/sles_migration
+++ b/xCAT-test/autotest/testcase/migration/sles_migration
@@ -45,7 +45,7 @@ check:output=~\d\d:\d\d:\d\d
 cmd:xdsh $$CN "rm -rf /oldxcat"
 cmd:xdsh $$CN "mkdir -p /oldxcat"
 check:rc==0
-cmd:xdsh $$CN "zypper install bzip2"
+cmd:xdsh $$CN "zypper -n install bzip2"
 check:rc==0
 cmd:xdsh $$CN "cd /oldxcat;wget $$MIGRATION1_DEP"
 check:rc==0
@@ -164,7 +164,7 @@ check:output=~\d\d:\d\d:\d\d
 cmd:xdsh $$CN "rm -rf /oldxcat"
 cmd:xdsh $$CN "mkdir -p /oldxcat"
 check:rc==0
-cmd:xdsh $$CN "zypper install bzip2"
+cmd:xdsh $$CN "zypper -n install bzip2"
 check:rc==0
 cmd:xdsh $$CN "cd /oldxcat;wget $$MIGRATION2_CORE"
 check:rc==0


### PR DESCRIPTION
The `sles_migration2` testcase on `sles15.2` calls `zypper install bzip2` without `--non-interactive` flag, which results in
```
c910f04x35v04: Continue? [y/n/v/...? shows all options] (y): 
[c910f04x35v02]: c910f04x35v04: Cannot read input: bad stream or EOF.
c910f04x35v04: If you run zypper without a terminal, use '--non-interactive' global
c910f04x35v04: option to make zypper use default answers to prompts.
CHECK:rc == 0	[Failed]
```

This PR adds `-n` flag so `zypper install` can run non-interactive.
Interestingly on SLES12 `bzip2` is already installed at that point in testcase, and `zypper install bzip2` does not need to prompt the user to continue.