### PR TITLE
Update pasu command documentation

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/pasu.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/pasu.1.rst
@@ -34,9 +34,9 @@ DESCRIPTION
 The \ **pasu**\  command runs the ASU command in out-of-band mode in parallel to multiple nodes.  Out-of-band mode means
 that ASU connects from the xCAT management node to the IMM (BMC) of each node to set or query the ASU settings.  To
 see all of the ASU settings available on the node, use the "show all" command.  To query or set multiple values,
-use the \ **-b**\  (batch) option.  To group similar output from multiple nodes, use xcoll(1)|xcoll.1.
+use the \ **-b**\  (batch) option.  To group similar output from multiple nodes, use \ **xcoll**\ .
 
-Before running \ **pasu**\ , you must install the ASU RPM from IBM.  You can download it from the IBM Fix Central site.
+Before running \ **pasu**\ , you must install the ASU RPM.  At the time of this writing, the latest version can be downloaded from https://support.lenovo.com/us/en/solutions/ht115050-advanced-settings-utility-asu Older versions can be found on the IBM Fix Central site.
 You also must configure the IMMs properly according to xCAT documentation.  Run "\ **rpower**\  \ *noderange*\  \ **stat**\ "
 to confirm that the IMMs are configured properly.
 
@@ -49,14 +49,14 @@ OPTIONS
 
 \ **-l|-**\ **-loginname**\  \ *username*\ 
  
- The username to use to connect to the IMMs.  If not specified, the row in the xCAT \ **passwd**\  table with key "ipmi"
+ The username to use to connect to the IMMs.  If not specified, the row in the xCAT \ *passwd*\  table with key "ipmi"
  will be used to get the username.
  
 
 
 \ **-p|-**\ **-passwd**\  \ *passwd*\ 
  
- The password to use to connect to the IMMs.  If not specified, the row in the xCAT passwd table with key "ipmi"
+ The password to use to connect to the IMMs.  If not specified, the row in the xCAT \ *passwd*\  table with key "ipmi"
  will be used to get the password.
  
 
@@ -76,7 +76,7 @@ OPTIONS
 
 \ **-d|-**\ **-donotfilter**\ 
  
- By default, pasu filters out (i.e. does not display) the standard initial output from ASU:
+ By default, \ **pasu**\  filters out (i.e. does not display) the standard initial output from ASU:
  
  
  .. code-block:: perl

--- a/xCAT-client/pods/man1/pasu.1.pod
+++ b/xCAT-client/pods/man1/pasu.1.pod
@@ -15,9 +15,9 @@ B<pasu> [B<-h> | B<--help>]
 The B<pasu> command runs the ASU command in out-of-band mode in parallel to multiple nodes.  Out-of-band mode means
 that ASU connects from the xCAT management node to the IMM (BMC) of each node to set or query the ASU settings.  To
 see all of the ASU settings available on the node, use the "show all" command.  To query or set multiple values,
-use the B<-b> (batch) option.  To group similar output from multiple nodes, use L<xcoll(1)|xcoll.1>.
+use the B<-b> (batch) option.  To group similar output from multiple nodes, use B<xcoll>.
 
-Before running B<pasu>, you must install the ASU RPM from IBM.  You can download it from the IBM Fix Central site.
+Before running B<pasu>, you must install the ASU RPM.  At the time of this writing, the latest version can be downloaded from https://support.lenovo.com/us/en/solutions/ht115050-advanced-settings-utility-asu Older versions can be found on the IBM Fix Central site.
 You also must configure the IMMs properly according to xCAT documentation.  Run "B<rpower> I<noderange> B<stat>"
 to confirm that the IMMs are configured properly.
 
@@ -27,12 +27,12 @@ to confirm that the IMMs are configured properly.
 
 =item B<-l|--loginname> I<username>
 
-The username to use to connect to the IMMs.  If not specified, the row in the xCAT B<passwd> table with key "ipmi"
+The username to use to connect to the IMMs.  If not specified, the row in the xCAT I<passwd> table with key "ipmi"
 will be used to get the username.
 
 =item B<-p|--passwd> I<passwd>
 
-The password to use to connect to the IMMs.  If not specified, the row in the xCAT passwd table with key "ipmi"
+The password to use to connect to the IMMs.  If not specified, the row in the xCAT I<passwd> table with key "ipmi"
 will be used to get the password.
 
 =item B<-f|--fanout>
@@ -46,7 +46,7 @@ A simple text file that contains multiple ASU commands, each on its own line.
 
 =item B<-d|--donotfilter>
 
-By default, pasu filters out (i.e. does not display) the standard initial output from ASU:
+By default, B<pasu> filters out (i.e. does not display) the standard initial output from ASU:
 
  IBM Advanced Settings Utility version 9.30.79N
  Licensed Materials - Property of IBM


### PR DESCRIPTION
Update man page for `pasu` command to specify where ASU rpm can be downloaded from and fix some formatting.