### PR TITLE
Fix RHEL9 yum repo paths for ospkgs and otherpkgs

### DIFF
--- a/xCAT/postscripts/ospkgs
+++ b/xCAT/postscripts/ospkgs
@@ -261,7 +261,7 @@ do
     # (1)for rhels6, there is one repodata in the os base dir; so keep it here, and handle the other cases below
     # (2)for sles, we should specified the baseurl should be ./install/sles11/ppc64/1
     # (3)for SL5, we should append the /SL
-    # (4)for rhels8, centos8, ol8, alma8 and rocky8 we should append /BaseOS and /AppStream to base directory
+    # (4)for rhels8/9, centos8/9, ol8/9, alma8/9 and rocky8/9 we should append /BaseOS and /AppStream to base directory
     # (5) for other os, we just keep it here.
     # For other pkg paths, we just keep it here.
     if [ $dir == $default_pkgdir ] || [ $dir == "$default_pkgdir/" ]; then
@@ -273,12 +273,12 @@ do
             ospkgdir="$ospkgdir/SL"
         fi
     fi
-    if ( ! pmatch "$OSVER" "rhels8*" && 
-         ! pmatch "$OSVER" "centos8*" &&
-         ! pmatch "$OSVER" "rocky8*" &&
-         ! pmatch "$OSVER" "alma8*" &&
-         ! pmatch "$OSVER" "ol8*"); then
-        # For rhels8, centos8, ol8, alma8 and rocky8 do not put $ospkgdir by itself
+    if ( ! pmatch "$OSVER" "rhels[89]*" && 
+         ! pmatch "$OSVER" "centos[89]*" &&
+         ! pmatch "$OSVER" "rocky[89]*" &&
+         ! pmatch "$OSVER" "alma[89]*" &&
+         ! pmatch "$OSVER" "ol[89]*"); then
+        # For rhels8/9, centos8/9, ol8/9, alma8/9 and rocky8 do not put $ospkgdir by itself
         array_set_element os_path $index $ospkgdir
     fi
     array_set_element os_path $index $ospkgdir
@@ -345,12 +345,12 @@ do
                          array_set_element os_path $index $ospkgdir_ok
                      done
                  fi   # x86_64
-            elif ( pmatch "$OSVER" "rhels8*" || 
-                   pmatch "$OSVER" "centos8*" || 
-                   pmatch "$OSVER" "rocky8*" ||
-                   pmatch "$OSVER" "alma8*" ||
-                   pmatch "$OSVER" "ol8*"); then
-                 # for rhels8, centos8, ol8, alma8 and rocky8 the repodata is in ./BaseOS, ./AppStream, not in ./
+            elif ( pmatch "$OSVER" "rhels[89]*" || 
+                   pmatch "$OSVER" "centos[89]*" || 
+                   pmatch "$OSVER" "rocky[89]*" ||
+                   pmatch "$OSVER" "alma[89]*" ||
+                   pmatch "$OSVER" "ol[89]*"); then
+                 # for rhels8/9, centos8/9, ol8/9, alma8/9 and rocky8/9 the repodata is in ./BaseOS, ./AppStream, not in ./
                  for arg in "BaseOS" "AppStream"
                  do
                      ospkgdir_ok="$ospkgdir/$arg"

--- a/xCAT/postscripts/otherpkgs
+++ b/xCAT/postscripts/otherpkgs
@@ -340,7 +340,7 @@ fi
         # (1)for rhels6, there is one repodata in the os base dir; so keep it here, and handle the other cases below
         # (2)for sles, we should specified the baseurl should be ./install/sles11/ppc64/1
         # (3)for SL5, we should append the /SL
-        # (4)for rhels8, centos8, ol8, alma8 and rocky8 we should append /BaseOS and /AppStream to base directory
+        # (4)for rhels8/9, centos8/9, ol8/9, alma8/9 and rocky8/9 we should append /BaseOS and /AppStream to base directory
         # (5) for other os, we just keep it here.
         # For other pkg paths, we just keep it here.
         if [ $dir == $default_pkgdir ] || [ $dir == "$default_pkgdir/" ]; then
@@ -352,12 +352,12 @@ fi
                 ospkgdir="$ospkgdir/SL"
             fi
         fi
-        if ( ! pmatch "$OSVER" "rhels8*" && 
-             ! pmatch "$OSVER" "centos8*" && 
-             ! pmatch "$OSVER" "rocky8*" &&
-             ! pmatch "$OSVER" "alma8*" &&
-             ! pmatch "$OSVER" "ol8*"); then
-        # For rhels8, centos8, ol8, and rocky8 do not put $ospkgdir by itself
+        if ( ! pmatch "$OSVER" "rhels[89]*" && 
+             ! pmatch "$OSVER" "centos[89]*" && 
+             ! pmatch "$OSVER" "rocky[89]*" &&
+             ! pmatch "$OSVER" "alma[89]*" &&
+             ! pmatch "$OSVER" "ol[89]*"); then
+        # For rhels8/9, centos8/9, ol8/9, and rocky8/9 do not put $ospkgdir by itself
             array_set_element os_path $index $ospkgdir
         fi
 
@@ -398,12 +398,12 @@ fi
                              array_set_element os_path $index $ospkgdir_ok
                          done
                      fi   # x86_64
-                elif ( pmatch "$OSVER" "rhels8*" || 
-                       pmatch "$OSVER" "centos8*" || 
-                       pmatch "$OSVER" "rocky8*" ||
-                       pmatch "$OSVER" "alma8*" ||
-                       pmatch "$OSVER" "ol8*"); then
-                     # for rhels8, centos8, ol8, alma8 and rocky8 the repodata is in ./BaseOS, ./AppStream, not in ./
+                elif ( pmatch "$OSVER" "rhels[89]*" || 
+                       pmatch "$OSVER" "centos[89]*" || 
+                       pmatch "$OSVER" "rocky[89]*" ||
+                       pmatch "$OSVER" "alma[89]*" ||
+                       pmatch "$OSVER" "ol[89]*"); then
+                     # for rhels8/9, centos8/9, ol8/9, alma8/9 and rocky8/9 the repodata is in ./BaseOS, ./AppStream, not in ./
                      for arg in "BaseOS" "AppStream"
                      do
                          ospkgdir_ok="$ospkgdir/$arg"


### PR DESCRIPTION
### The PR is to fix issue _#7346_

Similarly to EL8, EL9 OSes also need yum repository paths to `BaseOS` and `AppStream`
