### PR TITLE
fix: misleading plugin error message

### DIFF
--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -2091,7 +2091,8 @@ sub plugin_command {
                             chomp(my $eval_err = $@);
                             $error = "$modname: $eval_err";
                         } else {
-                            $error = "$modname: unexpected error (pid $$, $$progname)";
+                            # XS libraries (Sys::Virt, Net::SNMP) can crash without setting $@
+                            $error = "$modname plugin bug (pid $$): died without setting an error. Run xcatd -f to debug";
                         }
                         if (scalar(@nodes)) {
                             $error .= " [nodes: " . join(",", @nodes) . "]";

--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -2086,14 +2086,15 @@ sub plugin_command {
                         $@ = ""; # sometimes a child 'eval' doesn't clean up $@, if we make it this far, no non-eval bug bombed out
                     };    # REMOVEEVALFORDEBUG
                     if ($sock or $shouldbealivepid != $$) { # We shouldn't still be alive, try to send as much detail to parent as possible as to why
-                        my $error = "$modname plugin bug, pid $$, process description: '$$progname'";
+                        my $error;
                         if ($@) {
-                            $error .= " with error '$@'";
-                        } else { # Sys::Virt and perhaps Net::SNMP sometimes crashes in a way $@ won't catch..
-                            $error .= " with missing eval error, probably due to special manipulation of $@ or strange circumstances in an XS library, remove evals in xcatd marked 'REMOVEEVALFORDEBUG and run xcatd -f for more info";
+                            chomp(my $eval_err = $@);
+                            $error = "$modname: $eval_err";
+                        } else {
+                            $error = "$modname: unexpected error (pid $$, $$progname)";
                         }
-                        if (scalar(@nodes)) { # Don't know which of the nodes, so one error message warning about the possibliity..
-                            $error .= " while trying to fulfill request for the following nodes: " . join(",", @nodes);
+                        if (scalar(@nodes)) {
+                            $error .= " [nodes: " . join(",", @nodes) . "]";
                         }
                         xCAT::MsgUtils->message("S", "xcatd: $error");
                         $callback->({ error => [$error], errorcode => [1] });


### PR DESCRIPTION
This PR fixes xcat2/xcat-core#2719:

- When a plugin dies during request processing, xcatd wrapped the error in a misleading "plugin bug" message that hid the real cause
- Now passes through the actual error from the eval directly
- Covers any failure type (disk full, permission denied, etc.)
- Keeps "plugin bug" label for the rare case where XS libraries crash without setting `$@ (Sys::Virt, Net::SNMP)`

Before: `xnba plugin bug, pid 32640, process description: 'xcatd SSL: ...' with error 'Died at ...'`
After: `xnba: No space left on device [nodes: c910f04x35]`

## Test plan

Tested on a live xCAT 2.17.0 system:

```
# Normal operations with patched xcatd
$ rpower power9bmc state
power9bmc: on

$ lsdef power9bmc -i mgt,bmc
Object name: power9bmc
    bmc=10.20.0.56
    mgt=openbmc

# Injected die "No space left on device" into openbmc preprocess_request
$ rpower power9bmc state
Error: [cloyster]: openbmc: No space left on device at
  /opt/xcat/lib/perl/xCAT_plugin/openbmc.pm line 763. [nodes: power9bmc]

# Restored plugin, normal operation confirmed working again
$ rpower power9bmc state
power9bmc: on
```