### PR TITLE
Update docs for password encryption

### DIFF
--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/configure/password.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/configure/password.rst
@@ -1,13 +1,14 @@
 Configure passwords
 ===================
 
-#. Configure the system password for the ``root`` user on the compute nodes.
+#. Configure the system password for the ``root`` user on the compute nodes. This password can be provided in encrypted or clear text form using the :doc:`chtab </guides/admin-guides/references/man8/chtab.8>` command.
 
-   * Set using the :doc:`chtab </guides/admin-guides/references/man8/chtab.8>` command:  ::
+   * Clear text: ::
+
 
        chtab key=system passwd.username=root passwd.password=abc123
 
-     To encrypt the password using ``openssl``, use the following command: ::
+   * Encrypted using ``openssl``: ::
 
        chtab key=system passwd.username=root passwd.password=`openssl passwd -1 abc123`
 

--- a/docs/source/guides/admin-guides/manage_clusters/ppc64le/configure/password.rst
+++ b/docs/source/guides/admin-guides/manage_clusters/ppc64le/configure/password.rst
@@ -10,7 +10,7 @@ Configure passwords
 
    * Encrypted using ``openssl``: ::
 
-       chtab key=system passwd.username=root passwd.password=`openssl passwd -1 abc123`
+       chtab key=system passwd.username=root passwd.password=`openssl passwd -6 abc123`
 
 
 #. Configure the passwords for Management modules of the compute nodes.

--- a/docs/source/guides/get-started/quick_start.rst
+++ b/docs/source/guides/get-started/quick_start.rst
@@ -43,10 +43,10 @@ Prepare the Management Node ``xcatmn.mydomain.com``
 
     wget https://raw.githubusercontent.com/xcat2/xcat-core/master/xCAT-server/share/xcat/tools/go-xcat -O - >/tmp/go-xcat
     chmod +x /tmp/go-xcat
-    go-xcat --yes install
+    /tmp/go-xcat --yes install
     source /etc/profile.d/xcat.sh
    
-#. Configure the system password for the root user on the compute nodes: ::
+#. Configure the system password for the ```root`` user on the compute nodes: ::
 
     chtab key=system passwd.username=root passwd.password=abc123
 
@@ -89,7 +89,7 @@ Stage 2 Provision a node and manage it with parallel shell
 
     copycds RHEL-7.6-20181010.0-Server-x86_64-dvd1.iso
 
-   After ``copycds``, the corresponding basic osimage will be generated automatically. And then you can list the new osimage name here. You can refer document to customize the package list or postscript for target compute nodes, but here just use the default one: ::
+   After ``copycds``, the corresponding basic osimage will be generated automatically. Later, package list or postscripts for target compute nodes can be customised. List generated osimages: ::
 
     lsdef -t osimage
 

--- a/perl-xCAT/xCAT/Schema.pm
+++ b/perl-xCAT/xCAT/Schema.pm
@@ -884,7 +884,7 @@ passed as argument rather than by table value',
         descriptions => {
             key => 'The type of component this user/pw is for.  Valid values: blade (management module), ipmi (BMC), system (nodes), omapi (DHCP), hmc, ivm, cec, frame, switch.',
             username => 'The default userid for this type of component',
-            password => 'The default password for this type of component. On Linux, a crypted form could be provided. Hashes starting with $1$, $5$ and $6$ (md5, sha256 and sha512 respectively) are supported.',
+            password => 'The default password for this type of component. On Linux, a crypted form could be provided for the "system" component, which will be used during initial node provisioning. Hashes starting with $1$, $5$ and $6$ (md5, sha256 and sha512 respectively) are supported.',
             cryptmethod => 'Indicates the method to use to encrypt the password attribute.  On AIX systems, if a value is provided for this attribute it indicates that the password attribute is encrypted.  If the cryptmethod value is not set it indicates the password is a simple string value. On Linux systems, the cryptmethod can be set to md5, sha256 or sha512. If not set, sha256 will be used as default to encrypt plain-text passwords.',
             authdomain => 'The domain in which this entry has meaning, e.g. specifying different domain administrators per active directory domain',
             comments => 'Any user-written notes.',

--- a/xCAT-test/autotest/testcase/passwd/case0
+++ b/xCAT-test/autotest/testcase/passwd/case0
@@ -228,7 +228,7 @@ cmd:gettab key=system passwd.cryptmethod > /tmp/tmpcryptmethod
 check:rc==0
 cmd:gettab key=system passwd.password > /tmp/tmppassword
 check:rc==0
-cmd:chtab key=system passwd.username=root passwd.password=`openssl passwd -1 abc123`
+cmd:chtab key=system passwd.username=root passwd.password=`openssl passwd -6 abc123`
 check:rc==0
 cmd:gettab key=system passwd.password > /tmp/tmpcryptedpasswd
 check:rc==0
@@ -254,7 +254,7 @@ cmd:gettab key=system passwd.cryptmethod > /tmp/tmpcryptmethod
 check:rc==0
 cmd:gettab key=system passwd.password > /tmp/tmppassword
 check:rc==0
-cmd:chtab key=system passwd.username=root passwd.password=`openssl passwd -1 abc123`
+cmd:chtab key=system passwd.username=root passwd.password=`openssl passwd -6 abc123`
 check:rc==0
 cmd:gettab key=system passwd.password |grep '\$1\$'
 check:rc==0


### PR DESCRIPTION
### The PR is to address issue _#7312_

* Update documentation to only mention encryption when discussing `system` password. 
* Update documentation and testcases to use `sha512`. 