### PR TITLE
Better xcatprobe message when makedhcp -q returns no output

### DIFF
--- a/xCAT-probe/subcmds/xcatmn
+++ b/xCAT-probe/subcmds/xcatmn
@@ -1143,8 +1143,15 @@ sub check_dhcp_service {
                     last;
                 }
                 chomp($tmp);
+                if (length($tmp) == 0) {
+                    # makedhcp -q did not return anything, and RC was 0
+                    push @$error_ref, "DHCP server returned no data for 'makedhcp -q xcatmntest'";
+                    returncmdoutput($tmp, $error_ref) if ($verbose);
+                    $rc = 1;
+                    last;
+                }
                 if ($tmp !~ /xcatmntest: ip-address = $serverip, hardware-address = aa:aa:aa:aa:aa:aa/) {
-                    push @$error_ref, "DHCP server reply is wrong";
+                    push @$error_ref, "DHCP server reply does not match expected IP and MAC";
                     returncmdoutput($tmp, $error_ref) if ($verbose);
                     $rc = 1;
                     `makedhcp -d xcatmntest 2>&1 &&  rmdef xcatmntest 2>&1`;


### PR DESCRIPTION
`xcatprobe` uses `makedhcp -q xcatmntest` command to test if `makedhcp -q` returns expected data for `xcatmntest` node created during running of `xcatprobe`.

Sometimes for whatever reason `makedhcp -q xcatmntest` returns nothing, but RC is still gets set to 0. `xcatprobe` in that case returns very generic message `DHCP server reply is wrong`, making it hard to figure out what went wrong.

This PR tests to see if  `makedhcp -q xcatmntest` returned anything and prints better failure messages.