### PR TITLE
Provide more options to setup BMC port for Dell servers

### DIFF
--- a/perl-xCAT/xCAT/Schema.pm
+++ b/perl-xCAT/xCAT/Schema.pm
@@ -430,6 +430,15 @@ passed as argument rather than by table value',
                         2 2   Third interface on ML2 or mezzanine adapter
                         2 3   Fourth interface on ML2 or mezzanine adapter
 
+                For Dell systems, a second and third values can also be used:
+                        1st value:  0 = shared / 1 = dedicated
+                        2nd value   shared LOM (1-4)   (0 or no value means first available LOM)
+                        3rd value:  failover LOM (1-4) (0 means no failover, no value means all LOMs)
+                            0      Shared with first available interface, failover all LOMs (catch all mode)
+                            0 1    Shared with LOM1, failover all LOMs
+                            0 1 2  Shared with LOM1, failover LOM2
+                            0 2 0  Shared with LOM2, no failover
+                            1      Dedicated',
             taggedvlan => 'bmcsetup script will configure the network interface of the BMC to be tagged to the VLAN specified.',
             bmcid => 'Unique identified data used by discovery processes to distinguish known BMCs from unrecognized BMCs',
             username => 'The BMC userid.  If not specified, the key=ipmi row in the passwd table is used as the default.',

--- a/perl-xCAT/xCAT/Schema.pm
+++ b/perl-xCAT/xCAT/Schema.pm
@@ -412,41 +412,24 @@ passed as argument rather than by table value',
             bmc  => 'The hostname of the BMC adapter.',
             bmcport => 'In systems with selectable shared/dedicated ethernet ports, this parameter can be used to specify the preferred port. 0 means use the shared port, 1 means dedicated, blank is to not assign.
 
-           The following special cases exist for IBM System x servers:
+                The following special cases exist for IBM System x servers:
 
-           For x3755 M3 systems, 0 means use the dedicated port, 1 means
-           shared, blank is to not assign.
+                  - For x3755 M3 systems, 0 means use the dedicated port, 1 means shared, blank is to not assign.
 
-       For certain systems which have a mezzaine or ML2 adapter, there is a second
-       value to include:
+                  - For certain systems which have a mezzaine or ML2 adapter, there is a second value to include:
+                      For x3750 M4 (Model 8722):
+                        0 2   1st 1Gbps interface for LOM
+                        0 0   1st 10Gbps interface for LOM
+                        0 3   2nd 1Gbps interface for LOM
+                        0 1   2nd 10Gbps interface for LOM
+                      For  x3750 M4 (Model 8752), x3850/3950 X6, dx360 M4, x3550 M4, and x3650 M4:
+                        0     Shared (1st onboard interface)
+                        1     Dedicated
+                        2 0   First interface on ML2 or mezzanine adapter
+                        2 1   Second interface on ML2 or mezzanine adapter
+                        2 2   Third interface on ML2 or mezzanine adapter
+                        2 3   Fourth interface on ML2 or mezzanine adapter
 
-
-           For x3750 M4 (Model 8722):
-
-
-           0 2   1st 1Gbps interface for LOM
-
-           0 0   1st 10Gbps interface for LOM
-
-           0 3   2nd 1Gbps interface for LOM
-
-           0 1   2nd 10Gbps interface for LOM
-
-
-           For  x3750 M4 (Model 8752), x3850/3950 X6, dx360 M4, x3550 M4, and x3650 M4:
-
-
-           0     Shared (1st onboard interface)
-
-           1     Dedicated
-
-           2 0   First interface on ML2 or mezzanine adapter
-
-           2 1   Second interface on ML2 or mezzanine adapter
-
-           2 2   Third interface on ML2 or mezzanine adapter
-
-           2 3   Fourth interface on ML2 or mezzanine adapter',
             taggedvlan => 'bmcsetup script will configure the network interface of the BMC to be tagged to the VLAN specified.',
             bmcid => 'Unique identified data used by discovery processes to distinguish known BMCs from unrecognized BMCs',
             username => 'The BMC userid.  If not specified, the key=ipmi row in the passwd table is used as the default.',

--- a/xCAT-genesis-scripts/usr/bin/bmcsetup
+++ b/xCAT-genesis-scripts/usr/bin/bmcsetup
@@ -263,16 +263,53 @@ elif [ "$IPMIMFG" == 20301 -o "$IPMIMFG" == 19046 ] ; then
 elif [ "$IPMIMFG" == "47488" ]; then
     LOCKEDUSERS=1
 elif [ "$IPMIMFG" == "674" ]; then # DELL
+    logger -s -t $log_label -p local4.info "Dell server detected"
     BMCPORT=`grep bmcport /tmp/ipmicfg.xml |awk -F\> '{print $2}'|awk -F\< '{print $1}'`
