### PR TITLE
Add genimage/packimage to cleanup_postscripts_diskless testcase

### DIFF
--- a/xCAT-test/autotest/testcase/installation/compare_postscripts
+++ b/xCAT-test/autotest/testcase/installation/compare_postscripts
@@ -42,6 +42,11 @@ start:cleanup_postscripts_diskless
 os:Linux
 label:provision
 description: Verify postscripts cleaned up after diskless installation
+cmd:rootimgdir=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep rootimgdir|awk -F'=' ' {print $2}'`; if [ -d $rootimgdir ]; then mv $rootimgdir $rootimgdir.regbak -f;fi
+cmd:genimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+check:rc==0
+cmd:packimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
+check:rc==0
 cmd:chdef -t site clustersite cleanupxcatpost="yes"
 cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute 1
 check:rc==0
@@ -58,4 +63,6 @@ cmd:xdsh $$CN ls /xcatpost | wc -l
 check:rc==0
 check:output==0
 cmd:chdef -t site clustersite cleanupxcatpost="no"
+cmd:rootimgdir=`lsdef -t osimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir.regbak ]; then rm -rf $rootimgdir; mv $rootimgdir.regbak $rootimgdir; fi
+check:rc==0
 end


### PR DESCRIPTION
Diskless image might not always be there at the time `cleanup_postscripts_diskless` testcase runs.
This PR adds explicit `genimage` and `packimage` to generate diskless image.