### PR TITLE
Added missing curly bracket to xcatconfig

### DIFF
--- a/xCAT-server/sbin/xcatconfig
+++ b/xCAT-server/sbin/xcatconfig
@@ -1011,6 +1011,7 @@ sub genSSHNodeHostKey
 	else{
             push @sshkeylist,"/etc/xcat/hostkeys/ssh_host_ecdsa_key";
 	}
+    }
 
     # see if this system supports the ed25519
     xCAT::Utils->runcmd('rm -rf /tmp/ed25519_key >/dev/null 2>&1 ; /usr/bin/ssh-keygen -t ed25519 -f /tmp/ed25519_key  -P "" &>/dev/null', 0);


### PR DESCRIPTION
@khm FYI

The following error was encountered after merging #7136:
```
  Installing       : xCAT-2.16.4-snap202205060017.ppc64le               132/133 
  Running scriptlet: xCAT-2.16.4-snap202205060017.ppc64le               132/133 
Missing right curly or square bracket at /opt/xcat/sbin/xcatconfig line 2411, at end of line
syntax error at /opt/xcat/sbin/xcatconfig line 2411, at EOF
Execution of /opt/xcat/sbin/xcatconfig aborted due to compilation errors.
```
Root cause is a missing `}`.

Unit test before:
```
[root@f6u13k16 ~]# xcatconfig -i
Missing right curly or square bracket at /opt/xcat/sbin/xcatconfig line 2411, at end of line
syntax error at /opt/xcat/sbin/xcatconfig line 2411, at EOF
Execution of /opt/xcat/sbin/xcatconfig aborted due to compilation errors.
```

Unit test after:
```
[root@f6u13k16 ~]# xcatconfig -i
Generating new node hostkeys...
Generating SSH2 RSA Key...
Generating SSH2 DSA Key...
Generating SSH2 ECDSA Key...
Generating SSH2 ed25519 Key...
Added updates to the /root/.ssh/config file.
...
```
