### PR TITLE
Spelling correction in chvm output

### DIFF
--- a/xCAT-server/lib/xcat/plugins/kvm.pm
+++ b/xCAT-server/lib/xcat/plugins/kvm.pm
@@ -2258,7 +2258,7 @@ sub chvm {
     }
     if ($cpucount or $memory) {
         if ($currstate eq 'on') {
-            if ($cpucount) { xCAT::SvrUtils::sendmsg([ 1, "Hot add of cpus not supported (VM must be powered down to successfuly change)" ], $callback, $node); }
+            if ($cpucount) { xCAT::SvrUtils::sendmsg([ 1, "Hot add of cpus not supported (VM must be powered down to successfully change)" ], $callback, $node); }
             if ($cpucount) {
 
                 #$dom->set_vcpus($cpucount); this didn't work out as well as I hoped..


### PR DESCRIPTION
Noticed a minor typo in the `chvm` output:
```
[root@c910f03c17k07 ~]# chvm c910f04x35v05 --cpus 2
c910f04x35v05: [c910f03c17k07]: Error: Hot add of cpus not supported (VM must be powered down to successfuly change)
```
>successfuly

After the fix:
```
[root@c910f03c17k07 ~]# chvm c910f04x35v05 --cpus 2
c910f04x35v05: [c910f03c17k07]: Error: Hot add of cpus not supported (VM must be powered down to successfully change)
```