### PR TITLE
Better module failure message

### DIFF
--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -919,7 +919,7 @@ sub scan_plugins {
         /.*\/([^\/]*).pm$/;
         my $modname = $1;
         unless (eval { require "$_" }) {
-            xCAT::MsgUtils->message("S", "Error loading module " . $_ . "  ...skipping");
+            xCAT::MsgUtils->message("S", "Error loading module " . $_ . "  ...skipping. \n Run \"perl -c $_\" to view details of the failure");
 
             next;
         }


### PR DESCRIPTION
When `xcatd` fails to load a Perl module, it is hard for user to determine the reason.
This PR adds a message to suggest the command to try.

```
root@f6u13k04:~# xcatd -f
Error loading module markg.pm  ...skipping.
 Run "perl -c markg.pm" to view details of the failure
```