### PR TITLE
Update the kernel options to disable selinux

### DIFF
--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -762,7 +762,7 @@ sub mknetboot
         }
 
         # turn off the selinux
-        if ($osver =~ m/(fedora12|fedora13|rhels7)/) {
+        if ($osver =~ m/(fedora12|fedora13|rhels7|rhels8)/) {
             $kcmdline .= " selinux=0 ";
         }
 


### PR DESCRIPTION
Was having issues building a diskless image for RHEL8

### The PR is to fix issue https://github.com/xcat2/xcat-core/issues/7013

### The modification include

* Simple addition of a regex match to the correct os version
