### PR TITLE
Revert "Provide an error message when a new node name is an existing group name"

### DIFF
--- a/perl-xCAT/xCAT/NodeRange.pm
+++ b/perl-xCAT/xCAT/NodeRange.pm
@@ -4,7 +4,6 @@ use Text::Balanced qw/extract_bracketed/;
 require xCAT::Table;
 require Exporter;
 use strict;
-use xCAT::MsgUtils;
 
 #Perl implementation of noderange
 our @ISA       = qw(Exporter);
@@ -294,9 +293,6 @@ sub expandatom {
                     #my @grouplist = $grptab->getAllAttribs('groupname');
                 for my $row (@grplist) {
                     if ($row->{groupname} eq $atom) {
-                        my $rsp;
-                        $rsp->{data}->[0] = "Could not create an object named \'$atom\' of type 'node'. A definition for a group object with the same name already exists.";
-                        xCAT::MsgUtils->message("E", $rsp, $::callback);
                         return ();
                     }
                 }

--- a/xCAT-test/autotest/bundle/rhels_ppcle_daily.bundle
+++ b/xCAT-test/autotest/bundle/rhels_ppcle_daily.bundle
@@ -151,7 +151,6 @@ mkdef_regex_nicsip
 mkdef_rhels73
 mkdef_t_o_error
 mkdef_z
-mkdef_nodename_hit_groupname
 nodeadd_err_symbol
 nodeadd_h
 nodeadd_noderange

--- a/xCAT-test/autotest/bundle/rhels_x86_daily.bundle
+++ b/xCAT-test/autotest/bundle/rhels_x86_daily.bundle
@@ -151,7 +151,6 @@ mkdef_regex_nicsip
 mkdef_rhels73
 mkdef_t_o_error
 mkdef_z
-mkdef_nodename_hit_groupname
 nodeadd_err_symbol
 nodeadd_h
 nodeadd_noderange

--- a/xCAT-test/autotest/bundle/sles_ppcle_daily.bundle
+++ b/xCAT-test/autotest/bundle/sles_ppcle_daily.bundle
@@ -110,7 +110,6 @@ mkdef_regex_kvm
 mkdef_regex_nicsip
 mkdef_t_o_error
 mkdef_z
-mkdef_nodename_hit_groupname
 nodeadd_err_symbol
 nodeadd_h
 nodeadd_noderange

--- a/xCAT-test/autotest/bundle/sles_x86_daily.bundle
+++ b/xCAT-test/autotest/bundle/sles_x86_daily.bundle
@@ -110,7 +110,6 @@ mkdef_regex_kvm
 mkdef_regex_nicsip
 mkdef_t_o_error
 mkdef_z
-mkdef_nodename_hit_groupname
 nodeadd_err_symbol
 nodeadd_h
 nodeadd_noderange

--- a/xCAT-test/autotest/bundle/ubuntu_ppcle_daily.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu_ppcle_daily.bundle
@@ -79,7 +79,6 @@ mkdef_regex_kvm
 mkdef_regex_nicsip
 mkdef_t_o_error
 mkdef_z
-mkdef_nodename_hit_groupname
 nodeadd_err_symbol
 nodeadd_h
 nodeadd_noderange

--- a/xCAT-test/autotest/bundle/ubuntu_x86_daily.bundle
+++ b/xCAT-test/autotest/bundle/ubuntu_x86_daily.bundle
@@ -81,7 +81,6 @@ mkdef_regex_kvm
 mkdef_regex_nicsip
 mkdef_t_o_error
 mkdef_z
-mkdef_nodename_hit_groupname
 nodeadd_err_symbol
 nodeadd_h
 nodeadd_noderange

--- a/xCAT-test/autotest/testcase/mkdef/cases1
+++ b/xCAT-test/autotest/testcase/mkdef/cases1
@@ -150,24 +150,3 @@ check:rc==0
 cmd:rmdef -t group -o xcattest_tmp_group_regex
 check:rc==0
 end
-
-start:mkdef_nodename_hit_groupname
-cmd:mkdef -t group -o tempgroup13579
-check:rc==0
-cmd:mkdef -t node -o tempgroup13579 groups=tempgroup13579
-check:rc==1
-check:output=~A definition for a group object with the same name already exists.
-check:output=~No object names were provided
-cmd:mkdef -t node -o tempgroup13579 groups=all
-check:rc==1
-check:output=~A definition for a group object with the same name already exists.
-check:output=~No object names were provided
-cmd:mkdef -t node -o tempnode02468,tempgroup13579 groups=tempgroup13579
-check:rc==1
-check:output=~A definition for a group object with the same name already exists.
-check:output=~1 object definitions have been created
-cmd:rmdef -t node -o tempnode02468
-check:rc==0
-cmd:rmdef -t group -o tempgroup13579
-check:rc==0
-end


### PR DESCRIPTION
Revert xcat2/xcat-core#7159

It turns out the expandatom routine is called from a wide range of xCAT calls. The error message given out can be confusing when no node is created.

We will revisit Issue 6418 https://github.com/xcat2/xcat-core/issues/6418 later.