### PR TITLE
Fix OpenPOWER detection regex

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -1619,7 +1619,7 @@ sub isopenpower {
     if ($sessdata->{prod_id} == 43707 and $sessdata->{mfg_id} == 0) {
         # mft_id 0 and prod_id 43707 is for Firestone,Minsky
         return 1;
-    } elsif (($sessdata->{prod_id} =~ /0|2355|2437/) and $sessdata->{mfg_id} == 10876) {
+    } elsif (($sessdata->{prod_id} =~ /^(?:0|2355|2437)$/) and $sessdata->{mfg_id} == 10876) {
         # mfg_id 10876 is for IBM Power S822LC for Big Data (Supermicro), prod_id 2355 for B&S, and 0 or 2437 for Boston
         return 1;
     } else {


### PR DESCRIPTION
The old regex matches product IDs containing a `0` (like `1230` or `1023`, ...), too.
This causes issues for some x86 Supermicro servers resulting in the following error:

```
rpower node01 cycle
node01: [xcat]: Error: unsupported command rpower cycle for OpenPOWER
```

The new regex fixes this issue and matches `^0$` only.