### PR TITLE
Add perl packages for building on CentOS8 (6)

### DIFF
--- a/xCAT-client/xCAT-client.spec
+++ b/xCAT-client/xCAT-client.spec
@@ -29,8 +29,8 @@ Requires: cpio
 
 # fping or nmap is needed by pping (in case xCAT-client is installed by itself on a remote client)
 %ifos linux
+BuildRequires: perl-generators
 Requires: nmap perl-XML-Simple perl-XML-Parser
-Recommends: perl-Sys-Syslog perl-Text-Balanced perl-JSON perl-Expect
 %else
 Requires: expat
 %endif

--- a/xCAT-server/xCAT-server.spec
+++ b/xCAT-server/xCAT-server.spec
@@ -37,6 +37,7 @@ BuildArch: noarch
 %if %s390x
 Requires: perl-IO-Socket-SSL perl-XML-Simple perl-XML-Parser
 %else
+BuildRequires: perl-generators
 Requires: perl-IO-Socket-SSL perl-XML-Simple perl-XML-Parser perl-Digest-SHA1 perl(LWP::Protocol::https) perl-XML-LibXML
 %endif
 Obsoletes: atftp-xcat


### PR DESCRIPTION
Add `.spec` statement to pull in some missing `perl` dependencies.