### PR TITLE
Update ospkgs and otherpkgs postscripts for RHEL8 and its variants

### DIFF
--- a/xCAT/postscripts/ospkgs
+++ b/xCAT/postscripts/ospkgs
@@ -261,7 +261,8 @@ do
     # (1)for rhels6, there is one repodata in the os base dir; so keep it here, and handle the other cases below
     # (2)for sles, we should specified the baseurl should be ./install/sles11/ppc64/1
     # (3)for SL5, we should append the /SL
-    # (4) for other os, we just keep it here.
+    # (4)for rhels8, centos8, ol8 and rocky8 we should append /BaseOS and /AppStream to base directory
+    # (5) for other os, we just keep it here.
     # For other pkg paths, we just keep it here.
     if [ $dir == $default_pkgdir ] || [ $dir == "$default_pkgdir/" ]; then
         if ( pmatch "$OSVER" "sle*" ); then
@@ -271,6 +272,13 @@ do
             OSPKGDIR="$OSPKGDIR/SL"
             ospkgdir="$ospkgdir/SL"
         fi
+    fi
+    if ( ! pmatch "$OSVER" "rhels8*" && 
+         ! pmatch "$OSVER" "centos8*" &&
+         ! pmatch "$OSVER" "rocky8*" &&
+         ! pmatch "$OSVER" "ol8*"); then
+        # For rhels8, centos8, ol8 and rocky8 do not put $ospkgdir by itself
+        array_set_element os_path $index $ospkgdir
     fi
     array_set_element os_path $index $ospkgdir
     if [ $dir == $default_pkgdir ] || [ $dir == "$default_pkgdir/" ]; then
@@ -299,7 +307,10 @@ do
             fi
         fi
     fi 
-    if ( pmatch "$OSVER" "rhel*" ); then
+    if ( pmatch "$OSVER" "rhel*" || 
+         pmatch "$OSVER" "centos*" || 
+         pmatch "$OSVER" "rocky*" ||
+         pmatch "$OSVER" "ol*"); then
         #default_pkgdir="$INSTALLDIR/$OSVER/$ARCH"
         if [ $dir == $default_pkgdir ] || [ $dir == "$default_pkgdir/" ]; then
 
@@ -332,6 +343,17 @@ do
                          array_set_element os_path $index $ospkgdir_ok
                      done
                  fi   # x86_64
+            elif ( pmatch "$OSVER" "rhels8*" || 
+                   pmatch "$OSVER" "centos8*" || 
+                   pmatch "$OSVER" "rocky8*" ||
+                   pmatch "$OSVER" "ol8*"); then
+                 # for rhels8, centos8, ol8 and rocky8 the repodata is in ./BaseOS, ./AppStream, not in ./
+                 for arg in "BaseOS" "AppStream"
+                 do
+                     ospkgdir_ok="$ospkgdir/$arg"
+                     array_set_element os_path $index $ospkgdir_ok
+                     index=$(expr $index + 1)
+                 done
             fi # if...elif..fi
          fi  # eq default_pkgdir
       fi    # match rhel*
@@ -864,10 +886,10 @@ else
     fi
 
     if [ $keeprepo -ne 1 ]; then
-       #remove old repo
+       #remove old repo files
 	mkdir -p /etc/yum.repos.d
-        if [ -r "/etc/yum.repos.d/local-repository.repo" ]; then
-	    result=`rm /etc/yum.repos.d/local-repository.repo 2>&1`
+        if [ `ls -1 /etc/yum.repos.d/local-repository*.repo 2>/dev/null | wc -l` -gt 0 ]; then
+	    result=`rm /etc/yum.repos.d/local-repository*.repo 2>&1`
         fi
         rm /etc/yum.repos.d/$OSVER-path*.repo >/dev/null 2>&1
         result=`rm /etc/yum.repos.d/xCAT-$OSVER-path*.repo 2>&1`

--- a/xCAT/postscripts/otherpkgs
+++ b/xCAT/postscripts/otherpkgs
@@ -340,7 +340,8 @@ fi
         # (1)for rhels6, there is one repodata in the os base dir; so keep it here, and handle the other cases below
         # (2)for sles, we should specified the baseurl should be ./install/sles11/ppc64/1
         # (3)for SL5, we should append the /SL
-        # (4) for other os, we just keep it here.
+        # (4)for rhels8, centos8, ol8, and rocky8 we should append /BaseOS and /AppStream to base directory
+        # (5) for other os, we just keep it here.
         # For other pkg paths, we just keep it here.
         if [ $dir == $default_pkgdir ] || [ $dir == "$default_pkgdir/" ]; then
             if ( pmatch "$OSVER" "sle*" ); then
@@ -351,9 +352,18 @@ fi
                 ospkgdir="$ospkgdir/SL"
             fi
         fi
-        array_set_element os_path $index $ospkgdir
+        if ( ! pmatch "$OSVER" "rhels8*" && 
+             ! pmatch "$OSVER" "centos8*" && 
+             ! pmatch "$OSVER" "rocky8*" &&
+             ! pmatch "$OSVER" "ol8*"); then
+        # For rhels8, centos8, ol8, and rocky8 do not put $ospkgdir by itself
+            array_set_element os_path $index $ospkgdir
+        fi
 
