### PR TITLE
Fixed makedns autotest tescases

### DIFF
--- a/xCAT-test/autotest/testcase/makedns/cases0
+++ b/xCAT-test/autotest/testcase/makedns/cases0
@@ -25,12 +25,12 @@ check:rc==0
 cmd:makedns dnstestnode
 check:rc==0
 cmd:nslookup dnstestnode $$MN
-check:output=~Server:             $$MN
+check:output=~Server:\s*$$MN
 check:output!~(server can't find dnstestnode)
 cmd:makedns -d dnstestnode
 check:rc==0
 cmd:nslookup dnstestnode $$MN
-check:output=~Server:             $$MN
+check:output=~Server:\s*$$MN
 check:output=~(server can't find dnstestnode)
 cmd:rmdef -t node dnstestnode
 check:rc==0
@@ -56,12 +56,12 @@ cmd:ps aux|grep name
 cmd:makedns dnstestnode
 check:rc==0
 cmd:nslookup dnstestnode $$MN
-check:output=~Server:             $$MN
+check:output=~Server:\s*$$MN
 check:output!~(server can't find dnstestnode)
 cmd:makedns -d dnstestnode
 check:rc==0
 cmd:nslookup dnstestnode $$MN
-check:output=~Server:             $$MN
+check:output=~Server:\s*$$MN
 check:output=~(server can't find dnstestnode)
 cmd:rmdef -t node dnstestnode
 check:rc==0
@@ -87,7 +87,7 @@ cmd:cat /etc/bind/named.conf
 check:rc==0
 check:output=~zone "100.100.100.IN-ADDR.ARPA."
 cmd:nslookup dnstestnode $$MN
-check:output=~Server:             $$MN
+check:output=~Server:\s*$$MN
 check:output!~(server can't find dnstestnode)
 cmd:rm -f /etc/hosts
 check:rc==0
@@ -101,7 +101,7 @@ cmd:cat /etc/bind/named.conf
 check:rc==0
 check:output!~zone "100.100.100.IN-ADDR.ARPA."
 cmd:nslookup dnstestnode $$MN
-check:output=~Server:             $$MN
+check:output=~Server:\s*$$MN
 check:output=~(server can't find dnstestnode)
 end
 
@@ -121,7 +121,7 @@ cmd:cat /etc/named.conf
 check:rc==0
 check:output=~zone "100.100.100.IN-ADDR.ARPA."
 cmd:nslookup dnstestnode $$MN
-check:output=~Server:             $$MN
+check:output=~Server:\s*$$MN
 check:output!~(server can't find dnstestnode)
 cmd:yes|cp -rf /etc/hosts.testbak   /etc/hosts
 check:rc==0
@@ -134,7 +134,7 @@ cmd:cat /etc/named.conf
 check:rc==0
 check:output!~zone "100.100.100.IN-ADDR.ARPA."
 cmd:nslookup dnstestnode $$MN
-check:output=~Server:             $$MN
+check:output=~Server:\s*$$MN
 check:output=~(server can't find dnstestnode)
 end
 
@@ -159,7 +159,7 @@ check:rc==0
 cmd:makedns
 check:rc==0
 cmd:nslookup dnstestnode $$MN
-check:output=~Server:             $$MN
+check:output=~Server:\s*$$MN
 check:output!~(server can't find dnstestnode)
 cmd:if [ -f "/etc/named.conf" ]; then a="/etc/named.conf"; elif [ -f "/etc/bind/named.conf" ]; then a="/etc/bind/named.conf";fi; cat $a > /tmp/makedns_named_conf.new
 check:rc==0
@@ -179,7 +179,7 @@ cmd:if [ -f "/etc/named.conf" ]; then a="/etc/named.conf"; elif [ -f "/etc/bind/
 check:rc==0
 check:output!~zone "100.100.100.IN-ADDR.ARPA."
 cmd:nslookup dnstestnode $$MN
-check:output=~Server:             $$MN
+check:output=~Server:\s*$$MN
 check:output=~(server can't find dnstestnode)
 end
 
@@ -223,7 +223,7 @@ cmd:service named status
 check:rc==0
 check:output=~running
 cmd:nslookup dnstestnode $$MN
-check:output=~Server:             $$MN
+check:output=~Server:\s*$$MN
 check:output!~(server can't find dnstestnode)
 cmd:xdsh $$SN "service named status"
 check:rc==0
@@ -232,10 +232,10 @@ cmd:xdsh $$SN "more /etc/named.conf"
 check:rc==0
 check:output=~forward only
 cmd:nslookup $$SN $$MN
-check:output=~Server:             $$MN
+check:output=~Server:\s*$$MN
 check:output!~(server can't find $$SN)
 cmd:nslookup dnstestnode $$SN
-check:output=~Server:             $$SN
+check:output=~Server:\s*$$SN
 check:output!~(server can't find dnstestnode)
 cmd:rm -f /etc/hosts
 check:rc==0
@@ -290,7 +290,7 @@ cmd:service named status
 check:rc==0
 check:output=~running
 cmd:nslookup dnstestnode $$MN
-check:output=~Server:             $$MN
+check:output=~Server:\s*$$MN
 check:output!~(server can't find dnstestnode)
 cmd:xdsh $$SN "service named status"
 check:rc==0
@@ -299,10 +299,10 @@ cmd:xdsh $$SN "more /etc/named.conf"
 check:rc==0
 check:output=~forward only
 cmd:nslookup $$SN $$MN
-check:output=~Server:             $$MN
+check:output=~Server:\s*$$MN
 check:output!~(server can't find $$SN)
 cmd:nslookup dnstestnode $$SN
-check:output=~Server:             $$SN
+check:output=~Server:\s*$$SN
 check:output!~(server can't find dnstestnode)
 cmd:rm -f /etc/hosts
 check:rc==0
@@ -363,7 +363,7 @@ check:output=~1
 cmd:service named status
 check:output=~running
 cmd:nslookup dnstestnode $$MN
-check:output=~Server:             $$MN
+check:output=~Server:\s*$$MN
 check:output!~(server can't find dnstestnode)
 cmd:xdsh $$SN "service named status"
 check:output=~running
@@ -371,10 +371,10 @@ cmd:xdsh $$SN "more /etc/named.conf"
 check:rc==0
 check:output=~type slave
 cmd:nslookup $$SN $$MN
-check:output=~Server:             $$MN
+check:output=~Server:\s*$$MN
 check:output!~(server can't find $$SN)
 cmd:nslookup dnstestnode $$SN
-check:output=~Server:             $$SN
+check:output=~Server:\s*$$SN
 check:output!~(server can't find dnstestnode)
 cmd:rm -f /etc/hosts
 check:rc==0
@@ -434,7 +434,7 @@ check:output=~1
 cmd:service named status
 check:output=~running
 cmd:nslookup dnstestnode $$MN
-check:output=~Server:             $$MN
+check:output=~Server:\s*$$MN
 check:output!~(server can't find dnstestnode)
 cmd:xdsh $$SN "service named status"
 check:output=~running
@@ -442,10 +442,10 @@ cmd:xdsh $$SN "more /etc/named.conf"
 check:rc==0
 check:output=~type slave
 cmd:nslookup $$SN $$MN
-check:output=~Server:             $$MN
+check:output=~Server:\s*$$MN
 check:output!~(server can't find $$SN)
 cmd:nslookup dnstestnode $$SN
-check:output=~Server:             $$SN
+check:output=~Server:\s*$$SN
 check:output!~(server can't find dnstestnode)
 cmd:rm -f /etc/hosts
 check:rc==0
@@ -485,11 +485,11 @@ check:rc==0
 check:output=~running
 cmd:nslookup dnstestnode $$MN
 check:rc==0
-check:output=~Server:         $$MN
+check:output=~Server:\s*$$MN
 check:output!~(server can't find dnstestnode)
 cmd:nslookup dnstestnode $$SN
 check:rc==0
-check:output=~Server:         $$SN
+check:output=~Server:\s*$$SN
 check:output!~(server can't find dnstestnode)
 cmd:service named stop
 check:rc==0
@@ -497,11 +497,11 @@ cmd:service named status
 check:output=~stopped
 cmd:nslookup dnstestnode $$MN
 check:rc!=0
-check:output=~Server:         $$MN
+check:output=~Server:\s*$$MN
 check:output=~(server can't find dnstestnode)
 cmd:nslookup dnstestnode $$SN
 check:rc==0
-check:output=~Server:         $$SN
+check:output=~Server:\s*$$SN
 check:output!~(server can't find dnstestnode)
 cmd:service named start
 check:rc==0
@@ -543,20 +543,20 @@ cmd:xdsh $$SN "service xcatd status"
 check:rc==0
 check:output=~running
 cmd:nslookup dnstestnode $$MN
-check:output=~Server:         $$MN
+check:output=~Server:\s*$$MN
 check:output!~(server can't find dnstestnode)
 cmd:nslookup dnstestnode $$SN
-check:output=~Server:         $$SN
+check:output=~Server:\s*$$SN
 check:output!~(server can't find dnstestnode)
 cmd:service named stop
 check:rc==0
 cmd:service named status
 check:output=~unused
 cmd:nslookup dnstestnode $$MN
-check:output=~Server:         $$MN
+check:output=~Server:\s*$$MN
 check:output=~(server can't find dnstestnode)
 cmd:nslookup dnstestnode $$SN
-check:output=~Server:         $$SN
+check:output=~Server:\s*$$SN
 check:output!~(server can't find dnstestnode)
 cmd:service named start
 check:rc==0
@@ -600,11 +600,11 @@ check:rc==0
 check:output=~running
 cmd:nslookup dnstestnode $$MN
 check:rc==0
-check:output=~Server:         $$MN
+check:output=~Server:\s*$$MN
 check:output!~(server can't find dnstestnode)
 cmd:nslookup dnstestnode $$SN
 check:rc==0
-check:output=~Server:         $$SN
+check:output=~Server:\s*$$SN
 check:output!~(server can't find dnstestnode)
 cmd:xdsh $$SN "service named stop"
 check:rc==0
@@ -613,11 +613,11 @@ check:rc!=0
 check:output=~stopped
 cmd:nslookup dnstestnode $$MN
 check:rc==0
-check:output=~Server:         $$MN
+check:output=~Server:\s*$$MN
 check:output!~(server can't find dnstestnode)
 cmd:nslookup dnstestnode $$SN
 check:rc!=0
-check:output=~Server:         $$SN
+check:output=~Server:\s*$$SN
 check:output=~(server can't find dnstestnode)
 cmd:xdsh $$SN "service named start"
 check:rc==0
@@ -660,20 +660,20 @@ cmd:xdsh $$SN "service xcatd status"
 check:rc==0
 check:output=~running
 cmd:nslookup dnstestnode $$MN
-check:output=~Server:         $$MN
+check:output=~Server:\s*$$MN
 check:output!~(server can't find dnstestnode)
 cmd:nslookup dnstestnode $$SN
-check:output=~Server:         $$SN
+check:output=~Server:\s*$$SN
 check:output!~(server can't find dnstestnode)
 cmd:xdsh $$SN "service named stop"
 check:rc==0
 cmd:xdsh $$SN "service named status"
 check:output=~unused
 cmd:nslookup dnstestnode $$MN
-check:output=~Server:         $$MN
+check:output=~Server:\s*$$MN
 check:output!~(server can't find dnstestnode)
 cmd:nslookup dnstestnode $$SN
-check:output=~Server:         $$SN
+check:output=~Server:\s*$$SN
 check:output=~(server can't find dnstestnode)
 cmd:xdsh $$SN "service named start"
 check:rc==0
@@ -712,21 +712,21 @@ cmd:makedns dnstestnode
 check:rc==0
 cmd:nslookup dnstestnode $$MN
 check:rc==0
-check:output=~Server:         $$MN
+check:output=~Server:\s*$$MN
 check:output!~(server can't find dnstestnode)
 cmd:sleep 2
 cmd:nslookup dnstestnode $$SN
 check:rc==0
-check:output=~Server:         $$SN
+check:output=~Server:\s*$$SN
 check:output!~(server can't find dnstestnode)
 cmd:makedns -d dnstestnode
 check:rc==0
 cmd:nslookup dnstestnode $$MN
-check:output=~Server:         $$MN
+check:output=~Server:\s*$$MN
 check:output=~(server can't find dnstestnode)
 cmd:sleep 2
 cmd:nslookup dnstestnode $$SN
-check:output=~Server:         $$SN
+check:output=~Server:\s*$$SN
 check:output=~(server can't find dnstestnode)
 cmd:rmdef -t node dnstestnode
 check:rc==0
@@ -805,7 +805,7 @@ cmd:makedns dnstestnode
 check:rc==0
 cmd:nslookup dnstestnode $$MN
 check:rc==0
-check:output=~Server:         $$MN
+check:output=~Server:\s*$$MN
 check:output!~(server can't find dnstestnode)
 cmd:xdsh $$SN "service named start"
 check:rc==0
@@ -815,7 +815,7 @@ check:output=~running
 cmd:sleep 2
 cmd:nslookup dnstestnode $$SN
 check:rc==0
-check:output=~Server:         $$SN
+check:output=~Server:\s*$$SN
 check:output!~(server can't find $$CN)
 cmd:xdsh $$SN "service named stop"
 check:rc==0
@@ -823,7 +823,7 @@ cmd:makedns -d dnstestnode
 check:rc==0
 cmd:nslookup dnstestnode $$MN
 check:rc!=0
-check:output=~Server:         $$MN
+check:output=~Server:\s*$$MN
 check:output=~(server can't find $$CN)
 cmd:xdsh $$SN "service named start"
 check:rc==0
@@ -858,22 +858,22 @@ cmd:tabdump networks
 cmd:makedns -n dnstestnode[1-10]
 check:rc==0
 cmd:nslookup dnstestnode5 $$MN
-check:output=~Server:             $$MN
+check:output=~Server:\s*$$MN
 check:output!~(server can't find dnstestnode)
 cmd:makedns -d dnstestnode[1-10]
 check:rc==0
 cmd:nslookup dnstestnode5 $$MN
-check:output=~Server:             $$MN
+check:output=~Server:\s*$$MN
 check:output=~(server can't find dnstestnode)
 cmd:makedns -n dnsnode
 check:rc==0
 cmd:nslookup dnstestnode5 $$MN
-check:output=~Server:             $$MN
+check:output=~Server:\s*$$MN
 check:output!~(server can't find dnstestnode)
 cmd:makedns -d dnsnode
 check:rc==0
 cmd:nslookup dnstestnode5 $$MN
-check:output=~Server:             $$MN
+check:output=~Server:\s*$$MN
 check:output=~(server can't find dnstestnode)
 cmd:rmdef -t node dnstestnode[1-10]
 check:rc==0

--- a/xCAT-test/autotest/testcase/makedns/cases0
+++ b/xCAT-test/autotest/testcase/makedns/cases0
@@ -26,12 +26,12 @@ cmd:makedns dnstestnode
 check:rc==0
 cmd:nslookup dnstestnode $$MN
 check:output=~Server:\s*$$MN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:makedns -d dnstestnode
 check:rc==0
 cmd:nslookup dnstestnode $$MN
 check:output=~Server:\s*$$MN
-check:output=~(server can't find dnstestnode)
+check:output=~Can't find dnstestnode
 cmd:rmdef -t node dnstestnode
 check:rc==0
 cmd:chtab -d netname=testnetwork networks
@@ -57,12 +57,12 @@ cmd:makedns dnstestnode
 check:rc==0
 cmd:nslookup dnstestnode $$MN
 check:output=~Server:\s*$$MN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:makedns -d dnstestnode
 check:rc==0
 cmd:nslookup dnstestnode $$MN
 check:output=~Server:\s*$$MN
-check:output=~(server can't find dnstestnode)
+check:output=~Can't find dnstestnode
 cmd:rmdef -t node dnstestnode
 check:rc==0
 cmd:chtab -d netname=testnetwork networks
@@ -88,7 +88,7 @@ check:rc==0
 check:output=~zone "100.100.100.IN-ADDR.ARPA."
 cmd:nslookup dnstestnode $$MN
 check:output=~Server:\s*$$MN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:rm -f /etc/hosts
 check:rc==0
 cmd:mv /etc/hosts.testbak   /etc/hosts
@@ -102,7 +102,7 @@ check:rc==0
 check:output!~zone "100.100.100.IN-ADDR.ARPA."
 cmd:nslookup dnstestnode $$MN
 check:output=~Server:\s*$$MN
-check:output=~(server can't find dnstestnode)
+check:output=~Can't find dnstestnode
 end
 
 start:makedns_n
@@ -122,7 +122,7 @@ check:rc==0
 check:output=~zone "100.100.100.IN-ADDR.ARPA."
 cmd:nslookup dnstestnode $$MN
 check:output=~Server:\s*$$MN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:yes|cp -rf /etc/hosts.testbak   /etc/hosts
 check:rc==0
 cmd:rm -rf /etc/hosts.testbak
@@ -135,7 +135,7 @@ check:rc==0
 check:output!~zone "100.100.100.IN-ADDR.ARPA."
 cmd:nslookup dnstestnode $$MN
 check:output=~Server:\s*$$MN
-check:output=~(server can't find dnstestnode)
+check:output=~Can't find dnstestnode
 end
 
 start:makedns
@@ -160,7 +160,7 @@ cmd:makedns
 check:rc==0
 cmd:nslookup dnstestnode $$MN
 check:output=~Server:\s*$$MN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:if [ -f "/etc/named.conf" ]; then a="/etc/named.conf"; elif [ -f "/etc/bind/named.conf" ]; then a="/etc/bind/named.conf";fi; cat $a > /tmp/makedns_named_conf.new
 check:rc==0
 cmd:diff /tmp/makedns_named_conf.org   /tmp/makedns_named_conf.new
@@ -180,7 +180,7 @@ check:rc==0
 check:output!~zone "100.100.100.IN-ADDR.ARPA."
 cmd:nslookup dnstestnode $$MN
 check:output=~Server:\s*$$MN
-check:output=~(server can't find dnstestnode)
+check:output=~Can't find dnstestnode
 end
 
 #------------------------------------
@@ -224,7 +224,7 @@ check:rc==0
 check:output=~running
 cmd:nslookup dnstestnode $$MN
 check:output=~Server:\s*$$MN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:xdsh $$SN "service named status"
 check:rc==0
 check:output=~running
@@ -233,10 +233,10 @@ check:rc==0
 check:output=~forward only
 cmd:nslookup $$SN $$MN
 check:output=~Server:\s*$$MN
-check:output!~(server can't find $$SN)
+check:output!~Can't find $$SN 
 cmd:nslookup dnstestnode $$SN
 check:output=~Server:\s*$$SN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:rm -f /etc/hosts
 check:rc==0
 cmd:mv /etc/hosts.testbak   /etc/hosts
@@ -291,7 +291,7 @@ check:rc==0
 check:output=~running
 cmd:nslookup dnstestnode $$MN
 check:output=~Server:\s*$$MN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:xdsh $$SN "service named status"
 check:rc==0
 check:output=~running
@@ -300,10 +300,10 @@ check:rc==0
 check:output=~forward only
 cmd:nslookup $$SN $$MN
 check:output=~Server:\s*$$MN
-check:output!~(server can't find $$SN)
+check:output!~Can't find $$SN 
 cmd:nslookup dnstestnode $$SN
 check:output=~Server:\s*$$SN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:rm -f /etc/hosts
 check:rc==0
 cmd:mv /etc/hosts.testbak   /etc/hosts
@@ -364,7 +364,7 @@ cmd:service named status
 check:output=~running
 cmd:nslookup dnstestnode $$MN
 check:output=~Server:\s*$$MN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:xdsh $$SN "service named status"
 check:output=~running
 cmd:xdsh $$SN "more /etc/named.conf"
@@ -372,10 +372,10 @@ check:rc==0
 check:output=~type slave
 cmd:nslookup $$SN $$MN
 check:output=~Server:\s*$$MN
-check:output!~(server can't find $$SN)
+check:output!~Can't find $$SN 
 cmd:nslookup dnstestnode $$SN
 check:output=~Server:\s*$$SN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:rm -f /etc/hosts
 check:rc==0
 cmd:mv /etc/hosts.testbak   /etc/hosts
@@ -435,7 +435,7 @@ cmd:service named status
 check:output=~running
 cmd:nslookup dnstestnode $$MN
 check:output=~Server:\s*$$MN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:xdsh $$SN "service named status"
 check:output=~running
 cmd:xdsh $$SN "more /etc/named.conf"
@@ -443,10 +443,10 @@ check:rc==0
 check:output=~type slave
 cmd:nslookup $$SN $$MN
 check:output=~Server:\s*$$MN
-check:output!~(server can't find $$SN)
+check:output!~Can't find $$SN 
 cmd:nslookup dnstestnode $$SN
 check:output=~Server:\s*$$SN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:rm -f /etc/hosts
 check:rc==0
 cmd:mv /etc/hosts.testbak   /etc/hosts
@@ -486,11 +486,11 @@ check:output=~running
 cmd:nslookup dnstestnode $$MN
 check:rc==0
 check:output=~Server:\s*$$MN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:nslookup dnstestnode $$SN
 check:rc==0
 check:output=~Server:\s*$$SN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:service named stop
 check:rc==0
 cmd:service named status
@@ -498,11 +498,11 @@ check:output=~stopped
 cmd:nslookup dnstestnode $$MN
 check:rc!=0
 check:output=~Server:\s*$$MN
-check:output=~(server can't find dnstestnode)
+check:output=~Can't find dnstestnode
 cmd:nslookup dnstestnode $$SN
 check:rc==0
 check:output=~Server:\s*$$SN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:service named start
 check:rc==0
 cmd:service named status
@@ -544,20 +544,20 @@ check:rc==0
 check:output=~running
 cmd:nslookup dnstestnode $$MN
 check:output=~Server:\s*$$MN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:nslookup dnstestnode $$SN
 check:output=~Server:\s*$$SN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:service named stop
 check:rc==0
 cmd:service named status
 check:output=~unused
 cmd:nslookup dnstestnode $$MN
 check:output=~Server:\s*$$MN
-check:output=~(server can't find dnstestnode)
+check:output=~Can't find dnstestnode
 cmd:nslookup dnstestnode $$SN
 check:output=~Server:\s*$$SN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:service named start
 check:rc==0
 cmd:service named status
@@ -601,11 +601,11 @@ check:output=~running
 cmd:nslookup dnstestnode $$MN
 check:rc==0
 check:output=~Server:\s*$$MN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:nslookup dnstestnode $$SN
 check:rc==0
 check:output=~Server:\s*$$SN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:xdsh $$SN "service named stop"
 check:rc==0
 cmd:xdsh $$SN "service named status"
@@ -614,11 +614,11 @@ check:output=~stopped
 cmd:nslookup dnstestnode $$MN
 check:rc==0
 check:output=~Server:\s*$$MN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:nslookup dnstestnode $$SN
 check:rc!=0
 check:output=~Server:\s*$$SN
-check:output=~(server can't find dnstestnode)
+check:output=~Can't find dnstestnode
 cmd:xdsh $$SN "service named start"
 check:rc==0
 cmd:xdsh $$SN "service named status"
@@ -661,20 +661,20 @@ check:rc==0
 check:output=~running
 cmd:nslookup dnstestnode $$MN
 check:output=~Server:\s*$$MN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:nslookup dnstestnode $$SN
 check:output=~Server:\s*$$SN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:xdsh $$SN "service named stop"
 check:rc==0
 cmd:xdsh $$SN "service named status"
 check:output=~unused
 cmd:nslookup dnstestnode $$MN
 check:output=~Server:\s*$$MN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:nslookup dnstestnode $$SN
 check:output=~Server:\s*$$SN
-check:output=~(server can't find dnstestnode)
+check:output=~Can't find dnstestnode
 cmd:xdsh $$SN "service named start"
 check:rc==0
 cmd:xdsh $$SN "service named status"
@@ -713,21 +713,21 @@ check:rc==0
 cmd:nslookup dnstestnode $$MN
 check:rc==0
 check:output=~Server:\s*$$MN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:sleep 2
 cmd:nslookup dnstestnode $$SN
 check:rc==0
 check:output=~Server:\s*$$SN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:makedns -d dnstestnode
 check:rc==0
 cmd:nslookup dnstestnode $$MN
 check:output=~Server:\s*$$MN
-check:output=~(server can't find dnstestnode)
+check:output=~Can't find dnstestnode
 cmd:sleep 2
 cmd:nslookup dnstestnode $$SN
 check:output=~Server:\s*$$SN
-check:output=~(server can't find dnstestnode)
+check:output=~Can't find dnstestnode
 cmd:rmdef -t node dnstestnode
 check:rc==0
 cmd:chtab -d netname=testnetwork networks
@@ -806,7 +806,7 @@ check:rc==0
 cmd:nslookup dnstestnode $$MN
 check:rc==0
 check:output=~Server:\s*$$MN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode
 cmd:xdsh $$SN "service named start"
 check:rc==0
 cmd:xdsh $$SN "service named status"
@@ -816,7 +816,7 @@ cmd:sleep 2
 cmd:nslookup dnstestnode $$SN
 check:rc==0
 check:output=~Server:\s*$$SN
-check:output!~(server can't find $$CN)
+check:output!~Can't find $$CN
 cmd:xdsh $$SN "service named stop"
 check:rc==0
 cmd:makedns -d dnstestnode
@@ -824,7 +824,7 @@ check:rc==0
 cmd:nslookup dnstestnode $$MN
 check:rc!=0
 check:output=~Server:\s*$$MN
-check:output=~(server can't find $$CN)
+check:output=~Can't find $$CN 
 cmd:xdsh $$SN "service named start"
 check:rc==0
 cmd:xdsh $$SN "service named status"
@@ -859,22 +859,22 @@ cmd:makedns -n dnstestnode[1-10]
 check:rc==0
 cmd:nslookup dnstestnode5 $$MN
 check:output=~Server:\s*$$MN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode 
 cmd:makedns -d dnstestnode[1-10]
 check:rc==0
 cmd:nslookup dnstestnode5 $$MN
 check:output=~Server:\s*$$MN
-check:output=~(server can't find dnstestnode)
+check:output=~Can't find dnstestnode 
 cmd:makedns -n dnsnode
 check:rc==0
 cmd:nslookup dnstestnode5 $$MN
 check:output=~Server:\s*$$MN
-check:output!~(server can't find dnstestnode)
+check:output!~Can't find dnstestnode 
 cmd:makedns -d dnsnode
 check:rc==0
 cmd:nslookup dnstestnode5 $$MN
 check:output=~Server:\s*$$MN
-check:output=~(server can't find dnstestnode)
+check:output=~Can't find dnstestnode 
 cmd:rmdef -t node dnstestnode[1-10]
 check:rc==0
 cmd:chtab -d netname=testnetwork networks

--- a/xCAT-test/autotest/testcase/makedns/cases0
+++ b/xCAT-test/autotest/testcase/makedns/cases0
@@ -25,13 +25,13 @@ check:rc==0
 cmd:makedns dnstestnode
 check:rc==0
 cmd:nslookup dnstestnode $$MN
-check:output~=Server:             $$MN
+check:output=~Server:             $$MN
 check:output!~(server can't find dnstestnode)
 cmd:makedns -d dnstestnode
 check:rc==0
 cmd:nslookup dnstestnode $$MN
-check:output~=Server:             $$MN
-check:output~=(server can't find dnstestnode)
+check:output=~Server:             $$MN
+check:output=~(server can't find dnstestnode)
 cmd:rmdef -t node dnstestnode
 check:rc==0
 cmd:chtab -d netname=testnetwork networks
@@ -56,13 +56,13 @@ cmd:ps aux|grep name
 cmd:makedns dnstestnode
 check:rc==0
 cmd:nslookup dnstestnode $$MN
-check:output~=Server:             $$MN
+check:output=~Server:             $$MN
 check:output!~(server can't find dnstestnode)
 cmd:makedns -d dnstestnode
 check:rc==0
 cmd:nslookup dnstestnode $$MN
-check:output~=Server:             $$MN
-check:output~=(server can't find dnstestnode)
+check:output=~Server:             $$MN
+check:output=~(server can't find dnstestnode)
 cmd:rmdef -t node dnstestnode
 check:rc==0
 cmd:chtab -d netname=testnetwork networks
@@ -85,9 +85,9 @@ cmd:makedns -n
 check:rc==0
 cmd:cat /etc/bind/named.conf
 check:rc==0
-check:output~=zone "100.100.100.IN-ADDR.ARPA."
+check:output=~zone "100.100.100.IN-ADDR.ARPA."
 cmd:nslookup dnstestnode $$MN
-check:output~=Server:             $$MN
+check:output=~Server:             $$MN
 check:output!~(server can't find dnstestnode)
 cmd:rm -f /etc/hosts
 check:rc==0
@@ -101,8 +101,8 @@ cmd:cat /etc/bind/named.conf
 check:rc==0
 check:output!~zone "100.100.100.IN-ADDR.ARPA."
 cmd:nslookup dnstestnode $$MN
-check:output~=Server:             $$MN
-check:output~=(server can't find dnstestnode)
+check:output=~Server:             $$MN
+check:output=~(server can't find dnstestnode)
 end
 
 start:makedns_n
@@ -119,9 +119,9 @@ cmd:makedns -n
 check:rc==0
 cmd:cat /etc/named.conf
 check:rc==0
-check:output~=zone "100.100.100.IN-ADDR.ARPA."
+check:output=~zone "100.100.100.IN-ADDR.ARPA."
 cmd:nslookup dnstestnode $$MN
-check:output~=Server:             $$MN
+check:output=~Server:             $$MN
 check:output!~(server can't find dnstestnode)
 cmd:yes|cp -rf /etc/hosts.testbak   /etc/hosts
 check:rc==0
@@ -134,8 +134,8 @@ cmd:cat /etc/named.conf
 check:rc==0
 check:output!~zone "100.100.100.IN-ADDR.ARPA."
 cmd:nslookup dnstestnode $$MN
-check:output~=Server:             $$MN
-check:output~=(server can't find dnstestnode)
+check:output=~Server:             $$MN
+check:output=~(server can't find dnstestnode)
 end
 
 start:makedns
@@ -147,7 +147,7 @@ cmd:makedns -n
 check:rc==0
 cmd:if [ -f "/etc/named.conf" ]; then a="/etc/named.conf"; elif [ -f "/etc/bind/named.conf" ]; then a="/etc/bind/named.conf";fi; cat $a
 check:rc==0
-check:output~=zone "100.100.100.IN-ADDR.ARPA."
+check:output=~zone "100.100.100.IN-ADDR.ARPA."
 cmd:rm -f /tmp/makedns_named_conf.org /tmp/makedns_named_conf.new
 check:rc==0
 cmd:if [ -f "/etc/named.conf" ]; then a="/etc/named.conf"; elif [ -f "/etc/bind/named.conf" ]; then a="/etc/bind/named.conf";fi; cat $a >/tmp/makedns_named_conf.org
@@ -159,13 +159,13 @@ check:rc==0
 cmd:makedns
 check:rc==0
 cmd:nslookup dnstestnode $$MN
-check:output~=Server:             $$MN
+check:output=~Server:             $$MN
 check:output!~(server can't find dnstestnode)
 cmd:if [ -f "/etc/named.conf" ]; then a="/etc/named.conf"; elif [ -f "/etc/bind/named.conf" ]; then a="/etc/bind/named.conf";fi; cat $a > /tmp/makedns_named_conf.new
 check:rc==0
 cmd:diff /tmp/makedns_named_conf.org   /tmp/makedns_named_conf.new
 check:rc==0
-check:output~=
+check:output=~
 cmd:rm -f /tmp/makedns_named_conf.org /tmp/makedns_named_conf.new
 check:rc==0
 cmd:yes|cp -rf /etc/hosts.testbak   /etc/hosts
@@ -179,8 +179,8 @@ cmd:if [ -f "/etc/named.conf" ]; then a="/etc/named.conf"; elif [ -f "/etc/bind/
 check:rc==0
 check:output!~zone "100.100.100.IN-ADDR.ARPA."
 cmd:nslookup dnstestnode $$MN
-check:output~=Server:             $$MN
-check:output~=(server can't find dnstestnode)
+check:output=~Server:             $$MN
+check:output=~(server can't find dnstestnode)
 end
 
 #------------------------------------
@@ -205,7 +205,7 @@ check:rc==0
 cmd:xdsh $$SN "service xcatd restart"
 check:rc==0
 cmd:xdsh $$SN "service xcatd status"
-check:output~=running
+check:output=~running
 cmd:more /etc/resolv.conf |grep nameserver
 cmd:xdsh $$SN "more /etc/resolv.conf |grep nameserver"
 cmd:xdsh $$CN "more /etc/resolv.conf |grep nameserver"
@@ -215,27 +215,27 @@ cmd:tabdump site|grep nameservers
 cmd:tabdump networks
 cmd:lsdef $$SN -i setupnameserver |grep setupnameserver
 check:rc==0
-check:output~=1
+check:output=~1
 cmd:lsdef $$SN -i setupdhcp |grep setupdhcp
 check:rc==0
-check:output~=1
+check:output=~1
 cmd:service named status
 check:rc==0
-check:output~=running
+check:output=~running
 cmd:nslookup dnstestnode $$MN
-check:output~=Server:             $$MN
+check:output=~Server:             $$MN
 check:output!~(server can't find dnstestnode)
 cmd:xdsh $$SN "service named status"
 check:rc==0
-check:output~=running
+check:output=~running
 cmd:xdsh $$SN "more /etc/named.conf"
 check:rc==0
-check:output~=forward only
+check:output=~forward only
 cmd:nslookup $$SN $$MN
-check:output~=Server:             $$MN
+check:output=~Server:             $$MN
 check:output!~(server can't find $$SN)
 cmd:nslookup dnstestnode $$SN
-check:output~=Server:             $$SN
+check:output=~Server:             $$SN
 check:output!~(server can't find dnstestnode)
 cmd:rm -f /etc/hosts
 check:rc==0
@@ -248,7 +248,7 @@ check:rc==0
 cmd:xdsh $$SN "service xcatd restart"
 check:rc==0
 cmd:xdsh $$SN "service xcatd status"
-check:output~=running
+check:output=~running
 end
 
 start:makedns_environment_check_forworder_mode
@@ -272,7 +272,7 @@ check:rc==0
 cmd:xdsh $$SN "service xcatd restart"
 check:rc==0
 cmd:xdsh $$SN "service xcatd status"
-cnd:output~=running
+cnd:output=~running
 cmd:more /etc/resolv.conf |grep nameserver
 cmd:xdsh $$SN "more /etc/resolv.conf |grep nameserver"
 cmd:xdsh $$CN "more /etc/resolv.conf |grep nameserver"
@@ -282,27 +282,27 @@ cmd:tabdump site|grep nameservers
 cmd:tabdump networks
 cmd:lsdef $$SN -i setupnameserver|grep setupnameserver
 check:rc==0
-check:output~=1
+check:output=~1
 cmd:lsdef $$SN -i setupdhcp|grep setupdhcp
 check:rc==0
-check:output~=1
+check:output=~1
 cmd:service named status
 check:rc==0
-check:output~=running
+check:output=~running
 cmd:nslookup dnstestnode $$MN
-check:output~=Server:             $$MN
+check:output=~Server:             $$MN
 check:output!~(server can't find dnstestnode)
 cmd:xdsh $$SN "service named status"
 check:rc==0
-check:output~=running
+check:output=~running
 cmd:xdsh $$SN "more /etc/named.conf"
 check:rc==0
-check:output~=forward only
+check:output=~forward only
 cmd:nslookup $$SN $$MN
-check:output~=Server:             $$MN
+check:output=~Server:             $$MN
 check:output!~(server can't find $$SN)
 cmd:nslookup dnstestnode $$SN
-check:output~=Server:             $$SN
+check:output=~Server:             $$SN
 check:output!~(server can't find dnstestnode)
 cmd:rm -f /etc/hosts
 check:rc==0
@@ -315,7 +315,7 @@ check:rc==0
 cmd:xdsh $$SN "service xcatd restart"
 check:rc==0
 cmd:xdsh $$SN "service xcatd status"
-check:output~=running
+check:output=~running
 end
 
 
@@ -340,7 +340,7 @@ check:rc==0
 cmd:xdsh $$SN "service xcatd restart"
 check:rc==0
 cmd:xdsh $$SN "service xcatd status"
-check:output~=running
+check:output=~running
 cmd:more /etc/resolv.conf|grep nameserver
 check:rc==0
 cmd:xdsh $$SN "more /etc/resolv.conf|grep nameserver"
@@ -356,25 +356,25 @@ cmd:tabdump networks
 check:rc==0
 cmd:lsdef $$SN -i setupnameserver|grep setupnameserver
 check:rc==0
-check:output~=2
+check:output=~2
 cmd:lsdef $$SN -i setupdhcp|grep setupdhcp
 check:rc==0
-check:output~=1
+check:output=~1
 cmd:service named status
-check:output~=running
+check:output=~running
 cmd:nslookup dnstestnode $$MN
-check:output~=Server:             $$MN
+check:output=~Server:             $$MN
 check:output!~(server can't find dnstestnode)
 cmd:xdsh $$SN "service named status"
-check:output~=running
+check:output=~running
 cmd:xdsh $$SN "more /etc/named.conf"
 check:rc==0
-check:output~=type slave
+check:output=~type slave
 cmd:nslookup $$SN $$MN
-check:output~=Server:             $$MN
+check:output=~Server:             $$MN
 check:output!~(server can't find $$SN)
 cmd:nslookup dnstestnode $$SN
-check:output~=Server:             $$SN
+check:output=~Server:             $$SN
 check:output!~(server can't find dnstestnode)
 cmd:rm -f /etc/hosts
 check:rc==0
@@ -387,7 +387,7 @@ check:rc==0
 cmd:xdsh $$SN "service xcatd restart"
 check:rc==0
 cmd:xdsh $$SN "service xcatd status"
-check:output~=running
+check:output=~running
 end
 
 start:makedns_environment_check_master_slave_mode
@@ -411,7 +411,7 @@ check:rc==0
 cmd:xdsh $$SN "service xcatd restart"
 check:rc==0
 cmd:xdsh $$SN "service xcatd status"
-check:output~=running
+check:output=~running
 cmd:more /etc/resolv.conf|grep nameserver
 check:rc==0
 cmd:xdsh $$SN "more /etc/resolv.conf|grep nameserver"
@@ -427,25 +427,25 @@ cmd:tabdump networks
 check:rc==0
 cmd:lsdef $$SN -i setupnameserver|grep setupnameserver
 check:rc==0
-check:output~=2
+check:output=~2
 cmd:lsdef $$SN -i setupdhcp|grep setupdhcp
 check:rc==0
-check:output~=1
+check:output=~1
 cmd:service named status
-check:output~=running
+check:output=~running
 cmd:nslookup dnstestnode $$MN
-check:output~=Server:             $$MN
+check:output=~Server:             $$MN
 check:output!~(server can't find dnstestnode)
 cmd:xdsh $$SN "service named status"
-check:output~=running
+check:output=~running
 cmd:xdsh $$SN "more /etc/named.conf"
 check:rc==0
-check:output~=type slave
+check:output=~type slave
 cmd:nslookup $$SN $$MN
-check:output~=Server:             $$MN
+check:output=~Server:             $$MN
 check:output!~(server can't find $$SN)
 cmd:nslookup dnstestnode $$SN
-check:output~=Server:             $$SN
+check:output=~Server:             $$SN
 check:output!~(server can't find dnstestnode)
 cmd:rm -f /etc/hosts
 check:rc==0
@@ -458,7 +458,7 @@ check:rc==0
 cmd:xdsh $$SN "service xcatd restart"
 check:rc==0
 cmd:xdsh $$SN "service xcatd status"
-check:output~=running
+check:output=~running
 end
 
 #---------------------------------------------------------------------
@@ -477,37 +477,37 @@ cmd:makedns -n
 check:rc==0
 cmd:service named status
 check:rc==0
-check:output~=running
+check:output=~running
 cmd:xdsh $$SN "service xcatd restart"
 check:rc==0
 cmd:xdsh $$SN "service xcatd status"
 check:rc==0
-check:output~=running
+check:output=~running
 cmd:nslookup dnstestnode $$MN
 check:rc==0
-check:output~=Server:         $$MN
+check:output=~Server:         $$MN
 check:output!~(server can't find dnstestnode)
 cmd:nslookup dnstestnode $$SN
 check:rc==0
-check:output~=Server:         $$SN
+check:output=~Server:         $$SN
 check:output!~(server can't find dnstestnode)
 cmd:service named stop
 check:rc==0
 cmd:service named status
-check:output~=stopped
+check:output=~stopped
 cmd:nslookup dnstestnode $$MN
 check:rc!=0
-check:output~=Server:         $$MN
-check:output~=(server can't find dnstestnode)
+check:output=~Server:         $$MN
+check:output=~(server can't find dnstestnode)
 cmd:nslookup dnstestnode $$SN
 check:rc==0
-check:output~=Server:         $$SN
+check:output=~Server:         $$SN
 check:output!~(server can't find dnstestnode)
 cmd:service named start
 check:rc==0
 cmd:service named status
 check:rc==0
-check:output~=running
+check:output=~running
 cmd:rm -f /etc/hosts
 check:rc==0
 cmd:mv /etc/hosts.testbak   /etc/hosts
@@ -519,7 +519,7 @@ check:rc==0
 cmd:xdsh $$SN "service xcatd restart"
 check:rc==0
 cmd:xdsh $$SN "service xcatd status"
-check:output~=running
+check:output=~running
 end
 
 start:makedns_when_nameserver_on_mn_down
@@ -536,33 +536,33 @@ cmd:makedns -n
 check:rc==0
 cmd:service named status
 check:rc==0
-check:output~=running
+check:output=~running
 cmd:xdsh $$SN "service xcatd restart"
 check:rc==0
 cmd:xdsh $$SN "service xcatd status"
 check:rc==0
-check:output~=running
+check:output=~running
 cmd:nslookup dnstestnode $$MN
-check:output~=Server:         $$MN
+check:output=~Server:         $$MN
 check:output!~(server can't find dnstestnode)
 cmd:nslookup dnstestnode $$SN
-check:output~=Server:         $$SN
+check:output=~Server:         $$SN
 check:output!~(server can't find dnstestnode)
 cmd:service named stop
 check:rc==0
 cmd:service named status
-check:output~=unused
+check:output=~unused
 cmd:nslookup dnstestnode $$MN
-check:output~=Server:         $$MN
-check:output~=(server can't find dnstestnode)
+check:output=~Server:         $$MN
+check:output=~(server can't find dnstestnode)
 cmd:nslookup dnstestnode $$SN
-check:output~=Server:         $$SN
+check:output=~Server:         $$SN
 check:output!~(server can't find dnstestnode)
 cmd:service named start
 check:rc==0
 cmd:service named status
 check:rc==0
-check:output~=running
+check:output=~running
 cmd:rm -f /etc/hosts
 check:rc==0
 cmd:mv /etc/hosts.testbak   /etc/hosts
@@ -574,7 +574,7 @@ check:rc==0
 cmd:xdsh $$SN "service xcatd restart"
 check:rc==0
 cmd:xdsh $$SN "service xcatd status"
-check:output~=running
+check:output=~running
 end
 
 
@@ -592,38 +592,38 @@ cmd:makedns -n
 check:rc==0
 cmd:service named status
 check:rc==0
-check:output~=running
+check:output=~running
 cmd:xdsh $$SN "service xcatd restart"
 check:rc==0
 cmd:xdsh $$SN "service xcatd status"
 check:rc==0
-check:output~=running
+check:output=~running
 cmd:nslookup dnstestnode $$MN
 check:rc==0
-check:output~=Server:         $$MN
+check:output=~Server:         $$MN
 check:output!~(server can't find dnstestnode)
 cmd:nslookup dnstestnode $$SN
 check:rc==0
-check:output~=Server:         $$SN
+check:output=~Server:         $$SN
 check:output!~(server can't find dnstestnode)
 cmd:xdsh $$SN "service named stop"
 check:rc==0
 cmd:xdsh $$SN "service named status"
 check:rc!=0
-check:output~=stopped
+check:output=~stopped
 cmd:nslookup dnstestnode $$MN
 check:rc==0
-check:output~=Server:         $$MN
+check:output=~Server:         $$MN
 check:output!~(server can't find dnstestnode)
 cmd:nslookup dnstestnode $$SN
 check:rc!=0
-check:output~=Server:         $$SN
-check:output~=(server can't find dnstestnode)
+check:output=~Server:         $$SN
+check:output=~(server can't find dnstestnode)
 cmd:xdsh $$SN "service named start"
 check:rc==0
 cmd:xdsh $$SN "service named status"
 check:rc==0
-check:output~=running
+check:output=~running
 cmd:rm -f /etc/hosts
 check:rc==0
 cmd:mv /etc/hosts.testbak   /etc/hosts
@@ -636,7 +636,7 @@ cmd:xdsh $$SN "service xcatd restart"
 check:rc==0
 cmd:xdsh $$SN "service xcatd status"
 check:rc==0
-check:output~=running
+check:output=~running
 end
 
 start:makedns_when_nameserver_on_sn_down
@@ -653,33 +653,33 @@ cmd:makedns -n
 check:rc==0
 cmd:service named status
 check:rc==0
-check:output~=running
+check:output=~running
 cmd:xdsh $$SN "service xcatd restart"
 check:rc==0
 cmd:xdsh $$SN "service xcatd status"
 check:rc==0
-check:output~=running
+check:output=~running
 cmd:nslookup dnstestnode $$MN
-check:output~=Server:         $$MN
+check:output=~Server:         $$MN
 check:output!~(server can't find dnstestnode)
 cmd:nslookup dnstestnode $$SN
-check:output~=Server:         $$SN
+check:output=~Server:         $$SN
 check:output!~(server can't find dnstestnode)
 cmd:xdsh $$SN "service named stop"
 check:rc==0
 cmd:xdsh $$SN "service named status"
-check:output~=unused
+check:output=~unused
 cmd:nslookup dnstestnode $$MN
-check:output~=Server:         $$MN
+check:output=~Server:         $$MN
 check:output!~(server can't find dnstestnode)
 cmd:nslookup dnstestnode $$SN
-check:output~=Server:         $$SN
-check:output~=(server can't find dnstestnode)
+check:output=~Server:         $$SN
+check:output=~(server can't find dnstestnode)
 cmd:xdsh $$SN "service named start"
 check:rc==0
 cmd:xdsh $$SN "service named status"
 check:rc==0
-check:output~=running
+check:output=~running
 cmd:rm -f /etc/hosts
 check:rc==0
 cmd:mv /etc/hosts.testbak   /etc/hosts
@@ -692,7 +692,7 @@ cmd:xdsh $$SN "service xcatd restart"
 check:rc==0
 cmd:xdsh $$SN "service xcatd status"
 check:rc==0
-check:output~=running
+check:output=~running
 end
 
 #999999999999999999999999999
@@ -712,22 +712,22 @@ cmd:makedns dnstestnode
 check:rc==0
 cmd:nslookup dnstestnode $$MN
 check:rc==0
-check:output~=Server:         $$MN
+check:output=~Server:         $$MN
 check:output!~(server can't find dnstestnode)
 cmd:sleep 2
 cmd:nslookup dnstestnode $$SN
 check:rc==0
-check:output~=Server:         $$SN
+check:output=~Server:         $$SN
 check:output!~(server can't find dnstestnode)
 cmd:makedns -d dnstestnode
 check:rc==0
 cmd:nslookup dnstestnode $$MN
-check:output~=Server:         $$MN
-check:output~=(server can't find dnstestnode)
+check:output=~Server:         $$MN
+check:output=~(server can't find dnstestnode)
 cmd:sleep 2
 cmd:nslookup dnstestnode $$SN
-check:output~=Server:         $$SN
-check:output~=(server can't find dnstestnode)
+check:output=~Server:         $$SN
+check:output=~(server can't find dnstestnode)
 cmd:rmdef -t node dnstestnode
 check:rc==0
 cmd:chtab -d netname=testnetwork networks
@@ -756,7 +756,7 @@ cmd:makedns -n
 check:rc==0
 cmd:cat /etc/named.conf
 check:rc==0
-check:output~=zone "100.100.100.IN-ADDR.ARPA."
+check:output=~zone "100.100.100.IN-ADDR.ARPA."
 cmd:xdsh $$SN "cat /etc/named.conf"
 check:rc==0
 check:output!~zone "100.100.100.IN-ADDR.ARPA."
@@ -764,7 +764,7 @@ cmd:xdsh $$SN "service xcatd restart"
 check:rc==0
 cmd:xdsh $$SN "cat /etc/named.conf"
 check:rc==0
-check:output~=zone "100.100.100.IN-ADDR.ARPA."
+check:output=~zone "100.100.100.IN-ADDR.ARPA."
 cmd:chtab -d netname=testnetwork networks
 check:rc==0
 cmd:makedns -n
@@ -774,12 +774,12 @@ check:rc==0
 check:output!~zone "100.100.100.IN-ADDR.ARPA."
 cmd:xdsh $$SN "cat /etc/named.conf"
 check:rc==0
-check:output~=zone "100.100.100.IN-ADDR.ARPA."
+check:output=~zone "100.100.100.IN-ADDR.ARPA."
 cmd:xdsh $$SN "service xcatd restart"
 check:rc==0
 cmd:xdsh $$SN "cat /etc/named.conf"
 check:rc==0
-check:output!~=zone "100.100.100.IN-ADDR.ARPA."
+check:output!~zone "100.100.100.IN-ADDR.ARPA."
 end
 
 
@@ -791,10 +791,10 @@ cmd:makedns -n
 check:rc==0
 cmd:service named status
 check:rc==0
-check:output~=running
+check:output=~running
 cmd:xdsh $$SN "service named status"
 check:rc==0
-check:output~=running
+check:output=~running
 cmd:chtab netname=testnetwork networks.net=100.100.100.0 networks.mask=255.255.255.0 networks.mgtifname=eth0 networks.gateway=100.100.100.254
 check:rc==0
 cmd:chdef -t node -o dnstestnode groups=all  ip=100.100.100.2
@@ -805,17 +805,17 @@ cmd:makedns dnstestnode
 check:rc==0
 cmd:nslookup dnstestnode $$MN
 check:rc==0
-check:output~=Server:         $$MN
+check:output=~Server:         $$MN
 check:output!~(server can't find dnstestnode)
 cmd:xdsh $$SN "service named start"
 check:rc==0
 cmd:xdsh $$SN "service named status"
 check:rc==0
-check:output~=running
+check:output=~running
 cmd:sleep 2
 cmd:nslookup dnstestnode $$SN
 check:rc==0
-check:output~=Server:         $$SN
+check:output=~Server:         $$SN
 check:output!~(server can't find $$CN)
 cmd:xdsh $$SN "service named stop"
 check:rc==0
@@ -823,13 +823,13 @@ cmd:makedns -d dnstestnode
 check:rc==0
 cmd:nslookup dnstestnode $$MN
 check:rc!=0
-check:output~=Server:         $$MN
-check:output~=(server can't find $$CN)
+check:output=~Server:         $$MN
+check:output=~(server can't find $$CN)
 cmd:xdsh $$SN "service named start"
 check:rc==0
 cmd:xdsh $$SN "service named status"
 check:rc==0
-check:output~=running
+check:output=~running
 cmd:sleep 2
 cmd:nslookup dnstestnode $$SN
 check:rc!=0
@@ -858,23 +858,23 @@ cmd:tabdump networks
 cmd:makedns -n dnstestnode[1-10]
 check:rc==0
 cmd:nslookup dnstestnode5 $$MN
-check:output~=Server:             $$MN
+check:output=~Server:             $$MN
 check:output!~(server can't find dnstestnode)
 cmd:makedns -d dnstestnode[1-10]
 check:rc==0
 cmd:nslookup dnstestnode5 $$MN
-check:output~=Server:             $$MN
-check:output~=(server can't find dnstestnode)
+check:output=~Server:             $$MN
+check:output=~(server can't find dnstestnode)
 cmd:makedns -n dnsnode
 check:rc==0
 cmd:nslookup dnstestnode5 $$MN
-check:output~=Server:             $$MN
+check:output=~Server:             $$MN
 check:output!~(server can't find dnstestnode)
 cmd:makedns -d dnsnode
 check:rc==0
 cmd:nslookup dnstestnode5 $$MN
-check:output~=Server:             $$MN
-check:output~=(server can't find dnstestnode)
+check:output=~Server:             $$MN
+check:output=~(server can't find dnstestnode)
 cmd:rmdef -t node dnstestnode[1-10]
 check:rc==0
 cmd:chtab -d netname=testnetwork networks

--- a/xCAT-test/autotest/testcase/makedns/cases0
+++ b/xCAT-test/autotest/testcase/makedns/cases0
@@ -163,9 +163,9 @@ check:output=~Server:\s*$$MN
 check:output!~Can't find dnstestnode
 cmd:if [ -f "/etc/named.conf" ]; then a="/etc/named.conf"; elif [ -f "/etc/bind/named.conf" ]; then a="/etc/bind/named.conf";fi; cat $a > /tmp/makedns_named_conf.new
 check:rc==0
-cmd:diff /tmp/makedns_named_conf.org   /tmp/makedns_named_conf.new
+cmd:diff -s /tmp/makedns_named_conf.org   /tmp/makedns_named_conf.new
 check:rc==0
-check:output=~
+check:output=~are identical
 cmd:rm -f /tmp/makedns_named_conf.org /tmp/makedns_named_conf.new
 check:rc==0
 cmd:yes|cp -rf /etc/hosts.testbak   /etc/hosts

--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -1447,11 +1447,6 @@ sub run_case {
                         || (($op eq '==') && ($lvalue ne $rvalue))
                         || (($op eq '!=') && ($lvalue eq $rvalue))) {
                         $failflag = 1;
-                    } elsif (($op ne '=~') && ($op ne '!~') && ($op ne '==') && ($op ne '!=')) {
-                        $failflag = 1;
-                        log_this($running_log_fd, "CHECK:output unrecognized operator: $op\t[Failed]");
-                        push(@caselog, "CHECK:output unrecognized operator: $op\t[Failed]");
-                        last;
                     }
                     if ($failflag) {
                         log_this($running_log_fd, "CHECK:output $op $rvalue\t[Failed]");
@@ -1496,13 +1491,7 @@ sub run_case {
                     } else {
                         log_this($running_log_fd, "CHECK:output $op $rvalue\t[Pass]");
                         push(@caselog, "CHECK:output $op $rvalue\t[Pass]");
-                    } 
-                } else {
-                    $failflag = 1;
-                    log_this($running_log_fd, "Unrecognized testcase syntax: CHECK:$check\t[Failed]");
-                    push(@caselog, "Unrecognized testcase syntax: CHECK:$check\t[Failed]");
-                } 
-            }
+                    } } }
             foreach my $cmdcheck (@{ $cases_ref->[ $case_name_index_map_ref->{$case} ]->{cmdcheck}->[$j] }) {
                 if ($cmdcheck) {
                     &runcmd($cmdcheck);

--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -1447,6 +1447,11 @@ sub run_case {
                         || (($op eq '==') && ($lvalue ne $rvalue))
                         || (($op eq '!=') && ($lvalue eq $rvalue))) {
                         $failflag = 1;
+                    } elsif (($op ne '=~') && ($op ne '!~') && ($op ne '==') && ($op ne '!=')) {
+                        $failflag = 1;
+                        log_this($running_log_fd, "CHECK:output unrecognized operator: $op\t[Failed]");
+                        push(@caselog, "CHECK:output unrecognized operator: $op\t[Failed]");
+                        last;
                     }
                     if ($failflag) {
                         log_this($running_log_fd, "CHECK:output $op $rvalue\t[Failed]");
@@ -1491,7 +1496,13 @@ sub run_case {
                     } else {
                         log_this($running_log_fd, "CHECK:output $op $rvalue\t[Pass]");
                         push(@caselog, "CHECK:output $op $rvalue\t[Pass]");
-                    } } }
+                    } 
+                } else {
+                    $failflag = 1;
+                    log_this($running_log_fd, "Unrecognized testcase syntax: CHECK:$check\t[Failed]");
+                    push(@caselog, "Unrecognized testcase syntax: CHECK:$check\t[Failed]");
+                } 
+            }
             foreach my $cmdcheck (@{ $cases_ref->[ $case_name_index_map_ref->{$case} ]->{cmdcheck}->[$j] }) {
                 if ($cmdcheck) {
                     &runcmd($cmdcheck);


### PR DESCRIPTION
This PR contains the first set of changes needed to address #7110. Due to the scope of the changes, I am breaking them into smaller pieces. 

There are many existing autotest cases that are not executing as expected due to unnoticed syntax errors. I am fixing the broken tests before checking in the changes in `xcattest` to begin flagging broken tests. The `makedns` autotest case has 122 broken tests that falsely report "PASS" due to incorrect use of `check:output~=` instead of `check:output=~`:
```
[root@f6u13k04 autotest]# grep "check:output" testcase/makedns/cases0 | wc -l
165
[root@f6u13k04 autotest]# grep "check:output" testcase/makedns/cases0 | fgrep '~=' | wc -l
122
```
This PR contains 4 broad fixes:
1.) Changed all instances of `check:output~=` to `check:output=~`:
This fixes the syntax error and causes the 122 tests that were previously falsely reporting `[Pass]` without executing to now execute.

2.) Many tests began to fail due to checking the `nslookup` output for a fixed amount of white space between `Server:` and the node name. The next fix was to replace this logic:
```
check:output~=Server: $$MN
```
 with a regex that would accept a variable amount of white space:
```
check:output=~Server:\s*$$MN
```
Unit test before:
```
RUN:nslookup dnstestnode f6u13k04 [Tue Feb 22 09:03:06 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Server:         f6u13k04
Address:        10.6.13.4#53

Name:   dnstestnode.pok.stglabs.ibm.com
Address: 100.100.100.1

CHECK:output ~= Server:             f6u13k04      [Failed]
```

Unit test after:
```
RUN:nslookup dnstestnode f6u13k04 [Tue Feb 22 09:31:36 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Server:         f6u13k04
Address:        10.6.13.4#53

Name:   dnstestnode.pok.stglabs.ibm.com
Address: 100.100.100.1

CHECK:output =~ Server:\s*f6u13k04        [Pass]
```
3.) Another failing check was due to looking for incorrect output from `nslookup` for nodes that were not known to DNS.
Changed this logic:
```
check:output!~(server can't find dnstestnode)
```
to this:
```
check:output!~Can't find dnstestnode
```

Unit test before:
```
RUN:nslookup dnstestnode f6u13k04 [Tue Feb 22 09:31:41 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Server:         f6u13k04
Address:        10.6.13.4#53

Non-authoritative answer:
*** Can't find dnstestnode: No answer

CHECK:output =~ Server:\s*f6u13k04        [Pass]
CHECK:output =~ (server can't find dnstestnode)      [Failed]
```
Unit test after:
```
RUN:nslookup dnstestnode f6u13k04 [Tue Feb 22 10:37:54 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Server:         f6u13k04
Address:        10.6.13.4#53

Non-authoritative answer:
*** Can't find dnstestnode: No answer

CHECK:output =~ Server:\s*f6u13k04        [Pass]
CHECK:output =~ Can't find dnstestnode       [Pass]
```

4.) The last fix was related to trying to call `check:output=~` with no string on the right side of the expression. I fixed this specific problem by adding the `-s` flag to `diff` to indicate whether the files compared are identical.
Replaced this logic:
```
cmd:diff /tmp/makedns_named_conf.org   /tmp/makedns_named_conf.new
check:rc==0
check:output~=
```

with this:
```
cmd:diff -s /tmp/makedns_named_conf.org   /tmp/makedns_named_conf.new
check:rc==0
check:output=~are identical
```
Unit test before (falsely reported as Pass):
```
RUN:diff /tmp/makedns_named_conf.org   /tmp/makedns_named_conf.new [Tue Feb 22 10:37:49 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0     [Pass]
CHECK:output = ~     [Pass]
```

Unit test after (correctly reported as Pass):
```
RUN:diff -s /tmp/makedns_named_conf.org   /tmp/makedns_named_conf.new [Tue Feb 22 12:40:52 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Files /tmp/makedns_named_conf.org and /tmp/makedns_named_conf.new are identical
CHECK:rc == 0     [Pass]
CHECK:output =~ are identical        [Pass]
```

After all of the changes above, I did a final test of the most commonly run tests in our test case buckets and confirmed all tests passed:
```
[root@f6u13k04 autotest]# xcattest -f default.conf -t makedns,makedns_d_node,makedns_h,makedns_n,makedns_n_noderange 2>&1 | tee /tmp/makedns.4

[root@f6u13k04 autotest]# egrep "START|END|Total" /tmp/makedns.4
------START::makedns::Time:Tue Feb 22 12:40:43 2022------
------END::makedns::Passed::Time:Tue Feb 22 12:40:57 2022 ::Duration::14 sec------
------START::makedns_d_node::Time:Tue Feb 22 12:40:57 2022------
------END::makedns_d_node::Passed::Time:Tue Feb 22 12:41:13 2022 ::Duration::16 sec------
------START::makedns_h::Time:Tue Feb 22 12:41:13 2022------
------END::makedns_h::Passed::Time:Tue Feb 22 12:41:13 2022 ::Duration::0 sec------
------START::makedns_n::Time:Tue Feb 22 12:41:13 2022------
------END::makedns_n::Passed::Time:Tue Feb 22 12:41:24 2022 ::Duration::11 sec------
------START::makedns_n_noderange::Time:Tue Feb 22 12:41:24 2022------
------END::makedns_n_noderange::Passed::Time:Tue Feb 22 12:41:44 2022 ::Duration::20 sec------
------Total: 5 , Failed: 0------

[root@f6u13k04 autotest]# grep CHECK /tmp/makedns.4 | grep "Pass" | wc -l
71

[root@f6u13k04 autotest]# grep CHECK /tmp/makedns.4 | grep -v "Pass" | wc -l
0
```


