### PR TITLE
Adjustments to configib to handle Rocky9 precreated connections

### DIFF
--- a/xCAT/postscripts/configib
+++ b/xCAT/postscripts/configib
@@ -388,10 +388,6 @@ do
 
            if [ -f /etc/sysctl.conf ]
            then
-               TMP1=`sed "/net.ipv4.conf.$nic.arp_filter=1/d" /etc/sysctl.conf`
-	       echo "$TMP1" > /etc/sysctl.conf
-               TMP2=`sed "/net.ipv4.conf.$nic.arp_ignore=1/d" /etc/sysctl.conf`
-	       echo "$TMP2" > /etc/sysctl.conf
                cfg="net.ipv4.conf.$nic.arp_filter=1"
                grep "$cfg" /etc/sysctl.conf 2>&1 1>/dev/null
                if [ $? -ne 0 ]
@@ -489,10 +485,10 @@ IPADDR_$ipindex=$nicip" >> $dir/ifcfg-$nic
                        # ipv6
                        if echo $nicip | grep : 2>&1 1>/dev/null
                        then
-                           nmcli con add type infiniband con-name $nic ifname $nic ipv6.method manual ipv6.addresses $nicip
+                           nmcli con modify $nic type infiniband con-name $nic ifname $nic ipv6.method manual ipv6.addresses $nicip
                        else # ipv4
                            prefix=$(convert_netmask_to_cidr $netmask)
-                           nmcli con add type infiniband con-name $nic ifname $nic ipv4.method manual ipv4.addresses $nicip/$prefix
+                           nmcli con modify $nic type infiniband con-name $nic ifname $nic ipv4.method manual ipv4.addresses $nicip/$prefix
                        fi
                    else
                        nmcontrol=""
@@ -540,7 +536,7 @@ IPADDR=$nicip" > $dir/ifcfg-$nic
                         value="${array_extra_param_values[$i]}"
                         echo "  $i: name=$name value=$value"
                         if [[ "$OSVER" =~ ^(rhels9|alma9|rocky9) ]]; then
-                            nmcli con modify $con_name $name $value
+                            nmcli con modify $nic $name $value
                         else
                             grep -i "${name}" $dir/ifcfg-$nic
                             if [ $? -eq 0 ];then
@@ -556,10 +552,10 @@ IPADDR=$nicip" > $dir/ifcfg-$nic
                        # ipv6
                        if echo $nicip | grep : 2>&1 1>/dev/null
                        then
-                           nmcli con add type infiniband con-name $nic ifname $nic ipv6.method manual ipv6.addresses $nicip
+                           nmcli con modify $nic type infiniband con-name $nic ifname $nic ipv6.method manual ipv6.addresses $nicip
                        else # ipv4
                            prefix=$(convert_netmask_to_cidr $netmask)
-                           nmcli con add type infiniband con-name $nic ifname $nic ipv4.method manual ipv4.addresses $nicip/$prefix
+                           nmcli con modify $nic type infiniband con-name $nic ifname $nic ipv4.method manual ipv4.addresses $nicip/$prefix
                        fi
                    else
                        # ipv6
@@ -620,7 +616,7 @@ IPADDR$ipindex=$nicip"
                             value="${array_extra_param_values[$i]}"
                             echo "  $i: name=$name value=$value"
                             if [[ "$OSVER" =~ ^(rhels9|alma9|rocky9) ]]; then
-                                nmcli con modify $con_name $name $value
+                                nmcli con modify $nic $name $value
                             else
                                 grep -i "${name}" $cfgfile
                                 if [ $? -eq 0 ]; then

--- a/xCAT/postscripts/configib
+++ b/xCAT/postscripts/configib
@@ -388,6 +388,10 @@ do
 
            if [ -f /etc/sysctl.conf ]
            then
+               TMP1=`sed "/net.ipv4.conf.$nic.arp_filter=1/d" /etc/sysctl.conf`
+	       echo "$TMP1" > /etc/sysctl.conf
+               TMP2=`sed "/net.ipv4.conf.$nic.arp_ignore=1/d" /etc/sysctl.conf`
+	       echo "$TMP2" > /etc/sysctl.conf
                cfg="net.ipv4.conf.$nic.arp_filter=1"
                grep "$cfg" /etc/sysctl.conf 2>&1 1>/dev/null
                if [ $? -ne 0 ]

