### PR TITLE
Prevent rpmbuild from checking and modifying interpreter directives(2)

### DIFF
--- a/xCAT-probe/xCAT-probe.spec
+++ b/xCAT-probe/xCAT-probe.spec
@@ -13,6 +13,9 @@ Prefix: /opt/xcat
 BuildRoot: /var/tmp/%{name}-%{version}-%{release}-root
 Requires: xCAT-client = 4:%{version}-%{release}
 
+# Disable shebang mangling of python scripts
+%undefine __brp_mangle_shebangs
+
 %ifos linux
 BuildArch: noarch
 %endif


### PR DESCRIPTION
Continuation of #7234 (missed `xCAT-probe.spec` there).