### PR TITLE
Free up disk space for regression test on SLES

### DIFF
--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat
@@ -139,6 +139,9 @@ check:rc==0
 cmd:copycds $$ISO
 check:rc==0
 
+#Move .iso out of the way to free up disk space
+cmd:if [[ "$$OS" =~ "sle" ]]; then mv $$ISO /home; fi
+
 cmd:rootimgdir=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir ]; then mv $rootimgdir $rootimgdir.regbak -f;fi
 check:rc==0
 cmd:if [[ -f /test.synclist ]] ;then mv -f /test.synclist /test.synclist.bak;fi;
@@ -213,4 +216,7 @@ cmd:if [ -x /usr/bin/goconserver ]; then makegocons -d $$CN; else makeconserverc
 cmd:if [[ -f /test.synclist.bak ]] ;then mv -f /test.synclist.bak /test.synclist;else rm -rf /test.synclist;fi
 cmd:chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute synclists=
 check:rc==0
+
+#Move .iso back
+cmd:if [[ "$$OS" =~ "sle" ]]; then mv /home/$$ISO /; fi
 end


### PR DESCRIPTION
On SLES15.3 x86 weekly testcase `reg_linux_diskless_installation_flat_squashfs` started failing when running `packimage` - Not enough disk space. I suspect `xcat-deps` is now larger, since `rh9` rpms were added (431M).

This PR temporarily moves `.iso` file to `/home` dir which is located on a different partition than `/`