### PR TITLE
Automatically add biosboot partition on >2TB drives with RHEL 7/8

### DIFF
--- a/xCAT-server/share/xcat/install/scripts/pre.rh.rhels7
+++ b/xCAT-server/share/xcat/install/scripts/pre.rh.rhels7
@@ -245,6 +245,9 @@ echo "ignoredisk --only-use=$instdisk" >> /tmp/partitionfile
 if [ `uname -m` = "ppc64" -o `uname -m` = "ppc64le" ]; then
 	echo 'part None --fstype "PPC PReP Boot" --ondisk '$instdisk' --size 8' >> /tmp/partitionfile
 fi
+if [ `blockdev --getsz $instdisk` -gt 4294967295 ]; then
+    echo 'part biosboot --size 1 --ondisk '$instdisk >> /tmp/partitionfile
+fi
 if [ -d /sys/firmware/efi ]; then
     echo 'part /boot/efi --size 50 --ondisk '$instdisk' --fstype '$EFIFSTYPE >> /tmp/partitionfile
 fi

--- a/xCAT-server/share/xcat/install/scripts/pre.rhels8
+++ b/xCAT-server/share/xcat/install/scripts/pre.rhels8
@@ -264,6 +264,9 @@ case "$(uname -m)" in
     echo "part prepboot --fstype=prepboot --asprimary --ondisk=$instdisk --size=8" >>/tmp/partitionfile
     ;;
 esac
+if [ `blockdev --getsz $instdisk` -gt 4294967295 ]; then
+    echo "part biosboot --ondisk=$instdisk --size=1" >> /tmp/partitionfile
+fi
 if [ -d /sys/firmware/efi ]
 then
     echo "part /boot/efi --fstype=$EFIFSTYPE --ondisk=$instdisk --size=256" >>/tmp/partitionfile


### PR DESCRIPTION
### The PR is to fix issue
An error message "Your BIOS-based system needs a special partition to boot from a GPT disk label. To continue, please create a 1MiB 'biosboot' type partition. " is displayed on rinstall console and the Anaconda installation fails on >2TB drives, for which disklabel is automatically switched from msdos to gpt.

### The modification include
Two pre-install scripts:
share/xcat/install/scripts/pre.rh.rhels7
share/xcat/install/scripts/pre.rhels8

### The UT result
`##The UT output##`

### The content of the PR:
A similar 3-line code snippet is added to both scripts. It checks the $instdisk size using `blockdev --getsz' command and if it exceeds 2TB a one-megabyte biosboot partition is added to the partitionfile.
Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1032428

### The UT result
`##The UT output##`
