### PR TITLE
kdump on Power RHEL 8.5

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/common/deployment/enable_kdump.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/common/deployment/enable_kdump.rst
@@ -86,7 +86,7 @@ If the NFS server is the Service Node or Management Node, the server can be left
 The ``crashkernelsize`` attribute
 ---------------------------------
 
-To allow the Operating System to automatically reserve the appropriate amount of memory for the ``kdump`` kernel, set ``crashkernelsize=auto``.
+To allow the Operating System to automatically reserve the appropriate amount of memory for the ``kdump`` kernel, set ``crashkernelsize=auto``. For RHELS 8.5 on System P machines, do not use ``auto``, instead set specific size (see below).
 
 For setting specific sizes, use the following example:
 
@@ -101,6 +101,10 @@ For setting specific sizes, use the following example:
 * For System P machines, set the ``crashkernelsize`` using this format: ::
 
     chdef -t osimage <image name> crashkernelsize=<size>@32M
+
+* For System P machines running RHELS 8.5 , set the ``crashkernelsize`` using this format: ::
+
+    chdef -t osimage <image name> crashkernelsize=<size>@64M
 
 .. note:: The value of the ``crashkernelsize`` depends on the total physical memory size on the machine. For more about size, refer to `Appedix`_
 

--- a/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
+++ b/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
@@ -41,7 +41,7 @@ cmd:cd /etc; export exports;cd -;service nfs-server restart
 cmd:chdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute dump=nfs://$$MN/opt/xcat/share/xcat/tools/autotest/kdumpdir
 check:rc==0
 
-cmd:chdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute crashkernelsize=auto
+cmd:if [[ "__GETNODEATTR($$CN,arch)__" = "ppc64le" ]] && [[ "__GETNODEATTR($$CN,os)__" =~ "rhels8.5" ]]; then chdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute crashkernelsize=512M@64M; else chdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute crashkernelsize=auto; fi
 check:rc==0
 
 cmd:chdef -t node $$CN -p postscripts=enablekdump


### PR DESCRIPTION
For RHEL 8.5 on Power `crashkernelsize=auto`, does not work. Need to set `crashkernelsize=<size>@64M`