### PR TITLE
Add other algorithms for DNS/DHCP (HMAC-SHA512)

### DIFF
--- a/docs/source/advanced/domain_name_resolution/domain_name_resolution.rst
+++ b/docs/source/advanced/domain_name_resolution/domain_name_resolution.rst
@@ -90,6 +90,16 @@ For example: ::
 
 Edit **/etc/resolv.conf** to contain the cluster domain value you set in the site table's **domain**  attribute above, and to point to the same DNS server you will be using for your nodes (if you are using DNS).
 
+By default xCAT uses HMAC-MD5 as the DNS signing algorithm.  It's possible that a different algorithm is required or desired for your installation.  You can set the omapi-algorithm value in the site table to choose a different algorithm. ::
+
+      chdef -t site omapi-algorithm=HMAC-SHA256
+
+If you choose to update the algorithm, you will also need to supply a new secret for the omapi entry in the passwd table. This can be done using the dnssec-keygen command.  For example something like ::
+
+       dnssec-keygen -a HMAC-SHA256 -b 128 -n host xcat_key
+
+This should generate files with the needed key.  This key will need to be entered into the passwd table and the DNS and DHCP files will need to be recreated (makedns, makedhcp) to use the new method.
+
 Option #1: Running DNS on Your Management Node
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -162,6 +172,14 @@ The **domain** and **nameservers** values must be set correctly in **/etc/resolv
     * To update the name resolution entries from ``/etc/hosts`` or hosts table of xCAT MN to external DNS, run ``makedns -e``
 
       Alternatively, you can set site.externaldns=1 and run ``makedns``
+
+It's possible that the external DNS provider will not allow you to choose the key name and they may provide both the key name and the secret to you.  I this case you will need to update the passwd table with the proper key and username.  You will also need to set the site table value for omapi-username to match the username used in the passwd table ::
+
+        chdef -t site omapi-username=mydnsuser
+        tabdump -w key==omapi passwd
+        #key,username,password,cryptmethod,authdomain,comments,disable
+        "omapi","mydnsuser","<my super secret stuff here>",,,,
+
 
 Option #3: Run DNS on Management Node and Service Nodes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/xCAT-server/lib/xcat/plugins/dhcp.pm
+++ b/xCAT-server/lib/xcat/plugins/dhcp.pm
@@ -186,10 +186,24 @@ sub listnode
         }
     }
 
+    # Get path for omshell from site table, if set
+    my $omshellbin="/usr/bin/omshell";
+    my @oms=xCAT::TableUtils->get_site_attribute("omshell");
+    if ($oms[0]){
+        $omshellbin=$oms[0];
+    }
+    # Get HMAC algorithum from site table, if set
+    my $omapialgorithm = "HMAC-MD5";
+    my @omapia=xCAT::TableUtils->get_site_attribute("omapi-algorithm");
+    if ($omapia[0]){
+        $omapialgorithm=$omapia[0];
+    }
+
     # open ipv4 omshell file handles - $OMOUT will contain the response
-    open2($OMOUT, $OMIN, "/usr/bin/omshell ");
+    open2($OMOUT, $OMIN, "$omshellbin ");
 
     # setup omapi for the connection and check for the node requested
+    print $OMIN "key-algorithm $omapialgorithm\n";
     print $OMIN "key "
       . $omapiuser . " \""
       . $omapikey . "\"\n";
@@ -252,9 +266,10 @@ sub listnode
 
     # if using IPv6 addresses check using omshell IPv6 port
     if ($usingipv6) {
-        open2($OMOUT6, $OMIN6, "/usr/bin/omshell ");
+        open2($OMOUT6, $OMIN6, "$omshellbin ");
         print $OMOUT6 "port 7912\n";
         print $OMOUT6 "connect\n";
+        print $OMOUT6 "key-algorithm $omapialgorithm\n";
         print $OMIN6 "key "
           . $omapiuser . " \""
           . $omapikey . "\"\n";
@@ -2029,9 +2044,22 @@ sub process_request
                 return;
             }    # TODO sane err
 
+            # Get path for omshell from site table, if set
+            my $omshellbin="/usr/bin/omshell";
+            my @oms=xCAT::TableUtils->get_site_attribute("omshell");
+            if ($oms[0]){
+                $omshellbin=$oms[0];
+            }
+            # Get HMAC algorithum from site table, if set
+            my $omapialgorithm = "HMAC-MD5";
+            my @omapia=xCAT::TableUtils->get_site_attribute("omapi-algorithm");
+            if ($omapia[0]){
+                $omapialgorithm=$omapia[0];
+            }
+
             #Have nodes to update
-            #open2($omshellout,$omshell,"/usr/bin/omshell");
-            open($omshell, "|/usr/bin/omshell > /dev/null");
+            open($omshell, "|$omshellbin > /dev/null");
+            print $omshell "key-algorithm $omapialgorithm\n";
             print $omshell "key "
               . $ent->{username} . " \""
               . $ent->{password} . "\"\n";
