### PR TITLE
Improve imgexport man page description of destination parameter

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/imgexport.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/imgexport.1.rst
@@ -31,33 +31,48 @@ DESCRIPTION
 
 The \ **imgexport**\  command will export an image that is being used by xCAT.  To export images, you must have the images defined in the \ *osimage*\  table. All the columns in the \ *osimage*\  and \ *linuximage*\  tables will be exported. If kits are used in stateful or stateless images, \ *kit*\ , \ *kitcomponent*\  and \ *kitrepo*\  tables will be exported. In addition, the following files will also be exported.
 
-For stateful:
-  x.pkglist
-  x.otherpkgs.pkglist
-  x.tmpl
-  x.synclist
-  kits related files
+\ **For stateful**\ :
 
-For stateless:
-  kernel
-  initrd.gz
-  rootimg.cpio.xz or rootimg.cpio.gz or rootimg.tar.xz or rootimg.tar.gz or rootimg.gz(for backward-compatibility)
-  x.pkglist
-  x.otherpkgs.pkglist
-  x.synclist
-  x.postinstall
-  x.exlist
-  kits related files
 
-For statelite:
-  kernel
-  initrd.gz
-  root image tree
-  x.pkglist
-  x.synclist
-  x.otherpkgs.pkglist
-  x.postinstall
-  x.exlist
+.. code-block:: perl
+
+   x.pkglist
+   x.otherpkgs.pkglist
+   x.tmpl
+   x.synclist
+   kits related files
+
+
+\ **For stateless**\ :
+
+
+.. code-block:: perl
+
+   kernel
+   initrd.gz
+   rootimg.cpio.xz or rootimg.cpio.gz or rootimg.tar.xz or rootimg.tar.gz or rootimg.gz(for backward-compatibility)
+   x.pkglist
+   x.otherpkgs.pkglist
+   x.synclist
+   x.postinstall
+   x.exlist
+   kits related files
+
+
+\ **For statelite**\ :
+
+
+.. code-block:: perl
+
+   kernel
+   initrd.gz
+   root image tree
+   x.pkglist
+   x.synclist
+   x.otherpkgs.pkglist
+   x.postinstall
+   x.exlist
+
 
 where x is the name of the profile.
 
@@ -110,7 +125,10 @@ OPTIONS
 
 \ *destination*\ 
  
- The output bundle file name.
+ The output bundle file name. If remote host is specified with \ **-**\ **-remotehost**\  option, 
+ the \ *destination*\  can include the path to the bundle file. If remote host is not
+ specified, the bundle file is placed in a local working directory, even if \ *destination*\ 
+ includes a path.
  
 
 

--- a/docs/source/guides/admin-guides/references/man1/imgimport.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/imgimport.1.rst
@@ -31,33 +31,48 @@ DESCRIPTION
 
 The \ **imgimport**\  command will import an image that has been exported by \ **imgexport**\  from xCAT.  This is the easiest way to transfer, backup, change or share images created by xCAT whether they be stateless or stateful. The bundle file will be unpacked in the current working directory. The xCAT configuration such as \ *osimage*\  and \ *linuximage*\  tables will then be updated.
 
-For stateful, the following files will be copied to the appropriate directories.
-  x.pkglist
-  x.otherpkgs.pkglist
-  x.tmpl
-  x.synclist
-  kits related files
+\ **For stateful, the following files will be copied to the appropriate directories**\ 
 
-For stateless, the following files will be copied to the appropriate directories.
-  kernel
-  initrd.gz
-  rootimg.cpio.xz or rootimg.cpio.gz or rootimg.tar.xz or rootimg.tar.gz or rootimg.gz(for backward-compatibility)
-  x.pkglist
-  x.otherpkgs.pkglist
-  x.synclist
-  x.postinstall
-  x.exlist
-  kits related files
 
-For statelite, the following files will be copied to the appropriate directories.
-  kernel
-  initrd.gz
-  root image tree
-  x.pkglist
-  x.synclist
-  x.otherpkgs.pkglist
-  x.postinstall
-  x.exlist
+.. code-block:: perl
+
+   x.pkglist
+   x.otherpkgs.pkglist
+   x.tmpl
+   x.synclist
+   kits related files
+
+
+\ **For stateless, the following files will be copied to the appropriate directories**\ 
+
+
+.. code-block:: perl
+
+   kernel
+   initrd.gz
+   rootimg.cpio.xz or rootimg.cpio.gz or rootimg.tar.xz or rootimg.tar.gz or rootimg.gz(for backward-compatibility)
+   x.pkglist
+   x.otherpkgs.pkglist
+   x.synclist
+   x.postinstall
+   x.exlist
+   kits related files
+
+
+\ **For statelite, the following files will be copied to the appropriate directories**\ 
+
+
+.. code-block:: perl
+
+   kernel
+   initrd.gz
+   root image tree
+   x.pkglist
+   x.synclist
+   x.otherpkgs.pkglist
+   x.postinstall
+   x.exlist
+
 
 where x is the profile name.
 
