### PR TITLE
kvm: replace ac97 with ich6 for default audio support

### DIFF
--- a/xCAT-server/lib/xcat/plugins/kvm.pm
+++ b/xCAT-server/lib/xcat/plugins/kvm.pm
@@ -970,7 +970,7 @@ sub build_xmldesc {
         # do nothing for ppc64le, do not support sound at this time
         ;
     } else {
-        $xtree{devices}->{sound}->{model} = 'ac97';
+        $xtree{devices}->{sound}->{model} = 'ich6';
     }
 
     $xtree{devices}->{console}->{type} = 'pty';


### PR DESCRIPTION
ac97 audio support has been removed from QEMU.
For example in RHEL 9.1 (qemu-kvm-7.0.0), creating new VMs fail to start with the following error:

	'AC97' is not a valid device model name.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1995819
