### PR TITLE
Improve packimage time zone handling

### DIFF
--- a/xCAT-server/lib/xcat/plugins/packimage.pm
+++ b/xCAT-server/lib/xcat/plugins/packimage.pm
@@ -351,6 +351,8 @@ sub process_request {
             
                 # Add the zoneinfo to the include list
                 $excludetext .= "+./usr/share/zoneinfo/$timezone[0]\n";
+            } else {
+                $callback->({ info => ["No timezone defined in site table, skipping timezone configuration"] });
             }
 
             #handle the #INLCUDE# tag recursively

--- a/xCAT-server/lib/xcat/plugins/packimage.pm
+++ b/xCAT-server/lib/xcat/plugins/packimage.pm
@@ -351,6 +351,10 @@ sub process_request {
             
                 # Add the zoneinfo to the include list
                 $excludetext .= "+./usr/share/zoneinfo/$timezone[0]\n";
+                
+                if (not stat "$rootimg_dir/etc/localtime") {
+                    $callback->({ warning => ["Unable to set timezone to \'$timezone[0]\', check this is a valid timezone"] });
+                } 
             } else {
                 $callback->({ info => ["No timezone defined in site table, skipping timezone configuration"] });
             }

--- a/xCAT-server/lib/xcat/plugins/packimage.pm
+++ b/xCAT-server/lib/xcat/plugins/packimage.pm
@@ -352,6 +352,15 @@ sub process_request {
                 # Add the zoneinfo to the include list
                 $excludetext .= "+./usr/share/zoneinfo/$timezone[0]\n";
                 
+                # /usr/share/zoneinfo can have many levels of links
+                # If the configured timezone is a link, also add the link target to the include list
+                # Note: this logic can only handle 2 levels of linking
+                my $realtimezonefile = Cwd::abs_path("$rootimg_dir/usr/share/zoneinfo/$timezone[0]");
+                if ("$rootimg_dir/usr/share/zoneinfo/$timezone[0]" ne "$realtimezonefile") {
+                    my $relativetzpath = substr($realtimezonefile, length($rootimg_dir));
+                    $excludetext .= "+.$relativetzpath\n";
+                }
+                
                 if (not stat "$rootimg_dir/etc/localtime") {
                     $callback->({ warning => ["Unable to set timezone to \'$timezone[0]\', check this is a valid timezone"] });
                 } 


### PR DESCRIPTION
By default, xCAT usually strips the contents of `/usr/share/zoneinfo` out of diskless images to save space. `packimage` attempts to workaround the missing `/usr/share/zoneinfo` by copying zoneinfo files directly to `/etc/` in the image. Two attempts have been made to configure the timezone on the diskless image when no files exist in `/usr/share/zoneinfo`.

The older approach copied the time zone file from `/usr/share/zoneinfo` directly to `/etc/localtime` in the image.
The more recent attempt (#7032) copied the time zone file from `/usr/share/zoneinfo` to `/etc`, then linked `/etc/localtime` to that file. Unfortunately, neither of these approaches succeeded and `timedatectl` reports the time zone as "n/a".

### Behavior prior to the changes contained in this PR (RHEL 8.4):
```
root@f6u13k04 ~]# tabdump site | grep timezone
"timezone","America/New_York",,

[root@f6u13k04 ~]# grep "/usr/share/zoneinfo" /opt/xcat/share/xcat/netboot/rh/compute.rhels8.ppc64le.exlist
./usr/share/zoneinfo*

[root@f6u13k04 ~]# packimage rhels8.4.0-ppc64le-netboot-compute
Packing contents of /install/netboot/rhels8.4.0/ppc64le/compute/rootimg
archive method:cpio
compress method:pigz

[root@f6u13k04 ~]# rinstall f6u13k06 osimage=rhels8.4.0-ppc64le-netboot-compute
Provision node(s): f6u13k06
f6u13k06: netboot rhels8.4.0-ppc64le-compute

[root@f6u13k04 ~]# xdsh f6u13k06 timedatectl
f6u13k06:                Local time: Tue 2021-11-23 19:20:37 UTC
f6u13k06:            Universal time: Tue 2021-11-23 19:20:37 UTC
f6u13k06:                  RTC time: Tue 2021-11-23 19:20:37
f6u13k06:                 Time zone: n/a (UTC, +0000)
f6u13k06: System clock synchronized: yes
f6u13k06:               NTP service: active
f6u13k06:           RTC in local TZ: no

[root@f6u13k04 ~]# xdsh f6u13k06 'ls -al /etc/localtime'
f6u13k06: lrwxrwxrwx 1 root root 16 Nov 23 14:17 /etc/localtime -> America/New_York

[root@f6u13k04 ~]# xdsh f6u13k06 'find /usr/share/zoneinfo'
[f6u13k04]: f6u13k06: find: '/usr/share/zoneinfo': No such file or directory
```

This PR revisits the timezone configuration for diskless images.
The first change is to include the configured timezone files in `/usr/share/zoneinfo` during `packimage`, even if `/usr/share/zoneinfo` is marked for exclusion from the packed image in the image `exlist`. In addition, `/usr/share/zoneinfo` can contain more than one level of links, on Ubuntu 18.04.2, for example. In order to handle this, the new `packimage` logic preserves up to two levels of linking from `/etc/localtime`.
For example, on Ubuntu 18.04.2, the timezone `US/Eastern` looks like this:
```
root@f6u13k10:~# xdsh f6u13k12 "realpath /etc/localtime"
f6u13k12: /usr/share/zoneinfo/posixrules

root@f6u13k10:~# xdsh f6u13k12 "ls -al /etc/localtime"
f6u13k12: lrwxrwxrwx 1 root root 32 Dec  2 09:49 /etc/localtime -> ../usr/share/zoneinfo/US/Eastern

root@f6u13k10:~# xdsh f6u13k12 "ls -al /usr/share/zoneinfo/US/Eastern"
f6u13k12: lrwxrwxrwx 1 root root 13 Dec  2 09:49 /usr/share/zoneinfo/US/Eastern -> ../posixrules

root@f6u13k10:~# xdsh f6u13k12 "ls -al /usr/share/zoneinfo/posixrules"
f6u13k12: -rw-r--r-- 1 root root 3545 Mar 26  2018 /usr/share/zoneinfo/posixrules

root@f6u13k10:~# xdsh f6u13k12 "find /usr/share/zoneinfo"
f6u13k12: /usr/share/zoneinfo
f6u13k12: /usr/share/zoneinfo/posixrules
f6u13k12: /usr/share/zoneinfo/US
f6u13k12: /usr/share/zoneinfo/US/Eastern
```
`packimage` will also now display additional information if either:
- No timezone is configured in the site table
- packimage cannot correlate the configured time zone with the files in `/usr/share/zoneinfo`

### Updated behavior showing successful time zone configuration (RHEL 8.4):
```
[root@f6u13k04 ~]# tabdump site | grep timezone
"timezone","America/New_York",,
[root@f6u13k04 ~]# grep "/usr/share/zoneinfo" /opt/xcat/share/xcat/netboot/rh/compute.rhels8.ppc64le.exlist
./usr/share/zoneinfo*

[root@f6u13k04 ~]# packimage rhels8.4.0-ppc64le-netboot-compute
Packing contents of /install/netboot/rhels8.4.0/ppc64le/compute/rootimg
archive method:cpio
compress method:pigz

[root@f6u13k04 ~]# rinstall f6u13k06 osimage=rhels8.4.0-ppc64le-netboot-compute
Provision node(s): f6u13k06
f6u13k06: netboot rhels8.4.0-ppc64le-compute
. 
[root@f6u13k04 ~]# xdsh f6u13k06 timedatectl
f6u13k06:                Local time: Wed 2021-12-08 09:39:42 EST
f6u13k06:            Universal time: Wed 2021-12-08 14:39:42 UTC
f6u13k06:                  RTC time: Wed 2021-12-08 14:39:42
f6u13k06:                 Time zone: America/New_York (EST, -0500)
f6u13k06: System clock synchronized: yes
f6u13k06:               NTP service: active
f6u13k06:           RTC in local TZ: no

[root@f6u13k04 ~]# xdsh f6u13k06 "realpath /etc/localtime"
f6u13k06: /usr/share/zoneinfo/America/New_York

[root@f6u13k04 ~]# xdsh f6u13k06 'ls -al /etc/localtime'
f6u13k06: lrwxrwxrwx 1 root root 38 Dec  8 09:34 /etc/localtime -> ../usr/share/zoneinfo/America/New_York

[root@f6u13k04 ~]# xdsh f6u13k06 "find /usr/share/zoneinfo"
f6u13k06: /usr/share/zoneinfo
f6u13k06: /usr/share/zoneinfo/America
f6u13k06: /usr/share/zoneinfo/America/New_York
```

### Test with timezone missing from site table (RHEL 8.4):
> No timezone defined in site table, skipping timezone configuration
```
[root@f6u13k04 xCAT_plugin]# tabdump site | grep timezone

[root@f6u13k04 xCAT_plugin]# grep "/usr/share/zoneinfo" /opt/xcat/share/xcat/netboot/rh/compute.rhels8.ppc64le.exlist
./usr/share/zoneinfo*

[root@f6u13k04 xCAT_plugin]# packimage rhels8.4.0-ppc64le-netboot-compute
No timezone defined in site table, skipping timezone configuration
Packing contents of /install/netboot/rhels8.4.0/ppc64le/compute/rootimg
archive method:cpio
compress method:pigz

[root@f6u13k04 xCAT_plugin]# rinstall f6u13k06 osimage=rhels8.4.0-ppc64le-netboot-compute
Provision node(s): f6u13k06
f6u13k06: netboot rhels8.4.0-ppc64le-compute

[root@f6u13k04 xCAT_plugin]# xdsh f6u13k06 timedatectl
f6u13k06:                Local time: Tue 2021-11-30 18:08:07 UTC
f6u13k06:            Universal time: Tue 2021-11-30 18:08:07 UTC
f6u13k06:                  RTC time: Tue 2021-11-30 18:08:06
f6u13k06:                 Time zone: UTC (UTC, +0000)
f6u13k06: System clock synchronized: yes
f6u13k06:               NTP service: active
f6u13k06:           RTC in local TZ: no

[root@f6u13k04 xCAT_plugin]# xdsh f6u13k06 'ls -al /etc/localtime'
f6u13k06: lrwxrwxrwx 1 root root 25 Nov 30 07:22 /etc/localtime -> ../usr/share/zoneinfo/UTC

[root@f6u13k04 xCAT_plugin]# xdsh f6u13k06 'find /usr/share/zoneinfo'
[f6u13k04]: f6u13k06: find: '/usr/share/zoneinfo': No such file or directory
```

### Test with invalid timezone configured, `packimage` warns, but time zone is still partially set (RHEL 8.4):
> Warning: [f6u13k04]: Unable to set timezone to 'America/Old_York', check this is a valid timezone
```
[root@f6u13k04 xCAT_plugin]# tabdump site | grep timezone
"timezone","America/Old_York",,

[root@f6u13k04 xCAT_plugin]# packimage rhels8.4.0-ppc64le-netboot-compute
Warning: [f6u13k04]: Unable to set timezone to 'America/Old_York', check this is a valid timezone
Packing contents of /install/netboot/rhels8.4.0/ppc64le/compute/rootimg
archive method:cpio
compress method:pigz

[root@f6u13k04 xCAT_plugin]# rinstall f6u13k06 osimage=rhels8.4.0-ppc64le-netboot-compute
Provision node(s): f6u13k06
f6u13k06: netboot rhels8.4.0-ppc64le-compute

[root@f6u13k04 xCAT_plugin]# xdsh f6u13k06 timedatectl
f6u13k06:                Local time: Tue 2021-11-30 19:02:17 America
f6u13k06:            Universal time: Tue 2021-11-30 19:02:17 UTC
f6u13k06:                  RTC time: Tue 2021-11-30 19:02:17
f6u13k06:                 Time zone: America/Old_York (America, +0000)
f6u13k06: System clock synchronized: yes
f6u13k06:               NTP service: active
f6u13k06:           RTC in local TZ: no

[root@f6u13k04 xCAT_plugin]# xdsh f6u13k06 'ls -al /etc/localtime'
f6u13k06: lrwxrwxrwx 1 root root 38 Nov 30 18:38 /etc/localtime -> ../usr/share/zoneinfo/America/Old_York

[root@f6u13k04 xCAT_plugin]# xdsh f6u13k06 'find /usr/share/zoneinfo'
[f6u13k04]: f6u13k06: find: '/usr/share/zoneinfo': No such file or directory 
```

### Updated behavior showing successful time zone configuration, two levels of linking (Ubuntu 18.04.2):
```
root@f6u13k10:~# tabdump site | grep timezone
"timezone","America/New_York",,

root@f6u13k10:~# packimage ubuntu18.04.2-ppc64el-netboot-compute
Packing contents of /install/netboot/ubuntu18.04.2/ppc64el/compute/rootimg
archive method:cpio
compress method:gzip

root@f6u13k10:~# rinstall f6u13k12 osimage=ubuntu18.04.2-ppc64el-netboot-compute
Provision node(s): f6u13k12
root@f6u13k10:~# xdsh f6u13k12 timedatectl                                  
f6u13k12:                       Local time: Wed 2021-12-08 10:44:38 EST
f6u13k12:                   Universal time: Wed 2021-12-08 15:44:38 UTC
f6u13k12:                         RTC time: Wed 2021-12-08 15:44:39
f6u13k12:                        Time zone: America/New_York (EST, -0500)
f6u13k12:        System clock synchronized: yes
f6u13k12: systemd-timesyncd.service active: yes
f6u13k12:                  RTC in local TZ: no

root@f6u13k10:~# xdsh f6u13k12 realpath /etc/localtime
f6u13k12: /usr/share/zoneinfo/posixrules

root@f6u13k10:~# xdsh f6u13k12 ls -al /etc/localtime
f6u13k12: lrwxrwxrwx 1 root root 38 Dec  8 10:19 /etc/localtime -> ../usr/share/zoneinfo/America/New_York

root@f6u13k10:~# xdsh f6u13k12 ls -al /usr/share/zoneinfo/America/New_York 
f6u13k12: lrwxrwxrwx 1 root root 13 Dec  8 10:19 /usr/share/zoneinfo/America/New_York -> ../posixrules

root@f6u13k10:~# xdsh f6u13k12 ls -al /usr/share/zoneinfo/posixrules       
f6u13k12: -rw-r--r-- 1 root root 3545 Mar 26  2018 /usr/share/zoneinfo/posixrules

root@f6u13k10:~# xdsh f6u13k12 find /usr/share/zoneinfo            
f6u13k12: /usr/share/zoneinfo
f6u13k12: /usr/share/zoneinfo/America
f6u13k12: /usr/share/zoneinfo/America/New_York
f6u13k12: /usr/share/zoneinfo/posixrules
```
### Updated behavior showing successful time zone configuration (SLES 15.1):
```
f6u13k13:~ # tabdump site | grep timezone
"timezone","America/New_York",,

f6u13k13:~ # packimage sle15.1-ppc64le-netboot-compute
Packing contents of /install/netboot/sle15.1/ppc64le/compute/rootimg
archive method:cpio
compress method:pigz

f6u13k13:~ # rinstall f6u13k15 osimage=sle15.1-ppc64le-netboot-compute
Provision node(s): f6u13k15
f6u13k15: netboot sle15.1-ppc64le-compute

f6u13k13:~ # xdsh f6u13k15 timedatectl
f6u13k15:       Local time: Wed 2021-12-08 14:27:06 EST
f6u13k15:   Universal time: Wed 2021-12-08 19:27:06 UTC
f6u13k15:         RTC time: Wed 2021-12-08 19:27:07
f6u13k15:        Time zone: America/New_York (EST, -0500)
f6u13k15:  Network time on: no
f6u13k15: NTP synchronized: no
f6u13k15:  RTC in local TZ: no

f6u13k13:~ # xdsh f6u13k15 realpath /etc/localtime
f6u13k15: /usr/share/zoneinfo/America/New_York

f6u13k13:~ # xdsh f6u13k15 ls -al /etc/localtime
f6u13k15: lrwxrwxrwx 1 root root 38 Dec  8 14:14 /etc/localtime -> ../usr/share/zoneinfo/America/New_York
```
### Updated behavior showing successful time zone configuration (RHEL 7.6-Alt):
```
[root@f6u13k07 ~]# tabdump site | grep timezone
"timezone","America/New_York",,

[root@f6u13k07 ~]# packimage rhels7.6-alternate-ppc64le-netboot-compute
Packing contents of /install/netboot/rhels7.6-alternate/ppc64le/compute/rootimg
archive method:cpio
compress method:gzip

[root@f6u13k07 ~]# rinstall f6u13k09 osimage=rhels7.6-alternate-ppc64le-netboot-compute
Provision node(s): f6u13k09
f6u13k09: netboot rhels7.6-alternate-ppc64le-compute

[root@f6u13k07 ~]# xdsh f6u13k09 timedatectl
f6u13k09:       Local time: Wed 2021-12-08 10:13:17 EST
f6u13k09:   Universal time: Wed 2021-12-08 15:13:17 UTC
f6u13k09:         RTC time: Wed 2021-12-08 15:13:16
f6u13k09:        Time zone: America/New_York (EST, -0500)
f6u13k09:      NTP enabled: no
f6u13k09: NTP synchronized: no
f6u13k09:  RTC in local TZ: no
f6u13k09:       DST active: no
f6u13k09:  Last DST change: DST ended at
f6u13k09:                   Sun 2021-11-07 01:59:59 EDT
f6u13k09:                   Sun 2021-11-07 01:00:00 EST
f6u13k09:  Next DST change: DST begins (the clock jumps one hour forward) at
f6u13k09:                   Sun 2022-03-13 01:59:59 EST
f6u13k09:                   Sun 2022-03-13 03:00:00 EDT

[root@f6u13k07 ~]# xdsh f6u13k09 realpath /etc/localtime
f6u13k09: /usr/share/zoneinfo/America/New_York

[root@f6u13k07 ~]# xdsh f6u13k09 ls -al /etc/localtime
f6u13k09: lrwxrwxrwx 1 root root 38 Dec  8 10:09 /etc/localtime -> ../usr/share/zoneinfo/America/New_York

[root@f6u13k07 ~]# xdsh f6u13k09 find /usr/share/zoneinfo
f6u13k09: /usr/share/zoneinfo
f6u13k09: /usr/share/zoneinfo/America
f6u13k09: /usr/share/zoneinfo/America/New_York
```