### PR TITLE
Remove invalid default gateway on RHEL 8.x systems

### DIFF
--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -702,6 +702,15 @@ elif [ "$1" = "-s" ];then
         hostname $NODE
         echo $NODE > /etc/HOSTNAME
     else
+        # Extract the first numeric part of the VERSION_ID, ignoring any non-numeric characters.
+        os_major_version=`cat /etc/os* | grep VERSION_ID | cut -d '=' -f2 | sed s/\"//g | cut -d "." -f1`
+
+        if [[ -z "${os_major_version}" ]] ; then
+          logger -t xcat -p local4.err "configeth: Could not determine the OS version, defaulting to the RHEL 7 behavior"
+          log_warn "configeth on $NODE: Could not determine the OS version, defaulting to the RHEL 7 behavior"
+          os_major_version=7
+        fi 
+    
         #write ifcfg-* file for redhat
         con_name="xcat-"${str_inst_nic}
         str_inst_prefix=$(v4mask2prefix ${str_inst_mask})
@@ -732,7 +741,11 @@ elif [ "$1" = "-s" ];then
             echo "ONBOOT=yes" >> $str_conf_file
             echo "NAME=${con_name}" >> $str_conf_file
             echo "HWADDR=${str_inst_mac}" >> $str_conf_file
-            echo "GATEWAY=${str_inst_gateway}" >> $str_conf_file
+
+            # Add GATEWAY to $str_conf_file only if the OS version is above RHEL 7.x.
+            if (( $os_major_version > 7 )) ; then
+              echo "GATEWAY=${str_inst_gateway}" >> $str_conf_file
+            fi
         fi
         if [ $networkmanager_active -eq 2 ]; then
             echo "AUTOCONNECT_PRIORITY=9" >> $str_conf_file
@@ -748,6 +761,18 @@ elif [ "$1" = "-s" ];then
             else
                 echo "MTU=${str_inst_mtu}" >> $str_conf_file
 	        fi
+        fi
+
+        # Add GATEWAY to the network file only if the OS version is RHEL 7.x or below.
+        if (( $os_major_version < 8 )) ; then
+          if [ -n "$str_inst_gateway" ];then
+              grep -i "GATEWAY" /etc/sysconfig/network
+              if [ $? -eq 0 ];then
+                  sed -i "s/.*GATEWAY.*/GATEWAY=${str_inst_gateway}/i" /etc/sysconfig/network
+              else
+                  echo "GATEWAY=${str_inst_gateway}" >> /etc/sysconfig/network
+              fi
+          fi
         fi
 	    #add extra params
         i=0

--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -715,7 +715,7 @@ elif [ "$1" = "-s" ];then
                 tmp_con_name=${str_inst_nic}"-tmp"
                 nmcli con modify $con_name connection.id $tmp_con_name
             fi
-            nmcli con add type ethernet con-name $con_name ifname ${str_inst_nic} ipv4.method manual ipv4.addresses  ${str_inst_ip}/${str_inst_prefix} connection.autoconnect-priority 9
+            nmcli con add type ethernet con-name $con_name ifname ${str_inst_nic} ipv4.method manual ipv4.addresses  ${str_inst_ip}/${str_inst_prefix} connection.autoconnect-priority 9 gw4 ${str_inst_gateway}
             str_conf_file_1="/etc/sysconfig/network-scripts/ifcfg-xcat-${str_inst_nic}-1"
             if [ -f $str_conf_file_1 ]; then
                 grep $con_name $str_conf_file_1 >/dev/null 2>/dev/null
@@ -732,6 +732,7 @@ elif [ "$1" = "-s" ];then
             echo "ONBOOT=yes" >> $str_conf_file
             echo "NAME=${con_name}" >> $str_conf_file
             echo "HWADDR=${str_inst_mac}" >> $str_conf_file
+            echo "GATEWAY=${str_inst_gateway}" >> $str_conf_file
         fi
         if [ $networkmanager_active -eq 2 ]; then
             echo "AUTOCONNECT_PRIORITY=9" >> $str_conf_file
@@ -747,14 +748,6 @@ elif [ "$1" = "-s" ];then
             else
                 echo "MTU=${str_inst_mtu}" >> $str_conf_file
 	        fi
