### PR TITLE
Return the correct network mask by matching the netname exactly in nicutils.sh

### DIFF
--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -397,7 +397,7 @@ function get_network_attr {
    while [ $index -le $NETWORKS_LINES ]
    do
        eval netline=\$NETWORKS_LINE$index
-       echo "$netline" | grep -sq ".*netname=$netname" && break;
+       echo "$netline" | grep -sq ".*netname=$netname||" && break;
        ((index+=1))
    done
 


### PR DESCRIPTION
This PR is to fix https://github.com/xcat2/xcat-core/issues/7000 .

Mark is correct that the problem is with **grep -sq ".\*netname=$netname"** in **get_network_attr()** of **xCAT/postscripts/nicutils.sh**.
```
function get_network_attr {
   local netname=$1
   local attrname=$2

   local netline=""
   local index=1
   while [ $index -le $NETWORKS_LINES ]
   do
       eval netline=\$NETWORKS_LINE$index
       echo "$netline" | grep -sq ".*netname=$netname" && break;
       ((index+=1))
   done

   if [ $index -le $NETWORKS_LINES ]; then
       echo "$netline" | $sed -e 's/||/\n/g' | $awk -F'=' '$1 == "'$attrname'" {print $2}'   else
       return 1
   fi
}
```
The while loop examines records of Table networks. An example record is as follows:
```
<node name>: +++ netline='netname=subnet_10||net=102.6.0.0||mask=255.255.0.0||mgtifname=||gateway=||dhcpserver=||tftpserver=||nameservers=||ntpservers=||logservers=||dynamicrange=||staticrange=||staticrangeincrement=||nodehostname=||ddnsdomain=||vlanid=||domain=||mtu=||disable=||comments='
```
Assume that there is another record with netname=subnet and mask=255.255.255.0 and br0 is associated with it. And this record is inserted **after** the one above.

**grep -sq "\*.netname=subnet"** sees a match for netname=subnet_10 and does not search further. It returns mask=255.255.0.0, which is the wrong record.

By seeing **||** right after $netname, **grep -sq ".\*netname=$netname||"** does an exact match.

I did some string manipulation of the record earlier and achieved the same thing.

By noticing **||** right after $netname, Nate suggested a simpler and more elegant solution. Thanks Nate.