### PR TITLE
Added security advisory documentation for xCAT CVE-2023-27486

### DIFF
--- a/docs/source/security/2023/20230308_xcat.rst
+++ b/docs/source/security/2023/20230308_xcat.rst
@@ -1,5 +1,5 @@
 2023-03-08 - xCAT Vulnerabilities
-====================================
+=================================
 
 *Mar 8, 2023*, xCAT announced the following security advisory: https://github.com/xcat2/xcat-core/security/advisories/GHSA-hpxg-7428-6jvv
 

--- a/docs/source/security/2023/20230308_xcat.rst
+++ b/docs/source/security/2023/20230308_xcat.rst
@@ -1,0 +1,18 @@
+2023-03-08 - xCAT Vulnerabilities
+====================================
+
+*Mar 8, 2023*, xCAT announced the following security advisory: https://github.com/xcat2/xcat-core/security/advisories/GHSA-hpxg-7428-6jvv
+
+
+Advisory CVEs
+-------------
+
+* CVE-2023-27486 - **Insufficient authorization validation between zones when xCAT zones are enabled** (Severity: High)
+
+Please see the security bulletin above for patch, upgrade, or suggested work around information.
+
+Action
+------
+
+The issue described in CVE-2023-27486 only impacts users making use of the optional xCAT zones feature. xCAT zones are not enabled by default. Users making use of xCAT zones should upgrade to xCAT 2.16.5 or newer. Users that do not use xCAT zones are not impacted and do not need to upgrade.
+

--- a/docs/source/security/2023/index.rst
+++ b/docs/source/security/2023/index.rst
@@ -1,0 +1,7 @@
+2023 Notices
+============
+
+.. toctree::
+   :maxdepth: 1
+
+   20230308_xcat.rst

--- a/docs/source/security/index.rst
+++ b/docs/source/security/index.rst
@@ -4,6 +4,7 @@ Security Notices
 .. toctree::
    :maxdepth: 2
 
+   2023/index.rst
    2018/index.rst
    2017/index.rst
    2016/index.rst


### PR DESCRIPTION
Includes additional documentation related to: 
xCAT CVE-2023-27486 - Insufficient authorization validation between zones when xCAT zones are enabled
https://github.com/xcat2/xcat-core/security/advisories/GHSA-hpxg-7428-6jvv