-        fi
-        if [ -n "$str_inst_gateway" ];then
-            grep -i "GATEWAY" /etc/sysconfig/network
-            if [ $? -eq 0 ];then
-                sed -i "s/.*GATEWAY.*/GATEWAY=${str_inst_gateway}/i" /etc/sysconfig/network
-            else
-                echo "GATEWAY=${str_inst_gateway}" >> /etc/sysconfig/network
-            fi
         fi
 	    #add extra params
         i=0


### PR DESCRIPTION
(A) Network information on a RHEL 8.6 system (a Compute Node or CN) was recorded for the following three steps:
(1)	Provisioned RHEL 8.6 on a CN from a Management Node (or MN) with “confignetwork -s” as one of the postscript operations, where “-s” corresponds to the use of static address for the boot network interface. Without “-s”, a DHCP server is called.
(2)	After the CN is installed, ran **updatenode CN -P “confignetwork -s”** on the MN.
(3)	Ran **updatenode CN -P “confignetwork -s”** on the MN one more time.

Note that all the network data were obtained on the CN.

(1) Right after the CN was provisioned:

```
# ip route
default via 10.0.0.102 dev enp0s1 proto static metric 100
default via 10.0.0.102 dev enp0s2 proto static metric 101
10.0.0.0/8 dev enp0s1 proto kernel scope link src 10.3.11.15 metric 100
10.0.0.102 dev enp0s2 proto static scope link metric 101
50.0.0.0/8 dev enp0s2 proto kernel scope link src 50.3.11.15 metric 101
```

There were two NICs connecting to the default gateway 10.0.0.102. However, enp0s2 was on the 50. network and was invalid. Since enp0s1 (on 10. Network) was the first NIC for accessing the gateway, further downloading of packages was fine. However, if enp0s2 was the first NIC for accessing the gateway (due to the non-deterministic nature of NetworkManager on setting up these two NICs), no more downloading of packages was possible. In many situations, it means the CN is no longer operational.

The reason of having two NICs leading to the gateway is that GATEWAY=10.0.0.102 was in /etc/sysconfig/network which is applicable for all NICs on the system as far as NetworkManger is concerned. Again, the problem here is that enp0s2 was on the 50. network, not 10. network.

```
# cd /etc/sysconfig/
# cat network
# Created by anaconda
GATEWAY=10.0.0.102

# cd /etc/sysconfig/network-scripts
# ls -lrt
total 24
-rw-r--r--. 1 root root   7 Aug 17 12:01 xcat_history_important
-rw-r--r--. 1 root root 288 Aug 17 12:01 ifcfg-enp0s1
-rw-r--r--. 1 root root 150 Aug 17 12:01 ifcfg-xcat-enp0s1
-rw-r--r--. 1 root root 248 Aug 17 12:01 ifcfg-enp0s3
-rw-r--r--. 1 root root 248 Aug 17 12:01 ifcfg-enp0s2
-rw-r--r--. 1 root root 116 Aug 17 12:01 ifcfg-xcat-enp0s2

# cat ifcfg-xcat-enp0s1
DEVICE=enp0s1
IPADDR=10.3.11.15
NETMASK=255.0.0.0
BOOTPROTO=none
ONBOOT=yes
NAME=xcat-enp0s1
HWADDR=42:7a:0a:03:0b:0f
AUTOCONNECT_PRIORITY=9
MTU=1500
```

Note that GATEWAY information is NOT in this file.

```
# nmcli con show
NAME           UUID                                  TYPE      DEVICE
enp0s3         40702fda-330c-408c-b287-0c07075de0a9  ethernet  enp0s3
xcat-enp0s1    f2190402-0449-4607-31ff-a863a3ae7ba7  ethernet  enp0s1
xcat-enp0s2    fe177797-2385-37a5-a5b2-507b6f621ea2  ethernet  enp0s2
enp0s2         f8893382-bc9b-48e3-b4f8-35b6cb20b969  ethernet  --
System enp0s1  8eee662c-6b2e-47c2-bfe2-962ddfeaff36  ethernet  --
```

