### PR TITLE
Testecase to detect genimage WARNING

### DIFF
--- a/xCAT-test/autotest/testcase/xdsh/cases0
+++ b/xCAT-test/autotest/testcase/xdsh/cases0
@@ -89,6 +89,7 @@ cmd: copycds $$ISO
 check:rc==0
 cmd: genimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute
 check:rc==0
+check:output!~WARNING
 cmd: xdsh -i /install/netboot/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/compute/rootimg  "rpm -qa|grep uuid"
 check:rc==0
 check:output=~libuuid


### PR DESCRIPTION
On RHEL8.6 and similar OS, `genimage` displays `dracut: WARNING: <key>+=" <values> ": <values> should have surrounding white spaces!`

This PR adds output check to catch the `WARNING`

```
:
:
:
/etc/dracut.conf:dracutmodules+="xcat nfs base network kernel-modules syslog systemd systemd-initrd dracut-systemd kernel-modules-extra"
/etc/dracut.conf:add_drivers+="tg3 bnx2 bnx2x e1000 e1000e igb mlx4_en virtio_net be2net ext3 ext4"
/etc/dracut.conf:filesystems+="nfs"
dracut: WARNING: <key>+=" <values> ": <values> should have surrounding white spaces!
dracut: WARNING: This will lead to unwanted side effects! Please fix the configuration file.
dracut: No '/dev/log' or 'logger' included for syslog logging
grep: /etc/udev/rules.d/*: No such file or directory
the initial ramdisk for statelite is generated successfully.
CHECK:rc == 0   [Pass]
CHECK:output !~ WARNING [Failed]
```