### PR TITLE
Limit lzma testcase to run only on EL8 family of OSes

### DIFF
--- a/xCAT-test/autotest/testcase/genesis/cases0
+++ b/xCAT-test/autotest/testcase/genesis/cases0
@@ -1,5 +1,5 @@
 start:nodeset_shell_lzma
-os:rhels
+os:rhels8
 label:others,genesis
 description: verify could log in genesis shell lzma compression
 cmd:yum install -y https://rpmfind.net/linux/centos/8-stream/PowerTools/__GETNODEATTR($$CN,arch)__/os/Packages/xz-lzma-compat-5.2.4-3.el8.__GETNODEATTR($$CN,arch)__.rpm


### PR DESCRIPTION
Limit `nodeset_shell_lzma` testcase to run on RHEL8, Rocky8 and OL8. 

Requires #7241 to be merges in order for `os:rhels8` label to work.