### PR TITLE
fix: show useful error when mkdef is called without attributes

### DIFF
--- a/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
+++ b/xCAT-server/lib/xcat/plugins/DBobjectdefs.pm
@@ -1676,6 +1676,24 @@ sub defmk
         $error = 1;
     }
 
+    # If no object definitions ended up in FINALATTRS, there is nothing to create
+    if (!$error && !%::FINALATTRS)
+    {
+        my $rsp;
+        my $is_node_type = (grep { $_ eq "node" } @::finalTypeList) ||
+                           ($::opt_t && $::opt_t =~ /\bnode\b/);
+        if ($is_node_type)
+        {
+            $rsp->{data}->[0] = "No object definitions have been created or modified: no attributes were specified. The \'groups\' attribute is required when creating node definitions.";
+        }
+        else
+        {
+            $rsp->{data}->[0] = "No object definitions have been created or modified: no attributes were specified.";
+        }
+        xCAT::MsgUtils->message("E", $rsp, $::callback);
+        return 1;
+    }
+
     # we need a list of objects that are
     #    already defined for each type.
     foreach my $t (@::finalTypeList)

--- a/xCAT-test/autotest/testcase/mkdef/cases0
+++ b/xCAT-test/autotest/testcase/mkdef/cases0
@@ -411,3 +411,34 @@ check:rc==0
 cmd:rmdef -t osimage -o rhels7.3-test
 check:rc==0
 end
+
+start:mkdef_node_no_attrs
+description:mkdef -t node with no attributes should fail and mention groups
+label:mn_only,ci_test,db
+cmd:mkdef -t node -o testnode_noattr
+check:rc!=0
+check:output=~groups
+cmd:lsdef testnode_noattr
+check:rc!=0
+end
+
+start:mkdef_node_no_groups
+description:mkdef -t node with attributes but no groups should fail
+label:mn_only,ci_test,db
+cmd:mkdef -t node -o testnode_nogrp ip=10.0.0.99
+check:rc!=0
+check:output=~groups
+cmd:lsdef testnode_nogrp
+check:rc!=0
+cmd:rmdef -t node -o testnode_nogrp
+end
+
+start:mkdef_nonnode_no_attrs
+description:mkdef with non-node type and no attributes should fail with generic message
+label:mn_only,ci_test,db
+cmd:mkdef -t network -o testnet_noattr
+check:rc!=0
+check:output=~no attributes were specified
+cmd:rmdef -t network -o testnet_noattr
+end
+


### PR DESCRIPTION
When `mkdef` is called with an object name but no attributes (e.g. `mkdef -t node -o mynode`), `setFINALattrs` produces an empty hash and the OBJ loop has nothing to iterate. The code falls through to "0 object definitions have been created or modified" with no explanation of what went wrong.

Add a check after `setFINALattrs`: if `FINALATTRS` is empty, tell the user what's missing. For nodes, mention that '`groups`' is required.

Fixes #2765