### PR TITLE
Use inst instead of inst_rules to install into diskless image

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/dracut_033/install.netboot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_033/install.netboot
@@ -9,5 +9,5 @@ inst "$moddir/xcat-updateflag" "/tmp/updateflag"
 inst "$moddir/xcatroot" "/sbin/xcatroot"
 inst_hook cmdline 10 "$moddir/xcat-cmdline.sh"
 for file in /etc/udev/rules.d/*;do
-	grep -qi xcat $file && inst_rules $(basename $file)
+	grep -qi xcat $file && inst $file $file
 done

--- a/xCAT-server/share/xcat/netboot/rh/dracut_047/install.netboot
+++ b/xCAT-server/share/xcat/netboot/rh/dracut_047/install.netboot
@@ -9,5 +9,5 @@ inst "$moddir/xcat-updateflag" "/tmp/updateflag"
 inst "$moddir/xcatroot" "/sbin/xcatroot"
 inst_hook cmdline 10 "$moddir/xcat-cmdline.sh"
 for file in /etc/udev/rules.d/*;do
-	grep -qi xcat $file && inst_rules $(basename $file)
+	grep -qi xcat $file && inst $file $file
 done


### PR DESCRIPTION
Use `inst` instead of `inst_rules` to install into diskless image.
This PR replaces #7045. Similar problem happens on RH7.6 and `dracut_33/install.netboot` file needs to be updated.

### UT 

* RH7.6:

File in `/install/netboot/rhels7.6-alternate/ppc64le/compute/rootimg/etc/udev/rules.d/` containing `xcat` string:
```
[root@f6u13k19 xcat]# grep xcat /install/netboot/rhels7.6-alternate/ppc64le/compute/rootimg/etc/udev/rules.d/*
/install/netboot/rhels7.6-alternate/ppc64le/compute/rootimg/etc/udev/rules.d/99-mlx5-net-names.rules:# Try xcat rules for eth names
[root@f6u13k19 xcat]#
```
Run `genimage` then `gunzip /install/netboot/rhels7.6-alternate/ppc64le/compute/initrd-stateless.gz`

Before this change:
```
[root@f6u13k19 xcat]# lsinitrd /install/netboot/rhels7.6-alternate/ppc64le/compute/initrd-stateless | grep "99-mlx5-net-names.rules"
[root@f6u13k19 xcat]#
```
After:
```
[root@f6u13k19 xcat]# lsinitrd /install/netboot/rhels7.6-alternate/ppc64le/compute/initrd-stateless | grep "99-mlx5-net-names.rules"
-rw-r--r--   1 root     root          377 Oct 19 12:24 etc/udev/rules.d/99-mlx5-net-names.rules
[root@f6u13k19 xcat]#
```

* RH8.2:

File in `/install/netboot/rhels8.2.0/ppc64le/compute/rootimg/etc/udev/rules.d/` containing `xcat` string:
```
[root@f6u13k16 ~]# grep xcat /install/netboot/rhels8.2.0/ppc64le/compute/rootimg/etc/udev/rules.d/*
/install/netboot/rhels8.2.0/ppc64le/compute/rootimg/etc/udev/rules.d/99-mlx5-net-names.rules:# Try xcat rules for eth names
[root@f6u13k16 ~]#
```
Run `genimage` then `gunzip /install/netboot/rhels8.2.0/ppc64le/compute/initrd-stateless.gz`

Before this change:
```
[root@f6u13k16 ~]# lsinitrd /install/netboot/rhels8.2.0/ppc64le/compute/initrd-stateless | grep "99-mlx5-net-names.rules"
[root@f6u13k16 ~]#
```
After:
```
[root@f6u13k16 ~]# lsinitrd /install/netboot/rhels8.2.0/ppc64le/compute/initrd-stateless | grep "99-mlx5-net-names.rules"
-rw-r--r--   1 root     root          378 Feb 28  2020 etc/udev/rules.d/99-mlx5-net-names.rules
[root@f6u13k16 ~]#