@@ -2040,11 +2068,12 @@ sub process_request
             }
             print $omshell "connect\n";
             if ($usingipv6) {
-                open($omshell6, "|/usr/bin/omshell > /dev/null");
+                open($omshell6, "|$omshellbin > /dev/null");
                 if ($::XCATSITEVALS{externaldhcpservers}) {
                     print $omshell "server $::XCATSITEVALS{externaldhcpservers}\n";
                 }
                 print $omshell6 "port 7912\n";
+                print $omshell6 "key-algorithm $omapialgorithm\n";
                 print $omshell6 "key "
                   . $ent->{username} . " \""
                   . $ent->{password} . "\"\n";
@@ -2366,17 +2395,23 @@ sub addnet6
         $ddnsdomain = $netcfgs{$net}->{ddnsdomain};
     }
     if ($::XCATSITEVALS{dnshandler} =~ /ddns/) {
+	my $omapiuser = "xcat_key";
+	my @omapiu = xCAT::TableUtils->get_site_attribute("omapi-username");
+	if ($omapiu[0]){
+	    $omapiuser = $omapiu[0];
+	}
+
         if ($ddnsdomain) {
             push @netent, "    ddns-domainname \"" . $ddnsdomain . "\";\n";
             push @netent, "    zone $ddnsdomain. {\n";
         } else {
             push @netent, "    zone $netdomain. {\n";
         }
-        push @netent, "       primary $ddnserver; key xcat_key; \n";
+        push @netent, "       primary $ddnserver; key $omapiuser; \n";
         push @netent, "    }\n";
         foreach (getzonesfornet($net)) {
             push @netent, "    zone $_ {\n";
-            push @netent, "       primary $ddnserver; key xcat_key; \n";
+            push @netent, "       primary $ddnserver; key $omapiuser; \n";
             push @netent, "    }\n";
         }
     }
@@ -2693,6 +2728,11 @@ sub addnet
             $ddnsdomain = $netcfgs{$net}->{ddnsdomain};
         }
         if ($::XCATSITEVALS{dnshandler} =~ /ddns/) {
+	    my $omapiuser = "xcat_key";
+	    my @omapiu = xCAT::TableUtils->get_site_attribute("omapi-username");
+	    if ($omapiu[0]){
+		$omapiuser = $omapiu[0];
+	    }
             if ($ddnsdomain) {
                 push @netent, "    ddns-domainname \"" . $ddnsdomain . "\";\n";
                 push @netent, "    zone $ddnsdomain. {\n";
@@ -2701,14 +2741,14 @@ sub addnet
             }
             if ($ddnserver)
             {
-                push @netent, "       primary $ddnserver; key xcat_key; \n";
+                push @netent, "       primary $ddnserver; key $omapiuser; \n";
             }
             push @netent, "    }\n";
             foreach (getzonesfornet($net, $mask)) {
                 push @netent, "    zone $_ {\n";
                 if ($ddnserver)
                 {
-                    push @netent, "       primary $ddnserver; key xcat_key; \n";
+                    push @netent, "       primary $ddnserver; key $omapiuser; \n";
                 }
                 push @netent, "    }\n";
             }
@@ -2953,6 +2993,19 @@ sub writeout
 sub newconfig6 {
     if ($::XCATSITEVALS{externaldhcpservers}) { return; }
 
+    # Get HMAC algorithum from site table, if set
+    my $omapialgorithm = "HMAC-MD5";
+    my @omapia=xCAT::TableUtils->get_site_attribute("omapi-algorithm");
+    if ($omapia[0]){
+        $omapialgorithm=$omapia[0];
+    }
+    my $omapiuser = "xcat_key";
+    my @omapiu = xCAT::TableUtils->get_site_attribute("omapi-username");
+    if ($omapiu[0]){
+        $omapiuser = $omapiu[0];
+    }
+
+
     #phase 1, basic working
     #phase 2, ddns too, evaluate other stuff from dhcpv4 as applicable
     push @dhcp6conf, "#xCAT generated dhcp configuration\n";
@@ -2962,11 +3015,11 @@ sub newconfig6 {
 
     #    push @dhcp6conf, "update-static-leases on;\n";
     push @dhcp6conf, "omapi-port 7912;\n";        #Enable omapi...
-    push @dhcp6conf, "key xcat_key {\n";
-    push @dhcp6conf, "  algorithm hmac-md5;\n";
+    push @dhcp6conf, "key $omapiuser {\n";
+    push @dhcp6conf, "  algorithm $omapialgorithm;\n";
     my $passtab = xCAT::Table->new('passwd', -create => 1);
     (my $passent) =
-      $passtab->getAttribs({ key => 'omapi', username => 'xcat_key' }, 'password');
+      $passtab->getAttribs({ key => 'omapi', username => $omapiuser }, 'password');
     my $secret = encode_base64(genpassword(32));    #Random from set of  62^32
     chomp $secret;
     if ($passent->{password}) { $secret = $passent->{password}; }
@@ -2979,12 +3032,12 @@ sub newconfig6 {
             }
         );
         $passtab->setAttribs({ key => 'omapi' },
-            { username => 'xcat_key', password => $secret });
+            { username => $omapiuser, password => $secret });
     }
 
     push @dhcp6conf, "  secret \"" . $secret . "\";\n";
     push @dhcp6conf, "};\n";
