### PR TITLE
Change uefi to not do elilo

### DIFF
--- a/xCAT-server/lib/xcat/plugins/mknb.pm
+++ b/xCAT-server/lib/xcat/plugins/mknb.pm
@@ -327,7 +327,9 @@ sub process_request {
                 close($cfg);
                 open($cfg, ">", "$tftpdir/xcat/xnba/nets/$net.uefi");
                 print $cfg "#!gpxe\n";
-                print $cfg 'chain http://${next-server}:'.$httpport.'/tftpboot/xcat/elilo-x64.efi -C /tftpboot/xcat/xnba/nets/' . "$net.elilo\n";
+                print $cfg 'imgfetch -n kernel http://${next-server}:'.$httpport.'/tftpboot/xcat/genesis.kernel.' . "$arch\nimgload kernel\n";
+                print $cfg "imgargs kernel quiet xcatd=" . $normnets->{$_} . ":$xcatdport $consolecmdline BOOTIF=01-" . '${netX/machyp}' . " destiny=discover initrd=initrd\n";
+                print $cfg 'imgfetch -n initrd http://${next-server}:'.$httpport.'/tftpboot/xcat/genesis.fs.' . "$arch.gz\nimgexec kernel\n";
                 close($cfg);
             }
         } elsif ($arch =~ /ppc/) {


### PR DESCRIPTION
### This PR is to allow a genesis boot without elilo 

The particular Dell R640 systems we have don't seem to like something about elilo, but I couldn't see a way around xcat trying to use elilo.  I made this change to use boot the genesis image directly rather than having xnba boot elilo. 

I didn't see another way to avoid using elilo.
