### PR TITLE
Add support for ed25519 host keys

### DIFF
--- a/xCAT-server/lib/xcat/plugins/credentials.pm
+++ b/xCAT-server/lib/xcat/plugins/credentials.pm
@@ -216,6 +216,17 @@ sub process_request
                 xCAT::MsgUtils->trace(0, 'E', "credentials: Unable to read private ECDSA key");
                 next;
             }
+        } elsif ($parm =~ /ssh_ed25519_hostkey/) {
+            xCAT::MsgUtils->trace(0, 'I', "credentials: sending $parm to $client");
+            if (-r "/etc/xcat/hostkeys/$client/ssh_host_ed25519_key") {
+                $tfilename = "/etc/xcat/hostkeys/$client/ssh_host_ed25519_key";
+            } elsif (-r "/etc/xcat/hostkeys/ssh_host_ed25519_key") {
+                $tfilename = "/etc/xcat/hostkeys/ssh_host_ed25519_key";
+            } else {
+                push @{ $rsp->{'error'} }, "Unable to read private ed25519 key from /etc/xcat/hostkeys";
+                xCAT::MsgUtils->trace(0, 'E', "credentials: Unable to read private ed25519 key");
+                next;
+            }
         } elsif ($parm =~ /xcat_cfgloc/) {
             xCAT::MsgUtils->trace(0, 'I', "credentials: sending $parm to $client");
             unless (-r "/etc/xcat/cfgloc") {

--- a/xCAT-server/sbin/xcatconfig
+++ b/xCAT-server/sbin/xcatconfig
@@ -1011,6 +1011,21 @@ sub genSSHNodeHostKey
 	else{
             push @sshkeylist,"/etc/xcat/hostkeys/ssh_host_ecdsa_key";
 	}
+
+    # see if this system supports the ed25519
+    xCAT::Utils->runcmd('rm -rf /tmp/ed25519_key >/dev/null 2>&1 ; /usr/bin/ssh-keygen -t ed25519 -f /tmp/ed25519_key  -P "" &>/dev/null', 0);
+    if ($::RUNCMD_RC == 0) {
+        xCAT::MsgUtils->message('I', "Generating SSH2 ed25519 Key...");
+        $cmd =
+"/usr/bin/ssh-keygen -t ed25519 -f /etc/xcat/hostkeys/ssh_host_ed25519_key -C '' -N ''";
+        $outref = xCAT::Utils->runcmd("$cmd", 0);
+        if ($::RUNCMD_RC != 0)
+        {
+            xCAT::MsgUtils->message('E', "Could not generate SSH2 ed25519 key.");
+        }
+	else{
+            push @sshkeylist,"/etc/xcat/hostkeys/ssh_host_ed25519_key";
+	}
     }
 
     if(@sshkeylist){

--- a/xCAT/postscripts/aixremoteshell
+++ b/xCAT/postscripts/aixremoteshell
@@ -226,6 +226,27 @@ sub setupSSH
             `logger -t xcat  -p local4.err $msg`;
         }
     }
+
+    # is there is a ed25519 host key on the node, then get the one from the MN/SN
+    my $filename = "/etc/ssh/ssh_host_ed25519_key";
+    if (-e $filename) {
+        my $response = &getresponse("ssh_ed25519_hostkey");
+        if (defined($response)) {
+            my $fd;
+            &runcmd("mkdir -p /etc/ssh");
+            open($fd, '>', $filename);
+            print $fd $response;
+            close($fd);
+
+            # set the permissions
+            my $cmd = "chmod 600 $filename > /dev/null 2>&1";
+            &runcmd($cmd);
+        }
+        else {
+            $msg = "aixremoteshell: Could not get ssh_host_ed25519_key file.\n";
+            `logger -t xcat  -p local4.err $msg`;
+        }
+    }
     if ($nodetype eq "service") {
         &runcmd("mkdir -p /etc/xcat/hostkeys; cp /etc/ssh/ssh* /etc/xcat/hostkeys/. > /dev/null 2>&1");
     }

--- a/xCAT/postscripts/remoteshell
+++ b/xCAT/postscripts/remoteshell
@@ -313,6 +313,86 @@ if ssh-keygen -t ecdsa -f /tmp/ecdsa_key -P "" &>/dev/null ; then
   rm /tmp/ssh_ecdsa_hostkey
 fi
 
+# if node supports ed25519 host key then download the replacement from the MN/SN
+# remove the /tmp/ed25519_key first, otherwise the "ssh-keygen" below might hang
+# at waiting for user confirmation to overwritten the existing file
+rm -rf /tmp/ed25519_key >/dev/null 2>&1
+if ssh-keygen -t ed25519 -f /tmp/ed25519_key -P "" &>/dev/null ; then
+  # download the host ed25519 key
+  if [ $useflowcontrol = "1" ]; then
+    #first contact daemon  xcatflowrequest <server> 3001
+    logger -t $log_label -p local4.info "remoteshell: sending xcatflowrequest $master 3001"
+    /$xcatpost/xcatflowrequest $master 3001
+    rc=$?
+    logger -t $log_label -p local4.info "remoteshell:xcatflowrequest return=$rc"
+    if [ $rc -ne 0 ]; then
+      logger -t $log_label -p local4.info "remoteshell: error from xcatflowrequest, will not use flow control"
+      useflowcontrol=0
+    fi
+  fi
+
+  getcredentials.awk ssh_ed25519_hostkey | grep -E -v '</{0,1}xcatresponse>|</{0,1}serverdone>' | sed -e 's/&lt;/</' -e 's/&gt;/>/' -e 's/&amp;/&/' -e 's/&quot/"/' -e "s/&apos;/'/" > /tmp/ssh_ed25519_hostkey
+
+  #check whether the message is an error or not
+  grep -E '<error>' /tmp/ssh_ed25519_hostkey > /dev/null 2>&1
+  if [ $? -ne 0 ]; then
+	#the message received is the data we request
+	cat /tmp/ssh_ed25519_hostkey | grep -E -v '</{0,1}errorcode>|/{0,1}data>|</{0,1}content>|</{0,1}desc>' >/etc/ssh/ssh_host_ed25519_key
+	logger -t $log_label -p local4.info ssh_ed25519_hostkey
+	MYCONT=`cat /etc/ssh/ssh_host_ed25519_key`
+   MAX_RETRIES=10
+   RETRY=0
+	while [ -z "$MYCONT" ]; do
+              # not using flow control , need to sleep
+              if [ $useflowcontrol = "0" ]; then
+                let SLI=$RANDOM%10
+                let SLI=SLI+10
+                sleep $SLI
+              fi
+                RETRY=$(($RETRY+1))
+                if [ $RETRY -eq $MAX_RETRIES ]
+                then
+                  break
+                fi
+                if [ $useflowcontrol = "1" ]; then
+                  #first contact daemon  xcatflowrequest <server> 3001
+                  logger -t $log_label -p local4.info "remoteshell: sending xcatflowrequest $master 3001"
+                  /$xcatpost/xcatflowrequest $master 3001
+                  rc=$?
+                  logger -t $log_label -p local4.info "remoteshell:xcatflowrequest return=$rc"
+                  if [ $rc -ne 0 ]; then
+                      logger -t $log_label -p local4.info "remoteshell: error from xcatflowrequest, will not use flow control"
+                      useflowcontrol=0
+                  fi
+                fi
+
+    		getcredentials.awk ssh_ed25519_hostkey | grep -v '<'|sed -e 's/&lt;/</' -e 's/&gt;/>/' -e 's/&amp;/&/' -e 's/&quot/"/' -e "s/&apos;/'/" > /etc/ssh/ssh_host_ed25519_key
+    		MYCONT=`cat /etc/ssh/ssh_host_ed25519_key`
+	done
+	egrep  -i "^ssh_keys:" /etc/group >/dev/null 2>&1 && chown root:ssh_keys /etc/ssh/ssh_host_ed25519_key 2>/dev/null && chmod 640 /etc/ssh/ssh_host_ed25519_key
+	if ! grep "PRIVATE KEY" /etc/ssh/ssh_host_ed25519_key > /dev/null 2>&1 ; then
+   		rm /etc/ssh/ssh_host_ed25519_key
+	else
+		# Because of openssh version differs, provisioning errors may happen when MN support ed25519 while CN don't ed25519.
+		# Judge CN support ed25519 or not. "-t ed25519" indicate the key type, "-P "" " avoid hang-on and wait for input passphrase when CN don't support ed25519.
+		# If ture, means support ed25519, then generate corresponding key.pub.
+		# If false, remove ssh_host_ed25519_key useless file, to avoid future errors.
+		if ssh-keygen -t ed25519 -y -f /etc/ssh/ssh_host_ed25519_key -P "" &>/dev/null ; then
+			ssh-keygen -y -f /etc/ssh/ssh_host_ed25519_key -P "" > /etc/ssh/ssh_host_ed25519_key.pub
+			chmod 644 /etc/ssh/ssh_host_ed25519_key.pub
+			chown root /etc/ssh/ssh_host_ed25519_key.pub
+		else
+			rm -fr /etc/ssh/ssh_host_ed25519_key
+		fi
+	fi
+  else
+	#This is an error message
+	ERR_MSG=`sed -n 's%.*<error>\(.*\)</error>.*%\1%p' /tmp/ssh_ed25519_hostkey`
+	logger -s -t $log_label -p local4.err Error: $ERR_MSG
+  fi
+  rm /tmp/ssh_ed25519_hostkey
+fi
+
 if [[ $NTYPE = service ]]; then
    mkdir -p /etc/xcat/hostkeys
    cp /etc/ssh/ssh* /etc/xcat/hostkeys/.


### PR DESCRIPTION
### The PR is to add support for ed25519 host keys.

This updates `plugins/credentials.pm`, `xcatconfig`, and the `remoteshell` and `aixremoteshell` postscripts to support ed25519 host key types.

Currently these keys are created as part of EL8 installs, but ignored by xcat.  If a user caches this host key type in their .known_hosts file, and a stateless node reboots, EL8 will regenerate keys and the user will get a scary warning!

With these updates xcat should generate and use these hostkeys alongside the others.

The logic in the postscripts was duplicated from the support for ECDSA key types.
