### PR TITLE
Install initscripts RPM during xCAT install(2)

### DIFF
--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -1718,8 +1718,8 @@ function install_packages_dnf()
 	el9_epel_and_crb_check dnf
 	local -a yes=()
 	[[ "$1" = "-y" ]] && yes=("-y") && shift
-	dnf --nogpgcheck "${yes[@]}" install "$@"
 	dnf --nogpgcheck "${yes[@]}" install initscripts
+	dnf --nogpgcheck "${yes[@]}" install "$@"
 }
 
 function install_packages_yum()
@@ -1728,8 +1728,8 @@ function install_packages_yum()
 	el9_epel_and_crb_check yum
 	local -a yes=()
 	[[ "$1" = "-y" ]] && yes=("-y") && shift
-	yum --nogpgcheck "${yes[@]}" install "$@"
 	yum --nogpgcheck "${yes[@]}" install initscripts
+	yum --nogpgcheck "${yes[@]}" install "$@"
 }
 
 # Dirty workaround on SLES 11 SP4
@@ -1770,7 +1770,7 @@ Installation on ${GO_XCAT_LINUX_DISTRO} ${GO_XCAT_LINUX_VERSION} requires EPEL r
 	ret="$?"
 	case "${ret}" in
 	"1")
-		# Ccan not find EL9_CRB_TEST_RPM
+		# Can not find EL9_CRB_TEST_RPM
 		echo "
 Installation on ${GO_XCAT_LINUX_DISTRO} ${GO_XCAT_LINUX_VERSION} requires CRB repository to be enabled"
 		echo "Try adding the following entries to new or existing '.repo' file:"


### PR DESCRIPTION
Update to #7279 

`initscripts` need to be installed first, before xCAT RPM installation.
If xCAT RPMs are installed first, one of them creates file `/etc/init.d/xcatd`. Later when `initscripts` is attempted be installed, it tries to install a dependency `chkconfig`, which fails, because `chkconfig` expects to be creating a `/etc/init.d/`:
```
Running transaction
  Preparing        :                                                        1/1
  Installing       : initscripts-service-10.11.4-1.el9.noarch               1/4
  Installing       : initscripts-rename-device-10.11.4-1.el9.ppc64le        2/4
  Installing       : chkconfig-1.20-2.el9.ppc64le                           3/4
Error unpacking rpm package chkconfig-1.20-2.el9.ppc64le
  Installing       : initscripts-10.11.4-1.el9.ppc64le                      4/4
error: unpacking of archive failed on file /etc/init.d: cpio: File from package already exists as a directory in system
error: chkconfig-1.20-2.el9.ppc64le: install failed
```