### PR TITLE
Installing xCAT on EL9 show message that EPEL and CRB repos are needed

### DIFF
--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -2,7 +2,7 @@
 #
 # go-xcat - Install xCAT automatically.
 #
-# Version 1.0.51
+# Version 1.0.52
 #
 # Copyright (C) 2016 - 2021 International Business Machines
 # Eclipse Public License, Version 1.0 (EPL-1.0)

--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -42,6 +42,8 @@
 #     - Add support for Rocky Linux
 # 2022-11-01 Mark Gurevich <gurevich@us.ibm.com>
 #     - Make sure initscripts installed on RH family of OSes
+# 2022-12-06 Mark Gurevich <gurevich@us.ibm.com>
+#     - Check for EPEL and CRB repository on EL9 family of OSes
 #
 
 
@@ -205,6 +207,8 @@ GO_XCAT_UNINSTALL_LIST=("${GO_XCAT_INSTALL_LIST[@]}"
 
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
 export PATH
+EL9_EPEL_TEST_RPM="perl-Crypt-CBC"
+EL9_CRB_TEST_RPM="perl-IO-Tty"
 
 #
 # warn_if_bad		Put out warning message(s) if $1 has bad RC.
@@ -1708,6 +1712,7 @@ function update_repo()
 function install_packages_dnf()
 {
 	type dnf >/dev/null 2>&1 || return 255
+	el9_epel_and_crb_check dnf
 	local -a yes=()
 	[[ "$1" = "-y" ]] && yes=("-y") && shift
 	dnf --nogpgcheck "${yes[@]}" install "$@"
@@ -1717,6 +1722,7 @@ function install_packages_dnf()
 function install_packages_yum()
 {
 	type yum >/dev/null 2>&1 || return 255
+	el9_epel_and_crb_check yum
 	local -a yes=()
 	[[ "$1" = "-y" ]] && yes=("-y") && shift
 	yum --nogpgcheck "${yes[@]}" install "$@"
@@ -1729,6 +1735,55 @@ function github_issue_5503_workaround()
 	[[ "${GO_XCAT_LINUX_DISTRO}" = "sles" ]] || return 0
 	[[ "${GO_XCAT_LINUX_VERSION}" =~ ^11(\.[0-4]){0,1}$ ]] || return 0
 	rpm -e --allmatches gpg-pubkey-ca548a47-5b2c830b >/dev/null 2>&1
+	return 0
+}
+
+# Check for EPEL and CRB repositories when installing on RH family of OSes
+function el9_epel_and_crb_check()
+{
+	action="$@" # Passed parameter will only be 'yum' or 'dnf'
+	if [[ "${GO_XCAT_LINUX_DISTRO}" = "fedora" ]]
+	then
+		# For Fedora, version 35 is equivalent to EL9
+		# But since xCAT currently does not support that version, just
+		# return and let 'yum install' fail if needed packages are not
+		# found
+		return 0
+	else
+		[[ "${GO_XCAT_LINUX_VERSION}" =~ ^9(\.[0-9]) ]] || return 0
+	fi
+	${action} list available -q ${EL9_EPEL_TEST_RPM} 
+	ret="$?"
+	case "${ret}" in
+	"1")
+		# Can not find EL9_EPEL_TEST_RPM
+		echo "
+Installation on ${GO_XCAT_LINUX_DISTRO} ${GO_XCAT_LINUX_VERSION} requires EPEL repository to be enabled"
+		echo "Running '${action} install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm' will enable EPEL repository"
+		exit 1
+		;;
+	esac
+	${action} list available -q ${EL9_CRB_TEST_RPM} 
+	ret="$?"
+	case "${ret}" in
+	"1")
+		# Ccan not find EL9_CRB_TEST_RPM
+		echo "
+Installation on ${GO_XCAT_LINUX_DISTRO} ${GO_XCAT_LINUX_VERSION} requires CRB repository to be enabled"
+		echo "Try adding the following entries to new or existing '.repo' file:"
+		echo "
+[crb]
+name=CentOS Stream $releasever - CRB
+metalink=https://mirrors.centos.org/metalink?repo=centos-crb-$stream&arch=$basearch&protocol=https,http
+gpgcheck=0
+repo_gpgcheck=0
+metadata_expire=6h
+countme=1
+enabled=1
+		"
+		exit 1
+		;;
+	esac
 	return 0
 }
 


