### PR TITLE
Allow SLES15 node on Power to reboot in standby mode

### DIFF
--- a/xCAT-server/lib/xcat/plugins/grub2.pm
+++ b/xCAT-server/lib/xcat/plugins/grub2.pm
@@ -289,7 +289,7 @@ sub setstate {
         my $os_version = $nodeos;
         $os_version =~ s/sles//i; # Strip sles if there
         $os_version =~ s/sle//i; # String sle if there
-        if ($os_version ge "15") {
+        if ($os_version >= "15") {
             # Make sure for SLES15 or higher can still boot 
             # from disk in "standby" state
             unlink("grub2-$node");

--- a/xCAT-server/lib/xcat/plugins/grub2.pm
+++ b/xCAT-server/lib/xcat/plugins/grub2.pm
@@ -100,7 +100,8 @@ sub setstate {
     my $tftpdir      = shift;
     my %nrhash       = %{ shift() };
     my $linuximghash = shift();
-    my $nodearch = shift;
+    my $nodearch     = shift;
+    my $nodeos       = shift;
     my $kern = $bphash{$node}->[0]; #$bptab->getNodeAttribs($node,['kernel','initrd','kcmdline']);
     if ($kern->{kcmdline} =~ /!myipfn!/) {
         my $ipfn;
@@ -284,6 +285,8 @@ sub setstate {
     chdir("$bootloader_root");
     if ($cref->{currstate} eq "offline" or $cref->{currstate} eq "boot") {
         unlink("grub2-$node");
+    } elsif ($cref->{currstate} eq "standby" and $nodeos =~ /^sle15/i) {
+        unlink("grub2-$node"); #Make sure SLES15 can still boot from disk in "standby" state
     } elsif (! -e "grub2-$node") {
         symlink("grub2." . $nodearch, "grub2-$node");
     }
@@ -751,13 +754,14 @@ sub process_request {
         if ($args[0]) { # Send it on to the destiny plugin, then setstate
             my $ent          = $typehash->{$_}->[0];
             my $nodearch     = $ent->{'arch'};
+            my $nodeos       = $ent->{'os'};
             my $osimgname    = $ent->{'provmethod'};
             my $linuximghash = undef;
             unless ($osimgname =~ /^(install|netboot|statelite)$/) {
                 $linuximghash = $linuximgtab->getAttribs({ imagename => $osimgname }, 'boottarget', 'addkcmdline');
             }
 
-            ($rc, $errstr) = setstate($_, \%bphash, $chainhash, $machash, $tftpdir, $nrhash, $linuximghash, $nodearch);
+            ($rc, $errstr) = setstate($_, \%bphash, $chainhash, $machash, $tftpdir, $nrhash, $linuximghash, $nodearch, $nodeos);
             if ($rc) {
                 $response{node}->[0]->{errorcode}->[0] = $rc;
                 $response{node}->[0]->{error}->[0]    = $errstr;

--- a/xCAT-server/lib/xcat/plugins/grub2.pm
+++ b/xCAT-server/lib/xcat/plugins/grub2.pm
@@ -285,8 +285,15 @@ sub setstate {
     chdir("$bootloader_root");
     if ($cref->{currstate} eq "offline" or $cref->{currstate} eq "boot") {
         unlink("grub2-$node");
-    } elsif ($cref->{currstate} eq "standby" and $nodeos =~ /^sle15/i) {
-        unlink("grub2-$node"); #Make sure SLES15 can still boot from disk in "standby" state
+    } elsif ($cref->{currstate} eq "standby" and $nodeos =~ /^sle/i) {
+        my $os_version = $nodeos;
+        $os_version =~ s/sles//i; # Strip sles if there
+        $os_version =~ s/sle//i; # String sle if there
+        if ($os_version ge "15") {
+            # Make sure for SLES15 or higher can still boot 
+            # from disk in "standby" state
+            unlink("grub2-$node");
+        }
     } elsif (! -e "grub2-$node") {
         symlink("grub2." . $nodearch, "grub2-$node");
     }

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_flat
@@ -71,12 +71,15 @@ cmd:lsdef -l $$CN
 cmd:ping $$CN -c 3
 check:rc==0
 check:output=~64 bytes from $$CN
-# Check node ends up in boot state
-cmd:lsdef $$CN -i currstate -c
-check:output==boot
 cmd:xdsh $$CN  "cat /var/log/xcat/xcat.log"
 cmd:xdsh $$CN "cat /test.synclist"
 check:rc==0
+# Check node can be rebooted from disk
+cmd:xdsh $$CN shutdown -r now
+cmd:sleep 300
+cmd:xdsh $$CN uptime
+check:rc==0
+check:output=~up
 cmd:if [ -x /usr/bin/goconserver ]; then makegocons -d $$CN; else makeconservercf -d $$CN; fi
 cmd:if [[ -f /test.synclist.bak ]] ;then mv -f /test.synclist.bak /tmp/test.synclist;else rm -rf /test.synclist;fi
 cmd:chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute synclists=

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_hierarchy
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_hierarchy
@@ -107,7 +107,10 @@ check:rc==0
 cmd:sitetz=`lsdef -t site -i timezone | awk -F= '{print $2}'`;nodetz=`xdsh $$CN "timedatectl | grep 'Time zone'" | awk -F: '{print $3}' | awk '{print $1}'`; test $sitetz = $nodetz
 check:rc==0
 
-# Check node ends up in boot state
-cmd:lsdef $$CN -i currstate -c
-check:output==boot
+# Check node can be rebooted from disk
+cmd:xdsh $$CN shutdown -r now
+cmd:sleep 300
+cmd:xdsh $$CN uptime
+check:rc==0
+check:output=~up
 end


### PR DESCRIPTION
Because of two phase installation process on SLES15, the diskfull node winds up with `currstate=standby` after the initial install. On x86, `xCAT-server/lib/xcat/plugins/xnba.pm` removes `/tftpboot/xcat/xnba/nodes/<node>.pxelinux` which allows node to reboot from local disk. On Power `xCAT-server/lib/xcat/plugins/grub2.pm` does not remove `/tftpboot/boot/grub2/grub2-<node>`, which prevents node from rebooting from local disk.

This PR makes behavior on Power to be the same as on x86, by removing `/tftpboot/boot/grub2/grub2-<node>` when `currstate=standby`.
This RP also removes the testcase changes added by #7104 and instead modifies testcases to verify that diskfull node can be rebooted after initial installation.