### PR TITLE
Detect SLES15 when running detect_dhcpd xcatprobe

### DIFF
--- a/xCAT-probe/subcmds/detect_dhcpd
+++ b/xCAT-probe/subcmds/detect_dhcpd
@@ -96,11 +96,13 @@ if (!$IP || !$MAC) {
 }
 
 # check the distro
-$msg = "The operating system on current server is supported";
+$msg = "The operating system on current server is not supported";
 my $os;
 if (-f "/etc/redhat-release") {
     $os = "rh";
 } elsif (-f "/etc/SuSE-release") {
+    $os = "sles";
+} elsif (-f "/etc/SUSE-brand") {
     $os = "sles";
 } elsif (-f "/etc/lsb-release") {
     $os = "ubuntu";
@@ -108,7 +110,7 @@ if (-f "/etc/redhat-release") {
 #    $os = "debian";
 } else {
     probe_utils->send_msg("$output", "f", $msg);
-    probe_utils->send_msg("$output", "d", "Only support the RedHat, SLES and Ubuntu.");
+    probe_utils->send_msg("$output", "d", "Only supported on RedHat, SLES and Ubuntu.");
     exit 1;
 }
 probe_utils->send_msg("$output", "d", "Current operating system is $os") if ($::VERBOSE);


### PR DESCRIPTION
On SLES15 file `/etc/SuSE-release` is no longer there.
When running there, get:
```
c910f04x35v02:/opt/xcat # xcatprobe  detect_dhcpd -i eth0 -m 42:b0:0a:04:23:04
The operating system on current server is supported                                                              [FAIL]
Only support the RedHat, SLES and Ubuntu.
c910f04x35v02:/opt/xcat #
```

This PR adds a check for `/etc/SUSE-brand`:
```
c910f04x35v02:/opt/xcat # xcatprobe  detect_dhcpd -i eth0 -m 42:b0:0a:04:23:04
Start to detect DHCP, please wait 10 seconds                                                                     [INFO]
++++++++++++++++++++++++++++++++++                                                                               [INFO]
There are 2 servers replied to dhcp discover.                                                                    [INFO]
    Server:10.4.35.2 assign IP [10.4.35.4]. The next server is [10.4.35.2]!                                      [INFO]
    Server:10.4.35.3 assign IP [10.4.35.4]. The next server is [10.4.35.2]!                                      [INFO]
++++++++++++++++++++++++++++++++++                                                                               [INFO]
c910f04x35v02:/opt/xcat #
```