### PR TITLE
Update github action to run on Ubuntu20

### DIFF
--- a/.github/workflows/xcat_test.yml
+++ b/.github/workflows/xcat_test.yml
@@ -3,7 +3,7 @@ on:
   pull_request
 jobs:
   xcat_pr_test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - run: sudo apt-get install -y fakeroot reprepro devscripts debhelper libcapture-tiny-perl libjson-perl libsoap-lite-perl libdbi-perl libcgi-pm-perl quilt openssh-server dpkg looptools genometools software-properties-common


### PR DESCRIPTION
Currently used Ubuntu18.04 has been deprecated on 08/08/2023 and will be unsupported on 04/01/2023.