### PR TITLE
RH8 genesis scripts

### DIFF
--- a/docs/source/references/coral/known_issues/genesis_base.rst
+++ b/docs/source/references/coral/known_issues/genesis_base.rst
@@ -10,13 +10,13 @@ To support the Power9 hardware, changes are made to the kernel in the Red Hat En
 Work-around
 -----------
 
-.. note:: The genesis-base must be compiled on the Power9 hardware, running RHEL7.  If the management node is not Power9 hardware, manually provision a RHEL7 compute node, build the genesis-base RPM, then install it on the management node.
+.. note:: The genesis-base must be compiled on the Power9 hardware, running RHEL8.  If the management node is not Power9 hardware, manually provision a RHEL8 compute node, build the genesis-base RPM, then install it on the management node.
 
-xCAT cannot ship a kernel based on RHEL distribution, so the customer needs to build a version of the ``xCAT-genesis-base`` on-site using a server running Red Hat Enterprise Linux 7. Building ``xCAT-genesis-base`` on a server running Red Hat Enterprise Linux 8 is currently not supported.
+xCAT cannot ship a kernel based on RHEL distribution, so the customer needs to build a version of the ``xCAT-genesis-base`` on-site using a server running Red Hat Enterprise Linux 8. Building ``xCAT-genesis-base`` on a server running Red Hat Enterprise Linux 7 is no longer supported.
 
 1. Download the latest timestamp version of the ``xCAT-genesis-builder`` RPM provided here: http://xcat.org/files/xcat/xcat-dep/2.x_Linux/beta/
 
-2. Install the ``xCAT-genesis-builder`` RPM on a node that is installed with the RHEL version 7. 
+2. Install the ``xCAT-genesis-builder`` RPM on a node that is installed with the RHEL version 8. 
 
 3. Build the ``xCAT-genesis-base`` RPM: ::
 

--- a/xCAT-genesis-scripts/usr/bin/doxcat
+++ b/xCAT-genesis-scripts/usr/bin/doxcat
@@ -8,11 +8,14 @@ log_label="xcat.genesis.doxcat"
 # Start rsyslogd and log into a local file specified in /etc/rsyslog.conf
 # Later, once xCAT MN is known, dhclient-script will change
 # rsyslog.conf file to send log entries to xCAT MN
-RSYSLOGD_VERSION=`rsyslogd -v | grep "rsyslogd" | cut -d" " -f2 | cut -d"." -f1`
+RSYSLOGD_VERSION=`rsyslogd -v | grep -m1 "rsyslogd" | tr -s ' ' | cut -d" " -f2 | cut -d"." -f1`
 
 # if syslog is running and there's a pid file, kill it before restarting syslogd
 if [ -f /var/run/syslogd.pid ]; then
     kill -TERM `cat /var/run/syslogd.pid`
+fi
+if [ -f /var/run/rsyslogd.pid ]; then
+    kill -TERM `cat /var/run/rsyslogd.pid`
 fi
 
 if [ $RSYSLOGD_VERSION -ge 8 ]; then
@@ -66,6 +69,10 @@ fi
 rpcbind
 rpc.statd
 
+# Generate some entropy, needed for ssh-keygen to unblock getrandom()
+if [ -e /usr/sbin/rngd ]; then
+    /usr/sbin/rngd
+fi
 # Try -A available on more current version of ssh-keygen to generate all keys
 ssh-keygen -A 2> /dev/null
 if [ $? -ne 0 ]; then
@@ -263,17 +270,21 @@ logger -s -t $log_label -p local4.info "Acquired IPv4 address on $bootnic"
 
 ip -4 -o a show dev $bootnic|grep -v 'scope link'|grep -v 'dynamic'|awk '{print $4}'
 
-logger -s -t $log_label -p local4.info "Starting ntpd..."
-ntpd -g -x
+if [ -e /usr/sbin/ntpd ]; then
+    logger -s -t $log_label -p local4.info "Starting ntpd..."
+    ntpd -g -x
 
