### PR TITLE
Use default MaxStartups value.

### DIFF
--- a/xCAT/postscripts/remoteshell
+++ b/xCAT/postscripts/remoteshell
@@ -61,8 +61,8 @@ then
         #delete all occurance of the attribute and then add xCAT settings
         sed -i '/X11Forwarding /'d /etc/ssh/sshd_config
         echo "X11Forwarding yes" >>/etc/ssh/sshd_config
+        # delete all MaxStartups settings and use default value
         sed -i '/MaxStartups /'d /etc/ssh/sshd_config
-        echo "MaxStartups 1024" >>/etc/ssh/sshd_config
 
     if [ "$SETUPFORPCM" = "1" ]; then
         if [[ $OSVER == sle* ]];then


### PR DESCRIPTION
### The PR is to fix issue _#7493_

## Modification Includes:

## Clear `MaxStartups` sshd_config parameter.

Currently the `xCAT/postscripts/remoteshell` script unconditionally adds `MaxStartups 1024` to `/etc/ssh/sshd_config`. This setting causes some versions of openssh (notably 8.9p1, as ships with Ubuntu 22.04) to behave pathologically, making it impossible to log into a diskful node after it has finished building. Dropping the value to 1023 (or anything less than 1024) resolves the issue, as does removing the `MaxStartups` parameter entirely.

See https://lists.mindrot.org/pipermail/openssh-bugs/2022-March/023864.html for more details on the openssh bug.

### Detailed Description

This change simply removes the code in `remoteshell` setting a value for `MaxStartups`, which results in the default value being used by sshd.

This approach to fixing the issue was driven by considering the interaction between the `MaxStartups` setting and the `MaxSessions` setting - `MaxStartups` limits the number of unauthenticated client connections sshd allows before dropping all new connection attempts, and `MaxSessions` limits the number of *fully authenticated* client sessions. Assuming well-behaved clients and an sshd that can keep up with authenticating them (a reasonable expectation in an xCAT managed environment), `MaxStartups` is unlikely to have any impact; the most important limit on concurrent connections will always be `MaxSessions`.

The default value of `MaxSessions` is 10; the default value of `MaxStartups` is `10:30:100` (a maximum of 100 connections, with 30% of incoming connections being dropped after the backlog reaches 10 connections, ramping up to 100% dropped at 100 connections). These default values are quite compatible; a `MaxStartups` value of 1024 (setting a hard limit of 1024 unauthenticated connections) is very high relative to the number of available session slots.

Assuming the default value of `MaxSessions` is functional in an xCAT context, there doesn't seem to be any reason to override the default value of `MaxStartups` at all, and certainly no reason to set such a high value.

## Note

In addition to the `remoteshell` postscript, a number of other pieces of code set the same `MaxStartups` value of 1024:

- `xCAT/postscripts/setupesx:64-65`
- `xCAT/postscripts/aixremoteshell:131`
- `xCAT-server/share/xcat/netboot/add-on/statelite/add_ssh:42-43`

I have chosen to leave these cases untouched, as I currently have no reason to believe they are causing any issues.
