### PR TITLE
Disable internet repos to avoid unexpected and silent upgrades

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/post.rhels8
+++ b/xCAT-server/share/xcat/install/scripts/post.rhels8
@@ -18,3 +18,14 @@ do
         sed -i 's/ONBOOT=no/ONBOOT=yes/' "$i"
     fi
 done
+
+# List of internal repos to be disabled
+
+internet_repo_file_list="oracle-linux-ol8.repo uek-ol8.repo Rocky-AppStream.repo Rocky-BaseOS.repo Rocky-Extras.repo CentOS-Base.repo"
+
+for repo_file in $internet_repo_file_list
+do
+  if [ -f /etc/yum.repos.d/$repo_file ]; then
+    sed -i -e 's/enabled=1/enabled=0/' /etc/yum.repos.d/$repo_file
+  fi
+done

--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -784,25 +784,15 @@ if ((-d "$rootimg_dir/usr/share/dracut") or (-d "$rootimg_dir/usr/lib/dracut")) 
     print "Enter the dracut mode. Dracut version: $dracutver. Dracut directory: $dracutdir.\n";
 }
 
+# List of internet repos to be disabled
 
-#-- for centos, disable the internet repository
-if (-e "$rootimg_dir/etc/yum.repos.d/CentOS-Base.repo") {
-    my $repo_content = `sed -e '/enabled/d' $rootimg_dir/etc/yum.repos.d/CentOS-Base.repo | sed -e '/^gpgkey/i enabled=0'`;
-    system("echo '$repo_content' > $rootimg_dir/etc/yum.repos.d/CentOS-Base.repo");
-}
-#
+my @internet_repo_file_list = ("oracle-linux-ol8.repo", "uek-ol8.repo", "Rocky-AppStream.repo", "Rocky-BaseOS.repo", "Rocky-Extras.repo", "CentOS-Base.repo");
 
-#-- Oracle Linux, disable internet repositories
-if (-e "$rootimg_dir/etc/yum.repos.d/oracle-linux-ol8.repo") {
-    my $repo_content = `sed -e '/enabled/d' $rootimg_dir/etc/yum.repos.d/oracle-linux-ol8.repo | sed -e '/^gpgkey/i enabled=0'`;
-    system("echo '$repo_content' > $rootimg_dir/etc/yum.repos.d/oracle-linux-ol8.repo");
+foreach ( @internet_repo_file_list ) {
+  if (-e "$rootimg_dir/etc/yum.repos.d/$_") {
+    system("sed -i -e 's/enabled=1/enabled=0/' $rootimg_dir/etc/yum.repos.d/$_");
+  }
 }
-
-if (-e "$rootimg_dir/etc/yum.repos.d/uek-ol8.repo") {
-    my $repo_content = `sed -e '/enabled/d' $rootimg_dir/etc/yum.repos.d/uek-ol8.repo | sed -e '/^gpgkey/i enabled=0'`;
-    system("echo '$repo_content' > $rootimg_dir/etc/yum.repos.d/uek-ol8.repo");
-}
-#
 
 #-- run postinstall script
 unless ($imagename) {


### PR DESCRIPTION
The changes in xCAT-server/share/xcat/install/scripts/post.rhels8 cover install-compute, install-service and stateful-mgmtnode.

The changes in xCAT-server/share/xcat/netboot/rh/genimage cover netboot-compute and statelite-compute.

As we find more internet repos to be included, append them to internet_repo_file_list.

Currently, the repos are from CentOS, Oracle Linux and Rocky Linux.