### PR TITLE
Support xcat-core builds on CentOS8 (2)

### DIFF
--- a/xCAT-SoftLayer/bin/getslnodes.py
+++ b/xCAT-SoftLayer/bin/getslnodes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Usage: getslnodes.py [-h] [-v] [<hostname-match>]

--- a/xCAT-SoftLayer/bin/softlayer_storage.py
+++ b/xCAT-SoftLayer/bin/softlayer_storage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 """
 Usage:
     softlayer_storage.py --type=<type> [--hostname=<hostname> --username=<username> --password=<password> --mountpoint=<mountpoint> ] (mount | unmount)

--- a/xCAT-SoftLayer/xCAT-SoftLayer.spec
+++ b/xCAT-SoftLayer/xCAT-SoftLayer.spec
@@ -26,10 +26,6 @@ Provides: xCAT-SoftLayer = %{epoch}:%{version}
 %description
 xCAT-SoftLayer provides Utilities to make xCAT work in a SoftLayer environment.  This package should be installed on your management server
 
-# %define VERBOSE %(if [ "$VERBOSE" = "1" -o "$VERBOSE" = "yes" ];then echo 1; else echo 0; fi)
-# %define NOVERBOSE %(if [ "$VERBOSE" = "1" -o "$VERBOSE" = "yes" ];then echo 0; else echo 1; fi)
-# %define NOVERBOSE %{?VERBOSE:1}%{!?VERBOSE:0}
-
 %prep
 # %if %NOVERBOSE
 # echo NOVERBOSE is on

--- a/xCAT-probe/scripts/dbstats.py
+++ b/xCAT-probe/scripts/dbstats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- encoding: utf-8 -*-
 from __future__ import print_function
 import argparse

--- a/xCAT-server/xCAT-server.spec
+++ b/xCAT-server/xCAT-server.spec
@@ -70,10 +70,6 @@ xCAT-server provides the core server and configuration management components of 
 
 %define zvm %(if [ "$zvm" = "1" ];then echo 1; else echo 0; fi)
 
-# %define VERBOSE %(if [ "$VERBOSE" = "1" -o "$VERBOSE" = "yes" ];then echo 1; else echo 0; fi)
-# %define NOVERBOSE %(if [ "$VERBOSE" = "1" -o "$VERBOSE" = "yes" ];then echo 0; else echo 1; fi)
-# %define NOVERBOSE %{?VERBOSE:1}%{!?VERBOSE:0}
-
 %prep
 # %if %NOVERBOSE
 # echo NOVERBOSE is on
@@ -398,8 +394,6 @@ rm -rf $RPM_BUILD_ROOT
 %else
 /etc/init.d/xcatd
 /usr/lib/systemd/system/xcatd.service
-#/etc/%httpconfigdir/conf.orig/xcat-ws.conf.apache24
-#/etc/%httpconfigdir/conf.orig/xcat-ws.conf.apache22
 /etc/apache2/conf.d/xcat-ws.conf
 /etc/httpd/conf.d/xcat-ws.conf
 %endif

--- a/xCAT-server/xCAT-wsapi/xcatws-test.py
+++ b/xCAT-server/xCAT-wsapi/xcatws-test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Usage:
   xcatws_test.py [--xcatmn=<xcatmn>] [--user=<user>] [--password=<password>]
 """

--- a/xCAT-test/autotest/testcase/xcat_inventory/validatehelper
+++ b/xCAT-test/autotest/testcase/xcat_inventory/validatehelper
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 
 import yaml


### PR DESCRIPTION
Continue work of #7169

This PR 
* Changes `#!/usr/bin/env python` to `#!/usr/bin/env python3` for files missed by #7143.  These files are not part of `openbmc-py`, but get flagged when building on CentOS8.
* Removes comment lines from `.spec` files that contain macro expansions. These lines get flagged by `rpmbuild` when building on CentOS8.