### PR TITLE
Do not use copytruncate for xcat log rotation

### DIFF
--- a/xCAT/etc/logrotate.d/xcat
+++ b/xCAT/etc/logrotate.d/xcat
@@ -6,5 +6,6 @@
         test -f /var/run/rsyslogd.pid && kill -HUP `cat /var/run/rsyslogd.pid 2> /dev/null` 2> /dev/null || true
         test -f /var/run/syslogd.pid && kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
         test -f /var/run/xcat/cmdlogservice.pid && kill -HUP `cat /var/run/xcat/cmdlogservice.pid 2> /dev/null` 2> /dev/null || true
+        test -x /usr/lib/rsyslog/rsyslog-rotate && /usr/lib/rsyslog/rsyslog-rotate || true
     endscript
 }

--- a/xCAT/etc/logrotate.d/xcat
+++ b/xCAT/etc/logrotate.d/xcat
@@ -1,7 +1,6 @@
 /var/log/xcat/*.log {
     missingok
     sharedscripts
-    copytruncate
     delaycompress
     postrotate
         test -f /var/run/rsyslogd.pid && kill -HUP `cat /var/run/rsyslogd.pid 2> /dev/null` 2> /dev/null || true


### PR DESCRIPTION
PR https://github.com/xcat2/xcat-core/pull/6510 tried to fix missing logs for goconserver, but also added copytruncate to all xcat logs in `/var/log/xcat*.log`. This is not needed because these logs are written by rsyslog and xcat itself, not goconserver.

The main rsyslog developer does not recommend to use copytruncate for rsyslog: https://serverfault.com/a/901366

For HA setups with logs on NFS etc. copytruncate can be very slow. A simple move/rename is way faster and cleaner.

I'm keeping `delaycompress` because I think it's nice to have some more days/weeks of logs uncompressed. Furthermore, some users might be used to it already.