### PR TITLE
Fixed testcase check:output typos

### DIFF
--- a/xCAT-test/autotest/testcase/addkit/cases0
+++ b/xCAT-test/autotest/testcase/addkit/cases0
@@ -12,7 +12,7 @@ label:others,KIT
 cmd:addkit -h
 check:rc==0
 check:output=~Usage
-check:outpur!~error
+check:output!~error
 end
 
 start:addkit_kit

--- a/xCAT-test/autotest/testcase/chkkitcomp/cases0
+++ b/xCAT-test/autotest/testcase/chkkitcomp/cases0
@@ -12,7 +12,7 @@ label:others,KIT
 cmd:addkit -h
 check:rc==0
 check:output=~Usage
-check:outpur!~error
+check:output!~error
 end
 
 start:chkkitcomp_V

--- a/xCAT-test/autotest/testcase/dockercommand/cases0
+++ b/xCAT-test/autotest/testcase/dockercommand/cases0
@@ -9,9 +9,9 @@ cmd:mkdocker  $$DOCKERCN image=$$DOCKERIMAGE command=$$DOCKERCOMMAND dockerflag=
 check:rc==0
 cmd:rpower $$DOCKERCN stop
 check:rc==0
-check:ouptut=~container already stopped
+check:output=~container already stopped
 cmd:rpower $$DOCKERCN restart
-check:ouptut=~success
+check:output=~success
 cmd:rpower $$DOCKERCN state
 check:rc==0
 check:output=~running
@@ -156,7 +156,7 @@ check:rc==0
 cmd:rpower $$DOCKERCN start
 check:rc==0
 cmd:rpower $$DOCKERCN pause
-check:ouptut=~paused
+check:output=~paused
 cmd:rpower $$DOCKERCN unpause
 check:rc==0
 check:output=~success

--- a/xCAT-test/autotest/testcase/lsvm/cases0
+++ b/xCAT-test/autotest/testcase/lsvm/cases0
@@ -33,7 +33,7 @@ description:lsvm -a/--all could work as design, to display all the information f
 label:others,hctrl_kvm
 cmd:rpower $$CN on
 cmd:a=0;while ! `rpower $$CN stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
-check:ouptut=~Running|on
+check:output=~Running|on
 cmd:lsvm $$CN
 check:rc==0 
 check:output=~$$CN: Id:\s*\w+
@@ -69,11 +69,11 @@ label:others,hctrl_kvm
 cmd:rpower $$CN on
 cmd:a=0;while ! `rpower $$CN stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$CN stat
-check:ouptut=~Running|on
+check:output=~Running|on
 cmd:rpower $$SN on
 cmd:a=0;while ! `rpower $$SN stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$SN stat
-check:ouptut=~Running|on
+check:output=~Running|on
 cmd:lsvm $$CN,$$SN
 check:rc==0
 check:output=~$$CN: Id:\s*\w+
@@ -113,11 +113,11 @@ label:others,hctrl_kvm
 cmd:rpower $$CN off
 cmd:a=0;while ! `rpower $$CN stat|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$CN stat
-check:ouptut=~Not Activated|off
+check:output=~Not Activated|off
 cmd:rpower $$SN on
 cmd:a=0;while ! `rpower $$SN stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
 cmd:rpower $$SN stat
-check:ouptut=~Running|on
+check:output=~Running|on
 cmd:lsvm $$CN,$$SN
 check:output=~$$SN: Id:\s*\w+
 check:output=~$$SN: Host:\s*\w+

--- a/xCAT-test/autotest/testcase/pdu/case0
+++ b/xCAT-test/autotest/testcase/pdu/case0
@@ -190,6 +190,6 @@ check:output=~Error
 cmd:oldpdu=`cat /tmp/pduvalue`;chdef $$CN pdu=$oldpdu
 cmd:rpower $$CN pduof
 check:rc!=0
-check:outpu=~Unsupported command
+check:output=~Unsupported command
 cmd:rmdef $$PDU
 end

--- a/xCAT-test/autotest/testcase/rpower/cases0
+++ b/xCAT-test/autotest/testcase/rpower/cases0
@@ -144,7 +144,7 @@ Attribute: $$CN-The operation object of rpower command
 label:cn_bmc_ready,hctrl_fsp,hctrl_openbmc
 cmd:rpower $$CN on
 cmd:a=0;while ! `rpower $$CN stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
-check:ouptut=~Running|on
+check:output=~Running|on
 cmd:rpower $$CN softoff
 check:rc==0
 cmd:a=0;while ! `rpower $$CN stat|grep "Not Activated\|off" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
@@ -164,7 +164,7 @@ cmd:rpower $$CN stat
 check:output=~Not Activated|off
 cmd:rpower $$CN onstandby
 cmd:a=0;while ! `rpower $$CN stat|grep "standby\|Standby" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
