### PR TITLE
fix: IPMI VLAN disable

### DIFF
--- a/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
+++ b/docs/source/guides/admin-guides/references/man1/rspconfig.1.rst
@@ -450,7 +450,7 @@ OPTIONS
 
 \ **vlan**\ 
  
- Get or set vlan ID. For get vlan ID, if vlan is not enabled, 'BMC VLAN disabled' will be displayed. For set vlan ID, the valid value are [1-4096].
+ Get or set VLAN ID. Valid VLAN IDs are 1-4094. On IPMI managed nodes, use \ **vlan=off**\  or \ **vlan=disable**\  to disable VLAN tagging.
  
 
 

--- a/xCAT-client/pods/man1/rspconfig.1.pod
+++ b/xCAT-client/pods/man1/rspconfig.1.pod
@@ -352,7 +352,7 @@ Get or set hostname on the service processor.
 
 =item B<vlan>
 
-Get or set vlan ID. For get vlan ID, if vlan is not enabled, 'BMC VLAN disabled' will be displayed. For set vlan ID, the valid value are [1-4096].
+Get or set VLAN ID. Valid VLAN IDs are 1-4094. On IPMI managed nodes, use B<vlan=off> or B<vlan=disable> to disable VLAN tagging.
 
 =item B<ipsrc>
 

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -895,10 +895,10 @@ sub setnetinfo {
     if ($subcommand eq "thermprofile") {
         return idpxthermprofile($argument);
     }
-    if ($subcommand eq "alert" and $argument eq "on" or $argument =~ /^en/ or $argument =~ /^enable/) {
+    if ($subcommand eq "alert" and ($argument =~ /^(on|en|enable|enabled)$/i)) {
         $netfun = 0x4;
         @cmd = (0x12, 0x9, 0x1, 0x18, 0x11, 0x00);
-    } elsif ($subcommand eq "alert" and $argument eq "off" or $argument =~ /^dis/ or $argument =~ /^disable/) {
+    } elsif ($subcommand eq "alert" and ($argument =~ /^(off|dis|disable|disabled)$/i)) {
         $netfun = 0x4;
         @cmd = (0x12, 0x9, 0x1, 0x10, 0x11, 0x00);
     }

--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -946,18 +946,22 @@ sub setnetinfo {
         }
         @cmd = (0x01, $channel_number, 12, @mask);
     } elsif ($subcommand =~ m/vlan/) {
-        unless ( int($argument) == $argument ) {
-            $callback->({ errorcode => [1], error => ["The input $argument is invalid, please input an integer"] });
-            return;
+        if ($argument =~ /^(off|disable|disabled)$/i) {
+            @cmd = (0x01, $channel_number, 0x14, 0x00, 0x00);
+        } else {
+            unless ( $argument =~ /^\d+$/ ) {
+                $callback->({ errorcode => [1], error => ["The input $argument is invalid, please input an integer or 'off'"] });
+                return;
+            }
+            unless (($argument>=1) && ($argument<=4094)) {
+                $callback->({ errorcode => [1], error => ["The input $argument is invalid, valid value [1-4094] or 'off'"] });
+                return;
+            }
+            my @vlanparam = ();
+            $vlanparam[0] = ($argument & 0xff);
+            $vlanparam[1] = 0x80 | (($argument & 0xf00) >> 8);
+            @cmd = (0x01, $channel_number, 0x14, @vlanparam);
         }
-        unless (($argument>=1) && ($argument<=4096)) {
-            $callback->({ errorcode => [1], error => ["The input $argument is invalid, valid value [1-4096]"] });
-            return;
-        }
-        my @vlanparam = ();
-        $vlanparam[0] = ($argument & 0xff);
-        $vlanparam[1] = 0x80 | (($argument & 0xf00) >> 8);
-        @cmd = (0x01, $channel_number, 0x14, @vlanparam);
     } elsif ($subcommand =~ m/ip/ and $argument =~ m/dhcp/) {
         @cmd = (0x01, $channel_number, 0x4, 0x2);
     } elsif ($subcommand =~ m/ip/) {


### PR DESCRIPTION
This PR fixes xcat2/xcat-core#3725:

Changes:
- Accept `vlan=off`, `vlan=disable`, `vlan=disabled` to clear VLAN tagging (standard IPMI parameter 0x14)
- Fix valid VLAN range from 1-4096 to 1-4094 (IEEE 802.1Q)
- Use strict digit matching (`/^\d+$/`) to reject malformed inputs like `123abc`
- Fix alert handler precedence: parenthesize `or` alternatives so they're scoped to `$subcommand eq "alert"`
- Tighten alert input matching to exact tokens while preserving `en`/`dis` abbreviations used by snmpmon.pm

## Test plan

Tested on Supermicro IPMI BMC:

```
# Before fix: vlan=0 rejected, no way to disable
$ rspconfig smcbmc vlan=0
Error: The input 0 is invalid, valid value [1-4096]

# After fix: set and disable VLAN
$ rspconfig smcbmc vlan=100
smcbmc: BMC VLAN ID enabled: 100
$ rspconfig smcbmc vlan=off
smcbmc: BMC VLAN disabled

# BMC accessible after all operations
$ rspconfig smcbmc ip
smcbmc: BMC IP: 10.20.0.51
$ rspconfig smcbmc vlan
smcbmc: BMC VLAN disabled
```
