### PR TITLE
feat: Use systemd instead of legacy initscripts

### DIFF
--- a/perl-xCAT/debian/rules
+++ b/perl-xCAT/debian/rules
@@ -36,8 +36,8 @@ binary-arch: build install
 	dh_installdocs
 #	dh_installexamples
 	dh_install -X".svn"
-	chmod 644 `pwd`/debian/perl-xcat/opt/xcat/lib/perl/xCAT/*
-	chmod 755 `pwd`/debian/perl-xcat/opt/xcat/lib/perl/xCAT/data
+	find `pwd`/debian/perl-xcat/opt/xcat/lib/perl/xCAT -type d -exec chmod 755 {} +
+	find `pwd`/debian/perl-xcat/opt/xcat/lib/perl/xCAT -type f -exec chmod 644 {} +
 	chmod 644 `pwd`/debian/perl-xcat/opt/xcat/share/doc/packages/perl-xCAT/*
 	chmod 644 `pwd`/debian/perl-xcat/opt/xcat/README
 	chmod 644 `pwd`/debian/perl-xcat/opt/xcat/share/man/man5/*
@@ -66,7 +66,7 @@ binary-arch: build install
 	dh_shlibdeps
 	dh_gencontrol
 	dh_md5sums
-	dh_builddeb
+	dh_builddeb -- -Zgzip
 
 binary: binary-indep binary-arch
 .PHONY: build clean binary-indep binary-arch binary install configure

--- a/perl-xCAT/perl-xCAT.spec
+++ b/perl-xCAT/perl-xCAT.spec
@@ -60,9 +60,8 @@ mkdir -p $RPM_BUILD_ROOT/%{prefix}/share/man/man7
 mkdir -p $RPM_BUILD_ROOT/%{prefix}/share/doc/man7
 
 cp -r xCAT/* $RPM_BUILD_ROOT/%{prefix}/lib/perl/xCAT/
-chmod 644 $RPM_BUILD_ROOT/%{prefix}/lib/perl/xCAT/*
-chmod 755 $RPM_BUILD_ROOT/%{prefix}/lib/perl/xCAT/data
-chmod 644 $RPM_BUILD_ROOT/%{prefix}/lib/perl/xCAT/data/*
+find $RPM_BUILD_ROOT/%{prefix}/lib/perl/xCAT -type d -exec chmod 755 {} +
+find $RPM_BUILD_ROOT/%{prefix}/lib/perl/xCAT -type f -exec chmod 644 {} +
 
 
 # For now, don't ship these plugins on AIX, to avoid AIX dependency error.
@@ -153,4 +152,3 @@ exit 0
 
 * Wed Jan 24 2007 Jarrod Johnson <jbjohnso@us.ibm.com>
 -It begins
-

--- a/xCAT-client/debian/postrm
+++ b/xCAT-client/debian/postrm
@@ -25,7 +25,7 @@ case "$1" in
 
     remove)
        if [ -f "/proc/cmdline" ]; then   # prevent running it during install into chroot image
-             rm /etc/profile.d/xcat.*
+             rm -f /etc/profile.d/xcat.*
        fi
     ;;
 

--- a/xCAT-client/debian/rules
+++ b/xCAT-client/debian/rules
@@ -71,9 +71,9 @@ binary-arch:
 	dh_makeshlibs
 	dh_installdeb
 	dh_shlibdeps
-	dh_gencontrol
+	dh_gencontrol -- -Vperl:Depends=perl
 	dh_md5sums
-	dh_builddeb
+	dh_builddeb -- -Zgzip
 
 binary: binary-indep binary-arch
 .PHONY: build clean binary-indep binary-arch binary install configure

--- a/xCAT-server/debian/postinst
+++ b/xCAT-server/debian/postinst
@@ -5,6 +5,11 @@
 
 set -e
 
+xcat_can_use_systemctl()
+{
+    [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1
+}
+
 # summary of how this script can be called:
 #        * <postinst> `configure' <most-recently-configured-version>
 #        * <old-postinst> `abort-upgrade' <new version>
@@ -22,26 +27,25 @@ case "$1" in
     configure)
         . /etc/profile.d/xcat.sh
         if [ -f /tmp/xCAT-server_upgrade.tmp ]; then
-          if [ -x /lib/systemd/systemd ]; then
+          if xcat_can_use_systemctl; then
             if [ -f /run/systemd/generator.late/xcatd.service ]; then
                 # To cover the case upgrade from no xcatd systemd unit file (cannot enable by default for HA case)
-                ls /etc/rc?.d/S??xcatd >/dev/null 2>&1
-                if [ "$?" = "0" ]; then
+                if ls /etc/rc?.d/S??xcatd >/dev/null 2>&1; then
                    [ -x /usr/sbin/update-rc.d ] && /usr/sbin/update-rc.d xcatd remove
-                   /bin/systemctl daemon-reload
-                   /bin/systemctl enable xcatd.service
+                   systemctl daemon-reload
+                   systemctl enable xcatd.service
                 fi
             else
-                /bin/systemctl daemon-reload
+                systemctl daemon-reload
             fi
           fi
           # No need to reload xcatd here as it will be covered by xCAT/xCATsn now
           rm /tmp/xCAT-server_upgrade.tmp
         else
-          if [ -x /lib/systemd/systemd ]; then
-            /bin/systemctl daemon-reload
-            /bin/systemctl enable xcatd.service
-          else
+          if xcat_can_use_systemctl; then
+            systemctl daemon-reload
+            systemctl enable xcatd.service
+          elif command -v update-rc.d >/dev/null 2>&1; then
             update-rc.d xcatd defaults
           fi
         fi

--- a/xCAT-server/debian/prerm
+++ b/xCAT-server/debian/prerm
@@ -5,6 +5,11 @@
 
 set -e
 
+xcat_can_use_systemctl()
+{
+    [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1
+}
+
 # summary of how this script can be called:
 #        * <prerm> `remove'
 #        * <old-prerm> `upgrade' <new-version>
@@ -20,9 +25,17 @@ set -e
 case "$1" in
     remove)
        if [ -f "/proc/cmdline" ]; then   # prevent running it during install into chroot image
-            systemctl stop xcatd.service
+            if xcat_can_use_systemctl; then
+                systemctl stop xcatd.service
+            elif [ -x /etc/init.d/xcatd ]; then
+                /etc/init.d/xcatd stop
+            fi
        fi
-       systemctl disable xcatd.service
+       if xcat_can_use_systemctl; then
+           systemctl disable xcatd.service
+       elif command -v update-rc.d >/dev/null 2>&1; then
+           update-rc.d -f xcatd remove
+       fi
     ;;
     upgrade|deconfigure)
     ;;

--- a/xCAT-server/debian/rules
+++ b/xCAT-server/debian/rules
@@ -89,9 +89,9 @@ binary-arch:
 	dh_makeshlibs
 	dh_installdeb
 	dh_shlibdeps
-	dh_gencontrol
+	dh_gencontrol -- -Vperl:Depends=perl
 	dh_md5sums
-	dh_builddeb
+	dh_builddeb -- -Zgzip
 
 binary: binary-indep binary-arch
 .PHONY: build clean binary-indep binary-arch binary install configure

--- a/xCAT-server/etc/init.d/xcatd
+++ b/xCAT-server/etc/init.d/xcatd
@@ -35,8 +35,13 @@ RHFailure()
     failure
     echo
 }
+
 MStatus()
 {
+  if [ ! -s /var/run/xcatd.pid ]; then
+    echo "xcatd service is not running"
+    return 3
+  fi
   PID=`cat /var/run/xcatd.pid`
   if [ -z "$PID" ]; then
     echo "xcatd service is not running"
@@ -201,4 +206,3 @@ start)
   xcatd -p /var/run/xcatd.pid && $LOG_SUCCESS || $LOG_FAILURE
   ;;
 esac
-

--- a/xCAT-server/etc/init.d/xcatd.service
+++ b/xCAT-server/etc/init.d/xcatd.service
@@ -6,13 +6,17 @@ After=network.target syslog.service
 EnvironmentFile=-/etc/sysconfig/xcat
 Type=forking
 PIDFile=/run/xcatd.pid
-ExecStart=/etc/init.d/xcatd start
-ExecStop=/etc/init.d/xcatd stop
+RuntimeDirectory=xcat
+RuntimeDirectoryMode=0755
+ExecStart=/bin/sh -c '[ -r /etc/profile.d/xcat.sh ] && . /etc/profile.d/xcat.sh; exec /usr/sbin/xcatd -p /run/xcatd.pid'
+ExecStop=/bin/sh -c 'if [ -s /run/xcatd.pid ]; then kill -TERM "$(cat /run/xcatd.pid)" 2>/dev/null || true; fi'
 LimitNOFILE=16000
 RemainAfterExit=no
 Restart=on-failure
 RestartSec=5s
 TimeoutStartSec=600
+TimeoutStopSec=30
+KillMode=mixed
 
 [Install]
 WantedBy=multi-user.target

--- a/xCAT-server/xCAT-server.spec
+++ b/xCAT-server/xCAT-server.spec
@@ -64,7 +64,10 @@ Requires: perl-HTTP-Async >= 0.30-3
 %endif
 %endif
 
+%if 0%{?rhel} && 0%{?rhel} < 7
 Requires: initscripts
+Requires: chkconfig
+%endif
 %if 0%{?rhel} >= 10
 Requires: openssl
 %endif
@@ -483,10 +486,15 @@ ln -sf $RPM_INSTALL_PREFIX0/share/xcat/netboot/sles $RPM_INSTALL_PREFIX0/share/x
 
 ln -sf $RPM_INSTALL_PREFIX0/share/xcat/install/centos $RPM_INSTALL_PREFIX0/share/xcat/install/centos-stream
 ln -sf $RPM_INSTALL_PREFIX0/share/xcat/netboot/centos $RPM_INSTALL_PREFIX0/share/xcat/netboot/centos-stream
+xcat_can_use_systemctl()
+{
+   [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1
+}
+
 if [ "$1" = "1" ]; then #Only if installing for the first time..
-   if [ -x /usr/lib/systemd/systemd ]; then
-       /usr/bin/systemctl daemon-reload
-       /usr/bin/systemctl enable xcatd.service
+   if xcat_can_use_systemctl; then
+       systemctl daemon-reload
+       systemctl enable xcatd.service
    elif [ -x /sbin/chkconfig ]; then
        /sbin/chkconfig --add xcatd
    elif [ -x /usr/lib/lsb/install_initd ]; then
@@ -497,17 +505,16 @@ if [ "$1" = "1" ]; then #Only if installing for the first time..
 fi
 
 if [ "$1" -gt "1" ]; then #only on upgrade...
-  if [ -x /usr/lib/systemd/systemd ]; then
+  if xcat_can_use_systemctl; then
     if [ -f /run/systemd/generator.late/xcatd.service ]; then
         # To cover the case upgrade from no xcatd systemd unit file (cannot enable by default for HA case)
-        ls /etc/rc.d/rc?.d/S??xcatd >/dev/null 2>&1
-        if [ "$?" = "0" ]; then
+        if ls /etc/rc.d/rc?.d/S??xcatd >/dev/null 2>&1; then
            [ -x /sbin/chkconfig ] && /sbin/chkconfig --del xcatd
-           /usr/bin/systemctl daemon-reload
-           /usr/bin/systemctl enable xcatd.service
+           systemctl daemon-reload
+           systemctl enable xcatd.service
         fi
     else
-        /usr/bin/systemctl daemon-reload
+        systemctl daemon-reload
     fi
   fi
   #migration issue for monitoring
@@ -545,13 +552,22 @@ exit 0
 
 %preun
 %ifos linux
+xcat_can_use_systemctl()
+{
+   [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1
+}
+
 if [ $1 == 0 ]; then  #This means only on -e
 	if [ -f "/proc/cmdline" ]; then   # prevent running it during install into chroot image
-  		/etc/init.d/xcatd stop
-  	fi
+      if xcat_can_use_systemctl; then
+          systemctl stop xcatd.service
+      elif [ -x /etc/init.d/xcatd ]; then
+          /etc/init.d/xcatd stop
+      fi
+  fi
 
-  if [ -x /usr/lib/systemd/systemd ]; then
-       /usr/bin/systemctl disable xcatd.service
+  if xcat_can_use_systemctl; then
+       systemctl disable xcatd.service
   elif [ -x /sbin/chkconfig ]; then
       /sbin/chkconfig --del xcatd
   elif [ -x /usr/lib/lsb/remove_initd ]; then

--- a/xCAT-test/autotest/testcase/xcatd/case0
+++ b/xCAT-test/autotest/testcase/xcatd/case0
@@ -3,7 +3,7 @@ description:stop then start xcatd daemon, and check all the 6 processes are runn
 label:mn_only,ci_test,xcatd
 cmd:if [ -d "/tmp/xcatd_start" ]; then mv /tmp/xcatd_start /tmp/xcatd_start.org; fi; mkdir -p /tmp/xcatd_start
 check:rc==0
-cmd:service xcatd status
+cmd:if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then systemctl status xcatd; else service xcatd status; fi
 check:rc==0
 check:output=~xcatd service|xcatd.service
 check:output=~Active: active \(running\)|xcatd service is running
@@ -11,17 +11,17 @@ cmd:ps axjf |grep -v grep |grep "xcatd:" | tee /tmp/xcatd_start/original_xcatd_p
 check:rc==0
 cmd:cat /tmp/xcatd_start/original_xcatd_processes_status |wc -l
 #check:output=~6
-cmd:service xcatd stop
+cmd:if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then systemctl stop xcatd; else service xcatd stop; fi
 check:rc==0
 cmd:sleep 3
 cmd:ps axjf |grep -v grep |grep "xcatd:" | tee /tmp/xcatd_start/after_stop_xcatd_processes_status
 check:rc==0
 cmd:cat /tmp/xcatd_start/after_stop_xcatd_processes_status|wc -l
 check:output=~0
-cmd:service xcatd start
+cmd:if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then systemctl start xcatd; else service xcatd start; fi
 check:rc==0
 cmd:sleep 3
-cmd:service xcatd status
+cmd:if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then systemctl status xcatd; else service xcatd status; fi
 check:rc==0
 check:output=~xcatd service|xcatd.service
 check:output=~Active: active \(running\)|xcatd service is running
@@ -49,17 +49,17 @@ end
 start:xcatd_stop
 description:stop xcatd daemon, then check all the 6 processes are stopped
 label:mn_only,ci_test,xcatd
-cmd:service xcatd status
+cmd:if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then systemctl status xcatd; else service xcatd status; fi
 check:rc==0
 check:output=~xcatd service|xcatd.service
 check:output=~xcatd service is running|active \(running\)
-cmd:service xcatd stop
+cmd:if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then systemctl stop xcatd; else service xcatd stop; fi
 check:rc==0
 cmd:sleep 3
 cmd:ps axjf |grep -v grep |grep "xcatd:" | wc -l
 check:rc==0
 check:output=~0
-cmd:service xcatd status
+cmd:if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then systemctl status xcatd; else service xcatd status; fi
 check:output=~xcatd service|xcatd.service
 check:output=~xcatd service is not running|inactive \(dead\)
 cmd:ps -ef | grep xcatd
@@ -69,7 +69,7 @@ check:output!~"xcatd: UDP listener"
 check:output!~"xcatd: install monitor"
 check:output!~"xcatd: Discovery worke"
 check:output!~"xcatd: Command log writer"
-cmd:service xcatd start
+cmd:if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then systemctl start xcatd; else service xcatd start; fi
 check:rc==0
 end
 
@@ -77,14 +77,14 @@ end
 start:xcatd_restart
 description:restart xcatd daemon
 label:mn_only,xcatd
-cmd:service xcatd status
+cmd:if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then systemctl status xcatd; else service xcatd status; fi
 check:output=~xcatd service|xcatd.service
 check:output=~xcatd service is running|active \(running\)
 check:rc==0
-cmd:service xcatd restart
+cmd:if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then systemctl restart xcatd; else service xcatd restart; fi
 check:rc==0
 cmd:sleep 10
-cmd:service xcatd status
+cmd:if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then systemctl status xcatd; else service xcatd status; fi
 check:output=~xcatd service|xcatd.service
 check:output=~xcatd service is running|active \(running\)
 check:rc==0
@@ -95,27 +95,27 @@ end
 start:run_command_with_XCATBYPASS
 description:with XCATBYPASS=YES, the command works either xcatd deamon running or not
 label:mn_only,ci_test,xcatd
-cmd:service xcatd status
+cmd:if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then systemctl status xcatd; else service xcatd status; fi
 check:rc==0
 check:output=~xcatd service|xcatd.service
 check:output=~xcatd service is running|active \(running\)
 cmd:XCATBYPASS=YES tabdump site
 check:rc==0
-cmd:service xcatd stop
+cmd:if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then systemctl stop xcatd; else service xcatd stop; fi
 check:rc==0
 cmd:sleep 3
 cmd:ps aux|tee /tmp/run_command_with_XCATBYPASS.log
 cmd:awk '{print $11}' /tmp/run_command_with_XCATBYPASS.log|grep -E ^xcatd
 check:rc!=0
 cmd:rm -rf /tmp/run_command_with_XCATBYPASS.log
-cmd:service xcatd status
+cmd:if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then systemctl status xcatd; else service xcatd status; fi
 cmd:tabdump site
 check:rc!=0
 cmd:XCATBYPASS=YES tabdump site
 check:rc==0
-cmd:service xcatd start
+cmd:if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then systemctl start xcatd; else service xcatd start; fi
 check:rc==0
-cmd:service xcatd status
+cmd:if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then systemctl status xcatd; else service xcatd status; fi
 check:rc==0
 check:output=~xcatd service|xcatd.service
 check:output=~xcatd service is running|active \(running\)
@@ -124,7 +124,7 @@ end
 start:disable_root_permission_in_policy_table
 description:disable root permission, only with XCATBYPASS=YES, the command works
 label:mn_only,ci_test,xcatd
-cmd:service xcatd status
+cmd:if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then systemctl status xcatd; else service xcatd status; fi
 check:rc==0
 check:output=~ xcatd service|xcatd.service
 check:output=~xcatd service is running|active \(running\)
@@ -144,7 +144,7 @@ end
 start:assign_certain_command_permission
 description:assign root permission to certain command, only this command works
 label:mn_only,ci_test,xcatd
-cmd:service xcatd status
+cmd:if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then systemctl status xcatd; else service xcatd status; fi
 check:rc==0
 check:output=~ xcatd service |xcatd.service
 check:output=~xcatd service is running|active \(running\)
@@ -165,17 +165,17 @@ end
 start:reload_xcatd_with_XCATBYPASS
 description:with XCATBYPASS=YES, there is no error when restart xcatd deamon. This case is add test case for issue 2727 : run xCAT in "XCATBYPASS" mode and simply reload xCAT to check if there is any errors. 
 label:mn_only,ci_test,xcatd
-cmd:service xcatd status
+cmd:if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then systemctl status xcatd; else service xcatd status; fi
 check:rc==0
 check:output=~xcatd service|xcatd.service
 check:output=~xcatd service is running|active \(running\)
 cmd:XCATBYPASS=YES lsxcatd -a
 check:rc==0
 check:output!~Error|ERROR
-cmd:XCATBYPASS=YES service xcatd status
+cmd:if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then XCATBYPASS=YES systemctl status xcatd; else XCATBYPASS=YES service xcatd status; fi
 check:rc==0
 check:output!~Error|ERROR
-cmd:XCATBYPASS=YES service xcatd restart
+cmd:if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then XCATBYPASS=YES systemctl restart xcatd; else XCATBYPASS=YES service xcatd restart; fi
 check:rc==0
 check:output!~Error|ERROR 
 end

--- a/xCAT/debian/postinst
+++ b/xCAT/debian/postinst
@@ -40,7 +40,7 @@ case "$1" in
             xcatconfig -u -V >> /var/log/xcat/upgrade.log
             rm /tmp/xCAT_upgrade.tmp
         else
-            xcatconfig -i -d -s
+            xcatconfig -i
         fi
 
         ln -s -f /etc/apache2/conf-available/xcat.conf.apach24 /etc/apache2/conf-enabled/xcat.conf

--- a/xCAT/debian/rules
+++ b/xCAT/debian/rules
@@ -60,9 +60,9 @@ binary-arch:
 	dh_makeshlibs
 	dh_installdeb
 	dh_shlibdeps
-	dh_gencontrol
+	dh_gencontrol -- -Vperl:Depends=perl
 	dh_md5sums
-	dh_builddeb
+	dh_builddeb -- -Zgzip
 
 binary: binary-indep binary-arch
 .PHONY: build clean binary-indep binary-arch binary install configure


### PR DESCRIPTION
This PR fixes a long-standing issue with xCAT that was a proper systemd setup:

- Use a native systemd `xcatd.service` start/stop path instead of delegating to the SysV init script.
- Keep SysV fallback support for non-systemd boots and old releases while dropping the EL7+ runtime dependency on `initscripts`/`chkconfig`.
- The same for Ubuntu 16.04+
- Make Debian maintainer scripts use systemd only when systemd is actually booted.
- Keep generated DEBs readable by old supported Ubuntu releases
- Update the `xcatd` autotest service commands to dispatch through systemd when available.

Fixes xcat2/xcat-core#7343.