### PR TITLE
Support building genesis-base on Fedora34

### DIFF
--- a/makerpm-genesisbuilder
+++ b/makerpm-genesisbuilder
@@ -1,5 +1,5 @@
 #!/bin/sh
-VER=`git describe`
+VER=`cat Version`
 VER=${VER/-/.post}
 VER=${VER/-/.}
 rpmbuild --version > /dev/null

--- a/xCAT-genesis-builder/buildrpm
+++ b/xCAT-genesis-builder/buildrpm
@@ -12,7 +12,7 @@ DIR=`dirname $0`
 #DIR=`realpath $DIR`
 DIR=`readlink -f $DIR`
 BUILDARCH=`uname -m`
-REQUIRED_PACKAGES="rpmdevtools rpm-build screen lldpad mstflint epel-release ipmitool pciutils mdadm dosfstools usbutils bind-utils psmisc nmap-ncat"
+REQUIRED_PACKAGES="rpmdevtools rpm-build screen lldpad mstflint epel-release ipmitool pciutils mdadm dosfstools usbutils bind-utils psmisc nmap-ncat ethtool kexec-tools"
 
 # Install required packages
 for required_package in $REQUIRED_PACKAGES; do

--- a/xCAT-genesis-builder/xCAT-genesis-base.spec
+++ b/xCAT-genesis-builder/xCAT-genesis-base.spec
@@ -12,6 +12,8 @@ Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
 %endif
 BuildArch: noarch
 %define name	xCAT-genesis-base-%{tarch}
+# Use xz compression instead of default gzip on Fedora34
+%define _binary_payload w7.xzdio
 %define __spec_install_post :
 %define debug_package %{nil}
 %define __prelink_undo_cmd %{nil}


### PR DESCRIPTION
Some changes are needed to support building `genesis-base` on Fedora34
* Use `Version` file to determine xCAT version number, more reliable than `git describe`
* Make sure `ethtool` and `kexec-tools` are installed before building the `genesis-base` RPM
* When building `genesis-base` on Fedora34, `gzip` is used to compress the RPM, need to specify `xz` compression instead. Otherwise an error is reported when installing that `genesis-base` RPM on RH8 with:
```
[root@briggs01 built_Fedora34]# rpm -ivh xCAT-genesis-base-ppc64-2.16.3.8-snap202109291028.noarch.rpm
error: Failed dependencies:
        rpmlib(PayloadIsZstd) <= 5.4.18-1 is needed by xCAT-genesis-base-ppc64-2:2.16.3.8-snap202109291028.noarch
[root@briggs01 built_Fedora34]#
```