### PR TITLE
Improve xcattest check:output syntax checking

### DIFF
--- a/xCAT-test/autotest/testcase/UT_openbmc/rspconfig_cases0
+++ b/xCAT-test/autotest/testcase/UT_openbmc/rspconfig_cases0
@@ -152,7 +152,7 @@ check:rc==0
 #Remove last generated dump
 cmd: rspconfig $$CN dump -l | tail -1 | cut -d ' ' -f2 | tr -d "[]" | xargs -i{} rspconfig $$CN dump -c {}
 check:rc==0
-check:output=clear
+check:output==clear
 end
 
 start:openbmc_rspconfig_ntpservers

--- a/xCAT-test/autotest/testcase/gettab/cases0
+++ b/xCAT-test/autotest/testcase/gettab/cases0
@@ -27,7 +27,7 @@ cmd:gettab -H groups=master site.key
 check:rc!=0
 cmd:gettab -H key=master site.groups
 check:rc==0
-check:output=site.groups:
+check:output==site.groups:
 end
 
 

--- a/xCAT-test/autotest/testcase/xcattest/cases0
+++ b/xCAT-test/autotest/testcase/xcattest/cases0
@@ -1,0 +1,77 @@
+start:xcattest_checkoutput_exactmatch
+description:check:output== match an exact string
+label:mn_only,ci_test
+cmd:echo "Test"
+check:output==Test
+end
+
+start:xcattest_checkoutput_not_exactmatch
+description:check:output!= check that the output does not match an exact string
+label:mn_only,ci_test
+cmd:echo "Test"
+check:output!=Tes
+end
+
+start:xcattest_checkoutput_regexmatch_full
+description:check:output=~ matching a full string
+label:mn_only,ci_test
+cmd:echo "Running test now"
+check:output=~Running test now
+end
+
+start:xcattest_checkoutput_regexmatch_start
+description:checkoutput=~ matching a partial string from the start of the output 
+label:mn_only,ci_test
+cmd:echo "Running test now"
+check:output=~Running te
+end
+
+start:xcattest_checkoutput_regexmatch_middle
+description:checkoutput=~ matching a partial string in the middle of the output
+label:mn_only,ci_test
+cmd:echo "Running test now"
+check:output=~ing test
+end
+
+start:xcattest_checkoutput_regexmatch_end
+description:checkoutput=~ matching a partial string up to the end of the output
+label:mn_only,ci_test
+cmd:echo "Running test now"
+check:output=~ now
+end
+
+start:xcattest_checkoutput_not_regexmatch_independent
+description:check:output!~ two unrelated strings
+label:mn_only,ci_test
+cmd:echo "Running test now"
+check:output!~uptime
+end
+
+start:xcattest_checkoutput_not_regexmatch_superstring
+description:check:output!~ where the tested string is larger than the output
+label:mn_only,ci_test
+cmd:echo "Running test now"
+check:output!~Running test now, please wait
+end
+
+start:xcattest_checkoutput_not_regexmatch_start
+description:check:output!~ where the tested string fails near the start
+label:mn_only,ci_test
+cmd:echo "Running test now"
+check:output!~Running tess
+end
+
+start:xcattest_checkoutput_not_regexmatch_middle
+description:check:output!~ where the tested string fails in the middle
+label:mn_only,ci_test
+cmd:echo "Running test now"
+check:output!~ing  test
+end
+
+start:xcattest_checkoutput_not_regexmatch_end
+description:check:output!~ where the tested string fails near the end 
+label:mn_only,ci_test
+cmd:echo "Running test now"
+check:output!~est now pl
+end
+

--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -1435,8 +1435,7 @@ sub run_case {
                         log_this($running_log_fd, "CHECK:rc $op $rvalue\t[Pass]");
                         push(@caselog, "CHECK:rc $op $rvalue\t[Pass]");
                     }
