### PR TITLE
Updates to mkvm, chvm, and lsvm documentation.

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/chvm.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/chvm.1.rst
@@ -11,7 +11,7 @@ NAME
 ****
 
 
-\ **chvm**\  - Changes HMC-, DFM-, IVM-, and zVM-managed partition profiles or virtual machines. For Power 775, chvm could be used to change the octant configuration values for generating LPARs; change the I/O slots assignment to LPARs within the same CEC.
+\ **chvm**\  - Changes HMC-, DFM-, IVM-, KVM-, VMware-, and zVM-managed partition profiles or virtual machine attributes. For Power 775, chvm could be used to change the octant configuration values for generating LPARs; change the I/O slots assignment to LPARs within the same CEC.
 
 
 ********
@@ -324,7 +324,7 @@ VMware/KVM specific:
 
 \ **-**\ **-mem**\  \ *memory*\ 
  
- Set the memory, defaults to MB.
+ Set the memory size for kvm/vmware virtual machines, default unit is MB. Specify in MB or append K for KB, M for MB, or G for GB.
  
 
 
@@ -527,7 +527,7 @@ zVM specific:
 
 \ **-**\ **-removeloaddev**\  \ *wwpn*\  \ *lun*\ 
  
- Removes the LOADDEV statement from a virtual machines's directory entry.
+ Removes the LOADDEV statement from a virtual machine's directory entry.
  
 
 
@@ -749,7 +749,7 @@ then run the command:
   cat /tmp/lparfile | chvm lpar4 --p775
 
 
-5. To change the I/O slot profile for lpar1-lpar8 using the configuration data in the file /tmp/lparfile. Users can use the output of lsvm.and remove the cec information, and  modify the lpar id  before each I/O, and run the command as following:
+5. To change the I/O slot profile for lpar1-lpar8 using the configuration data in the file /tmp/lparfile. Users can use the output of lsvm, remove the cec information, modify the lpar id before each I/O, and run the command as following:
 
 
 .. code-block:: perl
@@ -848,7 +848,7 @@ VMware/KVM specific:
 
 .. code-block:: perl
 
-  chvm vm1 -a 8,16 --mem 512 --cpus 2
+  chvm vm1 -a 8,16 --mem 4096 --cpus 2
 
 
 Output is similar to:

--- a/docs/source/guides/admin-guides/references/man1/lsvm.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/lsvm.1.rst
@@ -11,7 +11,7 @@ NAME
 ****
 
 
-\ **lsvm**\  - Lists partition profile information for HMC-, DFM-, IVM-, KVM-, VMware- and zVM-managed nodes. For Power 775, it lists the LPARs' I/O slots information and CEC configuration.
+\ **lsvm**\  - Lists information about HMC-, DFM-, IVM-, KVM-, VMware-, and zVM-managed partitions or virtual machines. For Power 775, it lists the LPARs' I/O slots information and CEC configuration.
 
 
 ********
@@ -56,7 +56,7 @@ DESCRIPTION
 ***********
 
 
-The \ **lsvm**\  command lists all partition profiles defined for the partitions specified in \ *noderange*\ . If \ *noderange*\  is a CEC, all the partitions associated with that CEC are displayed.
+The \ **lsvm**\  command lists all profiles defined for the partitions or virtual machines specified in \ *noderange*\ . If \ *noderange*\  is a CEC, all the partitions associated with that CEC are displayed.
 
 For PPC (using Direct FSP Management):
 ======================================

--- a/docs/source/guides/admin-guides/references/man1/mkvm.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/mkvm.1.rst
@@ -11,7 +11,7 @@ NAME
 ****
 
 
-\ **mkvm**\  - Creates HMC-, DFM-, IVM-, and zVM-managed partitions or other virtual machines.
+\ **mkvm**\  - Creates HMC-, DFM-, IVM-, KVM-, VMware-, and zVM-managed partitions or virtual machines.
 
 
 ********
@@ -96,14 +96,14 @@ For PPC (using Direct FSP Management) specific:
 
 With option \ *full*\ , a partition using all the resources on a normal power machine will be created.
 
