### PR TITLE
fix: disable Apache directory indexing on /install and /tftpboot

### DIFF
--- a/docs/source/advanced/security/apache_hardening.rst
+++ b/docs/source/advanced/security/apache_hardening.rst
@@ -1,0 +1,172 @@
+Apache Hardening
+================
+
+xCAT uses Apache HTTP Server to serve install media, postscripts, and boot
+files to nodes during provisioning. The default configuration prioritizes
+ease of deployment, but administrators should apply the hardening measures
+below to reduce the attack surface.
+
+Directory Indexing Disabled by Default
+--------------------------------------
+
+Starting with xCAT 2.18, directory indexing (``Options Indexes``) is disabled
+by default for the ``/install`` and ``/tftpboot`` directories. This prevents
+unauthenticated users from browsing directory listings and discovering file
+paths. All provisioning workflows continue to work because nodes fetch files
+by their known paths.
+
+If you are upgrading from an earlier version of xCAT, update your Apache
+configuration manually. Remove ``Indexes`` from the ``/install`` and
+``/tftpboot`` blocks, but add explicit exceptions for the directories that
+provisioning scripts crawl recursively.
+
+**Apache 2.4** (RHEL 7+, SLES 12+, Ubuntu 16.04+)::
+
+    # /etc/httpd/conf.d/xcat.conf
+    <Directory "/tftpboot">
+        Options FollowSymLinks Includes MultiViews
+        AllowOverride None
+        Require all granted
+    </Directory>
+    <Directory "/install">
+        Options FollowSymLinks Includes MultiViews
+        AllowOverride None
+        Require all granted
+    </Directory>
+    <Directory "/install/postscripts">
+        Options Indexes FollowSymLinks
+        AllowOverride None
+        Require all granted
+    </Directory>
+    <Directory "/install/post">
+        Options Indexes FollowSymLinks
+        AllowOverride None
+        Require all granted
+    </Directory>
+
+**Apache 2.2** (RHEL 6, SLES 11)::
+
+    # /etc/httpd/conf.d/xcat.conf
+    <Directory "/tftpboot">
+        Options FollowSymLinks Includes MultiViews
+        AllowOverride None
+        Order allow,deny
+        Allow from all
+    </Directory>
+    <Directory "/install">
+        Options FollowSymLinks Includes MultiViews
+        AllowOverride None
+        Order allow,deny
+        Allow from all
+    </Directory>
+    <Directory "/install/postscripts">
+        Options Indexes FollowSymLinks
+        AllowOverride None
+        Order allow,deny
+        Allow from all
+    </Directory>
+    <Directory "/install/post">
+        Options Indexes FollowSymLinks
+        AllowOverride None
+        Order allow,deny
+        Allow from all
+    </Directory>
+
+.. warning::
+
+   Do not remove ``Indexes`` from ``/install/postscripts`` or
+   ``/install/post``. xCAT provisioning scripts use recursive ``wget`` to
+   download all files from these directories and depend on Apache directory
+   listings to discover file paths.
+
+Sensitive Directories
+---------------------
+
+The following directories under ``/install`` may contain sensitive data and
+should be protected with restrictive filesystem permissions:
+
+``/install/custom/``
+    Custom postscripts, templates, and package lists. May contain hardcoded
+    credentials or internal configuration details.
+
+``/install/syncfiles/``
+    Files synchronized to nodes. May include password files, SSL certificates,
+    or application secrets.
+
+``/install/autoinst/``
+    Generated kickstart and preseed files. Contains root password hashes and
+    full network configuration for each node. Nodes fetch these over HTTP
+    during installation, so filesystem permissions cannot be restricted without
+    breaking provisioning. Use IP-based access control (see below) to limit
+    access to the management network instead.
+
+Set restrictive permissions where possible::
+
+    chmod 750 /install/custom
+    chmod 750 /install/syncfiles
+
+.. note::
+
+   Do not restrict filesystem permissions on ``/install/postscripts``,
+   ``/install/autoinst``, or the OS media directories (e.g.,
+   ``/install/rhels9/``), as nodes require HTTP access to these during
+   provisioning. Protect these paths with network-level controls instead.
+
+Database Backups
+----------------
+
+Never store xCAT database backups under ``/install``. The database contains
+BMC credentials, password table entries, and full cluster topology. Store
+backups in a directory not served by Apache, for example::
+
+    dumpxCATdb -p /root/xcat-backups
+
+Network Binding
+---------------
+
+By default, Apache listens on all interfaces. In environments where the
+management network is separate from other networks, bind Apache to the
+management interface only::
+
+    # /etc/httpd/conf/httpd.conf
+    Listen 10.0.0.1:80
+
+Replace ``10.0.0.1`` with the management node's IP on the provisioning
+network.
+
+IP-Based Access Control
+-----------------------
+
+For additional protection, restrict access to the provisioning subnet::
+
+    # Apache 2.4+
+    <Directory "/install">
+        Options FollowSymLinks Includes MultiViews
+        AllowOverride None
+        Require ip 10.0.0.0/16
+    </Directory>
+    <Directory "/install/postscripts">
+        Options Indexes FollowSymLinks
+        AllowOverride None
+        Require ip 10.0.0.0/16
+    </Directory>
+    <Directory "/install/post">
+        Options Indexes FollowSymLinks
+        AllowOverride None
+        Require ip 10.0.0.0/16
+    </Directory>
+
+Replace ``10.0.0.0/16`` with your management network CIDR in all blocks.
+This ensures only nodes on the provisioning network can access install media.
+
+.. note::
+
+   If ``linuximage.otherpkgdir`` points to a custom path under ``/install``
+   outside of ``/install/post`` (e.g., ``/install/custom/mypkgs``), add an
+   additional ``<Directory>`` block for that path with ``Options Indexes``
+   to allow recursive package downloads.
+
+.. warning::
+
+   If service nodes or hierarchical xCAT setups are in use, ensure all service
+   node IPs are included in the allowed range.

