### PR TITLE
fix: fail nodeset when MASTER_IP cannot be resolved

### DIFF
--- a/xCAT-server/lib/perl/xCAT/Template.pm
+++ b/xCAT-server/lib/perl/xCAT/Template.pm
@@ -123,9 +123,11 @@ sub subvars {
 
     $ENV{XCATMASTER} = $master;
     my $ipaddr = xCAT::NetworkUtils->getipaddr($master);
-    if ($ipaddr) {
-        $ENV{MASTER_IP} = "$ipaddr";
+    unless ($ipaddr) {
+        $tmplerr = "Unable to resolve master \"$master\" to an IP address for $node";
+        return;
     }
+    $ENV{MASTER_IP} = "$ipaddr";
 
     my @nodestatus = xCAT::TableUtils->get_site_attribute("nodestatus");
     my $tmp        = $nodestatus[0];


### PR DESCRIPTION
This PR fixes an oversight in `Template.pm`, where it silently continued rendering kickstart templates when `getipaddr()` failed to resolve the `master` hostname, producing a kickstart file with an empty `MASTER_IP`. Nodes would install successfully but fail on first reboot when `post.xcat` and `xcatinstallpost` tried to contact the master.

Fixes #7544