-If no option is specified, a partition using the parameters specified with attributes such as 'vmcpus', 'vmmory', 'vmphyslots', 'vmothersetting', 'vmnics', 'vmstorage' will be created. Those attributes can either be specified with '\*def' commands running before or be specified with this command.
+If no option is specified, a partition using the parameters specified with attributes such as 'vmcpus', 'vmmemory', 'vmphyslots', 'vmothersetting', 'vmnics', 'vmstorage' will be created. Those attributes can either be specified with '\*def' commands running before or be specified with this command.
 
 
 For KVM and VMware:
 ===================
 
 
-The \ **mkvm**\  command creates new virtual machine(s) with the \ *disksize*\  size of hard disk, \ *memsize*\  size of memory and \ *cpucount*\  number of cpu.
+The \ **mkvm**\  command creates a new virtual machine with \ *disksize*\  GB of storage space, \ *memsize*\  MB of memory, and \ *cpucount*\  cpu(s).
 
 
 For zVM:
@@ -136,7 +136,7 @@ OPTIONS
 
 \ **-**\ **-cpus**\ 
  
- The cpu count which will be created for the kvm/vmware virtual machine.
+ Number of CPUs for the kvm/vmware virtual machine being created.
  
 
 
@@ -174,7 +174,7 @@ OPTIONS
 
 \ **-**\ **-mem**\ 
  
- The memory size which will be used for the new created kvm/vmware virtual machine. Unit is Megabyte.
+ Set the memory size for kvm/vmware virtual machines, default unit is MB. Specify in MB or append K for KB, M for MB, or G for GB.
  
 
 
@@ -186,7 +186,7 @@ OPTIONS
 
 \ **-s|-**\ **-size**\ 
  
- The size of storage which will be created for the kvm/vmware virtual machine.
+ Set the storage size for kvm/vmware virtual machines, default unit is GB. Specify in GB or append K for KB, M for MB, G for GB.
  
 
 
@@ -374,12 +374,36 @@ Output is similar to:
   gpok4: Starting LNX3... Done
 
 
-7. To create a new kvm/vmware virtual machine with 10G storage, 2048M memory and 2 cpus.
+7. To create a new kvm/vmware virtual machine with 20 GB of storage, 4096 MB of memory, and 2 cpus.
 
 
 .. code-block:: perl
 
-  mkvm vm1 -s 10G --mem 2048 --cpus 2
+  mkvm vm1 -s 20 --mem 4096 --cpus 2
+
+
+or
+
+
+.. code-block:: perl
+
+  mkvm vm1 -s 20G --mem 4194304K --cpus 2
+
+
+or
+
+
+.. code-block:: perl
+
+  mkvm vm1 -s 20480M --mem 4096M --cpus 2
+
+
+or
+
+
+.. code-block:: perl
+
+  mkvm vm1 -s 20971520K --mem 4G --cpus 2
 
 
 8. To create a full partition on normal power machine.
@@ -454,7 +478,7 @@ After a node object is defined, the resources that will be used for the partitio
   chdef lpar1 vmcpus=1/4/16 vmmemory=1G/4G/32G vmphyslots=0x21010201,0x21010200 vmothersetting=bsr:128,hugepage:2
 
 
-Then, create the partion on the specified cec.
+Then, create the partition on the specified cec.
 
 
 .. code-block:: perl
@@ -470,7 +494,7 @@ Option 2:
   mkvm lpar1 vmcpus=1/4/16 vmmemory=1G/4G/32G vmphyslots=0x21010201,0x21010200 vmothersetting=bsr:128,hugepage:2
 
 
-The outout is similar to:
+The output is similar to:
 
 
 .. code-block:: perl

--- a/xCAT-client/pods/man1/chvm.1.pod
+++ b/xCAT-client/pods/man1/chvm.1.pod
@@ -240,7 +240,7 @@ Deregister the Hard disk but leave the backing files.  Multiple can be done with
 
 =item B<--mem> I<memory>
 
-Set the memory, defaults to MB.
+Set the memory size for kvm/vmware virtual machines, default unit is MB. Specify in MB or append K for KB, M for MB, or G for GB.
 
 =item B<-p> I<disk>
 

