### PR TITLE
Improve PR 7193: Check host keys supported by the operating system and report new ones if any

### DIFF
--- a/xCAT-test/autotest/testcase/install_xCAT/case0
+++ b/xCAT-test/autotest/testcase/install_xCAT/case0
@@ -21,6 +21,16 @@ check:rc==0
 check:output=~running
 cmd:rm -rf /install_xCAT_xcat-core.tar.bz2 /install_xCAT_xcat-dep.tar.bz2
 
+# Check host keys supported by the operating system and report new ones, if any.
+cmd:echo -e "dsa\necdsa\ned25519\nrsa\nrsa1" > /tmp/known_host_keys
+check:rc==0
+cmd:ssh-keygen --help 2>&1 | grep "\[-t" | sed -E 's/.*(\[\-t.*)/\1/' | cut -d "[" -f2 | cut -d "]" -f1 | sed 's/-t//' | sed 's/|//g' | xargs -n 1 | grep -v '\-sk' > /tmp/current_os_host_keys
+check:rc==0
+cmd:diff /tmp/known_host_keys /tmp/current_os_host_keys
+check:output!~>
+cmd:rm -f /tmp/known_host_keys /tmp/current_os_host_keys
+check:rc==0
+
 # Obtain the highest version of TLS supported by OpenSSL/TLS.
 cmd:openssl s_client --help 2>&1 | grep "\-tls1" | awk '{print $1}' | sort | tail -1
 check:rc==0
@@ -60,6 +70,16 @@ cmd:service conserver stop
 cmd:sleep 5
 cmd:service goconserver status
 cmd:service conserver status
+
+# Check host keys supported by the operating system and report new ones, if any.
+cmd:echo -e "dsa\necdsa\ned25519\nrsa\nrsa1" > /tmp/known_host_keys
+check:rc==0
+cmd:ssh-keygen --help 2>&1 | grep "\[-t" | sed -E 's/.*(\[\-t.*)/\1/' | cut -d "[" -f2 | cut -d "]" -f1 | sed 's/-t//' | sed 's/|//g' | xargs -n 1 | grep -v '\-sk' > /tmp/current_os_host_keys
+check:rc==0
+cmd:diff /tmp/known_host_keys /tmp/current_os_host_keys
+check:output!~>
+cmd:rm -f /tmp/known_host_keys /tmp/current_os_host_keys
+check:rc==0
 
 # Obtain the highest version of TLS supported by OpenSSL/TLS.
 cmd:openssl s_client --help 2>&1 | grep "\-tls1" | awk '{print $1}' | sort | tail -1


### PR DESCRIPTION
The key difference between this PR and https://github.com/xcat2/xcat-core/pull/7193:

```
ssh-keygen --help 2>&1 | grep "\[-t" | sed -E 's/.*(\[\-t.*)/\1/' | cut -d "[" -f2 | cut -d "]" -f1 | sed 's/-t//' | sed 's/|//g' | xargs -n 1 | grep -v '\-sk' > /tmp/current_os_host_keys
```
and
```
ssh-keygen --help 2>&1 | grep "\[-t" | cut -d "[" -f4 | cut -d "]" -f1 | sed 's/-t//' | sed 's/|//g' | xargs -n 1 > /tmp/current_os_host_keys
```

The new implementation addresses the following:
(1) [-t key types] can be anywhere in the output of ssh-keygen.
(2) ecdsa-sk and ed25519-sk are to be ignored by xCAT, although they are supported by SLES 15.3.