### PR TITLE
Allow rscan to run on HMC V10

### DIFF
--- a/perl-xCAT/xCAT/PPCcli.pm
+++ b/perl-xCAT/xCAT/PPCcli.pm
@@ -1088,7 +1088,15 @@ sub send_cmd {
     ##########################################
     if ($result[3] =~ s/Rc=([0-9])+\r\n//) {
         if ($1 != 0) {
-            return ([ RC_ERROR, $result[3] ]);
+            if ($cmd =~ "lssyscfg -r frame -F") {
+                # On HMC V10 the "lssyscfg -r frame -F" command returns error,
+                # ON HMC V9 the same command returns "No results were found"
+                # Try to catch that command here and return 
+                # "No results were found" like we would on V9
+                return ([ NR_ERROR, "No results were found" ]);
+            } else {
+                return ([ RC_ERROR, $result[3] ]);
+            }
         }
     }
     ##########################################


### PR DESCRIPTION
On HMC V10, the `rscan` command fails:
```
[root@c712ems5-pvt ZZ]# rscan c643hmc2  -V
c643hmc2: [c712ems5-pvt]: The command entered is either missing a required parameter or a parameter value is invalid. The parameters that are missing or have an invalid value are -r. Please check your entry and retry the command.
[c712ems5-pvt]: 10:25:46 75596 Total Elapsed Time: 0.376 sec
```

This is due to the fact that the `lssyscfg -r frame` command is handled differently.
On HMC, version V9R1, it produces this:
```
hscroot@c910hmc03:~> lssyscfg -r frame
No results were found.
hscroot@c910hmc03:~> echo $?
0
hscroot@c910hmc03:~>
```
But on the newer HMC, version V10R1, it produces this:
```
hscroot@c643hmc2:~> lssyscfg -r frame
The command entered is either missing a required parameter or a parameter value is invalid. The parameters that are missing or have an invalid value are -r. Please check your entry and retry the command.
hscroot@c643hmc2:~> echo $?
1
hscroot@c643hmc2:~>
```

### UT

* HMC V9
```
root@c910f03c05k10:/opt/xcat# rscan c910hmc03
type    name                       id      type-model  serial-number  side
cec     Server-8375-42A-SN13C6xxx          8375-42A    13C6xxx
cec     c910f03c15                         8247-22L    1011xxx
hmc     c910hmc03                          7042-CR8    21E8xxx
lpar    c910f03c15p01              2       8247-22L    1011xxx
lpar    zztop                      1       8375-42A    13C6xxx

root@c910f03c05k10:/opt/xcat#
```

* HMC V10
```
[root@c712ems5-pvt xcat]# rscan c643hmc2
type    name                        id      type-model  serial-number  side
cec     BMC-9105-22A_13E0xxx                9105-22A    13E0xxx
cec     c643u27-9105-22A-SN13E0xxx         9105-22A    13E0xxx
cec     c643u31-9009-22G-ZZ40xxx           9009-22G    ZZ40xxx
cec     c643u35-9009-22G-SN78F9xxx          9009-22G    78F9xxx
cec     c643u37-9009-22G-SN78F9xxx          9009-22G    78F9xxx
cec     c643u39-9009-22A-13F5xxx           9009-22A    13F5xxx
hmc     c643hmc2                            7063-CR1    1310xxx
lpar    78-F91B0                    1       9009-22G    78F9xxx
lpar    78-F91C0                    1       9009-22G    78F9xxx
lpar    c643n07aix1                 1       9105-22A    13E0xxx
lpar    c643n07rh1                  2       9105-22A    13E0xxx
lpar    c643n09                     2       9009-22G    78F9xxx
lpar    c643n10                     2       9009-22G    78F9xxx
lpar    c643n11                     2       9009-22G    ZZ40xxx
lpar    c643n12                     1       9009-22A    13F5xxx

# 9105-22A*13E0xxx: ERROR HSCL0237 This operation is not allowed when the managed system is in the No Connection state.  After you have established a connection from the management console to the managed system and have entered a valid management console access password, try the operation again.

[root@c712ems5-pvt xcat]#
```