### PR TITLE
Properly parse newer BIND versions

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ddns.pm
+++ b/xCAT-server/lib/xcat/plugins/ddns.pm
@@ -14,6 +14,7 @@ use xCAT::SvrUtils;
 use Socket;
 use Fcntl qw/:flock/;
 use Data::Dumper;
+use version;
 
 # This is a rewrite of DNS management using nsupdate rather than
 #	direct zone mangling
@@ -1282,10 +1283,10 @@ sub update_namedconf {
                 push @newnamed, "\t\t$_;\n";
             }
             push @newnamed, "\t};\n";
-            my $bind_version_cmd="/usr/sbin/named -v | cut -d' ' -f2";
+            my $bind_version_cmd="/usr/sbin/named -v | cut -d' ' -f2 | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+'";
             my @bind_version =xCAT::Utils->runcmd($bind_version_cmd, 0);
             # Turn off DNSSEC if running with bind vers 9.16.6 or higher
-            if ((scalar @bind_version > 0) && ($bind_version[0] ge "9.16.6")) {
+            if ((scalar @bind_version > 0) && (version->parse($bind_version[0]) >= version->parse(9.16.6))) {
                 push @newnamed, "\tdnssec-enable no;\n";
                 push @newnamed, "\tdnssec-validation no;\n";
             }


### PR DESCRIPTION
Previous solution did not work for releases > `9.16.9` (ex. `9.16.10`)
Furthermore, EL9 adds -RH tag at the end (ex. `9.16.23-RH`) which needs to be removed.

Fixes dc0d43750de723b4f354401f99965436643afbc9