### PR TITLE
chore: Bump actions/checkout v4 to v6 for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/xcat_test.yml
+++ b/.github/workflows/xcat_test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install dependencies
         run: sudo apt-get install -y fakeroot reprepro devscripts debhelper libcapture-tiny-perl libjson-perl libsoap-lite-perl libdbi-perl libcgi-pm-perl quilt openssh-server dpkg looptools genometools software-properties-common
       - name: Run tests


### PR DESCRIPTION
Fix the annoying node.js warning on GitHub Actions.