### PR TITLE
Move SLES12 Postgres package from pkglist to otherpkglist

### DIFF
--- a/xCAT-server/share/xcat/install/sles/service.sles12.pkglist
+++ b/xCAT-server/share/xcat/install/sles/service.sles12.pkglist
@@ -14,5 +14,4 @@ perl-Net-DNS
 perl-DBD-mysql
 mariadb-client
 libmysqlclient18
-perl-DBD-Pg
 

--- a/xCAT-server/share/xcat/install/sles/service.sles12.ppc64le.otherpkgs.pkglist
+++ b/xCAT-server/share/xcat/install/sles/service.sles12.ppc64le.otherpkgs.pkglist
@@ -1,2 +1,3 @@
 xcat/xcat-core/xCATsn
 xcat/xcat-dep/sles12/ppc64le/goconserver
+xcat/xcat-dep/sles12/ppc64le/perl-DBD-Pg

--- a/xCAT-server/share/xcat/install/sles/service.sles12.x86_64.otherpkgs.pkglist
+++ b/xCAT-server/share/xcat/install/sles/service.sles12.x86_64.otherpkgs.pkglist
@@ -1,2 +1,3 @@
 xcat/xcat-core/xCATsn
 xcat/xcat-dep/sles12/x86_64/goconserver
+xcat/xcat-dep/sles12/x86_64/perl-DBD-Pg

--- a/xCAT-server/share/xcat/netboot/sles/service.sles12.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/service.sles12.pkglist
@@ -63,4 +63,3 @@ unixODBC
 perl-DBD-mysql
 mariadb-client
 libmysqlclient18
-perl-DBD-Pg

--- a/xCAT-server/share/xcat/netboot/sles/service.sles12.ppc64le.otherpkgs.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/service.sles12.ppc64le.otherpkgs.pkglist
@@ -1,2 +1,3 @@
 xcat/xcat-core/xCATsn
 xcat/xcat-dep/sles12/ppc64le/goconserver
+xcat/xcat-dep/sles12/ppc64le/perl-DBD-Pg

--- a/xCAT-server/share/xcat/netboot/sles/service.sles12.x86_64.otherpkgs.pkglist
+++ b/xCAT-server/share/xcat/netboot/sles/service.sles12.x86_64.otherpkgs.pkglist
@@ -1,3 +1,4 @@
 -perl-doc
 xcat/xcat-core/xCATsn
 xcat/xcat-dep/sles12/x86_64/goconserver
+xcat/xcat-dep/sles12/x86_64/perl-DBD-Pg


### PR DESCRIPTION
On SLES15, `perl-DBD-Pg` package is on the installation media, so it can be listed in the `pkglist` file and found during node provisioning. On SLES12, `perl-DBD-Pg` package is not on the installation media, instead it gets shipped in the `xcat-dep`.

This PR removes `perl-DBD-Pg` package from the SLES12 `pkglist` (added by #7360) and places it into SLES12 `otherpkgs.pkglist` so that it is grouped with other `xcat-dep` packages.