### PR TITLE
fix: invalidate NodeRange caches inherited across fork

### DIFF
--- a/perl-xCAT/xCAT/NodeRange.pm
+++ b/perl-xCAT/xCAT/NodeRange.pm
@@ -41,8 +41,11 @@ my $glstamp         = 0;
 my $allnodesetstamp = 0;
 my $allgrphashstamp = 0;
 my %allgrphash;
-my $retaincache  = 0;
-my $recurselevel = 0;
+my $retaincache      = 0;
+my $recurselevel     = 0;
+my $nodeset_pid      = 0;
+my $grplist_pid      = 0;
+my $allgrphash_pid   = 0;
 
 my @cachedcolumns;
 
@@ -74,6 +77,9 @@ sub reset_db {
     #workaround, something seems to be trying to use a corrupted reference to grptab
     #this allows init_dbworker to reset the object
     $grptab = 0;
+    $nodeset_pid = 0;
+    $grplist_pid = 0;
+    $allgrphash_pid = 0;
 }
 
 sub nodesbycriteria {
@@ -200,7 +206,8 @@ sub nodesbycriteria {
 sub expandatom {
     my $atom = shift;
     if ($recurselevel > 4096) { die "NodeRange seems to be hung on evaluating $atom, recursion limit hit"; }
-    unless (scalar(@allnodeset) and (($allnodesetstamp + 5) > time())) { #Build a cache of all nodes, some corner cases will perform worse, but by and large it will do better.  We could do tests to see where the breaking points are, and predict how many atoms we have to evaluate to mitigate, for now, implement the strategy that keeps performance from going completely off the rails
+    unless (scalar(@allnodeset) and (($allnodesetstamp + 5) > time()) and $nodeset_pid == $$) { #Build a cache of all nodes, some corner cases will perform worse, but by and large it will do better.  We could do tests to see where the breaking points are, and predict how many atoms we have to evaluate to mitigate, for now, implement the strategy that keeps performance from going completely off the rails
+        $nodeset_pid = $$;
         $allnodesetstamp = time();
         $nodelist->_set_use_cache(1);
         @allnodeset = $nodelist->getAllAttribs('node', 'groups');
@@ -234,7 +241,8 @@ sub expandatom {
         unless ($grptab) {
             $grptab = xCAT::Table->new('nodegroup');
         }
-        if ($grptab and (($glstamp < (time() - 5)) or (not $didgrouplist and not scalar @grplist))) {
+        if ($grptab and (($glstamp < (time() - 5)) or $grplist_pid != $$ or (not $didgrouplist and not scalar @grplist))) {
+            $grplist_pid = $$;
             $didgrouplist = 1;
             $glstamp      = time();
             my $grplist_ptr = $grptab->getAllEntries();
@@ -270,7 +278,8 @@ sub expandatom {
         # The atom is not a dynamic node group, is it a static node group???
         if (!$isdynamicgrp)
         {
-            unless (scalar %allgrphash and (time() < ($allgrphashstamp + 5))) { #build a group membership cache
+            unless (scalar %allgrphash and (time() < ($allgrphashstamp + 5)) and $allgrphash_pid == $$) { #build a group membership cache
+                $allgrphash_pid = $$;
                 $allgrphashstamp = time();
                 %allgrphash      = ();
                 my $nlent;
@@ -488,6 +497,9 @@ sub retain_cache { #A semi private operation to be used *ONLY* in the interestin
     unless ($retaincache) { #take a call to retain_cache(0) to also mean that any existing
                             #cache must be zapped
         if ($nodelist) { $nodelist->_build_cache(1); }
+        $nodeset_pid     = 0;
+        $grplist_pid     = 0;
+        $allgrphash_pid  = 0;
         $glstamp         = 0;
         $allnodesetstamp = 0;
         $allgrphashstamp = 0;


### PR DESCRIPTION
This PR aims to fix the annoying CI/CD error due to a race condition, while fixing a real bug that may occur in production.

- Fix non-deterministic CI failures in group-definition regression tests (`chdef_group`, `mkdef_group`, `rmdef_group`) caused by stale in-memory caches surviving across `fork()`.
- Track the PID at cache-build time in `NodeRange.pm` and force a fresh database read whenever a forked child detects it inherited caches from its parent.

## Root Cause

`xcatd` forks a child process for each plugin request. `NodeRange.pm` maintains module-level caches (`@allnodeset`, `%allgrphash`, `@grplist`) with a 5-second TTL. When a child is forked, it inherits these caches **and their timestamps** from the parent process.

If the parent populated caches within the past 5 seconds (from handling a prior request), the forked child treats them as valid and skips the database read. This means database changes committed between cache population and the fork—such as `mkdef -t group` updating the `nodelist.groups` column—are invisible to the child.

The `lsdef -s <groupname>` test step calls `noderange(groupname, 0)` inside the plugin child. With a stale `%allgrphash`, the group name cannot be resolved to its members. Since `verify=0`, `expandatom` returns the group name as a literal, the plugin looks for a **node** with that name, and fails with:

```
Error: Could not find an object named 'testgrp1' of type 'node'.
```

## Why It Is Non-Deterministic

- Tests pass when >5 seconds elapse between group creation and `lsdef` (cache expires naturally).
- Tests pass when the parent had no recent NodeRange activity (no inherited cache).
- Tests fail when the CI runner is fast and the parent served another request within 5 seconds, populating a cache that the child then inherits stale.

## Fix

Add a `$cachepid` variable that records `$$` at cache-build time. All three cache-validity checks now also require `$cachepid == $$`, ensuring forked children always rebuild from the database on first use.

## Notes

This one was extremely hard to find, and I had to ask Mr. Claude for help.