### PR TITLE
Improve nodeset_shell testcase

### DIFF
--- a/xCAT-test/autotest/testcase/genesis/genesistest.pl
+++ b/xCAT-test/autotest/testcase/genesis/genesistest.pl
@@ -288,15 +288,13 @@ sub testxdsh {
     if (($value == 1) || ($value == 2) || ($value == 3)) {
         `$xdsh_command | grep $checkstring`;
         if ($?) {
-            # First attempt to run xdsh failed, display console log to see what happened, then try few more times
-            my $console_log = `nodels $noderange | xargs -I % tail -v --lines 25 /var/log/consoles/%.log`;
-            send_msg(2, "Console log: $console_log \n");
+            # First attempt to run xdsh failed, then try few more times
             my @i = (1..3);
             for (@i) {
                 $xdsh_out=`$xdsh_command`;
                 $nodestatus=`lsdef $noderange -i status -c  2>&1 | awk -F'=' '{print \$2}'`;
-                send_msg(1,"[$_] \"$xdsh_command\" returned: $xdsh_out. Node status: $nodestatus");
-                sleep 180;
+                send_msg(2,"[$_] Command \"$xdsh_command\" looking for $checkstring returned:\n $xdsh_out.\n Node status: $nodestatus");
+                sleep 10;
                 `$xdsh_command | grep $checkstring`;
                 last if ($? == 0);
             }
@@ -344,6 +342,7 @@ sub clearenv {
     `cat $nodestanza | chdef -z`;
     unlink("$nodestanza");
     }
+    sleep 120; # wait 2 min for reboot to finish
     return 0;
 }
 ####################################


### PR DESCRIPTION
`nodeset_shell` testcase runs weekly and often fails on P8VM RHEL8.5

Running `nodeset_shell` testcase manually, by itself does not fail, but often fails when running in combination with `nodeset_cmdline` and `nodeset_runimg`. Each of these testcases boots into genesis, verifies a few things and then does a "cleanup" by removing some files and rebooting the node from hard disk. Currently there is no wait after rebooting the node from hard disk and before trying to run the next testcase.
My current theory, is that `nodeset_shell` testcase starts running before the "cleanup" from the previous `nodeset_runimg` testcase has a chance to reboot the node from hard disk.

This PR adds a wait time of 2 min after "cleanup" before running the next testcase. Also a few minor message enhancements added and a delay between retrying `xdsh` command is shortened.