### PR TITLE
nodeset testcase: Allow dash in hostnames

### DIFF
--- a/xCAT-test/autotest/testcase/nodeset/cases0
+++ b/xCAT-test/autotest/testcase/nodeset/cases0
@@ -6,7 +6,7 @@ check:rc==0
 check:output=~$$CN:\s+[discover|boot|reboot|install|netboot|shell|standby]
 cmd:nodeset $$CN stat -V
 check:rc==0
-check:output=~$$CN:\s+\[\w+\]:\s+[discover|boot|reboot|install|netboot|shell|standby]
+check:output=~$$CN:\s+\[[a-zA-Z0-9\-]+\]:\s+[discover|boot|reboot|install|netboot|shell|standby]
 end
 
 start:nodeset_noderange


### PR DESCRIPTION
Before:

```
------START::nodeset_stat::Time:Sun Apr 14 17:09:00 2024------

RUN:nodeset xcat01-cn stat [Sun Apr 14 17:09:00 2024]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
xcat01-cn: netboot alma8.6-x86_64-compute
CHECK:rc == 0	[Pass]
CHECK:output =~ xcat01-cn:\s+[discover|boot|reboot|install|netboot|shell|standby]	[Pass]
 
RUN:nodeset xcat01-cn stat -V [Sun Apr 14 17:09:00 2024]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
xcat01-cn: [xcat01-mn]: netboot alma8.6-x86_64-compute
CHECK:rc == 0	[Pass]
CHECK:output =~ xcat01-cn:\s+\[\w+\]:\s+[discover|boot|reboot|install|netboot|shell|standby]	[Failed]
 
------END::nodeset_stat::Failed::Time:Sun Apr 14 17:09:00 2024 ::Duration::0 sec------
------Total: 1 , Failed: 1------
```

After:

```
------START::nodeset_stat::Time:Sun Apr 14 17:17:09 2024------

RUN:nodeset xcat01-cn stat [Sun Apr 14 17:17:09 2024]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
xcat01-cn: netboot alma8.6-x86_64-compute
CHECK:rc == 0	[Pass]
CHECK:output =~ xcat01-cn:\s+[discover|boot|reboot|install|netboot|shell|standby]	[Pass]
 
RUN:nodeset xcat01-cn stat -V [Sun Apr 14 17:17:09 2024]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
xcat01-cn: [xcat01-mn]: netboot alma8.6-x86_64-compute
CHECK:rc == 0	[Pass]
CHECK:output =~ xcat01-cn:\s+\[[a-zA-Z0-9\-]+\]:\s+[discover|boot|reboot|install|netboot|shell|standby]	[Pass]
 
------END::nodeset_stat::Passed::Time:Sun Apr 14 17:17:09 2024 ::Duration::0 sec------
```