### PR TITLE
Update xCAT installation docs

### DIFF
--- a/docs/source/guides/install-guides/apt/configure_xcat.rst
+++ b/docs/source/guides/install-guides/apt/configure_xcat.rst
@@ -10,12 +10,12 @@ Internet Repository
 
 From the xCAT download page, find the build you want to install and add to ``/etc/apt/sources.list``.
 
-To configure the xCAT development build, add the following line to ``/etc/apt/sources.list``: ::
+To configure the xCAT stable build, add the following line to ``/etc/apt/sources.list``: ::
 
   [For x86_64 servers]
-  deb [arch=amd64] http://xcat.org/files/xcat/repos/apt/devel/core-snap bionic main
+  deb [arch=amd64] http://xcat.org/files/xcat/repos/apt/latest/xcat-core bionic main
   [For ppc64el servers]
-  deb [arch=ppc64el] http://xcat.org/files/xcat/repos/apt/devel/core-snap bionic main
+  deb [arch=ppc64el] http://xcat.org/files/xcat/repos/apt/latest/xcat-core bionic main
 
 
 **[xcat-dep]**
@@ -28,7 +28,7 @@ To configure the xCAT deps online repository, add the following line to ``/etc/a
   deb [arch=ppc64el] http://xcat.org/files/xcat/repos/apt/latest/xcat-dep bionic main
 
 
-If using internet repositories, continue to the next step to install xCAT.
+Continue to the next section to install xCAT.
 
 Local Repository
 ----------------

--- a/docs/source/guides/install-guides/common_sections.rst
+++ b/docs/source/guides/install-guides/common_sections.rst
@@ -74,17 +74,17 @@ The following sections describe the different methods for installing xCAT.
 
 **[xcat-core]**
 
-#. Download xcat-core: ::
+#. Download ``xcat-core``: ::
 
-        # downloading the latest development build, core-rpms-snap.tar.bz2
+        # downloading the latest stable build, xcat-core-<version>-linux.tar.bz2
         mkdir -p ~/xcat
         cd ~/xcat/
-        wget http://xcat.org/files/xcat/xcat-core/devel/Linux/core-snap/core-rpms-snap.tar.bz2
+        wget http://xcat.org/files/xcat/xcat-core/<version>.x_Linux/xcat-core/xcat-core-<version>-linux.tar.bz2
 
 
-#. Extract xcat-core: ::
+#. Extract ``xcat-core``: ::
 
-        tar jxvf core-rpms-snap.tar.bz2
+        tar xcat-core-<version>-linux.tar.bz2
 
 #. Configure the local repository for xcat-core by running ``mklocalrepo.sh`` script in the ``xcat-core`` directory: ::
 
@@ -98,17 +98,17 @@ The following sections describe the different methods for installing xCAT.
 
 **[xcat-core]**
 
-#. Download xcat-core: ::
+#. Download ``xcat-core``: ::
 
-        # downloading the latest development build, core-rpms-snap.tar.bz2
+        # downloading the latest stable build, xcat-core-<version>-ubuntu.tar.bz2
         mkdir -p ~/xcat
         cd ~/xcat/
-        wget http://xcat.org/files/xcat/xcat-core/devel/Ubuntu/core-snap/core-debs-snap.tar.bz2
+        wget http://xcat.org/files/xcat/xcat-core/<version>.x_Ubuntu/xcat-core/xcat-core-<version>-ubuntu.tar.bz2
 
 
-#. Extract xcat-core: ::
+#. Extract ``xcat-core``: ::
 
-        tar jxvf core-debs-snap.tar.bz2
+        tar jxvf xcat-core-<version>-ubuntu.tar.bz2
 
 #. Configure the local repository for xcat-core by running ``mklocalrepo.sh`` script in the ``xcat-core`` directory: ::
 
@@ -122,24 +122,24 @@ The following sections describe the different methods for installing xCAT.
 
 **[xcat-dep]**
 
-Unless you are downloading ``xcat-dep`` to match a specific package tested with a GA release, it's recommended to download the latest version of xcat-dep.
+Unless you are downloading ``xcat-dep`` to match a specific version of xCAT, it's recommended to download the latest version of ``xcat-dep``.
 
 
-#. Download xcat-dep: ::
+#. Download ``xcat-dep``: ::
 
-        # if downloading xcat-dep from June 11, 2015, xcat-dep-201506110324.tar.bz2
+        # downloading the latest stable version, xcat-dep-<version>-linux.tar.bz2
         mkdir -p ~/xcat/
         cd ~/xcat
-        wget http://xcat.org/files/xcat/xcat-dep/2.x_Linux/xcat-dep-201506110324.tar.bz2
+        wget http://xcat.org/files/xcat/xcat-dep/2.x_Linux/xcat-dep-<version>-linux.tar.bz2
 
