### PR TITLE
Update SLES15 service and compute template

### DIFF
--- a/xCAT-server/share/xcat/install/sles/compute.sle15.tmpl
+++ b/xCAT-server/share/xcat/install/sles/compute.sle15.tmpl
@@ -9,7 +9,7 @@
     <general>
       <mode>
         <confirm config:type="boolean">false</confirm>
-        <final_reboot config:type="boolean">true</final_reboot>
+        <final_reboot config:type="boolean">false</final_reboot>
       </mode>
       <signature-handling>
          <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
@@ -74,6 +74,7 @@
           <startmode>onboot</startmode>
         </interface>
       </interfaces>
+      <keep_install_network config:type="boolean">true</keep_install_network>
       <routing>
         <ipv4_forward config:type="boolean">false</ipv4_forward>
       </routing>

--- a/xCAT-server/share/xcat/install/sles/service.sle15.pkglist
+++ b/xCAT-server/share/xcat/install/sles/service.sle15.pkglist
@@ -20,6 +20,5 @@ postgresql-server
 postgresql
 perl-DBD-mysql
 mariadb-client
-#libmysqlclient18
 vim
 wget

--- a/xCAT-server/share/xcat/install/sles/service.sle15.tmpl
+++ b/xCAT-server/share/xcat/install/sles/service.sle15.tmpl
@@ -1,33 +1,16 @@
 <?xml version="1.0"?>
-<!DOCTYPE profile SYSTEM "/usr/share/YaST2/include/autoinstall/profile.dtd">
+<!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
-  <install>
     <bootloader>
-      <write_bootloader config:type="boolean">true</write_bootloader>
-      <activate config:type="boolean">true</activate>
-      <kernel_parameters>#XCATVAR:PERSKCMDLINE#</kernel_parameters>
-      <lba_support config:type="boolean">false</lba_support>
-      <linear config:type="boolean">false</linear>
-      <location>mbr</location>
+      <global>
+        <activate>true</activate>
+      </global>
     </bootloader>
     <general>
-      <clock>
-        <hwclock>UTC</hwclock>
-        <timezone>#TABLE:site:key=timezone:value#</timezone>
-      </clock>
-      <keyboard>
-        <keymap>english-us</keymap>
-      </keyboard>
-      <language>en_US</language>
       <mode>
         <confirm config:type="boolean">false</confirm>
-        <forceboot config:type="boolean">false</forceboot>
-        <interactive_boot config:type="boolean">false</interactive_boot>
-        <reboot config:type="boolean">true</reboot>
+        <final_reboot config:type="boolean">false</final_reboot>
       </mode>
-      <mouse>
-        <id>non</id>
-      </mouse>
       <signature-handling>
          <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
          <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
@@ -35,6 +18,16 @@
          <accept_verification_failed config:type="boolean">true</accept_verification_failed>
       </signature-handling>
     </general>
+    <timezone>
+      <hwclock>UTC</hwclock>
+      <timezone>#TABLE:site:key=timezone:value#</timezone>
+    </timezone>
+    <keyboard>
+      <keymap>english-us</keymap>
+    </keyboard>
+    <language>
+      <language>en_US</language>
+    </language>
     <partitioning config:type="list">
       <!-- XCAT-PARTITION-START -->
       <drive>
@@ -46,22 +39,20 @@
     </partitioning>
     <add-on>
         <add_on_products config:type="list">
-            #INSTALL_SOURCES#
+          #INSTALL_SOURCES#
         </add_on_products>
     </add-on>
     <software>
       <products config:type="list">
-          <product>SLES</product>
+        <product>SLES</product>
       </products>
       <patterns config:type="list">
         #INCLUDE_DEFAULT_PTRNLIST_S#
       </patterns>
       <packages config:type="list">
-    	#INCLUDE_DEFAULT_PKGLIST_S#
+        #INCLUDE_DEFAULT_PKGLIST_S#
       </packages>
     </software>
-  </install>
-  <configure>
     <users config:type="list">
       <user>
         <username>root</username>
@@ -72,10 +63,8 @@
       </user>
     </users>
     <networking>
-      <dns>
+       <dns>
         <dhcp_hostname config:type="boolean">true</dhcp_hostname>
-        <dhcp_resolv config:type="boolean">true</dhcp_resolv>
-        <domain>local</domain>
         <hostname>linux</hostname>
       </dns>
       <interfaces config:type="list">
