### PR TITLE
fix: silent failure with no site master attribute

### DIFF
--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -1885,7 +1885,8 @@ sub plugin_command {
             }
         }
     }
-    if ($req->{node} and not(defined xCAT::TableUtils->get_site_attribute('master'))) {
+    my $sitemaster = xCAT::TableUtils->get_site_attribute('master');
+    if ($req->{node} and not($sitemaster)) {
         my $rsp = { error => ["site.master is not set, unable to dispatch '$req->{command}->[0]'"], errorcode => [1] };
         $rsp->{serverdone} = [undef];
         if ($sock) {

--- a/xCAT-server/sbin/xcatd
+++ b/xCAT-server/sbin/xcatd
@@ -1885,6 +1885,17 @@ sub plugin_command {
             }
         }
     }
+    if ($req->{node} and not(defined xCAT::TableUtils->get_site_attribute('master'))) {
+        my $rsp = { error => ["site.master is not set, unable to dispatch '$req->{command}->[0]'"], errorcode => [1] };
+        $rsp->{serverdone} = [undef];
+        if ($sock) {
+            send_response($rsp, $sock);
+        } else {
+            $callback->($rsp);
+        }
+        return;
+    }
+
     my %xcatresponses = (xcatresponse => []);
     $plugin_numchildren = 0;
     %plugin_children    = ();


### PR DESCRIPTION
This PR fixes xcat2/xcat-core#6157:

- Hardware control commands (rpower, rinv, etc.) silently return no output when `site.master` is empty (#6157)
- The original fix (#6074) was reverted (#6158) because the warning repeated per-node with the wrong hostname
- This fix checks once in `plugin_command` before dispatching to plugins, so the error appears exactly once

## Test plan

Tested on POWER9 AC922 (cloyster):

```
# chdef -t site master=
# rpower power9bmc state
Error: site.master is not set, unable to dispatch 'rpower'
# echo $?
1

# chdef -t site master=172.21.1.10
# rpower power9bmc state
power9bmc: on

# lsdef power9bmc -i mgt   (with empty site.master - non-node command, unaffected)
Object name: power9bmc
    mgt=openbmc
```

