### PR TITLE
delete extraneous files from dest dirs in updatenode -F/syncfiles

### DIFF
--- a/perl-xCAT/xCAT/RSYNC.pm
+++ b/perl-xCAT/xCAT/RSYNC.pm
@@ -133,9 +133,9 @@ sub remote_copy_command
         # (no postscripts and no append lines)  then do not
         # get update file notification
         if (($::SYNCSN == 1) || ((!(@::postscripts)) && (!(@::appendlines)) && (!(@::mergelines)))) {
-            $sync_opt .= '-Lprogtz ';
+            $sync_opt .= '-Lprogtz -del ';
         } else {
-            $sync_opt .= '-Liprogtz --out-format=%f%L ';  # add notify of update
+            $sync_opt .= '-Liprogtz -del --out-format=%f%L ';  # add notify of update
         }
         $sync_opt .= $$config{'options'};
         if ($::SYNCSN == 1)


### PR DESCRIPTION
### The PR is to fix issue _#7408_

Add the `--del` option to `rsync` commands used in synchronizing directories between MN an SNs/CNs, to make sure no extraneous file remains in the destination directories.