### PR TITLE
logrotate daily rotation and compression

### DIFF
--- a/xCAT/etc/logrotate.d/xcat
+++ b/xCAT/etc/logrotate.d/xcat
@@ -2,7 +2,9 @@
     missingok
     sharedscripts
     copytruncate
-    delaycompress
+    compress
+    rotate 7
+    daily
     postrotate
         test -f /var/run/rsyslogd.pid && kill -HUP `cat /var/run/rsyslogd.pid 2> /dev/null` 2> /dev/null || true
         test -f /var/run/syslogd.pid && kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true


### PR DESCRIPTION
As the xCAT log files might become very large, they should be rotated on a daily basis and compressed.