+    # BMCPORT can take 3 values:
+    #   1st value:  0 = shared / 1 = dedicated
+    #   2nd value   shared LOM (1-4)   (0 or no value means first available LOM)
+    #   3rd value:  failover LOM (1-4) (0 means no failover, no value means all LOMs)
+    read -r bmc_mode shared_lom failover_lom <<< "$BMCPORT"
     logger -s -t $log_label -p local4.info "BMCPORT is $BMCPORT"
-    if [ "$BMCPORT" == "0" ]; then # shared
+    logger -s -t $log_label -p local4.info "bmc_mode:$bmc_mode shared_lom:$shared_lom failover_lom:$failover_lom"
+    if [ "$bmc_mode" == "1" ]; then # dedicated
+        logger -s -t $log_label -p local4.info "Setting BMC to dedicated mode"
         # https://github.com/ipmitool/ipmitool/issues/18
         # ipmitool raw 0x30 0x28 0xAA 0xBB, with:
         #   AA: 01 = dedicated, 02...05 = shared with lom1...4
         #   BB: 00 = no failover, 02...05 = failover on lom1...4, , 06 = failover on all loms
-        ipmitool raw 0x30 0x28 0x02 0x06
-    elif [ "$BMCPORT" == "1" ]; then # dedicated
         ipmitool raw 0x30 0x28 0x01 0x00
+    elif [ "$bmc_mode" == "0" ]; then # shared
+        logger -s -t $log_label -p local4.info "Setting BMC to shared mode"
+        case "$failover_lom" in
+            ""   )  xFAIL=0x06 ;;
+            0    )  xFAIL=0x00 ;;
+            [1-4])  xFAIL=$(printf 0x%02x $((failover_lom+1))) ;;
+                *)  logger -s -t $log_label -p local4.info "WARNING: can't set failover LOM to $failover_lom, defaulting to failover all LOMs"
+                    xFAIL=0x06 ;;
+        esac
+        case "$shared_lom" in
+            ""|0)   xLOM=00 ;;
+            [1-4])  xLOM=$(printf 0x%02x $((shared_lom+1))) ;;
+                *)  logger -s -t $log_label -p local4.info "WARNING: can't set shared LOM to $shared_lom, defaulting to first available LOMs"
+                    xLOM=00 ;;
+        esac
+        case "$xLOM" in
+            "00")   # try to find the first available LOM
+                    _lom=1
+                    while ! ipmitool raw 0x30 0x28 "$(printf 0x%02x $((_lom+1)))" "$xFAIL" 2>/dev/null; do
+                        _lom=$((_lom+1))
+                        snooze
+                        if [ $_lom -gt 4 ]; then
+                            logger -s -t $log_label -p local4.info "ERROR: setting BMC to share mode failed"
+                            break;
+                        fi
+                    done
+                    ;;
+            *)      ipmitool raw 0x30 0x28 "$xLOM" "$xFAIL" || \
+                        logger -s -t $log_label -p local4.info "ERROR: error setting BMCPORT to requested parameters"
+                    ;;
+        esac
     fi
 elif [ "$IPMIMFG" == "10876" ]; then # Supermicro
     BMCPORT=`grep bmcport /tmp/ipmicfg.xml |awk -F\> '{print $2}'|awk -F\< '{print $1}'`


### PR DESCRIPTION
This PR provides more options to setup BMC/iDRAC port sharing for Dell servers during initial discovery (or later via the `bmcsetup` postscript).

It extends the usual "0/1" "shared/dedicated" scheme and try to replicate the variety of options available via `ipmitool delloem`:
```
       lan set <Mode>
        sets the NIC Selection Mode :
            dedicated, shared with lom<idx>

       lan set <Shared Failover Mode>
        sets the shared Failover Mode :
            shared with failover lom<idx>
            shared with failover all loms,
            shared with failover none.
```

Since other types of servers already support multiple values in `ipmi.bmcport` ( f5851bc826b6c780ceac3f5a5dfab2755cbbd91e and 27d8ca563b81890e77cb6ae562e78ea9992c255a), this PR extends the concept by allowing 3 space-separated values for Dell servers: 
* **1st value**:  0 = shared, 1 = dedicated
* **2nd value**: shared LOM index (1-4) (0 or no value means "first available LOM")
* **3rd value**: failover LOM index (1-4) (0 means "no failover", no value means "all LOMs")


To ensure maximum compatibility with the default 0/1 shared/dedicated scheme, the 2nd and 3rd values are optional, and will retain the previous behavior when not specified.

For instance:
| `ipmi.bmcport` | BMC interface configuration |
| ---- | :---- |
| `0` | Shared with first available interface, failover with all LOMs (catch-all mode) | 
| `0 1` | Shared with LOM1, failover all LOMs |
| `0 1 2` | Shared with LOM1, failover LOM2 |
| `0 2 0` | Shared with LOM2, no failover |
| `1` | Dedicated |