Note that NAME corresponds to NAME in any ifcfg file. It is also called connection.id in the nmcli command. For example, ifcfg-enp0s1 had its NAME as “System enp0s1” and ifcfg-xcat-enp0s1 xcat-enp0s1. These were the two names for device enp0s1. However, NetworkManager uses only one connection at any time. When one connection is deleted, the next one (if there is another one) is picked up to continue the connection. It leads me to think that the full content of each ifcfg file is saved by NetworkManager, although **nmcli d show** only shows the **current** attributes of all the interfaces. 

And the ifcfg-enp0s1 file can be deleted by **nmcli con delete “System enp0s1”** where “System enp0s1” is a unique connection ID for that ifcfg file.

Here is the portion of enp0s1 returned by **nmcli d show**:
```
GENERAL.DEVICE:                         enp0s1
GENERAL.TYPE:                           ethernet
GENERAL.HWADDR:                         42:7A:0A:03:0B:0F
GENERAL.MTU:                            1500
GENERAL.STATE:                          100 (connected)
GENERAL.CONNECTION:                     xcat-enp0s1
GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/1
WIRED-PROPERTIES.CARRIER:               on
IP4.ADDRESS[1]:                         10.3.11.15/8
IP4.GATEWAY:                            10.0.0.102
IP4.ROUTE[1]:                           dst = 10.0.0.0/8, nh = 0.0.0.0, mt = 100
IP4.ROUTE[2]:                           dst = 0.0.0.0/0, nh = 10.0.0.102, mt = 100
IP6.ADDRESS[1]:                         fe80::407a:aff:fe03:b0f/64
IP6.GATEWAY:                            --
IP6.ROUTE[1]:                           dst = fe80::/64, nh = ::, mt = 256
```

The attributes are filled in from ifcfg-enpos1 initially and updated by ifcfg-xcat-enp0s1 later. Note that NAME=”System enp0s1” initially and was replaced by xcat-enp0s1 later.

After the first updatenode with “confignetwork -s”.

```
# ip route
default via 10.0.0.102 dev enp0s2 proto static metric 101
default via 10.0.0.102 dev enp0s1 proto static metric 103
10.0.0.0/8 dev enp0s1 proto kernel scope link src 10.3.11.15 metric 103
10.0.0.102 dev enp0s2 proto static scope link metric 101
50.0.0.0/8 dev enp0s2 proto kernel scope link src 50.3.11.15 metric 101
```

At this time, enp0s2 was the first NIC to access the gateway. Anymore gateway operations would fail at this point.

```
# cd /etc/sysconfig/network-scripts
# ls -lrt
total 24
-rw-r--r--. 1 root root   7 Aug 17 12:01 xcat_history_important
-rw-r--r--. 1 root root 288 Aug 17 12:01 ifcfg-enp0s1
-rw-r--r--. 1 root root 248 Aug 17 12:01 ifcfg-enp0s3
-rw-r--r--. 1 root root 248 Aug 17 12:01 ifcfg-enp0s2
-rw-r--r--. 1 root root 116 Aug 17 12:01 ifcfg-xcat-enp0s2
-rw-r--r--  1 root root 365 Aug 17 13:15 ifcfg-xcat-enp0s1-1
```

We see here that ifcfg-xcat-enp0s1-1 was created and ifcfg-xcat-enp0s1 was deleted.

Let’s get deeper.

On Line 159 of configeth, the NetworkManager modifies the NAME in ifcfg-xcat-enp0s1 from **xcat-enp0s1** to **xcat-tmp**.

One Line 161 of configeth, a new connection of enp0s1 is created:
                nmcli con add type ethernet con-name $con_name ifname ${str_if_name} ipv4.method manual  ipv4.addresses  ${str_v4ip}/${str_prefix} connection.autoconnect-priority 9
            
where $con_name is  xcat-enp0s1 (NAME or connection.id) and str_if_name is enp0s1 (interface name).

Why do we have ifcfg-xcat-enp0s1-1?

NetworkManager wants to create ifcfg-xcat-enp0s1 but finds there is one there already, so it creates ifcfg-xcat-enp0s1-1 and sets its NAME to xcat-enp0s1.

At this point, the older one had the NAME **xcat-tmp** and the new one **xcat-enp0s1**.