-                } elsif ($check =~ /output\s*([=!~]+)\s*(\S.*)/
-                    && $check !~ /output\s*([=!~])\1/) {
+                } elsif ($check =~ /output\s*(==|!=|=~|!~)\s*(\S.*)/) {
                     my $lvalue = join("\n", @output);
                     my $op     = $1;
                     my $rvalue = $2;

--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -1447,6 +1447,11 @@ sub run_case {
                         || (($op eq '==') && ($lvalue ne $rvalue))
                         || (($op eq '!=') && ($lvalue eq $rvalue))) {
                         $failflag = 1;
+                    } elsif (($op ne '=~') && ($op ne '!~') && ($op ne '==') && ($op ne '!=')) {
+                        $failflag = 1;
+                        log_this($running_log_fd, "CHECK:output unrecognized operator: $op\t[Failed]");
+                        push(@caselog, "CHECK:output unrecognized operator: $op\t[Failed]");
+                        last;
                     }
                     if ($failflag) {
                         log_this($running_log_fd, "CHECK:output $op $rvalue\t[Failed]");
@@ -1491,7 +1496,13 @@ sub run_case {
                     } else {
                         log_this($running_log_fd, "CHECK:output $op $rvalue\t[Pass]");
                         push(@caselog, "CHECK:output $op $rvalue\t[Pass]");
-                    } } }
+                    } 
+                } else {
+                    $failflag = 1;
+                    log_this($running_log_fd, "Unrecognized testcase syntax: CHECK:$check\t[Failed]");
+                    push(@caselog, "Unrecognized testcase syntax: CHECK:$check\t[Failed]");
+                } 
+            }
             foreach my $cmdcheck (@{ $cases_ref->[ $case_name_index_map_ref->{$case} ]->{cmdcheck}->[$j] }) {
                 if ($cmdcheck) {
                     &runcmd($cmdcheck);


### PR DESCRIPTION
This PR contains additional improvements related to #7110:
1.) Added additional logic to `xcattest check:output` to fail tests when called with invalid syntax.
2.) Added stricter syntax checking to `xcattest check:output`
3.) Added testcases for `xcattest check:output`
4.) Fixed two existing testcases that were calling `check:output=` to now call `check:output==`

