### PR TITLE
Fix Perl error in AAsn.pm

### DIFF
--- a/xCAT-server/lib/xcat/plugins/AAsn.pm
+++ b/xCAT-server/lib/xcat/plugins/AAsn.pm
@@ -2,6 +2,12 @@
 # IBM(c) 2007 EPL license http://www.eclipse.org/legal/epl-v10.html
 #-------------------------------------------------------
 package xCAT_plugin::AAsn;
+
+BEGIN
+{
+    $::XCATROOT = $ENV{'XCATROOT'} ? $ENV{'XCATROOT'} : '/opt/xcat';
+}
+use lib "$::XCATROOT/lib/perl";
 use strict;
 use xCAT::Table;
 


### PR DESCRIPTION
Currently Perl reports an error on `AAsn.pm" file:
```
root@c910f04x12v05:/opt/xcat/lib/perl/xCAT_plugin# perl -c /opt/xcat/lib/perl/xCAT_plugin/AAsn.pm
Can't locate xCAT/Table.pm in @INC (you may need to install the xCAT::Table module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.30.0 /usr/local/share/perl/5.30.0 /usr/lib/x86_64-linux-gnu/perl5/5.30 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.30 /usr/share/perl/5.30 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base) at /opt/xcat/lib/perl/xCAT_plugin/AAsn.pm line 6.
BEGIN failed--compilation aborted at /opt/xcat/lib/perl/xCAT_plugin/AAsn.pm line 6.
root@c910f04x12v05:/opt/xcat/lib/perl/xCAT_plugin#
```

After the fix:
```
root@c910f04x12v05:/opt/xcat/lib/perl/xCAT_plugin# perl -c /opt/xcat/lib/perl/xCAT_plugin/kvm.pm
/opt/xcat/lib/perl/xCAT_plugin/kvm.pm syntax OK
root@c910f04x12v05:/opt/xcat/lib/perl/xCAT_plugin#
```