### PR TITLE
Add perl packages for building on CentOS8 (3)

### DIFF
--- a/xCAT-client/xCAT-client.spec
+++ b/xCAT-client/xCAT-client.spec
@@ -29,7 +29,8 @@ Requires: cpio
 
 # fping or nmap is needed by pping (in case xCAT-client is installed by itself on a remote client)
 %ifos linux
-Requires: nmap perl-XML-Simple perl-XML-Parser perl-Sys-Syslog perl-Text-Balanced perl-JSON perl-Expect
+Requires: nmap perl-XML-Simple perl-XML-Parser
+Suggests: perl-Sys-Syslog perl-Text-Balanced perl-JSON perl-Expect
 %else
 Requires: expat
 %endif


### PR DESCRIPTION
Continue work of #7175 

Move some Perl packages from `Requires` to `Suggests` so the installation does not fail if package is not found.
On some distros some Perl modules are part of base Perl, on some, they are part of separate package.