### PR TITLE
Update SLES15 compute template

### DIFF
--- a/xCAT-server/lib/perl/xCAT/Template.pm
+++ b/xCAT-server/lib/perl/xCAT/Template.pm
@@ -1576,6 +1576,11 @@ sub includefile
     }
 
     chomp($text);
+    if (($pkglist == 2) && (length($text)) < 1) {
+        # If processing a "pattern" (pkglist==2), and no patterns 
+        # were listed in pkglist file, just return start and end tags
+        $text="$pkgb$pkge"
+    }
     return ($text);
 }
 

--- a/xCAT-server/share/xcat/install/sles/compute.sle15.tmpl
+++ b/xCAT-server/share/xcat/install/sles/compute.sle15.tmpl
@@ -1,33 +1,16 @@
 <?xml version="1.0"?>
-<!DOCTYPE profile SYSTEM "/usr/share/YaST2/include/autoinstall/profile.dtd">
+<!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
-  <install>
     <bootloader>
-      <write_bootloader config:type="boolean">true</write_bootloader>
-      <activate config:type="boolean">true</activate>
-      <kernel_parameters></kernel_parameters>
-      <lba_support config:type="boolean">false</lba_support>
-      <linear config:type="boolean">false</linear>
-      <location>mbr</location>
+      <global>
+        <activate>true</activate>
+      </global>
     </bootloader>
     <general>
-      <clock>
-        <hwclock>UTC</hwclock>
-        <timezone>#TABLE:site:key=timezone:value#</timezone>
-      </clock>
-      <keyboard>
-        <keymap>english-us</keymap>
-      </keyboard>
-      <language>en_US</language>
       <mode>
         <confirm config:type="boolean">false</confirm>
-        <forceboot config:type="boolean">false</forceboot>
-        <interactive_boot config:type="boolean">false</interactive_boot>
-        <reboot config:type="boolean">true</reboot>
+        <final_reboot config:type="boolean">true</final_reboot>
       </mode>
-      <mouse>
-        <id>non</id>
-      </mouse>
       <signature-handling>
          <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
          <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
@@ -35,6 +18,16 @@
          <accept_verification_failed config:type="boolean">true</accept_verification_failed>
       </signature-handling>
     </general>
+    <timezone>
+      <hwclock>UTC</hwclock>
+      <timezone>#TABLE:site:key=timezone:value#</timezone>
+    </timezone>
+    <keyboard>
+      <keymap>english-us</keymap>
+    </keyboard>
+    <language>
+      <language>en_US</language>
+    </language>
     <partitioning config:type="list">
       <!-- XCAT-PARTITION-START -->
       <drive>
@@ -46,22 +39,20 @@
     </partitioning>
     <add-on>
         <add_on_products config:type="list">
-            #INSTALL_SOURCES# 
+          #INSTALL_SOURCES#
         </add_on_products>
     </add-on>
     <software>
       <products config:type="list">
-          <product>SLES</product>
+        <product>SLES</product>
       </products>
       <patterns config:type="list">
         #INCLUDE_DEFAULT_PTRNLIST_S#
       </patterns>
       <packages config:type="list">
-    	#INCLUDE_DEFAULT_PKGLIST_S#
+        #INCLUDE_DEFAULT_PKGLIST_S#
       </packages>
     </software>
-  </install>
-  <configure>
     <users config:type="list">
       <user>
         <username>root</username>
@@ -72,10 +63,8 @@
       </user>
     </users>
     <networking>
-      <dns>
+       <dns>
         <dhcp_hostname config:type="boolean">true</dhcp_hostname>
-        <dhcp_resolv config:type="boolean">true</dhcp_resolv>
-        <domain>local</domain>
         <hostname>linux</hostname>
       </dns>
       <interfaces config:type="list">
@@ -86,8 +75,7 @@
         </interface>
       </interfaces>
       <routing>
-        <ip_forward config:type="boolean">false</ip_forward>
-        <routes config:type="list"/>
+        <ipv4_forward config:type="boolean">false</ipv4_forward>
       </routing>
     </networking>
     <scripts>
@@ -95,5 +83,4 @@
    #INCLUDE:#ENV:XCATROOT#/share/xcat/install/scripts/chroot.sles#
    #INCLUDE:#ENV:XCATROOT#/share/xcat/install/scripts/post.sle#
     </scripts>
-  </configure>
 </profile>


### PR DESCRIPTION
This PR:

* Updates SLES15 compute template file, such that it will work on SLES15 SP3 and SP2
* Fixes processing of `#INCLUDE_DEFAULT_PTRNLIST_S#` such that if there are no "patterns" specified in package list file, a `<pattern></pattern>` is inserted instead of blank line.

```
c910f04x20:~ # hostnamectl
   Static hostname: linux
Transient hostname: c910f04x20
         Icon name: computer-server
           Chassis: server
        Machine ID: 0aae6dc8866545ad8ee255c4e0b4f5fb
           Boot ID: e09ba588e48d431888023c41d2879835
  Operating System: SUSE Linux Enterprise Server 15 SP3
       CPE OS Name: cpe:/o:suse:sles:15:sp3
            Kernel: Linux 5.3.18-59.24-default
      Architecture: x86-64
c910f04x20:~ #
```
