### PR TITLE
Add more wait time after reboot of SLES15.3

### DIFF
--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_hierarchy
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_hierarchy
@@ -109,7 +109,7 @@ check:rc==0
 
 # Check node can be rebooted from disk
 cmd:xdsh $$CN shutdown -r now
-cmd:sleep 300
+cmd:sleep 360
 cmd:xdsh $$CN uptime
 check:rc==0
 check:output=~up


### PR DESCRIPTION
Testcase `reg_linux_diskfull_installation_hierarchy` fails sometimes:
```
50/xcattest.log.20220419055406:------END::reg_linux_diskfull_installation_hierarchy::Passed::Time:Tue Apr 19 08:02:53 2022 ::Duration::2091 sec------
51/xcattest.log.20220420070515:------END::reg_linux_diskfull_installation_hierarchy::Passed::Time:Wed Apr 20 09:09:53 2022 ::Duration::2561 sec------
52/xcattest.log.20220421070032:------END::reg_linux_diskfull_installation_hierarchy::Passed::Time:Thu Apr 21 09:02:16 2022 ::Duration::2560 sec------
53/xcattest.log.20220422070952:------END::reg_linux_diskfull_installation_hierarchy::Passed::Time:Fri Apr 22 08:48:36 2022 ::Duration::1857 sec------
54/xcattest.log.20220425070320:------END::reg_linux_diskfull_installation_hierarchy::Passed::Time:Mon Apr 25 09:04:13 2022 ::Duration::2073 sec------
5/xcattest.log.20220223091021:------END::reg_linux_diskfull_installation_hierarchy::Failed::Time:Wed Feb 23 12:10:41 2022 ::Duration::8085 sec------
6/xcattest.log.20220224070022:------END::reg_linux_diskfull_installation_hierarchy::Failed::Time:Thu Feb 24 09:53:59 2022 ::Duration::8002 sec------
7/xcattest.log.20220225070430:------END::reg_linux_diskfull_installation_hierarchy::Failed::Time:Fri Feb 25 12:46:18 2022 ::Duration::8000 sec------
8/xcattest.log.20220225142527:------END::reg_linux_diskfull_installation_hierarchy::Failed::Time:Fri Feb 25 17:40:55 2022 ::Duration::8040 sec------
```

Checking the `uptime` from `Passed` testcases it appears that 5 min might not be enough:
```
RUN:xdsh c910f04x35v04 uptime [Mon Apr 25 09:04:12 2022]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f04x35v04:  09:21:21  up   0:00,  0 users,  load average: 0.59, 0.15, 0.05
CHECK:rc == 0   [Pass]
CHECK:output =~ up      [Pass]
```