### PR TITLE
fix: reset newcmdstart between files in xcattest load_case

### DIFF
--- a/xCAT-test/xcattest
+++ b/xCAT-test/xcattest
@@ -1229,6 +1229,7 @@ sub load_case {
             }
         }
         close($fd);
+        $newcmdstart = 0;
     }
 
     my @wrong_cases = ();


### PR DESCRIPTION
When a test case file is missing the end marker and the last line is a cmd: directive, $newcmdstart stays set. The parser then appends lines from the next file into the current command. If that next file is a shell script (like simulatorctl.sh in the testcase tree), thousands of lines of Perl/bash get concatenated and executed.

Reset $newcmdstart after closing each file to prevent state leaking between files.

Fixes #5255