### PR TITLE
Operator corrections and test case improvement

### DIFF
--- a/xCAT-test/autotest/testcase/addkitcomp/case0
+++ b/xCAT-test/autotest/testcase/addkitcomp/case0
@@ -152,7 +152,7 @@ check:rc==0
 check:output=~Assigning kit component ubuntukit-compute-2
 cmd:lsdef -t osimage -o testimage
 check:rc==0
-check:output!=~postbootscripts
+check:output!~postbootscripts
 cmd:rmkitcomp -i testimage -f ubuntukit-compute-1-1.0-1-ubuntu-14.04-ppc64el
 check:rc==0
 check:output=~Removing kitcomponent ubuntukit-compute-1-1.0-1-ubuntu-14.04-ppc64el from osimage testimage

--- a/xCAT-test/autotest/testcase/copycds/cases0
+++ b/xCAT-test/autotest/testcase/copycds/cases0
@@ -170,7 +170,7 @@ cmd:rm -rf /install/__GETNODEATTR($$CN,os)__
 check:rc==0
 cmd:copycds -w $$ISO
 check:rc==0
-check:output=~~Copying media to /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__
+check:output=~Copying media to /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__
 end
 
 
@@ -191,7 +191,7 @@ cmd:rm -rf /install/__GETNODEATTR($$CN,os)__
 check:rc==0
 cmd:copycds --nonoverwrite $$ISO
 check:rc==0
-check:output=~~Copying media to /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__
+check:output=~Copying media to /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__
 end
 
 

--- a/xCAT-test/autotest/testcase/mkdef/cases0
+++ b/xCAT-test/autotest/testcase/mkdef/cases0
@@ -70,10 +70,10 @@ check:output!~testnode2
 check:output!~testnode4
 cmd:lsdef testnode1
 check:rc==0
-check:output=~=all,systemp,testgrp
+check:output=~all,systemp,testgrp
 cmd:lsdef testnode3
 check:rc==0
-check:output=~=all,systemx,testgrp
+check:output=~all,systemx,testgrp
 cmd:rmdef -t group testgrp
 check:rc==0
 cmd:lsdef testgrp
@@ -82,12 +82,12 @@ cmd:lsdef -t group -o testgrp
 check:output=~Could not find an object named 'testgrp'
 cmd:lsdef testnode1
 check:rc==0
-check:output=~=all,systemp
-check:output!~=testgrp
+check:output=~all,systemp
+check:output!~testgrp
 cmd:lsdef testnode3
 check:rc==0
-check:output=~=all,systemx
-check:output!~=testgrp
+check:output=~all,systemx
+check:output!~testgrp
 cmd:rmdef -t node -o testnode1-testnode4
 check:rc==0
 end

--- a/xCAT-test/autotest/testcase/nodeset/cases2
+++ b/xCAT-test/autotest/testcase/nodeset/cases2
@@ -13,21 +13,20 @@ cmd:pre=`lsdef -l $$CN |grep prescripts-begin|awk -F= '{print $2}'`;echo $pre >>
 check:rc==0
 cmd:nodeset $$CN install 
 check:output=~Running begin script test_prescripts_all.sh for nodes $$CN 
-check:output!=~test_prescripts_boot.sh
-check:output!=~test_prescripts_osimage.sh
+check:output!~test_prescripts_boot.sh
+check:output!~test_prescripts_osimage.sh
 cmd:nodeset $$CN boot
 check:rc==0
 check:output=~Running begin script test_prescripts_all.sh for nodes $$CN
 check:output=~Running begin script test_prescripts_boot.sh for nodes $$CN
-check:output!=~test_prescripts_osimage.sh
+check:output!~test_prescripts_osimage.sh
 cmd:nodeset $$CN osimage 
 check:rc==0
 check:output=~Running begin script test_prescripts_all.sh for nodes $$CN
 check:output=~Running begin script test_prescripts_osimage.sh for nodes $$CN
-check:output!=~test_prescripts_boot.sh
+check:output!~test_prescripts_boot.sh
 cmd:rm -rf /install/prescripts/test_prescripts_all.sh /install/prescripts/test_prescripts_boot.sh /install/prescripts/test_prescripts_osimage.sh
 cmd:pre=`cat /tmp/prescriptssave`;chdef $$CN prescripts-begin=$pre 
 check:rc==0
 cmd:rm -rf /tmp/prescriptssave
 end
