### PR TITLE
Fix nicutils.sh for non english locales

### DIFF
--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -1860,7 +1860,7 @@ function is_connection_activate_intime {
     fi
     i=0
     while [ $i -lt "$time_out" ]; do
-        con_state=$($nmcli con show $con_name | grep -i state| awk '{print $2}');
+        con_state=$(LC_ALL=C $nmcli con show $con_name | grep -i state| awk '{print $2}');
         if [ ! -z "$con_state" -a "$con_state" = "activated" ]; then
             break
         fi


### PR DESCRIPTION
Using a non english locale breaks the `is_connection_activate_intime()` function because nmcli outputs the connection state localized.

Example:

```
❯ export LC_ALL=de_DE.UTF-8
❯ nmcli con show  "eth0" | grep -i state
GENERAL.STATE:                          aktiviert
❯ LC_ALL=C nmcli con show  "BKA-Berlin" | grep -i state
GENERAL.STATE:                          activated
```

This is just a fix for this specific problem, but I think this should be fixed on a global level with something like:
```
export LC_ALL=C
```
in every xCAT bash script to prevent something like this in the future.
What do you think?