### PR TITLE
Turn off DNSSEC on Service Node for bind 9.16.6

### DIFF
--- a/xCAT-server/sbin/makenamed.conf
+++ b/xCAT-server/sbin/makenamed.conf
@@ -62,6 +62,11 @@ for i in $(grep "^nameserver" /etc/resolv.conf | awk '{print $2}')
 do
 	echo "		$i;"
 done >>$FILE
-echo "	};
-};" >>$FILE
+echo "	};" >>$FILE
+BIND_VERSION=$(/usr/sbin/named -v | cut -d" " -f2)
+if [[ $BIND_VERSION > "9.16.5" ]]; then
+        echo "	dnssec-enable no;
+	dnssec-validation no;" >>$FILE
+fi
+echo "};" >>$FILE
 


### PR DESCRIPTION
DNSSEC is enabled by default with bind 9.16.6.
This prevents compute nodes from resolving management node's host name when running in a hierarchical environment.
This PR disables DNSSEC in /etc/named.conf file on service node.