-        if ( pmatch "$OSVER" "rhel*" ); then
+        if ( pmatch "$OSVER" "rhel*" || 
+             pmatch "$OSVER" "centos*" || 
+             pmatch "$OSVER" "rocky*" ||
+             pmatch "$OSVER" "ol*"); then
             #default_pkgdir="$INSTALLDIR/$OSVER/$ARCH"
             if [ $dir == $default_pkgdir ] || [ $dir == "$default_pkgdir/" ]; then
 
@@ -386,6 +396,17 @@ fi
                              array_set_element os_path $index $ospkgdir_ok
                          done
                      fi   # x86_64
+                elif ( pmatch "$OSVER" "rhels8*" || 
+                       pmatch "$OSVER" "centos8*" || 
+                       pmatch "$OSVER" "rocky8*" ||
+                       pmatch "$OSVER" "ol8*"); then
+                     # for rhels8, centos8 and rocky8 the repodata is in ./BaseOS, ./AppStream, not in ./
+                     for arg in "BaseOS" "AppStream"
+                     do
+                         ospkgdir_ok="$ospkgdir/$arg"
+                         array_set_element os_path $index $ospkgdir_ok
+                         index=$(expr $index + 1)
+                     done
                 fi # if...elif..fi
              fi  # eq default_pkgdir
           fi    # match rhel*
@@ -544,10 +565,10 @@ if ( ! ( pmatch "$OSVER" "sles10*" ) && [ $haszypper -eq 1 ] ); then
     result=`zypper --non-interactive --no-gpg-checks refresh 2>&1`
 
 elif ( ((pmatch "$OSVER" "rhel*") || (pmatch "$OSVER" "centos*") || (pmatch "$OSVER" "SL*")) && [ $hasyum -eq 1 ] ); then
-    #remove old repo
+    #remove old repo files
     mkdir -p /etc/yum.repos.d
-    if [ -r "/etc/yum.repos.d/local-repository.repo" ]; then
-        result=`rm /etc/yum.repos.d/local-repository.repo 2>&1`
+    if [ `ls -1 /etc/yum.repos.d/local-repository*.repo 2>/dev/null | wc -l` -gt 0 ]; then
+        result=`rm /etc/yum.repos.d/local-repository*.repo 2>&1`
     fi
     rm /etc/yum.repos.d/$OSVER-path*.repo >/dev/null 2>&1
     result=`rm /etc/yum.repos.d/xCAT-$OSVER-path*.repo 2>&1`


### PR DESCRIPTION
### The PR is to fix issue _#6577_ and _#6625_

This PR updates `ospkgs` and `otherpkgs` postscripts for RHEL8 and its variants by extending a section for "special cases" already handled by those postscripts.
1. Add `BaseOS` and `AppStream` subdirs to the path specified in the `pkgdir` attribute.
2. Remove `/etc/yum.repos.d/local-repository<x>.repo` files, not just `/etc/yum.repos.d/local-repository.repo`

### UT:

```
[root@c910f03c09k18 ~]# rinstall c910f03c09k20 osimage=rhels8.2.0-ppc64le-install-compute
Provision node(s): c910f03c09k20
[root@c910f03c09k18 ~]#

[root@c910f03c09k18 ~]# xdsh c910f03c09k20 ls /etc/yum.repos.d/
c910f03c09k20: local-repository-0.repo
c910f03c09k20: redhat.repo
[root@c910f03c09k18 ~]#

[root@c910f03c09k18 ~]# xdsh c910f03c09k20 cat /etc/yum.repos.d/local-repository-0.repo
c910f03c09k20: [local-rhels8.2.0-ppc64le--install-rhels8.2.0-ppc64le-BaseOS]
c910f03c09k20: name=xCAT configured yum repository for /install/rhels8.2.0/ppc64le/BaseOS
c910f03c09k20: baseurl=http://c910f03c09k18:80//install/rhels8.2.0/ppc64le/BaseOS
c910f03c09k20: enabled=1
c910f03c09k20: gpgcheck=0
c910f03c09k20:
c910f03c09k20: [local-rhels8.2.0-ppc64le--install-rhels8.2.0-ppc64le-AppStream]
c910f03c09k20: name=xCAT configured yum repository for /install/rhels8.2.0/ppc64le/AppStream
c910f03c09k20: baseurl=http://c910f03c09k18:80//install/rhels8.2.0/ppc64le/AppStream
c910f03c09k20: enabled=1
c910f03c09k20: gpgcheck=0
c910f03c09k20:
c910f03c09k20:
[root@c910f03c09k18 ~]#
```

