### PR TITLE
fix: Improve rspconfig SET readback and fix backupgateway SET target

### DIFF
--- a/xCAT-server/lib/xcat/plugins/ipmi.pm
+++ b/xCAT-server/lib/xcat/plugins/ipmi.pm
@@ -936,15 +936,25 @@ sub setnetinfo {
             foreach (0 .. 3) {
                 $mask[$_] = $mask[$_] + 0;
             }
+            $sessdata->{setnetinfo_value} = join(".", @mask);
             @cmd = (0x01, $channel_number, 0x6, @mask);
         }
-    } elsif ($subcommand =~ m/gateway/ and $argument) {
+    } elsif ($subcommand eq "gateway" and $argument) {
         my $gw = inet_ntoa(inet_aton($argument));
         my @mask = split /\./, $gw;
         foreach (0 .. 3) {
             $mask[$_] = $mask[$_] + 0;
         }
-        @cmd = (0x01, $channel_number, 12, @mask);
+        $sessdata->{setnetinfo_value} = $gw;
+        @cmd = (0x01, $channel_number, 0x0C, @mask);
+    } elsif ($subcommand eq "backupgateway" and $argument) {
+        my $gw = inet_ntoa(inet_aton($argument));
+        my @mask = split /\./, $gw;
+        foreach (0 .. 3) {
+            $mask[$_] = $mask[$_] + 0;
+        }
+        $sessdata->{setnetinfo_value} = $gw;
+        @cmd = (0x01, $channel_number, 0x0E, @mask);
     } elsif ($subcommand =~ m/vlan/) {
         unless ( int($argument) == $argument ) {
             $callback->({ errorcode => [1], error => ["The input $argument is invalid, please input an integer"] });
@@ -975,6 +985,7 @@ sub setnetinfo {
         foreach (0 .. 3) {
             $mask[$_] = $mask[$_] + 0;
         }
+        $sessdata->{setnetinfo_value} = $mip;
         @cmd = (0x01, $channel_number, 0x3, @mask);
     }
 
@@ -1165,34 +1176,17 @@ sub getnetinfo_response {
         } else {
             xCAT::SvrUtils::sendmsg("BMC VLAN disabled" . $bmcifo, $callback, $sessdata->{node}, %allerrornodes);
         }
-    } elsif ($subcommand eq "ip") {
-        xCAT::SvrUtils::sendmsg(sprintf("$format %d.%d.%d.%d" . $bmcifo,
-                "BMC IP:",
-                $returnd[2],
-                $returnd[3],
-                $returnd[4],
-                $returnd[5]), $callback, $sessdata->{node}, %allerrornodes);
-    } elsif ($subcommand eq "netmask") {
-        xCAT::SvrUtils::sendmsg(sprintf("$format %d.%d.%d.%d" . $bmcifo,
-                "BMC Netmask:",
-                $returnd[2],
-                $returnd[3],
-                $returnd[4],
-                $returnd[5]), $callback, $sessdata->{node}, %allerrornodes);
-    } elsif ($subcommand eq "gateway") {
-        xCAT::SvrUtils::sendmsg(sprintf("$format %d.%d.%d.%d" . $bmcifo,
-                "BMC Gateway:",
-                $returnd[2],
-                $returnd[3],
-                $returnd[4],
-                $returnd[5]), $callback, $sessdata->{node}, %allerrornodes);
-    } elsif ($subcommand eq "backupgateway") {
-        xCAT::SvrUtils::sendmsg(sprintf("$format %d.%d.%d.%d" . $bmcifo,
-                "BMC Backup Gateway:",
-                $returnd[2],
-                $returnd[3],
-                $returnd[4],
-                $returnd[5]), $callback, $sessdata->{node}, %allerrornodes);
+    } elsif ($subcommand =~ /^(ip|netmask|gateway|backupgateway)$/) {
+        my %labels = (ip => "BMC IP:", netmask => "BMC Netmask:", gateway => "BMC Gateway:", backupgateway => "BMC Backup Gateway:");
+        my $current = sprintf("%d.%d.%d.%d", $returnd[2], $returnd[3], $returnd[4], $returnd[5]);
+        my $requested = delete $sessdata->{setnetinfo_value};
+        if (defined($requested) and $requested ne $current) {
+            xCAT::SvrUtils::sendmsg(sprintf("$format %s (requested %s, not yet reflected)" . $bmcifo,
+                    $labels{$subcommand}, $current, $requested), $callback, $sessdata->{node}, %allerrornodes);
+        } else {
+            xCAT::SvrUtils::sendmsg(sprintf("$format %s" . $bmcifo,
+                    $labels{$subcommand}, $current), $callback, $sessdata->{node}, %allerrornodes);
+        }
     } elsif ($subcommand eq "community") {
         my $text = sprintf("$format ", "SP SNMP Community:");
         my $l = 2;


### PR DESCRIPTION
This PR fixes xcat2/xcat-core#3445:

- On Supermicro (and potentially other) BMCs, a GET immediately after SET returns the old value
- `rspconfig` output was misleading: showed old value after setting new one
- Also fixes `backupgateway` SET writing to wrong IPMI parameter (`0x0C` instead of `0x0E`)

Changes:
- Store canonical SET value after normalization, compare with GET readback
- When they differ, annotate: `BMC Gateway: 10.20.0.1 (requested 10.20.0.254, not yet reflected)`
- Consolidate ip/netmask/gateway/backupgateway display into one block
- Fix backupgateway SET to write parameter `0x0E` (was silently writing primary gateway `0x0C`)
- Readback comparison covers all four: ip, netmask, gateway, backupgateway

## Test plan

All tests on Supermicro IPMI BMC:

```
# gateway SET (stale readback on SMC firmware)
$ rspconfig smcbmc gateway=10.20.0.254
smcbmc: BMC Gateway: 10.20.0.1 (requested 10.20.0.254, not yet reflected)
# inband confirms SET worked:
$ ipmitool lan print 1 | grep Gateway
Default Gateway IP      : 10.20.0.254

# ip SET (static, stale readback)
$ rspconfig smcbmc ip=10.20.0.52
smcbmc: BMC IP: 10.20.0.51 (requested 10.20.0.52, not yet reflected)
# inband confirms SET worked:
$ ipmitool lan print 1 | grep IP
IP Address Source       : Static Address
IP Address              : 10.20.0.52

# backupgateway SET (now writes to correct parameter 0x0E)
$ rspconfig smcbmc backupgateway=10.20.0.2
smcbmc: BMC Backup Gateway: 10.20.0.2
# inband confirms backup gateway changed, primary untouched:
$ ipmitool lan print 1 | grep -i gateway
Default Gateway IP      : 10.20.0.1
Backup Gateway IP       : 10.20.0.2

# plain reads unchanged
$ rspconfig smcbmc ip
smcbmc: BMC IP: 10.20.0.51
$ rspconfig smcbmc netmask
smcbmc: BMC Netmask: 255.255.255.0
$ rspconfig smcbmc gateway
smcbmc: BMC Gateway: 10.20.0.1
$ rspconfig smcbmc backupgateway
smcbmc: BMC Backup Gateway: 0.0.0.0
```
