### PR TITLE
Fix litefile entries for osimages with groups

### DIFF
--- a/xCAT-server/lib/xcat/plugins/litetree.pm
+++ b/xCAT-server/lib/xcat/plugins/litetree.pm
@@ -344,25 +344,20 @@ sub getNodeData {
         my $imagegroups = $osimagetab->getAttribs({ imagename => $image }, @imagegroupsattr);
         if ($imagegroups and $imagegroups->{groups}) {
 
-            # get the directories with no names
-            push @imageInfo, $tab->getAttribs({ image => '' }, @attrs);
-
             # get for the image groups specific directories
             push @imageInfo, $tab->getAttribs({ image => $imagegroups->{groups} }, @attrs);
 
-            # get for the image specific directories
-            push @imageInfo, $tab->getAttribs({ image => $image }, @attrs);
-        } else {
-
-            # get the directories with no names
-            push @imageInfo, $tab->getAttribs({ image => '' }, @attrs);
-
-            # get the ALL directories
-            push @imageInfo, $tab->getAttribs({ image => 'ALL' }, @attrs);
-
-            # get for the image specific directories
-            push @imageInfo, $tab->getAttribs({ image => $image }, @attrs);
         }
+        # These cases should run for all images
+        # get the directories with no names
+        push @imageInfo, $tab->getAttribs({ image => '' }, @attrs);
+
+        # get the ALL directories
+        push @imageInfo, $tab->getAttribs({ image => 'ALL' }, @attrs);
+
+        # get for the image specific directories
+        push @imageInfo, $tab->getAttribs({ image => $image }, @attrs);
+        
     }
 
     # pass back a reference to the directory


### PR DESCRIPTION
### The PR is to fix an old issue described at https://sourceforge.net/p/xcat/bugs/4351/

### The modifications include:
Fix `litefile` command to get `litefile` table entries for `ALL` images when the `groups` parameter is set in the `osimage` definition

Before this change, any `osimage` with the `groups` parameter defined to anything but `ALL` would not get entries set for `ALL` in the `litefile` table.

### Our `litefile` table
```
#image,file,options,comments,disable
"ALL","/etc/adjtime","tmpfs",,
"ALL","/etc/securetty","tmpfs",,
"ALL","/etc/lvm/","tmpfs",,
"ALL","/etc/ntp.conf","tmpfs",,
"ALL","/etc/rsyslog.conf","tmpfs",,
"ALL","/etc/rsyslog.conf.XCATORIG","tmpfs",,
"ALL","/etc/udev/","tmpfs",,
"ALL","/etc/ntp.conf.predhclient","tmpfs",,
"ALL","/etc/resolv.conf","tmpfs",,
"ALL","/etc/yp.conf","tmpfs",,
"ALL","/etc/resolv.conf.predhclient","tmpfs",,
"ALL","/etc/sysconfig/","tmpfs",,
"ALL","/etc/ssh/","tmpfs",,
"ALL","/etc/inittab","tmpfs",,
"ALL","/tmp/","tmpfs",,
"ALL","/var/","tmpfs",,
"ALL","/var/lib/yum/","ro",,
"ALL","/var/lib/rpm/","ro",,
"ALL","/opt/xcat/","tmpfs",,
"ALL","/xcatpost/","tmpfs",,
"ALL","/etc/systemd/system/multi-user.target.wants/","tmpfs",,
"ALL","/root/","tmpfs",,
"ALL","/etc/rc3.d/","tmpfs",,
"ALL","/etc/rc2.d/","tmpfs",,
"ALL","/etc/rc4.d/","tmpfs",,
"ALL","/etc/rc5.d/","tmpfs",,
"ALL","/var/lib/mlocate/mlocate.db","tmpfs",,
"ALL","/etc/kdump.conf","tmpfs",,
"ALL","/etc/dracut.conf","tmpfs",,
"ALL","/boot","tmpfs",,
"gateway","/var/lib/pacemaker","persistent",,
"dtr","/var/lib/pacemaker","persistent",,
"dtr","/etc/lnet.conf","persistent",,
"login","/etc/grid-security","persistent",,
"login","/usr/local/ace/sdstatus.1","persistent",,
```

