### PR TITLE
Remove failing makedns tests from ubuntu_ppcle_daily.bundle

### DIFF
--- a/xCAT-test/autotest/bundle/ubuntu_ppcle_daily.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu_ppcle_daily.bundle
@@ -65,8 +65,6 @@ makedhcp_d
 makedhcp_n
 makedhcp_remote_network
 makedns_d_node
-makedns_n_noderange
-makedns_ubuntu_n
 makehost_n_r
 makehosts_h
 makehosts_help


### PR DESCRIPTION
This PR disables the failing testcases described in #7121. When issue #7121, these tests will be re-added to the bundle.