### PR TITLE
Check SUSE-brand file on SLES

### DIFF
--- a/xCAT-server/lib/xcat/plugins/updatenode.pm
+++ b/xCAT-server/lib/xcat/plugins/updatenode.pm
@@ -3352,7 +3352,7 @@ sub updateOS
         $version =~ s/[^0-9]*([0-9]+).*/$1/;
     }
 
-    # SUSE Linux
+    # SUSE Linux 12 and earlier
     elsif (
 `ssh -o ConnectTimeout=5 $node "test -f /etc/SuSE-release && echo 'SuSE'"`
       )
@@ -3360,6 +3360,17 @@ sub updateOS
         $installOS = "sles";
         chomp($version =
               `ssh $node "tr -d '.' < /etc/SuSE-release" | head -n 1`);
+        $version =~ s/[^0-9]*([0-9]+).*/$1/;
+    }
+
+    # SUSE Linux 15 and later
+    elsif (
+`ssh -o ConnectTimeout=5 $node "test -f /etc/SUSE-brand && echo 'SuSE'"`
+      )
+    {
+        $installOS = "sles";
+        chomp($version =
+              `ssh $node "tr -d '.' < /etc/SUSE-brand" | grep VERSION`);
         $version =~ s/[^0-9]*([0-9]+).*/$1/;
     }
 

--- a/xCAT-server/share/xcat/ib/scripts/Mellanox/mlnxofed_ib_install
+++ b/xCAT-server/share/xcat/ib/scripts/Mellanox/mlnxofed_ib_install
@@ -376,7 +376,7 @@ EOF
 
         # Being called from <image>.postinstall script
         # Assume we are on the same machine
-        if [ -f /etc/SuSE-release ]; then
+        if [ -f /etc/SuSE-release ] || [ -f /etc/SUSE-brand ]; then
             chroot "$IMGROOTPATH" rpm -e --noscripts --allmatches mlnx-ofa_kernel-kmp-default 2>/dev/null
             chroot "$IMGROOTPATH" rpm -e --nodeps --allmatches libibverbs 2>/dev/null
         elif grep -q Ubuntu /etc/os-release 2>/dev/null; then

--- a/xCAT-server/share/xcat/ib/scripts/configiba.1port
+++ b/xCAT-server/share/xcat/ib/scripts/configiba.1port
@@ -64,7 +64,7 @@ then
     if [ -f /etc/redhat-release ]
     then
         OS_name="redhat"
-    elif [ -f /etc/SuSE-release ]
+    elif [ -f /etc/SuSE-release ] || [ -f /etc/SUSE-brand ]
     then
         OS_name="suse"
     else

--- a/xCAT-server/share/xcat/ib/scripts/configiba.2ports
+++ b/xCAT-server/share/xcat/ib/scripts/configiba.2ports
@@ -57,7 +57,7 @@ then
     if [ -f /etc/redhat-release ]
     then
         OS_name="redhat"
-    elif [ -f /etc/SuSE-release ]
+    elif [ -f /etc/SuSE-release ] || [ -f /etc/SUSE-brand ]
     then
         OS_name="suse"
     else
@@ -142,7 +142,7 @@ do
             if [ -f /etc/redhat-release ]
             then
                 OS_name="redhat"
-            elif [ -f /etc/SuSE-release ]
+            elif [ -f /etc/SuSE-release ] || [ -f /etc/SUSE-brand ]
             then
                 OS_name="suse"
             else

--- a/xCAT-server/share/xcat/netboot/add-on/torque/add_torque
+++ b/xCAT-server/share/xcat/netboot/add-on/torque/add_torque
@@ -101,7 +101,7 @@ echo "export PATH=\$PATH:$TORQUEDIR/\$XARCH/bin:$TORQUEDIR/\$XARCH/sbin" >>etc/p
 echo "export PBS_DEFAULT=$TORQUESERVER" >>etc/profile.d/torque.sh
 chmod 755 etc/profile.d/torque.*
 
