### PR TITLE
Make sure initd files are installed with xCAT-server

### DIFF
--- a/xCAT-server/xCAT-server.spec
+++ b/xCAT-server/xCAT-server.spec
@@ -41,7 +41,7 @@ BuildArch: noarch
 Requires: perl-IO-Socket-SSL perl-XML-Simple perl-XML-Parser
 %else
 BuildRequires: perl-generators
-Requires: perl-IO-Socket-SSL perl-XML-Simple perl-XML-Parser perl-Digest-SHA1 perl(LWP::Protocol::https) perl-XML-LibXML
+Requires: perl-IO-Socket-SSL perl-XML-Simple perl-XML-Parser perl-Digest-SHA1 perl(LWP::Protocol::https) perl-XML-LibXML (initscripts or insserv-compat)
 %endif
 Obsoletes: atftp-xcat
 %endif


### PR DESCRIPTION
Put a dependency on `initscripts` (for RH) or `insserv-compat` (for SLES).
`xcatd` verifies that `/etc/init.d/functions` or `/lib/lsb/init-functions` files are there before xCAT can start.
Those files are provided by `initscripts` or `insserv-compat` RPMs. 
Usually that RPM is installed with OS install, but was missing on RH9 x86 on one of the test machines.