### PR TITLE
Fixed failing `gettab_err` and `rpower_off` testcases after enhanced xcattest syntax checking was enabled

### DIFF
--- a/xCAT-test/autotest/testcase/gettab/cases0
+++ b/xCAT-test/autotest/testcase/gettab/cases0
@@ -18,16 +18,17 @@ check:output=~site.value:
 end
 
 start:gettab_err
-description:gettab with error symble ,error key ,error attr.
+description:gettab with invalid option, invalid key, and invalid attribute
 label:mn_only,ci_test,db
 cmd:gettab -c
 check:rc!=0
 check:output=~Usage
 cmd:gettab -H groups=master site.key
 check:rc!=0
+check:output=~Error:
 cmd:gettab -H key=master site.groups
 check:rc==0
-check:output==site.groups:
+check:output=~^$
 end
 
 

--- a/xCAT-test/autotest/testcase/rpower/cases0
+++ b/xCAT-test/autotest/testcase/rpower/cases0
@@ -4,7 +4,8 @@ Attribute: $$CN-The operation object of rpower command
 label:cn_bmc_ready,hctrl_general
 cmd:rpower $$CN on
 cmd:a=0;while ! `rpower $$CN stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
-check:ouptut=~Running|on
+cmd:rpower $$CN stat
+check:output=~Running|on
 cmd:rpower $$CN off
 check:rc==0
 cmd:a=0;while ! `rpower $$CN stat|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done


### PR DESCRIPTION
This PR contains several fixes related to #7110.

### After enabling stricter `xcattest` syntax checking, the `gettab_err` testcase is now failing.
Before fix:
```
[root@f6u13k19 autotest]# xcattest -f default.conf -t gettab_err
...
------START::gettab_err::Time:Tue Apr 26 08:51:59 2022------

RUN:gettab -c [Tue Apr 26 08:51:59 2022]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Usage: gettab [-H|--with-fieldname] key=value,...  table.attribute ...
       gettab [-?|-h|--help]
CHECK:rc != 0	[Pass]
CHECK:output =~ Usage	[Pass]
 
RUN:gettab -H groups=master site.key [Tue Apr 26 08:51:59 2022]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Error: [f6u13k19]: Unkown key groups to site
CHECK:rc != 0	[Pass]
 
RUN:gettab -H key=master site.groups [Tue Apr 26 08:51:59 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]
CHECK:output == site.groups:	[Failed]
 
------END::gettab_err::Failed::Time:Tue Apr 26 08:51:59 2022 ::Duration::0 sec------
------Total: 1 , Failed: 1------
```
The test is failing because `gettab` with an invalid attribute returns no output, but
the test expects it to return output containing a label for the invalid attribute: "site.groups:".

I made some enhancements to the testcase and replaced the failing check:
```
check:output==site.groups:
```
with a check that expects no output to be returned:
```
check:output=~^$
```
when running:
```
gettab -H key=master site.groups 
```

After fix:
```
[root@f6u13k19 autotest]# xcattest -f default.conf -t gettab_err
...

------START::gettab_err::Time:Tue Apr 26 09:09:02 2022------

RUN:gettab -c [Tue Apr 26 09:09:02 2022]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Usage: gettab [-H|--with-fieldname] key=value,...  table.attribute ...
       gettab [-?|-h|--help]
CHECK:rc != 0	[Pass]
CHECK:output =~ Usage	[Pass]
 
RUN:gettab -H groups=master site.key [Tue Apr 26 09:09:02 2022]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: [f6u13k19]: Unkown key groups to site
CHECK:rc != 0	[Pass]
CHECK:output =~ Error:	[Pass]
 
RUN:gettab -H key=master site.groups [Tue Apr 26 09:09:03 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]
CHECK:output =~ ^$	[Pass]
 
------END::gettab_err::Passed::Time:Tue Apr 26 09:09:03 2022 ::Duration::1 sec------
------Total: 1 , Failed: 0------
```

### After enabling stricter `xcattest` syntax checking, the `rpower_off` testcase is now failing.
Before fix:
```
[root@f6u13k19 autotest]# xcattest -f default.conf -t rpower_off
------START::rpower_off::Time:Tue Apr 26 09:44:56 2022------

RUN:rpower f6u13k21 on [Tue Apr 26 09:44:56 2022]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u13k21: on
 
RUN:a=0;while ! `rpower f6u13k21 stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done [Tue Apr 26 09:44:57 2022]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Unrecognized testcase syntax: CHECK:ouptut=~Running|on	[Failed]
 
RUN:rpower f6u13k21 off [Tue Apr 26 09:44:58 2022]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u13k21: off
 
RUN:a=0;while ! `rpower f6u13k21 stat|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done [Tue Apr 26 09:44:59 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
 
RUN:rpower f6u13k21 stat [Tue Apr 26 09:44:59 2022]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u13k21: off
 
------END::rpower_off::Failed::Time:Tue Apr 26 09:45:00 2022 ::Duration::4 sec------
------Total: 1 , Failed: 1------
```

Problem was due to incorrect check output syntax and missing call to `rpower stat`:
```
check:ouptut=~Running|on
```
fix was to change the check to:
```
cmd:rpower $$CN stat
check:output=~Running|on
```

After fix:
```
[root@f6u13k19 autotest]# xcattest -f default.conf -t rpower_off

------START::rpower_off::Time:Tue Apr 26 09:52:36 2022------

RUN:rpower f6u13k21 on [Tue Apr 26 09:52:36 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
f6u13k21: on
 
RUN:a=0;while ! `rpower f6u13k21 stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done [Tue Apr 26 09:52:36 2022]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
 
RUN:rpower f6u13k21 stat [Tue Apr 26 09:52:37 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
f6u13k21: on
CHECK:output =~ Running|on	[Pass]
 
RUN:rpower f6u13k21 off [Tue Apr 26 09:52:37 2022]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
f6u13k21: off
CHECK:rc == 0	[Pass]
 
RUN:a=0;while ! `rpower f6u13k21 stat|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done [Tue Apr 26 09:52:38 2022]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
 
RUN:rpower f6u13k21 stat [Tue Apr 26 09:52:39 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
f6u13k21: off
CHECK:output =~ Not Activated|off	[Pass]
 
------END::rpower_off::Passed::Time:Tue Apr 26 09:52:39 2022 ::Duration::3 sec------
------Total: 1 , Failed: 0------
```