### PR TITLE
Testcase script needs to capture output and display using send_msg()

### DIFF
--- a/xCAT-test/autotest/testcase/genesis/genesistest.pl
+++ b/xCAT-test/autotest/testcase/genesis/genesistest.pl
@@ -278,7 +278,8 @@ sub testxdsh {
         `$xdsh_command`;
         if ($?) {
             # First attempt to run xdsh failed, display console log to see what happened, then try few more times
-            `nodels $noderange | xargs -I % tail -v --lines 25 /var/log/consoles/%.log`;
+            my $console_log = `nodels $noderange | xargs -I % tail -v --lines 25 /var/log/consoles/%.log`;
+            send_msg(2, "Console log: $console_log \n");
             my @i = (1..5);
             for (@i) {
                 sleep 300;


### PR DESCRIPTION
Continue work #7069 

The command output needs to be captured in a variable and displayed using `send_msg`