--- a/xCAT-client/pods/man1/chvm.1.pod
+++ b/xCAT-client/pods/man1/chvm.1.pod
@@ -576,7 +576,7 @@ Note: The physical I/O resources specified with I<add_physlots> will be appended
 
 =head2 VMware/KVM specific:
 
- chvm vm1 -a 8,16 --mem 512 --cpus 2
+ chvm vm1 -a 8,16 --mem 4096 --cpus 2
 
 Output is similar to:
 

--- a/xCAT-client/pods/man1/chvm.1.pod
+++ b/xCAT-client/pods/man1/chvm.1.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-B<chvm> - Changes HMC-, DFM-, IVM-, and zVM-managed partition profiles or virtual machines. For Power 775, chvm could be used to change the octant configuration values for generating LPARs; change the I/O slots assignment to LPARs within the same CEC.
+B<chvm> - Changes HMC-, DFM-, IVM-, KVM-, VMware-, and zVM-managed partition profiles or virtual machine attributes. For Power 775, chvm could be used to change the octant configuration values for generating LPARs; change the I/O slots assignment to LPARs within the same CEC.
 
 =head1 SYNOPSIS
 

--- a/xCAT-client/pods/man1/chvm.1.pod
+++ b/xCAT-client/pods/man1/chvm.1.pod
@@ -387,7 +387,7 @@ Removes a processor from an active virtual machine's configuration.
 
 =item B<--removeloaddev> I<wwpn> I<lun>
 
-Removes the LOADDEV statement from a virtual machines's directory entry.
+Removes the LOADDEV statement from a virtual machine's directory entry.
 
 =item B<--removezfcp> I<device_address> I<wwpn> I<lun>
 
@@ -515,7 +515,7 @@ then run the command:
 
  cat /tmp/lparfile | chvm lpar4 --p775
 
-5. To change the I/O slot profile for lpar1-lpar8 using the configuration data in the file /tmp/lparfile. Users can use the output of lsvm.and remove the cec information, and  modify the lpar id  before each I/O, and run the command as following:
+5. To change the I/O slot profile for lpar1-lpar8 using the configuration data in the file /tmp/lparfile. Users can use the output of lsvm, remove the cec information, modify the lpar id before each I/O, and run the command as following:
 
  chvm lpar1-lpar8 --p775 -p /tmp/lparfile
 

--- a/xCAT-client/pods/man1/lsvm.1.pod
+++ b/xCAT-client/pods/man1/lsvm.1.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-B<lsvm> - Lists partition profile information for HMC-, DFM-, IVM-, KVM-, VMware- and zVM-managed nodes. For Power 775, it lists the LPARs' I/O slots information and CEC configuration.
+B<lsvm> - Lists information about HMC-, DFM-, IVM-, KVM-, VMware-, and zVM-managed partitions or virtual machines. For Power 775, it lists the LPARs' I/O slots information and CEC configuration.
 
 =head1 SYNOPSIS
 
@@ -28,7 +28,7 @@ B<lsvm> I<noderange>
 
 =head1 DESCRIPTION
 
-The B<lsvm> command lists all partition profiles defined for the partitions specified in I<noderange>. If I<noderange> is a CEC, all the partitions associated with that CEC are displayed.
+The B<lsvm> command lists all profiles defined for the partitions or virtual machines specified in I<noderange>. If I<noderange> is a CEC, all the partitions associated with that CEC are displayed.
 
 =head2 For PPC (using Direct FSP Management):
 

--- a/xCAT-client/pods/man1/mkvm.1.pod
+++ b/xCAT-client/pods/man1/mkvm.1.pod
@@ -106,8 +106,7 @@ The partition name of the source.
 
 =item B<--mem>
 
-Memory size for the kvm/vmware virtual machine being created. Specify units in MB
-or append K (4194304K) for KB, M (4096M) for MB, or G (4G) for GB.
+Memory size for the kvm/vmware virtual machine being created. Specify units in MB (default) or append K for KB, M for MB, or G for GB.
 
 =item B<-p>
 
@@ -115,7 +114,7 @@ The file that contains the profiles for the source partitions.
 
 =item B<-s|--size>
 
