### PR TITLE
Enable go-xcat to insall xCAT on Alma Linux

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/post.rhels8
+++ b/xCAT-server/share/xcat/install/scripts/post.rhels8
@@ -22,7 +22,7 @@ done
 
 # List of internal repos to be disabled
 
-internet_repo_file_list="oracle-linux-ol8.repo uek-ol8.repo Rocky-AppStream.repo Rocky-BaseOS.repo Rocky-Extras.repo CentOS-Base.repo"
+internet_repo_file_list="oracle-linux-ol8.repo uek-ol8.repo Rocky-AppStream.repo Rocky-BaseOS.repo Rocky-Extras.repo CentOS-Base.repo almalinux-ha.repo almalinux-nfv.repo almalinux-powertools.repo almalinux.repo almalinux-resilientstorage.repo almalinux-rt.repo"
 
 for repo_file in $internet_repo_file_list
 do

--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -786,7 +786,7 @@ if ((-d "$rootimg_dir/usr/share/dracut") or (-d "$rootimg_dir/usr/lib/dracut")) 
 
 # List of internet repos to be disabled
 
-my @internet_repo_file_list = ("oracle-linux-ol8.repo", "uek-ol8.repo", "Rocky-AppStream.repo", "Rocky-BaseOS.repo", "Rocky-Extras.repo", "CentOS-Base.repo");
+my @internet_repo_file_list = ("oracle-linux-ol8.repo", "uek-ol8.repo", "Rocky-AppStream.repo", "Rocky-BaseOS.repo", "Rocky-Extras.repo", "CentOS-Base.repo", "almalinux-ha.repo", "almalinux-nfv.repo", "almalinux-plus.repo", "almalinux-powertools.repo", "almalinux.repo", "almalinux-resilientstorage.repo", "almalinux-rt.repo");
 
 foreach ( @internet_repo_file_list ) {
   if (-e "$rootimg_dir/etc/yum.repos.d/$_") {

--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -2,7 +2,7 @@
 #
 # go-xcat - Install xCAT automatically.
 #
-# Version 1.0.52
+# Version 1.0.53
 #
 # Copyright (C) 2016 - 2021 International Business Machines
 # Eclipse Public License, Version 1.0 (EPL-1.0)
@@ -44,6 +44,8 @@
 #     - Make sure initscripts installed on RH family of OSes
 # 2022-12-06 Mark Gurevich <gurevich@us.ibm.com>
 #     - Check for EPEL and CRB repository on EL9 family of OSes
+# 2023-01-19 Mark Gurevich <gurevich@us.ibm.com>
+#     - Add support for Alma Linux
 #
 
 
@@ -1601,6 +1603,7 @@ function add_xcat_dep_repo_yum_or_zypper()
 	"centos"*)             distro="rh${distro#centos}" ;;
 	"ol"*)                 distro="rh${distro#ol}" ;;
 	"rocky"*)              distro="rh${distro#rocky}" ;;
+	"alma"*)               distro="rh${distro#almalinux}" ;;
 	"fedora10"|"fedora11") distro="fedora9" ;;
 	"fedora1"[678])        distro="rh6" ;;
 	"fedora19"|"fedora2"?) distro="rh7" ;;
@@ -2353,7 +2356,7 @@ Version:            ${GO_XCAT_LINUX_VERSION}
 EOF
 
 case "${GO_XCAT_LINUX_DISTRO}" in
-"centos"|"fedora"|"rhel"|"sles"|"ubuntu"|"ol"|"rocky")
+"centos"|"fedora"|"rhel"|"sles"|"ubuntu"|"ol"|"rocky"|"almalinux")
 	;;
 *)
 	warn_if_bad 1 "${GO_XCAT_LINUX_DISTRO}: unsupported Linux distro"


### PR DESCRIPTION
```
[root@c910f04x37v07 tmp]# ./go-xcat install
Operating system:   linux
Architecture:       x86_64
Linux Distribution: almalinux
Version:            8.6
go-xcat Version:    1.0.53


Reading repositories ...... done
:
:
:
xCAT has been installed!
========================

If this is the very first time xCAT has been installed, run one of the
following commands to set the environment variables.

For sh:
    source /etc/profile.d/xcat.sh

For csh:
    source /etc/profile.d/xcat.csh
[root@c910f04x37v07 tmp]#

[root@c910f04x37v07 tmp]# source /etc/profile.d/xcat.sh
[root@c910f04x37v07 tmp]#
[root@c910f04x37v07 tmp]# lsxcatd -a
Version 2.16.4 (git commit bb7a4bbbc8bde7e6613558d8d039fe43d49d2079, built Mon Jun 13 08:53:10 EDT 2022)
This is a Management Node
dbengine=SQLite
[root@c910f04x37v07 tmp]#
```