### PR TITLE
Missing quote when checking for externaldns in xcatprobe

### DIFF
--- a/xCAT-probe/subcmds/xcatmn
+++ b/xCAT-probe/subcmds/xcatmn
@@ -969,7 +969,7 @@ sub check_dns_service {
         $checkdns = `lsdef $nodename -i setupnameserver -c  2>&1| awk -F'=' '{print \$2}'`;
         chomp($checkdns);
     } else { # management node
-        my $dns_is_external = `lsdef -t site -i externaldns -c 2>&1 | awk -F'=' {print \$2}'`;
+        my $dns_is_external = `lsdef -t site -i externaldns -c 2>&1 | awk -F'=' '{print \$2}'`;
         chomp($dns_is_external);
         if ($dns_is_external eq "1") {
           $checkdns = 0;


### PR DESCRIPTION
Most likely a typo