### PR TITLE
Make sure sshd is launched in anaconda chroot on EL8 and EL9-based distros

### DIFF
--- a/xCAT/postscripts/remoteshell
+++ b/xCAT/postscripts/remoteshell
@@ -640,6 +640,12 @@ else
     fi
     restartservice sshd
 fi
+
+if [[ $OSVER == rocky* || $OSVER == rhels8* || $OSVER == rhels9 ]]; then
+    pkill -9 sshd # Get rid of any previously started sshd, e.g. from anaconda inst.sshd
+    /sbin/sshd -f /etc/ssh/sshd_config || echo "ERR: Could not start sshd in chroot!"
+fi
+
 #if the service restart with "service/systemctl" failed
 #try to kill the process and start
 if [ "$?" != "0" ];then


### PR DESCRIPTION
### The PR is to fix issue #6981

The `remoteshell` script that is included in `xcatdefaults` intends to start sshd after anaconda goes into the %post section. On EL8 and later, this fails as there is no longer init.d compatability as there was in EL7.

This causes the `syncfiles` postscript to fail, either because `sshd` is simply not running, or if anaconda was launched with `inst.sshd` because the intended destination from the synclists file is not correct. From the sshd's context, the correct path would be `/mnt/sysroot/etc/hosts` instead of `/etc/hosts` because sshd is running outside of the chroot.

The fix detects OSVER being either rocky, rhels8 or rhels9 and starts sshd from the correct path, after the host keys are generated.