On Line 813, it has **nmcli con delete xcat-tmp**, so ifcfg-xcat-enp0s1 is deleted since its NAME currently has **xcat-tmp**.

Now, ran updatenode CN -P “confignetwork -s” one more time.

```
# ip route
default via 10.0.0.102 dev enp0s2 proto static metric 101
default via 10.0.0.102 dev enp0s1 proto static metric 102
10.0.0.0/8 dev enp0s1 proto kernel scope link src 10.3.11.15 metric 102
10.0.0.102 dev enp0s2 proto static scope link metric 101
50.0.0.0/8 dev enp0s2 proto kernel scope link src 50.3.11.15 metric 101

# pwd
/etc/sysconfig/network-scripts
# ls -lrt
total 24
-rw-r--r--. 1 root root   7 Aug 17 12:01 xcat_history_important
-rw-r--r--. 1 root root 288 Aug 17 12:01 ifcfg-enp0s1
-rw-r--r--. 1 root root 248 Aug 17 12:01 ifcfg-enp0s3
-rw-r--r--. 1 root root 248 Aug 17 12:01 ifcfg-enp0s2
-rw-r--r--. 1 root root 116 Aug 17 12:01 ifcfg-xcat-enp0s2
-rw-r--r--  1 root root 365 Aug 17 13:53 ifcfg-xcat-enp0s1
```

What happens here? ifcfg-xcat-enp0s1 was created and ifcfg-xcat-enp0s1-1 was deleted.

The reason is that **nmcli con add xcat-enp0s1** is called and since there is no ifcfg-xcat-enp0s1 there, so ifcfg-xcat-enp0s1 (NOT ifcfg-xcat-enp0s1-2) is created.

Change the NAME of ifcfg-xcat-enp0s1-1 to xcat-tmp and delete it later on, so ifcfg-xcat-enp0s1-1 is deleted. That is the reason we see the toggling between ifcfg-xcat-enp0s1 and ifcfg-xcat-enp0s1-1 with successive **updatenode CN -P “confignetwork -s”** calls.

What happens with my code changes?

After the provisioning of the CN:

```
# ip route
default via 10.0.0.102 dev enp0s1 proto static metric 100
10.0.0.0/8 dev enp0s1 proto kernel scope link src 10.3.11.15 metric 100
50.0.0.0/8 dev enp0s2 proto kernel scope link src 50.3.11.15 metric 102
```

There is only one default gateway accessed through the boot interface enp0s1.

```
# pwd
/etc/sysconfig
# cat network
# Created by anaconda
```

My code does not put the GATEWAY information in this file. And, the GATEWAY is put in the boot interface enp0s1, without which we would not have any default gateway.

```
# cd /etc/sysconfig/network-scripts
# ls -lrt
total 24
-rw-r--r--. 1 root root   7 Aug 17 14:09 xcat_history_important
-rw-r--r--. 1 root root 248 Aug 17 14:09 ifcfg-enp0s3
-rw-r--r--. 1 root root 248 Aug 17 14:09 ifcfg-enp0s2
-rw-r--r--. 1 root root 288 Aug 17 14:09 ifcfg-enp0s1
-rw-r--r--. 1 root root 116 Aug 17 14:09 ifcfg-xcat-enp0s2
-rw-r--r--. 1 root root 169 Aug 17 14:09 ifcfg-xcat-enp0s1

# cat ifcfg-xcat-enp0s1
DEVICE=enp0s1
IPADDR=10.3.11.15
NETMASK=255.0.0.0
BOOTPROTO=none
ONBOOT=yes
NAME=xcat-enp0s1
HWADDR=42:7a:0a:03:0b:0f
GATEWAY=10.0.0.102
AUTOCONNECT_PRIORITY=9
MTU=1500
```
We can see GATEWAY is in this file. It is put in by my code.

After the first updatenode with “confignetwork -s”.

