### PR TITLE
Increase timeout for wait_nic_connect_intime in nicutils.sh from 40 seconds to 80

### DIFF
--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -1886,7 +1886,7 @@ function is_connection_activate_intime {
 
 function wait_nic_connect_intime {
     nic_name=$1
-    time_out=40
+    time_out=80
     con_name=''
     if [ ! -z "$2" ]; then
         time_out=$2


### PR DESCRIPTION
This gives more time to create bonds and bridges for confignetwork test cases. It is definitely helpful in bare-metal systems.