### PR TITLE
go-xcat should not use available option

### DIFF
--- a/xCAT-server/share/xcat/tools/go-xcat
+++ b/xCAT-server/share/xcat/tools/go-xcat
@@ -1755,7 +1755,7 @@ function el9_epel_and_crb_check()
 	else
 		[[ "${GO_XCAT_LINUX_VERSION}" =~ ^9(\.[0-9]) ]] || return 0
 	fi
-	${action} list available -q ${EL9_EPEL_TEST_RPM} 
+	${action} list -q ${EL9_EPEL_TEST_RPM} 
 	ret="$?"
 	case "${ret}" in
 	"1")
@@ -1766,7 +1766,7 @@ Installation on ${GO_XCAT_LINUX_DISTRO} ${GO_XCAT_LINUX_VERSION} requires EPEL r
 		exit 1
 		;;
 	esac
-	${action} list available -q ${EL9_CRB_TEST_RPM} 
+	${action} list -q ${EL9_CRB_TEST_RPM} 
 	ret="$?"
 	case "${ret}" in
 	"1")


### PR DESCRIPTION
When running on EL9, `go-xcat` uses `yum list available` to check if some EL9 RPMs from `epel` and `crb` are available and if not advises the user to enable `epel` and `crb` repositories.
However if RPM is already installed `yum list available` returns false, which causes `go-xcat` to enable `epel` and `crb` repositories and exit with failure.
This PR removes the `available` option, so that both already installed and available to install is treated the same:
* RPM not installed and not available:
```
[root@f6u13k06 ~]# yum list available -q xzsh
Error: No matching Packages to list
[root@f6u13k06 ~]# echo $?
1
[root@f6u13k06 ~]# yum list -q xzsh
Error: No matching Packages to list
[root@f6u13k06 ~]# echo $?
1
[root@f6u13k06 ~]#
```
* RPM not installed but available:
```
[root@f6u13k06 ~]# yum list available -q zsh
Available Packages
zsh.ppc64le 5.5.1-6.el8_1.2 local-rhels8.4.0-ppc64le--install-rhels8.4.0-ppc64le-BaseOS
[root@f6u13k06 ~]# echo $?
0
[root@f6u13k06 ~]# yum list -q zsh
Available Packages
zsh.ppc64le 5.5.1-6.el8_1.2 local-rhels8.4.0-ppc64le--install-rhels8.4.0-ppc64le-BaseOS
[root@f6u13k06 ~]# echo $?
0
[root@f6u13k06 ~]#
```
* RPM is already installed (this was the problem with using `available` flag):
```
[root@f6u13k06 ~]# yum list available -q zsh
Error: No matching Packages to list
[root@f6u13k06 ~]# echo $?
1
[root@f6u13k06 ~]# yum list -q zsh
Installed Packages
zsh.ppc64le 5.5.1-6.el8_1.2 @local-rhels8.4.0-ppc64le--install-rhels8.4.0-ppc64le-BaseOS
[root@f6u13k06 ~]# echo $?
0
[root@f6u13k06 ~]#