--- a/xCAT/postscripts/configib
+++ b/xCAT/postscripts/configib
@@ -482,13 +482,25 @@ IPADDR_$ipindex=$nicip" >> $dir/ifcfg-$nic
                if [ $ipindex -eq 1 ]
                then
                    if [[ "$OSVER" =~ ^(rhels9|alma9|rocky9) ]]; then
-                       # ipv6
-                       if echo $nicip | grep : 2>&1 1>/dev/null
-                       then
-                           nmcli con modify $nic type infiniband con-name $nic ifname $nic ipv6.method manual ipv6.addresses $nicip
-                       else # ipv4
-                           prefix=$(convert_netmask_to_cidr $netmask)
-                           nmcli con modify $nic type infiniband con-name $nic ifname $nic ipv4.method manual ipv4.addresses $nicip/$prefix
+                       if nmcli --field connection.id con show $nic 2>&1 1>/dev/null
+                       then # create new connection
+                            # ipv6
+                            if echo $nicip | grep : 2>&1 1>/dev/null
+                            then
+                                nmcli con add type infiniband con-name $nic ifname $nic ipv6.method manual ipv6.addresses $nicip
+                            else # ipv4
+                                prefix=$(convert_netmask_to_cidr $netmask)
+                                nmcli con add type infiniband con-name $nic ifname $nic ipv4.method manual ipv4.addresses $nicip/$prefix
+                            fi
+                       else # modify current connection
+                            # ipv6
+                            if echo $nicip | grep : 2>&1 1>/dev/null
+                            then
+                                nmcli con modify $nic type infiniband con-name $nic ifname $nic ipv6.method manual ipv6.addresses $nicip
+                            else # ipv4
+                                prefix=$(convert_netmask_to_cidr $netmask)
+                                nmcli con modify $nic type infiniband con-name $nic ifname $nic ipv4.method manual ipv4.addresses $nicip/$prefix
+                            fi
                        fi
                    else
                        nmcontrol=""
@@ -549,13 +561,25 @@ IPADDR=$nicip" > $dir/ifcfg-$nic
                     done		
                else # not the first ip address
                    if [[ "$OSVER" =~ ^(rhels9|alma9|rocky9) ]]; then
-                       # ipv6
-                       if echo $nicip | grep : 2>&1 1>/dev/null
-                       then
-                           nmcli con modify $nic type infiniband con-name $nic ifname $nic ipv6.method manual ipv6.addresses $nicip
-                       else # ipv4
-                           prefix=$(convert_netmask_to_cidr $netmask)
-                           nmcli con modify $nic type infiniband con-name $nic ifname $nic ipv4.method manual ipv4.addresses $nicip/$prefix
+                       if nmcli --field connection.id con show $nic 2>&1 1>/dev/null
+                       then # create new connection
+                            # ipv6
+                            if echo $nicip | grep : 2>&1 1>/dev/null
+                            then
+                                nmcli con add type infiniband con-name $nic ifname $nic ipv6.method manual ipv6.addresses $nicip
+                            else # ipv4
+                                prefix=$(convert_netmask_to_cidr $netmask)
+                                nmcli con add type infiniband con-name $nic ifname $nic ipv4.method manual ipv4.addresses $nicip/$prefix
+                            fi
+                       else # modify current connection
+                            # ipv6
+                            if echo $nicip | grep : 2>&1 1>/dev/null
+                            then
+                                nmcli con modify $nic type infiniband con-name $nic ifname $nic ipv6.method manual ipv6.addresses $nicip
+                            else # ipv4
+                                prefix=$(convert_netmask_to_cidr $netmask)
+                                nmcli con modify $nic type infiniband con-name $nic ifname $nic ipv4.method manual ipv4.addresses $nicip/$prefix
+                            fi
                        fi
                    else
                        # ipv6

