### PR TITLE
Run date +"%Y" > /tmp/currentyear in makentp_extntpserver_value

### DIFF
--- a/xCAT-test/autotest/testcase/makentp/cases0
+++ b/xCAT-test/autotest/testcase/makentp/cases0
@@ -46,7 +46,7 @@ cmd:lsdef -t site -o clustersite -i extntpservers -c >/tmp/extntpserver
 check:rc==0
 cmd:chtab key=extntpservers site.value="$$extntpserversip"
 check:rc==0
-cmd:date | awk '{print $6}' > /tmp/currentyear
+cmd:date +"%Y" > /tmp/currentyear
 check:rc==0
 cmd:date -s 20000101
 check:rc==0


### PR DESCRIPTION
The default date format of SLES 15.3 puts the year in the 4th position instead of the 6th position. 

For example, **Sat 01 Jan 2000 12:00:00 AM EST** instead of **Sat Jan  1 00:00:00 EST 2000** .

This would cause makentp_extntpserver_value to fail.

With this fix, it does not depend on the default date format of the underlying operating system.
