### PR TITLE
Support xcat-core builds on CentOS8

### DIFF
--- a/buildcore.sh
+++ b/buildcore.sh
@@ -114,14 +114,19 @@ if [ "$OSNAME" != "AIX" ]; then
     GSA=http://pokgsa.ibm.com/projects/x/xcat/build/linux
 
         if [ "$(id -u)" == "0" ]; then
-        # Get a lock, so can not do 2 builds at once
-        exec 8>/var/lock/xcatbld-$REL.lock
-        if ! flock -n 8; then
+            # Some docker containers are missing /var/run/lock to which
+            # /var/lock is linked. Add here if missing.
+            if [ ! -e /var/run/lock ]; then
+                mkdir -p /var/run/lock
+            fi
+            # Get a lock, so can not do 2 builds at once
+            exec 8>/var/lock/xcatbld-$REL.lock
+            if ! flock -n 8; then
                 echo "Can't get lock /var/lock/xcatbld-$REL.lock.  Someone else must be doing a build right now.  Exiting...."
                 exit 1
-        fi
-        # This is so rpm and gpg will know home, even in sudo
-        export HOME=/root
+            fi
+            # This is so rpm and gpg will know home, even in sudo
+            export HOME=/root
         fi
 fi
 


### PR DESCRIPTION
`buildcore.sh` takes a lock on `/var/lock/xcatbld-$REL.lock` file so that 2 builds can not run at the same time.
Normally:
```
[root@c910f04x33@xcat /]# ls -l /var/lock
lrwxrwxrwx 1 root root 11 Apr 18 00:55 /var/lock -> ../run/lock
[root@c910f04x33@xcat /]#
```
Inside CentOS8 build container that link is broken - there is no `/var/run/lock`

This PR fixes formatting of the `if` block and adds `/var/run/lock` is not already there.