### PR TITLE
Remove Recommends tag, not supported on CentOS7 build container

### DIFF
--- a/xCAT-client/xCAT-client.spec
+++ b/xCAT-client/xCAT-client.spec
@@ -30,7 +30,6 @@ Requires: cpio
 # fping or nmap is needed by pping (in case xCAT-client is installed by itself on a remote client)
 %ifos linux
 Requires: nmap perl-XML-Simple perl-XML-Parser
-Recommends: perl-Sys-Syslog perl-Text-Balanced perl-JSON perl-Expect
 %else
 Requires: expat
 %endif


### PR DESCRIPTION
Going back to building on CentOS7 bases containers