### PR TITLE
Turn off DNSSEC on Management Node for bind 9.16.6

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ddns.pm
+++ b/xCAT-server/lib/xcat/plugins/ddns.pm
@@ -1282,6 +1282,13 @@ sub update_namedconf {
                 push @newnamed, "\t\t$_;\n";
             }
             push @newnamed, "\t};\n";
+            my $bind_version_cmd="/usr/sbin/named -v | cut -d' ' -f2";
+            my @bind_version =xCAT::Utils->runcmd($bind_version_cmd, 0);
+            # Turn off DNSSEC if running with bind vers 9.16.6 or higher
+            if ((scalar @bind_version > 0) && ($bind_version[0] ge "9.16.6")) {
+                push @newnamed, "\tdnssec-enable no;\n";
+                push @newnamed, "\tdnssec-validation no;\n";
+            }
         }
 
         if ($ctx->{forwardmode}){


### PR DESCRIPTION
Similar to #7126, but in Perl for Management node.
In a non-hierarchical environment, compute node can not resolve external name, if MN is running `bind` version `9.16.6` or higher:
```
c910f04x35v04:~ # ping xcat.org
ping: xcat.org: Temporary failure in name resolution
c910f04x35v04:~ #
```

This PR will turn off DNSSEC in `/etc/named.conf`, when `makedns -n` command is ran.