### PR TITLE
Fix typos on help output for genimage and OpenStack

### DIFF
--- a/xCAT-OpenStack/postscripts/setup_openstack_repo
+++ b/xCAT-OpenStack/postscripts/setup_openstack_repo
@@ -61,11 +61,11 @@ if [ "$(uname -s)" = "Linux" ]; then
 	apt-get install ubuntu-cloud-keyring -y
 	apt-get update
 
-	echo "Added the OpenStack ${opsrelease} version for Ubunto ${urelease} release to the repository, Please modify this script if you need a different version."
+	echo "Added the OpenStack ${opsrelease} version for Ubuntu ${urelease} release to the repository, Please modify this script if you need a different version."
 
     elif ( pmatch "$OSVER" "rh*" ) || [ -f /etc/redhat-release ]; then
 	#use yum repository
-	echo "Redhat. Please refer to http://sourceforge.net/apps/mediawiki/xcat/index.php?title=Deploying_OpenStack for how to setup OpenStack repository for RedHat".
+	echo "Red Hat. Please refer to http://sourceforge.net/apps/mediawiki/xcat/index.php?title=Deploying_OpenStack for how to setup OpenStack repository for Red Hat".
     else
 	echo "OpenStack deployment with xCAT is not supported on this platform yet.".
     fi

--- a/xCAT-client/bin/genimage
+++ b/xCAT-client/bin/genimage
@@ -61,7 +61,7 @@ sub print_usage
     print '    genimage [-o <osver>] [-a <arch>] [-p <profile>] [-i <nodebootif>] [-n <nodenetdrivers>] [--onlyinitrd] [-r <otherifaces>] [-k <kernelver>] [-g <krpmver>] [-m statelite] [-l rootlimitsize] [-t tmplimitsize] [--permission <permission>] [--interactive] [--dryrun] [--noupdate] <imagename>' . "\n\n";
     print "      --permission is used for statelite only\n";
     print "      -g is used for SLES only\n\n";
-    print "      -m is used for urbuntu, debian and fedora12 only\n\n";
+    print "      -m is used for Ubuntu, Debian and legacy Fedora versions only\n\n";
     print "Examples:\n";
     print "    genimage\n";
     print "    genimage --interactive\n";


### PR DESCRIPTION
There's a typo on genimage thats easy to fix, also the explanation for
Fedora is extremely outdated, on modern Fedora releases statelite is
generated automatically:

[root@headnode ~]# lsdef -t osimage
fedora35-x86_64-install-compute  (osimage)
fedora35-x86_64-install-service  (osimage)
fedora35-x86_64-netboot-compute  (osimage)
fedora35-x86_64-statelite-compute  (osimage)

Also theres a typo on OpenStack setup that grep caught, so we added
it too, for cosmetic reasons.