### PR TITLE
Fix for getting MAC table over SSH on recent ONIE switches

### DIFF
--- a/perl-xCAT/xCAT/MacMap.pm
+++ b/perl-xCAT/xCAT/MacMap.pm
@@ -723,7 +723,7 @@ sub refresh_switch {
         my $mymac;
         my $myport;
 
-        my @res=xCAT::Utils->runcmd("ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no $switch 'bridge fdb show|grep -i -v permanent|tr A-Z a-z  2>/dev/null' 2>/dev/null",-1);
+        my @res=xCAT::Utils->runcmd("ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no $switch \"bash -lc 'set -o pipefail; bridge fdb show |grep -i -v permanent |tr A-Z a-z  2>/dev/null'\" 2>/dev/null",-1);
         if ($::RUNCMD_RC) {
             xCAT::MsgUtils->message("S", "Failed to get mac table with ssh to $switch, fall back to snmp! To obtain mac table with ssh, please make sure the passwordless root ssh to $switch is available");
             if ($self->{collect_mac_info}) {
@@ -773,6 +773,7 @@ sub refresh_switch {
             }
         }
     }
+
 
     my $session = $self->getsnmpsession('community' => $community, 'switch' => $switch);
     unless ($session) {


### PR DESCRIPTION
### The PR is to fix issue #7463 

### The modification include

_## fix remote PATH_

Run the remote `bridge` command in a login shell, to make sure PATH is properly defined

_## fix remote error propagation_

Add `set -o pipefail` to ensure that errors are properly propagated back through the remote SSH command


