### PR TITLE
Update conserver setting for testcase

### DIFF
--- a/xCAT-test/autotest/testcase/installation/SN_setup_case
+++ b/xCAT-test/autotest/testcase/installation/SN_setup_case
@@ -30,7 +30,7 @@ cmd:chdef -t node $$SN groups=service,all
 check:rc==0
 cmd:chdef -t group -o service profile=service  primarynic=mac installnic=mac
 check:rc==0
-cmd:chdef -t group -o service setupnfs=1 setupdhcp=1 setuptftp=1 setupnameserver=1 setupconserver=1 setupntp=1
+cmd:chdef -t group -o service setupnfs=1 setupdhcp=1 setuptftp=1 setupnameserver=1 setupconserver=2 setupntp=1
 check:rc==0
 cmd:chdef -t group -o service nfsserver=$$MN tftpserver=$$MN xcatmaster=$$MN monserver=$$MN
 check:rc==0


### PR DESCRIPTION
Switch regression testcase which sets up service node to use `goconserver` (`setupconserver=2`) instead of `conserver` (`setupconserver=1`).
Current use of `conserver` results in the following message on service node:
```
[root@c910f04x37v03 ~]# xcatd -f
Warning: makeconservercf is deprecrated as well as conserver, go to makegocons for more information about enabling goconserver.
Error: conserver is not supported or not installed.
:
:
```