### PR TITLE
Testcase enhancements

### DIFF
--- a/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_diskless_installation_flat
@@ -20,7 +20,7 @@ cmd:makedhcp -n
 check:rc==0
 cmd:makedhcp -a
 check:rc==0
-cmd:a=0;while true; do [ $a -eq 100 ] && { echo "After 100 iterations, makedhcp -q $$CN did not return any output"; makedhcp -q all; exit 1; }; output=$(makedhcp -q $$CN);[ $? -ne 0 ] && exit 1;echo $output|grep $$CN 2>/dev/null && exit 0;echo "[$a] Waiting for makedhcp -q $$CN to return output"; a=$[$a+1]; sleep 1;done
+cmd:a=0;while true; do [ $a -eq 10 ] && { echo "After 10 iterations, makedhcp -q $$CN did not return any output"; makedhcp -q all; exit 1; }; [ $a -eq 5 ] && { echo "After 5 iterations, makedhcp -q $$CN did not return any output. Retrying makedhcp -a again"; makedhcp -a; }; output=$(makedhcp -q $$CN);[ $? -ne 0 ] && exit 1;echo $output|grep $$CN 2>/dev/null && exit 0;echo "[$a] Waiting for makedhcp -q $$CN to return output"; a=$[$a+1]; sleep 1;done
 check:rc==0
 cmd:copycds $$ISO
 check:rc==0
@@ -134,7 +134,7 @@ cmd:makedhcp -n
 check:rc==0
 cmd:makedhcp -a
 check:rc==0
-cmd:a=0;while true; do [ $a -eq 100 ] && { echo "After 100 iterations, makedhcp -q $$CN did not return any output"; makedhcp -q all; exit 1; }; output=$(makedhcp -q $$CN);[ $? -ne 0 ] && exit 1;echo $output|grep $$CN 2>/dev/null && exit 0;echo "[$a] Waiting for makedhcp -q $$CN to return output"; a=$[$a+1]; sleep 1;done
+cmd:a=0;while true; do [ $a -eq 10 ] && { echo "After 10 iterations, makedhcp -q $$CN did not return any output"; makedhcp -q all; exit 1; }; [ $a -eq 5 ] && { echo "After 5 iterations, makedhcp -q $$CN did not return any output. Retrying makedhcp -a again"; makedhcp -a; }; output=$(makedhcp -q $$CN);[ $? -ne 0 ] && exit 1;echo $output|grep $$CN 2>/dev/null && exit 0;echo "[$a] Waiting for makedhcp -q $$CN to return output"; a=$[$a+1]; sleep 1;done
 check:rc==0
 cmd:copycds $$ISO
 check:rc==0

--- a/xCAT-test/autotest/testcase/pythonsupport/cases0
+++ b/xCAT-test/autotest/testcase/pythonsupport/cases0
@@ -33,6 +33,7 @@ check:rc==0
 cmd:cat /etc/yum.repos.d/xcat-dep-python-local.repo
 check:rc==0 
 cmd:wget https://xcat.org/files/xcat/xcat-dep/2.x_Linux/beta/xCAT-openbmc-py-RH7-2.14.6-snap202204090016.noarch.rpm --no-check-certificate  -O /tmp/xCAT-openbmc-py-RH7.noarch.rpm
+check:rc==0
 cmd:ls -l /tmp/xCAT-openbmc-py-RH7.noarch.rpm
 check:rc==0
 cmd:yum install -y /tmp/xCAT-openbmc-py-RH7.noarch.rpm


### PR DESCRIPTION
1. Check RC after `wget` call
2. Improve handling of `makedhcp` failures. On Ubuntu `makedhcp -a` fails one in a while, most likely due to `omshell` failure under the covers. This results in `makedhcp -q` not returning any output. Retrying `makedhcp -q` 100 times seems wasteful since the problem is most likely `makedhcp -a` failed to add entries. This enhancement retries `makedhcp -q` 5 times, then calls `makedhcp -a`, then retries  `makedhcp -q` 5 more times.

### UT:
```
RETURN rc = 0
OUTPUT:
[0] Waiting for makedhcp -q c910f04x35v07 to return output
[1] Waiting for makedhcp -q c910f04x35v07 to return output
[2] Waiting for makedhcp -q c910f04x35v07 to return output
[3] Waiting for makedhcp -q c910f04x35v07 to return output
[4] Waiting for makedhcp -q c910f04x35v07 to return output
After 5 iterations, makedhcp -q c910f04x35v07 did not return any output. Retrying makedhcp -a again
[5] Waiting for makedhcp -q c910f04x35v07 to return output
[6] Waiting for makedhcp -q c910f04x35v07 to return output
c910f04x35v07: ip-address = 10.4.35.7, hardware-address = 42:36:0a:04:23:07
CHECK:rc == 0   [Pass]
```
