### PR TITLE
In linux_diskless_kdump, search the node file based on the netboot value: grub2 or petitboot

### DIFF
--- a/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
+++ b/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
@@ -62,8 +62,8 @@ cmd:rinstall $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-ne
 check:rc==0
 check:output=~Provision node\(s\)\: $$CN
 
-# Verify kdump related attributes showup in tftpboot file and file was changed
-cmd:if [[ "__GETNODEATTR($$CN,arch)__" = "x86_64" ]]; then cat /tftpboot/xcat/xnba/nodes/$$CN; else cat /tftpboot/boot/grub2/$$CN; fi
+# Verify that the kdump attribute is included in the node file under either /tftpboot/boot/grub2 or /tftpboot/petitboot.
+cmd:if [[ "__GETNODEATTR($$CN,arch)__" = "x86_64" ]]; then cat /tftpboot/xcat/xnba/nodes/$$CN; elif [[ "__GETNODEATTR($$CN,netboot)__" = "grub2" ]]; then cat /tftpboot/boot/grub2/$$CN; elif [[ "__GETNODEATTR($$CN,netboot)__" = "petitboot" ]]; then cat /tftpboot/petitboot/$$CN; fi;
 check:output=~dump
 
 cmd:sleep 300


### PR DESCRIPTION
Currently, the code assumes netboot=grub2 and /tftpboot/boot/grub2/<node file> is to be searched for the word "dump". It works for our KVM regression environment.

For our POWER bare-metal systems, netboot=petitboot, /tftpboot/petitboot/<node file> is to be searched.

In this implementation, grub2 and petitboot are checked explicitly.

This has been tested on a KVM environment and a bare-metal environment.