### PR TITLE
Use correct substring operator in migration testcase

### DIFF
--- a/xCAT-test/autotest/testcase/migration/sles_migration
+++ b/xCAT-test/autotest/testcase/migration/sles_migration
@@ -189,7 +189,7 @@ check:rc==0
 cmd:xdsh $$CN "zypper -n install xCAT"
 check:rc==0
 # Name of createrepo package on sles15 is different from sles12
-cmd:if [ "__GETNODEATTR($$CN,os)__" = "sle15" ]; then xdsh $$CN "zypper -n install createrepo_c"; else xdsh $$CN "zypper -n install createrepo";fi
+cmd:if [[ "__GETNODEATTR($$CN,os)__" =~ "sle15" ]]; then xdsh $$CN "zypper -n install createrepo_c"; else xdsh $$CN "zypper -n install createrepo";fi
 check:rc==0
 cmd:xdsh $$CN "source /etc/profile.d/xcat.sh"
 check:rc==0


### PR DESCRIPTION
In `sles_migration2` testcase, the test `if [ "__GETNODEATTR($$CN,os)__" = "sle15" ]` fails to match `sle15.2`. 
Substring operator `=~` should be used instead.

```
RUN:if [ "sle15.2" = "sle15" ]; then xdsh c910f04x35v07 "zypper -n install createrepo_c"; else xdsh c910f04x35v07 "zypper -n install createrepo";fi [Thu May 20 06:10:38 2021]
ElapsedTime:3 sec
RETURN rc = 1
OUTPUT:
c910f04x35v07: Loading repository data...
c910f04x35v07: Reading installed packages...
c910f04x35v07: 'createrepo' not found in package names. Trying capabilities.
[c910f04x35v05]: c910f04x35v07: No provider of 'createrepo' found.
CHECK:rc == 0	[Failed]
```