--- a/xCAT/postscripts/configib
+++ b/xCAT/postscripts/configib
@@ -483,16 +483,7 @@ IPADDR_$ipindex=$nicip" >> $dir/ifcfg-$nic
                then
                    if [[ "$OSVER" =~ ^(rhels9|alma9|rocky9) ]]; then
                        if nmcli --field connection.id con show $nic 2>&1 1>/dev/null
-                       then # create new connection
-                            # ipv6
-                            if echo $nicip | grep : 2>&1 1>/dev/null
-                            then
-                                nmcli con add type infiniband con-name $nic ifname $nic ipv6.method manual ipv6.addresses $nicip
-                            else # ipv4
-                                prefix=$(convert_netmask_to_cidr $netmask)
-                                nmcli con add type infiniband con-name $nic ifname $nic ipv4.method manual ipv4.addresses $nicip/$prefix
-                            fi
-                       else # modify current connection
+                       then # modify current connection
                             # ipv6
                             if echo $nicip | grep : 2>&1 1>/dev/null
                             then
@@ -500,6 +491,15 @@ IPADDR_$ipindex=$nicip" >> $dir/ifcfg-$nic
                             else # ipv4
                                 prefix=$(convert_netmask_to_cidr $netmask)
                                 nmcli con modify $nic type infiniband con-name $nic ifname $nic ipv4.method manual ipv4.addresses $nicip/$prefix
+                            fi
+                       else # create new connection
+                            # ipv6
+                            if echo $nicip | grep : 2>&1 1>/dev/null
+                            then
+                                nmcli con add type infiniband con-name $nic ifname $nic ipv6.method manual ipv6.addresses $nicip
+                            else # ipv4
+                                prefix=$(convert_netmask_to_cidr $netmask)
+                                nmcli con add type infiniband con-name $nic ifname $nic ipv4.method manual ipv4.addresses $nicip/$prefix
                             fi
                        fi
                    else
@@ -562,16 +562,7 @@ IPADDR=$nicip" > $dir/ifcfg-$nic
                else # not the first ip address
                    if [[ "$OSVER" =~ ^(rhels9|alma9|rocky9) ]]; then
                        if nmcli --field connection.id con show $nic 2>&1 1>/dev/null
-                       then # create new connection
-                            # ipv6
-                            if echo $nicip | grep : 2>&1 1>/dev/null
-                            then
-                                nmcli con add type infiniband con-name $nic ifname $nic ipv6.method manual ipv6.addresses $nicip
-                            else # ipv4
-                                prefix=$(convert_netmask_to_cidr $netmask)
-                                nmcli con add type infiniband con-name $nic ifname $nic ipv4.method manual ipv4.addresses $nicip/$prefix
-                            fi
-                       else # modify current connection
+                       then # modify current connection
                             # ipv6
                             if echo $nicip | grep : 2>&1 1>/dev/null
                             then
@@ -579,6 +570,15 @@ IPADDR=$nicip" > $dir/ifcfg-$nic
                             else # ipv4
                                 prefix=$(convert_netmask_to_cidr $netmask)
                                 nmcli con modify $nic type infiniband con-name $nic ifname $nic ipv4.method manual ipv4.addresses $nicip/$prefix
+                            fi
+                       else # create new connection
+                            # ipv6
+                            if echo $nicip | grep : 2>&1 1>/dev/null
+                            then
+                                nmcli con add type infiniband con-name $nic ifname $nic ipv6.method manual ipv6.addresses $nicip
+                            else # ipv4
+                                prefix=$(convert_netmask_to_cidr $netmask)
+                                nmcli con add type infiniband con-name $nic ifname $nic ipv4.method manual ipv4.addresses $nicip/$prefix
                             fi
                        fi
                    else


### PR DESCRIPTION
### The PR is to fix an issue with `configib` that fails to configure an IB connection if it already exists

### The modification include

files altered: `xCAT/postscripts/configib`

1. Take out a useless segment of `arp_ignore` and `arp_filter` that was clearing any sysctl.conf
2. Create a logic to perform `nmcli con add` if the `$nic` doesnt exist ELSE perform `nmcli con modify`
   - Otherwise an error is thrown stating a duplicate con exists with the same name and the adjustments dont occur 