### PR TITLE
SLES15.3 statelite support

### DIFF
--- a/xCAT-server/share/xcat/netboot/add-on/statelite/rc.statelite
+++ b/xCAT-server/share/xcat/netboot/add-on/statelite/rc.statelite
@@ -167,8 +167,11 @@ ResolveLinks () {
     i=0
     while read type path
     do
-        ELIST[$i]="$type $path";
-        i=$[ $i+1 ];
+        if [ -n "$path" ]; then
+            # Only add non empty entries
+            ELIST[$i]="$type $path";
+            i=$[ $i+1 ];
+        fi
     done
 
     num=${#ELIST[@]}

--- a/xCAT-server/share/xcat/netboot/sles/dracut_033/xcat-prepivot.sh
+++ b/xCAT-server/share/xcat/netboot/sles/dracut_033/xcat-prepivot.sh
@@ -120,6 +120,11 @@ if [ ! -z $SNAPSHOTSERVER ]; then
 fi
 
 # TODO: handle the dhclient/resolv.conf/ntp, etc
+
+# On systems with no /bin/bash, create a link to /usr/bin/bash
+if [ ! -e /bin/bash ] && [ -e /usr/bin/bash ]; then
+    ln -s /usr/bin/bash /bin/bash
+fi
 logger $SYSLOGHOST -t $log_label -p local4.info "Enabling localdisk ..."
 echo "Enable localdisk ..."
 $NEWROOT/etc/init.d/localdisk
@@ -153,7 +158,8 @@ function getdevfrommac() {
     done
 }
 
-bootif=$(ls /tmp/net.*.conf|sed -e s/.*net\.// -e s/\.conf//)
+# get boot interface name and generate network/ifcfg-<name> file
+bootif=$(ls /tmp/net.*.up|grep -v ":"|sed -e s/.*net\.// -e s/\.up//)
 cat <<EOF >  $NEWROOT/etc/sysconfig/network/ifcfg-$bootif
 BOOTPROTO='dhcp'
 STARTMODE='auto'

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_nfs
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_nfs
@@ -92,7 +92,6 @@ check:output=~64 bytes from $$CN
 cmd:lsdef -l $$CN | grep status
 check:rc==0
 check:output=~booted
-cmd:cat /var/log/consoles/$$CN.log
 cmd:xdsh $$CN date
 check:rc==0
 check:output=~\d\d:\d\d:\d\d
@@ -107,7 +106,7 @@ cmd:xdsh $$CN  "cat /var/log/xcat/xcat.log"
 cmd:xdsh $$CN "echo "test"> /test.statelite"
 check:rc!=0
 cmd:if [ -x /usr/bin/goconserver ]; then makegocons -d $$CN; else makeconservercf -d $$CN; fi
-cmd:output=$(xdsh $$CN ls -al / |grep test.statelite);if [[ $? -eq 0 ]];then  xdsh $$CN rm -rf /test.tatelite;fi
+cmd:output=$(xdsh $$CN ls -al / |grep test.statelite);if [[ $? -eq 0 ]];then  xdsh $$CN rm -rf /test.statelite;fi
 cmd:rootimgdir=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir ]; then rm -rf $rootimgdir;fi
 check:rc==0
 end

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_ramdisk
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_hierarchy_by_ramdisk
@@ -85,7 +85,6 @@ check:output=~64 bytes from $$CN
 cmd:lsdef -l $$CN | grep status
 check:rc==0
 check:output=~booted
-cmd:cat /var/log/consoles/$$CN.log
 cmd:xdsh $$CN date
 check:rc==0
 check:output=~\d\d:\d\d:\d\d


### PR DESCRIPTION
Currently `reg_linux_statelite_installation_hierarchy_by_nfs` testcase fails, not able to correctly provision statelite x86 SLES15.3 node.
The problem is the `#!/bin/bash` and other references to `/bin/bash`  inside `xCAT-server/share/xcat/netboot/add-on/statelite/rc.statelite`. Rather than changing multiple references to `/bin/bash`  inside that file, a link is created in `xCAT-server/share/xcat/netboot/sles/dracut_033/xcat-prepivot.sh`, which calls `rc.statelite`. Same idea as #7128 which was needed for diskfull.

Additionally this PR cleans up the `ELIST` which gets generated from the entries stored in:
```
c910f04x35v02:/etc # tabdump litefile
#image,file,options,comments,disable
"ALL","/etc/adjtime","tmpfs",,
"ALL","/etc/fstab","tmpfs",,
"ALL","/etc/hostname","tmpfs",,
"ALL","/etc/init.d/rc3.d/","tmpfs",,
"ALL","/etc/init.d/rc5.d/","tmpfs",,
"ALL","/etc/inittab","tmpfs",,
"ALL","/etc/lvm/","tmpfs",,
"ALL","/etc/ntp.conf","tmpfs",,
"ALL","/etc/ntp.conf.org","tmpfs",,
"ALL","/etc/resolv.conf","tmpfs",,
"ALL","/etc/ssh/","tmpfs",,
"ALL","/etc/sysconfig/","tmpfs",,
"ALL","/etc/syslog-ng/","tmpfs",,
"ALL","/etc/systemd/system/","tmpfs",,
"ALL","/etc/yp.conf","tmpfs",,
"ALL","/opt/xcat/","tmpfs",,
"ALL","/root/.ssh/","tmpfs",,
"ALL","/tmp/","tmpfs",,
"ALL","/var/","tmpfs",,
"ALL","/xcatpost/","tmpfs",,
c910f04x35v02:/etc #
```
The list contains blank line entries, which later get used and cause these errors on the console:
```
:
:
/usr/bin/dirname: missing operand
Try '/usr/bin/dirname --help' for more information.
/usr/bin/dirname: missing operand
Try '/usr/bin/dirname --help' for more information.
/usr/bin/dirname: missing operand
Try '/usr/bin/dirname --help' for more information.
/usr/bin/dirname: missing operand
Try '/usr/bin/dirname --help' for more information.
:
:
```

### UT:
```
c910f04x35v04:~ # hostnamectl
   Static hostname: c910f04x35v04
         Icon name: computer-vm
           Chassis: vm
        Machine ID: 16ad4e3b7bcbec1188f542a30a042304
           Boot ID: 457fdcc54a244bc588aeca5ae870c384
    Virtualization: kvm
  Operating System: SUSE Linux Enterprise Server 15 SP3
       CPE OS Name: cpe:/o:suse:sles:15:sp3
            Kernel: Linux 5.3.18-57-default
      Architecture: x86-64
c910f04x35v04:~ #

c910f04x35v04:~ # mount | grep "^rw on"
rw on /.statelite type tmpfs (rw,relatime)
rw on /.sllocal/log type tmpfs (rw,relatime)
rw on /etc/adjtime type tmpfs (rw,relatime)
rw on /etc/fstab type tmpfs (rw,relatime)
rw on /etc/hostname type tmpfs (rw,relatime)
rw on /etc/init.d/rc3.d type tmpfs (rw,relatime)
rw on /etc/init.d/rc5.d type tmpfs (rw,relatime)
rw on /etc/inittab type tmpfs (rw,relatime)
rw on /etc/lvm type tmpfs (rw,relatime)
rw on /etc/ntp.conf type tmpfs (rw,relatime)
rw on /etc/ntp.conf.org type tmpfs (rw,relatime)
rw on /etc/resolv.conf type tmpfs (rw,relatime)
rw on /etc/ssh type tmpfs (rw,relatime)
rw on /etc/sysconfig type tmpfs (rw,relatime)
rw on /etc/syslog-ng type tmpfs (rw,relatime)
rw on /etc/systemd/system type tmpfs (rw,relatime)
rw on /opt/xcat type tmpfs (rw,relatime)
rw on /root/.ssh type tmpfs (rw,relatime)
rw on /tmp type tmpfs (rw,relatime)
rw on /var type tmpfs (rw,relatime)
rw on /xcatpost type tmpfs (rw,relatime)
c910f04x35v04:~ #
```