-# ntp-wait defaults to 6 seconds between retries, wait for 1 minute
-NTP_TRIES=10
-NTP_SLEEP=6
-logger -s -t $log_label -p local4.info "Waiting for $NTP_TRIES x $NTP_SLEEP seconds for ntpd to synchronize..."
-ntp-wait -n $NTP_TRIES -s $NTP_SLEEP -v
-if [ $? -ne 0 ]
-then
-    logger -s -t $log_label -p local4.info "... ntpd did not synchronize."
+    # ntp-wait defaults to 6 seconds between retries, wait for 1 minute
+    NTP_TRIES=10
+    NTP_SLEEP=6
+    logger -s -t $log_label -p local4.info "Waiting for $NTP_TRIES x $NTP_SLEEP seconds for ntpd to synchronize..."
+    ntp-wait -n $NTP_TRIES -s $NTP_SLEEP -v
+    if [ $? -ne 0 ]; then
+        logger -s -t $log_label -p local4.info "... ntpd did not synchronize."
+    fi
+else
+    logger -s -t $log_label -p local4.info "Starting chronyd..."
+    chronyd -s
 fi
 
 if [ -e "/dev/rtc" ]; then
@@ -283,15 +294,13 @@ if [ -e "/dev/rtc" ]; then
 fi
 
 logger -s -t $log_label -p local4.info "Restarting syslog..."
-read -r RSYSLOG_PID </var/run/syslogd.pid 2>/dev/null
-kill "$RSYSLOG_PID" 2>/dev/null
-while kill -0 "$RSYSLOG_PID" 2>/dev/null
-do
-    sleep 0.5
-done
-unset RSYSLOG_PID
+if [ -f /var/run/syslogd.pid ]; then
+    kill -TERM `cat /var/run/syslogd.pid`
+fi
+if [ -f /var/run/rsyslogd.pid ]; then
+    kill -TERM `cat /var/run/rsyslogd.pid`
+fi
 
-RSYSLOGD_VERSION=`rsyslogd -v | awk '/rsyslogd/ { split($2, a, "."); print a[1]; }'`
 if [ "$RSYSLOGD_VERSION" -ge 8 ]; then
     /sbin/rsyslogd
 else

--- a/xCAT-genesis-scripts/usr/bin/restart
+++ b/xCAT-genesis-scripts/usr/bin/restart
@@ -44,9 +44,15 @@ while [ $WAITING -gt 0 ]; do
     done
 
     # restart rsyslog after dhclient
-    kill -9 `cat /var/run/syslogd.pid`
+    if [ -f /var/run/syslogd.pid ]; then
+        kill -TERM `cat /var/run/syslogd.pid`
+    fi
+    if [ -f /var/run/rsyslogd.pid ]; then
+        kill -TERM `cat /var/run/rsyslogd.pid`
+    fi
     sleep 3
-    RSYSLOGD_VERSION=`rsyslogd -v | grep "rsyslogd" | cut -d" " -f2 | cut -d"." -f1`
+
+    RSYSLOGD_VERSION=`rsyslogd -v | grep -m1 "rsyslogd" | tr -s ' ' | cut -d" " -f2 | cut -d"." -f1`
     if [ $RSYSLOGD_VERSION -ge 8 ]; then
         # Newer versions of rsyslogd do not support -c flag anymore
         /sbin/rsyslogd


### PR DESCRIPTION
PR #7037 allows building genesis base on RH8
This PR modifies genesis scripts to run on RH8:
* The output of `rsyslogd -v` is slightly different on RH8, the code to determine the version of syslog needs to only grab the first occurrence of `rsyslogd` string.
* The name of the file where the pid of running rsyslogd process is stored, has changed in RH8. It is now `/var/run/rsyslogd.pid` on RH7 it is `/var/run/syslogd.pid`
* Run `/usr/sbin/rngd` to generate some entropy, otherwise `ssh-keygen` gets stuck calling `getrandom()`
* The time synchronization on RH8 is done with `chronyd` instead of `ntpd` on RH7

### UT