-check:ouptut=~standby|Standby
+check:output=~standby|Standby
 end
 
 start:rpower_wrongpasswd

--- a/xCAT-test/autotest/testcase/rpower/cases0
+++ b/xCAT-test/autotest/testcase/rpower/cases0
@@ -144,6 +144,7 @@ Attribute: $$CN-The operation object of rpower command
 label:cn_bmc_ready,hctrl_fsp,hctrl_openbmc
 cmd:rpower $$CN on
 cmd:a=0;while ! `rpower $$CN stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done
+cmd:rpower $$CN stat
 check:output=~Running|on
 cmd:rpower $$CN softoff
 check:rc==0

--- a/xCAT-test/autotest/testcase/xcat_inventory/cases.common
+++ b/xCAT-test/autotest/testcase/xcat_inventory/cases.common
@@ -2,17 +2,17 @@ start:xcat_inventory_option_h
 description:This case is used to test xcat-inventory usage information
 label:others,inventory_ci
 cmd:xcat-inventory -h
-check:ouptut=~usage: xcat-inventory
-check:ouptut!~usage: xcat-inventory export
-check:ouptut!~usage: xcat-inventory import
+check:output=~usage: xcat-inventory
+check:output!~usage: xcat-inventory export
+check:output!~usage: xcat-inventory import
 check:rc==0
 cmd:xcat-inventory help
-check:ouptut=~usage: xcat-inventory
-check:ouptut!~usage: xcat-inventory export
-check:ouptut!~usage: xcat-inventory import
+check:output=~usage: xcat-inventory
+check:output!~usage: xcat-inventory export
+check:output!~usage: xcat-inventory import
 check:rc==0
 cmd:xcat-inventory help export
-check:ouptut=~usage: xcat-inventory export
+check:output=~usage: xcat-inventory export
 check:rc==0
 cmd:xcat-inventory help import
 check:output=~usage: xcat-inventory import
@@ -27,7 +27,7 @@ start:xcat_inventory_option_V
 description:This case is used to test xcat-inventory option V which used to get version information
 label:others,inventory_ci
 cmd:xcat-inventory -V
-check:ouptut=~\d\.\d
+check:output=~\d\.\d
 check:rc==0
 end
 


### PR DESCRIPTION
This PR contains additional improvements related to #7110.

I did some additional searching and identified the following additional typos:
```
grep -R "check:o" . | egrep -v "check:rc|check:output"
./rpower/cases0:check:ouptut=~Running|on
./rpower/cases0:check:ouptut=~standby|Standby
./pdu/case0:check:outpu=~Unsupported command
./chkkitcomp/cases0:check:outpur!~error
./xcat_inventory/cases.common:check:ouptut=~usage: xcat-inventory
./xcat_inventory/cases.common:check:ouptut!~usage: xcat-inventory export
./xcat_inventory/cases.common:check:ouptut!~usage: xcat-inventory import
./xcat_inventory/cases.common:check:ouptut=~usage: xcat-inventory
./xcat_inventory/cases.common:check:ouptut!~usage: xcat-inventory export
./xcat_inventory/cases.common:check:ouptut!~usage: xcat-inventory import
./xcat_inventory/cases.common:check:ouptut=~usage: xcat-inventory export
./xcat_inventory/cases.common:check:ouptut=~\d\.\d
./addkit/cases0:check:outpur!~error
./dockercommand/cases0:check:ouptut=~container already stopped
./dockercommand/cases0:check:ouptut=~success
./dockercommand/cases0:check:ouptut=~paused
./lsvm/cases0:check:ouptut=~Running|on
./lsvm/cases0:check:ouptut=~Running|on
./lsvm/cases0:check:ouptut=~Running|on
./lsvm/cases0:check:ouptut=~Not Activated|off
./lsvm/cases0:check:ouptut=~Running|on
```

This PR corrects the syntax for all of the `check:output` calls above.

Example from before the syntax fix:
```
xcattest -f default.conf -t rpower_softoff
...
RUN:a=0;while ! `rpower f6u13k21 stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done [Wed Apr 27 16:34:11 2022]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Unrecognized testcase syntax: CHECK:ouptut=~Running|on	[Failed]
...
``` 

Example after the syntax fix:
```
xcattest -f default.conf -t rpower_softoff
...
RUN:a=0;while ! `rpower f6u13k21 stat|grep "Running\|on" >/dev/null`; do sleep 5;((a++));if [ $a -gt 11 ];then break;fi done [Wed Apr 27 16:57:13 2022]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
 
RUN:rpower f6u13k21 stat [Wed Apr 27 16:57:14 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
f6u13k21: on
CHECK:output =~ Running|on	[Pass]
...
```