### PR TITLE
Testcase check for Ubuntu version before mounting mini.iso 2

### DIFF
--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_flat
@@ -5,7 +5,7 @@ label:flat_cn_diskful,provision
 cmd:fdisk -l
 cmd:df -T
 cmd:if ping -c 1 $$SN > /dev/null;then rpower $$SN off > /dev/null;fi
-cmd:if [[ "__GETNODEATTR($$CN,os)__" < "ubuntu16.04.2" ]] && [[ "__GETNODEATTR($$CN,arch)__" =~ "ppc64" ]];then mkdir /tmp/iso; mount -o loop $$MINIISO /tmp/iso ;  mkdir -p  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot; cp  /tmp/iso/install/initrd.gz  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot;umount /tmp/iso; rmdir /tmp/iso; fi
+cmd:if [[ "__GETNODEATTR($$CN,os)__" =~ "ubuntu" ]] && [[ "__GETNODEATTR($$CN,os)__" < "ubuntu16.04.2" ]] && [[ "__GETNODEATTR($$CN,arch)__" =~ "ppc64" ]];then mkdir /tmp/iso; mount -o loop $$MINIISO /tmp/iso ;  mkdir -p  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot; cp  /tmp/iso/install/initrd.gz  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot;umount /tmp/iso; rmdir /tmp/iso; fi
 check:rc==0
 check:output!~failed to setup loop device
 cmd: if lsdef service > /dev/null 2>&1; then chdef service -m groups=service;fi

--- a/xCAT-test/autotest/testcase/migration/ubuntu_migration1_p8le
+++ b/xCAT-test/autotest/testcase/migration/ubuntu_migration1_p8le
@@ -4,7 +4,7 @@ description:update xCAT from $$UBUNTU_MIGRATION1_VERSION to latest version, thes
 label:others,migration,invoke_provision
 cmd:copycds $$ISO
 check:rc==0
-cmd:if [[ "__GETNODEATTR($$CN,os)__" < "ubuntu16.04.2" ]];then mkdir /tmp/iso; mount -o loop $$MINIISO /tmp/iso ;  mkdir -p  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot; cp  /tmp/iso/install/initrd.gz  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot;umount /tmp/iso; rmdir /tmp/iso; fi
+cmd:if [[ "__GETNODEATTR($$CN,os)__" =~ "ubuntu" ]] && [[ "__GETNODEATTR($$CN,os)__" < "ubuntu16.04.2" ]];then mkdir /tmp/iso; mount -o loop $$MINIISO /tmp/iso ;  mkdir -p  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot; cp  /tmp/iso/install/initrd.gz  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot;umount /tmp/iso; rmdir /tmp/iso; fi
 check:rc==0
 check:output!~failed to setup loop device
 cmd:makedhcp -n

--- a/xCAT-test/autotest/testcase/migration/ubuntu_migration2_p8le
+++ b/xCAT-test/autotest/testcase/migration/ubuntu_migration2_p8le
@@ -4,7 +4,7 @@ description:update xCAT from $$UBUNTU_MIGRATION2_VERSION to latest version, thes
 label:others,migration,invoke_provision
 cmd:copycds $$ISO
 check:rc==0
-cmd:if [[ "__GETNODEATTR($$CN,os)__" < "ubuntu16.04.2" ]];then mkdir /tmp/iso; mount -o loop $$MINIISO /tmp/iso ;  mkdir -p  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot; cp  /tmp/iso/install/initrd.gz  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot;umount /tmp/iso; rmdir /tmp/iso; fi
+cmd:if [[ "__GETNODEATTR($$CN,os)__" =~ "ubuntu" ]] && [[ "__GETNODEATTR($$CN,os)__" < "ubuntu16.04.2" ]];then mkdir /tmp/iso; mount -o loop $$MINIISO /tmp/iso ;  mkdir -p  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot; cp  /tmp/iso/install/initrd.gz  /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot;umount /tmp/iso; rmdir /tmp/iso; fi
 check:rc==0
 check:output!~failed to setup loop device
 cmd:makedhcp -n


### PR DESCRIPTION
Update to #7050

Need to also check that `osname =~ "ubuntu"` otherwise osnames of `rhel` and `sles` will evaluate to true.

Verified on Ubuntu and RH