### PR TITLE
Make /etc/localtime a link

### DIFF
--- a/xCAT-server/lib/xcat/plugins/packimage.pm
+++ b/xCAT-server/lib/xcat/plugins/packimage.pm
@@ -655,7 +655,10 @@ sub copybootscript {
         copy("$installroot/postscripts/xcatdsklspost", "$rootimg_dir/opt/xcat/xcatdsklspost");
         if ($timezone[0]) {
             unlink("$rootimg_dir/etc/localtime");
-            copy("$rootimg_dir/usr/share/zoneinfo/$timezone[0]", "$rootimg_dir/etc/localtime");
+            # Copy timezone file to /etc and link 'localtime' to it
+            mkpath(dirname("$rootimg_dir/etc/$timezone[0]"));
+            copy("$rootimg_dir/usr/share/zoneinfo/$timezone[0]", "$rootimg_dir/etc/$timezone[0]");
+            symlink("./$timezone[0]", "$rootimg_dir/etc/localtime");
         }
 
 


### PR DESCRIPTION
Some software packages, like R, want `/etc/localtime` to be links.
Currently, for diskless image `packimage` code copies the timezone file to `/etc` and renames the file to `localtime`.

This PR copies the timezone file to `/etc` and links `localtime` to that file:
```
[root@f6u13k18 ~]# ls -ld /etc/localtime
lrwxrwxrwx 1 root root 23 Sep 13 14:21 /etc/localtime -> ../etc/America/New_York
[root@f6u13k18 ~]#
```