### PR TITLE
Use specified non-root user for REST API nodeshell method

### DIFF
--- a/xCAT-server/lib/xcat/plugins/xdsh.pm
+++ b/xCAT-server/lib/xcat/plugins/xdsh.pm
@@ -1226,12 +1226,17 @@ sub process_request
         $ENV{$var} = $value;
     }
 
-    # if DSH_FROM_USERID does not exist, set for internal calls
-    # if request->{username} exists,  set DSH_FROM_USERID to it
+    # if DSH_FROM_USERID or DSH_TO_USERID do not exist, set for internal calls
+    # if request->{username} exists,  set DSH_FROM_USERID and DSH_TO_USERID to it
     # override input,  this is what was authenticated
     if (!($ENV{'DSH_FROM_USERID'})) {
         if (($request->{username}) && defined($request->{username}->[0])) {
             $ENV{DSH_FROM_USERID} = $request->{username}->[0];
+        }
+    }
+    if (!($ENV{'DSH_TO_USERID'})) {
+        if (($request->{username}) && defined($request->{username}->[0])) {
+            $ENV{DSH_TO_USERID} = $request->{username}->[0];
         }
     }
     if ($command eq "xdsh")


### PR DESCRIPTION
### The PR is to fix issue _#7049_

The fix is to set `DSH_TO_USERID` environment variable, which will later be used when executing REST API `nodeshell` method (which is equivalent to `xdsh` command).

## UT:

* ### Non-root local user added the system
```
[root@f6u13k04 xcat]$ tabch key=xcat,username=mg passwd.password=gurevich

[root@f6u13k04 xcat]$ mkdef -t policy 9 name=mg rule=allow
1 object definitions have been created or modified.

[root@f6u13k06 ~]# useradd -u 99 mg

[root@f6u13k06 ~]# echo gurevich | passwd --stdin mg
Changing password for user mg.
passwd: all authentication tokens updated successfully.

[root@f6u13k06 ~]# cut -d: -f1,3,4 /etc/passwd | grep "root"
root:0:0

[root@f6u13k06 ~]# cut -d: -f1,3,4 /etc/passwd | grep "mg"
mg:99:1000
```

* #### BEFORE FIX with created local user :
```
root@f6u13k06 ~]# curl -k -X POST  'https://f6u13k04/xcatws/nodes/f6u13k06/nodeshell?userName=root&userPW=xxxx' -H Content-Type:application/json --data '{"command":["id"]}'
{"f6u13k06":[" uid=0(root) gid=0(root) groups=0(root)"]}

[root@f6u13k06 ~]# curl -k -X POST  'https://f6u13k04/xcatws/nodes/f6u13k06/nodeshell?userName=root&userPW=xxxxx' -H Content-Type:application/json --data '{"command":["echo $HOME"]}'
{"f6u13k06":[" /root"]}

[root@f6u13k06 ~]# curl -k -X POST  'https://f6u13k04/xcatws/nodes/f6u13k06/nodeshell?userName=mg&userPW=gurevich' -H Content-Type:application/json --data '{"command":["id"]}'
{"f6u13k06":[" uid=0(root) gid=0(root) groups=0(root)"]}

[root@f6u13k06 ~]# curl -k -X POST  'https://f6u13k04/xcatws/nodes/f6u13k06/nodeshell?userName=mg&userPW=gurevich' -H Content-Type:application/json --data '{"command":["echo $HOME"]}'
{"f6u13k06":[" /root"]}

[root@f6u13k06 ~]# curl -k -X POST  'https://f6u13k04/xcatws/nodes/f6u13k06/nodeshell?userName=root&userPW=abc' -H Content-Type:application/json --data '{"command":["date"]}'
{"errorcode":"2","error":"Authentication failure"}

[root@f6u13k06 ~]# curl -k -X POST  'https://f6u13k04/xcatws/nodes/f6u13k06/nodeshell?userName=xyz&userPW=abc' -H Content-Type:application/json --data '{"command":["date"]}'
{"error":"Authentication failure","errorcode":"2"}
```

