### PR TITLE
Add Perl library path to xcat.sh

### DIFF
--- a/xCAT-client/xCAT-client.spec
+++ b/xCAT-client/xCAT-client.spec
@@ -318,6 +318,11 @@ PATH=\$XCATROOT/bin:\$XCATROOT/sbin:\$XCATROOT/share/xcat/tools:\$PATH
 MANPATH=\$XCATROOT/share/man:\$MANPATH
 export XCATROOT PATH MANPATH
 export PERL_BADLANG=0
+# If /usr/local/share/perl5 is not already in @INC, add it to PERL5LIB
+perl -e "print \"@INC\"" | egrep "(^|\W)/usr/local/share/perl5($| )" > /dev/null
+if [ \$? = 1 ]; then
+    export PERL5LIB=/usr/local/share/perl5:\$PERL5LIB
+fi
 EOF
 
 # export XCATSSLVER for sles11. Others OS can work without this setting.
@@ -337,6 +342,11 @@ else
      setenv MANPATH \${XCATROOT}/share/man:\${MANPATH}
 endif
 setenv PERL_BADLANG 0
+# If /usr/local/share/perl5 is not already in @INC, add it to PERL5LIB
+perl -e "print \"@INC\"" | egrep "(^|\W)/usr/local/share/perl5($| )" > /dev/null
+if [ \$? = 1 ]; then
+    setenv PERL5LIB /usr/local/share/perl5:\$PERL5LIB
+fi
 EOF
 chmod 755 /etc/profile.d/xcat.*
 


### PR DESCRIPTION
Discovered the following while attempting to get xCAT running on ppc64le RH9:
```
[root@mid05tor12cn03 tmp]# rpower mid05tor12cn05 stat
Error: [mid05tor12cn03]: A fatal error was encountered, the following information may help identify a bug: Can't locate HTTP/Async.pm in @INC (you may need to install the HTTP::Async module) (@INC contains: /opt/xcat/lib/perl /usr/local/lib64/perl5/5.32 /usr/local/share/perl5/5.32 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at /opt/xcat/lib/perl/xCAT/OPENBMC.pm line 14.
BEGIN failed--compilation aborted at /opt/xcat/lib/perl/xCAT/OPENBMC.pm line 14.
Compilation failed in require at /opt/xcat/lib/perl/xCAT_plugin/openbmc2.pm line 18.
BEGIN failed--compilation aborted at /opt/xcat/lib/perl/xCAT_plugin/openbmc2.pm line 18.
Compilation failed in require at /opt/xcat/sbin/xcatd line 1993.
ERROR/WARNING: communication with the xCAT server seems to have been ended prematurely
[root@mid05tor12cn03 tmp]#

[root@mid05tor12cn03 tmp]# perl -c /opt/xcat/lib/perl/xCAT/OPENBMC.pm
Can't locate HTTP/Async.pm in @INC (you may need to install the HTTP::Async module) (@INC contains: /opt/xcat/lib/perl /usr/local/lib64/perl5/5.32 /usr/local/share/perl5/5.32 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at /opt/xcat/lib/perl/xCAT/OPENBMC.pm line 14.
BEGIN failed--compilation aborted at /opt/xcat/lib/perl/xCAT/OPENBMC.pm line 14.
[root@mid05tor12cn03 tmp]#
```

RH9 is running Perl `5.32`
RH8 is running Perl `5.26`
The `@INC` is different:
Perl `5.32`:
```
  @INC:
    /usr/local/lib64/perl5/5.32
    /usr/local/share/perl5/5.32
    /usr/lib64/perl5/vendor_perl
    /usr/share/perl5/vendor_perl
    /usr/lib64/perl5
    /usr/share/perl5
```
Perl `5.26`
```
  @INC:
    /usr/local/lib64/perl5
    /usr/local/share/perl5
    /usr/lib64/perl5/vendor_perl
    /usr/share/perl5/vendor_perl
    /usr/lib64/perl5
    /usr/share/perl5
```
The problem is one of the `xcat-dep` modules `perl-HTTP-Async`. It contains:
```
[root@mid05tor12cn03 tmp]# rpm -qll perl-HTTP-Async
/usr/local/share/man/man3/HTTP::Async.3pm
/usr/local/share/man/man3/HTTP::Async::Polite.3pm
/usr/local/share/perl5/HTTP/Async.pm
/usr/local/share/perl5/HTTP/Async/Polite.pm
[root@mid05tor12cn03 tmp]#
```

Perl `5.26` finds the `.pm` modules from that RPM because they are installed under `@INC` directory `/usr/local/share/perl5`, but Perl `5.32` does not find it because it is not under `@INC` directory `/usr/local/lib64/perl5/5.32`

This PR updates the `/etc/profile.d/xcat.sh` which gets generated during `xCAT-client` installation.
The script is then executed when `xcatd` starts. The `xcat.sh` will export `PERL5LIB` pointing to `/usr/local/share/perl5` if `@INC` does not already contain that path.

UT verified that the `xcat.sh` code works, but not easy to rebuild the `xCAT-client` RPM in order to verify that spec file correctly generates the `xcat.sh` with all the escape characters needed.
Leaving that to daily build and regression.