-Storage size in GB for the kvm/vmware virtual machine being created.
+Storage size for the kvm/vmware virtual machine being created. Specify units in GB (default) or append K for KB, M for MB, G for GB.
 
 =item B<-v|--version>
 
@@ -232,21 +231,21 @@ Output is similar to:
  gpok4: Detatching source disk (0100) at (1100)
  gpok4: Starting LNX3... Done
 
-7. To create a new kvm/vmware virtual machine with 10G storage, 4096M memory, and 2 cpus.
+7. To create a new kvm/vmware virtual machine with 20 GB of storage, 4096 MB of memory, and 2 cpus.
 
- mkvm vm1 -s 10G --mem 4096 --cpus 2
+ mkvm vm1 -s 20 --mem 4096 --cpus 2
 
 or 
 
- mkvm vm1 -s 10G --mem 4194304K --cpus 2
+ mkvm vm1 -s 20G --mem 4194304K --cpus 2
 
 or
  
- mkvm vm1 -s 10G --mem 4096M --cpus 2
+ mkvm vm1 -s 20480M --mem 4096M --cpus 2
 
 or
  
- mkvm vm1 -s 10G --mem 4G --cpus 2
+ mkvm vm1 -s 20971520K --mem 4G --cpus 2
 
 8. To create a full partition on normal power machine.
 

--- a/xCAT-client/pods/man1/mkvm.1.pod
+++ b/xCAT-client/pods/man1/mkvm.1.pod
@@ -106,7 +106,7 @@ The partition name of the source.
 
 =item B<--mem>
 
-Memory size for the kvm/vmware virtual machine being created. Specify units in MB (default) or append K for KB, M for MB, or G for GB.
+Set the memory size for kvm/vmware virtual machines, default unit is MB. Specify in MB or append K for KB, M for MB, or G for GB.
 
 =item B<-p>
 
@@ -114,7 +114,7 @@ The file that contains the profiles for the source partitions.
 
 =item B<-s|--size>
 
-Storage size for the kvm/vmware virtual machine being created. Specify units in GB (default) or append K for KB, M for MB, G for GB.
+Set the storage size for kvm/vmware virtual machines, default unit is GB. Specify in GB or append K for KB, M for MB, G for GB.
 
 =item B<-v|--version>
 

--- a/xCAT-client/pods/man1/mkvm.1.pod
+++ b/xCAT-client/pods/man1/mkvm.1.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-B<mkvm> - Creates HMC-, DFM-, IVM-, and zVM-managed partitions or other virtual machines.
+B<mkvm> - Creates HMC-, DFM-, IVM-, KVM-, VMware-, and zVM-managed partitions or virtual machines.
 
 =head1 SYNOPSIS
 

--- a/xCAT-client/pods/man1/mkvm.1.pod
+++ b/xCAT-client/pods/man1/mkvm.1.pod
@@ -54,7 +54,7 @@ Note that the B<mkvm> command currently only supports creating standard LPARs, n
 
 With option I<full>, a partition using all the resources on a normal power machine will be created.
 
-If no option is specified, a partition using the parameters specified with attributes such as 'vmcpus', 'vmmory', 'vmphyslots', 'vmothersetting', 'vmnics', 'vmstorage' will be created. Those attributes can either be specified with '*def' commands running before or be specified with this command.
+If no option is specified, a partition using the parameters specified with attributes such as 'vmcpus', 'vmmemory', 'vmphyslots', 'vmothersetting', 'vmnics', 'vmstorage' will be created. Those attributes can either be specified with '*def' commands running before or be specified with this command.
 
 =head2 For KVM and VMware:
 

--- a/xCAT-client/pods/man1/mkvm.1.pod
+++ b/xCAT-client/pods/man1/mkvm.1.pod
@@ -231,9 +231,9 @@ Output is similar to:
  gpok4: Detatching source disk (0100) at (1100)
  gpok4: Starting LNX3... Done
 
-7. To create a new kvm/vmware virtual machine with 10G storage, 2048M memory and 2 cpus.
+7. To create a new kvm/vmware virtual machine with 10G storage, 4096M memory and 2 cpus.
 
