### PR TITLE
Return correct return code from enablekdump postscript

### DIFF
--- a/xCAT/postscripts/enablekdump
+++ b/xCAT/postscripts/enablekdump
@@ -85,6 +85,7 @@ if [ ! -z "$DUMP" ]; then
     KDPATH=${KDPATH/\/\//}
     KDIP=`echo $KDPATH | cut -d'/' -f1`
     KDPATH=${KDPATH/$KDIP/}
+    retval=0
 
     # if "dump=<proto>:///<directory>", use $xcatmaster as the default NFS server
     if [ -z $KDIP ]; then
@@ -182,6 +183,7 @@ EOF
                 /bin/rm -rf "/var/tmp/tempinit"
                 #service kdump restart
                 restartservice kdump
+                retval=$?
             else
                 /bin/mount -o nolock $KDIP:$KDPATH $MOUNTPATH
 	        KDTEMPPATH=${KDPATH//\//\\\/}
@@ -264,6 +266,7 @@ EOF
                fi
                [ -f /etc/dracut.conf ] && mv /etc/dracut.conf  /tmp/dracut.conf
                restartservice kdump
+               retval=$?
                [ -f /tmp/dracut.conf ] && mv /tmp/dracut.conf /etc/dracut.conf
 	    elif (pmatch $OSVER "fedora*") || (pmatch $OSVER "rhel6*") || (pmatch $OSVER "rhels6*") || [ -f /etc/fedora-release ] || [ -f /etc/redhat-release ];then
                 /bin/mount -o nolock $KDIP:$KDPATH $MOUNTPATH
@@ -271,6 +274,7 @@ EOF
                 echo "link_delay 180" >> /etc/kdump.conf
 		#/etc/init.d/kdump restart
 		restartservice kdump
+		retval=$?
 	    fi
 	fi
     fi
@@ -280,4 +284,4 @@ else
     /bin/echo "The kdump server is not configured"
 fi
 
-exit 0
+exit $retval

--- a/xCAT/postscripts/xcatlib.sh
+++ b/xCAT/postscripts/xcatlib.sh
@@ -512,11 +512,15 @@ function restartservice {
    fi
 
    #for the linux distributions with systemd support
-   #In the chrooted env, the system management commands(start/stop/restart) will be ignored and the return code is 0
-   #need to return the proper code in the chrooted scenario
    local retmsg
    retmsg=`$cmd 2>&1`
    retval=$?
+   
+   #If non 0 return code, display failure message
+   [ "$retval" = "1" ] && echo "$retmsg"
+
+   #In the chrooted env, the system management commands(start/stop/restart) will be ignored and the return code is 0
+   #need to return the proper code in the chrooted scenario
    [ "$retval" = "0" ] && (echo "$retmsg" | grep -i "Running in chroot,\s*ignoring request.*" >/dev/null 2>&1) && retval=1
 
    return $retval


### PR DESCRIPTION
Currently `enablekdump` postscript does not capture and return the return code after calling `restartservice()`. As a result if restarting `kdump` service fails, `enablekdump` postscript still returns `rc=0`
```
Thu Mar 17 16:00:00 EDT 2022 [info]: xcat.deployment.postbootscript: postbootscript start..: enablekdump
Thu Mar 17 16:00:00 EDT 2022 [info]: xcat.deployment.postbootscript: postbootscript end...:enablekdump return with 0
```

After this PR:

```
Thu Mar 17 16:08:16 EDT 2022 [info]: xcat.deployment.postbootscript: postbootscript start..: enablekdump
Job for kdump.service failed because the control process exited with error code.
See "systemctl status kdump.service" and "journalctl -xe" for details.
Thu Mar 17 16:08:25 EDT 2022 [info]: xcat.deployment.postbootscript: postbootscript end...:enablekdump return with 1
```