### PR TITLE
mknb: Correctly specify initrd file when generating netboot configs.

### DIFF
--- a/xCAT-server/lib/xcat/plugins/mknb.pm
+++ b/xCAT-server/lib/xcat/plugins/mknb.pm
@@ -300,14 +300,10 @@ sub process_request {
             print $cfg "#!gpxe\n";
             if ($invisibletouch) {
                 print $cfg 'imgfetch -n kernel http://${next-server}:'.$httpport.'/tftpboot/xcat/genesis.kernel.' . "$arch quiet xcatd=" . $normnets->{$_} . ":$xcatdport $consolecmdline BOOTIF=01-" . '${netX/machyp}' . "\n";
-                if ($lzma_exit_value) {
-                    print $cfg 'imgfetch -n nbfs http://${next-server}:'.$httpport.'/tftpboot/xcat/genesis.fs.' . "$arch.gz\n";
-                } else {
-                    print $cfg 'imgfetch -n nbfs http://${next-server}:'.$httpport.'/tftpboot/xcat/genesis.fs.' . "$arch.lzma\n";
-                }
+                print $cfg 'imgfetch -n nbfs http://${next-server}:'.$httpport . "$initrd_file\n";
             } else {
                 print $cfg 'imgfetch -n kernel http://${next-server}:'.$httpport.'/tftpboot/xcat/nbk.' . "$arch quiet xcatd=" . $normnets->{$_} . ":$xcatdport $consolecmdline\n";
-                print $cfg 'imgfetch -n nbfs http://${next-server}:'.$httpport.'/tftpboot/xcat/nbfs.' . "$arch.gz\n";
+                print $cfg 'imgfetch -n nbfs http://${next-server}:'.$httpport . "$initrd_file\n";
             }
             print $cfg "imgload kernel\n";
             print $cfg "imgexec kernel\n";
@@ -318,18 +314,14 @@ sub process_request {
                 print $cfg "   delay=5\n";
                 print $cfg '   image=/tftpboot/xcat/genesis.kernel.' . "$arch\n";
                 print $cfg "   label=\"xCAT Genesis (" . $normnets->{$_} . ")\"\n";
-                if ($lzma_exit_value) {
-                    print $cfg "   initrd=/tftpboot/xcat/genesis.fs.$arch.gz\n";
-                } else {
-                    print $cfg "   initrd=/tftpboot/xcat/genesis.fs.$arch.lzma\n";
-                }
+                print $cfg "   initrd=$initrd_file\n";
                 print $cfg "   append=\"quiet xcatd=" . $normnets->{$_} . ":$xcatdport destiny=discover $consolecmdline BOOTIF=%B\"\n";
                 close($cfg);
                 open($cfg, ">", "$tftpdir/xcat/xnba/nets/$net.uefi");
                 print $cfg "#!gpxe\n";
                 print $cfg 'imgfetch -n kernel http://${next-server}:'.$httpport.'/tftpboot/xcat/genesis.kernel.' . "$arch\nimgload kernel\n";
                 print $cfg "imgargs kernel quiet xcatd=" . $normnets->{$_} . ":$xcatdport $consolecmdline BOOTIF=01-" . '${netX/mac:hexhyp}' . " destiny=discover initrd=initrd\n";
-                print $cfg 'imgfetch -n initrd http://${next-server}:'.$httpport.'/tftpboot/xcat/genesis.fs.' . "$arch.gz\nimgexec kernel\n";
+                print $cfg 'imgfetch -n initrd http://${next-server}:'.$httpport . "$initrd_file\nimgexec kernel\n";
                 close($cfg);
             }
         } elsif ($arch =~ /ppc/) {
@@ -364,11 +356,12 @@ sub process_request {
             }
         }
         if ($dopxe) {
+            my ($ignored, $tftp_initrd) = split /\/tftpboot\//, $initrd_file, 2;
             open($cfgfile, ">", "$tftpdir/pxelinux.cfg/" . uc($_));
             print $cfgfile "DEFAULT xCAT\n";
             print $cfgfile "  LABEL xCAT\n";
             print $cfgfile "  KERNEL xcat/nbk.$arch\n";
-            print $cfgfile "  APPEND initrd=xcat/nbfs.$arch.gz quiet xcatd=" . $hexnets->{$_} . ":$xcatdport $consolecmdline\n";
+            print $cfgfile "  APPEND initrd=$tftp_initrd quiet xcatd=" . $hexnets->{$_} . ":$xcatdport $consolecmdline\n";
             close($cfgfile);
         } elsif ($arch =~ /ppc/) {
             open($cfgfile, ">", "$tftpdir/etc/" . lc($_));


### PR DESCRIPTION
The mknb command builds a new initrd file from the filesystem under `/opt/xcat/share/xcat/netboot/genesis/<arch>/fs` and creates netboot config files under `/tftpboot/xcat/xnba/nets/` and `/tftpboot/pxelinux.cfg/` to support booting nodes using the newly created initrd file.  mknb will attempt to compress the initrd using lzma, falling back to gzip if that fails; the suffix of the initrd file will thus depend on whether lzma runs successfully. It should ensure that the generated netboot config files use the correct initrd file name in all cases.

The code which generates the netboot config files was correctly checking for success of the lzma compression and specifying the `.lzma` suffix in some cases, but was using a hard-coded `.gz` suffix in a few cases. This change fixes those cases, as well as cleaning up some of the associated code.

Testing with `mknb x86_64` and `mknb ppc64` gave the expected result: the initrd specified in the generated files matches the initrd created earlier in the script, or the existing image when run with `-c`.

I'm not certain that some of these code paths are correct in other ways - some of the config files specify 'KERNEL xcat/nbk.$arch', but nothing I can see creates that file; there are code paths that create `/tftpboot/xcat/nbfs.$arch.gz` as specified elsewhere in the file, which suggests it should be creating the nbk.$arch kernel file but isn't. It's very hard to know if this is legacy code that can be removed, or if it needs to be updated to create the `nbk.$arch` file, so I haven't tried to change that behaviour.

Also note that the `-c` code path assumes that if an lzma image exists it should be used, rather than specifying the newest image file regardless of the suffix - this is probably incorrect, but I haven't tried to change this behviour either.

As always, I'm happy to make any changes requested.