### PR TITLE
SLES15.4 genimage dracut rpm version

### DIFF
--- a/xCAT-server/share/xcat/netboot/sles/genimage
+++ b/xCAT-server/share/xcat/netboot/sles/genimage
@@ -666,7 +666,7 @@ if ((-d "$rootimg_dir/usr/share/dracut") or (-d "$rootimg_dir/usr/lib/dracut")) 
     $dracutmode = 1;
 
     # get dracut version
-    $dracutver = `chroot $rootimg_dir rpm -qi dracut | awk '/Version/{print \$3}' | awk -F. '{print \$1}'`;
+    $dracutver = `chroot $rootimg_dir rpm -qi dracut | awk '/Version/ {print \$3}' | awk -F[.+] '{print \$1}'`;
     chomp($dracutver);
     if ($dracutver =~ /^\d\d\d$/) {
         if ($dracutver >= "033") {


### PR DESCRIPTION
Extract version number from `dracut` rpm on SLES15 SP4

On SLES15 SP4 `dracut` rpm name format does not contain `.` expected by the existing pattern match.
* SLES15 SP4: `dracut-055+suse.252.g4988b0bf-150400.1.8.x86_64.rpm`
* SLES15 SP3: `dracut-049.1+suse.187.g63c1504f-3.27.1.x86_64.rpm`

This PR adds a pattern to match `.` or `+`
