### PR TITLE
Fix EL9 chroot detection for syncfiles

### DIFF
--- a/xCAT/postscripts/xcatlib.sh
+++ b/xCAT/postscripts/xcatlib.sh
@@ -430,7 +430,7 @@ function startservice {
    local retmsg
    retmsg=`$cmd 2>&1`
    retval=$?
-   [ "$retval" = "0" ] && (echo "$retmsg" | grep -i "Running in chroot,\s*ignoring request.*" >/dev/null 2>&1)   && retval=1
+   [ "$retval" = "0" ] && (echo "$retmsg" | grep -i "Running in chroot,\s*ignoring .*" >/dev/null 2>&1)   && retval=1
 
    return $retval
 }
@@ -474,7 +474,7 @@ function stopservice {
    local retmsg
    retmsg=`$cmd 2>&1`
    retval=$?
-   [ "$retval" = "0" ] && (echo "$retmsg" | grep -i "Running in chroot,\s*ignoring request.*" >/dev/null 2>&1) && retval=1
+   [ "$retval" = "0" ] && (echo "$retmsg" | grep -i "Running in chroot,\s*ignoring .*" >/dev/null 2>&1) && retval=1
    return $retval
 }
 
@@ -522,7 +522,7 @@ function restartservice {
 
    #In the chrooted env, the system management commands(start/stop/restart) will be ignored and the return code is 0
    #need to return the proper code in the chrooted scenario
-   [ "$retval" = "0" ] && (echo "$retmsg" | grep -i "Running in chroot,\s*ignoring request.*" >/dev/null 2>&1) && retval=1
+   [ "$retval" = "0" ] && (echo "$retmsg" | grep -i "Running in chroot,\s*ignoring .*" >/dev/null 2>&1) && retval=1
 
    return $retval
 }


### PR DESCRIPTION
Syncfiles do not work during stateful deployment (kickstart process) on EL9 host because the chroot detection is broken on EL9. The return message changed:
    
EL9 shows the following message:

```
Running in chroot, ignoring command ...
```
    
Previously this was:

```
Running in chroot, ignoring request ...
```
    
Truncate regex to detect both.
Because of this, `sshd` was never started during kickstart and syncfiles `rsync` failed.

PS: I didn't include `command` as regex OR on purpose. Maybe they come up with yet another term in the future ;)