### PR TITLE
Enable Oracle Linux and Rocky Linux to Run Statelite Test Cases Successfully

### DIFF
--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -145,7 +145,7 @@ sub process_request
 sub using_dracut
 {
     my $os = shift;
-    if ($os =~ /(rhels|rhel|centos|rocky)(\d+)/) {
+    if ($os =~ /(rhels|rhel|centos|rocky|ol)(\d+)/) {
         if ($2 >= 6) {
             return 1;
         }

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_flat
@@ -25,7 +25,7 @@ cmd:copycds $$ISO
 check:rc==0
 
 
-cmd:if cat /etc/*release |grep SUSE >/dev/null; then  cp /opt/xcat/share/xcat/tools/autotest/testcase/installation/litefile_sles.csv /tmp/litefile.csv;tabrestore /tmp/litefile.csv; elif cat /etc/*release |grep "Red Hat" >/dev/null; then  tabrestore /opt/xcat/share/xcat/tools/autotest/testcase/installation/litefile.csv;fi
+cmd:if cat /etc/*release |grep SUSE >/dev/null; then  cp /opt/xcat/share/xcat/tools/autotest/testcase/installation/litefile_sles.csv /tmp/litefile.csv;tabrestore /tmp/litefile.csv; elif cat /etc/*release |grep "Red Hat\|Rocky" >/dev/null; then  tabrestore /opt/xcat/share/xcat/tools/autotest/testcase/installation/litefile.csv;fi
 check:rc==0
 cmd:tabdump litefile
 check:rc==0
@@ -38,7 +38,7 @@ cmd:cat /etc/exports|grep nodedata; if [ "$?" -ne "0" ]; then echo "/nodedata *(
 check:rc==0
 cmd:cd /etc; export exports;cd -
 check:rc==0
-cmd:if cat /etc/*release |grep SUSE >/dev/null;then service nfsserver restart; elif cat /etc/*release |grep "Red Hat" >/dev/null;then if [ -f /usr/lib/systemd/system/nfs-server.service ]; then service nfs-server restart; else service nfs restart;fi; fi
+cmd:if cat /etc/*release |grep SUSE >/dev/null;then service nfsserver restart; elif cat /etc/*release |grep "Red Hat\|Rocky" >/dev/null;then if [ -f /usr/lib/systemd/system/nfs-server.service ]; then service nfs-server restart; else service nfs restart;fi; fi
 check:rc==0
 cmd:chtab node=$$CN statelite.statemnt="$$MN:/nodedata"
 check:rc==0

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_nfs
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_nfs
@@ -41,7 +41,7 @@ cmd:xdsh $$SN 'cat /etc/exports|grep nodedata; if [ "$?" -ne "0" ]; then echo "/
 check:rc==0
 cmd:xdsh $$SN 'cd /etc; export exports;cd -'
 check:rc==0
-cmd:if cat /etc/*release |grep SUSE >/dev/null;then xdsh $$SN 'service nfsserver restart'; elif cat /etc/*release |grep "Red Hat" >/dev/null;then xdsh $$SN 'if [ -f /usr/lib/systemd/system/nfs-server.service ]; then service nfs-server restart; else service nfs restart;fi'; fi
+cmd:if cat /etc/*release |grep SUSE >/dev/null;then xdsh $$SN 'service nfsserver restart'; elif cat /etc/*release |grep "Red Hat\|Rocky" >/dev/null;then xdsh $$SN 'if [ -f /usr/lib/systemd/system/nfs-server.service ]; then service nfs-server restart; else service nfs restart;fi'; fi
 check:rc==0
 
 cmd:xdsh $$SN 'showmount -e'
@@ -49,7 +49,7 @@ cmd:xdsh $$SN 'showmount -e'
 cmd:chtab node=$$CN statelite.statemnt="$$SN:/nodedata"
 check:rc==0
 
-cmd:if cat /etc/*release |grep SUSE >/dev/null; then cp /opt/xcat/share/xcat/tools/autotest/testcase/installation/litefile_sles.csv /tmp/litefile.csv; tabrestore /tmp/litefile.csv; elif cat /etc/*release |grep "Red Hat" >/dev/null; then  tabrestore /opt/xcat/share/xcat/tools/autotest/testcase/installation/litefile.csv; fi
+cmd:if cat /etc/*release |grep SUSE >/dev/null; then cp /opt/xcat/share/xcat/tools/autotest/testcase/installation/litefile_sles.csv /tmp/litefile.csv; tabrestore /tmp/litefile.csv; elif cat /etc/*release |grep "Red Hat\|Rocky" >/dev/null; then  tabrestore /opt/xcat/share/xcat/tools/autotest/testcase/installation/litefile.csv; fi
 check:rc==0
 cmd:tabdump litefile
 check:rc==0

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_ramdisk
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_ramdisk
@@ -41,13 +41,13 @@ cmd:xdsh $$SN 'cat /etc/exports|grep nodedata; if [ "$?" -ne "0" ]; then echo "/
 check:rc==0
 cmd:xdsh $$SN 'cd /etc; export exports;cd -'
 check:rc==0
-cmd:if cat /etc/*release |grep SUSE >/dev/null;then xdsh $$SN 'service nfsserver restart'; elif cat /etc/*release |grep "Red Hat" >/dev/null;then xdsh $$SN 'if [ -f /usr/lib/systemd/system/nfs-server.service ]; then service nfs-server restart; else service nfs restart;fi'; fi
+cmd:if cat /etc/*release |grep SUSE >/dev/null;then xdsh $$SN 'service nfsserver restart'; elif cat /etc/*release |grep "Red Hat\|Rocky" >/dev/null;then xdsh $$SN 'if [ -f /usr/lib/systemd/system/nfs-server.service ]; then service nfs-server restart; else service nfs restart;fi'; fi
 check:rc==0
 
 cmd:chtab node=$$CN statelite.statemnt="$$SN:/nodedata"
 check:rc==0
 
-cmd:if cat /etc/*release |grep SUSE >/dev/null; then cp /opt/xcat/share/xcat/tools/autotest/testcase/installation/litefile_sles.csv /tmp/litefile.csv; tabrestore /tmp/litefile.csv; elif cat /etc/*release |grep "Red Hat" >/dev/null; then  tabrestore /opt/xcat/share/xcat/tools/autotest/testcase/installation/litefile.csv; fi
+cmd:if cat /etc/*release |grep SUSE >/dev/null; then cp /opt/xcat/share/xcat/tools/autotest/testcase/installation/litefile_sles.csv /tmp/litefile.csv; tabrestore /tmp/litefile.csv; elif cat /etc/*release |grep "Red Hat\|Rocky" >/dev/null; then  tabrestore /opt/xcat/share/xcat/tools/autotest/testcase/installation/litefile.csv; fi
 check:rc==0
 cmd:tabdump litefile
 check:rc==0


### PR DESCRIPTION
/etc/*release contains "Red Hat" in the output on RHEL and Oracle Linux, but not Rocky Linux. The last one has "Rocky" in it. 

Rocky Linux has a problem with the following command in reg_linux_statelite_installation_hierarchy_by_nfs:
```
cmd:if cat /etc/*release |grep SUSE >/dev/null; then cp /opt/xcat/share/xcat/tools/autotest/testcase/installation/litefile_sles.csv /tmp/litefile.csv; tabrestore /tmp/litefile.csv; elif cat /etc/*release |grep "Red Hat" >/dev/null; then  tabrestore /opt/xcat/share/xcat/tools/autotest/testcase/installation/litefile.csv; fi
```
The litefile table is loaded on MN only if "/etc/*release" contains the string "Red Hat". If true, the files in litefile.csv will be copied from MN to SN. And later, CN will mount to /install on SN for provisioning.

Since Rocky Linux missed all these files, it failed on reg_linux_statelite_installation_hierarchy_by_nfs, reg_linux_statelite_installation_hierarchy_by_ramdisk and reg_linux_statelite_installation_flat.

The inclusion of Rocky "(\\|Rocky)" for OS checking in the above three statelite test cases fixed the problem.

However, Oracle Linux failed too, not due to these missing files. The console showed problems in dracut-pre-pivot.

It turns out that "ol" is not included in the subroutine "using_dracut" in anaconda.pm. Once included, reg_linux_statelite_installation_hierarchy_by_nfs ran to completion quickly.