### The `osimage` definition
```
Object name: centos7-statelite-login-20211109
    dump=nfs://10.187.1.150/install/crash
    exlist=/install/custom/netboot/centos/login.centos7.exlist
    groups=login
    imagetype=linux
    osarch=x86_64
    osdistroname=centos7.6-x86_64
    osname=Linux
    osvers=centos7.6
    otherpkgdir=/install/post/otherpkgs/centos7.6/x86_64
    permission=755
    pkgdir=/install/centos7.5/x86_64,/install/mirror/centos7/base,/install/mirror/centos7/updates,/install/mirror/centos7/extras,/install/mirror/centos7/Fairmont-EPEL-7,/install/mirror/rdhpcs
    pkglist=/install/custom/netboot/centos/login.centos7.pkglist
    postinstall=/install/custom/netboot/centos/compute.centos7.postinstall
    profile=compute
    provmethod=statelite
    rootimgdir=/install/netboot/centos7-statelite/x86_64/login-20211109
```


### Before change:
```
[root@j1x1 xcat]# ilitefile centos7-statelite-login-20211109
centos7-statelite-login-20211109: persistent    /etc/grid-security
centos7-statelite-login-20211109: persistent    /usr/local/ace/sdstatus.1
centos7-statelite-login-20211109: link          /etc/mtab
```

### After change:
```
[root@j1x1 xcat]# ilitefile centos7-statelite-login-20211109
centos7-statelite-login-20211109: tmpfs         /boot
centos7-statelite-login-20211109: tmpfs         /etc/adjtime
centos7-statelite-login-20211109: tmpfs         /etc/dracut.conf
centos7-statelite-login-20211109: persistent    /etc/grid-security
centos7-statelite-login-20211109: tmpfs         /etc/inittab
centos7-statelite-login-20211109: tmpfs         /etc/kdump.conf
centos7-statelite-login-20211109: tmpfs         /etc/lvm/
centos7-statelite-login-20211109: link          /etc/mtab
centos7-statelite-login-20211109: tmpfs         /etc/ntp.conf
centos7-statelite-login-20211109: tmpfs         /etc/ntp.conf.predhclient
centos7-statelite-login-20211109: tmpfs         /etc/rc2.d/
centos7-statelite-login-20211109: tmpfs         /etc/rc3.d/
centos7-statelite-login-20211109: tmpfs         /etc/rc4.d/
centos7-statelite-login-20211109: tmpfs         /etc/rc5.d/
centos7-statelite-login-20211109: tmpfs         /etc/resolv.conf
centos7-statelite-login-20211109: tmpfs         /etc/resolv.conf.predhclient
centos7-statelite-login-20211109: tmpfs         /etc/rsyslog.conf
centos7-statelite-login-20211109: tmpfs         /etc/rsyslog.conf.XCATORIG
centos7-statelite-login-20211109: tmpfs         /etc/securetty
centos7-statelite-login-20211109: tmpfs         /etc/ssh/
centos7-statelite-login-20211109: tmpfs         /etc/sysconfig/
centos7-statelite-login-20211109: tmpfs         /etc/systemd/system/multi-user.target.wants/
centos7-statelite-login-20211109: tmpfs         /etc/udev/
centos7-statelite-login-20211109: tmpfs         /etc/yp.conf
centos7-statelite-login-20211109: tmpfs         /opt/xcat/
centos7-statelite-login-20211109: tmpfs         /root/
centos7-statelite-login-20211109: tmpfs         /tmp/
centos7-statelite-login-20211109: persistent    /usr/local/ace/sdstatus.1
centos7-statelite-login-20211109: tmpfs         /var/
centos7-statelite-login-20211109: tmpfs         /var/lib/mlocate/mlocate.db
centos7-statelite-login-20211109: ro            /var/lib/rpm/
centos7-statelite-login-20211109: ro            /var/lib/yum/
centos7-statelite-login-20211109: tmpfs         /xcatpost/
```