```
# ip route
default via 10.0.0.102 dev enp0s1 proto static metric 103
10.0.0.0/8 dev enp0s1 proto kernel scope link src 10.3.11.15 metric 103
50.0.0.0/8 dev enp0s2 proto kernel scope link src 50.3.11.15 metric 102

# cd /etc/sysconfig/network-scripts
# ls -lrt
total 24
-rw-r--r--. 1 root root   7 Aug 17 14:09 xcat_history_important
-rw-r--r--. 1 root root 248 Aug 17 14:09 ifcfg-enp0s3
-rw-r--r--. 1 root root 248 Aug 17 14:09 ifcfg-enp0s2
-rw-r--r--. 1 root root 288 Aug 17 14:09 ifcfg-enp0s1
-rw-r--r--. 1 root root 116 Aug 17 14:09 ifcfg-xcat-enp0s2
-rw-r--r--  1 root root 365 Aug 17 14:22 ifcfg-xcat-enp0s1-1

# cat ifcfg-xcat-enp0s1-1
TYPE=Ethernet
PROXY_METHOD=none
BROWSER_ONLY=no
BOOTPROTO=none
IPADDR=10.3.11.15
PREFIX=8
GATEWAY=10.0.0.102
DEFROUTE=yes
IPV4_FAILURE_FATAL=no
IPV6INIT=yes
IPV6_AUTOCONF=yes
IPV6_DEFROUTE=yes
IPV6_FAILURE_FATAL=no
IPV6_ADDR_GEN_MODE=stable-privacy
NAME=xcat-enp0s1
UUID=179a8b6f-aeb4-47f4-a646-c7425bae2f4d
DEVICE=enp0s1
ONBOOT=yes
AUTOCONNECT_PRIORITY=9
MTU=1500
```

The GATEWAY information “gw4 ${str_inst_gateway}” is added to configeth on Line 718 while adding the new connection.

After the second updatenode with “confignetwork -s”.

```
# ip route
default via 10.0.0.102 dev enp0s1 proto static metric 103
10.0.0.0/8 dev enp0s1 proto kernel scope link src 10.3.11.15 metric 103
50.0.0.0/8 dev enp0s2 proto kernel scope link src 50.3.11.15 metric 102

# cat ifcfg-xcat-enp0s1
TYPE=Ethernet
PROXY_METHOD=none
BROWSER_ONLY=no
BOOTPROTO=none
IPADDR=10.3.11.15
PREFIX=8
GATEWAY=10.0.0.102
DEFROUTE=yes
IPV4_FAILURE_FATAL=no
IPV6INIT=yes
IPV6_AUTOCONF=yes
IPV6_DEFROUTE=yes
IPV6_FAILURE_FATAL=no
IPV6_ADDR_GEN_MODE=stable-privacy
NAME=xcat-enp0s1
UUID=db73ea71-0efb-45cb-9517-1b00608c12c9
DEVICE=enp0s1
ONBOOT=yes
AUTOCONNECT_PRIORITY=9
MTU=1500
```

The GATEWAY information is there too.

= = = = = = = = = = = = = = = = = = = = =

Now, let’s see what happens to RHEL 7.7 with “confignetwork -s” in these three steps without my changes.

After the provisioning:

```
# ip route
default via 10.0.0.102 dev eth0
10.0.0.0/8 dev eth0 proto kernel scope link src 10.3.9.9
50.0.0.0/8 dev eth1 proto kernel scope link src 50.3.9.9
169.254.0.0/16 dev eth0 scope link metric 1002
169.254.0.0/16 dev eth1 scope link metric 1003
```

I am not sure how 169.254.0.0 got into the picture and it is not part of this investigation.

```
# cd /etc/sysconfig/network-scripts
# cat network
# Created by anaconda
GATEWAY=10.0.0.102
```

The existing configeth code puts GATEWAY into the network file. However, eth1 on 50. does not tie to the gateway. The older software does the right thing. 

```
# cd /etc/sysconfig/network-scripts
# cat ifcfg-eth0
DEVICE=eth0
IPADDR=10.3.9.9
NETMASK=255.0.0.0
BOOTPROTO=none
ONBOOT=yes
NAME=xcat-eth0
MTU=1500
```

ifcfg-eth0 does not have the GATEWAY information as expected.