--- a/docs/source/advanced/security/index.rst
+++ b/docs/source/advanced/security/index.rst
@@ -8,3 +8,4 @@ The security of a system covers a wide range of elements, from the security of s
 
    ssl_config.rst
    security.rst
+   apache_hardening.rst

--- a/xCAT/xcat.conf
+++ b/xCAT/xcat.conf
@@ -8,13 +8,25 @@ AliasMatch ^/install/(.*)$ "/install/$1"
 AliasMatch ^/tftpboot/(.*)$ "/tftpboot/$1"
 
 <Directory "/tftpboot">
-    Options Indexes +FollowSymLinks +Includes MultiViews
+    Options FollowSymLinks Includes MultiViews
     AllowOverride None
     Order allow,deny
     Allow from all
 </Directory>
 <Directory "/install">
-    Options Indexes +FollowSymLinks +Includes MultiViews
+    Options FollowSymLinks Includes MultiViews
+    AllowOverride None
+    Order allow,deny
+    Allow from all
+</Directory>
+<Directory "/install/postscripts">
+    Options Indexes FollowSymLinks
+    AllowOverride None
+    Order allow,deny
+    Allow from all
+</Directory>
+<Directory "/install/post">
+    Options Indexes FollowSymLinks
     AllowOverride None
     Order allow,deny
     Allow from all

--- a/xCAT/xcat.conf.apach24
+++ b/xCAT/xcat.conf.apach24
@@ -8,12 +8,22 @@ AliasMatch ^/install/(.*)$ "/install/$1"
 AliasMatch ^/tftpboot/(.*)$ "/tftpboot/$1"
 
 <Directory "/tftpboot">
-    Options Indexes FollowSymLinks Includes MultiViews
+    Options FollowSymLinks Includes MultiViews
     AllowOverride None
     Require all granted
 </Directory>
 <Directory "/install">
-    Options Indexes FollowSymLinks Includes MultiViews
+    Options FollowSymLinks Includes MultiViews
+    AllowOverride None
+    Require all granted
+</Directory>
+<Directory "/install/postscripts">
+    Options Indexes FollowSymLinks
+    AllowOverride None
+    Require all granted
+</Directory>
+<Directory "/install/post">
+    Options Indexes FollowSymLinks
     AllowOverride None
     Require all granted
 </Directory>

