### PR TITLE
Add testcase to verify xCAT public keys

### DIFF
--- a/xCAT-test/autotest/testcase/go_xcat/case3
+++ b/xCAT-test/autotest/testcase/go_xcat/case3
@@ -39,6 +39,33 @@ check:output=~Version
 cmd:xdsh $$CN "service xcatd status"
 check:rc==0
 check:output=~running
+
+#Uninstall xCAT, then install again and verify public keys
+cmd:xdsh $$CN "cd /; ./go-xcat completely uninstall"
+check:rc==0
+check:output=~xCAT has been uninstalled
+
+#Remove --nogpgcheck (yum/dnf) --no-gpg-checks (zypper) and --allow-unauthenticated (apt-get) flags from go-xcat 
+# to install xCAT public key when installing packages
+cmd:xdsh $$CN "sed -i 's/\-\-nogpgcheck//g' /go-xcat"
+cmd:xdsh $$CN "sed -i 's/\-\-no\-gpg\-checks//g' /go-xcat"
+cmd:xdsh $$CN "sed -i 's/\-\-allow\-unauthenticated//g' /go-xcat"
+
+#Install devel version of xCAT. If first attempt fails, try again
+cmd:xdsh $$CN "cd /; ./go-xcat --xcat-version=devel -y install"
+cmd:version=`xdsh $$CN /opt/xcat/bin/lsxcatd -v`; if [[ $version =~ "Version" ]]; then echo "xCAT installed successfully first time"; else echo "First attempt to install xCAT failed, attempting to install xCAT again"; xdsh $$CN "cd /; ./go-xcat --xcat-version=devel -y install"; fi
+
+cmd:xdsh $$CN "source /etc/profile.d/xcat.sh; lsxcatd -v"
+check:output=~Version
+cmd:xdsh $$CN "service xcatd status"
+check:rc==0
+check:output=~running
+
+#Verify xCAT public key was installed
+cmd:xdsh $$CN "rpm -q gpg-pubkey --qf '%{name}-%{version}-%{release} --> %{summary}\n'"
+check:output=~xCAT Automatic Signing Key
+
+cmd:xdsh $$CN "rpm -e gpg-pubkey-ca548a47-5b2c830b"
 cmd:xdsh $$CN "service xcatd stop"
 end
 


### PR DESCRIPTION
Currently when xCAT is installed with `go-xcat` script, it uses "nogpgcheck" style flags for `yum/zypper/apt`.
As a result xCAT public key provided in the repository is not installed and packages are not checked against it.

This PR extends existing `go_xcat_devel_from_repo` testcase to uninstall xCAT, remove "nogpgcheck" style flags from `go-xcat` script and install xCAT again. This time xCAT public key should be downloaded and packages checked against it.