### PR TITLE
Do not write the pid of chronyd to /dev/null for all distros

### DIFF
--- a/xCAT/postscripts/setupntp
+++ b/xCAT/postscripts/setupntp
@@ -168,15 +168,6 @@ warn_if_bad "$?" "Failed to configure the system to maintain the RTC in universa
 # Synchronize and set the system clock once
 logger -t $log_label -p local4.info "Syncing the clock ..."
 
-if [ -f /etc/os-release ] && cat /etc/os-release |grep NAME|grep Ubuntu>/dev/null
-then
-       # Some versions of chronyd on Ubuntu distros have an issue
-       # with the valid option "pidfile /dev/null".
-       pidfile_option=""
-else
-       pidfile_option="pidfile /dev/null"
-fi
-
 chronyd -f /dev/null -q "$(
 	if [ "${#NTP_SERVERS[@]}" -gt "0" ]
 	then
@@ -184,7 +175,7 @@ chronyd -f /dev/null -q "$(
 	else
 		echo "pool pool.ntp.org iburst"
 	fi
-)" "$pidfile_option"
+)"
 
 rm -f /etc/adjtime
 # Set the hardware clock from the system clock


### PR DESCRIPTION
Oracle Linux 8.5, Rocky Linux 8.5 and probably RHEL 8.5 have a problem running chronyd with "pidfile /dev/null" which is to write its pid to /dev/null.

The character device /dev/null (permission 666) is changed to a regular text file (permission 644) by the above command.

So far, we have not seen this problem on SLES.

For simplicity, we remove "pidfile /dev/null" from the chronyd command. This option does not seem to be essential.

Earlier in April 2021, https://github.com/xcat2/xcat-core/pull/6951 tackled this problem for Ubuntu only.