### PR TITLE
Free up disk space for regression test on SLES (3)

### DIFF
--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat
@@ -139,8 +139,8 @@ check:rc==0
 cmd:copycds $$ISO
 check:rc==0
 
-#Move .iso out of the way to free up disk space
-cmd:if [[ "$$OS" =~ "sle" ]]; then mv $$ISO /home; fi
+#On SLES remove rh dependency dirs to free up disk space
+cmd:if [[ "$$OS" =~ "sle" ]]; then rm -rf /xcat-dep/rh*; fi
 
 cmd:rootimgdir=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir ]; then mv $rootimgdir $rootimgdir.regbak -f;fi
 check:rc==0
@@ -217,6 +217,4 @@ cmd:if [[ -f /test.synclist.bak ]] ;then mv -f /test.synclist.bak /test.synclist
 cmd:chdef -t osimage -o __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute synclists=
 check:rc==0
 
-#Move .iso back
-cmd:if [[ "$$OS" =~ "sle" ]]; then mv /home/$$ISO /; fi
 end

--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_flat
@@ -24,8 +24,8 @@ check:rc==0
 cmd:copycds $$ISO
 check:rc==0
 
-#Move .iso out of the way to free up disk space
-cmd:if [[ "$$OS" =~ "sle" ]]; then mv $$ISO /home; fi
+#On SLES remove rh dependency dirs to free up disk space
+cmd:if [[ "$$OS" =~ "sle" ]]; then rm -rf /xcat-dep/rh*; fi
 
 cmd:if cat /etc/*release |grep SUSE >/dev/null; then  cp /opt/xcat/share/xcat/tools/autotest/testcase/installation/litefile_sles.csv /tmp/litefile.csv;tabrestore /tmp/litefile.csv; elif cat /etc/*release |grep "Red Hat\|Rocky" >/dev/null; then  tabrestore /opt/xcat/share/xcat/tools/autotest/testcase/installation/litefile.csv;fi
 check:rc==0
@@ -135,6 +135,4 @@ cmd:if [ -x /usr/bin/goconserver ]; then makegocons -d $$CN; else makeconserverc
 cmd:rootimgdir=`lsdef -t osimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir.regbak ]; then rm -rf $rootimgdir; mv $rootimgdir.regbak $rootimgdir; fi
 check:rc==0
 
-#Move .iso back
-cmd:if [[ "$$OS" =~ "sle" ]]; then mv /home/$$ISO /; fi
 end


### PR DESCRIPTION
The solution to free up disk space on SLES added by #7278 and #7270 does not work on SLES15.1
On that OS the `$$ISO` variable contains 2 `.iso` files and a simple `mv $$ISO /home` command does not work.

This PR, instead will free up space by removing `rh*` directories from `/xcat-dep` when running on SLES. When running on SLES only RPMs located in `/xcat-dep` and `/xcat-dep/sles*` directories are used. 