### PR TITLE
Doc updates for MariaDB and mypostscript.tmpl

### DIFF
--- a/docs/source/advanced/hierarchy/databases/mysql_install.rst
+++ b/docs/source/advanced/hierarchy/databases/mysql_install.rst
@@ -37,8 +37,8 @@ Red Hat Enterprise Linux
 
 * For RHEL 8, MariaDB is shipped. Using ``dnf``, ensure that the following packages are installed on the management node: ::
 
-       mariadb-server-5.*
-       mariadb-5.*
+       mariadb-server-10.*
+       mariadb-10.*
        perl-DBD-MySQL*
        mariadb-connector-odbc-*
 

--- a/docs/source/guides/admin-guides/manage_clusters/common/deployment/prepostscripts/post_script.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/deployment/prepostscripts/post_script.rst
@@ -397,7 +397,7 @@ Kinds of variables in the template
     NTYPE=$NTYPE
     export NTYPE
 
-**Type 2:** This is the syntax to get the value of one attribute from the ``<tablename>`` and its key is ``$NODE``. It does not support tables with two keys. Some of the tables with two keys are ``litefile``, ``prodkey``, ``deps``, ``monsetting``, ``mpa``, ``networks``. It does not support tables with key other than ``$NODE``. Some of the tables with not ``$NODE`` keys are ``passwd``, ``rack``, ``token`` ::
+**Type 2:** This is the syntax to get the value of one attribute from the ``<tablename>`` and its key is ``$NODE``. It does not support tables with two keys. Some of the tables with two keys are ``litefile``, ``prodkey``, ``deps``, ``monsetting``, ``mpa``, ``networks``. It does not support tables with keys other than ``$NODE``. Some of the tables that do not use ``$NODE`` as the key, are ``passwd``, ``rack``, ``token`` ::
 
     VARNAME=#TABLE:tablename:$NODE:attribute#
 

--- a/docs/source/guides/admin-guides/manage_clusters/common/deployment/prepostscripts/post_script.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/deployment/prepostscripts/post_script.rst
@@ -397,7 +397,7 @@ Kinds of variables in the template
     NTYPE=$NTYPE
     export NTYPE
 
-**Type 2:** This is the syntax to get the value of one attribute from the ``<tablename>`` and its key is ``$NODE``. It does not support tables with two keys. Some of the tables with two keys are ``litefile``, ``prodkey``, ``deps``, ``monsetting``, ``mpa``, ``networks``. ::
+**Type 2:** This is the syntax to get the value of one attribute from the ``<tablename>`` and its key is ``$NODE``. It does not support tables with two keys. Some of the tables with two keys are ``litefile``, ``prodkey``, ``deps``, ``monsetting``, ``mpa``, ``networks``. It does not support tables with key other than ``$NODE``. Some of the tables with not ``$NODE`` keys are ``passwd``, ``rack``, ``token`` ::
 
     VARNAME=#TABLE:tablename:$NODE:attribute#
 


### PR DESCRIPTION
Doc updates:
* MariaDB version 5 is not available on RHEL8, version 10 used for regression testing
* Explicitly state that tables with non `$NODE` key can not be used in `VARNAME=#TABLE:tablename:xxxxx:attribute#` in `mypostscript.tmpl` file.