### PR TITLE
Better test when removing firewalld service files

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels8.ppc64le.postinstall
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels8.ppc64le.postinstall
@@ -42,13 +42,15 @@ fi
 
 #--for redhat 8 and 8.1
 #-- Need to disable firewalld, otherwise, the remoteshell script will not able to get all the SSH keys
-if [ -f "$installroot/etc/systemd/system/multi-user.target.wants/firewalld.service" ]
+FIREWALLD="$installroot/etc/systemd/system/multi-user.target.wants/firewalld.service"
+if [[ -f "$FIREWALLD" || -L "$FIREWALLD" ]]
 then
-    rm -rf $installroot/etc/systemd/system/multi-user.target.wants/firewalld.service
+    rm -f $FIREWALLD
 fi
-if [ -f "$installroot/etc/systemd/system/dbus-org.fedoraproject.FirewallD1.service" ]
+FIREWALLD1="$installroot/etc/systemd/system/dbus-org.fedoraproject.FirewallD1.service"
+if [[ -f "$FIREWALLD1" || -L "$FIREWALLD1" ]]
 then
-    rm -rf $installroot/etc/systemd/system/dbus-org.fedoraproject.FirewallD1.service
+    rm -f $FIREWALLD1
 fi
 
 

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels8.x86_64.postinstall
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels8.x86_64.postinstall
@@ -41,13 +41,15 @@ then
 fi
 #--for redhat 8 and 8.1
 #-- Need to disable firewalld, otherwise, the remoteshell script will not able to get all the SSH keys
-if [ -f "$installroot/etc/systemd/system/multi-user.target.wants/firewalld.service" ]
+FIREWALLD="$installroot/etc/systemd/system/multi-user.target.wants/firewalld.service"
+if [[ -f "$FIREWALLD" || -L "$FIREWALLD" ]]
 then
-    rm -rf $installroot/etc/systemd/system/multi-user.target.wants/firewalld.service
+    rm -f $FIREWALLD
 fi
-if [ -f "$installroot/etc/systemd/system/dbus-org.fedoraproject.FirewallD1.service" ]
+FIREWALLD1="$installroot/etc/systemd/system/dbus-org.fedoraproject.FirewallD1.service"
+if [[ -f "$FIREWALLD1" || -L "$FIREWALLD1" ]]
 then
-    rm -rf $installroot/etc/systemd/system/dbus-org.fedoraproject.FirewallD1.service
+    rm -f $FIREWALLD1
 fi
 
 


### PR DESCRIPTION
When `-f` file test is done on a broken link file, it returns false, as a result, firewall service file is not removed.

This PR improves file test to remove the file regardless if it is regular file or good or broken link.
There is also no need to do a recursive remove.

#### UT:
* regular file -> file removed
* no file -> no attempt to remove
* good link -> link removed
* bad link -> link removed