### PR TITLE
Do not rely on GPG key id

### DIFF
--- a/build-ubunturepo
+++ b/build-ubunturepo
@@ -373,7 +373,8 @@ __EOF__
            #echo "GPGSIGN=$GPGSIGN specified, the repo will not be signed"
            echo "" >> conf/distributions
        else
-           echo "SignWith: 5619700D" >> conf/distributions
+           keyid=$(gpg --list-keys --keyid-format long "xCAT Automatic Signing Key" | grep '^pub' | sed -e 's/.*\///' -e 's/ .*//')
+           echo "SignWith: $keyid" >> conf/distributions
            echo "" >> conf/distributions
        fi
     done
@@ -514,7 +515,8 @@ __EOF__
             echo "GPGSIGN=$GPGSIGN specified, the repo will not be signed"
             echo "" >> conf/distributions
         else
-            echo "SignWith: 5619700D" >> conf/distributions
+            keyid=$(gpg --list-keys --keyid-format long "xCAT Automatic Signing Key" | grep '^pub' | sed -e 's/.*\///' -e 's/ .*//')
+            echo "SignWith: $keyid" >> conf/distributions
             echo "" >> conf/distributions
         fi
 

--- a/buildcore.sh
+++ b/buildcore.sh
@@ -479,13 +479,13 @@ if [ "$OSNAME" != "AIX" ]; then
         rm -f $SRCDIR/repodata/repomd.xml.asc
         rm -f $DESTDIR/repodata/repomd.xml.asc
         # Use the xCAT Automatic Signing Key to do the signing
-        gpg -a --detach-sign --default-key 5619700D $DESTDIR/repodata/repomd.xml
-        gpg -a --detach-sign --default-key 5619700D $SRCDIR/repodata/repomd.xml
+        gpg -a --detach-sign --default-key "xCAT Automatic Signing Key" $DESTDIR/repodata/repomd.xml
+        gpg -a --detach-sign --default-key "xCAT Automatic Signing Key" $SRCDIR/repodata/repomd.xml
         if [ ! -f $DESTDIR/repodata/repomd.xml.key ]; then
-            ${WGET_CMD} --no-check-certificate -q -P $DESTDIR/repodata $GSA/keys/repomd.xml.key
+            gpg -a --export "xCAT Automatic Signing Key" > $DESTDIR/repodata/repomd.xml.key
         fi
         if [ ! -f $SRCDIR/repodata/repomd.xml.key ]; then
-            ${WGET_CMD} --no-check-certificate -P $SRCDIR/repodata $GSA/keys/repomd.xml.key
+            gpg -a --export "xCAT Automatic Signing Key" > $SRCDIR/repodata/repomd.xml.key
         fi
     else
         createrepo $DESTDIR

--- a/builddep.sh
+++ b/builddep.sh
@@ -265,9 +265,9 @@ for i in `find -mindepth 2 -maxdepth 2 -type d `; do
 		createrepo $i >/dev/null
 	fi
 	rm -f $i/repodata/repomd.xml.asc
-	gpg -a --detach-sign --default-key 5619700D $i/repodata/repomd.xml
+	gpg -a --detach-sign --default-key "xCAT Automatic Signing Key" $i/repodata/repomd.xml
 	if [ ! -f $i/repodata/repomd.xml.key ]; then
-		cp $GSA/../keys/repomd.xml.key $i/repodata
+		gpg -a --export "xCAT Automatic Signing Key" > $i/repodata/repomd.xml.key
 	fi
 done
 

--- a/xCAT-server/share/xcat/install/rh/service.rhels9.pkglist
+++ b/xCAT-server/share/xcat/install/rh/service.rhels9.pkglist
@@ -14,3 +14,4 @@ python3
 tar
 bzip2
 perl-interpreter
+perl-lib

--- a/xCAT-server/share/xcat/install/rh/service.rhels9.ppc64le.otherpkgs.pkglist
+++ b/xCAT-server/share/xcat/install/rh/service.rhels9.ppc64le.otherpkgs.pkglist
@@ -1,2 +1,2 @@
 xcat/xcat-core/xCATsn
-xcat/xcat-dep/rh8/ppc64le/goconserver
+xcat/xcat-dep/rh9/ppc64le/goconserver

--- a/xCAT-server/share/xcat/install/rh/service.rhels9.x86_64.otherpkgs.pkglist
+++ b/xCAT-server/share/xcat/install/rh/service.rhels9.x86_64.otherpkgs.pkglist
@@ -1,2 +1,2 @@
 xcat/xcat-core/xCATsn
-xcat/xcat-dep/rh8/x86_64/goconserver
+xcat/xcat-dep/rh9/x86_64/goconserver

--- a/xCAT-server/share/xcat/netboot/rh/service.rhels9.ppc64le.otherpkgs.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/service.rhels9.ppc64le.otherpkgs.pkglist
@@ -1,2 +1,2 @@
 xcat/xcat-core/xCATsn
-xcat/xcat-dep/rh8/ppc64le/goconserver
+xcat/xcat-dep/rh9/ppc64le/goconserver

--- a/xCAT-server/share/xcat/netboot/rh/service.rhels9.x86_64.otherpkgs.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/service.rhels9.x86_64.otherpkgs.pkglist
@@ -1,2 +1,2 @@
 xcat/xcat-core/xCATsn
-xcat/xcat-dep/rh8/x86_64/goconserver
+xcat/xcat-dep/rh9/x86_64/goconserver

--- a/xCAT-server/share/xcat/netboot/rh/service.rhels9.x86_64.pkglist
+++ b/xCAT-server/share/xcat/netboot/rh/service.rhels9.x86_64.pkglist
@@ -10,6 +10,7 @@ util-linux
 wget
 perl-DBD-MySQL
 perl-DBD-Pg
+perl-lib
 python3
 tar
 bzip2


### PR DESCRIPTION
- use the key name if possible
- instead of downloading repomd.xml.key, create it on the fly

@gurevichmark please check if this works for your environment, too.