### PR TITLE
Delay userdel by 11 seconds in xdcp_nonroot_user for RHEL 8.5

### DIFF
--- a/xCAT-test/autotest/testcase/xdcp/cases1
+++ b/xCAT-test/autotest/testcase/xdcp/cases1
@@ -22,7 +22,7 @@ cmd:su -c "xdcp $$CN /etc/sysctl.conf /tmp/sysctl.conf" - xyzzy
 check:rc==0
 cmd:xdsh $$CN "stat -c '%U' /tmp/sysctl.conf"
 check:output=~xyzzy
-cmd:xdsh $$CN "userdel xyzzy"
+cmd:xdsh $$CN "userdel xyzzy"; if [ $? == 1 ]; then sleep 11; xdsh $$CN "userdel xyzzy"; fi
 check:rc==0
 cmd:servicenode=`lsdef $$CN |grep servicenode |awk -F= '{print $2}'`; if [ -n "$servicenode" ]; then xdsh $servicenode "userdel xyzzy";userdel xyzzy;else userdel xyzzy;fi
 check:rc==0


### PR DESCRIPTION
UserStopDelaySec is introduced in RHEL 8.5 where Process "systemd --user" and its (sd-pm) stay around 10 seconds before it is deleted.

Since "userdel xyzzy" is executed quickly right after xyzzy is created, it would fail, saying user xyzzy is currently used by process xyz.

With this change, if "userdel xyzzy" fails the first time, it is tried again after 11 seconds.