### PR TITLE
Fix mysql setup for RH family of OSes

### DIFF
--- a/xCAT-client/bin/mysqlsetup
+++ b/xCAT-client/bin/mysqlsetup
@@ -952,7 +952,7 @@ sub mysqlstart
     else
     {
         if ($::MariaDB == 1) {    # running MariaDB
-            if ( ($::linuxos =~ /rh.*/) || ($::linuxos =~ /sles15.*/) ) {
+            if ( $::linuxos =~ /rh.*|ol.*|rocky.*|alma.*|sles15.*/) {
                 $ret = xCAT::Utils->startservice("mariadb");
             } else {              # sles
                 $ret = xCAT::Utils->startservice("mysql");
@@ -960,7 +960,7 @@ sub mysqlstart
 
         } else {    # it is mysql
 
-            if ($::linuxos =~ /rh.*/)
+            if ($::linuxos =~ /rh.*|ol.*|rocky.*|alma.*/)
             {
                 $ret = xCAT::Utils->startservice("mysqld");
             }
@@ -1063,7 +1063,7 @@ sub mysqlreboot
     {
         if ($::MariaDB == 1) {    # MariaDB not MySQL
 
-            if ( ($::linuxos =~ /rh.*/) || ($::linuxos =~ /sles15.*/) ){
+            if ($::linuxos =~ /rh.*|ol.*|rocky.*|alma.*|sles15.*/) {
                 $cmd = "chkconfig mariadb on";
             } else {              #sles
                 $cmd = "chkconfig mysql on";
@@ -1073,7 +1073,7 @@ sub mysqlreboot
 
             }
         } else {    # mysql
-            if ($::linuxos =~ /rh.*/)
+            if ($::linuxos =~ /rh.*|ol.*|rocky.*|alma.*/)
             {
                 $cmd = "chkconfig mysqld on";
             }
@@ -1611,7 +1611,7 @@ sub setupODBC
     }
 
     # for aix and redhat
-    if (($::linuxos =~ /rh.*/) || ($::osname eq 'AIX'))
+    if (($::linuxos =~ /rh.*|ol.*|rocky.*|alma.*/) || ($::osname eq 'AIX'))
     {
         $cmd = "rpm -qa | grep mysql-connector-odbc";
         xCAT::Utils->runcmd($cmd, 0);
@@ -1699,7 +1699,7 @@ sub setupODBC
     (my $connstring, my $adminid, my $passwd) = split(/\|/, $output[0]);
     (my $database,   my $id,      my $server) = split(/=/,  $connstring);
 
-    if (($::linuxos =~ /rh.*/) || ($::osname eq 'AIX'))
+    if (($::linuxos =~ /rh.*|ol.*|rocky.*|alma.*/) || ($::osname eq 'AIX'))
     {
         $odbcinstfile = "/etc/odbcinst.ini";
         $odbcfile     = "/etc/odbc.ini";


### PR DESCRIPTION
Currently when `mysqlsetup` script is executed on RHEL, it enables `mariadb` service:
```
XCATMYSQLADMIN_PW=12345 XCATMYSQLROOT_PW=12345 /opt/xcat/bin/mysqlsetup -i -V 
:
:
Running command on c910f04x12v02: chkconfig mariadb on 2>&1

Backing up xCAT Database to /root/xcat-dbback.
:
:
```

But on Alma, Rocky and Oracle, this error is displayed:
```
XCATMYSQLADMIN_PW=12345 XCATMYSQLROOT_PW=12345 /opt/xcat/bin/mysqlsetup -i -V
:
:
Running command on c910f04x12v02: chkconfig mysql on 2>&1

Command failed: chkconfig mysql on 2>&1. Error message: error reading information on service mysql: No such file or directory.

 chkconfig mysql on failed. MySQL will not restart on reboot.
Backing up xCAT Database to /root/xcat-dbback.
:
:
```

This PR makes Alma, Rocky and Oracle behave similar to RH, and enables `mariadb` service instead of `mysql`.