### PR TITLE
Support for xCAT installation on Ubuntu20

### DIFF
--- a/build-ubunturepo
+++ b/build-ubunturepo
@@ -105,7 +105,7 @@ for package in ${packages[@]}; do
 done
 
 # Supported distributions
-dists="saucy trusty utopic xenial bionic"
+dists="saucy trusty utopic xenial bionic focal"
 
 c_flag=            # xcat-core (trunk-delvel) path
 d_flag=            # xcat-dep (trunk) path

--- a/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu20.04.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/ubuntu/compute.ubuntu20.04.x86_64.pkglist
@@ -1,5 +1,4 @@
 bash
-ifupdown
 nfs-common
 openssl
 isc-dhcp-client
@@ -8,7 +7,6 @@ linux-image-generic
 openssh-server
 openssh-client
 wget
-vim
 rsync
 busybox-static
 gawk

--- a/xCAT/debian/control
+++ b/xCAT/debian/control
@@ -10,7 +10,7 @@ Homepage: https://xcat.org/
 Package: xcat
 Architecture: amd64 ppc64el
 Depends: ${perl:Depends}, goconserver(>= 0.3.3-snap000000000000), xcat-server (>= 2.13-snap000000000000), xcat-client (>= 2.13-snap000000000000), libdbd-sqlite3-perl, isc-dhcp-server, apache2, nfs-kernel-server, libxml-parser-perl, rsync, tftpd-hpa, libnet-telnet-perl, xcat-genesis-scripts-ppc64 (>= 2.13-snap000000000000), xcat-genesis-scripts-amd64 (>= 2.13-snap000000000000)
-Recommends: bind9, nmap, tftp-hpa, ipmitool-xcat (>= 1.8.17-1), syslinux[any-amd64], libsys-virt-perl, syslinux-xcat, xnba-undi, elilo-xcat, xcat-buildkit (>= 2.13-snap000000000000), xcat-probe (>= 2.13-snap000000000000)
+Recommends: bind9, net-tools, nmap, tftp-hpa, ipmitool-xcat (>= 1.8.17-1), syslinux[any-amd64], libsys-virt-perl, syslinux-xcat, xnba-undi, elilo-xcat, xcat-buildkit (>= 2.13-snap000000000000), xcat-probe (>= 2.13-snap000000000000)
 Suggests: yaboot-xcat
 Description: Metapackage for a common, default xCAT setup
  xCAT is Extreme Cluster/Cloud Administration Toolkit. xCAT offers complete

--- a/xCATsn/debian/control
+++ b/xCATsn/debian/control
@@ -9,7 +9,7 @@ Homepage: https://xcat.org/
 Package: xcatsn
 Architecture: amd64 ppc64el
 Depends: ${perl:Depends}, goconserver (>=0.3.3-snap000000000000), xcat-server (>= 2.13-snap000000000000), xcat-client (>= 2.13-snap000000000000), libdbd-sqlite3-perl, libxml-parser-perl, tftpd-hpa, libnet-telnet-perl, isc-dhcp-server, apache2, nfs-kernel-server, xcat-genesis-scripts-ppc64 (>= 2.13-snap000000000000), xcat-genesis-scripts-amd64 (>= 2.13-snap000000000000)
-Recommends: bind9, nmap, tftp-hpa, ipmitool-xcat (>= 1.8.17-1), syslinux[any-amd64], libsys-virt-perl, syslinux-xcat, xnba-undi, elilo-xcat, xcat-buildkit (>= 2.13-snap000000000000), xcat-probe (>= 2.13-snap000000000000)
+Recommends: bind9, net-tools, nmap, tftp-hpa, ipmitool-xcat (>= 1.8.17-1), syslinux[any-amd64], libsys-virt-perl, syslinux-xcat, xnba-undi, elilo-xcat, xcat-buildkit (>= 2.13-snap000000000000), xcat-probe (>= 2.13-snap000000000000)
 Suggests: yaboot-xcat
 Description: Metapackage for a common, default xCAT service node setup
  xCATsn is a service node management package intended for at-scale


### PR DESCRIPTION
This PR allows xCAT to be installed on Ubuntu 20 management node

* Remove `ifupdown` and `vim` packages from diskless Ubuntu 20 image generation. `ifupdown` is no longer available on Ubuntu 20, `vim` is not included on Ubuntu 18 either.
* Add `net-tools` to `xCAT` and `xCATsn` dependencies for deb package, similar to RPM `.spec` files. `xCAT` and `xCATsn` deb package has a dependency on `bind9`, which in turn on Ubuntu 16 and Ubuntu 18 had a dependency on `net-tools`. On Ubuntu 20, `bind9` does not have a dependency on `net-tools`
* Add `focal` release name to Ubuntu repository building script to create a `dists` directory for Ubuntu 20.

```
root@c910f04x12v07:/# hostnamectl
   Static hostname: c910f04x12v07
         Icon name: computer-vm
           Chassis: vm
        Machine ID: 06977a8b85f2f23b04feb7ff632b0a3c
           Boot ID: e258fabe3add446d9daabe5293365051
    Virtualization: kvm
  Operating System: Ubuntu 20.04.1 LTS
            Kernel: Linux 5.4.0-126-generic
      Architecture: x86-64
root@c910f04x12v07:/#

root@c910f04x12v07:/# lsxcatd -a
Version 2.16.4 (git commit bb7a4bbbc8bde7e6613558d8d039fe43d49d2079, built Mon Jun 13 08:53:30 EDT 2022)
This is a Management Node
dbengine=SQLite
root@c910f04x12v07:/#

root@c910f04x12v07:/# lsdef -t osimage
ubuntu20.04.1-x86_64-install-compute  (osimage)
ubuntu20.04.1-x86_64-install-service  (osimage)
ubuntu20.04.1-x86_64-netboot-compute  (osimage)
root@c910f04x12v07:/#
```