### PR TITLE
Support for diskful Ubuntu20.04 legacy OS image

### DIFF
--- a/xCAT-server/lib/perl/xCAT/SvrUtils.pm
+++ b/xCAT-server/lib/perl/xCAT/SvrUtils.pm
@@ -691,6 +691,7 @@ sub update_tables_with_templates
     my $arch         = shift;    #like ppc64, x86, x86_64
     my $ospkgdir     = shift;
     my $osdistroname = shift;
+    my $legacyUB20   = shift;
     my %args         = @_;
 
     my $osname    = $osver;;     #like sles, rh, centos, windows
@@ -722,7 +723,7 @@ sub update_tables_with_templates
         # for Focal and later Ubuntu we repurpose genos to indicate the use
         # of the subiquity installer
         if ($osver =~ /ubuntu(\d+\.\d+)/) {
-            if ($1 >= 20.04) {
+            if (($1 >= 20.04) and ($legacyUB20 !~ /legacy/)) {
                 $genos = "subiquity";
             }
         }

--- a/xCAT-server/share/xcat/install/ubuntu/compute.tmpl
+++ b/xCAT-server/share/xcat/install/ubuntu/compute.tmpl
@@ -143,6 +143,8 @@ d-i preseed/late_command string \
      mount -o bind /dev/pts /target/dev/pts -t devpts; \
      mount -o bind /sys /target/sys; \
      chroot /target /root/post.script; \
-     cp /target/etc/network/interfaces /etc/network/interfaces; \
+     if [ -f /target/etc/network/interfaces ]; then \
+       cp /target/etc/network/interfaces /etc/network/interfaces; \
+     fi; \
      } >>/target/var/log/xcat/xcat.log 2>&1
 


### PR DESCRIPTION
Support diskful installation of Ubuntu20.04 with legacy installer.

### UT:

#### Ubuntu 20.04.1 (legacy)
```
root@c910f04x12v05:/opt/xcat# copycds -i /tmp/automation_mountpoint/iso/ubuntu-20.04.1-legacy-server-amd64.iso
OS Image:/tmp/automation_mountpoint/iso/ubuntu-20.04.1-legacy-server-amd64.iso
DISTNAME:ubuntu20.04.1(legacy)
ARCH:amd64
DISCNO:1


root@c910f04x12v05:/opt/xcat# copycds /tmp/automation_mountpoint/iso/ubuntu-20.04.1-legacy-server-amd64.iso
Copying media to /install/ubuntu20.04.1/x86_64
Media copy operation successful
root@c910f04x12v05:/opt/xcat#

root@c910f04x12v05:/opt/xcat# lsdef -t osimage ubuntu20.04.1-x86_64-install-compute
Object name: ubuntu20.04.1-x86_64-install-compute
    imagetype=linux
    osarch=x86_64
    osname=Linux
    osvers=ubuntu20.04.1
    otherpkgdir=/install/post/otherpkgs/ubuntu20.04.1/x86_64
    pkgdir=/install/ubuntu20.04.1/x86_64
    pkglist=/opt/xcat/share/xcat/install/ubuntu/compute.ubuntu20.04.x86_64.pkglist
    profile=compute
    provmethod=install
    template=/opt/xcat/share/xcat/install/ubuntu/compute.tmpl
root@c910f04x12v05:/opt/xcat#

root@c910f04x12v05:/opt/xcat# rinstall c910f04x12v07 osimage=ubuntu20.04.1-x86_64-install-compute
Provision node(s): c910f04x12v07
root@c910f04x12v05:/opt/xcat#

root@c910f04x12v07:~# hostnamectl
   Static hostname: c910f04x12v07
         Icon name: computer-vm
           Chassis: vm
        Machine ID: b7eddee10a24df6d660a70e563221679
           Boot ID: 8193fedcd01548528ad3a7fa5e6bfc65
    Virtualization: kvm
  Operating System: Ubuntu 20.04.1 LTS
            Kernel: Linux 5.4.0-125-generic
      Architecture: x86-64
root@c910f04x12v07:~#
```

#### Ubuntu 20.04.4 (subiquity)
```
root@c910f04x12v05:/opt/xcat# copycds -i /tmp/automation_mountpoint/iso/ubuntu-20.04.4-live-server-amd64.iso
OS Image:/tmp/automation_mountpoint/iso/ubuntu-20.04.4-live-server-amd64.iso
DISTNAME:ubuntu20.04.4
ARCH:amd64
DISCNO:

root@c910f04x12v05:/opt/xcat# copycds /tmp/automation_mountpoint/iso/ubuntu-20.04.4-live-server-amd64.iso
Copying media to /install/ubuntu20.04.4/x86_64
Media copy operation successful
root@c910f04x12v05:/opt/xcat#

root@c910f04x12v05:/opt/xcat# lsdef -t osimage ubuntu20.04.4-x86_64-install-compute
Object name: ubuntu20.04.4-x86_64-install-compute
    imagetype=linux
    osarch=x86_64
    osname=Linux
    osvers=ubuntu20.04.4
    otherpkgdir=/install/post/otherpkgs/ubuntu20.04.4/x86_64
    pkgdir=/install/ubuntu20.04.4/x86_64
    pkglist=/opt/xcat/share/xcat/install/ubuntu/compute.ubuntu20.04.x86_64.pkglist
    profile=compute
    provmethod=install
    template=/opt/xcat/share/xcat/install/ubuntu/compute.subiquity.tmpl
root@c910f04x12v05:/opt/xcat#

root@c910f04x12v05:/opt/xcat# chdef c910f04x12v07 installnic=mac kcmdline=modprobe.blacklist=nvidiafb nfsserver=10.4.12.5 xcatmaster=10.4.12.5 tftpserver=10.4.12.5
1 object definitions have been created or modified.
root@c910f04x12v05:/opt/xcat#

root@c910f04x12v05:/opt/xcat# rinstall c910f04x12v07 osimage=ubuntu20.04.4-x86_64-install-compute
Provision node(s): c910f04x12v07
root@c910f04x12v05:/opt/xcat#

root@c910f04x12v07:~# hostnamectl
   Static hostname: c910f04x12v07
         Icon name: computer-vm
           Chassis: vm
        Machine ID: 5cf932c41734ed118ce242e10a040c07
           Boot ID: bda8914b890d4462a7b298c408857fc2
    Virtualization: kvm
  Operating System: Ubuntu 20.04.4 LTS
            Kernel: Linux 5.15.0-46-generic
      Architecture: x86-64
root@c910f04x12v07:~#
```