### PR TITLE
Add the function of custom ipmi port

### DIFF
--- a/perl-xCAT/xCAT/Schema.pm
+++ b/perl-xCAT/xCAT/Schema.pm
@@ -404,12 +404,13 @@ passed as argument rather than by table value',
         },
     },
     ipmi => {
-        cols => [qw(node bmc bmcport taggedvlan bmcid username password comments disable )],
+        cols => [qw(node bmc port bmcport taggedvlan bmcid username password comments disable )],
         keys => [qw(node)],
         table_desc => 'Settings for nodes that are controlled by an on-board BMC via IPMI.',
         descriptions => {
             node => 'The node name or group name.',
             bmc  => 'The hostname of the BMC adapter.',
+	    port  => 'The port of the ipmi traffic (UDP). default is 623',
             bmcport => 'In systems with selectable shared/dedicated ethernet ports, this parameter can be used to specify the preferred port. 0 means use the shared port, 1 means dedicated, blank is to not assign.
 
            The following special cases exist for IBM System x servers:
@@ -2482,6 +2483,11 @@ my @nodeattrs = (
     { attr_name => 'bmc',
         only_if         => 'mgt=ipmi',
         tabentry        => 'ipmi.bmc',
+        access_tabentry => 'ipmi.node=attr:node',
+    },
+    { attr_name => 'port',
+        only_if         => 'mgt=ipmi',
+        tabentry        => 'ipmi.port',
         access_tabentry => 'ipmi.node=attr:node',
     },
     { attr_name => 'bmcport',

--- a/xCAT-server/lib/perl/xCAT/IPMI.pm
+++ b/xCAT-server/lib/perl/xCAT/IPMI.pm
@@ -199,6 +199,10 @@ sub new {
     unless ($args{'port'}) {    #default to port 623 unless specified
         $self->{'port'} = 623;
     }
+    else
+    {
+        $self->{'port'} = $args{'port'} ;
+    }
     unless ($socket) {
         if ($doipv6) {
             $socket = IO::Socket::INET6->new(Proto => 'udp');


### PR DESCRIPTION
### The PR is to implement feature #xxx

_##Feature description##_
When I try to manage virtualbmc+qemu+kvm with rpower command, I need to customize node IPMI UDP port (default is 623). I don't know if there is an easy way to specify the port, so I modified the xCAT code to add the function of customizing the ipmi port. Of course, I only performed a simple test, including getting the status of the node and switching the node power on and off. If you feel this feature is redundant, please decline this request.

### The UT result
`##The UT output##`
