### PR TITLE
More time needed for ol7 to reboot

### DIFF
--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_hierarchy
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_hierarchy
@@ -109,7 +109,7 @@ check:rc==0
 
 # Check node can be rebooted from disk
 cmd:xdsh $$CN shutdown -r now
-cmd:sleep 360
+cmd:sleep 420
 cmd:xdsh $$CN uptime
 check:rc==0
 check:output=~up

--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_hierarchy
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_hierarchy
@@ -109,7 +109,10 @@ check:rc==0
 
 # Check node can be rebooted from disk
 cmd:xdsh $$CN shutdown -r now
-cmd:sleep 420
+
+# Wait for node to reboot (10sec x 60)
+cmd:a=0;while ! `xdsh $$CN -t 5 uptime 2>&1 | grep up >/dev/null`; do sleep 10;((a++));if [ $a -gt 60 ];then break;fi done
+
 cmd:xdsh $$CN uptime
 check:rc==0
 check:output=~up


### PR DESCRIPTION
Time added by https://github.com/xcat2/xcat-core/pull/7152 was not enough for OL7.9 to reboot

Currently we `shutdown -r`, then wait 360 seconds and try to `xdsh`. Connection gets refused.

```
RUN:sleep 360 [Thu Apr 28 04:28:17 2022]
ElapsedTime:360 sec
RETURN rc = 0
OUTPUT:
 
RUN:xdsh c910f04x37v10 uptime [Thu Apr 28 04:34:17 2022]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
[c910f04x37v09]: c910f04x37v10: ssh: connect to host c910f04x37v10 port 22: Connection refused

CHECK:rc == 0	[Failed]
```

But then in the next testcase, 16 seconds later, the `xdsh` works again:
```
RUN:xdsh c910f04x37v10 "rm /tmp/updatenode_P_script" [Thu Apr 28 04:34:33 2022]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
[c910f04x37v09]: c910f04x37v10: rm: cannot remove '/tmp/updatenode_P_script': No such file or directory
```

This RP adds another 60 seconds of wait time for the node to reboot.