### PR TITLE
Various GitHub Action xcat_test fixes

### DIFF
--- a/.github/workflows/xcat_test.yml
+++ b/.github/workflows/xcat_test.yml
@@ -6,5 +6,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
-      - run: sudo apt-get install -y fakeroot reprepro devscripts debhelper libcapture-tiny-perl libjson-perl libsoap-lite-perl libdbi-perl libcgi-pm-perl quilt openssh-server dpkg looptools genometools software-properties-common
-      - run: perl github_action_xcat_test.pl
+      - name: Install dependencies
+        run: sudo apt-get install -y fakeroot reprepro devscripts debhelper libcapture-tiny-perl libjson-perl libsoap-lite-perl libdbi-perl libcgi-pm-perl quilt openssh-server dpkg looptools genometools software-properties-common
+      - name: Run tests
+        run: perl github_action_xcat_test.pl

--- a/.github/workflows/xcat_test.yml
+++ b/.github/workflows/xcat_test.yml
@@ -3,6 +3,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
   xcat_pr_test:
     runs-on: ubuntu-20.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - run: sudo apt-get install -y fakeroot reprepro devscripts debhelper libcapture-tiny-perl libjson-perl libsoap-lite-perl libdbi-perl libcgi-pm-perl quilt openssh-server dpkg looptools genometools software-properties-common

--- a/.github/workflows/xcat_test.yml
+++ b/.github/workflows/xcat_test.yml
@@ -4,6 +4,6 @@ jobs:
   xcat_pr_test:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: sudo apt-get install -y fakeroot reprepro devscripts debhelper libcapture-tiny-perl libjson-perl libsoap-lite-perl libdbi-perl libcgi-pm-perl quilt openssh-server dpkg looptools genometools software-properties-common
       - run: perl github_action_xcat_test.pl

--- a/xCAT-test/autotest/testcase/makedhcp/cases0
+++ b/xCAT-test/autotest/testcase/makedhcp/cases0
@@ -34,7 +34,7 @@ end
 
 start:makedhcp_n_linux
 description:Create a new dhcp configuration file with a network statement for each network the dhcp daemon should listen on
-label:others,ci_test
+label:others
 os:Linux
 cmd:if [ -f "/etc/dhcp/dhcpd.conf" ];then cp -f /etc/dhcp/dhcpd.conf /etc/dhcp/dhcpd.conf.bak ; elif [ -f "/etc/dhcpd.conf" ]; then cp -f /etc/dhcpd.conf /etc/dhcpd.conf.bak; fi
 cmd:makedhcp -n


### PR DESCRIPTION
- Upgrade to `actions/checkout@v4` to fix the following GitHub warning: 
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
- Add a 60 minute timeout. Let's not waste resources if our CI job has issues
- Remove duplicate makedhcp_n_linux test case
- Add step names