### PR TITLE
Verify the correctness of network mask returned by get_network_attr in nicutils.sh

### DIFF
--- a/xCAT-test/autotest/testcase/confignetwork/cases0
+++ b/xCAT-test/autotest/testcase/confignetwork/cases0
@@ -794,12 +794,15 @@ cmd:updatenode $$CN -P confignetwork -t 1800
 check:rc==0
 cmd:chdef $$CN nicips.$$SECONDNIC= nictypes.$$SECONDNIC= nicnetworks.$$SECONDNIC= nicips.$$THIRDNIC= nictypes.$$THIRDNIC= nicnetworks.$$THIRDNIC=
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=102.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test3 net=$secondnet mask=255.255.0.0
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var3=102.;var4=`echo $cnip |awk -F. '{print $2}'`;var5=.0.0;secondnet=$var3$var4$var5;mkdef -t network -o confignetworks_test net=$secondnet mask=255.255.255.0
 check:rc==0
-cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=103;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;br0ip=$var1$var2;chdef $$CN nicnetworks.br0=confignetworks_test3 nicdevices.br0=bond0 nictypes.br0=bridge nicips.br0=$br0ip nicdevices.bond0="$$SECONDNIC|$$THIRDNIC" nictypes.bond0=bond nictypes.$$SECONDNIC=ethernet nictypes.$$THIRDNIC=ethernet
+cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=103;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;br0ip=$var1$var2;chdef $$CN nicnetworks.br0=confignetworks_test nicdevices.br0=bond0 nictypes.br0=bridge nicips.br0=$br0ip nicdevices.bond0="$$SECONDNIC|$$THIRDNIC" nictypes.bond0=bond nictypes.$$SECONDNIC=ethernet nictypes.$$THIRDNIC=ethernet
 check:rc==0
 cmd:updatenode $$CN -P confignetwork -t 1800
 check:rc==0
+cmd:br0_netmask=`xdsh $$CN ifconfig br0 | grep netmask | awk '{print $5}'`;if [[ $br0_netmask = "255.255.255.0" ]]; then echo YES; else echo NO; fi
+check:rc==0
+check:output=~YES
 cmd:xdsh $$CN "ls /sys/class/net"
 check:output=~br0
 cmd:xdsh $$CN "cat /sys/class/net/bonding_masters"
@@ -812,7 +815,7 @@ check:rc==0
 cmd:rmdef -t network -o confignetworks_test2
 cmd:if grep SUSE /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network/ifcfg-$$THIRDNIC"; elif grep -E "Red Hat|CentOS" /etc/*release;then xdsh $$CN "rm -rf /etc/sysconfig/network-scripts/ifcfg-$$THIRDNIC"; elif grep Ubuntu /etc/*release;then xdsh $$CN "rm -rf /etc/network/interfaces.d/$$THIRDNIC";else echo "Sorry,this is not supported os"; fi
 check:rc==0
-cmd:rmdef -t network -o confignetworks_test3
+cmd:rmdef -t network -o confignetworks_test
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=103;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;br0ip=$var1$var2;xdsh $$CN "ip addr del $br0ip/16 dev br0"
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=101;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;xdsh $$CN "ip addr del $second1ip/16 dev $$SECONDNIC"
 cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=102;var2=`echo $cnip |sed -r 's/[^\.]{1,3}(\..*)/\1/'`;second1ip=$var1$var2;xdsh $$CN "ip addr del $second1ip/16 dev $$THIRDNIC"

--- a/xCAT-test/autotest/testcase/confignetwork/cases0
+++ b/xCAT-test/autotest/testcase/confignetwork/cases0
@@ -800,9 +800,9 @@ cmd:cnip=__GETNODEATTR($$CN,ip)__;echo $cnip;var1=103;var2=`echo $cnip |sed -r '
 check:rc==0
 cmd:updatenode $$CN -P confignetwork -t 1800
 check:rc==0
-cmd:br0_netmask=`xdsh $$CN ifconfig br0 | grep netmask | awk '{print $5}'`;if [[ $br0_netmask = "255.255.255.0" ]]; then echo YES; else echo NO; fi
+cmd:xdsh $$CN ifconfig br0 | grep netmask | awk '{print $5}'
 check:rc==0
-check:output=~YES
+check:output=~255.255.255.0
 cmd:xdsh $$CN "ls /sys/class/net"
 check:output=~br0
 cmd:xdsh $$CN "cat /sys/class/net/bonding_masters"


### PR DESCRIPTION
This PR is to strengthen network testing to address https://github.com/xcat2/xcat-core/issues/7000 and demonstrate the correctness of changes in https://github.com/xcat2/xcat-core/pull/7005 .

The key changes in confignetwork_2eth_bridge_br0 are as follows:
(1) confignetworks_test3 is the 4th record in the networks table. Rename it to confignetworks_test so that it becomes a substring of confignetworks_test1 which is the 2nd record in the table.
(2) Change its mask from 255.255.0.0 to 255.255.255.0 to make it different from others for verification purposes.
(3) After "updatenode <node> -P confignetwork -t 1800" is done, check the mask of br0. If it has 255.255.255.0, then the mask extraction is correct. Otherwise, issue an error.