-if [ -r /etc/SuSE-release ]
+if [ -r /etc/SuSE-release ] || [ -r /etc/SUSE-brand ]
 then
 	cp $XCATROOT/share/xcat/netboot/add-on/torque/pbs_mom.suse etc/init.d/pbs_mom
 	cp $XCATROOT/share/xcat/netboot/add-on/torque/pbs_mom.suse sbin/rcpbs_mom

--- a/xCAT-server/share/xcat/netboot/suse/genimage
+++ b/xCAT-server/share/xcat/netboot/suse/genimage
@@ -212,7 +212,7 @@ unless (grep /af_packet/, @ndrivers) {
 }
 
 my $osver_host;
-if (`grep VERSION /etc/SuSE-release` =~ /VERSION = (\d+)/) {
+if (`grep VERSION /etc/SUSE-brand` =~ /VERSION = (\d+)/) {
     $osver_host = $1;
 } else {
     $osver_host = 11;

--- a/xCAT-server/share/xcat/netboot/suse/genimage
+++ b/xCAT-server/share/xcat/netboot/suse/genimage
@@ -211,8 +211,10 @@ unless (grep /af_packet/, @ndrivers) {
     unshift(@ndrivers, "af_packet.ko");
 }
 
+# Check both possible SLES files for version number. 
+# "--no-messages" suppresses "grep: <file>: No such file or directory"
 my $osver_host;
-if (`grep VERSION /etc/SUSE-brand` =~ /VERSION = (\d+)/) {
+if (`grep --no-messages VERSION /etc/SuSE-release /etc/SUSE-brand` =~ /VERSION = (\d+)/) {
     $osver_host = $1;
 } else {
     $osver_host = 11;

--- a/xCAT-server/share/xcat/scripts/xHRM
+++ b/xCAT-server/share/xcat/scripts/xHRM
@@ -246,7 +246,7 @@ elif [ "bridgeprereq" = "$1" ]; then
     fi
 
     #now save the settings into the config files so that they will be persistent among reboots
-    if [[ $OSVER = sles* ]] || [[ $OSVER = suse* ]] || [[ -f /etc/SuSE-release ]]; then
+    if [[ $OSVER = sles* ]] || [[ $OSVER = suse* ]] || [[ -f /etc/SuSE-release ]] || [[ -f /etc/SUSE-brand ]]; then
         nwdir="/etc/sysconfig/network"
         isSLES=1
     elif [ -f "/etc/debian_version" ];then

--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -515,6 +515,7 @@ function check_linux_distro()
 		echo "${ID}")"
 	[[ -z "${distro}" && -f /etc/redhat-release ]] && distro="rhel"
 	[[ -z "${distro}" && -f /etc/SuSE-release ]] && distro="sles"
+	[[ -z "${distro}" && -f /etc/SUSE-brand ]] && distro="sles"
 	echo "${distro}"
 }
 
@@ -528,6 +529,8 @@ function check_linux_version()
 			/etc/redhat-release)"
 	[[ -z "${ver}" && -f /etc/SuSE-release ]] &&
 		ver="$(awk '/VERSION/ { print $NF }' /etc/SuSE-release)"
+	[[ -z "${ver}" && -f /etc/SUSE-brand ]] &&
+		ver="$(awk '/VERSION/ { print $NF }' /etc/SUSE-brand)"
 	echo "${ver}"
 }
 

