### PR TITLE
SLES Service Node pkglist should include Postgres package

### DIFF
--- a/xCAT-server/share/xcat/install/sles/service.sles12.pkglist
+++ b/xCAT-server/share/xcat/install/sles/service.sles12.pkglist
@@ -14,9 +14,5 @@ perl-Net-DNS
 perl-DBD-mysql
 mariadb-client
 libmysqlclient18
-#   The following rpms are available on the SLES SDK
-#   You will need to locate and make these rpms available in your zypper
-#   repository for service node installs and uncomment the following lines:
-#MyODBC-unixODBC
-#perl-DBD-Pg
+perl-DBD-Pg
 

--- a/xCAT-server/share/xcat/netboot/sles/service.sle15.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/service.sle15.pkglist
@@ -64,10 +64,5 @@ rsyslog
 unixODBC
 perl-DBD-mysql
 mariadb-client
-#libmysqlclient18
-#   The following rpms are available on the SLES SDK
-#   You will need to locate and make these rpms available in your zypper
-#   repository for service node installs and uncomment the following lines:
-#MyODBC-unixODBC
 perl-DBD-Pg
 iputils

--- a/xCAT-server/share/xcat/netboot/sles/service.sles12.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/service.sles12.pkglist
@@ -63,8 +63,4 @@ unixODBC
 perl-DBD-mysql
 mariadb-client
 libmysqlclient18
-#   The following rpms are available on the SLES SDK
-#   You will need to locate and make these rpms available in your zypper
-#   repository for service node installs and uncomment the following lines:
-#MyODBC-unixODBC
-#perl-DBD-Pg
+perl-DBD-Pg


### PR DESCRIPTION
Currently RHEL service node pkglist includes packages for all xCAT supported databases. 
This way, no matter which DB is chosen on MN, the service node can be installed out of the box.

This PR updates SLES service node pkglist to include `perl-DBD-Pg` package, so that all xCAT supported database
packages are installed on service node. The `perl-DBD-Pg` package is available on the installation ISO for SLES12 and SLES15