### PR TITLE
Fix bind version comparison

### DIFF
--- a/xCAT-server/sbin/makenamed.conf
+++ b/xCAT-server/sbin/makenamed.conf
@@ -63,8 +63,19 @@ do
 	echo "		$i;"
 done >>$FILE
 echo "	};" >>$FILE
+
+# Natural version compare against version of bind.
+# If version 9.16.6 or higher, turn off DNSSEC
 BIND_VERSION=$(/usr/sbin/named -v | cut -d" " -f2)
-if [[ $BIND_VERSION > "9.16.5" ]]; then
+CONTROL_BIND_VERSION="9.16.6"
+
+# "sort --version-sort" takes lines of version strings and sorts them.
+# Output is lines of versions in sorted order, last line is highest version number
+LAST_IN_COMPARE=`printf '%s\n' $BIND_VERSION $CONTROL_BIND_VERSION | sort --version-sort | tail -n1`
+
+if [ $BIND_VERSION = $LAST_IN_COMPARE ]; then
+        # current version of BIND was last in sorted order,
+        # therefor it is higher than CONTROL_BIND_VERSION
         echo "	dnssec-enable no;
 	dnssec-validation no;" >>$FILE
 fi

--- a/xCAT-server/sbin/makenamed.conf
+++ b/xCAT-server/sbin/makenamed.conf
@@ -66,7 +66,7 @@ echo "	};" >>$FILE
 
 # Natural version compare against version of bind.
 # If version 9.16.6 or higher, turn off DNSSEC
-BIND_VERSION=$(/usr/sbin/named -v | cut -d" " -f2)
+BIND_VERSION=$(/usr/sbin/named -v | cut -d" " -f2 | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
 CONTROL_BIND_VERSION="9.16.6"
 
 # "sort --version-sort" takes lines of version strings and sorts them.


### PR DESCRIPTION
### The PR is to fix PR _#7126_

That PR used incorrect version comparison to compare versions of `bind`
As a result on SLES15.4 version of bind is `9.16.20` which compared to be less that `9.16.6`.

This PR uses `sort --version-sort` to do a "natural" version comparison 