-

--- a/xCAT-test/autotest/testcase/rbeacon/cases0
+++ b/xCAT-test/autotest/testcase/rbeacon/cases0
@@ -44,7 +44,7 @@ check:output=~Version
 check:output =~git commit
 cmd:rbeacon --version
 check:rc==0
-check:output=~~Version
+check:output=~Version
 check:output =~git commit
 end
 

--- a/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
+++ b/xCAT-test/autotest/testcase/rflash/rflash_openbmc.0
@@ -521,7 +521,7 @@ check:rc != 0
 check:output =~$$CN\s*:\s*(\[.*?\]: )?Error: Deleting currently active firmware on powered on host is not supported
 cmd:activenum=`rflash $$CN -l |grep -w "BMC\s*Active(\*)" |awk '{print $2}'`;rflash $$CN $activenum --delete
 check:rc != 0
-check:output =~~$$CN\s*:\s*(\[.*?\]: )?Error: Deleting currently active BMC firmware is not supported
+check:output =~$$CN\s*:\s*(\[.*?\]: )?Error: Deleting currently active BMC firmware is not supported
 end
 
 start:rflash_d_relative_path

--- a/xCAT-test/autotest/testcase/updatenode/cases0
+++ b/xCAT-test/autotest/testcase/updatenode/cases0
@@ -618,7 +618,7 @@ cmd:xdsh $$C2 ls /tmp/file.post2
 check:rc!=0
 cmd:xdsh $$C2 "cat /tmp/test2"
 check:rc!=0
-check:output!=~hello2
+check:output!~hello2
 cmd:chdef -t osimage -o  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute synclists=
 check:rc==0
 cmd:rm -rf /install/custom/install/__GETNODEATTR($$CN,os)__/compute.$$OS.synclist

--- a/xCAT-test/autotest/testcase/xcat_inventory/cases.diff
+++ b/xCAT-test/autotest/testcase/xcat_inventory/cases.diff
@@ -67,8 +67,8 @@ cmd:xcat-inventory diff --files /opt/xcat/share/xcat/tools/autotest/testcase/xca
 check:rc==0
 cmd:sh /opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/templates/diff/change_name.sh /opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/templates/diff/xcat-inventory_diff_file1.json /opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/templates/diff/xcat-inventory_diff_file2.json /tmp/tmp_diff.result
 check:rc==0
-cmd:diff /tmp/xcat_inventory_diff_files.result /tmp/tmp_diff.result
-check:output=
+cmd:diff -s /tmp/xcat_inventory_diff_files.result /tmp/tmp_diff.result
+check:output=~are identical
 check:rc==0
 end
 
@@ -79,8 +79,8 @@ cmd:xcat-inventory diff --files /opt/xcat/share/xcat/tools/autotest/testcase/xca
 check:rc==0
 cmd:sh /opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/templates/diff/change_name.sh xcat_inventory_diff_files_filename.test xcat_inventory_diff_files_filename.test /tmp/tmp_diff.result
 check:rc==0
-cmd:diff /tmp/xcat_inventory_diff_files_filename.result /tmp/tmp_diff.result
-check:output=
+cmd:diff -s /tmp/xcat_inventory_diff_files_filename.result /tmp/tmp_diff.result
+check:output=~are identical
 check:rc==0
 end
 
@@ -94,8 +94,8 @@ cmd:xcat-inventory import -f /opt/xcat/share/xcat/tools/autotest/testcase/xcat_i
 check:rc==0
 cmd:xcat-inventory diff --source /opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/templates/diff/xcat-inventory_diff_file2.json > /tmp/xcat_inventory_diff_source.result
 check:rc==0
-cmd:diff /tmp/xcat_inventory_diff_source.result /opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/templates/diff/diff_source.result
-check:output=
+cmd:diff -s /tmp/xcat_inventory_diff_source.result /opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/templates/diff/diff_source.result
+check:output=~are identical
 check:rc==0
 cmd:xcat-inventory import -c -f /tmp/xcat-inventory_diff_case.json
 check:rc==0

--- a/xCAT-test/autotest/testcase/xcatd/case0
+++ b/xCAT-test/autotest/testcase/xcatd/case0
@@ -171,11 +171,11 @@ check:output=~xcatd service|xcatd.service
 check:output=~xcatd service is running|active \(running\)
 cmd:XCATBYPASS=YES lsxcatd -a
 check:rc==0
