### PR TITLE
Update xCAT-genesis-base.spec

### DIFF
--- a/xCAT-genesis-builder/xCAT-genesis-base.spec
+++ b/xCAT-genesis-builder/xCAT-genesis-base.spec
@@ -1,5 +1,5 @@
-%define version %(rpm -q xCAT --qf "%{VERSION}" 2>/dev/null)
-Version: %{?version:%{version}}%{!?version:%(cat Version)}
+%global version %(rpm -q xCAT --qf "%{VERSION}" 2>/dev/null | grep -Po '[0-9\.]+' || cat ../Version)
+Version: %{version}
 Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
 %ifarch i386 i586 i686 x86
 %define tarch x86

--- a/xCAT-genesis-builder/xCAT-genesis-base.spec
+++ b/xCAT-genesis-builder/xCAT-genesis-base.spec
@@ -1,4 +1,4 @@
-%global version %(rpm -q xCAT --qf "%{VERSION}" 2>/dev/null | grep -Po %%'[0-9\.]+' || echo "2.16.5")
+%global version %(rpm -q xCAT --qf "%{VERSION}" 2>/dev/null | grep -Po '[0-9\.]+' || echo "2.16.5")
 Version: %{version}
 Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
 %ifarch i386 i586 i686 x86

--- a/xCAT-genesis-builder/xCAT-genesis-base.spec
+++ b/xCAT-genesis-builder/xCAT-genesis-base.spec
@@ -1,4 +1,4 @@
-%define version     %%REPLACE_CURRENT_VERSION%%
+%define version %(rpm -q xCAT --qf "%{VERSION}" 2>/dev/null)
 Version: %{?version:%{version}}%{!?version:%(cat Version)}
 Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
 %ifarch i386 i586 i686 x86

--- a/xCAT-genesis-builder/xCAT-genesis-base.spec
+++ b/xCAT-genesis-builder/xCAT-genesis-base.spec
@@ -1,4 +1,4 @@
-%global version %(rpm -q xCAT --qf "%{VERSION}" 2>/dev/null | grep -Po '[0-9\.]+' || cat ../Version)
+%global version %(rpm -q xCAT --qf "%{VERSION}" 2>/dev/null | grep -Po %%'[0-9\.]+' || echo "2.16.5")
 Version: %{version}
 Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
 %ifarch i386 i586 i686 x86


### PR DESCRIPTION
Automatically get xCAT version from installed package, rather than having to manually replace the `%%REPLACE_CURRENT_VERSION%%` string.

Without this change, the `xCAT-genesis-builder` RPMs provided at https://xcat.org/files/xcat/xcat-dep/2.x_Linux/beta/ generate RPMs named like this:
```
Wrote: /root/rpmbuild/SRPMS/xCAT-genesis-base-x86_64-%REPLACE_CURRENT_VERSION.src.rpm
Wrote: /root/rpmbuild/RPMS/noarch/xCAT-genesis-base-x86_64-%REPLACE_CURRENT_VERSION.noarch.rpm
```