### PR TITLE
Support VM machine types specified through vm.othersettings

### DIFF
--- a/docs/source/guides/admin-guides/references/man5/nodetype.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/nodetype.5.rst
@@ -44,7 +44,7 @@ nodetype Attributes:
 
 \ **os**\ 
  
- The operating system deployed on this node.  Valid values: AIX, rhels\*,rhelc\*, rhas\*,centos\*,SL\*, fedora\*, sles\* (where \* is the version #). As a special case, if this is set to "boottarget", then it will use the initrd/kernel/parameters specified in the row in the boottarget table in which boottarget.bprofile equals nodetype.profile.
+ The operating system deployed on this node.  Valid values: AIX, rhels\*,rhelc\*, rhas\*,centos\*,rocky\*,SL\*, fedora\*, sles\* (where \* is the version #). As a special case, if this is set to "boottarget", then it will use the initrd/kernel/parameters specified in the row in the boottarget table in which boottarget.bprofile equals nodetype.profile.
  
 
 

--- a/docs/source/guides/admin-guides/references/man5/osimage.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/osimage.5.rst
@@ -104,7 +104,7 @@ osimage Attributes:
 
 \ **osvers**\ 
  
- The Linux operating system deployed on this node.  Valid values:  rhels\*,rhelc\*, rhas\*,centos\*,SL\*, fedora\*, sles\* (where \* is the version #).
+ The Linux operating system deployed on this node.  Valid values:  rhels\*,rhelc\*, rhas\*,centos\*,rocky\*,SL\*, fedora\*, sles\* (where \* is the version #).
  
 
 

--- a/docs/source/guides/admin-guides/references/man5/vm.5.rst
+++ b/docs/source/guides/admin-guides/references/man5/vm.5.rst
@@ -191,7 +191,19 @@ vm Attributes:
 
 \ **othersettings**\ 
  
- This allows specifying a semicolon delimited list of key->value pairs to include in a vmx file of VMware or KVM. For partitioning on normal power machines, this option is used to specify the hugepage and/or bsr information, the value is like:'hugepage:1,bsr=2'. For KVM cpu mode use either:'cpumode:host-passthrough' or 'cpumode:host-model'. This improves performance on x86 VMs significantly. For KVM cpu pinning, this option is used to specify the physical cpu set on the host, the value is like:"vcpupin:'0-15,^8'",Its syntax is a comma separated list and a special markup using '-' and '^' (ex. '0-4', '0-3,^2') can also be allowed, the '-' denotes the range and the '^' denotes exclusive. For KVM memory binding, the value is like:'membind:0', restrict a guest to allocate memory from the specified set of NUMA nodes. For PCI passthrough, the value is like:'devpassthrough:pci_0001_01_00_0,pci_0000_03_00_0', the value for PCI device format also can be like:'devpassthrough:0001:01:00.1', the PCI devices are assigned to a virtual machine, and the virtual machine can use this I/O exclusively, the devices list are a list of PCI device names delimited with comma, the PCI device names can be obtained by running \ **virsh nodedev-list**\  on the host.
+ This is a semicolon-delimited list of key-value pairs to be included in a vmx file of VMware or KVM. DO NOT use 'chdef <node> -p vmothersetting=...' to add new options to it because chdef uses commas, not semicolons, to separate items.
+           Hugepage on POWER systems:
+              Specify the hugepage and/or bsr (Barrier Synchronization Register) values, e.g., 'hugepage:1,bsr=2'.
+           KVM CPU mode:
+              Specify how the host CPUs are utilized, e.g., 'cpumode:host-passthrough', 'cpumode:host-model'. With the passthrough mode, the performance of x86 VMs can be improved significantly.
+           KVM CPU pinning:
+              Specify which host CPUs are used, e.g., 'vcpupin:'0-15,^8', where '-' denotes the range and '^' denotes exclusion. This option allows a comma-delimited list.
+           KVM memory binding:
+              Specify which host memmory modules are used, e.g., 'membind:0'. This option allows a guest to access specified memory regions.
+           PCI passthrough:
+              PCI devices can be assigned to a virtual machine for exclusive usage, e.g., 'devpassthrough:pci_0001_01_00_0,pci_0000_03_00_0'. A PCI device can also be expressed as 'devpassthrough:0001:01:00.1'. The devices are put in a comma-delimited list. The PCI device names can be obtained by running \ **virsh nodedev-list**\  on the host.
+           VM machine type:
+              Specify a machine type for VM creation on the host, e.g., 'machine:pc'. Typical machine types are pc, q35, and pseries.
  
 
 

--- a/docs/source/guides/admin-guides/references/man7/group.7.rst
+++ b/docs/source/guides/admin-guides/references/man7/group.7.rst
@@ -277,7 +277,19 @@ group Attributes:
 
 \ **dockerflag**\  (vm.othersettings)
  
- This allows specifying a semicolon delimited list of key->value pairs to include in a vmx file of VMware or KVM. For partitioning on normal power machines, this option is used to specify the hugepage and/or bsr information, the value is like:'hugepage:1,bsr=2'. For KVM cpu mode use either:'cpumode:host-passthrough' or 'cpumode:host-model'. This improves performance on x86 VMs significantly. For KVM cpu pinning, this option is used to specify the physical cpu set on the host, the value is like:"vcpupin:'0-15,^8'",Its syntax is a comma separated list and a special markup using '-' and '^' (ex. '0-4', '0-3,^2') can also be allowed, the '-' denotes the range and the '^' denotes exclusive. For KVM memory binding, the value is like:'membind:0', restrict a guest to allocate memory from the specified set of NUMA nodes. For PCI passthrough, the value is like:'devpassthrough:pci_0001_01_00_0,pci_0000_03_00_0', the value for PCI device format also can be like:'devpassthrough:0001:01:00.1', the PCI devices are assigned to a virtual machine, and the virtual machine can use this I/O exclusively, the devices list are a list of PCI device names delimited with comma, the PCI device names can be obtained by running \ **virsh nodedev-list**\  on the host.
+ This is a semicolon-delimited list of key-value pairs to be included in a vmx file of VMware or KVM. DO NOT use 'chdef <node> -p vmothersetting=...' to add new options to it because chdef uses commas, not semicolons, to separate items.
+           Hugepage on POWER systems:
+              Specify the hugepage and/or bsr (Barrier Synchronization Register) values, e.g., 'hugepage:1,bsr=2'.
+           KVM CPU mode:
+              Specify how the host CPUs are utilized, e.g., 'cpumode:host-passthrough', 'cpumode:host-model'. With the passthrough mode, the performance of x86 VMs can be improved significantly.
+           KVM CPU pinning:
+              Specify which host CPUs are used, e.g., 'vcpupin:'0-15,^8', where '-' denotes the range and '^' denotes exclusion. This option allows a comma-delimited list.
+           KVM memory binding:
+              Specify which host memmory modules are used, e.g., 'membind:0'. This option allows a guest to access specified memory regions.
+           PCI passthrough:
+              PCI devices can be assigned to a virtual machine for exclusive usage, e.g., 'devpassthrough:pci_0001_01_00_0,pci_0000_03_00_0'. A PCI device can also be expressed as 'devpassthrough:0001:01:00.1'. The devices are put in a comma-delimited list. The PCI device names can be obtained by running \ **virsh nodedev-list**\  on the host.
+           VM machine type:
+              Specify a machine type for VM creation on the host, e.g., 'machine:pc'. Typical machine types are pc, q35, and pseries.
  
 
 
@@ -721,7 +733,7 @@ group Attributes:
 
 \ **os**\  (nodetype.os)
  
- The operating system deployed on this node.  Valid values: AIX, rhels\*,rhelc\*, rhas\*,centos\*,SL\*, fedora\*, sles\* (where \* is the version #). As a special case, if this is set to "boottarget", then it will use the initrd/kernel/parameters specified in the row in the boottarget table in which boottarget.bprofile equals nodetype.profile.
+ The operating system deployed on this node.  Valid values: AIX, rhels\*,rhelc\*, rhas\*,centos\*,rocky\*,SL\*, fedora\*, sles\* (where \* is the version #). As a special case, if this is set to "boottarget", then it will use the initrd/kernel/parameters specified in the row in the boottarget table in which boottarget.bprofile equals nodetype.profile.
  
 
 
@@ -1330,7 +1342,19 @@ group Attributes:
 
 \ **vmothersetting**\  (vm.othersettings)
  
- This allows specifying a semicolon delimited list of key->value pairs to include in a vmx file of VMware or KVM. For partitioning on normal power machines, this option is used to specify the hugepage and/or bsr information, the value is like:'hugepage:1,bsr=2'. For KVM cpu mode use either:'cpumode:host-passthrough' or 'cpumode:host-model'. This improves performance on x86 VMs significantly. For KVM cpu pinning, this option is used to specify the physical cpu set on the host, the value is like:"vcpupin:'0-15,^8'",Its syntax is a comma separated list and a special markup using '-' and '^' (ex. '0-4', '0-3,^2') can also be allowed, the '-' denotes the range and the '^' denotes exclusive. For KVM memory binding, the value is like:'membind:0', restrict a guest to allocate memory from the specified set of NUMA nodes. For PCI passthrough, the value is like:'devpassthrough:pci_0001_01_00_0,pci_0000_03_00_0', the value for PCI device format also can be like:'devpassthrough:0001:01:00.1', the PCI devices are assigned to a virtual machine, and the virtual machine can use this I/O exclusively, the devices list are a list of PCI device names delimited with comma, the PCI device names can be obtained by running \ **virsh nodedev-list**\  on the host.
+ This is a semicolon-delimited list of key-value pairs to be included in a vmx file of VMware or KVM. DO NOT use 'chdef <node> -p vmothersetting=...' to add new options to it because chdef uses commas, not semicolons, to separate items.
+           Hugepage on POWER systems:
+              Specify the hugepage and/or bsr (Barrier Synchronization Register) values, e.g., 'hugepage:1,bsr=2'.
+           KVM CPU mode:
+              Specify how the host CPUs are utilized, e.g., 'cpumode:host-passthrough', 'cpumode:host-model'. With the passthrough mode, the performance of x86 VMs can be improved significantly.
+           KVM CPU pinning:
+              Specify which host CPUs are used, e.g., 'vcpupin:'0-15,^8', where '-' denotes the range and '^' denotes exclusion. This option allows a comma-delimited list.
+           KVM memory binding:
+              Specify which host memmory modules are used, e.g., 'membind:0'. This option allows a guest to access specified memory regions.
+           PCI passthrough:
+              PCI devices can be assigned to a virtual machine for exclusive usage, e.g., 'devpassthrough:pci_0001_01_00_0,pci_0000_03_00_0'. A PCI device can also be expressed as 'devpassthrough:0001:01:00.1'. The devices are put in a comma-delimited list. The PCI device names can be obtained by running \ **virsh nodedev-list**\  on the host.
+           VM machine type:
+              Specify a machine type for VM creation on the host, e.g., 'machine:pc'. Typical machine types are pc, q35, and pseries.
  
 
 

--- a/docs/source/guides/admin-guides/references/man7/node.7.rst
+++ b/docs/source/guides/admin-guides/references/man7/node.7.rst
@@ -289,7 +289,19 @@ node Attributes:
 
 \ **dockerflag**\  (vm.othersettings)
  
- This allows specifying a semicolon delimited list of key->value pairs to include in a vmx file of VMware or KVM. For partitioning on normal power machines, this option is used to specify the hugepage and/or bsr information, the value is like:'hugepage:1,bsr=2'. For KVM cpu mode use either:'cpumode:host-passthrough' or 'cpumode:host-model'. This improves performance on x86 VMs significantly. For KVM cpu pinning, this option is used to specify the physical cpu set on the host, the value is like:"vcpupin:'0-15,^8'",Its syntax is a comma separated list and a special markup using '-' and '^' (ex. '0-4', '0-3,^2') can also be allowed, the '-' denotes the range and the '^' denotes exclusive. For KVM memory binding, the value is like:'membind:0', restrict a guest to allocate memory from the specified set of NUMA nodes. For PCI passthrough, the value is like:'devpassthrough:pci_0001_01_00_0,pci_0000_03_00_0', the value for PCI device format also can be like:'devpassthrough:0001:01:00.1', the PCI devices are assigned to a virtual machine, and the virtual machine can use this I/O exclusively, the devices list are a list of PCI device names delimited with comma, the PCI device names can be obtained by running \ **virsh nodedev-list**\  on the host.
+ This is a semicolon-delimited list of key-value pairs to be included in a vmx file of VMware or KVM. DO NOT use 'chdef <node> -p vmothersetting=...' to add new options to it because chdef uses commas, not semicolons, to separate items.
+           Hugepage on POWER systems:
+              Specify the hugepage and/or bsr (Barrier Synchronization Register) values, e.g., 'hugepage:1,bsr=2'.
+           KVM CPU mode:
+              Specify how the host CPUs are utilized, e.g., 'cpumode:host-passthrough', 'cpumode:host-model'. With the passthrough mode, the performance of x86 VMs can be improved significantly.
+           KVM CPU pinning:
+              Specify which host CPUs are used, e.g., 'vcpupin:'0-15,^8', where '-' denotes the range and '^' denotes exclusion. This option allows a comma-delimited list.
+           KVM memory binding:
+              Specify which host memmory modules are used, e.g., 'membind:0'. This option allows a guest to access specified memory regions.
+           PCI passthrough:
+              PCI devices can be assigned to a virtual machine for exclusive usage, e.g., 'devpassthrough:pci_0001_01_00_0,pci_0000_03_00_0'. A PCI device can also be expressed as 'devpassthrough:0001:01:00.1'. The devices are put in a comma-delimited list. The PCI device names can be obtained by running \ **virsh nodedev-list**\  on the host.
+           VM machine type:
+              Specify a machine type for VM creation on the host, e.g., 'machine:pc'. Typical machine types are pc, q35, and pseries.
  
 
 
@@ -727,7 +739,7 @@ node Attributes:
 
 \ **os**\  (nodetype.os)
  
- The operating system deployed on this node.  Valid values: AIX, rhels\*,rhelc\*, rhas\*,centos\*,SL\*, fedora\*, sles\* (where \* is the version #). As a special case, if this is set to "boottarget", then it will use the initrd/kernel/parameters specified in the row in the boottarget table in which boottarget.bprofile equals nodetype.profile.
+ The operating system deployed on this node.  Valid values: AIX, rhels\*,rhelc\*, rhas\*,centos\*,rocky\*,SL\*, fedora\*, sles\* (where \* is the version #). As a special case, if this is set to "boottarget", then it will use the initrd/kernel/parameters specified in the row in the boottarget table in which boottarget.bprofile equals nodetype.profile.
  
 
 
@@ -1366,7 +1378,19 @@ node Attributes:
 
 \ **vmothersetting**\  (vm.othersettings)
  
- This allows specifying a semicolon delimited list of key->value pairs to include in a vmx file of VMware or KVM. For partitioning on normal power machines, this option is used to specify the hugepage and/or bsr information, the value is like:'hugepage:1,bsr=2'. For KVM cpu mode use either:'cpumode:host-passthrough' or 'cpumode:host-model'. This improves performance on x86 VMs significantly. For KVM cpu pinning, this option is used to specify the physical cpu set on the host, the value is like:"vcpupin:'0-15,^8'",Its syntax is a comma separated list and a special markup using '-' and '^' (ex. '0-4', '0-3,^2') can also be allowed, the '-' denotes the range and the '^' denotes exclusive. For KVM memory binding, the value is like:'membind:0', restrict a guest to allocate memory from the specified set of NUMA nodes. For PCI passthrough, the value is like:'devpassthrough:pci_0001_01_00_0,pci_0000_03_00_0', the value for PCI device format also can be like:'devpassthrough:0001:01:00.1', the PCI devices are assigned to a virtual machine, and the virtual machine can use this I/O exclusively, the devices list are a list of PCI device names delimited with comma, the PCI device names can be obtained by running \ **virsh nodedev-list**\  on the host.
+ This is a semicolon-delimited list of key-value pairs to be included in a vmx file of VMware or KVM. DO NOT use 'chdef <node> -p vmothersetting=...' to add new options to it because chdef uses commas, not semicolons, to separate items.
+           Hugepage on POWER systems:
+              Specify the hugepage and/or bsr (Barrier Synchronization Register) values, e.g., 'hugepage:1,bsr=2'.
+           KVM CPU mode:
+              Specify how the host CPUs are utilized, e.g., 'cpumode:host-passthrough', 'cpumode:host-model'. With the passthrough mode, the performance of x86 VMs can be improved significantly.
+           KVM CPU pinning:
+              Specify which host CPUs are used, e.g., 'vcpupin:'0-15,^8', where '-' denotes the range and '^' denotes exclusion. This option allows a comma-delimited list.
+           KVM memory binding:
+              Specify which host memmory modules are used, e.g., 'membind:0'. This option allows a guest to access specified memory regions.
+           PCI passthrough:
+              PCI devices can be assigned to a virtual machine for exclusive usage, e.g., 'devpassthrough:pci_0001_01_00_0,pci_0000_03_00_0'. A PCI device can also be expressed as 'devpassthrough:0001:01:00.1'. The devices are put in a comma-delimited list. The PCI device names can be obtained by running \ **virsh nodedev-list**\  on the host.
+           VM machine type:
+              Specify a machine type for VM creation on the host, e.g., 'machine:pc'. Typical machine types are pc, q35, and pseries.
  
 
 

--- a/docs/source/guides/admin-guides/references/man7/osimage.7.rst
+++ b/docs/source/guides/admin-guides/references/man7/osimage.7.rst
@@ -249,7 +249,7 @@ osimage Attributes:
 
 \ **osvers**\  (osimage.osvers)
  
- The Linux operating system deployed on this node.  Valid values:  rhels\*,rhelc\*, rhas\*,centos\*,SL\*, fedora\*, sles\* (where \* is the version #).
+ The Linux operating system deployed on this node.  Valid values:  rhels\*,rhelc\*, rhas\*,centos\*,rocky\*,SL\*, fedora\*, sles\* (where \* is the version #).
  
 
 

--- a/perl-xCAT/xCAT/Schema.pm
+++ b/perl-xCAT/xCAT/Schema.pm
@@ -226,7 +226,19 @@ qq{ link,ro - The file is readonly, and will be placed in tmpfs on the booted no
 'vncport' => 'Tracks the current VNC display port (currently not meant to be set',
 'textconsole' => 'Tracks the Psuedo-TTY that maps to the serial port or console of a VM',
 'powerstate' => "This flag is used by xCAT to track the last known power state of the VM.",
-'othersettings' => "This allows specifying a semicolon delimited list of key->value pairs to include in a vmx file of VMware or KVM. For partitioning on normal power machines, this option is used to specify the hugepage and/or bsr information, the value is like:'hugepage:1,bsr=2'. For KVM cpu mode use either:'cpumode:host-passthrough' or 'cpumode:host-model'. This improves performance on x86 VMs significantly. For KVM cpu pinning, this option is used to specify the physical cpu set on the host, the value is like:\"vcpupin:'0-15,^8'\",Its syntax is a comma separated list and a special markup using '-' and '^' (ex. '0-4', '0-3,^2') can also be allowed, the '-' denotes the range and the '^' denotes exclusive. For KVM memory binding, the value is like:'membind:0', restrict a guest to allocate memory from the specified set of NUMA nodes. For PCI passthrough, the value is like:'devpassthrough:pci_0001_01_00_0,pci_0000_03_00_0', the value for PCI device format also can be like:'devpassthrough:0001:01:00.1', the PCI devices are assigned to a virtual machine, and the virtual machine can use this I/O exclusively, the devices list are a list of PCI device names delimited with comma, the PCI device names can be obtained by running B<virsh nodedev-list> on the host.",
+'othersettings' => "This is a semicolon-delimited list of key-value pairs to be included in a vmx file of VMware or KVM. DO NOT use 'chdef <node> -p vmothersetting=...' to add new options to it because chdef uses commas, not semicolons, to separate items.
+          Hugepage on POWER systems:
+             Specify the hugepage and/or bsr (Barrier Synchronization Register) values, e.g., 'hugepage:1,bsr=2'.
+          KVM CPU mode:
+             Specify how the host CPUs are utilized, e.g., 'cpumode:host-passthrough', 'cpumode:host-model'. With the passthrough mode, the performance of x86 VMs can be improved significantly.
+          KVM CPU pinning:
+             Specify which host CPUs are used, e.g., 'vcpupin:'0-15,^8', where '-' denotes the range and '^' denotes exclusion. This option allows a comma-delimited list.
+          KVM memory binding:
+             Specify which host memmory modules are used, e.g., 'membind:0'. This option allows a guest to access specified memory regions.
+          PCI passthrough:
+             PCI devices can be assigned to a virtual machine for exclusive usage, e.g., 'devpassthrough:pci_0001_01_00_0,pci_0000_03_00_0'. A PCI device can also be expressed as 'devpassthrough:0001:01:00.1'. The devices are put in a comma-delimited list. The PCI device names can be obtained by running B<virsh nodedev-list> on the host.
+          VM machine type:
+             Specify a machine type for VM creation on the host, e.g., 'machine:pc'. Typical machine types are pc, q35, and pseries.",
 'guestostype' => "This allows administrator to specify an identifier for OS to pass through to virtualization stack.  Normally this should be ignored as xCAT will translate from nodetype.os rather than requiring this field be used\n",
 'beacon' => "This flag is used by xCAT to track the state of the identify LED with respect to the VM.",
 'datacenter' => "Optionally specify a datacenter for the VM to exist in (only applicable to VMWare)",

--- a/xCAT-server/lib/xcat/plugins/kvm.pm
+++ b/xCAT-server/lib/xcat/plugins/kvm.pm
@@ -731,6 +731,7 @@ sub build_xmldesc {
     my @passthrudevices;
     my $memnumanodes;
     my $cpumode;
+    my $machine_type;
     my $advsettings = undef;
     if (defined $confdata->{vm}->{$node}->[0]->{othersettings}) {
         $advsettings = $confdata->{vm}->{$node}->[0]->{othersettings};
@@ -742,6 +743,7 @@ sub build_xmldesc {
     #pci passthrough:    "devpassthrough:<pci device name1>,<pci device name2>..."
     #memory binding:     "membind:<numa node set>"
     #cpu mode:           "cpumode:<host-model|host-passthrough>"
+    #machine type:       "machine:<pc|q35|any valid VM machine type>"
     if ($advsettings) {
         my @tmp_array = split ";", $advsettings;
         foreach (@tmp_array) {
@@ -767,7 +769,15 @@ sub build_xmldesc {
             if (/cpumode:(.*)/) {
                 $cpumode = $1;
             }
+            if (/machine:(.*)/) {
+                $machine_type = $1;
+            }
         }
+    }
+
+    # Support VM machine types specified through vm.othersettings, e.g., q35, pseries-rhel7.4.0.
+    if (defined $machine_type) {
+        $xtree{os}->{type}->{machine} = $machine_type;
     }
 
     #prepare the xml hash for memory binding


### PR DESCRIPTION
This PR is to address https://github.com/xcat2/xcat-core/issues/6934.

Thanks to rbudden for providing the code. The comments are slightly enhanced.