### PR TITLE
Fix #7370 ospkgs issue

### DIFF
--- a/xCAT/postscripts/ospkgs
+++ b/xCAT/postscripts/ospkgs
@@ -357,6 +357,7 @@ do
                      array_set_element os_path $index $ospkgdir_ok
                      index=$(expr $index + 1)
                  done
+		 continue
             fi # if...elif..fi
          fi  # eq default_pkgdir
       fi    # match rhel*


### PR DESCRIPTION
### The PR is to fix issue _#7370_

### The modification include

A fix in the **ospkgs** postscript that skips an extra increment of index variable by continuing to the next iteration of the loop that initializes the array "os_path" with all the valid repository paths.

In the specific case for RHEL 8/9 like OSes the script enters in a default_pkgdir if statement into another loop to add AppStreaam and BaseOS subdirectories and after each iteration it increases the index variable too, therefore when this loop ends continues until the end of the main loop which adds another increment to the index variable. For that reason, the proposed solution is to skip one of those increments to avoid including a void entry in the array.

Another solution could be not to make a loop for the AppStream and BaseOS subdirectories but to add two lines with the array_set_element and to increase the index once.
I.e.:
- changing this:
```
# for rhels8/9, centos8/9, ol8/9, alma8/9 and rocky8/9 the repodata is in ./BaseOS, ./AppStream, not in ./
for arg in "BaseOS" "AppStream"
do
    ospkgdir_ok="$ospkgdir/$arg"
    array_set_element os_path $index $ospkgdir_ok
    index=$(expr $index + 1)
done
continue
```
- to this:
```
# for rhels8/9, centos8/9, ol8/9, alma8/9 and rocky8/9 the repodata is in ./BaseOS, ./AppStream, not in ./
array_set_element os_path $index "$ospkgdir/AppStream"
index=$(expr $index + 1)
array_set_element os_path $index "$ospkgdir/BaseOS"
```
