### PR TITLE
Remove imgexport command from testcase

### DIFF
--- a/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_flat
+++ b/xCAT-test/autotest/testcase/installation/reg_linux_statelite_installation_flat
@@ -129,8 +129,6 @@ check:output=~No load hostkey warning
 
 cmd:rm -rf /tmp/image;mkdir /tmp/image
 check:rc==0
-cmd:imgexport __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute /tmp/image/image.tgz
-check:rc==0
 cmd:if [ -x /usr/bin/goconserver ]; then makegocons -d $$CN; else makeconservercf -d $$CN; fi
 cmd:rootimgdir=`lsdef -t osimage  __GETNODEATTR($$CN,os)__-__GETNODEATTR($$CN,arch)__-statelite-compute|grep rootimgdir|awk -F'=' '{print $2}'`; if [ -d $rootimgdir.regbak ]; then rm -rf $rootimgdir; mv $rootimgdir.regbak $rootimgdir; fi
 check:rc==0


### PR DESCRIPTION
Release testcase `reg_linux_statelite_installation_flat` on SLES15.4 fails when running `imgexport` command. The VM runs out of disk space.
Looking at the "blame" history, that command was added by #1595 for debugging purposes and appears to not be necessary. Most likely it was forgotten to be removed after debug was done.
This PR removes that command to allow the testcase to succeed.