### PR TITLE
Speedup statelite testcase execution

### DIFF
--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_nfs
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_nfs
@@ -80,7 +80,7 @@ check:rc==0
 check:output=~$$SN: done
 check:output!~write failed
 
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute 1
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 
@@ -92,6 +92,7 @@ check:output=~64 bytes from $$CN
 cmd:lsdef -l $$CN | grep status
 check:rc==0
 check:output=~booted
+cmd:cat /var/log/consoles/$$CN.log
 cmd:xdsh $$CN date
 check:rc==0
 check:output=~\d\d:\d\d:\d\d

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_ramdisk
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_ramdisk
@@ -73,7 +73,7 @@ check:rc==0
 check:output=~$$SN: done
 check:output!~write failed
 
-cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute
+cmd:/opt/xcat/share/xcat/tools/autotest/testcase/commoncmd/retry_install.sh  $$CN __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute 1
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 
@@ -85,6 +85,7 @@ check:output=~64 bytes from $$CN
 cmd:lsdef -l $$CN | grep status
 check:rc==0
 check:output=~booted
+cmd:cat /var/log/consoles/$$CN.log
 cmd:xdsh $$CN date
 check:rc==0
 check:output=~\d\d:\d\d:\d\d


### PR DESCRIPTION
Temporarily make statelite testcases run faster while debugging failure of  `reg_linux_statelite_installation_hierarchy_by_nfs` on SLES15.3:
* Only do `retry_install` one time
* Display console log file