### PR TITLE
Add testcase for nodeshell REST API method for non-root user(3)

### DIFF
--- a/xCAT-test/autotest/testcase/restapi/cases0
+++ b/xCAT-test/autotest/testcase/restapi/cases0
@@ -250,15 +250,16 @@ start:restapi_nodeshell_cmd_non_root
 description: Call nodeshell method to execute a command by non-root user
 label:restapi
 # Create nonroot user on MN
-cmd:useradd -u 99 nonroot
+cmd:useradd -u 518 nonroot
 cmd:echo "nonroot:nonrootpw" | chpasswd
+cmd:chmod a+x /home/nonroot/
 cmd:tabch key=xcat,username=nonroot passwd.password=nonrootpw
 cmd:mkdef -t policy 9 name=nonroot rule=allow
 # Create nonroot user on SN
-cmd:xdsh $$SN "useradd -u 99 nonroot"
+cmd:xdsh $$SN "useradd -u 518 nonroot"
 cmd:xdsh $$SN "echo \"nonroot:nonrootpw\" | chpasswd"
 # Create nonroot user on CN
-cmd:xdsh $$CN "useradd -u 99 nonroot"
+cmd:xdsh $$CN "useradd -u 518 nonroot"
 cmd:xdsh $$CN "echo \"nonroot:nonrootpw\" | chpasswd"
 cmd:/opt/xcat/share/xcat/scripts/setup-local-client.sh nonroot -f
 # Setup ssh keys on SN and CN


### PR DESCRIPTION
Update to #7088

*  On RH7, uid `99` is already used by `nobody` user. Use `518` instead for all OSes
*  On SLES the `runuser -l nonroot -c` command complains `cannot change directory to /home/nonroot: Permission denied`. Change `/home/nonroot` directory permission before executing `runuser`