* x86 VM
```
[root@c910f04x37v05 xcat]# mknb x86_64
Creating genesis.fs.x86_64.gz in /tftpboot/xcat

[root@c910f04x37v05 xcat]# rinstall c910f04x37v07 shell -c
Provision node(s): c910f04x37v07
c910f04x37v07: shell

:
:
starting version 219
[    3.044206] Error: Driver 'pcspkr' is already registered, aborting...
There is no screen to be detached matching doxcat.
xcat.genesis.doxcat: Beginning doxcat process...
xcat.genesis.doxcat: Waiting for device with address 42:1f:0a:04:25:07 to appear..
Done
ssh-keygen: generating new host keys: RSA1 RSA DSA ECDSA ED25519
xcat.genesis.doxcat: Generating private key...
xcat.genesis.doxcat: Done
xcat.genesis.doxcat: Creating /var/lib/lldpad file...
xcat.genesis.doxcat: lldpad started.
xcat.genesis.doxcat: XCATMASTER is c910f04x37v05, XCATPORT is 3001
xcat.genesis.doxcat: Setting IP via DHCP...
xcat.genesis.doxcat: Acquiring network addresses..
xcat.genesis.doxcat: Acquired IPv4 address on ens3
10.4.37.7/8
xcat.genesis.doxcat: Starting ntpd...
xcat.genesis.doxcat: Waiting for 10 x 6 seconds for ntpd to synchronize...
Waiting for ntpd to synchronize... OK!
xcat.genesis.doxcat: Attempting to sync hardware clock...
xcat.genesis.doxcat: Restarting syslog...
modprobe: ERROR: could not insert 'ipmi_si': No such device
xcat.genesis.doxcat: Getting initial certificate --> c910f04x37v05:3001
xcat.genesis.doxcat: The destiny=shell, destiny parameters=shell
xcat.genesis.doxcat: Dropping to debug shell(exit to run next destiny)...
[xCAT Genesis running on c910f04x37v07 /]#
```

* ppc64le VM:
```
[root@f6u13k07 xcat]#  mknb ppc64
Creating genesis.fs.ppc64.gz in /tftpboot/xcat
[root@f6u13k07 xcat]# rinstall f6u13k09 shell -c
Provision node(s): f6u13k09
f6u13k09: shell

:
:
starting version 233
[    1.776835] vio vio: uevent: failed to send synthetic uevent
There is no screen to be detached matching doxcat.
rsyslogd: getaddrinfo failed obtaining local hostname - using '(none)' instead; error: System error [v8.35.0]
<166>Sep 22 18:58:08 xcat.genesis.doxcat: Beginning doxcat process...
Done
<163>Sep 22 18:58:08 xcat.genesis.doxcat: BOOTIF missing, can't detect boot nic
sh: /usr/bin/systemd-tmpfiles: No such file or directory
rpcbind: /run/rpcbind/rpcbind.lock: No such file or directory
ssh-keygen: generating new host keys: RSA DSA ECDSA ED25519
<166>Sep 22 18:58:08 xcat.genesis.doxcat: Generating private key...
<166>Sep 22 18:58:08 xcat.genesis.doxcat: Done
<166>Sep 22 18:58:08 xcat.genesis.doxcat: Creating /var/lib/lldpad file...
<166>Sep 22 18:58:08 xcat.genesis.doxcat: lldpad started.
<166>Sep 22 18:58:08 xcat.genesis.doxcat: XCATMASTER is f6u13k07, XCATPORT is 3001
<166>Sep 22 18:58:08 xcat.genesis.doxcat: Setting IP via DHCP...
<166>Sep 22 18:58:08 xcat.genesis.doxcat: Acquiring network addresses..
<166>Sep 22 14:58:11 xcat.genesis.doxcat: the nic enp0s1 can ping f6u13k07
<166>Sep 22 14:58:14 xcat.genesis.doxcat: Acquired IPv4 address on enp0s1
10.6.13.9/8
<166>Sep 22 14:58:14 xcat.genesis.doxcat: Starting ntpd...
<166>Sep 22 14:58:14 xcat.genesis.doxcat: Waiting for 10 x 6 seconds for ntpd to synchronize...
Waiting for ntpd to synchronize... OK!
<166>Sep 22 14:58:27 xcat.genesis.doxcat: Attempting to sync hardware clock...



<166>Sep 22 14:58:27 xcat.genesis.doxcat: Restarting syslog...
ppc64
<166>Sep 22 14:58:27 xcat.genesis.doxcat: Getting initial certificate --> f6u13k07:3001
<166>Sep 22 14:58:27 xcat.genesis.doxcat: The destiny=shell, destiny parameters=shell
<166>Sep 22 14:58:27 xcat.genesis.doxcat: Dropping to debug shell(exit to run next destiny)...
[xCAT Genesis running on f6u13k09 /]#
```

