### PR TITLE
Revert PR 7193 - Need a better approach to extract supported host keys

### DIFF
--- a/xCAT-test/autotest/testcase/install_xCAT/case0
+++ b/xCAT-test/autotest/testcase/install_xCAT/case0
@@ -21,16 +21,6 @@ check:rc==0
 check:output=~running
 cmd:rm -rf /install_xCAT_xcat-core.tar.bz2 /install_xCAT_xcat-dep.tar.bz2
 
-# Check host keys supported by the operating system and report new ones, if any.
-cmd:echo -e "dsa\necdsa\ned25519\nrsa\nrsa1" > /tmp/known_host_keys
-check:rc==0
-cmd:ssh-keygen --help 2>&1 | grep "\[-t" | cut -d "[" -f4 | cut -d "]" -f1 | sed 's/-t//' | sed 's/|//g' | xargs -n 1 > /tmp/current_os_host_keys
-check:rc==0
-cmd:diff /tmp/known_host_keys /tmp/current_os_host_keys
-check:output!~>
-cmd:rm -f /tmp/known_host_keys /tmp/current_os_host_keys
-check:rc==0
-
 # Obtain the highest version of TLS supported by OpenSSL/TLS.
 cmd:openssl s_client --help 2>&1 | grep "\-tls1" | awk '{print $1}' | sort | tail -1
 check:rc==0
@@ -70,16 +60,6 @@ cmd:service conserver stop
 cmd:sleep 5
 cmd:service goconserver status
 cmd:service conserver status
-
-# Check host keys supported by the operating system and report new ones, if any.
-cmd:echo -e "dsa\necdsa\ned25519\nrsa\nrsa1" > /tmp/known_host_keys
-check:rc==0
-cmd:ssh-keygen --help 2>&1 | grep "\[-t" | cut -d "[" -f4 | cut -d "]" -f1 | sed 's/-t//' | sed 's/|//g' | xargs -n 1 > /tmp/current_os_host_keys
-check:rc==0
-cmd:diff /tmp/known_host_keys /tmp/current_os_host_keys
-check:output!~>
-cmd:rm -f /tmp/known_host_keys /tmp/current_os_host_keys
-check:rc==0
 
 # Obtain the highest version of TLS supported by OpenSSL/TLS.
 cmd:openssl s_client --help 2>&1 | grep "\-tls1" | awk '{print $1}' | sort | tail -1


### PR DESCRIPTION
On SLES 15.3, we have the following:
```
# ssh-keygen --help 2>&1
unknown option -- -
usage: ssh-keygen [-q] [-a rounds] [-b bits] [-C comment] [-f output_keyfile]
                  [-m format] [-N new_passphrase] [-O option]
                  [-t dsa | ecdsa | ecdsa-sk | ed25519 | ed25519-sk | rsa]
                  [-w provider]
       ssh-keygen -p [-a rounds] [-f keyfile] [-m format] [-N new_passphrase]
                   [-P old_passphrase]
```
Note that the host key options are by themselves on a separate line.

A better approach is needd to extract supported host keys.