### PR DESCRIPTION
On EL9, RPMs required by xCAT have been updated and now themselves require many other dependencies, which are not shipped in `xcat-dep`.
Instead of shipping these additional RPMs in `xcat-dep` (around 30), it has been decided to require `epel` and `crb` repositories to be enabled when installing on EL9 family of OSes.

This PR adds code to `go-xcat` to display a message when installing on EL9 and `epel` or `crb` repositories are not enabled.

## UT:

* RHEL9.0 EPEL not enabled, CRB not enabled:
```
[root@vm-2021 yum.repos.d]# /tmp/go-xcat --xcat-version=devel install
Operating system:   linux
Architecture:       x86_64
Linux Distribution: rhel
Version:            9.0
go-xcat Version:    1.0.51


Reading repositories ...... done
:
:
:
xCAT is going to be installed.
Continue? [y/n] y
Error: No matching Packages to list

Installation on rhel 9.0 requires EPEL repository to be enabled
Running 'dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm' will enable EPEL repository

Boo-boo
=======

Something went wrong. :(

Please check log file `/tmp/go-xcat.log' for more details.
[root@vm-2021 yum.repos.d]#
```

* RHEL9.0 EPEL enabled, CRB not enabled:
```
[root@vm-2021 tmp]# /tmp/go-xcat --xcat-version=devel install
Operating system:   linux
Architecture:       x86_64
Linux Distribution: rhel
Version:            9.0
go-xcat Version:    1.0.51


Reading repositories ...... done
:
:
:
xCAT is going to be installed.
Continue? [y/n] y
Available Packages
perl-Crypt-CBC.noarch                      3.04-1.el9                       epe
Error: No matching Packages to list

Installation on rhel 9.0 requires CRB repository to be enabled
Try adding the following entries to new or existing '.repo' file:

[crb]
name=CentOS Stream  - CRB
metalink=https://mirrors.centos.org/metalink?repo=centos-crb-&arch=&protocol=htps,http
gpgcheck=0
repo_gpgcheck=0
metadata_expire=6h
countme=1
enabled=1


Boo-boo
=======

Something went wrong. :(

Please check log file `/tmp/go-xcat.log' for more details.
[root@vm-2021 tmp]#
```

* RHEL9.0 EPEL enabled, CRB enabled: 
```
[root@vm-2021 yum.repos.d]# /tmp/go-xcat --xcat-version=devel install
Operating system:   linux
Architecture:       x86_64
Linux Distribution: rhel
Version:            9.0
go-xcat Version:    1.0.51


Reading repositories ...... done
:
:
:
Complete!
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered with an entitlement server. You can use subscription-manager to register.

Last metadata expiration check: 0:06:02 ago on Wed 07 Dec 2022 10:00:33 AM EST.
Package initscripts-10.11.5-1.el9.x86_64 is already installed.
Dependencies resolved.
Nothing to do.
Complete!

xCAT has been installed!
========================

If this is the very first time xCAT has been installed, run one of the
following commands to set the environment variables.

For sh:
    source /etc/profile.d/xcat.sh

For csh:
    source /etc/profile.d/xcat.csh
[root@vm-2021 yum.repos.d]#
```

* RHEL8.6 EPEL not enabled CRB not enabled:
```
[root@c910f04x37v07 tmp]# /tmp/go-xcat --xcat-version=devel install
Operating system:   linux
Architecture:       x86_64
Linux Distribution: rhel
Version:            8.6
go-xcat Version:    1.0.51


Reading repositories ...... done
:
:
:
Complete!
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered with an entitlement server. You can use subscription-manager to register.

Last metadata expiration check: 0:04:51 ago on Wed 07 Dec 2022 10:37:39 AM EST.
Package initscripts-10.00.15-1.el8.x86_64 is already installed.
Dependencies resolved.
Nothing to do.
Complete!

xCAT has been installed!
========================

If this is the very first time xCAT has been installed, run one of the
following commands to set the environment variables.

For sh:
    source /etc/profile.d/xcat.sh

For csh:
    source /etc/profile.d/xcat.csh
[root@c910f04x37v07 tmp]#
```