### PR TITLE
Fix password testcases for sha512

### DIFF
--- a/xCAT-test/autotest/testcase/passwd/case0
+++ b/xCAT-test/autotest/testcase/passwd/case0
@@ -235,8 +235,7 @@ check:rc==0
 cmd:if grep Ubuntu /etc/*release;then if [ ! -e /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot/initrd.gz ]; then copycds $$ISO;mkdir -p /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot/;touch /install/__GETNODEATTR($$CN,os)__/__GETNODEATTR($$CN,arch)__/install/netboot/initrd.gz;fi;fi
 cmd:nodeset $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-install-compute
 check:rc==0
-cmd:if grep SUSE /etc/*release;then grep '\$1\$' /install/autoinst/$$CN | awk 'gsub(/^ *| *$/,"")'| awk -v head="<user_password>" -v tail="</user_password>" '{print substr($0, index($0,head)+length(head),index($0,tail)-index($0,head)-length(head))}' > /tmp/instcryptedpasswd; elif grep -E "Red Hat|CentOS|Rocky" /etc/*release;then grep '\$1\$' /install/autoinst/$$CN |awk -F " " '{print $3}' > /tmp/instcryptedpasswd; elif grep Ubuntu /etc/*release;then grep '\$1\$' /install/autoinst/$$CN |awk -F " " '{print $4}' > /tmp/instcryptedpasswd;else echo "Sorry,this is not supported os"; fi
-#cmd:grep '\$1\$' /install/autoinst/$$CN |awk -F " " '{print $3}' > /tmp/instcryptedpasswd
+cmd:if grep SUSE /etc/*release;then grep '\$6\$' /install/autoinst/$$CN | awk 'gsub(/^ *| *$/,"")'| awk -v head="<user_password>" -v tail="</user_password>" '{print substr($0, index($0,head)+length(head),index($0,tail)-index($0,head)-length(head))}' > /tmp/instcryptedpasswd; elif grep -E "Red Hat|CentOS|Rocky" /etc/*release;then grep '\$6\$' /install/autoinst/$$CN |awk -F " " '{print $3}' > /tmp/instcryptedpasswd; elif grep Ubuntu /etc/*release;then grep '\$6\$' /install/autoinst/$$CN |awk -F " " '{print $4}' > /tmp/instcryptedpasswd;else echo "Sorry,this is not supported os"; fi
 check:rc==0
 cmd:diff /tmp/tmpcryptedpasswd /tmp/instcryptedpasswd
 check:rc==0
@@ -256,7 +255,7 @@ cmd:gettab key=system passwd.password > /tmp/tmppassword
 check:rc==0
 cmd:chtab key=system passwd.username=root passwd.password=`openssl passwd -6 abc123`
 check:rc==0
-cmd:gettab key=system passwd.password |grep '\$1\$'
+cmd:gettab key=system passwd.password |grep '\$6\$'
 check:rc==0
 #config CN to do diskless provision
 cmd:chdef -t node -o $$CN servicenode= monserver=$$MN nfsserver=$$MN tftpserver=$$MN  xcatmaster=$$MN
@@ -286,7 +285,7 @@ cmd:nodeset $$CN osimage=__GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-net
 check:rc==0
 cmd:if [[ "__GETNODEATTR($$CN,arch)__" =~ "ppc64" ]]; then rnetboot $$CN;elif [[ "__GETNODEATTR($$CN,arch)__" =~ "x86_64" ]];then rpower $$CN boot; fi
 check:rc==0
-cmd:sleep 900
+cmd:sleep 300
 cmd:a=0;while ! `lsdef -l $$CN|grep status|grep booted >/dev/null`; do sleep 10;((a++));if [ $a -gt 60 ];then break;fi done
 cmd:ping $$CN -c 3
 check:rc==0
@@ -296,7 +295,7 @@ check:rc==0
 check:output=~booted
 cmd:scp $$CN:/etc/shadow /tmp
 check:rc==0
-cmd:grep 'root:\$1\$' /tmp/shadow
+cmd:grep 'root:\$6\$' /tmp/shadow
 check:rc==0
 cmd:rootimgdir=`lsdef -t osimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-netboot-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir.regbak ]; then rm -rf $rootimgdir; mv $rootimgdir.regbak $rootimgdir; fi
 check:rc==0


### PR DESCRIPTION
Testcase changes made in #7319 were not enough.

When using `openssl -6`, verification of the generated string needs to be `$6` instead of `$1` as was used for `openssl -1`

### UT

#### Diskfull
```
[root@c910f04x37v05 autotest]# xcattest -f default.conf -t encrypted_passwd_openssl_diskfull
xCAT automated test started at Wed Feb  1 11:00:29 2023
:
:
:
------START::encrypted_passwd_openssl_diskfull::Time:Wed Feb  1 11:00:34 2023------

RUN:gettab key=system passwd.cryptmethod > /tmp/tmpcryptmethod [Wed Feb  1 11:00:34 2023]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0   [Pass]

RUN:gettab key=system passwd.password > /tmp/tmppassword [Wed Feb  1 11:00:34 2023]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0   [Pass]

RUN:chtab key=system passwd.username=root passwd.password=`openssl passwd -6 abc123` [Wed Feb  1 11:00:35 2023]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0   [Pass]

RUN:gettab key=system passwd.password > /tmp/tmpcryptedpasswd [Wed Feb  1 11:00:35 2023]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0   [Pass]

RUN:if grep Ubuntu /etc/*release;then if [ ! -e /install/__GETNODEATTR(c910f04x37v07,os)__/__GETNODEATTR(c910f04x37v07,arch)__/install/netboot/initrd.gz ]; then copycds /RHEL-8.6.0-20220420.3-x86_64-dvd1.iso;mkdir -p /install/__GETNODEATTR(c910f04x37v07,os)__/__GETNODEATTR(c910f04x37v07,arch)__/install/netboot/;touch /install/__GETNODEATTR(c910f04x37v07,os)__/__GETNODEATTR(c910f04x37v07,arch)__/install/netboot/initrd.gz;fi;fi [Wed Feb  1 11:00:35 2023]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:

RUN:nodeset c910f04x37v07 osimage=__GETNODEATTR(c910f04x37v07,os)__-__GETNODEATTR(c910f04x37v07,arch)__-install-compute [Wed Feb  1 11:00:36 2023]
ElapsedTime:3 sec
RETURN rc = 0
OUTPUT:
c910f04x37v07: install rhels8.6.0-x86_64-compute
CHECK:rc == 0   [Pass]

RUN:if grep SUSE /etc/*release;then grep '\$6\$' /install/autoinst/c910f04x37v07 | awk 'gsub(/^ *| *$/,"")'| awk -v head="<user_password>" -v tail="</user_password>" '{print substr($0, index($0,head)+length(head),index($0,tail)-index($0,head)-length(head))}' > /tmp/instcryptedpasswd; elif grep -E "Red Hat|CentOS|Rocky" /etc/*release;then grep '\$6\$' /install/autoinst/c910f04x37v07 |awk -F " " '{print $3}' > /tmp/instcryptedpasswd; elif grep Ubuntu /etc/*release;then grep '\$6\$' /install/autoinst/c910f04x37v07 |awk -F " " '{print $4}' > /tmp/instcryptedpasswd;else echo "Sorry,this is not supported os"; fi [Wed Feb  1 11:00:39 2023]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
/etc/os-release:NAME="Red Hat Enterprise Linux"
/etc/os-release:PRETTY_NAME="Red Hat Enterprise Linux 8.6 (Ootpa)"
/etc/os-release:REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 8"
/etc/os-release:REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
/etc/redhat-release:Red Hat Enterprise Linux release 8.6 (Ootpa)
/etc/system-release:Red Hat Enterprise Linux release 8.6 (Ootpa)
CHECK:rc == 0   [Pass]

RUN:diff /tmp/tmpcryptedpasswd /tmp/instcryptedpasswd [Wed Feb  1 11:00:39 2023]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0   [Pass]

RUN:oldpassword=`cat /tmp/tmppassword |sed 's/\"//g'`;oldcryptmethod=`cat /tmp/tmpcryptmethod |sed 's/\"//g'`;chtab key=system passwd.password=$oldpassword passwd.cryptmethod=$oldcryptmethod [Wed Feb  1 11:00:39 2023]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0   [Pass]

RUN:nodeset c910f04x37v07 osimage=__GETNODEATTR(c910f04x37v07,os)__-__GETNODEATTR(c910f04x37v07,arch)__-install-compute [Wed Feb  1 11:00:40 2023]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
c910f04x37v07: install rhels8.6.0-x86_64-compute
CHECK:rc == 0   [Pass]

RUN:rm -rf /tmp/tmpcryptmethod /tmp/tmppassword /tmp/tmpcryptedpasswd /tmp/instcryptedpasswd [Wed Feb  1 11:00:42 2023]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::encrypted_passwd_openssl_diskfull::Passed::Time:Wed Feb  1 11:00:42 2023 ::Duration::8 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished at Wed Feb  1 11:00:42 2023
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20230201110029 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20230201110029 file for time consumption
[root@c910f04x37v05 autotest]#
```

#### Diskless
```
[root@c910f04x37v05 autotest]# xcattest -f default.conf -t encrypted_passwd_openssl_diskless
:
:
:
RUN:rootimgdir=`lsdef -t osimage  __GETNODEATTR(c910f04x37v07,os)__-__GETNODEATTR(c910f04x37v07,arch)__-netboot-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir.regbak ]; then rm -rf $rootimgdir; mv $rootimgdir.regbak $rootimgdir; fi [Wed Feb  1 11:44:40 2023]
ElapsedTime:4 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0   [Pass]

RUN:oldpassword=`cat /tmp/tmppassword |sed 's/\"//g'`;oldcryptmethod=`cat /tmp/tmpcryptmethod |sed 's/\"//g'`;chtab key=system passwd.password=$oldpassword passwd.cryptmethod=$oldcryptmethod [Wed Feb  1 11:44:44 2023]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0   [Pass]

RUN:if [ -x /usr/bin/goconserver ]; then makegocons -d c910f04x37v07; else makeconservercf -d c910f04x37v07; fi [Wed Feb  1 11:44:45 2023]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
c910f04x37v07: Deleted

RUN:rm -rf /tmp/tmpcryptmethod  /tmp/tmppassword /tmp/shadow [Wed Feb  1 11:44:46 2023]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::encrypted_passwd_openssl_diskless::Passed::Time:Wed Feb  1 11:44:46 2023 ::Duration::1063 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished at Wed Feb  1 11:44:46 2023
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20230201112658 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20230201112658 file for time consumption
[root@c910f04x37v05 autotest]#