### PR TITLE
rh/genimage:  update systemd list to include Rocky Linux

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -1965,6 +1965,10 @@ sub using_systemd {
         if ($1 >= 7) {
             return 1;
         }
+    } elsif ($os =~ /rocky(\d+)/) {
+        if ($1 >= 8) {
+            return 1;
+        }
     } elsif ($os =~ /ol(\d+)/) {
         if ($1 >= 7) {
             return 1;


### PR DESCRIPTION
### The PR is to fix genimage systemd detection for Rocky Linux.

### The modification include

_rh/genimage_: added an elsif clause to account for Rocky Linux.