Unit test before changes in this PR (all of these are expected to pass)
Note the incorrect behavior of `xcattest_checkoutput_exactmatch`:
```
[root@f6u13k04 autotest]# xcattest -f ./default.conf -c xcattest

******************************
loading test cases
******************************
To run:
xcattest_checkoutput_exactmatch
xcattest_checkoutput_not_exactmatch
xcattest_checkoutput_regexmatch_full
xcattest_checkoutput_regexmatch_start
xcattest_checkoutput_regexmatch_middle
xcattest_checkoutput_regexmatch_end
xcattest_checkoutput_not_regexmatch_independent
xcattest_checkoutput_not_regexmatch_superstring
xcattest_checkoutput_not_regexmatch_start
xcattest_checkoutput_not_regexmatch_middle
xcattest_checkoutput_not_regexmatch_end
******************************
Start to run test cases
******************************
------START::xcattest_checkoutput_exactmatch::Time:Thu Apr 21 15:50:02 2022------

RUN:echo "Test" [Thu Apr 21 15:50:02 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Test
 
------END::xcattest_checkoutput_exactmatch::Passed::Time:Thu Apr 21 15:50:02 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_not_exactmatch::Time:Thu Apr 21 15:50:02 2022------

RUN:echo "Test" [Thu Apr 21 15:50:02 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Test
CHECK:output != Tes	[Pass]
 
------END::xcattest_checkoutput_not_exactmatch::Passed::Time:Thu Apr 21 15:50:02 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_regexmatch_full::Time:Thu Apr 21 15:50:02 2022------

RUN:echo "Running test now" [Thu Apr 21 15:50:02 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Running test now
CHECK:output =~ Running test now	[Pass]
 
------END::xcattest_checkoutput_regexmatch_full::Passed::Time:Thu Apr 21 15:50:02 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_regexmatch_start::Time:Thu Apr 21 15:50:02 2022------

RUN:echo "Running test now" [Thu Apr 21 15:50:02 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Running test now
CHECK:output =~ Running te	[Pass]
 
------END::xcattest_checkoutput_regexmatch_start::Passed::Time:Thu Apr 21 15:50:02 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_regexmatch_middle::Time:Thu Apr 21 15:50:02 2022------

RUN:echo "Running test now" [Thu Apr 21 15:50:02 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Running test now
CHECK:output =~ ing test	[Pass]
 
------END::xcattest_checkoutput_regexmatch_middle::Passed::Time:Thu Apr 21 15:50:02 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_regexmatch_end::Time:Thu Apr 21 15:50:02 2022------

RUN:echo "Running test now" [Thu Apr 21 15:50:02 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Running test now
CHECK:output =~ now	[Pass]
 
------END::xcattest_checkoutput_regexmatch_end::Passed::Time:Thu Apr 21 15:50:02 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_not_regexmatch_independent::Time:Thu Apr 21 15:50:02 2022------

RUN:echo "Running test now" [Thu Apr 21 15:50:02 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Running test now
CHECK:output !~ uptime	[Pass]
 
------END::xcattest_checkoutput_not_regexmatch_independent::Passed::Time:Thu Apr 21 15:50:02 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_not_regexmatch_superstring::Time:Thu Apr 21 15:50:02 2022------

RUN:echo "Running test now" [Thu Apr 21 15:50:02 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Running test now
CHECK:output !~ Running test now, please wait	[Pass]
 
------END::xcattest_checkoutput_not_regexmatch_superstring::Passed::Time:Thu Apr 21 15:50:02 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_not_regexmatch_start::Time:Thu Apr 21 15:50:02 2022------

RUN:echo "Running test now" [Thu Apr 21 15:50:02 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Running test now
CHECK:output !~ Running tess	[Pass]
 
------END::xcattest_checkoutput_not_regexmatch_start::Passed::Time:Thu Apr 21 15:50:02 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_not_regexmatch_middle::Time:Thu Apr 21 15:50:02 2022------

RUN:echo "Running test now" [Thu Apr 21 15:50:02 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Running test now
CHECK:output !~ ing  test	[Pass]
 
------END::xcattest_checkoutput_not_regexmatch_middle::Passed::Time:Thu Apr 21 15:50:02 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_not_regexmatch_end::Time:Thu Apr 21 15:50:02 2022------

RUN:echo "Running test now" [Thu Apr 21 15:50:02 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Running test now
CHECK:output !~ est now pl	[Pass]
 
------END::xcattest_checkoutput_not_regexmatch_end::Passed::Time:Thu Apr 21 15:50:02 2022 ::Duration::0 sec------
------Total: 11 , Failed: 0------
```

