### PR TITLE
Allow Genesis Builder to run on RHEL8 Systems

### DIFF
--- a/xCAT-genesis-builder/README.md
+++ b/xCAT-genesis-builder/README.md
@@ -1,0 +1,168 @@
+# xCAT-genesis-builder
+
+xCAT-genesis-builder is a utility for building base initrd images for deploying
+diskless nodes in your cluster.  This tool is required only if you have the
+intention of deploying diskless nodes within your xCAT cluster.
+
+# Background
+
+For every architecture in your cluster, be it x86_64, ppc64, or arm, you need to have a default
+initrd image for performing the initial boot and deploying the diskless operating system.
+
+If for some reason, the versions included in the xCAT repository are insufficient, you can simply
+run this utility on the target architecture which will build an RPM designed for the target
+architecture.  You can then transfer that RPM to your xCAT servers, install it, and then rebuild
+the various netboot images.
+
+# Pre-requisites
+
+The xCAT-genesis-builder package is designed to be run from a Red Hat compatible operating system
+that support the Red Hat Package Manager (rpm) development tools.  The script `buildrpm` will
+attempt to install some of these core packages if they are not already present.
+
+## Instructions
+
+First, you need to clone the xcat-core repo to the target architecture using the following
+command:
+
+```sh
+git clone -b master https://github.com/xcat2/xcat-core.git
+```
+
+Once there, you can choose to either build the entire package, or more simply, 
+do the following (assuming 2.16.10 is your xCAT version):
+
+```sh
+cd xcat-core/xCAT-genesis-builder
+sed -i 's/%%REPLACE_CURRENT_VERSION%%/2.16.10/g' xCAT-genesis-base.spec
+buildrpm
+```
+
+If this command is successful, runs error free, it will generate an RPM that you can transfer
+to your xCAT server and install and then rebuild your netboot images prior to deploying
+the netboot images to your nodes.
+
+The RPM will be placed into the following directory `/root/rpmbuild/RPMS/noarch` if the build
+is successful.
+
+When running the `buildrpm` the output should look similar to the following:
+
+```sh
+[root@vmhost6 xcat-core]# cd xCAT-genesis-builder
+[root@vmhost6 xCAT-genesis-builder]# ./buildrpm
+Last metadata expiration check: 3:03:21 ago on Fri 27 Aug 2021 06:07:01 AM EDT.
+Package rpmdevtools-8.10-8.el8.noarch is already installed.
+Package rpm-build-4.14.3-14.el8_4.x86_64 is already installed.
+Package screen-4.6.2-12.el8.x86_64 is already installed.
+Package lldpad-1.0.1-13.git036e314.el8.x86_64 is already installed.
+Package mstflint-4.15.0-1.el8.x86_64 is already installed.
+Dependencies resolved.
+Nothing to do.
+Complete!
+Last metadata expiration check: 3:03:23 ago on Fri 27 Aug 2021 06:07:01 AM EDT.
+Package efibootmgr-16-1.el8.x86_64 is already installed.
+Package bc-1.07.1-5.el8.x86_64 is already installed.
+Dependencies resolved.
+Nothing to do.
+Complete!
+/root/xcat-core/xCAT-genesis-builder
+cp: -r not specified; omitting directory '/root/xcat-core/xCAT-genesis-builder/debian'
+Creating the initramfs in /tmp/xcatgenesis.351827.rfs using dracut ...
+
+Expanding the initramfs into /tmp/xcatgenesis.351827/opt/xcat/share/xcat/netboot/genesis/x86_64/fs ...
+623218 blocks
+Adding perl libary /usr/share/perl5
+Adding perl libary /usr/lib64/perl5
+Adding kernel /boot/vmlinuz-x86_64 ...
+/root/xcat-core/xCAT-genesis-builder
+Tarring /tmp/xcatgenesis.351827/opt into /root/rpmbuild/SOURCES/xCAT-genesis-base-x86_64.tar.bz2 ...
+Building xCAT-genesis-base rpm from /root/rpmbuild/SOURCES/xCAT-genesis-base-x86_64.tar.bz2 and /root/xcat-core/xCAT-genesis-builder/xCAT-genesis-base.spec ...
+Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.z5jzb9
++ umask 022
++ cd /root/rpmbuild/BUILD
++ exit 0
+Executing(%build): /bin/sh -e /var/tmp/rpm-tmp.Q5Rg87
++ umask 022
++ cd /root/rpmbuild/BUILD
++ exit 0
+Executing(%install): /bin/sh -e /var/tmp/rpm-tmp.F7t435
++ umask 022
++ cd /root/rpmbuild/BUILD
++ '[' /root/rpmbuild/BUILDROOT/xCAT-genesis-base-x86_64-2.16.10-snap202108270912.x86_64 '!=' / ']'
++ rm -rf /root/rpmbuild/BUILDROOT/xCAT-genesis-base-x86_64-2.16.10-snap202108270912.x86_64
+++ dirname /root/rpmbuild/BUILDROOT/xCAT-genesis-base-x86_64-2.16.10-snap202108270912.x86_64
++ mkdir -p /root/rpmbuild/BUILDROOT
++ mkdir /root/rpmbuild/BUILDROOT/xCAT-genesis-base-x86_64-2.16.10-snap202108270912.x86_64
++ rm -rf /root/rpmbuild/BUILDROOT/xCAT-genesis-base-x86_64-2.16.10-snap202108270912.x86_64
++ mkdir -p /root/rpmbuild/BUILDROOT/xCAT-genesis-base-x86_64-2.16.10-snap202108270912.x86_64
++ cd /root/rpmbuild/BUILDROOT/xCAT-genesis-base-x86_64-2.16.10-snap202108270912.x86_64
++ tar jxf /root/rpmbuild/SOURCES/xCAT-genesis-base-x86_64.tar.bz2
++ cd -
+/root/rpmbuild/BUILD
++ :
+Processing files: xCAT-genesis-base-x86_64-2.16.10-snap202108270912.noarch
+Provides: xCAT-genesis-base-x86_64 = 2:2.16.10-snap202108270912
+Requires(interp): /bin/sh
+Requires(rpmlib): rpmlib(BuiltinLuaScripts) <= 4.2.2-1 rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PartialHardlinkSets) <= 4.0.4-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
+Requires(post): /bin/sh
+Conflicts: xCAT-genesis-scripts-x86_64 < 1:2.13.10
+warning: Arch dependent binaries in noarch package
+Checking for unpackaged file(s): /usr/lib/rpm/check-files /root/rpmbuild/BUILDROOT/xCAT-genesis-base-x86_64-2.16.10-snap202108270912.x86_64
+Wrote: /root/rpmbuild/SRPMS/xCAT-genesis-base-x86_64-2.16.10-snap202108270912.src.rpm
+Wrote: /root/rpmbuild/RPMS/noarch/xCAT-genesis-base-x86_64-2.16.10-snap202108270912.noarch.rpm
+Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.yShjx5
++ umask 022
++ cd /root/rpmbuild/BUILD
++ /usr/bin/rm -rf /root/rpmbuild/BUILDROOT/xCAT-genesis-base-x86_64-2.16.10-snap202108270912.x86_64
++ exit 0
+```
+
+Once you transfer the RPM to your xCAT server, you should install it.  However, if there is
+already an xCAT-genesis-base-* RPM for your architecture installed, you will have to uninstall
+it first using the command below, assuming x86_64 architecture.  We use the 
+`--nodeps` option as the uninstall will fail due to other dependencies.
+
+```sh
+rpm -e --nodeps xCAT-genesis-base-x86_64*
+```
+
+To install the new RPM, issue the following command, using the 2.16.10 example from above:
+
+```sh
+rpm -ivh xCAT-genesis-base*.rpm
+```
+
+Now, assuming that the architecture that you have built the xCAT-genesis-base for was ppc64,
+you would then, on the xCAT server run the following command:
+
+```sh
+mknb ppc64
+```
+
+At this point in time, you can re-generate your netboot images by running the following
+commands:
+
+```sh
+rmimage rhels8.4.0-ppc64le-netboot-image
+genimage rhels8.4.0-ppc64le-netboot-image
+packimage rhels8.4.0-ppc64le-netboot-image
+```
+
+Finally, attempt a re-imaging of a host using the following command:
+
+```sh
+rinstall hostname
+rcons hostname
+```
+
+If you rcons into the hosts, you can watch the actual initilization of the operating
+system with the resulting netboot image.
+
+# Open Source License
+
+xCAT is made available under the EPL license: https://opensource.org/licenses/eclipse-1.0.php
+
+# Developers
+
+Want to help? Check out the [developers guide](http://xcat-docs.readthedocs.io/en/latest/developers)!
+

--- a/xCAT-genesis-builder/buildrpm
+++ b/xCAT-genesis-builder/buildrpm
@@ -13,6 +13,9 @@ DIR=`dirname $0`
 DIR=`readlink -f $DIR`
 BUILDARCH=`uname -m`
 
+# Install required packages
+yum -y install rpmdevtools rpm-build screen lldpad mstflint
+
 rpmdev-setuptree
 
 #For Openpower
@@ -67,21 +70,23 @@ if [ $BUILDARCH = "x86_64" ]; then
     sed -i 's/ mkreiserfs//' $DRACUTMODDIR/install
     sed -i 's/ reiserfstune//' $DRACUTMODDIR/install
     sed -i 's/ vconfig//' $DRACUTMODDIR/install
+	sed -i 's/mkfs.btrfs//' $DRACUTMODDIR/install
     sed -i 's/\/lib\/terminfo\/l\/linux/\/usr\/share\/terminfo\/l\/linux/g' $DRACUTMODDIR/install
     sed -i 's/\/lib\/terminfo\/v\/vt100/\/usr\/share\/terminfo\/v\/vt100/g' $DRACUTMODDIR/install
+	sed -i 's/mkfs.btrfs//' $DRACUTMODDIR/install
 fi
 if [ "$HOSTOS" = "mcp" ]; then
-        #Special handlings for MCP PPC64 platform building.
-        if [ $BUILDARCH = "ppc64" ]; then
-            sed -i 's/dracut_install efibootmgr//' $DRACUTMODDIR/install
-            sed -i 's/dracut_install dmidecode \/usr\/lib64\/libstdc++.so.5//' $DRACUTMODDIR/install
-            sed -i 's/dmidecode//' $DRACUTMODDIR/install
-            sed -i 's/\/lib\/ld-linux.so.2/\/usr\/lib64\/ld-2.17.so/' $DRACUTMODDIR/install
-            sed -i 's/\/lib64\/libsysfs.so.2//' $DRACUTMODDIR/install
-            sed -i '/\/usr\/sbin\/iprconfig/ d' $DRACUTMODDIR/install
-        else
-            sed -i 's/\/lib\/ld-linux.so.2/\/usr\/lib64\/ld-linux-x86-64.so.2/' $DRACUTMODDIR/install
-        fi
+	#Special handlings for MCP PPC64 platform building.
+	if [ $BUILDARCH = "ppc64" ]; then
+		sed -i 's/dracut_install efibootmgr//' $DRACUTMODDIR/install
+		sed -i 's/dracut_install dmidecode \/usr\/lib64\/libstdc++.so.5//' $DRACUTMODDIR/install
+		sed -i 's/dmidecode//' $DRACUTMODDIR/install
+		sed -i 's/\/lib\/ld-linux.so.2/\/usr\/lib64\/ld-2.17.so/' $DRACUTMODDIR/install
+		sed -i 's/\/lib64\/libsysfs.so.2//' $DRACUTMODDIR/install
+		sed -i '/\/usr\/sbin\/iprconfig/ d' $DRACUTMODDIR/install
+	else
+		sed -i 's/\/lib\/ld-linux.so.2/\/usr\/lib64\/ld-linux-x86-64.so.2/' $DRACUTMODDIR/install
+	fi
 	sed -i 's/mkfs.btrfs//' $DRACUTMODDIR/install
 	sed -i 's/\/etc\/redhat-release/\/etc\/base-release \/etc\/system-release/' $DRACUTMODDIR/install
 	sed -i 's/btrfs//' $DRACUTMODDIR/installkernel
@@ -90,19 +95,19 @@ if [ "$HOSTOS" = "mcp" ]; then
 
 	sed -i 's/\/lib64\/libnss_dns-2.12.so/\/usr\/lib64\/libnss_dns-2.17.so/' $DRACUTMODDIR/install
 	sed -i 's/\/lib64\/libnss_dns.so.2/\/usr\/lib64\/libnss_dns.so.2/' $DRACUTMODDIR/install
-        sed -i 's/\/lib\/libc.so.6/\/usr\/lib64\/libc.so.6/' $DRACUTMODDIR/install
-        sed -i 's/\/lib\/libdl.so.2/\/usr\/lib64\/libdl.so.2/' $DRACUTMODDIR/install
-        sed -i 's/\/lib\/libm.so.6/\/usr\/lib64\/libm.so.6/' $DRACUTMODDIR/install
-        sed -i 's/\/usr\/lib\/libstdc++.so.6.0.13/\/usr\/lib64\/libstdc++.so.6.0.19/' $DRACUTMODDIR/install
-        sed -i 's/\/usr\/lib64\/libstdc++.so.5//' $DRACUTMODDIR/install
-        sed -i 's/\/lib\/libpthread.so.0/\/usr\/lib64\/libpthread.so.0/' $DRACUTMODDIR/install
-        sed -i 's/\/lib\/libncurses.so.5.7/\/usr\/lib64\/libncurses.so.5.9/' $DRACUTMODDIR/install
-        sed -i 's/\/lib\/libgcc_s.so.1/\/usr\/lib64\/libgcc_s.so.1/' $DRACUTMODDIR/install
-        sed -i 's/\/lib\/libtinfo.so.5.7/\/usr\/lib64\/libtinfo.so.5.9/' $DRACUTMODDIR/install
-        sed -i 's/\/usr\/lib64\/libsasl2.so.2/\/usr\/lib64\/libsasl2.so.3/' $DRACUTMODDIR/install
+	sed -i 's/\/lib\/libc.so.6/\/usr\/lib64\/libc.so.6/' $DRACUTMODDIR/install
+	sed -i 's/\/lib\/libdl.so.2/\/usr\/lib64\/libdl.so.2/' $DRACUTMODDIR/install
+	sed -i 's/\/lib\/libm.so.6/\/usr\/lib64\/libm.so.6/' $DRACUTMODDIR/install
+	sed -i 's/\/usr\/lib\/libstdc++.so.6.0.13/\/usr\/lib64\/libstdc++.so.6.0.19/' $DRACUTMODDIR/install
+	sed -i 's/\/usr\/lib64\/libstdc++.so.5//' $DRACUTMODDIR/install
+	sed -i 's/\/lib\/libpthread.so.0/\/usr\/lib64\/libpthread.so.0/' $DRACUTMODDIR/install
+	sed -i 's/\/lib\/libncurses.so.5.7/\/usr\/lib64\/libncurses.so.5.9/' $DRACUTMODDIR/install
+	sed -i 's/\/lib\/libgcc_s.so.1/\/usr\/lib64\/libgcc_s.so.1/' $DRACUTMODDIR/install
+	sed -i 's/\/lib\/libtinfo.so.5.7/\/usr\/lib64\/libtinfo.so.5.9/' $DRACUTMODDIR/install
+	sed -i 's/\/usr\/lib64\/libsasl2.so.2/\/usr\/lib64\/libsasl2.so.3/' $DRACUTMODDIR/install
 
-        sed -i 's/\/lib\/terminfo\/l\/linux/\/usr\/share\/terminfo\/l\/linux/g' $DRACUTMODDIR/install
-        sed -i 's/\/lib\/terminfo\/v\/vt100/\/usr\/share\/terminfo\/v\/vt100/g' $DRACUTMODDIR/install
+	sed -i 's/\/lib\/terminfo\/l\/linux/\/usr\/share\/terminfo\/l\/linux/g' $DRACUTMODDIR/install
+	sed -i 's/\/lib\/terminfo\/v\/vt100/\/usr\/share\/terminfo\/v\/vt100/g' $DRACUTMODDIR/install
 
 	# these are needed for sysclone, but are not yet in mcp
 	sed -i 's/ bc//' $DRACUTMODDIR/install
@@ -118,26 +123,26 @@ if [ "$HOSTOS" = "mcp" ]; then
 	sed -i 's/ vconfig//' $DRACUTMODDIR/install
 	sed -i 's/ killall//' $DRACUTMODDIR/install
 
-        # These timezone files are not available in the latest mcp build
-        sed -i 's/dracut_install \/usr\/share\/zoneinfo\/posix\/Asia\/Riyadh87//' $DRACUTMODDIR/install
-        sed -i 's/dracut_install \/usr\/share\/zoneinfo\/posix\/Asia\/Riyadh88//' $DRACUTMODDIR/install
-        sed -i 's/dracut_install \/usr\/share\/zoneinfo\/posix\/Asia\/Riyadh89//' $DRACUTMODDIR/install
-        sed -i 's/dracut_install \/usr\/share\/zoneinfo\/posix\/Mideast\/Riyadh87//' $DRACUTMODDIR/install
-        sed -i 's/dracut_install \/usr\/share\/zoneinfo\/posix\/Mideast\/Riyadh88//' $DRACUTMODDIR/install
-        sed -i 's/dracut_install \/usr\/share\/zoneinfo\/posix\/Mideast\/Riyadh89//' $DRACUTMODDIR/install
+	# These timezone files are not available in the latest mcp build
+	sed -i 's/dracut_install \/usr\/share\/zoneinfo\/posix\/Asia\/Riyadh87//' $DRACUTMODDIR/install
+	sed -i 's/dracut_install \/usr\/share\/zoneinfo\/posix\/Asia\/Riyadh88//' $DRACUTMODDIR/install
+	sed -i 's/dracut_install \/usr\/share\/zoneinfo\/posix\/Asia\/Riyadh89//' $DRACUTMODDIR/install
+	sed -i 's/dracut_install \/usr\/share\/zoneinfo\/posix\/Mideast\/Riyadh87//' $DRACUTMODDIR/install
+	sed -i 's/dracut_install \/usr\/share\/zoneinfo\/posix\/Mideast\/Riyadh88//' $DRACUTMODDIR/install
+	sed -i 's/dracut_install \/usr\/share\/zoneinfo\/posix\/Mideast\/Riyadh89//' $DRACUTMODDIR/install
 
 # For ppc64 platform, needs to remove some files,
 # # and some files are in different directories
 elif [ $BUILDARCH = "ppc64" ]; then
-        if [ "$HOSTOS" = "Pegas1.0" ]; then
-           sed -i 's/ mkreiserfs//' $DRACUTMODDIR/install
-           sed -i 's/ reiserfstune//' $DRACUTMODDIR/install
-           sed -i 's/ vconfig//' $DRACUTMODDIR/install
-        fi
-        sed -i 's/ efibootmgr//' $DRACUTMODDIR/install
-        sed -i 's/ dmidecode//' $DRACUTMODDIR/install
-        sed -i 's/\/lib\/terminfo\/l\/linux/\/usr\/share\/terminfo\/l\/linux/g' $DRACUTMODDIR/install
-        sed -i 's/\/lib\/terminfo\/v\/vt100/\/usr\/share\/terminfo\/v\/vt100/g' $DRACUTMODDIR/install
+	if [ "$HOSTOS" = "Pegas1.0" ]; then
+		sed -i 's/ mkreiserfs//' $DRACUTMODDIR/install
+		sed -i 's/ reiserfstune//' $DRACUTMODDIR/install
+		sed -i 's/ vconfig//' $DRACUTMODDIR/install
+	fi
+	sed -i 's/ efibootmgr//' $DRACUTMODDIR/install
+	sed -i 's/ dmidecode//' $DRACUTMODDIR/install
+	sed -i 's/\/lib\/terminfo\/l\/linux/\/usr\/share\/terminfo\/l\/linux/g' $DRACUTMODDIR/install
+	sed -i 's/\/lib\/terminfo\/v\/vt100/\/usr\/share\/terminfo\/v\/vt100/g' $DRACUTMODDIR/install
 fi
 
 libnss_pkgname=`find /usr/lib64/ -name libnss_dns-2*.so | xargs basename`

--- a/xCAT-genesis-builder/cmdlist_check
+++ b/xCAT-genesis-builder/cmdlist_check
@@ -1,1 +1,0 @@
-ntp-wait

--- a/xCAT-genesis-builder/install
+++ b/xCAT-genesis-builder/install
@@ -4,11 +4,11 @@ dracut_install wget openssl tar mstflint ipmitool cpio gzip lsmod ethtool modpro
 dracut_install netstat # broadcom update requires
 dracut_install uniq # mellanox update requires
 dracut_install grep ip hostname /usr/bin/awk egrep grep dirname expr
-dracut_install mount.nfs sshd vi reboot lspci parted screen mkfs mkfs.ext4 mkfs.xfs xfs_db #mkfs.btrfs removed
+dracut_install mount.nfs sshd vi reboot lspci parted screen mkfs mkfs.ext4 mkfs.xfs xfs_db
 #dracut_install libvirtd /usr/share/libvirt/cpu_map.xml /usr/bin/qemu-img /usr/libexec/qemu-kvm
-dracut_install mkswap df brctl vconfig ifenslave ssh-keygen scp clear dhclient lldpad
+dracut_install mkswap df vconfig ifenslave ssh-keygen scp clear dhclient lldpad
 dracut_install /lib64/libnss_dns-2.12.so /lib64/libnss_dns.so.2
-dracut_install poweroff ntpq ntpd ntp-wait hwclock date /usr/share/terminfo/x/xterm /usr/share/terminfo/s/screen /etc/nsswitch.conf /etc/services
+dracut_install poweroff hwclock date /usr/share/terminfo/x/xterm /usr/share/terminfo/s/screen /etc/nsswitch.conf /etc/services
 dracut_install /sbin/rsyslogd /etc/protocols umount /bin/rpm /usr/lib/rpm/rpmrc
 dracut_install chmod /sbin/route /sbin/ifconfig /usr/bin/whoami /usr/bin/head /usr/bin/tail basename /etc/redhat-release ping tr lsusb /usr/share/hwdata/usb.ids #ibm fw wrapper requirements
 dracut_install efibootmgr lldptool dmidecode #uxspi prereqs, but will use dmidecode to improve decision on loading ipmi_si
@@ -605,7 +605,6 @@ dracut_install /lib64/rsyslog/lmtcpsrv.so
 dracut_install /lib64/rsyslog/lmnsd_ptcp.so
 dracut_install /lib64/rsyslog/imtcp.so
 dracut_install /lib64/rsyslog/lmnet.so
-dracut_install /lib64/rsyslog/lmstrmsrv.so
 dracut_install /lib64/rsyslog/imuxsock.so
 dracut_install /usr/lib64/libnfsidmap/nsswitch.so
 dracut_install killall logger nc nslookup bc chown chroot dd expr kill mkdosfs parted rsync shutdown sort ssh-keygen tr blockdev findfs insmod kexec lvm mdadm mke2fs pivot_root sshd swapon tune2fs mkreiserfs reiserfstune  pvcreate lvremove vgremove vgcreate  lvcreate  lvscan  lvchange vgchange pvdisplay lvdisplay vgdisplay blkid dmsetup sfdisk # for sysclone

--- a/xCAT-genesis-builder/xCAT-genesis-base.spec
+++ b/xCAT-genesis-builder/xCAT-genesis-base.spec
@@ -32,7 +32,6 @@ Source1: xCAT-genesis-base-%{tarch}.tar.bz2
 Conflicts: xCAT-genesis-scripts-%{tarch} < 1:2.13.10
 
 Buildroot: %{_localstatedir}/tmp/xCAT-genesis
-BuildRequires: /usr/sbin/ntp-wait
 Packager: IBM Corp.
 
 %Description

--- a/xCAT-genesis-builder/xCAT-genesis-builder.spec
+++ b/xCAT-genesis-builder/xCAT-genesis-builder.spec
@@ -4,7 +4,7 @@ Version: %{?version:%{version}}%{!?version:%(cat Version)}
 Release: %{?release:%{release}}%{!?release:%(cat Release)}
 Epoch: 1
 AutoReq: false
-Requires: ipmitool screen btrfs-progs lldpad rpm-build mstflint xfsprogs nc rpmdevtools libstdc++-devel pciutils bridge-utils ntp ntp-perl iprutils psmisc mdadm bind-utils dosfstools usbutils libusbx bc
+Requires: ipmitool screen lldpad rpm-build mstflint xfsprogs nc rpmdevtools libstdc++-devel pciutils bridge-utils iprutils psmisc mdadm bind-utils dosfstools usbutils libusbx bc rpmdevtools 
 Prefix: /opt/xcat
 AutoProv: false
 


### PR DESCRIPTION
### The PR is to fix issue #3870

### The modification include

This enhancement removes the requirement for the following packages:

* btrfs and related tools
* ntp and related tools
* deprecated/removed rsyslog library

So that the xCAT-genesis-builder can build base netboot images from a RHEL8 system.  There are some additional light formatting changes here as well.
