### PR TITLE
Update kernel options to disable selinux on OL and Rocky

### DIFF
--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -762,7 +762,7 @@ sub mknetboot
         }
 
         # turn off the selinux
-        if ($osver =~ m/(fedora12|fedora13|rhels7|rhels8)/) {
+        if ($osver =~ m/(fedora12|fedora13|rhels7|rhels8|ol7|ol8|rocky8)/) {
             $kcmdline .= " selinux=0 ";
         }
 


### PR DESCRIPTION
### The PR is to add to PR _#7014_

Set `selinux=0` of Oracle and Rocky also.