Unit test after the changes in this PR (all of these are expected to pass)
Note the corrected behavior of `xcattest_checkoutput_exactmatch`:
```
[root@f6u13k04 autotest]# xcattest -f ./default.conf -c xcattest

******************************
loading test cases
******************************
To run:
xcattest_checkoutput_exactmatch
xcattest_checkoutput_not_exactmatch
xcattest_checkoutput_regexmatch_full
xcattest_checkoutput_regexmatch_start
xcattest_checkoutput_regexmatch_middle
xcattest_checkoutput_regexmatch_end
xcattest_checkoutput_not_regexmatch_independent
xcattest_checkoutput_not_regexmatch_superstring
xcattest_checkoutput_not_regexmatch_start
xcattest_checkoutput_not_regexmatch_middle
xcattest_checkoutput_not_regexmatch_end
******************************
Start to run test cases
******************************
------START::xcattest_checkoutput_exactmatch::Time:Thu Apr 21 15:59:28 2022------

RUN:echo "Test" [Thu Apr 21 15:59:28 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Test
CHECK:output == Test	[Pass]
 
------END::xcattest_checkoutput_exactmatch::Passed::Time:Thu Apr 21 15:59:28 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_not_exactmatch::Time:Thu Apr 21 15:59:28 2022------

RUN:echo "Test" [Thu Apr 21 15:59:28 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Test
CHECK:output != Tes	[Pass]
 
------END::xcattest_checkoutput_not_exactmatch::Passed::Time:Thu Apr 21 15:59:28 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_regexmatch_full::Time:Thu Apr 21 15:59:28 2022------

RUN:echo "Running test now" [Thu Apr 21 15:59:28 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Running test now
CHECK:output =~ Running test now	[Pass]
 
------END::xcattest_checkoutput_regexmatch_full::Passed::Time:Thu Apr 21 15:59:28 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_regexmatch_start::Time:Thu Apr 21 15:59:28 2022------

RUN:echo "Running test now" [Thu Apr 21 15:59:28 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Running test now
CHECK:output =~ Running te	[Pass]
 
------END::xcattest_checkoutput_regexmatch_start::Passed::Time:Thu Apr 21 15:59:28 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_regexmatch_middle::Time:Thu Apr 21 15:59:28 2022------

RUN:echo "Running test now" [Thu Apr 21 15:59:28 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Running test now
CHECK:output =~ ing test	[Pass]
 
------END::xcattest_checkoutput_regexmatch_middle::Passed::Time:Thu Apr 21 15:59:28 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_regexmatch_end::Time:Thu Apr 21 15:59:28 2022------

RUN:echo "Running test now" [Thu Apr 21 15:59:28 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Running test now
CHECK:output =~ now	[Pass]
 
------END::xcattest_checkoutput_regexmatch_end::Passed::Time:Thu Apr 21 15:59:28 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_not_regexmatch_independent::Time:Thu Apr 21 15:59:28 2022------

RUN:echo "Running test now" [Thu Apr 21 15:59:28 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Running test now
CHECK:output !~ uptime	[Pass]
 
------END::xcattest_checkoutput_not_regexmatch_independent::Passed::Time:Thu Apr 21 15:59:28 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_not_regexmatch_superstring::Time:Thu Apr 21 15:59:28 2022------

RUN:echo "Running test now" [Thu Apr 21 15:59:28 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Running test now
CHECK:output !~ Running test now, please wait	[Pass]
 
------END::xcattest_checkoutput_not_regexmatch_superstring::Passed::Time:Thu Apr 21 15:59:28 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_not_regexmatch_start::Time:Thu Apr 21 15:59:28 2022------

RUN:echo "Running test now" [Thu Apr 21 15:59:28 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Running test now
CHECK:output !~ Running tess	[Pass]
 
------END::xcattest_checkoutput_not_regexmatch_start::Passed::Time:Thu Apr 21 15:59:28 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_not_regexmatch_middle::Time:Thu Apr 21 15:59:28 2022------

RUN:echo "Running test now" [Thu Apr 21 15:59:28 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Running test now
CHECK:output !~ ing  test	[Pass]
 
------END::xcattest_checkoutput_not_regexmatch_middle::Passed::Time:Thu Apr 21 15:59:28 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_not_regexmatch_end::Time:Thu Apr 21 15:59:28 2022------

RUN:echo "Running test now" [Thu Apr 21 15:59:28 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Running test now
CHECK:output !~ est now pl	[Pass]
 
------END::xcattest_checkoutput_not_regexmatch_end::Passed::Time:Thu Apr 21 15:59:28 2022 ::Duration::0 sec------
------Total: 11 , Failed: 0------
```

