### PR TITLE
Fix dracut warnings during genimage on newer OSs

### DIFF
--- a/xCAT-server/share/xcat/netboot/rh/genimage
+++ b/xCAT-server/share/xcat/netboot/rh/genimage
@@ -1178,8 +1178,10 @@ sub mkinitrd_dracut {
 
 
     print "\nchroot $rootimg_dir dracut $additional_options -f /tmp/initrd.$$.gz $kernelver\n";
+    mount_chroot($rootimg_dir);
     !system("chroot $rootimg_dir dracut $additional_options -f /tmp/initrd.$$.gz $kernelver")
-      or die("Error: failed to generate the initial ramdisk for $mode.\n");
+      or xdie("Error: failed to generate the initial ramdisk for $mode.\n");
+    umount_chroot($rootimg_dir);
     print "the initial ramdisk for $mode is generated successfully.\n";
     move("$rootimg_dir/tmp/initrd.$$.gz", "$destdir/initrd-$mode.gz");
 }


### PR DESCRIPTION
Fixes the following errors when building stateless EL 9 images.
```
/bin/dracut: line 1054: /sys/module/firmware_class/parameters/path: No such file or directory
findmnt: can't read /proc/mounts: No such file or directory
/usr/lib/dracut/modules.d/00systemd/module-setup.sh: line 168: /dev/fd/63: No such file or directory
/proc/ is not mounted. This is not a supported mode of operation. Please fix
your invocation environment to mount /proc/ and /sys/ properly. Proceeding anyway.
```