### PR TITLE
Minor documentation updates

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
@@ -777,9 +777,7 @@ EXAMPLES
  
 
 
-4.
- 
- To display the frame number for frame 9A00-10000001
+4. To display the frame number for frame 9A00-10000001
  
  
  .. code-block:: perl

--- a/docs/source/guides/admin-guides/references/man1/xcattest.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/xcattest.1.rst
@@ -193,7 +193,7 @@ EXAMPLES
 
 4.
  
- To add a new test case to test \ **chvm**\ . In this example, we assume that the \ **min_mem**\  should not be equal to 16 in the lpar profile of computenode. The case name is \ **chvm_customi**\ . It creates a test lpar named \ **testnode**\  first, then changes the \ **min_mem**\  of the lpar to 16 using \ **chvm**\ , then checks if \ **min_mem**\  have changed correctly. Finally, the \ **testnode**\  is removed.
+ To add a new test case to test \ **chvm**\ . In this example, we assume that the \ **min_mem**\  should not be equal to 16 in the lpar profile of computenode. The case name is \ **chvm_custom**\ . It creates a test lpar named \ **testnode**\  first, then changes the \ **min_mem**\  of the lpar to 16 using \ **chvm**\ , then checks if \ **min_mem**\  have changed correctly. Finally, the \ **testnode**\  is removed.
  
  
  .. code-block:: perl

--- a/perl-xCAT/xCAT/Zone.pm
+++ b/perl-xCAT/xCAT/Zone.pm
@@ -270,12 +270,12 @@ sub getmyzonename
 
 =head3    enableSSHbetweennodes
     Arguments:
-      zonename
+      nodename
     Returns:
      1 if the  sshbetweennodes attribute is yes/1 or undefined
      0 if the  sshbetweennodes attribute is no/0
     Example:
-     xCAT::Zone->enableSSHbetweennodes($zonename);
+     xCAT::Zone->enableSSHbetweennodes($nodename);
 =cut
 
 #--------------------------------------------------------------------------------

--- a/xCAT-client/pods/man1/rspconfig.1.pod
+++ b/xCAT-client/pods/man1/rspconfig.1.pod
@@ -572,7 +572,6 @@ Output is similar to:
  node4: BMC SNMP Destination 1: 9.114.47.227
 
 =item 4.
-
 To display the frame number for frame 9A00-10000001
 
  rspconfig> 9A00-10000001 frame

--- a/xCAT-test/pods/man1/xcattest.1.pod
+++ b/xCAT-test/pods/man1/xcattest.1.pod
@@ -123,7 +123,7 @@ To run specified test cases with I</tmp/config> file:
 
 =item 4.
 
-To add a new test case to test B<chvm>. In this example, we assume that the B<min_mem> should not be equal to 16 in the lpar profile of computenode. The case name is B<chvm_customi>. It creates a test lpar named B<testnode> first, then changes the B<min_mem> of the lpar to 16 using B<chvm>, then checks if B<min_mem> have changed correctly. Finally, the B<testnode> is removed.
+To add a new test case to test B<chvm>. In this example, we assume that the B<min_mem> should not be equal to 16 in the lpar profile of computenode. The case name is B<chvm_custom>. It creates a test lpar named B<testnode> first, then changes the B<min_mem> of the lpar to 16 using B<chvm>, then checks if B<min_mem> have changed correctly. Finally, the B<testnode> is removed.
 
   add a new test case file in /opt/xcat/share/xcat/tools/autotest/chvm
   edit filename


### PR DESCRIPTION
This pull request addresses three minor documentation updates:

1. https://github.com/xcat2/xcat-core/issues/7246#issuecomment-1239074906

2. POD syntax error in rspconfig.1.pod

Issue:
```
POD ERRORS
       Hey! The above document had some coding errors, which are explained below:

       Around line 574:
           Expected text after =item, not a number
```
Fix verified:
```
$ pod2man ./xCAT-client/pods/man1/rspconfig.1.pod | grep errors
./xCAT-client/pods/man1/rspconfig.1.pod around line 574: Expected text after =item, not a number
POD document had syntax errors at /usr/bin/pod2man line 69.

$ vi ./xCAT-client/pods/man1/rspconfig.1.pod

$ pod2man ./xCAT-client/pods/man1/rspconfig.1.pod | grep errors
```

3. Documentation typo noticed while reviewing https://github.com/xcat2/xcat-core/pull/7241