### PR TITLE
Provide an error message when a new node name is an existing group name

### DIFF
--- a/perl-xCAT/xCAT/NodeRange.pm
+++ b/perl-xCAT/xCAT/NodeRange.pm
@@ -295,8 +295,8 @@ sub expandatom {
                 for my $row (@grplist) {
                     if ($row->{groupname} eq $atom) {
                         my $rsp;
-                        $rsp->{data}->[0] = "$atom is a defined group name, so Node $atom is not created.";
-                        xCAT::MsgUtils->message("E", $rsp, $::callback);
+                        $rsp->{data}->[0] = "Could not create an object named \'$atom\' of type 'node'. A definition for a group object with the same name already exists.";
+                        xCAT::MsgUtils->message("W", $rsp, $::callback);
                         return ();
                     }
                 }

--- a/perl-xCAT/xCAT/NodeRange.pm
+++ b/perl-xCAT/xCAT/NodeRange.pm
@@ -4,6 +4,7 @@ use Text::Balanced qw/extract_bracketed/;
 require xCAT::Table;
 require Exporter;
 use strict;
+use xCAT::MsgUtils;
 
 #Perl implementation of noderange
 our @ISA       = qw(Exporter);
@@ -293,6 +294,9 @@ sub expandatom {
                     #my @grouplist = $grptab->getAllAttribs('groupname');
                 for my $row (@grplist) {
                     if ($row->{groupname} eq $atom) {
+                        my $rsp;
+                        $rsp->{data}->[0] = "$atom is a defined group name, so Node $atom is not created.";
+                        xCAT::MsgUtils->message("E", $rsp, $::callback);
                         return ();
                     }
                 }

--- a/perl-xCAT/xCAT/NodeRange.pm
+++ b/perl-xCAT/xCAT/NodeRange.pm
@@ -296,7 +296,7 @@ sub expandatom {
                     if ($row->{groupname} eq $atom) {
                         my $rsp;
                         $rsp->{data}->[0] = "Could not create an object named \'$atom\' of type 'node'. A definition for a group object with the same name already exists.";
-                        xCAT::MsgUtils->message("W", $rsp, $::callback);
+                        xCAT::MsgUtils->message("E", $rsp, $::callback);
                         return ();
                     }
                 }

--- a/xCAT-test/autotest/bundle/rhels_ppcle_daily.bundle
+++ b/xCAT-test/autotest/bundle/rhels_ppcle_daily.bundle
@@ -151,6 +151,7 @@ mkdef_regex_nicsip
 mkdef_rhels73
 mkdef_t_o_error
 mkdef_z
+mkdef_nodename_hit_groupname
 nodeadd_err_symbol
 nodeadd_h
 nodeadd_noderange

--- a/xCAT-test/autotest/bundle/rhels_x86_daily.bundle
+++ b/xCAT-test/autotest/bundle/rhels_x86_daily.bundle
@@ -151,6 +151,7 @@ mkdef_regex_nicsip
 mkdef_rhels73
 mkdef_t_o_error
 mkdef_z
+mkdef_nodename_hit_groupname
 nodeadd_err_symbol
 nodeadd_h
 nodeadd_noderange

--- a/xCAT-test/autotest/bundle/sles_ppcle_daily.bundle
+++ b/xCAT-test/autotest/bundle/sles_ppcle_daily.bundle
@@ -110,6 +110,7 @@ mkdef_regex_kvm
 mkdef_regex_nicsip
 mkdef_t_o_error
 mkdef_z
+mkdef_nodename_hit_groupname
 nodeadd_err_symbol
 nodeadd_h
 nodeadd_noderange

--- a/xCAT-test/autotest/bundle/sles_x86_daily.bundle
+++ b/xCAT-test/autotest/bundle/sles_x86_daily.bundle
@@ -110,6 +110,7 @@ mkdef_regex_kvm
 mkdef_regex_nicsip
 mkdef_t_o_error
 mkdef_z
+mkdef_nodename_hit_groupname
 nodeadd_err_symbol
 nodeadd_h
 nodeadd_noderange

--- a/xCAT-test/autotest/bundle/ubuntu_ppcle_daily.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu_ppcle_daily.bundle
@@ -79,6 +79,7 @@ mkdef_regex_kvm
 mkdef_regex_nicsip
 mkdef_t_o_error
 mkdef_z
+mkdef_nodename_hit_groupname
 nodeadd_err_symbol
 nodeadd_h
 nodeadd_noderange

--- a/xCAT-test/autotest/bundle/ubuntu_x86_daily.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu_x86_daily.bundle
@@ -81,6 +81,7 @@ mkdef_regex_kvm
 mkdef_regex_nicsip
 mkdef_t_o_error
 mkdef_z
+mkdef_nodename_hit_groupname
 nodeadd_err_symbol
 nodeadd_h
 nodeadd_noderange

--- a/xCAT-test/autotest/testcase/mkdef/cases1
+++ b/xCAT-test/autotest/testcase/mkdef/cases1
@@ -162,8 +162,7 @@ cmd:mkdef -t node -o tempgroup13579 groups=all
 check:rc==1
 check:output=~A definition for a group object with the same name already exists.
 check:output=~No object names were provided
-#cmd:mkdef -t node -o tempnode02468,tempgroup13579 groups=tempgroup13579
-cmd:mkdef -t node -o tempgroup13579,tempnode02468 groups=tempgroup13579
+cmd:mkdef -t node -o tempnode02468,tempgroup13579 groups=tempgroup13579
 check:rc==0
 check:output=~A definition for a group object with the same name already exists.
 check:output=~1 object definitions have been created

--- a/xCAT-test/autotest/testcase/mkdef/cases1
+++ b/xCAT-test/autotest/testcase/mkdef/cases1
@@ -150,3 +150,20 @@ check:rc==0
 cmd:rmdef -t group -o xcattest_tmp_group_regex
 check:rc==0
 end
+
+start:mkdef_nodename_hit_groupname
+cmd:mkdef -t group -o tempgroup13579
+check:rc==0
+cmd:mkdef -t node -o tempgroup13579 groups=tempgroup13579
+check:rc==1
+check:output=~a defined group name
+check:output=~No object names were provided
+cmd:mkdef -t node -o tempnode02468,tempgroup13579 groups=tempgroup13579
+check:rc==1
+check:output=~a defined group name
+check:output=~1 object definitions have been created
+cmd:rmdef -t node -o tempnode02468
+check:rc==0
+cmd:rmdef -t group -o tempgroup13579
+check:rc==0
+end

--- a/xCAT-test/autotest/testcase/mkdef/cases1
+++ b/xCAT-test/autotest/testcase/mkdef/cases1
@@ -156,11 +156,16 @@ cmd:mkdef -t group -o tempgroup13579
 check:rc==0
 cmd:mkdef -t node -o tempgroup13579 groups=tempgroup13579
 check:rc==1
-check:output=~a defined group name
+check:output=~A definition for a group object with the same name already exists.
 check:output=~No object names were provided
-cmd:mkdef -t node -o tempnode02468,tempgroup13579 groups=tempgroup13579
+cmd:mkdef -t node -o tempgroup13579 groups=all
 check:rc==1
-check:output=~a defined group name
+check:output=~A definition for a group object with the same name already exists.
+check:output=~No object names were provided
+#cmd:mkdef -t node -o tempnode02468,tempgroup13579 groups=tempgroup13579
+cmd:mkdef -t node -o tempgroup13579,tempnode02468 groups=tempgroup13579
+check:rc==0
+check:output=~A definition for a group object with the same name already exists.
 check:output=~1 object definitions have been created
 cmd:rmdef -t node -o tempnode02468
 check:rc==0

--- a/xCAT-test/autotest/testcase/mkdef/cases1
+++ b/xCAT-test/autotest/testcase/mkdef/cases1
@@ -163,7 +163,7 @@ check:rc==1
 check:output=~A definition for a group object with the same name already exists.
 check:output=~No object names were provided
 cmd:mkdef -t node -o tempnode02468,tempgroup13579 groups=tempgroup13579
-check:rc==0
+check:rc==1
 check:output=~A definition for a group object with the same name already exists.
 check:output=~1 object definitions have been created
 cmd:rmdef -t node -o tempnode02468


### PR DESCRIPTION
This PR is to fix Issue https://github.com/xcat2/xcat-core/issues/6418.
```
------START::mkdef_nodename_hit_groupname::Time:Fri Apr 29 16:48:58 2022------

RUN:mkdef -t group -o tempgroup13579 [Fri Apr 29 16:48:58 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Warning: [f6u13k04]: Cannot determine a member list for group 'tempgroup13579'.
1 object definitions have been created or modified.
CHECK:rc == 0   [Pass]

RUN:mkdef -t node -o tempgroup13579 groups=tempgroup13579 [Fri Apr 29 16:48:58 2022]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
Error: [f6u13k04]: tempgroup13579 is a defined group name, so Node tempgroup13579 is not created.
Error: [f6u13k04]: No object names were provided.
CHECK:rc == 1   [Pass]
CHECK:output =~ a defined group name    [Pass]
CHECK:output =~ No object names were provided   [Pass]

RUN:mkdef -t node -o tempnode02468,tempgroup13579 groups=tempgroup13579 [Fri Apr 29 16:48:59 2022]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Error: [f6u13k04]: tempgroup13579 is a defined group name, so Node tempgroup13579 is not created.
1 object definitions have been created or modified.
CHECK:rc == 1   [Pass]
CHECK:output =~ a defined group name    [Pass]
CHECK:output =~ 1 object definitions have been created  [Pass]

RUN:rmdef -t node -o tempnode02468 [Fri Apr 29 16:48:59 2022]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0   [Pass]

RUN:rmdef -t group -o tempgroup13579 [Fri Apr 29 16:49:00 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0   [Pass]

------END::mkdef_nodename_hit_groupname::Passed::Time:Fri Apr 29 16:49:00 2022 ::Duration::2 sec------
```