```
[root@c910f03c09k18 postscripts]# updatenode c910f03c09k20
There were no syncfiles defined to process. File synchronization has completed.
Performing software maintenance operations. This could take a while, if there are packages to install.

c910f03c09k20: =============updatenode starting====================
c910f03c09k20: trying to download postscripts...
c910f03c09k20: postscripts downloaded successfully
c910f03c09k20: trying to get mypostscript from 10.3.9.18...
c910f03c09k20: postscript start..: ospkgs
c910f03c09k20: postscript end....: ospkgs exited with code 0
c910f03c09k20: postscript start..: otherpkgs
c910f03c09k20: otherpkgs: no extra rpms to install
c910f03c09k20: postscript end....: otherpkgs exited with code 0
c910f03c09k20: postscript start..: syscloneimgupdate
c910f03c09k20: postscript end....: syscloneimgupdate exited with code 0
c910f03c09k20: Running of Software Maintenance has completed.
c910f03c09k20: =============updatenode ending====================
c910f03c09k20: =============updatenode starting====================
c910f03c09k20: trying to download postscripts...
c910f03c09k20: postscripts downloaded successfully
c910f03c09k20: trying to get mypostscript from 10.3.9.18...
c910f03c09k20: postscript start..: syslog
c910f03c09k20: postscript end....: syslog exited with code 0
c910f03c09k20: postscript start..: remoteshell
c910f03c09k20:
c910f03c09k20: postscript end....: remoteshell exited with code 0
c910f03c09k20: postscript start..: syncfiles
c910f03c09k20: postscript end....: syncfiles exited with code 0
c910f03c09k20: postscript start..: otherpkgs
c910f03c09k20: otherpkgs: no extra rpms to install
c910f03c09k20: postscript end....: otherpkgs exited with code 0
c910f03c09k20: Running of postscripts has completed.
c910f03c09k20: =============updatenode ending====================


[root@c910f03c09k18 postscripts]# xdsh c910f03c09k20 ls /etc/yum.repos.d/
c910f03c09k20: redhat.repo
c910f03c09k20: xCAT-rhels8.2.0-path0.repo
c910f03c09k20: xCAT-rhels8.2.0-path1.repo
[root@c910f03c09k18 postscripts]#

[root@c910f03c09k18 postscripts]# xdsh c910f03c09k20 cat /etc/yum.repos.d/xCAT-rhels8.2.0-path0.repo
c910f03c09k20: [xCAT-rhels8.2.0-path0]
c910f03c09k20: name=xCAT-rhels8.2.0-path0
c910f03c09k20: baseurl=http://c910f03c09k18:80/install/rhels8.2.0/ppc64le/BaseOS
c910f03c09k20: enabled=1
c910f03c09k20: gpgcheck=0
c910f03c09k20: skip_if_unavailable=True

[root@c910f03c09k18 postscripts]# xdsh c910f03c09k20 cat /etc/yum.repos.d/xCAT-rhels8.2.0-path1.repo
c910f03c09k20: [xCAT-rhels8.2.0-path1]
c910f03c09k20: name=xCAT-rhels8.2.0-path1
c910f03c09k20: baseurl=http://c910f03c09k18:80/install/rhels8.2.0/ppc64le/AppStream
c910f03c09k20: enabled=1
c910f03c09k20: gpgcheck=0
c910f03c09k20: skip_if_unavailable=True
[root@c910f03c09k18 postscripts]#


[root@c910f03c09k18 postscripts]# xdsh c910f03c09k20 yum repolist -v
:
:
:
c910f03c09k20:
c910f03c09k20: Repo-id            : xCAT-rhels8.2.0-path0
c910f03c09k20: Repo-name          : xCAT-rhels8.2.0-path0
c910f03c09k20: Repo-revision      : 1585986738
c910f03c09k20: Repo-updated       : Sat Apr  4 03:52:18 2020
c910f03c09k20: Repo-pkgs          : 1265
c910f03c09k20: Repo-available-pkgs: 1263
c910f03c09k20: Repo-size          : 803 M
c910f03c09k20: Repo-baseurl       : http://c910f03c09k18:80/install/rhels8.2.0/ppc64le/BaseOS
c910f03c09k20: Repo-expire        : 172800 second(s) (last: Mon Aug  2 15:53:43 2021)
c910f03c09k20: Repo-filename      : /etc/yum.repos.d/xCAT-rhels8.2.0-path0.repo
c910f03c09k20:
c910f03c09k20: Repo-id            : xCAT-rhels8.2.0-path1
c910f03c09k20: Repo-name          : xCAT-rhels8.2.0-path1
c910f03c09k20: Repo-revision      : 1585986681
c910f03c09k20: Repo-updated       : Sat Apr  4 03:51:22 2020
c910f03c09k20: Repo-pkgs          : 4270
c910f03c09k20: Repo-available-pkgs: 3843
c910f03c09k20: Repo-size          : 5.1 G
c910f03c09k20: Repo-baseurl       : http://c910f03c09k18:80/install/rhels8.2.0/ppc64le/AppStream
c910f03c09k20: Repo-expire        : 172800 second(s) (last: Mon Aug  2 15:53:43 2021)
c910f03c09k20: Repo-filename      : /etc/yum.repos.d/xCAT-rhels8.2.0-path1.repo
c910f03c09k20: Total packages: 5535
[root@c910f03c09k18 postscripts]#
```