### PR TITLE
Add more time for node to reboot

### DIFF
--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskfull_installation_flat
@@ -79,7 +79,7 @@ cmd:xdsh $$CN "grep 'load host key' /var/log/xcat/xcat.log || echo 'No load host
 check:output=~No load hostkey warning
 # Check node can be rebooted from disk
 cmd:xdsh $$CN shutdown -r now
-cmd:sleep 300
+cmd:sleep 360
 cmd:xdsh $$CN uptime
 check:rc==0
 check:output=~up


### PR DESCRIPTION
Sometimes weekly testcase `reg_linux_diskfull_installation_flat` fails on SLES12.5 x86.
The failure is accessing the node with `xdsh` after `shutdown -r now` and waiting 5 min.

I suspect the newly added regression on SLES12.5 takes a little longer to reboot than previous version of SLES12.
Running the testcase manually works, but there seems to be only 4 second "buffer":

```
RUN:xdsh c910f04x12v07 shutdown -r now [Wed Oct 26 10:49:18 2022]
ElapsedTime:1 sec
RETURN rc = 1
OUTPUT:
[c910f04x12v05]: c910f04x12v07: Connection to c910f04x12v07 closed by remote hot.


RUN:sleep 300 [Wed Oct 26 10:49:19 2022]
ElapsedTime:300 sec
RETURN rc = 0
OUTPUT:

RUN:xdsh c910f04x12v07 uptime [Wed Oct 26 10:54:19 2022]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
c910f04x12v07:  10:54am  up   0:04,  0 users,  load average: 0.01, 0.06, 0.03
CHECK:rc == 0   [Pass]
CHECK:output =~ up      [Pass]
```