### PR TITLE
Support CentOS8 Stream

### DIFF
--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -2066,6 +2066,8 @@ sub copycd
         }
     } elsif ($desc and $desc =~ /CentOS Linux (.*)/) {
           $distname = "centos" . $1;
+    } elsif ($desc and $desc =~ /CentOS Stream (.*)/) {
+          $distname = "centos-stream" . $1;
     } elsif ($desc and $desc =~ /Rocky Linux (.*)/) {
           $distname = "rocky" . $1;
     }

--- a/xCAT-server/share/xcat/install/centos/compute.centos-stream8.pkglist
+++ b/xCAT-server/share/xcat/install/centos/compute.centos-stream8.pkglist
@@ -1,0 +1,1 @@
+compute.centos8.pkglist

--- a/xCAT-server/share/xcat/install/centos/compute.centos-stream8.tmpl
+++ b/xCAT-server/share/xcat/install/centos/compute.centos-stream8.tmpl
@@ -1,0 +1,1 @@
+compute.centos8.tmpl

--- a/xCAT-server/share/xcat/install/centos/service.centos-stream8.pkglist
+++ b/xCAT-server/share/xcat/install/centos/service.centos-stream8.pkglist
@@ -1,0 +1,1 @@
+../rh/service.rhels8.pkglist

--- a/xCAT-server/share/xcat/install/centos/service.centos-stream8.ppc64le.otherpkgs.pkglist
+++ b/xCAT-server/share/xcat/install/centos/service.centos-stream8.ppc64le.otherpkgs.pkglist
@@ -1,0 +1,1 @@
+../rh/service.rhels8.ppc64le.otherpkgs.pkglist

--- a/xCAT-server/share/xcat/install/centos/service.centos-stream8.tmpl
+++ b/xCAT-server/share/xcat/install/centos/service.centos-stream8.tmpl
@@ -1,0 +1,1 @@
+compute.centos-stream8.tmpl

--- a/xCAT-server/share/xcat/install/centos/service.centos-stream8.x86_64.otherpkgs.pkglist
+++ b/xCAT-server/share/xcat/install/centos/service.centos-stream8.x86_64.otherpkgs.pkglist
@@ -1,0 +1,1 @@
+../rh/service.rhels8.x86_64.otherpkgs.pkglist

--- a/xCAT-server/share/xcat/netboot/centos/compute.centos-stream8.ppc64le.exlist
+++ b/xCAT-server/share/xcat/netboot/centos/compute.centos-stream8.ppc64le.exlist
@@ -1,0 +1,1 @@
+../rh/compute.rhels8.ppc64le.exlist

--- a/xCAT-server/share/xcat/netboot/centos/compute.centos-stream8.ppc64le.pkglist
+++ b/xCAT-server/share/xcat/netboot/centos/compute.centos-stream8.ppc64le.pkglist
@@ -1,0 +1,1 @@
+../rh/compute.rhels8.ppc64le.pkglist

--- a/xCAT-server/share/xcat/netboot/centos/compute.centos-stream8.ppc64le.postinstall
+++ b/xCAT-server/share/xcat/netboot/centos/compute.centos-stream8.ppc64le.postinstall
@@ -1,0 +1,1 @@
+../rh/compute.rhels8.ppc64le.postinstall

--- a/xCAT-server/share/xcat/netboot/centos/compute.centos-stream8.x86_64.exlist
+++ b/xCAT-server/share/xcat/netboot/centos/compute.centos-stream8.x86_64.exlist
@@ -1,0 +1,1 @@
+../rh/compute.rhels8.x86_64.exlist

--- a/xCAT-server/share/xcat/netboot/centos/compute.centos-stream8.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/centos/compute.centos-stream8.x86_64.pkglist
@@ -1,0 +1,1 @@
+../rh/compute.rhels8.x86_64.pkglist

--- a/xCAT-server/share/xcat/netboot/centos/compute.centos-stream8.x86_64.postinstall
+++ b/xCAT-server/share/xcat/netboot/centos/compute.centos-stream8.x86_64.postinstall
@@ -1,0 +1,1 @@
+../rh/compute.rhels8.x86_64.postinstall

--- a/xCAT-server/xCAT-server.spec
+++ b/xCAT-server/xCAT-server.spec
@@ -443,6 +443,9 @@ fi
 ln -sf $RPM_INSTALL_PREFIX0/sbin/xcatd /usr/sbin/xcatd
 ln -sf $RPM_INSTALL_PREFIX0/share/xcat/install/sles $RPM_INSTALL_PREFIX0/share/xcat/install/sle
 ln -sf $RPM_INSTALL_PREFIX0/share/xcat/netboot/sles $RPM_INSTALL_PREFIX0/share/xcat/netboot/sle
+
+ln -sf $RPM_INSTALL_PREFIX0/share/xcat/install/centos $RPM_INSTALL_PREFIX0/share/xcat/install/centos-stream
+ln -sf $RPM_INSTALL_PREFIX0/share/xcat/netboot/centos $RPM_INSTALL_PREFIX0/share/xcat/netboot/centos-stream
 if [ "$1" = "1" ]; then #Only if installing for the first time..
    if [ -x /usr/lib/systemd/systemd ]; then
        /usr/bin/systemctl daemon-reload


### PR DESCRIPTION
### The PR is to fix issue _#7026_

Supports CentOS8 Stream diskfull install:
```
[root@f6u13k06 ~]# hostnamectl
   Static hostname: localhost.localdomain
Transient hostname: f6u13k06
         Icon name: computer-vm
           Chassis: vm
        Machine ID: 2d15cfeab0e9414490914acb695d86cf
           Boot ID: 0b15dee010914c0f8a9eaa9e26368cf7
    Virtualization: kvm
  Operating System: CentOS Stream 8
       CPE OS Name: cpe:/o:centos:centos:8
            Kernel: Linux 4.18.0-240.el8.ppc64le
      Architecture: ppc64-le
[root@f6u13k06 ~]#
```

* More work needed to support diskless install.