### PR TITLE
Fix legacy PIDFile location

### DIFF
--- a/xCAT-server/etc/init.d/xcatd.service
+++ b/xCAT-server/etc/init.d/xcatd.service
@@ -5,7 +5,7 @@ After=network.target syslog.service
 [Service]
 EnvironmentFile=-/etc/sysconfig/xcat
 Type=forking
-PIDFile=/var/run/xcatd.pid
+PIDFile=/run/xcatd.pid
 ExecStart=/etc/init.d/xcatd start
 ExecStop=/etc/init.d/xcatd stop
 LimitNOFILE=16000


### PR DESCRIPTION
Fixes warning:
```
/usr/lib/systemd/system/xcatd.service:8: PIDFile= references a path below legacy directory /var/run/, updating /var/run/xcatd.pid → /run/xcatd.pid; please update the unit file accordingly.
```