@@ -71,18 +86,33 @@ If \ **-f**\  flag is not specified, all the files will be copied to the same di
 
 After this command, you can run the \ **nodeset**\  command and then start deploying the nodes. You can also choose to modify the files and run the following commands before the node deployment.
 
-For stateful:
-  nodeset
+\ **For stateful**\ :
 
-For stateless:
-  genimage
-  packimage
-  nodeset
 
-For statelite
-  genimage
-  liteimg
-  nodeset
+.. code-block:: perl
+
+   nodeset
+
+
+\ **For stateless**\ :
+
+
+.. code-block:: perl
+
+   genimage
+   packimage
+   nodeset
+
+
+\ **For statelite**\ :
+
+
+.. code-block:: perl
+
+   genimage
+   liteimg
+   nodeset
+
 
 
 *******

--- a/xCAT-client/pods/man1/imgexport.1.pod
+++ b/xCAT-client/pods/man1/imgexport.1.pod
@@ -13,14 +13,16 @@ B<imgexport> I<image_name> [I<destination>] [B<-e>|B<--extra> I<file:dir>] ... ]
 
 The B<imgexport> command will export an image that is being used by xCAT.  To export images, you must have the images defined in the I<osimage> table. All the columns in the I<osimage> and I<linuximage> tables will be exported. If kits are used in stateful or stateless images, I<kit>, I<kitcomponent> and I<kitrepo> tables will be exported. In addition, the following files will also be exported.
 
-For stateful:
+B<For stateful>:
+
   x.pkglist
   x.otherpkgs.pkglist
   x.tmpl
   x.synclist
   kits related files
 
-For stateless:
+B<For stateless>:
+
   kernel
   initrd.gz
   rootimg.cpio.xz or rootimg.cpio.gz or rootimg.tar.xz or rootimg.tar.gz or rootimg.gz(for backward-compatibility)
@@ -32,7 +34,8 @@ For stateless:
   kits related files
 
 
-For statelite:
+B<For statelite>:
+
   kernel
   initrd.gz
   root image tree
@@ -79,7 +82,10 @@ The name of the image. Use B<lsdef -t osimage> to find out all the image names.
 
 =item I<destination>
 
-The output bundle file name.
+The output bundle file name. If remote host is specified with B<--remotehost> option, 
+the I<destination> can include the path to the bundle file. If remote host is not
+specified, the bundle file is placed in a local working directory, even if I<destination>
+includes a path.
 
 =back
 

--- a/xCAT-client/pods/man1/imgimport.1.pod
+++ b/xCAT-client/pods/man1/imgimport.1.pod
@@ -12,14 +12,16 @@ B<imgimport> I<bundle_file_name> [B<-p>|B<--postscripts> I<nodelist>] [B<-f>|B<-
 
 The B<imgimport> command will import an image that has been exported by B<imgexport> from xCAT.  This is the easiest way to transfer, backup, change or share images created by xCAT whether they be stateless or stateful. The bundle file will be unpacked in the current working directory. The xCAT configuration such as I<osimage> and I<linuximage> tables will then be updated.
 
-For stateful, the following files will be copied to the appropriate directories.
+B<For stateful, the following files will be copied to the appropriate directories>
+
   x.pkglist
   x.otherpkgs.pkglist
   x.tmpl
   x.synclist
   kits related files
 
-For stateless, the following files will be copied to the appropriate directories.
+B<For stateless, the following files will be copied to the appropriate directories>
+
   kernel
   initrd.gz
   rootimg.cpio.xz or rootimg.cpio.gz or rootimg.tar.xz or rootimg.tar.gz or rootimg.gz(for backward-compatibility)
@@ -30,7 +32,8 @@ For stateless, the following files will be copied to the appropriate directories
   x.exlist
   kits related files
 
-For statelite, the following files will be copied to the appropriate directories.
+B<For statelite, the following files will be copied to the appropriate directories>
+
   kernel
   initrd.gz
   root image tree
@@ -52,15 +55,18 @@ If B<-f> flag is not specified, all the files will be copied to the same directo
 
 After this command, you can run the B<nodeset> command and then start deploying the nodes. You can also choose to modify the files and run the following commands before the node deployment.
 
-For stateful:
+B<For stateful>:
+
   nodeset
 
-For stateless:
+B<For stateless>:
+
   genimage
   packimage
   nodeset
 
-For statelite
+B<For statelite>:
+
   genimage
   liteimg
   nodeset


### PR DESCRIPTION
* Update `imgexport` man page description of `destination` parameter.
* Fix `imgexport` and `imgimport` man page lists formatting

Currently formatting of the list is on a single line, making it very hard to read:

![image](https://user-images.githubusercontent.com/16106630/223840498-98bc8b81-ea0b-4164-96f7-ac033a317bf3.png)

After this PR:

![image](https://user-images.githubusercontent.com/16106630/223840677-ec6af7af-82c1-4c00-9b11-4789b01b84c3.png)
