### PR TITLE
Revert "Make sure initd files are installed with xCAT-server"

### DIFF
--- a/xCAT-server/xCAT-server.spec
+++ b/xCAT-server/xCAT-server.spec
@@ -41,7 +41,7 @@ BuildArch: noarch
 Requires: perl-IO-Socket-SSL perl-XML-Simple perl-XML-Parser
 %else
 BuildRequires: perl-generators
-Requires: perl-IO-Socket-SSL perl-XML-Simple perl-XML-Parser perl-Digest-SHA1 perl(LWP::Protocol::https) perl-XML-LibXML (initscripts or insserv-compat)
+Requires: perl-IO-Socket-SSL perl-XML-Simple perl-XML-Parser perl-Digest-SHA1 perl(LWP::Protocol::https) perl-XML-LibXML
 %endif
 Obsoletes: atftp-xcat
 %endif


### PR DESCRIPTION
Reverts xcat2/xcat-core#7276

While `or` operator is valid while building `xCAT-server` RPM on EL8 build machine, the `or` operator is not valid while installing `xCAT-server` RPM on target node with `rpm` version below 4.13 (SLES12, EL7)

#7279 will verify `initscripts` is installed during `go-xcat` install on RH family of OSes.