### PR TITLE
Fix MTM detection for incomplete FRU pages

### DIFF
--- a/xCAT-genesis-scripts/usr/bin/dodiscovery
+++ b/xCAT-genesis-scripts/usr/bin/dodiscovery
@@ -94,7 +94,7 @@ if [ -r /sys/devices/virtual/dmi/id/product_name ]; then  #x86
 		if [ -z "$MTM" ]; then
 			FRU=`ipmitool fru print 0`
 			if [ $? -eq 0 ]; then
-                                MTM=`echo "$FRU" | awk -F': ' '/Product Manufacturer/ {m=$2} /Product Name|Product Part Number/ {if (n==""||n=="NONE") {n=$2}} END {print m":"n}'`
+				MTM=`echo "$FRU" | awk -F': ' '/Product Manufacturer/ {m=$2} /Product Name|Product Part Number/ {if (n==""||n=="NONE") {n=$2}} END {print m":"n}'`
 			fi
 			if [ -z "$MTM" -o "$MTM" == ":" ]; then
 				logger -s -t $log_label -p local4.warning "Couldn't find MTM information in FRU, falling back to DMI (MTMS-based discovery may fail)"
@@ -267,7 +267,7 @@ for dev in `ip link|grep -B1 ether|grep UP|awk '{print $2}'|sed -e s/://|grep -v
         if [[ ! -z "$myport" && ! "$myport" =~ "Agent instance for device not found" ]]; then
         	echo "	<switchport>$myport</switchport>" >> /tmp/discopacket
         fi
-        	
+
         echo "</nic>" >> /tmp/discopacket
 done
 if [ "$UUID" == "unknown" ]; then

--- a/xCAT-genesis-scripts/usr/bin/dodiscovery
+++ b/xCAT-genesis-scripts/usr/bin/dodiscovery
@@ -94,7 +94,7 @@ if [ -r /sys/devices/virtual/dmi/id/product_name ]; then  #x86
 		if [ -z "$MTM" ]; then
 			FRU=`ipmitool fru print 0`
 			if [ $? -eq 0 ]; then
-				MTM=`echo "$FRU" | awk -F': ' '/Product Manufacturer/ {m=$2} /Product Name|Product Part Number/ {if (n==""||n~/ +/||n=="NONE") {n=$2}} END {print m":"n}'`
+				MTM=`echo "$FRU" | awk -F': ' '/Product Manufacturer/ {m=$2} /Product Name|Product Part Number/ {if (n==""||n~/\s+/||n=="NONE") {n=$2}} END {print m":"n}'`
 			fi
 			if [ -z "$MTM" -o "$MTM" == ":" ]; then
 				logger -s -t $log_label -p local4.warning "Couldn't find MTM information in FRU, falling back to DMI (MTMS-based discovery may fail)"

--- a/xCAT-genesis-scripts/usr/bin/dodiscovery
+++ b/xCAT-genesis-scripts/usr/bin/dodiscovery
@@ -94,7 +94,7 @@ if [ -r /sys/devices/virtual/dmi/id/product_name ]; then  #x86
 		if [ -z "$MTM" ]; then
 			FRU=`ipmitool fru print 0`
 			if [ $? -eq 0 ]; then
-				MTM=`echo "$FRU" | awk -F': ' '/Product Manufacturer/ {m=$2} /Product Name|Product Part Number/ {if (n==""||n=="NONE") {n=$2}} END {print m":"n}'`
+				MTM=`echo "$FRU" | awk -F': ' '/Product Manufacturer/ {m=$2} /Product Name|Product Part Number/ {if (n==""||n~/ +/||n=="NONE") {n=$2}} END {print m":"n}'`
 			fi
 			if [ -z "$MTM" -o "$MTM" == ":" ]; then
 				logger -s -t $log_label -p local4.warning "Couldn't find MTM information in FRU, falling back to DMI (MTMS-based discovery may fail)"


### PR DESCRIPTION
### The PR is to fix issue _#7397_

When FRU pages include empty fields (more precisely blank fields that are just spaces), the FRU parsing in `dodiscovery` returns blank values. 

This PR makes sure that blank fields containing only spaces are ignored, so the correct field can be returned.

For instance, with the following FRU page:
```
# ipmitool fru print 0
 Chassis Type          : Other
 Chassis Part Number   : CSE-228GTS-R2K21P
 Chassis Serial        : [redacted]
 Board Mfg Date        : Sun Apr 23 04:33:00 2023 PDT
 Board Mfg             : Supermicro
 Board Product         : H12DSG-Q-CPU6
 Board Serial          : [redacted]
 Board Part Number     : H12DSG-Q-CPU6
 Product Manufacturer  : Supermicro
 Product Name          :
 Product Part Number   : AS -2124GQ-NART
 Product Version       :
 Product Serial        : [redacted]
 Product Asset Tag     :
 ```
 the original `dodiscovery` script returns
 ```
# ipmitool fru print 0 | awk -F': ' '/Product Manufacturer/ {m=$2} /Product Name|Product Part Number/ {if (n==""||n=="NONE") {n=$2}} END {print m":"n}'
Supermicro:
```
 
And with the fix:
 ```
# ipmitool fru print 0 | awk -F': ' '/Product Manufacturer/ {m=$2} /Product Name|Product Part Number/ {if (n==""||n~/ +/||n=="NONE") {n=$2}} END {print m":"n}'
Supermicro:AS -2124GQ-NART
 ```