### PR TITLE
Add perl packages for building on CentOS8

### DIFF
--- a/xCAT-client/xCAT-client.spec
+++ b/xCAT-client/xCAT-client.spec
@@ -29,7 +29,7 @@ Requires: cpio
 
 # fping or nmap is needed by pping (in case xCAT-client is installed by itself on a remote client)
 %ifos linux
-Requires: nmap perl-XML-Simple perl-XML-Parser
+Requires: nmap perl-XML-Simple perl-XML-Parser perl-Sys-Syslog perl-Text-Balanced perl-JSON
 %else
 Requires: expat
 %endif


### PR DESCRIPTION
When building xCAT RPM on CentOS8, three Perl packages are not installed - `perl-Sys-Syslog`, `perl-Text-Balanced` and `perl-JSON`. This results in runtime error: 
```
[root@c910f04x37v05 ~]# lsdef
Can't locate Sys/Syslog.pm in @INC (you may need to install the Sys::Syslog module) (@INC contains: /opt/xcat/lib/perl /usr/localrl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at /opt/xerl/xCAT/MsgUtils.pm line 13.
BEGIN failed--compilation aborted at /opt/xcat/lib/perl/xCAT/MsgUtils.pm line 13.
Compilation failed in require at /opt/xcat/bin/lsdef line 11.
BEGIN failed--compilation aborted at /opt/xcat/bin/lsdef line 11.
[root@c910f04x37v05 ~]#
```

`xCAT-client` RPM built on CentOS7:
```
[root@c910f03c17k07 xcat2_autobuild_daily_builds]# rpm -qpR /install/core/xcat/build/xcat2_autobuild_daily_builds/20220505.0015/linux_rpm/devel/core-snap/xCAT-client-2.16.4-snap202205050017.noarch.rpm
/bin/bash
/bin/ksh
/bin/sh
/bin/sh
/bin/sh
/bin/sh
/usr/bin/env
/usr/bin/perl
cpio
nmap
perl(Cwd)
perl(DBI)
perl(Data::Dumper)
perl(Expect)
perl(File::Basename)
perl(File::Path)
perl(Getopt::Long)
perl(Getopt::Std)
perl(IO::Handle)
perl(IO::Select)
perl(IO::Socket)
perl(IO::Socket::SSL)
perl(IO::Socket::UNIX)
perl(POSIX)
perl(Socket)
perl(Sys::Syslog)
perl(Thread)
perl(Time::HiRes)
perl(XML::Simple)
perl(lib)
perl(locale)
perl(strict)
perl(xCAT::Client)
perl(xCAT::DSHCLI)
perl(xCAT::MsgUtils)
perl(xCAT::NetworkUtils)
perl(xCAT::RemoteShellExp)
perl(xCAT::Table)
perl(xCAT::TableUtils)
perl(xCAT::Usage)
perl(xCAT::Utils)
perl-XML-Parser
perl-XML-Simple
perl-xCAT = 4:2.16.4-snap202205050017
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsXz) <= 5.2-1
[root@c910f03c17k07 xcat2_autobuild_daily_builds]#
```

But `xCAT-client` RPM built on CentOS8:
```
[root@c910f03c17k07 xcat2_autobuild_daily_builds]# rpm -qpR /install/core/xcat/build/xcat2_autobuild_daily_builds/20220513.1421/linux_rpm/devel/core-snap/xCAT-client-2.16.4-snap202205131424.noarch.rpm
/bin/bash
/bin/ksh
/bin/sh
/bin/sh
/bin/sh
/bin/sh
/usr/bin/perl
cpio
nmap
perl-XML-Parser
perl-XML-Simple
perl-xCAT = 4:2.16.4-snap202205131424
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsXz) <= 5.2-1
[root@c910f03c17k07 xcat2_autobuild_daily_builds]#
```
