### PR TITLE
Improve readability of generated AutoYaST for SLES15

### DIFF
--- a/xCAT-server/lib/perl/xCAT/Template.pm
+++ b/xCAT-server/lib/perl/xCAT/Template.pm
@@ -298,6 +298,8 @@ sub subvars {
             my $source_in_pre;
             my $writerepo;
             my $c = 0;
+            my $space10 = " " x 10;
+            my $space12 = " " x 12;
             foreach my $pkgdir (@pkgdirs) {
                 if ($platform =~ /^(rh|SL|centos|ol|fedora|rocky)$/) {
                     if ($c == 0) {
@@ -350,13 +352,14 @@ sub subvars {
                                 $product_name=$subdir;
                             }
                             if (defined($product_name) && defined($product_dir)){
-                                $source .="<listentry><media_url>http://XCATNEXTSERVERHOOK$httpportsuffix$pkgdir</media_url><product>$product_name</product><product_dir>/$product_dir</product_dir></listentry>";
+                                $source .="<listentry>\n$space12<media_url>http://XCATNEXTSERVERHOOK$httpportsuffix$pkgdir</media_url>\n$space12<product>$product_name</product>\n$space12<product_dir>/$product_dir</product_dir>\n$space12</listentry>\n$space10";
                             } 
                         }
                     }
                 }
                 $c++;
             }
+            $source =~ s/\s+$//; # trim end of string
             $inc =~ s/#INSTALL_SOURCES#/$source/g;
             $inc =~ s/#INSTALL_SOURCES_IN_PRE#/$source_in_pre/g;
             if (("ubuntu" eq $platform) || ("debian" eq $platform)) {


### PR DESCRIPTION
Currently the `/install/autoinst/<node>` AutoYaST file generated from template file `install/sle/compute.sle15.tmpl` entry :
```
    <add-on>
        <add_on_products config:type="list">
          #INSTALL_SOURCES#
        </add_on_products>
    </add-on>
```

Looks like this, making it very hard to read
```
   <add-on>
        <add_on_products config:type="list">
          <listentry><media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url><product>sle-module-basesystem</product><product_dir>/Module-Basesystem</product_dir></listentry><listentry><media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url><product>sle-module-containers</product><product_dir>/Module-Containers</product_dir></listentry><listentry><media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url><product>sle-module-desktop-applications</product><product_dir>/Module-Desktop-Applications</product_dir></listentry><listentry><media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url><product>sle-module-development-tools</product><product_dir>/Module-Development-Tools</product_dir></listentry><listentry><media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url><product>sle-module-legacy</product><product_dir>/Module-Legacy</product_dir></listentry><listentry><media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url><product>sle-module-live-patching</product><product_dir>/Module-Live-Patching</product_dir></listentry><listentry><media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url><product>sle-module-public-cloud</product><product_dir>/Module-Public-Cloud</product_dir></listentry><listentry><media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url><product>sle-module-python2</product><product_dir>/Module-Python2</product_dir></listentry><listentry><media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url><product>sle-module-sap-applications</product><product_dir>/Module-SAP-Applications</product_dir></listentry><listentry><media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url><product>sle-module-server-applications</product><product_dir>/Module-Server-Applications</product_dir></listentry><listentry><media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url><product>sle-module-transactional-server</product><product_dir>/Module-Transactional-Server</product_dir></listentry><listentry><media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url><product>sle-module-web-scripting</product><product_dir>/Module-Web-Scripting</product_dir></listentry><listentry><media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url><product>HA</product><product_dir>/Product-HA</product_dir></listentry><listentry><media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url><product>SLES</product><product_dir>/Product-SLES</product_dir></listentry>
        </add_on_products>
    </add-on>
```

This PR adds some new lines and spaces to that entry:
```
    <add-on>
        <add_on_products config:type="list">
          <listentry>
            <media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url>
            <product>sle-module-basesystem</product>
            <product_dir>/Module-Basesystem</product_dir>
          </listentry>
          <listentry>
            <media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url>
            <product>sle-module-containers</product>
            <product_dir>/Module-Containers</product_dir>
          </listentry>
          <listentry>
            <media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url>
            <product>sle-module-desktop-applications</product>
            <product_dir>/Module-Desktop-Applications</product_dir>
          </listentry>
          <listentry>
            <media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url>
            <product>sle-module-development-tools</product>
            <product_dir>/Module-Development-Tools</product_dir>
          </listentry>
          <listentry>
            <media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url>
            <product>sle-module-legacy</product>
            <product_dir>/Module-Legacy</product_dir>
          </listentry>
          <listentry>
            <media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url>
            <product>sle-module-live-patching</product>
            <product_dir>/Module-Live-Patching</product_dir>
          </listentry>
          <listentry>
            <media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url>
            <product>sle-module-public-cloud</product>
            <product_dir>/Module-Public-Cloud</product_dir>
          </listentry>
          <listentry>
            <media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url>
            <product>sle-module-python2</product>
            <product_dir>/Module-Python2</product_dir>
          </listentry>
          <listentry>
            <media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url>
            <product>sle-module-sap-applications</product>
            <product_dir>/Module-SAP-Applications</product_dir>
          </listentry>
          <listentry>
            <media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url>
            <product>sle-module-server-applications</product>
            <product_dir>/Module-Server-Applications</product_dir>
          </listentry>
          <listentry>
            <media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url>
            <product>sle-module-transactional-server</product>
            <product_dir>/Module-Transactional-Server</product_dir>
          </listentry>
          <listentry>
            <media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url>
            <product>sle-module-web-scripting</product>
            <product_dir>/Module-Web-Scripting</product_dir>
          </listentry>
          <listentry>
            <media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url>
            <product>HA</product>
            <product_dir>/Product-HA</product_dir>
          </listentry>
          <listentry>
            <media_url>http://XCATNEXTSERVERHOOK:80/install/sle15.1/ppc64le/2</media_url>
            <product>SLES</product>
            <product_dir>/Product-SLES</product_dir>
          </listentry>
        </add_on_products>
    </add-on>
```