* ppc64le Power9 host
```
[root@briggs01 gurevich]# mknb ppc64
Creating genesis.fs.ppc64.gz in /tftpboot/xcat

[root@briggs01 xcat]# rsetboot node-8335-gth-1318c4a net

[root@briggs01 xcat]#  rpower node-8335-gth-1318c4a on

[root@briggs01 xcat]# rcons node-8335-gth-1318c4a

:
:
<166>Sep 22 19:12:35 xcat.genesis.doxcat: Beginning doxcat process...
Done
<163>Sep 22 19:12:35 xcat.genesis.doxcat: BOOTIF missing, can't detect boot nic

Initializing available sources

Failed to init entropy source hwrng

Enabling power DARN rng support

Initializing entropy source darn

Initializing AES buffer

Enabling JITTER rng support

Initializing entropy source jitter

ssh-keygen: generating new host keys: RSA DSA ECDSA ED25519
<166>Sep 22 19:12:40 xcat.genesis.doxcat: Generating private key...
<166>Sep 22 19:12:40 xcat.genesis.doxcat: Done
<166>Sep 22 19:12:40 xcat.genesis.doxcat: Creating /var/lib/lldpad file...
<166>Sep 22 19:12:40 xcat.genesis.doxcat: lldpad started.
<166>Sep 22 19:12:40 xcat.genesis.doxcat: XCATMASTER is 172.12.253.27, XCATPORT is 3001
<166>Sep 22 19:12:40 xcat.genesis.doxcat: Setting IP via DHCP...
<166>Sep 22 19:12:40 xcat.genesis.doxcat: Acquiring network addresses..
<166>Sep 22 15:12:43 xcat.genesis.doxcat: the nic enP5p1s0f0 can ping 172.12.253.27
<166>Sep 22 15:12:46 xcat.genesis.doxcat: Acquired IPv4 address on enP5p1s0f0
172.12.253.101/16
<166>Sep 22 15:12:46 xcat.genesis.doxcat: Starting chronyd...
<166>Sep 22 19:12:46 xcat.genesis.doxcat: Attempting to sync hardware clock...
<166>Sep 22 19:12:46 xcat.genesis.doxcat: Restarting syslog...
rsyslogd: getaddrinfo failed obtaining local hostname - using '(none)' instead; error: System error [v8.1911.0-3.el8]
ppc64le
<166>Sep 22 19:12:46 xcat.genesis.doxcat: Getting initial certificate --> 172.12.253.27:3001
<166>Sep 22 19:12:48 xcat.genesis.doxcat: Running getdestiny --> 172.12.253.27:3001

<166>Sep 22 19:12:48 xcat.genesis.doxcat: Received destiny=discover
<166>Sep 22 19:12:48 xcat.genesis.doxcat: The destiny=discover, destiny parameters=discover
<166>Sep 22 19:12:48 xcat.genesis.doxcat: Running dodiscovery...
<166>Sep 22 19:12:48 xcat.genesis.dodiscovery: Beginning node discovery process...
Cannot find device "ip6tnl0@NONE"
<166>Sep 22 19:12:48 xcat.genesis.dodiscovery: Waiting for nics to get addresses
enP5p1s0f0|172.12.253.101
<164>Sep 22 19:14:05 xcat.genesis.dodiscovery: No DHCP answer for wpan1, ignoring interface...
<166>Sep 22 19:14:05 xcat.genesis.dodiscovery: Network configuration complete, commencing transmit of discovery packets
<166>Sep 22 19:14:05 xcat.genesis.dodiscovery: Beginning echo information to discovery packet file...
connect: Connection refused
Failed to connect to lldpad - clif_open: Connection refused
:
:
:
<166>Sep 22 19:14:06 xcat.genesis.dodiscovery: Discovery packet file is ready.
<166>Sep 22 19:14:06 xcat.genesis.dodiscovery: Sending the discovery packet to xCAT (172.12.253.27:3001)...
<166>Sep 22 19:14:06 xcat.genesis.dodiscovery: Sleeping 5 seconds...
<166>Sep 22 19:14:06 xcat.genesis.minixcatd: The request is processing by xCAT master...
```