### PR TITLE
Add testcases for nodeshell REST API method

### DIFF
--- a/xCAT-test/autotest/bundle/restapi.bundle
+++ b/xCAT-test/autotest/bundle/restapi.bundle
@@ -25,4 +25,5 @@ restapi_list_wrong_osimage
 restapi_modify_wrong_field_CN
 restapi_delete_temp_CN_put
 restapi_nodeshell_cmd_root
+restapi_nodeshell_cmd_non_root
 restapi_cleanup_on_MN_CN

--- a/xCAT-test/autotest/bundle/restapi.bundle
+++ b/xCAT-test/autotest/bundle/restapi.bundle
@@ -24,4 +24,5 @@ restapi_list_invalid_resource
 restapi_list_wrong_osimage
 restapi_modify_wrong_field_CN
 restapi_delete_temp_CN_put
+restapi_nodeshell_cmd_root
 restapi_cleanup_on_MN_CN

--- a/xCAT-test/autotest/testcase/restapi/cases0
+++ b/xCAT-test/autotest/testcase/restapi/cases0
@@ -237,3 +237,11 @@ cmd:username=__GETTABLEVALUE(key,system,username,passwd)__;password=__GETTABLEVA
 check:rc==0
 check:output=~'vmmemori' is not a valid attribute name for an object type
 end
+
+start:restapi_nodeshell_cmd_root
+description: Call nodeshell method to execute a command by root user
+label:restapi
+cmd:username=__GETTABLEVALUE(key,system,username,passwd)__;password=__GETTABLEVALUE(key,system,password,passwd)__;xdsh $$CN "curl -X POST -s --cacert /root/ca-cert.pem 'https://$$MN/xcatws/nodes/$$CN/nodeshell?userName=$username&userPW=$password' -H Content-Type:application/json --data '{\"command\":\"id\"}'"
+check:rc==0
+check:output=~root
+end

--- a/xCAT-test/autotest/testcase/restapi/cases0
+++ b/xCAT-test/autotest/testcase/restapi/cases0
@@ -245,3 +245,19 @@ cmd:username=__GETTABLEVALUE(key,system,username,passwd)__;password=__GETTABLEVA
 check:rc==0
 check:output=~root
 end
+
+start:restapi_nodeshell_cmd_non_root
+description: Call nodeshell method to execute a command by non-root user
+label:restapi
+cmd:useradd -u 99 nonroot
+cmd:echo nonrootpw | passwd --stdin nonroot
+cmd:tabch key=xcat,username=nonroot passwd.password=nonrootpw
+cmd:mkdef -t policy 9 name=nonroot rule=allow
+cmd:xdsh $$CN "useradd -u 99 nonroot"
+cmd:xdsh $$CN "echo nonrootpw | passwd --stdin nonroot"
+cmd:/opt/xcat/share/xcat/scripts/setup-local-client.sh nonroot -f
+cmd:runuser -l nonroot -c 'echo nonrootpw | xdsh $$CN -K'
+cmd:username=nonroot;password=nonrootpw;xdsh $$CN "curl -X POST -s --cacert /root/ca-cert.pem 'https://$$MN/xcatws/nodes/$$CN/nodeshell?userName=$username&userPW=$password' -H Content-Type:application/json --data '{\"command\":\"id\"}'"
+check:rc==0
+check:output=~nonroot
+end


### PR DESCRIPTION
### UT

* #### root user
```
------START::restapi_nodeshell_cmd_root::Time:Thu Jan  6 14:29:48 2022------

RUN:username=__GETTABLEVALUE(key,system,username,passwd)__;password=__GETTABLEVALUE(key,system,password,passwd)__;xdsh f6u13k06 "curl -X POST -s --cacert /root/ca-cert.pem 'https://f6u13k04/xcatws/nodes/f6u13k06/nodeshell?userName=$username&userPW=$password' -H Content-Type:application/json --data '{\"command\":\"id\"}'" [Thu Jan  6 14:29:48 2022]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u13k06: {"f6u13k06":[" uid=0(root) gid=0(root) groups=0(root)"]}
CHECK:rc == 0   [Pass]
CHECK:output =~ root    [Pass]

------END::restapi_nodeshell_cmd_root::Passed::Time:Thu Jan  6 14:29:49 2022 ::Duration::1 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished at Thu Jan  6 14:29:49 2022
```

* #### non-root user
```
------START::restapi_nodeshell_cmd_non_root::Time:Thu Jan  6 15:51:39 2022------

RUN:useradd -u 99 nonroot [Thu Jan  6 15:51:39 2022]
ElapsedTime:0 sec
RETURN rc = 9
OUTPUT:

RUN:echo nonrootpw | passwd --stdin nonroot [Thu Jan  6 15:51:39 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Changing password for user nonroot.
passwd: all authentication tokens updated successfully.

RUN:tabch key=xcat,username=nonroot passwd.password=nonrootpw [Thu Jan  6 15:51:39 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:mkdef -t policy 9 name=nonroot rule=allow [Thu Jan  6 15:51:39 2022]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
1 object definitions have been created or modified.

RUN:xdsh f6u13k06 "useradd -u 99 nonroot" [Thu Jan  6 15:51:39 2022]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:

RUN:xdsh f6u13k06 "echo nonrootpw | passwd --stdin nonroot" [Thu Jan  6 15:51:40 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
f6u13k06: Changing password for user nonroot.
f6u13k06: passwd: all authentication tokens updated successfully.

RUN:/opt/xcat/share/xcat/scripts/setup-local-client.sh nonroot -f [Thu Jan  6 15:51:40 2022]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Using configuration from /etc/xcat/ca/openssl.cnf
Revoking Certificate 0D.
Data Base Updated
Generating RSA private key, 2048 bit long modulus (2 primes)
.................................+++++
.......+++++
e is 65537 (0x010001)
Using configuration from openssl.cnf
Check that the request matches the signature
Signature ok
:
:
:
Certificate is to be certified until Jan  1 20:51:40 2042 GMT (7300 days)

Write out database with 1 new entries
Data Base Updated

RUN:runuser -l nonroot -c 'echo nonrootpw | xdsh f6u13k06 -K' [Thu Jan  6 15:51:41 2022]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Enter the password for the userid: nonroot on the node where the ssh keys
will be updated:

stty: 'standard input': Inappropriate ioctl for device
stty: 'standard input': Inappropriate ioctl for device
/usr/bin/ssh setup is complete.
return code = 0

RUN:username=nonroot;password=nonrootpw;xdsh f6u13k06 "curl -X POST -s --cacert /root/ca-cert.pem 'https://f6u13k04/xcatws/nodes/f6u13k06/nodeshell?userName=$username&userPW=$password' -H Content-Type:application/json --data '{\"command\":\"id\"}'" [Thu Jan  6 15:51:42 2022]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u13k06: {"f6u13k06":[" uid=99(nonroot) gid=1000(nonroot) groups=1000(nonroot)"]}
CHECK:rc == 0   [Pass]
CHECK:output =~ nonroot [Pass]

------END::restapi_nodeshell_cmd_non_root::Passed::Time:Thu Jan  6 15:51:43 2022 ::Duration::4 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished at Thu Jan  6 15:51:43 2022
```
