### PR TITLE
Use xCAT::Utils:CheckVersion to compare BIND versions without using version.pm

### DIFF
--- a/perl-xCAT/xCAT/Utils.pm
+++ b/perl-xCAT/xCAT/Utils.pm
@@ -2201,7 +2201,7 @@ sub CheckVersion
     my $index = 0;
     my $max_index = ($len_a > $len_b) ? $len_a : $len_b;
 
-    for ($index = 0 ; $index <= $max_index ; $index++)
+    for ($index = 0 ; $index < $max_index ; $index++)
     {
         my $val_a = ($len_a < $index) ? 0 : $a[$index];
         my $val_b = ($len_b < $index) ? 0 : $b[$index];

--- a/xCAT-server/lib/xcat/plugins/ddns.pm
+++ b/xCAT-server/lib/xcat/plugins/ddns.pm
@@ -1286,7 +1286,7 @@ sub update_namedconf {
             my $bind_version_cmd="/usr/sbin/named -v | cut -d' ' -f2 | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+'";
             my @bind_version =xCAT::Utils->runcmd($bind_version_cmd, 0);
             # Turn off DNSSEC if running with bind vers 9.16.6 or higher
-            if ((scalar @bind_version > 0) && (version->parse($bind_version[0]) >= version->parse(9.16.6))) {
+            if ((scalar @bind_version > 0) && (xCAT::Utils::CheckVersion($bind_version[0], "9.16.6") >= 0)) {
                 push @newnamed, "\tdnssec-enable no;\n";
                 push @newnamed, "\tdnssec-validation no;\n";
             }

--- a/xCAT-server/lib/xcat/plugins/ddns.pm
+++ b/xCAT-server/lib/xcat/plugins/ddns.pm
@@ -14,7 +14,6 @@ use xCAT::SvrUtils;
 use Socket;
 use Fcntl qw/:flock/;
 use Data::Dumper;
-use version;
 
 # This is a rewrite of DNS management using nsupdate rather than
 #	direct zone mangling


### PR DESCRIPTION
The PR is to improve https://github.com/xcat2/xcat-core/pull/7260.

Some older systems may not have version.pm installed, which can cause failure while doing xCAT upgrades. This PR makes use of xCAT::Utils:CheckVersion to achieve the same function.

And, there is a bug in the for loop of Checkversion:
    for ($index = 0 ; $index <= $max_index ; $index++)

The arrays start at index 0. "<=" should be "<".

When two versions are different, the loop is exited before hitting $index = $max_index. However, when they are the same, the comparison continues with $index = $max_index, which is one larger than the size of the arrays.
