### PR TITLE
Use 'nmcli con modify' for nicextraparams on RHEL9

### DIFF
--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -68,21 +68,21 @@ function configipv4(){
             if [ "$str_nic_mtu" != "$str_default_token" ]; then
                 echo "MTU=${str_nic_mtu}" >> $str_conf_file
             fi
-	    #add extra params
-	    i=0
-	    while [ $i -lt ${#array_extra_param_names[@]} ]
-	    do
-	        name="${array_extra_param_names[$i]}"
-		value="${array_extra_param_values[$i]}"
-                echo "  $i: name=$name value=$value"
-                grep -i "${name}" $str_conf_file
-                if [ $? -eq 0 ];then
-                    sed -i "s/.*${name}.*/${name}=${value}/i" $str_conf_file
-                else
-		    echo "${name}=${value}" >> $str_conf_file
-                fi
-        	i=$((i+1))
-	    done		
+            #add extra params
+            i=0
+            while [ $i -lt ${#array_extra_param_names[@]} ]
+            do
+                name="${array_extra_param_names[$i]}"
+            value="${array_extra_param_values[$i]}"
+                    echo "  $i: name=$name value=$value"
+                    grep -i "${name}" $str_conf_file
+                    if [ $? -eq 0 ];then
+                        sed -i "s/.*${name}.*/${name}=${value}/i" $str_conf_file
+                    else
+                echo "${name}=${value}" >> $str_conf_file
+                    fi
+                i=$((i+1))
+            done		
         else
             echo "IPADDR_${num_v4num}=${str_v4ip}" >> $str_conf_file
             echo "NETMASK_${num_v4num}=${str_v4mask}" >> $str_conf_file
@@ -91,21 +91,21 @@ function configipv4(){
             if [ "$str_nic_mtu" != "$str_default_token" ]; then
                 echo "MTU_${num_v4num}=${str_nic_mtu}" >> $str_conf_file
             fi
-	    #add extra params
-	    i=0
-	    while [ $i -lt ${#array_extra_param_names[@]} ]
-	    do
-	        name="${array_extra_param_names[$i]}"
-		value="${array_extra_param_values[$i]}"
-                echo "  $i: name=$name value=$value"
-                grep -i "${name}" $str_conf_file
-                if [ $? -eq 0 ];then
-                    sed -i "s/.*${name}.*/${name}=${value}/i" $str_conf_file
-                else
-                    echo "${name}=${value}" >> $str_conf_file
-                fi
-		i=$((i+1))
-	    done		
+            #add extra params
+            i=0
+            while [ $i -lt ${#array_extra_param_names[@]} ]
+            do
+                name="${array_extra_param_names[$i]}"
+            value="${array_extra_param_values[$i]}"
+                    echo "  $i: name=$name value=$value"
+                    grep -i "${name}" $str_conf_file
+                    if [ $? -eq 0 ];then
+                        sed -i "s/.*${name}.*/${name}=${value}/i" $str_conf_file
+                    else
+                        echo "${name}=${value}" >> $str_conf_file
+                    fi
+            i=$((i+1))
+            done		
         fi
 
         if [[ ${str_if_name} == [a-zA-Z0-9]*.[0-9]* ]]; then
@@ -127,21 +127,21 @@ function configipv4(){
         if [ "$str_nic_mtu" != "$str_default_token" ]; then
             echo "  mtu ${str_nic_mtu}" >> $str_conf_file
         fi
-	#add extra params
-	i=0
-	while [ $i -lt ${#array_extra_param_names[@]} ]
-	do
-	    name="${array_extra_param_names[$i]}"
-	    value="${array_extra_param_values[$i]}"
-            echo "  $i: name=$name value=$value"
-            grep -i "${name}" $str_conf_file
-            if [ $? -eq 0 ];then
-                sed -i "s/.*${name}.*/${name} ${value}/i" $str_conf_file
-            else
-                echo "${name} ${value}" >> $str_conf_file
-            fi
-	    i=$((i+1))
-	done		
+        #add extra params
+        i=0
+        while [ $i -lt ${#array_extra_param_names[@]} ]
+        do
+            name="${array_extra_param_names[$i]}"
+            value="${array_extra_param_values[$i]}"
+                echo "  $i: name=$name value=$value"
+                grep -i "${name}" $str_conf_file
+                if [ $? -eq 0 ];then
+                    sed -i "s/.*${name}.*/${name} ${value}/i" $str_conf_file
+                else
+                    echo "${name} ${value}" >> $str_conf_file
+                fi
+            i=$((i+1))
+        done		
         if [[ ${str_if_name} == [a-zA-Z0-9]*.[0-9]* ]]; then
             parent_device=`echo ${str_if_name} | sed -e 's/\([a-zA-Z0-9]*\)\.[0-9]*/\1/g'`
             echo "  vlan-raw-device ${parent_device}" >> $str_conf_file
@@ -213,11 +213,15 @@ function configipv4(){
         do
             name="${array_extra_param_names[$i]}"
             value="${array_extra_param_values[$i]}"
-            grep -i "${name}" $str_conf_file
-            if [ $? -eq 0 ];then
-                sed -i "s/.*${name}.*/${name}=${value}/i" $str_conf_file
+            if [[ "$OSVER" =~ rhels9 ]]; then
+                nmcli con modify $con_name $name $value
             else
-                echo "${name}=${value}" >> $str_conf_file
+                grep -i "${name}" $str_conf_file
+                if [ $? -eq 0 ];then
+                    sed -i "s/.*${name}.*/${name}=${value}/i" $str_conf_file
+                else
+                    echo "${name}=${value}" >> $str_conf_file
+                fi
             fi
     	    i=$((i+1))
         done
@@ -264,20 +268,20 @@ configipv6(){
         fi
 
         #add extra params
-	i=0
-	while [ $i -lt ${#array_extra_param_names[@]} ]
-	do
-	    name="${array_extra_param_names[$i]}"
-	    value="${array_extra_param_values[$i]}"
-            echo "  $i: name=$name value=$value"
-            grep -i "${name}" $str_conf_file
-            if [ $? -eq 0 ];then
-                sed -i "s/.*${name}.*/${name}=${value}/i" $str_conf_file
-            else
-                echo "${name}=${value}" >> $str_conf_file
-            fi
-	    i=$((i+1))
-	done		
+        i=0
+        while [ $i -lt ${#array_extra_param_names[@]} ]
+        do
+            name="${array_extra_param_names[$i]}"
+            value="${array_extra_param_values[$i]}"
+                echo "  $i: name=$name value=$value"
+                grep -i "${name}" $str_conf_file
+                if [ $? -eq 0 ];then
+                    sed -i "s/.*${name}.*/${name}=${value}/i" $str_conf_file
+                else
+                    echo "${name}=${value}" >> $str_conf_file
+                fi
+            i=$((i+1))
+        done		
     elif [ "$str_os_type" = "debian" ];then
         #debian or ubuntu
         str_conf_file="/etc/network/interfaces.d/${str_if_name}"
@@ -294,20 +298,20 @@ configipv6(){
             fi
 
             #add extra params
-	    i=0
-	    while [ $i -lt ${#array_extra_param_names[@]} ]
-	    do
-	        name="${array_extra_param_names[$i]}"
-		value="${array_extra_param_values[$i]}"
-		echo "  $i: name=$name value=$value"
-                grep -i "${name}" $str_conf_file
-                if [ $? -eq 0 ];then
-                    sed -i "s/.*${name}.*/${name} ${value}/i" $str_conf_file
-                else
-                    echo "${name} ${value}" >> $str_conf_file
-                fi
-	        i=$((i+1))
-	    done		
+            i=0
+            while [ $i -lt ${#array_extra_param_names[@]} ]
+            do
+                name="${array_extra_param_names[$i]}"
+            value="${array_extra_param_values[$i]}"
+            echo "  $i: name=$name value=$value"
+                    grep -i "${name}" $str_conf_file
+                    if [ $? -eq 0 ];then
+                        sed -i "s/.*${name}.*/${name} ${value}/i" $str_conf_file
+                    else
+                        echo "${name} ${value}" >> $str_conf_file
+                    fi
+                i=$((i+1))
+            done		
         else
             echo "  post-up /sbin/ifconfig ${str_if_name} inet6 add ${str_v6ip}/${str_v6prefix}" >> $str_conf_file
             echo "  pre-down /sbin/ifconfig ${str_if_name} inet6 del ${str_v6ip}/${str_v6prefix}" >> $str_conf_file
@@ -332,20 +336,20 @@ configipv6(){
         fi
 
         #add extra params
-	i=0
-	while [ $i -lt ${#array_extra_param_names[@]} ]
-	do
-	    name="${array_extra_param_names[$i]}"
-	    value="${array_extra_param_values[$i]}"
-            echo "  $i: name=$name value=$value"
-            grep -i "${name}" $str_conf_file
-            if [ $? -eq 0 ];then
-                sed -i "s/.*${name}.*/${name}=${value}/i" $str_conf_file
-            else
-                echo "${name}=${value}" >> $str_conf_file
-            fi
-	    i=$((i+1))
-	done		
+        i=0
+        while [ $i -lt ${#array_extra_param_names[@]} ]
+        do
+            name="${array_extra_param_names[$i]}"
+            value="${array_extra_param_values[$i]}"
+                echo "  $i: name=$name value=$value"
+                grep -i "${name}" $str_conf_file
+                if [ $? -eq 0 ];then
+                    sed -i "s/.*${name}.*/${name}=${value}/i" $str_conf_file
+                else
+                    echo "${name}=${value}" >> $str_conf_file
+                fi
+            i=$((i+1))
+        done		
     fi
 }
 
@@ -647,21 +651,21 @@ elif [ "$1" = "-s" ];then
         if [ -n "$str_inst_gateway" ];then
             echo "  gateway $str_inst_gateway" >> $str_conf_file
         fi
-	#add extra params
-	i=0
-	while [ $i -lt ${#array_extra_param_names[@]} ]
-	do
-	    name="${array_extra_param_names[$i]}"
-	    value="${array_extra_param_values[$i]}"
-            echo "  $i: name=$name value=$value"
-            grep -i "${name}" $str_conf_file
-            if [ $? -eq 0 ];then
-                sed -i "s/.*${name}.*/${name} ${value}/i" $str_conf_file
-            else
-                echo "${name} ${value}" >> $str_conf_file
-            fi
-	    i=$((i+1))
-	done		
+        #add extra params
+        i=0
+        while [ $i -lt ${#array_extra_param_names[@]} ]
+        do
+            name="${array_extra_param_names[$i]}"
+            value="${array_extra_param_values[$i]}"
+                echo "  $i: name=$name value=$value"
+                grep -i "${name}" $str_conf_file
+                if [ $? -eq 0 ];then
+                    sed -i "s/.*${name}.*/${name} ${value}/i" $str_conf_file
+                else
+                    echo "${name} ${value}" >> $str_conf_file
+                fi
+            i=$((i+1))
+        done		
         hostname $NODE
         echo $NODE > /etc/hostname
     elif [ "$str_os_type" = "sles" ];then
@@ -684,21 +688,21 @@ elif [ "$1" = "-s" ];then
             fi
         fi
 
-	#add extra params
-	i=0
-	while [ $i -lt ${#array_extra_param_names[@]} ]
-	do
-	    name="${array_extra_param_names[$i]}"
-	    value="${array_extra_param_values[$i]}"
-            echo "  $i: name=$name value=$value"
-            grep -i "${name}" $str_conf_file
-            if [ $? -eq 0 ];then
-                sed -i "s/.*${name}.*/${name}=${value}/i" $str_conf_file
-            else
-                echo "${name}=${value}" >> $str_conf_file
-            fi
-            i=$((i+1))
-	done		
+        #add extra params
+        i=0
+        while [ $i -lt ${#array_extra_param_names[@]} ]
+        do
+            name="${array_extra_param_names[$i]}"
+            value="${array_extra_param_values[$i]}"
+                echo "  $i: name=$name value=$value"
+                grep -i "${name}" $str_conf_file
+                if [ $? -eq 0 ];then
+                    sed -i "s/.*${name}.*/${name}=${value}/i" $str_conf_file
+                else
+                    echo "${name}=${value}" >> $str_conf_file
+                fi
+                i=$((i+1))
+        done		
         hostname $NODE
         echo $NODE > /etc/HOSTNAME
     else
@@ -774,6 +778,7 @@ elif [ "$1" = "-s" ];then
               fi
           fi
         fi
+
 	    #add extra params
         i=0
         while [ $i -lt ${#array_extra_param_names[@]} ]
@@ -781,11 +786,15 @@ elif [ "$1" = "-s" ];then
             name="${array_extra_param_names[$i]}"
             value="${array_extra_param_values[$i]}"
             echo "$i: name=$name value=$value"
-            grep -i "${name}" $str_conf_file
-            if [ $? -eq 0 ];then
-                sed -i "s/.*${name}.*/${name}=${value}/i" $str_conf_file
+            if [[ "$OSVER" =~ rhels9 ]]; then
+                nmcli con modify $con_name $name $value
             else
-                echo "${name}=${value}" >> $str_conf_file
+                grep -i "${name}" $str_conf_file
+                if [ $? -eq 0 ];then
+                    sed -i "s/.*${name}.*/${name}=${value}/i" $str_conf_file
+                else
+                    echo "${name}=${value}" >> $str_conf_file
+                fi
             fi
             i=$((i+1))
         done		

--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -68,21 +68,21 @@ function configipv4(){
             if [ "$str_nic_mtu" != "$str_default_token" ]; then
                 echo "MTU=${str_nic_mtu}" >> $str_conf_file
             fi
-            #add extra params
-            i=0
-            while [ $i -lt ${#array_extra_param_names[@]} ]
-            do
-                name="${array_extra_param_names[$i]}"
-            value="${array_extra_param_values[$i]}"
-                    echo "  $i: name=$name value=$value"
-                    grep -i "${name}" $str_conf_file
-                    if [ $? -eq 0 ];then
-                        sed -i "s/.*${name}.*/${name}=${value}/i" $str_conf_file
-                    else
-                echo "${name}=${value}" >> $str_conf_file
-                    fi
-                i=$((i+1))
-            done		
+	    #add extra params
+	    i=0
+	    while [ $i -lt ${#array_extra_param_names[@]} ]
+	    do
+	        name="${array_extra_param_names[$i]}"
+		value="${array_extra_param_values[$i]}"
+                echo "  $i: name=$name value=$value"
+                grep -i "${name}" $str_conf_file
+                if [ $? -eq 0 ];then
+                    sed -i "s/.*${name}.*/${name}=${value}/i" $str_conf_file
+                else
+		    echo "${name}=${value}" >> $str_conf_file
+                fi
+        	i=$((i+1))
+	    done		
         else
             echo "IPADDR_${num_v4num}=${str_v4ip}" >> $str_conf_file
             echo "NETMASK_${num_v4num}=${str_v4mask}" >> $str_conf_file
@@ -91,21 +91,21 @@ function configipv4(){
             if [ "$str_nic_mtu" != "$str_default_token" ]; then
                 echo "MTU_${num_v4num}=${str_nic_mtu}" >> $str_conf_file
             fi
-            #add extra params
-            i=0
-            while [ $i -lt ${#array_extra_param_names[@]} ]
-            do
-                name="${array_extra_param_names[$i]}"
-            value="${array_extra_param_values[$i]}"
-                    echo "  $i: name=$name value=$value"
-                    grep -i "${name}" $str_conf_file
-                    if [ $? -eq 0 ];then
-                        sed -i "s/.*${name}.*/${name}=${value}/i" $str_conf_file
-                    else
-                        echo "${name}=${value}" >> $str_conf_file
-                    fi
-            i=$((i+1))
-            done		
+	    #add extra params
+	    i=0
+	    while [ $i -lt ${#array_extra_param_names[@]} ]
+	    do
+	        name="${array_extra_param_names[$i]}"
+		value="${array_extra_param_values[$i]}"
+                echo "  $i: name=$name value=$value"
+                grep -i "${name}" $str_conf_file
+                if [ $? -eq 0 ];then
+                    sed -i "s/.*${name}.*/${name}=${value}/i" $str_conf_file
+                else
+                    echo "${name}=${value}" >> $str_conf_file
+                fi
+		i=$((i+1))
+	    done		
         fi
 
         if [[ ${str_if_name} == [a-zA-Z0-9]*.[0-9]* ]]; then
@@ -127,21 +127,21 @@ function configipv4(){
         if [ "$str_nic_mtu" != "$str_default_token" ]; then
             echo "  mtu ${str_nic_mtu}" >> $str_conf_file
         fi
-        #add extra params
-        i=0
-        while [ $i -lt ${#array_extra_param_names[@]} ]
-        do
-            name="${array_extra_param_names[$i]}"
-            value="${array_extra_param_values[$i]}"
-                echo "  $i: name=$name value=$value"
-                grep -i "${name}" $str_conf_file
-                if [ $? -eq 0 ];then
-                    sed -i "s/.*${name}.*/${name} ${value}/i" $str_conf_file
-                else
-                    echo "${name} ${value}" >> $str_conf_file
-                fi
-            i=$((i+1))
-        done		
+	#add extra params
+	i=0
+	while [ $i -lt ${#array_extra_param_names[@]} ]
+	do
+	    name="${array_extra_param_names[$i]}"
+	    value="${array_extra_param_values[$i]}"
+            echo "  $i: name=$name value=$value"
+            grep -i "${name}" $str_conf_file
+            if [ $? -eq 0 ];then
+                sed -i "s/.*${name}.*/${name} ${value}/i" $str_conf_file
+            else
+                echo "${name} ${value}" >> $str_conf_file
+            fi
+	    i=$((i+1))
+	done		
         if [[ ${str_if_name} == [a-zA-Z0-9]*.[0-9]* ]]; then
             parent_device=`echo ${str_if_name} | sed -e 's/\([a-zA-Z0-9]*\)\.[0-9]*/\1/g'`
             echo "  vlan-raw-device ${parent_device}" >> $str_conf_file
@@ -268,20 +268,20 @@ configipv6(){
         fi
 
         #add extra params
-        i=0
-        while [ $i -lt ${#array_extra_param_names[@]} ]
-        do
-            name="${array_extra_param_names[$i]}"
-            value="${array_extra_param_values[$i]}"
-                echo "  $i: name=$name value=$value"
-                grep -i "${name}" $str_conf_file
-                if [ $? -eq 0 ];then
-                    sed -i "s/.*${name}.*/${name}=${value}/i" $str_conf_file
-                else
-                    echo "${name}=${value}" >> $str_conf_file
-                fi
-            i=$((i+1))
-        done		
+	i=0
+	while [ $i -lt ${#array_extra_param_names[@]} ]
+	do
+	    name="${array_extra_param_names[$i]}"
+	    value="${array_extra_param_values[$i]}"
+            echo "  $i: name=$name value=$value"
+            grep -i "${name}" $str_conf_file
+            if [ $? -eq 0 ];then
+                sed -i "s/.*${name}.*/${name}=${value}/i" $str_conf_file
+            else
+                echo "${name}=${value}" >> $str_conf_file
+            fi
+	    i=$((i+1))
+	done		
     elif [ "$str_os_type" = "debian" ];then
         #debian or ubuntu
         str_conf_file="/etc/network/interfaces.d/${str_if_name}"
@@ -298,20 +298,20 @@ configipv6(){
             fi
 
             #add extra params
-            i=0
-            while [ $i -lt ${#array_extra_param_names[@]} ]
-            do
-                name="${array_extra_param_names[$i]}"
-            value="${array_extra_param_values[$i]}"
-            echo "  $i: name=$name value=$value"
-                    grep -i "${name}" $str_conf_file
-                    if [ $? -eq 0 ];then
-                        sed -i "s/.*${name}.*/${name} ${value}/i" $str_conf_file
-                    else
-                        echo "${name} ${value}" >> $str_conf_file
-                    fi
-                i=$((i+1))
-            done		
+	    i=0
+	    while [ $i -lt ${#array_extra_param_names[@]} ]
+	    do
+	        name="${array_extra_param_names[$i]}"
+		value="${array_extra_param_values[$i]}"
+		echo "  $i: name=$name value=$value"
+                grep -i "${name}" $str_conf_file
+                if [ $? -eq 0 ];then
+                    sed -i "s/.*${name}.*/${name} ${value}/i" $str_conf_file
+                else
+                    echo "${name} ${value}" >> $str_conf_file
+                fi
+	        i=$((i+1))
+	    done		
         else
             echo "  post-up /sbin/ifconfig ${str_if_name} inet6 add ${str_v6ip}/${str_v6prefix}" >> $str_conf_file
             echo "  pre-down /sbin/ifconfig ${str_if_name} inet6 del ${str_v6ip}/${str_v6prefix}" >> $str_conf_file
@@ -336,20 +336,20 @@ configipv6(){
         fi
 
         #add extra params
-        i=0
-        while [ $i -lt ${#array_extra_param_names[@]} ]
-        do
-            name="${array_extra_param_names[$i]}"
-            value="${array_extra_param_values[$i]}"
-                echo "  $i: name=$name value=$value"
-                grep -i "${name}" $str_conf_file
-                if [ $? -eq 0 ];then
-                    sed -i "s/.*${name}.*/${name}=${value}/i" $str_conf_file
-                else
-                    echo "${name}=${value}" >> $str_conf_file
-                fi
-            i=$((i+1))
-        done		
+	i=0
+	while [ $i -lt ${#array_extra_param_names[@]} ]
+	do
+	    name="${array_extra_param_names[$i]}"
+	    value="${array_extra_param_values[$i]}"
+            echo "  $i: name=$name value=$value"
+            grep -i "${name}" $str_conf_file
+            if [ $? -eq 0 ];then
+                sed -i "s/.*${name}.*/${name}=${value}/i" $str_conf_file
+            else
+                echo "${name}=${value}" >> $str_conf_file
+            fi
+	    i=$((i+1))
+	done		
     fi
 }
 
@@ -651,21 +651,21 @@ elif [ "$1" = "-s" ];then
         if [ -n "$str_inst_gateway" ];then
             echo "  gateway $str_inst_gateway" >> $str_conf_file
         fi
-        #add extra params
-        i=0
-        while [ $i -lt ${#array_extra_param_names[@]} ]
-        do
-            name="${array_extra_param_names[$i]}"
-            value="${array_extra_param_values[$i]}"
-                echo "  $i: name=$name value=$value"
-                grep -i "${name}" $str_conf_file
-                if [ $? -eq 0 ];then
-                    sed -i "s/.*${name}.*/${name} ${value}/i" $str_conf_file
-                else
-                    echo "${name} ${value}" >> $str_conf_file
-                fi
-            i=$((i+1))
-        done		
+	#add extra params
+	i=0
+	while [ $i -lt ${#array_extra_param_names[@]} ]
+	do
+	    name="${array_extra_param_names[$i]}"
+	    value="${array_extra_param_values[$i]}"
+            echo "  $i: name=$name value=$value"
+            grep -i "${name}" $str_conf_file
+            if [ $? -eq 0 ];then
+                sed -i "s/.*${name}.*/${name} ${value}/i" $str_conf_file
+            else
+                echo "${name} ${value}" >> $str_conf_file
+            fi
+	    i=$((i+1))
+	done		
         hostname $NODE
         echo $NODE > /etc/hostname
     elif [ "$str_os_type" = "sles" ];then
@@ -688,21 +688,21 @@ elif [ "$1" = "-s" ];then
             fi
         fi
 
-        #add extra params
-        i=0
-        while [ $i -lt ${#array_extra_param_names[@]} ]
-        do
-            name="${array_extra_param_names[$i]}"
-            value="${array_extra_param_values[$i]}"
-                echo "  $i: name=$name value=$value"
-                grep -i "${name}" $str_conf_file
-                if [ $? -eq 0 ];then
-                    sed -i "s/.*${name}.*/${name}=${value}/i" $str_conf_file
-                else
-                    echo "${name}=${value}" >> $str_conf_file
-                fi
-                i=$((i+1))
-        done		
+	#add extra params
+	i=0
+	while [ $i -lt ${#array_extra_param_names[@]} ]
+	do
+	    name="${array_extra_param_names[$i]}"
+	    value="${array_extra_param_values[$i]}"
+            echo "  $i: name=$name value=$value"
+            grep -i "${name}" $str_conf_file
+            if [ $? -eq 0 ];then
+                sed -i "s/.*${name}.*/${name}=${value}/i" $str_conf_file
+            else
+                echo "${name}=${value}" >> $str_conf_file
+            fi
+            i=$((i+1))
+	done		
         hostname $NODE
         echo $NODE > /etc/HOSTNAME
     else
@@ -778,17 +778,16 @@ elif [ "$1" = "-s" ];then
               fi
           fi
         fi
-
 	    #add extra params
         i=0
         while [ $i -lt ${#array_extra_param_names[@]} ]
         do
             name="${array_extra_param_names[$i]}"
             value="${array_extra_param_values[$i]}"
-            echo "$i: name=$name value=$value"
             if [[ "$OSVER" =~ rhels9 ]]; then
                 nmcli con modify $con_name $name $value
             else
+                echo "$i: name=$name value=$value"
                 grep -i "${name}" $str_conf_file
                 if [ $? -eq 0 ];then
                     sed -i "s/.*${name}.*/${name}=${value}/i" $str_conf_file

--- a/xCAT/postscripts/configeth
+++ b/xCAT/postscripts/configeth
@@ -213,7 +213,7 @@ function configipv4(){
         do
             name="${array_extra_param_names[$i]}"
             value="${array_extra_param_values[$i]}"
-            if [[ "$OSVER" =~ rhels9 ]]; then
+            if [[ "$OSVER" =~ (rhels9|alma9|rocky9) ]]; then
                 nmcli con modify $con_name $name $value
             else
                 grep -i "${name}" $str_conf_file
@@ -784,7 +784,7 @@ elif [ "$1" = "-s" ];then
         do
             name="${array_extra_param_names[$i]}"
             value="${array_extra_param_values[$i]}"
-            if [[ "$OSVER" =~ rhels9 ]]; then
+            if [[ "$OSVER" =~ (rhels9|alma9|rocky9) ]]; then
                 nmcli con modify $con_name $name $value
             else
                 echo "$i: name=$name value=$value"

--- a/xCAT/postscripts/configib
+++ b/xCAT/postscripts/configib
@@ -439,16 +439,16 @@ IPADDR=$nicip" > $dir/ifcfg-$nic
 					   name="${array_extra_param_names[$i]}"
 					   value="${array_extra_param_values[$i]}"
 					   echo "  $i: name=$name value=$value"
-                       if [[ "$OSVER" =~ (rhels9|alma9|rocky9) ]]; then
-                           nmcli con modify $con_name $name $value
-                       else
-                                           grep -i "${name}" $dir/ifcfg-$nic
-                                           if [ $? -eq 0 ];then
-                                               sed -i "s/.*${name}.*/${name}=${value}/i" >> $dir/ifcfg-$nic
-                                           else
-                                               echo "${name}=${value}" >> $dir/ifcfg-$nic
-                                           fi
-                       fi
+					   if [[ "$OSVER" =~ (rhels9|alma9|rocky9) ]]; then
+						   nmcli con modify $con_name $name $value
+					   else
+										   grep -i "${name}" $dir/ifcfg-$nic
+										   if [ $? -eq 0 ];then
+											   sed -i "s/.*${name}.*/${name}=${value}/i" >> $dir/ifcfg-$nic
+										   else
+											   echo "${name}=${value}" >> $dir/ifcfg-$nic
+										   fi
+					   fi
 					   i=$((i+1))
 				   done		
 			   else # not the first ip address
@@ -475,16 +475,16 @@ IPADDR_$ipindex=$nicip" >> $dir/ifcfg-$nic
 					   name="${array_extra_param_names[$i]}"
 					   value="${array_extra_param_values[$i]}"
 					   echo "  $i: name=$name value=$value"
-                       if [[ "$OSVER" =~ (rhels9|alma9|rocky9) ]]; then
-                           nmcli con modify $con_name $name $value
-                       else
-                                           grep -i "${name}" $dir/ifcfg-$nic
-                                           if [ $? -eq 0 ];then
-                                               sed -i "s/.*${name}.*/${name}=${value}/i" >> $dir/ifcfg-$nic
-                                           else
-                                               echo "${name}=${value}" >> $dir/ifcfg-$nic
-                                           fi
-                       fi
+					   if [[ "$OSVER" =~ (rhels9|alma9|rocky9) ]]; then
+						   nmcli con modify $con_name $name $value
+					   else
+										   grep -i "${name}" $dir/ifcfg-$nic
+										   if [ $? -eq 0 ];then
+											   sed -i "s/.*${name}.*/${name}=${value}/i" >> $dir/ifcfg-$nic
+										   else
+											   echo "${name}=${value}" >> $dir/ifcfg-$nic
+										   fi
+					   fi
 					   i=$((i+1))
 				   done		
                 fi # end if [ $ipindex -eq 1 ]
@@ -536,16 +536,16 @@ IPADDR=$nicip" > $dir/ifcfg-$nic
 						name="${array_extra_param_names[$i]}"
 						value="${array_extra_param_values[$i]}"
 						echo "  $i: name=$name value=$value"
-                        if [[ "$OSVER" =~ (rhels9|alma9|rocky9) ]]; then
-                            nmcli con modify $con_name $name $value
-                        else
-                                                grep -i "${name}" $dir/ifcfg-$nic
-                                                if [ $? -eq 0 ];then
-                                                    sed -i "s/.*${name}.*/${name}=${value}/i" >> $dir/ifcfg-$nic
-                                                else
-                                                    echo "${name}=${value}" >> $dir/ifcfg-$nic
-                                                fi
-                        fi
+						if [[ "$OSVER" =~ (rhels9|alma9|rocky9) ]]; then
+							nmcli con modify $con_name $name $value
+						else
+												grep -i "${name}" $dir/ifcfg-$nic
+												if [ $? -eq 0 ];then
+													sed -i "s/.*${name}.*/${name}=${value}/i" >> $dir/ifcfg-$nic
+												else
+													echo "${name}=${value}" >> $dir/ifcfg-$nic
+												fi
+						fi
 						i=$((i+1))
 					done		
                else # not the first ip address
@@ -605,16 +605,16 @@ IPADDR$ipindex=$nicip"
 							name="${array_extra_param_names[$i]}"
 							value="${array_extra_param_values[$i]}"
 							echo "  $i: name=$name value=$value"
-                            if [[ "$OSVER" =~ (rhels9|alma9|rocky9) ]]; then
-                                nmcli con modify $con_name $name $value
-                            else
-                                                        grep -i "${name}" $cfgfile
-                                                        if [ $? -eq 0 ];then
-                                                            sed -i "s/.*${name}.*/${name}=${value}/i" >> $cfgfile
-                                                        else
-                                                            echo "${name}=${value}" >> $cfgfile
-                                                        fi
-                            fi
+							if [[ "$OSVER" =~ (rhels9|alma9|rocky9) ]]; then
+								nmcli con modify $con_name $name $value
+							else
+														grep -i "${name}" $cfgfile
+														if [ $? -eq 0 ];then
+															sed -i "s/.*${name}.*/${name}=${value}/i" >> $cfgfile
+														else
+															echo "${name}=${value}" >> $cfgfile
+														fi
+							fi
 							i=$((i+1))
 						done		
 

--- a/xCAT/postscripts/configib
+++ b/xCAT/postscripts/configib
@@ -439,12 +439,16 @@ IPADDR=$nicip" > $dir/ifcfg-$nic
 					   name="${array_extra_param_names[$i]}"
 					   value="${array_extra_param_values[$i]}"
 					   echo "  $i: name=$name value=$value"
+                       if [[ "$OSVER" =~ (rhels9|alma9|rocky9) ]]; then
+                           nmcli con modify $con_name $name $value
+                       else
                                            grep -i "${name}" $dir/ifcfg-$nic
                                            if [ $? -eq 0 ];then
                                                sed -i "s/.*${name}.*/${name}=${value}/i" >> $dir/ifcfg-$nic
                                            else
                                                echo "${name}=${value}" >> $dir/ifcfg-$nic
                                            fi
+                       fi
 					   i=$((i+1))
 				   done		
 			   else # not the first ip address
@@ -471,12 +475,16 @@ IPADDR_$ipindex=$nicip" >> $dir/ifcfg-$nic
 					   name="${array_extra_param_names[$i]}"
 					   value="${array_extra_param_values[$i]}"
 					   echo "  $i: name=$name value=$value"
+                       if [[ "$OSVER" =~ (rhels9|alma9|rocky9) ]]; then
+                           nmcli con modify $con_name $name $value
+                       else
                                            grep -i "${name}" $dir/ifcfg-$nic
                                            if [ $? -eq 0 ];then
                                                sed -i "s/.*${name}.*/${name}=${value}/i" >> $dir/ifcfg-$nic
                                            else
                                                echo "${name}=${value}" >> $dir/ifcfg-$nic
                                            fi
+                       fi
 					   i=$((i+1))
 				   done		
                 fi # end if [ $ipindex -eq 1 ]
@@ -528,12 +536,16 @@ IPADDR=$nicip" > $dir/ifcfg-$nic
 						name="${array_extra_param_names[$i]}"
 						value="${array_extra_param_values[$i]}"
 						echo "  $i: name=$name value=$value"
+                        if [[ "$OSVER" =~ (rhels9|alma9|rocky9) ]]; then
+                            nmcli con modify $con_name $name $value
+                        else
                                                 grep -i "${name}" $dir/ifcfg-$nic
                                                 if [ $? -eq 0 ];then
                                                     sed -i "s/.*${name}.*/${name}=${value}/i" >> $dir/ifcfg-$nic
                                                 else
                                                     echo "${name}=${value}" >> $dir/ifcfg-$nic
                                                 fi
+                        fi
 						i=$((i+1))
 					done		
                else # not the first ip address
@@ -593,12 +605,16 @@ IPADDR$ipindex=$nicip"
 							name="${array_extra_param_names[$i]}"
 							value="${array_extra_param_values[$i]}"
 							echo "  $i: name=$name value=$value"
+                            if [[ "$OSVER" =~ (rhels9|alma9|rocky9) ]]; then
+                                nmcli con modify $con_name $name $value
+                            else
                                                         grep -i "${name}" $cfgfile
                                                         if [ $? -eq 0 ];then
                                                             sed -i "s/.*${name}.*/${name}=${value}/i" >> $cfgfile
                                                         else
                                                             echo "${name}=${value}" >> $cfgfile
                                                         fi
+                            fi
 							i=$((i+1))
 						done		
 
@@ -772,7 +788,9 @@ then
                 done
             else 
                 if [ $nmcli_used -eq 1 ]; then
-                    nmcli con reload $dir/ifcfg-$nic
+                    if ! [[ "$OSVER" =~ (rhels9|alma9|rocky9) ]]; then
+                        nmcli con reload $dir/ifcfg-$nic
+                    fi
                     nmcli con up $nic 2>&1
                 else
                     ifup $nic > /dev/null 2>&1

--- a/xCAT/postscripts/configib
+++ b/xCAT/postscripts/configib
@@ -433,25 +433,25 @@ IPADDR=$nicip" > $dir/ifcfg-$nic
                    fi
 
                    #add extra params
-				   i=0
-				   while [ $i -lt ${#array_extra_param_names[@]} ]
-				   do
-					   name="${array_extra_param_names[$i]}"
-					   value="${array_extra_param_values[$i]}"
-					   echo "  $i: name=$name value=$value"
-					   if [[ "$OSVER" =~ (rhels9|alma9|rocky9) ]]; then
-						   nmcli con modify $con_name $name $value
-					   else
-										   grep -i "${name}" $dir/ifcfg-$nic
-										   if [ $? -eq 0 ];then
-											   sed -i "s/.*${name}.*/${name}=${value}/i" >> $dir/ifcfg-$nic
-										   else
-											   echo "${name}=${value}" >> $dir/ifcfg-$nic
-										   fi
-					   fi
-					   i=$((i+1))
-				   done		
-			   else # not the first ip address
+                   i=0
+                   while [ $i -lt ${#array_extra_param_names[@]} ]
+                   do
+                       name="${array_extra_param_names[$i]}"
+                       value="${array_extra_param_values[$i]}"
+                       echo "  $i: name=$name value=$value"
+                       if [[ "$OSVER" =~ (rhels9|alma9|rocky9) ]]; then
+                           nmcli con modify $con_name $name $value
+                       else
+                           grep -i "${name}" $dir/ifcfg-$nic
+                           if [ $? -eq 0 ];then
+                               sed -i "s/.*${name}.*/${name}=${value}/i" >> $dir/ifcfg-$nic
+                           else
+                               echo "${name}=${value}" >> $dir/ifcfg-$nic
+                           fi
+                       fi
+                       i=$((i+1))
+                   done		
+                else # not the first ip address
                    echo "LABEL_$ipindex=$ipindex
 IPADDR_$ipindex=$nicip" >> $dir/ifcfg-$nic
                     # ipv6
@@ -469,24 +469,24 @@ IPADDR_$ipindex=$nicip" >> $dir/ifcfg-$nic
                        fi
                    fi
                    #add extra params
-				   i=0
-				   while [ $i -lt ${#array_extra_param_names[@]} ]
-				   do
-					   name="${array_extra_param_names[$i]}"
-					   value="${array_extra_param_values[$i]}"
-					   echo "  $i: name=$name value=$value"
-					   if [[ "$OSVER" =~ (rhels9|alma9|rocky9) ]]; then
-						   nmcli con modify $con_name $name $value
-					   else
-										   grep -i "${name}" $dir/ifcfg-$nic
-										   if [ $? -eq 0 ];then
-											   sed -i "s/.*${name}.*/${name}=${value}/i" >> $dir/ifcfg-$nic
-										   else
-											   echo "${name}=${value}" >> $dir/ifcfg-$nic
-										   fi
-					   fi
-					   i=$((i+1))
-				   done		
+                   i=0
+                   while [ $i -lt ${#array_extra_param_names[@]} ]
+                   do
+                       name="${array_extra_param_names[$i]}"
+                       value="${array_extra_param_values[$i]}"
+                       echo "  $i: name=$name value=$value"
+                       if [[ "$OSVER" =~ (rhels9|alma9|rocky9) ]]; then
+                           nmcli con modify $con_name $name $value
+                       else
+                           grep -i "${name}" $dir/ifcfg-$nic
+                           if [ $? -eq 0 ];then
+                               sed -i "s/.*${name}.*/${name}=${value}/i" >> $dir/ifcfg-$nic
+                           else
+                               echo "${name}=${value}" >> $dir/ifcfg-$nic
+                           fi
+                       fi
+                       i=$((i+1))
+                   done		
                 fi # end if [ $ipindex -eq 1 ]
             elif [ $OS_name == 'redhat' ]
             then
@@ -529,25 +529,25 @@ IPADDR=$nicip" > $dir/ifcfg-$nic
                     fi
 
 
-					#add extra params
-					i=0
-					while [ $i -lt ${#array_extra_param_names[@]} ]
-					do
-						name="${array_extra_param_names[$i]}"
-						value="${array_extra_param_values[$i]}"
-						echo "  $i: name=$name value=$value"
-						if [[ "$OSVER" =~ (rhels9|alma9|rocky9) ]]; then
-							nmcli con modify $con_name $name $value
-						else
-												grep -i "${name}" $dir/ifcfg-$nic
-												if [ $? -eq 0 ];then
-													sed -i "s/.*${name}.*/${name}=${value}/i" >> $dir/ifcfg-$nic
-												else
-													echo "${name}=${value}" >> $dir/ifcfg-$nic
-												fi
-						fi
-						i=$((i+1))
-					done		
+                    #add extra params
+                    i=0
+                    while [ $i -lt ${#array_extra_param_names[@]} ]
+                    do
+                        name="${array_extra_param_names[$i]}"
+                        value="${array_extra_param_values[$i]}"
+                        echo "  $i: name=$name value=$value"
+                        if [[ "$OSVER" =~ (rhels9|alma9|rocky9) ]]; then
+                            nmcli con modify $con_name $name $value
+                        else
+                            grep -i "${name}" $dir/ifcfg-$nic
+                            if [ $? -eq 0 ];then
+                                sed -i "s/.*${name}.*/${name}=${value}/i" >> $dir/ifcfg-$nic
+                            else
+                                echo "${name}=${value}" >> $dir/ifcfg-$nic
+                            fi
+                        fi
+                        i=$((i+1))
+                    done		
                else # not the first ip address
                    # ipv6
                    if echo $nicip | grep : 2>&1 1>/dev/null
@@ -598,25 +598,25 @@ IPADDR$ipindex=$nicip"
                             fi
                         fi
 
-						#add extra params
-						i=0
-						while [ $i -lt ${#array_extra_param_names[@]} ]
-						do
-							name="${array_extra_param_names[$i]}"
-							value="${array_extra_param_values[$i]}"
-							echo "  $i: name=$name value=$value"
-							if [[ "$OSVER" =~ (rhels9|alma9|rocky9) ]]; then
-								nmcli con modify $con_name $name $value
-							else
-														grep -i "${name}" $cfgfile
-														if [ $? -eq 0 ];then
-															sed -i "s/.*${name}.*/${name}=${value}/i" >> $cfgfile
-														else
-															echo "${name}=${value}" >> $cfgfile
-														fi
-							fi
-							i=$((i+1))
-						done		
+                        #add extra params
+                        i=0
+                        while [ $i -lt ${#array_extra_param_names[@]} ]
+                        do
+                            name="${array_extra_param_names[$i]}"
+                            value="${array_extra_param_values[$i]}"
+                            echo "  $i: name=$name value=$value"
+                            if [[ "$OSVER" =~ (rhels9|alma9|rocky9) ]]; then
+                                nmcli con modify $con_name $name $value
+                            else
+                                grep -i "${name}" $cfgfile
+                                if [ $? -eq 0 ]; then
+                                    sed -i "s/.*${name}.*/${name}=${value}/i" >> $cfgfile
+                                else
+                                    echo "${name}=${value}" >> $cfgfile
+                                fi
+                            fi
+                            i=$((i+1))
+                        done		
 
                         # need to run ifup eth1:1 for RedHat
                         if [ $nmcli_used -eq 0 ]; then
@@ -673,24 +673,24 @@ netmask $netmask" >> /etc/network/interfaces
                         #    echo "gateway $gateway" >> /etc/network/interfaces
                         #fi
                     fi
-				fi
-				#add extra params
-				i=0
-				while [ $i -lt ${#array_extra_param_names[@]} ]
-				do
-					name="${array_extra_param_names[$i]}"
-					value="${array_extra_param_values[$i]}"
-					echo "  $i: name=$name value=$value"
-                                        grep -i "${name}" /etc/network/interfaces
-                                        if [ $? -eq 0 ];then
-                                            sed -i "s/.*${name}.*/${name} ${value}/i" >> /etc/network/interfaces 
-                                        else
-                                            echo "${name} ${value}" >> /etc/network/interfaces 
-                                        fi
-					i=$((i+1))
-				done
+                fi
+                #add extra params
+                i=0
+                while [ $i -lt ${#array_extra_param_names[@]} ]
+                do
+                    name="${array_extra_param_names[$i]}"
+                    value="${array_extra_param_values[$i]}"
+                    echo "  $i: name=$name value=$value"
+                    grep -i "${name}" /etc/network/interfaces
+                    if [ $? -eq 0 ];then
+                        sed -i "s/.*${name}.*/${name} ${value}/i" >> /etc/network/interfaces 
+                    else
+                        echo "${name} ${value}" >> /etc/network/interfaces 
+                    fi
+                    i=$((i+1))
+                done
 
-           else
+            else
                 echo "Unsupported operating system"
                 logger -p local4.err -t $log_label "Unsupported operating system"
             fi

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -1832,7 +1832,7 @@ function add_extra_params_nmcli {
             # For RHEL 9, use nmcli directly, otherwise use ifcfg scheme.
             if [[ "$OSVER" =~ rhels9 ]]; then
                 nmcli con modify "$con_name" "$name" "$value"
-                return $?
+                rc+=$?
             else
                 grep $name $str_conf_file >/dev/null 2>/dev/null
                 if [ $? -eq 0 ]; then

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -1808,14 +1808,18 @@ function add_extra_params_nmcli {
     nicdev=$1
     con_name=$2
     rc=0
-    str_conf_file="/etc/sysconfig/network-scripts/ifcfg-${con_name}"
-    str_conf_file_1="/etc/sysconfig/network-scripts/ifcfg-${con_name}-1"
-    if [ -f $str_conf_file_1 ]; then
-        grep -x "NAME=$con_name" $str_conf_file_1 >/dev/null 2>/dev/null
-        if [ $? -eq 0 ]; then
-            str_conf_file=$str_conf_file_1
+
+    if [[ $OSVER != rhels9* ]]; then
+        str_conf_file="/etc/sysconfig/network-scripts/ifcfg-${con_name}"
+        str_conf_file_1="/etc/sysconfig/network-scripts/ifcfg-${con_name}-1"
+        if [ -f $str_conf_file_1 ]; then
+            grep -x "NAME=$con_name" $str_conf_file_1 >/dev/null 2>/dev/null
+            if [ $? -eq 0 ]; then
+                str_conf_file=$str_conf_file_1
+            fi
         fi
     fi
+
     #query extra params
     query_extra_params $nicdev
     i=0
@@ -1823,13 +1827,20 @@ function add_extra_params_nmcli {
     do
         name="${array_extra_param_names[$i]}"
         value="${array_extra_param_values[$i]}"
+
         if [ -n "$name" -a -n "$value" ]; then
-            grep $name $str_conf_file >/dev/null 2>/dev/null
-            if [ $? -eq 0 ]; then
-                replacevalue="$name=$value"
-                sed -i "s/^$name=.*/$replacevalue/" $str_conf_file
+            # For RHEL 9, use nmcli directly, otherwise use ifcfg scheme.
+            if [[ "$OSVER" =~ rhels9 ]]; then
+                nmcli con modify "$con_name" "$name" "$value"
+                return $?
             else
-                echo "$name="$value"" >> $str_conf_file
+                grep $name $str_conf_file >/dev/null 2>/dev/null
+                if [ $? -eq 0 ]; then
+                    replacevalue="$name=$value"
+                    sed -i "s/^$name=.*/$replacevalue/" $str_conf_file
+                else
+                    echo "$name="$value"" >> $str_conf_file
+                fi
             fi
         else
             log_error "invalid extra params $name $value, please check nics.nicextraparams"
@@ -1837,7 +1848,10 @@ function add_extra_params_nmcli {
         fi
         i=$((i+1))
     done
-    $nmcli con reload $str_conf_file
+
+    if [[ $OSVER != rhels9* ]]; then
+        $nmcli con reload $str_conf_file
+    fi
     return $rc
 }
 

--- a/xCAT/postscripts/nicutils.sh
+++ b/xCAT/postscripts/nicutils.sh
@@ -1809,7 +1809,7 @@ function add_extra_params_nmcli {
     con_name=$2
     rc=0
 
-    if [[ $OSVER != rhels9* ]]; then
+    if ! [[ $OSVER =~ (rhels9|alma9|rocky9) ]]; then
         str_conf_file="/etc/sysconfig/network-scripts/ifcfg-${con_name}"
         str_conf_file_1="/etc/sysconfig/network-scripts/ifcfg-${con_name}-1"
         if [ -f $str_conf_file_1 ]; then
@@ -1830,7 +1830,7 @@ function add_extra_params_nmcli {
 
         if [ -n "$name" -a -n "$value" ]; then
             # For RHEL 9, use nmcli directly, otherwise use ifcfg scheme.
-            if [[ "$OSVER" =~ rhels9 ]]; then
+            if [[ "$OSVER" =~ (rhels9|alma9|rocky9) ]]; then
                 nmcli con modify "$con_name" "$name" "$value"
                 rc+=$?
             else
@@ -1849,7 +1849,7 @@ function add_extra_params_nmcli {
         i=$((i+1))
     done
 
-    if [[ $OSVER != rhels9* ]]; then
+    if [[ $OSVER != (rhels9|alma9|rocky9) ]]; then
         $nmcli con reload $str_conf_file
     fi
     return $rc


### PR DESCRIPTION
### The PR is to address issue #7416 

### The modification include

 - update to xCAT/postscripts/nicutils.sh to include RHEL9-specific logic in `add_extra_params_nmcli()` that calls `nmcli connection modify` instead of writing to ifcfg files.
 -  updates configeth postscript to use the `nmcli con modify` approach for RHEL9 in two places.

### The UT result
`##The UT output##`