--- a/xCATsn/xcat.conf
+++ b/xCATsn/xcat.conf
@@ -8,13 +8,25 @@ AliasMatch ^/install/(.*)$ "/install/$1"
 AliasMatch ^/tftpboot/(.*)$ "/tftpboot/$1"
 
 <Directory "/tftpboot">
-    Options Indexes +FollowSymLinks +Includes MultiViews
+    Options FollowSymLinks Includes MultiViews
     AllowOverride None
     Order allow,deny
     Allow from all
 </Directory>
 <Directory "/install">
-    Options Indexes +FollowSymLinks +Includes MultiViews
+    Options FollowSymLinks Includes MultiViews
+    AllowOverride None
+    Order allow,deny
+    Allow from all
+</Directory>
+<Directory "/install/postscripts">
+    Options Indexes FollowSymLinks
+    AllowOverride None
+    Order allow,deny
+    Allow from all
+</Directory>
+<Directory "/install/post">
+    Options Indexes FollowSymLinks
     AllowOverride None
     Order allow,deny
     Allow from all

--- a/xCATsn/xcat.conf.apach24
+++ b/xCATsn/xcat.conf.apach24
@@ -8,12 +8,22 @@ AliasMatch ^/install/(.*)$ "/install/$1"
 AliasMatch ^/tftpboot/(.*)$ "/tftpboot/$1"
 
 <Directory "/tftpboot">
-    Options Indexes FollowSymLinks Includes MultiViews
+    Options FollowSymLinks Includes MultiViews
     AllowOverride None
     Require all granted
 </Directory>
 <Directory "/install">
-    Options Indexes FollowSymLinks Includes MultiViews
+    Options FollowSymLinks Includes MultiViews
+    AllowOverride None
+    Require all granted
+</Directory>
+<Directory "/install/postscripts">
+    Options Indexes FollowSymLinks
+    AllowOverride None
+    Require all granted
+</Directory>
+<Directory "/install/post">
+    Options Indexes FollowSymLinks
     AllowOverride None
     Require all granted
 </Directory>


### PR DESCRIPTION
This PR disables Apache directory indexing (autoindex) on `/install` and `/tftpboot` to prevent unauthenticated information disclosure. Provisioning-critical directories that require recursive `wget` access retain explicit `Indexes` exceptions.

Accordingly to #7450: The default xCAT Apache config ships with `Options Indexes` on `/install` and `/tftpboot`, allowing anyone with network access to browse the full directory tree — including postscripts, CA certificates, SSH authorized_keys, and (in production) kickstart files with password hashes.

**Fix:**
- Remove `Indexes` from parent `/install` and `/tftpboot` directory blocks
- Add targeted `Indexes` exceptions for `/install/postscripts` and `/install/post` (required by `xcatdsklspost` and `otherpkgs` recursive wget)
- Use absolute `Options` directives to prevent inheriting unsafe parent settings
- All four shipped config variants updated (MN/SN × Apache 2.2/2.4)
- New Apache hardening documentation with upgrade instructions for both Apache versions

## What remains indexed (required for provisioning)

| Path | Reason |
|------|--------|
| `/install/postscripts/` | `xcatdsklspost`, `post.xcat`, `cumulusztp` use recursive wget |
| `/install/post/` | `otherpkgs` uses recursive wget for package directories |
| `/opt/xcat/share/doc/` | xcat-doc browsing (harmless) |

## What is now blocked (403 on directory listing)

| Path | Previously exposed |
|------|-------------------|
| `/install/` | Full tree listing |
| `/install/custom/` | Custom scripts, potential credentials |
| `/install/autoinst/` | Kickstart files with password hashes |
| `/tftpboot/` | PXE configs, boot topology |

Direct file access by known path continues to work for all paths.

## Test cases:

- [x] `apachectl configtest` — Syntax OK
- [x] `/install/` returns 403 (directory listing blocked)
- [x] `/tftpboot/` returns 403 (directory listing blocked)
- [x] `/install/postscripts/` returns 200 with full listing (recursive wget works)                    
