### PR TITLE
Change from inst_rules to inst

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/dracut_047/install.netboot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_047/install.netboot
@@ -9,5 +9,5 @@ inst "$moddir/xcat-updateflag" "/tmp/updateflag"
 inst "$moddir/xcatroot" "/sbin/xcatroot"
 inst_hook cmdline 10 "$moddir/xcat-cmdline.sh"
 for file in /etc/udev/rules.d/*;do
-	grep -qi xcat $file && inst_rules $(basename $file)
+	grep -qi xcat $file && inst $file $file
 done


### PR DESCRIPTION
The inst_rules command didn't seem to work for us on RHEL8.
I switched it to "inst" with listing the source and dest as $file and it seems to work fine for us.

### The PR is to fix issue _#xxx_

### The modification include

_##item1_

_##item2_

### The UT result
`##The UT output##`

# Please remove this line and below if fix issue

# Please remove this line and above for tasks or features

### The PR is for task _#xxx_ or to implement feature #xxx

_##Feature description##_

### The content of the PR:
* [ ] _##The mini-design link_
* [ ] _##The basic code logic_

### The UT result
`##The UT output##`