-#. Extract xcat-dep: ::
+#. Extract ``xcat-dep``: ::
 
-        tar jxvf xcat-dep-201506110324.tar.bz2
+        tar jxvf xcat-dep-<version>-linux.tar.bz2
 
 #. Configure the local repository for xcat-dep by switching to the architecture and os subdirectory of the node you are installing on, then run the ``mklocalrepo.sh`` script: ::
 
         cd ~/xcat/xcat-dep/
-        # Example, on redhat 7.1 ppc64le: cd rh7/ppc64le
+        # On redhat 7.1 ppc64le: cd rh7/ppc64le
         cd <os>/<arch>
         ./mklocalrepo.sh
 
@@ -149,19 +149,19 @@ Unless you are downloading ``xcat-dep`` to match a specific package tested with 
 
 **[xcat-dep]**
 
-Unless you are downloading ``xcat-dep`` to match a specific package tested with a GA release, it's recommended to download the latest version of xcat-dep.
+Unless you are downloading ``xcat-dep`` to match a specific version of xCAT, it's recommended to download the latest version of ``xcat-dep``.
 
 
 #. Download xcat-dep: ::
 
-        # if downloading xcat-dep from June 11, 2015, xcat-dep-ubuntu-snap20150611.tar.bz
+        # downloading the latest stable version, xcat-dep-<version>-ubuntu.tar.bz2
         mkdir -p ~/xcat/
         cd ~/xcat
-        wget http://xcat.org/files/xcat/xcat-dep/2.x_Ubuntu/xcat-dep-ubuntu-snap20150611.tar.bz
+        wget http://xcat.org/files/xcat/xcat-dep/2.x_Ubuntu/xcat-dep-<version>-ubuntu.tar.bz2
 
 #. Extract xcat-dep: ::
 
-        tar jxvf xcat-dep-ubuntu-snap20150611.tar.bz
+        tar jxvf xcat-dep-<version>-ubuntu.tar.bz2
 
 #. Configure the local repository for xcat-dep by running the ``mklocalrepo.sh`` script: ::
 

--- a/docs/source/guides/install-guides/yum/configure_xcat.rst
+++ b/docs/source/guides/install-guides/yum/configure_xcat.rst
@@ -8,13 +8,13 @@ Internet Repository
 
 **[xcat-core]**
 
-For the xCAT build you want to install, download the ``xcat-core.repo`` file and copy to ``/etc/yum.repos.d``
+For the xCAT version you want to install, download the ``xcat-core.repo`` file and copy it to ``/etc/yum.repos.d``
 
 **[xcat-dep]**
 
-From the `xCAT-dep Online Repository <http://xcat.org/files/xcat/repos/yum/xcat-dep/>`_, navigate to the correct subdirectory for the target machine and download the ``xcat-dep.repo`` file and copy to ``/etc/yum.repos.d``.
+From the `xCAT-dep Online Repository <http://xcat.org/files/xcat/repos/yum/xcat-dep/>`_, navigate to the correct subdirectory for the target machine and download the ``xcat-dep.repo`` file and copy it to ``/etc/yum.repos.d``.
 
-If using internet repositories, continue to the next step to install xCAT.
+Continue to the next section to install xCAT.
 
 Local Repository
 ----------------

--- a/docs/source/guides/install-guides/zypper/configure_xcat.rst
+++ b/docs/source/guides/install-guides/zypper/configure_xcat.rst
@@ -8,13 +8,13 @@ Internet Repository
 
 **[xcat-core]**
 
-For the xCAT build you want to install, download the ``xcat-core.repo`` file and copy to ``/etc/zypp/repos.d``
+For the xCAT version you want to install, download the ``xcat-core.repo`` file and copy it to ``/etc/zypp/repos.d``
 
 **[xcat-dep]**
 
-From the `xCAT-dep Online Repository <http://xcat.org/files/xcat/repos/yum/xcat-dep/>`_, navigate to the correct subdirectory for the target machine and download the ``xcat-dep.repo`` file and copy to ``/etc/zypp/repos.d``.
+From the `xCAT-dep Online Repository <http://xcat.org/files/xcat/repos/yum/xcat-dep/>`_, navigate to the correct subdirectory for the target machine and download the ``xcat-dep.repo`` file and copy it to ``/etc/zypp/repos.d``.
 
-If using internet repositories, continue to the next step to install xCAT.
+Continue to the next section to install xCAT.
 
 Local Repository
 ----------------


### PR DESCRIPTION
Update xCAT installation documentation to:
* Fix some formatting and wording
* Use latest/stable builds instead of development builds