### PR TITLE
Add testcase for nodeshell REST API method for non-root user(2)

### DIFF
--- a/xCAT-test/autotest/testcase/restapi/cases0
+++ b/xCAT-test/autotest/testcase/restapi/cases0
@@ -249,13 +249,20 @@ end
 start:restapi_nodeshell_cmd_non_root
 description: Call nodeshell method to execute a command by non-root user
 label:restapi
+# Create nonroot user on MN
 cmd:useradd -u 99 nonroot
-cmd:echo nonrootpw | passwd --stdin nonroot
+cmd:echo "nonroot:nonrootpw" | chpasswd
 cmd:tabch key=xcat,username=nonroot passwd.password=nonrootpw
 cmd:mkdef -t policy 9 name=nonroot rule=allow
+# Create nonroot user on SN
+cmd:xdsh $$SN "useradd -u 99 nonroot"
+cmd:xdsh $$SN "echo \"nonroot:nonrootpw\" | chpasswd"
+# Create nonroot user on CN
 cmd:xdsh $$CN "useradd -u 99 nonroot"
-cmd:xdsh $$CN "echo nonrootpw | passwd --stdin nonroot"
+cmd:xdsh $$CN "echo \"nonroot:nonrootpw\" | chpasswd"
 cmd:/opt/xcat/share/xcat/scripts/setup-local-client.sh nonroot -f
+# Setup ssh keys on SN and CN
+cmd:runuser -l nonroot -c 'echo nonrootpw | xdsh $$SN -K'
 cmd:runuser -l nonroot -c 'echo nonrootpw | xdsh $$CN -K'
 cmd:username=nonroot;password=nonrootpw;xdsh $$CN "curl -X POST -s --cacert /root/ca-cert.pem 'https://$$MN/xcatws/nodes/$$CN/nodeshell?userName=$username&userPW=$password' -H Content-Type:application/json --data '{\"command\":\"id\"}'"
 check:rc==0


### PR DESCRIPTION
Update to #7084 

* When REST API testcases run in regression, it is hierarchical environment. The non-root user has be created on the server node also.
* On SLES the `passwd --stdin` flag is not supported. Use `chpasswd` command instead, which works on RH and SLES.

### UT

```
------START::restapi_nodeshell_cmd_non_root::Time:Fri Jan  7 10:07:32 2022------

RUN:useradd -u 99 nonroot [Fri Jan  7 10:07:32 2022]
ElapsedTime:0 sec
RETURN rc = 9
OUTPUT:

RUN:echo "nonroot:nonrootpw" | chpasswd [Fri Jan  7 10:07:32 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:tabch key=xcat,username=nonroot passwd.password=nonrootpw [Fri Jan  7 10:07:32 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:mkdef -t policy 9 name=nonroot rule=allow [Fri Jan  7 10:07:32 2022]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
1 object definitions have been created or modified.

RUN:xdsh f6u13k05 "useradd -u 99 nonroot" [Fri Jan  7 10:07:32 2022]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:

RUN:xdsh f6u13k05 "echo \"nonroot:nonrootpw\" | chpasswd" [Fri Jan  7 10:07:33 2022]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:xdsh f6u13k06 "useradd -u 99 nonroot" [Fri Jan  7 10:07:34 2022]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:

RUN:xdsh f6u13k06 "echo \"nonroot:nonrootpw\" | chpasswd" [Fri Jan  7 10:07:34 2022]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:/opt/xcat/share/xcat/scripts/setup-local-client.sh nonroot -f [Fri Jan  7 10:07:35 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Using configuration from /etc/xcat/ca/openssl.cnf
ERROR:Already revoked, serial number 05
Using configuration from /etc/xcat/ca/openssl.cnf
Revoking Certificate 06.
Data Base Updated
Generating RSA private key, 2048 bit long modulus (2 primes)
.......+++++
.............+++++
e is 65537 (0x010001)
Using configuration from openssl.cnf
Check that the request matches the signature
Signature ok
:
:
:
Certificate is to be certified until Jan  2 15:07:35 2042 GMT (7300 days)

Write out database with 1 new entries
Data Base Updated

RUN:runuser -l nonroot -c 'echo nonrootpw | xdsh f6u13k05 -K' [Fri Jan  7 10:07:35 2022]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
Enter the password for the userid: nonroot on the node where the ssh keys
will be updated:

stty: 'standard input': Inappropriate ioctl for device
stty: 'standard input': Inappropriate ioctl for device
/usr/bin/ssh setup is complete.
return code = 0

RUN:runuser -l nonroot -c 'echo nonrootpw | xdsh f6u13k06 -K' [Fri Jan  7 10:07:37 2022]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Enter the password for the userid: nonroot on the node where the ssh keys
will be updated:

stty: 'standard input': Inappropriate ioctl for device
stty: 'standard input': Inappropriate ioctl for device
/usr/bin/ssh setup is complete.
return code = 0

RUN:username=nonroot;password=nonrootpw;xdsh f6u13k06 "curl -X POST -s --cacert /root/ca-cert.pem 'https://f6u13k04/xcatws/nodes/f6u13k06/nodeshell?userName=$username&userPW=$password' -H Content-Type:application/json --data '{\"command\":\"id\"}'" [Fri Jan  7 10:07:38 2022]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u13k06: {"f6u13k06":[" uid=99(nonroot) gid=1000(nonroot) groups=1000(nonroot)"]}
CHECK:rc == 0   [Pass]
CHECK:output =~ nonroot [Pass]

------END::restapi_nodeshell_cmd_non_root::Passed::Time:Fri Jan  7 10:07:39 2022 ::Duration::7 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished at Fri Jan  7 10:07:39 2022
```
