### PR TITLE
Add a crashkernel size check to linux_diskless_kdump testcase

### DIFF
--- a/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
+++ b/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
@@ -95,6 +95,9 @@ check:output=~/opt/xcat/share/xcat/tools/autotest/kdumpdir
 # Verify kdump parameters are in /proc/cmdline file
 cmd:xdsh $$CN cat /proc/cmdline
 
+# Check how much memory was really allocated for crashkernel
+cmd:xdsh $$CN grep "Reserving" /var/log/messages
+
 # Verify no error configuring kdump server
 cmd:xdsh $$CN cat /var/log/xcat/xcat.log | grep "The kdump server is not configured"
 check:output!="The kdump server is not configured"


### PR DESCRIPTION
The `linux_diskless_kdump` testcase continues to fail on RHEL8.5
Perhaps `crashkernel=auto` does not allocate enough space ? (https://sigillatum.tesarici.cz/2022-01-27-whats-wrong-with-crashkernel-auto.html)

This PR adds a command to see how much was really allocated.