### PR TITLE
Do not exclude ./usr/lib/locale/C*

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels6.ppc64.exlist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels6.ppc64.exlist
@@ -25,6 +25,7 @@
 +./usr/share/locale/locale.alias
 +./usr/lib/locale/locale-archive
 +./usr/lib/locale/en*
++./usr/lib/locale/C*
 ./usr/share/man*
 ./usr/share/omf*
 ./usr/share/vim/site/doc*

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels6.x86_64.exlist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels6.x86_64.exlist
@@ -25,6 +25,7 @@
 +./usr/share/locale/locale.alias
 +./usr/lib/locale/locale-archive
 +./usr/lib/locale/en*
++./usr/lib/locale/C*
 ./usr/share/man*
 ./usr/share/omf*
 ./usr/share/vim/site/doc*

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels7.ppc64.exlist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels7.ppc64.exlist
@@ -25,6 +25,7 @@
 +./usr/share/locale/locale.alias
 +./usr/lib/locale/locale-archive
 +./usr/lib/locale/en*
++./usr/lib/locale/C*
 ./usr/share/omf*
 ./usr/share/vim/site/doc*
 ./usr/share/vim/vim74/doc*

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels7.x86_64.exlist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels7.x86_64.exlist
@@ -25,6 +25,7 @@
 +./usr/share/locale/locale.alias
 +./usr/lib/locale/locale-archive
 +./usr/lib/locale/en*
++./usr/lib/locale/C*
 ./usr/share/man*
 ./usr/share/omf*
 ./usr/share/vim/site/doc*

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels8.ppc64le.exlist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels8.ppc64le.exlist
@@ -23,6 +23,7 @@
 +./usr/share/locale/locale.alias
 +./usr/lib/locale/locale-archive
 +./usr/lib/locale/en*
++./usr/lib/locale/C*
 ./usr/share/omf*
 ./usr/share/vim/site/doc*
 ./usr/share/vim/vim74/doc*

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels8.x86_64.exlist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels8.x86_64.exlist
@@ -23,6 +23,7 @@
 +./usr/share/locale/locale.alias
 +./usr/lib/locale/locale-archive
 +./usr/lib/locale/en*
++./usr/lib/locale/C*
 ./usr/share/man*
 ./usr/share/omf*
 ./usr/share/vim/site/doc*

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels9.ppc64le.exlist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels9.ppc64le.exlist
@@ -23,6 +23,7 @@
 +./usr/share/locale/locale.alias
 +./usr/lib/locale/locale-archive
 +./usr/lib/locale/en*
++./usr/lib/locale/C*
 ./usr/share/omf*
 ./usr/share/vim/site/doc*
 ./usr/share/vim/vim74/doc*

--- a/xCAT-server/share/xcat/netboot/rh/compute.rhels9.x86_64.exlist
+++ b/xCAT-server/share/xcat/netboot/rh/compute.rhels9.x86_64.exlist
@@ -23,6 +23,7 @@
 +./usr/share/locale/locale.alias
 +./usr/lib/locale/locale-archive
 +./usr/lib/locale/en*
++./usr/lib/locale/C*
 ./usr/share/man*
 ./usr/share/omf*
 ./usr/share/vim/site/doc*

--- a/xCAT-server/share/xcat/netboot/rh/service.rhels7.ppc64le.exlist
+++ b/xCAT-server/share/xcat/netboot/rh/service.rhels7.ppc64le.exlist
@@ -25,6 +25,7 @@
 +./usr/share/locale/locale.alias
 +./usr/lib/locale/locale-archive
 +./usr/lib/locale/en*
++./usr/lib/locale/C*
 ./usr/share/man*
 ./usr/share/omf*
 ./usr/share/vim/site/doc*

--- a/xCAT-server/share/xcat/netboot/rh/service.rhels7.x86_64.exlist
+++ b/xCAT-server/share/xcat/netboot/rh/service.rhels7.x86_64.exlist
@@ -25,6 +25,7 @@
 +./usr/share/locale/locale.alias
 +./usr/lib/locale/locale-archive
 +./usr/lib/locale/en*
++./usr/lib/locale/C*
 ./usr/share/man*
 ./usr/share/omf*
 ./usr/share/vim/site/doc*


### PR DESCRIPTION
Missing C locale can cause issues with programs like tmux.

Furthermore `/usr/share/locale/C*` is excluded already.