### PR TITLE
Add perl packages for building on CentOS8 (5)

### DIFF
--- a/xCAT-client/xCAT-client.spec
+++ b/xCAT-client/xCAT-client.spec
@@ -30,6 +30,7 @@ Requires: cpio
 # fping or nmap is needed by pping (in case xCAT-client is installed by itself on a remote client)
 %ifos linux
 Requires: nmap perl-XML-Simple perl-XML-Parser
+Recommends: perl-Sys-Syslog perl-Text-Balanced perl-JSON perl-Expect
 %else
 Requires: expat
 %endif


### PR DESCRIPTION
Put back `Recommends` tag into `.spec` file to continue attempt to build on CentOS8.

This was originally added by #7177 and then removed by #7178