### PR TITLE
Fix syntax error in pgsqlsetup

### DIFF
--- a/xCAT-client/bin/pgsqlsetup
+++ b/xCAT-client/bin/pgsqlsetup
@@ -318,7 +318,7 @@ if (($INIT) && ($xcatrunningpgsql == 0))
                           # if that does not exist use resolved hostname
                           # double check site.master for resolution
         my $sitefile = "$::backupdir/site.csv";
-        my $cmd      = "grep \"master $sitefile";
+        my $cmd      = q{grep \"master } . $sitefile;
         my @output   = xCAT::Utils->runcmd($cmd, -1);
         if ($::RUNCMD_RC == 0)    #  entry in site table
         {


### PR DESCRIPTION
PR #6762 used incorrect formatting to insert `\"` into the `grep` command, which results in:
```
[root@vm-229 xcat]# XCATPGPW=12345 /opt/xcat/bin/pgsqlsetup -i -V
:
:
Shutting down the xcatd daemon during database migration.
Running command on vm-229: grep "master /root/xcat-dbback/site.csv 2>&1

sh: -c: line 1: unexpected EOF while looking for matching `"'
sh: -c: line 2: syntax error: unexpected end of file
The files belonging to this database system will be owned by user "postgres".
This user must also own the server process.
:
:
```

After PR:
```
[root@vm-229 xcat]# XCATPGPW=12345 /opt/xcat/bin/pgsqlsetup -i -V
:
:
Shutting down the xcatd daemon during database migration.
Running command on vm-229: grep \"master /root/xcat-dbback/site.csv 2>&1

The files belonging to this database system will be owned by user "postgres".
This user must also own the server process.
:
:
```