@@ -87,8 +76,7 @@
       </interfaces>
       <keep_install_network config:type="boolean">true</keep_install_network>
       <routing>
-        <ip_forward config:type="boolean">false</ip_forward>
-        <routes config:type="list"/>
+        <ipv4_forward config:type="boolean">false</ipv4_forward>
       </routing>
     </networking>
     <scripts>
@@ -96,5 +84,4 @@
    #INCLUDE:#ENV:XCATROOT#/share/xcat/install/scripts/chroot.sles#
    #INCLUDE:#ENV:XCATROOT#/share/xcat/install/scripts/post.sle#
     </scripts>
-  </configure>
 </profile>

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_flat
@@ -71,6 +71,9 @@ cmd:lsdef -l $$CN
 cmd:ping $$CN -c 3
 check:rc==0
 check:output=~64 bytes from $$CN
+# Check node ends up in boot state
+cmd:lsdef $$CN -i currstate -c
+check:output==boot
 cmd:xdsh $$CN  "cat /var/log/xcat/xcat.log"
 cmd:xdsh $$CN "cat /test.synclist"
 check:rc==0

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_hierarchy
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_hierarchy
@@ -58,11 +58,7 @@ check:output=~Provision node\(s\)\: $$CN
 cmd:xdsh $$SN "if [[ -f /var/lib/dhcp/db/dhcpd.leases ]]; then cat /var/lib/dhcp/db/dhcpd.leases; elif [[ -f /var/lib/dhcpd/dhcpd.leases ]];then cat /var/lib/dhcpd/dhcpd.leases;elif [[ -f /var/lib/dhcp/dhcpd.leases ]];then cat /var/lib/dhcp/dhcpd.leases; fi"
 cmd:if [[ "__GETNODEATTR($$CN,arch)__" =~ "ppc" ]]; then sleep 120;elif [[ "__GETNODEATTR($$CN,arch)__" =~ "x86_64" ]];then sleep 200;else sleep 180;fi
 
-#cmd:lsdef -l $$CN | grep status
-#check:rc==0
-#check:output!~booted
-
-cmd:ping $$CN -c 3
+ping $$CN -c 3
 check:rc==0
 check:output=~64 bytes from $$CN
 cmd:lsdef -l $$CN | grep status
@@ -110,4 +106,8 @@ check:rc==0
 # Verify the compute node timezone matches the site table timezone
 cmd:sitetz=`lsdef -t site -i timezone | awk -F= '{print $2}'`;nodetz=`xdsh $$CN "timedatectl | grep 'Time zone'" | awk -F: '{print $3}' | awk '{print $1}'`; test $sitetz = $nodetz
 check:rc==0
+
+# Check node ends up in boot state
+cmd:lsdef $$CN -i currstate -c
+check:output==boot
 end

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_hierarchy
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_hierarchy
@@ -58,7 +58,7 @@ check:output=~Provision node\(s\)\: $$CN
 cmd:xdsh $$SN "if [[ -f /var/lib/dhcp/db/dhcpd.leases ]]; then cat /var/lib/dhcp/db/dhcpd.leases; elif [[ -f /var/lib/dhcpd/dhcpd.leases ]];then cat /var/lib/dhcpd/dhcpd.leases;elif [[ -f /var/lib/dhcp/dhcpd.leases ]];then cat /var/lib/dhcp/dhcpd.leases; fi"
 cmd:if [[ "__GETNODEATTR($$CN,arch)__" =~ "ppc" ]]; then sleep 120;elif [[ "__GETNODEATTR($$CN,arch)__" =~ "x86_64" ]];then sleep 200;else sleep 180;fi
 
-ping $$CN -c 3
+cmd:ping $$CN -c 3
 check:rc==0
 check:output=~64 bytes from $$CN
 cmd:lsdef -l $$CN | grep status


### PR DESCRIPTION
Continue work of supporting SLES15 SP3 (#7099)

This PR:
* Adds a service node template in the new format. The compute and service node templates are identical for SLES12, so SLES15 service node template is the same as for compute node
* Remove `#` entry from the SLES15 pkglist file. On SLES, `#` in the pkglist never worked, but the error was not reported, since prior to SLES15, the AutoYaST file problems were ignored by the installer.
* Removes the extra reboot after SLES15 installation.
* Adds a check to existing testcases to verify that after installation compute node ends up in `boot` state