### PR TITLE
Prevent rpmbuild from checking and modifying interpreter directives

### DIFF
--- a/xCAT-openbmc-py/xCAT-openbmc-py.spec
+++ b/xCAT-openbmc-py/xCAT-openbmc-py.spec
@@ -12,6 +12,9 @@ Distribution: %{?_distribution:%{_distribution}}%{!?_distribution:%{_vendor}}
 Prefix: /opt/xcat
 BuildRoot: /var/tmp/%{name}-%{version}-%{release}-root
 
+# Disable shebang mangling of python scripts
+%undefine __brp_mangle_shebangs
+
 %ifnos linux
 AutoReqProv: no
 %endif

--- a/xCAT-server/xCAT-server.spec
+++ b/xCAT-server/xCAT-server.spec
@@ -28,6 +28,9 @@ AutoReqProv: no
 # Define a different location for various httpd configs in s390x mode
 %define httpconfigdir %(if [ "$s390x" = "1" ];then echo "xcathttpdsave"; else echo "xcat"; fi)
 
+# Disable shebang mangling of python scripts
+%undefine __brp_mangle_shebangs
+
 # AIX will build with an arch of "ppc"
 # also need to fix Requires for AIX
 %ifos linux


### PR DESCRIPTION
When building on CentOS 8, the `rpmbuild` changes `#!/usr/bin/env python3` in Python files to `#!/usr/libexec/platform-python`. That works on RH7 and RH8, but on SLES12 and SLES15, when installing xCAT, it results in:
```
Resolving package dependencies...
2 Problems:
Problem: nothing provides /usr/libexec/platform-python needed by xCAT-server-4:2.16.5-snap202208100021.noarch
Problem: nothing provides /usr/libexec/platform-python needed by xCAT-server-4:2.16.5-snap202208100021.noarch
```

SLES does not have `platform-python` RPM
```
c910f04x12v05:~ # zypper search platform-python
Loading repository data...
Reading installed packages...
No matching items found.
c910f04x12v05:~ #
```

But on RH is installed:
```
[root@c910f04x37v02 xcat]# rpm -qa | grep "platform"
platform-python-pip-9.0.3-22.el8.noarch
platform-python-3.6.8-45.el8.x86_64
platform-python-setuptools-39.2.0-6.el8.noarch
[root@c910f04x37v02 xcat]#
```

This PR turns off changing of `#!/usr/bin/env python3`