--- a/xCAT-server/share/xcat/tools/mktoolscenter
+++ b/xCAT-server/share/xcat/tools/mktoolscenter
@@ -191,6 +191,8 @@ my $OSVER = "unknown";
 
 if (-e '/etc/SuSE-release') {
     $OSVER = `grep -h VERSION /etc/SuSE-release |awk '{print $3}'`
+} elsif (-e '/etc/SUSE-brand') {
+    $OSVER = `grep -h VERSION /etc/SUSE-brand |awk '{print $3}'`
 } elsif (-e '/etc/redhat-release') {
     $OSVER = "rhels" . `cat /etc/redhat-release |cut -f7 -d' '`;
     chomp($OSVER);

--- a/xCAT-server/xCAT-wsapi/xcatws.cgi
+++ b/xCAT-server/xCAT-wsapi/xcatws.cgi
@@ -3449,7 +3449,7 @@ sub fetchParameters {
         # in the sles 11.x, the 'PUTDATA' param is not supported for PUT method
         # so we have to work around it by getting it by myself
         unless ($pdata) {
-            if (-f "/etc/SuSE-release") {    # SUSE os
+            if ((-f "/etc/SuSE-release") || (-f "/etc/SUSE-brand")) {    # SUSE os
                 if ($ENV{'CONTENT_TYPE'} =~ /json/) {
                     $q->read_from_client(\$pdata, $ENV{'CONTENT_LENGTH'});
                 }

--- a/xCAT-test/autotest/testcase/probe/detect_dhcpd
+++ b/xCAT-test/autotest/testcase/probe/detect_dhcpd
@@ -12,7 +12,7 @@ if [ -e "/etc/redhat-release" ]; then
    if [ "$?" != "0" ] ;then
        yum install -y tcpdump
    fi
-elif [ -e "/etc/SuSE-release" ]; then
+elif [ -e "/etc/SuSE-release" ] || [ -e "/etc/SUSE-brand" ]; then
     rpm -qa |grep tcpdump
     if [ "$?" != "0" ] ;then
        zypper -n install tcpdump

--- a/xCAT-vlan/install/postscripts/configvlan
+++ b/xCAT-vlan/install/postscripts/configvlan
@@ -21,7 +21,7 @@ if [[ -z $VLANMAXINDEX ]] || [[ $VLANMAXINDEX -eq 0 ]]; then
 fi
 
 if [[ $OSTYPE = linux* ]]; then
-  if [[ $OSVER = sles* ]] || [[ $OSVER = suse* ]] || [[ -f /etc/SuSE-release ]]; then
+  if [[ $OSVER = sles* ]] || [[ $OSVER = suse* ]] || [[ -f /etc/SuSE-release ]] || [[ -f /etc/SUSE-base ]]; then
       nwdir="/etc/sysconfig/network"
       isSLES=1
   else
@@ -260,7 +260,7 @@ EOF
 	hostname $VLANHOSTNAME
 
         #change the hostname permanently
-	if [ -f /etc/SuSE-release ]
+	if [ -f /etc/SuSE-release ] || [ -f /etc/SUSE-brand ]
 	then
             #SLES x
 	    echo $VLANHOSTNAME > /etc/HOSTNAME

--- a/xCAT-vlan/install/postscripts/configvlan
+++ b/xCAT-vlan/install/postscripts/configvlan
@@ -21,7 +21,7 @@ if [[ -z $VLANMAXINDEX ]] || [[ $VLANMAXINDEX -eq 0 ]]; then
 fi
 
 if [[ $OSTYPE = linux* ]]; then
-  if [[ $OSVER = sles* ]] || [[ $OSVER = suse* ]] || [[ -f /etc/SuSE-release ]] || [[ -f /etc/SUSE-base ]]; then
+  if [[ $OSVER = sles* ]] || [[ $OSVER = suse* ]] || [[ -f /etc/SuSE-release ]] || [[ -f /etc/SUSE-brand ]]; then
       nwdir="/etc/sysconfig/network"
       isSLES=1
   else

--- a/xCAT-vlan/install/postscripts/deconfigvlan
+++ b/xCAT-vlan/install/postscripts/deconfigvlan
@@ -15,7 +15,7 @@ if [[ -z $VLANMAXINDEX ]] || [[ $VLANMAXINDEX -eq 0 ]]; then
 fi
 
 if [[ $OSTYPE = linux* ]]; then
-  if [[ $OSVER = sles* ]] || [[ $OSVER = suse* ]] || [[ -f /etc/SuSE-release ]]; then
+  if [[ $OSVER = sles* ]] || [[ $OSVER = suse* ]] || [[ -f /etc/SuSE-release ]] || [[ -f /etc/SUSE-brand ]]; then
       nwdir="/etc/sysconfig/network"
       isSLES=1
   else
@@ -206,7 +206,7 @@ while [ $index -le $VLANMAXINDEX ]; do
 	hostname $NODE
 	
         #change the hostname permanently
-	if [ -f /etc/SuSE-release ]
+	if [ -f /etc/SuSE-release ] || [ -f /etc/SUSE-brand ]
 	then
             #SLES x
 	    echo $NODE > /etc/HOSTNAME

--- a/xCAT/postscripts/configfirewall
+++ b/xCAT/postscripts/configfirewall
@@ -143,7 +143,7 @@ if (-f "/etc/redhat-release")
     #system($cmd);
     xCAT::Utils->enableservice("iptables");
 }
-elsif (-f "/etc/SuSE-release")
+elsif ((-f "/etc/SuSE-release") || (-f "/etc/SUSE-brand"))
 {
     my $conffile;
     my $conf;

--- a/xCAT/postscripts/configib
+++ b/xCAT/postscripts/configib
@@ -165,7 +165,7 @@ then
     if [ -f /etc/redhat-release ]
     then
         OS_name="redhat"
-    elif [ -f /etc/SuSE-release ]
+    elif [ -f /etc/SuSE-release ] || [ -f /etc/SUSE-brand ]
     then
         OS_name="suse"
     elif [ -f /etc/os-release ] && cat /etc/os-release |grep NAME|grep Ubuntu>/dev/null

--- a/xCAT/postscripts/enablekdump
+++ b/xCAT/postscripts/enablekdump
@@ -40,7 +40,7 @@ for i in `/bin/cat /proc/cmdline`; do
 done
 
 if [ ! -z "$MACX" ] && [ ! -z "$ETHX" ]; then
-	if (pmatch $OSVER "sle*") || (pmatch $OSVER "suse*") || [ -f /etc/SuSE-release ]; then
+	if (pmatch $OSVER "sle*") || (pmatch $OSVER "suse*") || [ -f /etc/SuSE-release ] || [ -f /etc/SUSE-brand ]; then
 		CONFFILE=$MNTDIR/etc/sysconfig/network/ifcfg-$ETHX
 	fi
 	if (pmatch $OSVER "fedora*") || (pmatch $OSVER "rhel6*") || (pmatch $OSVER "rhels6*") || [ -f /etc/fedora-release ] || [ -f /etc/redhat-release ];then
@@ -104,7 +104,7 @@ if [ ! -z "$DUMP" ]; then
     fi
 
     if [ "$KDPROTO" = "nfs" ]; then
-	if (pmatch $OSVER "sle*") || (pmatch $OSVER "suse*") || [ -f /etc/SuSE-release ]; then
+	if (pmatch $OSVER "sle*") || (pmatch $OSVER "suse*") || [ -f /etc/SuSE-release ] || [ -f /etc/SUSE-brand ]; then
             if (pmatch $OSVER "*10*"); then
                 #run mkinitrd to generater the kdump-init base
                 if (pmatch $ARCH "x86*"); then

--- a/xCAT/postscripts/killsyslog
+++ b/xCAT/postscripts/killsyslog
@@ -5,7 +5,7 @@
 # (so /a can be umounted cleanly)
 # SI post-install scripts run in a chroot environment of the final OS image
 
-if [ -f "/etc/SuSE-release" ];then
+if [ -f "/etc/SuSE-release" ] || [ -f "/etc/SUSE-brand" ] ;then
     str_out=`ps -ef | grep -v grep | grep syslog-ng`
     if [ $? -eq 0 ];then
         str_id=`echo $str_out | awk '{print $2}'`

--- a/xCAT/postscripts/routeop
+++ b/xCAT/postscripts/routeop
@@ -206,7 +206,7 @@ replace_persistent_route()
     if [ -f /etc/redhat-release ]
     then
         OS_name="redhat"  #it can be RedHatFerdora or CentOS
-    elif [ -f /etc/SuSE-release ]
+    elif [ -f /etc/SuSE-release ] || [ -f /etc/SUSE-brand ]
     then
         OS_name="sles"
     else
@@ -407,7 +407,7 @@ add_persistent_route()
     if [ -f /etc/redhat-release ]
     then
         OS_name="redhat"  #it can be RedHatFerdora or CentOS
-    elif [ -f /etc/SuSE-release ]
+    elif [ -f /etc/SuSE-release ] || [ -f /etc/SUSE-brand ]
     then
         OS_name="sles"
     else
@@ -647,7 +647,7 @@ rm_persistent_route()
     if [ -f /etc/redhat-release ]
     then
         OS_name="redhat"  #it can be RedHatFerdora or CentOS
-    elif [ -f /etc/SuSE-release ]
+    elif [ -f /etc/SuSE-release ] || [ -f /etc/SUSE-brand ]
     then
         OS_name="sles"
     else

--- a/xCAT/postscripts/setupntp.traditional
+++ b/xCAT/postscripts/setupntp.traditional
@@ -94,7 +94,7 @@ if [ $OS_TYPE = Linux ]; then
 
     mkdir -p /var/lib/ntp
     chown ntp /var/lib/ntp
-    if ( pmatch $OSVER "sle*" ) || ( pmatch $OSVER "suse*" ) || [ -f /etc/SuSE-release ];then
+    if ( pmatch $OSVER "sle*" ) || ( pmatch $OSVER "suse*" ) || [ -f /etc/SuSE-release ] || [ -f /etc/SUSE-brand ];then
         echo "driftfile /var/lib/ntp/drift/ntp.drift" >>$conf_file
     else
         echo "driftfile /var/lib/ntp/drift" >>$conf_file
@@ -135,7 +135,7 @@ if [ $OS_TYPE = Linux ]; then
     hwclock --systohc --utc
 
     #setup the RTC is UTC format, which will be used by os
-    if ( pmatch $OSVER "sle*" ) || ( pmatch $OSVER "suse*" ) || [ -f /etc/SuSE-release ];then
+    if ( pmatch $OSVER "sle*" ) || ( pmatch $OSVER "suse*" ) || [ -f /etc/SuSE-release ] || [ -f /etc/SUSE-brand ];then
         grep -i -q "HWCLOCK" /etc/sysconfig/clock
         if [ $? -eq 0 ];then
             sed -i 's/.*HWCLOCK.*/HWCLOCK=\"-u\"/' /etc/sysconfig/clock

--- a/xCAT/postscripts/syslog
+++ b/xCAT/postscripts/syslog
@@ -336,7 +336,7 @@ if [ "$(uname -s)" = "Linux" ]; then
       fi
     fi
   else
-    if ( pmatch $OSVER "sle*" ) || ( pmatch $OSVER "suse*" ) || [ -f /etc/SuSE-release ]; then
+    if ( pmatch $OSVER "sle*" ) || ( pmatch $OSVER "suse*" ) || [ -f /etc/SuSE-release ] || [ -f /etc/SUSE-brand ]; then
       #find out which syslog is used for SLES, syslog or syslog-ng
       result=`grep "^SYSLOG_DAEMON=" $sysconfig 2>&1`
       if ( pmatch $result "*syslog-ng*" ); then

--- a/xCAT/postscripts/xcatdsklspost
+++ b/xCAT/postscripts/xcatdsklspost
@@ -537,9 +537,13 @@ else # for common mode  MODE=1,2,3,5 (updatenode,moncfg,node deployment)
     # download poscripts has not worked yet
     #try the dhcp server, this is used for initial boot for the node.
     if [ $downloaded -eq 0 ]; then
-        #setup $OSVER ,for SLES11
+        #setup $OSVER ,for SLES12 and earlier
         if [ -e '/etc/SuSE-release' ]; then
             OSVER=`grep -h VERSION /etc/SuSE-release |awk '{print $3}'`
+        fi
+        #setup $OSVER ,for SLES15 and later
+        if [ -e '/etc/SUSE-brand' ]; then
+            OSVER=`grep -h VERSION /etc/SUSE-brand |awk '{print $3}'`
         fi
         SIPS=`grep -h dhcp-server-identifier /var/lib/dhclient/dhclient*eth*.leases 2> /dev/null|awk '{print $3}'|sed -e 's/;//'`
         if [ -z "$SIPS" ]; then


### PR DESCRIPTION
### The PR is to fix issue _#7231_

File `/etc/SuSE-release` is present on SLES12, but no longer there on SLES15.
Both SLES12 and SLES15 contain file `/etc/SUSE-brand`

This PR adds a check for `/etc/SUSE-brand` either for identification of SLES OS, or for determining SLES version. 