-    push @dhcp6conf, "omapi-key xcat_key;\n";
+    push @dhcp6conf, "omapi-key $omapiuser;\n";
 
     #that is all for pristine ipv6 config
 }
@@ -2993,6 +3046,18 @@ sub newconfig
 {
     if ($::XCATSITEVALS{externaldhcpservers}) { return; }
     return newconfig_aix() if ($^O eq 'aix');
+
+    # Get HMAC algorithum from site table, if set
+    my $omapialgorithm = "HMAC-MD5";
+    my @omapia=xCAT::TableUtils->get_site_attribute("omapi-algorithm");
+    if ($omapia[0]){
+        $omapialgorithm=$omapia[0];
+    }
+    my $omapiuser = "xcat_key";
+    my @omapiu = xCAT::TableUtils->get_site_attribute("omapi-username");
+    if ($omapiu[0]){
+        $omapiuser = $omapiu[0];
+    }
 
     # This function puts a standard header in and enough to make omapi work.
     my $passtab = xCAT::Table->new('passwd', -create => 1);
@@ -3025,10 +3090,10 @@ sub newconfig
     push @dhcpconf, "option cumulus-provision-url code 239 = text;\n";
     push @dhcpconf, "\n";
     push @dhcpconf, "omapi-port 7911;\n";            #Enable omapi...
-    push @dhcpconf, "key xcat_key {\n";
-    push @dhcpconf, "  algorithm hmac-md5;\n";
+    push @dhcpconf, "key $omapiuser {\n";
+    push @dhcpconf, "  algorithm $omapialgorithm;\n";
     (my $passent) =
-      $passtab->getAttribs({ key => 'omapi', username => 'xcat_key' }, 'password');
+      $passtab->getAttribs({ key => 'omapi', username => $omapiuser }, 'password');
     my $secret = encode_base64(genpassword(32));     #Random from set of  62^32
     chomp $secret;
     if ($passent->{password}) { $secret = $passent->{password}; }
@@ -3041,12 +3106,12 @@ sub newconfig
             }
         );
         $passtab->setAttribs({ key => 'omapi' },
-            { username => 'xcat_key', password => $secret });
+            { username => $omapiuser, password => $secret });
     }
 
     push @dhcpconf, "  secret \"" . $secret . "\";\n";
     push @dhcpconf, "};\n";
-    push @dhcpconf, "omapi-key xcat_key;\n";
+    push @dhcpconf, "omapi-key $omapiuser;\n";
     push @dhcpconf, ('class "pxe" {' . "\n", "   match if substring (option vendor-class-identifier, 0, 9) = \"PXEClient\";\n", "   ddns-updates off;\n", "    max-lease-time 600;\n", "}\n");
 }
 


### PR DESCRIPTION
### The PR is to fix issue _#7173

### The modification include

### Change ddns.pm to allow for other signing algorithms and key names

Without changes to the site table, this should default to working as expected in the past.  The default is still HMAC-MD5

### Change dhcp.pm to allow for other signing algorithms and key names

Without changes to the site table, this should default to the past functionality.  

### Summary of changes

In both cases an optional site table parameter (omapi-algorithm)  is used to specify the signing algorithm for ddns and dhcp communication with the DNS server.  It adds support for HMAC-SHA1, HMAC-SHA256, HMAC-SHA384 and HMAC-SHA512 as possible signing options for DNS communications.  While additional options may also be possible the code expects the above options, otherwise HMAC-MD5 is used.

It also allows the site table parameter (omapi-username) to choose a different username for the DNS communication.  In some cases the DNS provider may require you to use the key name and secret they provide rather than allowing the use of the key name and secret provided by xCAT.

I have no specific unit tests for this change.  I've build/installed RPMs based on this change with no impacts to existing test installation.  I've successfully added the omapi-algorithm and omapi-username information to the site table and have updated the passwd table to reflect the username and secret.  It seems to build local DNS configurations and also allow for externaldns=1 and allow to point at an external DNS provider when the external provider uses the appropriate key and username.

### The UT result
No specific unit tests written for this change
`##The UT output##`