-check:output!=~Error|ERROR
+check:output!~Error|ERROR
 cmd:XCATBYPASS=YES service xcatd status
 check:rc==0
-check:output!=~Error|ERROR
+check:output!~Error|ERROR
 cmd:XCATBYPASS=YES service xcatd restart
 check:rc==0
-check:output!=~Error|ERROR 
+check:output!~Error|ERROR 
 end

--- a/xCAT-test/autotest/testcase/xcatstanzafile/cases0
+++ b/xCAT-test/autotest/testcase/xcatstanzafile/cases0
@@ -75,7 +75,7 @@ testnode:
 check:rc==0
 cmd:cat testfile|chdef -z
 cmd:lsdef testnode
-check:output!~=MS02.ppd.pok.com
+check:output!~MS02.ppd.pok.com
 cmd:rmdef -t node testnode
 cmd:rm -f testfile
 end

--- a/xCAT-test/autotest/testcase/xdsh/cases0
+++ b/xCAT-test/autotest/testcase/xdsh/cases0
@@ -20,9 +20,12 @@ end
 
 start:xdsh_Q_command
 label:cn_os_ready,parallel_cmds
-cmd:xdsh $$CN -Q "ps -ef"
+cmd:xdsh $$CN -Q "ps -ef" > /tmp/abc
 check:rc==0
-check:output=~
+cmd:if [ -s /tmp/abc ]; then echo "File has content"; else echo "File is empty";fi
+check:output=~empty
+cmd:rm -f /tmp/abc
+check:rc==0
 end
 
 start:xdsh_c_sn
@@ -35,7 +38,7 @@ cmd: echo Y | xdsh $$SN -c 2>/dev/null
 check:rc==0
 cmd:xdsh $$SN "ls -l /var/xcat/syncfiles"
 check:rc==0
-check:output=~
+check:output=~total 0
 end
 
 start:xdsh_c_cn
@@ -48,7 +51,7 @@ cmd: echo Y | xdsh $$CN -c 2>/dev/null
 check:rc==0
 cmd:xdsh $$CN "ls -l /var/xcat/node"
 check:rc==0
-check:output=~
+check:output=~total 0
 end
 
 start:xdsh_e_filename
@@ -75,7 +78,7 @@ cmd:echo 'export DSH_FANOUT=8' > /tmp/xdsh.test
 check:rc==0
 cmd:xdsh $$CN -E /tmp/xdsh.test  "export |grep DSH_FANOUT"
 check:rc==0
-check:output=$$CN: declare -x DSH_FANOUT="8"
+check:output=~$$CN: declare -x DSH_FANOUT="8"
 cmd:rm -r /tmp/xdsh.test
 check:rc==0
 end
@@ -101,9 +104,9 @@ check:rc!=0
 check:output=~Error: (\[.*?\]: )?Caught SIGINT - terminating the child processes.
 cmd:date +%s > /tmp/end.txt
 check:rc==0
-cmd:a=`cat /tmp/start.txt`;b=`cat /tmp/end.txt`;c=$[$b-$a];echo $c
+cmd:a=`cat /tmp/start.txt`;b=`cat /tmp/end.txt`;c=$[$b-$a];if [ $c -lt 7 ]; then echo "diff is less than 7 seconds"; else echo "diff is at least 7 seconds";fi
 check:rc==0
-check:output<7
+check:output=~less than
 cmd:rm -f /tmp/start.txt /tmp/end.txt
 end
 


### PR DESCRIPTION
The PR is another fix for Issue https://github.com/xcat2/xcat-core/issues/7110.

I have unit tested all the test cases changed in PR https://github.com/xcat2/xcat-core/pull/7127 and this one.

Except xdsh_Q_command, xdsh_c_cn and xdsh_t, all others are not currently tested in nightly regression.

The above three test cases run fine after the changes.

For those not in nightly regression fail in various ways.
(1) KITDATA is not defined for the kit test cases. KITS are not supported on RHEL 8 and above.
(2) dsdf is not defined for osdeploy_n_p_invalid, dadf not defined for osdeploy_n_r_invalid.
(3) hcp is not defined for rbeacon_version.
(4) C2 is not defined for updatenode_syncfile_EXECUTE_EXECUTEALWAYS_noderange.