### PR TITLE
Dummy pod files need content

### DIFF
--- a/xCAT-client/xpod2man
+++ b/xCAT-client/xpod2man
@@ -98,7 +98,7 @@ sub createDummyPods {
     mkdir "$poddir/man7";
     foreach my $d (@dummyPods) {
         if (!open(TMP, ">>$d")) { warn "Could not create dummy pod file $d ($!)\n"; }
-        else                    { close TMP; }
+        else                    { print TMP "=head1 NAME"; close TMP; }
     }
 
     return @dummyPods;


### PR DESCRIPTION
`xpod2html` script gets executed during building of `xCAT-client` RPM.
It generates man page `.html` files from `.pod` files. Some man pages have references to other man pages (usually under "See Also" section). Some of those "linked-to" references are to man pages in sections 5 and 7 which are generated from `Schema.pm` file when `perl-xCAT` RPM is build. However, those `.pod` files generated from `Schema.pm` are not available when `xCAT-client` RPM is build. To get around it, `xpod2html` script creates a bunch of empty dummy `.pod` files so that when `pod2html` command runs, it can find the reference "linked-to" file.
It appears the `pod2html` command in EL8 based build container is no longer happy with the empty dummy file and reports a warning:
```
[root@c910f04x33@xcat xCAT-client]# LANG=C ./xpod2man
Converting PODs to man pages...
Creating empty linked-to files: pods/man5/vmmaster.5.pod, pods/man5/nodehm.5.pod, pods/man5/vm.5.pod, pods/man5/xcatdb.5.pod, pods/man5/site.5.pod, pods/man5/nodetype.5.pod, pods/man5/networks.5.pod, pods/man5/hosts.5.pod, pods/man5/noderes.5.pod, pods/man7/osimage.7.pod, pods/man1/xcattest.1.pod, pods/man1/buildkit.1.pod
Converting PODs to HTML pages...
Cannot find "vmmaster.5" in podpath: cannot find suitable replacement path, cannot resolve link
Cannot find "nodehm.5" in podpath: cannot find suitable replacement path, cannot resolve link
Cannot find "vm.5" in podpath: cannot find suitable replacement path, cannot resolve link
Cannot find "nodehm.5" in podpath: cannot find suitable replacement path, cannot resolve link
Cannot find "nodehm.5" in podpath: cannot find suitable replacement path, cannot resolve link
Cannot find "nodehm.5" in podpath: cannot find suitable replacement path, cannot resolve link
Cannot find "xcatdb.5" in podpath: cannot find suitable replacement path, cannot resolve link
Cannot find "xcattest.1" in podpath: cannot find suitable replacement path, cannot resolve link
Cannot find "buildkit.1" in podpath: cannot find suitable replacement path, cannot resolve link
Cannot find "site.5" in podpath: cannot find suitable replacement path, cannot resolve link
Cannot find "nodetype.5" in podpath: cannot find suitable replacement path, cannot resolve link
Cannot find "networks.5" in podpath: cannot find suitable replacement path, cannot resolve link
Cannot find "site.5" in podpath: cannot find suitable replacement path, cannot resolve link
Cannot find "hosts.5" in podpath: cannot find suitable replacement path, cannot resolve link
Cannot find "site.5" in podpath: cannot find suitable replacement path, cannot resolve link
Cannot find "noderes.5" in podpath: cannot find suitable replacement path, cannot resolve link
Cannot find "nodetype.5" in podpath: cannot find suitable replacement path, cannot resolve link
Cannot find "site.5" in podpath: cannot find suitable replacement path, cannot resolve link
Cannot find "osimage.7" in podpath: cannot find suitable replacement path, cannot resolve link
Cannot find "xcatdb.5" in podpath: cannot find suitable replacement path, cannot resolve link
Cannot find "xcattest.1" in podpath: cannot find suitable replacement path, cannot resolve link
Cannot find "buildkit.1" in podpath: cannot find suitable replacement path, cannot resolve link
[root@c910f04x33@xcat xCAT-client]#
```

This PR writes a single header line into this dummy file, making it look more like a real `.pod` file. After this PR:
```
[root@c910f04x33@xcat xCAT-client]# LANG=C ./xpod2man
Converting PODs to man pages...
Creating empty linked-to files: pods/man5/vmmaster.5.pod, pods/man5/nodehm.5.pod, pods/man5/vm.5.pod, pods/man5/xcatdb.5.pod, pods/man5/site.5.pod, pods/man5/nodetype.5.pod, pods/man5/networks.5.pod, pods/man5/hosts.5.pod, pods/man5/noderes.5.pod, pods/man7/osimage.7.pod, pods/man1/xcattest.1.pod, pods/man1/buildkit.1.pod
Converting PODs to HTML pages...
[root@c910f04x33@xcat xCAT-client]#
```
