### PR TITLE
Check host keys supported by the operating system and report new ones if any

### DIFF
--- a/xCAT-test/autotest/testcase/install_xCAT/case0
+++ b/xCAT-test/autotest/testcase/install_xCAT/case0
@@ -20,16 +20,6 @@ cmd:service xcatd status
 check:rc==0
 check:output=~running
 cmd:rm -rf /install_xCAT_xcat-core.tar.bz2 /install_xCAT_xcat-dep.tar.bz2
-
-# Check host keys supported by the current OS.
-cmd:echo -e "dsa\necdsa\ned25519\nrsa\nrsa1" > /tmp/known_host_keys
-check:rc==0
-cmd:ssh-keygen --help 2>&1 | grep "\[-t" | cut -d "[" -f4 | cut -d "]" -f1 | sed 's/-t//' | sed 's/|//g' | xargs -n 1 > /tmp/current_os_host_keys
-check:rc==0
-cmd:diff /tmp/known_host_keys /tmp/current_os_host_keys
-check:output!~>
-cmd:rm -f /tmp/known_host_keys /tmp/current_os_host_keys
-check:rc==0
 end
 
 
@@ -67,16 +57,6 @@ cmd:service conserver stop
 cmd:sleep 5
 cmd:service goconserver status
 cmd:service conserver status
-
-# Check host keys supported by the current OS.
-cmd:echo -e "dsa\necdsa\ned25519\nrsa\nrsa1" > /tmp/known_host_keys
-check:rc==0
-cmd:ssh-keygen --help 2>&1 | grep "\[-t" | cut -d "[" -f4 | cut -d "]" -f1 | sed 's/-t//' | sed 's/|//g' | xargs -n 1 > /tmp/current_os_host_keys
-check:rc==0
-cmd:diff /tmp/known_host_keys /tmp/current_os_host_keys
-check:output!~>
-cmd:rm -f /tmp/known_host_keys /tmp/current_os_host_keys
-check:rc==0
 end
 
 

--- a/xCAT-test/autotest/testcase/install_xCAT/case0
+++ b/xCAT-test/autotest/testcase/install_xCAT/case0
@@ -20,6 +20,16 @@ cmd:service xcatd status
 check:rc==0
 check:output=~running
 cmd:rm -rf /install_xCAT_xcat-core.tar.bz2 /install_xCAT_xcat-dep.tar.bz2
+
+# Check host keys supported by the current OS.
+cmd:echo -e "dsa\necdsa\ned25519\nrsa\nrsa1" > /tmp/known_host_keys
+check:rc==0
+cmd:ssh-keygen --help 2>&1 | grep "\[-t" | cut -d "[" -f4 | cut -d "]" -f1 | sed 's/-t//' | sed 's/|//g' | xargs -n 1 > /tmp/current_os_host_keys
+check:rc==0
+cmd:diff /tmp/known_host_keys /tmp/current_os_host_keys
+check:output!~>
+cmd:rm -f /tmp/known_host_keys /tmp/current_os_host_keys
+check:rc==0
 end
 
 
@@ -57,6 +67,16 @@ cmd:service conserver stop
 cmd:sleep 5
 cmd:service goconserver status
 cmd:service conserver status
+
+# Check host keys supported by the current OS.
+cmd:echo -e "dsa\necdsa\ned25519\nrsa\nrsa1" > /tmp/known_host_keys
+check:rc==0
+cmd:ssh-keygen --help 2>&1 | grep "\[-t" | cut -d "[" -f4 | cut -d "]" -f1 | sed 's/-t//' | sed 's/|//g' | xargs -n 1 > /tmp/current_os_host_keys
+check:rc==0
+cmd:diff /tmp/known_host_keys /tmp/current_os_host_keys
+check:output!~>
+cmd:rm -f /tmp/known_host_keys /tmp/current_os_host_keys
+check:rc==0
 end
 
 

