### PR TITLE
fix: skip empty local-repository.tmpl in nodeset

### DIFF
--- a/xCAT-server/lib/perl/xCAT/Template.pm
+++ b/xCAT-server/lib/perl/xCAT/Template.pm
@@ -312,7 +312,7 @@ sub subvars {
                         $source .= "repo --name=pkg$c --baseurl=http://#TABLE:noderes:\$NODE:nfsserver#$httpportsuffix/$pkgdir\n"; #for rhels5.9
                     }
                     my $distrepofile="/install/postscripts/repos/$pkgdir/local-repository.tmpl";
-                    if( -f "$distrepofile"){
+                    if( -f "$distrepofile" and -s "$distrepofile"){
                         my $repofd;
                         my $repo_in_post;
                         local $/=undef;


### PR DESCRIPTION
When a `pkgdir` has no valid repodata, `Yum.pm` creates an empty `local-repository.tmpl` file. `Template.pm` then reads it and generates an empty yum repo config block in the kickstart. Adding a `-s` check skips empty template files instead of silently including them.

Revives the fix from PR #4769 which was closed without merging.

Fixes #3572
