### PR TITLE
Free up disk space for regression test on SLES (2)

### DIFF
--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_flat
@@ -24,6 +24,8 @@ check:rc==0
 cmd:copycds $$ISO
 check:rc==0
 
+#Move .iso out of the way to free up disk space
+cmd:if [[ "$$OS" =~ "sle" ]]; then mv $$ISO /home; fi
 
 cmd:if cat /etc/*release |grep SUSE >/dev/null; then  cp /opt/xcat/share/xcat/tools/autotest/testcase/installation/litefile_sles.csv /tmp/litefile.csv;tabrestore /tmp/litefile.csv; elif cat /etc/*release |grep "Red Hat\|Rocky" >/dev/null; then  tabrestore /opt/xcat/share/xcat/tools/autotest/testcase/installation/litefile.csv;fi
 check:rc==0
@@ -132,4 +134,7 @@ check:rc==0
 cmd:if [ -x /usr/bin/goconserver ]; then makegocons -d $$CN; else makeconservercf -d $$CN; fi
 cmd:rootimgdir=`lsdef -t osimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir.regbak ]; then rm -rf $rootimgdir; mv $rootimgdir.regbak $rootimgdir; fi
 check:rc==0
+
+#Move .iso back
+cmd:if [[ "$$OS" =~ "sle" ]]; then mv /home/$$ISO /; fi
 end


### PR DESCRIPTION
On SLES15.3 x86 weekly testcase `reg_linux_statelite_installation_flat` started failing when running `imgexport` - Not enough disk space. I suspect `xcat-dep`s is now larger, since `rh9` rpms were added (431M).

```
RUN:imgexport __GETNODEATTR(c910f04x35v04,os)__-__GETNODEATTR(c910f04x35v04,arch)__-statelite-compute /tmp/image/image.tgz [Mon Oct 31 11:00:35 2022]
ElapsedTime:81 sec
RETURN rc = 1
OUTPUT:
Error: [c910f04x35v02]: Failed to compress archive!  (Maybe there was no space left?)
Exporting sle15.3-x86_64-statelite-compute to /opt/xcat/share/xcat/tools/autotest...
Packing root image. It will take a while
Getting litefile settings
/install/netboot/sle15.3/x86_64/compute/kernel
/install/netboot/sle15.3/x86_64/compute/initrd-statelite.gz
/opt/xcat/share/xcat/netboot/sle/compute.sle15.x86_64.pkglist
/opt/xcat/share/xcat/netboot/sle/compute.sle15.postinstall
/opt/xcat/share/xcat/netboot/sle/compute.sle15.exlist
Inside /opt/xcat/share/xcat/tools/autotest/imgexport.13848.JE9ELM.
Compressing sle15.3-x86_64-statelite-compute bundle.  Please be patient.
Done!
CHECK:rc == 0   [Failed]
```

Similar to #7270. This PR temporarily moves `.iso` file to `/home` dir which is located on a different partition than `/`

After this PR:

```
RUN:imgexport __GETNODEATTR(c910f04x35v04,os)__-__GETNODEATTR(c910f04x35v04,arch)__-statelite-compute /tmp/image/image.tgz [Mon Oct 31 12:32:50 2022]
ElapsedTime:85 sec
RETURN rc = 0
OUTPUT:
Exporting sle15.3-x86_64-statelite-compute to /opt/xcat/share/xcat/tools/autotest...
Packing root image. It will take a while
Getting litefile settings
/install/netboot/sle15.3/x86_64/compute/kernel
/install/netboot/sle15.3/x86_64/compute/initrd-statelite.gz
/opt/xcat/share/xcat/netboot/sle/compute.sle15.x86_64.pkglist
/opt/xcat/share/xcat/netboot/sle/compute.sle15.postinstall
/opt/xcat/share/xcat/netboot/sle/compute.sle15.exlist
Inside /opt/xcat/share/xcat/tools/autotest/imgexport.933.JE9ELM.
Compressing sle15.3-x86_64-statelite-compute bundle.  Please be patient.
Done!
CHECK:rc == 0   [Pass]
```
