### PR TITLE
Display console log entries when genesis nodeset testcases fail

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/index.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/index.rst
@@ -5,7 +5,7 @@ Most of the content is general information for xCAT, the focus and examples are 
 
 IBM OpenPOWER Servers
   * based on POWER8 Processor Technology is IPMI managed
-  * based on POWER9 Processor Technology is OpenBMC managed [**Alpha**]
+  * based on POWER9 Processor Technology is OpenBMC managed
 
 
 .. toctree::

--- a/xCAT-test/autotest/testcase/genesis/genesistest.pl
+++ b/xCAT-test/autotest/testcase/genesis/genesistest.pl
@@ -277,6 +277,8 @@ sub testxdsh {
     if (($value == 1) || ($value == 2) || ($value == 3)) {
         `$xdsh_command`;
         if ($?) {
+            # First attempt to run xdsh failed, display console log to see what happened, then try few more times
+            `tail --lines 25 /var/log/consoles/$noderange.log`;
             my @i = (1..5);
             for (@i) {
                 sleep 300;

--- a/xCAT-test/autotest/testcase/genesis/genesistest.pl
+++ b/xCAT-test/autotest/testcase/genesis/genesistest.pl
@@ -278,7 +278,7 @@ sub testxdsh {
         `$xdsh_command`;
         if ($?) {
             # First attempt to run xdsh failed, display console log to see what happened, then try few more times
-            `tail --lines 25 /var/log/consoles/$noderange.log`;
+            `nodels $noderange | xargs -I % tail -v --lines 25 /var/log/consoles/%.log`
             my @i = (1..5);
             for (@i) {
                 sleep 300;

--- a/xCAT-test/autotest/testcase/genesis/genesistest.pl
+++ b/xCAT-test/autotest/testcase/genesis/genesistest.pl
@@ -278,7 +278,7 @@ sub testxdsh {
         `$xdsh_command`;
         if ($?) {
             # First attempt to run xdsh failed, display console log to see what happened, then try few more times
-            `nodels $noderange | xargs -I % tail -v --lines 25 /var/log/consoles/%.log`
+            `nodels $noderange | xargs -I % tail -v --lines 25 /var/log/consoles/%.log`;
             my @i = (1..5);
             for (@i) {
                 sleep 300;


### PR DESCRIPTION
Sometimes genesis `nodeset_*` testcases fail during weekly regression run, but are successful when started manually.

Most likely `rinstall <node> shell` fails to provision the node with genesis. This PR displays the end of console log file to help figure out what happened.