### PR TITLE
Ignore lzma dependency on Oracle

### DIFF
--- a/xCAT-test/autotest/testcase/genesis/cases0
+++ b/xCAT-test/autotest/testcase/genesis/cases0
@@ -2,7 +2,7 @@ start:nodeset_shell_lzma
 os:rhels8
 label:others,genesis
 description: verify could log in genesis shell lzma compression
-cmd:yum install -y https://rpmfind.net/linux/centos/8-stream/PowerTools/__GETNODEATTR($$CN,arch)__/os/Packages/xz-lzma-compat-5.2.4-3.el8.__GETNODEATTR($$CN,arch)__.rpm
+cmd:if [[ "__GETNODEATTR($$CN,os)__" =~ "rhel" ]]; then yum install -y https://rpmfind.net/linux/centos/8-stream/PowerTools/__GETNODEATTR($$CN,arch)__/os/Packages/xz-lzma-compat-5.2.4-3.el8.__GETNODEATTR($$CN,arch)__.rpm; elif rpm -q xz; then yum download https://rpmfind.net/linux/centos/8-stream/PowerTools/__GETNODEATTR($$CN,arch)__/os/Packages/xz-lzma-compat-5.2.4-3.el8.__GETNODEATTR($$CN,arch)__.rpm; rpm -ivh --nodeps xz-lzma-compat-5.2.4-3.el8.__GETNODEATTR($$CN,arch)__.rpm; fi
 #Generate genesis network boot with lzma compression
 cmd:mknb __GETNODEATTR($$CN,arch)__
 check:rc==0


### PR DESCRIPTION
`xcattest` treats Oracle as RHEL, when checking `os:` tag in the testcase. So `nodeset_shell_lzma` testcase will run on Oracle8.

However, even though required `xz-5.2.4-3.el8` rpm is installed on Oracle8, `yum` or `dnf` can no resolve that dependency. The installed rpm is `...el8.1`, but `xz-lzma-compat` is looking for just `el8` :

```
[root@c910f04x12v02 autotest]# rpm -qa | grep "xz"
xz-libs-5.2.4-3.el8.1.x86_64
xz-5.2.4-3.el8.1.x86_64
[root@c910f04x12v02 autotest]#

[root@c910f04x12v02 autotest]# yum install https://vault.centos.org/centos/8/PowerTools/x86_64/os/Packages/xz-lzma-compat-5.2.4-3.el8.x86_64.rpm
xz-lzma-compat-5.2.4-3.el8.x86_64.rpm           263 kB/s |  28 kB     00:00
Error:
 Problem: conflicting requests
  - nothing provides xz(x86-64) = 5.2.4-3.el8 needed by xz-lzma-compat-5.2.4-3.el8.x86_64
[root@c910f04x12v02 autotest]#
```

I could not find a `xz-lzma-compat` rpm which would be happy with `xz-5.2.4-3.el8.1`

With this PR, when running on real RHEL, will use `yum install xz-lzma-compat`, but if running on a non RH family of EL OSes will download `xz-lzma-compat` and then install it without dependencies, if `xz` package is there.
