### PR TITLE
Add testcase for nodeshell REST API method for non-root user(4)

### DIFF
--- a/xCAT-test/autotest/testcase/restapi/cases0
+++ b/xCAT-test/autotest/testcase/restapi/cases0
@@ -250,16 +250,16 @@ start:restapi_nodeshell_cmd_non_root
 description: Call nodeshell method to execute a command by non-root user
 label:restapi
 # Create nonroot user on MN
-cmd:useradd -u 518 nonroot
+cmd:useradd -u 518 -m nonroot
 cmd:echo "nonroot:nonrootpw" | chpasswd
 cmd:chmod a+x /home/nonroot/
 cmd:tabch key=xcat,username=nonroot passwd.password=nonrootpw
 cmd:mkdef -t policy 9 name=nonroot rule=allow
 # Create nonroot user on SN
-cmd:xdsh $$SN "useradd -u 518 nonroot"
+cmd:xdsh $$SN "useradd -u 518 -m nonroot"
 cmd:xdsh $$SN "echo \"nonroot:nonrootpw\" | chpasswd"
 # Create nonroot user on CN
-cmd:xdsh $$CN "useradd -u 518 nonroot"
+cmd:xdsh $$CN "useradd -u 518 -m nonroot"
 cmd:xdsh $$CN "echo \"nonroot:nonrootpw\" | chpasswd"
 cmd:/opt/xcat/share/xcat/scripts/setup-local-client.sh nonroot -f
 # Setup ssh keys on SN and CN


### PR DESCRIPTION
Update to #7089 

On SLES `useradd` command does not create user home directory by default.
This PR adds `-m` flag to explicitly create user home directory.