- mkvm vm1 -s 10G --mem 2048 --cpus 2
+ mkvm vm1 -s 10G --mem 4096 --cpus 2
 
 8. To create a full partition on normal power machine.
 

--- a/xCAT-client/pods/man1/mkvm.1.pod
+++ b/xCAT-client/pods/man1/mkvm.1.pod
@@ -297,7 +297,7 @@ After a node object is defined, the resources that will be used for the partitio
 
  chdef lpar1 vmcpus=1/4/16 vmmemory=1G/4G/32G vmphyslots=0x21010201,0x21010200 vmothersetting=bsr:128,hugepage:2
 
-Then, create the partion on the specified cec.
+Then, create the partition on the specified cec.
 
  mkvm lpar1
 
@@ -305,7 +305,7 @@ Option 2:
 
  mkvm lpar1 vmcpus=1/4/16 vmmemory=1G/4G/32G vmphyslots=0x21010201,0x21010200 vmothersetting=bsr:128,hugepage:2
 
-The outout is similar to:
+The output is similar to:
 
  lpar1: Done
 

--- a/xCAT-client/pods/man1/mkvm.1.pod
+++ b/xCAT-client/pods/man1/mkvm.1.pod
@@ -58,7 +58,7 @@ If no option is specified, a partition using the parameters specified with attri
 
 =head2 For KVM and VMware:
 
-The B<mkvm> command creates new virtual machine(s) with the I<disksize> size of hard disk, I<memsize> size of memory and I<cpucount> number of cpu.
+The B<mkvm> command creates a new virtual machine with I<disksize> GB of storage space, I<memsize> MB of memory, and I<cpucount> cpu(s).
 
 =head2 For zVM:
 
@@ -80,7 +80,7 @@ The cec (fsp) name for the destination.
 
 =item B<--cpus>
 
-The cpu count which will be created for the kvm/vmware virtual machine.
+Number of CPUs for the kvm/vmware virtual machine being created.
 
 =item B<--full>
 
@@ -106,7 +106,7 @@ The partition name of the source.
 
 =item B<--mem>
 
-The memory size which will be used for the new created kvm/vmware virtual machine. Unit is Megabyte.
+Memory size in MB for the kvm/vmware virtual machine being created.
 
 =item B<-p>
 
@@ -114,7 +114,7 @@ The file that contains the profiles for the source partitions.
 
 =item B<-s|--size>
 
-The size of storage which will be created for the kvm/vmware virtual machine.
+Storage size in GB for the kvm/vmware virtual machine being created.
 
 =item B<-v|--version>
 

--- a/xCAT-client/pods/man1/mkvm.1.pod
+++ b/xCAT-client/pods/man1/mkvm.1.pod
@@ -106,7 +106,8 @@ The partition name of the source.
 
 =item B<--mem>
 
-Memory size in MB for the kvm/vmware virtual machine being created.
+Memory size for the kvm/vmware virtual machine being created. Specify units in MB
+or append K (4194304K) for KB, M (4096M) for MB, or G (4G) for GB.
 
 =item B<-p>
 
@@ -231,9 +232,21 @@ Output is similar to:
  gpok4: Detatching source disk (0100) at (1100)
  gpok4: Starting LNX3... Done
 
-7. To create a new kvm/vmware virtual machine with 10G storage, 4096M memory and 2 cpus.
+7. To create a new kvm/vmware virtual machine with 10G storage, 4096M memory, and 2 cpus.
 
  mkvm vm1 -s 10G --mem 4096 --cpus 2
+
+or 
+
+ mkvm vm1 -s 10G --mem 4194304K --cpus 2
+
+or
+ 
+ mkvm vm1 -s 10G --mem 4096M --cpus 2
+
+or
+ 
+ mkvm vm1 -s 10G --mem 4G --cpus 2
 
 8. To create a full partition on normal power machine.
 


### PR DESCRIPTION
I made the following improvements to the mkvm, chvm, and lsvm documentation:

- Fixed typos and misspellings
- Unified wording for consistency
- Increased kvm memory size and storage size examples to match the recommendations for RHEL 8.5 ppc64le
- Added additional information about unit specifications
- Added additional examples to help illustrate certain features