### PR TITLE
Prevent comment character removal from /etc/rsyslog.conf

### DIFF
--- a/xCAT/postscripts/syslog
+++ b/xCAT/postscripts/syslog
@@ -273,6 +273,7 @@ config_rsyslog_V8()
 
         [ -f "$conf_file" ] && sed -i '/#\$ModLoad \+imudp\|imtcp\|imudp.so\|imtcp.so/s/^#//;
                        /#\$InputTCPServerRun\|UDPServerRun.*/s/^#//' $conf_file
+        [ -f "$conf_file" ] && sed -i '/mtcp.html/s/^/#/' $conf_file
 
         [ -f "/etc/rsyslog.d/xcat-cluster.conf" ] && rm -f "/etc/rsyslog.d/xcat-cluster.conf" ;
         [ -f "/etc/rsyslog.d/xcat-compute.conf" ] && rm -f "/etc/rsyslog.d/xcat-compute.conf" ;


### PR DESCRIPTION
When `syslog` postscript runs, it tries to modify `/etc/rsyslog.conf` file on the node being provisioned before restarting `rsyslog` service.
Specifically, the postscript tries to remove the comment character (`#`) from `/etc/rsyslog.conf` file for lines that contain
`$ModLoad +imudp | imtcp | imudp.so | imtcp.so` using `sed` command. However, the current `sed` commands gets a hit for the line: `# for parameters see http://www.rsyslog.com/doc/imtcp.html`, which should stay as a comment:
```
# Provides TCP syslog reception
 for parameters see http://www.rsyslog.com/doc/imtcp.html
module(load="imtcp") # needs to be done just once
input(type="imtcp" port="514")
```

As a result, when `rsyslogd` starts and reads the configuration from `/etc/rsyslog.conf` file, the following errors get reported:
```
Apr 19 02:18:13 f6u13k20 systemd[1]: INFO  Started System Logging Service.
Apr 19 02:18:13 f6u13k20 rsyslogd[1154]: ERR  error during parsing file /etc/rsyslog.conf, on or before line 23: warnings occured in file '/etc/rsyslog.conf' around line 23 [v8.2102.0-5.el8 try https://www.rsyslog.com/e/2207 ]
Apr 19 02:18:13 f6u13k20 systemd[1]: INFO  Starting xcat service on compute node, the framework to run postbootscript and update node status...
Apr 19 02:18:13 f6u13k20 rsyslogd[1154]: WARNING  action 'parameters' treated as ':omusrmsg:parameters' - please use ':omusrmsg:parameters' syntax instead, 'parameters' will not be supported in the future [v8.2102.0-5.el8 try https://www.rsyslog.com/e/2184 ]
Apr 19 02:18:13 f6u13k20 rsyslogd[1154]: ERR  error during parsing file /etc/rsyslog.conf, on or before line 23: warnings occured in file '/etc/rsyslog.conf' around line 23 [v8.2102.0-5.el8 try https://www.rsyslog.com/e/2207 ]
Apr 19 02:18:13 f6u13k20 rsyslogd[1154]: WARNING  action 'see' treated as ':omusrmsg:see' - please use ':omusrmsg:see' syntax instead, 'see' will not be supported in the future [v8.2102.0-5.el8 try https://www.rsyslog.com/e/2184 ]
Apr 19 02:18:13 f6u13k20 rsyslogd[1154]: ERR  error during parsing file /etc/rsyslog.conf, on or before line 23: warnings occured in file '/etc/rsyslog.conf' around line 23 [v8.2102.0-5.el8 try https://www.rsyslog.com/e/2207 ]
Apr 19 02:18:13 f6u13k20 rsyslogd[1154]: WARNING  action 'http' treated as ':omusrmsg:http' - please use ':omusrmsg:http' syntax instead, 'http' will not be supported in the future [v8.2102.0-5.el8 try https://www.rsyslog.com/e/2184 ]
Apr 19 02:18:13 f6u13k20 rsyslogd[1154]: ERR  error during parsing file /etc/rsyslog.conf, on or before line 23: warnings occured in file '/etc/rsyslog.conf' around line 23 [v8.2102.0-5.el8 try https://www.rsyslog.com/e/2207 ]
Apr 19 02:18:13 f6u13k20 rsyslogd[1154]: ERR  error during parsing file /etc/rsyslog.conf, on or before line 23: invalid character ':' - is there an invalid escape sequence somewhere? [v8.2102.0-5.el8 try https://www.rsyslog.com/e/2207 ]
Apr 19 02:18:13 f6u13k20 rsyslogd[1154]: WARNING  warning: ~ action is deprecated, consider using the 'stop' statement instead [v8.2102.0-5.el8 try https://www.rsyslog.com/e/2307 ]
```

This PR adds a `sed` line to put back comment character for a line containing `mtcp.html` in the `/etc/rsyslog.conf` file:
```
# Provides TCP syslog reception
# for parameters see http://www.rsyslog.com/doc/imtcp.html
module(load="imtcp") # needs to be done just once
input(type="imtcp" port="514")
```

Tested on P9 RHEL8.5, no more `ERR` or `WARNING` messages get reported, just:
```
Apr 19 13:49:02 f6u13k20 systemd[1]: INFO  Started System Logging Service.
```