### PR TITLE
Add packages missing from default SLES15 SP3 installation

### DIFF
--- a/xCAT-server/share/xcat/install/sles/compute.sle15.pkglist
+++ b/xCAT-server/share/xcat/install/sles/compute.sle15.pkglist
@@ -7,3 +7,6 @@ net-tools-deprecated
 rsyslog
 nfs-client
 wget
+openssh
+zypper
+chrony


### PR DESCRIPTION
Needed for `remoteshell` and `setupntp` postscripts.