### PR TITLE
Testcase check for Ubuntu version before mounting mini.iso

### DIFF
--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_flat
@@ -5,8 +5,9 @@ label:flat_cn_diskful,provision
 cmd:fdisk -l
 cmd:df -T
 cmd:if ping -c 1 $$SN > /dev/null;then rpower $$SN off > /dev/null;fi
-cmd:MINIISO=NUll;if [[ "__GETNODEATTR($$CN,os)__" =~ "ubuntu" ]] && [[ "__GETNODEATTR($$CN,arch)__" =~ "ppc64" ]];then mkdir /tmp/iso; mount -o loop $$MINIISO /tmp/iso ;  mkdir -p  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot; cp  /tmp/iso/install/initrd.gz  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot;umount /tmp/iso; rmdir /tmp/iso; fi
+cmd:if [[ "__GETNODEATTR($$CN,os)__" < "ubuntu16.04.2" ]] && [[ "__GETNODEATTR($$CN,arch)__" =~ "ppc64" ]];then mkdir /tmp/iso; mount -o loop $$MINIISO /tmp/iso ;  mkdir -p  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot; cp  /tmp/iso/install/initrd.gz  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot;umount /tmp/iso; rmdir /tmp/iso; fi
 check:rc==0
+check:output!~failed to setup loop device
 cmd: if lsdef service > /dev/null 2>&1; then chdef service -m groups=service;fi
 check:rc==0
 cmd:chdef -t node -o $$CN servicenode= monserver=$$MN nfsserver=$$MN tftpserver=$$MN  xcatmaster=$$MN

--- a/xCAT-test/autotest/testcase/migration/ubuntu_migration1_p8le
+++ b/xCAT-test/autotest/testcase/migration/ubuntu_migration1_p8le
@@ -4,8 +4,9 @@ description:update xCAT from $$UBUNTU_MIGRATION1_VERSION to latest version, thes
 label:others,migration,invoke_provision
 cmd:copycds $$ISO
 check:rc==0
-cmd:if [[ "__GETNODEATTR($$CN,os)__" =~ "ubuntu" ]];then mkdir /tmp/iso; mount -o loop $$MINIISO /tmp/iso ;  mkdir -p  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot; cp  /tmp/iso/install/initrd.gz  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot;umount /tmp/iso; rmdir /tmp/iso; fi
+cmd:if [[ "__GETNODEATTR($$CN,os)__" < "ubuntu16.04.2" ]];then mkdir /tmp/iso; mount -o loop $$MINIISO /tmp/iso ;  mkdir -p  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot; cp  /tmp/iso/install/initrd.gz  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot;umount /tmp/iso; rmdir /tmp/iso; fi
 check:rc==0
+check:output!~failed to setup loop device
 cmd:makedhcp -n
 check:rc==0
 cmd:makedhcp -a

--- a/xCAT-test/autotest/testcase/migration/ubuntu_migration2_p8le
+++ b/xCAT-test/autotest/testcase/migration/ubuntu_migration2_p8le
@@ -4,8 +4,9 @@ description:update xCAT from $$UBUNTU_MIGRATION2_VERSION to latest version, thes
 label:others,migration,invoke_provision
 cmd:copycds $$ISO
 check:rc==0
-cmd:if [[ "__GETNODEATTR($$CN,os)__" =~ "ubuntu" ]];then mkdir /tmp/iso; mount -o loop $$MINIISO /tmp/iso ;  mkdir -p  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot; cp  /tmp/iso/install/initrd.gz  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot;umount /tmp/iso; rmdir /tmp/iso; fi
+cmd:if [[ "__GETNODEATTR($$CN,os)__" < "ubuntu16.04.2" ]];then mkdir /tmp/iso; mount -o loop $$MINIISO /tmp/iso ;  mkdir -p  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot; cp  /tmp/iso/install/initrd.gz  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot;umount /tmp/iso; rmdir /tmp/iso; fi
 check:rc==0
+check:output!~failed to setup loop device
 cmd:makedhcp -n
 check:rc==0
 cmd:makedhcp -a


### PR DESCRIPTION
Currently some testcases try to access `mini.iso` when running on Ubuntu.
According to documentation https://xcat-docs.readthedocs.io/en/stable/guides/admin-guides/manage_clusters/ppc64le/diskful/copy_image.html the `mini.iso` is needed only for pre-16.04.02 version of Ubuntu for ppc64el.
This PR modifies testcase to only access `mini.iso` when running on pre-16.04.02 version of Ubuntu for ppc64el.