### PR TITLE
syslog postscript check for config files

### DIFF
--- a/xCAT/postscripts/syslog
+++ b/xCAT/postscripts/syslog
@@ -179,26 +179,32 @@ config_rsyslog_V8()
     cp -f $conf_file $conf_file.XCATORIG
   fi
 
-  # check if already an old entry by xCAT. If so, we need to remove it
-  grep "$xCATSettingsOLD$" $conf_file 2>&1 1> /dev/null
-  if [ $? -eq 0 ]; then
-       sed -i "/$xCATSettingsOLD/,+1 d" $conf_file
+  if [ -e $conf_file ]; then
+      # check if already an old entry by xCAT. If so, we need to remove it
+      grep "$xCATSettingsOLD$" $conf_file 2>&1 1> /dev/null
+      if [ $? -eq 0 ]; then
+          sed -i "/$xCATSettingsOLD/,+1 d" $conf_file
+      fi
+
+      # check if already a previous entry by xCAT. If so, we need to remove it
+      grep "$xCATSettingsSTART" $conf_file 2>&1 1> /dev/null
+      if [ $? -eq 0 ]; then
+          sed -i "/$xCATSettingsSTART/,/$xCATSettingsEND/ d" $conf_file
+      fi
   fi
 
-  grep "$xCATSettingsOLD$" $remoteconf 2>&1 1> /dev/null
-  if [ $? -eq 0 ]; then
-       sed -i "/$xCATSettingsOLD/,+1 d" $remoteconf
-  fi
+  if [ -e $remoteconf ]; then
+      # check if already an old entry by xCAT. If so, we need to remove it
+      grep "$xCATSettingsOLD$" $remoteconf 2>&1 1> /dev/null
+      if [ $? -eq 0 ]; then
+          sed -i "/$xCATSettingsOLD/,+1 d" $remoteconf
+      fi
 
-  # check if already a previous entry by xCAT. If so, we need to remove it
-  grep "$xCATSettingsSTART" $conf_file 2>&1 1> /dev/null
-  if [ $? -eq 0 ]; then
-        sed -i "/$xCATSettingsSTART/,/$xCATSettingsEND/ d" $conf_file
-  fi
-
-  grep "$xCATSettingsSTART" $remoteconf 2>&1 1> /dev/null
-  if [ $? -eq 0 ]; then
-     sed -i "/$xCATSettingsSTART/,/$xCATSettingsEND/ d" $remoteconf
+      # check if already a previous entry by xCAT. If so, we need to remove it
+      grep "$xCATSettingsSTART" $remoteconf 2>&1 1> /dev/null
+      if [ $? -eq 0 ]; then
+          sed -i "/$xCATSettingsSTART/,/$xCATSettingsEND/ d" $remoteconf
+      fi
   fi
 
   if [ $goLocal -eq 1 ]; then


### PR DESCRIPTION
When `syslog` postscript runs during initial node provisioning it displays `No such file or directory` in `xcat.log` file :
```
c910f03c11k16: Wed Nov 10 22:50:54 EST 2021 [info]: xcat.deployment.postscript: Running postscript: syslog
c910f03c11k16: grep: /etc/rsyslog.d/remote.conf: No such file or directory
c910f03c11k16: grep: /etc/rsyslog.d/remote.conf: No such file or directory
c910f03c11k16: Wed Nov 10 22:50:55 EST 2021 [info]: xcat.deployment.postscript: postscript syslog return with 0
```

This could lead user to believe that something has failed during `syslog` postscript execution.

This PR checks that the file exists, before running `grep` on it.