### PR TITLE
Add openbmc Python installation test on SN

### DIFF
--- a/xCAT-test/autotest/testcase/commoncmd/retry_install.sh
+++ b/xCAT-test/autotest/testcase/commoncmd/retry_install.sh
@@ -49,6 +49,10 @@ do
         sleep $check_status
         stat=`lsdef $node -i status -c | cut -d '=' -f 2`
         echo "[$a] The status is not booted... ($stat)" 
+        if [ $stat = "failed" ]; then
+            # Installation failed, no reason to keep checking
+            break
+        fi
         a=++a 
         if [ $a -gt $(($iterations + 0)) ];then
             a=0 

--- a/xCAT-test/autotest/testcase/installation/SN_install_openbmc_py.sh
+++ b/xCAT-test/autotest/testcase/installation/SN_install_openbmc_py.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+if [ -z $1 ]; then
+   echo "ARCH parameter not provided";
+   exit 1;
+fi
+if [ -z $2 ]; then
+   echo "OS parameter not provided";
+   exit 1;
+fi
+ARCH=$1;
+OS=$2;
+PYTHON_DEP_FED_DIR=$3;
+PYTHON_DEP_EPEL_DIR=$4;
+PYTHON_DEP_EXTRAS_DIR=$5;
+echo "Checking if xCAT-openbmc-py installation is needed on $OS $ARCH service node";
+if [[ $ARCH =~ "ppc64" ]] && [[ $OS =~ "rhels7" ]]; then
+    if rpm -qa|grep xCAT-openbmc-py 2>&1; then 
+        echo "Setting up for xCAT-openbmc-py installation on $OS $ARCH service node";
+        osimage="$OS-$ARCH-install-service";
+        otherpkgdir=$(lsdef -t osimage $osimage -i otherpkgdir -c|awk -F"=" '{print $2}'); 
+        otherpkglist=$(lsdef -t osimage $osimage -i otherpkglist -c|awk -F"=" '{print $2}');
+        mkdir -p $otherpkgdir/xcat/Packages; 
+        cp -r $PYTHON_DEP_FED_DIR/Packages/*.rpm $otherpkgdir/xcat/Packages;
+        cp -r $PYTHON_DEP_EPEL_DIR/Packages/* $otherpkgdir/xcat/Packages;
+        cp -r $PYTHON_DEP_EXTRAS_DIR/Packages/* $otherpkgdir/xcat/Packages;
+        cd $otherpkgdir/xcat/Packages && createrepo .;
+        if [ -e /tmp/xCAT-openbmc-py-RH7.noarch.rpm ]; then
+            echo "Replacing installed xCAT-openbmc-py RPM with RH7 version";
+            rm -f $otherpkgdir/xcat/xcat-core/xCAT-openbmc-py-*;
+            cp /tmp/xCAT-openbmc-py-RH7.noarch.rpm $otherpkgdir/xcat/xcat-core/xCAT-openbmc-py-RH7.noarch.rpm;
+            cd $otherpkgdir/xcat/xcat-core && createrepo .;
+        fi
+        echo "xcat/Packages/python2-gevent" >> $otherpkglist;
+        echo "xcat/Packages/python2-greenlet" >> $otherpkglist;
+        echo "xcat/xcat-core/xCAT-openbmc-py" >> $otherpkglist;
+        echo "--Checking otherpkgdir";
+        ls -Rl $otherpkgdir/xcat/Packages;
+        if ! ls -l $otherpkgdir/xcat/Packages|grep python2-gevent- > /dev/null 2>&1; then 
+            echo "There is no python2-gevent package under $otherpkgdir/xcat/Packages";
+            exit 1;
+        fi;
+        if ! ls -l $otherpkgdir/xcat/Packages|grep python2-greenlet- > /dev/null 2>&1; then 
+            echo "There is no python2-greenlet under $otherpkgdir/xcat/Packages";
+            exit 1;
+        fi; 
+        echo "--Checking otherpkglist";
+        cat $otherpkglist;
+        if ! grep python2-gevent  $otherpkglist > /dev/null 2>&1; then 
+            echo "There is no python2-gevent entry in $otherpkglist";
+            exit 1;
+        fi;
+        if ! grep python2-greenlet $otherpkglist  > /dev/null 2>&1; then 
+            echo "There is no python2-greenlet entry in $otherpkglist";
+            exit 1;
+        fi;
+        exit 0;
+    else 
+        echo "There is no xCAT-openbmc-py installed on $ARCH $OS MN, skip installing xCAT-openbmc-py on SN";
+        exit 0;
+    fi
+fi
+if [[ $ARCH =~ "ppc64" ]] && [[ $OS =~ "rhels8" ]]; then
+    if rpm -qa|grep xCAT-openbmc-py 2>&1; then 
+        echo "Setting up for xCAT-openbmc-py installation on $OS $ARCH service node";
+        osimage="$OS-$ARCH-install-service";
+        otherpkgdir=$(lsdef -t osimage $osimage -i otherpkgdir -c|awk -F"=" '{print $2}'); 
+        otherpkglist=$(lsdef -t osimage $osimage -i otherpkglist -c|awk -F"=" '{print $2}');
+        mkdir -p $otherpkgdir/epel/Packages; 
+        wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm --no-check-certificate -O $otherpkgdir/epel/Packages/epel-release-latest-8.noarch.rpm
+        if [ -e $otherpkgdir/epel/Packages/epel-release-latest-8.noarch.rpm ]; then
+            # Downloaded epel-release-latest-8.noarch.rpm
+            # once it is installed on SN, it will setup the repo for
+            # required python3 packages
+            cd $otherpkgdir/epel/Packages && createrepo .;
+            echo "--Checking otherpkgdir";
+            ls -Rl $otherpkgdir/epel/Packages;
+            # Add separator, so epel-release-latest-8 will be called by yum separately
+            echo "#NEW_INSTALL_LIST#" >> $otherpkglist;
+            echo "epel/Packages/epel-release-latest-8" >> $otherpkglist;
+            # Add separator, so xCAT-openbmc-py will be called by yum separately
+            echo "#NEW_INSTALL_LIST#" >> $otherpkglist;
+            echo "xcat/xcat-core/xCAT-openbmc-py" >> $otherpkglist;
+            echo "--Checking otherpkglist";
+            cat $otherpkglist;
+        else
+            echo "Could not download https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm";
+            exit 1;
+        fi
+    else 
+        echo "There is no xCAT-openbmc-py installed on $ARCH $OS MN, skip installing xCAT-openbmc-py on SN";
+        exit 0;
+    fi
+fi

--- a/xCAT-test/autotest/testcase/installation/SN_setup_case
+++ b/xCAT-test/autotest/testcase/installation/SN_setup_case
@@ -56,8 +56,7 @@ cmd:if [[ "__GETNODEATTR($$SN,os)__" =~ "rh" ]]; then path="rh";elif [[ "__GETNO
 check:rc==0
 
 #add support python in sn
-#if xCAT-openbmc-py has been installed in MN, will install xCAT-openbmc-py in sn
-cmd:if rpm -qa|grep xCAT-openbmc-py 2>&1; then osimage="__GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-install-service"; otherpkgdir=$(lsdef -t osimage $osimage -i otherpkgdir -c|awk -F"=" '{print $2}'); otherpkglist=$(lsdef -t osimage $osimage -i otherpkglist -c|awk -F"=" '{print $2}');mkdir -p $otherpkgdir/xcat/Packages; cp -r $$PYTHON_DEP_FED_DIR/Packages/*.rpm $otherpkgdir/xcat/Packages; cp -r $$PYTHON_DEP_EPEL_DIR/Packages/* $otherpkgdir/xcat/Packages; cp -r $$PYTHON_DEP_EXTRAS_DIR/Packages/* $otherpkgdir/xcat/Packages; cd $otherpkgdir/xcat/Packages && createrepo .; echo "xcat/Packages/python2-gevent" >> $otherpkglist; echo "xcat/Packages/python2-greenlet" >> $otherpkglist; echo "xcat/xcat-core/xCAT-openbmc-py" >> $otherpkglist; echo "--To check otherpkgdir"; ls -Rl $otherpkgdir/xcat/Packages; if ! ls -l $otherpkgdir/xcat/Packages|grep python2-gevent- > /dev/null 2>&1; then echo "there is no python2-gevent package under $otherpkgdir/xcat/Packages";exit 1; fi; if ! ls -l $otherpkgdir/xcat/Packages|grep python2-greenlet- > /dev/null 2>&1; then echo "there is no python2-greenlet under $otherpkgdir/xcat/Packages";exit 1; fi; echo "--To check otherpkglist"; cat $otherpkglist; if ! grep python2-gevent $otherpkglist > /dev/null 2>&1; then echo "there is no entry about python2-gevent in $otherpkglist"; exit 1;fi; if ! grep python2-greenlet $otherpkglist  > /dev/null 2>&1; then echo "there is no entry about python2-greenlet in $otherpkglist"; exit 1;fi; exit 0; else echo "there is no xCAT-openbmc-py installed in MN, skip installing xCAT-openbmc-py in SN"; exit 0;fi
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/installation/SN_install_openbmc_py.sh __GETNODEATTR($$SN,arch)__ __GETNODEATTR($$SN,os)__ $$PYTHON_DEP_FED_DIR $$PYTHON_DEP_EPEL_DIR $$PYTHON_DEP_EXTRAS_DIR
 check:rc==0
 
 
@@ -66,7 +65,6 @@ check:rc==0
 check:output=~Provision node\(s\)\: $$SN
 
 cmd:if [[ -f /var/lib/dhcp/db/dhcpd.leases ]]; then cat /var/lib/dhcp/db/dhcpd.leases; elif [[ -f /var/lib/dhcpd/dhcpd.leases ]];then cat /var/lib/dhcpd/dhcpd.leases;elif [[ -f /var/lib/dhcp/dhcpd.leases ]];then cat /var/lib/dhcp/dhcpd.leases; fi
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/installation/customize_sleep_for_sn __GETNODEATTR($$SN,os)__ __GETNODEATTR($$SN,arch)__
 
 cmd:ping $$SN -c 3
 check:rc==0
@@ -99,11 +97,7 @@ cmd:xdsh $$SN cat /opt/xcat/xcatinfo
 check:rc==0
 check:output=~NODE=$$SN
 check:output=~IMAGENAME=__GETNODEATTR($$SN,os)__-__GETNODEATTR($$SN,arch)__-install-service
-cmd:if rpm -qa|grep xCAT-openbmc-py 2>&1; then xdsh $$SN "rpm -qa|grep xCAT-openbmc-py";else echo "there is no xCAT-openbmc-py installed in MN, skip check xCAT-openbmc-py installation in SN"; exit 0;fi
-check:rc==0
-cmd:if rpm -qa|grep xCAT-openbmc-py 2>&1; then xdsh $$SN "rpm -qa|grep python2-gevent"; else echo "there is no xCAT-openbmc-py installed in MN, skip check python2-gevent installation in SN"; exit 0;fi
-check:rc==0 
-cmd:if rpm -qa|grep xCAT-openbmc-py 2>&1; then xdsh $$SN "rpm -qa|grep python2-greenlet"; else echo "there is no xCAT-openbmc-py installed in MN, skip check python2-greenlet installation in SN"; exit 0;fi
+cmd:if rpm -qa|grep xCAT-openbmc-py 2>&1; then xdsh $$SN "rpm -qa|grep xCAT-openbmc-py";else echo "There is no xCAT-openbmc-py installed in MN, skip check xCAT-openbmc-py installation in SN"; exit 0;fi
 check:rc==0
 cmd:xdsh $$SN  "cat /var/log/xcat/xcat.log"
 cmd:if [[ "__GETNODEATTR($$SN,arch)__" =~ "x86_64" ]]; then if [[ "__GETNODEATTR($$SN,os)__" =~ "sle" ]];then xdsh $$SN "zypper -n install perl-Sys-Virt"; elif [[ "__GETNODEATTR($$SN,os)__" =~ "rh" || "__GETNODEATTR($$SN,os)__" =~ "ol" || "__GETNODEATTR($$SN,os)__" =~ "rocky" ]];then xdsh $$SN "yum install -y perl-Sys-Virt";fi;fi

--- a/xCAT-test/autotest/testcase/pythonsupport/cases0
+++ b/xCAT-test/autotest/testcase/pythonsupport/cases0
@@ -32,13 +32,13 @@ cmd:sed -i "s|__REPLACE_PATH__FED__|$$PYTHON_DEP_FED_DIR|" /etc/yum.repos.d/xcat
 check:rc==0
 cmd:cat /etc/yum.repos.d/xcat-dep-python-local.repo
 check:rc==0 
-cmd:wget https://xcat.org/files/xcat/xcat-dep/2.x_Linux/beta/xCAT-openbmc-py-RH7-2.14.6-snap202204090016.noarch.rpm -O /tmp/xCAT-openbmc-py-RH7.noarch.rpm
-cmd:ls -l /tmp/xCAT-openbmc-py-RH7-2.14.6.rpm
+cmd:wget https://xcat.org/files/xcat/xcat-dep/2.x_Linux/beta/xCAT-openbmc-py-RH7-2.14.6-snap202204090016.noarch.rpm --no-check-certificate  -O /tmp/xCAT-openbmc-py-RH7.noarch.rpm
+cmd:ls -l /tmp/xCAT-openbmc-py-RH7.noarch.rpm
 check:rc==0
 cmd:yum install -y /tmp/xCAT-openbmc-py-RH7.noarch.rpm
 check:rc==0
-cmd:rpm -qa|grep "^xCAT-openbmc-py-RH7"
-check:output=~ xCAT-openbmc-py-RH7\d
+cmd:rpm -qa|grep "^xCAT-openbmc-py"
+check:output=~ xCAT-openbmc-py-\d
 check:rc==0
 cmd:rm -rf /tmp/set_up_env_for_support_openbmc_in_python
 check:rc==0


### PR DESCRIPTION
Testcase to verify `xCAT-openbmc-py` RPM can be installed on service node.

This PR:
* Removes inline code to install Python prereqs from `SN_setup_case` testcase and instead create external script `SN_install_openbmc_py.sh`, for much easier readability.
* Add a check to `retry_install.sh` for `failed` state. Currently just waits for `booted`, but if state is `failed`, no reason to keep waiting for it to change to `booted`.
* Remove calling `customize_sleep_for_sn` script from `SN_setup_case` testcase. The `customize_sleep_for_sn` script is designed to wait until node state changes to `booted`, which is needed after `rinstall`. But since `SN_setup_case` testcase uses `retry_install`, which already waits for `booted` state, calling `customize_sleep_for_sn` script is not needed.
* Remove checks for `gevent` and `greenlet` installed RPMs from `SN_setup_case` testcase. Checking for installed `xCAT-openbmc-py` RPM is enough, since `gevent` and `greenlet` are prereqs for `xCAT-openbmc-py` RPM.
* Add `--no-check-certificate` flag to `wget` when downloading from xcat.org