### PR TITLE
xcatws doesn't forward URI parameters with null values to xcatd

### DIFF
--- a/xCAT-server/xCAT-wsapi/xcatws.cgi
+++ b/xCAT-server/xCAT-wsapi/xcatws.cgi
@@ -2093,7 +2093,7 @@ sub defhdl {
             push(@args, "$k=$val") if $val;
             next;
         }
-        push @args, "$k=$paramhash->{$k}" if $paramhash->{$k};
+        push @args, ($paramhash->{$k}) ? "$k=$paramhash->{$k}" : "$k=";
     }
 
     if ($params->{'resourcename'} eq "allnode") {


### PR DESCRIPTION
Let's say i want to zero a cell in a table, e.g. `nodech -t node -o host1 ip=` , which works perfectly fine. However doing the same via xcatws call like `PUT /xcatws/nodes/host1?ip=` does nothing: "No object definitions have been created or modified."

Please review the PR.