### PR TITLE
Obtain the highest version of TLS supported by OpenSSL/TLS

### DIFF
--- a/xCAT-test/autotest/testcase/install_xCAT/case0
+++ b/xCAT-test/autotest/testcase/install_xCAT/case0
@@ -30,6 +30,10 @@ cmd:diff /tmp/known_host_keys /tmp/current_os_host_keys
 check:output!~>
 cmd:rm -f /tmp/known_host_keys /tmp/current_os_host_keys
 check:rc==0
+
+# Obtain the highest version of TLS supported by OpenSSL/TLS.
+cmd:openssl s_client --help 2>&1 | grep "\-tls1" | awk '{print $1}' | sort | tail -1
+check:rc==0
 end
 
 start:install_xCAT_on_ubuntu
@@ -75,5 +79,9 @@ check:rc==0
 cmd:diff /tmp/known_host_keys /tmp/current_os_host_keys
 check:output!~>
 cmd:rm -f /tmp/known_host_keys /tmp/current_os_host_keys
+check:rc==0
+
+# Obtain the highest version of TLS supported by OpenSSL/TLS.
+cmd:openssl s_client --help 2>&1 | grep "\-tls1" | awk '{print $1}' | sort | tail -1
 check:rc==0
 end


### PR DESCRIPTION
On RHEL 7.6 with OpenSSL 1.0.2k-fips:
```
openssl s_client --help 2>&1 | grep "\-tls1" | awk '{print $1}' | sort | tail -1
-tls1_2
```

On RHEL 8.1 with OpenSSL OpenSSL 1.1.1c
```
openssl s_client --help 2>&1 | grep "\-tls1" | awk '{print $1}' | sort | tail -1
-tls1_3
```