### PR TITLE
Eliminate some duplicate output lines from xcatprobe osdeploy

### DIFF
--- a/xCAT-probe/subcmds/osdeploy
+++ b/xCAT-probe/subcmds/osdeploy
@@ -812,15 +812,28 @@ Start capturing every message during OS provision process....
         my @hdls;
         my $starttime = time();
         my @candidate_mn_hostname_in_log = $log_parse->obtain_candidate_mn_hostname_in_log();
+        my $log_content_ref_last;
 
-        #read log realtimely, then handle each log
+        # Loop forever, reading each log file
         for (; ;) {
             if (@hdls = $select->can_read(0)) {
                 foreach my $hdl (@hdls) {
                     my $line = "";
                     chomp($line = <$hdl>);
                     my $log_content_ref = $log_parse->obtain_log_content($fd_filetype_map{$hdl}, $line);
-                    dispatch_log_to_handler($log_content_ref, \@candidate_mn_hostname_in_log, \%node_state);
+                    if ($log_content_ref->{label} == $::LOGLABEL_XCAT) {
+                        # If reading computes or cluster log files, try to eliminate duplicated lines
+                        unless (($log_content_ref_last->{time_record} eq $log_content_ref->{time_record}) && 
+                                ($log_content_ref_last->{sender} eq $log_content_ref->{sender}) && 
+                                ($log_content_ref_last->{msg} eq $log_content_ref->{msg})) {
+                            dispatch_log_to_handler($log_content_ref, \@candidate_mn_hostname_in_log, \%node_state);
+                        }
+                        # Save messages details for later duplicate detection
+                        $log_content_ref_last = { %$log_content_ref };
+                    }
+                    else {
+                        dispatch_log_to_handler($log_content_ref, \@candidate_mn_hostname_in_log, \%node_state);
+                    }
                 }
             }
 


### PR DESCRIPTION
When `xcatprobe osdeploy` runs, it reads latest log file entries (via `tail -f`) from `messages.log`, `http.log`, `cluster.log` and `computes.log` files.
Several deployment related entries displayed twice because they appear in both `computes.log` and `cluster.log`:

```
[root@f6u13k10 ~]# xcatprobe osdeploy -n f6u13k12
:
:
[f6u13k12] 14:19:04 DHCPREQUEST for 10.6.13.12 from 42:68:0a:06:0d:0c via enp0s1
[f6u13k12] 14:19:04 Send DHCPACK on 10.6.13.12 back to 42:68:0a:06:0d:0c via enp0s1
[f6u13k12] 14:19:17 INFO ============deployment starting============
[f6u13k12] 14:19:17 INFO ============deployment starting============
[f6u13k12] 14:19:17 INFO Running Anaconda Pre-Installation script...
[f6u13k12] 14:19:17 INFO Running Anaconda Pre-Installation script...
[f6u13k12] 14:19:17 INFO Detecting install disk...
[f6u13k12] 14:19:17 INFO Detecting install disk...
[f6u13k12] 14:19:20 INFO Found /dev/sda, generate partition file...
[f6u13k12] 14:19:17 Node status is changed to installing
[f6u13k12] 14:19:20 INFO Found /dev/sda, generate partition file...
[f6u13k12] 14:19:20 INFO Generate the repository for the installation
[f6u13k12] 14:19:20 INFO Generate the repository for the installation
[f6u13k12] 14:19:22 Receive DHCPDISCOVER via enp0s1
[f6u13k12] 14:19:22 Send DHCPOFFER on 10.6.13.12 back to 42:68:0a:06:0d:0c via enp0s1
[f6u13k12] 14:19:22 DHCPREQUEST for 10.6.13.12 (10.6.13.10) from 42:68:0a:06:0d:0c via enp0s1
[f6u13k12] 14:19:22 Send DHCPACK on 10.6.13.12 back to 42:68:0a:06:0d:0c via enp0s1
:
:
```

This PR tries to eliminate such duplicate lines, if they are read from `computes.log` and `cluster.log` one after the other.
Message details from a previous, already displayed message are compared to currently read message. If identical, display of currently read message is skipped.

After this PR:
```
[root@f6u13k10 ~]# xcatprobe osdeploy -n f6u13k12
:
:
[f6u13k12] 15:51:16 DHCPREQUEST for 10.6.13.12 from 42:fa:0a:06:0d:0c via enp0s1
[f6u13k12] 15:51:16 Send DHCPACK on 10.6.13.12 back to 42:fa:0a:06:0d:0c via enp0s1
[f6u13k12] 15:51:30 INFO ============deployment starting============
[f6u13k12] 15:51:30 INFO Running Anaconda Pre-Installation script...
[f6u13k12] 15:51:30 INFO Detecting install disk...
[f6u13k12] 15:51:32 INFO Found /dev/sda, generate partition file...
[f6u13k12] 15:51:30 Node status is changed to installing
[f6u13k12] 15:51:32 INFO Found /dev/sda, generate partition file...
[f6u13k12] 15:51:32 INFO Generate the repository for the installation
[f6u13k12] 15:51:34 Receive DHCPDISCOVER via enp0s1
[f6u13k12] 15:51:34 Send DHCPOFFER on 10.6.13.12 back to 42:fa:0a:06:0d:0c via enp0s1
[f6u13k12] 15:51:34 DHCPREQUEST for 10.6.13.12 (10.6.13.10) from 42:fa:0a:06:0d:0c via enp0s1
[f6u13k12] 15:51:34 Send DHCPACK on 10.6.13.12 back to 42:fa:0a:06:0d:0c via enp0s1
:
:
```