### PR TITLE
Fix non-local networks being skipped in makedhcp

### DIFF
--- a/xCAT-server/lib/xcat/plugins/dhcp.pm
+++ b/xCAT-server/lib/xcat/plugins/dhcp.pm
@@ -1966,9 +1966,7 @@ sub process_request
         my $netif = $line[1];
         if ($netif =~ /!remote!\S+/) {
             $netif =~ s/!remote!\s*(.*)$/$1/;
-            if (!defined($activenics{"!remote!"})) {
-                next;
-            } elsif (!defined($activenics{$netif})) {
+            if (!defined($activenics{$netif})) {
                 addnic($netif, \@dhcpconf);
                 $activenics{$netif} = 1;
             }


### PR DESCRIPTION
If this logic check exists all non-local virtual networks are skipped if the site table has dhcpinterfaces defined or if the node is an enabled service node with dhcpinterfaces defined. Obviously this requires querynics to occur and to have at least one network mgtifname be set to '!remote!' I'd be interested if anyone knows the consequences if any of removing these lines? Our setup does not work since we use the site table to define interfaces on a per service/management node definition. Maybe someone also has a recommendation of best configuration for a combination of service nodes and remote (non-local) networks? Do we use the site table or service node table for dhcpinterfaces? Or do we just use the networks table by itself?


