### PR TITLE
Add ipmi_si module to be able to run bmcsetup manually

### DIFF
--- a/xCAT-genesis-scripts/usr/bin/bmcsetup
+++ b/xCAT-genesis-scripts/usr/bin/bmcsetup
@@ -110,6 +110,7 @@ fi
 
 # Add ipmi_devintf module to allow the ipmitool operation in-band
 modprobe ipmi_devintf
+modprobe ipmi_si
 
 for parm in `cat /proc/cmdline`; do
     key=`echo $parm|awk -F= '{print $1}'`

--- a/xCAT-genesis-scripts/usr/bin/bmcsetup
+++ b/xCAT-genesis-scripts/usr/bin/bmcsetup
@@ -109,8 +109,12 @@ if ! ipmitool -V 2>/dev/null| grep "version"; then
 fi
 
 # Add ipmi_devintf module to allow the ipmitool operation in-band
+if grep -q "^ppc64" <<< "$(uname -m)"; then
+    modprobe ipmi_powernv
+else
+    modprobe ipmi_si
+fi
 modprobe ipmi_devintf
-modprobe ipmi_si
 
 for parm in `cat /proc/cmdline`; do
     key=`echo $parm|awk -F= '{print $1}'`


### PR DESCRIPTION
Just a quick addition for easier debugging.