### PR TITLE
Fix warnings of newer dracut versions

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -1103,9 +1103,9 @@ sub mkinitrd_dracut {
             }
         }
 
-        print $DRACUTCONF qq{dracutmodules+="$dracutmodulelist"\n};
-        print $DRACUTCONF qq{add_drivers+="$add_drivers"\n};
-        print $DRACUTCONF qq{filesystems+="nfs"\n};
+        print $DRACUTCONF qq{dracutmodules+=" $dracutmodulelist "\n};
+        print $DRACUTCONF qq{add_drivers+=" $add_drivers "\n};
+        print $DRACUTCONF qq{filesystems+=" nfs "\n};
         close $DRACUTCONF;
     } elsif ($mode eq "stateless") {
         cp("$fullpath/$dracutdir/install.netboot", "$dracutmpath/install");
@@ -1146,8 +1146,8 @@ sub mkinitrd_dracut {
 
         # update etc/dracut.conf
         open($DRACUTCONF, '>', "$rootimg_dir/etc/dracut.conf");
-        print $DRACUTCONF qq{dracutmodules+="$dracutmodulelist"\n};
-        print $DRACUTCONF qq{add_drivers+="$add_drivers"\n};
+        print $DRACUTCONF qq{dracutmodules+=" $dracutmodulelist "\n};
+        print $DRACUTCONF qq{add_drivers+=" $add_drivers "\n};
         close $DRACUTCONF;
     } else {
         xdie "the mode: $mode is not supported by genimage";

--- a/xCAT-server/share/xcat/netboot/sles/genimage
+++ b/xCAT-server/share/xcat/netboot/sles/genimage
@@ -1097,13 +1097,13 @@ sub mkinitrd_dracut {
         #update etc/dracut.conf
         open($DRACUTCONF, '>', "$rootimg_dir/etc/dracut.conf");
         if (-d glob($dracutmoduledir . "[0-9]*fadump")) {
-            print $DRACUTCONF qq{dracutmodules+="xcat nfs base network kernel-modules lvm fadump"\n};
+            print $DRACUTCONF qq{dracutmodules+=" xcat nfs base network kernel-modules lvm fadump "\n};
         }
         else {
-            print $DRACUTCONF qq{dracutmodules+="xcat nfs base network kernel-modules lvm"\n};
+            print $DRACUTCONF qq{dracutmodules+=" xcat nfs base network kernel-modules lvm "\n};
         }
-        print $DRACUTCONF qq{add_drivers+="$add_drivers"\n};
-        print $DRACUTCONF qq{filesystems+="nfs"\n};
+        print $DRACUTCONF qq{add_drivers+=" $add_drivers "\n};
+        print $DRACUTCONF qq{filesystems+=" nfs "\n};
         close $DRACUTCONF;
     } elsif ($mode eq "stateless") {
         cp("$fullpath/$dracutdir/install.netboot", "$dracutmpath/install");
@@ -1135,12 +1135,12 @@ sub mkinitrd_dracut {
         # update etc/dracut.conf
         open($DRACUTCONF, '>', "$rootimg_dir/etc/dracut.conf");
         if (-d glob($dracutmoduledir . "[0-9]*fadump")) {
-            print $DRACUTCONF qq{dracutmodules+="xcat nfs base network kernel-modules lvm fadump syslog"\n};
+            print $DRACUTCONF qq{dracutmodules+=" xcat nfs base network kernel-modules lvm fadump syslog "\n};
         }
         else {
-            print $DRACUTCONF qq{dracutmodules+="xcat nfs base network kernel-modules lvm syslog"\n};
+            print $DRACUTCONF qq{dracutmodules+=" xcat nfs base network kernel-modules lvm syslog "\n};
         }
-        print $DRACUTCONF qq{add_drivers+="$add_drivers"\n};
+        print $DRACUTCONF qq{add_drivers+=" $add_drivers "\n};
         close $DRACUTCONF;
     } else {
         xdie "the mode: $mode is not supported by genimage";

--- a/xCAT-server/share/xcat/netboot/ubuntu/genimage
+++ b/xCAT-server/share/xcat/netboot/ubuntu/genimage
@@ -947,9 +947,9 @@ sub mkinitrd_dracut {
 
         # update etc/dracut.conf
         open($DRACUTCONF, '>', "$rootimg_dir/etc/dracut.conf");
-        print $DRACUTCONF qq{dracutmodules+="xcat nfs base network kernel-modules"\n};
-        print $DRACUTCONF qq{add_drivers+="$add_drivers"\n};
-        print $DRACUTCONF qq{filesystems+="nfs"\n};
+        print $DRACUTCONF qq{dracutmodules+=" xcat nfs base network kernel-modules "\n};
+        print $DRACUTCONF qq{add_drivers+=" $add_drivers "\n};
+        print $DRACUTCONF qq{filesystems+=" nfs "\n};
         close $DRACUTCONF;
     } elsif ($mode eq "stateless") {
         cp("$fullpath/$dracutdir/install.netboot", "$dracutmpath/install");
@@ -977,8 +977,8 @@ sub mkinitrd_dracut {
 
         # update etc/dracut.conf
         open($DRACUTCONF, '>', "$rootimg_dir/etc/dracut.conf");
-        print $DRACUTCONF qq{dracutmodules+="xcat nfs base network kernel-modules"\n};
-        print $DRACUTCONF qq{add_drivers+="$add_drivers"\n};
+        print $DRACUTCONF qq{dracutmodules+=" xcat nfs base network kernel-modules "\n};
+        print $DRACUTCONF qq{add_drivers+=" $add_drivers "\n};
         close $DRACUTCONF;
     } else {
         xdie "the mode: $mode is not supported by genimage";


### PR DESCRIPTION
### Fix warnings of newer dracut versions

```
dracut: WARNING: <key>+=" <values> ": <values> should have surrounding white spaces!
dracut: WARNING: This will lead to unwanted side effects! Please fix the configuration file.
```

dracut commit: https://github.com/dracutdevs/dracut/commit/dfe2247a43d6a216d9af533825c9a103e3b056cd

First noticed in Rocky/Alma 8.6