In addition to the good path tests above, here are some tests that are expected to fail if xcattest is working correctly:
```
[root@f6u13k04 autotest]# cat testcase/xcattest/cases0.fail 
start:xcattest_checkoutput_exactmatch_fail
description:check:output== match an exact string (Fail expected)
label:mn_only,fail
cmd:echo "Test"
check:output==Tes
end

start:xcattest_checkoutput_not_exactmatch_fail
description:check:output!= check that the output does not match an exact string (Fail expected)
label:mn_only,fail
cmd:echo "Test"
check:output!=Test
end

start:xcattest_checkoutput_regexmatch_independent_fail
description:check:output=~ two unrelated strings (Fail expected)
label:mn_only,fail
cmd:echo "Running test now"
check:output=~uptime
end

start:xcattest_checkoutput_not_regexmatch_fail
description:check:output!~ two identical strings (Fail expected)
label:mn_only,fail
cmd:echo "Running test now"
check:output!~Running test now
end

start:xcattest_checkoutput_invalidoperator_1
description:check:output= invalid operator (Fail expected)
label:mn_only,fail
cmd:echo "Test"
check:output=Test
end

start:xcattest_checkoutput_invalidoperator_2
description:check:output=== invalid operator (Fail expected)
label:mn_only,fail
cmd:echo "Test"
check:output===Test
end

start:xcattest_checkoutput_invalidoperator_3
description:check:output=! invalid operator (Fail expected)
label:mn_only,fail
cmd:echo "Test"
check:output=!Test2
end

start:xcattest_checkoutput_invalidoperator_4
description:check:output~= invalid operator (Fail expected)
label:mn_only,fail
cmd:echo "Test"
check:output~=Test
end

start:xcattest_checkoutput_invalidoperator_5
description:check:output~! invalid operator (Fail expected)
label:mn_only,fail
cmd:echo "Test"
check:output~!Test2
end
```
Unit test results for the bad case tests above, before the changes in this PR (all are expected to fail):
Note that only 3 of the 9 tests correctly report as failed prior to the changes in this PR.
```
[root@f6u13k04 autotest]# xcattest -f ./default.conf -c xcattest -s fail

******************************
loading test cases
******************************
To run:
xcattest_checkoutput_invalidoperator_4
xcattest_checkoutput_invalidoperator_3
xcattest_checkoutput_not_regexmatch_fail
xcattest_checkoutput_invalidoperator_2
xcattest_checkoutput_not_exactmatch_fail
xcattest_checkoutput_exactmatch_fail
xcattest_checkoutput_regexmatch_independent_fail
xcattest_checkoutput_invalidoperator_1
xcattest_checkoutput_invalidoperator_5
******************************
Start to run test cases
******************************
------START::xcattest_checkoutput_invalidoperator_4::Time:Thu Apr 21 15:51:25 2022------

RUN:echo "Test" [Thu Apr 21 15:51:25 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Test
CHECK:output ~= Test	[Pass]
 
------END::xcattest_checkoutput_invalidoperator_4::Passed::Time:Thu Apr 21 15:51:25 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_invalidoperator_3::Time:Thu Apr 21 15:51:25 2022------

RUN:echo "Test" [Thu Apr 21 15:51:25 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Test
CHECK:output =! Test2	[Pass]
 
------END::xcattest_checkoutput_invalidoperator_3::Passed::Time:Thu Apr 21 15:51:25 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_not_regexmatch_fail::Time:Thu Apr 21 15:51:25 2022------

RUN:echo "Running test now" [Thu Apr 21 15:51:25 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Running test now
CHECK:output !~ Running test now	[Failed]
 
------END::xcattest_checkoutput_not_regexmatch_fail::Failed::Time:Thu Apr 21 15:51:25 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_invalidoperator_2::Time:Thu Apr 21 15:51:25 2022------

RUN:echo "Test" [Thu Apr 21 15:51:25 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Test
 
------END::xcattest_checkoutput_invalidoperator_2::Passed::Time:Thu Apr 21 15:51:25 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_not_exactmatch_fail::Time:Thu Apr 21 15:51:25 2022------

RUN:echo "Test" [Thu Apr 21 15:51:25 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Test
CHECK:output != Test	[Failed]
 
------END::xcattest_checkoutput_not_exactmatch_fail::Failed::Time:Thu Apr 21 15:51:25 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_exactmatch_fail::Time:Thu Apr 21 15:51:25 2022------

RUN:echo "Test" [Thu Apr 21 15:51:25 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Test
 
------END::xcattest_checkoutput_exactmatch_fail::Passed::Time:Thu Apr 21 15:51:25 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_regexmatch_independent_fail::Time:Thu Apr 21 15:51:25 2022------

RUN:echo "Running test now" [Thu Apr 21 15:51:25 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Running test now
CHECK:output =~ uptime	[Failed]
 
------END::xcattest_checkoutput_regexmatch_independent_fail::Failed::Time:Thu Apr 21 15:51:25 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_invalidoperator_1::Time:Thu Apr 21 15:51:25 2022------

RUN:echo "Test" [Thu Apr 21 15:51:25 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Test
CHECK:output = Test	[Pass]
 
------END::xcattest_checkoutput_invalidoperator_1::Passed::Time:Thu Apr 21 15:51:25 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_invalidoperator_5::Time:Thu Apr 21 15:51:25 2022------

RUN:echo "Test" [Thu Apr 21 15:51:25 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Test
CHECK:output ~! Test2	[Pass]
 
------END::xcattest_checkoutput_invalidoperator_5::Passed::Time:Thu Apr 21 15:51:25 2022 ::Duration::0 sec------
------Total: 9 , Failed: 3------
```

