### PR TITLE
Sunsetting xCAT and transitioning to Confluent

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,33 @@
 
 xCAT is a toolkit for deployment and administration of clusters of all sizes.
 
+# Sunsetting xCAT and transitioning to Confluent
+
+Dear xCAT Community,
+
+As noted in our previous updates and during the informal BoF sessions at SC’23 and SC’24, the consortium has been focused on both completing the final work for xCAT and preparing for the transition to its successor.
+
+As committed, we delivered Enterprise Linux 9 (EL9) support in the xCAT 2.17 release. This represents the final planned enablement for xCAT.
+
+xCAT is now officially being sunsetted. The consortium will not provide support beyond existing platforms, and Enterprise Linux 10 (EL10) will not be supported. Active development and all new feature work have transitioned fully to **Confluent**, which we recognise as the official successor to xCAT.
+
+While xCAT will remain in maintenance mode, with community pull requests still welcome and reviewed, there will be no new features or support for future operating systems.
+
+In summary:
+
+- xCAT has delivered its final milestone with EL9 support.
+- No EL10 or future OS enablement will be added.
+- Community contributions are still accepted and reviewed.
+- All development effort is now focused on **Confluent**, the successor to xCAT.
+
+We want to sincerely thank the community for the years of contributions, support, and participation in shaping xCAT. We now look forward to continuing that journey with you in the **Confluent community**, where the future of open, vendor-agnostic cluster management will continue to grow.
+
+For more information on **Confluent** and how to get started, please visit the **Confluent**: [Project Page](https://github.com/xcat2/confluent), [Documentation](https://xcat2.github.io/confluent-docs/) or [Confluent vs xCAT comparison](https://xcat2.github.io/confluent-docs/miscellaneous/confluentvxcat/).
+
+With thanks,
+
+The xCAT Consortium
+
 # Documentation 
 
 xCAT Documentation is hosted on Read The Docs: https://xcat-docs.readthedocs.io

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,6 +22,34 @@ Go to GitHub to view the source, open issues, ask questions, and participate in 
 
 Enjoy!
 
+Sunsetting xCAT and transitioning to Confluent
+==============================================
+
+Dear xCAT Community,
+
+As noted in our previous updates and during the informal BoF sessions at SC’23 and SC’24, the consortium has been focused on both completing the final work for xCAT and preparing for the transition to its successor.
+
+As committed, we delivered Enterprise Linux 9 (EL9) support in the xCAT 2.17 release. This represents the final planned enablement for xCAT.
+
+xCAT is now officially being sunsetted. The consortium will not provide support beyond existing platforms, and Enterprise Linux 10 (EL10) will not be supported. Active development and all new feature work have transitioned fully to **Confluent**, which we recognise as the official successor to xCAT.
+
+While xCAT will remain in maintenance mode, with community pull requests still welcome and reviewed, there will be no new features or support for future operating systems.
+
+In summary:
+
+- xCAT has delivered its final milestone with EL9 support.
+- No EL10 or future OS enablement will be added.
+- Community contributions are still accepted and reviewed.
+- All development effort is now focused on **Confluent**, the successor to xCAT.
+
+We want to sincerely thank the community for the years of contributions, support, and participation in shaping xCAT. We now look forward to continuing that journey with you in the **Confluent community**, where the future of open, vendor-agnostic cluster management will continue to grow.
+
+For more information on **Confluent** and how to get started, please visit the **Confluent**: [Project Page](https://github.com/xcat2/confluent), [Documentation](https://xcat2.github.io/confluent-docs/) or [Confluent vs xCAT comparison](https://xcat2.github.io/confluent-docs/miscellaneous/confluentvxcat/).
+
+With thanks,
+
+The xCAT Consortium
+
 Table of Contents
 =================
 


### PR DESCRIPTION
# Sunsetting xCAT and transitioning to Confluent

Dear xCAT Community,

As noted in our previous updates and during the informal BoF sessions at SC’23 and SC’24, the consortium has been focused on both completing the final work for xCAT and preparing for the transition to its successor.

As committed, we delivered Enterprise Linux 9 (EL9) support in the xCAT 2.17 release. This represents the final planned enablement for xCAT.

xCAT is now officially being sunsetted. The consortium will not provide support beyond existing platforms, and Enterprise Linux 10 (EL10) will not be supported. Active development and all new feature work have transitioned fully to **Confluent**, which we recognise as the official successor to xCAT.

While xCAT will remain in maintenance mode, with community pull requests still welcome and reviewed, there will be no new features or support for future operating systems.

In summary:

- xCAT has delivered its final milestone with EL9 support.
- No EL10 or future OS enablement will be added.
- Community contributions are still accepted and reviewed.
- All development effort is now focused on **Confluent**, the successor to xCAT.

We want to sincerely thank the community for the years of contributions, support, and participation in shaping xCAT. We now look forward to continuing that journey with you in the **Confluent community**, where the future of open, vendor-agnostic cluster management will continue to grow.

For more information on **Confluent** and how to get started, please visit the **Confluent**: [Project Page](https://github.com/xcat2/confluent), [Documentation](https://xcat2.github.io/confluent-docs/) or [Confluent vs xCAT comparison](https://xcat2.github.io/confluent-docs/miscellaneous/confluentvxcat/).

With thanks,

The xCAT Consortium