--- a/xCAT-test/autotest/testcase/install_xCAT/case0
+++ b/xCAT-test/autotest/testcase/install_xCAT/case0
@@ -20,8 +20,17 @@ cmd:service xcatd status
 check:rc==0
 check:output=~running
 cmd:rm -rf /install_xCAT_xcat-core.tar.bz2 /install_xCAT_xcat-dep.tar.bz2
-end
 
+# Check host keys supported by the operating system and report new ones, if any.
+cmd:echo -e "dsa\necdsa\ned25519\nrsa\nrsa1" > /tmp/known_host_keys
+check:rc==0
+cmd:ssh-keygen --help 2>&1 | grep "\[-t" | cut -d "[" -f4 | cut -d "]" -f1 | sed 's/-t//' | sed 's/|//g' | xargs -n 1 > /tmp/current_os_host_keys
+check:rc==0
+cmd:diff /tmp/known_host_keys /tmp/current_os_host_keys
+check:output!~>
+cmd:rm -f /tmp/known_host_keys /tmp/current_os_host_keys
+check:rc==0
+end
 
 start:install_xCAT_on_ubuntu
 description:install xCAT with go-xcat tool in a fresh environment for ubuntu
@@ -57,6 +66,14 @@ cmd:service conserver stop
 cmd:sleep 5
 cmd:service goconserver status
 cmd:service conserver status
+
+# Check host keys supported by the operating system and report new ones, if any.
+cmd:echo -e "dsa\necdsa\ned25519\nrsa\nrsa1" > /tmp/known_host_keys
+check:rc==0
+cmd:ssh-keygen --help 2>&1 | grep "\[-t" | cut -d "[" -f4 | cut -d "]" -f1 | sed 's/-t//' | sed 's/|//g' | xargs -n 1 > /tmp/current_os_host_keys
+check:rc==0
+cmd:diff /tmp/known_host_keys /tmp/current_os_host_keys
+check:output!~>
+cmd:rm -f /tmp/known_host_keys /tmp/current_os_host_keys
+check:rc==0
 end
-
-


### PR DESCRIPTION
Explanation of getting the host keys supported by the operating system:
```
ssh-keygen --help 2>&1 | grep "\[-t"
usage: ssh-keygen [-q] [-b bits] [-t dsa | ecdsa | ed25519 | rsa] [-m format]

ssh-keygen --help 2>&1 | grep "\[-t" | cut -d "[" -f4
-t dsa | ecdsa | ed25519 | rsa]

ssh-keygen --help 2>&1 | grep "\[-t" | cut -d "[" -f4 | cut -d "]" -f1
-t dsa | ecdsa | ed25519 | rsa

ssh-keygen --help 2>&1 | grep "\[-t" | cut -d "[" -f4 | cut -d "]" -f1 | sed 's/-t//'
 dsa | ecdsa | ed25519 | rsa

ssh-keygen --help 2>&1 | grep "\[-t" | cut -d "[" -f4 | cut -d "]" -f1 | sed 's/-t//' | sed 's/|//g'
 dsa  ecdsa  ed25519  rsa

ssh-keygen --help 2>&1 | grep "\[-t" | cut -d "[" -f4 | cut -d "]" -f1 | sed 's/-t//' | sed 's/|//g' | xargs -n 1
dsa
ecdsa
ed25519
rsa
```

RHEL 8.4 has dsa, ecdsa, ed25519 and rsa, and the known_host_keys includes dsa, ecdsa, ed25519, rsa and rsa1.
```
RUN:diff /tmp/known_host_keys /tmp/current_os_host_keys [Tue Jun  7 16:03:37 2022]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
5d4
< rsa1
CHECK:output !~ >       [Pass]
```
rsa1 is supported by RHEL 7.6, but disabled later. "< rsa1" in the output is fine.

If a new host key is supported by a newer operating system, ">" would show up in the output and [Failed] would be the result.