Unit test results for the bad case tests above, after the changes in this PR (all are expected to fail):
9 out of 9 tests now fail correctly after the changes in this PR.
```
[root@f6u13k04 autotest]# xcattest -f ./default.conf -c xcattest -s fail

******************************
loading test cases
******************************
To run:
xcattest_checkoutput_invalidoperator_3
xcattest_checkoutput_exactmatch_fail
xcattest_checkoutput_regexmatch_independent_fail
xcattest_checkoutput_invalidoperator_5
xcattest_checkoutput_invalidoperator_4
xcattest_checkoutput_invalidoperator_2
xcattest_checkoutput_invalidoperator_1
xcattest_checkoutput_not_exactmatch_fail
xcattest_checkoutput_not_regexmatch_fail
******************************
Start to run test cases
******************************
------START::xcattest_checkoutput_invalidoperator_3::Time:Thu Apr 21 16:01:12 2022------

RUN:echo "Test" [Thu Apr 21 16:01:12 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Test
Unrecognized testcase syntax: CHECK:output=!Test2	[Failed]
 
------END::xcattest_checkoutput_invalidoperator_3::Failed::Time:Thu Apr 21 16:01:12 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_exactmatch_fail::Time:Thu Apr 21 16:01:12 2022------

RUN:echo "Test" [Thu Apr 21 16:01:12 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Test
CHECK:output == Tes	[Failed]
 
------END::xcattest_checkoutput_exactmatch_fail::Failed::Time:Thu Apr 21 16:01:12 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_regexmatch_independent_fail::Time:Thu Apr 21 16:01:12 2022------

RUN:echo "Running test now" [Thu Apr 21 16:01:12 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Running test now
CHECK:output =~ uptime	[Failed]
 
------END::xcattest_checkoutput_regexmatch_independent_fail::Failed::Time:Thu Apr 21 16:01:12 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_invalidoperator_5::Time:Thu Apr 21 16:01:12 2022------

RUN:echo "Test" [Thu Apr 21 16:01:12 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Test
Unrecognized testcase syntax: CHECK:output~!Test2	[Failed]
 
------END::xcattest_checkoutput_invalidoperator_5::Failed::Time:Thu Apr 21 16:01:12 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_invalidoperator_4::Time:Thu Apr 21 16:01:12 2022------

RUN:echo "Test" [Thu Apr 21 16:01:12 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Test
Unrecognized testcase syntax: CHECK:output~=Test	[Failed]
 
------END::xcattest_checkoutput_invalidoperator_4::Failed::Time:Thu Apr 21 16:01:12 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_invalidoperator_2::Time:Thu Apr 21 16:01:12 2022------

RUN:echo "Test" [Thu Apr 21 16:01:12 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Test
CHECK:output == =Test	[Failed]
 
------END::xcattest_checkoutput_invalidoperator_2::Failed::Time:Thu Apr 21 16:01:12 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_invalidoperator_1::Time:Thu Apr 21 16:01:12 2022------

RUN:echo "Test" [Thu Apr 21 16:01:12 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Test
Unrecognized testcase syntax: CHECK:output=Test	[Failed]
 
------END::xcattest_checkoutput_invalidoperator_1::Failed::Time:Thu Apr 21 16:01:12 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_not_exactmatch_fail::Time:Thu Apr 21 16:01:12 2022------

RUN:echo "Test" [Thu Apr 21 16:01:12 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Test
CHECK:output != Test	[Failed]
 
------END::xcattest_checkoutput_not_exactmatch_fail::Failed::Time:Thu Apr 21 16:01:12 2022 ::Duration::0 sec------
------START::xcattest_checkoutput_not_regexmatch_fail::Time:Thu Apr 21 16:01:12 2022------

RUN:echo "Running test now" [Thu Apr 21 16:01:12 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Running test now
CHECK:output !~ Running test now	[Failed]
 
------END::xcattest_checkoutput_not_regexmatch_fail::Failed::Time:Thu Apr 21 16:01:12 2022 ::Duration::0 sec------
------Total: 9 , Failed: 9------
```
