### PR TITLE
Redact passwords in log files

### DIFF
--- a/xCAT-server/lib/perl/xCAT/xcatd.pm
+++ b/xCAT-server/lib/perl/xCAT/xcatd.pm
@@ -514,6 +514,7 @@ sub verifytoken {
 sub redact_password {
     my $class = shift;
     my $request = shift;
+    my $redact_string = "xxxxxxxx";
 
     my %commads_with_password = (
         bmcdiscover => {
@@ -550,13 +551,13 @@ sub redact_password {
                 if ($flag_index >= 0) {
                     # Passed in command contains one of the flags, redact pw
                     my ($passwd, $rest) = split(/\s+/,substr($parameters, $flag_index+length($password_flag)));
+                    my $pw_replacement = $redact_string;
                     if (index($passwd, "'") > 0) {
-                        # Password and password flag was enclosed in "'", do not replace that quote with 'x'
-                        substr($parameters, $flag_index+length($password_flag), length($passwd)) = "x" x (length($passwd)-1) . "'";
-                    } else {
-                        # Replace password with the same number of 'x'
-                        substr($parameters, $flag_index+length($password_flag), length($passwd)) = "x" x length($passwd);
+                        # Password and password flag was enclosed in "'", preserve that quote
+                        $pw_replacement .= "'";
                     }
+                    # Replace password with $pw_replacement
+                    substr($parameters, $flag_index+length($password_flag), length($passwd)) = $pw_replacement;
                 }
             }
         }

--- a/xCAT-server/lib/perl/xCAT/xcatd.pm
+++ b/xCAT-server/lib/perl/xCAT/xcatd.pm
@@ -271,6 +271,7 @@ sub validate {
                         $saveArglist = "$first$restcommand";
                    }
                 }
+                # Replace passwords with 'x'
                 if ($arglist)  { $logst .= redact_password($request->{command}->[0], $saveArglist); }
                 if ($peername) { $logst .= " for " . $request->{username}->[0] }
                 if ($peerhost) { $logst .= " from " . $peerhost }
@@ -490,20 +491,20 @@ sub verifytoken {
 
                       $class: Calling module name, for example:
                           xCAT::xcatd
-                      $request: Single line string of the command + arguments, for example:
-                          [Request]    rspconfig f6u13k18 'HMC_passwd=123' '*_passwd=abc,xyz'
+                      $request: Single line string of the header + command + arguments, for example:
+                          header [Request]    rspconfig f6u13k18 'HMC_passwd=123' '*_passwd=abc,xyz'
 
                   Type 2:
                       Called from this module to log command to /var/log/messages and
                                                                 /var/log/xcat/cluster.log
 
                       $class: Command name sting, for example:
-                          respconfig
+                          rspconfig
                       $request: Single line string of arguments, for example:
-                          f6u13k18 'HMC_passwd=123' '*_passwd=abc,xyz'
+                          'HMC_passwd=123' '*_passwd=abc,xyz'
      Returns string:
                   Type 1:
-                      [Request]    rspconfig f6u13k18 'HMC_passwd=xxx' '*_passwd=xxxxxxx'
+                      header [Request]    rspconfig f6u13k18 'HMC_passwd=xxx' '*_passwd=xxxxxxx'
 
                   Type 2:
                       'HMC_passwd=xxx' '*_passwd=xxxxxxx'
@@ -517,6 +518,9 @@ sub redact_password {
     my %commads_with_password = (
         bmcdiscover => {
             flags => ["-p ", "-n "],
+        },
+        mkhwconn => {
+            flags => ["-P "],
         },
         rspconfig => {
             flags => ["admin_passwd=","HMC_passwd=","general_passwd=","*_passwd=","USERID="],

--- a/xCAT-server/lib/perl/xCAT/xcatd.pm
+++ b/xCAT-server/lib/perl/xCAT/xcatd.pm
@@ -271,7 +271,7 @@ sub validate {
                         $saveArglist = "$first$restcommand";
                    }
                 }
-                if ($arglist)  { $logst .= $saveArglist; }
+                if ($arglist)  { $logst .= redact_password($request->{command}->[0], $saveArglist); }
                 if ($peername) { $logst .= " for " . $request->{username}->[0] }
                 if ($peerhost) { $logst .= " from " . $peerhost }
 
@@ -475,6 +475,93 @@ sub verifytoken {
     } else {
         # Token entry was not found
         return undef;
+    }
+}
+# --------------------------------------------------------------------------------
+
+=head3 redact_password
+
+     Used to redact the password in command line parameters with 'x'
+     For example, command: rspconfig f6u13k18 'HMC_passwd=123' '*_passwd=abc,xyz'
+
+     Arguments:
+                  Type 1:
+                      Called from sbin/xcatd to log command to /var/log/xcat/commands.log
+
+                      $class: Calling module name, for example:
+                          xCAT::xcatd
+                      $request: Single line string of the command + arguments, for example:
+                          [Request]    rspconfig f6u13k18 'HMC_passwd=123' '*_passwd=abc,xyz'
+
+                  Type 2:
+                      Called from this module to log command to /var/log/messages and
+                                                                /var/log/xcat/cluster.log
+
+                      $class: Command name sting, for example:
+                          respconfig
+                      $request: Single line string of arguments, for example:
+                          f6u13k18 'HMC_passwd=123' '*_passwd=abc,xyz'
+     Returns string:
+                  Type 1:
+                      [Request]    rspconfig f6u13k18 'HMC_passwd=xxx' '*_passwd=xxxxxxx'
+
+                  Type 2:
+                      'HMC_passwd=xxx' '*_passwd=xxxxxxx'
+=cut
+
+# --------------------------------------------------------------------------------
+sub redact_password {
+    my $class = shift;
+    my $request = shift;
+
+    my %commads_with_password = (
+        bmcdiscover => {
+            flags => ["-p ", "-n "],
+        },
+        rspconfig => {
+            flags => ["admin_passwd=","HMC_passwd=","general_passwd=","*_passwd=","USERID="],
+        },
+    );
+
+    my $full_command;
+    my $header;
+    # split out command and its parameters and flags
+    if ($request =~ '\[Request\]') {
+        ($header, $full_command) = split('\[Request\]',$request,2);
+    } else {
+        $full_command = $class . " " . $request;
+    }
+    my ($command, $parameters) = split(' ',$full_command,2);
+
+    # Check if passed in $command appears in the %commads_with_password hash
+    for (keys %commads_with_password) {
+        if ($_ eq $command) {
+            my @all_command_flags = split(' ', $parameters);
+            my $ref = $commads_with_password{$command}{flags};
+            my @flags_array = @$ref;
+            foreach my $password_flag (@flags_array) {
+                # For each flag of the command from hash, check if passed in
+                # command flags match
+                my $flag_index = index ($parameters, $password_flag);
+                if ($flag_index >= 0) {
+                    # Passed in command contains one of the flags, redact pw
+                    my ($passwd, $rest) = split(/\s+/,substr($parameters, $flag_index+length($password_flag)));
+                    if (index($passwd, "'") > 0) {
+                        # Password and password flag was enclosed in "'", do not replace that quote with 'x'
+                        substr($parameters, $flag_index+length($password_flag), length($passwd)) = "x" x (length($passwd)-1) . "'";
+                    } else {
+                        # Replace password with the same number of 'x'
+                        substr($parameters, $flag_index+length($password_flag), length($passwd)) = "x" x length($passwd);
+                    }
+                }
+            }
+        }
+    }
+    # Return original request with password replaced by 'x' in $parameters string
+    if ($request =~ '\[Request\]') {
+        return $header . "[Request]    " . $command . " " . $parameters;
+    } else {
+        return " " . $parameters;
     }
 }
 1;

--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -2862,6 +2862,8 @@ sub service_connection {
                     }
                 }
             }
+            # Replace passwords with 'x'
+            $cmdlog_alllog = xCAT::xcatd->redact_password($cmdlog_alllog);
             $cmdlog_alllog .= "\n[Response]\n";
 
             # ----used for command log end----------


### PR DESCRIPTION
### The PR is to fix issue _#6516_

Redact passwords strings so that they do not appear in log files.

`xCAT-server/lib/perl/xCAT/xcatd.pm` logs entries to `/var/log/messages` and `/var/log/xcat/cluster.log`
`xCAT-server/sbin/xcatd` logs entries to `/var/log/xcat/commands.log`

### UT:
* Command: `bmcdiscover --range f6u13k06 -p abc -n 123`
* Log entry `/var/log/messages/`:
    `Jun 29 12:05:03 f6u13k04 xcat[174681]: xCAT: Allowing bmcdiscover --range f6u13k06 -p xxx -n xxx for root from localhost`
* Log entry `/var/log/xcat/cluster.log`:
    `Jun 29 12:05:03 f6u13k04 xcat[174681]: INFO xCAT: Allowing bmcdiscover --range f6u13k06 -p xxx -n xxx for root from localhost`
* Log entry `/var/log/xcat/commands.log`:
    ```
    [Date]       2021-06-29 12:05:03
    [ClientType] cli
    [Request]    bmcdiscover --range f6u13k06 -p xxx -n xxx
    [Response]
    Warning: No bmc found.

    [NumberNodes] 0
    [ElapsedTime] 0.676 s
    ```

* Command: `rspconfig f6u13k06 HMC_passwd=abc *_passwd=xyz,123`
* Log entry `/var/log/messages/`:
    `Jun 29 12:04:03 f6u13k04 xcat[174670]: xCAT: Allowing rspconfig to f6u13k06 HMC_passwd=xxx *_passwd=xxxxxxx for root from localhost`
* Log entry `/var/log/xcat/cluster.log`:
    `Jun 29 12:04:03 f6u13k04 xcat[174670]: INFO xCAT: Allowing rspconfig to f6u13k06 HMC_passwd=xxx *_passwd=xxxxxxx for root from localhost`
* Log entry `/var/log/xcat/commands.log`:
    ```
    [Date]       2021-06-29 12:04:03
    [ClientType] cli
    [Request]    rspconfig f6u13k06 'HMC_passwd=xxx' '*_passwd=xxxxxxx'
    [Response]
    f6u13k06: Error: Unable to identify plugin for this command, check relevant tables: nodehm.mgt=blade|fsp|ipmi;switches.switchtype;nodehm.mgt=openbmc
    [NumberNodes] 1
    [ElapsedTime] 0.041 s
    ```