### PR TITLE
fix: strip redundant alternate suffix from RHEL distnames in copycds

### DIFF
--- a/xCAT-server/lib/xcat/plugins/anaconda.pm
+++ b/xCAT-server/lib/xcat/plugins/anaconda.pm
@@ -2105,6 +2105,12 @@ sub copycd
             else {
                 $distname = "rhels" . $rhel_version[-1];
             }
+            # Strip the "alternate" suffix from RHEL distnames.
+            # RHEL 7 used "alternate" for ppc64le ISOs, but the architecture
+            # is already encoded in the path (ppc64le vs ppc64), so the suffix
+            # is redundant and causes mismatches with osver() detection.
+            $distname =~ s/-alternate$//;
+
             open($dinfo, $mntpath . "/.treeinfo");
             while (<$dinfo>) {
                 chomp($_);


### PR DESCRIPTION
RHEL 7 shipped ppc64le ISOs under the "alternate" label, causing copycds to create distro paths like rhels7.6-alternate/ppc64le. This mismatched osver() which returns rhels7.6 since /etc/os-release has no knowledge of the alternate designation.

The architecture (ppc64le vs ppc64) already differentiates the builds, making the alternate suffix redundant. Strip it during auto-detection so copycds paths match osver() output.

Fixes #5593