### PR TITLE
Improve SLES15 copycds for Media2 iso

### DIFF
--- a/xCAT-server/lib/xcat/plugins/sles.pm
+++ b/xCAT-server/lib/xcat/plugins/sles.pm
@@ -1770,6 +1770,15 @@ sub copycd
                     $distname = "sle15";
                 }
             };
+        } elsif ($dsc =~ /SLE-15/ and $dsc =~ /SOURCE/) {
+            $discnumber = 2;
+            unless ($distname) {
+                if ($dsc =~ /SLE-15-SP(\d)/) {
+                    $distname = "sle15.$1";
+                } else {
+                    $distname = "sle15";
+                }
+            };
         } elsif ($dsc =~ /SLE-15/ and $dsc =~ /Full/) {
             $discnumber = 1;
 	    $linktwo = 1;


### PR DESCRIPTION
For SLES15.2 and SLES15.3 only `Media1.iso` file is needed. However, when both `Media1.iso` and `Media2.iso` files are specified for `copycds` command, the contents of `Media2.iso`, overwrite copied files in `<pkgdir>/1` directory. The `Media2.iso` contains source code rpms.

This PR detects the `SOURCE` iso and, if specified for `copycds` command, copies it to `<pkgdir>/2`. The logic is similar to SLES15.1, where `Media1.iso` is `Installer` and is copied to  `<pkgdir>/1`, and `Media2.iso` is `Packages` and is copied to  `<pkgdir>/2`.