### PR TITLE
add support for cleanupxcatpost in diskfull installations

### DIFF
--- a/xCAT/postscripts/xcatinstallpost
+++ b/xCAT/postscripts/xcatinstallpost
@@ -139,6 +139,12 @@ fi
 " >> /xcatpost/mypostscript.post
 fi
 
+CLEANUPXCATPOST=`grep CLEANUPXCATPOST= /xcatpost/mypostscript |awk -F = '{print $2}' | tr -d \'\" | tr A-Z a-z`
+if [[ "$CLEANUPXCATPOST" =~ ^(1|yes|y)$ ]]; then
+  echo "cd /" >> /xcatpost/mypostscript.post
+  echo "rm -rf /xcatpost/*" >> /xcatpost/mypostscript.post
+fi
+
 
 chmod +x /xcatpost/mypostscript.post
 if [ -x /xcatpost/mypostscript.post ];then


### PR DESCRIPTION
### The PR is to fix issue _#7002_

_## Add support for `site` property `cleanupxcatpost` in `xcatinstallpost`_

This PR checks for the presence and value of `CLEANUPXCATPOST` in `/xcatpost/mypostscript` during diskfull installations, and adds commands in `/xcatpost/mypostscript.post` to delete the `/xcatpost` contents at the end of a diskfull deployment.