* #### AFTER FIX with created local user:
```
root@f6u13k06 ~]# curl -k -X POST  'https://f6u13k04/xcatws/nodes/f6u13k06/nodeshell?userName=root&userPW=xxxx' -H Content-Type:application/json --data '{"command":["id"]}'
{"f6u13k06":[" uid=0(root) gid=0(root) groups=0(root)"]}

[root@f6u13k06 ~]# curl -k -X POST  'https://f6u13k04/xcatws/nodes/f6u13k06/nodeshell?userName=root&userPW=xxxxx' -H Content-Type:application/json --data '{"command":["echo $HOME"]}'
{"f6u13k06":[" /root"]}

curl -k -X POST  'https://f6u13k04/xcatws/nodes/f6u13k06/nodeshell?userName=mg&userPW=gurevich' -H Content-Type:application/json --data '{"command":["id"]}'
{"f6u13k06":[" uid=99(mg) gid=1000(mg) groups=1000(mg)"]}

[root@f6u13k06 ~]# curl -k -X POST  'https://f6u13k04/xcatws/nodes/f6u13k06/nodeshell?userName=mg&userPW=gurevich' -H Content-Type:application/json --data '{"command":["echo $HOME"]}'
{"f6u13k06":[" /home/mg"]}

[root@f6u13k06 ~]# curl -k -X POST  'https://f6u13k04/xcatws/nodes/f6u13k06/nodeshell?userName=root&userPW=abc' -H Content-Type:application/json --data '{"command":["date"]}'
{"error":"Authentication failure","errorcode":"2"}

[root@f6u13k06 ~]# curl -k -X POST  'https://f6u13k04/xcatws/nodes/f6u13k06/nodeshell?userName=xyz&userPW=abc' -H Content-Type:application/json --data '{"command":["date"]}'
{"error":"Authentication failure","errorcode":"2"}
```

* ### Non-root local user not added the system
```
[root@f6u13k04 xcat]$ tabch key=xcat,username=mark passwd.password=markg

[root@f6u13k04 xcat]$ mkdef -t policy 10 name=mark rule=allow
1 object definitions have been created or modified.

[root@f6u13k06 ~]# cut -d: -f1,3,4 /etc/passwd | grep "root"
root:0:0

[root@f6u13k06 ~]# cut -d: -f1,3,4 /etc/passwd | grep "mark"
```

* #### BEFORE FIX without created local user :
```
[root@f6u13k06 ~]# curl -k -X POST  'https://f6u13k04/xcatws/nodes/f6u13k06/nodeshell?userName=mark&userPW=markg' -H Content-Type:application/json --data '{"command":["date"]}'
{"f6u13k06":[" Wed Jan  5 14:23:55 EST 2022"]}

[root@f6u13k06 ~]# curl -k -X POST  'https://f6u13k04/xcatws/nodes/f6u13k06/nodeshell?userName=mark&userPW=markg' -H Content-Type:application/json --data '{"command":["id"]}'
{"f6u13k06":[" uid=0(root) gid=0(root) groups=0(root)"]}

[root@f6u13k06 ~]# curl -k -X POST  'https://f6u13k04/xcatws/nodes/f6u13k06/nodeshell?userName=root&userPW=cluster' -H Content-Type:application/json --data '{"command":["date"]}'
{"f6u13k06":[" Wed Jan  5 14:32:48 EST 2022"]}

[root@f6u13k06 ~]# curl -k -X POST  'https://f6u13k04/xcatws/nodes/f6u13k06/nodeshell?userName=root&userPW=cluster' -H Content-Type:application/json --data '{"command":["id"]}'
{"f6u13k06":[" uid=0(root) gid=0(root) groups=0(root)"]}
```

* #### AFTER FIX without created local user :
```
[root@f6u13k06 ~]# curl -k -X POST  'https://f6u13k04/xcatws/nodes/f6u13k06/nodeshell?userName=mark&userPW=markg' -H Content-Type:application/json --data '{"command":["date"]}'
{"errorcode":"2","error":"Authentication failure"}
[root@f6u13k06 ~]#

[root@f6u13k06 ~]# curl -k -X POST  'https://f6u13k04/xcatws/nodes/f6u13k06/nodeshell?userName=mark&userPW=markg' -H Content-Type:application/json --data '{"command":["id"]}'
{"errorcode":"2","error":"Authentication failure"}

[root@f6u13k06 ~]# curl -k -X POST  'https://f6u13k04/xcatws/nodes/f6u13k06/nodeshell?userName=root&userPW=xxxxx' -H Content-Type:application/json --data '{"command":["date"]}'
{"f6u13k06":[" Wed Jan  5 14:31:20 EST 2022"]}

[root@f6u13k06 ~]# curl -k -X POST  'https://f6u13k04/xcatws/nodes/f6u13k06/nodeshell?userName=root&userPW=xxxxx' -H Content-Type:application/json --data '{"command":["id"]}'
{"f6u13k06":[" uid=0(root) gid=0(root) groups=0(root)"]}
```