### PR TITLE
Better formatting for xcatprobe output

### DIFF
--- a/xCAT-probe/xcatprobe
+++ b/xCAT-probe/xcatprobe
@@ -100,7 +100,10 @@ sub format_cmd_output {
     $msg =~ s/\t/        /g;
     my $flaglen      = 6;
     my $desiredwidth = 120;
-    my $screenwidth  = (`tput cols` + 0);
+    my $screenwidth = 80;
+    if ($ENV{'TERM'}) {
+        $screenwidth  = (`tput cols` + 0);
+    }
     my $maxlen = ($screenwidth > $desiredwidth ? $desiredwidth : $screenwidth);
 
     my @finalmsg = ();
@@ -194,7 +197,10 @@ sub listvalidsubcmd {
     $maxlen += 4;
 
     my $desiredwidth = 120;
-    my $screenwidth  = (`tput cols` + 0);
+    my $screenwidth = 80;
+    if ($ENV{'TERM'}) {
+        $screenwidth  = (`tput cols` + 0);
+    }
     my $finallen = ($screenwidth > $desiredwidth ? $desiredwidth : $screenwidth);
 
     print "Supported sub commands are:\n";


### PR DESCRIPTION
`xcatprobe` uses `tput cols` command to determine window width and format output accordingly.
When running unattended (for example Jenkins regression), without the interactive terminal, the `$TERM` environment variable is not set and `tput cols` fails with `tput: No value for $TERM and no -T specified`.
As a result, `xcatprobe` displays output in a single column:
```
RUN:xcatprobe -l [Sat Jun  4 08:36:55 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
tput: No value for $TERM and no -T specified
Supported sub commands are:
detect_dhcpd     
                 detect_dhcpd
                 can
                 be
                 used
                 to
                 detect
                 the
                 dhcp
                 server
                 in
                 a
                 network
                 for
                 a
                 specific
                 mac
                 address.
                 Before
                 using
                 this
                 command,
                 install
                 'tcpdump'
                 command.
                 The
                 operating
                 system
                 supported
                 are
                 RedHat,
                 SLES
                 and
                 Ubuntu.
osdeploy         
                 Probe
                 operating
                 system
                 provision
                 process.
                 Supports
                 two
                 modes
                 -
                 'Realtime
                 monitor'
                 and
                 'Replay
                 history'.
nodecheck        
                 Use
                 this
                 command
                 to
                 check
                 node
                 defintions
                 in
                 xCAT
                 DB.
xcatmn           
                 After
                 xcat
                 installation,
                 use
                 this
                 command
                 to
                 check
                 if
                 xcat
                 has
                 been
                 installed
                 correctly
                 and
                 is
                 ready
                 for
                 use.
                 Before
                 using
                 this
                 command,
                 install
                 'tftp',
                 'nslookup'
                 and
                 'wget'
                 commands.
                 Supported
                 platforms
                 are
                 RedHat,
                 SLES
                 and
                 Ubuntu.
osimagecheck     
                 Use
                 this
                 command
                 to
                 check
                 osimage
                 defintions
                 in
                 xCAT
                 DB.
discovery        
                 Probe
                 for
                 discovery
                 process,
                 including
                 pre-check
                 for
                 required
                 configuration
                 and
                 realtime
                 monitor
                 of
                 discovery
                 process.
image            
                 Use
                 this
                 command
                 to
                 check
                 if
                 specified
                 diskless
                 nodes
                 have
                 the
                 same
                 images
                 installed
                 or
                 if
                 nodes
                 are
                 installed
                 with
                 the
                 same
                 image
                 as
                 defined
                 on
                 the
                 management
                 node.
clusterstatus    
                 Use
                 this
                 command
                 to
                 get
                 node
                 summary
                 in
                 the
                 cluster.
code_template    
                 This
                 isn't
                 a
                 probe
                 tool,
                 this
                 is
                 just
                 a
                 template
                 for
                 sub
                 command
                 coding.
                 Use
                 it
                 to
                 develop
                 sub
                 command
                 which
                 need
                 to
                 cover
                 hierarchical
                 cluster
```

This PR uses `tput cols` only if `$TERM` is set, otherwise default terminal column with it `80`.

### UT:

* Before fix

![image](https://user-images.githubusercontent.com/16106630/172179341-1c0ddf80-30df-4404-8ccd-16c76b81a4a9.png)

* After fix

![image](https://user-images.githubusercontent.com/16106630/172178551-644803da-6f71-41d8-8b58-e284ff2cd0e1.png)

![image](https://user-images.githubusercontent.com/16106630/172178653-1ecabd97-8fe8-47c5-b4f6-85b6b541031a.png)
