### PR TITLE
bmcsetup: add support for setting bmcport on Supermicro servers

### DIFF
--- a/xCAT-genesis-scripts/usr/bin/bmcsetup
+++ b/xCAT-genesis-scripts/usr/bin/bmcsetup
@@ -266,6 +266,14 @@ elif [ "$IPMIMFG" == "674" ]; then # DELL
         ipmitool delloem lan set shared with lom$BMCPORT &>/dev/null
         ipmitool delloem lan set shared with failover all loms &>/dev/null
     fi
+elif [ "$IPMIMFG" == "10876" ]; then # Supermicro
+    BMCPORT=`grep bmcport /tmp/ipmicfg.xml |awk -F\> '{print $2}'|awk -F\< '{print $1}'`
+    logger -s -t $log_label -p local4.info "BMCPORT is $BMCPORT"
+    if [ "$BMCPORT" == "0" ]; then # shared
+        ipmitool raw 0x30 0x70 0x0c 1 2
+    elif [ "$BMCPORT" == "1" ]; then # dedicated
+        ipmitool raw 0x30 0x70 0x0c 1 0
+    fi
 elif [ "$IPMIMFG" == "42817" -a "$XPROD" == "16975" ]; then # IBM OpenPOWER servers with OpenBMC (AC922)
     ISOPENBMC=1
 elif [ "$IPMIMFG" == "42817" -a "$XPROD" == "1" ]; then # IBM OpenPOWER servers with OpenBMC (IC922)

--- a/xCAT-genesis-scripts/usr/bin/bmcsetup
+++ b/xCAT-genesis-scripts/usr/bin/bmcsetup
@@ -269,8 +269,9 @@ elif [ "$IPMIMFG" == "674" ]; then # DELL
 elif [ "$IPMIMFG" == "10876" ]; then # Supermicro
     BMCPORT=`grep bmcport /tmp/ipmicfg.xml |awk -F\> '{print $2}'|awk -F\< '{print $1}'`
     logger -s -t $log_label -p local4.info "BMCPORT is $BMCPORT"
+    # https://www.supermicro.com/support/faqs/faq.cfm?faq=17953
     if [ "$BMCPORT" == "0" ]; then # shared
-        ipmitool raw 0x30 0x70 0x0c 1 2
+        ipmitool raw 0x30 0x70 0x0c 1 1
     elif [ "$BMCPORT" == "1" ]; then # dedicated
         ipmitool raw 0x30 0x70 0x0c 1 0
     fi


### PR DESCRIPTION
This PR includes support in `bmcsetup` to configure the BMC port on Supermicro servers (manufacturer id 10876) to use the dedicated interface, or share it with the system.

IPMI raw command documented here:
https://www.supermicro.com/support/faqs/faq.cfm?faq=9848