### PR TITLE
Remove epel-release from list of required RPMs

### DIFF
--- a/xCAT-genesis-builder/buildrpm
+++ b/xCAT-genesis-builder/buildrpm
@@ -5,20 +5,20 @@
 #            this whole dir into it somewhere (like /tmp).
 # Then run this script.  The optional 1st arg should be mcp if you are building against mcp.
 
-# Currently, *Fedora 26* is the only OS supported to build genesis-base for ppc64, and Centos 6.5 for x86_64
+# Currently, *Fedora 34* and *RedHat 8* are the only OSes supported to build genesis-base for ppc64, and Centos 6.5 for x86_64
 
 HOSTOS="$1"
 DIR=`dirname $0`
 #DIR=`realpath $DIR`
 DIR=`readlink -f $DIR`
 BUILDARCH=`uname -m`
-REQUIRED_PACKAGES="rpmdevtools rpm-build screen lldpad mstflint epel-release ipmitool pciutils mdadm dosfstools usbutils bind-utils psmisc nmap-ncat ethtool kexec-tools"
+REQUIRED_PACKAGES="rpmdevtools rpm-build screen lldpad mstflint ipmitool pciutils mdadm dosfstools usbutils bind-utils psmisc nmap-ncat ethtool kexec-tools"
 
 # Install required packages
 for required_package in $REQUIRED_PACKAGES; do
     yum -y install $required_package
     if [ $? -ne 0 ]; then
-        echo "ERROR: Can not install required packages $required_package, make sure EPEL repository is configured"
+        echo "ERROR: Can not install required package $required_package, make sure EPEL repository is configured"
         exit 1
     fi
 done


### PR DESCRIPTION
Remove `epel-release` from list of required RPMs when building `xCAT-genesis-base`.

The `epel-release` RPM is not there on Fedora and on RH it just contains several `.repo` files which point to `fedoraproject.org` and help in locating EPEL RPMs.

* On Fedora, this RPM is not needed, since when the node is provisioned, it already contains `.repo` files which point to `fedoraproject.org` and all the needed RPMs
* On RH in order to install this `epel-release` RPM, a `.repo` file must already point to EPEL location and therefore would find all the needed EPEL RPMs, without the need of a `.repo` file from `epel-release` RPM