This is the eth0 record by NetworkManager. Note that NetworkManager does not normally run on RHEL 7.7.
```
GENERAL.DEVICE:                         eth0
GENERAL.TYPE:                           ethernet
GENERAL.HWADDR:                         42:E3:0A:03:09:09
GENERAL.MTU:                            1500
GENERAL.STATE:                          100 (connected)
GENERAL.CONNECTION:                     xcat-eth0
GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/1
WIRED-PROPERTIES.CARRIER:               on
IP4.ADDRESS[1]:                         10.3.9.9/8
IP4.GATEWAY:                            10.0.0.102
IP4.ROUTE[1]:                           dst = 0.0.0.0/0, nh = 10.0.0.102, mt = 0
IP4.ROUTE[2]:                           dst = 10.0.0.0/8, nh = 0.0.0.0, mt = 0
IP4.ROUTE[3]:                           dst = 169.254.0.0/16, nh = 0.0.0.0, mt = 1002
IP4.ROUTE[4]:                           dst = 10.0.0.0/8, nh = 0.0.0.0, mt = 100
IP6.ADDRESS[1]:                         fe80::40e3:aff:fe03:909/64
IP6.GATEWAY:                            --
IP6.ROUTE[1]:                           dst = fe80::/64, nh = ::, mt = 256
IP6.ROUTE[2]:                           dst = ff00::/8, nh = ::, mt = 256, table=255
```

It is clear that the code that create xcat-enp0s1 and xcat-enp0s1-1 is not hit when NetworkManager is not used. 

After the first updatenode CN -P “confignetwork -s”:

The above network data remain the same here.

After the second updatenode CN -P “confignetwork -s”:

The above network data remain the same here.

Now, with my code changes.

After the provisioning:

```
# ip route
default via 10.0.0.102 dev eth0
10.0.0.0/8 dev eth0 proto kernel scope link src 10.3.9.9
50.0.0.0/8 dev eth1 proto kernel scope link src 50.3.9.9
169.254.0.0/16 dev eth0 scope link metric 1002
169.254.0.0/16 dev eth1 scope link metric 1003

# cd /etc/sysconfig
# cat network
# Created by anaconda
```

My code removes the GATEWAY information here.

```
# cd /etc/sysconfig/network-scripts
# cat ifcfg-eth0
DEVICE=eth0
IPADDR=10.3.9.9
NETMASK=255.0.0.0
BOOTPROTO=none
ONBOOT=yes
NAME=xcat-eth0
GATEWAY=10.0.0.102
MTU=1500
```

My code adds GATEWAY information to ifcfg-eth0.

This is the eth0 record by NetworkManager.
```
GENERAL.DEVICE:                         eth0
GENERAL.TYPE:                           ethernet
GENERAL.HWADDR:                         42:E3:0A:03:09:09
GENERAL.MTU:                            1500
GENERAL.STATE:                          100 (connected)
GENERAL.CONNECTION:                     xcat-eth0
GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/1
WIRED-PROPERTIES.CARRIER:               on
IP4.ADDRESS[1]:                         10.3.9.9/8
IP4.GATEWAY:                            10.0.0.102
IP4.ROUTE[1]:                           dst = 0.0.0.0/0, nh = 10.0.0.102, mt = 0
IP4.ROUTE[2]:                           dst = 10.0.0.0/8, nh = 0.0.0.0, mt = 0
IP4.ROUTE[3]:                           dst = 169.254.0.0/16, nh = 0.0.0.0, mt = 1002
IP4.ROUTE[4]:                           dst = 10.0.0.0/8, nh = 0.0.0.0, mt = 100
IP6.ADDRESS[1]:                         fe80::40e3:aff:fe03:909/64
IP6.GATEWAY:                            --
IP6.ROUTE[1]:                           dst = fe80::/64, nh = ::, mt = 256
IP6.ROUTE[2]:                           dst = ff00::/8, nh = ::, mt = 256, table=255
```

After the first updatenode CN -P “confignetwork -s”:

The above network data remain the same here.

After the second updatenode CN -P “confignetwork -s”:

The above network data remain the same here.

My changes modify /etc/sysconfig/network and /etc/sysconfg/network-scripts/ifcfg-eth0, but there are no changes in network behaviors.

= = = = = =

In summary, my changes should fix the default gateway problem for RHEL 8.x systems.

In addition, the changes should not affect SLES and Ubuntu as they have their own codes.