### PR TITLE
Fixed comments in sudoer postscript for issue #7301

### DIFF
--- a/xCAT/postscripts/sudoer
+++ b/xCAT/postscripts/sudoer
@@ -43,7 +43,7 @@ sleep 1
 rm -rf $HOME/.ssh/authorized_keys
 
 #-----------------
-# Retrieve DSA key
+# Retrieve RSA key
 #-----------------
 KEY=`cat /xcatpost/hostkeys/ssh_host_rsa_key.pub`
 
@@ -52,7 +52,7 @@ echo -e $KEY >> $HOME/.ssh/authorized_keys
 
 
 #-----------------
-# Retrieve RSA key
+# Retrieve DSA key
 #-----------------
 KEY=`cat /xcatpost/hostkeys/ssh_host_dsa_key.pub`
 


### PR DESCRIPTION
### The PR is to fix issue #7301

### Unit test results:
```
# Prior to running the postscript, no user named xcat with sudo permission exists
[root@c910f04x37v05 ~]# xdsh c910f04x37v07 "su xcat -c 'sudo ls /root'"
[c910f04x37v05]: c910f04x37v07: su: user xcat does not exist

[root@c910f04x37v05 ~]# updatenode c910f04x37v07 -P sudoer
c910f04x37v07: =============updatenode starting====================
c910f04x37v07: trying to download postscripts...
c910f04x37v07: postscripts downloaded successfully
c910f04x37v07: trying to get mypostscript from 10.4.37.5...
c910f04x37v07: postscript start..: sudoer
c910f04x37v07: userdel: user 'xcat' does not exist
c910f04x37v07: postscript end....: sudoer exited with code 0
c910f04x37v07: Running of postscripts has completed.
c910f04x37v07: =============updatenode ending====================

# After running the postscript, user xcat can sudo successfully
[root@c910f04x37v05 ~]# xdsh c910f04x37v07 "su xcat -c 'sudo ls /root'"
c910f04x37v07: anaconda-ks.cfg
c910f04x37v07: original-ks.cfg
```