### PR TITLE
Change uefi to not do elilo for network discovery boot

### DIFF
--- a/xCAT-server/lib/xcat/plugins/mknb.pm
+++ b/xCAT-server/lib/xcat/plugins/mknb.pm
@@ -327,7 +327,9 @@ sub process_request {
                 close($cfg);
                 open($cfg, ">", "$tftpdir/xcat/xnba/nets/$net.uefi");
                 print $cfg "#!gpxe\n";
-                print $cfg 'chain http://${next-server}:'.$httpport.'/tftpboot/xcat/elilo-x64.efi -C /tftpboot/xcat/xnba/nets/' . "$net.elilo\n";
+                print $cfg 'imgfetch -n kernel http://${next-server}:'.$httpport.'/tftpboot/xcat/genesis.kernel.' . "$arch\nimgload kernel\n";
+                print $cfg "imgargs kernel quiet xcatd=" . $normnets->{$_} . ":$xcatdport $consolecmdline BOOTIF=01-" . '${netX/machyp}' . " destiny=discover initrd=initrd\n";
+                print $cfg 'imgfetch -n initrd http://${next-server}:'.$httpport.'/tftpboot/xcat/genesis.fs.' . "$arch.gz\nimgexec kernel\n";
                 close($cfg);
             }
         } elsif ($arch =~ /ppc/) {

--- a/xCAT-server/lib/xcat/plugins/mknb.pm
+++ b/xCAT-server/lib/xcat/plugins/mknb.pm
@@ -328,7 +328,7 @@ sub process_request {
                 open($cfg, ">", "$tftpdir/xcat/xnba/nets/$net.uefi");
                 print $cfg "#!gpxe\n";
                 print $cfg 'imgfetch -n kernel http://${next-server}:'.$httpport.'/tftpboot/xcat/genesis.kernel.' . "$arch\nimgload kernel\n";
-                print $cfg "imgargs kernel quiet xcatd=" . $normnets->{$_} . ":$xcatdport $consolecmdline BOOTIF=01-" . '${netX/machyp}' . " destiny=discover initrd=initrd\n";
+                print $cfg "imgargs kernel quiet xcatd=" . $normnets->{$_} . ":$xcatdport $consolecmdline BOOTIF=01-" . '${netX/mac:hexhyp}' . " destiny=discover initrd=initrd\n";
                 print $cfg 'imgfetch -n initrd http://${next-server}:'.$httpport.'/tftpboot/xcat/genesis.fs.' . "$arch.gz\nimgexec kernel\n";
                 close($cfg);
             }


### PR DESCRIPTION
### The PR replaces _#7052_ 
(with one variation: `BOOTIF=01-${netX/mac:hexhyp}` instead of `BOOTIF=01-${netX/machyp}`)

Verified with discovery of `IBM System x3550 M4` node (`c910f04x18`)

```
[root@c910f04x40 gurevich]# cat /tftpboot/xcat/xnba/nets/10.0.0.0_8.uefi
#!gpxe
imgfetch -n kernel http://${next-server}:80/tftpboot/xcat/genesis.kernel.x86_64
imgload kernel
imgargs kernel quiet xcatd=10.4.40.1:3001  BOOTIF=01-${netX/mac:hexhyp} destiny=discover initrd=initrd
imgfetch -n initrd http://${next-server}:80/tftpboot/xcat/genesis.fs.x86_64.gz
imgexec kernel
[root@c910f04x40 gurevich]#
```