### PR TITLE
Add perl packages for building on CentOS8 (2)

### DIFF
--- a/xCAT-client/xCAT-client.spec
+++ b/xCAT-client/xCAT-client.spec
@@ -29,7 +29,7 @@ Requires: cpio
 
 # fping or nmap is needed by pping (in case xCAT-client is installed by itself on a remote client)
 %ifos linux
-Requires: nmap perl-XML-Simple perl-XML-Parser perl-Sys-Syslog perl-Text-Balanced perl-JSON
+Requires: nmap perl-XML-Simple perl-XML-Parser perl-Sys-Syslog perl-Text-Balanced perl-JSON perl-Expect
 %else
 Requires: expat
 %endif


### PR DESCRIPTION
Continue work of #7174

Regression run revealed another missing Perl package `perl-Expect`:

```
>>>To run: XCATMYSQLADMIN_PW=12345 XCATMYSQLROOT_PW=12345 /opt/xcat/bin/mysqlsetup -i -V  [Mon May 16 10:36:48 2022]
Can't locate Expect.pm in @INC (you may need to install the Expect module) (@INC contains: /opt/xcat/lib/perl /usr/local/lib64/perl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at /opt/xcat/bin/mysqlsetup line 42.
BEGIN failed--compilation aborted at /opt/xcat/bin/mysqlsetup line 42.
>>>Run XCATMYSQLADMIN_PW=12345 XCATMYSQLROOT_PW=12345 /opt/xcat/bin/mysqlsetup -i -V ....[error]
CHECK:rc == 0   [Failed]
```