### PR TITLE
Better file linking for xCAT-probe

### DIFF
--- a/xCAT-probe/debian/xcat-probe.links
+++ b/xCAT-probe/debian/xcat-probe.links
@@ -1,1 +1,0 @@
-/opt/xcat/bin/xcatclient /opt/xcat/probe/subcmds/bin/switchprobe

--- a/xCAT-probe/xCAT-probe.spec
+++ b/xCAT-probe/xCAT-probe.spec
@@ -71,10 +71,6 @@ if [ -e %{prefix}/probe/subcmds/bin/switchprobe ]; then
 else
     mkdir -p %{prefix}/probe/subcmds/bin/
 fi
-cd %{prefix}/probe/subcmds/bin/
-if [ -e %{prefix}/bin/xcatclient ]; then
-    ln -s %{prefix}/bin/xcatclient switchprobe
-fi
 
 %preun
 #remove the bin directory if not on upgrade

--- a/xCAT-probe/xcatprobe
+++ b/xCAT-probe/xcatprobe
@@ -259,6 +259,19 @@ foreach my $attr (@tmpargv) {
     }
 }
 
+# Create symlink /opt/xcat/probe/subcmds/bin/switchprobe -> /opt/xcat/bin/xcatclient if not already there
+my $switchprobe_link = $plugin_dir."/bin/switchprobe";
+unless (-l $switchprobe_link) {
+    my $xcatclient = `which xcatclient`;
+    chomp($xcatclient);
+    if ($xcatclient) {
+        symlink($xcatclient, $switchprobe_link);
+    }
+    else {
+        print "Can not create symbolic link $switchprobe_link to xcatclient. xCAT-client package not installed.\n";
+        exit 1;
+    }
+}
 
 &loadsubcmds;
 if (defined($pluginname)) {


### PR DESCRIPTION
Sometimes `xcatprobe_work` testcase fails on RH7.7 and OL7.9.
This is because during `xCAT-probe` RPM installation, in `%post` section of `xCAT-probe.spec`, a link is made `/opt/xcat/probe/subcmds/bin/switchprobe -> /opt/xcat/bin/xcatclient`. 
Even though `xCAT-probe.spec`, has `Requires: xCAT-client = 4:%{version}-%{release}`, it does not guarantee that `xCAT-client` is installed first.

This PR move this link creation from RPM installation to `xcatprobe` runtime.

### UT:
* `xCAT-client` not installed:
```
[root@c910f04x37v08 probe]# xcatprobe -l
which: no xcatclient in (/opt/xcat/bin:/opt/xcat/sbin:/opt/xcat/share/xcat/tools:/opt/xcat/bin:/opt/xcat/sbin:/opt/xcat/share/xcat/tools:/opt/xcat/bin:/opt/xcat/sbin:/opt/xcat/share/xcat/tools:/usr/sbin:/usr/bin:/sbin:/bin:/root/bin)
Can not create symbolic link /opt/xcat/probe//subcmds/bin/switchprobe to xcatclient. xCAT-client package not installed.
[root@c910f04x37v08 probe]#
```

* `xCAT-client` installed, first time running `xcatprobe`:
```
[root@c910f04x37v08 probe]# ls /opt/xcat/probe/subcmds/bin
[root@c910f04x37v08 probe]#

[root@c910f04x37v08 probe]# xcatprobe -l
Supported sub commands are:
detect_dhcpd     detect_dhcpd can be used to detect the dhcp server in a network for a specific mac
                 address. Before using this command, install 'tcpdump' command. The operating system
                 supported are RedHat, SLES and Ubuntu.
osdeploy         Probe operating system provision process. Supports two modes - 'Realtime monitor' and
                 'Replay history'.
nodecheck        Use this command to check node defintions in xCAT DB.
xcatmn           After xcat installation, use this command to check if xcat has been installed correctly
                 and is ready for use. Before using this command, install 'tftp', 'nslookup' and 'wget'
                 commands. Supported platforms are RedHat, SLES and Ubuntu.
osimagecheck     Use this command to check osimage defintions in xCAT DB.
discovery        Probe for discovery process, including pre-check for required configuration and
                 realtime monitor of discovery process.
image            Use this command to check if specified diskless nodes have the same images installed or
                 if nodes are installed with the same image as defined on the management node.
clusterstatus    Use this command to get node summary in the cluster.
switch_macmap    To retrieve MAC address mapping for the specified switch, or all the switches defined
                 in 'switches' table in xCAT db. Currently, this command does not support hierarchy.
code_template    This isn't a probe tool, this is just a template for sub command coding. Use it to
                 develop sub command which need to cover hierarchical cluster

[root@c910f04x37v08 probe]# ls -l /opt/xcat/probe/subcmds/bin
total 0
lrwxrwxrwx 1 root root 24 Jun 10 10:51 switchprobe -> /opt/xcat/bin/xcatclient
[root@c910f04x37v08 probe]#
```
* `xCAT-client` installed, second time running `xcatprobe`:
```
[root@c910f04x37v08 probe]# ls /opt/xcat/probe/subcmds/bin
switchprobe
[root@c910f04x37v08 probe]#

[root@c910f04x37v08 probe]# xcatprobe -l
Supported sub commands are:
detect_dhcpd     detect_dhcpd can be used to detect the dhcp server in a network for a specific mac
                 address. Before using this command, install 'tcpdump' command. The operating system
                 supported are RedHat, SLES and Ubuntu.
osdeploy         Probe operating system provision process. Supports two modes - 'Realtime monitor' and
                 'Replay history'.
nodecheck        Use this command to check node defintions in xCAT DB.
xcatmn           After xcat installation, use this command to check if xcat has been installed correctly
                 and is ready for use. Before using this command, install 'tftp', 'nslookup' and 'wget'
                 commands. Supported platforms are RedHat, SLES and Ubuntu.
osimagecheck     Use this command to check osimage defintions in xCAT DB.
discovery        Probe for discovery process, including pre-check for required configuration and
                 realtime monitor of discovery process.
image            Use this command to check if specified diskless nodes have the same images installed or
                 if nodes are installed with the same image as defined on the management node.
clusterstatus    Use this command to get node summary in the cluster.
switch_macmap    To retrieve MAC address mapping for the specified switch, or all the switches defined
                 in 'switches' table in xCAT db. Currently, this command does not support hierarchy.
code_template    This isn't a probe tool, this is just a template for sub command coding. Use it to
                 develop sub command which need to cover hierarchical cluster

[root@c910f04x37v08 probe]# ls -l /opt/xcat/probe/subcmds/bin
total 0
lrwxrwxrwx 1 root root 24 Jun 10 10:51 switchprobe -> /opt/xcat/bin/xcatclient
[root@c910f04x37v08 probe]#
```