### PR TITLE
Remove added osimage and node attributes at the end of linux_diskless_kdump

### DIFF
--- a/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
+++ b/xCAT-test/autotest/testcase/kdump/linux_diskless_kdump
@@ -118,4 +118,12 @@ cmd:rm -rf /opt/xcat/share/xcat/tools/autotest/kdumpdir
 cmd:cat /tmp/node.stanza | chdef -z;rm -rf /tmp/node.stanza
 cmd:cat /tmp/osimage.stanza | chdef -z;rm -rf /tmp/osimage.stanza
 cmd:rootimgdir=`lsdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir.regbak ]; then mv $rootimgdir.regbak $rootimgdir -f;fi
+
+# Remove crashkernelsize and dump from the osimage definition and enablekdump from the node defintion
+cmd:chdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute crashkernelsize=
+check:rc==0
+cmd:chdef -t osimage __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute dump=
+check:rc==0
+cmd:chdef -t node $$CN -m postscripts=enablekdump
+check:rc==0
 end


### PR DESCRIPTION
linux_diskless_kdump is the last test case of rhels_ppcle_weekly.bundle.

In order to set up the kdump server, enablekdump is added to the postscripts of CN, crashkernelsize and dump to the diskless image.

Currently, they are not removed at the end of the test case.

Further diskless installations will fail since enablekdump is executed but without the kdump setup logic as used in linux_diskless_kdump.

These attributes should be rolled back at the end of the test case.